### PR TITLE
Fix unexpected print of migration status warning

### DIFF
--- a/server/datastore/mysql/migrations/data/20181119180000_Placeholder.go
+++ b/server/datastore/mysql/migrations/data/20181119180000_Placeholder.go
@@ -1,0 +1,24 @@
+package data
+
+import (
+	"database/sql"
+)
+
+// This migration exists as a "placeholder" to prevent the unexpected printing
+// of a migration inconsistency warning on Fleet startup. The migration is
+// intentionally empty. See https://github.com/fleetdm/fleet/issues/48 for more
+// details.
+
+func init() {
+	MigrationClient.AddMigration(Up_20181119180000, Down_20181119180000)
+}
+
+func Up_20181119180000(tx *sql.Tx) error {
+	// Intentional noop
+	return nil
+}
+
+func Down_20181119180000(tx *sql.Tx) error {
+	// Intentional noop
+	return nil
+}


### PR DESCRIPTION
Replace the now-deleted migration
server/datastore/mysql/migrations/data/20181119180000_DeleteSoftDeletedEntities.go
with a new migration containing the same timestamp. This allows Fleet to
see the appropriate migration state for users upgrading from previous
versions without actually modifying the DB.

Fixes #48