### PR TITLE
E2e test: addDockerHost to a specific team

### DIFF
--- a/cypress/integration/basic/admin.spec.ts
+++ b/cypress/integration/basic/admin.spec.ts
@@ -6,7 +6,7 @@ if (Cypress.env("FLEET_TIER") === "basic") {
       cy.seedBasic();
       cy.setupSMTP();
       cy.seedQueries();
-      cy.addDockerHost();
+      cy.addDockerHost("oranges");
       cy.logout();
     });
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -234,6 +234,7 @@ Cypress.Commands.add("addUser", (username, options = {}) => {
   );
 });
 
+// Ability to add a docker host to a team using args if ran after seedBasic()
 Cypress.Commands.add("addDockerHost", (team = "") => {
   const serverPort = new URL(Cypress.config().baseUrl).port;
   // Get enroll secret
@@ -250,7 +251,6 @@ Cypress.Commands.add("addDockerHost", (team = "") => {
       bearer: window.localStorage.getItem("FLEET::auth_token"),
     },
   }).then(({ body }) => {
-    console.log("body:", body);
     const enrollSecret =
       team === "" ? body.specs.secrets[0].secret : body.secrets[0].secret;
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -234,16 +234,25 @@ Cypress.Commands.add("addUser", (username, options = {}) => {
   );
 });
 
-Cypress.Commands.add("addDockerHost", () => {
+Cypress.Commands.add("addDockerHost", (team = "") => {
   const serverPort = new URL(Cypress.config().baseUrl).port;
   // Get enroll secret
+  let enrollSecretURL = "/api/v1/fleet/spec/enroll_secret";
+  if (team === "apples") {
+    enrollSecretURL = "/api/v1/fleet/teams/1/secrets";
+  } else if (team === "oranges") {
+    enrollSecretURL = "/api/v1/fleet/teams/2/secrets";
+  }
+
   cy.request({
-    url: "/api/v1/fleet/spec/enroll_secret",
+    url: enrollSecretURL,
     auth: {
       bearer: window.localStorage.getItem("FLEET::auth_token"),
     },
   }).then(({ body }) => {
-    const enrollSecret = body.specs.secrets[0].secret;
+    console.log("body:", body);
+    const enrollSecret =
+      team === "" ? body.specs.secrets[0].secret : body.secrets[0].secret;
 
     // Start up docker-compose with enroll secret
     cy.exec(


### PR DESCRIPTION
- Uses addDockerHost argument to specify team as "apples" or "oranges"

Note: Can only add a host to a team if seedBasic() seeds teams first