### PR TITLE
Fix targeting Teams in live queries

### DIFF
--- a/server/datastore/mysql/campaigns.go
+++ b/server/datastore/mysql/campaigns.go
@@ -76,11 +76,14 @@ func (d *Datastore) DistributedQueryCampaignTargetIDs(id uint) (*fleet.HostTarge
 	labelIDs := []uint{}
 	teamIDs := []uint{}
 	for _, target := range targets {
-		if target.Type == fleet.TargetHost {
+		switch target.Type {
+		case fleet.TargetHost:
 			hostIDs = append(hostIDs, target.TargetID)
-		} else if target.Type == fleet.TargetLabel {
+		case fleet.TargetLabel:
 			labelIDs = append(labelIDs, target.TargetID)
-		} else {
+		case fleet.TargetTeam:
+			teamIDs = append(teamIDs, target.TargetID)
+		default:
 			return nil, errors.Errorf("invalid target type: %d", target.Type)
 		}
 	}

--- a/server/service/service_campaigns.go
+++ b/server/service/service_campaigns.go
@@ -109,11 +109,11 @@ func (svc Service) NewDistributedQueryCampaign(ctx context.Context, queryString 
 	}
 
 	// Add team targets
-	for _, lid := range targets.TeamIDs {
+	for _, tid := range targets.TeamIDs {
 		_, err = svc.ds.NewDistributedQueryCampaignTarget(&fleet.DistributedQueryCampaignTarget{
 			Type:                       fleet.TargetTeam,
 			DistributedQueryCampaignID: campaign.ID,
-			TargetID:                   lid,
+			TargetID:                   tid,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "adding team target")


### PR DESCRIPTION
Properly handle the `TargetTeam` type, allowing live queries to
successfully execute against Teams.

Part of #1022