### PR TITLE
Fix bug in running orbit on Linux

### DIFF
--- a/orbit/pkg/packaging/macos.go
+++ b/orbit/pkg/packaging/macos.go
@@ -232,7 +232,7 @@ func xarBom(opt Options, rootPath string) error {
 	case "darwin":
 		cmdMkbom = exec.Command("mkbom", filepath.Join(rootPath, "root"), filepath.Join("flat", "base.pkg", "Bom"))
 	case "linux":
-		cmdMkbom = exec.Command("mkbom", "-u", "0", "-g", "80", filepath.Join(rootPath, "flat", "root"), filepath.Join("flat", "base.pkg", "Bom"))
+		cmdMkbom = exec.Command("mkbom", "-u", "0", "-g", "80", filepath.Join(rootPath, "root"), filepath.Join("flat", "base.pkg", "Bom"))
 	}
 	cmdMkbom.Dir = rootPath
 	cmdMkbom.Stdout = os.Stdout


### PR DESCRIPTION
Mkbom was referencing a non-existant folder, updated to point at the correct folder.

# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

- [x] Changes file added (if needed)
- [ ] Documented any API changes - **not needed**
- [ ] Added tests for all functionality- **Can't find existing tests**
- [x] Manual QA for all functionality
