### PR TITLE
Spiffier UI: Label pills

### DIFF
--- a/changes/1660-spiffier-pills-admin-role
+++ b/changes/1660-spiffier-pills-admin-role
@@ -1,0 +1,1 @@
+Fix: Label pills to not wrap

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -102,6 +102,7 @@ $base-class: "button";
     font-size: $xx-small;
     padding: $pad-xsmall 10px;
     height: 24px;
+    white-space: nowrap;
 
     &:active {
       box-shadow: inset 2px 2px 2px rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
- Remove text wrap from fixed height label pills for prettier UI
- Expose `global_role: "admin"` in UI (bug: outdated key was still being used `admin: true`)
- Updates `userStub` and `adminUserStub` with global_role key and removes outdated key.

(removed any PR work for issue #1656 and added it to pr #1659)
Closes #1643 

https://www.loom.com/share/3e7869a447a4480bb92009d6fd4ed121