### PR TITLE
closes #503 w/ readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,31 @@ Fleet is the most widely used open source osquery manager.  Deploying osquery wi
 
 ## Try Fleet
 
-#### With [Node.js](https://nodejs.org/en/download/), [Docker](https://docs.docker.com/get-docker/), and [Docker Compose](https://docs.docker.com/compose/install/) installed:
+#### With [Node.js](https://nodejs.org/en/download/) and [Docker](https://docs.docker.com/get-docker/) installed:
 
 ```bash
 # Install the Fleet command-line tool
 npm install -g fleetctl
+
+# Edit your Docker config
+#  • remove "credsStore": "desktop"
+#  • remove the preceding comma (,) to ensure well-formed JSON
+nano ~/.docker/config.json
+
 # Run a local demo of the Fleet server
 fleetctl preview
 ```
 
-A local copy of the Fleet server is now running at https://localhost:8412. The preview experience will start sample Linux hosts connected to this server.
+A local demo copy of the Fleet server is now running at https://localhost:8412.
+
+> **Seeing a warning in your browser?**  You can safely skirt the browser warning ("Your connection is not private") when accessing Fleet locally over https.  For example in Google Chrome, visit `chrome://flags/#allow-insecure-localhost` to enable self-signed certs on localhost.  Then [refresh Fleet](https://localhost:8412) and click through this warning using the "Advanced" option.
 
 #### Your first query
-
 Ready to run your first query?  Target some of your sample hosts and try it out:
 <img width="500" alt="Screenshot of query editor" src="https://user-images.githubusercontent.com/618009/101847266-769a2700-3b18-11eb-9109-7f1320ed5c45.png"/>
+
+#### Using real devices
+For convenience, the demo includes a few simulated Linux hosts.  To query a real device, [install the osquery agent](https://github.com/fleetdm/orbit).
 
 ## Team
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Fleet is the most widely used open source osquery manager.  Deploying osquery wi
 # Install the Fleet command-line tool
 npm install -g fleetctl
 
-# Edit your Docker config
+# Edit your Docker config  (Required on macOS w/ default Docker install.)
 #  • remove "credsStore": "desktop"
 #  • remove the preceding comma (,) to ensure well-formed JSON
 nano ~/.docker/config.json

--- a/README.md
+++ b/README.md
@@ -14,14 +14,8 @@ Fleet is the most widely used open source osquery manager.  Deploying osquery wi
 ```bash
 # Install the Fleet command-line tool
 npm install -g fleetctl
-
-# Edit your Docker config  (Required on macOS w/ default Docker install.)
-#  • remove "credsStore": "desktop"
-#  • remove the preceding comma (,) to ensure well-formed JSON
-nano ~/.docker/config.json
-
 # Run a local demo of the Fleet server
-fleetctl preview
+sudo fleetctl preview
 ```
 
 A local demo copy of the Fleet server is now running at https://localhost:8412.


### PR DESCRIPTION
- Add workaround for browser warning when accessing Fleet
- Add workaround for docker/compose#7495 to quickstart instructions
- Add quickstart instructions for using a real-world device