### PR TITLE
Add instructions for running osquery agents to development docs.

### DIFF
--- a/docs/development/faq.md
+++ b/docs/development/faq.md
@@ -27,7 +27,7 @@ First, in the Fleet UI, navigate to the App Settings page under Admin. Then, in 
 
 Visit [locahost:8025](http://localhost:8025) to view Mailhog's admin interface which will display all emails sent using the simulated mail server.
 
-## Adding fake hosts for testing
+## Adding hosts for testing
 
 The `osquery` directory contains a docker-compose.yml and additional configuration files to start containerized osquery agents. 
 

--- a/docs/development/faq.md
+++ b/docs/development/faq.md
@@ -26,3 +26,14 @@ If you get an `undefined: Asset` error it is likely because you did not run `mak
 First, in the Fleet UI, navigate to the App Settings page under Admin. Then, in the "SMTP Options" section, enter any email address in the "Sender Address" field, set the "SMTP Server" to `localhost` on port `1025`, and set "Authentication Type" to `None`. Note that you may use any active or inactive sender address.
 
 Visit [locahost:8025](http://localhost:8025) to view Mailhog's admin interface which will display all emails sent using the simulated mail server.
+
+## Adding fake hosts for testing
+
+The `osquery` directory contains a docker-compose.yml and additional configuration files to start containerized osquery agents. 
+
+To start osquery, first retrieve the "Enroll Secret" from Fleet (by clicking the "Add New Host") button in the Fleet dashboard, or with `fleetctl get enroll-secret`).
+
+```
+cd tools/osquery
+ENROLL_SECRET=<copy from fleet> docker-compose up
+```


### PR DESCRIPTION
Used same verbiage from osquery-in-a-box README (https://github.com/fleetdm/osquery-in-a-box#run-osquery).

Title "Adding fake hosts for testing" is less technical.