### PR TITLE
App UI: Remove form autocomplete from UI input fields

### DIFF
--- a/changes/issue-2670-remove-autocompletes
+++ b/changes/issue-2670-remove-autocompletes
@@ -1,0 +1,1 @@
+* Forms with input fields now have autocomplete turned off

--- a/frontend/components/forms/ConfigurePackQueryForm/ConfigurePackQueryForm.jsx
+++ b/frontend/components/forms/ConfigurePackQueryForm/ConfigurePackQueryForm.jsx
@@ -103,7 +103,7 @@ export class ConfigurePackQueryForm extends Component {
     const loggingType = fields.logging_type.value || "snapshot";
 
     return (
-      <form className={baseClass} onSubmit={handleSubmit}>
+      <form className={baseClass} onSubmit={handleSubmit} autoComplete="off">
         <h2 className={`${baseClass}__title`}>Configuration</h2>
         <div className={`${baseClass}__fields`}>
           <Dropdown

--- a/frontend/components/forms/ConfirmInviteForm/ConfirmInviteForm.jsx
+++ b/frontend/components/forms/ConfirmInviteForm/ConfirmInviteForm.jsx
@@ -26,7 +26,7 @@ class ConfirmInviteForm extends Component {
     const { baseError, className, fields, handleSubmit } = this.props;
 
     return (
-      <form className={className}>
+      <form className={className} autoComplete="off">
         {baseError && <div className="form__base-error">{baseError}</div>}
         <div className="fields">
           <InputFieldWithIcon

--- a/frontend/components/forms/ConfirmSSOInviteForm/ConfirmSSOInviteForm.jsx
+++ b/frontend/components/forms/ConfirmSSOInviteForm/ConfirmSSOInviteForm.jsx
@@ -26,7 +26,7 @@ class ConfirmSSOInviteForm extends Component {
     const { baseError, className, fields, handleSubmit } = this.props;
 
     return (
-      <form className={className}>
+      <form className={className} autoComplete="off">
         {baseError && <div className="form__base-error">{baseError}</div>}
         <div className="fields">
           <InputFieldWithIcon

--- a/frontend/components/forms/ForgotPasswordForm/ForgotPasswordForm.jsx
+++ b/frontend/components/forms/ForgotPasswordForm/ForgotPasswordForm.jsx
@@ -24,7 +24,7 @@ class ForgotPasswordForm extends Component {
     const { baseError, fields, handleSubmit } = this.props;
 
     return (
-      <form onSubmit={handleSubmit} className={baseClass}>
+      <form onSubmit={handleSubmit} className={baseClass} autoComplete="off">
         {baseError && <div className="form__base-error">{baseError}</div>}
         <InputFieldWithIcon {...fields.email} autofocus placeholder="Email" />
         <div className={`${baseClass}__button-wrap`}>

--- a/frontend/components/forms/LabelForm/LabelForm.tsx
+++ b/frontend/components/forms/LabelForm/LabelForm.tsx
@@ -133,7 +133,11 @@ const LabelForm = ({
   }
 
   return (
-    <form className={`${baseClass}__wrapper`} onSubmit={submitForm}>
+    <form
+      className={`${baseClass}__wrapper`}
+      onSubmit={submitForm}
+      autoComplete="off"
+    >
       <h1>{headerText}</h1>
       {!isManual && (
         <FleetAce

--- a/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
@@ -42,7 +42,7 @@ class AdminDetails extends Component {
     const tabIndex = currentPage ? 1 : -1;
 
     return (
-      <form onSubmit={handleSubmit} className={className}>
+      <form onSubmit={handleSubmit} className={className} autoComplete="off">
         <div className="registration-fields">
           <InputFieldWithIcon
             {...fields.name}

--- a/frontend/components/forms/RegistrationForm/ConfirmationPage/ConfirmationPage.tsx
+++ b/frontend/components/forms/RegistrationForm/ConfirmationPage/ConfirmationPage.tsx
@@ -63,7 +63,11 @@ const ConfirmationPage = ({
   const confirmRegClasses = classnames(className, baseClass);
 
   return (
-    <form onSubmit={handleSubmit} className={confirmRegClasses}>
+    <form
+      onSubmit={handleSubmit}
+      className={confirmRegClasses}
+      autoComplete="off"
+    >
       <div className={`${baseClass}__wrapper`}>
         <table className={`${baseClass}__table`}>
           <caption>Administrator configuration</caption>

--- a/frontend/components/forms/RegistrationForm/FleetDetails/FleetDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/FleetDetails/FleetDetails.jsx
@@ -39,7 +39,7 @@ class FleetDetails extends Component {
     const tabIndex = currentPage ? 1 : -1;
 
     return (
-      <form onSubmit={handleSubmit} className={className}>
+      <form onSubmit={handleSubmit} className={className} autoComplete="off">
         <div className="registration-fields">
           <InputFieldWithIcon
             {...fields.server_url}

--- a/frontend/components/forms/RegistrationForm/OrgDetails/OrgDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/OrgDetails/OrgDetails.jsx
@@ -40,7 +40,7 @@ class OrgDetails extends Component {
     const tabIndex = currentPage ? 1 : -1;
 
     return (
-      <form onSubmit={handleSubmit} className={className}>
+      <form onSubmit={handleSubmit} className={className} autoComplete="off">
         <div className="registration-fields">
           <InputFieldWithIcon
             {...fields.org_name}

--- a/frontend/components/forms/UserSettingsForm/UserSettingsForm.jsx
+++ b/frontend/components/forms/UserSettingsForm/UserSettingsForm.jsx
@@ -44,7 +44,7 @@ class UserSettingsForm extends Component {
     const { renderEmailHint } = this;
 
     return (
-      <form onSubmit={handleSubmit} className={baseClass}>
+      <form onSubmit={handleSubmit} className={baseClass} autoComplete="off">
         <div
           className="smtp-not-configured"
           data-tip

--- a/frontend/components/forms/admin/AppConfigForm/AppConfigForm.jsx
+++ b/frontend/components/forms/admin/AppConfigForm/AppConfigForm.jsx
@@ -324,7 +324,7 @@ class AppConfigForm extends Component {
 
     return (
       <>
-        <form className={baseClass} onSubmit={handleSubmit}>
+        <form className={baseClass} onSubmit={handleSubmit} autoComplete="off">
           <div className={`${baseClass}__section`}>
             <h2>
               <a id="organization-info">Organization info</a>

--- a/frontend/components/forms/packs/EditPackForm/EditPackForm.tsx
+++ b/frontend/components/forms/packs/EditPackForm/EditPackForm.tsx
@@ -117,7 +117,11 @@ const EditPackForm = ({
   };
 
   return (
-    <form className={`${baseClass} ${className}`} onSubmit={onFormSubmit}>
+    <form
+      className={`${baseClass} ${className}`}
+      onSubmit={onFormSubmit}
+      autoComplete="off"
+    >
       <h1>Edit pack</h1>
       <InputField
         onChange={onChangePackName}

--- a/frontend/components/forms/packs/PackForm/PackForm.tsx
+++ b/frontend/components/forms/packs/PackForm/PackForm.tsx
@@ -79,7 +79,7 @@ const EditPackForm = ({
   const packFormClass = classnames(baseClass, className);
 
   return (
-    <form className={packFormClass} onSubmit={onFormSubmit}>
+    <form className={packFormClass} onSubmit={onFormSubmit} autoComplete="off">
       <h1>New pack</h1>
       {baseError && <div className="form__base-error">{baseError}</div>}
       <InputField

--- a/frontend/pages/admin/TeamManagementPage/components/CreateTeamModal/CreateTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/CreateTeamModal/CreateTeamModal.tsx
@@ -42,7 +42,11 @@ const CreateTeamModal = ({
 
   return (
     <Modal title={"Create team"} onExit={onCancel} className={baseClass}>
-      <form className={`${baseClass}__form`} onSubmit={onFormSubmit}>
+      <form
+        className={`${baseClass}__form`}
+        onSubmit={onFormSubmit}
+        autoComplete="off"
+      >
         <InputFieldWithIcon
           autofocus
           // error={errors.name}

--- a/frontend/pages/admin/TeamManagementPage/components/EditTeamModal/EditTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/EditTeamModal/EditTeamModal.tsx
@@ -39,7 +39,11 @@ const EditTeamModal = ({
 
   return (
     <Modal title={"Edit team"} onExit={onCancel} className={baseClass}>
-      <form className={`${baseClass}__form`} onSubmit={onFormSubmit}>
+      <form
+        className={`${baseClass}__form`}
+        onSubmit={onFormSubmit}
+        autoComplete="off"
+      >
         <InputFieldWithIcon
           autofocus
           // error={errors.name}

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -449,7 +449,7 @@ class UserForm extends Component<ICreateUserFormProps, ICreateUserFormState> {
     }
 
     return (
-      <form className={baseClass}>
+      <form className={baseClass} autoComplete="off">
         {/* {baseError && <div className="form__base-error">{baseError}</div>} */}
         <InputFieldWithIcon
           autofocus

--- a/frontend/pages/queries/QueryPage/components/NewQueryModal/NewQueryModal.tsx
+++ b/frontend/pages/queries/QueryPage/components/NewQueryModal/NewQueryModal.tsx
@@ -67,7 +67,7 @@ const NewQueryModal = ({
 
   return (
     <Modal title={"Save query"} onExit={() => setIsSaveModalOpen(false)}>
-      <form className={`${baseClass}__save-modal-form`}>
+      <form className={`${baseClass}__save-modal-form`} autoComplete="off">
         <InputField
           name="name"
           onChange={(value: string) => setName(value)}

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -252,7 +252,7 @@ const QueryForm = ({
 
   const renderForGlobalAdminOrAnyMaintainer = (
     <>
-      <form className={`${baseClass}__wrapper`}>
+      <form className={`${baseClass}__wrapper`} autoComplete="off">
         {isEditMode ? (
           <InputField
             id="query-name"


### PR DESCRIPTION
Cerra #2690 

- Forms with input fields now have autocomplete turned off.
- Did not change autocomplete for log in form
- Did not change autocomplete with forms that do not have input fields

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
