### PR TITLE
Add link to simulated host instructions in Testing docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,9 +7,17 @@ assignees: ''
 
 ---
 
-**Fleet version** (Head to the "My account" page in the Fleet UI or run `fleetctl version`): 
+**Fleet version** (Head to the "My account" page in the Fleet UI or run `fleetctl version`):
+
+**Fleet tier** (Are you using the free (Fleet Core) or paid (Fleet Basic) tier?):
+
+**User role** (Which role are you assigned in Fleet? (Admin, Maintainer, or Observer)):
+> 3 roles are introduced in Fleet 4.0.0. If you're using a prior version of Fleet or don't know your assigned role, please feel free to leave this item blank.
+
 **Operating system** _(e.g. macOS 11.2.3)_: 
+
 **Web browser** _(e.g. Chrome 88.0.4324)_: 
+
 <hr/>
 
 ### 🧑‍💻  Expected behavior

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,17 +7,9 @@ assignees: ''
 
 ---
 
-**Fleet version** (Head to the "My account" page in the Fleet UI or run `fleetctl version`):
-
-**Fleet tier** (Are you using the free (Fleet Core) or paid (Fleet Basic) tier?):
-
-**User role** (Which role are you assigned in Fleet? (Admin, Maintainer, or Observer)):
-> 3 roles are introduced in Fleet 4.0.0. If you're using a prior version of Fleet or don't know your assigned role, please feel free to leave this item blank.
-
+**Fleet version** (Head to the "My account" page in the Fleet UI or run `fleetctl version`): 
 **Operating system** _(e.g. macOS 11.2.3)_: 
-
 **Web browser** _(e.g. Chrome 88.0.4324)_: 
-
 <hr/>
 
 ### 🧑‍💻  Expected behavior

--- a/docs/4-Contribution/2-Testing.md
+++ b/docs/4-Contribution/2-Testing.md
@@ -1,6 +1,7 @@
 # Testing & Local Development
 
 - [License key](#license-key)
+- [Simulated hosts](#hosts)
 - [Test suite](#test-suite)
 - [End-to-end tests](#end-to-end-tests)
 - [Email](#email)
@@ -30,6 +31,12 @@ or
 ```
 ./build/fleet serve --dev --license_key=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbGVldCBEZXZpY2UgTWFuYWdlbWVudCBJbmMuIiwiZXhwIjoxNjQwOTk1MjAwLCJzdWIiOiJkZXZlbG9wbWVudCIsImRldmljZXMiOjEwMCwibm90ZSI6ImZvciBkZXZlbG9wbWVudCBvbmx5IiwidGllciI6ImJhc2ljIiwiaWF0IjoxNjIyNDI2NTg2fQ.WmZ0kG4seW3IrNvULCHUPBSfFdqj38A_eiXdV_DFunMHechjHbkwtfkf1J6JQJoDyqn8raXpgbdhafDwv3rmDw
 ```
+
+## Simulated hosts
+
+It can be helpful to quickly populate the UI with simulated hosts when developing or testing features that require host information.
+
+Check out [the instructions in the `/tools/osquery` directory](../../tools/osquery/README.md#testing-with-containerized-osqueryd) for starting up simulated hosts in your development environment.
 
 ## Test suite
 


### PR DESCRIPTION
- Add link testing documentation that points to instructions for starting up containerized hosts in the development environment. 