### PR TITLE
Host Details Page: Remove enroll secret

### DIFF
--- a/frontend/interfaces/user.ts
+++ b/frontend/interfaces/user.ts
@@ -4,6 +4,7 @@ import teamInterface, { ITeam } from "./team";
 export default PropTypes.shape({
   email: PropTypes.string,
   force_password_reset: PropTypes.bool,
+  api_only: PropTypes.bool,
   global_role: PropTypes.string,
   gravatar_url: PropTypes.string,
   id: PropTypes.number,
@@ -16,7 +17,7 @@ export default PropTypes.shape({
 export interface IUser {
   email: string;
   force_password_reset: boolean;
-  test_only: boolean;
+  api_only: boolean;
   global_role: string | null;
   gravatar_url: string;
   id: number;

--- a/frontend/interfaces/user.ts
+++ b/frontend/interfaces/user.ts
@@ -16,6 +16,7 @@ export default PropTypes.shape({
 export interface IUser {
   email: string;
   force_password_reset: boolean;
+  test_only: boolean;
   global_role: string | null;
   gravatar_url: string;
   id: number;

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -550,12 +550,6 @@ export class HostDetailsPage extends Component {
                 <span className="info__header">OS</span>
                 <span className="info__data">{titleData.os_version}</span>
               </div>
-              <div className="info__item info__item--title">
-                <span className="info__header">Enroll secret</span>
-                <span className="info__data">
-                  {titleData.enroll_secret_name}
-                </span>
-              </div>
             </div>
           </div>
           {renderActionButtons()}

--- a/frontend/test/stubs.ts
+++ b/frontend/test/stubs.ts
@@ -171,7 +171,7 @@ export const userStub: IUser = {
   id: 1,
   email: "hi@gnar.dog",
   force_password_reset: false,
-  test_only: false,
+  api_only: false,
   global_role: "admin",
   gravatar_url: "https://image.com",
   name: "Gnar Mike",

--- a/frontend/test/stubs.ts
+++ b/frontend/test/stubs.ts
@@ -171,6 +171,7 @@ export const userStub: IUser = {
   id: 1,
   email: "hi@gnar.dog",
   force_password_reset: false,
+  test_only: false,
   global_role: "admin",
   gravatar_url: "https://image.com",
   name: "Gnar Mike",


### PR DESCRIPTION
- self-explanatory
- add api_only to user interface and user stub that's erroring out code until other PR is merged

Closes #1115 

![Screen Shot 2021-06-17 at 1 42 36 PM](https://user-images.githubusercontent.com/71795832/122448110-6b65ff00-cf72-11eb-9dff-5d5389024f04.png)

