### PR TITLE
Fix flaky E2E test

### DIFF
--- a/cypress/integration/core/admin.spec.ts
+++ b/cypress/integration/core/admin.spec.ts
@@ -94,7 +94,7 @@ describe("Core tier - Admin user", () => {
     });
 
     cy.contains("a", /back to queries/i).click({ force: true });
-    cy.findByText(/cypress test query/i).click();
+    cy.findByText(/cypress test query/i).click({ force: true });
     cy.findByText(/edit & run query/i).should("exist");
 
     // On the Packs pages (manage, new, and edit), they should…


### PR DESCRIPTION
Due to https://github.com/cypress-io/cypress/issues/7306, we need to use
`force: true` in many places to avoid flakiness in Cypress tests.