### PR TITLE
Improved handling for long values in software inventory

### DIFF
--- a/server/datastore/mysql/migrations/tables/20210421112652_AddSoftwareInventory.go
+++ b/server/datastore/mysql/migrations/tables/20210421112652_AddSoftwareInventory.go
@@ -16,7 +16,7 @@ func Up_20210421112652(tx *sql.Tx) error {
 		CREATE TABLE IF NOT EXISTS software (
 		id bigint unsigned PRIMARY KEY AUTO_INCREMENT,
 		name varchar(255) NOT NULL,
-		version varchar(64) NOT NULL DEFAULT '',
+		version varchar(255) NOT NULL DEFAULT '',
 		source varchar(64) NOT NULL,
         UNIQUE KEY idx_name_version (name, version, source)
 	)`); err != nil {

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -9,6 +9,19 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	maxSoftwareNameLen    = 255
+	maxSoftwareVersionLen = 255
+	maxSoftwareSourceLen  = 64
+)
+
+func truncateString(str string, length int) string {
+	if len(str) > length {
+		return str[:length]
+	}
+	return str
+}
+
 func (d *Datastore) SaveHostSoftware(host *kolide.Host) error {
 	if !host.HostSoftware.Modified {
 		return nil
@@ -28,6 +41,9 @@ func (d *Datastore) SaveHostSoftware(host *kolide.Host) error {
 		// Bulk insert software entries
 		var args []interface{}
 		for _, s := range host.HostSoftware.Software {
+			s.Name = truncateString(s.Name, maxSoftwareNameLen)
+			s.Version = truncateString(s.Version, maxSoftwareVersionLen)
+			s.Source = truncateString(s.Source, maxSoftwareSourceLen)
 			args = append(args, s.Name, s.Version, s.Source)
 		}
 		values := strings.TrimSuffix(strings.Repeat("(?,?,?),", len(host.HostSoftware.Software)), ",")


### PR DESCRIPTION
- Increase version length to 255.
- Truncate any values too large.

Fixes #681