### PR TITLE
Host Details Page: Render disk space

### DIFF
--- a/changes/1770-render-disk-space
+++ b/changes/1770-render-disk-space
@@ -1,0 +1,1 @@
+Render disk space on host details page

--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -655,6 +655,8 @@ The endpoint returns the host's installed `software` if the software inventory f
     "pack_stats": null,
     "team_name": null,
     "additional": {},
+    "gigs_disk_space_available": 46.1,
+    "percent_disk_space_available": 73,
     "users": [
       {
         "id": 98,
@@ -773,6 +775,8 @@ Returns the information of the host specified using the `uuid`, `osquery_host_id
     "display_text": "2ceca32fe484",
     "team_id": null,
     "team_name": null,
+    "gigs_disk_space_available": 45.86,
+    "percent_disk_space_available": 73,
     "pack_stats": null,
   }
 }

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -48,14 +48,14 @@ export default PropTypes.shape({
   ),
   team_name: PropTypes.string,
   additional: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  percent_disk_space_available: PropTypes.number,
+  gigs_disk_space_available: PropTypes.number,
   labels: PropTypes.arrayOf(labelInterface),
   packs: PropTypes.arrayOf(packInterface),
   software: PropTypes.arrayOf(softwareInterface),
   status: PropTypes.string,
   display_text: PropTypes.string,
   users: PropTypes.arrayOf(hostUserInterface),
-  percent_disk_space_available: PropTypes.number,
-  gigs_disk_space_available: PropTypes.number,
 });
 
 export interface IHost {
@@ -99,12 +99,12 @@ export interface IHost {
   }[];
   team_name: string;
   additional: object; // eslint-disable-line @typescript-eslint/ban-types
+  percent_disk_space_available: number;
+  gigs_disk_space_available: number;
   labels: ILabel[];
   packs: IPack[];
   software: ISoftware[];
   status: string;
   display_text: string;
   users: IHostUser[];
-  percent_disk_space_available: number;
-  gigs_disk_space_available: number;
 }

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -54,6 +54,8 @@ export default PropTypes.shape({
   status: PropTypes.string,
   display_text: PropTypes.string,
   users: PropTypes.arrayOf(hostUserInterface),
+  percent_disk_space_available: PropTypes.number,
+  gigs_disk_space_available: PropTypes.number,
 });
 
 export interface IHost {
@@ -103,4 +105,6 @@ export interface IHost {
   status: string;
   display_text: string;
   users: IHostUser[];
+  percent_disk_space_available: number;
+  gigs_disk_space_available: number;
 }

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -667,7 +667,6 @@ export class HostDetailsPage extends Component {
         </div>
       );
     };
-
     return (
       <div className={`${baseClass} body-wrap`}>
         <div>
@@ -697,13 +696,17 @@ export class HostDetailsPage extends Component {
                 </span>
               </div>
               {isBasicTier && hostTeam()}
-              {titleData.percent_disk_space_available && (
+              {host.percent_disk_space_available && (
                 <div className="info__item info__item--title">
                   <span className="info__header">Disk Space</span>
                   <span className="info__data">
                     <div className="info__disk-space">
                       <div
-                        className="info__disk-space-used"
+                        className={
+                          titleData.percent_disk_space_available > 20
+                            ? "info__disk-space-used"
+                            : "info__disk-space-warning"
+                        }
                         style={{
                           width:
                             100 - titleData.percent_disk_space_available + "%",

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -625,6 +625,8 @@ export class HostDetailsPage extends Component {
         "os_version",
         "enroll_secret_name",
         "detail_updated_at",
+        "percent_disk_space_available",
+        "gigs_disk_space_available",
       ])
     );
     const aboutData = normalizeEmptyValues(
@@ -665,6 +667,7 @@ export class HostDetailsPage extends Component {
         </div>
       );
     };
+
     return (
       <div className={`${baseClass} body-wrap`}>
         <div>
@@ -693,7 +696,23 @@ export class HostDetailsPage extends Component {
                   {titleData.status}
                 </span>
               </div>
-              {isBasicTier ? hostTeam() : null}
+              {isBasicTier && hostTeam()}
+              {titleData.percent_disk_space_avaiable && (
+                <div className="info__item info__item--title">
+                  <span className="info__header">Disk Space</span>
+                  <span className="info__data">
+                    <div className="info__disk-space">
+                      <div
+                        className="info__disk-space-used"
+                        style={{
+                          width: titleData.percent_disk_space_avaiable + "%",
+                        }}
+                      ></div>
+                    </div>
+                    {titleData.gigs_disk_space_availabe} GB available
+                  </span>
+                </div>
+              )}
               <div className="info__item info__item--title">
                 <span className="info__header">RAM</span>
                 <span className="info__data">

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -670,8 +670,8 @@ export class HostDetailsPage extends Component {
 
     const renderDiskSpace = () => {
       if (
-        host.gigs_disk_space_available !== 0 ||
-        host.percent_disk_space_available !== 0
+        host.gigs_disk_space_available > 0 ||
+        host.percent_disk_space_available > 0
       ) {
         return (
           <span className="info__data">

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -668,9 +668,6 @@ export class HostDetailsPage extends Component {
       );
     };
 
-    console.log(host);
-    console.log(host.percent_disk_space_available);
-
     const renderDiskSpace = () => {
       if (
         host.gigs_disk_space_available !== 0 ||

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -696,7 +696,7 @@ export class HostDetailsPage extends Component {
                 </span>
               </div>
               {isBasicTier && hostTeam()}
-              {host.percent_disk_space_available && (
+              {host.percent_disk_space_available ? (
                 <div className="info__item info__item--title">
                   <span className="info__header">Disk Space</span>
                   <span className="info__data">
@@ -717,7 +717,7 @@ export class HostDetailsPage extends Component {
                     {titleData.gigs_disk_space_available} GB available
                   </span>
                 </div>
-              )}
+              ) : null}
               <div className="info__item info__item--title">
                 <span className="info__header">RAM</span>
                 <span className="info__data">

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -697,7 +697,7 @@ export class HostDetailsPage extends Component {
                 </span>
               </div>
               {isBasicTier && hostTeam()}
-              {titleData.percent_disk_space_avaiable && (
+              {titleData.percent_disk_space_available && (
                 <div className="info__item info__item--title">
                   <span className="info__header">Disk Space</span>
                   <span className="info__data">
@@ -705,11 +705,12 @@ export class HostDetailsPage extends Component {
                       <div
                         className="info__disk-space-used"
                         style={{
-                          width: titleData.percent_disk_space_avaiable + "%",
+                          width:
+                            100 - titleData.percent_disk_space_available + "%",
                         }}
                       ></div>
                     </div>
-                    {titleData.gigs_disk_space_availabe} GB available
+                    {titleData.gigs_disk_space_available} GB available
                   </span>
                 </div>
               )}

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -708,10 +708,11 @@ export class HostDetailsPage extends Component {
                             : "info__disk-space-warning"
                         }
                         style={{
-                          width:
-                            100 - titleData.percent_disk_space_available + "%",
+                          width: `${
+                            100 - titleData.percent_disk_space_available
+                          }%`,
                         }}
-                      ></div>
+                      />
                     </div>
                     {titleData.gigs_disk_space_available} GB available
                   </span>

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -667,6 +667,36 @@ export class HostDetailsPage extends Component {
         </div>
       );
     };
+
+    console.log(host);
+    console.log(host.percent_disk_space_available);
+
+    const renderDiskSpace = () => {
+      if (
+        host.gigs_disk_space_available !== 0 ||
+        host.percent_disk_space_available !== 0
+      ) {
+        return (
+          <span className="info__data">
+            <div className="info__disk-space">
+              <div
+                className={
+                  titleData.percent_disk_space_available > 20
+                    ? "info__disk-space-used"
+                    : "info__disk-space-warning"
+                }
+                style={{
+                  width: `${100 - titleData.percent_disk_space_available}%`,
+                }}
+              />
+            </div>
+            {titleData.gigs_disk_space_available} GB available
+          </span>
+        );
+      }
+      return <span className="info__data">No data available</span>;
+    };
+
     return (
       <div className={`${baseClass} body-wrap`}>
         <div>
@@ -696,28 +726,10 @@ export class HostDetailsPage extends Component {
                 </span>
               </div>
               {isBasicTier && hostTeam()}
-              {host.percent_disk_space_available ? (
-                <div className="info__item info__item--title">
-                  <span className="info__header">Disk Space</span>
-                  <span className="info__data">
-                    <div className="info__disk-space">
-                      <div
-                        className={
-                          titleData.percent_disk_space_available > 20
-                            ? "info__disk-space-used"
-                            : "info__disk-space-warning"
-                        }
-                        style={{
-                          width: `${
-                            100 - titleData.percent_disk_space_available
-                          }%`,
-                        }}
-                      />
-                    </div>
-                    {titleData.gigs_disk_space_available} GB available
-                  </span>
-                </div>
-              ) : null}
+              <div className="info__item info__item--title">
+                <span className="info__header">Disk Space</span>
+                {renderDiskSpace()}
+              </div>
               <div className="info__item info__item--title">
                 <span className="info__header">RAM</span>
                 <span className="info__data">

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -38,6 +38,21 @@
         }
       }
 
+      &__disk-space {
+        display: inline-block;
+        height: 4px;
+        width: 50px;
+        background-color: $ui-fleet-blue-15;
+        border-radius: 2px;
+        margin-right: $pad-small;
+        overflow: hidden;
+      }
+
+      &__disk-space-used {
+        background-color: $ui-success;
+        height: 100%;
+      }
+
       &__header {
         color: $core-fleet-black;
         font-weight: $bold;

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -53,6 +53,11 @@
         height: 100%;
       }
 
+      &__disk-space-used-warning {
+        background-color: $ui-warning;
+        height: 100%;
+      }
+
       &__header {
         color: $core-fleet-black;
         font-weight: $bold;

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -53,7 +53,7 @@
         height: 100%;
       }
 
-      &__disk-space-used-warning {
+      &__disk-space-warning {
         background-color: $ui-warning;
         height: 100%;
       }


### PR DESCRIPTION
- Render disk space on Host Details Page
- Green bar renders yellow when <20% of disk space is available
- Add disk space to API docs and frontend interfaces

<img width="1295" alt="Screen Shot 2021-08-23 at 3 49 20 PM" src="https://user-images.githubusercontent.com/71795832/130529246-54a852a7-acaa-4952-a9e0-d1eab33c8666.png">

https://www.loom.com/share/815d59e591164d999b795f415923a0c6

Add @zwass as a reviewer since @noahtalerman is out 👍 