### PR TITLE
Fix non-unique key warnings on user table

### DIFF
--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.jsx
@@ -493,7 +493,7 @@ export class HostDetailsPage extends Component {
                   {users.map((hostUser) => {
                     return (
                       <HostUsersListRow
-                        key={`host-users-row-${hostUser.id}`}
+                        key={`host-users-row-${hostUser.username}`}
                         hostUser={hostUser}
                       />
                     );


### PR DESCRIPTION
Closes #2222

Note: Submitted checklist has been omitted. This is a one-line bug fix to console warnings so checklist is largely inapplicable.
