### PR TITLE
Improvements to fleetctl enroll secret specs

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -252,7 +252,7 @@ Cypress.Commands.add("addDockerHost", (team = "") => {
     },
   }).then(({ body }) => {
     const enrollSecret =
-      team === "" ? body.specs.secrets[0].secret : body.secrets[0].secret;
+      team === "" ? body.spec.secrets[0].secret : body.secrets[0].secret;
 
     // Start up docker-compose with enroll secret
     cy.exec(

--- a/frontend/redux/nodes/app/actions.js
+++ b/frontend/redux/nodes/app/actions.js
@@ -84,7 +84,7 @@ export const getEnrollSecret = () => {
     return Fleet.config
       .loadEnrollSecret()
       .then((secret) => {
-        dispatch(enrollSecretSuccess(secret.specs.secrets));
+        dispatch(enrollSecretSuccess(secret.spec.secrets));
 
         return secret;
       })

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -333,7 +333,7 @@ type EnrollSecret struct {
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
 	// TeamID is the ID for the associated team. If no ID is set, then this is a
 	// global enroll secret.
-	TeamID *uint `json:"team_id" db:"team_id"`
+	TeamID *uint `json:"team_id,omitempty" db:"team_id"`
 }
 
 func (e *EnrollSecret) AuthzType() string {

--- a/server/service/endpoint_appconfig.go
+++ b/server/service/endpoint_appconfig.go
@@ -189,7 +189,7 @@ func makeApplyEnrollSecretSpecEndpoint(svc fleet.Service) endpoint.Endpoint {
 ////////////////////////////////////////////////////////////////////////////////
 
 type getEnrollSecretSpecResponse struct {
-	Spec *fleet.EnrollSecretSpec `json:"specs"`
+	Spec *fleet.EnrollSecretSpec `json:"spec"`
 	Err  error                   `json:"error,omitempty"`
 }
 


### PR DESCRIPTION
- Do not render Team ID if null.
- Make request and response schema consistent (breaking change).

Fixes #186