### PR TITLE
Update usage of os.IsNotExist

### DIFF
--- a/cmd/fleetctl/config.go
+++ b/cmd/fleetctl/config.go
@@ -53,7 +53,7 @@ func contextFlag() cli.Flag {
 }
 
 func makeConfigIfNotExists(fp string) error {
-	if _, err := os.Stat(filepath.Dir(fp)); os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Dir(fp)); errors.Is(err, os.ErrNotExist) {
 		if err := os.Mkdir(filepath.Dir(fp), 0700); err != nil {
 			return err
 		}

--- a/server/logging/filesystem.go
+++ b/server/logging/filesystem.go
@@ -100,7 +100,7 @@ func (l *rawLogWriter) Write(b []byte) (int, error) {
 	if l.buff == nil || l.file == nil {
 		return 0, errors.New("filesystemLogWriter: can't write to closed file")
 	}
-	if _, statErr := os.Stat(l.file.Name()); os.IsNotExist(statErr) {
+	if _, statErr := os.Stat(l.file.Name()); errors.Is(statErr, os.ErrNotExist) {
 		f, err := os.OpenFile(l.file.Name(), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
 		if err != nil {
 			return 0, errors.Wrapf(err, "create file for filesystemLogWriter %s", l.file.Name())

--- a/server/vulnerabilities/cpe_test.go
+++ b/server/vulnerabilities/cpe_test.go
@@ -1,6 +1,7 @@
 package vulnerabilities
 
 import (
+	"errors"
 	"net/http"
 	"os"
 	"path"
@@ -61,7 +62,7 @@ func TestSyncCPEDatabase(t *testing.T) {
 	dbPath := path.Join(tempDir, "cpe.sqlite")
 
 	err = os.Remove(dbPath)
-	if !os.IsNotExist(err) {
+	if !errors.Is(err, os.ErrNotExist) {
 		require.NoError(t, err)
 	}
 

--- a/server/vulnerabilities/db.go
+++ b/server/vulnerabilities/db.go
@@ -1,6 +1,7 @@
 package vulnerabilities
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -73,7 +74,7 @@ const batchSize = 800
 
 func GenerateCPEDB(path string, items *cpedict.CPEList) error {
 	err := os.Remove(path)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 	db, err := CPEDB(path)


### PR DESCRIPTION
Per [godoc](https://pkg.go.dev/os#IsNotExist), this is the preferred method.