### PR TITLE
Make enrollment cooldown configurable

### DIFF
--- a/docs/2-Deployment/2-Configuration.md
+++ b/docs/2-Deployment/2-Configuration.md
@@ -550,7 +550,9 @@ The identifier to use when determining uniqueness of hosts.
 
 Options are `instance` (default), `uuid`, `hostname`, or `provided`.
 
-This setting works in combination with the `--host_identifier` flag in osquery. In most deployments, using `instance` will be the best option. The flag defaults to `provided` -- preserving the existing behavior of Fleet's handling of host identifiers -- using the identifier provided by osquery. `instance`, `uuid`, and `hostname` correspond to the same meanings as for osquery's `--host_identifier` flag. 
+This setting works in combination with the `--host_identifier` flag in osquery. In most deployments, using `instance` will be the best option. The flag defaults to `provided` -- preserving the existing behavior of Fleet's handling of host identifiers -- using the identifier provided by osquery. `instance`, `uuid`, and `hostname` correspond to the same meanings as for osquery's `--host_identifier` flag.
+
+Users that have duplicate UUIDs in their environment can benefit from setting this flag to `instance`.
 
 - Default value: `provided`
 - Environment variable:	`FLEET_OSQUERY_HOST_IDENTIFIER`
@@ -559,6 +561,21 @@ This setting works in combination with the `--host_identifier` flag in osquery. 
 	```
 	osquery:
 		host_identifier: uuid
+	```
+
+###### `osquery_enroll_cooldown`
+
+The cooldown period for host enrollment. If a host (uniquely identified by the `osquery_host_identifier` option) tries to enroll within this duration from the last enrollment, enroll will fail.
+
+This flag can be used to control load on the database in scenarios in which many hosts are using the same identifier. Often configuring `osquery_host_identifier` to `instance` may be a better solution.
+
+- Default value: `0` (off)
+- Environment variable: `FLEET_ENROLL_COOLDOWN`
+- Config file format:
+
+	```
+	osquery:
+		enroll_cooldown: 1m
 	```
 
 ###### `osquery_label_update_interval`

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -81,6 +81,7 @@ type SessionConfig struct {
 type OsqueryConfig struct {
 	NodeKeySize          int           `yaml:"node_key_size"`
 	HostIdentifier       string        `yaml:"host_identifier"`
+	EnrollCooldown       time.Duration `yaml:"enroll_cooldown"`
 	StatusLogPlugin      string        `yaml:"status_log_plugin"`
 	ResultLogPlugin      string        `yaml:"result_log_plugin"`
 	LabelUpdateInterval  time.Duration `yaml:"label_update_interval"`
@@ -255,6 +256,8 @@ func (man Manager) addConfigs() {
 		"Size of generated osqueryd node keys")
 	man.addConfigString("osquery.host_identifier", "provided",
 		"Identifier used to uniquely determine osquery clients")
+	man.addConfigDuration("osquery.enroll_cooldown", 0,
+		"Cooldown period for duplicate host enrollment (default off)")
 	man.addConfigString("osquery.status_log_plugin", "filesystem",
 		"Log plugin to use for status logs")
 	man.addConfigString("osquery.result_log_plugin", "filesystem",
@@ -410,6 +413,7 @@ func (man Manager) LoadConfig() KolideConfig {
 		Osquery: OsqueryConfig{
 			NodeKeySize:          man.getConfigInt("osquery.node_key_size"),
 			HostIdentifier:       man.getConfigString("osquery.host_identifier"),
+			EnrollCooldown:       man.getConfigDuration("osquery.enroll_cooldown"),
 			StatusLogPlugin:      man.getConfigString("osquery.status_log_plugin"),
 			ResultLogPlugin:      man.getConfigString("osquery.result_log_plugin"),
 			StatusLogFile:        man.getConfigString("osquery.status_log_file"),
@@ -681,6 +685,7 @@ func TestConfig() KolideConfig {
 		Osquery: OsqueryConfig{
 			NodeKeySize:          24,
 			HostIdentifier:       "instance",
+			EnrollCooldown:       42 * time.Minute,
 			StatusLogPlugin:      "filesystem",
 			ResultLogPlugin:      "filesystem",
 			LabelUpdateInterval:  1 * time.Hour,

--- a/server/datastore/datastore_labels_test.go
+++ b/server/datastore/datastore_labels_test.go
@@ -19,7 +19,7 @@ func testLabels(t *testing.T, db kolide.Datastore) {
 	var host *kolide.Host
 	var err error
 	for i := 0; i < 10; i++ {
-		host, err = db.EnrollHost(fmt.Sprint(i), fmt.Sprint(i), "default")
+		host, err = db.EnrollHost(fmt.Sprint(i), fmt.Sprint(i), "default", 0)
 		require.Nil(t, err, "enrollment should succeed")
 		hosts = append(hosts, *host)
 	}

--- a/server/datastore/datastore_targets_test.go
+++ b/server/datastore/datastore_targets_test.go
@@ -129,7 +129,7 @@ func testHostStatus(t *testing.T, ds kolide.Datastore) {
 
 	mockClock := clock.NewMockClock()
 
-	h, err := ds.EnrollHost("1", "key1", "default")
+	h, err := ds.EnrollHost("1", "key1", "default", 0)
 	require.Nil(t, err)
 
 	// Make host no longer appear new

--- a/server/datastore/inmem/hosts.go
+++ b/server/datastore/inmem/hosts.go
@@ -157,7 +157,7 @@ func (d *Datastore) GenerateHostStatusStatistics(now time.Time) (online, offline
 	return online, offline, mia, new, nil
 }
 
-func (d *Datastore) EnrollHost(osQueryHostID, nodeKey, secretName string) (*kolide.Host, error) {
+func (d *Datastore) EnrollHost(osQueryHostID, nodeKey, secretName string, cooldown time.Duration) (*kolide.Host, error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -289,7 +289,7 @@ func (d *Datastore) GenerateHostStatusStatistics(now time.Time) (online, offline
 }
 
 // EnrollHost enrolls a host
-func (d *Datastore) EnrollHost(osqueryHostID, nodeKey, secretName string) (*kolide.Host, error) {
+func (d *Datastore) EnrollHost(osqueryHostID, nodeKey, secretName string, cooldown time.Duration) (*kolide.Host, error) {
 	if osqueryHostID == "" {
 		return nil, fmt.Errorf("missing osquery host identifier")
 	}
@@ -328,7 +328,7 @@ func (d *Datastore) EnrollHost(osqueryHostID, nodeKey, secretName string) (*koli
 			// Prevent hosts from enrolling too often with the same identifier.
 			// Prior to adding this we saw many hosts (probably VMs) with the
 			// same identifier competing for enrollment and causing perf issues.
-			if time.Since(host.LastEnrollTime) < kolide.HostEnrollCooldown {
+			if cooldown > 0 && time.Since(host.LastEnrollTime) < cooldown {
 				return backoff.Permanent(fmt.Errorf("host identified by %s enrolling too often", osqueryHostID))
 			}
 			id = int64(host.ID)

--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -33,12 +33,6 @@ const (
 	// online interval to avoid flapping of hosts that check in a bit later
 	// than their expected checkin interval.
 	OnlineIntervalBuffer = 30
-
-	// HostEnrollCooldown is how often a host can enroll. Users sometimes deploy
-	// osquery in a configuration in which multiple hosts use the same host
-	// identifier and Fleet needs to have a cooldown period to prevent this from
-	// cascading into out of control host enrollment.
-	HostEnrollCooldown = 1 * time.Minute
 )
 
 type HostStore interface {
@@ -50,8 +44,9 @@ type HostStore interface {
 	Host(id uint) (*Host, error)
 	// EnrollHost will enroll a new host with the given identifier, setting the
 	// node key, and enroll secret used for the host. Implementations of this
-	// method should respect HostEnrollCooldown.
-	EnrollHost(osqueryHostId, nodeKey, secretName string) (*Host, error)
+	// method should respect the provided host enrollment cooldown, by returning
+	// an error if the host has enrolled within the cooldown period.
+	EnrollHost(osqueryHostId, nodeKey, secretName string, cooldown time.Duration) (*Host, error)
 	ListHosts(opt HostListOptions) ([]*Host, error)
 	// AuthenticateHost authenticates and returns host metadata by node key.
 	// This method should not return the host "additional" information as this

--- a/server/mock/datastore_hosts.go
+++ b/server/mock/datastore_hosts.go
@@ -22,7 +22,7 @@ type HostByIdentifierFunc func(identifier string) (*kolide.Host, error)
 
 type ListHostsFunc func(opt kolide.HostListOptions) ([]*kolide.Host, error)
 
-type EnrollHostFunc func(osqueryHostId, nodeKey, secretName string) (*kolide.Host, error)
+type EnrollHostFunc func(osqueryHostId, nodeKey, secretName string, cooldown time.Duration) (*kolide.Host, error)
 
 type AuthenticateHostFunc func(nodeKey string) (*kolide.Host, error)
 
@@ -112,9 +112,9 @@ func (s *HostStore) ListHosts(opt kolide.HostListOptions) ([]*kolide.Host, error
 	return s.ListHostsFunc(opt)
 }
 
-func (s *HostStore) EnrollHost(osqueryHostId, nodeKey, secretName string) (*kolide.Host, error) {
+func (s *HostStore) EnrollHost(osqueryHostId, nodeKey, secretName string, cooldown time.Duration) (*kolide.Host, error) {
 	s.EnrollHostFuncInvoked = true
-	return s.EnrollHostFunc(osqueryHostId, nodeKey, secretName)
+	return s.EnrollHostFunc(osqueryHostId, nodeKey, secretName, cooldown)
 }
 
 func (s *HostStore) AuthenticateHost(nodeKey string) (*kolide.Host, error) {

--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -92,7 +92,7 @@ func (svc service) EnrollAgent(ctx context.Context, enrollSecret, hostIdentifier
 
 	hostIdentifier = getHostIdentifier(svc.logger, svc.config.Osquery.HostIdentifier, hostIdentifier, hostDetails)
 
-	host, err := svc.ds.EnrollHost(hostIdentifier, nodeKey, secretName)
+	host, err := svc.ds.EnrollHost(hostIdentifier, nodeKey, secretName, svc.config.Osquery.EnrollCooldown)
 	if err != nil {
 		return "", osqueryError{message: "save enroll failed: " + err.Error(), nodeInvalid: true}
 	}

--- a/server/service/service_osquery_test.go
+++ b/server/service/service_osquery_test.go
@@ -36,7 +36,7 @@ func TestEnrollAgent(t *testing.T) {
 			return "", errors.New("not found")
 		}
 	}
-	ds.EnrollHostFunc = func(osqueryHostId, nodeKey, secretName string) (*kolide.Host, error) {
+	ds.EnrollHostFunc = func(osqueryHostId, nodeKey, secretName string, cooldown time.Duration) (*kolide.Host, error) {
 		return &kolide.Host{
 			OsqueryHostID: osqueryHostId, NodeKey: nodeKey, EnrollSecretName: secretName,
 		}, nil
@@ -74,7 +74,7 @@ func TestEnrollAgentDetails(t *testing.T) {
 	ds.VerifyEnrollSecretFunc = func(secret string) (string, error) {
 		return "valid", nil
 	}
-	ds.EnrollHostFunc = func(osqueryHostId, nodeKey, secretName string) (*kolide.Host, error) {
+	ds.EnrollHostFunc = func(osqueryHostId, nodeKey, secretName string, cooldown time.Duration) (*kolide.Host, error) {
 		return &kolide.Host{
 			OsqueryHostID: osqueryHostId, NodeKey: nodeKey, EnrollSecretName: secretName,
 		}, nil


### PR DESCRIPTION
The enrollment cooldown period was sometimes causing problems when
osquery (probably unintentionally, see
https://github.com/osquery/osquery/issues/6993) tried to enroll more
than once from the same osqueryd process.

We now set this to default to off and make it configurable. With #417
this feature may be unnecessary for most deployments.