### PR TITLE
Improve UI contrast for select values in multi input

### DIFF
--- a/frontend/components/forms/fields/SelectTargetsDropdown/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/_styles.scss
@@ -88,7 +88,10 @@
       }
 
       .Select-value {
-        line-height: 1.9;
+        line-height: 34px;
+        border: 1px solid $core-dark-blue-grey;
+        margin-top: 5px;
+        margin-bottom: 0;
       }
     }
 
@@ -131,7 +134,7 @@
   }
 
   .Select-value {
-    border-radius: 2px;
+    border-radius: $border-radius;
     background-color: $white;
     border: solid 1px $ui-borders;
 
@@ -149,20 +152,19 @@
         @extend %kolidecon;
         transition: color 150ms ease-in-out;
         transform: translate(-50%, -50%);
-        content: '\f036';
+        content: '\2715'; // hex code for multiplication cross
         position: absolute;
         top: 50%;
         left: 50%;
         visibility: visible;
-        font-size: 20px;
-        color: $ui-medium-grey;
+        color: $core-dark-blue-grey;
         display: block;
         text-indent: 0;
       }
 
       &:hover {
         &::after {
-          color: $core-medium-blue-grey;
+          color: $alert;
         }
       }
     }


### PR DESCRIPTION
relates to https://github.com/fleetdm/fleet/issues/216

The contrast for the UI on select values in the multi select input was poor. This improves it

It went from this:

![image](https://user-images.githubusercontent.com/1153709/106597665-9fee9680-654e-11eb-9206-1ddb486a3a91.png)

to this:

![image](https://user-images.githubusercontent.com/1153709/106597583-86e5e580-654e-11eb-9cf2-a281f7ed0da9.png)
