### PR TITLE
Add page titles and descriptions to fleetdm.com

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -13,19 +13,59 @@ module.exports.routes = {
   //  ╦ ╦╔═╗╔╗ ╔═╗╔═╗╔═╗╔═╗╔═╗
   //  ║║║║╣ ╠╩╗╠═╝╠═╣║ ╦║╣ ╚═╗
   //  ╚╩╝╚═╝╚═╝╩  ╩ ╩╚═╝╚═╝╚═╝
-  'GET /':                   { action: 'view-homepage-or-redirect', locals: { isHomepage: true } },
-  'GET /company/contact':    { action: 'view-contact' },
-  'GET /get-started':        { action: 'view-get-started' },
-  'GET /pricing':            { action: 'view-pricing' },
-  'GET /press-kit':          { action: 'view-press-kit' },
+  'GET /': {
+    action: 'view-homepage-or-redirect',
+    locals: { isHomepage: true }
+  },
+  'GET /company/contact': {
+    action: 'view-contact',
+    locals:{
+      title: 'Contact us | Fleet for osquery',
+    }
+  },
+  'GET /get-started': {
+    action: 'view-get-started' ,
+    locals:{
+      title: 'Get Started | Fleet for osquery',
+    }
+  },
+  'GET /pricing': {
+    action: 'view-pricing',
+    locals:{
+      title: 'Pricing | Fleet for osquery',
+      description: 'howdy there :o'
+    }
+  },
+  'GET /press-kit': {
+    action: 'view-press-kit',
+    locals:{
+      title: 'Press kit | Fleet for osquery',
+    }
+  },
 
-  'GET /queries':            { action: 'view-query-library' },
-  'GET /queries/:slug':      { action: 'view-query-detail' },
+  'GET /queries': {
+    action: 'view-query-library',
+    locals:{
+      title: 'Queries | Fleet for osquery',
+    }
+  },
+  'GET /queries/:slug': {
+    action: 'view-query-detail',
+    locals:{
+      title: 'Query details | Fleet for osquery',
+    }
+  },
 
-  'GET /docs/?*':            { skipAssets: false, action: 'docs/view-basic-documentation' },// handles /docs and /docs/foo/bar
-  // 'GET /handbook/?*':        { skipAssets: false, action: 'handbook/view-basic-handbook' },// handles /handbook and /handbook/foo/bar
+  'GET /docs/?*': { skipAssets: false, action: 'docs/view-basic-documentation' },// handles /docs and /docs/foo/bar
 
-  'GET /transparency':       { action: 'view-transparency' },
+  // 'GET /handbook/?*':  { skipAssets: false, action: 'handbook/view-basic-handbook' },// handles /handbook and /handbook/foo/bar
+
+  'GET /transparency': {
+    action: 'view-transparency',
+    locals:{
+      title: 'Transparency | Fleet for osquery',
+    }
+  },
 
 
 

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -17,32 +17,36 @@ module.exports.routes = {
     action: 'view-homepage-or-redirect',
     locals: { isHomepage: true }
   },
+
   'GET /company/contact': {
     action: 'view-contact',
     locals:{
       title: 'Contact us | Fleet for osquery',
-      description: 'Contact our team'
+      description: 'Get in touch with our team.'
     }
   },
+
   'GET /get-started': {
     action: 'view-get-started' ,
     locals:{
       title: 'Get Started | Fleet for osquery',
-      description: 'Get started using Fleet for osquery'
+      description: 'Learn about getting started with Fleet.'
     }
   },
+
   'GET /pricing': {
     action: 'view-pricing',
     locals:{
       title: 'Pricing | Fleet for osquery',
-      description: 'View Fleet plans and pricing details'
+      description: 'View Fleet plans and pricing details.'
     }
   },
+
   'GET /press-kit': {
     action: 'view-press-kit',
     locals:{
       title: 'Press kit | Fleet for osquery',
-      description: 'Download Fleet logos, wallpapers, and screenshots'
+      description: 'Download Fleet logos, wallpapers, and screenshots.'
     }
   },
 
@@ -50,9 +54,10 @@ module.exports.routes = {
     action: 'view-query-library',
     locals:{
       title: 'Queries | Fleet for osquery',
-      description: 'A library of commonly used queries'
+      description: 'A curated collection of commonly used queries for osquery.'
     }
   },
+
   'GET /queries/:slug': {
     action: 'view-query-detail',
     locals:{
@@ -66,7 +71,7 @@ module.exports.routes = {
     action: 'docs/view-basic-documentation',
     locals:{
       title: 'Documentation | Fleet for osquery',
-      description: 'Documentation for Fleet for osquery',
+      description: 'Documentation for Fleet for osquery.',
     }
   },// handles /docs and /docs/foo/bar
 
@@ -76,7 +81,7 @@ module.exports.routes = {
     action: 'view-transparency',
     locals:{
       title: 'Transparency | Fleet for osquery',
-      description: 'Learn more about what data osquery can see',
+      description: 'Learn what data osquery can see.',
     }
   },
 

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -21,25 +21,28 @@ module.exports.routes = {
     action: 'view-contact',
     locals:{
       title: 'Contact us | Fleet for osquery',
+      description: 'Contact our team'
     }
   },
   'GET /get-started': {
     action: 'view-get-started' ,
     locals:{
       title: 'Get Started | Fleet for osquery',
+      description: 'Get started using Fleet for osquery'
     }
   },
   'GET /pricing': {
     action: 'view-pricing',
     locals:{
       title: 'Pricing | Fleet for osquery',
-      description: 'howdy there :o'
+      description: 'View Fleet plans and pricing details'
     }
   },
   'GET /press-kit': {
     action: 'view-press-kit',
     locals:{
       title: 'Press kit | Fleet for osquery',
+      description: 'Download Fleet logos, wallpapers, and screenshots'
     }
   },
 
@@ -47,16 +50,25 @@ module.exports.routes = {
     action: 'view-query-library',
     locals:{
       title: 'Queries | Fleet for osquery',
+      description: 'A library of commonly used queries'
     }
   },
   'GET /queries/:slug': {
     action: 'view-query-detail',
     locals:{
       title: 'Query details | Fleet for osquery',
+      description: '',
     }
   },
 
-  'GET /docs/?*': { skipAssets: false, action: 'docs/view-basic-documentation' },// handles /docs and /docs/foo/bar
+  'GET /docs/?*': {
+    skipAssets: false,
+    action: 'docs/view-basic-documentation',
+    locals:{
+      title: 'Documentation | Fleet for osquery',
+      description: 'Documentation for Fleet for osquery',
+    }
+  },// handles /docs and /docs/foo/bar
 
   // 'GET /handbook/?*':  { skipAssets: false, action: 'handbook/view-basic-handbook' },// handles /handbook and /handbook/foo/bar
 
@@ -64,6 +76,7 @@ module.exports.routes = {
     action: 'view-transparency',
     locals:{
       title: 'Transparency | Fleet for osquery',
+      description: 'Learn more about what data osquery can see',
     }
   },
 

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -54,7 +54,7 @@ module.exports.routes = {
     action: 'view-query-library',
     locals:{
       title: 'Queries | Fleet for osquery',
-      description: 'A curated collection of commonly used queries for osquery.'
+      description: 'A growing collection of useful queries for organizations deploying Fleet and osquery.'
     }
   },
 
@@ -62,7 +62,7 @@ module.exports.routes = {
     action: 'view-query-detail',
     locals:{
       title: 'Query details | Fleet for osquery',
-      description: '',
+      description: 'View more information about a query in Fleet\'s standard query library',
     }
   },
 

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -7,14 +7,15 @@
 %><!DOCTYPE html>
 <html>
   <head>
-    <title>Fleet for osquery | Open source device management</title>
+    <title><%= typeof title !== 'undefined' ? title : 'Fleet for osquery | Open source device management' %></title>
+    <meta name="description" content="<%= typeof description !== 'undefined' ? description : 'Open source software, built on osquery. With Fleet you can ask important questions about your devices. Whatever operating system, wherever they live.' %>" />
 
     <% /* Viewport tag for sensible mobile support */ %>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="https://fleetdm.com" />
-    <meta name="twitter:title" content="Open source device management" />
-    <meta name="twitter:description" content="Open source software, built on osquery. With Fleet you can ask important questions about your devices. Whatever operating system, wherever they live." />
+    <meta name="twitter:title" content="<%= typeof title !== 'undefined' ? title : 'Open source device management' %>" />
+    <meta name="twitter:description" content="<%= description !== 'undefined' ? description : 'Open source software, built on osquery. With Fleet you can ask important questions about your devices. Whatever operating system, wherever they live.' %>" />
     <meta name="twitter:image" content="https://fleetdm.com/images/fleet-logo-square@2x.png" />
     <% /* Script tags should normally be included further down the page- but any
     scripts that load fonts (e.g. Fontawesome ≥v5) are special exceptions to the

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -15,7 +15,11 @@
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="https://fleetdm.com" />
     <meta name="twitter:title" content="<%= typeof title !== 'undefined' ? title : 'Open source device management' %>" />
-    <meta name="twitter:description" content="<%= description !== 'undefined' ? description : 'Open source software, built on osquery. With Fleet you can ask important questions about your devices. Whatever operating system, wherever they live.' %>" />
+    <%if(typeof description !== 'undefined') { %>
+      <meta name="twitter:description" content="<%= description !== 'undefined' ? description : 'Open source software, built on osquery. With Fleet you can ask important questions about your devices. Whatever operating system, wherever they live.' %>" />
+    <% } else { %>
+      <meta name="twitter:description" content="Open source software, built on osquery. With Fleet you can ask important questions about your devices. Whatever operating system, wherever they live." />
+    <% } %>
     <meta name="twitter:image" content="https://fleetdm.com/images/fleet-logo-square@2x.png" />
     <% /* Script tags should normally be included further down the page- but any
     scripts that load fonts (e.g. Fontawesome ≥v5) are special exceptions to the

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -14,7 +14,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="https://fleetdm.com" />
-    <meta name="twitter:title" content="<%= typeof title !== 'undefined' ? title : 'Open source device management' %>" />
+    <meta name="twitter:title" content="<%= typeof title !== 'undefined' ? title : 'Fleet for osquery | Open source device management' %>" />
     <meta name="twitter:description" content="<%= typeof description !== 'undefined' ? description : 'Open source software, built on osquery. With Fleet you can ask important questions about your devices. Whatever operating system, wherever they live.' %>" />
     <meta name="twitter:image" content="https://fleetdm.com/images/fleet-logo-square@2x.png" />
     <% /* Script tags should normally be included further down the page- but any

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -14,7 +14,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="https://fleetdm.com" />
-    <meta name="twitter:title" content="<%= typeof title !== 'undefined' ? title : 'Fleet for osquery | Open source device management' %>" />
+    <meta name="twitter:title" content="<%= typeof title !== 'undefined' ? title : 'Open source device management' %>" />
     <meta name="twitter:description" content="<%= typeof description !== 'undefined' ? description : 'Open source software, built on osquery. With Fleet you can ask important questions about your devices. Whatever operating system, wherever they live.' %>" />
     <meta name="twitter:image" content="https://fleetdm.com/images/fleet-logo-square@2x.png" />
     <% /* Script tags should normally be included further down the page- but any

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -15,11 +15,7 @@
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="https://fleetdm.com" />
     <meta name="twitter:title" content="<%= typeof title !== 'undefined' ? title : 'Open source device management' %>" />
-    <%if(typeof description !== 'undefined') { %>
-      <meta name="twitter:description" content="<%= description !== 'undefined' ? description : 'Open source software, built on osquery. With Fleet you can ask important questions about your devices. Whatever operating system, wherever they live.' %>" />
-    <% } else { %>
-      <meta name="twitter:description" content="Open source software, built on osquery. With Fleet you can ask important questions about your devices. Whatever operating system, wherever they live." />
-    <% } %>
+    <meta name="twitter:description" content="<%= typeof description !== 'undefined' ? description : 'Open source software, built on osquery. With Fleet you can ask important questions about your devices. Whatever operating system, wherever they live.' %>" />
     <meta name="twitter:image" content="https://fleetdm.com/images/fleet-logo-square@2x.png" />
     <% /* Script tags should normally be included further down the page- but any
     scripts that load fonts (e.g. Fontawesome ≥v5) are special exceptions to the


### PR DESCRIPTION
Closes #2020 
Changes:

- Added titles and descriptions to existing pages on fleetdm.com
- Updated the layout to use the new page titles and descriptions if the page has them
- Changed the twitter <meta> tags to use the new page descriptions and titles

# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

- [ ] Changes file added (if needed)
- [ ] Documented any API changes
- [ ] Added tests for all functionality
- [ ] Manual QA for all functionality
