### PR TITLE
Update media queries on fleetdm.com/docs and /handbook

### DIFF
--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -431,7 +431,7 @@
     }
 
     // for larger screens
-    @media (min-width: 990px) {
+    @media (min-width: 992px) {
 
       ul {
         .topic {
@@ -486,7 +486,7 @@
     }
 
     // for smaller screens
-    @media (max-width: 990px) {
+    @media (max-width: 991px) {
 
       padding: 0px 40px;
 

--- a/website/assets/styles/pages/handbook/basic-handbook.less
+++ b/website/assets/styles/pages/handbook/basic-handbook.less
@@ -231,7 +231,7 @@
 
 
   // for larger screens
-  @media (min-width: 990px) {
+  @media (min-width: 992px) {
     ul {
       .topic {
         padding-left: 8px;
@@ -252,7 +252,7 @@
   }
 
   // for smaller screens
-  @media (max-width: 990px) {
+  @media (max-width: 991px) {
     padding: 0px 40px;
 
     [purpose='search'] {

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -101,7 +101,7 @@
             </div>
           </div>
           <div class="d-none d-lg-flex">
-            <a href="/get-started" class="header-link d-flex align-items-center px-3 py-2 mr-2 text-decoration-none" style="text-decoration: none; line-height: 23px;">Get started</a>
+            <a href="/get-started" class="header-link d-flex align-items-center px-3 py-2 mr-4 text-decoration-none" style="text-decoration: none; line-height: 23px;">Get started</a>
             <a href="/docs" class="header-link d-flex align-items-center px-3 py-2 mr-4 text-decoration-none" style=" text-decoration: none; line-height: 23px;">Docs</a>
             <a href="/queries" class="header-link d-flex align-items-center px-3 py-2 mr-4 text-decoration-none" style=" text-decoration: none; line-height: 23px;">Queries</a>
             <a href="/pricing" class="header-link d-flex align-items-center px-3 py-2 mr-4 text-decoration-none" style=" text-decoration: none; line-height: 23px;">Pricing</a>


### PR DESCRIPTION
closes #2310 

changes:
- Updated breakpoints for styles on handbook and docs pages to fix style issues at 991px width
- Changed the bootstrap class on the 'get started' masthead nav item to make margins consistent in the masthead

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
