### PR TITLE
E2e Testing: Fleet Core global observer

### DIFF
--- a/cypress/integration/basic/maintainer.spec.ts
+++ b/cypress/integration/basic/maintainer.spec.ts
@@ -13,7 +13,7 @@ if (Cypress.env("FLEET_TIER") === "basic") {
       cy.stopDockerHost();
     });
 
-    it("Can perform the appropriate actions", () => {
+    it("Can perform the appropriate basic global maintainer actions", () => {
       cy.login("mary@organization.com", "user123#");
       cy.visit("/");
 

--- a/cypress/integration/core/maintainer.spec.ts
+++ b/cypress/integration/core/maintainer.spec.ts
@@ -13,7 +13,7 @@ if (Cypress.env("FLEET_TIER") === "core") {
       cy.stopDockerHost();
     });
 
-    it("Can perform the appropriate actions", () => {
+    it("Can perform the appropriate core global maintainer actions", () => {
       cy.login("mary@organization.com", "user123#");
       cy.visit("/");
 

--- a/cypress/integration/core/observer.spec.ts
+++ b/cypress/integration/core/observer.spec.ts
@@ -4,10 +4,15 @@ if (Cypress.env("FLEET_TIER") === "core") {
       cy.setup();
       cy.login();
       cy.seedCore();
+      cy.addDockerHost();
       cy.logout();
     });
 
-    it("Can perform the appropriate actions", () => {
+    afterEach(() => {
+      cy.stopDockerHost();
+    });
+
+    it("Can perform the appropriate core global observer actions", () => {
       cy.login("oliver@organization.com", "user123#");
       cy.visit("/");
 

--- a/cypress/integration/core/observer.spec.ts
+++ b/cypress/integration/core/observer.spec.ts
@@ -4,6 +4,7 @@ if (Cypress.env("FLEET_TIER") === "core") {
       cy.setup();
       cy.login();
       cy.seedCore();
+      cy.seedQueries();
       cy.addDockerHost();
       cy.logout();
     });
@@ -19,7 +20,68 @@ if (Cypress.env("FLEET_TIER") === "core") {
       // Ensure page is loaded
       cy.contains("All hosts");
 
-      // TODO write the test!
+      // Nav restrictions
+      cy.findByText(/settings/i).should("not.exist");
+      cy.findByText(/packs/i).should("not.exist");
+      cy.visit("/settings/organization");
+      cy.findByText(/you do not have permissions/i).should("exist");
+      cy.visit("/packs/manage");
+      cy.findByText(/you do not have permissions/i).should("exist");
+
+      // Host manage page: No team UI, cannot add host or label
+      cy.visit("/hosts/manage");
+      cy.findByText(/teams/i).should("not.exist");
+      cy.contains("button", /add new host/i).should("not.exist");
+      cy.contains("button", /add new label/i).should("not.exist");
+
+      // Host details page: No team UI, cannot delete or query
+      cy.get("tbody").within(() => {
+        // Test host text varies
+        cy.findByRole("button").click();
+      });
+
+      cy.findByText(/team/i).should("not.exist");
+      cy.contains("button", /delete/i).should("not.exist");
+      cy.contains("button", /query/i).should("not.exist");
+
+      // Queries pages: Observer can or cannot run UI
+      cy.visit("/queries/manage");
+      cy.get("thead").within(() => {
+        cy.findByText(/observers can run/i).should("not.exist");
+      });
+
+      cy.findByRole("button", { name: /create new query/i }).should(
+        "not.exist"
+      );
+
+      cy.findByText(/detect presence/i).click();
+      cy.findByText(/sql/i).should("not.exist");
+      cy.findByText(/packs/i).should("not.exist");
+      cy.findByRole("button", { name: /run query/i }).click();
+      cy.findByLabelText(/query name/i).should("not.exist");
+      cy.findByLabelText(/sql/i).should("not.exist");
+      cy.findByLabelText(/description/i).should("not.exist");
+      cy.findByLabelText(/observer can run/i).should("not.exist");
+      cy.findByText(/show sql/i).click();
+      cy.get(".target-select").within(() => {
+        cy.findByText(/Label name, host name, IP address, etc./i).click();
+        cy.findByText(/teams/i).should("not.exist");
+      });
+      cy.findByRole("button", { name: /run/i }).should("exist");
+
+      cy.visit("/queries/manage");
+
+      cy.findByText(/get authorized/i).click();
+      cy.findByText(/sql/i).should("not.exist");
+      cy.findByText(/packs/i).should("not.exist");
+      cy.findByRole("button", { name: /show query/i }).click();
+      cy.findByLabelText(/query name/i).should("not.exist");
+      cy.findByLabelText(/sql/i).should("not.exist");
+      cy.findByLabelText(/description/i).should("not.exist");
+      cy.findByLabelText(/observer can run/i).should("not.exist");
+      cy.findByText(/show sql/i).click();
+      cy.get(".target-select").should("not.exist");
+      cy.findByRole("button", { name: /run/i }).should("not.exist");
     });
   });
 }

--- a/frontend/components/AuthGlobalAdminMaintainerRoutes/AuthGlobalAdminMaintainerRoutes.tsx
+++ b/frontend/components/AuthGlobalAdminMaintainerRoutes/AuthGlobalAdminMaintainerRoutes.tsx
@@ -40,7 +40,7 @@ const AuthGlobalAdminMaintainerRoutes = (
     !permissionUtils.isGlobalMaintainer(user)
   ) {
     dispatch(push(HOME));
-    dispatch(renderFlash("error", "test"));
+    dispatch(renderFlash("error", "You do not have permissions for that page"));
     return null;
   }
   return <>{children}</>;


### PR DESCRIPTION
- Core global observer e2e test matches manual QA docs

Nice add-ons:
- Better, differentiating test names
- Fix error message for attempting to reach packs/manage without permission

#1080 