### PR TITLE
Make host identifier configurable within Fleet

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -109,6 +109,16 @@ the way that the Fleet server works.
 				config.Filesystem.EnableLogRotation = config.Osquery.EnableLogRotation
 			}
 
+			allowedHostIdentifiers := map[string]bool{
+				"provided": true,
+				"instance": true,
+				"uuid":     true,
+				"hostname": true,
+			}
+			if !allowedHostIdentifiers[config.Osquery.HostIdentifier] {
+				initFatal(errors.Errorf("%s is not a valid value for osquery_host_identifier", config.Osquery.HostIdentifier), "set host identifier")
+			}
+
 			if len(config.Server.URLPrefix) > 0 {
 				// Massage provided prefix to match expected format
 				config.Server.URLPrefix = strings.TrimSuffix(config.Server.URLPrefix, "/")

--- a/docs/2-Deployment/2-Configuration.md
+++ b/docs/2-Deployment/2-Configuration.md
@@ -544,6 +544,22 @@ The size of the node key which is negotiated with `osqueryd` clients.
 		node_key_size: 36
 	```
 
+###### `osquery_host_identifier`
+
+The identifier to use when determining uniqueness of hosts.
+
+Options are `instance` (default), `uuid`, `hostname`, or `provided`.
+
+This setting works in combination with the `--host_identifier` flag in osquery. In most deployments, using the default value of `instance` is appropriate. `instance`, `uuid`, and `hostname` correspond to the same meanings as osquery's `--host_identifier` flag. `provided` instructs Fleet to use whichever identifier is provided by osquery.
+
+- Default value: `instance`
+- Environment variable:	`FLEET_OSQUERY_HOST_IDENTIFIER`
+- Config file format:
+
+	```
+	osquery:
+		host_identifier: uuid
+	```
 
 ###### `osquery_label_update_interval`
 

--- a/docs/2-Deployment/2-Configuration.md
+++ b/docs/2-Deployment/2-Configuration.md
@@ -550,9 +550,9 @@ The identifier to use when determining uniqueness of hosts.
 
 Options are `instance` (default), `uuid`, `hostname`, or `provided`.
 
-This setting works in combination with the `--host_identifier` flag in osquery. In most deployments, using the default value of `instance` is appropriate. `instance`, `uuid`, and `hostname` correspond to the same meanings as osquery's `--host_identifier` flag. `provided` instructs Fleet to use whichever identifier is provided by osquery.
+This setting works in combination with the `--host_identifier` flag in osquery. In most deployments, using `instance` will be the best option. The flag defaults to `provided` -- preserving the existing behavior of Fleet's handling of host identifiers -- using the identifier provided by osquery. `instance`, `uuid`, and `hostname` correspond to the same meanings as for osquery's `--host_identifier` flag. 
 
-- Default value: `instance`
+- Default value: `provided`
 - Environment variable:	`FLEET_OSQUERY_HOST_IDENTIFIER`
 - Config file format:
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -80,6 +80,7 @@ type SessionConfig struct {
 // OsqueryConfig defines configs related to osquery
 type OsqueryConfig struct {
 	NodeKeySize          int           `yaml:"node_key_size"`
+	HostIdentifier       string        `yaml:"host_identifier"`
 	StatusLogPlugin      string        `yaml:"status_log_plugin"`
 	ResultLogPlugin      string        `yaml:"result_log_plugin"`
 	LabelUpdateInterval  time.Duration `yaml:"label_update_interval"`
@@ -252,6 +253,8 @@ func (man Manager) addConfigs() {
 	// Osquery
 	man.addConfigInt("osquery.node_key_size", 24,
 		"Size of generated osqueryd node keys")
+	man.addConfigString("osquery.host_identifier", "instance",
+		"Identifier used to uniquely determine osquery clients")
 	man.addConfigString("osquery.status_log_plugin", "filesystem",
 		"Log plugin to use for status logs")
 	man.addConfigString("osquery.result_log_plugin", "filesystem",
@@ -406,6 +409,7 @@ func (man Manager) LoadConfig() KolideConfig {
 		},
 		Osquery: OsqueryConfig{
 			NodeKeySize:          man.getConfigInt("osquery.node_key_size"),
+			HostIdentifier:       man.getConfigString("osquery.host_identifier"),
 			StatusLogPlugin:      man.getConfigString("osquery.status_log_plugin"),
 			ResultLogPlugin:      man.getConfigString("osquery.result_log_plugin"),
 			StatusLogFile:        man.getConfigString("osquery.status_log_file"),
@@ -676,6 +680,7 @@ func TestConfig() KolideConfig {
 		},
 		Osquery: OsqueryConfig{
 			NodeKeySize:          24,
+			HostIdentifier:       "instance",
 			StatusLogPlugin:      "filesystem",
 			ResultLogPlugin:      "filesystem",
 			LabelUpdateInterval:  1 * time.Hour,

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -253,7 +253,7 @@ func (man Manager) addConfigs() {
 	// Osquery
 	man.addConfigInt("osquery.node_key_size", 24,
 		"Size of generated osqueryd node keys")
-	man.addConfigString("osquery.host_identifier", "instance",
+	man.addConfigString("osquery.host_identifier", "provided",
 		"Identifier used to uniquely determine osquery clients")
 	man.addConfigString("osquery.status_log_plugin", "filesystem",
 		"Log plugin to use for status logs")

--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fleetdm/fleet/server/kolide"
 	"github.com/fleetdm/fleet/server/pubsub"
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/spf13/cast"
 )
@@ -89,6 +90,8 @@ func (svc service) EnrollAgent(ctx context.Context, enrollSecret, hostIdentifier
 		}
 	}
 
+	hostIdentifier = getHostIdentifier(svc.logger, svc.config.Osquery.HostIdentifier, hostIdentifier, hostDetails)
+
 	host, err := svc.ds.EnrollHost(hostIdentifier, nodeKey, secretName)
 	if err != nil {
 		return "", osqueryError{message: "save enroll failed: " + err.Error(), nodeInvalid: true}
@@ -115,6 +118,73 @@ func (svc service) EnrollAgent(ctx context.Context, enrollSecret, hostIdentifier
 	}
 
 	return host.NodeKey, nil
+}
+
+func getHostIdentifier(logger log.Logger, identifierOption, providedIdentifier string, details map[string](map[string]string)) string {
+	switch identifierOption {
+	case "provided":
+		// Use the host identifier already provided in the request.
+		return providedIdentifier
+
+	case "instance":
+		r, ok := details["osquery_info"]
+		if !ok {
+			level.Info(logger).Log(
+				"msg", "could not get host identifier",
+				"reason", "missing osquery_info",
+				"identifier", "instance",
+			)
+		} else if r["instance_id"] == "" {
+			level.Info(logger).Log(
+				"msg", "could not get host identifier",
+				"reason", "missing instance_id in osquery_info",
+				"identifier", "instance",
+			)
+		} else {
+			return r["instance_id"]
+		}
+
+	case "uuid":
+		r, ok := details["osquery_info"]
+		if !ok {
+			level.Info(logger).Log(
+				"msg", "could not get host identifier",
+				"reason", "missing osquery_info",
+				"identifier", "uuid",
+			)
+		} else if r["uuid"] == "" {
+			level.Info(logger).Log(
+				"msg", "could not get host identifier",
+				"reason", "missing instance_id in osquery_info",
+				"identifier", "uuid",
+			)
+		} else {
+			return r["uuid"]
+		}
+
+	case "hostname":
+		r, ok := details["system_info"]
+		if !ok {
+			level.Info(logger).Log(
+				"msg", "could not get host identifier",
+				"reason", "missing system_info",
+				"identifier", "hostname",
+			)
+		} else if r["hostname"] == "" {
+			level.Info(logger).Log(
+				"msg", "could not get host identifier",
+				"reason", "missing instance_id in system_info",
+				"identifier", "hostname",
+			)
+		} else {
+			return r["hostname"]
+		}
+
+	default:
+		panic("Unknown option for host_identifier: " + identifierOption)
+	}
+
+	return providedIdentifier
 }
 
 func (svc service) GetClientConfig(ctx context.Context) (map[string]interface{}, error) {


### PR DESCRIPTION
Osquery now exposes more information during host enrollment than Fleet
previously handled. We can use this to provide more options to users in
problematic enrollment scenarios.

Users can configure `--osquery_host_identifier` in Fleet to set which
identifier is used to determine uniqueness of hosts. The
default (`provided`) replicates existing behavior in Fleet. For many
users, setting this to `instance` will provide better enrollment
stability.

Closes #373