### PR TITLE
Add backend and fleetctl support for API-only user

### DIFF
--- a/cmd/fleetctl/user.go
+++ b/cmd/fleetctl/user.go
@@ -22,6 +22,7 @@ const (
 	passwordFlagName   = "password"
 	emailFlagName      = "email"
 	ssoFlagName        = "sso"
+	apiOnlyFlagName    = "api-only"
 )
 
 func userCommand() *cli.Command {
@@ -58,11 +59,15 @@ func createUserCommand() *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:  ssoFlagName,
-				Usage: "Enable user login via SSO (default false)",
+				Usage: "Enable user login via SSO",
+			},
+			&cli.BoolFlag{
+				Name:  apiOnlyFlagName,
+				Usage: "Make \"API-only\" user",
 			},
 			&cli.StringFlag{
 				Name:  globalRoleFlagName,
-				Usage: "Global role to assign to user (default observer)",
+				Usage: "Global role to assign to user (default \"observer\")",
 			},
 			&cli.StringSliceFlag{
 				Name:    "team",
@@ -84,6 +89,7 @@ func createUserCommand() *cli.Command {
 			password := c.String(passwordFlagName)
 			email := c.String(emailFlagName)
 			sso := c.Bool(ssoFlagName)
+			apiOnly := c.Bool(apiOnlyFlagName)
 			globalRoleString := c.String(globalRoleFlagName)
 			teamStrings := c.StringSlice(teamFlagName)
 
@@ -153,6 +159,7 @@ func createUserCommand() *cli.Command {
 				Email:                    &email,
 				SSOEnabled:               &sso,
 				AdminForcedPasswordReset: &force_reset,
+				APIOnly:                  &apiOnly,
 				GlobalRole:               globalRole,
 				Teams:                    &teams,
 			})

--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -1406,6 +1406,7 @@ None.
       "force_password_reset": false,
       "gravatar_url": "",
       "sso_enabled": false,
+      "api_only": false,
       "teams": [
         {
           "id": 1,
@@ -1563,13 +1564,14 @@ Creates a user account without requiring an invitation, the user is enabled imme
 
 #### Parameters
 
-| Name        | Type   | In   | Description                                                                                                                                                                                                                                                                                                                                            |
-| ----------- | ------ | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| username    | string | body | **Required**. The user's username.                                                                                                                                                                                                                                                                                                                     |
-| email       | string | body | **Required**. The user's email address.                                                                                                                                                                                                                                                                                                                |
-| password    | string | body | **Required**. The user's password.                                                                                                                                                                                                                                                                                                                     |
-| global_role | string | body | The role assigned to the user. In Fleet 4.0.0, 3 user roles were introduced (`admin`, `maintainer`, and `observer`). If `global_role` is specified, `teams` cannot be specified.                                                                                                                                                                       |
-| teams       | array  | body | _Available in Fleet Basic_ The teams and respective roles assigned to the user. Should contain an array of objects in which each object includes the team's `id` and the user's `role` on each team. In Fleet 4.0.0, 3 user roles were introduced (`admin`, `maintainer`, and `observer`). If `teams` is specified, `global_role` cannot be specified. |
+| Name        | Type    | In   | Description                                                                                                                                                                                                                                                                                                                                            |
+| ----------- | ------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| username    | string  | body | **Required**. The user's username.                                                                                                                                                                                                                                                                                                                     |
+| email       | string  | body | **Required**. The user's email address.                                                                                                                                                                                                                                                                                                                |
+| password    | string  | body | **Required**. The user's password.                                                                                                                                                                                                                                                                                                                     |
+| api_only    | boolean | body | User is an "API-only" user (cannot use web UI) if true.                                                                                                                                                                                                                                                                                                |
+| global_role | string  | body | The role assigned to the user. In Fleet 4.0.0, 3 user roles were introduced (`admin`, `maintainer`, and `observer`). If `global_role` is specified, `teams` cannot be specified.                                                                                                                                                                       |
+| teams       | array   | body | _Available in Fleet Basic_ The teams and respective roles assigned to the user. Should contain an array of objects in which each object includes the team's `id` and the user's `role` on each team. In Fleet 4.0.0, 3 user roles were introduced (`admin`, `maintainer`, and `observer`). If `teams` is specified, `global_role` cannot be specified. |
 
 #### Example
 
@@ -1612,6 +1614,7 @@ Creates a user account without requiring an invitation, the user is enabled imme
     "force_password_reset": false,
     "gravatar_url": "",
     "sso_enabled": false,
+    "api_only": false,
     "global_role": null,
     "teams": [
       {
@@ -1752,6 +1755,7 @@ Returns all information about a specific user.
 | position    | string  | body | The user's position.                                                                                                                                                                                                                                                                                                                                   |
 | email       | string  | body | The user's email.                                                                                                                                                                                                                                                                                                                                      |
 | sso_enabled | boolean | body | Whether or not SSO is enabled for the user.                                                                                                                                                                                                                                                                                                            |
+| api_only    | boolean | body | User is an "API-only" user (cannot use web UI) if true.                                                                                                                                                                                                                                                                                                |
 | global_role | string  | body | The role assigned to the user. In Fleet 4.0.0, 3 user roles were introduced (`admin`, `maintainer`, and `observer`). If `global_role` is specified, `teams` cannot be specified.                                                                                                                                                                       |
 | teams       | array   | body | _Available in Fleet Basic_ The teams and respective roles assigned to the user. Should contain an array of objects in which each object includes the team's `id` and the user's `role` on each team. In Fleet 4.0.0, 3 user roles were introduced (`admin`, `maintainer`, and `observer`). If `teams` is specified, `global_role` cannot be specified. |
 
@@ -1785,6 +1789,7 @@ Returns all information about a specific user.
     "force_password_reset": false,
     "gravatar_url": "",
     "sso_enabled": false,
+    "api_only": false,
     "teams": []
   }
 }

--- a/server/datastore/mysql/migrations/tables/20210616163757_AddApiOnlyToUser.go
+++ b/server/datastore/mysql/migrations/tables/20210616163757_AddApiOnlyToUser.go
@@ -1,0 +1,26 @@
+package tables
+
+import (
+	"database/sql"
+
+	"github.com/pkg/errors"
+)
+
+func init() {
+	MigrationClient.AddMigration(Up_20210616163757, Down_20210616163757)
+}
+
+func Up_20210616163757(tx *sql.Tx) error {
+	sql := `
+		ALTER TABLE users
+		ADD COLUMN api_only TINYINT(1) NOT NULL DEFAULT 0
+	`
+	if _, err := tx.Exec(sql); err != nil {
+		return errors.Wrap(err, "add column api_only")
+	}
+	return nil
+}
+
+func Down_20210616163757(tx *sql.Tx) error {
+	return nil
+}

--- a/server/datastore/mysql/users.go
+++ b/server/datastore/mysql/users.go
@@ -25,12 +25,13 @@ func (d *Datastore) NewUser(user *fleet.User) (*fleet.User, error) {
       	gravatar_url,
       	position,
         sso_enabled,
+		api_only,
 		global_role
-      ) VALUES (?,?,?,?,?,?,?,?,?,?)
+      ) VALUES (?,?,?,?,?,?,?,?,?,?,?)
       `
 	result, err := d.db.Exec(sqlStatement, user.Password, user.Salt, user.Name,
 		user.Username, user.Email,
-		user.AdminForcedPasswordReset, user.GravatarURL, user.Position, user.SSOEnabled,
+		user.AdminForcedPasswordReset, user.GravatarURL, user.Position, user.SSOEnabled, user.APIOnly,
 		user.GlobalRole)
 	if err != nil {
 		return nil, errors.Wrap(err, "create new user")
@@ -124,12 +125,13 @@ func (d *Datastore) SaveUser(user *fleet.User) error {
       	gravatar_url = ?,
       	position = ?,
         sso_enabled = ?,
+        api_only = ?,
 		global_role = ?
       WHERE id = ?
       `
 	result, err := d.db.Exec(sqlStatement, user.Username, user.Password,
 		user.Salt, user.Name, user.Email,
-		user.AdminForcedPasswordReset, user.GravatarURL, user.Position, user.SSOEnabled,
+		user.AdminForcedPasswordReset, user.GravatarURL, user.Position, user.SSOEnabled, user.APIOnly,
 		user.GlobalRole, user.ID)
 	if err != nil {
 		return errors.Wrap(err, "save user")

--- a/server/fleet/users.go
+++ b/server/fleet/users.go
@@ -108,6 +108,7 @@ type User struct {
 	// SSOEnabled if true, the user may only log in via SSO
 	SSOEnabled bool    `json:"sso_enabled" db:"sso_enabled"`
 	GlobalRole *string `json:"global_role" db:"global_role"`
+	APIOnly    bool    `json:"api_only" db:"api_only"`
 
 	// Teams is the teams this user has roles in.
 	Teams []UserTeam `json:"teams"`
@@ -145,6 +146,7 @@ type UserPayload struct {
 	SSOEnabled               *bool       `json:"sso_enabled,omitempty"`
 	GlobalRole               *string     `json:"global_role,omitempty"`
 	AdminForcedPasswordReset *bool       `json:"admin_forced_password_reset,omitempty"`
+	APIOnly                  *bool       `json:"api_only,omitempty"`
 	Teams                    *[]UserTeam `json:"teams,omitempty"`
 }
 
@@ -174,6 +176,9 @@ func (p UserPayload) User(keySize, cost int) (*User, error) {
 	}
 	if p.AdminForcedPasswordReset != nil {
 		user.AdminForcedPasswordReset = *p.AdminForcedPasswordReset
+	}
+	if p.APIOnly != nil {
+		user.APIOnly = *p.APIOnly
 	}
 	if p.Teams != nil {
 		user.Teams = *p.Teams


### PR DESCRIPTION
- Add api_only to users table.
- Pass api_only values through service.
- Allow setting api_only in `fleetctl user create`.

Backend part of #402