### PR TITLE
Only log distributed queries ingestion errors (except for one case)

### DIFF
--- a/changes/log-errors-when-injesting-distributed-query-results
+++ b/changes/log-errors-when-injesting-distributed-query-results
@@ -1,0 +1,1 @@
+* Only log errors and try to process all distributed query results from hosts instead of erroring out.

--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -1114,11 +1114,11 @@ func (svc *Service) SubmitDistributedQueryResults(ctx context.Context, results f
 		return osqueryError{message: "internal error: missing host from request context"}
 	}
 
-	// Check for label queries and if so, load host additional. If we don't do
-	// this, we will end up unintentionally dropping any existing host
-	// additional info.
+	// Check for host details queries and if so, load host additional.
+	// If we don't do this, we will end up unintentionally dropping
+	// any existing host additional info.
 	for query := range results {
-		if strings.HasPrefix(query, hostLabelQueryPrefix) {
+		if strings.HasPrefix(query, hostDetailQueryPrefix) {
 			fullHost, err := svc.ds.Host(host.ID)
 			if err != nil {
 				// leave this error return here, we don't want to drop host additionals

--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -1165,7 +1165,7 @@ func (svc *Service) SubmitDistributedQueryResults(ctx context.Context, results f
 		host.LabelUpdatedAt = svc.clock.Now()
 		err = svc.ds.RecordLabelQueryExecutions(&host, labelResults, svc.clock.Now())
 		if err != nil {
-			logging.WithExtras(ctx, "save-labels-err", err)
+			logging.WithErr(ctx, err)
 		}
 	}
 
@@ -1174,16 +1174,17 @@ func (svc *Service) SubmitDistributedQueryResults(ctx context.Context, results f
 		host.DetailUpdatedAt = svc.clock.Now()
 		additionalJSON, err := json.Marshal(additionalResults)
 		if err != nil {
-			logging.WithExtras(ctx, "marshal-additional-err", err)
+			logging.WithErr(ctx, err)
+		} else {
+			additional := json.RawMessage(additionalJSON)
+			host.Additional = &additional
 		}
-		additional := json.RawMessage(additionalJSON)
-		host.Additional = &additional
 	}
 
 	if host.Modified {
 		err = svc.ds.SaveHost(&host)
 		if err != nil {
-			logging.WithExtras(ctx, "update-host-details-err", err)
+			logging.WithErr(ctx, err)
 		}
 	}
 

--- a/server/service/service_osquery_test.go
+++ b/server/service/service_osquery_test.go
@@ -832,6 +832,10 @@ func TestDetailQueries(t *testing.T) {
 		return nil
 	}
 
+	ds.HostFunc = func(id uint) (*fleet.Host, error) {
+		return &host, nil
+	}
+
 	// Verify that results are ingested properly
 	svc.SubmitDistributedQueryResults(ctx, results, map[string]fleet.OsqueryStatus{}, map[string]string{})
 

--- a/server/service/service_osquery_test.go
+++ b/server/service/service_osquery_test.go
@@ -645,6 +645,10 @@ func TestDetailQueriesWithEmptyStrings(t *testing.T) {
 		return nil
 	}
 
+	ds.HostFunc = func(id uint) (*fleet.Host, error) {
+		return &host, nil
+	}
+
 	// Verify that results are ingested properly
 	svc.SubmitDistributedQueryResults(ctx, results, map[string]fleet.OsqueryStatus{}, map[string]string{})
 

--- a/server/service/service_osquery_test.go
+++ b/server/service/service_osquery_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -13,8 +14,10 @@ import (
 	"time"
 
 	"github.com/WatchBeam/clock"
+	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/config"
 	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
+	fleetLogging "github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/live_query"
@@ -23,6 +26,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/pubsub"
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1820,4 +1824,75 @@ func TestGetHostIdentifier(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestDistributedQueriesLogsManyErrors(t *testing.T) {
+	buf := new(bytes.Buffer)
+	logger := log.NewJSONLogger(buf)
+	logger = level.NewFilter(logger, level.AllowDebug())
+	ds := new(mock.Store)
+	svc := newTestService(ds, nil, nil)
+
+	host := &fleet.Host{Platform: "darwin"}
+
+	ds.SaveHostFunc = func(host *fleet.Host) error {
+		return authz.CheckMissingWithResponse(nil)
+	}
+	ds.RecordLabelQueryExecutionsFunc = func(host *fleet.Host, results map[uint]bool, t time.Time) error {
+		return errors.New("something went wrong")
+	}
+
+	lCtx := &fleetLogging.LoggingContext{}
+	ctx := fleetLogging.NewContext(context.Background(), lCtx)
+	ctx = hostctx.NewContext(ctx, *host)
+
+	err := svc.SubmitDistributedQueryResults(
+		ctx,
+		map[string][]map[string]string{
+			hostLabelQueryPrefix + "1": {{"col1": "val1"}},
+		},
+		map[string]fleet.OsqueryStatus{},
+		map[string]string{},
+	)
+	assert.Nil(t, err)
+
+	lCtx.Log(ctx, logger)
+
+	logs := buf.String()
+	parts := strings.Split(strings.TrimSpace(logs), "\n")
+	require.Len(t, parts, 1)
+	logData := make(map[string]json.RawMessage)
+	require.NoError(t, json.Unmarshal([]byte(parts[0]), &logData))
+	assert.Equal(t, json.RawMessage(`["something went wrong"]`), logData["err"])
+	assert.Equal(t, json.RawMessage(`["Missing authorization check"]`), logData["internal"])
+}
+
+func TestDistributedQueriesReloadsHostIfDetailsAreIn(t *testing.T) {
+	ds := new(mock.Store)
+	svc := newTestService(ds, nil, nil)
+
+	host := &fleet.Host{ID: 42, Platform: "darwin"}
+	ip := "1.1.1.1"
+
+	ds.SaveHostFunc = func(host *fleet.Host) error {
+		assert.Equal(t, ip, host.PrimaryIP)
+		return nil
+	}
+	ds.HostFunc = func(id uint) (*fleet.Host, error) {
+		require.Equal(t, uint(42), id)
+		return &fleet.Host{ID: 42, Platform: "darwin", PrimaryIP: ip}, nil
+	}
+
+	ctx := hostctx.NewContext(context.Background(), *host)
+
+	err := svc.SubmitDistributedQueryResults(
+		ctx,
+		map[string][]map[string]string{
+			hostDetailQueryPrefix + "1": {{"col1": "val1"}},
+		},
+		map[string]fleet.OsqueryStatus{},
+		map[string]string{},
+	)
+	assert.Nil(t, err)
+	assert.True(t, ds.HostFuncInvoked)
 }


### PR DESCRIPTION
We don't want a bug in one part, keeping another part from working altogether.

Particularly, if we remove a label while a host is computing the results, then it'll fail here constantly.

There might be a case where we lose data though, possibly? Even then, it feels the best case rather than basically killing everything that comes from that host.

Meant to address errors such as: https://osquery.slack.com/archives/C01DXJL16D8/p1627688497036600?thread_ts=1627656787.010700&cid=C01DXJL16D8

If this looks reasonably, I'll add a test.