### PR TITLE
Add sub label for "Enable single sign on" checkbox

### DIFF
--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -319,8 +319,11 @@ class UserForm extends Component<ICreateUserFormProps, ICreateUserFormState> {
             disabled={!this.props.canUseSSO}
             wrapperClassName={`${baseClass}__invite-admin`}
           >
-            Enable Single Sign On
+            Enable single sign on
           </Checkbox>
+          <p className={`${baseClass}__sso-input sublabel`}>
+            Password authentication will be disabled for this user.
+          </p>
         </div>
 
         <div className={`${baseClass}__selected-teams-container`}>

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
@@ -1,6 +1,7 @@
 .create-user-form {
   &__sso-input {
     margin-top: $pad-large;
+    margin-bottom: $pad-large;
 
     .kolide-checkbox {
       margin-top: 5px;
@@ -9,7 +10,7 @@
         font-size: $x-small;
         font-weight: $bold;
         color: $core-fleet-black;
-        padding-left: $pad-xlarge;
+        padding-left: 12px;
       }
     }
   }
@@ -60,4 +61,13 @@
   &__btn {
     margin-left: 12px;
   }
+
+  &__invite-admin {
+    margin-bottom: 8px;
+  }
+  
+  .sublabel {
+    margin: 0px;   
+  }
+
 }


### PR DESCRIPTION
- Adds the following text below the "Enable single sign-on" option: "Password authentication will be disabled for this user."
- Adds sentence casing so that "Enable Single Sign On" becomes "Enable single sign-on"

Closes #725 