### PR TITLE
Filter hosts and label counts by teams

### DIFF
--- a/server/datastore/datastore_labels.go
+++ b/server/datastore/datastore_labels.go
@@ -335,9 +335,10 @@ func testListHostsInLabel(t *testing.T, db kolide.Datastore) {
 	err = db.ApplyLabelSpecs([]*kolide.LabelSpec{l1})
 	require.Nil(t, err)
 
-	{
+	filter := kolide.TeamFilter{User: test.UserAdmin}
 
-		hosts, err := db.ListHostsInLabel(l1.ID, kolide.HostListOptions{})
+	{
+		hosts, err := db.ListHostsInLabel(filter, l1.ID, kolide.HostListOptions{})
 		require.Nil(t, err)
 		assert.Len(t, hosts, 0)
 	}
@@ -348,7 +349,7 @@ func testListHostsInLabel(t *testing.T, db kolide.Datastore) {
 	}
 
 	{
-		hosts, err := db.ListHostsInLabel(l1.ID, kolide.HostListOptions{})
+		hosts, err := db.ListHostsInLabel(filter, l1.ID, kolide.HostListOptions{})
 		require.Nil(t, err)
 		assert.Len(t, hosts, 3)
 	}
@@ -408,11 +409,13 @@ func testListUniqueHostsInLabels(t *testing.T, db kolide.Datastore) {
 		assert.Nil(t, err)
 	}
 
-	uniqueHosts, err := db.ListUniqueHostsInLabels([]uint{l1.ID, l2.ID})
+	filter := kolide.TeamFilter{User: test.UserAdmin}
+
+	uniqueHosts, err := db.ListUniqueHostsInLabels(filter, []uint{l1.ID, l2.ID})
 	assert.Nil(t, err)
 	assert.Equal(t, len(hosts), len(uniqueHosts))
 
-	labels, err := db.ListLabels(kolide.ListOptions{})
+	labels, err := db.ListLabels(filter, kolide.ListOptions{})
 	require.Nil(t, err)
 	require.Len(t, labels, 2)
 

--- a/server/datastore/inmem/hosts.go
+++ b/server/datastore/inmem/hosts.go
@@ -60,7 +60,7 @@ func (d *Datastore) Host(id uint) (*kolide.Host, error) {
 	return host, nil
 }
 
-func (d *Datastore) ListHosts(opt kolide.HostListOptions) ([]*kolide.Host, error) {
+func (d *Datastore) ListHosts(filter kolide.TeamFilter, opt kolide.HostListOptions) ([]*kolide.Host, error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
@@ -132,7 +132,7 @@ func (d *Datastore) ListHosts(opt kolide.HostListOptions) ([]*kolide.Host, error
 	return hosts, nil
 }
 
-func (d *Datastore) GenerateHostStatusStatistics(now time.Time) (online, offline, mia, new uint, err error) {
+func (d *Datastore) GenerateHostStatusStatistics(filter kolide.TeamFilter, now time.Time) (online, offline, mia, new uint, err error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 

--- a/server/datastore/inmem/labels.go
+++ b/server/datastore/inmem/labels.go
@@ -115,7 +115,7 @@ func (d *Datastore) Label(lid uint) (*kolide.Label, error) {
 	return label, nil
 }
 
-func (d *Datastore) ListLabels(opt kolide.ListOptions) ([]*kolide.Label, error) {
+func (d *Datastore) ListLabels(filter kolide.TeamFilter, opt kolide.ListOptions) ([]*kolide.Label, error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 	// We need to sort by keys to provide reliable ordering
@@ -177,7 +177,7 @@ func (d *Datastore) SearchLabels(filter kolide.TeamFilter, query string, omit ..
 	return results, nil
 }
 
-func (d *Datastore) ListHostsInLabel(lid uint, opt kolide.HostListOptions) ([]*kolide.Host, error) {
+func (d *Datastore) ListHostsInLabel(filter kolide.TeamFilter, lid uint, opt kolide.HostListOptions) ([]*kolide.Host, error) {
 	var hosts []*kolide.Host
 
 	d.mtx.Lock()
@@ -192,7 +192,7 @@ func (d *Datastore) ListHostsInLabel(lid uint, opt kolide.HostListOptions) ([]*k
 	return hosts, nil
 }
 
-func (d *Datastore) ListUniqueHostsInLabels(labels []uint) ([]*kolide.Host, error) {
+func (d *Datastore) ListUniqueHostsInLabels(filter kolide.TeamFilter, labels []uint) ([]*kolide.Host, error) {
 	var hosts []*kolide.Host
 
 	labelSet := map[uint]bool{}

--- a/server/kolide/hosts.go
+++ b/server/kolide/hosts.go
@@ -47,7 +47,7 @@ type HostStore interface {
 	// provided host enrollment cooldown, by returning an error if the host has
 	// enrolled within the cooldown period.
 	EnrollHost(osqueryHostId, nodeKey string, teamID *uint, cooldown time.Duration) (*Host, error)
-	ListHosts(opt HostListOptions) ([]*Host, error)
+	ListHosts(filter TeamFilter, opt HostListOptions) ([]*Host, error)
 	// AuthenticateHost authenticates and returns host metadata by node key.
 	// This method should not return the host "additional" information as this
 	// is not typically necessary for the operations performed by the osquery
@@ -66,9 +66,9 @@ type HostStore interface {
 	CleanupIncomingHosts(now time.Time) error
 	// GenerateHostStatusStatistics retrieves the count of online, offline,
 	// MIA and new hosts.
-	GenerateHostStatusStatistics(now time.Time) (online, offline, mia, new uint, err error)
+	GenerateHostStatusStatistics(filter TeamFilter, now time.Time) (online, offline, mia, new uint, err error)
 	// HostIDsByName Retrieve the IDs associated with the given hostnames
-	HostIDsByName(hostnames []string) ([]uint, error)
+	HostIDsByName(filter TeamFilter, hostnames []string) ([]uint, error)
 	// HostByIdentifier returns one host matching the provided identifier.
 	// Possible matches can be on osquery_host_identifier, node_key, UUID, or
 	// hostname.

--- a/server/kolide/labels.go
+++ b/server/kolide/labels.go
@@ -21,7 +21,7 @@ type LabelStore interface {
 	SaveLabel(label *Label) (*Label, error)
 	DeleteLabel(name string) error
 	Label(lid uint) (*Label, error)
-	ListLabels(opt ListOptions) ([]*Label, error)
+	ListLabels(filter TeamFilter, opt ListOptions) ([]*Label, error)
 
 	// LabelQueriesForHost returns the label queries that should be executed
 	// for the given host. The cutoff is the minimum timestamp a query
@@ -41,12 +41,12 @@ type LabelStore interface {
 
 	// ListHostsInLabel returns a slice of hosts in the label with the
 	// given ID.
-	ListHostsInLabel(lid uint, opt HostListOptions) ([]*Host, error)
+	ListHostsInLabel(filter TeamFilter, lid uint, opt HostListOptions) ([]*Host, error)
 
 	// ListUniqueHostsInLabels returns a slice of all of the hosts in the
 	// given label IDs. A host will only appear once in the results even if
 	// it is in multiple of the provided labels.
-	ListUniqueHostsInLabels(labels []uint) ([]*Host, error)
+	ListUniqueHostsInLabels(filter TeamFilter, labels []uint) ([]*Host, error)
 
 	SearchLabels(filter TeamFilter, query string, omit ...uint) ([]*Label, error)
 

--- a/server/mock/datastore_hosts.go
+++ b/server/mock/datastore_hosts.go
@@ -20,7 +20,7 @@ type HostFunc func(id uint) (*kolide.Host, error)
 
 type HostByIdentifierFunc func(identifier string) (*kolide.Host, error)
 
-type ListHostsFunc func(opt kolide.HostListOptions) ([]*kolide.Host, error)
+type ListHostsFunc func(filter kolide.TeamFilter, opt kolide.HostListOptions) ([]*kolide.Host, error)
 
 type EnrollHostFunc func(osqueryHostId, nodeKey string, teamID *uint, cooldown time.Duration) (*kolide.Host, error)
 
@@ -34,11 +34,11 @@ type CleanupIncomingHostsFunc func(t time.Time) error
 
 type SearchHostsFunc func(filter kolide.TeamFilter, query string, omit ...uint) ([]*kolide.Host, error)
 
-type GenerateHostStatusStatisticsFunc func(now time.Time) (online uint, offline uint, mia uint, new uint, err error)
+type GenerateHostStatusStatisticsFunc func(filter kolide.TeamFilter, now time.Time) (online uint, offline uint, mia uint, new uint, err error)
 
 type DistributedQueriesForHostFunc func(host *kolide.Host) (map[uint]string, error)
 
-type HostIDsByNameFunc func(hostnames []string) ([]uint, error)
+type HostIDsByNameFunc func(filter kolide.TeamFilter, hostnames []string) ([]uint, error)
 
 type AddHostsToTeamFunc func(teamID *uint, hostIDs []uint) error
 
@@ -122,9 +122,9 @@ func (s *HostStore) HostByIdentifier(identifier string) (*kolide.Host, error) {
 	return s.HostByIdentifierFunc(identifier)
 }
 
-func (s *HostStore) ListHosts(opt kolide.HostListOptions) ([]*kolide.Host, error) {
+func (s *HostStore) ListHosts(filter kolide.TeamFilter, opt kolide.HostListOptions) ([]*kolide.Host, error) {
 	s.ListHostsFuncInvoked = true
-	return s.ListHostsFunc(opt)
+	return s.ListHostsFunc(filter, opt)
 }
 
 func (s *HostStore) EnrollHost(osqueryHostId, nodeKey string, teamID *uint, cooldown time.Duration) (*kolide.Host, error) {
@@ -157,9 +157,9 @@ func (s *HostStore) SearchHosts(filter kolide.TeamFilter, query string, omit ...
 	return s.SearchHostsFunc(filter, query, omit...)
 }
 
-func (s *HostStore) GenerateHostStatusStatistics(now time.Time) (online uint, offline uint, mia uint, new uint, err error) {
+func (s *HostStore) GenerateHostStatusStatistics(filter kolide.TeamFilter, now time.Time) (online uint, offline uint, mia uint, new uint, err error) {
 	s.GenerateHostStatusStatisticsFuncInvoked = true
-	return s.GenerateHostStatusStatisticsFunc(now)
+	return s.GenerateHostStatusStatisticsFunc(filter, now)
 }
 
 func (s *HostStore) DistributedQueriesForHost(host *kolide.Host) (map[uint]string, error) {
@@ -167,9 +167,9 @@ func (s *HostStore) DistributedQueriesForHost(host *kolide.Host) (map[uint]strin
 	return s.DistributedQueriesForHostFunc(host)
 }
 
-func (s *HostStore) HostIDsByName(hostnames []string) ([]uint, error) {
+func (s *HostStore) HostIDsByName(filter kolide.TeamFilter, hostnames []string) ([]uint, error) {
 	s.HostIDsByNameFuncInvoked = true
-	return s.HostIDsByNameFunc(hostnames)
+	return s.HostIDsByNameFunc(filter, hostnames)
 }
 
 func (s *HostStore) AddHostsToTeam(teamID *uint, hostIDs []uint) error {

--- a/server/mock/datastore_labels.go
+++ b/server/mock/datastore_labels.go
@@ -24,7 +24,7 @@ type DeleteLabelFunc func(name string) error
 
 type LabelFunc func(lid uint) (*kolide.Label, error)
 
-type ListLabelsFunc func(opt kolide.ListOptions) ([]*kolide.Label, error)
+type ListLabelsFunc func(filter kolide.TeamFilter, opt kolide.ListOptions) ([]*kolide.Label, error)
 
 type LabelQueriesForHostFunc func(host *kolide.Host, cutoff time.Time) (map[string]string, error)
 
@@ -32,9 +32,9 @@ type RecordLabelQueryExecutionsFunc func(host *kolide.Host, results map[uint]boo
 
 type ListLabelsForHostFunc func(hid uint) ([]*kolide.Label, error)
 
-type ListHostsInLabelFunc func(lid uint, opt kolide.HostListOptions) ([]*kolide.Host, error)
+type ListHostsInLabelFunc func(filter kolide.TeamFilter, lid uint, opt kolide.HostListOptions) ([]*kolide.Host, error)
 
-type ListUniqueHostsInLabelsFunc func(labels []uint) ([]*kolide.Host, error)
+type ListUniqueHostsInLabelsFunc func(filter kolide.TeamFilter, labels []uint) ([]*kolide.Host, error)
 
 type SearchLabelsFunc func(filter kolide.TeamFilter, query string, omit ...uint) ([]*kolide.Label, error)
 
@@ -122,9 +122,9 @@ func (s *LabelStore) Label(lid uint) (*kolide.Label, error) {
 	return s.LabelFunc(lid)
 }
 
-func (s *LabelStore) ListLabels(opt kolide.ListOptions) ([]*kolide.Label, error) {
+func (s *LabelStore) ListLabels(filter kolide.TeamFilter, opt kolide.ListOptions) ([]*kolide.Label, error) {
 	s.ListLabelsFuncInvoked = true
-	return s.ListLabelsFunc(opt)
+	return s.ListLabelsFunc(filter, opt)
 }
 
 func (s *LabelStore) LabelQueriesForHost(host *kolide.Host, cutoff time.Time) (map[string]string, error) {
@@ -142,14 +142,14 @@ func (s *LabelStore) ListLabelsForHost(hid uint) ([]*kolide.Label, error) {
 	return s.ListLabelsForHostFunc(hid)
 }
 
-func (s *LabelStore) ListHostsInLabel(lid uint, opt kolide.HostListOptions) ([]*kolide.Host, error) {
+func (s *LabelStore) ListHostsInLabel(filter kolide.TeamFilter, lid uint, opt kolide.HostListOptions) ([]*kolide.Host, error) {
 	s.ListHostsInLabelFuncInvoked = true
-	return s.ListHostsInLabelFunc(lid, opt)
+	return s.ListHostsInLabelFunc(filter, lid, opt)
 }
 
-func (s *LabelStore) ListUniqueHostsInLabels(labels []uint) ([]*kolide.Host, error) {
+func (s *LabelStore) ListUniqueHostsInLabels(filter kolide.TeamFilter, labels []uint) ([]*kolide.Host, error) {
 	s.ListUniqueHostsInLabelsFuncInvoked = true
-	return s.ListUniqueHostsInLabelsFunc(labels)
+	return s.ListUniqueHostsInLabelsFunc(filter, labels)
 }
 
 func (s *LabelStore) SearchLabels(filter kolide.TeamFilter, query string, omit ...uint) ([]*kolide.Label, error) {

--- a/server/service/service_campaigns.go
+++ b/server/service/service_campaigns.go
@@ -16,7 +16,13 @@ import (
 )
 
 func (svc Service) NewDistributedQueryCampaignByNames(ctx context.Context, queryString string, queryID *uint, hosts []string, labels []string) (*kolide.DistributedQueryCampaign, error) {
-	hostIDs, err := svc.ds.HostIDsByName(hosts)
+	vc, ok := viewer.FromContext(ctx)
+	if !ok {
+		return nil, kolide.ErrNoContext
+	}
+	filter := kolide.TeamFilter{User: vc.User, IncludeObserver: true}
+
+	hostIDs, err := svc.ds.HostIDsByName(filter, hosts)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding host IDs")
 	}
@@ -25,8 +31,6 @@ func (svc Service) NewDistributedQueryCampaignByNames(ctx context.Context, query
 	if err != nil {
 		return nil, errors.Wrap(err, "finding label IDs")
 	}
-
-	// TODO handle teams
 
 	targets := kolide.HostTargets{HostIDs: hostIDs, LabelIDs: labelIDs}
 	return svc.NewDistributedQueryCampaign(ctx, queryString, queryID, targets)
@@ -41,6 +45,7 @@ func (svc Service) NewDistributedQueryCampaign(ctx context.Context, queryString 
 	if !ok {
 		return nil, kolide.ErrNoContext
 	}
+	filter := kolide.TeamFilter{User: vc.User, IncludeObserver: true}
 
 	if queryID == nil && queryString == "" {
 		return nil, kolide.NewInvalidArgumentError("query", "one of query or query_id must be specified")
@@ -113,8 +118,6 @@ func (svc Service) NewDistributedQueryCampaign(ctx context.Context, queryString 
 			return nil, errors.Wrap(err, "adding team target")
 		}
 	}
-
-	filter := kolide.TeamFilter{User: vc.User}
 
 	hostIDs, err := svc.ds.HostIDsInTargets(filter, targets)
 	if err != nil {

--- a/server/service/service_campaigns.go
+++ b/server/service/service_campaigns.go
@@ -45,7 +45,6 @@ func (svc Service) NewDistributedQueryCampaign(ctx context.Context, queryString 
 	if !ok {
 		return nil, kolide.ErrNoContext
 	}
-	filter := kolide.TeamFilter{User: vc.User, IncludeObserver: true}
 
 	if queryID == nil && queryString == "" {
 		return nil, kolide.NewInvalidArgumentError("query", "one of query or query_id must be specified")
@@ -73,6 +72,8 @@ func (svc Service) NewDistributedQueryCampaign(ctx context.Context, queryString 
 	if err != nil {
 		return nil, errors.Wrap(err, "new query")
 	}
+
+	filter := kolide.TeamFilter{User: vc.User, IncludeObserver: query.ObserverCanRun}
 
 	campaign, err := svc.ds.NewDistributedQueryCampaign(&kolide.DistributedQueryCampaign{
 		QueryID: query.ID,

--- a/server/service/service_hosts_test.go
+++ b/server/service/service_hosts_test.go
@@ -48,7 +48,8 @@ func TestDeleteHost(t *testing.T) {
 	err = svc.DeleteHost(test.UserContext(test.UserAdmin), host.ID)
 	assert.Nil(t, err)
 
-	hosts, err := ds.ListHosts(kolide.HostListOptions{})
+	filter := kolide.TeamFilter{User: test.UserAdmin}
+	hosts, err := ds.ListHosts(filter, kolide.HostListOptions{})
 	assert.Nil(t, err)
 	assert.Len(t, hosts, 0)
 
@@ -113,7 +114,7 @@ func TestAddHostsToTeamByFilter(t *testing.T) {
 	expectedHostIDs := []uint{1, 2, 4}
 	expectedTeam := (*uint)(nil)
 
-	ds.ListHostsFunc = func(opt kolide.HostListOptions) ([]*kolide.Host, error) {
+	ds.ListHostsFunc = func(filter kolide.TeamFilter, opt kolide.HostListOptions) ([]*kolide.Host, error) {
 		var hosts []*kolide.Host
 		for _, id := range expectedHostIDs {
 			hosts = append(hosts, &kolide.Host{ID: id})
@@ -137,7 +138,7 @@ func TestAddHostsToTeamByFilterLabel(t *testing.T) {
 	expectedTeam := ptr.Uint(1)
 	expectedLabel := ptr.Uint(2)
 
-	ds.ListHostsInLabelFunc = func(lid uint, opt kolide.HostListOptions) ([]*kolide.Host, error) {
+	ds.ListHostsInLabelFunc = func(filter kolide.TeamFilter, lid uint, opt kolide.HostListOptions) ([]*kolide.Host, error) {
 		assert.Equal(t, *expectedLabel, lid)
 		var hosts []*kolide.Host
 		for _, id := range expectedHostIDs {
@@ -157,7 +158,7 @@ func TestAddHostsToTeamByFilterEmptyHosts(t *testing.T) {
 	ds := new(mock.Store)
 	svc := newTestService(ds, nil, nil)
 
-	ds.ListHostsFunc = func(opt kolide.HostListOptions) ([]*kolide.Host, error) {
+	ds.ListHostsFunc = func(filter kolide.TeamFilter, opt kolide.HostListOptions) ([]*kolide.Host, error) {
 		return []*kolide.Host{}, nil
 	}
 	ds.AddHostsToTeamFunc = func(teamID *uint, hostIDs []uint) error {

--- a/server/service/service_labels.go
+++ b/server/service/service_labels.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 
+	"github.com/fleetdm/fleet/server/contexts/viewer"
 	"github.com/fleetdm/fleet/server/kolide"
 	"github.com/pkg/errors"
 )
@@ -94,8 +95,13 @@ func (svc *Service) ListLabels(ctx context.Context, opt kolide.ListOptions) ([]*
 	if err := svc.authz.Authorize(ctx, &kolide.Label{}, kolide.ActionRead); err != nil {
 		return nil, err
 	}
+	vc, ok := viewer.FromContext(ctx)
+	if !ok {
+		return nil, kolide.ErrNoContext
+	}
+	filter := kolide.TeamFilter{User: vc.User, IncludeObserver: true}
 
-	return svc.ds.ListLabels(opt)
+	return svc.ds.ListLabels(filter, opt)
 }
 
 func (svc *Service) GetLabel(ctx context.Context, id uint) (*kolide.Label, error) {
@@ -130,8 +136,13 @@ func (svc *Service) ListHostsInLabel(ctx context.Context, lid uint, opt kolide.H
 	if err := svc.authz.Authorize(ctx, &kolide.Label{}, kolide.ActionRead); err != nil {
 		return nil, err
 	}
+	vc, ok := viewer.FromContext(ctx)
+	if !ok {
+		return nil, kolide.ErrNoContext
+	}
+	filter := kolide.TeamFilter{User: vc.User, IncludeObserver: true}
 
-	return svc.ds.ListHostsInLabel(lid, opt)
+	return svc.ds.ListHostsInLabel(filter, lid, opt)
 }
 
 func (svc *Service) ListLabelsForHost(ctx context.Context, hid uint) ([]*kolide.Label, error) {


### PR DESCRIPTION
- Add TeamFilter to relevant host and label methods.
- Pass appropriate filter in service methods.

The dashboard should now show the appropriate hosts for a user's team membership.