### PR TITLE
Add valid time units to Configuration documentation

### DIFF
--- a/docs/2-Deploying/2-Configuration.md
+++ b/docs/2-Deploying/2-Configuration.md
@@ -120,6 +120,8 @@ mysql:
 
 Basically, just capitalize the option and prepend `FLEET_` to it in order to get the environment variable. The conversion works the same the opposite way.
 
+All duration-based settings accept valid time units of `s`, `m`, `h`.
+
 ##### MySQL
 
 ###### `mysql_address`

--- a/docs/2-Deploying/2-Configuration.md
+++ b/docs/2-Deploying/2-Configuration.md
@@ -534,6 +534,8 @@ The size of the session key.
 
 The amount of time that a session should last for.
 
+Valid time units are `s`, `m`, `h`.
+
 - Default value: `4 hours`
 - Environment variable: `FLEET_SESSION_DURATION`
 - Config file format:
@@ -612,6 +614,8 @@ Setting this to a higher value can reduce baseline load on the Fleet server in l
 The interval at which Fleet will ask osquery agents to update host details (such as uptime, hostname, network interfaces, etc.)
 
 Setting this to a higher value can reduce baseline load on the Fleet server in larger deployments.
+
+Valid time units are `s`, `m`, `h`.
 
 - Default value: `1h`
 - Environment variable: `FLEET_OSQUERY_DETAIL_UPDATE_INTERVAL`

--- a/docs/2-Deploying/2-Configuration.md
+++ b/docs/2-Deploying/2-Configuration.md
@@ -600,6 +600,8 @@ The interval at which Fleet will ask osquery agents to update their results for 
 
 Setting this to a higher value can reduce baseline load on the Fleet server in larger deployments.
 
+Valid time units are `s`, `m`, `h`.
+
 - Default value: `1h`
 - Environment variable: `FLEET_OSQUERY_LABEL_UPDATE_INTERVAL`
 - Config file format:


### PR DESCRIPTION
- Specify valid time units of `s`, `m`, and `h` for the `session_duration`, `osquery_label_update_interval`, and `osquery_detail_update_interval` configuration options.
- Did not document `ns`, `us` (or `µs`), `ms` time units even though they are valid. This is because the hypothesis is that these smaller time units are rarely (if ever) used for these configuration options. @zwass do you think this is correct?