### PR TITLE
Edit live query results table width for UI layout

### DIFF
--- a/frontend/components/queries/QueryResultsTable/QueryResultsTable.jsx
+++ b/frontend/components/queries/QueryResultsTable/QueryResultsTable.jsx
@@ -175,8 +175,6 @@ class QueryResultsTable extends Component {
     const { hosts_count: hostsCount, query_results: queryResults, errors } = campaign;
     const hasNoResults = !queryIsRunning && (!hostsCount.successful || (!queryResults || !queryResults.length));
     const hasErrors = !queryIsRunning && errors;
-    console.log(hasNoResults)
-    console.log(hasErrors)
 
     const resultsTableWrapClass = classnames(baseClass, {
       [`${baseClass}--full-screen`]: isQueryFullScreen,

--- a/frontend/components/queries/QueryResultsTable/QueryResultsTable.jsx
+++ b/frontend/components/queries/QueryResultsTable/QueryResultsTable.jsx
@@ -175,6 +175,8 @@ class QueryResultsTable extends Component {
     const { hosts_count: hostsCount, query_results: queryResults, errors } = campaign;
     const hasNoResults = !queryIsRunning && (!hostsCount.successful || (!queryResults || !queryResults.length));
     const hasErrors = !queryIsRunning && errors;
+    console.log(hasNoResults)
+    console.log(hasErrors)
 
     const resultsTableWrapClass = classnames(baseClass, {
       [`${baseClass}--full-screen`]: isQueryFullScreen,

--- a/frontend/components/queries/QueryResultsTable/_styles.scss
+++ b/frontend/components/queries/QueryResultsTable/_styles.scss
@@ -161,11 +161,11 @@
 
 @keyframes growFullScreen {
   100% {
-    top: $pad-half;
+    top: 60px;
     right: $pad-half;
     bottom: $pad-half;
-    left: calc(#{$nav-tablet-width} + #{$pad-half});
-    max-width: calc(100vw - #{$nav-tablet-width} - #{$pad-half} - #{$pad-half});
+    left: $pad-half;
+    max-width: calc(100vw - #{$pad-half} - #{$pad-half});
     max-height: 100vh;
   }
 }

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -62,6 +62,7 @@ a {
     .has-sidebar & {
       margin-right: 0;
       min-width: 610px;
+      max-width: calc(100vw - #{$pad-body} - #{$pad-body} - #{$pad-borders} - #{$sidepanel-width});
     }
   }
 }


### PR DESCRIPTION
- Fixes #413. Reintroduce a `max-width` for the`.has-sidebar` selector. This prevents the query results table from horizontally overflowing the screen's width.
- Adjust the positioning of the expanded live query results table to fit the new layout
https://www.loom.com/share/891e6af2723f44db91f7d2f003d4774e