### PR TITLE
Prepare for Fleet 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## Fleet 4.2.0 (Aug 11, 2021)
+
+* Add ability to simultaneously filter hosts by status (`online`, `offline`, `new`, `mia`) and by label on the **Hosts** page.
+
+* Add ability to filter hosts by team in the Fleet UI, fleetctl CLI tool, and Fleet API. *Available for Fleet Basic customers*.
+
+* Add ability to create a Team schedule in Fleet. The Schedule feature was released in Fleet 4.1.0. For more information on the new Schedule feature, check out the [Fleet 4.1.0 release blog post](https://blog.fleetdm.com/fleet-4-1-0-57dfa25e89c1). *Available for Fleet Basic customers*.
+
+* Add Beta Vulnerable software feature which surfaces vulnerable software on the **Host details** page and the `GET /api/v1/fleet/hosts/{id}` API route. For information on how to configure the Vulnerable software feature and how exactly Fleet processes vulnerabilities, check out the [Vulnerability processing documentation](https://github.com/fleetdm/fleet/blob/main/docs/1-Using-Fleet/13-Vulnerability-Processing.md#vulnerability-processing).
+
+* Add ability to see which logging destination is configured for Fleet in the Fleet UI. To see this information, head to the **Schedule** page and then select "Schedule a query." Configured logging destination information is also available in the `GET api/v1/fleet/config` API route.
+
+* Improve the `fleetctl preview` experience by downloading Fleet's standard query library and loading the queries into the Fleet UI.
+
+* Improve the user interface for the **Packs** page and **Queries** page in the Fleet UI.
+
+* Add ability to modify scheduled queries in your Schedule in Fleet. The Schedule feature was released in Fleet 4.1.0. For more information on the new Schedule feature, check out the [Fleet 4.1.0 release blog post](https://blog.fleetdm.com/fleet-4-1-0-57dfa25e89c1).
+
+* Add ability to disable the Users feature in Fleet by setting the new `enable_host_users` key to `true` in the `config` yaml, configuration file. For documentation on using configuration files in yaml syntax, check out the [Using yaml files in Fleet](https://github.com/fleetdm/fleet/tree/main/docs/1-Using-Fleet/configuration-files#using-yaml-files-in-fleet) documentation.
+
+* Improve performance of the Software inventory feature. Software inventory is currently under a feature flag. To enable this feature flag, check out the [feature flag documentation](https://github.com/fleetdm/fleet/blob/main/docs/2-Deploying/2-Configuration.md#feature-flags).
+
+* Improve performance of inserting `pack_stats` in the database. The `pack_stats` information is used to display "Frequency" and "Last run" information for a specific host's scheduled queries. You can find this information on the **Host details** page.
+
+* Improve Fleet server logging so that it is more uniform.
+
+* Fix a bug in which a user with the Observer role was unable to run a live query.
+
+* Fix a bug that prevented the new **Home** page from being displayed in some Fleet instances.
+
+* Fix a bug that prevented accurate sorting issues across multiple pages on the **Hosts** page.
+
 ## Fleet 4.1.0 (Jul 26, 2021)
 
 The primary additions in Fleet 4.1.0 are the new Schedule and Activity feed features.

--- a/changes/1269-refresh-matching-hosts
+++ b/changes/1269-refresh-matching-hosts
@@ -1,1 +1,0 @@
-* Fixed refreshing manage hosts table to include current label and query after changing a host's team.

--- a/changes/1372-hosts-status-dropdown
+++ b/changes/1372-hosts-status-dropdown
@@ -1,5 +1,0 @@
-- Added support for getting hosts by label and by status
-- Created new dropdown on manage hosts page for status
-- Removed status from sidebar
-- Modified url to contain status, label or both
-- Modified edit and delete buttons for labels, now icons

--- a/changes/1490-host-count-bug
+++ b/changes/1490-host-count-bug
@@ -1,1 +1,0 @@
-- Fix host count bug by refactoring host counts to use built-in labels with exact label names

--- a/changes/1496-sort-multiple-pages
+++ b/changes/1496-sort-multiple-pages
@@ -1,2 +1,0 @@
-- Better detection between API sorting and front end sorting
-- Fixed sorting issues across multiple pages

--- a/changes/1526-refactor-manage-queries-page
+++ b/changes/1526-refactor-manage-queries-page
@@ -1,7 +1,0 @@
-Refactor ManageQueriesPage as functional component in TypeScript
-Refactor old table using TableContainer component
-Enhance ActionButton component with optional icons
-Update DataTable component to render table header buttons per Figma
-Update Query interface with additional properties
-Update Cypress e2e tests
-Remove unused files

--- a/changes/1550-team-schedules-ui
+++ b/changes/1550-team-schedules-ui
@@ -1,1 +1,0 @@
-* Paid users can create, update, delete queries scheduled by team in the UI

--- a/changes/1567-refactor-manage-packs-page
+++ b/changes/1567-refactor-manage-packs-page
@@ -1,1 +1,0 @@
-* Refactor ManagePacksPage to new UI and components

--- a/changes/1587-surface-logging-destination
+++ b/changes/1587-surface-logging-destination
@@ -1,1 +1,0 @@
-* Users reminded of their logging destination when adding or modifying their schedules.

--- a/changes/1590-observers-can-run-query
+++ b/changes/1590-observers-can-run-query
@@ -1,1 +1,0 @@
-* Fix API call to add query_id so backend can validate observer_can_run when an observer attempts to run as a live query

--- a/changes/1627-fix-edit-label-platform
+++ b/changes/1627-fix-edit-label-platform
@@ -1,1 +1,0 @@
-Disable select platform dropdown for edit label page

--- a/changes/dont-fail-if-duplicate-host-software
+++ b/changes/dont-fail-if-duplicate-host-software
@@ -1,1 +1,0 @@
-* Prevent failing to store software in the case where the insert falls within a small window of time where duplicate host software rows might be inserted.

--- a/changes/improve-fleet-serve-logging
+++ b/changes/improve-fleet-serve-logging
@@ -1,1 +1,0 @@
-* Make logging for fleet serve more uniform.

--- a/changes/issue-1159-preview-command-loads-standard-query-library
+++ b/changes/issue-1159-preview-command-loads-standard-query-library
@@ -1,1 +1,0 @@
-* Preview command now downloads the standard query library from "https://raw.githubusercontent.com/fleetdm/fleet/main/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml" and loads it into the console via fleet api

--- a/changes/issue-1325-filter-by-team_id
+++ b/changes/issue-1325-filter-by-team_id
@@ -1,2 +1,0 @@
-* add the `team_id` query parameter to `/api/v1/fleet/hosts` & `/api/v1/fleet/labels/{id}/hosts` which will filter the hosts by the specified team_id
-* add a `--team` command line flag to fleetctl to allow filtering hosts by team i.e. `fleetctl get hosts --team=1`

--- a/changes/issue-1436-convert-cpe-to-cve
+++ b/changes/issue-1436-convert-cpe-to-cve
@@ -1,1 +1,0 @@
-* Converts all stored CPEs into their corresponding CVEs if any are present. Fixes issue 1436

--- a/changes/issue-1437-expose-vulnerabilities-in-hosts
+++ b/changes/issue-1437-expose-vulnerabilities-in-hosts
@@ -1,1 +1,0 @@
-* Return CPEs and CVEs for host software if detected. Fixes issue 1437

--- a/changes/issue-1438-config-api-responds-with-logging-settings
+++ b/changes/issue-1438-config-api-responds-with-logging-settings
@@ -1,1 +1,0 @@
-* Add logging settings to `/config` API response. This includes both the results & status logging plugins. Implements issue 1438.

--- a/changes/issue-1475-flash-message-bug
+++ b/changes/issue-1475-flash-message-bug
@@ -1,1 +1,0 @@
-* Does not re-render page to display flash message

--- a/changes/issue-1485-prevent-changes-to-global-and-team-packs
+++ b/changes/issue-1485-prevent-changes-to-global-and-team-packs
@@ -1,2 +1,0 @@
-* /api/v1/fleet/packs only returns packs that have nil or empty 'type' to prevent displaying global and team packs as modifiable packs
-* /api/v1/fleet/packs now prevent edit/deletion of Global & Team packs

--- a/changes/issue-1498-team-schedules
+++ b/changes/issue-1498-team-schedules
@@ -1,1 +1,0 @@
-* Add team level schedules

--- a/changes/issue-1515-observer-query-issues
+++ b/changes/issue-1515-observer-query-issues
@@ -1,1 +1,0 @@
-* Observers can run queries that admins create, but not create their own. Improves errors returned and checks.

--- a/changes/issue-1525-schedule-action-dropdown
+++ b/changes/issue-1525-schedule-action-dropdown
@@ -1,1 +1,0 @@
-* Users can update and remove a global scheduled query with an Action dropdown

--- a/changes/issue-1559-transfer-filter-by-status
+++ b/changes/issue-1559-transfer-filter-by-status
@@ -1,1 +1,0 @@
-* When filtering hosts to transfer to a team, allow to filter by label, status, and query string

--- a/changes/issue-1569-disallow-target-id-null
+++ b/changes/issue-1569-disallow-target-id-null
@@ -1,1 +1,0 @@
-* Disallow target_id NULL for pack_targets to prevent issues when listing packs. This could happen because of a pack spec applied with a label name that was not existent anymore.

--- a/changes/issue-1570-improve-performance
+++ b/changes/issue-1570-improve-performance
@@ -1,1 +1,0 @@
-* Improve performance of pack statistic insertions in the database.

--- a/changes/issue-1588-allow-disabling-host-users
+++ b/changes/issue-1588-allow-disabling-host-users
@@ -1,1 +1,0 @@
-* In some cases, host users are not useful. Users can disable this through the enable_host_users config.

--- a/changes/issue-1632-software-inventory-config
+++ b/changes/issue-1632-software-inventory-config
@@ -1,1 +1,0 @@
-* Allow users to enable software inventory through the app config.

--- a/changes/log-errors-when-injesting-distributed-query-results
+++ b/changes/log-errors-when-injesting-distributed-query-results
@@ -1,1 +1,0 @@
-* Only log errors and try to process all distributed query results from hosts instead of erroring out.

--- a/changes/timeout-in-request-analytics
+++ b/changes/timeout-in-request-analytics
@@ -1,1 +1,0 @@
-* When posting usage analytics, timeout after 30secs.

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,8 +4,8 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v4.1.0
+version: v4.2.0
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git
-appVersion: v4.1.0
+appVersion: v4.2.0

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -2,7 +2,7 @@
 # All settings related to how Fleet is deployed in Kubernetes
 hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
-imageTag: v4.1.0 # Version of Fleet to deploy
+imageTag: v4.2.0 # Version of Fleet to deploy
 createIngress: true # Whether or not to automatically create an Ingress
 ingressAnnotations: {} # Additional annotation to add to the Ingress
 podAnnotations: {} # Additional annotations to add to the Fleet pod

--- a/docs/1-Using-Fleet/configuration-files/multi-file-configuration/organization-settings.yml
+++ b/docs/1-Using-Fleet/configuration-files/multi-file-configuration/organization-settings.yml
@@ -6,8 +6,8 @@ spec:
     config:
       decorators:
         load:
-        - SELECT uuid AS host_uuid FROM system_info;
-        - SELECT hostname AS hostname FROM system_info;
+          - SELECT uuid AS host_uuid FROM system_info;
+          - SELECT hostname AS hostname FROM system_info;
       options:
         disable_distributed: false
         distributed_interval: 10
@@ -23,6 +23,8 @@ spec:
     host_expiry_window: 0
   host_settings:
     additional_queries: null
+    enable_host_users: true
+    enable_software_inventory: true
   org_info:
     org_logo_url: ""
     org_name: org
@@ -38,7 +40,7 @@ spec:
     enable_smtp: false
     enable_ssl_tls: true
     enable_start_tls: true
-    password: '********'
+    password: "********"
     port: 587
     sender_address: ""
     server: ""

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetctl",
-  "version": "v4.1.0",
+  "version": "v4.2.0",
   "description": "Installer for the fleetctl CLI tool",
   "bin": {
     "fleetctl": "./run.js"


### PR DESCRIPTION
- Edit CHANGELOG
- Bump versioning
- Add new configuration options to example `config` document

The following are open PRs that I believe are intended to be merged into `main` prior to release:
- #1641 
- #1634 
- #1621 