### PR TITLE
Manage hosts: render host status icon

### DIFF
--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -112,6 +112,15 @@
         height: 8px;
         margin-right: $pad-small;
         width: 8px;
+        margin-bottom: 1px;
+      }
+
+      &--online:before {
+        background-color: $ui-success;
+      }
+
+      &--offline:before {
+        background-color: $ui-offline;
       }
     }
 


### PR DESCRIPTION
- Renders online and offline icons on manage host page

(I think refactoring this page in teams removed the icons somehow)

![Screen Shot 2021-06-02 at 3 46 24 PM](https://user-images.githubusercontent.com/71795832/120543073-e4355a80-c3b9-11eb-89b3-00f8917f799d.png)


