### PR TITLE
Deprecate environment variable prefix

### DIFF
--- a/.github/workflows/pr-helm.yaml
+++ b/.github/workflows/pr-helm.yaml
@@ -60,29 +60,29 @@ jobs:
       run: |
         .github/scripts/helm-check-expected.sh \
         "helm-temp/output-defaults.yaml" \
-        'KOLIDE_FILESYSTEM_STATUS_LOG_FILE KOLIDE_FILESYSTEM_RESULT_LOG_FILE KOLIDE_FILESYSTEM_ENABLE_LOG_ROTATION KOLIDE_FILESYSTEM_ENABLE_LOG_COMPRESSION' \
+        'FLEET_FILESYSTEM_STATUS_LOG_FILE FLEET_FILESYSTEM_RESULT_LOG_FILE FLEET_FILESYSTEM_ENABLE_LOG_ROTATION FLEET_FILESYSTEM_ENABLE_LOG_COMPRESSION' \
         'fleet-tls osquery-logs'
     - name: check pubusb values
       run: |
         .github/scripts/helm-check-expected.sh \
         "helm-temp/logger-pubsub.yaml" \
-        'KOLIDE_PUBSUB_PROJECT KOLIDE_PUBSUB_STATUS_TOPIC KOLIDE_PUBSUB_RESULT_TOPIC' \
+        'FLEET_PUBSUB_PROJECT FLEET_PUBSUB_STATUS_TOPIC FLEET_PUBSUB_RESULT_TOPIC' \
         'fleet-tls'
     - name: check firehose accesskey values
       run: |
         .github/scripts/helm-check-expected.sh \
         "helm-temp/logger-firehose-accesssid.yaml" \
-        'KOLIDE_FIREHOSE_REGION KOLIDE_FIREHOSE_STATUS_STREAM KOLIDE_FIREHOSE_RESULT_STREAM KOLIDE_FIREHOSE_ACCESS_KEY_ID KOLIDE_FIREHOSE_SECRET_ACCESS_KEY' \
+        'FLEET_FIREHOSE_REGION FLEET_FIREHOSE_STATUS_STREAM FLEET_FIREHOSE_RESULT_STREAM FLEET_FIREHOSE_ACCESS_KEY_ID FLEET_FIREHOSE_SECRET_ACCESS_KEY' \
         'fleet-tls'
     - name: check firehose sts values
       run: |
         .github/scripts/helm-check-expected.sh \
         "helm-temp/logger-firehose-sts.yaml" \
-        'KOLIDE_FIREHOSE_REGION KOLIDE_FIREHOSE_STATUS_STREAM KOLIDE_FIREHOSE_RESULT_STREAM KOLIDE_FIREHOSE_STS_ASSUME_ROLE_ARN' \
+        'FLEET_FIREHOSE_REGION FLEET_FIREHOSE_STATUS_STREAM FLEET_FIREHOSE_RESULT_STREAM FLEET_FIREHOSE_STS_ASSUME_ROLE_ARN' \
         'fleet-tls'
     - name: check mysql tls enabled values
       run: |
         .github/scripts/helm-check-expected.sh \
         "helm-temp/enable-mysql-tls.yaml" \
-        'KOLIDE_MYSQL_TLS_CA KOLIDE_MYSQL_TLS_CERT KOLIDE_MYSQL_TLS_KEY KOLIDE_MYSQL_TLS_CONFIG KOLIDE_MYSQL_TLS_SERVER_NAME' \
+        'FLEET_MYSQL_TLS_CA FLEET_MYSQL_TLS_CERT FLEET_MYSQL_TLS_KEY FLEET_MYSQL_TLS_CONFIG FLEET_MYSQL_TLS_SERVER_NAME' \
         'fleet-tls osquery-logs mysql-tls'

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -65,98 +65,98 @@ spec:
             memory: {{ .Values.resources.requests.memory }}
         env:
           ## BEGIN FLEET SECTION
-          - name: KOLIDE_SERVER_ADDRESS
+          - name: FLEET_SERVER_ADDRESS
             value: "0.0.0.0:{{ .Values.fleet.listenPort }}"
-          - name: KOLIDE_AUTH_BCRYPT_COST
+          - name: FLEET_AUTH_BCRYPT_COST
             value: "{{ .Values.fleet.auth.bcryptCost }}"
-          - name: KOLIDE_AUTH_SALT_KEY_SIZE
+          - name: FLEET_AUTH_SALT_KEY_SIZE
             value: "{{ .Values.fleet.auth.saltKeySize }}"
-          - name: KOLIDE_AUTH_JWT_KEY
+          - name: FLEET_AUTH_JWT_KEY
             valueFrom:
               secretKeyRef:
                 name: "{{ .Values.fleet.secretName }}"
                 key: "{{ .Values.fleet.auth.jwtSecretKey }}"
-          - name: KOLIDE_APP_TOKEN_KEY_SIZE
+          - name: FLEET_APP_TOKEN_KEY_SIZE
             value: "{{ .Values.fleet.app.tokenKeySize }}"
-          - name: KOLIDE_APP_TOKEN_VALIDITY_PERIOD
+          - name: FLEET_APP_TOKEN_VALIDITY_PERIOD
             value: "{{ .Values.fleet.app.inviteTokenValidityPeriod }}"
-          - name: KOLIDE_SESSION_KEY_SIZE
+          - name: FLEET_SESSION_KEY_SIZE
             value: "{{ .Values.fleet.session.keySize }}"
-          - name: KOLIDE_SESSION_DURATION
+          - name: FLEET_SESSION_DURATION
             value: "{{ .Values.fleet.session.duration }}"
-          - name: KOLIDE_LOGGING_DEBUG
+          - name: FLEET_LOGGING_DEBUG
             value: "{{ .Values.fleet.logging.debug }}"
-          - name: KOLIDE_LOGGING_JSON
+          - name: FLEET_LOGGING_JSON
             value: "{{ .Values.fleet.logging.json }}"
-          - name: KOLIDE_LOGGING_DISABLE_BANNER
+          - name: FLEET_LOGGING_DISABLE_BANNER
             value: "{{ .Values.fleet.logging.disableBanner }}"
-          - name: KOLIDE_SERVER_TLS
+          - name: FLEET_SERVER_TLS
             value: "{{ .Values.fleet.tls.enabled }}"
           {{- if .Values.fleet.tls.enabled }}
-          - name: KOLIDE_SERVER_TLS_COMPATIBILITY
+          - name: FLEET_SERVER_TLS_COMPATIBILITY
             value: "{{ .Values.fleet.tls.compatibility }}"
-          - name: KOLIDE_SERVER_CERT
+          - name: FLEET_SERVER_CERT
             value: "/secrets/tls/{{ .Values.fleet.tls.certSecretKey }}"
-          - name: KOLIDE_SERVER_KEY
+          - name: FLEET_SERVER_KEY
             value: "/secrets/tls/{{ .Values.fleet.tls.keySecretKey }}"
           {{- end }}
           {{- if ne .Values.fleet.carving.s3.bucketName "" }}
-          - name: KOLIDE_S3_BUCKET
+          - name: FLEET_S3_BUCKET
             value: "{{ .Values.fleet.carving.s3.bucketName }}"
-          - name: KOLIDE_S3_PREFIX
+          - name: FLEET_S3_PREFIX
             value: "{{ .Values.fleet.carving.s3.prefix }}"
           {{- if ne .Values.fleet.carving.s3.accessKeyID "" }}
-          - name: KOLIDE_S3_ACCESS_KEY_ID
+          - name: FLEET_S3_ACCESS_KEY_ID
             value: "{{ .Values.fleet.carving.s3.accessKeyID }}"
-          - name: KOLIDE_S3_SECRET_ACCESS_KEY
+          - name: FLEET_S3_SECRET_ACCESS_KEY
             valueFrom:
               secretKeyRef:
                 name: "{{ .Values.fleet.secretName }}"
                 key: "{{ .Values.fleet.carving.s3.secretKey }}"
           {{ else }}
-          - name: KOLIDE_S3_STS_ASSUME_ROLE_ARN
+          - name: FLEET_S3_STS_ASSUME_ROLE_ARN
             value: "{{ .Values.fleet.carving.s3.stsAssumeRoleARN }}"
           {{- end }}
           {{- end }}
           ## END FLEET SECTION
           ## BEGIN MYSQL SECTION
-          - name: KOLIDE_MYSQL_ADDRESS
+          - name: FLEET_MYSQL_ADDRESS
             value: "{{ .Values.mysql.address }}"
-          - name: KOLIDE_MYSQL_DATABASE
+          - name: FLEET_MYSQL_DATABASE
             value: "{{ .Values.mysql.database }}"
-          - name: KOLIDE_MYSQL_USERNAME
+          - name: FLEET_MYSQL_USERNAME
             value: "{{ .Values.mysql.username }}"
-          - name: KOLIDE_MYSQL_PASSWORD
+          - name: FLEET_MYSQL_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: {{ .Values.mysql.secretName }}
                 key: {{ .Values.mysql.passwordKey }}
-          - name: KOLIDE_MYSQL_MAX_OPEN_CONNS
+          - name: FLEET_MYSQL_MAX_OPEN_CONNS
             value: "{{ .Values.mysql.maxOpenConns }}"
-          - name: KOLIDE_MYSQL_MAX_IDLE_CONNS
+          - name: FLEET_MYSQL_MAX_IDLE_CONNS
             value: "{{ .Values.mysql.maxIdleConns }}"
-          - name: KOLIDE_MYSQL_CONN_MAX_LIFETIME
+          - name: FLEET_MYSQL_CONN_MAX_LIFETIME
             value: "{{ .Values.mysql.connMaxLifetime }}"
           {{- if .Values.mysql.tls.enabled }}
-          - name: KOLIDE_MYSQL_TLS_CA
+          - name: FLEET_MYSQL_TLS_CA
             value: "/secrets/mysql/{{ .Values.mysql.tls.caCertKey }}"
-          - name: KOLIDE_MYSQL_TLS_CERT
+          - name: FLEET_MYSQL_TLS_CERT
             value: "/secrets/mysql/{{ .Values.mysql.tls.certKey }}"
-          - name: KOLIDE_MYSQL_TLS_KEY
+          - name: FLEET_MYSQL_TLS_KEY
             value: "/secrets/mysql/{{ .Values.mysql.tls.keyKey }}"
-          - name: KOLIDE_MYSQL_TLS_CONFIG
+          - name: FLEET_MYSQL_TLS_CONFIG
             value: "{{ .Values.mysql.tls.config }}"
-          - name: KOLIDE_MYSQL_TLS_SERVER_NAME
+          - name: FLEET_MYSQL_TLS_SERVER_NAME
             value: "{{ .Values.mysql.tls.serverName }}"
           {{- end }}
           ## END MYSQL SECTION
           ## BEGIN REDIS SECTION
-          - name: KOLIDE_REDIS_ADDRESS
+          - name: FLEET_REDIS_ADDRESS
             value: "{{ .Values.redis.address }}"
-          - name: KOLIDE_REDIS_DATABASE
+          - name: FLEET_REDIS_DATABASE
             value: "{{ .Values.redis.database }}"
           {{- if .Values.redis.usePassword }}
-          - name: KOLIDE_REDIS_PASSWORD
+          - name: FLEET_REDIS_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: "{{ .Values.redis.secretName }}"
@@ -164,90 +164,90 @@ spec:
           {{- end }}
           ## END REDIS SECTION
           ## BEGIN OSQUERY SECTION
-          - name: KOLIDE_OSQUERY_NODE_KEY_SIZE
+          - name: FLEET_OSQUERY_NODE_KEY_SIZE
             value: "{{ .Values.osquery.nodeKeySize }}"
-          - name: KOLIDE_OSQUERY_LABEL_UPDATE_INTERVAL
+          - name: FLEET_OSQUERY_LABEL_UPDATE_INTERVAL
             value: "{{ .Values.osquery.labelUpdateInterval }}"
-          - name: KOLIDE_OSQUERY_DETAIL_UPDATE_INTERVAL
+          - name: FLEET_OSQUERY_DETAIL_UPDATE_INTERVAL
             value: "{{ .Values.osquery.detailUpdateInterval }}"
-          - name: KOLIDE_OSQUERY_STATUS_LOG_PLUGIN
+          - name: FLEET_OSQUERY_STATUS_LOG_PLUGIN
             value: "{{ .Values.osquery.logging.statusPlugin }}"
-          - name: KOLIDE_OSQUERY_RESULT_LOG_PLUGIN
+          - name: FLEET_OSQUERY_RESULT_LOG_PLUGIN
             value: "{{ .Values.osquery.logging.resultPlugin }}"
           {{- if eq .Values.osquery.logging.statusPlugin "filesystem" }}
-          - name: KOLIDE_FILESYSTEM_STATUS_LOG_FILE
+          - name: FLEET_FILESYSTEM_STATUS_LOG_FILE
             value: "/logs/{{ .Values.osquery.logging.filesystem.statusLogFile }}"
           {{- end }}
           {{- if eq .Values.osquery.logging.resultPlugin "filesystem" }}
-          - name: KOLIDE_FILESYSTEM_RESULT_LOG_FILE
+          - name: FLEET_FILESYSTEM_RESULT_LOG_FILE
             value: "/logs/{{ .Values.osquery.logging.filesystem.resultLogFile }}"
           {{- end }}
           {{- if or (eq .Values.osquery.logging.statusPlugin "filesystem") (eq .Values.osquery.logging.resultPlugin "filesystem") }}
-          - name: KOLIDE_FILESYSTEM_ENABLE_LOG_ROTATION
+          - name: FLEET_FILESYSTEM_ENABLE_LOG_ROTATION
             value: "{{ .Values.osquery.logging.filesystem.enableRotation }}"
-          - name: KOLIDE_FILESYSTEM_ENABLE_LOG_COMPRESSION
+          - name: FLEET_FILESYSTEM_ENABLE_LOG_COMPRESSION
             value: "{{ .Values.osquery.logging.filesystem.enableCompression }}"
           {{- end }}
           {{- if or (eq .Values.osquery.logging.statusPlugin "firehose") (eq .Values.osquery.logging.resultPlugin "firehose") }}
-          - name: KOLIDE_FIREHOSE_REGION
+          - name: FLEET_FIREHOSE_REGION
             value: "{{ .Values.osquery.logging.firehose.region }}"
           {{- if eq .Values.osquery.logging.statusPlugin "firehose" }}
-          - name: KOLIDE_FIREHOSE_STATUS_STREAM
+          - name: FLEET_FIREHOSE_STATUS_STREAM
             value: "{{ .Values.osquery.logging.firehose.statusStream }}"
           {{- end }}
           {{- if eq .Values.osquery.logging.resultPlugin "firehose" }}
-          - name: KOLIDE_FIREHOSE_RESULT_STREAM
+          - name: FLEET_FIREHOSE_RESULT_STREAM
             value: "{{ .Values.osquery.logging.firehose.resultStream }}"
           {{- end }}
           {{- if ne .Values.osquery.logging.firehose.accessKeyID "" }}
-          - name: KOLIDE_FIREHOSE_ACCESS_KEY_ID
+          - name: FLEET_FIREHOSE_ACCESS_KEY_ID
             value: "{{ .Values.osquery.logging.firehose.accessKeyID }}"
-          - name: KOLIDE_FIREHOSE_SECRET_ACCESS_KEY
+          - name: FLEET_FIREHOSE_SECRET_ACCESS_KEY
             valueFrom:
               secretKeyRef:
                 name: "{{ .Values.osquery.secretName }}"
                 key: "{{ .Values.osquery.logging.firehose.secretKey }}"
           {{ else }}
-          - name: KOLIDE_FIREHOSE_STS_ASSUME_ROLE_ARN
+          - name: FLEET_FIREHOSE_STS_ASSUME_ROLE_ARN
             value: "{{ .Values.osquery.logging.firehose.stsAssumeRoleARN }}"
           {{- end }}
           {{- end }}
 
           {{- if or (eq .Values.osquery.logging.statusPlugin "kinesis") (eq .Values.osquery.logging.resultPlugin "kinesis") }}
-          - name: KOLIDE_KINESIS_REGION
+          - name: FLEET_KINESIS_REGION
             value: "{{ .Values.osquery.logging.kinesis.region }}"
           {{- if eq .Values.osquery.logging.statusPlugin "kinesis" }}
-          - name: KOLIDE_KINESIS_STATUS_STREAM
+          - name: FLEET_KINESIS_STATUS_STREAM
             value: "{{ .Values.osquery.logging.kinesis.statusStream }}"
           {{- end }}
           {{- if eq .Values.osquery.logging.resultPlugin "kinesis" }}
-          - name: KOLIDE_KINESIS_RESULT_STREAM
+          - name: FLEET_KINESIS_RESULT_STREAM
             value: "{{ .Values.osquery.logging.kinesis.resultStream }}"
           {{- end }}
           {{- if ne .Values.osquery.logging.kinesis.accessKeyID "" }}
-          - name: KOLIDE_KINESIS_ACCESS_KEY_ID
+          - name: FLEET_KINESIS_ACCESS_KEY_ID
             value: "{{ .Values.osquery.logging.kinesis.accessKeyID }}"
-          - name: KOLIDE_KINESIS_SECRET_ACCESS_KEY
+          - name: FLEET_KINESIS_SECRET_ACCESS_KEY
             valueFrom:
               secretKeyRef:
                 name: "{{ .Values.osquery.secretName }}"
                 key: "{{ .Values.osquery.logging.kinesis.secretKey }}"
           {{ else }}
-          - name: KOLIDE_KINESIS_STS_ASSUME_ROLE_ARN
+          - name: FLEET_KINESIS_STS_ASSUME_ROLE_ARN
             value: "{{ .Values.osquery.logging.kinesis.stsAssumeRoleARN }}"
           {{- end }}
           {{- end }}
 
           {{- if or (eq .Values.osquery.logging.statusPlugin "pubsub") (eq .Values.osquery.logging.resultPlugin "pubsub") }}
-          - name: KOLIDE_PUBSUB_PROJECT
+          - name: FLEET_PUBSUB_PROJECT
             value: "{{ .Values.osquery.logging.pubsub.project }}"
           {{- end }}
           {{- if eq .Values.osquery.logging.statusPlugin "pubsub" }}
-          - name: KOLIDE_PUBSUB_STATUS_TOPIC
+          - name: FLEET_PUBSUB_STATUS_TOPIC
             value: "{{ .Values.osquery.logging.pubsub.statusTopic }}"
           {{- end }}
           {{- if eq .Values.osquery.logging.resultPlugin "pubsub" }}
-          - name: KOLIDE_PUBSUB_RESULT_TOPIC
+          - name: FLEET_PUBSUB_RESULT_TOPIC
             value: "{{ .Values.osquery.logging.pubsub.resultTopic }}"
           {{- end }}
           ## END OSQUERY SECTION

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -294,11 +294,11 @@ the way that the Fleet server works.
 			rootMux.Handle("/", frontendHandler)
 			rootMux.Handle("/debug/", service.MakeDebugHandler(svc, config, logger))
 
-			if path, ok := os.LookupEnv("KOLIDE_TEST_PAGE_PATH"); ok {
+			if path, ok := os.LookupEnv("FLEET_TEST_PAGE_PATH"); ok {
 				// test that we can load this
 				_, err := ioutil.ReadFile(path)
 				if err != nil {
-					initFatal(err, "loading KOLIDE_TEST_PAGE_PATH")
+					initFatal(err, "loading FLEET_TEST_PAGE_PATH")
 				}
 				rootMux.HandleFunc("/test", func(rw http.ResponseWriter, req *http.Request) {
 					testPage, err := ioutil.ReadFile(path)

--- a/docs/2-Deployment/2-Configuration.md
+++ b/docs/2-Deployment/2-Configuration.md
@@ -54,6 +54,8 @@ In order of precedence, options can be specified via:
 - Environment variables
 - Command-line flags
 
+Note: We have deprecated `KOLIDE_` environment variables and will remove them in the Fleet 4.0 release. Please migrate all environment variables to `FLEET_`.
+
 For example, all of the following ways of launching Fleet are equivalent:
 
 ##### Using only CLI flags
@@ -74,15 +76,15 @@ For example, all of the following ways of launching Fleet are equivalent:
 ##### Using only environment variables
 
 ```
-KOLIDE_MYSQL_ADDRESS=127.0.0.1:3306 \
-KOLIDE_MYSQL_DATABASE=kolide \
-KOLIDE_MYSQL_USERNAME=root \
-KOLIDE_MYSQL_PASSWORD=toor \
-KOLIDE_REDIS_ADDRESS=127.0.0.1:6379 \
-KOLIDE_SERVER_CERT=/tmp/server.cert \
-KOLIDE_SERVER_KEY=/tmp/server.key \
-KOLIDE_LOGGING_JSON=true \
-KOLIDE_AUTH_JWT_KEY=changeme \
+FLEET_MYSQL_ADDRESS=127.0.0.1:3306 \
+FLEET_MYSQL_DATABASE=kolide \
+FLEET_MYSQL_USERNAME=root \
+FLEET_MYSQL_PASSWORD=toor \
+FLEET_REDIS_ADDRESS=127.0.0.1:6379 \
+FLEET_SERVER_CERT=/tmp/server.cert \
+FLEET_SERVER_KEY=/tmp/server.key \
+FLEET_LOGGING_JSON=true \
+FLEET_AUTH_JWT_KEY=changeme \
 /usr/bin/fleet serve
 ```
 
@@ -110,7 +112,7 @@ fleet serve --config /tmp/kolide.yml
 
 #### What are the options?
 
-Note that all option names can be converted consistently from flag name to environment variable and visa-versa. For example, the `--mysql_address` flag would be the `KOLIDE_MYSQL_ADDRESS`. Further, specifying the `mysql_address` option in the config would follow the pattern:
+Note that all option names can be converted consistently from flag name to environment variable and visa-versa. For example, the `--mysql_address` flag would be the `FLEET_MYSQL_ADDRESS`. Further, specifying the `mysql_address` option in the config would follow the pattern:
 
 ```
 mysql:
@@ -118,7 +120,7 @@ mysql:
 ```
 
 
-Basically, just capitalize the option and prepend `KOLIDE_` to it in order to get the environment variable. The conversion works the same the opposite way.
+Basically, just capitalize the option and prepend `FLEET_` to it in order to get the environment variable. The conversion works the same the opposite way.
 
 ##### MySQL
 
@@ -127,7 +129,7 @@ Basically, just capitalize the option and prepend `KOLIDE_` to it in order to ge
 The address of the MySQL server which Fleet should connect to. Include the hostname and port.
 
 - Default value: `localhost:3306`
-- Environment variable: `KOLIDE_MYSQL_ADDRESS`
+- Environment variable: `FLEET_MYSQL_ADDRESS`
 - Config file format:
 
 	```
@@ -140,7 +142,7 @@ The address of the MySQL server which Fleet should connect to. Include the hostn
 The name of the MySQL database which Fleet will use.
 
 - Default value: `kolide`
-- Environment variable: `KOLIDE_MYSQL_DATABASE`
+- Environment variable: `FLEET_MYSQL_DATABASE`
 - Config file format:
 
 	```
@@ -153,7 +155,7 @@ The name of the MySQL database which Fleet will use.
 The username to use when connecting to the MySQL instance.
 
 - Default value: `kolide`
-- Environment variable: `KOLIDE_MYSQL_USERNAME`
+- Environment variable: `FLEET_MYSQL_USERNAME`
 - Config file format:
 
 	```
@@ -166,7 +168,7 @@ The username to use when connecting to the MySQL instance.
 The password to use when connecting to the MySQL instance.
 
 - Default value: `kolide`
-- Environment variable: `KOLIDE_MYSQL_PASSWORD`
+- Environment variable: `FLEET_MYSQL_PASSWORD`
 - Config file format:
 
 	```
@@ -192,7 +194,7 @@ File path to a file that contains the password to use when connecting to the MyS
 The path to a PEM encoded certificate of MYSQL's CA for client certificate authentication.
 
 - Default value: none
-- Environment variable: `KOLIDE_MYSQL_TLS_CA`
+- Environment variable: `FLEET_MYSQL_TLS_CA`
 - Config file format:
 
 	```
@@ -205,7 +207,7 @@ The path to a PEM encoded certificate of MYSQL's CA for client certificate authe
 The path to a PEM encoded certificate use for tls authentication.
 
 - Default value: none
-- Environment variable: `KOLIDE_MYSQL_TLS_CERT`
+- Environment variable: `FLEET_MYSQL_TLS_CERT`
 - Config file format:
 
 	```
@@ -218,7 +220,7 @@ The path to a PEM encoded certificate use for tls authentication.
 The path to a PEM encoded private key use for tls authentication.
 
 - Default value: none
-- Environment variable: `KOLIDE_MYSQL_TLS_KEY`
+- Environment variable: `FLEET_MYSQL_TLS_KEY`
 - Config file format:
 
 	```
@@ -231,7 +233,7 @@ The path to a PEM encoded private key use for tls authentication.
 The tls value in a MYSQL DSN. Can be `true`,`false`,`skip-verify` or the CN value of the certificate.
 
 - Default value: none
-- Environment variable: `KOLIDE_MYSQL_TLS_CONFIG`
+- Environment variable: `FLEET_MYSQL_TLS_CONFIG`
 - Config file format:
 
 	```
@@ -244,7 +246,7 @@ The tls value in a MYSQL DSN. Can be `true`,`false`,`skip-verify` or the CN valu
 The server name or IP address used by the client certificate.
 
 - Default value: none
-- Environment variable: `KOLIDE_MYSQL_TLS_SERVER_NAME`
+- Environment variable: `FLEET_MYSQL_TLS_SERVER_NAME`
 - Config file format:
 
 	```
@@ -257,7 +259,7 @@ The server name or IP address used by the client certificate.
 Maximum open connections to database
 
 - Default value: 50
-- Environment variable: `KOLIDE_MYSQL_MAX_OPEN_CONNS`
+- Environment variable: `FLEET_MYSQL_MAX_OPEN_CONNS`
 - Config file format:
 
 	```
@@ -270,7 +272,7 @@ Maximum open connections to database
 Maximum idle connections to database. This value should be equal to or less than `mysql_max_open_conns`
 
 - Default value: 50
-- Environment variable: `KOLIDE_MYSQL_MAX_IDLE_CONNS`
+- Environment variable: `FLEET_MYSQL_MAX_IDLE_CONNS`
 - Config file format:
 
 	```
@@ -283,7 +285,7 @@ Maximum idle connections to database. This value should be equal to or less than
 Maximum amount of time, in seconds, a connection may be reused.
 
 - Default value: 0 (Unlimited)
-- Environment variable: `KOLIDE_MYSQL_CONN_MAX_LIFETIME`
+- Environment variable: `FLEET_MYSQL_CONN_MAX_LIFETIME`
 - Config file format:
 
 	```
@@ -298,7 +300,7 @@ Maximum amount of time, in seconds, a connection may be reused.
 The address of the Redis server which Fleet should connect to. Include the hostname and port.
 
 - Default value: `localhost:6379`
-- Environment variable: `KOLIDE_REDIS_ADDRESS`
+- Environment variable: `FLEET_REDIS_ADDRESS`
 - Config file format:
 
 	```
@@ -311,7 +313,7 @@ The address of the Redis server which Fleet should connect to. Include the hostn
 The password to use when connecting to the Redis instance.
 
 - Default value: `<empty>`
-- Environment variable: `KOLIDE_REDIS_PASSWORD`
+- Environment variable: `FLEET_REDIS_PASSWORD`
 - Config file format:
 
 	```
@@ -323,7 +325,7 @@ The password to use when connecting to the Redis instance.
 The database to use when connecting to the Redis instance.
 
 - Default value: `0`
-- Environment variable: `KOLIDE_REDIS_DATABASE`
+- Environment variable: `FLEET_REDIS_DATABASE`
 - Config file format:
 
   ```
@@ -338,7 +340,7 @@ The database to use when connecting to the Redis instance.
 The address to serve the Fleet webserver.
 
 - Default value: `0.0.0.0:8080`
-- Environment variable: `KOLIDE_SERVER_ADDRESS`
+- Environment variable: `FLEET_SERVER_ADDRESS`
 - Config file format:
 
 	```
@@ -351,7 +353,7 @@ The address to serve the Fleet webserver.
 The TLS cert to use when terminating TLS.
 
 - Default value: `./tools/osquery/kolide.crt`
-- Environment variable: `KOLIDE_SERVER_CERT`
+- Environment variable: `FLEET_SERVER_CERT`
 - Config file format:
 
 	```
@@ -365,7 +367,7 @@ The TLS cert to use when terminating TLS.
 The TLS key to use when terminating TLS.
 
 - Default value: `./tools/osquery/kolide.key`
-- Environment variable: `KOLIDE_SERVER_KEY`
+- Environment variable: `FLEET_SERVER_KEY`
 - Config file format:
 
 	```
@@ -379,7 +381,7 @@ The TLS key to use when terminating TLS.
 Whether or not the server should be served over TLS.
 
 - Default value: `true`
-- Environment variable: `KOLIDE_SERVER_TLS`
+- Environment variable: `FLEET_SERVER_TLS`
 - Config file format:
 
 	```
@@ -392,7 +394,7 @@ Whether or not the server should be served over TLS.
 Configures the TLS settings for compatibility with various user agents. Options are `modern` and `intermediate`. These correspond to the compatibility levels [defined by the Mozilla OpSec team](https://wiki.mozilla.org/index.php?title=Security/Server_Side_TLS&oldid=1229478) (updated July 24, 2020).
 
 - Default value: `intermediate`
-- Environment variable: `KOLIDE_SERVER_TLS_COMPATIBILITY`
+- Environment variable: `FLEET_SERVER_TLS_COMPATIBILITY`
 - Config file format:
 
 	```
@@ -409,7 +411,7 @@ Sets a URL prefix to use when serving the Fleet API and frontend. Prefixes shoul
 Note that some other configurations may need to be changed when modifying the URL prefix. In particular, URLs that are provided to osquery via flagfile, the configuration served by Fleet, the URL prefix used by `fleetctl`, and the redirect URL set with an SSO Identity Provider.
 
 - Default value: Empty (no prefix set)
-- Environment variable: `KOLIDE_SERVER_URL_PREFIX`
+- Environment variable: `FLEET_SERVER_URL_PREFIX`
 - Config file format:
 
 	```
@@ -425,7 +427,7 @@ Note that some other configurations may need to be changed when modifying the UR
 The [JWT](https://jwt.io/) key to use when signing and validating session keys. If this value is not specified the Fleet server will fail to start and a randomly generated key will be provided for use.
 
 - Default value: None
-- Environment variable: `KOLIDE_AUTH_JWT_KEY`
+- Environment variable: `FLEET_AUTH_JWT_KEY`
 - Config file format:
 
 	```
@@ -450,7 +452,7 @@ File path to a file that contains the [JWT](https://jwt.io/) key to use when sig
 The bcrypt cost to use when hashing user passwords.
 
 - Default value: `12`
-- Environment variable:	`KOLIDE_AUTH_BCRYT_COST`
+- Environment variable:	`FLEET_AUTH_BCRYT_COST`
 - Config file format:
 
 	```
@@ -463,7 +465,7 @@ The bcrypt cost to use when hashing user passwords.
 The key size of the salt which is generated when hashing user passwords.
 
 - Default value: `24`
-- Environment variable: `KOLIDE_AUTH_SALT_KEY_SIZE`
+- Environment variable: `FLEET_AUTH_SALT_KEY_SIZE`
 - Config file format:
 
 	```
@@ -478,7 +480,7 @@ The key size of the salt which is generated when hashing user passwords.
 Size of generated app tokens.
 
 - Default value: `24`
-- Environment variable: `KOLIDE_APP_TOKEN_KEY_SIZE`
+- Environment variable: `FLEET_APP_TOKEN_KEY_SIZE`
 - Config file format:
 
 	```
@@ -491,7 +493,7 @@ Size of generated app tokens.
 How long invite tokens should be valid for.
 
 - Default value: `5 days`
-- Environment variable: `KOLIDE_APP_TOKEN_VALIDITY_PERIOD`
+- Environment variable: `FLEET_APP_TOKEN_VALIDITY_PERIOD`
 - Config file format:
 
 	```
@@ -506,7 +508,7 @@ How long invite tokens should be valid for.
 The size of the session key.
 
 - Default value: `64`
-- Environment variable: `KOLIDE_SESSION_KEY_SIZE`
+- Environment variable: `FLEET_SESSION_KEY_SIZE`
 - Config file format:
 
 	```
@@ -519,7 +521,7 @@ The size of the session key.
 The amount of time that a session should last for.
 
 - Default value: `90 days`
-- Environment variable: `KOLIDE_SESSION_DURATION`
+- Environment variable: `FLEET_SESSION_DURATION`
 - Config file format:
 
 	```
@@ -534,7 +536,7 @@ The amount of time that a session should last for.
 The size of the node key which is negotiated with `osqueryd` clients.
 
 - Default value: `24`
-- Environment variable:	`KOLIDE_OSQUERY_NODE_KEY_SIZE`
+- Environment variable:	`FLEET_OSQUERY_NODE_KEY_SIZE`
 - Config file format:
 
 	```
@@ -550,7 +552,7 @@ The interval at which Fleet will ask osquery agents to update their results for 
 Setting this to a higher value can reduce baseline load on the Fleet server in larger deployments.
 
 - Default value: `1h`
-- Environment variable: `KOLIDE_OSQUERY_LABEL_UPDATE_INTERVAL`
+- Environment variable: `FLEET_OSQUERY_LABEL_UPDATE_INTERVAL`
 - Config file format:
 
 	```
@@ -565,7 +567,7 @@ The interval at which Fleet will ask osquery agents to update host details (such
 Setting this to a higher value can reduce baseline load on the Fleet server in larger deployments.
 
 - Default value: `1h`
-- Environment variable: `KOLIDE_OSQUERY_DETAIL_UPDATE_INTERVAL`
+- Environment variable: `FLEET_OSQUERY_DETAIL_UPDATE_INTERVAL`
 - Config file format:
 
 	```
@@ -580,7 +582,7 @@ Which log output plugin should be used for osquery status logs received from cli
 Options are `filesystem`, `firehose`, `kinesis`, `pubsub`, and `stdout`.
 
 - Default value: `filesystem`
-- Environment variable: `KOLIDE_OSQUERY_STATUS_LOG_PLUGIN`
+- Environment variable: `FLEET_OSQUERY_STATUS_LOG_PLUGIN`
 - Config file format:
 
 	```
@@ -595,7 +597,7 @@ Which log output plugin should be used for osquery result logs received from cli
 Options are `filesystem`, `firehose`, `kinesis`, `pubsub`, and `stdout`.
 
 - Default value: `filesystem`
-- Environment variable: `KOLIDE_OSQUERY_RESULT_LOG_PLUGIN`
+- Environment variable: `FLEET_OSQUERY_RESULT_LOG_PLUGIN`
 - Config file format:
 
 	```
@@ -610,7 +612,7 @@ DEPRECATED: Use filesystem_status_log_file.
 The path which osquery status logs will be logged to.
 
 - Default value: `/tmp/osquery_status`
-- Environment variable: `KOLIDE_OSQUERY_STATUS_LOG_FILE`
+- Environment variable: `FLEET_OSQUERY_STATUS_LOG_FILE`
 - Config file format:
 
 	```
@@ -625,7 +627,7 @@ DEPRECATED: Use filesystem_result_log_file.
 The path which osquery result logs will be logged to.
 
 - Default value: `/tmp/osquery_result`
-- Environment variable: `KOLIDE_OSQUERY_RESULT_LOG_FILE`
+- Environment variable: `FLEET_OSQUERY_RESULT_LOG_FILE`
 - Config file format:
 
 	```
@@ -641,7 +643,7 @@ This flag will cause the osquery result and status log files to be automatically
 rotated when files reach a size of 500 Mb or an age of 28 days.
 
 - Default value: `false`
-- Environment variable: `KOLIDE_OSQUERY_ENABLE_LOG_ROTATION`
+- Environment variable: `FLEET_OSQUERY_ENABLE_LOG_ROTATION`
 - Config file format:
 
   ```
@@ -656,7 +658,7 @@ rotated when files reach a size of 500 Mb or an age of 28 days.
 Whether or not to enable debug logging.
 
 - Default value: `false`
-- Environment variable: `KOLIDE_LOGGING_DEBUG`
+- Environment variable: `FLEET_LOGGING_DEBUG`
 - Config file format:
 
 	```
@@ -669,7 +671,7 @@ Whether or not to enable debug logging.
 Whether or not to log in JSON.
 
 - Default value: `false`
-- Environment variable: `KOLIDE_LOGGING_JSON`
+- Environment variable: `FLEET_LOGGING_JSON`
 - Config file format:
 
 	```
@@ -682,7 +684,7 @@ Whether or not to log in JSON.
 Whether or not to log the welcome banner.
 
 - Default value: `false`
-- Environment variable: `KOLIDE_LOGGING_DISABLE_BANNER`
+- Environment variable: `FLEET_LOGGING_DISABLE_BANNER`
 - Config file format:
 
 	```
@@ -699,7 +701,7 @@ This flag only has effect if `osquery_status_log_plugin` is set to `filesystem` 
 The path which osquery status logs will be logged to.
 
 - Default value: `/tmp/osquery_status`
-- Environment variable: `KOLIDE_FILESYSTEM_STATUS_LOG_FILE`
+- Environment variable: `FLEET_FILESYSTEM_STATUS_LOG_FILE`
 - Config file format:
 
 	```
@@ -714,7 +716,7 @@ This flag only has effect if `osquery_result_log_plugin` is set to `filesystem` 
 The path which osquery result logs will be logged to.
 
 - Default value: `/tmp/osquery_result`
-- Environment variable: `KOLIDE_FILESYSTEM_RESULT_LOG_FILE`
+- Environment variable: `FLEET_FILESYSTEM_RESULT_LOG_FILE`
 - Config file format:
 
 	```
@@ -730,7 +732,7 @@ This flag will cause the osquery result and status log files to be automatically
 rotated when files reach a size of 500 Mb or an age of 28 days.
 
 - Default value: `false`
-- Environment variable: `KOLIDE_FILESYSTEM_ENABLE_LOG_ROTATION`
+- Environment variable: `FLEET_FILESYSTEM_ENABLE_LOG_ROTATION`
 - Config file format:
 
   ```
@@ -745,7 +747,7 @@ This flag only has effect if `filesystem_enable_log_rotation` is set to `true`.
 This flag will cause the rotated logs to be compressed with gzip.
 
 - Default value: `false`
-- Environment variable: `KOLIDE_FILESYSTEM_ENABLE_LOG_COMPRESSION`
+- Environment variable: `FLEET_FILESYSTEM_ENABLE_LOG_COMPRESSION`
 - Config file format:
 
   ```
@@ -762,7 +764,7 @@ This flag only has effect if `osquery_status_log_plugin` is set to `firehose`.
 AWS region to use for Firehose connection
 
 - Default value: none
-- Environment variable: `KOLIDE_FIREHOSE_REGION`
+- Environment variable: `FLEET_FIREHOSE_REGION`
 - Config file format:
 
 	```
@@ -779,7 +781,7 @@ If `firehose_access_key_id` and `firehose_secret_access_key` are omitted, Fleet 
 AWS access key ID to use for Firehose authentication.
 
 - Default value: none
-- Environment variable: `KOLIDE_FIREHOSE_ACCESS_KEY_ID`
+- Environment variable: `FLEET_FIREHOSE_ACCESS_KEY_ID`
 - Config file format:
 
 	```
@@ -794,7 +796,7 @@ This flag only has effect if `osquery_status_log_plugin` or `osquery_result_log_
 AWS secret access key to use for Firehose authentication.
 
 - Default value: none
-- Environment variable: `KOLIDE_FIREHOSE_SECRET_ACCESS_KEY`
+- Environment variable: `FLEET_FIREHOSE_SECRET_ACCESS_KEY`
 - Config file format:
 
 	```
@@ -810,7 +812,7 @@ This flag only has effect if `osquery_status_log_plugin` or
 AWS STS role ARN to use for Firehose authentication.
 
 - Default value: none
-- Environment variable: `KOLIDE_FIREHOSE_STS_ASSUME_ROLE_ARN`
+- Environment variable: `FLEET_FIREHOSE_STS_ASSUME_ROLE_ARN`
 - Config file format:
 
 	```
@@ -825,7 +827,7 @@ This flag only has effect if `osquery_status_log_plugin` is set to `firehose`.
 Name of the Firehose stream to write osquery status logs received from clients.
 
 - Default value: none
-- Environment variable: `KOLIDE_FIREHOSE_STATUS_STREAM`
+- Environment variable: `FLEET_FIREHOSE_STATUS_STREAM`
 - Config file format:
 
 	```
@@ -846,7 +848,7 @@ This flag only has effect if `osquery_result_log_plugin` is set to `firehose`.
 Name of the Firehose stream to write osquery result logs received from clients.
 
 - Default value: none
-- Environment variable: `KOLIDE_FIREHOSE_RESULT_STREAM`
+- Environment variable: `FLEET_FIREHOSE_RESULT_STREAM`
 - Config file format:
 
 	```
@@ -869,7 +871,7 @@ This flag only has effect if `osquery_status_log_plugin` is set to `kinesis`.
 AWS region to use for Kinesis connection
 
 - Default value: none
-- Environment variable: `KOLIDE_KINESIS_REGION`
+- Environment variable: `FLEET_KINESIS_REGION`
 - Config file format:
 
 	```
@@ -890,7 +892,7 @@ credentials.
 AWS access key ID to use for Kinesis authentication.
 
 - Default value: none
-- Environment variable: `KOLIDE_KINESIS_ACCESS_KEY_ID`
+- Environment variable: `FLEET_KINESIS_ACCESS_KEY_ID`
 - Config file format:
 
 	```
@@ -906,7 +908,7 @@ This flag only has effect if `osquery_status_log_plugin` or
 AWS secret access key to use for Kinesis authentication.
 
 - Default value: none
-- Environment variable: `KOLIDE_KINESIS_SECRET_ACCESS_KEY`
+- Environment variable: `FLEET_KINESIS_SECRET_ACCESS_KEY`
 - Config file format:
 
 	```
@@ -922,7 +924,7 @@ This flag only has effect if `osquery_status_log_plugin` or
 AWS STS role ARN to use for Kinesis authentication.
 
 - Default value: none
-- Environment variable: `KOLIDE_KINESIS_STS_ASSUME_ROLE_ARN`
+- Environment variable: `FLEET_KINESIS_STS_ASSUME_ROLE_ARN`
 - Config file format:
 
 	```
@@ -937,7 +939,7 @@ This flag only has effect if `osquery_status_log_plugin` is set to `kinesis`.
 Name of the Kinesis stream to write osquery status logs received from clients.
 
 - Default value: none
-- Environment variable: `KOLIDE_KINESIS_STATUS_STREAM`
+- Environment variable: `FLEET_KINESIS_STATUS_STREAM`
 - Config file format:
 
 	```
@@ -958,7 +960,7 @@ This flag only has effect if `osquery_result_log_plugin` is set to `kinesis`.
 Name of the Kinesis stream to write osquery result logs received from clients.
 
 - Default value: none
-- Environment variable: `KOLIDE_KINESIS_RESULT_STREAM`
+- Environment variable: `FLEET_KINESIS_RESULT_STREAM`
 - Config file format:
 
 	```
@@ -985,7 +987,7 @@ Note that the pubsub plugin uses [Application Default Credentials (ADCs)](https:
 for authentication with the service.
 
 - Default value: none
-- Environment variable: `KOLIDE_PUBSUB_PROJECT`
+- Environment variable: `FLEET_PUBSUB_PROJECT`
 - Config file format:
 
   ```
@@ -1000,7 +1002,7 @@ This flag only has effect if `osquery_status_log_plugin` is set to `pubsub`.
 The identifier of the pubsub topic that client results will be published to.
 
 - Default value: none
-- Environment variable: `KOLIDE_PUBSUB_RESULT_TOPIC`
+- Environment variable: `FLEET_PUBSUB_RESULT_TOPIC`
 - Config file format:
 
   ```
@@ -1015,7 +1017,7 @@ This flag only has effect if `osquery_status_log_plugin` is set to `pubsub`.
 The identifier of the pubsub topic that osquery status logs will be published to.
 
 - Default value: none
-- Environment variable: `KOLIDE_PUBSUB_STATUS_TOPIC`
+- Environment variable: `FLEET_PUBSUB_STATUS_TOPIC`
 - Config file format:
 
   ```
@@ -1031,7 +1033,7 @@ The identifier of the pubsub topic that osquery status logs will be published to
 Name of the S3 bucket to use to store file carves.
 
 - Default value: none
-- Environment variable: `KOLIDE_S3_BUCKET`
+- Environment variable: `FLEET_S3_BUCKET`
 - Config file format:
 
 	```
@@ -1046,7 +1048,7 @@ Prefix to prepend to carve objects.
 All carve objects will also be prefixed by date and hour (UTC), making the resulting keys look like: `<prefix><year>/<month>/<day>/<hour>/<carve-name>`.
 
 - Default value: none
-- Environment variable: `KOLIDE_S3_PREFIX`
+- Environment variable: `FLEET_S3_PREFIX`
 - Config file format:
 
 	```
@@ -1064,7 +1066,7 @@ If `s3_access_key_id` and `s3_secret_access_key` are omitted, Fleet will try to 
 The IAM identity used in this context must be allowed to perform the following actions on the bucket: `s3:PutObject`, `s3:GetObject`, `s3:ListMultipartUploadParts`, `s3:ListBucket`, `s3:GetBucketLocation`.
 
 - Default value: none
-- Environment variable: `KOLIDE_S3_ACCESS_KEY_ID`
+- Environment variable: `FLEET_S3_ACCESS_KEY_ID`
 - Config file format:
 
 	```
@@ -1077,7 +1079,7 @@ The IAM identity used in this context must be allowed to perform the following a
 AWS secret access key to use for S3 authentication.
 
 - Default value: none
-- Environment variable: `KOLIDE_S3_SECRET_ACCESS_KEY`
+- Environment variable: `FLEET_S3_SECRET_ACCESS_KEY`
 - Config file format:
 
 	```
@@ -1090,7 +1092,7 @@ AWS secret access key to use for S3 authentication.
 AWS STS role ARN to use for S3 authentication.
 
 - Default value: none
-- Environment variable: `KOLIDE_S3_STS_ASSUME_ROLE_ARN`
+- Environment variable: `FLEET_S3_STS_ASSUME_ROLE_ARN`
 - Config file format:
 
 	```

--- a/examples/kubernetes/fleet-deployment.yml
+++ b/examples/kubernetes/fleet-deployment.yml
@@ -29,28 +29,28 @@ spec:
             mountPath: "/secrets/fleet-tls"
             readOnly: true
         env:
-          - name: KOLIDE_MYSQL_ADDRESS
+          - name: FLEET_MYSQL_ADDRESS
             value: fleet-database-mysql:3306
-          - name: KOLIDE_MYSQL_PASSWORD
+          - name: FLEET_MYSQL_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: fleet-database-mysql
                 key: mysql-password
-          - name: KOLIDE_REDIS_ADDRESS
+          - name: FLEET_REDIS_ADDRESS
             value: fleet-cache-redis:6379
-          - name: KOLIDE_REDIS_PASSWORD
+          - name: FLEET_REDIS_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: fleet-cache-redis
                 key: redis-password
-          - name: KOLIDE_AUTH_JWT_KEY
+          - name: FLEET_AUTH_JWT_KEY
             valueFrom:
               secretKeyRef:
                 name: fleet-server-auth-key
                 key: fleet-server-auth-key
-          - name: KOLIDE_SERVER_ADDRESS
+          - name: FLEET_SERVER_ADDRESS
             value: "0.0.0.0:443"
-          - name: KOLIDE_SERVER_CERT
+          - name: FLEET_SERVER_CERT
             value: "/secrets/fleet-tls/tls.crt"
-          - name: KOLIDE_SERVER_KEY
+          - name: FLEET_SERVER_KEY
             value: "/secrets/fleet-tls/tls.key"

--- a/examples/kubernetes/fleet-migrations.yml
+++ b/examples/kubernetes/fleet-migrations.yml
@@ -12,9 +12,9 @@ spec:
         image: kolide/fleet:1.0.5
         command: ["fleet",  "prepare", "db"]
         env:
-          - name: KOLIDE_MYSQL_ADDRESS
+          - name: FLEET_MYSQL_ADDRESS
             value: fleet-database-mysql:3306
-          - name: KOLIDE_MYSQL_PASSWORD
+          - name: FLEET_MYSQL_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: fleet-database-mysql

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	envPrefix = "KOLIDE"
+	envPrefix = "FLEET"
 )
 
 // MysqlConfig defines configs related to MySQL
@@ -312,6 +312,29 @@ func (man Manager) addConfigs() {
 // LoadConfig will load the config variables into a fully initialized
 // KolideConfig struct
 func (man Manager) LoadConfig() KolideConfig {
+	// Shim old style environment variables with a warning
+	// TODO #260 remove this on major version release
+	haveLogged := false
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "KOLIDE_") {
+			splits := strings.SplitN(e, "=", 2)
+			if len(splits) != 2 {
+				panic("env " + e + " does not contain 2 splits")
+			}
+
+			key, val := splits[0], splits[1]
+
+			if !haveLogged {
+				fmt.Println("Environment variables prefixed with KOLIDE_ are deprecated. Please migrate to FLEET_ prefixes.`")
+				haveLogged = true
+			}
+
+			if err := os.Setenv("FLEET"+strings.TrimPrefix(key, "KOLIDE"), val); err != nil {
+				panic(err)
+			}
+		}
+	}
+
 	man.loadConfigFile()
 
 	return KolideConfig{

--- a/tools/ci/k8s-templates/branch-deployment.template
+++ b/tools/ci/k8s-templates/branch-deployment.template
@@ -32,23 +32,23 @@ spec:
           - "/fleet"
           - "serve"
         env:
-            - name: KOLIDE_MYSQL_USERNAME
+            - name: FLEET_MYSQL_USERNAME
               valueFrom:
                 secretKeyRef:
                     name: cloudsql.cloudmaster
                     key: username
-            - name: KOLIDE_SERVER_TLS
+            - name: FLEET_SERVER_TLS
               value: "false"
-            - name: KOLIDE_MYSQL_PASSWORD
+            - name: FLEET_MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:
                     name: cloudsql.cloudmaster
                     key: password
-            - name: KOLIDE_MYSQL_DATABASE
+            - name: FLEET_MYSQL_DATABASE
               value: fleet_{{ .Name }}
-            - name: KOLIDE_REDIS_ADDRESS
+            - name: FLEET_REDIS_ADDRESS
               value: redis-fleet-{{ .Name }}:6379
-            - name: KOLIDE_AUTH_JWT_KEY
+            - name: FLEET_AUTH_JWT_KEY
               value: changeme_fake_jwt_key
         ports:
         - containerPort: 8080

--- a/tools/ci/k8s-templates/pr-deployment.template
+++ b/tools/ci/k8s-templates/pr-deployment.template
@@ -35,23 +35,23 @@ spec:
           - "/fleet"
           - "serve"
         env:
-            - name: KOLIDE_MYSQL_USERNAME
+            - name: FLEET_MYSQL_USERNAME
               valueFrom:
                 secretKeyRef:
                     name: cloudsql.cloudmaster
                     key: username
-            - name: KOLIDE_SERVER_TLS
+            - name: FLEET_SERVER_TLS
               value: "false"
-            - name: KOLIDE_MYSQL_PASSWORD
+            - name: FLEET_MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:
                     name: cloudsql.cloudmaster
                     key: password
-            - name: KOLIDE_MYSQL_DATABASE
+            - name: FLEET_MYSQL_DATABASE
               value: pr_{{ .Number }}_{{ .RevShort }}
-            - name: KOLIDE_REDIS_ADDRESS
+            - name: FLEET_REDIS_ADDRESS
               value: redis-fleet-pr-{{ .Number }}:6379
-            - name: KOLIDE_AUTH_JWT_KEY
+            - name: FLEET_AUTH_JWT_KEY
               value: changeme_fake_jwt_key
         ports:
         - containerPort: 8080


### PR DESCRIPTION
- Support both `FLEET_` and `KOLIDE_` prefixes.
- Add logging about deprecated `KOLIDE_` prefix.
- Update documentation and sample configs.