### PR TITLE
Fix Bug: Global maintainer can now edit SQL in create new query

### DIFF
--- a/changes/issue-2201-global-maintainer-create-query
+++ b/changes/issue-2201-global-maintainer-create-query
@@ -1,0 +1,1 @@
+- Bug fix: Global maintainer can create and save a new query

--- a/frontend/components/forms/queries/QueryForm/QueryForm.tsx
+++ b/frontend/components/forms/queries/QueryForm/QueryForm.tsx
@@ -434,7 +434,7 @@ const QueryForm = ({
     });
   }
 
-  if (isAnyTeamMaintainer || isGlobalMaintainer) {
+  if (isAnyTeamMaintainer) {
     return renderRunForMaintainer({ nameText, descText, queryValue });
   }
 


### PR DESCRIPTION
- Fixed logic that had global maintainers treated like team maintainers which produced an edit bug (default return in line 441   was already aptly named `renderForGlobalAdminOrMaintainer`)

Closes #2201 

NOTE: Team maintainer access to creating queries is being revamped shortly. This PR only unblocks a customer issue where global maintainers could not create a new query

TODO: We pushed an entire query experience with various RBAC and 0 e2e tests. Need functioning e2e tests to help avoid releasing bugs like this.

@noahtalerman added you as a reviewer since this is a pushed bug a customer found. Feel free to merge when needed.
https://www.loom.com/share/280808f671c44caaab99e143bc02fa4e