### PR TITLE
Fix subsequent delete checkbox state

### DIFF
--- a/changes/issue-2525-resets-checkboxes-subsequent-deletes
+++ b/changes/issue-2525-resets-checkboxes-subsequent-deletes
@@ -1,0 +1,1 @@
+* Bug Fix: All app table checkboxes reset after subsequent deletes

--- a/frontend/components/flash_messages/FlashMessage/FlashMessage.tsx
+++ b/frontend/components/flash_messages/FlashMessage/FlashMessage.tsx
@@ -32,13 +32,30 @@ const FlashMessage = ({
     [`${baseClass}--full-width`]: fullWidth,
   });
 
-  if (alertType === "success") {
-    setTimeout(() => {
-      onRemoveFlash();
-    }, 4000);
-  }
+  const [hide, setHide] = useState(false);
 
-  if (!isVisible) {
+  // This useEffect handles hiding successful flash messages after a 4s timeout. By putting the
+  // notification in the dependency array, we can properly reset whenever a new flash message comes through.
+  useEffect(() => {
+    // Any time this hook runs, we reset the hide to false (so that subsequent messages that will be
+    // using this same component instance will be visible).
+    setHide(false);
+
+    if (alertType === "success" && isVisible) {
+      // After 4 seconds, set hide to true.
+      const timer = setTimeout(() => {
+        setHide(true);
+        onRemoveFlash();
+      }, 4000);
+      // Return a cleanup function that will clear this reset, in case another render happens
+      // after this. We want that render to set a new timeout (if needed).
+      return () => clearTimeout(timer);
+    }
+
+    return undefined; // No cleanup when we don't set a timeout.
+  }, [notification, alertType, isVisible, setHide]);
+
+  if (hide || !isVisible) {
     return false;
   }
 

--- a/frontend/components/flash_messages/FlashMessage/FlashMessage.tsx
+++ b/frontend/components/flash_messages/FlashMessage/FlashMessage.tsx
@@ -32,27 +32,13 @@ const FlashMessage = ({
     [`${baseClass}--full-width`]: fullWidth,
   });
 
-  const [hide, setHide] = useState(false);
+  if (alertType === "success") {
+    setTimeout(() => {
+      onRemoveFlash();
+    }, 4000);
+  }
 
-  // This useEffect handles hiding successful flash messages after a 4s timeout. By putting the
-  // notification in the dependency array, we can properly reset whenever a new flash message comes through.
-  useEffect(() => {
-    // Any time this hook runs, we reset the hide to false (so that subsequent messages that will be
-    // using this same component instance will be visible).
-    setHide(false);
-
-    if (alertType === "success" && isVisible) {
-      // After 4 seconds, set hide to true.
-      const timer = setTimeout(() => setHide(true), 4000);
-      // Return a cleanup function that will clear this reset, in case another render happens
-      // after this. We want that render to set a new timeout (if needed).
-      return () => clearTimeout(timer);
-    }
-
-    return undefined; // No cleanup when we don't set a timeout.
-  }, [notification, alertType, isVisible, setHide]);
-
-  if (hide || !isVisible) {
+  if (!isVisible) {
     return false;
   }
 

--- a/frontend/components/flash_messages/FlashMessage/FlashMessage.tsx
+++ b/frontend/components/flash_messages/FlashMessage/FlashMessage.tsx
@@ -45,7 +45,7 @@ const FlashMessage = ({
       // After 4 seconds, set hide to true.
       const timer = setTimeout(() => {
         setHide(true);
-        onRemoveFlash();
+        onRemoveFlash(); // This function resets notifications which allows CoreLayout reset of selected rows
       }, 4000);
       // Return a cleanup function that will clear this reset, in case another render happens
       // after this. We want that render to set a new timeout (if needed).


### PR DESCRIPTION
Cerra #2525 

- Checkboxes reset after hitting subsequent delete


This is going to sound strange following the rabbit hole:
1. Figured out the subsequent delete checkbox problem was app wide, not just `ManageHostPage.tsx`
2. Went straight to `DataTable.tsx` for a solution
3. Data table updates using context/table `RESET_SELECTED_ROWS`
4. Reset selected rows was not firing on second delete... so why... 
5. Found out it was looking into `if (!isEqual(this.props.notifications, notifications))` in `CoreLayout.tsx`
6. So I tried to see where `this.props.notifications` comes from and `notifications` comes from (which is a little too abstract for me)
7. So I `console.log(notifications)` to find out it would only fire on the first success message, even though the second success message would properly show.. meaning `state.notifications` was somehow the reason the `CoreLayout.tsx` would not reset selected rows...
8. So I followed the rabbit hole into notifications and how it was being used in `FlashMessage.tsx` and why is it that it's not resetting `state.notifications`... Oh, because it's hiding the message NOT updating `state.notifications`... but if you hit the X on the success flash message, it would update `state.notifications` and everything would work properly.
9. I just made the flashmessage fire using the `onRemoveFlash` as if it clicked the X which updates `state.notification` and next time the checkboxes will be able to reset.
10. Voila.
11. "success" notification now resets after 4 seconds causing checkboxes to be able to be reset

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
