### PR TITLE
fleetctl preview downloads standard query library and populates console

### DIFF
--- a/server/fleet/meta.go
+++ b/server/fleet/meta.go
@@ -1,6 +1,6 @@
 package fleet
 
 type ObjectMetadata struct {
-	ApiVersion string `json:"apiVersion"`
-	Kind       string `json:"kind"`
+	ApiVersion string `json:"apiVersion" yaml:"api_version"`
+	Kind       string `json:"kind" yaml:"kind"`
 }

--- a/server/fleet/queries.go
+++ b/server/fleet/queries.go
@@ -109,13 +109,13 @@ const (
 
 type QueryObject struct {
 	ObjectMetadata
-	Spec QuerySpec `json:"spec"`
+	Spec QuerySpec `json:"spec" yaml:"spec"`
 }
 
 type QuerySpec struct {
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	Query       string `json:"query"`
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description,omitempty" yaml:"description"`
+	Query       string `json:"query" yaml:"query"`
 }
 
 func LoadQueriesFromYaml(yml string) ([]*Query, error) {


### PR DESCRIPTION
added yaml tags to `QueryObjec`t, `QueryMeta`, & `QuerySpec` to facilitate downloading and parsing https://raw.githubusercontent.com/fleetdm/fleet/main/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml which is a multi-document yaml file.

implements #1159 