### PR TITLE
Manage Host Page: Reintroduce add host modal

### DIFF
--- a/changes/issue-2290-2670-generate-installer-and-revert
+++ b/changes/issue-2290-2670-generate-installer-and-revert
@@ -1,0 +1,2 @@
+* New CTA for new users to generate installer to add hosts onto Fleet is wired up in frontend PR #2493
+* Issue #2670 revert so generate installer is unavailable to UI until product is Orbit ready

--- a/changes/issue-2290-generate-installer-new-to-fleet
+++ b/changes/issue-2290-generate-installer-new-to-fleet
@@ -1,1 +1,0 @@
-* New CTA for new users to generate installer to add hosts onto Fleet

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -141,7 +141,7 @@ describe(
               cy.findByRole("button", { name: /delete/i }).click();
             })
             .then(() => {
-              cy.findByText(/add your devices to fleet/i).should("exist");
+              cy.findByText(/add your hosts to fleet/i).should("exist");
               cy.findByText(/add new host/i).should("exist");
               cy.findByText(/about this host/i).should("not.exist");
               cy.findByText(hostname).should("not.exist");

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -28,10 +28,10 @@ describe(
       () => {
         cy.visit("/hosts/manage");
 
-        cy.contains("button", /generate installer/i).click();
+        cy.contains("button", /add new host/i).click();
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(1000);
-        cy.findByText(/rpm/i).click();
+        cy.get('a[href*="showSecret"]').click();
         cy.contains("a", /download/i)
           .first()
           .click();
@@ -42,11 +42,13 @@ describe(
         if (Cypress.platform !== "win32") {
           // windows has issues with downloads location
           cy.readFile(
-            path.join(Cypress.config("downloadsFolder"), "fleet.pem"),
+            path.join(Cypress.config("downloadsFolder"), "secret.txt"),
             {
               timeout: 5000,
             }
-          );
+          ).then((contents) => {
+            cy.get("input[disabled]").should("have.value", contents);
+          });
         }
 
         cy.visit("/hosts/manage");
@@ -140,7 +142,7 @@ describe(
             })
             .then(() => {
               cy.findByText(/add your devices to fleet/i).should("exist");
-              cy.findByText(/generate installer/i).should("exist");
+              cy.findByText(/add new host/i).should("exist");
               cy.findByText(/about this host/i).should("not.exist");
               cy.findByText(hostname).should("not.exist");
             });

--- a/cypress/integration/free/admin.spec.ts
+++ b/cypress/integration/free/admin.spec.ts
@@ -37,12 +37,12 @@ describe(
         cy.findByText(/settings/i).should("exist");
       });
 
-      // See and select "generate installer"
-      cy.findByRole("button", { name: /generate installer/i }).click();
-      cy.findByRole("button", { name: /done/i }).click();
+      // See and select "add new host"
+      cy.findByRole("button", { name: /add new host/i }).click();
+      cy.contains(/team/i).should("not.exist");
 
-      // See the "Manage enroll secret” button. A modal appears after the user selects the button
-      cy.contains("button", /manage enroll secret/i).click();
+      // See the “Show enroll secret” button. A modal appears after the user selects the button
+      cy.contains("button", /show enroll secret/i).click();
       cy.contains("button", /done/i).click();
 
       // See and select "add label"

--- a/cypress/integration/free/admin.spec.ts
+++ b/cypress/integration/free/admin.spec.ts
@@ -40,6 +40,7 @@ describe(
       // See and select "add new host"
       cy.findByRole("button", { name: /add new host/i }).click();
       cy.contains(/team/i).should("not.exist");
+      cy.contains("button", /done/i).click();
 
       // See the “Show enroll secret” button. A modal appears after the user selects the button
       cy.contains("button", /show enroll secret/i).click();

--- a/cypress/integration/free/maintainer.spec.ts
+++ b/cypress/integration/free/maintainer.spec.ts
@@ -36,11 +36,12 @@ describe(
 
       cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.findByText(/teams/i).should("not.exist");
-      cy.contains("button", /generate installer/i).click();
+      cy.contains("button", /add new host/i).click();
+      cy.findByText("select a team").should("not.exist");
       cy.contains("button", /done/i).click();
 
-      // See the “Manage enroll secret” button. A modal appears after the user selects the button
-      cy.contains("button", /manage enroll secret/i).click();
+      // See the “Show enroll secret” button. A modal appears after the user selects the button
+      cy.contains("button", /show enroll secret/i).click();
       cy.contains("button", /done/i).click();
 
       cy.contains("button", /add label/i).click();

--- a/cypress/integration/free/observer.spec.ts
+++ b/cypress/integration/free/observer.spec.ts
@@ -39,9 +39,9 @@ describe("Free tier - Observer user", () => {
     // Host manage page: No team UI, cannot add host, add label, nor enroll secret
     cy.visit("/hosts/manage");
     cy.findByText(/teams/i).should("not.exist");
-    cy.contains("button", /generate installer/i).should("not.exist");
+    cy.contains("button", /add new host/i).should("not.exist");
     cy.contains("button", /add label/i).should("not.exist");
-    cy.contains("button", /manage enroll secret/i).should("not.exist");
+    cy.contains("button", /show enroll secret/i).should("not.exist");
 
     // Host details page: No team UI, cannot delete or query
     cy.get("tbody").within(() => {

--- a/cypress/integration/premium/admin.spec.ts
+++ b/cypress/integration/premium/admin.spec.ts
@@ -36,9 +36,19 @@ describe(
         // See the “Teams” column in the Hosts table
         cy.get("thead").contains(/team/i).should("exist");
 
-        // See and select the “Generate installer” button
-        cy.contains("button", /generate installer/i).click();
-        cy.contains("button", /done/i).click();
+        // See and select the “Add new host” button
+        cy.contains("button", /add new host/i).click();
+
+        // See the “Select a team for this new host” in the Add new host modal. This modal appears after the user selects the “Add new host” button
+        cy.get(
+          ".add-host-modal__team-dropdown-wrapper .Select-control"
+        ).click();
+
+        cy.get(".Select-menu-outer").within(() => {
+          cy.findByText(/no team/i).should("exist");
+          cy.findByText(/apples/i).should("exist");
+          cy.findByText(/oranges/i).should("exist");
+        });
 
         // On the Host details page, they should…
         // See the “Team” information below the hostname

--- a/cypress/integration/premium/maintainer.spec.ts
+++ b/cypress/integration/premium/maintainer.spec.ts
@@ -29,9 +29,10 @@ describe(
 
       cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
 
-      cy.findByText(/manage enroll secret/i).should("exist");
+      cy.findByText(/show enroll secret/i).should("exist");
 
-      cy.contains("button", /generate installer/i).click();
+      cy.contains("button", /add new host/i).click();
+      // TODO: Check Team Apples is in Select a team dropdown
       cy.contains("button", /done/i).click();
 
       // Host details page: Can see team UI
@@ -94,6 +95,6 @@ describe(
       cy.findByText("Role")
         .next()
         .contains(/maintainer/i);
-    });
+    };);
   }
 );

--- a/cypress/integration/premium/maintainer.spec.ts
+++ b/cypress/integration/premium/maintainer.spec.ts
@@ -95,6 +95,6 @@ describe(
       cy.findByText("Role")
         .next()
         .contains(/maintainer/i);
-    };);
+    });
   }
 );

--- a/cypress/integration/premium/observer.spec.ts
+++ b/cypress/integration/premium/observer.spec.ts
@@ -38,8 +38,8 @@ describe("Premium tier - Observer user", () => {
     cy.contains("button", /query/i).click();
     cy.contains("button", /create custom query/i).should("not.exist");
 
-    // Not see the “Manage enroll secret” button
-    cy.contains("button", /manage enroll secret/i).should("not.exist");
+    // Not see the "Show enroll secret” button
+    cy.contains("button", /show enroll secret/i).should("not.exist");
 
     // TODO - Fix tests according to improved query experience - MP
     // Query pages: Can see team in select targets dropdown

--- a/cypress/integration/premium/team_maintainer_observer.spec.ts
+++ b/cypress/integration/premium/team_maintainer_observer.spec.ts
@@ -27,7 +27,7 @@ describe(
       // On the Hosts page, they should…
 
       // See hosts
-      // cy.findByText(/generate installer/i).should("not.exist");
+      // cy.findByText(/kinda empty in here/i).should("not.exist");
       // ^^TODO hosts table is not rendering because we need new forEach script/command for admin to assign team after the host is added
 
       // See the “Teams” column in the Hosts table
@@ -140,8 +140,16 @@ describe(
       // cy.get("thead").contains(/team/i).should("exist");
       // ^^TODO hosts table is not rendering because we need new forEach script/command for admin to assign team after the host is added
 
-      // See and select the “Generate installer” button
-      cy.findByRole("button", { name: /generate installer/i }).click();
+      // See and select the “Add new host” button
+      cy.findByRole("button", { name: /add new host/i }).click();
+
+      // See the “Select a team for this new host” in the Add new host modal. This modal appears after the user selects the “Add new host” button
+      cy.get(".add-host-modal__team-dropdown-wrapper .Select-control").click();
+      cy.get(".Select-menu-outer").within(() => {
+        cy.findByText(/no team/i).should("not.exist");
+        cy.findByText(/apples/i).should("not.exist");
+        cy.findByText(/oranges/i).should("exist");
+      });
       cy.findByRole("button", { name: /done/i }).click();
 
       // On the Host details page, they should…

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1274,7 +1274,7 @@ const ManageHostsPage = ({
 
     // Hosts have not been set up for this instance yet.
     if (getStatusSelected() === ALL_HOSTS_LABEL && selectedLabel.count === 0) {
-      return <NoHosts />;
+      return <NoHosts setShowAddHostModal={setShowAddHostModal} />;
     }
 
     const secondarySelectActions: IActionButtonProps[] = [
@@ -1349,14 +1349,22 @@ const ManageHostsPage = ({
                   <span>Show enroll secret</span>
                 </Button>
               )}
-              {canAddNewHosts && (
-                <Button
-                  onClick={() => setShowAddHostModal(true)}
-                  className={`${baseClass}__add-hosts button button--brand`}
-                >
-                  <span>Add new host</span>
-                </Button>
-              )}
+              {canAddNewHosts &&
+                !(
+                  getStatusSelected() === ALL_HOSTS_LABEL &&
+                  selectedLabel?.count === 0
+                ) &&
+                !(
+                  getStatusSelected() === ALL_HOSTS_LABEL &&
+                  filteredHostCount === 0
+                ) && (
+                  <Button
+                    onClick={() => setShowAddHostModal(true)}
+                    className={`${baseClass}__add-hosts button button--brand`}
+                  >
+                    <span>Add new host</span>
+                  </Button>
+                )}
             </div>
           </div>
           {renderActiveFilterBlock()}

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -72,7 +72,7 @@ import PoliciesFilter from "./components/PoliciesFilter"; // @ts-ignore
 import EditColumnsModal from "./components/EditColumnsModal/EditColumnsModal";
 import TransferHostModal from "./components/TransferHostModal";
 import DeleteHostModal from "./components/DeleteHostModal";
-import SoftwareVulnerabilities from "./components/SoftwareVulnerabilities";
+import SoftwareVulnerabilities from "./components/SoftwareVulnerabilities"; // @ts-ignore
 import AddHostModal from "./components/AddHostModal";
 import EditColumnsIcon from "../../../../assets/images/icon-edit-columns-16x16@2x.png";
 import PencilIcon from "../../../../assets/images/icon-pencil-14x14@2x.png";

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -73,7 +73,7 @@ import EditColumnsModal from "./components/EditColumnsModal/EditColumnsModal";
 import TransferHostModal from "./components/TransferHostModal";
 import DeleteHostModal from "./components/DeleteHostModal";
 import SoftwareVulnerabilities from "./components/SoftwareVulnerabilities";
-import GenerateInstallerModal from "./components/GenerateInstallerModal";
+import AddHostModal from "./components/AddHostModal";
 import EditColumnsIcon from "../../../../assets/images/icon-edit-columns-16x16@2x.png";
 import PencilIcon from "../../../../assets/images/icon-pencil-14x14@2x.png";
 import TrashIcon from "../../../../assets/images/icon-trash-14x14@2x.png";
@@ -157,6 +157,7 @@ const ManageHostsPage = ({
   // ========= states
   const [selectedLabel, setSelectedLabel] = useState<ILabel>();
   const [statusLabels, setStatusLabels] = useState<IStatusLabels>();
+  const [showAddHostModal, setShowAddHostModal] = useState<boolean>(false);
   const [showEnrollSecretModal, setShowEnrollSecretModal] = useState<boolean>(
     false
   );
@@ -172,10 +173,6 @@ const ManageHostsPage = ({
   const [showDeleteHostModal, setShowDeleteHostModal] = useState<boolean>(
     false
   );
-  const [
-    showGenerateInstallerModal,
-    setShowGenerateInstallerModal,
-  ] = useState<boolean>(false);
   const [hiddenColumns, setHiddenColumns] = useState<string[]>(
     storedHiddenColumns || defaultHiddenColumns
   );

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -220,11 +220,6 @@ const ManageHostsPage = ({
     isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer;
   const canAddNewLabels = isGlobalAdmin || isGlobalMaintainer;
 
-  const generateInstallerTeam = currentTeam || {
-    name: "No team",
-    secrets: globalSecret,
-  };
-
   const {
     isLoading: isLabelsLoading,
     data: labels,
@@ -287,16 +282,33 @@ const ManageHostsPage = ({
     setShowDeleteHostModal(!showDeleteHostModal);
   };
 
-  const toggleGenerateInstallerModal = () => {
-    setShowGenerateInstallerModal(!showGenerateInstallerModal);
-  };
-
   const toggleAllMatchingHosts = (shouldSelect: boolean) => {
     if (typeof shouldSelect !== "undefined") {
       setIsAllMatchingHostsSelected(shouldSelect);
     } else {
       setIsAllMatchingHostsSelected(!isAllMatchingHostsSelected);
     }
+  };
+
+  const renderAddHostModal = () => {
+    if (!canAddNewHosts || !showAddHostModal) {
+      return null;
+    }
+
+    return (
+      <Modal
+        title="New host"
+        onExit={() => setShowAddHostModal(false)}
+        className={`${baseClass}__invite-modal`}
+      >
+        <AddHostModal
+          teams={teams}
+          onReturnToApp={() => setShowAddHostModal(false)}
+          config={config}
+          currentUser={currentUser}
+        />
+      </Modal>
+    );
   };
 
   const getLabelSelected = () => {
@@ -1095,19 +1107,6 @@ const ManageHostsPage = ({
     );
   };
 
-  const renderGenerateInstallerModal = () => {
-    if (!showGenerateInstallerModal) {
-      return null;
-    }
-
-    return (
-      <GenerateInstallerModal
-        onCancel={toggleGenerateInstallerModal}
-        selectedTeam={generateInstallerTeam}
-      />
-    );
-  };
-
   const renderHeaderLabelBlock = () => {
     if (selectedLabel) {
       const {
@@ -1258,7 +1257,7 @@ const ManageHostsPage = ({
     );
   };
 
-  const renderTable = (selectedTeam: number) => {
+  const renderTable = () => {
     if (
       !config ||
       !currentUser ||
@@ -1274,15 +1273,8 @@ const ManageHostsPage = ({
     }
 
     // Hosts have not been set up for this instance yet.
-    if (
-      (getStatusSelected() === ALL_HOSTS_LABEL && selectedLabel.count === 0) ||
-      (getStatusSelected() === ALL_HOSTS_LABEL &&
-        filteredHostCount === 0 &&
-        searchQuery === "")
-    ) {
-      return (
-        <NoHosts toggleGenerateInstallerModal={toggleGenerateInstallerModal} />
-      );
+    if (getStatusSelected() === ALL_HOSTS_LABEL && selectedLabel.count === 0) {
+      return <NoHosts />;
     }
 
     const secondarySelectActions: IActionButtonProps[] = [
@@ -1354,39 +1346,31 @@ const ManageHostsPage = ({
                   className={`${baseClass}__enroll-hosts button`}
                   variant="inverse"
                 >
-                  <span>Manage enroll secret</span>
+                  <span>Show enroll secret</span>
                 </Button>
               )}
-              {canAddNewHosts &&
-                !(
-                  getStatusSelected() === ALL_HOSTS_LABEL &&
-                  selectedLabel?.count === 0
-                ) &&
-                !(
-                  getStatusSelected() === ALL_HOSTS_LABEL &&
-                  filteredHostCount === 0
-                ) && (
-                  <Button
-                    onClick={toggleGenerateInstallerModal}
-                    className={`${baseClass}__add-hosts button button--brand`}
-                  >
-                    <span>Generate installer</span>
-                  </Button>
-                )}
+              {canAddNewHosts && (
+                <Button
+                  onClick={() => setShowAddHostModal(true)}
+                  className={`${baseClass}__add-hosts button button--brand`}
+                >
+                  <span>Add new host</span>
+                </Button>
+              )}
             </div>
           </div>
           {renderActiveFilterBlock()}
           {renderSoftwareVulnerabilities()}
-          {config && (!isPremiumTier || teams) && renderTable(selectedTeam)}
+          {config && (!isPremiumTier || teams) && renderTable()}
         </div>
       )}
       {!isLabelsLoading && renderSidePanel()}
+      {renderAddHostModal()}
       {renderEnrollSecretModal()}
       {renderEditColumnsModal()}
       {renderDeleteLabelModal()}
       {renderTransferHostModal()}
       {renderDeleteHostModal()}
-      {renderGenerateInstallerModal()}
     </div>
   );
 };

--- a/frontend/pages/hosts/ManageHostsPage/components/AddHostModal/AddHostModal.jsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/AddHostModal/AddHostModal.jsx
@@ -1,0 +1,373 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import FileSaver from "file-saver";
+
+import Fleet from "fleet";
+import Button from "components/buttons/Button";
+import configInterface from "interfaces/config";
+import teamInterface from "interfaces/team";
+import userInterface from "interfaces/user";
+import permissionUtils from "utilities/permissions";
+import EnrollSecretTable from "components/config/EnrollSecretTable";
+import FleetIcon from "components/icons/FleetIcon";
+import Dropdown from "components/forms/fields/Dropdown";
+import InputField from "components/forms/fields/InputField";
+import { stringToClipboard } from "utilities/copy_text";
+import DownloadIcon from "../../../../../../assets/images/icon-download-12x12@2x.png";
+
+const baseClass = "add-host-modal";
+
+const NO_TEAM_OPTION = {
+  value: "no-team",
+  label: "No team",
+};
+
+class AddHostModal extends Component {
+  static propTypes = {
+    teams: PropTypes.arrayOf(teamInterface),
+    onReturnToApp: PropTypes.func,
+    config: configInterface,
+    currentUser: userInterface,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.userRole = {
+      isAnyTeamMaintainer: permissionUtils.isAnyTeamMaintainer(
+        this.props.currentUser
+      ),
+      isGlobalAdmin: permissionUtils.isGlobalAdmin(this.props.currentUser),
+      isGlobalMaintainer: permissionUtils.isGlobalMaintainer(
+        this.props.currentUser
+      ),
+    };
+    this.currentUserTeams = this.userRole.isAnyTeamMaintainer
+      ? Object.values(this.props.currentUser.teams).filter(
+          (team) => team.role === "maintainer"
+        )
+      : this.props.teams;
+
+    this.teamSecrets = this.props.teams
+      ? Object.values(this.props.teams).map((team) => {
+          return { id: team.id, name: team.name, secrets: team.secrets };
+        })
+      : [];
+
+    this.state = {
+      fetchCertificateError: undefined,
+      selectedTeam: null,
+      globalSecrets: [],
+      selectedEnrollSecrets: [],
+      copyMessage: "",
+    };
+  }
+
+  componentDidMount() {
+    const { isGlobalAdmin, isGlobalMaintainer } = this.userRole;
+
+    (() => {
+      if (isGlobalAdmin || isGlobalMaintainer) {
+        Fleet.config
+          .loadEnrollSecret()
+          .then((response) => {
+            this.setState({
+              globalSecrets: response.spec.secrets,
+              selectedTeam: { id: NO_TEAM_OPTION.value }, // Reset initial selectedTeam value to "no-team" in the case of global users
+            });
+          })
+          .catch((err) => {
+            console.log(err);
+          });
+      } else {
+        this.setState({ selectedTeam: this.currentUserTeams[0] });
+      }
+    })();
+
+    Fleet.config
+      .loadCertificate()
+      .then((certificate) => {
+        this.setState({ certificate });
+      })
+      .catch(() => {
+        this.setState({
+          fetchCertificateError:
+            "Failed to load certificate. Is Fleet app URL configured properly?",
+        });
+      });
+  }
+
+  onFetchCertificate = (evt) => {
+    evt.preventDefault();
+
+    const { certificate } = this.state;
+
+    const filename = "fleet.pem";
+    const file = new global.window.File([certificate], filename, {
+      type: "application/x-pem-file",
+    });
+
+    FileSaver.saveAs(file);
+
+    return false;
+  };
+
+  onCopyRunCommand = (evt) => {
+    evt.preventDefault();
+
+    stringToClipboard("osqueryd --flagfile=flagfile.txt --verbose")
+      .then(() => this.setState({ copyMessage: "Copied!" }))
+      .catch(() => this.setState({ copyMessage: "Copy failed" }));
+
+    // Clear message after 1 second
+    setTimeout(() => this.setState({ copyMessage: "" }), 1000);
+
+    return false;
+  };
+
+  // if isGlobalAdmin or isGlobalMaintainer, we include a "No team" option and reveal globalSecrets
+  // if not, we pull secrets for the user's teams from the teamsSecrets
+  onChangeSelectTeam = (teamId) => {
+    const { globalSecrets } = this.state;
+    const { currentUserTeams, teamSecrets } = this;
+    if (teamId === "no-team") {
+      this.setState({ selectedTeam: { id: NO_TEAM_OPTION.value } });
+      this.setState({ selectedEnrollSecrets: globalSecrets || [] });
+    } else {
+      const selectedTeam = currentUserTeams.find((team) => team.id === teamId);
+      const selectedEnrollSecrets =
+        teamSecrets.find((e) => e.id === selectedTeam.id)?.secrets || "";
+      this.setState({ selectedTeam });
+      this.setState({
+        selectedEnrollSecrets,
+      });
+    }
+  };
+
+  getSelectedEnrollSecrets = (selectedTeam) => {
+    if (selectedTeam.id === NO_TEAM_OPTION.value) {
+      return this.state.globalSecrets;
+    }
+    return (
+      this.teamSecrets.find((e) => e.id === selectedTeam.id)?.secrets || ""
+    );
+  };
+
+  createTeamDropdownOptions = (currentUserTeams = []) => {
+    const teamOptions = currentUserTeams.map((team) => {
+      return {
+        value: team.id,
+        label: team.name,
+      };
+    });
+    return this.userRole.isAnyTeamMaintainer
+      ? teamOptions
+      : [NO_TEAM_OPTION, ...teamOptions];
+  };
+
+  renderRunCommandLabel = () => {
+    const { copyMessage } = this.state;
+    const { onCopyRunCommand } = this;
+
+    return (
+      <span className={`${baseClass}__name`}>
+        <span className="buttons">
+          {copyMessage && <span>{`${copyMessage} `}</span>}
+          <Button
+            variant="unstyled"
+            className={`${baseClass}__run-osquery-copy-icon`}
+            onClick={onCopyRunCommand}
+          >
+            <FleetIcon name="clipboard" />
+          </Button>
+        </span>
+      </span>
+    );
+  };
+
+  render() {
+    const { config, onReturnToApp } = this.props;
+    const { fetchCertificateError, selectedTeam, globalSecrets } = this.state;
+    const {
+      createTeamDropdownOptions,
+      currentUserTeams,
+      getSelectedEnrollSecrets,
+      onChangeSelectTeam,
+      renderRunCommandLabel,
+    } = this;
+
+    const isPremiumTier = permissionUtils.isPremiumTier(config);
+
+    let tlsHostname = config.server_url;
+    try {
+      const serverUrl = new URL(config.server_url);
+      tlsHostname = serverUrl.hostname;
+      if (serverUrl.port) {
+        tlsHostname += `:${serverUrl.port}`;
+      }
+    } catch (e) {
+      if (!(e instanceof TypeError)) {
+        throw e;
+      }
+    }
+
+    const flagfileContent = `# Server
+--tls_hostname=${tlsHostname}
+--tls_server_certs=fleet.pem
+# Enrollment
+--host_identifier=instance
+--enroll_secret_path=secret.txt
+--enroll_tls_endpoint=/api/v1/osquery/enroll
+# Configuration
+--config_plugin=tls
+--config_tls_endpoint=/api/v1/osquery/config
+--config_refresh=10
+# Live query
+--disable_distributed=false
+--distributed_plugin=tls
+--distributed_interval=10
+--distributed_tls_max_attempts=3
+--distributed_tls_read_endpoint=/api/v1/osquery/distributed/read
+--distributed_tls_write_endpoint=/api/v1/osquery/distributed/write
+# Logging
+--logger_plugin=tls
+--logger_tls_endpoint=/api/v1/osquery/log
+--logger_tls_period=10
+# File carving
+--disable_carver=false
+--carver_start_endpoint=/api/v1/osquery/carve/begin
+--carver_continue_endpoint=/api/v1/osquery/carve/block
+--carver_block_size=2000000`;
+
+    const onDownloadFlagfile = (evt) => {
+      evt.preventDefault();
+
+      const filename = "flagfile.txt";
+      const file = new global.window.File([flagfileContent], filename);
+
+      FileSaver.saveAs(file);
+
+      return false;
+    };
+
+    return (
+      <div className={baseClass}>
+        <div className={`${baseClass}__manual-install-content`}>
+          <div className={`${baseClass}__documentation-link`}>
+            <h4>
+              <a
+                href="https://github.com/fleetdm/fleet/blob/2f42c281f98e39a72ab4a5125ecd26d303a16a6b/docs/1-Using-Fleet/4-Adding-hosts.md"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Add Hosts Documentation <FleetIcon name="external-link" />
+              </a>
+            </h4>
+          </div>
+          <ol className={`${baseClass}__install-steps`}>
+            <li>
+              <h4>
+                <span className={`${baseClass}__step-number`}>1</span>Enroll
+                secret
+              </h4>
+              <p>
+                Osquery uses an enroll secret to authenticate with the Fleet
+                server.
+              </p>
+              <div className={`${baseClass}__secret-wrapper`}>
+                {isPremiumTier && currentUserTeams ? (
+                  <Dropdown
+                    wrapperClassName={`${baseClass}__team-dropdown-wrapper`}
+                    label={"Select a team for this new host:"}
+                    value={selectedTeam && selectedTeam.id}
+                    options={createTeamDropdownOptions(currentUserTeams)}
+                    onChange={onChangeSelectTeam}
+                    placeholder={"Select a team"}
+                    searchable={false}
+                  />
+                ) : null}
+                {isPremiumTier && selectedTeam && (
+                  <EnrollSecretTable
+                    secrets={getSelectedEnrollSecrets(selectedTeam)}
+                  />
+                )}
+                {!isPremiumTier && (
+                  <EnrollSecretTable secrets={globalSecrets} />
+                )}
+              </div>
+            </li>
+            <li>
+              <h4>
+                <span className={`${baseClass}__step-number`}>2</span>Server
+                certificate
+              </h4>
+              <p>
+                Provide the TLS certificate used by the Fleet server to enable
+                secure connections from osquery:
+              </p>
+              <p>
+                {fetchCertificateError ? (
+                  <span className={`${baseClass}__error`}>
+                    {fetchCertificateError}
+                  </span>
+                ) : (
+                  <a
+                    href="#downloadCertificate"
+                    onClick={this.onFetchCertificate}
+                  >
+                    Download
+                    <img src={DownloadIcon} alt="download icon" />
+                  </a>
+                )}
+              </p>
+            </li>
+            <li>
+              <h4>
+                <span className={`${baseClass}__step-number`}>3</span>Flagfile
+              </h4>
+              <p>
+                If using the enroll secret and server certificate downloaded
+                above, use the generated flagfile. In some configurations,
+                modifications may need to be made:
+              </p>
+              <p>
+                <a href="#downloadFlagfile" onClick={onDownloadFlagfile}>
+                  Download
+                  <img src={DownloadIcon} alt="download icon" />
+                </a>
+              </p>
+            </li>
+            <li>
+              <h4>
+                <span className={`${baseClass}__step-number`}>4</span>Run
+                osquery
+              </h4>
+              <p>
+                Run osquery from the directory containing the above files (may
+                require sudo or Run as Administrator privileges):
+              </p>
+              <div>
+                <InputField
+                  disabled
+                  inputWrapperClass={`${baseClass}__run-osquery-input`}
+                  name="run-osquery"
+                  label={renderRunCommandLabel()}
+                  type={"text"}
+                  value={"osqueryd --flagfile=flagfile.txt --verbose"}
+                />
+              </div>
+            </li>
+          </ol>
+        </div>
+
+        <div className={`${baseClass}__button-wrap`}>
+          <Button onClick={onReturnToApp} className="button button--brand">
+            Done
+          </Button>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default AddHostModal;

--- a/frontend/pages/hosts/ManageHostsPage/components/AddHostModal/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/AddHostModal/_styles.scss
@@ -1,0 +1,171 @@
+.add-host-modal {
+  &__manual-install-header {
+    position: relative;
+    z-index: 2;
+
+    h2 {
+      font-size: 18px;
+      font-weight: $bold;
+      line-height: 1.33;
+      letter-spacing: -0.6px;
+      color: #48c586;
+      margin: 0;
+    }
+
+    h3 {
+      font-size: 15px;
+      font-weight: $regular;
+      line-height: 1.6;
+      letter-spacing: normal;
+      color: rgba(32, 37, 50, 0.48);
+      margin: 0;
+    }
+
+    .fleeticon {
+      float: left;
+      font-size: 44px;
+      color: #48c586;
+      margin-right: 15px;
+    }
+  }
+
+  &__manual-install-content {
+    h4 {
+      font-size: $small;
+      font-weight: $bold;
+      margin: $pad-xlarge 0 0;
+
+      .fleeticon {
+        margin-left: 5px;
+        font-size: 18px;
+      }
+    }
+
+    p {
+      font-size: $x-small;
+      font-weight: $regular;
+      line-height: 20px;
+      letter-spacing: normal;
+      color: $core-fleet-black;
+      margin: 8px 0 0 44px;
+    }
+
+    a {
+      font-size: $x-small;
+      color: $core-vibrant-blue;
+      font-weight: $bold;
+      text-decoration: none;
+
+      img {
+        width: 12px;
+        height: 12px;
+        margin-left: 7px;
+      }
+    }
+  }
+
+  &__documentation-link {
+    h4 {
+      margin: 0;
+    }
+  }
+
+  &__install-steps {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__step-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 100px;
+    border: 2px solid $core-vibrant-blue;
+    color: $core-vibrant-blue;
+    font-weight: $bold;
+    text-align: center;
+    margin-right: $pad-medium;
+  }
+
+  &__button-wrap {
+    display: flex;
+    justify-content: flex-end;
+    margin: $pad-large 0 0;
+  }
+
+  &__download-cert {
+    text-align: center;
+    padding-top: 15px;
+
+    span {
+      display: block;
+    }
+  }
+
+  &__reveal-secret {
+    float: right;
+    text-decoration: none;
+  }
+
+  &__secret-wrapper {
+    position: relative;
+    margin: $pad-medium 0 0 44px;
+  }
+
+  &__team-dropdown-wrapper {
+    .form-field__label {
+      font-weight: $bold;
+    }
+  }
+
+  &__team-dropdown-wrapper {
+    .form-field__label {
+      font-weight: $bold;
+    }
+  }
+
+  pre,
+  code {
+    background-color: $ui-off-white;
+    color: $core-fleet-blue;
+    border: 1px solid $ui-fleet-blue-15;
+    border-radius: 4px;
+    padding: 7px $pad-medium;
+    margin: $pad-large 0 0 44px;
+  }
+
+  &__error {
+    color: $ui-error;
+  }
+
+  &__run-osquery-input {
+    margin-left: 44px;
+  }
+
+  &__run-osquery-copy-icon {
+    color: $core-vibrant-blue;
+    margin-left: $pad-small;
+    margin-right: $pad-xxlarge;
+  }
+
+  .buttons {
+    display: flex;
+    align-items: center;
+    position: absolute;
+    right: 16px;
+    transform: translateY(80%);
+    height: 16px;
+
+    span {
+      font-weight: $regular;
+    }
+
+    img {
+      width: 16px;
+      height: 16px;
+    }
+  }
+}

--- a/frontend/pages/hosts/ManageHostsPage/components/AddHostModal/index.js
+++ b/frontend/pages/hosts/ManageHostsPage/components/AddHostModal/index.js
@@ -1,0 +1,1 @@
+export { default } from "./AddHostModal";

--- a/frontend/pages/hosts/ManageHostsPage/components/NoHosts/NoHosts.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/NoHosts/NoHosts.tsx
@@ -13,24 +13,20 @@ interface INoHostsProps {
 
 const baseClass = "no-hosts";
 
-const NoHosts = ({
-  toggleGenerateInstallerModal,
-}: INoHostsProps): JSX.Element => {
+const NoHosts = (): JSX.Element => {
   return (
     <div className={`${baseClass}`}>
       <div className={`${baseClass}__inner`}>
         <img src={RoboDogImage} alt="No Hosts" />
         <div>
-          <h2>Add your devices to Fleet</h2>
-          <p>Generate an installer to add your own devices.</p>
-          <div className={`${baseClass}__no-hosts-button`}>
-            <Button
-              onClick={toggleGenerateInstallerModal}
-              type="button"
-              className="button button--brand"
-            >
-              Generate installer
-            </Button>
+          <h1>It&#39;s kinda empty in here...</h1>
+          <h2>Get started adding hosts to Fleet.</h2>
+          <p>Add your laptops and servers to securely monitor them.</p>
+          <div className={`${baseClass}__no-hosts-contact`}>
+            <p>Still having trouble?</p>
+            <a href="https://github.com/fleetdm/fleet/issues">
+              File a GitHub issue
+            </a>
           </div>
         </div>
       </div>

--- a/frontend/pages/hosts/ManageHostsPage/components/NoHosts/NoHosts.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/NoHosts/NoHosts.tsx
@@ -8,25 +8,27 @@ import { ITeam } from "interfaces/team";
 import RoboDogImage from "../../../../../../assets/images/robo-dog-176x144@2x.png";
 
 interface INoHostsProps {
-  toggleGenerateInstallerModal: () => void;
+  setShowAddHostModal: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const baseClass = "no-hosts";
 
-const NoHosts = (): JSX.Element => {
+const NoHosts = ({ setShowAddHostModal }: INoHostsProps): JSX.Element => {
   return (
     <div className={`${baseClass}`}>
       <div className={`${baseClass}__inner`}>
         <img src={RoboDogImage} alt="No Hosts" />
         <div>
-          <h1>It&#39;s kinda empty in here...</h1>
-          <h2>Get started adding hosts to Fleet.</h2>
+          <h2>Add your hosts to Fleet</h2>
           <p>Add your laptops and servers to securely monitor them.</p>
-          <div className={`${baseClass}__no-hosts-contact`}>
-            <p>Still having trouble?</p>
-            <a href="https://github.com/fleetdm/fleet/issues">
-              File a GitHub issue
-            </a>
+          <div className={`${baseClass}__no-hosts-button`}>
+            <Button
+              onClick={() => setShowAddHostModal(true)}
+              type="button"
+              className="button button--brand"
+            >
+              Add new hosts
+            </Button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Cerra #2670 

Note to future developer: 

**Code from generate installer modalstill living in codebase:**
_frontend/components/app/App.tsx_
- Enroll Secret
_frontend/context/app.tsx_
- Enroll secret and set enroll secret new API patterns
_frontend/pages/hosts/ManageHostsPage/compoentns/GenerateInstallerModal directory
- Everything for this modal is still in tack in codebase

**Code needed to be reverted from previous merge** #2493
https://github.com/fleetdm/fleet/commit/cc40bf132dbf8f64ad03a355cc81ab5cbd167c0c
- Manage host page
- No Host page
- All e2e tests

<img width="1514" alt="Screen Shot 2021-10-26 at 11 43 42 AM" src="https://user-images.githubusercontent.com/71795832/138913989-2b7142ef-e995-4c33-a563-56ef573cee21.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
