### PR TITLE
Learn-how-to-use-Fleet.md - fixed line-break on enroll device command

### DIFF
--- a/docs/01-Using-Fleet/00-Learn-how-to-use-Fleet.md
+++ b/docs/01-Using-Fleet/00-Learn-how-to-use-Fleet.md
@@ -93,8 +93,7 @@ To add your own device to Fleet, you'll first need to install the osquery agent.
 2. With [fleetctl preview](http://fleetdm.com/get-started) still running, run the following command (remembering to swap ```YOUR_FLEET_ENROLL_SECRET_HERE``` for the one you copied in the previous step):
 
 	``` 
-	fleetctl package --type=pkg --fleet-url=https://localhost:8412
-	--enroll-secret=YOUR_FLEET_ENROLL_SECRET_HERE
+	fleetctl package --type=pkg --fleet-url=https://localhost:8412 --enroll-secret=YOUR_FLEET_ENROLL_SECRET_HERE
 	```
 	> If you'd like to build a Windows package, set `--type=msi` in the above command. If you'd like to build a Linux package, set `--type=deb` (Debian, Ubuntu, etc.) or `--type=rpm` (RHEL, CentOS, etc.) in the above command.
 


### PR DESCRIPTION
Update to enroll device command to remove line-break.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
