### PR TITLE
AuthenticatedRoutes conditionally reroutes api_only user

### DIFF
--- a/frontend/components/AuthenticatedRoutes/AuthenticatedRoutes.jsx
+++ b/frontend/components/AuthenticatedRoutes/AuthenticatedRoutes.jsx
@@ -8,7 +8,6 @@ import paths from "router/paths";
 import redirectLocationInterface from "interfaces/redirect_location";
 import { setRedirectLocation } from "redux/nodes/redirectLocation/actions";
 import userInterface from "interfaces/user";
-import permissionUtils from "utilities/permissions";
 
 export class AuthenticatedRoutes extends Component {
   static propTypes = {
@@ -35,7 +34,7 @@ export class AuthenticatedRoutes extends Component {
       return redirectToPasswordReset();
     }
 
-    if (permissionUtils.isApiUserOnly(user)) {
+    if (user && user.api_only) {
       return redirectToApiUserOnly();
     }
 
@@ -60,7 +59,7 @@ export class AuthenticatedRoutes extends Component {
       return redirectToPasswordReset();
     }
 
-    if (permissionUtils.isApiUserOnly(user)) {
+    if (user && user.api_only) {
       return redirectToApiUserOnly();
     }
 

--- a/frontend/components/AuthenticatedRoutes/AuthenticatedRoutes.jsx
+++ b/frontend/components/AuthenticatedRoutes/AuthenticatedRoutes.jsx
@@ -8,6 +8,7 @@ import paths from "router/paths";
 import redirectLocationInterface from "interfaces/redirect_location";
 import { setRedirectLocation } from "redux/nodes/redirectLocation/actions";
 import userInterface from "interfaces/user";
+import permissionUtils from "utilities/permissions";
 
 export class AuthenticatedRoutes extends Component {
   static propTypes = {
@@ -20,7 +21,11 @@ export class AuthenticatedRoutes extends Component {
 
   componentWillMount() {
     const { loading, user } = this.props;
-    const { redirectToLogin, redirectToPasswordReset } = this;
+    const {
+      redirectToLogin,
+      redirectToPasswordReset,
+      redirectToApiUserOnly,
+    } = this;
 
     if (!loading && !user) {
       return redirectToLogin();
@@ -28,6 +33,10 @@ export class AuthenticatedRoutes extends Component {
 
     if (user && user.force_password_reset) {
       return redirectToPasswordReset();
+    }
+
+    if (permissionUtils.isApiUserOnly(user)) {
+      return redirectToApiUserOnly();
     }
 
     return false;
@@ -37,7 +46,11 @@ export class AuthenticatedRoutes extends Component {
     if (isEqual(this.props, nextProps)) return false;
 
     const { loading, user } = nextProps;
-    const { redirectToLogin, redirectToPasswordReset } = this;
+    const {
+      redirectToLogin,
+      redirectToPasswordReset,
+      redirectToApiUserOnly,
+    } = this;
 
     if (!loading && !user) {
       return redirectToLogin();
@@ -45,6 +58,10 @@ export class AuthenticatedRoutes extends Component {
 
     if (user && user.force_password_reset) {
       return redirectToPasswordReset();
+    }
+
+    if (permissionUtils.isApiUserOnly(user)) {
+      return redirectToApiUserOnly();
     }
 
     return false;
@@ -63,6 +80,13 @@ export class AuthenticatedRoutes extends Component {
     const { RESET_PASSWORD } = paths;
 
     return dispatch(push(RESET_PASSWORD));
+  };
+
+  redirectToApiUserOnly = () => {
+    const { dispatch } = this.props;
+    const { API_ONLY_USER } = paths;
+
+    return dispatch(push(API_ONLY_USER));
   };
 
   render() {

--- a/frontend/interfaces/user.ts
+++ b/frontend/interfaces/user.ts
@@ -4,6 +4,7 @@ import teamInterface, { ITeam } from "./team";
 export default PropTypes.shape({
   email: PropTypes.string,
   force_password_reset: PropTypes.bool,
+  api_only: PropTypes.bool,
   global_role: PropTypes.string,
   gravatar_url: PropTypes.string,
   id: PropTypes.number,
@@ -16,6 +17,7 @@ export default PropTypes.shape({
 export interface IUser {
   email: string;
   force_password_reset: boolean;
+  api_only: boolean;
   global_role: string | null;
   gravatar_url: string;
   id: number;

--- a/frontend/pages/ApiOnlyUser/ApiOnlyUser.tsx
+++ b/frontend/pages/ApiOnlyUser/ApiOnlyUser.tsx
@@ -22,7 +22,7 @@ const ApiOnlyUser = (): JSX.Element => {
           <p className={`${baseClass}__lead-text`}>
             You attempted to access Fleet with an API only user.
           </p>
-          <p className={`${baseClass}__sub-lead-text cool`}>
+          <p className={`${baseClass}__sub-lead-text`}>
             This user doesn&apos;t have access to the Fleet UI.
           </p>
         </div>

--- a/frontend/pages/ApiOnlyUser/ApiOnlyUser.tsx
+++ b/frontend/pages/ApiOnlyUser/ApiOnlyUser.tsx
@@ -5,7 +5,6 @@ import { push } from "react-router-redux";
 import { fetchCurrentUser, logoutUser } from "redux/nodes/auth/actions";
 import Button from "components/buttons/Button";
 import paths from "router/paths";
-import { IUser } from "interfaces/user";
 // @ts-ignore
 import fleetLogoText from "../../../assets/images/fleet-logo-text-white.svg";
 

--- a/frontend/pages/ApiOnlyUser/ApiOnlyUser.tsx
+++ b/frontend/pages/ApiOnlyUser/ApiOnlyUser.tsx
@@ -1,8 +1,8 @@
-import React from "react";
-import { useDispatch, useSelector, useStore } from "react-redux";
+import React, { useEffect } from "react";
+import { useDispatch } from "react-redux";
 import { push } from "react-router-redux";
 // @ts-ignore
-import { logoutUser } from "redux/nodes/auth/actions";
+import { fetchCurrentUser, logoutUser } from "redux/nodes/auth/actions";
 import Button from "components/buttons/Button";
 import paths from "router/paths";
 import { IUser } from "interfaces/user";
@@ -10,30 +10,21 @@ import { IUser } from "interfaces/user";
 import fleetLogoText from "../../../assets/images/fleet-logo-text-white.svg";
 
 const baseClass = "api-only-user";
-interface IRootState {
-  auth: {
-    user: IUser;
-  };
-}
 
 const ApiOnlyUser = (): JSX.Element => {
   const dispatch = useDispatch();
   const { LOGIN, HOME } = paths;
   const handleClick = (event: any) => dispatch(logoutUser());
 
-  // These are showing up empty. Need to be able to get state loaded in from redux store.
-  // const auth = useSelector((state: any) => state.auth);
-  // const app = useSelector((state: any) => state.app);
-  // console.log("state.auth:", auth);
-  // console.log("state.app:", app);
-
-  const user = useSelector((state: IRootState) => state.auth.user);
-
-  if (!user) {
-    dispatch(push(LOGIN));
-  } else if (user && !user.api_only) {
-    dispatch(push(HOME));
-  }
+  useEffect(() => {
+    dispatch(fetchCurrentUser()).then((user: any) => {
+      if (!user) {
+        dispatch(push(LOGIN));
+      } else if (user && !user.payload.user.api_only) {
+        dispatch(push(HOME));
+      }
+    });
+  }, []);
 
   return (
     <div className={baseClass}>

--- a/frontend/pages/ApiOnlyUser/ApiOnlyUser.tsx
+++ b/frontend/pages/ApiOnlyUser/ApiOnlyUser.tsx
@@ -9,20 +9,20 @@ import fleetLogoText from "../../../assets/images/fleet-logo-text-white.svg";
 
 const baseClass = "api-only-user";
 
-const ApiOnlyUser = (): JSX.Element | null => {
+const ApiOnlyUser = (): JSX.Element => {
   const dispatch = useDispatch();
   const { LOGIN } = paths;
   const handleClick = (event: any) => dispatch(push(LOGIN));
 
   return (
-    <div className="api-only-user">
+    <div className={baseClass}>
       <img alt="Fleet" src={fleetLogoText} className={`${baseClass}__logo`} />
       <div className={`${baseClass}__wrap`}>
         <div className={`${baseClass}__lead-wrapper`}>
           <p className={`${baseClass}__lead-text`}>
             You attempted to access Fleet with an API only user.
           </p>
-          <p className={`${baseClass}__sub-lead-text`}>
+          <p className={`${baseClass}__sub-lead-text cool`}>
             This user doesn&apos;t have access to the Fleet UI.
           </p>
         </div>

--- a/frontend/pages/ApiOnlyUser/ApiOnlyUser.tsx
+++ b/frontend/pages/ApiOnlyUser/ApiOnlyUser.tsx
@@ -1,19 +1,39 @@
 import React from "react";
-import { useDispatch } from "react-redux";
-// import { push } from "react-router-redux";
+import { useDispatch, useSelector, useStore } from "react-redux";
+import { push } from "react-router-redux";
 // @ts-ignore
 import { logoutUser } from "redux/nodes/auth/actions";
 import Button from "components/buttons/Button";
-// import paths from "router/paths";
+import paths from "router/paths";
+import { IUser } from "interfaces/user";
 // @ts-ignore
 import fleetLogoText from "../../../assets/images/fleet-logo-text-white.svg";
 
 const baseClass = "api-only-user";
+interface IRootState {
+  auth: {
+    user: IUser;
+  };
+}
 
 const ApiOnlyUser = (): JSX.Element => {
   const dispatch = useDispatch();
-  // const { LOGIN } = paths;
+  const { LOGIN, HOME } = paths;
   const handleClick = (event: any) => dispatch(logoutUser());
+
+  // These are showing up empty. Need to be able to get state loaded in from redux store.
+  // const auth = useSelector((state: any) => state.auth);
+  // const app = useSelector((state: any) => state.app);
+  // console.log("state.auth:", auth);
+  // console.log("state.app:", app);
+
+  const user = useSelector((state: IRootState) => state.auth.user);
+
+  if (!user) {
+    dispatch(push(LOGIN));
+  } else if (user && !user.api_only) {
+    dispatch(push(HOME));
+  }
 
   return (
     <div className={baseClass}>

--- a/frontend/pages/ApiOnlyUser/ApiOnlyUser.tsx
+++ b/frontend/pages/ApiOnlyUser/ApiOnlyUser.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { useDispatch } from "react-redux";
-import { push } from "react-router-redux";
-
+// import { push } from "react-router-redux";
+// @ts-ignore
+import { logoutUser } from "redux/nodes/auth/actions";
 import Button from "components/buttons/Button";
-import paths from "router/paths";
+// import paths from "router/paths";
 // @ts-ignore
 import fleetLogoText from "../../../assets/images/fleet-logo-text-white.svg";
 
@@ -11,8 +12,8 @@ const baseClass = "api-only-user";
 
 const ApiOnlyUser = (): JSX.Element => {
   const dispatch = useDispatch();
-  const { LOGIN } = paths;
-  const handleClick = (event: any) => dispatch(push(LOGIN));
+  // const { LOGIN } = paths;
+  const handleClick = (event: any) => dispatch(logoutUser());
 
   return (
     <div className={baseClass}>

--- a/frontend/test/stubs.ts
+++ b/frontend/test/stubs.ts
@@ -171,6 +171,7 @@ export const userStub: IUser = {
   id: 1,
   email: "hi@gnar.dog",
   force_password_reset: false,
+  api_only: false,
   global_role: "admin",
   gravatar_url: "https://image.com",
   name: "Gnar Mike",

--- a/frontend/utilities/permissions/permissions.ts
+++ b/frontend/utilities/permissions/permissions.ts
@@ -9,10 +9,6 @@ export const isBasicTier = (config: IConfig): boolean => {
   return config.tier === "basic";
 };
 
-export const isApiOnlyUser = (user: IUser): boolean => {
-  return user.api_only;
-};
-
 export const isGlobalAdmin = (user: IUser): boolean => {
   return user.global_role === "admin";
 };

--- a/frontend/utilities/permissions/permissions.ts
+++ b/frontend/utilities/permissions/permissions.ts
@@ -9,6 +9,10 @@ export const isBasicTier = (config: IConfig): boolean => {
   return config.tier === "basic";
 };
 
+export const isApiOnlyUser = (user: IUser): boolean => {
+  return user.api_only;
+};
+
 export const isGlobalAdmin = (user: IUser): boolean => {
   return user.global_role === "admin";
 };


### PR DESCRIPTION
- Didn't need to add to `permissions.ts` since I suspect we're only using this column once in routing and `user.api_only` is pretty straight forward

- Edge cases render for no user logged in and api_only user false

Closes #402 