### PR TITLE
Software Inventory on Host Details Page

### DIFF
--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -3,6 +3,6 @@ import PropTypes from "prop-types";
 export default PropTypes.shape({
   type: PropTypes.string,
   name: PropTypes.string,
-version: PropTypes.string,
+  version: PropTypes.string,
   id: PropTypes.number,
 });

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -3,6 +3,6 @@ import PropTypes from "prop-types";
 export default PropTypes.shape({
   type: PropTypes.string,
   name: PropTypes.string,
-  installed_version: PropTypes.string,
+version: PropTypes.string,
   id: PropTypes.number,
 });

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -1,0 +1,8 @@
+import PropTypes from "prop-types";
+
+export default PropTypes.shape({
+  type: PropTypes.string,
+  name: PropTypes.string,
+  installed_version: PropTypes.string,
+  id: PropTypes.number,
+});

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -251,7 +251,17 @@ export class HostDetailsPage extends Component {
     return (
       <div className="section section--software">
         <p className="section__header">Software</p>
-        {host.software ? (
+        {host.software.length === 0 ? (
+          <div className="results">
+            <p className="results__header">
+              No installed software detected on this host.
+            </p>
+            <p className="results__data">
+              Expecting to see software? Try again in a few seconds as the
+              system catches up.
+            </p>
+          </div>
+        ) : (
           <div className={`${baseClass}__wrapper`}>
             <table className={wrapperClassName}>
               <thead>
@@ -273,16 +283,6 @@ export class HostDetailsPage extends Component {
                   })}
               </tbody>
             </table>
-          </div>
-        ) : (
-          <div className="results">
-            <p className="results__header">
-              No installed software detected on this host.
-            </p>
-            <p className="results__data">
-              Expecting to see software? Try again in a few seconds as the
-              system catches up.
-            </p>
           </div>
         )}
       </div>
@@ -436,7 +436,7 @@ export class HostDetailsPage extends Component {
         </div>
         {renderLabels()}
         {renderPacks()}
-        {renderSoftware()}
+        {host.software && renderSoftware()}
         {renderDeleteHostModal()}
       </div>
     );

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -275,9 +275,11 @@ export class HostDetailsPage extends Component {
             </table>
           </div>
         ) : (
-          <div>
-            <p>No installed software detected on this host.</p>
-            <p>
+          <div className="results">
+            <p className="results__header">
+              No installed software detected on this host.
+            </p>
+            <p className="results__data">
               Expecting to see software? Try again in a few seconds as the
               system catches up.
             </p>

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -266,62 +266,66 @@ export class HostDetailsPage extends Component {
   renderSoftware = () => {
     const wrapperClassName = `${baseClass}__table`;
 
-    const softwareList = [
-      {
-        id: 1,
-        name: "Keynote",
-        type: "Application (macOS)",
-        installedVersion: "10.3.9",
-      },
-      {
-        id: 2,
-        name: "vim",
-        type: "Package (APT)",
-        installedVersion: "7.4.963",
-      },
-      {
-        id: 3,
-        name: "Birdfont",
-        type: "Package (deb)",
-        installedVersion: "2.25.0-3",
-      },
-      {
-        id: 4,
-        name: "Birdfont",
-        type: "Package (pkg)",
-        installedVersion: "2.25.0-3",
-      },
-    ];
+    const realData = false;
 
-    return (
-      <div className="section section--software">
-        <div className={baseClass}>
-          <p className="section__header">Software</p>
-          <div className={`${baseClass}__wrapper`}>
-            <table className={wrapperClassName}>
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>Type</th>
-                  <th>Installed Version</th>
-                </tr>
-              </thead>
-              <tbody>
-                {!!softwareList.length &&
-                  softwareList.map((software) => {
-                    return (
-                      <SoftwareListRow
-                        key={`software-row-${software.id}`}
-                        software={software}
-                      />
-                    );
-                  })}
-              </tbody>
-            </table>
+    if (realData) {
+      const softwareList = [
+        {
+          id: 1,
+          name: "Keynote",
+          type: "Application (macOS)",
+          installedVersion: "10.3.9",
+        },
+        {
+          id: 2,
+          name: "vim",
+          type: "Package (APT)",
+          installedVersion: "7.4.963",
+        },
+        {
+          id: 3,
+          name: "Birdfont",
+          type: "Package (deb)",
+          installedVersion: "2.25.0-3",
+        },
+        {
+          id: 4,
+          name: "Birdfont",
+          type: "Package (pkg)",
+          installedVersion: "2.25.0-3",
+        },
+      ];
+
+      return (
+        <div className="section section--software">
+          <div className={baseClass}>
+            <p className="section__header">Software</p>
+            <div className={`${baseClass}__wrapper`}>
+              <table className={wrapperClassName}>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Type</th>
+                    <th>Installed Version</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {!!softwareList.length &&
+                    softwareList.map((software) => {
+                      return (
+                        <SoftwareListRow
+                          key={`software-row-${software.id}`}
+                          software={software}
+                        />
+                      );
+                    })}
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
-      </div>
-    );
+      );
+    }
   };
 
   render() {

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -264,38 +264,11 @@ export class HostDetailsPage extends Component {
   };
 
   renderSoftware = () => {
+    const { host } = this.props;
+    debugger;
     const wrapperClassName = `${baseClass}__table`;
 
-    const realData = false;
-
-    if (realData) {
-      const softwareList = [
-        {
-          id: 1,
-          name: "Keynote",
-          type: "Application (macOS)",
-          installedVersion: "10.3.9",
-        },
-        {
-          id: 2,
-          name: "vim",
-          type: "Package (APT)",
-          installedVersion: "7.4.963",
-        },
-        {
-          id: 3,
-          name: "Birdfont",
-          type: "Package (deb)",
-          installedVersion: "2.25.0-3",
-        },
-        {
-          id: 4,
-          name: "Birdfont",
-          type: "Package (pkg)",
-          installedVersion: "2.25.0-3",
-        },
-      ];
-
+    if (host.software) {
       return (
         <div className="section section--software">
           <div className={baseClass}>
@@ -310,8 +283,8 @@ export class HostDetailsPage extends Component {
                   </tr>
                 </thead>
                 <tbody>
-                  {!!softwareList.length &&
-                    softwareList.map((software) => {
+                  {!!host.software.length &&
+                    host.software.map((software) => {
                       return (
                         <SoftwareListRow
                           key={`software-row-${software.id}`}

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -204,7 +204,11 @@ export class HostDetailsPage extends Component {
     return (
       <div className="section labels">
         <p className="section__header">Labels</p>
-        <ul className="list">{labelItems}</ul>
+        {labels.length === 0 ? (
+          <p className="info__item">No labels are associated with this host.</p>
+        ) : (
+          <ul className="list">{labelItems}</ul>
+        )}
       </div>
     );
   };
@@ -231,34 +235,11 @@ export class HostDetailsPage extends Component {
     return (
       <div className="section section--packs">
         <p className="section__header">Packs</p>
-        <ul className="list">{packItems}</ul>
-      </div>
-    );
-  };
-
-  renderPacks = () => {
-    const { onPackClick } = this;
-    const { host } = this.props;
-    const { packs = [] } = host;
-
-    const packItems = packs.map((pack) => {
-      return (
-        <li className="list__item" key={pack.id}>
-          <Button
-            onClick={() => onPackClick(pack)}
-            variant="text-link"
-            className="list__button"
-          >
-            {pack.name}
-          </Button>
-        </li>
-      );
-    });
-
-    return (
-      <div className="section section--packs">
-        <p className="section__header">Packs</p>
-        <ul className="list">{packItems}</ul>
+        {packs.length === 0 ? (
+          <p className="info__item">No packs have this host as a target.</p>
+        ) : (
+          <ul className="list">{packItems}</ul>
+        )}
       </div>
     );
   };
@@ -267,37 +248,43 @@ export class HostDetailsPage extends Component {
     const { host } = this.props;
     const wrapperClassName = `${baseClass}__table`;
 
-    if (host.software) {
-      return (
-        <div className="section section--software">
-          <div className={baseClass}>
-            <p className="section__header">Software</p>
-            <div className={`${baseClass}__wrapper`}>
-              <table className={wrapperClassName}>
-                <thead>
-                  <tr>
-                    <th>Name</th>
-                    <th>Type</th>
-                    <th>Installed Version</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {!!host.software.length &&
-                    host.software.map((software) => {
-                      return (
-                        <SoftwareListRow
-                          key={`software-row-${software.id}`}
-                          software={software}
-                        />
-                      );
-                    })}
-                </tbody>
-              </table>
-            </div>
+    return (
+      <div className="section section--software">
+        <p className="section__header">Software</p>
+        {host.software ? (
+          <div className={`${baseClass}__wrapper`}>
+            <table className={wrapperClassName}>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Installed Version</th>
+                </tr>
+              </thead>
+              <tbody>
+                {!!host.software.length &&
+                  host.software.map((software) => {
+                    return (
+                      <SoftwareListRow
+                        key={`software-row-${software.id}`}
+                        software={software}
+                      />
+                    );
+                  })}
+              </tbody>
+            </table>
           </div>
-        </div>
-      );
-    }
+        ) : (
+          <div>
+            <p>No installed software detected on this host.</p>
+            <p>
+              Expecting to see software? Try again in a few seconds as the
+              system catches up.
+            </p>
+          </div>
+        )}
+      </div>
+    );
   };
 
   render() {

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -9,6 +9,7 @@ import { noop, pick } from "lodash";
 import Spinner from "components/loaders/Spinner";
 import Button from "components/buttons/Button";
 import Modal from "components/modals/Modal";
+import SoftwareListRow from "pages/hosts/HostDetailsPage/SoftwareListRow";
 
 import entityGetter from "redux/utilities/entityGetter";
 import { renderFlash } from "redux/nodes/notifications/actions";
@@ -235,12 +236,107 @@ export class HostDetailsPage extends Component {
     );
   };
 
+  renderPacks = () => {
+    const { onPackClick } = this;
+    const { host } = this.props;
+    const { packs = [] } = host;
+
+    const packItems = packs.map((pack) => {
+      return (
+        <li className="list__item" key={pack.id}>
+          <Button
+            onClick={() => onPackClick(pack)}
+            variant="text-link"
+            className="list__button"
+          >
+            {pack.name}
+          </Button>
+        </li>
+      );
+    });
+
+    return (
+      <div className="section section--packs">
+        <p className="section__header">Packs</p>
+        <ul className="list">{packItems}</ul>
+      </div>
+    );
+  };
+
+  renderSoftware = () => {
+    // const alphaSort = (q) => q.name.toLowerCase();
+    // const {
+    //   queries,
+    // } = this.props;
+    // const sortedQueries = sortBy(queries, [alphaSort]);
+
+    const wrapperClassName = `${baseClass}__table`;
+
+    const softwareList = [
+      {
+        id: 1,
+        name: "Keynote",
+        type: "Application (macOS)",
+        installedVersion: "10.3.9",
+      },
+      {
+        id: 2,
+        name: "vim",
+        type: "Package (APT)",
+        installedVersion: "7.4.963",
+      },
+      {
+        id: 3,
+        name: "Birdfont",
+        type: "Package (deb)",
+        installedVersion: "2.25.0-3",
+      },
+      {
+        id: 4,
+        name: "Birdfont",
+        type: "Package (pkg)",
+        installedVersion: "2.25.0-3",
+      },
+    ];
+
+    return (
+      <div className="section section--software">
+        <div className={baseClass}>
+          <p className="section__header">Software</p>
+          <div className={`${baseClass}__wrapper`}>
+            <table className={wrapperClassName}>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Installed Version</th>
+                </tr>
+              </thead>
+              <tbody>
+                {!!softwareList.length &&
+                  softwareList.map((software) => {
+                    return (
+                      <SoftwareListRow
+                        key={`software-row-${software.id}`}
+                        software={software}
+                      />
+                    );
+                  })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
   render() {
     const { host, isLoadingHost } = this.props;
     const {
       renderDeleteHostModal,
       renderActionButtons,
       renderLabels,
+      renderSoftware,
       renderPacks,
     } = this;
 
@@ -381,6 +477,7 @@ export class HostDetailsPage extends Component {
         </div>
         {renderLabels()}
         {renderPacks()}
+        {renderSoftware()}
         {renderDeleteHostModal()}
       </div>
     );

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -264,12 +264,6 @@ export class HostDetailsPage extends Component {
   };
 
   renderSoftware = () => {
-    // const alphaSort = (q) => q.name.toLowerCase();
-    // const {
-    //   queries,
-    // } = this.props;
-    // const sortedQueries = sortBy(queries, [alphaSort]);
-
     const wrapperClassName = `${baseClass}__table`;
 
     const softwareList = [

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -265,7 +265,6 @@ export class HostDetailsPage extends Component {
 
   renderSoftware = () => {
     const { host } = this.props;
-    debugger;
     const wrapperClassName = `${baseClass}__table`;
 
     if (host.software) {

--- a/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/SoftwareListRow.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/SoftwareListRow.jsx
@@ -33,7 +33,7 @@ class SoftwareListRow extends Component {
       pkg_packages: "Package (pkg)",
     };
 
-    const type = TYPE_CONVERSION[source];
+    const type = TYPE_CONVERSION[source] || "Unknown";
 
     return (
       <tr>

--- a/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/SoftwareListRow.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/SoftwareListRow.jsx
@@ -13,10 +13,32 @@ class SoftwareListRow extends Component {
     const { software } = this.props;
     const { name, source, version } = software;
 
+    const TYPE_CONVERSION = {
+      apt_sources: "Package (APT)",
+      deb_packages: "Package (deb)",
+      portage_packages: "Package (Portage)",
+      rpm_packages: "Package (RPM)",
+      yum_sources: "Package (YUM)",
+      npm_packages: "Package (NPM)",
+      atom_packages: "Package (Atom)",
+      python_packages: "Package (Python)",
+      apps: "Application (macOS)",
+      chrome_extensions: "Browser plugin (Chrome)",
+      firefox_addons: "Browser plugin (Firefox)",
+      safari_extensions: "Browser plugin (Safari)",
+      homebrew_packages: "Package (Homebrew)",
+      programs: "Program (Windows)",
+      ie_extensions: "Browser plugin (IE)",
+      chocolatey_packages: "Package (Chocolatey)",
+      pkg_packages: "Package (pkg)",
+    };
+
+    const type = TYPE_CONVERSION[source];
+
     return (
       <tr>
         <td className={`${baseClass}__name`}>{name}</td>
-        <td className={`${baseClass}__type`}>{source}</td>
+        <td className={`${baseClass}__type`}>{type}</td>
         <td className={`${baseClass}__installed-version`}>{version}</td>
       </tr>
     );

--- a/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/SoftwareListRow.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/SoftwareListRow.jsx
@@ -14,15 +14,13 @@ class SoftwareListRow extends Component {
 
   render() {
     const { software } = this.props;
-    const { name, type, installedVersion } = software;
+    const { name, source, version } = software;
 
     return (
       <tr>
         <td className={`${baseClass}__name`}>{name}</td>
-        <td className={`${baseClass}__type`}>{type}</td>
-        <td className={`${baseClass}__installed-version`}>
-          {installedVersion}
-        </td>
+        <td className={`${baseClass}__type`}>{source}</td>
+        <td className={`${baseClass}__installed-version`}>{version}</td>
       </tr>
     );
   }

--- a/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/SoftwareListRow.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/SoftwareListRow.jsx
@@ -1,0 +1,31 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import classnames from "classnames";
+import moment from "moment";
+
+import softwareInterface from "interfaces/software";
+
+const baseClass = "software-list-row";
+
+class SoftwareListRow extends Component {
+  static propTypes = {
+    software: softwareInterface.isRequired,
+  };
+
+  render() {
+    const { software } = this.props;
+    const { name, type, installedVersion } = software;
+
+    return (
+      <tr>
+        <td className={`${baseClass}__name`}>{name}</td>
+        <td className={`${baseClass}__type`}>{type}</td>
+        <td className={`${baseClass}__installed-version`}>
+          {installedVersion}
+        </td>
+      </tr>
+    );
+  }
+}
+
+export default SoftwareListRow;

--- a/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/SoftwareListRow.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/SoftwareListRow.jsx
@@ -1,7 +1,4 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
-import classnames from "classnames";
-import moment from "moment";
 
 import softwareInterface from "interfaces/software";
 

--- a/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/_styles.scss
@@ -1,0 +1,43 @@
+.software-list-row {
+  line-height: 38px;
+  border-bottom: 1px solid $ui-borders;
+
+  &__type {
+    max-width: 280px;
+  }
+
+  &__installed-version {
+    max-width: 280px;
+  }
+
+  &:last-child {
+    border-bottom: 0;
+  }
+
+  &--selected {
+    background-color: $core-blue-label-down;
+  }
+
+  &:hover {
+    cursor: pointer;
+    background-color: $core-blue-label-over;
+  }
+
+  &:active,
+  &:focus {
+    outline: none;
+  }
+
+  td {
+    font-size: $x-small;
+
+    .form-field {
+      margin: 0;
+    }
+  }
+
+  &__name {
+    @include ellipsis(120px);
+    display: table-cell;
+  }
+}

--- a/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/_styles.scss
@@ -14,20 +14,6 @@
     border-bottom: 0;
   }
 
-  &--selected {
-    background-color: $core-blue-label-down;
-  }
-
-  &:hover {
-    cursor: pointer;
-    background-color: $core-blue-label-over;
-  }
-
-  &:active,
-  &:focus {
-    outline: none;
-  }
-
   td {
     font-size: $x-small;
 

--- a/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/index.js
+++ b/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/index.js
@@ -1,0 +1,1 @@
+export { default } from "./SoftwareListRow";

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -163,4 +163,50 @@
     justify-content: center;
     text-align: center;
   }
+
+  &__wrapper {
+    border: solid 1px $ui-borders;
+    border-radius: 6px;
+    margin-top: $pad-half;
+    overflow: scroll;
+    box-shadow: inset -8px 0 17px -10px #e8edf4;
+  }
+
+  &__table {
+    width: 100%;
+    border-collapse: collapse;
+    color: $core-black;
+    font-size: $x-small;
+  }
+  tr {
+    border-bottom: 1px solid $ui-borders;
+
+    &:last-child {
+      border-bottom: 0;
+    }
+  }
+
+  thead {
+    background-color: $core-light-blue-grey;
+    color: $core-black;
+    text-align: left;
+    border-bottom: 1px solid $ui-borders;
+
+    th {
+      padding: 16px 27px;
+      white-space: nowrap;
+      border-right: 1px solid $ui-borders;
+
+      &:last-child {
+        border-right: none;
+      }
+    }
+  }
+
+  tbody {
+    td {
+      padding: 12px 27px;
+      white-space: nowrap;
+    }
+  }
 }

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -48,6 +48,21 @@
         }
       }
     }
+
+    .results {
+      margin: auto;
+      width: 350px;
+
+      &__header {
+        font-size: $small;
+        color: $core-black;
+        font-weight: $bold;
+      }
+
+      &__data {
+        font-size: $x-small;
+      }
+    }
   }
 
   .title {


### PR DESCRIPTION

<img width="1132" alt="Screen Shot 2021-04-27 at 3 37 53 PM" src="https://user-images.githubusercontent.com/71795832/116302295-ff83c900-a76e-11eb-8b68-e91c809a0a8c.png">
<img width="1116" alt="Screen Shot 2021-04-27 at 3 39 00 PM" src="https://user-images.githubusercontent.com/71795832/116302306-01e62300-a76f-11eb-987e-d3b60dbfd470.png">

Updated and ready for review  4/27:
- Includes ternary for no packs, no labels, no software inventory
- Type updated with user-friendly verbage
- Styling matching Figma

 @noahtalerman with the assist.