### PR TITLE
fix deleting host breaking host table

### DIFF
--- a/frontend/redux/nodes/entities/base/config.js
+++ b/frontend/redux/nodes/entities/base/config.js
@@ -1,5 +1,5 @@
 import BaseConfig from 'redux/nodes/entities/base/base_config';
-import { entitiesExceptID } from 'redux/nodes/entities/base/helpers';
+import { entitiesExceptID, orderExceptId } from 'redux/nodes/entities/base/helpers';
 
 class ReduxConfig extends BaseConfig {
   get actions () {
@@ -56,6 +56,7 @@ class ReduxConfig extends BaseConfig {
             data: {
               ...entitiesExceptID(state.data, payload.data),
             },
+            originalOrder: orderExceptId(state.originalOrder, payload.data),
           };
         }
         case actionTypes.CREATE_FAILURE:

--- a/frontend/redux/nodes/entities/base/config_reducer.tests.js
+++ b/frontend/redux/nodes/entities/base/config_reducer.tests.js
@@ -9,6 +9,7 @@ describe('ReduxConfig - reducer', () => {
     data: {
       [userStub.id]: userStub,
     },
+    originalOrder: [userStub.id],
   };
 
   describe('creating an entity', () => {
@@ -69,6 +70,7 @@ describe('ReduxConfig - reducer', () => {
           loading: false,
           errors: {},
           data: {},
+          originalOrder: [],
         });
       });
     });

--- a/frontend/redux/nodes/entities/base/helpers.js
+++ b/frontend/redux/nodes/entities/base/helpers.js
@@ -6,6 +6,10 @@ export const entitiesExceptID = (entities, id) => {
   });
 };
 
+export const orderExceptId = (originalOrder, id) => {
+  return originalOrder.filter(entitiesId => entitiesId !== id);
+};
+
 const formatServerErrors = (errors) => {
   if (!errors || !errors.length) {
     return {};
@@ -35,4 +39,4 @@ export const formatErrorResponse = (errorResponse) => {
   };
 };
 
-export default { entitiesExceptID, formatErrorResponse };
+export default { entitiesExceptID, orderExceptId, formatErrorResponse };

--- a/frontend/redux/nodes/entities/base/helpers.tests.js
+++ b/frontend/redux/nodes/entities/base/helpers.tests.js
@@ -1,4 +1,4 @@
-import { entitiesExceptID, formatErrorResponse } from './helpers';
+import { entitiesExceptID, orderExceptId, formatErrorResponse } from './helpers';
 
 describe('reduxConfig - helpers', () => {
   describe('#entitiesExceptID', () => {
@@ -21,6 +21,13 @@ describe('reduxConfig - helpers', () => {
       expect(entitiesExceptID(entities, id)).toEqual({
         2: { name: 'Dog' },
       });
+    });
+  });
+
+  describe('#orderExceptId', () => {
+    it('returns a new orderId array with the deleted entityID no longer in this array', () => {
+      const originalOrder = [1, 2, 3, 4];
+      expect(orderExceptId(originalOrder, 3)).toEqual([1, 2, 4]);
     });
   });
 


### PR DESCRIPTION
This fixes a bug when you delete a host and the data table rendering breaks when it goes back to the manage host page

Fixes #387 