### PR TITLE
Enhance UI for query-platform compatibility checks in new/edit query form

### DIFF
--- a/changes/issue-2628-2697-query-compatibility
+++ b/changes/issue-2628-2697-query-compatibility
@@ -1,0 +1,5 @@
+* Add improved UI messaging for query-platform compatibility checks in case of invalid sql syntax and
+queries that return no compatible platforms
+* Change query-platform compatibility response if query is valid sql but includes no tables (e.g.,
+`SELECT 1 WHERE FALSE`) to indicate the query is compatible on all platforms rather than none
+* Add tooltip to explain compatibility is estimated based on the tables present in the query

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useContext, useEffect } from "react";
+import React, { useState, useContext, useEffect } from "react";
 import { IAceEditor } from "react-ace/lib/types";
 import ReactTooltip from "react-tooltip";
 import { size } from "lodash";
@@ -49,7 +49,7 @@ const validateQuerySQL = (query: string) => {
   return { valid, errors };
 };
 
-// https://usehooks.com/useDebounce/
+// This custom hook is adapted from https://github.com/uidotdev/usehooks/blob/master/src/pages/useDebounce.md
 const useDebounce = (value: number | string, delay: number) => {
   // State and setters for debounced value
   const [debouncedValue, setDebouncedValue] = useState(value);
@@ -111,7 +111,7 @@ const QueryForm = ({
     isGlobalMaintainer,
   } = useContext(AppContext);
 
-  const debouncedQueryString = useDebounce(lastEditedQueryBody, 500);
+  const debouncedQueryString = useDebounce(lastEditedQueryBody, 250);
 
   useEffect(
     () =>
@@ -121,12 +121,6 @@ const QueryForm = ({
 
     [debouncedQueryString]
   );
-
-  // useEffect(() => {
-  //   setCompatiblePlatforms(
-  //     listCompatiblePlatforms(parseSqlTables(lastEditedQueryBody))
-  //   );
-  // }, [lastEditedQueryBody]);
 
   const hasTeamMaintainerPermissions = isEditMode
     ? isAnyTeamMaintainerOrTeamAdmin &&

--- a/frontend/pages/queries/QueryPage/components/QueryForm/_styles.scss
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/_styles.scss
@@ -116,20 +116,34 @@
     b,
     img,
     span {
-      display: inline-flex;
+      display: flex;
       align-items: center;
     }
 
-    b,
-    span {
-      padding-right: $pad-small;
-      margin-right: $pad-xsmall;
+    b {
+      padding-right: $pad-xsmall;
     }
 
     img {
       height: 16px;
       width: auto;
       padding-left: $pad-xsmall;
+    }
+
+    .tooltip {
+      padding-right: 12px;
+
+      img {
+        padding: 0px;
+      }
+
+      &__tooltip-text {
+        text-align: center;
+      }
+    }
+
+    .platform {
+      padding-right: 12px;
     }
   }
 }

--- a/frontend/utilities/sql_tools.js
+++ b/frontend/utilities/sql_tools.js
@@ -31,7 +31,10 @@ const _visit = (abstractSyntaxTree, callback) => {
 };
 
 export const listCompatiblePlatforms = (tablesList) => {
-  if (tablesList[0] === "Invalid query") {
+  if (
+    tablesList[0] === "Invalid query" ||
+    tablesList[0] === "No tables in query AST"
+  ) {
     return tablesList;
   }
   const compatiblePlatforms = intersection(
@@ -60,9 +63,9 @@ export const parseSqlTables = (sqlString) => {
     const sqlTree = sqliteParser(sqlString);
     _visit(sqlTree, _callback);
 
-    return tablesList;
+    return tablesList.length ? tablesList : ["No tables in query AST"];
   } catch (err) {
-    console.log(`Invalid query syntax: ${err.message}\n\n${sqlString}`);
+    // console.log(`Invalid query syntax: ${err.message}\n\n${sqlString}`);
 
     return ["Invalid query"];
   }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "select": "1.1.2",
     "sockjs-client": "^1.4.0",
     "sqlite-parser": "1.0.1",
+    "use-debounce": "^7.0.0",
     "whatwg-fetch": "0.11.1",
     "when": "3.7.8"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13273,6 +13273,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-debounce@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-7.0.0.tgz#00a67d23d4fe09905e11145a99278da06c01c880"
+  integrity sha512-4fvxEEs7ztdNMh+c497HAgysdq2+Ascem6EaDANGlCIap1JzqfL03Xw8xkYc2lShfXm4uO6PA6V5zcXN7gJdFA==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"


### PR DESCRIPTION
* Add improved UI messaging for query-platform compatibility checks in case of invalid sql syntax and
queries that return no compatible platforms
* Change query-platform compatibility response if query is valid sql but includes no tables (e.g.,
`SELECT 1 WHERE FALSE`) to indicate the query is compatible on all platforms rather than none
* Add tooltip to explain compatibility is estimated based on the tables present in the query

Covers issues #2628 & #2697

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
