### PR TITLE
Display All Hosts label on host detail page

### DIFF
--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -147,8 +147,7 @@ export class HostDetailsPage extends Component {
     const { host } = this.props;
     const { labels = [] } = host;
 
-    const filteredLabels = labels.filter(label => label.name !== 'All Hosts');
-    const labelItems = filteredLabels.map((label) => {
+    const labelItems = labels.map((label) => {
       return (
         <li className="list__item" key={label.id}>
           <Button


### PR DESCRIPTION
All Hosts is a label after all, and maybe it's best to render it on
every page rather than hiding it?