### PR TITLE
cmd/cpe: fix dropped error

### DIFF
--- a/cmd/cpe/generate.go
+++ b/cmd/cpe/generate.go
@@ -61,6 +61,7 @@ func main() {
 	panicif(err)
 
 	db, err := os.Open(dbPath)
+	panicif(err)
 	w := gzip.NewWriter(compressedDB)
 
 	_, err = io.Copy(w, db)


### PR DESCRIPTION
This fixes a dropped `err` variable in `cmd/cpe`.