### PR TITLE
Update fleetctl NPM package to 3.7.4

### DIFF
--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetctl",
-  "version": "3.7.1",
+  "version": "3.7.4",
   "description": "Installer for the fleetctl CLI tool",
   "bin": {
     "fleetctl": "./run.js"


### PR DESCRIPTION
This corresponds with the published 3.7.4 fleetctl release.