### PR TITLE
Handle live query case when selected target contains 0 hosts 

### DIFF
--- a/frontend/pages/queries/QueryPage/QueryPage.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.jsx
@@ -233,6 +233,15 @@ export class QueryPage extends Component {
       return false;
     }
 
+    if (!selectedTargets.count) {
+      this.setState({
+        targetsError:
+          "You must select a target with at least one host to run a query",
+      });
+
+      return false;
+    }
+
     if (error) {
       dispatch(renderFlash("error", error));
 

--- a/frontend/pages/queries/QueryPage/QueryPage.tests.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.tests.jsx
@@ -12,7 +12,7 @@ import queryActions from "redux/nodes/entities/queries/actions";
 import ConnectedQueryPage, {
   QueryPage,
 } from "pages/queries/QueryPage/QueryPage";
-import { hostStub, queryStub } from "test/stubs";
+import { hostStub, queryStub, labelStub } from "test/stubs";
 
 const {
   connectedComponent,
@@ -153,6 +153,36 @@ describe("QueryPage - component", () => {
     QueryPageSelectTargets = page.find("QueryPageSelectTargets");
     expect(QueryPageSelectTargets.prop("error")).toEqual(
       "You must select at least one target to run a query"
+    );
+  });
+
+  it("sets targetError in state when the query is run and the selected target contains no hosts", () => {
+    const selectedTargetStore = {
+      ...store,
+      components: {
+        ...store.components,
+        QueryPages: {
+          ...store.components.QueryPages,
+          selectedTargets: [{ ...labelStub, count: 0 }],
+        },
+      },
+    };
+    const page = mount(
+      connectedComponent(ConnectedQueryPage, {
+        mockStore: reduxMockStore(selectedTargetStore),
+        props: locationProp,
+      })
+    );
+    const runQueryBtn = page.find(".query-progress-details__run-btn");
+    let QueryPageSelectTargets = page.find("QueryPageSelectTargets");
+
+    expect(QueryPageSelectTargets.prop("error")).toBeFalsy();
+
+    runQueryBtn.hostNodes().simulate("click");
+
+    QueryPageSelectTargets = page.find("QueryPageSelectTargets");
+    expect(QueryPageSelectTargets.prop("error")).toEqual(
+      "You must select a target with at least one host to run a query"
     );
   });
 


### PR DESCRIPTION
- Add an error message to handle the case when the user runs a live query with a target that contains 0 hosts
- Add unit test

Loom demo displaying the behavior before and after changes
https://www.loom.com/share/4232be8c72ee4982815098881d34d13e

Resolves #635