### PR TITLE
Add note to `POST /api/v1/fleet/queries/run` about required parameter for running live query as an observer

### DIFF
--- a/docs/1-Using-Fleet/3-REST-API.md
+++ b/docs/1-Using-Fleet/3-REST-API.md
@@ -2578,7 +2578,7 @@ After the query has been initiated, [get results via WebSocket](#retrieve-live-q
 | Name     | Type    | In   | Description                                                                                                                                                |
 | -------- | ------- | ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | query    | string  | body | The SQL if using a custom query.                                                                                                                           |
-| query_id | integer | body | The saved query (if any) that will be run. The `observer_can_run` property on the query effects which targets are included.                                |
+| query_id | integer | body | The saved query (if any) that will be run. Required if running query as an observer. The `observer_can_run` property on the query effects which targets are included.                                |
 | selected | object  | body | **Required.** The desired targets for the query specified by ID. This object can contain `hosts`, `labels`, and/or `teams` properties. See examples below. |
 
 One of `query` and `query_id` must be specified.


### PR DESCRIPTION
- When making a request to the `POST /api/v1/fleet/queries/run` API route as a user with the Observer role, the `queryId` parameter must be specified in order for the backend to determine observer_can_run permissions.

@rlynnj11 I'm adding you as a reviewer so you can verify that you get a Slack notification. No need to review the changes made in this PR :)