### PR TITLE
Host Management and User Management Pages: Reorder tables to ascending order

### DIFF
--- a/changes/issue-1447-tables-ascending-order
+++ b/changes/issue-1447-tables-ascending-order
@@ -1,0 +1,1 @@
+* Reorder hosts and user UI tables in ascending order (A-Z)

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
@@ -577,7 +577,7 @@ export class UserManagementPage extends Component {
           data={tableData}
           isLoading={loadingTableData}
           defaultSortHeader={"name"}
-          defaultSortDirection={"desc"}
+          defaultSortDirection={"asc"}
           inputPlaceHolder={"Search"}
           actionButtonText={"Create user"}
           onActionButtonClick={toggleCreateUserModal}

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.jsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.jsx
@@ -659,7 +659,7 @@ export class ManageHostsPage extends PureComponent {
         data={hosts}
         isLoading={loadingHosts}
         defaultSortHeader={"hostname"}
-        defaultSortDirection={"desc"}
+        defaultSortDirection={"asc"}
         actionButtonText={"Edit columns"}
         actionButtonIcon={EditColumnsIcon}
         actionButtonVariant={"text-icon"}


### PR DESCRIPTION
Reorder host and user tables to ascending order (A-Z) on UI



<img width="1169" alt="Screen Shot 2021-07-26 at 9 11 26 AM" src="https://user-images.githubusercontent.com/71795832/126994376-f6c2cb04-cb3f-4d99-b98d-6118e2adf633.png">
<img width="1165" alt="Screen Shot 2021-07-26 at 9 11 40 AM" src="https://user-images.githubusercontent.com/71795832/126994382-4275f1c7-2e6f-4285-a040-d232a3907185.png">
