### PR TITLE
Implement add hosts to team by filters API

### DIFF
--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -478,6 +478,8 @@ This is the callback endpoint that the identity provider will use to send securi
 - [Get host by identifier](#get-host-by-identifier)
 - [Delete host](#delete-host)
 - [Refetch host](#refetch-host)
+- [Add hosts to team](#add-hosts-to-team)
+- [Add hosts to team by filters](#add-hosts-to-team-by-filters)
 
 ### List hosts
 
@@ -796,6 +798,84 @@ Flags the host details to be refetched the next time the host checks in for live
 #### Example
 
 `POST /api/v1/fleet/hosts/121/refetch`
+
+##### Default response
+
+`Status: 200`
+
+```
+{}
+```
+
+### Add hosts to team
+
+Add the hosts to the specified team, clearing their team assignment if `team_id` is `null`.
+
+`POST /api/v1/fleet/hosts/transfer`
+
+#### Parameters
+
+| Name    | Type            | In   | Description                                              |
+| ------- | --------------- | ---- | -------------------------------------------------------- |
+| team_id | integer or null | body | The ID of the team to assign. Clears team if empty/null. |
+| hosts   | list            | body | List of host IDs to assign.                              |
+
+#### Example
+
+`POST /api/v1/fleet/hosts/transfer`
+
+##### Request body
+
+```
+{
+  "team_id": 4,
+  "hosts": [ 1, 3, 4 ]
+}
+```
+
+##### Default response
+
+`Status: 200`
+
+```
+{}
+```
+
+### Add hosts to team by filters
+
+Add the hosts to the specified team, clearing their team assignment if `team_id` is `null`. All hosts matching the provided filters are transferred.
+
+`POST /api/v1/fleet/hosts/transfer/filter`
+
+#### Parameters
+
+| Name             | Type            | In   | Description                                              |
+| ---------------- | --------------- | ---- | -------------------------------------------------------- |
+| team_id          | integer or null | body | The ID of the team to assign. Clears team if empty/null. |
+| filters          | object          | body | Filters to apply when retrieving hosts                   |
+| filters.label_id | integer         | body | Only transfer hosts in this label.                       |
+| filters.query    | string          | body | Only transfer hosts matching this query string.          |
+| filters.status   | string          | body | Only transfer hosts matching this status.                |
+
+See the [List hosts](#list-hosts) documentation for more on the filters.
+
+`status` and `label_id` may not be provided in the same request.
+
+#### Example
+
+`POST /api/v1/fleet/hosts/transfer/filter`
+
+##### Request body
+
+```
+{
+  "team_id": 4,
+  "filters": {
+    "label_id": 8,
+    "query": "foobar"
+  }
+}
+```
 
 ##### Default response
 

--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -94,6 +94,10 @@ type HostService interface {
 	// AddHostsToTeam adds hosts to an existing team, clearing their team
 	// settings if teamID is nil.
 	AddHostsToTeam(ctx context.Context, teamID *uint, hostIDs []uint) error
+	// AddHostsToTeamByFilter adds hosts to an existing team, clearing their
+	// team settings if teamID is nil. Hosts are selected by the label and
+	// HostListOptions provided.
+	AddHostsToTeamByFilter(ctx context.Context, teamID *uint, opt HostListOptions, lid *uint) error
 }
 
 type HostListOptions struct {

--- a/server/service/endpoint_hosts.go
+++ b/server/service/endpoint_hosts.go
@@ -194,7 +194,7 @@ func makeDeleteHostEndpoint(svc kolide.Service) endpoint.Endpoint {
 ////////////////////////////////////////////////////////////////////////////////
 
 type addHostsToTeamRequest struct {
-	TeamID  uint   `json:"team_id"`
+	TeamID  *uint  `json:"team_id"`
 	HostIDs []uint `json:"hosts"`
 }
 
@@ -202,15 +202,54 @@ type addHostsToTeamResponse struct {
 	Err error `json:"error,omitempty"`
 }
 
+func (r addHostsToTeamResponse) error() error { return r.Err }
+
 func makeAddHostsToTeamEndpoint(svc kolide.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(addHostsToTeamRequest)
-		err := svc.AddHostsToTeam(ctx, &req.TeamID, req.HostIDs)
+		err := svc.AddHostsToTeam(ctx, req.TeamID, req.HostIDs)
 		if err != nil {
 			return addHostsToTeamResponse{Err: err}, nil
 		}
 
 		return addHostsToTeamResponse{}, err
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Add Hosts to Team by Filter
+////////////////////////////////////////////////////////////////////////////////
+
+type addHostsToTeamByFilterRequest struct {
+	TeamID  *uint `json:"team_id"`
+	Filters struct {
+		MatchQuery string            `json:"query"`
+		Status     kolide.HostStatus `json:"status"`
+		LabelID    *uint             `json:"label_id"`
+	} `json:"filters"`
+}
+
+type addHostsToTeamByFilterResponse struct {
+	Err error `json:"error,omitempty"`
+}
+
+func (r addHostsToTeamByFilterResponse) error() error { return r.Err }
+
+func makeAddHostsToTeamByFilterEndpoint(svc kolide.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(addHostsToTeamByFilterRequest)
+		listOpt := kolide.HostListOptions{
+			ListOptions: kolide.ListOptions{
+				MatchQuery: req.Filters.MatchQuery,
+			},
+			StatusFilter: req.Filters.Status,
+		}
+		err := svc.AddHostsToTeamByFilter(ctx, req.TeamID, listOpt, req.Filters.LabelID)
+		if err != nil {
+			return addHostsToTeamByFilterResponse{Err: err}, nil
+		}
+
+		return addHostsToTeamByFilterResponse{}, err
 	}
 }
 

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -98,6 +98,7 @@ type KolideEndpoints struct {
 	ListHosts                             endpoint.Endpoint
 	GetHostSummary                        endpoint.Endpoint
 	AddHostsToTeam                        endpoint.Endpoint
+	AddHostsToTeamByFilter                endpoint.Endpoint
 	SearchTargets                         endpoint.Endpoint
 	GetCertificate                        endpoint.Endpoint
 	ChangeEmail                           endpoint.Endpoint
@@ -202,6 +203,7 @@ func MakeKolideServerEndpoints(svc kolide.Service, jwtKey, urlPrefix string, lim
 		GetHostSummary:                        authenticatedUser(jwtKey, svc, makeGetHostSummaryEndpoint(svc)),
 		DeleteHost:                            authenticatedUser(jwtKey, svc, makeDeleteHostEndpoint(svc)),
 		AddHostsToTeam:                        authenticatedUser(jwtKey, svc, makeAddHostsToTeamEndpoint(svc)),
+		AddHostsToTeamByFilter:                authenticatedUser(jwtKey, svc, makeAddHostsToTeamByFilterEndpoint(svc)),
 		RefetchHost:                           authenticatedUser(jwtKey, svc, makeRefetchHostEndpoint(svc)),
 		CreateLabel:                           authenticatedUser(jwtKey, svc, makeCreateLabelEndpoint(svc)),
 		ModifyLabel:                           authenticatedUser(jwtKey, svc, makeModifyLabelEndpoint(svc)),
@@ -326,6 +328,7 @@ type kolideHandlers struct {
 	ListHosts                             http.Handler
 	GetHostSummary                        http.Handler
 	AddHostsToTeam                        http.Handler
+	AddHostsToTeamByFilter                http.Handler
 	SearchTargets                         http.Handler
 	GetCertificate                        http.Handler
 	ChangeEmail                           http.Handler
@@ -430,6 +433,7 @@ func makeKolideKitHandlers(e KolideEndpoints, opts []kithttp.ServerOption) *koli
 		ListHosts:                             newServer(e.ListHosts, decodeListHostsRequest),
 		GetHostSummary:                        newServer(e.GetHostSummary, decodeNoParamsRequest),
 		AddHostsToTeam:                        newServer(e.AddHostsToTeam, decodeAddHostsToTeamRequest),
+		AddHostsToTeamByFilter:                newServer(e.AddHostsToTeamByFilter, decodeAddHostsToTeamByFilterRequest),
 		SearchTargets:                         newServer(e.SearchTargets, decodeSearchTargetsRequest),
 		GetCertificate:                        newServer(e.GetCertificate, decodeNoParamsRequest),
 		ChangeEmail:                           newServer(e.ChangeEmail, decodeChangeEmailRequest),
@@ -648,6 +652,7 @@ func attachKolideAPIRoutes(r *mux.Router, h *kolideHandlers) {
 	r.Handle("/api/v1/fleet/hosts/identifier/{identifier}", h.HostByIdentifier).Methods("GET").Name("host_by_identifier")
 	r.Handle("/api/v1/fleet/hosts/{id}", h.DeleteHost).Methods("DELETE").Name("delete_host")
 	r.Handle("/api/v1/fleet/hosts/transfer", h.AddHostsToTeam).Methods("POST").Name("add_hosts_to_team")
+	r.Handle("/api/v1/fleet/hosts/transfer/filter", h.AddHostsToTeamByFilter).Methods("POST").Name("add_hosts_to_team_by_filter")
 	r.Handle("/api/v1/fleet/hosts/{id}/refetch", h.RefetchHost).Methods("POST").Name("refetch_host")
 
 	r.Handle("/api/v1/fleet/targets", h.SearchTargets).Methods("POST").Name("search_targets")

--- a/server/service/transport_hosts.go
+++ b/server/service/transport_hosts.go
@@ -55,3 +55,12 @@ func decodeAddHostsToTeamRequest(ctx context.Context, r *http.Request) (interfac
 	}
 	return req, nil
 }
+
+func decodeAddHostsToTeamByFilterRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	var req addHostsToTeamByFilterRequest
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, err
+	}
+	return req, nil
+}


### PR DESCRIPTION
- Add hosts to team using label, status, and query filters.
- Documentation (+ docs for regular add hosts to team).