### PR TITLE
Update links to new documentation locations.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -21,7 +21,7 @@ Please provide as much context as you can about your use case.
 
 ### If this is a performance issue: Please attach the debug archive.
 <!--
-Follow the steps documented in https://github.com/fleetdm/fleet/blob/master/docs/infrastructure/performance.md#debugging-performance-issues to generate a debug archive
+Follow the steps documented in https://github.com/fleetdm/fleet/blob/master/docs/1-Using-Fleet/5-Monitoring-Fleet.md#debugging-performance-issues to generate a debug archive
 -->
 
 ### What did you do?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -353,7 +353,7 @@ to 2.0.0.
 
 ## Kolide Fleet 2.0.0 (currently preparing for release)
 
-The primary new addition in Fleet 2 is the new `fleetctl` CLI and file-format, which dramatically increases the flexibility and control that administrators have over their osquery deployment. The CLI and the file format are documented [in the Fleet documentation](https://github.com/kolide/fleet/blob/master/docs/cli/README.md).
+The primary new addition in Fleet 2 is the new `fleetctl` CLI and file-format, which dramatically increases the flexibility and control that administrators have over their osquery deployment. The CLI and the file format are documented [in the Fleet documentation](https://github.com/fleetdm/fleet/blob/master/docs/1-Using-Fleet/2-fleetctl-CLI.md).
 
 ### New Features
 

--- a/docs/1-Using-Fleet/2-fleetctl-CLI.md
+++ b/docs/1-Using-Fleet/2-fleetctl-CLI.md
@@ -570,7 +570,7 @@ spec:
 
 Fleet supports osquery's file carving functionality as of Fleet 3.3.0. This allows the Fleet server to request files (and sets of files) from osquery agents, returning the full contents to Fleet.
 
-File carving data can be either stored in Fleet's database or to an external S3 bucket. For information on how to configure the latter, consult the [configuration docs](https://github.com/fleetdm/fleet/blob/master/docs/infrastructure/configuring-the-fleet-binary.md#s3-file-carving-backend).
+File carving data can be either stored in Fleet's database or to an external S3 bucket. For information on how to configure the latter, consult the [configuration docs](https://github.com/fleetdm/fleet/blob/master/docs/2-Deployment/2-Configuration.md#s3-file-carving-backend).
 
 ### Configuration
 

--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -519,7 +519,7 @@ Gets the current SSO configuration.
 | per_page                | integer | query | Results per page.                                                                                                                                                                                                                                                                              |
 | order_key               | string  | query | What to order results by. Can be any column in the hosts table.                                                                                                                                                                                                                                |
 | status                  | string  | query | Indicates the status of the hosts to return. Can either be `new`, `online`, `offline`, or `mia`.                                                                                                                                                                                               |
-| additional_info_filters | string  | query | A comma-delimited list of fields to include in each host's additional information object. See [Fleet Configuration Options](https://github.com/fleetdm/fleet/blob/master/docs/cli/file-format.md#fleet-configuration-options) for an example configuration with hosts' additional information. |
+| additional_info_filters | string  | query | A comma-delimited list of fields to include in each host's additional information object. See [Fleet Configuration Options](https://github.com/fleetdm/fleet/blob/master/docs/1-Using-Fleet/2-fleetctl-CLI.md#fleet-configuration-options) for an example configuration with hosts' additional information. |
 
 #### Example
 

--- a/docs/1-Using-Fleet/6-Security-best-practices.md
+++ b/docs/1-Using-Fleet/6-Security-best-practices.md
@@ -27,7 +27,7 @@ Fleet supports SAML auth which means that it can be configured such that it neve
 
 Passwords are never stored in plaintext in the database. We store a `bcrypt`ed hash of the password along with a randomly generated salt. The `bcrypt` iteration count and salt key size are admin-configurable.
 ### Authentication tokens
-The size and expiration time of session tokens is admin-configurable.  See [https://github.com/fleetdm/fleet/blob/master/docs/infrastructure/configuring-the-fleet-binary.md#session_duration](./1-Deployment/(b)-Configuration.md#session_duration).
+The size and expiration time of session tokens is admin-configurable.  See [https://github.com/fleetdm/fleet/blob/master/docs/2-Deployment/2-Configuration.md#session_duration](./1-Deployment/2-Configuration.md#session_duration).
 
 It is possible to revoke all session tokens for a user by forcing a password reset.
 

--- a/docs/1-Using-Fleet/FAQ.md
+++ b/docs/1-Using-Fleet/FAQ.md
@@ -16,7 +16,7 @@ It’s standard deployment practice to have multiple Fleet servers behind a load
 
 ## How often do labels refresh? Is the refresh frequency configurable?
 
-The update frequency for labels is configurable with the [—osquery_label_update_interval](https://github.com/fleetdm/fleet/blob/master/docs/infrastructure/configuring-the-fleet-binary.md#osquery_label_update_interval) flag (default 1 hour).
+The update frequency for labels is configurable with the [—osquery_label_update_interval](https://github.com/fleetdm/fleet/blob/master/docs/2-Deployment/2-Configuration.md#osquery_label_update_interval) flag (default 1 hour).
 
 ## How do I revoke the authorization tokens for a user?
 
@@ -53,7 +53,7 @@ It is possible to configure osqueryd to log query results outside of Fleet. For 
 
 Folks typically use Fleet to ship logs to data aggregation systems like Splunk, the ELK stack, and Graylog. 
 
-The [logger configuration options](https://github.com/fleetdm/fleet/blob/master/docs/infrastructure/configuring-the-fleet-binary.md#osquery_status_log_plugin) allow you to select the log output plugin. Using the log outputs you can route the logs to your chosen aggregation system.
+The [logger configuration options](https://github.com/fleetdm/fleet/blob/master/docs/2-Deployment/2-Configuration.md#osquery_status_log_plugin) allow you to select the log output plugin. Using the log outputs you can route the logs to your chosen aggregation system.
 
 ### Troubleshooting
 

--- a/docs/3-Contribution/5-Releasing-Fleet.md
+++ b/docs/3-Contribution/5-Releasing-Fleet.md
@@ -26,7 +26,7 @@ Make note of the SHA256 checksum output at the end of this build command to past
 
 ### Upgrading
 
-Please visit our [update guide](https://github.com/fleetdm/fleet/blob/master/docs/infrastructure/updating-fleet.md) for upgrade instructions.
+Please visit our [update guide](https://github.com/fleetdm/fleet/blob/master/docs/1-Using-Fleet/7-Updating-Fleet.md) for upgrade instructions.
 
 ### Documentation
 

--- a/frontend/components/hosts/AddHostModal/AddHostModal.jsx
+++ b/frontend/components/hosts/AddHostModal/AddHostModal.jsx
@@ -109,7 +109,7 @@ class AddHostModal extends Component {
           <div className={`${baseClass}__documentation-link`}>
             <h4>
               <a
-                href="https://github.com/fleetdm/fleet/blob/master/docs/infrastructure/adding-hosts-to-fleet.md"
+                href="https://github.com/fleetdm/fleet/blob/master/docs/2-Deployment/3-Adding-hosts.md"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/frontend/pages/admin/OsqueryOptionsPage/OsqueryOptionsPage.jsx
+++ b/frontend/pages/admin/OsqueryOptionsPage/OsqueryOptionsPage.jsx
@@ -79,7 +79,7 @@ export class OsqueryOptionsPage extends Component {
           <p>This file describes options returned to osqueryd when it checks for configuration.</p>
           <p>See Fleet documentation for an example file that includes the overrides option.</p>
           <a
-            href="https://github.com/fleetdm/fleet/blob/master/docs/cli/file-format.md#osquery-configuration-options"
+            href="https://github.com/fleetdm/fleet/blob/master/docs/1-Using-Fleet/2-fleetctl-CLI.md#osquery-configuration-options"
             target="_blank"
             rel="noreferrer"
           >

--- a/tools/fleetctl-npm/README.md
+++ b/tools/fleetctl-npm/README.md
@@ -10,4 +10,4 @@ Simply install `fleetctl` with `npm install -g fleetctl`.
 
 ## Usage
 
-See the [fleetctl documentation](https://github.com/fleetdm/fleet/tree/master/docs/cli#cli-documentation) or `fleetctl --help` for usage instructions. 
+See the [fleetctl documentation](https://github.com/fleetdm/fleet/blob/master/docs/1-Using-Fleet/2-fleetctl-CLI.md) or `fleetctl --help` for usage instructions. 


### PR DESCRIPTION
Fixes #157. 
- Add correct links to the new docs locations for links within the Fleet UI and Fleet documentation.