### PR TITLE
Reveal live query error information in Fleet UI

### DIFF
--- a/frontend/components/hosts/HostsTable/_styles.scss
+++ b/frontend/components/hosts/HostsTable/_styles.scss
@@ -63,7 +63,7 @@
 
     &--offline {
       &:before {
-        background-color: $core-red;
+        background-color: $ui-dark-grey;
         border-radius: 100%;
         content: ' ';
         display: inline-block;

--- a/frontend/components/loaders/ProgressBar/_styles.scss
+++ b/frontend/components/loaders/ProgressBar/_styles.scss
@@ -1,9 +1,10 @@
 .progress-bar {
   display: flex;
-  background-color: $ui-medium-grey;
+  background-color: $ui-dark-grey;
   height: 10px;
   overflow: hidden;
   border-radius: 2px;
+  margin-top: 4px;
   
   &__progress {
     height: 100%;

--- a/frontend/components/loaders/ProgressBar/_styles.scss
+++ b/frontend/components/loaders/ProgressBar/_styles.scss
@@ -5,7 +5,7 @@
   overflow: hidden;
   border-radius: 2px;
   margin-top: 4px;
-  
+
   &__progress {
     height: 100%;
     overflow: hidden;

--- a/frontend/components/loaders/ProgressBar/_styles.scss
+++ b/frontend/components/loaders/ProgressBar/_styles.scss
@@ -3,7 +3,8 @@
   background-color: $ui-medium-grey;
   height: 10px;
   overflow: hidden;
-
+  border-radius: 2px;
+  
   &__progress {
     height: 100%;
     overflow: hidden;

--- a/frontend/components/queries/QueryProgressDetails/QueryProgressDetails.jsx
+++ b/frontend/components/queries/QueryProgressDetails/QueryProgressDetails.jsx
@@ -11,10 +11,19 @@ const baseClass = 'query-progress-details';
 
 const QueryProgressDetails = ({ campaign, className, onRunQuery, onStopQuery, queryIsRunning, queryTimerMilliseconds, disableRun }) => {
   const { hosts_count: hostsCount } = campaign;
-  const { Metrics: metrics } = campaign;
+  const { Metrics: metrics = {} } = campaign;
   const { errors } = campaign;
   const totalHostsCount = get(campaign, ['totals', 'count'], 0);
   const totalRowsCount = get(campaign, ['query_results', 'length'], 0);
+
+  const onlineHostsTotalDisplay = metrics.OnlineHosts === 1 ? '1 host' : `${metrics.OnlineHosts} hosts`;
+  const onlineResultsTotalDisplay = totalRowsCount === 1 ? '1 result' : `${totalRowsCount} results`;
+  const offlineHostsTotalDisplay = metrics.OfflineHosts === 1 ? '1 host' : `${metrics.OfflineHosts} hosts`;
+  const failedHostsTotalDisplay = hostsCount.failed === 1 ? '1 host' : `${hostsCount.failed} hosts`;
+  let totalErrorsDisplay = '0 errors';
+  if (errors) {
+    totalErrorsDisplay = errors.length === 1 ? '1 error' : `${errors.length} errors`;
+  }
 
   const runQueryBtn = (
     <div className={`${baseClass}__btn-wrapper`}>
@@ -54,9 +63,9 @@ const QueryProgressDetails = ({ campaign, className, onRunQuery, onStopQuery, qu
     <div className={`${baseClass} ${className}`}>
       <div className={`${baseClass}__wrapper`}>
         <div className={`${baseClass}__text-wrapper`}>
-          <span className={`${baseClass}__text-online`}>Online - {metrics.OnlineHosts} hosts returning {totalRowsCount} results</span>
-          <span className={`${baseClass}__text-offline`}>Offline - {metrics.OfflineHosts} hosts returning 0 results</span>
-          <span className={`${baseClass}__text-error`}>Failed - {hostsCount.failed} hosts returning {errors ? errors.length : '0'} errors</span>
+          <span className={`${baseClass}__text-online`}>Online - {onlineHostsTotalDisplay} returning {onlineResultsTotalDisplay}</span>
+          <span className={`${baseClass}__text-offline`}>Offline - {offlineHostsTotalDisplay} returning 0 results</span>
+          <span className={`${baseClass}__text-error`}>Failed - {failedHostsTotalDisplay} returning {totalErrorsDisplay}</span>
         </div>
         <ProgressBar
           error={hostsCount.failed}

--- a/frontend/components/queries/QueryProgressDetails/QueryProgressDetails.jsx
+++ b/frontend/components/queries/QueryProgressDetails/QueryProgressDetails.jsx
@@ -54,9 +54,9 @@ const QueryProgressDetails = ({ campaign, className, onRunQuery, onStopQuery, qu
     <div className={`${baseClass} ${className}`}>
       <div className={`${baseClass}__wrapper`}>
         <div className={`${baseClass}__text-wrapper`}>
-          <span>Online - {metrics.OnlineHosts} hosts returning {totalRowsCount} results</span>
-          <span>Offline - {metrics.OfflineHosts} hosts returning 0 results</span>
-          <span>Failed - {hostsCount.failed} hosts returning {errors ? errors.length : '0'} errors</span>
+          <span className={`${baseClass}__text-online`}>Online - {metrics.OnlineHosts} hosts returning {totalRowsCount} results</span>
+          <span className={`${baseClass}__text-offline`}>Offline - {metrics.OfflineHosts} hosts returning 0 results</span>
+          <span className={`${baseClass}__text-error`}>Failed - {hostsCount.failed} hosts returning {errors ? errors.length : '0'} errors</span>
         </div>
         <ProgressBar
           error={hostsCount.failed}

--- a/frontend/components/queries/QueryProgressDetails/QueryProgressDetails.jsx
+++ b/frontend/components/queries/QueryProgressDetails/QueryProgressDetails.jsx
@@ -11,6 +11,8 @@ const baseClass = 'query-progress-details';
 
 const QueryProgressDetails = ({ campaign, className, onRunQuery, onStopQuery, queryIsRunning, queryTimerMilliseconds, disableRun }) => {
   const { hosts_count: hostsCount } = campaign;
+  const { Metrics: metrics } = campaign;
+  const { errors } = campaign;
   const totalHostsCount = get(campaign, ['totals', 'count'], 0);
   const totalRowsCount = get(campaign, ['query_results', 'length'], 0);
 
@@ -51,12 +53,11 @@ const QueryProgressDetails = ({ campaign, className, onRunQuery, onStopQuery, qu
   return (
     <div className={`${baseClass} ${className}`}>
       <div className={`${baseClass}__wrapper`}>
-        <span>
-          <b>{hostsCount.total}</b>&nbsp;of&nbsp;
-          <b>{totalHostsCount} Hosts</b>&nbsp;Returning&nbsp;
-          <b>{totalRowsCount} Records&nbsp;</b>
-          <em>({hostsCount.failed} failed)</em>
-        </span>
+        <div className={`${baseClass}__text-wrapper`}>
+          <span>Online - {metrics.OnlineHosts} hosts returning {totalRowsCount} results</span>
+          <span>Offline - {metrics.OfflineHosts} hosts returning 0 results</span>
+          <span>Failed - {hostsCount.failed} hosts returning {errors ? errors.length : '0'} errors</span>
+        </div>
         <ProgressBar
           error={hostsCount.failed}
           max={totalHostsCount}

--- a/frontend/components/queries/QueryProgressDetails/_styles.scss
+++ b/frontend/components/queries/QueryProgressDetails/_styles.scss
@@ -14,6 +14,12 @@
     }
   }
 
+  &__text-wrapper {
+    display: flex;
+    flex-direction: column;
+    font-size: $x-small;
+  }
+
   &__btn-wrapper {
     float: right;
 

--- a/frontend/components/queries/QueryProgressDetails/_styles.scss
+++ b/frontend/components/queries/QueryProgressDetails/_styles.scss
@@ -20,6 +20,42 @@
     font-size: $x-small;
   }
 
+  &__text-online {
+    &:before {
+      background-color: $success;
+      border-radius: 100%;
+      content: ' ';
+      display: inline-block;
+      height: 8px;
+      margin-right: 8px;
+      width: 8px;
+    }
+  }
+
+  &__text-offline {
+    &:before {
+      background-color: $ui-dark-grey;
+      border-radius: 100%;
+      content: ' ';
+      display: inline-block;
+      height: 8px;
+      margin-right: 8px;
+      width: 8px;
+    }
+  }
+
+  &__text-error {
+    &:before {
+      background-color: $alert;
+      border-radius: 100%;
+      content: ' ';
+      display: inline-block;
+      height: 8px;
+      margin-right: 8px;
+      width: 8px;
+    }
+  }
+
   &__btn-wrapper {
     float: right;
 

--- a/frontend/components/queries/QueryResultsTable/QueryResultsTable.jsx
+++ b/frontend/components/queries/QueryResultsTable/QueryResultsTable.jsx
@@ -56,7 +56,7 @@ class QueryResultsTable extends Component {
     };
   }
 
-  renderTableHeaderRowData = (column, index) => {
+  renderTableHeaderColumn = (column, index) => {
     const filterable = column === 'hostname' ? 'host_hostname' : column;
     const { activeColumn, resultsFilter } = this.state;
     const { onFilterAttribute, onSetActiveColumn } = this;
@@ -77,29 +77,29 @@ class QueryResultsTable extends Component {
     );
   }
 
-  renderTableHeaderRow = (data) => {
-    const { renderTableHeaderRowData } = this;
+  renderTableHeaderRow = (rows) => {
+    const { renderTableHeaderColumn } = this;
 
-    const queryAttrs = omit(data[0], ['host_hostname']);
+    const queryAttrs = omit(rows[0], ['host_hostname']);
     const queryResultColumns = keys(queryAttrs);
 
     return (
       <tr>
-        {renderTableHeaderRowData('hostname', -1)}
+        {renderTableHeaderColumn('hostname', -1)}
         {queryResultColumns.map((column, i) => {
-          return renderTableHeaderRowData(column, i);
+          return renderTableHeaderColumn(column, i);
         })}
       </tr>
     );
   }
 
-  renderTableRows = (data) => {
+  renderTableRows = (rows) => {
     const { resultsFilter } = this.state;
-    const filteredData = filterArrayByHash(data, resultsFilter);
+    const filteredRows = filterArrayByHash(rows, resultsFilter);
 
-    return filteredData.map((item) => {
+    return filteredRows.map((row) => {
       return (
-        <QueryResultsRow queryResult={item} />
+        <QueryResultsRow queryResult={row} />
       );
     });
   }

--- a/frontend/components/queries/QueryResultsTable/QueryResultsTable.jsx
+++ b/frontend/components/queries/QueryResultsTable/QueryResultsTable.jsx
@@ -214,7 +214,7 @@ class QueryResultsTable extends Component {
         </header>
         <span className={`${baseClass}__table-title`}>Results</span>
         <div className={`${baseClass}__results-table-wrapper`}>
-          {hasNoResults && <span className="no-results-message">No results found</span>}
+          {hasNoResults && <span className="no-results-message">No results found. Check the table below for errors.</span>}
           {!hasNoResults && renderTable()}
         </div>
         {hasErrors &&

--- a/frontend/components/queries/QueryResultsTable/QueryResultsTable.jsx
+++ b/frontend/components/queries/QueryResultsTable/QueryResultsTable.jsx
@@ -77,12 +77,10 @@ class QueryResultsTable extends Component {
     );
   }
 
-  renderTableHeaderRow = () => {
-    const { campaign } = this.props;
+  renderTableHeaderRow = (data) => {
     const { renderTableHeaderRowData } = this;
-    const { query_results: queryResults } = campaign;
 
-    const queryAttrs = omit(queryResults[0], ['host_hostname']);
+    const queryAttrs = omit(data[0], ['host_hostname']);
     const queryResultColumns = keys(queryAttrs);
 
     return (
@@ -95,15 +93,13 @@ class QueryResultsTable extends Component {
     );
   }
 
-  renderTableRows = () => {
-    const { campaign } = this.props;
-    const { query_results: queryResults } = campaign;
+  renderTableRows = (data) => {
     const { resultsFilter } = this.state;
-    const filteredQueryResults = filterArrayByHash(queryResults, resultsFilter);
+    const filteredData = filterArrayByHash(data, resultsFilter);
 
-    return filteredQueryResults.map((queryResult) => {
+    return filteredData.map((item) => {
       return (
-        <QueryResultsRow queryResult={queryResult} />
+        <QueryResultsRow queryResult={item} />
       );
     });
   }
@@ -116,7 +112,6 @@ class QueryResultsTable extends Component {
 
     const { queryIsRunning, campaign } = this.props;
     const { query_results: queryResults } = campaign;
-
     const loading = queryIsRunning && (!queryResults || !queryResults.length);
 
     if (loading) {
@@ -126,10 +121,37 @@ class QueryResultsTable extends Component {
     return (
       <table className={`${baseClass}__table`}>
         <thead>
-          {renderTableHeaderRow()}
+          {renderTableHeaderRow(queryResults)}
         </thead>
         <tbody>
-          {renderTableRows()}
+          {renderTableRows(queryResults)}
+        </tbody>
+      </table>
+    );
+  }
+
+  renderErrorsTable = () => {
+    const {
+      renderTableHeaderRow,
+      renderTableRows,
+    } = this;
+
+    const { queryIsRunning, campaign } = this.props;
+    const { errors } = campaign;
+
+    const loading = queryIsRunning && (!errors || !errors.length);
+
+    if (loading) {
+      return <Spinner />;
+    }
+
+    return (
+      <table className={`${baseClass}__table`}>
+        <thead>
+          {renderTableHeaderRow(errors)}
+        </thead>
+        <tbody>
+          {renderTableRows(errors)}
         </tbody>
       </table>
     );
@@ -148,10 +170,11 @@ class QueryResultsTable extends Component {
       queryTimerMilliseconds,
     } = this.props;
 
-    const { renderTable } = this;
+    const { renderTable, renderErrorsTable } = this;
 
-    const { hosts_count: hostsCount, query_results: queryResults } = campaign;
+    const { hosts_count: hostsCount, query_results: queryResults, errors } = campaign;
     const hasNoResults = !queryIsRunning && (!hostsCount.successful || (!queryResults || !queryResults.length));
+    const hasErrors = !queryIsRunning && (hostsCount.failed || errors);
 
     const resultsTableWrapClass = classnames(baseClass, {
       [`${baseClass}--full-screen`]: isQueryFullScreen,
@@ -174,7 +197,6 @@ class QueryResultsTable extends Component {
             className={`${baseClass}__full-screen`}
             queryTimerMilliseconds={queryTimerMilliseconds}
           />}
-
           <Button
             className={toggleFullScreenBtnClass}
             onClick={onToggleQueryFullScreen}
@@ -187,13 +209,22 @@ class QueryResultsTable extends Component {
             onClick={onExportQueryResults}
             variant="inverse"
           >
-            Export
+            Export results
           </Button>
         </header>
-        <div className={`${baseClass}__table-wrapper`}>
-          {hasNoResults && <em className="no-results-message">No results found</em>}
+        <span className={`${baseClass}__table-title`}>Results</span>
+        <div className={`${baseClass}__results-table-wrapper`}>
+          {hasNoResults && <span className="no-results-message">No results found</span>}
           {!hasNoResults && renderTable()}
         </div>
+        {hasErrors &&
+        <div className={`${baseClass}__error-table-container`}>
+          <span className={`${baseClass}__table-title`}>Errors</span>
+          <div className={`${baseClass}__error-table-wrapper`}>
+            {renderErrorsTable()}
+          </div>
+        </div>
+        }
       </div>
     );
   }

--- a/frontend/components/queries/QueryResultsTable/QueryResultsTable.tests.jsx
+++ b/frontend/components/queries/QueryResultsTable/QueryResultsTable.tests.jsx
@@ -49,6 +49,10 @@ const campaignWithQueryResults = {
     { host_hostname: 'dfoihgsx', cwd: '/', directory: '/root' },
     { host_hostname: 'abc123', cwd: '/', directory: '/root' },
   ],
+  Metrics: {
+    OnlineHosts: 2,
+    OfflineHosts: 0,
+  },
   hosts_count: {
     failed: 0,
     successful: 2,

--- a/frontend/components/queries/QueryResultsTable/_styles.scss
+++ b/frontend/components/queries/QueryResultsTable/_styles.scss
@@ -20,6 +20,7 @@
   }
 
   &__filter-icon {
+    color: #AFBEC1;
     &--is-active {
       color: $core-blue;
     }
@@ -34,7 +35,6 @@
     display: flex;
     border: solid 1px $ui-borders;
     border-radius: 3px;
-    box-shadow: inset 0 0 8px 0 rgba(0, 0, 0, 0.12);
     overflow: scroll;
     margin-top: 4px;
     min-height: 400px;
@@ -60,7 +60,6 @@
     display: flex;
     border: solid 1px $ui-borders;
     border-radius: 3px;
-    box-shadow: inset 0 0 8px 0 rgba(0, 0, 0, 0.12);
     overflow: scroll;
     margin-bottom: 40px;
     margin-top: 4px;
@@ -79,10 +78,15 @@
     background-color: $core-light-blue-grey;
     color: $core-black;
     text-align: left;
+    border-bottom: 1px solid $ui-borders;
 
     th {
-      padding: $pad-small $pad-xsmall;
+      padding: 12px 24px;
       min-width: 125px;
+
+      .form-field {
+        margin-bottom: 0;
+      }
 
       span {
         white-space: nowrap;
@@ -102,13 +106,16 @@
     background-color: $white;
 
     td {
-      padding: 7px;
+      padding: 12px 24px;
+      white-space: nowrap;
     }
 
     tr {
-      &:nth-child(even) {
-        background-color: $core-light-blue-grey;
-      }
+      border-bottom: 1px solid $ui-borders;
+    }
+
+    tr:last-child {
+      border-bottom: none;
     }
   }
 

--- a/frontend/components/queries/QueryResultsTable/_styles.scss
+++ b/frontend/components/queries/QueryResultsTable/_styles.scss
@@ -21,6 +21,7 @@
 
   &__filter-icon {
     color: $ui-dark-grey;
+
     &--is-active {
       color: $core-blue;
     }
@@ -40,6 +41,7 @@
     min-height: 200px;
     max-height: 400px;
     width: 100%;
+
     .kolide-spinner {
       align-self: center;
     }
@@ -112,10 +114,10 @@
 
     tr {
       border-bottom: 1px solid $ui-borders;
-    }
 
-    tr:last-child {
-      border-bottom: none;
+      &:last-child {
+        border-bottom: 0;
+      }
     }
   }
 

--- a/frontend/components/queries/QueryResultsTable/_styles.scss
+++ b/frontend/components/queries/QueryResultsTable/_styles.scss
@@ -20,7 +20,7 @@
   }
 
   &__filter-icon {
-    color: #AFBEC1;
+    color: $ui-dark-grey;
     &--is-active {
       color: $core-blue;
     }
@@ -129,6 +129,10 @@
     padding: 20px;
 
     .query-progress-details__run-btn {
+      display: none;
+    }
+
+    .query-progress-details__stop-btn {
       display: none;
     }
 

--- a/frontend/components/queries/QueryResultsTable/_styles.scss
+++ b/frontend/components/queries/QueryResultsTable/_styles.scss
@@ -37,8 +37,8 @@
     border-radius: 3px;
     overflow: scroll;
     margin-top: 4px;
-    min-height: 400px;
-    height: 400px;
+    min-height: 200px;
+    max-height: 400px;
     width: 100%;
     .kolide-spinner {
       align-self: center;

--- a/frontend/components/queries/QueryResultsTable/_styles.scss
+++ b/frontend/components/queries/QueryResultsTable/_styles.scss
@@ -2,11 +2,14 @@
   display: flex;
   flex-direction: column;
   background-color: $white;
-  padding: $pad-base;
   width: 100%;
   min-height: calc(500px + (#{$pad-base} * 2));
   box-sizing: border-box;
-  max-height: 75vh;
+
+  &__table-title {
+    font-size: $x-small;
+    font-weight: $bold;
+  }
 
   &__button-wrap {
     @include clearfix;
@@ -27,17 +30,16 @@
     width: 378px;
   }
 
-  &__table-wrapper {
+  &__results-table-wrapper {
     display: flex;
-    flex-grow: 1;
     border: solid 1px $ui-borders;
     border-radius: 3px;
     box-shadow: inset 0 0 8px 0 rgba(0, 0, 0, 0.12);
     overflow: scroll;
-    margin-top: 30px;
+    margin-top: 4px;
     min-height: 400px;
+    height: 400px;
     width: 100%;
-
     .kolide-spinner {
       align-self: center;
     }
@@ -46,13 +48,30 @@
       flex-grow: 1;
       align-self: center;
       text-align: center;
+      font-size: $x-small;
     }
+  }
+
+  &__error-table-container {
+    margin-top: 24px;
+  }
+
+  &__error-table-wrapper {
+    display: flex;
+    border: solid 1px $ui-borders;
+    border-radius: 3px;
+    box-shadow: inset 0 0 8px 0 rgba(0, 0, 0, 0.12);
+    overflow: scroll;
+    margin-bottom: 40px;
+    margin-top: 4px;
+    max-height: 200px;
+    width: 100%;
   }
 
   &__table {
     border-collapse: collapse;
     color: $core-dark-blue-grey;
-    font-size: $small;
+    font-size: $x-small;
     width: 100%;
   }
 
@@ -83,7 +102,7 @@
     background-color: $white;
 
     td {
-      padding: $pad-xsmall;
+      padding: 7px;
     }
 
     tr {
@@ -100,8 +119,17 @@
     box-shadow: 0 0 12px 0 rgba(0, 0, 0, 0.1);
     border: solid 1px $ui-borders;
     z-index: 99;
+    padding: 20px;
 
     .query-progress-details__run-btn {
+      display: none;
+    }
+
+    .query-results-table__results-table-wrapper {
+      height: auto;
+    }
+
+    .query-results-table__error-table-container {
       display: none;
     }
   }

--- a/frontend/pages/queries/QueryPage/QueryPage.tests.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.tests.jsx
@@ -196,7 +196,7 @@ describe('QueryPage - component', () => {
       'resets selected targets and removed the campaign when the hostname changes',
       () => {
         const queryResult = { org_name: 'Kolide', org_url: 'https://kolide.co' };
-        const campaign = { id: 1, query_results: [queryResult], hosts_count: { total: 1 } };
+        const campaign = { id: 1, query_results: [queryResult], hosts_count: { total: 1 }, Metrics: { OnlineHosts: 1, OfflineHosts: 0 } };
         const props = {
           dispatch: noop,
           loadingQueries: false,
@@ -232,6 +232,10 @@ describe('QueryPage - component', () => {
           successful: 1,
           total: 1,
         },
+        Metrics: {
+          OnlineHosts: 1,
+          OfflineHosts: 0,
+        },
         query_results: [queryResult],
       };
       const queryResultsCSV = convertToCSV([queryResult]);
@@ -262,6 +266,10 @@ describe('QueryPage - component', () => {
             failed: 0,
             successful: 1,
             total: 1,
+          },
+          Metrics: {
+            OnlineHosts: 1,
+            OfflineHosts: 0,
           },
           query_results: [queryResult],
         };

--- a/frontend/redux/nodes/entities/campaigns/helpers.js
+++ b/frontend/redux/nodes/entities/campaigns/helpers.js
@@ -10,14 +10,17 @@ const updateCampaignStateFromTotals = (campaign, { data }) => {
 
 const updateCampaignStateFromResults = (campaign, { data }) => {
   const queryResults = campaign.query_results || [];
+  const errors = campaign.errors || [];
   const hosts = campaign.hosts || [];
-  const { host, rows } = data;
+  const { host, rows, error } = data;
   const { hosts_count: hostsCount } = campaign;
   const newHosts = [...hosts, host];
   const newQueryResults = [...queryResults, ...rows];
   let newHostsCount;
-
-  if (data.error) {
+  let newErrors;
+  // Host's with osquery version above 4.4.0 receive an error message
+  // when the live query fails.
+  if (error) {
     const newFailed = hostsCount.failed + 1;
     const newTotal = hostsCount.successful + newFailed;
 
@@ -26,6 +29,20 @@ const updateCampaignStateFromResults = (campaign, { data }) => {
       failed: newFailed,
       total: newTotal,
     };
+
+    newErrors = [...errors, { host_hostname: host.hostname, error }];
+  // Host's with osquery version below 4.4.0 receive an empty error message
+  // when the live query fails so we create our own message.
+  } else if (error === '') {
+    const newFailed = hostsCount.failed + 1;
+    const newTotal = hostsCount.successful + newFailed;
+
+    newHostsCount = {
+      successful: hostsCount.successful,
+      failed: newFailed,
+      total: newTotal,
+    };
+    newErrors = [...errors, { host_hostname: host.hostname, error: 'unknown error: upgrade osquery on this host to a version > 4.4.0 to see a more descriptive message.' }];
   } else {
     const newSuccessful = hostsCount.successful + 1;
     const newTotal = hostsCount.failed + newSuccessful;
@@ -43,6 +60,7 @@ const updateCampaignStateFromResults = (campaign, { data }) => {
       hosts: newHosts,
       query_results: newQueryResults,
       hosts_count: newHostsCount,
+      errors: newErrors,
     },
   };
 };

--- a/frontend/redux/nodes/entities/campaigns/helpers.js
+++ b/frontend/redux/nodes/entities/campaigns/helpers.js
@@ -54,7 +54,7 @@ const updateCampaignStateFromResults = (campaign, { data }) => {
       {
         host_hostname: host.hostname,
         osquery_version: host.osquery_version,
-        error: 'unknown error: upgrade osquery on this host to a version > 4.4.0 to see a more descriptive message.',
+        error: 'upgrade osquery on this host to 4.4.0+ for error details',
       },
     ];
   } else {

--- a/frontend/redux/nodes/entities/campaigns/helpers.js
+++ b/frontend/redux/nodes/entities/campaigns/helpers.js
@@ -30,7 +30,14 @@ const updateCampaignStateFromResults = (campaign, { data }) => {
       total: newTotal,
     };
 
-    newErrors = [...errors, { host_hostname: host.hostname, error }];
+    newErrors = [
+      ...errors,
+      {
+        host_hostname: host.hostname,
+        osquery_version: host.osquery_version,
+        error,
+      },
+    ];
   // Host's with osquery version below 4.4.0 receive an empty error message
   // when the live query fails so we create our own message.
   } else if (error === '') {
@@ -42,7 +49,14 @@ const updateCampaignStateFromResults = (campaign, { data }) => {
       failed: newFailed,
       total: newTotal,
     };
-    newErrors = [...errors, { host_hostname: host.hostname, error: 'unknown error: upgrade osquery on this host to a version > 4.4.0 to see a more descriptive message.' }];
+    newErrors = [
+      ...errors,
+      {
+        host_hostname: host.hostname,
+        osquery_version: host.osquery_version,
+        error: 'unknown error: upgrade osquery on this host to a version > 4.4.0 to see a more descriptive message.',
+      },
+    ];
   } else {
     const newSuccessful = hostsCount.successful + 1;
     const newTotal = hostsCount.failed + newSuccessful;

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -16,6 +16,7 @@ $core-blue-green: #25c3ba;
 $ui-borders: #dbe3e5;
 $ui-light-grey: #fafafa;
 $ui-medium-grey: #e3e3e3;
+$ui-dark-grey: #afbec1;
 $warning: #ffad00;
 
 // Colors for over (hover) and down (active) buttons styles

--- a/frontend/test/stubs.js
+++ b/frontend/test/stubs.js
@@ -175,6 +175,10 @@ export const campaignStub = {
     successful: 2,
     total: 2,
   },
+  Metrics: {
+    OnlineHosts: 2,
+    OfflineHosts: 0,
+  },
   id: 1,
   query_id: queryStub.id,
   query_results: [queryResultStub],


### PR DESCRIPTION
This PR adds an "Errors" table to the live query UI.

Loom demo (recommended speed 1.5x)
https://www.loom.com/share/a60d0321d9e04566ad3138ee8de6ec36

Summary of changes:
- Errors table includes the columns `hostname`, `osquery_version`, and `error`
- The errors table is only rendered when at least one host fails
- Hosts with an osquery verion less than 4.4.0 always display the error "unknown error: upgrade osquery on this host to a version > 4.4.0 to see a more descriptive message."

Additional changes include:
- Add offline hosts count to `<QueryProgressDetails />` and adjust and `<ProgressBar />` styles
- Change offline hosts' color tag from red to grey

Addresses #192 