### PR TITLE
Reorder migrations for pre-4.0 upgrades

### DIFF
--- a/server/datastore/mysql/migrations/tables/20210601000001_CreateTeamsTables.go
+++ b/server/datastore/mysql/migrations/tables/20210601000001_CreateTeamsTables.go
@@ -7,10 +7,10 @@ import (
 )
 
 func init() {
-	MigrationClient.AddMigration(Up_20210315111056, Down_20210315111056)
+	MigrationClient.AddMigration(Up_20210601000001, Down_20210601000001)
 }
 
-func Up_20210315111056(tx *sql.Tx) error {
+func Up_20210601000001(tx *sql.Tx) error {
 	if _, err := tx.Exec(`CREATE TABLE IF NOT EXISTS teams (
 		id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
 		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -49,6 +49,6 @@ func Up_20210315111056(tx *sql.Tx) error {
 	return nil
 }
 
-func Down_20210315111056(tx *sql.Tx) error {
+func Down_20210601000001(tx *sql.Tx) error {
 	return nil
 }

--- a/server/datastore/mysql/migrations/tables/20210601000002_AddRolesToInvites.go
+++ b/server/datastore/mysql/migrations/tables/20210601000002_AddRolesToInvites.go
@@ -7,10 +7,10 @@ import (
 )
 
 func init() {
-	MigrationClient.AddMigration(Up_20210401164226, Down_20210401164226)
+	MigrationClient.AddMigration(Up_20210601000002, Down_20210601000002)
 }
 
-func Up_20210401164226(tx *sql.Tx) error {
+func Up_20210601000002(tx *sql.Tx) error {
 	// Invites <> Teams mapping
 	if _, err := tx.Exec(`CREATE TABLE IF NOT EXISTS invite_teams (
 		invite_id INT UNSIGNED NOT NULL,
@@ -32,6 +32,6 @@ func Up_20210401164226(tx *sql.Tx) error {
 	return nil
 }
 
-func Down_20210401164226(tx *sql.Tx) error {
+func Down_20210601000002(tx *sql.Tx) error {
 	return nil
 }

--- a/server/datastore/mysql/migrations/tables/20210601000003_MigrateAdmin.go
+++ b/server/datastore/mysql/migrations/tables/20210601000003_MigrateAdmin.go
@@ -7,10 +7,10 @@ import (
 )
 
 func init() {
-	MigrationClient.AddMigration(Up_20210406113434, Down_20210406113434)
+	MigrationClient.AddMigration(Up_20210601000003, Down_20210601000003)
 }
 
-func Up_20210406113434(tx *sql.Tx) error {
+func Up_20210601000003(tx *sql.Tx) error {
 	// Old admins become global admins
 	query := `
 		UPDATE users
@@ -69,6 +69,6 @@ func Up_20210406113434(tx *sql.Tx) error {
 	return nil
 }
 
-func Down_20210406113434(tx *sql.Tx) error {
+func Down_20210601000003(tx *sql.Tx) error {
 	return nil
 }

--- a/server/datastore/mysql/migrations/tables/20210601000004_DeleteUsers.go
+++ b/server/datastore/mysql/migrations/tables/20210601000004_DeleteUsers.go
@@ -7,10 +7,10 @@ import (
 )
 
 func init() {
-	MigrationClient.AddMigration(Up_20210408153510, Down_20210408153510)
+	MigrationClient.AddMigration(Up_20210601000004, Down_20210601000004)
 }
 
-func Up_20210408153510(tx *sql.Tx) error {
+func Up_20210601000004(tx *sql.Tx) error {
 	query := "DELETE FROM users WHERE NOT enabled"
 	if _, err := tx.Exec(query); err != nil {
 		return errors.Wrap(err, "delete disabled users")
@@ -23,6 +23,6 @@ func Up_20210408153510(tx *sql.Tx) error {
 	return nil
 }
 
-func Down_20210408153510(tx *sql.Tx) error {
+func Down_20210601000004(tx *sql.Tx) error {
 	return nil
 }

--- a/server/datastore/mysql/migrations/tables/20210601000005_TeamsAgentOptions.go
+++ b/server/datastore/mysql/migrations/tables/20210601000005_TeamsAgentOptions.go
@@ -7,10 +7,10 @@ import (
 )
 
 func init() {
-	MigrationClient.AddMigration(Up_20210428163822, Down_20210428163822)
+	MigrationClient.AddMigration(Up_20210601000005, Down_20210601000005)
 }
 
-func Up_20210428163822(tx *sql.Tx) error {
+func Up_20210601000005(tx *sql.Tx) error {
 	sql := `
 		ALTER TABLE teams
 		ADD COLUMN agent_options JSON
@@ -18,9 +18,10 @@ func Up_20210428163822(tx *sql.Tx) error {
 	if _, err := tx.Exec(sql); err != nil {
 		return errors.Wrap(err, "add column agent_options")
 	}
+
 	return nil
 }
 
-func Down_20210428163822(tx *sql.Tx) error {
+func Down_20210601000005(tx *sql.Tx) error {
 	return nil
 }

--- a/server/datastore/mysql/migrations/tables/20210601000006_TeamsGlobalAgentOptions.go
+++ b/server/datastore/mysql/migrations/tables/20210601000006_TeamsGlobalAgentOptions.go
@@ -11,10 +11,10 @@ import (
 )
 
 func init() {
-	MigrationClient.AddMigration(Up_20210510111225, Down_20210510111225)
+	MigrationClient.AddMigration(Up_20210601000006, Down_20210601000006)
 }
 
-func Up_20210510111225(tx *sql.Tx) error {
+func Up_20210601000006(tx *sql.Tx) error {
 	existingOptions, err := copyOptions(tx)
 	if err != nil {
 		return errors.Wrap(err, "get existing options")
@@ -80,6 +80,6 @@ type optionsRow struct {
 	Options            string `db:"options"`
 }
 
-func Down_20210510111225(tx *sql.Tx) error {
+func Down_20210601000006(tx *sql.Tx) error {
 	return nil
 }

--- a/server/datastore/mysql/migrations/tables/20210601000007_TeamsObserverQueries.go
+++ b/server/datastore/mysql/migrations/tables/20210601000007_TeamsObserverQueries.go
@@ -7,10 +7,10 @@ import (
 )
 
 func init() {
-	MigrationClient.AddMigration(Up_20210517112751, Down_20210517112751)
+	MigrationClient.AddMigration(Up_20210601000007, Down_20210601000007)
 }
 
-func Up_20210517112751(tx *sql.Tx) error {
+func Up_20210601000007(tx *sql.Tx) error {
 	sql := `
 		ALTER TABLE queries
 		ADD COLUMN observer_can_run TINYINT(1) NOT NULL DEFAULT FALSE
@@ -21,6 +21,6 @@ func Up_20210517112751(tx *sql.Tx) error {
 	return nil
 }
 
-func Down_20210517112751(tx *sql.Tx) error {
+func Down_20210601000007(tx *sql.Tx) error {
 	return nil
 }

--- a/server/datastore/mysql/migrations/tables/20210601000008_TeamsEnrollSecrets.go
+++ b/server/datastore/mysql/migrations/tables/20210601000008_TeamsEnrollSecrets.go
@@ -7,10 +7,10 @@ import (
 )
 
 func init() {
-	MigrationClient.AddMigration(Up_20210527151852, Down_20210527151852)
+	MigrationClient.AddMigration(Up_20210601000008, Down_20210601000008)
 }
 
-func Up_20210527151852(tx *sql.Tx) error {
+func Up_20210601000008(tx *sql.Tx) error {
 	// Add team_id
 	sql := `
 		ALTER TABLE enroll_secrets
@@ -51,6 +51,6 @@ func Up_20210527151852(tx *sql.Tx) error {
 	return nil
 }
 
-func Down_20210527151852(tx *sql.Tx) error {
+func Down_20210601000008(tx *sql.Tx) error {
 	return nil
 }


### PR DESCRIPTION
Reorder migrations from the long-running `teams` branch to ensure that
they can run successfully for deployments upgrading from a pre-4.0
release.

All migrations from the `teams` branch are reordered to take place
_after_ all migrations from the `main` branch, using `20210601` as the
new date, after the latest released `main` branch migration on `20210526`.

Fixes #1058