### PR TITLE
Add "Fleet tier" and "User role" as fields in "Bug" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,9 +7,17 @@ assignees: ''
 
 ---
 
-**Fleet version** (Head to the "My account" page in the Fleet UI or run `fleetctl version`): 
+**Fleet version** (Head to the "My account" page in the Fleet UI or run `fleetctl version`):
+
+**Fleet tier** (Are you using the free (Fleet Core) or paid (Fleet Basic) tier?):
+
+**User role** (Which role are you assigned in Fleet? (Admin, Maintainer, or Observer)):
+> 3 roles are introduced in Fleet 4.0.0. If you're using a prior version of Fleet or don't know your assigned role, please feel free to leave this item blank.
+
 **Operating system** _(e.g. macOS 11.2.3)_: 
+
 **Web browser** _(e.g. Chrome 88.0.4324)_: 
+
 <hr/>
 
 ### 🧑‍💻  Expected behavior

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,9 +6,10 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        check-modified-files-only: 'yes'
-        use-quiet-mode: 'yes'
-        config-file: .github/workflows/markdown-link-check-config.json
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          check-modified-files-only: "yes"
+          use-quiet-mode: "yes"
+          base-branch: main
+          config-file: .github/workflows/markdown-link-check-config.json


### PR DESCRIPTION
This PR is made to the `main` branch so the Fleet team can begin to use these fields when filing issues during manual QA. 

A note has been added to notify users of Fleet to leave these fields blank if they are using a version of Fleet prior to 4.0.0 (which will be everyone to start)

- Add a "Fleet tier" and "User role" to specify which tier of Fleet and which role the individual reporting the bug is assigned
- Edit Markdown Link Check GitHub action to run against the `main` branch