### PR TITLE
Fix url-prefix links

### DIFF
--- a/frontend/components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection.jsx
+++ b/frontend/components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection.jsx
@@ -25,7 +25,7 @@ class ScheduledQueriesSection extends Component {
             return (
               <li key={`scheduled-query-${scheduledQuery.id}`}>
                 <Link
-                  to={PATHS.EDIT_QUERY(scheduledQuery)}
+                  to={PATHS.EDIT_QUERY({ id: scheduledQuery.query_id })}
                   className={`${baseClass}__query-name`}
                 >
                   {scheduledQuery.name}

--- a/frontend/components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection.jsx
+++ b/frontend/components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection.jsx
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router";
 
+import PATHS from "router/paths";
+
 import scheduledQueryInterface from "interfaces/scheduled_query";
 
 const baseClass = "pack-details-side-panel";
@@ -23,7 +25,7 @@ class ScheduledQueriesSection extends Component {
             return (
               <li key={`scheduled-query-${scheduledQuery.id}`}>
                 <Link
-                  to={`/queries/${scheduledQuery.query_id}`}
+                  to={PATHS.EDIT_QUERY(scheduledQuery)}
                   className={`${baseClass}__query-name`}
                 >
                   {scheduledQuery.name}

--- a/frontend/components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection.tests.jsx
+++ b/frontend/components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection.tests.jsx
@@ -12,7 +12,7 @@ describe("ScheduledQueriesSection - component", () => {
       <ScheduledQueriesSection scheduledQueries={[scheduledQuery]} />
     );
     const Link = Component.find("Link");
-    const path = `${PATHS.EDIT_QUERY(scheduledQuery)}`;
+    const path = `${PATHS.EDIT_QUERY({ id: scheduledQuery.query_id })}`;
 
     expect(Link.prop("to")).toEqual(path);
   });

--- a/frontend/components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection.tests.jsx
+++ b/frontend/components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection.tests.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { mount } from "enzyme";
+import PATHS from "router/paths";
 
 import ScheduledQueriesSection from "components/side_panels/PackDetailsSidePanel/ScheduledQueriesSection";
 import { scheduledQueryStub } from "test/stubs";
@@ -11,7 +12,8 @@ describe("ScheduledQueriesSection - component", () => {
       <ScheduledQueriesSection scheduledQueries={[scheduledQuery]} />
     );
     const Link = Component.find("Link");
+    const path = `${PATHS.EDIT_QUERY(scheduledQuery)}`;
 
-    expect(Link.prop("to")).toEqual(`/queries/${scheduledQuery.query_id}`);
+    expect(Link.prop("to")).toEqual(path);
   });
 });

--- a/frontend/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
+++ b/frontend/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
@@ -4,6 +4,8 @@ import { connect } from "react-redux";
 import { push } from "react-router-redux";
 import { noop } from "lodash";
 
+import PATHS from "router/paths";
+
 import {
   clearForgotPasswordErrors,
   forgotPasswordAction,
@@ -84,7 +86,7 @@ export class ForgotPasswordPage extends Component {
     return (
       <StackedWhiteBoxes
         leadText={leadText}
-        previousLocation="/login"
+        previousLocation={PATHS.LOGIN}
         className="forgot-password"
         onLeave={handleLeave}
       >

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -407,7 +407,7 @@ export class HostDetailsPage extends Component {
     return (
       <div className={`${baseClass} body-wrap`}>
         <div>
-          <Link to="/hosts/manage">
+          <Link to={PATHS.MANAGE_HOSTS}>
             <img src={BackChevron} alt="back chevron" id="back-chevron" />
             Back to Hosts
           </Link>


### PR DESCRIPTION
- Must always route links through `paths.ts` to account for `${URL_PREFIX}/`

Closes #734

Co-authored by: @gillespi314 