### PR TITLE
Add relative markdown links to teams branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Improve Fleet performance by batch updating host seen time instead of updating synchronously. This improvement reduces MySQL CPU usage by ~33% with 4,000 simulated hosts and MySQL running in Docker.
 
-* Add support for software inventory, introducing a list of installed software items on each host's respective _Host details_ page. This feature is flagged off by default (for now). Check out [the feature flag documentation for instructions on how to turn this feature on](https://github.com/fleetdm/fleet/blob/master/docs/2-Deployment/2-Configuration.md#software-inventory).
+* Add support for software inventory, introducing a list of installed software items on each host's respective _Host details_ page. This feature is flagged off by default (for now). Check out [the feature flag documentation for instructions on how to turn this feature on](./docs/2-Deployment/2-Configuration.md#software-inventory).
 
 * Add Windows support for `fleetctl` agent autoupdates. The `fleetctl updates` command provides the ability to self-manage an agent update server. Available for Fleet Basic customers.
 

--- a/docs/1-Using-Fleet/2-fleetctl-CLI.md
+++ b/docs/1-Using-Fleet/2-fleetctl-CLI.md
@@ -577,7 +577,7 @@ spec:
 
 Fleet supports osquery's file carving functionality as of Fleet 3.3.0. This allows the Fleet server to request files (and sets of files) from osquery agents, returning the full contents to Fleet.
 
-File carving data can be either stored in Fleet's database or to an external S3 bucket. For information on how to configure the latter, consult the [configuration docs](https://github.com/fleetdm/fleet/blob/master/docs/2-Deployment/2-Configuration.md#s3-file-carving-backend).
+File carving data can be either stored in Fleet's database or to an external S3 bucket. For information on how to configure the latter, consult the [configuration docs](../2-Deployment/2-Configuration.md#s3-file-carving-backend).
 
 ### Configuration
 

--- a/docs/1-Using-Fleet/FAQ.md
+++ b/docs/1-Using-Fleet/FAQ.md
@@ -16,7 +16,7 @@ It’s standard deployment practice to have multiple Fleet servers behind a load
 
 ## How often do labels refresh? Is the refresh frequency configurable?
 
-The update frequency for labels is configurable with the [—osquery_label_update_interval](https://github.com/fleetdm/fleet/blob/master/docs/2-Deployment/2-Configuration.md#osquery_label_update_interval) flag (default 1 hour).
+The update frequency for labels is configurable with the [—osquery_label_update_interval](../2-Deployment/2-Configuration.md#osquery_label_update_interval) flag (default 1 hour).
 
 ## How do I revoke the authorization tokens for a user?
 
@@ -53,7 +53,7 @@ It is possible to configure osqueryd to log query results outside of Fleet. For 
 
 Folks typically use Fleet to ship logs to data aggregation systems like Splunk, the ELK stack, and Graylog. 
 
-The [logger configuration options](https://github.com/fleetdm/fleet/blob/master/docs/2-Deployment/2-Configuration.md#osquery_status_log_plugin) allow you to select the log output plugin. Using the log outputs you can route the logs to your chosen aggregation system.
+The [logger configuration options](../2-Deployment/2-Configuration.md#osquery_status_log_plugin) allow you to select the log output plugin. Using the log outputs you can route the logs to your chosen aggregation system.
 
 ### Troubleshooting
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -5,7 +5,7 @@ The Fleet front-end is a Single Page Application using React and Redux.
 ## Running the Fleet web app
 
 For details instruction on building and serving the Fleet web application
-consult the [Development Documentation](https://github.com/fleetdm/fleet/tree/master/docs/2-Deployment)
+consult the [Contribution documentation](../docs/3-Contribution/README.md)
 
 ## Directory Structure
 


### PR DESCRIPTION
My changes to the documentation file structure made in #717 resolved all broken documentation links on the `master` branch but not on the `teams` branch. As a result, those developing on the `teams` branch always get a ❌  for the "Markdown link check" test.

- Add relative markdown links in the `teams` branch to resolve failed link test

Important note: 
The next time we merge `master` into `teams` it will be important to accept all of the documentation changes coming from the `master` branch. This is because the documentation file structure on `master` is the up-to-date version of the docs.