### PR TITLE
Add --tag flag to fleetctl preview 

### DIFF
--- a/changes/preview-tag
+++ b/changes/preview-tag
@@ -1,0 +1,1 @@
+* Allow specifying Fleet version in `fleetctl preview` with `--tag` flag.

--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	downloadUrl             = "https://github.com/fleetdm/osquery-in-a-box/archive/master.zip"
-	standardQueryLibraryUrl = "https://raw.githubusercontent.com/fleetdm/fleet/main/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml"
+	standardQueryLibraryUrl = "https://raw.githubusercontent.com/fleetdm/fleet/main/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml"
 	licenseKeyFlagName      = "license-key"
 	tagFlagName             = "tag"
 )
@@ -76,6 +76,10 @@ Use the stop and reset subcommands to manage the server and dependencies once st
 			// Linux with a non-root user inside the container.
 			if err := os.Chmod(filepath.Join(previewDir, "logs"), 0777); err != nil {
 				return errors.Wrap(err, "make logs writable")
+			}
+
+			if err := os.Setenv("FLEET_VERSION", c.String(tagFlagName)); err != nil {
+				return errors.Wrap(err, "failed to set Fleet version")
 			}
 
 			fmt.Println("Pulling Docker dependencies...")

--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -24,6 +24,7 @@ const (
 	downloadUrl             = "https://github.com/fleetdm/osquery-in-a-box/archive/master.zip"
 	standardQueryLibraryUrl = "https://raw.githubusercontent.com/fleetdm/fleet/main/docs/1-Using-Fleet/standard-query-library/standard-query-library.yml"
 	licenseKeyFlagName      = "license-key"
+	tagFlagName             = "tag"
 )
 
 func previewCommand() *cli.Command {
@@ -44,6 +45,11 @@ Use the stop and reset subcommands to manage the server and dependencies once st
 			&cli.StringFlag{
 				Name:  licenseKeyFlagName,
 				Usage: "License key to enable Fleet Premium (optional)",
+			},
+			&cli.StringFlag{
+				Name:  tagFlagName,
+				Usage: "Run a specific version of Fleet",
+				Value: "latest",
 			},
 		},
 		Action: func(c *cli.Context) error {


### PR DESCRIPTION
Allows specifying a version of the Fleet image to run. Also fix standard query library URL.

# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

- [x] Changes file added (if needed)
- [x] Manual QA for all functionality
