### PR TITLE
Delete Query UX:  Better error handling if query is a part of policies

### DIFF
--- a/changes/issue-2059-delete-query-in-policy-ux
+++ b/changes/issue-2059-delete-query-in-policy-ux
@@ -1,0 +1,1 @@
+* Better error handling when a user tries to delete a query that is set in a policy

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -108,13 +108,26 @@ const ManageQueriesPage = (): JSX.Element => {
         toggleRemoveQueryModal();
         dispatch(queryActions.loadAll());
       })
-      .catch(() => {
-        dispatch(
-          renderFlash(
-            "error",
-            `Unable to remove ${queryOrQueries}. Please try again.`
-          )
-        );
+      .catch((response) => {
+        if (
+          response.base.slice(0, 47) ===
+          "the operation violates a foreign key constraint"
+        ) {
+          dispatch(
+            renderFlash(
+              "error",
+              `Could not delete query because this query is used as a policy. First remove the policy and then try deleting the query again.`
+            )
+          );
+          dispatch(queryActions.loadAll());
+        } else {
+          dispatch(
+            renderFlash(
+              "error",
+              `Unable to remove ${queryOrQueries}. Please try again.`
+            )
+          );
+        }
         toggleRemoveQueryModal();
       });
   }, [dispatch, selectedQueryIds, toggleRemoveQueryModal]);


### PR DESCRIPTION
- New flash error message if trying to delete a query that is a part of a policy
- Replaces error table rendering with the reloaded query table

Note: I don't feel like specific error handling is worth added to an e2e test so I did not add it. @rlynnj11 

Cerra #2059 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality

<img width="1518" alt="Screen Shot 2021-09-29 at 10 24 12 AM" src="https://user-images.githubusercontent.com/71795832/135288314-9496de82-b829-4060-a27c-fc3375640c58.png">


