### PR TITLE
#1269 fixed routing to label after team change

### DIFF
--- a/changes/1269-refresh-matching-hosts
+++ b/changes/1269-refresh-matching-hosts
@@ -1,0 +1,1 @@
+* Fixed refreshing manage hosts table to include current label and query after changing a host's team.

--- a/frontend/fleet/entities/hosts.tests.js
+++ b/frontend/fleet/entities/hosts.tests.js
@@ -46,7 +46,13 @@ describe("Kolide - API client (hosts)", () => {
 
       Fleet.setBearerToken(bearerToken);
       return Fleet.hosts
-        .loadAll(page, perPage, selectedFilter, query, sortBy)
+        .loadAll({
+          page,
+          perPage,
+          selectedLabel: selectedFilter,
+          globalFilter: query,
+          sortBy,
+        })
         .then(() => {
           expect(request.isDone()).toEqual(true);
         });
@@ -61,9 +67,15 @@ describe("Kolide - API client (hosts)", () => {
       });
 
       Fleet.setBearerToken(bearerToken);
-      return Fleet.hosts.loadAll(2, 50, "labels/6").then(() => {
-        expect(request.isDone()).toEqual(true);
-      });
+      return Fleet.hosts
+        .loadAll({
+          page: 2,
+          perPage: 50,
+          selectedLabel: "labels/6",
+        })
+        .then(() => {
+          expect(request.isDone()).toEqual(true);
+        });
     });
   });
 });

--- a/frontend/fleet/entities/hosts.ts
+++ b/frontend/fleet/entities/hosts.ts
@@ -1,5 +1,18 @@
 import endpoints from "fleet/endpoints";
-import { IHost, IHostLoadOptions } from "interfaces/host";
+import { IHost } from "interfaces/host";
+
+interface ISortOption {
+  id: number;
+  direction: string;
+}
+
+interface IHostLoadOptions {
+  page: number;
+  perPage: number;
+  selectedLabel: string;
+  globalFilter: string;
+  sortBy: ISortOption[];
+}
 
 export default (client: any) => {
   return {
@@ -25,14 +38,13 @@ export default (client: any) => {
         .authenticatedGet(endpoint)
         .then((response: any) => response.host);
     },
-    loadAll: ({
-      page = 0,
-      perPage = 100,
-      selectedLabel = "",
-      globalFilter = "",
-      sortBy = [],
-    }: IHostLoadOptions) => {
+    loadAll: (options: IHostLoadOptions | undefined) => {
       const { HOSTS, LABEL_HOSTS } = endpoints;
+      const page = options?.page || 0;
+      const perPage = options?.perPage || 100;
+      const selectedLabel = options?.selectedLabel || "";
+      const globalFilter = options?.globalFilter || "";
+      const sortBy = options?.sortBy || [];
 
       // TODO: add this query param logic to client class
       const pagination = `page=${page}&per_page=${perPage}`;

--- a/frontend/fleet/entities/hosts.ts
+++ b/frontend/fleet/entities/hosts.ts
@@ -1,10 +1,5 @@
 import endpoints from "fleet/endpoints";
-import { IHost } from "interfaces/host";
-
-interface ISortOption {
-  id: number;
-  direction: string;
-}
+import { IHost, IHostLoadOptions } from "interfaces/host";
 
 export default (client: any) => {
   return {
@@ -30,13 +25,13 @@ export default (client: any) => {
         .authenticatedGet(endpoint)
         .then((response: any) => response.host);
     },
-    loadAll: (
+    loadAll: ({
       page = 0,
       perPage = 100,
-      selected = "",
+      selectedLabel = "",
       globalFilter = "",
-      sortBy: ISortOption[] = []
-    ) => {
+      sortBy = [],
+    }: IHostLoadOptions) => {
       const { HOSTS, LABEL_HOSTS } = endpoints;
 
       // TODO: add this query param logic to client class
@@ -57,20 +52,20 @@ export default (client: any) => {
 
       let endpoint = "";
       const labelPrefix = "labels/";
-      if (selected.startsWith(labelPrefix)) {
-        const lid = selected.substr(labelPrefix.length);
+      if (selectedLabel.startsWith(labelPrefix)) {
+        const lid = selectedLabel.substr(labelPrefix.length);
         endpoint = `${LABEL_HOSTS(
           parseInt(lid, 10)
         )}?${pagination}${searchQuery}${orderKeyParam}${orderDirection}`;
       } else {
         let selectedFilter = "";
         if (
-          selected === "new" ||
-          selected === "online" ||
-          selected === "offline" ||
-          selected === "mia"
+          selectedLabel === "new" ||
+          selectedLabel === "online" ||
+          selectedLabel === "offline" ||
+          selectedLabel === "mia"
         ) {
-          selectedFilter = `&status=${selected}`;
+          selectedFilter = `&status=${selectedLabel}`;
         }
         endpoint = `${HOSTS}?${pagination}${selectedFilter}${searchQuery}${orderKeyParam}${orderDirection}`;
       }

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -35,17 +35,4 @@ export interface IHost {
   uuid: string;
   seen_time: string;
   users: IHostUser[];
-};
-
-interface ISortOption {
-  id: number;
-  direction: string;
 }
-
-export interface IHostLoadOptions {
-  page: number,
-  perPage: number,
-  selectedLabel: string,
-  globalFilter: string,
-  sortBy: ISortOption[],
-};

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -35,4 +35,17 @@ export interface IHost {
   uuid: string;
   seen_time: string;
   users: IHostUser[];
+};
+
+interface ISortOption {
+  id: number;
+  direction: string;
 }
+
+export interface IHostLoadOptions {
+  page: number,
+  perPage: number,
+  selectedLabel: string,
+  globalFilter: string,
+  sortBy: ISortOption[],
+};

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.jsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.jsx
@@ -198,7 +198,13 @@ export class ManageHostsPage extends PureComponent {
     this.setState({ searchQuery });
 
     dispatch(
-      getHosts(pageIndex, pageSize, selectedFilter, searchQuery, sortBy)
+      getHosts({
+        page: pageIndex,
+        perPage: pageSize,
+        selectedLabel: selectedFilter,
+        globalFilter: searchQuery,
+        sortBy,
+      })
     );
   };
 
@@ -309,9 +315,7 @@ export class ManageHostsPage extends PureComponent {
             ? `Hosts successfully removed from teams.`
             : `Hosts successfully transferred to  ${team.name}.`;
         dispatch(renderFlash("success", successMessage));
-
-        // TODO: make getHosts call better to accept optional params
-        dispatch(getHosts(undefined, undefined, selectedFilter, searchQuery));
+        dispatch(getHosts({ selectedLabel: selectedFilter, searchQuery }));
       })
       .catch(() => {
         dispatch(

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.jsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.jsx
@@ -309,7 +309,9 @@ export class ManageHostsPage extends PureComponent {
             ? `Hosts successfully removed from teams.`
             : `Hosts successfully transferred to  ${team.name}.`;
         dispatch(renderFlash("success", successMessage));
-        dispatch(getHosts());
+
+        // TODO: make getHosts call better to accept optional params
+        dispatch(getHosts(undefined, undefined, selectedFilter, searchQuery));
       })
       .catch(() => {
         dispatch(

--- a/frontend/redux/nodes/components/ManageHostsPage/actions.js
+++ b/frontend/redux/nodes/components/ManageHostsPage/actions.js
@@ -66,15 +66,15 @@ export const getLabels = () => (dispatch) => {
   dispatch(silentGetStatusLabelCounts);
 };
 
-export const getHosts = (
+export const getHosts = ({
   page,
   perPage,
   selectedLabel,
   globalFilter,
-  sortBy
-) => (dispatch) => {
+  sortBy,
+}) => (dispatch) => {
   dispatch(
-    hostActions.loadAll(page, perPage, selectedLabel, globalFilter, sortBy)
+    hostActions.loadAll({ page, perPage, selectedLabel, globalFilter, sortBy })
   );
 };
 


### PR DESCRIPTION
Closes #1269

Manage Hosts page re-routes to current label and query after changing a host's team.