### PR TITLE
Add ability to configure a specific log level

### DIFF
--- a/docs/2-Deployment/2-Configuration.md
+++ b/docs/2-Deployment/2-Configuration.md
@@ -699,6 +699,23 @@ Whether or not to enable debug logging.
 		debug: true
 	```
 
+###### `logging_level`
+
+Specify the level of logs to be output. Valid values are:
+* `error`
+* `warn`
+* `info`
+* `debug`
+
+- Default value: `info`
+- Environment variable: `FLEET_LOGGING_LEVEL`
+- Config file format:
+
+        ```
+        logging:
+                level: error
+        ```
+
 ###### `logging_json`
 
 Whether or not to log in JSON.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -94,6 +94,7 @@ type OsqueryConfig struct {
 // LoggingConfig defines configs related to logging
 type LoggingConfig struct {
 	Debug         bool
+	Level         string
 	JSON          bool
 	DisableBanner bool `yaml:"disable_banner"`
 }
@@ -276,6 +277,8 @@ func (man Manager) addConfigs() {
 	// Logging
 	man.addConfigBool("logging.debug", false,
 		"Enable debug logging")
+	man.addConfigString("logging.level", "info",
+		"Syslog level to log at")
 	man.addConfigBool("logging.json", false,
 		"Log in JSON format")
 	man.addConfigBool("logging.disable_banner", false,
@@ -424,6 +427,7 @@ func (man Manager) LoadConfig() KolideConfig {
 		},
 		Logging: LoggingConfig{
 			Debug:         man.getConfigBool("logging.debug"),
+			Level:         man.getConfigString("logging.level"),
 			JSON:          man.getConfigBool("logging.json"),
 			DisableBanner: man.getConfigBool("logging.disable_banner"),
 		},
@@ -693,6 +697,7 @@ func TestConfig() KolideConfig {
 		},
 		Logging: LoggingConfig{
 			Debug:         true,
+			Level:         "debug",
 			DisableBanner: true,
 		},
 		Filesystem: FilesystemConfig{


### PR DESCRIPTION
This adds the ability to specify one of `error`, `warn`, `info`, or `debug` for the logger.   It is set with `logger.level` and defaults to `info` level if not specified.  It still accepts the `level.debug` config option and will ignore `logger.level` if it is set.