### PR TITLE
Add Fleet version number and Go version number to "My account" page

### DIFF
--- a/frontend/kolide/endpoints.js
+++ b/frontend/kolide/endpoints.js
@@ -1,7 +1,7 @@
 export default {
   CHANGE_PASSWORD: '/v1/fleet/change_password',
   CONFIG: '/v1/fleet/config',
-  VERSION: 'v1/fleet/version',
+  VERSION: '/v1/fleet/version',
   CONFIRM_EMAIL_CHANGE: (token) => {
     return `/v1/fleet/email/change/${token}`;
   },

--- a/frontend/kolide/endpoints.js
+++ b/frontend/kolide/endpoints.js
@@ -1,6 +1,7 @@
 export default {
   CHANGE_PASSWORD: '/v1/fleet/change_password',
   CONFIG: '/v1/fleet/config',
+  VERSION: 'v1/fleet/version',
   CONFIRM_EMAIL_CHANGE: (token) => {
     return `/v1/fleet/email/change/${token}`;
   },

--- a/frontend/kolide/entities/version.js
+++ b/frontend/kolide/entities/version.js
@@ -1,0 +1,10 @@
+import endpoints from 'kolide/endpoints';
+
+export default (client) => {
+  return {
+    load: () => {
+      const { VERSION } = endpoints;
+      return client.authenticatedGet(client._endpoint(VERSION));
+    },
+  };
+};

--- a/frontend/kolide/index.js
+++ b/frontend/kolide/index.js
@@ -2,6 +2,7 @@ import Base from 'kolide/base';
 import Request from 'kolide/request';
 import accountMethods from 'kolide/entities/account';
 import configMethods from 'kolide/entities/config';
+import versionMethods from 'kolide/entities/version';
 import osqueryOptionsMethods from 'kolide/entities/osquery_options';
 import hostMethods from 'kolide/entities/hosts';
 import inviteMethods from 'kolide/entities/invites';
@@ -24,6 +25,7 @@ class Kolide extends Base {
 
     this.account = accountMethods(this);
     this.config = configMethods(this);
+    this.version = versionMethods(this);
     this.osqueryOptions = osqueryOptionsMethods(this);
     this.hosts = hostMethods(this);
     this.invites = inviteMethods(this);

--- a/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
@@ -294,7 +294,6 @@ export class UserSettingsPage extends Component {
       renderApiTokenModal,
     } = this;
     const { version, errors, user } = this.props;
-    console.log(version)
     const { pendingEmail } = this.state;
 
     if (!user) {

--- a/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
@@ -10,6 +10,8 @@ import {
   COPY_TEXT_ERROR,
 } from 'utilities/copy_text';
 
+import { noop } from 'lodash';
+
 import Avatar from 'components/Avatar';
 import Button from 'components/buttons/Button';
 import ChangeEmailForm from 'components/forms/ChangeEmailForm';
@@ -44,6 +46,11 @@ export class UserSettingsPage extends Component {
       new_password: PropTypes.string,
       old_password: PropTypes.string,
     }),
+  };
+
+  static defaultProps = {
+    version: {},
+    dispatch: noop,
   };
 
   constructor(props) {
@@ -360,7 +367,7 @@ export class UserSettingsPage extends Component {
 }
 
 const mapStateToProps = (state) => {
-  const version = state.version.data;
+  const { data: version } = state.version;
   const { errors, user } = state.auth;
   const { errors: userErrors } = state.entities.users;
 

--- a/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
@@ -356,7 +356,7 @@ export class UserSettingsPage extends Component {
           >
             Get API token
           </Button>
-          <span className={`${baseClass}__version`}>{`Version: Fleet ${version.version} • Go ${version.go_version}`}</span>
+          <span className={`${baseClass}__version`}>{`Fleet ${version.version} • Go ${version.go_version}`}</span>
         </div>
         {renderEmailModal()}
         {renderPasswordModal()}

--- a/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
@@ -21,6 +21,7 @@ import { logoutUser, updateUser } from 'redux/nodes/auth/actions';
 import Modal from 'components/modals/Modal';
 import { renderFlash } from 'redux/nodes/notifications/actions';
 import userActions from 'redux/nodes/entities/users/actions';
+import versionActions from 'redux/nodes/version/actions';
 import userInterface from 'interfaces/user';
 import UserSettingsForm from 'components/forms/UserSettingsForm';
 
@@ -29,6 +30,10 @@ const baseClass = 'user-settings';
 export class UserSettingsPage extends Component {
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
+    version: PropTypes.shape({
+      version: PropTypes.string,
+      go_version: PropTypes.string,
+    }),
     errors: PropTypes.shape({
       username: PropTypes.string,
       base: PropTypes.string,
@@ -50,6 +55,14 @@ export class UserSettingsPage extends Component {
       showPasswordModal: false,
       updatedUser: {},
     };
+  }
+
+  componentDidMount () {
+    const { dispatch } = this.props;
+
+    dispatch(versionActions.getVersion());
+
+    return false;
   }
 
   onCancel = (evt) => {
@@ -280,7 +293,8 @@ export class UserSettingsPage extends Component {
       renderPasswordModal,
       renderApiTokenModal,
     } = this;
-    const { errors, user } = this.props;
+    const { version, errors, user } = this.props;
+    console.log(version)
     const { pendingEmail } = this.state;
 
     if (!user) {
@@ -336,7 +350,7 @@ export class UserSettingsPage extends Component {
           >
             Get API token
           </Button>
-          <span className={`${baseClass}__version`}>Version: Fleet 3.7.0 • go 1.17.0</span>
+          <span className={`${baseClass}__version`}>{`Version: Fleet ${version.version} • Go ${version.go_version}`}</span>
         </div>
         {renderEmailModal()}
         {renderPasswordModal()}
@@ -347,10 +361,11 @@ export class UserSettingsPage extends Component {
 }
 
 const mapStateToProps = (state) => {
+  const version = state.version.data;
   const { errors, user } = state.auth;
   const { errors: userErrors } = state.entities.users;
 
-  return { errors, user, userErrors };
+  return { version, errors, user, userErrors };
 };
 
 export default connect(mapStateToProps)(UserSettingsPage);

--- a/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
@@ -294,7 +294,7 @@ export class UserSettingsPage extends Component {
     return (
       <div className={baseClass}>
         <div className={`${baseClass}__manage body-wrap`}>
-          <h1>Account</h1>
+          <h1>My account</h1>
           <UserSettingsForm
             formData={user}
             handleSubmit={handleSubmit}
@@ -323,7 +323,7 @@ export class UserSettingsPage extends Component {
           <Button
             onClick={onShowModal}
             disabled={ssoEnabled}
-            className={`${baseClass}__button button button--grey`}
+            className={`${baseClass}__button`}
           >
             Change password
           </Button>
@@ -332,10 +332,11 @@ export class UserSettingsPage extends Component {
           </p>
           <Button
             onClick={onShowApiTokenModal}
-            className={`${baseClass}__button button button--grey`}
+            className={`${baseClass}__button`}
           >
             Get API token
           </Button>
+          <span className={`${baseClass}__version`}>Version: Fleet 3.7.0 • go 1.17.0</span>
         </div>
         {renderEmailModal()}
         {renderPasswordModal()}

--- a/frontend/pages/UserSettingsPage/UserSettingsPage.tests.jsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.tests.jsx
@@ -14,7 +14,7 @@ const {
 } = testHelpers;
 
 describe('UserSettingsPage - component', () => {
-  const store = { auth: { user: userStub }, entities: { users: {} } };
+  const store = { auth: { user: userStub }, entities: { users: {} }, version: { data: {} } };
   const mockStore = reduxMockStore(store);
 
   it('renders a UserSettingsForm component', () => {

--- a/frontend/pages/UserSettingsPage/_styles.scss
+++ b/frontend/pages/UserSettingsPage/_styles.scss
@@ -1,5 +1,6 @@
 .user-settings {
   display: flex;
+  align-items: stretch;
 
   h1 {
     margin: 0 0 30px;
@@ -12,7 +13,6 @@
 
   &__manage {
     flex-grow: 1;
-    align-self: flex-start;
     min-width: 542px;
   }
 
@@ -130,5 +130,12 @@
         letter-spacing: 3px;
       }
     }
+  }
+
+  &__version {
+    font-size: $xx-small;
+    text-align: center;
+    display: block;
+    margin-top: 40px;
   }
 }

--- a/frontend/redux/nodes/version/actions.js
+++ b/frontend/redux/nodes/version/actions.js
@@ -1,0 +1,37 @@
+import Kolide from 'kolide';
+
+export const VERSION_FAILURE = 'VERSION_FAILURE';
+export const VERSION_START = 'VERSION_START';
+export const VERSION_SUCCESS = 'VERSION_SUCCESS';
+
+export const loadVersion = { type: VERSION_START };
+
+export const versionSuccess = (data) => {
+  return { type: VERSION_SUCCESS, payload: { data } };
+};
+
+export const versionFailure = (errors) => {
+  return { type: VERSION_FAILURE, payload: { errors } };
+};
+
+export const getVersion = () => {
+  return (dispatch) => {
+    dispatch(loadVersion);
+
+    return Kolide.version.load()
+      .then((version) => {
+        dispatch(versionSuccess(version));
+
+        return version;
+      })
+      .catch((errors) => {
+        dispatch(versionFailure(errors));
+
+        throw errors;
+      });
+  };
+};
+
+export default {
+  getVersion,
+};

--- a/frontend/redux/nodes/version/reducer.js
+++ b/frontend/redux/nodes/version/reducer.js
@@ -1,0 +1,37 @@
+import {
+  VERSION_FAILURE,
+  VERSION_START,
+  VERSION_SUCCESS,
+} from './actions';
+
+export const initialState = {
+  data: {},
+  errors: {},
+  loading: false,
+};
+
+const reducer = (state = initialState, { type, payload }) => {
+  switch (type) {
+    case VERSION_START:
+      return {
+        ...state,
+        loading: true,
+      };
+    case VERSION_SUCCESS:
+      return {
+        ...state,
+        data: payload.data,
+        loading: false,
+      };
+    case VERSION_FAILURE:
+      return {
+        ...state,
+        errors: payload.errors,
+        loading: false,
+      };
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/frontend/redux/reducers.js
+++ b/frontend/redux/reducers.js
@@ -11,6 +11,7 @@ import notifications from './nodes/notifications/reducer';
 import osquery from './nodes/osquery/reducer';
 import persistentFlash from './nodes/persistent_flash/reducer';
 import redirectLocation from './nodes/redirectLocation/reducer';
+import version from './nodes/version/reducer';
 
 export default combineReducers({
   app,
@@ -24,4 +25,5 @@ export default combineReducers({
   persistentFlash,
   redirectLocation,
   routing: routerReducer,
+  version,
 });


### PR DESCRIPTION
- Consume new `api/v1/fleet/version` endpoint and display Fleet version and Go version on the _My account_ page
![localhost_8080_profile](https://user-images.githubusercontent.com/47070608/112706988-3d868800-8e65-11eb-9ed1-ac52284d1ffa.png)
Closes #371 Add Fleet and go version to my account page
