### PR TITLE
Prevent modify user to include global and team roles

### DIFF
--- a/cypress/integration/app/teamflow.spec.ts
+++ b/cypress/integration/app/teamflow.spec.ts
@@ -17,6 +17,7 @@ describe("Teams flow", () => {
     cy.findByRole("button", { name: /^create$/i }).click();
 
     cy.visit("/settings/teams");
+    cy.wait(100);
 
     cy.contains("Valor").get(".Select-arrow-zone").click();
 
@@ -30,6 +31,7 @@ describe("Teams flow", () => {
     cy.findByRole("button", { name: /save/i }).click();
 
     cy.visit("/settings/teams");
+    cy.wait(100);
 
     cy.contains("Mystic").get(".Select-arrow-zone").click();
 

--- a/server/kolide/users.go
+++ b/server/kolide/users.go
@@ -135,7 +135,7 @@ type UserPayload struct {
 	InviteToken              *string     `json:"invite_token,omitempty"`
 	SSOInvite                *bool       `json:"sso_invite,omitempty"`
 	SSOEnabled               *bool       `json:"sso_enabled,omitempty"`
-	GlobalRole               null.String `json:"global_role,omitempty"`
+	GlobalRole               *string     `json:"global_role,omitempty"`
 	AdminForcedPasswordReset *bool       `json:"admin_forced_password_reset,omitempty"`
 	Teams                    *[]UserTeam `json:"teams,omitempty"`
 }
@@ -143,10 +143,9 @@ type UserPayload struct {
 // User creates a user from payload.
 func (p UserPayload) User(keySize, cost int) (*User, error) {
 	user := &User{
-		Username:   *p.Username,
-		Email:      *p.Email,
-		Teams:      []UserTeam{},
-		GlobalRole: p.GlobalRole,
+		Username: *p.Username,
+		Email:    *p.Email,
+		Teams:    []UserTeam{},
 	}
 	if err := user.SetPassword(*p.Password, keySize, cost); err != nil {
 		return nil, err
@@ -170,6 +169,9 @@ func (p UserPayload) User(keySize, cost int) (*User, error) {
 	}
 	if p.Teams != nil {
 		user.Teams = *p.Teams
+	}
+	if p.GlobalRole != nil {
+		user.GlobalRole = null.StringFrom(*p.GlobalRole)
 	}
 
 	return user, nil

--- a/server/service/endpoint_setup.go
+++ b/server/service/endpoint_setup.go
@@ -6,7 +6,6 @@ import (
 	"github.com/fleetdm/fleet/server/kolide"
 	"github.com/go-kit/kit/endpoint"
 	"github.com/pkg/errors"
-	"gopkg.in/guregu/null.v3"
 )
 
 type setupRequest struct {
@@ -59,7 +58,7 @@ func makeSetupEndpoint(svc kolide.Service) endpoint.Endpoint {
 				return setupResponse{Err: err}, nil
 			}
 			// Make the user an admin
-			req.Admin.GlobalRole = null.StringFrom("admin")
+			*req.Admin.GlobalRole = "admin"
 			admin, err = svc.CreateUser(ctx, *req.Admin)
 			if err != nil {
 				return setupResponse{Err: err}, nil


### PR DESCRIPTION
A user should have a global role or roles on some teams, but not both.
This ensures that is set properly and does validation.