### PR TITLE
Revise help text on team members page

### DIFF
--- a/cypress/integration/basic/admin.spec.ts
+++ b/cypress/integration/basic/admin.spec.ts
@@ -63,7 +63,8 @@ if (Cypress.env("FLEET_TIER") === "basic") {
       });
       // Access the Settings - Team details page
       cy.findByText(/apples/i).click();
-      cy.findByText(/Add and remove members from Apples/i).should("exist");
+      cy.findByText(/apples/i).should("exist");
+      cy.findByText(/manage users with global access here/i).should("exist");
 
       // See the “Team” section in the create user modal. This modal is summoned when the “Create user” button is selected
       cy.visit("/settings/organization");

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPagePage/MembersPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPagePage/MembersPage.tsx
@@ -228,7 +228,7 @@ const MembersPage = (props: IMembersPageProps): JSX.Element => {
   return (
     <div className={baseClass}>
       <p className={`${baseClass}__page-description`}>
-        Add and remove members from {team.name}.{" "}
+        Users can either be a member of team(s) or a global user.{" "}
         <Link to={PATHS.ADMIN_USERS}>Manage users with global access here</Link>
       </p>
       <TableContainer


### PR DESCRIPTION
Revise help text to "Users can either be a member of team(s) or a global user."

<img width="1648" alt="Screen Shot 2021-06-23 at 2 28 35 PM" src="https://user-images.githubusercontent.com/73313222/123157644-6bfa0c00-d430-11eb-86ce-bf07b905381f.png">
