### PR TITLE
Move community project links into Example deployment scenario docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,4 @@ Please join us in the #fleet channel on [osquery Slack](https://osquery.slack.co
 
 Contributions are welcome, whether you answer questions on Slack/GitHub/StackOverflow/Twitter, improve the documentation or website, write a tutorial, give a talk, start a local osquery meetup, troubleshoot reported issues, or [submit a patch](https://github.com/fleetdm/fleet/blob/master/CONTRIBUTING.md).  The Fleet code of conduct is [on GitHub](https://github.com/fleetdm/fleet/blob/master/CODE_OF_CONDUCT.md).
 
-#### Community projects
-
-Below are some projects created by Fleet community members. Please submit a pull request if you'd like your project featured.
-
-- [Kolide Cloud ("K2")](https://kolide.com) is a cloud-hosted, user-driven security SaaS application.  To be clear: Kolide ≠ Fleet.
-- [davidrecordon/terraform-aws-kolide-fleet](https://github.com/davidrecordon/terraform-aws-kolide-fleet) - Deploy Fleet into AWS using Terraform.
-- [deeso/fleet-deployment](https://github.com/deeso/fleet-deployment) - Install Fleet on a Ubuntu box.
-- [gjyoung1974/kolide-fleet-chart](https://github.com/gjyoung1974/kolide-fleet-chart) - Kubernetes Helm chart for deploying Fleet.
-
 <a href="https://fleetdm.com"><img alt="Banner featuring a futuristic cloud city with the Fleet logo" src="https://user-images.githubusercontent.com/618009/98254443-eaf21100-1f41-11eb-9e2c-63a0545601f3.jpg"/></a>

--- a/docs/3-Deployment/4-Example-deployment-scenarios.md
+++ b/docs/3-Deployment/4-Example-deployment-scenarios.md
@@ -557,7 +557,7 @@ Once you have the public IP address for the load balancer, create an A record in
 
 #### Community projects
 
-Below are some projects created by Fleet community members. Please submit a pull request if you'd like your project featured.
+Below are some projects created by Fleet community members. These projects provide additional solutions for deploying Fleet. Please submit a pull request if you'd like your project featured.
 
 - [davidrecordon/terraform-aws-kolide-fleet](https://github.com/davidrecordon/terraform-aws-kolide-fleet) - Deploy Fleet into AWS using Terraform.
 - [deeso/fleet-deployment](https://github.com/deeso/fleet-deployment) - Install Fleet on a Ubuntu box.

--- a/docs/3-Deployment/4-Example-deployment-scenarios.md
+++ b/docs/3-Deployment/4-Example-deployment-scenarios.md
@@ -26,6 +26,7 @@
     - [Deploying Fleet](#deploying-fleet)
     - [Deploying the load balancer](#deploying-the-load-balancer)
     - [Configure DNS](#configure-dns)
+- [Community projects](#community-projects)
 
 ## Fleet on CentOS
 
@@ -553,3 +554,11 @@ kubectl get services fleet-loadbalancer
 In this output, you should see an "EXTERNAL-IP" column. If this column says `<pending>`, then give it a few minutes. Sometimes acquiring a public IP address can take a moment.
 
 Once you have the public IP address for the load balancer, create an A record in your DNS server of choice. You should now be able to browse to your Fleet server from the internet!
+
+#### Community projects
+
+Below are some projects created by Fleet community members. Please submit a pull request if you'd like your project featured.
+
+- [davidrecordon/terraform-aws-kolide-fleet](https://github.com/davidrecordon/terraform-aws-kolide-fleet) - Deploy Fleet into AWS using Terraform.
+- [deeso/fleet-deployment](https://github.com/deeso/fleet-deployment) - Install Fleet on a Ubuntu box.
+- [gjyoung1974/kolide-fleet-chart](https://github.com/gjyoung1974/kolide-fleet-chart) - Kubernetes Helm chart for deploying Fleet.


### PR DESCRIPTION
- Move the community Fleet deployment tools to `docs/3-Deployment/4-Example-deployment-scenarios.md`