### PR TITLE
Adjust UI layout styles and fix empty state on "Hosts" page

### DIFF
--- a/frontend/components/flash_messages/FlashMessage/_styles.scss
+++ b/frontend/components/flash_messages/FlashMessage/_styles.scss
@@ -20,10 +20,6 @@
   background-color: #3d4758;
   min-width: $min-width;
 
-  @include breakpoint(smalldesk) {
-    left: $nav-tablet-width;
-  }
-
   &--full-width {
     left: 0;
   }

--- a/frontend/components/flash_messages/PersistentFlash/_styles.scss
+++ b/frontend/components/flash_messages/PersistentFlash/_styles.scss
@@ -9,7 +9,7 @@
 }
 
 .persistent-flash {
-  @include position(fixed, 0 0 null $nav-width);
+  @include position(fixed, 0 0 null 0);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -19,10 +19,6 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
   background-color: #3d4758;
   min-width: $min-width;
-
-  @include breakpoint(smalldesk) {
-    left: $nav-tablet-width;
-  }
 
   &__content {
     flex-grow: 1;

--- a/frontend/layouts/CoreLayout/_styles.scss
+++ b/frontend/layouts/CoreLayout/_styles.scss
@@ -10,6 +10,8 @@
   padding: 0;
   position: relative;
   background-color: $white;
+  display: flex;
+  flex-direction: column;
 }
 
 .site-nav {

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -1,5 +1,4 @@
 .manage-hosts {
-  min-height: 90vh;
 
   .header-wrap {
     display: flex;

--- a/frontend/pages/hosts/ManageHostsPage/components/HostContainer/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostContainer/_styles.scss
@@ -41,6 +41,7 @@
     &__inner {
       display: flex;
       flex-direction: row;
+      align-items: flex-start;
 
       h1 {
         font-size: $small;

--- a/frontend/pages/packs/AllPacksPage/_styles.scss
+++ b/frontend/pages/packs/AllPacksPage/_styles.scss
@@ -65,7 +65,6 @@
 
   &__wrapper {
     padding: 40px 30px;
-    min-height: 90vh;
   }
 
   &__table {

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -61,7 +61,6 @@
 
   &__wrapper {
     padding: 40px 30px;
-    min-height: 90vh;
   }
 
   &__modal-btn-wrap {

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -69,7 +69,7 @@ a {
 
 .has-sidebar {
   display: flex;
-  height: 100%;
+  flex-grow: 1;
 
   > * {
     &:first-child {

--- a/frontend/styles/var/_global.scss
+++ b/frontend/styles/var/_global.scss
@@ -1,6 +1,5 @@
 $border-radius: 4px;
-$nav-width: 217px;
-$nav-tablet-width: 55px;
+$nav-height: 52px;
 $base-font-size: 16;
 $sidepanel-width: 300px;
 $sidepanel-tablet-width: 300px;

--- a/frontend/styles/var/_global.scss
+++ b/frontend/styles/var/_global.scss
@@ -1,5 +1,4 @@
 $border-radius: 4px;
-$nav-height: 52px;
 $base-font-size: 16;
 $sidepanel-width: 300px;
 $sidepanel-tablet-width: 300px;


### PR DESCRIPTION
- Remove `$nav-width` and `$nav-tablet-width` because the navigation is now on the top of the layout.
- Add styles to `CoreLayout` to make the main content (everything except the top nav) fill the window height.

Fixes #502 Empty state on "Hosts" page is stretched
Safari screenshot
![Screen Shot 2021-03-25 at 12 41 14 PM](https://user-images.githubusercontent.com/47070608/112533648-67598500-8d67-11eb-9a0d-53d14057e84e.png)
