### PR TITLE
Replace README logo with one from orbit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1><img width="200" alt="Fleet logo, landscape, dark text, transparent background" src="https://user-images.githubusercontent.com/78363703/112149147-06746480-8c22-11eb-8893-031ffa99539b.png"></h1>
+<h1><img width="200" alt="Fleet logo, landscape, dark text, transparent background" src="https://user-images.githubusercontent.com/618009/103300491-9197e280-49c4-11eb-8677-6b41027be800.png"></h1>
 
 #### [Website](https://fleetdm.com/)  &nbsp;  [News](http://twitter.com/fleetctl) &nbsp; [Report a bug](https://github.com/fleetdm/fleet/issues/new)
 


### PR DESCRIPTION
The current image has an opaque background which looks off when using the dark Github theme.