### PR TITLE
Improve REST API auth docs

### DIFF
--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -64,28 +64,9 @@ All of these objects are put together and distributed to the appropriate osquery
 - [Initiate SSO](#initiate-sso)
 - [SSO callback](#sso-callback)
 
-All API requests to the Fleet server require API token authentication unless noted in the documentation.
+All API requests to the Fleet server require API token authentication unless noted in the documentation.  API tokens are tied to your Fleet user account.  
 
-To get an API token, send a request to the [login endpoint](#log-in):
-
-```
-{
-  "token": "<your token>",
-  "user": {
-    "created_at": "2020-11-13T22:57:12Z",
-    "updated_at": "2020-11-13T22:57:12Z",
-    "id": 1,
-    "username": "jane",
-    "name": "",
-    "email": "janedoe@example.com",
-    "admin": true,
-    "enabled": true,
-    "force_password_reset": false,
-    "gravatar_url": "",
-    "sso_enabled": false
-  }
-}
-```
+To get an API token, retrieve it from the "Account settings" > "Get API token" in the Fleet UI (`/profile`).  Or, you can send a request to the [login API endpoint](#log-in) to get your token.
 
 Then, use that API token to authenticate all subsequent API requests by sending it in the "Authorization" request header, prefixed with "Bearer ":
 
@@ -93,13 +74,14 @@ Then, use that API token to authenticate all subsequent API requests by sending 
 Authorization: Bearer <your token>
 ```
 
-> For SSO users, username/password login is disabled. The API token can instead be retrieved from the "Account settings" page in the UI (/profile). Choose "Get API token".
 
 ### Log in
 
 Authenticates the user with the specified credentials. Use the token returned from this endpoint to authenticate further API requests.
 
 `POST /api/v1/fleet/login`
+
+> This API endpoint is not available to SSO users, since username/password login is disabled for SSO users.  To get an API token for an SSO user, you can use the Fleet UI.
 
 #### Parameters
 


### PR DESCRIPTION
- based on customer feedback from today's call
- removes some sample data to increase signal-to-noise ratio  (and to dedupe)
- clarifies explicitly where API tokens come from
- make SSO note more visible
- but move SSO note so it's only visible in the situation where it's relevant:  i.e. when you're trying to programmatically get an API token.  (The easiest way to get a token for >80% of use cases is just to use the Fleet UI, so that's now what we recommend first.)