### PR TITLE
Docs image replacement

### DIFF
--- a/docs/1-Using-Fleet/0-Learn-how-to-use-Fleet.md
+++ b/docs/1-Using-Fleet/0-Learn-how-to-use-Fleet.md
@@ -95,7 +95,7 @@ To add your own device to Fleet, you'll first need to install the osquery agent.
 
 > Take note on where your new Orbit directory is located on you device. Knowing this will be helpful when building the Orbit package in step 3.
 
-<img src="https://user-images.githubusercontent.com/78363703/130035034-7363ebe1-f89b-42af-9e88-24db867e8047.png" alt="Clone Orbit repository"/>
+<img src="https://user-images.githubusercontent.com/78363703/133367260-d78d1e11-b8a9-4c36-a39b-b11b2f4d1197.png" alt="Clone Orbit repository"/>
 
 2. In Fleet UI's Host page, hit the "Add new host" button, and copy your Fleet enroll secret (you'll need this in the next step.)
 


### PR DESCRIPTION
Recent PR https://github.com/fleetdm/fleet/pull/2071 (removing hardcoded widths on images) undoes what we previously did for making smaller images look good at <990px breakpoints.

The only current examples of these smaller images are on file edited here, in the docs, although there are a couple of instances in the handbook. So I propose that we only crop/use images suitable for full container-width sizes.

With that in mind I have replaced one of the affected images on this page. Note, I have left the "Select targets" image as is. I will replace this when we update this article to match the new query console UI.

cc @mikermcneil 

# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

- [ ] Changes file added (if needed)
- [ ] Documented any API changes
- [ ] Added tests for all functionality
- [x] Manual QA for all functionality
