### PR TITLE
Fix migration for MariaDB compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
 
   mysql_test:
     image: ${FLEET_MYSQL_IMAGE:-mysql:5.7}
+    platform: linux/x86_64
     # innodb-file-per-table=OFF gives ~20% speedup for test runs.
     command: mysqld --datadir=/tmpfs --slow_query_log=1 --log_output=TABLE --log-queries-not-using-indexes --event-scheduler=ON --innodb-file-per-table=OFF
     tmpfs: /tmpfs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
 ---
 version: '2'
 services:
+  # To test with MariaDB, set FLEET_MYSQL_IMAGE to mariadb:10.6 or the like.
   mysql:
-    image: mysql:5.7
+    image: ${FLEET_MYSQL_IMAGE:-mysql:5.7}
     volumes:
       - mysql-persistent-volume:/tmp
     command: mysqld --datadir=/tmp/mysqldata --event-scheduler=ON
@@ -15,7 +16,7 @@ services:
       - "3306:3306"
 
   mysql_test:
-    image: mysql:5.7
+    image: ${FLEET_MYSQL_IMAGE:-mysql:5.7}
     # innodb-file-per-table=OFF gives ~20% speedup for test runs.
     command: mysqld --datadir=/tmpfs --slow_query_log=1 --log_output=TABLE --log-queries-not-using-indexes --event-scheduler=ON --innodb-file-per-table=OFF
     tmpfs: /tmpfs

--- a/server/datastore/mysql/migrations/tables/20210601000001_CreateTeamsTables.go
+++ b/server/datastore/mysql/migrations/tables/20210601000001_CreateTeamsTables.go
@@ -27,15 +27,15 @@ func Up_20210601000001(tx *sql.Tx) error {
 		team_id INT UNSIGNED NOT NULL,
 		role VARCHAR(64) NOT NULL,
 		PRIMARY KEY (user_id, team_id),
-		FOREIGN KEY fk_user_id (user_id) REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE,
-		FOREIGN KEY fk_team_id (team_id) REFERENCES teams (id) ON DELETE CASCADE ON UPDATE CASCADE
+		FOREIGN KEY fk_user_teams_user_id (user_id) REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE,
+		FOREIGN KEY fk_user_teams_team_id (team_id) REFERENCES teams (id) ON DELETE CASCADE ON UPDATE CASCADE
 	)`); err != nil {
 		return errors.Wrap(err, "create user_teams")
 	}
 
 	if _, err := tx.Exec(`ALTER TABLE hosts
 		ADD team_id INT UNSIGNED DEFAULT NULL,
-		ADD FOREIGN KEY fk_team_id (team_id) REFERENCES teams (id) ON DELETE SET NULL
+		ADD FOREIGN KEY fk_hosts_team_id (team_id) REFERENCES teams (id) ON DELETE SET NULL
 	`); err != nil {
 		return errors.Wrap(err, "alter hosts")
 	}

--- a/server/datastore/mysql/migrations/tables/20210601000008_TeamsEnrollSecrets.go
+++ b/server/datastore/mysql/migrations/tables/20210601000008_TeamsEnrollSecrets.go
@@ -15,7 +15,7 @@ func Up_20210601000008(tx *sql.Tx) error {
 	sql := `
 		ALTER TABLE enroll_secrets
 		ADD COLUMN team_id INT UNSIGNED,
-		ADD FOREIGN KEY fk_team_id (team_id) REFERENCES teams (id) ON DELETE CASCADE ON UPDATE CASCADE
+		ADD FOREIGN KEY fk_enroll_secrets_team_id (team_id) REFERENCES teams (id) ON DELETE CASCADE ON UPDATE CASCADE
 	`
 	if _, err := tx.Exec(sql); err != nil {
 		return errors.Wrap(err, "add team_id to enroll_secrets")


### PR DESCRIPTION
Give unique names to each new foreign key in the migrations.

Fixes #1279