### PR TITLE
reduce Slack notifications by limiting activity from maintainers

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -25,8 +25,23 @@ module.exports = {
     let GitHub = require('machinepack-github');
 
     let GREEN_LABEL_COLOR = 'C2E0C6';// « Used in multiple places below.
-    let GITHUB_USERNAMES_OF_BOTS = [// « Used in multiple places below.
-      'sailsbot'
+    let GITHUB_USERNAMES_OF_BOTS = [// « Used in multiple places below.  (actually, some maintainers too, not just bots)
+      'sailsbot',
+      'noahtalerman',
+      'mike-j-thomas',
+      'mikermcneil',
+      'lukeheath',
+      'zwass',
+      'rlynnj11',
+      'martavis',
+      'rachelelysia',
+      'gillespi314',
+      'chiiph',
+      'mna',
+      'edwardsb',
+      'alphabrevity',
+      'eashaw',
+      'drewbakerfdm'
     ];
     let GITHUB_USERNAME_OF_DRI_FOR_LABELS = 'noahtalerman';// « Used below
 

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -25,8 +25,9 @@ module.exports = {
     let GitHub = require('machinepack-github');
 
     let GREEN_LABEL_COLOR = 'C2E0C6';// « Used in multiple places below.
-    let GITHUB_USERNAMES_OF_BOTS = [// « Used in multiple places below.  (actually, some maintainers too, not just bots)
+    let GITHUB_USERNAMES_OF_BOTS_AND_MAINTAINERS = [// « Used in multiple places below.
       'sailsbot',
+      'fleet-release',
       'noahtalerman',
       'mike-j-thomas',
       'mikermcneil',
@@ -109,7 +110,7 @@ module.exports = {
       //     `For help with questions about Sails, [click here](http://sailsjs.com/support).\n`;
       //   }
       // } else {
-      //   let wasReopenedByBot = GITHUB_USERNAMES_OF_BOTS.includes(sender.login);
+      //   let wasReopenedByBot = GITHUB_USERNAMES_OF_BOTS_AND_MAINTAINERS.includes(sender.login);
       //   if (wasReopenedByBot) {
       //     newBotComment = '';// « checked below
       //   } else {
@@ -161,7 +162,7 @@ module.exports = {
       // if (action === 'edited' && pr.state !== 'open') {
       //   // If this is an edit to an already-closed pull request, then do nothing.
       // } else if (action === 'reopened') {
-      //   let wasReopenedByBot = GITHUB_USERNAMES_OF_BOTS.includes(sender.login);
+      //   let wasReopenedByBot = GITHUB_USERNAMES_OF_BOTS_AND_MAINTAINERS.includes(sender.login);
       //   if (!wasReopenedByBot) {
       //     let newBotComment =
       //     `Oh hey again, @${issueOrPr.user.login}.  Now that this pull request is reopened, it's on our radar.  Please let us know if there's any new information we should be aware of!\n`+
@@ -224,7 +225,7 @@ module.exports = {
       let repo = repository.name;
       let issueNumber = issueOrPr.number;
 
-      let wasPostedByBot = GITHUB_USERNAMES_OF_BOTS.includes(sender.login);
+      let wasPostedByBot = GITHUB_USERNAMES_OF_BOTS_AND_MAINTAINERS.includes(sender.login);
       if (!wasPostedByBot) {
         let greenLabels = _.filter(issueOrPr.labels, ({color}) => color === GREEN_LABEL_COLOR);
         await sails.helpers.flow.simultaneouslyForEach(greenLabels, async(greenLabel)=>{
@@ -232,7 +233,7 @@ module.exports = {
         });//∞ß
       }//ﬁ
     } else if (
-      (ghNoun === 'issue_comment' && ['deleted'].includes(action) && !GITHUB_USERNAMES_OF_BOTS.includes(comment.user.login))||
+      (ghNoun === 'issue_comment' && ['deleted'].includes(action) && !GITHUB_USERNAMES_OF_BOTS_AND_MAINTAINERS.includes(comment.user.login))||
       (ghNoun === 'commit_comment' && ['created'].includes(action))||
       (ghNoun === 'label' && ['created','edited','deleted'].includes(action) && GITHUB_USERNAME_OF_DRI_FOR_LABELS !== sender.login)||//« exempt label changes made by the directly responsible individual for labels, because otherwise when process changes/fiddlings happen, they can otherwise end up making too much noise in Slack
       (ghNoun === 'issue_comment' && ['created'].includes(action) && issueOrPr.state !== 'open' && (issueOrPr.closed_at) && ((new Date(issueOrPr.closed_at)).getTime() < Date.now() - 7*24*60*60*1000 ) )


### PR DESCRIPTION
The purpose of deleted comment monitoring is to watch out for abuse / violations of our contributor code of conduct.  (Which has, I think, never even been a problem with this awesome community so far!  But we care about making Fleet a nice, happy place.)

But in the course of everyday project management, we move a lot of issues around.  This change reduces noise in Slack by focusing deleted comment monitoring on comments that were originally contributed by folks outside of the Fleet core team.