### PR TITLE
Handbook style fix

### DIFF
--- a/website/assets/styles/bootstrap-overrides.less
+++ b/website/assets/styles/bootstrap-overrides.less
@@ -43,7 +43,6 @@ h2 {
 }
 
 p {
-  font-size: 16px;
   line-height: 24px;
 }
 

--- a/website/assets/styles/pages/handbook/basic-handbook.less
+++ b/website/assets/styles/pages/handbook/basic-handbook.less
@@ -190,7 +190,6 @@
     }
     p {
       font-family: @header-font;
-      font-size: 14px;
     }
     ul {
       list-style-type: disc;

--- a/website/views/pages/handbook/basic-handbook.ejs
+++ b/website/views/pages/handbook/basic-handbook.ejs
@@ -1,5 +1,5 @@
 <div id="basic-handbook" v-cloak>
-  <div purpose="handbook-template" style="max-width: 1200px;" class="container-fluid p-0 px-lg-3 mb-5">
+  <div purpose="handbook-template" style="max-width: 1000px;" class="container-fluid p-0 px-lg-3 mb-5">
     <div class="d-flex flex-column flex-md-row pt-lg-4 pb-lg-4 m-0">
       <div purpose="mobile-breadcrumbs-container" class="d-flex justify-content-lg-between p-0 pt-4 pb-lg-2 m-0">
         <div purpose="mobile-breadcrumbs" class="d-block d-md-none">


### PR DESCRIPTION
- Reduced handbook template max-width to 1000px to bring inline with Figma. (The extra 200px forces the text content a little too wide, introducing reading fatigue.)

- Reverted paragraph font size back to default 16px, and also removed the bootstrap override to avoid duplicate declarations.

Thank you @eashaw for humoring me with the font-size change. I realize now that it's not the size, but the actual font that is throwing me off. Looks like there is a discrepancy between how Figma and the browser are rendering Nunito (specifically the curly tails on the 'l'). I will track this separately for later.

FYI, it was quicker for me to action these changes myself than track them and assign to you 😘

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
