### PR TITLE
Fix forbidden error for password reset

### DIFF
--- a/server/service/service_users.go
+++ b/server/service/service_users.go
@@ -438,7 +438,7 @@ func (svc *Service) RequestPasswordReset(ctx context.Context, email string) erro
 		return err
 	}
 
-	config, err := svc.AppConfig(ctx)
+	config, err := svc.ds.AppConfig()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Access the app config directly through the data store, skipping the
incorrect permission check on the service method.