### PR TITLE
Fix NPM fleetctl with new release archive formats

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,27 +57,30 @@ archives:
     builds:
       - fleet
       - fleetctl
-    name_template: fleet_{{.Version}}_{{.Os}}
+    name_template: fleet_v{{.Version}}_{{.Os}}
     replacements:
       darwin: macos
     format_overrides:
       - goos: windows
         format: zip
+    wrap_in_directory: true
 
   - id: fleetctl
     builds:
       - fleetctl
-    name_template: fleetctl_{{.Version}}_{{.Os}}
+    name_template: fleetctl_v{{.Version}}_{{.Os}}
     replacements:
       darwin: macos
+    wrap_in_directory: true
 
   - id: fleetctl-zip
     builds:
       - fleetctl
-    name_template: fleetctl_{{.Version}}_{{.Os}}
+    name_template: fleetctl_v{{.Version}}_{{.Os}}
     format: zip
     replacements:
       darwin: macos
+    wrap_in_directory: true
 
 dockers:
   - goos: linux

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetctl",
-  "version": "v4.0.0-rc3",
+  "version": "v4.0.0-rc3-1",
   "description": "Installer for the fleetctl CLI tool",
   "bin": {
     "fleetctl": "./run.js"

--- a/tools/fleetctl-npm/run.js
+++ b/tools/fleetctl-npm/run.js
@@ -19,7 +19,7 @@ const strippedVersion = version.replace(/-[0-9]+/i, "");
 const binDir = path.join(__dirname, "install");
 // Determine the install directory by version so that we can detect when we need
 // to upgrade to a new version.
-const installDir = path.join(binDir, version);
+const installDir = path.join(binDir, strippedVersion);
 
 const platform = () => {
   switch (os.type()) {


### PR DESCRIPTION
- Wrap extracted archives in directory.
- Adjust naming of archives and directories.