### PR TITLE
Change Email form: Fix button font size

### DIFF
--- a/frontend/components/forms/ChangeEmailForm/_styles.scss
+++ b/frontend/components/forms/ChangeEmailForm/_styles.scss
@@ -5,10 +5,6 @@
   }
 
   &__btn {
-    font-size: $small;
-    height: 38px;
-    margin-bottom: 5px;
-    margin-left: 15px;
-    padding: 0;
+    margin-left: 12px;
   }
 }


### PR DESCRIPTION
- Inherits button styling from `<Button>`

Hoping this is the last button I missed styling from https://github.com/fleetdm/fleet/pull/1583

<img width="1140" alt="Screen Shot 2021-08-11 at 5 25 39 PM" src="https://user-images.githubusercontent.com/71795832/129105596-2d13412a-43d1-4781-8ebb-f49a029060c0.png">
