### PR TITLE
Allow empty TLS CA for Redis TLS connections

### DIFF
--- a/docs/02-Deploying/02-Configuration.md
+++ b/docs/02-Deploying/02-Configuration.md
@@ -356,6 +356,19 @@ The database to use when connecting to the Redis instance.
     database: 14
   ```
 
+##### redis_use_tls
+
+Use a TLS connection to the Redis server.
+
+- Default value: `false`
+- Environment variable: `FLEET_REDIS_USE_TLS`
+- Config file format:
+
+  ```
+  redis:
+    use_tls: true
+  ```
+
 ##### redis_duplicate_results
 
 Whether or not to duplicate Live Query results to another Redis channel named `LQDuplicate`. This is useful in a scenario that would involve shipping the Live Query results outside of Fleet, near-realtime.
@@ -470,7 +483,6 @@ The path to a PEM-encoded private key used for tls authentication.
 ##### redis_tls_ca
 
 The path to a PEM-encoded certificate of Redis' CA for client certificate authentication.
-Required to use TLS connections.
 
 - Default value: none
 - Environment variable: `FLEET_REDIS_TLS_CA`
@@ -1536,7 +1548,7 @@ See [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html) f
 
 AWS S3 Region. Leave blank to enable region discovery.
 
-- Default value: 
+- Default value:
 - Environment variable: `FLEET_S3_REGION`
 - Config file format:
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -230,13 +230,16 @@ type TLS struct {
 }
 
 func (t *TLS) ToTLSConfig() (*tls.Config, error) {
-	rootCertPool := x509.NewCertPool()
-	pem, err := ioutil.ReadFile(t.TLSCA)
-	if err != nil {
-		return nil, errors.Wrap(err, "read server-ca pem")
-	}
-	if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
-		return nil, errors.New("failed to append PEM.")
+	var rootCertPool *x509.CertPool
+	if t.TLSCA != "" {
+		rootCertPool = x509.NewCertPool()
+		pem, err := ioutil.ReadFile(t.TLSCA)
+		if err != nil {
+			return nil, errors.Wrap(err, "read server-ca pem")
+		}
+		if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
+			return nil, errors.New("failed to append PEM.")
+		}
 	}
 
 	cfg := &tls.Config{

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -88,7 +88,7 @@ func TestToTLSConfig(t *testing.T) {
 		in          TLS
 		errContains string
 	}{
-		{"zero", TLS{}, "no such file"},
+		{"zero", TLS{}, ""},
 		{"invalid file", TLS{TLSCA: "/no/such/file"}, "no such file"},
 		{"CA", TLS{TLSCA: caFile}, ""},
 		{"invalid CA content", TLS{TLSCA: garbageFile}, "failed to append PEM"},
@@ -113,8 +113,12 @@ func TestToTLSConfig(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, got)
 
-			// root ca is required
-			require.NotNil(t, got.RootCAs)
+			// root ca is required if TLSCA is set
+			if c.in.TLSCA != "" {
+				require.NotNil(t, got.RootCAs)
+			} else {
+				require.Nil(t, got.RootCAs)
+			}
 			require.Equal(t, got.ServerName, c.in.TLSServerName)
 			if c.in.TLSCert != "" {
 				require.Len(t, got.Certificates, 1)


### PR DESCRIPTION
I couldn't find a way to extract the CA from AWS elasticache, but apparently this is not required (https://stackoverflow.com/a/48731008/1094941), presumably because the servers can verify those certificates with the system-installed root CAs. This PR makes the CA optional when setting Redis TLS.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] ~~Changes file added (for user-visible changes)~~ (part of #2568 )
- [x] Documented any API changes
- [ ] ~~Documented any permissions changes~~
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
