### PR TITLE
Add "observer can run" to query objects

### DIFF
--- a/server/datastore/datastore_queries.go
+++ b/server/datastore/datastore_queries.go
@@ -17,7 +17,7 @@ func testApplyQueries(t *testing.T, ds kolide.Datastore) {
 	zwass := test.NewUser(t, ds, "Zach", "zwass", "zwass@kolide.co", true)
 	groob := test.NewUser(t, ds, "Victor", "groob", "victor@kolide.co", true)
 	expectedQueries := []*kolide.Query{
-		{Name: "foo", Description: "get the foos", Query: "select * from foo"},
+		{Name: "foo", Description: "get the foos", Query: "select * from foo", ObserverCanRun: true},
 		{Name: "bar", Description: "do some bars", Query: "select baz from bar"},
 	}
 
@@ -34,6 +34,7 @@ func testApplyQueries(t *testing.T, ds kolide.Datastore) {
 		assert.Equal(t, comp.Description, q.Description)
 		assert.Equal(t, comp.Query, q.Query)
 		assert.Equal(t, &zwass.ID, q.AuthorID)
+		assert.Equal(t, comp.ObserverCanRun, q.ObserverCanRun)
 	}
 
 	// Victor modifies a query (but also pushes the same version of the
@@ -160,6 +161,7 @@ func testSaveQuery(t *testing.T, ds kolide.Datastore) {
 	assert.NotEqual(t, 0, query.ID)
 
 	query.Query = "baz"
+	query.ObserverCanRun = true
 	err = ds.SaveQuery(query)
 
 	require.Nil(t, err)
@@ -169,6 +171,7 @@ func testSaveQuery(t *testing.T, ds kolide.Datastore) {
 	require.NotNil(t, queryVerify)
 	assert.Equal(t, "baz", queryVerify.Query)
 	assert.Equal(t, "Zach", queryVerify.AuthorName)
+	assert.True(t, queryVerify.ObserverCanRun)
 }
 
 func testListQuery(t *testing.T, ds kolide.Datastore) {

--- a/server/datastore/mysql/migrations/tables/20210517112751_TeamsObserverQueries.go
+++ b/server/datastore/mysql/migrations/tables/20210517112751_TeamsObserverQueries.go
@@ -1,0 +1,26 @@
+package tables
+
+import (
+	"database/sql"
+
+	"github.com/pkg/errors"
+)
+
+func init() {
+	MigrationClient.AddMigration(Up_20210517112751, Down_20210517112751)
+}
+
+func Up_20210517112751(tx *sql.Tx) error {
+	sql := `
+		ALTER TABLE queries
+		ADD COLUMN observer_can_run TINYINT(1) NOT NULL DEFAULT FALSE
+	`
+	if _, err := tx.Exec(sql); err != nil {
+		return errors.Wrap(err, "add column observer_run")
+	}
+	return nil
+}
+
+func Down_20210517112751(tx *sql.Tx) error {
+	return nil
+}

--- a/server/kolide/queries.go
+++ b/server/kolide/queries.go
@@ -73,7 +73,10 @@ type Query struct {
 	Description string `json:"description"`
 	Query       string `json:"query"`
 	Saved       bool   `json:"saved"`
-	AuthorID    *uint  `json:"author_id" db:"author_id"`
+	// ObserverCanRun indicates whether users with Observer role can run this as
+	// a live query.
+	ObserverCanRun bool  `json:"observer_can_run" db:"observer_can_run"`
+	AuthorID       *uint `json:"author_id" db:"author_id"`
 	// AuthorName is retrieved with a join to the users table in the MySQL
 	// backend (using AuthorID)
 	AuthorName string `json:"author_name" db:"author_name"`


### PR DESCRIPTION
- Database migration.
- Update model and datastore methods.