### PR TITLE
Skip match to not add empty searches

### DIFF
--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -536,7 +536,7 @@ func isChildForeignKeyError(err error) bool {
 //
 // The input columns must be sanitized if they are provided by the user.
 func searchLike(sql string, params []interface{}, match string, columns ...string) (string, []interface{}) {
-	if len(columns) == 0 {
+	if len(columns) == 0 || len(match) == 0 {
 		return sql, params
 	}
 


### PR DESCRIPTION
I was debugging the list host issue, and I saw the query ended up having a few `hostname LIKE '%%'`, which made no sense. This removes them.

I want to think the db engine would ignore those checks, but just in case...