### PR TITLE
Add api/v1/status/ endpoints and api/v1/sso/callback endpoint to REST API docs

### DIFF
--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -1948,6 +1948,7 @@ Deletes the session specified by ID. When the user associated with the session n
 - [Get query spec](#get-query-spec)
 - [Apply queries specs](#apply-queries-specs)
 - [Check live query status](#check-live-query-status)
+- [Check result store status](#check-result-store-status)
 - [Run live query](#run-live-query)
 - [Run live query by name](#run-live-query-by-name)
 - [Retrieve live query results (standard WebSocket API)](#retrieve-live-query-results-standard-websocket-api)

--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -63,6 +63,7 @@ All of these objects are put together and distributed to the appropriate osquery
 - [Me](#me)
 - [SSO config](#sso-config)
 - [Initiate SSO](#initiate-sso)
+- [SSO callback](#sso-callback)
 
 All API requests to the Fleet server require API token authentication unless noted in the documentation.
 
@@ -419,6 +420,54 @@ Gets the current SSO configuration.
 ##### Default response
 
 `Status: 200`
+
+##### Unknown error
+
+`Status: 500`
+
+```
+{
+  "message": "Unknown Error",
+  "errors": [
+    {
+      "name": "base",
+      "reason": "InitiateSSO getting metadata: Get \"https://idp.example.org/idp-meta.xml\": dial tcp: lookup idp.example.org on [2001:558:feed::1]:53: no such host"
+    }
+  ]
+}
+```
+
+### SSO callback
+
+This is the callback endpoint that the identity provider will use to send security assertions to Fleet. This is where Fleet receives and processes the response from the identify provider.
+
+`POST /api/v1/fleet/sso/callback`
+
+#### Parameters
+
+| Name      | Type   | In   | Description                                                                |
+| --------- | ------ | ---- | -------------------------------------------------------------------------- |
+| SAMLResponse | string | body | **Required**. The SAML response from the identity provider. |
+
+#### Example
+
+`POST /api/v1/fleet/sso/callback`
+
+##### Request body
+
+```
+{
+  "SAMLResponse": "<SAML response from IdP>"
+}
+```
+
+##### Default response
+
+`Status: 200`
+
+```
+{}
+```
 
 ##### Unknown error
 
@@ -1914,7 +1963,7 @@ Deletes the session specified by ID. When the user associated with the session n
 - [Get queries specs](#get-queries-specs)
 - [Get query spec](#get-query-spec)
 - [Apply queries specs](#apply-queries-specs)
-- [Check live query status](#run-live-query)
+- [Check live query status](#check-live-query-status)
 - [Run live query](#run-live-query)
 - [Run live query by name](#run-live-query-by-name)
 - [Retrieve live query results (standard WebSocket API)](#retrieve-live-query-results-standard-websocket-api)
@@ -2370,7 +2419,7 @@ Creates and/or modifies the queries included in the specs list. To modify an exi
 
 ### Check live query status
 
-Checks the status of the system's ability to run a live query. If an error is present in the response, the system won't be able to successfully run a live query. This endpoint is used by the Fleet UI to make sure that the Fleet instance is correctly configured to run live queries.
+Checks the status of the Fleet's ability to run a live query. If an error is present in the response, Fleet won't be able to successfully run a live query. This endpoint is used by the Fleet UI to make sure that the Fleet instance is correctly configured to run live queries.
 
 `GET /api/v1/fleet/status/live_query`
 
@@ -2381,6 +2430,28 @@ None.
 #### Example
 
 `GET /api/v1/fleet/status/live_query`
+
+##### Default response
+
+`Status: 200`
+
+```
+{}
+```
+
+### Check result store status
+
+Checks the status of the Fleet's result store. If an error is present in the response, Fleet won't be able to successfully run a live query. This endpoint is used by the Fleet UI to make sure that the Fleet instance is correctly configured to run live queries.
+
+`GET /api/v1/fleet/status/result_store`
+
+#### Parameters
+
+None.
+
+#### Example
+
+`GET /api/v1/fleet/status/result_store`
 
 ##### Default response
 

--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -1914,6 +1914,7 @@ Deletes the session specified by ID. When the user associated with the session n
 - [Get queries specs](#get-queries-specs)
 - [Get query spec](#get-query-spec)
 - [Apply queries specs](#apply-queries-specs)
+- [Check live query status](#run-live-query)
 - [Run live query](#run-live-query)
 - [Run live query by name](#run-live-query-by-name)
 - [Retrieve live query results (standard WebSocket API)](#retrieve-live-query-results-standard-websocket-api)
@@ -2358,6 +2359,28 @@ Creates and/or modifies the queries included in the specs list. To modify an exi
   ]
 }
 ```
+
+##### Default response
+
+`Status: 200`
+
+```
+{}
+```
+
+### Check live query status
+
+Checks the status of the system's ability to run a live query. If an error is present in the response, the system won't be able to successfully run a live query. This endpoint is used by the Fleet UI to make sure that the Fleet instance is correctly configured to run live queries.
+
+`GET /api/v1/fleet/status/live_query`
+
+#### Parameters
+
+None.
+
+#### Example
+
+`GET /api/v1/fleet/status/live_query`
 
 ##### Default response
 

--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -469,22 +469,6 @@ This is the callback endpoint that the identity provider will use to send securi
 {}
 ```
 
-##### Unknown error
-
-`Status: 500`
-
-```
-{
-  "message": "Unknown Error",
-  "errors": [
-    {
-      "name": "base",
-      "reason": "InitiateSSO getting metadata: Get \"https://idp.example.org/idp-meta.xml\": dial tcp: lookup idp.example.org on [2001:558:feed::1]:53: no such host"
-    }
-  ]
-}
-```
-
 ---
 
 ## Hosts


### PR DESCRIPTION
This PR concludes the Complete API documentation project #43 

Add documentation for the following endpoints: 
- `api/v1/status/live_query`
- `api/v1/status/result_store`
- `api/v1/sso/callback`

Closes #43 