### PR TITLE
Add platform text to Queries list on "Pack" page

### DIFF
--- a/frontend/components/queries/ScheduledQueriesList/ScheduledQueriesListItem/ScheduledQueriesListItem.jsx
+++ b/frontend/components/queries/ScheduledQueriesList/ScheduledQueriesListItem/ScheduledQueriesListItem.jsx
@@ -10,16 +10,24 @@ import scheduledQueryInterface from 'interfaces/scheduled_query';
 
 const baseClass = 'scheduled-query-list-item';
 
-const generatePlatformText = (platform) => {
+const generatePlatformText = (platforms) => {
   const ALL_PLATFORMS = [
     { text: 'All', value: 'all' },
     { text: 'macOS', value: 'darwin' },
     { text: 'Windows', value: 'windows' },
     { text: 'Linux', value: 'linux' },
   ];
+  console.log(platforms)
+  if (platforms) {
+    const platformArray = platforms.split(',');
+    console.log(platformArray);
+    const textArray = platformArray.map((platform) => {
+      const text = find(ALL_PLATFORMS, { value: platform }).text;
 
-  if (platform) {
-    const displayText = find(ALL_PLATFORMS, { value: platform }).text;
+      return text;
+    });
+
+    const displayText = textArray.join(', ');
 
     return displayText;
   }

--- a/frontend/components/queries/ScheduledQueriesList/ScheduledQueriesListItem/ScheduledQueriesListItem.jsx
+++ b/frontend/components/queries/ScheduledQueriesList/ScheduledQueriesListItem/ScheduledQueriesListItem.jsx
@@ -10,7 +10,7 @@ import scheduledQueryInterface from 'interfaces/scheduled_query';
 
 const baseClass = 'scheduled-query-list-item';
 
-const generatePlatformText = (inputPlatform) => {
+const generatePlatformText = (platform) => {
   const ALL_PLATFORMS = [
     { text: 'All', value: 'all' },
     { text: 'macOS', value: 'darwin' },
@@ -18,8 +18,8 @@ const generatePlatformText = (inputPlatform) => {
     { text: 'Linux', value: 'linux' },
   ];
 
-  if (inputPlatform) {
-    const displayText = find(ALL_PLATFORMS, { value: inputPlatform }).text;
+  if (platform) {
+    const displayText = find(ALL_PLATFORMS, { value: platform }).text;
 
     return displayText;
   }

--- a/frontend/components/queries/ScheduledQueriesList/ScheduledQueriesListItem/ScheduledQueriesListItem.jsx
+++ b/frontend/components/queries/ScheduledQueriesList/ScheduledQueriesListItem/ScheduledQueriesListItem.jsx
@@ -5,11 +5,27 @@ import classnames from 'classnames';
 import Checkbox from 'components/forms/fields/Checkbox';
 import ClickableTableRow from 'components/ClickableTableRow';
 import KolideIcon from 'components/icons/KolideIcon';
-import PlatformIcon from 'components/icons/PlatformIcon';
-import { includes, isEmpty, isEqual } from 'lodash';
+import { isEqual, find } from 'lodash';
 import scheduledQueryInterface from 'interfaces/scheduled_query';
 
 const baseClass = 'scheduled-query-list-item';
+
+const generatePlatformText = (inputPlatform) => {
+  const ALL_PLATFORMS = [
+    { text: 'All', value: 'all' },
+    { text: 'macOS', value: 'darwin' },
+    { text: 'Windows', value: 'windows' },
+    { text: 'Linux', value: 'linux' },
+  ];
+
+  if (inputPlatform) {
+    const displayText = find(ALL_PLATFORMS, { value: inputPlatform }).text;
+
+    return displayText;
+  }
+
+  return '---';
+};
 
 class ScheduledQueriesListItem extends Component {
   static propTypes = {
@@ -63,21 +79,10 @@ class ScheduledQueriesListItem extends Component {
     return 'bold-plus';
   }
 
-  renderPlatformIcon = () => {
-    const { scheduledQuery: { platform } } = this.props;
-    const platformArr = platform ? platform.split(',') : [];
-
-    if (isEmpty(platformArr) || includes(platformArr, 'all')) {
-      return <PlatformIcon name="all" title="All Platforms" className={`${baseClass}__icon`} />;
-    }
-
-    return platformArr.map(pltf => <PlatformIcon name={pltf} title={pltf} className={`${baseClass}__icon`} key={pltf} />);
-  }
-
   render () {
     const { checked, disabled, isSelected, scheduledQuery } = this.props;
-    const { id, query_name: name, interval, shard, version } = scheduledQuery;
-    const { loggingTypeString, onDblClick, onCheck, onSelect, renderPlatformIcon } = this;
+    const { id, query_name: name, interval, shard, version, platform } = scheduledQuery;
+    const { loggingTypeString, onDblClick, onCheck, onSelect } = this;
     const rowClassname = classnames(baseClass, {
       [`${baseClass}--selected`]: isSelected,
     });
@@ -94,7 +99,7 @@ class ScheduledQueriesListItem extends Component {
         </td>
         <td className="scheduled-queries-list__query-name">{name}</td>
         <td>{interval}</td>
-        <td>{renderPlatformIcon()}</td>
+        <td>{generatePlatformText(platform)}</td>
         <td>{version ? `${version}+` : 'Any'}</td>
         <td>{shard}</td>
         <td><KolideIcon name={loggingTypeString()} /></td>

--- a/frontend/components/queries/ScheduledQueriesList/ScheduledQueriesListItem/ScheduledQueriesListItem.jsx
+++ b/frontend/components/queries/ScheduledQueriesList/ScheduledQueriesListItem/ScheduledQueriesListItem.jsx
@@ -17,10 +17,10 @@ const generatePlatformText = (platforms) => {
     { text: 'Windows', value: 'windows' },
     { text: 'Linux', value: 'linux' },
   ];
-  console.log(platforms)
+
   if (platforms) {
     const platformArray = platforms.split(',');
-    console.log(platformArray);
+
     const textArray = platformArray.map((platform) => {
       const text = find(ALL_PLATFORMS, { value: platform }).text;
 

--- a/frontend/components/queries/ScheduledQueriesList/ScheduledQueriesListItem/ScheduledQueriesListItem.tests.jsx
+++ b/frontend/components/queries/ScheduledQueriesList/ScheduledQueriesListItem/ScheduledQueriesListItem.tests.jsx
@@ -18,7 +18,6 @@ describe('ScheduledQueriesListItem - component', () => {
     expect(component.text()).toContain(scheduledQueryStub.query_name);
     expect(component.text()).toContain(scheduledQueryStub.interval);
     expect(component.text()).toContain(scheduledQueryStub.shard);
-    expect(component.find('PlatformIcon').length).toEqual(1);
   });
 
   it('renders when the platform attribute is null', () => {
@@ -27,7 +26,6 @@ describe('ScheduledQueriesListItem - component', () => {
     expect(component.text()).toContain(scheduledQueryStub.query_name);
     expect(component.text()).toContain(scheduledQueryStub.interval);
     expect(component.text()).toContain(scheduledQueryStub.shard);
-    expect(component.find('PlatformIcon').length).toEqual(1);
   });
 
   it('renders a Checkbox component', () => {

--- a/frontend/components/queries/ScheduledQueriesList/_styles.scss
+++ b/frontend/components/queries/ScheduledQueriesList/_styles.scss
@@ -39,7 +39,6 @@
 
         &:nth-child(4) {
           width: 18%;
-          text-align: center;
         }
 
         &:nth-child(5) {
@@ -85,7 +84,15 @@
           color: $core-black;
         }
 
-        &:nth-child(4),
+        &:nth-child(4) {
+          font-size: 14px;
+          font-weight: $regular;
+          line-height: 2.71;
+          letter-spacing: -0.5px;
+          text-align: left;
+          color: $core-black;
+        }
+        
         &:nth-child(5),
         &:nth-child(6) {
           font-size: 14px;


### PR DESCRIPTION
- Add platform text to the Queries list. This text better reflects the options in the "Platform" dropdown when scheduling a query.
- Remove platform icons.

"Platform" dropdown
![Screen Shot 2021-03-30 at 2 55 42 PM](https://user-images.githubusercontent.com/47070608/113062073-04515f00-9168-11eb-8313-7481ad755bbb.png)

Queries list
![localhost_8080_packs_1_edit (3)](https://user-images.githubusercontent.com/47070608/113066127-d9b6d480-916e-11eb-8223-8a2a0f2cccdb.png)

Fixes #555 