### PR TITLE
New Cypress configs and commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
         make e2e-serve-${{ matrix.fleet-tier }} &
         sleep 3
         make e2e-setup
-        CYPRESS_FLEET_TIER=${{ matrix.fleet-tier }} yarn cypress run --config video=false
+        CYPRESS_FLEET_TIER=${{ matrix.fleet-tier }} yarn cypress run --config-file cypress-${{ matrix.fleet-tier }}.json --config video=false
 
 
   test-js:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
         make e2e-serve-${{ matrix.fleet-tier }} &
         sleep 3
         make e2e-setup
-        CYPRESS_FLEET_TIER=${{ matrix.fleet-tier }} yarn cypress run --config-file cypress-${{ matrix.fleet-tier }}.json --config video=false
+        yarn cypress run --config-file cypress-${{ matrix.fleet-tier }}.json --config video=false
 
 
   test-js:

--- a/cypress-all.json
+++ b/cypress-all.json
@@ -1,0 +1,5 @@
+{
+  "baseUrl": "https://localhost:8642",
+  "fixturesFolder": false,
+  "testFiles": "all/**/*.spec.ts"
+}

--- a/cypress-all.json
+++ b/cypress-all.json
@@ -1,5 +1,0 @@
-{
-  "baseUrl": "https://localhost:8642",
-  "fixturesFolder": false,
-  "testFiles": "all/**/*.spec.ts"
-}

--- a/cypress-basic.json
+++ b/cypress-basic.json
@@ -1,0 +1,5 @@
+{
+  "baseUrl": "https://localhost:8642",
+  "fixturesFolder": false,
+  "testFiles": "basic/**/*.spec.ts"
+}

--- a/cypress-basic.json
+++ b/cypress-basic.json
@@ -1,5 +1,5 @@
 {
   "baseUrl": "https://localhost:8642",
   "fixturesFolder": false,
-  "testFiles": "basic/**/*.spec.ts"
+  "testFiles": "{all,basic}/**/*.spec.ts"
 }

--- a/cypress-core.json
+++ b/cypress-core.json
@@ -1,0 +1,5 @@
+{
+  "baseUrl": "https://localhost:8642",
+  "fixturesFolder": false,
+  "testFiles": "core/**/*.spec.ts"
+}

--- a/cypress-core.json
+++ b/cypress-core.json
@@ -1,5 +1,5 @@
 {
   "baseUrl": "https://localhost:8642",
   "fixturesFolder": false,
-  "testFiles": "core/**/*.spec.ts"
+  "testFiles": "{all,core}/**/*.spec.ts"
 }

--- a/cypress/integration/basic/admin.spec.ts
+++ b/cypress/integration/basic/admin.spec.ts
@@ -1,90 +1,88 @@
-if (Cypress.env("FLEET_TIER") === "basic") {
-  describe("Basic tier - Admin user", () => {
-    beforeEach(() => {
-      cy.setup();
-      cy.login();
-      cy.seedBasic();
-      cy.setupSMTP();
-      cy.seedQueries();
-      cy.addDockerHost("apples");
-      cy.logout();
-    });
-    afterEach(() => {
-      cy.stopDockerHost();
-    });
-
-    it("Can perform the appropriate basic-tier admin actions", () => {
-      cy.login("anna@organization.com", "user123#");
-      cy.visit("/");
-
-      // Ensure the hosts page is loaded
-      cy.contains("All hosts");
-
-      // On the hosts page, they should…
-
-      // See the “Teams” column in the Hosts table
-      cy.get("thead").contains(/team/i).should("exist");
-
-      // See and select the “Add new host” button
-      cy.contains("button", /add new host/i).click();
-
-      // See the “Select a team for this new host” in the Add new host modal. This modal appears after the user selects the “Add new host” button
-      cy.get(".Select-control").click();
-
-      cy.get(".add-host-modal__team-dropdown-wrapper").within(() => {
-        cy.findByText(/no team/i).should("exist");
-        cy.findByText(/apples/i).should("exist");
-        cy.findByText(/oranges/i).should("exist");
-      });
-
-      cy.contains("button", /done/i).click();
-
-      // On the Host details page, they should…
-      // See the “Team” information below the hostname
-      // Be able to transfer Teams
-      cy.visit("/hosts/1");
-      cy.findByText(/team/i).next().contains("Apples");
-      cy.contains("button", /transfer/i).click();
-      cy.get(".Select-control").click();
-      cy.findByText(/create a team/i).should("exist");
-      cy.get(".Select-menu").within(() => {
-        cy.findByText(/no team/i).should("exist");
-        cy.findByText(/apples/i).should("exist");
-        cy.findByText(/oranges/i).click();
-      });
-      cy.get(".transfer-action-btn").click();
-      cy.findByText(/transferred to oranges/i).should("exist");
-      cy.findByText(/team/i).next().contains("Oranges");
-
-      // On the Queries - new / edit / run page, they should…
-      // See the “Teams” section in the Select target picker. This picker is summoned when the “Select targets” field is selected.
-      cy.visit("/queries/new");
-      cy.get(".target-select").within(() => {
-        cy.findByText(/Label name, host name, IP address, etc./i).click();
-        cy.findByText(/teams/i).should("exist");
-      });
-
-      // On the Packs pages (manage, new, and edit), they should…
-      // ^^General admin functionality for packs page is being tested in app/packflow.spec.ts
-
-      // On the Settings pages, they should…
-      // See the “Teams” navigation item and access the Settings - Teams page
-      cy.visit("/settings/organization");
-      cy.get(".react-tabs").within(() => {
-        cy.findByText(/teams/i).click();
-      });
-      // Access the Settings - Team details page
-      cy.findByText(/apples/i).click();
-      cy.findByText(/apples/i).should("exist");
-      cy.findByText(/manage users with global access here/i).should("exist");
-
-      // See the “Team” section in the create user modal. This modal is summoned when the “Create user” button is selected
-      cy.visit("/settings/organization");
-      cy.get(".react-tabs").within(() => {
-        cy.findByText(/users/i).click();
-      });
-      cy.findByRole("button", { name: /create user/i }).click();
-      cy.findByText(/assign teams/i).should("exist");
-    });
+describe("Basic tier - Admin user", () => {
+  beforeEach(() => {
+    cy.setup();
+    cy.login();
+    cy.seedBasic();
+    cy.setupSMTP();
+    cy.seedQueries();
+    cy.addDockerHost("apples");
+    cy.logout();
   });
-}
+  afterEach(() => {
+    cy.stopDockerHost();
+  });
+
+  it("Can perform the appropriate basic-tier admin actions", () => {
+    cy.login("anna@organization.com", "user123#");
+    cy.visit("/");
+
+    // Ensure the hosts page is loaded
+    cy.contains("All hosts");
+
+    // On the hosts page, they should…
+
+    // See the “Teams” column in the Hosts table
+    cy.get("thead").contains(/team/i).should("exist");
+
+    // See and select the “Add new host” button
+    cy.contains("button", /add new host/i).click();
+
+    // See the “Select a team for this new host” in the Add new host modal. This modal appears after the user selects the “Add new host” button
+    cy.get(".Select-control").click();
+
+    cy.get(".add-host-modal__team-dropdown-wrapper").within(() => {
+      cy.findByText(/no team/i).should("exist");
+      cy.findByText(/apples/i).should("exist");
+      cy.findByText(/oranges/i).should("exist");
+    });
+
+    cy.contains("button", /done/i).click();
+
+    // On the Host details page, they should…
+    // See the “Team” information below the hostname
+    // Be able to transfer Teams
+    cy.visit("/hosts/1");
+    cy.findByText(/team/i).next().contains("Apples");
+    cy.contains("button", /transfer/i).click();
+    cy.get(".Select-control").click();
+    cy.findByText(/create a team/i).should("exist");
+    cy.get(".Select-menu").within(() => {
+      cy.findByText(/no team/i).should("exist");
+      cy.findByText(/apples/i).should("exist");
+      cy.findByText(/oranges/i).click();
+    });
+    cy.get(".transfer-action-btn").click();
+    cy.findByText(/transferred to oranges/i).should("exist");
+    cy.findByText(/team/i).next().contains("Oranges");
+
+    // On the Queries - new / edit / run page, they should…
+    // See the “Teams” section in the Select target picker. This picker is summoned when the “Select targets” field is selected.
+    cy.visit("/queries/new");
+    cy.get(".target-select").within(() => {
+      cy.findByText(/Label name, host name, IP address, etc./i).click();
+      cy.findByText(/teams/i).should("exist");
+    });
+
+    // On the Packs pages (manage, new, and edit), they should…
+    // ^^General admin functionality for packs page is being tested in app/packflow.spec.ts
+
+    // On the Settings pages, they should…
+    // See the “Teams” navigation item and access the Settings - Teams page
+    cy.visit("/settings/organization");
+    cy.get(".react-tabs").within(() => {
+      cy.findByText(/teams/i).click();
+    });
+    // Access the Settings - Team details page
+    cy.findByText(/apples/i).click();
+    cy.findByText(/apples/i).should("exist");
+    cy.findByText(/manage users with global access here/i).should("exist");
+
+    // See the “Team” section in the create user modal. This modal is summoned when the “Create user” button is selected
+    cy.visit("/settings/organization");
+    cy.get(".react-tabs").within(() => {
+      cy.findByText(/users/i).click();
+    });
+    cy.findByRole("button", { name: /create user/i }).click();
+    cy.findByText(/assign teams/i).should("exist");
+  });
+});

--- a/cypress/integration/basic/maintainer.spec.ts
+++ b/cypress/integration/basic/maintainer.spec.ts
@@ -1,76 +1,74 @@
-if (Cypress.env("FLEET_TIER") === "basic") {
-  describe("Basic tier - Maintainer user", () => {
-    beforeEach(() => {
-      cy.setup();
-      cy.login();
-      cy.seedBasic();
-      cy.seedQueries();
-      cy.addDockerHost();
-      cy.logout();
+describe("Basic tier - Maintainer user", () => {
+  beforeEach(() => {
+    cy.setup();
+    cy.login();
+    cy.seedBasic();
+    cy.seedQueries();
+    cy.addDockerHost();
+    cy.logout();
+  });
+
+  afterEach(() => {
+    cy.stopDockerHost();
+  });
+
+  it("Can perform the appropriate basic global maintainer actions", () => {
+    cy.login("mary@organization.com", "user123#");
+    cy.visit("/");
+
+    // Ensure page is loaded
+    cy.contains("All hosts");
+
+    // Host manage page: Teams column, select a team
+    cy.visit("/hosts/manage");
+
+    cy.get("thead").within(() => {
+      cy.findByText(/team/i).should("exist");
     });
 
-    afterEach(() => {
-      cy.stopDockerHost();
+    cy.contains("button", /add new host/i).click();
+    // TODO: Check Team Apples is in Select a team dropdown
+    cy.contains("button", /done/i).click();
+
+    // Host details page: Can see team UI
+    cy.get("tbody").within(() => {
+      // Test host text varies
+      cy.findByRole("button").click();
+    });
+    cy.get(".title").within(() => {
+      cy.findByText("Team").should("exist");
+    });
+    cy.contains("button", /transfer/i).click();
+    cy.get(".Select-control").click();
+    cy.findByText(/create a team/i).should("not.exist");
+    cy.get(".Select-menu").within(() => {
+      cy.findByText(/no team/i).should("exist");
+      cy.findByText(/apples/i).should("exist");
+      cy.findByText(/oranges/i).click();
+    });
+    cy.get(".transfer-action-btn").click();
+    cy.findByText(/transferred to oranges/i).should("exist");
+    cy.findByText(/team/i).next().contains("Oranges");
+
+    // Query pages: Can see teams UI for create, edit, and run query
+    cy.visit("/queries/manage");
+
+    cy.findByRole("button", { name: /create new query/i }).click();
+
+    cy.get(".target-select").within(() => {
+      cy.findByText(/Label name, host name, IP address, etc./i).click();
+      cy.findByText(/teams/i).should("exist");
     });
 
-    it("Can perform the appropriate basic global maintainer actions", () => {
-      cy.login("mary@organization.com", "user123#");
-      cy.visit("/");
+    cy.visit("/queries/manage");
 
-      // Ensure page is loaded
-      cy.contains("All hosts");
+    cy.findByText(/detect presence/i).click();
 
-      // Host manage page: Teams column, select a team
-      cy.visit("/hosts/manage");
+    cy.findByRole("button", { name: /edit or run query/i }).click();
 
-      cy.get("thead").within(() => {
-        cy.findByText(/team/i).should("exist");
-      });
-
-      cy.contains("button", /add new host/i).click();
-      // TODO: Check Team Apples is in Select a team dropdown
-      cy.contains("button", /done/i).click();
-
-      // Host details page: Can see team UI
-      cy.get("tbody").within(() => {
-        // Test host text varies
-        cy.findByRole("button").click();
-      });
-      cy.get(".title").within(() => {
-        cy.findByText("Team").should("exist");
-      });
-      cy.contains("button", /transfer/i).click();
-      cy.get(".Select-control").click();
-      cy.findByText(/create a team/i).should("not.exist");
-      cy.get(".Select-menu").within(() => {
-        cy.findByText(/no team/i).should("exist");
-        cy.findByText(/apples/i).should("exist");
-        cy.findByText(/oranges/i).click();
-      });
-      cy.get(".transfer-action-btn").click();
-      cy.findByText(/transferred to oranges/i).should("exist");
-      cy.findByText(/team/i).next().contains("Oranges");
-
-      // Query pages: Can see teams UI for create, edit, and run query
-      cy.visit("/queries/manage");
-
-      cy.findByRole("button", { name: /create new query/i }).click();
-
-      cy.get(".target-select").within(() => {
-        cy.findByText(/Label name, host name, IP address, etc./i).click();
-        cy.findByText(/teams/i).should("exist");
-      });
-
-      cy.visit("/queries/manage");
-
-      cy.findByText(/detect presence/i).click();
-
-      cy.findByRole("button", { name: /edit or run query/i }).click();
-
-      cy.get(".target-select").within(() => {
-        cy.findByText(/Label name, host name, IP address, etc./i).click();
-        cy.findByText(/teams/i).should("exist");
-      });
+    cy.get(".target-select").within(() => {
+      cy.findByText(/Label name, host name, IP address, etc./i).click();
+      cy.findByText(/teams/i).should("exist");
     });
   });
-}
+});

--- a/cypress/integration/basic/observer.spec.ts
+++ b/cypress/integration/basic/observer.spec.ts
@@ -1,69 +1,67 @@
-if (Cypress.env("FLEET_TIER") === "basic") {
-  describe("Basic tier - Observer user", () => {
-    beforeEach(() => {
-      cy.setup();
-      cy.login();
-      cy.seedBasic();
-      cy.seedQueries();
-      cy.addDockerHost("apples");
-      cy.logout();
+describe("Basic tier - Observer user", () => {
+  beforeEach(() => {
+    cy.setup();
+    cy.login();
+    cy.seedBasic();
+    cy.seedQueries();
+    cy.addDockerHost("apples");
+    cy.logout();
+  });
+
+  afterEach(() => {
+    cy.stopDockerHost();
+  });
+
+  it("Can perform the appropriate basic global observer actions", () => {
+    cy.login("oliver@organization.com", "user123#");
+    cy.visit("/");
+
+    // Ensure page is loaded
+    cy.contains("All hosts");
+
+    // Host manage page: Can see team column
+    cy.visit("/hosts/manage");
+
+    cy.get("thead").within(() => {
+      cy.findByText(/team/i).should("exist");
     });
 
-    afterEach(() => {
-      cy.stopDockerHost();
+    // Host details page: Can see team on host
+    cy.get("tbody").within(() => {
+      // Test host text varies
+      cy.findByRole("button").click();
     });
-
-    it("Can perform the appropriate basic global observer actions", () => {
-      cy.login("oliver@organization.com", "user123#");
-      cy.visit("/");
-
-      // Ensure page is loaded
-      cy.contains("All hosts");
-
-      // Host manage page: Can see team column
-      cy.visit("/hosts/manage");
-
-      cy.get("thead").within(() => {
-        cy.findByText(/team/i).should("exist");
-      });
-
-      // Host details page: Can see team on host
-      cy.get("tbody").within(() => {
-        // Test host text varies
-        cy.findByRole("button").click();
-      });
-      cy.get(".title").within(() => {
-        cy.findByText("Team").should("exist");
-      });
-      cy.contains("button", /transfer/i).should("not.exist");
-
-      // Query pages: Can see team in select targets dropdown
-      cy.visit("/queries/manage");
-
-      cy.findByText(/detect presence/i).click();
-
-      cy.findByRole("button", { name: /run query/i }).click();
-
-      cy.get(".target-select").within(() => {
-        cy.findByText(/Label name, host name, IP address, etc./i).click();
-        cy.findByText(/teams/i).should("exist");
-      });
+    cy.get(".title").within(() => {
+      cy.findByText("Team").should("exist");
     });
+    cy.contains("button", /transfer/i).should("not.exist");
 
-    // Pseudo code for team observer only
-    // TODO: Rebuild this test according to new manual QA
-    it("Can perform the appropriate basic team observer only actions", () => {
-      cy.login("toni@organization.com", "user123#");
-      cy.visit("/hosts/manage");
+    // Query pages: Can see team in select targets dropdown
+    cy.visit("/queries/manage");
 
-      cy.findByText("All hosts which have enrolled in Fleet").should("exist");
+    cy.findByText(/detect presence/i).click();
 
-      cy.findByText("Packs").should("not.exist");
-      cy.findByText("Settings").should("not.exist");
+    cy.findByRole("button", { name: /run query/i }).click();
 
-      cy.contains(".table-container .data-table__table th", "Team").should(
-        "be.visible"
-      );
+    cy.get(".target-select").within(() => {
+      cy.findByText(/Label name, host name, IP address, etc./i).click();
+      cy.findByText(/teams/i).should("exist");
     });
   });
-}
+
+  // Pseudo code for team observer only
+  // TODO: Rebuild this test according to new manual QA
+  it("Can perform the appropriate basic team observer only actions", () => {
+    cy.login("toni@organization.com", "user123#");
+    cy.visit("/hosts/manage");
+
+    cy.findByText("All hosts which have enrolled in Fleet").should("exist");
+
+    cy.findByText("Packs").should("not.exist");
+    cy.findByText("Settings").should("not.exist");
+
+    cy.contains(".table-container .data-table__table th", "Team").should(
+      "be.visible"
+    );
+  });
+});

--- a/cypress/integration/basic/team_maintainer_observer.spec.ts
+++ b/cypress/integration/basic/team_maintainer_observer.spec.ts
@@ -1,177 +1,175 @@
-if (Cypress.env("FLEET_TIER") === "basic") {
-  describe("Basic tier - Team observer/maintainer user", () => {
-    beforeEach(() => {
-      cy.setup();
-      cy.login();
-      cy.seedBasic();
-      cy.seedQueries();
-      cy.addDockerHost();
-      cy.logout();
-    });
-    afterEach(() => {
-      cy.stopDockerHost();
-    });
+describe("Basic tier - Team observer/maintainer user", () => {
+  beforeEach(() => {
+    cy.setup();
+    cy.login();
+    cy.seedBasic();
+    cy.seedQueries();
+    cy.addDockerHost();
+    cy.logout();
+  });
+  afterEach(() => {
+    cy.stopDockerHost();
+  });
 
-    it("Can perform the appropriate team observer actions", () => {
-      cy.login("marco@organization.com", "user123#");
-      cy.visit("/");
+  it("Can perform the appropriate team observer actions", () => {
+    cy.login("marco@organization.com", "user123#");
+    cy.visit("/");
 
-      // Ensure page is loaded
-      cy.contains("All hosts");
+    // Ensure page is loaded
+    cy.contains("All hosts");
 
-      // On the Hosts page, they should…
+    // On the Hosts page, they should…
 
-      // See hosts
-      // cy.findByText(/kinda empty in here/i).should("not.exist");
-      // ^^TODO hosts table is not rendering because we need new forEach script/command for admin to assign team after the host is added
+    // See hosts
+    // cy.findByText(/kinda empty in here/i).should("not.exist");
+    // ^^TODO hosts table is not rendering because we need new forEach script/command for admin to assign team after the host is added
 
-      // See the “Teams” column in the Hosts table
-      // cy.get("thead").contains(/team/i).should("exist");
+    // See the “Teams” column in the Hosts table
+    // cy.get("thead").contains(/team/i).should("exist");
 
-      // NOT see the “Packs” and “Settings” navigation items
+    // NOT see the “Packs” and “Settings” navigation items
+    cy.findByText(/packs/i).should("not.exist");
+    cy.findByText(/settings/i).should("not.exist");
+
+    // NOT see and select "add new label"
+    cy.findByRole("button", { name: /new label/i }).should("not.exist");
+
+    // On the Host details page, they should…
+
+    // See the “Team” information below the hostname
+    // cy.visit("/hosts/1");
+    // cy.findByText(/team/i).next().contains("Apples");
+    // ^^TODO need new forEach script/command for admin to assign team after the host is added
+
+    // NOT see and select the “Delete” button
+    // cy.findByText(/delete/i).should("not.exist");
+    // ^^ TODO this is restriction only applies to hosts where they are not a maintainer
+
+    // NOT see and select the “Query” button
+    // cy.findByText(/query/i).should("not.exist");
+    // ^^ TODO this is restriction only applies to hosts where they are not a maintainer
+
+    // On the Queries manage page, they should…
+    cy.visit("/queries/manage");
+    cy.findByText(/no queries available/i).should("not.exist");
+
+    // See and select the “Show query” button in the right side panel if the saved query has `observer_can_run` set to `false`. This button appears after the user selects a query in the Queries table.
+    // See and select the “Run query” button in the right side panel if the saved query has `observer_can_run` set to `true`. This button appears after the user selects a query in the Queries table.
+    // ^^TODO confirm if these distinctions apply to dual-role user like Marco
+
+    // NOT see the “Observers can run” column in the Queries table
+    // cy.findByText(/observers can run/i).should("not.exist");
+    // ^^TODO confirm this does not apply to dual-role user like Marco
+
+    // NOT see and select the “Create new query” button
+    // cy.findByText(/create new query/i).should("not.exist");
+    // ^^TODO confirm this does not apply to dual-role user like Marco
+
+    // NOT see the “SQL” and “Packs” sections in the right side bar. These sections appear after the user selects a query in the Queries table.
+    // cy.get(".secondary-side-panel-container").within(() => {
+    //   cy.findByText(/sql/i).should("not.exist");
+    //   cy.findByText(/packs/i).should("not.exist");
+    // });
+    // ^^TODO confirm this does not apply to dual-role user like Marco
+
+    // On the Query details page they should…
+    cy.visit("/queries/1");
+
+    // See the “Show SQL” button.
+    cy.findByText(/show sql/i).click();
+    cy.findByText(/hide sql/i).should("exist");
+
+    // See the “Select targets” input
+    cy.findByText(/select targets/i).should("exist");
+
+    // NOT see and edit “Query name,” “Description,” “SQL”, and “Observer can run” fields.
+    cy.findByLabelText(/query name/i).should("not.exist");
+    cy.findByLabelText(/description/i).should("not.exist");
+    cy.findByLabelText(/observers can run/i).should("not.exist");
+    cy.get(".ace_scroller")
+      .click({ force: true })
+      .type("{selectall}{backspace}SELECT * FROM windows_crashes;");
+    cy.findByText(/SELECT * FROM windows_crashes;/i).should("not.exist");
+
+    // NOT see a the “Select targets” input if the saved query has `observer_can_run` set to false.
+    // cy.findByText(/select targets/i).should("not.exist");
+    // ^^ TODO confirm if this restriction applies to a dual-role user like Marco
+
+    // NOT see a the “Teams” section in the Select target picker. This picker is summoned when the “Select targets” field is selected.
+    // ^^ TODO confirm if this restriction applies to a dual-role user like Marco
+  });
+
+  it("Can perform the appropriate maintainer actions", () => {
+    cy.login("marco@organization.com", "user123#");
+    cy.visit("/");
+
+    // Ensure page is loaded and appropriate nav links are displayed
+    cy.contains("All hosts");
+    cy.get("nav").within(() => {
+      cy.findByText(/hosts/i).should("exist");
+      cy.findByText(/queries/i).should("exist");
       cy.findByText(/packs/i).should("not.exist");
       cy.findByText(/settings/i).should("not.exist");
-
-      // NOT see and select "add new label"
-      cy.findByRole("button", { name: /new label/i }).should("not.exist");
-
-      // On the Host details page, they should…
-
-      // See the “Team” information below the hostname
-      // cy.visit("/hosts/1");
-      // cy.findByText(/team/i).next().contains("Apples");
-      // ^^TODO need new forEach script/command for admin to assign team after the host is added
-
-      // NOT see and select the “Delete” button
-      // cy.findByText(/delete/i).should("not.exist");
-      // ^^ TODO this is restriction only applies to hosts where they are not a maintainer
-
-      // NOT see and select the “Query” button
-      // cy.findByText(/query/i).should("not.exist");
-      // ^^ TODO this is restriction only applies to hosts where they are not a maintainer
-
-      // On the Queries manage page, they should…
-      cy.visit("/queries/manage");
-      cy.findByText(/no queries available/i).should("not.exist");
-
-      // See and select the “Show query” button in the right side panel if the saved query has `observer_can_run` set to `false`. This button appears after the user selects a query in the Queries table.
-      // See and select the “Run query” button in the right side panel if the saved query has `observer_can_run` set to `true`. This button appears after the user selects a query in the Queries table.
-      // ^^TODO confirm if these distinctions apply to dual-role user like Marco
-
-      // NOT see the “Observers can run” column in the Queries table
-      // cy.findByText(/observers can run/i).should("not.exist");
-      // ^^TODO confirm this does not apply to dual-role user like Marco
-
-      // NOT see and select the “Create new query” button
-      // cy.findByText(/create new query/i).should("not.exist");
-      // ^^TODO confirm this does not apply to dual-role user like Marco
-
-      // NOT see the “SQL” and “Packs” sections in the right side bar. These sections appear after the user selects a query in the Queries table.
-      // cy.get(".secondary-side-panel-container").within(() => {
-      //   cy.findByText(/sql/i).should("not.exist");
-      //   cy.findByText(/packs/i).should("not.exist");
-      // });
-      // ^^TODO confirm this does not apply to dual-role user like Marco
-
-      // On the Query details page they should…
-      cy.visit("/queries/1");
-
-      // See the “Show SQL” button.
-      cy.findByText(/show sql/i).click();
-      cy.findByText(/hide sql/i).should("exist");
-
-      // See the “Select targets” input
-      cy.findByText(/select targets/i).should("exist");
-
-      // NOT see and edit “Query name,” “Description,” “SQL”, and “Observer can run” fields.
-      cy.findByLabelText(/query name/i).should("not.exist");
-      cy.findByLabelText(/description/i).should("not.exist");
-      cy.findByLabelText(/observers can run/i).should("not.exist");
-      cy.get(".ace_scroller")
-        .click({ force: true })
-        .type("{selectall}{backspace}SELECT * FROM windows_crashes;");
-      cy.findByText(/SELECT * FROM windows_crashes;/i).should("not.exist");
-
-      // NOT see a the “Select targets” input if the saved query has `observer_can_run` set to false.
-      // cy.findByText(/select targets/i).should("not.exist");
-      // ^^ TODO confirm if this restriction applies to a dual-role user like Marco
-
-      // NOT see a the “Teams” section in the Select target picker. This picker is summoned when the “Select targets” field is selected.
-      // ^^ TODO confirm if this restriction applies to a dual-role user like Marco
     });
 
-    it("Can perform the appropriate maintainer actions", () => {
-      cy.login("marco@organization.com", "user123#");
-      cy.visit("/");
+    // On the hosts page, they should…
 
-      // Ensure page is loaded and appropriate nav links are displayed
-      cy.contains("All hosts");
-      cy.get("nav").within(() => {
-        cy.findByText(/hosts/i).should("exist");
-        cy.findByText(/queries/i).should("exist");
-        cy.findByText(/packs/i).should("not.exist");
-        cy.findByText(/settings/i).should("not.exist");
+    // See the “Teams” column in the Hosts table
+    // cy.get("thead").contains(/team/i).should("exist");
+    // ^^TODO hosts table is not rendering because we need new forEach script/command for admin to assign team after the host is added
+
+    // See and select the “Add new host” button
+    cy.findByText(/add new host/i).click();
+
+    // See the “Select a team for this new host” in the Add new host modal. This modal appears after the user selects the “Add new host” button
+    cy.get(".add-host-modal__team-dropdown-wrapper").within(() => {
+      cy.findByText(/select a team for this new host/i).should("exist");
+      cy.get(".Select").within(() => {
+        cy.findByText(/select a team/i).click();
+        cy.findByText(/no team/i).should("exist");
+        // cy.findByText(/apples/i).should("exist");
+        // cy.findByText(/oranges/i).should("not exist");
+        // ^ TODO: Team maintainer has access to only their teams, team observer does not have access
       });
+    });
+    cy.findByRole("button", { name: /done/i }).click();
 
-      // On the hosts page, they should…
+    // On the Host details page, they should…
+    // cy.visit("/hosts/1");
+    // ^^TODO hosts details page returning 403 likely because we need new forEach script/command for admin to assign team after the host is added
 
-      // See the “Teams” column in the Hosts table
-      // cy.get("thead").contains(/team/i).should("exist");
-      // ^^TODO hosts table is not rendering because we need new forEach script/command for admin to assign team after the host is added
+    // See and select the “Create new query” button in the Select a query modal. This modal appears after the user selects the “Query” button
+    // cy.findByRole("button", { name: /query/i }).click();
+    // cy.findByRole("button", { name: /create custom query/i }).should("exist");
+    // cy.get(".modal__ex").within(() => {
+    //   cy.findByRole("button").click();
+    // });
+    // ^^TODO hosts details page returning 403 likely because we need new forEach script/command for admin to assign team after the host is added
 
-      // See and select the “Add new host” button
-      cy.findByText(/add new host/i).click();
+    // On the Queries manage page, they should…
+    cy.visit("/queries/manage");
 
-      // See the “Select a team for this new host” in the Add new host modal. This modal appears after the user selects the “Add new host” button
-      cy.get(".add-host-modal__team-dropdown-wrapper").within(() => {
-        cy.findByText(/select a team for this new host/i).should("exist");
-        cy.get(".Select").within(() => {
-          cy.findByText(/select a team/i).click();
-          cy.findByText(/no team/i).should("exist");
-          // cy.findByText(/apples/i).should("exist");
-          // cy.findByText(/oranges/i).should("not exist");
-          // ^ TODO: Team maintainer has access to only their teams, team observer does not have access
+    // See and select the “Create new query” button
+    cy.findByText(/create new query/i).click();
+    cy.findByText(/custom query/i).should("exist");
+    cy.findByRole("button", { name: "Run" }).should("exist");
+    cy.findByRole("button", { name: "Save" }).should("not.exist");
+
+    cy.get(".ace_scroller")
+      .click({ force: true })
+      .type("{selectall}{backspace}SELECT * FROM windows_crashes;");
+
+    cy.get(".target-select").within(() => {
+      cy.findByText(/Label name, host name, IP address, etc./i).click();
+      cy.findByText(/teams/i).should("exist");
+      cy.findByText(/apples/i).should("not.exist"); // Marco is only an observer on team apples
+      cy.findByText(/oranges/i) // Marco is a maintainer on team oranges
+        .parent()
+        .parent()
+        .within(() => {
+          cy.findByText(/0 hosts/i).should("exist");
+          // ^^TODO modify for expected host count once hosts are seeded
         });
-      });
-      cy.findByRole("button", { name: /done/i }).click();
-
-      // On the Host details page, they should…
-      // cy.visit("/hosts/1");
-      // ^^TODO hosts details page returning 403 likely because we need new forEach script/command for admin to assign team after the host is added
-
-      // See and select the “Create new query” button in the Select a query modal. This modal appears after the user selects the “Query” button
-      // cy.findByRole("button", { name: /query/i }).click();
-      // cy.findByRole("button", { name: /create custom query/i }).should("exist");
-      // cy.get(".modal__ex").within(() => {
-      //   cy.findByRole("button").click();
-      // });
-      // ^^TODO hosts details page returning 403 likely because we need new forEach script/command for admin to assign team after the host is added
-
-      // On the Queries manage page, they should…
-      cy.visit("/queries/manage");
-
-      // See and select the “Create new query” button
-      cy.findByText(/create new query/i).click();
-      cy.findByText(/custom query/i).should("exist");
-      cy.findByRole("button", { name: "Run" }).should("exist");
-      cy.findByRole("button", { name: "Save" }).should("not.exist");
-
-      cy.get(".ace_scroller")
-        .click({ force: true })
-        .type("{selectall}{backspace}SELECT * FROM windows_crashes;");
-
-      cy.get(".target-select").within(() => {
-        cy.findByText(/Label name, host name, IP address, etc./i).click();
-        cy.findByText(/teams/i).should("exist");
-        cy.findByText(/apples/i).should("not.exist"); // Marco is only an observer on team apples
-        cy.findByText(/oranges/i) // Marco is a maintainer on team oranges
-          .parent()
-          .parent()
-          .within(() => {
-            cy.findByText(/0 hosts/i).should("exist");
-            // ^^TODO modify for expected host count once hosts are seeded
-          });
-      });
     });
   });
-}
+});

--- a/cypress/integration/basic/teamflow.spec.ts
+++ b/cypress/integration/basic/teamflow.spec.ts
@@ -1,74 +1,72 @@
-if (Cypress.env("FLEET_TIER") === "basic") {
-  describe("Teams flow", () => {
-    beforeEach(() => {
-      cy.setup();
-      cy.login();
-    });
-
-    it("Create, edit, and delete a team successfully", () => {
-      cy.visit("/settings/teams");
-
-      cy.findByRole("button", { name: /create team/i }).click();
-
-      cy.findByLabelText(/team name/i)
-        .click()
-        .type("Valor");
-
-      // ^$ forces exact match
-      cy.findByRole("button", { name: /^create$/i }).click();
-
-      cy.visit("/settings/teams");
-      // Allow rendering to settle
-      // TODO this might represent a bug in the React code.
-      cy.wait(100); // eslint-disable-line cypress/no-unnecessary-waiting
-
-      cy.contains("Valor").click({ force: true });
-
-      cy.findByText(/agent options/i).click();
-
-      cy.get(".ace_content")
-        .click()
-        .type("{selectall}{backspace}apiVersion: v1{enter}kind: options");
-
-      cy.findByRole("button", { name: /save/i }).click();
-
-      cy.visit("/settings/teams/1/options");
-
-      cy.contains(/apiVersion: v1/i).should("be.visible");
-      cy.contains(/kind: options/i).should("be.visible");
-
-      cy.visit("/settings/teams");
-
-      cy.contains("Valor").get(".Select-arrow-zone").click();
-
-      // need force:true for dropdown
-      cy.findByText(/edit/i).click({ force: true });
-
-      cy.findByLabelText(/team name/i)
-        .click()
-        .type("{selectall}{backspace}Mystic");
-
-      cy.findByRole("button", { name: /save/i }).click();
-
-      cy.visit("/settings/teams");
-      // Allow rendering to settle
-      // TODO this might represent a bug in the React code.
-      cy.wait(100); // eslint-disable-line cypress/no-unnecessary-waiting
-
-      cy.contains("Mystic").get(".Select-arrow-zone").click();
-
-      cy.findByText(/delete/i).click({ force: true });
-
-      cy.findByRole("button", { name: /delete/i }).click();
-
-      cy.findByText(/successfully deleted/i).should("be.visible");
-
-      cy.visit("/settings/teams");
-      // Allow rendering to settle
-      // TODO this might represent a bug in the React code.
-      cy.wait(100); // eslint-disable-line cypress/no-unnecessary-waiting
-
-      cy.findByText(/mystic/i).should("not.exist");
-    });
+describe("Teams flow", () => {
+  beforeEach(() => {
+    cy.setup();
+    cy.login();
   });
-}
+
+  it("Create, edit, and delete a team successfully", () => {
+    cy.visit("/settings/teams");
+
+    cy.findByRole("button", { name: /create team/i }).click();
+
+    cy.findByLabelText(/team name/i)
+      .click()
+      .type("Valor");
+
+    // ^$ forces exact match
+    cy.findByRole("button", { name: /^create$/i }).click();
+
+    cy.visit("/settings/teams");
+    // Allow rendering to settle
+    // TODO this might represent a bug in the React code.
+    cy.wait(100); // eslint-disable-line cypress/no-unnecessary-waiting
+
+    cy.contains("Valor").click({ force: true });
+
+    cy.findByText(/agent options/i).click();
+
+    cy.get(".ace_content")
+      .click()
+      .type("{selectall}{backspace}apiVersion: v1{enter}kind: options");
+
+    cy.findByRole("button", { name: /save/i }).click();
+
+    cy.visit("/settings/teams/1/options");
+
+    cy.contains(/apiVersion: v1/i).should("be.visible");
+    cy.contains(/kind: options/i).should("be.visible");
+
+    cy.visit("/settings/teams");
+
+    cy.contains("Valor").get(".Select-arrow-zone").click();
+
+    // need force:true for dropdown
+    cy.findByText(/edit/i).click({ force: true });
+
+    cy.findByLabelText(/team name/i)
+      .click()
+      .type("{selectall}{backspace}Mystic");
+
+    cy.findByRole("button", { name: /save/i }).click();
+
+    cy.visit("/settings/teams");
+    // Allow rendering to settle
+    // TODO this might represent a bug in the React code.
+    cy.wait(100); // eslint-disable-line cypress/no-unnecessary-waiting
+
+    cy.contains("Mystic").get(".Select-arrow-zone").click();
+
+    cy.findByText(/delete/i).click({ force: true });
+
+    cy.findByRole("button", { name: /delete/i }).click();
+
+    cy.findByText(/successfully deleted/i).should("be.visible");
+
+    cy.visit("/settings/teams");
+    // Allow rendering to settle
+    // TODO this might represent a bug in the React code.
+    cy.wait(100); // eslint-disable-line cypress/no-unnecessary-waiting
+
+    cy.findByText(/mystic/i).should("not.exist");
+  });
+});

--- a/cypress/integration/core/admin.spec.ts
+++ b/cypress/integration/core/admin.spec.ts
@@ -1,119 +1,117 @@
-if (Cypress.env("FLEET_TIER") === "core") {
-  describe("Core tier - Admin user", () => {
-    beforeEach(() => {
-      cy.setup();
-      cy.login();
-      cy.setupSMTP();
-      cy.seedCore();
-      cy.seedQueries();
-      cy.addDockerHost();
-      cy.logout();
-    });
-    afterEach(() => {
-      cy.stopDockerHost();
-    });
-
-    it("Can perform the appropriate core-tier admin actions", () => {
-      cy.login("anna@organization.com", "user123#");
-      cy.visit("/");
-
-      // Ensure page is loaded
-      cy.contains("All hosts");
-
-      // On the hosts page, they should…
-
-      // Not see "team" anywhere on the page
-      cy.contains(/team/i).should("not.exist");
-
-      // See all navigation items
-      cy.get("nav").within(() => {
-        cy.findByText(/hosts/i).should("exist");
-        cy.findByText(/queries/i).should("exist");
-        cy.findByText(/packs/i).should("exist");
-        cy.findByText(/settings/i).should("exist");
-      });
-
-      // See and select "add new host"
-      cy.findByRole("button", { name: /new host/i }).click();
-      cy.contains(/team/i).should("not.exist");
-      cy.findByRole("button", { name: /done/i }).click();
-
-      // See and select "add new label"
-      cy.findByRole("button", { name: /new label/i }).click();
-      cy.findByRole("button", { name: /cancel/i }).click();
-
-      // On the Host details page, they should…
-      cy.visit("/hosts/1");
-
-      // Not see "team" information or transfer button
-      cy.findByText(/team/i).should("not.exist");
-      cy.contains("button", /transfer/i).should("not.exist");
-
-      // See and select the “Delete” button
-      cy.findByRole("button", { name: /delete/i }).click();
-      cy.findByText(/delete host/i).should("exist");
-      cy.findByRole("button", { name: /cancel/i }).click();
-
-      // See and select the “Query” button
-      cy.findByRole("button", { name: /query/i }).click();
-      cy.findByRole("button", { name: /create custom query/i }).should("exist");
-      cy.get(".modal__ex").within(() => {
-        cy.findByRole("button").click();
-      });
-
-      // On the queries manage page, they should…
-      cy.contains("a", "Queries").click();
-      // See the "observers can run column"
-      cy.contains(/observers can run/i);
-      // See and select the "create new query" button
-      cy.findByRole("button", { name: /new query/i }).click();
-
-      // On the Queries - new/edit/run page, they should…
-      // Edit the “Query name,” “SQL,” “Description,” “Observers can run,” and “Select targets” input fields.
-      cy.findByLabelText(/query name/i)
-        .click()
-        .type("time");
-      // ACE editor requires special handling to get typing to work sometimes
-      cy.get(".ace_text-input")
-        .first()
-        .click({ force: true })
-        .type("{selectall}{backspace}SELECT * FROM time;", { force: true });
-      cy.findByLabelText(/description/i)
-        .click()
-        .type("Get the time.");
-      cy.findByLabelText(/observers can run/i).click({ force: true });
-
-      // See and select the “Save changes,” “Save as new,” and “Run” buttons.
-      cy.findByRole("button", { name: /save/i }).click();
-      cy.findByRole("button", { name: /new/i }).click();
-      cy.findByRole("button", { name: /run/i }).should("exist");
-
-      // NOT see the “Teams” section in the Select target picker. This picker is summoned when the “Select targets” field is selected.
-      cy.get(".target-select").within(() => {
-        cy.findByText(/Label name, host name, IP address, etc./i).click();
-        cy.findByText(/teams/i).should("not.exist");
-      });
-
-      // See and select the “Edit or run query” button in the right side panel. This button appears after the user selects a query in the Queries table
-      cy.contains("a", /back to queries/i).click({ force: true });
-      cy.findByText(/get the time/i).click();
-      cy.findByRole("button", { name: /edit or run query/i }).should("exist");
-
-      // On the Packs pages (manage, new, and edit), they should…
-      // ^^General admin functionality for packs page is being tested in app/packflow.spec.ts
-
-      // On the Settings pages, they should…
-      // See everything except for the “Teams” pages
-      cy.visit("/settings/organization");
-      cy.findByText(/teams/i).should("not.exist");
-      cy.get(".react-tabs").within(() => {
-        cy.findByText(/organization settings/i).should("exist");
-        cy.findByText(/users/i).click();
-      });
-      cy.findByRole("button", { name: /create user/i }).click();
-      cy.findByText(/team/i).should("not.exist");
-      cy.visit("/settings/teams");
-      cy.findByText(/you do not have permissions/i).should("exist");
-    });
+describe("Core tier - Admin user", () => {
+  beforeEach(() => {
+    cy.setup();
+    cy.login();
+    cy.setupSMTP();
+    cy.seedCore();
+    cy.seedQueries();
+    cy.addDockerHost();
+    cy.logout();
   });
-}
+  afterEach(() => {
+    cy.stopDockerHost();
+  });
+
+  it("Can perform the appropriate core-tier admin actions", () => {
+    cy.login("anna@organization.com", "user123#");
+    cy.visit("/");
+
+    // Ensure page is loaded
+    cy.contains("All hosts");
+
+    // On the hosts page, they should…
+
+    // Not see "team" anywhere on the page
+    cy.contains(/team/i).should("not.exist");
+
+    // See all navigation items
+    cy.get("nav").within(() => {
+      cy.findByText(/hosts/i).should("exist");
+      cy.findByText(/queries/i).should("exist");
+      cy.findByText(/packs/i).should("exist");
+      cy.findByText(/settings/i).should("exist");
+    });
+
+    // See and select "add new host"
+    cy.findByRole("button", { name: /new host/i }).click();
+    cy.contains(/team/i).should("not.exist");
+    cy.findByRole("button", { name: /done/i }).click();
+
+    // See and select "add new label"
+    cy.findByRole("button", { name: /new label/i }).click();
+    cy.findByRole("button", { name: /cancel/i }).click();
+
+    // On the Host details page, they should…
+    cy.visit("/hosts/1");
+
+    // Not see "team" information or transfer button
+    cy.findByText(/team/i).should("not.exist");
+    cy.contains("button", /transfer/i).should("not.exist");
+
+    // See and select the “Delete” button
+    cy.findByRole("button", { name: /delete/i }).click();
+    cy.findByText(/delete host/i).should("exist");
+    cy.findByRole("button", { name: /cancel/i }).click();
+
+    // See and select the “Query” button
+    cy.findByRole("button", { name: /query/i }).click();
+    cy.findByRole("button", { name: /create custom query/i }).should("exist");
+    cy.get(".modal__ex").within(() => {
+      cy.findByRole("button").click();
+    });
+
+    // On the queries manage page, they should…
+    cy.contains("a", "Queries").click();
+    // See the "observers can run column"
+    cy.contains(/observers can run/i);
+    // See and select the "create new query" button
+    cy.findByRole("button", { name: /new query/i }).click();
+
+    // On the Queries - new/edit/run page, they should…
+    // Edit the “Query name,” “SQL,” “Description,” “Observers can run,” and “Select targets” input fields.
+    cy.findByLabelText(/query name/i)
+      .click()
+      .type("time");
+    // ACE editor requires special handling to get typing to work sometimes
+    cy.get(".ace_text-input")
+      .first()
+      .click({ force: true })
+      .type("{selectall}{backspace}SELECT * FROM time;", { force: true });
+    cy.findByLabelText(/description/i)
+      .click()
+      .type("Get the time.");
+    cy.findByLabelText(/observers can run/i).click({ force: true });
+
+    // See and select the “Save changes,” “Save as new,” and “Run” buttons.
+    cy.findByRole("button", { name: /save/i }).click();
+    cy.findByRole("button", { name: /new/i }).click();
+    cy.findByRole("button", { name: /run/i }).should("exist");
+
+    // NOT see the “Teams” section in the Select target picker. This picker is summoned when the “Select targets” field is selected.
+    cy.get(".target-select").within(() => {
+      cy.findByText(/Label name, host name, IP address, etc./i).click();
+      cy.findByText(/teams/i).should("not.exist");
+    });
+
+    // See and select the “Edit or run query” button in the right side panel. This button appears after the user selects a query in the Queries table
+    cy.contains("a", /back to queries/i).click({ force: true });
+    cy.findByText(/get the time/i).click();
+    cy.findByRole("button", { name: /edit or run query/i }).should("exist");
+
+    // On the Packs pages (manage, new, and edit), they should…
+    // ^^General admin functionality for packs page is being tested in app/packflow.spec.ts
+
+    // On the Settings pages, they should…
+    // See everything except for the “Teams” pages
+    cy.visit("/settings/organization");
+    cy.findByText(/teams/i).should("not.exist");
+    cy.get(".react-tabs").within(() => {
+      cy.findByText(/organization settings/i).should("exist");
+      cy.findByText(/users/i).click();
+    });
+    cy.findByRole("button", { name: /create user/i }).click();
+    cy.findByText(/team/i).should("not.exist");
+    cy.visit("/settings/teams");
+    cy.findByText(/you do not have permissions/i).should("exist");
+  });
+});

--- a/cypress/integration/core/maintainer.spec.ts
+++ b/cypress/integration/core/maintainer.spec.ts
@@ -1,129 +1,127 @@
-if (Cypress.env("FLEET_TIER") === "core") {
-  describe("Core tier - Maintainer user", () => {
-    beforeEach(() => {
-      cy.setup();
-      cy.login();
-      cy.seedCore();
-      cy.seedQueries();
-      cy.addDockerHost();
-      cy.logout();
-    });
-
-    afterEach(() => {
-      cy.stopDockerHost();
-    });
-
-    it("Can perform the appropriate core global maintainer actions", () => {
-      cy.login("mary@organization.com", "user123#");
-      cy.visit("/");
-
-      // Ensure page is loaded
-      cy.contains("All hosts");
-
-      // Settings restrictions
-      cy.findByText(/settings/i).should("not.exist");
-      cy.visit("/settings/organization");
-      cy.findByText(/you do not have permissions/i).should("exist");
-
-      // Host manage page: No team UI, can add host and label
-      cy.visit("/hosts/manage");
-      cy.findByText(/teams/i).should("not.exist");
-      cy.contains("button", /add new host/i).click();
-      cy.findByText("select a team").should("not.exist");
-      cy.contains("button", /done/i).click();
-
-      cy.contains("button", /add new label/i).click();
-      cy.contains("button", /cancel/i).click();
-
-      // Host details page: No team UI, can delete and create new query
-      cy.get("tbody").within(() => {
-        // Test host text varies
-        cy.findByRole("button").click();
-      });
-      cy.get(".title").within(() => {
-        cy.findByText(/team/i).should("not.exist");
-      });
-      cy.contains("button", /transfer/i).should("not.exist");
-
-      cy.contains("button", /delete/i).click();
-      cy.contains("button", /cancel/i).click();
-
-      cy.contains("button", /query/i).click();
-      cy.contains("button", /create custom query/i).click();
-
-      // Queries pages: Can create, edit, and run query
-      cy.visit("/queries/manage");
-      cy.get("thead").within(() => {
-        cy.findByText(/observers can run/i).should("exist");
-      });
-
-      cy.findByRole("button", { name: /create new query/i }).click();
-
-      cy.findByLabelText(/query name/i)
-        .click()
-        .type("Query all window crashes");
-
-      cy.get(".ace_scroller")
-        .click({ force: true })
-        .type("{selectall}{backspace}SELECT * FROM windows_crashes;");
-
-      cy.findByLabelText(/description/i)
-        .click()
-        .type("See all window crashes");
-
-      cy.findByRole("button", { name: /save/i }).click();
-
-      cy.findByRole("button", { name: /save as new/i }).click();
-
-      cy.findByLabelText(/observers can run/i).click({ force: true });
-
-      cy.get(".target-select").within(() => {
-        cy.findByText(/Label name, host name, IP address, etc./i).click();
-        cy.findByText(/teams/i).should("not.exist");
-      });
-
-      cy.findByRole("button", { name: /run/i }).should("exist");
-
-      cy.visit("/queries/manage");
-
-      cy.findByText(/query all/i).click();
-
-      cy.findByRole("button", { name: /edit or run query/i }).click();
-
-      // Packs pages: Can create, edit, delete a pack
-      cy.visit("/packs/manage");
-
-      cy.findByRole("button", { name: /create new pack/i }).click();
-
-      cy.findByLabelText(/query pack title/i)
-        .click()
-        .type("Errors and crashes");
-
-      cy.findByLabelText(/description/i)
-        .click()
-        .type("See all user errors and window crashes.");
-
-      cy.findByRole("button", { name: /save query pack/i }).click();
-
-      cy.visit("/packs/manage");
-
-      cy.findByText(/errors and crashes/i).click();
-
-      cy.findByRole("link", { name: /edit pack/i }).should("exist");
-
-      cy.get("#select-pack-1").check({ force: true });
-
-      cy.findByRole("button", { name: /delete/i }).click();
-
-      // Can't figure out how attach findByRole onto modal button
-      // Can't use findByText because delete button under modal
-      cy.get(".all-packs-page__modal-btn-wrap > .button--alert")
-        .contains("button", /delete/i)
-        .click();
-
-      cy.findByText(/successfully deleted/i).should("be.visible");
-
-      cy.findByText(/server errors/i).should("not.exist");
-    });
+describe("Core tier - Maintainer user", () => {
+  beforeEach(() => {
+    cy.setup();
+    cy.login();
+    cy.seedCore();
+    cy.seedQueries();
+    cy.addDockerHost();
+    cy.logout();
   });
-}
+
+  afterEach(() => {
+    cy.stopDockerHost();
+  });
+
+  it("Can perform the appropriate core global maintainer actions", () => {
+    cy.login("mary@organization.com", "user123#");
+    cy.visit("/");
+
+    // Ensure page is loaded
+    cy.contains("All hosts");
+
+    // Settings restrictions
+    cy.findByText(/settings/i).should("not.exist");
+    cy.visit("/settings/organization");
+    cy.findByText(/you do not have permissions/i).should("exist");
+
+    // Host manage page: No team UI, can add host and label
+    cy.visit("/hosts/manage");
+    cy.findByText(/teams/i).should("not.exist");
+    cy.contains("button", /add new host/i).click();
+    cy.findByText("select a team").should("not.exist");
+    cy.contains("button", /done/i).click();
+
+    cy.contains("button", /add new label/i).click();
+    cy.contains("button", /cancel/i).click();
+
+    // Host details page: No team UI, can delete and create new query
+    cy.get("tbody").within(() => {
+      // Test host text varies
+      cy.findByRole("button").click();
+    });
+    cy.get(".title").within(() => {
+      cy.findByText(/team/i).should("not.exist");
+    });
+    cy.contains("button", /transfer/i).should("not.exist");
+
+    cy.contains("button", /delete/i).click();
+    cy.contains("button", /cancel/i).click();
+
+    cy.contains("button", /query/i).click();
+    cy.contains("button", /create custom query/i).click();
+
+    // Queries pages: Can create, edit, and run query
+    cy.visit("/queries/manage");
+    cy.get("thead").within(() => {
+      cy.findByText(/observers can run/i).should("exist");
+    });
+
+    cy.findByRole("button", { name: /create new query/i }).click();
+
+    cy.findByLabelText(/query name/i)
+      .click()
+      .type("Query all window crashes");
+
+    cy.get(".ace_scroller")
+      .click({ force: true })
+      .type("{selectall}{backspace}SELECT * FROM windows_crashes;");
+
+    cy.findByLabelText(/description/i)
+      .click()
+      .type("See all window crashes");
+
+    cy.findByRole("button", { name: /save/i }).click();
+
+    cy.findByRole("button", { name: /save as new/i }).click();
+
+    cy.findByLabelText(/observers can run/i).click({ force: true });
+
+    cy.get(".target-select").within(() => {
+      cy.findByText(/Label name, host name, IP address, etc./i).click();
+      cy.findByText(/teams/i).should("not.exist");
+    });
+
+    cy.findByRole("button", { name: /run/i }).should("exist");
+
+    cy.visit("/queries/manage");
+
+    cy.findByText(/query all/i).click();
+
+    cy.findByRole("button", { name: /edit or run query/i }).click();
+
+    // Packs pages: Can create, edit, delete a pack
+    cy.visit("/packs/manage");
+
+    cy.findByRole("button", { name: /create new pack/i }).click();
+
+    cy.findByLabelText(/query pack title/i)
+      .click()
+      .type("Errors and crashes");
+
+    cy.findByLabelText(/description/i)
+      .click()
+      .type("See all user errors and window crashes.");
+
+    cy.findByRole("button", { name: /save query pack/i }).click();
+
+    cy.visit("/packs/manage");
+
+    cy.findByText(/errors and crashes/i).click();
+
+    cy.findByRole("link", { name: /edit pack/i }).should("exist");
+
+    cy.get("#select-pack-1").check({ force: true });
+
+    cy.findByRole("button", { name: /delete/i }).click();
+
+    // Can't figure out how attach findByRole onto modal button
+    // Can't use findByText because delete button under modal
+    cy.get(".all-packs-page__modal-btn-wrap > .button--alert")
+      .contains("button", /delete/i)
+      .click();
+
+    cy.findByText(/successfully deleted/i).should("be.visible");
+
+    cy.findByText(/server errors/i).should("not.exist");
+  });
+});

--- a/cypress/integration/core/observer.spec.ts
+++ b/cypress/integration/core/observer.spec.ts
@@ -1,88 +1,84 @@
-if (Cypress.env("FLEET_TIER") === "core") {
-  describe("Core tier - Observer user", () => {
-    beforeEach(() => {
-      cy.setup();
-      cy.login();
-      cy.seedCore();
-      cy.seedQueries();
-      cy.addDockerHost();
-      cy.logout();
-    });
-
-    afterEach(() => {
-      cy.stopDockerHost();
-    });
-
-    it("Can perform the appropriate core global observer actions", () => {
-      cy.login("oliver@organization.com", "user123#");
-      cy.visit("/");
-
-      // Ensure page is loaded
-      cy.contains("All hosts");
-
-      // Nav restrictions
-      cy.findByText(/settings/i).should("not.exist");
-      cy.findByText(/packs/i).should("not.exist");
-      cy.visit("/settings/organization");
-      cy.findByText(/you do not have permissions/i).should("exist");
-      cy.visit("/packs/manage");
-      cy.findByText(/you do not have permissions/i).should("exist");
-
-      // Host manage page: No team UI, cannot add host or label
-      cy.visit("/hosts/manage");
-      cy.findByText(/teams/i).should("not.exist");
-      cy.contains("button", /add new host/i).should("not.exist");
-      cy.contains("button", /add new label/i).should("not.exist");
-
-      // Host details page: No team UI, cannot delete or query
-      cy.get("tbody").within(() => {
-        // Test host text varies
-        cy.findByRole("button").click();
-      });
-
-      cy.findByText(/team/i).should("not.exist");
-      cy.contains("button", /transfer/i).should("not.exist");
-      cy.contains("button", /delete/i).should("not.exist");
-      cy.contains("button", /query/i).should("not.exist");
-
-      // Queries pages: Observer can or cannot run UI
-      cy.visit("/queries/manage");
-      cy.get("thead").within(() => {
-        cy.findByText(/observers can run/i).should("not.exist");
-      });
-
-      cy.findByRole("button", { name: /create new query/i }).should(
-        "not.exist"
-      );
-
-      cy.findByText(/detect presence/i).click();
-      cy.findByText(/sql/i).should("not.exist");
-      cy.findByText(/packs/i).should("not.exist");
-      cy.findByRole("button", { name: /run query/i }).click();
-      cy.findByLabelText(/query name/i).should("not.exist");
-      cy.findByLabelText(/sql/i).should("not.exist");
-      cy.findByLabelText(/description/i).should("not.exist");
-      cy.findByLabelText(/observer can run/i).should("not.exist");
-      cy.findByText(/show sql/i).click();
-      cy.get(".target-select").within(() => {
-        cy.findByText(/Label name, host name, IP address, etc./i).click();
-        cy.findByText(/teams/i).should("not.exist");
-      });
-      cy.findByRole("button", { name: /run/i }).should("exist");
-
-      cy.visit("/queries/manage");
-
-      cy.findByText(/get authorized/i).click();
-      cy.findByText(/sql/i).should("not.exist");
-      cy.findByText(/packs/i).should("not.exist");
-      cy.findByRole("button", { name: /show query/i }).click();
-      cy.findByLabelText(/query name/i).should("not.exist");
-      cy.findByLabelText(/sql/i).should("not.exist");
-      cy.findByLabelText(/description/i).should("not.exist");
-      cy.findByLabelText(/observer can run/i).should("not.exist");
-      cy.findByText(/show sql/i).click();
-      cy.get(".target-select").should("not.exist");
-      cy.findByRole("button", { name: /run/i }).should("not.exist");
-    });
+describe("Core tier - Observer user", () => {
+  beforeEach(() => {
+    cy.setup();
+    cy.login();
+    cy.seedCore();
+    cy.seedQueries();
+    cy.addDockerHost();
+    cy.logout();
   });
-}
+
+  afterEach(() => {
+    cy.stopDockerHost();
+  });
+
+  it("Can perform the appropriate core global observer actions", () => {
+    cy.login("oliver@organization.com", "user123#");
+    cy.visit("/");
+
+    // Ensure page is loaded
+    cy.contains("All hosts");
+
+    // Nav restrictions
+    cy.findByText(/settings/i).should("not.exist");
+    cy.findByText(/packs/i).should("not.exist");
+    cy.visit("/settings/organization");
+    cy.findByText(/you do not have permissions/i).should("exist");
+    cy.visit("/packs/manage");
+    cy.findByText(/you do not have permissions/i).should("exist");
+
+    // Host manage page: No team UI, cannot add host or label
+    cy.visit("/hosts/manage");
+    cy.findByText(/teams/i).should("not.exist");
+    cy.contains("button", /add new host/i).should("not.exist");
+    cy.contains("button", /add new label/i).should("not.exist");
+
+    // Host details page: No team UI, cannot delete or query
+    cy.get("tbody").within(() => {
+      // Test host text varies
+      cy.findByRole("button").click();
+    });
+
+    cy.findByText(/team/i).should("not.exist");
+    cy.contains("button", /transfer/i).should("not.exist");
+    cy.contains("button", /delete/i).should("not.exist");
+    cy.contains("button", /query/i).should("not.exist");
+
+    // Queries pages: Observer can or cannot run UI
+    cy.visit("/queries/manage");
+    cy.get("thead").within(() => {
+      cy.findByText(/observers can run/i).should("not.exist");
+    });
+
+    cy.findByRole("button", { name: /create new query/i }).should("not.exist");
+
+    cy.findByText(/detect presence/i).click();
+    cy.findByText(/sql/i).should("not.exist");
+    cy.findByText(/packs/i).should("not.exist");
+    cy.findByRole("button", { name: /run query/i }).click();
+    cy.findByLabelText(/query name/i).should("not.exist");
+    cy.findByLabelText(/sql/i).should("not.exist");
+    cy.findByLabelText(/description/i).should("not.exist");
+    cy.findByLabelText(/observer can run/i).should("not.exist");
+    cy.findByText(/show sql/i).click();
+    cy.get(".target-select").within(() => {
+      cy.findByText(/Label name, host name, IP address, etc./i).click();
+      cy.findByText(/teams/i).should("not.exist");
+    });
+    cy.findByRole("button", { name: /run/i }).should("exist");
+
+    cy.visit("/queries/manage");
+
+    cy.findByText(/get authorized/i).click();
+    cy.findByText(/sql/i).should("not.exist");
+    cy.findByText(/packs/i).should("not.exist");
+    cy.findByRole("button", { name: /show query/i }).click();
+    cy.findByLabelText(/query name/i).should("not.exist");
+    cy.findByLabelText(/sql/i).should("not.exist");
+    cy.findByLabelText(/description/i).should("not.exist");
+    cy.findByLabelText(/observer can run/i).should("not.exist");
+    cy.findByText(/show sql/i).click();
+    cy.get(".target-select").should("not.exist");
+    cy.findByRole("button", { name: /run/i }).should("not.exist");
+  });
+});

--- a/docs/3-Contributing/2-Testing.md
+++ b/docs/3-Contributing/2-Testing.md
@@ -164,13 +164,13 @@ Tests can be run in interactive mode, or from the command line.
 For Fleet Core tests:
 
 ```
-CYPRESS_FLEET_TIER=core yarn cypress open
+yarn cypress:browser-core
 ```
 
 For Fleet Basic tests:
 
 ```
-CYPRESS_FLEET_TIER=basic yarn cypress open
+yarn cypress:browser-basic
 ```
 
 Use the graphical UI controls to run and view tests.
@@ -180,13 +180,13 @@ Use the graphical UI controls to run and view tests.
 For Fleet Core tests:
 
 ```
-CYPRESS_FLEET_TIER=core yarn cypress run
+yarn e2e-cli:core
 ```
 
 For Fleet Basic tests:
 
 ```
-CYPRESS_FLEET_TIER=basic yarn cypress run
+yarn e2e-cli:basic
 ```
 
 Tests will run automatically and results are reported to the shell.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,14 @@
     "lint": "eslint frontend cypress --ext .js,.jsx,.ts,.tsx",
     "prettier:check": "prettier --check frontend/**/*.{jsx,js,tsx,ts} ./cypress/**/*.{js,ts}",
     "test": "jest",
-    "cypress:open": "cypress open"
+    "e2e-browser": "cypress open",
+    "e2e-browser:all": "yarn cypress open --config-file cypress-all.json",
+    "e2e-browser:core": "CYPRESS_FLEET_TIER=core yarn cypress open --config-file cypress-core.json",
+    "e2e-browser:basic": "CYPRESS_FLEET_TIER=basic yarn cypress open --config-file cypress-basic.json",
+    "e2e-cli": "cypress run",
+    "e2e-cli:all": "yarn cypress run --config-file cypress-all.json",
+    "e2e-cli:core": "CYPRESS_FLEET_TIER=core yarn cypress run --config-file cypress-core.json",
+    "e2e-cli:basic": "CYPRESS_FLEET_TIER=basic yarn cypress run --config-file cypress-basic.json"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,11 @@
     "prettier:check": "prettier --check frontend/**/*.{jsx,js,tsx,ts} ./cypress/**/*.{js,ts}",
     "test": "jest",
     "e2e-browser": "cypress open",
-    "e2e-browser:all": "yarn cypress open --config-file cypress-all.json",
-    "e2e-browser:core": "CYPRESS_FLEET_TIER=core yarn cypress open --config-file cypress-core.json",
-    "e2e-browser:basic": "CYPRESS_FLEET_TIER=basic yarn cypress open --config-file cypress-basic.json",
+    "e2e-browser:core": "yarn cypress open --config-file cypress-core.json",
+    "e2e-browser:basic": "yarn cypress open --config-file cypress-basic.json",
     "e2e-cli": "cypress run",
-    "e2e-cli:all": "yarn cypress run --config-file cypress-all.json",
-    "e2e-cli:core": "CYPRESS_FLEET_TIER=core yarn cypress run --config-file cypress-core.json",
-    "e2e-cli:basic": "CYPRESS_FLEET_TIER=basic yarn cypress run --config-file cypress-basic.json"
+    "e2e-cli:core": "yarn cypress run --config-file cypress-core.json",
+    "e2e-cli:basic": "yarn cypress run --config-file cypress-basic.json"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.5.1",


### PR DESCRIPTION
Closes #1024

Created new configs that removes the need to detect `FLEET_TIER` environment variable when running core or basic e2e tests. 

New commands are:
```
// for browser only
yarn e2e-browser
yarn e2e-browser:all
yarn e2e-browser:core
yarn e2e-browser:basic

// for terminal only
yarn e2e-cli
yarn e2e-cli:all
yarn e2e-cli:core
yarn e2e-cli:basic
```

These can be found in `package.json`.