### PR TITLE
Add "Asking questions about your devices" tutorial to "Using Fleet" documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Fleet UI is now available at http://localhost:1337.
 
 #### Now what?
 
-Check out the [Ask questions about your devices tutorial](./docs/1-Using-Fleet/tutorials/Ask-questions-about-your-devices.md) to learn where to see your devices in Fleet, how to add Fleet's standard query library, and how to asking questions about your devices by running queries.
+Check out the [Ask questions about your devices tutorial](./docs/1-Using-Fleet/tutorials/Ask-questions-about-your-devices.md) to learn where to see your devices in Fleet, how to add Fleet's standard query library, and how to ask questions about your devices by running queries.
 
 ## Team
 Fleet is [independently backed](https://linkedin.com/company/fleetdm) and actively maintained with the help of many amazing [contributors](https://github.com/fleetdm/fleet/graphs/contributors).

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Fleet UI is now available at http://localhost:1337.
 
 #### Now what?
 
-Check out the [Ask questions about your devices tutorial](./docs/1-Using-fleet/tutorials/ask-questions-about-your-devices.md) to learn where to see your devices in Fleet, how to add Fleet's standard query library, and how to asking questions about your devices by running queries.
+Check out the [Ask questions about your devices tutorial](./docs/1-Using-Fleet/tutorials/ask-questions-about-your-devices.md) to learn where to see your devices in Fleet, how to add Fleet's standard query library, and how to asking questions about your devices by running queries.
 
 ## Team
 Fleet is [independently backed](https://linkedin.com/company/fleetdm) and actively maintained with the help of many amazing [contributors](https://github.com/fleetdm/fleet/graphs/contributors).

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Fleet UI is now available at http://localhost:1337.
 
 #### Now what?
 
-Check out the [Ask questions about your devices tutorial](./docs/1-Using-Fleet/tutorials/ask-questions-about-your-devices.md) to learn where to see your devices in Fleet, how to add Fleet's standard query library, and how to asking questions about your devices by running queries.
+Check out the [Ask questions about your devices tutorial](./docs/1-Using-Fleet/tutorials/Ask-questions-about-your-devices.md) to learn where to see your devices in Fleet, how to add Fleet's standard query library, and how to asking questions about your devices by running queries.
 
 ## Team
 Fleet is [independently backed](https://linkedin.com/company/fleetdm) and actively maintained with the help of many amazing [contributors](https://github.com/fleetdm/fleet/graphs/contributors).

--- a/README.md
+++ b/README.md
@@ -20,12 +20,9 @@ sudo fleetctl preview
 
 The Fleet UI is now available at http://localhost:1337.
 
-#### Your first query
-Ready to run your first query?  Target some of your sample hosts and try it out:
-<img width="800" alt="Screenshot of query editor" src="https://user-images.githubusercontent.com/618009/111853677-099de680-88ea-11eb-90bb-f5cd787f1f15.png"/>
+#### Now what?
 
-#### Using real devices
-For convenience, the demo includes a few simulated Linux hosts.  To query a real device, [install the osquery agent](https://github.com/fleetdm/orbit).
+Check out the [Ask questions about your devices tutorial](./docs/1-Using-fleet/tutorials/ask-questions-about-your-devices.md) to learn where to see your devices in Fleet, how to add Fleet's standard query library, and how to asking questions about your devices by running queries.
 
 ## Team
 Fleet is [independently backed](https://linkedin.com/company/fleetdm) and actively maintained with the help of many amazing [contributors](https://github.com/fleetdm/fleet/graphs/contributors).

--- a/docs/1-Using-Fleet/1-Fleet-UI.md
+++ b/docs/1-Using-Fleet/1-Fleet-UI.md
@@ -4,8 +4,7 @@
 
 ## Scheduling queries
 
-The Fleet application allows you to schedule queries. This way these queries will run on an on-going basis against the hosts that you have installed osquery on. To schedule specific queries in Fleet you must organize these queries into "Query Packs". To view all saved packs and perhaps create a new pack, select "Packs" from the top nav. Packs are usually organized by the general class of instrumentation that you're trying to perform.
-
+The Fleet application allows you to schedule queries. This way these queries will run on an ongoing basis against the hosts that you have installed osquery on. To schedule specific queries in Fleet, you can organize these queries into "Query Packs". To view all saved packs and perhaps create a new pack, select "Schedule" from the top nav.
 ![Manage Packs](https://raw.githubusercontent.com/fleetdm/fleet/main/docs/images/manage-packs.png)
 
 If you select a pack from the list, you can quickly enable and disable the entire pack, or you can configure it further.
@@ -16,7 +15,7 @@ When you edit a pack, you can decide which targets you would like to execute the
 
 ![Edit Pack Targets](https://raw.githubusercontent.com/fleetdm/fleet/main/docs/images/edit-pack-targets.png)
 
-To add queries to a pack, use the right-hand sidebar. You can take an existing scheduled query and add it to the pack. You must also define a few key details such as:
+To add queries to a pack, use the right-hand sidebar. You can take an existing scheduled query and add it to the pack. You can also define a few key details such as:
 
 - interval: how often should the query be executed?
 - logging: which osquery logging format would you like to use?

--- a/docs/1-Using-Fleet/1-Fleet-UI.md
+++ b/docs/1-Using-Fleet/1-Fleet-UI.md
@@ -1,28 +1,10 @@
 # Fleet UI
-- [Running queries](#running-queries)
 - [Scheduling queries](#scheduling-queries)
 - [Configuring agent options](#configuring-agent-options)
 
-## Running queries
-
-The Fleet application allows you to query hosts that you have installed osquery on. To run a new query, navigate to "Queries" from the top nav, and then hit the "Create new query" button from the Queries page. From here, you can compose your query, view SQL table documentation via the sidebar, select arbitrary hosts (or groups of hosts), and execute your query. As results are returned, they will populate the interface in real time. You can use the integrated filtering tool to perform useful initial analytics and easily export the entire dataset for offline analysis.
-
-![Distributed new query with local filter](https://raw.githubusercontent.com/fleetdm/fleet/main/docs/images/distributed-new-query-with-local-filter.png)
-
-After you've composed a query that returns the information you were looking for, you may choose to save the query. You can still continue to execute the query on whatever set of hosts you would like after you have saved the query.
-
-![Distributed saved query with local filter](https://raw.githubusercontent.com/fleetdm/fleet/main/docs/images/distributed-saved-query-with-local-filter.png)
-
-Saved queries can be accessed from the "Query" section of the top nav. Here, you will find all of the queries you've ever saved. You can filter the queries by query name, so name your queries something memorable!
-
-![Manage Queries](https://raw.githubusercontent.com/fleetdm/fleet/main/docs/images/manage-queries.png)
-
-To learn more about scheduling queries so that they run on an on-going basis, see the scheduling queries guide below.
-
-
 ## Scheduling queries
 
-As discussed in the running queries documentation, you can use the Fleet application to create, execute, and save osquery queries. You can organize these queries into "Query Packs". To view all saved packs and perhaps create a new pack, select "Packs" from the top nav. Packs are usually organized by the general class of instrumentation that you're trying to perform.
+The Fleet application allows you to schedule queries. This way these queries will run on an on-going basis against the hosts that you have installed osquery on. To schedule specific queries in Fleet you must organize these queries into "Query Packs". To view all saved packs and perhaps create a new pack, select "Packs" from the top nav. Packs are usually organized by the general class of instrumentation that you're trying to perform.
 
 ![Manage Packs](https://raw.githubusercontent.com/fleetdm/fleet/main/docs/images/manage-packs.png)
 

--- a/docs/1-Using-Fleet/tutorials/Ask-questions-about-your-devices.md
+++ b/docs/1-Using-Fleet/tutorials/Ask-questions-about-your-devices.md
@@ -22,13 +22,13 @@ Fleet uses queries to determine the information to return from your devices. Put
 
 > Fleet facilitates providing the answer to these questions by communicating to the osquery agent that runs on any device. To learn more about osquery, check out [the osquery documentation](https://osquery.readthedocs.io/en/stable/).
 
-In the Fleet, select the "Queries" tab from the top navigation bar. You should see an empty "Queries" table. This is because you don't have any queries yet in your Fleet.
+In Fleet, select the "Queries" tab from the top navigation bar. You should see an empty "Queries" table. This is because you don't have any queries yet in your Fleet.
 
 We'll now populate your Fleet with Fleet's standard query library.
 
 First, head to the following file in the fleetdm/fleet GitHub repository: https://github.com/fleetdm/fleet/blob/main/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
 
-Copy the contents of this file into a new file on you local computer called `standard-query-library.yml`. Please take note on where this new file is located in your local filesystem.
+Copy the contents of this file into a new file on you local computer called `standard-query-library.yml`. Please note where this file is located in your local filesystem.
 
 > You can manage your Fleet with configuration files in yaml syntax. This concept might be familiar to those that have used Kubernetes or another tool that offers yaml configuration files. Checkout [the configuration file documentation](../configuration-files/README.md) for more information on managing Fleet with configuration files.
 
@@ -48,9 +48,9 @@ Import the queries into fleet by running the following command:
 fleetctl apply -f standard-query-library.yml
 ```
 
-If you received a message that looks like `open standard-query-library.yml: no such file or directory` you may need to confirm the absolute path to your `standard-query-library.yml` file and change this in the command above.
+> If you received a message that looks like `open standard-query-library.yml: no such file or directory` you may need to confirm the absolute path to your `standard-query-library.yml` file and change this in the command above.
 
-Success! Now if you refresh the **Queries** page in the Fleet UI you should see the "Queries" table populated with Fleet's Standard query library.
+Success! Now, refresh the **Queries** page in the Fleet. You should see the "Queries" table populated with Fleet's Standard query library.
 
 ### Asking questions by running queries
 
@@ -62,11 +62,11 @@ Now, you're going to ask the following questions about the simulated, Linux host
 
 To answer these questions with Fleet, you're going to run the following query: "Detect Linux hosts with high severity vulnerable versions of OpenSSL." 
 
-On the **Queries** page, find this query by entering the query's name in the search bar. In the "Queries" table, select this query's row and then select "Edit or run query" in the right side bar to navigate to the **Edit or run query** page.
+On the **Queries** page, find this query by entering the query's name in the search bar. In the "Queries" table, select this query to navigate to the **Edit or run query** page.
 
-Next, select the "Select targets" dropdown and then select the purple "+" icon to the right of "All hosts." This means we will be attempting to run this query against all hosts connected to your Fleet.
+Next, select the "Select targets" dropdown and then select the purple "+" icon to the right of "All hosts." This means we'll be attempting to run this query against all hosts connected to your Fleet.
 
-Next, select the "Run" button to start the query. The query may take several seconds to complete because Fleet is waiting for the osquery agents to respond with results.
+Next, select the "Run" button to run the query. The query may take several seconds to complete because Fleet must wait for the osquery agents to respond with results.
 
 > Fleet's query response time is inherently variable because of osquery's heartbeat response time. This helps prevent performance issues on hosts.
 

--- a/docs/1-Using-Fleet/tutorials/Ask-questions-about-your-devices.md
+++ b/docs/1-Using-Fleet/tutorials/Ask-questions-about-your-devices.md
@@ -50,7 +50,7 @@ fleetctl apply -f standard-query-library.yml
 
 > If you received a message that looks like `open standard-query-library.yml: no such file or directory` you may need to confirm the absolute path to your `standard-query-library.yml` file and change this in the command above.
 
-Success! Now, refresh the **Queries** page in the Fleet. You should see the "Queries" table populated with Fleet's Standard query library.
+Success! Now, refresh the **Queries** page in the Fleet. You should see the "Queries" table populated with Fleet's standard query library.
 
 ### Asking questions by running queries
 
@@ -71,13 +71,13 @@ Next, select the "Run" button to run the query. The query may take several secon
 > Fleet's query response time is inherently variable because of osquery's heartbeat response time. This helps prevent performance issues on hosts.
 
 When the query has finished, you should see 4 columns and several rows in the "Results" table:
-- The "hostname" column answers...which device responded for a given row of results? 
+- The "hostname" column answers: which device responded for a given row of results? 
 
-- The "name" column answers...what is the name of the installed software item? The query you just ran asked for all software items that contain "openssl" in their name, so each row in this column should contain "openssl."
+- The "name" column answers: what is the name of the installed software item? The query you just ran asked for all software items that contain "openssl" in their name, so each row in this column should contain "openssl."
 
-- The "source" column answers...what osquery table is the result coming from? For more information on the table's available in osquery, check out the [osquery schema documentation](https://osquery.io/schema).
+- The "source" column answers: what osquery table is the result coming from? For more information on the table's available in osquery, check out the [osquery schema documentation](https://osquery.io/schema).
 
-- The "version" column answers...which version of the software item was detected on this device?
+- The "version" column answers: which version of the software item was detected on this device?
 
 The "Results" table presented in Fleet answers our first question of interest which was "What version of OpenSSL is installed on each device if any?"
 
@@ -105,5 +105,5 @@ Next, you can compare the results in the "version" column to table below which i
 | 1.0.1-1.0.1h                                              | [CVE-2014-3511](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-3511) |
 | 1.0.1-1.0.1h                                              | [CVE-2014-3511](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-3511) |
 
-Do any of the simulated, Linux hosts have a high severity vulnerable version of OpenSSL installed? If the answers is yes, don't worry. The devices are running in a simulated Docker environment and do not provide any additional vectors for performing malicious actions against your device.
+Do any of the simulated, Linux hosts have a high severity vulnerable version of OpenSSL installed? If the answer is yes, don't worry. The devices are running in a simulated Docker environment and do not provide any additional vectors for performing malicious actions against your device.
 

--- a/docs/1-Using-Fleet/tutorials/Ask-questions-about-your-devices.md
+++ b/docs/1-Using-Fleet/tutorials/Ask-questions-about-your-devices.md
@@ -4,25 +4,25 @@
 
 This tutorial covers the following Fleet concepts:
 
-- Where your devices are presented in Fleet
-- How to add queries to Fleet by importing Fleet's standard query library
+- Where to see your devices in Fleet
+- How to add Fleet's standard query library
 - How to asking questions about your devices by running queries
 
 ### Devices in Fleet
 
-Immediately after logging in to Fleet, you're presented with the "Hosts" page. In Fleet, devices are called "hosts." 
+Immediately after logging in to Fleet, you're presented with the **Hosts** page. In Fleet, devices are called "hosts." 
 
-On this page you'll see 7 hosts. These hosts are simulated devices and, like the Fleet preview environment, they're running locally on your computer in Docker.
+On this page you'll see 7 hosts. These hosts are simulated, Linux devices and, like the Fleet preview environment, they're running locally on your computer in Docker.
 
-In this tutorial we'll be asking questions about these devices by running several queries.
+In this tutorial we'll be asking questions about these devices by running some queries against them.
 
 ### Add queries
 
 Fleet uses queries to determine the information to return from your devices. Put simply, a query is a specific question you can ask about your devices. 
 
-> Fleet facilitates providing the answer to these questions by communicating to the osquery agent that rungs on any device. To learn more about osquery, check out [the osquery documentation](https://osquery.readthedocs.io/en/stable/).
+> Fleet facilitates providing the answer to these questions by communicating to the osquery agent that runs on any device. To learn more about osquery, check out [the osquery documentation](https://osquery.readthedocs.io/en/stable/).
 
-In the Fleet, select the "Query" button from the top navigation bar. You should see an empty table. This is because you don't have any queries yet in your Fleet.
+In the Fleet, select the "Queries" tab from the top navigation bar. You should see an empty "Queries" table. This is because you don't have any queries yet in your Fleet.
 
 We'll now populate your Fleet with Fleet's standard query library.
 
@@ -30,9 +30,9 @@ First, head to the following file in the fleetdm/fleet GitHub repository: https:
 
 Copy the contents of this file into a new file on you local computer called `standard-query-library.yml`. Please take note on where this new file is located in your local filesystem.
 
-> You can manage your Fleet with configuration files in yaml syntax. This concept might be familiar to those that have used Kubernetes or a tool that offers configuration files. Checkout [the configuration file documentation](../configuration-files/README.md) for more information on managing Fleet with configuration files.
+> You can manage your Fleet with configuration files in yaml syntax. This concept might be familiar to those that have used Kubernetes or another tool that offers yaml configuration files. Checkout [the configuration file documentation](../configuration-files/README.md) for more information on managing Fleet with configuration files.
 
-Now, we're going to use `fleetctl` to import the queries into Fleet.
+Now, we're going to use the `fleetctl` command-line tool to import the queries into Fleet.
 
 Login to `fleetctl` by running the following command in your terminal window:
 
@@ -48,6 +48,62 @@ Import the queries into fleet by running the following command:
 fleetctl apply -f standard-query-library.yml
 ```
 
-If you received a message that looks like `open standard-query-library.yml: no such file or directory` you may need to confirm the absolute path to your `standard-query-library.yml` file.
+If you received a message that looks like `open standard-query-library.yml: no such file or directory` you may need to confirm the absolute path to your `standard-query-library.yml` file and change this in the command above.
 
+Success! Now if you refresh the **Queries** page in the Fleet UI you should see the "Queries" table populated with Fleet's Standard query library.
+
+### Asking questions by running queries
+
+Now, you're going to ask the following questions about the simulated, Linux hosts connected to your Fleet:
+
+1. What version of OpenSSL is installed on each device if any?
+
+2. Do these devices have a high severity vulnerable version of OpenSSL installed?
+
+To answer these questions with Fleet, you're going to run the following query: "Detect Linux hosts with high severity vulnerable versions of OpenSSL." 
+
+On the **Queries** page, find this query by entering the query's name in the search bar. In the "Queries" table, select this query's row and then select "Edit or run query" in the right side bar to navigate to the **Edit or run query** page.
+
+Next, select the "Select targets" dropdown and then select the purple "+" icon to the right of "All hosts." This means we will be attempting to run this query against all hosts connected to your Fleet.
+
+Next, select the "Run" button to start the query. The query may take several seconds to complete because Fleet is waiting for the osquery agents to respond with results.
+
+> Fleet's query response time is inherently variable because of osquery's heartbeat response time. This helps prevent performance issues on hosts.
+
+When the query has finished, you should see 4 columns and several rows in the "Results" table:
+- The "hostname" column answers...which device responded for a given row of results? 
+
+- The "name" column answers...what is the name of the installed software item? The query you just ran asked for all software items that contain "openssl" in their name, so each row in this column should contain "openssl."
+
+- The "source" column answers...what osquery table is the result coming from? For more information on the table's available in osquery, check out the [osquery schema documentation](https://osquery.io/schema).
+
+- The "version" column answers...which version of the software item was detected on this device?
+
+The "Results" table presented in Fleet answers our first question of interest which was "What version of OpenSSL is installed on each device if any?"
+
+Next, you can compare the results in the "version" column to table below which includes the high severity vulnerabilities reported by [OpenSSL](https://www.openssl.org/news/vulnerabilities.html).
+
+
+| OpenSSL version range                                                  | Vulnerability (CVE)                                                                           |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| 1.1.1h-1.1.1j                                             | [CVE-2021-3450](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3450) |
+| 1.1.1-1.1.1j                                              | [CVE-2021-3449](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3449) |
+| 1.1.1-1.1.1h and 1.0.2-1.0.2w                             | [CVE-2020-1971](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1971) |
+| 1.1.1d-1.1.1f                                             | [CVE-2020-1967](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1967) |
+| 1.1.1-1.1.1d and 1.0.2-1.0.2t                             | [CVE-2019-1551](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1551) |
+| 1.1.1-1.1.1c                                              | [CVE-2019-1549](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1549) |
+| 1.1.0-1.1.0d                                              | [CVE-2017-3733](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-3733) |
+| 1.1.0-1.1.0b                                              | [CVE-2016-7054](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-7054) |
+| 1.1.0 and 1.0.2-1.0.2h and 1.0.1-1.0.1t                   | [CVE-2016-6304](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-6304) |
+| 1.0.2-1.0.2b and 1.0.1-1.0.1n                             | [CVE-2016-2108](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2108) |
+| 1.0.2-1.0.2f and 1.0.1-1.0.1r                             | [CVE-2016-0800](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0800) |
+| 1.0.2 and 1.0.1-1.0.1l and 1.0.0-1.0.0q and 0.9.8-0.9.8ze | [CVE-2016-0703](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0703) |
+| 1.0.2-1.0.2e                                              | [CVE-2016-0701](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0701) |
+| 1.0.2b-1.0.2c and 1.0.1n-1.0.1o                           | [CVE-2015-1793](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-1793) |
+| 1.0.2                                                     | [CVE-2015-0291](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-0291) |
+| 1.0.1-1.0.1i                                              | [CVE-2014-3513](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-3513) |
+| 1.0.1-1.0.1h                                              | [CVE-2014-3511](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-3511) |
+| 1.0.1-1.0.1h                                              | [CVE-2014-3511](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-3511) |
+
+Do any of the simulated, Linux hosts have a high severity vulnerable version of OpenSSL installed? If the answers is yes, don't worry. The devices are running in a simulated Docker environment and do not provide any additional vectors for performing malicious actions against your device.
 

--- a/docs/1-Using-Fleet/tutorials/Ask-questions-about-your-devices.md
+++ b/docs/1-Using-Fleet/tutorials/Ask-questions-about-your-devices.md
@@ -1,0 +1,53 @@
+# Ask questions about your devices
+
+> This tutorial assumes that you have a preview environment of Fleet up and running. Check out [the "Try Fleet" instructions](../../../README.md#try-fleet) on how to start a preview environment of Fleet.
+
+This tutorial covers the following Fleet concepts:
+
+- Where your devices are presented in Fleet
+- How to add queries to Fleet by importing Fleet's standard query library
+- How to asking questions about your devices by running queries
+
+### Devices in Fleet
+
+Immediately after logging in to Fleet, you're presented with the "Hosts" page. In Fleet, devices are called "hosts." 
+
+On this page you'll see 7 hosts. These hosts are simulated devices and, like the Fleet preview environment, they're running locally on your computer in Docker.
+
+In this tutorial we'll be asking questions about these devices by running several queries.
+
+### Add queries
+
+Fleet uses queries to determine the information to return from your devices. Put simply, a query is a specific question you can ask about your devices. 
+
+> Fleet facilitates providing the answer to these questions by communicating to the osquery agent that rungs on any device. To learn more about osquery, check out [the osquery documentation](https://osquery.readthedocs.io/en/stable/).
+
+In the Fleet, select the "Query" button from the top navigation bar. You should see an empty table. This is because you don't have any queries yet in your Fleet.
+
+We'll now populate your Fleet with Fleet's standard query library.
+
+First, head to the following file in the fleetdm/fleet GitHub repository: https://github.com/fleetdm/fleet/blob/main/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml
+
+Copy the contents of this file into a new file on you local computer called `standard-query-library.yml`. Please take note on where this new file is located in your local filesystem.
+
+> You can manage your Fleet with configuration files in yaml syntax. This concept might be familiar to those that have used Kubernetes or a tool that offers configuration files. Checkout [the configuration file documentation](../configuration-files/README.md) for more information on managing Fleet with configuration files.
+
+Now, we're going to use `fleetctl` to import the queries into Fleet.
+
+Login to `fleetctl` by running the following command in your terminal window:
+
+```
+fleetctl login
+```
+
+Use the same `admin@example.com` email and `admin123#` password when prompted.
+
+Import the queries into fleet by running the following command:
+
+```
+fleetctl apply -f standard-query-library.yml
+```
+
+If you received a message that looks like `open standard-query-library.yml: no such file or directory` you may need to confirm the absolute path to your `standard-query-library.yml` file.
+
+


### PR DESCRIPTION
This PR includes a tutorial to link to immediately following completion of the "Try Fleet" section of the top-level README.

This tutorial is the first step at bridging the gaps between trying Fleet, getting to know Fleet in an enterprise setting, and deploying Fleet.

- Add "tutorials" subdirectory 
- Add walkthrough
- Remove duplicate documentation from "Fleet UI" section
- Link to walkthrough from top-level README

Resolves fleetdm/confidential/issues/356