### PR TITLE
Add limit 1 to disk space queries

### DIFF
--- a/changes/ensure-only-one-row-disk-space
+++ b/changes/ensure-only-one-row-disk-space
@@ -1,0 +1,1 @@
+* Ensure only one row is returned when checking for disk space in hosts.

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -340,7 +340,7 @@ var detailQueries = map[string]DetailQuery{
 		Query: `
 SELECT (blocks_available * 100 / blocks) AS percent_disk_space_available, 
        round((blocks_available * blocks_size *10e-10),2) AS gigs_disk_space_available 
-FROM mounts WHERE path = '/';`,
+FROM mounts WHERE path = '/' LIMIT 1;`,
 		Platforms:  []string{"darwin", "linux", "rhel", "ubuntu", "centos"},
 		IngestFunc: ingestDiskSpace,
 	},
@@ -348,7 +348,7 @@ FROM mounts WHERE path = '/';`,
 		Query: `
 SELECT ROUND((sum(free_space) * 100 * 10e-10) / (sum(size) * 10e-10)) AS percent_disk_space_available, 
        ROUND(sum(free_space) * 10e-10) AS gigs_disk_space_available 
-FROM logical_drives WHERE file_system = 'NTFS';`,
+FROM logical_drives WHERE file_system = 'NTFS' LIMIT 1;`,
 		Platforms:  []string{"windows"},
 		IngestFunc: ingestDiskSpace,
 	},


### PR DESCRIPTION
In some cases, it seems the disk space queries are returning more than one row: https://osquery.slack.com/archives/C01DXJL16D8/p1631644195218800

# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

- [x] Changes file added (if needed)
- ~Documented any API changes~
- ~Added tests for all functionality~
- [x] Manual QA for all functionality
