### PR TITLE
Remove usage of temporary table in migration

### DIFF
--- a/changes/no-temp-table
+++ b/changes/no-temp-table
@@ -1,0 +1,1 @@
+* Fix migration errors under some MySQL configurations due to use of temporary tables.

--- a/server/datastore/mysql/migrations/tables/20210819131107_AddCascadeToHostSoftware.go
+++ b/server/datastore/mysql/migrations/tables/20210819131107_AddCascadeToHostSoftware.go
@@ -31,7 +31,9 @@ func Up_20210819131107(tx *sql.Tx) error {
 	}
 
 	// Clear any orphan software and host_software
-	_, err = tx.Exec(`CREATE TEMPORARY TABLE temp_host_software AS SELECT * FROM host_software;`)
+	// Note that we can't use CREATE TEMPORARY TABLE here as it caused problems in some MySQL
+	// configurations. See https://github.com/fleetdm/fleet/issues/2462.
+	_, err = tx.Exec(`CREATE TABLE temp_host_software AS SELECT * FROM host_software;`)
 	if err != nil {
 		return errors.Wrap(err, "save current host software to a temp table")
 	}


### PR DESCRIPTION
Temporary tables were causing migration issues under some MySQL
configurations as discussed in #2462.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [ ] Documented any API changes
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
