### PR TITLE
Flash Messages: Fix 4 second success render

### DIFF
--- a/.github/workflows/orbit-golangci-lint.yml
+++ b/.github/workflows/orbit-golangci-lint.yml
@@ -18,3 +18,4 @@ jobs:
           # version.
           version: v1.33
           working-directory: orbit/
+          args: --timeout 3m

--- a/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
+++ b/frontend/components/flash_messages/FlashMessage/FlashMessage.jsx
@@ -30,7 +30,7 @@ const FlashMessage = ({
         document.getElementById(`${klass}`).style.visibility = "hidden";
       }, 4000); // Hides success alerts after 4 seconds
     }
-  }, []);
+  });
 
   if (!isVisible) {
     return false;


### PR DESCRIPTION
- Fixes bug: Success messages render for 4 seconds again

@martavis, you had added the empty dependency array into #1556 Let me know if there's a particular reason we need the empty array because that's what broke my 4 second render. I'm not 100% familiar with the minute details of `useEffect` so maybe we need dependencies in it if we're using the dependency array?
Link: https://github.com/fleetdm/fleet/commit/672db9e2a7e72a2411a99f416d402b827a6a64c8#diff-41e51887a0890080c05d751375bf3ac5dba2156d7be7ebc8658b326d54adf074

Closes #1647 