### PR TITLE
Add fleetctl installer for NPM

### DIFF
--- a/docs/development/release.md
+++ b/docs/development/release.md
@@ -48,4 +48,7 @@ Upload the `fleet.zip` binary bundle and click "Publish Release".
 make docker-push-release
 ```
 
-6. Announce the release in the #fleet channel of [osquery Slack](https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/).
+6. Publish the new version of `fleetctl` on NPM. Update the version in the [package.json](../../../tools/fleetctl-npm/package.json) and publish with `npm publish`. Note that NPM does not allow replacing a package without creating a new version number. Take care to get things correct before running `npm publish`!
+
+7. Announce the release in the #fleet channel of [osquery Slack](https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/).
+

--- a/tools/fleetctl-npm/.gitignore
+++ b/tools/fleetctl-npm/.gitignore
@@ -1,0 +1,13 @@
+.DS_Store
+.idea
+*.log
+tmp/
+
+*.tern-port
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+*.tsbuildinfo
+.npm
+.eslintcache

--- a/tools/fleetctl-npm/README.md
+++ b/tools/fleetctl-npm/README.md
@@ -1,0 +1,13 @@
+[![banner-fleet-cloud-city](https://user-images.githubusercontent.com/618009/98254443-eaf21100-1f41-11eb-9e2c-63a0545601f3.jpg)](https://fleetdm.com)
+
+This is an installer for the `fleetctl` CLI tool.
+
+Use the `fleetctl` CLI to interact with a Fleet server and manage connected osquery agents. Have a look at the [Fleet README](https://github.com/fleetdm/fleet#readme) for more information.
+
+## Installation
+
+Simply install `fleetctl` with `npm install -g fleetctl`.
+
+## Usage
+
+See the [fleetctl documentation](https://github.com/fleetdm/fleet/tree/master/docs/cli#cli-documentation) or `fleetctl --help` for usage instructions. 

--- a/tools/fleetctl-npm/binary.js
+++ b/tools/fleetctl-npm/binary.js
@@ -1,0 +1,71 @@
+// Based on the MIT licensed example in
+// https://github.com/cloudflare/binary-install/blob/master/packages/binary-install-example/binary.js
+
+const { Binary } = require('binary-install');
+const os = require('os');
+
+const { version } = require('./package.json');
+
+const downloadUrl = 'https://github.com/fleetdm/fleet/releases/download';
+
+const supportedPlatforms = [
+  {
+    TYPE: 'Windows_NT',
+    ARCHITECTURE: 'x64',
+    TARGET: 'fleetctl-windows.tar.gz',
+  },
+  {
+    TYPE: 'Linux',
+    ARCHITECTURE: 'x64',
+    TARGET: 'fleetctl-linux.tar.gz',
+  },
+  {
+    TYPE: 'Darwin',
+    ARCHITECTURE: 'x64',
+    TARGET: 'fleetctl-macos.tar.gz',
+  },
+];
+
+const getPlatform = () => {
+  const type = os.type();
+  const architecture = os.arch();
+
+  for (const index in supportedPlatforms) {
+    const supportedPlatform = supportedPlatforms[index];
+    if (
+      type === supportedPlatform.TYPE &&
+        architecture === supportedPlatform.ARCHITECTURE
+    ) {
+      return supportedPlatform.TARGET;
+    }
+  }
+
+  console.error(
+    `Platform ${type} and architecture ${architecture} is not supported.`,
+  );
+  process.exit(1);
+
+  return undefined;
+};
+
+const getBinary = () => {
+  const target = getPlatform();
+  // the url for this binary is constructed from values in `package.json`
+  const url = `${downloadUrl}/${version}/${target}`;
+  return new Binary('fleetctl', url);
+};
+
+const run = () => {
+  const binary = getBinary();
+  binary.run();
+};
+
+const install = () => {
+  const binary = getBinary();
+  binary.install();
+};
+
+module.exports = {
+  install,
+  run,
+};

--- a/tools/fleetctl-npm/binary.js
+++ b/tools/fleetctl-npm/binary.js
@@ -13,20 +13,23 @@ const supportedPlatforms = [
     TYPE: 'Windows_NT',
     ARCHITECTURE: 'x64',
     TARGET: 'fleetctl-windows.tar.gz',
+    BINARY_NAME: 'fleetctl.exe',
   },
   {
     TYPE: 'Linux',
     ARCHITECTURE: 'x64',
     TARGET: 'fleetctl-linux.tar.gz',
+    BINARY_NAME: 'fleetctl',
   },
   {
     TYPE: 'Darwin',
     ARCHITECTURE: 'x64',
     TARGET: 'fleetctl-macos.tar.gz',
+    BINARY_NAME: 'fleetctl',
   },
 ];
 
-const getPlatform = () => {
+const getPlatformMetadata = () => {
   const type = os.type();
   const architecture = os.arch();
 
@@ -36,7 +39,7 @@ const getPlatform = () => {
       type === supportedPlatform.TYPE &&
         architecture === supportedPlatform.ARCHITECTURE
     ) {
-      return supportedPlatform.TARGET;
+      return supportedPlatform;
     }
   }
 
@@ -49,10 +52,10 @@ const getPlatform = () => {
 };
 
 const getBinary = () => {
-  const target = getPlatform();
+  const metadata = getPlatformMetadata();
   // the url for this binary is constructed from values in `package.json`
-  const url = `${downloadUrl}/${version}/${target}`;
-  return new Binary('fleetctl', url);
+  const url = `${downloadUrl}/${version}/${metadata.TARGET}`;
+  return new Binary(metadata.BINARY_NAME, url);
 };
 
 const run = () => {

--- a/tools/fleetctl-npm/install.js
+++ b/tools/fleetctl-npm/install.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+const { install } = require('./binary');
+
+install();

--- a/tools/fleetctl-npm/package-lock.json
+++ b/tools/fleetctl-npm/package-lock.json
@@ -1,0 +1,185 @@
+{
+  "name": "fleetctl",
+  "version": "3.3.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "binary-install": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-0.1.0.tgz",
+      "integrity": "sha512-f5y8Iyh1PPu/zUYKGt7qXOCuZv8tiAiyluXQokmeOC5leWAyBKqWD3T1QPx0iRRvHbRCO+v/VU+5+ai5Keswmg==",
+      "requires": {
+        "axios": "^0.19.2",
+        "rimraf": "^3.0.2",
+        "tar": "^6.0.2"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minipass": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      }
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "tar": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
+      "integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
+      "requires": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    }
+  }
+}

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -21,5 +21,6 @@
   "homepage": "https://fleetdm.com",
   "dependencies": {
     "binary-install": "0.1.0"
-  }
+  },
+  "keywords": ["osquery", "security"]
 }

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "osquery-fleetctl",
+  "version": "3.3.0",
+  "description": "Installer for the fleetctl CLI tool",
+  "main": "binary.js",
+  "bin": {
+    "fleetctl": "./run.js"
+  },
+  "scripts": {
+    "postinstall": "node ./install.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fleetdm/fleet"
+  },
+  "author": "Fleet Developers",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/fleetdm/fleet/issues"
+  },
+  "homepage": "https://fleetdm.com",
+  "dependencies": {
+    "binary-install": "0.1.0"
+  }
+}

--- a/tools/fleetctl-npm/run.js
+++ b/tools/fleetctl-npm/run.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+const { run } = require('./binary');
+
+run();


### PR DESCRIPTION
This PR adds all the necessary configuration to install fleetctl via NPM.

Binaries are downloaded from the GitHub release page.