### PR TITLE
Manage Host Page: Delete multiple hosts

### DIFF
--- a/changes/issue-1840-bulk-delete-hosts
+++ b/changes/issue-1840-bulk-delete-hosts
@@ -1,1 +1,2 @@
 * Add a mechanism to bulk delete hosts based on different criteria.
+* Ability to bulk delete hosts in the UI.

--- a/frontend/components/TableContainer/DataTable/ActionButton/ActionButton.tsx
+++ b/frontend/components/TableContainer/DataTable/ActionButton/ActionButton.tsx
@@ -9,6 +9,7 @@ import CloseIcon from "../../../../../assets/images/icon-close-vibrant-blue-16x1
 import DeleteIcon from "../../../../../assets/images/icon-delete-vibrant-blue-12x14@2x.png";
 import CheckIcon from "../../../../../assets/images/icon-action-check-16x15@2x.png";
 import DisableIcon from "../../../../../assets/images/icon-action-disable-14x14@2x.png";
+import TransferIcon from "../../../../../assets/images/icon-action-transfer-16x16@2x.png";
 
 const baseClass = "action-button";
 export interface IActionButtonProps {
@@ -59,6 +60,8 @@ const ActionButton = (buttonProps: IActionButtonProps): JSX.Element | null => {
         return CheckIcon;
       case "disable":
         return DisableIcon;
+      case "transfer":
+        return TransferIcon;
       default:
         return null;
     }

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -176,7 +176,11 @@ const DataTable = ({
   const renderSelectedCount = (): JSX.Element => {
     return (
       <p>
-        <span>{selectedFlatRows.length}</span> selected
+        <span>
+          {selectedFlatRows.length}
+          {isAllPagesSelected && "+"}
+        </span>{" "}
+        selected
       </p>
     );
   };

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -177,8 +177,7 @@ const DataTable = ({
     return (
       <p>
         <span>
-          {selectedFlatRows.length}
-          {isAllPagesSelected && "+"}
+          {isAllPagesSelected ? "All matching" : selectedFlatRows.length}
         </span>{" "}
         selected
       </p>

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -177,7 +177,8 @@ const DataTable = ({
     return (
       <p>
         <span>
-          {isAllPagesSelected ? "All matching" : selectedFlatRows.length}
+          {selectedFlatRows.length}
+          {isAllPagesSelected && "+"}
         </span>{" "}
         selected
       </p>

--- a/frontend/fleet/endpoints.ts
+++ b/frontend/fleet/endpoints.ts
@@ -17,6 +17,7 @@ export default {
   ACTIVITIES: "/v1/fleet/activities",
   GLOBAL_SCHEDULE: "/v1/fleet/global/schedule",
   HOSTS: "/v1/fleet/hosts",
+  HOSTS_DELETE: "/v1/fleet/hosts/delete",
   HOSTS_TRANSFER: "/v1/fleet/hosts/transfer",
   HOSTS_TRANSFER_BY_FILTER: "/v1/fleet/hosts/transfer/filter",
   INVITES: "/v1/fleet/invites",

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -288,16 +288,24 @@ const generateAvailableTableHeaders = (
 ): IHostDataColumn[] => {
   return allHostTableHeaders.reduce(
     (columns: IHostDataColumn[], currentColumn: IHostDataColumn) => {
-      // skip over column headers that are not shown in free tier
-      if (permissionUtils.isFreeTier(config)) {
+      // skip over column headers that are not shown in free observer tier
+      if (
+        permissionUtils.isFreeTier(config) &&
+        permissionUtils.isGlobalObserver(currentUser)
+      ) {
         if (
           currentColumn.accessor === "team_name" ||
           currentColumn.id === "selection"
         ) {
           return columns;
         }
-        // In base tier, we want to check user role to enable/disable select column
+        // skip over column headers that are not shown in free admin/maintainer
+      } else if (permissionUtils.isFreeTier(config)) {
+        if (currentColumn.accessor === "team_name") {
+          return columns;
+        }
       } else if (
+        // In premium tier, we want to check user role to enable/disable select column
         !permissionUtils.isGlobalAdmin(currentUser) &&
         !permissionUtils.isGlobalMaintainer(currentUser)
       ) {

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -733,11 +733,6 @@ const ManageHostsPage = ({
         labelId = selectedLabel?.id as number;
       }
 
-      console.log(teamId);
-      console.log(searchQuery);
-      console.log(status);
-      console.log(labelId);
-      debugger;
       action = hostsAPI.destroyByFilter(teamId, searchQuery, status, labelId);
     }
 

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -924,7 +924,7 @@ const ManageHostsPage = ({
     );
   };
 
-  const renderDeleteHostModal = (isAllMatchingHostsSelected: boolean) => {
+  const renderDeleteHostModal = () => {
     if (!showDeleteHostModal) {
       return null;
     }
@@ -1176,7 +1176,7 @@ const ManageHostsPage = ({
       {renderEditColumnsModal()}
       {renderDeleteLabelModal()}
       {renderTransferHostModal()}
-      {renderDeleteHostModal(isAllMatchingHostsSelected)}
+      {renderDeleteHostModal()}
     </div>
   );
 };

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -719,7 +719,27 @@ const ManageHostsPage = ({
   };
 
   const onDeleteHostSubmit = async () => {
-    const action = hostsAPI.destroyBulk(selectedHostIds);
+    let action = hostsAPI.destroyBulk(selectedHostIds);
+
+    if (isAllMatchingHostsSelected) {
+      let status = "";
+      let labelId = null;
+      let teamId = currentTeam?.id || null;
+      const selectedStatus = getStatusSelected();
+
+      if (selectedStatus && isAcceptableStatus(selectedStatus)) {
+        status = getStatusSelected() || "";
+      } else {
+        labelId = selectedLabel?.id as number;
+      }
+
+      console.log(teamId);
+      console.log(searchQuery);
+      console.log(status);
+      console.log(labelId);
+      debugger;
+      action = hostsAPI.destroyByFilter(teamId, searchQuery, status, labelId);
+    }
 
     try {
       await action;

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -71,8 +71,6 @@ import EditColumnsIcon from "../../../../assets/images/icon-edit-columns-16x16@2
 import PencilIcon from "../../../../assets/images/icon-pencil-14x14@2x.png";
 import TrashIcon from "../../../../assets/images/icon-trash-14x14@2x.png";
 import CloseIcon from "../../../../assets/images/icon-close-fleet-black-16x16@2x.png";
-import TransferIcon from "../../../../assets/images/icon-action-transfer-16x16@2x.png";
-
 interface IManageHostsProps {
   route: RouteProps;
   router: InjectedRouter;

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1097,6 +1097,7 @@ const ManageHostsPage = ({
         buttonText: "Transfer",
         variant: "text-icon",
         icon: "transfer",
+        hideButton: !isPremiumTier,
       },
     ];
 

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -71,6 +71,7 @@ import EditColumnsIcon from "../../../../assets/images/icon-edit-columns-16x16@2
 import PencilIcon from "../../../../assets/images/icon-pencil-14x14@2x.png";
 import TrashIcon from "../../../../assets/images/icon-trash-14x14@2x.png";
 import CloseIcon from "../../../../assets/images/icon-close-fleet-black-16x16@2x.png";
+
 interface IManageHostsProps {
   route: RouteProps;
   router: InjectedRouter;

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -752,7 +752,7 @@ const ManageHostsPage = ({
         policyId,
         policyResponse,
       });
-
+      refetchLabels();
       toggleDeleteHostModal();
       setSelectedHostIds([]);
       setIsAllMatchingHostsSelected(false);

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -724,7 +724,7 @@ const ManageHostsPage = ({
     if (isAllMatchingHostsSelected) {
       let status = "";
       let labelId = null;
-      let teamId = currentTeam?.id || null;
+      const teamId = currentTeam?.id || null;
       const selectedStatus = getStatusSelected();
 
       if (selectedStatus && isAcceptableStatus(selectedStatus)) {

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -924,7 +924,7 @@ const ManageHostsPage = ({
     );
   };
 
-  const renderDeleteHostModal = () => {
+  const renderDeleteHostModal = (isAllMatchingHostsSelected: boolean) => {
     if (!showDeleteHostModal) {
       return null;
     }
@@ -934,6 +934,7 @@ const ManageHostsPage = ({
         selectedHostIds={selectedHostIds}
         onSubmit={onDeleteHostSubmit}
         onCancel={toggleDeleteHostModal}
+        isAllMatchingHostsSelected={isAllMatchingHostsSelected}
       />
     );
   };
@@ -1175,7 +1176,7 @@ const ManageHostsPage = ({
       {renderEditColumnsModal()}
       {renderDeleteLabelModal()}
       {renderTransferHostModal()}
-      {renderDeleteHostModal()}
+      {renderDeleteHostModal(isAllMatchingHostsSelected)}
     </div>
   );
 };

--- a/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/DeleteHostModal.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/DeleteHostModal.tsx
@@ -11,9 +11,11 @@ interface IDeleteHostModalProps {
   onCancel: () => void;
 }
 
-const DeleteHostModal = (props: IDeleteHostModalProps): JSX.Element => {
-  const { selectedHostIds, onSubmit, onCancel } = props;
-
+const DeleteHostModal = ({
+  selectedHostIds,
+  onSubmit,
+  onCancel,
+}: IDeleteHostModalProps): JSX.Element => {
   return (
     <Modal title={"Delete host"} onExit={onCancel} className={baseClass}>
       <form className={`${baseClass}__form`}>

--- a/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/DeleteHostModal.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/DeleteHostModal.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+import Modal from "components/modals/Modal";
+import Button from "components/buttons/Button";
+
+const baseClass = "delete-host-modal";
+
+interface IDeleteHostModalProps {
+  selectedHostIds: number[];
+  onSubmit: () => void;
+  onCancel: () => void;
+}
+
+const DeleteHostModal = (props: IDeleteHostModalProps): JSX.Element => {
+  const { selectedHostIds, onSubmit, onCancel } = props;
+
+  return (
+    <Modal title={"Delete host"} onExit={onCancel} className={baseClass}>
+      <form className={`${baseClass}__form`}>
+        <p>
+          This action will delete{" "}
+          <b>
+            {selectedHostIds.length}{" "}
+            {selectedHostIds.length === 1 ? "host" : "hosts"}
+          </b>{" "}
+          from your Fleet instance.
+        </p>
+        <p>If the hosts come back online, they will automatically re-enroll.</p>
+        <p>
+          To prevent re-enrollment, you can disable or uninstall osquery on
+          these hosts.
+        </p>
+        <div className={`${baseClass}__btn-wrap`}>
+          <Button
+            className={`${baseClass}__btn`}
+            type="button"
+            onClick={onSubmit}
+            variant="alert"
+          >
+            Delete
+          </Button>
+          <Button
+            className={`${baseClass}__btn`}
+            onClick={onCancel}
+            variant="inverse-alert"
+          >
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default DeleteHostModal;

--- a/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/DeleteHostModal.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/DeleteHostModal.tsx
@@ -24,8 +24,9 @@ const DeleteHostModal = ({
         <p>
           This action will delete{" "}
           <b>
-            {selectedHostIds.length}
-            {isAllMatchingHostsSelected && "+"}{" "}
+            {isAllMatchingHostsSelected
+              ? "all matching"
+              : selectedHostIds.length}{" "}
             {selectedHostIds.length === 1 ? "host" : "hosts"}
           </b>{" "}
           from your Fleet instance.

--- a/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/DeleteHostModal.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/DeleteHostModal.tsx
@@ -9,12 +9,14 @@ interface IDeleteHostModalProps {
   selectedHostIds: number[];
   onSubmit: () => void;
   onCancel: () => void;
+  isAllMatchingHostsSelected: boolean;
 }
 
 const DeleteHostModal = ({
   selectedHostIds,
   onSubmit,
   onCancel,
+  isAllMatchingHostsSelected,
 }: IDeleteHostModalProps): JSX.Element => {
   return (
     <Modal title={"Delete host"} onExit={onCancel} className={baseClass}>
@@ -22,7 +24,8 @@ const DeleteHostModal = ({
         <p>
           This action will delete{" "}
           <b>
-            {selectedHostIds.length}{" "}
+            {selectedHostIds.length}
+            {isAllMatchingHostsSelected && "+"}{" "}
             {selectedHostIds.length === 1 ? "host" : "hosts"}
           </b>{" "}
           from your Fleet instance.

--- a/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/DeleteHostModal.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/DeleteHostModal.tsx
@@ -24,9 +24,8 @@ const DeleteHostModal = ({
         <p>
           This action will delete{" "}
           <b>
-            {isAllMatchingHostsSelected
-              ? "all matching"
-              : selectedHostIds.length}{" "}
+            {selectedHostIds.length}
+            {isAllMatchingHostsSelected && "+"}{" "}
             {selectedHostIds.length === 1 ? "host" : "hosts"}
           </b>{" "}
           from your Fleet instance.

--- a/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/_styles.scss
@@ -1,0 +1,44 @@
+.delete-host-modal {
+  &__btn-wrap {
+    display: flex;
+    flex-direction: row-reverse;
+    margin-top: $pad-xxlarge;
+  }
+
+  &__btn {
+    margin-left: 12px;
+  }
+
+  &__team-link {
+    color: $core-vibrant-blue;
+    font-size: $x-small;
+    font-weight: $bold;
+    text-decoration: none;
+  }
+
+  .Select {
+    .Select-control {
+      cursor: pointer;
+
+      &:hover .Select-placeholder {
+        color: $core-vibrant-blue;
+      }
+    }
+
+    .Select-arrow {
+      margin-top: 7px;
+    }
+
+    &:not(.is-open) {
+      .Select-control:hover .Select-arrow {
+        content: url("../assets/images/icon-chevron-blue-16x16@2x.png");
+      }
+    }
+
+    &.is-open {
+      .Select-control .Select-placeholder {
+        color: $core-vibrant-blue;
+      }
+    }
+  }
+}

--- a/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/_styles.scss
@@ -8,37 +8,4 @@
   &__btn {
     margin-left: 12px;
   }
-
-  &__team-link {
-    color: $core-vibrant-blue;
-    font-size: $x-small;
-    font-weight: $bold;
-    text-decoration: none;
-  }
-
-  .Select {
-    .Select-control {
-      cursor: pointer;
-
-      &:hover .Select-placeholder {
-        color: $core-vibrant-blue;
-      }
-    }
-
-    .Select-arrow {
-      margin-top: 7px;
-    }
-
-    &:not(.is-open) {
-      .Select-control:hover .Select-arrow {
-        content: url("../assets/images/icon-chevron-blue-16x16@2x.png");
-      }
-    }
-
-    &.is-open {
-      .Select-control .Select-placeholder {
-        color: $core-vibrant-blue;
-      }
-    }
-  }
 }

--- a/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/index.ts
+++ b/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeleteHostModal";

--- a/frontend/pages/hosts/ManageHostsPage/components/TransferHostModal/TransferHostModal.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/TransferHostModal/TransferHostModal.tsx
@@ -26,9 +26,12 @@ const NO_TEAM_OPTION = {
   label: "No team",
 };
 
-const TransferHostModal = (props: ITransferHostModal): JSX.Element => {
-  const { onCancel, onSubmit, teams, isGlobalAdmin } = props;
-
+const TransferHostModal = ({
+  onCancel,
+  onSubmit,
+  teams,
+  isGlobalAdmin,
+}: ITransferHostModal): JSX.Element => {
   const [selectedTeam, setSelectedTeam] = useState<ITeam | INoTeamOption>();
 
   const onChangeSelectTeam = useCallback(

--- a/frontend/pages/packs/ManagePacksPage/components/PacksListWrapper/PacksListWrapper.tsx
+++ b/frontend/pages/packs/ManagePacksPage/components/PacksListWrapper/PacksListWrapper.tsx
@@ -33,15 +33,13 @@ interface IRootState {
   };
 }
 
-const PacksListWrapper = (props: IPacksListWrapperProps): JSX.Element => {
-  const {
-    onRemovePackClick,
-    onEnablePackClick,
-    onDisablePackClick,
-    onCreatePackClick,
-    packsList,
-  } = props;
-
+const PacksListWrapper = ({
+  onRemovePackClick,
+  onEnablePackClick,
+  onDisablePackClick,
+  onCreatePackClick,
+  packsList,
+}: IPacksListWrapperProps): JSX.Element => {
   const loadingTableData = useSelector(
     (state: IRootState) => state.entities.packs.isLoading
   );

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -25,6 +25,12 @@ export default {
 
     return sendRequest("DELETE", path);
   },
+  destroyBulk: (hostIds: number[]) => {
+    const { HOSTS } = endpoints;
+    const path = `${HOSTS}/delete`;
+
+    return sendRequest("POST", path, { ids: hostIds });
+  },
   refetch: (host: IHost) => {
     const { HOSTS } = endpoints;
     const path = `${HOSTS}/${host.id}/refetch`;

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -38,11 +38,11 @@ export default {
   ) => {
     const { HOSTS_DELETE } = endpoints;
     return sendRequest("POST", HOSTS_DELETE, {
-      team_id: teamId,
       filters: {
         query,
         status,
         label_id: labelId,
+        team_id: teamId,
       },
     });
   },

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -26,10 +26,25 @@ export default {
     return sendRequest("DELETE", path);
   },
   destroyBulk: (hostIds: number[]) => {
-    const { HOSTS } = endpoints;
-    const path = `${HOSTS}/delete`;
+    const { HOSTS_DELETE } = endpoints;
 
-    return sendRequest("POST", path, { ids: hostIds });
+    return sendRequest("POST", HOSTS_DELETE, { ids: hostIds });
+  },
+  destroyByFilter: (
+    teamId: number | null,
+    query: string,
+    status: string,
+    labelId: number | null
+  ) => {
+    const { HOSTS_DELETE } = endpoints;
+    return sendRequest("POST", HOSTS_DELETE, {
+      team_id: teamId,
+      filters: {
+        query,
+        status,
+        label_id: labelId,
+      },
+    });
   },
   refetch: (host: IHost) => {
     const { HOSTS } = endpoints;


### PR DESCRIPTION
Cerra #1840  
Cerra #2336  

- Ability to delete multiple hosts on the Manage Host Page

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes~~ Done by Tomas' PR
~~- [ ] Documented any permissions changes~~ N/A
~~- [ ] Added/updated tests~~ Martavis building out Manage Host e2e tests
- [x] Manual QA for all new/changed functionality

Just changed `TableContainer.tsx` `const DEFAULT_PAGE_SIZE = 4;` for a manual QA:
<img width="1176" alt="Screen Shot 2021-10-04 at 3 53 14 PM" src="https://user-images.githubusercontent.com/71795832/135915581-46864bbc-04c8-4edc-a02c-103f4d1796f7.png">

