### PR TITLE
Fix sql-related missing Close/Err calls

### DIFF
--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -45,8 +45,14 @@ func (d *Datastore) isEventSchedulerEnabled() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	defer rows.Close()
+
 	if !rows.Next() {
-		return false, errors.New("Error detecting MySQL event scheduler status.")
+		err := errors.New("Error detecting MySQL event scheduler status.")
+		if rerr := rows.Err(); rerr != nil {
+			err = rerr
+		}
+		return false, err
 	}
 	var value string
 	if err := rows.Scan(&value); err != nil {

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -35,6 +35,7 @@ func (d *Datastore) ApplyLabelSpecs(specs []*fleet.LabelSpec) (err error) {
 		if err != nil {
 			return errors.Wrap(err, "prepare ApplyLabelSpecs insert")
 		}
+		defer stmt.Close()
 
 		for _, s := range specs {
 			if s.Name == "" {
@@ -324,9 +325,11 @@ func (d *Datastore) LabelQueriesForHost(host *fleet.Host, cutoff time.Time) (map
 
 		results[id] = query
 	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "iterating over returned rows")
+	}
 
 	return results, nil
-
 }
 
 func (d *Datastore) RecordLabelQueryExecutions(host *fleet.Host, results map[uint]bool, updated time.Time) error {

--- a/server/datastore/mysql/queries.go
+++ b/server/datastore/mysql/queries.go
@@ -49,6 +49,7 @@ func (d *Datastore) ApplyQueries(authorID uint, queries []*fleet.Query) (err err
 	if err != nil {
 		return errors.Wrap(err, "prepare ApplyQueries insert")
 	}
+	defer stmt.Close()
 
 	for _, q := range queries {
 		if q.Name == "" {


### PR DESCRIPTION
While preparing for #1695 , I noticed a few missing Close/Err calls with SQL-related values. This PR addresses those before making larger changes in that area.

I ran `$ golangci-lint run --disable-all --presets sql ./server/datastore/mysql/` to get the full list. There's still one (false positive) that remains after the fix, it's because the `*sql.Rows` is embedded in a struct and so isn't closed in its enclosing function. I checked where that returned struct is used, and it is properly closed there (https://github.com/fleetdm/fleet/blob/main/server/vulnerabilities/cpe.go#L223-L227). 

# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

- [ ] ~~Changes file added (if needed)~~ (purely internal static checks/linting fixes)
- [ ] ~~Documented any API changes~~ (none)
- [ ] ~~Added tests for all functionality~~ (no new functionality, however I did run the tests after the fixes of course)
- [ ] ~~Manual QA for all functionality~~
