### PR TITLE
Remove extra params from host count API call

### DIFF
--- a/frontend/services/entities/host_count.ts
+++ b/frontend/services/entities/host_count.ts
@@ -1,7 +1,6 @@
 /* eslint-disable  @typescript-eslint/explicit-module-boundary-types */
 import sendRequest from "services";
 import endpoints from "fleet/endpoints";
-import { IHost } from "interfaces/host";
 
 export interface ISortOption {
   key: string;
@@ -11,7 +10,6 @@ export interface ISortOption {
 export interface IHostCountLoadOptions {
   page?: number;
   perPage?: number;
-  sortBy?: ISortOption[];
   status?: string;
   globalFilter?: string;
   teamId?: number;
@@ -24,25 +22,11 @@ export default {
   // hostCount.load share similar variables and parameters with hosts.loadAll
   load: (options: IHostCountLoadOptions | undefined) => {
     const { HOSTS_COUNT } = endpoints;
-    const sortBy = options?.sortBy || [];
     const globalFilter = options?.globalFilter || "";
     const teamId = options?.teamId || null;
     const policyId = options?.policyId || null;
     const policyResponse = options?.policyResponse || null;
     const selectedLabels = options?.selectedLabels || [];
-
-    let orderKeyParam = "";
-    let orderDirection = "";
-    if (sortBy.length !== 0) {
-      const sortItem = sortBy[0];
-      orderKeyParam += `order_key=${sortItem.key}`;
-      orderDirection = `&order_direction=${sortItem.direction}`;
-    }
-
-    let searchQuery = "";
-    if (globalFilter !== "") {
-      searchQuery = `&query=${globalFilter}`;
-    }
 
     const labelPrefix = "labels/";
 
@@ -55,24 +39,34 @@ export default {
       status === "offline" ||
       status === "mia";
 
-    let path = `${HOSTS_COUNT}?${orderKeyParam}${orderDirection}${searchQuery}`;
+    let queryString = "";
+
+    if (globalFilter !== "") {
+      queryString += `&query=${globalFilter}`;
+    }
 
     if (status && isValidStatus) {
-      path += `&status=${status}`;
+      queryString += `&status=${status}`;
     }
 
     if (label) {
-      path += `&label_id=${parseInt(label.substr(labelPrefix.length), 10)}`;
+      queryString += `&label_id=${parseInt(
+        label.substr(labelPrefix.length),
+        10
+      )}`;
     }
 
     if (teamId) {
-      path += `&team_id=${teamId}`;
+      queryString += `&team_id=${teamId}`;
     }
 
     if (!label && policyId) {
-      path += `&policy_id=${policyId}`;
-      path += `&policy_response=${policyResponse || "passing"}`; // TODO confirm whether there should be a default if there is an id but no response specified
+      queryString += `&policy_id=${policyId}`;
+      queryString += `&policy_response=${policyResponse || "passing"}`; // TODO confirm whether there should be a default if there is an id but no response specified
     }
+
+    // Append query string to endpoint route after slicing off the leading ampersand
+    const path = `${HOSTS_COUNT}${queryString && `?${queryString.slice(1)}`}`;
 
     return sendRequest("GET", path);
   },


### PR DESCRIPTION
- Fix issue where `count` endpoint was being called with extraneous URL query params (`order_key`, `order_direction`) and causing the endpoint to return error `Error 1054: Unknown column`

- [x] Manual QA for all new/changed functionality
