### PR TITLE
Add edit page button to the top of documentation pages on fleetdm.com/docs

### DIFF
--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -207,7 +207,7 @@
         opacity: 0;
         font-size: 12px;
         position: absolute;
-        right: 5px;
+        right: 4px;
         top: 8px;
         cursor: pointer;
         border: 1px solid @core-fleet-black-25;

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -199,6 +199,56 @@
       }
 
     }
+    .edit-container {
+      position: relative;
+
+      .edit-button {
+        color: @core-vibrant-blue;
+        opacity: 0;
+        font-size: 12px;
+        position: absolute;
+        right: 15px;
+        top: 8px;
+        cursor: pointer;
+        border: 1px solid @core-fleet-black-25;
+        border-radius: 6px;
+        padding: 4px 8px;
+        text-decoration: none;
+
+        .edit-link {
+          color: @core-vibrant-blue;
+
+        }
+        .edit-pencil {
+          height: 16px;
+          padding-right: 5px;
+        }
+
+      }
+
+      .edit-button:hover {
+
+        background: @ui-off-white;
+
+        a {
+          text-decoration: none;
+        }
+        .edit-link {
+          color: @core-fleet-black;
+
+        }
+      }
+
+    }
+
+    &:hover {
+
+      .edit-button{
+        opacity: 1;
+
+      }
+
+    }
 
     [purpose='search'] {
 

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -207,11 +207,11 @@
         opacity: 0;
         font-size: 12px;
         position: absolute;
-        right: 15px;
+        right: 5px;
         top: 8px;
         cursor: pointer;
         border: 1px solid @core-fleet-black-25;
-        border-radius: 6px;
+        border-radius: 4px;
         padding: 4px 8px;
         text-decoration: none;
 

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -210,7 +210,7 @@
         right: 4px;
         top: 8px;
         cursor: pointer;
-        border: 1px solid @core-fleet-black-25;
+        border: 1px solid @core-vibrant-blue;
         border-radius: 4px;
         padding: 4px 8px;
         text-decoration: none;

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -243,7 +243,7 @@
 
     &:hover {
 
-      .edit-button{
+      .edit-button {
         opacity: 1;
 
       }

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -234,7 +234,7 @@
           text-decoration: none;
         }
         .edit-link {
-          color: @core-fleet-black;
+          color: @accent-white;
 
         }
       }

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -199,7 +199,7 @@
       }
 
     }
-    .edit-container {
+    .edit-button-container {
       position: relative;
 
       .edit-button {

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -228,7 +228,7 @@
 
       .edit-button:hover {
 
-        background: @ui-off-white;
+        background: @core-vibrant-blue;
 
         a {
           text-decoration: none;

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -189,6 +189,13 @@
         </div>
 
         <div purpose="content" id="body-content" class="d-flex flex-column px-lg-5 content" parasails-has-no-page-script>
+
+          <div class="edit-container">
+            <div class="edit-button">
+              <a class="edit-link" :href="'https://github.com/fleetdm/fleet/tree/main/docs/'+thisPage.sectionRelativeRepoPath"><i class="edit-pencil fa fa-pencil"></i>Edit page</a>
+            </div>
+          </div>
+
           <%- partial(
             path.relative(
               path.dirname(__filename), 

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -190,7 +190,7 @@
 
         <div purpose="content" id="body-content" class="d-flex flex-column px-lg-5 content" parasails-has-no-page-script>
 
-          <div class="edit-container">
+          <div class="edit-button-container">
             <div class="edit-button">
               <a class="edit-link" :href="'https://github.com/fleetdm/fleet/tree/main/docs/'+thisPage.sectionRelativeRepoPath"><i class="edit-pencil fa fa-pencil"></i>Edit page</a>
             </div>


### PR DESCRIPTION
closes #2122 
Changes: 
- added an "Edit page" button( that appears when hovering over the page) to the top of documentation pages that takes you to the file on Github

# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

- [ ] Changes file added (if needed)
- [ ] Documented any API changes
- [ ] Documented any permissions changes
- [ ] Added tests for all functionality
- [x] Manual QA for all functionality
