### PR TITLE
TableContainer additions: simpleSearch utility and IconCell

### DIFF
--- a/frontend/components/TableContainer/DataTable/IconCell/IconCell.tsx
+++ b/frontend/components/TableContainer/DataTable/IconCell/IconCell.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+// @ts-ignore
+import FleetIcon from "components/icons/FleetIcon";
+
+interface IIconTooltipCellProps<T> {
+  value: string;
+}
+
+const IconTooltipCell = (
+  props: IIconTooltipCellProps<any>
+): JSX.Element | null => {
+  const { value } = props;
+
+  // The value passed in must be a valid FleetIcon name
+  return <FleetIcon name={value} />;
+};
+
+export default IconTooltipCell;

--- a/frontend/components/TableContainer/DataTable/IconCell/index.ts
+++ b/frontend/components/TableContainer/DataTable/IconCell/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./IconCell";

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -6,7 +6,7 @@ import classnames from "classnames";
 import { Link } from "react-router";
 import ReactTooltip from "react-tooltip";
 import { isEmpty, noop, pick, reduce, filter, includes } from "lodash";
-
+import simpleSearch from "utilities/simple_search";
 import Spinner from "components/loaders/Spinner";
 import Button from "components/buttons/Button";
 import Modal from "components/modals/Modal";
@@ -208,19 +208,7 @@ export class HostDetailsPage extends Component {
       return;
     }
 
-    const lowerSearchQuery = searchQuery.toLowerCase();
-
-    const filteredSoftware = filter(host.software, (softwareItem) => {
-      if (!softwareItem.name) {
-        return false;
-      }
-
-      const lowerSoftwareName = softwareItem.name.toLowerCase();
-
-      return includes(lowerSoftwareName, lowerSearchQuery);
-    });
-
-    this.setState({ softwareState: filteredSoftware });
+    this.setState({ softwareState: simpleSearch(searchQuery, host.software) });
   };
 
   clearHostUpdates() {

--- a/frontend/utilities/simple_search/index.js
+++ b/frontend/utilities/simple_search/index.js
@@ -1,0 +1,1 @@
+export { default } from "./simple_search";

--- a/frontend/utilities/simple_search/simple_search.js
+++ b/frontend/utilities/simple_search/simple_search.js
@@ -1,0 +1,21 @@
+import { filter, includes } from "lodash";
+
+const simpleSearch = (searchQuery = "", dictionary) => {
+  const lowerSearchQuery = searchQuery.toLowerCase();
+
+  console.log("Hello");
+
+  const filterResults = filter(dictionary, (item) => {
+    if (!item.name) {
+      return false;
+    }
+
+    const lowerItemName = item.name.toLowerCase();
+
+    return includes(lowerItemName, lowerSearchQuery);
+  });
+
+  return filterResults;
+};
+
+export default simpleSearch;

--- a/frontend/utilities/simple_search/simple_search.js
+++ b/frontend/utilities/simple_search/simple_search.js
@@ -3,8 +3,6 @@ import { filter, includes } from "lodash";
 const simpleSearch = (searchQuery = "", dictionary) => {
   const lowerSearchQuery = searchQuery.toLowerCase();
 
-  console.log("Hello");
-
   const filterResults = filter(dictionary, (item) => {
     if (!item.name) {
       return false;


### PR DESCRIPTION
More reusable code for `TableContainer` that we projected we'll need for various tables (pulled out of EditPacksPage draft PR so code can be used in other concurrent work)

- simpleSearch function reusable across client-side searching
- IconCell for `TableContainer` (e.g. for logging type)

Note: @gillespi314 has ideas for advancing client-side search

Co-authored by: @gillespi314 