### PR TITLE
Fix <ul> not showing up in documentation

### DIFF
--- a/website/api/helpers/strings/to-html.js
+++ b/website/api/helpers/strings/to-html.js
@@ -77,7 +77,7 @@ module.exports = {
       var headingRenderer = new marked.Renderer();
       headingRenderer.heading = function (text, level) {
         var headingID = _.kebabCase(text);
-        return '<span class="docs-heading"><h'+level+' id="'+headingID+'">'+text+'<a href="#'+headingID+'" class="docs-link"></a></h'+level+'></span>';
+        return '<h'+level+' class="markdown-heading" id="'+headingID+'">'+text+'<a href="#'+headingID+'" class="markdown-link"></a></h'+level+'>\n';
       };
       markedOpts.renderer = headingRenderer;
     } else  {

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -38,9 +38,9 @@
     }
 
   }
-  .docs-heading:hover {
+  .markdown-heading:hover {
 
-    .docs-link {
+    .markdown-link {
       height: 16px;
       vertical-align: middle;
       margin-left: 8px;
@@ -352,7 +352,7 @@
         padding-bottom: 24px;
       }
 
-      span + ul {
+      h1 + ul {
         display: none; // Hides links at top of some markdown files
       }
 


### PR DESCRIPTION
closes #2164 

Changes:
- updated heading renderer to get rid of the <span> around it, so we can make sure we're only hiding the `<ul>` of all the sections on the page with a `h1 + ul` rule instead of `span + ul`
- updated class names (e.g. docs-link -> markdown-link)

# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

- [ ] Changes file added (if needed)
- [ ] Documented any API changes
- [ ] Documented any permissions changes
- [ ] Added tests for all functionality
- [x] Manual QA for all functionality
