### PR TITLE
Update sources (links) to check when on call in Support process document

### DIFF
--- a/docs/3-Contributing/2-Testing.md
+++ b/docs/3-Contributing/2-Testing.md
@@ -225,7 +225,7 @@ Note that a "restore" will replace the state of the development database with th
 
 ## Teams seed data
 
-When developing on both the `master` and `teams` branches, it may be useful to create seed data that includes users and teams.
+When developing Fleet, it may be useful to create seed data that includes users and teams.
 
 Check out this Loom demo video that walks through creating teams seed data:
 https://www.loom.com/share/1c41a1540e8f41328a7a6cfc56ad0a01

--- a/handbook/support-process.md
+++ b/handbook/support-process.md
@@ -76,13 +76,15 @@ To provide another way of tracking status without closing issues altogether, con
 
 ## Sources
 
-There are three sources that the individual on-call should monitor for activity:
+There are four sources that the individual on-call should monitor for activity:
 
 1. Customer Slack channels - Found under the "Connections" section in Slack. These channels are usually titled "at-insert-customer-name-here"
 
 2. Community chatroom - https://osquery.slack.com, #fleet channel
 
-3. GitHub issues and pull requests - [Github Triage: Community contributions with no milestones or assignees](https://github.com/issues?q=is%3Aopen+archived%3Afalse+org%3Afleetdm+no%3Amilestone+no%3Aassignee+sort%3Aupdated-desc+)
+3. Reported bugs - [GitHub issues with the "bug" and ":reproduce" label](https://github.com/fleetdm/fleet/issues?q=is%3Aopen+is%3Aissue+label%3Abug+label%3A%3Areproduce)
+
+4. Pull requests opened by the community - [GitHub open pull requests](https://github.com/fleetdm/fleet/pulls?q=is%3Aopen+is%3Apr)
 
 ## Resources
 

--- a/handbook/support-process.md
+++ b/handbook/support-process.md
@@ -24,7 +24,7 @@ This way, the Fleet team can constantly improve the effectiveness and experience
 
 - Celebrate contributions. 
 
-- Triage bugs, identify community pull requests and questions.
+- Triage bugs, identify community feature requests, community pull requests and community questions.
 
 ## How?
 

--- a/handbook/support-process.md
+++ b/handbook/support-process.md
@@ -24,7 +24,7 @@ This way, the Fleet team can constantly improve the effectiveness and experience
 
 - Celebrate contributions. 
 
-- Identify actionable bugs, feature requests, pull requests and questions.
+- Triage bugs, identify community pull requests and questions.
 
 ## How?
 
@@ -82,7 +82,7 @@ There are four sources that the individual on-call should monitor for activity:
 
 2. Community chatroom - https://osquery.slack.com, #fleet channel
 
-3. Reported bugs - [GitHub issues with the "bug" and ":reproduce" label](https://github.com/fleetdm/fleet/issues?q=is%3Aopen+is%3Aissue+label%3Abug+label%3A%3Areproduce)
+3. Reported bugs - [GitHub issues with the "bug" and ":reproduce" label](https://github.com/fleetdm/fleet/issues?q=is%3Aopen+is%3Aissue+label%3Abug+label%3A%3Areproduce). Please remove the ":reproduce" label after you've followed up in the issue.
 
 4. Pull requests opened by the community - [GitHub open pull requests](https://github.com/fleetdm/fleet/pulls?q=is%3Aopen+is%3Apr)
 


### PR DESCRIPTION
- Add item and link to all "Reported bugs" (GitHub issues with the "bug" and ":reproduce" label). This way, the individual on call can navigate to a list of bugs that need reproduction. 
   - After the bug has been successfully (or unsuccessfully) reproduce, it is the on call individual's responsibility to remove the ":reproduce" label.
- Add a link to the open pull requests. This way, the individual on call can identify any PRs that have been opened by the community.

If some of the following don't apply, please write a short explanation why.

**Changes only affect Fleet handbook**.

> - [ ] Changes file added (if needed)
> - [ ] Documented any API changes
> - [ ] Added tests for all functionality
> - [ ] Manual QA for all functionality
