### PR TITLE
Remove Redis read/write timeouts

### DIFF
--- a/server/pubsub/redis_query_results.go
+++ b/server/pubsub/redis_query_results.go
@@ -32,9 +32,9 @@ func NewRedisPool(server, password string, database int, useTLS bool) *redis.Poo
 				redis.DialDatabase(database),
 				redis.DialUseTLS(useTLS),
 				redis.DialConnectTimeout(5*time.Second),
-				redis.DialReadTimeout(5*time.Second),
-				redis.DialWriteTimeout(5*time.Second),
-				redis.DialKeepAlive(5*time.Second),
+				redis.DialKeepAlive(10*time.Second),
+				// Read/Write timeouts not set here because we may see results
+				// only rarely on the pub/sub channel.
 			)
 
 			if err != nil {


### PR DESCRIPTION
If no results were sent over the pubsub channel, the client would hang
up. This would cause the query to seem "hung".

Closes #911