### PR TITLE
Better handling of config_refresh values from clients

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,6 @@ jobs:
         make generate
         make
 
-    - name: Ensure Infra Dependencies
-      run: docker-compose up -d mysql redis mailhog
-    
     - name: Run E2E Tests
       run: |
         ./build/fleet prepare db --dev
@@ -141,9 +138,6 @@ jobs:
         export PATH=$PATH:~/go/bin
         make generate-go
 
-    - name: Ensure Infra Dependencies
-      run: docker-compose up -d mysql_test redis
-      
     - name: Run Go Tests
       run: |
         MYSQL_TEST=1 REDIS_TEST=1 make test-go

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -296,7 +296,7 @@ export class HostDetailsPage extends Component {
           <p className="section__header">Osquery configuration</p>
           <div className="info">
             <div className="info__item info__item--title">
-              <span className="info__header">Config TLS refresh</span>
+              <span className="info__header">Config refresh</span>
               <span className="info__data">{osqueryData.config_tls_refresh}</span>
             </div>
             <div className="info__item info__item--title">

--- a/server/service/service_osquery_test.go
+++ b/server/service/service_osquery_test.go
@@ -1405,6 +1405,25 @@ func TestUpdateHostIntervals(t *testing.T) {
 			}}`),
 			true,
 		},
+		// config_refresh should also cause an update
+		{
+			kolide.Host{
+				DistributedInterval: 11,
+				LoggerTLSPeriod:     33,
+				ConfigTLSRefresh:    60,
+			},
+			kolide.Host{
+				DistributedInterval: 11,
+				LoggerTLSPeriod:     33,
+				ConfigTLSRefresh:    42,
+			},
+			json.RawMessage(`{"options":{
+				"distributed_interval": 11,
+				"logger_tls_period":    33,
+				"config_refresh":    42
+			}}`),
+			true,
+		},
 		// SaveHost should not be called with no changes
 		{
 			kolide.Host{


### PR DESCRIPTION
Since the original logic was implemented, there have been some changes
in the way that config refreshes are configured. This commit reflects
those changes and should be backwards compatible.

Closes #357