### PR TITLE
Add host details in API responses

### DIFF
--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -13,13 +13,10 @@ type HostStatus string
 const (
 	// StatusOnline host is active.
 	StatusOnline = HostStatus("online")
-
 	// StatusOffline no communication with host for OfflineDuration.
 	StatusOffline = HostStatus("offline")
-
 	// StatusMIA no communication with host for MIADuration.
 	StatusMIA = HostStatus("mia")
-
 	// StatusNew means the host has enrolled in the interval defined by
 	// NewDuration. It is independent of offline and online.
 	StatusNew = HostStatus("new")
@@ -28,7 +25,7 @@ const (
 	// considered new.
 	NewDuration = 24 * time.Hour
 
-	// OfflineDuration if a host hasn't been in communication for this period it
+	// MIADuration if a host hasn't been in communication for this period it
 	// is considered MIA.
 	MIADuration = 30 * 24 * time.Hour
 
@@ -84,13 +81,13 @@ type HostStore interface {
 
 type HostService interface {
 	ListHosts(ctx context.Context, opt HostListOptions) (hosts []*Host, err error)
-	GetHost(ctx context.Context, id uint) (host *Host, err error)
+	GetHost(ctx context.Context, id uint) (host *HostDetail, err error)
 	GetHostSummary(ctx context.Context) (summary *HostSummary, err error)
 	DeleteHost(ctx context.Context, id uint) (err error)
 	// HostByIdentifier returns one host matching the provided identifier.
 	// Possible matches can be on osquery_host_identifier, node_key, UUID, or
 	// hostname.
-	HostByIdentifier(ctx context.Context, identifier string) (*Host, error)
+	HostByIdentifier(ctx context.Context, identifier string) (*HostDetail, error)
 }
 
 type HostListOptions struct {
@@ -144,6 +141,16 @@ type Host struct {
 	LoggerTLSPeriod           uint                `json:"logger_tls_period" db:"logger_tls_period"`
 	Additional                *json.RawMessage    `json:"additional,omitempty" db:"additional"`
 	EnrollSecretName          string              `json:"enroll_secret_name" db:"enroll_secret_name"`
+}
+
+// HostDetail provides the full host metadata along with associated labels and
+// packs.
+type HostDetail struct {
+	Host
+	// Labels is the list of labels the host is a member of.
+	Labels []Label `json:"labels"`
+	// Packs is the list of packs the host is a member of.
+	Packs []Pack `json:"packs"`
 }
 
 const (

--- a/server/kolide/labels.go
+++ b/server/kolide/labels.go
@@ -169,12 +169,12 @@ type Label struct {
 	UpdateCreateTimestamps
 	ID                  uint                `json:"id"`
 	Name                string              `json:"name"`
-	Description         string              `json:"description"`
+	Description         string              `json:"description,omitempty"`
 	Query               string              `json:"query"`
-	Platform            string              `json:"platform"`
+	Platform            string              `json:"platform,omitempty"`
 	LabelType           LabelType           `json:"label_type" db:"label_type"`
 	LabelMembershipType LabelMembershipType `json:"label_membership_type" db:"label_membership_type"`
-	HostCount           int                 `json:"host_count" db:"host_count"`
+	HostCount           int                 `json:"host_count,omitempty" db:"host_count"`
 }
 
 const (

--- a/server/kolide/packs.go
+++ b/server/kolide/packs.go
@@ -124,9 +124,9 @@ type Pack struct {
 	UpdateCreateTimestamps
 	ID          uint   `json:"id"`
 	Name        string `json:"name"`
-	Description string `json:"description"`
-	Platform    string `json:"platform"`
-	Disabled    bool   `json:"disabled"`
+	Description string `json:"description,omitempty"`
+	Platform    string `json:"platform,omitempty"`
+	Disabled    bool   `json:"disabled,omitempty"`
 }
 
 const (

--- a/server/service/client_hosts.go
+++ b/server/service/client_hosts.go
@@ -37,7 +37,7 @@ func (c *Client) GetHosts() ([]HostResponse, error) {
 
 // HostByIdentifier retrieves a host by the uuid, osquery_host_id, hostname, or
 // node_key.
-func (c *Client) HostByIdentifier(identifier string) (*HostResponse, error) {
+func (c *Client) HostByIdentifier(identifier string) (*HostDetailResponse, error) {
 	response, err := c.AuthenticatedDo("GET", "/api/v1/kolide/hosts/identifier/"+identifier, "", nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "GET /api/v1/kolide/hosts/identifier")

--- a/server/service/logging_hosts.go
+++ b/server/service/logging_hosts.go
@@ -25,9 +25,9 @@ func (mw loggingMiddleware) ListHosts(ctx context.Context, opt kolide.HostListOp
 	return hosts, err
 }
 
-func (mw loggingMiddleware) GetHost(ctx context.Context, id uint) (*kolide.Host, error) {
+func (mw loggingMiddleware) GetHost(ctx context.Context, id uint) (*kolide.HostDetail, error) {
 	var (
-		host *kolide.Host
+		host *kolide.HostDetail
 		err  error
 	)
 

--- a/server/service/service_hosts.go
+++ b/server/service/service_hosts.go
@@ -4,18 +4,50 @@ import (
 	"context"
 
 	"github.com/fleetdm/fleet/server/kolide"
+	"github.com/pkg/errors"
 )
 
 func (svc service) ListHosts(ctx context.Context, opt kolide.HostListOptions) ([]*kolide.Host, error) {
 	return svc.ds.ListHosts(opt)
 }
 
-func (svc service) GetHost(ctx context.Context, id uint) (*kolide.Host, error) {
-	return svc.ds.Host(id)
+func (svc service) GetHost(ctx context.Context, id uint) (*kolide.HostDetail, error) {
+	host, err := svc.ds.Host(id)
+	if err != nil {
+		return nil, errors.Wrap(err, "get host")
+	}
+
+	return svc.getHostDetails(ctx, host)
 }
 
-func (svc service) HostByIdentifier(ctx context.Context, identifier string) (*kolide.Host, error) {
-	return svc.ds.HostByIdentifier(identifier)
+func (svc service) HostByIdentifier(ctx context.Context, identifier string) (*kolide.HostDetail, error) {
+	host, err := svc.ds.HostByIdentifier(identifier)
+	if err != nil {
+		return nil, errors.Wrap(err, "get host by identifier")
+	}
+
+	return svc.getHostDetails(ctx, host)
+}
+
+func (svc service) getHostDetails(ctx context.Context, host *kolide.Host) (*kolide.HostDetail, error) {
+	labels, err := svc.ds.ListLabelsForHost(host.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "get labels for host")
+	}
+
+	packPtrs, err := svc.ds.ListPacksForHost(host.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "get packs for host")
+	}
+
+	// TODO refactor List* APIs to be consistent so we don't have to do this
+	// transformation
+	packs := make([]kolide.Pack, 0, len(packPtrs))
+	for _, p := range packPtrs {
+		packs = append(packs, *p)
+	}
+
+	return &kolide.HostDetail{Host: *host, Labels: labels, Packs: packs}, nil
 }
 
 func (svc service) GetHostSummary(ctx context.Context) (*kolide.HostSummary, error) {


### PR DESCRIPTION
Add label and pack information for the returned hosts in the single-host
API endpoints.

Example:

```
curl -k 'https://localhost:8080/api/v1/kolide/hosts/7' -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXNzaW9uX2tleSI6Ii9oNEZ4MUpEVmlvQWhtMC8wNUJKbzZpdldsUDZpMDhjQVBuZXRLeFIvWjNOUGgvMW9VdCsxQnFlNU1CVDVsMlU3ckVGMm5Sb1VxS3ZSUllzSmJJR2lBPT0ifQ.GQQsJgBU3JA1H1o4Y8fPjyfF78F_VY4c9AbrP5k0sCg'
{
  "host": {
    "created_at": "2021-01-16T00:22:33Z",
    "updated_at": "2021-01-16T00:22:51Z",
    "id": 7,
    "detail_updated_at": "1970-01-02T00:00:00Z",
    "label_updated_at": "1970-01-02T00:00:00Z",
    "last_enrolled_at": "2021-01-16T00:22:33Z",
    "seen_time": "2021-01-16T00:22:51Z",
    "hostname": "55d91fc9c303",
    "uuid": "853a4588-0000-0000-a061-7d494d04e9c4",
    "platform": "ubuntu",
    "osquery_version": "4.6.0",
    "os_version": "Ubuntu 20.04.0",
    "build": "",
    "platform_like": "debian",
    "code_name": "",
    "uptime": 0,
    "memory": 16794206208,
    "cpu_type": "x86_64",
    "cpu_subtype": "158",
    "cpu_brand": "Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
    "cpu_physical_cores": 8,
    "cpu_logical_cores": 8,
    "hardware_vendor": "",
    "hardware_model": "",
    "hardware_version": "",
    "hardware_serial": "",
    "computer_name": "55d91fc9c303",
    "primary_ip": "",
    "primary_mac": "",
    "distributed_interval": 10,
    "config_tls_refresh": 0,
    "logger_tls_period": 10,
    "enroll_secret_name": "default",
    "labels": [
      {
        "created_at": "2020-12-22T01:22:47Z",
        "updated_at": "2020-12-22T01:22:47Z",
        "id": 6,
        "name": "All Hosts",
        "description": "All hosts which have enrolled in Fleet",
        "query": "select 1;",
        "label_type": "builtin",
        "label_membership_type": "dynamic"
      }
    ],
    "packs": [
      {
        "created_at": "2021-01-20T16:36:42Z",
        "updated_at": "2021-01-20T16:36:42Z",
        "id": 2,
        "name": "test"
      }
    ],
    "status": "offline",
    "display_text": "55d91fc9c303"
  }
}
```