### PR TITLE
fix availability on website chat box

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -107,7 +107,7 @@
     */ %>
 
     <% /* Chat (Papercups) */ %>
-    <script>window.Papercups = { config: { accountId: '5b59eeac-1578-4fdb-b946-e17c1dca0c51', showAgentAvailability: true, requireEmailUpfront: true } };</script>
+    <script>window.Papercups = { config: { accountId: '5b59eeac-1578-4fdb-b946-e17c1dca0c51', requireEmailUpfront: true } };</script>
     <script type="text/javascript" async defer src="https://app.papercups.io/widget.js"></script>
     <script type="text/javascript" async defer src="https://app.papercups.io/storytime.js"></script>
 


### PR DESCRIPTION
Until Papercups integrates status with working hours, this removes the availability indicator (it currently always shows offline since we respond from Slack instead of the dashboard)