### PR TITLE
Deploy compiled HTML to the remote even though it's in the gitignore.

### DIFF
--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -56,7 +56,7 @@ jobs:
     # (This commit will never be pushed to GitHub- only to Heroku.)
     # > The local config flags make this work in GitHub's environment.
     - run: git add website/.www
-    - run: git add website/views/partials/built-from-markdown  > /dev/null 2>&1 || echo '* * * WARNING - Silently ignoring the fact that there are no HTML partials generated from markdown to include in automated commit...'
+    - run: git add -f website/views/partials/built-from-markdown  > /dev/null 2>&1 || echo '* * * WARNING - Silently ignoring the fact that there are no HTML partials generated from markdown to include in automated commit...'
     - run: git -c "user.name=Fleetwood" -c "user.email=github@example.com" commit -am 'AUTOMATED COMMIT - Deployed the latest, including generated collateral such as compiled documentation, modified HTML layouts, and a .sailsrc file that references minified client-side code assets.'
 
     # Configure the Heroku app we'll be deploying to


### PR DESCRIPTION
Relates to #706 #1380 