### PR TITLE
Fix for deploy-fleet-website GitHub action.

### DIFF
--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
 
-    if: GITHUB_REPOSITORY == 'fleetdm/fleet'
+    if: $GITHUB_REPOSITORY == 'fleetdm/fleet'
     
     runs-on: ubuntu-latest
 

--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   build:
-
     if: $GITHUB_REPOSITORY == 'fleetdm/fleet'
     
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fourth attempt to limit the "Deploy Fleet Website" workflow to only the fleetdm/fleet repository.
Add the `$` character to the `$GITHUB_REPOSITORY` env variable.