### PR TITLE
Query Results: Render errors table on fullscreen

### DIFF
--- a/frontend/components/queries/QueryResultsTable/QueryResultsTable.jsx
+++ b/frontend/components/queries/QueryResultsTable/QueryResultsTable.jsx
@@ -227,25 +227,23 @@ class QueryResultsTable extends Component {
           {!hasNoResults && renderTable()}
         </div>
         {hasErrors && (
-          <>
-            <div className={`${baseClass}__error-table-container`}>
-              <header className={`${baseClass}__button-wrap`}>
-                <div>
-                  <Button
-                    className={`${baseClass}__export-btn`}
-                    onClick={onExportErrorsResults}
-                    variant="inverse"
-                  >
-                    Export errors
-                  </Button>
-                </div>
-              </header>
-              <span className={`${baseClass}__table-title`}>Errors</span>
-              <div className={`${baseClass}__error-table-wrapper`}>
-                {renderErrorsTable()}
+          <div className={`${baseClass}__error-table-container`}>
+            <header className={`${baseClass}__button-wrap`}>
+              <div>
+                <Button
+                  className={`${baseClass}__export-btn`}
+                  onClick={onExportErrorsResults}
+                  variant="inverse"
+                >
+                  Export errors
+                </Button>
               </div>
+            </header>
+            <span className={`${baseClass}__table-title`}>Errors</span>
+            <div className={`${baseClass}__error-table-wrapper`}>
+              {renderErrorsTable()}
             </div>
-          </>
+          </div>
         )}
       </div>
     );

--- a/frontend/components/queries/QueryResultsTable/QueryResultsTable.jsx
+++ b/frontend/components/queries/QueryResultsTable/QueryResultsTable.jsx
@@ -229,15 +229,13 @@ class QueryResultsTable extends Component {
         {hasErrors && (
           <div className={`${baseClass}__error-table-container`}>
             <header className={`${baseClass}__button-wrap`}>
-              <div>
-                <Button
-                  className={`${baseClass}__export-btn`}
-                  onClick={onExportErrorsResults}
-                  variant="inverse"
-                >
-                  Export errors
-                </Button>
-              </div>
+              <Button
+                className={`${baseClass}__export-btn`}
+                onClick={onExportErrorsResults}
+                variant="inverse"
+              >
+                Export errors
+              </Button>
             </header>
             <span className={`${baseClass}__table-title`}>Errors</span>
             <div className={`${baseClass}__error-table-wrapper`}>

--- a/frontend/components/queries/QueryResultsTable/_styles.scss
+++ b/frontend/components/queries/QueryResultsTable/_styles.scss
@@ -144,6 +144,10 @@
       max-height: none;
     }
 
+    .query-results-table__error-table-container {
+      max-height: none;
+    }
+
     .query-results-table__error-table-wrapper {
       max-height: none;
     }

--- a/frontend/components/queries/QueryResultsTable/_styles.scss
+++ b/frontend/components/queries/QueryResultsTable/_styles.scss
@@ -39,7 +39,7 @@
     border-radius: 3px;
     overflow: scroll;
     margin-top: $pad-xsmall;
-    min-height: 200px;
+    min-height: 100px;
     max-height: 400px;
     width: 100%;
 
@@ -57,18 +57,19 @@
 
   &__error-table-container {
     margin-top: $pad-large;
+    overflow: scroll;
   }
 
   &__error-table-wrapper {
     display: flex;
     border: solid 1px $ui-fleet-blue-15;
     border-radius: 3px;
-    overflow: scroll;
     margin-bottom: $pad-xxlarge;
     margin-top: $pad-xsmall;
     min-height: 200px;
     max-height: 400px;
     width: 100%;
+    box-sizing: border-box;
   }
 
   &__table {

--- a/frontend/components/queries/QueryResultsTable/_styles.scss
+++ b/frontend/components/queries/QueryResultsTable/_styles.scss
@@ -66,7 +66,8 @@
     overflow: scroll;
     margin-bottom: $pad-xxlarge;
     margin-top: $pad-xsmall;
-    max-height: 200px;
+    min-height: 200px;
+    max-height: 400px;
     width: 100%;
   }
 

--- a/frontend/components/queries/QueryResultsTable/_styles.scss
+++ b/frontend/components/queries/QueryResultsTable/_styles.scss
@@ -143,8 +143,8 @@
       max-height: none;
     }
 
-    .query-results-table__error-table-container {
-      display: none;
+    .query-results-table__error-table-wrapper {
+      max-height: none;
     }
   }
 


### PR DESCRIPTION
- Fixes CSS property that disabled the display of the error table on fullscreen

To do: Identify why `max-height: none; overflow: scroll; ` renders correctly for results table and not for errors table

Closes #797 

<img width="987" alt="Screen Shot 2021-05-19 at 11 26 15 AM" src="https://user-images.githubusercontent.com/71795832/118840091-119be780-b895-11eb-990c-ece6c6024c5f.png">
