### PR TITLE
E2e test: Fleet basic admin - test host on team

### DIFF
--- a/cypress/integration/basic/admin.spec.ts
+++ b/cypress/integration/basic/admin.spec.ts
@@ -6,7 +6,7 @@ if (Cypress.env("FLEET_TIER") === "basic") {
       cy.seedBasic();
       cy.setupSMTP();
       cy.seedQueries();
-      cy.addDockerHost();
+      cy.addDockerHost("apples");
       cy.logout();
     });
     afterEach(() => {
@@ -31,17 +31,15 @@ if (Cypress.env("FLEET_TIER") === "basic") {
       // See the “Select a team for this new host” in the Add new host modal. This modal appears after the user selects the “Add new host” button
       cy.get(".Select-control").click();
       cy.findByText(/no team/i).should("exist");
-      // cy.findByText(/apples/i).should("exist");
-      // cy.findByText(/oranges/i).should("exist");
-      // ^^TODO add back these assertions after dropdown bug is fixed
+      cy.findByText(/apples/i).should("exist");
+      cy.findByText(/oranges/i).should("exist");
 
       cy.contains("button", /done/i).click();
 
       // On the Host details page, they should…
       // See the “Team” information below the hostname
-      // cy.visit("/hosts/1");
-      // cy.findByText(/team/i).next().contains("Apples");
-      // ^^TODO this test depends on seeding hosts and assigning hosts to teams
+      cy.visit("/hosts/1");
+      cy.findByText(/team/i).next().contains("Apples");
 
       // On the Queries - new / edit / run page, they should…
       // See the “Teams” section in the Select target picker. This picker is summoned when the “Select targets” field is selected.

--- a/cypress/integration/basic/admin.spec.ts
+++ b/cypress/integration/basic/admin.spec.ts
@@ -30,9 +30,12 @@ if (Cypress.env("FLEET_TIER") === "basic") {
 
       // See the “Select a team for this new host” in the Add new host modal. This modal appears after the user selects the “Add new host” button
       cy.get(".Select-control").click();
-      cy.findByText(/no team/i).should("exist");
-      cy.findByText(/apples/i).should("exist");
-      cy.findByText(/oranges/i).should("exist");
+
+      cy.get(".add-host-modal__team-dropdown-wrapper").within(() => {
+        cy.findByText(/no team/i).should("exist");
+        cy.findByText(/apples/i).should("exist");
+        cy.findByText(/oranges/i).should("exist");
+      });
 
       cy.contains("button", /done/i).click();
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -234,16 +234,25 @@ Cypress.Commands.add("addUser", (username, options = {}) => {
   );
 });
 
-Cypress.Commands.add("addDockerHost", () => {
+// Ability to add a docker host to a team using args if ran after seedBasic()
+Cypress.Commands.add("addDockerHost", (team = "") => {
   const serverPort = new URL(Cypress.config().baseUrl).port;
   // Get enroll secret
+  let enrollSecretURL = "/api/v1/fleet/spec/enroll_secret";
+  if (team === "apples") {
+    enrollSecretURL = "/api/v1/fleet/teams/1/secrets";
+  } else if (team === "oranges") {
+    enrollSecretURL = "/api/v1/fleet/teams/2/secrets";
+  }
+
   cy.request({
-    url: "/api/v1/fleet/spec/enroll_secret",
+    url: enrollSecretURL,
     auth: {
       bearer: window.localStorage.getItem("FLEET::auth_token"),
     },
   }).then(({ body }) => {
-    const enrollSecret = body.specs.secrets[0].secret;
+    const enrollSecret =
+      team === "" ? body.specs.secrets[0].secret : body.secrets[0].secret;
 
     // Start up docker-compose with enroll secret
     cy.exec(


### PR DESCRIPTION
Global admin RBAC with host enrolled on a team
- Host enrolls on a team tested
- Enroll secrets dropdown tested


This PR is dependent of the last PR #1116 being merged. It uses the teams code.
@gillespi314 thanks for building out the code in the comments--worked great!