### PR TITLE
Linked development-infra docs from building-the-code docs.

### DIFF
--- a/docs/development/building-the-code.md
+++ b/docs/development/building-the-code.md
@@ -63,3 +63,4 @@ make build
 
 It's not necessary to use Make to build the code, but using Make allows us to account for cross-platform differences more effectively than the `go build` tool when writing automated tooling. Use whichever you prefer.
 
+Once you're successful in building the code, head to the [development infrastrucutre](../development/development-infrastructure.md) to use the local development Docker Compose infrastructure to run Fleet locally.

--- a/docs/development/building-the-code.md
+++ b/docs/development/building-the-code.md
@@ -63,4 +63,4 @@ make build
 
 It's not necessary to use Make to build the code, but using Make allows us to account for cross-platform differences more effectively than the `go build` tool when writing automated tooling. Use whichever you prefer.
 
-Once you're successful in building the code, head to the [development infrastrucutre](../development/development-infrastructure.md) documentation to use the local development Docker Compose infrastructure to run Fleet locally.
+Once you're successful in building the code, head to the [development infrastrucutre](/development-infrastructure.md) documentation to use the local development Docker Compose infrastructure to run Fleet locally.

--- a/docs/development/building-the-code.md
+++ b/docs/development/building-the-code.md
@@ -63,4 +63,4 @@ make build
 
 It's not necessary to use Make to build the code, but using Make allows us to account for cross-platform differences more effectively than the `go build` tool when writing automated tooling. Use whichever you prefer.
 
-Once you're successful in building the code, head to the [development infrastrucutre](/development-infrastructure.md) documentation to use the local development Docker Compose infrastructure to run Fleet locally.
+Once you're successful in building the code, head to the [development infrastrucutre](./development-infrastructure.md) documentation to use the local development Docker Compose infrastructure to run Fleet locally.

--- a/docs/development/building-the-code.md
+++ b/docs/development/building-the-code.md
@@ -63,4 +63,4 @@ make build
 
 It's not necessary to use Make to build the code, but using Make allows us to account for cross-platform differences more effectively than the `go build` tool when writing automated tooling. Use whichever you prefer.
 
-Once you're successful in building the code, head to the [development infrastrucutre](../development/development-infrastructure.md) to use the local development Docker Compose infrastructure to run Fleet locally.
+Once you're successful in building the code, head to the [development infrastrucutre](../development/development-infrastructure.md) documentation to use the local development Docker Compose infrastructure to run Fleet locally.

--- a/docs/development/development-infrastructure.md
+++ b/docs/development/development-infrastructure.md
@@ -32,9 +32,9 @@ fleet prepare db
 To start the Fleet server backed by the Docker development infrastructure, run the Fleet binary as follows:
 
 ```
-fleet serve
+fleet serve --auth_jwt_key="insecure"
 ```
 
-By default, Fleet will try to connect to servers running on default ports on localhost.
+By default, Fleet will try to connect to servers running on default ports on localhost. Depending on your browser's settings, you may have to click through a security warning.
 
 If you're using Docker via [Docker Toolbox](https://www.docker.com/products/docker-toolbox), you may have to modify the default values use the output of `docker-machine ip` instead of `localhost`. There is an example configuration file included in this repository to make this process easier for you.  Use the `--config` flag of the Fleet binary to specify the path to your config. See `fleet --help` for more options.


### PR DESCRIPTION
Added link to development-infrastructure docs at the end of building-the-code docs to walk contributors to the next step of serving Fleet locally.

Added `--auth_jwt_key="insecure"` flag to `fleet serve` command in development-infrastructure docs.