### PR TITLE
Host Details Page: Convert seconds to larger units, clean repetitive edge case code

### DIFF
--- a/frontend/kolide/helpers.ts
+++ b/frontend/kolide/helpers.ts
@@ -311,6 +311,16 @@ export const humanQueryLastRun = (lastRun: string): string => {
   return moment(lastRun).fromNow();
 };
 
+export const secondsToHms = (d: number): string => {
+  const h = Math.floor(d / 3600);
+  const m = Math.floor((d % 3600) / 60);
+  const s = Math.floor((d % 3600) % 60);
+
+  const hDisplay = h > 0 ? h + (h === 1 ? " hr " : " hrs ") : "";
+  const mDisplay = m > 0 ? m + (m === 1 ? " min " : " mins ") : "";
+  const sDisplay = s > 0 ? s + (s === 1 ? " sec " : " secs ") : "";
+  return hDisplay + mDisplay + sDisplay;
+};
 export default {
   addGravatarUrlToResource,
   formatConfigDataForServer,
@@ -324,6 +334,7 @@ export default {
   humanHostMemory,
   humanHostDetailUpdated,
   humanQueryLastRun,
+  secondsToHms,
   labelSlug,
   setupData,
 };

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -244,52 +244,55 @@ export class HostDetailsPage extends Component {
 
   renderPacks = () => {
     const { host } = this.props;
-    const { packs = [], pack_stats = [] } = host;
+    const { pack_stats } = host;
     const wrapperClassName = `${baseClass}__table`;
 
-    const packsAccordion = pack_stats.map((pack) => {
-      return (
-        <AccordionItem key={pack.pack_id}>
-          <AccordionItemHeading>
-            <AccordionItemButton>{pack.pack_name}</AccordionItemButton>
-          </AccordionItemHeading>
-          <AccordionItemPanel>
-            {pack.query_stats.length === 0 ? (
-              <div>There are no schedule queries for this pack.</div>
-            ) : (
-              <div className={`${baseClass}__wrapper`}>
-                <table className={wrapperClassName}>
-                  <thead>
-                    <tr>
-                      <th>Query Name</th>
-                      <th>Description</th>
-                      <th>Frequency</th>
-                      <th>Last Run</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {!!pack.query_stats.length &&
-                      pack.query_stats.map((query) => {
-                        return (
-                          <PackQueriesListRow
-                            key={`pack-row-${query.pack_id}-${query.scheduled_query_id}`}
-                            query={query}
-                          />
-                        );
-                      })}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </AccordionItemPanel>
-        </AccordionItem>
-      );
-    });
+    let packsAccordion;
+    if (pack_stats) {
+      packsAccordion = pack_stats.map((pack) => {
+        return (
+          <AccordionItem key={pack.pack_id}>
+            <AccordionItemHeading>
+              <AccordionItemButton>{pack.pack_name}</AccordionItemButton>
+            </AccordionItemHeading>
+            <AccordionItemPanel>
+              {pack.query_stats.length === 0 ? (
+                <div>There are no schedule queries for this pack.</div>
+              ) : (
+                <div className={`${baseClass}__wrapper`}>
+                  <table className={wrapperClassName}>
+                    <thead>
+                      <tr>
+                        <th>Query Name</th>
+                        <th>Description</th>
+                        <th>Frequency</th>
+                        <th>Last Run</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {!!pack.query_stats.length &&
+                        pack.query_stats.map((query) => {
+                          return (
+                            <PackQueriesListRow
+                              key={`pack-row-${query.pack_id}-${query.scheduled_query_id}`}
+                              query={query}
+                            />
+                          );
+                        })}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </AccordionItemPanel>
+          </AccordionItem>
+        );
+      });
+    }
 
     return (
       <div className="section section--packs">
         <p className="section__header">Packs</p>
-        {pack_stats.length === 0 ? (
+        {!pack_stats ? (
           <p className="info__item">
             No packs with scheduled queries have this host as a target.
           </p>

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -34,6 +34,7 @@ import {
   humanHostEnrolled,
   humanHostMemory,
   humanHostDetailUpdated,
+  secondsToHms,
 } from "kolide/helpers";
 import helpers from "./helpers";
 import SelectQueryModal from "./SelectQueryModal";
@@ -246,10 +247,6 @@ export class HostDetailsPage extends Component {
     const { packs = [], pack_stats = [] } = host;
     const wrapperClassName = `${baseClass}__table`;
 
-    if (pack_stats === null || pack_stats.length === 0) {
-      return <p>There are no packs for this host.</p>;
-    }
-
     const packsAccordion = pack_stats.map((pack) => {
       return (
         <AccordionItem key={pack.pack_id}>
@@ -288,7 +285,7 @@ export class HostDetailsPage extends Component {
         </AccordionItem>
       );
     });
-
+    console.log("packs:", packs);
     return (
       <div className="section section--packs">
         <p className="section__header">Packs</p>
@@ -303,7 +300,6 @@ export class HostDetailsPage extends Component {
     );
   };
 
-  //          <ul className="list">{packItems}</ul>
   renderSoftware = () => {
     const { host } = this.props;
     const wrapperClassName = `${baseClass}__table`;
@@ -311,7 +307,7 @@ export class HostDetailsPage extends Component {
     return (
       <div className="section section--software">
         <p className="section__header">Software</p>
-        {host.software.length === 0 ? (
+        {!host.software ? (
           <div className="results">
             <p className="results__header">
               No installed software detected on this host.
@@ -385,17 +381,6 @@ export class HostDetailsPage extends Component {
     const data = [titleData, aboutData, osqueryData];
     data.forEach((object) => {
       Object.keys(object).forEach((key) => {
-        const secondsToHms = (d) => {
-          const h = Math.floor(d / 3600);
-          const m = Math.floor((d % 3600) / 60);
-          const s = Math.floor((d % 3600) % 60);
-
-          const hDisplay = h > 0 ? h + (h === 1 ? " hr " : " hrs ") : "";
-          const mDisplay = m > 0 ? m + (m === 1 ? " min " : " mins ") : "";
-          const sDisplay = s > 0 ? s + (s === 1 ? " sec " : " secs ") : "";
-          return hDisplay + mDisplay + sDisplay;
-        };
-
         if (object[key] === "") {
           object[key] = "--";
         } else if (
@@ -513,7 +498,7 @@ export class HostDetailsPage extends Component {
         </div>
         {renderLabels()}
         {renderPacks()}
-        {host.software && renderSoftware()}
+        {renderSoftware()}
         {renderDeleteHostModal()}
         {showQueryHostModal && (
           <SelectQueryModal

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -289,8 +289,10 @@ export class HostDetailsPage extends Component {
     return (
       <div className="section section--packs">
         <p className="section__header">Packs</p>
-        {packs.length === 0 ? (
-          <p className="info__item">No packs have this host as a target.</p>
+        {pack_stats.length === 0 ? (
+          <p className="info__item">
+            No packs with scheduled queries have this host as a target.
+          </p>
         ) : (
           <Accordion allowMultipleExpanded="true" allowZeroExpanded="true">
             {packsAccordion}

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -254,7 +254,7 @@ export class HostDetailsPage extends Component {
             <AccordionItemButton>{pack.pack_name}</AccordionItemButton>
           </AccordionItemHeading>
           <AccordionItemPanel>
-            {!pack.query_stats.length ? (
+            {pack.query_stats.length === 0 ? (
               <div>There are no schedule queries for this pack.</div>
             ) : (
               <div className={`${baseClass}__wrapper`}>
@@ -285,7 +285,7 @@ export class HostDetailsPage extends Component {
         </AccordionItem>
       );
     });
-    console.log("packs:", packs);
+
     return (
       <div className="section section--packs">
         <p className="section__header">Packs</p>

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -385,6 +385,17 @@ export class HostDetailsPage extends Component {
     const data = [titleData, aboutData, osqueryData];
     data.forEach((object) => {
       Object.keys(object).forEach((key) => {
+        const secondsToHms = (d) => {
+          const h = Math.floor(d / 3600);
+          const m = Math.floor((d % 3600) / 60);
+          const s = Math.floor((d % 3600) % 60);
+
+          const hDisplay = h > 0 ? h + (h === 1 ? " hr " : " hrs ") : "";
+          const mDisplay = m > 0 ? m + (m === 1 ? " min " : " mins ") : "";
+          const sDisplay = s > 0 ? s + (s === 1 ? " sec " : " secs ") : "";
+          return hDisplay + mDisplay + sDisplay;
+        };
+
         if (object[key] === "") {
           object[key] = "--";
         } else if (
@@ -392,7 +403,7 @@ export class HostDetailsPage extends Component {
           key === "config_tls_refresh" ||
           key === "distributed_interval"
         ) {
-          object[key] = `${object[key]} sec`;
+          object[key] = secondsToHms(object[key]);
         }
       });
     });

--- a/frontend/pages/hosts/HostDetailsPage/PackQueriesListRow/PackQueriesListRow.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/PackQueriesListRow/PackQueriesListRow.jsx
@@ -19,11 +19,24 @@ class PackQueriesListRow extends Component {
       last_executed,
     } = query;
 
+    const secondsToHms = (d) => {
+      const h = Math.floor(d / 3600);
+      const m = Math.floor((d % 3600) / 60);
+      const s = Math.floor((d % 3600) % 60);
+
+      const hDisplay = h > 0 ? h + (h === 1 ? " hr " : " hrs ") : "";
+      const mDisplay = m > 0 ? m + (m === 1 ? " min " : " mins ") : "";
+      const sDisplay = s > 0 ? s + (s === 1 ? " sec " : " secs ") : "";
+      return hDisplay + mDisplay + sDisplay;
+    };
+
+    const frequency = secondsToHms(interval);
+
     return (
       <tr>
         <td className={`${baseClass}__name`}>{scheduled_query_name}</td>
         <td className={`${baseClass}__description`}>{description}</td>
-        <td className={`${baseClass}__frequency`}>{interval} seconds</td>
+        <td className={`${baseClass}__frequency`}>{frequency}</td>
         <td className={`${baseClass}__last-run`}>
           {humanQueryLastRun(last_executed)}
         </td>

--- a/frontend/pages/hosts/HostDetailsPage/PackQueriesListRow/PackQueriesListRow.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/PackQueriesListRow/PackQueriesListRow.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { humanQueryLastRun } from "kolide/helpers";
+import { humanQueryLastRun, secondsToHms } from "kolide/helpers";
 
 import queryInterface from "interfaces/query";
 
@@ -18,17 +18,6 @@ class PackQueriesListRow extends Component {
       interval,
       last_executed,
     } = query;
-
-    const secondsToHms = (d) => {
-      const h = Math.floor(d / 3600);
-      const m = Math.floor((d % 3600) / 60);
-      const s = Math.floor((d % 3600) % 60);
-
-      const hDisplay = h > 0 ? h + (h === 1 ? " hr " : " hrs ") : "";
-      const mDisplay = m > 0 ? m + (m === 1 ? " min " : " mins ") : "";
-      const sDisplay = s > 0 ? s + (s === 1 ? " sec " : " secs ") : "";
-      return hDisplay + mDisplay + sDisplay;
-    };
 
     const frequency = secondsToHms(interval);
 


### PR DESCRIPTION
Spruced up host details page with frequency conversion from seconds to hours, minutes, and seconds ⌚ 

![Screen Shot 2021-05-10 at 5 55 18 PM](https://user-images.githubusercontent.com/71795832/117729559-ffe18280-b1b8-11eb-92bd-dc1a316eae08.png)
