### PR TITLE
Manage Team UI: Disable CTA button if team name is empty

### DIFF
--- a/changes/issue-2701-team-validator
+++ b/changes/issue-2701-team-validator
@@ -1,0 +1,1 @@
+* Cannot click CTA to add or edit a team if the team name is blank

--- a/frontend/pages/admin/TeamManagementPage/components/CreateTeamModal/CreateTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/CreateTeamModal/CreateTeamModal.tsx
@@ -45,7 +45,6 @@ const CreateTeamModal = ({
       <form className={`${baseClass}__form`} onSubmit={onFormSubmit}>
         <InputFieldWithIcon
           autofocus
-          // error={errors.name}
           name="name"
           onChange={onInputChange}
           placeholder="Team name"
@@ -62,7 +61,12 @@ const CreateTeamModal = ({
           </p>
         </InfoBanner>
         <div className={`${baseClass}__btn-wrap`}>
-          <Button className={`${baseClass}__btn`} type="submit" variant="brand">
+          <Button
+            className={`${baseClass}__btn`}
+            type="submit"
+            variant="brand"
+            disabled={name === ""}
+          >
             Create
           </Button>
           <Button

--- a/frontend/pages/admin/TeamManagementPage/components/EditTeamModal/EditTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/EditTeamModal/EditTeamModal.tsx
@@ -42,14 +42,18 @@ const EditTeamModal = ({
       <form className={`${baseClass}__form`} onSubmit={onFormSubmit}>
         <InputFieldWithIcon
           autofocus
-          // error={errors.name}
           name="name"
           onChange={onInputChange}
           placeholder="Team name"
           value={name}
         />
         <div className={`${baseClass}__btn-wrap`}>
-          <Button className={`${baseClass}__btn`} type="submit" variant="brand">
+          <Button
+            className={`${baseClass}__btn`}
+            type="submit"
+            variant="brand"
+            disabled={name === ""}
+          >
             Save
           </Button>
           <Button


### PR DESCRIPTION
Cerra #2701 

- No longer is the user getting a something's gone wrong screen and error flash message
- Disable CTA button for adding a team and editing a team if the team name is empty
- Disable CTA button matches Schedule modal and Add member modal where the form submit button is disabled if the required field is empty (scheduled query, member name, team name respectively)

<img width="1547" alt="Screen Shot 2021-10-27 at 10 53 00 AM" src="https://user-images.githubusercontent.com/71795832/139092463-fcb31210-664a-4dad-ab2d-c16bb221dfa2.png">
<img width="1540" alt="Screen Shot 2021-10-27 at 10 51 42 AM" src="https://user-images.githubusercontent.com/71795832/139092465-db27ad68-dc82-40f7-acd7-c2ebe250382e.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
