### PR TITLE
Add template for roadmap projects / working groups

### DIFF
--- a/.github/ISSUE_TEMPLATE/z-new-project
+++ b/.github/ISSUE_TEMPLATE/z-new-project
@@ -1,0 +1,53 @@
+---
+name: Internal - New project
+about: Plan a new project and working group
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+This issue kicks off a ≈4 week company-sponsored project to ship some specific improvements to Fleet.
+
+### Goals
+
+> TODO: A sentence or two describing our high level goals for this project and timeframe
+
+### Steps
+
+- I. Drafting
+  - [x] High-level goals, due date set
+  - [x] GitHub issue
+  - [ ] Slack channel (`#2021-`…)
+  - [ ] Slack channel topic set (`🏁 Jan 31: https://github.com/fleetdm/fleet/issues/TODO`)
+  - [ ] Brainstorming, design research, talking to users
+  - [ ] Lo-fi wireframes (personal draft in Figma)
+    - [ ] Vision review w/ @edamamedesign, directional/aesthetic revisions 
+    - [ ] Practical review w/ @mikermcneil, simplifying/UX revisions
+  - [ ] Hi-fi wireframes (shared project in Figma)
+    - [ ] Engineering review w/ @zachw, tactical revisions
+  - [ ] Final wireframes
+    - [ ] Shared as a comment in this issue
+    - [ ] https://www.instagram.com/fleetctl
+- II. Implementation
+  - [ ] Pull request(s)
+    - [ ] Code changes
+    - [ ] Documentation changes
+    - [ ] Short Loom video demo (the happy path + the edge cases you've tested)
+    - [ ] Engineering review, quality/style revisions
+- III. Release
+  - [ ] Release tagged
+  - [ ] Release notes written
+  - [ ] Upgrade considerations documented (e.g. breaking change, DB schema migrations, etc)
+  - [ ] Release announced
+    - [ ] Release published
+      - [ ] GitHub
+      - [ ] NPM
+      - [ ] Docker
+    - [ ] Release blog post published
+    - [ ] Release announced in osquery Slack
+    - [ ] Release announced on social media 
+      - [ ] https://twitter.com/fleetctl
+      - [ ] https://linkedin.com/company/fleetdm
+      - [ ] https://www.facebook.com/fleetdm
+      - [ ] https://www.instagram.com/fleetctl/

--- a/.github/ISSUE_TEMPLATE/z-new-project
+++ b/.github/ISSUE_TEMPLATE/z-new-project
@@ -17,7 +17,7 @@ assignees: ''
   - [x] High-level goals, due date set
   - [x] GitHub issue
   - [ ] Slack channel (`#2021-`…)
-  - [ ] Slack channel topic set (`🏁 Jan 31: https://github.com/fleetdm/fleet/issues/TODO`)
+  - [ ] Slack channel topic set w/ issue link & internal target date (`🏁 Oct 31: https://github.com/fleetdm/fleet/issues/TODO`)
   - [ ] Brainstorming, design research, talking to users
   - [ ] Lo-fi wireframes (personal draft in Figma)
     - [ ] Vision review w/ @edamamedesign, directional/aesthetic revisions 

--- a/.github/ISSUE_TEMPLATE/z-new-project
+++ b/.github/ISSUE_TEMPLATE/z-new-project
@@ -1,17 +1,15 @@
 ---
 name: Internal - New project
-about: Plan a new project and working group
+about: Kick off a new company-sponsored project to ship particular improvements to Fleet
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-This issue kicks off a ≈4 week company-sponsored project to ship some specific improvements to Fleet.
+### Goal
 
-### Goals
-
-> TODO: A sentence or two describing our high level goals for this project and timeframe
+> TODO: A sentence or two describing the high level goal for this project
 
 ### Steps
 


### PR DESCRIPTION
This adds a new issue template for keeping track of the things we do when designing, shipping, and releasing major features on the Fleet roadmap.