### PR TITLE
Update build-fleet.md with chrome bug note and new link

### DIFF
--- a/docs/3-Contribution/1-Building-Fleet.md
+++ b/docs/3-Contribution/1-Building-Fleet.md
@@ -13,7 +13,7 @@ Clone this repository.
 
 To setup a working local development environment, you must install the following minimum toolset:
 
-* [Go](https://golang.org/dl/) (1.9 or greater)
+* [Go](https://golang.org/doc/install) (1.9 or greater)
 * [Node.js](https://nodejs.org/en/download/current/) and [Yarn](https://yarnpkg.com/en/docs/install)
 * [GNU Make](https://www.gnu.org/software/make/) (probably already installed if you're on macOS/Linux)
 * [Docker](https://www.docker.com/products/overview#/install_the_platform)
@@ -110,6 +110,8 @@ The server is accessible by default at [https://localhost:8080](https://localhos
 By default, Fleet will try to connect to servers running on default ports on localhost. Depending on your browser's settings, you may have to click through a security warning.
 
 If you're using the Google Chrome web browser, you have the option to always automatically bypass the security warning. Visit [chrome://flags/#allow-insecure-localhost](chrome://flags/#allow-insecure-localhost) and set the "Allow invalid certificates for resources loaded from localhost." flag to "Enabled."
+
+> Note: in Chrome version 88 there is a bug where you must first enable [chrome://flags/#temporary-unexpire-flags-m87](chrome://flags/#temporary-unexpire-flags-m87). The [chrome://flags/#allow-insecure-localhost](chrome://flags/#allow-insecure-localhost) flag will then be visible again.
 
 If you're using Docker via [Docker Toolbox](https://www.docker.com/products/docker-toolbox), you may have to modify the default values use the output of `docker-machine ip` instead of `localhost`. There is an example configuration file included in this repository to make this process easier for you.  Use the `--config` flag of the Fleet binary to specify the path to your config. See `fleet --help` for more options.
 


### PR DESCRIPTION
- The link for documentation to install go has been updated for to a more helpful link.

- a note has been added after finding a bug in chrome version 88 that would not show the #allow-insecure-localhost flag. This note shows how to work around this issue