### PR TITLE
Add several frontend, spiffier fixes to the Fleet UI

### DIFF
--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -187,7 +187,7 @@ const TableContainer = ({
         </div>
       )}
       <div className={`${baseClass}__header`}>
-        {data && data.length && !disableCount && (
+        {data && data.length && !disableCount ? (
           <p className={`${baseClass}__results-count`}>
             {TableContainerUtils.generateResultsCountText(
               resultsTitle,
@@ -196,6 +196,8 @@ const TableContainer = ({
               data.length
             )}
           </p>
+        ) : (
+          <p />
         )}
         <div className={`${baseClass}__table-controls`}>
           {actionButtonText && (

--- a/frontend/components/TableContainer/TableContainerUtils.ts
+++ b/frontend/components/TableContainer/TableContainerUtils.ts
@@ -7,6 +7,24 @@ const generateResultsCountText = (
   resultsCount: number
 ): string => {
   if (resultsCount === 0) return `No ${name}`;
+  // If there is 1 result and the last 3 letters in the result
+  // name are "ies," we remove the "ies" and add "y"
+  // to make the name singular
+  if (resultsCount === 1 && name.slice(-3) === "ies") {
+    return `${resultsCount} ${name.slice(0, -3)}y`;
+  }
+
+  // If there is 1 result and the last 2 letters in the result
+  // name are "es," we remove the "es" to make the name singular
+  if (resultsCount === 1 && name.slice(-2) === "es") {
+    return `${resultsCount} ${name.slice(0, -2)}y`;
+  }
+
+  // If there is 1 result and the last letter in the result
+  // name is "s," we remove the "s" to make the name singular
+  if (resultsCount === 1 && name[name.length - 1] === "s") {
+    return `${resultsCount} ${name.slice(0, -1)}`;
+  }
 
   if (pageSize === resultsCount) return `${pageSize}+ ${name}`;
   if (pageIndex !== 0 && resultsCount <= pageSize)

--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -180,7 +180,7 @@ const TeamManagementPage = (): JSX.Element => {
         defaultSortHeader={"name"}
         defaultSortDirection={"asc"}
         inputPlaceHolder={"Search"}
-        actionButtonText={"Create Team"}
+        actionButtonText={"Create team"}
         actionButtonVariant={"primary"}
         onActionButtonClick={toggleCreateTeamModal}
         onQueryChange={onQueryChange}

--- a/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
@@ -92,7 +92,7 @@ const generateTableHeaders = (
     },
     {
       title: "Actions",
-      Header: "Actions",
+      Header: "",
       disableSortBy: true,
       accessor: "actions",
       Cell: (cellProps) => (

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -511,7 +511,7 @@ export class HostDetailsPage extends Component {
                 defaultSortDirection={"asc"}
                 inputPlaceHolder={"Filter software"}
                 onQueryChange={onQueryChange}
-                resultsTitle={"software"}
+                resultsTitle={"software items"}
                 emptyComponent={EmptySoftware}
                 showMarkAllPages={false}
                 searchable

--- a/frontend/pages/hosts/HostDetailsPage/SoftwareTable/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/SoftwareTable/SoftwareTableConfig.tsx
@@ -70,8 +70,8 @@ const generateTableHeaders = (): IDataColumn[] => {
       Cell: (cellProps) => <TextCell value={cellProps.cell.value} />,
     },
     {
-      title: "Installed Version",
-      Header: "Installed Version",
+      title: "Installed version",
+      Header: "Installed version",
       disableSortBy: true,
       accessor: "version",
       Cell: (cellProps) => <TextCell value={cellProps.cell.value} />,


### PR DESCRIPTION
- Fix an issue in which `TableContainer` would render a text element with "0" when there are no matching search results
- Add 3 cases to render correct singular result count
- Sentence case fixes
- Remove "Actions" column title from "Users" table

These fixes are not attached to any specific GitHub issues