### PR TITLE
server: prune unused constants and functions

### DIFF
--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -275,10 +275,6 @@ func (d *Datastore) Close() error {
 	return d.db.Close()
 }
 
-func (d *Datastore) log(msg string) {
-	d.logger.Log("comp", d.Name(), "msg", msg)
-}
-
 func sanitizeColumn(col string) string {
 	return columnCharsRegexp.ReplaceAllString(col, "")
 }

--- a/server/kolide/users_test.go
+++ b/server/kolide/users_test.go
@@ -18,8 +18,6 @@ func TestValidatePassword(t *testing.T) {
 		{"jason", "bar0baz!?", "jason@kolide.co", true, false},
 	}
 
-	const bcryptCost = 6
-
 	for _, tt := range passwordTests {
 		user := newTestUser(t, tt.Username, tt.Password, tt.Email)
 

--- a/server/service/service_sessions_test.go
+++ b/server/service/service_sessions_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const bcryptCost = 6
-
 func TestAuthenticate(t *testing.T) {
 	ds, err := inmem.New(config.TestConfig())
 	require.Nil(t, err)

--- a/server/sso/authorization_response.go
+++ b/server/sso/authorization_response.go
@@ -106,13 +106,6 @@ func (r resp) rawResponse() string {
 	return r.rawResp
 }
 
-func (r resp) authResponse() (*Response, error) {
-	if r.response != nil {
-		return r.response, nil
-	}
-	return nil, errors.New("missing SAML response")
-}
-
 // DecodeAuthResponse extracts SAML assertions from IDP response
 func DecodeAuthResponse(samlResponse string) (kolide.Auth, error) {
 	var authInfo resp

--- a/server/sso/types.go
+++ b/server/sso/types.go
@@ -21,7 +21,6 @@ type AuthnRequest struct {
 	NameIDPolicy                *NameIDPolicy          `xml:"NameIDPolicy,omitempty"`
 	RequestedAuthnContext       *RequestedAuthnContext `xml:"RequestedAuthnContext,omitempty"`
 	Signature                   *Signature             `xml:"Signature,omitempty"`
-	originalString              string
 }
 
 // Response is submitted to the service provider (Kolide) from the IDP via a callback.
@@ -43,8 +42,6 @@ type Response struct {
 	Signature Signature `xml:"Signature"`
 	Issuer    Issuer    `xml:"Issuer"`
 	Status    Status    `xml:"Status"`
-
-	originalString string
 }
 
 type Issuer struct {

--- a/server/websocket/websocket.go
+++ b/server/websocket/websocket.go
@@ -4,7 +4,6 @@ package websocket
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/igm/sockjs-go/v3/sockjs"
 
@@ -13,20 +12,11 @@ import (
 )
 
 const (
-	// maxMessageSize is used to set a read limit on the websocket and
-	// prevent clients from flooding us with data.
-	maxMessageSize int64 = 8096
-
 	// authType is the type string used for auth messages.
 	authType string = "auth"
 
 	// errType is the type string used for error messages.
 	errType string = "error"
-
-	// defaultTimeout is the default timeout that should be used for
-	// sending and receiving over the websocket. It is used unless
-	// Conn.Timeout is set explicitly after Upgrade is called.
-	defaultTimeout time.Duration = 3 * time.Second
 )
 
 // JSONMessage is a wrapper struct for messages that will be sent across the wire


### PR DESCRIPTION
This removes unused `const` variables and functions from `server` and its subpackages.