### PR TITLE
Remove website hamburger menu delay

### DIFF
--- a/website/assets/styles/layout.less
+++ b/website/assets/styles/layout.less
@@ -59,6 +59,7 @@ html, body {
   }
   .collapsing {
     opacity: 0;
+    transition: 0s;
   }
   .collapse.show {
     opacity: 1;


### PR DESCRIPTION
fixes #784

Changes:
- set the transition for the `.collapsing` class to 0s to remove the delay when you open the navigation menu

# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

- [ ] Changes file added (if needed)
- [ ] Documented any API changes
- [ ] Added tests for all functionality
- [x] Manual QA for all functionality
