### PR TITLE
Add support for `query` parameter in list hosts endpoint

### DIFF
--- a/server/datastore/datastore_test.go
+++ b/server/datastore/datastore_test.go
@@ -46,6 +46,7 @@ var testFunctions = [...]func(*testing.T, kolide.Datastore){
 	testListHosts,
 	testListHostsFilterAdditional,
 	testListHostsStatus,
+	testListHostsQuery,
 	testListHostsInPack,
 	testListPacksForHost,
 	testHostIDsByName,

--- a/server/datastore/mysql/mysql_test.go
+++ b/server/datastore/mysql/mysql_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestSanitizeColumn(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		input  string
 		output string
@@ -20,7 +22,89 @@ func TestSanitizeColumn(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
 			assert.Equal(t, tt.output, sanitizeColumn(tt.input))
+		})
+	}
+}
+
+func TestSearchLike(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		inSQL     string
+		inParams  []interface{}
+		match     string
+		columns   []string
+		outSQL    string
+		outParams []interface{}
+	}{
+		{
+			inSQL:     "SELECT * FROM HOSTS WHERE TRUE",
+			inParams:  []interface{}{},
+			match:     "foobar",
+			columns:   []string{"hostname"},
+			outSQL:    "SELECT * FROM HOSTS WHERE TRUE AND (hostname LIKE ?)",
+			outParams: []interface{}{"%foobar%"},
+		},
+		{
+			inSQL:     "SELECT * FROM HOSTS WHERE TRUE",
+			inParams:  []interface{}{3},
+			match:     "foobar",
+			columns:   []string{},
+			outSQL:    "SELECT * FROM HOSTS WHERE TRUE",
+			outParams: []interface{}{3},
+		},
+		{
+			inSQL:     "SELECT * FROM HOSTS WHERE TRUE",
+			inParams:  []interface{}{1},
+			match:     "foobar",
+			columns:   []string{"hostname"},
+			outSQL:    "SELECT * FROM HOSTS WHERE TRUE AND (hostname LIKE ?)",
+			outParams: []interface{}{1, "%foobar%"},
+		},
+		{
+			inSQL:     "SELECT * FROM HOSTS WHERE TRUE",
+			inParams:  []interface{}{1},
+			match:     "foobar",
+			columns:   []string{"hostname", "uuid"},
+			outSQL:    "SELECT * FROM HOSTS WHERE TRUE AND (hostname LIKE ? OR uuid LIKE ?)",
+			outParams: []interface{}{1, "%foobar%", "%foobar%"},
+		},
+		{
+			inSQL:     "SELECT * FROM HOSTS WHERE TRUE",
+			inParams:  []interface{}{1},
+			match:     "foobar",
+			columns:   []string{"hostname", "uuid"},
+			outSQL:    "SELECT * FROM HOSTS WHERE TRUE AND (hostname LIKE ? OR uuid LIKE ?)",
+			outParams: []interface{}{1, "%foobar%", "%foobar%"},
+		},
+		{
+			inSQL:     "SELECT * FROM HOSTS WHERE 1=1",
+			inParams:  []interface{}{1},
+			match:     "forty_%",
+			columns:   []string{"ipv4", "uuid"},
+			outSQL:    "SELECT * FROM HOSTS WHERE 1=1 AND (ipv4 LIKE ? OR uuid LIKE ?)",
+			outParams: []interface{}{1, "%forty\\_\\%%", "%forty\\_\\%%"},
+		},
+		{
+			inSQL:     "SELECT * FROM HOSTS WHERE 1=1",
+			inParams:  []interface{}{1},
+			match:     "forty_%",
+			columns:   []string{"ipv4", "uuid"},
+			outSQL:    "SELECT * FROM HOSTS WHERE 1=1 AND (ipv4 LIKE ? OR uuid LIKE ?)",
+			outParams: []interface{}{1, "%forty\\_\\%%", "%forty\\_\\%%"},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
+			sql, params := searchLike(tt.inSQL, tt.inParams, tt.match, tt.columns...)
+			assert.Equal(t, tt.outSQL, sql)
+			assert.Equal(t, tt.outParams, params)
 		})
 	}
 }

--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -93,8 +93,13 @@ type HostService interface {
 type HostListOptions struct {
 	ListOptions
 
+	// AdditionalFilters selects which host additional fields should be
+	// populated.
 	AdditionalFilters []string
-	StatusFilter      HostStatus
+	// StatusFilter selects the online status of the hosts.
+	StatusFilter HostStatus
+	// MatchQuery is the query string to match in various columns of the host.
+	MatchQuery string
 }
 
 type Host struct {

--- a/server/service/transport_hosts.go
+++ b/server/service/transport_hosts.go
@@ -54,5 +54,9 @@ func decodeListHostsRequest(ctx context.Context, r *http.Request) (interface{}, 
 	if additionalInfoFiltersString != "" {
 		hopt.AdditionalFilters = strings.Split(additionalInfoFiltersString, ",")
 	}
+
+	query := r.URL.Query().Get("query")
+	hopt.MatchQuery = query
+
 	return listHostsRequest{ListOptions: hopt}, nil
 }


### PR DESCRIPTION
Uses a LIKE clause to search for hosts matching the query against
columns `host_name`, `uuid`, `hardware_serial`, and `primary_ip`.

Introduces the `searchLike` helper to add the appropriate filters to the
SQL query.