### PR TITLE
Add explicit sync to disk for critical file writes

### DIFF
--- a/changes/issue-1679-sync-file-writes
+++ b/changes/issue-1679-sync-file-writes
@@ -1,1 +1,1 @@
-* Sync critical file writes to disk.
+* Orbit: sync critical file writes to disk.

--- a/changes/issue-1679-sync-file-writes
+++ b/changes/issue-1679-sync-file-writes
@@ -1,0 +1,1 @@
+* Sync critical file writes to disk.

--- a/cmd/fleetctl/config.go
+++ b/cmd/fleetctl/config.go
@@ -60,7 +60,10 @@ func makeConfigIfNotExists(fp string) error {
 		}
 	}
 
-	_, err := secure.OpenFile(fp, os.O_RDONLY|os.O_CREATE, configFilePerms)
+	f, err := secure.OpenFile(fp, os.O_RDONLY|os.O_CREATE, configFilePerms)
+	if err == nil {
+		f.Close()
+	}
 	return err
 }
 

--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -137,6 +137,9 @@ func buildNFPM(opt Options, pkger nfpm.Packager) error {
 	if err := pkger.Package(info, out); err != nil {
 		return errors.Wrap(err, "write package")
 	}
+	if err := out.Sync(); err != nil {
+		return errors.Wrap(err, "sync output file")
+	}
 	log.Info().Str("path", filename).Msg("wrote package")
 
 	return nil

--- a/orbit/pkg/packaging/macos.go
+++ b/orbit/pkg/packaging/macos.go
@@ -316,9 +316,9 @@ func cpio(srcPath, dstPath string) error {
 	if err != nil {
 		return errors.Wrap(err, "wait gzip")
 	}
-	err = dst.Close()
+	err = dst.Sync()
 	if err != nil {
-		return errors.Wrap(err, "close dst")
+		return errors.Wrap(err, "sync dst")
 	}
 
 	return nil

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -70,6 +70,9 @@ func copyFile(srcPath, dstPath string, perm os.FileMode) error {
 	if _, err := io.Copy(dst, src); err != nil {
 		return errors.Wrap(err, "copy src to dst")
 	}
+	if err := dst.Sync(); err != nil {
+		return errors.Wrap(err, "sync dst after copy")
+	}
 
 	return nil
 }

--- a/orbit/pkg/update/filestore/filestore.go
+++ b/orbit/pkg/update/filestore/filestore.go
@@ -88,7 +88,10 @@ func (s *fileStore) writeData() error {
 	defer f.Close()
 
 	if err := json.NewEncoder(f).Encode(s.metadata); err != nil {
-		return errors.Wrap(err, "read file store")
+		return errors.Wrap(err, "write file store")
+	}
+	if err := f.Sync(); err != nil {
+		return errors.Wrap(err, "sync file store")
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #1679 . This is my first PR! :) I hesitated whether to include a changefile or not but opted to add one, let me know if I should remove it. I also fixed a potential file descriptor leak in `cmd/fleetctl/config.go`, where the opened file wasn't used (it would eventually be closed by way of GC and finalizer, but that may take an arbitrarily long time).

I found a few more places where files are opened for writing using `secure.OpenFile` but those seem to be in interactive CLI commands, that's probably why they weren't requested to be changed in the linked issue.