### PR TITLE
Hide enroll secret for team observer

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.jsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.jsx
@@ -1381,7 +1381,7 @@ const mapStateToProps = (state, ownProps) => {
   const teams = memoizedGetEntity(state.entities.teams.data);
 
   // If there is no team_id, set selectedTeam to 0 so dropdown defaults to "All teams"
-  const selectedTeam = location.query?.team_id || 0;
+  const selectedTeam = parseInt(location.query?.team_id, 10) || 0;
 
   const currentUser = state.auth.user;
   const canAddNewHosts =
@@ -1391,7 +1391,8 @@ const mapStateToProps = (state, ownProps) => {
   const canEnrollHosts =
     permissionUtils.isGlobalAdmin(currentUser) ||
     permissionUtils.isGlobalMaintainer(currentUser) ||
-    (permissionUtils.isAnyTeamMaintainer(currentUser) && selectedTeam !== 0);
+    (selectedTeam !== 0 &&
+      permissionUtils.isTeamMaintainer(currentUser, selectedTeam));
   const canAddNewLabels =
     permissionUtils.isGlobalAdmin(currentUser) ||
     permissionUtils.isGlobalMaintainer(currentUser);

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -6,6 +6,8 @@
     margin-bottom: $pad-medium;
 
     .button-wrap {
+      display: flex;
+      justify-content: flex-end;
       min-width: 266px;
     }
   }


### PR DESCRIPTION
Closes #1934

- Modify permissions check to hide "Show enroll secret" for team where user is observer
- Align "Add a host" button
