### PR TITLE
Updated product section of handbook

### DIFF
--- a/handbook/README.md
+++ b/handbook/README.md
@@ -20,8 +20,6 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 ### Product
 
-[Fleet EE](./product.md#fleet-ee)
-
 [Fleet docs](./product.md#fleet-docs)
 
 [Manual QA](./product.md#manual-qa)
@@ -29,6 +27,8 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 [Release process](./product.md#release-process)
 
 [Support process](./product.md#release-process)
+
+[UI design](./product.md#ui-design)
 
 ### Growth
 

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -1,25 +1,4 @@
 
-## Fleet EE
-
-### Communicating design changes to Engineering
-For something NEW that has been added to [Figma Fleet EE (current, dev-ready)](https://www.figma.com/file/qpdty1e2n22uZntKUZKEJl/?node-id=0%3A1):
-1. Create a new [GitHub issue](https://github.com/fleetdm/fleet/issues/new)
-2. Detail the required changes (including page links to the relevant layouts), then assign it to the __“Initiatives”__ project.
-
-<img src="https://user-images.githubusercontent.com/78363703/129840932-67d55b5b-8e0e-4fb9-9300-5d458e1b91e4.png" alt="Assign to Initiatives project"/>
-
-> ___NOTE:___ Artwork and layouts in Figma Fleet EE (current, dev-ready) are final assets, ready for implementation. Therefore, it’s important NOT to use the “idea” label, as designs in this document are more than ideas - they are something that WILL be implemented._
-
-3. Navigate to the [Initiatives project](https://github.com/orgs/fleetdm/projects/8), and hit “+ Add cards”, pick the new issue, and drag it into the “🤩Inspire me” column. 
-
-<img src="https://user-images.githubusercontent.com/78363703/129840496-54ea4301-be20-46c2-9138-b70bff7198d0.png" alt="Add cards"/>
-
-<img src="https://user-images.githubusercontent.com/78363703/129840735-3b270429-a92a-476d-87b4-86b93057b2dd.png" alt="Inspire me"/>
-
-### Communicating unplanned design changes
-
-For issues related to something that was ALREADY in Figma Fleet EE (current, dev-ready), but __implemented differently__, e.g, padding/spacing inconsistency etc. Create a [bug issue](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=bug%2C%3Areproduce&template=bug-report.md&title=) and detail the required changes.
-
 ## Fleet docs
 
 ### Adding a link to the Fleet docs
@@ -350,6 +329,35 @@ There are several locations in Fleet's public and internal documentation that ca
 
 2. The [Internal FAQ](https://docs.google.com/document/d/1I6pJ3vz0EE-qE13VmpE2G3gd5zA1m3bb_u8Q2G3Gmp0/edit#heading=h.ltavvjy511qv) document.
 
+
+## UI Design
+
+### Communicating design changes to Engineering
+For something NEW that has been added to [Figma Fleet EE (current, dev-ready)](https://www.figma.com/file/qpdty1e2n22uZntKUZKEJl/?node-id=0%3A1):
+1. Create a new [GitHub issue](https://github.com/fleetdm/fleet/issues/new)
+2. Detail the required changes (including page links to the relevant layouts), then assign it to the __“Initiatives”__ project.
+
+<img src="https://user-images.githubusercontent.com/78363703/129840932-67d55b5b-8e0e-4fb9-9300-5d458e1b91e4.png" alt="Assign to Initiatives project"/>
+
+> ___NOTE:___ Artwork and layouts in Figma Fleet EE (current, dev-ready) are final assets, ready for implementation. Therefore, it’s important NOT to use the “idea” label, as designs in this document are more than ideas - they are something that WILL be implemented._
+
+3. Navigate to the [Initiatives project](https://github.com/orgs/fleetdm/projects/8), and hit “+ Add cards”, pick the new issue, and drag it into the “🤩Inspire me” column. 
+
+<img src="https://user-images.githubusercontent.com/78363703/129840496-54ea4301-be20-46c2-9138-b70bff7198d0.png" alt="Add cards"/>
+
+<img src="https://user-images.githubusercontent.com/78363703/129840735-3b270429-a92a-476d-87b4-86b93057b2dd.png" alt="Inspire me"/>
+
+### Communicating unplanned design changes
+
+For issues related to something that was ALREADY in Figma Fleet EE (current, dev-ready), but __implemented differently__, e.g, padding/spacing inconsistency etc. Create a [bug issue](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=bug%2C%3Areproduce&template=bug-report.md&title=) and detail the required changes.
+
+### Design conventions
+
+We have certain design conventions that we include in Fleet. We will document more of these over time.
+
+**Table empty states**
+
+Use `---`, with color `$ui-fleet-black-50` as the default UI for empty columns.
 
 
 


### PR DESCRIPTION
Closes fleetdm/confidential#596

• Changed section heading Fleet EE to "UI design".
• Added sub-section "Design conventions" under UI design.
• Re-ordered content. I felt that QA and release process was of more importance than UI design.

# Checklist for submitter

- [ ] Manual QA for all new/changed functionality
