### PR TITLE
Mention the forward-only migrations in the docs

### DIFF
--- a/docs/3-Contributing/3-Migrations.md
+++ b/docs/3-Contributing/3-Migrations.md
@@ -10,6 +10,8 @@ Database schemas are managed by a series of migrations defined in go code. We us
 
 Note: Once committed to the Fleet repo, table migrations should be considered immutable. Any changes to an existing table should take place in a new migration executing ALTERs.
 
+Also note that we don't use the `Down` part of the migrations anymore (older migrations did implement them). The `Down` function should just `return nil`, as we use forward-only migrations.
+
 From the project root run the following shell command:
 
 ``` bash


### PR DESCRIPTION
As explained here: https://github.com/fleetdm/fleet/pull/1720, we don't use "down" migrations, so I thought I'd update the docs to mention it.

# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

- [ ] ~~Changes file added (if needed)~~ just a doc clarification
- [ ] ~~Documented any API changes~~ none
- [ ] ~~Added tests for all functionality~~ doc only
- [ ] ~~Manual QA for all functionality~~ doc only
