### PR TITLE
Make password reset styles consistent with new global styles.

### DIFF
--- a/frontend/components/StackedWhiteBoxes/_styles.scss
+++ b/frontend/components/StackedWhiteBoxes/_styles.scss
@@ -1,38 +1,33 @@
 .stacked-white-boxes {
   @include position(absolute, null null null 50%);
-  transition: transform 300ms ease-in;
-  margin: 75px 0 0 -262px;
-  width: 524px;
+  transition: opacity 300ms ease-in;
+  margin: 40px 0 0 -262px;
+  width: 516px;
 
   &--loading {
-    transform: scale(1.3);
     opacity: 0;
   }
 
   &--loaded {
-    transform: scale(1);
     opacity: 1;
   }
 
   &--leaving {
-    transform: scale(1.3);
     opacity: 0;
   }
 
   &__box {
     background-color: $white;
-    border-radius: 4px;
-    box-shadow: 0 0 30px 0 rgba($black, 0.3);
-    min-height: 402px;
+    border-radius: 10px;
+    min-height: 360px;
     box-sizing: border-box;
-    padding: 30px;
+    padding: 40px;
     font-weight: 300;
 
     &-text {
       color: $core-black;
-      font-size: $medium;
-      line-height: 30px;
-      letter-spacing: 0.64px;
+      font-size: $small;
+      margin: 40px 0 24px 0;
     }
   }
 
@@ -46,7 +41,6 @@
       line-height: 32px;
       margin-top: 0;
       margin-bottom: 0;
-      text-transform: uppercase;
     }
   }
 

--- a/frontend/components/StackedWhiteBoxes/_styles.scss
+++ b/frontend/components/StackedWhiteBoxes/_styles.scss
@@ -27,7 +27,7 @@
     &-text {
       color: $core-black;
       font-size: $small;
-      margin: 40px 0 24px 0;
+      margin: 40px 0 24px;
     }
   }
 

--- a/frontend/components/forms/ForgotPasswordForm/ForgotPasswordForm.jsx
+++ b/frontend/components/forms/ForgotPasswordForm/ForgotPasswordForm.jsx
@@ -29,16 +29,14 @@ class ForgotPasswordForm extends Component {
         <InputFieldWithIcon
           {...fields.email}
           autofocus
-          iconName="email"
-          placeholder="Email Address"
+          placeholder="Email"
         />
         <div className={`${baseClass}__button-wrap`}>
           <Button
-            className={`${baseClass}__submit-btn`}
+            className={`${baseClass}__submit-btn button button--brand`}
             type="submit"
-            variant="gradient"
           >
-            Reset Password
+            Reset password
           </Button>
         </div>
       </form>

--- a/frontend/components/forms/ForgotPasswordForm/_styles.scss
+++ b/frontend/components/forms/ForgotPasswordForm/_styles.scss
@@ -2,12 +2,12 @@
   width: 100%;
 
   &__button-wrap {
-    @include position(absolute, null 0 0 0);
+    margin-top: 40px;
+    display: flex;
+    justify-content: center;
   }
 
   &__submit-btn {
-    &:active {
-      box-shadow: 0 1px 0 $button-shadow;
-    }
+    width: 160px;
   }
 }

--- a/frontend/components/forms/LoginForm/LoginForm.jsx
+++ b/frontend/components/forms/LoginForm/LoginForm.jsx
@@ -84,7 +84,7 @@ class LoginForm extends Component {
           <InputFieldWithIcon
             {...fields.username}
             autofocus
-            placeholder="Username or Email"
+            placeholder="Username or email"
           />
           <InputFieldWithIcon
             {...fields.password}

--- a/frontend/components/forms/ResetPasswordForm/ResetPasswordForm.jsx
+++ b/frontend/components/forms/ResetPasswordForm/ResetPasswordForm.jsx
@@ -27,14 +27,12 @@ class ResetPasswordForm extends Component {
         <InputFieldWithIcon
           {...fields.new_password}
           autofocus
-          iconName="password"
           placeholder="New password"
           className={`${baseClass}__input`}
           type="password"
         />
         <InputFieldWithIcon
           {...fields.new_password_confirmation}
-          iconName="password"
           placeholder="Confirm password"
           className={`${baseClass}__input`}
           type="password"
@@ -42,11 +40,10 @@ class ResetPasswordForm extends Component {
         <div className={`${baseClass}__button-wrap`}>
           <Button
             onClick={handleSubmit}
-            className={`${baseClass}__btn`}
+            className={`${baseClass}__btn button button--brand`}
             type="submit"
-            variant="gradient"
           >
-            Reset Password
+            Reset password
           </Button>
         </div>
       </form>

--- a/frontend/components/forms/ResetPasswordForm/_styles.scss
+++ b/frontend/components/forms/ResetPasswordForm/_styles.scss
@@ -2,7 +2,8 @@
   width: 100%;
 
   &__button-wrap {
-    @include position(absolute, null 0 0 0);
+    display: flex;
+    justify-content: center;
   }
 
   &__input {
@@ -10,6 +11,8 @@
   }
 
   &__btn {
-    margin-top: $pad-base;
+    margin-top: 40px;
+    width: 160px;
+    margin-bottom: 20px;
   }
 }

--- a/frontend/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
+++ b/frontend/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
@@ -65,10 +65,6 @@ export class ForgotPasswordPage extends Component {
               Click the link on the email to proceed with the password reset process.
             </p>
           </div>
-          <div className={`${baseClass}__button`}>
-            <Icon name="success-check" className={`${baseClass}__icon`} />
-            EMAIL SENT
-          </div>
         </div>
       );
     }
@@ -84,11 +80,10 @@ export class ForgotPasswordPage extends Component {
 
   render () {
     const { handleLeave } = this;
-    const leadText = 'If you’ve forgotten your password enter your email below and we will email you a link so that you can reset your password.';
+    const leadText = 'Enter your email below and we will email you a link so that you can reset your password.';
 
     return (
       <StackedWhiteBoxes
-        headerText="Forgot Password"
         leadText={leadText}
         previousLocation="/login"
         className="forgot-password"

--- a/frontend/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
+++ b/frontend/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
@@ -10,7 +10,6 @@ import {
 } from 'redux/nodes/components/ForgotPasswordPage/actions';
 import debounce from 'utilities/debounce';
 import ForgotPasswordForm from 'components/forms/ForgotPasswordForm';
-import Icon from 'components/icons/Icon';
 import StackedWhiteBoxes from 'components/StackedWhiteBoxes';
 
 export class ForgotPasswordPage extends Component {

--- a/frontend/pages/ForgotPasswordPage/_styles.scss
+++ b/frontend/pages/ForgotPasswordPage/_styles.scss
@@ -1,41 +1,23 @@
 .forgot-password {
-  top: 50%;
-  margin-top: -170px;
-  height: 420px;
+  transform: translateY(-50px);
 
   &__header {
     text-align: left;
   }
 
   &__text-wrapper {
-    padding: $pad-base;
-    background-color: $ui-light-grey;
-    border-radius: 4px;
-    margin-bottom: $pad-base;
+    font-size: $small;
   }
 
   &__text {
-    font-size: $medium;
+    font-size: $small;
+
+    span {
+      color: $core-blue;
+    }
   }
 
   &__email {
     color: $core-purple;
-  }
-
-  &__button {
-    background-color: $success-light;
-    border-radius: 4px;
-    color: $white;
-    padding: $pad-base;
-    position: relative;
-    text-align: center;
-    text-transform: uppercase;
-  }
-
-  &__icon {
-    font-size: 35px;
-    left: 18px;
-    position: absolute;
-    top: 14px;
   }
 }

--- a/frontend/pages/ResetPasswordPage/ResetPasswordPage.jsx
+++ b/frontend/pages/ResetPasswordPage/ResetPasswordPage.jsx
@@ -86,8 +86,7 @@ export class ResetPasswordPage extends Component {
 
     return (
       <StackedWhiteBoxes
-        headerText="Reset Password"
-        leadText="Create a new password using at least one letter, one numeral and seven characters."
+        leadText="Create a new password. Your new password must include 7 characters, at least 1 number (e.g. 0 - 9), and at least 1 symbol (e.g. &*#)"
         onLeave={handleLeave}
       >
         <ResetPasswordForm


### PR DESCRIPTION
These changes are part of the UI Refresh #38.

The changes include adding sentence casing and updating the styles of the <ResetPasswordForm /> and <ForgotPasswordForm /> components.

![localhost_8080_login_reset_token=Z3pDMER6a2xSVVkvbkNzbzd4MHQ2RlBvM2p3bnkxNE8%3d](https://user-images.githubusercontent.com/47070608/101835217-4a6ab000-3af0-11eb-9927-6039cad5ca15.png)
![localhost_8080_login_forgot](https://user-images.githubusercontent.com/47070608/101835220-4b034680-3af0-11eb-9dda-f685ad37a5b0.png)
