### PR TITLE
server/datastore: fix swallowed test error

### DIFF
--- a/server/datastore/datastore_scheduled_queries_test.go
+++ b/server/datastore/datastore_scheduled_queries_test.go
@@ -104,7 +104,8 @@ func testScheduledQuery(t *testing.T, ds kolide.Datastore) {
 	denylist := false
 	query.Denylist = &denylist
 
-	query, err = ds.SaveScheduledQuery(query)
+	_, err = ds.SaveScheduledQuery(query)
+	require.Nil(t, err)
 
 	query, err = ds.ScheduledQuery(sq1.ID)
 	require.Nil(t, err)


### PR DESCRIPTION
This picks up a swallowed `error` and makes explicit the discard of the `query` variable.