### PR TITLE
Add support for Teams in targets and live queries

### DIFF
--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -2575,11 +2575,11 @@ Runs the specified query as a live query on the specified hosts or group of host
 
 #### Parameters
 
-| Name     | Type    | In   | Description                                                                                                                                      |
-| -------- | ------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| query    | string  | body | The SQL if using a custom query.                                                                                                                 |
-| query_id | integer | body | The saved query (if any) that will be run. The `observer_can_run` property on the query effects which targets are included.                      |
-| selected | object  | body | **Required.** The desired targets for the query specified by ID. This object can contain `hosts` and/or `labels` properties. See examples below. |
+| Name     | Type    | In   | Description                                                                                                                                                |
+| -------- | ------- | ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| query    | string  | body | The SQL if using a custom query.                                                                                                                           |
+| query_id | integer | body | The saved query (if any) that will be run. The `observer_can_run` property on the query effects which targets are included.                                |
+| selected | object  | body | **Required.** The desired targets for the query specified by ID. This object can contain `hosts`, `labels`, and/or `teams` properties. See examples below. |
 
 One of `query` and `query_id` must be specified.
 
@@ -2669,11 +2669,11 @@ Runs the specified query as a live query on the specified hosts or group of host
 
 #### Parameters
 
-| Name     | Type    | In   | Description                                                                                                                                        |
-| -------- | ------- | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| query    | string  | body | The SQL of the query.                                                                                                                              |
-| query_id | integer | body | The saved query (if any) that will be run. The `observer_can_run` property on the query effects which targets are included.                        |
-| selected | object  | body | **Required.** The desired targets for the query specified by name. This object can contain `hosts` and/or `labels` properties. See examples below. |
+| Name     | Type    | In   | Description                                                                                                                                                  |
+| -------- | ------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| query    | string  | body | The SQL of the query.                                                                                                                                        |
+| query_id | integer | body | The saved query (if any) that will be run. The `observer_can_run` property on the query effects which targets are included.                                  |
+| selected | object  | body | **Required.** The desired targets for the query specified by name. This object can contain `hosts`, `labels`, and/or `teams` properties. See examples below. |
 
 One of `query` and `query_id` must be specified.
 
@@ -3841,11 +3841,11 @@ The returned lists are filtered based on the hosts the requesting user has acces
 
 #### Parameters
 
-| Name     | Type    | In   | Description                                                                                                                                                        |
-| -------- | ------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| query    | string  | body | The search query. Searchable items include a host's hostname or IPv4 address and labels.                                                                           |
-| query_id | integer | body | The saved query (if any) that will be run. The `observer_can_run` property on the query and the user's roles effect which targets are included.                    |
-| selected | object  | body | The targets already selected. The object includes a `hosts` property which contains a list of host IDs and a `labels` property which contains a list of label IDs. |
+| Name     | Type    | In   | Description                                                                                                                                                                |
+| -------- | ------- | ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| query    | string  | body | The search query. Searchable items include a host's hostname or IPv4 address and labels.                                                                                   |
+| query_id | integer | body | The saved query (if any) that will be run. The `observer_can_run` property on the query and the user's roles effect which targets are included.                            |
+| selected | object  | body | The targets already selected. The object includes a `hosts` property which contains a list of host IDs, a `labels` with label IDs and/or a `teams` property with team IDs. |
 
 #### Example
 
@@ -3960,6 +3960,19 @@ The returned lists are filtered based on the hosts the requesting user has acces
         "host_count": 5,
         "display_text": "All Hosts",
         "count": 5
+      }
+    ],
+    "teams": [
+      {
+        "id": 1,
+        "created_at": "2021-05-27T20:02:20Z",
+        "name": "Client Platform Engineering",
+        "description": "",
+        "agent_options": null,
+        "user_count": 4,
+        "host_count": 2,
+        "display_text": "Client Platform Engineering",
+        "count": 2
       }
     ]
   },

--- a/server/datastore/datastore.go
+++ b/server/datastore/datastore.go
@@ -99,6 +99,7 @@ var TestFunctions = [...]func(*testing.T, kolide.Datastore){
 	testTeamGetSetDelete,
 	testTeamUsers,
 	testTeamListTeams,
+	testTeamSearchTeams,
 	testUserTeams,
 	testUserCreateWithTeams,
 	testSaveHostSoftware,

--- a/server/datastore/datastore_targets.go
+++ b/server/datastore/datastore_targets.go
@@ -24,7 +24,7 @@ func testCountHostsInTargets(t *testing.T, ds kolide.Datastore) {
 	mockClock := clock.NewMockClock()
 
 	hostCount := 0
-	initHost := func(seenTime time.Time, distributedInterval uint, configTLSRefresh uint) *kolide.Host {
+	initHost := func(seenTime time.Time, distributedInterval uint, configTLSRefresh uint, teamID *uint) *kolide.Host {
 		hostCount += 1
 		h, err := ds.NewHost(&kolide.Host{
 			OsqueryHostID:       strconv.Itoa(hostCount),
@@ -34,19 +34,27 @@ func testCountHostsInTargets(t *testing.T, ds kolide.Datastore) {
 			NodeKey:             strconv.Itoa(hostCount),
 			DistributedInterval: distributedInterval,
 			ConfigTLSRefresh:    configTLSRefresh,
+			TeamID:              teamID,
 		})
 		require.Nil(t, err)
 		require.Nil(t, ds.MarkHostSeen(h, seenTime))
 		return h
 	}
 
-	h1 := initHost(mockClock.Now().Add(-1*time.Second), 10, 60)
-	h2 := initHost(mockClock.Now().Add(-1*time.Hour), 30, 7200)
-	h3 := initHost(mockClock.Now().Add(-5*time.Second), 20, 20)
-	h4 := initHost(mockClock.Now().Add(-47*time.Second), 10, 10)
-	h5 := initHost(mockClock.Now(), 5, 5)
+	team1, err := ds.NewTeam(&kolide.Team{Name: "team1"})
+	require.NoError(t, err)
+	team2, err := ds.NewTeam(&kolide.Team{Name: "team2"})
+	require.NoError(t, err)
+	team3, err := ds.NewTeam(&kolide.Team{Name: "team3"})
+	require.NoError(t, err)
+
+	h1 := initHost(mockClock.Now().Add(-1*time.Second), 10, 60, &team1.ID)
+	h2 := initHost(mockClock.Now().Add(-1*time.Hour), 30, 7200, &team2.ID)
+	h3 := initHost(mockClock.Now().Add(-5*time.Second), 20, 20, &team2.ID)
+	h4 := initHost(mockClock.Now().Add(-47*time.Second), 10, 10, &team2.ID)
+	h5 := initHost(mockClock.Now(), 5, 5, nil)
 	const thirtyDaysAndAMinuteAgo = -1 * (30*24*60 + 1)
-	h6 := initHost(mockClock.Now().Add(thirtyDaysAndAMinuteAgo*time.Minute), 3600, 3600)
+	h6 := initHost(mockClock.Now().Add(thirtyDaysAndAMinuteAgo*time.Minute), 3600, 3600, nil)
 
 	l1 := kolide.LabelSpec{
 		ID:    1,
@@ -58,8 +66,7 @@ func testCountHostsInTargets(t *testing.T, ds kolide.Datastore) {
 		Name:  "label bar",
 		Query: "query bar",
 	}
-	err := ds.ApplyLabelSpecs([]*kolide.LabelSpec{&l1, &l2})
-	require.Nil(t, err)
+	require.NoError(t, ds.ApplyLabelSpecs([]*kolide.LabelSpec{&l1, &l2}))
 
 	for _, h := range []*kolide.Host{h1, h2, h3, h6} {
 		err = ds.RecordLabelQueryExecutions(h, map[uint]bool{l1.ID: true}, mockClock.Now())
@@ -71,51 +78,79 @@ func testCountHostsInTargets(t *testing.T, ds kolide.Datastore) {
 		assert.Nil(t, err)
 	}
 
-	metrics, err := ds.CountHostsInTargets(filter, nil, []uint{l1.ID, l2.ID}, mockClock.Now())
+	metrics, err := ds.CountHostsInTargets(filter, kolide.HostTargets{LabelIDs: []uint{l1.ID, l2.ID}}, mockClock.Now())
 	require.Nil(t, err)
 	assert.Equal(t, uint(6), metrics.TotalHosts)
 	assert.Equal(t, uint(2), metrics.OfflineHosts)
 	assert.Equal(t, uint(3), metrics.OnlineHosts)
 	assert.Equal(t, uint(1), metrics.MissingInActionHosts)
 
-	metrics, err = ds.CountHostsInTargets(filter, []uint{h1.ID, h2.ID}, []uint{l1.ID, l2.ID}, mockClock.Now())
+	metrics, err = ds.CountHostsInTargets(filter, kolide.HostTargets{HostIDs: []uint{h1.ID, h2.ID}, LabelIDs: []uint{l1.ID, l2.ID}}, mockClock.Now())
 	require.Nil(t, err)
 	assert.Equal(t, uint(6), metrics.TotalHosts)
 	assert.Equal(t, uint(2), metrics.OfflineHosts)
 	assert.Equal(t, uint(3), metrics.OnlineHosts)
 	assert.Equal(t, uint(1), metrics.MissingInActionHosts)
 
-	metrics, err = ds.CountHostsInTargets(filter, []uint{h1.ID, h2.ID}, nil, mockClock.Now())
+	metrics, err = ds.CountHostsInTargets(filter, kolide.HostTargets{HostIDs: []uint{h1.ID, h2.ID}, LabelIDs: []uint{l1.ID, l2.ID}, TeamIDs: []uint{team1.ID, team2.ID}}, mockClock.Now())
+	require.Nil(t, err)
+	assert.Equal(t, uint(6), metrics.TotalHosts)
+	assert.Equal(t, uint(2), metrics.OfflineHosts)
+	assert.Equal(t, uint(3), metrics.OnlineHosts)
+	assert.Equal(t, uint(1), metrics.MissingInActionHosts)
+
+	metrics, err = ds.CountHostsInTargets(filter, kolide.HostTargets{HostIDs: []uint{h1.ID, h2.ID}}, mockClock.Now())
 	require.Nil(t, err)
 	assert.Equal(t, uint(2), metrics.TotalHosts)
 	assert.Equal(t, uint(1), metrics.OnlineHosts)
 	assert.Equal(t, uint(1), metrics.OfflineHosts)
 	assert.Equal(t, uint(0), metrics.MissingInActionHosts)
 
-	metrics, err = ds.CountHostsInTargets(filter, []uint{h1.ID}, []uint{l2.ID}, mockClock.Now())
+	metrics, err = ds.CountHostsInTargets(filter, kolide.HostTargets{HostIDs: []uint{h1.ID, h2.ID}, TeamIDs: []uint{team2.ID}}, mockClock.Now())
+	require.Nil(t, err)
+	assert.Equal(t, uint(4), metrics.TotalHosts)
+	assert.Equal(t, uint(2), metrics.OnlineHosts)
+	assert.Equal(t, uint(2), metrics.OfflineHosts)
+	assert.Equal(t, uint(0), metrics.MissingInActionHosts)
+
+	metrics, err = ds.CountHostsInTargets(filter, kolide.HostTargets{HostIDs: []uint{h1.ID}, LabelIDs: []uint{l2.ID}}, mockClock.Now())
 	require.Nil(t, err)
 	assert.Equal(t, uint(4), metrics.TotalHosts)
 	assert.Equal(t, uint(3), metrics.OnlineHosts)
 	assert.Equal(t, uint(1), metrics.OfflineHosts)
 	assert.Equal(t, uint(0), metrics.MissingInActionHosts)
 
-	metrics, err = ds.CountHostsInTargets(filter, nil, nil, mockClock.Now())
+	metrics, err = ds.CountHostsInTargets(filter, kolide.HostTargets{}, mockClock.Now())
 	require.Nil(t, err)
 	assert.Equal(t, uint(0), metrics.TotalHosts)
 	assert.Equal(t, uint(0), metrics.OnlineHosts)
 	assert.Equal(t, uint(0), metrics.OfflineHosts)
 	assert.Equal(t, uint(0), metrics.MissingInActionHosts)
 
-	metrics, err = ds.CountHostsInTargets(filter, []uint{}, []uint{}, mockClock.Now())
+	metrics, err = ds.CountHostsInTargets(filter, kolide.HostTargets{HostIDs: []uint{}, LabelIDs: []uint{}, TeamIDs: []uint{}}, mockClock.Now())
 	require.Nil(t, err)
 	assert.Equal(t, uint(0), metrics.TotalHosts)
 	assert.Equal(t, uint(0), metrics.OnlineHosts)
 	assert.Equal(t, uint(0), metrics.OfflineHosts)
+	assert.Equal(t, uint(0), metrics.MissingInActionHosts)
+
+	metrics, err = ds.CountHostsInTargets(filter, kolide.HostTargets{TeamIDs: []uint{team1.ID, team3.ID}}, mockClock.Now())
+	require.Nil(t, err)
+	assert.Equal(t, uint(1), metrics.TotalHosts)
+	assert.Equal(t, uint(1), metrics.OnlineHosts)
+	assert.Equal(t, uint(0), metrics.OfflineHosts)
+	assert.Equal(t, uint(0), metrics.MissingInActionHosts)
+
+	metrics, err = ds.CountHostsInTargets(filter, kolide.HostTargets{TeamIDs: []uint{team2.ID}}, mockClock.Now())
+	require.Nil(t, err)
+	assert.Equal(t, uint(3), metrics.TotalHosts)
+	assert.Equal(t, uint(1), metrics.OnlineHosts)
+	assert.Equal(t, uint(2), metrics.OfflineHosts)
 	assert.Equal(t, uint(0), metrics.MissingInActionHosts)
 
 	// Advance clock so all hosts are offline
 	mockClock.AddTime(2 * time.Minute)
-	metrics, err = ds.CountHostsInTargets(filter, nil, []uint{l1.ID, l2.ID}, mockClock.Now())
+	metrics, err = ds.CountHostsInTargets(filter, kolide.HostTargets{LabelIDs: []uint{l1.ID, l2.ID}}, mockClock.Now())
 	require.Nil(t, err)
 	assert.Equal(t, uint(6), metrics.TotalHosts)
 	assert.Equal(t, uint(0), metrics.OnlineHosts)
@@ -181,7 +216,7 @@ func testHostStatus(t *testing.T, ds kolide.Datastore) {
 			require.Nil(t, ds.MarkHostSeen(h, tt.seenTime))
 
 			// Verify status
-			metrics, err := ds.CountHostsInTargets(filter, []uint{h.ID}, []uint{}, mockClock.Now())
+			metrics, err := ds.CountHostsInTargets(filter, kolide.HostTargets{HostIDs: []uint{h.ID}}, mockClock.Now())
 			require.Nil(t, err)
 			assert.Equal(t, tt.metrics, metrics)
 		})
@@ -240,31 +275,31 @@ func testHostIDsInTargets(t *testing.T, ds kolide.Datastore) {
 		assert.Nil(t, err)
 	}
 
-	ids, err := ds.HostIDsInTargets(filter, nil, []uint{l1.ID, l2.ID})
+	ids, err := ds.HostIDsInTargets(filter, kolide.HostTargets{LabelIDs: []uint{l1.ID, l2.ID}})
 	require.Nil(t, err)
 	assert.Equal(t, []uint{1, 2, 3, 4, 5, 6}, ids)
 
-	ids, err = ds.HostIDsInTargets(filter, []uint{h1.ID}, nil)
+	ids, err = ds.HostIDsInTargets(filter, kolide.HostTargets{HostIDs: []uint{h1.ID}})
 	require.Nil(t, err)
 	assert.Equal(t, []uint{1}, ids)
 
-	ids, err = ds.HostIDsInTargets(filter, []uint{h1.ID}, []uint{l1.ID})
+	ids, err = ds.HostIDsInTargets(filter, kolide.HostTargets{HostIDs: []uint{h1.ID}, LabelIDs: []uint{l1.ID}})
 	require.Nil(t, err)
 	assert.Equal(t, []uint{1, 2, 3, 6}, ids)
 
-	ids, err = ds.HostIDsInTargets(filter, []uint{4}, []uint{l1.ID})
+	ids, err = ds.HostIDsInTargets(filter, kolide.HostTargets{HostIDs: []uint{4}, LabelIDs: []uint{l1.ID}})
 	require.Nil(t, err)
 	assert.Equal(t, []uint{1, 2, 3, 4, 6}, ids)
 
-	ids, err = ds.HostIDsInTargets(filter, []uint{4}, []uint{l2.ID})
+	ids, err = ds.HostIDsInTargets(filter, kolide.HostTargets{HostIDs: []uint{4}, LabelIDs: []uint{l2.ID}})
 	require.Nil(t, err)
 	assert.Equal(t, []uint{3, 4, 5}, ids)
 
-	ids, err = ds.HostIDsInTargets(filter, []uint{}, []uint{l2.ID})
+	ids, err = ds.HostIDsInTargets(filter, kolide.HostTargets{HostIDs: []uint{}, LabelIDs: []uint{l2.ID}})
 	require.Nil(t, err)
 	assert.Equal(t, []uint{3, 4, 5}, ids)
 
-	ids, err = ds.HostIDsInTargets(filter, []uint{1, 6}, []uint{l2.ID})
+	ids, err = ds.HostIDsInTargets(filter, kolide.HostTargets{HostIDs: []uint{1, 6}, LabelIDs: []uint{l2.ID}})
 	require.Nil(t, err)
 	assert.Equal(t, []uint{1, 3, 4, 5, 6}, ids)
 }

--- a/server/datastore/inmem/campaigns.go
+++ b/server/datastore/inmem/campaigns.go
@@ -41,12 +41,12 @@ func (d *Datastore) SaveDistributedQueryCampaign(camp *kolide.DistributedQueryCa
 	return nil
 }
 
-func (d *Datastore) DistributedQueryCampaignTargetIDs(id uint) (hostIDs []uint, labelIDs []uint, err error) {
+func (d *Datastore) DistributedQueryCampaignTargetIDs(id uint) (*kolide.HostTargets, error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
-	hostIDs = []uint{}
-	labelIDs = []uint{}
+	hostIDs := []uint{}
+	labelIDs := []uint{}
 	for _, target := range d.distributedQueryCampaignTargets {
 		if target.DistributedQueryCampaignID == id {
 			if target.Type == kolide.TargetHost {
@@ -54,12 +54,12 @@ func (d *Datastore) DistributedQueryCampaignTargetIDs(id uint) (hostIDs []uint, 
 			} else if target.Type == kolide.TargetLabel {
 				labelIDs = append(labelIDs, target.TargetID)
 			} else {
-				return []uint{}, []uint{}, fmt.Errorf("invalid target type: %d", target.Type)
+				return nil, fmt.Errorf("invalid target type: %d", target.Type)
 			}
 		}
 	}
 
-	return hostIDs, labelIDs, nil
+	return &kolide.HostTargets{HostIDs: hostIDs, LabelIDs: labelIDs}, nil
 }
 
 func (d *Datastore) NewDistributedQueryCampaignTarget(target *kolide.DistributedQueryCampaignTarget) (*kolide.DistributedQueryCampaignTarget, error) {

--- a/server/datastore/inmem/targets.go
+++ b/server/datastore/inmem/targets.go
@@ -6,7 +6,7 @@ import (
 	"github.com/fleetdm/fleet/server/kolide"
 )
 
-func (d *Datastore) CountHostsInTargets(filter kolide.TeamFilter, hostIDs, labelIDs []uint, now time.Time) (kolide.TargetMetrics, error) {
+func (d *Datastore) CountHostsInTargets(filter kolide.TeamFilter, targets kolide.HostTargets, now time.Time) (kolide.TargetMetrics, error) {
 	// noop
 	return kolide.TargetMetrics{}, nil
 }

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -28,9 +28,10 @@ func (d *Datastore) NewHost(host *kolide.Host) (*kolide.Host, error) {
 		os_version,
 		uptime,
 		physical_memory,
-		seen_time
+		seen_time,
+		team_id
 	)
-	VALUES( ?,?,?,?,?,?,?,?,?,?,?,? )
+	VALUES( ?,?,?,?,?,?,?,?,?,?,?,?,? )
 	`
 	result, err := d.db.Exec(
 		sqlStatement,
@@ -46,6 +47,7 @@ func (d *Datastore) NewHost(host *kolide.Host) (*kolide.Host, error) {
 		host.Uptime,
 		host.PhysicalMemory,
 		host.SeenTime,
+		host.TeamID,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "new host")

--- a/server/datastore/mysql/mysql_test.go
+++ b/server/datastore/mysql/mysql_test.go
@@ -426,3 +426,39 @@ func TestWhereFilterHostsByTeams(t *testing.T) {
 		})
 	}
 }
+
+func TestWhereOmitIDs(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		omits    []uint
+		expected string
+	}{
+		{
+			omits:    nil,
+			expected: "TRUE",
+		},
+		{
+			omits:    []uint{},
+			expected: "TRUE",
+		},
+		{
+			omits:    []uint{1, 3, 4},
+			expected: "id NOT IN (1,3,4)",
+		},
+		{
+			omits:    []uint{42},
+			expected: "id NOT IN (42)",
+		},
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			ds := &Datastore{logger: log.NewNopLogger()}
+			sql := ds.whereOmitIDs("id", tt.omits)
+			assert.Equal(t, tt.expected, sql)
+		})
+	}
+}

--- a/server/datastore/mysql/targets.go
+++ b/server/datastore/mysql/targets.go
@@ -9,11 +9,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (d *Datastore) CountHostsInTargets(filter kolide.TeamFilter, hostIDs []uint, labelIDs []uint, now time.Time) (kolide.TargetMetrics, error) {
+func (d *Datastore) CountHostsInTargets(filter kolide.TeamFilter, targets kolide.HostTargets, now time.Time) (kolide.TargetMetrics, error) {
 	// The logic in this function should remain synchronized with
 	// host.Status and GenerateHostStatusStatistics
 
-	if len(hostIDs) == 0 && len(labelIDs) == 0 {
+	if len(targets.HostIDs) == 0 && len(targets.LabelIDs) == 0 && len(targets.TeamIDs) == 0 {
 		// No need to query if no targets selected
 		return kolide.TargetMetrics{}, nil
 	}
@@ -26,7 +26,7 @@ func (d *Datastore) CountHostsInTargets(filter kolide.TeamFilter, hostIDs []uint
 			COALESCE(SUM(CASE WHEN DATE_ADD(seen_time, INTERVAL LEAST(distributed_interval, config_tls_refresh) + %d SECOND) > ? THEN 1 ELSE 0 END), 0) online,
 			COALESCE(SUM(CASE WHEN DATE_ADD(created_at, INTERVAL 1 DAY) >= ? THEN 1 ELSE 0 END), 0) new
 		FROM hosts h
-		WHERE (id IN (?) OR (id IN (SELECT DISTINCT host_id FROM label_membership WHERE label_id IN (?)))) AND %s
+		WHERE (id IN (?) OR (id IN (SELECT DISTINCT host_id FROM label_membership WHERE label_id IN (?))) OR team_id IN (?)) AND %s
 `, kolide.OnlineIntervalBuffer, kolide.OnlineIntervalBuffer, d.whereFilterHostsByTeams(filter, "h"))
 
 	// Using -1 in the ID slices for the IN clause allows us to include the
@@ -34,15 +34,19 @@ func (d *Datastore) CountHostsInTargets(filter kolide.TeamFilter, hostIDs []uint
 	// auto-increment IDs, and will also allow us to use the same query in
 	// all situations (no need to remove the clause when there are no values)
 	queryLabelIDs := []int{-1}
-	for _, id := range labelIDs {
+	for _, id := range targets.LabelIDs {
 		queryLabelIDs = append(queryLabelIDs, int(id))
 	}
 	queryHostIDs := []int{-1}
-	for _, id := range hostIDs {
+	for _, id := range targets.HostIDs {
 		queryHostIDs = append(queryHostIDs, int(id))
 	}
+	queryTeamIDs := []int{-1}
+	for _, id := range targets.TeamIDs {
+		queryTeamIDs = append(queryTeamIDs, int(id))
+	}
 
-	query, args, err := sqlx.In(sql, now, now, now, now, now, queryHostIDs, queryLabelIDs)
+	query, args, err := sqlx.In(sql, now, now, now, now, now, queryHostIDs, queryLabelIDs, queryTeamIDs)
 	if err != nil {
 		return kolide.TargetMetrics{}, errors.Wrap(err, "sqlx.In CountHostsInTargets")
 	}
@@ -56,8 +60,8 @@ func (d *Datastore) CountHostsInTargets(filter kolide.TeamFilter, hostIDs []uint
 	return res, nil
 }
 
-func (d *Datastore) HostIDsInTargets(filter kolide.TeamFilter, hostIDs, labelIDs []uint) ([]uint, error) {
-	if len(hostIDs) == 0 && len(labelIDs) == 0 {
+func (d *Datastore) HostIDsInTargets(filter kolide.TeamFilter, targets kolide.HostTargets) ([]uint, error) {
+	if len(targets.HostIDs) == 0 && len(targets.LabelIDs) == 0 && len(targets.TeamIDs) == 0 {
 		// No need to query if no targets selected
 		return []uint{}, nil
 	}
@@ -65,7 +69,7 @@ func (d *Datastore) HostIDsInTargets(filter kolide.TeamFilter, hostIDs, labelIDs
 	sql := fmt.Sprintf(`
 			SELECT DISTINCT id
 			FROM hosts
-			WHERE (id IN (?) OR (id IN (SELECT host_id FROM label_membership WHERE label_id IN (?)))) AND %s
+			WHERE (id IN (?) OR (id IN (SELECT host_id FROM label_membership WHERE label_id IN (?))) OR team_id IN (?)) AND %s
 			ORDER BY id ASC
 		`,
 		d.whereFilterHostsByTeams(filter, "hosts"),
@@ -76,15 +80,19 @@ func (d *Datastore) HostIDsInTargets(filter kolide.TeamFilter, hostIDs, labelIDs
 	// auto-increment IDs, and will also allow us to use the same query in
 	// all situations (no need to remove the clause when there are no values)
 	queryLabelIDs := []int{-1}
-	for _, id := range labelIDs {
+	for _, id := range targets.LabelIDs {
 		queryLabelIDs = append(queryLabelIDs, int(id))
 	}
 	queryHostIDs := []int{-1}
-	for _, id := range hostIDs {
+	for _, id := range targets.HostIDs {
 		queryHostIDs = append(queryHostIDs, int(id))
 	}
+	queryTeamIDs := []int{-1}
+	for _, id := range targets.TeamIDs {
+		queryTeamIDs = append(queryTeamIDs, int(id))
+	}
 
-	query, args, err := sqlx.In(sql, queryHostIDs, queryLabelIDs)
+	query, args, err := sqlx.In(sql, queryHostIDs, queryLabelIDs, queryTeamIDs)
 	if err != nil {
 		return nil, errors.Wrap(err, "sqlx.In HostIDsInTargets")
 	}

--- a/server/kolide/campaigns.go
+++ b/server/kolide/campaigns.go
@@ -19,7 +19,7 @@ type CampaignStore interface {
 	SaveDistributedQueryCampaign(camp *DistributedQueryCampaign) error
 	// DistributedQueryCampaignTargetIDs gets the IDs of the targets for
 	// the query campaign of the provided ID
-	DistributedQueryCampaignTargetIDs(id uint) (hostIDs []uint, labelIDs []uint, err error)
+	DistributedQueryCampaignTargetIDs(id uint) (targets *HostTargets, err error)
 
 	// NewDistributedQueryCampaignTarget adds a new target to an existing
 	// distributed query campaign
@@ -44,7 +44,7 @@ type CampaignService interface {
 
 	// NewDistributedQueryCampaign creates a new distributed query campaign
 	// with the provided query (or the query referenced by ID) and host/label targets
-	NewDistributedQueryCampaign(ctx context.Context, queryString string, queryID *uint, hosts []uint, labels []uint) (*DistributedQueryCampaign, error)
+	NewDistributedQueryCampaign(ctx context.Context, queryString string, queryID *uint, targets HostTargets) (*DistributedQueryCampaign, error)
 
 	// StreamCampaignResults streams updates with query results and
 	// expected host totals over the provided websocket. Note that the type

--- a/server/kolide/teams.go
+++ b/server/kolide/teams.go
@@ -25,7 +25,10 @@ type TeamStore interface {
 	TeamByName(name string) (*Team, error)
 	// ListTeams lists teams with the ordering and filters in the provided
 	// options.
-	ListTeams(opt ListOptions) ([]*Team, error)
+	ListTeams(filter TeamFilter, opt ListOptions) ([]*Team, error)
+	// SearchTeams searches teams using the provided query and ommitting the
+	// provided existing selection.
+	SearchTeams(filter TeamFilter, matchQuery string, omit ...uint) ([]*Team, error)
 }
 
 type TeamService interface {

--- a/server/mock/datastore_campaigns.go
+++ b/server/mock/datastore_campaigns.go
@@ -16,7 +16,7 @@ type DistributedQueryCampaignFunc func(id uint) (*kolide.DistributedQueryCampaig
 
 type SaveDistributedQueryCampaignFunc func(camp *kolide.DistributedQueryCampaign) error
 
-type DistributedQueryCampaignTargetIDsFunc func(id uint) (hostIDs []uint, labelIDs []uint, err error)
+type DistributedQueryCampaignTargetIDsFunc func(id uint) (targets *kolide.HostTargets, err error)
 
 type NewDistributedQueryCampaignTargetFunc func(target *kolide.DistributedQueryCampaignTarget) (*kolide.DistributedQueryCampaignTarget, error)
 
@@ -57,7 +57,7 @@ func (s *CampaignStore) SaveDistributedQueryCampaign(camp *kolide.DistributedQue
 	return s.SaveDistributedQueryCampaignFunc(camp)
 }
 
-func (s *CampaignStore) DistributedQueryCampaignTargetIDs(id uint) (hostIDs []uint, labelIDs []uint, err error) {
+func (s *CampaignStore) DistributedQueryCampaignTargetIDs(id uint) (targets *kolide.HostTargets, err error) {
 	s.DistributedQueryCampaignTargetIDsFuncInvoked = true
 	return s.DistributedQueryCampaignTargetIDsFunc(id)
 }

--- a/server/mock/datastore_targets.go
+++ b/server/mock/datastore_targets.go
@@ -10,22 +10,24 @@ import (
 
 var _ kolide.TargetStore = (*TargetStore)(nil)
 
-type CountHostsInTargetsFunc func(filter kolide.TeamFilter, hostIDs, labelIDs []uint, now time.Time) (kolide.TargetMetrics, error)
-type HostIDsInTargetsFunc func(filter kolide.TeamFilter, hostIDs, labelIDs []uint) ([]uint, error)
+type CountHostsInTargetsFunc func(filter kolide.TeamFilter, targets kolide.HostTargets, now time.Time) (kolide.TargetMetrics, error)
+
+type HostIDsInTargetsFunc func(filter kolide.TeamFilter, targets kolide.HostTargets) ([]uint, error)
 
 type TargetStore struct {
 	CountHostsInTargetsFunc        CountHostsInTargetsFunc
 	CountHostsInTargetsFuncInvoked bool
-	HostIDsInTargetsFunc           HostIDsInTargetsFunc
-	HostIDsInTargetsFuncInvoked    bool
+
+	HostIDsInTargetsFunc        HostIDsInTargetsFunc
+	HostIDsInTargetsFuncInvoked bool
 }
 
-func (s *TargetStore) CountHostsInTargets(filter kolide.TeamFilter, hostIDs, labelIDs []uint, now time.Time) (kolide.TargetMetrics, error) {
+func (s *TargetStore) CountHostsInTargets(filter kolide.TeamFilter, targets kolide.HostTargets, now time.Time) (kolide.TargetMetrics, error) {
 	s.CountHostsInTargetsFuncInvoked = true
-	return s.CountHostsInTargetsFunc(filter, hostIDs, labelIDs, now)
+	return s.CountHostsInTargetsFunc(filter, targets, now)
 }
 
-func (s *TargetStore) HostIDsInTargets(filter kolide.TeamFilter, hostIDs, labelIDs []uint) ([]uint, error) {
+func (s *TargetStore) HostIDsInTargets(filter kolide.TeamFilter, targets kolide.HostTargets) ([]uint, error) {
 	s.HostIDsInTargetsFuncInvoked = true
-	return s.HostIDsInTargetsFunc(filter, hostIDs, labelIDs)
+	return s.HostIDsInTargetsFunc(filter, targets)
 }

--- a/server/mock/datastore_teams.go
+++ b/server/mock/datastore_teams.go
@@ -18,7 +18,9 @@ type TeamFunc func(id uint) (*kolide.Team, error)
 
 type TeamByNameFunc func(name string) (*kolide.Team, error)
 
-type ListTeamsFunc func(opt kolide.ListOptions) ([]*kolide.Team, error)
+type ListTeamsFunc func(filter kolide.TeamFilter, opt kolide.ListOptions) ([]*kolide.Team, error)
+
+type SearchTeamsFunc func(filter kolide.TeamFilter, matchQuery string, omit ...uint) ([]*kolide.Team, error)
 
 type TeamStore struct {
 	NewTeamFunc        NewTeamFunc
@@ -38,6 +40,9 @@ type TeamStore struct {
 
 	ListTeamsFunc        ListTeamsFunc
 	ListTeamsFuncInvoked bool
+
+	SearchTeamsFunc        SearchTeamsFunc
+	SearchTeamsFuncInvoked bool
 }
 
 func (s *TeamStore) NewTeam(team *kolide.Team) (*kolide.Team, error) {
@@ -65,7 +70,12 @@ func (s *TeamStore) TeamByName(identifier string) (*kolide.Team, error) {
 	return s.TeamByNameFunc(identifier)
 }
 
-func (s *TeamStore) ListTeams(opt kolide.ListOptions) ([]*kolide.Team, error) {
+func (s *TeamStore) ListTeams(filter kolide.TeamFilter, opt kolide.ListOptions) ([]*kolide.Team, error) {
 	s.ListTeamsFuncInvoked = true
-	return s.ListTeamsFunc(opt)
+	return s.ListTeamsFunc(filter, opt)
+}
+
+func (s *TeamStore) SearchTeams(filter kolide.TeamFilter, matchQuery string, omit ...uint) ([]*kolide.Team, error) {
+	s.SearchTeamsFuncInvoked = true
+	return s.SearchTeamsFunc(filter, matchQuery, omit...)
 }

--- a/server/service/client_targets.go
+++ b/server/service/client_targets.go
@@ -9,15 +9,13 @@ import (
 )
 
 // SearchTargets searches for the supplied targets in the Fleet instance.
-func (c *Client) SearchTargets(query string, selectedHostIDs, selectedLabelIDs []uint) (*kolide.TargetSearchResults, error) {
+func (c *Client) SearchTargets(query string, hostIDs, labelIDs []uint) (*kolide.TargetSearchResults, error) {
 	req := searchTargetsRequest{
 		MatchQuery: query,
-		Selected: struct {
-			Labels []uint `json:"labels"`
-			Hosts  []uint `json:"hosts"`
-		}{
-			Labels: selectedLabelIDs,
-			Hosts:  selectedHostIDs,
+		Selected: kolide.HostTargets{
+			LabelIDs: labelIDs,
+			HostIDs:  hostIDs,
+			// TODO handle TeamIDs
 		},
 	}
 

--- a/server/service/endpoint_campaigns.go
+++ b/server/service/endpoint_campaigns.go
@@ -18,14 +18,9 @@ import (
 ////////////////////////////////////////////////////////////////////////////////
 
 type createDistributedQueryCampaignRequest struct {
-	QuerySQL string                          `json:"query"`
-	QueryID  *uint                           `json:"query_id"`
-	Selected distributedQueryCampaignTargets `json:"selected"`
-}
-
-type distributedQueryCampaignTargets struct {
-	Labels []uint `json:"labels"`
-	Hosts  []uint `json:"hosts"`
+	QuerySQL string             `json:"query"`
+	QueryID  *uint              `json:"query_id"`
+	Selected kolide.HostTargets `json:"selected"`
 }
 
 type createDistributedQueryCampaignResponse struct {
@@ -38,7 +33,7 @@ func (r createDistributedQueryCampaignResponse) error() error { return r.Err }
 func makeCreateDistributedQueryCampaignEndpoint(svc kolide.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(createDistributedQueryCampaignRequest)
-		campaign, err := svc.NewDistributedQueryCampaign(ctx, req.QuerySQL, req.QueryID, req.Selected.Hosts, req.Selected.Labels)
+		campaign, err := svc.NewDistributedQueryCampaign(ctx, req.QuerySQL, req.QueryID, req.Selected)
 		if err != nil {
 			return createDistributedQueryCampaignResponse{Err: err}, nil
 		}

--- a/server/service/endpoint_packs.go
+++ b/server/service/endpoint_packs.go
@@ -41,7 +41,7 @@ func packResponseForPack(ctx context.Context, svc kolide.Service, pack kolide.Pa
 		return nil, err
 	}
 
-	hostMetrics, err := svc.CountHostsInTargets(ctx, nil, hosts, labelIDs)
+	hostMetrics, err := svc.CountHostsInTargets(ctx, nil, kolide.HostTargets{HostIDs: hosts, LabelIDs: labelIDs})
 	if err != nil {
 		return nil, err
 	}

--- a/server/service/endpoint_targets.go
+++ b/server/service/endpoint_targets.go
@@ -17,11 +17,8 @@ type searchTargetsRequest struct {
 	MatchQuery string `json:"query"`
 	// QueryID is the ID of a saved query to run (used to determine if this is a
 	// query that observers can run).
-	QueryID  *uint `json:"query_id"`
-	Selected struct {
-		Labels []uint `json:"labels"`
-		Hosts  []uint `json:"hosts"`
-	} `json:"selected"`
+	QueryID  *uint              `json:"query_id"`
+	Selected kolide.HostTargets `json:"selected"`
 }
 
 type hostSearchResult struct {
@@ -35,9 +32,16 @@ type labelSearchResult struct {
 	Count       int    `json:"count"`
 }
 
+type teamSearchResult struct {
+	*kolide.Team
+	DisplayText string `json:"display_text"`
+	Count       int    `json:"count"`
+}
+
 type targetsData struct {
 	Hosts  []hostSearchResult  `json:"hosts"`
 	Labels []labelSearchResult `json:"labels"`
+	Teams  []teamSearchResult  `json:"teams"`
 }
 
 type searchTargetsResponse struct {
@@ -55,7 +59,7 @@ func makeSearchTargetsEndpoint(svc kolide.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(searchTargetsRequest)
 
-		results, err := svc.SearchTargets(ctx, req.MatchQuery, req.QueryID, req.Selected.Hosts, req.Selected.Labels)
+		results, err := svc.SearchTargets(ctx, req.MatchQuery, req.QueryID, req.Selected)
 		if err != nil {
 			return searchTargetsResponse{Err: err}, nil
 		}
@@ -63,6 +67,7 @@ func makeSearchTargetsEndpoint(svc kolide.Service) endpoint.Endpoint {
 		targets := &targetsData{
 			Hosts:  []hostSearchResult{},
 			Labels: []labelSearchResult{},
+			Teams:  []teamSearchResult{},
 		}
 
 		for _, host := range results.Hosts {
@@ -87,7 +92,17 @@ func makeSearchTargetsEndpoint(svc kolide.Service) endpoint.Endpoint {
 			)
 		}
 
-		metrics, err := svc.CountHostsInTargets(ctx, req.QueryID, req.Selected.Hosts, req.Selected.Labels)
+		for _, team := range results.Teams {
+			targets.Teams = append(targets.Teams,
+				teamSearchResult{
+					Team:        team,
+					DisplayText: team.Name,
+					Count:       team.HostCount,
+				},
+			)
+		}
+
+		metrics, err := svc.CountHostsInTargets(ctx, req.QueryID, req.Selected)
 		if err != nil {
 			return searchTargetsResponse{Err: err}, nil
 		}

--- a/server/service/logging_campaigns.go
+++ b/server/service/logging_campaigns.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fleetdm/fleet/server/websocket"
 )
 
-func (mw loggingMiddleware) NewDistributedQueryCampaign(ctx context.Context, querySQL string, queryID *uint, hosts []uint, labels []uint) (*kolide.DistributedQueryCampaign, error) {
+func (mw loggingMiddleware) NewDistributedQueryCampaign(ctx context.Context, querySQL string, queryID *uint, targets kolide.HostTargets) (*kolide.DistributedQueryCampaign, error) {
 	var (
 		loggedInUser = "unauthenticated"
 		campaign     *kolide.DistributedQueryCampaign
@@ -34,11 +34,11 @@ func (mw loggingMiddleware) NewDistributedQueryCampaign(ctx context.Context, que
 			"took", time.Since(begin),
 		)
 	}(time.Now())
-	campaign, err = mw.Service.NewDistributedQueryCampaign(ctx, querySQL, queryID, hosts, labels)
+	campaign, err = mw.Service.NewDistributedQueryCampaign(ctx, querySQL, queryID, targets)
 	return campaign, err
 }
 
-func (mw loggingMiddleware) NewDistributedQueryCampaignByNames(ctx context.Context, querySQL string, queryID *uint, hosts []string, labels []string) (*kolide.DistributedQueryCampaign, error) {
+func (mw loggingMiddleware) NewDistributedQueryCampaignByNames(ctx context.Context, querySQL string, queryID *uint, hostIDs []string, labelIDs []string) (*kolide.DistributedQueryCampaign, error) {
 	var (
 		loggedInUser = "unauthenticated"
 		campaign     *kolide.DistributedQueryCampaign
@@ -63,7 +63,7 @@ func (mw loggingMiddleware) NewDistributedQueryCampaignByNames(ctx context.Conte
 			"took", time.Since(begin),
 		)
 	}(time.Now())
-	campaign, err = mw.Service.NewDistributedQueryCampaignByNames(ctx, querySQL, queryID, hosts, labels)
+	campaign, err = mw.Service.NewDistributedQueryCampaignByNames(ctx, querySQL, queryID, hostIDs, labelIDs)
 	return campaign, err
 }
 

--- a/server/service/service_osquery_test.go
+++ b/server/service/service_osquery_test.go
@@ -1158,10 +1158,10 @@ func TestNewDistributedQueryCampaign(t *testing.T) {
 		return target, nil
 	}
 
-	ds.CountHostsInTargetsFunc = func(filter kolide.TeamFilter, hostIDs, labelIDs []uint, now time.Time) (kolide.TargetMetrics, error) {
+	ds.CountHostsInTargetsFunc = func(filter kolide.TeamFilter, targets kolide.HostTargets, now time.Time) (kolide.TargetMetrics, error) {
 		return kolide.TargetMetrics{}, nil
 	}
-	ds.HostIDsInTargetsFunc = func(filter kolide.TeamFilter, hostIDs, labelIDs []uint) ([]uint, error) {
+	ds.HostIDsInTargetsFunc = func(filter kolide.TeamFilter, targets kolide.HostTargets) ([]uint, error) {
 		return []uint{1, 3, 5}, nil
 	}
 	lq.On("RunQuery", "21", "select year, month, day, hour, minutes, seconds from time", []uint{1, 3, 5}).Return(nil)
@@ -1171,7 +1171,7 @@ func TestNewDistributedQueryCampaign(t *testing.T) {
 		},
 	})
 	q := "select year, month, day, hour, minutes, seconds from time"
-	campaign, err := svc.NewDistributedQueryCampaign(viewerCtx, q, nil, []uint{2}, []uint{1})
+	campaign, err := svc.NewDistributedQueryCampaign(viewerCtx, q, nil, kolide.HostTargets{HostIDs: []uint{2}, LabelIDs: []uint{1}})
 	require.Nil(t, err)
 	assert.Equal(t, gotQuery.ID, gotCampaign.QueryID)
 	assert.Equal(t, []*kolide.DistributedQueryCampaignTarget{

--- a/server/service/service_teams.go
+++ b/server/service/service_teams.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/fleetdm/fleet/server/contexts/viewer"
 	"github.com/fleetdm/fleet/server/kolide"
 )
 
@@ -127,7 +128,13 @@ func (svc service) ListTeamUsers(ctx context.Context, teamID uint, opt kolide.Li
 }
 
 func (svc service) ListTeams(ctx context.Context, opt kolide.ListOptions) ([]*kolide.Team, error) {
-	return svc.ds.ListTeams(opt)
+	vc, ok := viewer.FromContext(ctx)
+	if !ok {
+		return nil, errNoContext
+	}
+	filter := kolide.TeamFilter{User: vc.User, IncludeObserver: true}
+
+	return svc.ds.ListTeams(filter, opt)
 }
 
 func (svc service) DeleteTeam(ctx context.Context, tid uint) error {

--- a/server/service/transport_targets_test.go
+++ b/server/service/transport_targets_test.go
@@ -19,8 +19,8 @@ func TestDecodeSearchTargetsRequest(t *testing.T) {
 
 		params := r.(searchTargetsRequest)
 		assert.Equal(t, "bar", params.MatchQuery)
-		assert.Len(t, params.Selected.Hosts, 3)
-		assert.Len(t, params.Selected.Labels, 2)
+		assert.Len(t, params.Selected.HostIDs, 3)
+		assert.Len(t, params.Selected.LabelIDs, 2)
 	}).Methods("POST")
 	var body bytes.Buffer
 


### PR DESCRIPTION
- Accept Teams as a searchable target type for the target selection API.
- Accept Teams for targets in running live queries.
- Refactoring to support these changes.
- Update API documentation.