### PR TITLE
Manage Hosts Page: Empty page state

### DIFF
--- a/frontend/components/Pagination/Pagination.jsx
+++ b/frontend/components/Pagination/Pagination.jsx
@@ -37,7 +37,7 @@ class Pagination extends PureComponent {
           disabled={this.disablePrev()}
           onClick={() => onPaginationChange(currentPage - 1)}
         >
-          <FleetIcon name="chevronleft" /> Prev
+          <FleetIcon name="chevronleft" /> Previous
         </Button>
         <Button
           variant="unstyled"

--- a/frontend/components/Pagination/_style.scss
+++ b/frontend/components/Pagination/_style.scss
@@ -13,10 +13,24 @@
 
       .fleeticon-chevronleft {
         margin-right: $pad-small;
+
+        &:before {
+          font-size: 0.6rem;
+          font-weight: $bold;
+          position: relative;
+          top: -2px;
+        }
       }
 
       .fleeticon-chevronright {
         margin-left: $pad-small;
+
+        &:before {
+          font-size: 0.6rem;
+          font-weight: $bold;
+          position: relative;
+          top: -2px;
+        }
       }
     }
 

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -247,7 +247,7 @@ const TableContainer = ({
       <div className={`${baseClass}__data-table-container`}>
         {/* No entities for this result. */}
         {!isLoading && data.length === 0 ? (
-          <EmptyComponent />
+          <EmptyComponent pageIndex={pageIndex} />
         ) : (
           <>
             <DataTable

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -247,7 +247,21 @@ const TableContainer = ({
       <div className={`${baseClass}__data-table-container`}>
         {/* No entities for this result. */}
         {!isLoading && data.length === 0 ? (
-          <EmptyComponent pageIndex={pageIndex} />
+          <>
+            <EmptyComponent pageIndex={pageIndex} />
+            {pageIndex !== 0 && (
+              <div className={`${baseClass}__empty-page`}>
+                <div className={`${baseClass}__previous`}>
+                  <Pagination
+                    resultsOnCurrentPage={data.length}
+                    currentPage={pageIndex}
+                    resultsPerPage={pageSize}
+                    onPaginationChange={onPaginationChange}
+                  />
+                </div>
+              </div>
+            )}
+          </>
         ) : (
           <>
             <DataTable

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -64,4 +64,22 @@
     margin-left: 0;
     padding-bottom: $pad-medium;
   }
+
+  &__empty-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  &__previous {
+    width: 350px;
+
+    .pagination__pager-wrap {
+      justify-content: left;
+
+      button:last-child {
+        display: none;
+      }
+    }
+  }
 }

--- a/frontend/pages/hosts/ManageHostsPage/components/EmptyHosts/EmptyHosts.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/EmptyHosts/EmptyHosts.tsx
@@ -5,15 +5,19 @@ import React from "react";
 
 const baseClass = "empty-hosts";
 
-const EmptyHosts = (): JSX.Element => {
+const EmptyHosts = (pageIndex: number): JSX.Element => {
   return (
     <div className={`${baseClass}`}>
       <div className={`${baseClass}__inner`}>
         <div className={`${baseClass}__empty-filter-results`}>
-          <h1>No hosts match the current criteria</h1>
+          <h1>
+            {pageIndex !== 0
+              ? "No more hosts to display"
+              : "No hosts match the current criteria"}
+          </h1>
           <p>
-            Expecting to see new hosts? Try again in a few seconds as the system
-            catches up
+            Expecting to see {pageIndex !== 0 ? "more" : "new"} hosts? Try again
+            in a few seconds as the system catches up
           </p>
         </div>
       </div>


### PR DESCRIPTION
- Renders a new empty state for manage host table based on what page the user is on
- Added basic mock in Figma based on @zwass 's suggestion in #1624 

Things to consider: Previous / next do not render for Empty state... should we add a back button for the user?

Closes #1624 

Added @zwass and @noahtalerman for review because we want this in today's release.

<img width="1396" alt="Screen Shot 2021-08-11 at 3 26 08 PM" src="https://user-images.githubusercontent.com/71795832/129090746-9d0542bd-ecab-486c-b5f1-ff214d6e3f84.png">

✨✨NEW LOOM: Final PR✨✨
https://www.loom.com/share/bba9f0e2528a48f3b93face186a1ad2c