### PR TITLE
Move "connecting to the Mailhog simulated server" out of the FAQ 

### DIFF
--- a/docs/4-Contribution/2-Testing.md
+++ b/docs/4-Contribution/2-Testing.md
@@ -148,9 +148,11 @@ Tests will run automatically and results are reported to the shell.
 
 #### Manually testing email with MailHog
 
-To intercept sent emails while running a Fleet development environment, make sure that you've set the SMTP address to `localhost:1025` and leave the username and password blank. Then, visit http://localhost:8025 in a web browser to view the [MailHog](https://github.com/mailhog/MailHog) UI.
+To intercept sent emails while running a Fleet development environment, first, in the Fleet UI, navigate to the Organization settings page under Admin. 
 
-When Fleet sends emails, the contents of the messages are available in the MailHog UI.
+Then, in the "SMTP Options" section, enter any email address in the "Sender Address" field, set the "SMTP Server" to `localhost` on port `1025`, and set "Authentication Type" to `None`. Note that you may use any active or inactive sender address.
+
+Visit [locahost:8025](http://localhost:8025) to view Mailhog's admin interface which will display all emails sent using the simulated mail server.
 
 ## Database Backup/Restore
 

--- a/docs/4-Contribution/FAQ.md
+++ b/docs/4-Contribution/FAQ.md
@@ -26,12 +26,6 @@ make: *** [fleet] Error 2
 
 If you get an `undefined: Asset` error it is likely because you did not run `make generate` before `make build`. See [Building Fleet](./1-Building-Fleet.md) for additional documentation on compiling the `fleet` binary.
 
-## How do I connect to the Mailhog simulated mail server?
-
-First, in the Fleet UI, navigate to the App Settings page under Admin. Then, in the "SMTP Options" section, enter any email address in the "Sender Address" field, set the "SMTP Server" to `localhost` on port `1025`, and set "Authentication Type" to `None`. Note that you may use any active or inactive sender address.
-
-Visit [locahost:8025](http://localhost:8025) to view Mailhog's admin interface which will display all emails sent using the simulated mail server.
-
 ## Adding hosts for testing
 
 The `osquery` directory contains a docker-compose.yml and additional configuration files to start containerized osquery agents. 


### PR DESCRIPTION
The `Testing.md` document in the `/docs/4-Contribution` directory has become THE file for instructions on developer tools in Fleet.

- Move instructions for connecting to the Mailhog simulated server out of the FAQ
- Merge instructions found in FAQ with existing instructions in `Testing.md`