### PR TITLE
Handle null resolution in host details

### DIFF
--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -938,7 +938,7 @@ func (d *Datastore) ListPoliciesForHost(ctx context.Context, hid uint) (packs []
 			ELSE '' 
 		END AS response,
 		q.description,
-		p.resolution
+		coalesce(p.resolution, '') as resolution
 	FROM (
 	    SELECT * FROM policy_membership_history WHERE id IN (
 	        SELECT max(id) AS id FROM policy_membership_history WHERE host_id=? GROUP BY host_id, policy_id

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -305,9 +305,17 @@ func testPolicyQueriesForHost(t *testing.T, ds *Datastore) {
 	require.NoError(t, ds.RecordPolicyQueryExecutions(
 		context.Background(), host2, map[uint]*bool{gp.ID: nil}, time.Now()))
 
+	// insert a null resolution
+	res, err := ds.writer.ExecContext(context.Background(), `INSERT INTO policies (query_id) VALUES (?)`, q.ID)
+	require.NoError(t, err)
+	id, err := res.LastInsertId()
+	require.NoError(t, err)
+	require.NoError(t, ds.RecordPolicyQueryExecutions(
+		context.Background(), host2, map[uint]*bool{uint(id): nil}, time.Now()))
+
 	policies, err = ds.ListPoliciesForHost(context.Background(), host2.ID)
 	require.NoError(t, err)
-	require.Len(t, policies, 1)
+	require.Len(t, policies, 2)
 
 	assert.Equal(t, "query1 desc", policies[0].QueryDescription)
 	assert.Equal(t, "some gp resolution", policies[0].Resolution)


### PR DESCRIPTION
TEXT columns cannot have a default in MySQL 5.7, so we need to do this kind of thing.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- ~Changes file added (for user-visible changes)~
- ~Documented any API changes~
- ~Documented any permissions changes~
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
