### PR TITLE
Only run markdown link check when markdown files are edited

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,5 +9,6 @@ jobs:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
+        check-modified-files-only: 'yes'
         use-quiet-mode: 'yes'
         config-file: .github/workflows/markdown-link-check-config.json


### PR DESCRIPTION
- Set `check-modified-files-only` to `'yes'`
  - This is so we only check modified markdown files instead of checking all markdown files.

From the Markdown Link Check GitHub action docs:
> When you use this variable, the action finds modififed files between two commits:
> - latest commit in you PR
> - latest commit in the `master` branch. If you are suing a different branch to merge PRs, specify the branch using base-branch.

- This means that the Markdown Link Check won't be run on PRs to the `teams` branch. I think this is ok because any broken links will be caught when `teams` is merged into `master`.
-  The `base-branch` option will have to be set to `main` when the fleetdm/fleet repo changes `master` to `main`

Resolves #868 