### PR TITLE
Windows friendly changes after walking through getting started guide

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,8 @@
 website/ linguist-vendored
 website/* linguist-vendored
 website/** linguist-vendored
+
+# windows is funny about line endings see https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings for more details
+# test TestCertificateChain in server/service/service_certificate_test.go was having issues on Windows
+server/service/testdata/server.key text eol=lf
+server/service/testdata/server.pem text eol=lf

--- a/docs/3-Contributing/1-Building-Fleet.md
+++ b/docs/3-Contributing/1-Building-Fleet.md
@@ -41,7 +41,7 @@ sudo npm install -g yarn
 
 To install dependecies, we recommend using [Chocolatey](https://chocolatey.org/install). Chocolatey must be run in Powershell as an Administrator. Assuming your setup does not include any of our requirements, please run:
 ```
-choco install nodejs git golang docker make
+choco install nodejs git golang docker make python2
 ```
 
 Note: all packages default to the latest versions. To specify a version, place `--version <version-number>` after each package. You may also install all packages manually from their websites if you prefer.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -334,9 +335,9 @@ func (man Manager) addConfigs() {
 	man.addConfigBool("pubsub.add_attributes", false, "Add PubSub attributes in addition to the message body")
 
 	// Filesystem
-	man.addConfigString("filesystem.status_log_file", "/tmp/osquery_status",
+	man.addConfigString("filesystem.status_log_file", fmt.Sprintf("%s%c%s", os.TempDir(), os.PathSeparator, "osquery_status"),
 		"Log file path to use for status logs")
-	man.addConfigString("filesystem.result_log_file", "/tmp/osquery_result",
+	man.addConfigString("filesystem.result_log_file", fmt.Sprintf("%s%c%s", os.TempDir(), os.PathSeparator, "osquery_result"),
 		"Log file path to use for result logs")
 	man.addConfigBool("filesystem.enable_log_rotation", false,
 		"Enable automatic rotation for osquery log files")
@@ -659,6 +660,10 @@ func (man Manager) loadConfigFile() {
 // TestConfig returns a barebones configuration suitable for use in tests.
 // Individual tests may want to override some of the values provided.
 func TestConfig() FleetConfig {
+	var testLogFile = "/dev/null"
+	if runtime.GOOS == "windows" {
+		testLogFile = "NUL"
+	}
 	return FleetConfig{
 		App: AppConfig{
 			TokenKeySize:              24,
@@ -686,8 +691,8 @@ func TestConfig() FleetConfig {
 			DisableBanner: true,
 		},
 		Filesystem: FilesystemConfig{
-			StatusLogFile: "/dev/null",
-			ResultLogFile: "/dev/null",
+			StatusLogFile: testLogFile,
+			ResultLogFile: testLogFile,
 		},
 	}
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -335,9 +336,9 @@ func (man Manager) addConfigs() {
 	man.addConfigBool("pubsub.add_attributes", false, "Add PubSub attributes in addition to the message body")
 
 	// Filesystem
-	man.addConfigString("filesystem.status_log_file", fmt.Sprintf("%s%c%s", os.TempDir(), os.PathSeparator, "osquery_status"),
+	man.addConfigString("filesystem.status_log_file", filepath.Join(os.TempDir(), "osquery_status"),
 		"Log file path to use for status logs")
-	man.addConfigString("filesystem.result_log_file", fmt.Sprintf("%s%c%s", os.TempDir(), os.PathSeparator, "osquery_result"),
+	man.addConfigString("filesystem.result_log_file", filepath.Join(os.TempDir(), "osquery_result"),
 		"Log file path to use for result logs")
 	man.addConfigBool("filesystem.enable_log_rotation", false,
 		"Enable automatic rotation for osquery log files")


### PR DESCRIPTION
- update gitattributes to be explicit about line endings with regards to the test certs
- update building-fleet guide to include python2 dependency on windows (this usually comes for free on other OS's so easy to miss
- update configuration to default to OS specific temporary directories