### PR TITLE
Change default organization name for Fleet preview

### DIFF
--- a/changes/Issue-2281-fleet-preview-name
+++ b/changes/Issue-2281-fleet-preview-name
@@ -1,0 +1,1 @@
+* Change fleetctl preview default organization name from "Fleet Preview" to "Fleet for osquery" 

--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -141,7 +141,7 @@ Use the stop and reset subcommands to manage the server and dependencies once st
 				return errors.Wrap(err, "Error creating Fleet API client handler")
 			}
 
-			token, err := fleetClient.Setup(email, "Admin", password, "Fleet Preview")
+			token, err := fleetClient.Setup(email, "Admin", password, "Fleet for osquery")
 			if err != nil {
 				switch errors.Cause(err).(type) {
 				case service.SetupAlreadyErr:
@@ -232,7 +232,8 @@ Use the stop and reset subcommands to manage the server and dependencies once st
 
 			// disable anonymous analytics collection for preview
 			if err := client.ApplyAppConfig(map[string]map[string]bool{
-				"server_settings": {"enable_analytics": false}},
+				"server_settings": {"enable_analytics": false},
+			},
 			); err != nil {
 				return errors.Wrap(err, "Error disabling anonymous analytics collection in app config")
 			}


### PR DESCRIPTION
- Change fleetctl preview default organization name from "Fleet Preview" to "Fleet for osquery"

Note to QA: Run `fleetctl preview reset` before testing

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
