### PR TITLE
Manage Host Page: Add tooltip to search

### DIFF
--- a/changes/issue-2285-manage-host-search-tooltip
+++ b/changes/issue-2285-manage-host-search-tooltip
@@ -1,0 +1,1 @@
+* Adds a tooltip for parameters to search on the manage host page

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -10,6 +10,7 @@ import Button from "components/buttons/Button";
 import { ButtonVariant } from "components/buttons/Button/Button"; // @ts-ignore
 import scrollToTop from "utilities/scroll_to_top";
 import { useDeepEffect } from "utilities/hooks";
+import ReactTooltip from "react-tooltip";
 
 // @ts-ignore
 import DataTable from "./DataTable/DataTable";
@@ -60,6 +61,7 @@ interface ITableContainerProps {
   customControl?: () => JSX.Element;
   onSelectSingleRow?: (value: Row) => void;
   filteredCount?: number;
+  searchToolTipText?: string;
 }
 
 const baseClass = "table-container";
@@ -67,6 +69,10 @@ const baseClass = "table-container";
 const DEFAULT_PAGE_SIZE = 100;
 const DEFAULT_PAGE_INDEX = 0;
 const DEBOUNCE_QUERY_DELAY = 300;
+
+const generateClassTag = (rawValue: string): string => {
+  return rawValue.replace(" ", "-").toLowerCase();
+};
 
 const TableContainer = ({
   columns,
@@ -104,6 +110,7 @@ const TableContainer = ({
   customControl,
   onSelectSingleRow,
   filteredCount,
+  searchToolTipText,
 }: ITableContainerProps): JSX.Element => {
   const [searchQuery, setSearchQuery] = useState("");
   const [sortHeader, setSortHeader] = useState(defaultSortHeader || "");
@@ -249,15 +256,34 @@ const TableContainer = ({
           {customControl && customControl()}
           {/* Render search bar only if not empty component */}
           {searchable && !wideSearch && (
-            <div className={`${baseClass}__search-input`}>
-              <InputField
-                placeholder={inputPlaceHolder}
-                name="searchQuery"
-                onChange={onSearchQueryChange}
-                value={searchQuery}
-                inputWrapperClass={`${baseClass}__input-wrapper`}
-              />
-            </div>
+            <>
+              <div
+                className={`${baseClass}__search-input`}
+                data-tip
+                data-for="search-tooltip"
+                data-tip-disable={!searchToolTipText}
+              >
+                <InputField
+                  placeholder={inputPlaceHolder}
+                  name="searchQuery"
+                  onChange={onSearchQueryChange}
+                  value={searchQuery}
+                  inputWrapperClass={`${baseClass}__input-wrapper`}
+                />
+              </div>
+              <ReactTooltip
+                place="top"
+                type="dark"
+                effect="solid"
+                backgroundColor="#3e4771"
+                id="search-tooltip"
+                data-html
+              >
+                <span className={`tooltip ${baseClass}__tooltip-text`}>
+                  {searchToolTipText}
+                </span>
+              </ReactTooltip>
+            </>
           )}
         </div>
       </div>

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -70,10 +70,6 @@ const DEFAULT_PAGE_SIZE = 100;
 const DEFAULT_PAGE_INDEX = 0;
 const DEBOUNCE_QUERY_DELAY = 300;
 
-const generateClassTag = (rawValue: string): string => {
-  return rawValue.replace(" ", "-").toLowerCase();
-};
-
 const TableContainer = ({
   columns,
   data,

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -82,4 +82,9 @@
       }
     }
   }
+
+  #search-tooltip {
+    width: 196px;
+    text-align: center;
+  }
 }

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1195,7 +1195,13 @@ const ManageHostsPage = ({
         toggleAllPagesSelected={toggleAllMatchingHosts}
         searchable
         customControl={renderStatusDropdown}
+<<<<<<< HEAD
         filteredCount={filteredHostCount}
+=======
+        searchToolTipText={
+          "Search hosts by hostname, UUID, machine serial or IP address"
+        }
+>>>>>>> cbed295f (Add tooltip to manage host page search)
       />
     );
   };

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1195,13 +1195,10 @@ const ManageHostsPage = ({
         toggleAllPagesSelected={toggleAllMatchingHosts}
         searchable
         customControl={renderStatusDropdown}
-<<<<<<< HEAD
         filteredCount={filteredHostCount}
-=======
         searchToolTipText={
           "Search hosts by hostname, UUID, machine serial or IP address"
         }
->>>>>>> cbed295f (Add tooltip to manage host page search)
       />
     );
   };


### PR DESCRIPTION
Cerra #2285 

- Adds a tooltip to the search bar of the Manage host page
- Utilizes a new TableContainer optional prop

<img width="1538" alt="Screen Shot 2021-10-11 at 1 17 57 PM" src="https://user-images.githubusercontent.com/71795832/136829875-64591848-e030-4187-a3d1-0c9b4556a976.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
