### PR TITLE
Update GET /software documentation to reflect the current response

### DIFF
--- a/docs/01-Using-Fleet/03-REST-API.md
+++ b/docs/01-Using-Fleet/03-REST-API.md
@@ -6316,7 +6316,6 @@ If the `name` is not already associated with an existing team, this API route cr
 {
     “software”: [
       {
-        "hosts_count": 124,
         "id": 1,
         "name": "Chrome.app",
         "version": "2.1.11",
@@ -6325,7 +6324,6 @@ If the `name` is not already associated with an existing team, this API route cr
         "vulnerabilities": null
       },
       {
-        "hosts_count": 112,
         "id": 2,
         "name": "Figma.app",
         "version": "2.1.11",
@@ -6334,7 +6332,6 @@ If the `name` is not already associated with an existing team, this API route cr
         "vulnerabilities": null
       },
       {
-        "hosts_count": 78,
         "id": 3,
         "name": "osquery",
         "version": "2.1.11",
@@ -6343,7 +6340,6 @@ If the `name` is not already associated with an existing team, this API route cr
         "vulnerabilities": null
       },
       {
-        "hosts_count": 78,
         "id": 4,
         "name": "osquery",
         "version": "2.1.11",

--- a/docs/01-Using-Fleet/03-REST-API.md
+++ b/docs/01-Using-Fleet/03-REST-API.md
@@ -6314,7 +6314,7 @@ If the `name` is not already associated with an existing team, this API route cr
 
 ```json
 {
-    “software”: [
+    "software": [
       {
         "id": 1,
         "name": "Chrome.app",


### PR DESCRIPTION
- Remove the `hosts_count` property from the `GET /api/v1/fleet/software` API route because this property is not currently included in the response.
  - The addition of the `hosts_count` property is specified in the following open issue: Add aggregate software and team filter to the "Home" page #2049
