### PR TITLE
Fix E2E CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,11 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v2
 
+    # Pre-starting dependencies here means they are ready to go when we need them.
+    - name: Start Infra Dependencies
+      # Use & to background this
+      run: docker-compose up -d mysql_test redis mailhog saml_idp &
+
     - name: JS Dependency Cache
       id: js-cache
       uses: actions/cache@v2
@@ -52,11 +57,6 @@ jobs:
     - name: Install Go Dependencies
       if: steps.go-cache.outputs.cache-hit != 'true'
       run: make deps-go
-
-    # Pre-starting dependencies here means they are ready to go when we need them.
-    - name: Start Infra Dependencies
-      # Use & to background this
-      run: docker-compose up -d mysql_test redis mailhog saml_idp &
 
     - name: Build Fleet
       run: |


### PR DESCRIPTION
Due to Go build caching in #687, the dependencies were sometimes not started before the E2E test. This PR reorders startup of the dependencies so that they should almost always have time to finish startup.