### PR TITLE
Dashboard: Fix activity feed verbage

### DIFF
--- a/changes/issue-2419-human-readable-activities
+++ b/changes/issue-2419-human-readable-activities
@@ -1,0 +1,1 @@
+* Update activity feed verbage

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -1,4 +1,5 @@
 import PropTypes from "prop-types";
+import { IQuery } from "./query";
 
 export enum ActivityType {
   CreatedPack = "created_pack",
@@ -10,8 +11,8 @@ export enum ActivityType {
   CreatedTeam = "created_team",
   DeletedTeam = "deleted_team",
   LiveQuery = "live_query",
-  AppliedPackSpec = "applied_pack_spec",
-  AppliedQuerySpec = "applied_query_spec",
+  AppliedSpecPack = "applied_spec_pack",
+  AppliedSpecSavedQuery = "applied_spec_saved_query",
 }
 export interface IActivity {
   created_at: string;
@@ -31,6 +32,7 @@ export interface IActivityDetails {
   team_id?: number;
   team_name?: string;
   targets_count?: number;
+  specs?: IQuery[];
 }
 
 export default PropTypes.shape({

--- a/frontend/pages/Homepage/ActivityFeed/ActivityFeed.tsx
+++ b/frontend/pages/Homepage/ActivityFeed/ActivityFeed.tsx
@@ -27,15 +27,27 @@ const TAGGED_TEMPLATES = {
       ? "ran a live query"
       : `ran a live query on ${count} ${count === 1 ? "host" : "hosts"}`;
   },
+  editPackCtlActivityTemplate: () => {
+    return "edited a pack using fleetctl";
+  },
+  editQueryCtlActivityTemplate: (activity: IActivity) => {
+    const count = activity.details?.specs?.length;
+    return typeof count === "undefined" || typeof count !== "number"
+      ? "edited a query using fleetctl"
+      : `edited ${count === 1 ? "a query" : "queries"} using fleetctl`;
+  },
   defaultActivityTemplate: (activity: IActivity) => {
     const entityName = find(activity.details, (_, key) =>
       key.includes("_name")
     );
+
+    const activityType = lowerCase(activity.type).replace(" saved", "");
+
     return !entityName ? (
-      `${lowerCase(activity.type)}`
+      `${activityType}`
     ) : (
       <span>
-        {lowerCase(activity.type)} <b>{entityName}</b>
+        {activityType} <b>{entityName}</b>
       </span>
     );
   },
@@ -77,6 +89,12 @@ const ActivityFeed = (): JSX.Element => {
   const getDetail = (activity: IActivity) => {
     if (activity.type === ActivityType.LiveQuery) {
       return TAGGED_TEMPLATES.liveQueryActivityTemplate(activity);
+    }
+    if (activity.type === ActivityType.AppliedSpecPack) {
+      return TAGGED_TEMPLATES.editPackCtlActivityTemplate();
+    }
+    if (activity.type === ActivityType.AppliedSpecSavedQuery) {
+      return TAGGED_TEMPLATES.editQueryCtlActivityTemplate(activity);
     }
     return TAGGED_TEMPLATES.defaultActivityTemplate(activity);
   };
@@ -146,6 +164,7 @@ const ActivityFeed = (): JSX.Element => {
   const renderActivities = activities.map((activity: IActivity, i: number) =>
     renderActivityBlock(activity, i)
   );
+
   return (
     <div className={baseClass}>
       {isLoadingError && renderError()}


### PR DESCRIPTION
# Checklist for submitter

Update verbage of activity feed according to figma for:
- packs/queries using Fleet CTL
- queries replacing the phrase "saved query" with just "query"

<img width="1285" alt="Screen Shot 2021-10-15 at 2 04 03 PM" src="https://user-images.githubusercontent.com/71795832/137532682-dc2ae508-d191-4adf-af6c-0be6b22b1e86.png">


If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
