### PR TITLE
Expose live query error messages via API

### DIFF
--- a/server/kolide/osquery.go
+++ b/server/kolide/osquery.go
@@ -17,7 +17,7 @@ type OsqueryService interface {
 	// for) should be returned. Returning 0 for this will not activate the
 	// feature.
 	GetDistributedQueries(ctx context.Context) (queries map[string]string, accelerate uint, err error)
-	SubmitDistributedQueryResults(ctx context.Context, results OsqueryDistributedQueryResults, statuses map[string]OsqueryStatus) (err error)
+	SubmitDistributedQueryResults(ctx context.Context, results OsqueryDistributedQueryResults, statuses map[string]OsqueryStatus, messages map[string]string) (err error)
 	SubmitStatusLogs(ctx context.Context, logs []json.RawMessage) (err error)
 	SubmitResultLogs(ctx context.Context, logs []json.RawMessage) (err error)
 	//CarveBegin(ctx context.Context)

--- a/server/launcher/launcher.go
+++ b/server/launcher/launcher.go
@@ -120,7 +120,9 @@ func (svc *launcherWrapper) PublishResults(ctx context.Context, nodeKey string, 
 		osqueryResults[result.QueryName] = result.Rows
 	}
 
-	err = svc.tls.SubmitDistributedQueryResults(newCtx, osqueryResults, statuses)
+	// TODO can Launcher expose the error messages?
+	messages := make(map[string]string)
+	err = svc.tls.SubmitDistributedQueryResults(newCtx, osqueryResults, statuses, messages)
 	return "", "", false, errors.Wrap(err, "submit launcher results")
 }
 

--- a/server/launcher/launcher_test.go
+++ b/server/launcher/launcher_test.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/go-kit/kit/log"
 	"github.com/fleetdm/fleet/server/health"
 	"github.com/fleetdm/fleet/server/kolide"
 	"github.com/fleetdm/fleet/server/mock"
+	"github.com/go-kit/kit/log"
 	"github.com/kolide/osquery-go/plugin/distributed"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,7 +66,9 @@ func TestLauncherPublishResults(t *testing.T) {
 	tls.SubmitDistributedQueryResultsFunc = func(
 		ctx context.Context,
 		results kolide.OsqueryDistributedQueryResults,
-		statuses map[string]kolide.OsqueryStatus) (err error) {
+		statuses map[string]kolide.OsqueryStatus,
+		messages map[string]string,
+	) (err error) {
 		assert.Equal(t, results["query"][0], result)
 		return nil
 	}
@@ -146,6 +148,7 @@ func newTLSService(t *testing.T) *mock.TLSService {
 			ctx context.Context,
 			results kolide.OsqueryDistributedQueryResults,
 			statuses map[string]kolide.OsqueryStatus,
+			messages map[string]string,
 		) (err error) {
 			return
 		},

--- a/server/mock/service_osquery.go
+++ b/server/mock/service_osquery.go
@@ -19,7 +19,7 @@ type GetClientConfigFunc func(ctx context.Context) (config map[string]interface{
 
 type GetDistributedQueriesFunc func(ctx context.Context) (queries map[string]string, accelerate uint, err error)
 
-type SubmitDistributedQueryResultsFunc func(ctx context.Context, results kolide.OsqueryDistributedQueryResults, statuses map[string]kolide.OsqueryStatus) (err error)
+type SubmitDistributedQueryResultsFunc func(ctx context.Context, results kolide.OsqueryDistributedQueryResults, statuses map[string]kolide.OsqueryStatus, messages map[string]string) (err error)
 
 type SubmitStatusLogsFunc func(ctx context.Context, logs []json.RawMessage) (err error)
 
@@ -68,9 +68,9 @@ func (s *TLSService) GetDistributedQueries(ctx context.Context) (queries map[str
 	return s.GetDistributedQueriesFunc(ctx)
 }
 
-func (s *TLSService) SubmitDistributedQueryResults(ctx context.Context, results kolide.OsqueryDistributedQueryResults, statuses map[string]kolide.OsqueryStatus) (err error) {
+func (s *TLSService) SubmitDistributedQueryResults(ctx context.Context, results kolide.OsqueryDistributedQueryResults, statuses map[string]kolide.OsqueryStatus, messages map[string]string) (err error) {
 	s.SubmitDistributedQueryResultsFuncInvoked = true
-	return s.SubmitDistributedQueryResultsFunc(ctx, results, statuses)
+	return s.SubmitDistributedQueryResultsFunc(ctx, results, statuses, messages)
 }
 
 func (s *TLSService) SubmitStatusLogs(ctx context.Context, logs []json.RawMessage) (err error) {

--- a/server/service/endpoint_osquery.go
+++ b/server/service/endpoint_osquery.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/go-kit/kit/endpoint"
 	"github.com/fleetdm/fleet/server/kolide"
+	"github.com/go-kit/kit/endpoint"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -98,6 +98,7 @@ type submitDistributedQueryResultsRequest struct {
 	NodeKey  string                                `json:"node_key"`
 	Results  kolide.OsqueryDistributedQueryResults `json:"queries"`
 	Statuses map[string]kolide.OsqueryStatus       `json:"statuses"`
+	Messages map[string]string                     `json:"messages"`
 }
 
 type submitDistributedQueryResultsResponse struct {
@@ -109,7 +110,7 @@ func (r submitDistributedQueryResultsResponse) error() error { return r.Err }
 func makeSubmitDistributedQueryResultsEndpoint(svc kolide.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(submitDistributedQueryResultsRequest)
-		err := svc.SubmitDistributedQueryResults(ctx, req.Results, req.Statuses)
+		err := svc.SubmitDistributedQueryResults(ctx, req.Results, req.Statuses, req.Messages)
 		if err != nil {
 			return submitDistributedQueryResultsResponse{Err: err}, nil
 		}

--- a/server/service/logging_osquery.go
+++ b/server/service/logging_osquery.go
@@ -92,7 +92,7 @@ func (mw loggingMiddleware) GetDistributedQueries(ctx context.Context) (map[stri
 	return queries, accelerate, err
 }
 
-func (mw loggingMiddleware) SubmitDistributedQueryResults(ctx context.Context, results kolide.OsqueryDistributedQueryResults, statuses map[string]kolide.OsqueryStatus) error {
+func (mw loggingMiddleware) SubmitDistributedQueryResults(ctx context.Context, results kolide.OsqueryDistributedQueryResults, statuses map[string]kolide.OsqueryStatus, messages map[string]string) error {
 	var (
 		err error
 	)
@@ -107,7 +107,7 @@ func (mw loggingMiddleware) SubmitDistributedQueryResults(ctx context.Context, r
 		)
 	}(time.Now())
 
-	err = mw.Service.SubmitDistributedQueryResults(ctx, results, statuses)
+	err = mw.Service.SubmitDistributedQueryResults(ctx, results, statuses, messages)
 	return err
 }
 

--- a/server/service/transport_osquery.go
+++ b/server/service/transport_osquery.go
@@ -52,10 +52,12 @@ func decodeSubmitDistributedQueryResultsRequest(ctx context.Context, r *http.Req
 	//  },
 	// "node_key":"IGXCXknWQ1baTa8TZ6rF3kAPZ4\/aTsui"
 	// }
+
 	type distributedQueryResultsShim struct {
 		NodeKey  string                     `json:"node_key"`
 		Results  map[string]json.RawMessage `json:"queries"`
 		Statuses map[string]interface{}     `json:"statuses"`
+		Messages map[string]string          `json:"messages"`
 	}
 
 	var shim distributedQueryResultsShim
@@ -97,6 +99,7 @@ func decodeSubmitDistributedQueryResultsRequest(ctx context.Context, r *http.Req
 		NodeKey:  shim.NodeKey,
 		Results:  results,
 		Statuses: statuses,
+		Messages: shim.Messages,
 	}
 
 	return req, nil

--- a/tools/osquery/docker-compose.yml
+++ b/tools/osquery/docker-compose.yml
@@ -14,29 +14,43 @@ x-default-settings:
       soft:  1000000000
 
 services:
-  ubuntu14-osquery:
-    image: "kolide/osquery:${KOLIDE_OSQUERY_VERSION}"
-    volumes: *default-volumes
-    environment: *default-environment
-    command: *default-command
-    ulimits: *default-ulimits
-
   ubuntu16-osquery:
-    image: "kolide/ubuntu16-osquery:${KOLIDE_OSQUERY_VERSION}"
+    image: "dactiv/osquery:4.3.0-ubuntu16.04"
     volumes: *default-volumes
     environment: *default-environment
     command: *default-command
     ulimits: *default-ulimits
 
-  centos7-osquery:
-    image: "kolide/centos7-osquery:${KOLIDE_OSQUERY_VERSION}"
+  ubuntu18-osquery:
+    image: "dactiv/osquery:4.3.0-ubuntu18.04"
+    volumes: *default-volumes
+    environment: *default-environment
+    command: *default-command
+    ulimits: *default-ulimits
+
+  ubuntu20-osquery:
+    image: "dactiv/osquery:4.3.0-ubuntu20.04"
     volumes: *default-volumes
     environment: *default-environment
     command: *default-command
     ulimits: *default-ulimits
 
   centos6-osquery:
-    image: "kolide/centos6-osquery:${KOLIDE_OSQUERY_VERSION}"
+    image: "dactiv/osquery:4.3.0-centos6"
+    volumes: *default-volumes
+    environment: *default-environment
+    command: *default-command
+    ulimits: *default-ulimits
+
+  centos7-osquery:
+    image: "dactiv/osquery:4.3.0-centos7"
+    volumes: *default-volumes
+    environment: *default-environment
+    command: *default-command
+    ulimits: *default-ulimits
+
+  centos8-osquery:
+    image: "dactiv/osquery:4.3.0-centos8"
     volumes: *default-volumes
     environment: *default-environment
     command: *default-command


### PR DESCRIPTION
Somewhere around osquery 4.4.0 these messages were added to query
responses. We can now expose them to the API clients rather than using
the placeholder text.

Required for #192