### PR TITLE
Dedupe setting of env var

### DIFF
--- a/website/Procfile
+++ b/website/Procfile
@@ -1,1 +1,1 @@
-web: NODE_ENV=production node app.js
+web: npm start


### PR DESCRIPTION
No need to set `NODE_ENV=production` twice