### PR TITLE
Display "No team" in Hosts table if the host is not assigned to any team

### DIFF
--- a/frontend/fleet/helpers.ts
+++ b/frontend/fleet/helpers.ts
@@ -344,8 +344,8 @@ export const humanHostDetailUpdated = (detailUpdated: string): string => {
   return moment(detailUpdated).fromNow();
 };
 
-export const hostTeamName = (teamName: string): string => {
-  if (teamName === "" || teamName === null) {
+export const hostTeamName = (teamName: string | null): string => {
+  if (!teamName) {
     return "No team";
   }
 

--- a/frontend/fleet/helpers.ts
+++ b/frontend/fleet/helpers.ts
@@ -345,7 +345,7 @@ export const humanHostDetailUpdated = (detailUpdated: string): string => {
 };
 
 export const hostTeamName = (teamName: string): string => {
-  if (!teamName) {
+  if (teamName === "" || teamName === null) {
     return "No team";
   }
 

--- a/frontend/fleet/helpers.ts
+++ b/frontend/fleet/helpers.ts
@@ -344,12 +344,12 @@ export const humanHostDetailUpdated = (detailUpdated: string): string => {
   return moment(detailUpdated).fromNow();
 };
 
-export const hostTeamName = (team: string): string => {
-  if (!team) {
+export const hostTeamName = (teamName: string): string => {
+  if (!teamName) {
     return "No team";
   }
 
-  return team;
+  return teamName;
 };
 
 export const humanQueryLastRun = (lastRun: string): string => {

--- a/frontend/fleet/helpers.ts
+++ b/frontend/fleet/helpers.ts
@@ -344,6 +344,14 @@ export const humanHostDetailUpdated = (detailUpdated: string): string => {
   return moment(detailUpdated).fromNow();
 };
 
+export const hostTeamName = (team: string): string => {
+  if (!team) {
+    return "No team";
+  }
+
+  return team;
+};
+
 export const humanQueryLastRun = (lastRun: string): string => {
   // Handles the case when a query has never been ran.
   // July 28, 2016 is the date of the initial commit to fleet/fleet.
@@ -405,6 +413,7 @@ export default {
   humanHostEnrolled,
   humanHostMemory,
   humanHostDetailUpdated,
+  hostTeamName,
   humanQueryLastRun,
   secondsToHms,
   labelSlug,

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -16,6 +16,7 @@ import {
   humanHostUptime,
   humanHostLastSeen,
   humanHostDetailUpdated,
+  hostTeamName,
 } from "fleet/helpers";
 import { IConfig } from "interfaces/config";
 import { IUser } from "interfaces/user";
@@ -107,9 +108,16 @@ const allHostTableHeaders: IHostDataColumn[] = [
   },
   {
     title: "Team",
-    Header: "Team",
+    Header: (cellProps) => (
+      <HeaderCell
+        value={cellProps.column.title}
+        isSortedDesc={cellProps.column.isSortedDesc}
+      />
+    ),
     accessor: "team_name",
-    Cell: (cellProps) => <TextCell value={cellProps.cell.value} />,
+    Cell: (cellProps) => (
+      <TextCell value={cellProps.cell.value} formatter={hostTeamName} />
+    ),
   },
   {
     title: "Status",


### PR DESCRIPTION
- Add new formatter that returns "No team" if `team` does not exist
- Add sort to the "Team" column
![localhost_8080_hosts_manage (42)](https://user-images.githubusercontent.com/47070608/123454487-9d98e180-d5ae-11eb-845d-1eb312410902.png)
