### PR TITLE
Add --dev flag and change docker defaults

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -56,3 +56,10 @@ wish to override the default value.
 
 	return rootCmd
 }
+
+func applyDevFlags(cfg *config.KolideConfig) {
+	cfg.Mysql.Username = "fleet"
+	cfg.Mysql.Database = "fleet"
+	cfg.Mysql.Password = "insecure"
+	cfg.Auth.JwtKey = "insecure"
+}

--- a/cmd/fleet/prepare.go
+++ b/cmd/fleet/prepare.go
@@ -39,6 +39,7 @@ To setup Fleet infrastructure, use one of the available commands.
 
 			if dev {
 				applyDevFlags(&config)
+				noPrompt = true
 			}
 
 			ds, err := mysql.New(config.Mysql, clock.C)

--- a/cmd/fleet/prepare.go
+++ b/cmd/fleet/prepare.go
@@ -27,6 +27,8 @@ To setup Fleet infrastructure, use one of the available commands.
 	}
 
 	noPrompt := false
+	// Whether to enable developer options
+	dev := false
 
 	var dbCmd = &cobra.Command{
 		Use:   "db",
@@ -34,6 +36,11 @@ To setup Fleet infrastructure, use one of the available commands.
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
 			config := configManager.LoadConfig()
+
+			if dev {
+				applyDevFlags(&config)
+			}
+
 			ds, err := mysql.New(config.Mysql, clock.C)
 			if err != nil {
 				initFatal(err, "creating db connection")
@@ -75,6 +82,7 @@ To setup Fleet infrastructure, use one of the available commands.
 	}
 
 	dbCmd.PersistentFlags().BoolVar(&noPrompt, "no-prompt", false, "disable prompting before migrations (for use in scripts)")
+	dbCmd.PersistentFlags().BoolVar(&dev, "dev", false, "Enable developer options")
 
 	prepareCmd.AddCommand(dbCmd)
 	return prepareCmd

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -49,6 +49,8 @@ type initializer interface {
 func createServeCmd(configManager config.Manager) *cobra.Command {
 	// Whether to enable the debug endpoints
 	debug := false
+	// Whether to enable developer options
+	dev := false
 
 	serveCmd := &cobra.Command{
 		Use:   "serve",
@@ -63,6 +65,10 @@ the way that the Fleet server works.
 `,
 		Run: func(cmd *cobra.Command, args []string) {
 			config := configManager.LoadConfig()
+
+			if dev {
+				applyDevFlags(&config)
+			}
 
 			var logger kitlog.Logger
 			{
@@ -362,6 +368,7 @@ the way that the Fleet server works.
 	}
 
 	serveCmd.PersistentFlags().BoolVar(&debug, "debug", false, "Enable debug endpoints")
+	serveCmd.PersistentFlags().BoolVar(&dev, "dev", false, "Enable developer options")
 
 	return serveCmd
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,9 @@ services:
     command: mysqld --datadir=/tmp/mysqldata --slow_query_log=1 --log_output=TABLE --log-queries-not-using-indexes --event-scheduler=ON
     environment: &mysql-default-environment
       MYSQL_ROOT_PASSWORD: toor
-      MYSQL_DATABASE: kolide
-      MYSQL_USER: kolide
-      MYSQL_PASSWORD: kolide
+      MYSQL_DATABASE: fleet
+      MYSQL_USER: fleet
+      MYSQL_PASSWORD: insecure
     ports:
       - "3306:3306"
 

--- a/docs/3-Contribution/1-Building-Fleet.md
+++ b/docs/3-Contribution/1-Building-Fleet.md
@@ -94,7 +94,7 @@ docker-compose down
 Once you `docker-compose up` and are running the databases, you can build the code and run the following command to create the database tables:
 
 ```
-fleet prepare db
+./build/fleet prepare db --dev
 ```
 
 ### Running Fleet using Docker development infrastructure
@@ -102,7 +102,7 @@ fleet prepare db
 To start the Fleet server backed by the Docker development infrastructure, run the Fleet binary as follows:
 
 ```
-fleet serve --auth_jwt_key="insecure"
+./build/fleet serve --dev
 ```
 
 The server is accessible by default at [https://localhost:8080](https://localhost:8080).


### PR DESCRIPTION
- Add --dev flag that will set default flag values. This simplifies the
  invocation of Fleet in a development environment.
- Change defaults in docker-compose to use `fleet` in place of `kolide`.
-  Skip prompt in `prepare db` when `--dev` specified.
- Update developer documentation.

Updates to MySQL configuration in docker-compose.yml may require
existing development containers and volumes to be deleted (this will
delete data in MySQL):

```shell
docker-compose rm -sf
docker volume rm fleet_mysql-persistent-volume
```

Closes #170