### PR TITLE
Make receive calls to redis conn thread safe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,7 +174,7 @@ jobs:
 
     - name: Run Go Tests
       run: |
-        MYSQL_TEST=1 REDIS_TEST=1 make test-go
+        MYSQL_TEST=1 make test-go
 
 
   lint-go:

--- a/changes/issue-1531-thread-safe-redis
+++ b/changes/issue-1531-thread-safe-redis
@@ -1,0 +1,1 @@
+* Reads live query results from redis in a thread safe manner.

--- a/docs/3-Contributing/2-Testing.md
+++ b/docs/3-Contributing/2-Testing.md
@@ -34,7 +34,7 @@ Check out [the instructions in the `/tools/osquery` directory](../../tools/osque
 To execute the basic unit and integration tests, run the following from the root of the repository:
 
 ```
-MYSQL_TEST=1 REDIS_TEST=1 make test
+MYSQL_TEST=1 make test
 ```
 
 It is a good idea to run `make test` before submitting a Pull Request.
@@ -89,14 +89,6 @@ To run MySQL integration tests set environment variables as follows:
 
 ```
 MYSQL_TEST=1 make test-go
-```
-
-#### Redis tests
-
-To run Redis integration tests set environment variables as follows:
-
-```
-REDIS_TEST=1 make test-go
 ```
 
 #### Email tests

--- a/server/live_query/redis_live_query_test.go
+++ b/server/live_query/redis_live_query_test.go
@@ -1,7 +1,6 @@
 package live_query
 
 import (
-	"os"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/pubsub"
@@ -11,10 +10,6 @@ import (
 )
 
 func TestRedisLiveQuery(t *testing.T) {
-	if _, ok := os.LookupEnv("REDIS_TEST"); !ok {
-		t.Skip("Redis tests not requested. Skipping.")
-	}
-
 	for _, f := range testFunctions {
 		t.Run(test.FunctionName(f), func(t *testing.T) {
 			store, teardown := setupRedisLiveQuery(t)

--- a/server/pubsub/query_results_test.go
+++ b/server/pubsub/query_results_test.go
@@ -243,10 +243,10 @@ func TestQueryResultsStore(t *testing.T) {
 	}()
 
 	// wait with a timeout to ensure that the test can't hang
-	if waitTimeout(&writerWg, 25*time.Second) {
+	if waitTimeout(&writerWg, 5*time.Second) {
 		t.Error("Timed out waiting for writers to join")
 	}
-	if waitTimeout(&readerWg, 25*time.Second) {
+	if waitTimeout(&readerWg, 5*time.Second) {
 		t.Error("Timed out waiting for readers to join")
 	}
 

--- a/server/service/service_campaigns.go
+++ b/server/service/service_campaigns.go
@@ -221,7 +221,10 @@ func (svc Service) StreamCampaignResults(ctx context.Context, conn *websocket.Co
 
 	// Open the channel from which we will receive incoming query results
 	// (probably from the redis pubsub implementation)
-	readChan, err := svc.resultStore.ReadChannel(context.Background(), *campaign)
+	cancelCtx, cancelFunc := context.WithCancel(ctx)
+	defer cancelFunc()
+
+	readChan, err := svc.resultStore.ReadChannel(cancelCtx, *campaign)
 	if err != nil {
 		conn.WriteJSONError(fmt.Sprintf("cannot open read channel for campaign %d ", campaignID))
 		return


### PR DESCRIPTION
Also removes REDIS_TEST env var. Redis is lightweight and fast, no need to skip these tests.