### PR TITLE
Manage Users Page: Fix teams header to render on refresh

### DIFF
--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
@@ -82,18 +82,22 @@ export class UserManagementPage extends Component {
       showResetSessionsModal: false,
       userEditing: null,
       usersEditing: [],
+      isBasicTier: props.isBasicTier, // starts as false and changes to true
     };
-
-    const { isBasicTier } = props;
 
     // done as an instance variable as these headers will not change, so dont
     // want to recalculate on re-renders.
-    this.tableHeaders = generateTableHeaders(this.onActionSelect, isBasicTier);
+    this.tableHeaders = generateTableHeaders(
+      this.onActionSelect,
+      this.state.isBasicTier
+    );
   }
 
   componentDidMount() {
-    const { dispatch } = this.props;
-    dispatch(teamActions.loadAll({}));
+    const { dispatch, isBasicTier } = this.props;
+    if (isBasicTier) {
+      dispatch(teamActions.loadAll({}));
+    }
   }
 
   onEditUser = (formData) => {

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
@@ -82,15 +82,7 @@ export class UserManagementPage extends Component {
       showResetSessionsModal: false,
       userEditing: null,
       usersEditing: [],
-      isBasicTier: props.isBasicTier, // starts as false and changes to true
     };
-
-    // done as an instance variable as these headers will not change, so dont
-    // want to recalculate on re-renders.
-    this.tableHeaders = generateTableHeaders(
-      this.onActionSelect,
-      this.state.isBasicTier
-    );
   }
 
   componentDidMount() {
@@ -548,7 +540,6 @@ export class UserManagementPage extends Component {
 
   render() {
     const {
-      tableHeaders,
       renderCreateUserModal,
       renderEditUserModal,
       renderDeleteUserModal,
@@ -558,7 +549,16 @@ export class UserManagementPage extends Component {
       onTableQueryChange,
       onActionSelect,
     } = this;
-    const { loadingTableData, users, invites, currentUser } = this.props;
+
+    const {
+      loadingTableData,
+      users,
+      invites,
+      currentUser,
+      isBasicTier,
+    } = this.props;
+
+    const tableHeaders = generateTableHeaders(onActionSelect, isBasicTier);
 
     let tableData = [];
     if (!loadingTableData) {

--- a/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
@@ -109,8 +109,6 @@ const generateTableHeaders = (
 
   // Add Teams tab for basic tier only
   if (isBasicTier) {
-    console.log("catching is basic tier on usertableconfig!!");
-
     tableHeaders.splice(3, 0, {
       title: "Teams",
       Header: "Teams",

--- a/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
@@ -109,6 +109,8 @@ const generateTableHeaders = (
 
   // Add Teams tab for basic tier only
   if (isBasicTier) {
+    console.log("catching is basic tier on usertableconfig!!");
+
     tableHeaders.splice(3, 0, {
       title: "Teams",
       Header: "Teams",

--- a/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/UsersTableConfig.tsx
@@ -50,7 +50,7 @@ interface IUserTableData {
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
 const generateTableHeaders = (
   actionSelectHandler: (value: string, user: IUser | IInvite) => void,
-  isBasicTier = false
+  isBasicTier: boolean
 ): IDataColumn[] => {
   const tableHeaders: IDataColumn[] = [
     {


### PR DESCRIPTION
Issue found: isBasicTier is catching as false for a split second in the constructor and then generating table headers only once before it would catch as true. Moved isBasicTier into render so the table headers (teams header is dependent on tier) would generate once isBasicTier catches as true.

Closes #1667 

Loom? Image?
While watching loom on 1667, imagine teams header now loading on refresh. 😂