### PR TITLE
Add canonical URL for link to prometheus example configuration

### DIFF
--- a/docs/1-Using-Fleet/6-Monitoring-Fleet.md
+++ b/docs/1-Using-Fleet/6-Monitoring-Fleet.md
@@ -19,7 +19,7 @@ The `/healthz` endpoint will return an `HTTP 200` status if the server is runnin
 
 ## Metrics
 
-Fleet exposes server metrics in a format compatible with [Prometheus](https://prometheus.io/). A simple example Prometheus configuration is available in [tools/app/prometheus.yml](../../tools/app/prometheus.yml).
+Fleet exposes server metrics in a format compatible with [Prometheus](https://prometheus.io/). A simple example Prometheus configuration is available in [tools/app/prometheus.yml](https://github.com/fleetdm/fleet/blob/194ad5963b0d55bdf976aa93f3de6cabd590c97a/tools/app/prometheus.yml).
 
 Prometheus can be configured to use a wide range of service discovery mechanisms within AWS, GCP, Azure, Kubernetes, and more. See the Prometheus [configuration documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/) for more information.
 


### PR DESCRIPTION
Steps for next time:
The fleetdm.com/docs compilation process does not account for relative links to directories outside of `/docs`. 

For future instances in which a broken link is discovered on fleetdm.com, see if the link is a relative link to a directory outside of `/docs`. In this case the link was to `../../tools/app/prometheus` which lives outside `/docs`.

If the link lives outside `/docs` head to the file's location on GitHub (https://github.com/fleetdm/fleet/blob/main/tools/app/prometheus.yml) and press "y" to tranform the URL into is canonical form (https://github.com/fleetdm/fleet/blob/194ad5963b0d55bdf976aa93f3de6cabd590c97a/tools/app/prometheus.yml). Replace the relative link with this link in the markdown file.
