### PR TITLE
Fix broken link in markdown compilation

### DIFF
--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -226,7 +226,7 @@ module.exports = {
                 // to some page on the destination site where this will be hosted, like `(*.)?fleetdm.com`.
                 // If external, add target="_blank" so the link will open in a new tab.
                 let isExternal = ! hrefString.match(/^href=\"https?:\/\/([^\.]+\.)*fleetdm\.com/g);// « FUTURE: make this smarter with sails.config.baseUrl + _.escapeRegExp()
-                let isBaseUrl = hrefString.match(/^href=\"https?:\/\/([^\.]+\.)*fleetdm\.com"$/g);// Checking if the link is to the fleetdm.com homepage
+                let isBaseUrl = hrefString.match(/^(href="https?:\/\/)([^\.]+\.)*fleetdm\.com"$/g);// Checking if the link is to the fleetdm.com homepage
                 if (isExternal) {
                   return hrefString.replace(/(href="https?:\/\/([^"]+)")/g, '$1 target="_blank"');
                 } else {

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -226,7 +226,8 @@ module.exports = {
                 // to some page on the destination site where this will be hosted, like `(*.)?fleetdm.com`.
                 // If external, add target="_blank" so the link will open in a new tab.
                 let isExternal = ! hrefString.match(/^href=\"https?:\/\/([^\.]+\.)*fleetdm\.com/g);// « FUTURE: make this smarter with sails.config.baseUrl + _.escapeRegExp()
-                let isBaseUrl = hrefString.match(/^(href="https?:\/\/)([^\.]+\.)*fleetdm\.com"$/g);// Checking if the link is to the fleetdm.com homepage
+                // Check if this link is to fleetdm.com or www.fleetdm.com.
+                let isBaseUrl = hrefString.match(/^(href="https?:\/\/)([^\.]+\.)*fleetdm\.com"$/g);
                 if (isExternal) {
                   return hrefString.replace(/(href="https?:\/\/([^"]+)")/g, '$1 target="_blank"');
                 } else {

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -234,7 +234,7 @@ module.exports = {
                   // (e.g. 'href="http://sailsjs.com/documentation/concepts"'' becomes simply 'href="/documentation/concepts"'')
                   // > Note: See the Git version history of "compile-markdown-content.js" in the sailsjs.com website repo for examples of ways this can work across versioned subdomains.
                   if (isBaseUrl) {
-                    return hrefString.replace(/href="https?:\/\//, '').replace(/^fleetdm\.com/, 'href="/');
+                    return hrefString.replace(/href="https?:\/\//, '').replace(/([^\.]+\.)*fleetdm\.com/, 'href="/');
                   } else {
                     return hrefString.replace(/href="https?:\/\//, '').replace(/^fleetdm\.com/, 'href="');
                   }

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -226,13 +226,18 @@ module.exports = {
                 // to some page on the destination site where this will be hosted, like `(*.)?fleetdm.com`.
                 // If external, add target="_blank" so the link will open in a new tab.
                 let isExternal = ! hrefString.match(/^href=\"https?:\/\/([^\.]+\.)*fleetdm\.com/g);// « FUTURE: make this smarter with sails.config.baseUrl + _.escapeRegExp()
+                let isBaseUrl = hrefString.match(/^href=\"https?:\/\/([^\.]+\.)*fleetdm\.com"$/g);// Checking if the link is to the fleetdm.com homepage
                 if (isExternal) {
                   return hrefString.replace(/(href="https?:\/\/([^"]+)")/g, '$1 target="_blank"');
                 } else {
                   // Otherwise, change the link to be web root relative.
                   // (e.g. 'href="http://sailsjs.com/documentation/concepts"'' becomes simply 'href="/documentation/concepts"'')
                   // > Note: See the Git version history of "compile-markdown-content.js" in the sailsjs.com website repo for examples of ways this can work across versioned subdomains.
-                  return hrefString.replace(/href="https?:\/\//, '').replace(/^fleetdm\.com/, 'href="');
+                  if (isBaseUrl) {
+                    return hrefString.replace(/href="https?:\/\//, '').replace(/^fleetdm\.com/, 'href="/');
+                  } else {
+                    return hrefString.replace(/href="https?:\/\//, '').replace(/^fleetdm\.com/, 'href="');
+                  }
                 }
 
               });//∞


### PR DESCRIPTION
closes #2150

changes:
- added a flag and a new conditional to build-static-content.js - `isBaseUrl`
- If the link being replaced is to fleetdm.com, it is replaced with `href="/"` (currently links going to fleetdm.com are set to `href=""` during markdown compilation)

# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

- [ ] Changes file added (if needed)
- [ ] Documented any API changes
- [ ] Documented any permissions changes
- [ ] Added tests for all functionality
- [ ] Manual QA for all functionality
