### PR TITLE
Fix set up flow styles

### DIFF
--- a/frontend/components/forms/RegistrationForm/_styles.scss
+++ b/frontend/components/forms/RegistrationForm/_styles.scss
@@ -43,7 +43,7 @@
       opacity: 0;
     }
 
-    &--kolide {
+    &--fleet {
       left: calc(150% + 220px);
       top: unquote("max(56%, 480px)");
       opacity: 0;
@@ -88,7 +88,7 @@
         opacity: 1;
       }
 
-      .user-registration__container--kolide {
+      .user-registration__container--fleet {
         left: calc(100% + 220px);
         opacity: 0;
       }
@@ -110,7 +110,7 @@
         opacity: 0;
       }
 
-      .user-registration__container--kolide {
+      .user-registration__container--fleet {
         left: 0;
         margin: auto;
         opacity: 1;
@@ -133,7 +133,7 @@
         opacity: 0;
       }
 
-      .user-registration__container--kolide {
+      .user-registration__container--fleet {
         left: -600px;
         opacity: 0;
       }


### PR DESCRIPTION
- The `<RegistrationForm />` component now uses `fleet` for class names. Update classnames in this component's stylesheet to use `fleet`

Before changes:
![localhost_8080_setup (5)](https://user-images.githubusercontent.com/47070608/121901296-45332b80-ccf4-11eb-8f4d-13f109f3e111.png)

After changes:
![localhost_8080_setup (6)](https://user-images.githubusercontent.com/47070608/121901315-48c6b280-ccf4-11eb-9523-b07fd578f208.png)
