### PR TITLE
Deprecate /api/v1/kolide routes

### DIFF
--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -16,13 +16,11 @@ Fleet is powered by a Go API server which serves three types of endpoints:
 
 - Endpoints starting with `/api/v1/osquery/` are osquery TLS server API endpoints. All of these endpoints are used for talking to osqueryd agents and that's it.
 - Endpoints starting with `/api/v1/fleet/` are endpoints to interact with the Fleet data model (packs, queries, scheduled queries, labels, hosts, etc) as well as application endpoints (configuring settings, logging in, session management, etc).
-- All other endpoints are served the React single page application bundle. The React app uses React Router to determine whether or not the URI is a valid route and what to do.
-
-Only osquery agents should interact with the osquery API, but we'd like to support the eventual use of the Fleet API extensively. The API is not very well documented at all right now, but we have plans to:
-
-- Generate and publish detailed documentation via a tool built using [test2doc](https://github.com/adams-sarah/test2doc) (or similar).
-- Release a JavaScript Fleet API client library (which would be derived from the [current](https://github.com/fleetdm/fleet/blob/master/frontend/kolide/index.js) JavaScript API client).
-- Commit to a stable, standardized API format.
+- All other endpoints are served by the React single page application bundle.
+  The React app uses React Router to determine whether or not the URI is a valid
+  route and what to do.
+  
+Note: We have deprecated `/api/v1/kolide/` routes and will remove them in the Fleet 4.0 release. Please migrate all routes to `/api/v1/fleet/`. 
 
 ### fleetctl
 

--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -15,7 +15,7 @@
 Fleet is powered by a Go API server which serves three types of endpoints:
 
 - Endpoints starting with `/api/v1/osquery/` are osquery TLS server API endpoints. All of these endpoints are used for talking to osqueryd agents and that's it.
-- Endpoints starting with `/api/v1/kolide/` are endpoints to interact with the Fleet data model (packs, queries, scheduled queries, labels, hosts, etc) as well as application endpoints (configuring settings, logging in, session management, etc).
+- Endpoints starting with `/api/v1/fleet/` are endpoints to interact with the Fleet data model (packs, queries, scheduled queries, labels, hosts, etc) as well as application endpoints (configuring settings, logging in, session management, etc).
 - All other endpoints are served the React single page application bundle. The React app uses React Router to determine whether or not the URI is a valid route and what to do.
 
 Only osquery agents should interact with the osquery API, but we'd like to support the eventual use of the Fleet API extensively. The API is not very well documented at all right now, but we have plans to:
@@ -39,11 +39,11 @@ The general idea with the current API is that there are many entities throughout
 
 Each set of objects follows a similar REST access pattern.
 
-- You can `GET /api/v1/kolide/packs` to get all packs
-- You can `GET /api/v1/kolide/packs/1` to get a specific pack.
-- You can `DELETE /api/v1/kolide/packs/1` to delete a specific pack.
-- You can `POST /api/v1/kolide/packs` (with a valid body) to create a new pack.
-- You can `PATCH /api/v1/kolide/packs/1` (with a valid body) to modify a specific pack.
+- You can `GET /api/v1/fleet/packs` to get all packs
+- You can `GET /api/v1/fleet/packs/1` to get a specific pack.
+- You can `DELETE /api/v1/fleet/packs/1` to delete a specific pack.
+- You can `POST /api/v1/fleet/packs` (with a valid body) to create a new pack.
+- You can `PATCH /api/v1/fleet/packs/1` (with a valid body) to modify a specific pack.
 
 Queries, packs, scheduled queries, labels, invites, users, sessions all behave this way. Some objects, like invites, have additional HTTP methods for additional functionality. Some objects, such as scheduled queries, are merely a relationship between two other objects (in this case, a query and a pack) with some details attached.
 
@@ -96,7 +96,7 @@ Authorization: Bearer <your token>
 
 Authenticates the user with the specified credentials. Use the token returned from this endpoint to authenticate further API requests.
 
-`POST /api/v1/kolide/login`
+`POST /api/v1/fleet/login`
 
 #### Parameters
 
@@ -107,7 +107,7 @@ Authenticates the user with the specified credentials. Use the token returned fr
 
 #### Example
 
-`POST /api/v1/kolide/login`
+`POST /api/v1/fleet/login`
 
 ##### Request body
 
@@ -147,11 +147,11 @@ Authenticates the user with the specified credentials. Use the token returned fr
 
 Logs out the authenticated user.
 
-`POST /api/v1/kolide/logout`
+`POST /api/v1/fleet/logout`
 
 #### Example
 
-`POST /api/v1/kolide/logout`
+`POST /api/v1/fleet/logout`
 
 ##### Default response
 
@@ -163,7 +163,7 @@ Logs out the authenticated user.
 
 Sends a password reset email to the specified email. Requires that SMTP is configured for your Fleet server.
 
-`POST /api/v1/kolide/forgot_password`
+`POST /api/v1/fleet/forgot_password`
 
 #### Parameters
 
@@ -173,7 +173,7 @@ Sends a password reset email to the specified email. Requires that SMTP is confi
 
 #### Example
 
-`POST /api/v1/kolide/forgot_password`
+`POST /api/v1/fleet/forgot_password`
 
 ##### Request body
 
@@ -207,7 +207,7 @@ Sends a password reset email to the specified email. Requires that SMTP is confi
 
 ### Change password
 
-`POST /api/v1/kolide/change_password`
+`POST /api/v1/fleet/change_password`
 
 Changes the password for the authenticated user.
 
@@ -220,7 +220,7 @@ Changes the password for the authenticated user.
 
 #### Example
 
-`POST /api/v1/kolide/change_password`
+`POST /api/v1/fleet/change_password`
 
 ##### Request body
 
@@ -257,11 +257,11 @@ Changes the password for the authenticated user.
 
 Retrieves the user data for the authenticated user.
 
-`POST /api/v1/kolide/me`
+`POST /api/v1/fleet/me`
 
 #### Example
 
-`POST /api/v1/kolide/me`
+`POST /api/v1/fleet/me`
 
 ##### Default response
 
@@ -291,11 +291,11 @@ Retrieves the user data for the authenticated user.
 
 Resets the password of the authenticated user. Requires that `force_password_reset` is set to `true` prior to the request.
 
-`POST /api/v1/kolide/perform_require_password_reset`
+`POST /api/v1/fleet/perform_require_password_reset`
 
 #### Example
 
-`POST /api/v1/kolide/perform_required_password_reset`
+`POST /api/v1/fleet/perform_required_password_reset`
 
 ##### Request body
 
@@ -333,11 +333,11 @@ Resets the password of the authenticated user. Requires that `force_password_res
 
 Gets the current SSO configuration.
 
-`GET /api/v1/kolide/sso`
+`GET /api/v1/fleet/sso`
 
 #### Example
 
-`GET /api/v1/kolide/sso`
+`GET /api/v1/fleet/sso`
 
 ##### Default response
 
@@ -357,7 +357,7 @@ Gets the current SSO configuration.
 
 ### Initiate SSO
 
-`POST /api/v1/kolide/sso`
+`POST /api/v1/fleet/sso`
 
 #### Parameters
 
@@ -367,7 +367,7 @@ Gets the current SSO configuration.
 
 #### Example
 
-`POST /api/v1/kolide/sso`
+`POST /api/v1/fleet/sso`
 
 ##### Request body
 
@@ -409,7 +409,7 @@ Gets the current SSO configuration.
 
 ### List hosts
 
-`GET /api/v1/kolide/hosts`
+`GET /api/v1/fleet/hosts`
 
 #### Parameters
 
@@ -423,7 +423,7 @@ Gets the current SSO configuration.
 
 #### Example
 
-`GET /api/v1/kolide/hosts?page=0&per_page=100&order_key=host_name`
+`GET /api/v1/fleet/hosts?page=0&per_page=100&order_key=host_name`
 
 ##### Request query parameters
 
@@ -524,7 +524,7 @@ Gets the current SSO configuration.
 
 Returns the count of all hosts organized by status. `online_count` includes all hosts currently enrolled in Fleet. `offline_count` includes all hosts that haven't checked into Fleet recently. `mia_count` includes all hosts that haven't been seen by Fleet in more than 30 days. `new_count` includes the hosts that have been enrolled to Fleet in the last 24 hours.
 
-`GET /api/v1/kolide/host_summary`
+`GET /api/v1/fleet/host_summary`
 
 #### Parameters
 
@@ -532,7 +532,7 @@ None.
 
 #### Example
 
-`GET /api/v1/kolide/host_summary`
+`GET /api/v1/fleet/host_summary`
 
 
 ##### Default response
@@ -552,7 +552,7 @@ None.
 
 Returns the information of the specified host.
 
-`GET /api/v1/kolide/hosts/{id}`
+`GET /api/v1/fleet/hosts/{id}`
 
 #### Parameters
 
@@ -562,7 +562,7 @@ Returns the information of the specified host.
 
 #### Example
 
-`GET /api/v1/kolide/hosts/121`
+`GET /api/v1/fleet/hosts/121`
 
 
 ##### Default response
@@ -617,7 +617,7 @@ Returns the information of the specified host.
 Returns the information of the host specified using the `uuid`, `osquery_host_id`, `hostname`, or
 `node_key` as an identifier
 
-`GET /api/v1/kolide/hosts/identifier/{identifier}`
+`GET /api/v1/fleet/hosts/identifier/{identifier}`
 
 #### Parameters
 
@@ -627,7 +627,7 @@ Returns the information of the host specified using the `uuid`, `osquery_host_id
 
 #### Example
 
-`GET /api/v1/kolide/hosts/identifier/f01c4390-0000-0000-a1e5-14346a5724dc`
+`GET /api/v1/fleet/hosts/identifier/f01c4390-0000-0000-a1e5-14346a5724dc`
 
 
 ##### Default response
@@ -681,7 +681,7 @@ Returns the information of the host specified using the `uuid`, `osquery_host_id
 
 Deletes the specified host from Fleet. Note that a deleted host will fail authentication with the previous node key, and in most osquery configurations will attempt to re-enroll automatically. If the host still has a valid enroll secret, it will re-enroll successfully.
 
-`DELETE /api/v1/kolide/hosts/{id}`
+`DELETE /api/v1/fleet/hosts/{id}`
 
 #### Parameters
 
@@ -691,7 +691,7 @@ Deletes the specified host from Fleet. Note that a deleted host will fail authen
 
 #### Example
 
-`DELETE /api/v1/kolide/hosts/121`
+`DELETE /api/v1/fleet/hosts/121`
 
 
 ##### Default response
@@ -717,7 +717,7 @@ The Fleet server exposes a handful of API endpoints that handles common user man
 
 Returns a list of all enabled users
 
-`GET /api/v1/kolide/users`
+`GET /api/v1/fleet/users`
 
 #### Parameters
 
@@ -725,7 +725,7 @@ None.
 
 #### Example
 
-`GET /api/v1/kolide/users`
+`GET /api/v1/fleet/users`
 
 ##### Request query parameters
 
@@ -775,7 +775,7 @@ None.
 
 Creates a user account after an invited user provides registration information and submits the form.
 
-`POST /api/v1/kolide/users`
+`POST /api/v1/fleet/users`
 
 #### Parameters
 
@@ -790,7 +790,7 @@ Creates a user account after an invited user provides registration information a
 
 #### Example
 
-`POST /api/v1/kolide/users`
+`POST /api/v1/fleet/users`
 
 ##### Request query parameters
 
@@ -881,7 +881,7 @@ The same error will be returned whenever one of the required parameters fails th
 
 Creates a user account without requiring an invitation, the user is enabled immediately.
 
-`POST /api/v1/kolide/users/admin`
+`POST /api/v1/fleet/users/admin`
 
 #### Parameters
 
@@ -895,7 +895,7 @@ Creates a user account without requiring an invitation, the user is enabled imme
 
 #### Example
 
-`POST /api/v1/kolide/users/admin`
+`POST /api/v1/fleet/users/admin`
 
 ##### Request query parameters
 
@@ -967,7 +967,7 @@ Creates a user account without requiring an invitation, the user is enabled imme
 
 Returns all information about a specific user.
 
-`GET /api/v1/kolide/users/{id}`
+`GET /api/v1/fleet/users/{id}`
 
 #### Parameters
 
@@ -977,7 +977,7 @@ Returns all information about a specific user.
 
 #### Example
 
-`GET /api/v1/kolide/users/2`
+`GET /api/v1/fleet/users/2`
 
 ##### Request query parameters
 
@@ -1061,7 +1061,7 @@ Returns all information about a specific user.
 
 Returns the query specified by ID.
 
-`GET /api/v1/kolide/queries/{id}`
+`GET /api/v1/fleet/queries/{id}`
 
 #### Parameters
 
@@ -1071,7 +1071,7 @@ Returns the query specified by ID.
 
 #### Example
 
-`GET /api/v1/kolide/queries/31`
+`GET /api/v1/fleet/queries/31`
 
 
 ##### Default response
@@ -1109,7 +1109,7 @@ Returns the query specified by ID.
 
 Returns a list of all queries in the Fleet instance.
 
-`GET /api/v1/kolide/queries`
+`GET /api/v1/fleet/queries`
 
 #### Parameters
 
@@ -1117,7 +1117,7 @@ None.
 
 #### Example
 
-`GET /api/v1/kolide/queries`
+`GET /api/v1/fleet/queries`
 
 
 ##### Default response
@@ -1207,7 +1207,7 @@ None.
 
 ### Create query
 
-`POST /api/v1/kolide/queries`
+`POST /api/v1/fleet/queries`
 
 #### Parameters
 
@@ -1219,7 +1219,7 @@ None.
 
 #### Example
 
-`POST /api/v1/kolide/queries`
+`POST /api/v1/fleet/queries`
 
 ##### Request body
 
@@ -1256,7 +1256,7 @@ None.
 
 Returns the query specified by ID.
 
-`PATCH /api/v1/kolide/queries/{id}`
+`PATCH /api/v1/fleet/queries/{id}`
 
 #### Parameters
 
@@ -1269,7 +1269,7 @@ Returns the query specified by ID.
 
 #### Example
 
-`PATCH /api/v1/kolide/queries/2`
+`PATCH /api/v1/fleet/queries/2`
 
 ##### Request body
 
@@ -1304,7 +1304,7 @@ Returns the query specified by ID.
 
 Deletes the query specified by name.
 
-`DELETE /api/v1/kolide/queries/{name}`
+`DELETE /api/v1/fleet/queries/{name}`
 
 #### Parameters
 
@@ -1314,7 +1314,7 @@ Deletes the query specified by name.
 
 #### Example
 
-`DELETE /api/v1/kolide/queries/{name}`
+`DELETE /api/v1/fleet/queries/{name}`
 
 ##### Default response
 
@@ -1328,7 +1328,7 @@ Deletes the query specified by name.
 
 Deletes the query specified by ID.
 
-`DELETE /api/v1/kolide/queries/id/{id}`
+`DELETE /api/v1/fleet/queries/id/{id}`
 
 #### Parameters
 
@@ -1338,7 +1338,7 @@ Deletes the query specified by ID.
 
 #### Example
 
-`DELETE /api/v1/kolide/queries/id/28`
+`DELETE /api/v1/fleet/queries/id/28`
 
 ##### Default response
 
@@ -1352,7 +1352,7 @@ Deletes the query specified by ID.
 
 Returns a list of all queries in the Fleet instance. Each item returned includes the name, description, and SQL of the query.
 
-`GET /api/v1/kolide/spec/queries`
+`GET /api/v1/fleet/spec/queries`
 
 #### Parameters
 
@@ -1360,7 +1360,7 @@ None.
 
 #### Example
 
-`GET /api/v1/kolide/spec/queries`
+`GET /api/v1/fleet/spec/queries`
 
 ##### Default response
 
@@ -1392,7 +1392,7 @@ None.
 
 Returns the name, description, and SQL of the query specified by name.
 
-`GET /api/v1/kolide/spec/queries/{name}`
+`GET /api/v1/fleet/spec/queries/{name}`
 
 #### Parameters
 
@@ -1402,7 +1402,7 @@ Returns the name, description, and SQL of the query specified by name.
 
 #### Example
 
-`GET /api/v1/kolide/spec/queries/query1`
+`GET /api/v1/fleet/spec/queries/query1`
 
 ##### Default response
 
@@ -1422,7 +1422,7 @@ Returns the name, description, and SQL of the query specified by name.
 
 Creates and/or modifies the queries included in the specs list. To modify an existing query, the name of the query included in `specs` must already be used by an existing query. If a query with the specified name doesn't exist in Fleet, a new query will be created.
 
-`POST /api/v1/kolide/spec/queries`
+`POST /api/v1/fleet/spec/queries`
 
 #### Parameters
 
@@ -1432,7 +1432,7 @@ Creates and/or modifies the queries included in the specs list. To modify an exi
 
 #### Example
 
-`POST /api/v1/kolide/spec/queries`
+`POST /api/v1/fleet/spec/queries`
 
 ##### Request body
 
@@ -1470,7 +1470,7 @@ Creates and/or modifies the queries included in the specs list. To modify an exi
 
 Runs the specified query as a live query on the specified hosts or group of hosts. Returns a new live query campaign. Individual hosts must be specified with the host's ID. Groups of hosts are specified by label ID.
 
-`POST /api/v1/kolide/spec/queries/run`
+`POST /api/v1/fleet/spec/queries/run`
 
 #### Parameters
 
@@ -1481,7 +1481,7 @@ Runs the specified query as a live query on the specified hosts or group of host
 
 #### Example with one host targeted by ID
 
-`POST /api/v1/kolide/spec/queries/run`
+`POST /api/v1/fleet/spec/queries/run`
 
 ##### Request body
 
@@ -1518,7 +1518,7 @@ Runs the specified query as a live query on the specified hosts or group of host
 
 #### Example with multiple hosts targeted by label ID
 
-`POST /api/v1/kolide/spec/queries/run`
+`POST /api/v1/fleet/spec/queries/run`
 
 ##### Request body
 
@@ -1557,7 +1557,7 @@ Runs the specified query as a live query on the specified hosts or group of host
 
 Runs the specified query by name as a live query on the specified hosts or group of hosts. Returns a new live query campaign. Individual hosts must be specified with the host's ID. Groups of hosts are specified by label.
 
-`POST /api/v1/kolide/spec/queries/run`
+`POST /api/v1/fleet/spec/queries/run`
 
 #### Parameters
 
@@ -1568,7 +1568,7 @@ Runs the specified query by name as a live query on the specified hosts or group
 
 #### Example with one host targeted
 
-`POST /api/v1/kolide/spec/queries/run`
+`POST /api/v1/fleet/spec/queries/run`
 
 ##### Request body
 
@@ -1624,7 +1624,7 @@ Runs the specified query by name as a live query on the specified hosts or group
 
 ### Create pack
 
-`POST /api/v1/kolide/packs`
+`POST /api/v1/fleet/packs`
 
 #### Parameters
 
@@ -1637,7 +1637,7 @@ Runs the specified query by name as a live query on the specified hosts or group
 
 #### Example
 
-`POST /api/v1/kolide/packs`
+`POST /api/v1/fleet/packs`
 
 ##### Request query parameters
 
@@ -1674,7 +1674,7 @@ Runs the specified query by name as a live query on the specified hosts or group
 
 ### Modify pack
 
-`PATCH /api/v1/kolide/packs/{id}`
+`PATCH /api/v1/fleet/packs/{id}`
 
 #### Parameters
 
@@ -1688,7 +1688,7 @@ Runs the specified query by name as a live query on the specified hosts or group
 
 #### Example
 
-`PATCH /api/v1/kolide/packs/{id}`
+`PATCH /api/v1/fleet/packs/{id}`
 
 ##### Request query parameters
 
@@ -1724,7 +1724,7 @@ Runs the specified query by name as a live query on the specified hosts or group
 
 ### Get pack
 
-`GET /api/v1/kolide/packs/{id}`
+`GET /api/v1/fleet/packs/{id}`
 
 #### Parameters
 
@@ -1734,7 +1734,7 @@ Runs the specified query by name as a live query on the specified hosts or group
 
 #### Example
 
-`GET /api/v1/kolide/packs/17`
+`GET /api/v1/fleet/packs/17`
 
 ##### Default response
 
@@ -1760,7 +1760,7 @@ Runs the specified query by name as a live query on the specified hosts or group
 
 ### List packs
 
-`GET /api/v1/kolide/packs`
+`GET /api/v1/fleet/packs`
 
 #### Parameters
 
@@ -1768,7 +1768,7 @@ None.
 
 #### Example
 
-`GET /api/v1/kolide/packs`
+`GET /api/v1/fleet/packs`
 
 ##### Default response
 
@@ -1809,7 +1809,7 @@ None.
 
 ### Delete pack
 
-`DELETE /api/v1/kolide/packs/{name}`
+`DELETE /api/v1/fleet/packs/{name}`
 
 #### Parameters
 
@@ -1819,7 +1819,7 @@ None.
 
 #### Example
 
-`DELETE /api/v1/kolide/packs/pack_number_one`
+`DELETE /api/v1/fleet/packs/pack_number_one`
 
 ##### Default response
 
@@ -1831,7 +1831,7 @@ None.
 
 ### Delete pack by ID
 
-`DELETE /api/v1/kolide/packs/id/{id}`
+`DELETE /api/v1/fleet/packs/id/{id}`
 
 #### Parameters
 
@@ -1841,7 +1841,7 @@ None.
 
 #### Example
 
-`DELETE /api/v1/kolide/packs/id/1`
+`DELETE /api/v1/fleet/packs/id/1`
 
 ##### Default response
 
@@ -1853,7 +1853,7 @@ None.
 
 ### Get scheduled queries in a pack
 
-`GET /api/v1/kolide/packs/{id}/scheduled`
+`GET /api/v1/fleet/packs/{id}/scheduled`
 
 #### Parameters
 
@@ -1863,7 +1863,7 @@ None.
 
 #### Example
 
-`GET /api/v1/kolide/packs/1/scheduled`
+`GET /api/v1/fleet/packs/1/scheduled`
 
 ##### Default response
 
@@ -1920,7 +1920,7 @@ None.
 
 ### Add scheduled query to a pack
 
-`POST /api/v1/kolide/schedule`
+`POST /api/v1/fleet/schedule`
 
 #### Parameters
 
@@ -1937,7 +1937,7 @@ None.
 
 #### Example
 
-`POST /api/v1/kolide/schedule`
+`POST /api/v1/fleet/schedule`
 
 #### Request body 
 
@@ -1981,7 +1981,7 @@ None.
 
 ### Get scheduled query
 
-`GET /api/v1/kolide/schedule/{id}`
+`GET /api/v1/fleet/schedule/{id}`
 
 #### Parameters
 
@@ -1991,7 +1991,7 @@ None.
 
 #### Example
 
-`GET /api/v1/kolide/schedule/56`
+`GET /api/v1/fleet/schedule/56`
 
 ##### Default response
 
@@ -2020,7 +2020,7 @@ None.
 
 ### Modify scheduled query
 
-`PATCH /api/v1/kolide/schedule/{id}`
+`PATCH /api/v1/fleet/schedule/{id}`
 
 #### Parameters
 
@@ -2036,7 +2036,7 @@ None.
 
 #### Example
 
-`PATCH /api/v1/kolide/schedule/56`
+`PATCH /api/v1/fleet/schedule/56`
 
 #### Request body 
 
@@ -2073,7 +2073,7 @@ None.
 
 ### Delete scheduled query
 
-`DELETE /api/v1/kolide/schedule/{id}`
+`DELETE /api/v1/fleet/schedule/{id}`
 
 #### Parameters
 
@@ -2083,7 +2083,7 @@ None.
 
 #### Example
 
-`DELETE /api/v1/kolide/schedule/56`
+`DELETE /api/v1/fleet/schedule/56`
 
 ##### Default response
 
@@ -2097,11 +2097,11 @@ None.
 
 Returns the specs for all packs in the Fleet instance.
 
-`GET /api/v1/kolide/spec/packs`
+`GET /api/v1/fleet/spec/packs`
 
 #### Example
 
-`GET /api/v1/kolide/spec/packs`
+`GET /api/v1/fleet/spec/packs`
 
 ##### Default response
 
@@ -2198,7 +2198,7 @@ Returns the specs for all packs in the Fleet instance.
 
 Returns the specs for all packs in the Fleet instance.
 
-`POST /api/v1/kolide/spec/packs`
+`POST /api/v1/fleet/spec/packs`
 
 #### Parameters
 
@@ -2208,7 +2208,7 @@ Returns the specs for all packs in the Fleet instance.
 
 #### Example
 
-`POST /api/v1/kolide/spec/packs`
+`POST /api/v1/fleet/spec/packs`
 
 ##### Request body
 
@@ -2311,7 +2311,7 @@ Returns the specs for all packs in the Fleet instance.
 
 Returns the spec for the specified pack by pack name.
 
-`GET /api/v1/kolide/spec/packs/{name}`
+`GET /api/v1/fleet/spec/packs/{name}`
 
 #### Parameters
 
@@ -2321,7 +2321,7 @@ Returns the spec for the specified pack by pack name.
 
 #### Example
 
-`GET /api/v1/kolide/spec/packs/pack_1`
+`GET /api/v1/fleet/spec/packs/pack_1`
 
 ##### Default response
 
@@ -2405,7 +2405,7 @@ The Fleet server exposes a handful of API endpoints that handle the configuratio
 
 Returns the Fleet certificate.
 
-`GET /api/v1/kolide/config/certificate`
+`GET /api/v1/fleet/config/certificate`
 
 #### Parameters
 
@@ -2413,7 +2413,7 @@ None.
 
 #### Example
 
-`GET /api/v1/kolide/config/certificate`
+`GET /api/v1/fleet/config/certificate`
 
 
 ##### Default response
@@ -2430,7 +2430,7 @@ None.
 
 Returns all information about the Fleet's configuration.
 
-`GET /api/v1/kolide/config`
+`GET /api/v1/fleet/config`
 
 #### Parameters
 
@@ -2438,7 +2438,7 @@ None.
 
 #### Example
 
-`GET /api/v1/kolide/config`
+`GET /api/v1/fleet/config`
 
 
 ##### Default response
@@ -2493,7 +2493,7 @@ None.
 
 Modifies the Fleet's configuration with the supplied information.
 
-`PATCH /api/v1/kolide/config`
+`PATCH /api/v1/fleet/config`
 
 #### Parameters
 
@@ -2527,7 +2527,7 @@ Modifies the Fleet's configuration with the supplied information.
 
 #### Example
 
-`PATCH /api/v1/kolide/config`
+`PATCH /api/v1/fleet/config`
 
 ##### Request body
 
@@ -2598,7 +2598,7 @@ Modifies the Fleet's configuration with the supplied information.
 
 Returns all the enroll secrets used by the Fleet server.
 
-`GET /api/v1/kolide/spec/enroll_secret`
+`GET /api/v1/fleet/spec/enroll_secret`
 
 #### Parameters
 
@@ -2606,7 +2606,7 @@ None.
 
 #### Example
 
-`GET /api/v1/kolide/spec/enroll_secret`
+`GET /api/v1/fleet/spec/enroll_secret`
 
 
 ##### Default response
@@ -2644,7 +2644,7 @@ None.
 
 Modifies and/or creates the specified enroll secret(s).
 
-`POST /api/v1/kolide/spec/enroll_secret`
+`POST /api/v1/fleet/spec/enroll_secret`
 
 #### Parameters
 
@@ -2672,7 +2672,7 @@ Modifies and/or creates the specified enroll secret(s).
 }
 ```
 
-`POST /api/v1/kolide/spec/enroll_secret`
+`POST /api/v1/fleet/spec/enroll_secret`
 
 
 ##### Default response
@@ -2686,7 +2686,7 @@ Modifies and/or creates the specified enroll secret(s).
 ### Create invite
 
 
-`POST /api/v1/kolide/invites`
+`POST /api/v1/fleet/invites`
 
 #### Parameters
 
@@ -2712,7 +2712,7 @@ Modifies and/or creates the specified enroll secret(s).
 }
 ```
 
-`POST /api/v1/kolide/invites`
+`POST /api/v1/fleet/invites`
 
 
 ##### Default response
@@ -2738,7 +2738,7 @@ Modifies and/or creates the specified enroll secret(s).
 
 Returns a list of the active invitations in Fleet.
 
-`GET /api/v1/kolide/invites`
+`GET /api/v1/fleet/invites`
 
 #### Parameters
 
@@ -2746,7 +2746,7 @@ None.
 
 #### Example
 
-`GET /api/v1/kolide/invites`
+`GET /api/v1/fleet/invites`
 
 
 ##### Default response
@@ -2784,7 +2784,7 @@ None.
 
 Delete the specified invite from Fleet.
 
-`DELETE /api/v1/kolide/invites/{id}`
+`DELETE /api/v1/fleet/invites/{id}`
 
 #### Parameters
 
@@ -2794,7 +2794,7 @@ Delete the specified invite from Fleet.
 
 #### Example
 
-`DELETE /api/v1/kolide/invites/{id}`
+`DELETE /api/v1/fleet/invites/{id}`
 
 
 ##### Default response
@@ -2809,7 +2809,7 @@ Delete the specified invite from Fleet.
 
 Verify the specified invite.
 
-`GET /api/v1/kolide/invites/{token}`
+`GET /api/v1/fleet/invites/{token}`
 
 #### Parameters
 
@@ -2819,7 +2819,7 @@ Verify the specified invite.
 
 #### Example
 
-`GET /api/v1/kolide/invites/{token}`
+`GET /api/v1/fleet/invites/{token}`
 
 
 ##### Default response
@@ -2867,7 +2867,7 @@ Verify the specified invite.
 
 Retrieve the osquery options configured via Fleet.
 
-`GET /api/v1/kolide/spec/osquery_options`
+`GET /api/v1/fleet/spec/osquery_options`
 
 #### Parameters
 
@@ -2875,7 +2875,7 @@ None.
 
 #### Example
 
-`GET /api/v1/kolide/spec/osquery_options`
+`GET /api/v1/fleet/spec/osquery_options`
 
 
 ##### Default response
@@ -2912,7 +2912,7 @@ None.
 
 Modifies the osquery options configuration set in Fleet.
 
-`POST /api/v1/kolide/spec/osquery_options`
+`POST /api/v1/fleet/spec/osquery_options`
 
 #### Parameters
 
@@ -2922,7 +2922,7 @@ Modifies the osquery options configuration set in Fleet.
 
 #### Example
 
-`POST /api/v1/kolide/spec/osquery_options`
+`POST /api/v1/fleet/spec/osquery_options`
 
 ##### Request body
 

--- a/docs/2-Deployment/2-Configuration.md
+++ b/docs/2-Deployment/2-Configuration.md
@@ -1160,12 +1160,12 @@ Several items are required to configure an IDP to provide SSO services to Fleet.
 
 * _Assertion Consumer Service_ - This is the call back URL that the identity provider
 will use to send security assertions to Fleet. In Okta, this field is called *Single sign on URL*. The value that you supply will be a fully qualified URL
-consisting of your Fleet web address and the callback path `/api/v1/kolide/sso/callback`. For example,
+consisting of your Fleet web address and the callback path `/api/v1/fleet/sso/callback`. For example,
 if your Fleet web address is https://fleet.acme.org, then the value you would
 use in the identity provider configuration would be:
 
   ```
-  https://fleet.acme.org/api/v1/kolide/sso/callback
+  https://fleet.acme.org/api/v1/fleet/sso/callback
   ```
 
 * _Entity ID_ - This value is a URI that you define. It identifies your Fleet instance as the service provider that issues authorization requests. The value must exactly match the

--- a/frontend/kolide/endpoints.js
+++ b/frontend/kolide/endpoints.js
@@ -1,40 +1,40 @@
 export default {
-  CHANGE_PASSWORD: '/v1/kolide/change_password',
-  CONFIG: '/v1/kolide/config',
+  CHANGE_PASSWORD: '/v1/fleet/change_password',
+  CONFIG: '/v1/fleet/config',
   CONFIRM_EMAIL_CHANGE: (token) => {
-    return `/v1/kolide/email/change/${token}`;
+    return `/v1/fleet/email/change/${token}`;
   },
-  OSQUERY_OPTIONS: '/v1/kolide/spec/osquery_options',
+  OSQUERY_OPTIONS: '/v1/fleet/spec/osquery_options',
   ENABLE_USER: (id) => {
-    return `/v1/kolide/users/${id}/enable`;
+    return `/v1/fleet/users/${id}/enable`;
   },
-  FORGOT_PASSWORD: '/v1/kolide/forgot_password',
-  HOSTS: '/v1/kolide/hosts',
-  INVITES: '/v1/kolide/invites',
-  LABELS: '/v1/kolide/labels',
+  FORGOT_PASSWORD: '/v1/fleet/forgot_password',
+  HOSTS: '/v1/fleet/hosts',
+  INVITES: '/v1/fleet/invites',
+  LABELS: '/v1/fleet/labels',
   LABEL_HOSTS: (id) => {
-    return `/v1/kolide/labels/${id}/hosts`;
+    return `/v1/fleet/labels/${id}/hosts`;
   },
-  LOGIN: '/v1/kolide/login',
-  LOGOUT: '/v1/kolide/logout',
-  ME: '/v1/kolide/me',
-  PACKS: '/v1/kolide/packs',
-  PERFORM_REQUIRED_PASSWORD_RESET: '/v1/kolide/perform_required_password_reset',
-  QUERIES: '/v1/kolide/queries',
-  RESET_PASSWORD: '/v1/kolide/reset_password',
-  RUN_QUERY: '/v1/kolide/queries/run',
-  SCHEDULED_QUERIES: '/v1/kolide/schedule',
+  LOGIN: '/v1/fleet/login',
+  LOGOUT: '/v1/fleet/logout',
+  ME: '/v1/fleet/me',
+  PACKS: '/v1/fleet/packs',
+  PERFORM_REQUIRED_PASSWORD_RESET: '/v1/fleet/perform_required_password_reset',
+  QUERIES: '/v1/fleet/queries',
+  RESET_PASSWORD: '/v1/fleet/reset_password',
+  RUN_QUERY: '/v1/fleet/queries/run',
+  SCHEDULED_QUERIES: '/v1/fleet/schedule',
   SCHEDULED_QUERY: (pack) => {
-    return `/v1/kolide/packs/${pack.id}/scheduled`;
+    return `/v1/fleet/packs/${pack.id}/scheduled`;
   },
   SETUP: '/v1/setup',
-  STATUS_LABEL_COUNTS: '/v1/kolide/host_summary',
-  TARGETS: '/v1/kolide/targets',
-  USERS: '/v1/kolide/users',
+  STATUS_LABEL_COUNTS: '/v1/fleet/host_summary',
+  TARGETS: '/v1/fleet/targets',
+  USERS: '/v1/fleet/users',
   UPDATE_USER_ADMIN: (id) => {
-    return `/v1/kolide/users/${id}/admin`;
+    return `/v1/fleet/users/${id}/admin`;
   },
-  SSO: '/v1/kolide/sso',
-  STATUS_LIVE_QUERY: '/v1/kolide/status/live_query',
-  STATUS_RESULT_STORE: '/v1/kolide/status/result_store',
+  SSO: '/v1/fleet/sso',
+  STATUS_LIVE_QUERY: '/v1/fleet/status/live_query',
+  STATUS_RESULT_STORE: '/v1/fleet/status/result_store',
 };

--- a/frontend/kolide/entities/config.js
+++ b/frontend/kolide/entities/config.js
@@ -11,13 +11,13 @@ export default (client) => {
       return client.authenticatedGet(client._endpoint(CONFIG));
     },
     loadCertificate: () => {
-      const endpoint = client._endpoint('/v1/kolide/config/certificate');
+      const endpoint = client._endpoint('/v1/fleet/config/certificate');
 
       return client.authenticatedGet(endpoint)
         .then(response => global.window.atob(response.certificate_chain));
     },
     loadEnrollSecret: () => {
-      const endpoint = client._endpoint('/v1/kolide/spec/enroll_secret');
+      const endpoint = client._endpoint('/v1/fleet/spec/enroll_secret');
 
       return client.authenticatedGet(endpoint);
     },

--- a/frontend/kolide/entities/hosts.tests.js
+++ b/frontend/kolide/entities/hosts.tests.js
@@ -41,7 +41,7 @@ describe('Kolide - API client (hosts)', () => {
     it('calls the label endpoint when used with label filter', () => {
       const request = createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/labels/6/hosts?page=1&per_page=50&order_key=host_name',
+        endpoint: '/api/v1/fleet/labels/6/hosts?page=1&per_page=50&order_key=host_name',
         method: 'get',
         response: { hosts: [] },
       });

--- a/frontend/kolide/entities/packs.js
+++ b/frontend/kolide/entities/packs.js
@@ -6,12 +6,12 @@ import helpers from 'kolide/helpers';
 export default (client) => {
   return {
     addLabel: ({ packID, labelID }) => {
-      const path = `/v1/kolide/packs/${packID}/labels/${labelID}`;
+      const path = `/v1/fleet/packs/${packID}/labels/${labelID}`;
 
       return client.authenticatedPost(client._endpoint(path));
     },
     addQuery: ({ packID, queryID }) => {
-      const endpoint = `/v1/kolide/packs/${packID}/queries/${queryID}`;
+      const endpoint = `/v1/fleet/packs/${packID}/queries/${queryID}`;
 
       return client.authenticatedPost(client._endpoint(endpoint));
     },

--- a/frontend/kolide/websockets.js
+++ b/frontend/kolide/websockets.js
@@ -7,7 +7,7 @@ export default (client) => {
     queries: {
       run: (campaignID) => {
         return new Promise((resolve) => {
-          const socket = new SockJS(`${client.baseURL}/v1/kolide/results`, undefined, {});
+          const socket = new SockJS(`${client.baseURL}/v1/fleet/results`, undefined, {});
 
           socket.onopen = () => {
             socket.send(JSON.stringify({ type: 'auth', data: { token: local.getItem('auth_token') } }));

--- a/frontend/pages/queries/QueryPage/QueryPage.tests.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.tests.jsx
@@ -24,7 +24,7 @@ describe('QueryPage - component', () => {
       .mockImplementation(() => () => Promise.resolve([]));
 
     nock('http://localhost:8080')
-      .post('/api/v1/kolide/targets', JSON.stringify({
+      .post('/api/v1/fleet/targets', JSON.stringify({
         selected: {
           hosts: [1, 99],
           labels: [],

--- a/frontend/redux/nodes/entities/labels/actions.tests.js
+++ b/frontend/redux/nodes/entities/labels/actions.tests.js
@@ -17,7 +17,7 @@ describe('Labels - actions', () => {
 
     describe('successful request', () => {
       it('does not call the LOAD_REQUEST action', (done) => {
-        nock('http://localhost:8080').get('/api/v1/kolide/labels').reply(200, { labels: [labelStub] });
+        nock('http://localhost:8080').get('/api/v1/fleet/labels').reply(200, { labels: [labelStub] });
 
         const mockStore = reduxMockStore(store);
         const expectedActionTypes = ['labels_LOAD_ALL_SUCCESS'];
@@ -49,7 +49,7 @@ describe('Labels - actions', () => {
           },
         };
 
-        nock('http://localhost:8080').get('/api/v1/kolide/labels').reply(422, { errors });
+        nock('http://localhost:8080').get('/api/v1/fleet/labels').reply(422, { errors });
 
         mockStore.dispatch(silentLoadAll())
           .then(done)

--- a/frontend/test/envSetup.js
+++ b/frontend/test/envSetup.js
@@ -14,7 +14,7 @@ nock.disableNetConnect();
 // included to mock the common HTTP request.
 beforeEach(() => {
   nock('http://localhost:8080')
-    .post('/api/v1/kolide/targets', () => true)
+    .post('/api/v1/fleet/targets', () => true)
     .reply(200, {
       targets_count: 1234,
       targets: [

--- a/frontend/test/mocks/README.md
+++ b/frontend/test/mocks/README.md
@@ -44,7 +44,7 @@ const queryMocks = {
     valid: (bearerToken, queryID) => {
       return createRequestMock({
         bearerToken,
-        endpoint: `/api/v1/kolide/queries/${queryID}`,
+        endpoint: `/api/v1/fleet/queries/${queryID}`,
         method: 'get',
         response: { query: { ...queryStub, id: queryID } },
         responseStatus: 200,

--- a/frontend/test/mocks/config_mocks.js
+++ b/frontend/test/mocks/config_mocks.js
@@ -5,7 +5,7 @@ export default {
     valid: (bearerToken) => {
       return createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/config',
+        endpoint: '/api/v1/fleet/config',
         method: 'get',
         response: { config: { name: 'Kolide' } },
       });
@@ -15,7 +15,7 @@ export default {
     valid: (bearerToken, params) => {
       return createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/config',
+        endpoint: '/api/v1/fleet/config',
         method: 'patch',
         params,
         response: {},

--- a/frontend/test/mocks/host_mocks.js
+++ b/frontend/test/mocks/host_mocks.js
@@ -5,7 +5,7 @@ export default {
     valid: (bearerToken, host) => {
       return createRequestMock({
         bearerToken,
-        endpoint: `/api/v1/kolide/hosts/${host.id}`,
+        endpoint: `/api/v1/fleet/hosts/${host.id}`,
         method: 'delete',
         response: {},
       });
@@ -15,7 +15,7 @@ export default {
     valid: (bearerToken) => {
       return createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/hosts?page=0&per_page=100&order_key=host_name',
+        endpoint: '/api/v1/fleet/hosts?page=0&per_page=100&order_key=host_name',
         method: 'get',
         response: { hosts: [] },
       });

--- a/frontend/test/mocks/invite_mocks.js
+++ b/frontend/test/mocks/invite_mocks.js
@@ -5,7 +5,7 @@ export default {
     valid: (bearerToken, params) => {
       return createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/invites',
+        endpoint: '/api/v1/fleet/invites',
         method: 'post',
         params,
         response: { invite: params },
@@ -16,7 +16,7 @@ export default {
     valid: (bearerToken) => {
       return createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/invites',
+        endpoint: '/api/v1/fleet/invites',
         method: 'get',
         response: { invites: [] },
       });
@@ -26,7 +26,7 @@ export default {
     valid: (bearerToken, invite) => {
       return createRequestMock({
         bearerToken,
-        endpoint: `/api/v1/kolide/invites/${invite.id}`,
+        endpoint: `/api/v1/fleet/invites/${invite.id}`,
         method: 'delete',
         response: {},
       });

--- a/frontend/test/mocks/label_mocks.js
+++ b/frontend/test/mocks/label_mocks.js
@@ -5,7 +5,7 @@ export default {
     valid: (bearerToken, params) => {
       return createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/labels',
+        endpoint: '/api/v1/fleet/labels',
         method: 'post',
         response: { label: { ...params, display_text: params.name } },
         responseStatus: 201,
@@ -16,7 +16,7 @@ export default {
     valid: (bearerToken, label) => {
       return createRequestMock({
         bearerToken,
-        endpoint: `/api/v1/kolide/labels/id/${label.id}`,
+        endpoint: `/api/v1/fleet/labels/id/${label.id}`,
         method: 'delete',
         response: {},
       });
@@ -26,7 +26,7 @@ export default {
     valid: (bearerToken, label, params) => {
       return createRequestMock({
         bearerToken,
-        endpoint: `/api/v1/kolide/labels/${label.id}`,
+        endpoint: `/api/v1/fleet/labels/${label.id}`,
         method: 'patch',
         response: { label: { ...label, ...params } },
       });

--- a/frontend/test/mocks/pack_mocks.js
+++ b/frontend/test/mocks/pack_mocks.js
@@ -4,7 +4,7 @@ import { packStub } from 'test/stubs';
 export default {
   addLabel: {
     valid: (bearerToken, packID, labelID) => {
-      const endpoint = `/api/v1/kolide/packs/${packID}/labels/${labelID}`;
+      const endpoint = `/api/v1/fleet/packs/${packID}/labels/${labelID}`;
 
       return createRequestMock({
         bearerToken,
@@ -16,7 +16,7 @@ export default {
   },
   addQuery: {
     valid: (bearerToken, packID, queryID) => {
-      const endpoint = `/api/v1/kolide/packs/${packID}/queries/${queryID}`;
+      const endpoint = `/api/v1/fleet/packs/${packID}/queries/${queryID}`;
 
       return createRequestMock({
         bearerToken,
@@ -30,7 +30,7 @@ export default {
     valid: (bearerToken, params) => {
       return createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/packs',
+        endpoint: '/api/v1/fleet/packs',
         params,
         method: 'post',
         response: { pack: params },
@@ -42,7 +42,7 @@ export default {
     valid: (bearerToken, pack) => {
       return createRequestMock({
         bearerToken,
-        endpoint: `/api/v1/kolide/packs/id/${pack.id}`,
+        endpoint: `/api/v1/fleet/packs/id/${pack.id}`,
         method: 'delete',
         response: {},
       });
@@ -52,7 +52,7 @@ export default {
     valid: (bearerToken, pack, params) => {
       return createRequestMock({
         bearerToken,
-        endpoint: `/api/v1/kolide/packs/${pack.id}`,
+        endpoint: `/api/v1/fleet/packs/${pack.id}`,
         method: 'patch',
         params,
         response: { pack: { ...pack, ...params } },

--- a/frontend/test/mocks/query_mocks.js
+++ b/frontend/test/mocks/query_mocks.js
@@ -15,7 +15,7 @@ export default {
     valid: (bearerToken, params) => {
       return createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/queries',
+        endpoint: '/api/v1/fleet/queries',
         method: 'post',
         params,
         response: { query: params },
@@ -27,7 +27,7 @@ export default {
     valid: (bearerToken, { id }) => {
       return createRequestMock({
         bearerToken,
-        endpoint: `/api/v1/kolide/queries/id/${id}`,
+        endpoint: `/api/v1/fleet/queries/id/${id}`,
         method: 'delete',
         response: {},
       });
@@ -37,7 +37,7 @@ export default {
     invalid: (bearerToken, id) => {
       return createRequestMock({
         bearerToken,
-        endpoint: `/api/v1/kolide/queries/${id}`,
+        endpoint: `/api/v1/fleet/queries/${id}`,
         method: 'get',
         response: errorResponse,
         responseStatus: 404,
@@ -46,7 +46,7 @@ export default {
     valid: (bearerToken, id) => {
       return createRequestMock({
         bearerToken,
-        endpoint: `/api/v1/kolide/queries/${id}`,
+        endpoint: `/api/v1/fleet/queries/${id}`,
         method: 'get',
         response: { query: { id } },
       });
@@ -56,7 +56,7 @@ export default {
     valid: (bearerToken) => {
       return createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/queries',
+        endpoint: '/api/v1/fleet/queries',
         method: 'get',
         response: { queries: [] },
       });
@@ -66,7 +66,7 @@ export default {
     valid: (bearerToken, params) => {
       return createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/queries/run',
+        endpoint: '/api/v1/fleet/queries/run',
         method: 'post',
         params,
         response: { campaign: { id: 1 } },
@@ -75,7 +75,7 @@ export default {
   },
   update: {
     valid: (bearerToken, query, params) => {
-      const endpoint = `/api/v1/kolide/queries/${query.id}`;
+      const endpoint = `/api/v1/fleet/queries/${query.id}`;
 
       return createRequestMock({
         bearerToken,

--- a/frontend/test/mocks/scheduled_query_mocks.js
+++ b/frontend/test/mocks/scheduled_query_mocks.js
@@ -16,7 +16,7 @@ export default {
 
       return createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/schedule',
+        endpoint: '/api/v1/fleet/schedule',
         method: 'post',
         params,
         response: { scheduled: scheduledQueryStub },
@@ -28,7 +28,7 @@ export default {
     valid: (bearerToken, scheduledQuery) => {
       return createRequestMock({
         bearerToken,
-        endpoint: `/api/v1/kolide/schedule/${scheduledQuery.id}`,
+        endpoint: `/api/v1/fleet/schedule/${scheduledQuery.id}`,
         method: 'delete',
         response: {},
       });
@@ -38,7 +38,7 @@ export default {
     valid: (bearerToken, pack) => {
       return createRequestMock({
         bearerToken,
-        endpoint: `/api/v1/kolide/packs/${pack.id}/scheduled`,
+        endpoint: `/api/v1/fleet/packs/${pack.id}/scheduled`,
         method: 'get',
         response: { scheduled: [scheduledQueryStub] },
       });
@@ -48,7 +48,7 @@ export default {
     valid: (bearerToken, scheduledQuery, params) => {
       return createRequestMock({
         bearerToken,
-        endpoint: `/api/v1/kolide/schedule/${scheduledQuery.id}`,
+        endpoint: `/api/v1/fleet/schedule/${scheduledQuery.id}`,
         method: 'patch',
         params,
         response: { scheduled: { ...scheduledQuery, ...params } },

--- a/frontend/test/mocks/session_mocks.js
+++ b/frontend/test/mocks/session_mocks.js
@@ -5,7 +5,7 @@ export default {
   create: {
     valid: (bearerToken = 'abc123', params) => {
       return createRequestMock({
-        endpoint: '/api/v1/kolide/login',
+        endpoint: '/api/v1/fleet/login',
         method: 'post',
         params,
         response: { token: bearerToken, user: userStub },
@@ -16,7 +16,7 @@ export default {
     valid: (bearerToken) => {
       return createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/logout',
+        endpoint: '/api/v1/fleet/logout',
         method: 'post',
         response: {},
       });

--- a/frontend/test/mocks/status_label_mocks.js
+++ b/frontend/test/mocks/status_label_mocks.js
@@ -5,7 +5,7 @@ export default {
     valid: (bearerToken) => {
       return createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/host_summary',
+        endpoint: '/api/v1/fleet/host_summary',
         method: 'get',
         response: { online_count: 1, offline_count: 23, mia_count: 2 },
       });

--- a/frontend/test/mocks/target_mocks.js
+++ b/frontend/test/mocks/target_mocks.js
@@ -5,7 +5,7 @@ export default {
     valid: (bearerToken, query) => {
       return createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/targets',
+        endpoint: '/api/v1/fleet/targets',
         method: 'post',
         params: {
           query,

--- a/frontend/test/mocks/user_mocks.js
+++ b/frontend/test/mocks/user_mocks.js
@@ -6,7 +6,7 @@ export default {
     valid: (bearerToken, params) => {
       return createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/change_password',
+        endpoint: '/api/v1/fleet/change_password',
         method: 'post',
         params,
         response: {},
@@ -15,7 +15,7 @@ export default {
   },
   confirmEmailChange: {
     valid: (bearerToken, token) => {
-      const endpoint = `/api/v1/kolide/email/change/${token}`;
+      const endpoint = `/api/v1/fleet/email/change/${token}`;
 
       return createRequestMock({
         bearerToken,
@@ -27,7 +27,7 @@ export default {
   },
   enable: {
     valid: (bearerToken, user, params) => {
-      const endpoint = `/api/v1/kolide/users/${user.id}/enable`;
+      const endpoint = `/api/v1/fleet/users/${user.id}/enable`;
 
       return createRequestMock({
         bearerToken,
@@ -41,7 +41,7 @@ export default {
   forgotPassword: {
     invalid: (response) => {
       return createRequestMock({
-        endpoint: '/api/v1/kolide/forgot_password',
+        endpoint: '/api/v1/fleet/forgot_password',
         method: 'post',
         response,
         responseStatus: 422,
@@ -49,7 +49,7 @@ export default {
     },
     valid: () => {
       return createRequestMock({
-        endpoint: '/api/v1/kolide/forgot_password',
+        endpoint: '/api/v1/fleet/forgot_password',
         method: 'post',
         response: { user: userStub },
       });
@@ -59,7 +59,7 @@ export default {
     valid: (bearerToken) => {
       return createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/users',
+        endpoint: '/api/v1/fleet/users',
         method: 'get',
         response: { users: [userStub] },
       });
@@ -69,7 +69,7 @@ export default {
     valid: (bearerToken) => {
       return createRequestMock({
         bearerToken,
-        endpoint: '/api/v1/kolide/me',
+        endpoint: '/api/v1/fleet/me',
         method: 'get',
         response: { user: userStub },
       });
@@ -80,7 +80,7 @@ export default {
       const params = { new_password: password, password_reset_token: token };
 
       return createRequestMock({
-        endpoint: '/api/v1/kolide/reset_password',
+        endpoint: '/api/v1/fleet/reset_password',
         method: 'post',
         params,
         response,
@@ -91,7 +91,7 @@ export default {
       const params = { new_password: password, password_reset_token: token };
 
       return createRequestMock({
-        endpoint: '/api/v1/kolide/reset_password',
+        endpoint: '/api/v1/fleet/reset_password',
         method: 'post',
         params,
         response: { user: userStub },
@@ -101,7 +101,7 @@ export default {
   update: {
     valid: (user, params) => {
       return createRequestMock({
-        endpoint: `/api/v1/kolide/users/${user.id}`,
+        endpoint: `/api/v1/fleet/users/${user.id}`,
         method: 'patch',
         params,
         response: { user: userStub },
@@ -112,7 +112,7 @@ export default {
     valid: (bearerToken, user, params) => {
       return createRequestMock({
         bearerToken,
-        endpoint: `/api/v1/kolide/users/${user.id}/admin`,
+        endpoint: `/api/v1/fleet/users/${user.id}/admin`,
         method: 'post',
         params,
         response: { user: { ...user, ...params } },

--- a/frontend/test/target_mock.js
+++ b/frontend/test/target_mock.js
@@ -17,6 +17,6 @@ const defaultResponse = {
 
 export default (params = defaultParams, response = defaultResponse, responseStatus = 200) => {
   return nock('http://localhost:8080')
-    .post('/api/v1/kolide/targets', JSON.stringify(params))
+    .post('/api/v1/fleet/targets', JSON.stringify(params))
     .reply(responseStatus, response);
 };

--- a/server/service/client_appconfig.go
+++ b/server/service/client_appconfig.go
@@ -10,9 +10,9 @@ import (
 
 // ApplyAppConfig sends the application config to be applied to the Fleet instance.
 func (c *Client) ApplyAppConfig(payload *kolide.AppConfigPayload) error {
-	response, err := c.AuthenticatedDo("PATCH", "/api/v1/kolide/config", "", payload)
+	response, err := c.AuthenticatedDo("PATCH", "/api/v1/fleet/config", "", payload)
 	if err != nil {
-		return errors.Wrap(err, "PATCH /api/v1/kolide/config")
+		return errors.Wrap(err, "PATCH /api/v1/fleet/config")
 	}
 	defer response.Body.Close()
 
@@ -38,9 +38,9 @@ func (c *Client) ApplyAppConfig(payload *kolide.AppConfigPayload) error {
 
 // GetAppConfig fetches the application config from the server API
 func (c *Client) GetAppConfig() (*kolide.AppConfigPayload, error) {
-	response, err := c.AuthenticatedDo("GET", "/api/v1/kolide/config", "", nil)
+	response, err := c.AuthenticatedDo("GET", "/api/v1/fleet/config", "", nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "GET /api/v1/kolide/config")
+		return nil, errors.Wrap(err, "GET /api/v1/fleet/config")
 	}
 	defer response.Body.Close()
 
@@ -72,9 +72,9 @@ func (c *Client) GetServerSettings() (*kolide.ServerSettings, error) {
 
 // GetEnrollSecretSpec fetches the enroll secrets stored on the server
 func (c *Client) GetEnrollSecretSpec() (*kolide.EnrollSecretSpec, error) {
-	response, err := c.AuthenticatedDo("GET", "/api/v1/kolide/spec/enroll_secret", "", nil)
+	response, err := c.AuthenticatedDo("GET", "/api/v1/fleet/spec/enroll_secret", "", nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "GET /api/v1/kolide/spec/enroll_secret")
+		return nil, errors.Wrap(err, "GET /api/v1/fleet/spec/enroll_secret")
 	}
 	defer response.Body.Close()
 
@@ -102,9 +102,9 @@ func (c *Client) GetEnrollSecretSpec() (*kolide.EnrollSecretSpec, error) {
 // ApplyEnrollSecretSpec applies the enroll secrets.
 func (c *Client) ApplyEnrollSecretSpec(spec *kolide.EnrollSecretSpec) error {
 	req := applyEnrollSecretSpecRequest{Spec: spec}
-	response, err := c.AuthenticatedDo("POST", "/api/v1/kolide/spec/enroll_secret", "", req)
+	response, err := c.AuthenticatedDo("POST", "/api/v1/fleet/spec/enroll_secret", "", req)
 	if err != nil {
-		return errors.Wrap(err, "POST /api/v1/kolide/spec/enroll_secret")
+		return errors.Wrap(err, "POST /api/v1/fleet/spec/enroll_secret")
 	}
 	defer response.Body.Close()
 

--- a/server/service/client_carves.go
+++ b/server/service/client_carves.go
@@ -12,14 +12,14 @@ import (
 
 // ListCarves lists the file carving sessions
 func (c *Client) ListCarves(opt kolide.CarveListOptions) ([]*kolide.CarveMetadata, error) {
-	endpoint := "/api/v1/kolide/carves"
+	endpoint := "/api/v1/fleet/carves"
 	rawQuery := ""
 	if opt.Expired {
 		rawQuery = "expired=1"
 	}
 	response, err := c.AuthenticatedDo("GET", endpoint, rawQuery, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "GET /api/v1/kolide/carves")
+		return nil, errors.Wrap(err, "GET /api/v1/fleet/carves")
 	}
 	defer response.Body.Close()
 
@@ -50,7 +50,7 @@ func (c *Client) ListCarves(opt kolide.CarveListOptions) ([]*kolide.CarveMetadat
 }
 
 func (c *Client) GetCarve(carveId int64) (*kolide.CarveMetadata, error) {
-	endpoint := fmt.Sprintf("/api/v1/kolide/carves/%d", carveId)
+	endpoint := fmt.Sprintf("/api/v1/fleet/carves/%d", carveId)
 	response, err := c.AuthenticatedDo("GET", endpoint, "", nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "GET "+endpoint)
@@ -78,7 +78,7 @@ func (c *Client) GetCarve(carveId int64) (*kolide.CarveMetadata, error) {
 
 func (c *Client) getCarveBlock(carveId, blockId int64) ([]byte, error) {
 	path := fmt.Sprintf(
-		"/api/v1/kolide/carves/%d/block/%d",
+		"/api/v1/fleet/carves/%d/block/%d",
 		carveId,
 		blockId,
 	)
@@ -161,7 +161,7 @@ func (r *carveReader) Read(p []byte) (n int, err error) {
 
 // DownloadCarve creates a Reader downloading a carve (by ID)
 func (c *Client) DownloadCarve(id int64) (io.Reader, error) {
-	path := fmt.Sprintf("/api/v1/kolide/carves/%d", id)
+	path := fmt.Sprintf("/api/v1/fleet/carves/%d", id)
 	response, err := c.AuthenticatedDo("GET", path, "", nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "GET %s", path)

--- a/server/service/client_hosts.go
+++ b/server/service/client_hosts.go
@@ -10,9 +10,9 @@ import (
 
 // GetHosts retrieves the list of all Hosts
 func (c *Client) GetHosts() ([]HostResponse, error) {
-	response, err := c.AuthenticatedDo("GET", "/api/v1/kolide/hosts", "", nil)
+	response, err := c.AuthenticatedDo("GET", "/api/v1/fleet/hosts", "", nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "GET /api/v1/kolide/hosts")
+		return nil, errors.Wrap(err, "GET /api/v1/fleet/hosts")
 	}
 	defer response.Body.Close()
 
@@ -38,9 +38,9 @@ func (c *Client) GetHosts() ([]HostResponse, error) {
 // HostByIdentifier retrieves a host by the uuid, osquery_host_id, hostname, or
 // node_key.
 func (c *Client) HostByIdentifier(identifier string) (*HostDetailResponse, error) {
-	response, err := c.AuthenticatedDo("GET", "/api/v1/kolide/hosts/identifier/"+identifier, "", nil)
+	response, err := c.AuthenticatedDo("GET", "/api/v1/fleet/hosts/identifier/"+identifier, "", nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "GET /api/v1/kolide/hosts/identifier")
+		return nil, errors.Wrap(err, "GET /api/v1/fleet/hosts/identifier")
 	}
 	defer response.Body.Close()
 
@@ -66,7 +66,7 @@ func (c *Client) HostByIdentifier(identifier string) (*HostDetailResponse, error
 // DeleteHost deletes the host with the matching id.
 func (c *Client) DeleteHost(id uint) error {
 	verb := "DELETE"
-	path := fmt.Sprintf("/api/v1/kolide/hosts/%d", id)
+	path := fmt.Sprintf("/api/v1/fleet/hosts/%d", id)
 	response, err := c.AuthenticatedDo(verb, path, "", nil)
 	if err != nil {
 		return errors.Wrapf(err, "%s %s", verb, path)

--- a/server/service/client_labels.go
+++ b/server/service/client_labels.go
@@ -13,9 +13,9 @@ import (
 // Fleet instance.
 func (c *Client) ApplyLabels(specs []*kolide.LabelSpec) error {
 	req := applyLabelSpecsRequest{Specs: specs}
-	response, err := c.AuthenticatedDo("POST", "/api/v1/kolide/spec/labels", "", req)
+	response, err := c.AuthenticatedDo("POST", "/api/v1/fleet/spec/labels", "", req)
 	if err != nil {
-		return errors.Wrap(err, "POST /api/v1/kolide/spec/labels")
+		return errors.Wrap(err, "POST /api/v1/fleet/spec/labels")
 	}
 	defer response.Body.Close()
 
@@ -42,10 +42,10 @@ func (c *Client) ApplyLabels(specs []*kolide.LabelSpec) error {
 
 // GetLabel retrieves information about a label by name
 func (c *Client) GetLabel(name string) (*kolide.LabelSpec, error) {
-	verb, path := "GET", "/api/v1/kolide/spec/labels/"+url.PathEscape(name)
+	verb, path := "GET", "/api/v1/fleet/spec/labels/"+url.PathEscape(name)
 	response, err := c.AuthenticatedDo(verb, path, "", nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "GET /api/v1/kolide/spec/labels")
+		return nil, errors.Wrap(err, "GET /api/v1/fleet/spec/labels")
 	}
 	defer response.Body.Close()
 
@@ -76,9 +76,9 @@ func (c *Client) GetLabel(name string) (*kolide.LabelSpec, error) {
 
 // GetLabels retrieves the list of all Labels.
 func (c *Client) GetLabels() ([]*kolide.LabelSpec, error) {
-	response, err := c.AuthenticatedDo("GET", "/api/v1/kolide/spec/labels", "", nil)
+	response, err := c.AuthenticatedDo("GET", "/api/v1/fleet/spec/labels", "", nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "GET /api/v1/kolide/spec/labels")
+		return nil, errors.Wrap(err, "GET /api/v1/fleet/spec/labels")
 	}
 	defer response.Body.Close()
 
@@ -105,7 +105,7 @@ func (c *Client) GetLabels() ([]*kolide.LabelSpec, error) {
 
 // DeleteLabel deletes the label with the matching name.
 func (c *Client) DeleteLabel(name string) error {
-	verb, path := "DELETE", "/api/v1/kolide/labels/"+url.PathEscape(name)
+	verb, path := "DELETE", "/api/v1/fleet/labels/"+url.PathEscape(name)
 	response, err := c.AuthenticatedDo(verb, path, "", nil)
 	if err != nil {
 		return errors.Wrapf(err, "%s %s", verb, path)

--- a/server/service/client_live_query.go
+++ b/server/service/client_live_query.go
@@ -64,9 +64,9 @@ func (c *Client) LiveQuery(query string, labels []string, hosts []string) (*Live
 		Query:    query,
 		Selected: distributedQueryCampaignTargetsByNames{Labels: labels, Hosts: hosts},
 	}
-	response, err := c.AuthenticatedDo("POST", "/api/v1/kolide/queries/run_by_names", "", req)
+	response, err := c.AuthenticatedDo("POST", "/api/v1/fleet/queries/run_by_names", "", req)
 	if err != nil {
-		return nil, errors.Wrap(err, "POST /api/v1/kolide/queries/run_by_names")
+		return nil, errors.Wrap(err, "POST /api/v1/fleet/queries/run_by_names")
 	}
 	defer response.Body.Close()
 
@@ -96,7 +96,7 @@ func (c *Client) LiveQuery(query string, labels []string, hosts []string) (*Live
 
 	wssURL := *c.baseURL
 	wssURL.Scheme = "wss"
-	wssURL.Path = c.urlPrefix + "/api/v1/kolide/results/websocket"
+	wssURL.Path = c.urlPrefix + "/api/v1/fleet/results/websocket"
 	conn, _, err := dialer.Dial(wssURL.String(), nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "upgrade live query result websocket")

--- a/server/service/client_options.go
+++ b/server/service/client_options.go
@@ -11,9 +11,9 @@ import (
 // ApplyOptions sends the osquery options to be applied to the Fleet instance.
 func (c *Client) ApplyOptions(spec *kolide.OptionsSpec) error {
 	req := applyOsqueryOptionsSpecRequest{Spec: spec}
-	response, err := c.AuthenticatedDo("POST", "/api/v1/kolide/spec/osquery_options", "", req)
+	response, err := c.AuthenticatedDo("POST", "/api/v1/fleet/spec/osquery_options", "", req)
 	if err != nil {
-		return errors.Wrap(err, "POST /api/v1/kolide/spec/osquery_options")
+		return errors.Wrap(err, "POST /api/v1/fleet/spec/osquery_options")
 	}
 	defer response.Body.Close()
 
@@ -40,7 +40,7 @@ func (c *Client) ApplyOptions(spec *kolide.OptionsSpec) error {
 
 // GetOptions retrieves the configured osquery options.
 func (c *Client) GetOptions() (*kolide.OptionsSpec, error) {
-	verb, path := "GET", "/api/v1/kolide/spec/osquery_options"
+	verb, path := "GET", "/api/v1/fleet/spec/osquery_options"
 	response, err := c.AuthenticatedDo(verb, path, "", nil)
 	if err != nil {
 		return nil, errors.Wrap(err, verb+" "+path)

--- a/server/service/client_packs.go
+++ b/server/service/client_packs.go
@@ -13,9 +13,9 @@ import (
 // Fleet instance.
 func (c *Client) ApplyPacks(specs []*kolide.PackSpec) error {
 	req := applyPackSpecsRequest{Specs: specs}
-	response, err := c.AuthenticatedDo("POST", "/api/v1/kolide/spec/packs", "", req)
+	response, err := c.AuthenticatedDo("POST", "/api/v1/fleet/spec/packs", "", req)
 	if err != nil {
-		return errors.Wrap(err, "POST /api/v1/kolide/spec/packs")
+		return errors.Wrap(err, "POST /api/v1/fleet/spec/packs")
 	}
 	defer response.Body.Close()
 
@@ -42,10 +42,10 @@ func (c *Client) ApplyPacks(specs []*kolide.PackSpec) error {
 
 // GetPack retrieves information about a pack
 func (c *Client) GetPack(name string) (*kolide.PackSpec, error) {
-	verb, path := "GET", "/api/v1/kolide/spec/packs/"+url.PathEscape(name)
+	verb, path := "GET", "/api/v1/fleet/spec/packs/"+url.PathEscape(name)
 	response, err := c.AuthenticatedDo(verb, path, "", nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "GET /api/v1/kolide/spec/packs")
+		return nil, errors.Wrap(err, "GET /api/v1/fleet/spec/packs")
 	}
 	defer response.Body.Close()
 
@@ -76,9 +76,9 @@ func (c *Client) GetPack(name string) (*kolide.PackSpec, error) {
 
 // GetPacks retrieves the list of all Packs.
 func (c *Client) GetPacks() ([]*kolide.PackSpec, error) {
-	response, err := c.AuthenticatedDo("GET", "/api/v1/kolide/spec/packs", "", nil)
+	response, err := c.AuthenticatedDo("GET", "/api/v1/fleet/spec/packs", "", nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "GET /api/v1/kolide/spec/packs")
+		return nil, errors.Wrap(err, "GET /api/v1/fleet/spec/packs")
 	}
 	defer response.Body.Close()
 
@@ -105,7 +105,7 @@ func (c *Client) GetPacks() ([]*kolide.PackSpec, error) {
 
 // DeletePack deletes the pack with the matching name.
 func (c *Client) DeletePack(name string) error {
-	verb, path := "DELETE", "/api/v1/kolide/packs/"+url.PathEscape(name)
+	verb, path := "DELETE", "/api/v1/fleet/packs/"+url.PathEscape(name)
 	response, err := c.AuthenticatedDo(verb, path, "", nil)
 	if err != nil {
 		return errors.Wrapf(err, "%s %s", verb, path)

--- a/server/service/client_queries.go
+++ b/server/service/client_queries.go
@@ -13,9 +13,9 @@ import (
 // Fleet instance.
 func (c *Client) ApplyQueries(specs []*kolide.QuerySpec) error {
 	req := applyQuerySpecsRequest{Specs: specs}
-	response, err := c.AuthenticatedDo("POST", "/api/v1/kolide/spec/queries", "", req)
+	response, err := c.AuthenticatedDo("POST", "/api/v1/fleet/spec/queries", "", req)
 	if err != nil {
-		return errors.Wrap(err, "POST /api/v1/kolide/spec/queries")
+		return errors.Wrap(err, "POST /api/v1/fleet/spec/queries")
 	}
 	defer response.Body.Close()
 
@@ -42,7 +42,7 @@ func (c *Client) ApplyQueries(specs []*kolide.QuerySpec) error {
 
 // GetQuery retrieves the list of all Queries.
 func (c *Client) GetQuery(name string) (*kolide.QuerySpec, error) {
-	verb, path := "GET", "/api/v1/kolide/spec/queries/"+url.PathEscape(name)
+	verb, path := "GET", "/api/v1/fleet/spec/queries/"+url.PathEscape(name)
 	response, err := c.AuthenticatedDo(verb, path, "", nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "%s %s", verb, path)
@@ -76,9 +76,9 @@ func (c *Client) GetQuery(name string) (*kolide.QuerySpec, error) {
 
 // GetQueries retrieves the list of all Queries.
 func (c *Client) GetQueries() ([]*kolide.QuerySpec, error) {
-	response, err := c.AuthenticatedDo("GET", "/api/v1/kolide/spec/queries", "", nil)
+	response, err := c.AuthenticatedDo("GET", "/api/v1/fleet/spec/queries", "", nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "GET /api/v1/kolide/spec/queries")
+		return nil, errors.Wrap(err, "GET /api/v1/fleet/spec/queries")
 	}
 	defer response.Body.Close()
 
@@ -105,7 +105,7 @@ func (c *Client) GetQueries() ([]*kolide.QuerySpec, error) {
 
 // DeleteQuery deletes the query with the matching name.
 func (c *Client) DeleteQuery(name string) error {
-	verb, path := "DELETE", "/api/v1/kolide/queries/"+url.PathEscape(name)
+	verb, path := "DELETE", "/api/v1/fleet/queries/"+url.PathEscape(name)
 	response, err := c.AuthenticatedDo(verb, path, "", nil)
 	if err != nil {
 		return errors.Wrapf(err, "%s %s", verb, path)

--- a/server/service/client_sessions.go
+++ b/server/service/client_sessions.go
@@ -15,9 +15,9 @@ func (c *Client) Login(email, password string) (string, error) {
 		Password: password,
 	}
 
-	response, err := c.Do("POST", "/api/v1/kolide/login", "", params)
+	response, err := c.Do("POST", "/api/v1/fleet/login", "", params)
 	if err != nil {
-		return "", errors.Wrap(err, "POST /api/v1/kolide/login")
+		return "", errors.Wrap(err, "POST /api/v1/fleet/login")
 	}
 	defer response.Body.Close()
 
@@ -50,9 +50,9 @@ func (c *Client) Login(email, password string) (string, error) {
 
 // Logout attempts to logout to the current Fleet instance.
 func (c *Client) Logout() error {
-	response, err := c.AuthenticatedDo("POST", "/api/v1/kolide/logout", "", nil)
+	response, err := c.AuthenticatedDo("POST", "/api/v1/fleet/logout", "", nil)
 	if err != nil {
-		return errors.Wrap(err, "POST /api/v1/kolide/logout")
+		return errors.Wrap(err, "POST /api/v1/fleet/logout")
 	}
 	defer response.Body.Close()
 

--- a/server/service/client_targets.go
+++ b/server/service/client_targets.go
@@ -21,9 +21,9 @@ func (c *Client) SearchTargets(query string, selectedHostIDs, selectedLabelIDs [
 		},
 	}
 
-	response, err := c.AuthenticatedDo("POST", "/api/v1/kolide/targets", "", req)
+	response, err := c.AuthenticatedDo("POST", "/api/v1/fleet/targets", "", req)
 	if err != nil {
-		return nil, errors.Wrap(err, "POST /api/v1/kolide/targets")
+		return nil, errors.Wrap(err, "POST /api/v1/fleet/targets")
 	}
 	defer response.Body.Close()
 

--- a/server/service/client_users.go
+++ b/server/service/client_users.go
@@ -10,7 +10,7 @@ import (
 
 // CreateUser creates a new user, skipping the invitation process.
 func (c *Client) CreateUser(p kolide.UserPayload) error {
-	verb, path := "POST", "/api/v1/kolide/users/admin"
+	verb, path := "POST", "/api/v1/fleet/users/admin"
 	response, err := c.AuthenticatedDo(verb, path, "", p)
 	if err != nil {
 		return errors.Wrapf(err, "%s %s", verb, path)

--- a/server/service/endpoint_appconfig_test.go
+++ b/server/service/endpoint_appconfig_test.go
@@ -22,7 +22,7 @@ type mockValidationError struct {
 }
 
 func testGetAppConfig(t *testing.T, r *testResource) {
-	req, err := http.NewRequest("GET", r.server.URL+"/api/v1/kolide/config", nil)
+	req, err := http.NewRequest("GET", r.server.URL+"/api/v1/fleet/config", nil)
 	require.Nil(t, err)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.adminToken))
 	client := &http.Client{}
@@ -72,7 +72,7 @@ func testModifyAppConfig(t *testing.T, r *testResource) {
 	var buffer bytes.Buffer
 	err := json.NewEncoder(&buffer).Encode(payload)
 	require.Nil(t, err)
-	req, err := http.NewRequest("PATCH", r.server.URL+"/api/v1/kolide/config", &buffer)
+	req, err := http.NewRequest("PATCH", r.server.URL+"/api/v1/fleet/config", &buffer)
 	require.Nil(t, err)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.adminToken))
 	client := &http.Client{}
@@ -112,7 +112,7 @@ func testModifyAppConfigWithValidationFail(t *testing.T, r *testResource) {
 	var buffer bytes.Buffer
 	err := json.NewEncoder(&buffer).Encode(payload)
 	require.Nil(t, err)
-	req, err := http.NewRequest("PATCH", r.server.URL+"/api/v1/kolide/config", &buffer)
+	req, err := http.NewRequest("PATCH", r.server.URL+"/api/v1/fleet/config", &buffer)
 	require.Nil(t, err)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.adminToken))
 	client := &http.Client{}

--- a/server/service/endpoint_campaigns.go
+++ b/server/service/endpoint_campaigns.go
@@ -78,7 +78,7 @@ func makeStreamDistributedQueryCampaignResultsHandler(svc kolide.Service, jwtKey
 	opt := sockjs.DefaultOptions
 	opt.Websocket = true
 	opt.RawWebsocket = true
-	return sockjs.NewHandler("/api/v1/kolide/results", opt, func(session sockjs.Session) {
+	return sockjs.NewHandler("/api/v1/fleet/results", opt, func(session sockjs.Session) {
 		conn := &websocket.Conn{Session: session}
 		defer func() {
 			if p := recover(); p != nil {

--- a/server/service/endpoint_test.go
+++ b/server/service/endpoint_test.go
@@ -67,7 +67,7 @@ func setupEndpointTest(t *testing.T) *testResource {
 	marshalledUser, _ := json.Marshal(&userParam)
 
 	requestBody := &nopCloser{bytes.NewBuffer(marshalledUser)}
-	resp, _ := http.Post(test.server.URL+"/api/v1/kolide/login", "application/json", requestBody)
+	resp, _ := http.Post(test.server.URL+"/api/v1/fleet/login", "application/json", requestBody)
 
 	var jsn = struct {
 		User  *kolide.User `json:"user"`
@@ -82,7 +82,7 @@ func setupEndpointTest(t *testing.T) *testResource {
 	userParam.Password = testUsers["user1"].PlaintextPassword
 	marshalledUser, _ = json.Marshal(userParam)
 	requestBody = &nopCloser{bytes.NewBuffer(marshalledUser)}
-	resp, err = http.Post(test.server.URL+"/api/v1/kolide/login", "application/json", requestBody)
+	resp, err = http.Post(test.server.URL+"/api/v1/fleet/login", "application/json", requestBody)
 	require.Nil(t, err)
 	err = json.NewDecoder(resp.Body).Decode(&jsn)
 	require.Nil(t, err)

--- a/server/service/endpoint_users_test.go
+++ b/server/service/endpoint_users_test.go
@@ -17,7 +17,7 @@ func testAdminUserSetAdmin(t *testing.T, r *testResource) {
 	assert.False(t, user.Admin)
 	inJson := `{"admin":true}`
 	buff := bytes.NewBufferString(inJson)
-	path := fmt.Sprintf("/api/v1/kolide/users/%d/admin", user.ID)
+	path := fmt.Sprintf("/api/v1/fleet/users/%d/admin", user.ID)
 	req, err := http.NewRequest("POST", r.server.URL+path, buff)
 	require.Nil(t, err)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.adminToken))
@@ -42,7 +42,7 @@ func testNonAdminUserSetAdmin(t *testing.T, r *testResource) {
 
 	inJson := `{"admin":true}`
 	buff := bytes.NewBufferString(inJson)
-	path := fmt.Sprintf("/api/v1/kolide/users/%d/admin", user.ID)
+	path := fmt.Sprintf("/api/v1/fleet/users/%d/admin", user.ID)
 	req, err := http.NewRequest("POST", r.server.URL+path, buff)
 	require.Nil(t, err)
 	// user NOT admin
@@ -63,7 +63,7 @@ func testAdminUserSetEnabled(t *testing.T, r *testResource) {
 	assert.True(t, user.Enabled)
 	inJson := `{"enabled":false}`
 	buff := bytes.NewBufferString(inJson)
-	path := fmt.Sprintf("/api/v1/kolide/users/%d/enable", user.ID)
+	path := fmt.Sprintf("/api/v1/fleet/users/%d/enable", user.ID)
 	req, err := http.NewRequest("POST", r.server.URL+path, buff)
 	require.Nil(t, err)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.adminToken))
@@ -88,7 +88,7 @@ func testNonAdminUserSetEnabled(t *testing.T, r *testResource) {
 
 	inJson := `{"enabled":false}`
 	buff := bytes.NewBufferString(inJson)
-	path := fmt.Sprintf("/api/v1/kolide/users/%d/enable", user.ID)
+	path := fmt.Sprintf("/api/v1/fleet/users/%d/enable", user.ID)
 	req, err := http.NewRequest("POST", r.server.URL+path, buff)
 	require.Nil(t, err)
 	// user NOT admin

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -432,7 +432,7 @@ func MakeHandler(svc kolide.Service, config config.KolideConfig, logger kitlog.L
 	r.PathPrefix("/api/v1/fleet/results/").
 		Handler(makeStreamDistributedQueryCampaignResultsHandler(svc, config.Auth.JwtKey, logger)).
 		Name("distributed_query_results")
-	r.PathPrefix("/api/v1/kolide/results/").
+	r.PathPrefix("/api/v1/fleet/results/").
 		Handler(makeStreamDistributedQueryCampaignResultsHandler(svc, config.Auth.JwtKey, logger)).
 		Name("distributed_query_results")
 

--- a/server/service/handler_test.go
+++ b/server/service/handler_test.go
@@ -37,119 +37,119 @@ func TestAPIRoutes(t *testing.T) {
 	}{
 		{
 			verb: "POST",
-			uri:  "/api/v1/kolide/users",
+			uri:  "/api/v1/fleet/users",
 		},
 		{
 			verb: "GET",
-			uri:  "/api/v1/kolide/users",
+			uri:  "/api/v1/fleet/users",
 		},
 		{
 			verb: "GET",
-			uri:  "/api/v1/kolide/users/1",
+			uri:  "/api/v1/fleet/users/1",
 		},
 		{
 			verb: "PATCH",
-			uri:  "/api/v1/kolide/users/1",
+			uri:  "/api/v1/fleet/users/1",
 		},
 		{
 			verb: "POST",
-			uri:  "/api/v1/kolide/login",
+			uri:  "/api/v1/fleet/login",
 		},
 		{
 			verb: "POST",
-			uri:  "/api/v1/kolide/forgot_password",
+			uri:  "/api/v1/fleet/forgot_password",
 		},
 		{
 			verb: "POST",
-			uri:  "/api/v1/kolide/reset_password",
+			uri:  "/api/v1/fleet/reset_password",
 		},
 		{
 			verb: "GET",
-			uri:  "/api/v1/kolide/me",
+			uri:  "/api/v1/fleet/me",
 		},
 		{
 			verb: "GET",
-			uri:  "/api/v1/kolide/config",
+			uri:  "/api/v1/fleet/config",
 		},
 		{
 			verb: "PATCH",
-			uri:  "/api/v1/kolide/config",
+			uri:  "/api/v1/fleet/config",
 		},
 		{
 			verb: "GET",
-			uri:  "/api/v1/kolide/invites",
+			uri:  "/api/v1/fleet/invites",
 		},
 		{
 			verb: "POST",
-			uri:  "/api/v1/kolide/invites",
+			uri:  "/api/v1/fleet/invites",
 		},
 		{
 			verb: "DELETE",
-			uri:  "/api/v1/kolide/invites/1",
+			uri:  "/api/v1/fleet/invites/1",
 		},
 		{
 			verb: "GET",
-			uri:  "/api/v1/kolide/queries/1",
+			uri:  "/api/v1/fleet/queries/1",
 		},
 		{
 			verb: "GET",
-			uri:  "/api/v1/kolide/queries",
+			uri:  "/api/v1/fleet/queries",
 		},
 		{
 			verb: "POST",
-			uri:  "/api/v1/kolide/queries",
+			uri:  "/api/v1/fleet/queries",
 		},
 		{
 			verb: "PATCH",
-			uri:  "/api/v1/kolide/queries/1",
+			uri:  "/api/v1/fleet/queries/1",
 		},
 		{
 			verb: "DELETE",
-			uri:  "/api/v1/kolide/queries/1",
+			uri:  "/api/v1/fleet/queries/1",
 		},
 		{
 			verb: "POST",
-			uri:  "/api/v1/kolide/queries/delete",
+			uri:  "/api/v1/fleet/queries/delete",
 		},
 		{
 			verb: "POST",
-			uri:  "/api/v1/kolide/queries/run",
+			uri:  "/api/v1/fleet/queries/run",
 		},
 		{
 			verb: "GET",
-			uri:  "/api/v1/kolide/packs/1",
+			uri:  "/api/v1/fleet/packs/1",
 		},
 		{
 			verb: "GET",
-			uri:  "/api/v1/kolide/packs",
+			uri:  "/api/v1/fleet/packs",
 		},
 		{
 			verb: "POST",
-			uri:  "/api/v1/kolide/packs",
+			uri:  "/api/v1/fleet/packs",
 		},
 		{
 			verb: "PATCH",
-			uri:  "/api/v1/kolide/packs/1",
+			uri:  "/api/v1/fleet/packs/1",
 		},
 		{
 			verb: "DELETE",
-			uri:  "/api/v1/kolide/packs/1",
+			uri:  "/api/v1/fleet/packs/1",
 		},
 		{
 			verb: "GET",
-			uri:  "/api/v1/kolide/packs/1/scheduled",
+			uri:  "/api/v1/fleet/packs/1/scheduled",
 		},
 		{
 			verb: "POST",
-			uri:  "/api/v1/kolide/schedule",
+			uri:  "/api/v1/fleet/schedule",
 		},
 		{
 			verb: "DELETE",
-			uri:  "/api/v1/kolide/schedule/1",
+			uri:  "/api/v1/fleet/schedule/1",
 		},
 		{
 			verb: "PATCH",
-			uri:  "/api/v1/kolide/schedule/1",
+			uri:  "/api/v1/fleet/schedule/1",
 		}, {
 			verb: "POST",
 			uri:  "/api/v1/osquery/enroll",
@@ -172,35 +172,35 @@ func TestAPIRoutes(t *testing.T) {
 		},
 		{
 			verb: "GET",
-			uri:  "/api/v1/kolide/labels/1",
+			uri:  "/api/v1/fleet/labels/1",
 		},
 		{
 			verb: "GET",
-			uri:  "/api/v1/kolide/labels",
+			uri:  "/api/v1/fleet/labels",
 		},
 		{
 			verb: "POST",
-			uri:  "/api/v1/kolide/labels",
+			uri:  "/api/v1/fleet/labels",
 		},
 		{
 			verb: "DELETE",
-			uri:  "/api/v1/kolide/labels/1",
+			uri:  "/api/v1/fleet/labels/1",
 		},
 		{
 			verb: "GET",
-			uri:  "/api/v1/kolide/hosts/1",
+			uri:  "/api/v1/fleet/hosts/1",
 		},
 		{
 			verb: "GET",
-			uri:  "/api/v1/kolide/hosts",
+			uri:  "/api/v1/fleet/hosts",
 		},
 		{
 			verb: "DELETE",
-			uri:  "/api/v1/kolide/hosts/1",
+			uri:  "/api/v1/fleet/hosts/1",
 		},
 		{
 			verb: "GET",
-			uri:  "/api/v1/kolide/host_summary",
+			uri:  "/api/v1/fleet/host_summary",
 		},
 	}
 
@@ -308,7 +308,7 @@ func TestModifyUserPermissions(t *testing.T) {
 			admin, enabled = tt.ActingUserAdmin, tt.ActingUserEnabled
 
 			recorder := httptest.NewRecorder()
-			path := fmt.Sprintf("/api/v1/kolide/users/%d", tt.TargetUserID)
+			path := fmt.Sprintf("/api/v1/fleet/users/%d", tt.TargetUserID)
 			request := httptest.NewRequest("PATCH", path, bytes.NewBufferString("{}"))
 			// Bearer token generated with session key CHANGEME on jwt.io
 			request.Header.Add("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXNzaW9uX2tleSI6ImZsb29wIn0.ukCPTFvgSJrXbHH2QeAMx3EKwoMh1OmhP3xXxy5I-Wk")

--- a/server/service/http_auth_test.go
+++ b/server/service/http_auth_test.go
@@ -90,7 +90,7 @@ func TestLogin(t *testing.T) {
 		assert.Nil(t, err)
 
 		requestBody := &nopCloser{bytes.NewBuffer(j)}
-		resp, err := http.Post(server.URL+"/api/v1/kolide/login", "application/json", requestBody)
+		resp, err := http.Post(server.URL+"/api/v1/fleet/login", "application/json", requestBody)
 		require.Nil(t, err)
 		assert.Equal(t, tt.status, resp.StatusCode)
 
@@ -120,7 +120,7 @@ func TestLogin(t *testing.T) {
 		assert.NotEqual(t, "", sessions[0].Key)
 
 		// test logout
-		req, _ := http.NewRequest("POST", server.URL+"/api/v1/kolide/logout", nil)
+		req, _ := http.NewRequest("POST", server.URL+"/api/v1/fleet/logout", nil)
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", jsn.Token))
 		client := &http.Client{}
 		resp, err = client.Do(req)

--- a/server/service/service_sessions.go
+++ b/server/service/service_sessions.go
@@ -42,7 +42,7 @@ func (svc service) InitiateSSO(ctx context.Context, redirectURL string) (string,
 	settings := sso.Settings{
 		Metadata: metadata,
 		// Construct call back url to send to idp
-		AssertionConsumerServiceURL: appConfig.KolideServerURL + svc.config.Server.URLPrefix + "/api/v1/kolide/sso/callback",
+		AssertionConsumerServiceURL: appConfig.KolideServerURL + svc.config.Server.URLPrefix + "/api/v1/fleet/sso/callback",
 		SessionStore:                svc.ssoSessionStore,
 		OriginalURL:                 redirectURL,
 	}

--- a/server/service/transport_invites_test.go
+++ b/server/service/transport_invites_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDecodeCreateInviteRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/invites", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/invites", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeCreateInviteRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -31,7 +31,7 @@ func TestDecodeCreateInviteRequest(t *testing.T) {
 
 		router.ServeHTTP(
 			httptest.NewRecorder(),
-			httptest.NewRequest("POST", "/api/v1/kolide/invites", &body),
+			httptest.NewRequest("POST", "/api/v1/fleet/invites", &body),
 		)
 	})
 
@@ -46,7 +46,7 @@ func TestDecodeCreateInviteRequest(t *testing.T) {
 
 		router.ServeHTTP(
 			httptest.NewRecorder(),
-			httptest.NewRequest("POST", "/api/v1/kolide/invites", &body),
+			httptest.NewRequest("POST", "/api/v1/fleet/invites", &body),
 		)
 	})
 
@@ -54,7 +54,7 @@ func TestDecodeCreateInviteRequest(t *testing.T) {
 
 func TestDecodeVerifyInviteRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/invites/{token}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/invites/{token}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeCreateInviteRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -64,7 +64,7 @@ func TestDecodeVerifyInviteRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("GET", "/api/v1/kolide/tokens/test_token", nil),
+		httptest.NewRequest("GET", "/api/v1/fleet/tokens/test_token", nil),
 	)
 
 }

--- a/server/service/transport_labels_test.go
+++ b/server/service/transport_labels_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDecodeDeleteLabelRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/labels/{name}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/labels/{name}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeDeleteLabelRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -23,13 +23,13 @@ func TestDecodeDeleteLabelRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("DELETE", "/api/v1/kolide/labels/foo", nil),
+		httptest.NewRequest("DELETE", "/api/v1/fleet/labels/foo", nil),
 	)
 }
 
 func TestDecodeGetLabelRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/labels/{id}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/labels/{id}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeGetLabelRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -39,13 +39,13 @@ func TestDecodeGetLabelRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("GET", "/api/v1/kolide/labels/1", nil),
+		httptest.NewRequest("GET", "/api/v1/fleet/labels/1", nil),
 	)
 }
 
 func TestDecodeCreateLabelRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/labels", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/labels", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeCreateLabelRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -64,6 +64,6 @@ func TestDecodeCreateLabelRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("POST", "/api/v1/kolide/labels", &body),
+		httptest.NewRequest("POST", "/api/v1/fleet/labels", &body),
 	)
 }

--- a/server/service/transport_packs_test.go
+++ b/server/service/transport_packs_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestDecodeCreatePackRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/packs", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/packs", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeCreatePackRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -37,13 +37,13 @@ func TestDecodeCreatePackRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("POST", "/api/v1/kolide/packs", &body),
+		httptest.NewRequest("POST", "/api/v1/fleet/packs", &body),
 	)
 }
 
 func TestDecodeModifyPackRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/packs/{id}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/packs/{id}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeModifyPackRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -67,13 +67,13 @@ func TestDecodeModifyPackRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("PATCH", "/api/v1/kolide/packs/1", &body),
+		httptest.NewRequest("PATCH", "/api/v1/fleet/packs/1", &body),
 	)
 }
 
 func TestDecodeDeletePackRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/packs/{name}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/packs/{name}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeDeletePackRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -83,13 +83,13 @@ func TestDecodeDeletePackRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("DELETE", "/api/v1/kolide/packs/packaday", nil),
+		httptest.NewRequest("DELETE", "/api/v1/fleet/packs/packaday", nil),
 	)
 }
 
 func TestDecodeGetPackRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/packs/{id}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/packs/{id}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeGetPackRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -99,6 +99,6 @@ func TestDecodeGetPackRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("GET", "/api/v1/kolide/packs/1", nil),
+		httptest.NewRequest("GET", "/api/v1/fleet/packs/1", nil),
 	)
 }

--- a/server/service/transport_queries_test.go
+++ b/server/service/transport_queries_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDecodeCreateQueryRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/queries", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/queries", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeCreateQueryRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -30,13 +30,13 @@ func TestDecodeCreateQueryRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("POST", "/api/v1/kolide/queries", &body),
+		httptest.NewRequest("POST", "/api/v1/fleet/queries", &body),
 	)
 }
 
 func TestDecodeModifyQueryRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/queries/{id}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/queries/{id}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeModifyQueryRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -52,13 +52,13 @@ func TestDecodeModifyQueryRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("PATCH", "/api/v1/kolide/queries/1", &body),
+		httptest.NewRequest("PATCH", "/api/v1/fleet/queries/1", &body),
 	)
 }
 
 func TestDecodeDeleteQueryRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/queries/{name}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/queries/{name}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeDeleteQueryRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -68,13 +68,13 @@ func TestDecodeDeleteQueryRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("DELETE", "/api/v1/kolide/queries/qwerty", nil),
+		httptest.NewRequest("DELETE", "/api/v1/fleet/queries/qwerty", nil),
 	)
 }
 
 func TestDecodeGetQueryRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/queries/{id}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/queries/{id}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeGetQueryRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -84,6 +84,6 @@ func TestDecodeGetQueryRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("GET", "/api/v1/kolide/queries/1", nil),
+		httptest.NewRequest("GET", "/api/v1/fleet/queries/1", nil),
 	)
 }

--- a/server/service/transport_scheduled_queries_test.go
+++ b/server/service/transport_scheduled_queries_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestDecodeGetScheduledQueriesInPackRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/packs/{id}/scheduled", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/packs/{id}/scheduled", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeGetScheduledQueriesInPackRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -24,13 +24,13 @@ func TestDecodeGetScheduledQueriesInPackRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("GET", "/api/v1/kolide/packs/1/scheduled", nil),
+		httptest.NewRequest("GET", "/api/v1/fleet/packs/1/scheduled", nil),
 	)
 }
 
 func TestDecodeScheduleQueryRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/schedule", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/schedule", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeScheduleQueryRequest(context.Background(), request)
 		require.Nil(t, err)
 
@@ -51,13 +51,13 @@ func TestDecodeScheduleQueryRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("POST", "/api/v1/kolide/schedule", &body),
+		httptest.NewRequest("POST", "/api/v1/fleet/schedule", &body),
 	)
 }
 
 func TestDecodeModifyScheduledQueryRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/scheduled/{id}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/scheduled/{id}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeModifyScheduledQueryRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -82,13 +82,13 @@ func TestDecodeModifyScheduledQueryRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("PATCH", "/api/v1/kolide/scheduled/1", &body),
+		httptest.NewRequest("PATCH", "/api/v1/fleet/scheduled/1", &body),
 	)
 }
 
 func TestDecodeDeleteScheduledQueryRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/scheduled/{id}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/scheduled/{id}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeDeleteScheduledQueryRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -98,13 +98,13 @@ func TestDecodeDeleteScheduledQueryRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("DELETE", "/api/v1/kolide/scheduled/1", nil),
+		httptest.NewRequest("DELETE", "/api/v1/fleet/scheduled/1", nil),
 	)
 }
 
 func TestDecodeGetScheduledQueryRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/scheduled/{id}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/scheduled/{id}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeGetScheduledQueryRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -114,6 +114,6 @@ func TestDecodeGetScheduledQueryRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("GET", "/api/v1/kolide/scheduled/1", nil),
+		httptest.NewRequest("GET", "/api/v1/fleet/scheduled/1", nil),
 	)
 }

--- a/server/service/transport_sessions_test.go
+++ b/server/service/transport_sessions_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDecodeGetInfoAboutSessionRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/sessions/{id}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/sessions/{id}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeGetInfoAboutSessionRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -23,13 +23,13 @@ func TestDecodeGetInfoAboutSessionRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("GET", "/api/v1/kolide/sessions/1", nil),
+		httptest.NewRequest("GET", "/api/v1/fleet/sessions/1", nil),
 	)
 }
 
 func TestDecodeGetInfoAboutSessionsForUserRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/user/{id}/sessions", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/user/{id}/sessions", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeGetInfoAboutSessionsForUserRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -39,13 +39,13 @@ func TestDecodeGetInfoAboutSessionsForUserRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("GET", "/api/v1/kolide/users/1/sessions", nil),
+		httptest.NewRequest("GET", "/api/v1/fleet/users/1/sessions", nil),
 	)
 }
 
 func TestDecodeDeleteSessionRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/sessions/{id}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/sessions/{id}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeDeleteSessionRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -55,13 +55,13 @@ func TestDecodeDeleteSessionRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("DELETE", "/api/v1/kolide/sessions/1", nil),
+		httptest.NewRequest("DELETE", "/api/v1/fleet/sessions/1", nil),
 	)
 }
 
 func TestDecodeDeleteSessionsForUserRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/user/{id}/sessions", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/user/{id}/sessions", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeDeleteSessionsForUserRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -71,13 +71,13 @@ func TestDecodeDeleteSessionsForUserRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("DELETE", "/api/v1/kolide/users/1/sessions", nil),
+		httptest.NewRequest("DELETE", "/api/v1/fleet/users/1/sessions", nil),
 	)
 }
 
 func TestDecodeLoginRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/login", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/login", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeLoginRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -94,7 +94,7 @@ func TestDecodeLoginRequest(t *testing.T) {
 
 		router.ServeHTTP(
 			httptest.NewRecorder(),
-			httptest.NewRequest("POST", "/api/v1/kolide/login", &body),
+			httptest.NewRequest("POST", "/api/v1/fleet/login", &body),
 		)
 	})
 	t.Run("uppercase username", func(t *testing.T) {
@@ -106,7 +106,7 @@ func TestDecodeLoginRequest(t *testing.T) {
 
 		router.ServeHTTP(
 			httptest.NewRecorder(),
-			httptest.NewRequest("POST", "/api/v1/kolide/login", &body),
+			httptest.NewRequest("POST", "/api/v1/fleet/login", &body),
 		)
 	})
 

--- a/server/service/transport_targets_test.go
+++ b/server/service/transport_targets_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDecodeSearchTargetsRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/targets", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/targets", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeSearchTargetsRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -41,6 +41,6 @@ func TestDecodeSearchTargetsRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("POST", "/api/v1/kolide/targets", &body),
+		httptest.NewRequest("POST", "/api/v1/fleet/targets", &body),
 	)
 }

--- a/server/service/transport_users_test.go
+++ b/server/service/transport_users_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestDecodeCreateUserRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/users", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/users", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeCreateUserRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -30,13 +30,13 @@ func TestDecodeCreateUserRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("POST", "/api/v1/kolide/users", &body),
+		httptest.NewRequest("POST", "/api/v1/fleet/users", &body),
 	)
 }
 
 func TestDecodeGetUserRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/users/{id}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/users/{id}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeGetUserRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -46,13 +46,13 @@ func TestDecodeGetUserRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("GET", "/api/v1/kolide/users/1", nil),
+		httptest.NewRequest("GET", "/api/v1/fleet/users/1", nil),
 	)
 }
 
 func TestDecodeChangePasswordRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/change_password", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/change_password", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeChangePasswordRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -69,13 +69,13 @@ func TestDecodeChangePasswordRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("POST", "/api/v1/kolide/change_password", &body),
+		httptest.NewRequest("POST", "/api/v1/fleet/change_password", &body),
 	)
 }
 
 func TestDecodeResetPasswordRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/users/{id}/password", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/users/{id}/password", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeResetPasswordRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -92,13 +92,13 @@ func TestDecodeResetPasswordRequest(t *testing.T) {
 
 	router.ServeHTTP(
 		httptest.NewRecorder(),
-		httptest.NewRequest("POST", "/api/v1/kolide/users/1/password", &body),
+		httptest.NewRequest("POST", "/api/v1/fleet/users/1/password", &body),
 	)
 }
 
 func TestDecodeModifyUserRequest(t *testing.T) {
 	router := mux.NewRouter()
-	router.HandleFunc("/api/v1/kolide/users/{id}", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc("/api/v1/fleet/users/{id}", func(writer http.ResponseWriter, request *http.Request) {
 		r, err := decodeModifyUserRequest(context.Background(), request)
 		assert.Nil(t, err)
 
@@ -114,7 +114,7 @@ func TestDecodeModifyUserRequest(t *testing.T) {
         "email": "foo@kolide.co"
     }`))
 
-	request := httptest.NewRequest("PATCH", "/api/v1/kolide/users/1", &body)
+	request := httptest.NewRequest("PATCH", "/api/v1/fleet/users/1", &body)
 	router.ServeHTTP(
 		httptest.NewRecorder(),
 		request,

--- a/tools/api/kolide/me
+++ b/tools/api/kolide/me
@@ -1,4 +1,4 @@
 #!/bin/bash
 source $FLEET_ENV_PATH
-endpoint="api/v1/kolide/me"
+endpoint="api/v1/fleet/me"
 curl $CURL_FLAGS -H "Authorization: Bearer $TOKEN" "$SERVER_URL/$endpoint"

--- a/tools/api/kolide/packs/create
+++ b/tools/api/kolide/packs/create
@@ -1,6 +1,6 @@
 #!/bin/bash
 source $FLEET_ENV_PATH
-endpoint="api/v1/kolide/packs"
+endpoint="api/v1/fleet/packs"
 jq -n \
   --arg name "$1" \
   '.name = $name 

--- a/tools/api/kolide/packs/list
+++ b/tools/api/kolide/packs/list
@@ -1,4 +1,4 @@
 #!/bin/bash
 source $FLEET_ENV_PATH
-endpoint="api/v1/kolide/packs"
+endpoint="api/v1/fleet/packs"
 curl $CURL_FLAGS -H "Authorization: Bearer $TOKEN" "$SERVER_URL/$endpoint" 

--- a/tools/api/kolide/packs/scheduled
+++ b/tools/api/kolide/packs/scheduled
@@ -1,4 +1,4 @@
 #!/bin/bash
 source $FLEET_ENV_PATH
-endpoint="api/v1/kolide/packs/$1/scheduled"
+endpoint="api/v1/fleet/packs/$1/scheduled"
 curl $CURL_FLAGS -H "Authorization: Bearer $TOKEN" "$SERVER_URL/$endpoint" 

--- a/tools/api/kolide/queries/create
+++ b/tools/api/kolide/queries/create
@@ -1,6 +1,6 @@
 #!/bin/bash
 source $FLEET_ENV_PATH
-endpoint="api/v1/kolide/queries"
+endpoint="api/v1/fleet/queries"
 jq -n \
   --arg name "$1" \
   --arg query "$2" \

--- a/tools/api/kolide/queries/list
+++ b/tools/api/kolide/queries/list
@@ -1,4 +1,4 @@
 #!/bin/bash
 source $FLEET_ENV_PATH
-endpoint="api/v1/kolide/queries"
+endpoint="api/v1/fleet/queries"
 curl $CURL_FLAGS -H "Authorization: Bearer $TOKEN" "$SERVER_URL/$endpoint" 

--- a/tools/api/kolide/schedule/add_query_to_pack
+++ b/tools/api/kolide/schedule/add_query_to_pack
@@ -1,6 +1,6 @@
 #!/bin/bash
 source $FLEET_ENV_PATH
-endpoint="api/v1/kolide/schedule"
+endpoint="api/v1/fleet/schedule"
 jq -n \
   --arg pack_id "$1" \
   --arg query_id "$2" \

--- a/tools/api/kolide/schedule/delete_scheduled_query
+++ b/tools/api/kolide/schedule/delete_scheduled_query
@@ -1,4 +1,4 @@
 #!/bin/bash
 source $FLEET_ENV_PATH
-endpoint="api/v1/kolide/schedule/$1"
+endpoint="api/v1/fleet/schedule/$1"
 curl $CURL_FLAGS -X DELETE -H "Authorization: Bearer $TOKEN" "$SERVER_URL/$endpoint"

--- a/tools/app/authtest.html
+++ b/tools/app/authtest.html
@@ -28,7 +28,7 @@
           console.log("user should be authenticated, fetching user with token " + sessionToken);
           $.ajax({
             type: "GET",
-            url: "https://localhost:8080/api/v1/kolide/me",
+            url: "https://localhost:8080/api/v1/fleet/me",
             headers: {"Authorization": "Bearer " + sessionToken},
             contentType: "text/plain;",
             dataType: "json",
@@ -62,7 +62,7 @@
 
             $.ajax({
               type: "POST",
-              url: "https://localhost:8080/api/v1/kolide/sso",
+              url: "https://localhost:8080/api/v1/fleet/sso",
               data: JSON.stringify(
                 {
                   // supply the url of the resource user was trying to access when


### PR DESCRIPTION
- Support both /api/v1/fleet and /api/v1/kolide routes in server.
- Add logging for use of deprecated routes.
- Rename routes in frontend JS.
- Rename routes and add notes in documentation.