### PR TITLE
Add minimum width for Fleet UI and "Pack" tables on "Host details" page and "Queries" table

### DIFF
--- a/cypress/integration/basic/teamflow.spec.ts
+++ b/cypress/integration/basic/teamflow.spec.ts
@@ -2,6 +2,7 @@ describe("Teams flow", () => {
   beforeEach(() => {
     cy.setup();
     cy.login();
+    cy.viewport(1200, 660);
   });
 
   it("Create, edit, and delete a team successfully", () => {

--- a/frontend/components/side_panels/SecondarySidePanelContainer/_styles.scss
+++ b/frontend/components/side_panels/SecondarySidePanelContainer/_styles.scss
@@ -4,10 +4,6 @@
   box-sizing: border-box;
   border-left: 1px solid $ui-gray;
   overflow: auto;
-  width: $sidepanel-width;
+  min-width: $sidepanel-width;
   padding: $pad-xxlarge;
-
-  @include breakpoint(smalldesk) {
-    width: $sidepanel-tablet-width;
-  }
 }

--- a/frontend/layouts/CoreLayout/_styles.scss
+++ b/frontend/layouts/CoreLayout/_styles.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  min-width: $app-min-width;
 }
 
 .core-wrapper {

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -385,7 +385,7 @@ export class HostDetailsPage extends Component {
   renderPacks = () => {
     const { host, isLoadingHost } = this.props;
     const { pack_stats } = host;
-    const wrapperClassName = `${baseClass}__table`;
+    const wrapperClassName = `${baseClass}__pack-table`;
     const tableHeaders = generatePackTableHeaders();
 
     let packsAccordion;
@@ -402,18 +402,20 @@ export class HostDetailsPage extends Component {
               ) : (
                 <>
                   {!!pack.query_stats.length && (
-                    <TableContainer
-                      columns={tableHeaders}
-                      data={generatePackDataSet(pack.query_stats)}
-                      isLoading={isLoadingHost}
-                      onQueryChange={() => null}
-                      resultsTitle={"queries"}
-                      defaultSortHeader={"scheduled_query_name"}
-                      defaultSortDirection={"asc"}
-                      showMarkAllPages={false}
-                      disablePagination
-                      disableCount
-                    />
+                    <div className={`${wrapperClassName}`}>
+                      <TableContainer
+                        columns={tableHeaders}
+                        data={generatePackDataSet(pack.query_stats)}
+                        isLoading={isLoadingHost}
+                        onQueryChange={() => null}
+                        resultsTitle={"queries"}
+                        defaultSortHeader={"scheduled_query_name"}
+                        defaultSortDirection={"asc"}
+                        showMarkAllPages={false}
+                        disablePagination
+                        disableCount
+                      />
+                    </div>
                   )}
                 </>
               )}

--- a/frontend/pages/hosts/HostDetailsPage/PackTable/PackTableConfig.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/PackTable/PackTableConfig.tsx
@@ -41,20 +41,9 @@ const generatePackTableHeaders = (): IDataColumn[] => {
   return [
     {
       title: "Query name",
-      Header: (cellProps) => (
-        <HeaderCell
-          value={cellProps.column.title}
-          isSortedDesc={cellProps.column.isSortedDesc}
-        />
-      ),
-      accessor: "scheduled_query_name",
-      Cell: (cellProps) => <TextCell value={cellProps.cell.value} />,
-    },
-    {
-      title: "Description",
-      Header: "Description",
-      accessor: "description",
+      Header: "Query name",
       disableSortBy: true,
+      accessor: "scheduled_query_name",
       Cell: (cellProps) => <TextCell value={cellProps.cell.value} />,
     },
     {

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -429,15 +429,13 @@
       table-layout: fixed;
 
       thead {
-        // Width and overflow behavior for all columns
-        // except the "Query name" column
+        // Width for all columns except the "Query name" column
         // Width calculation adjusts for each row's horizontal padding
         th {
           width: calc(160px - 27px * 2);
         }
 
-        // Width and overflow behavior the "Query name" column
-        // Width calculation adjusts for each row's horizontal padding
+        // Width for the "Query name" column
         th:nth-child(1) {
           width: auto !important;
         }

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -426,30 +426,25 @@
     }
 
     .data-table__table {
+      table-layout: fixed;
+
+      thead {
+        // Width and overflow behavior for all columns
+        // except the "Query name" column
+        // Width calculation adjusts for each row's horizontal padding
+        th {
+          width: calc(160px - 27px * 2);
+        }
+
+        // Width and overflow behavior the "Query name" column
+        // Width calculation adjusts for each row's horizontal padding
+        th:nth-child(1) {
+          width: auto !important;
+        }
+      }
+
       tbody {
-        // Width and overflow behavior for the "Query name" column
-        // Width calculation adjusts for each row's horizontal padding
-        td:nth-child(1) {
-          width: calc(740px - 27px * 2);
-          min-width: calc(740px - 27px * 2);
-          overflow: hidden;
-          text-overflow: ellipsis;
-        }
-
-        // Width and overflow behavior for the "Frequency" column
-        // Width calculation adjusts for each row's horizontal padding
-        td:nth-child(2) {
-          width: calc(740px - 27px * 2);
-          min-width: calc(160px - 27px * 2);
-          overflow: hidden;
-          text-overflow: ellipsis;
-        }
-
-        // Width and overflow behavior for the "Last run" column
-        // Width calculation adjusts for each row's horizontal padding
-        td:nth-child(3) {
-          width: calc(740px - 27px * 2);
-          min-width: calc(160px - 27px * 2);
+        td {
           overflow: hidden;
           text-overflow: ellipsis;
         }

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -402,7 +402,7 @@
   }
 
   .accordion__panel {
-    padding: 20px;
+    padding: 0;
     animation: fadein 0.35s ease-in;
   }
 
@@ -417,6 +417,37 @@
 
     100% {
       opacity: 1;
+    }
+  }
+
+  &__pack-table {
+    .table-container__header {
+      display: none;
+    }
+
+    .data-table__table {
+      tbody {
+        // Width and overflow behavior for the "Query name" column
+        td:nth-child(1) {
+          min-width: 740px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+
+        // Width and overflow behavior for the "Frequency" column
+        td:nth-child(2) {
+          min-width: 160px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+
+        // Width and overflow behavior for the "Last run" column
+        td:nth-child(3) {
+          min-width: 160px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+      }
     }
   }
 }

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -430,6 +430,7 @@
         // Width and overflow behavior for the "Query name" column
         // Width calculation adjusts for each row's horizontal padding
         td:nth-child(1) {
+          width: calc(740px - 27px * 2);
           min-width: calc(740px - 27px * 2);
           overflow: hidden;
           text-overflow: ellipsis;
@@ -438,6 +439,7 @@
         // Width and overflow behavior for the "Frequency" column
         // Width calculation adjusts for each row's horizontal padding
         td:nth-child(2) {
+          width: calc(740px - 27px * 2);
           min-width: calc(160px - 27px * 2);
           overflow: hidden;
           text-overflow: ellipsis;
@@ -446,6 +448,7 @@
         // Width and overflow behavior for the "Last run" column
         // Width calculation adjusts for each row's horizontal padding
         td:nth-child(3) {
+          width: calc(740px - 27px * 2);
           min-width: calc(160px - 27px * 2);
           overflow: hidden;
           text-overflow: ellipsis;

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -428,22 +428,25 @@
     .data-table__table {
       tbody {
         // Width and overflow behavior for the "Query name" column
+        // Width calculation adjusts for each row's horizontal padding
         td:nth-child(1) {
-          min-width: 740px;
+          min-width: calc(740px - 27px * 2);
           overflow: hidden;
           text-overflow: ellipsis;
         }
 
         // Width and overflow behavior for the "Frequency" column
+        // Width calculation adjusts for each row's horizontal padding
         td:nth-child(2) {
-          min-width: 160px;
+          min-width: calc(160px - 27px * 2);
           overflow: hidden;
           text-overflow: ellipsis;
         }
 
         // Width and overflow behavior for the "Last run" column
+        // Width calculation adjusts for each row's horizontal padding
         td:nth-child(3) {
-          min-width: 160px;
+          min-width: calc(160px - 27px * 2);
           overflow: hidden;
           text-overflow: ellipsis;
         }

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -81,6 +81,7 @@
   .queries-list-wrapper {
     .data-table__table {
       table-layout: fixed;
+
       thead {
         // Width and overflow behavior for all columns except
         // checkbox and "Name" columns
@@ -88,8 +89,6 @@
         // Width calculation adjusts for each row's horizontal padding
         th:not(:nth-child(1)):not(:nth-child(2)) {
           width: calc(180px - (27px * 2));
-          overflow: hidden;
-          text-overflow: ellipsis;
         }
       }
 

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -83,9 +83,8 @@
       table-layout: fixed;
 
       thead {
-        // Width and overflow behavior for all columns except
-        // checkbox and "Name" columns
-        // For observers all columns excpet "Name" and "Author" columns
+        // Width for all columns except checkbox and "Name" columns
+        // For observers all columns except "Name" and "Author" columns
         // Width calculation adjusts for each row's horizontal padding
         th:not(:nth-child(1)):not(:nth-child(2)) {
           width: calc(180px - (27px * 2));
@@ -97,7 +96,7 @@
           overflow: hidden;
           text-overflow: ellipsis;
         }
-        // Width and overflow behavior for the "Name" column
+        // Width and overflow behavior for the link in the "Name" column
         td {
           .button {
             display: block;

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -80,15 +80,30 @@
 
   .queries-list-wrapper {
     .data-table__table {
-      tbody {
-        // Width and overflow behavior for the "Name" column
+      table-layout: fixed;
+      thead {
+        // Width and overflow behavior for all columns except
+        // checkbox and "Name" columns
+        // For observers all columns excpet "Name" and "Author" columns
         // Width calculation adjusts for each row's horizontal padding
+        th:not(:nth-child(1)):not(:nth-child(2)) {
+          width: calc(180px - (27px * 2));
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+      }
+
+      tbody {
+        td {
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+        // Width and overflow behavior for the "Name" column
         td {
           .button {
             display: block;
             text-align: start;
-            width: calc(624px - 27px * 2);
-            max-width: calc(624px - 27px * 2);
+            width: 100%;
             overflow: hidden;
             text-overflow: ellipsis;
           }

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -81,11 +81,16 @@
   .queries-list-wrapper {
     .data-table__table {
       tbody {
+        // Width and overflow behavior for the "Name" column
+        // Width calculation adjusts for each row's horizontal padding
         td {
-          white-space: normal !important;
-
-          button {
-            text-align: left;
+          .button {
+            display: block;
+            text-align: start;
+            width: calc(624px - 27px * 2);
+            max-width: calc(624px - 27px * 2);
+            overflow: hidden;
+            text-overflow: ellipsis;
           }
         }
       }

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/_styles.scss
@@ -15,30 +15,6 @@
     th + th {
       border-left: 1px solid $ui-fleet-blue-15;
     }
-
-    th {
-      font-size: $x-small;
-      font-weight: $bold;
-      text-align: left;
-      padding: $pad-medium $pad-large;
-
-      &:nth-child(1) {
-        border-top-left-radius: 6px;
-        width: 20px;
-      }
-
-      &:nth-child(2) {
-        width: calc(49% - 20px);
-      }
-
-      &:nth-child(3) {
-        width: 37%;
-      }
-
-      &:last-child {
-        border-top-right-radius: 6px;
-      }
-    }
   }
 
   &__select-all {

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -60,7 +60,7 @@ a {
   @at-root {
     .has-sidebar & {
       margin-right: 0;
-      min-width: 760px;
+      min-width: calc(#{$app-min-width} - 30px - 30px - #{$sidepanel-width});
       max-width: calc(
         100vw - #{$pad-xlarge} - #{$pad-xlarge} - #{$pad-xxsmall} - #{$sidepanel-width}
       );

--- a/frontend/styles/var/_global.scss
+++ b/frontend/styles/var/_global.scss
@@ -1,4 +1,4 @@
 $border-radius: 4px;
 $base-font-size: 16;
 $sidepanel-width: 340px;
-$sidepanel-tablet-width: 340px;
+$app-min-width: 1200px;


### PR DESCRIPTION
- Add `$min-app-width: 1200px` to define the minimum width of the Fleet UI. 
  - TODO @noahtalerman add Figma screens to reflect minimum width behavior for all tables
- Remove sort form the "Query name" column in the "Pack" tables on the **Host details** page
- Set static widths all column in the "Pack" tables on the **Host details** page except the "Query name" column to support the new minimum width
- Set static widths for all columns in the "Queries" table except the "Name" and "Author" columns to support the new minimum width

https://www.loom.com/share/99a6e93d77474e89a62f91f58417d0b0

Resolves #1619