### PR TITLE
Add static to ldflags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,6 +47,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
+      - -extldflags "-static"
       - -X github.com/kolide/kit/version.appName={{ .ArtifactName }}
       - -X github.com/kolide/kit/version.version={{ .Version }}
       - -X github.com/kolide/kit/version.branch={{ .Branch }}


### PR DESCRIPTION
Should fix "not found" error with CGO compiled Fleet binary due to
missing static C libraries.