### PR TITLE
Updated "Install" link on basic-documentation.ejs

### DIFF
--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -28,7 +28,7 @@
             <img class="cta-image" alt="Install Fleet" src="/images/install-fleet-140x72@2x.png"/>
             <div class="text-center text-md-left cta-text">
               <p class="font-weight-bold p-0 pl-md-4 pt-2 pt-md-0 m-0">Install osquery and Fleet</p>
-              <a class="p-0 pl-md-4 pt-2 pt-md-0 arrow" href="/get-started">
+              <a class="p-0 pl-md-4 pt-2 pt-md-0 arrow" href="/install">
                 Get started
                 <img class="d-inline mb-1" style="height: 16px; width: auto;" alt="right arrow" src="/images/arrow-right-16x16@2x.png" />
               </a>  


### PR DESCRIPTION
This link change was missed this morning.

Background - we don't want to send existing users from the docs to the pricing page, so until we are able to deploy the new Get Started page, we are temporarily sending this link to the install guide on GitHub.