### PR TITLE
Answer to database connection error added to infrastructure faq.

### DIFF
--- a/docs/infrastructure/faq.md
+++ b/docs/infrastructure/faq.md
@@ -60,6 +60,22 @@ This error usually indicates that the Fleet server has run out of file descripto
 
 This could be caused by a mismatched connection limit between the Fleet server and the MySQL server that prevents Fleet from fully utilizing the database. First [determine how many open connections your MySQL server supports](https://dev.mysql.com/doc/refman/8.0/en/too-many-connections.html). Now set the [`--mysql_max_open_conns`](./configuring-the-fleet-binary.md#mysql_max_open_conns) and [`--mysql_max_idle_conns`](./configuring-the-fleet-binary.md#mysql_max_idle_conns) flags appropriately.
 
+## Why am I receiving a database connection error when attempting to "prepare" the databse?
+
+First, check if you have a version of MySQL installed that is at least 5.7. Then, make sure that you currently have a MySQL server running.
+
+The next step is to make sure the credentials for the database match what is expected. Test your ability to connect to the database with `mysql -u<username> -h<hostname_or_ip> -P<port> -D<database_name> -p`.
+
+If you're successful connecting to the database and still receive a database connection error, you may need to specify your database credentials when running `fleet prepare db`. It's encouraged to put your database credentials in environment variables or a config file.
+
+```
+$ /fleet prepare db \
+    --mysql_address=<database_address> \
+    --mysql_database=<database_name> \
+    --mysql_username=<username> \
+    --mysql_password=<database_password>
+```
+
 ## How do I monitor a Fleet server?
 
 Fleet provides a `/healthz` endpoint. If you query it with `curl` it will return an HTTP Status code. `200 OK` means everything is alright. `500 Internal Server Error` means Fleet is having trouble communicating with MySQL or Redis. Check the Fleet logs for additional details.
@@ -74,7 +90,7 @@ One way to hack around this is to use a simulated mailserver like [Mailhog](http
 
 ## Is Fleet available as a SaaS product?
 
-Kolide does not host a SaaS version of Fleet. We offer [Kolide Cloud](https://kolide.com) which is a separate product providing the capabilities of Fleet along with alerting and insights, all hosted in a secure SaaS platform.
+No. Currently, Fleet is only available as open-source software.
 
 ## How do I get support for working with Fleet?
 

--- a/docs/infrastructure/faq.md
+++ b/docs/infrastructure/faq.md
@@ -60,7 +60,7 @@ This error usually indicates that the Fleet server has run out of file descripto
 
 This could be caused by a mismatched connection limit between the Fleet server and the MySQL server that prevents Fleet from fully utilizing the database. First [determine how many open connections your MySQL server supports](https://dev.mysql.com/doc/refman/8.0/en/too-many-connections.html). Now set the [`--mysql_max_open_conns`](./configuring-the-fleet-binary.md#mysql_max_open_conns) and [`--mysql_max_idle_conns`](./configuring-the-fleet-binary.md#mysql_max_idle_conns) flags appropriately.
 
-## Why am I receiving a database connection error when attempting to "prepare" the databse?
+## Why am I receiving a database connection error when attempting to "prepare" the database?
 
 First, check if you have a version of MySQL installed that is at least 5.7. Then, make sure that you currently have a MySQL server running.
 
@@ -69,7 +69,7 @@ The next step is to make sure the credentials for the database match what is exp
 If you're successful connecting to the database and still receive a database connection error, you may need to specify your database credentials when running `fleet prepare db`. It's encouraged to put your database credentials in environment variables or a config file.
 
 ```
-$ /fleet prepare db \
+/fleet prepare db \
     --mysql_address=<database_address> \
     --mysql_database=<database_name> \
     --mysql_username=<username> \

--- a/docs/infrastructure/faq.md
+++ b/docs/infrastructure/faq.md
@@ -69,7 +69,7 @@ The next step is to make sure the credentials for the database match what is exp
 If you're successful connecting to the database and still receive a database connection error, you may need to specify your database credentials when running `fleet prepare db`. It's encouraged to put your database credentials in environment variables or a config file.
 
 ```
-/fleet prepare db \
+fleet prepare db \
     --mysql_address=<database_address> \
     --mysql_database=<database_name> \
     --mysql_username=<username> \


### PR DESCRIPTION
My best attempt at steps to solve the common database connection error users receive when installing or updating Fleet.

Inserted 'Why am I receiving a database connection error when attempting to "prepare" the database?'.

Also simplified the answer to "Is Fleet available as a SaaS product?".