### PR TITLE
Fix setting observer_can_run in query API

### DIFF
--- a/server/kolide/queries.go
+++ b/server/kolide/queries.go
@@ -61,9 +61,10 @@ type QueryService interface {
 }
 
 type QueryPayload struct {
-	Name        *string
-	Description *string
-	Query       *string
+	Name           *string
+	Description    *string
+	Query          *string
+	ObserverCanRun *bool `json:"observer_can_run"`
 }
 
 type Query struct {

--- a/server/service/service_queries.go
+++ b/server/service/service_queries.go
@@ -89,6 +89,10 @@ func (svc service) NewQuery(ctx context.Context, p kolide.QueryPayload) (*kolide
 		query.Query = *p.Query
 	}
 
+	if p.ObserverCanRun != nil {
+		query.ObserverCanRun = *p.ObserverCanRun
+	}
+
 	vc, ok := viewer.FromContext(ctx)
 	if ok {
 		query.AuthorID = uintPtr(vc.UserID())
@@ -123,6 +127,10 @@ func (svc service) ModifyQuery(ctx context.Context, id uint, p kolide.QueryPaylo
 
 	if p.Query != nil {
 		query.Query = *p.Query
+	}
+
+	if p.ObserverCanRun != nil {
+		query.ObserverCanRun = *p.ObserverCanRun
 	}
 
 	if err := query.ValidateSQL(); err != nil {


### PR DESCRIPTION
Previous work in #777 added the datastore and model layers, but didn't
handle setting this value in the service and transport.

Fixes #822