### PR TITLE
Team maintainer does not request enroll secret

### DIFF
--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -34,6 +34,7 @@ const App = ({ children }: IAppProps) => {
     currentUser,
     isGlobalObserver,
     isOnlyObserver,
+    isAnyTeamMaintainer,
   } = useContext(AppContext);
 
   useDeepEffect(() => {
@@ -56,7 +57,9 @@ const App = ({ children }: IAppProps) => {
       typeof isGlobalObserver !== "undefined" &&
       !isGlobalObserver &&
       typeof isOnlyObserver !== "undefined" &&
-      !isOnlyObserver;
+      !isOnlyObserver &&
+      typeof isAnyTeamMaintainer !== "undefined" &&
+      !isAnyTeamMaintainer;
 
     if (canGetEnrollSecret) {
       dispatch(getEnrollSecret()).catch(() => false);


### PR DESCRIPTION
- Changes permissions for the global enroll secret API to not include team maintainer
- Note: This request is needed to populate enroll secret in current UI

Cerra #2231 
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
