### PR TITLE
Add more padding to the docs at <990px width

### DIFF
--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -460,6 +460,8 @@
     // for smaller screens
     @media (max-width: 990px) {
 
+      padding: 0px 40px;
+
       [purpose='right-sidebar'] {
         width: 100%;
 
@@ -476,7 +478,6 @@
 
       [purpose='content'] {
         width: 100%;
-        padding: 0px 40px;
 
         h1:first-of-type {
           display: none;  // hides on mobile
@@ -488,13 +489,7 @@
     // for mobile
     @media (max-width: 576px) {
 
-      [purpose='content'] {
-        
-        padding-left: 24px;
-        padding-right: 24px;
-
-
-      }
+      padding: 0px 24px;
 
     }
 

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -359,7 +359,7 @@
 
       img {
         display: flex;
-        width: 100%;
+        max-width: 100%;
         height: auto;
         margin: auto;
         padding-top: 24px;
@@ -402,71 +402,8 @@
 
     }
 
-    @media (max-width: 576px) {
-
-      [purpose='content'] {
-        width: 100%;
-
-        // padding: 0px 40px;
-
-        img {
-          display: flex;
-          max-width: 100%;
-          height: auto;
-          margin: auto;
-          padding-top: 24px;
-          padding-bottom: 24px;
-        }
-
-        h1:first-of-type {
-          display: none;  // hides on mobile
-        }
-
-      }
-
-    }
-
-    // for smaller screens
-    @media (max-width: 991px) and (min-width: 576px) {
-
-      [purpose='right-sidebar'] {
-        width: 100%;
-
-        [purpose='subtopics'] {
-          color: @core-fleet-black;
-
-          a {
-            color: @core-vibrant-blue;
-          }
-
-        }
-
-      }
-
-      [purpose='content'] {
-        width: 100%;
-
-        padding: 0px 40px;
-
-        img {
-          display: flex;
-          max-width: 600px;
-          height: auto;
-          margin: auto;
-          padding-top: 24px;
-          padding-bottom: 24px;
-        }
-
-        h1:first-of-type {
-          display: none;  // hides on mobile
-        }
-
-      }
-
-    }
-
     // for larger screens
-    @media (min-width: 992px) {
+    @media (min-width: 990px) {
 
       ul {
         .topic {
@@ -510,24 +447,53 @@
 
           }
 
-          // .active {
-          //   color: @core-vibrant-blue;
-          //   position: absolute;
-          //   height: 32px;
-          //   transform: translate(-2px, -4px);
-          //   border-left: 3px solid @core-vibrant-blue;
-          //   border-radius: 2px;
-          //   a {
-          //     color: @core-vibrant-blue;
-          //   }
-          // }
-
         }
 
       }
 
       [purpose='content'] {
         min-width: 0px; // in order for <pre> elements to shrink properly, the parent flex element needs to override min-width auto
+      }
+
+    }
+
+    // for smaller screens
+    @media (max-width: 990px) {
+
+      [purpose='right-sidebar'] {
+        width: 100%;
+
+        [purpose='subtopics'] {
+          color: @core-fleet-black;
+
+          a {
+            color: @core-vibrant-blue;
+          }
+
+        }
+
+      }
+
+      [purpose='content'] {
+        width: 100%;
+        padding: 0px 40px;
+
+        h1:first-of-type {
+          display: none;  // hides on mobile
+        }
+
+      }
+
+    }
+    // for mobile
+    @media (max-width: 576px) {
+
+      [purpose='content'] {
+        
+        padding-left: 24px;
+        padding-right: 24px;
+
+
       }
 
     }

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -361,6 +361,7 @@
         display: flex;
         width: 100%;
         height: auto;
+        margin: auto;
         padding-top: 24px;
         padding-bottom: 24px;
       }
@@ -401,8 +402,32 @@
 
     }
 
+    @media (max-width: 576px) {
+
+      [purpose='content'] {
+        width: 100%;
+
+        // padding: 0px 40px;
+
+        img {
+          display: flex;
+          max-width: 100%;
+          height: auto;
+          margin: auto;
+          padding-top: 24px;
+          padding-bottom: 24px;
+        }
+
+        h1:first-of-type {
+          display: none;  // hides on mobile
+        }
+
+      }
+
+    }
+
     // for smaller screens
-    @media (max-width: 991px) {
+    @media (max-width: 991px) and (min-width: 576px) {
 
       [purpose='right-sidebar'] {
         width: 100%;
@@ -420,6 +445,17 @@
 
       [purpose='content'] {
         width: 100%;
+
+        padding: 0px 40px;
+
+        img {
+          display: flex;
+          max-width: 600px;
+          height: auto;
+          margin: auto;
+          padding-top: 24px;
+          padding-bottom: 24px;
+        }
 
         h1:first-of-type {
           display: none;  // hides on mobile

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -65,7 +65,7 @@
   </div>
 
   <div v-else>
-    <div purpose="docs-template" style="max-width: 1200px;" class="container-fluid px-3 px-sm-4 mb-5">
+    <div purpose="docs-template" style="max-width: 1200px;" class="container-fluid px-lg-3  mb-5">
 
       <div purpose="breadcrumbs-and-search" class="conainer-fluid d-flex flex-column flex-lg-row justify-content-lg-between p-0 pt-4 pb-lg-2 m-0 breadcrumbs-search">
         
@@ -181,7 +181,7 @@
   
         </div>
 
-        <div purpose="content" id="body-content" class="d-flex flex-column p-0 px-lg-5 content" parasails-has-no-page-script>
+        <div purpose="content" id="body-content" class="d-flex flex-column px-lg-5 content" parasails-has-no-page-script>
           <%- partial(
             path.relative(
               path.dirname(__filename), 

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -237,12 +237,6 @@
         <p class="px-4">
           Teams use osquery with Fleet every day to stay secure and compliant.
         </p>
-        <div class="logos container d-flex flex-wrap justify-content-center align-items-center pb-2 pb-md-5">
-          <img alt="The logo of a significant contributor, production user, and/or customer of Fleet" style="width: 160px; height: auto;" class="px-3 my-3" src="/images/logo-gusto-140x58@2x.png"/>
-          <img alt="The logo of a significant contributor, production user, and/or customer of Fleet" style="width: 160px; height: auto;" class="px-3 my-3" src="/images/logo-duo-93x47@2x.png"/>
-          <img alt="The logo of a significant contributor, production user, and/or customer of Fleet" style="width: 160px; height: auto;" class="px-3 my-3" src="/images/logo-cisco-117x70@2x.png"/>
-          <img alt="The logo of a significant contributor, production user, and/or customer of Fleet" style="width: 160px; height: auto;" class="px-3 my-3" src="/images/logo-adarga-112x32@2x.png"/>
-        </div>
         <div class="btn-toolbar justify-content-center px-5 px-sm-0 pt-3 pb-5 mb-md-5">
           <a
             style="max-width: 220px"


### PR DESCRIPTION
Changes:

- adjusted the width for images in docs
- added padding to the docs when viewing <990px and <576px
- removed bootstrap padding class from docs container


# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

- [ ] Changes file added (if needed)
- [ ] Documented any API changes
- [ ] Added tests for all functionality
- [x] Manual QA for all functionality
