### PR TITLE
Updated Dockerfile to allow Fleet to write to the default logging directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,13 @@ RUN addgroup -S fleet && adduser -S fleet -G fleet
 
 COPY ./build/binary-bundle/linux/fleet ./build/binary-bundle/linux/fleetctl /usr/bin/
 
+### Setup logging directory ###
+RUN mkdir /var/log/osquery && \
+	chown root:root /var/log/osquery && \
+	touch /var/log/osquery/status.log && \
+	touch /var/log/osquery/result.log && \
+	chown fleet:fleet /var/log/osquery/status.log && \
+	chown fleet:fleet /var/log/osquery/status.log
+
 USER fleet
 CMD ["fleet", "serve"]


### PR DESCRIPTION
Fleet doesn't have the proper permissions to write Osquery logs to `/var/log/osquery` - [docs](https://github.com/fleetdm/fleet/blob/main/docs/2-Deploying/2-Configuration.md). This PR creates the logging directory and creates empty log files with the proper permissions. Since Fleet can't write the ad-hoc Osquery query results it returns a 500 (NGINX log) and the Fleet UI just sits there waiting for results.

Lastly, this bug effects every Fleet Docker container since version 3.6.0 when the `fleet` user was added to the [Docekrfile](https://hub.docker.com/layers/fleetdm/fleet/3.6.0/images/sha256-d7f774401dc4079ddcf24166066d23133371b2dc3a9b432a5e0ceb312e43642a?context=explore).


Fleet debug log:
```
fleetdm_fleet.1.ttybwdbulxlo@docker-dev    | {"component":"http","err":["error writing status logs: writing log: can't make directories for new logfile: mkdir /var/log/osquery: permission denied"],"ip_addr":"10.0.50.4:35718","level":"debug","method":"POST","took":"1.055162ms","ts":"2021-08-29T19:18:16.796191144Z","uri":"/api/v1/osquery/log","x_for_ip_addr":"10.0.0.2"}
```

NGINX logs:
```
fleetdm_nginx.1.w4ia4ho7ovgm@docker-dev    | 10.0.0.2 - - [29/Aug/2021:19:40:43 +0000] "POST /api/v1/osquery/log HTTP/1.1" 500 139 "-" "osquery/4.9.0"
```

Osquery agent log:
```
I0829 21:40:09.904278 17235 buffered.cpp:90] Error sending status to logger: Request failed: error writing status logs: writing log: can't make directories for new logfile: mkdir /var/log/osquery: permission denied
```


# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

- [ ] Changes file added (if needed)
- [ ] Documented any API changes
- [ ] Added tests for all functionality
- [ ] Manual QA for all functionality
