### PR TITLE
Add sleep to give orbit a chance to win the id 1 for the host

### DIFF
--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -250,6 +250,9 @@ Use the stop and reset subcommands to manage the server and dependencies once st
 				return errors.Wrap(err, "downloading orbit and osqueryd")
 			}
 
+			// Give it a bit of time so the current device is the one with id 1
+			time.Sleep(2 * time.Second)
+
 			fmt.Println("Starting simulated hosts...")
 			cmd = exec.Command("docker-compose", "up", "-d", "--remove-orphans")
 			cmd.Dir = filepath.Join(previewDir, "osquery")


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- ~Changes file added (for user-visible changes)~
- ~Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
- ~Documented any permissions changes~
- ~Added/updated tests~
- [x] Manual QA for all new/changed functionality
