### PR TITLE
User Management Page: Edit user's email flash message

### DIFF
--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
@@ -109,6 +109,7 @@ export class UserManagementPage extends Component {
             renderFlash("success", `Successfully edited ${userEditing?.name}`)
           );
           toggleEditUserModal();
+          window.scrollTo(0, 0);
         })
         .catch(() => {
           dispatch(
@@ -118,13 +119,21 @@ export class UserManagementPage extends Component {
             )
           );
           toggleEditUserModal();
+          window.scrollTo(0, 0);
         });
+    }
+
+    let userUpdatedFlashMessage = "User updated";
+
+    if (userData.email !== formData.email) {
+      userUpdatedFlashMessage += `. A confirmation email was sent from ${currentUser.email} to ${formData.email}.`;
     }
 
     return dispatch(userActions.silentUpdate(userData, formData))
       .then(() => {
-        dispatch(renderFlash("success", "User updated"));
+        dispatch(renderFlash("success", userUpdatedFlashMessage));
         toggleEditUserModal();
+        window.scrollTo(0, 0);
       })
       .catch(() => {
         dispatch(
@@ -134,6 +143,7 @@ export class UserManagementPage extends Component {
           )
         );
         toggleEditUserModal();
+        window.scrollTo(0, 0);
       });
   };
 
@@ -151,12 +161,14 @@ export class UserManagementPage extends Component {
           renderFlash("success", `Successfully created ${formData.name}.`)
         );
         this.toggleCreateUserModal();
+        window.scrollTo(0, 0);
       })
       .catch(() => {
         dispatch(
           renderFlash("error", "Could not create user. Please try again.")
         );
         this.toggleCreateUserModal();
+        window.scrollTo(0, 0);
       });
   };
 
@@ -176,6 +188,7 @@ export class UserManagementPage extends Component {
           dispatch(
             renderFlash("success", `Successfully deleted ${userEditing?.name}.`)
           );
+          window.scrollTo(0, 0);
         })
         .catch(() => {
           dispatch(
@@ -184,6 +197,7 @@ export class UserManagementPage extends Component {
               `Could not delete ${userEditing?.name}. Please try again.`
             )
           );
+          window.scrollTo(0, 0);
         });
       toggleDeleteUserModal();
     } else {
@@ -199,6 +213,7 @@ export class UserManagementPage extends Component {
             )
           );
         });
+      window.scrollTo(0, 0);
       toggleDeleteUserModal();
     }
   };

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
@@ -126,7 +126,7 @@ export class UserManagementPage extends Component {
     let userUpdatedFlashMessage = "User updated";
 
     if (userData.email !== formData.email) {
-      userUpdatedFlashMessage += `. A confirmation email was sent from ${currentUser.email} to ${formData.email}.`;
+      userUpdatedFlashMessage += `: A confirmation email was sent from ${currentUser.email} to ${formData.email}`;
     }
 
     return dispatch(userActions.silentUpdate(userData, formData))

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
@@ -366,7 +366,13 @@ export class UserManagementPage extends Component {
   };
 
   renderCreateUserModal = () => {
-    const { currentUser, inviteErrors, config, teams } = this.props;
+    const {
+      currentUser,
+      inviteErrors,
+      config,
+      teams,
+      isBasicTier,
+    } = this.props;
     const { showCreateUserModal } = this.state;
     const { onCreateUserSubmit, toggleCreateUserModal } = this;
 
@@ -388,6 +394,7 @@ export class UserManagementPage extends Component {
           defaultGlobalRole={"observer"}
           defaultTeams={[]}
           submitText={"Create"}
+          isBasicTier={isBasicTier}
         />
       </Modal>
     );

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
@@ -95,7 +95,7 @@ export class UserManagementPage extends Component {
   }
 
   onEditUser = (formData) => {
-    const { currentUser, dispatch } = this.props;
+    const { currentUser, config, dispatch } = this.props;
     const { userEditing } = this.state;
     const { toggleEditUserModal, getUser } = this;
 
@@ -126,7 +126,7 @@ export class UserManagementPage extends Component {
     let userUpdatedFlashMessage = "User updated";
 
     if (userData.email !== formData.email) {
-      userUpdatedFlashMessage += `: A confirmation email was sent from ${currentUser.email} to ${formData.email}`;
+      userUpdatedFlashMessage += `: A confirmation email was sent from ${config.sender_address} to ${formData.email}`;
     }
 
     return dispatch(userActions.silentUpdate(userData, formData))

--- a/server/mail/templates/change_email_confirmation.html
+++ b/server/mail/templates/change_email_confirmation.html
@@ -1,11 +1,14 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
     <style>
       body {
-        font-family: 'Nunito Sans', sans-serif;
+        font-family: "Nunito Sans", sans-serif;
       }
 
       h1 {
@@ -14,7 +17,7 @@
       }
 
       p {
-        line-height: 2.0;
+        line-height: 2;
       }
 
       a {
@@ -38,43 +41,104 @@
           padding: 20px !important;
         }
       }
-
     </style>
   </head>
   <body>
-    <table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" bgcolor="#F9FAFC" style="background: #F9FAFC; font-family: 'Nunito Sans', sans-serif; color: #66696f; border-collapse:collapse;">
+    <table
+      align="center"
+      border="0"
+      cellpadding="0"
+      cellspacing="0"
+      height="100%"
+      width="100%"
+      bgcolor="#F9FAFC"
+      style="
+        background: #f9fafc;
+        font-family: 'Nunito Sans', sans-serif;
+        color: #66696f;
+        border-collapse: collapse;
+      "
+    >
       <tr>
         <td valign="top" align="center">
-          <table width="580" align="center" cellpadding="0" cellspacing="0" bgcolor="#ffffff" style="margin: 20px 10px;">
+          <table
+            width="580"
+            align="center"
+            cellpadding="0"
+            cellspacing="0"
+            bgcolor="#ffffff"
+            style="margin: 20px 10px"
+          >
             <tr>
-              <td colspan="2" bgcolor="#ffffff" style="padding:20px; font-family: 'Nunito Sans', sans-serif;">
-                <img src="{{.AssetURL}}/assets/images/fleet-logo-color@2x.png?raw=true" width="174" height="48" />
+              <td
+                colspan="2"
+                bgcolor="#ffffff"
+                style="padding: 20px; font-family: 'Nunito Sans', sans-serif"
+              >
+                <img
+                  src="{{.AssetURL}}/assets/images/fleet-logo-color@2x.png?raw=true"
+                  width="174"
+                  height="48"
+                />
               </td>
             </tr>
             <tr>
-              <td colspan="2" style="padding:60px; font-family: 'Nunito Sans', sans-serif;">
+              <td
+                colspan="2"
+                style="padding: 60px; font-family: 'Nunito Sans', sans-serif"
+              >
                 <h1>Change Confirmation</h1>
                 <p><strong>Hello,</strong></p>
-                <p>This message is to confirm that the email address you recently changed actually works.  Please click the link below to confirm that you want to change your email address in Kolide.</p>
+                <p>
+                  This message is to confirm that the email address you recently
+                  changed actually works. Please click the link below to confirm
+                  that you want to change your email address in Fleet.
+                </p>
                 <table bgcolor="#F9FAFC" height="100px" cellpadding="20px">
                   <tr>
-                    <td style="font-family: 'Nunito Sans', sans-serif;">
-                      <a href="{{.BaseURL}}/email/change/{{.Token}}">{{.BaseURL}}/email/change/{{.Token}}</a>
+                    <td style="font-family: 'Nunito Sans', sans-serif">
+                      <a href="{{.BaseURL}}/email/change/{{.Token}}"
+                        >{{.BaseURL}}/email/change/{{.Token}}</a
+                      >
                     </td>
                   </tr>
                 </table>
               </td>
             </tr>
             <tr bgcolor="#9ca3ac">
-              <td valign="middle" align="left" style="padding:10px 20px; font-family: 'Nunito Sans', sans-serif; color: #fff;">
-                <a href="https://github.com/fleetdm/fleet/tree/master/docs" style="color: #fff; text-decoration: none;">Fleet Documentation</a>
+              <td
+                valign="middle"
+                align="left"
+                style="
+                  padding: 10px 20px;
+                  font-family: 'Nunito Sans', sans-serif;
+                  color: #fff;
+                "
+              >
+                <a
+                  href="https://github.com/fleetdm/fleet/tree/master/docs"
+                  style="color: #fff; text-decoration: none"
+                  >Fleet Documentation</a
+                >
               </td>
-              <td valign="middle" align="right" style="padding:10px 20px; font-family: 'Nunito Sans', sans-serif;">
-                <a href="https://fleetdm.com" style="text-decoration: none;"><img src="{{.AssetURL}}/assets/images/fleet-logo-text-all-white@2x.png?raw=true" width="122" height="33" /></a>
+              <td
+                valign="middle"
+                align="right"
+                style="
+                  padding: 10px 20px;
+                  font-family: 'Nunito Sans', sans-serif;
+                "
+              >
+                <a href="https://fleetdm.com" style="text-decoration: none"
+                  ><img
+                    src="{{.AssetURL}}/assets/images/fleet-logo-text-all-white@2x.png?raw=true"
+                    width="122"
+                    height="33"
+                /></a>
               </td>
             </tr>
           </table>
-          <br>
+          <br />
         </td>
       </tr>
     </table>


### PR DESCRIPTION
- Renders flash message  "A confirmation email was sent from `currentUser.email `to `formData.email`."'
- For better UX, automatically scroll to flash messages for all flash messages rendered on this page
- Fix important email wording


Closes #1068 

Updated after change made to config.sender_address
![Screen Shot 2021-06-15 at 10 25 34 AM](https://user-images.githubusercontent.com/71795832/122070657-269c6580-cdc4-11eb-8e72-e3b3f180a094.png)

