### PR TITLE
Add debug endpoints and associated fleetctl commands

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -264,6 +264,7 @@ the way that the Fleet server works.
 			rootMux.Handle("/metrics", prometheus.InstrumentHandler("metrics", promhttp.Handler()))
 			rootMux.Handle("/api/", apiHandler)
 			rootMux.Handle("/", frontendHandler)
+			rootMux.Handle("/debug/", service.MakeDebugHandler(svc, config, logger))
 
 			if path, ok := os.LookupEnv("KOLIDE_TEST_PAGE_PATH"); ok {
 				// test that we can load this

--- a/cmd/fleetctl/debug.go
+++ b/cmd/fleetctl/debug.go
@@ -1,0 +1,309 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+func debugCommand() cli.Command {
+	return cli.Command{
+		Name:  "debug",
+		Usage: "Tools for debugging Fleet",
+		Flags: []cli.Flag{
+			configFlag(),
+			contextFlag(),
+		},
+		Subcommands: []cli.Command{
+			debugProfileCommand(),
+			debugCmdlineCommand(),
+			debugHeapCommand(),
+			debugGoroutineCommand(),
+			debugTraceCommand(),
+			debugArchiveCommand(),
+		},
+	}
+}
+
+func writeFile(filename string, bytes []byte, mode os.FileMode) error {
+	if err := ioutil.WriteFile(filename, bytes, mode); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "Output written to %s\n", filename)
+	return nil
+}
+
+func outfileName(name string) string {
+	return fmt.Sprintf("fleet-%s-%s", name, time.Now().Format(time.RFC3339))
+}
+
+func debugProfileCommand() cli.Command {
+	return cli.Command{
+		Name:      "profile",
+		Usage:     "Record a CPU profile from the Fleet server.",
+		UsageText: "Record a 30-second CPU profile. The output can be analyzed with go tool pprof.",
+		Flags: []cli.Flag{
+			configFlag(),
+			contextFlag(),
+			outfileFlag(),
+		},
+		Action: func(c *cli.Context) error {
+			fleet, err := clientFromCLI(c)
+			if err != nil {
+				return err
+			}
+
+			profile, err := fleet.DebugPprof("profile")
+			if err != nil {
+				return err
+			}
+
+			outfile := getOutfile(c)
+			if outfile == "" {
+				outfile = outfileName("profile")
+			}
+
+			if err := writeFile(outfile, profile, defaultFileMode); err != nil {
+				return errors.Wrap(err, "write profile to file")
+			}
+
+			return nil
+		},
+	}
+}
+
+func joinCmdline(cmdline string) string {
+	var tokens []string
+	for _, token := range strings.Split(string(cmdline), "\x00") {
+		tokens = append(tokens, fmt.Sprintf("'%s'", token))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(tokens, ", "))
+}
+
+func debugCmdlineCommand() cli.Command {
+	return cli.Command{
+		Name:  "cmdline",
+		Usage: "Get the command line used to invoke the Fleet server.",
+		Flags: []cli.Flag{
+			configFlag(),
+			contextFlag(),
+			outfileFlag(),
+		},
+		Action: func(c *cli.Context) error {
+			fleet, err := clientFromCLI(c)
+			if err != nil {
+				return err
+			}
+
+			cmdline, err := fleet.DebugPprof("cmdline")
+			if err != nil {
+				return err
+			}
+
+			out := joinCmdline(string(cmdline))
+
+			if outfile := getOutfile(c); outfile != "" {
+				if err := writeFile(outfile, []byte(out), defaultFileMode); err != nil {
+					return errors.Wrap(err, "write cmdline to file")
+				}
+				return nil
+			}
+
+			fmt.Println(out)
+
+			return nil
+		},
+	}
+}
+
+func debugHeapCommand() cli.Command {
+	name := "heap"
+	return cli.Command{
+		Name:      name,
+		Usage:     "Report the allocated memory in the Fleet server.",
+		UsageText: "Report the heap-allocated memory. The output can be analyzed with go tool pprof.",
+		Flags: []cli.Flag{
+			configFlag(),
+			contextFlag(),
+			outfileFlag(),
+		},
+		Action: func(c *cli.Context) error {
+			fleet, err := clientFromCLI(c)
+			if err != nil {
+				return err
+			}
+
+			profile, err := fleet.DebugPprof(name)
+			if err != nil {
+				return err
+			}
+
+			outfile := getOutfile(c)
+			if outfile == "" {
+				outfile = outfileName(name)
+			}
+
+			if err := writeFile(outfile, profile, defaultFileMode); err != nil {
+				return errors.Wrapf(err, "write %s to file", name)
+			}
+
+			return nil
+		},
+	}
+}
+
+func debugGoroutineCommand() cli.Command {
+	name := "goroutine"
+	return cli.Command{
+		Name:      name,
+		Usage:     "Get stack traces of all goroutines (threads) in the Fleet server.",
+		UsageText: "Get stack traces of all current goroutines (threads). The output can be analyzed with go tool pprof.",
+		Flags: []cli.Flag{
+			configFlag(),
+			contextFlag(),
+			outfileFlag(),
+		},
+		Action: func(c *cli.Context) error {
+			fleet, err := clientFromCLI(c)
+			if err != nil {
+				return err
+			}
+
+			profile, err := fleet.DebugPprof(name)
+			if err != nil {
+				return err
+			}
+
+			outfile := getOutfile(c)
+			if outfile == "" {
+				outfile = outfileName(name)
+			}
+
+			if err := writeFile(outfile, profile, defaultFileMode); err != nil {
+				return errors.Wrapf(err, "write %s to file", name)
+			}
+
+			return nil
+		},
+	}
+}
+
+func debugTraceCommand() cli.Command {
+	name := "trace"
+	return cli.Command{
+		Name:      name,
+		Usage:     "Record an execution trace on the Fleet server.",
+		UsageText: "Record a 1 second execution trace. The output can be analyzed with go tool trace.",
+		Flags: []cli.Flag{
+			configFlag(),
+			contextFlag(),
+			outfileFlag(),
+		},
+		Action: func(c *cli.Context) error {
+			fleet, err := clientFromCLI(c)
+			if err != nil {
+				return err
+			}
+
+			profile, err := fleet.DebugPprof(name)
+			if err != nil {
+				return err
+			}
+
+			outfile := getOutfile(c)
+			if outfile == "" {
+				outfile = outfileName(name)
+			}
+
+			if err := writeFile(outfile, profile, defaultFileMode); err != nil {
+				return errors.Wrapf(err, "write %s to file", name)
+			}
+
+			return nil
+		},
+	}
+}
+
+func debugArchiveCommand() cli.Command {
+	return cli.Command{
+		Name:  "archive",
+		Usage: "Create an archive with the entire suite of debug profiles.",
+		Flags: []cli.Flag{
+			configFlag(),
+			contextFlag(),
+			outfileFlag(),
+		},
+		Action: func(c *cli.Context) error {
+			fleet, err := clientFromCLI(c)
+			if err != nil {
+				return err
+			}
+
+			profiles := []string{
+				"allocs",
+				"block",
+				"cmdline",
+				"goroutine",
+				"heap",
+				"mutex",
+				"profile",
+				"threadcreate",
+				"trace",
+			}
+
+			outpath := getOutfile(c)
+			if outpath == "" {
+				outpath = outfileName("profiles-archive")
+			}
+			outfile := outpath + ".tar.gz"
+
+			f, err := os.OpenFile(outfile, os.O_CREATE|os.O_WRONLY, defaultFileMode)
+			if err != nil {
+				return errors.Wrap(err, "open archive for output")
+			}
+			defer f.Close()
+			gzwriter := gzip.NewWriter(f)
+			defer gzwriter.Close()
+			tarwriter := tar.NewWriter(gzwriter)
+			defer tarwriter.Close()
+
+			for _, profile := range profiles {
+				res, err := fleet.DebugPprof(profile)
+				if err != nil {
+					// Don't fail the entire process on errors. We'll take what
+					// we can get if the servers are in a bad state and not
+					// responding to all requests.
+					fmt.Fprintf(os.Stderr, "Failed %s: %v\n", profile, err)
+					continue
+				}
+				fmt.Fprintf(os.Stderr, "Ran %s\n", profile)
+
+				if err := tarwriter.WriteHeader(
+					&tar.Header{
+						Name: outpath + "/" + profile,
+						Size: int64(len(res)),
+						Mode: defaultFileMode,
+					},
+				); err != nil {
+					return errors.Wrapf(err, "write %s header", profile)
+				}
+
+				if _, err := tarwriter.Write(res); err != nil {
+					return errors.Wrapf(err, "write %s contents", profile)
+				}
+			}
+
+			fmt.Fprintf(os.Stderr, "Archive written to %s\n", outfile)
+
+			return nil
+		},
+	}
+}

--- a/cmd/fleetctl/flags.go
+++ b/cmd/fleetctl/flags.go
@@ -1,0 +1,20 @@
+package main
+
+import "github.com/urfave/cli"
+
+const (
+	outfileFlagName = "outfile"
+)
+
+func outfileFlag() cli.Flag {
+	return cli.StringFlag{
+		Name:   outfileFlagName,
+		Value:  "",
+		EnvVar: "OUTFILE",
+		Usage:  "Path to output file",
+	}
+}
+
+func getOutfile(c *cli.Context) string {
+	return c.String(outfileFlagName)
+}

--- a/cmd/fleetctl/fleetctl.go
+++ b/cmd/fleetctl/fleetctl.go
@@ -8,6 +8,10 @@ import (
 	"github.com/urfave/cli"
 )
 
+const (
+	defaultFileMode = 0600
+)
+
 func init() {
 	rand.Seed(time.Now().UnixNano())
 }
@@ -31,7 +35,7 @@ func main() {
 		getCommand(),
 		cli.Command{
 			Name:  "config",
-			Usage: "Modify how and which Fleet server to connect to",
+			Usage: "Modify Fleet server connection settings",
 			Subcommands: []cli.Command{
 				configSetCommand(),
 				configGetCommand(),
@@ -40,6 +44,7 @@ func main() {
 		convertCommand(),
 		goqueryCommand(),
 		userCommand(),
+		debugCommand(),
 	}
 
 	app.RunAndExitOnError()

--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -3,12 +3,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
-	"io"
 
-	"github.com/ghodss/yaml"
 	"github.com/fleetdm/fleet/server/kolide"
+	"github.com/ghodss/yaml"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
@@ -19,7 +19,6 @@ const (
 	jsonFlagName        = "json"
 	withQueriesFlagName = "with-queries"
 	expiredFlagName     = "expired"
-	outfileFlagName     = "outfile"
 	stdoutFlagName      = "stdout"
 )
 
@@ -652,8 +651,8 @@ func getHostsCommand() cli.Command {
 
 func getCarvesCommand() cli.Command {
 	return cli.Command{
-		Name:    "carves",
-		Usage:   "Retrieve the file carving sessions",
+		Name:  "carves",
+		Usage: "Retrieve the file carving sessions",
 		Flags: []cli.Flag{
 			configFlag(),
 			contextFlag(),
@@ -709,21 +708,17 @@ func getCarvesCommand() cli.Command {
 	}
 }
 
-
 func getCarveCommand() cli.Command {
 	return cli.Command{
-		Name:    "carve",
-		Usage:   "Retrieve details for a carve by ID",
+		Name:  "carve",
+		Usage: "Retrieve details for a carve by ID",
 		Flags: []cli.Flag{
 			configFlag(),
 			contextFlag(),
+			outfileFlag(),
 			cli.BoolFlag{
 				Name:  stdoutFlagName,
 				Usage: "Print carve contents to stdout",
-			},
-			cli.StringFlag{
-				Name:  outfileFlagName,
-				Usage: "Download carve contents to specified file path",
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -743,7 +738,7 @@ func getCarveCommand() cli.Command {
 				return errors.Wrap(err, "unable to parse carve ID as int")
 			}
 
-			outFile := c.String(outfileFlagName)
+			outFile := getOutfile(c)
 			stdout := c.Bool(stdoutFlagName)
 
 			if stdout && outFile != "" {
@@ -753,7 +748,7 @@ func getCarveCommand() cli.Command {
 			if stdout || outFile != "" {
 				out := os.Stdout
 				if outFile != "" {
-					f, err := os.OpenFile(outFile, os.O_CREATE|os.O_WRONLY, 0666)
+					f, err := os.OpenFile(outFile, os.O_CREATE|os.O_WRONLY, defaultFileMode)
 					if err != nil {
 						return errors.Wrap(err, "open out file")
 					}
@@ -786,4 +781,3 @@ func getCarveCommand() cli.Command {
 		},
 	}
 }
-

--- a/server/service/client_debug.go
+++ b/server/service/client_debug.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+// DebugPprof calls the /debug/pprof/ endpoints.
+func (c *Client) DebugPprof(name string) ([]byte, error) {
+	endpoint := "/debug/pprof/" + name
+	response, err := c.AuthenticatedDo("GET", endpoint, "", nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "GET %s", endpoint)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, errors.Errorf(
+			"get pprof received status %d",
+			response.StatusCode,
+		)
+	}
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "read pprof response body")
+	}
+
+	return body, nil
+}

--- a/server/service/debug_handler.go
+++ b/server/service/debug_handler.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+	"os"
+
+	"github.com/fleetdm/fleet/server/config"
+	"github.com/fleetdm/fleet/server/contexts/token"
+	"github.com/fleetdm/fleet/server/kolide"
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/gorilla/mux"
+)
+
+// MakeDebugHandler creates an HTTP handler for the Fleet debug endpoints.
+func MakeDebugHandler(svc kolide.Service, config config.KolideConfig, logger kitlog.Logger) http.Handler {
+	// kolideAPIOptions := []kithttp.ServerOption{
+	// 	kithttp.ServerBefore(
+	// 		kithttp.PopulateRequestContext, // populate the request context with common fields
+	// 		setRequestsContexts(svc, config.Auth.JwtKey),
+	// 	),
+	// 	kithttp.ServerErrorLogger(logger),
+	// 	kithttp.ServerErrorEncoder(encodeError),
+	// }
+
+	r := mux.NewRouter()
+	r.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	r.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	r.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	r.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	r.PathPrefix("/debug/pprof/").HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		token := token.FromHTTPRequest(req)
+		fmt.Fprintf(os.Stderr, "%v -- %+v\n", token, req)
+		pprof.Index(rw, req)
+	})
+
+	return r
+}

--- a/server/service/debug_handler.go
+++ b/server/service/debug_handler.go
@@ -2,10 +2,8 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/pprof"
-	"os"
 
 	"github.com/fleetdm/fleet/server/config"
 	"github.com/fleetdm/fleet/server/contexts/token"
@@ -51,8 +49,6 @@ func MakeDebugHandler(svc kolide.Service, config config.KolideConfig, logger kit
 	r.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	r.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	r.PathPrefix("/debug/pprof/").HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		token := token.FromHTTPRequest(req)
-		fmt.Fprintf(os.Stderr, "%v -- %+v\n", token, req)
 		pprof.Index(rw, req)
 	})
 

--- a/server/service/debug_handler_test.go
+++ b/server/service/debug_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/bmizerany/assert"
+	"github.com/fleetdm/fleet/server/config"
 	"github.com/fleetdm/fleet/server/kolide"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/mock"
@@ -33,34 +34,34 @@ func (m *mockService) User(ctx context.Context, userId uint) (*kolide.User, erro
 	return nil, args.Error(1)
 }
 
-func TestDebugHandlerAuthenticationTokenMissing(t *testing.T) {
-	handler := func(w http.ResponseWriter, r *http.Request) {}
+var testConfig = config.KolideConfig{
+	Auth: config.AuthConfig{
+		JwtKey: "insecure",
+	},
+}
 
-	mw := debugAuthenticationMiddleware{service: &mockService{}, jwtKey: "insecure"}
+func TestDebugHandlerAuthenticationTokenMissing(t *testing.T) {
+	handler := MakeDebugHandler(&mockService{}, testConfig, nil)
+
 	req := httptest.NewRequest(http.MethodGet, "https://fleetdm.com/debug/pprof/profile", nil)
 	res := httptest.NewRecorder()
 
-	mw.Middleware(http.HandlerFunc(handler)).ServeHTTP(res, req)
-
+	handler.ServeHTTP(res, req)
 	assert.Equal(t, http.StatusUnauthorized, res.Code)
-
 }
 
 func TestDebugHandlerAuthenticationTokenInvalid(t *testing.T) {
-	handler := func(w http.ResponseWriter, r *http.Request) {}
+	handler := MakeDebugHandler(&mockService{}, testConfig, nil)
 
-	mw := debugAuthenticationMiddleware{service: &mockService{}, jwtKey: "insecure"}
 	req := httptest.NewRequest(http.MethodGet, "https://fleetdm.com/debug/pprof/profile", nil)
 	req.Header.Add("Authorization", "BEARER foobar")
 	res := httptest.NewRecorder()
 
-	mw.Middleware(http.HandlerFunc(handler)).ServeHTTP(res, req)
-
+	handler.ServeHTTP(res, req)
 	assert.Equal(t, http.StatusUnauthorized, res.Code)
 }
 
 func TestDebugHandlerAuthenticationSessionInvalid(t *testing.T) {
-	handler := func(w http.ResponseWriter, r *http.Request) {}
 	svc := &mockService{}
 	svc.On(
 		"GetSessionByKey",
@@ -68,18 +69,17 @@ func TestDebugHandlerAuthenticationSessionInvalid(t *testing.T) {
 		"session",
 	).Return(nil, errors.New("invalid session"))
 
-	mw := debugAuthenticationMiddleware{service: svc, jwtKey: "insecure"}
+	handler := MakeDebugHandler(svc, testConfig, nil)
+
 	req := httptest.NewRequest(http.MethodGet, "https://fleetdm.com/debug/pprof/profile", nil)
 	req.Header.Add("Authorization", "BEARER eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXNzaW9uX2tleSI6InNlc3Npb24iLCJpYXQiOjE1MTYyMzkwMjJ9.YZIL9fKxfVg7fCms4CTKCPT2w8x8N3e2pciV_h0OvTk")
 	res := httptest.NewRecorder()
 
-	mw.Middleware(http.HandlerFunc(handler)).ServeHTTP(res, req)
-
+	handler.ServeHTTP(res, req)
 	assert.Equal(t, http.StatusUnauthorized, res.Code)
 }
 
 func TestDebugHandlerAuthenticationDisabled(t *testing.T) {
-	handler := func(w http.ResponseWriter, r *http.Request) {}
 	svc := &mockService{}
 	svc.On(
 		"GetSessionByKey",
@@ -91,19 +91,17 @@ func TestDebugHandlerAuthenticationDisabled(t *testing.T) {
 		mock.Anything,
 		uint(42),
 	).Return(&kolide.User{Enabled: false}, nil)
+	handler := MakeDebugHandler(svc, testConfig, nil)
 
-	mw := debugAuthenticationMiddleware{service: svc, jwtKey: "insecure"}
 	req := httptest.NewRequest(http.MethodGet, "https://fleetdm.com/debug/pprof/profile", nil)
 	req.Header.Add("Authorization", "BEARER eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXNzaW9uX2tleSI6InNlc3Npb24iLCJpYXQiOjE1MTYyMzkwMjJ9.YZIL9fKxfVg7fCms4CTKCPT2w8x8N3e2pciV_h0OvTk")
 	res := httptest.NewRecorder()
 
-	mw.Middleware(http.HandlerFunc(handler)).ServeHTTP(res, req)
-
+	handler.ServeHTTP(res, req)
 	assert.Equal(t, http.StatusForbidden, res.Code)
 }
 
 func TestDebugHandlerAuthenticationSuccess(t *testing.T) {
-	handler := func(w http.ResponseWriter, r *http.Request) {}
 	svc := &mockService{}
 	svc.On(
 		"GetSessionByKey",
@@ -116,12 +114,12 @@ func TestDebugHandlerAuthenticationSuccess(t *testing.T) {
 		uint(42),
 	).Return(&kolide.User{Enabled: true}, nil)
 
-	mw := debugAuthenticationMiddleware{service: svc, jwtKey: "insecure"}
-	req := httptest.NewRequest(http.MethodGet, "https://fleetdm.com/debug/pprof/profile", nil)
+	handler := MakeDebugHandler(svc, testConfig, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "https://fleetdm.com/debug/pprof/cmdline", nil)
 	req.Header.Add("Authorization", "BEARER eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXNzaW9uX2tleSI6InNlc3Npb24iLCJpYXQiOjE1MTYyMzkwMjJ9.YZIL9fKxfVg7fCms4CTKCPT2w8x8N3e2pciV_h0OvTk")
 	res := httptest.NewRecorder()
 
-	mw.Middleware(http.HandlerFunc(handler)).ServeHTTP(res, req)
-
+	handler.ServeHTTP(res, req)
 	assert.Equal(t, http.StatusOK, res.Code)
 }

--- a/server/service/debug_handler_test.go
+++ b/server/service/debug_handler_test.go
@@ -1,0 +1,127 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bmizerany/assert"
+	"github.com/fleetdm/fleet/server/kolide"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockService struct {
+	mock.Mock
+	kolide.Service
+}
+
+func (m *mockService) GetSessionByKey(ctx context.Context, sessionKey string) (*kolide.Session, error) {
+	args := m.Called(ctx, sessionKey)
+	if ret := args.Get(0); ret != nil {
+		return ret.(*kolide.Session), nil
+	}
+	return nil, args.Error(1)
+}
+
+func (m *mockService) User(ctx context.Context, userId uint) (*kolide.User, error) {
+	args := m.Called(ctx, userId)
+	if ret := args.Get(0); ret != nil {
+		return ret.(*kolide.User), nil
+	}
+	return nil, args.Error(1)
+}
+
+func TestDebugHandlerAuthenticationTokenMissing(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+
+	mw := debugAuthenticationMiddleware{service: &mockService{}, jwtKey: "insecure"}
+	req := httptest.NewRequest(http.MethodGet, "https://fleetdm.com/debug/pprof/profile", nil)
+	res := httptest.NewRecorder()
+
+	mw.Middleware(http.HandlerFunc(handler)).ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusUnauthorized, res.Code)
+
+}
+
+func TestDebugHandlerAuthenticationTokenInvalid(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+
+	mw := debugAuthenticationMiddleware{service: &mockService{}, jwtKey: "insecure"}
+	req := httptest.NewRequest(http.MethodGet, "https://fleetdm.com/debug/pprof/profile", nil)
+	req.Header.Add("Authorization", "BEARER foobar")
+	res := httptest.NewRecorder()
+
+	mw.Middleware(http.HandlerFunc(handler)).ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusUnauthorized, res.Code)
+}
+
+func TestDebugHandlerAuthenticationSessionInvalid(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	svc := &mockService{}
+	svc.On(
+		"GetSessionByKey",
+		mock.Anything,
+		"session",
+	).Return(nil, errors.New("invalid session"))
+
+	mw := debugAuthenticationMiddleware{service: svc, jwtKey: "insecure"}
+	req := httptest.NewRequest(http.MethodGet, "https://fleetdm.com/debug/pprof/profile", nil)
+	req.Header.Add("Authorization", "BEARER eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXNzaW9uX2tleSI6InNlc3Npb24iLCJpYXQiOjE1MTYyMzkwMjJ9.YZIL9fKxfVg7fCms4CTKCPT2w8x8N3e2pciV_h0OvTk")
+	res := httptest.NewRecorder()
+
+	mw.Middleware(http.HandlerFunc(handler)).ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusUnauthorized, res.Code)
+}
+
+func TestDebugHandlerAuthenticationDisabled(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	svc := &mockService{}
+	svc.On(
+		"GetSessionByKey",
+		mock.Anything,
+		"session",
+	).Return(&kolide.Session{UserID: 42, ID: 1}, nil)
+	svc.On(
+		"User",
+		mock.Anything,
+		uint(42),
+	).Return(&kolide.User{Enabled: false}, nil)
+
+	mw := debugAuthenticationMiddleware{service: svc, jwtKey: "insecure"}
+	req := httptest.NewRequest(http.MethodGet, "https://fleetdm.com/debug/pprof/profile", nil)
+	req.Header.Add("Authorization", "BEARER eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXNzaW9uX2tleSI6InNlc3Npb24iLCJpYXQiOjE1MTYyMzkwMjJ9.YZIL9fKxfVg7fCms4CTKCPT2w8x8N3e2pciV_h0OvTk")
+	res := httptest.NewRecorder()
+
+	mw.Middleware(http.HandlerFunc(handler)).ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusForbidden, res.Code)
+}
+
+func TestDebugHandlerAuthenticationSuccess(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	svc := &mockService{}
+	svc.On(
+		"GetSessionByKey",
+		mock.Anything,
+		"session",
+	).Return(&kolide.Session{UserID: 42, ID: 1}, nil)
+	svc.On(
+		"User",
+		mock.Anything,
+		uint(42),
+	).Return(&kolide.User{Enabled: true}, nil)
+
+	mw := debugAuthenticationMiddleware{service: svc, jwtKey: "insecure"}
+	req := httptest.NewRequest(http.MethodGet, "https://fleetdm.com/debug/pprof/profile", nil)
+	req.Header.Add("Authorization", "BEARER eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXNzaW9uX2tleSI6InNlc3Npb24iLCJpYXQiOjE1MTYyMzkwMjJ9.YZIL9fKxfVg7fCms4CTKCPT2w8x8N3e2pciV_h0OvTk")
+	res := httptest.NewRecorder()
+
+	mw.Middleware(http.HandlerFunc(handler)).ServeHTTP(res, req)
+
+	assert.Equal(t, http.StatusOK, res.Code)
+}


### PR DESCRIPTION
Adds endpoints and fleetctl commands to retrieve various debug profiles
from the Fleet server.

The best summary is from the help text:

```
fleetctl debug
NAME:
   fleetctl debug - Tools for debugging Fleet

USAGE:
   fleetctl debug command [command options] [arguments...]

COMMANDS:
   profile    Record a CPU profile from the Fleet server.
   cmdline    Get the command line used to invoke the Fleet server.
   heap       Report the allocated memory in the Fleet server.
   goroutine  Get stack traces of all goroutines (threads) in the Fleet server.
   trace      Record an execution trace on the Fleet server.
   archive    Create an archive with the entire suite of debug profiles.

OPTIONS:
   --config value   Path to the Fleet config file (default: "/Users/zwass/.fleet/config") [$CONFIG]
   --context value  Name of Fleet config context to use (default: "default") [$CONTEXT]
   --help, -h       show help
```