### PR TITLE
Use replace instead of push for host table changes

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.jsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { push, goBack } from "react-router-redux";
+import { goBack, push, replace } from "react-router-redux";
 import { find, isEmpty, memoize, omit } from "lodash";
 
 import Button from "components/buttons/Button";
@@ -381,7 +381,7 @@ export class ManageHostsPage extends PureComponent {
     }
 
     dispatch(
-      push(
+      replace(
         getNextLocationPath({
           pathPrefix: PATHS.MANAGE_HOSTS,
           routeTemplate,
@@ -635,7 +635,6 @@ export class ManageHostsPage extends PureComponent {
   };
 
   retrieveHosts = async (options = {}) => {
-    const { dispatch } = this.props;
     const { getValidatedTeamId } = this;
 
     this.setState({ isHostsLoading: true });
@@ -727,7 +726,7 @@ export class ManageHostsPage extends PureComponent {
     });
 
     dispatch(
-      push(
+      replace(
         getNextLocationPath({
           pathPrefix: PATHS.MANAGE_HOSTS,
           routeTemplate,
@@ -760,7 +759,7 @@ export class ManageHostsPage extends PureComponent {
       teamId: selectedTeam,
     });
     dispatch(
-      push(
+      replace(
         getNextLocationPath({
           pathPrefix: PATHS.MANAGE_HOSTS,
           routeTemplate,
@@ -806,7 +805,7 @@ export class ManageHostsPage extends PureComponent {
         ? omit(queryParams, "team_id")
         : Object.assign({}, queryParams, { team_id: teamIdParam }),
     });
-    dispatch(push(nextLocation));
+    dispatch(replace(nextLocation));
   };
 
   handleLabelChange = ({ slug }) => {
@@ -843,7 +842,7 @@ export class ManageHostsPage extends PureComponent {
     }
 
     dispatch(
-      push(
+      replace(
         getNextLocationPath({
           pathPrefix: isAllHosts
             ? MANAGE_HOSTS


### PR DESCRIPTION
Closes #1926

Use react-router `replace` instead of `push` for table changes on manage hosts page for better navigation UX when using browser back button