### PR TITLE
Fixes for fleetctl preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Fleet is the most widely used open source osquery manager.  Deploying osquery wi
 
 ## Try Fleet
 
-#### With [Node.js](https://nodejs.org/en/download/) and [Docker](https://docs.docker.com/get-docker/) installed:
+#### With [Node.js](https://nodejs.org/en/download/), [Docker](https://docs.docker.com/get-docker/), and [Docker Compose](https://docs.docker.com/compose/install/) installed:
 
 ```bash
 # Install the Fleet command-line tool

--- a/cmd/fleetctl/config.go
+++ b/cmd/fleetctl/config.go
@@ -63,20 +63,23 @@ func makeConfigIfNotExists(fp string) error {
 	return err
 }
 
-func readConfig(fp string) (c configFile, err error) {
+func readConfig(fp string) (configFile, error) {
+	var c configFile
 	b, err := ioutil.ReadFile(fp)
 	if err != nil {
-		return
+		return c, err
 	}
 
-	err = yaml.Unmarshal(b, &c)
+	if err := yaml.Unmarshal(b, &c); err != nil {
+		return c, errors.Wrap(err, "unmarshal config")
+	}
 
 	if c.Contexts == nil {
 		c.Contexts = map[string]Context{
 			"default": Context{},
 		}
 	}
-	return
+	return c, nil
 }
 
 func writeConfig(fp string, c configFile) error {

--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -57,6 +57,13 @@ This command will create a directory fleet-preview in the current working direct
 				return err
 			}
 
+			// Make sure the logs directory is writable, otherwise the Fleet
+			// server errors on startup. This can be a problem when running on
+			// Linux with a non-root user inside the container.
+			if err := os.Chmod(filepath.Join(previewDir, "logs"), 0777); err != nil {
+				return errors.Wrap(err, "make logs writable")
+			}
+
 			fmt.Println("Starting Docker containers...")
 			out, err := exec.Command("docker-compose", "up", "-d", "mysql01", "redis01", "fleet01").CombinedOutput()
 			if err != nil {

--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -65,7 +65,7 @@ This command will create a directory fleet-preview in the current working direct
 			}
 
 			fmt.Println("Starting Docker containers...")
-			out, err := exec.Command("docker-compose", "up", "-d", "mysql01", "redis01", "fleet01").CombinedOutput()
+			out, err := exec.Command("docker-compose", "up", "-d", "--remove-orphans", "mysql01", "redis01", "fleet01").CombinedOutput()
 			if err != nil {
 				fmt.Println(string(out))
 				return errors.Errorf("Failed to run docker-compose")
@@ -151,12 +151,9 @@ This command will create a directory fleet-preview in the current working direct
 				return errors.New("Expected 1 active enroll secret")
 			}
 
-			if err := os.Chdir(filepath.Join(previewDir, "osquery")); err != nil {
-				return errors.Wrap(err, "Error getting preview osquery directory")
-			}
-
 			fmt.Println("Starting simulated hosts...")
-			cmd := exec.Command("docker-compose", "up", "-d")
+			cmd := exec.Command("docker-compose", "up", "-d", "--remove-orphans")
+			cmd.Dir = filepath.Join(previewDir, "osquery")
 			cmd.Env = append(cmd.Env,
 				"ENROLL_SECRET="+secrets.Secrets[0].Secret,
 				"FLEET_URL="+address,

--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -100,7 +100,9 @@ This command will create a directory fleet-preview in the current working direct
 			config, err := readConfig(configPath)
 			if err != nil {
 				// No existing config
-				config.Contexts["default"] = contextConfig
+				config.Contexts = map[string]Context{
+					"default": contextConfig,
+				}
 			} else {
 				fmt.Println("Configured fleetctl in the 'preview' context to avoid overwriting existing config.")
 				context = "preview"
@@ -284,11 +286,11 @@ func waitStartup() error {
 
 func checkDocker() error {
 	// Check installed
-	if _, err := exec.LookPath("docker-compose"); err != nil {
-		return errors.New("Docker is required for the fleetctl preview experience.\n\nPlease install Docker (https://docs.docker.com/get-docker/).")
-	}
 	if _, err := exec.LookPath("docker"); err != nil {
 		return errors.New("Docker is required for the fleetctl preview experience.\n\nPlease install Docker (https://docs.docker.com/get-docker/).")
+	}
+	if _, err := exec.LookPath("docker-compose"); err != nil {
+		return errors.New("Docker Compose is required for the fleetctl preview experience.\n\nPlease install Docker Compose (https://docs.docker.com/compose/install/).")
 	}
 
 	// Check running


### PR DESCRIPTION
- Better documentation and error for missing docker-compose.
- Handle case of no existing config file.
- Make logs directory world-writable (to allow writes from inside container).

Fixes #286 