### PR TITLE
Remove bottom margin on footer on fleetdm.com

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -130,7 +130,7 @@
 
       <div style="background-color: #201E43;" purpose="page-footer">
         <div style="background-color: #201E43;">
-          <div style="max-width: 1248px;" class="container-fluid d-flex flex-column flex-lg-row justify-content-center justify-content-lg-between px-3 px-md-4 pt-4 pb-0 mt-md-5 mb-lg-5">
+          <div style="max-width: 1248px;" class="container-fluid d-flex flex-column flex-lg-row justify-content-center justify-content-lg-between px-3 px-md-4 pt-4 pb-0 mt-md-5">
           <div class="d-flex flex-grow-1 flex-column align-items-center">
             <div class="container-fluid d-block d-md-flex flex-md-row text-center justify-content-between justify-content-lg-end px-5 px-lg-0 pt-lg-3 pb-4 pb-md-0">
               <a href="/install" class="d-block pr-lg-4 pb-4">Try Fleet</a>


### PR DESCRIPTION
Fixes #1879 
Changes:
- Removed the bottom margin on a <div> inside of the footer (on Firefox it was creating whitespace below the footer)

# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

- [ ] Changes file added (if needed)
- [ ] Documented any API changes
- [ ] Added tests for all functionality
- [x] Manual QA for all functionality
