### PR TITLE
New styles for 404, 500, Login, User settings, and Confirm invite pages.

### DIFF
--- a/frontend/components/AuthenticationFormWrapper/AuthenticationFormWrapper.jsx
+++ b/frontend/components/AuthenticationFormWrapper/AuthenticationFormWrapper.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import fleetLogoText from '../../../assets/images/fleet-logo-text-black.svg';
+import fleetLogoText from '../../../assets/images/fleet-logo-text-white.svg';
 
 const baseClass = 'auth-form-wrapper';
 

--- a/frontend/components/AuthenticationFormWrapper/_styles.scss
+++ b/frontend/components/AuthenticationFormWrapper/_styles.scss
@@ -6,8 +6,7 @@
   padding: $pad-base 0;
 
   &__logo {
-    width: 160px;
-    height: 141px;
+    width: 120px;
     margin: 0 auto;
   }
 

--- a/frontend/components/LoginRoutes/_styles.scss
+++ b/frontend/components/LoginRoutes/_styles.scss
@@ -5,5 +5,5 @@
   justify-content: center;
   position: relative;
   min-height: 100vh;
-  background-color: $white;
+  background-color: $core-gradient;
 }

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -133,8 +133,6 @@ $base-class: 'button';
     color: $white;
     font-size: $large;
     font-weight: $regular;
-    letter-spacing: 4px;
-    padding: $medium;
     width: 100%;
     height: auto;
   }

--- a/frontend/components/forms/ChangePasswordForm/ChangePasswordForm.jsx
+++ b/frontend/components/forms/ChangePasswordForm/ChangePasswordForm.jsx
@@ -43,7 +43,7 @@ class ChangePasswordForm extends Component {
           type="password"
         />
         <div className={`${baseClass}__btn-wrap`}>
-          <Button type="submit" variant="brand" className={`${baseClass}__btn`}>Change Password</Button>
+          <Button type="submit" variant="brand" className={`${baseClass}__btn`}>Change password</Button>
           <Button onClick={onCancel} variant="inverse" className={`${baseClass}__btn`}>Cancel</Button>
         </div>
       </form>

--- a/frontend/components/forms/ChangePasswordForm/_styles.scss
+++ b/frontend/components/forms/ChangePasswordForm/_styles.scss
@@ -5,11 +5,8 @@
   }
 
   &__btn {
-    font-size: $small;
-    height: 38px;
-    margin-bottom: 5px;
-    margin-left: 15px;
-    padding: 0;
-    width: 120px;
+    &:last-child {
+      margin-right: 16px;
+    }
   }
 }

--- a/frontend/components/forms/ConfirmInviteForm/ConfirmInviteForm.jsx
+++ b/frontend/components/forms/ConfirmInviteForm/ConfirmInviteForm.jsx
@@ -51,7 +51,7 @@ class ConfirmInviteForm extends Component {
             type="password"
           />
         </div>
-        <div className={`${className}__button-wrap`}>
+        <div className="confirm-invite-button-wrap">
           <Button onClick={handleSubmit} type="Submit" className="button button--brand">
             Submit
           </Button>

--- a/frontend/components/forms/ConfirmInviteForm/ConfirmInviteForm.jsx
+++ b/frontend/components/forms/ConfirmInviteForm/ConfirmInviteForm.jsx
@@ -37,25 +37,25 @@ class ConfirmInviteForm extends Component {
           />
           <InputFieldWithIcon
             {...fields.username}
-            iconName="username"
             placeholder="Username"
           />
           <InputFieldWithIcon
             {...fields.password}
-            iconName="password"
             placeholder="Password"
             type="password"
+            hint={['Must include 7 characters, at least 1 number (e.g. 0 - 9), and at least 1 symbol (e.g. &*#)']}
           />
           <InputFieldWithIcon
             {...fields.password_confirmation}
-            iconName="password"
             placeholder="Confirm Password"
             type="password"
           />
         </div>
-        <Button onClick={handleSubmit} type="Submit" variant="gradient">
-          Submit
-        </Button>
+        <div className={`${className}__button-wrap`}>
+          <Button onClick={handleSubmit} type="Submit" className="button button--brand">
+            Submit
+          </Button>
+        </div>
       </form>
     );
   }

--- a/frontend/components/forms/LoginForm/LoginForm.jsx
+++ b/frontend/components/forms/LoginForm/LoginForm.jsx
@@ -84,27 +84,24 @@ class LoginForm extends Component {
           <InputFieldWithIcon
             {...fields.username}
             autofocus
-            iconName="username"
             placeholder="Username or Email"
           />
           <InputFieldWithIcon
             {...fields.password}
-            iconName="password"
             placeholder="Password"
             type="password"
           />
           <div className={`${baseClass}__forgot-wrap`}>
             <Link className={`${baseClass}__forgot-link`} to={paths.FORGOT_PASSWORD}>Forgot Password?</Link>
           </div>
+          <Button
+            className={`${baseClass}__submit-btn button button--brand`}
+            onClick={handleSubmit}
+            type="submit"
+          >
+            Login
+          </Button>
         </div>
-        <Button
-          className={`${baseClass}__submit-btn`}
-          onClick={handleSubmit}
-          type="submit"
-          variant="gradient"
-        >
-          Login
-        </Button>
         { ssoEnabled && showSingleSignOnButton()}
       </form>
     );

--- a/frontend/components/forms/LoginForm/_styles.scss
+++ b/frontend/components/forms/LoginForm/_styles.scss
@@ -1,13 +1,13 @@
 .login-form {
-  transition: transform 300ms ease-in;
-  transform: scale(1);
-  margin-top: -260px;
+  transition: opacity 300ms ease-in;
+  transform: translateY(-150px);
   opacity: 1;
-  width: 460px;
+  width: 500px;
   align-self: center;
+  border-radius: 10px;
+  overflow: hidden;
 
   &--hidden {
-    transform: scale(1.3);
     opacity: 0;
   }
 
@@ -19,37 +19,32 @@
     border-top-right-radius: 0;
     box-sizing: border-box;
     flex-direction: column;
-    padding: 30px;
-    width: 460px;
-    min-height: 350px;
+    padding: 40px;
     font-weight: $regular;
   }
 
   &__submit-btn {
-    border-radius: 2px;
-    padding: $pad-base;
-    width: 460px;
+    margin-top: 40px;
+    width: 160px;
   }
 
   &__sso-btn {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
     padding: $pad-base;
-    width: 460px;
     height: 72px;
   }
 
   &__forgot-wrap {
-    margin-top: $pad-base;
+    margin-top: 4px;
     text-align: right;
     width: 100%;
   }
 
   &__forgot-link {
-    font-size: $medium;
-    letter-spacing: 1px;
+    font-size: $x-small;
     text-decoration: none;
-    color: $core-medium-blue-grey;
+    color: $core-blue;
   }
 
   &__sso-image {

--- a/frontend/components/forms/UserSettingsForm/UserSettingsForm.jsx
+++ b/frontend/components/forms/UserSettingsForm/UserSettingsForm.jsx
@@ -62,8 +62,8 @@ class UserSettingsForm extends Component {
           label="Position"
         />
         <div className={`${baseClass}__button-wrap`}>
-          <Button onClick={onCancel} variant="inverse">CANCEL</Button>
-          <Button type="submit" variant="brand">UPDATE</Button>
+          <Button onClick={onCancel} variant="inverse">Cancel</Button>
+          <Button type="submit" variant="brand">Update</Button>
         </div>
       </form>
     );

--- a/frontend/components/forms/UserSettingsForm/_styles.scss
+++ b/frontend/components/forms/UserSettingsForm/_styles.scss
@@ -1,6 +1,13 @@
 .manage-user {
   .input-field {
-    width: 75%;
+    width: 100%;
+  }
+
+  .form-field {
+    &__label {
+      font-size: $x-small;
+      font-weight: $bold;
+    }
   }
 
   &__email-hint {
@@ -8,16 +15,15 @@
   }
 
   &__button-wrap {
-    width: 75%;
-    border-top: 1px solid $ui-borders;
-    padding-top: 45px;
-    margin-top: 45px;
+    width: 100%;
+    margin-top: 40px;
+    display: flex;
+    justify-content: flex-end;
 
     .button {
-      width: calc(50% - 30px);
 
       &:last-child {
-        margin-left: 60px;
+        margin-left: 16px;
       }
     }
   }

--- a/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
+++ b/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
@@ -49,7 +49,7 @@
   &__label {
     font-size: $x-small;
     font-weight: $bold;
-    margin-bottom: 2px;
+    margin-bottom: 4px;
   }
 
   &__errors {

--- a/frontend/pages/ConfirmInvitePage/ConfirmInvitePage.jsx
+++ b/frontend/pages/ConfirmInvitePage/ConfirmInvitePage.jsx
@@ -55,18 +55,14 @@ class ConfirmInvitePage extends Component {
 
     return (
       <AuthenticationFormWrapper>
-        <div className={`${baseClass}__lead-wrapper`}>
-          <p className={`${baseClass}__lead-text`}>
-            Welcome to the party, {inviteFormData.email}!
-          </p>
-          <p className={`${baseClass}__sub-lead-text`}>
-            Please take a moment to fill out the following information before we take you into <b>Fleet</b>
-          </p>
-        </div>
-        <div className={`${baseClass}__form-section-wrapper`}>
-          <div className={`${baseClass}__form-section-description`}>
-            <h2>SET USERNAME & PASSWORD</h2>
-            <p>Password must include 7 characters, at least 1 number (eg. 0-9), and at least 1 symbol (eg. ^&*#)</p>
+        <div className={`${baseClass}`}>
+          <div className={`${baseClass}__lead-wrapper`}>
+            <p className={`${baseClass}__lead-text`}>
+              Welcome to Fleet
+            </p>
+            <p className={`${baseClass}__sub-lead-text`}>
+              Before you get started, please take a moment to complete the following information.
+            </p>
           </div>
           <ConfirmInviteForm
             className={`${baseClass}__form`}

--- a/frontend/pages/ConfirmInvitePage/_styles.scss
+++ b/frontend/pages/ConfirmInvitePage/_styles.scss
@@ -36,7 +36,7 @@
   &__lead-text {
     font-size: $medium;
     font-weight: $regular;
-    margin: 0 0 6px 0;
+    margin: 0 0 6px;
     text-align: center;
   }
 
@@ -47,7 +47,7 @@
     margin: 0;
   }
 
-  .confirm-invite-page__form__button-wrap {
+  .confirm-invite-button-wrap {
     display: flex;
     justify-content: center;
     margin-top: 40px;

--- a/frontend/pages/ConfirmInvitePage/_styles.scss
+++ b/frontend/pages/ConfirmInvitePage/_styles.scss
@@ -1,4 +1,10 @@
 .confirm-invite-page {
+  background-color: $white;
+  border-radius: 10px;
+  width: 436px;
+  padding: 40px;
+  margin-top: 40px;
+
   &__form-section-description {
     h2 {
       font-size: 18px;
@@ -18,51 +24,36 @@
   }
 
   &__form-section-wrapper {
-    background-color: $white;
-    border-radius: 4px;
-    box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.3);
     box-sizing: border-box;
-    height: 459px;
-    padding: 35px;
-    width: 500px;
     margin-bottom: 110px;
   }
 
-  &__form {
-    width: 440px;
-
-    .fields {
-      background-color: $white;
-      border-top-left-radius: 4px;
-      border-top-right-radius: 4px;
-      box-shadow: 0 10px 30px 0 rgba(0, 0, 0, 0.3);
-      box-sizing: border-box;
-      padding: 30px;
-    }
-  }
-
   &__lead-wrapper {
-    background-color: $white;
     border-radius: 4px;
-    box-shadow: 0 0 30px 0 rgba(0, 0, 0, 0.3);
     box-sizing: border-box;
-    margin-bottom: 30px;
-    padding: 35px;
-    width: 500px;
   }
 
   &__lead-text {
-    color: $core-blue;
-    font-size: 18px;
+    font-size: $medium;
     font-weight: $regular;
-    margin-top: 0;
+    margin: 0 0 6px 0;
     text-align: center;
   }
 
   &__sub-lead-text {
-    color: $core-dark-blue-grey;
-    font-size: 14px;
+    font-size: $x-small;
     font-weight: $regular;
-    margin-bottom: 0;
+    text-align: center;
+    margin: 0;
+  }
+
+  .confirm-invite-page__form__button-wrap {
+    display: flex;
+    justify-content: center;
+    margin-top: 40px;
+
+    .button {
+      width: 160px;
+    }
   }
 }

--- a/frontend/pages/Fleet404/Fleet404.jsx
+++ b/frontend/pages/Fleet404/Fleet404.jsx
@@ -3,9 +3,9 @@ import React, { Component } from 'react';
 import fleetLogoText from '../../../assets/images/fleet-logo-text-white.svg';
 import backgroundImg from '../../../assets/images/404.svg';
 
-const baseClass = 'kolide-404';
+const baseClass = 'fleet-404';
 
-class Kolide404 extends Component {
+class Fleet404 extends Component {
   render () {
     return (
       <div className={baseClass}>
@@ -16,7 +16,7 @@ class Kolide404 extends Component {
         </header>
         <img src={backgroundImg} alt="404 background" className="background-image" />
         <main>
-          <h1>404: Oops, sorry we can&apos;t find that page!</h1>
+          <h1><span>404:</span> Oops, sorry we can&apos;t find that page!</h1>
           <p>The page you are looking for has either moved, or doesn&apos;t exist.</p>
           <a href="https://fleetdm.com/support">Get help</a>
         </main>
@@ -25,4 +25,4 @@ class Kolide404 extends Component {
   }
 }
 
-export default Kolide404;
+export default Fleet404;

--- a/frontend/pages/Fleet404/_styles.scss
+++ b/frontend/pages/Fleet404/_styles.scss
@@ -1,10 +1,11 @@
-.kolide-404 {
+.fleet-404 {
   p {
-    color: #666;
+    color: #333;
+    font-style: $regular;
   }
 
   a {
-    color: #4a90e2;
+    color: $core-blue;
     text-decoration: none;
 
     &:hover {
@@ -38,8 +39,11 @@
       display: inline;
       font-size: 32px;
       max-width: 479px;
-      font-weight: $bold;
       color: $core-black;
+
+      span {
+        font-weight: $bold;
+      }
     }
 
     > h2 {

--- a/frontend/pages/Fleet404/index.js
+++ b/frontend/pages/Fleet404/index.js
@@ -1,0 +1,1 @@
+export default from './Fleet404';

--- a/frontend/pages/Fleet500/Fleet500.jsx
+++ b/frontend/pages/Fleet500/Fleet500.jsx
@@ -8,9 +8,9 @@ import errorsInterface from 'interfaces/errors500';
 import fleetLogoText from '../../../assets/images/fleet-logo-text-white.svg';
 import backgroundImg from '../../../assets/images/500.svg';
 
-const baseClass = 'kolide-500';
+const baseClass = 'fleet-500';
 
-class Kolide500 extends Component {
+class Fleet500 extends Component {
   static propTypes = {
     errors: errorsInterface,
     dispatch: PropTypes.func,
@@ -76,7 +76,7 @@ class Kolide500 extends Component {
         </header>
         <img className="background-image" src={backgroundImg} alt="500 background" />
         <main>
-          <h1>500: Oh, something went wrong.</h1>
+          <h1><span>500:</span> Oh, something went wrong.</h1>
           <p>Please file an issue if you believe this is a bug.</p>
           {renderError()}
           <a
@@ -99,4 +99,4 @@ const mapStateToProps = (state) => {
   };
 };
 
-export default connect(mapStateToProps)(Kolide500);
+export default connect(mapStateToProps)(Fleet500);

--- a/frontend/pages/Fleet500/_styles.scss
+++ b/frontend/pages/Fleet500/_styles.scss
@@ -1,10 +1,10 @@
-.kolide-500 {
+.fleet-500 {
   p {
-    color: #666;
+    color: #333;
   }
 
   a {
-    color: #4a90e2;
+    color: $core-blue;
     text-decoration: none;
 
     &:hover {
@@ -32,7 +32,7 @@
   }
 
   .error-message-container {
-    display: inline;
+    display: block;
   }
 
   main {
@@ -41,8 +41,11 @@
     > h1 {
       font-size: 32px;
       min-width: 479px;
-      font-weight: $bold;
       color: $core-black;
+
+      span {
+        font-weight: $bold;
+      }
     }
 
     > h2 {

--- a/frontend/pages/Fleet500/index.js
+++ b/frontend/pages/Fleet500/index.js
@@ -1,0 +1,1 @@
+export default from './Fleet500';

--- a/frontend/pages/Kolide404/index.js
+++ b/frontend/pages/Kolide404/index.js
@@ -1,1 +1,0 @@
-export default from './Kolide404';

--- a/frontend/pages/Kolide500/index.js
+++ b/frontend/pages/Kolide500/index.js
@@ -1,1 +1,0 @@
-export default from './Kolide500';

--- a/frontend/pages/LoginSuccessfulPage/LoginSuccessfulPage.jsx
+++ b/frontend/pages/LoginSuccessfulPage/LoginSuccessfulPage.jsx
@@ -1,14 +1,11 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-import Icon from 'components/icons/Icon';
-
 class LoginSuccessfulPage extends Component {
   render () {
     const baseClass = 'login-success';
     return (
       <div className={baseClass}>
-        <Icon name="success-check" className={`${baseClass}__icon`} />
         <p className={`${baseClass}__text`}>Login successful</p>
         <p className={`${baseClass}__sub-text`}>Taking you to the Fleet UI...</p>
       </div>

--- a/frontend/pages/LoginSuccessfulPage/_styles.scss
+++ b/frontend/pages/LoginSuccessfulPage/_styles.scss
@@ -1,30 +1,19 @@
 .login-success {
   background-color: $white;
   margin-top: 20px;
-  padding-bottom: $pad-base;
-  padding-left: $pad-base;
-  padding-right: $pad-base;
-  padding-top: $pad-most;
+  padding: 40px;
   text-align: center;
-  width: 340px;
+  border-radius: 10px;
   z-index: 0;
   align-self: center;
+  transform: translateY(80px);
 
   &__text {
-    color: $success;
-    text-transform: uppercase;
-    font-size: $large;
-    letter-spacing: 2px;
-    font-weight: 300;
+    font-size: $small;
   }
 
   &__sub-text {
-    font-size: $medium;
+    font-size: $x-small;
     color: $core-medium-blue-grey;
-  }
-
-  &__icon {
-    color: $success;
-    font-size: 100px;
   }
 }

--- a/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
@@ -315,7 +315,7 @@ export class UserSettingsPage extends Component {
 
           <div className={`${baseClass}__more-info-detail`}>
             <p className={`${baseClass}__header`}>Role</p>
-            <p className={`${baseClass}__description`}>{roleText}</p>
+            <p className={`${baseClass}__description ${baseClass}__role`}>{roleText}</p>
           </div>
           <div className={`${baseClass}__more-info-detail`}>
             <p className={`${baseClass}__header`}>Password</p>

--- a/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
@@ -234,9 +234,9 @@ export class UserSettingsPage extends Component {
     }
 
     return (
-      <Modal title="Get API Token" onExit={onToggleApiTokenModal}>
+      <Modal title="Get API token" onExit={onToggleApiTokenModal}>
         <p className={`${baseClass}__secret-label`}>
-          The following is your API Token:
+          Your API Token:
           <a
             href="#revealSecret"
             onClick={onToggleSecret}
@@ -262,8 +262,8 @@ export class UserSettingsPage extends Component {
           </Button>
         </div>
         <div className={`${baseClass}__button-wrap`}>
-          <Button onClick={onToggleApiTokenModal} variant="success">
-            Return To App
+          <Button onClick={onToggleApiTokenModal} className="button button--brand">
+            Done
           </Button>
         </div>
       </Modal>
@@ -274,7 +274,6 @@ export class UserSettingsPage extends Component {
     const {
       handleSubmit,
       onCancel,
-      onLogout,
       onShowModal,
       onShowApiTokenModal,
       renderEmailModal,
@@ -289,13 +288,13 @@ export class UserSettingsPage extends Component {
     }
 
     const { admin, updated_at: updatedAt, sso_enabled: ssoEnabled } = user;
-    const roleText = admin ? 'ADMIN' : 'USER';
+    const roleText = admin ? 'Admin' : 'User';
     const lastUpdatedAt = moment(updatedAt).fromNow();
 
     return (
       <div className={baseClass}>
         <div className={`${baseClass}__manage body-wrap`}>
-          <h1>Manage User Settings</h1>
+          <h1>User settings</h1>
           <UserSettingsForm
             formData={user}
             handleSubmit={handleSubmit}
@@ -305,48 +304,37 @@ export class UserSettingsPage extends Component {
           />
         </div>
         <div className={`${baseClass}__additional body-wrap`}>
-          <h1>Additional Info</h1>
+          <h2>Photo</h2>
 
           <div className={`${baseClass}__change-avatar`}>
             <Avatar user={user} className={`${baseClass}__avatar`} />
             <a href="http://en.gravatar.com/emails/">
-              Change Photo at Gravatar
+              Change photo at Gravatar
             </a>
           </div>
 
-          <Button
-            onClick={onShowApiTokenModal}
-            variant="brand"
-            className={`${baseClass}__button`}
-          >
-            GET API TOKEN
-          </Button>
-
           <div className={`${baseClass}__more-info-detail`}>
-            <Icon name="username" />
-            <strong>Role</strong> - {roleText}
+            <p className={`${baseClass}__header`}>Role</p>
+            <p className={`${baseClass}__description`}>{roleText}</p>
           </div>
           <div className={`${baseClass}__more-info-detail`}>
-            <Icon name="lock-big" />
-            <strong>Password</strong>
+            <p className={`${baseClass}__header`}>Password</p>
           </div>
           <Button
             onClick={onShowModal}
-            variant="brand"
             disabled={ssoEnabled}
-            className={`${baseClass}__button`}
+            className={`${baseClass}__button button button--muted`}
           >
-            CHANGE PASSWORD
+            Change password
           </Button>
           <p className={`${baseClass}__last-updated`}>
             Last changed: {lastUpdatedAt}
           </p>
           <Button
-            onClick={onLogout}
-            variant="alert"
-            className={`${baseClass}__button`}
+            onClick={onShowApiTokenModal}
+            className={`${baseClass}__button button button--muted`}
           >
-            LOGOUT
+            Get API token
           </Button>
         </div>
         {renderEmailModal()}

--- a/frontend/pages/UserSettingsPage/UserSettingsPage.tests.jsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.tests.jsx
@@ -28,10 +28,10 @@ describe('UserSettingsPage - component', () => {
     const pageWithUser = mount(<UserSettingsPage dispatch={noop} user={userStub} />);
     const pageWithAdmin = mount(<UserSettingsPage dispatch={noop} user={admin} />);
 
-    expect(pageWithUser.text()).toContain('Role - USER');
-    expect(pageWithUser.text()).not.toContain('Role - ADMIN');
-    expect(pageWithAdmin.text()).not.toContain('Role - USER');
-    expect(pageWithAdmin.text()).toContain('Role - ADMIN');
+    expect(pageWithUser.find('.user-settings__role').text()).toContain('User');
+    expect(pageWithUser.find('.user-settings__role').text()).not.toContain('Admin');
+    expect(pageWithAdmin.find('.user-settings__role').text()).not.toContain('User');
+    expect(pageWithAdmin.find('.user-settings__role').text()).toContain('Admin');
   });
 
   it('updates a user with only the updated attributes', () => {

--- a/frontend/pages/UserSettingsPage/_styles.scss
+++ b/frontend/pages/UserSettingsPage/_styles.scss
@@ -5,10 +5,14 @@
     margin: 0 0 30px;
   }
 
+  h2 {
+    font-size: $x-small;
+    font-weight: $bold;
+  }
+
   &__manage {
     flex-grow: 1;
     align-self: flex-start;
-    padding: 30px;
     min-width: 542px;
   }
 
@@ -18,6 +22,8 @@
     min-width: 350px;
     box-sizing: border-box;
     padding: 30px;
+    background-color: $ui-light-grey;
+    min-height: 100vh;
   }
 
   &__change-avatar {
@@ -26,27 +32,37 @@
 
     a {
       display: block;
-      background-color: $core-blue;
-      line-height: 40px;
-      color: #fff;
+      color: $core-blue;
       text-align: center;
       position: relative;
       z-index: 1;
       text-decoration: none;
-      margin-top: -10px;
+      font-size: $x-small;
+      margin-top: 4px;
     }
   }
 
+  &__header {
+    font-size: $x-small;
+    font-weight: $bold;
+    margin: 24px 0 4px 0;
+  }
+
+  &__description {
+    font-size: $x-small;
+    font-style: italic;
+    margin: 4px 0;
+  }
+
   &__avatar {
-    @include size(200px);
-    border: solid 1px $core-blue;
+    @include size(120px);
+    border: solid 1px $ui-borders;
     margin: 0 auto;
     display: block;
   }
 
   &__more-info-detail {
-    line-height: 50px;
-    border-top: 1px solid $ui-borders;
+
     color: $core-dark-blue-grey;
 
     .kolidecon {
@@ -61,12 +77,9 @@
   }
 
   &__last-updated {
-    font-size: 13px;
-    line-height: 40px;
-    letter-spacing: 0.5px;
-    color: $core-dark-blue-grey;
-    border-bottom: 1px solid $ui-borders;
-    margin: 0 0 35px;
+    font-size: $x-small;
+    font-style: italic;
+    margin: 4px 0 24px;
   }
 
   &__reveal-secret {
@@ -75,16 +88,22 @@
   }
 
   &__secret-label {
-    font-size: 15px;
-    font-weight: $regular;
-    line-height: 1.6;
-    letter-spacing: normal;
-    color: rgba(32, 37, 50, 0.66);
-    margin: 0;
+    font-size: $x-small;
+    font-weight: $bold;
+    margin: 0 0 4px 0;
+
+    a {
+      color: $core-blue;
+    }
   }
 
   &__secret-wrapper {
     position: relative;
+  }
+
+  &__button-wrap {
+    display: flex;
+    justify-content: flex-end;
   }
 
   &__secret-copy-icon {
@@ -92,7 +111,7 @@
     top: 8px;
     right: 10px;
     font-size: 18px;
-    color: $core-purple;
+    color: $core-blue;
 
     &:active {
       top: 8px;
@@ -104,7 +123,6 @@
       border-radius: 2px;
       background-color: $core-light-blue-grey;
       border-color: $ui-borders;
-      color: $core-purple;
       padding-right: 36px;
       font-family: 'SourceCodePro', $monospace;
 

--- a/frontend/pages/UserSettingsPage/_styles.scss
+++ b/frontend/pages/UserSettingsPage/_styles.scss
@@ -45,7 +45,7 @@
   &__header {
     font-size: $x-small;
     font-weight: $bold;
-    margin: 24px 0 4px 0;
+    margin: 24px 0 4px;
   }
 
   &__description {
@@ -90,7 +90,7 @@
   &__secret-label {
     font-size: $x-small;
     font-weight: $bold;
-    margin: 0 0 4px 0;
+    margin: 0 0 4px;
 
     a {
       color: $core-blue;

--- a/frontend/redux/middlewares/redirect/index.js
+++ b/frontend/redux/middlewares/redirect/index.js
@@ -13,7 +13,7 @@ const redirectMiddleware = store => next => (action) => {
     const httpStatus = get(payload, 'errors.http_status');
 
     if (HTTP_STATUS.INTERNAL_ERROR.test(httpStatus)) {
-      store.dispatch(push(PATHS.KOLIDE_500));
+      store.dispatch(push(PATHS.FLEET_500));
     }
   }
 

--- a/frontend/router/index.jsx
+++ b/frontend/router/index.jsx
@@ -24,8 +24,8 @@ import PackComposerPage from 'pages/packs/PackComposerPage';
 import QueryPage from 'pages/queries/QueryPage';
 import QueryPageWrapper from 'components/queries/QueryPageWrapper';
 import RegistrationPage from 'pages/RegistrationPage';
-import Kolide404 from 'pages/Kolide404';
-import Kolide500 from 'pages/Kolide500';
+import Fleet404 from 'pages/Fleet404';
+import Fleet500 from 'pages/Fleet500';
 import store from 'redux/store';
 import UserSettingsPage from 'pages/UserSettingsPage';
 import PATHS from 'router/paths';
@@ -75,9 +75,9 @@ const routes = (
           </Route>
         </Route>
       </Route>
-      <Route path="/500" component={Kolide500} />
-      <Route path="/404" component={Kolide404} />
-      <Route component={Kolide404} />
+      <Route path="/500" component={Fleet500} />
+      <Route path="/404" component={Fleet404} />
+      <Route component={Fleet404} />
     </Router>
   </Provider>
 );

--- a/frontend/router/index.jsx
+++ b/frontend/router/index.jsx
@@ -77,7 +77,7 @@ const routes = (
       </Route>
       <Route path="/500" component={Fleet500} />
       <Route path="/404" component={Fleet404} />
-      <Route component={Fleet404} />
+      <Route path="*" component={Fleet404} />
     </Router>
   </Provider>
 );

--- a/frontend/router/paths.js
+++ b/frontend/router/paths.js
@@ -16,7 +16,7 @@ export default {
   },
   FORGOT_PASSWORD: `${URL_PREFIX}/login/forgot`,
   HOME: `${URL_PREFIX}/`,
-  KOLIDE_500: `${URL_PREFIX}/500`,
+  FLEET_500: `${URL_PREFIX}/500`,
   LOGIN: `${URL_PREFIX}/login`,
   LOGOUT: `${URL_PREFIX}/logout`,
   MANAGE_HOSTS: `${URL_PREFIX}/hosts/manage`,


### PR DESCRIPTION
These changes are part of UI Refresh #38.

- `Kolide404` and `Kolide500` components renamed to `Fleet404` and `Fleet500`
- Styling for `Login` and `Confirm invite` pages are consistent with the recent changes to the `Setup` page.
- Add `*` character to the 404 `<Route />`'s `path` property. Now the 404 page renders when there is no exact path match.

404
![localhost_8080_404 (2)](https://user-images.githubusercontent.com/47070608/101547724-89b5c700-395f-11eb-9de5-28f1ca36512d.png)

500
![localhost_8080_500 (3)](https://user-images.githubusercontent.com/47070608/101547741-90443e80-395f-11eb-9943-00ab8f417150.png)

User settings
![localhost_8080_settings (1)](https://user-images.githubusercontent.com/47070608/101547770-9c300080-395f-11eb-8ec5-6df5cfefdf83.png)

Confirm invite
![localhost_8080_login_invites_cW1NUVlWSjlpTE04Q2lWSi9BaEcxZzAyRWhnNStIZjY=_name=steven email=steve%40example com](https://user-images.githubusercontent.com/47070608/101547801-a7832c00-395f-11eb-8c0c-6ded904258a0.png)

Login
![localhost_8080_login (1)](https://user-images.githubusercontent.com/47070608/101547828-b669de80-395f-11eb-9dd6-6d1c45562aec.png)


