### PR TITLE
User Modal: Fix default behaviors based on organization settings

### DIFF
--- a/changes/1348-edit-user-modal
+++ b/changes/1348-edit-user-modal
@@ -1,0 +1,4 @@
+- Update create/edit user modal to accurately reflect if SSO is enabled for the individual user (rather than if enabled for the organization as a whole)
+- Update create/edit user modal tooltips and disabled fields based on state of organization settings (SSO and SMTP)
+
+Closes #1348

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -9,6 +9,7 @@ export default PropTypes.shape({
   domain: PropTypes.string,
   enable_analytics: PropTypes.bool,
   enable_ssl_tls: PropTypes.bool,
+  enabled_sso: PropTypes.bool,
   enable_start_tls: PropTypes.bool,
   host_expiry_enabled: PropTypes.bool,
   host_expiry_window: PropTypes.number,
@@ -33,6 +34,7 @@ export interface IConfig {
   domain: string;
   enable_analytics: boolean;
   enable_ssl_tls: boolean;
+  enable_sso: boolean;
   enable_start_tls: boolean;
   host_expiry_enabled: boolean;
   host_expiry_window: number;

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPagePage/MembersPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPagePage/MembersPage.tsx
@@ -99,6 +99,10 @@ const MembersPage = (props: IMembersPageProps): JSX.Element => {
     return state.app.config.configured;
   });
 
+  const canUseSso = useSelector((state: IRootState) => {
+    return state.app.config.enable_sso;
+  });
+
   const [showAddMemberModal, setShowAddMemberModal] = useState(false);
   const [showRemoveMemberModal, setShowRemoveMemberModal] = useState(false);
   const [showEditUserModal, setShowEditUserModal] = useState(false);
@@ -267,11 +271,12 @@ const MembersPage = (props: IMembersPageProps): JSX.Element => {
           defaultEmail={userEditing?.email}
           defaultGlobalRole={userEditing?.global_role}
           defaultTeams={userEditing?.teams}
-          defaultSSOEnabled={userEditing?.sso_enabled}
           availableTeams={teams}
           validationErrors={[]}
           isBasicTier={isBasicTier}
           smtpConfigured={smtpConfigured}
+          canUseSso={canUseSso}
+          isSsoEnabled={userEditing?.sso_enabled}
         />
       ) : null}
       {showRemoveMemberModal ? (

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
@@ -439,11 +439,12 @@ export class UserManagementPage extends Component {
           currentUserId={currentUser.id}
           onCancel={toggleEditUserModal}
           onSubmit={onEditUser}
-          canUseSSO={config.enable_sso}
           availableTeams={teams}
           submitText={"Save"}
           isBasicTier={isBasicTier}
           smtpConfigured={config.configured}
+          canUseSso={config.enable_sso}
+          isSsoEnabled={userData.sso_enabled}
         />
       </Modal>
     );
@@ -473,14 +474,14 @@ export class UserManagementPage extends Component {
           currentUserId={currentUser.id}
           onCancel={toggleCreateUserModal}
           onSubmit={onCreateUserSubmit}
-          canUseSSO={config.enable_sso}
           availableTeams={teams}
           defaultGlobalRole={"observer"}
           defaultTeams={[]}
           defaultNewUserType={false}
           submitText={"Create"}
           isBasicTier={isBasicTier}
-          isSmtpConfigured={config.configured}
+          smtpConfigured={config.configured}
+          canUseSso={config.enable_sso}
           isNewUser
         />
       </Modal>

--- a/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
@@ -185,7 +185,7 @@ const generateRole = (teams: ITeam[], globalRole: string | null): string => {
 const generateActionDropdownOptions = (
   isCurrentUser: boolean,
   isInvitePending: boolean,
-  isSSOEnabled: boolean
+  isSsoEnabled: boolean
 ): IDropdownOption[] => {
   let dropdownOptions = [
     {
@@ -209,7 +209,7 @@ const generateActionDropdownOptions = (
       value: "delete",
     },
   ];
-  if (isSSOEnabled) {
+  if (isSsoEnabled) {
     // remove "Require password reset" from dropdownOptions
     dropdownOptions = dropdownOptions.filter(
       (option) => option.label !== "Require password reset"

--- a/frontend/pages/admin/UserManagementPage/components/EditUserModal/EditUserModal.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/EditUserModal/EditUserModal.tsx
@@ -12,11 +12,12 @@ interface IEditUserModalProps {
   defaultEmail?: string;
   defaultGlobalRole?: string | null;
   defaultTeams?: ITeam[];
-  defaultSSOEnabled?: boolean;
   availableTeams: ITeam[];
   validationErrors: any[];
   isBasicTier: boolean;
   smtpConfigured: boolean;
+  canUseSso: boolean; // corresponds to whether SSO is enabled for the organization
+  isSsoEnabled?: boolean; // corresponds to whether SSO is enabled for the individual user
 }
 
 const baseClass = "edit-user-modal";
@@ -29,11 +30,12 @@ const EditUserModal = (props: IEditUserModalProps): JSX.Element => {
     defaultEmail,
     defaultGlobalRole,
     defaultTeams,
-    defaultSSOEnabled,
     availableTeams,
     isBasicTier,
     validationErrors,
     smtpConfigured,
+    canUseSso,
+    isSsoEnabled,
   } = props;
 
   return (
@@ -50,11 +52,12 @@ const EditUserModal = (props: IEditUserModalProps): JSX.Element => {
         defaultTeams={defaultTeams}
         onCancel={onCancel}
         onSubmit={onSubmit}
-        canUseSSO={defaultSSOEnabled}
         availableTeams={availableTeams}
         submitText={"Save"}
         isBasicTier={isBasicTier}
         smtpConfigured={smtpConfigured}
+        canUseSso={canUseSso}
+        isSsoEnabled={isSsoEnabled}
       />
     </Modal>
   );


### PR DESCRIPTION
- Update create/edit user modal to accurately reflect if SSO is enabled for the individual user (rather than if enabled for the organization as a whole)
- Update create/edit user modal tooltips and disabled fields based on state of organization settings (SSO and SMTP)

Closes #1348
