### PR TITLE
Remove https check for client connection

### DIFF
--- a/server/service/client.go
+++ b/server/service/client.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -38,6 +39,10 @@ func NewClient(addr string, insecureSkipVerify bool, rootCA, urlPrefix string, o
 	baseURL, err := url.Parse(addr)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing URL")
+	}
+
+	if baseURL.Scheme != "https" && !strings.Contains(baseURL.Host, "localhost") {
+		return nil, errors.New("address must start with https:// for remote connections")
 	}
 
 	rootCAPool := x509.NewCertPool()

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -36,10 +35,6 @@ type ClientOption func(*Client) error
 func NewClient(addr string, insecureSkipVerify bool, rootCA, urlPrefix string, options ...ClientOption) (*Client, error) {
 	// TODO #265 refactor all optional parameters to functional options
 	// API breaking change, needs a major version release
-	if !strings.HasPrefix(addr, "https://") {
-		return nil, errors.New("Address must start with https://")
-	}
-
 	baseURL, err := url.Parse(addr)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing URL")


### PR DESCRIPTION
This fixes an issue where if we are running the fleet server on
HTTP instead of HTTPS, fleetctl would fail to connect even with
--tls-skip-verify.