### PR TITLE
Include "tier" when updating config after the form is submitted on the Organization settings page

### DIFF
--- a/frontend/pages/admin/AppSettingsPage/AppSettingsPage.jsx
+++ b/frontend/pages/admin/AppSettingsPage/AppSettingsPage.jsx
@@ -24,7 +24,7 @@ class AppSettingsPage extends Component {
     const { appConfig, dispatch } = this.props;
     const diff = deepDifference(formData, appConfig);
 
-    dispatch(updateConfig(diff))
+    dispatch(updateConfig(diff, appConfig))
       .then(() => {
         dispatch(renderFlash("success", "Settings updated!"));
 

--- a/frontend/redux/nodes/app/actions.js
+++ b/frontend/redux/nodes/app/actions.js
@@ -55,7 +55,7 @@ export const getConfig = () => {
       });
   };
 };
-export const updateConfig = (configData) => {
+export const updateConfig = (configData, prevConfig) => {
   return (dispatch) => {
     dispatch(loadConfig);
 
@@ -63,8 +63,16 @@ export const updateConfig = (configData) => {
       .update(configData)
       .then((config) => {
         const formattedConfig = frontendFormattedConfig(config);
+        // We merge the previous config with the new config
+        // because the new config does not include the 'tier'
+        // property
+        const formattedConfigWithTier = Object.assign(
+          {},
+          prevConfig,
+          formattedConfig
+        );
 
-        dispatch(configSuccess(formattedConfig));
+        dispatch(configSuccess(formattedConfigWithTier));
 
         return formattedConfig;
       })


### PR DESCRIPTION
- Merge the previous config with the new config because the new config does not include the `tier` property

Closes #1129 

It seems like the `PATCH api/v1/fleet/config` endpoint doesn't return the `license` object. This PR includes a working workaround to handle this. @zwass, to verify, is this is the intended behavior of the API:
   https://www.loom.com/share/54c8396f5b4e4dee8071b433ff7cb633