### PR TITLE
Update temp dir permissions when creating install packages

### DIFF
--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -23,6 +23,7 @@ func buildNFPM(opt Options, pkger nfpm.Packager) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create temp dir")
 	}
+	os.Chmod(tmpDir, 0755)
 	defer os.RemoveAll(tmpDir)
 	log.Debug().Str("path", tmpDir).Msg("created temp dir")
 

--- a/orbit/pkg/packaging/macos.go
+++ b/orbit/pkg/packaging/macos.go
@@ -27,6 +27,7 @@ func BuildPkg(opt Options) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create temp dir")
 	}
+	os.Chmod(tmpDir, 0755)
 	defer os.RemoveAll(tmpDir)
 	log.Debug().Str("path", tmpDir).Msg("created temp dir")
 

--- a/orbit/pkg/packaging/windows.go
+++ b/orbit/pkg/packaging/windows.go
@@ -22,6 +22,7 @@ func BuildMSI(opt Options) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create temp dir")
 	}
+	os.Chmod(tmpDir, 0755)
 	defer os.RemoveAll(tmpDir)
 	log.Debug().Str("path", tmpDir).Msg("created temp dir")
 


### PR DESCRIPTION
When creating an installation package with `go run ./cmd/package --type=...` a temp folder is created to perform the operation. By default a temp folder created with `ioutil.TempDir` has 0700 permissions, which later in the code causes the error

> FTL package failed error="initialize updates: failed to update metadata: update metadata: tuf: failed to decode timestamp.json: expired at 2021-09-06 09:41:08 -0700 -0700" 

Changing the folder permission with `os.Chmod(tmpDir, 0755)` right after its creation solves the issue.

To reproduce the issue:

```
git clone https://github.com/fleetdm/fleet                                                                                      
cd fleet/orbit
go run ./cmd/package --type=deb --fleet-url=localhost:1337 --enroll-secret=deadbeefdeadbeefdeadbeefdeadbeef --insecure
```
