### PR TITLE
Log all errors regardless of log level

### DIFF
--- a/server/service/logging.go
+++ b/server/service/logging.go
@@ -1,9 +1,9 @@
 package service
 
 import (
+	"github.com/fleetdm/fleet/server/kolide"
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
-	"github.com/fleetdm/fleet/server/kolide"
 )
 
 // logging middleware logs the service actions
@@ -17,8 +17,11 @@ func NewLoggingService(svc kolide.Service, logger kitlog.Logger) kolide.Service 
 	return loggingMiddleware{Service: svc, logger: logger}
 }
 
-// loggerDebug returns the debug level
+// loggerDebug returns the debug level if the error is nil, or else the Info level.
 func (mw loggingMiddleware) loggerDebug(err error) kitlog.Logger {
+	if err != nil {
+		return level.Info(mw.logger)
+	}
 	return level.Debug(mw.logger)
 }
 

--- a/server/service/logging.go
+++ b/server/service/logging.go
@@ -17,7 +17,7 @@ func NewLoggingService(svc kolide.Service, logger kitlog.Logger) kolide.Service 
 	return loggingMiddleware{Service: svc, logger: logger}
 }
 
-// loggerDebug returns the debug level if the error is nil, or else the Info level.
+// loggerDebug returns the the info level if there error is non-nil, otherwise defaulting to the debug level.
 func (mw loggingMiddleware) loggerDebug(err error) kitlog.Logger {
 	if err != nil {
 		return level.Info(mw.logger)


### PR DESCRIPTION
Modify the loggerDebug function to check whether the error is nil before
choosing the log level.

Fixes #473