### PR TITLE
Change name from Kolide Fleet to Fleet in documentation.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Fleet Documentation
 
-Welcome to the documentation for the Kolide Fleet osquery fleet manager.
+Welcome to the documentation for the Fleet osquery fleet manager.
 
 - If you're interested in using the `fleetctl` CLI to manage your osquery fleet, see the [CLI Documentation](./cli/README.md).
 - Resources for deploying osquery to hosts, deploying the Fleet server, installing Fleet's infrastructure dependencies, etc. can all be found in the [Infrastructure Documentation](./infrastructure/README.md).

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,7 +1,7 @@
 API Documentation
 =================
 
-Kolide Fleet is powered by a Go API server which serves three types of endpoints:
+Fleet is powered by a Go API server which serves three types of endpoints:
 
 - Endpoints starting with `/api/v1/osquery/` are osquery TLS server API endpoints. All of these endpoints are used for talking to osqueryd agents and that's it.
 - Endpoints starting with `/api/v1/kolide/` are endpoints to interact with the Fleet data model (packs, queries, scheduled queries, labels, hosts, etc) as well as application endpoints (configuring settings, logging in, session management, etc).

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1,7 +1,7 @@
 CLI Documentation
 =================
 
-Kolide Fleet provides a server which allows you to manage and orchestrate an osquery deployment across of a set of workstations and servers. For certain use-cases, it makes sense to maintain the configuration and data of an osquery deployment in source-controlled files. It is also desirable to be able to manage these files with a familiar command-line tool. To facilitate this, Kolide Fleet includes a `fleetctl` CLI for managing osquery fleets in this way.
+Fleet provides a server which allows you to manage and orchestrate an osquery deployment across of a set of workstations and servers. For certain use-cases, it makes sense to maintain the configuration and data of an osquery deployment in source-controlled files. It is also desirable to be able to manage these files with a familiar command-line tool. To facilitate this, Fleet includes a `fleetctl` CLI for managing osquery fleets in this way.
 
 For more information, see:
 

--- a/docs/cli/file-format.md
+++ b/docs/cli/file-format.md
@@ -251,7 +251,7 @@ spec:
 
 ### Auto Table Construction
 
-You can use Kolide Fleet to query local SQLite databases as tables. For more information on creating ATC configuration from a SQLite database, see the [Osquery Automatic Table Construction documentation](https://osquery.readthedocs.io/en/stable/deployment/configuration/#automatic-table-construction)
+You can use Fleet to query local SQLite databases as tables. For more information on creating ATC configuration from a SQLite database, see the [Osquery Automatic Table Construction documentation](https://osquery.readthedocs.io/en/stable/deployment/configuration/#automatic-table-construction)
 
 If you already know what your ATC configuration needs to look like, you can add it to an options config file:
 

--- a/docs/dashboard/README.md
+++ b/docs/dashboard/README.md
@@ -1,9 +1,9 @@
 Dashboard Documentation
 =========================
 
-Kolide Fleet is an application that allows you to take advantage of the power of osquery in order to maintain constant insight into the state of your infrastructure (security, health, stability, performance, compliance, etc). The dashboard documentation contains documents on the following topics:
+Fleet is an application that allows you to take advantage of the power of osquery in order to maintain constant insight into the state of your infrastructure (security, health, stability, performance, compliance, etc). The dashboard documentation contains documents on the following topics:
 
-## Using the Kolide Fleet Dashboard
+## Using the Fleet Dashboard
 
 - For information on running osquery queries on hosts in your infrastructure, you can refer to the [Running Queries](./running-queries.md) page.
 - For information on configuring SSO for logging in to Fleet, see the guide on [Configuring Single Sign On](./single-sign-on.md).

--- a/docs/infrastructure/README.md
+++ b/docs/infrastructure/README.md
@@ -1,7 +1,7 @@
 Infrastructure Documentation
 ============================
 
-Kolide Fleet is an infrastructure instrumentation application which has it's own infrastructure dependencies and requirements. The infrastructure documentation contains documents on the following topics:
+Fleet is an infrastructure instrumentation application which has it's own infrastructure dependencies and requirements. The infrastructure documentation contains documents on the following topics:
 
 ## Deploying and configuring osquery
 

--- a/docs/infrastructure/adding-hosts-to-fleet.md
+++ b/docs/infrastructure/adding-hosts-to-fleet.md
@@ -1,12 +1,12 @@
 # Adding Hosts To Fleet
 
-Kolide Fleet is powered by the open source osquery tool. To connect a host to Kolide Fleet, you have two general options. You can install the osquery binaries on your hosts via the packages distributed at https://osquery.io/downloads or you can use the [Kolide Osquery Launcher](https://github.com/kolide/launcher). The Launcher is a light wrapper that aims to make running and deploying osquery easier by adding a few features and minimizing the configuration interface. Some features of The Launcher are:
+Fleet is powered by the open source osquery tool. To connect a host to Fleet, you have two general options. You can install the osquery binaries on your hosts via the packages distributed at https://osquery.io/downloads or you can use the [Kolide Osquery Launcher](https://github.com/kolide/launcher). The Launcher is a light wrapper that aims to make running and deploying osquery easier by adding a few features and minimizing the configuration interface. Some features of The Launcher are:
 
 - Secure autoupdates to the latest stable osqueryd
 - Remote communication via a strongly-typed, versioned, modern gRPC server API
 - a curated `kolide_best_practices` table which includes a curated set of standards for the modern enterprise
 
-The Launcher also contains robust tooling to help you generate packages for your environment that are designed to work together with Kolide Fleet. For specific documentation on using Launcher with Fleet, see the section below called "Kolide Osquery Launcher".
+The Launcher also contains robust tooling to help you generate packages for your environment that are designed to work together with Fleet. For specific documentation on using Launcher with Fleet, see the section below called "Kolide Osquery Launcher".
 
 If you'd like to use the native osqueryd binaries to connect to Fleet, this is enabled by using osquery's TLS API plugins that are principally documented on the official osquery wiki: http://osquery.readthedocs.io/en/stable/deployment/remote/. These plugins are very customizable and thus have a large configuration surface. Configuring osqueryd to communicate with Fleet is documented below in the "Native Osquery TLS Plugins" section.
 

--- a/docs/infrastructure/fleet-on-centos.md
+++ b/docs/infrastructure/fleet-on-centos.md
@@ -1,7 +1,7 @@
-Kolide Fleet on CentOS
+Fleet on CentOS
 ======================
 
-In this guide, we're going to install Kolide Fleet and all of it's application dependencies on a CentOS 7.1 server. Once we have Fleet up and running, we're going to install osquery on that same CentOS 7.1 host and enroll it in Fleet. This should give you a good understanding of both how to install Fleet as well as how to install and configure osquery such that it can communicate with Fleet.
+In this guide, we're going to install Fleet and all of it's application dependencies on a CentOS 7.1 server. Once we have Fleet up and running, we're going to install osquery on that same CentOS 7.1 host and enroll it in Fleet. This should give you a good understanding of both how to install Fleet as well as how to install and configure osquery such that it can communicate with Fleet.
 
 ## Setting up a host
 

--- a/docs/infrastructure/fleet-on-kubernetes.md
+++ b/docs/infrastructure/fleet-on-kubernetes.md
@@ -70,7 +70,7 @@ We will use this address when we configure the Kubernetes deployment, but if you
 
 > ### A note on container versions
 >
-> The Kubernetes files referenced by this tutorial use the Kolide Fleet container tagged at `1.0.5`. The tag is something that should be consistent across the migration job and the deployment specification. If you use these files, I suggest creating a workflow that allows you templatize the value of this tag. For further reading on this topic, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/overview/#container-images).
+> The Kubernetes files referenced by this tutorial use the Fleet container tagged at `1.0.5`. The tag is something that should be consistent across the migration job and the deployment specification. If you use these files, I suggest creating a workflow that allows you templatize the value of this tag. For further reading on this topic, see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/overview/#container-images).
 
 ### Create Server Secrets
 

--- a/docs/infrastructure/fleet-on-ubuntu.md
+++ b/docs/infrastructure/fleet-on-ubuntu.md
@@ -1,7 +1,7 @@
-Kolide Fleet on Ubuntu
+Fleet on Ubuntu
 ======================
 
-In this guide, we're going to install Kolide Fleet and all of it's application dependencies on an Ubuntu 16.04 LTS server. Once we have Fleet up and running, we're going to install osquery on that same Ubuntu 16.04 host and enroll it in Fleet. This should give you a good understanding of both how to install Fleet as well as how to install and configure osquery such that it can communicate with Fleet.
+In this guide, we're going to install Fleet and all of it's application dependencies on an Ubuntu 16.04 LTS server. Once we have Fleet up and running, we're going to install osquery on that same Ubuntu 16.04 host and enroll it in Fleet. This should give you a good understanding of both how to install Fleet as well as how to install and configure osquery such that it can communicate with Fleet.
 
 ## Setting up a host
 

--- a/docs/infrastructure/systemd.md
+++ b/docs/infrastructure/systemd.md
@@ -6,7 +6,7 @@ Below is a sample unit file.
 
 ```
 [Unit]
-Description=Kolide Fleet
+Description=Fleet
 After=network.target
 
 [Service]


### PR DESCRIPTION
In the documentation, all references to the Fleet product now use "Fleet" instead of "Kolide Fleet"