### PR TITLE
Fix fleetctl preview error: docker-compose "Cannot open self"

### DIFF
--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -174,7 +174,7 @@ Use the stop and reset subcommands to manage the server and dependencies once st
 			fmt.Println("Starting simulated hosts...")
 			cmd := exec.Command("docker-compose", "up", "-d", "--remove-orphans")
 			cmd.Dir = filepath.Join(previewDir, "osquery")
-			cmd.Env = append(cmd.Env,
+			cmd.Env = append(os.Environ(),
 				"ENROLL_SECRET="+secrets.Secrets[0].Secret,
 				"FLEET_URL="+address,
 			)
@@ -355,7 +355,7 @@ func previewStopCommand() *cli.Command {
 
 			cmd := exec.Command("docker-compose", "stop")
 			cmd.Dir = filepath.Join(previewDir, "osquery")
-			cmd.Env = append(cmd.Env,
+			cmd.Env = append(os.Environ(),
 				// Note that these must be set even though they are unused while
 				// stopping because docker-compose will error otherwise.
 				"ENROLL_SECRET=empty",
@@ -404,7 +404,7 @@ func previewResetCommand() *cli.Command {
 
 			cmd := exec.Command("docker-compose", "rm", "-sf")
 			cmd.Dir = filepath.Join(previewDir, "osquery")
-			cmd.Env = append(cmd.Env,
+			cmd.Env = append(os.Environ(),
 				// Note that these must be set even though they are unused while
 				// stopping because docker-compose will error otherwise.
 				"ENROLL_SECRET=empty",


### PR DESCRIPTION
The following error occurs when running `fleetctl preview`:

 Starting simulated hosts...
 [13247] Cannot open self /home/chrb/.fleet/preview/osquery/docker-compose or archive /home/chrb/.fleet/preview/osquery/docker-compose.pkg

 Failed to run docker-compose

This is caused by a missing PATH environment variable when launching
docker-compose (which appears to re-exec the docker-compose binary).
Fix this by passing on the current environment.