### PR TITLE
Fix render issue in errors table

### DIFF
--- a/frontend/components/queries/QueryResultsTable/QueryResultsTable.jsx
+++ b/frontend/components/queries/QueryResultsTable/QueryResultsTable.jsx
@@ -174,7 +174,7 @@ class QueryResultsTable extends Component {
 
     const { hosts_count: hostsCount, query_results: queryResults, errors } = campaign;
     const hasNoResults = !queryIsRunning && (!hostsCount.successful || (!queryResults || !queryResults.length));
-    const hasErrors = !queryIsRunning && (hostsCount.failed && errors);
+    const hasErrors = !queryIsRunning && errors;
 
     const resultsTableWrapClass = classnames(baseClass, {
       [`${baseClass}--full-screen`]: isQueryFullScreen,
@@ -219,12 +219,12 @@ class QueryResultsTable extends Component {
           {!hasNoResults && renderTable()}
         </div>
         {hasErrors &&
-        <div className={`${baseClass}__error-table-container`}>
-          <span className={`${baseClass}__table-title`}>Errors</span>
-          <div className={`${baseClass}__error-table-wrapper`}>
-            {renderErrorsTable()}
+          <div className={`${baseClass}__error-table-container`}>
+            <span className={`${baseClass}__table-title`}>Errors</span>
+            <div className={`${baseClass}__error-table-wrapper`}>
+              {renderErrorsTable()}
+            </div>
           </div>
-        </div>
         }
       </div>
     );


### PR DESCRIPTION
This is a visual bug fix.

- Fixes a rendering issue in the Errors table in which the number "0" is rendered below the results table. This rendering issue occurs when the query is completed and no errors are returned.