### PR TITLE
Fix host target select input to reflect to host context for a query

### DIFF
--- a/frontend/pages/queries/QueryPage/helpers.js
+++ b/frontend/pages/queries/QueryPage/helpers.js
@@ -1,5 +1,8 @@
+import { push } from 'react-router-redux';
+import PATHS from 'router/paths';
 import { differenceWith, isEqual, uniqWith } from 'lodash';
 
+import hostActions from 'redux/nodes/entities/hosts/actions';
 import { setSelectedTargets } from 'redux/nodes/components/QueryPages/actions';
 
 const targetsChanged = (hosts, targets) => {
@@ -31,4 +34,14 @@ const selectHosts = (dispatch, { hosts = [], selectedTargets = [] }) => {
   return false;
 };
 
-export default { selectHosts };
+// TODO: pull out to common module. This same code is used in HostDetailsPage/helpers.js
+export const fetchHost = (dispatch, hostID) => {
+  return dispatch(hostActions.load(hostID))
+    .catch(() => {
+      dispatch(push(PATHS.FLEET_500));
+
+      return false;
+    });
+};
+
+export default { selectHosts, fetchHost };


### PR DESCRIPTION
related to https://github.com/fleetdm/fleet/issues/217

When coming to the query page from a url with a host query param (e.g. /query/new?host=4) the host should be selected already in the select dropdown. This was not the case and this PR fixes that.