### PR TITLE
Add retries to flaky enroll secret test

### DIFF
--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -11,36 +11,44 @@ describe("Hosts page", () => {
     cy.stopDockerHost();
   });
 
-  it("Add new host", () => {
-    cy.visit("/");
-
-    cy.contains("button", /add new host/i).click();
-
-    cy.contains("a", /download/i)
-      .first()
-      .click();
-
-    cy.get('a[href*="showSecret"]').click();
-
-    // Assert enroll secret downloaded matches the one displayed
-    cy.readFile(path.join(Cypress.config("downloadsFolder"), "secret.txt"), {
-      timeout: 5000,
-    }).then((contents) => {
-      cy.get("input[disabled]").should("have.value", contents);
-    });
-
-    // Wait until the host becomes available (usually immediate in local
-    // testing, but may vary by environment).
-    cy.waitUntil(
-      () => {
-        cy.visit("/");
-        return Cypress.$('button[title="Online"]').length > 0;
+  it(
+    "Add new host",
+    {
+      retries: {
+        runMode: 2,
       },
-      { timeout: 30000, interval: 1000 }
-    );
+    },
+    () => {
+      cy.visit("/");
 
-    // Go to host details page
-    cy.get('button[title="Online"]').click();
-    cy.get("span.status").contains("online");
-  });
+      cy.contains("button", /add new host/i).click();
+
+      cy.contains("a", /download/i)
+        .first()
+        .click();
+
+      cy.get('a[href*="showSecret"]').click();
+
+      // Assert enroll secret downloaded matches the one displayed
+      cy.readFile(path.join(Cypress.config("downloadsFolder"), "secret.txt"), {
+        timeout: 5000,
+      }).then((contents) => {
+        cy.get("input[disabled]").should("have.value", contents);
+      });
+
+      // Wait until the host becomes available (usually immediate in local
+      // testing, but may vary by environment).
+      cy.waitUntil(
+        () => {
+          cy.visit("/");
+          return Cypress.$('button[title="Online"]').length > 0;
+        },
+        { timeout: 30000, interval: 1000 }
+      );
+
+      // Go to host details page
+      cy.get('button[title="Online"]').click();
+      cy.get("span.status").contains("online");
+    }
+  );
 });


### PR DESCRIPTION
There seems to be something flaky about downloading the enroll secret in
the test. I can't reproduce any issue with doing so locally, so I'm
adding a retry to get this to quiet down in CI.