### PR TITLE
Host Details Page: Spiffier vertically centered header

### DIFF
--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -147,10 +147,11 @@
     flex-direction: row;
     justify-content: space-between;
     margin: 0;
+    min-width: 758px;
 
     .hostname-container {
       display: flex;
-      align-items: flex-end;
+      align-items: center;
     }
 
     .hostname {
@@ -172,8 +173,8 @@
         color: $core-vibrant-blue;
         cursor: default;
         font-size: $x-small;
-        display: inline;
-        margin: 9px 0 0 0; // aligns with spinner
+        height: 38px;
+        margin-right: $pad-small;
 
         &::before {
           display: inline-block;
@@ -181,8 +182,7 @@
           padding: 5px 0 0 0; // centers spin
           content: url(../assets/images/icon-refetch-12x12@2x.png);
           transform: scale(0.5);
-          vertical-align: bottom;
-          height: 20px;
+          height: 28px;
         }
 
         &:hover {
@@ -202,14 +202,13 @@
         color: $core-vibrant-blue;
         cursor: default;
         font-size: $x-small;
-        display: inline;
+        height: 38px;
         opacity: 50%;
         filter: saturate(100%);
 
         &::before {
           display: inline-block;
           position: relative;
-          top: 7px; // aligns with text
           padding: 5px 0 0 0; // centers spin
           display: inline-block;
           content: url(../assets/images/icon-refetch-12x12@2x.png);
@@ -304,7 +303,7 @@
 
   &__action-button-container {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
   }
 
   &__query-button,

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -147,7 +147,6 @@
     flex-direction: row;
     justify-content: space-between;
     margin: 0;
-    min-width: 758px;
 
     .hostname-container {
       display: flex;
@@ -168,6 +167,7 @@
 
     .refetch {
       display: flex;
+      margin-right: $pad-small;
 
       .refetch-btn {
         color: $core-vibrant-blue;


### PR DESCRIPTION
Cerra #2563 

- The refetch button aligns with the right side buttons
- Min width: 840px

Screenshots  (840 px, 840px, 1040px)

<img width="736" alt="Screen Shot 2021-10-18 at 6 34 58 PM" src="https://user-images.githubusercontent.com/71795832/137816104-930b2b4b-20f4-49d3-8f83-8f957a07ac1b.png">
<img width="745" alt="Screen Shot 2021-10-18 at 6 35 09 PM" src="https://user-images.githubusercontent.com/71795832/137816106-0e9e6c69-95e8-4674-beb3-b9a925a9a3fb.png">
<img width="920" alt="Screen Shot 2021-10-18 at 6 35 31 PM" src="https://user-images.githubusercontent.com/71795832/137816107-756986dc-2d34-40f4-86a4-584219201ac8.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
