### PR TITLE
Added osquery link to testimonial

### DIFF
--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -52,7 +52,7 @@
       <div style="max-width: 800px; text-align: center;" class="position-relative mx-auto">
         <p>"Fleet is hands down the best osquery platform out there. Zach and I created Fleet as a natural extension to our original vision for osquery and this has manifested in the ease-of-use, flexibility, and adoption it has today. Look to Fleet for the future of open-source endpoint monitoring."</p>
         <p style="color: #676A7A" class="mb-4">- Mike Arpaia, Co-creator of <a style="color:#676A7A;" target="_blank" href="https://osquery.io/">osquery</a></p>
-        <a style="display:inline-block;" target="_blank" href="https://osquery.io/"><img alt="osquery logo" src="/images/logo-osquery-89x24@2x.png" style="height: 40px; width: 137px;" class="mb-3 mx-auto"/></a>
+        <a target="_blank" href="https://osquery.io/"><img alt="osquery logo" src="/images/logo-osquery-89x24@2x.png" style="height: 40px; width: 137px;" class="d-inline-block mb-3 mx-auto"/></a>
       </div>
     </div>
   </div>

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -51,8 +51,8 @@
     <div style="max-width: 800px" class="pb-5 mx-auto">
       <div style="max-width: 800px; text-align: center;" class="position-relative mx-auto">
         <p>"Fleet is hands down the best osquery platform out there. Zach and I created Fleet as a natural extension to our original vision for osquery and this has manifested in the ease-of-use, flexibility, and adoption it has today. Look to Fleet for the future of open-source endpoint monitoring."</p>
-        <p style="color: #676A7A" class="mb-4">- Mike Arpaia, Co-creator of osquery</p>
-        <img alt="osquery logo" src="/images/logo-osquery-89x24@2x.png" style="height: 40px; width: 137px;" class="mb-3 mx-auto"/>
+        <p style="color: #676A7A" class="mb-4">- Mike Arpaia, Co-creator of <a style="color:#676A7A;" target="_blank" href="https://osquery.io/">osquery</a></p>
+        <a style="display:inline-block;" target="_blank" href="https://osquery.io/"><img alt="osquery logo" src="/images/logo-osquery-89x24@2x.png" style="height: 40px; width: 137px;" class="mb-3 mx-auto"/></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Added osquery to testimonial links as per Growth doc request

> Make clicking osquery go to osquery.io in a new tab
> at least logo
> maybe also the word "osquery" if there's an appropriate look, not a big deal
> that means cursor:pointer on hover

My inline css properties feel messy. Please review, and I'll move to somewhere more appropriate if you think it's better.

@mikermcneil not sure what you meant by `cursor:pointer on hover`? It seemed to already do that by default.

Thanks.