### PR TITLE
Update sidepanel padding on existing "New" and "Edit/run" query pages + additional "spiffier" changes

### DIFF
--- a/frontend/components/side_panels/HostSidePanel/HostSidePanel.jsx
+++ b/frontend/components/side_panels/HostSidePanel/HostSidePanel.jsx
@@ -64,7 +64,7 @@ class HostSidePanel extends Component {
           type="all-hosts"
         />
 
-        <h3>Operating Systems</h3>
+        <h3>Operating systems</h3>
         <PanelGroup
           groupItems={hostPlatformLabels}
           onLabelClick={onLabelClick}

--- a/frontend/components/side_panels/HostSidePanel/PanelGroupItem/PanelGroupItem.jsx
+++ b/frontend/components/side_panels/HostSidePanel/PanelGroupItem/PanelGroupItem.jsx
@@ -13,7 +13,7 @@ const baseClass = "panel-group-item";
 
 const displayIcon = (name) => {
   switch (name) {
-    case "Darwin":
+    case "macOS":
       return <img src={darwinIcon} alt="Apple icon" />;
     case "Linux":
       return <img src={linuxIcon} alt="Linux icon" />;

--- a/frontend/components/side_panels/QuerySidePanel/_styles.scss
+++ b/frontend/components/side_panels/QuerySidePanel/_styles.scss
@@ -1,13 +1,13 @@
 .query-side-panel {
   &__header {
-    margin: 0 0 $pad-medium;
+    margin: 0 0 $pad-small;
     font-size: $x-small;
     font-weight: $bold;
     color: $core-fleet-black;
   }
 
   &__choose-table {
-    margin: 0 0 $pad-medium;
+    margin: 0 0 $pad-xlarge;
 
     .form-field {
       margin-bottom: $pad-medium;
@@ -29,7 +29,7 @@
     font-size: $x-small;
     color: $core-fleet-black;
     list-style: none;
-    margin: 0 0 $pad-large;
+    margin: 0 0 $pad-xlarge;
     padding: 0;
 
     .fleeticon {
@@ -96,7 +96,7 @@
     justify-content: space-between;
     color: $core-fleet-black;
     font-size: px-to-rem(14);
-    padding: 12px 0;
+    padding: $pad-small 0;
 
     &:first-of-type {
       border: 0;

--- a/frontend/components/side_panels/SecondarySidePanelContainer/_styles.scss
+++ b/frontend/components/side_panels/SecondarySidePanelContainer/_styles.scss
@@ -4,6 +4,6 @@
   box-sizing: border-box;
   border-left: 1px solid $ui-gray;
   overflow: auto;
-  min-width: $sidepanel-width;
+  width: $sidepanel-width;
   padding: $pad-xxlarge;
 }

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -332,6 +332,15 @@
         }
       }
     }
+
+    .data-table__table {
+      table-layout: fixed;
+
+      td {
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    }
   }
 
   tbody {

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -56,12 +56,14 @@
     margin-top: $pad-medium;
 
     .title {
+      display: flex;
+      align-items: center;
       span {
         font-size: $x-small;
         font-weight: $bold;
       }
       button {
-        margin-left: 12px;
+        margin-left: $pad-small;
         padding: 0;
         height: auto;
 
@@ -178,7 +180,7 @@
           margin-top: 0 !important;
         }
       }
-      
+
       .Select-multi-value-wrapper {
         width: max-content; // move select arrow
         height: 20px;


### PR DESCRIPTION
- Set explicit width so that changing the selected table does not alter the side panel's width
- Update padding to match Figma
- Update "Software" table on the **Host details** page to prevent the table from overflowing the page
  - Note: This is another occurrence of the table and column width as seen in #1701 
- Adjust alignment for edit and delete label icons
- Reveal macOS icon the "Hosts" page