### PR TITLE
Remove @fleetdm.com emails from fleetdm/fleet repo

### DIFF
--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -13,9 +13,6 @@
             "pattern": "fleet.corp.example.com"
         },
         {
-            "pattern": "hello@fleetdm.com"
-        },
-        {
             "pattern": "/server/datastore/mysql/migrations/"
         },
         {

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by [contacting the Fleet team](hello@fleetdm.com). The team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by [contacting the Fleet team](https://fleetdm.com/contact). The team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ To open your browser's **network requests**, press Control Shift J (Windows, Lin
 ### Report a security vulnerability
 
 Sensitive security-related issues should be reported to
-[security@fleetdm.com](mailto:security@fleetdm.com) before a public issue is made.
+[fleetdm.com/contact](https://fleetdm.com/contact) before a public issue is made.
 
 ## Contributing to documentation
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine
-MAINTAINER Fleet Developers <engineering@fleetdm.com>
+MAINTAINER Fleet Developers <hello@fleetdm.com>
 
 RUN apk --update add ca-certificates
 

--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ e2e-reset-db:
 e2e-setup:
 	./build/fleetctl config set --context e2e --address https://localhost:8642
 	./build/fleetctl config set --context e2e --tls-skip-verify true
-	./build/fleetctl setup --context e2e --email=test@fleetdm.com --username=test --password=admin123# --org-name='Fleet Test'
+	./build/fleetctl setup --context e2e --email=test@example.com --username=test --password=admin123# --org-name='Fleet Test'
 	./build/fleetctl user create --context e2e --username=user1 --email=user1@example.com --sso=true
 
 e2e-serve:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,6 @@
 
 ## Reporting a Vulnerability
 
-Please report any vulnerabilities discovered in Fleet products to [security@fleetdm.com](mailto:security@fleetdm.com).
+Please report any vulnerabilities discovered in Fleet products to [fleetdm.com/contact](https://fleetdm.com/contact).
 
 Fleet endeavors to acknowledge and fix any reported vulnerabilities ASAP. Acknowledgement is typically within 1 business day, and patches usually go out within 5 business days (depending on severity and timing).

--- a/cypress/integration/app/activateuser.spec.ts
+++ b/cypress/integration/app/activateuser.spec.ts
@@ -14,7 +14,7 @@ describe("User invite and activation", () => {
 
     cy.findByLabelText(/name/i).click().type("Ash Ketchum");
 
-    cy.findByLabelText(/email/i).click().type("ash@fleetdm.com");
+    cy.findByLabelText(/email/i).click().type("ash@example.com");
 
     cy.findByRole("button", { name: /invite/i }).click();
 

--- a/cypress/integration/app/activateuser.spec.ts
+++ b/cypress/integration/app/activateuser.spec.ts
@@ -29,9 +29,9 @@ describe("User invite and activation", () => {
     cy.getEmails().then((response) => {
       expect(response.body.items[0].To[0]).to.have.property("Domain");
       expect(response.body.items[0].To[0].Mailbox).to.equal("ash");
-      expect(response.body.items[0].To[0].Domain).to.equal("fleetdm.com");
+      expect(response.body.items[0].To[0].Domain).to.equal("example.com");
       expect(response.body.items[0].From.Mailbox).to.equal("gabriel+dev");
-      expect(response.body.items[0].From.Domain).to.equal("fleetdm.com");
+      expect(response.body.items[0].From.Domain).to.equal("example.com");
       const match = response.body.items[0].Content.Body.match(regex);
       inviteLink.url = match[0];
     });

--- a/cypress/integration/app/settingsflow.spec.ts
+++ b/cypress/integration/app/settingsflow.spec.ts
@@ -48,7 +48,7 @@ describe("Settings flow", () => {
 
     cy.findByLabelText(/sender address/i)
       .click()
-      .type("rachel@fleetdm.com");
+      .type("rachel@example.com");
 
     cy.findByLabelText(/smtp server/i)
       .click()
@@ -121,7 +121,7 @@ describe("Settings flow", () => {
 
     cy.findByLabelText(/sender address/i).should(
       "have.value",
-      "rachel@fleetdm.com"
+      "rachel@example.com"
     );
 
     cy.findByLabelText(/smtp server/i).should("have.value", "localhost");

--- a/cypress/integration/app/settingsflow.spec.ts
+++ b/cypress/integration/app/settingsflow.spec.ts
@@ -140,9 +140,9 @@ describe("Settings flow", () => {
     cy.getEmails().then((response) => {
       expect(response.body.items[0].To[0]).to.have.property("Domain");
       expect(response.body.items[0].To[0].Mailbox).to.equal("test");
-      expect(response.body.items[0].To[0].Domain).to.equal("fleetdm.com");
+      expect(response.body.items[0].To[0].Domain).to.equal("example.com");
       expect(response.body.items[0].From.Mailbox).to.equal("rachel");
-      expect(response.body.items[0].From.Domain).to.equal("fleetdm.com");
+      expect(response.body.items[0].From.Domain).to.equal("example.com");
       expect(response.body.items[0].Content.Headers.Subject[0]).to.equal(
         "Hello from Fleet"
       );

--- a/cypress/integration/sessions/sessions.spec.ts
+++ b/cypress/integration/sessions/sessions.spec.ts
@@ -10,7 +10,7 @@ describe("Sessions", () => {
     cy.contains(/forgot password/i);
 
     // Log in
-    cy.get("input").first().type("test@fleetdm.com");
+    cy.get("input").first().type("test@example.com");
     cy.get("input").last().type("admin123#");
     cy.get("button").click();
 
@@ -27,7 +27,7 @@ describe("Sessions", () => {
 
   it("Fails login with invalid password", () => {
     cy.visit("/");
-    cy.get("input").first().type("test@fleetdm.com");
+    cy.get("input").first().type("test@example.com");
     cy.get("input").last().type("bad_password");
     cy.get(".button").click();
 

--- a/cypress/integration/sessions/sso.spec.ts
+++ b/cypress/integration/sessions/sso.spec.ts
@@ -12,7 +12,7 @@ describe("SSO Sessions", () => {
     cy.contains(/forgot password/i);
 
     // Log in
-    cy.get("input").first().type("test@fleetdm.com");
+    cy.get("input").first().type("test@example.com");
     cy.get("input").last().type("admin123#");
     cy.contains("button", "Login").click();
 

--- a/cypress/integration/setup/setup.spec.ts
+++ b/cypress/integration/setup/setup.spec.ts
@@ -20,7 +20,7 @@ describe("Setup", () => {
       .last()
       .type("admin123#");
 
-    cy.findByPlaceholderText(/email/i).type("test@fleetdm.com");
+    cy.findByPlaceholderText(/email/i).type("test@example.com");
 
     cy.contains("button:enabled", /next/i).click();
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -59,7 +59,7 @@ Cypress.Commands.add("setupSMTP", () => {
       authentication_type: "authtype_none",
       enable_smtp: true,
       port: 1025,
-      sender_address: "gabriel+dev@fleetdm.com",
+      sender_address: "gabriel+dev@example.com",
       server: "localhost",
     },
   };

--- a/docs/2-Orbit-osquery/README.md
+++ b/docs/2-Orbit-osquery/README.md
@@ -123,7 +123,7 @@ For Notarization, valid App Store Connect credentials must be available on the b
 Build a signed and notarized macOS package with an invocation like the following:
 
 ```sh
-AC_USERNAME=zach@fleetdm.com AC_PASSWORD=llpk-sije-kjlz-jdzw go run ./cmd/package --type=pkg --fleet-url=fleet.example.com --enroll-secret=63SBzTT+2UyW --sign-identity 3D7260BF99539C6E80A94835A8921A988F4E6498 --notarize
+AC_USERNAME=zach@example.com AC_PASSWORD=llpk-sije-kjlz-jdzw go run ./cmd/package --type=pkg --fleet-url=fleet.example.com --enroll-secret=63SBzTT+2UyW --sign-identity 3D7260BF99539C6E80A94835A8921A988F4E6498 --notarize
 ```
 
 This process may take several minutes to complete as the Notarization process completes on Apple's servers.

--- a/tools/ci/docker/fleet-builder/1.9/Dockerfile
+++ b/tools/ci/docker/fleet-builder/1.9/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.9-alpine
-MAINTAINER Fleet Developers <engineering@fleetdm.com>
+MAINTAINER Fleet Developers <hello@fleetdm.com>
 
 ENV NPM_CONFIG_LOGLEVEL info
 ENV NODE_VERSION 8.7.0


### PR DESCRIPTION
- In tests and documentation, replace `@fleetdm.com` with `@example.com`
- In documentation, replace `hello@fleetdm.com` with `fleetdm.com/contact`
- In documentation, replace `security@fleetdm.com` with `fleetdm.com/contact`
- In Dockerfiles, replace `engineering@fleetdm.com` with `hello@fleetdm.com`. These two files are the only remaining files with a `@fleetdm.com` email.

Resolves fleetdm/confidential#224