### PR TITLE
Manage Schedule Page: Fix empty schedule quote

### DIFF
--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleListWrapper.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleListWrapper.tsx
@@ -72,7 +72,7 @@ const ScheduleListWrapper = (props: IScheduleListWrapperProps): JSX.Element => {
             <h2>You don&apos;t have any queries scheduled.</h2>
             <p>
               {!isTeamMaintainer
-                ? "Schedule a query, or go to your osquery packs via the &lsquo;Advanced&rsquo; button."
+                ? "Schedule a query, or go to your osquery packs via the 'Advanced' button."
                 : "Schedule a query to run on hosts assigned to this team."}
             </p>
             <div className={`${noScheduleClass}__-cta-buttons`}>

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/_styles.scss
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/_styles.scss
@@ -130,7 +130,7 @@
   }
 
   &__inner-text {
-    width: 350px;
+    width: 290px;
   }
 
   &__schedule-button {


### PR DESCRIPTION
Cerra #2408 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

Matches Figma single quotes: https://www.figma.com/file/qpdty1e2n22uZntKUZKEJl/%E2%9C%85-Fleet-EE-(current%2C-dev-ready)?node-id=3213%3A71819

<img width="1483" alt="Screen Shot 2021-10-06 at 2 00 12 PM" src="https://user-images.githubusercontent.com/71795832/136258177-14eca54c-5cb7-4e16-8cc8-6fae2a0a8ea8.png">


