### PR TITLE
Batch updates to host seen time

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -235,13 +235,16 @@ the way that the Fleet server works.
 				}
 			}()
 
+			// Flush seen hosts every second
 			go func() {
 				ticker := time.NewTicker(1 * time.Second)
 				for {
 					if err := svc.FlushSeenHosts(context.Background()); err != nil {
-						logger.Log("err", err)
+						level.Info(logger).Log(
+							"err", err,
+							"msg", "failed to update host seen times",
+						)
 					}
-					logger.Log("msg", "flushed seen")
 					<-ticker.C
 				}
 			}()

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -235,6 +235,17 @@ the way that the Fleet server works.
 				}
 			}()
 
+			go func() {
+				ticker := time.NewTicker(1 * time.Second)
+				for {
+					if err := svc.FlushSeenHosts(context.Background()); err != nil {
+						logger.Log("err", err)
+					}
+					logger.Log("msg", "flushed seen")
+					<-ticker.C
+				}
+			}()
+
 			fieldKeys := []string{"method", "error"}
 			requestCount := kitprometheus.NewCounterFrom(prometheus.CounterOpts{
 				Namespace: "api",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: mysql:5.7
     volumes:
       - mysql-persistent-volume:/tmp
-    command: mysqld --datadir=/tmp/mysqldata --slow_query_log=1 --log_output=TABLE --log-queries-not-using-indexes --event-scheduler=ON
+    command: mysqld --datadir=/tmp/mysqldata --event-scheduler=ON
     environment: &mysql-default-environment
       MYSQL_ROOT_PASSWORD: toor
       MYSQL_DATABASE: fleet

--- a/server/datastore/datastore.go
+++ b/server/datastore/datastore.go
@@ -68,6 +68,7 @@ var TestFunctions = [...]func(*testing.T, kolide.Datastore){
 	testAddLabelToPackTwice,
 	testGenerateHostStatusStatistics,
 	testMarkHostSeen,
+	testMarkHostsSeen,
 	testCleanupIncomingHosts,
 	testDuplicateNewQuery,
 	testChangeEmail,

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -446,18 +446,25 @@ func (d *Datastore) MarkHostsSeen(hostIDs []uint, t time.Time) error {
 	if len(hostIDs) == 0 {
 		return nil
 	}
-	query := `
+
+	if err := d.withRetryTxx(func(tx *sqlx.Tx) error {
+		query := `
 		UPDATE hosts SET
 			seen_time = ?
 		WHERE id IN (?)
 	`
-	query, args, err := sqlx.In(query, t, hostIDs)
-	if err != nil {
-		return errors.Wrap(err, "IN for MarkHostsSeen")
-	}
-	query = d.db.Rebind(query)
-	if _, err := d.db.Exec(query, args...); err != nil {
-		return errors.Wrap(err, "update MarkHostsSeen")
+		query, args, err := sqlx.In(query, t, hostIDs)
+		if err != nil {
+			return errors.Wrap(err, "sqlx in")
+		}
+		query = d.db.Rebind(query)
+		if _, err := d.db.Exec(query, args...); err != nil {
+			return errors.Wrap(err, "exec update")
+		}
+
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "MarkHostsSeen transaction")
 	}
 
 	return nil

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -442,6 +442,27 @@ func (d *Datastore) MarkHostSeen(host *kolide.Host, t time.Time) error {
 	return nil
 }
 
+func (d *Datastore) MarkHostsSeen(hostIDs []uint, t time.Time) error {
+	if len(hostIDs) == 0 {
+		return nil
+	}
+	query := `
+		UPDATE hosts SET
+			seen_time = ?
+		WHERE id IN (?)
+	`
+	query, args, err := sqlx.In(query, t, hostIDs)
+	if err != nil {
+		return errors.Wrap(err, "IN for MarkHostsSeen")
+	}
+	query = d.db.Rebind(query)
+	if _, err := d.db.Exec(query, args...); err != nil {
+		return errors.Wrap(err, "update MarkHostsSeen")
+	}
+
+	return nil
+}
+
 func (d *Datastore) searchHostsWithOmits(query string, omit ...uint) ([]*kolide.Host, error) {
 	hostQuery := transformQuery(query)
 	ipQuery := `"` + query + `"`

--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -54,6 +54,7 @@ type HostStore interface {
 	// endpoints.
 	AuthenticateHost(nodeKey string) (*Host, error)
 	MarkHostSeen(host *Host, t time.Time) error
+	MarkHostsSeen(hostIDs []uint, t time.Time) error
 	SearchHosts(query string, omit ...uint) ([]*Host, error)
 	// CleanupIncomingHosts deletes hosts that have enrolled but never
 	// updated their status details. This clears dead "incoming hosts" that
@@ -83,6 +84,8 @@ type HostService interface {
 	// Possible matches can be on osquery_host_identifier, node_key, UUID, or
 	// hostname.
 	HostByIdentifier(ctx context.Context, identifier string) (*HostDetail, error)
+
+	FlushSeenHosts(ctx context.Context) error
 }
 
 type HostListOptions struct {

--- a/server/mock/datastore_hosts.go
+++ b/server/mock/datastore_hosts.go
@@ -28,6 +28,8 @@ type AuthenticateHostFunc func(nodeKey string) (*kolide.Host, error)
 
 type MarkHostSeenFunc func(host *kolide.Host, t time.Time) error
 
+type MarkHostsSeenFunc func(hostIDs []uint, t time.Time) error
+
 type CleanupIncomingHostsFunc func(t time.Time) error
 
 type SearchHostsFunc func(query string, omit ...uint) ([]*kolide.Host, error)
@@ -65,6 +67,9 @@ type HostStore struct {
 
 	MarkHostSeenFunc        MarkHostSeenFunc
 	MarkHostSeenFuncInvoked bool
+
+	MarkHostsSeenFunc        MarkHostsSeenFunc
+	MarkHostsSeenFuncInvoked bool
 
 	CleanupIncomingHostsFunc        CleanupIncomingHostsFunc
 	CleanupIncomingHostsFuncInvoked bool
@@ -125,6 +130,11 @@ func (s *HostStore) AuthenticateHost(nodeKey string) (*kolide.Host, error) {
 func (s *HostStore) MarkHostSeen(host *kolide.Host, t time.Time) error {
 	s.MarkHostSeenFuncInvoked = true
 	return s.MarkHostSeenFunc(host, t)
+}
+
+func (s *HostStore) MarkHostsSeen(hostIDs []uint, t time.Time) error {
+	s.MarkHostsSeenFuncInvoked = true
+	return s.MarkHostsSeenFunc(hostIDs, t)
 }
 
 func (s *HostStore) CleanupIncomingHosts(t time.Time) error {

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/WatchBeam/clock"
@@ -29,7 +30,7 @@ func NewService(ds kolide.Datastore, resultStore kolide.QueryResultStore,
 		return nil, errors.Wrap(err, "initializing osquery logging")
 	}
 
-	svc = service{
+	svc = &service{
 		ds:               ds,
 		carveStore:       carveStore,
 		resultStore:      resultStore,
@@ -40,6 +41,7 @@ func NewService(ds kolide.Datastore, resultStore kolide.QueryResultStore,
 		osqueryLogWriter: osqueryLogger,
 		mailService:      mailService,
 		ssoSessionStore:  sso,
+		seenHostMap:      newSeenHostMap(),
 		metaDataClient: &http.Client{
 			Timeout: 5 * time.Second,
 		},
@@ -62,6 +64,8 @@ type service struct {
 	mailService     kolide.MailService
 	ssoSessionStore sso.SessionStore
 	metaDataClient  *http.Client
+
+	seenHostMap *seenHostMap
 }
 
 func (s service) SendEmail(mail kolide.Email) error {
@@ -89,4 +93,33 @@ func getAssetURL() template.URL {
 	}
 
 	return template.URL("https://github.com/fleetdm/fleet/blob/" + tag)
+}
+
+type seenHostMap struct {
+	mutex   sync.Mutex
+	hostIDs map[uint]bool
+}
+
+func newSeenHostMap() *seenHostMap {
+	return &seenHostMap{
+		mutex:   sync.Mutex{},
+		hostIDs: make(map[uint]bool),
+	}
+}
+
+func (m *seenHostMap) addHostID(id uint) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.hostIDs[id] = true
+}
+
+func (m *seenHostMap) getAndClearHostIDs() []uint {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	var ids []uint
+	for id, _ := range m.hostIDs {
+		ids = append(ids, id)
+	}
+	m.hostIDs = make(map[uint]bool)
+	return ids
 }

--- a/server/service/service_hosts.go
+++ b/server/service/service_hosts.go
@@ -68,7 +68,6 @@ func (svc service) DeleteHost(ctx context.Context, id uint) error {
 }
 
 func (svc *service) FlushSeenHosts(ctx context.Context) error {
-	hostIDs := svc.seenHostMap.getAndClearHostIDs()
-	err := svc.ds.MarkHostsSeen(hostIDs, svc.clock.Now())
-	return err
+	hostIDs := svc.seenHostSet.getAndClearHostIDs()
+	return svc.ds.MarkHostsSeen(hostIDs, svc.clock.Now())
 }

--- a/server/service/service_hosts.go
+++ b/server/service/service_hosts.go
@@ -66,3 +66,9 @@ func (svc service) GetHostSummary(ctx context.Context) (*kolide.HostSummary, err
 func (svc service) DeleteHost(ctx context.Context, id uint) error {
 	return svc.ds.DeleteHost(id)
 }
+
+func (svc *service) FlushSeenHosts(ctx context.Context) error {
+	hostIDs := svc.seenHostMap.getAndClearHostIDs()
+	err := svc.ds.MarkHostsSeen(hostIDs, svc.clock.Now())
+	return err
+}

--- a/server/service/service_invites_test.go
+++ b/server/service/service_invites_test.go
@@ -89,7 +89,7 @@ func setupInviteTest(t *testing.T) (kolide.Service, *mock.Store, *mockMailServic
 		KolideServerURL: "https://acme.co",
 	})
 	mailer := &mockMailService{SendEmailFn: func(e kolide.Email) error { return nil }}
-	svc := validationMiddleware{service{
+	svc := validationMiddleware{&service{
 		ds:          ms,
 		config:      config.TestConfig(),
 		mailService: mailer,

--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -64,11 +64,10 @@ func (svc service) AuthenticateHost(ctx context.Context, nodeKey string) (*kolid
 		}
 	}
 
-	// Update the "seen" time used to calculate online status
-	err = svc.ds.MarkHostSeen(host, svc.clock.Now())
-	if err != nil {
-		return nil, osqueryError{message: "failed to mark host seen: " + err.Error()}
-	}
+	// Update the "seen" time used to calculate online status. These updates are
+	// batched for MySQL performance reasons.
+	svc.seenHostMap.addHostID(host.ID)
+	host.SeenTime = svc.clock.Now()
 
 	return host, nil
 }

--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -65,8 +65,12 @@ func (svc service) AuthenticateHost(ctx context.Context, nodeKey string) (*kolid
 	}
 
 	// Update the "seen" time used to calculate online status. These updates are
-	// batched for MySQL performance reasons.
-	svc.seenHostMap.addHostID(host.ID)
+	// batched for MySQL performance reasons. Because this is done
+	// asynchronously, it is possible for the server to shut down before
+	// updating the seen time for these hosts. This seems to be an acceptable
+	// tradeoff as an online host will continue to check in and quickly be
+	// marked online again.
+	svc.seenHostSet.addHostID(host.ID)
 	host.SeenTime = svc.clock.Now()
 
 	return host, nil


### PR DESCRIPTION
Instead of synchronously updating the `seen_time` column for a host on an update, batch these updates to be written together every 1 second.

This results in a ~33% reduction in MySQL CPU usage in a local test with 4,000 simulated hosts and MySQL running in Docker.

Top is after optimization, bottom is before:
<img width="582" alt="Screen Shot 2021-04-12 at 10 57 06 AM" src="https://user-images.githubusercontent.com/575602/114442880-e5989280-9b81-11eb-94c1-3198f52dbd24.png">
