### PR TITLE
Fix flapping IP addresses

### DIFF
--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -371,40 +371,7 @@ func (d *Datastore) EnrollHost(osqueryHostID, nodeKey, secretName string, cooldo
 
 func (d *Datastore) AuthenticateHost(nodeKey string) (*kolide.Host, error) {
 	sqlStatement := `
-		SELECT
-			id,
-			osquery_host_id,
-			created_at,
-			updated_at,
-			detail_update_time,
-			label_update_time,
-			node_key,
-			host_name,
-			uuid,
-			platform,
-			osquery_version,
-			os_version,
-			build,
-			platform_like,
-			code_name,
-			uptime,
-			physical_memory,
-			cpu_type,
-			cpu_subtype,
-			cpu_brand,
-			cpu_physical_cores,
-			cpu_logical_cores,
-			hardware_vendor,
-			hardware_model,
-			hardware_version,
-			hardware_serial,
-			computer_name,
-			primary_ip_id,
-			seen_time,
-			distributed_interval,
-			logger_tls_period,
-			config_tls_refresh,
-			enroll_secret_name
+		SELECT *
 		FROM hosts
 		WHERE node_key = ?
 		LIMIT 1

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -370,8 +370,44 @@ func (d *Datastore) EnrollHost(osqueryHostID, nodeKey, secretName string, cooldo
 }
 
 func (d *Datastore) AuthenticateHost(nodeKey string) (*kolide.Host, error) {
+	// Select everything besides `additional`
 	sqlStatement := `
-		SELECT *
+		SELECT
+			id,
+			osquery_host_id,
+			created_at,
+			updated_at,
+			detail_update_time,
+			label_update_time,
+			node_key,
+			host_name,
+			uuid,
+			platform,
+			osquery_version,
+			os_version,
+			build,
+			platform_like,
+			code_name,
+			uptime,
+			physical_memory,
+			cpu_type,
+			cpu_subtype,
+			cpu_brand,
+			cpu_physical_cores,
+			cpu_logical_cores,
+			hardware_vendor,
+			hardware_model,
+			hardware_version,
+			hardware_serial,
+			computer_name,
+			primary_ip_id,
+			seen_time,
+			distributed_interval,
+			logger_tls_period,
+			config_tls_refresh,
+			primary_ip,
+			primary_mac,
+			enroll_secret_name
 		FROM hosts
 		WHERE node_key = ?
 		LIMIT 1

--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -745,7 +745,6 @@ func (svc service) SubmitDistributedQueryResults(ctx context.Context, results ko
 		if err != nil {
 			return osqueryError{message: "failed to ingest result: " + err.Error()}
 		}
-
 	}
 
 	if len(labelResults) > 0 {

--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -717,6 +717,20 @@ func (svc service) SubmitDistributedQueryResults(ctx context.Context, results ko
 		return osqueryError{message: "internal error: missing host from request context"}
 	}
 
+	// Check for label queries and if so, load host additional. If we don't do
+	// this, we will end up unintentionally dropping any existing host
+	// additional info.
+	for query, _ := range results {
+		if strings.HasPrefix(query, hostLabelQueryPrefix) {
+			fullHost, err := svc.ds.Host(host.ID)
+			if err != nil {
+				return osqueryError{message: "internal error: load host additional: " + err.Error()}
+			}
+			host = *fullHost
+			break
+		}
+	}
+
 	var err error
 	detailUpdated := false // Whether detail or additional was updated
 	additionalResults := make(kolide.OsqueryDistributedQueryResults)

--- a/server/service/service_osquery_test.go
+++ b/server/service/service_osquery_test.go
@@ -280,11 +280,16 @@ func TestLabelQueries(t *testing.T) {
 	svc, err := newTestServiceWithClock(ds, nil, lq, mockClock)
 	require.Nil(t, err)
 
+	host := &kolide.Host{}
+
 	ds.LabelQueriesForHostFunc = func(host *kolide.Host, cutoff time.Time) (map[string]string, error) {
 		return map[string]string{}, nil
 	}
 	ds.DistributedQueriesForHostFunc = func(host *kolide.Host) (map[uint]string, error) {
 		return map[uint]string{}, nil
+	}
+	ds.HostFunc = func(id uint) (*kolide.Host, error) {
+		return host, nil
 	}
 	ds.SaveHostFunc = func(host *kolide.Host) error {
 		return nil
@@ -295,7 +300,6 @@ func TestLabelQueries(t *testing.T) {
 
 	lq.On("QueriesForHost", uint(0)).Return(map[string]string{}, nil)
 
-	host := &kolide.Host{}
 	ctx := hostctx.NewContext(context.Background(), *host)
 
 	// With a new host, we should get the detail queries (and accelerate


### PR DESCRIPTION
The AuthenticateHost loading of hosts accidentally dropped IP addresses,
which would cause the IP to be dropped on save under certain scenarios.

Fixes #358