### PR TITLE
Align Fleet UI with Figma (spacing and fonts)

### DIFF
--- a/frontend/components/AuthenticationFormWrapper/_styles.scss
+++ b/frontend/components/AuthenticationFormWrapper/_styles.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   justify-content: center;
   flex-grow: 1;
-  padding: $pad-base 0;
+  padding: $pad-medium 0;
 
   &__logo {
     width: 120px;

--- a/frontend/components/InfoBanner/_styles.scss
+++ b/frontend/components/InfoBanner/_styles.scss
@@ -1,5 +1,5 @@
 .info-banner {
-  padding: 16px;
+  padding: $pad-medium;
   border-radius: $border-radius;
   border: 1px solid #D9D9FE;
   background-color: $ui-vibrant-blue-10;

--- a/frontend/components/KolideAce/_styles.scss
+++ b/frontend/components/KolideAce/_styles.scss
@@ -4,7 +4,7 @@
     font-weight: $regular;
     color: $core-fleet-black;
     display: block;
-    margin-bottom: 4px;
+    margin-bottom: $pad-xsmall;
     min-height: 25px;
 
     &--error {

--- a/frontend/components/Pagination/_style.scss
+++ b/frontend/components/Pagination/_style.scss
@@ -3,8 +3,8 @@
   &__pager-wrap {
     display: flex;
     justify-content: flex-end;
-    margin-top: $pad-half;
-    margin-bottom: $pad-half;
+    margin-top: $pad-small;
+    margin-bottom: $pad-small;
     margin-left: auto;
     text-align: right;
 
@@ -13,11 +13,11 @@
       padding: 6px;
 
       .kolidecon-chevronleft {
-        margin-right: $pad-half;
+        margin-right: $pad-small;
       }
 
       .kolidecon-chevronright {
-        margin-left: $pad-half;
+        margin-left: $pad-small;
       }
     }
 

--- a/frontend/components/StackedWhiteBoxes/_styles.scss
+++ b/frontend/components/StackedWhiteBoxes/_styles.scss
@@ -1,7 +1,7 @@
 .stacked-white-boxes {
   @include position(absolute, null null null 50%);
   transition: opacity 300ms ease-in;
-  margin: 40px 0 0 -262px;
+  margin: $pad-xxlarge 0 0 -262px;
   width: 516px;
 
   &--loading {
@@ -21,13 +21,13 @@
     border-radius: 10px;
     min-height: 360px;
     box-sizing: border-box;
-    padding: 40px;
+    padding: $pad-xxlarge;
     font-weight: 300;
 
     &-text {
       color: $core-fleet-black;
       font-size: $small;
-      margin: 40px 0 24px;
+      margin: $pad-xxlarge 0 $pad-large;
     }
   }
 

--- a/frontend/components/TableContainer/DataTable/DropdownCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/DropdownCell/_styles.scss
@@ -20,7 +20,7 @@
     }
 
     .Select-menu-outer {
-    margin-top: 4px;
+    margin-top: $pad-xsmall;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
     border-radius: $border-radius;
     z-index: 6;

--- a/frontend/components/TableContainer/DataTable/HeaderCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/HeaderCell/_styles.scss
@@ -5,7 +5,7 @@
 
   .sort-arrows {
     height: 14px;
-    padding-left: $pad-half;
+    padding-left: $pad-small;
     display: flex;
     flex-direction: column;
     justify-content: space-between;

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -5,7 +5,7 @@
     &__wrapper {
       border: solid 1px $ui-fleet-blue-15;
       border-radius: 6px;
-      margin-top: $pad-half;
+      margin-top: $pad-small;
       overflow: scroll;
       box-shadow: inset -8px 0 17px -10px #e8edf4;
     }
@@ -32,7 +32,7 @@
       border-bottom: 1px solid $ui-fleet-blue-15;
 
       th {
-        padding: 16px 27px;
+        padding: $pad-medium 27px;
         white-space: nowrap;
         border-right: 1px solid $ui-fleet-blue-15;
 
@@ -71,7 +71,7 @@
         content: ' ';
         display: inline-block;
         height: 8px;
-        margin-right: 8px;
+        margin-right: $pad-small;
         width: 8px;
       }
  

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -27,7 +27,7 @@
 
     img {
       width: 20px;
-      margin-right: $pad-half;
+      margin-right: $pad-small;
     }
   }
 
@@ -56,8 +56,8 @@
       position: absolute;
       top: 10px;
       left: 12px;
-      font-size: 20px;
-      color: $core-fleet-blue;
+      font-size: $medium;
+      color: $core-fleet-black;
     }
   }
 }

--- a/frontend/components/UserRow/_styles.scss
+++ b/frontend/components/UserRow/_styles.scss
@@ -37,7 +37,7 @@
       content: ' ';
       display: inline-block;
       height: 8px;
-      margin-right: 8px;
+      margin-right: $pad-small;
       width: 8px;
     }
   }
@@ -49,7 +49,7 @@
       content: ' ';
       display: inline-block;
       height: 8px;
-      margin-right: 8px;
+      margin-right: $pad-small;
       width: 8px;
     }
   }
@@ -61,7 +61,7 @@
       content: ' ';
       display: inline-block;
       height: 8px;
-      margin-right: 8px;
+      margin-right: $pad-small;
       width: 8px;
     }
   }

--- a/frontend/components/WarningBanner/_styles.scss
+++ b/frontend/components/WarningBanner/_styles.scss
@@ -2,13 +2,13 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  background-color: $ui-warning;
+  background-color: #fff0b9;
   color: $core-fleet-black;
   padding: 15px 20px;
   border-radius: $border-radius;
-  border: 1px solid $ui-warning;
+  border: 1px solid #f2c94c;
   font-size: $x-small;
-  margin: 0 0 25px;
+  margin: 0 0 $pad-large;
 
   &__message {
     flex-grow: 1;

--- a/frontend/components/YamlAce/_styles.scss
+++ b/frontend/components/YamlAce/_styles.scss
@@ -1,6 +1,6 @@
 .yaml-ace {
   &__label {
-    font-size: 16px;
+    font-size: $small;
     font-weight: $bold;
     font-style: normal;
     font-stretch: normal;

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -35,8 +35,8 @@ $base-class: 'button';
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  padding: 8px 16px;
-  border-radius: 4px;
+  padding: $pad-small $pad-medium;
+  border-radius: $border-radius;
   font-size: $small;
   font-family: 'Nunito Sans', sans-serif;
   font-weight: $bold;
@@ -84,7 +84,7 @@ $base-class: 'button';
     border: 1px solid $core-vibrant-blue;
     box-sizing: border-box;
     font-size: $xx-small;
-    padding: 4px 10px;
+    padding: $pad-xsmall 10px;
     height: 24px;
 
     &:active {

--- a/frontend/components/config/EnrollSecretTable/_styles.scss
+++ b/frontend/components/config/EnrollSecretTable/_styles.scss
@@ -7,7 +7,7 @@
       position: relative;
       font-size: $x-small;
       font-weight: $bold;
-      margin-top: 8px;
+      margin-top: $pad-small;
     }
 
     .input-field {
@@ -23,7 +23,7 @@
 
   &__secret-copy-icon {
     color: $core-vibrant-blue;
-    margin-right: 16px;
+    margin-right: $pad-medium;
   }
 
   .buttons {
@@ -98,7 +98,7 @@
     }
 
     .enroll-secrets__secret-download-icon {
-      margin-bottom: 16px;
+      margin-bottom: $pad-medium;
     }
   }
 }

--- a/frontend/components/flash_messages/FlashMessage/_styles.scss
+++ b/frontend/components/flash_messages/FlashMessage/_styles.scss
@@ -14,7 +14,7 @@
   align-items: center;
   justify-content: center;
   color: $core-white;
-  padding: $pad-half;
+  padding: $pad-small;
   z-index: 3;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
   background-color: #3d4758;
@@ -46,14 +46,14 @@
     }
 
     .kolidecon {
-      font-size: 24px;
+      font-size: $large;
     }
   }
 
   &__undo {
     color: $core-white;
     cursor: pointer;
-    font-size: 16px;
+    font-size: $small;
     text-decoration: underline;
     text-transform: uppercase;
   }
@@ -67,7 +67,7 @@
     .kolidecon {
       transition: color 150ms ease-in-out;
       color: $core-fleet-black;
-      font-size: 24px;
+      font-size: $large;
 
       &:hover {
         color: $core-white;

--- a/frontend/components/flash_messages/PersistentFlash/_styles.scss
+++ b/frontend/components/flash_messages/PersistentFlash/_styles.scss
@@ -14,7 +14,7 @@
   align-items: center;
   justify-content: center;
   color: $core-white;
-  padding: $pad-half;
+  padding: $pad-small;
   z-index: 2;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
   background-color: #3d4758;
@@ -26,7 +26,7 @@
 
     i {
       color: $ui-error;
-      font-size: 24px;
+      font-size: $large;
     }
 
     span {

--- a/frontend/components/forms/ChangePasswordForm/_styles.scss
+++ b/frontend/components/forms/ChangePasswordForm/_styles.scss
@@ -6,7 +6,7 @@
 
   &__btn {
     &:last-child {
-      margin-right: 16px;
+      margin-right: $pad-medium;
     }
   }
 }

--- a/frontend/components/forms/ConfigurePackQueryForm/_styles.scss
+++ b/frontend/components/forms/ConfigurePackQueryForm/_styles.scss
@@ -20,7 +20,7 @@
   }
 
   &__title {
-    font-size: 16px;
+    font-size: $small;
     font-weight: $bold;
     letter-spacing: -0.5px;
     color: $core-fleet-black;

--- a/frontend/components/forms/ForgotPasswordForm/_styles.scss
+++ b/frontend/components/forms/ForgotPasswordForm/_styles.scss
@@ -2,7 +2,7 @@
   width: 100%;
 
   &__button-wrap {
-    margin-top: 40px;
+    margin-top: $pad-xxlarge;
     display: flex;
     justify-content: center;
   }

--- a/frontend/components/forms/FormField/_styles.scss
+++ b/frontend/components/forms/FormField/_styles.scss
@@ -1,12 +1,12 @@
 .form-field {
-  margin-bottom: 24px;
+  margin-bottom: $pad-large;
 
   &__label {
     font-size: $x-small;
     font-weight: $regular;
     color: $core-fleet-black;
     display: block;
-    margin-bottom: 4px;
+    margin-bottom: $pad-xsmall;
 
     &--error {
       color: $ui-error;

--- a/frontend/components/forms/LabelForm/_styles.scss
+++ b/frontend/components/forms/LabelForm/_styles.scss
@@ -20,7 +20,7 @@
   }
 
   &__cancel-btn {
-    margin-right: 14px;
+    margin-right: $pad-medium;
   }
 
   &__save-btn {
@@ -28,7 +28,7 @@
   }
 
   &__text-editor-wrapper {
-    margin: 24px 0;
+    margin: $pad-large 0;
   }
 }
 

--- a/frontend/components/forms/LoginForm/_styles.scss
+++ b/frontend/components/forms/LoginForm/_styles.scss
@@ -19,21 +19,21 @@
     border-top-right-radius: 0;
     box-sizing: border-box;
     flex-direction: column;
-    padding: 40px;
+    padding: $pad-xxlarge;
     font-weight: $regular;
   }
 
   &__submit-btn {
-    margin-top: 40px;
+    margin-top: $pad-xxlarge;
     width: 160px;
   }
 
   &__sso-btn {
-    margin-top: 40px;
+    margin-top: $pad-xxlarge;
   }
 
   &__forgot-wrap {
-    margin-top: 4px;
+    margin-top: $pad-xsmall;
     text-align: right;
     width: 100%;
   }

--- a/frontend/components/forms/LogoutForm/_styles.scss
+++ b/frontend/components/forms/LogoutForm/_styles.scss
@@ -8,7 +8,7 @@
     flex-direction: column;
     background-color: $core-white;
     box-sizing: border-box;
-    padding: 30px;
+    padding: $pad-xlarge;
     width: 460px;
     min-height: 350px;
   }
@@ -21,14 +21,14 @@
   &__username {
     color: $core-vibrant-blue;
     font-size: $large;
-    margin: $pad-half 0;
+    margin: $pad-small 0;
     text-transform: uppercase;
   }
 
   &__subtext {
     color: $core-fleet-blue;
     font-size: $medium;
-    margin-top: $pad-half;
+    margin-top: $pad-small;
   }
 
   &__submit-btn {

--- a/frontend/components/forms/RegistrationForm/ConfirmationPage/_styles.scss
+++ b/frontend/components/forms/RegistrationForm/ConfirmationPage/_styles.scss
@@ -33,7 +33,7 @@
     caption {
       font-size: $small;
       font-weight: $bold;
-      margin-bottom: 24px;
+      margin-bottom: $pad-large;
       text-align: left;
     }
 
@@ -63,12 +63,12 @@
 
   &__import {
     user-select: none;
-    font-size: 14px;
+    font-size: $x-small;
     font-weight: $regular;
     line-height: 1.71;
     letter-spacing: 0.5px;
     color: $core-fleet-black;
-    margin: 30px 0 0;
+    margin: $pad-xlarge 0 0;
 
     .kolide-checkbox {
       display: block;
@@ -80,7 +80,7 @@
 
     p {
       margin: 0;
-      padding-left: 40px;
+      padding-left: $pad-xxlarge;
     }
 
     .kolide-checkbox__input {
@@ -92,6 +92,6 @@
 
   .button {
     width: 160px;
-    margin-top: 40px;
+    margin-top: $pad-xxlarge;
   }
 }

--- a/frontend/components/forms/RegistrationForm/_styles.scss
+++ b/frontend/components/forms/RegistrationForm/_styles.scss
@@ -3,7 +3,7 @@
   justify-content: center;
   align-items: stretch;
   flex-grow: 1;
-  margin-top: 24px;
+  margin-top: $pad-large;
 
   &__container {
     @include size(500px auto);
@@ -12,7 +12,7 @@
     border-radius: 10px;
     background-color: $ui-off-white;
     box-sizing: border-box;
-    padding: 40px;
+    padding: $pad-xxlarge;
     z-index: 1;
     transform: translateY(-50%);
 
@@ -20,9 +20,9 @@
       font-size: $large;
       font-weight: $regular;
       text-align: center;
-      padding: 0 0 16px;
+      padding: 0 0 $pad-medium;
       margin: 0;
-      margin-bottom: 40px;
+      margin-bottom: $pad-xxlarge;
       border-bottom: 1px solid $ui-fleet-blue-15;
     }
 
@@ -59,10 +59,10 @@
       padding: 0;
 
       .user-registration__title {
-        font-size: 24px;
+        font-size: $large;
         font-weight: $bold;
         color: $core-fleet-black;
-        padding: 25px 35px;
+        padding: $pad-large 35px;
       }
     }
   }
@@ -160,7 +160,7 @@
   }
 
   &__description {
-    font-size: 14px;
+    font-size: $x-small;
     font-weight: $regular;
     color: $core-fleet-blue;
   }
@@ -183,7 +183,7 @@
 
     .button {
       width: 160px;
-      margin-top: 40px;
+      margin-top: $pad-xxlarge;
     }
 
     .registration-fields {

--- a/frontend/components/forms/ResetPasswordForm/_styles.scss
+++ b/frontend/components/forms/ResetPasswordForm/_styles.scss
@@ -11,7 +11,7 @@
   }
 
   &__btn {
-    margin-top: 40px;
+    margin-top: $pad-xxlarge;
     width: 160px;
     margin-bottom: 20px;
   }

--- a/frontend/components/forms/UserSettingsForm/_styles.scss
+++ b/frontend/components/forms/UserSettingsForm/_styles.scss
@@ -16,14 +16,14 @@
 
   &__button-wrap {
     width: 100%;
-    margin-top: 40px;
+    margin-top: $pad-xxlarge;
     display: flex;
     justify-content: flex-end;
 
     .button {
 
       &:last-child {
-        margin-left: 16px;
+        margin-left: $pad-medium;
       }
     }
   }

--- a/frontend/components/forms/_styles.scss
+++ b/frontend/components/forms/_styles.scss
@@ -3,7 +3,7 @@
     background-color: $ui-error;
     border-radius: 3px;
     color: $core-white;
-    font-size: 14px;
+    font-size: $x-small;
     margin-top: 10px;
     padding: 5px 0;
     text-align: center;

--- a/frontend/components/forms/admin/AppConfigForm/_styles.scss
+++ b/frontend/components/forms/admin/AppConfigForm/_styles.scss
@@ -20,7 +20,7 @@
   .form-field {
     &__label {
       font-weight: $bold;
-      margin-bottom: 4px;
+      margin-bottom: $pad-xsmall;
     }
 
     &__hint {
@@ -31,7 +31,7 @@
 
   &__section {
     @include clearfix;
-    margin: 0 0 30px;
+    margin: 0 0 $pad-xlarge;
 
     h2 {
       a {
@@ -67,7 +67,7 @@
   &__inputs {
     width: 60%;
     float: left;
-    padding: 0 40px 0 0;
+    padding: 0 $pad-xxlarge 0 0;
     box-sizing: border-box;
 
     .input-field {
@@ -75,7 +75,7 @@
     }
 
     &--smtp {
-      margin: 0 0 $pad-base;
+      margin: 0 0 $pad-medium;
 
       .form-field {
         width: 18%;
@@ -100,7 +100,7 @@
     width: 40%;
 
     .icon-tooltip {
-      margin: 32px 0;
+      margin: $pad-xlarge 0;
     }
 
     .hint {

--- a/frontend/components/forms/admin/EditUserForm/_styles.scss
+++ b/frontend/components/forms/admin/EditUserForm/_styles.scss
@@ -2,7 +2,7 @@
   box-sizing: border-box;
   height: 100%;
   position: relative;
-  margin-top: 24px;
+  margin-top: $pad-large;
 
   &__btn-wrap {
     display: flex;
@@ -10,13 +10,13 @@
   }
 
   .form-field {
-    margin-bottom: 24px;
+    margin-bottom: $pad-large;
   }
 
   form &__input {
     font-size: $small;
     width: 100%;
-    padding: $pad-xsmall $pad-half;
+    padding: $pad-xsmall $pad-small;
   }
 
   form &__label {
@@ -28,7 +28,7 @@
   &__form-btn {
 
     &--cancel {
-      margin-right: 14px;
+      margin-right: $pad-medium;
     }
   }
 }

--- a/frontend/components/forms/admin/OsqueryOptionsForm/_styles.scss
+++ b/frontend/components/forms/admin/OsqueryOptionsForm/_styles.scss
@@ -17,7 +17,7 @@
 
   &__text-editor-wrapper {
     width: 100%;
-    margin-bottom: 16px;
+    margin-bottom: $pad-medium;
   }
 
   .yaml-ace__label {

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -55,6 +55,7 @@
     &--disabled {
       &::after {
         background-color: $ui-fleet-blue-15;
+        border: 1px solid $ui-fleet-blue-15;
       }
     }
   }

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -5,7 +5,6 @@
 
   &__input {
     opacity: 0;
-    margin: 0;
 
     &:focus + .kolide-checkbox__tick {
       &::after {
@@ -44,8 +43,8 @@
     &::after {
       @include size(20px);
       transition: border 75ms ease-in-out, background 75ms ease-in-out;
-      border-radius: 2px;
-      border: solid 2px $ui-fleet-blue-15;
+      border-radius: $border-radius;
+      border: solid 2px $ui-fleet-black-25;
       content: '';
       box-sizing: border-box;
       display: block;
@@ -61,10 +60,9 @@
   }
 
   &__label {
-    font-size: 13px;
+    font-size: $x-small;
     font-weight: $regular;
     line-height: 20px;
-    letter-spacing: 0.5px;
     color: $core-fleet-black;
     padding-left: $pad-small;
   }

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -32,7 +32,7 @@
   }
 
   &__help-text {
-    margin-top: 4px;
+    margin-top: $pad-xsmall;
     font-size: $xx-small;
     white-space: normal;
     color: $core-fleet-blue;
@@ -44,7 +44,7 @@
   .Select-control {
     border: 1px solid $ui-fleet-blue-15;
     background-color: $ui-light-grey;
-    border-radius: 4px;
+    border-radius: $border-radius;
     height: 40px;
 
     .Select-value {
@@ -54,7 +54,7 @@
 
   .Select-value {
     font-size: $x-small;
-    border-radius: 4px;
+    border-radius: $border-radius;
     background-color: $ui-light-grey;
     border: solid 1px $ui-fleet-blue-15;
 
@@ -134,9 +134,9 @@
   }
 
   .Select-menu-outer {
-    margin-top: 4px;
+    margin-top: $pad-xsmall;
     box-shadow: 0 4px 10px rgba(52, 59, 96, 0.15);
-    border-radius: 4px;
+    border-radius: $border-radius;
     z-index: 6;
     overflow: hidden;
     border: 0;
@@ -150,7 +150,7 @@
     color: $core-fleet-black;
     font-size: $x-small;
     margin: $pad-small;
-    padding: $pad-half;
+    padding: $pad-small;
     display: block;
 
     &.is-focused {

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -2,7 +2,7 @@
   line-height: 34px;
   background-color: $ui-light-grey;
   border: solid 1px $ui-fleet-blue-15;
-  border-radius: 4px;
+  border-radius: $border-radius;
   font-size: $small;
   padding: $pad-xsmall 12px;
   color: $core-fleet-black;
@@ -10,8 +10,8 @@
   box-sizing: border-box;
   height: 40px;
 
-  ::placeholder {
-    color: $ui-fleet-black-50;
+  &::placeholder {
+    color: $ui-fleet-black-25;
   }
 
   &:focus {
@@ -60,11 +60,11 @@
   }
 
   &__wrapper {
-    margin-bottom: $pad-base;
+    margin-bottom: $pad-medium;
   }
 
   &__hint {
-    font-size: 14px;
+    font-size: $x-small;
     font-weight: $regular;
     line-height: 1.57;
     letter-spacing: 1px;

--- a/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
+++ b/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
@@ -1,5 +1,5 @@
 .input-icon-field {
-  margin-top: 16px;
+  margin-top: $pad-medium;
   position: relative;
   width: 100%;
 
@@ -22,8 +22,8 @@
   &__input {
     border: 1px solid $ui-fleet-blue-15;
     background-color: $ui-light-grey;
-    border-radius: 4px;
-    padding: 9px 30px 9px 16px;
+    border-radius: $border-radius;
+    padding: 9px 30px 9px $pad-medium;
     font-size: $small;
     text-indent: 1px;
     position: relative;
@@ -32,8 +32,8 @@
     color: $core-fleet-black;
     font-weight: $regular;
 
-    ::placeholder {
-      color: $ui-fleet-black-50;
+    &::placeholder {
+      color: $ui-fleet-black-25;
     }
 
     &:focus {
@@ -49,7 +49,7 @@
   &__label {
     font-size: $x-small;
     font-weight: $bold;
-    margin-bottom: 4px;
+    margin-bottom: $pad-xsmall;
   }
 
   &__errors {
@@ -62,7 +62,7 @@
     font-weight: $regular;
     line-height: 20px;
     display: inline-block;
-    margin-top: 8px;
+    margin-top: $pad-small;
 
     code {
       color: $core-vibrant-blue;

--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/_styles.scss
@@ -2,7 +2,7 @@
 
   &__type {
     padding: 0 8px 4px;
-    margin: 40px 0 0;
+    margin: $pad-xxlarge 0 0;
     text-transform: uppercase;
     font-weight: $bold;
     font-size: $xx-small;
@@ -22,7 +22,7 @@
     min-height: 500px;
     position: relative;
     z-index: 2;
-    padding: 24px 16px;
+    padding: $pad-large $pad-medium;
     border-right: 1px solid $ui-fleet-blue-15;
     background-color: $core-white;
   }

--- a/frontend/components/forms/fields/SelectTargetsDropdown/TargetDetails/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/TargetDetails/_styles.scss
@@ -21,7 +21,7 @@
   }
 
   @include breakpoint(ltdesktop) {
-    padding-top: $pad-most;
+    padding-top: $pad-xxlarge;
   }
 }
 
@@ -175,7 +175,7 @@
       font-weight: $bold;
       line-height: 2.3;
       color: $core-fleet-black;
-      padding-right: $pad-half;
+      padding-right: $pad-small;
     }
   }
 }

--- a/frontend/components/forms/fields/SelectTargetsDropdown/TargetOption/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/TargetOption/_styles.scss
@@ -13,7 +13,7 @@
     align-content: stretch;
     cursor: default;
     border-radius: 8px;
-    padding: 4px 8px;
+    padding: $pad-xsmall 8px;
   }
 
   &__target-content,
@@ -75,13 +75,13 @@
   &__label-host {
     color: $core-fleet-purple;
     font-size: $medium;
-    margin-left: $pad-half;
+    margin-left: $pad-small;
   }
 
   &__label-label {
     color: $core-fleet-black;
-    font-size: 14px;
-    margin-left: $pad-half;
+    font-size: $x-small;
+    margin-left: $pad-small;
 
     .all-hosts {
       font-weight: $bold;
@@ -92,7 +92,7 @@
     color: $core-vibrant-blue;
     cursor: pointer;
     float: right;
-    margin-right: $pad-base;
+    margin-right: $pad-medium;
   }
 
   &__target-icon {
@@ -115,6 +115,6 @@
 
   .target-option__label-label {
     font-weight: $bold;
-    margin-right: 8px;
+    margin-right: $pad-small;
   }
 }

--- a/frontend/components/forms/fields/SelectTargetsDropdown/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/_styles.scss
@@ -5,7 +5,7 @@
     font-size: $x-small;
     color: $core-fleet-black;
     display: block;
-    margin: 40px 0 4px;
+    margin: $pad-xxlarge 0 $pad-xsmall;
     text-align: right;
 
     &--error {
@@ -50,20 +50,20 @@
 
     .Select-input {
       height: 46px;
-      margin: 0 0 0 $pad-base;
+      margin: 0 0 0 $pad-medium;
 
       > input {
         line-height: 30px;
-        padding: 8px 0;
+        padding: $pad-small 0;
         color: $core-fleet-black;
-        font-size: 16px;
+        font-size: $small;
       }
     }
 
     .Select-placeholder {
       line-height: 46px;
-      font-size: 16px;
-      padding: 0 $pad-base;
+      font-size: $small;
+      padding: 0 $pad-medium;
     }
 
     .Select-arrow-zone {
@@ -170,7 +170,7 @@
     }
 
     .Select-value-label {
-      font-size: 16px;
+      font-size: $small;
       font-weight: $regular;
       color: $core-fleet-black;
       padding: 0 0 0 $pad-medium;
@@ -179,7 +179,7 @@
   }
 
   .Select-clear {
-    font-size: 28px;
+    font-size: $x-large;
     margin-right: 10px;
     color: $core-fleet-blue;
 

--- a/frontend/components/forms/packs/EditPackForm/_styles.scss
+++ b/frontend/components/forms/packs/EditPackForm/_styles.scss
@@ -24,7 +24,7 @@
   }
 
   &__pack-buttons {
-    margin: 25px 0;
+    margin: $pad-large 0;
     text-align: right;
 
     .button {

--- a/frontend/components/forms/queries/QueryForm/_styles.scss
+++ b/frontend/components/forms/queries/QueryForm/_styles.scss
@@ -2,7 +2,7 @@
   &__wrapper {
 
     h1 {
-      margin-bottom: 24px;
+      margin-bottom: $pad-large;
     }
   }
 
@@ -30,7 +30,7 @@
   }
 
   &__text-editor-wrapper {
-    margin: $pad-base 0;
+    margin: $pad-medium 0;
   }
 
   &__title {

--- a/frontend/components/hosts/AddHostModal/_styles.scss
+++ b/frontend/components/hosts/AddHostModal/_styles.scss
@@ -34,7 +34,7 @@
     h4 {
       font-size: $small;
       font-weight: $bold;
-      margin: 34px 0 0;
+      margin: $pad-xlarge 0 0;
 
       .kolidecon {
         margin-left: 5px;
@@ -48,7 +48,7 @@
       line-height: 20px;
       letter-spacing: normal;
       color: $core-fleet-black;
-      margin: 8px 0 0 44px;
+      margin: $pad-small 0 0 44px;
     }
 
     a {
@@ -88,13 +88,13 @@
     color: $core-vibrant-blue;
     font-weight: $bold;
     text-align: center;
-    margin-right: 16px;
+    margin-right: $pad-medium;
   }
 
   &__button-wrap {
     display: flex;
     justify-content: flex-end;
-    margin: 24px 0 0;
+    margin: $pad-large 0 0;
   }
 
   &__download-cert {
@@ -121,9 +121,9 @@
     background-color: $ui-off-white;
     color: $core-fleet-black;
     border: 1px solid $ui-fleet-blue-15;
-    border-radius: 4px;
-    padding: 7px 16px;
-    margin: 24px 0 0 44px;
+    border-radius: $border-radius;
+    padding: 7px $pad-medium;
+    margin: $pad-large 0 0 44px;
   }
 
   &__error {

--- a/frontend/components/loaders/ProgressBar/_styles.scss
+++ b/frontend/components/loaders/ProgressBar/_styles.scss
@@ -4,7 +4,7 @@
   height: 10px;
   overflow: hidden;
   border-radius: 2px;
-  margin-top: 4px;
+  margin-top: $pad-xsmall;
 
   &__progress {
     height: 100%;

--- a/frontend/components/loaders/Timer/_styles.scss
+++ b/frontend/components/loaders/Timer/_styles.scss
@@ -1,4 +1,4 @@
 .kolide-timer {
-  font-size: 14px;
+  font-size: $x-small;
   color: $core-fleet-black;
 }

--- a/frontend/components/modals/Modal/_styles.scss
+++ b/frontend/components/modals/Modal/_styles.scss
@@ -46,7 +46,7 @@
     @include position(absolute, 22px null null null);
     background-color: $core-white;
     width: 658px;
-    padding: 40px;
+    padding: $pad-xxlarge;
     border-radius: 8px;
   }
 }

--- a/frontend/components/packs/PacksList/_styles.scss
+++ b/frontend/components/packs/PacksList/_styles.scss
@@ -4,9 +4,9 @@
 
   &__wrapper {
     border: 1px solid $ui-fleet-blue-15;
-    border-radius: 4px;
+    border-radius: $border-radius;
     overflow: hidden;
-    margin-top: 16px;
+    margin-top: $pad-medium;
   }
 
   thead {

--- a/frontend/components/queries/QueriesList/_styles.scss
+++ b/frontend/components/queries/QueriesList/_styles.scss
@@ -1,9 +1,9 @@
 .queries-list {
   background-color: $core-white;
   border: 1px solid $ui-fleet-blue-15;
-  border-radius: 4px;
+  border-radius: $border-radius;
   box-sizing: border-box;
-  margin-top: 16px;
+  margin-top: $pad-medium;
   overflow: scroll;
 
   &__table {

--- a/frontend/components/queries/QueryPageSelectTargets/_styles.scss
+++ b/frontend/components/queries/QueryPageSelectTargets/_styles.scss
@@ -1,5 +1,5 @@
 .query-page-select-targets {
   &__wrapper {
-    padding: 0 30px;
+    padding: 0 $pad-xlarge;
   }
 }

--- a/frontend/components/queries/QueryProgressDetails/_styles.scss
+++ b/frontend/components/queries/QueryProgressDetails/_styles.scss
@@ -1,5 +1,5 @@
 .query-progress-details {
-  margin-top: 24px;
+  margin-top: $pad-large;
   @at-root &.query-results-table__full-screen {
     float: left;
   }
@@ -27,7 +27,7 @@
       content: ' ';
       display: inline-block;
       height: 8px;
-      margin-right: 8px;
+      margin-right: $pad-small;
       width: 8px;
     }
   }
@@ -39,7 +39,7 @@
       content: ' ';
       display: inline-block;
       height: 8px;
-      margin-right: 8px;
+      margin-right: $pad-small;
       width: 8px;
     }
   }
@@ -51,7 +51,7 @@
       content: ' ';
       display: inline-block;
       height: 8px;
-      margin-right: 8px;
+      margin-right: $pad-small;
       width: 8px;
     }
   }

--- a/frontend/components/queries/QueryResultsTable/_styles.scss
+++ b/frontend/components/queries/QueryResultsTable/_styles.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   background-color: $core-white;
   width: 100%;
-  min-height: calc(500px + (#{$pad-base} * 2));
+  min-height: calc(500px + (#{$pad-medium} * 2));
   box-sizing: border-box;
 
   &__table-title {
@@ -37,7 +37,7 @@
     border: solid 1px $ui-fleet-blue-15;
     border-radius: 3px;
     overflow: scroll;
-    margin-top: 4px;
+    margin-top: $pad-xsmall;
     min-height: 200px;
     max-height: 400px;
     width: 100%;
@@ -55,7 +55,7 @@
   }
 
   &__error-table-container {
-    margin-top: 24px;
+    margin-top: $pad-large;
   }
 
   &__error-table-wrapper {
@@ -63,8 +63,8 @@
     border: solid 1px $ui-fleet-blue-15;
     border-radius: 3px;
     overflow: scroll;
-    margin-bottom: 40px;
-    margin-top: 4px;
+    margin-bottom: $pad-xxlarge;
+    margin-top: $pad-xsmall;
     max-height: 200px;
     width: 100%;
   }
@@ -83,7 +83,7 @@
     border-bottom: 1px solid $ui-fleet-blue-15;
 
     th {
-      padding: 12px 24px;
+      padding: 12px $pad-large;
       min-width: 125px;
 
       .form-field {
@@ -108,7 +108,7 @@
     background-color: $core-white;
 
     td {
-      padding: 12px 24px;
+      padding: 12px $pad-large;
       white-space: nowrap;
     }
 
@@ -162,20 +162,20 @@
 @keyframes growFullScreen {
   100% {
     top: 60px;
-    right: $pad-half;
-    bottom: $pad-half;
-    left: $pad-half;
-    max-width: calc(100vw - #{$pad-half} - #{$pad-half});
+    right: $pad-small;
+    bottom: $pad-small;
+    left: $pad-small;
+    max-width: calc(100vw - #{$pad-small} - #{$pad-small});
     max-height: 100vh;
   }
 }
 
 @keyframes shrinkFullScreen {
   0% {
-    top: $pad-half;
+    top: $pad-small;
     right: auto;
     bottom: auto;
-    left: $pad-half;
+    left: $pad-small;
     max-width: 100vw;
     max-height: 100vh;
   }

--- a/frontend/components/queries/ScheduledQueriesList/_styles.scss
+++ b/frontend/components/queries/ScheduledQueriesList/_styles.scss
@@ -1,7 +1,7 @@
 .scheduled-queries-list {
   background-color: $core-white;
   border: 1px solid $ui-fleet-blue-15;
-  border-radius: 4px;
+  border-radius: $border-radius;
   box-sizing: border-box;
 
   &__table {
@@ -68,7 +68,7 @@
         }
 
         &:nth-child(2) {
-          font-size: 14px;
+          font-size: $x-small;
           font-weight: $bold;
           line-height: 2.71;
           letter-spacing: -0.5px;
@@ -77,7 +77,7 @@
         }
 
         &:nth-child(3) {
-          font-size: 14px;
+          font-size: $x-small;
           font-weight: $regular;
           line-height: 2.71;
           letter-spacing: -0.5px;
@@ -85,7 +85,7 @@
         }
 
         &:nth-child(4) {
-          font-size: 14px;
+          font-size: $x-small;
           font-weight: $regular;
           line-height: 2.71;
           letter-spacing: -0.5px;
@@ -95,7 +95,7 @@
         
         &:nth-child(5),
         &:nth-child(6) {
-          font-size: 14px;
+          font-size: $x-small;
           font-weight: $regular;
           line-height: 2.71;
           letter-spacing: -0.5px;
@@ -121,12 +121,12 @@
   }
 
   &__first-query {
-    padding: 30px 15px 100px;
+    padding: $pad-xlarge 15px 100px;
     text-align: left;
 
     h1 {
       color: $core-fleet-black;
-      font-size: 24px;
+      font-size: $large;
       font-weight: $regular;
       line-height: 1.96;
       letter-spacing: -0.5px;
@@ -134,7 +134,7 @@
     }
 
     h2 {
-      font-size: 20px;
+      font-size: $medium;
       line-height: 2;
       letter-spacing: -0.4px;
       color: $core-fleet-black;
@@ -143,7 +143,7 @@
     }
 
     p {
-      font-size: 16px;
+      font-size: $small;
       font-weight: $regular;
       line-height: 2.5;
       color: $core-fleet-black;
@@ -158,7 +158,7 @@
 
     li {
       margin-left: 15px;
-      font-size: 16px;
+      font-size: $small;
       font-weight: $regular;
       line-height: 2.5;
       color: $core-fleet-black;

--- a/frontend/components/queries/ScheduledQueriesListWrapper/_styles.scss
+++ b/frontend/components/queries/ScheduledQueriesListWrapper/_styles.scss
@@ -1,16 +1,16 @@
 .scheduled-queries-list-wrapper {
   flex-grow: 1;
-  padding: 40px 30px;
-  margin-bottom: $pad-base;
+  padding: $pad-xxlarge $pad-xlarge;
+  margin-bottom: $pad-medium;
 
   &__query-count {
     font-size: $x-small;
     font-weight: $bold;
-    margin: 24px 0;
+    margin: $pad-large 0;
   }
 
   &__queries-list-wrapper {
-    margin-top: $pad-base;
+    margin-top: $pad-medium;
     clear: both;
   }
 

--- a/frontend/components/side_panels/HostSidePanel/PanelGroupItem/_styles.scss
+++ b/frontend/components/side_panels/HostSidePanel/PanelGroupItem/_styles.scss
@@ -30,12 +30,12 @@ $base-class: 'panel-group-item';
   &__name {
     @include ellipsis(80%);
     flex-grow: 1;
-    padding-left: 16px;
+    padding-left: $pad-medium;
   }
 
   &__description {
     font-size: 13px;
-    margin-left: 4px;
+    margin-left: $pad-xsmall;
     text-transform: lowercase;
   }
 
@@ -43,7 +43,7 @@ $base-class: 'panel-group-item';
     transition: color 75ms ease-in-out;
     font-weight: $regular;
     text-align: right;
-    padding-right: 16px;
-    font-size: 14px;
+    padding-right: $pad-medium;
+    font-size: $x-small;
   }
 }

--- a/frontend/components/side_panels/HostSidePanel/_styles.scss
+++ b/frontend/components/side_panels/HostSidePanel/_styles.scss
@@ -18,12 +18,12 @@
     font-size: $x-small;
     font-weight: $bold;
     color: $core-fleet-black;
-    margin: 24px 0 10px 16px;
+    margin: $pad-large 0 10px $pad-medium;
   }
 
   &__add-label-btn {
     width: 100%;
-    margin-top: 24px;
+    margin-top: $pad-large;
   }
 
   &__panel-group-item {
@@ -37,19 +37,19 @@
         position: absolute;
         top: 10px;
         left: 12px;
-        font-size: 20px;
+        font-size: $medium;
         color: $core-fleet-black;
       }
     }
 
     .title {
       padding-left: 20px;
-      font-size: 16px;
+      font-size: $small;
     }
   }
 
   &__filter-labels {
-    margin-bottom: 16px;
+    margin-bottom: $pad-medium;
 
     .input-field {
       padding-left: 42px;

--- a/frontend/components/side_panels/PackDetailsSidePanel/_styles.scss
+++ b/frontend/components/side_panels/PackDetailsSidePanel/_styles.scss
@@ -1,16 +1,16 @@
 .pack-details-side-panel {
-  padding: 16px 20px 0;
+  padding: $pad-medium 20px 0;
 
   &__description {
     color: $core-fleet-blue;
-    font-size: 14px;
+    font-size: $x-small;
     word-wrap: break-word;
   }
 
   &__section-label {
     font-size: $medium;
     font-weight: $bold;
-    margin: 24px 0 16px;
+    margin: $pad-large 0 $pad-medium;
   }
 
   &__edit-pack-link {
@@ -32,13 +32,13 @@
 
   &__query-icon {
     color: $core-fleet-black;
-    font-size: 16px;
+    font-size: $small;
     margin-right: 15px;
   }
 
   &__queries-list {
     list-style: none;
-    margin: 0 0 16px;
+    margin: 0 0 $pad-medium;
     padding: 0;
   }
 

--- a/frontend/components/side_panels/PackInfoSidePanel/_styles.scss
+++ b/frontend/components/side_panels/PackInfoSidePanel/_styles.scss
@@ -4,14 +4,14 @@
   border-left: 1px solid $ui-fleet-blue-15;
   box-sizing: border-box;
   overflow: scroll;
-  padding: 30px;
+  padding: $pad-xlarge;
 
   &__title {
     font-size: $medium;
     font-weight: $regular;
     color: $core-fleet-black;
     border-bottom: 1px solid $ui-fleet-blue-15;
-    padding-bottom: 8px;
+    padding-bottom: $pad-small;
     margin: 0 0 4px;
   }
 
@@ -36,7 +36,7 @@
       color: $core-fleet-black;
 
       .kolidecon {
-        font-size: 20px;
+        font-size: $medium;
         margin-right: 5px;
       }
 
@@ -48,7 +48,7 @@
     dd {
       font-size: 13px;
       color: $core-fleet-black;
-      margin-left: 30px;
+      margin-left: $pad-xlarge;
     }
   }
 }

--- a/frontend/components/side_panels/QueryDetailsSidePanel/_styles.scss
+++ b/frontend/components/side_panels/QueryDetailsSidePanel/_styles.scss
@@ -15,7 +15,7 @@
   &__label {
     font-size: $medium;
     font-weight: $bold;
-    margin: 24px 0 16px;
+    margin: $pad-large 0 $pad-medium;
   }
 
   &__description {
@@ -38,7 +38,7 @@
   }
 
   &__packs {
-    margin-bottom: 24px;
+    margin-bottom: $pad-large;
     padding: 0;
     list-style: none;
   }

--- a/frontend/components/side_panels/QuerySidePanel/_styles.scss
+++ b/frontend/components/side_panels/QuerySidePanel/_styles.scss
@@ -1,22 +1,22 @@
 .query-side-panel {
-  padding: 0 28px;
+  padding: 0 $pad-large;
 
   &__header {
-    margin: 0 0 16px;
+    margin: 0 0 $pad-medium;
     font-size: $x-small;
     font-weight: $bold;
     color: $core-fleet-black;
   }
 
   &__choose-table {
-    margin: 40px 0 16px;
+    margin: $pad-xxlarge 0 $pad-medium;
 
     .form-field {
-      margin-bottom: 16px;
+      margin-bottom: $pad-medium;
     }
 
     .Select {
-      margin: 0 0 $pad-half;
+      margin: 0 0 $pad-small;
     }
   }
 
@@ -28,19 +28,19 @@
   }
 
   &__platforms {
-    font-size: 14px;
+    font-size: $x-small;
     color: $core-fleet-black;
     list-style: none;
-    margin: 0 0 24px;
+    margin: 0 0 $pad-large;
     padding: 0;
 
     .kolidecon {
       font-size: 18px;
-      margin-right: 16px;
+      margin-right: $pad-medium;
     }
 
     .icon {
-      margin-right: 16px;
+      margin-right: $pad-medium;
       width: 20px;
       height: 20px;
     }
@@ -49,7 +49,7 @@
       height: 20px;
       display: flex;
       align-items: center;
-      padding-bottom: 16px;
+      padding-bottom: $pad-medium;
 
       &:last-child {
         padding-bottom: 0;
@@ -59,7 +59,7 @@
 
   &__columns,
   &__suggested-queries {
-    margin: 0 0 24px;
+    margin: 0 0 $pad-large;
   }
 
   &__column-list {
@@ -71,13 +71,13 @@
   &__column-wrapper {
     display: flex;
     margin: 0 0 15px;
-    padding-top: $pad-half;
+    padding-top: $pad-small;
     border-top: 1px solid $ui-fleet-blue-15;
   }
 
   &__suggestion {
     flex-grow: 1;
-    font-size: 14px;
+    font-size: $x-small;
     line-height: 1.71;
     letter-spacing: 0.5px;
     text-align: left;
@@ -107,9 +107,9 @@
   }
 
   &__name {
-    border-radius: 4px;
+    border-radius: $border-radius;
     border: solid 1px $core-fleet-black;
-    padding: 4px 10px;
+    padding: $pad-xsmall 10px;
     box-sizing: border-box;
     font-size: $xx-small;
     font-weight: $bold;
@@ -129,7 +129,7 @@
   &__help {
     margin-left: 12px;
     vertical-align: text-bottom;
-    font-size: 20px;
+    font-size: $medium;
     color: $core-fleet-black;
   }
 }

--- a/frontend/components/side_panels/ScheduleQuerySidePanel/SearchPackQuery/_styles.scss
+++ b/frontend/components/side_panels/ScheduleQuerySidePanel/SearchPackQuery/_styles.scss
@@ -17,11 +17,11 @@
   }
 
   &__description {
-    margin: 0 0 30px;
+    margin: 0 0 $pad-xlarge;
     word-wrap: break-word;
 
     h2 {
-      font-size: 16px;
+      font-size: $small;
       font-weight: $bold;
       letter-spacing: -0.5px;
       color: $core-fleet-black;
@@ -32,7 +32,7 @@
 
     p {
       margin: 0 0 10px;
-      font-size: 14px;
+      font-size: $x-small;
       font-weight: $regular;
       line-height: 1.71;
       color: $core-fleet-black;

--- a/frontend/components/side_panels/SiteNavSidePanel/_styles.scss
+++ b/frontend/components/side_panels/SiteNavSidePanel/_styles.scss
@@ -25,7 +25,7 @@
   &__icon {
     position: relative;
     font-size: $large;
-    margin-right: 8px;
+    margin-right: $pad-small;
     width: 16px;
     height: 16px;
     vertical-align: sub;

--- a/frontend/components/side_panels/UserMenu/_styles.scss
+++ b/frontend/components/side_panels/UserMenu/_styles.scss
@@ -4,7 +4,7 @@
   }
 
   .dropdown-button__options {
-    padding: 8px;
+    padding: $pad-small;
     right: 10px;
 
     button {

--- a/frontend/pages/ConfirmInvitePage/_styles.scss
+++ b/frontend/pages/ConfirmInvitePage/_styles.scss
@@ -2,8 +2,8 @@
   background-color: $core-white;
   border-radius: 10px;
   width: 436px;
-  padding: 40px;
-  margin-top: 40px;
+  padding: $pad-xxlarge;
+  margin-top: $pad-xxlarge;
 
   &__form-section-description {
     h2 {
@@ -18,7 +18,7 @@
 
     p {
       color: $core-fleet-black;
-      font-size: 14px;
+      font-size: $x-small;
       font-weight: $regular;
     }
   }
@@ -29,7 +29,7 @@
   }
 
   &__lead-wrapper {
-    border-radius: 4px;
+    border-radius: $border-radius;
     box-sizing: border-box;
   }
 
@@ -50,7 +50,7 @@
   .confirm-invite-button-wrap {
     display: flex;
     justify-content: center;
-    margin-top: 40px;
+    margin-top: $pad-xxlarge;
 
     .button {
       width: 160px;

--- a/frontend/pages/Fleet404/_styles.scss
+++ b/frontend/pages/Fleet404/_styles.scss
@@ -48,7 +48,7 @@
 
     > h2 {
       font-size: 36px;
-      margin: 13px 0 30px;
+      margin: 13px 0 $pad-xlarge;
     }
   }
 

--- a/frontend/pages/Fleet500/_styles.scss
+++ b/frontend/pages/Fleet500/_styles.scss
@@ -7,7 +7,7 @@
     color: $core-vibrant-blue;
     text-decoration: none;
     display: block;
-    margin-top: 16px;
+    margin-top: $pad-medium;
 
     &:hover {
       text-decoration: underline;

--- a/frontend/pages/LoginSuccessfulPage/_styles.scss
+++ b/frontend/pages/LoginSuccessfulPage/_styles.scss
@@ -1,7 +1,7 @@
 .login-success {
   background-color: $core-white;
   margin-top: 20px;
-  padding: 40px;
+  padding: $pad-xxlarge;
   text-align: center;
   border-radius: 10px;
   z-index: 0;

--- a/frontend/pages/LogoutPage/_styles.scss
+++ b/frontend/pages/LogoutPage/_styles.scss
@@ -11,8 +11,8 @@
     background-color: $core-white;
     height: 30px;
     margin-top: 20px;
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-top-left-radius: $border-radius;
+    border-top-right-radius: $border-radius;
     box-shadow: 0 5px 30px 0 rgba($core-fleet-black, 0.3);
     width: 376px;
   }

--- a/frontend/pages/RegistrationPage/Breadcrumbs/_styles.scss
+++ b/frontend/pages/RegistrationPage/Breadcrumbs/_styles.scss
@@ -39,14 +39,14 @@
       display: block;
       border-radius: 50%;
       content: '';
-      font-size: 28px;
+      font-size: $x-large;
       margin: 14px auto 0;
       position: relative;
       z-index: 1;
       cursor: pointer;
 
       @include breakpoint(tablet) {
-        margin-top: 4px;
+        margin-top: $pad-xsmall;
       }
     }
 

--- a/frontend/pages/UserSettingsPage/_styles.scss
+++ b/frontend/pages/UserSettingsPage/_styles.scss
@@ -3,7 +3,7 @@
   align-items: stretch;
 
   h1 {
-    margin: 0 0 30px;
+    margin: 0 0 $pad-xlarge;
   }
 
   h2 {
@@ -21,7 +21,7 @@
     max-width: 350px;
     min-width: 350px;
     box-sizing: border-box;
-    padding: 30px;
+    padding: $pad-xlarge;
     background-color: $ui-light-grey;
     min-height: 100vh;
   }
@@ -38,20 +38,20 @@
       z-index: 1;
       text-decoration: none;
       font-size: $x-small;
-      margin-top: 4px;
+      margin-top: $pad-xsmall;
     }
   }
 
   &__header {
     font-size: $x-small;
     font-weight: $bold;
-    margin: 24px 0 4px;
+    margin: $pad-large 0 $pad-xsmall;
   }
 
   &__description {
     font-size: $x-small;
     font-style: italic;
-    margin: 4px 0;
+    margin: $pad-xsmall 0;
   }
 
   &__avatar {
@@ -79,7 +79,7 @@
   &__last-updated {
     font-size: $x-small;
     font-style: italic;
-    margin: 4px 0 24px;
+    margin: $pad-xsmall 0 $pad-large;
   }
 
   &__reveal-secret {
@@ -136,6 +136,6 @@
     font-size: $xx-small;
     text-align: center;
     display: block;
-    margin-top: 40px;
+    margin-top: $pad-xxlarge;
   }
 }

--- a/frontend/pages/admin/AppSettingsPage/_styles.scss
+++ b/frontend/pages/admin/AppSettingsPage/_styles.scss
@@ -1,5 +1,5 @@
 .app-settings {
-  padding: 40px 30px;
+  padding: $pad-xxlarge $pad-xlarge;
 
   &__page-description {
     font-size: $x-small;
@@ -8,7 +8,7 @@
   }
 
   h2 {
-    font-size: 20px;
+    font-size: $medium;
     font-weight: $regular;
     color: $core-fleet-black;
     border-bottom: solid 1px $ui-fleet-blue-15;
@@ -50,7 +50,7 @@
     font-size: $x-small;
 
     li {
-      margin-bottom: 16px;
+      margin-bottom: $pad-medium;
     }
 
     a {

--- a/frontend/pages/admin/OsqueryOptionsPage/_styles.scss
+++ b/frontend/pages/admin/OsqueryOptionsPage/_styles.scss
@@ -1,5 +1,5 @@
 .osquery-options {
-  padding: 40px 30px;
+  padding: $pad-xxlarge $pad-xlarge;
   flex-grow: 1;
 
   &__page-wrap {
@@ -18,7 +18,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin-bottom: 16px;
+    margin-bottom: $pad-medium;
 
     p {
       margin: 0;
@@ -30,13 +30,13 @@
       font-size: $x-small;
       font-weight: $bold;
       text-decoration: none;
-      margin-left: 16px;
+      margin-left: $pad-medium;
     }
 
     img {
       width: 12px;
       height: 12px;
-      margin-left: 6px;
+      margin-left: $pad-small;
     }
   }
 
@@ -58,6 +58,6 @@
   }
 
   i {
-    margin-left: 8px;
+    margin-left: $pad-small;
   }
 }

--- a/frontend/pages/admin/SettingsWrapper/_styles.scss
+++ b/frontend/pages/admin/SettingsWrapper/_styles.scss
@@ -1,7 +1,7 @@
 @import '../../../../node_modules/react-tabs/style/react-tabs.scss';
 
 .settings-wrapper {
-  padding: 25px 30px 50px; // different to pad sticky subnav properly
+  padding: 25px $pad-xlarge 50px; // different to pad sticky subnav properly
 
   &__nav-header {
     padding-top: 15px;
@@ -12,7 +12,7 @@
   }
 
   h1 {
-    margin-bottom: $pad-half;
+    margin-bottom: $pad-small;
   }
 
   .body-wrap {
@@ -27,8 +27,8 @@
     &__tab {
       font-size: $x-small;
       border: none;
-      padding: 0 0 $pad-base 0;
-      margin-left: 40px;
+      padding: 0 0 $pad-medium 0;
+      margin-left: $pad-xxlarge;
       display: inline-flex;
       flex-direction: column;
       align-items: center;

--- a/frontend/pages/admin/UserManagementPage/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/_styles.scss
@@ -1,5 +1,5 @@
 .user-management {
-  padding: 30px;
+  padding: $pad-xlarge;
 
   &__page-description {
     font-size: $x-small;

--- a/frontend/pages/admin/UserManagementPage/components/EmptyUsers/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/components/EmptyUsers/_styles.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 80px;
+  margin-top: $pad-xxxlarge;
 
   &__inner {
     display: flex;
@@ -16,7 +16,7 @@
 
     img {
       width: 176px;
-      margin-right: 34px;
+      margin-right: $pad-xlarge;
     }
 
     p {

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
@@ -2,7 +2,7 @@
   margin-top: $pad-large;
 
   &__sso-input {
-    margin-top: 22px;
+    margin-top: $pad-large;
 
     .kolide-checkbox {
       margin-top: 5px;
@@ -11,7 +11,7 @@
         font-size: $x-small;
         font-weight: $bold;
         color: $core-fleet-black;
-        padding-left: 32px;
+        padding-left: $pad-xlarge;
       }
     }
   }
@@ -20,7 +20,7 @@
     color: $core-fleet-black;
     font-size: $x-small;
     font-weight: $bold;
-    margin-bottom: 4px;
+    margin-bottom: $pad-xsmall;
   }
 
   &__user-permissions-info {
@@ -47,7 +47,7 @@
   }
 
   &__selected-teams-container {
-    margin-bottom: $pad-most;
+    margin-bottom: $pad-xxlarge;
   }
 
   &__radio-input {

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -7,10 +7,10 @@
   .section {
     display: flex;
     flex-direction: column;
-    margin: 40px 0 0;
+    margin: $pad-xxlarge 0 0;
 
     &__header {
-      margin: 0 0 16px;
+      margin: 0 0 $pad-medium;
       font-size: $medium;
     }
 
@@ -24,7 +24,7 @@
         white-space: nowrap;
 
         &--title {
-          margin-right: 40px;
+          margin-right: $pad-xxlarge;
         }
 
       }
@@ -59,7 +59,7 @@
     margin: 0;
 
     &__inner {
-      padding-bottom: 16px;
+      padding-bottom: $pad-medium;
     }
 
     .hostname-container {
@@ -97,10 +97,10 @@
       &__block {
         display: flex;
         flex-direction: column;
-        margin-right: 40px;
+        margin-right: $pad-xxlarge;
 
         span {
-          margin-bottom: 16px;
+          margin-bottom: $pad-medium;
 
           &:last-child {
             margin-bottom: 0;
@@ -122,7 +122,7 @@
         content: ' ';
         display: inline-block;
         height: 8px;
-        margin-right: 8px;
+        margin-right: $pad-small;
         width: 8px;
       }
     }
@@ -134,7 +134,7 @@
         content: ' ';
         display: inline-block;
         height: 8px;
-        margin-right: 8px;
+        margin-right: $pad-small;
         width: 8px;
       }
     }
@@ -151,7 +151,7 @@
 
   &__modal {
     p {
-      font-size: 16px;
+      font-size: $small;
     }
   }
 

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -4,11 +4,11 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 16px;
+    margin-bottom: $pad-medium;
   }
 
   .ace-kolide {
-    margin-bottom: $pad-base;
+    margin-bottom: $pad-medium;
   }
 
   &__header {
@@ -17,7 +17,7 @@
   }
 
   &__text {
-    margin-right: 24px;
+    margin-right: $pad-large;
   }
 
   &__title {
@@ -28,19 +28,19 @@
 
     button {
       &:first-child {
-        margin-right: 12px;
+        margin-right: $pad-medium;
       }
     }
   }
 
   &__description {
-    margin: 0 0 16px;
+    margin: 0 0 $pad-medium;
 
     h2 {
       text-transform: uppercase;
       color: $core-fleet-blue;
       font-weight: $regular;
-      font-size: 16px;
+      font-size: $small;
     }
 
     p {
@@ -57,7 +57,7 @@
     justify-content: flex-end;
 
     .button:first-child {
-      margin-right: $pad-base;
+      margin-right: $pad-medium;
     }
   }
 

--- a/frontend/pages/hosts/ManageHostsPage/components/EditColumnsModal/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/EditColumnsModal/_styles.scss
@@ -5,7 +5,7 @@
     justify-content: flex-end;
 
     .save-button {
-      margin-left: $pad-half;
+      margin-left: $pad-small;
     }
   }
 }

--- a/frontend/pages/hosts/ManageHostsPage/components/EmptyHosts/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/EmptyHosts/_styles.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 80px;
+  margin-top: $pad-xxxlarge;
 
   &__inner {
     display: flex;
@@ -16,7 +16,7 @@
 
     img {
       width: 176px;
-      margin-right: 34px;
+      margin-right: $pad-xlarge;
     }
 
     p {

--- a/frontend/pages/hosts/ManageHostsPage/components/NoHosts/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/NoHosts/_styles.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 80px;
+  margin-top: $pad-xxxlarge;
 
   h1 {
     font-size: $large;
@@ -15,7 +15,7 @@
   h2 {
     font-size: $x-small;
     font-weight: $bold;
-    margin: 0 0 24px;
+    margin: 0 0 $pad-large;
     line-height: 20px;
     color: $core-fleet-black;
   }
@@ -31,7 +31,7 @@
       &::before {
         content: '•';
         color: $core-vibrant-blue;
-        margin-right: 16px;
+        margin-right: $pad-medium;
       }
     }
   }
@@ -48,7 +48,7 @@
 
     img {
       width: 176px;
-      margin-right: 34px;
+      margin-right: $pad-xlarge;
     }
 
     p {
@@ -66,12 +66,12 @@
   }
 
   .host-pagination__pager-wrap {
-    margin-top: $pad-base;
+    margin-top: $pad-medium;
   }
 
   &__no-hosts-contact {
     text-align: left;
-    margin-top: 24px;
+    margin-top: $pad-large;
 
     p {
       color: $core-fleet-black;

--- a/frontend/pages/packs/AllPacksPage/_styles.scss
+++ b/frontend/pages/packs/AllPacksPage/_styles.scss
@@ -3,7 +3,7 @@
     color: $core-fleet-purple;
     font-size: 15px;
     font-weight: $regular;
-    margin-left: 26px;
+    margin-left: $pad-large;
 
     &--disable {
       margin-left: 0;
@@ -55,7 +55,7 @@
       top: 36px;
       left: 9px;
       font-size: 18px;
-      color: $ui-gray;
+      color: $core-fleet-black;
     }
   }
 
@@ -64,7 +64,7 @@
   }
 
   &__wrapper {
-    padding: 40px 30px;
+    padding: $pad-xxlarge $pad-xlarge;
   }
 
   &__table {

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -33,7 +33,7 @@
     input {
       &[name='query-filter'] {
         width: 100%;
-        margin-top: 24px;
+        margin-top: $pad-large;
       }
     }
   }
@@ -51,7 +51,7 @@
       top: 36px;
       left: 9px;
       font-size: 18px;
-      color: $ui-gray;
+      color: $core-fleet-black;
     }
   }
 
@@ -60,7 +60,7 @@
   }
 
   &__wrapper {
-    padding: 40px 30px;
+    padding: $pad-xxlarge $pad-xlarge;
   }
 
   &__modal-btn-wrap {
@@ -77,7 +77,7 @@
     font-size: $medium;
     font-weight: $bold;
     padding: 20px 20px 0;
-    margin: 24px 0;
+    margin: $pad-large 0;
   }
 
   &__empty-description {

--- a/frontend/pages/queries/QueryPage/_styles.scss
+++ b/frontend/pages/queries/QueryPage/_styles.scss
@@ -3,7 +3,7 @@
     display: flex;
     flex-direction: column;
     align-self: stretch;
-    margin-bottom: $pad-base;
+    margin-bottom: $pad-medium;
   }
 
   &__results {

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -52,7 +52,7 @@ a {
 }
 
 .body-wrap {
-  padding: 40px 30px 0;
+  padding: $pad-xxlarge $pad-xlarge 0;
   border-radius: 3px;
   background-color: $core-white;
   border: solid 1px $core-white;
@@ -62,7 +62,7 @@ a {
     .has-sidebar & {
       margin-right: 0;
       min-width: 610px;
-      max-width: calc(100vw - #{$pad-body} - #{$pad-body} - #{$pad-borders} - #{$sidepanel-width});
+      max-width: calc(100vw - #{$pad-xlarge} - #{$pad-xlarge} - #{$pad-xxsmall} - #{$sidepanel-width});
     }
   }
 }

--- a/frontend/styles/var/fonts.scss
+++ b/frontend/styles/var/fonts.scss
@@ -1,3 +1,4 @@
+// Font sizes
 $xx-small: px-to-rem(12);
 $x-small: px-to-rem(14);
 $small: px-to-rem(16);
@@ -5,5 +6,6 @@ $medium: px-to-rem(20);
 $large: px-to-rem(24);
 $x-large: px-to-rem(28);
 
+// Font weights
 $regular: 400;
 $bold: 700;

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -30,7 +30,7 @@ $max-width: 2560px;
 @mixin sticky-settings-description {
   position: sticky;
   // this is the current spacing needed to keep the description looking correct under the sub nav when scrolling.
-  top: 97px;
+  top: 94px;
   z-index: 2;
   background-color: $core-white;
   margin: 0;

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -34,5 +34,5 @@ $max-width: 2560px;
   z-index: 2;
   background-color: $core-white;
   margin: 0;
-  padding: 40px 0 54px 0;
+  padding: $pad-xxlarge 0 54px 0;
 }

--- a/frontend/styles/var/padding.scss
+++ b/frontend/styles/var/padding.scss
@@ -1,12 +1,9 @@
 $pad-auto: auto;
+$pad-xxsmall: px-to-rem(2);
 $pad-xsmall: px-to-rem(4);
 $pad-small: px-to-rem(8);
 $pad-medium: px-to-rem(16);
-$pad-base: px-to-rem(18);
 $pad-large: px-to-rem(24);
 $pad-xlarge: px-to-rem(32);
-$pad-half: px-to-rem(9);
-$pad-none: 0;
-$pad-most: px-to-rem(40);
-$pad-body: px-to-rem(30);
-$pad-borders: px-to-rem(2);
+$pad-xxlarge: px-to-rem(40);
+$pad-xxxlarge: px-to-rem(80);


### PR DESCRIPTION
This if the 2nd PR as part of the of the Align components in Fleet UI with design system in Figma #539

These changes **refactor the spacing and font sizes** used by the frontend. 

- Change the scss variables in `padding.scss` and `fonts.scss`. 
- Replace custom styles with the new variables throughout all stylesheets.