### PR TITLE
Add commands for enrolling hosts in E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,8 +219,8 @@ e2e-setup:
 	./build/fleetctl user create --context e2e --username=sso_user --email=sso_user@example.com --sso=true
 
 e2e-serve-core:
-	./build/fleet serve --mysql_address=localhost:3307 --mysql_username=root --mysql_password=toor --mysql_database=e2e --server_address=localhost:8642 
+	./build/fleet serve --mysql_address=localhost:3307 --mysql_username=root --mysql_password=toor --mysql_database=e2e --server_address=0.0.0.0:8642 
 
 e2e-serve-basic:
-	./build/fleet serve  --dev_license --mysql_address=localhost:3307 --mysql_username=root --mysql_password=toor --mysql_database=e2e --server_address=localhost:8642
+	./build/fleet serve  --dev_license --mysql_address=localhost:3307 --mysql_username=root --mysql_password=toor --mysql_database=e2e --server_address=0.0.0.0:8642
 

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -29,9 +29,17 @@ describe("Hosts page", () => {
       cy.get("input[disabled]").should("have.value", contents);
     });
 
-    // Possibly in some environments the host will not yet be enrolled? Do we
-    // need some retry logic here?
-    cy.visit("/");
+    // Wait until the host becomes available (usually immediate in local
+    // testing, but may vary by environment).
+    cy.waitUntil(
+      () => {
+        cy.visit("/");
+        cy.get('button[title="Online"]');
+        return true;
+      },
+      { timeout: 30000, interval: 1000 }
+    );
+
     // Go to host details page
     cy.get('button[title="Online"]').click();
     cy.get("span.status").contains("online");

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -34,8 +34,7 @@ describe("Hosts page", () => {
     cy.waitUntil(
       () => {
         cy.visit("/");
-        cy.get('button[title="Online"]');
-        return true;
+        return Cypress.$('button[title="Online"]').length > 0;
       },
       { timeout: 30000, interval: 1000 }
     );

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -31,7 +31,6 @@ describe("Hosts page", () => {
 
     // Possibly in some environments the host will not yet be enrolled? Do we
     // need some retry logic here?
-    cy.wait(10000);
     cy.visit("/");
     // Go to host details page
     cy.get('button[title="Online"]').click();

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -31,6 +31,7 @@ describe("Hosts page", () => {
 
     // Possibly in some environments the host will not yet be enrolled? Do we
     // need some retry logic here?
+    cy.wait(10000);
     cy.visit("/");
     // Go to host details page
     cy.get('button[title="Online"]').click();

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -4,6 +4,11 @@ describe("Hosts page", () => {
   beforeEach(() => {
     cy.setup();
     cy.login();
+    cy.addDockerHost();
+  });
+
+  afterEach(() => {
+    cy.stopDockerHost();
   });
 
   it("Add new host", () => {
@@ -23,5 +28,12 @@ describe("Hosts page", () => {
     }).then((contents) => {
       cy.get("input[disabled]").should("have.value", contents);
     });
+
+    // Possibly in some environments the host will not yet be enrolled? Do we
+    // need some retry logic here?
+    cy.visit("/");
+    // Go to host details page
+    cy.get('button[title="Online"]').click();
+    cy.get("span.status").contains("online");
   });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,4 +1,5 @@
 import "@testing-library/cypress/add-commands";
+import "cypress-wait-until";
 
 // ***********************************************
 // This example commands.js shows you how to

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -80,5 +80,18 @@ declare namespace Cypress {
      * requests.
      */
     seedFigma(): Chainable<Element>;
+
+    /**
+     * Custom command to add Docker osquery host.
+     *
+     * NOTE: login() command is required before this, as it will make authenticated
+     * requests.
+     */
+    addDockerHost(): Chainable;
+
+    /**
+     * Custom command to stop any running Docker hosts.
+     */
+    stopDockerHost(): Chainable;
   }
 }

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -2,7 +2,12 @@
   "compilerOptions": {
     "target": "es5",
     "lib": ["es5", "dom"],
-    "types": ["cypress", "@testing-library/cypress", "node"]
+    "types": [
+      "cypress",
+      "@testing-library/cypress",
+      "node",
+      "cypress-wait-until"
+    ]
   },
   "include": ["**/*.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "babel-loader": "^8.2.1",
     "css-loader": "0.28.11",
     "cypress": "^6.9.1",
+    "cypress-wait-until": "^1.7.1",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
     "eslint": "^7.20.0",

--- a/tools/osquery/docker-compose.yml
+++ b/tools/osquery/docker-compose.yml
@@ -12,6 +12,8 @@ x-default-settings:
     core:
       hard:  1000000000
       soft:  1000000000
+  extra_hosts: &extra-hosts
+    - "host.docker.internal:host-gateway"
 
 services:
   ubuntu16-osquery:
@@ -20,6 +22,7 @@ services:
     environment: *default-environment
     command: *default-command
     ulimits: *default-ulimits
+    extra_hosts: *extra-hosts
 
   ubuntu18-osquery:
     image: "dactiv/osquery:4.5.1-ubuntu18.04"
@@ -27,6 +30,7 @@ services:
     environment: *default-environment
     command: *default-command
     ulimits: *default-ulimits
+    extra_hosts: *extra-hosts
 
   ubuntu20-osquery:
     image: "dactiv/osquery:4.5.1-ubuntu20.04"
@@ -34,6 +38,7 @@ services:
     environment: *default-environment
     command: *default-command
     ulimits: *default-ulimits
+    extra_hosts: *extra-hosts
 
   centos6-osquery:
     image: "dactiv/osquery:4.5.1-centos6"
@@ -41,6 +46,7 @@ services:
     environment: *default-environment
     command: *default-command
     ulimits: *default-ulimits
+    extra_hosts: *extra-hosts
 
   centos7-osquery:
     image: "dactiv/osquery:4.5.1-centos7"
@@ -48,6 +54,7 @@ services:
     environment: *default-environment
     command: *default-command
     ulimits: *default-ulimits
+    extra_hosts: *extra-hosts
 
   centos8-osquery:
     image: "dactiv/osquery:4.5.1-centos8"
@@ -55,3 +62,4 @@ services:
     environment: *default-environment
     command: *default-command
     ulimits: *default-ulimits
+    extra_hosts: *extra-hosts

--- a/yarn.lock
+++ b/yarn.lock
@@ -4580,6 +4580,11 @@ cyclist@~0.2.2:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
 
+cypress-wait-until@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-1.7.1.tgz#3789cd18affdbb848e3cfc1f918353c7ba1de6f8"
+  integrity sha512-8DL5IsBTbAxBjfYgCzdbohPq/bY+IKc63fxtso1C8RWhLnQkZbVESyaclNr76jyxfId6uyzX8+Xnt0ZwaXNtkA==
+
 cypress@*:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.8.0.tgz#8338f39212a8f71e91ff8c017a1b6e22d823d8c1"


### PR DESCRIPTION
- Add `addDockerHost` and `stopDockerHost` commands.
- Example usage in test.