### PR TITLE
Add instructions to connect to Mailhog server in development docs.

### DIFF
--- a/docs/development/faq.md
+++ b/docs/development/faq.md
@@ -20,3 +20,9 @@ make: *** [fleet] Error 2
 ```
 
 If you get an `undefined: Asset` error it is likely because you did not run `make generate` before `make build`. See [Building the Code](https://github.com/fleetdm/fleet/blob/master/docs/development/building-the-code.md) for additional documentation on compiling the `fleet` binary.
+
+## How do I connect to the Mailhog simulated mailserver?
+
+First, in the Fleet UI, navigate to the App Settings page under Admin. Then, in the "SMTP Options" section, enter any email address in the "Sender Address" field, set the "SMPT Server" to 'localhost' on port '1025,' and set "Authentication Type" to 'None.' Note that you may use any active or inactive sender address.
+
+Visit `locahost:8025` to view Mailhog's admin interface which will display all emails sent using the simulated mailserver.

--- a/docs/development/faq.md
+++ b/docs/development/faq.md
@@ -25,4 +25,4 @@ If you get an `undefined: Asset` error it is likely because you did not run `mak
 
 First, in the Fleet UI, navigate to the App Settings page under Admin. Then, in the "SMTP Options" section, enter any email address in the "Sender Address" field, set the "SMTP Server" to `localhost` on port `1025`, and set "Authentication Type" to `None`. Note that you may use any active or inactive sender address.
 
-Visit `locahost:8025` to view Mailhog's admin interface which will display all emails sent using the simulated mail server.
+Visit [locahost:8025](http://localhost:8025) to view Mailhog's admin interface which will display all emails sent using the simulated mail server.

--- a/docs/development/faq.md
+++ b/docs/development/faq.md
@@ -23,6 +23,6 @@ If you get an `undefined: Asset` error it is likely because you did not run `mak
 
 ## How do I connect to the Mailhog simulated mail server?
 
-First, in the Fleet UI, navigate to the App Settings page under Admin. Then, in the "SMTP Options" section, enter any email address in the "Sender Address" field, set the "SMPT Server" to 'localhost' on port '1025,' and set "Authentication Type" to 'None.' Note that you may use any active or inactive sender address.
+First, in the Fleet UI, navigate to the App Settings page under Admin. Then, in the "SMTP Options" section, enter any email address in the "Sender Address" field, set the "SMTP Server" to `localhost` on port `1025`, and set "Authentication Type" to `None`. Note that you may use any active or inactive sender address.
 
 Visit `locahost:8025` to view Mailhog's admin interface which will display all emails sent using the simulated mail server.

--- a/docs/development/faq.md
+++ b/docs/development/faq.md
@@ -21,8 +21,8 @@ make: *** [fleet] Error 2
 
 If you get an `undefined: Asset` error it is likely because you did not run `make generate` before `make build`. See [Building the Code](https://github.com/fleetdm/fleet/blob/master/docs/development/building-the-code.md) for additional documentation on compiling the `fleet` binary.
 
-## How do I connect to the Mailhog simulated mailserver?
+## How do I connect to the Mailhog simulated mail server?
 
 First, in the Fleet UI, navigate to the App Settings page under Admin. Then, in the "SMTP Options" section, enter any email address in the "Sender Address" field, set the "SMPT Server" to 'localhost' on port '1025,' and set "Authentication Type" to 'None.' Note that you may use any active or inactive sender address.
 
-Visit `locahost:8025` to view Mailhog's admin interface which will display all emails sent using the simulated mailserver.
+Visit `locahost:8025` to view Mailhog's admin interface which will display all emails sent using the simulated mail server.


### PR DESCRIPTION
Added walkthrough for users attempting to connect to mailhog server.

Connecting to the simulated mailserver allows contributors to interact with features in Fleet UI that require email configuration.