### PR TITLE
Host Details Page: Query button for observers

### DIFF
--- a/changes/1799-observer-query-from-host-details
+++ b/changes/1799-observer-query-from-host-details
@@ -1,0 +1,1 @@
+Query CTA extended to observers on host details page

--- a/cypress/integration/basic/maintainer.spec.ts
+++ b/cypress/integration/basic/maintainer.spec.ts
@@ -49,7 +49,6 @@ describe("Basic tier - Maintainer user", () => {
     cy.get(".transfer-action-btn").click();
     cy.findByText(/transferred to oranges/i).should("exist");
     cy.findByText(/team/i).next().contains("Oranges");
-    cy.contains("button", /transfer/i).should("not.exist");
     cy.contains("button", /delete/i).should("exist");
     cy.contains("button", /query/i).click();
     cy.contains("button", /create custom query/i).should("exist");

--- a/cypress/integration/basic/maintainer.spec.ts
+++ b/cypress/integration/basic/maintainer.spec.ts
@@ -49,6 +49,9 @@ describe("Basic tier - Maintainer user", () => {
     cy.get(".transfer-action-btn").click();
     cy.findByText(/transferred to oranges/i).should("exist");
     cy.findByText(/team/i).next().contains("Oranges");
+    cy.contains("button", /delete/i).should("exist");
+    cy.contains("button", /query/i).click();
+    cy.contains("button", /create custom query/i).should("exist");
 
     // Query pages: Can see teams UI for create, edit, and run query
     cy.visit("/queries/manage");

--- a/cypress/integration/basic/maintainer.spec.ts
+++ b/cypress/integration/basic/maintainer.spec.ts
@@ -49,6 +49,7 @@ describe("Basic tier - Maintainer user", () => {
     cy.get(".transfer-action-btn").click();
     cy.findByText(/transferred to oranges/i).should("exist");
     cy.findByText(/team/i).next().contains("Oranges");
+    cy.contains("button", /transfer/i).should("not.exist");
     cy.contains("button", /delete/i).should("exist");
     cy.contains("button", /query/i).click();
     cy.contains("button", /create custom query/i).should("exist");

--- a/cypress/integration/basic/observer.spec.ts
+++ b/cypress/integration/basic/observer.spec.ts
@@ -35,6 +35,9 @@ describe("Basic tier - Observer user", () => {
       cy.findByText("Team").should("exist");
     });
     cy.contains("button", /transfer/i).should("not.exist");
+    cy.contains("button", /delete/i).should("not.exist");
+    cy.contains("button", /query/i).click();
+    cy.contains("button", /create custom query/i).should("not.exist");
 
     // Query pages: Can see team in select targets dropdown
     cy.visit("/queries/manage");

--- a/cypress/integration/core/observer.spec.ts
+++ b/cypress/integration/core/observer.spec.ts
@@ -44,7 +44,8 @@ describe("Core tier - Observer user", () => {
     cy.findByText(/team/i).should("not.exist");
     cy.contains("button", /transfer/i).should("not.exist");
     cy.contains("button", /delete/i).should("not.exist");
-    cy.contains("button", /query/i).should("not.exist");
+    cy.contains("button", /query/i).click();
+    cy.contains("button", /create custom query/i).should("not.exist");
 
     // Queries pages: Observer can or cannot run UI
     cy.visit("/queries/manage");

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -337,11 +337,6 @@ export class HostDetailsPage extends Component {
 
     const isOnline = host.status === "online";
 
-    // Hide action buttons for global and team only observers
-    if (isOnlyObserver) {
-      return null;
-    }
-
     return (
       <div className={`${baseClass}__action-button-container`}>
         {canTransferTeam && (
@@ -374,9 +369,11 @@ export class HostDetailsPage extends Component {
             You can’t query <br /> an offline host.
           </span>
         </ReactTooltip>
-        <Button onClick={toggleDeleteHostModal()} variant="text-icon">
-          Delete <img src={DeleteIcon} alt="Delete host icon" />
-        </Button>
+        {!isOnlyObserver && (
+          <Button onClick={toggleDeleteHostModal()} variant="text-icon">
+            Delete <img src={DeleteIcon} alt="Delete host icon" />
+          </Button>
+        )}
       </div>
     );
   };
@@ -610,6 +607,7 @@ export class HostDetailsPage extends Component {
       isBasicTier,
       isGlobalAdmin,
       teams,
+      isOnlyObserver,
     } = this.props;
     const {
       host,
@@ -817,6 +815,7 @@ export class HostDetailsPage extends Component {
             queries={queries}
             dispatch={dispatch}
             queryErrors={queryErrors}
+            isOnlyObserver={isOnlyObserver}
           />
         )}
         {showTransferHostModal && (

--- a/frontend/pages/hosts/HostDetailsPage/SelectQueryModal/SelectQueryModal.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/SelectQueryModal/SelectQueryModal.jsx
@@ -34,18 +34,33 @@ const onQueryHostSaved = (host, selectedQuery, dispatch) => {
 };
 
 const SelectQueryModal = (props) => {
-  const { host, onCancel, dispatch, queries, queryErrors } = props;
+  const {
+    host,
+    onCancel,
+    dispatch,
+    queries,
+    queryErrors,
+    isOnlyObserver,
+  } = props;
+
+  let queriesAvailableToRun = queries;
+
+  if (isOnlyObserver) {
+    queriesAvailableToRun = queries.filter(
+      (query) => query.observer_can_run === true
+    );
+  }
 
   const [queriesFilter, setQueriesFilter] = useState("");
 
   const getQueries = () => {
     if (!queriesFilter) {
-      return queries;
+      return queriesAvailableToRun;
     }
 
     const lowerQueryFilter = queriesFilter.toLowerCase();
 
-    return filter(queries, (query) => {
+    return filter(queriesAvailableToRun, (query) => {
       if (!query.name) {
         return false;
       }
@@ -140,10 +155,12 @@ const SelectQueryModal = (props) => {
                 value={queriesFilter}
               />
             </div>
-            <div className={`${baseClass}__create-query`}>
-              <span>OR</span>
-              {customQueryButton()}
-            </div>
+            {!isOnlyObserver && (
+              <div className={`${baseClass}__create-query`}>
+                <span>OR</span>
+                {customQueryButton()}
+              </div>
+            )}
           </div>
           <div>{queryList}</div>
         </div>
@@ -199,6 +216,7 @@ SelectQueryModal.propTypes = {
   queries: PropTypes.arrayOf(queryInterface),
   onCancel: PropTypes.func,
   queryErrors: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  isOnlyObserver: PropTypes.bool,
 };
 
 export default SelectQueryModal;


### PR DESCRIPTION
- Host Details Page Query CTA button/modal now available for Observer
- Only queries that observers can run will render in the modal
- Custom query CTA not available for Observer
- All e2e tests updated accordingly

Closes #1513 

<img width="1417" alt="Screen Shot 2021-08-25 at 10 26 30 AM" src="https://user-images.githubusercontent.com/71795832/130837192-649d2773-faf8-40ad-92d1-96eb921fe46f.png">

https://www.loom.com/share/0cbbd0ef692f496783e93bcfe6767bd9