### PR TITLE
fix issue with 500s when pack sidebar not depopulating when query is removed

### DIFF
--- a/frontend/pages/packs/EditPackPage/EditPackPage.jsx
+++ b/frontend/pages/packs/EditPackPage/EditPackPage.jsx
@@ -194,6 +194,7 @@ export class EditPackPage extends Component {
 
     return Promise.all(promises)
       .then(() => {
+        this.setState({ selectedScheduledQuery: null, selectedQuery: null });
         dispatch(renderFlash('success', 'Scheduled queries removed'));
       });
   }


### PR DESCRIPTION
relates to https://github.com/fleetdm/fleet/issues/90

This fixes a 500 error when you would remove a query from the pack, but were still able to save its configuration after it was deleted.

The fix was 1 line, but took a while to figure out the cause 😅 