### PR TITLE
Fix search bar active state on documentation and handbook pages on Safari

### DIFF
--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -58,9 +58,6 @@
     animation-duration: 4s;
     animation-fill-mode: forwards;
   }
-  .markdown-heading.copied:hover::before {
-    // right: -15px;
-  }
 
   @keyframes copiedText {
     0% {opacity: 0;}
@@ -101,7 +98,7 @@
       width: 98%;
     }
 
-    .ds-input:focus-visible {
+    .ds-input:focus {
       outline: rgba(0, 0, 0, 0);
     }
 

--- a/website/assets/styles/pages/handbook/basic-handbook.less
+++ b/website/assets/styles/pages/handbook/basic-handbook.less
@@ -43,7 +43,7 @@
       width: 98%;
     }
 
-    .ds-input:focus-visible {
+    .ds-input:focus {
       outline: rgba(0, 0, 0, 0);
     }
 


### PR DESCRIPTION
Closes #2562 

changes:
- Updated the search bar styles to disable the default focus state on Safari

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
