### PR TITLE
Add Helm chart

### DIFF
--- a/.github/scripts/helm-check-expected.sh
+++ b/.github/scripts/helm-check-expected.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+usage() {
+    echo "${0} <templated-deployment.yaml> 'LIST OF EXPECTED ENVS' 'LIST OF EXPECTED VOLUMES'"
+}
+
+TEMPLATED_DEPLOYMENT=${1}
+if [ -z "${TEMPLATED_DEPLOYMENT}" ]; then
+    echo "Error: Missing path to templated deployment"
+    usage
+    exit 1
+fi
+
+EXPECTED_ENVS=${2}
+if [ -z "${EXPECTED_ENVS}" ]; then
+    echo "Error: Missing space-separated list of expected environment variables"
+    usage
+    exit 1
+fi
+
+EXPECTED_VOLUMES=${3}
+if [ -z "${EXPECTED_VOLUMES}" ]; then
+    echo "Error: Missing space-separated list of expected volumes"
+    usage
+    exit 1
+fi
+
+ALL_ENVS=$(yq eval 'select(.kind == "Deployment") | .spec.template.spec.containers[].env[].name' ${TEMPLATED_DEPLOYMENT})
+ALL_VOLUME_MOUNTS=$(yq eval 'select(.kind == "Deployment") | .spec.template.spec.containers[].volumeMounts[].name' ${TEMPLATED_DEPLOYMENT})
+ALL_VOLUMES=$(yq eval 'select(.kind == "Deployment") | .spec.template.spec.volumes[].name' ${TEMPLATED_DEPLOYMENT})
+
+seen=0
+for EE in ${EXPECTED_ENVS}; do
+    seen=0
+    for AE in ${ALL_ENVS}; do
+        if [ "${AE}" == "${EE}" ]; then
+            seen=1
+            echo "Expected env found: ${AE}"
+            break
+        fi
+    done
+done
+if [ ${seen} -eq 0 ]; then
+    echo "Error: not all expected envs were found"
+    exit 1
+fi
+
+for EV in ${EXPECTED_VOLUMES}; do
+    seen=0
+    for AV in ${ALL_VOLUMES}; do
+        if [ "${AV}" == "${EV}" ]; then
+            echo "Expected volume found: ${AV}"
+            break
+        fi
+    done
+    for AVM in ${ALL_VOLUME_MOUNTS}; do
+        if [ "${AVM}" == "${EV}" ]; then
+            seen=1
+            echo "Expected volume mount found: ${AVM}"
+            break
+        fi
+    done
+done
+if [ ${seen} -eq 0 ]; then
+    echo "Error: not all expected volumes and their mounts were found"
+    exit 1
+fi

--- a/.github/workflows/pr-helm.yaml
+++ b/.github/workflows/pr-helm.yaml
@@ -9,7 +9,7 @@ jobs:
   sanity-check:
     strategy:
       matrix:
-        kube-version: [1.16, 1.17, 1.18, 1.19, 1.20] # all currently supported versions
+        kube-version: [1.16.0, 1.17.0, 1.18.0] # kubeval is currently lagging behind the active schema versions, so these are the ones we can test against. see https://github.com/instrumenta/kubernetes-json-schema/issues/26
     runs-on: ubuntu-20.04
     steps:
     - name: checkout

--- a/.github/workflows/pr-helm.yaml
+++ b/.github/workflows/pr-helm.yaml
@@ -1,0 +1,43 @@
+name: pr-helm
+on:
+  pull_request:
+    paths:
+    - chart
+
+jobs:
+  sanity-check:
+    strategy:
+      matrix:
+        kube-version: [1.16, 1.17, 1.18, 1.19, 1.20] # all currently supported versions
+    runs-on: ubuntu-20.04
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: create temp dir
+      run: mkdir -p helm-temp
+    - name: helm template -- default values
+      run: >
+        helm template
+          --namespace fleet
+          --release-name fleet
+          --values chart/values.yaml
+          chart
+        > helm-temp/output-defaults.yaml
+    - name: helm template -- other configurations
+      run: |
+        VALUES_FILES=$(find tools/ci/helm-values -type f)
+        for FILE_PATH in ${VALUES_FILES}; do
+          FILE=$(echo ${FILE_PATH} | rev | cut -d"/" -f1 | rev)
+          REL_NAME=$(echo ${FILE} | cut -d"." -f1)
+          helm template \
+            --namespace ${REL_NAME} \
+            --release-name ${REL_NAME} \
+            --values ${FILE_PATH} \
+            chart \
+          > helm-temp/${FILE}
+        done
+    - name: kubeval sanity check    
+      uses: instrumenta/kubeval-action
+      with:
+        files: helm-temp
+        version: ${{ matrix.kube-version }}

--- a/.github/workflows/pr-helm.yaml
+++ b/.github/workflows/pr-helm.yaml
@@ -17,12 +17,12 @@ jobs:
     - name: create temp dir
       run: mkdir -p helm-temp
     - name: helm template -- default values
-      run: >
-        helm template
-          --namespace fleet
-          --release-name fleet
-          --values chart/values.yaml
-          chart
+      run: |
+        helm template \
+          --namespace fleet \
+          --release-name fleet \
+          --values chart/values.yaml \
+          chart \
         > helm-temp/output-defaults.yaml
     - name: helm template -- other configurations
       run: |
@@ -42,3 +42,45 @@ jobs:
       with:
         files: helm-temp
         version: ${{ matrix.kube-version }}
+    - name: install yq
+      env:
+        YQ_VERSION: 4.4.1
+      run: |
+        curl -LO https://github.com/mikefarah/yq/releases/download/v$YQ_VERSION/yq_linux_amd64
+        curl -LO https://github.com/mikefarah/yq/releases/download/v$YQ_VERSION/checksums
+        echo "$(grep linux_amd64 checksums | awk '{print $19}') yq_linux_amd64" > sha256
+        sha256sum --check sha256
+        chmod +x yq_linux_amd64
+        mkdir -p ${HOME}/.bin
+        mv yq_linux_amd64 ${HOME}/.bin/yq
+        echo PATH=${PATH}:${HOME}/.bin >> $GITHUB_ENV
+    - name: check default values
+      run: |
+        .github/scripts/helm-check-expected.sh \
+        "helm-temp/output-defaults.yaml" \
+        'KOLIDE_FILESYSTEM_STATUS_LOG_FILE KOLIDE_FILESYSTEM_RESULT_LOG_FILE KOLIDE_FILESYSTEM_ENABLE_LOG_ROTATION KOLIDE_FILESYSTEM_ENABLE_LOG_COMPRESSION' \
+        'fleet-tls osquery-logs'
+    - name: check pubusb values
+      run: |
+        .github/scripts/helm-check-expected.sh \
+        "helm-temp/logger-pubsub.yaml" \
+        'KOLIDE_PUBSUB_PROJECT KOLIDE_PUBSUB_STATUS_TOPIC KOLIDE_PUBSUB_RESULT_TOPIC' \
+        'fleet-tls'
+    - name: check firehose accesskey values
+      run: |
+        .github/scripts/helm-check-expected.sh \
+        "helm-temp/logger-firehose-accesssid.yaml" \
+        'KOLIDE_FIREHOSE_REGION KOLIDE_FIREHOSE_STATUS_STREAM KOLIDE_FIREHOSE_RESULT_STREAM KOLIDE_FIREHOSE_ACCESS_KEY_ID KOLIDE_FIREHOSE_SECRET_ACCESS_KEY' \
+        'fleet-tls'
+    - name: check firehose sts values
+      run: |
+        .github/scripts/helm-check-expected.sh \
+        "helm-temp/logger-firehose-sts.yaml" \
+        'KOLIDE_FIREHOSE_REGION KOLIDE_FIREHOSE_STATUS_STREAM KOLIDE_FIREHOSE_RESULT_STREAM KOLIDE_FIREHOSE_STS_ASSUME_ROLE_ARN' \
+        'fleet-tls'
+    - name: check mysql tls enabled values
+      run: |
+        .github/scripts/helm-check-expected.sh \
+        "helm-temp/enable-mysql-tls.yaml" \
+        'KOLIDE_MYSQL_TLS_CA KOLIDE_MYSQL_TLS_CERT KOLIDE_MYSQL_TLS_KEY KOLIDE_MYSQL_TLS_CONFIG KOLIDE_MYSQL_TLS_SERVER_NAME' \
+        'fleet-tls osquery-logs mysql-tls'

--- a/.github/workflows/pr-helm.yaml
+++ b/.github/workflows/pr-helm.yaml
@@ -2,7 +2,8 @@ name: pr-helm
 on:
   pull_request:
     paths:
-    - chart
+    - 'chart/**'
+    - '.github/workflows/pr-helm.yaml'
 
 jobs:
   sanity-check:

--- a/.github/workflows/pr-helm.yaml
+++ b/.github/workflows/pr-helm.yaml
@@ -4,6 +4,8 @@ on:
     paths:
     - 'chart/**'
     - '.github/workflows/pr-helm.yaml'
+    - '.github/scripts/helm-check-expected.sh'
+    - 'tools/ci/helm-values/**'
 
 jobs:
   sanity-check:

--- a/.github/workflows/pr-helm.yaml
+++ b/.github/workflows/pr-helm.yaml
@@ -37,7 +37,7 @@ jobs:
             chart \
           > helm-temp/${FILE}
         done
-    - name: kubeval sanity check    
+    - name: kubeval sanity check
       uses: instrumenta/kubeval-action
       with:
         files: helm-temp

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ tmp/
 
 # test mysql server data
 mysqldata/
+
+# test helm charts
+helm-temp

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+description: A Helm chart for Fleet
+name: fleet
+keywords:
+  - fleet
+  - osquery
+version: 3.6.0
+home: https://github.com/fleetdm/fleet
+sources:
+  - https://github.com/fleetdm/fleet.git
+appVersion: 3.6.0

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,0 +1,64 @@
+## Fleet Helm Chart
+
+This directory contains a Helm Chart that makes deploying Fleet on Kubernetes easy.
+
+### Usage
+
+#### 1. Create namespace
+
+This Helm chart does not auto-provision a namespace. You can add one with `kubectl create namespace <name>` or by creating a YAML file containing a service and applying it to your cluster.
+
+#### 2. Create the necessary secrets
+
+This Helm chart does not create the Kubernetes `Secret`s necessary for Fleet to operate. At a minimum, secrets for the JWT key and MySQL password must be created. For example, if you are deploying into a namespace called `fleet`:
+
+```yaml
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: mysql
+  namespace: fleet
+stringData:
+  mysql-password: this-is-a-bad-password
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: fleet
+  namespace: fleet
+stringData:
+  jwt-secret: dont-use-this
+```
+
+If you use Fleet's TLS capabilities, TLS connections to the MySQL server, or AWS access secret keys, additional secrets and keys are needed. The name of each `Secret` must match the value of `secretName` for each section in the `values.yaml` file and the key of each secret must match the related key value from the values file. For example, to configure Fleet's TLS, you would use a Secret like the one below.
+
+```yaml
+kind: Secret
+apiVersion: v1
+metadata:
+  name: fleet
+  namespace: fleet
+stringData:
+  jwt-secret: dont-use-this
+  server.cert: |
+    your-pem-encoded-certificate-here
+  server.key: |
+    your-pem-encoded-key-here
+```
+
+Once all of your secrets are configured, use `kubectl apply -f <secret_file_name.yaml> --namespace <your_namespace>` to create them in the cluster. 
+
+#### 3. Further Configuration
+
+To configure how Fleet runs, such as specifying the number of Fleet instances to deploy or changing the logger plugin for Fleet, edit the `values.yaml` file to your desired settings.
+
+#### 4. Deploy Fleet
+
+Once the secrets have been created and you have updated the values to match your required configuration, you can deploy with the following command.
+
+```sh
+helm upgrade --install fleet . \
+  --namespace <your_namespace> \
+  --values values.yaml
+```

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -178,19 +178,16 @@ spec:
           - name: KOLIDE_FILESYSTEM_STATUS_LOG_FILE
             value: "/logs/{{ .Values.osquery.logging.filesystem.statusLogFile }}"
           {{- end }}
-
           {{- if eq .Values.osquery.logging.resultPlugin "filesystem" }}
           - name: KOLIDE_FILESYSTEM_RESULT_LOG_FILE
             value: "/logs/{{ .Values.osquery.logging.filesystem.resultLogFile }}"
           {{- end }}
-
           {{- if or (eq .Values.osquery.logging.statusPlugin "filesystem") (eq .Values.osquery.logging.resultPlugin "filesystem") }}
           - name: KOLIDE_FILESYSTEM_ENABLE_LOG_ROTATION
             value: "{{ .Values.osquery.logging.filesystem.enableRotation }}"
           - name: KOLIDE_FILESYSTEM_ENABLE_LOG_COMPRESSION
             value: "{{ .Values.osquery.logging.filesystem.enableCompression }}"
           {{- end }}
-
           {{- if or (eq .Values.osquery.logging.statusPlugin "firehose") (eq .Values.osquery.logging.resultPlugin "firehose") }}
           - name: KOLIDE_FIREHOSE_REGION
             value: "{{ .Values.osquery.logging.firehose.region }}"

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,322 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: fleet
+    chart: fleet
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: fleet
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: fleet
+      chart: fleet
+      heritage: {{ .Release.Service }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+{{- with .Values.podAnnotations }}
+      annotations:
+{{- toYaml . | trim | nindent 8 }}
+{{- end }}
+      labels:
+        app: fleet
+        chart: fleet
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - fleet
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - name: fleet
+        command:
+        {{- if .Values.fleet.autoApplySQLMigrations }}
+        - /bin/sh
+        - -c
+        - /usr/bin/fleet prepare db --no-prompt && /usr/bin/fleet serve
+        {{ else }}
+        - /usr/bin/fleet
+        - serve
+        {{- end }}
+        image: fleetdm/fleet:{{ .Values.imageTag }}
+        ports:
+        - name: fleet
+          containerPort: {{ .Values.fleet.listenPort }}
+        resources:
+          limits:
+            cpu: {{ .Values.resources.limits.cpu }}
+            memory: {{ .Values.resources.limits.memory }}
+          requests:
+            cpu: {{ .Values.resources.requests.cpu }}
+            memory: {{ .Values.resources.requests.memory }}
+        env:
+          ## BEGIN FLEET SECTION
+          - name: KOLIDE_SERVER_ADDRESS
+            value: "0.0.0.0:{{ .Values.fleet.listenPort }}"
+          - name: KOLIDE_AUTH_BCRYPT_COST
+            value: "{{ .Values.fleet.auth.bcryptCost }}"
+          - name: KOLIDE_AUTH_SALT_KEY_SIZE
+            value: "{{ .Values.fleet.auth.saltKeySize }}"
+          - name: KOLIDE_AUTH_JWT_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.fleet.secretName }}"
+                key: "{{ .Values.fleet.auth.jwtSecretKey }}"
+          - name: KOLIDE_APP_TOKEN_KEY_SIZE
+            value: "{{ .Values.fleet.app.tokenKeySize }}"
+          - name: KOLIDE_APP_TOKEN_VALIDITY_PERIOD
+            value: "{{ .Values.fleet.app.inviteTokenValidityPeriod }}"
+          - name: KOLIDE_SESSION_KEY_SIZE
+            value: "{{ .Values.fleet.session.keySize }}"
+          - name: KOLIDE_SESSION_DURATION
+            value: "{{ .Values.fleet.session.duration }}"
+          - name: KOLIDE_LOGGING_DEBUG
+            value: "{{ .Values.fleet.logging.debug }}"
+          - name: KOLIDE_LOGGING_JSON
+            value: "{{ .Values.fleet.logging.json }}"
+          - name: KOLIDE_LOGGING_DISABLE_BANNER
+            value: "{{ .Values.fleet.logging.disableBanner }}"
+          - name: KOLIDE_SERVER_TLS
+            value: "{{ .Values.fleet.tls.enabled }}"
+          {{- if .Values.fleet.tls.enabled }}
+          - name: KOLIDE_SERVER_TLS_COMPATIBILITY
+            value: "{{ .Values.fleet.tls.compatibility }}"
+          - name: KOLIDE_SERVER_CERT
+            value: "/secrets/tls/{{ .Values.fleet.tls.certSecretKey }}"
+          - name: KOLIDE_SERVER_KEY
+            value: "/secrets/tls/{{ .Values.fleet.tls.keySecretKey }}"
+          {{- end }}
+          {{- if ne .Values.fleet.carving.s3.bucketName "" }}
+          - name: KOLIDE_S3_BUCKET
+            value: "{{ .Values.fleet.carving.s3.bucketName }}"
+          - name: KOLIDE_S3_PREFIX
+            value: "{{ .Values.fleet.carving.s3.prefix }}"
+          {{- if ne .Values.fleet.carving.s3.accessKeyID "" }}
+          - name: KOLIDE_S3_ACCESS_KEY_ID
+            value: "{{ .Values.fleet.carving.s3.accessKeyID }}"
+          - name: KOLIDE_S3_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.fleet.secretName }}"
+                key: "{{ .Values.fleet.carving.s3.secretKey }}"
+          {{ else }}
+          - name: KOLIDE_S3_STS_ASSUME_ROLE_ARN
+            value: "{{ .Values.fleet.carving.s3.stsAssumeRoleARN }}"
+          {{- end }}
+          {{- end }}
+          ## END FLEET SECTION
+          ## BEGIN MYSQL SECTION
+          - name: KOLIDE_MYSQL_ADDRESS
+            value: "{{ .Values.mysql.address }}"
+          - name: KOLIDE_MYSQL_DATABASE
+            value: "{{ .Values.mysql.database }}"
+          - name: KOLIDE_MYSQL_USERNAME
+            value: "{{ .Values.mysql.username }}"
+          - name: KOLIDE_MYSQL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.mysql.secretName }}
+                key: {{ .Values.mysql.passwordKey }}
+          - name: KOLIDE_MYSQL_MAX_OPEN_CONNS
+            value: "{{ .Values.mysql.maxOpenConns }}"
+          - name: KOLIDE_MYSQL_MAX_IDLE_CONNS
+            value: "{{ .Values.mysql.maxIdleConns }}"
+          - name: KOLIDE_MYSQL_CONN_MAX_LIFETIME
+            value: "{{ .Values.mysql.connMaxLifetime }}"
+          {{- if .Values.mysql.tls.enabled }}
+          - name: KOLIDE_MYSQL_TLS_CA
+            value: "/secrets/mysql/{{ .Values.mysql.tls.caCertKey }}"
+          - name: KOLIDE_MYSQL_TLS_CERT
+            value: "/secrets/mysql/{{ .Values.mysql.tls.certKey }}"
+          - name: KOLIDE_MYSQL_TLS_KEY
+            value: "/secrets/mysql/{{ .Values.mysql.tls.keyKey }}"
+          - name: KOLIDE_MYSQL_TLS_CONFIG
+            value: "{{ .Values.mysql.tls.config }}"
+          - name: KOLIDE_MYSQL_TLS_SERVER_NAME
+            value: "{{ .Values.mysql.tls.serverName }}"
+          {{- end }}
+          ## END MYSQL SECTION
+          ## BEGIN REDIS SECTION
+          - name: KOLIDE_REDIS_ADDRESS
+            value: "{{ .Values.redis.address }}"
+          - name: KOLIDE_REDIS_DATABASE
+            value: "{{ .Values.redis.database }}"
+          {{- if .Values.redis.usePassword }}
+          - name: KOLIDE_REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.redis.secretName }}
+                key: {{ .Values.redis.passwordKey }}
+          {{- end }}
+          ## END REDIS SECTION
+          ## BEGIN OSQUERY SECTION
+          - name: KOLIDE_OSQUERY_NODE_KEY_SIZE
+            value: "{{ .Values.osquery.nodeKeySize }}"
+          - name: KOLIDE_OSQUERY_LABEL_UPDATE_INTERVAL
+            value: "{{ .Values.osquery.labelUpdateInterval }}"
+          - name: KOLIDE_OSQUERY_DETAIL_UPDATE_INTERVAL
+            value: "{{ .Values.osquery.detailUpdateInterval }}"
+          - name: KOLIDE_OSQUERY_STATUS_LOG_PLUGIN
+            value: "{{ .Values.osquery.logging.statusPlugin }}"
+          - name: KOLIDE_OSQUERY_RESULT_LOG_PLUGIN
+            value: "{{ .Values.osquery.logging.resultPlugin }}"
+          {{- if eq .Values.osquery.logging.statusPlugin "filesystem" }}
+          - name: KOLIDE_FILESYSTEM_STATUS_LOG_FILE
+            value: "{{ .Values.osquery.logging.filesystem.statusLogFile }}"
+          {{- end }}
+          {{- if eq .Values.osquery.logging.resultPlugin "filesystem" }}
+          - name: KOLIDE_FILESYSTEM_RESULT_LOG_FILE
+            value: "{{ .Values.osquery.logging.filesystem.resultLogFile }}"
+          {{- end }}
+          {{- if or (eq .Values.osquery.logging.statusPlugin "filesystem") (eq .Values.osquery.logging.resultPlugin "filesystem") }}
+          - name: KOLIDE_FILESYSTEM_ENABLE_LOG_ROTATION
+            value: "{{ .Values.osquery.logging.filesystem.enableRotation }}"
+          - name: KOLIDE_FILESYSTEM_ENABLE_LOG_COMPRESSION
+            value: "{{ .Values.osquery.logging.filesystem.enableCompression }}"
+          {{- end }}
+          {{- if or (eq .Values.osquery.logging.statusPlugin "firehose") (eq .Values.osquery.logging.resultPlugin "firehose") }}
+          - name: KOLIDE_FIREHOSE_REGION
+            value: "{{ .Values.osquery.logging.firehose.region }}"
+          {{- if eq .Values.osquery.logging.statusPlugin "firehose" }}
+          - name: KOLIDE_FIREHOSE_STATUS_STREAM
+            value: "{{ .Values.osquery.logging.firehose.statusStream }}"
+          {{- end }}
+          {{- if eq .Values.osquery.logging.resultPlugin "firehose" }}
+          - name: KOLIDE_FIREHOSE_RESULT_STREAM
+            value: "{{ .Values.osquery.logging.firehose.resultStream }}"
+          {{- end }}
+          {{- if ne .Values.osquery.logging.firehose.accessKeyID "" }}
+          - name: KOLIDE_FIREHOSE_ACCESS_KEY_ID
+            value: "{{ .Values.osquery.logging.firehose.accessKeyID }}"
+          - name: KOLIDE_FIREHOSE_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.osquery.secretName }}
+                key: {{ .Values.osquery.logging.firehose.secretKey }}
+          {{ else }}
+          - name: KOLIDE_FIREHOSE_STS_ASSUME_ROLE_ARN
+            value: "{{ .Values.osquery.logging.firehose.stsAssumeRoleARN }}"
+          {{- end }}
+          {{- end }}
+          {{- if or (eq .Values.osquery.logging.statusPlugin "kinesis") (eq .Values.osquery.logging.resultPlugin "kinesis") }}
+          - name: KOLIDE_KINESIS_REGION
+            value: "{{ .Values.osquery.logging.kinesis.region }}"
+          {{- if eq .Values.osquery.logging.statusPlugin "kinesis" }}
+          - name: KOLIDE_KINESIS_STATUS_STREAM
+            value: "{{ .Values.osquery.logging.kinesis.statusStream }}"
+          {{- end }}
+          {{- if eq .Values.osquery.logging.resultPlugin "kinesis" }}
+          - name: KOLIDE_KINESIS_RESULT_STREAM
+            value: "{{ .Values.osquery.logging.kinesis.resultStream }}"
+          {{- end }}
+          {{- if ne .Values.osquery.logging.kinesis.accessKeyID "" }}
+          - name: KOLIDE_KINESIS_ACCESS_KEY_ID
+            value: "{{ .Values.osquery.logging.kinesis.accessKeyID }}"
+          - name: KOLIDE_KINESIS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.osquery.secretName }}
+                key: {{ .Values.osquery.logging.kinesis.secretKey }}
+          {{ else }}
+          - name: KOLIDE_KINESIS_STS_ASSUME_ROLE_ARN
+            value: "{{ .Values.osquery.logging.kinesis.stsAssumeRoleARN }}"
+          {{- end }}
+          {{- end }}
+          {{- if or (eq .Values.osquery.logging.statusPlugin "pubsub") (eq .Values.osquery.logging.resultPlugin "pubsub") }}
+          - name: KOLIDE_PUBSUB_PROJECT
+            value: "{{ .Values.osquery.logging.pubsub.project }}"
+          {{- if eq .Values.osquery.logging.statusPlugin "pubsub" }}
+          - name: KOLIDE_PUBSUB_STATUS_TOPIC
+            value: "{{ .Values.osquery.logging.pubsub.statusTopic }}"
+          {{- end }}
+          {{- if eq .Values.osquery.logging.resultPlugin "pubsub" }}
+          - name: KOLIDE_PUBSUB_RESULT_TOPIC
+            value: "{{ .Values.osquery.logging.pubsub.resultTopic }}"
+          {{- end }}
+          ## END OSQUERY SECTION
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 3333
+          runAsUser: 3333
+          runAsNonRoot: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.fleet.listenPort }}
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.fleet.listenPort }}
+        {{- if or (.Values.fleet.tls.enabled) (.Values.mysql.tls.enabled) }}
+        volumeMounts:
+          {{- if .Values.fleet.tls.enabled }}
+          - name: fleet-tls
+            readOnly: true
+            mountPath: /secrets/tls
+          {{- end }}
+          {{- if .Values.mysql.tls.enabled }}
+          - name: mysql-tls
+            readOnly: true
+            mountPath: /secrets/mysql
+          {{- end }}
+        {{- end }}
+      {{- if .Values.gke.cloudSQL.enableProxy }}
+      - name: cloudsql-proxy
+        image: gcr.io/cloudsql-docker/gce-proxy:{{ .Values.gke.cloudSQL.imageTag }}
+        command:
+        - "/cloud_sql_proxy"
+        - "-verbose={{ .Values.gke.cloudSQL.verbose}}"
+        - "-instances={{ .Values.gke.cloudSQL.instanceName }}=tcp:3306"
+        resources:
+          limits:
+            cpu: 0.5 # 500Mhz
+            memory: 150Mi
+          requests:
+            cpu: 0.1 # 100Mhz
+            memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 3333
+          runAsUser: 3333
+          runAsNonRoot: true
+      {{- end }}
+      hostPID: false
+      hostNetwork: false
+      hostIPC: false
+      serviceAccountName: fleet
+      {{- if or (.Values.fleet.tls.enabled) (.Values.mysql.tls.enabled) }}
+      volumes:
+        {{- if .Values.fleet.tls.enabled }}
+        - name: fleet-tls
+          secret:
+            secretName: {{ .Values.fleet.secretName }}
+        {{- end }}
+        {{- if .Values.mysql.tls.enabled }}
+        - name: mysql-tls
+          secret:
+            secretName: {{ .Values.mysql.secretName }}
+        {{- end }}
+      {{- end }}
+{{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -159,8 +159,8 @@ spec:
           - name: KOLIDE_REDIS_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.redis.secretName }}
-                key: {{ .Values.redis.passwordKey }}
+                name: "{{ .Values.redis.secretName }}"
+                key: "{{ .Values.redis.passwordKey }}"
           {{- end }}
           ## END REDIS SECTION
           ## BEGIN OSQUERY SECTION
@@ -176,18 +176,21 @@ spec:
             value: "{{ .Values.osquery.logging.resultPlugin }}"
           {{- if eq .Values.osquery.logging.statusPlugin "filesystem" }}
           - name: KOLIDE_FILESYSTEM_STATUS_LOG_FILE
-            value: "{{ .Values.osquery.logging.filesystem.statusLogFile }}"
+            value: "/logs/{{ .Values.osquery.logging.filesystem.statusLogFile }}"
           {{- end }}
+
           {{- if eq .Values.osquery.logging.resultPlugin "filesystem" }}
           - name: KOLIDE_FILESYSTEM_RESULT_LOG_FILE
-            value: "{{ .Values.osquery.logging.filesystem.resultLogFile }}"
+            value: "/logs/{{ .Values.osquery.logging.filesystem.resultLogFile }}"
           {{- end }}
+
           {{- if or (eq .Values.osquery.logging.statusPlugin "filesystem") (eq .Values.osquery.logging.resultPlugin "filesystem") }}
           - name: KOLIDE_FILESYSTEM_ENABLE_LOG_ROTATION
             value: "{{ .Values.osquery.logging.filesystem.enableRotation }}"
           - name: KOLIDE_FILESYSTEM_ENABLE_LOG_COMPRESSION
             value: "{{ .Values.osquery.logging.filesystem.enableCompression }}"
           {{- end }}
+
           {{- if or (eq .Values.osquery.logging.statusPlugin "firehose") (eq .Values.osquery.logging.resultPlugin "firehose") }}
           - name: KOLIDE_FIREHOSE_REGION
             value: "{{ .Values.osquery.logging.firehose.region }}"
@@ -205,13 +208,14 @@ spec:
           - name: KOLIDE_FIREHOSE_SECRET_ACCESS_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.osquery.secretName }}
-                key: {{ .Values.osquery.logging.firehose.secretKey }}
+                name: "{{ .Values.osquery.secretName }}"
+                key: "{{ .Values.osquery.logging.firehose.secretKey }}"
           {{ else }}
           - name: KOLIDE_FIREHOSE_STS_ASSUME_ROLE_ARN
             value: "{{ .Values.osquery.logging.firehose.stsAssumeRoleARN }}"
           {{- end }}
           {{- end }}
+
           {{- if or (eq .Values.osquery.logging.statusPlugin "kinesis") (eq .Values.osquery.logging.resultPlugin "kinesis") }}
           - name: KOLIDE_KINESIS_REGION
             value: "{{ .Values.osquery.logging.kinesis.region }}"
@@ -229,16 +233,18 @@ spec:
           - name: KOLIDE_KINESIS_SECRET_ACCESS_KEY
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.osquery.secretName }}
-                key: {{ .Values.osquery.logging.kinesis.secretKey }}
+                name: "{{ .Values.osquery.secretName }}"
+                key: "{{ .Values.osquery.logging.kinesis.secretKey }}"
           {{ else }}
           - name: KOLIDE_KINESIS_STS_ASSUME_ROLE_ARN
             value: "{{ .Values.osquery.logging.kinesis.stsAssumeRoleARN }}"
           {{- end }}
           {{- end }}
+
           {{- if or (eq .Values.osquery.logging.statusPlugin "pubsub") (eq .Values.osquery.logging.resultPlugin "pubsub") }}
           - name: KOLIDE_PUBSUB_PROJECT
             value: "{{ .Values.osquery.logging.pubsub.project }}"
+          {{- end }}
           {{- if eq .Values.osquery.logging.statusPlugin "pubsub" }}
           - name: KOLIDE_PUBSUB_STATUS_TOPIC
             value: "{{ .Values.osquery.logging.pubsub.statusTopic }}"
@@ -265,7 +271,7 @@ spec:
           httpGet:
             path: /healthz
             port: {{ .Values.fleet.listenPort }}
-        {{- if or (.Values.fleet.tls.enabled) (.Values.mysql.tls.enabled) }}
+        {{- if or (.Values.fleet.tls.enabled) (.Values.mysql.tls.enabled) (eq .Values.osquery.logging.statusPlugin "filesystem") (eq .Values.osquery.logging.resultPlugin "filesystem") }}
         volumeMounts:
           {{- if .Values.fleet.tls.enabled }}
           - name: fleet-tls
@@ -277,10 +283,14 @@ spec:
             readOnly: true
             mountPath: /secrets/mysql
           {{- end }}
+          {{- if or (eq .Values.osquery.logging.statusPlugin "filesystem") (eq .Values.osquery.logging.resultPlugin "filesystem") }}
+          - name: osquery-logs
+            mountPath: /logs
+          {{- end }}
         {{- end }}
       {{- if .Values.gke.cloudSQL.enableProxy }}
       - name: cloudsql-proxy
-        image: gcr.io/cloudsql-docker/gce-proxy:{{ .Values.gke.cloudSQL.imageTag }}
+        image: "gcr.io/cloudsql-docker/gce-proxy:{{ .Values.gke.cloudSQL.imageTag }}"
         command:
         - "/cloud_sql_proxy"
         - "-verbose={{ .Values.gke.cloudSQL.verbose}}"
@@ -306,17 +316,21 @@ spec:
       hostNetwork: false
       hostIPC: false
       serviceAccountName: fleet
-      {{- if or (.Values.fleet.tls.enabled) (.Values.mysql.tls.enabled) }}
+      {{- if or (.Values.fleet.tls.enabled) (.Values.mysql.tls.enabled) (eq .Values.osquery.logging.statusPlugin "filesystem") (eq .Values.osquery.logging.resultPlugin "filesystem") }}
       volumes:
         {{- if .Values.fleet.tls.enabled }}
         - name: fleet-tls
           secret:
-            secretName: {{ .Values.fleet.secretName }}
+            secretName: "{{ .Values.fleet.secretName }}"
         {{- end }}
         {{- if .Values.mysql.tls.enabled }}
         - name: mysql-tls
           secret:
-            secretName: {{ .Values.mysql.secretName }}
+            secretName: "{{ .Values.mysql.secretName }}"
+        {{- end }}
+        {{- if or (eq .Values.osquery.logging.statusPlugin "filesystem") (eq .Values.osquery.logging.resultPlugin "filesystem") }}
+        - name: osquery-logs
+          emptyDir:
+            sizeLimit: "{{ .Values.osquery.logging.filesystem.volumeSize }}"
         {{- end }}
       {{- end }}
-{{- end }}

--- a/chart/templates/gke-managedcertificate.yaml
+++ b/chart/templates/gke-managedcertificate.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.gke.ingress.useManagedCertificate }}
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: fleet
+spec:
+  domains:
+  - {{ .Values.hostName }}
+{{- end }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.createIngress }}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+{{- if or .Values.ingressAnnotations .Values.gke.useGKEIngress }}
+  annotations:
+  {{- with .Values.ingressAnnotations }}
+  {{ toYaml . | trim | indent 2 }}
+  {{- end }}
+  {{- if .Values.gke.ingress.useGKEIngress }}
+    kubernetes.io/ingress.class: gce
+    {{- if .Values.gke.ingress.useManagedCertificate }}
+    kubernetes.io/ingress.allow-http: "false"
+    networking.gke.io/managed-certificates: fleet
+    {{- end }}
+  {{- end }}
+{{- end }}
+  labels:
+    app: fleet
+    chart: fleet
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: fleet
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+spec:
+  rules:
+  - host: {{ .Values.hostName }}
+    http:
+      paths:
+      - path: /*
+        pathType: Exact
+        backend:
+          serviceName: fleet
+          servicePort: fleet

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -22,7 +22,6 @@ metadata:
     release: {{ .Release.Name }}
   name: fleet
   namespace: {{ .Release.Namespace }}
-{{- end }}
 spec:
   rules:
   - host: {{ .Values.hostName }}
@@ -33,3 +32,4 @@ spec:
         backend:
           serviceName: fleet
           servicePort: fleet
+{{- end }}

--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: fleet
+    chart: fleet
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: fleet
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - core
+  resources:
+  - secrets
+  resourceNames:
+  - {{ .Values.mysql.secretName }}
+  - {{ .Values.redis.secretName }}
+  - {{ .Values.fleet.secretName }}
+  - {{ .Values.osquery.secretName }}
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: fleet
+    chart: fleet
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: fleet
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: fleet
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: fleet
+  namespace: {{ .Release.Namespace }}

--- a/chart/templates/sa.yaml
+++ b/chart/templates/sa.yaml
@@ -4,7 +4,7 @@ metadata:
 {{- if or .Values.serviceAccountAnnotations .Values.gke.workloadIdentityEmail }}
   annotations:
   {{- with .Values.serviceAccountAnnotations}}
-  {{ toYaml . | trim | nindent 2}}
+  {{ toYaml . | trim | indent 2}}
   {{- end }}
   {{- if ne .Values.gke.workloadIdentityEmail "" }}
     iam.gke.io/gcp-service-account: {{ .Values.gke.workloadIdentityEmail }}

--- a/chart/templates/sa.yaml
+++ b/chart/templates/sa.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+{{- if or .Values.serviceAccountAnnotations .Values.gke.workloadIdentityEmail }}
+  annotations:
+  {{- with .Values.serviceAccountAnnotations}}
+  {{ toYaml . | trim | nindent 2}}
+  {{- end }}
+  {{- if ne .Values.gke.workloadIdentityEmail "" }}
+    iam.gke.io/gcp-service-account: {{ .Values.gke.workloadIdentityEmail }}
+  {{- end }}
+{{- end }}
+  labels:
+    app: fleet
+    chart: fleet
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: fleet
+  namespace: {{ .Release.Namespace }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: fleet
+    chart: fleet
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: fleet
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    app: fleet
+    chart: fleet
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  ports:
+  - name: fleet
+    port: {{ .Values.fleet.listenPort }}
+  {{- if .Values.gke.ingress.useGKEIngress }}
+  type: NodePort
+  {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,142 @@
+## Section: Kubernetes
+# All settings related to how Fleet is deployed in Kubernetes
+hostName: fleet.localhost
+replicas: 3 # The number of Fleet instances to deploy
+imageTag: 3.6.0 # Version of Fleet to deploy
+createIngress: true # Whether or not to automatically create an Ingress
+ingressAnnotations: {} # Additional annotation to add to the Ingress
+podAnnotations: {} # Additional annotations to add to the Fleet pod
+serviceAccountAnnotations: {} # Additional annotations to add to the Fleet service account
+resources:
+  limits:
+    cpu: 1 # 1GHz
+    memory: 1Gi
+  requests:
+    cpu: 0.1 # 100Mhz
+    memory: 50Mi
+
+## Section: Fleet
+# All of the settings relating to configuring the Fleet server
+fleet:
+  listenPort: 8080
+  # Name of the Secret resource storing TLS, JWT, and S3 bucket secrets
+  secretName: fleet
+  # Whether or not to run `fleet db prepare` to run SQL migrations before starting Fleet
+  # WARNING: This may cause database corruption if more than one migration is attempted at a time
+  autoApplySQLMigrations: false
+  tls:
+    enabled: true
+    compatibility: modern
+    certSecretKey: server.cert
+    keySecretKey: server.key
+  auth:
+    jwtSecretKey: jwt-secret
+    bcryptCost: 12
+    saltKeySize: 24
+  app:
+    tokenKeySize: 24
+    inviteTokenValidityPeriod: 120h # 5 days
+  session:
+    keySize: 64
+    duration: 2160h # 90 days
+  logging:
+    debug: false
+    json: false
+    disableBanner: false
+  carving:
+    s3:
+      bucketName: ""
+      prefix: ""
+      accessKeyID: ""
+      secretKey: s3-bucket
+      stsAssumeRoleARN: ""
+
+## Section: osquery
+# All of the settings related to osquery's interactions with the Fleet server 
+osquery:
+  # Name of the secret resource containing optional secrets for AWS credentials
+  secretName: osquery
+  nodeKeySize: 24
+  labelUpdateInterval: 30m
+  detailUpdateInterval: 30m
+
+  # To change where Fleet store the logs sent from osquery, set the values below
+  logging:
+    statusPlugin: filesystem
+    resultPlugin: filesystem
+
+    # To congigure the filesystem logger, change the values below
+    filesystem:
+      statusLogFile: /tmp/osquery_status
+      resultLogFile: /tmp/osquery_result
+      enableRotation: "false"
+      enableCompression: "false"
+
+    # To configure the AWS Firehose logger, change the values below
+    firehose:
+      region: ""
+      accessKeyID: ""
+      secretKey: firehose
+      stsAssumeRoleARN: ""
+      statusStream: ""
+      resultStream: ""
+
+    # To configure the AWS Kinesis logger, change the values below
+    kinesis:
+      region: ""
+      accessKeyID: ""
+      secretKey: kinesis
+      stsAssumeRoleARN: ""
+      statusStream: ""
+      resultStream: ""
+
+    # To configure the GCP PubSub logger, change the values below
+    pubsub:
+      project: ""
+      statusTopic: ""
+      resultTopic: ""
+
+## Section: MySQL
+# All of the connection settings for MySQL
+mysql:
+  # Name of the Secret resource containing MySQL password and TLS secrets
+  secretName: mysql
+  address: 127.0.0.1:3306
+  database: kolide
+  username: kolide
+  passwordKey: mysql-password
+  maxOpenConns: 50
+  maxIdleConns: 50
+  connMaxLifetime: 0
+  tls:
+    enabled: false
+    caCertKey: ca.cert
+    certKey: client.cert
+    keyKey: client.key
+    config: ""
+    serverName: ""
+
+## Section: Redis
+# All of the connection settings for Redis
+redis:
+  address: 127.0.0.1:6379
+  database: "0"
+  usePassword: false
+  secretName: redis
+  passwordKey: redis-password
+
+## Section: GKE
+# Settings that make running on Google Kubernetes Engine easier
+gke:
+  # The CloudSQL Proxy runs as a container in the Fleet Pod that proxies connections to a Cloud SQL instance
+  cloudSQL:
+    enableProxy: false
+    imageTag: 1.17-alpine
+    verbose: true
+    instanceName: ""
+  # The GKE Ingress requires a few changes that other ingress controllers don't
+  ingress:
+    useGKEIngress: false
+    useManagedCertificate: false
+  # Workload Identity allows the K8s service account to assume the IAM permissions of a GCP service account
+  workloadIdentityEmail: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -67,10 +67,11 @@ osquery:
 
     # To congigure the filesystem logger, change the values below
     filesystem:
-      statusLogFile: /tmp/osquery_status
-      resultLogFile: /tmp/osquery_result
-      enableRotation: "false"
-      enableCompression: "false"
+      statusLogFile: osquery_status # will be placed in the /logs volume
+      resultLogFile: osquery_result # will be placed in the /logs volume
+      enableRotation: false
+      enableCompression: false
+      volumeSize: 20Gi # the maximum size of the volume
 
     # To configure the AWS Firehose logger, change the values below
     firehose:

--- a/tools/ci/helm-values/custom-annotations.yaml
+++ b/tools/ci/helm-values/custom-annotations.yaml
@@ -1,0 +1,145 @@
+## Section: Kubernetes
+# All settings related to how Fleet is deployed in Kubernetes
+hostName: fleet.localhost
+replicas: 3 # The number of Fleet instances to deploy
+imageTag: 3.6.0 # Version of Fleet to deploy
+createIngress: true # Whether or not to automatically create an Ingress
+ingressAnnotations: # Additional annotation to add to the Ingress
+  a.b/c: d
+podAnnotations: # Additional annotations to add to the Fleet pod
+  a.b/c: d
+serviceAccountAnnotations: # Additional annotations to add to the Fleet service account
+  a.b/c: d
+resources:
+  limits:
+    cpu: 1 # 1GHz
+    memory: 1Gi
+  requests:
+    cpu: 0.1 # 100Mhz
+    memory: 50Mi
+
+## Section: Fleet
+# All of the settings relating to configuring the Fleet server
+fleet:
+  listenPort: 8080
+  # Name of the Secret resource storing TLS, JWT, and S3 bucket secrets
+  secretName: fleet
+  # Whether or not to run `fleet db prepare` to run SQL migrations before starting Fleet
+  # WARNING: This may cause database corruption if more than one migration is attempted at a time
+  autoApplySQLMigrations: false
+  tls:
+    enabled: true
+    compatibility: modern
+    certSecretKey: server.cert
+    keySecretKey: server.key
+  auth:
+    jwtSecretKey: jwt-secret
+    bcryptCost: 12
+    saltKeySize: 24
+  app:
+    tokenKeySize: 24
+    inviteTokenValidityPeriod: 120h # 5 days
+  session:
+    keySize: 64
+    duration: 2160h # 90 days
+  logging:
+    debug: false
+    json: false
+    disableBanner: false
+  carving:
+    s3:
+      bucketName: ""
+      prefix: ""
+      accessKeyID: ""
+      secretKey: s3-bucket
+      stsAssumeRoleARN: ""
+
+## Section: osquery
+# All of the settings related to osquery's interactions with the Fleet server 
+osquery:
+  # Name of the secret resource containing optional secrets for AWS credentials
+  secretName: osquery
+  nodeKeySize: 24
+  labelUpdateInterval: 30m
+  detailUpdateInterval: 30m
+
+  # To change where Fleet store the logs sent from osquery, set the values below
+  logging:
+    statusPlugin: filesystem
+    resultPlugin: filesystem
+
+    # To congigure the filesystem logger, change the values below
+    filesystem:
+      statusLogFile: /tmp/osquery_status
+      resultLogFile: /tmp/osquery_result
+      enableRotation: "false"
+      enableCompression: "false"
+
+    # To configure the AWS Firehose logger, change the values below
+    firehose:
+      region: ""
+      accessKeyID: ""
+      secretKey: firehose
+      stsAssumeRoleARN: ""
+      statusStream: ""
+      resultStream: ""
+
+    # To configure the AWS Kinesis logger, change the values below
+    kinesis:
+      region: ""
+      accessKeyID: ""
+      secretKey: kinesis
+      stsAssumeRoleARN: ""
+      statusStream: ""
+      resultStream: ""
+
+    # To configure the GCP PubSub logger, change the values below
+    pubsub:
+      project: ""
+      statusTopic: ""
+      resultTopic: ""
+
+## Section: MySQL
+# All of the connection settings for MySQL
+mysql:
+  # Name of the Secret resource containing MySQL password and TLS secrets
+  secretName: mysql
+  address: 127.0.0.1:3306
+  database: kolide
+  username: kolide
+  passwordKey: mysql-password
+  maxOpenConns: 50
+  maxIdleConns: 50
+  connMaxLifetime: 0
+  tls:
+    enabled: false
+    caCertKey: ca.cert
+    certKey: client.cert
+    keyKey: client.key
+    config: ""
+    serverName: ""
+
+## Section: Redis
+# All of the connection settings for Redis
+redis:
+  address: 127.0.0.1:6379
+  database: "0"
+  usePassword: false
+  secretName: redis
+  passwordKey: redis-password
+
+## Section: GKE
+# Settings that make running on Google Kubernetes Engine easier
+gke:
+  # The CloudSQL Proxy runs as a container in the Fleet Pod that proxies connections to a Cloud SQL instance
+  cloudSQL:
+    enableProxy: false
+    imageTag: 1.17-alpine
+    verbose: true
+    instanceName: ""
+  # The GKE Ingress requires a few changes that other ingress controllers don't
+  ingress:
+    useGKEIngress: false
+    useManagedCertificate: false
+  # Workload Identity allows the K8s service account to assume the IAM permissions of a GCP service account
+  workloadIdentityEmail: ""

--- a/tools/ci/helm-values/disable-fleet-tls.yaml
+++ b/tools/ci/helm-values/disable-fleet-tls.yaml
@@ -1,0 +1,142 @@
+## Section: Kubernetes
+# All settings related to how Fleet is deployed in Kubernetes
+hostName: fleet.localhost
+replicas: 3 # The number of Fleet instances to deploy
+imageTag: 3.6.0 # Version of Fleet to deploy
+createIngress: true # Whether or not to automatically create an Ingress
+ingressAnnotations: {} # Additional annotation to add to the Ingress
+podAnnotations: {} # Additional annotations to add to the Fleet pod
+serviceAccountAnnotations: {} # Additional annotations to add to the Fleet service account
+resources:
+  limits:
+    cpu: 1 # 1GHz
+    memory: 1Gi
+  requests:
+    cpu: 0.1 # 100Mhz
+    memory: 50Mi
+
+## Section: Fleet
+# All of the settings relating to configuring the Fleet server
+fleet:
+  listenPort: 8080
+  # Name of the Secret resource storing TLS, JWT, and S3 bucket secrets
+  secretName: fleet
+  # Whether or not to run `fleet db prepare` to run SQL migrations before starting Fleet
+  # WARNING: This may cause database corruption if more than one migration is attempted at a time
+  autoApplySQLMigrations: false
+  tls:
+    enabled: false
+    compatibility: modern
+    certSecretKey: server.cert
+    keySecretKey: server.key
+  auth:
+    jwtSecretKey: jwt-secret
+    bcryptCost: 12
+    saltKeySize: 24
+  app:
+    tokenKeySize: 24
+    inviteTokenValidityPeriod: 120h # 5 days
+  session:
+    keySize: 64
+    duration: 2160h # 90 days
+  logging:
+    debug: false
+    json: false
+    disableBanner: false
+  carving:
+    s3:
+      bucketName: ""
+      prefix: ""
+      accessKeyID: ""
+      secretKey: s3-bucket
+      stsAssumeRoleARN: ""
+
+## Section: osquery
+# All of the settings related to osquery's interactions with the Fleet server 
+osquery:
+  # Name of the secret resource containing optional secrets for AWS credentials
+  secretName: osquery
+  nodeKeySize: 24
+  labelUpdateInterval: 30m
+  detailUpdateInterval: 30m
+
+  # To change where Fleet store the logs sent from osquery, set the values below
+  logging:
+    statusPlugin: filesystem
+    resultPlugin: filesystem
+
+    # To congigure the filesystem logger, change the values below
+    filesystem:
+      statusLogFile: /tmp/osquery_status
+      resultLogFile: /tmp/osquery_result
+      enableRotation: "false"
+      enableCompression: "false"
+
+    # To configure the AWS Firehose logger, change the values below
+    firehose:
+      region: ""
+      accessKeyID: ""
+      secretKey: firehose
+      stsAssumeRoleARN: ""
+      statusStream: ""
+      resultStream: ""
+
+    # To configure the AWS Kinesis logger, change the values below
+    kinesis:
+      region: ""
+      accessKeyID: ""
+      secretKey: kinesis
+      stsAssumeRoleARN: ""
+      statusStream: ""
+      resultStream: ""
+
+    # To configure the GCP PubSub logger, change the values below
+    pubsub:
+      project: ""
+      statusTopic: ""
+      resultTopic: ""
+
+## Section: MySQL
+# All of the connection settings for MySQL
+mysql:
+  # Name of the Secret resource containing MySQL password and TLS secrets
+  secretName: mysql
+  address: 127.0.0.1:3306
+  database: kolide
+  username: kolide
+  passwordKey: mysql-password
+  maxOpenConns: 50
+  maxIdleConns: 50
+  connMaxLifetime: 0
+  tls:
+    enabled: false
+    caCertKey: ca.cert
+    certKey: client.cert
+    keyKey: client.key
+    config: ""
+    serverName: ""
+
+## Section: Redis
+# All of the connection settings for Redis
+redis:
+  address: 127.0.0.1:6379
+  database: "0"
+  usePassword: false
+  secretName: redis
+  passwordKey: redis-password
+
+## Section: GKE
+# Settings that make running on Google Kubernetes Engine easier
+gke:
+  # The CloudSQL Proxy runs as a container in the Fleet Pod that proxies connections to a Cloud SQL instance
+  cloudSQL:
+    enableProxy: false
+    imageTag: 1.17-alpine
+    verbose: true
+    instanceName: ""
+  # The GKE Ingress requires a few changes that other ingress controllers don't
+  ingress:
+    useGKEIngress: false
+    useManagedCertificate: false
+  # Workload Identity allows the K8s service account to assume the IAM permissions of a GCP service account
+  workloadIdentityEmail: ""

--- a/tools/ci/helm-values/enable-cloudsql-proxy.yaml
+++ b/tools/ci/helm-values/enable-cloudsql-proxy.yaml
@@ -1,0 +1,142 @@
+## Section: Kubernetes
+# All settings related to how Fleet is deployed in Kubernetes
+hostName: fleet.localhost
+replicas: 3 # The number of Fleet instances to deploy
+imageTag: 3.6.0 # Version of Fleet to deploy
+createIngress: true # Whether or not to automatically create an Ingress
+ingressAnnotations: {} # Additional annotation to add to the Ingress
+podAnnotations: {} # Additional annotations to add to the Fleet pod
+serviceAccountAnnotations: {} # Additional annotations to add to the Fleet service account
+resources:
+  limits:
+    cpu: 1 # 1GHz
+    memory: 1Gi
+  requests:
+    cpu: 0.1 # 100Mhz
+    memory: 50Mi
+
+## Section: Fleet
+# All of the settings relating to configuring the Fleet server
+fleet:
+  listenPort: 8080
+  # Name of the Secret resource storing TLS, JWT, and S3 bucket secrets
+  secretName: fleet
+  # Whether or not to run `fleet db prepare` to run SQL migrations before starting Fleet
+  # WARNING: This may cause database corruption if more than one migration is attempted at a time
+  autoApplySQLMigrations: false
+  tls:
+    enabled: true
+    compatibility: modern
+    certSecretKey: server.cert
+    keySecretKey: server.key
+  auth:
+    jwtSecretKey: jwt-secret
+    bcryptCost: 12
+    saltKeySize: 24
+  app:
+    tokenKeySize: 24
+    inviteTokenValidityPeriod: 120h # 5 days
+  session:
+    keySize: 64
+    duration: 2160h # 90 days
+  logging:
+    debug: false
+    json: false
+    disableBanner: false
+  carving:
+    s3:
+      bucketName: ""
+      prefix: ""
+      accessKeyID: ""
+      secretKey: s3-bucket
+      stsAssumeRoleARN: ""
+
+## Section: osquery
+# All of the settings related to osquery's interactions with the Fleet server 
+osquery:
+  # Name of the secret resource containing optional secrets for AWS credentials
+  secretName: osquery
+  nodeKeySize: 24
+  labelUpdateInterval: 30m
+  detailUpdateInterval: 30m
+
+  # To change where Fleet store the logs sent from osquery, set the values below
+  logging:
+    statusPlugin: filesystem
+    resultPlugin: filesystem
+
+    # To congigure the filesystem logger, change the values below
+    filesystem:
+      statusLogFile: /tmp/osquery_status
+      resultLogFile: /tmp/osquery_result
+      enableRotation: "false"
+      enableCompression: "false"
+
+    # To configure the AWS Firehose logger, change the values below
+    firehose:
+      region: ""
+      accessKeyID: ""
+      secretKey: firehose
+      stsAssumeRoleARN: ""
+      statusStream: ""
+      resultStream: ""
+
+    # To configure the AWS Kinesis logger, change the values below
+    kinesis:
+      region: ""
+      accessKeyID: ""
+      secretKey: kinesis
+      stsAssumeRoleARN: ""
+      statusStream: ""
+      resultStream: ""
+
+    # To configure the GCP PubSub logger, change the values below
+    pubsub:
+      project: ""
+      statusTopic: ""
+      resultTopic: ""
+
+## Section: MySQL
+# All of the connection settings for MySQL
+mysql:
+  # Name of the Secret resource containing MySQL password and TLS secrets
+  secretName: mysql
+  address: 127.0.0.1:3306
+  database: kolide
+  username: kolide
+  passwordKey: mysql-password
+  maxOpenConns: 50
+  maxIdleConns: 50
+  connMaxLifetime: 0
+  tls:
+    enabled: false
+    caCertKey: ca.cert
+    certKey: client.cert
+    keyKey: client.key
+    config: ""
+    serverName: ""
+
+## Section: Redis
+# All of the connection settings for Redis
+redis:
+  address: 127.0.0.1:6379
+  database: "0"
+  usePassword: false
+  secretName: redis
+  passwordKey: redis-password
+
+## Section: GKE
+# Settings that make running on Google Kubernetes Engine easier
+gke:
+  # The CloudSQL Proxy runs as a container in the Fleet Pod that proxies connections to a Cloud SQL instance
+  cloudSQL:
+    enableProxy: true
+    imageTag: 1.17-alpine
+    verbose: true
+    instanceName: "project:instance:region"
+  # The GKE Ingress requires a few changes that other ingress controllers don't
+  ingress:
+    useGKEIngress: false
+    useManagedCertificate: false
+  # Workload Identity allows the K8s service account to assume the IAM permissions of a GCP service account
+  workloadIdentityEmail: ""

--- a/tools/ci/helm-values/enable-mysql-tls.yaml
+++ b/tools/ci/helm-values/enable-mysql-tls.yaml
@@ -1,0 +1,142 @@
+## Section: Kubernetes
+# All settings related to how Fleet is deployed in Kubernetes
+hostName: fleet.localhost
+replicas: 3 # The number of Fleet instances to deploy
+imageTag: 3.6.0 # Version of Fleet to deploy
+createIngress: true # Whether or not to automatically create an Ingress
+ingressAnnotations: {} # Additional annotation to add to the Ingress
+podAnnotations: {} # Additional annotations to add to the Fleet pod
+serviceAccountAnnotations: {} # Additional annotations to add to the Fleet service account
+resources:
+  limits:
+    cpu: 1 # 1GHz
+    memory: 1Gi
+  requests:
+    cpu: 0.1 # 100Mhz
+    memory: 50Mi
+
+## Section: Fleet
+# All of the settings relating to configuring the Fleet server
+fleet:
+  listenPort: 8080
+  # Name of the Secret resource storing TLS, JWT, and S3 bucket secrets
+  secretName: fleet
+  # Whether or not to run `fleet db prepare` to run SQL migrations before starting Fleet
+  # WARNING: This may cause database corruption if more than one migration is attempted at a time
+  autoApplySQLMigrations: false
+  tls:
+    enabled: true
+    compatibility: modern
+    certSecretKey: server.cert
+    keySecretKey: server.key
+  auth:
+    jwtSecretKey: jwt-secret
+    bcryptCost: 12
+    saltKeySize: 24
+  app:
+    tokenKeySize: 24
+    inviteTokenValidityPeriod: 120h # 5 days
+  session:
+    keySize: 64
+    duration: 2160h # 90 days
+  logging:
+    debug: false
+    json: false
+    disableBanner: false
+  carving:
+    s3:
+      bucketName: ""
+      prefix: ""
+      accessKeyID: ""
+      secretKey: s3-bucket
+      stsAssumeRoleARN: ""
+
+## Section: osquery
+# All of the settings related to osquery's interactions with the Fleet server 
+osquery:
+  # Name of the secret resource containing optional secrets for AWS credentials
+  secretName: osquery
+  nodeKeySize: 24
+  labelUpdateInterval: 30m
+  detailUpdateInterval: 30m
+
+  # To change where Fleet store the logs sent from osquery, set the values below
+  logging:
+    statusPlugin: filesystem
+    resultPlugin: filesystem
+
+    # To congigure the filesystem logger, change the values below
+    filesystem:
+      statusLogFile: /tmp/osquery_status
+      resultLogFile: /tmp/osquery_result
+      enableRotation: "false"
+      enableCompression: "false"
+
+    # To configure the AWS Firehose logger, change the values below
+    firehose:
+      region: ""
+      accessKeyID: ""
+      secretKey: firehose
+      stsAssumeRoleARN: ""
+      statusStream: ""
+      resultStream: ""
+
+    # To configure the AWS Kinesis logger, change the values below
+    kinesis:
+      region: ""
+      accessKeyID: ""
+      secretKey: kinesis
+      stsAssumeRoleARN: ""
+      statusStream: ""
+      resultStream: ""
+
+    # To configure the GCP PubSub logger, change the values below
+    pubsub:
+      project: ""
+      statusTopic: ""
+      resultTopic: ""
+
+## Section: MySQL
+# All of the connection settings for MySQL
+mysql:
+  # Name of the Secret resource containing MySQL password and TLS secrets
+  secretName: mysql
+  address: 127.0.0.1:3306
+  database: kolide
+  username: kolide
+  passwordKey: mysql-password
+  maxOpenConns: 50
+  maxIdleConns: 50
+  connMaxLifetime: 0
+  tls:
+    enabled: true
+    caCertKey: ca.cert
+    certKey: client.cert
+    keyKey: client.key
+    config: ""
+    serverName: ""
+
+## Section: Redis
+# All of the connection settings for Redis
+redis:
+  address: 127.0.0.1:6379
+  database: "0"
+  usePassword: false
+  secretName: redis
+  passwordKey: redis-password
+
+## Section: GKE
+# Settings that make running on Google Kubernetes Engine easier
+gke:
+  # The CloudSQL Proxy runs as a container in the Fleet Pod that proxies connections to a Cloud SQL instance
+  cloudSQL:
+    enableProxy: false
+    imageTag: 1.17-alpine
+    verbose: true
+    instanceName: ""
+  # The GKE Ingress requires a few changes that other ingress controllers don't
+  ingress:
+    useGKEIngress: false
+    useManagedCertificate: false
+  # Workload Identity allows the K8s service account to assume the IAM permissions of a GCP service account
+  workloadIdentityEmail: ""

--- a/tools/ci/helm-values/logger-firehose-accesssid.yaml
+++ b/tools/ci/helm-values/logger-firehose-accesssid.yaml
@@ -1,0 +1,142 @@
+## Section: Kubernetes
+# All settings related to how Fleet is deployed in Kubernetes
+hostName: fleet.localhost
+replicas: 3 # The number of Fleet instances to deploy
+imageTag: 3.6.0 # Version of Fleet to deploy
+createIngress: true # Whether or not to automatically create an Ingress
+ingressAnnotations: {} # Additional annotation to add to the Ingress
+podAnnotations: {} # Additional annotations to add to the Fleet pod
+serviceAccountAnnotations: {} # Additional annotations to add to the Fleet service account
+resources:
+  limits:
+    cpu: 1 # 1GHz
+    memory: 1Gi
+  requests:
+    cpu: 0.1 # 100Mhz
+    memory: 50Mi
+
+## Section: Fleet
+# All of the settings relating to configuring the Fleet server
+fleet:
+  listenPort: 8080
+  # Name of the Secret resource storing TLS, JWT, and S3 bucket secrets
+  secretName: fleet
+  # Whether or not to run `fleet db prepare` to run SQL migrations before starting Fleet
+  # WARNING: This may cause database corruption if more than one migration is attempted at a time
+  autoApplySQLMigrations: false
+  tls:
+    enabled: true
+    compatibility: modern
+    certSecretKey: server.cert
+    keySecretKey: server.key
+  auth:
+    jwtSecretKey: jwt-secret
+    bcryptCost: 12
+    saltKeySize: 24
+  app:
+    tokenKeySize: 24
+    inviteTokenValidityPeriod: 120h # 5 days
+  session:
+    keySize: 64
+    duration: 2160h # 90 days
+  logging:
+    debug: false
+    json: false
+    disableBanner: false
+  carving:
+    s3:
+      bucketName: ""
+      prefix: ""
+      accessKeyID: ""
+      secretKey: s3-bucket
+      stsAssumeRoleARN: ""
+
+## Section: osquery
+# All of the settings related to osquery's interactions with the Fleet server 
+osquery:
+  # Name of the secret resource containing optional secrets for AWS credentials
+  secretName: osquery
+  nodeKeySize: 24
+  labelUpdateInterval: 30m
+  detailUpdateInterval: 30m
+
+  # To change where Fleet store the logs sent from osquery, set the values below
+  logging:
+    statusPlugin: firehose
+    resultPlugin: firehose
+
+    # To congigure the filesystem logger, change the values below
+    filesystem:
+      statusLogFile: /tmp/osquery_status
+      resultLogFile: /tmp/osquery_result
+      enableRotation: "false"
+      enableCompression: "false"
+
+    # To configure the AWS Firehose logger, change the values below
+    firehose:
+      region: "us-west1"
+      accessKeyID: "abc123"
+      secretKey: firehose
+      stsAssumeRoleARN: ""
+      statusStream: "osquery-status"
+      resultStream: "osquery-result"
+
+    # To configure the AWS Kinesis logger, change the values below
+    kinesis:
+      region: ""
+      accessKeyID: ""
+      secretKey: kinesis
+      stsAssumeRoleARN: ""
+      statusStream: ""
+      resultStream: ""
+
+    # To configure the GCP PubSub logger, change the values below
+    pubsub:
+      project: ""
+      statusTopic: ""
+      resultTopic: ""
+
+## Section: MySQL
+# All of the connection settings for MySQL
+mysql:
+  # Name of the Secret resource containing MySQL password and TLS secrets
+  secretName: mysql
+  address: 127.0.0.1:3306
+  database: kolide
+  username: kolide
+  passwordKey: mysql-password
+  maxOpenConns: 50
+  maxIdleConns: 50
+  connMaxLifetime: 0
+  tls:
+    enabled: false
+    caCertKey: ca.cert
+    certKey: client.cert
+    keyKey: client.key
+    config: ""
+    serverName: ""
+
+## Section: Redis
+# All of the connection settings for Redis
+redis:
+  address: 127.0.0.1:6379
+  database: "0"
+  usePassword: false
+  secretName: redis
+  passwordKey: redis-password
+
+## Section: GKE
+# Settings that make running on Google Kubernetes Engine easier
+gke:
+  # The CloudSQL Proxy runs as a container in the Fleet Pod that proxies connections to a Cloud SQL instance
+  cloudSQL:
+    enableProxy: false
+    imageTag: 1.17-alpine
+    verbose: true
+    instanceName: ""
+  # The GKE Ingress requires a few changes that other ingress controllers don't
+  ingress:
+    useGKEIngress: false
+    useManagedCertificate: false
+  # Workload Identity allows the K8s service account to assume the IAM permissions of a GCP service account
+  workloadIdentityEmail: ""

--- a/tools/ci/helm-values/logger-firehose-sts.yaml
+++ b/tools/ci/helm-values/logger-firehose-sts.yaml
@@ -1,0 +1,142 @@
+## Section: Kubernetes
+# All settings related to how Fleet is deployed in Kubernetes
+hostName: fleet.localhost
+replicas: 3 # The number of Fleet instances to deploy
+imageTag: 3.6.0 # Version of Fleet to deploy
+createIngress: true # Whether or not to automatically create an Ingress
+ingressAnnotations: {} # Additional annotation to add to the Ingress
+podAnnotations: {} # Additional annotations to add to the Fleet pod
+serviceAccountAnnotations: {} # Additional annotations to add to the Fleet service account
+resources:
+  limits:
+    cpu: 1 # 1GHz
+    memory: 1Gi
+  requests:
+    cpu: 0.1 # 100Mhz
+    memory: 50Mi
+
+## Section: Fleet
+# All of the settings relating to configuring the Fleet server
+fleet:
+  listenPort: 8080
+  # Name of the Secret resource storing TLS, JWT, and S3 bucket secrets
+  secretName: fleet
+  # Whether or not to run `fleet db prepare` to run SQL migrations before starting Fleet
+  # WARNING: This may cause database corruption if more than one migration is attempted at a time
+  autoApplySQLMigrations: false
+  tls:
+    enabled: true
+    compatibility: modern
+    certSecretKey: server.cert
+    keySecretKey: server.key
+  auth:
+    jwtSecretKey: jwt-secret
+    bcryptCost: 12
+    saltKeySize: 24
+  app:
+    tokenKeySize: 24
+    inviteTokenValidityPeriod: 120h # 5 days
+  session:
+    keySize: 64
+    duration: 2160h # 90 days
+  logging:
+    debug: false
+    json: false
+    disableBanner: false
+  carving:
+    s3:
+      bucketName: ""
+      prefix: ""
+      accessKeyID: ""
+      secretKey: s3-bucket
+      stsAssumeRoleARN: ""
+
+## Section: osquery
+# All of the settings related to osquery's interactions with the Fleet server 
+osquery:
+  # Name of the secret resource containing optional secrets for AWS credentials
+  secretName: osquery
+  nodeKeySize: 24
+  labelUpdateInterval: 30m
+  detailUpdateInterval: 30m
+
+  # To change where Fleet store the logs sent from osquery, set the values below
+  logging:
+    statusPlugin: firehose
+    resultPlugin: firehose
+
+    # To congigure the filesystem logger, change the values below
+    filesystem:
+      statusLogFile: /tmp/osquery_status
+      resultLogFile: /tmp/osquery_result
+      enableRotation: "false"
+      enableCompression: "false"
+
+    # To configure the AWS Firehose logger, change the values below
+    firehose:
+      region: "us-west1"
+      accessKeyID: ""
+      secretKey: firehose
+      stsAssumeRoleARN: "some:arn:abc"
+      statusStream: "osquery-status"
+      resultStream: "osquery-result"
+
+    # To configure the AWS Kinesis logger, change the values below
+    kinesis:
+      region: ""
+      accessKeyID: ""
+      secretKey: kinesis
+      stsAssumeRoleARN: ""
+      statusStream: ""
+      resultStream: ""
+
+    # To configure the GCP PubSub logger, change the values below
+    pubsub:
+      project: ""
+      statusTopic: ""
+      resultTopic: ""
+
+## Section: MySQL
+# All of the connection settings for MySQL
+mysql:
+  # Name of the Secret resource containing MySQL password and TLS secrets
+  secretName: mysql
+  address: 127.0.0.1:3306
+  database: kolide
+  username: kolide
+  passwordKey: mysql-password
+  maxOpenConns: 50
+  maxIdleConns: 50
+  connMaxLifetime: 0
+  tls:
+    enabled: false
+    caCertKey: ca.cert
+    certKey: client.cert
+    keyKey: client.key
+    config: ""
+    serverName: ""
+
+## Section: Redis
+# All of the connection settings for Redis
+redis:
+  address: 127.0.0.1:6379
+  database: "0"
+  usePassword: false
+  secretName: redis
+  passwordKey: redis-password
+
+## Section: GKE
+# Settings that make running on Google Kubernetes Engine easier
+gke:
+  # The CloudSQL Proxy runs as a container in the Fleet Pod that proxies connections to a Cloud SQL instance
+  cloudSQL:
+    enableProxy: false
+    imageTag: 1.17-alpine
+    verbose: true
+    instanceName: ""
+  # The GKE Ingress requires a few changes that other ingress controllers don't
+  ingress:
+    useGKEIngress: false
+    useManagedCertificate: false
+  # Workload Identity allows the K8s service account to assume the IAM permissions of a GCP service account
+  workloadIdentityEmail: ""

--- a/tools/ci/helm-values/logger-pubsub.yaml
+++ b/tools/ci/helm-values/logger-pubsub.yaml
@@ -1,0 +1,142 @@
+## Section: Kubernetes
+# All settings related to how Fleet is deployed in Kubernetes
+hostName: fleet.localhost
+replicas: 3 # The number of Fleet instances to deploy
+imageTag: 3.6.0 # Version of Fleet to deploy
+createIngress: true # Whether or not to automatically create an Ingress
+ingressAnnotations: {} # Additional annotation to add to the Ingress
+podAnnotations: {} # Additional annotations to add to the Fleet pod
+serviceAccountAnnotations: {} # Additional annotations to add to the Fleet service account
+resources:
+  limits:
+    cpu: 1 # 1GHz
+    memory: 1Gi
+  requests:
+    cpu: 0.1 # 100Mhz
+    memory: 50Mi
+
+## Section: Fleet
+# All of the settings relating to configuring the Fleet server
+fleet:
+  listenPort: 8080
+  # Name of the Secret resource storing TLS, JWT, and S3 bucket secrets
+  secretName: fleet
+  # Whether or not to run `fleet db prepare` to run SQL migrations before starting Fleet
+  # WARNING: This may cause database corruption if more than one migration is attempted at a time
+  autoApplySQLMigrations: false
+  tls:
+    enabled: true
+    compatibility: modern
+    certSecretKey: server.cert
+    keySecretKey: server.key
+  auth:
+    jwtSecretKey: jwt-secret
+    bcryptCost: 12
+    saltKeySize: 24
+  app:
+    tokenKeySize: 24
+    inviteTokenValidityPeriod: 120h # 5 days
+  session:
+    keySize: 64
+    duration: 2160h # 90 days
+  logging:
+    debug: false
+    json: false
+    disableBanner: false
+  carving:
+    s3:
+      bucketName: ""
+      prefix: ""
+      accessKeyID: ""
+      secretKey: s3-bucket
+      stsAssumeRoleARN: ""
+
+## Section: osquery
+# All of the settings related to osquery's interactions with the Fleet server 
+osquery:
+  # Name of the secret resource containing optional secrets for AWS credentials
+  secretName: osquery
+  nodeKeySize: 24
+  labelUpdateInterval: 30m
+  detailUpdateInterval: 30m
+
+  # To change where Fleet store the logs sent from osquery, set the values below
+  logging:
+    statusPlugin: pubsub
+    resultPlugin: pubsub
+
+    # To congigure the filesystem logger, change the values below
+    filesystem:
+      statusLogFile: /tmp/osquery_status
+      resultLogFile: /tmp/osquery_result
+      enableRotation: "false"
+      enableCompression: "false"
+
+    # To configure the AWS Firehose logger, change the values below
+    firehose:
+      region: ""
+      accessKeyID: ""
+      secretKey: firehose
+      stsAssumeRoleARN: ""
+      statusStream: ""
+      resultStream: ""
+
+    # To configure the AWS Kinesis logger, change the values below
+    kinesis:
+      region: ""
+      accessKeyID: ""
+      secretKey: kinesis
+      stsAssumeRoleARN: ""
+      statusStream: ""
+      resultStream: ""
+
+    # To configure the GCP PubSub logger, change the values below
+    pubsub:
+      project: "project"
+      statusTopic: "osquery-status"
+      resultTopic: "osquery-result"
+
+## Section: MySQL
+# All of the connection settings for MySQL
+mysql:
+  # Name of the Secret resource containing MySQL password and TLS secrets
+  secretName: mysql
+  address: 127.0.0.1:3306
+  database: kolide
+  username: kolide
+  passwordKey: mysql-password
+  maxOpenConns: 50
+  maxIdleConns: 50
+  connMaxLifetime: 0
+  tls:
+    enabled: false
+    caCertKey: ca.cert
+    certKey: client.cert
+    keyKey: client.key
+    config: ""
+    serverName: ""
+
+## Section: Redis
+# All of the connection settings for Redis
+redis:
+  address: 127.0.0.1:6379
+  database: "0"
+  usePassword: false
+  secretName: redis
+  passwordKey: redis-password
+
+## Section: GKE
+# Settings that make running on Google Kubernetes Engine easier
+gke:
+  # The CloudSQL Proxy runs as a container in the Fleet Pod that proxies connections to a Cloud SQL instance
+  cloudSQL:
+    enableProxy: false
+    imageTag: 1.17-alpine
+    verbose: true
+    instanceName: ""
+  # The GKE Ingress requires a few changes that other ingress controllers don't
+  ingress:
+    useGKEIngress: false
+    useManagedCertificate: false
+  # Workload Identity allows the K8s service account to assume the IAM permissions of a GCP service account
+  workloadIdentityEmail: ""


### PR DESCRIPTION
Providing a Helm chart makes it easier for users to deploy to Kubernetes.

I think this is good to go, and I've tested deploying to Kind and GKE using the GKE ingress, sql proxy, and managed certificate, but I haven't tested anything AWS related.