### PR TITLE
Host Details Page: Relocate host details page header and buttons

### DIFF
--- a/changes/issue-2240-host-details-move-action-buttons
+++ b/changes/issue-2240-host-details-move-action-buttons
@@ -1,0 +1,1 @@
+* Host details page UI cleaner with action buttons outside details table

--- a/cypress/integration/free/maintainer.spec.ts
+++ b/cypress/integration/free/maintainer.spec.ts
@@ -148,6 +148,6 @@ describe(
       cy.findByText("Role")
         .next()
         .contains(/maintainer/i);
-    };);
+    });
   }
 );

--- a/cypress/integration/free/maintainer.spec.ts
+++ b/cypress/integration/free/maintainer.spec.ts
@@ -22,7 +22,7 @@ describe(
       cy.visit("/hosts/manage");
 
       // Ensure page is loaded
-      // cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.contains("All hosts");
 
       // Settings restrictions
@@ -32,6 +32,8 @@ describe(
 
       // Host manage page: No team UI, can add host and label
       cy.visit("/hosts/manage");
+
+      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.findByText(/teams/i).should("not.exist");
       cy.contains("button", /add new host/i).click();
       cy.findByText("select a team").should("not.exist");
@@ -146,6 +148,6 @@ describe(
       cy.findByText("Role")
         .next()
         .contains(/maintainer/i);
-    });
+    };);
   }
 );

--- a/cypress/integration/premium/maintainer.spec.ts
+++ b/cypress/integration/premium/maintainer.spec.ts
@@ -27,7 +27,7 @@ describe(
       // Host manage page: Teams column, select a team
       cy.visit("/hosts/manage");
 
-      cy.wait(10000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
 
       cy.findByText(/show enroll secret/i).should("exist");
 
@@ -40,9 +40,9 @@ describe(
         // Test host text varies
         cy.findByRole("button").click();
       });
-      cy.get(".title").within(() => {
-        cy.findByText("Team").should("exist");
-      });
+
+      cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.findByText("Team").should("exist");
       cy.contains("button", /transfer/i).click();
       cy.get(".Select-control").click();
       cy.findByText(/create a team/i).should("not.exist");

--- a/cypress/integration/premium/observer.spec.ts
+++ b/cypress/integration/premium/observer.spec.ts
@@ -18,7 +18,7 @@ describe("Premium tier - Observer user", () => {
     cy.visit("/hosts/manage");
 
     // Ensure page is loaded
-    cy.wait(5000); // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
     cy.contains("All hosts");
 
     cy.get("thead").within(() => {
@@ -30,9 +30,9 @@ describe("Premium tier - Observer user", () => {
       // Test host text varies
       cy.findByRole("button").click();
     });
-    cy.get(".title").within(() => {
-      cy.findByText("Team").should("exist");
-    });
+
+    cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.findByText("Team").should("exist");
     cy.contains("button", /transfer/i).should("not.exist");
     cy.contains("button", /delete/i).should("not.exist");
     cy.contains("button", /query/i).click();

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.tsx
@@ -702,7 +702,7 @@ const HostDetailsPage = ({
           <span>Back to all hosts</span>
         </Link>
       </div>
-      <div className="section title">
+      <div className="header title">
         <div className="title__inner">
           <div className="hostname-container">
             <h1 className="hostname">{host?.hostname || "---"}</h1>
@@ -714,6 +714,11 @@ const HostDetailsPage = ({
             </p>
             {renderRefetch()}
           </div>
+        </div>
+        {renderActionButtons()}
+      </div>
+      <div className="section title">
+        <div className="title__inner">
           <div className="info-flex">
             <div className="info-flex__item info-flex__item--title">
               <span className="info-flex__header">Status</span>
@@ -743,7 +748,6 @@ const HostDetailsPage = ({
             </div>
           </div>
         </div>
-        {renderActionButtons()}
       </div>
       <div className="section about">
         <p className="section__header">About this host</p>

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -6,7 +6,13 @@
   padding-bottom: 50px;
   min-width: 0;
   background-color: $ui-off-white;
-  gap: $pad-large;
+  gap: $pad-medium;
+
+  .header {
+    flex: 100%;
+    display: flex;
+    flex-direction: column;
+  }
 
   .section {
     flex: 100%;
@@ -140,17 +146,11 @@
   .title {
     flex-direction: row;
     justify-content: space-between;
-    border-bottom: 1px solid $ui-fleet-blue-15;
     margin: 0;
-
-    &__inner {
-      padding-bottom: $pad-medium;
-    }
 
     .hostname-container {
       display: flex;
       align-items: flex-end;
-      margin-bottom: $pad-large;
     }
 
     .hostname {
@@ -420,6 +420,7 @@
   &__back-link {
     display: flex;
     align-items: center;
+    padding-bottom: $pad-small;
     height: 16px;
     font-size: $x-small;
     color: $core-vibrant-blue;


### PR DESCRIPTION
Cerra #2440 

- Updated UI for host details header and buttons

Figma: https://www.figma.com/file/qpdty1e2n22uZntKUZKEJl/%E2%9C%85-Fleet-EE-(current%2C-dev-ready)?node-id=4413%3A95573

Before: host name, last refetch, refetch, and action buttons on right ... were all inside the first card
After:
<img width="1575" alt="Screen Shot 2021-10-07 at 4 53 08 PM" src="https://user-images.githubusercontent.com/71795832/136461262-97231695-c038-488f-ae7b-f405ef7032a1.png">
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
