### PR TITLE
Prepare queries for Software inventory

### DIFF
--- a/handbook/queries/get-installed-freebsd-software.md
+++ b/handbook/queries/get-installed-freebsd-software.md
@@ -12,6 +12,7 @@ FreeBSD
 SELECT
   name AS name,
   version AS version,
+  'Browser plugin (Chrome)' AS type,
   '' AS 'architecture',
   'chrome_extensions' AS source
 FROM chrome_extensions
@@ -19,6 +20,7 @@ UNION
 SELECT
   name AS name,
   version AS version,
+  'Browser plugin (Firefox)' AS type,
   '' AS 'architecture',
   'firefox_addons' AS source
 FROM firefox_addons
@@ -26,6 +28,7 @@ UNION
 SELECT
   name AS name,
   version AS version,
+  'Package (Atom)' AS type,
   '' AS 'architecture',
   'atom_packages' AS source
 FROM atom_packages
@@ -33,6 +36,7 @@ UNION
 SELECT
   name AS name,
   version AS version,
+  'Package (Python)' AS type,
   '' AS 'architecture',
   'python_packages' AS source
 FROM python_packages
@@ -40,6 +44,7 @@ UNION
 SELECT
   name AS name,
   version AS version,
+  'Package (pkg)' AS type,
   arch AS 'architecture',
   'pkg_packages' AS source
 FROM pkg_packages;

--- a/handbook/queries/get-installed-freebsd-software.md
+++ b/handbook/queries/get-installed-freebsd-software.md
@@ -12,30 +12,35 @@ FreeBSD
 SELECT
   name AS name,
   version AS version,
+  '' AS 'architecture',
   'chrome_extensions' AS source
 FROM chrome_extensions
 UNION
 SELECT
   name AS name,
   version AS version,
+  '' AS 'architecture',
   'firefox_addons' AS source
 FROM firefox_addons
 UNION
 SELECT
   name AS name,
   version AS version,
+  '' AS 'architecture',
   'atom_packages' AS source
 FROM atom_packages
 UNION
 SELECT
   name AS name,
   version AS version,
+  '' AS 'architecture',
   'python_packages' AS source
 FROM python_packages
 UNION
 SELECT
   name AS name,
   version AS version,
+  arch AS 'architecture',
   'pkg_packages' AS source
 FROM pkg_packages;
 ```

--- a/handbook/queries/get-installed-linux-software.md
+++ b/handbook/queries/get-installed-linux-software.md
@@ -12,54 +12,64 @@ Linux
 SELECT
   name AS name,
   version AS version,
+  architectures AS 'architecture',
+  '' AS 'install_time',
   'apt_sources' AS source
 FROM apt_sources
 UNION
 SELECT
   name AS name,
   version AS version,
+  arch AS 'architecture',
+  '' AS 'install_time',
   'deb_packages' AS source
 FROM deb_packages
 UNION
 SELECT
   package AS name,
   version AS version,
+  '' AS 'architecture',
+  '' AS 'install_time',
   'portage_packages' AS source
 FROM portage_packages
 UNION
 SELECT
   name AS name,
   version AS version,
+  arch AS 'architecture',
+  install_time AS 'install_time',
   'rpm_packages' AS source
 FROM rpm_packages
 UNION
 SELECT
   name AS name,
   '' AS version,
+  '' AS 'architecture',
+  '' AS 'install_time',
   'yum_sources' AS source
 FROM yum_sources
 UNION
 SELECT
   name AS name,
   version AS version,
-  'opera_extensions' AS source
-FROM opera_extensions
-UNION
-SELECT
-  name AS name,
-  version AS version,
+  '' AS 'architecture',
+  '' AS 'install_time',
   'npm_packages' AS source
 FROM npm_packages
 UNION
 SELECT
   name AS name,
   version AS version,
+  '' AS 'architecture',
+  '' AS 'install_time',
   'atom_packages' AS source
 FROM atom_packages
 UNION
 SELECT
   name AS name,
   version AS version,
+  '' AS 'architecture',
+  '' AS 'install_time',
   'python_packages' AS source
 FROM python_packages;
 ```

--- a/handbook/queries/get-installed-linux-software.md
+++ b/handbook/queries/get-installed-linux-software.md
@@ -12,6 +12,7 @@ Linux
 SELECT
   name AS name,
   version AS version,
+  'Package (APT)' AS type,
   architectures AS 'architecture',
   '' AS 'install_time',
   'apt_sources' AS source
@@ -20,6 +21,7 @@ UNION
 SELECT
   name AS name,
   version AS version,
+  'Package (deb)' AS type,
   arch AS 'architecture',
   '' AS 'install_time',
   'deb_packages' AS source
@@ -28,6 +30,7 @@ UNION
 SELECT
   package AS name,
   version AS version,
+  'Package (Portage)' AS type,
   '' AS 'architecture',
   '' AS 'install_time',
   'portage_packages' AS source
@@ -36,6 +39,7 @@ UNION
 SELECT
   name AS name,
   version AS version,
+  'Package (RPM)' AS type,
   arch AS 'architecture',
   install_time AS 'install_time',
   'rpm_packages' AS source
@@ -44,6 +48,7 @@ UNION
 SELECT
   name AS name,
   '' AS version,
+  'Package (YUM)' AS type,
   '' AS 'architecture',
   '' AS 'install_time',
   'yum_sources' AS source
@@ -52,6 +57,7 @@ UNION
 SELECT
   name AS name,
   version AS version,
+  'Package (NPM)' AS type,
   '' AS 'architecture',
   '' AS 'install_time',
   'npm_packages' AS source
@@ -60,6 +66,7 @@ UNION
 SELECT
   name AS name,
   version AS version,
+  'Package (Atom)' AS type,
   '' AS 'architecture',
   '' AS 'install_time',
   'atom_packages' AS source
@@ -68,6 +75,7 @@ UNION
 SELECT
   name AS name,
   version AS version,
+  'Package (Python)' AS type,
   '' AS 'architecture',
   '' AS 'install_time',
   'python_packages' AS source

--- a/handbook/queries/get-installed-macos-software.md
+++ b/handbook/queries/get-installed-macos-software.md
@@ -12,7 +12,7 @@ macOS
 SELECT
   name AS name,
   bundle_short_version AS version,
-  'Application' AS type,
+  'Application (macOS)' AS type,
   'apps' AS source
 FROM apps
 UNION

--- a/handbook/queries/get-installed-macos-software.md
+++ b/handbook/queries/get-installed-macos-software.md
@@ -12,42 +12,42 @@ macOS
 SELECT
   name AS name,
   bundle_short_version AS version,
+  'Application' AS type,
   'apps' AS source
 FROM apps
 UNION
 SELECT
   name AS name,
   version AS version,
+  'Package (Python)' AS type,
   'python_packages' AS source
 FROM python_packages
 UNION
 SELECT
   name AS name,
   version AS version,
+  'Browswer plugin (Chrome)' AS type,
   'chrome_extensions' AS source
 FROM chrome_extensions
 UNION
 SELECT
   name AS name,
   version AS version,
+  'Browswer plugin (Firefox)' AS type,
   'firefox_addons' AS source
 FROM firefox_addons
 UNION
 SELECT
-  name AS name,
-  version AS version,
-  'opera_extensions' AS source
-FROM opera_extensions
-UNION
-SELECT
   name As name,
   version AS version,
+  'Browswer plugin (Safari)' AS type,
   'safari_extensions' AS source
 FROM safari_extensions
 UNION
 SELECT
   name AS name,
   version AS version,
+  'Package (Homebrew)' AS type,
   'homebrew_packages' AS source
 FROM homebrew_packages;
 ```

--- a/handbook/queries/get-installed-windows-software.md
+++ b/handbook/queries/get-installed-windows-software.md
@@ -12,48 +12,56 @@ Windows
 SELECT
   name AS name,
   version AS version,
+  'Program (Windows)' AS type,
   'programs' AS source
 FROM programs
 UNION
 SELECT
   name AS name,
   version AS version,
+  'Package (Python)' AS type,
   'python_packages' AS source
 FROM python_packages
 UNION
 SELECT
   name AS name,
   version AS version,
+  'Broswer plugin (IE)' AS type,
   'ie_extensions' AS source
 FROM ie_extensions
 UNION
 SELECT
   name AS name,
   version AS version,
+  'Broswer plugin (Chrome)' AS type,
   'chrome_extensions' AS source
 FROM chrome_extensions
 UNION
 SELECT
   name AS name,
   version AS version,
+  'Broswer plugin (Firefox)' AS type,
   'firefox_addons' AS source
 FROM firefox_addons
 UNION
 SELECT
   name AS name,
   version AS version,
+  'Package (Chocolatey)' AS type,
   'chocolatey_packages' AS source
 FROM chocolatey_packages
 UNION
 SELECT
   name AS name,
   version AS version,
+  'Package (Atom)' AS type,
   'atom_packages' AS source
 FROM atom_packages
 UNION
 SELECT
   name AS name,
   version AS version,
+  'Package (Python)' AS type,
   'python_packages' AS source
 FROM python_packages;
 ```


### PR DESCRIPTION
This PR includes changes to the "Get installed ___ software" queries in the query handbook (4 total. 1 for each OS supported by osquery). 

These queries provide a wireframe for the queries that will enrich the `/hosts/{id}` endpoint in Fleet REST API. This endpoint will power the "Software inventory" page in the Fleet UI #399. 

Changes include:
- Add `type` column to all queries.
- Add `architecture and `install_time` column to Linux query.
- Add `architecture` column to FreeBSD query.
- Remove `opera_extensions` clause because osquery doesn't have an `opera_extensions` table.