### PR TITLE
Add Detect high severity vulnerable versions of OpenSSL to query handbook

### DIFF
--- a/handbook/queries/detect-hosts-with-high-severity-vulnerable-versions-of-openssl.md
+++ b/handbook/queries/detect-hosts-with-high-severity-vulnerable-versions-of-openssl.md
@@ -1,0 +1,45 @@
+# Detect macOS hosts with high severity vulnerable versions of OpenSSL
+
+Retrieves the OpenSSL version if the package was installed using the Homebrew package manager.
+
+See the table below to determine if the installed version is a high severity vulnerability and view the corresponding CVE(s).
+
+### Support
+
+macOS
+
+### Query
+
+```sql
+SELECT name, version FROM homebrew_packages WHERE name LIKE 'openssl%';
+```
+
+### Table of vulnerable OpenSSL versions
+
+The table below includes the high severity vulnerabilities reported by [OpenSSL](https://www.openssl.org/news/vulnerabilities.html).
+
+
+| Versions                                                  | CVE                                                                           |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| 1.1.1h-1.1.1j                                             | [CVE-2021-3450](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3450) |
+| 1.1.1-1.1.1j                                              | [CVE-2021-3449](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3449) |
+| 1.1.1-1.1.1h and 1.0.2-1.0.2w                             | [CVE-2020-1971](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1971) |
+| 1.1.1d-1.1.1f                                             | [CVE-2020-1967](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1967) |
+| 1.1.1-1.1.1d and 1.0.2-1.0.2t                             | [CVE-2019-1551](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1551) |
+| 1.1.1-1.1.1c                                              | [CVE-2019-1549](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1549) |
+| 1.1.0-1.1.0d                                              | [CVE-2017-3733](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-3733) |
+| 1.1.0-1.1.0b                                              | [CVE-2016-7054](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-7054) |
+| 1.1.0 and 1.0.2-1.0.2h and 1.0.1-1.0.1t                   | [CVE-2016-6304](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-6304) |
+| 1.0.2-1.0.2b and 1.0.1-1.0.1n                             | [CVE-2016-2108](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2108) |
+| 1.0.2-1.0.2f and 1.0.1-1.0.1r                             | [CVE-2016-0800](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0800) |
+| 1.0.2 and 1.0.1-1.0.1l and 1.0.0-1.0.0q and 0.9.8-0.9.8ze | [CVE-2016-0703](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0703) |
+| 1.0.2-1.0.2e                                              | [CVE-2016-0701](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0701) |
+| 1.0.2b-1.0.2c and 1.0.1n-1.0.1o                           | [CVE-2015-1793](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-1793) |
+| 1.0.2                                                     | [CVE-2015-0291](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-0291) |
+| 1.0.1-1.0.1i                                              | [CVE-2014-3513](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-3513) |
+| 1.0.1-1.0.1h                                              | [CVE-2014-3511](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-3511) |
+| 1.0.1-1.0.1h                                              | [CVE-2014-3511](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-3511) |
+
+### Purpose
+
+Detection

--- a/handbook/queries/detect-hosts-with-high-severity-vulnerable-versions-of-openssl.md
+++ b/handbook/queries/detect-hosts-with-high-severity-vulnerable-versions-of-openssl.md
@@ -1,17 +1,39 @@
-# Detect macOS hosts with high severity vulnerable versions of OpenSSL
+# Detect Linux hosts with high severity vulnerable versions of OpenSSL
 
-Retrieves the OpenSSL version if the package was installed using the Homebrew package manager.
+Retrieves the OpenSSL version.
 
 See the table below to determine if the installed version is a high severity vulnerability and view the corresponding CVE(s).
 
 ### Support
 
-macOS
+Linux
 
 ### Query
 
 ```sql
-SELECT name, version FROM homebrew_packages WHERE name LIKE 'openssl%';
+SELECT
+  name AS name,
+  version AS version,
+  'deb_packages' AS source
+FROM deb_packages
+WHERE 
+  name LIKE 'openssl%'
+UNION
+SELECT
+  name AS name,
+  version AS version,
+  'apt_sources' AS source
+FROM apt_sources
+WHERE 
+  name LIKE 'openssl%'
+UNION
+SELECT
+  name AS name,
+  version AS version,
+  'rpm_packages' AS source
+FROM rpm_packages
+WHERE 
+  name LIKE 'openssl%';
 ```
 
 ### Table of vulnerable OpenSSL versions


### PR DESCRIPTION
- Adds _Detect Linux hosts with high severity vulnerable versions of OpenSSL_ to query handbook
  - Includes query to retrieve OpenSSL version
  - Includes table to compare version results with high severity vulnerabilities