### PR TITLE
Fix broken links and duplicate IDs on fleetdm.com/docs

### DIFF
--- a/website/api/helpers/strings/to-html.js
+++ b/website/api/helpers/strings/to-html.js
@@ -75,8 +75,16 @@ module.exports = {
     };
     if (inputs.addIdsToHeadings === true) {
       var headingRenderer = new marked.Renderer();
+      var headingsRenderedOnThisPage = [];
       headingRenderer.heading = function (text, level) {
-        var headingID = _.kebabCase(text);
+        var headingID = _.kebabCase(_.unescape(text).replace(/[\’\']/g, ''));
+        if(_.contains(headingsRenderedOnThisPage, headingID)){
+          var duplicateHeadingIDs = _.where(headingsRenderedOnThisPage, headingID);
+          headingID = headingID + '-' + duplicateHeadingIDs.length;
+          headingsRenderedOnThisPage.push(headingID);
+        } else {
+          headingsRenderedOnThisPage.push(headingID);
+        }
         return '<h'+level+' class="markdown-heading" id="'+headingID+'">'+text+'<a href="#'+headingID+'" class="markdown-link"></a></h'+level+'>\n';
       };
       markedOpts.renderer = headingRenderer;

--- a/website/api/helpers/strings/to-html.js
+++ b/website/api/helpers/strings/to-html.js
@@ -78,11 +78,10 @@ module.exports = {
       var headingsRenderedOnThisPage = [];
       headingRenderer.heading = function (text, level) {
         var headingID = _.kebabCase(_.unescape(text).replace(/[\’\']/g, ''));
-        if(_.contains(headingsRenderedOnThisPage, headingID)){
-          var duplicateHeadingIDs = _.where(headingsRenderedOnThisPage, headingID);
-          headingID = headingID + '-' + duplicateHeadingIDs.length;
+        if(!_.contains(headingsRenderedOnThisPage, headingID)){
           headingsRenderedOnThisPage.push(headingID);
         } else {
+          headingID = sails.helpers.strings.ensureUniq(headingID, headingsRenderedOnThisPage);
           headingsRenderedOnThisPage.push(headingID);
         }
         return '<h'+level+' class="markdown-heading" id="'+headingID+'">'+text+'<a href="#'+headingID+'" class="markdown-link"></a></h'+level+'>\n';

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -229,10 +229,12 @@ module.exports = {
                 // Check if this is an external link (like https://google.com) but that is ALSO not a link
                 // to some page on the destination site where this will be hosted, like `(*.)?fleetdm.com`.
                 // If external, add target="_blank" so the link will open in a new tab.
-                let isExternal = ! hrefString.match(/^href=\"https?:\/\/([^\.]+\.)*fleetdm\.com/g);// « FUTURE: make this smarter with sails.config.baseUrl + _.escapeRegExp()
+                // Note: links to blog.fleetdm.com will be treated as an external link.
+                let isExternal = ! hrefString.match(/^href=\"https?:\/\/([^\.|blog]+\.)*fleetdm\.com/g);// « FUTURE: make this smarter with sails.config.baseUrl + _.escapeRegExp()
                 // Check if this link is to fleetdm.com or www.fleetdm.com.
                 let isBaseUrl = hrefString.match(/^(href="https?:\/\/)([^\.]+\.)*fleetdm\.com"$/g);
                 if (isExternal) {
+
                   return hrefString.replace(/(href="https?:\/\/([^"]+)")/g, '$1 target="_blank"');
                 } else {
                   // Otherwise, change the link to be web root relative.


### PR DESCRIPTION

Changes:
- Updated the markdown heading renderer to not create duplicate IDs for headings
- Updated the way external links are handled to include links to blog.fleetdm.com

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
