### PR TITLE
Query Edit/Run Page: Conditionally render Teams grouping in select targets dropdown

### DIFF
--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsDropdown.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsDropdown.jsx
@@ -21,6 +21,7 @@ class SelectTargetsDropdown extends Component {
     selectedTargets: PropTypes.arrayOf(targetInterface),
     targetsCount: PropTypes.number,
     queryId: PropTypes.number,
+    isBasicTier: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -199,11 +200,12 @@ class SelectTargetsDropdown extends Component {
       onTargetSelectMoreInfo,
       renderLabel,
     } = this;
-    const { disabled, onSelect, selectedTargets } = this.props;
+    const { disabled, onSelect, selectedTargets, isBasicTier } = this.props;
     const menuRenderer = Menu(
       onTargetSelectMoreInfo,
       moreInfoTarget,
-      onBackToResults
+      onBackToResults,
+      isBasicTier
     );
 
     const inputClasses = classnames({
@@ -226,6 +228,7 @@ class SelectTargetsDropdown extends Component {
           onTargetSelectInputChange={fetchTargets}
           selectedTargets={selectedTargets}
           targets={targets}
+          isBasicTier={isBasicTier}
         />
       </div>
     );

--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/SelectTargetsMenu.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/SelectTargetsMenu.jsx
@@ -13,7 +13,8 @@ const baseClass = "target-list";
 const SelectTargetsMenuWrapper = (
   onMoreInfoClick,
   moreInfoTarget,
-  handleBackToResults
+  handleBackToResults,
+  isBasicTier
 ) => {
   const SelectTargetsMenu = ({
     focusedOption,
@@ -103,16 +104,20 @@ const SelectTargetsMenuWrapper = (
       return options.find((option) => option.count !== 0) !== undefined;
     };
 
+    const renderTargetGroups = (
+      <>
+        {renderTargets("all")}
+        {isBasicTier && renderTargets("teams")}
+        {renderTargets("labels")}
+        {renderTargets("hosts")}
+      </>
+    );
+
     return (
       <div className={baseClass}>
         <div className={`${baseClass}__options`}>
           {hasHostTargets ? (
-            <>
-              {renderTargets("all")}
-              {renderTargets("teams")}
-              {renderTargets("labels")}
-              {renderTargets("hosts")}
-            </>
+            renderTargetGroups
           ) : (
             <>
               <div className={`${baseClass}__no-hosts`}>
@@ -145,6 +150,7 @@ const SelectTargetsMenuWrapper = (
     valueArray: PropTypes.arrayOf(targetInterface),
     valueKey: PropTypes.string,
     onOptionRef: PropTypes.func,
+    isBasicTier: PropTypes.bool,
   };
 
   return SelectTargetsMenu;

--- a/frontend/components/queries/QueryPageSelectTargets/QueryPageSelectTargets.jsx
+++ b/frontend/components/queries/QueryPageSelectTargets/QueryPageSelectTargets.jsx
@@ -22,6 +22,7 @@ class QueryPageSelectTargets extends Component {
     queryTimerMilliseconds: PropTypes.number,
     disableRun: PropTypes.bool,
     queryId: PropTypes.number,
+    isBasicTier: PropTypes.bool,
   };
 
   render() {
@@ -38,6 +39,7 @@ class QueryPageSelectTargets extends Component {
       queryTimerMilliseconds,
       disableRun,
       queryId,
+      isBasicTier,
     } = this.props;
 
     return (
@@ -50,6 +52,7 @@ class QueryPageSelectTargets extends Component {
           targetsCount={targetsCount}
           label="Select targets"
           queryId={queryId}
+          isBasicTier={isBasicTier}
         />
         <QueryProgressDetails
           campaign={campaign}

--- a/frontend/pages/queries/QueryPage/QueryPage.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.jsx
@@ -70,6 +70,7 @@ export class QueryPage extends Component {
     requestHost: PropTypes.bool,
     hostId: PropTypes.string,
     currentUser: userInterface,
+    isBasicTier: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -609,7 +610,7 @@ export class QueryPage extends Component {
       runQueryMilliseconds,
       liveQueryError,
     } = this.state;
-    const { selectedTargets } = this.props;
+    const { selectedTargets, isBasicTier } = this.props;
     const queryId = this.props.query.id;
 
     return (
@@ -626,6 +627,7 @@ export class QueryPage extends Component {
         queryTimerMilliseconds={runQueryMilliseconds}
         disableRun={liveQueryError !== undefined}
         queryId={queryId}
+        isBasicTier={isBasicTier}
       />
     );
   };
@@ -859,6 +861,9 @@ const mapStateToProps = (state, ownProps) => {
     .findBy({ id: parseInt(hostId, 10) });
   const requestHost = hostId !== undefined && relatedHost === undefined;
   const currentUser = state.auth.user;
+  const config = state.app.config;
+
+  const isBasicTier = permissionUtils.isBasicTier(config);
 
   return {
     errors,
@@ -871,6 +876,7 @@ const mapStateToProps = (state, ownProps) => {
     hostId,
     title,
     currentUser,
+    isBasicTier,
   };
 };
 

--- a/frontend/pages/queries/QueryPage/QueryPage.tests.jsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.tests.jsx
@@ -12,7 +12,13 @@ import queryActions from "redux/nodes/entities/queries/actions";
 import ConnectedQueryPage, {
   QueryPage,
 } from "pages/queries/QueryPage/QueryPage";
-import { hostStub, queryStub, labelStub, userStub } from "test/stubs";
+import {
+  hostStub,
+  queryStub,
+  labelStub,
+  userStub,
+  configStub,
+} from "test/stubs";
 
 const {
   connectedComponent,
@@ -35,6 +41,7 @@ describe("QueryPage - component", () => {
   const store = {
     app: {
       isSmallNav: false,
+      config: configStub,
     },
     components: {
       QueryPages: {
@@ -206,6 +213,7 @@ describe("QueryPage - component", () => {
     const mockStoreWithQuery = reduxMockStore({
       app: {
         isSmallNav: false,
+        config: configStub,
       },
       components: {
         QueryPages: {


### PR DESCRIPTION
- Fleet Basic can see hosts grouped by teams, Fleet core cannot
- Utilizes permissions.ts `permissionUtils.isBasicTier `

Closes #1018 

Fleet Basic Admin:
![Screen Shot 2021-06-09 at 6 46 27 PM](https://user-images.githubusercontent.com/71795832/121439038-1d8a3f00-c953-11eb-95b1-ff1ba1180429.png)
Fleet Core Admin:
![Screen Shot 2021-06-09 at 6 46 53 PM](https://user-images.githubusercontent.com/71795832/121439041-1e22d580-c953-11eb-944d-1a14455f3d4f.png)
