### PR TITLE
Team Settings: Edit team modal can hit enter to save team name

### DIFF
--- a/changes/issue-1620-team-modal-hit-enter
+++ b/changes/issue-1620-team-modal-hit-enter
@@ -1,0 +1,1 @@
+* Can hit enter to add team or edit team

--- a/cypress/integration/all/app/labelflow.spec.ts
+++ b/cypress/integration/all/app/labelflow.spec.ts
@@ -65,7 +65,7 @@ describe(
       // delete custom label
       cy.get(".manage-hosts__label-block button").last().click();
 
-      cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.get(".manage-hosts__modal-buttons > .button--alert")
         .contains("button", /delete/i)
         .click();

--- a/frontend/pages/admin/TeamManagementPage/components/EditTeamModal/EditTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/EditTeamModal/EditTeamModal.tsx
@@ -37,7 +37,7 @@ const EditTeamModal = (props: IEditTeamModalProps): JSX.Element => {
 
   return (
     <Modal title={"Edit team"} onExit={onCancel} className={baseClass}>
-      <form className={`${baseClass}__form`}>
+      <form className={`${baseClass}__form`} onSubmit={onFormSubmit}>
         <InputFieldWithIcon
           autofocus
           // error={errors.name}
@@ -47,12 +47,7 @@ const EditTeamModal = (props: IEditTeamModalProps): JSX.Element => {
           value={name}
         />
         <div className={`${baseClass}__btn-wrap`}>
-          <Button
-            className={`${baseClass}__btn`}
-            type="button"
-            variant="brand"
-            onClick={onFormSubmit}
-          >
+          <Button className={`${baseClass}__btn`} type="submit" variant="brand">
             Save
           </Button>
           <Button


### PR DESCRIPTION
Cerra #1620 

- Already functional to hit enter to create team
- Added functionality to hit enter to edit team

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
