### PR TITLE
alter migration that isn't compatible with mysql8

### DIFF
--- a/changes/1991-mysql8
+++ b/changes/1991-mysql8
@@ -1,0 +1,1 @@
+* Fix migration that was incompatible with MySQL primary key requirements (default on DigitalOcean MySQL 5.8)

--- a/docker-compose-mysql8.yml
+++ b/docker-compose-mysql8.yml
@@ -1,0 +1,19 @@
+---
+version: '2'
+services:
+  # To test with MariaDB, set FLEET_MYSQL_IMAGE to mariadb:10.6 or the like.
+  mysql:
+    image: ${FLEET_MYSQL_IMAGE:-mysql:8}
+    platform: linux/x86_64
+    volumes:
+      - mysql-persistent-volume:/tmp
+    # see https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_sql_require_primary_key
+    command: mysqld --datadir=/tmp/mysqldata --event-scheduler=ON --sql-require-primary-key=ON
+    environment: &mysql-default-environment
+      MYSQL_ROOT_PASSWORD: toor
+      MYSQL_DATABASE: fleet
+      MYSQL_USER: fleet
+      MYSQL_PASSWORD: insecure
+    ports:
+      - "3306:3306"
+

--- a/server/datastore/mysql/migrations/tables/20210601000008_TeamsEnrollSecrets.go
+++ b/server/datastore/mysql/migrations/tables/20210601000008_TeamsEnrollSecrets.go
@@ -71,8 +71,7 @@ func Up_20210601000008(tx *sql.Tx) error {
 		ALTER TABLE enroll_secrets
 		DROP COLUMN active,
 		DROP COLUMN name,
-		ADD PRIMARY KEY (secret),
-		ADD UNIQUE INDEX (secret)
+		ADD PRIMARY KEY (secret)
 	`
 	if _, err := tx.Exec(sql); err != nil {
 		return errors.Wrap(err, "alter enroll_secrets")

--- a/server/datastore/mysql/migrations/tables/20210601000008_TeamsEnrollSecrets.go
+++ b/server/datastore/mysql/migrations/tables/20210601000008_TeamsEnrollSecrets.go
@@ -71,6 +71,7 @@ func Up_20210601000008(tx *sql.Tx) error {
 		ALTER TABLE enroll_secrets
 		DROP COLUMN active,
 		DROP COLUMN name,
+		ADD PRIMARY KEY (secret),
 		ADD UNIQUE INDEX (secret)
 	`
 	if _, err := tx.Exec(sql); err != nil {

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -137,9 +137,9 @@ CREATE TABLE `email_changes` (
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `enroll_secrets` (
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `secret` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
+  `secret` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
   `team_id` int(10) unsigned DEFAULT NULL,
-  UNIQUE KEY `secret` (`secret`),
+  PRIMARY KEY (`secret`),
   KEY `fk_enroll_secrets_team_id` (`team_id`),
   CONSTRAINT `enroll_secrets_ibfk_1` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
when using mysql8 with https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_sql_require_primary_key `ON` migrations fail to run -- this PR updated the SQL to make it compliant.

closes #1991 

# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

~~- [ ] Changes file added (if needed)~~
~~- [ ] Documented any API changes~~
~~- [ ] Added tests for all functionality~~
- [X] Manual QA for all functionality
