### PR TITLE
Updated 500 page copy and added button to reveal error message. 

### DIFF
--- a/frontend/interfaces/errors500.js
+++ b/frontend/interfaces/errors500.js
@@ -1,0 +1,6 @@
+import PropTypes from 'prop-types';
+
+export default PropTypes.shape({
+  http_request: PropTypes.number,
+  base: PropTypes.string,
+});

--- a/frontend/interfaces/errors500.js
+++ b/frontend/interfaces/errors500.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
 export default PropTypes.shape({
-  http_request: PropTypes.number,
+  http_status: PropTypes.number,
   base: PropTypes.string,
 });

--- a/frontend/pages/Kolide500/Kolide500.jsx
+++ b/frontend/pages/Kolide500/Kolide500.jsx
@@ -91,7 +91,7 @@ class Kolide500 extends Component {
 }
 
 const mapStateToProps = (state) => {
-  const { errors } = state.errors;
+  const { errors } = state.errors500;
   return {
     errors,
   };

--- a/frontend/pages/Kolide500/Kolide500.jsx
+++ b/frontend/pages/Kolide500/Kolide500.jsx
@@ -79,7 +79,8 @@ class Kolide500 extends Component {
           <h2>Error 500</h2>
           <p>Something went wrong on our end.</p>
           {renderError()}
-          <p>Need assistance? <a href="https://github.com/kolide/fleet/issues">File an issue</a>.</p>
+          <p>Please file an issue if you believe this is a bug.</p>
+          <a href="https://github.com/kolide/fleet/issues">File an issue</a>
           <div className="gopher-container">
             <img src={gopher} alt="" />
           </div>

--- a/frontend/pages/Kolide500/Kolide500.jsx
+++ b/frontend/pages/Kolide500/Kolide500.jsx
@@ -80,7 +80,13 @@ class Kolide500 extends Component {
           <p>Something went wrong on our end.</p>
           {renderError()}
           <p>Please file an issue if you believe this is a bug.</p>
-          <a href="https://github.com/kolide/fleet/issues">File an issue</a>
+          <a
+            href="https://github.com/fleetdm/fleet/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            File an issue
+          </a>
           <div className="gopher-container">
             <img src={gopher} alt="" />
           </div>

--- a/frontend/pages/Kolide500/Kolide500.jsx
+++ b/frontend/pages/Kolide500/Kolide500.jsx
@@ -1,12 +1,72 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { noop } from 'lodash';
+import { resetErrors } from 'redux/nodes/errors500/actions';
+import errorsInterface from 'interfaces/errors500';
 
 import kolideLogo from '../../../assets/images/kolide-logo-condensed.svg';
 import gopher from '../../../assets/images/500.svg';
 
 const baseClass = 'kolide-500';
 
-class Kolide404 extends Component {
+class Kolide500 extends Component {
+  static propTypes = {
+    errors: errorsInterface,
+    dispatch: PropTypes.func,
+  };
+
+  static defaultProps = {
+    dispatch: noop,
+  };
+
+  constructor (props) {
+    super(props);
+
+    this.state = {
+      showErrorMessage: false,
+    };
+  }
+
+  componentWillUnmount() {
+    const { dispatch } = this.props;
+    dispatch(resetErrors());
+  }
+
+  onShowErrorMessage = () => {
+    this.setState({ showErrorMessage: true });
+  }
+
+  renderError = () => {
+    const { errors } = this.props;
+    const errorMessage = errors ? errors.base : null;
+    const { showErrorMessage } = this.state;
+    const { onShowErrorMessage } = this;
+
+    if (errorMessage && !showErrorMessage) {
+      // We only show the button when errorMessage exists
+      // and showErrorMessage is set to false
+      return (
+        <button className="button button--muted" onClick={onShowErrorMessage}>SHOW ERROR</button>
+      );
+    }
+
+    if (errorMessage && showErrorMessage) {
+      // We only show the error message when errorMessage exists
+      // and showErrorMessage is set to true
+      return (
+        <div className="error-message-container">
+          <p>{errorMessage}</p>
+        </div>
+      );
+    }
+
+    return false;
+  }
+
   render () {
+    const { renderError } = this;
+
     return (
       <div className={baseClass}>
         <header className="primary-header">
@@ -18,10 +78,10 @@ class Kolide404 extends Component {
           <h1>Uh oh!</h1>
           <h2>Error 500</h2>
           <p>Something went wrong on our end.</p>
-          <p>We have alerted the engineers and they are working on a solution.</p>
+          {renderError()}
+          <p>Need assistance? <a href="https://github.com/kolide/fleet/issues">File an issue</a>.</p>
           <div className="gopher-container">
             <img src={gopher} alt="" />
-            <p>Need assistance? <a href="https://github.com/kolide/fleet/issues">File an issue</a>.</p>
           </div>
         </main>
       </div>
@@ -29,4 +89,11 @@ class Kolide404 extends Component {
   }
 }
 
-export default Kolide404;
+const mapStateToProps = (state) => {
+  const { errors } = state.errors;
+  return {
+    errors,
+  };
+};
+
+export default connect(mapStateToProps)(Kolide500);

--- a/frontend/pages/Kolide500/_styles.scss
+++ b/frontend/pages/Kolide500/_styles.scss
@@ -36,6 +36,10 @@
     }
   }
 
+  .error-message-container {
+    display: inline;
+  }
+
   main {
     text-align: center;
 

--- a/frontend/redux/nodes/errors500/actions.js
+++ b/frontend/redux/nodes/errors500/actions.js
@@ -1,0 +1,7 @@
+export const RESET_ERRORS = 'RESET_ERRORS';
+
+export const resetErrors = () => {
+  return {
+    type: RESET_ERRORS,
+  };
+};

--- a/frontend/redux/nodes/errors500/reducer.js
+++ b/frontend/redux/nodes/errors500/reducer.js
@@ -1,0 +1,22 @@
+import {
+  RESET_ERRORS,
+} from './actions';
+
+const initialState = {
+  errors: null,
+};
+
+const reducer = (state = initialState, { type, payload }) => {
+  if (payload && payload.errors) {
+    return {
+      errors: payload.errors,
+    };
+  } else if (type === RESET_ERRORS) {
+    return {
+      errors: null,
+    };
+  }
+  return state;
+};
+
+export default reducer;

--- a/frontend/redux/nodes/errors500/reducer.tests.js
+++ b/frontend/redux/nodes/errors500/reducer.tests.js
@@ -1,46 +1,39 @@
 import expect from 'expect';
-import { LOCATION_CHANGE } from 'react-router-redux';
 
-import reducer, { initialState } from './reducer';
-import {
-  hideFlash,
-  renderFlash,
-} from './actions';
+import reducer from './reducer';
 
-describe('Notifications - reducer', () => {
-  it('Updates state with notification info when RENDER_FLASH is dispatched', () => {
-    const undoAction = { type: 'UNDO' };
-    const newState = reducer(initialState, renderFlash('success', 'You did it!', undoAction));
+describe('Errors - reducer', () => {
+  it('Updates state with errors object when an action that has a payload with an errors object is dispatched', () => {
+    const payload = {
+      errors: {
+        base: "inserting pack: Error 1136: Column count doesn't match value count at row 1",
+        http_status: 500,
+      },
+    };
+    const packsCreateFailureAction = { type: 'packs_CREATE_FAILURE', payload };
+    const initialState = {
+      errors: null,
+    };
+    const newState = reducer(initialState, packsCreateFailureAction);
 
     expect(newState).toEqual({
-      alertType: 'success',
-      isVisible: true,
-      message: 'You did it!',
-      undoAction,
+      errors: {
+        base: "inserting pack: Error 1136: Column count doesn't match value count at row 1",
+        http_status: 500,
+      },
     });
   });
 
-  it('Updates state to hide notifications when HIDE_FLASH is dispatched', () => {
-    const stateWithFlashDisplayed = reducer(initialState, renderFlash('success', 'You did it!'));
-    const newState = reducer(stateWithFlashDisplayed, hideFlash);
-
+  it('Updates state by setting errors to null when the RESET_ERRORS action is dipatched', () => {
+    const errorsState = {
+      errors: {
+        base: "inserting pack: Error 1136: Column count doesn't match value count at row 1",
+        http_status: 500,
+      },
+    };
+    const newState = reducer(errorsState, { type: 'RESET_ERRORS' });
     expect(newState).toEqual({
-      alertType: null,
-      isVisible: false,
-      message: null,
-      undoAction: null,
-    });
-  });
-
-  it('Updates state to hide notifications during location change', () => {
-    const stateWithFlashDisplayed = reducer(initialState, renderFlash('success', 'You did it!'));
-    const newState = reducer(stateWithFlashDisplayed, { type: LOCATION_CHANGE });
-
-    expect(newState).toEqual({
-      alertType: null,
-      isVisible: false,
-      message: null,
-      undoAction: null,
+      errors: null,
     });
   });
 });

--- a/frontend/redux/nodes/errors500/reducer.tests.js
+++ b/frontend/redux/nodes/errors500/reducer.tests.js
@@ -1,0 +1,46 @@
+import expect from 'expect';
+import { LOCATION_CHANGE } from 'react-router-redux';
+
+import reducer, { initialState } from './reducer';
+import {
+  hideFlash,
+  renderFlash,
+} from './actions';
+
+describe('Notifications - reducer', () => {
+  it('Updates state with notification info when RENDER_FLASH is dispatched', () => {
+    const undoAction = { type: 'UNDO' };
+    const newState = reducer(initialState, renderFlash('success', 'You did it!', undoAction));
+
+    expect(newState).toEqual({
+      alertType: 'success',
+      isVisible: true,
+      message: 'You did it!',
+      undoAction,
+    });
+  });
+
+  it('Updates state to hide notifications when HIDE_FLASH is dispatched', () => {
+    const stateWithFlashDisplayed = reducer(initialState, renderFlash('success', 'You did it!'));
+    const newState = reducer(stateWithFlashDisplayed, hideFlash);
+
+    expect(newState).toEqual({
+      alertType: null,
+      isVisible: false,
+      message: null,
+      undoAction: null,
+    });
+  });
+
+  it('Updates state to hide notifications during location change', () => {
+    const stateWithFlashDisplayed = reducer(initialState, renderFlash('success', 'You did it!'));
+    const newState = reducer(stateWithFlashDisplayed, { type: LOCATION_CHANGE });
+
+    expect(newState).toEqual({
+      alertType: null,
+      isVisible: false,
+      message: null,
+      undoAction: null,
+    });
+  });
+});

--- a/frontend/redux/reducers.js
+++ b/frontend/redux/reducers.js
@@ -6,6 +6,7 @@ import app from './nodes/app/reducer';
 import auth from './nodes/auth/reducer';
 import components from './nodes/components/reducer';
 import entities from './nodes/entities/reducer';
+import errors500 from './nodes/errors500/reducer';
 import notifications from './nodes/notifications/reducer';
 import persistentFlash from './nodes/persistent_flash/reducer';
 import redirectLocation from './nodes/redirectLocation/reducer';
@@ -15,6 +16,7 @@ export default combineReducers({
   auth,
   components,
   entities,
+  errors500,
   loadingBar: loadingBarReducer,
   notifications,
   persistentFlash,


### PR DESCRIPTION
Updated the 500 page component to render a "SHOW ERROR" button.

This button is only rendered if the errors slice of the state contains an error and the `base` property exists. Otherwise, the 500 page will not render this button because there is no error message to show the user.

Created a errors500 reducer and actions to update the state tree when a 500 error occurs. When 500 error occurs, the errors slice of state is updated with the error object. When the 500 page component unmounts the error object is removed from state.

Demo: https://www.loom.com/share/b87c4aee42274e7bb553e703d3f950c6