### PR TITLE
Minor amendments to README in the `Try Fleet` area

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ Now that you've finished setting up Fleet, you will want to enroll a server, con
 > 
 > Then after cloning this repository, `cd` into the [`osquery/`](./tools/osquery) directory:
 > ```shell
-> cd osquery/
+> cd tools/osquery/
 > ```
 >
 > This directory contains configuration that can start up Docker containers running osquery agents.  To start them up:
 > ```shell
-> ENROLL_SECRET=<paste your enroll secret here> docker-compose up
+> ENROLL_SECRET=<paste your enroll secret here> FLEET_SERVER=host.docker.internal:8412 docker-compose up
 > ```
 >
 > Now navigate back to https://localhost:8412 or refresh to see your new hosts in Fleet!


### PR DESCRIPTION
- update the path of the directory to cd into (the link above it seems correct)
- add a `FLEET_SERVER` env var that worked (the default in the `docker-compose.yml` used `8080`

Instruction changes of what I needed to do to run locally on my mac