### PR TITLE
add host additional info filters

### DIFF
--- a/server/datastore/datastore_test.go
+++ b/server/datastore/datastore_test.go
@@ -44,6 +44,7 @@ var testFunctions = [...]func(*testing.T, kolide.Datastore){
 	testSaveHosts,
 	testDeleteHost,
 	testListHosts,
+	testListHostsFilterAdditional,
 	testListHostsStatus,
 	testListHostsInPack,
 	testListPacksForHost,

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -152,9 +152,62 @@ func (d *Datastore) Host(id uint) (*kolide.Host, error) {
 }
 
 func (d *Datastore) ListHosts(opt kolide.HostListOptions) ([]*kolide.Host, error) {
-	sql := `
-		SELECT * FROM hosts
-	`
+	sql := `SELECT id,
+        osquery_host_id, 
+        created_at, 
+        updated_at, 
+        detail_update_time, 
+        node_key, 
+        host_name, 
+        uuid, 
+        platform, 
+        osquery_version, 
+        os_version, 
+        build, 
+        platform_like, 
+        code_name, 
+        uptime, 
+        physical_memory, 
+        cpu_type, 
+        cpu_subtype, 
+        cpu_brand, 
+        cpu_physical_cores, 
+        cpu_logical_cores, 
+        hardware_vendor, 
+        hardware_model, 
+        hardware_version, 
+        hardware_serial, 
+        computer_name, 
+        primary_ip_id, 
+        seen_time, 
+        distributed_interval, 
+        logger_tls_period, 
+        config_tls_refresh, 
+        primary_ip, 
+        primary_mac, 
+        label_update_time, 
+        enroll_secret_name,
+		`
+
+	// Filter additional info by extracting into a new json object
+	if len(opt.AdditionalFilters) > 0 {
+		sql += `JSON_OBJECT(
+			`
+		for _, field := range opt.AdditionalFilters {
+			sql += fmt.Sprintf(`'%s', JSON_EXTRACT(additional, '$."%s"'), `, field, field)
+		}
+		sql = sql[:len(sql)-2]
+		sql += `
+		    ) AS additional
+		    `
+	} else {
+		sql += `
+		additional
+		`
+	}
+
+	sql += `FROM hosts
+    `
 	var params []interface{}
 	switch opt.StatusFilter {
 	case "new":

--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -87,7 +87,8 @@ type HostService interface {
 type HostListOptions struct {
 	ListOptions
 
-	StatusFilter HostStatus
+	AdditionalFilters []string
+	StatusFilter      HostStatus
 }
 
 type Host struct {

--- a/server/service/transport_hosts.go
+++ b/server/service/transport_hosts.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/kolide/fleet/server/kolide"
 	"github.com/pkg/errors"
@@ -47,6 +48,11 @@ func decodeListHostsRequest(ctx context.Context, r *http.Request) (interface{}, 
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	additionalInfoFiltersString := r.URL.Query().Get("additional_info_filters")
+	if additionalInfoFiltersString != "" {
+		hopt.AdditionalFilters = strings.Split(additionalInfoFiltersString, ",")
 	}
 	return listHostsRequest{ListOptions: hopt}, nil
 }


### PR DESCRIPTION
This change adds the ability to filter additional host info via the list hosts endpoint; a continuation from [here](https://github.com/kolide/fleet/pull/2330), but now filtering is accomplished via SQL. 

Additional object without filter:
```
curl 'https://localhost:8080/api/v1/kolide/hosts'
...
"additional": {
        "macs": [
          {
            "mac": "00:00:00:00:00:00"
          },
          {
            "mac": "02:42:c0:a8:10:05"
          }
        ],
        "time": [
          {
            "day": "13",
            "hour": "3",
            "year": "2020",
            "month": "10",
            "minutes": "43",
            "seconds": "11",
            "weekday": "Tuesday",
            "datetime": "2020-10-13T03:43:11Z",
            "iso_8601": "2020-10-13T03:43:11Z",
            "timezone": "GMT",
            "timestamp": "Tue Oct 13 03:43:11 2020 UTC",
            "unix_time": "1602560591",
            "local_time": "1602560591",
            "local_timezone": "UTC"
          }
},
...
```

Additional object with filter:
```
curl 'https://localhost:8080/api/v1/kolide/hosts?additional_info_filters=macs,notreal'
...
"additional": {
        "macs": [
          {
            "mac": "00:00:00:00:00:00"
          },
          {
            "mac": "02:42:c0:a8:10:05"
          }
        ],
        "notreal": null
},
...
```