### PR TITLE
Add a walkthrough for previewing Fleet (fleetctl preview) to top level README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Please check out [the blog post](https://medium.com/fleetdm/a-new-fleet-d4096c7d
 
 ## Preview Fleet
 
-### Get the latest release of the fleetctl CLI tool
+#### Get the latest release of the fleetctl CLI tool
 
 With [node installed](https://nodejs.org/en/download/):
 ```
 npm install -g fleetctl
 ```
 
-### Set up a preview deployment of the Fleet server
+#### Set up a preview deployment of the Fleet server
 
 With [docker installed](https://docs.docker.com/get-docker/):
 ```
@@ -26,7 +26,7 @@ fleetctl preview
 
 Preview Fleet at https://localhost:8412.
 
-### Add containerized hosts to your preview deployment
+#### Add containerized hosts to your preview deployment
 The [`osquery`](./osquery) directory contains a `docker-compose.yml` and
 additional configuration files to start containerized osquery agents. To start
 osquery, first retrieve the "Enroll Secret" from Fleet (by clicking the "Add New

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ With your "Enroll Secret" copied:
 cd fleet-preview/osquery
 ENROLL_SECRET=<copy from fleet> docker-compose up
 ```
-Refresh your broswer to see the containerized hosts populate the Fleet dashboard.
+Refresh the page to see the containerized hosts populate the Fleet dashboard.
 
 ## Query editor
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ With [docker installed](https://docs.docker.com/get-docker/):
 fleetctl preview
 ```
 
-Preview Fleet at https://localhost:8412
+Preview Fleet at https://localhost:8412.
 
-### Add containerized hosts to your preview deployment:
+### Add containerized hosts to your preview deployment
 The [`osquery`](./osquery) directory contains a `docker-compose.yml` and
 additional configuration files to start containerized osquery agents. To start
 osquery, first retrieve the "Enroll Secret" from Fleet (by clicking the "Add New
@@ -34,10 +34,10 @@ Host") button in the Fleet dashboard.
 
 With your "Enroll Secret" copied:
 ``` shell
-cd osquery
+cd fleet-preview/osquery
 ENROLL_SECRET=<copy from fleet> docker-compose up
 ```
-Refresh your broswer to 
+Refresh your broswer to see the containerized hosts populate the Fleet dashboard.
 
 ## Query editor
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,45 @@
-:tada: Announcing the transition of Fleet to a new independent entity :tada:
-
-Please check out [the blog post](https://medium.com/fleetdm/a-new-fleet-d4096c7de978) to understand what is happening with Fleet and our commitment to improving the product.  To upgrade from Fleet ≤3.2.0, just grab the latest release from this repository (it'll work out of the box).
-
 # Fleet [![CircleCI](https://circleci.com/gh/fleetdm/fleet/tree/master.svg?style=svg)](https://circleci.com/gh/fleetdm/fleet/tree/master) [![Go Report Card](https://goreportcard.com/badge/github.com/fleetdm/fleet)](https://goreportcard.com/report/github.com/fleetdm/fleet)
 
 Fleet is the most widely used open source osquery manager.  Deploying osquery with Fleet enables programmable live queries, streaming logs, and effective management of osquery across 50,000+ servers, containers, and laptops.  It's especially useful for talking to multiple devices at the same time.
 
-Fleet is a Go app. You can run it on your own hardware or deploy it in any cloud.
-
-Documentation for Fleet can be found on [GitHub](./docs/README.md).
-
 ![banner-fleet-cloud-city](https://user-images.githubusercontent.com/618009/98254443-eaf21100-1f41-11eb-9e2c-63a0545601f3.jpg)
+
+:tada: Announcing the transition of Fleet to a new independent entity :tada:
+
+Please check out [the blog post](https://medium.com/fleetdm/a-new-fleet-d4096c7de978) to understand what is happening with Fleet and our commitment to improving the product.  To upgrade from Fleet ≤3.2.0, just grab the latest release from this repository (it'll work out of the box).
+
+## Preview Fleet
+
+### Get the latest release of the fleetctl CLI tool
+
+With [node installed](https://nodejs.org/en/download/):
+```
+npm install -g fleetctl
+```
+
+### Set up a preview deployment of the Fleet server
+
+With [docker installed](https://docs.docker.com/get-docker/):
+```
+fleetctl preview
+```
+
+Preview Fleet at https://localhost:8412
+
+### Add containerized hosts to your preview deployment:
+The [`osquery`](./osquery) directory contains a `docker-compose.yml` and
+additional configuration files to start containerized osquery agents. To start
+osquery, first retrieve the "Enroll Secret" from Fleet (by clicking the "Add New
+Host") button in the Fleet dashboard.
+
+With your "Enroll Secret" copied:
+``` shell
+cd osquery
+ENROLL_SECRET=<copy from fleet> docker-compose up
+```
+Refresh your broswer to 
+
+## Query editor
 
 <img alt="Screenshot of query editor" src="https://user-images.githubusercontent.com/618009/101847266-769a2700-3b18-11eb-9109-7f1320ed5c45.png"/>
 
@@ -25,34 +54,9 @@ Documentation for Fleet can be found on [GitHub](./docs/README.md).
 **Scheduled Query/Pack Editor**
 ![Screenshot of pack editor](./assets/images/pack-screenshot.png)
 -->
+## Documentation
 
-## Using Fleet
-
-#### The CLI
-
-If you're interested in learning about the `fleetctl` CLI and flexible osquery deployment file format, see the [CLI Documentation](./docs/cli/README.md).
-
-#### Deploying osquery and Fleet
-
-Resources for deploying osquery to hosts, deploying the Fleet server, installing Fleet's infrastructure dependencies, etc. can all be found in the [Infrastructure Documentation](./docs/infrastructure/README.md).
-
-#### Accessing The Fleet API
-
-If you are interested in accessing the Fleet REST API in order to programmatically interact with your osquery installation, please see the [API Documentation](./docs/api/README.md).
-
-#### The Web Dashboard
-
-Information about using the web dashboard can be found in the [Dashboard Documentation](./docs/dashboard/README.md).
-
-## Developing Fleet
-
-Organizations large and small use osquery with Fleet every day to stay secure and compliant. That’s good news, since it means there are lots of other developers and security practitioners talking about Fleet, dreaming up features, and contributing patches. Let’s stop reinventing the wheel and build the future of device management together.
-
-#### Development Documentation
-
-If you're interested in interacting with the Fleet source code, you will find information on modifying and building the code in the [Development Documentation](./docs/development/README.md).
-
-If you have any questions, please create a [GitHub Issue](https://github.com/fleetdm/fleet/issues/new).
+Documentation for Fleet can be found [here on GitHub](./docs/README.md).
 
 ## Community
 


### PR DESCRIPTION
- Move the transition announcement below the banner image.
- Remove the old documentation section and add a link to the updated docs.