### PR TITLE
Update npm package name to fleetctl

### DIFF
--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "osquery-fleetctl",
+  "name": "fleetctl",
   "version": "3.5.1",
   "description": "Installer for the fleetctl CLI tool",
   "main": "binary.js",


### PR DESCRIPTION
This is an update from the prior name osquery-fleetctl now that we got
the fleetctl name.