### PR TITLE
Add the query that populates the `users` property in Host vitals to the standard query library

### DIFF
--- a/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -426,3 +426,13 @@ spec:
   query: SELECT CASE cnt WHEN 2 THEN "TRUE" ELSE "FALSE" END "Vulnerable" FROM (SELECT name start_type, COUNT(name) AS cnt FROM services WHERE name = 'NTDS' or (name = 'Spooler' and start_type <> 'DISABLED')) WHERE cnt = 2;
   purpose: Detection
   contributors: maravedi
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Get local users and their privileges
+  platforms: macOS, Linux, Windows
+  description: Collects the local user accounts and their respective user group.
+  query: SELECT uid, username, type, groupname FROM users u JOIN groups g ON g.gid = u.gid;
+  purpose: Informational
+  contributors: noahtalerman


### PR DESCRIPTION
- The included query populates the `users` property in the `/api/v1/fleet/hosts/{id}` response object.
- This information also populates the new "Users" table on the Host details page