### PR TITLE
Add configuration file wireframe for interacting with Teams via fleetctl

### DIFF
--- a/docs/1-Using-Fleet/configuration-files/multi-file-configuration/enroll-secrets.yml
+++ b/docs/1-Using-Fleet/configuration-files/multi-file-configuration/enroll-secrets.yml
@@ -4,5 +4,8 @@ kind: enroll_secret
 spec:
   secrets:
     - secret: RzTlxPvugG4o4O5IKS/HqEDJUmI1hwBoffff
-    - secret: reallyworks
-    - secret: thissecretwontwork!
+      team: null
+    - secret: anothersecret
+      team: Apples
+    - secret: anothersecret
+      team: Oranges

--- a/docs/1-Using-Fleet/configuration-files/multi-file-configuration/enroll-secrets.yml
+++ b/docs/1-Using-Fleet/configuration-files/multi-file-configuration/enroll-secrets.yml
@@ -4,8 +4,3 @@ kind: enroll_secret
 spec:
   secrets:
     - secret: RzTlxPvugG4o4O5IKS/HqEDJUmI1hwBoffff
-      team: null
-    - secret: anothersecret
-      team: Apples
-    - secret: anothersecret
-      team: Oranges

--- a/docs/1-Using-Fleet/configuration-files/multi-file-configuration/teams-users-secrets.yml
+++ b/docs/1-Using-Fleet/configuration-files/multi-file-configuration/teams-users-secrets.yml
@@ -19,6 +19,8 @@ spec:
           - "SELECT user AS username FROM logged_in_users WHERE user <> '' ORDER BY time LIMIT 1"
         interval:
           3600: "SELECT total_seconds AS uptime FROM uptime"
+    secrets:
+    - secret: applessecret
 ---
 apiVersion: v1
 kind: team
@@ -40,17 +42,14 @@ spec:
           - "SELECT user AS username FROM logged_in_users WHERE user <> '' ORDER BY time LIMIT 1"
         interval:
           3600: "SELECT total_seconds AS uptime FROM uptime"
+    secrets:
+      - secret: orangessecret
 ---
 apiVersion: v1
 kind: enroll_secret
 spec:
   secrets:
     - secret: RzTlxPvugG4o4O5IKS/HqEDJUmI1hwBoffff
-      team: null
-    - secret: anothersecret
-      team: Apples
-    - secret: anothersecret
-      team: Oranges
 ---
 apiVersion: v1
 kind: user_roles

--- a/docs/1-Using-Fleet/configuration-files/multi-file-configuration/teams-users-secrets.yml
+++ b/docs/1-Using-Fleet/configuration-files/multi-file-configuration/teams-users-secrets.yml
@@ -40,3 +40,35 @@ spec:
           - "SELECT user AS username FROM logged_in_users WHERE user <> '' ORDER BY time LIMIT 1"
         interval:
           3600: "SELECT total_seconds AS uptime FROM uptime"
+---
+apiVersion: v1
+kind: enroll_secret
+spec:
+  secrets:
+    - secret: RzTlxPvugG4o4O5IKS/HqEDJUmI1hwBoffff
+      team: null
+    - secret: anothersecret
+      team: Apples
+    - secret: anothersecret
+      team: Oranges
+---
+apiVersion: v1
+kind: user
+spec:
+  users:
+    - email: anna@example.com
+      global_role: admin
+      teams: null
+    - email: mary@example.com
+      global_role: maintainer
+      teams: null
+    - email: oliver@example.com
+      global_role: observer
+      teams: null
+    - email: marco@example.com
+      global_role: null
+      teams:
+        - team: Apples
+          role: maintainer
+        - team: Oranges
+          role: observer

--- a/docs/1-Using-Fleet/configuration-files/multi-file-configuration/teams-users-secrets.yml
+++ b/docs/1-Using-Fleet/configuration-files/multi-file-configuration/teams-users-secrets.yml
@@ -53,19 +53,19 @@ spec:
       team: Oranges
 ---
 apiVersion: v1
-kind: user
+kind: user_roles
 spec:
-  users:
-    - email: anna@example.com
+  roles:
+    anna@example.com:
       global_role: admin
       teams: null
-    - email: mary@example.com
+    mary@example.com
       global_role: maintainer
       teams: null
-    - email: oliver@example.com
+    oliver@example.com
       global_role: observer
       teams: null
-    - email: marco@example.com
+    marco@example.com
       global_role: null
       teams:
         - team: Apples

--- a/docs/1-Using-Fleet/configuration-files/multi-file-configuration/teams.yml
+++ b/docs/1-Using-Fleet/configuration-files/multi-file-configuration/teams.yml
@@ -1,31 +1,12 @@
-# Applies to Fleet Basic:
-# This configuration file allows for the managing of teams in Fleet.
-# The file can be used for the creating, updating, and deleting of teams.
-# A team's members, agent options, and enroll secrets are managed with this file.
-
-# The example below includes two teams called 'Workstations' and 'Servers.' Each team
-# maintains its own list of members and their roles, agent options, and enroll secrets.
-
 ---
 apiVersion: v1
 kind: team
 spec:
   team:
-    name: Workstations
-    # Below are the memebers of the Workstations team.
-    # Only users that are members of the Workstations team or users with a Global role
-    # have permission to view, delete, and run live queries against the Workstations team's
-    # hosts. See the `enroll_secrets` property for more information on enrolling hosts
-    # to a specific team.
+    name: Apples
     members:
-      - email: email1
-        role: admin
-      - email: email2
+      - email: marco@organization.com
         role: maintainer
-    # Below are the agent options that belong to the Workstations team
-    # These options will apply to all hosts that are assigned to the Workstations team.
-    # These options will override the 'default' options. See the config.yml for
-    # example 'default' options.
     agent_options:
       options:
         distributed_interval: 3
@@ -41,33 +22,15 @@ spec:
           - "SELECT user AS username FROM logged_in_users WHERE user <> '' ORDER BY time LIMIT 1"
         interval:
           3600: "SELECT total_seconds AS uptime FROM uptime"
-    # Below are the enroll secrets that belong to the Workstations team
-    # A host that enrolls to Fleet using either of the following enroll secrets
-    # is assigned to the Workstations team.
-    enroll_secrets:
-      secrets:
-        - secret: djRf6C40dp5pP02unLS7
-        - secret: djRf6C40dp5pP02unLS7
 ---
 apiVersion: v1
 kind: team
 spec:
   team:
-    name: Servers
-    # Below are the memebers of the Servers team.
-    # Only users that are members of the Servers team or users with a Global role
-    # have permission to view, delete, and run live queries against the Server team's hosts.
-    # See the `enroll_secrets` property for more information on enrolling hosts
-    # to a specific team.
+    name: Oranges
     members:
-      - email: email1
-        role: admin
-      - email: email2
-        role: maintainer
-    # Below are the agent options that belong to the Servers team.
-    # These options will apply to all hosts that belong to the Servers team.
-    # These options will override the 'default' options. See the config.yml for
-    # example 'default' options.
+      - email: marco@organization.com
+        role: observer
     agent_options:
       options:
         distributed_interval: 3
@@ -83,9 +46,3 @@ spec:
           - "SELECT user AS username FROM logged_in_users WHERE user <> '' ORDER BY time LIMIT 1"
         interval:
           3600: "SELECT total_seconds AS uptime FROM uptime"
-    # Below are the enroll secrets that belong to the Servers team
-    # A host that enrolls to Fleet using the following enroll secret
-    # is automatically assigned to the Servers team.
-    enroll_secrets:
-      secrets:
-        - secret: 4NE6wxMlDwZruCfie8oW

--- a/docs/1-Using-Fleet/configuration-files/multi-file-configuration/teams.yml
+++ b/docs/1-Using-Fleet/configuration-files/multi-file-configuration/teams.yml
@@ -1,0 +1,91 @@
+# Applies to Fleet Basic:
+# This configuration file allows for the managing of teams in Fleet.
+# The file can be used for the creating, updating, and deleting of teams.
+# A team's members, agent options, and enroll secrets are managed with this file.
+
+# The example below includes two teams called 'Workstations' and 'Servers.' Each team
+# maintains its own list of members and their roles, agent options, and enroll secrets.
+
+---
+apiVersion: v1
+kind: team
+spec:
+  team:
+    name: Workstations
+    # Below are the memebers of the Workstations team.
+    # Only users that are members of the Workstations team or users with a Global role
+    # have permission to view, delete, and run live queries against the Workstations team's
+    # hosts. See the `enroll_secrets` property for more information on enrolling hosts
+    # to a specific team.
+    members:
+      - email: email1
+        role: admin
+      - email: email2
+        role: maintainer
+    # Below are the agent options that belong to the Workstations team
+    # These options will apply to all hosts that are assigned to the Workstations team.
+    # These options will override the 'default' options. See the config.yml for
+    # example 'default' options.
+    agent_options:
+      options:
+        distributed_interval: 3
+        distributed_tls_max_attempts: 3
+        logger_plugin: tls
+        logger_tls_endpoint: /api/v1/osquery/log
+        logger_tls_period: 10
+      decorators:
+        load:
+          - "SELECT version FROM osquery_info"
+          - "SELECT uuid AS host_uuid FROM system_info"
+        always:
+          - "SELECT user AS username FROM logged_in_users WHERE user <> '' ORDER BY time LIMIT 1"
+        interval:
+          3600: "SELECT total_seconds AS uptime FROM uptime"
+    # Below are the enroll secrets that belong to the Workstations team
+    # A host that enrolls to Fleet using either of the following enroll secrets
+    # is assigned to the Workstations team.
+    enroll_secrets:
+      secrets:
+        - secret: djRf6C40dp5pP02unLS7
+        - secret: djRf6C40dp5pP02unLS7
+---
+apiVersion: v1
+kind: team
+spec:
+  team:
+    name: Servers
+    # Below are the memebers of the Servers team.
+    # Only users that are members of the Servers team or users with a Global role
+    # have permission to view, delete, and run live queries against the Server team's hosts.
+    # See the `enroll_secrets` property for more information on enrolling hosts
+    # to a specific team.
+    members:
+      - email: email1
+        role: admin
+      - email: email2
+        role: maintainer
+    # Below are the agent options that belong to the Servers team.
+    # These options will apply to all hosts that belong to the Servers team.
+    # These options will override the 'default' options. See the config.yml for
+    # example 'default' options.
+    agent_options:
+      options:
+        distributed_interval: 3
+        distributed_tls_max_attempts: 3
+        logger_plugin: tls
+        logger_tls_endpoint: /api/v1/osquery/log
+        logger_tls_period: 10
+      decorators:
+        load:
+          - "SELECT version FROM osquery_info"
+          - "SELECT uuid AS host_uuid FROM system_info"
+        always:
+          - "SELECT user AS username FROM logged_in_users WHERE user <> '' ORDER BY time LIMIT 1"
+        interval:
+          3600: "SELECT total_seconds AS uptime FROM uptime"
+    # Below are the enroll secrets that belong to the Servers team
+    # A host that enrolls to Fleet using the following enroll secret
+    # is automatically assigned to the Servers team.
+    enroll_secrets:
+      secrets:
+        - secret: 4NE6wxMlDwZruCfie8oW

--- a/docs/1-Using-Fleet/configuration-files/multi-file-configuration/users.yml
+++ b/docs/1-Using-Fleet/configuration-files/multi-file-configuration/users.yml
@@ -1,22 +1,18 @@
 ---
 apiVersion: v1
-kind: user
+kind: user_roles
 spec:
-  users:
-    - email: anna@example.com
-      full_name: Anna
+  roles:
+    anna@example.com:
       global_role: admin
       teams: null
-    - email: mary@example.com
-      full_name: Mary
+    mary@example.com
       global_role: maintainer
       teams: null
-    - email: oliver@example.com
-      full_name: Oliver
+    oliver@example.com
       global_role: observer
       teams: null
-    - email: marco@example.com
-      full_name: Marco
+    marco@example.com
       global_role: null
       teams:
         - team: Apples

--- a/docs/1-Using-Fleet/configuration-files/multi-file-configuration/users.yml
+++ b/docs/1-Using-Fleet/configuration-files/multi-file-configuration/users.yml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: user
+spec:
+  user:
+    full_name: Anna
+    global_role: admin
+---
+apiVersion: v1
+kind: user
+spec:
+  user:
+    full_name: Mary
+    global_role: maintainer
+---
+apiVersion: v1
+kind: user
+spec:
+  user:
+    full_name: Oliver
+    global_role: observer
+---
+apiVersion: v1
+kind: user
+spec:
+  user:
+    full_name: Marco
+    global_role: null

--- a/docs/1-Using-Fleet/configuration-files/multi-file-configuration/users.yml
+++ b/docs/1-Using-Fleet/configuration-files/multi-file-configuration/users.yml
@@ -2,27 +2,24 @@
 apiVersion: v1
 kind: user
 spec:
-  user:
-    full_name: Anna
-    global_role: admin
----
-apiVersion: v1
-kind: user
-spec:
-  user:
-    full_name: Mary
-    global_role: maintainer
----
-apiVersion: v1
-kind: user
-spec:
-  user:
-    full_name: Oliver
-    global_role: observer
----
-apiVersion: v1
-kind: user
-spec:
-  user:
-    full_name: Marco
-    global_role: null
+  users:
+    - email: anna@example.com
+      full_name: Anna
+      global_role: admin
+      teams: null
+    - email: mary@example.com
+      full_name: Mary
+      global_role: maintainer
+      teams: null
+    - email: oliver@example.com
+      full_name: Oliver
+      global_role: observer
+      teams: null
+    - email: marco@example.com
+      full_name: Marco
+      global_role: null
+      teams:
+        - team: Apples
+          role: maintainer
+        - team: Oranges
+          role: observer


### PR DESCRIPTION
- `teams.yml`
  - This file is used to create, update, and delete teams in Fleet via the `fleetctl apply` command.
  - This file is also used to manage each team's members, agent options, and enroll secrets.
    - Members: The `members` property allows users to define which users have access to the hosts assigned to the given team. This property also specifies the `role` for each user.
    - Agent options: The `agent_options` field allows users to define the agent options to be applied to the hosts that are assigned to the given team. The agent options supplied here will override the global agent options specified by this `config.yml` file.
    - Enroll secrets: The `enroll_secrets` property allows users to define unique enroll secrets for the given team. Hosts that enrolls to Fleet using the enroll secrets specified in this file will be automatically assigned to the given team in Fleet.