### PR TITLE
Update live query and targets APIs for Teams

### DIFF
--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -2575,10 +2575,13 @@ Runs the specified query as a live query on the specified hosts or group of host
 
 #### Parameters
 
-| Name     | Type   | In   | Description                                                                                                                                      |
-| -------- | ------ | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| query    | string | body | **Required.** The SQL of the query.                                                                                                              |
-| selected | object | body | **Required.** The desired targets for the query specified by ID. This object can contain `hosts` and/or `labels` properties. See examples below. |
+| Name     | Type    | In   | Description                                                                                                                                      |
+| -------- | ------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| query    | string  | body | The SQL if using a custom query.                                                                                                                 |
+| query_id | integer | body | The saved query (if any) that will be run. The `observer_can_run` property on the query effects which targets are included.                      |
+| selected | object  | body | **Required.** The desired targets for the query specified by ID. This object can contain `hosts` and/or `labels` properties. See examples below. |
+
+One of `query` and `query_id` must be specified.
 
 #### Example with one host targeted by ID
 
@@ -2666,10 +2669,13 @@ Runs the specified query as a live query on the specified hosts or group of host
 
 #### Parameters
 
-| Name     | Type   | In   | Description                                                                                                                                        |
-| -------- | ------ | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| query    | string | body | **Required.** The SQL of the query.                                                                                                                |
-| selected | object | body | **Required.** The desired targets for the query specified by name. This object can contain `hosts` and/or `labels` properties. See examples below. |
+| Name     | Type    | In   | Description                                                                                                                                        |
+| -------- | ------- | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| query    | string  | body | The SQL of the query.                                                                                                                              |
+| query_id | integer | body | The saved query (if any) that will be run. The `observer_can_run` property on the query effects which targets are included.                        |
+| selected | object  | body | **Required.** The desired targets for the query specified by name. This object can contain `hosts` and/or `labels` properties. See examples below. |
+
+One of `query` and `query_id` must be specified.
 
 #### Example with one host targeted by hostname
 
@@ -2679,7 +2685,7 @@ Runs the specified query as a live query on the specified hosts or group of host
 
 ```
 {
-  "query": "select instance_id from system_info",
+  "query_id": 1,
   "selected": {
     "hosts": [
       "macbook-pro.local",
@@ -3835,11 +3841,11 @@ The returned lists are filtered based on the hosts the requesting user has acces
 
 #### Parameters
 
-| Name             | Type    | In   | Description                                                                                                                                                        |
-| ---------------- | ------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| query            | string  | body | The search query. Searchable items include a host's hostname or IPv4 address and labels.                                                                           |
-| selected         | object  | body | The targets already selected. The object includes a `hosts` property which contains a list of host IDs and a `labels` property which contains a list of label IDs. |
-| include_observer | boolean | body | Whether to include hosts that the user only has `observer` permission on.                                                                                          |
+| Name     | Type    | In   | Description                                                                                                                                                        |
+| -------- | ------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| query    | string  | body | The search query. Searchable items include a host's hostname or IPv4 address and labels.                                                                           |
+| query_id | integer | body | The saved query (if any) that will be run. The `observer_can_run` property on the query and the user's roles effect which targets are included.                    |
+| selected | object  | body | The targets already selected. The object includes a `hosts` property which contains a list of host IDs and a `labels` property which contains a list of label IDs. |
 
 #### Example
 

--- a/server/kolide/campaigns.go
+++ b/server/kolide/campaigns.go
@@ -37,13 +37,14 @@ type CampaignStore interface {
 // CampaignService defines the distributed query campaign related service
 // methods
 type CampaignService interface {
-	// NewDistributedQueryCampaign creates a new distributed query campaign
-	// with the provided query and host/label targets (specified by name).
-	NewDistributedQueryCampaignByNames(ctx context.Context, queryString string, hosts []string, labels []string) (*DistributedQueryCampaign, error)
+	// NewDistributedQueryCampaign creates a new distributed query campaign with
+	// the provided query (or the query referenced by ID) and host/label targets
+	// (specified by name).
+	NewDistributedQueryCampaignByNames(ctx context.Context, queryString string, queryID *uint, hosts []string, labels []string) (*DistributedQueryCampaign, error)
 
 	// NewDistributedQueryCampaign creates a new distributed query campaign
-	// with the provided query and host/label targets
-	NewDistributedQueryCampaign(ctx context.Context, queryString string, hosts []uint, labels []uint) (*DistributedQueryCampaign, error)
+	// with the provided query (or the query referenced by ID) and host/label targets
+	NewDistributedQueryCampaign(ctx context.Context, queryString string, queryID *uint, hosts []uint, labels []uint) (*DistributedQueryCampaign, error)
 
 	// StreamCampaignResults streams updates with query results and
 	// expected host totals over the provided websocket. Note that the type

--- a/server/kolide/targets.go
+++ b/server/kolide/targets.go
@@ -32,14 +32,18 @@ type TargetMetrics struct {
 }
 
 type TargetService interface {
-	// SearchTargets will accept a search query, a slice of IDs of hosts to omit,
-	// and a slice of IDs of labels to omit, and it will return a set of targets
-	// (hosts and label) which match the supplied search query.
-	SearchTargets(ctx context.Context, query string, selectedHostIDs []uint, selectedLabelIDs []uint, includeObserver bool) (*TargetSearchResults, error)
+	// SearchTargets will accept a search query, a slice of IDs of hosts to
+	// omit, and a slice of IDs of labels to omit, and it will return a set of
+	// targets (hosts and label) which match the supplied search query. If the
+	// query ID is provided and the referenced query allows observers to run,
+	// targets will include hosts that the user has observer role for.
+	SearchTargets(ctx context.Context, searchQuery string, queryID *uint, selectedHostIDs []uint, selectedLabelIDs []uint) (*TargetSearchResults, error)
 
 	// CountHostsInTargets returns the metrics of the hosts in the provided
-	// label and explicit host IDs.
-	CountHostsInTargets(ctx context.Context, hostIDs []uint, labelIDs []uint, includeObserver bool) (*TargetMetrics, error)
+	// label and explicit host IDs. If the query ID is provided and the
+	// referenced query allows observers to run, targets will include hosts that
+	// the user has observer role for.
+	CountHostsInTargets(ctx context.Context, queryID *uint, hostIDs []uint, labelIDs []uint) (*TargetMetrics, error)
 }
 
 type TargetStore interface {

--- a/server/service/client_live_query.go
+++ b/server/service/client_live_query.go
@@ -61,7 +61,7 @@ func (h *LiveQueryResultsHandler) Status() *campaignStatus {
 // LiveQuery creates a new live query and begins streaming results.
 func (c *Client) LiveQuery(query string, labels []string, hosts []string) (*LiveQueryResultsHandler, error) {
 	req := createDistributedQueryCampaignByNamesRequest{
-		Query:    query,
+		QuerySQL: query,
 		Selected: distributedQueryCampaignTargetsByNames{Labels: labels, Hosts: hosts},
 	}
 	response, err := c.AuthenticatedDo("POST", "/api/v1/fleet/queries/run_by_names", "", req)

--- a/server/service/client_targets.go
+++ b/server/service/client_targets.go
@@ -11,7 +11,7 @@ import (
 // SearchTargets searches for the supplied targets in the Fleet instance.
 func (c *Client) SearchTargets(query string, selectedHostIDs, selectedLabelIDs []uint) (*kolide.TargetSearchResults, error) {
 	req := searchTargetsRequest{
-		Query: query,
+		MatchQuery: query,
 		Selected: struct {
 			Labels []uint `json:"labels"`
 			Hosts  []uint `json:"hosts"`

--- a/server/service/endpoint_campaigns.go
+++ b/server/service/endpoint_campaigns.go
@@ -18,7 +18,8 @@ import (
 ////////////////////////////////////////////////////////////////////////////////
 
 type createDistributedQueryCampaignRequest struct {
-	Query    string                          `json:"query"`
+	QuerySQL string                          `json:"query"`
+	QueryID  *uint                           `json:"query_id"`
 	Selected distributedQueryCampaignTargets `json:"selected"`
 }
 
@@ -37,7 +38,7 @@ func (r createDistributedQueryCampaignResponse) error() error { return r.Err }
 func makeCreateDistributedQueryCampaignEndpoint(svc kolide.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(createDistributedQueryCampaignRequest)
-		campaign, err := svc.NewDistributedQueryCampaign(ctx, req.Query, req.Selected.Hosts, req.Selected.Labels)
+		campaign, err := svc.NewDistributedQueryCampaign(ctx, req.QuerySQL, req.QueryID, req.Selected.Hosts, req.Selected.Labels)
 		if err != nil {
 			return createDistributedQueryCampaignResponse{Err: err}, nil
 		}
@@ -50,7 +51,8 @@ func makeCreateDistributedQueryCampaignEndpoint(svc kolide.Service) endpoint.End
 ////////////////////////////////////////////////////////////////////////////////
 
 type createDistributedQueryCampaignByNamesRequest struct {
-	Query    string                                 `json:"query"`
+	QuerySQL string                                 `json:"query"`
+	QueryID  *uint                                  `json:"query_id"`
 	Selected distributedQueryCampaignTargetsByNames `json:"selected"`
 }
 
@@ -62,7 +64,7 @@ type distributedQueryCampaignTargetsByNames struct {
 func makeCreateDistributedQueryCampaignByNamesEndpoint(svc kolide.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(createDistributedQueryCampaignByNamesRequest)
-		campaign, err := svc.NewDistributedQueryCampaignByNames(ctx, req.Query, req.Selected.Hosts, req.Selected.Labels)
+		campaign, err := svc.NewDistributedQueryCampaignByNames(ctx, req.QuerySQL, req.QueryID, req.Selected.Hosts, req.Selected.Labels)
 		if err != nil {
 			return createDistributedQueryCampaignResponse{Err: err}, nil
 		}

--- a/server/service/endpoint_packs.go
+++ b/server/service/endpoint_packs.go
@@ -41,7 +41,7 @@ func packResponseForPack(ctx context.Context, svc kolide.Service, pack kolide.Pa
 		return nil, err
 	}
 
-	hostMetrics, err := svc.CountHostsInTargets(ctx, hosts, labelIDs, false)
+	hostMetrics, err := svc.CountHostsInTargets(ctx, nil, hosts, labelIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/server/service/endpoint_targets.go
+++ b/server/service/endpoint_targets.go
@@ -13,14 +13,15 @@ import (
 ////////////////////////////////////////////////////////////////////////////////
 
 type searchTargetsRequest struct {
-	Query    string `json:"query"`
+	// MatchQuery is the query SQL
+	MatchQuery string `json:"query"`
+	// QueryID is the ID of a saved query to run (used to determine if this is a
+	// query that observers can run).
+	QueryID  *uint `json:"query_id"`
 	Selected struct {
 		Labels []uint `json:"labels"`
 		Hosts  []uint `json:"hosts"`
 	} `json:"selected"`
-	// IncludeObserver determines whether targets for which the user is only an
-	// observer should be included.
-	IncludeObserver bool `json:"include_observer"`
 }
 
 type hostSearchResult struct {
@@ -54,7 +55,7 @@ func makeSearchTargetsEndpoint(svc kolide.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(searchTargetsRequest)
 
-		results, err := svc.SearchTargets(ctx, req.Query, req.Selected.Hosts, req.Selected.Labels, req.IncludeObserver)
+		results, err := svc.SearchTargets(ctx, req.MatchQuery, req.QueryID, req.Selected.Hosts, req.Selected.Labels)
 		if err != nil {
 			return searchTargetsResponse{Err: err}, nil
 		}
@@ -86,7 +87,7 @@ func makeSearchTargetsEndpoint(svc kolide.Service) endpoint.Endpoint {
 			)
 		}
 
-		metrics, err := svc.CountHostsInTargets(ctx, req.Selected.Hosts, req.Selected.Labels, req.IncludeObserver)
+		metrics, err := svc.CountHostsInTargets(ctx, req.QueryID, req.Selected.Hosts, req.Selected.Labels)
 		if err != nil {
 			return searchTargetsResponse{Err: err}, nil
 		}

--- a/server/service/logging_campaigns.go
+++ b/server/service/logging_campaigns.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fleetdm/fleet/server/websocket"
 )
 
-func (mw loggingMiddleware) NewDistributedQueryCampaign(ctx context.Context, queryString string, hosts []uint, labels []uint) (*kolide.DistributedQueryCampaign, error) {
+func (mw loggingMiddleware) NewDistributedQueryCampaign(ctx context.Context, querySQL string, queryID *uint, hosts []uint, labels []uint) (*kolide.DistributedQueryCampaign, error) {
 	var (
 		loggedInUser = "unauthenticated"
 		campaign     *kolide.DistributedQueryCampaign
@@ -28,16 +28,17 @@ func (mw loggingMiddleware) NewDistributedQueryCampaign(ctx context.Context, que
 			"method", "NewDistributedQueryCampaign",
 			"err", err,
 			"user", loggedInUser,
-			"sql", queryString,
+			"sql", querySQL,
+			"query_id", queryID,
 			"numHosts", numHosts,
 			"took", time.Since(begin),
 		)
 	}(time.Now())
-	campaign, err = mw.Service.NewDistributedQueryCampaign(ctx, queryString, hosts, labels)
+	campaign, err = mw.Service.NewDistributedQueryCampaign(ctx, querySQL, queryID, hosts, labels)
 	return campaign, err
 }
 
-func (mw loggingMiddleware) NewDistributedQueryCampaignByNames(ctx context.Context, queryString string, hosts []string, labels []string) (*kolide.DistributedQueryCampaign, error) {
+func (mw loggingMiddleware) NewDistributedQueryCampaignByNames(ctx context.Context, querySQL string, queryID *uint, hosts []string, labels []string) (*kolide.DistributedQueryCampaign, error) {
 	var (
 		loggedInUser = "unauthenticated"
 		campaign     *kolide.DistributedQueryCampaign
@@ -56,11 +57,13 @@ func (mw loggingMiddleware) NewDistributedQueryCampaignByNames(ctx context.Conte
 			"method", "NewDistributedQueryCampaignByNames",
 			"err", err,
 			"user", loggedInUser,
+			"sql", querySQL,
+			"query_id", queryID,
 			"numHosts", numHosts,
 			"took", time.Since(begin),
 		)
 	}(time.Now())
-	campaign, err = mw.Service.NewDistributedQueryCampaignByNames(ctx, queryString, hosts, labels)
+	campaign, err = mw.Service.NewDistributedQueryCampaignByNames(ctx, querySQL, queryID, hosts, labels)
 	return campaign, err
 }
 

--- a/server/service/service_osquery_test.go
+++ b/server/service/service_osquery_test.go
@@ -1171,7 +1171,7 @@ func TestNewDistributedQueryCampaign(t *testing.T) {
 		},
 	})
 	q := "select year, month, day, hour, minutes, seconds from time"
-	campaign, err := svc.NewDistributedQueryCampaign(viewerCtx, q, []uint{2}, []uint{1})
+	campaign, err := svc.NewDistributedQueryCampaign(viewerCtx, q, nil, []uint{2}, []uint{1})
 	require.Nil(t, err)
 	assert.Equal(t, gotQuery.ID, gotCampaign.QueryID)
 	assert.Equal(t, []*kolide.DistributedQueryCampaignTarget{

--- a/server/service/service_queries.go
+++ b/server/service/service_queries.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fleetdm/fleet/server/contexts/viewer"
 	"github.com/fleetdm/fleet/server/kolide"
+	"github.com/fleetdm/fleet/server/ptr"
 	"github.com/pkg/errors"
 )
 
@@ -95,7 +96,7 @@ func (svc service) NewQuery(ctx context.Context, p kolide.QueryPayload) (*kolide
 
 	vc, ok := viewer.FromContext(ctx)
 	if ok {
-		query.AuthorID = uintPtr(vc.UserID())
+		query.AuthorID = ptr.Uint(vc.UserID())
 		query.AuthorName = vc.FullName()
 	}
 

--- a/server/service/service_targets_test.go
+++ b/server/service/service_targets_test.go
@@ -39,7 +39,7 @@ func TestSearchTargets(t *testing.T) {
 		return labels, nil
 	}
 
-	results, err := svc.SearchTargets(ctx, "foo", nil, nil, false)
+	results, err := svc.SearchTargets(ctx, "foo", nil, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, hosts[0], results.Hosts[0])
 	assert.Equal(t, labels[0], results.Labels[0])
@@ -64,6 +64,6 @@ func TestSearchWithOmit(t *testing.T) {
 		return nil, nil
 	}
 
-	_, err = svc.SearchTargets(ctx, "foo", []uint{1, 2}, []uint{3, 4}, false)
+	_, err = svc.SearchTargets(ctx, "foo", nil, []uint{1, 2}, []uint{3, 4})
 	require.Nil(t, err)
 }

--- a/server/service/transport_targets_test.go
+++ b/server/service/transport_targets_test.go
@@ -18,7 +18,7 @@ func TestDecodeSearchTargetsRequest(t *testing.T) {
 		assert.Nil(t, err)
 
 		params := r.(searchTargetsRequest)
-		assert.Equal(t, "bar", params.Query)
+		assert.Equal(t, "bar", params.MatchQuery)
 		assert.Len(t, params.Selected.Hosts, 3)
 		assert.Len(t, params.Selected.Labels, 2)
 	}).Methods("POST")


### PR DESCRIPTION
- Take query_id in live query and target APIs.
- Use query_id to determine observer targets.
- Update documentation.