### PR TITLE
Render flash bug

### DIFF
--- a/changes/issue-1475-flash-message-bug
+++ b/changes/issue-1475-flash-message-bug
@@ -1,0 +1,1 @@
+* Does not re-render page to display flash message

--- a/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
+++ b/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
@@ -22,7 +22,7 @@ const FlashMessage = ({
   });
 
   useEffect(() => {
-    if (alertType === "success") {
+    if (alertType === "success" && isVisible) {
       setTimeout(function () {
         document.getElementById(`${klass}`).style.visibility = "visible";
       }, 0); // Ensures successive, success alerts are visible

--- a/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
+++ b/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
@@ -22,9 +22,14 @@ const FlashMessage = ({
   });
 
   useEffect(() => {
-    setTimeout(function () {
-      document.getElementById(`${klass}`).style.visibility = "visible";
-    }, 0); // Ensures successive, success alerts are visible
+    if (alertType === "success") {
+      setTimeout(function () {
+        document.getElementById(`${klass}`).style.visibility = "visible";
+      }, 0); // Ensures successive, success alerts are visible
+      setTimeout(function () {
+        document.getElementById(`${klass}`).style.visibility = "hidden";
+      }, 4000); // Hides success alerts after 4 seconds
+    }
   });
 
   if (!isVisible) {
@@ -33,12 +38,6 @@ const FlashMessage = ({
 
   const alertIcon =
     alertType === "success" ? "success-check" : "warning-filled";
-
-  if (alertType === "success") {
-    setTimeout(function () {
-      document.getElementById(`${klass}`).style.visibility = "hidden";
-    }, 4000); // Hides success alerts after 4 seconds
-  }
 
   return (
     <div className={klass} id={klass}>

--- a/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
+++ b/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
@@ -28,14 +28,13 @@ const FlashMessage = ({
   const alertIcon =
     alertType === "success" ? "success-check" : "warning-filled";
 
-  // Success alerts will not be visible after 4 seconds
   if (alertType === "success") {
     setTimeout(function () {
       document.getElementById(`${klass}`).style.visibility = "visible";
-    }, 0);
+    }, 0); // Ensures successive flash messages are visible
     setTimeout(function () {
       document.getElementById(`${klass}`).style.visibility = "hidden";
-    }, 4000);
+    }, 4000); // Hides success alerts after 4 seconds
   }
 
   return (

--- a/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
+++ b/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
@@ -22,7 +22,11 @@ const FlashMessage = ({
   });
 
   useEffect(() => {
-    if (alertType === "success" && isVisible) {
+    if (
+      alertType === "success" &&
+      isVisible &&
+      document.getElementById(`${klass}`)
+    ) {
       setTimeout(function () {
         document.getElementById(`${klass}`).style.visibility = "visible";
       }, 0); // Ensures successive, success alerts are visible

--- a/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
+++ b/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
@@ -21,18 +21,18 @@ const FlashMessage = ({
     [`${baseClass}--full-width`]: fullWidth,
   });
 
+  useEffect(() => {
+    setTimeout(function () {
+      document.getElementById(`${klass}`).style.visibility = "visible";
+    }, 0); // Ensures successive, success alerts are visible
+  });
+
   if (!isVisible) {
     return false;
   }
 
   const alertIcon =
     alertType === "success" ? "success-check" : "warning-filled";
-
-  useEffect(() => {
-    setTimeout(function () {
-      document.getElementById(`${klass}`).style.visibility = "visible";
-    }, 0); // Ensures successive, success alerts are visible
-  });
 
   if (alertType === "success") {
     setTimeout(function () {

--- a/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
+++ b/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
@@ -30,7 +30,12 @@ const FlashMessage = ({
 
   // Success alerts will not be visible after 4 seconds
   if (alertType === "success") {
-    setTimeout(onRemoveFlash, 4000);
+    setTimeout(function () {
+      document.getElementById(`${klass}`).style.visibility = "visible";
+    }, 0);
+    setTimeout(function () {
+      document.getElementById(`${klass}`).style.visibility = "hidden";
+    }, 4000);
   }
 
   return (

--- a/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
+++ b/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
@@ -22,11 +22,7 @@ const FlashMessage = ({
   });
 
   useEffect(() => {
-    if (
-      alertType === "success" &&
-      isVisible &&
-      document.getElementById(`${klass}`)
-    ) {
+    if (alertType === "success" && isVisible) {
       setTimeout(function () {
         document.getElementById(`${klass}`).style.visibility = "visible";
       }, 0); // Ensures successive, success alerts are visible

--- a/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
+++ b/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 
@@ -28,10 +28,13 @@ const FlashMessage = ({
   const alertIcon =
     alertType === "success" ? "success-check" : "warning-filled";
 
-  if (alertType === "success") {
+  useEffect(() => {
     setTimeout(function () {
       document.getElementById(`${klass}`).style.visibility = "visible";
-    }, 0); // Ensures successive flash messages are visible
+    }, 0); // Ensures successive, success alerts are visible
+  });
+
+  if (alertType === "success") {
     setTimeout(function () {
       document.getElementById(`${klass}`).style.visibility = "hidden";
     }, 4000); // Hides success alerts after 4 seconds

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
@@ -248,9 +248,10 @@ export class UserManagementPage extends Component {
     const { toggleResetSessionsUserModal } = this;
     dispatch(userActions.deleteSessions(userEditing))
       .then(() => {
-        dispatch(renderFlash("success", "Sessions reset"));
         if (currentUser.id === userEditing.id) {
           dispatch(push(LOGIN));
+        } else {
+          dispatch(renderFlash("success", "Sessions reset"));
         }
       })
       .catch(() => {


### PR DESCRIPTION
- Allows multiple flash messages and doesn't rerender page on close

Closes #1475 

@noahtalerman please QA for the intended behaviors:

- [ ] Can see multiple flash messages without refreshing the page
- [ ] Can click checkboxes to your heart's desire before flash message closes
- [ ] Anything else you think might be wonky