### PR TITLE
Improve handling of empty passphrase and initialized updates repo

### DIFF
--- a/ee/fleetctl/updates.go
+++ b/ee/fleetctl/updates.go
@@ -426,7 +426,7 @@ func (p *passphraseHandler) passphraseEnvName(role string) string {
 }
 
 func (p *passphraseHandler) getPassphraseFromEnv(role string) []byte {
-	if pass := os.Getenv(p.passphraseEnvName(role)); pass != "" {
+	if pass, ok := os.LookupEnv(p.passphraseEnvName(role)); ok {
 		return []byte(pass)
 	}
 

--- a/ee/fleetctl/updates_test.go
+++ b/ee/fleetctl/updates_test.go
@@ -1,0 +1,135 @@
+package eefleetctl
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/theupdateframework/go-tuf/data"
+	"github.com/urfave/cli/v2"
+)
+
+func TestPassphraseHandlerEnvironment(t *testing.T) {
+	// Not t.Parallel() due to modifications to environment.
+	testCases := []struct {
+		role       string
+		passphrase string
+	}{
+		{role: "root", passphrase: "rootpassphrase"},
+		{role: "timestamp", passphrase: "timestamp5#$#@"},
+		{role: "snapshot", passphrase: "snapshot$#@"},
+		{role: "targets", passphrase: "$#^#$@targets"},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.role, func(t *testing.T) {
+			tt := tt
+			t.Parallel()
+
+			handler := newPassphraseHandler()
+			envKey := fmt.Sprintf("FLEET_%s_PASSPHRASE", strings.ToUpper(tt.role))
+			require.NoError(t, os.Setenv(envKey, tt.passphrase))
+
+			passphrase, err := handler.getPassphrase(tt.role, false)
+			require.NoError(t, err)
+			assert.Equal(t, tt.passphrase, string(passphrase))
+
+			// Should work second time with cache
+			passphrase, err = handler.getPassphrase(tt.role, false)
+			require.NoError(t, err)
+			assert.Equal(t, tt.passphrase, string(passphrase))
+		})
+	}
+}
+
+func TestPassphraseHandlerEmpty(t *testing.T) {
+	// Not t.Parallel() due to modifications to environment.
+	handler := newPassphraseHandler()
+	require.NoError(t, os.Setenv("FLEET_ROOT_PASSPHRASE", ""))
+	_, err := handler.getPassphrase("root", false)
+	require.Error(t, err)
+}
+
+func setPassphrases(t *testing.T) {
+	t.Helper()
+	require.NoError(t, os.Setenv("FLEET_ROOT_PASSPHRASE", "root"))
+	require.NoError(t, os.Setenv("FLEET_TIMESTAMP_PASSPHRASE", "timestamp"))
+	require.NoError(t, os.Setenv("FLEET_TARGETS_PASSPHRASE", "targets"))
+	require.NoError(t, os.Setenv("FLEET_SNAPSHOT_PASSPHRASE", "snapshot"))
+}
+
+func runUpdatesCommand(args ...string) error {
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{UpdatesCommand()}
+	return app.Run(append([]string{os.Args[0], "updates"}, args...))
+}
+
+func TestUpdatesInit(t *testing.T) {
+	// Not t.Parallel() due to modifications to environment.
+	tmpDir, err := ioutil.TempDir("", "fleetctl-updates-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	setPassphrases(t)
+
+	require.NoError(t, runUpdatesCommand("init", "--path", tmpDir))
+
+	// Should fail with already initialized
+	require.Error(t, runUpdatesCommand("init", "--path", tmpDir))
+}
+
+func TestUpdatesInitKeysInitializedError(t *testing.T) {
+	// Not t.Parallel() due to modifications to environment.
+	tmpDir, err := ioutil.TempDir("", "fleetctl-updates-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	setPassphrases(t)
+
+	// Create an empty "keys" directory
+	require.NoError(t, os.Mkdir(filepath.Join(tmpDir, "keys"), os.ModePerm|os.ModeDir))
+	// Should fail with already initialized
+	require.Error(t, runUpdatesCommand("init", "--path", tmpDir))
+}
+
+func TestUpdatesFlow(t *testing.T) {
+	// Not t.Parallel() due to modifications to environment.
+	tmpDir, err := ioutil.TempDir("", "fleetctl-updates-test-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	setPassphrases(t)
+
+	require.NoError(t, runUpdatesCommand("init", "--path", tmpDir))
+	
+	// Capture stdout while running the updates roots command
+	func() {
+		stdout := os.Stdout
+		defer func() { os.Stdout = stdout }()
+
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stdout = w
+
+		require.NoError(t, runUpdatesCommand("roots", "--path", tmpDir))
+		require.NoError(t, w.Close())
+
+		out, err := ioutil.ReadAll(r)
+		require.NoError(t, err)
+
+		// Check output
+		var keys []data.Key
+		require.NoError(t, json.Unmarshal(out, &keys))
+		assert.Len(t, keys, 1)		
+		assert.Greater(t, len(keys[0].IDs()), 0)
+		assert.Equal(t, "ed25519", keys[0].Type)
+	}()
+
+	// TODO test the `add` and `timestamp` commands
+}

--- a/ee/fleetctl/updates_test.go
+++ b/ee/fleetctl/updates_test.go
@@ -72,9 +72,7 @@ func runUpdatesCommand(args ...string) error {
 
 func TestUpdatesInit(t *testing.T) {
 	// Not t.Parallel() due to modifications to environment.
-	tmpDir, err := ioutil.TempDir("", "fleetctl-updates-test-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	setPassphrases(t)
 
@@ -86,9 +84,7 @@ func TestUpdatesInit(t *testing.T) {
 
 func TestUpdatesInitKeysInitializedError(t *testing.T) {
 	// Not t.Parallel() due to modifications to environment.
-	tmpDir, err := ioutil.TempDir("", "fleetctl-updates-test-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	setPassphrases(t)
 
@@ -101,16 +97,13 @@ func TestUpdatesInitKeysInitializedError(t *testing.T) {
 func assertFileExists(t *testing.T, path string) {
 	t.Helper()
 	st, err := os.Stat(path)
-	if assert.NoError(t, err, "stat should succeed") {
-		assert.True(t, st.Mode().IsRegular(), "should be regular file: %s", path)
-	}
+	require.NoError(t, err, "stat should succeed")
+	assert.True(t, st.Mode().IsRegular(), "should be regular file: %s", path)
 }
 
 func TestUpdatesIntegration(t *testing.T) {
 	// Not t.Parallel() due to modifications to environment.
-	tmpDir, err := ioutil.TempDir("", "fleetctl-updates-test-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	setPassphrases(t)
 
@@ -134,7 +127,7 @@ func TestUpdatesIntegration(t *testing.T) {
 		// Check output
 		var keys []data.Key
 		require.NoError(t, json.Unmarshal(out, &keys))
-		assert.Len(t, keys, 1)
+		require.Len(t, keys, 1)
 		assert.Greater(t, len(keys[0].IDs()), 0)
 		assert.Equal(t, "ed25519", keys[0].Type)
 	}()


### PR DESCRIPTION
- Prevent usage of initialized keys.
- Reject empty passphrase.
- Add testing for updates commands.