### PR TITLE
Fix frontend rendering error when software vulnerabilities missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,8 +238,8 @@ e2e-setup:
 	./build/fleetctl user create --context e2e --email=sso_user@example.com --name "SSO user" --sso=true
 
 e2e-serve-core:
-	./build/fleet serve --mysql_address=localhost:3307 --mysql_username=root --mysql_password=toor --mysql_database=e2e --server_address=0.0.0.0:8642 
+	FLEET_SOFTWARE_INVENTORY=1 ./build/fleet serve --mysql_address=localhost:3307 --mysql_username=root --mysql_password=toor --mysql_database=e2e --server_address=0.0.0.0:8642 
 
 e2e-serve-basic:
-	./build/fleet serve  --dev_license --mysql_address=localhost:3307 --mysql_username=root --mysql_password=toor --mysql_database=e2e --server_address=0.0.0.0:8642
+	FLEET_SOFTWARE_INVENTORY=1 ./build/fleet serve  --dev_license --mysql_address=localhost:3307 --mysql_username=root --mysql_password=toor --mysql_database=e2e --server_address=0.0.0.0:8642
 

--- a/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/SoftwareListRow.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/SoftwareListRow/SoftwareListRow.jsx
@@ -1,3 +1,4 @@
+import { isEmpty } from "lodash";
 import React, { Component } from "react";
 import IconToolTip from "components/IconToolTip";
 
@@ -37,7 +38,7 @@ class SoftwareListRow extends Component {
     const type = TYPE_CONVERSION[source] || "Unknown";
 
     const vulnerabilitiesIcon = () => {
-      if (vulnerabilities.length === 0) {
+      if (isEmpty(vulnerabilities)) {
         return null;
       }
 


### PR DESCRIPTION
This error was not caught in E2E testing because the software inventory
feature flag was turned off. This is now also enabled for E2E tests.

Fixes #1245