### PR TITLE
Prevent user enumeration

### DIFF
--- a/cmd/fleetctl/login.go
+++ b/cmd/fleetctl/login.go
@@ -71,12 +71,10 @@ Interactively prompts for email and password if not specified in the flags or en
 			token, err := fleet.Login(flEmail, flPassword)
 			if err != nil {
 				switch err.(type) {
-				case service.InvalidLoginErr:
-					return err
 				case service.NotSetupErr:
 					return err
 				}
-				return errors.Wrap(err, "error logging in")
+				return errors.Wrap(err, "Login failed")
 			}
 
 			configPath, context := c.String("config"), c.String("context")

--- a/cypress/integration/sessions/sessions.spec.ts
+++ b/cypress/integration/sessions/sessions.spec.ts
@@ -40,7 +40,7 @@ describe('Sessions', () => {
       .click();
 
     cy.url().should('match', /\/login$/);
-    cy.contains('username or email and password do not match');
+    cy.contains('Authentication failed');
   });
 
   it('Fails to access authenticated resource', () => {

--- a/server/service/client_errors.go
+++ b/server/service/client_errors.go
@@ -20,21 +20,6 @@ func (e setupAlreadyErr) SetupAlready() bool {
 	return true
 }
 
-type InvalidLoginErr interface {
-	InvalidLogin() bool
-	Error() string
-}
-
-type invalidLoginErr struct{}
-
-func (e invalidLoginErr) Error() string {
-	return "The credentials supplied were invalid"
-}
-
-func (e invalidLoginErr) InvalidLogin() bool {
-	return true
-}
-
 type NotSetupErr interface {
 	NotSetup() bool
 	Error() string

--- a/server/service/client_sessions.go
+++ b/server/service/client_sessions.go
@@ -24,8 +24,6 @@ func (c *Client) Login(email, password string) (string, error) {
 	switch response.StatusCode {
 	case http.StatusNotFound:
 		return "", notSetupErr{}
-	case http.StatusUnauthorized:
-		return "", invalidLoginErr{}
 	}
 	if response.StatusCode != http.StatusOK {
 		return "", errors.Errorf(

--- a/server/service/endpoint_sessions.go
+++ b/server/service/endpoint_sessions.go
@@ -6,8 +6,8 @@ import (
 	"html/template"
 	"time"
 
-	"github.com/go-kit/kit/endpoint"
 	"github.com/fleetdm/fleet/server/kolide"
+	"github.com/go-kit/kit/endpoint"
 )
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/server/service/endpoint_users.go
+++ b/server/service/endpoint_users.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/go-kit/kit/endpoint"
 	"github.com/fleetdm/fleet/server/kolide"
+	"github.com/go-kit/kit/endpoint"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -308,10 +308,10 @@ func (r forgotPasswordResponse) status() int  { return http.StatusAccepted }
 func makeForgotPasswordEndpoint(svc kolide.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(forgotPasswordRequest)
-		err := svc.RequestPasswordReset(ctx, req.Email)
-		if err != nil {
-			return forgotPasswordResponse{Err: err}, nil
-		}
+		// Any error returned by the service should not be returned to the
+		// client to prevent information disclosure (it will be logged in the
+		// server logs).
+		_ = svc.RequestPasswordReset(ctx, req.Email)
 		return forgotPasswordResponse{}, nil
 	}
 }

--- a/server/service/logging.go
+++ b/server/service/logging.go
@@ -19,13 +19,21 @@ func NewLoggingService(svc kolide.Service, logger kitlog.Logger) kolide.Service 
 
 // loggerDebug returns the the info level if there error is non-nil, otherwise defaulting to the debug level.
 func (mw loggingMiddleware) loggerDebug(err error) kitlog.Logger {
-	if err != nil {
-		return level.Info(mw.logger)
+	logger := mw.logger
+	if e, ok := err.(ErrWithInternal); ok {
+		logger = kitlog.With(logger, "err_internal", e.Internal())
 	}
-	return level.Debug(mw.logger)
+	if err != nil {
+		return level.Info(logger)
+	}
+	return level.Debug(logger)
 }
 
 // loggerInfo returns the info level
 func (mw loggingMiddleware) loggerInfo(err error) kitlog.Logger {
-	return level.Info(mw.logger)
+	logger := mw.logger
+	if e, ok := err.(ErrWithInternal); ok {
+		logger = kitlog.With(logger, "err_internal", e.Internal())
+	}
+	return level.Info(logger)
 }

--- a/server/service/service_users.go
+++ b/server/service/service_users.go
@@ -322,6 +322,12 @@ func (svc service) RequirePasswordReset(ctx context.Context, uid uint, require b
 }
 
 func (svc service) RequestPasswordReset(ctx context.Context, email string) error {
+	// Regardless of error, sleep until the request has taken at least 1 second.
+	// This means that any request to this method will take ~1s and frustrate a timing attack.
+	defer func(start time.Time) {
+		time.Sleep(time.Until(start.Add(1 * time.Second)))
+	}(time.Now())
+
 	user, err := svc.ds.UserByEmail(email)
 	if err != nil {
 		return err

--- a/server/service/transport_error.go
+++ b/server/service/transport_error.go
@@ -149,9 +149,16 @@ func encodeError(ctx context.Context, err error, w http.ResponseWriter) {
 		return
 	}
 
-	w.WriteHeader(http.StatusInternalServerError)
+	// Get specific status code if it is available from this error type,
+	// defaulting to HTTP 500
+	status := http.StatusInternalServerError
+	if e, ok := err.(ErrWithStatusCode); ok {
+		status = e.StatusCode()
+	}
+
+	w.WriteHeader(status)
 	je := jsonError{
-		Message: "Unknown Error",
+		Message: err.Error(),
 		Errors:  baseError(err.Error()),
 	}
 	enc.Encode(je)


### PR DESCRIPTION
- Return same error in all cases for login endpoint.
- Log error details in server logs.
- Make most login errors take ~1s to prevent timing attacks.
- Don't return forgot password errors.
- Log password errors in server logs.
- Make most forgot password requests take ~1s to prevent timing attacks.

Fixes #531