### PR TITLE
Fix Kinesis/Firehose error messages

### DIFF
--- a/changes/1316-kinesis-firehose-errors
+++ b/changes/1316-kinesis-firehose-errors
@@ -1,0 +1,1 @@
+* Fix printing of failed record count in AWS Kinesis/Firehose logging plugins.

--- a/server/logging/firehose.go
+++ b/server/logging/firehose.go
@@ -178,7 +178,7 @@ func (f *firehoseLogWriter) putRecordBatch(try int, records []*firehose.Record) 
 
 			return errors.Errorf(
 				"failed to put %d records, retries exhausted. First error: %s",
-				output.FailedPutCount, errMsg,
+				*output.FailedPutCount, errMsg,
 			)
 		}
 

--- a/server/logging/kinesis.go
+++ b/server/logging/kinesis.go
@@ -186,7 +186,7 @@ func (k *kinesisLogWriter) putRecords(try int, records []*kinesis.PutRecordsRequ
 
 			return errors.Errorf(
 				"failed to put %d records, retries exhausted. First error: %s",
-				output.FailedRecordCount, errMsg,
+				*output.FailedRecordCount, errMsg,
 			)
 		}
 


### PR DESCRIPTION
Previously we unintentionally logged the *pointer* when we intended to
log the *value* of how many records failed.