### PR TITLE
Move vulnerabilities configuration options into 2-Deploying/2-Configuration.md

### DIFF
--- a/docs/1-Using-Fleet/13-Vulnerability-Processing.md
+++ b/docs/1-Using-Fleet/13-Vulnerability-Processing.md
@@ -62,20 +62,6 @@ fleet serve --config /tmp/fleet.yml
 ```
 
 The path specified needs to exist and fleet needs to be able to read and write to and from it. This is the only mandatory
-configuration needed for vulnerability processing to work. However, there are other optional configuration options:
-
-- periodicity: how often vulnerabilities are checked. Default: 1h. Env var: FLEET_VULNERABILITIES_PERIODICITY
-- cpe_database_url: URL to fetch the CPE dictionary database from. Some users want to control where fleet gets its database
-from. When Fleet sees this value defined, it downloads the file directly. It expects a file in the same format as can be found
-in https://github.com/fleetdm/nvd/releases. If this value is not defined, Fleet checks for the latest release in Github
-and only downloads it if needed. Default: "". Env var: FLEET_VULNERABILITIES_CPE_DATABASE_URL
-- cve_feed_prefix_url: similarly to the CPE dictionary, we allow users to define where to get the CVE feeds from. In this 
-case, the url should be a host that serves the files in the path /feeds/json/cve/1.1/. Fleet expects to find there all the
-JSON Feeds that can be found in https://nvd.nist.gov/vuln/data-feeds. When not defined, Fleet downloads from the nvd.nist.gov 
-host. Default: "". Env var: FLEET_VULNERABILITIES_CPE_DATABASE_URL
-- current_instance_checks: When running multiple instances of the Fleet server, by default, one of them dynamically takes
-the lead in vulnerability processing. This lead can change over time. Some Fleet users want to be able to define which 
-deployment is doing this checking. If you wish to do this, you'll need to deploy your Fleet instances with this set explicitly
-to no and one of them set to yes. Default: auto. Env var: FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS
+configuration needed for vulnerability processing to work. However, there are other optional configuration options which can be found [here in the Configuration documentation](../2-Deploying/2-Configuration.md#vulnerabilities).
 
 You'll need to restart the Fleet instances after changing these settings.

--- a/docs/2-Deploying/2-Configuration.md
+++ b/docs/2-Deploying/2-Configuration.md
@@ -1255,7 +1255,7 @@ The path specified needs to exist and fleet needs to be able to read and write t
   	databases_path: /some/path
   ```
 
-###### `vulnerabilities_periodicity`
+###### `periodicity`
 
 How often vulnerabilities are checked.
 
@@ -1268,7 +1268,7 @@ How often vulnerabilities are checked.
   	vulnerabilities_periodicity: 1hr
   ```
 
-###### `vulnerabilities_cpe_database_url`
+###### `cpe_database_url`
 
 URL to fetch the CPE dictionary database from. Some users want to control where fleet gets its database from. When Fleet sees this value defined, it downloads the file directly. It expects a file in the same format as can be found in https://github.com/fleetdm/nvd/releases. If this value is not defined, Fleet checks for the latest release in Github and only downloads it if needed.
 
@@ -1281,12 +1281,12 @@ URL to fetch the CPE dictionary database from. Some users want to control where 
   	vulnerabilities_cpe_database_url: ""
   ```
 
-###### `vulnerabilities_cve_database_url`
+###### `cve_feed_prefix_url`
 
 Similarly to the CPE dictionary, we allow users to define where to get the CVE feeds from. In this case, the url should be a host that serves the files in the path /feeds/json/cve/1.1/. Fleet expects to find there all the JSON Feeds that can be found in https://nvd.nist.gov/vuln/data-feeds. When not defined, Fleet downloads from the nvd.nist.gov host.
 
 - Default value: `""`
-- Environment variable: `FLEET_VULNERABILITIES_CVE_DATABASE_URL`
+- Environment variable: `FLEET_VULNERABILITIES_CVE_FEED_PREFIX_URL`
 - Config file format:
 
   ```
@@ -1298,7 +1298,7 @@ Similarly to the CPE dictionary, we allow users to define where to get the CVE f
 
 When running multiple instances of the Fleet server, by default, one of them dynamically takes the lead in vulnerability processing. This lead can change over time. Some Fleet users want to be able to define which deployment is doing this checking. If you wish to do this, you'll need to deploy your Fleet instances with this set explicitly to no and one of them set to yes.
 
-- Default value: `""`
+- Default value: `auto`
 - Environment variable: `FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS`
 - Config file format:
 

--- a/docs/2-Deploying/2-Configuration.md
+++ b/docs/2-Deploying/2-Configuration.md
@@ -1240,6 +1240,73 @@ AWS STS role ARN to use for S3 authentication.
   	sts_assume_role_arn: arn:aws:iam::1234567890:role/some-s3-role
   ```
 
+##### Vulnerabilities
+
+###### `databases_path`
+
+The path specified needs to exist and fleet needs to be able to read and write to and from it. This is the only mandatory configuration needed for vulnerability processing to work.
+
+- Default value: none
+- Environment variable: `FLEET_VULNERABILITIES_DATABASES_PATH`
+- Config file format:
+
+  ```
+  vulnerabilities:
+  	databases_path: /some/path
+  ```
+
+###### `vulnerabilities_periodicity`
+
+How often vulnerabilities are checked.
+
+- Default value: `1hr`
+- Environment variable: `FLEET_VULNERABILITIES_PERIODICITY`
+- Config file format:
+
+  ```
+  vulnerabilities:
+  	vulnerabilities_periodicity: 1hr
+  ```
+
+###### `vulnerabilities_cpe_database_url`
+
+URL to fetch the CPE dictionary database from. Some users want to control where fleet gets its database from. When Fleet sees this value defined, it downloads the file directly. It expects a file in the same format as can be found in https://github.com/fleetdm/nvd/releases. If this value is not defined, Fleet checks for the latest release in Github and only downloads it if needed.
+
+- Default value: `""`
+- Environment variable: `FLEET_VULNERABILITIES_CPE_DATABASE_URL`
+- Config file format:
+
+  ```
+  vulnerabilities:
+  	vulnerabilities_cpe_database_url: ""
+  ```
+
+###### `vulnerabilities_cve_database_url`
+
+Similarly to the CPE dictionary, we allow users to define where to get the CVE feeds from. In this case, the url should be a host that serves the files in the path /feeds/json/cve/1.1/. Fleet expects to find there all the JSON Feeds that can be found in https://nvd.nist.gov/vuln/data-feeds. When not defined, Fleet downloads from the nvd.nist.gov host.
+
+- Default value: `""`
+- Environment variable: `FLEET_VULNERABILITIES_CVE_DATABASE_URL`
+- Config file format:
+
+  ```
+  vulnerabilities:
+  	vulnerabilities_cve_database_url: ""
+  ```
+
+###### `current_instance_checks`
+
+When running multiple instances of the Fleet server, by default, one of them dynamically takes the lead in vulnerability processing. This lead can change over time. Some Fleet users want to be able to define which deployment is doing this checking. If you wish to do this, you'll need to deploy your Fleet instances with this set explicitly to no and one of them set to yes.
+
+- Default value: `""`
+- Environment variable: `FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS`
+- Config file format:
+
+  ```
+  vulnerabilities:
+  	current_instance_checks: yes
+  ```
+
 ## Managing osquery configurations
 
 We recommend that you use an infrastructure configuration management tool to manage these osquery configurations consistently across your environment. If you're unsure about what configuration management tools your organization uses, contact your company's system administrators. If you are evaluating new solutions for this problem, the founders of Fleet have successfully managed configurations in large production environments using [Chef](https://www.chef.io/chef/) and [Puppet](https://puppet.com/).

--- a/docs/2-Deploying/2-Configuration.md
+++ b/docs/2-Deploying/2-Configuration.md
@@ -1265,7 +1265,7 @@ How often vulnerabilities are checked.
 
   ```
   vulnerabilities:
-  	vulnerabilities_periodicity: 1hr
+  	periodicity: 1hr
   ```
 
 ###### `cpe_database_url`
@@ -1278,7 +1278,7 @@ URL to fetch the CPE dictionary database from. Some users want to control where 
 
   ```
   vulnerabilities:
-  	vulnerabilities_cpe_database_url: ""
+  	cpe_database_url: ""
   ```
 
 ###### `cve_feed_prefix_url`
@@ -1291,7 +1291,7 @@ Similarly to the CPE dictionary, we allow users to define where to get the CVE f
 
   ```
   vulnerabilities:
-  	vulnerabilities_cve_database_url: ""
+  	cve_database_url: ""
   ```
 
 ###### `current_instance_checks`


### PR DESCRIPTION
- Move vulnerabilities config options into `2-Deploying/2-Configuration.md` and link to these options from the Vulnerability processing docs. This way, all Fleet server configuration options live in a central location.
- Edit the second `FLEET_VULNERABILITIES_CPE_DATABASE_URL` to `FLEET_VULNERABILITIES_CVE_DATABASE_URL`. 
  - @chiiph I believe this was a typo in the previous version of the docs. Please let me know if I'm incorrect.