### PR TITLE
Resetting session for other user won't trigger logout

### DIFF
--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.jsx
@@ -267,15 +267,14 @@ export class UserManagementPage extends Component {
   };
 
   onResetSessions = () => {
-    const { LOGIN } = paths;
     const { currentUser, dispatch } = this.props;
     const { userEditing } = this.state;
     const { toggleResetSessionsUserModal } = this;
-    dispatch(userActions.deleteSessions(userEditing))
+    const isResettingCurrentUser = currentUser.id === userEditing.id;
+
+    dispatch(userActions.deleteSessions(userEditing, isResettingCurrentUser))
       .then(() => {
-        if (currentUser.id === userEditing.id) {
-          dispatch(push(LOGIN));
-        } else {
+        if (!isResettingCurrentUser) {
           dispatch(renderFlash("success", "Sessions reset"));
         }
       })

--- a/frontend/redux/nodes/entities/users/actions.js
+++ b/frontend/redux/nodes/entities/users/actions.js
@@ -116,14 +116,17 @@ export const createUserWithoutInvitation = (formData) => {
   };
 };
 
-export const deleteSessions = (user) => {
+export const deleteSessions = (user, isResettingCurrentUser = false) => {
   const { successAction, destroyFailure, destroySuccess } = actions;
 
   return (dispatch) => {
     return Fleet.users
       .deleteSessions(user)
       .then((userResponse) => {
-        dispatch(logoutSuccess);
+        if (isResettingCurrentUser) {
+          dispatch(logoutSuccess);
+        }
+
         return dispatch(successAction(userResponse, destroySuccess));
       })
       .catch((response) => {


### PR DESCRIPTION
Relates to #2694 

- Fixed bug that logged out current user after resetting session for another

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] ~Changes file added (for user-visible changes)~
- [ ] ~Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
- [ ] ~Documented any permissions changes~
- [ ] ~Added/updated tests~
- [x] Manual QA for all new/changed functionality
