### PR TITLE
Fix query table sorting

### DIFF
--- a/changes/issue-1705-client-side-sort
+++ b/changes/issue-1705-client-side-sort
@@ -1,0 +1,2 @@
+Add custom sortType for case insensitive search to DataTable component
+Add sortTypes to QueriesTableConfig

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 import { useTable, useSortBy, useRowSelect } from "react-table";
-import { kebabCase, noop } from "lodash";
+import { isString, kebabCase, noop } from "lodash";
 
 import useDeepEffect from "utilities/hooks/useDeepEffect";
 
@@ -81,6 +81,26 @@ const DataTable = ({
       disableMultiSort: true,
       disableSortRemove: true,
       manualSortBy,
+      sortTypes: React.useMemo(
+        () => ({
+          caseInsensitive: (a: any, b: any, id: any) => {
+            let valueA = a.values[id];
+            let valueB = b.values[id];
+
+            valueA = isString(valueA) ? valueA.toLowerCase() : valueA;
+            valueB = isString(valueB) ? valueB.toLowerCase() : valueB;
+
+            if (valueB > valueA) {
+              return 1;
+            }
+            if (valueB < valueA) {
+              return -1;
+            }
+            return 0;
+          },
+        }),
+        []
+      ),
     },
     useSortBy,
     useRowSelect

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesTableConfig.tsx
@@ -44,6 +44,7 @@ interface IDataColumn {
   accessor?: string;
   disableHidden?: boolean;
   disableSortBy?: boolean;
+  sortType?: string;
 }
 
 // NOTE: cellProps come from react-table
@@ -65,6 +66,7 @@ const generateTableHeaders = (isOnlyObserver = true): IDataColumn[] => {
           path={PATHS.EDIT_QUERY(cellProps.row.original)}
         />
       ),
+      sortType: "caseInsensitive",
     },
     {
       title: "Author",
@@ -78,6 +80,7 @@ const generateTableHeaders = (isOnlyObserver = true): IDataColumn[] => {
       Cell: (cellProps: ICellProps): JSX.Element => (
         <TextCell value={cellProps.cell.value} />
       ),
+      sortType: "caseInsensitive",
     },
     {
       title: "Last modified",
@@ -127,6 +130,7 @@ const generateTableHeaders = (isOnlyObserver = true): IDataColumn[] => {
       Cell: (cellProps: ICellProps): JSX.Element => (
         <TextCell value={capitalize(cellProps.cell.value.toString())} />
       ),
+      sortType: "basic",
     });
   }
   return tableHeaders;


### PR DESCRIPTION
Closes #1705 

- Add custom `sortType` to `DataTable` component for case insensitive search
- Specify `sortType` in `QueriesTableConfig`