### PR TITLE
Fix live query UI expanded view

### DIFF
--- a/frontend/components/queries/QueryResultsTable/_styles.scss
+++ b/frontend/components/queries/QueryResultsTable/_styles.scss
@@ -139,7 +139,6 @@
     }
 
     .query-results-table__results-table-wrapper {
-      height: auto;
       max-height: none;
     }
 

--- a/frontend/components/queries/QueryResultsTable/_styles.scss
+++ b/frontend/components/queries/QueryResultsTable/_styles.scss
@@ -140,6 +140,7 @@
 
     .query-results-table__results-table-wrapper {
       height: auto;
+      max-height: none;
     }
 
     .query-results-table__error-table-container {


### PR DESCRIPTION
- The expanded view for live query UI now fills the screen's height. Vertical scroll is allowed on the table if the results table's height larger than the screen's height.

Fixes #392 