### PR TITLE
Update redisc and replace EachRedisNode implementation

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,4 +17,4 @@ jobs:
           # specified without patch version: we always use the latest patch
           # version.
           version: v1.42
-          args: --verbose --timeout 3m --max-same-issues 0
+          args: --timeout 3m

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,4 +17,4 @@ jobs:
           # specified without patch version: we always use the latest patch
           # version.
           version: v1.42
-          args: --verbose --timeout 3m
+          args: --verbose --timeout 3m --max-same-issues 0

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,4 +17,4 @@ jobs:
           # specified without patch version: we always use the latest patch
           # version.
           version: v1.42
-          args: --timeout 3m
+          args: --verbose --timeout 3m

--- a/go.mod
+++ b/go.mod
@@ -49,9 +49,8 @@ require (
 	github.com/mattermost/xml-roundtrip-validator v0.0.0-20201213122252-bcd7e1b9601e
 	github.com/mattn/go-sqlite3 v1.14.8
 	github.com/mitchellh/gon v0.2.3
-	github.com/mna/redisc v1.2.1
+	github.com/mna/redisc v1.3.2
 	github.com/oklog/run v1.1.0
-	github.com/oleiade/reflections v1.0.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/open-policy-agent/opa v0.24.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -204,7 +204,6 @@ github.com/facebookincubator/nvdtools v0.1.4 h1:x1Ucw9+bSkMd8DJJN4jNQ1Lk4PSFlJar
 github.com/facebookincubator/nvdtools v0.1.4/go.mod h1:0/FIVnSEl9YHXLq3tKBPpKaI0iUceDhdSHPlIwIX44Y=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
@@ -604,8 +603,8 @@ github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/mna/redisc v1.2.1 h1:7rI/qv2sa0OT8rsxDbKg7XPysr5AIDeXwL0T0vFOvlM=
-github.com/mna/redisc v1.2.1/go.mod h1:OxLEDNNDFOYJBo7MuSC+SEoP3k8bZY2dFW7T12TzX4c=
+github.com/mna/redisc v1.3.2 h1:sc9C+nj6qmrTFnsXb70xkjAHpXKtjjBuE6v2UcQV0ZE=
+github.com/mna/redisc v1.3.2/go.mod h1:CplIoaSTDi5h9icnj4FLbRgHoNKCHDNJDVRztWDGeSQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
@@ -630,8 +629,6 @@ github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/oklog/ulid v0.3.0/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/oleiade/reflections v1.0.1 h1:D1XO3LVEYroYskEsoSiGItp9RUxG6jWnCVvrqH0HHQM=
-github.com/oleiade/reflections v1.0.1/go.mod h1:rdFxbxq4QXVZWj0F+e9jqjDkc7dbp97vkRixKo2JR60=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
@@ -859,7 +856,6 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
-github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 github.com/zwass/kit v0.0.0-20210625184505-ec5b5c5cce9c h1:TWQ2UvXPkhPxI2KmApKBOCaV6yD2N4mlvqFQ/DlPtpQ=
 github.com/zwass/kit v0.0.0-20210625184505-ec5b5c5cce9c/go.mod h1:OYYulo9tUqRadRLwB0+LE914sa1ui2yL7OrcU3Q/1XY=

--- a/server/datastore/redis/redis.go
+++ b/server/datastore/redis/redis.go
@@ -1,7 +1,6 @@
 package redis
 
 import (
-	"bufio"
 	"strings"
 	"time"
 
@@ -61,63 +60,14 @@ func SplitRedisKeysBySlot(pool fleet.RedisPool, keys ...string) [][]string {
 // fn is called only once.
 func EachRedisNode(pool fleet.RedisPool, fn func(conn redis.Conn) error) error {
 	if cluster, isCluster := pool.(*redisc.Cluster); isCluster {
-		addrs, err := getClusterPrimaryAddrs(cluster)
-		if err != nil {
-			return err
-		}
-		for _, addr := range addrs {
-			err := func() error {
-				// NOTE(mna): using CreatePool means that we respect the redis timeouts
-				// and configs.  This is a temporary pool as we can't reuse the
-				// (internal) cluster pools for each host at the moment, would require
-				// a change to redisc (one that would make sense to make for that
-				// use-case of visiting each node, IMO).
-				tempPool, err := cluster.CreatePool(addr)
-				if err != nil {
-					return errors.Wrap(err, "create pool")
-				}
-				defer tempPool.Close()
-
-				conn := tempPool.Get()
-				defer conn.Close()
-				return fn(conn)
-			}()
-			if err != nil {
-				return err
-			}
-		}
-		return nil
+		return cluster.EachNode(false, func(_ string, conn redis.Conn) error {
+			return fn(conn)
+		})
 	}
 
 	conn := pool.Get()
 	defer conn.Close()
 	return fn(conn)
-}
-
-func getClusterPrimaryAddrs(pool *redisc.Cluster) ([]string, error) {
-	conn := pool.Get()
-	defer conn.Close()
-	nodes, err := redis.String(conn.Do("CLUSTER", "NODES"))
-	if err != nil {
-		return nil, errors.Wrap(err, "get cluster nodes")
-	}
-
-	var addrs []string
-	s := bufio.NewScanner(strings.NewReader(nodes))
-	for s.Scan() {
-		fields := strings.Fields(s.Text())
-		if len(fields) > 2 {
-			flags := fields[2]
-			if strings.Contains(flags, "master") {
-				addrField := fields[1]
-				if ix := strings.Index(addrField, "@"); ix >= 0 {
-					addrField = addrField[:ix]
-				}
-				addrs = append(addrs, addrField)
-			}
-		}
-	}
-	return addrs, nil
 }
 
 func newCluster(server, password string, database int, useTLS bool) *redisc.Cluster {


### PR DESCRIPTION
I released a new version of `redisc` over the weekend, and among other things it exposes a way to connect to each node in the cluster. This PR updates to the latest version of `redisc` and replaces the hacky way to connect to each node mentioned in https://github.com/fleetdm/fleet/pull/1885#issue-724589888 with the proper redisc-exposed way, which reuses the internal pools (if pooling is configured).

# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

- [ ] ~~Changes file added (if needed)~~ (implementation detail)
- [ ] ~~Documented any API changes~~
- [ ] ~~Added tests for all functionality~~ (tests already exist)
- [ ] ~~Manual QA for all functionality~~
