### PR TITLE
Changed the Help link and other links to fleetdm/fleet documentation.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,4 +9,4 @@ Welcome to the documentation for the Kolide Fleet osquery fleet manager.
 - Architecturally significant decisions are documented in the [Architecture Documentation](./architecture/README.md).
 - Finally, if you're interested in interacting with the Fleet source code, you will find information on modifying and building the code in the [Development Documentation](./development/README.md).
 
-If you have any questions, please don't hesitate to [File a GitHub issue](https://github.com/kolide/fleet/issues) or [join us on Slack](https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/). You can find us in the `#kolide` channel.
+If you have any questions, please don't hesitate to [File a GitHub issue](https://github.com/fleetdm/fleet/issues) or [join us on Slack](https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/). You can find us in the `#kolide` channel.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -10,7 +10,7 @@ Kolide Fleet is powered by a Go API server which serves three types of endpoints
 Only osquery agents should interact with the osquery API, but we'd like to support the eventual use of the Fleet API extensively. The API is not very well documented at all right now, but we have plans to:
 
 - Generate and publish detailed documentation via a tool built using [test2doc](https://github.com/adams-sarah/test2doc) (or similar).
-- Release a JavaScript Fleet API client library (which would be derived from the [current](https://github.com/kolide/fleet/blob/master/frontend/kolide/index.js) JavaScript API client).
+- Release a JavaScript Fleet API client library (which would be derived from the [current](https://github.com/fleetdm/fleet/blob/master/frontend/kolide/index.js) JavaScript API client).
 - Commit to a stable, standardized API format.
 
 ## Fleetctl
@@ -36,4 +36,4 @@ Each set of objects follows a similar REST access pattern.
 
 Queries, packs, scheduled queries, labels, invites, users, sessions all behave this way. Some objects, like invites, have additional HTTP methods for additional functionality. Some objects, such as scheduled queries, are merely a relationship between two other objects (in this case, a query and a pack) with some details attached.
 
-All of these objects are put together and distributed to the appropriate osquery agents at the appropriate time. At this time, the best source of truth for the API is the [HTTP handler file](https://github.com/kolide/fleet/blob/master/server/service/handler.go) in the Go application. The REST API is exposed via a transport layer on top of an RPC service which is implemented using a micro-service library called [Go Kit](https://github.com/go-kit/kit). If using the Fleet API is important to you right now, being familiar with Go Kit would definitely be helpful.
+All of these objects are put together and distributed to the appropriate osquery agents at the appropriate time. At this time, the best source of truth for the API is the [HTTP handler file](https://github.com/fleetdm/fleet/blob/master/server/service/handler.go) in the Go application. The REST API is exposed via a transport layer on top of an RPC service which is implemented using a micro-service library called [Go Kit](https://github.com/go-kit/kit). If using the Fleet API is important to you right now, being familiar with Go Kit would definitely be helpful.

--- a/docs/development/faq.md
+++ b/docs/development/faq.md
@@ -19,4 +19,4 @@ server/kolide/emails.go:90:23: undefined: Asset
 make: *** [fleet] Error 2
 ```
 
-If you get an `undefined: Asset` error it is likely because you did not run `make generate` before `make build`. See [Building the Code](https://github.com/kolide/fleet/blob/master/docs/development/building-the-code.md) for additional documentation on compiling the `fleet` binary.
+If you get an `undefined: Asset` error it is likely because you did not run `make generate` before `make build`. See [Building the Code](https://github.com/fleetdm/fleet/blob/master/docs/development/building-the-code.md) for additional documentation on compiling the `fleet` binary.

--- a/docs/development/linux.md
+++ b/docs/development/linux.md
@@ -42,8 +42,7 @@ rm -rf tmp
 ### Clone and build depenencies
 
 ```
-mkdir -p ~/go/src/github.com/kolide/
-git clone https://github.com/kolide/fleet.git
+git clone https://github.com/fleetdm/fleet.git
 cd fleet
 make deps
 make generate

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -16,7 +16,7 @@ git push origin <VERSION>
 make binary-bundle
 ```
 
-4. Create a new release on the [GitHub releases page](https://github.com/kolide/fleet/releases). Select the newly pushed tag (GitHub should say "Existing tag"). Use the version number as the release title. Use the below template for the release description (replace items in <> with the appropriate values):
+4. Create a new release on the [GitHub releases page](https://github.com/fleetdm/fleet/releases). Select the newly pushed tag (GitHub should say "Existing tag"). Use the version number as the release title. Use the below template for the release description (replace items in <> with the appropriate values):
 
 ````
 ### Changes
@@ -25,11 +25,11 @@ make binary-bundle
 
 ### Upgrading
 
-Please visit our [update guide](https://github.com/kolide/fleet/blob/master/docs/infrastructure/updating-fleet.md) for upgrade instructions.
+Please visit our [update guide](https://github.com/fleetdm/fleet/blob/master/docs/infrastructure/updating-fleet.md) for upgrade instructions.
 
 ### Documentation
 
-Documentation for this release can be found at https://github.com/kolide/fleet/blob/<VERSION>/docs/README.md
+Documentation for this release can be found at https://github.com/fleetdm/fleet/blob/<VERSION>/docs/README.md
 
 ### Binary Checksum
 

--- a/docs/infrastructure/adding-hosts-to-fleet.md
+++ b/docs/infrastructure/adding-hosts-to-fleet.md
@@ -12,7 +12,7 @@ If you'd like to use the native osqueryd binaries to connect to Fleet, this is e
 
 ## Kolide Osquery Launcher
 
-We provide compiled releases of the launcher for all supported platforms. Those can be found [here](https://github.com/kolide/launcher/releases). But if you’d like to compile from source, the instructions are [here](https://github.com/kolide/fleet/tree/master/docs/development).
+We provide compiled releases of the launcher for all supported platforms. Those can be found [here](https://github.com/kolide/launcher/releases). But if you’d like to compile from source, the instructions are [here](https://github.com/fleetdm/fleet/tree/master/docs/development).
 
 #### Connecting a single Launcher to Fleet
 

--- a/docs/infrastructure/faq.md
+++ b/docs/infrastructure/faq.md
@@ -78,6 +78,6 @@ Kolide does not host a SaaS version of Fleet. We offer [Kolide Cloud](https://ko
 
 ## How do I get support for working with Fleet?
 
-For bug reports, please use the [Github issue tracker](https://github.com/kolide/fleet/issues).
+For bug reports, please use the [Github issue tracker](https://github.com/fleetdm/fleet/issues).
 
 For questions and discussion, please join us in the #kolide channel of [osquery Slack](https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/).

--- a/docs/infrastructure/fleet-on-centos.md
+++ b/docs/infrastructure/fleet-on-centos.md
@@ -21,7 +21,7 @@ $ vagrant ssh
 To install Fleet, run the following:
 
 ```
-$ wget https://github.com/kolide/fleet/releases/latest/download/fleet.zip
+$ wget https://github.com/fleetdm/fleet/releases/latest/download/fleet.zip
 $ unzip fleet.zip 'linux/*' -d fleet
 $ sudo cp fleet/linux/fleet* /usr/bin/
 ```

--- a/docs/infrastructure/fleet-on-ubuntu.md
+++ b/docs/infrastructure/fleet-on-ubuntu.md
@@ -21,7 +21,7 @@ $ vagrant ssh
 To install Fleet, run the following:
 
 ```
-$ wget https://github.com/kolide/fleet/releases/latest/download/fleet.zip
+$ wget https://github.com/fleetdm/fleet/releases/latest/download/fleet.zip
 $ unzip fleet.zip 'linux/*' -d fleet
 $ sudo cp fleet/linux/fleet /usr/bin/fleet
 $ sudo cp fleet/linux/fleetctl /usr/bin/fleetctl

--- a/docs/infrastructure/owasp-top-10.md
+++ b/docs/infrastructure/owasp-top-10.md
@@ -16,7 +16,7 @@ The Fleet community follows best practices when coding.  Here are some of the wa
 - Fleet supports SAML auth which means that it can be configured such that it never sees passwords.
 - Passwords are never stored in plaintext in the database. We store a `bcrypt`ed hash of the password along with a randomly generated salt. The `bcrypt` iteration count and salt key size are admin-configurable.
 #### Authentication tokens
-- The size and expiration time of session tokens is admin-configurable.  See [https://github.com/kolide/fleet/blob/master/docs/infrastructure/configuring-the-fleet-binary.md#session_duration](https://github.com/kolide/fleet/blob/master/docs/infrastructure/configuring-the-fleet-binary.md#session_duration).
+- The size and expiration time of session tokens is admin-configurable.  See [https://github.com/fleetdm/fleet/blob/master/docs/infrastructure/configuring-the-fleet-binary.md#session_duration](https://github.com/fleetdm/fleet/blob/master/docs/infrastructure/configuring-the-fleet-binary.md#session_duration).
 - It is possible to revoke all session tokens for a user by forcing a password reset.
 
 
@@ -24,7 +24,7 @@ The Fleet community follows best practices when coding.  Here are some of the wa
 - By default, all traffic between user clients (such as the web browser and fleetctl) and the Fleet server is encrypted with TLS. By default, all traffic between osqueryd clients and the Fleet server is encrypted with TLS. Fleet does not encrypt any data at rest (*however a user could separately configure encryption for the MySQL database and logs that Fleet writes*).
 
 ### Broken access controls – how restrictions on what authorized users are allowed to do/access are enforced.
-- Each session is associated with a viewer context that is used to determine the access granted to that user. Access controls can easily be applied as middleware in the routing table, so the access to a route is clearly defined in the same place where the route is attached to the server see [https://github.com/kolide/fleet/blob/master/server/service/handler.go#L114-L189](https://github.com/kolide/fleet/blob/master/server/service/handler.go#L114-L189).
+- Each session is associated with a viewer context that is used to determine the access granted to that user. Access controls can easily be applied as middleware in the routing table, so the access to a route is clearly defined in the same place where the route is attached to the server see [https://github.com/fleetdm/fleet/blob/master/server/service/handler.go#L114-L189](https://github.com/fleetdm/fleet/blob/master/server/service/handler.go#L114-L189).
 
 ### Cross-site scripting – ensure an attacker can’t execute scripts in the user’s browser
 - We render the frontend with React and benefit from built-in XSS protection in React's rendering. This is not sufficient to prevent all XSS, so we also follow additional best practices as discussed in [https://stackoverflow.com/a/51852579/491710](https://stackoverflow.com/a/51852579/491710).

--- a/frontend/components/hosts/AddHostModal/AddHostModal.jsx
+++ b/frontend/components/hosts/AddHostModal/AddHostModal.jsx
@@ -108,7 +108,7 @@ class AddHostModal extends Component {
           <div className={`${baseClass}__documentation-link`}>
             <h4>
               <a
-                href="https://github.com/kolide/fleet/blob/master/docs/infrastructure/adding-hosts-to-fleet.md"
+                href="https://github.com/fleetdm/fleet/blob/master/docs/infrastructure/adding-hosts-to-fleet.md"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/frontend/components/hosts/HostContainer/HostContainer.jsx
+++ b/frontend/components/hosts/HostContainer/HostContainer.jsx
@@ -38,7 +38,7 @@ class HostContainer extends Component {
 
         <div className={`${baseClass}__no-hosts-contact`}>
           <p>Still having trouble?</p>
-          <p><a href="https://github.com/kolide/fleet/issues">File a Github issue</a>.</p>
+          <p><a href="https://github.com/fleetdm/fleet/issues">File a Github issue</a>.</p>
         </div>
       </div>
     );

--- a/frontend/components/side_panels/SiteNavSidePanel/navItems.js
+++ b/frontend/components/side_panels/SiteNavSidePanel/navItems.js
@@ -108,7 +108,7 @@ export default (admin) => {
       name: 'Help',
       location: {
         regex: /^\/help/,
-        pathname: 'https://github.com/kolide/fleet/blob/master/docs/README.md',
+        pathname: 'https://github.com/fleetdm/fleet/blob/master/docs/README.md',
       },
       subItems: [],
     },

--- a/frontend/pages/Kolide404/Kolide404.jsx
+++ b/frontend/pages/Kolide404/Kolide404.jsx
@@ -21,7 +21,7 @@ class Kolide404 extends Component {
           <p>Might we recommend going back on your browser or visiting the <a href="/">home page?</a></p>
           <div className="gopher-container">
             <img src={gopher} alt="" />
-            <p>Need assistance? <a href="https://github.com/kolide/fleet/issues">File an issue</a>.</p>
+            <p>Need assistance? <a href="https://github.com/fleetdm/fleet/issues">File an issue</a>.</p>
           </div>
         </main>
       </div>


### PR DESCRIPTION
Began by only changing the "Help" link in the main navigation to link to the fleetdm/fleet docs.

Then went through other components and docs to change link to fleetdm/fleet docs as well.