### PR TITLE
Default to --host_identifier=instance in docs

### DIFF
--- a/docs/infrastructure/adding-hosts-to-fleet.md
+++ b/docs/infrastructure/adding-hosts-to-fleet.md
@@ -109,7 +109,7 @@ sudo osqueryd \
  --enroll_secret_path=/etc/osquery/enroll_secret \
  --tls_server_certs=/etc/osquery/kolide.crt \
  --tls_hostname=kolide.acme.net \
- --host_identifier=uuid \
+ --host_identifier=instance \
  --enroll_tls_endpoint=/api/v1/osquery/enroll \
  --config_plugin=tls \
  --config_tls_endpoint=/api/v1/osquery/config \

--- a/docs/infrastructure/fleet-on-centos.md
+++ b/docs/infrastructure/fleet-on-centos.md
@@ -185,7 +185,7 @@ sudo /usr/bin/osqueryd \
   --enroll_secret_path=/var/osquery/enroll_secret \
   --tls_server_certs=/var/osquery/server.pem \
   --tls_hostname=localhost:8080 \
-  --host_identifier=uuid \
+  --host_identifier=instance \
   --enroll_tls_endpoint=/api/v1/osquery/enroll \
   --config_plugin=tls \
   --config_tls_endpoint=/api/v1/osquery/config \

--- a/docs/infrastructure/fleet-on-ubuntu.md
+++ b/docs/infrastructure/fleet-on-ubuntu.md
@@ -155,7 +155,7 @@ sudo /usr/bin/osqueryd \
   --enroll_secret_path=/var/osquery/enroll_secret \
   --tls_server_certs=/var/osquery/server.pem \
   --tls_hostname=localhost:8080 \
-  --host_identifier=hostname \
+  --host_identifier=instance \
   --enroll_tls_endpoint=/api/v1/osquery/enroll \
   --config_plugin=tls \
   --config_tls_endpoint=/api/v1/osquery/config \

--- a/frontend/components/hosts/AddHostModal/AddHostModal.jsx
+++ b/frontend/components/hosts/AddHostModal/AddHostModal.jsx
@@ -72,7 +72,7 @@ class AddHostModal extends Component {
     const flagfileContent = `--enroll_secret_path=secret.txt
 --tls_server_certs=fleet.pem
 --tls_hostname=${tlsHostname}
---host_identifier=uuid
+--host_identifier=instance
 --enroll_tls_endpoint=/api/v1/osquery/enroll
 --config_plugin=tls
 --config_tls_endpoint=/api/v1/osquery/config

--- a/tools/mac/config.mk
+++ b/tools/mac/config.mk
@@ -12,7 +12,7 @@ endef
 # Osquery flag file. No need to modify.
 define KOLIDE_FLAGS
 --force=true
---host_identifier=hostname
+--host_identifier=instance
 --verbose=true
 --debug
 --tls_dump=true

--- a/tools/osquery/example_osquery.flags
+++ b/tools/osquery/example_osquery.flags
@@ -1,5 +1,5 @@
 --force=true
---host_identifier=hostname
+--host_identifier=instance
 --verbose=true
 --debug
 --tls_dump=true


### PR DESCRIPTION
This may be a better default for folks to use as it will prevent the
issues caused by duplicate UUIDs in #102.