### PR TITLE
Fix live query for observers

### DIFF
--- a/server/service/service_campaigns.go
+++ b/server/service/service_campaigns.go
@@ -185,7 +185,10 @@ type campaignStatus struct {
 func (svc Service) StreamCampaignResults(ctx context.Context, conn *websocket.Conn, campaignID uint) {
 	logging.WithExtras(ctx, "campaign_id", campaignID)
 
-	if err := svc.authz.Authorize(ctx, &fleet.Query{}, fleet.ActionRun); err != nil {
+	// Explicitly set ObserverCanRun: true in this check because we check that the user trying to
+	// read results is the same user that initiated the query. This means the observer check already
+	// happened with the actual value for this query.
+	if err := svc.authz.Authorize(ctx, &fleet.Query{ObserverCanRun: true}, fleet.ActionRun); err != nil {
 		level.Info(svc.logger).Log("err", "stream results authorization failed")
 		conn.WriteJSONError(authz.ForbiddenErrorMessage)
 		return

--- a/server/service/service_status.go
+++ b/server/service/service_status.go
@@ -3,17 +3,26 @@ package service
 import (
 	"context"
 
+	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/pkg/errors"
 )
 
 func (svc *Service) StatusResultStore(ctx context.Context) error {
+	if err := svc.authz.Authorize(ctx, &fleet.AppConfig{}, fleet.ActionRead); err != nil {
+		return err
+	}
+
 	return svc.resultStore.HealthCheck()
 }
 
 func (svc *Service) StatusLiveQuery(ctx context.Context) error {
-	cfg, err := svc.AppConfig(ctx)
+	if err := svc.authz.Authorize(ctx, &fleet.AppConfig{}, fleet.ActionRead); err != nil {
+		return err
+	}
+
+	cfg, err := svc.ds.AppConfig()
 	if err != nil {
-		return errors.Wrap(err, "retreiving app config")
+		return errors.Wrap(err, "retrieve app config")
 	}
 
 	if cfg.LiveQueryDisabled {


### PR DESCRIPTION
Set observer can run when performing authz check for live query results.

Final backend fix for #1515