### PR TITLE
Improve examples and API documentation for managing teams with `fleetctl`

### DIFF
--- a/docs/01-Using-Fleet/03-REST-API.md
+++ b/docs/01-Using-Fleet/03-REST-API.md
@@ -6068,11 +6068,11 @@ _Available in Fleet Premium_
 
 ### Apply team spec
 
+_Available in Fleet Premium_
+
 If the `name` specified is associated with an existing team, this API route, completely replaces this team's existing `agent_options` and `secrets` with those that are specified.
 
 If the `name` is not already associated with an existing team, this API route creates a new team with the specified `name`, `agent_options`, and `secrets`.
-
-_Available in Fleet Premium_
 
 `POST /api/v1/fleet/spec/teams`
 

--- a/docs/01-Using-Fleet/03-REST-API.md
+++ b/docs/01-Using-Fleet/03-REST-API.md
@@ -6066,6 +6066,74 @@ _Available in Fleet Premium_
 
 `Status: 200`
 
+### Apply team spec
+
+If the `name` specified is associated with an existing team, this API route, completely replaces this team's existing `agent_options` and `secrets` with those that are specified.
+
+If the `name` is not already associated with an existing team, this API route creates a new team with the specified `name`, `agent_options`, and `secrets`.
+
+_Available in Fleet Premium_
+
+`POST /api/v1/fleet/spec/teams`
+
+#### Parameters
+
+| Name | Type   | In   | Description                    |
+| ---- | ------ | ---- | ------------------------------ |
+| name | string | body | **Required.** The team's name. |
+| agent_options | string | body | **Required.** The agent options spec that is applied to the hosts assigned to the specified to team. These agent agent options completely override the global agent options specified in the [`GET /api/v1/fleet/config API route`](#get-configuration)|
+| secrets | list | body | **Required.** A list of plain text strings used as the enroll secrets. |
+
+#### Example
+
+`POST /api/v1/fleet/spec/teams`
+
+##### Request body
+
+```json
+{
+  "specs": [
+    {
+      "name": "Client Platform Engineering",
+      "agent_options": {
+        "spec": {
+          "config": {
+            "options": {
+              "logger_plugin": "tls",
+              "pack_delimiter": "/",
+              "logger_tls_period": 10,
+              "distributed_plugin": "tls",
+              "disable_distributed": false,
+              "logger_tls_endpoint": "/api/v1/osquery/log",
+              "distributed_interval": 10,
+              "distributed_tls_max_attempts": 3
+            },
+            "decorators": {
+              "load": [
+                "SELECT uuid AS host_uuid FROM system_info;",
+                "SELECT hostname AS hostname FROM system_info;"
+              ]
+            }
+          },
+          "overrides": {}
+        }
+      },
+      "secrets": [
+        {
+         "secret": "fTp52/twaxBU6gIi0J6PHp8o5Sm1k1kn",
+        },
+        {
+          "secret": "bhD5kiX2J+KBgZSk118qO61ZIdX/v8On",
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### Default response
+
+`Status: 200`
 
 ---
 

--- a/docs/01-Using-Fleet/configuration-files/multi-file-configuration/team.yml
+++ b/docs/01-Using-Fleet/configuration-files/multi-file-configuration/team.yml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: team
+spec:
+  team:
+    name: Client Platform Engineerin
+    agent_options:
+      config:
+        decorators:
+          load:
+            - SELECT uuid AS host_uuid FROM system_info;
+            - SELECT hostname AS hostname FROM system_info;
+        options:
+          disable_distributed: false
+          distributed_interval: 10
+          distributed_plugin: tls
+          distributed_tls_max_attempts: 3
+          logger_plugin: tls
+          logger_tls_endpoint: /api/v1/osquery/log
+          logger_tls_period: 10
+          pack_delimiter: /
+      overrides: {}
+    secrets:
+      - secret: RzTlxPvugG4o4O5IKS/HqEDJUmI1hwBoffff


### PR DESCRIPTION
- Add example `team.yml` configuration file. A file with this format can be used to apply teams using `fleetctl apply`
- Add `spec/teams` API route to API docs

# Checklist for submitter

If some of the following don't apply, please write a short explanation why.

**Changes only affect documentation.**

- [ ] Changes file added (if needed)
- [ ] Documented any API changes
- [ ] Documented any permissions changes
- [ ] Added tests for all functionality
- [ ] Manual QA for all functionality
