### PR TITLE
Add ciphersuites for compability with Go HTTP/2

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -387,6 +387,11 @@ func getTLSConfig(profile string) *tls.Config {
 			tls.TLS_AES_128_GCM_SHA256,
 			tls.TLS_AES_256_GCM_SHA384,
 			tls.TLS_CHACHA20_POLY1305_SHA256,
+			// These cipher suites not explicitly listed by Mozilla, but
+			// required by Go's HTTP/2 implementation
+			// See: https://go-review.googlesource.com/c/net/+/200317/
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 		)
 	case config.TLSProfileIntermediate:
 		cfg.MinVersion = tls.VersionTLS12


### PR DESCRIPTION
Fixes a misconfiguration due to #212 that prevented the server from
starting up in `modern` tls compatibility mode.

This bug never made it to a release.