### PR TITLE
Sort labels for membership update

### DIFF
--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"database/sql"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -319,13 +320,21 @@ func (d *Datastore) LabelQueriesForHost(host *fleet.Host, cutoff time.Time) (map
 }
 
 func (d *Datastore) RecordLabelQueryExecutions(host *fleet.Host, results map[uint]bool, updated time.Time) error {
+	// Sort the results to have generated SQL queries ordered to minimize
+	// deadlocks. See https://github.com/fleetdm/fleet/issues/1146.
+	orderedIDs := make([]uint, 0, len(results))
+	for labelID, _ := range results {
+		orderedIDs = append(orderedIDs, labelID)
+	}
+	sort.Slice(orderedIDs, func(i, j int) bool { return orderedIDs[i] < orderedIDs[j] })
+
 	// Loop through results, collecting which labels we need to insert/update,
 	// and which we need to delete
 	vals := []interface{}{}
 	bindvars := []string{}
 	removes := []uint{}
-
-	for labelID, matches := range results {
+	for _, labelID := range orderedIDs {
+		matches := results[labelID]
 		if matches {
 			// Add/update row
 			bindvars = append(bindvars, "(?,?,?)")


### PR DESCRIPTION
This may help with deadlocks on the `label_membership` table. It is not
clear from MySQL documentation whether the order of the records is
significant for locking within a single query. If it is, this should
help the problem. If it is not, this should have no negative impact.

May fix #1146