### PR TITLE
Update table row height and button font size

### DIFF
--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -83,8 +83,9 @@
 
     tbody {
       td {
-        padding: 12px 27px;
+        padding: 0px 27px;
         white-space: nowrap;
+        height: 40px;
 
         // form-field wraps the dropdown menu
         .form-field {

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -36,7 +36,7 @@ $base-class: "button";
   align-items: center;
   padding: $pad-small $pad-medium;
   border-radius: 4px;
-  font-size: $small;
+  font-size: $x-small;
   font-family: "Nunito Sans", sans-serif;
   font-weight: $bold;
   display: inline-flex;

--- a/frontend/components/queries/QueriesList/QueriesListRow/_styles.scss
+++ b/frontend/components/queries/QueriesList/QueriesListRow/_styles.scss
@@ -1,5 +1,5 @@
 .queries-list-row {
-  line-height: 38px;
+  line-height: 40px;
   border-bottom: 1px solid $ui-fleet-blue-15;
 
   &__description {

--- a/frontend/pages/hosts/HostDetailsPage/PackQueriesListRow/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/PackQueriesListRow/_styles.scss
@@ -1,5 +1,5 @@
 .pack-queries-list-row {
-  line-height: 38px;
+  line-height: 40px;
   border-bottom: 1px solid $ui-fleet-blue-15;
 
   &__type {


### PR DESCRIPTION
- Small styling changes to all tables to have a row height of 40px
- Small styling changes to all buttons to have a font-size of 14px (`$x-small`)

Closes #1265 

Note: From now on, we will build tables with `TableContainer`. At some point, we may want to refactor the Query page table, Packs page table, tables on the host details page, etc.. that do not use new maintainable/reusable component `TableContainer.tsx` (~2-4 hours).

<img width="1560" alt="Screen Shot 2021-07-05 at 1 07 01 PM" src="https://user-images.githubusercontent.com/71795832/124502802-26273700-dd92-11eb-875e-f430a69df406.png">

