### PR TITLE
Fix fleetctl Windows issues

### DIFF
--- a/cmd/fleetctl/api.go
+++ b/cmd/fleetctl/api.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/fleetdm/fleet/server/service"
 	"github.com/pkg/errors"
@@ -25,6 +26,10 @@ func unauthenticatedClientFromCLI(c *cli.Context) (*service.Client, error) {
 
 	if cc.Address == "" {
 		return nil, errors.New("set the Fleet API address with: fleetctl config set --address https://localhost:8080")
+	}
+
+	if runtime.GOOS == "windows" && cc.RootCA == "" && !cc.TLSSkipVerify {
+		return nil, errors.New("Windows clients must configure rootca (secure) or tls-skip-verify (insecure)")
 	}
 
 	fleet, err := service.NewClient(cc.Address, cc.TLSSkipVerify, cc.RootCA, cc.URLPrefix)

--- a/cmd/fleetctl/config.go
+++ b/cmd/fleetctl/config.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 
 	"github.com/ghodss/yaml"
-	"github.com/kolide/kit/env"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -31,9 +30,14 @@ type Context struct {
 }
 
 func configFlag() cli.Flag {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		homeDir = "~"
+	}
+	defaultConfigPath := filepath.Join(homeDir, ".fleet", "config")
 	return cli.StringFlag{
 		Name:   "config",
-		Value:  fmt.Sprintf("%s/.fleet/config", env.String("HOME", "~/")),
+		Value:  defaultConfigPath,
 		EnvVar: "CONFIG",
 		Usage:  "Path to the Fleet config file",
 	}


### PR DESCRIPTION
- Properly set the path for the config file on Windows.
- Check for appropriate settings for TLS config.

Fixes #39