### PR TITLE
Add aliases for order keys in API

### DIFF
--- a/server/service/endpoint_hosts.go
+++ b/server/service/endpoint_hosts.go
@@ -121,11 +121,6 @@ func (r listHostsResponse) error() error { return r.Err }
 func makeListHostsEndpoint(svc kolide.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(listHostsRequest)
-		// Special case this key so that the frontend can migrate to using only "hostname"
-		// TODO #317 remove special cases for host_name by standardizing on hostname
-		if req.ListOptions.OrderKey == "hostname" {
-			req.ListOptions.OrderKey = "host_name"
-		}
 		hosts, err := svc.ListHosts(ctx, req.ListOptions)
 		if err != nil {
 			return listHostsResponse{Err: err}, nil

--- a/server/service/transport.go
+++ b/server/service/transport.go
@@ -8,8 +8,8 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/gorilla/mux"
 	"github.com/fleetdm/fleet/server/kolide"
+	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 )
 
@@ -142,6 +142,15 @@ func listOptionsFromRequest(r *http.Request) (kolide.ListOptions, error) {
 		return kolide.ListOptions{},
 			errors.New("unknown order_direction: " + orderDirectionString)
 
+	}
+
+	// Special some keys so that the frontend can use consistent names.
+	// TODO #317 remove special cases
+	switch orderKey {
+	case "hostname":
+		orderKey = "host_name"
+	case "memory":
+		orderKey = "physical_memory"
 	}
 
 	return kolide.ListOptions{


### PR DESCRIPTION
Aliases `hostname` (`host_name`) and `memory` (`physical_memory`) when
used as keys for ordering in the API this allows for better consistency
on the frontend.

To be cleaned up further in #317