### PR TITLE
Change user settings dropdown for current user

### DIFF
--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
@@ -230,7 +230,12 @@ export class UserManagementPage extends Component {
   };
 
   onActionSelect = (action, user) => {
-    const { toggleEditUserModal, toggleDeleteUserModal, resetPassword } = this;
+    const {
+      toggleEditUserModal,
+      toggleDeleteUserModal,
+      resetPassword,
+      goToUserSettingsPage,
+    } = this;
     switch (action) {
       case "edit":
         toggleEditUserModal(user);
@@ -240,6 +245,9 @@ export class UserManagementPage extends Component {
         break;
       case "passwordReset":
         resetPassword(user);
+        break;
+      case "editMyAccount":
+        goToUserSettingsPage();
         break;
       default:
         return null;
@@ -299,6 +307,13 @@ export class UserManagementPage extends Component {
         );
       }
     );
+  };
+
+  goToUserSettingsPage = () => {
+    const { USER_SETTINGS } = paths;
+    const { dispatch } = this.props;
+
+    dispatch(push(USER_SETTINGS));
   };
 
   goToAppConfigPage = (evt) => {

--- a/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
@@ -186,6 +186,15 @@ const generateActionDropdownOptions = (
   id: number,
   currentUserId: number
 ): IDropdownOption[] => {
+  if (id === currentUserId) {
+    return [
+      {
+        label: "Edit my account",
+        disabled: false,
+        value: "editMyAccount",
+      },
+    ];
+  }
   return [
     {
       label: "Edit",

--- a/frontend/pages/admin/UserManagementPage/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/_styles.scss
@@ -120,4 +120,30 @@
       }
     }
   }
+
+  .Select.is-focused:not(.is-open) > .Select-control {
+    border: none;
+    box-shadow: none;
+  }
+  
+  .Select.is-open {
+    .Select-arrow {
+      margin-top: 4px;
+    }
+  }
+
+  .Select-arrow {
+    margin-top: 4px;
+  }
+
+  .Select-control:hover {
+    box-shadow: none;
+  }
+
+  .Select-placeholder {
+    font-size: 14px;
+    margin-top: 2px;
+    padding-left: 0;
+  }
+
 }


### PR DESCRIPTION
Closes #1010

On the user management page (`/settings/users`), replace the options presented in the "Actions" dropdown for the the current user with an "Edit my account" option that routes to the current user's `/profile` page.

<img width="561" alt="Screen Shot 2021-06-09 at 4 41 35 PM" src="https://user-images.githubusercontent.com/73313222/121433484-abf5c500-c941-11eb-8d91-c032aed909f2.png">
