### PR TITLE
Add flag to disable HTTP keepalives

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -368,7 +368,7 @@ the way that the Fleet server works.
 				IdleTimeout:       5 * time.Minute,
 				MaxHeaderBytes:    1 << 18, // 0.25 MB (262144 bytes)
 			}
-			srv.SetKeepAlivesEnabled(config.Server.KeepAlive)
+			srv.SetKeepAlivesEnabled(config.Server.Keepalive)
 			errs := make(chan error, 2)
 			go func() {
 				if !config.Server.TLS {

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -368,6 +368,7 @@ the way that the Fleet server works.
 				IdleTimeout:       5 * time.Minute,
 				MaxHeaderBytes:    1 << 18, // 0.25 MB (262144 bytes)
 			}
+			srv.SetKeepAlivesEnabled(config.Server.KeepAlive)
 			errs := make(chan error, 2)
 			go func() {
 				if !config.Server.TLS {

--- a/docs/3-Deployment/2-Configuration.md
+++ b/docs/3-Deployment/2-Configuration.md
@@ -420,6 +420,19 @@ Note that some other configurations may need to be changed when modifying the UR
   	url_prefix: /apps/fleet
   ```
 
+###### `server_keepalive`
+
+Controls the server side http keep alive property. 
+
+- Default value: True
+- Environment variable: `FLEET_SERVER_KEEPALIVE`
+- Config file format:
+
+  ```
+  server:
+  	keepalive: true
+  ```
+
 ##### Auth
 
 ###### `auth_jwt_key`

--- a/docs/3-Deployment/2-Configuration.md
+++ b/docs/3-Deployment/2-Configuration.md
@@ -424,7 +424,7 @@ Note that some other configurations may need to be changed when modifying the UR
 
 Controls the server side http keep alive property. 
 
-- Default value: True
+- Default value: true
 - Environment variable: `FLEET_SERVER_KEEPALIVE`
 - Config file format:
 

--- a/docs/3-Deployment/2-Configuration.md
+++ b/docs/3-Deployment/2-Configuration.md
@@ -422,7 +422,9 @@ Note that some other configurations may need to be changed when modifying the UR
 
 ###### `server_keepalive`
 
-Controls the server side http keep alive property. 
+Controls the server side http keep alive property.
+
+Turning off keepalives has helped reduce outstanding TCP connections in some deployments.
 
 - Default value: true
 - Environment variable: `FLEET_SERVER_KEEPALIVE`

--- a/docs/3-Deployment/FAQ.md
+++ b/docs/3-Deployment/FAQ.md
@@ -47,7 +47,7 @@ Osquery requires that all communication between the agent and Fleet are over a s
 
 This error usually indicates that the Fleet server has run out of file descriptors. Fix this by increasing the `ulimit` on the Fleet process. See the `LimitNOFILE` setting in the [example systemd unit file](./2-Configuration.md#runing-with-systemd) for an example of how to do this with systemd.
 
-Some deployments may benefit by setting the [`--server_keepalive`](./2-Configuration.md#server_keepalive) flag.
+Some deployments may benefit by setting the [`--server_keepalive`](./2-Configuration.md#server_keepalive) flag to false.
 
 ## I upgraded my database, but Fleet is still running slowly. What could be going on?
 

--- a/docs/3-Deployment/FAQ.md
+++ b/docs/3-Deployment/FAQ.md
@@ -47,6 +47,8 @@ Osquery requires that all communication between the agent and Fleet are over a s
 
 This error usually indicates that the Fleet server has run out of file descriptors. Fix this by increasing the `ulimit` on the Fleet process. See the `LimitNOFILE` setting in the [example systemd unit file](./2-Configuration.md#runing-with-systemd) for an example of how to do this with systemd.
 
+Some deployments may benefit by setting the [`--server_keepalive`](./2-Configuration.md#server_keepalive) flag.
+
 ## I upgraded my database, but Fleet is still running slowly. What could be going on?
 
 This could be caused by a mismatched connection limit between the Fleet server and the MySQL server that prevents Fleet from fully utilizing the database. First [determine how many open connections your MySQL server supports](https://dev.mysql.com/doc/refman/8.0/en/too-many-connections.html). Now set the [`--mysql_max_open_conns`](./2-Configuration.md#mysql_max_open_conns) and [`--mysql_max_idle_conns`](./2-Configuration.md#mysql_max_idle_conns) flags appropriately.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -55,7 +55,7 @@ type ServerConfig struct {
 	TLS        bool
 	TLSProfile string // TODO #271 set `yaml:"tls_compatibility"`
 	URLPrefix  string `yaml:"url_prefix"`
-	KeepAlive  bool   `yaml:"keepalive"`
+	Keepalive  bool   `yaml:"keepalive"`
 }
 
 // AuthConfig defines configs related to user authorization
@@ -398,7 +398,7 @@ func (man Manager) LoadConfig() KolideConfig {
 			TLS:        man.getConfigBool("server.tls"),
 			TLSProfile: man.getConfigTLSProfile(),
 			URLPrefix:  man.getConfigString("server.url_prefix"),
-			KeepAlive:  man.getConfigBool("server.keepalive"),
+			Keepalive:  man.getConfigBool("server.keepalive"),
 		},
 		Auth: AuthConfig{
 			JwtKey:      man.getConfigString("auth.jwt_key"),

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -228,7 +228,7 @@ func (man Manager) addConfigs() {
 	man.addConfigString("server.url_prefix", "",
 		"URL prefix used on server and frontend endpoints")
 	man.addConfigBool("server.keepalive", true,
-		"Controls wether HTTP keep-alives are enabled."
+		"Controls wether HTTP keep-alives are enabled.")
 
 	// Auth
 	man.addConfigString("auth.jwt_key", "",

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -55,6 +55,7 @@ type ServerConfig struct {
 	TLS        bool
 	TLSProfile string // TODO #271 set `yaml:"tls_compatibility"`
 	URLPrefix  string `yaml:"url_prefix"`
+	KeepAlive  bool   `yaml:"keepalive"`
 }
 
 // AuthConfig defines configs related to user authorization
@@ -226,6 +227,8 @@ func (man Manager) addConfigs() {
 			TLSProfileModern, TLSProfileIntermediate))
 	man.addConfigString("server.url_prefix", "",
 		"URL prefix used on server and frontend endpoints")
+	man.addConfigBool("server.keepalive", true,
+		"Controls wether HTTP keep-alives are enabled."
 
 	// Auth
 	man.addConfigString("auth.jwt_key", "",
@@ -395,6 +398,7 @@ func (man Manager) LoadConfig() KolideConfig {
 			TLS:        man.getConfigBool("server.tls"),
 			TLSProfile: man.getConfigTLSProfile(),
 			URLPrefix:  man.getConfigString("server.url_prefix"),
+			KeepAlive:  man.getConfigBool("server.keepalive"),
 		},
 		Auth: AuthConfig{
 			JwtKey:      man.getConfigString("auth.jwt_key"),


### PR DESCRIPTION
In my environment, it appears that my reverse proxy keeps an http-session open, but does not re-use the existing session.  This setting is to force the connection to close between the reverse proxy and fleetdm.  However, the connection between osquery and the reverse proxy are unchanged.