### PR TITLE
Host Details Page: Transfer button

### DIFF
--- a/cypress/integration/basic/admin.spec.ts
+++ b/cypress/integration/basic/admin.spec.ts
@@ -52,7 +52,7 @@ if (Cypress.env("FLEET_TIER") === "basic") {
         cy.findByText(/apples/i).should("exist");
         cy.findByText(/oranges/i).click();
       });
-      cy.get(".transfer-host-modal__btn").click();
+      cy.get(".transfer-action-btn").click();
       cy.findByText(/transferred to oranges/i).should("exist");
       cy.findByText(/team/i).next().contains("Oranges");
 

--- a/cypress/integration/basic/admin.spec.ts
+++ b/cypress/integration/basic/admin.spec.ts
@@ -41,8 +41,20 @@ if (Cypress.env("FLEET_TIER") === "basic") {
 
       // On the Host details page, they should…
       // See the “Team” information below the hostname
+      // Be able to transfer Teams
       cy.visit("/hosts/1");
       cy.findByText(/team/i).next().contains("Apples");
+      cy.contains("button", /transfer/i).click();
+      cy.get(".Select-control").click();
+      cy.findByText(/create a team/i).should("exist");
+      cy.get(".Select-menu").within(() => {
+        cy.findByText(/no team/i).should("exist");
+        cy.findByText(/apples/i).should("exist");
+        cy.findByText(/oranges/i).click();
+      });
+      cy.get(".transfer-host-modal__btn").click();
+      cy.findByText(/transferred to oranges/i).should("exist");
+      cy.findByText(/team/i).next().contains("Oranges");
 
       // On the Queries - new / edit / run page, they should…
       // See the “Teams” section in the Select target picker. This picker is summoned when the “Select targets” field is selected.

--- a/cypress/integration/basic/maintainer.spec.ts
+++ b/cypress/integration/basic/maintainer.spec.ts
@@ -39,6 +39,17 @@ if (Cypress.env("FLEET_TIER") === "basic") {
       cy.get(".title").within(() => {
         cy.findByText("Team").should("exist");
       });
+      cy.contains("button", /transfer/i).click();
+      cy.get(".Select-control").click();
+      cy.findByText(/create a team/i).should("not.exist");
+      cy.get(".Select-menu").within(() => {
+        cy.findByText(/no team/i).should("exist");
+        cy.findByText(/apples/i).should("exist");
+        cy.findByText(/oranges/i).click();
+      });
+      cy.get(".transfer-host-modal__btn").click();
+      cy.findByText(/transferred to oranges/i).should("exist");
+      cy.findByText(/team/i).next().contains("Oranges");
 
       // Query pages: Can see teams UI for create, edit, and run query
       cy.visit("/queries/manage");

--- a/cypress/integration/basic/maintainer.spec.ts
+++ b/cypress/integration/basic/maintainer.spec.ts
@@ -47,7 +47,7 @@ if (Cypress.env("FLEET_TIER") === "basic") {
         cy.findByText(/apples/i).should("exist");
         cy.findByText(/oranges/i).click();
       });
-      cy.get(".transfer-host-modal__btn").click();
+      cy.get(".transfer-action-btn").click();
       cy.findByText(/transferred to oranges/i).should("exist");
       cy.findByText(/team/i).next().contains("Oranges");
 

--- a/cypress/integration/basic/observer.spec.ts
+++ b/cypress/integration/basic/observer.spec.ts
@@ -35,6 +35,7 @@ if (Cypress.env("FLEET_TIER") === "basic") {
       cy.get(".title").within(() => {
         cy.findByText("Team").should("exist");
       });
+      cy.contains("button", /transfer/i).should("not.exist");
 
       // Query pages: Can see team in select targets dropdown
       cy.visit("/queries/manage");

--- a/cypress/integration/basic/team_maintainer_observer.spec.ts
+++ b/cypress/integration/basic/team_maintainer_observer.spec.ts
@@ -128,8 +128,9 @@ if (Cypress.env("FLEET_TIER") === "basic") {
         cy.get(".Select").within(() => {
           cy.findByText(/select a team/i).click();
           cy.findByText(/no team/i).should("exist");
-          cy.findByText(/apples/i).should("exist");
-          cy.findByText(/oranges/i).should("not exist");
+          // cy.findByText(/apples/i).should("exist");
+          // cy.findByText(/oranges/i).should("not exist");
+          // ^ TODO: Team maintainer has access to only their teams, team observer does not have access
         });
       });
       cy.findByRole("button", { name: /done/i }).click();

--- a/cypress/integration/basic/team_maintainer_observer.spec.ts
+++ b/cypress/integration/basic/team_maintainer_observer.spec.ts
@@ -128,9 +128,8 @@ if (Cypress.env("FLEET_TIER") === "basic") {
         cy.get(".Select").within(() => {
           cy.findByText(/select a team/i).click();
           cy.findByText(/no team/i).should("exist");
-          // cy.findByText(/apples/i).should("exist");
-          // cy.findByText(/oranges/i).should("not exist");
-          // ^^TODO add back these assertions after dropdown bug is fixed
+          cy.findByText(/apples/i).should("exist");
+          cy.findByText(/oranges/i).should("not exist");
         });
       });
       cy.findByRole("button", { name: /done/i }).click();

--- a/cypress/integration/core/admin.spec.ts
+++ b/cypress/integration/core/admin.spec.ts
@@ -45,8 +45,9 @@ if (Cypress.env("FLEET_TIER") === "core") {
       // On the Host details page, they should…
       cy.visit("/hosts/1");
 
-      // Not see "team" information
+      // Not see "team" information or transfer button
       cy.findByText(/team/i).should("not.exist");
+      cy.contains("button", /transfer/i).should("not.exist");
 
       // See and select the “Delete” button
       cy.findByRole("button", { name: /delete/i }).click();

--- a/cypress/integration/core/maintainer.spec.ts
+++ b/cypress/integration/core/maintainer.spec.ts
@@ -43,6 +43,7 @@ if (Cypress.env("FLEET_TIER") === "core") {
       cy.get(".title").within(() => {
         cy.findByText(/team/i).should("not.exist");
       });
+      cy.contains("button", /transfer/i).should("not.exist");
 
       cy.contains("button", /delete/i).click();
       cy.contains("button", /cancel/i).click();

--- a/cypress/integration/core/observer.spec.ts
+++ b/cypress/integration/core/observer.spec.ts
@@ -41,6 +41,7 @@ if (Cypress.env("FLEET_TIER") === "core") {
       });
 
       cy.findByText(/team/i).should("not.exist");
+      cy.contains("button", /transfer/i).should("not.exist");
       cy.contains("button", /delete/i).should("not.exist");
       cy.contains("button", /query/i).should("not.exist");
 

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -158,6 +158,7 @@ export class HostDetailsPage extends Component {
           renderFlash("error", "Could not transfer hosts. Please try again.")
         );
       });
+    console.log("onTransferHostSubmit");
     toggleTransferHostModal();
   };
 
@@ -169,9 +170,10 @@ export class HostDetailsPage extends Component {
   }
 
   toggleQueryHostModal = () => {
+    console.log("toggleQUERYHostModal");
     return () => {
+      console.log("RETURN of toggleQUERYHostModal");
       const { showQueryHostModal } = this.state;
-
       this.setState({
         showQueryHostModal: !showQueryHostModal,
       });
@@ -193,8 +195,13 @@ export class HostDetailsPage extends Component {
   };
 
   toggleTransferHostModal = () => {
+    console.log("toggleTRANSFERHostModal");
+
     return () => {
+      console.log("RETURN toggleTRANSFERHostModal");
+
       const { showTransferHostModal } = this.state;
+      console.log("showTransferHostModal:", showTransferHostModal);
 
       this.setState({
         showTransferHostModal: !showTransferHostModal,
@@ -202,24 +209,6 @@ export class HostDetailsPage extends Component {
 
       return false;
     };
-  };
-
-  renderTransferHostModal = () => {
-    const { toggleTransferHostModal, onTransferHostSubmit } = this;
-    const { teams, isGlobalAdmin, host } = this.props;
-    const { showTransferHostModal } = this.state;
-
-    if (!showTransferHostModal) return null;
-
-    return (
-      <TransferHostModal
-        host={host}
-        onCancel={toggleTransferHostModal}
-        onSubmit={onTransferHostSubmit}
-        teams={teams}
-        isGlobalAdmin={isGlobalAdmin}
-      />
-    );
   };
 
   renderDeleteHostModal = () => {
@@ -546,12 +535,15 @@ export class HostDetailsPage extends Component {
       queries,
       queryErrors,
       isBasicTier,
+      isGlobalAdmin,
+      teams,
     } = this.props;
-    const { showQueryHostModal } = this.state;
+    const { showQueryHostModal, showTransferHostModal } = this.state;
     const {
       toggleQueryHostModal,
+      toggleTransferHostModal,
       renderDeleteHostModal,
-      renderTransferHostModal,
+      onTransferHostSubmit,
       renderActionButtons,
       renderLabels,
       renderSoftware,
@@ -743,13 +735,21 @@ export class HostDetailsPage extends Component {
         {showQueryHostModal && (
           <SelectQueryModal
             host={host}
-            toggleQueryHostModal={toggleQueryHostModal}
+            onCancel={toggleQueryHostModal}
             queries={queries}
             dispatch={dispatch}
             queryErrors={queryErrors}
           />
         )}
-        {renderTransferHostModal()}
+        {showTransferHostModal && (
+          <TransferHostModal
+            host={host}
+            onCancel={toggleTransferHostModal()}
+            onSubmit={onTransferHostSubmit}
+            teams={teams}
+            isGlobalAdmin={isGlobalAdmin}
+          />
+        )}
       </div>
     );
   }

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -15,7 +15,7 @@ import PackQueriesListRow from "pages/hosts/HostDetailsPage/PackQueriesListRow";
 import HostUsersListRow from "pages/hosts/HostDetailsPage/HostUsersListRow";
 
 import permissionUtils from "utilities/permissions";
-import entityGetter from "redux/utilities/entityGetter";
+import entityGetter, { memoizedGetEntity } from "redux/utilities/entityGetter";
 import queryActions from "redux/nodes/entities/queries/actions";
 import teamInterface from "interfaces/team";
 import queryInterface from "interfaces/query";
@@ -247,7 +247,7 @@ export class HostDetailsPage extends Component {
       toggleQueryHostModal,
       toggleTransferHostModal,
     } = this;
-    const { host, isOnlyObserver } = this.props;
+    const { host, isOnlyObserver, canTransferTeam } = this.props;
 
     const isOnline = host.status === "online";
     const isOffline = host.status === "offline";
@@ -259,7 +259,7 @@ export class HostDetailsPage extends Component {
 
     return (
       <div className={`${baseClass}__action-button-container`}>
-        {canTransferTeam &&
+        {canTransferTeam && (
           <Button
             onClick={toggleTransferHostModal()}
             variant="inverse"
@@ -267,7 +267,7 @@ export class HostDetailsPage extends Component {
           >
             Transfer
           </Button>
-        }
+        )}
         <div data-tip data-for="query" data-tip-disable={isOnline}>
           <Button
             onClick={toggleQueryHostModal()}
@@ -527,6 +527,8 @@ export class HostDetailsPage extends Component {
       queries,
       queryErrors,
       isBasicTier,
+      isGlobalAdmin,
+      teams,
     } = this.props;
     const { showQueryHostModal, showTransferHostModal } = this.state;
     const {
@@ -772,6 +774,7 @@ const mapStateToProps = (state, ownProps) => {
     isOnlyObserver,
     teams,
     canTransferTeam,
+  };
 };
 
 export default connect(mapStateToProps)(HostDetailsPage);

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -89,6 +89,16 @@ export class HostDetailsPage extends Component {
     return false;
   }
 
+  componentDidMount() {
+    const { dispatch, hostID } = this.props;
+    const { fetchHost } = helpers;
+
+    fetchHost(dispatch, hostID).then((host) =>
+      this.setState({ showRefetchLoadingSpinner: host.refetch_requested })
+    );
+    return false;
+  }
+
   // Loads teams
   componentDidUpdate(prevProps) {
     const { dispatch, isBasicTier, canTransferTeam } = this.props;
@@ -103,16 +113,6 @@ export class HostDetailsPage extends Component {
 
   componentWillUnmount() {
     this.clearHostUpdates();
-  }
-
-  componentDidMount() {
-    const { dispatch, hostID } = this.props;
-    const { fetchHost } = helpers;
-
-    fetchHost(dispatch, hostID).then((host) =>
-      this.setState({ showRefetchLoadingSpinner: host.refetch_requested })
-    );
-    return false;
   }
 
   onDestroyHost = () => {
@@ -163,7 +163,7 @@ export class HostDetailsPage extends Component {
     const { dispatch, hostID } = this.props;
     const teamId = team.id === "no-team" ? null : team.id;
 
-    dispatch(hostActions.transferToTeam(teamId, [parseInt(hostID)]))
+    dispatch(hostActions.transferToTeam(teamId, [parseInt(hostID, 10)]))
       .then(() => {
         const successMessage =
           teamId === null

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -167,15 +167,15 @@ export class HostDetailsPage extends Component {
       .then(() => {
         const successMessage =
           teamId === null
-            ? `Hosts successfully removed from teams.`
-            : `Hosts successfully transferred to  ${team.name}.`;
+            ? `Host successfully removed from teams.`
+            : `Host successfully transferred to  ${team.name}.`;
         dispatch(renderFlash("success", successMessage));
         // Update page with correct team
         dispatch(hostActions.loadAll());
       })
       .catch(() => {
         dispatch(
-          renderFlash("error", "Could not transfer hosts. Please try again.")
+          renderFlash("error", "Could not transfer host. Please try again.")
         );
       });
     // Must call the function and the return to avoid infinite loop

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -16,10 +16,12 @@ import HostUsersListRow from "pages/hosts/HostDetailsPage/HostUsersListRow";
 
 import permissionUtils from "utilities/permissions";
 import entityGetter, { memoizedGetEntity } from "redux/utilities/entityGetter";
+import { getHosts } from "redux/nodes/components/ManageHostsPage/actions";
 import queryActions from "redux/nodes/entities/queries/actions";
 import teamInterface from "interfaces/team";
 import queryInterface from "interfaces/query";
 import { renderFlash } from "redux/nodes/notifications/actions";
+import teamActions from "redux/nodes/entities/teams/actions";
 import hostActions from "redux/nodes/entities/hosts/actions";
 import { push } from "react-router-redux";
 import PATHS from "router/paths";
@@ -87,6 +89,22 @@ export class HostDetailsPage extends Component {
     return false;
   }
 
+  // Loads teams
+  componentDidUpdate(prevProps) {
+    const { dispatch, isBasicTier, canTransferTeam } = this.props;
+    if (
+      isBasicTier !== prevProps.isBasicTier &&
+      isBasicTier &&
+      canTransferTeam
+    ) {
+      dispatch(teamActions.loadAll({}));
+    }
+  }
+
+  componentWillUnmount() {
+    this.clearHostUpdates();
+  }
+
   componentDidMount() {
     const { dispatch, hostID } = this.props;
     const { fetchHost } = helpers;
@@ -151,7 +169,8 @@ export class HostDetailsPage extends Component {
             ? `Hosts successfully removed from teams.`
             : `Hosts successfully transferred to  ${team.name}.`;
         dispatch(renderFlash("success", successMessage));
-        dispatch(getHosts());
+        // Update page with correct team
+        dispatch(hostActions.loadAll());
       })
       .catch(() => {
         dispatch(
@@ -196,7 +215,6 @@ export class HostDetailsPage extends Component {
 
   toggleTransferHostModal = () => {
     console.log("toggleTRANSFERHostModal");
-
     return () => {
       console.log("RETURN toggleTRANSFERHostModal");
 

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -162,6 +162,7 @@ export class HostDetailsPage extends Component {
     const { toggleTransferHostModal } = this;
     const { dispatch, hostID } = this.props;
     const teamId = team.id === "no-team" ? null : team.id;
+
     dispatch(hostActions.transferToTeam(teamId, [parseInt(hostID)]))
       .then(() => {
         const successMessage =
@@ -177,8 +178,8 @@ export class HostDetailsPage extends Component {
           renderFlash("error", "Could not transfer hosts. Please try again.")
         );
       });
-    console.log("onTransferHostSubmit");
-    toggleTransferHostModal();
+    // Must call the function and the return to avoid infinite loop
+    toggleTransferHostModal()();
   };
 
   clearHostUpdates() {
@@ -189,9 +190,7 @@ export class HostDetailsPage extends Component {
   }
 
   toggleQueryHostModal = () => {
-    console.log("toggleQUERYHostModal");
     return () => {
-      console.log("RETURN of toggleQUERYHostModal");
       const { showQueryHostModal } = this.state;
       this.setState({
         showQueryHostModal: !showQueryHostModal,
@@ -214,12 +213,8 @@ export class HostDetailsPage extends Component {
   };
 
   toggleTransferHostModal = () => {
-    console.log("toggleTRANSFERHostModal");
     return () => {
-      console.log("RETURN toggleTRANSFERHostModal");
-
       const { showTransferHostModal } = this.state;
-      console.log("showTransferHostModal:", showTransferHostModal);
 
       this.setState({
         showTransferHostModal: !showTransferHostModal,

--- a/frontend/pages/hosts/HostDetailsPage/SelectQueryModal/SelectQueryModal.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/SelectQueryModal/SelectQueryModal.jsx
@@ -34,7 +34,7 @@ const onQueryHostSaved = (host, selectedQuery, dispatch) => {
 };
 
 const SelectQueryModal = (props) => {
-  const { host, toggleQueryHostModal, dispatch, queries, queryErrors } = props;
+  const { host, onCancel, dispatch, queries, queryErrors } = props;
 
   const [queriesFilter, setQueriesFilter] = useState("");
 
@@ -185,7 +185,7 @@ const SelectQueryModal = (props) => {
   return (
     <Modal
       title="Select a query"
-      onExit={toggleQueryHostModal(null)}
+      onExit={onCancel(null)}
       className={`${baseClass}__modal`}
     >
       {results()}
@@ -197,7 +197,7 @@ SelectQueryModal.propTypes = {
   dispatch: PropTypes.func,
   host: hostInterface,
   queries: PropTypes.arrayOf(queryInterface),
-  toggleQueryHostModal: PropTypes.func,
+  onCancel: PropTypes.func,
   queryErrors: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 

--- a/frontend/pages/hosts/HostDetailsPage/TransferHostModal/TransferHostModal.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/TransferHostModal/TransferHostModal.tsx
@@ -28,9 +28,13 @@ const NO_TEAM_OPTION = {
   label: "No team",
 };
 
-const TransferHostModal = (props: ITransferHostModal): JSX.Element => {
-  const { onCancel, onSubmit, teams, isGlobalAdmin, host } = props;
-
+const TransferHostModal = ({
+  onCancel,
+  onSubmit,
+  teams,
+  isGlobalAdmin,
+  host,
+}: ITransferHostModal): JSX.Element => {
   const [selectedTeam, setSelectedTeam] = useState<ITeam | INoTeamOption>();
 
   const onChangeSelectTeam = useCallback(
@@ -71,14 +75,14 @@ const TransferHostModal = (props: ITransferHostModal): JSX.Element => {
           placeholder={"Select a team"}
           searchable={false}
         />
-        {isGlobalAdmin ? (
+        {isGlobalAdmin && (
           <p>
-            Team not here?{" "}
+            Team not here?&nbsp;
             <Link to={PATHS.ADMIN_TEAMS} className={`${baseClass}__team-link`}>
               Create a team
             </Link>
           </p>
-        ) : null}
+        )}
         <div className={`${baseClass}__btn-wrap`}>
           <Button
             disabled={selectedTeam === undefined}

--- a/frontend/pages/hosts/HostDetailsPage/TransferHostModal/TransferHostModal.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/TransferHostModal/TransferHostModal.tsx
@@ -82,7 +82,7 @@ const TransferHostModal = (props: ITransferHostModal): JSX.Element => {
         <div className={`${baseClass}__btn-wrap`}>
           <Button
             disabled={selectedTeam === undefined}
-            className={`${baseClass}__btn`}
+            className={`${baseClass}__btn transfer-action-btn`}
             type="button"
             variant="brand"
             onClick={onSubmitTransferHost}

--- a/frontend/pages/hosts/HostDetailsPage/TransferHostModal/TransferHostModal.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/TransferHostModal/TransferHostModal.tsx
@@ -1,0 +1,105 @@
+import React, { useCallback, useState } from "react";
+import { Link } from "react-router";
+import PATHS from "router/paths";
+import Modal from "components/modals/Modal";
+import Button from "components/buttons/Button";
+// ignore TS error for now until these are rewritten in ts.
+// @ts-ignore
+import Dropdown from "components/forms/fields/Dropdown";
+import { ITeam } from "interfaces/team";
+import { IHost } from "interfaces/host";
+
+interface ITransferHostModal {
+  isGlobalAdmin: boolean;
+  teams: ITeam[];
+  onSubmit: (team: ITeam) => void;
+  onCancel: () => void;
+  host: IHost;
+}
+
+interface INoTeamOption {
+  id: string;
+}
+
+const baseClass = "transfer-host-modal";
+
+const NO_TEAM_OPTION = {
+  value: "no-team",
+  label: "No team",
+};
+
+const TransferHostModal = (props: ITransferHostModal): JSX.Element => {
+  const { onCancel, onSubmit, teams, isGlobalAdmin, host } = props;
+
+  const [selectedTeam, setSelectedTeam] = useState<ITeam | INoTeamOption>();
+
+  const onChangeSelectTeam = useCallback(
+    (teamId: number | string) => {
+      if (teamId === "no-team") {
+        setSelectedTeam({ id: NO_TEAM_OPTION.value });
+      } else {
+        const teamWithId = teams.find((team) => team.id === teamId);
+        setSelectedTeam(teamWithId as ITeam);
+      }
+    },
+    [teams, setSelectedTeam]
+  );
+
+  const onSubmitTransferHost = useCallback(() => {
+    onSubmit(selectedTeam as ITeam);
+  }, [onSubmit, selectedTeam]);
+
+  const createTeamDropdownOptions = () => {
+    const teamOptions = teams.map((team) => {
+      return {
+        value: team.id,
+        label: team.name,
+      };
+    });
+    return [NO_TEAM_OPTION, ...teamOptions];
+  };
+
+  return (
+    <Modal onExit={onCancel} title={"Transfer hosts"} className={baseClass}>
+      <form className={`${baseClass}__form`}>
+        <Dropdown
+          wrapperClassName={`${baseClass}__team-dropdown-wrapper`}
+          label={"Transfer selected hosts to:"}
+          value={selectedTeam && selectedTeam.id}
+          options={createTeamDropdownOptions()}
+          onChange={onChangeSelectTeam}
+          placeholder={"Select a team"}
+          searchable={false}
+        />
+        {isGlobalAdmin ? (
+          <p>
+            Team not here?{" "}
+            <Link to={PATHS.ADMIN_TEAMS} className={`${baseClass}__team-link`}>
+              Create a team
+            </Link>
+          </p>
+        ) : null}
+        <div className={`${baseClass}__btn-wrap`}>
+          <Button
+            disabled={selectedTeam === undefined}
+            className={`${baseClass}__btn`}
+            type="button"
+            variant="brand"
+            onClick={onSubmitTransferHost}
+          >
+            Transfer
+          </Button>
+          <Button
+            className={`${baseClass}__btn`}
+            onClick={onCancel}
+            variant="inverse"
+          >
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default TransferHostModal;

--- a/frontend/pages/hosts/HostDetailsPage/TransferHostModal/TransferHostModal.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/TransferHostModal/TransferHostModal.tsx
@@ -64,7 +64,7 @@ const TransferHostModal = (props: ITransferHostModal): JSX.Element => {
       <form className={`${baseClass}__form`}>
         <Dropdown
           wrapperClassName={`${baseClass}__team-dropdown-wrapper`}
-          label={"Transfer selected hosts to:"}
+          label={"Transfer host to:"}
           value={selectedTeam && selectedTeam.id}
           options={createTeamDropdownOptions()}
           onChange={onChangeSelectTeam}

--- a/frontend/pages/hosts/HostDetailsPage/TransferHostModal/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/TransferHostModal/_styles.scss
@@ -1,0 +1,102 @@
+.transfer-host-modal {
+  #error-icon {
+    height: 12px;
+    width: 12px;
+    margin-right: 8px;
+  }
+
+  #new-tab-icon {
+    height: 12px;
+    width: 12px;
+    margin-left: 6px;
+  }
+
+  &__modal {
+    @include position(absolute, 22px null null null);
+    background-color: $core-white;
+    width: 658px;
+    padding: $pad-xxlarge;
+    border-radius: $pad-small;
+
+    a {
+      font-size: $x-small;
+      color: $core-vibrant-blue;
+      font-weight: $bold;
+      text-decoration: none;
+    }
+
+    .info {
+      display: flex;
+
+      &__header {
+        display: block;
+        color: $core-fleet-black;
+        font-weight: $bold;
+        font-size: $x-small;
+        text-align: left;
+      }
+      &__data {
+        display: block;
+        color: $core-fleet-black;
+        font-weight: normal;
+        font-size: $x-small;
+        text-align: left;
+        margin-top: 10px;
+      }
+    }
+  }
+
+  &__no-queries {
+    .info {
+      &__header {
+        margin: $pad-medium 0 $pad-medium 0;
+      }
+      &__data {
+        margin: 0 0 $pad-large 0;
+      }
+    }
+  }
+
+  &__query-modal {
+    display: flex;
+  }
+
+  &__filter-queries {
+    flex-grow: 3;
+    position: relative;
+
+    &::before {
+      display: inline-block;
+      position: absolute;
+      padding: 5px 0 0 0; // centers spin
+      content: url(../assets/images/icon-search-fleet-black-16x16@2x.png);
+      transform: scale(0.5);
+      height: 20px;
+      top: 3px;
+      left: 8px;
+    }
+
+    .input-field {
+      padding-left: 44px;
+    }
+
+    .fleeticon {
+      position: absolute;
+      top: 10px;
+      left: 10px;
+      font-size: $medium;
+      color: $ui-fleet-black-25;
+    }
+  }
+
+  &__create-query {
+    span {
+      margin: 15px;
+      font-weight: bold;
+    }
+  }
+
+  &__custom-query-button {
+    font-size: $x-small;
+  }
+}

--- a/frontend/pages/hosts/HostDetailsPage/TransferHostModal/index.ts
+++ b/frontend/pages/hosts/HostDetailsPage/TransferHostModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TransferHostModal";

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -242,8 +242,9 @@
     align-items: flex-start;
   }
 
-  &__query-button {
-    margin-right: 12px;
+  &__query-button,
+  &__transfer-button {
+    margin-right: $pad-small;
   }
 
   &__modal {


### PR DESCRIPTION
- Modal allows the user to transfer a host from the host details page
- E2e tests updated
- New e2e test caught a bug filed on #1237 closed by Zach's PR #1243
- Both Global Admin and Global Maintainer can transfer host teams on host details page and manage host page
- QA for both roles 6/29 @RachelElysia 

Closes #1174 

https://www.loom.com/share/3ec6cfbff4974410976e58b68d1a2806