### PR TITLE
Update permissions documentation

### DIFF
--- a/docs/01-Using-Fleet/09-Permissions.md
+++ b/docs/01-Using-Fleet/09-Permissions.md
@@ -70,23 +70,20 @@ The following table depicts various permissions levels in a team.
 | Action                                                       | Observer | Maintainer | Admin   |
 | ------------------------------------------------------------ | -------- | ---------- | ------- |
 | Browse hosts assigned to team                                | ✅       | ✅         | ✅       |
-| Browse team policies                                         | ✅       | ✅         | ✅       |
+| Browse policies for hosts assigned to team                   | ✅       | ✅         | ✅       |
 | Filter hosts assigned to team using policies                 | ✅       | ✅         | ✅       |
 | Filter hosts assigned to team using labels                   | ✅       | ✅         | ✅       |
 | Target hosts assigned to team using labels                   | ✅       | ✅         | ✅       |
 | Run saved queries as live queries on hosts assigned to team  | ✅       | ✅         | ✅       |
 | Run custom queries as live queries on hosts assigned to team |          | ✅         | ✅       |
-| Enroll hosts to member team                                  |          | ✅         | ✅       |
-| Delete hosts belonging to member team                        |          | ✅         | ✅       |
-| Create saved queries                                         |          | ✅         | ✅       |
+| Enroll hosts to team                                         |          | ✅         | ✅       |
+| Delete hosts assigned to team                                |          | ✅         | ✅       |
+| Create queries                                               |          | ✅         | ✅       |
 | Edit queries they authored                                   |          | ✅         | ✅       |
 | Delete queries they authored                                 |          | ✅         | ✅       |
-| Add queries to team schedule                                 |          | ✅         | ✅       |
-| Remove queries from team schedule                            |          | ✅         | ✅       |
-| Browse queries from "All teams" schedule                     |          | ✅         | ✅       |
-| Add new team policies                                        |          | ✅         | ✅       |
-| Remove team policies                                         |          | ✅         | ✅       |
-| Browse "All teams" policies                                  |          | ✅         | ✅       |
+| Schedule queries for hosts assigned to team                  |          | ✅         | ✅       |
+| Add policies for hosts assigned to team                      |          | ✅         | ✅       |
+| Remove policies for hosts assigned to team                   |          | ✅         | ✅       |
 | Edit users assigned to team                                  |          |            | ✅       |
 | Remove users assigned to team                                |          |            | ✅       |
 | Edit agent options for hosts assigned to team                |          |            | ✅       |

--- a/docs/01-Using-Fleet/09-Permissions.md
+++ b/docs/01-Using-Fleet/09-Permissions.md
@@ -70,7 +70,7 @@ The following table depicts various permissions levels in a team.
 | Action                                                       | Observer | Maintainer | Admin   |
 | ------------------------------------------------------------ | -------- | ---------- | ------- |
 | Browse hosts assigned to team                                | ✅       | ✅         | ✅       |
-| Browse policies for hosts assigned to team                   | ✅       | ✅         | ✅       |
+| Browse team policies                                         | ✅       | ✅         | ✅       |
 | Filter hosts assigned to team using policies                 | ✅       | ✅         | ✅       |
 | Filter hosts assigned to team using labels                   | ✅       | ✅         | ✅       |
 | Target hosts assigned to team using labels                   | ✅       | ✅         | ✅       |
@@ -81,15 +81,12 @@ The following table depicts various permissions levels in a team.
 | Create saved queries                                         |          | ✅         | ✅       |
 | Edit queries they authored                                   |          | ✅         | ✅       |
 | Delete queries they authored                                 |          | ✅         | ✅       |
-| Create new team schedules                                    |          | ✅         | ✅       |
-| Delete team schedules                                        |          | ✅         | ✅       |
-| Browse global schedules                                      |          | ✅         | ✅       |
-| Create new team policies                                     |          | ✅         | ✅       |
-| Delete team policies                                         |          | ✅         | ✅       |
-| Browse global policies                                       |          | ✅         | ✅       |
-| Create enroll secrets that belong to team                    |          |            | ✅       |
-| Edit enroll secrets that belong to team                      |          |            | ✅       |
-| Delete enroll secrets that belong to team                    |          |            | ✅       |
+| Add queries to team schedule                                 |          | ✅         | ✅       |
+| Remove queries from team schedule                            |          | ✅         | ✅       |
+| Browse queries from "All teams" schedule                     |          | ✅         | ✅       |
+| Add new team policies                                        |          | ✅         | ✅       |
+| Remove team policies                                         |          | ✅         | ✅       |
+| Browse "All teams" policies                                  |          | ✅         | ✅       |
 | Edit users assigned to team                                  |          |            | ✅       |
 | Remove users assigned to team                                |          |            | ✅       |
-| Edit team level agent options                                |          |            | ✅       |
+| Edit agent options for hosts assigned to team                |          |            | ✅       |

--- a/docs/01-Using-Fleet/09-Permissions.md
+++ b/docs/01-Using-Fleet/09-Permissions.md
@@ -35,16 +35,16 @@ The following table depicts various permissions levels for each role.
 | Create labels                                        |          | ✅         | ✅    |
 | Edit labels                                          |          | ✅         | ✅    |
 | Delete labels                                        |          | ✅         | ✅    |
-| Create new global policies                           |          | ✅         | ✅    |
-| Delete global policies                               |          | ✅         | ✅    |
+| Add policies for all hosts                           |          | ✅         | ✅    |
+| Remove policies for all hosts                        |          | ✅         | ✅    |
 | Create users                                         |          |            | ✅    |
 | Edit users                                           |          |            | ✅    |
 | Delete users                                         |          |            | ✅    |
 | Edit organization settings                           |          |            | ✅    |
 | Create enroll secrets                                |          |            | ✅    |
 | Edit enroll secrets                                  |          |            | ✅    |
-| Edit global level agent options                      |          |            | ✅    |
-| Edit team level agent options\*                      |          |            | ✅    |
+| Edit agent options                                   |          |            | ✅    |
+| Edit agent options for hosts assigned to teams\*     |          |            | ✅    |
 | Create teams\*                                       |          |            | ✅    |
 | Edit teams\*                                         |          |            | ✅    |
 | Add members to teams\*                               |          |            | ✅    |
@@ -59,7 +59,9 @@ The following table depicts various permissions levels for each role.
 ℹ️  In Fleet 4.0, the Teams feature was introduced.
 ```
 
-Users either have global access to Fleet or team access to Fleet. Check out [the user permissions table](#user-permissions) above for global user permissions.
+Users either have global access or team access in Fleet. Users with global access can observe and act on all hosts in Fleet. Check out [the user permissions table](#user-permissions) above for global user permissions.
+
+Users with team access can only observe and act on hosts that are assigned to their team.
 
 Users can be a member of multiple teams in Fleet.
 


### PR DESCRIPTION
- Removed create/edit/delete enroll secret permissions from team level users
- Update verbiage to clarify the distinction between users with global access and users with team access.
