### PR TITLE
Speed up labels MySQL tests

### DIFF
--- a/server/datastore/datastore_labels_test.go
+++ b/server/datastore/datastore_labels_test.go
@@ -433,7 +433,7 @@ func testChangeLabelDetails(t *testing.T, db kolide.Datastore) {
 }
 
 func setupLabelSpecsTest(t *testing.T, ds kolide.Datastore) []*kolide.LabelSpec {
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 10; i++ {
 		_, err := ds.NewHost(&kolide.Host{
 			DetailUpdateTime: time.Now(),
 			LabelUpdateTime:  time.Now(),


### PR DESCRIPTION
This saves a few seconds per test by only creating 10 hosts rather than
1000. The tests required no further changes as they were not using more
than the first few created hosts.