### PR TITLE
Clean up linter warnings

### DIFF
--- a/frontend/components/AuthAnyMaintainerGlobalAdminRoutes/AuthAnyMaintainerGlobalAdminRoutes.tsx
+++ b/frontend/components/AuthAnyMaintainerGlobalAdminRoutes/AuthAnyMaintainerGlobalAdminRoutes.tsx
@@ -25,7 +25,7 @@ const { HOME } = paths;
  */
 const AuthAnyMaintainerGlobalAdminRoutes = (
   props: IAuthAnyMaintainerGlobalAdminRoutesProps
-) => {
+): JSX.Element | null => {
   const { children } = props;
 
   const dispatch = useDispatch();

--- a/frontend/components/BasicTierRoutes/BasicTierRoutes.tsx
+++ b/frontend/components/BasicTierRoutes/BasicTierRoutes.tsx
@@ -5,8 +5,6 @@ import { push } from "react-router-redux";
 import { IConfig } from "interfaces/config";
 import permissionUtils from "utilities/permissions";
 import paths from "router/paths";
-// @ts-ignore
-import { renderFlash } from "redux/nodes/notifications/actions";
 
 interface IBasicTierRoutes {
   children: JSX.Element;
@@ -20,7 +18,7 @@ interface IRootState {
 
 const { FLEET_403 } = paths;
 
-const BasicTierRoutes = (props: IBasicTierRoutes) => {
+const BasicTierRoutes = (props: IBasicTierRoutes): JSX.Element | null => {
   const { children } = props;
 
   const dispatch = useDispatch();

--- a/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tsx
+++ b/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useDispatch } from "react-redux";
 import { push } from "react-router-redux";
 
-import helpers from "fleet/helpers";
 import Button from "components/buttons/Button/Button";
 
 interface ILinkCellProps<T> {

--- a/frontend/components/TableContainer/TableContainerUtils.ts
+++ b/frontend/components/TableContainer/TableContainerUtils.ts
@@ -5,7 +5,7 @@ const generateResultsCountText = (
   pageIndex: number,
   pageSize: number,
   resultsCount: number
-) => {
+): string => {
   if (resultsCount === 0) return `No ${name}`;
 
   if (pageSize === resultsCount) return `${pageSize}+ ${name}`;

--- a/frontend/components/forms/validators/validate_presence/index.ts
+++ b/frontend/components/forms/validators/validate_presence/index.ts
@@ -1,3 +1,3 @@
-export default (actual: any) => {
+export default (actual: any): boolean => {
   return !!actual;
 };

--- a/frontend/components/modals/Modal/Modal.tsx
+++ b/frontend/components/modals/Modal/Modal.tsx
@@ -11,7 +11,7 @@ interface IModalProps {
 }
 
 class Modal extends Component<IModalProps> {
-  render() {
+  render(): JSX.Element {
     const { children, className, onExit, title } = this.props;
     const modalContainerClassName = classnames(
       `${baseClass}__modal_container`,

--- a/frontend/components/packs/PacksList/Row/Row.jsx
+++ b/frontend/components/packs/PacksList/Row/Row.jsx
@@ -44,10 +44,6 @@ class Row extends Component {
 
   renderStatusData = () => {
     const { disabled } = this.props.pack;
-    const iconClassName = classNames(`${baseClass}__status-icon`, {
-      [`${baseClass}__status-icon--enabled`]: !disabled,
-      [`${baseClass}__status-icon--disabled`]: disabled,
-    });
 
     if (disabled) {
       return (

--- a/frontend/components/side_panels/QueryDetailsSidePanel/QueryDetailsSidePanel.jsx
+++ b/frontend/components/side_panels/QueryDetailsSidePanel/QueryDetailsSidePanel.jsx
@@ -77,9 +77,7 @@ class QueryDetailsSidePanel extends Component {
       ) {
         return "Run query";
       }
-      if (permissionUtils.isOnlyObserver(currentUser) && !observer_can_run) {
-        return "Show query";
-      }
+      return "Show query";
     };
 
     return (

--- a/frontend/components/side_panels/SiteNavHeader/SiteNavHeader.jsx
+++ b/frontend/components/side_panels/SiteNavHeader/SiteNavHeader.jsx
@@ -2,21 +2,16 @@ import React, { Component } from "react";
 
 import configInterface from "interfaces/config";
 import OrgLogoIcon from "components/icons/OrgLogoIcon";
-import userInterface from "interfaces/user";
 
 class SiteNavHeader extends Component {
   static propTypes = {
     config: configInterface,
-    user: userInterface,
   };
 
   render() {
     const {
       config: { org_logo_url: orgLogoURL },
-      user,
     } = this.props;
-
-    const { username } = user;
 
     const headerBaseClass = "site-nav-header";
 

--- a/frontend/fleet/endpoints.ts
+++ b/frontend/fleet/endpoints.ts
@@ -45,10 +45,10 @@ export default {
   TEAMS_MEMBERS: (teamId: number): string => {
     return `/v1/fleet/teams/${teamId}/users`;
   },
-  TEAMS_TRANSFER_HOSTS: (teamId: number) => {
+  TEAMS_TRANSFER_HOSTS: (teamId: number): string => {
     return `/v1/fleet/teams/${teamId}/hosts`;
   },
-  TEAMS_ENROLL_SECRETS: (teamId: number) => {
+  TEAMS_ENROLL_SECRETS: (teamId: number): string => {
     return `/v1/fleet/teams/${teamId}/secrets`;
   },
   TEAMS_AGENT_OPTIONS: (teamId: number): string => {

--- a/frontend/fleet/entities/invites.tests.js
+++ b/frontend/fleet/entities/invites.tests.js
@@ -1,5 +1,3 @@
-import nock from "nock";
-
 import Fleet from "fleet";
 import mocks from "test/mocks";
 import { userStub } from "test/stubs";

--- a/frontend/interfaces/team.ts
+++ b/frontend/interfaces/team.ts
@@ -21,7 +21,7 @@ export interface ITeam {
   user_count: number;
   // role value is included when the team is in the context of a user.
   role?: string;
-  agent_options?: object; // eslint-disable-line react/forbid-prop-types
+  agent_options?: any;
 }
 
 /**

--- a/frontend/interfaces/team.ts
+++ b/frontend/interfaces/team.ts
@@ -7,7 +7,7 @@ export default PropTypes.shape({
   hosts: PropTypes.number,
   members: PropTypes.number,
   role: PropTypes.string,
-  agent_options: PropTypes.string,
+  agent_options: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 });
 
 /**
@@ -21,7 +21,7 @@ export interface ITeam {
   user_count: number;
   // role value is included when the team is in the context of a user.
   role?: string;
-  agent_options?: string;
+  agent_options?: object; // eslint-disable-line react/forbid-prop-types
 }
 
 /**

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
@@ -45,7 +45,7 @@ const AgentOptionsPage = (props: IAgentOptionsPageProps): JSX.Element => {
     osquery_options: yaml.dump(team.agent_options),
   };
 
-  const onSaveOsqueryOptionsFormSubmit = (updatedForm: any) => {
+  const onSaveOsqueryOptionsFormSubmit = (updatedForm: any): void | false => {
     const { error } = validateYaml(updatedForm.osquery_options);
     if (error) {
       dispatch(renderFlash("error", error.reason));
@@ -60,6 +60,7 @@ const AgentOptionsPage = (props: IAgentOptionsPageProps): JSX.Element => {
         dispatch(renderFlash("error", errors.stack));
       });
   };
+
   return (
     <div className={`${baseClass} body-wrap`}>
       <p className={`${baseClass}__page-description`}>

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPagePage/MembersPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPagePage/MembersPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 // @ts-ignore
 import memoize from "memoize-one";
@@ -201,7 +201,7 @@ const MembersPage = (props: IMembersPageProps): JSX.Element => {
       tableQueryData = { ...queryData, teamId };
       fetchUsers(queryData);
     },
-    [fetchUsers]
+    [fetchUsers, teamId]
   );
 
   const onActionSelection = (action: string, user: IUser): void => {

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
@@ -240,6 +240,7 @@ export class UserManagementPage extends Component {
       default:
         return null;
     }
+    return null;
   };
 
   getUser = (type, id) => {

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.tests.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.tests.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { mount } from "enzyme";
 
 import { connectedComponent, reduxMockStore } from "test/helpers";
@@ -14,15 +13,6 @@ const currentUser = {
   username: "gnardog",
   teams: [],
   global_role: "admin",
-};
-const invitedUser = {
-  email: "test+4@example.com",
-  global_role: "observer",
-  id: 6,
-  invited_by: 1,
-  name: "test 4",
-  sso_enabled: false,
-  teams: [],
 };
 const store = {
   app: {

--- a/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
@@ -1,4 +1,3 @@
-import { string } from "prop-types";
 import React from "react";
 
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";

--- a/frontend/pages/admin/UserManagementPage/components/DeleteUserForm/DeleteUserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/DeleteUserForm/DeleteUserForm.tsx
@@ -9,7 +9,7 @@ interface IDeleteUserForm {
   onCancel: () => void;
 }
 
-const DeleteUserForm = (props: IDeleteUserForm) => {
+const DeleteUserForm = (props: IDeleteUserForm): JSX.Element => {
   const { name, onDelete, onCancel } = props;
 
   return (

--- a/frontend/pages/admin/UserManagementPage/components/EditUserModal/EditUserModal.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/EditUserModal/EditUserModal.tsx
@@ -19,7 +19,7 @@ interface IEditUserModalProps {
 
 const baseClass = "edit-user-modal";
 
-const EditUserModal = (props: IEditUserModalProps) => {
+const EditUserModal = (props: IEditUserModalProps): JSX.Element => {
   const {
     onCancel,
     onSubmit,

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -1,4 +1,3 @@
-import { create } from "domain";
 import React, { Component, FormEvent } from "react";
 
 import { ITeam } from "interfaces/team";

--- a/frontend/pages/hosts/HostDetailsPage/SelectQueryModal/SelectQueryModal.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/SelectQueryModal/SelectQueryModal.jsx
@@ -179,6 +179,7 @@ const SelectQueryModal = (props) => {
         </div>
       );
     }
+    return null;
   };
 
   return (

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.jsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.jsx
@@ -215,6 +215,8 @@ export class ManageQueriesPage extends Component {
         </Button>
       );
     }
+
+    return null;
   };
 
   renderModal = () => {

--- a/frontend/pages/queries/QueryPage/QueryPage.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.jsx
@@ -400,7 +400,6 @@ export class QueryPage extends Component {
       window,
     } = global;
     const { queryResultsToggle, queryPosition } = this.state;
-    const { dispatch } = this.props;
     window.scrollTo(0, 0);
     const {
       parentNode: { parentNode: parent },

--- a/frontend/pages/queries/QueryPage/QueryPage.tests.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.tests.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import FileSave from "file-saver";
 import { mount } from "enzyme";
-import nock from "nock";
 import { noop } from "lodash";
 
 import convertToCSV from "utilities/convert_to_csv";


### PR DESCRIPTION
- Label easily recognizable proptypes
- Remove unused variables and functions
- Leave anything ambiguous alone include recently created files with numerous warnings

Co-authored by: Sarah Gillespie @gillespi314 