### PR TITLE
Add link to release blog post in Software inventory documentation

### DIFF
--- a/docs/3-Deployment/2-Configuration.md
+++ b/docs/3-Deployment/2-Configuration.md
@@ -1436,4 +1436,4 @@ When enabled, Fleet will store a "software inventory" for hosts, updated along w
 
 This is currently feature flagged because we would like to evaluate the performance characteristics on larger deployments.
 
-To read more about the software inventory feature, [check out the Fleet 3.11.0 release blog post](https://medium.com/fleetdm/fleet-3-11-0-released-with-software-inventory-25d5a1ee19c).
+To read more about the software inventory feature, [check out the Fleet 3.11.0 release blog post](https://medium.com/fleetdm/fleet-3-11-0-released-with-software-inventory-25d5a1efe19c).

--- a/docs/3-Deployment/2-Configuration.md
+++ b/docs/3-Deployment/2-Configuration.md
@@ -1432,6 +1432,8 @@ Feature flags on the server are controlled by environment variables prefixed wit
 
 Enable by setting the environment variable `FLEET_BETA_SOFTWARE_INVENTORY=1`.
 
-When enabled, Fleet will store a "software inventory" for hosts, updated along with the other host details. Note that it will take some time for the data to be available after setting this flag (it will be updated when the host details are next updated, configurable by [--osquery_detail_update_interval](#osquery_detail_update_interval)).
+When enabled, Fleet will store a "software inventory" for hosts, updated along with the other host vitals. Note that it will take some time for the data to be available after setting this flag (it will be updated when the host details are next updated, configurable by [--osquery_detail_update_interval](#osquery_detail_update_interval)).
 
 This is currently feature flagged because we would like to evaluate the performance characteristics on larger deployments.
+
+To read more about the software inventory feature, [check out the Fleet 3.11.0 release blog post](https://medium.com/fleetdm/fleet-3-11-0-released-with-software-inventory-25d5a1ee19c).


### PR DESCRIPTION
- Add link to "Fleet 3.11.0 released with software inventory" to location in docs where software inventory is described.
- Change "host details" to "host vitals"