### PR TITLE
More defensive handling of edge cases for IP detection

### DIFF
--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -365,9 +365,18 @@ var detailQueries = map[string]struct {
 			}
 
 			// If only link-local and loopback found, still use the first
-			// interface.
-			host.PrimaryIP = rows[0]["address"]
-			host.PrimaryMac = rows[0]["mac"]
+			// nonempty interface.
+			for _, row := range rows {
+				if row["address"] != "" {
+					host.PrimaryIP = row["address"]
+					host.PrimaryMac = row["mac"]
+					return nil
+				}
+			}
+
+			logger.Log("component", "service", "method", "IngestFunc", "err",
+				"found no nonempty network interfaces", "host", host.HostName)
+
 			return nil
 		},
 	},


### PR DESCRIPTION
Save the first nonempty IP address if no preferred IP address is
available. Previously we just used the first interface, and it's
possible this could have had an empty address value.

Possibly fixes #358