### PR TITLE
Feature/live query duplicate

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -216,7 +216,7 @@ the way that the Fleet server works.
 			}
 
 			redisPool := pubsub.NewRedisPool(config.Redis.Address, config.Redis.Password, config.Redis.Database, config.Redis.UseTLS)
-			resultStore := pubsub.NewRedisQueryResults(redisPool)
+			resultStore := pubsub.NewRedisQueryResults(redisPool, config.Redis.DuplicateResults)
 			liveQueryStore := live_query.NewRedisLiveQuery(redisPool)
 			ssoSessionStore := sso.NewSessionStore(redisPool)
 

--- a/docs/3-Deployment/2-Configuration.md
+++ b/docs/3-Deployment/2-Configuration.md
@@ -333,6 +333,19 @@ The database to use when connecting to the Redis instance.
   redis:
     database: 14
   ```
+  
+###### `redis_duplicate_results`
+
+Whether or not to duplicate Live Query results to another Redis channel named `LQDuplicate`. This is useful in a scenario that would involve shipping the Live Query results outside of Fleet, near-realtime.
+
+- Default value: `false`
+- Environment variable: `FLEET_REDIS_DUPLICATE_RESULTS`
+- Config file format:
+
+  ```
+  redis:
+    duplicate_results: true
+  ```
 
 ##### Server
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -35,10 +35,11 @@ type MysqlConfig struct {
 
 // RedisConfig defines configs related to Redis
 type RedisConfig struct {
-	Address  string
-	Password string
-	Database int
-	UseTLS   bool `yaml:"use_tls"`
+	Address          string
+	Password         string
+	Database         int
+	UseTLS           bool `yaml:"use_tls"`
+	DuplicateResults bool `yaml:"duplicate_results"`
 }
 
 const (
@@ -213,6 +214,7 @@ func (man Manager) addConfigs() {
 	man.addConfigInt("redis.database", 0,
 		"Redis server database number")
 	man.addConfigBool("redis.use_tls", false, "Redis server enable TLS")
+	man.addConfigBool("redis.duplicate_results", false, "Duplicate Live Query results to another Redis channel")
 
 	// Server
 	man.addConfigString("server.address", "0.0.0.0:8080",
@@ -388,10 +390,11 @@ func (man Manager) LoadConfig() KolideConfig {
 			ConnMaxLifetime: man.getConfigInt("mysql.conn_max_lifetime"),
 		},
 		Redis: RedisConfig{
-			Address:  man.getConfigString("redis.address"),
-			Password: man.getConfigString("redis.password"),
-			Database: man.getConfigInt("redis.database"),
-			UseTLS:   man.getConfigBool("redis.use_tls"),
+			Address:          man.getConfigString("redis.address"),
+			Password:         man.getConfigString("redis.password"),
+			Database:         man.getConfigInt("redis.database"),
+			UseTLS:           man.getConfigBool("redis.use_tls"),
+			DuplicateResults: man.getConfigBool("redis.duplicate_results"),
 		},
 		Server: ServerConfig{
 			Address:    man.getConfigString("server.address"),

--- a/server/pubsub/query_results_test.go
+++ b/server/pubsub/query_results_test.go
@@ -61,13 +61,14 @@ func TestInmem(t *testing.T) {
 
 func setupRedis(t *testing.T) (store *redisQueryResults, teardown func()) {
 	var (
-		addr     = "127.0.0.1:6379"
-		password = ""
-		database = 0
-		useTLS   = false
+		addr       = "127.0.0.1:6379"
+		password   = ""
+		database   = 0
+		useTLS     = false
+		DupResults = false
 	)
 
-	store = NewRedisQueryResults(NewRedisPool(addr, password, database, useTLS))
+	store = NewRedisQueryResults(NewRedisPool(addr, password, database, useTLS), DupResults)
 
 	_, err := store.pool.Get().Do("PING")
 	require.Nil(t, err)

--- a/server/pubsub/query_results_test.go
+++ b/server/pubsub/query_results_test.go
@@ -65,10 +65,10 @@ func setupRedis(t *testing.T) (store *redisQueryResults, teardown func()) {
 		password   = ""
 		database   = 0
 		useTLS     = false
-		DupResults = false
+		dupResults = false
 	)
 
-	store = NewRedisQueryResults(NewRedisPool(addr, password, database, useTLS), DupResults)
+	store = NewRedisQueryResults(NewRedisPool(addr, password, database, useTLS), dupResults)
 
 	_, err := store.pool.Get().Do("PING")
 	require.Nil(t, err)

--- a/server/pubsub/redis_query_results.go
+++ b/server/pubsub/redis_query_results.go
@@ -6,14 +6,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
 	"github.com/fleetdm/fleet/server/kolide"
+	"github.com/gomodule/redigo/redis"
 	"github.com/pkg/errors"
 )
 
 type redisQueryResults struct {
 	// connection pool
-	pool *redis.Pool
+	pool             *redis.Pool
+	duplicateResults bool
 }
 
 var _ kolide.QueryResultStore = &redisQueryResults{}
@@ -49,8 +50,8 @@ func NewRedisPool(server, password string, database int, useTLS bool) *redis.Poo
 
 // NewRedisQueryResults creats a new Redis implementation of the
 // QueryResultStore interface using the provided Redis connection pool.
-func NewRedisQueryResults(pool *redis.Pool) *redisQueryResults {
-	return &redisQueryResults{pool: pool}
+func NewRedisQueryResults(pool *redis.Pool, duplicateResults bool) *redisQueryResults {
+	return &redisQueryResults{pool: pool, duplicateResults: duplicateResults}
 }
 
 func pubSubForID(id uint) string {
@@ -69,6 +70,11 @@ func (r *redisQueryResults) WriteResult(result kolide.DistributedQueryResult) er
 	}
 
 	n, err := redis.Int(conn.Do("PUBLISH", channelName, string(jsonVal)))
+
+	if n != 0 && r.duplicateResults {
+		redis.Int(conn.Do("PUBLISH", "LQDuplicate", string(jsonVal)))
+	}
+
 	if err != nil {
 		return errors.Wrap(err, "PUBLISH failed to channel "+channelName)
 	}


### PR DESCRIPTION
This feature enables a new config option (`redis.duplicate_results`). When set to `true`, all Live Query results will be copied to an additional Redis pubsub channel named `LQDuplicate`