### PR TITLE
Fix foreign key cascade for query stats table

### DIFF
--- a/server/datastore/mysql/migrations/tables/20210506095025_AddScheduledQueryStats.go
+++ b/server/datastore/mysql/migrations/tables/20210506095025_AddScheduledQueryStats.go
@@ -25,8 +25,8 @@ func Up_20210506095025(tx *sql.Tx) error {
 			user_time int,
 			wall_time int,
 			PRIMARY KEY (host_id, scheduled_query_id),
-			FOREIGN KEY (host_id) REFERENCES hosts (id),
-			FOREIGN KEY (scheduled_query_id) REFERENCES scheduled_queries (id)
+			FOREIGN KEY (host_id) REFERENCES hosts (id) ON DELETE CASCADE ON UPDATE CASCADE,
+			FOREIGN KEY (scheduled_query_id) REFERENCES scheduled_queries (id) ON DELETE CASCADE ON UPDATE CASCADE
 		)
 	`
 	if _, err := tx.Exec(sql); err != nil {


### PR DESCRIPTION
Introduces the appropriate cascading for foreign keys on the
scheduled_query_stats table to prevent errors when deleting the
associated packs, scheduled queries, and queries.

Fixes #764
Fixes #766