### PR TITLE
Edits to Fleet public load testing documentation

### DIFF
--- a/docs/02-Deploying/05-Fleet-public-load-testing.md
+++ b/docs/02-Deploying/05-Fleet-public-load-testing.md
@@ -4,11 +4,13 @@ The following document outlines the most recent results of a semi-annual load te
 
 Fleet uses [osquery-perf](https://github.com/fleetdm/fleet/tree/main/cmd/osquery-perf), a free and open source tool, to generate realistic traffic to the Fleet server.
 
+A test is deemed successful when the Fleet server is able to receive and make requests to the specified number of hosts without over utilizing the specified resources. In addition, a successful test must report that the Fleet server can run a live query against the specified number of hosts.
+
+This document reports the minimum resources for successfully running Fleet with 1,000 hosts and 150,000 hosts. 
+
 ## Test parameters
 
-The Fleet load tests are conducted with a Fleet server that contains 2 packs, with ~6 queries each, and 6 labels. 
-
-This document reports the minimum dependencies for successfully running Fleet with 1,000 hosts and 150,000 hosts. In addition, this document records the results of running live queries in each scenario.
+The Fleet load tests are conducted with a Fleet server that contains 2 packs, with ~6 queries each, and 6 labels.
 
 ## How we are simulating osquery
 
@@ -37,7 +39,9 @@ terraform apply \
   -var fleet_min_capacity=5
 ```
 
-## 1,000 hosts
+## Results
+
+### 1,000 hosts
 
 Fleet instances:
 - 1 Fargate Task
@@ -54,7 +58,7 @@ MySQL:
 
 With the above infrastructure, 1,000 hosts successfully communicate with Fleet. The Fleet server is able to run live queries against all hosts.
 
-## 150,000 hosts
+### 150,000 hosts
 
 Fleet instances:
 - 25 Task

--- a/docs/02-Deploying/05-Fleet-public-load-testing.md
+++ b/docs/02-Deploying/05-Fleet-public-load-testing.md
@@ -1,6 +1,6 @@
 # Load testing
 
-The following document outlines the most recent results of a semi-annual load test on the Fleet server conducted by the Fleet team. 
+The following document outlines the most recent results of a semi-annual load test of the Fleet server. These tests are conducted by the Fleet team. 
 
 Fleet uses [osquery-perf](https://github.com/fleetdm/fleet/tree/main/cmd/osquery-perf), a free and open source tool, to generate realistic traffic to the Fleet server.
 
@@ -43,6 +43,8 @@ terraform apply \
 
 ### 1,000 hosts
 
+With the infrastructure listed below, 1,000 hosts successfully communicate with Fleet. The Fleet server is able to run live queries against all hosts.
+
 Fleet instances:
 - 1 Fargate Task
 - 256 CPU units
@@ -56,9 +58,9 @@ MySQL:
 - Version: 5.7.mysql_aurora.2.10.0
 - Instance type: db.t4g.medium
 
-With the above infrastructure, 1,000 hosts successfully communicate with Fleet. The Fleet server is able to run live queries against all hosts.
-
 ### 150,000 hosts
+
+With the infrastructure listed below, 150,000 hosts successfully communicate with Fleet. The Fleet server is able to run live queries against all hosts.
 
 Fleet instances:
 - 25 Task
@@ -72,8 +74,6 @@ Redis:
 MySQL:
 - Version: 5.7.mysql_aurora.2.10.0
 - Instance: db.r5.4xlarge
-
-With the above infrastructure, 150,000 hosts successfully communicate with Fleet. The Fleet server is able to run live queries against all hosts.
 
 The above setup auto scaled based on CPU usage. After a while, the task count ended up in 25 instances even while live querying or adding a new label. 
 

--- a/docs/02-Deploying/05-Fleet-public-load-testing.md
+++ b/docs/02-Deploying/05-Fleet-public-load-testing.md
@@ -1,19 +1,26 @@
 # Load testing
 
-## Baseline Test
+The following document outlines the most recent results of a semi-annual load test on the Fleet server conducted by the Fleet team. 
 
-Baseline setup: 6 custom labels, 6 policies, and 2 packs with ~6 queries each, and be able to live query all the hosts.
+Fleet uses [osquery-perf](https://github.com/fleetdm/fleet/tree/main/cmd/osquery-perf), a free and open source tool, to generate realistic traffic to the Fleet server.
+
+## Test parameters
+
+The Fleet load tests are conducted with a Fleet server that contains 2 packs, with ~6 queries each, and 6 labels. 
+
+This document reports the minimum dependencies for successfully running Fleet with 1,000 hosts and 150,000 hosts. In addition, this document records the results of running live queries in each scenario.
 
 ## How we are simulating osquery
 
-The simulation is run by using [osquery-perf](https://github.com/fleetdm/fleet/tree/main/cmd/osquery-perf) using the following command:
+The simulation is run by using [osquery-perf](https://github.com/fleetdm/fleet/tree/main/cmd/osquery-perf).
+
+The following command enrolls and simulates 150,000 hosts on Fleet:
 
 ```bash
 go run cmd/osquery-perf/agent.go -enroll_secret <secret here> -host_count 150000 -server_url <server URL here> -node_key_file nodekeys
 ```
 
-After the hosts have been enrolled, you can simply add `-only_already_enrolled` to make sure the node keys from the file 
-are used and no enrollment happens, virtually "resuming" the execution of all the simulated hosts.
+After the hosts have been enrolled, you can add `-only_already_enrolled` to make sure the node keys from the file are used and no enrollment happens. This "resumes" the execution of all the simulated hosts.
 
 ## Infrastructure setup
 
@@ -30,44 +37,42 @@ terraform apply \
   -var fleet_min_capacity=5
 ```
 
-## Bare minimum setup
+## 1,000 hosts
 
 Fleet instances:
 - 1 Fargate Task
 - 256 CPU units
 - 512 MB of memory
-- Amount of hosts: 1000
 
 Redis: 
 - Version: 5.0.6
 - Instance type: cache.m5.large
 
-Mysql:
+MySQL:
 - Version: 5.7.mysql_aurora.2.10.0
 - Instance type: db.t4g.medium
 
-With the above infrastructure, 1000 hosts were able to run and be live query without a problem.
+With the above infrastructure, 1,000 hosts successfully communicate with Fleet. The Fleet server is able to run live queries against all hosts.
 
-## 150k hosts
+## 150,000 hosts
 
 Fleet instances:
 - 25 Task
 - 1024 CPU units
 - 2048 MB of memory
-- Amount of hosts: 150000k
 
 Redis:
 - Version: 5.0.6
 - Instance: cache.m5.large
 
-Mysql:
+MySQL:
 - Version: 5.7.mysql_aurora.2.10.0
 - Instance: db.r5.4xlarge
 
-The setup auto scaled based on CPU usage. After a while, the task count ended up in 25 instances even while live querying 
-or adding a new label. 
+With the above infrastructure, 150,000 hosts successfully communicate with Fleet. The Fleet server is able to run live queries against all hosts.
 
-## Limitations of the test
+The above setup auto scaled based on CPU usage. After a while, the task count ended up in 25 instances even while live querying or adding a new label. 
 
-While osquery-perf simulates enough of osquery to be a good first step, it's not the smartest simulation as of the time of
-this writing. Particularly, it doesn't simulate host users and software inventory yet.
+## Limitations
+
+The [osquery-perf](https://github.com/fleetdm/fleet/tree/main/cmd/osquery-perf) tool doesn't simulate all data that's included when a real device communicates to a Fleet instance. For example, system users and software inventory data are not yet simulated by osquery-perf.

--- a/docs/02-Deploying/05-Fleet-public-load-testing.md
+++ b/docs/02-Deploying/05-Fleet-public-load-testing.md
@@ -20,7 +20,7 @@ The following command enrolls and simulates 150,000 hosts on Fleet:
 go run cmd/osquery-perf/agent.go -enroll_secret <secret here> -host_count 150000 -server_url <server URL here> -node_key_file nodekeys
 ```
 
-After the hosts have been enrolled, you can add `-only_already_enrolled` to make sure the node keys from the file are used and no enrollment happens. This "resumes" the execution of all the simulated hosts.
+After the hosts have been enrolled, you can add `-only_already_enrolled` to make sure the node keys from the file are used and no enrollment happens. This resumes the execution of all the simulated hosts.
 
 ## Infrastructure setup
 


### PR DESCRIPTION
- Add a summary to the top of the document
- Rename "Baseline Test" section to "Test parameters"
- Rename "Bare minimum setup" section to "1,000 hosts"
- Several smaller edits that call out the number of hosts tested and the results (did Fleet work?)
