### PR TITLE
Update flags for development cAdvisor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,7 @@ services:
     ports:
       - "5678:8080"
     volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:rw
+      - /var/run/docker.sock:/var/run/docker.sock:ro
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
 


### PR DESCRIPTION
Updates to a minimal set of permissions for working CAdvisor.

Tested with Docker Desktop 3.3.1 on macOS 11.2.3