### PR TITLE
Fixed table column wrapping for host details page

### DIFF
--- a/changes/1619-host-details-table-wrap
+++ b/changes/1619-host-details-table-wrap
@@ -1,0 +1,1 @@
+- Fixed table column wrapping for host details page

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -337,7 +337,7 @@
   tbody {
     td {
       padding: 12px 27px;
-      white-space: nowrap;
+      white-space: normal !important;
     }
   }
 


### PR DESCRIPTION
Closes #1619.

Small CSS change to remove `nowrap` rule for table columns.