### PR TITLE
Updated .dockerignore and added non-root user to Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 *
-!build/
+!build/binary-bundle/linux/fleet 
+!build/binary-bundle/linux/fleetctl

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ MAINTAINER Fleet Developers <engineering@fleetdm.com>
 
 RUN apk --update add ca-certificates
 
+# Create FleetDM group and user
+RUN addgroup -S fleetdm && adduser -S fleetdm -G fleetdm
+
 COPY ./build/binary-bundle/linux/fleet ./build/binary-bundle/linux/fleetctl /usr/bin/
 
+USER fleetdm
 CMD ["fleet", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ RUN addgroup -S fleet && adduser -S fleet -G fleet
 
 COPY ./build/binary-bundle/linux/fleet ./build/binary-bundle/linux/fleetctl /usr/bin/
 
-USER fleetdm
+USER fleet
 CMD ["fleet", "serve"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Fleet Developers <engineering@fleetdm.com>
 RUN apk --update add ca-certificates
 
 # Create FleetDM group and user
-RUN addgroup -S fleetdm && adduser -S fleetdm -G fleetdm
+RUN addgroup -S fleet && adduser -S fleet -G fleet
 
 COPY ./build/binary-bundle/linux/fleet ./build/binary-bundle/linux/fleetctl /usr/bin/
 


### PR DESCRIPTION
The goal of this PR is to run the FleetDM application as a non-root user in line with Docker best practices.

For development you can still access the container as root with the following command: `docker run -it --user=0 <fleetdm container ID> ash`