### PR TITLE
Host details page: Remove Query and Delete button for observers only

### DIFF
--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -53,6 +53,7 @@ export class HostDetailsPage extends Component {
     queries: PropTypes.arrayOf(queryInterface),
     queryErrors: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     isBasicTier: PropTypes.bool,
+    isOnlyObserver: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -195,10 +196,15 @@ export class HostDetailsPage extends Component {
 
   renderActionButtons = () => {
     const { toggleDeleteHostModal, toggleQueryHostModal } = this;
-    const { host } = this.props;
+    const { host, isOnlyObserver } = this.props;
 
     const isOnline = host.status === "online";
     const isOffline = host.status === "offline";
+
+    // Hide action buttons for global and team only observers
+    if (isOnlyObserver) {
+      return null;
+    }
 
     return (
       <div className={`${baseClass}__action-button-container`}>
@@ -640,7 +646,9 @@ const mapStateToProps = (state, ownProps) => {
   const host = entityGetter(state).get("hosts").findBy({ id: hostID });
   const { loading: isLoadingHost } = state.entities.hosts;
   const config = state.app.config;
+  const currentUser = state.auth.user;
   const isBasicTier = permissionUtils.isBasicTier(config);
+  const isOnlyObserver = permissionUtils.isOnlyObserver(currentUser);
 
   return {
     host,
@@ -649,6 +657,7 @@ const mapStateToProps = (state, ownProps) => {
     queries,
     queryErrors,
     isBasicTier,
+    isOnlyObserver,
   };
 };
 


### PR DESCRIPTION
- Utilize permissionUtils.isOnlyObserver to conditionally render CTA div containing Query and Delete button
- Tested backend post request for delete does not work for observer

Closes #1013 
Closes #1014 
 
Admin:
![Screen Shot 2021-06-09 at 11 07 48 AM](https://user-images.githubusercontent.com/71795832/121381196-805be600-c913-11eb-858b-0ea5ab084bb3.png)

Oliver the Observer:
![Screen Shot 2021-06-09 at 11 07 30 AM](https://user-images.githubusercontent.com/71795832/121381211-82be4000-c913-11eb-9eab-e202a5704c0c.png)