### PR TITLE
Refactor struct slices for consistent pointer use

### DIFF
--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -563,7 +563,7 @@ func getHostsCommand() *cli.Command {
 
 				if c.Bool(jsonFlagName) || c.Bool(yamlFlagName) {
 					for _, host := range hosts {
-						err = printHost(c, &host.Host)
+						err = printHost(c, host.Host)
 						if err != nil {
 							return err
 						}

--- a/cmd/fleetctl/goquery.go
+++ b/cmd/fleetctl/goquery.go
@@ -48,7 +48,7 @@ func (c *goqueryClient) CheckHost(query string) (gqhosts.Host, error) {
 	for _, h := range res.Hosts {
 		// We allow hosts to be looked up by hostname in addition to UUID
 		if query == h.UUID || query == h.HostName || query == h.ComputerName {
-			host = &h
+			host = h
 			break
 		}
 	}

--- a/server/datastore/datastore_labels.go
+++ b/server/datastore/datastore_labels.go
@@ -247,12 +247,12 @@ func testSearchLabels(t *testing.T, db kolide.Datastore) {
 	// don't error.
 	labels, err := db.SearchLabels(filter, "")
 	require.Nil(t, err)
-	assert.Contains(t, labels, *all)
+	assert.Contains(t, labels, all)
 
 	labels, err = db.SearchLabels(filter, "foo")
 	require.Nil(t, err)
 	assert.Len(t, labels, 3)
-	assert.Contains(t, labels, *all)
+	assert.Contains(t, labels, all)
 
 	labels, err = db.SearchLabels(filter, "foo", all.ID, l3.ID)
 	require.Nil(t, err)
@@ -262,7 +262,7 @@ func testSearchLabels(t *testing.T, db kolide.Datastore) {
 	labels, err = db.SearchLabels(filter, "xxx")
 	require.Nil(t, err)
 	assert.Len(t, labels, 1)
-	assert.Contains(t, labels, *all)
+	assert.Contains(t, labels, all)
 }
 
 func testSearchLabelsLimit(t *testing.T, db kolide.Datastore) {

--- a/server/datastore/inmem/labels.go
+++ b/server/datastore/inmem/labels.go
@@ -28,16 +28,16 @@ func (d *Datastore) NewLabel(label *kolide.Label, opts ...kolide.OptionalArg) (*
 	return &newLabel, nil
 }
 
-func (d *Datastore) ListLabelsForHost(hid uint) ([]kolide.Label, error) {
+func (d *Datastore) ListLabelsForHost(hid uint) ([]*kolide.Label, error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 	// First get IDs of label executions for the host
-	resLabels := []kolide.Label{}
+	resLabels := []*kolide.Label{}
 
 	for _, lqe := range d.labelQueryExecutions {
 		if lqe.HostID == hid && lqe.Matches {
 			if label := d.labels[lqe.LabelID]; label != nil {
-				resLabels = append(resLabels, *label)
+				resLabels = append(resLabels, label)
 			}
 		}
 	}
@@ -151,13 +151,13 @@ func (d *Datastore) ListLabels(opt kolide.ListOptions) ([]*kolide.Label, error) 
 	return labels, nil
 }
 
-func (d *Datastore) SearchLabels(filter kolide.TeamFilter, query string, omit ...uint) ([]kolide.Label, error) {
+func (d *Datastore) SearchLabels(filter kolide.TeamFilter, query string, omit ...uint) ([]*kolide.Label, error) {
 	omitLookup := map[uint]bool{}
 	for _, o := range omit {
 		omitLookup[o] = true
 	}
 
-	var results []kolide.Label
+	var results []*kolide.Label
 
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
@@ -168,7 +168,7 @@ func (d *Datastore) SearchLabels(filter kolide.TeamFilter, query string, omit ..
 		}
 
 		if (strings.Contains(l.Name, query) || l.Name == "All Hosts") && !omitLookup[l.ID] {
-			results = append(results, *l)
+			results = append(results, l)
 			continue
 		}
 	}
@@ -177,23 +177,23 @@ func (d *Datastore) SearchLabels(filter kolide.TeamFilter, query string, omit ..
 	return results, nil
 }
 
-func (d *Datastore) ListHostsInLabel(lid uint, opt kolide.HostListOptions) ([]kolide.Host, error) {
-	var hosts []kolide.Host
+func (d *Datastore) ListHostsInLabel(lid uint, opt kolide.HostListOptions) ([]*kolide.Host, error) {
+	var hosts []*kolide.Host
 
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
 	for _, lqe := range d.labelQueryExecutions {
 		if lqe.LabelID == lid && lqe.Matches {
-			hosts = append(hosts, *d.hosts[lqe.HostID])
+			hosts = append(hosts, d.hosts[lqe.HostID])
 		}
 	}
 
 	return hosts, nil
 }
 
-func (d *Datastore) ListUniqueHostsInLabels(labels []uint) ([]kolide.Host, error) {
-	var hosts []kolide.Host
+func (d *Datastore) ListUniqueHostsInLabels(labels []uint) ([]*kolide.Host, error) {
+	var hosts []*kolide.Host
 
 	labelSet := map[uint]bool{}
 	hostSet := map[uint]bool{}
@@ -208,7 +208,7 @@ func (d *Datastore) ListUniqueHostsInLabels(labels []uint) ([]kolide.Host, error
 	for _, lqe := range d.labelQueryExecutions {
 		if labelSet[lqe.LabelID] && lqe.Matches {
 			if !hostSet[lqe.HostID] {
-				hosts = append(hosts, *d.hosts[lqe.HostID])
+				hosts = append(hosts, d.hosts[lqe.HostID])
 				hostSet[lqe.HostID] = true
 			}
 		}

--- a/server/kolide/app.go
+++ b/server/kolide/app.go
@@ -288,6 +288,11 @@ type OrderDirection int
 const (
 	OrderAscending OrderDirection = iota
 	OrderDescending
+
+	// PerPageUnlimited is the value to pass to PerPage when we want
+	// "unlimited". If we ever find this limit to be too low, congratulations on
+	// incredible growth of the product!
+	PerPageUnlimited uint = 9999999
 )
 
 // ListOptions defines options related to paging and ordering to be used when

--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -165,9 +165,9 @@ type Host struct {
 type HostDetail struct {
 	Host
 	// Labels is the list of labels the host is a member of.
-	Labels []Label `json:"labels"`
+	Labels []*Label `json:"labels"`
 	// Packs is the list of packs the host is a member of.
-	Packs []Pack `json:"packs"`
+	Packs []*Pack `json:"packs"`
 }
 
 const (

--- a/server/kolide/labels.go
+++ b/server/kolide/labels.go
@@ -37,18 +37,18 @@ type LabelStore interface {
 	RecordLabelQueryExecutions(host *Host, results map[uint]bool, t time.Time) error
 
 	// LabelsForHost returns the labels that the given host is in.
-	ListLabelsForHost(hid uint) ([]Label, error)
+	ListLabelsForHost(hid uint) ([]*Label, error)
 
 	// ListHostsInLabel returns a slice of hosts in the label with the
 	// given ID.
-	ListHostsInLabel(lid uint, opt HostListOptions) ([]Host, error)
+	ListHostsInLabel(lid uint, opt HostListOptions) ([]*Host, error)
 
 	// ListUniqueHostsInLabels returns a slice of all of the hosts in the
 	// given label IDs. A host will only appear once in the results even if
 	// it is in multiple of the provided labels.
-	ListUniqueHostsInLabels(labels []uint) ([]Host, error)
+	ListUniqueHostsInLabels(labels []uint) ([]*Host, error)
 
-	SearchLabels(filter TeamFilter, query string, omit ...uint) ([]Label, error)
+	SearchLabels(filter TeamFilter, query string, omit ...uint) ([]*Label, error)
 
 	// LabelIDsByName Retrieve the IDs associated with the given labels
 	LabelIDsByName(labels []string) ([]uint, error)
@@ -74,10 +74,10 @@ type LabelService interface {
 
 	// ListHostsInLabel returns a slice of hosts in the label with the
 	// given ID.
-	ListHostsInLabel(ctx context.Context, lid uint, opt HostListOptions) ([]Host, error)
+	ListHostsInLabel(ctx context.Context, lid uint, opt HostListOptions) ([]*Host, error)
 
 	// LabelsForHost returns the labels that the given host is in.
-	ListLabelsForHost(ctx context.Context, hid uint) ([]Label, error)
+	ListLabelsForHost(ctx context.Context, hid uint) ([]*Label, error)
 
 	// HostIDsForLabel returns ids of hosts that belong to the label identified
 	// by lid

--- a/server/kolide/targets.go
+++ b/server/kolide/targets.go
@@ -6,8 +6,8 @@ import (
 )
 
 type TargetSearchResults struct {
-	Hosts  []Host
-	Labels []Label
+	Hosts  []*Host
+	Labels []*Label
 }
 
 // TargetMetrics contains information about the online status of a set of

--- a/server/mock/datastore_labels.go
+++ b/server/mock/datastore_labels.go
@@ -30,13 +30,13 @@ type LabelQueriesForHostFunc func(host *kolide.Host, cutoff time.Time) (map[stri
 
 type RecordLabelQueryExecutionsFunc func(host *kolide.Host, results map[uint]bool, t time.Time) error
 
-type ListLabelsForHostFunc func(hid uint) ([]kolide.Label, error)
+type ListLabelsForHostFunc func(hid uint) ([]*kolide.Label, error)
 
-type ListHostsInLabelFunc func(lid uint, opt kolide.HostListOptions) ([]kolide.Host, error)
+type ListHostsInLabelFunc func(lid uint, opt kolide.HostListOptions) ([]*kolide.Host, error)
 
-type ListUniqueHostsInLabelsFunc func(labels []uint) ([]kolide.Host, error)
+type ListUniqueHostsInLabelsFunc func(labels []uint) ([]*kolide.Host, error)
 
-type SearchLabelsFunc func(filter kolide.TeamFilter, query string, omit ...uint) ([]kolide.Label, error)
+type SearchLabelsFunc func(filter kolide.TeamFilter, query string, omit ...uint) ([]*kolide.Label, error)
 
 type LabelIDsByNameFunc func(labels []string) ([]uint, error)
 
@@ -137,22 +137,22 @@ func (s *LabelStore) RecordLabelQueryExecutions(host *kolide.Host, results map[u
 	return s.RecordLabelQueryExecutionsFunc(host, results, t)
 }
 
-func (s *LabelStore) ListLabelsForHost(hid uint) ([]kolide.Label, error) {
+func (s *LabelStore) ListLabelsForHost(hid uint) ([]*kolide.Label, error) {
 	s.ListLabelsForHostFuncInvoked = true
 	return s.ListLabelsForHostFunc(hid)
 }
 
-func (s *LabelStore) ListHostsInLabel(lid uint, opt kolide.HostListOptions) ([]kolide.Host, error) {
+func (s *LabelStore) ListHostsInLabel(lid uint, opt kolide.HostListOptions) ([]*kolide.Host, error) {
 	s.ListHostsInLabelFuncInvoked = true
 	return s.ListHostsInLabelFunc(lid, opt)
 }
 
-func (s *LabelStore) ListUniqueHostsInLabels(labels []uint) ([]kolide.Host, error) {
+func (s *LabelStore) ListUniqueHostsInLabels(labels []uint) ([]*kolide.Host, error) {
 	s.ListUniqueHostsInLabelsFuncInvoked = true
 	return s.ListUniqueHostsInLabelsFunc(labels)
 }
 
-func (s *LabelStore) SearchLabels(filter kolide.TeamFilter, query string, omit ...uint) ([]kolide.Label, error) {
+func (s *LabelStore) SearchLabels(filter kolide.TeamFilter, query string, omit ...uint) ([]*kolide.Label, error) {
 	s.SearchLabelsFuncInvoked = true
 	return s.SearchLabelsFunc(filter, query, omit...)
 }

--- a/server/service/client_targets.go
+++ b/server/service/client_targets.go
@@ -45,12 +45,12 @@ func (c *Client) SearchTargets(query string, selectedHostIDs, selectedLabelIDs [
 		return nil, errors.Errorf("SearchTargets: %s", responseBody.Err)
 	}
 
-	hosts := make([]kolide.Host, len(responseBody.Targets.Hosts))
+	hosts := make([]*kolide.Host, len(responseBody.Targets.Hosts))
 	for i, h := range responseBody.Targets.Hosts {
 		hosts[i] = h.HostResponse.Host
 	}
 
-	labels := make([]kolide.Label, len(responseBody.Targets.Labels))
+	labels := make([]*kolide.Label, len(responseBody.Targets.Labels))
 	for i, h := range responseBody.Targets.Labels {
 		labels[i] = h.Label
 	}

--- a/server/service/endpoint_campaigns.go
+++ b/server/service/endpoint_campaigns.go
@@ -133,6 +133,5 @@ func makeStreamDistributedQueryCampaignResultsHandler(svc kolide.Service, jwtKey
 		}
 
 		svc.StreamCampaignResults(ctx, conn, info.CampaignID)
-
 	})
 }

--- a/server/service/endpoint_hosts.go
+++ b/server/service/endpoint_hosts.go
@@ -12,7 +12,7 @@ import (
 // along with the host online status and the "display text" to be used when
 // rendering in the UI.
 type HostResponse struct {
-	kolide.Host
+	*kolide.Host
 	Status      kolide.HostStatus `json:"status"`
 	DisplayText string            `json:"display_text"`
 	Labels      []kolide.Label    `json:"labels,omitempty"`
@@ -20,7 +20,7 @@ type HostResponse struct {
 
 func hostResponseForHost(ctx context.Context, svc kolide.Service, host *kolide.Host) (*HostResponse, error) {
 	return &HostResponse{
-		Host:        *host,
+		Host:        host,
 		Status:      host.Status(time.Now()),
 		DisplayText: host.HostName,
 	}, nil

--- a/server/service/endpoint_labels.go
+++ b/server/service/endpoint_labels.go
@@ -172,7 +172,7 @@ func makeListHostsInLabelEndpoint(svc kolide.Service) endpoint.Endpoint {
 
 		hostResponses := make([]HostResponse, len(hosts))
 		for i, host := range hosts {
-			h, err := hostResponseForHost(ctx, svc, &host)
+			h, err := hostResponseForHost(ctx, svc, host)
 			if err != nil {
 				return listHostsResponse{Err: err}, nil
 			}

--- a/server/service/endpoint_targets.go
+++ b/server/service/endpoint_targets.go
@@ -29,7 +29,7 @@ type hostSearchResult struct {
 }
 
 type labelSearchResult struct {
-	kolide.Label
+	*kolide.Label
 	DisplayText string `json:"display_text"`
 	Count       int    `json:"count"`
 }

--- a/server/service/service_campaigns.go
+++ b/server/service/service_campaigns.go
@@ -190,8 +190,9 @@ func (svc service) StreamCampaignResults(ctx context.Context, conn *websocket.Co
 		metrics, err := svc.CountHostsInTargets(context.Background(), hostIDs, labelIDs, false)
 		if err != nil {
 			if err = conn.WriteJSONError("error retrieving target counts"); err != nil {
-				return errors.New("retrieve target counts")
+				return errors.Wrap(err, "retrieve target counts, write failed")
 			}
+			return errors.Wrap(err, "retrieve target counts")
 		}
 
 		totals := targetTotals{

--- a/server/service/service_hosts.go
+++ b/server/service/service_hosts.go
@@ -39,16 +39,9 @@ func (svc service) getHostDetails(ctx context.Context, host *kolide.Host) (*koli
 		return nil, errors.Wrap(err, "get labels for host")
 	}
 
-	packPtrs, err := svc.ds.ListPacksForHost(host.ID)
+	packs, err := svc.ds.ListPacksForHost(host.ID)
 	if err != nil {
 		return nil, errors.Wrap(err, "get packs for host")
-	}
-
-	// TODO refactor List* APIs to be consistent so we don't have to do this
-	// transformation
-	packs := make([]kolide.Pack, 0, len(packPtrs))
-	for _, p := range packPtrs {
-		packs = append(packs, *p)
 	}
 
 	return &kolide.HostDetail{Host: *host, Labels: labels, Packs: packs}, nil

--- a/server/service/service_hosts_test.go
+++ b/server/service/service_hosts_test.go
@@ -65,16 +65,16 @@ func TestHostDetails(t *testing.T) {
 
 	host := &kolide.Host{ID: 3}
 	ctx := context.Background()
-	expectedLabels := []kolide.Label{
+	expectedLabels := []*kolide.Label{
 		{
 			Name:        "foobar",
 			Description: "the foobar label",
 		},
 	}
-	ds.ListLabelsForHostFunc = func(hid uint) ([]kolide.Label, error) {
+	ds.ListLabelsForHostFunc = func(hid uint) ([]*kolide.Label, error) {
 		return expectedLabels, nil
 	}
-	expectedPacks := []kolide.Pack{
+	expectedPacks := []*kolide.Pack{
 		{
 			Name: "pack1",
 		},
@@ -83,13 +83,7 @@ func TestHostDetails(t *testing.T) {
 		},
 	}
 	ds.ListPacksForHostFunc = func(hid uint) ([]*kolide.Pack, error) {
-		packs := []*kolide.Pack{}
-		for _, p := range expectedPacks {
-			// Make pointer in inner scope
-			p2 := p
-			packs = append(packs, &p2)
-		}
-		return packs, nil
+		return expectedPacks, nil
 	}
 	ds.LoadHostSoftwareFunc = func(host *kolide.Host) error {
 		return nil

--- a/server/service/service_labels.go
+++ b/server/service/service_labels.go
@@ -90,11 +90,11 @@ func (svc service) DeleteLabelByID(ctx context.Context, id uint) error {
 	return svc.ds.DeleteLabel(label.Name)
 }
 
-func (svc service) ListHostsInLabel(ctx context.Context, lid uint, opt kolide.HostListOptions) ([]kolide.Host, error) {
+func (svc service) ListHostsInLabel(ctx context.Context, lid uint, opt kolide.HostListOptions) ([]*kolide.Host, error) {
 	return svc.ds.ListHostsInLabel(lid, opt)
 }
 
-func (svc service) ListLabelsForHost(ctx context.Context, hid uint) ([]kolide.Label, error) {
+func (svc service) ListLabelsForHost(ctx context.Context, hid uint) ([]*kolide.Label, error) {
 	return svc.ds.ListLabelsForHost(hid)
 }
 

--- a/server/service/service_targets.go
+++ b/server/service/service_targets.go
@@ -23,7 +23,7 @@ func (svc service) SearchTargets(ctx context.Context, query string, selectedHost
 	}
 
 	for _, h := range hosts {
-		results.Hosts = append(results.Hosts, *h)
+		results.Hosts = append(results.Hosts, h)
 	}
 
 	labels, err := svc.ds.SearchLabels(filter, query, selectedLabelIDs...)

--- a/server/service/service_targets_test.go
+++ b/server/service/service_targets_test.go
@@ -23,7 +23,7 @@ func TestSearchTargets(t *testing.T) {
 	hosts := []*kolide.Host{
 		{HostName: "foo.local"},
 	}
-	labels := []kolide.Label{
+	labels := []*kolide.Label{
 		{
 			Name:  "label foo",
 			Query: "query foo",
@@ -34,14 +34,14 @@ func TestSearchTargets(t *testing.T) {
 		assert.Equal(t, user, filter.User)
 		return hosts, nil
 	}
-	ds.SearchLabelsFunc = func(filter kolide.TeamFilter, query string, omit ...uint) ([]kolide.Label, error) {
+	ds.SearchLabelsFunc = func(filter kolide.TeamFilter, query string, omit ...uint) ([]*kolide.Label, error) {
 		assert.Equal(t, user, filter.User)
 		return labels, nil
 	}
 
 	results, err := svc.SearchTargets(ctx, "foo", nil, nil, false)
 	require.NoError(t, err)
-	assert.Equal(t, *hosts[0], results.Hosts[0])
+	assert.Equal(t, hosts[0], results.Hosts[0])
 	assert.Equal(t, labels[0], results.Labels[0])
 }
 
@@ -58,7 +58,7 @@ func TestSearchWithOmit(t *testing.T) {
 		assert.Equal(t, []uint{1, 2}, omit)
 		return nil, nil
 	}
-	ds.SearchLabelsFunc = func(filter kolide.TeamFilter, query string, omit ...uint) ([]kolide.Label, error) {
+	ds.SearchLabelsFunc = func(filter kolide.TeamFilter, query string, omit ...uint) ([]*kolide.Label, error) {
 		assert.Equal(t, user, filter.User)
 		assert.Equal(t, []uint{3, 4}, omit)
 		return nil, nil


### PR DESCRIPTION
Some datastore and service methods would return slices of structs,
rather than slices to pointers of structs (which most methods used).
Make this more consistent.