### PR TITLE
Standard Queries Initial First Contribution

### DIFF
--- a/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -333,10 +333,23 @@ spec:
 apiVersion: v1
 kind: query
 spec:
-  name: Detect dynamic linker hijacking (MITRE. T1574.006)
-  platforms: macOS, Linux
-  description: Detect any processes that run with an LD_PRELOAD or DYLD_INSERT_LIBRARIES environment variable
-  query: SELECT env.pid, env.key, env.value, p.name,p.path, p.cmdline, p.cwd FROM process_envs env join processes p USING (pid) WHERE key IN ('LD_PRELOAD', 'DYLD_INSERT_LIBRARIES') AND env.value != '/Applications/Firefox.app/Contents/MacOS/libplugin_child_interpose.dylib';
+  name: Detect dynamic linker hijacking on Linux (MITRE. T1574.006)
+  platforms: Linux
+  description: Detect any processes that run with LD_PRELOAD environment variable
+  query: SELECT env.pid, env.key, env.value, p.name,p.path, p.cmdline, p.cwd FROM process_envs env join processes p USING (pid) WHERE key='LD_PRELOAD';
+  purpose: Detection
+  remediation:
+    - Identify the process/binary detected
+    - Confirm with system owner
+  contributors: anelshaer
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Detect dynamic linker hijacking on macOS (MITRE. T1574.006)
+  platforms: macOS
+  description: Detect any processes that run with DYLD_INSERT_LIBRARIES environment variable
+  query: SELECT env.pid, env.key, env.value, p.name,p.path, p.cmdline, p.cwd FROM process_envs env join processes p USING (pid) WHERE key='DYLD_INSERT_LIBRARIES' AND env.value != '/Applications/Firefox.app/Contents/MacOS/libplugin_child_interpose.dylib';
   purpose: Detection
   remediation:
     - Identify the process/binary detected

--- a/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -48,6 +48,7 @@ spec:
   query: SELECT * FROM users CROSS JOIN authorized_keys USING (uid);
   purpose: Informational
   remediation: N/A
+  contributors: anelshaer
 ---
 apiVersion: v1
 kind: query
@@ -58,6 +59,7 @@ spec:
   query: SELECT *  FROM users CROSS JOIN  authorized_keys USING(uid) WHERE  username IN (SELECT distinct(username) FROM last);
   purpose: Informational
   remediation: N/A
+  contributors: anelshaer
 ---
 apiVersion: v1
 kind: query
@@ -228,6 +230,7 @@ spec:
   query: SELECT user,host,time, p.name, p.cmdline, p.cwd, p.root FROM logged_in_users liu, processes p WHERE liu.pid = p.pid and liu.type='user' and liu.user <> '' ORDER BY time;
   purpose: Informational
   remediation: N/A
+  contributors: anelshaer
 ---
 apiVersion: v1
 kind: query
@@ -278,6 +281,7 @@ spec:
   query: SELECT * FROM disk_encryption;
   purpose: Informational
   remediation: N/A
+  contributors: anelshaer
 ---
 apiVersion: v1
 kind: query
@@ -290,6 +294,7 @@ spec:
   remediation:
     - User awareness about the impact of SSH Keys
     - Rotate the identified Keys
+  contributors: anelshaer
 ---
 apiVersion: v1
 kind: query
@@ -302,6 +307,7 @@ spec:
   remediation:
     - User awareness about the impact of SSH Keys
     - Rotate the identified Keys
+  contributors: anelshaer
 ---
 apiVersion: v1
 kind: query
@@ -312,6 +318,7 @@ spec:
   query: SELECT * FROM crontab;
   purpose: Informational
   remediation: N/A
+  contributors: anelshaer
 ---
 apiVersion: v1
 kind: query
@@ -334,6 +341,7 @@ spec:
   remediation:
     - Identify the process/binary detected
     - Confirm with system owner
+  contributors: anelshaer
 ---
 apiVersion: v1
 kind: query
@@ -344,6 +352,7 @@ spec:
   query: SELECT * FROM etc_hosts WHERE address not in ('127.0.0.1', '::1');
   purpose: Informational
   remediation: N/A
+  contributors: anelshaer
 ---
 apiVersion: v1
 kind: query
@@ -354,6 +363,7 @@ spec:
   query: SELECT a.interface, a.address, d.mac FROM interface_addresses a JOIN interface_details d USING (interface) WHERE address not in ('127.0.0.1', '::1');
   purpose: Informational
   remediation: N/A
+  contributors: anelshaer
 ---
 apiVersion: v1
 kind: query
@@ -364,6 +374,7 @@ spec:
   query: SELECT uid, gid, username, description,directory, shell FROM users;
   purpose: Informational
   remediation: N/A
+  contributors: anelshaer
 ---
 apiVersion: v1
 kind: query
@@ -374,6 +385,7 @@ spec:
   query: SELECT * FROM shadow WHERE password_status='active' and username!='root';
   purpose: Detection
   remediation: N/A
+  contributors: anelshaer
 ---
 apiVersion: v1
 kind: query
@@ -387,6 +399,7 @@ spec:
     FROM processes as p WHERE cmdline like 'nmap%';
   purpose: Detection
   remediation: N/A
+  contributors: anelshaer
 ---
 apiVersion: v1
 kind: query
@@ -397,6 +410,7 @@ spec:
   query: SELECT * FROM docker_images;
   purpose: Informational
   remediation: N/A
+  contributors: anelshaer
 ---
 apiVersion: v1
 kind: query
@@ -407,6 +421,7 @@ spec:
   query: SELECT * FROM docker_containers;
   purpose: Informational
   remediation: N/A
+  contributors: anelshaer
 ---
 apiVersion: v1
 kind: query
@@ -417,3 +432,4 @@ spec:
   query: SELECT c.id, c.name, c.image, c.image_id, c.command, c.created, c.state, c.status, p.cmdline  FROM docker_containers c CROSS JOIN docker_container_processes p using(id);
   purpose: Informational
   remediation: N/A
+  contributors: anelshaer

--- a/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -349,7 +349,7 @@ spec:
   name: Detect dynamic linker hijacking on macOS (MITRE. T1574.006)
   platforms: macOS
   description: Detect any processes that run with DYLD_INSERT_LIBRARIES environment variable
-  query: SELECT env.pid, env.key, env.value, p.name,p.path, p.cmdline, p.cwd FROM process_envs env join processes p USING (pid) WHERE key='DYLD_INSERT_LIBRARIES' AND env.value != '/Applications/Firefox.app/Contents/MacOS/libplugin_child_interpose.dylib';
+  query: SELECT env.pid, env.key, env.value, p.name,p.path, p.cmdline, p.cwd FROM process_envs env join processes p USING (pid) WHERE key='DYLD_INSERT_LIBRARIES';
   purpose: Detection
   remediation:
     - Identify the process/binary detected

--- a/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -387,3 +387,33 @@ spec:
     FROM processes as p WHERE cmdline like 'nmap%';
   purpose: Detection
   remediation: N/A
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Get docker images on a system
+  platforms: macOS, Linux
+  description: Docker images information, can be used on normal system or a kubenode.
+  query: SELECT * FROM docker_images;
+  purpose: Informational
+  remediation: N/A
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Get docker running containers on a system
+  platforms: macOS, Linux
+  description: Docker containers information, can be used on normal system or a kubenode.
+  query: SELECT * FROM docker_containers;
+  purpose: Informational
+  remediation: N/A
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Get docker running process on a system
+  platforms: macOS, Linux
+  description: Docker containers Processes, can be used on normal system or a kubenode.
+  query: SELECT c.id, c.name, c.image, c.image_id, c.command, c.created, c.state, c.status, p.cmdline  FROM docker_containers c CROSS JOIN docker_container_processes p using(id);
+  purpose: Informational
+  remediation: N/A

--- a/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -289,7 +289,7 @@ spec:
   name: Detect unencrypted SSH keys for local accounts
   platforms: macOS, Linux, Windows, FreeBSD
   description: Identify SSH keys created without a passphrase which can be used in Lateral Movement (MITRE. TA0008)
-  query: SELECT uid, username, description, path, encrypted FROM user_ssh_keys cross join users using (uid) WHERE encrypted=0;
+  query: SELECT uid, username, description, path, encrypted FROM users CROSS JOIN user_ssh_keys using (uid) WHERE encrypted=0;
   purpose: Detection
   remediation:
     - User awareness about the impact of SSH Keys
@@ -302,7 +302,7 @@ spec:
   name: Detect unencrypted SSH keys for domain joined accounts
   platforms: macOS, Linux, Windows, FreeBSD
   description: Identify SSH keys created without a passphrase which can be used in Lateral Movement (MITRE. TA0008)
-  query: SELECT uid, username, description, path, encrypted FROM user_ssh_keys cross join users using (uid) WHERE encrypted=0 and username in (SELECT distinct(username) FROM last);
+  query: SELECT uid, username, description, path, encrypted FROM users CROSS JOIN user_ssh_keys using (uid) WHERE encrypted=0 and username in (SELECT distinct(username) FROM last);
   purpose: Detection
   remediation:
     - User awareness about the impact of SSH Keys
@@ -336,7 +336,7 @@ spec:
   name: Detect dynamic linker hijacking (MITRE. T1574.006)
   platforms: macOS, Linux
   description: Detect any processes that run with an LD_PRELOAD or DYLD_INSERT_LIBRARIES environment variable
-  query: SELECT env.pid, env.key, env.value, p.name,p.path, p.cmdline, p.cwd FROM process_envs env join processes p USING (pid) WHERE key IN ('LD_PRELOAD', 'DYLD_INSERT_LIBRARIES');
+  query: SELECT env.pid, env.key, env.value, p.name,p.path, p.cmdline, p.cwd FROM process_envs env join processes p USING (pid) WHERE key IN ('LD_PRELOAD', 'DYLD_INSERT_LIBRARIES') AND env.value != '/Applications/Firefox.app/Contents/MacOS/libplugin_child_interpose.dylib';
   purpose: Detection
   remediation:
     - Identify the process/binary detected

--- a/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -55,7 +55,7 @@ spec:
   name: Get authorized keys for Domain Joined Accounts
   platforms: macOS, Linux
   description: List authorized_keys for each user on the system.
-  query: SELECT * FROM users CROSS JOIN authorized_keys USING (uid) and username in (SELECT distinct(username) FROM last);
+  query: SELECT *  FROM users CROSS JOIN  authorized_keys USING(uid) WHERE  username IN (SELECT distinct(username) FROM last);
   purpose: Informational
   remediation: N/A
 ---
@@ -272,7 +272,7 @@ spec:
 apiVersion: v1
 kind: query
 spec:
-  name: Get Disk encryption status
+  name: Get disk encryption status
   platforms: macOS, Linux
   description: Disk encryption status and information.
   query: SELECT * FROM disk_encryption;
@@ -282,31 +282,31 @@ spec:
 apiVersion: v1
 kind: query
 spec:
-  name: Detect Unencrypted SSH Keys for Local Accounts
+  name: Detect unencrypted SSH keys for local accounts
   platforms: macOS, Linux, Windows, FreeBSD
   description: Identify SSH keys created without a passphrase which can be used in Lateral Movement (MITRE. TA0008)
   query: SELECT uid, username, description, path, encrypted FROM user_ssh_keys cross join users using (uid) WHERE encrypted=0;
   purpose: Detection
   remediation:
-    - User Awareness about the impact of SSH Keys
+    - User awareness about the impact of SSH Keys
     - Rotate the identified Keys
 ---
 apiVersion: v1
 kind: query
 spec:
-  name: Detect Unencrypted SSH Keys for Domain Joined Accounts
+  name: Detect unencrypted SSH keys for domain joined accounts
   platforms: macOS, Linux, Windows, FreeBSD
   description: Identify SSH keys created without a passphrase which can be used in Lateral Movement (MITRE. TA0008)
   query: SELECT uid, username, description, path, encrypted FROM user_ssh_keys cross join users using (uid) WHERE encrypted=0 and username in (SELECT distinct(username) FROM last);
   purpose: Detection
   remediation:
-    - User Awareness about the impact of SSH Keys
+    - User awareness about the impact of SSH Keys
     - Rotate the identified Keys
 ---
 apiVersion: v1
 kind: query
 spec:
-  name: Get Crontab jobs
+  name: Get crontab jobs
   platforms: macOS, Linux
   description: Line parsed values from system and user cron/tab.
   query: SELECT * FROM crontab;
@@ -326,9 +326,9 @@ spec:
 apiVersion: v1
 kind: query
 spec:
-  name: Detect Dynamic Linker Hijacking (MITRE. T1574.006)
+  name: Detect dynamic linker hijacking (MITRE. T1574.006)
   platforms: macOS, Linux
-  description: Detect Any processes that run with an LD_PRELOAD or DYLD_INSERT_LIBRARIES environment variable
+  description: Detect any processes that run with an LD_PRELOAD or DYLD_INSERT_LIBRARIES environment variable
   query: SELECT env.pid, env.key, env.value, p.name,p.path, p.cmdline, p.cwd FROM process_envs env join processes p USING (pid) WHERE key IN ('LD_PRELOAD', 'DYLD_INSERT_LIBRARIES');
   purpose: Detection
   remediation:
@@ -348,7 +348,7 @@ spec:
 apiVersion: v1
 kind: query
 spec:
-  name: Get Network Interfaces
+  name: Get network interfaces
   platforms: macOS, Linux, Windows, FreeBSD
   description: Network interfaces MAC address
   query: SELECT a.interface, a.address, d.mac FROM interface_addresses a JOIN interface_details d USING (interface) WHERE address not in ('127.0.0.1', '::1');
@@ -358,7 +358,7 @@ spec:
 apiVersion: v1
 kind: query
 spec:
-  name: Get Local User Accounts
+  name: Get local user accounts
   platforms: macOS, Linux, Windows, FreeBSD
   description: Local user accounts (including domain accounts that have logged on locally (Windows)).
   query: SELECT uid, gid, username, description,directory, shell FROM users;
@@ -378,9 +378,9 @@ spec:
 apiVersion: v1
 kind: query
 spec:
-  name: Detect Nmap Scanner
+  name: Detect Nmap scanner
   platforms: macOS, Linux, Windows, FreeBSD
-  description: Detect Nmap Scanner process, identify the user, parent, process details.
+  description: Detect Nmap scanner process, identify the user, parent, process details.
   query: SELECT p.pid, name, p.path, cmdline, cwd, start_time, parent,
     (SELECT name FROM processes WHERE pid=p.parent) AS parent_name,
     (SELECT username FROM users WHERE uid=p.uid) AS username

--- a/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -42,10 +42,20 @@ spec:
 apiVersion: v1
 kind: query
 spec:
-  name: Get authorized keys
+  name: Get authorized keys for Local Accounts
   platforms: macOS, Linux
   description: List authorized_keys for each user on the system.
   query: SELECT * FROM users CROSS JOIN authorized_keys USING (uid);
+  purpose: Informational
+  remediation: N/A
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Get authorized keys for Domain Joined Accounts
+  platforms: macOS, Linux
+  description: List authorized_keys for each user on the system.
+  query: SELECT * FROM users CROSS JOIN authorized_keys USING (uid) and username in (SELECT distinct(username) FROM last);
   purpose: Informational
   remediation: N/A
 ---
@@ -212,6 +222,16 @@ spec:
 apiVersion: v1
 kind: query
 spec:
+  name: Get current users with active shell/console on the system
+  platforms: macOS, Linux, Windows, FreeBSD
+  description: Get current users with active shell/console on the system and associated process
+  query: SELECT user,host,time, p.name, p.cmdline, p.cwd, p.root FROM logged_in_users liu, processes p WHERE liu.pid = p.pid and liu.type='user' and liu.user <> '' ORDER BY time;
+  purpose: Informational
+  remediation: N/A
+---
+apiVersion: v1
+kind: query
+spec:
   name: Get system uptime
   platforms: macOS, Linux, Windows, FreeBSD
   description: Shows the system uptime.
@@ -247,4 +267,123 @@ spec:
   description:
   query: SELECT * FROM bitlocker_info WHERE protection_status = 0;
   purpose: Informational
+  remediation: N/A
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Get Disk encryption status
+  platforms: macOS, Linux
+  description: Disk encryption status and information.
+  query: SELECT * FROM disk_encryption;
+  purpose: Informational
+  remediation: N/A
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Detect Unencrypted SSH Keys for Local Accounts
+  platforms: macOS, Linux, Windows, FreeBSD
+  description: Identify SSH keys created without a passphrase which can be used in Lateral Movement (MITRE. TA0008)
+  query: SELECT uid, username, description, path, encrypted FROM user_ssh_keys cross join users using (uid) WHERE encrypted=0;
+  purpose: Detection
+  remediation:
+    - User Awareness about the impact of SSH Keys
+    - Rotate the identified Keys
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Detect Unencrypted SSH Keys for Domain Joined Accounts
+  platforms: macOS, Linux, Windows, FreeBSD
+  description: Identify SSH keys created without a passphrase which can be used in Lateral Movement (MITRE. TA0008)
+  query: SELECT uid, username, description, path, encrypted FROM user_ssh_keys cross join users using (uid) WHERE encrypted=0 and username in (SELECT distinct(username) FROM last);
+  purpose: Detection
+  remediation:
+    - User Awareness about the impact of SSH Keys
+    - Rotate the identified Keys
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Get Crontab jobs
+  platforms: macOS, Linux
+  description: Line parsed values from system and user cron/tab.
+  query: SELECT * FROM crontab;
+  purpose: Informational
+  remediation: N/A
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Get suid binaries
+  platforms: macOS, Linux
+  description: suid binaries in common locations.
+  query: SELECT * FROM suid_bin;
+  purpose: Informational
+  remediation: N/A
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Detect Dynamic Linker Hijacking (MITRE. T1574.006)
+  platforms: macOS, Linux
+  description: Detect Any processes that run with an LD_PRELOAD or DYLD_INSERT_LIBRARIES environment variable
+  query: SELECT env.pid, env.key, env.value, p.name,p.path, p.cmdline, p.cwd FROM process_envs env join processes p USING (pid) WHERE key IN ('LD_PRELOAD', 'DYLD_INSERT_LIBRARIES');
+  purpose: Detection
+  remediation:
+    - Identify the process/binary detected
+    - Confirm with system owner
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Get etc hosts entries
+  platforms: macOS, Linux
+  description: Line-parsed /etc/hosts
+  query: SELECT * FROM etc_hosts WHERE address not in ('127.0.0.1', '::1');
+  purpose: Informational
+  remediation: N/A
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Get Network Interfaces
+  platforms: macOS, Linux, Windows, FreeBSD
+  description: Network interfaces MAC address
+  query: SELECT a.interface, a.address, d.mac FROM interface_addresses a JOIN interface_details d USING (interface) WHERE address not in ('127.0.0.1', '::1');
+  purpose: Informational
+  remediation: N/A
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Get Local User Accounts
+  platforms: macOS, Linux, Windows, FreeBSD
+  description: Local user accounts (including domain accounts that have logged on locally (Windows)).
+  query: SELECT uid, gid, username, description,directory, shell FROM users;
+  purpose: Informational
+  remediation: N/A
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Detect active user accounts on servers
+  platforms: Linux
+  description: Domain Joined environment normally have root or other service account only and users are SSH-ing using their Domain Accounts.
+  query: SELECT * FROM shadow WHERE password_status='active' and username!='root';
+  purpose: Detection
+  remediation: N/A
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Detect Nmap Scanner
+  platforms: macOS, Linux, Windows, FreeBSD
+  description: Detect Nmap Scanner process, identify the user, parent, process details.
+  query: SELECT p.pid, name, p.path, cmdline, cwd, start_time, parent,
+    (SELECT name FROM processes WHERE pid=p.parent) AS parent_name,
+    (SELECT username FROM users WHERE uid=p.uid) AS username
+    FROM processes as p WHERE cmdline like 'nmap%';
+  purpose: Detection
   remediation: N/A


### PR DESCRIPTION
Adds the following queries to the Standard query library:
- Get authorized keys for Local Accounts
- Get authorized keys for Domain Joined Accounts
- Get current users with active shell/console on the system
- Get Disk encryption status
- Detect Unencrypted SSH Keys for Local Accounts
- Detect Unencrypted SSH Keys for Domain Joined Accounts
- Line parsed values from system and user cron/tab.
- Detect Dynamic Linker Hijacking (MITRE. T1574.006)
- Get etc hosts entries
- Get Network Interfaces
- Get Local User Accounts
- Detect active user accounts on servers
- Detect Nmap Scanner
- Get docker images on a system
- Get docker running containers on a system
- Get docker running process on a system