### PR TITLE
Optimize policy_updated_at migration

### DIFF
--- a/changes/2360-updated-at
+++ b/changes/2360-updated-at
@@ -1,0 +1,1 @@
+* Improve performance and reliability of Policy database migrations.

--- a/server/datastore/mysql/migrations/tables/20210927143115_AddPolicyUpdatedAtColumn.go
+++ b/server/datastore/mysql/migrations/tables/20210927143115_AddPolicyUpdatedAtColumn.go
@@ -11,14 +11,14 @@ func init() {
 }
 
 func Up_20210927143115(tx *sql.Tx) error {
-	_, err := tx.Exec("ALTER TABLE hosts ADD COLUMN policy_updated_at timestamp NOT NULL DEFAULT '2000-01-01 00:00:00'")
-	if err != nil {
-		return errors.Wrap(err, "adding policy_updated_at column")
-	}
-
-	_, err = tx.Exec("delete from policy_membership_history")
+	_, err := tx.Exec("TRUNCATE TABLE policy_membership_history")
 	if err != nil {
 		return errors.Wrap(err, "clearing policy_membership_history")
+	}
+
+	_, err = tx.Exec("ALTER TABLE hosts ADD COLUMN policy_updated_at timestamp NOT NULL DEFAULT '2000-01-01 00:00:00'")
+	if err != nil {
+		return errors.Wrap(err, "adding policy_updated_at column")
 	}
 
 	return err


### PR DESCRIPTION
- Use `TRUNCATE TABLE` rather than `DELETE FROM` for improved performance.
- Move DDL statement after truncate to avoid issues with retries (due to
  column already being created).

#2360

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Documented any API changes
- [x] Documented any permissions changes
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
