### PR TITLE
Update Helm README with deploy command using published chart

### DIFF
--- a/charts/fleet/README.md
+++ b/charts/fleet/README.md
@@ -58,7 +58,8 @@ To configure how Fleet runs, such as specifying the number of Fleet instances to
 Once the secrets have been created and you have updated the values to match your required configuration, you can deploy with the following command.
 
 ```sh
-helm upgrade --install fleet . \
+helm upgrade --install fleet fleet \
   --namespace <your_namespace> \
+  --repo https://fleetdm.github.io/fleet/charts \
   --values values.yaml
 ```


### PR DESCRIPTION
Now that the chart is published, the instructions should reference that instead of assuming the Helm chart has been or needs to be cloned to a local system.