### PR TITLE
Include fleetctl binary archives in release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,5 +227,9 @@ xp-fleetctl: .pre-binary-bundle .pre-fleetctl generate-go
 	CGO_ENABLED=0 GOOS=windows go build -tags full -o build/binary-bundle/windows/fleetctl.exe -ldflags ${KIT_VERSION} ./cmd/fleetctl
 
 binary-bundle: xp-fleet xp-fleetctl
-	cd build/binary-bundle && zip -r "fleet_${VERSION}.zip" darwin/ linux/ windows/
-	cp build/binary-bundle/fleet_${VERSION}.zip build/binary-bundle/fleet.zip
+	cd build/binary-bundle && zip -r fleet.zip darwin/ linux/ windows/
+	cd build/binary-bundle && mkdir fleetctl-macos && cp darwin/fleetctl fleetctl-macos && tar -czf fleetctl-macos.tar.gz fleetctl-macos 
+	cd build/binary-bundle && mkdir fleetctl-linux && cp linux/fleetctl fleetctl-linux && tar -czf fleetctl-linux.tar.gz fleetctl-linux 
+	cd build/binary-bundle && mkdir fleetctl-windows && cp windows/fleetctl.exe fleetctl-windows && tar -czf fleetctl-windows.tar.gz fleetctl-windows 
+	cd build/binary-bundle && shasum -a 256 fleet.zip fleetctl-macos.tar.gz fleetctl-windows.tar.gz fleetctl-linux.tar.gz
+

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -16,6 +16,8 @@ git push origin <VERSION>
 make binary-bundle
 ```
 
+Make note of the SHA256 checksum output at the end of this build command to paste into the release documentation on GitHub.
+
 4. Create a new release on the [GitHub releases page](https://github.com/fleetdm/fleet/releases). Select the newly pushed tag (GitHub should say "Existing tag"). Use the version number as the release title. Use the below template for the release description (replace items in <> with the appropriate values):
 
 ````
@@ -25,7 +27,7 @@ make binary-bundle
 
 ### Upgrading
 
-Please visit our [update guide](https://github.com/fleetdm/fleet/blob/master/docs/infrastructure/updating-fleet.md) for upgrade instructions.
+Please visit our [update guide](https://github.com/fleetdm/fleet/blob/master/docs/infrastructure/updating-fleet.md** for upgrade instructions.
 
 ### Documentation
 
@@ -33,14 +35,17 @@ Documentation for this release can be found at https://github.com/fleetdm/fleet/
 
 ### Binary Checksum
 
+**SHA256**
 ```
-sha256sum fleet.zip
 <HASH VALUE>  fleet.zip
+<HASH VALUE>  fleetctl-linux.tar.gz
+<HASH VALUE>  fleetctl-macos.tar.gz
+<HASH VALUE>  fleetctl-windows.tar.gz
 ```
 
 ````
 
-Upload the `fleet.zip` binary bundle and click "Publish Release".
+Upload the `fleet.zip` binary bundle along with the `fleetctl-*.tar.gz` for each platform and click "Publish Release".
 
 5. Push the new version to Docker Hub (ensure working tree is clean because this will effect the version string built into the binary):
 

--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -27,7 +27,7 @@ Make note of the SHA256 checksum output at the end of this build command to past
 
 ### Upgrading
 
-Please visit our [update guide](https://github.com/fleetdm/fleet/blob/master/docs/infrastructure/updating-fleet.md** for upgrade instructions.
+Please visit our [update guide](https://github.com/fleetdm/fleet/blob/master/docs/infrastructure/updating-fleet.md) for upgrade instructions.
 
 ### Documentation
 


### PR DESCRIPTION
This adds tooling to include fleetctl binaries (in separate .tar.gz
archives for each platform) in the release.