### PR TITLE
Add fixes for IP labeling in UI and edit Hosts table styles

### DIFF
--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -17,6 +17,7 @@
   &:focus {
     outline: none;
     border-color: $core-blue;
+    border-top-color: $core-purple;
   }
 
   &--disabled {

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -282,7 +282,7 @@ export class HostDetailsPage extends Component {
               <div className="info__block">
                 <span className="info__header">Hardware model</span>
                 <span className="info__header">Serial number</span>
-                <span className="info__header">IPv4</span>
+                <span className="info__header">IP address</span>
               </div>
               <div className="info__block">
                 <span className="info__data">{aboutData.hardware_model}</span>

--- a/frontend/pages/hosts/ManageHostsPage/components/HostContainer/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostContainer/HostTableConfig.tsx
@@ -60,7 +60,7 @@ const hostDataHeaders: IHostDataColumn[] = [
     Cell: cellProps => <TextCell value={cellProps.cell.value} />,
   },
   {
-    title: 'IPv4',
+    title: 'IP address',
     Header: cellProps => <HeaderCell value={cellProps.column.title} isSortedDesc={cellProps.column.isSortedDesc} />,
     accessor: 'primary_ip',
     Cell: cellProps => <TextCell value={cellProps.cell.value} />,
@@ -91,7 +91,7 @@ const hostDataHeaders: IHostDataColumn[] = [
     Cell: cellProps => <TextCell value={cellProps.cell.value} />,
   },
   {
-    title: 'Memory',
+    title: 'RAM',
     Header: cellProps => <HeaderCell value={cellProps.column.title} isSortedDesc={cellProps.column.isSortedDesc} />,
     accessor: 'memory',
     Cell: cellProps => <TextCell value={cellProps.cell.value} formatter={humanHostMemory} />,


### PR DESCRIPTION
- Change column name in _Hosts_ table and section name on _Host details_ page from "IPv4" to "IP address". Fleet uses the IP of the most "active" (by bytes) interface. This could be v4 or v6.
- Change column name in _Hosts_ table from "Memory" to "RAM". Fleet uses the total amount of physical RAM (in bytes).
- Edit border styles for `focus` of input 
- Closes #361 and #363