### PR TITLE
Homepage: Refactor platform counts in host summary

### DIFF
--- a/changes/1490-host-count-bug
+++ b/changes/1490-host-count-bug
@@ -1,0 +1,1 @@
+- Fix host count bug by refactoring host counts to use built-in labels with exact label names

--- a/frontend/interfaces/label.ts
+++ b/frontend/interfaces/label.ts
@@ -1,15 +1,34 @@
-import PropTypes from "prop-types";
+import PropTypes, { string } from "prop-types";
 
 export default PropTypes.shape({
+  created_at: PropTypes.string,
+  description: PropTypes.string,
+  display_text: PropTypes.string,
   hosts_count: PropTypes.number,
+  host_ids: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  ),
   id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  title: PropTypes.string,
-  type: PropTypes.string,
+  name: PropTypes.string,
+  label_type: PropTypes.string,
+  title: PropTypes.string, // confirm on rest api doc
+  type: PropTypes.string, // confirm on rest api doc
+  count: PropTypes.number, // confirm on rest api doc
 });
 
 export interface ILabel {
+  created_at: string;
+  description: string;
+  display_text: string;
   hosts_count: number;
+  host_ids: number[] | null;
   id: number | string;
-  title: string;
-  type: string;
+  label_membership_type: string;
+  label_type: string;
+  name: string;
+  query: string;
+  updated_at: string;
+  title: string; // confirm on rest api doc
+  type: string; // confirm on rest api doc
+  count: number;
 }

--- a/frontend/pages/Homepage/HostsSummary/HostsSummary.tsx
+++ b/frontend/pages/Homepage/HostsSummary/HostsSummary.tsx
@@ -7,7 +7,6 @@ import { getLabels } from "redux/nodes/components/ManageHostsPage/actions";
 import WindowsIcon from "../../../../assets/images/icon-windows-48x48@2x.png";
 import LinuxIcon from "../../../../assets/images/icon-linux-48x48@2x.png";
 import MacIcon from "../../../../assets/images/icon-mac-48x48@2x.png";
-import { PLATFORM_OPTIONS } from "utilities/constants";
 
 const baseClass = "hosts-summary";
 

--- a/frontend/pages/Homepage/HostsSummary/HostsSummary.tsx
+++ b/frontend/pages/Homepage/HostsSummary/HostsSummary.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { filter, isEmpty, reduce } from "lodash";
+import { isEmpty, reduce } from "lodash";
 // @ts-ignore
 import { getLabels } from "redux/nodes/components/ManageHostsPage/actions";
 import WindowsIcon from "../../../../assets/images/icon-windows-48x48@2x.png";
@@ -46,6 +46,7 @@ const HostsSummary = (): JSX.Element => {
     const index = Number(id);
     return isNaN(index) ? null : labels[index];
   });
+
   const platformLabelsArray = labelsWithIds.filter((label: any) => {
     return (
       label &&
@@ -53,6 +54,7 @@ const HostsSummary = (): JSX.Element => {
       PLATFORM_STRINGS.includes(label.name)
     );
   });
+
   const getCount = (platformTitles: string[]) => {
     return reduce(
       platformLabelsArray,

--- a/frontend/pages/Homepage/HostsSummary/HostsSummary.tsx
+++ b/frontend/pages/Homepage/HostsSummary/HostsSummary.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { isEmpty, reduce } from "lodash";
+import { ILabel } from "interfaces/label";
 // @ts-ignore
 import { getLabels } from "redux/nodes/components/ManageHostsPage/actions";
 import WindowsIcon from "../../../../assets/images/icon-windows-48x48@2x.png";
 import LinuxIcon from "../../../../assets/images/icon-linux-48x48@2x.png";
 import MacIcon from "../../../../assets/images/icon-mac-48x48@2x.png";
+import { PLATFORM_OPTIONS } from "utilities/constants";
 
 const baseClass = "hosts-summary";
 
@@ -14,23 +16,17 @@ interface IRootState {
     labels: {
       isLoading: boolean;
       data: {
-        [id: number]: {
-          count: number;
-          name: string;
-          label_type: string;
-        };
+        [id: number]: ILabel;
       };
     };
   };
 }
 
-const PLATFORM_STRINGS = [
-  "macOS",
-  "MS Windows",
-  "Red Hat Linux",
-  "CentOS Linux",
-  "Ubuntu Linux",
-];
+const PLATFORM_STRINGS = {
+  macOS: ["macOS"],
+  windows: ["MS Windows"],
+  linux: ["Red Hat Linux", "CentOS Linux", "Ubuntu Linux"],
+};
 
 const HostsSummary = (): JSX.Element => {
   const dispatch = useDispatch();
@@ -42,38 +38,25 @@ const HostsSummary = (): JSX.Element => {
   const labels = useSelector((state: IRootState) => state.entities.labels.data);
 
   // Builtin labels from state populate os counts
-  const labelsWithIds: any = Object.keys(labels).map((id) => {
-    const index = Number(id);
-    return isNaN(index) ? null : labels[index];
-  });
-
-  const platformLabelsArray = labelsWithIds.filter((label: any) => {
-    return (
-      label &&
-      label.label_type === "builtin" &&
-      PLATFORM_STRINGS.includes(label.name)
-    );
-  });
-
   const getCount = (platformTitles: string[]) => {
     return reduce(
-      platformLabelsArray,
-      (acc: number, label: any) => {
-        return platformTitles.includes(label.name) && !isEmpty(label.count)
-          ? acc + label.count
-          : acc;
+      Object.values(labels),
+      (total, label) => {
+        return label.label_type === "builtin" &&
+          platformTitles.includes(label.name) &&
+          label.count
+          ? total + label.count
+          : total;
       },
       0
     );
   };
 
-  const macCount = getCount(["macOS"]);
-  const windowsCount = getCount(["MS Windows"]);
-  const linuxCount = getCount([
-    "Red Hat Linux",
-    "Ubuntu Linux",
-    "CentOS Linux",
-  ]);
+  const macCount = getCount(PLATFORM_STRINGS.macOS).toLocaleString("en-US");
+  const windowsCount = getCount(PLATFORM_STRINGS.windows).toLocaleString(
+    "en-US"
+  );
+  const linuxCount = getCount(PLATFORM_STRINGS.linux).toLocaleString("en-US");
 
   return (
     <div className={baseClass}>


### PR DESCRIPTION
- Refactor host counts to use built-in labels with exact label names.
 
TODO:
Build out a Host Summary API that is less brittle #1491 

Co-authored by: @gillespi314 

![Screen Shot 2021-07-27 at 1 30 52 PM](https://user-images.githubusercontent.com/71795832/127200648-df770954-a9fc-4306-8a61-87a1eec054a6.png)
