### PR TITLE
Add help text within user actions dropdown menu. Update copy in API documentation.

### DIFF
--- a/docs/api/rest-endpoints.md
+++ b/docs/api/rest-endpoints.md
@@ -4,11 +4,11 @@
 
 Making authenticated requests to the Fleet server requires that you are granted permission to access data. The Fleet Authentication API enables you to receive an authorization token.
 
-All Fleet API requests are authenticated unless noted in the documentation. This means that almost all Fleet API requests will require sending the auth token in the request header.
+All Fleet API requests are authenticated unless noted in the documentation. This means that almost all Fleet API requests will require sending the API token in the request header.
 
 The typical steps to making an authenticated API request are outlined below.
 
-First, utilize the `/login` endpoint to receive an authentication token. For SSO users, username/password login is disabled and the API token can be retrieved from the "Settings" page in the UI.
+First, utilize the `/login` endpoint to receive an API token. For SSO users, username/password login is disabled and the API token can be retrieved from the "Settings" page in the UI.
 
 `POST /api/v1/kolide/login`
 

--- a/frontend/components/UserRow/_styles.scss
+++ b/frontend/components/UserRow/_styles.scss
@@ -12,9 +12,13 @@
         font-size: $x-small;
       }
 
-      .Select-menu-outer {
-        width: 186px;
-        transform: translateX(-33%);
+      .Select-menu {
+        max-height: 220px;
+        &-outer {
+          width: 186px;
+          transform: translateX(-33%);
+          max-height: 220px;
+        }
       }
     }
   }

--- a/frontend/components/UserRow/_styles.scss
+++ b/frontend/components/UserRow/_styles.scss
@@ -14,6 +14,7 @@
 
       .Select-menu {
         max-height: 220px;
+
         &-outer {
           width: 186px;
           transform: translateX(-33%);

--- a/frontend/components/UserRow/helpers.js
+++ b/frontend/components/UserRow/helpers.js
@@ -16,7 +16,7 @@ const userActionOptions = (isCurrentUser, user, invite) => {
     userPromotionAction,
   ];
   if (!user.sso_enabled) {
-    result.push({ disabled: false, label: 'Require Password Reset', value: 'reset_password' });
+    result.push({ disabled: false, label: 'Require Password Reset', value: 'reset_password', helpText: 'This will revoke all active Fleet API tokens for this user.' });
   }
   result.push({ disabled: false, label: 'Modify Details', value: 'modify_details' });
   return result;

--- a/frontend/components/UserRow/helpers.tests.js
+++ b/frontend/components/UserRow/helpers.tests.js
@@ -15,7 +15,7 @@ describe('UserRow - helpers', () => {
       expect(userActionOptions(false, userStub, false)).toEqual([
         { disabled: false, label: 'Disable Account', value: 'disable_account' },
         { disabled: false, label: 'Promote User', value: 'promote_user' },
-        { disabled: false, label: 'Require Password Reset', value: 'reset_password' },
+        { disabled: false, label: 'Require Password Reset', value: 'reset_password', helpText: 'This will revoke all active Fleet API tokens for this user.' },
         { disabled: false, label: 'Modify Details', value: 'modify_details' },
       ]);
     });
@@ -26,7 +26,7 @@ describe('UserRow - helpers', () => {
       expect(userActionOptions(false, disabledUser, false)).toEqual([
         { disabled: false, label: 'Enable Account', value: 'enable_account' },
         { disabled: false, label: 'Promote User', value: 'promote_user' },
-        { disabled: false, label: 'Require Password Reset', value: 'reset_password' },
+        { disabled: false, label: 'Require Password Reset', value: 'reset_password', helpText: 'This will revoke all active Fleet API tokens for this user.' },
         { disabled: false, label: 'Modify Details', value: 'modify_details' },
       ]);
     });
@@ -37,7 +37,7 @@ describe('UserRow - helpers', () => {
       expect(userActionOptions(false, adminUser, false)).toEqual([
         { disabled: false, label: 'Disable Account', value: 'disable_account' },
         { disabled: false, label: 'Demote User', value: 'demote_user' },
-        { disabled: false, label: 'Require Password Reset', value: 'reset_password' },
+        { disabled: false, label: 'Require Password Reset', value: 'reset_password', helpText: 'This will revoke all active Fleet API tokens for this user.' },
         { disabled: false, label: 'Modify Details', value: 'modify_details' },
       ]);
     });
@@ -48,7 +48,7 @@ describe('UserRow - helpers', () => {
       expect(userActionOptions(true, adminUser, false)).toEqual([
         { disabled: true, label: 'Disable Account', value: 'disable_account' },
         { disabled: true, label: 'Demote User', value: 'demote_user' },
-        { disabled: false, label: 'Require Password Reset', value: 'reset_password' },
+        { disabled: false, label: 'Require Password Reset', value: 'reset_password', helpText: 'This will revoke all active Fleet API tokens for this user.' },
         { disabled: false, label: 'Modify Details', value: 'modify_details' },
       ]);
     });

--- a/frontend/components/forms/fields/Dropdown/Dropdown.jsx
+++ b/frontend/components/forms/fields/Dropdown/Dropdown.jsx
@@ -67,8 +67,17 @@ class Dropdown extends Component {
     );
   }
 
+  renderOption = (option) => {
+    return (
+      <div className={`${baseClass}__option`}>
+        {option.label}
+        {option.helpText && <span className={`${baseClass}__help-text`}>{option.helpText}</span>}
+      </div>
+    );
+  }
+
   render () {
-    const { handleChange } = this;
+    const { handleChange, renderOption } = this;
     const { error, className, clearable, disabled, multi, name, options, placeholder, value, wrapperClassName } = this.props;
 
     const formFieldProps = pick(this.props, ['hint', 'label', 'error', 'name']);
@@ -86,6 +95,7 @@ class Dropdown extends Component {
           name={`${name}-select`}
           onChange={handleChange}
           options={options}
+          optionRenderer={renderOption}
           placeholder={placeholder}
           value={value}
         />

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -25,6 +25,19 @@
       }
     }
   }
+
+  &__option {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__help-text {
+    margin-top: 4px;
+    font-size: $xx-small;
+    white-space: normal;
+    color: $core-medium-blue-grey;
+    font-style: italic;
+  }
 }
 
 .Select {


### PR DESCRIPTION
- Add help text within dropdown in smaller font size underneath "Require password reset" saying "This will revoke all active Fleet API tokens for this user."
- Update API docs to use "API token" parlance instead of "Auth token"
- Example code for custom rendering using React Select v1 https://github.com/JedWatson/react-select/blob/v1.x/examples/src/components/CustomRender.js
![localhost_8080_admin_users (10)](https://user-images.githubusercontent.com/47070608/102820995-106c9a00-438b-11eb-99a8-ee4983fcd966.png)
