### PR TITLE
Redirect user to login when they reset their own sessions/API tokens from admin user management page

### DIFF
--- a/cypress/integration/all/app/resetsessions.spec.ts
+++ b/cypress/integration/all/app/resetsessions.spec.ts
@@ -33,7 +33,7 @@ describe("Reset user sessions flow", () => {
       cy.findByText(/reset sessions/i).should("exist");
       cy.findByRole("button", { name: /confirm/i }).click();
     });
-    cy.findByText(/sessions reset/i).should("exist");
+    cy.findByText(/reset sessions/i).should("not.exist");
 
     // user should be logged out now so log in again and go to profile to get new API token
     cy.visit("/");

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
@@ -216,7 +216,7 @@ export class UserManagementPage extends Component {
   };
 
   onResetSessions = () => {
-    const { HOME } = paths;
+    const { LOGIN } = paths;
     const { currentUser, dispatch } = this.props;
     const { userEditing } = this.state;
     const { toggleResetSessionsUserModal } = this;
@@ -224,7 +224,7 @@ export class UserManagementPage extends Component {
       .then(() => {
         dispatch(renderFlash("success", "Sessions reset"));
         if (currentUser.id === userEditing.id) {
-          dispatch(push(HOME));
+          dispatch(push(LOGIN));
         }
       })
       .catch(() => {

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
@@ -216,12 +216,16 @@ export class UserManagementPage extends Component {
   };
 
   onResetSessions = () => {
-    const { dispatch } = this.props;
+    const { HOME } = paths;
+    const { currentUser, dispatch } = this.props;
     const { userEditing } = this.state;
     const { toggleResetSessionsUserModal } = this;
     dispatch(userActions.deleteSessions(userEditing))
       .then(() => {
         dispatch(renderFlash("success", "Sessions reset"));
+        if (currentUser.id === userEditing.id) {
+          dispatch(push(HOME));
+        }
       })
       .catch(() => {
         dispatch(


### PR DESCRIPTION
Closes #1232

- When admin user resets their own API sessions, redirect to the login page immediately following confirmation of the reset action.

