### PR TITLE
No teams tab for Core Tier

### DIFF
--- a/frontend/pages/admin/SettingsWrapper/SettingsWrapper.tsx
+++ b/frontend/pages/admin/SettingsWrapper/SettingsWrapper.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { Tab, Tabs, TabList } from "react-tabs";
 import { push } from "react-router-redux";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { IConfig } from "interfaces/config";
+import permissionUtils from "utilities/permissions";
 
 import PATHS from "router/paths";
 
@@ -10,7 +12,13 @@ interface ISettingSubNavItem {
   pathname: string;
 }
 
-const settingsSubNav: ISettingSubNavItem[] = [
+interface IRootState {
+  app: {
+    config: IConfig;
+  };
+}
+
+let settingsSubNav: ISettingSubNavItem[] = [
   {
     name: "Organization settings",
     pathname: PATHS.ADMIN_SETTINGS,
@@ -18,10 +26,6 @@ const settingsSubNav: ISettingSubNavItem[] = [
   {
     name: "Users",
     pathname: PATHS.ADMIN_USERS,
-  },
-  {
-    name: "Teams",
-    pathname: PATHS.ADMIN_TEAMS,
   },
 ];
 
@@ -45,6 +49,16 @@ const SettingsWrapper = (props: ISettingsWrapperProp): JSX.Element => {
     children,
     location: { pathname },
   } = props;
+
+  // Add Teams tab for basic tier only
+  const config = useSelector((state: IRootState) => state.app.config);
+  if (permissionUtils.isBasicTier(config)) {
+    settingsSubNav.push({
+      name: "Teams",
+      pathname: PATHS.ADMIN_TEAMS,
+    });
+  }
+
   const dispatch = useDispatch();
 
   const navigateToNav = (i: number): void => {

--- a/frontend/pages/admin/SettingsWrapper/SettingsWrapper.tsx
+++ b/frontend/pages/admin/SettingsWrapper/SettingsWrapper.tsx
@@ -18,7 +18,7 @@ interface IRootState {
   };
 }
 
-let settingsSubNav: ISettingSubNavItem[] = [
+const settingsSubNav: ISettingSubNavItem[] = [
   {
     name: "Organization settings",
     pathname: PATHS.ADMIN_SETTINGS,


### PR DESCRIPTION
- Utilizes permissions to render Teams tab for Basic Tier only

Closes #999 

Core Tier:
<img width="1590" alt="Screen Shot 2021-06-07 at 7 04 16 PM" src="https://user-images.githubusercontent.com/71795832/121098123-3532bd80-c7c3-11eb-9ec9-b2d5d4481680.png">

Basic Tier:
<img width="1585" alt="Screen Shot 2021-06-07 at 7 02 05 PM" src="https://user-images.githubusercontent.com/71795832/121098141-3b289e80-c7c3-11eb-9b6a-5a71a82d25e5.png">
