### PR TITLE
H5 >> H4 heading fix

### DIFF
--- a/handbook/product.md
+++ b/handbook/product.md
@@ -1,7 +1,7 @@
 
 ## Fleet EE
 
-##### Communicating design changes to Engineering
+#### Communicating design changes to Engineering
 For something NEW that has been added to [Figma Fleet EE (current, dev-ready)](https://www.figma.com/file/qpdty1e2n22uZntKUZKEJl/?node-id=0%3A1):
 1. Create a new [GitHub issue](https://github.com/fleetdm/fleet/issues/new)
 2. Detail the required changes (including page links to the relevant layouts), then assign it to the __“Initiatives”__ project.
@@ -16,7 +16,7 @@ For something NEW that has been added to [Figma Fleet EE (current, dev-ready)](h
 
 <img src="https://user-images.githubusercontent.com/78363703/129840735-3b270429-a92a-476d-87b4-86b93057b2dd.png" alt="Inspire me"/>
 
-##### Communicating unplanned design changes
+#### Communicating unplanned design changes
 
 For issues related to something that was ALREADY in Figma Fleet EE (current, dev-ready), but __implemented differently__, e.g, padding/spacing inconsistency etc. Create a [bug issue](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=bug%2C%3Areproduce&template=bug-report.md&title=) and detail the required changes.
 


### PR DESCRIPTION
Changed the H5 headings under Fleet EE to H4 to match.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
