### PR TITLE
User Settings Page: Add validation for email and full name

### DIFF
--- a/frontend/components/forms/UserSettingsForm/UserSettingsForm.jsx
+++ b/frontend/components/forms/UserSettingsForm/UserSettingsForm.jsx
@@ -6,6 +6,7 @@ import Button from "components/buttons/Button";
 import Form from "components/forms/Form";
 import formFieldInterface from "interfaces/form_field";
 import InputField from "components/forms/fields/InputField";
+import validate from "components/forms/UserSettingsForm/validate";
 
 const formFields = ["email", "name", "position", "username"];
 
@@ -64,4 +65,4 @@ class UserSettingsForm extends Component {
   }
 }
 
-export default Form(UserSettingsForm, { fields: formFields });
+export default Form(UserSettingsForm, { fields: formFields, validate });

--- a/frontend/components/forms/UserSettingsForm/validate.js
+++ b/frontend/components/forms/UserSettingsForm/validate.js
@@ -1,0 +1,21 @@
+import { size } from "lodash";
+import validatePresence from "components/forms/validators/validate_presence";
+
+const validate = (formData) => {
+  const errors = {};
+  const { email, name } = formData;
+
+  if (!validatePresence(email)) {
+    errors.email = "Email field must be completed";
+  }
+
+  if (!validatePresence(name)) {
+    errors.name = "Full name field must be completed";
+  }
+
+  const valid = !size(errors);
+
+  return { valid, errors };
+};
+
+export default validate;


### PR DESCRIPTION
- User email and full name must be present to make post request

Related: UX of User Settings Page #1133 
Before:
<img width="1564" alt="Screen Shot 2021-06-28 at 11 56 57 AM" src="https://user-images.githubusercontent.com/71795832/123689434-134bba00-d808-11eb-9f4a-9605d408af3f.png">


After:
<img width="1568" alt="Screen Shot 2021-06-28 at 11 52 04 AM" src="https://user-images.githubusercontent.com/71795832/123689451-18106e00-d808-11eb-8a76-5076e7d27b34.png">
