### PR TITLE
Improvements to built-in labels

### DIFF
--- a/frontend/kolide/helpers.ts
+++ b/frontend/kolide/helpers.ts
@@ -113,6 +113,7 @@ const formatLabelResponse = (response: any): {[index: string]: any} => {
     'CentOS Linux': 'platform',
     macOS: 'platform',
     'Ubuntu Linux': 'platform',
+    'Red Hat Linux': 'platform',
   };
 
   const labels = response.labels.map((label: any) => {

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/e-dard/netbug v0.0.0-20151029172837-e64d308a0b20
 	github.com/elazarl/go-bindata-assetfs v1.0.0
 	github.com/fatih/color v1.7.0 // indirect
-	github.com/fleetdm/goose v0.0.0-20210209032905-c3c01484bacb
+	github.com/fleetdm/goose v0.0.0-20210205022138-27718647ba5b
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-kit/kit v0.9.0
 	github.com/go-sql-driver/mysql v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/elazarl/go-bindata-assetfs v1.0.0 h1:G/bYguwHIzWq9ZoyUQqrjTmJbbYn3j3C
 github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fleetdm/goose v0.0.0-20210205022138-27718647ba5b h1:Ybt9lIr16BghU3nK0jpeRC4B6JguVLtdubUEcRBPdzQ=
+github.com/fleetdm/goose v0.0.0-20210205022138-27718647ba5b/go.mod h1:d7Q+0eCENnKQUhkfAUVLfGnD4QcgJMF/uB9WRTN9TDI=
 github.com/fleetdm/goose v0.0.0-20210209032905-c3c01484bacb h1:p02npmJlTo+Px1s0VptKOJOJqH/rGlGBEVvLJRtzY3A=
 github.com/fleetdm/goose v0.0.0-20210209032905-c3c01484bacb/go.mod h1:d7Q+0eCENnKQUhkfAUVLfGnD4QcgJMF/uB9WRTN9TDI=
 github.com/flynn/go-docopt v0.0.0-20140912013429-f6dd2ebbb31e/go.mod h1:HyVoz1Mz5Co8TFO8EupIdlcpwShBmY98dkT2xeHkvEI=
@@ -250,6 +252,7 @@ github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
+github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2 h1:NAfh7zF0/3/HqtMvJNZ/RFrSlCE6ZTlHmKfhL/Dm1Jk=

--- a/server/datastore/internal/appstate/labels.go
+++ b/server/datastore/internal/appstate/labels.go
@@ -47,28 +47,24 @@ func Labels2() []kolide.Label {
 			LabelType:   kolide.LabelTypeBuiltIn,
 		},
 		{
-			Platform:    "darwin",
 			Name:        "macOS",
 			Query:       "select 1 from os_version where platform = 'darwin';",
 			Description: "All macOS hosts",
 			LabelType:   kolide.LabelTypeBuiltIn,
 		},
 		{
-			Platform:    "ubuntu",
 			Name:        "Ubuntu Linux",
 			Query:       "select 1 from os_version where platform = 'ubuntu';",
 			Description: "All Ubuntu hosts",
 			LabelType:   kolide.LabelTypeBuiltIn,
 		},
 		{
-			Platform:    "centos",
 			Name:        "CentOS Linux",
 			Query:       "select 1 from os_version where platform = 'centos';",
 			Description: "All CentOS hosts",
 			LabelType:   kolide.LabelTypeBuiltIn,
 		},
 		{
-			Platform:    "windows",
 			Name:        "MS Windows",
 			Query:       "select 1 from os_version where platform = 'windows';",
 			Description: "All Windows hosts",

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -513,7 +513,7 @@ func (d *Datastore) searchLabelsDefault(omit ...uint) ([]kolide.Label, error) {
 	WHERE id NOT IN (?)
 	GROUP BY id
 	ORDER BY label_type DESC, id ASC
-	LIMIT 5
+	LIMIT 7
 	`
 
 	var in interface{}

--- a/server/datastore/mysql/migrations/data/20210330130314_UpdateBuiltinLabels.go
+++ b/server/datastore/mysql/migrations/data/20210330130314_UpdateBuiltinLabels.go
@@ -1,0 +1,52 @@
+package data
+
+import (
+	"database/sql"
+
+	"github.com/fleetdm/fleet/server/kolide"
+	"github.com/pkg/errors"
+)
+
+func init() {
+	MigrationClient.AddMigration(Up_20210330130314, Down_20210330130314)
+}
+
+func Up_20210330130314(tx *sql.Tx) error {
+	// Update labels to set platform to empty. Previously the platform meant
+	// that if a host changed platform (say by installing a new OS and still
+	// having the same hardware UUID) the old label query would never run again
+	// and a host could show up in multiple of the built-in platform labels.
+	sql := "UPDATE labels SET platform = '' WHERE label_type = ?"
+	if _, err := tx.Exec(sql, kolide.LabelTypeBuiltIn); err != nil {
+		return errors.Wrap(err, "update labels")
+	}
+
+	// Insert Red Hat label
+	sql = `
+		INSERT INTO labels (
+			name,
+			description,
+			query,
+			platform,
+			label_type,
+			label_membership_type
+		) VALUES (?, ?, ?, ?, ?, ?)
+`
+	if _, err := tx.Exec(
+		sql,
+		"Red Hat Linux",
+		"All Red Hat Enterprise Linux hosts",
+		"SELECT 1 FROM os_version WHERE name LIKE '%red hat%'",
+		"",
+		kolide.LabelTypeBuiltIn,
+		kolide.LabelMembershipTypeDynamic,
+	); err != nil {
+		return errors.Wrap(err, "add red hat label")
+	}
+
+	return nil
+}
+
+func Down_20210330130314(tx *sql.Tx) error {
+	return nil
+}


### PR DESCRIPTION
- Fix issue with built-in labels showing multiple platforms when hosts
  are reinstalled with new platform.
- Add Red Hat Linux built-in label.
- Display more labels by default in target selector.

Fixes #546, #553