### PR TITLE
Add success notification for creating and updating labels

### DIFF
--- a/cypress/integration/all/app/labelflow.spec.ts
+++ b/cypress/integration/all/app/labelflow.spec.ts
@@ -46,6 +46,9 @@ describe("Label flow", () => {
 
     cy.findByRole("button", { name: /update label/i }).click();
 
+    // Close success notification
+    cy.get(".flash-message__remove").click();
+
     cy.findByRole("button", { name: /delete/i }).click();
 
     // Can't figure out how attach findByRole onto modal button

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.jsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.jsx
@@ -203,7 +203,12 @@ export class ManageHostsPage extends PureComponent {
     return dispatch(labelActions.update(selectedLabel, updateAttrs))
       .then(() => {
         dispatch(push(`${PATHS.MANAGE_HOSTS}/${selectedFilter}`));
-
+        dispatch(
+          renderFlash(
+            "success",
+            "Label updated. Try refreshing this page in just a moment to see the updated host count for your label."
+          )
+        );
         return false;
       })
       .catch(() => false);
@@ -234,7 +239,12 @@ export class ManageHostsPage extends PureComponent {
 
     return dispatch(labelActions.create(formData)).then(() => {
       dispatch(push(PATHS.MANAGE_HOSTS));
-
+      dispatch(
+        renderFlash(
+          "success",
+          "Label created. Try refreshing this page in just a moment to see the updated host count for your label."
+        )
+      );
       return false;
     });
   };


### PR DESCRIPTION
- Add "Label created. Try refreshing this page in just a moment to see the updated host count for your label." message after the user successfully creates a label.
  - This way, the user is asked to allow the hosts to update their label membership, before expecting to see the correct host count 
  - Resolves #796 