### PR TITLE
Add MVP support for software inventory to osquery-perf for load testing

### DIFF
--- a/cmd/osquery-perf/README.md
+++ b/cmd/osquery-perf/README.md
@@ -11,26 +11,12 @@ The only requirement for running this tool is a working installation of
 
 ## Usage
 
-Typically `go run` is used:
+Typically `go run` is used.
+
+You can use `--help` to view the available configuration:
 
 ```
 go run agent.go --help
-Usage of agent.go:
-  -config_interval duration
-    	Interval for config requests (default 1m0s)
-  -enroll_secret string
-    	Enroll secret to authenticate enrollment
-  -host_count int
-    	Number of hosts to start (default 10) (default 10)
-  -query_interval duration
-    	Interval for live query requests (default 10s)
-  -seed int
-    	Seed for random generator (default current time) (default 1586310930917739000)
-  -server_url string
-    	URL (with protocol and port of osquery server) (default "https://localhost:8080")
-  -start_period duration
-    	Duration to spread start of hosts over (default 10s)
-exit status 2
 ```
 
 The tool should be invoked with the appropriate enroll secret. A typical

--- a/cmd/osquery-perf/mac10.14.6.tmpl
+++ b/cmd/osquery-perf/mac10.14.6.tmpl
@@ -54,256 +54,319 @@
         }
     },
     "host_identifier": "{{ .CachedString "hostname" }}",
-    "platform_type": "21"
+    "platform_type": "16"
 }
 {{- end }}
 
-{{ define "distributed_write" -}}
-{
-  "queries":{
-    "fleet_detail_query_network_interface":[
-      {
-        "point_to_point":"",
-        "address":"fe80::8cb:112d:ff51:1e5d%en0",
-        "mask":"ffff:ffff:ffff:ffff::",
-        "broadcast":"",
-        "interface":"en0",
-        "mac":"f8:2d:88:93:56:5c",
-        "type":"6",
-        "mtu":"1500",
-        "metric":"0",
-        "ipackets":"278493",
-        "opackets":"206238",
-        "ibytes":"275799040",
-        "obytes":"37720064",
-        "ierrors":"0",
-        "oerrors":"0",
-        "idrops":"0",
-        "odrops":"0",
-        "last_change":"1582848084"
-
-},
-      {
-        "point_to_point":"",
-        "address":"192.168.1.3",
-        "mask":"255.255.255.0",
-        "broadcast":"192.168.1.255",
-        "interface":"en0",
-        "mac":"f5:5a:80:92:52:5b",
-        "type":"6",
-        "mtu":"1500",
-        "metric":"0",
-        "ipackets":"278493",
-        "opackets":"206238",
-        "ibytes":"275799040",
-        "obytes":"37720064",
-        "ierrors":"0",
-        "oerrors":"0",
-        "idrops":"0",
-        "odrops":"0",
-        "last_change":"1582848084"
-
-},
-      {
-        "point_to_point":"127.0.0.1",
-        "address":"127.0.0.1",
-        "mask":"255.0.0.0",
-        "broadcast":"",
-        "interface":"lo0",
-        "mac":"00:00:00:00:00:00",
-        "type":"24",
-        "mtu":"16384",
-        "metric":"0",
-        "ipackets":"132952",
-        "opackets":"132952",
-        "ibytes":"67053568",
-        "obytes":"67053568",
-        "ierrors":"0",
-        "oerrors":"0",
-        "idrops":"0",
-        "odrops":"0",
-        "last_change":"1582840871"
-
-},
-      {
-        "point_to_point":"::1",
-        "address":"::1",
-        "mask":"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
-        "broadcast":"",
-        "interface":"lo0",
-        "mac":"00:00:00:00:00:00",
-        "type":"24",
-        "mtu":"16384",
-        "metric":"0",
-        "ipackets":"132952",
-        "opackets":"132952",
-        "ibytes":"67053568",
-        "obytes":"67053568",
-        "ierrors":"0",
-        "oerrors":"0",
-        "idrops":"0",
-        "odrops":"0",
-        "last_change":"1582840871"
-
-},
-      {
-        "point_to_point":"",
-        "address":"fe80::1%lo0",
-        "mask":"ffff:ffff:ffff:ffff::",
-        "broadcast":"",
-        "interface":"lo0",
-        "mac":"00:00:00:00:00:00",
-        "type":"24",
-        "mtu":"16384",
-        "metric":"0",
-        "ipackets":"132952",
-        "opackets":"132952",
-        "ibytes":"67053568",
-        "obytes":"67053568",
-        "ierrors":"0",
-        "oerrors":"0",
-        "idrops":"0",
-        "odrops":"0",
-        "last_change":"1582840871"
-
-},
-      {
-        "point_to_point":"",
-        "address":"fe80::3a:84ff:fe6b:bf75%awdl0",
-        "mask":"ffff:ffff:ffff:ffff::",
-        "broadcast":"",
-        "interface":"awdl0",
-        "mac":"03:3b:94:5b:be:75",
-        "type":"6",
-        "mtu":"1484",
-        "metric":"0",
-        "ipackets":"0",
-        "opackets":"16",
-        "ibytes":"0",
-        "obytes":"3072",
-        "ierrors":"0",
-        "oerrors":"0",
-        "idrops":"0",
-        "odrops":"0",
-        "last_change":"1582842892"
-
-},
-      {
-        "point_to_point":"",
-        "address":"fe80::6eaf:9721:3476:b691%utun0",
-        "mask":"ffff:ffff:ffff:ffff::",
-        "broadcast":"",
-        "interface":"utun0",
-        "mac":"00:00:00:00:00:00",
-        "type":"1",
-        "mtu":"2000",
-        "metric":"0",
-        "ipackets":"0",
-        "opackets":"2",
-        "ibytes":"0",
-        "obytes":"0",
-        "ierrors":"0",
-        "oerrors":"0",
-        "idrops":"0",
-        "odrops":"0",
-        "last_change":"1582840897"
-
-}
-
-],
-    "fleet_detail_query_os_version":[
-      {
-        "name":"Mac OS X",
-        "version":"10.14.6",
-        "major":"10",
-        "minor":"14",
-        "patch":"6",
-        "build":"18G3020",
-        "platform":"darwin",
-        "platform_like":"darwin",
-        "codename":""
-
-}
-
-],
-    "fleet_detail_query_osquery_flags":[
-      {
-        "name":"config_refresh",
-        "value":"{{ printf "%.0f" .ConfigInterval.Seconds }}"
-
-},
-      {
-        "name":"distributed_interval",
-        "value":"{{ printf "%.0f" .QueryInterval.Seconds }}"
-
-},
-      {
-        "name":"logger_tls_period",
-        "value":"99999"
-
-}
-
-],
-    "fleet_detail_query_osquery_info":[
-      {
-        "pid":"11287",
-        "uuid":"{{ .UUID }}",
-        "instance_id":"{{ .UUID }}",
-        "version":"4.1.2",
-        "config_hash":"b01efbf375ac6767f259ae98751154fef727ce35",
-        "config_valid":"1",
-        "extensions":"inactive",
-        "build_platform":"darwin",
-        "build_distro":"10.12",
-        "start_time":"1582857555",
-        "watcher":"11286",
-        "platform_mask":"21"
-
-}
-
-],
-    "fleet_detail_query_system_info":[
-      {
-        "hostname":"{{ .CachedString "hostname" }}",
-        "uuid":"4740D59F-699E-5B29-960B-979AAF9BBEEB",
-        "cpu_type":"x86_64h",
-        "cpu_subtype":"Intel x86-64h Haswell",
-        "cpu_brand":"Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz",
-        "cpu_physical_cores":"4",
-        "cpu_logical_cores":"8",
-        "cpu_microcode":"",
-        "physical_memory":"17179869184",
-        "hardware_vendor":"Apple Inc.",
-        "hardware_model":"MacBookPro11,4",
-        "hardware_version":"1.0",
-        "hardware_serial":"C02R262BM8LN",
-        "computer_name":"{{ .CachedString "hostname" }}",
-        "local_hostname":"{{ .CachedString "hostname" }}"
-
-}
-
-],
-    "fleet_detail_query_uptime":[
-      {
-        "days":"0",
-        "hours":"4",
-        "minutes":"38",
-        "seconds":"11",
-        "total_seconds":"16691"
-
-}
-
+{{ define "fleet_detail_query_network_interface" -}}
+[
+  {
+    "point_to_point":"",
+    "address":"fe80::8cb:112d:ff51:1e5d%en0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"en0",
+    "mac":"f8:2d:88:93:56:5c",
+    "type":"6",
+    "mtu":"1500",
+    "metric":"0",
+    "ipackets":"278493",
+    "opackets":"206238",
+    "ibytes":"275799040",
+    "obytes":"37720064",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582848084"
+  },
+  {
+    "point_to_point":"",
+    "address":"192.168.1.3",
+    "mask":"255.255.255.0",
+    "broadcast":"192.168.1.255",
+    "interface":"en0",
+    "mac":"f5:5a:80:92:52:5b",
+    "type":"6",
+    "mtu":"1500",
+    "metric":"0",
+    "ipackets":"278493",
+    "opackets":"206238",
+    "ibytes":"275799040",
+    "obytes":"37720064",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582848084"
+  },
+  {
+    "point_to_point":"127.0.0.1",
+    "address":"127.0.0.1",
+    "mask":"255.0.0.0",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"::1",
+    "address":"::1",
+    "mask":"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::1%lo0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::3a:84ff:fe6b:bf75%awdl0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"awdl0",
+    "mac":"03:3b:94:5b:be:75",
+    "type":"6",
+    "mtu":"1484",
+    "metric":"0",
+    "ipackets":"0",
+    "opackets":"16",
+    "ibytes":"0",
+    "obytes":"3072",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582842892"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::6eaf:9721:3476:b691%utun0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"utun0",
+    "mac":"00:00:00:00:00:00",
+    "type":"1",
+    "mtu":"2000",
+    "metric":"0",
+    "ipackets":"0",
+    "opackets":"2",
+    "ibytes":"0",
+    "obytes":"0",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840897"
+  }
 ]
+{{- end }}
+{{ define "fleet_detail_query_os_version" -}}
+[
+  {
+    "name":"Mac OS X",
+    "version":"10.14.6",
+    "major":"10",
+    "minor":"14",
+    "patch":"6",
+    "build":"18G3020",
+    "platform":"darwin",
+    "platform_like":"darwin",
+    "codename":""
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_flags" -}}
+[
+  {
+    "name":"config_refresh",
+    "value":"{{ printf "%.0f" .ConfigInterval.Seconds }}"
+  },
+  {
+    "name":"distributed_interval",
+    "value":"{{ printf "%.0f" .QueryInterval.Seconds }}"
+  },
+  {
+    "name":"logger_tls_period",
+    "value":"99999"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_info" -}}
+[
+  {
+    "pid":"11287",
+    "uuid":"{{ .UUID }}",
+    "instance_id":"{{ .UUID }}",
+    "version":"4.1.2",
+    "config_hash":"b01efbf375ac6767f259ae98751154fef727ce35",
+    "config_valid":"1",
+    "extensions":"inactive",
+    "build_platform":"darwin",
+    "build_distro":"10.12",
+    "start_time":"1582857555",
+    "watcher":"11286",
+    "platform_mask":"21"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_system_info" -}}
+[
+  {
+    "hostname":"{{ .CachedString "hostname" }}",
+    "uuid":"4740D59F-699E-5B29-960B-979AAF9BBEEB",
+    "cpu_type":"x86_64h",
+    "cpu_subtype":"Intel x86-64h Haswell",
+    "cpu_brand":"Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz",
+    "cpu_physical_cores":"4",
+    "cpu_logical_cores":"8",
+    "cpu_microcode":"",
+    "physical_memory":"17179869184",
+    "hardware_vendor":"Apple Inc.",
+    "hardware_model":"MacBookPro11,4",
+    "hardware_version":"1.0",
+    "hardware_serial":"C02R262BM8LN",
+    "computer_name":"{{ .CachedString "hostname" }}",
+    "local_hostname":"{{ .CachedString "hostname" }}"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_uptime" -}}
+[
+  {
+    "days":"0",
+    "hours":"4",
+    "minutes":"38",
+    "seconds":"11",
+    "total_seconds":"16691"
+  }
+]
+{{- end }}
 
-},
-  "statuses":{
-    "fleet_detail_query_network_interface":0,
-    "fleet_detail_query_os_version":0,
-    "fleet_detail_query_osquery_flags":0,
-    "fleet_detail_query_osquery_info":0,
-    "fleet_detail_query_system_info":0,
-    "fleet_detail_query_uptime":0
-},
-  "node_key":"{{ .NodeKey }}"
-}
+{{ define "fleet_detail_query_users" -}}
+[
+  {
+    "uid":"0",
+    "username":"gandalf",
+    "type":"wizard",
+    "groupname":"bree"
+  },
+  {
+    "uid":"1",
+    "username":"frodo",
+    "type":"hobbit",
+    "groupname":"shire"
+  },
+  {
+    "uid":"1",
+    "username":"sam",
+    "type":"hobbit",
+    "groupname":"shire"
+  },
+  {
+    "uid":"1",
+    "username":"legolas",
+    "type":"elve",
+    "groupname":"mirkwood"
+  }
+]
+{{- end }}
+
+{{/* all hosts */}}
+{{ define "fleet_label_query_6" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All macOS hosts */}}
+{{ define "fleet_label_query_7" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All Ubuntu hosts */}}
+{{ define "fleet_label_query_8" -}}
+[]
+{{- end }}
+
+{{/* All CentOS hosts */}}
+{{ define "fleet_label_query_9" -}}
+[]
+{{- end }}
+
+{{/* All Windows hosts */}}
+{{ define "fleet_label_query_10" -}}
+[]
+{{- end }}
+
+{{/* All Red Hat hosts */}}
+{{ define "fleet_label_query_11" -}}
+[]
+{{- end }}
+
+{{/* All Linux distributions */}}
+{{ define "fleet_label_query_12" -}}
+[]
+{{- end }}
+
+{{ define "fleet_detail_query_software_macos" -}}
+[
+  {{ range $index, $item := .SoftwareMacOS }}
+  {{if $index}},{{end}}
+  {
+    "name": "{{ .Name }}_{{ $index }}",
+    "version": "{{ .Version }}",
+    "type": "Application (macOS)",
+    "bundle_identifier": "{{ .BundleIdentifier }}",
+    "source": "apps"
+  }
+  {{- end }}
+]
 {{- end }}

--- a/server/service/endpoint_osquery.go
+++ b/server/service/endpoint_osquery.go
@@ -94,7 +94,7 @@ func makeGetDistributedQueriesEndpoint(svc fleet.Service) endpoint.Endpoint {
 // Write Distributed Query Results
 ////////////////////////////////////////////////////////////////////////////////
 
-type submitDistributedQueryResultsRequest struct {
+type SubmitDistributedQueryResultsRequest struct {
 	NodeKey  string                               `json:"node_key"`
 	Results  fleet.OsqueryDistributedQueryResults `json:"queries"`
 	Statuses map[string]fleet.OsqueryStatus       `json:"statuses"`
@@ -109,7 +109,7 @@ func (r submitDistributedQueryResultsResponse) error() error { return r.Err }
 
 func makeSubmitDistributedQueryResultsEndpoint(svc fleet.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		req := request.(submitDistributedQueryResultsRequest)
+		req := request.(SubmitDistributedQueryResultsRequest)
 		err := svc.SubmitDistributedQueryResults(ctx, req.Results, req.Statuses, req.Messages)
 		if err != nil {
 			return submitDistributedQueryResultsResponse{Err: err}, nil

--- a/server/service/integration_live_queries_test.go
+++ b/server/service/integration_live_queries_test.go
@@ -95,7 +95,7 @@ func (s *liveQueriesTestSuite) TestLiveQueriesRestOneHostOneQuery() {
 
 	cid := getCIDForQ(s, q1)
 
-	distributedReq := submitDistributedQueryResultsRequest{
+	distributedReq := SubmitDistributedQueryResultsRequest{
 		NodeKey: host.NodeKey,
 		Results: map[string][]map[string]string{
 			hostDistributedQueryPrefix + cid: {{"col1": "a", "col2": "b"}},
@@ -159,7 +159,7 @@ func (s *liveQueriesTestSuite) TestLiveQueriesRestOneHostMultipleQuery() {
 	cid1 := getCIDForQ(s, q1)
 	cid2 := getCIDForQ(s, q2)
 
-	distributedReq := submitDistributedQueryResultsRequest{
+	distributedReq := SubmitDistributedQueryResultsRequest{
 		NodeKey: host.NodeKey,
 		Results: map[string][]map[string]string{
 			hostDistributedQueryPrefix + cid1: {{"col1": "a", "col2": "b"}},
@@ -257,7 +257,7 @@ func (s *liveQueriesTestSuite) TestLiveQueriesRestMultipleHostMultipleQuery() {
 	cid1 := getCIDForQ(s, q1)
 	cid2 := getCIDForQ(s, q2)
 	for i, h := range []*fleet.Host{h1, h2} {
-		distributedReq := submitDistributedQueryResultsRequest{
+		distributedReq := SubmitDistributedQueryResultsRequest{
 			NodeKey: h.NodeKey,
 			Results: map[string][]map[string]string{
 				hostDistributedQueryPrefix + cid1: {{"col1": fmt.Sprintf("a%d", i), "col2": fmt.Sprintf("b%d", i)}},
@@ -352,7 +352,7 @@ func (s *liveQueriesTestSuite) TestLiveQueriesRestFailsOnSomeHost() {
 	// Give the above call a couple of seconds to create the campaign
 	time.Sleep(2 * time.Second)
 	cid1 := getCIDForQ(s, q1)
-	distributedReq := submitDistributedQueryResultsRequest{
+	distributedReq := SubmitDistributedQueryResultsRequest{
 		NodeKey: h1.NodeKey,
 		Results: map[string][]map[string]string{
 			hostDistributedQueryPrefix + cid1: {{"col1": "a", "col2": "b"}},
@@ -367,7 +367,7 @@ func (s *liveQueriesTestSuite) TestLiveQueriesRestFailsOnSomeHost() {
 	distributedResp := submitDistributedQueryResultsResponse{}
 	s.DoJSON("POST", "/api/v1/osquery/distributed/write", distributedReq, http.StatusOK, &distributedResp)
 
-	distributedReq = submitDistributedQueryResultsRequest{
+	distributedReq = SubmitDistributedQueryResultsRequest{
 		NodeKey: h2.NodeKey,
 		Results: map[string][]map[string]string{
 			hostDistributedQueryPrefix + cid1: {},

--- a/server/service/transport_osquery.go
+++ b/server/service/transport_osquery.go
@@ -95,7 +95,7 @@ func decodeSubmitDistributedQueryResultsRequest(ctx context.Context, r *http.Req
 		}
 	}
 
-	req := submitDistributedQueryResultsRequest{
+	req := SubmitDistributedQueryResultsRequest{
 		NodeKey:  shim.NodeKey,
 		Results:  results,
 		Statuses: statuses,

--- a/server/service/transport_osquery_test.go
+++ b/server/service/transport_osquery_test.go
@@ -85,7 +85,7 @@ func TestDecodeSubmitDistributedQueryResultsRequest(t *testing.T) {
 		r, err := decodeSubmitDistributedQueryResultsRequest(context.Background(), request)
 		require.Nil(t, err)
 
-		params := r.(submitDistributedQueryResultsRequest)
+		params := r.(SubmitDistributedQueryResultsRequest)
 		assert.Equal(t, "key", params.NodeKey)
 		assert.Equal(t, fleet.OsqueryDistributedQueryResults{
 			"id1": {


### PR DESCRIPTION
- Adds minimal support for software inventory to osquery-perf.
- Osquery-perf agents identify themselves as macOS (hardcoded for now). Fixes: #2514 
- I'll improve code quality and add more functionality later, but wanted to have this ready ASAP for load testing.

~- [ ] Changes file added (for user-visible changes)~
~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality
