### PR TITLE
Add instructions for moving queries and packs from one Fleet env to another

### DIFF
--- a/docs/1-Using-Fleet/2-fleetctl-CLI.md
+++ b/docs/1-Using-Fleet/2-fleetctl-CLI.md
@@ -12,6 +12,7 @@
   - [Convert osquery JSON](#convert-osquery-json)
   - [Osquery queries](#osquery-queries)
   - [Query packs](#query-packs)
+    - [Moving queries and packs from one Fleet environement to another](#moving-queries-and-packs-from-one-fleet-environement-to-another)
   - [Host labels](#host-labels)
   - [Osquery configuration options](#osquery-configuration-options)
   - [Auto table construction](#auto-table-construction)
@@ -347,6 +348,17 @@ spec:
       interval: 600
       removed: false
 ```
+
+#### Moving queries and packs from one Fleet environement to another
+
+When managing multiple Fleet environments, you may want to move queries and/or packs from one environment (exporter) to the other (importer).
+
+1. With your exporter Fleet instance running, run `fleetctl get queries --yaml > queries.yml`. This will write a list of all queries in yaml syntax to a file named queries.yml.
+2. With your exporter Fleet instance running, run `fleetctl get packs --yaml > packs.yml`. This will write a list of all query packs in yaml syntax to a file named packs.yml.
+3. Now, with your importer Fleet instance running, run `fleetctl apply -f queries.yml`. This will import all the queries from your new queries.yml file into your importer Fleet instance.
+4. With your importer Fleet instance running, run `fleetctl apply -f packs.yml`. This will import all the query packs along with the correct queries (that you just imported) into your importer Fleet instance.
+
+
 
 ### Host labels
 

--- a/docs/1-Using-Fleet/2-fleetctl-CLI.md
+++ b/docs/1-Using-Fleet/2-fleetctl-CLI.md
@@ -351,11 +351,11 @@ spec:
 
 #### Moving queries and packs from one Fleet environment to another
 
-When managing multiple Fleet environments, you may want to move queries and/or packs from one "exporter" environment to a different "importer" environment.
+When managing multiple Fleet environments, you may want to move queries and/or packs from one "exporter" environment to a another "importer" environment.
 
-1. Navigate to `~/.fleet/config` to find the context names for your "exporter" and "importer" environment. For the purpose of these intructions we will use the context names `exporter` and `importer` respectively.
-2. Run the command `fleetctl get queries --yaml --context exporter > queries.yaml && fleetctl apply -f queries.yml --context importer`. This will import all the queries from your exporter Fleet instance into your importer Fleet instance. Note this will also write a list of all queries in yaml syntax to a file names `queries.yml`.
-3. Run the command `fleetctl get packs --yaml --context exporter > packs.yaml && fleetctl apply -f packs.yml --context importer`. This will import all the queries from your exporter Fleet instance into your importer Fleet instance. Note: this will also write a list of all packs in yaml syntax to a file names `packs.yml`.
+1. Navigate to `~/.fleet/config` to find the context names for your "exporter" and "importer" environment. For the purpose of these instructions we will use the context names `exporter` and `importer` respectively.
+2. Run the command `fleetctl get queries --yaml --context exporter > queries.yaml && fleetctl apply -f queries.yml --context importer`. This will import all the queries from your exporter Fleet instance into your importer Fleet instance. *Note, this will also write a list of all queries in yaml syntax to a file names `queries.yml`.*
+3. Run the command `fleetctl get packs --yaml --context exporter > packs.yaml && fleetctl apply -f packs.yml --context importer`. This will import all the queries from your exporter Fleet instance into your importer Fleet instance. *Note, this will also write a list of all packs in yaml syntax to a file names `packs.yml`.*
 
 ### Host labels
 

--- a/docs/1-Using-Fleet/2-fleetctl-CLI.md
+++ b/docs/1-Using-Fleet/2-fleetctl-CLI.md
@@ -12,7 +12,7 @@
   - [Convert osquery JSON](#convert-osquery-json)
   - [Osquery queries](#osquery-queries)
   - [Query packs](#query-packs)
-    - [Moving queries and packs from one Fleet environement to another](#moving-queries-and-packs-from-one-fleet-environement-to-another)
+    - [Moving queries and packs from one Fleet environment to another](#moving-queries-and-packs-from-one-fleet-environment-to-another)
   - [Host labels](#host-labels)
   - [Osquery configuration options](#osquery-configuration-options)
   - [Auto table construction](#auto-table-construction)
@@ -349,14 +349,13 @@ spec:
       removed: false
 ```
 
-#### Moving queries and packs from one Fleet environement to another
+#### Moving queries and packs from one Fleet environment to another
 
-When managing multiple Fleet environments, you may want to move queries and/or packs from one environment (exporter) to the other (importer).
+When managing multiple Fleet environments, you may want to move queries and/or packs from one "exporter" environment to a different "importer" environment.
 
-1. With your exporter Fleet environment running, run `fleetctl get queries --yaml > queries.yml`. This will write a list of all queries in yaml syntax to a file named queries.yml.
-2. With your exporter Fleet environment running, run `fleetctl get packs --yaml > packs.yml`. This will write a list of all query packs in yaml syntax to a file named packs.yml.
-3. Now, with your importer Fleet environment running, run `fleetctl apply -f queries.yml`. This will import all the queries from your new queries.yml file into your importer Fleet instance.
-4. With your importer Fleet environment running, run `fleetctl apply -f packs.yml`. This will import all the query packs along with the correct queries (that you just imported) into your importer Fleet instance.
+1. Navigate to `~/.fleet/config` to find the context names for your "exporter" and "importer" environment. For the purpose of these intructions we will use the context names `exporter` and `importer` respectively.
+2. Run the command `fleetctl get queries --yaml --context exporter > queries.yaml && fleetctl apply -f queries.yml --context importer`. This will import all the queries from your exporter Fleet instance into your importer Fleet instance. Note this will also write a list of all queries in yaml syntax to a file names `queries.yml`.
+3. Run the command `fleetctl get packs --yaml --context exporter > packs.yaml && fleetctl apply -f packs.yml --context importer`. This will import all the queries from your exporter Fleet instance into your importer Fleet instance. Note: this will also write a list of all packs in yaml syntax to a file names `packs.yml`.
 
 ### Host labels
 

--- a/docs/1-Using-Fleet/2-fleetctl-CLI.md
+++ b/docs/1-Using-Fleet/2-fleetctl-CLI.md
@@ -12,7 +12,7 @@
   - [Convert osquery JSON](#convert-osquery-json)
   - [Osquery queries](#osquery-queries)
   - [Query packs](#query-packs)
-    - [Moving queries and packs from one Fleet environement to another](#moving-queries-and-packs-from-one-fleet-environement-to-another)
+    - [Moving queries and packs from one Fleet environment to another](#moving-queries-and-packs-from-one-fleet-environment-to-another)
   - [Host labels](#host-labels)
   - [Osquery configuration options](#osquery-configuration-options)
   - [Auto table construction](#auto-table-construction)
@@ -675,4 +675,3 @@ can be helpful to debug carving problems.
 This value must be less than the `max_allowed_packet` setting in MySQL. If it is too large, MySQL will reject the writes.
 
 The value must be small enough that HTTP requests do not time out.
-

--- a/docs/1-Using-Fleet/2-fleetctl-CLI.md
+++ b/docs/1-Using-Fleet/2-fleetctl-CLI.md
@@ -353,10 +353,10 @@ spec:
 
 When managing multiple Fleet environments, you may want to move queries and/or packs from one environment (exporter) to the other (importer).
 
-1. With your exporter Fleet instance running, run `fleetctl get queries --yaml > queries.yml`. This will write a list of all queries in yaml syntax to a file named queries.yml.
-2. With your exporter Fleet instance running, run `fleetctl get packs --yaml > packs.yml`. This will write a list of all query packs in yaml syntax to a file named packs.yml.
-3. Now, with your importer Fleet instance running, run `fleetctl apply -f queries.yml`. This will import all the queries from your new queries.yml file into your importer Fleet instance.
-4. With your importer Fleet instance running, run `fleetctl apply -f packs.yml`. This will import all the query packs along with the correct queries (that you just imported) into your importer Fleet instance.
+1. With your exporter Fleet environment running, run `fleetctl get queries --yaml > queries.yml`. This will write a list of all queries in yaml syntax to a file named queries.yml.
+2. With your exporter Fleet environment running, run `fleetctl get packs --yaml > packs.yml`. This will write a list of all query packs in yaml syntax to a file named packs.yml.
+3. Now, with your importer Fleet environment running, run `fleetctl apply -f queries.yml`. This will import all the queries from your new queries.yml file into your importer Fleet instance.
+4. With your importer Fleet environment running, run `fleetctl apply -f packs.yml`. This will import all the query packs along with the correct queries (that you just imported) into your importer Fleet instance.
 
 ### Host labels
 

--- a/docs/1-Using-Fleet/2-fleetctl-CLI.md
+++ b/docs/1-Using-Fleet/2-fleetctl-CLI.md
@@ -349,7 +349,7 @@ spec:
       removed: false
 ```
 
-#### Moving queries and packs from one Fleet environement to another
+#### Moving queries and packs from one Fleet environment to another
 
 When managing multiple Fleet environments, you may want to move queries and/or packs from one environment (exporter) to the other (importer).
 
@@ -675,5 +675,4 @@ can be helpful to debug carving problems.
 This value must be less than the `max_allowed_packet` setting in MySQL. If it is too large, MySQL will reject the writes.
 
 The value must be small enough that HTTP requests do not time out.
-
 

--- a/docs/1-Using-Fleet/2-fleetctl-CLI.md
+++ b/docs/1-Using-Fleet/2-fleetctl-CLI.md
@@ -358,8 +358,6 @@ When managing multiple Fleet environments, you may want to move queries and/or p
 3. Now, with your importer Fleet instance running, run `fleetctl apply -f queries.yml`. This will import all the queries from your new queries.yml file into your importer Fleet instance.
 4. With your importer Fleet instance running, run `fleetctl apply -f packs.yml`. This will import all the query packs along with the correct queries (that you just imported) into your importer Fleet instance.
 
-
-
 ### Host labels
 
 The following file describes the labels which hosts should be automatically grouped into. The label resource should include the actual SQL query so that the label is self-contained:

--- a/docs/1-Using-Fleet/2-fleetctl-CLI.md
+++ b/docs/1-Using-Fleet/2-fleetctl-CLI.md
@@ -355,7 +355,7 @@ When managing multiple Fleet environments, you may want to move queries and/or p
 
 1. Navigate to `~/.fleet/config` to find the context names for your "exporter" and "importer" environment. For the purpose of these instructions we will use the context names `exporter` and `importer` respectively.
 2. Run the command `fleetctl get queries --yaml --context exporter > queries.yaml && fleetctl apply -f queries.yml --context importer`. This will import all the queries from your exporter Fleet instance into your importer Fleet instance. *Note, this will also write a list of all queries in yaml syntax to a file names `queries.yml`.*
-3. Run the command `fleetctl get packs --yaml --context exporter > packs.yaml && fleetctl apply -f packs.yml --context importer`. This will import all the queries from your exporter Fleet instance into your importer Fleet instance. *Note, this will also write a list of all packs in yaml syntax to a file names `packs.yml`.*
+3. Run the command `fleetctl get packs --yaml --context exporter > packs.yaml && fleetctl apply -f packs.yml --context importer`. This will import all the packs from your exporter Fleet instance into your importer Fleet instance. *Note, this will also write a list of all packs in yaml syntax to a file names `packs.yml`.*
 
 ### Host labels
 


### PR DESCRIPTION
- New section includes lean instructions for exporting queries and packs from one Fleet environment and importing them in another.
- This section of the docs will be referenced by a new blog post "Import and export queries and packs in Fleet." ([link to draft](https://medium.com/fleetdm/import-and-export-queries-and-packs-in-fleet-68c35583d007))
- The blog post will be published Monday after minor revisions and the addition of a cover illustration.