### PR TITLE
Add configurable Redis connection retries and following of cluster redirections

### DIFF
--- a/changes/issue-1969-redis-config
+++ b/changes/issue-1969-redis-config
@@ -1,0 +1,2 @@
+* Add redis configuration option to retry failed connections.
+* Add redis configuration option to follow cluster redirections.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -200,14 +200,14 @@ the way that the Fleet server works.
 				}
 			}
 
-			redisPool, err := redis.NewRedisPool(
-				config.Redis.Address,
-				config.Redis.Password,
-				config.Redis.Database,
-				config.Redis.UseTLS,
-				config.Redis.ConnectTimeout,
-				config.Redis.KeepAlive,
-			)
+			redisPool, err := redis.NewRedisPool(redis.PoolConfig{
+				Server:      config.Redis.Address,
+				Password:    config.Redis.Password,
+				Database:    config.Redis.Database,
+				UseTLS:      config.Redis.UseTLS,
+				ConnTimeout: config.Redis.ConnectTimeout,
+				KeepAlive:   config.Redis.KeepAlive,
+			})
 			if err != nil {
 				initFatal(err, "initialize Redis")
 			}

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -201,20 +201,20 @@ the way that the Fleet server works.
 			}
 
 			redisPool, err := redis.NewRedisPool(redis.PoolConfig{
-				Server:      config.Redis.Address,
-				Password:    config.Redis.Password,
-				Database:    config.Redis.Database,
-				UseTLS:      config.Redis.UseTLS,
-				ConnTimeout: config.Redis.ConnectTimeout,
-				KeepAlive:   config.Redis.KeepAlive,
+				Server:                    config.Redis.Address,
+				Password:                  config.Redis.Password,
+				Database:                  config.Redis.Database,
+				UseTLS:                    config.Redis.UseTLS,
+				ConnTimeout:               config.Redis.ConnectTimeout,
+				KeepAlive:                 config.Redis.KeepAlive,
+				ConnectRetryAttempts:      config.Redis.ConnectRetryAttempts,
+				ClusterFollowRedirections: config.Redis.ClusterFollowRedirections,
 			})
 			if err != nil {
 				initFatal(err, "initialize Redis")
 			}
 			resultStore := pubsub.NewRedisQueryResults(redisPool, config.Redis.DuplicateResults)
 			liveQueryStore := live_query.NewRedisLiveQuery(redisPool)
-			// TODO: should that only be done when a certain "migrate" flag is set,
-			// to prevent affecting every startup?
 			if err := liveQueryStore.MigrateKeys(); err != nil {
 				level.Info(logger).Log(
 					"err", err,

--- a/docs/2-Deploying/2-Configuration.md
+++ b/docs/2-Deploying/2-Configuration.md
@@ -289,7 +289,7 @@ Maximum idle connections to database. This value should be equal to or less than
   	max_idle_conns: 50
   ```
 
-###### conn_max_lifetime
+###### mysql_conn_max_lifetime
 
 Maximum amount of time, in seconds, a connection may be reused.
 
@@ -358,7 +358,7 @@ Whether or not to duplicate Live Query results to another Redis channel named `L
 
 ###### redis_connect_timeout
 
-Timeout for redis connection. 
+Timeout for redis connection.
 
 - Default value: 5s
 - Environment variable: `FLEET_REDIS_CONNECT_TIMEOUT`
@@ -380,6 +380,38 @@ Interval between keep alive probes.
   ```
   redis:
     keep_alive: 30s
+  ```
+
+###### redis_connect_retry_attempts
+
+Maximum number of attempts to retry a failed connection to a redis node. Only
+certain type of errors are retried, such as connection timeouts.
+
+- Default value: 0 (no retry)
+- Environment variable: `FLEET_REDIS_CONNECT_RETRY_ATTEMPTS`
+- Config file format:
+
+  ```
+  redis:
+    connect_retry_attempts: 2
+  ```
+
+###### redis_cluster_follow_redirections
+
+Whether or not to automatically follow redirection errors received from the
+Redis server. Applies only to Redis Cluster setups, ignored in standalone
+Redis. In Redis Cluster, keys can be moved around to different nodes when the
+cluster is unstable and reorganizing the data. With this configuration option
+set to true, those (typically short and transient) redirection errors can be
+handled transparently instead of ending in an error.
+
+- Default value: false
+- Environment variable: `FLEET_REDIS_CLUSTER_FOLLOW_REDIRECTIONS`
+- Config file format:
+
+  ```
+  redis:
+    cluster_follow_redirections: true
   ```
 
 ##### Server

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -37,13 +37,15 @@ type MysqlConfig struct {
 
 // RedisConfig defines configs related to Redis
 type RedisConfig struct {
-	Address          string
-	Password         string
-	Database         int
-	UseTLS           bool          `yaml:"use_tls"`
-	DuplicateResults bool          `yaml:"duplicate_results"`
-	ConnectTimeout   time.Duration `yaml:"connect_timeout"`
-	KeepAlive        time.Duration `yaml:"keep_alive"`
+	Address                   string
+	Password                  string
+	Database                  int
+	UseTLS                    bool          `yaml:"use_tls"`
+	DuplicateResults          bool          `yaml:"duplicate_results"`
+	ConnectTimeout            time.Duration `yaml:"connect_timeout"`
+	KeepAlive                 time.Duration `yaml:"keep_alive"`
+	ConnectRetryAttempts      int           `yaml:"connect_retry_attempts"`
+	ClusterFollowRedirections bool          `yaml:"cluster_follow_redirections"`
 }
 
 const (
@@ -243,6 +245,8 @@ func (man Manager) addConfigs() {
 	man.addConfigBool("redis.duplicate_results", false, "Duplicate Live Query results to another Redis channel")
 	man.addConfigDuration("redis.connect_timeout", 5*time.Second, "Timeout at connection time")
 	man.addConfigDuration("redis.keep_alive", 10*time.Second, "Interval between keep alive probes")
+	man.addConfigInt("redis.connect_retry_attempts", 0, "Number of attempts to retry a failed connection")
+	man.addConfigBool("redis.cluster_follow_redirections", false, "Automatically follow Redis Cluster redirections")
 
 	// Server
 	man.addConfigString("server.address", "0.0.0.0:8080",
@@ -417,13 +421,15 @@ func (man Manager) LoadConfig() FleetConfig {
 		Mysql:            loadMysqlConfig("mysql"),
 		MysqlReadReplica: loadMysqlConfig("mysql_read_replica"),
 		Redis: RedisConfig{
-			Address:          man.getConfigString("redis.address"),
-			Password:         man.getConfigString("redis.password"),
-			Database:         man.getConfigInt("redis.database"),
-			UseTLS:           man.getConfigBool("redis.use_tls"),
-			DuplicateResults: man.getConfigBool("redis.duplicate_results"),
-			ConnectTimeout:   man.getConfigDuration("redis.connect_timeout"),
-			KeepAlive:        man.getConfigDuration("redis.keep_alive"),
+			Address:                   man.getConfigString("redis.address"),
+			Password:                  man.getConfigString("redis.password"),
+			Database:                  man.getConfigInt("redis.database"),
+			UseTLS:                    man.getConfigBool("redis.use_tls"),
+			DuplicateResults:          man.getConfigBool("redis.duplicate_results"),
+			ConnectTimeout:            man.getConfigDuration("redis.connect_timeout"),
+			KeepAlive:                 man.getConfigDuration("redis.keep_alive"),
+			ConnectRetryAttempts:      man.getConfigInt("redis.connect_retry_attempts"),
+			ClusterFollowRedirections: man.getConfigBool("redis.cluster_follow_redirections"),
 		},
 		Server: ServerConfig{
 			Address:    man.getConfigString("server.address"),

--- a/server/datastore/redis/redis_test.go
+++ b/server/datastore/redis/redis_test.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"fmt"
 	"io"
+	"runtime"
 	"testing"
 	"time"
 
@@ -217,6 +218,10 @@ func TestEachRedisNode(t *testing.T) {
 }
 
 func setupRedisForTest(t *testing.T, cluster, redir bool) (pool fleet.RedisPool, teardown func()) {
+	if cluster && (runtime.GOOS == "darwin" || runtime.GOOS == "windows") {
+		t.Skipf("docker networking limitations prevent running redis cluster tests on %s", runtime.GOOS)
+	}
+
 	var (
 		addr     = "127.0.0.1:"
 		password = ""

--- a/server/datastore/redis/redis_test.go
+++ b/server/datastore/redis/redis_test.go
@@ -15,49 +15,74 @@ import (
 
 type netError struct {
 	error
-	timeout   bool
-	temporary bool
-	count     int // once this reaches 0, mockDial does not return an error
+	timeout      bool
+	temporary    bool
+	allowedCalls int // once this reaches 0, mockDial does not return an error
+	countCalls   int
 }
 
 func (t *netError) Timeout() bool   { return t.timeout }
 func (t *netError) Temporary() bool { return t.temporary }
 
+var errFromConn = errors.New("SUCCESS")
+
 type redisConn struct{}
 
-func (redisConn) Close() error                                       { return io.EOF }
-func (redisConn) Err() error                                         { return io.EOF }
-func (redisConn) Do(_ string, _ ...interface{}) (interface{}, error) { return nil, io.EOF }
-func (redisConn) Send(_ string, _ ...interface{}) error              { return io.EOF }
-func (redisConn) Flush() error                                       { return io.EOF }
-func (redisConn) Receive() (interface{}, error)                      { return nil, io.EOF }
+func (redisConn) Close() error                                       { return errFromConn }
+func (redisConn) Err() error                                         { return errFromConn }
+func (redisConn) Do(_ string, _ ...interface{}) (interface{}, error) { return nil, errFromConn }
+func (redisConn) Send(_ string, _ ...interface{}) error              { return errFromConn }
+func (redisConn) Flush() error                                       { return errFromConn }
+func (redisConn) Receive() (interface{}, error)                      { return nil, errFromConn }
 
 func TestConnectRetry(t *testing.T) {
 	mockDial := func(err error) func(net, addr string, opts ...redis.DialOption) (redis.Conn, error) {
 		return func(net, addr string, opts ...redis.DialOption) (redis.Conn, error) {
 			var ne *netError
 			if errors.As(err, &ne) {
-				ne.count--
-				if ne.count <= 0 {
+				ne.countCalls++
+				if ne.allowedCalls <= 0 {
 					return redisConn{}, nil
 				}
+				ne.allowedCalls--
 			}
 			return nil, err
 		}
 	}
 
 	cases := []struct {
-		err      error
-		retries  int
-		min, max time.Duration
+		err       error
+		retries   int
+		wantCalls int
+		min, max  time.Duration
 	}{
-		{io.EOF, 0, 0, 100 * time.Millisecond},                                                  // non-retryable, no retry configured
-		{&netError{io.EOF, true, false, 10}, 0, 0, 100 * time.Millisecond},                      // retryable, but no retry configured
-		{io.EOF, 3, 0, 100 * time.Millisecond},                                                  // non-retryable, retry configured
-		{&netError{io.EOF, true, false, 10}, 2, time.Second, 3 * time.Second},                   // retryable, retry configured
-		{&netError{io.EOF, false, true, 10}, 2, time.Second, 3 * time.Second},                   // retryable, retry configured
-		{&netError{io.EOF, false, false, 10}, 2, 0, 100 * time.Millisecond},                     // net error, but non-retryable
-		{&netError{io.EOF, true, false, 2}, 10, 100 * time.Millisecond, 500 * time.Millisecond}, // retryable, but succeeded after one
+		// the min-max time intervals are based on the backoff default configuration as
+		// used in the Dial func of the redis pool. It starts with 500ms interval,
+		// multiplies by 1.5 on each attempt, and has a randomization of 0.5 that must
+		// be accounted for. Example ranges of intervals are given at
+		// https://github.com/fleetdm/fleet/pull/1962#issue-729635664
+		// and were used to calculate the (approximate) expected range.
+		{
+			io.EOF, 0, 1, 0, 100 * time.Millisecond,
+		}, // non-retryable, no retry configured
+		{
+			&netError{error: io.EOF, timeout: true, allowedCalls: 10}, 0, 1, 0, 100 * time.Millisecond,
+		}, // retryable, but no retry configured
+		{
+			io.EOF, 3, 1, 0, 100 * time.Millisecond,
+		}, // non-retryable, retry configured
+		{
+			&netError{error: io.EOF, timeout: true, allowedCalls: 10}, 2, 3, 625 * time.Millisecond, 3500 * time.Millisecond,
+		}, // retryable, retry configured
+		{
+			&netError{error: io.EOF, temporary: true, allowedCalls: 10}, 2, 3, 625 * time.Millisecond, 3500 * time.Millisecond,
+		}, // retryable, retry configured
+		{
+			&netError{error: io.EOF, allowedCalls: 10}, 2, 1, 0, 100 * time.Millisecond,
+		}, // net error, but non-retryable
+		{
+			&netError{error: io.EOF, timeout: true, allowedCalls: 1}, 10, 2, 250 * time.Millisecond, 750 * time.Millisecond,
+		}, // retryable, but succeeded after one retry
 	}
 	for _, c := range cases {
 		t.Run(c.err.Error(), func(t *testing.T) {
@@ -71,9 +96,21 @@ func TestConnectRetry(t *testing.T) {
 			require.GreaterOrEqual(t, diff, c.min)
 			require.LessOrEqual(t, diff, c.max)
 			require.Error(t, err)
+
+			wantErr := io.EOF
+			var ne *netError
+			if errors.As(c.err, &ne) {
+				require.Equal(t, c.wantCalls, ne.countCalls)
+				if ne.allowedCalls == 0 {
+					wantErr = errFromConn
+				}
+			} else {
+				require.Equal(t, c.wantCalls, 1)
+			}
+
 			// the error is returned as part of the cluster.Refresh error, hence the
 			// check with Contains.
-			require.Contains(t, err.Error(), io.EOF.Error())
+			require.Contains(t, err.Error(), wantErr.Error())
 		})
 	}
 }

--- a/server/datastore/redis/redis_test.go
+++ b/server/datastore/redis/redis_test.go
@@ -74,7 +74,14 @@ func setupRedisForTest(t *testing.T, cluster bool) (pool fleet.RedisPool, teardo
 	}
 	addr += port
 
-	pool, err := NewRedisPool(addr, password, database, useTLS, 5*time.Second, 10*time.Second)
+	pool, err := NewRedisPool(PoolConfig{
+		Server:      addr,
+		Password:    password,
+		Database:    database,
+		UseTLS:      useTLS,
+		ConnTimeout: 5 * time.Second,
+		KeepAlive:   10 * time.Second,
+	})
 	require.NoError(t, err)
 
 	conn := pool.Get()

--- a/server/fleet/redis_pool.go
+++ b/server/fleet/redis_pool.go
@@ -5,7 +5,17 @@ import "github.com/gomodule/redigo/redis"
 // RedisPool is the common interface for redigo's Pool for standalone Redis
 // and redisc's Cluster for Redis Cluster.
 type RedisPool interface {
+	// Get returns a redis connection. It must always be closed after use.
 	Get() redis.Conn
+
+	// Close closes the redis connection.
 	Close() error
+
+	// Stats returns a map of redis pool statistics for each server address.
 	Stats() map[string]redis.PoolStats
+
+	// ConfigureDoer returns a redis connection that is properly configured
+	// to execute Do commands. This should only be called when the actions
+	// to execute are all done with conn.Do.
+	ConfigureDoer(redis.Conn) redis.Conn
 }

--- a/server/live_query/redis_live_query.go
+++ b/server/live_query/redis_live_query.go
@@ -194,7 +194,7 @@ func (r *redisLiveQuery) RunQuery(name, sql string, hostIDs []uint) error {
 }
 
 func (r *redisLiveQuery) StopQuery(name string) error {
-	conn := r.pool.Get()
+	conn := r.pool.ConfigureDoer(r.pool.Get())
 	defer conn.Close()
 
 	targetKey, sqlKey := generateKeys(name)
@@ -279,7 +279,7 @@ func (r *redisLiveQuery) collectBatchQueriesForHost(hostID uint, queryKeys []str
 }
 
 func (r *redisLiveQuery) QueryCompletedByHost(name string, hostID uint) error {
-	conn := r.pool.Get()
+	conn := r.pool.ConfigureDoer(r.pool.Get())
 	defer conn.Close()
 
 	targetKey, _ := generateKeys(name)

--- a/server/live_query/redis_live_query_test.go
+++ b/server/live_query/redis_live_query_test.go
@@ -1,6 +1,7 @@
 package live_query
 
 import (
+	"runtime"
 	"testing"
 	"time"
 
@@ -99,6 +100,10 @@ func TestMigrateKeys(t *testing.T) {
 }
 
 func setupRedisLiveQuery(t *testing.T, cluster bool) (store *redisLiveQuery, teardown func()) {
+	if cluster && (runtime.GOOS == "darwin" || runtime.GOOS == "windows") {
+		t.Skipf("docker networking limitations prevent running redis cluster tests on %s", runtime.GOOS)
+	}
+
 	var (
 		addr     = "127.0.0.1:"
 		password = ""

--- a/server/live_query/redis_live_query_test.go
+++ b/server/live_query/redis_live_query_test.go
@@ -111,7 +111,14 @@ func setupRedisLiveQuery(t *testing.T, cluster bool) (store *redisLiveQuery, tea
 	}
 	addr += port
 
-	pool, err := redis.NewRedisPool(addr, password, database, useTLS, 5*time.Second, 10*time.Second)
+	pool, err := redis.NewRedisPool(redis.PoolConfig{
+		Server:      addr,
+		Password:    password,
+		Database:    database,
+		UseTLS:      useTLS,
+		ConnTimeout: 5 * time.Second,
+		KeepAlive:   10 * time.Second,
+	})
 	require.NoError(t, err)
 	store = NewRedisLiveQuery(pool)
 

--- a/server/pubsub/testing_utils.go
+++ b/server/pubsub/testing_utils.go
@@ -23,7 +23,14 @@ func SetupRedisForTest(t *testing.T, cluster bool) (store *redisQueryResults, te
 	}
 	addr += port
 
-	pool, err := redis.NewRedisPool(addr, password, database, useTLS, 5*time.Second, 10*time.Second)
+	pool, err := redis.NewRedisPool(redis.PoolConfig{
+		Server:      addr,
+		Password:    password,
+		Database:    database,
+		UseTLS:      useTLS,
+		ConnTimeout: 5 * time.Second,
+		KeepAlive:   10 * time.Second,
+	})
 	require.NoError(t, err)
 	store = NewRedisQueryResults(pool, dupResults)
 

--- a/server/pubsub/testing_utils.go
+++ b/server/pubsub/testing_utils.go
@@ -1,6 +1,7 @@
 package pubsub
 
 import (
+	"runtime"
 	"testing"
 	"time"
 
@@ -10,6 +11,10 @@ import (
 )
 
 func SetupRedisForTest(t *testing.T, cluster bool) (store *redisQueryResults, teardown func()) {
+	if cluster && (runtime.GOOS == "darwin" || runtime.GOOS == "windows") {
+		t.Skipf("docker networking limitations prevent running redis cluster tests on %s", runtime.GOOS)
+	}
+
 	var (
 		addr       = "127.0.0.1:"
 		password   = ""

--- a/server/sso/session_store.go
+++ b/server/sso/session_store.go
@@ -46,7 +46,7 @@ func (s *store) create(requestID, originalURL, metadata string, lifetimeSecs uin
 	if len(requestID) < 8 {
 		return errors.New("request id must be 8 or more characters in length")
 	}
-	conn := s.pool.Get()
+	conn := s.pool.ConfigureDoer(s.pool.Get())
 	defer conn.Close()
 	sess := Session{OriginalURL: originalURL, Metadata: metadata}
 	var writer bytes.Buffer
@@ -59,7 +59,7 @@ func (s *store) create(requestID, originalURL, metadata string, lifetimeSecs uin
 }
 
 func (s *store) Get(requestID string) (*Session, error) {
-	conn := s.pool.Get()
+	conn := s.pool.ConfigureDoer(s.pool.Get())
 	defer conn.Close()
 	val, err := redis.String(conn.Do("GET", requestID))
 	if err != nil {
@@ -81,7 +81,7 @@ func (s *store) Get(requestID string) (*Session, error) {
 var ErrSessionNotFound = errors.New("session not found")
 
 func (s *store) Expire(requestID string) error {
-	conn := s.pool.Get()
+	conn := s.pool.ConfigureDoer(s.pool.Get())
 	defer conn.Close()
 	_, err := conn.Do("DEL", requestID)
 	return err

--- a/server/sso/session_store_test.go
+++ b/server/sso/session_store_test.go
@@ -25,7 +25,14 @@ func newPool(t *testing.T, cluster bool) fleet.RedisPool {
 		}
 		addr += port
 
-		pool, err := redis.NewRedisPool(addr, password, database, useTLS, 5*time.Second, 10*time.Second)
+		pool, err := redis.NewRedisPool(redis.PoolConfig{
+			Server:      addr,
+			Password:    password,
+			Database:    database,
+			UseTLS:      useTLS,
+			ConnTimeout: 5 * time.Second,
+			KeepAlive:   10 * time.Second,
+		})
 		require.NoError(t, err)
 		conn := pool.Get()
 		defer conn.Close()

--- a/server/sso/session_store_test.go
+++ b/server/sso/session_store_test.go
@@ -2,6 +2,7 @@ package sso
 
 import (
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -12,6 +13,10 @@ import (
 )
 
 func newPool(t *testing.T, cluster bool) fleet.RedisPool {
+	if cluster && (runtime.GOOS == "darwin" || runtime.GOOS == "windows") {
+		t.Skipf("docker networking limitations prevent running redis cluster tests on %s", runtime.GOOS)
+	}
+
 	if _, ok := os.LookupEnv("REDIS_TEST"); ok {
 		var (
 			addr     = "127.0.0.1:"


### PR DESCRIPTION
Closes #1969 , and also adds a configuration option to enable automatic following of Redis Cluster redirections where possible (i.e. where we only make Do calls on the connection). This had been mentioned as a possible improvement in #1885 .

Note that I deliberately use hard-coded configuration for the `RetryConn` max attempts and TRYAGAIN delays, as I think this might be a bit too low-level/nitty-gritty to be worth exposing to users - I think those are reasonable values for cluster redirections, the only configuration is deciding whether the user wants to enable the automatic following or not. Let me know if you'd prefer to expose all options directly, I'll update the PR.

# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

- [x] Changes file added (if needed)
- [x] Documented any API changes
- [x] Added tests for all functionality
- [ ] Manual QA for all functionality
