### PR TITLE
Make name and secret required for enroll secrets

### DIFF
--- a/server/service/service_appconfig.go
+++ b/server/service/service_appconfig.go
@@ -241,6 +241,15 @@ func appConfigFromAppConfigPayload(p kolide.AppConfigPayload, config kolide.AppC
 }
 
 func (svc service) ApplyEnrollSecretSpec(ctx context.Context, spec *kolide.EnrollSecretSpec) error {
+	for _, s := range spec.Secrets {
+		if s.Name == "" {
+			return errors.New("enroll secret name must not be empty")
+		}
+		if s.Secret == "" {
+			return errors.New("enroll secret must not be empty")
+		}
+	}
+
 	return svc.ds.ApplyEnrollSecretSpec(spec)
 }
 

--- a/server/service/service_appconfig_test.go
+++ b/server/service/service_appconfig_test.go
@@ -99,25 +99,29 @@ func TestEmptyEnrollSecret(t *testing.T) {
 
 	err = svc.ApplyEnrollSecretSpec(
 		context.Background(),
-		&kolide.EnrollSecretSpec{[]kolide.EnrollSecret{kolide.EnrollSecret{}}},
+		&kolide.EnrollSecretSpec{
+			Secrets: []kolide.EnrollSecret{{}},
+		},
 	)
 	require.Error(t, err)
 
 	err = svc.ApplyEnrollSecretSpec(
 		context.Background(),
-		&kolide.EnrollSecretSpec{[]kolide.EnrollSecret{{Name: "foo"}}},
+		&kolide.EnrollSecretSpec{Secrets: []kolide.EnrollSecret{{Name: "foo"}}},
 	)
 	require.Error(t, err)
 
 	err = svc.ApplyEnrollSecretSpec(
 		context.Background(),
-		&kolide.EnrollSecretSpec{[]kolide.EnrollSecret{{Secret: "foo"}}},
+		&kolide.EnrollSecretSpec{Secrets: []kolide.EnrollSecret{{Secret: "foo"}}},
 	)
 	require.Error(t, err)
 
 	err = svc.ApplyEnrollSecretSpec(
 		context.Background(),
-		&kolide.EnrollSecretSpec{[]kolide.EnrollSecret{{Name: "foo", Secret: "foo"}}},
+		&kolide.EnrollSecretSpec{
+			Secrets: []kolide.EnrollSecret{{Name: "foo", Secret: "foo"}},
+		},
 	)
 	require.NoError(t, err)
 }

--- a/server/service/service_appconfig_test.go
+++ b/server/service/service_appconfig_test.go
@@ -84,3 +84,40 @@ func TestCreateAppConfig(t *testing.T) {
 		assert.Len(t, gotSecretSpec.Secrets[0].Secret, 32)
 	}
 }
+
+func TestEmptyEnrollSecret(t *testing.T) {
+	ds := new(mock.Store)
+	svc, err := newTestService(ds, nil, nil)
+	require.Nil(t, err)
+
+	ds.ApplyEnrollSecretSpecFunc = func(spec *kolide.EnrollSecretSpec) error {
+		return nil
+	}
+	ds.AppConfigFunc = func() (*kolide.AppConfig, error) {
+		return &kolide.AppConfig{}, nil
+	}
+
+	err = svc.ApplyEnrollSecretSpec(
+		context.Background(),
+		&kolide.EnrollSecretSpec{[]kolide.EnrollSecret{kolide.EnrollSecret{}}},
+	)
+	require.Error(t, err)
+
+	err = svc.ApplyEnrollSecretSpec(
+		context.Background(),
+		&kolide.EnrollSecretSpec{[]kolide.EnrollSecret{{Name: "foo"}}},
+	)
+	require.Error(t, err)
+
+	err = svc.ApplyEnrollSecretSpec(
+		context.Background(),
+		&kolide.EnrollSecretSpec{[]kolide.EnrollSecret{{Secret: "foo"}}},
+	)
+	require.Error(t, err)
+
+	err = svc.ApplyEnrollSecretSpec(
+		context.Background(),
+		&kolide.EnrollSecretSpec{[]kolide.EnrollSecret{{Name: "foo", Secret: "foo"}}},
+	)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Adds a check to prevent users from unintentionally setting empty
secrets.

Fixes #188