### PR TITLE
Refactor enroll secrets to support Teams

### DIFF
--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -127,16 +127,6 @@ func printSecret(c *cli.Context, secret *kolide.EnrollSecretSpec) error {
 		Spec:    secret,
 	}
 
-	if name := c.Args().Get(0); name != "" {
-		for _, s := range secret.Secrets {
-			if s.Name == name {
-				fmt.Println(s.Secret)
-				return nil
-			}
-		}
-		return fmt.Errorf("Secret '%s' not found", name)
-	}
-
 	var err error
 
 	if c.Bool(jsonFlagName) {

--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -167,7 +167,7 @@ Use the stop and reset subcommands to manage the server and dependencies once st
 				return errors.Wrap(err, "Error retrieving enroll secret")
 			}
 
-			if len(secrets.Secrets) != 1 || !secrets.Secrets[0].Active {
+			if len(secrets.Secrets) != 1 {
 				return errors.New("Expected 1 active enroll secret")
 			}
 

--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -551,7 +551,6 @@ This is the callback endpoint that the identity provider will use to send securi
       "config_tls_refresh": 10,
       "logger_tls_period": 8,
       "additional": {},
-      "enroll_secret_name": "default",
       "status": "offline",
       "display_text": "2ceca32fe484"
     },
@@ -644,7 +643,6 @@ The endpoint returns the host's installed `software` if the software inventory f
         "config_tls_refresh": 10,
         "logger_tls_period": 10,
         "additional": {},
-        "enroll_secret_name": "bar",
         "status": "offline",
         "display_text": "259404d30eb6",
         "labels": [
@@ -752,7 +750,6 @@ Returns the information of the host specified using the `uuid`, `osquery_host_id
         "config_tls_refresh": 10,
         "logger_tls_period": 10,
         "additional": {},
-        "enroll_secret_name": "bar",
         "status": "offline",
         "display_text": "259404d30eb6"
     }
@@ -1203,7 +1200,6 @@ Returns a list of the hosts that belong to the specified label.
       "config_tls_refresh": 10,
       "logger_tls_period": 10,
       "additional": {},
-      "enroll_secret_name": "default",
       "status": "offline",
       "display_text": "e2e7f8d8983d"
     },
@@ -3904,7 +3900,6 @@ The returned lists are filtered based on the hosts the requesting user has acces
         "config_tls_refresh": 10,
         "logger_tls_period": 10,
         "additional": {},
-        "enroll_secret_name": "default",
         "status": "offline",
         "display_text": "7a2f41482833"
       },
@@ -3942,7 +3937,6 @@ The returned lists are filtered based on the hosts the requesting user has acces
         "config_tls_refresh": 10,
         "logger_tls_period": 10,
         "additional": {},
-        "enroll_secret_name": "default",
         "status": "offline",
         "display_text": "78c96e72746c"
       }
@@ -4190,9 +4184,9 @@ Modifies the Fleet's configuration with the supplied information.
 }
 ```
 
-### Get enroll secret(s)
+### Get global enroll secret(s)
 
-Returns all the enroll secrets used by the Fleet server.
+Returns the valid global enroll secrets.
 
 `GET /api/v1/fleet/spec/enroll_secret`
 
@@ -4213,23 +4207,13 @@ None.
   "specs": {
     "secrets": [
       {
-        "name": "bar",
         "secret": "fTp52/twaxBU6gIi0J6PHp8o5Sm1k1kn",
-        "active": true,
         "created_at": "2021-01-07T19:40:04Z"
       },
       {
-        "name": "default",
-        "secret": "fTp52/twaxBU6gIi0J6PHp8o5Sm1k1kn",
-        "active": true,
+        "secret": "bhD5kiX2J+KBgZSk118qO61ZIdX/v8On",
         "created_at": "2021-01-04T21:18:07Z"
       },
-      {
-        "name": "foo",
-        "secret": "fTp52/twaxBU6gIi0J6PHp8o5Sm1k1kn",
-        "active": true,
-        "created_at": "2021-01-07T19:40:04Z"
-      }
     ]
   }
 }
@@ -4237,17 +4221,15 @@ None.
 
 ### Modify enroll secret(s)
 
-Modifies and/or creates the specified enroll secret(s).
+Replaces the active global enroll secrets with the secrets specified.
 
 `POST /api/v1/fleet/spec/enroll_secret`
 
 #### Parameters
 
-| Name   | Type    | In   | Description                                                                                                  |
-| ------ | ------- | ---- | ------------------------------------------------------------------------------------------------------------ |
-| name   | string  | body | **Required.** The name of the enroll secret                                                                  |
-| secret | string  | body | **Required.** The plain text string used as the enroll secret.                                               |
-| active | boolean | body | Whether or not the enroll secret is active. Must be set to true for hosts to enroll using the enroll secret. |
+| Name   | Type   | In   | Description                                                    |
+| ------ | ------ | ---- | -------------------------------------------------------------- |
+| secret | string | body | **Required.** The plain text string used as the enroll secret. |
 
 #### Example
 
@@ -4258,7 +4240,6 @@ Modifies and/or creates the specified enroll secret(s).
   "spec": {
     "secrets": [
       {
-        "name": "bar",
         "secret": "fTp52/twaxBU6gIi0J6PHp8o5Sm1k1kn",
         "active": false,
       },

--- a/frontend/components/config/EnrollSecretTable/EnrollSecretTable.jsx
+++ b/frontend/components/config/EnrollSecretTable/EnrollSecretTable.jsx
@@ -14,7 +14,6 @@ const baseClass = "enroll-secrets";
 
 class EnrollSecretRow extends Component {
   static propTypes = {
-    name: PropTypes.string.isRequired,
     secret: PropTypes.string.isRequired,
   };
 
@@ -61,13 +60,11 @@ class EnrollSecretRow extends Component {
   };
 
   renderLabel = () => {
-    const { name } = this.props;
     const { copyMessage } = this.state;
     const { onCopySecret, onToggleSecret } = this;
 
     return (
       <span className={`${baseClass}__name`}>
-        {name}
         <span className="buttons">
           {copyMessage && <span>{`${copyMessage} `}</span>}
           <Button
@@ -125,22 +122,21 @@ class EnrollSecretTable extends Component {
 
   render() {
     const { secrets } = this.props;
-    const activeSecrets = secrets.filter((s) => s.active);
 
     let enrollSecretsClass = baseClass;
-    if (activeSecrets.length === 0) {
+    if (secrets.length === 0) {
       return (
         <div className={baseClass}>
           <em>No active enroll secrets.</em>
         </div>
       );
-    } else if (activeSecrets.length > 1)
+    } else if (secrets.length > 1)
       enrollSecretsClass += ` ${baseClass}--multiple-secrets`;
 
     return (
       <div className={enrollSecretsClass}>
-        {activeSecrets.map(({ name, secret }) => (
-          <EnrollSecretRow key={name} name={name} secret={secret} />
+        {secrets.map(({ secret }) => (
+          <EnrollSecretRow key={secret} secret={secret} />
         ))}
       </div>
     );

--- a/frontend/components/config/EnrollSecretTable/EnrollSecretTable.tests.jsx
+++ b/frontend/components/config/EnrollSecretTable/EnrollSecretTable.tests.jsx
@@ -9,15 +9,15 @@ import EnrollSecretTable, {
 describe("EnrollSecretTable", () => {
   const defaultProps = {
     secrets: [
-      { name: "foo", secret: "foo_secret", active: true },
-      { name: "bar", secret: "bar_secret", active: true },
-      { name: "inactive", secret: "inactive", active: false },
+      { secret: "foo_secret" },
+      { secret: "bar_secret" },
+      { secret: "baz_secret" },
     ],
   };
 
   it("renders properly filtered rows", () => {
     const table = shallow(<EnrollSecretTable {...defaultProps} />);
-    expect(table.find("EnrollSecretRow").length).toEqual(2);
+    expect(table.find("EnrollSecretRow").length).toEqual(3);
   });
 
   it("renders text when empty", () => {

--- a/frontend/components/forms/admin/AppConfigForm/AppConfigForm.tests.jsx
+++ b/frontend/components/forms/admin/AppConfigForm/AppConfigForm.tests.jsx
@@ -11,9 +11,9 @@ describe("AppConfigForm - form", () => {
     handleSubmit: noop,
     smtpConfigured: false,
     enrollSecret: [
-      { name: "foo", secret: "foo_secret", active: true },
-      { name: "bar", secret: "bar_secret", active: true },
-      { name: "inactive", secret: "inactive", active: false },
+      { secret: "foo_secret" },
+      { secret: "bar_secret" },
+      { secret: "baz_secret" },
     ],
   };
   const form = mount(<AppConfigForm {...defaultProps} />);

--- a/server/datastore/datastore.go
+++ b/server/datastore/datastore.go
@@ -15,6 +15,7 @@ var TestFunctions = [...]func(*testing.T, kolide.Datastore){
 	testEnrollSecrets,
 	testEnrollSecretsCaseSensitive,
 	testEnrollSecretRoundtrip,
+	testEnrollSecretUniqueness,
 	testCreateInvite,
 	testInviteByEmail,
 	testInviteByToken,

--- a/server/datastore/datastore_labels.go
+++ b/server/datastore/datastore_labels.go
@@ -20,7 +20,7 @@ func testLabels(t *testing.T, db kolide.Datastore) {
 	var host *kolide.Host
 	var err error
 	for i := 0; i < 10; i++ {
-		host, err = db.EnrollHost(fmt.Sprint(i), fmt.Sprint(i), "default", 0)
+		host, err = db.EnrollHost(fmt.Sprint(i), fmt.Sprint(i), nil, 0)
 		require.Nil(t, err, "enrollment should succeed")
 		hosts = append(hosts, *host)
 	}

--- a/server/datastore/datastore_targets.go
+++ b/server/datastore/datastore_targets.go
@@ -168,7 +168,7 @@ func testHostStatus(t *testing.T, ds kolide.Datastore) {
 
 	mockClock := clock.NewMockClock()
 
-	h, err := ds.EnrollHost("1", "key1", "default", 0)
+	h, err := ds.EnrollHost("1", "key1", nil, 0)
 	require.Nil(t, err)
 
 	user := &kolide.User{GlobalRole: ptr.String(kolide.RoleAdmin)}

--- a/server/datastore/inmem/hosts.go
+++ b/server/datastore/inmem/hosts.go
@@ -155,7 +155,7 @@ func (d *Datastore) GenerateHostStatusStatistics(now time.Time) (online, offline
 	return online, offline, mia, new, nil
 }
 
-func (d *Datastore) EnrollHost(osQueryHostID, nodeKey, secretName string, cooldown time.Duration) (*kolide.Host, error) {
+func (d *Datastore) EnrollHost(osQueryHostID, nodeKey string, teamID *uint, cooldown time.Duration) (*kolide.Host, error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 

--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -189,30 +189,32 @@ func (d *Datastore) SaveAppConfig(info *kolide.AppConfig) error {
 	return err
 }
 
-func (d *Datastore) VerifyEnrollSecret(secret string) (string, error) {
+func (d *Datastore) VerifyEnrollSecret(secret string) (*kolide.EnrollSecret, error) {
 	var s kolide.EnrollSecret
-	err := d.db.Get(&s, "SELECT name, active FROM enroll_secrets WHERE secret = ?", secret)
+	err := d.db.Get(&s, "SELECT name, active, team_id FROM enroll_secrets WHERE secret = ?", secret)
 	if err != nil {
-		return "", errors.New("no matching secret found")
+		return nil, errors.New("no matching secret found")
 	}
 	if !s.Active {
-		return "", errors.New("secret is inactive")
+		return nil, errors.New("secret is inactive")
 	}
 
-	return s.Name, nil
+	return &s, nil
 }
 
-func (d *Datastore) ApplyEnrollSecretSpec(spec *kolide.EnrollSecretSpec) error {
+func (d *Datastore) ApplyEnrollSecrets(teamID *uint, secrets []kolide.EnrollSecret) error {
 	err := d.withRetryTxx(func(tx *sqlx.Tx) error {
-		for _, secret := range spec.Secrets {
+		sql := `DELETE FROM enroll_secrets WHERE team_id = ?`
+		if _, err := tx.Exec(sql, teamID); err != nil {
+			return errors.Wrap(err, "clear before insert")
+		}
+
+		for _, secret := range secrets {
 			sql := `
-				INSERT INTO enroll_secrets (name, secret, active)
-				VALUES (?, ?, ?)
-				ON DUPLICATE KEY UPDATE
-					secret = VALUES(secret),
-					active = VALUES(active)
+				INSERT INTO enroll_secrets (name, secret, active, team_id)
+				VALUES (?, ?, ?, ?)
 			`
-			if _, err := tx.Exec(sql, secret.Name, secret.Secret, secret.Active); err != nil {
+			if _, err := tx.Exec(sql, secret.Name, secret.Secret, secret.Active, teamID); err != nil {
 				return errors.Wrap(err, "upsert secret")
 			}
 		}
@@ -222,11 +224,11 @@ func (d *Datastore) ApplyEnrollSecretSpec(spec *kolide.EnrollSecretSpec) error {
 	return err
 }
 
-func (d *Datastore) GetEnrollSecretSpec() (*kolide.EnrollSecretSpec, error) {
-	var spec kolide.EnrollSecretSpec
-	sql := `SELECT * FROM enroll_secrets`
-	if err := d.db.Select(&spec.Secrets, sql); err != nil {
+func (d *Datastore) GetEnrollSecrets(teamID *uint) ([]kolide.EnrollSecret, error) {
+	var secrets []kolide.EnrollSecret
+	sql := `SELECT * FROM enroll_secrets WHERE team_id = ?`
+	if err := d.db.Select(&secrets, sql, teamID); err != nil {
 		return nil, errors.Wrap(err, "get secrets")
 	}
-	return &spec, nil
+	return secrets, nil
 }

--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -191,30 +191,34 @@ func (d *Datastore) SaveAppConfig(info *kolide.AppConfig) error {
 
 func (d *Datastore) VerifyEnrollSecret(secret string) (*kolide.EnrollSecret, error) {
 	var s kolide.EnrollSecret
-	err := d.db.Get(&s, "SELECT name, active, team_id FROM enroll_secrets WHERE secret = ?", secret)
+	err := d.db.Get(&s, "SELECT team_id FROM enroll_secrets WHERE secret = ?", secret)
 	if err != nil {
 		return nil, errors.New("no matching secret found")
-	}
-	if !s.Active {
-		return nil, errors.New("secret is inactive")
 	}
 
 	return &s, nil
 }
 
-func (d *Datastore) ApplyEnrollSecrets(teamID *uint, secrets []kolide.EnrollSecret) error {
+func (d *Datastore) ApplyEnrollSecrets(teamID *uint, secrets []*kolide.EnrollSecret) error {
 	err := d.withRetryTxx(func(tx *sqlx.Tx) error {
-		sql := `DELETE FROM enroll_secrets WHERE team_id = ?`
-		if _, err := tx.Exec(sql, teamID); err != nil {
-			return errors.Wrap(err, "clear before insert")
+		if teamID != nil {
+			sql := `DELETE FROM enroll_secrets WHERE team_id = ?`
+			if _, err := tx.Exec(sql, teamID); err != nil {
+				return errors.Wrap(err, "clear before insert")
+			}
+		} else {
+			sql := `DELETE FROM enroll_secrets WHERE team_id IS NULL`
+			if _, err := tx.Exec(sql); err != nil {
+				return errors.Wrap(err, "clear before insert")
+			}
 		}
 
 		for _, secret := range secrets {
 			sql := `
-				INSERT INTO enroll_secrets (name, secret, active, team_id)
-				VALUES (?, ?, ?, ?)
+				INSERT INTO enroll_secrets (secret, team_id)
+				VALUES ( ?, ? )
 			`
-			if _, err := tx.Exec(sql, secret.Name, secret.Secret, secret.Active, teamID); err != nil {
+			if _, err := tx.Exec(sql, secret.Secret, teamID); err != nil {
 				return errors.Wrap(err, "upsert secret")
 			}
 		}
@@ -224,10 +228,18 @@ func (d *Datastore) ApplyEnrollSecrets(teamID *uint, secrets []kolide.EnrollSecr
 	return err
 }
 
-func (d *Datastore) GetEnrollSecrets(teamID *uint) ([]kolide.EnrollSecret, error) {
-	var secrets []kolide.EnrollSecret
-	sql := `SELECT * FROM enroll_secrets WHERE team_id = ?`
-	if err := d.db.Select(&secrets, sql, teamID); err != nil {
+func (d *Datastore) GetEnrollSecrets(teamID *uint) ([]*kolide.EnrollSecret, error) {
+	var args []interface{}
+	sql := "SELECT * FROM enroll_secrets WHERE "
+	// MySQL requires comparing NULL with IS. NULL = NULL evaluates to FALSE.
+	if teamID == nil {
+		sql += "team_id IS NULL"
+	} else {
+		sql += "team_id = ?"
+		args = append(args, teamID)
+	}
+	var secrets []*kolide.EnrollSecret
+	if err := d.db.Select(&secrets, sql, args...); err != nil {
 		return nil, errors.Wrap(err, "get secrets")
 	}
 	return secrets, nil

--- a/server/datastore/mysql/migrations/tables/20210513174845_TeamsEnrollSecrets.go
+++ b/server/datastore/mysql/migrations/tables/20210513174845_TeamsEnrollSecrets.go
@@ -1,0 +1,28 @@
+package tables
+
+import (
+	"database/sql"
+
+	"github.com/pkg/errors"
+)
+
+func init() {
+	MigrationClient.AddMigration(Up_20210513174845, Down_20210513174845)
+}
+
+func Up_20210513174845(tx *sql.Tx) error {
+	sql := `
+		ALTER TABLE enroll_secrets
+		ADD COLUMN team_id INT UNSIGNED,
+		ADD FOREIGN KEY fk_team_id (team_id) REFERENCES teams (id) ON DELETE CASCADE ON UPDATE CASCADE
+	`
+	if _, err := tx.Exec(sql); err != nil {
+		return errors.Wrap(err, "add team_id to enroll_secrets")
+	}
+
+	return nil
+}
+
+func Down_20210513174845(tx *sql.Tx) error {
+	return nil
+}

--- a/server/datastore/mysql/migrations/tables/20210527151852_TeamsEnrollSecrets.go
+++ b/server/datastore/mysql/migrations/tables/20210527151852_TeamsEnrollSecrets.go
@@ -2,15 +2,13 @@ package tables
 
 import (
 	"database/sql"
-
-	"github.com/pkg/errors"
 )
 
 func init() {
-	MigrationClient.AddMigration(Up_20210513174845, Down_20210513174845)
+	MigrationClient.AddMigration(Up_20210527151852, Down_20210527151852)
 }
 
-func Up_20210513174845(tx *sql.Tx) error {
+func Up_20210527151852(tx *sql.Tx) error {
 	sql := `
 		ALTER TABLE enroll_secrets
 		ADD COLUMN team_id INT UNSIGNED,
@@ -23,6 +21,6 @@ func Up_20210513174845(tx *sql.Tx) error {
 	return nil
 }
 
-func Down_20210513174845(tx *sql.Tx) error {
+func Down_20210527151852(tx *sql.Tx) error {
 	return nil
 }

--- a/server/kolide/app.go
+++ b/server/kolide/app.go
@@ -16,14 +16,13 @@ type AppConfigStore interface {
 	SaveAppConfig(info *AppConfig) error
 
 	// VerifyEnrollSecret checks that the provided secret matches an active
-	// enroll secret. If it is successfully matched, the name of the secret is
-	// returned. Otherwise an error is returned.
-	VerifyEnrollSecret(secret string) (string, error)
-	// ApplyEnrollSecretSpec adds and updates the enroll secrets specified in
-	// the spec.
-	ApplyEnrollSecretSpec(spec *EnrollSecretSpec) error
-	// GetEnrollSecretSpec gets the spec for the current enroll secrets.
-	GetEnrollSecretSpec() (*EnrollSecretSpec, error)
+	// enroll secret. If it is successfully matched, that secret is returned.
+	// Otherwise an error is returned.
+	VerifyEnrollSecret(secret string) (*EnrollSecret, error)
+	// GetEnrollSecrets gets the enroll secrets for a team (or global if teamID is nil).
+	GetEnrollSecrets(teamID *uint) ([]EnrollSecret, error)
+	// ApplyEnrollSecrets replaces the current enroll secrets for a team with the provided secrets.
+	ApplyEnrollSecrets(teamID *uint, secrets []EnrollSecret) error
 }
 
 // AppConfigService provides methods for configuring
@@ -325,6 +324,9 @@ type EnrollSecret struct {
 	Active bool `json:"active" db:"active"`
 	// CreatedAt is the time this enroll secret was first added.
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
+	// TeamID is the ID for the associated team. If no ID is set, then this is a
+	// global enroll secret.
+	TeamID *uint `json:"team_id" db:"team_id"`
 }
 
 const (

--- a/server/kolide/app.go
+++ b/server/kolide/app.go
@@ -20,9 +20,9 @@ type AppConfigStore interface {
 	// Otherwise an error is returned.
 	VerifyEnrollSecret(secret string) (*EnrollSecret, error)
 	// GetEnrollSecrets gets the enroll secrets for a team (or global if teamID is nil).
-	GetEnrollSecrets(teamID *uint) ([]EnrollSecret, error)
+	GetEnrollSecrets(teamID *uint) ([]*EnrollSecret, error)
 	// ApplyEnrollSecrets replaces the current enroll secrets for a team with the provided secrets.
-	ApplyEnrollSecrets(teamID *uint, secrets []EnrollSecret) error
+	ApplyEnrollSecrets(teamID *uint, secrets []*EnrollSecret) error
 }
 
 // AppConfigService provides methods for configuring
@@ -315,13 +315,8 @@ type ListOptions struct {
 // EnrollSecret contains information about an enroll secret, name, and active
 // status. Enroll secrets are used for osquery authentication.
 type EnrollSecret struct {
-	// Name is the name assigned to the secret
-	Name string `json:"name" db:"name"`
 	// Secret is the actual secret key.
 	Secret string `json:"secret" db:"secret"`
-	// Active determines whether the secret is currently allowed to be used for
-	// authentication.
-	Active bool `json:"active" db:"active"`
 	// CreatedAt is the time this enroll secret was first added.
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
 	// TeamID is the ID for the associated team. If no ID is set, then this is a
@@ -330,13 +325,14 @@ type EnrollSecret struct {
 }
 
 const (
-	EnrollSecretKind = "enroll_secret"
+	EnrollSecretKind          = "enroll_secret"
+	EnrollSecretDefaultLength = 24
 )
 
 // EnrollSecretSpec is the fleetctl spec type for enroll secrets.
 type EnrollSecretSpec struct {
 	// Secrets is the list of enroll secrets.
-	Secrets []EnrollSecret `json:"secrets"`
+	Secrets []*EnrollSecret `json:"secrets"`
 }
 
 // LicenseInfo contains information about the Fleet license.

--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -43,10 +43,10 @@ type HostStore interface {
 	DeleteHost(hid uint) error
 	Host(id uint) (*Host, error)
 	// EnrollHost will enroll a new host with the given identifier, setting the
-	// node key, and enroll secret used for the host. Implementations of this
-	// method should respect the provided host enrollment cooldown, by returning
-	// an error if the host has enrolled within the cooldown period.
-	EnrollHost(osqueryHostId, nodeKey, secretName string, cooldown time.Duration) (*Host, error)
+	// node key, and team. Implementations of this method should respect the
+	// provided host enrollment cooldown, by returning an error if the host has
+	// enrolled within the cooldown period.
+	EnrollHost(osqueryHostId, nodeKey string, teamID *uint, cooldown time.Duration) (*Host, error)
 	ListHosts(opt HostListOptions) ([]*Host, error)
 	// AuthenticateHost authenticates and returns host metadata by node key.
 	// This method should not return the host "additional" information as this
@@ -155,7 +155,6 @@ type Host struct {
 	ConfigTLSRefresh          uint                `json:"config_tls_refresh" db:"config_tls_refresh"`
 	LoggerTLSPeriod           uint                `json:"logger_tls_period" db:"logger_tls_period"`
 	Additional                *json.RawMessage    `json:"additional,omitempty" db:"additional"`
-	EnrollSecretName          string              `json:"enroll_secret_name" db:"enroll_secret_name"`
 
 	TeamID *uint `json:"team_id" db:"team_id"`
 	// TeamName is the name of the team, loaded by JOIN to the teams table.

--- a/server/kolide/teams.go
+++ b/server/kolide/teams.go
@@ -29,6 +29,8 @@ type TeamStore interface {
 	// SearchTeams searches teams using the provided query and ommitting the
 	// provided existing selection.
 	SearchTeams(filter TeamFilter, matchQuery string, omit ...uint) ([]*Team, error)
+	// TeamEnrollSecrets lists the enroll secrets for the team.
+	TeamEnrollSecrets(teamID uint) ([]*EnrollSecret, error)
 }
 
 type TeamService interface {
@@ -49,11 +51,14 @@ type TeamService interface {
 	ListTeams(ctx context.Context, opt ListOptions) ([]*Team, error)
 	// ListTeams lists users on the team with the provided list options.
 	ListTeamUsers(ctx context.Context, teamID uint, opt ListOptions) ([]*User, error)
+	// TeamEnrollSecrets lists the enroll secrets for the team.
+	TeamEnrollSecrets(ctx context.Context, teamID uint) ([]*EnrollSecret, error)
 }
 
 type TeamPayload struct {
-	Name        *string `json:"name"`
-	Description *string `json:"description"`
+	Name        *string         `json:"name"`
+	Description *string         `json:"description"`
+	Secrets     []*EnrollSecret `json:"secrets"`
 	// Note AgentOptions must be set by a separate endpoint.
 }
 
@@ -83,6 +88,8 @@ type Team struct {
 	HostCount int `json:"host_count" db:"host_count"`
 	// Hosts are the hosts assigned to the team.
 	Hosts []Host `json:"hosts,omitempty"`
+	// Secrets is the enroll secrets valid for this team.
+	Secrets []*EnrollSecret `json:"secrets,omitempty"`
 }
 
 // TeamUser is a user mapped to a team with a role.

--- a/server/mock/datastore_appconfig.go
+++ b/server/mock/datastore_appconfig.go
@@ -12,11 +12,11 @@ type AppConfigFunc func() (*kolide.AppConfig, error)
 
 type SaveAppConfigFunc func(info *kolide.AppConfig) error
 
-type VerifyEnrollSecretFunc func(secret string) (string, error)
+type VerifyEnrollSecretFunc func(secret string) (*kolide.EnrollSecret, error)
 
-type ApplyEnrollSecretSpecFunc func(spec *kolide.EnrollSecretSpec) error
+type ApplyEnrollSecretsFunc func(treamID *uint, secrets []*kolide.EnrollSecret) error
 
-type GetEnrollSecretSpecFunc func() (*kolide.EnrollSecretSpec, error)
+type GetEnrollSecretsFunc func(teamID *uint) ([]*kolide.EnrollSecret, error)
 
 type AppConfigStore struct {
 	NewAppConfigFunc        NewAppConfigFunc
@@ -31,11 +31,11 @@ type AppConfigStore struct {
 	VerifyEnrollSecretFunc        VerifyEnrollSecretFunc
 	VerifyEnrollSecretFuncInvoked bool
 
-	ApplyEnrollSecretSpecFunc        ApplyEnrollSecretSpecFunc
-	ApplyEnrollSecretSpecFuncInvoked bool
+	ApplyEnrollSecretsFunc        ApplyEnrollSecretsFunc
+	ApplyEnrollSecretsFuncInvoked bool
 
-	GetEnrollSecretSpecFunc        GetEnrollSecretSpecFunc
-	GetEnrollSecretSpecFuncInvoked bool
+	GetEnrollSecretsFunc        GetEnrollSecretsFunc
+	GetEnrollSecretsFuncInvoked bool
 }
 
 func (s *AppConfigStore) NewAppConfig(info *kolide.AppConfig) (*kolide.AppConfig, error) {
@@ -53,17 +53,17 @@ func (s *AppConfigStore) SaveAppConfig(info *kolide.AppConfig) error {
 	return s.SaveAppConfigFunc(info)
 }
 
-func (s *AppConfigStore) VerifyEnrollSecret(secret string) (string, error) {
+func (s *AppConfigStore) VerifyEnrollSecret(secret string) (*kolide.EnrollSecret, error) {
 	s.VerifyEnrollSecretFuncInvoked = true
 	return s.VerifyEnrollSecretFunc(secret)
 }
 
-func (s *AppConfigStore) ApplyEnrollSecretSpec(spec *kolide.EnrollSecretSpec) error {
-	s.ApplyEnrollSecretSpecFuncInvoked = true
-	return s.ApplyEnrollSecretSpecFunc(spec)
+func (s *AppConfigStore) ApplyEnrollSecrets(teamID *uint, secrets []*kolide.EnrollSecret) error {
+	s.ApplyEnrollSecretsFuncInvoked = true
+	return s.ApplyEnrollSecretsFunc(teamID, secrets)
 }
 
-func (s *AppConfigStore) GetEnrollSecretSpec() (*kolide.EnrollSecretSpec, error) {
-	s.GetEnrollSecretSpecFuncInvoked = true
-	return s.GetEnrollSecretSpecFunc()
+func (s *AppConfigStore) GetEnrollSecrets(teamID *uint) ([]*kolide.EnrollSecret, error) {
+	s.GetEnrollSecretsFuncInvoked = true
+	return s.GetEnrollSecretsFunc(teamID)
 }

--- a/server/mock/datastore_hosts.go
+++ b/server/mock/datastore_hosts.go
@@ -22,7 +22,7 @@ type HostByIdentifierFunc func(identifier string) (*kolide.Host, error)
 
 type ListHostsFunc func(opt kolide.HostListOptions) ([]*kolide.Host, error)
 
-type EnrollHostFunc func(osqueryHostId, nodeKey, secretName string, cooldown time.Duration) (*kolide.Host, error)
+type EnrollHostFunc func(osqueryHostId, nodeKey string, teamID *uint, cooldown time.Duration) (*kolide.Host, error)
 
 type AuthenticateHostFunc func(nodeKey string) (*kolide.Host, error)
 
@@ -122,9 +122,9 @@ func (s *HostStore) ListHosts(opt kolide.HostListOptions) ([]*kolide.Host, error
 	return s.ListHostsFunc(opt)
 }
 
-func (s *HostStore) EnrollHost(osqueryHostId, nodeKey, secretName string, cooldown time.Duration) (*kolide.Host, error) {
+func (s *HostStore) EnrollHost(osqueryHostId, nodeKey string, teamID *uint, cooldown time.Duration) (*kolide.Host, error) {
 	s.EnrollHostFuncInvoked = true
-	return s.EnrollHostFunc(osqueryHostId, nodeKey, secretName, cooldown)
+	return s.EnrollHostFunc(osqueryHostId, nodeKey, teamID, cooldown)
 }
 
 func (s *HostStore) AuthenticateHost(nodeKey string) (*kolide.Host, error) {

--- a/server/mock/datastore_teams.go
+++ b/server/mock/datastore_teams.go
@@ -22,6 +22,8 @@ type ListTeamsFunc func(filter kolide.TeamFilter, opt kolide.ListOptions) ([]*ko
 
 type SearchTeamsFunc func(filter kolide.TeamFilter, matchQuery string, omit ...uint) ([]*kolide.Team, error)
 
+type TeamEnrollSecretsFunc func(teamID uint) ([]*kolide.EnrollSecret, error)
+
 type TeamStore struct {
 	NewTeamFunc        NewTeamFunc
 	NewTeamFuncInvoked bool
@@ -43,6 +45,9 @@ type TeamStore struct {
 
 	SearchTeamsFunc        SearchTeamsFunc
 	SearchTeamsFuncInvoked bool
+
+	TeamEnrollSecretsFunc        TeamEnrollSecretsFunc
+	TeamEnrollSecretsFuncInvoked bool
 }
 
 func (s *TeamStore) NewTeam(team *kolide.Team) (*kolide.Team, error) {
@@ -78,4 +83,9 @@ func (s *TeamStore) ListTeams(filter kolide.TeamFilter, opt kolide.ListOptions) 
 func (s *TeamStore) SearchTeams(filter kolide.TeamFilter, matchQuery string, omit ...uint) ([]*kolide.Team, error) {
 	s.SearchTeamsFuncInvoked = true
 	return s.SearchTeamsFunc(filter, matchQuery, omit...)
+}
+
+func (s *TeamStore) TeamEnrollSecrets(teamID uint) ([]*kolide.EnrollSecret, error) {
+	s.TeamEnrollSecretsFuncInvoked = true
+	return s.TeamEnrollSecretsFunc(teamID)
 }

--- a/server/service/endpoint_setup.go
+++ b/server/service/endpoint_setup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/fleetdm/fleet/server/kolide"
+	"github.com/fleetdm/fleet/server/ptr"
 	"github.com/go-kit/kit/endpoint"
 	"github.com/pkg/errors"
 )
@@ -63,8 +64,7 @@ func makeSetupEndpoint(svc kolide.Service) endpoint.Endpoint {
 			return setupResponse{Err: err}, nil
 		}
 		// Make the user an admin
-		adminStr := "admin"
-		adminPayload.GlobalRole = &adminStr
+		adminPayload.GlobalRole = ptr.String(kolide.RoleAdmin)
 		admin, err = svc.CreateUser(ctx, adminPayload)
 		if err != nil {
 			return setupResponse{Err: err}, nil

--- a/server/service/endpoint_teams.go
+++ b/server/service/endpoint_teams.go
@@ -193,3 +193,30 @@ func makeDeleteTeamUsersEndpoint(svc kolide.Service) endpoint.Endpoint {
 		return teamResponse{Team: team}, err
 	}
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// Get enroll secrets for team
+////////////////////////////////////////////////////////////////////////////////
+
+type teamEnrollSecretsRequest struct {
+	TeamID uint
+}
+
+type teamEnrollSecretsResponse struct {
+	Secrets []*kolide.EnrollSecret `json:"secrets"`
+	Err     error                  `json:"error,omitempty"`
+}
+
+func (r teamEnrollSecretsResponse) error() error { return r.Err }
+
+func makeTeamEnrollSecretsEndpoint(svc kolide.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(teamEnrollSecretsRequest)
+		secrets, err := svc.TeamEnrollSecrets(ctx, req.TeamID)
+		if err != nil {
+			return teamEnrollSecretsResponse{Err: err}, nil
+		}
+
+		return teamEnrollSecretsResponse{Secrets: secrets}, err
+	}
+}

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -119,6 +119,7 @@ type KolideEndpoints struct {
 	ListTeamUsers                         endpoint.Endpoint
 	AddTeamUsers                          endpoint.Endpoint
 	DeleteTeamUsers                       endpoint.Endpoint
+	TeamEnrollSecrets                     endpoint.Endpoint
 }
 
 // MakeKolideServerEndpoints creates the Kolide API endpoints.
@@ -231,6 +232,7 @@ func MakeKolideServerEndpoints(svc kolide.Service, jwtKey, urlPrefix string, lim
 		ListTeamUsers:          authenticatedUser(jwtKey, svc, makeListTeamUsersEndpoint(svc)),
 		AddTeamUsers:           authenticatedUser(jwtKey, svc, makeAddTeamUsersEndpoint(svc)),
 		DeleteTeamUsers:        authenticatedUser(jwtKey, svc, makeDeleteTeamUsersEndpoint(svc)),
+		TeamEnrollSecrets:      authenticatedUser(jwtKey, svc, makeTeamEnrollSecretsEndpoint(svc)),
 
 		// Authenticated status endpoints
 		StatusResultStore: authenticatedUser(jwtKey, svc, makeStatusResultStoreEndpoint(svc)),
@@ -349,6 +351,7 @@ type kolideHandlers struct {
 	ListTeamUsers                         http.Handler
 	AddTeamUsers                          http.Handler
 	DeleteTeamUsers                       http.Handler
+	TeamEnrollSecrets                     http.Handler
 }
 
 func makeKolideKitHandlers(e KolideEndpoints, opts []kithttp.ServerOption) *kolideHandlers {
@@ -454,6 +457,7 @@ func makeKolideKitHandlers(e KolideEndpoints, opts []kithttp.ServerOption) *koli
 		ListTeamUsers:                         newServer(e.ListTeamUsers, decodeListTeamUsersRequest),
 		AddTeamUsers:                          newServer(e.AddTeamUsers, decodeModifyTeamUsersRequest),
 		DeleteTeamUsers:                       newServer(e.DeleteTeamUsers, decodeModifyTeamUsersRequest),
+		TeamEnrollSecrets:                     newServer(e.TeamEnrollSecrets, decodeTeamEnrollSecretsRequest),
 	}
 }
 
@@ -674,6 +678,7 @@ func attachKolideAPIRoutes(r *mux.Router, h *kolideHandlers) {
 	r.Handle("/api/v1/fleet/teams/{id}/users", h.ListTeamUsers).Methods("GET").Name("team_users")
 	r.Handle("/api/v1/fleet/teams/{id}/users", h.AddTeamUsers).Methods("PATCH").Name("add_team_users")
 	r.Handle("/api/v1/fleet/teams/{id}/users", h.DeleteTeamUsers).Methods("DELETE").Name("delete_team_users")
+	r.Handle("/api/v1/fleet/teams/{id}/secrets", h.TeamEnrollSecrets).Methods("GET").Name("get_team_enroll_secrets")
 
 	r.Handle("/api/v1/osquery/enroll", h.EnrollAgent).Methods("POST").Name("enroll_agent")
 	r.Handle("/api/v1/osquery/config", h.GetClientConfig).Methods("POST").Name("get_client_config")

--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -78,7 +78,7 @@ func (svc service) AuthenticateHost(ctx context.Context, nodeKey string) (*kolid
 }
 
 func (svc service) EnrollAgent(ctx context.Context, enrollSecret, hostIdentifier string, hostDetails map[string](map[string]string)) (string, error) {
-	secretName, err := svc.ds.VerifyEnrollSecret(enrollSecret)
+	secret, err := svc.ds.VerifyEnrollSecret(enrollSecret)
 	if err != nil {
 		return "", osqueryError{
 			message:     "enroll failed: " + err.Error(),
@@ -96,7 +96,7 @@ func (svc service) EnrollAgent(ctx context.Context, enrollSecret, hostIdentifier
 
 	hostIdentifier = getHostIdentifier(svc.logger, svc.config.Osquery.HostIdentifier, hostIdentifier, hostDetails)
 
-	host, err := svc.ds.EnrollHost(hostIdentifier, nodeKey, secretName, svc.config.Osquery.EnrollCooldown)
+	host, err := svc.ds.EnrollHost(hostIdentifier, nodeKey, secret.TeamID, svc.config.Osquery.EnrollCooldown)
 	if err != nil {
 		return "", osqueryError{message: "save enroll failed: " + err.Error(), nodeInvalid: true}
 	}

--- a/server/service/transport_teams.go
+++ b/server/service/transport_teams.go
@@ -81,3 +81,12 @@ func decodeModifyTeamUsersRequest(ctx context.Context, r *http.Request) (interfa
 	}
 	return req, nil
 }
+
+func decodeTeamEnrollSecretsRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	id, err := idFromRequest(r, "id")
+	if err != nil {
+		return nil, err
+	}
+	req := teamEnrollSecretsRequest{TeamID: id}
+	return req, nil
+}


### PR DESCRIPTION
- Add `team_id` field to secrets.
- Remove secret `name` and `active` fields (migration deletes inactive secrets).
- Assign hosts to Team based on secret provided.
- Add API for retrieving secrets by Team.