### PR TITLE
Fix anchor links for "Get enroll secrets" and "Modify enroll secrets" sections in API docs

### DIFF
--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -4965,7 +4965,7 @@ Modifies the Fleet's configuration with the supplied information.
 }
 ```
 
-### Get global enroll secret(s)
+### Get enroll secrets
 
 Returns the valid global enroll secrets.
 
@@ -5000,7 +5000,7 @@ None.
 }
 ```
 
-### Modify enroll secret(s)
+### Modify enroll secrets
 
 Replaces the active global enroll secrets with the secrets specified.
 


### PR DESCRIPTION
Resolves #1736 
