### PR TITLE
Add number of hosts responding in live query UI.

### DIFF
--- a/frontend/components/queries/QueryProgressDetails/QueryProgressDetails.jsx
+++ b/frontend/components/queries/QueryProgressDetails/QueryProgressDetails.jsx
@@ -19,10 +19,10 @@ const QueryProgressDetails = ({ campaign, className, onRunQuery, onStopQuery, qu
   const totalRowsCount = get(campaign, ['query_results', 'length'], 0);
   const campaignIsEmpty = !hostsCount.successful && hostsCount.successful !== 0;
 
-  const onlineHostsTotalDisplay = totalHostsOnline === 1 ? '1 host' : `${totalHostsOnline} hosts`;
+  const onlineHostsTotalDisplay = totalHostsOnline === 1 ? '1 online host' : `${totalHostsOnline} online hosts`;
   const onlineResultsTotalDisplay = totalRowsCount === 1 ? '1 result' : `${totalRowsCount} results`;
-  const offlineHostsTotalDisplay = totalHostsOffline === 1 ? '1 host' : `${totalHostsOffline} hosts`;
-  const failedHostsTotalDisplay = hostsCount.failed === 1 ? '1 host' : `${hostsCount.failed} hosts`;
+  const offlineHostsTotalDisplay = totalHostsOffline === 1 ? '1 offline host' : `${totalHostsOffline} offline hosts`;
+  const failedHostsTotalDisplay = hostsCount.failed === 1 ? '1 failed host' : `${hostsCount.failed} failed hosts`;
   let totalErrorsDisplay = '0 errors';
   if (errors) {
     totalErrorsDisplay = errors.length === 1 ? '1 error' : `${errors.length} errors`;
@@ -66,9 +66,15 @@ const QueryProgressDetails = ({ campaign, className, onRunQuery, onStopQuery, qu
     <div className={`${baseClass} ${className}`}>
       <div className={`${baseClass}__wrapper`}>
         <div className={`${baseClass}__text-wrapper`}>
-          <span className={`${baseClass}__text-online`}>Online - {onlineHostsTotalDisplay} returning {onlineResultsTotalDisplay}</span>
-          <span className={`${baseClass}__text-offline`}>Offline - {offlineHostsTotalDisplay} returning 0 results</span>
-          <span className={`${baseClass}__text-error`}>Failed - {failedHostsTotalDisplay} returning {totalErrorsDisplay}</span>
+          <span className={`${baseClass}__text-online`}>{hostsCount.successful} out of {onlineHostsTotalDisplay} responding
+            <span className={`${baseClass}__text-results`}> and returning {onlineResultsTotalDisplay}</span>
+          </span>
+          <span className={`${baseClass}__text-offline`}>{offlineHostsTotalDisplay}
+            <span className={`${baseClass}__text-results`}> returning 0 results</span>
+          </span>
+          <span className={`${baseClass}__text-error`}>{failedHostsTotalDisplay}
+            <span className={`${baseClass}__text-results`}> returning {totalErrorsDisplay}</span>
+          </span>
         </div>
         <ProgressBar
           error={hostsCount.failed}

--- a/frontend/components/queries/QueryProgressDetails/QueryProgressDetails.jsx
+++ b/frontend/components/queries/QueryProgressDetails/QueryProgressDetails.jsx
@@ -67,7 +67,7 @@ const QueryProgressDetails = ({ campaign, className, onRunQuery, onStopQuery, qu
       <div className={`${baseClass}__wrapper`}>
         <div className={`${baseClass}__text-wrapper`}>
           <span className={`${baseClass}__text-online`}>{hostsCount.successful} out of {onlineHostsTotalDisplay} responding
-            <span className={`${baseClass}__text-results`}> and returning {onlineResultsTotalDisplay}</span>
+            <span className={`${baseClass}__text-results`}> returning {onlineResultsTotalDisplay}</span>
           </span>
           <span className={`${baseClass}__text-offline`}>{offlineHostsTotalDisplay}
             <span className={`${baseClass}__text-results`}> returning 0 results</span>

--- a/frontend/components/queries/QueryProgressDetails/_styles.scss
+++ b/frontend/components/queries/QueryProgressDetails/_styles.scss
@@ -56,6 +56,10 @@
     }
   }
 
+  &__text-results {
+    color: $core-medium-blue-grey;
+  }
+
   &__btn-wrapper {
     float: right;
 


### PR DESCRIPTION
This PR fixes #303 by adding the number of hosts successfully responding to the live query UI. This information was previously removed in Fleet 3.7.1

Changes reflected with hosts successfully responding to a live query:
![Screen Shot 2021-02-18 at 10 03 51 AM](https://user-images.githubusercontent.com/47070608/108401378-20f59100-71d1-11eb-94af-8b69cacb67e8.png)

Changes reflected with hosts failing during a live query:
![Screen Shot 2021-02-18 at 10 04 07 AM](https://user-images.githubusercontent.com/47070608/108401365-1cc97380-71d1-11eb-800b-55437b2ea6fe.png)
