### PR TITLE
Copy documentation links to clipboard when a user clicks on them

### DIFF
--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -168,7 +168,6 @@ parasails.registerPage('basic-documentation', {
         let linkToCopy = _.first($(heading).find('a.markdown-link'));
         // If this heading has already been clicked and still has the copied class we'll just ignore this click
         if(!$(heading).hasClass('copied')){
-          console.log('test');
           // If the link's href is missing, we'll copy the current url (and remove any hashes) to the clipboard instead
           if(linkToCopy) {
             navigator.clipboard.writeText(linkToCopy.href);

--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -165,7 +165,7 @@ parasails.registerPage('basic-documentation', {
       $(elem).click(()=>{
         // find the child <a> element
         let linkToCopy = _.first($(elem).find('a.markdown-link'));
-        // If the link is missing, we'll copy the current url (and remove any hashes) to the clipboard instead
+        // If the link's href is missing, we'll copy the current url (and remove any hashes) to the clipboard instead
         if(linkToCopy.href) {
           navigator.clipboard.writeText(linkToCopy.href);
         } else {

--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -159,6 +159,23 @@ parasails.registerPage('basic-documentation', {
       });
     })();
 
+    // Adding event handlers to the Headings on the page, allowing users to copy links by clicking on the heading.
+    let headingsOnThisPage = $('#body-content').find(':header');
+    _.forEach(headingsOnThisPage, (elem)=> {
+      $(elem).click(()=>{
+        // find the child <a> element
+        let linkToCopy = _.first($(elem).find('a.markdown-link'));
+        // If the link is missing, we'll copy the current url (and remove any hashes) to the clipboard instead
+        if(linkToCopy.href) {
+          navigator.clipboard.writeText(linkToCopy.href);
+        } else {
+          navigator.clipboard.writeText(elem.baseURI.split('#')[0]);
+        }
+
+        return;
+      });
+    });
+
   },
 
   //  ╦╔╗╔╔╦╗╔═╗╦═╗╔═╗╔═╗╔╦╗╦╔═╗╔╗╔╔═╗

--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -171,7 +171,7 @@ parasails.registerPage('basic-documentation', {
         } else {
           navigator.clipboard.writeText(elem.baseURI.split('#')[0]);
         }
-
+        $(elem).addClass('copied');
         return;
       });
     });

--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -161,19 +161,27 @@ parasails.registerPage('basic-documentation', {
 
     // Adding event handlers to the Headings on the page, allowing users to copy links by clicking on the heading.
     let headingsOnThisPage = $('#body-content').find(':header');
-    _.forEach(headingsOnThisPage, (elem)=> {
-      $(elem).click(()=>{
-        // find the child <a> element
-        let linkToCopy = _.first($(elem).find('a.markdown-link'));
-        // If the link's href is missing, we'll copy the current url (and remove any hashes) to the clipboard instead
-        if(linkToCopy) {
-          navigator.clipboard.writeText(linkToCopy.href);
-        } else {
-          navigator.clipboard.writeText(elem.baseURI.split('#')[0]);
+    for(let key in Object.values(headingsOnThisPage)){
+      let heading = headingsOnThisPage[key];
+      $(heading).click(()=> {
+        // Find the child <a> element
+        let linkToCopy = _.first($(heading).find('a.markdown-link'));
+        // If this heading has already been clicked and still has the copied class we'll just ignore this click
+        if(!$(heading).hasClass('copied')){
+          console.log('test');
+          // If the link's href is missing, we'll copy the current url (and remove any hashes) to the clipboard instead
+          if(linkToCopy) {
+            navigator.clipboard.writeText(linkToCopy.href);
+          } else {
+            navigator.clipboard.writeText(heading.baseURI.split('#')[0]);
+          }
+          // Add the copied class to the header to notify the user that the link has been copied.
+          $(heading).addClass('copied');
+          // Remove the copied class 5 seconds later, so we can notify the user again if they re-cick on this heading
+          setTimeout(()=>{$(heading).removeClass('copied');}, 5000);
         }
-        $(elem).addClass('copied');
       });
-    });
+    }
 
   },
 

--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -166,13 +166,12 @@ parasails.registerPage('basic-documentation', {
         // find the child <a> element
         let linkToCopy = _.first($(elem).find('a.markdown-link'));
         // If the link's href is missing, we'll copy the current url (and remove any hashes) to the clipboard instead
-        if(linkToCopy.href) {
+        if(linkToCopy) {
           navigator.clipboard.writeText(linkToCopy.href);
         } else {
           navigator.clipboard.writeText(elem.baseURI.split('#')[0]);
         }
         $(elem).addClass('copied');
-        return;
       });
     });
 

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -59,7 +59,7 @@
     line-height: 12px;
     color: @core-vibrant-blue;
     animation-name: copiedText;
-    animation-duration: 3s;
+    animation-duration: 4s;
     animation-fill-mode: both;
   } .markdown-heading.copied:hover::after {
       right: -15px;
@@ -68,9 +68,10 @@
   @keyframes copiedText {
     0% {opacity: 0;}
     20% {opacity: 100;}
-    50% {opacity: 80;}
-    70% {opacity: 70;}
-    90% {opacity: 50;}
+    50% {opacity: 70;}
+    70% {opacity: 50;}
+    80% {opacity: 30;}
+    90% {opacity: 10;}
     100% {opacity: 0;}
   }
 

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -61,9 +61,10 @@
     animation-name: copiedText;
     animation-duration: 4s;
     animation-fill-mode: both;
-  } .markdown-heading.copied:hover::after {
-      right: -15px;
-    }
+  }
+  .markdown-heading.copied:hover::after {
+    right: -15px;
+  }
 
   @keyframes copiedText {
     0% {opacity: 0;}

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -48,6 +48,31 @@
     }
 
   }
+  .markdown-heading.copied::after {
+    content: 'Link copied to clipboard';
+    display: inline;
+    font-weight: 400;
+    vertical-align: middle;
+    position: relative;
+    right: -39px;
+    font-size: 12px;
+    line-height: 12px;
+    color: @core-vibrant-blue;
+    animation-name: copiedText;
+    animation-duration: 3s;
+    animation-fill-mode: both;
+  } .markdown-heading.copied:hover::after {
+      right: -15px;
+    }
+
+  @keyframes copiedText {
+    0% {opacity: 0;}
+    20% {opacity: 100;}
+    50% {opacity: 80;}
+    70% {opacity: 70;}
+    90% {opacity: 50;}
+    100% {opacity: 0;}
+  }
 
 
   [purpose='search'] {

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -48,31 +48,31 @@
     }
 
   }
-  .markdown-heading.copied::after {
+  .markdown-heading.copied::before {
     content: 'Link copied to clipboard';
-    display: inline;
+    display: flex;
     font-weight: 400;
-    vertical-align: middle;
     position: relative;
-    right: -39px;
-    font-size: 12px;
-    line-height: 12px;
+    top: -25px;
+    height: 0px;
+    font-size: 14px;
+    // line-height: 14px;
     color: @core-vibrant-blue;
     animation-name: copiedText;
     animation-duration: 4s;
-    animation-fill-mode: both;
+    animation-fill-mode: forwards;
   }
-  .markdown-heading.copied:hover::after {
-    right: -15px;
+  .markdown-heading.copied:hover::before {
+    // right: -15px;
   }
 
   @keyframes copiedText {
     0% {opacity: 0;}
     20% {opacity: 100;}
-    50% {opacity: 70;}
-    70% {opacity: 50;}
-    80% {opacity: 30;}
-    90% {opacity: 10;}
+    30% {opacity: 80;}
+    50% {opacity: 60;}
+    70% {opacity: 40;}
+    80% {opacity: 20;}
     100% {opacity: 0;}
   }
 


### PR DESCRIPTION
Closes #2017 

Changes:
- Added a click event to headings in documentation that copies the link to that section to the user's clipboard
- Added a notification that appears next to the heading letting the user know the link has been copied

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
