### PR TITLE
Handle hosts that have not had details updated in "Hosts" table

### DIFF
--- a/frontend/kolide/helpers.ts
+++ b/frontend/kolide/helpers.ts
@@ -293,8 +293,8 @@ export const humanHostMemory = (bytes: number): string => {
 export const humanHostDetailUpdated = (detailUpdated: string): string => {
   // Handles the case when a host has checked in to Fleet but
   // its details haven't been updated.
-  // July 30, 2014 is the date of the iitial commit to osquery.
-  if (detailUpdated < "2014-07-30T00:00:00Z") {
+  // July 28, 2016 is the date of the iitial commit to kolide/fleet.
+  if (detailUpdated < "2016-07-28T00:00:00Z") {
     return "Never";
   }
 

--- a/frontend/kolide/helpers.ts
+++ b/frontend/kolide/helpers.ts
@@ -293,7 +293,7 @@ export const humanHostMemory = (bytes: number): string => {
 export const humanHostDetailUpdated = (detailUpdated: string): string => {
   // Handles the case when a host has checked in to Fleet but
   // its details haven't been updated.
-  // July 28, 2016 is the date of the iitial commit to kolide/fleet.
+  // July 28, 2016 is the date of the initial commit to kolide/fleet.
   if (detailUpdated < "2016-07-28T00:00:00Z") {
     return "Never";
   }

--- a/frontend/kolide/helpers.ts
+++ b/frontend/kolide/helpers.ts
@@ -291,6 +291,13 @@ export const humanHostMemory = (bytes: number): string => {
 };
 
 export const humanHostDetailUpdated = (detailUpdated: string): string => {
+  // Handles the case when a host has checked in to Fleet but
+  // its details haven't been updated.
+  // July 30, 2014 is the date of the iitial commit to osquery.
+  if (detailUpdated < "2014-07-30T00:00:00Z") {
+    return "Never";
+  }
+
   return moment(detailUpdated).fromNow();
 };
 

--- a/frontend/pages/hosts/ManageHostsPage/components/HostContainer/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostContainer/HostTableConfig.tsx
@@ -211,15 +211,4 @@ const defaultHiddenColumns = [
   "hardware_serial",
 ];
 
-const enhanceLastFetchedData = (
-  detailedUpdatedAt: string,
-  enrolledAt: string
-): string => {
-  if (detailedUpdatedAt < enrolledAt) {
-    return "Never";
-  }
-
-  return detailedUpdatedAt;
-};
-
 export { hostDataHeaders, defaultHiddenColumns };

--- a/frontend/pages/hosts/ManageHostsPage/components/HostContainer/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostContainer/HostTableConfig.tsx
@@ -211,4 +211,15 @@ const defaultHiddenColumns = [
   "hardware_serial",
 ];
 
+const enhanceLastFetchedData = (
+  detailedUpdatedAt: string,
+  enrolledAt: string
+): string => {
+  if (detailedUpdatedAt < enrolledAt) {
+    return "Never";
+  }
+
+  return detailedUpdatedAt;
+};
+
 export { hostDataHeaders, defaultHiddenColumns };


### PR DESCRIPTION
It's possible for a host to successfully check in to Fleet and not have its host details updated. In this case, the "Last fetched" column in the "Hosts" table displays confusing information because the column relies on the accuracy of `detail_last_updated` (see #639)

Changes:
- Render "Never" in the "Last fetched" column if the value of `detail_updated_at` is improbable.
  - Ideally, the `detail_last_updated` would be compared to a time that is tied to the host itself (like `enroll_time`). However, the HostTable configuration makes it difficult to access two different host values for comparison when rendering the information.

Resolves #639 