### PR TITLE
Teams grouping in Select Targets Dropdown

### DIFF
--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/SelectTargetsMenu.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/SelectTargetsMenu.jsx
@@ -99,13 +99,29 @@ const SelectTargetsMenuWrapper = (
       return targetsOutput;
     };
 
+    debugger;
+
     return (
       <div className={baseClass}>
         <div className={`${baseClass}__options`}>
-          {renderTargets("all")}
-          {renderTargets("teams")}
-          {renderTargets("labels")}
-          {renderTargets("hosts")}
+          {"all" === "all" ? (
+            <>
+              <div className={`${baseClass}__no-hosts`}>
+                <div className={`${baseClass}__no-hosts-heading`}>
+                  You have no hosts to run this query against.
+                </div>
+                Expecting to see hosts? Try again in a few seconds as the system
+                catches up.
+              </div>
+            </>
+          ) : (
+            <>
+              {renderTargets("all")}
+              {renderTargets("teams")}
+              {renderTargets("labels")}
+              {renderTargets("hosts")}
+            </>
+          )}
         </div>
         <TargetDetails
           target={moreInfoTarget}

--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/SelectTargetsMenu.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/SelectTargetsMenu.jsx
@@ -103,6 +103,7 @@ const SelectTargetsMenuWrapper = (
       <div className={baseClass}>
         <div className={`${baseClass}__options`}>
           {renderTargets("all")}
+          {renderTargets("teams")}
           {renderTargets("labels")}
           {renderTargets("hosts")}
         </div>

--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/SelectTargetsMenu.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/SelectTargetsMenu.jsx
@@ -99,7 +99,7 @@ const SelectTargetsMenuWrapper = (
       return targetsOutput;
     };
 
-    const hasHostTargets = (options) => {
+    const hasHostTargets = () => {
       return options.find((option) => option.count !== 0) !== undefined;
     };
 

--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/SelectTargetsMenu.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/SelectTargetsMenu.jsx
@@ -99,12 +99,21 @@ const SelectTargetsMenuWrapper = (
       return targetsOutput;
     };
 
-    debugger;
+    const hasHostTargets = (options) => {
+      return options.find((option) => option.count !== 0) !== undefined;
+    };
 
     return (
       <div className={baseClass}>
         <div className={`${baseClass}__options`}>
-          {"all" === "all" ? (
+          {hasHostTargets ? (
+            <>
+              {renderTargets("all")}
+              {renderTargets("teams")}
+              {renderTargets("labels")}
+              {renderTargets("hosts")}
+            </>
+          ) : (
             <>
               <div className={`${baseClass}__no-hosts`}>
                 <div className={`${baseClass}__no-hosts-heading`}>
@@ -113,13 +122,6 @@ const SelectTargetsMenuWrapper = (
                 Expecting to see hosts? Try again in a few seconds as the system
                 catches up.
               </div>
-            </>
-          ) : (
-            <>
-              {renderTargets("all")}
-              {renderTargets("teams")}
-              {renderTargets("labels")}
-              {renderTargets("hosts")}
             </>
           )}
         </div>

--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/_styles.scss
@@ -2,18 +2,16 @@
   &__type {
     padding: 0 8px $pad-xsmall;
     margin: $pad-medium 0 0;
-    text-transform: lowercase;
     font-weight: $bold;
-    font-size: $xx-small;
+    font-size: $x-small;
     color: $core-fleet-black;
-    letter-spacing: 0.5px;
     border-bottom: 1px solid $ui-fleet-blue-15;
 
     &::first-letter {
       text-transform: uppercase;
     }
     &:first-child {
-      margin: $pad-small 00;
+      margin: $pad-large 0 $pad-small 0;
     }
   }
 
@@ -24,7 +22,7 @@
     min-height: 500px;
     position: relative;
     z-index: 2;
-    padding: 0 $pad-small;
+    padding: 0 $pad-large;
     border-right: 1px solid $ui-fleet-blue-15;
     background-color: $core-white;
   }

--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/_styles.scss
@@ -1,16 +1,19 @@
 .target-list {
   &__type {
     padding: 0 8px $pad-xsmall;
-    margin: $pad-xxlarge 0 0;
-    text-transform: uppercase;
+    margin: $pad-medium 0 0;
+    text-transform: lowercase;
     font-weight: $bold;
     font-size: $xx-small;
     color: $core-fleet-black;
     letter-spacing: 0.5px;
     border-bottom: 1px solid $ui-fleet-blue-15;
 
+    &::first-letter {
+      text-transform: uppercase;
+    }
     &:first-child {
-      margin: 0;
+      margin: $pad-small 00;
     }
   }
 

--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/_styles.scss
@@ -21,9 +21,20 @@
     min-height: 500px;
     position: relative;
     z-index: 2;
-    padding: $pad-large $pad-medium;
+    padding: 0 $pad-small;
     border-right: 1px solid $ui-fleet-blue-15;
     background-color: $core-white;
+  }
+
+  &__no-hosts {
+    font-size: $x-small;
+    padding: $pad-large;
+  }
+
+  &__no-hosts-heading {
+    font-weight: $bold;
+    font-size: $small;
+    padding-bottom: $pad-medium;
   }
 
   &__spotlight {

--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/helpers.js
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/helpers.js
@@ -3,6 +3,19 @@ export const targetFilter = (targetType) => {
     return { name: "All Hosts" };
   }
 
+  // added code 5/26
+  // need option.name !== all host
+  if (targetType === "teams") {
+    return (option) => {
+      console.log("This is option:", option);
+      return (
+        (option.team_name !== null && option.name !== "All Hosts") ||
+        option.name !== "labels"
+      );
+    };
+  }
+
+  // previous working code
   if (targetType === "labels") {
     return (option) => {
       return option.target_type === targetType && option.name !== "All Hosts";

--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/helpers.js
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/helpers.js
@@ -3,7 +3,7 @@ export const targetFilter = (targetType) => {
     return { name: "All Hosts" };
   }
 
-  if (targetType !== "labels" || targetType === "teams") {
+  if (targetType === "labels" || targetType === "teams") {
     return (option) => {
       return option.target_type === targetType && option.name !== "All Hosts";
     };

--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/helpers.js
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/helpers.js
@@ -3,20 +3,7 @@ export const targetFilter = (targetType) => {
     return { name: "All Hosts" };
   }
 
-  // added code 5/26
-  // need option.name !== all host
-  if (targetType === "teams") {
-    return (option) => {
-      console.log("This is option:", option);
-      return (
-        (option.team_name !== null && option.name !== "All Hosts") ||
-        option.name !== "labels"
-      );
-    };
-  }
-
-  // previous working code
-  if (targetType === "labels") {
+  if (targetType !== "labels" || targetType === "teams") {
     return (option) => {
       return option.target_type === targetType && option.name !== "All Hosts";
     };

--- a/frontend/components/forms/fields/SelectTargetsDropdown/TargetOption/TargetOption.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/TargetOption/TargetOption.jsx
@@ -62,7 +62,9 @@ class TargetOption extends Component {
         >
           <div>
             <TargetIcon target={target} />
-            <span className={`${baseClass}__label-label`}>{displayText}</span>
+            <span className={`${baseClass}__label-label`}>
+              {displayText !== "All Hosts" ? displayText : "All hosts"}
+            </span>
           </div>
           {renderTargetDetail()}
         </button>

--- a/frontend/components/forms/fields/SelectTargetsDropdown/TargetOption/TargetOption.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/TargetOption/TargetOption.jsx
@@ -46,11 +46,9 @@ class TargetOption extends Component {
 
   render() {
     const { onMoreInfoClick, target } = this.props;
-    console.log("This is a target", target);
     const { display_text: displayText, target_type: targetType } = target;
     const { handleSelect, renderTargetDetail } = this;
     const wrapperClassName = classnames(`${baseClass}__wrapper`, {
-      // added 5/26
       "is-team": targetType === "teams",
       "is-label": targetType === "labels",
       "is-host": targetType === "hosts",

--- a/frontend/components/forms/fields/SelectTargetsDropdown/TargetOption/TargetOption.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/TargetOption/TargetOption.jsx
@@ -46,9 +46,12 @@ class TargetOption extends Component {
 
   render() {
     const { onMoreInfoClick, target } = this.props;
+    console.log("This is a target", target);
     const { display_text: displayText, target_type: targetType } = target;
     const { handleSelect, renderTargetDetail } = this;
     const wrapperClassName = classnames(`${baseClass}__wrapper`, {
+      // added 5/26
+      "is-team": targetType === "teams",
       "is-label": targetType === "labels",
       "is-host": targetType === "hosts",
     });

--- a/frontend/components/forms/fields/SelectTargetsDropdown/TargetOption/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/TargetOption/_styles.scss
@@ -18,7 +18,6 @@
 
   &__target-content,
   &__add-btn {
-    line-height: 34px;
     font-size: $small;
     font-weight: $regular;
     text-transform: none;
@@ -28,7 +27,6 @@
   &__add-btn::after {
     content: url("../assets/images/icon-plus-circle-16x16@2x.png");
     transform: scale(0.5);
-    margin-top: 8px;
     border: none;
   }
 
@@ -47,7 +45,6 @@
     line-height: 16px;
     font-weight: bold;
     padding: 2px 10px;
-    margin-right: 12px;
   }
 
   &__icon {
@@ -81,7 +78,7 @@
 
   &__label-label {
     color: $core-fleet-black;
-    font-size: $x-small;
+    font-size: $xx-small;
     margin-left: $pad-small;
 
     .all-hosts {

--- a/frontend/components/forms/fields/SelectTargetsDropdown/TargetOption/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/TargetOption/_styles.scss
@@ -13,7 +13,7 @@
     align-content: stretch;
     cursor: default;
     border-radius: 8px;
-    padding: $pad-xsmall 8px;
+    padding: 0 $pad-xsmall;
   }
 
   &__target-content,

--- a/frontend/components/forms/fields/SelectTargetsDropdown/TargetOption/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/TargetOption/_styles.scss
@@ -53,6 +53,7 @@
   &__icon {
     color: $core-fleet-black;
     font-size: $small;
+    margin-left: $pad-small;
 
     &--online {
       color: $core-fleet-black;

--- a/frontend/components/forms/fields/SelectTargetsDropdown/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/_styles.scss
@@ -69,7 +69,8 @@
 
     .Select-input {
       height: 46px;
-      margin: 0 0 0 $pad-medium;
+      margin: 0;
+      padding: 0 0 0 $pad-medium;
 
       > input {
         line-height: 30px;

--- a/frontend/components/icons/KolideIcon/KolideIcon.jsx
+++ b/frontend/components/icons/KolideIcon/KolideIcon.jsx
@@ -8,7 +8,7 @@ export class KolideIcon extends Component {
   static propTypes = {
     className: PropTypes.string,
     fw: PropTypes.bool,
-    name: PropTypes.string.isRequired,
+    name: PropTypes.string,
     size: PropTypes.string,
     title: PropTypes.string,
   };

--- a/frontend/interfaces/target.js
+++ b/frontend/interfaces/target.js
@@ -1,5 +1,12 @@
 import PropTypes from "prop-types";
 import hostInterface from "interfaces/host";
 import labelInterface from "interfaces/label";
+// teamInterface added 5/26
+import teamInterface from "interfaces/team";
 
-export default PropTypes.oneOfType([hostInterface, labelInterface]);
+// teamInterface added 5/26
+export default PropTypes.oneOfType([
+  hostInterface,
+  labelInterface,
+  teamInterface,
+]);

--- a/frontend/kolide/entities/targets.js
+++ b/frontend/kolide/entities/targets.js
@@ -18,13 +18,12 @@ export default (client) => {
         )
         .then((response) => {
           const { targets } = response;
-          console.log("\n\n\n\n Targets: \n\n\n\n", targets);
+
           return {
             ...response,
             targets: [
               ...appendTargetTypeToTargets(targets.hosts, "hosts"),
               ...appendTargetTypeToTargets(targets.labels, "labels"),
-              // added 5/26
               ...appendTargetTypeToTargets(targets.teams, "teams"),
             ],
           };

--- a/frontend/kolide/entities/targets.js
+++ b/frontend/kolide/entities/targets.js
@@ -18,12 +18,14 @@ export default (client) => {
         )
         .then((response) => {
           const { targets } = response;
-
+          console.log("\n\n\n\n Targets: \n\n\n\n", targets);
           return {
             ...response,
             targets: [
               ...appendTargetTypeToTargets(targets.hosts, "hosts"),
               ...appendTargetTypeToTargets(targets.labels, "labels"),
+              // added 5/26
+              ...appendTargetTypeToTargets(targets.teams, "teams"),
             ],
           };
         });

--- a/frontend/redux/nodes/entities/targets/helpers.js
+++ b/frontend/redux/nodes/entities/targets/helpers.js
@@ -7,6 +7,10 @@ export const appendTargetTypeToTargets = (targets, targetType) => {
     if (targetType === "hosts") {
       return parseEntityFunc(target);
     }
+    // added 5/26 this is wrong, look into this
+    if (targetType === "teams") {
+      return parseEntityFunc(target);
+    }
 
     return {
       ...target,

--- a/frontend/redux/nodes/entities/targets/helpers.js
+++ b/frontend/redux/nodes/entities/targets/helpers.js
@@ -7,10 +7,6 @@ export const appendTargetTypeToTargets = (targets, targetType) => {
     if (targetType === "hosts") {
       return parseEntityFunc(target);
     }
-    // added 5/26 this is wrong, look into this
-    if (targetType === "teams") {
-      return parseEntityFunc(target);
-    }
 
     return {
       ...target,


### PR DESCRIPTION
- Renders Teams in Select targets dropdown

Here's a screenshot from Admin and Team observer.

![Screen Shot 2021-06-03 at 4 52 27 PM](https://user-images.githubusercontent.com/71795832/120710532-3fd01880-c48c-11eb-82ff-eb8d8a8c698a.png)
![Screen Shot 2021-06-03 at 4 53 08 PM](https://user-images.githubusercontent.com/71795832/120710530-3f378200-c48c-11eb-8dac-c566e71339bd.png)

 There is a no host rendering according to the new figma mock, but it cannot be reached until the API fix so that the targets in teams aren't reachable outside the user's team.
 `hasHostTargets` function conditionally renders the no hosts UI.

![Screen Shot 2021-06-03 at 5 00 11 PM](https://user-images.githubusercontent.com/71795832/120711368-4a3ee200-c48d-11eb-8aec-8e5038cde8e3.png)


Next steps:
Review from @noahtalerman 
Merge @RachelElysia 
New PR fixing API to not return hosts on teams the user is not a part of @zwass 
Final QA with various users (including a user with access to no host) @noahtalerman 