### PR TITLE
Bug Fix: Loading veil

### DIFF
--- a/changes/issue-2505-loading-veil
+++ b/changes/issue-2505-loading-veil
@@ -1,0 +1,1 @@
+* Bug fix: Loading veil covers all of the host table during loading

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -265,12 +265,12 @@ const DataTable = ({
 
   return (
     <div className={baseClass}>
+      {isLoading && (
+        <div className={"loading-overlay"}>
+          <Spinner />
+        </div>
+      )}
       <div className={"data-table data-table__wrapper"}>
-        {isLoading && (
-          <div className={"loading-overlay"}>
-            <Spinner />
-          </div>
-        )}
         <table className={"data-table__table"}>
           {Object.keys(selectedRowIds).length !== 0 && (
             <thead className={"active-selection"}>

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -1,5 +1,7 @@
 .data-table-container {
   position: relative;
+  display: inline-block;
+  width: 100%;
 
   .data-table {
     &__wrapper {
@@ -8,6 +10,8 @@
       border-radius: 6px;
       margin-top: $pad-small;
       box-shadow: inset -8px 0 17px -10px #e8edf4;
+      flex-grow: 1;
+      width: 100%;
     }
 
     &__table {
@@ -198,15 +202,16 @@
         text-transform: uppercase;
       }
     }
-
-    .loading-overlay {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      background-color: rgba(255, 255, 255, 0.8);
-      z-index: 1;
-    }
+  }
+  .loading-overlay {
+    display: flex;
+    flex-grow: 1;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: rgba(255, 255, 255, 0.8);
+    z-index: 1;
   }
 }


### PR DESCRIPTION
Cerra #2505 

How do you get the loading veil to cover a table with variable width with a horizontal scroll?
You stop trying to get it to cover the table and start trying to get it to cover the wrapper.

- DataTable component's "Loading veil" covers the entire table wrapper on load (bug fix is on host page where there's a horizontal scroll)

<img width="1130" alt="Screen Shot 2021-10-15 at 10 41 42 AM" src="https://user-images.githubusercontent.com/71795832/137505993-9d24839c-f216-4e99-96f9-93dc123b9943.png">
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
