### PR TITLE
Return denylist parameter with pack configs

### DIFF
--- a/server/kolide/osquery.go
+++ b/server/kolide/osquery.go
@@ -46,6 +46,7 @@ type QueryContent struct {
 	Snapshot    *bool   `json:"snapshot,omitempty"`
 	Removed     *bool   `json:"removed,omitempty"`
 	Shard       *uint   `json:"shard,omitempty"`
+	Denylist    *bool   `json:"denylist,omitempty"`
 }
 
 type PermissiveQueryContent struct {

--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -158,6 +158,7 @@ func (svc service) GetClientConfig(ctx context.Context) (map[string]interface{},
 				Version:  query.Version,
 				Removed:  query.Removed,
 				Shard:    query.Shard,
+				Denylist: query.Denylist,
 			}
 
 			if query.Removed != nil {


### PR DESCRIPTION
This was previously handled correctly within the Fleet server datastores
and API endpoints, but not returned to the actual osquery client.

Fixes #338