### PR TITLE
Add environment to release action

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    environment: Docker Hub
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This allows the action to get access to Docker Hub credentials.