### PR TITLE
Add routes for Schedule feature to REST API documentation

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,5 @@
 # markdown
-# *.md
+*.md
 
 # output directories
 build

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,5 @@
 # markdown
-*.md
+# *.md
 
 # output directories
 build

--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -3158,9 +3158,38 @@ None.
 
 ```
 {
-  "global_schedule": {
-
-  }
+  "global_schedule": [
+    {
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z",
+      "id": 461,
+      "pack_id": 5,
+      "name": "arp_cache",
+      "query_id": 275,
+      "query_name": "arp_cache",
+      "query": "select * from arp_cache;",
+      "interval": 120,
+      "snapshot": null,
+      "removed": null,
+      "shard": null,
+      "denylist": null
+    },
+    {
+      "created_at": "0001-01-01T00:00:00Z",
+      "updated_at": "0001-01-01T00:00:00Z",
+      "id": 463,
+      "pack_id": 5,
+      "name": "distributed_testexample.com_1624654109",
+      "query_id": 84,
+      "query_name": "distributed_testexample.com_1624654109",
+      "query": "Get",
+      "interval": 86400,
+      "snapshot": null,
+      "removed": null,
+      "shard": null,
+      "denylist": null
+    }
+  ]
 }
 ```
 

--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -3169,7 +3169,7 @@ None.
       "query_name": "arp_cache",
       "query": "select * from arp_cache;",
       "interval": 120,
-      "snapshot": null,
+      "snapshot": true,
       "removed": null,
       "shard": null,
       "denylist": null
@@ -3184,7 +3184,7 @@ None.
       "query_name": "distributed_testexample.com_1624654109",
       "query": "Get",
       "interval": 86400,
-      "snapshot": null,
+      "snapshot": true,
       "removed": null,
       "shard": null,
       "denylist": null
@@ -3239,7 +3239,7 @@ None.
     "query_name": "arp_cache",
     "query": "select * from arp_cache;",
     "interval": 120,
-    "snapshot": null,
+    "snapshot": true,
     "removed": null,
     "shard": null,
     "denylist": null

--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -3162,7 +3162,7 @@ None.
     {
       "created_at": "0001-01-01T00:00:00Z",
       "updated_at": "0001-01-01T00:00:00Z",
-      "id": 461,
+      "id": 4,
       "pack_id": 1,
       "name": "arp_cache",
       "query_id": 2,
@@ -3177,7 +3177,7 @@ None.
     {
       "created_at": "0001-01-01T00:00:00Z",
       "updated_at": "0001-01-01T00:00:00Z",
-      "id": 463,
+      "id": 5,
       "pack_id": 1,
       "name": "disk_encryption",
       "query_id": 7,

--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -3142,7 +3142,7 @@ o
 
 Fleet’s query schedule lets you add queries which are executed on your devices at regular intervals.
 
-For those familiar with osquery query packs, Fleet's query schedule can be thought of as a query pack built in to Fleet. Instead of creating a query pack and then adding queries, just add queries to Fleet's query schedule to start running them against all your devices.
+For those familiar with osquery query packs, Fleet's query schedule can be thought of as a query pack built into Fleet. Instead of creating a query pack and then adding queries, just add queries to Fleet's query schedule to start running them against all your devices.
 
 ### Get schedule
 

--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -3218,6 +3218,8 @@ None.
 }
 ```
 
+> Note that the `pack_id` is included in the response object because Fleet's Schedule feature uses osquery query packs under the hood.
+
 ### Edit query in schedule
 
 `PATCH /api/v1/fleet/global/schedule/{id}`

--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -9,6 +9,7 @@
 - [Users](#users)
 - [Sessions](#sessions)
 - [Queries](#queries)
+- [Schedule](#schedule)
 - [Packs](#packs)
 - [Targets](#targets)
 - [Fleet configuration](#fleet-configuration)
@@ -3126,6 +3127,168 @@ o
 
   }
 ]
+```
+
+---
+
+## Schedule
+
+- [Get schedule](#get-schedule)
+- [Add query to schedule](#add-query-to-schedule)
+- [Edit query in schedule](#edit-query-in-schedule)
+- [Remove query from schedule](#remove-query-from-schedule)
+
+`In Fleet 4.1.0, the Schedule feature was introduced.`
+
+Fleet’s query schedule lets you add queries which are executed on your devices at regular intervals.
+
+For those familiar with osquery query packs, Fleet's query schedule can be thought of as a query pack built in to Fleet. Instead of creating a query pack and then adding queries, just add queries to Fleet's query schedule to start running them against all your devices.
+
+### Get schedule
+
+`GET /api/v1/fleet/global/schedule`
+
+#### Parameters
+
+None.
+
+##### Default response
+
+`Status: 200`
+
+```
+{
+  "global_schedule": {
+
+  }
+}
+```
+
+### Add query to schedule
+
+`POST /api/v1/fleet/global/schedule`
+
+#### Parameters
+
+| Name     | Type    | In   | Description                                                                                                                      |
+| -------- | ------- | ---- | -------------------------------------------------------------------------------------------------------------------------------- |
+| query_id | integer | body | **Required.** The query's ID.                                                                                                    |
+| interval | integer | body | **Required.** The amount of time, in seconds, the query waits before running.                                                    |
+| snapshot | boolean | body | **Required.** Whether the queries logs show everything in its current state.                                                     |
+| removed  | boolean | body | Whether "removed" actions should be logged. Default is `null`.                                                                   |
+| platform | string  | body | The computer platform where this query will run (other platforms ignored). Empty value runs on all platforms. Default is `null`. |
+| shard    | integer | body | Restrict this query to a percentage (1-100) of target hosts. Default is `null`.                                                  |
+| version  | string  | body | The minimum required osqueryd version installed on a host. Default is `null`.                                                    |
+
+#### Example
+
+`POST /api/v1/fleet/global/schedule`
+
+##### Request body
+
+```
+{
+  "interval": 120,
+  "query_id": 23,
+  "snapshot": true,
+}
+```
+
+##### Default response
+
+`Status: 200`
+
+```
+{
+  "scheduled": {
+    "created_at": "0001-01-01T00:00:00Z",
+    "updated_at": "0001-01-01T00:00:00Z",
+    "id": 461,
+    "pack_id": 5,
+    "name": "arp_cache",
+    "query_id": 275,
+    "query_name": "arp_cache",
+    "query": "select * from arp_cache;",
+    "interval": 120,
+    "snapshot": null,
+    "removed": null,
+    "shard": null,
+    "denylist": null
+  }
+}
+```
+
+### Edit query in schedule
+
+`PATCH /api/v1/fleet/global/schedule/{id}`
+
+#### Parameters
+
+| Name     | Type    | In   | Description                                                                                                   |
+| -------- | ------- | ---- | ------------------------------------------------------------------------------------------------------------- |
+| id       | integer | path | **Required.** The scheduled query's ID.                                                                       |
+| interval | integer | body | The amount of time, in seconds, the query waits before running.                                               |
+| snapshot | boolean | body | Whether the queries logs show everything in its current state.                                                |
+| removed  | boolean | body | Whether "removed" actions should be logged.                                                                   |
+| platform | string  | body | The computer platform where this query will run (other platforms ignored). Empty value runs on all platforms. |
+| shard    | integer | body | Restrict this query to a percentage (1-100) of target hosts.                                                  |
+| version  | string  | body | The minimum required osqueryd version installed on a host.                                                    |
+
+#### Example
+
+`PATCH /api/v1/fleet/global/schedule/462`
+
+##### Request body
+
+```
+{
+  "interval": 86400,
+}
+```
+
+##### Default response
+
+`Status: 200`
+
+```
+{
+  "scheduled": {
+    "created_at": "2021-07-16T14:40:15Z",
+    "updated_at": "2021-07-16T14:40:15Z",
+    "id": 462,
+    "pack_id": 5,
+    "name": "arp_cache",
+    "query_id": 275,
+    "query_name": "arp_cache",
+    "query": "select * from arp_cache;",
+    "interval": 86400,
+    "snapshot": true,
+    "removed": null,
+    "platform": "",
+    "shard": null,
+    "denylist": null
+  }
+}
+```
+
+### Remove query from schedule
+
+`DELETE /api/v1/fleet/global/schedule/{id}`
+
+#### Parameters
+
+None.
+
+#### Example
+
+`DELETE /api/v1/fleet/global/schedule/462`
+
+##### Default response
+
+`Status: 200`
+
+```
+{}
 ```
 
 ---

--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -3163,9 +3163,9 @@ None.
       "created_at": "0001-01-01T00:00:00Z",
       "updated_at": "0001-01-01T00:00:00Z",
       "id": 461,
-      "pack_id": 5,
+      "pack_id": 1,
       "name": "arp_cache",
-      "query_id": 275,
+      "query_id": 2,
       "query_name": "arp_cache",
       "query": "select * from arp_cache;",
       "interval": 120,
@@ -3178,11 +3178,11 @@ None.
       "created_at": "0001-01-01T00:00:00Z",
       "updated_at": "0001-01-01T00:00:00Z",
       "id": 463,
-      "pack_id": 5,
-      "name": "distributed_testexample.com_1624654109",
-      "query_id": 84,
-      "query_name": "distributed_testexample.com_1624654109",
-      "query": "Get",
+      "pack_id": 1,
+      "name": "disk_encryption",
+      "query_id": 7,
+      "query_name": "disk_encryption",
+      "query": "select * from disk_encryption;",
       "interval": 86400,
       "snapshot": true,
       "removed": null,
@@ -3217,8 +3217,8 @@ None.
 
 ```
 {
-  "interval": 120,
-  "query_id": 23,
+  "interval": 86400,
+  "query_id": 2,
   "snapshot": true,
 }
 ```
@@ -3232,13 +3232,13 @@ None.
   "scheduled": {
     "created_at": "0001-01-01T00:00:00Z",
     "updated_at": "0001-01-01T00:00:00Z",
-    "id": 461,
+    "id": 1,
     "pack_id": 5,
     "name": "arp_cache",
-    "query_id": 275,
+    "query_id": 2,
     "query_name": "arp_cache",
     "query": "select * from arp_cache;",
-    "interval": 120,
+    "interval": 86400,
     "snapshot": true,
     "removed": null,
     "shard": null,
@@ -3267,13 +3267,13 @@ None.
 
 #### Example
 
-`PATCH /api/v1/fleet/global/schedule/462`
+`PATCH /api/v1/fleet/global/schedule/5`
 
 ##### Request body
 
 ```
 {
-  "interval": 86400,
+  "interval": 604800,
 }
 ```
 
@@ -3286,13 +3286,13 @@ None.
   "scheduled": {
     "created_at": "2021-07-16T14:40:15Z",
     "updated_at": "2021-07-16T14:40:15Z",
-    "id": 462,
-    "pack_id": 5,
+    "id": 5,
+    "pack_id": 1,
     "name": "arp_cache",
-    "query_id": 275,
+    "query_id": 2,
     "query_name": "arp_cache",
     "query": "select * from arp_cache;",
-    "interval": 86400,
+    "interval": 604800,
     "snapshot": true,
     "removed": null,
     "platform": "",
@@ -3312,7 +3312,7 @@ None.
 
 #### Example
 
-`DELETE /api/v1/fleet/global/schedule/462`
+`DELETE /api/v1/fleet/global/schedule/5`
 
 ##### Default response
 


### PR DESCRIPTION
`In Fleet 4.1.0, the Schedule feature will be introduced.`

Add documentation (route, parameters, example) for the following routes:
- `GET /api/v1/fleet/global/schedule`
- `POST /api/v1/fleet/global/schedule`
- `PATCH /api/v1/fleet/global/schedule/{id}`
- `DELETE /api/v1/fleet/global/schedule/{id}`