### PR TITLE
FleetUI: Update column sort options

### DIFF
--- a/changes/Issue1507-disable-sort-remove
+++ b/changes/Issue1507-disable-sort-remove
@@ -1,0 +1,1 @@
+Add disableSortRemove property to to disable react-tables's default of three clicks "asc-desc-none" for column sort

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -93,13 +93,12 @@ const DataTable = ({
   useEffect(() => {
     const column = sortBy[0];
     if (column !== undefined) {
-      onSort(column.id, column.desc);
-      // if (
-      //   column.id !== sortHeader ||
-      //   column.desc !== (sortDirection === "desc")
-      // ) {
-      //   onSort(column.id, column.desc);
-      // }
+      if (
+        column.id !== sortHeader ||
+        column.desc !== (sortDirection === "desc")
+      ) {
+        onSort(column.id, column.desc);
+      }
     } else {
       onSort(undefined);
     }

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -79,6 +79,7 @@ const DataTable = ({
         }, [sortHeader, sortDirection]),
       },
       disableMultiSort: true,
+      disableSortRemove: true,
       manualSortBy,
     },
     useSortBy,
@@ -92,12 +93,13 @@ const DataTable = ({
   useEffect(() => {
     const column = sortBy[0];
     if (column !== undefined) {
-      if (
-        column.id !== sortHeader ||
-        column.desc !== (sortDirection === "desc")
-      ) {
-        onSort(column.id, column.desc);
-      }
+      onSort(column.id, column.desc);
+      // if (
+      //   column.id !== sortHeader ||
+      //   column.desc !== (sortDirection === "desc")
+      // ) {
+      //   onSort(column.id, column.desc);
+      // }
     } else {
       onSort(undefined);
     }

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -109,15 +109,15 @@ const TableContainer = ({
   const onSortChange = useCallback(
     (id?: string, isDesc?: boolean) => {
       if (id === undefined) {
-        setSortHeader("");
-        setSortDirection("");
+        setSortHeader(defaultSortHeader || "");
+        setSortDirection(defaultSortDirection || "");
       } else {
         setSortHeader(id);
         const direction = isDesc ? "desc" : "asc";
         setSortDirection(direction);
       }
     },
-    [setSortHeader, setSortDirection]
+    [defaultSortHeader, defaultSortDirection, setSortHeader, setSortDirection]
   );
 
   const onSearchQueryChange = (value: string) => {

--- a/frontend/fleet/entities/hosts.tests.js
+++ b/frontend/fleet/entities/hosts.tests.js
@@ -61,7 +61,8 @@ describe("Kolide - API client (hosts)", () => {
     it("calls the label endpoint when used with label filter", () => {
       const request = createRequestMock({
         bearerToken,
-        endpoint: "/api/v1/fleet/labels/6/hosts?page=2&per_page=50",
+        endpoint:
+          "/api/v1/fleet/labels/6/hosts?page=2&per_page=50&order_key=hostname&order_direction=asc",
         method: "get",
         response: { hosts: [] },
       });

--- a/frontend/fleet/entities/hosts.ts
+++ b/frontend/fleet/entities/hosts.ts
@@ -55,6 +55,9 @@ export default (client: any) => {
         const sortItem = sortBy[0];
         orderKeyParam += `&order_key=${sortItem.id}`;
         orderDirection = `&order_direction=${sortItem.direction}`;
+      } else {
+        orderKeyParam += `&order_key=hostname`;
+        orderDirection = `&order_direction=asc`;
       }
 
       let searchQuery = "";

--- a/frontend/test/mocks/host_mocks.js
+++ b/frontend/test/mocks/host_mocks.js
@@ -15,7 +15,8 @@ export default {
     valid: (bearerToken) => {
       return createRequestMock({
         bearerToken,
-        endpoint: "/api/v1/fleet/hosts?page=0&per_page=100",
+        endpoint:
+          "/api/v1/fleet/hosts?page=0&per_page=100&order_key=hostname&order_direction=asc",
         method: "get",
         response: { hosts: [] },
       });


### PR DESCRIPTION
Closes #1507 

- Add disableSortRemove property to to disable react-tables's default of three clicks "asc-desc-none" for column sort 
