### PR TITLE
Add persistence to saved columns in "Hosts" table after user logs out

### DIFF
--- a/frontend/redux/middlewares/auth.js
+++ b/frontend/redux/middlewares/auth.js
@@ -35,7 +35,7 @@ const authMiddleware = (store) => (next) => (action) => {
   if (type === LOGOUT_SUCCESS || type === LOGIN_FAILURE) {
     const { LOGIN } = PATHS;
 
-    local.clear();
+    local.removeItem("auth_token");
     Fleet.setBearerToken(null);
     store.dispatch(push(LOGIN));
   }

--- a/frontend/utilities/local.js
+++ b/frontend/utilities/local.js
@@ -16,6 +16,11 @@ const local = {
 
     return localStorage.setItem(`FLEET::${itemName}`, value);
   },
+  removeItem: (itemName) => {
+    const { localStorage } = window;
+
+    localStorage.removeItem(`FLEET::${itemName}`);
+  },
 };
 
 export const authToken = () => {


### PR DESCRIPTION
- Add `removeItem` method so that we only remove the `auth_token`, and not the saved columns, from `localStorage` when the user logs out
- Merging changes into the `teams` branch

Closes #1127 