### PR TITLE
Add javascript source maps for development

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,8 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const WebpackNotifierPlugin = require('webpack-notifier');
 
+const DEV_SOURCE_MAPS = 'eval-source-map';
+
 var plugins = [
   new webpack.NoEmitOnErrorsPlugin(),
   new HtmlWebpackPlugin({
@@ -46,6 +48,7 @@ var config  = {
     publicPath: "/assets/",
     filename: '[name].js'
   },
+  devtool: process.env.NODE_ENV === 'development' ? DEV_SOURCE_MAPS : false,
   plugins: plugins,
   optimization: {
     minimize: process.env.NODE_ENV == 'production',


### PR DESCRIPTION
There were no JS source maps so debugging was difficult. This adds source maps for the development environment.

> NOTE: I wanted to try to add css source maps too but after playing with if for a while I think that will have to be a larger change. I'll revisit that later