### PR TITLE
Query Edit/Run: Conditional select targets dropdown

### DIFF
--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsDropdown.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsDropdown.jsx
@@ -20,6 +20,7 @@ class SelectTargetsDropdown extends Component {
     onSelect: PropTypes.func.isRequired,
     selectedTargets: PropTypes.arrayOf(targetInterface),
     targetsCount: PropTypes.number,
+    queryId: PropTypes.number,
   };
 
   static defaultProps = {
@@ -118,7 +119,12 @@ class SelectTargetsDropdown extends Component {
     this.setState({ moreInfoTarget: null });
   };
 
-  fetchTargets = (query = "", selectedTargets = this.props.selectedTargets) => {
+  // TODO determine how to handle queryId; can it simply be a const that is passed as a prop? confirm how API handles "", null, undefined
+  fetchTargets = (
+    query = "",
+    queryId = this.props.queryId,
+    selectedTargets = this.props.selectedTargets
+  ) => {
     const { onFetchTargets } = this.props;
 
     if (!this.mounted) {
@@ -128,7 +134,7 @@ class SelectTargetsDropdown extends Component {
     this.setState({ isLoadingTargets: true, query });
 
     return Kolide.targets
-      .loadAll(query, formatSelectedTargetsForApi(selectedTargets))
+      .loadAll(query, queryId, formatSelectedTargetsForApi(selectedTargets))
       .then((response) => {
         const { targets } = response;
         const isEmpty = targets.length === 0;
@@ -142,7 +148,7 @@ class SelectTargetsDropdown extends Component {
           targets.push({});
         }
 
-        onFetchTargets(query, response);
+        onFetchTargets(query, response); // TODO trace how onFetch works with query and investigate how to refactor for query string vs. queryId; does this work if queryId is const based on this.props?
 
         this.setState({
           isEmpty,

--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsDropdown.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsDropdown.jsx
@@ -119,7 +119,6 @@ class SelectTargetsDropdown extends Component {
     this.setState({ moreInfoTarget: null });
   };
 
-  // TODO determine how to handle queryId; can it simply be a const that is passed as a prop? confirm how API handles "", null, undefined
   fetchTargets = (
     query = "",
     queryId = this.props.queryId,
@@ -148,7 +147,7 @@ class SelectTargetsDropdown extends Component {
           targets.push({});
         }
 
-        onFetchTargets(query, response); // TODO trace how onFetch works with query and investigate how to refactor for query string vs. queryId; does this work if queryId is const based on this.props?
+        onFetchTargets(query, response);
 
         this.setState({
           isEmpty,

--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsDropdown.tests.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsDropdown.tests.jsx
@@ -112,34 +112,12 @@ describe("SelectTargetsDropdown - component", () => {
     const defaultSelectedTargets = { hosts: [], labels: [] };
     const defaultParams = {
       query: "",
-      queryId: 1,
+      query_id: 1,
       selected: defaultSelectedTargets,
     };
     const expectedApiClientResponseWithTargets = {
       targets: [{ ...Test.Stubs.labelStub, target_type: "labels" }],
     };
-
-    it("calls the api", () => {
-      Test.Mocks.targetMock(defaultParams, apiResponseWithTargets);
-      const Component = shallow(<SelectTargetsDropdown {...defaultProps} />);
-      const node = Component.instance();
-
-      nock.cleanAll();
-      const request = Test.Mocks.targetMock(
-        defaultParams,
-        apiResponseWithTargets
-      );
-
-      expect.assertions(1);
-      return node
-        .fetchTargets()
-        .then(() => {
-          expect(request.isDone()).toEqual(true);
-        })
-        .catch((error) => {
-          expect(error).toBe(undefined);
-        });
-    });
 
     it("calls the onFetchTargets prop", () => {
       const onFetchTargets = jest.fn();

--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsDropdown.tests.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsDropdown.tests.jsx
@@ -16,6 +16,7 @@ describe("SelectTargetsDropdown - component", () => {
     onSelect: noop,
     selectedTargets: [],
     targetsCount: 0,
+    queryId: 1,
   };
   afterEach(() => nock.cleanAll());
 
@@ -111,6 +112,7 @@ describe("SelectTargetsDropdown - component", () => {
     const defaultSelectedTargets = { hosts: [], labels: [] };
     const defaultParams = {
       query: "",
+      queryId: 1,
       selected: defaultSelectedTargets,
     };
     const expectedApiClientResponseWithTargets = {

--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsInput/SelectTargetsInput.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsInput/SelectTargetsInput.jsx
@@ -27,7 +27,7 @@ class SelectTargetsInput extends Component {
 
     return difference(options, selectedTargets);
   };
-
+  // TODO see react-select docs for onInputChange; it specifies two parameters "string", {action} so how to handle queryId? Can this be solved with const queryId from this.props?
   handleInputChange = debounce(
     (query) => {
       const { onTargetSelectInputChange } = this.props;

--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsInput/SelectTargetsInput.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsInput/SelectTargetsInput.jsx
@@ -27,7 +27,7 @@ class SelectTargetsInput extends Component {
 
     return difference(options, selectedTargets);
   };
-  // TODO see react-select docs for onInputChange; it specifies two parameters "string", {action} so how to handle queryId? Can this be solved with const queryId from this.props?
+
   handleInputChange = debounce(
     (query) => {
       const { onTargetSelectInputChange } = this.props;

--- a/frontend/components/queries/QueryPageSelectTargets/QueryPageSelectTargets.jsx
+++ b/frontend/components/queries/QueryPageSelectTargets/QueryPageSelectTargets.jsx
@@ -21,6 +21,7 @@ class QueryPageSelectTargets extends Component {
     targetsCount: PropTypes.number,
     queryTimerMilliseconds: PropTypes.number,
     disableRun: PropTypes.bool,
+    queryId: PropTypes.number,
   };
 
   render() {
@@ -36,6 +37,7 @@ class QueryPageSelectTargets extends Component {
       queryIsRunning,
       queryTimerMilliseconds,
       disableRun,
+      queryId,
     } = this.props;
 
     return (
@@ -47,6 +49,7 @@ class QueryPageSelectTargets extends Component {
           selectedTargets={selectedTargets}
           targetsCount={targetsCount}
           label="Select targets"
+          queryId={queryId}
         />
         <QueryProgressDetails
           campaign={campaign}

--- a/frontend/kolide/entities/targets.js
+++ b/frontend/kolide/entities/targets.js
@@ -8,13 +8,13 @@ const defaultSelected = {
 
 export default (client) => {
   return {
-    loadAll: (query, selected = defaultSelected) => {
+    loadAll: (query = "", queryId = null, selected = defaultSelected) => {
       const { TARGETS } = endpoints;
 
       return client
         .authenticatedPost(
           client._endpoint(TARGETS),
-          JSON.stringify({ query, selected })
+          JSON.stringify({ query, query_id: queryId, selected })
         )
         .then((response) => {
           const { targets } = response;

--- a/frontend/kolide/entities/targets.tests.js
+++ b/frontend/kolide/entities/targets.tests.js
@@ -19,12 +19,15 @@ describe("Kolide - API client (targets)", () => {
       const hosts = [];
       const labels = [];
       const query = "mac";
-      const request = targetMocks.loadAll.valid(bearerToken, query);
+      const queryId = 1;
+      const request = targetMocks.loadAll.valid(bearerToken, query, queryId);
 
       Kolide.setBearerToken(bearerToken);
-      return Kolide.targets.loadAll(query, { hosts, labels }).then(() => {
-        expect(request.isDone()).toEqual(true);
-      });
+      return Kolide.targets
+        .loadAll(query, queryId, { hosts, labels })
+        .then(() => {
+          expect(request.isDone()).toEqual(true);
+        });
     });
   });
 });

--- a/frontend/pages/queries/QueryPage/QueryPage.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.jsx
@@ -686,21 +686,17 @@ export class QueryPage extends Component {
       );
     };
 
-    // TODO: Modify observerCanQueryHostCount to reflect all hosts user can query
-    // This will depend on 5/26 API changes, if it comes back as 0, we will not render the dropdown for observers
-    const observerCanQueryHostCount = 1;
+    // Restricts Saving for Team maintainer
+    const { hasSavePermissions } = helpers;
 
-    // If team maintainer, can create and run new query, but not save
-    const hasSavePermissions =
-      permissionUtils.isGlobalAdmin(currentUser) ||
-      permissionUtils.isGlobalMaintainer(currentUser);
-
+    // Team maintainer: Create and run new query, but not save
     if (permissionUtils.isAnyTeamMaintainer(currentUser)) {
-      return (
-        <>
-          <div className={`${baseClass} has-sidebar`}>
-            <div className={`${baseClass}__content`}>
-              <div className={`${baseClass}__form body-wrap`}>
+      // Team maintainer: Existing query
+      if (queryId) {
+        return (
+          <div className={`${baseClass}__content`}>
+            <div className={`${baseClass}__observer-query-view body-wrap`}>
+              <div className={`${baseClass}__observer-query-details`}>
                 <Link
                   to={PATHS.MANAGE_QUERIES}
                   className={`${baseClass}__back-link`}
@@ -708,55 +704,66 @@ export class QueryPage extends Component {
                   <img src={BackChevron} alt="back chevron" id="back-chevron" />
                   <span>Back to queries</span>
                 </Link>
-                {queryId && (
-                  <>
-                    <h1>{query.name}</h1>
-                    <p>{query.description}</p>
-                    {editDisabledSql()}
-                  </>
-                )}
-                {!queryId && (
-                  <QueryForm
-                    formData={query}
-                    handleSubmit={onSaveQueryFormSubmit}
-                    onChangeFunc={onChangeQueryFormField}
-                    onOsqueryTableSelect={onOsqueryTableSelect}
-                    onRunQuery={onRunQuery}
-                    onStopQuery={onStopQuery}
-                    onUpdate={onUpdateQuery}
-                    queryIsRunning={queryIsRunning}
-                    serverErrors={errors}
-                    selectedOsqueryTable={selectedOsqueryTable}
-                    title={title}
-                    hasSavePermissions={hasSavePermissions}
-                  />
-                )}
+                <h1>{query.name}</h1>
+                <p>{query.description}</p>
+                {editDisabledSql()}
               </div>
-              {observerCanQueryHostCount > 0 && (
-                <>
-                  {renderLiveQueryWarning()}
-                  {renderTargetsInput()}
-                  {renderResultsTable()}
-                </>
-              )}
+              {renderLiveQueryWarning()}
+              {renderTargetsInput()}
+              {renderResultsTable()}
             </div>
-            {!queryId && (
-              <QuerySidePanel
-                onOsqueryTableSelect={onOsqueryTableSelect}
-                onTextEditorInputChange={onTextEditorInputChange}
-                selectedOsqueryTable={selectedOsqueryTable}
-              />
-            )}
           </div>
-        </>
+        );
+      }
+
+      // Team maintainer: New query
+      return (
+        <div className={`${baseClass} has-sidebar`}>
+          <div className={`${baseClass}__content`}>
+            <div className={`${baseClass}__form body-wrap`}>
+              <Link
+                to={PATHS.MANAGE_QUERIES}
+                className={`${baseClass}__back-link`}
+              >
+                <img src={BackChevron} alt="back chevron" id="back-chevron" />
+                <span>Back to queries</span>
+              </Link>
+              <QueryForm
+                formData={query}
+                handleSubmit={onSaveQueryFormSubmit}
+                onChangeFunc={onChangeQueryFormField}
+                onOsqueryTableSelect={onOsqueryTableSelect}
+                onRunQuery={onRunQuery}
+                onStopQuery={onStopQuery}
+                onUpdate={onUpdateQuery}
+                queryIsRunning={queryIsRunning}
+                serverErrors={errors}
+                selectedOsqueryTable={selectedOsqueryTable}
+                title={title}
+                hasSavePermissions={hasSavePermissions(currentUser)}
+              />
+            </div>
+            {renderLiveQueryWarning()}
+            {renderTargetsInput()}
+            {renderResultsTable()}
+          </div>
+          <QuerySidePanel
+            onOsqueryTableSelect={onOsqueryTableSelect}
+            onTextEditorInputChange={onTextEditorInputChange}
+            selectedOsqueryTable={selectedOsqueryTable}
+          />
+        </div>
       );
     }
 
+    // Global Observer or Team Maintainer or Team Observer: Restricted UI
     if (
       permissionUtils.isGlobalObserver(currentUser) ||
       !permissionUtils.isOnGlobalTeam(currentUser)
     ) {
-      // Restricted UI for Global Observer or Team Maintainer or Team Observer
+      // Restricts targets dropdown
+      const { showDropdown } = helpers;
+
       return (
         <div className={`${baseClass}__content`}>
           <div className={`${baseClass}__observer-query-view body-wrap`}>
@@ -772,7 +779,7 @@ export class QueryPage extends Component {
               <p>{query.description}</p>
               {editDisabledSql()}
             </div>
-            {observerCanQueryHostCount > 0 && (
+            {showDropdown(query, currentUser) && (
               <div>
                 {renderLiveQueryWarning()}
                 {renderTargetsInput()}
@@ -784,7 +791,7 @@ export class QueryPage extends Component {
       );
     }
 
-    // UI for Global Admin and Global Maintainer
+    // Global Admin or Global Maintainer: Full functionality
     return (
       <div className={`${baseClass} has-sidebar`}>
         <div className={`${baseClass}__content`}>

--- a/frontend/pages/queries/QueryPage/QueryPage.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.jsx
@@ -234,7 +234,7 @@ export class QueryPage extends Component {
 
     return false;
   };
-
+  // TODO trace onFetch and related setSelected methods with query params/arguments to see if they need to be updated to take queryId
   onFetchTargets = (query, targetResponse) => {
     const { dispatch } = this.props;
 
@@ -608,6 +608,8 @@ export class QueryPage extends Component {
       liveQueryError,
     } = this.state;
     const { selectedTargets } = this.props;
+    const queryId = this.props.query.id;
+    console.log("queryId::::", queryId);
 
     return (
       <QueryPageSelectTargets
@@ -622,6 +624,7 @@ export class QueryPage extends Component {
         targetsCount={targetsCount}
         queryTimerMilliseconds={runQueryMilliseconds}
         disableRun={liveQueryError !== undefined}
+        queryId={queryId}
       />
     );
   };

--- a/frontend/pages/queries/QueryPage/QueryPage.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.jsx
@@ -233,7 +233,7 @@ export class QueryPage extends Component {
 
     return false;
   };
-  // TODO trace onFetch and related setSelected methods with query params/arguments to see if they need to be updated to take queryId
+
   onFetchTargets = (query, targetResponse) => {
     const { dispatch } = this.props;
 

--- a/frontend/pages/queries/QueryPage/QueryPage.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.jsx
@@ -649,6 +649,7 @@ export class QueryPage extends Component {
       title,
       currentUser,
     } = this.props;
+    const { hasSavePermissions, showDropdown } = helpers;
 
     const queryId = this.props.query.id;
 
@@ -685,9 +686,6 @@ export class QueryPage extends Component {
         </div>
       );
     };
-
-    // Restricts Saving for Team maintainer
-    const { hasSavePermissions } = helpers;
 
     // Team maintainer: Create and run new query, but not save
     if (permissionUtils.isAnyTeamMaintainer(currentUser)) {
@@ -761,9 +759,6 @@ export class QueryPage extends Component {
       permissionUtils.isGlobalObserver(currentUser) ||
       !permissionUtils.isOnGlobalTeam(currentUser)
     ) {
-      // Restricts targets dropdown
-      const { showDropdown } = helpers;
-
       return (
         <div className={`${baseClass}__content`}>
           <div className={`${baseClass}__observer-query-view body-wrap`}>
@@ -815,7 +810,7 @@ export class QueryPage extends Component {
               serverErrors={errors}
               selectedOsqueryTable={selectedOsqueryTable}
               title={title}
-              hasSavePermissions={hasSavePermissions}
+              hasSavePermissions={hasSavePermissions(currentUser)}
             />
           </div>
           {renderLiveQueryWarning()}

--- a/frontend/pages/queries/QueryPage/QueryPage.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.jsx
@@ -608,7 +608,6 @@ export class QueryPage extends Component {
     } = this.state;
     const { selectedTargets } = this.props;
     const queryId = this.props.query.id;
-    console.log("queryId::::", queryId);
 
     return (
       <QueryPageSelectTargets
@@ -695,7 +694,7 @@ export class QueryPage extends Component {
     const hasSavePermissions =
       permissionUtils.isGlobalAdmin(currentUser) ||
       permissionUtils.isGlobalMaintainer(currentUser);
-    console.log("queryId", queryId);
+
     if (permissionUtils.isAnyTeamMaintainer(currentUser)) {
       return (
         <>

--- a/frontend/pages/queries/QueryPage/helpers.js
+++ b/frontend/pages/queries/QueryPage/helpers.js
@@ -2,6 +2,7 @@ import { push } from "react-router-redux";
 import PATHS from "router/paths";
 import { differenceWith, isEqual, uniqWith } from "lodash";
 
+import permissionUtils from "utilities/permissions";
 import hostActions from "redux/nodes/entities/hosts/actions";
 import { setSelectedTargets } from "redux/nodes/components/QueryPages/actions";
 
@@ -44,4 +45,18 @@ export const fetchHost = (dispatch, hostID) => {
   });
 };
 
-export default { selectHosts, fetchHost };
+export const showDropdown = (query, currentUser) => {
+  if (query.observer_can_run) {
+    return true;
+  }
+  return !permissionUtils.isOnlyObserver(currentUser);
+};
+
+export const hasSavePermissions = (currentUser) => {
+  return (
+    permissionUtils.isGlobalAdmin(currentUser) ||
+    permissionUtils.isGlobalMaintainer(currentUser)
+  );
+};
+
+export default { selectHosts, fetchHost, showDropdown, hasSavePermissions };

--- a/frontend/test/mocks/target_mocks.js
+++ b/frontend/test/mocks/target_mocks.js
@@ -2,13 +2,14 @@ import createRequestMock from "test/mocks/create_request_mock";
 
 export default {
   loadAll: {
-    valid: (bearerToken, query) => {
+    valid: (bearerToken, query, queryId) => {
       return createRequestMock({
         bearerToken,
         endpoint: "/api/v1/fleet/targets",
         method: "post",
         params: {
           query,
+          query_id: queryId,
           selected: {
             hosts: [],
             labels: [],

--- a/frontend/test/target_mock.js
+++ b/frontend/test/target_mock.js
@@ -2,7 +2,7 @@ import nock from "nock";
 
 const defaultParams = {
   query: "",
-  queryId: 1,
+  query_id: 1,
   selected: {
     hosts: [],
     labels: [],

--- a/frontend/test/target_mock.js
+++ b/frontend/test/target_mock.js
@@ -2,6 +2,7 @@ import nock from "nock";
 
 const defaultParams = {
   query: "",
+  queryId: 1,
   selected: {
     hosts: [],
     labels: [],


### PR DESCRIPTION
Query Edit/Run: Select targets dropdown menu
- Utilizes API to only show hosts the user has access to
- If user `isOnlyObserver` and `observer_can_run` is` false`, does not render dropdown
- Move some helper functions to helpers.ts

TODO (chronological):
- [x]  Meet with @ghernandez345 re: code / organization
- [x] Fix broken tests
- [x] Attach screenshots @RachelElysia 
- [x] @noahtalerman QA

Global:
![Screen Shot 2021-06-04 at 12 53 53 PM](https://user-images.githubusercontent.com/71795832/120837383-a01a9500-c534-11eb-9937-971a632b7bb4.png)

Team Maintainer "create new query":
![Screen Shot 2021-06-04 at 1 01 36 PM](https://user-images.githubusercontent.com/71795832/120837693-069fb300-c535-11eb-84b1-9a7cca6fdc3c.png)

Team Maintainer existing query:
![Screen Shot 2021-06-04 at 1 15 00 PM](https://user-images.githubusercontent.com/71795832/120839408-e670f380-c536-11eb-96c1-2085f8383ad8.png)


Team observer `observer_can_run: true`:
![Screen Shot 2021-06-04 at 1 03 00 PM](https://user-images.githubusercontent.com/71795832/120837910-4797c780-c535-11eb-9584-3e47892ebf19.png)

Team observer `observe_can_run: false`:
Once API is updated, will not render dropdown
Conditional rendering on _QueryPage.jsx_ line 777 using helper function in _helpers.js_ line 48

Co-authored by: Sarah Gillespie @gillespi314 
Testing co-authored by: Gabriel Hernandez @ghernandez345 