### PR TITLE
Make fleetctl preview available over HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ sudo fleetctl preview
 
 The Fleet UI is now available at http://localhost:1337.
 
-> **Seeing a warning in your browser?**  You can safely skirt the browser warning ("Your connection is not private") when accessing Fleet locally over https.  For example in Google Chrome, visit `chrome://flags/#allow-insecure-localhost` to enable self-signed certs on localhost.  Then [refresh Fleet](https://localhost:8412) and click through this warning using the "Advanced" option.
-
 #### Your first query
 Ready to run your first query?  Target some of your sample hosts and try it out:
 <img width="800" alt="Screenshot of query editor" src="https://user-images.githubusercontent.com/618009/111853677-099de680-88ea-11eb-90bb-f5cd787f1f15.png"/>

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install -g fleetctl
 fleetctl preview
 ```
 
-A local copy of the Fleet server is now running at https://localhost:8412. The preview experience will start sample Linux hosts connected to this server.
+The Fleet UI is now available at http://localhost:1337. The preview experience will start sample Linux hosts connected to this server.
 
 #### Your first query
 


### PR DESCRIPTION
Run a second copy of the Fleet server listening over HTTP on
localhost:1337 so that the UI can be used without the errors displayed
with a self-signed TLS certificate. Osquery clients and fleetctl
continue to communicate with the existing Fleet server on
https://localhost:8412.

Closes #504