### PR TITLE
Prevent SQLite ATTACH from being used in queries

### DIFF
--- a/server/kolide/queries.go
+++ b/server/kolide/queries.go
@@ -2,6 +2,8 @@ package kolide
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -78,6 +80,19 @@ type Query struct {
 	// Packs is loaded when retrieving queries, but is stored in a join
 	// table in the MySQL backend.
 	Packs []Pack `json:"packs" db:"-"`
+}
+
+var (
+	validateSQLRegexp = regexp.MustCompile(`(?i)attach[^\w]+.*[^\w]+as[^\w]+`)
+)
+
+// ValidateSQL performs security validations on the input query. It does not
+// actually determine whether the query is well formed.
+func (q Query) ValidateSQL() error {
+	if validateSQLRegexp.MatchString(q.Query) {
+		return fmt.Errorf("ATTACH not allowed in queries")
+	}
+	return nil
 }
 
 const (

--- a/server/kolide/queries_test.go
+++ b/server/kolide/queries_test.go
@@ -102,3 +102,38 @@ func TestRoundtripQueriesYaml(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSQL(t *testing.T) {
+	var testCases = []struct {
+		sql       string
+		shouldErr bool
+	}{
+		{"", false},
+		{"foo", false},
+		{"select 1", false},
+		{"select * from time", false},
+		{"select 1 from ATTACH", false},
+		{"select * from attach where fast = 3", false},
+
+		{"attach 'foo' as bar;", true},
+		{"attach   (foo )as bar", true},
+		{"attach('foo')AS bar", true},
+		{"ATTACH 'foo' AS bar", true},
+		{"ATTACH select name from where path = '/foobar' as bar", true},
+		{`attach
+   foo
+    as
+  bar`, true},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.sql, func(t *testing.T) {
+			err := Query{Query: tt.sql}.ValidateSQL()
+			if tt.shouldErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/server/service/logging_queries.go
+++ b/server/service/logging_queries.go
@@ -118,6 +118,15 @@ func (mw loggingMiddleware) ModifyQuery(ctx context.Context, id uint, p kolide.Q
 		loggedInUser = vc.Username()
 	}
 	defer func(begin time.Time) {
+		if query == nil {
+			_ = mw.loggerInfo(err).Log(
+				"method", "ModifyQuery",
+				"err", err,
+				"user", loggedInUser,
+				"took", time.Since(begin),
+			)
+			return
+		}
 		_ = mw.loggerInfo(err).Log(
 			"method", "ModifyQuery",
 			"err", err,

--- a/server/service/service_campaigns.go
+++ b/server/service/service_campaigns.go
@@ -6,10 +6,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/igm/sockjs-go/v3/sockjs"
 	"github.com/fleetdm/fleet/server/contexts/viewer"
 	"github.com/fleetdm/fleet/server/kolide"
 	"github.com/fleetdm/fleet/server/websocket"
+	"github.com/igm/sockjs-go/v3/sockjs"
 	"github.com/pkg/errors"
 )
 
@@ -41,12 +41,16 @@ func (svc service) NewDistributedQueryCampaign(ctx context.Context, queryString 
 		return nil, errNoContext
 	}
 
-	query, err := svc.ds.NewQuery(&kolide.Query{
+	query := &kolide.Query{
 		Name:     fmt.Sprintf("distributed_%s_%d", vc.Username(), time.Now().Unix()),
 		Query:    queryString,
 		Saved:    false,
 		AuthorID: uintPtr(vc.UserID()),
-	})
+	}
+	if err := query.ValidateSQL(); err != nil {
+		return nil, err
+	}
+	query, err := svc.ds.NewQuery(query)
 	if err != nil {
 		return nil, errors.Wrap(err, "new query")
 	}

--- a/server/service/service_queries_test.go
+++ b/server/service/service_queries_test.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fleetdm/fleet/server/kolide"
+	"github.com/fleetdm/fleet/server/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewQueryAttach(t *testing.T) {
+	ds := new(mock.Store)
+	svc, err := newTestService(ds, nil, nil)
+	require.Nil(t, err)
+
+	name := "bad"
+	query := "attach '/nope' as bad"
+	_, err = svc.NewQuery(
+		context.Background(),
+		kolide.QueryPayload{Name: &name, Query: &query},
+	)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Mitigate
[CVE-2020-26273](https://github.com/osquery/osquery/security/advisories/GHSA-4g56-2482-x7q8)
by attempting to prevent users from executing or saving queries that use
the SQLite `ATTACH` command.

Users must still update to osquery 4.6.0 to ensure the functionality is
fully disabled in osquery.