### PR TITLE
Empty query message

### DIFF
--- a/frontend/components/queries/QueriesList/QueriesList.jsx
+++ b/frontend/components/queries/QueriesList/QueriesList.jsx
@@ -85,7 +85,7 @@ class QueriesList extends Component {
       <tr>
         <td colSpan={6}>
           <p>
-            No queries available. Try creating one or get started by{" "}
+            No queries available. Try creating one or get started by&nbsp;
             <a
               href="https://fleetdm.com/queries"
               target="_blank"

--- a/frontend/components/queries/QueriesList/QueriesList.jsx
+++ b/frontend/components/queries/QueriesList/QueriesList.jsx
@@ -86,7 +86,11 @@ class QueriesList extends Component {
         <td colSpan={6}>
           <p>
             No queries available. Try creating one or get started by{" "}
-            <a href="https://fleetdm.com/queries" target="_blank">
+            <a
+              href="https://fleetdm.com/queries"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               importing standard queries <FleetIcon name="external-link" />
             </a>
           </p>

--- a/frontend/components/queries/QueriesList/QueriesList.jsx
+++ b/frontend/components/queries/QueriesList/QueriesList.jsx
@@ -4,6 +4,7 @@ import classnames from "classnames";
 import { includes, sortBy, size } from "lodash";
 
 import queryInterface from "interfaces/query";
+import FleetIcon from "components/icons/FleetIcon";
 import Checkbox from "components/forms/fields/Checkbox";
 import QueriesListRow from "components/queries/QueriesList/QueriesListRow";
 
@@ -86,9 +87,8 @@ class QueriesList extends Component {
           <p>
             No queries available. Try creating one or get started by{" "}
             <a href="https://fleetdm.com/queries" target="_blank">
-              importing standard queries
+              importing standard queries <FleetIcon name="external-link" />
             </a>
-            .
           </p>
         </td>
       </tr>

--- a/frontend/components/queries/QueriesList/QueriesList.jsx
+++ b/frontend/components/queries/QueriesList/QueriesList.jsx
@@ -83,7 +83,13 @@ class QueriesList extends Component {
     return (
       <tr>
         <td colSpan={6}>
-          <p>No queries available. Try creating one.</p>
+          <p>
+            No queries available. Try creating one or get started by{" "}
+            <a href="https://fleetdm.com/queries" target="_blank">
+              importing standard queries
+            </a>
+            .
+          </p>
         </td>
       </tr>
     );

--- a/frontend/components/queries/QueriesList/_styles.scss
+++ b/frontend/components/queries/QueriesList/_styles.scss
@@ -6,6 +6,19 @@
   margin-top: $pad-medium;
   overflow: scroll;
 
+  a {
+    font-size: $x-small;
+    color: $core-vibrant-blue;
+    font-weight: $bold;
+    text-decoration: none;
+
+    img {
+      width: 12px;
+      height: 12px;
+      margin-left: 7px;
+    }
+  }
+
   &__table {
     border-collapse: collapse;
     width: 100%;


### PR DESCRIPTION
- Add link to standard query library into empty state in Query Manage page.

Short term solution until official mocks are made. 
Addresses #956 

![Screen Shot 2021-06-07 at 11 06 17 AM](https://user-images.githubusercontent.com/71795832/121041090-6fc73680-c780-11eb-8e31-61b9b9f7acc7.png)
