### PR TITLE
Make password criteria messaging consistent

### DIFF
--- a/frontend/components/forms/ChangePasswordForm/ChangePasswordForm.jsx
+++ b/frontend/components/forms/ChangePasswordForm/ChangePasswordForm.jsx
@@ -40,6 +40,9 @@ class ChangePasswordForm extends Component {
           {...fields.new_password}
           label="New password"
           type="password"
+          hint={[
+            "Must include 7 characters, at least 1 number (e.g. 0 - 9), and at least 1 symbol (e.g. &*#)",
+          ]}
         />
         <InputField
           {...fields.new_password_confirmation}

--- a/frontend/components/forms/ChangePasswordForm/ChangePasswordForm.tests.jsx
+++ b/frontend/components/forms/ChangePasswordForm/ChangePasswordForm.tests.jsx
@@ -105,8 +105,7 @@ describe("ChangePasswordForm - component", () => {
     expect(handleSubmitSpy).not.toHaveBeenCalled();
 
     expect(component.state("errors")).toMatchObject({
-      new_password:
-        "Password must be at least 7 characters and contain at least 1 letter, 1 number, and 1 symbol",
+      new_password: "Password must meet the criteria below",
     });
   });
 });

--- a/frontend/components/forms/ChangePasswordForm/validate.js
+++ b/frontend/components/forms/ChangePasswordForm/validate.js
@@ -11,8 +11,7 @@ export default (formData) => {
   } = formData;
 
   if (newPassword && newPasswordConfirmation && !validPassword(newPassword)) {
-    errors.new_password =
-      "Password must be at least 7 characters and contain at least 1 letter, 1 number, and 1 symbol";
+    errors.new_password = "Password must meet the criteria below";
   }
 
   if (!oldPassword) {

--- a/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.tests.jsx
+++ b/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.tests.jsx
@@ -98,8 +98,7 @@ describe("AdminDetails - form", () => {
 
       expect(onSubmitSpy).not.toHaveBeenCalled();
       expect(form.state().errors).toMatchObject({
-        password:
-          "Password must be at least 7 characters and contain at least 1 letter, 1 number, and 1 symbol",
+        password: "Password must meet the criteria below",
       });
     });
 

--- a/frontend/components/forms/RegistrationForm/AdminDetails/helpers.js
+++ b/frontend/components/forms/RegistrationForm/AdminDetails/helpers.js
@@ -25,8 +25,7 @@ const validate = (formData) => {
   }
 
   if (password && passwordConfirmation && !validPassword(password)) {
-    errors.password =
-      "Password must be at least 7 characters and contain at least 1 letter, 1 number, and 1 symbol";
+    errors.password = "Password must meet the criteria below";
   }
 
   if (

--- a/frontend/components/forms/ResetPasswordForm/ResetPasswordForm.jsx
+++ b/frontend/components/forms/ResetPasswordForm/ResetPasswordForm.jsx
@@ -30,6 +30,9 @@ class ResetPasswordForm extends Component {
           placeholder="New password"
           className={`${baseClass}__input`}
           type="password"
+          hint={[
+            "Must include 7 characters, at least 1 number (e.g. 0 - 9), and at least 1 symbol (e.g. &*#)",
+          ]}
         />
         <InputFieldWithIcon
           {...fields.new_password_confirmation}

--- a/frontend/components/forms/ResetPasswordForm/ResetPasswordForm.tests.jsx
+++ b/frontend/components/forms/ResetPasswordForm/ResetPasswordForm.tests.jsx
@@ -90,7 +90,7 @@ describe("ResetPasswordForm - component", () => {
 
     expect(submitSpy).not.toHaveBeenCalled();
     expect(form.state().errors).toMatchObject({
-      new_password_confirmation: "Passwords Do Not Match",
+      new_password_confirmation: "Passwords do not match",
     });
   });
 
@@ -110,8 +110,7 @@ describe("ResetPasswordForm - component", () => {
 
     expect(submitSpy).not.toHaveBeenCalled();
     expect(form.state().errors).toMatchObject({
-      new_password:
-        "Password must be at least 7 characters and contain at least 1 letter, 1 number, and 1 symbol",
+      new_password: "Password must meet the criteria below",
     });
   });
 });

--- a/frontend/components/forms/ResetPasswordForm/validate.js
+++ b/frontend/components/forms/ResetPasswordForm/validate.js
@@ -16,8 +16,7 @@ const validate = (formData) => {
     !validateEquality(newPassword, newPasswordConfirmation);
 
   if (!validPassword(newPassword)) {
-    errors.new_password =
-      "Password must be at least 7 characters and contain at least 1 letter, 1 number, and 1 symbol";
+    errors.new_password = "Password must meet the criteria below";
   }
 
   if (!validatePresence(newPasswordConfirmation)) {
@@ -30,7 +29,7 @@ const validate = (formData) => {
   }
 
   if (noMatch) {
-    errors.new_password_confirmation = "Passwords Do Not Match";
+    errors.new_password_confirmation = "Passwords do not match";
   }
 
   const valid = !size(errors);


### PR DESCRIPTION
- Add the `hint` that is used on the _Set up_ page to the _Change password_ form and _Reset password_ form
- Add a consistent error message when a password fails to meet the criteria. Using the phrase "criteria below" because all pages render the above `hint`
- Adjust unit tests

Closes #1000 

![localhost_8080_setup (7)](https://user-images.githubusercontent.com/47070608/121961097-f8bc1000-cd34-11eb-90a4-5a842d0adc4e.png)
![localhost_8080_setup (8)](https://user-images.githubusercontent.com/47070608/121961100-f9ed3d00-cd34-11eb-88f3-bdfc32293df6.png)

The styling for error messages on the Set up page and the Change password page are inconsistent (red underline v. red background). A new issue will be filed and linked here: https://github.com/fleetdm/fleet/issues/1085