### PR TITLE
Fix handling of 0 targets for live queries

### DIFF
--- a/frontend/pages/queries/QueryPage/QueryPage.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.jsx
@@ -219,7 +219,7 @@ export class QueryPage extends Component {
   };
 
   onRunQuery = debounce(() => {
-    const { queryText } = this.state;
+    const { queryText, targetsCount } = this.state;
     const { query } = this.props.query;
     const sql = queryText || query;
     const { dispatch, selectedTargets } = this.props;
@@ -233,7 +233,7 @@ export class QueryPage extends Component {
       return false;
     }
 
-    if (!selectedTargets.count) {
+    if (!targetsCount) {
       this.setState({
         targetsError:
           "You must select a target with at least one host to run a query",


### PR DESCRIPTION
- Fix handling of live query error when the number of hosts targeted is 0.

PR #641 attempted to handle the case when a user, running a live query, selects a label that contains 0 hosts. 

The fix in this earlier PR introduced a bug that prevented the user from running a live query at all!