### PR TITLE
Implementation of a Kafka REST Proxy logging plugin

### DIFF
--- a/docs/02-Deploying/02-Configuration.md
+++ b/docs/02-Deploying/02-Configuration.md
@@ -720,7 +720,7 @@ Valid time units are `s`, `m`, `h`.
 
 Which log output plugin should be used for osquery status logs received from clients.
 
-Options are `filesystem`, `firehose`, `kinesis`, `lambda`, `pubsub`, and `stdout`.
+Options are `filesystem`, `firehose`, `kinesis`, `lambda`, `pubsub`, `kafkarest`, and `stdout`.
 
 - Default value: `filesystem`
 - Environment variable: `FLEET_OSQUERY_STATUS_LOG_PLUGIN`
@@ -735,7 +735,7 @@ Options are `filesystem`, `firehose`, `kinesis`, `lambda`, `pubsub`, and `stdout
 
 Which log output plugin should be used for osquery result logs received from clients.
 
-Options are `filesystem`, `firehose`, `kinesis`, `lambda`, `pubsub`, and `stdout`.
+Options are `filesystem`, `firehose`, `kinesis`, `lambda`, `pubsub`, `kafkarest`, and `stdout`.
 
 - Default value: `filesystem`
 - Environment variable: `FLEET_OSQUERY_RESULT_LOG_PLUGIN`
@@ -1268,6 +1268,68 @@ This feature is useful when combined with [subscription filters](https://cloud.g
   ```
   pubsub:
     status_topic: osquery_status
+  ```
+
+#### Kafka Rest Proxy Logging
+
+##### kafkarest_proxyhost
+
+This flag only has effect if `osquery_status_log_plugin` or `osquery_status_result_plugin` is set to `kafkarest`.
+
+The URL of the host which to check for the topic existence and post messages to the specified topic.
+
+- Default value: none
+- Environment variable: `FLEET_KAFKAREST_PROXYHOST`
+- Config file format:
+
+  ```
+  kafkarest:
+    proxyhost: "https://localhost:8443"
+  ```
+
+##### kafkarest_status_topic
+
+This flag only has effect if `osquery_status_log_plugin` is set to `kafkarest`.
+
+The identifier of the kafka topic that osquery status logs will be published to.
+
+- Default value: none
+- Environment variable: `FLEET_KAFKAREST_STATUS_TOPIC`
+- Config file format:
+
+  ```
+  kafkarest:
+    status_topic: osquery_status
+  ```
+
+##### kafkarest_result_topic
+
+This flag only has effect if `osquery_result_log_plugin` is set to `kafkarest`.
+
+The identifier of the kafka topic that osquery status logs will be published to.
+
+- Default value: none
+- Environment variable: `FLEET_KAFKAREST_RESULT_TOPIC`
+- Config file format:
+
+  ```
+  kafkarest:
+    status_topic: osquery_result
+  ```
+
+##### kafkarest_timeout
+
+This flag only has effect if `osquery_status_log_plugin` or `osquery_status_result_plugin` is set to `kafkarest`.
+
+The timeout value for the http post attempt.  Value is in units of seconds.
+
+- Default value: 5
+- Environment variable: `FLEET_KAFKAREST_TIMEOUT`
+- Config file format:
+
+  ```
+  kafkarest:
+    timeout: 5
   ```
 
 #### S3 file carving backend

--- a/docs/02-Deploying/02-Configuration.md
+++ b/docs/02-Deploying/02-Configuration.md
@@ -1274,7 +1274,7 @@ This feature is useful when combined with [subscription filters](https://cloud.g
 
 ##### kafkarest_proxyhost
 
-This flag only has effect if `osquery_status_log_plugin` or `osquery_status_result_plugin` is set to `kafkarest`.
+This flag only has effect if `osquery_status_log_plugin` or `osquery_result_log_plugin` is set to `kafkarest`.
 
 The URL of the host which to check for the topic existence and post messages to the specified topic.
 
@@ -1319,7 +1319,7 @@ The identifier of the kafka topic that osquery status logs will be published to.
 
 ##### kafkarest_timeout
 
-This flag only has effect if `osquery_status_log_plugin` or `osquery_status_result_plugin` is set to `kafkarest`.
+This flag only has effect if `osquery_status_log_plugin` or `osquery_result_log_plugin` is set to `kafkarest`.
 
 The timeout value for the http post attempt.  Value is in units of seconds.
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -166,6 +166,7 @@ type FilesystemConfig struct {
 type KafkaRESTConfig struct {
 	StatusTopic string `json:"status_topic" yaml:"status_topic"`
 	ResultTopic string `json:"result_topic" yaml:"result_topic"`
+	ProxyHost string `json:"proxyhost" yaml:"proxyhost"`
 }
 
 // LicenseConfig defines configs related to licensing Fleet.
@@ -390,6 +391,7 @@ func (man Manager) addConfigs() {
 	// KafkaREST
 	man.addConfigString("kafkarest.status_topic", "", "Kafka REST topic for status logs")
 	man.addConfigString("kafkarest.result_topic", "", "Kafka REST topic for result logs")
+	man.addConfigString("kafkarest.proxyhost", "", "Kafka REST proxy host url")
 
 	// License
 	man.addConfigString("license.key", "", "Fleet license key (to enable Fleet Premium features)")
@@ -535,6 +537,7 @@ func (man Manager) LoadConfig() FleetConfig {
 		KafkaREST: KafkaRESTConfig{
 			StatusTopic: man.getConfigString("kafkarest.status_topic"),
 			ResultTopic: man.getConfigString("kafkarest.result_topic"),
+			ProxyHost: man.getConfigString("kafkarest.proxyhost"),
 		},
 		License: LicenseConfig{
 			Key: man.getConfigString("license.key"),

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -166,7 +166,8 @@ type FilesystemConfig struct {
 type KafkaRESTConfig struct {
 	StatusTopic string `json:"status_topic" yaml:"status_topic"`
 	ResultTopic string `json:"result_topic" yaml:"result_topic"`
-	ProxyHost string `json:"proxyhost" yaml:"proxyhost"`
+	ProxyHost   string `json:"proxyhost" yaml:"proxyhost"`
+	Timeout     int    `json:"timeout" yaml:"timeout"`
 }
 
 // LicenseConfig defines configs related to licensing Fleet.
@@ -392,6 +393,7 @@ func (man Manager) addConfigs() {
 	man.addConfigString("kafkarest.status_topic", "", "Kafka REST topic for status logs")
 	man.addConfigString("kafkarest.result_topic", "", "Kafka REST topic for result logs")
 	man.addConfigString("kafkarest.proxyhost", "", "Kafka REST proxy host url")
+	man.addConfigInt("kafkarest.timeout", 5, "Kafka REST proxy json post timeout")
 
 	// License
 	man.addConfigString("license.key", "", "Fleet license key (to enable Fleet Premium features)")
@@ -537,7 +539,8 @@ func (man Manager) LoadConfig() FleetConfig {
 		KafkaREST: KafkaRESTConfig{
 			StatusTopic: man.getConfigString("kafkarest.status_topic"),
 			ResultTopic: man.getConfigString("kafkarest.result_topic"),
-			ProxyHost: man.getConfigString("kafkarest.proxyhost"),
+			ProxyHost:   man.getConfigString("kafkarest.proxyhost"),
+			Timeout:     man.getConfigInt("kafkarest.timeout"),
 		},
 		License: LicenseConfig{
 			Key: man.getConfigString("license.key"),

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -163,6 +163,11 @@ type FilesystemConfig struct {
 	EnableLogCompression bool   `json:"enable_log_compression" yaml:"enable_log_compression"`
 }
 
+type KafkaRESTConfig struct {
+	StatusTopic string `json:"status_topic" yaml:"status_topic"`
+	ResultTopic string `json:"result_topic" yaml:"result_topic"`
+}
+
 // LicenseConfig defines configs related to licensing Fleet.
 type LicenseConfig struct {
 	Key string `yaml:"key"`
@@ -198,6 +203,7 @@ type FleetConfig struct {
 	S3               S3Config
 	PubSub           PubSubConfig
 	Filesystem       FilesystemConfig
+	KafkaREST        KafkaRESTConfig
 	License          LicenseConfig
 	Vulnerabilities  VulnerabilitiesConfig
 }
@@ -381,6 +387,10 @@ func (man Manager) addConfigs() {
 	man.addConfigBool("filesystem.enable_log_compression", false,
 		"Enable compression for the rotated osquery log files")
 
+	// KafkaREST
+	man.addConfigString("kafkarest.status_topic", "", "Kafka REST topic for status logs")
+	man.addConfigString("kafkarest.result_topic", "", "Kafka REST topic for result logs")
+
 	// License
 	man.addConfigString("license.key", "", "Fleet license key (to enable Fleet Premium features)")
 
@@ -521,6 +531,10 @@ func (man Manager) LoadConfig() FleetConfig {
 			ResultLogFile:        man.getConfigString("filesystem.result_log_file"),
 			EnableLogRotation:    man.getConfigBool("filesystem.enable_log_rotation"),
 			EnableLogCompression: man.getConfigBool("filesystem.enable_log_compression"),
+		},
+		KafkaREST: KafkaRESTConfig{
+			StatusTopic: man.getConfigString("kafkarest.status_topic"),
+			ResultTopic: man.getConfigString("kafkarest.result_topic"),
 		},
 		License: LicenseConfig{
 			Key: man.getConfigString("license.key"),

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -29,7 +29,7 @@ type MysqlConfig struct {
 	TLSKey          string `yaml:"tls_key"`
 	TLSCA           string `yaml:"tls_ca"`
 	TLSServerName   string `yaml:"tls_server_name"`
-	TLSConfig       string `yaml:"tls_config"` //tls=customValue in DSN
+	TLSConfig       string `yaml:"tls_config"` // tls=customValue in DSN
 	MaxOpenConns    int    `yaml:"max_open_conns"`
 	MaxIdleConns    int    `yaml:"max_idle_conns"`
 	ConnMaxLifetime int    `yaml:"conn_max_lifetime"`
@@ -163,6 +163,7 @@ type FilesystemConfig struct {
 	EnableLogCompression bool   `json:"enable_log_compression" yaml:"enable_log_compression"`
 }
 
+// KafkaRESTConfig defines configs for the Kafka REST Proxy logging plugin.
 type KafkaRESTConfig struct {
 	StatusTopic string `json:"status_topic" yaml:"status_topic"`
 	ResultTopic string `json:"result_topic" yaml:"result_topic"`
@@ -740,7 +741,6 @@ func (man Manager) loadConfigFile() {
 
 	man.viper.SetConfigFile(configFile)
 	err := man.viper.ReadInConfig()
-
 	if err != nil {
 		fmt.Println("Error loading config file:", err)
 		os.Exit(1)
@@ -752,7 +752,7 @@ func (man Manager) loadConfigFile() {
 // TestConfig returns a barebones configuration suitable for use in tests.
 // Individual tests may want to override some of the values provided.
 func TestConfig() FleetConfig {
-	var testLogFile = "/dev/null"
+	testLogFile := "/dev/null"
 	if runtime.GOOS == "windows" {
 		testLogFile = "NUL"
 	}

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -383,3 +383,10 @@ type LambdaConfig struct {
 	StatusFunction string `json:"status_function"`
 	ResultFunction string `json:"result_function"`
 }
+
+// KafkaRESTConfig shadows config.KafkaRESTConfig
+type KafkaRESTConfig struct {
+	StatusTopic string `json:"status_topic"`
+	ResultTopic string `json:"result_topic"`
+	ProxyHost   string `json:"proxyhost"`
+}

--- a/server/logging/kafkarest.go
+++ b/server/logging/kafkarest.go
@@ -5,18 +5,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"net/http"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 const (
-	CONTENT_TYPE_MIME = "application/vnd.kafka.json.v1+json"
-	CONTENT_TYPE      = "Content-Type"
-	TIMESTAMP         = "TimeStamp"
-	URL_PUBLISH_TOPIC = "%s/topics/%s"
-	URL_CHECK_TOPIC   = "%s/topics/?topic=%s"
+	krContentTypeValue  = "application/vnd.kafka.json.v1+json"
+	krContentTypeHeader = "Content-Type"
+	krTimestampHeader   = "TimeStamp"
+	krPublishTopicURL   = "%s/topics/%s"
+	krCheckTopicURL     = "%s/topics/?topic=%s"
 )
 
 type KafkaRESTParams struct {
@@ -41,8 +42,8 @@ type kafkaValue struct {
 
 func NewKafkaRESTWriter(p *KafkaRESTParams) (*kafkaRESTProducer, error) {
 	producer := &kafkaRESTProducer{
-		URL:      fmt.Sprintf(URL_PUBLISH_TOPIC, p.KafkaProxyHost, p.KafkaTopic),
-		CheckURL: fmt.Sprintf(URL_CHECK_TOPIC, p.KafkaProxyHost, p.KafkaTopic),
+		URL:      fmt.Sprintf(krPublishTopicURL, p.KafkaProxyHost, p.KafkaTopic),
+		CheckURL: fmt.Sprintf(krCheckTopicURL, p.KafkaProxyHost, p.KafkaTopic),
 		client: &http.Client{
 			Timeout: time.Duration(p.KafkaTimeout) * time.Second,
 		},
@@ -71,18 +72,18 @@ func (l *kafkaRESTProducer) Write(ctx context.Context, logs []json.RawMessage) e
 	if err != nil {
 		return errors.Wrap(err, "kafka rest post")
 	}
-
 	defer resp.Body.Close()
+
 	return checkResponse(resp)
 }
 
 func checkResponse(resp *http.Response) (err error) {
 	if resp.StatusCode != http.StatusOK {
 		body, _ := ioutil.ReadAll(resp.Body)
-		err = errors.Errorf("Error: %d. %s", resp.StatusCode, string(body))
+		return errors.Errorf("Error: %d. %s", resp.StatusCode, string(body))
 	}
 
-	return
+	return nil
 }
 
 func (l *kafkaRESTProducer) checkTopic() (err error) {
@@ -90,8 +91,8 @@ func (l *kafkaRESTProducer) checkTopic() (err error) {
 	if err != nil {
 		return errors.Wrap(err, "kafka rest topic check")
 	}
-
 	defer resp.Body.Close()
+
 	return checkResponse(resp)
 }
 
@@ -102,8 +103,8 @@ func (l *kafkaRESTProducer) post(url string, buf *bytes.Buffer) (*http.Response,
 	}
 
 	now := float64(time.Now().UnixNano()) / float64(time.Second)
-	req.Header.Set(CONTENT_TYPE, CONTENT_TYPE_MIME)
-	req.Header.Set(TIMESTAMP, fmt.Sprintf("%f", now))
+	req.Header.Set(krContentTypeHeader, krContentTypeValue)
+	req.Header.Set(krTimestampHeader, fmt.Sprintf("%f", now))
 
 	return l.client.Do(req)
 }

--- a/server/logging/kafkarest.go
+++ b/server/logging/kafkarest.go
@@ -1,0 +1,85 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	CONTENT_TYPE_MIME = "application/vnd.kafka.json.v1+json"
+	CONTENT_TYPE      = "Content-Type"
+	TIMESTAMP         = "TimeStamp"
+	URL_PUBLISH_TOPIC = "%s/topics/%s"
+)
+
+type KafkaRESTParams struct {
+	KafkaProxyHost string
+	KafkaTopic     string
+	KafkaTimeout   int
+}
+
+type kafkaRESTProducer struct {
+	client *http.Client
+	URL    string
+}
+
+type kafkaRecords struct {
+	Records []kafkaValue `json:"records"`
+}
+
+type kafkaValue struct {
+	Value json.RawMessage `json:"value"`
+}
+
+func NewKafkaRESTWriter(p *KafkaRESTParams) (*kafkaRESTProducer, error) {
+	return &kafkaRESTProducer{
+		URL: fmt.Sprintf(URL_PUBLISH_TOPIC, p.KafkaProxyHost, p.KafkaTopic),
+		client: &http.Client{
+			Timeout: time.Duration(p.KafkaTimeout) * time.Second,
+		},
+	}, nil
+}
+
+func (l *kafkaRESTProducer) Write(ctx context.Context, logs []json.RawMessage) error {
+	data := kafkaRecords{
+		Records: make([]kafkaValue, len(logs)),
+	}
+
+	for i, log := range logs {
+		data.Records[i] = kafkaValue{
+			Value: log,
+		}
+	}
+
+	output, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	resp, err := l.post(l.URL, bytes.NewBuffer(output))
+	if err != nil {
+		return err
+	}
+
+	resp.Body.Close()
+
+	return nil
+}
+
+func (l *kafkaRESTProducer) post(url string, buf *bytes.Buffer) (resp *http.Response, err error) {
+	req, err := http.NewRequest(http.MethodPost, url, buf)
+	if err != nil {
+		return
+	}
+
+	now := float64(time.Now().UnixNano()) / float64(time.Second)
+
+	req.Header.Set(CONTENT_TYPE, CONTENT_TYPE_MIME)
+	req.Header.Set(TIMESTAMP, fmt.Sprintf("%f", now))
+
+	return l.client.Do(req)
+}

--- a/server/logging/kafkarest_test.go
+++ b/server/logging/kafkarest_test.go
@@ -1,0 +1,1 @@
+package logging

--- a/server/logging/kafkarest_test.go
+++ b/server/logging/kafkarest_test.go
@@ -1,1 +1,0 @@
-package logging

--- a/server/logging/logging.go
+++ b/server/logging/logging.go
@@ -87,6 +87,15 @@ func New(config config.FleetConfig, logger log.Logger) (*OsqueryLogger, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "create stdout status logger")
 		}
+	case "kafkarest":
+		status, err = NewKafkaRESTWriter(&KafkaRESTParams{
+			KafkaProxyHost: config.KafkaREST.ProxyHost,
+			KafkaTopic: config.KafkaREST.StatusTopic,
+			KafkaTimeout: 10,
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "create kafka rest status logger")
+		}
 	default:
 		return nil, errors.Errorf(
 			"unknown status log plugin: %s", config.Osquery.StatusLogPlugin,
@@ -160,6 +169,15 @@ func New(config config.FleetConfig, logger log.Logger) (*OsqueryLogger, error) {
 		result, err = NewStdoutLogWriter()
 		if err != nil {
 			return nil, errors.Wrap(err, "create stdout result logger")
+		}
+	case "kafkarest":
+		status, err = NewKafkaRESTWriter(&KafkaRESTParams{
+			KafkaProxyHost: config.KafkaREST.ProxyHost,
+			KafkaTopic: config.KafkaREST.ResultTopic,
+			KafkaTimeout: 10,
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "create kafka rest status logger")
 		}
 	default:
 		return nil, errors.Errorf(

--- a/server/logging/logging.go
+++ b/server/logging/logging.go
@@ -171,13 +171,13 @@ func New(config config.FleetConfig, logger log.Logger) (*OsqueryLogger, error) {
 			return nil, errors.Wrap(err, "create stdout result logger")
 		}
 	case "kafkarest":
-		status, err = NewKafkaRESTWriter(&KafkaRESTParams{
+		result, err = NewKafkaRESTWriter(&KafkaRESTParams{
 			KafkaProxyHost: config.KafkaREST.ProxyHost,
 			KafkaTopic: config.KafkaREST.ResultTopic,
 			KafkaTimeout: 10,
 		})
 		if err != nil {
-			return nil, errors.Wrap(err, "create kafka rest status logger")
+			return nil, errors.Wrap(err, "create kafka rest result logger")
 		}
 	default:
 		return nil, errors.Errorf(

--- a/server/logging/logging.go
+++ b/server/logging/logging.go
@@ -90,8 +90,8 @@ func New(config config.FleetConfig, logger log.Logger) (*OsqueryLogger, error) {
 	case "kafkarest":
 		status, err = NewKafkaRESTWriter(&KafkaRESTParams{
 			KafkaProxyHost: config.KafkaREST.ProxyHost,
-			KafkaTopic: config.KafkaREST.StatusTopic,
-			KafkaTimeout: 10,
+			KafkaTopic:     config.KafkaREST.StatusTopic,
+			KafkaTimeout:   config.KafkaREST.Timeout,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "create kafka rest status logger")
@@ -173,8 +173,8 @@ func New(config config.FleetConfig, logger log.Logger) (*OsqueryLogger, error) {
 	case "kafkarest":
 		result, err = NewKafkaRESTWriter(&KafkaRESTParams{
 			KafkaProxyHost: config.KafkaREST.ProxyHost,
-			KafkaTopic: config.KafkaREST.ResultTopic,
-			KafkaTimeout: 10,
+			KafkaTopic:     config.KafkaREST.ResultTopic,
+			KafkaTimeout:   config.KafkaREST.Timeout,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "create kafka rest result logger")

--- a/server/service/service_appconfig.go
+++ b/server/service/service_appconfig.go
@@ -248,6 +248,14 @@ func (svc *Service) LoggingConfig(ctx context.Context) (*fleet.Logging, error) {
 		}
 	case "stdout":
 		logging.Status = fleet.LoggingPlugin{Plugin: "stdout"}
+	case "kafkarest":
+		logging.Status = fleet.LoggingPlugin{
+			Plugin: "kafkarest",
+			Config: fleet.KafkaRESTConfig{
+				StatusTopic: conf.KafkaREST.StatusTopic,
+				ProxyHost:   conf.KafkaREST.ProxyHost,
+			},
+		}
 	default:
 		return nil, errors.Errorf("unrecognized logging plugin: %s", conf.Osquery.StatusLogPlugin)
 	}
@@ -293,6 +301,14 @@ func (svc *Service) LoggingConfig(ctx context.Context) (*fleet.Logging, error) {
 	case "stdout":
 		logging.Result = fleet.LoggingPlugin{
 			Plugin: "stdout",
+		}
+	case "kafkarest":
+		logging.Result = fleet.LoggingPlugin{
+			Plugin: "kafkarest",
+			Config: fleet.KafkaRESTConfig{
+				ResultTopic: conf.KafkaREST.ResultTopic,
+				ProxyHost:   conf.KafkaREST.ProxyHost,
+			},
 		}
 	default:
 		return nil, errors.Errorf("unrecognized logging plugin: %s", conf.Osquery.ResultLogPlugin)


### PR DESCRIPTION
This PR implements the status/result logger functions necessary interface with a Kafka REST Proxy service.  

Specifically, this is compatible with the [Confluent KAFKA Rest Proxy Service ](https://docs.confluent.io/1.0/kafka-rest/docs/intro.html).

- [X] Manual QA for all new/changed functionality
This is running in our staging and production fleet.
