### PR TITLE
Change default TLS compatibility to `intermediate`

### DIFF
--- a/docs/2-Deployment/2-Configuration.md
+++ b/docs/2-Deployment/2-Configuration.md
@@ -391,14 +391,16 @@ Whether or not the server should be served over TLS.
 
 Configures the TLS settings for compatibility with various user agents. Options are `modern` and `intermediate`. These correspond to the compatibility levels [defined by the Mozilla OpSec team](https://wiki.mozilla.org/index.php?title=Security/Server_Side_TLS&oldid=1229478) (updated July 24, 2020).
 
-- Default value: `modern`
+- Default value: `intermediate`
 - Environment variable: `KOLIDE_SERVER_TLS_COMPATIBILITY`
 - Config file format:
 
 	```
 	server:
-		tls_compatibility: intermediate
+		tlsprofile: intermediate
 	```
+	
+Please note this option has an inconsistent key name in the config file. This will be fixed in Fleet 4.0.0.
 
 ###### `server_url_prefix`
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -53,7 +53,7 @@ type ServerConfig struct {
 	Cert       string
 	Key        string
 	TLS        bool
-	TLSProfile string
+	TLSProfile string // TODO #271 set `yaml:"tls_compatibility"`
 	URLPrefix  string `yaml:"url_prefix"`
 }
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -208,7 +208,7 @@ func (man Manager) addConfigs() {
 		"Fleet TLS key path")
 	man.addConfigBool("server.tls", true,
 		"Enable TLS (required for osqueryd communication)")
-	man.addConfigString(TLSProfileKey, TLSProfileModern,
+	man.addConfigString(TLSProfileKey, TLSProfileIntermediate,
 		fmt.Sprintf("TLS security profile choose one of %s or %s",
 			TLSProfileModern, TLSProfileIntermediate))
 	man.addConfigString("server.url_prefix", "",

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -40,7 +40,7 @@ func TestConfigRoundtrip(t *testing.T) {
 				case "TLSProfile":
 					// we have to explicitly set value for this key as it will only
 					// accept old, intermediate, or modern
-					key_v.SetString(TLSProfileModern)
+					key_v.SetString(TLSProfileIntermediate)
 				default:
 					key_v.SetString(v.Elem().Type().Field(conf_index).Name + "_" + conf_v.Type().Field(key_index).Name)
 				}

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -40,6 +40,9 @@ func TestConfigRoundtrip(t *testing.T) {
 				case "TLSProfile":
 					// we have to explicitly set value for this key as it will only
 					// accept old, intermediate, or modern
+
+					// TODO #271 use TLSProfileIntermediate to ensure that the
+					// non-default option gets set here.
 					key_v.SetString(TLSProfileIntermediate)
 				default:
 					key_v.SetString(v.Elem().Type().Field(conf_index).Name + "_" + conf_v.Type().Field(key_index).Name)


### PR DESCRIPTION
In #212 these settings were updated and caused connectivity issues for
users in common environment configurations. The new changes are
aggressive (`modern` enforces TLS 1.3) and Mozilla indicates that
`intermediate` is an appropriate default. This will ensure better
compatibility for common deployments while still allowing the option to
use the strictest settings.

Document unintentional mismatched yaml key.

Fixes #269