### PR TITLE
Add CODEOWNERS for Go engineering team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# Go engineers are automatically added as reviewers when changes are made to go
+files or related backend files.
+*.go @fleetdm/go
+go.sum @fleetdm/go
+go.mod @fleetdm/go
+/server/ @fleetdm/go
+/cmd/ @fleetdm/go


### PR DESCRIPTION
This should result in automatic review requests for everyone the
@fleetdm/go group when Go or server related files are touched.