### PR TITLE
Fix regression creating packs

### DIFF
--- a/server/datastore/datastore_packs_test.go
+++ b/server/datastore/datastore_packs_test.go
@@ -25,6 +25,20 @@ func testDeletePack(t *testing.T, ds kolide.Datastore) {
 	assert.NotNil(t, err)
 }
 
+func testNewPack(t *testing.T, ds kolide.Datastore) {
+	pack := &kolide.Pack{
+		Name: "foo",
+	}
+
+	pack, err := ds.NewPack(pack)
+	require.NoError(t, err)
+	assert.NotEqual(t, uint(0), pack.ID)
+
+	pack, err = ds.Pack(pack.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "foo", pack.Name)
+}
+
 func testGetPackByName(t *testing.T, ds kolide.Datastore) {
 	pack := test.NewPack(t, ds, "foo")
 	assert.NotEqual(t, uint(0), pack.ID)

--- a/server/datastore/datastore_test.go
+++ b/server/datastore/datastore_test.go
@@ -23,6 +23,7 @@ var testFunctions = [...]func(*testing.T, kolide.Datastore){
 	testSaveQuery,
 	testListQuery,
 	testDeletePack,
+	testNewPack,
 	testEnrollHost,
 	testAuthenticateHost,
 	testAuthenticateHostCaseSensitive,

--- a/server/datastore/mysql/packs.go
+++ b/server/datastore/mysql/packs.go
@@ -223,7 +223,7 @@ func (d *Datastore) NewPack(pack *kolide.Pack, opts ...kolide.OptionalArg) (*kol
 	query := `
 	INSERT INTO packs
 		(name, description, platform, disabled)
-		VALUES ( ?, ?, ?, ?, ?)
+		VALUES ( ?, ?, ?, ? )
 	`
 
 	result, err := db.Exec(query, pack.Name, pack.Description, pack.Platform, pack.Disabled)


### PR DESCRIPTION
This is another error introduced in
https://github.com/kolide/fleet/pull/2327 we did not catch previously
due to insufficient unit test coverage. Test is now added