### PR TITLE
Remove push loop for Teams tab

### DIFF
--- a/frontend/pages/admin/SettingsWrapper/SettingsWrapper.tsx
+++ b/frontend/pages/admin/SettingsWrapper/SettingsWrapper.tsx
@@ -52,7 +52,8 @@ const SettingsWrapper = (props: ISettingsWrapperProp): JSX.Element => {
 
   // Add Teams tab for basic tier only
   const config = useSelector((state: IRootState) => state.app.config);
-  if (permissionUtils.isBasicTier(config)) {
+
+  if (settingsSubNav.length === 2 && permissionUtils.isBasicTier(config)) {
     settingsSubNav.push({
       name: "Teams",
       pathname: PATHS.ADMIN_TEAMS,


### PR DESCRIPTION
- Fix bug created by rendering Teams tab for Core only


Bug: Every time a user clicks a tab, it pushes a new Teams tab because it calls the component again

![Screen Shot 2021-06-08 at 11 48 20 AM](https://user-images.githubusercontent.com/71795832/121228971-65c63600-c85b-11eb-84c7-7a98fd100e63.png)
