### PR TITLE
add permission to host page

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -280,9 +280,16 @@ const generateAvailableTableHeaders = (
 ): IHostDataColumn[] => {
   return allHostTableHeaders.reduce(
     (columns: IHostDataColumn[], currentColumn: IHostDataColumn) => {
-      if (
-        currentColumn.accessor === "team_name" &&
-        permissionUtils.isCoreTier(config)
+      // skip over column headers that are not shown in core tier
+
+      if (permissionUtils.isCoreTier(config) && permissionUtils.isGlobalAdmin(currentUser) ||
+        !permissionUtils.isGlobalMaintainer(currentUser)) {
+        return columns;
+      } else if (
+        !permissionUtils.isGlobalAdmin(currentUser) ||
+        !permissionUtils.isGlobalMaintainer(currentUser) &&
+          (currentColumn.accessor === "team_name" ||
+            currentColumn.id === "selection"))
       ) {
         return columns;
       }

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -281,18 +281,19 @@ const generateAvailableTableHeaders = (
   return allHostTableHeaders.reduce(
     (columns: IHostDataColumn[], currentColumn: IHostDataColumn) => {
       // skip over column headers that are not shown in core tier
-
-      if (permissionUtils.isCoreTier(config) && permissionUtils.isGlobalAdmin(currentUser) ||
-        !permissionUtils.isGlobalMaintainer(currentUser)) {
-        return columns;
-      } else if (
-        !permissionUtils.isGlobalAdmin(currentUser) ||
-        !permissionUtils.isGlobalMaintainer(currentUser) &&
-          (currentColumn.accessor === "team_name" ||
-            currentColumn.id === "selection"))
+      if (
+        permissionUtils.isCoreTier(config) &&
+        (permissionUtils.isGlobalAdmin(currentUser) ||
+          permissionUtils.isGlobalMaintainer(currentUser))
       ) {
-        return columns;
+        if (
+          currentColumn.accessor === "team_name" ||
+          currentColumn.id === "selection"
+        ) {
+          return columns;
+        }
       }
+
       columns.push(currentColumn);
       return columns;
     },

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -281,15 +281,19 @@ const generateAvailableTableHeaders = (
   return allHostTableHeaders.reduce(
     (columns: IHostDataColumn[], currentColumn: IHostDataColumn) => {
       // skip over column headers that are not shown in core tier
-      if (
-        permissionUtils.isCoreTier(config) &&
-        (permissionUtils.isGlobalAdmin(currentUser) ||
-          permissionUtils.isGlobalMaintainer(currentUser))
-      ) {
+      if (permissionUtils.isCoreTier(config)) {
         if (
           currentColumn.accessor === "team_name" ||
           currentColumn.id === "selection"
         ) {
+          return columns;
+        }
+        // In base tier, we want to check user role to enable/disable select column
+      } else if (
+        !permissionUtils.isGlobalAdmin(currentUser) &&
+        !permissionUtils.isGlobalMaintainer(currentUser)
+      ) {
+        if (currentColumn.id === "selection") {
           return columns;
         }
       }

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -17,7 +17,10 @@ import {
   humanHostLastSeen,
   humanHostDetailUpdated,
 } from "kolide/helpers";
-import PATHS from "../../../router/paths";
+import { IConfig } from "interfaces/config";
+import { IUser } from "interfaces/user";
+import PATHS from "router/paths";
+import permissionUtils from "utilities/permissions";
 
 interface IHeaderProps {
   column: {
@@ -56,7 +59,7 @@ const lastSeenTime = (status: string, seenTime: string): string => {
   return "Online";
 };
 
-const hostTableHeaders: IHostDataColumn[] = [
+const allHostTableHeaders: IHostDataColumn[] = [
   // We are using React Table useRowSelect functionality for the selection header.
   // More information on its API can be found here
   // https://react-table.tanstack.com/docs/api/useRowSelect
@@ -101,6 +104,12 @@ const hostTableHeaders: IHostDataColumn[] = [
       />
     ),
     disableHidden: true,
+  },
+  {
+    title: "Team",
+    Header: "Team",
+    accessor: "team_name",
+    Cell: (cellProps) => <TextCell value={cellProps.cell.value} />,
   },
   {
     title: "Status",
@@ -261,12 +270,46 @@ const defaultHiddenColumns = [
   "hardware_serial",
 ];
 
-const generateVisibleHostColumns = (
-  hiddenColumns: string[]
+/**
+ * Will generate a host table column configuration based off of the current user
+ * permissions and license tier of fleet they are on.
+ */
+const generateAvailableTableHeaders = (
+  config: IConfig,
+  currentUser: IUser
 ): IHostDataColumn[] => {
-  return hostTableHeaders.filter((column) => {
+  return allHostTableHeaders.reduce(
+    (columns: IHostDataColumn[], currentColumn: IHostDataColumn) => {
+      if (
+        currentColumn.accessor === "team_name" &&
+        permissionUtils.isCoreTier(config)
+      ) {
+        return columns;
+      }
+      columns.push(currentColumn);
+      return columns;
+    },
+    []
+  );
+};
+
+/**
+ * Will generate a host table column configuration that a user currently sees.
+ *
+ */
+const generateVisibleTableColumns = (
+  hiddenColumns: string[],
+  config: IConfig,
+  currentUser: IUser
+): IHostDataColumn[] => {
+  // remove columns set as hidden by the user.
+  return generateAvailableTableHeaders(config, currentUser).filter((column) => {
     return !hiddenColumns.includes(column.accessor as string);
   });
 };
 
-export { hostTableHeaders, defaultHiddenColumns, generateVisibleHostColumns };
+export {
+  defaultHiddenColumns,
+  generateAvailableTableHeaders,
+  generateVisibleTableColumns,
+};

--- a/frontend/utilities/permissions/permissions.ts
+++ b/frontend/utilities/permissions/permissions.ts
@@ -1,5 +1,5 @@
 import { IUser } from "interfaces/user";
-import { IConfig } from "../../interfaces/config";
+import { IConfig } from "interfaces/config";
 
 const isCoreTier = (config: IConfig): boolean => {
   return config.tier === "core";


### PR DESCRIPTION
This adds various permissions gates behind features on host page. These include:

* showing teams column in table
* showing and allowing selection of data in table
* showing of enable/disable visibility of teams column 