### PR TITLE
Make migrations compatible with GTID replication

### DIFF
--- a/changes/gtid-replication
+++ b/changes/gtid-replication
@@ -1,0 +1,1 @@
+* Fix migration compatibility with MySQL GTID replication.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,15 @@ services:
     platform: linux/x86_64
     volumes:
       - mysql-persistent-volume:/tmp
-    # Run MySQL with GTID consistency enforced to avoid issues with production deployments that use it.
-    command: mysqld --datadir=/tmp/mysqldata --event-scheduler=ON --enforce-gtid-consistency=ON --log-bin=bin.log --server-id=master-01
+    command: [
+        "mysqld",
+        "--datadir=/tmp/mysqldata",
+        "--event-scheduler=ON",
+        # These 3 keys run MySQL with GTID consistency enforced to avoid issues with production deployments that use it.
+        "--enforce-gtid-consistency=ON",
+        "--log-bin=bin.log",
+        "--server-id=master-01",
+      ]
     environment: &mysql-default-environment
       MYSQL_ROOT_PASSWORD: toor
       MYSQL_DATABASE: fleet
@@ -21,8 +28,19 @@ services:
     image: ${FLEET_MYSQL_IMAGE:-mysql:5.7}
     platform: linux/x86_64
     # innodb-file-per-table=OFF gives ~20% speedup for test runs.
-    # Run MySQL with GTID consistency enforced to avoid issues with production deployments that use it.
-    command: mysqld --datadir=/tmpfs --slow_query_log=1 --log_output=TABLE --log-queries-not-using-indexes --event-scheduler=ON --innodb-file-per-table=OFF --enforce-gtid-consistency=ON --log-bin=bin.log --server-id=master-01
+    command: [
+        "mysqld",
+        "--datadir=/tmpfs",
+        "--slow_query_log=1",
+        "--log_output=TABLE",
+        "--log-queries-not-using-indexes",
+        "--event-scheduler=ON",
+        "--innodb-file-per-table=OFF",
+        # These 3 keys run MySQL with GTID consistency enforced to avoid issues with production deployments that use it.
+        "--enforce-gtid-consistency=ON",
+        "--log-bin=bin.log",
+        "--server-id=master-01",
+      ]
     environment: *mysql-default-environment
     ports:
       - "3307:3306"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '2'
+version: "2"
 services:
   # To test with MariaDB, set FLEET_MYSQL_IMAGE to mariadb:10.6 or the like.
   mysql:
@@ -7,7 +7,8 @@ services:
     platform: linux/x86_64
     volumes:
       - mysql-persistent-volume:/tmp
-    command: mysqld --datadir=/tmp/mysqldata --event-scheduler=ON
+    # Run MySQL with GTID consistency enforced to avoid issues with production deployments that use it.
+    command: mysqld --datadir=/tmp/mysqldata --event-scheduler=ON --enforce-gtid-consistency=ON --log-bin=bin.log --server-id=master-01
     environment: &mysql-default-environment
       MYSQL_ROOT_PASSWORD: toor
       MYSQL_DATABASE: fleet
@@ -20,7 +21,8 @@ services:
     image: ${FLEET_MYSQL_IMAGE:-mysql:5.7}
     platform: linux/x86_64
     # innodb-file-per-table=OFF gives ~20% speedup for test runs.
-    command: mysqld --datadir=/tmpfs --slow_query_log=1 --log_output=TABLE --log-queries-not-using-indexes --event-scheduler=ON --innodb-file-per-table=OFF
+    # Run MySQL with GTID consistency enforced to avoid issues with production deployments that use it.
+    command: mysqld --datadir=/tmpfs --slow_query_log=1 --log_output=TABLE --log-queries-not-using-indexes --event-scheduler=ON --innodb-file-per-table=OFF --enforce-gtid-consistency=ON --log-bin=bin.log --server-id=master-01
     environment: *mysql-default-environment
     ports:
       - "3307:3306"
@@ -57,7 +59,7 @@ services:
     image: redis:5
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
-      - '7001:7001'
+      - "7001:7001"
     volumes:
       - ./tools/redis-tests/redis-cluster-1.conf:/usr/local/etc/redis/redis.conf
     networks:
@@ -68,7 +70,7 @@ services:
     image: redis:5
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
-      - '7002:7002'
+      - "7002:7002"
     volumes:
       - ./tools/redis-tests/redis-cluster-2.conf:/usr/local/etc/redis/redis.conf
     networks:
@@ -79,7 +81,7 @@ services:
     image: redis:5
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
-      - '7003:7003'
+      - "7003:7003"
     volumes:
       - ./tools/redis-tests/redis-cluster-3.conf:/usr/local/etc/redis/redis.conf
     networks:
@@ -90,7 +92,7 @@ services:
     image: redis:5
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
-      - '7004:7004'
+      - "7004:7004"
     volumes:
       - ./tools/redis-tests/redis-cluster-4.conf:/usr/local/etc/redis/redis.conf
     networks:
@@ -101,7 +103,7 @@ services:
     image: redis:5
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
-      - '7005:7005'
+      - "7005:7005"
     volumes:
       - ./tools/redis-tests/redis-cluster-5.conf:/usr/local/etc/redis/redis.conf
     networks:
@@ -112,7 +114,7 @@ services:
     image: redis:5
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
-      - '7006:7006'
+      - "7006:7006"
     volumes:
       - ./tools/redis-tests/redis-cluster-6.conf:/usr/local/etc/redis/redis.conf
     networks:
@@ -122,8 +124,8 @@ services:
   saml_idp:
     image: fleetdm/docker-idp:latest
     environment:
-      SIMPLESAMLPHP_SP_ENTITY_ID: 'https://localhost:8080'
-      SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE: 'https://localhost:8080/api/v1/fleet/sso/callback'
+      SIMPLESAMLPHP_SP_ENTITY_ID: "https://localhost:8080"
+      SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE: "https://localhost:8080/api/v1/fleet/sso/callback"
     volumes:
       - ./tools/saml/users.php:/var/www/simplesamlphp/config/authsources.php
     ports:

--- a/server/datastore/mysql/migrations/tables/20210819131107_AddCascadeToHostSoftware.go
+++ b/server/datastore/mysql/migrations/tables/20210819131107_AddCascadeToHostSoftware.go
@@ -32,30 +32,30 @@ func Up_20210819131107(tx *sql.Tx) error {
 
 	// Clear any orphan software and host_software
 	// Note that we can't use CREATE TEMPORARY TABLE here as it caused problems in some MySQL
-	// configurations. See https://github.com/fleetdm/fleet/issues/2462.
-	_, err = tx.Exec(`CREATE TABLE temp_host_software AS SELECT * FROM host_software;`)
+	// configurations (GTID replication). See https://github.com/fleetdm/fleet/issues/2462.
+	_, err = tx.Exec(`CREATE TABLE IF NOT EXISTS temp_host_software LIKE host_software`)
 	if err != nil {
-		return errors.Wrap(err, "save current host software to a temp table")
+		return errors.Wrap(err, "")
 	}
-	_, err = tx.Exec(`DELETE FROM host_software;`)
-	if err != nil {
-		return errors.Wrap(err, "clear all host software")
-	}
-
 	if _, err := tx.Exec(`
-		ALTER TABLE host_software
+		ALTER TABLE temp_host_software
 		ADD FOREIGN KEY host_software_hosts_fk(host_id) REFERENCES hosts (id) ON DELETE CASCADE,
 		ADD FOREIGN KEY host_software_software_fk(software_id) REFERENCES software (id) ON DELETE CASCADE
 	`); err != nil {
 		return errors.Wrap(err, "add fk on host_software hosts & software")
 	}
 
-	_, err = tx.Exec(`INSERT IGNORE INTO host_software SELECT * FROM temp_host_software;`)
+	_, err = tx.Exec(`INSERT IGNORE INTO temp_host_software SELECT * FROM host_software;`)
 	if err != nil {
-		return errors.Wrap(err, "reinserting host software")
+		return errors.Wrap(err, "reinsert host software")
 	}
 
-	_, err = tx.Exec(`DROP TABLE temp_host_software;`)
+	_, err = tx.Exec(`DROP TABLE host_software;`)
+	if err != nil {
+		return errors.Wrap(err, "clear all host software")
+	}
+
+	_, err = tx.Exec(`RENAME TABLE temp_host_software TO host_software`)
 	if err != nil {
 		return errors.Wrap(err, "dropping temp table")
 	}

--- a/server/datastore/mysql/migrations/tables/20210819131107_AddCascadeToHostSoftware.go
+++ b/server/datastore/mysql/migrations/tables/20210819131107_AddCascadeToHostSoftware.go
@@ -45,12 +45,12 @@ func Up_20210819131107(tx *sql.Tx) error {
 		return errors.Wrap(err, "add fk on host_software hosts & software")
 	}
 
-	_, err = tx.Exec(`INSERT IGNORE INTO temp_host_software SELECT * FROM host_software;`)
+	_, err = tx.Exec(`INSERT IGNORE INTO temp_host_software SELECT * FROM host_software`)
 	if err != nil {
 		return errors.Wrap(err, "reinsert host software")
 	}
 
-	_, err = tx.Exec(`DROP TABLE host_software;`)
+	_, err = tx.Exec(`DROP TABLE IF EXISTS host_software`)
 	if err != nil {
 		return errors.Wrap(err, "clear all host software")
 	}

--- a/server/datastore/mysql/testing_utils.go
+++ b/server/datastore/mysql/testing_utils.go
@@ -52,6 +52,8 @@ func connectMySQL(t *testing.T, testName string, opts *DatastoreTestOptions) *Da
 }
 
 func setupReadReplica(t *testing.T, testName string, ds *Datastore, opts *DatastoreTestOptions) {
+	t.Helper()
+
 	// create the context that will cancel the replication goroutine on test exit
 	var cancel func()
 	ctx := context.Background()
@@ -132,7 +134,11 @@ func setupReadReplica(t *testing.T, testName string, ds *Datastore, opts *Datast
 					t.Log(stmt)
 					_, err = replica.ExecContext(ctx, stmt)
 					require.NoError(t, err)
-					stmt = fmt.Sprintf(`CREATE TABLE %s.%s SELECT * FROM %s.%s`, replicaDB, tbl, testName, tbl)
+					stmt = fmt.Sprintf(`CREATE TABLE %s.%s LIKE %s.%s`, replicaDB, tbl, testName, tbl)
+					t.Log(stmt)
+					_, err = replica.ExecContext(ctx, stmt)
+					require.NoError(t, err)
+					stmt = fmt.Sprintf(`INSERT INTO %s.%s SELECT * FROM %s.%s`, replicaDB, tbl, testName, tbl)
 					t.Log(stmt)
 					_, err = replica.ExecContext(ctx, stmt)
 					require.NoError(t, err)


### PR DESCRIPTION
Fixes an issue some deployments encountered when migrations used a
statement that is unsupported in GTID replication mode (#2462).

Local dev MySQL now enforces this consistency, so it should be easier to
maintain compatibility going forward.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Documented any API changes - None
- [x] Documented any permissions changes - None
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
