### PR TITLE
Remove github.com/golang/dep from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,6 @@ deps-js:
 deps-go:
 	GO111MODULE=off go get -u \
 		github.com/kolide/go-bindata/... \
-		github.com/golang/dep/cmd/dep \
 		github.com/groob/mockimpl
 	go mod download
 


### PR DESCRIPTION
This has been long unused in favor of Go modules.