### PR TITLE
Replace user permissions link with newer docs.

### DIFF
--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -303,7 +303,7 @@ class UserForm extends Component<ICreateUserFormProps, ICreateUserFormState> {
               manage or observe all users, entities, and settings in Fleet.
             </p>
             <a
-              href="https://github.com/fleetdm/fleet/blob/e1ba813f0c70289575ed19dc6dfac28b47c617e4/docs/1-Using-Fleet/9-Permissions.md#permissions"
+              href="https://fleetdm.com/docs/using-fleet/permissions#user-permissions"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -360,7 +360,7 @@ class UserForm extends Component<ICreateUserFormProps, ICreateUserFormState> {
             observe team-specific users, entities, and settings in Fleet.
           </p>
           <a
-            href="https://github.com/fleetdm/fleet/blob/e1ba813f0c70289575ed19dc6dfac28b47c617e4/docs/1-Using-Fleet/9-Permissions.md#team-member-permissions"
+            href="https://fleetdm.com/docs/using-fleet/permissions#team-member-permissions"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -303,7 +303,7 @@ class UserForm extends Component<ICreateUserFormProps, ICreateUserFormState> {
               manage or observe all users, entities, and settings in Fleet.
             </p>
             <a
-              href="https://github.com/fleetdm/fleet/blob/2f42c281f98e39a72ab4a5125ecd26d303a16a6b/docs/1-Using-Fleet/9-Permissions.md#permissions"
+              href="https://github.com/fleetdm/fleet/blob/e1ba813f0c70289575ed19dc6dfac28b47c617e4/docs/1-Using-Fleet/9-Permissions.md#permissions"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -360,7 +360,7 @@ class UserForm extends Component<ICreateUserFormProps, ICreateUserFormState> {
             observe team-specific users, entities, and settings in Fleet.
           </p>
           <a
-            href="https://github.com/fleetdm/fleet/blob/2f42c281f98e39a72ab4a5125ecd26d303a16a6b/docs/1-Using-Fleet/9-Permissions.md#team-member-permissions"
+            href="https://github.com/fleetdm/fleet/blob/e1ba813f0c70289575ed19dc6dfac28b47c617e4/docs/1-Using-Fleet/9-Permissions.md#team-member-permissions"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
The docs link in 4.3.0 is for a commit before the tiers were renamed.