### PR TITLE
Host details page: Render team

### DIFF
--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -13,6 +13,7 @@ import Modal from "components/modals/Modal";
 import SoftwareListRow from "pages/hosts/HostDetailsPage/SoftwareListRow";
 import PackQueriesListRow from "pages/hosts/HostDetailsPage/PackQueriesListRow";
 
+import permissionUtils from "utilities/permissions";
 import entityGetter from "redux/utilities/entityGetter";
 import queryActions from "redux/nodes/entities/queries/actions";
 import queryInterface from "interfaces/query";
@@ -51,6 +52,7 @@ export class HostDetailsPage extends Component {
     isLoadingHost: PropTypes.bool,
     queries: PropTypes.arrayOf(queryInterface),
     queryErrors: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+    isBasicTier: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -413,7 +415,14 @@ export class HostDetailsPage extends Component {
   };
 
   render() {
-    const { host, isLoadingHost, dispatch, queries, queryErrors } = this.props;
+    const {
+      host,
+      isLoadingHost,
+      dispatch,
+      queries,
+      queryErrors,
+      isBasicTier,
+    } = this.props;
     const { showQueryHostModal } = this.state;
     const {
       toggleQueryHostModal,
@@ -467,17 +476,13 @@ export class HostDetailsPage extends Component {
       return <Spinner />;
     }
 
-    // API only has team_id and not team_name, need to convert
-    console.log(host);
-    // hardcoded in basic tier
-    const isBasicTier = true;
     const hostTeam = () => {
       return (
         <div className="info__item info__item--title">
           <span className="info__header">Team</span>
           <span className={`info__data`}>
-            {host.team_id ? (
-              `${host.team_id}`
+            {host.team_name ? (
+              `${host.team_name}`
             ) : (
               <span className="info__no-team">No team</span>
             )}
@@ -612,12 +617,16 @@ const mapStateToProps = (state, ownProps) => {
   const { host_id: hostID } = ownProps.params;
   const host = entityGetter(state).get("hosts").findBy({ id: hostID });
   const { loading: isLoadingHost } = state.entities.hosts;
+  const config = state.app.config;
+  const isBasicTier = permissionUtils.isBasicTier(config);
+
   return {
     host,
     hostID,
     isLoadingHost,
     queries,
     queryErrors,
+    isBasicTier,
   };
 };
 

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -467,6 +467,20 @@ export class HostDetailsPage extends Component {
       return <Spinner />;
     }
 
+    // API only has team_id and not team_name, need to convert
+    console.log(host);
+    // hardcoded in basic tier
+    const isBasicTier = true;
+    const hostTeam = () => {
+      return (
+        <div className="info__item info__item--title">
+          <span className="info__header">Team</span>
+          <span className={`info__data`}>
+            {host.team_id ? `${host.team_id}` : "No team"}
+          </span>
+        </div>
+      );
+    };
     return (
       <div className={`${baseClass} body-wrap`}>
         <div>
@@ -484,7 +498,7 @@ export class HostDetailsPage extends Component {
                   titleData.detail_updated_at
                 )}`}{" "}
               </p>
-              {renderRefetch()}
+              {isBasicTier ? renderRefetch() : null}
             </div>
             <div className="info">
               <div className="info__item info__item--title">
@@ -493,6 +507,7 @@ export class HostDetailsPage extends Component {
                   {titleData.status}
                 </span>
               </div>
+              {hostTeam()}
               <div className="info__item info__item--title">
                 <span className="info__header">RAM</span>
                 <span className="info__data">

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -476,7 +476,11 @@ export class HostDetailsPage extends Component {
         <div className="info__item info__item--title">
           <span className="info__header">Team</span>
           <span className={`info__data`}>
-            {host.team_id ? `${host.team_id}` : "No team"}
+            {host.team_id ? (
+              `${host.team_id}`
+            ) : (
+              <span className="info__no-team">No team</span>
+            )}
           </span>
         </div>
       );

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -498,7 +498,7 @@ export class HostDetailsPage extends Component {
                   titleData.detail_updated_at
                 )}`}{" "}
               </p>
-              {isBasicTier ? renderRefetch() : null}
+              {renderRefetch()}
             </div>
             <div className="info">
               <div className="info__item info__item--title">
@@ -507,7 +507,7 @@ export class HostDetailsPage extends Component {
                   {titleData.status}
                 </span>
               </div>
-              {hostTeam()}
+              {isBasicTier ? hostTeam() : null}
               <div className="info__item info__item--title">
                 <span className="info__header">RAM</span>
                 <span className="info__data">

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -42,6 +42,10 @@
         color: $core-fleet-black;
         font-weight: $bold;
       }
+
+      &__no-team {
+        color: $ui-fleet-black-50;
+      }
     }
 
     .list {


### PR DESCRIPTION
WIP:
Hardcoded in basic tier
Currently uses team_id

TODO:
- [x] Properly render by tier
- [x]  Modify API to include team_name instead of team_id, or  introduce team API on page to grab team name
- [x] Styling and code consistency between renders on Host page and Host details page