### PR TITLE
Fix firefox icons

### DIFF
--- a/frontend/components/forms/admin/AppConfigForm/_styles.scss
+++ b/frontend/components/forms/admin/AppConfigForm/_styles.scss
@@ -32,22 +32,23 @@
     @include clearfix;
     margin: 0 0 $pad-xlarge;
 
-    .upcarat {
+    .upcarat::after {
       content: url("../assets/images/icon-collapse-black-16x16@2x.png");
-      width: 16px;
-      height: 16px;
+      transform: scale(0.5);
       border-radius: 0px;
-      top: 5px;
-      margin: 4px;
+      position: relative;
+      top: 8px;
+      margin: $pad-xsmall;
     }
 
-    .downcarat {
+    .downcarat::after {
       content: url("../assets/images/icon-chevron-black-16x16@2x.png");
-      width: 16px;
-      height: 16px;
+      transform: scale(0.5);
       border-radius: 0px;
-      top: 5px;
-      margin: 4px;
+      position: relative;
+      top: 8px;
+      margin: $pad-xsmall;
+      margin-right: 18px;
     }
 
     h2 {

--- a/frontend/components/forms/fields/SelectTargetsDropdown/TargetOption/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/TargetOption/_styles.scss
@@ -25,10 +25,9 @@
     padding: 0;
   }
 
-  &__add-btn {
+  &__add-btn::after {
     content: url("../assets/images/icon-plus-circle-16x16@2x.png");
-    height: 16px;
-    width: 16px;
+    transform: scale(0.5);
     margin-top: 8px;
     border: none;
   }

--- a/frontend/components/modals/Modal/_styles.scss
+++ b/frontend/components/modals/Modal/_styles.scss
@@ -20,17 +20,15 @@
   &__ex {
     text-decoration: none;
 
-    .button {
+    .button::after {
       content: url("../assets/images/icon-close-fleet-blue-16x16@2x.png");
-      width: 17px;
-      height: 17px;
+      transform: scale(0.5);
       border-radius: 0px;
     }
 
-    .button:hover {
+    .button:hover::after {
       content: url("../assets/images/icon-close-vibrant-blue-16x16@2x.png");
-      width: 17px;
-      height: 17px;
+      transform: scale(0.5);
       border-radius: 0px;
     }
   }


### PR DESCRIPTION
Underlying issue: Firefox does not allow CSS property `content: url(imageurl);` unless it's on a pseudo element `::before` or `::after`

- Updates any css built icons appropriately

Closes #862 

<img width="1055" alt="Screen Shot 2021-06-02 at 4 35 41 PM" src="https://user-images.githubusercontent.com/71795832/120548839-d33c1780-c3c0-11eb-98a2-c8eba1fb2311.png">
<img width="276" alt="Screen Shot 2021-06-02 at 4 36 00 PM" src="https://user-images.githubusercontent.com/71795832/120548840-d3d4ae00-c3c0-11eb-9cd5-c51cc9eace70.png">
<img width="622" alt="Screen Shot 2021-06-02 at 4 36 18 PM" src="https://user-images.githubusercontent.com/71795832/120548843-d3d4ae00-c3c0-11eb-8612-988be8ba2e1f.png">
