### PR TITLE
Fix missing manage hosts page title for Fleet Free version

### DIFF
--- a/changes/fix-2458
+++ b/changes/fix-2458
@@ -1,0 +1,1 @@
+* Fix missing default header on manage hosts page for Fleet Free version

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -224,14 +224,14 @@ const ManageHostsPage = ({
     }
   );
 
-  const { data: teams } = useQuery<ITeamsResponse, Error, ITeam[]>(
-    ["teams"],
-    () => teamsAPI.loadAll(),
-    {
-      enabled: isPremiumTier,
-      select: (data: ITeamsResponse) => data.teams,
-    }
-  );
+  const { data: teams, isLoading: isLoadingTeams } = useQuery<
+    ITeamsResponse,
+    Error,
+    ITeam[]
+  >(["teams"], () => teamsAPI.loadAll(), {
+    enabled: !!isPremiumTier,
+    select: (data: ITeamsResponse) => data.teams,
+  });
 
   useQuery<IPolicyAPIResponse, Error>(
     ["policy"],
@@ -757,7 +757,7 @@ const ManageHostsPage = ({
   };
 
   const renderTeamsFilterDropdown = () => {
-    if (!isPremiumTier || !teams) {
+    if (isPremiumTier && isLoadingTeams) {
       return null;
     }
 
@@ -766,7 +766,7 @@ const ManageHostsPage = ({
     }
 
     const teamOptions = generateTeamFilterDropdownOptions(
-      teams,
+      teams || [],
       currentUser,
       isOnGlobalTeam as boolean
     );


### PR DESCRIPTION
Fix for #2458 

- Fix missing header on manage hosts page for Fleet Free version
- Remove teams API calls on manage hosts page for Fleet Free version 

- [x] Manual QA for all new/changed functionality
