### PR TITLE
Complete front end QA

### DIFF
--- a/frontend/components/config/EnrollSecretTable/_styles.scss
+++ b/frontend/components/config/EnrollSecretTable/_styles.scss
@@ -28,9 +28,11 @@
 
   .buttons {
     display: flex;
+    align-items: center;
     position: absolute;
     right: 16px;
-    transform: translateY(60%);
+    transform: translateY(90%);
+    height: 16px;
 
     span {
       font-weight: $regular;

--- a/frontend/components/config/EnrollSecretTable/_styles.scss
+++ b/frontend/components/config/EnrollSecretTable/_styles.scss
@@ -31,7 +31,7 @@
     align-items: center;
     position: absolute;
     right: 16px;
-    transform: translateY(90%);
+    transform: translateY(100%);
     height: 16px;
 
     span {

--- a/frontend/components/forms/fields/SelectTargetsDropdown/TargetDetails/TargetDetails.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/TargetDetails/TargetDetails.jsx
@@ -64,12 +64,12 @@ class TargetDetails extends Component {
         </button>
 
         <p className={`${hostBaseClass}__display-text`}>
-          <KolideIcon name="single-host" fw className={`${hostBaseClass}__icon`} />
+          <KolideIcon name="single-host" className={`${hostBaseClass}__icon`} />
           <span>{displayText}</span>
         </p>
         <p className={statusClassName}>
-          {isOnline && <KolideIcon name="success-check" fw className={`${hostBaseClass}__icon ${hostBaseClass}__icon--online`} />}
-          {isOffline && <KolideIcon name="offline" fw className={`${hostBaseClass}__icon ${hostBaseClass}__icon--offline`} />}
+          {isOnline && <KolideIcon name="success-check" className={`${hostBaseClass}__icon ${hostBaseClass}__icon--online`} />}
+          {isOffline && <KolideIcon name="offline" className={`${hostBaseClass}__icon ${hostBaseClass}__icon--offline`} />}
           <span>{status}</span>
         </p>
         <table className={`${baseClass}__table`}>

--- a/frontend/layouts/CoreLayout/_styles.scss
+++ b/frontend/layouts/CoreLayout/_styles.scss
@@ -32,6 +32,7 @@
   left: 0;
   z-index: 100;
   max-height: 100vh;
+  min-height: 600px;
 
   &--small {
     padding-left: 0;

--- a/frontend/layouts/CoreLayout/_styles.scss
+++ b/frontend/layouts/CoreLayout/_styles.scss
@@ -32,7 +32,7 @@
   left: 0;
   z-index: 100;
   max-height: 100vh;
-  min-height: 600px;
+  min-height: 500px;
 
   &--small {
     padding-left: 0;

--- a/frontend/layouts/CoreLayout/_styles.scss
+++ b/frontend/layouts/CoreLayout/_styles.scss
@@ -32,7 +32,7 @@
   left: 0;
   z-index: 100;
   max-height: 100vh;
-  min-height: 500px;
+  min-height: 560px;
 
   &--small {
     padding-left: 0;

--- a/frontend/pages/Fleet500/Fleet500.jsx
+++ b/frontend/pages/Fleet500/Fleet500.jsx
@@ -47,7 +47,7 @@ class Fleet500 extends Component {
       // We only show the button when errorMessage exists
       // and showErrorMessage is set to false
       return (
-        <button className="button button--grey" onClick={onShowErrorMessage}>SHOW ERROR</button>
+        <button className="button button--grey" onClick={onShowErrorMessage}>Show error</button>
       );
     }
 

--- a/frontend/pages/Fleet500/_styles.scss
+++ b/frontend/pages/Fleet500/_styles.scss
@@ -6,6 +6,8 @@
   a {
     color: $core-blue;
     text-decoration: none;
+    display: block;
+    margin-top: 16px;
 
     &:hover {
       text-decoration: underline;


### PR DESCRIPTION
- Conduct complete visual QA for recent icon changes merged in #128 
- Edit styles to vertically align the "copy" and "reveal" icons in EnrollSecretTable
![localhost_8080_hosts_manage (33)](https://user-images.githubusercontent.com/47070608/103939047-01eae600-50e0-11eb-8cde-363f01c9976e.png)
- Clean up unused `<KolideIcon />` properties in `<SelectTargetsDropdown />`
- Add `min-height` to left side navigation. At window heights under 500px, the user can now vertically scroll to reveal the remainder of the nav options.
![localhost_8080_hosts_manage (34)](https://user-images.githubusercontent.com/47070608/103939110-2050e180-50e0-11eb-8960-c044bdf0f4f6.png)
- Edit 500 page styles by moving the "Show error" button above the link to "File an issue"
![localhost_8080_packs_1_edit](https://user-images.githubusercontent.com/47070608/103938873-c6e8b280-50df-11eb-9638-fdd4feea7d9b.png)

