### PR TITLE
Cleanup live query store for orphaned query

### DIFF
--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -1010,6 +1010,9 @@ func (svc service) ingestDistributedQuery(host kolide.Host, name string, rows []
 		// execute that query when we can't write to any subscriber
 		campaign, err := svc.ds.DistributedQueryCampaign(uint(campaignID))
 		if err != nil {
+			if err := svc.liveQueryStore.StopQuery(strconv.Itoa(int(campaignID))); err != nil {
+				return osqueryError{message: "stop orphaned campaign after load failure: " + err.Error()}
+			}
 			return osqueryError{message: "loading orphaned campaign: " + err.Error()}
 		}
 

--- a/server/service/service_osquery_test.go
+++ b/server/service/service_osquery_test.go
@@ -1321,6 +1321,8 @@ func TestIngestDistributedQueryOrphanedCampaignLoadError(t *testing.T) {
 		return nil, fmt.Errorf("missing campaign")
 	}
 
+	lq.On("StopQuery", "42").Return(nil)
+
 	host := kolide.Host{ID: 1}
 
 	err := svc.ingestDistributedQuery(host, "fleet_distributed_query_42", []map[string]string{}, false, "")


### PR DESCRIPTION
Cleans up a case in which a query could continue to be returned even
after it had been detected orphaned.