### PR TITLE
Add hosts count to Team details page

### DIFF
--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -17,6 +17,7 @@ import EditTeamModal from "../components/EditTeamModal";
 import { IEditTeamFormData } from "../components/EditTeamModal/EditTeamModal";
 import AddHostsRedirectModal from "./components/AddHostsModal/AddHostsRedirectModal";
 
+import BackChevron from "../../../../../assets/images/icon-chevron-down-9x6@2x.png";
 import PencilIcon from "../../../../../assets/images/icon-pencil-14x14@2x.png";
 import TrashIcon from "../../../../../assets/images/icon-trash-14x14@2x.png";
 
@@ -159,17 +160,22 @@ const TeamDetailsWrapper = (props: ITeamDetailsPageProps): JSX.Element => {
       </div>
     );
   }
+  const hostsCount = team.host_count;
+  const hostsTotalDisplay = hostsCount === 1 ? "1 host" : `${hostsCount} hosts`;
 
   return (
     <div className={baseClass}>
       <div className={`${baseClass}__nav-header`}>
-        <Link className={`${baseClass}__back-link`} to={PATHS.ADMIN_TEAMS}>
-          Back to teams
+        <Link to={PATHS.ADMIN_TEAMS} className={`${baseClass}__back-link`}>
+          <img src={BackChevron} alt="back chevron" id="back-chevron" />
+          <span>Back to teams</span>
         </Link>
         <div className={`${baseClass}__team-header`}>
           <div className={`${baseClass}__team-details`}>
             <h1>{team.name}</h1>
-            <span className={`${baseClass}__host-count`}>0 hosts</span>
+            <span className={`${baseClass}__host-count`}>
+              {hostsTotalDisplay}
+            </span>
           </div>
           <div className={`${baseClass}__team-actions`}>
             <Button onClick={toggleAddHostsRedirectModal}>Add hosts</Button>

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/_styles.scss
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/_styles.scss
@@ -8,10 +8,18 @@
   }
 
   &__back-link {
-    color: $core-vibrant-blue;
+    display: flex;
+    align-items: center;
+    height: 16px;
     font-size: $x-small;
+    color: $core-vibrant-blue;
     font-weight: $bold;
     text-decoration: none;
+  }
+
+  #back-chevron {
+    width: 16px;
+    margin-right: $pad-small;
   }
 
   &__nav-header {


### PR DESCRIPTION
- Display number of hosts assigned to a team on the Team details page
  - Show "host" if only 1 host is assigned. Show "hosts" otherwise
- Add back button styles to "Back to teams" link
![localhost_8080_settings_teams_1_members (3)](https://user-images.githubusercontent.com/47070608/122071312-a4f90780-cdc4-11eb-868e-5ea25f1eeb74.png)
