### PR TITLE
Improve performance of the Go test suite

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Run Go Tests
       run: |
-        MYSQL_TEST=1 make test-go
+        REDIS_TEST=1 MYSQL_TEST=1 make test-go
 
     - name: Upload to Codecov
       uses: codecov/codecov-action@v2

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Run Go Tests
       run: |
-        REDIS_TEST=1 MYSQL_TEST=1 make test-go
+        NETWORK_TEST=1 REDIS_TEST=1 MYSQL_TEST=1 make test-go
 
     - name: Upload to Codecov
       uses: codecov/codecov-action@v2

--- a/cmd/fleetctl/convert_test.go
+++ b/cmd/fleetctl/convert_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestConvertFileOutput(t *testing.T) {
-	t.Parallel()
 	// setup the cli and the convert command
 	app := cli.NewApp()
 	app.Commands = []*cli.Command{convertCommand()}
@@ -41,7 +40,6 @@ func TestConvertFileOutput(t *testing.T) {
 }
 
 func TestConvertFileStdout(t *testing.T) {
-	t.Parallel()
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 

--- a/cmd/fleetctl/package_test.go
+++ b/cmd/fleetctl/package_test.go
@@ -1,12 +1,16 @@
 package main
 
 import (
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestPackage(t *testing.T) {
+	if os.Getenv("NETWORK_TEST") == "" {
+		t.Skip("set environment variable NETWORK_TEST=1 to run")
+	}
 
 	// --type is required
 	runAppCheckErr(t, []string{"package", "deb"}, "Required flag \"type\" not set")

--- a/cmd/fleetctl/vulnerability_data_stream_test.go
+++ b/cmd/fleetctl/vulnerability_data_stream_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func TestVulnerabilityDataStream(t *testing.T) {
+	if os.Getenv("NETWORK_TEST") == "" {
+		t.Skip("set environment variable NETWORK_TEST=1 to run")
+	}
+
 	runAppCheckErr(t, []string{"vulnerability-data-stream"}, "No directory provided")
 
 	vulnPath := t.TempDir()

--- a/docs/3-Contributing/2-Testing.md
+++ b/docs/3-Contributing/2-Testing.md
@@ -105,6 +105,14 @@ To run email related integration tests using MailHog set environment as follows:
 MAIL_TEST=1 make test-go
 ```
 
+#### Network tests
+
+A few tests require network access as they make requests to external hosts. Given that the network is unreliable, may not be available, and those hosts may also not be unavailable, those tests are skipped by default and are opt-in via the `NETWORK_TEST` environment variable. To run them:
+
+```
+NETWORK_TEST=1 make test-go
+```
+
 ### Viewing test coverage
 
 When you run `make test` or `make test-go` from the root of the repository, test coverage reports are generated in every subpackage. For example, the `server` subpackage will have a coverage report generated in `./server/server.cover`

--- a/docs/3-Contributing/2-Testing.md
+++ b/docs/3-Contributing/2-Testing.md
@@ -40,7 +40,7 @@ go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.0
 Make sure it is available in your PATH. To execute the basic unit and integration tests, run the following from the root of the repository:
 
 ```
-MYSQL_TEST=1 make test
+REDIS_TEST=1 MYSQL_TEST=1 make test
 ```
 
 It is a good idea to run `make test` before submitting a Pull Request.
@@ -50,7 +50,7 @@ It is a good idea to run `make test` before submitting a Pull Request.
 To run all Go unit tests, run the following:
 
 ```
-make test-go
+REDIS_TEST=1 MYSQL_TEST=1 make test-go
 ```
 
 #### Go linters

--- a/server/datastore/mysql/activities_test.go
+++ b/server/datastore/mysql/activities_test.go
@@ -10,10 +10,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestActivityUsernameChange(t *testing.T) {
+func TestActivity(t *testing.T) {
 	ds := CreateMySQLDS(t)
-	defer ds.Close()
 
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, ds *Datastore)
+	}{
+		{"UsernameChange", testActivityUsernameChange},
+		{"New", testActivityNew},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer TruncateTables(t, ds, "user_teams", "users", "activities")
+			c.fn(t, ds)
+		})
+	}
+}
+
+func testActivityUsernameChange(t *testing.T, ds *Datastore) {
 	u := &fleet.User{
 		Password:    []byte("asd"),
 		Name:        "fullname",
@@ -52,10 +67,7 @@ func TestActivityUsernameChange(t *testing.T) {
 	assert.Nil(t, activities[0].ActorGravatar)
 }
 
-func TestNewActivity(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testActivityNew(t *testing.T, ds *Datastore) {
 	u := &fleet.User{
 		Password:   []byte("asd"),
 		Name:       "fullname",
@@ -86,4 +98,12 @@ func TestNewActivity(t *testing.T) {
 	assert.Len(t, activities, 1)
 	assert.Equal(t, "fullname", activities[0].ActorFullName)
 	assert.Equal(t, "test2", activities[0].Type)
+
+	opt = fleet.ListOptions{
+		Page:    0,
+		PerPage: 10,
+	}
+	activities, err = ds.ListActivities(context.Background(), opt)
+	require.NoError(t, err)
+	assert.Len(t, activities, 2)
 }

--- a/server/datastore/mysql/activities_test.go
+++ b/server/datastore/mysql/activities_test.go
@@ -22,7 +22,7 @@ func TestActivity(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds, "user_teams", "users", "activities")
+			defer TruncateTables(t, ds)
 			c.fn(t, ds)
 		})
 	}

--- a/server/datastore/mysql/app_configs_test.go
+++ b/server/datastore/mysql/app_configs_test.go
@@ -140,7 +140,7 @@ func testAppConfigAdditionalQueries(t *testing.T, ds *Datastore) {
 }
 
 func testAppConfigEnrollSecrets(t *testing.T, ds *Datastore) {
-	defer TruncateTables(t, ds, "teams", "enroll_secrets")
+	defer TruncateTables(t, ds)
 
 	team1, err := ds.NewTeam(context.Background(), &fleet.Team{Name: "team1"})
 	require.NoError(t, err)
@@ -195,7 +195,7 @@ func testAppConfigEnrollSecrets(t *testing.T, ds *Datastore) {
 }
 
 func testAppConfigEnrollSecretsCaseSensitive(t *testing.T, ds *Datastore) {
-	defer TruncateTables(t, ds, "enroll_secrets")
+	defer TruncateTables(t, ds)
 
 	err := ds.ApplyEnrollSecrets(
 		context.Background(),
@@ -213,7 +213,7 @@ func testAppConfigEnrollSecretsCaseSensitive(t *testing.T, ds *Datastore) {
 }
 
 func testAppConfigEnrollSecretRoundtrip(t *testing.T, ds *Datastore) {
-	defer TruncateTables(t, ds, "teams", "enroll_secrets")
+	defer TruncateTables(t, ds)
 
 	team1, err := ds.NewTeam(context.Background(), &fleet.Team{Name: "team1"})
 	require.NoError(t, err)
@@ -254,7 +254,7 @@ func testAppConfigEnrollSecretRoundtrip(t *testing.T, ds *Datastore) {
 }
 
 func testAppConfigEnrollSecretUniqueness(t *testing.T, ds *Datastore) {
-	defer TruncateTables(t, ds, "teams", "enroll_secrets")
+	defer TruncateTables(t, ds)
 
 	team1, err := ds.NewTeam(context.Background(), &fleet.Team{Name: "team1"})
 	require.NoError(t, err)

--- a/server/datastore/mysql/app_configs_test.go
+++ b/server/datastore/mysql/app_configs_test.go
@@ -14,10 +14,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOrgInfo(t *testing.T) {
+func TestAppConfig(t *testing.T) {
 	ds := CreateMySQLDS(t)
-	defer ds.Close()
 
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, ds *Datastore)
+	}{
+		{"OrgInfo", testAppConfigOrgInfo},
+		{"AdditionalQueries", testAppConfigAdditionalQueries},
+		{"EnrollSecrets", testAppConfigEnrollSecrets},
+		{"EnrollSecretsCaseSensitive", testAppConfigEnrollSecretsCaseSensitive},
+		{"EnrollSecretRoundtrip", testAppConfigEnrollSecretRoundtrip},
+		{"EnrollSecretUniqueness", testAppConfigEnrollSecretUniqueness},
+		{"Defaults", testAppConfigDefaults},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			c.fn(t, ds)
+		})
+	}
+}
+
+func testAppConfigOrgInfo(t *testing.T, ds *Datastore) {
 	info := &fleet.AppConfig{
 		OrgInfo: fleet.OrgInfo{
 			OrgName:    "Test",
@@ -94,10 +113,7 @@ func TestOrgInfo(t *testing.T) {
 	assert.False(t, verify.SSOEnabled)
 }
 
-func TestAdditionalQueries(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testAppConfigAdditionalQueries(t *testing.T, ds *Datastore) {
 	additional := ptr.RawMessage(json.RawMessage("not valid json"))
 	info := &fleet.AppConfig{
 		OrgInfo: fleet.OrgInfo{
@@ -123,9 +139,8 @@ func TestAdditionalQueries(t *testing.T) {
 	assert.JSONEq(t, `{"foo":"bar"}`, string(rawJson))
 }
 
-func TestEnrollSecrets(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
+func testAppConfigEnrollSecrets(t *testing.T, ds *Datastore) {
+	defer TruncateTables(t, ds, "teams", "enroll_secrets")
 
 	team1, err := ds.NewTeam(context.Background(), &fleet.Team{Name: "team1"})
 	require.NoError(t, err)
@@ -179,9 +194,8 @@ func TestEnrollSecrets(t *testing.T) {
 	assert.Equal(t, (*uint)(nil), secret.TeamID)
 }
 
-func TestEnrollSecretsCaseSensitive(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
+func testAppConfigEnrollSecretsCaseSensitive(t *testing.T, ds *Datastore) {
+	defer TruncateTables(t, ds, "enroll_secrets")
 
 	err := ds.ApplyEnrollSecrets(
 		context.Background(),
@@ -198,9 +212,8 @@ func TestEnrollSecretsCaseSensitive(t *testing.T) {
 	assert.Error(t, err, "enroll secret with different case should not verify")
 }
 
-func TestEnrollSecretRoundtrip(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
+func testAppConfigEnrollSecretRoundtrip(t *testing.T, ds *Datastore) {
+	defer TruncateTables(t, ds, "teams", "enroll_secrets")
 
 	team1, err := ds.NewTeam(context.Background(), &fleet.Team{Name: "team1"})
 	require.NoError(t, err)
@@ -240,9 +253,8 @@ func TestEnrollSecretRoundtrip(t *testing.T) {
 
 }
 
-func TestEnrollSecretUniqueness(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
+func testAppConfigEnrollSecretUniqueness(t *testing.T, ds *Datastore) {
+	defer TruncateTables(t, ds, "teams", "enroll_secrets")
 
 	team1, err := ds.NewTeam(context.Background(), &fleet.Team{Name: "team1"})
 	require.NoError(t, err)
@@ -258,10 +270,7 @@ func TestEnrollSecretUniqueness(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestAppConfigDefaults(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testAppConfigDefaults(t *testing.T, ds *Datastore) {
 	insertAppConfigQuery := `INSERT INTO app_config_json(json_value) VALUES(?) ON DUPLICATE KEY UPDATE json_value = VALUES(json_value)`
 	_, err := ds.writer.Exec(insertAppConfigQuery, `{}`)
 	require.NoError(t, err)

--- a/server/datastore/mysql/campaigns_test.go
+++ b/server/datastore/mysql/campaigns_test.go
@@ -25,10 +25,7 @@ func TestCampaigns(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds,
-				"users", "hosts", "distributed_query_campaigns",
-				"distributed_query_campaign_targets", "queries",
-				"labels", "label_membership")
+			defer TruncateTables(t, ds)
 
 			c.fn(t, ds)
 		})

--- a/server/datastore/mysql/carves_test.go
+++ b/server/datastore/mysql/carves_test.go
@@ -29,7 +29,7 @@ func TestCarves(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds, "hosts", "carve_metadata", "carve_blocks")
+			defer TruncateTables(t, ds)
 			c.fn(t, ds)
 		})
 	}

--- a/server/datastore/mysql/delete_test.go
+++ b/server/datastore/mysql/delete_test.go
@@ -11,9 +11,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDeleteEntity(t *testing.T) {
+func TestDelete(t *testing.T) {
 	ds := CreateMySQLDS(t)
-	defer ds.Close()
+
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, ds *Datastore)
+	}{
+		{"Entity", testDeleteEntity},
+		{"EntityByName", testDeleteEntityByName},
+		{"Entities", testDeleteEntities},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			c.fn(t, ds)
+		})
+	}
+}
+
+func testDeleteEntity(t *testing.T, ds *Datastore) {
+	defer TruncateTables(t, ds, "hosts")
 
 	host, err := ds.NewHost(context.Background(), &fleet.Host{
 		DetailUpdatedAt: time.Now(),
@@ -36,9 +53,8 @@ func TestDeleteEntity(t *testing.T) {
 	assert.Nil(t, host)
 }
 
-func TestDeleteEntityByName(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
+func testDeleteEntityByName(t *testing.T, ds *Datastore) {
+	defer TruncateTables(t, ds, "queries")
 
 	query1 := test.NewQuery(t, ds, t.Name()+"time", "select * from time", 0, true)
 
@@ -49,9 +65,8 @@ func TestDeleteEntityByName(t *testing.T) {
 	assert.Nil(t, gotQ)
 }
 
-func TestDeleteEntities(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
+func testDeleteEntities(t *testing.T, ds *Datastore) {
+	defer TruncateTables(t, ds, "queries")
 
 	query1 := test.NewQuery(t, ds, t.Name()+"time1", "select * from time", 0, true)
 	query2 := test.NewQuery(t, ds, t.Name()+"time2", "select * from time", 0, true)

--- a/server/datastore/mysql/delete_test.go
+++ b/server/datastore/mysql/delete_test.go
@@ -30,7 +30,7 @@ func TestDelete(t *testing.T) {
 }
 
 func testDeleteEntity(t *testing.T, ds *Datastore) {
-	defer TruncateTables(t, ds, "hosts")
+	defer TruncateTables(t, ds)
 
 	host, err := ds.NewHost(context.Background(), &fleet.Host{
 		DetailUpdatedAt: time.Now(),
@@ -54,7 +54,7 @@ func testDeleteEntity(t *testing.T, ds *Datastore) {
 }
 
 func testDeleteEntityByName(t *testing.T, ds *Datastore) {
-	defer TruncateTables(t, ds, "queries")
+	defer TruncateTables(t, ds)
 
 	query1 := test.NewQuery(t, ds, t.Name()+"time", "select * from time", 0, true)
 
@@ -66,7 +66,7 @@ func testDeleteEntityByName(t *testing.T, ds *Datastore) {
 }
 
 func testDeleteEntities(t *testing.T, ds *Datastore) {
-	defer TruncateTables(t, ds, "queries")
+	defer TruncateTables(t, ds)
 
 	query1 := test.NewQuery(t, ds, t.Name()+"time1", "select * from time", 0, true)
 	query2 := test.NewQuery(t, ds, t.Name()+"time2", "select * from time", 0, true)

--- a/server/datastore/mysql/email_changes_test.go
+++ b/server/datastore/mysql/email_changes_test.go
@@ -11,10 +11,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestChangeEmail(t *testing.T) {
+func TestEmailChanges(t *testing.T) {
 	ds := CreateMySQLDS(t)
-	defer ds.Close()
 
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, ds *Datastore)
+	}{
+		{"Confirm", testEmailChangesConfirm},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer TruncateTables(t, ds, "users", "email_changes")
+			c.fn(t, ds)
+		})
+	}
+}
+
+func testEmailChangesConfirm(t *testing.T, ds *Datastore) {
 	user := &fleet.User{
 		Password:   []byte("foobar"),
 		Email:      "bob@bob.com",
@@ -45,5 +59,4 @@ func TestChangeEmail(t *testing.T) {
 	require.Nil(t, err)
 	_, err = ds.ConfirmPendingEmailChange(context.Background(), otheruser.ID, "uniquetoken")
 	assert.NotNil(t, err)
-
 }

--- a/server/datastore/mysql/email_changes_test.go
+++ b/server/datastore/mysql/email_changes_test.go
@@ -22,7 +22,7 @@ func TestEmailChanges(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds, "users", "email_changes")
+			defer TruncateTables(t, ds)
 			c.fn(t, ds)
 		})
 	}

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -84,12 +84,7 @@ func TestHosts(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds,
-				"hosts", "scheduled_query_stats", "software",
-				"host_software", "host_additional", "host_users",
-				"packs", "pack_targets", "scheduled_queries", "queries",
-				"teams", "enroll_secrets", "labels", "label_membership",
-				"policies", "policy_membership_history")
+			defer TruncateTables(t, ds)
 
 			c.fn(t, ds)
 		})

--- a/server/datastore/mysql/invites_test.go
+++ b/server/datastore/mysql/invites_test.go
@@ -28,7 +28,7 @@ func TestInvites(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds, "teams", "invites", "invite_teams")
+			defer TruncateTables(t, ds)
 			c.fn(t, ds)
 		})
 	}

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -37,9 +37,39 @@ func TestBatchHostnamesLarge(t *testing.T) {
 }
 
 func TestLabels(t *testing.T) {
-	db := CreateMySQLDS(t)
-	defer db.Close()
+	ds := CreateMySQLDS(t)
 
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, ds *Datastore)
+	}{
+		{"AddAllHosts", testLabelsAddAllHosts},
+		{"Search", testLabelsSearch},
+		{"ListHostsInLabel", testLabelsListHostsInLabel},
+		{"ListHostsInLabelAndStatus", testLabelsListHostsInLabelAndStatus},
+		{"ListHostsInLabelAndTeamFilter", testLabelsListHostsInLabelAndTeamFilter},
+		{"BuiltIn", testLabelsBuiltIn},
+		{"ListUniqueHostsInLabels", testLabelsListUniqueHostsInLabels},
+		{"ChangeDetails", testLabelsChangeDetails},
+		{"GetSpec", testLabelsGetSpec},
+		{"ApplySpecsRoundtrip", testLabelsApplySpecsRoundtrip},
+		{"IDsByName", testLabelsIDsByName},
+		{"Save", testLabelsSave},
+		{"QueriesForCentOSHost", testLabelsQueriesForCentOSHost},
+		{"RecordNonExistentQueryLabelExecution", testLabelsRecordNonexistentQueryLabelExecution},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer TruncateTables(t, ds,
+				"hosts", "labels", "label_membership",
+				"host_software", "software", "host_additional",
+				"host_users", "users", "teams")
+			c.fn(t, ds)
+		})
+	}
+}
+
+func testLabelsAddAllHosts(t *testing.T, db *Datastore) {
 	test.AddAllHostsLabel(t, db)
 	hosts := []fleet.Host{}
 	var host *fleet.Host
@@ -185,10 +215,7 @@ func TestLabels(t *testing.T) {
 	assert.Len(t, labels, 1)
 }
 
-func TestSearchLabels(t *testing.T) {
-	db := CreateMySQLDS(t)
-	defer db.Close()
-
+func testLabelsSearch(t *testing.T, db *Datastore) {
 	specs := []*fleet.LabelSpec{
 		{ID: 1, Name: "foo"},
 		{ID: 2, Name: "bar"},
@@ -241,10 +268,7 @@ func TestSearchLabels(t *testing.T) {
 	assert.Contains(t, labels, all)
 }
 
-func TestListHostsInLabel(t *testing.T) {
-	db := CreateMySQLDS(t)
-	defer db.Close()
-
+func testLabelsListHostsInLabel(t *testing.T, db *Datastore) {
 	h1, err := db.NewHost(context.Background(), &fleet.Host{
 		DetailUpdatedAt: time.Now(),
 		LabelUpdatedAt:  time.Now(),
@@ -306,10 +330,7 @@ func TestListHostsInLabel(t *testing.T) {
 	}
 }
 
-func TestListHostsInLabelAndStatus(t *testing.T) {
-	db := CreateMySQLDS(t)
-	defer db.Close()
-
+func testLabelsListHostsInLabelAndStatus(t *testing.T, db *Datastore) {
 	h1, err := db.NewHost(context.Background(), &fleet.Host{
 		DetailUpdatedAt: time.Now(),
 		LabelUpdatedAt:  time.Now(),
@@ -362,10 +383,7 @@ func TestListHostsInLabelAndStatus(t *testing.T) {
 	}
 }
 
-func TestListHostsInLabelAndTeamFilter(t *testing.T) {
-	db := CreateMySQLDS(t)
-	defer db.Close()
-
+func testLabelsListHostsInLabelAndTeamFilter(t *testing.T, db *Datastore) {
 	h1, err := db.NewHost(context.Background(), &fleet.Host{
 		DetailUpdatedAt: time.Now(),
 		LabelUpdatedAt:  time.Now(),
@@ -439,10 +457,7 @@ func TestListHostsInLabelAndTeamFilter(t *testing.T) {
 	}
 }
 
-func TestBuiltInLabels(t *testing.T) {
-	db := CreateMySQLDS(t)
-	defer db.Close()
-
+func testLabelsBuiltIn(t *testing.T, db *Datastore) {
 	require.Nil(t, db.MigrateData(context.Background()))
 
 	user := &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}
@@ -456,10 +471,7 @@ func TestBuiltInLabels(t *testing.T) {
 	assert.Equal(t, fleet.LabelTypeBuiltIn, hits[1].LabelType)
 }
 
-func TestListUniqueHostsInLabels(t *testing.T) {
-	db := CreateMySQLDS(t)
-	defer db.Close()
-
+func testLabelsListUniqueHostsInLabels(t *testing.T, db *Datastore) {
 	hosts := []*fleet.Host{}
 	for i := 0; i < 4; i++ {
 		h, err := db.NewHost(context.Background(), &fleet.Host{
@@ -508,13 +520,9 @@ func TestListUniqueHostsInLabels(t *testing.T) {
 	labels, err := db.ListLabels(context.Background(), filter, fleet.ListOptions{})
 	require.Nil(t, err)
 	require.Len(t, labels, 2)
-
 }
 
-func TestChangeLabelDetails(t *testing.T) {
-	db := CreateMySQLDS(t)
-	defer db.Close()
-
+func testLabelsChangeDetails(t *testing.T, db *Datastore) {
 	label := fleet.LabelSpec{
 		ID:          1,
 		Name:        "my label",
@@ -583,10 +591,7 @@ func setupLabelSpecsTest(t *testing.T, ds fleet.Datastore) []*fleet.LabelSpec {
 	return expectedSpecs
 }
 
-func TestGetLabelSpec(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testLabelsGetSpec(t *testing.T, ds *Datastore) {
 	expectedSpecs := setupLabelSpecsTest(t, ds)
 
 	for _, s := range expectedSpecs {
@@ -596,10 +601,7 @@ func TestGetLabelSpec(t *testing.T) {
 	}
 }
 
-func TestApplyLabelSpecsRoundtrip(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testLabelsApplySpecsRoundtrip(t *testing.T, ds *Datastore) {
 	expectedSpecs := setupLabelSpecsTest(t, ds)
 
 	specs, err := ds.GetLabelSpecs(context.Background())
@@ -614,10 +616,7 @@ func TestApplyLabelSpecsRoundtrip(t *testing.T) {
 	test.ElementsMatchSkipTimestampsID(t, expectedSpecs, specs)
 }
 
-func TestLabelIDsByName(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testLabelsIDsByName(t *testing.T, ds *Datastore) {
 	setupLabelSpecsTest(t, ds)
 
 	labels, err := ds.LabelIDsByName(context.Background(), []string{"foo", "bar", "bing"})
@@ -626,10 +625,7 @@ func TestLabelIDsByName(t *testing.T) {
 	assert.Equal(t, []uint{1, 2, 3}, labels)
 }
 
-func TestSaveLabel(t *testing.T) {
-	db := CreateMySQLDS(t)
-	defer db.Close()
-
+func testLabelsSave(t *testing.T, db *Datastore) {
 	label := &fleet.Label{
 		Name:        "my label",
 		Description: "a label",
@@ -648,10 +644,7 @@ func TestSaveLabel(t *testing.T) {
 	assert.Equal(t, label.Description, saved.Description)
 }
 
-func TestLabelQueriesForCentOSHost(t *testing.T) {
-	db := CreateMySQLDS(t)
-	defer db.Close()
-
+func testLabelsQueriesForCentOSHost(t *testing.T, db *Datastore) {
 	host, err := db.EnrollHost(context.Background(), "0", "0", nil, 0)
 	require.Nil(t, err, "enrollment should succeed")
 	host.Platform = "rhel"
@@ -680,10 +673,7 @@ func TestLabelQueriesForCentOSHost(t *testing.T) {
 	assert.Equal(t, "select 1;", queries[fmt.Sprint(label.ID)])
 }
 
-func TestRecordNonexistentQueryLabelExecution(t *testing.T) {
-	db := CreateMySQLDS(t)
-	defer db.Close()
-
+func testLabelsRecordNonexistentQueryLabelExecution(t *testing.T, db *Datastore) {
 	h1, err := db.NewHost(context.Background(), &fleet.Host{
 		DetailUpdatedAt: time.Now(),
 		LabelUpdatedAt:  time.Now(),

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -60,10 +60,7 @@ func TestLabels(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds,
-				"hosts", "labels", "label_membership",
-				"host_software", "software", "host_additional",
-				"host_users", "users", "teams")
+			defer TruncateTables(t, ds)
 			c.fn(t, ds)
 		})
 	}

--- a/server/datastore/mysql/packs_test.go
+++ b/server/datastore/mysql/packs_test.go
@@ -41,11 +41,7 @@ func TestPacks(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds,
-				"packs", "pack_targets", "scheduled_queries",
-				"labels", "users", "host_users", "queries",
-				"hosts", "labels", "label_membership", "teams",
-				"software", "host_software", "host_additional")
+			defer TruncateTables(t, ds)
 			c.fn(t, ds)
 		})
 	}

--- a/server/datastore/mysql/packs_test.go
+++ b/server/datastore/mysql/packs_test.go
@@ -15,10 +15,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDeletePack(t *testing.T) {
+func TestPacks(t *testing.T) {
 	ds := CreateMySQLDS(t)
-	defer ds.Close()
 
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, ds *Datastore)
+	}{
+		{"Delete", testPacksDelete},
+		{"Save", testPacksSave},
+		{"GetByName", testPacksGetByName},
+		{"List", testPacksList},
+		{"ApplySpecRoundtrip", testPacksApplySpecRoundtrip},
+		{"GetSpec", testPacksGetSpec},
+		{"ApplySpecMissingQueries", testPacksApplySpecMissingQueries},
+		{"ApplySpecMissingName", testPacksApplySpecMissingName},
+		{"ListForHost", testPacksListForHost},
+		{"EnsureGlobal", testPacksEnsureGlobal},
+		{"EnsureTeam", testPacksEnsureTeam},
+		{"TeamNameChangesTeamSchedule", testPacksTeamNameChangesTeamSchedule},
+		{"TeamScheduleNamesMigrateToNewFormat", testPacksTeamScheduleNamesMigrateToNewFormat},
+		{"ApplySpecFailsOnTargetIDNull", testPacksApplySpecFailsOnTargetIDNull},
+		{"ApplyStatsNotLocking", testPacksApplyStatsNotLocking},
+		{"ApplyStatsNotLockingTryTwo", testPacksApplyStatsNotLockingTryTwo},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer TruncateTables(t, ds,
+				"packs", "pack_targets", "scheduled_queries",
+				"labels", "users", "host_users", "queries",
+				"hosts", "labels", "label_membership", "teams",
+				"software", "host_software", "host_additional")
+			c.fn(t, ds)
+		})
+	}
+}
+
+func testPacksDelete(t *testing.T, ds *Datastore) {
 	pack := test.NewPack(t, ds, "foo")
 	assert.NotEqual(t, uint(0), pack.ID)
 
@@ -33,10 +66,7 @@ func TestDeletePack(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestSavePack(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testPacksSave(t *testing.T, ds *Datastore) {
 	expectedPack := &fleet.Pack{
 		Name:     "foo",
 		HostIDs:  []uint{1},
@@ -70,10 +100,7 @@ func TestSavePack(t *testing.T) {
 	test.EqualSkipTimestampsID(t, expectedPack, pack)
 }
 
-func TestGetPackByName(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testPacksGetByName(t *testing.T, ds *Datastore) {
 	pack := test.NewPack(t, ds, "foo")
 	assert.NotEqual(t, uint(0), pack.ID)
 
@@ -87,13 +114,9 @@ func TestGetPackByName(t *testing.T) {
 	require.Nil(t, err)
 	assert.False(t, ok)
 	assert.Nil(t, pack)
-
 }
 
-func TestListPacks(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testPacksList(t *testing.T, ds *Datastore) {
 	p1 := &fleet.PackSpec{
 		ID:   1,
 		Name: "foo_pack",
@@ -223,10 +246,7 @@ func setupPackSpecsTest(t *testing.T, ds fleet.Datastore) []*fleet.PackSpec {
 	return expectedSpecs
 }
 
-func TestApplyPackSpecRoundtrip(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testPacksApplySpecRoundtrip(t *testing.T, ds *Datastore) {
 	expectedSpecs := setupPackSpecsTest(t, ds)
 
 	gotSpec, err := ds.GetPackSpecs(context.Background())
@@ -234,10 +254,7 @@ func TestApplyPackSpecRoundtrip(t *testing.T) {
 	assert.Equal(t, expectedSpecs, gotSpec)
 }
 
-func TestGetPackSpec(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testPacksGetSpec(t *testing.T, ds *Datastore) {
 	expectedSpecs := setupPackSpecsTest(t, ds)
 
 	for _, s := range expectedSpecs {
@@ -247,10 +264,7 @@ func TestGetPackSpec(t *testing.T) {
 	}
 }
 
-func TestApplyPackSpecMissingQueries(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testPacksApplySpecMissingQueries(t *testing.T, ds *Datastore) {
 	// Do not define queries mentioned in spec
 	specs := []*fleet.PackSpec{
 		{
@@ -275,10 +289,7 @@ func TestApplyPackSpecMissingQueries(t *testing.T) {
 	}
 }
 
-func TestApplyPackSpecMissingName(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testPacksApplySpecMissingName(t *testing.T, ds *Datastore) {
 	setupPackSpecsTest(t, ds)
 
 	specs := []*fleet.PackSpec{
@@ -304,10 +315,7 @@ func TestApplyPackSpecMissingName(t *testing.T) {
 	assert.Equal(t, "foo", spec.Queries[0].Name)
 }
 
-func TestListPacksForHost(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testPacksListForHost(t *testing.T, ds *Datastore) {
 	mockClock := clock.NewMockClock()
 
 	l1 := &fleet.LabelSpec{
@@ -416,10 +424,7 @@ func TestListPacksForHost(t *testing.T) {
 	}
 }
 
-func TestEnsureGlobalPack(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testPacksEnsureGlobal(t *testing.T, ds *Datastore) {
 	test.AddAllHostsLabel(t, ds)
 
 	packs, err := ds.ListPacks(context.Background(), fleet.PackListOptions{IncludeSystemPacks: true})
@@ -450,10 +455,7 @@ func TestEnsureGlobalPack(t *testing.T) {
 	assert.Equal(t, "global", *gp.Type)
 }
 
-func TestEnsureTeamPack(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testPacksEnsureTeam(t *testing.T, ds *Datastore) {
 	packs, err := ds.ListPacks(context.Background(), fleet.PackListOptions{IncludeSystemPacks: true})
 	require.Nil(t, err)
 	assert.Len(t, packs, 0)
@@ -499,10 +501,7 @@ func TestEnsureTeamPack(t *testing.T) {
 	assert.Equal(t, []uint{team2.ID}, tp2.TeamIDs)
 }
 
-func TestTeamNameChangesTeamSchedule(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testPacksTeamNameChangesTeamSchedule(t *testing.T, ds *Datastore) {
 	team1, err := ds.NewTeam(context.Background(), &fleet.Team{Name: "team1"})
 	require.NoError(t, err)
 
@@ -521,10 +520,7 @@ func TestTeamNameChangesTeamSchedule(t *testing.T) {
 	assert.Equal(t, teamScheduleName(team1), tp.Name)
 }
 
-func TestTeamScheduleNamesMigrateToNewFormat(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testPacksTeamScheduleNamesMigrateToNewFormat(t *testing.T, ds *Datastore) {
 	team1, err := ds.NewTeam(context.Background(), &fleet.Team{Name: "team1"})
 	require.NoError(t, err)
 
@@ -547,10 +543,7 @@ func TestTeamScheduleNamesMigrateToNewFormat(t *testing.T) {
 	require.Equal(t, teamScheduleName(team1), tp.Name)
 }
 
-func TestApplyPackSpecFailsOnTargetIDNull(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testPacksApplySpecFailsOnTargetIDNull(t *testing.T, ds *Datastore) {
 	// Do not define queries mentioned in spec
 	specs := []*fleet.PackSpec{
 		{
@@ -602,11 +595,8 @@ func randomPackStatsForHost(hostID, packID uint, scheduledQueries []*fleet.Sched
 	}
 }
 
-func TestPackApplyStatsNotLocking(t *testing.T) {
+func testPacksApplyStatsNotLocking(t *testing.T, ds *Datastore) {
 	t.Skip("This can be too much for the test db if you're running all tests")
-
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
 
 	specs := setupPackSpecsTest(t, ds)
 
@@ -650,11 +640,8 @@ func TestPackApplyStatsNotLocking(t *testing.T) {
 	cancelFunc()
 }
 
-func TestPackApplyStatsNotLockingTryTwo(t *testing.T) {
+func testPacksApplyStatsNotLockingTryTwo(t *testing.T, ds *Datastore) {
 	t.Skip("This can be too much for the test db if you're running all tests")
-
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
 
 	setupPackSpecsTest(t, ds)
 

--- a/server/datastore/mysql/password_reset_test.go
+++ b/server/datastore/mysql/password_reset_test.go
@@ -9,11 +9,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPasswordResetRequests(t *testing.T) {
-	db := CreateMySQLDS(t)
-	defer db.Close()
+func TestPasswordReset(t *testing.T) {
+	ds := CreateMySQLDS(t)
 
-	createTestUsers(t, db)
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, ds *Datastore)
+	}{
+		{"Requests", testPasswordResetRequests},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer TruncateTables(t, ds, "users", "password_reset_requests")
+			c.fn(t, ds)
+		})
+	}
+}
+
+func testPasswordResetRequests(t *testing.T, ds *Datastore) {
+	createTestUsers(t, ds)
 	now := time.Now().UTC()
 	tomorrow := now.Add(time.Hour * 24)
 	var passwordResetTests = []struct {
@@ -30,7 +44,7 @@ func TestPasswordResetRequests(t *testing.T) {
 			ExpiresAt: tt.expires,
 			Token:     tt.token,
 		}
-		req, err := db.NewPasswordResetRequest(context.Background(), r)
+		req, err := ds.NewPasswordResetRequest(context.Background(), r)
 		assert.Nil(t, err)
 		assert.Equal(t, tt.userID, req.UserID)
 	}

--- a/server/datastore/mysql/password_reset_test.go
+++ b/server/datastore/mysql/password_reset_test.go
@@ -20,7 +20,7 @@ func TestPasswordReset(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds, "users", "password_reset_requests")
+			defer TruncateTables(t, ds)
 			c.fn(t, ds)
 		})
 	}

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -24,7 +24,7 @@ func TestPolicies(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds, "queries", "policies")
+			defer TruncateTables(t, ds)
 			c.fn(t, ds)
 		})
 	}

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -12,10 +12,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewGlobalPolicy(t *testing.T) {
+func TestPolicies(t *testing.T) {
 	ds := CreateMySQLDS(t)
-	defer ds.Close()
 
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, ds *Datastore)
+	}{
+		{"NewGlobalPolicy", testPoliciesNewGlobalPolicy},
+		{"MembershipView", testPoliciesMembershipView},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer TruncateTables(t, ds, "queries", "policies")
+			c.fn(t, ds)
+		})
+	}
+}
+
+func testPoliciesNewGlobalPolicy(t *testing.T, ds *Datastore) {
 	q, err := ds.NewQuery(context.Background(), &fleet.Query{
 		Name:        "query1",
 		Description: "query1 desc",
@@ -58,10 +73,7 @@ func TestNewGlobalPolicy(t *testing.T) {
 	require.NoError(t, ds.DeleteQuery(context.Background(), q.Name))
 }
 
-func TestPolicyMembershipView(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testPoliciesMembershipView(t *testing.T, ds *Datastore) {
 	host1, err := ds.NewHost(context.Background(), &fleet.Host{
 		OsqueryHostID:   "1234",
 		DetailUpdatedAt: time.Now(),

--- a/server/datastore/mysql/queries_test.go
+++ b/server/datastore/mysql/queries_test.go
@@ -30,9 +30,7 @@ func TestQueries(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds,
-				"queries", "labels", "users", "packs",
-				"scheduled_queries", "pack_targets")
+			defer TruncateTables(t, ds)
 			c.fn(t, ds)
 		})
 	}

--- a/server/datastore/mysql/queries_test.go
+++ b/server/datastore/mysql/queries_test.go
@@ -12,10 +12,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestApplyQueries(t *testing.T) {
+func TestQueries(t *testing.T) {
 	ds := CreateMySQLDS(t)
-	defer ds.Close()
 
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, ds *Datastore)
+	}{
+		{"Apply", testQueriesApply},
+		{"Delete", testQueriesDelete},
+		{"GetByName", testQueriesGetByName},
+		{"DeleteMany", testQueriesDeleteMany},
+		{"Save", testQueriesSave},
+		{"List", testQueriesList},
+		{"LoadPacksForQueries", testQueriesLoadPacksForQueries},
+		{"DuplicateNew", testQueriesDuplicateNew},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer TruncateTables(t, ds,
+				"queries", "labels", "users", "packs",
+				"scheduled_queries", "pack_targets")
+			c.fn(t, ds)
+		})
+	}
+}
+
+func testQueriesApply(t *testing.T, ds *Datastore) {
 	test.AddAllHostsLabel(t, ds)
 
 	zwass := test.NewUser(t, ds, "Zach", "zwass@fleet.co", true)
@@ -79,10 +102,7 @@ func TestApplyQueries(t *testing.T) {
 	assert.Equal(t, &zwass.ID, queries[2].AuthorID)
 }
 
-func TestDeleteQuery(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testQueriesDelete(t *testing.T, ds *Datastore) {
 	user := test.NewUser(t, ds, "Zach", "zwass@fleet.co", true)
 
 	query := &fleet.Query{
@@ -103,10 +123,7 @@ func TestDeleteQuery(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestGetQueryByName(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testQueriesGetByName(t *testing.T, ds *Datastore) {
 	user := test.NewUser(t, ds, "Zach", "zwass@fleet.co", true)
 	test.NewQuery(t, ds, "q1", "select * from time", user.ID, true)
 	actual, err := ds.QueryByName(context.Background(), "q1")
@@ -119,10 +136,7 @@ func TestGetQueryByName(t *testing.T) {
 	assert.True(t, fleet.IsNotFound(err))
 }
 
-func TestDeleteQueries(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testQueriesDeleteMany(t *testing.T, ds *Datastore) {
 	user := test.NewUser(t, ds, "Zach", "zwass@fleet.co", true)
 
 	q1 := test.NewQuery(t, ds, "q1", "select * from time", user.ID, true)
@@ -157,13 +171,9 @@ func TestDeleteQueries(t *testing.T) {
 	queries, err = ds.ListQueries(context.Background(), fleet.ListOptions{})
 	require.Nil(t, err)
 	assert.Len(t, queries, 0)
-
 }
 
-func TestSaveQuery(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testQueriesSave(t *testing.T, ds *Datastore) {
 	user := test.NewUser(t, ds, "Zach", "zwass@fleet.co", true)
 
 	query := &fleet.Query{
@@ -190,10 +200,7 @@ func TestSaveQuery(t *testing.T) {
 	assert.True(t, queryVerify.ObserverCanRun)
 }
 
-func TestListQuery(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testQueriesList(t *testing.T, ds *Datastore) {
 	user := test.NewUser(t, ds, "Zach", "zwass@fleet.co", true)
 
 	for i := 0; i < 10; i++ {
@@ -221,10 +228,7 @@ func TestListQuery(t *testing.T) {
 	assert.Equal(t, 10, len(results))
 }
 
-func TestLoadPacksForQueries(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testQueriesLoadPacksForQueries(t *testing.T, ds *Datastore) {
 	zwass := test.NewUser(t, ds, "Zach", "zwass@fleet.co", true)
 	queries := []*fleet.Query{
 		{Name: "q1", Query: "select * from time"},
@@ -234,9 +238,9 @@ func TestLoadPacksForQueries(t *testing.T) {
 	require.Nil(t, err)
 
 	specs := []*fleet.PackSpec{
-		&fleet.PackSpec{Name: "p1"},
-		&fleet.PackSpec{Name: "p2"},
-		&fleet.PackSpec{Name: "p3"},
+		{Name: "p1"},
+		{Name: "p2"},
+		{Name: "p3"},
 	}
 	err = ds.ApplyPackSpecs(context.Background(), specs)
 	require.Nil(t, err)
@@ -250,10 +254,10 @@ func TestLoadPacksForQueries(t *testing.T) {
 	assert.Empty(t, q1.Packs)
 
 	specs = []*fleet.PackSpec{
-		&fleet.PackSpec{
+		{
 			Name: "p2",
 			Queries: []fleet.PackSpecQuery{
-				fleet.PackSpecQuery{
+				{
 					Name:      "q0",
 					QueryName: queries[0].Name,
 					Interval:  60,
@@ -275,19 +279,19 @@ func TestLoadPacksForQueries(t *testing.T) {
 	assert.Empty(t, q1.Packs)
 
 	specs = []*fleet.PackSpec{
-		&fleet.PackSpec{
+		{
 			Name: "p1",
 			Queries: []fleet.PackSpecQuery{
-				fleet.PackSpecQuery{
+				{
 					QueryName: queries[1].Name,
 					Interval:  60,
 				},
 			},
 		},
-		&fleet.PackSpec{
+		{
 			Name: "p3",
 			Queries: []fleet.PackSpecQuery{
-				fleet.PackSpecQuery{
+				{
 					QueryName: queries[1].Name,
 					Interval:  60,
 				},
@@ -312,15 +316,15 @@ func TestLoadPacksForQueries(t *testing.T) {
 	}
 
 	specs = []*fleet.PackSpec{
-		&fleet.PackSpec{
+		{
 			Name: "p3",
 			Queries: []fleet.PackSpecQuery{
-				fleet.PackSpecQuery{
+				{
 					Name:      "q0",
 					QueryName: queries[0].Name,
 					Interval:  60,
 				},
-				fleet.PackSpecQuery{
+				{
 					Name:      "q1",
 					QueryName: queries[1].Name,
 					Interval:  60,
@@ -348,10 +352,7 @@ func TestLoadPacksForQueries(t *testing.T) {
 	}
 }
 
-func TestDuplicateNewQuery(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testQueriesDuplicateNew(t *testing.T, ds *Datastore) {
 	user := test.NewUser(t, ds, "Mike Arpaia", "mike@fleet.co", true)
 	q1, err := ds.NewQuery(context.Background(), &fleet.Query{
 		Name:     "foo",

--- a/server/datastore/mysql/scheduled_queries_test.go
+++ b/server/datastore/mysql/scheduled_queries_test.go
@@ -28,9 +28,7 @@ func TestScheduledQueries(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds,
-				"queries", "labels", "users", "packs",
-				"scheduled_queries", "pack_targets", "scheduled_query_stats")
+			defer TruncateTables(t, ds)
 			c.fn(t, ds)
 		})
 	}

--- a/server/datastore/mysql/sessions_test.go
+++ b/server/datastore/mysql/sessions_test.go
@@ -21,7 +21,7 @@ func TestSessions(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds, "users", "sessions")
+			defer TruncateTables(t, ds)
 			c.fn(t, ds)
 		})
 	}

--- a/server/datastore/mysql/sessions_test.go
+++ b/server/datastore/mysql/sessions_test.go
@@ -10,10 +10,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSessionGetters(t *testing.T) {
+func TestSessions(t *testing.T) {
 	ds := CreateMySQLDS(t)
-	defer ds.Close()
 
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, ds *Datastore)
+	}{
+		{"Getters", testSessionsGetters},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer TruncateTables(t, ds, "users", "sessions")
+			c.fn(t, ds)
+		})
+	}
+}
+
+func testSessionsGetters(t *testing.T, ds *Datastore) {
 	user, err := ds.NewUser(context.Background(), &fleet.User{
 		Password:   []byte("supersecret"),
 		Email:      "other@bobcom",

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -35,7 +35,7 @@ func TestSoftware(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds, "hosts", "software", "host_software", "software_cpe", "software_cve")
+			defer TruncateTables(t, ds)
 			c.fn(t, ds)
 		})
 	}

--- a/server/datastore/mysql/statistics_test.go
+++ b/server/datastore/mysql/statistics_test.go
@@ -10,10 +10,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestShouldSendStatistics(t *testing.T) {
+func TestStatistics(t *testing.T) {
 	ds := CreateMySQLDS(t)
-	defer ds.Close()
 
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, ds *Datastore)
+	}{
+		{"ShouldSend", testStatisticsShouldSend},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer TruncateTables(t, ds, "hosts", "statistics")
+			c.fn(t, ds)
+		})
+	}
+}
+
+func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	_, err := ds.NewHost(context.Background(), &fleet.Host{
 		DetailUpdatedAt: time.Now(),
 		LabelUpdatedAt:  time.Now(),

--- a/server/datastore/mysql/statistics_test.go
+++ b/server/datastore/mysql/statistics_test.go
@@ -21,7 +21,7 @@ func TestStatistics(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds, "hosts", "statistics")
+			defer TruncateTables(t, ds)
 			c.fn(t, ds)
 		})
 	}

--- a/server/datastore/mysql/targets_test.go
+++ b/server/datastore/mysql/targets_test.go
@@ -28,9 +28,7 @@ func TestTargets(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds,
-				"users", "hosts", "teams", "enroll_secrets",
-				"labels", "label_membership", "host_users", "teams")
+			defer TruncateTables(t, ds)
 			c.fn(t, ds)
 		})
 	}

--- a/server/datastore/mysql/teams_test.go
+++ b/server/datastore/mysql/teams_test.go
@@ -28,9 +28,7 @@ func TestTeams(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds,
-				"teams", "users", "user_teams",
-				"packs", "hosts", "enroll_secrets")
+			defer TruncateTables(t, ds)
 			c.fn(t, ds)
 		})
 	}

--- a/server/datastore/mysql/teams_test.go
+++ b/server/datastore/mysql/teams_test.go
@@ -13,10 +13,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTeamGetSetDelete(t *testing.T) {
+func TestTeams(t *testing.T) {
 	ds := CreateMySQLDS(t)
-	defer ds.Close()
 
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, ds *Datastore)
+	}{
+		{"GetSetDelete", testTeamsGetSetDelete},
+		{"Users", testTeamsUsers},
+		{"List", testTeamsList},
+		{"Search", testTeamsSearch},
+		{"EnrollSecrets", testTeamsEnrollSecrets},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer TruncateTables(t, ds,
+				"teams", "users", "user_teams",
+				"packs", "hosts", "enroll_secrets")
+			c.fn(t, ds)
+		})
+	}
+}
+
+func testTeamsGetSetDelete(t *testing.T, ds *Datastore) {
 	var createTests = []struct {
 		name, description string
 	}{
@@ -25,7 +45,7 @@ func TestTeamGetSetDelete(t *testing.T) {
 	}
 
 	for _, tt := range createTests {
-		t.Run("", func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			team, err := ds.NewTeam(context.Background(), &fleet.Team{
 				Name:        tt.name,
 				Description: tt.description,
@@ -52,10 +72,7 @@ func TestTeamGetSetDelete(t *testing.T) {
 	}
 }
 
-func TestTeamUsers(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testTeamsUsers(t *testing.T, ds *Datastore) {
 	users := createTestUsers(t, ds)
 	user1 := fleet.User{Name: users[0].Name, Email: users[0].Email, ID: users[0].ID}
 	user2 := fleet.User{Name: users[1].Name, Email: users[1].Email, ID: users[1].ID}
@@ -111,10 +128,7 @@ func TestTeamUsers(t *testing.T) {
 	assert.ElementsMatch(t, team2Users, team2.Users)
 }
 
-func TestTeamListTeams(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testTeamsList(t *testing.T, ds *Datastore) {
 	users := createTestUsers(t, ds)
 	user1 := fleet.User{Name: users[0].Name, Email: users[0].Email, ID: users[0].ID, GlobalRole: ptr.String(fleet.RoleAdmin)}
 	user2 := fleet.User{Name: users[1].Name, Email: users[1].Email, ID: users[1].ID, GlobalRole: ptr.String(fleet.RoleObserver)}
@@ -168,10 +182,7 @@ func TestTeamListTeams(t *testing.T) {
 	assert.Equal(t, 1, teams[1].UserCount)
 }
 
-func TestTeamSearchTeams(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testTeamsSearch(t *testing.T, ds *Datastore) {
 	team1, err := ds.NewTeam(context.Background(), &fleet.Team{Name: "team1"})
 	require.NoError(t, err)
 	team2, err := ds.NewTeam(context.Background(), &fleet.Team{Name: "team2"})
@@ -207,10 +218,7 @@ func TestTeamSearchTeams(t *testing.T) {
 	assert.Len(t, teams, 0)
 }
 
-func TestTeamEnrollSecrets(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testTeamsEnrollSecrets(t *testing.T, ds *Datastore) {
 	secrets := []*fleet.EnrollSecret{{Secret: "secret1"}, {Secret: "secret2"}}
 	team1, err := ds.NewTeam(context.Background(), &fleet.Team{
 		Name:    "team1",

--- a/server/datastore/mysql/testing_utils.go
+++ b/server/datastore/mysql/testing_utils.go
@@ -216,7 +216,6 @@ func createMySQLDSWithOptions(t *testing.T, opts *DatastoreTestOptions) *Datasto
 		t.Skip("MySQL tests are disabled")
 	}
 
-	fmt.Println(">>>>> created mysql db")
 	t.Parallel()
 
 	if opts == nil {

--- a/server/datastore/mysql/testing_utils.go
+++ b/server/datastore/mysql/testing_utils.go
@@ -216,6 +216,7 @@ func createMySQLDSWithOptions(t *testing.T, opts *DatastoreTestOptions) *Datasto
 		t.Skip("MySQL tests are disabled")
 	}
 
+	fmt.Println(">>>>> created mysql db")
 	t.Parallel()
 
 	if opts == nil {

--- a/server/datastore/mysql/users_test.go
+++ b/server/datastore/mysql/users_test.go
@@ -32,7 +32,7 @@ func TestUsers(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			defer TruncateTables(t, ds, "users", "user_teams", "teams")
+			defer TruncateTables(t, ds)
 			c.fn(t, ds)
 		})
 	}

--- a/server/datastore/mysql/users_test.go
+++ b/server/datastore/mysql/users_test.go
@@ -15,10 +15,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateUser(t *testing.T) {
+func TestUsers(t *testing.T) {
 	ds := CreateMySQLDS(t)
-	defer ds.Close()
 
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, ds *Datastore)
+	}{
+		{"Create", testUsersCreate},
+		{"ByID", testUsersByID},
+		{"Save", testUsersSave},
+		{"List", testUsersList},
+		{"Teams", testUsersTeams},
+		{"CreateWithTeams", testUsersCreateWithTeams},
+		{"SaveMany", testUsersSaveMany},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer TruncateTables(t, ds, "users", "user_teams", "teams")
+			c.fn(t, ds)
+		})
+	}
+}
+
+func testUsersCreate(t *testing.T, ds *Datastore) {
 	var createTests = []struct {
 		password, email             string
 		isAdmin, passwordReset, sso bool
@@ -48,10 +68,7 @@ func TestCreateUser(t *testing.T) {
 	}
 }
 
-func TestUserByID(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testUsersByID(t *testing.T, ds *Datastore) {
 	users := createTestUsers(t, ds)
 	for _, tt := range users {
 		returned, err := ds.UserByID(context.Background(), tt.ID)
@@ -92,10 +109,7 @@ func createTestUsers(t *testing.T, ds fleet.Datastore) []*fleet.User {
 	return users
 }
 
-func TestSaveUser(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testUsersSave(t *testing.T, ds *Datastore) {
 	users := createTestUsers(t, ds)
 	testUserGlobalRole(t, ds, users)
 	testEmailAttribute(t, ds, users)
@@ -150,10 +164,7 @@ func testUserGlobalRole(t *testing.T, ds fleet.Datastore, users []*fleet.User) {
 	assert.Equal(t, "Cannot specify both Global Role and Team Roles", flErr.Message)
 }
 
-func TestListUsers(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testUsersList(t *testing.T, ds *Datastore) {
 	createTestUsers(t, ds)
 
 	users, err := ds.ListUsers(context.Background(), fleet.UserListOptions{})
@@ -171,10 +182,7 @@ func TestListUsers(t *testing.T) {
 	assert.Equal(t, "mike@fleet.co", users[0].Email)
 }
 
-func TestUserTeams(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testUsersTeams(t *testing.T, ds *Datastore) {
 	for i := 0; i < 10; i++ {
 		_, err := ds.NewTeam(context.Background(), &fleet.Team{Name: fmt.Sprintf("%d", i)})
 		require.NoError(t, err)
@@ -264,10 +272,7 @@ func TestUserTeams(t *testing.T) {
 	assert.Len(t, users[1].Teams, 0)
 }
 
-func TestUserCreateWithTeams(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testUsersCreateWithTeams(t *testing.T, ds *Datastore) {
 	for i := 0; i < 10; i++ {
 		_, err := ds.NewTeam(context.Background(), &fleet.Team{Name: fmt.Sprintf("%d", i)})
 		require.NoError(t, err)
@@ -306,10 +311,7 @@ func TestUserCreateWithTeams(t *testing.T) {
 	assert.Equal(t, "maintainer", user.Teams[2].Role)
 }
 
-func TestSaveUsers(t *testing.T) {
-	ds := CreateMySQLDS(t)
-	defer ds.Close()
-
+func testUsersSaveMany(t *testing.T, ds *Datastore) {
 	u1 := test.NewUser(t, ds, t.Name()+"Admin1", t.Name()+"admin1@fleet.co", true)
 	u2 := test.NewUser(t, ds, t.Name()+"Admin2", t.Name()+"admin2@fleet.co", true)
 	u3 := test.NewUser(t, ds, t.Name()+"Admin3", t.Name()+"admin3@fleet.co", true)

--- a/server/vulnerabilities/cpe_test.go
+++ b/server/vulnerabilities/cpe_test.go
@@ -53,6 +53,10 @@ func TestCpeFromSoftware(t *testing.T) {
 }
 
 func TestSyncCPEDatabase(t *testing.T) {
+	if os.Getenv("NETWORK_TEST") == "" {
+		t.Skip("set environment variable NETWORK_TEST=1 to run")
+	}
+
 	// Disabling vcr because the resulting file exceeds the 100mb limit for github
 	r, err := recorder.NewAsMode("fixtures/nvd-cpe-release", recorder.ModeDisabled, http.DefaultTransport)
 	require.NoError(t, err)
@@ -144,6 +148,10 @@ func (f *fakeSoftwareIterator) Err() error   { return nil }
 func (f *fakeSoftwareIterator) Close() error { f.closed = true; return nil }
 
 func TestTranslateSoftwareToCPE(t *testing.T) {
+	if os.Getenv("NETWORK_TEST") == "" {
+		t.Skip("set environment variable NETWORK_TEST=1 to run")
+	}
+
 	tempDir, err := os.MkdirTemp(os.TempDir(), "TestTranslateSoftwareToCPE-*")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempDir)

--- a/server/vulnerabilities/cve_test.go
+++ b/server/vulnerabilities/cve_test.go
@@ -26,6 +26,10 @@ var cvetests = []struct {
 }
 
 func TestTranslateCPEToCVE(t *testing.T) {
+	if os.Getenv("NETWORK_TEST") == "" {
+		t.Skip("set environment variable NETWORK_TEST=1 to run")
+	}
+
 	tempDir := t.TempDir()
 
 	ds := new(mock.Store)


### PR DESCRIPTION
Closes #1805 .

This PR addresses two categories of slow tests: network requests and creating temporary mysql databases.

### Network Requests

I introduced the `NETWORK_TEST=1` environment variable, similar to how we have `MYSQL_TEST` and `REDIS_TEST` to enable those specific tests. I did enable them on CI as we do want to run them, but it is easier to skip when running tests locally (i.e. `make test-go` does not run them automatically).

It's not the ideal solution, I would've liked to mock them completely by starting a test server and mocking responses, but after a closer look this seems quite complex to setup as the data returned has a specific format (e.g. for vulnerabilities) and hashes that must match and the requests themselves are sometimes made quite deep in the code (even in 3rd-party code).

### Temporary MySQL Databases

I refactored the tests in `server/datastore/mysql` to use sub-tests and drop the number of temporary databases created from 130 to 24. I opted to keep a top-level test (that creates the temp DB) for each "entity" (or .go file) to make it easier to identify the cleanup required and so that the test setup applies to the tests in the same file, a bit easier to reason about and to read the tests that way, I think. 

The speedup is quite interesting too, comparing `MYSQL_TEST=1 go test ./server/datastore/mysql/ -count=1` locally on this branch vs `main`, I get ~10s vs ~30s (though part of it is also in reducing the number of records created in "load" tests to verify mysql locking).

Also, the race detector (`MYSQL_TEST=1 go test ./server/datastore/mysql/ -count=1 -race`) now passes, there was a data race previously (in the test code, so nothing critical).

# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

- [ ] ~~Changes file added (if needed)~~
- [ ] ~~Documented any API changes~~
- [ ] ~~Added tests for all functionality~~
- [ ] ~~Manual QA for all functionality~~
