### PR TITLE
Add ability to rotate a user's API token

### DIFF
--- a/cypress/integration/all/app/resetsessions.spec.ts
+++ b/cypress/integration/all/app/resetsessions.spec.ts
@@ -1,11 +1,12 @@
-describe("Reset user sessions", () => {
+describe("Reset user sessions flow", () => {
   beforeEach(() => {
     cy.setup();
     cy.login();
     cy.setupSMTP();
   });
 
-  it("Resets a user's sessions", () => {
+  it("Resets a user's API tokens", () => {
+    // visit user's profile page and get current API token
     cy.visit("/profile");
 
     cy.findByRole("button", { name: /get api token/i }).click();
@@ -14,8 +15,11 @@ describe("Reset user sessions", () => {
       cy.get("input").invoke("val").as("token1");
     });
 
+    // reset user sessions via the admin user management page
     cy.visit("/settings/users");
 
+    // first select the table cell with the user's email address then go back up to the containing row
+    // so we can select reset sessions from actions dropdown
     cy.get("tbody>tr>td")
       .contains(/admin@example.com/i)
       .parent()
@@ -31,7 +35,9 @@ describe("Reset user sessions", () => {
     });
     cy.findByText(/sessions reset/i).should("exist");
 
+    // user should be logged out now so log in again and go to profile to get new API token
     cy.visit("/");
+    cy.findByRole("button", { name: /login/i }).should("exist");
     cy.login();
 
     cy.visit("/profile");
@@ -41,6 +47,7 @@ describe("Reset user sessions", () => {
       cy.get("input").invoke("val").as("token2");
     });
 
+    // new token should not equal old token
     cy.get("@token1").then((val1) => {
       cy.get("@token2").then((val2) => {
         expect(val1).to.not.eq(val2);

--- a/cypress/integration/all/app/resetsessions.spec.ts
+++ b/cypress/integration/all/app/resetsessions.spec.ts
@@ -1,0 +1,50 @@
+describe("Reset user sessions", () => {
+  beforeEach(() => {
+    cy.setup();
+    cy.login();
+    cy.setupSMTP();
+  });
+
+  it("Resets a user's sessions", () => {
+    cy.visit("/profile");
+
+    cy.findByRole("button", { name: /get api token/i }).click();
+    cy.findByText(/reveal token/i).click();
+    cy.get(".user-settings__secret-input").within(() => {
+      cy.get("input").invoke("val").as("token1");
+    });
+
+    cy.visit("/settings/users");
+
+    cy.get("tbody>tr>td")
+      .contains(/admin@example.com/i)
+      .parent()
+      .parent()
+      .within(() => {
+        cy.findByText(/actions/i).click();
+        cy.findByText(/reset sessions/i).click();
+      });
+
+    cy.get(".modal__modal_container").within(() => {
+      cy.findByText(/reset sessions/i).should("exist");
+      cy.findByRole("button", { name: /confirm/i }).click();
+    });
+    cy.findByText(/sessions reset/i).should("exist");
+
+    cy.visit("/");
+    cy.login();
+
+    cy.visit("/profile");
+    cy.findByRole("button", { name: /get api token/i }).click();
+    cy.findByText(/reveal token/i).click();
+    cy.get(".user-settings__secret-input").within(() => {
+      cy.get("input").invoke("val").as("token2");
+    });
+
+    cy.get("@token1").then((val1) => {
+      cy.get("@token2").then((val2) => {
+        expect(val1).to.not.eq(val2);
+      });
+    });
+  });
+});

--- a/frontend/fleet/endpoints.ts
+++ b/frontend/fleet/endpoints.ts
@@ -38,6 +38,9 @@ export default {
   UPDATE_USER_ADMIN: (id: number): string => {
     return `/v1/fleet/users/${id}/admin`;
   },
+  USER_SESSIONS: (id: number): string => {
+    return `/v1/fleet/users/${id}/sessions`;
+  },
   SSO: "/v1/fleet/sso",
   STATUS_LIVE_QUERY: "/v1/fleet/status/live_query",
   STATUS_RESULT_STORE: "/v1/fleet/status/result_store",

--- a/frontend/fleet/entities/users.js
+++ b/frontend/fleet/entities/users.js
@@ -11,6 +11,12 @@ export default (client) => {
         .authenticatedPost(client._endpoint(USERS), JSON.stringify(formData))
         .then((response) => helpers.addGravatarUrlToResource(response.user));
     },
+    deleteSessions: (user) => {
+      const { USER_SESSIONS } = endpoints;
+      const endpoint = client._endpoint(USER_SESSIONS(user.id));
+
+      return client.authenticatedDelete(endpoint);
+    },
     destroy: (user) => {
       const { USERS } = endpoints;
       const endpoint = `${client._endpoint(USERS)}/${user.id}`;

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
@@ -221,6 +221,25 @@ export class UserManagementPage extends Component {
     }
   };
 
+  onResetSessions = () => {
+    const { dispatch } = this.props;
+    const { userEditing } = this.state;
+    const { toggleResetSessionsUserModal } = this;
+    dispatch(userActions.deleteSessions(userEditing))
+      .then(() => {
+        dispatch(renderFlash("success", "Sessions reset"));
+      })
+      .catch(() => {
+        dispatch(
+          renderFlash(
+            "error",
+            "Could not reset sessions for the selected user. Please try again."
+          )
+        );
+      });
+    toggleResetSessionsUserModal();
+  };
+
   // NOTE: this is called once on the initial rendering. The initial render of
   // the TableContainer child component calls this handler.
   onTableQueryChange = (queryData) => {
@@ -348,24 +367,6 @@ export class UserManagementPage extends Component {
         toggleResetPasswordUserModal();
       }
     );
-  };
-
-  resetSessions = (user) => {
-    const { dispatch } = this.props;
-    const { toggleResetSessionsUserModal } = this;
-    const { resetSessions } = userActions; // TODO
-
-    // TODO
-    return dispatch(resetSessions(user.id, { require: true })).then(() => {
-      dispatch(
-        renderFlash(
-          "success",
-          "User sessions will be reset",
-          resetSessions(user.id, { require: false }) // this is an undo action. // TODO doees this apply?
-        )
-      );
-      toggleResetSessionsUserModal();
-    });
   };
 
   goToUserSettingsPage = () => {
@@ -498,7 +499,7 @@ export class UserManagementPage extends Component {
   // TODO wire this up and get styles working
   renderResetSessionsModal = () => {
     const { showResetSessionsModal, userEditing } = this.state;
-    const { toggleResetSessionsUserModal, resetSessions } = this;
+    const { toggleResetSessionsUserModal, onResetSessions } = this;
 
     if (!showResetSessionsModal) return null;
 
@@ -506,7 +507,7 @@ export class UserManagementPage extends Component {
       <ResetSessionsModal
         user={userEditing}
         modalBaseClass={baseClass}
-        onResetConfirm={resetSessions}
+        onResetConfirm={onResetSessions}
         onResetCancel={toggleResetSessionsUserModal}
       />
     );

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
@@ -27,6 +27,7 @@ import EmptyUsers from "./components/EmptyUsers";
 import { generateTableHeaders, combineDataSets } from "./UsersTableConfig";
 import DeleteUserForm from "./components/DeleteUserForm";
 import ResetPasswordModal from "./components/ResetPasswordModal";
+import ResetSessionsModal from "./components/ResetSessionsModal"; // TODO get styles working
 
 const baseClass = "user-management";
 
@@ -79,6 +80,7 @@ export class UserManagementPage extends Component {
       showEditUserModal: false,
       showDeleteUserModal: false,
       showResetPasswordModal: false,
+      showResetSessionsModal: false,
       userEditing: null,
       usersEditing: [],
     };
@@ -251,6 +253,7 @@ export class UserManagementPage extends Component {
       toggleDeleteUserModal,
       goToUserSettingsPage,
       toggleResetPasswordUserModal,
+      toggleResetSessionsUserModal,
     } = this;
     switch (action) {
       case "edit":
@@ -261,6 +264,9 @@ export class UserManagementPage extends Component {
         break;
       case "passwordReset":
         toggleResetPasswordUserModal(user);
+        break;
+      case "resetSessions":
+        toggleResetSessionsUserModal(user);
         break;
       case "editMyAccount":
         goToUserSettingsPage();
@@ -313,6 +319,14 @@ export class UserManagementPage extends Component {
     });
   };
 
+  toggleResetSessionsUserModal = (user) => {
+    const { showResetSessionsModal } = this.state;
+    this.setState({
+      showResetSessionsModal: !showResetSessionsModal,
+      userEditing: !showResetSessionsModal ? user : null,
+    });
+  };
+
   combineUsersAndInvites = memoize((users, invites, currentUserId) => {
     return combineDataSets(users, invites, currentUserId);
   });
@@ -334,6 +348,24 @@ export class UserManagementPage extends Component {
         toggleResetPasswordUserModal();
       }
     );
+  };
+
+  resetSessions = (user) => {
+    const { dispatch } = this.props;
+    const { toggleResetSessionsUserModal } = this;
+    const { resetSessions } = userActions; // TODO
+
+    // TODO
+    return dispatch(resetSessions(user.id, { require: true })).then(() => {
+      dispatch(
+        renderFlash(
+          "success",
+          "User sessions will be reset",
+          resetSessions(user.id, { require: false }) // this is an undo action. // TODO doees this apply?
+        )
+      );
+      toggleResetSessionsUserModal();
+    });
   };
 
   goToUserSettingsPage = () => {
@@ -463,6 +495,23 @@ export class UserManagementPage extends Component {
     );
   };
 
+  // TODO wire this up and get styles working
+  renderResetSessionsModal = () => {
+    const { showResetSessionsModal, userEditing } = this.state;
+    const { toggleResetSessionsUserModal, resetSessions } = this;
+
+    if (!showResetSessionsModal) return null;
+
+    return (
+      <ResetSessionsModal
+        user={userEditing}
+        modalBaseClass={baseClass}
+        onResetConfirm={resetSessions}
+        onResetCancel={toggleResetSessionsUserModal}
+      />
+    );
+  };
+
   renderSmtpWarning = () => {
     const { appConfigLoading, config } = this.props;
     const { goToAppConfigPage } = this;
@@ -498,6 +547,7 @@ export class UserManagementPage extends Component {
       renderEditUserModal,
       renderDeleteUserModal,
       renderResetPasswordModal,
+      renderResetSessionsModal,
       renderSmtpWarning,
       toggleCreateUserModal,
       onTableQueryChange,
@@ -546,6 +596,8 @@ export class UserManagementPage extends Component {
         {renderCreateUserModal()}
         {renderEditUserModal()}
         {renderDeleteUserModal()}
+        {renderResetSessionsModal()}
+
         {renderResetPasswordModal()}
       </div>
     );

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
@@ -27,7 +27,7 @@ import EmptyUsers from "./components/EmptyUsers";
 import { generateTableHeaders, combineDataSets } from "./UsersTableConfig";
 import DeleteUserForm from "./components/DeleteUserForm";
 import ResetPasswordModal from "./components/ResetPasswordModal";
-import ResetSessionsModal from "./components/ResetSessionsModal"; // TODO get styles working
+import ResetSessionsModal from "./components/ResetSessionsModal";
 
 const baseClass = "user-management";
 
@@ -496,7 +496,6 @@ export class UserManagementPage extends Component {
     );
   };
 
-  // TODO wire this up and get styles working
   renderResetSessionsModal = () => {
     const { showResetSessionsModal, userEditing } = this.state;
     const { toggleResetSessionsUserModal, onResetSessions } = this;

--- a/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
@@ -187,7 +187,7 @@ const generateActionDropdownOptions = (
   isInvitePending: boolean,
   isSSOEnabled: boolean
 ): IDropdownOption[] => {
-  const dropdownOptions = [
+  let dropdownOptions = [
     {
       label: "Edit",
       disabled: isInvitePending,
@@ -209,8 +209,11 @@ const generateActionDropdownOptions = (
       value: "delete",
     },
   ];
-  if (isSSOEnabled) {
-    dropdownOptions.splice(1, 1);
+  if (isCurrentUser || isSSOEnabled) {
+    // remove "Require password reset" from dropdownOptions
+    dropdownOptions = dropdownOptions.filter(
+      (option) => option.label !== "Require password reset"
+    );
   }
   return dropdownOptions;
 };

--- a/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
@@ -183,45 +183,36 @@ const generateRole = (teams: ITeam[], globalRole: string | null): string => {
 };
 
 const generateActionDropdownOptions = (
-  id: number,
-  currentUserId: number
+  isCurrentUser: boolean,
+  isInvitePending: boolean,
+  isSSOEnabled: boolean
 ): IDropdownOption[] => {
-  if (id === currentUserId) {
-    return [
-      {
-        label: "Edit my account",
-        disabled: false,
-        value: "editMyAccount",
-      },
-    ];
-  }
-  return [
+  const dropdownOptions = [
     {
       label: "Edit",
-      disabled: false,
-      value: "edit",
+      disabled: isInvitePending,
+      value: isCurrentUser ? "editMyAccount" : "edit",
     },
     {
       label: "Require password reset",
-      disabled: false,
+      disabled: isInvitePending,
       value: "passwordReset",
     },
     {
-      label: "Delete",
-      disabled: id === currentUserId,
-      value: "delete",
+      label: "Reset sessions",
+      disabled: isInvitePending,
+      value: "resetSessions",
     },
-  ];
-};
-
-const generateInviteDropdownOptions = (): IDropdownOption[] => {
-  return [
     {
       label: "Delete",
-      disabled: false,
+      disabled: isCurrentUser,
       value: "delete",
     },
   ];
+  if (isSSOEnabled) {
+    dropdownOptions.splice(1, 1);
+  }
+  return dropdownOptions;
 };
 
 const enhanceUserData = (
@@ -235,7 +226,11 @@ const enhanceUserData = (
       email: user.email,
       teams: generateTeam(user.teams, user.global_role),
       roles: generateRole(user.teams, user.global_role),
-      actions: generateActionDropdownOptions(user.id, currentUserId),
+      actions: generateActionDropdownOptions(
+        user.id === currentUserId,
+        false,
+        user.sso_enabled
+      ),
       id: user.id,
       type: "user",
     };
@@ -250,7 +245,7 @@ const enhanceInviteData = (invites: IInvite[]): IUserTableData[] => {
       email: invite.email,
       teams: generateTeam(invite.teams, invite.global_role),
       roles: generateRole(invite.teams, invite.global_role),
-      actions: generateInviteDropdownOptions(),
+      actions: generateActionDropdownOptions(false, true, invite.sso_enabled),
       id: invite.id,
       type: "invite",
     };

--- a/frontend/pages/admin/UserManagementPage/components/ResetSessionsModal/ResetSessionsModal.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/ResetSessionsModal/ResetSessionsModal.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { IUser } from "interfaces/user";
+import Modal from "components/modals/Modal";
+import Button from "components/buttons/Button";
+
+const baseClass = "reset-sessions-modal";
+
+interface IResetSessionsModal {
+  user: IUser;
+  modalBaseClass: string;
+  onResetConfirm: (user: IUser) => void;
+  onResetCancel: () => void;
+}
+
+const ResetSessionsModal = ({
+  user,
+  modalBaseClass,
+  onResetConfirm,
+  onResetCancel,
+}: IResetSessionsModal): JSX.Element => {
+  return (
+    <Modal
+      title="Reset sessions"
+      onExit={onResetCancel}
+      className={`${modalBaseClass}__${baseClass}`}
+    >
+      <div className={baseClass}>
+        <p>
+          This user will be logged out of Fleet.
+          <br />
+          This will revoke all active Fleet API tokens for this user.
+        </p>
+        <div className={`${baseClass}__btn-wrap`}>
+          <Button
+            className={`${baseClass}__btn`}
+            type="button"
+            variant="brand"
+            onClick={() => onResetConfirm(user)}
+          >
+            Confirm
+          </Button>
+          <Button
+            className={`${baseClass}__btn`}
+            onClick={onResetCancel}
+            variant="inverse"
+          >
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ResetSessionsModal;

--- a/frontend/pages/admin/UserManagementPage/components/ResetSessionsModal/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/components/ResetSessionsModal/_styles.scss
@@ -13,7 +13,7 @@
 
   &__btn {
     font-size: $small;
-    height: 138px;
+    height: 38px;
     margin-bottom: 5px;
     margin-left: 15px;
     padding: 0;

--- a/frontend/pages/admin/UserManagementPage/components/ResetSessionsModal/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/components/ResetSessionsModal/_styles.scss
@@ -1,0 +1,22 @@
+.reset-sessions-modal {
+  margin-top: $pad-large;
+
+  p {
+    margin-bottom: 40px;
+    font-size: $small;
+  }
+
+  &__btn-wrap {
+    display: flex;
+    flex-direction: row-reverse;
+  }
+
+  &__btn {
+    font-size: $small;
+    height: 138px;
+    margin-bottom: 5px;
+    margin-left: 15px;
+    padding: 0;
+    width: 120px;
+  }
+}

--- a/frontend/pages/admin/UserManagementPage/components/ResetSessionsModal/index.ts
+++ b/frontend/pages/admin/UserManagementPage/components/ResetSessionsModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ResetSessionsModal";

--- a/frontend/redux/nodes/entities/users/actions.js
+++ b/frontend/redux/nodes/entities/users/actions.js
@@ -114,6 +114,12 @@ export const requirePasswordReset = (userId, { require }) => {
   };
 };
 
+export const resetSessions = (userId) => {
+  return () => {
+    console.log("resetting sessions for: ", userId);
+  };
+};
+
 export const updateAdmin = (user, { admin }) => {
   const { successAction, updateFailure, updateSuccess } = actions;
 
@@ -139,5 +145,6 @@ export default {
   confirmEmailChange,
   enableUser,
   requirePasswordReset,
+  resetSessions,
   updateAdmin,
 };

--- a/frontend/redux/nodes/entities/users/actions.js
+++ b/frontend/redux/nodes/entities/users/actions.js
@@ -77,6 +77,25 @@ export const confirmEmailChange = (user, token) => {
   };
 };
 
+export const deleteSessions = (user) => {
+  const { successAction, destroyFailure, destroySuccess } = actions;
+
+  return (dispatch) => {
+    return Fleet.users
+      .deleteSessions(user)
+      .then((userResponse) => {
+        return dispatch(successAction(userResponse, destroySuccess));
+      })
+      .catch((response) => {
+        const errorsObject = formatErrorResponse(response);
+
+        dispatch(destroyFailure(errorsObject));
+
+        throw errorsObject;
+      });
+  };
+};
+
 export const enableUser = (user, { enabled }) => {
   const { successAction, updateFailure, updateSuccess } = actions;
 
@@ -114,12 +133,6 @@ export const requirePasswordReset = (userId, { require }) => {
   };
 };
 
-export const resetSessions = (userId) => {
-  return () => {
-    console.log("resetting sessions for: ", userId);
-  };
-};
-
 export const updateAdmin = (user, { admin }) => {
   const { successAction, updateFailure, updateSuccess } = actions;
 
@@ -145,6 +158,6 @@ export default {
   confirmEmailChange,
   enableUser,
   requirePasswordReset,
-  resetSessions,
+  deleteSessions,
   updateAdmin,
 };


### PR DESCRIPTION
Closes #1074 
- Add `USER_SESSIONS` endpoint to `fleet/endpoints`
- Add `deleteSessions` action to `redux/nodes/entities/users`
- Add `ResetSessionsModal` to `UserManagementPage`
- Refactor `generateActionDropdownOptions` in `UserTableConfig` to add "Reset sessions" option and conditionally disable options based on user status (e.g., if invite pending or SSO enabled)
- Add Cypress test for resetting a user's API token