### PR TITLE
Update team maintainer schedules routes

### DIFF
--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -126,6 +126,8 @@ const routes = (
                   <Route path="edit" component={EditPackPage} />
                 </Route>
               </Route>
+            </Route>
+            <Route component={AuthAnyMaintainerGlobalAdminRoutes}>
               <Route path="schedule" component={SchedulePageWrapper}>
                 <Route path="manage" component={ManageSchedulePage} />
                 <Route


### PR DESCRIPTION
Issue #2333

- Update UI routes to fix team maintainer access to schedules page, which was inadvertently removed when resolving merge conflicts