### PR TITLE
Teams API: Free tier no longer calls team API throughout the app

### DIFF
--- a/changes/issue-2517-free-tier-no-teams-api
+++ b/changes/issue-2517-free-tier-no-teams-api
@@ -1,1 +1,1 @@
-* Bug fix: Free Tier does not call teams API (fix: host details page, edit packs page, schedule page)
+* Bug fix: Free Tier does not call teams API (fix: host details page, edit packs page)

--- a/changes/issue-2517-free-tier-no-teams-api
+++ b/changes/issue-2517-free-tier-no-teams-api
@@ -1,0 +1,1 @@
+* Bug fix: Free Tier does not call teams API (fix: host details page, edit packs page, schedule page)

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.tsx
@@ -172,7 +172,7 @@ const HostDetailsPage = ({
     Error,
     ITeam[]
   >("teams", () => teamAPI.loadAll(), {
-    enabled: !!hostIdFromURL && isPremiumTier,
+    enabled: !!hostIdFromURL && !!isPremiumTier,
     refetchOnMount: false,
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,

--- a/frontend/pages/packs/EditPackPage/EditPackPage.tsx
+++ b/frontend/pages/packs/EditPackPage/EditPackPage.tsx
@@ -161,6 +161,7 @@ const EditPacksPage = ({
     ["all teams"],
     () => teamsAPI.loadAll(),
     {
+      enabled: !!isPremiumTier,
       select: (data: IStoredTeamsResponse) => data.teams,
     }
   );

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -196,9 +196,7 @@ const ManageSchedulePage = ({
 
   useEffect(() => {
     dispatch(queryActions.loadAll());
-    {
-      isPremiumTier && dispatch(teamActions.loadAll());
-    }
+    dispatch(teamActions.loadAll());
     dispatch(
       teamId
         ? teamScheduledQueryActions.loadAll(teamId)

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -148,7 +148,7 @@ const ManageSchedulePage = ({
   const { MANAGE_PACKS } = paths;
   const handleAdvanced = () => dispatch(push(MANAGE_PACKS));
 
-  const { currentUser, isOnGlobalTeam } = useContext(AppContext);
+  const { currentUser, isOnGlobalTeam, isPremiumTier } = useContext(AppContext);
 
   const isTeamMaintainerOrTeamAdmin = (() => {
     return !!permissionUtils.isTeamMaintainerOrTeamAdmin(currentUser, teamId);
@@ -196,17 +196,15 @@ const ManageSchedulePage = ({
 
   useEffect(() => {
     dispatch(queryActions.loadAll());
-    dispatch(teamActions.loadAll());
+    {
+      isPremiumTier && dispatch(teamActions.loadAll());
+    }
     dispatch(
       teamId
         ? teamScheduledQueryActions.loadAll(teamId)
         : globalScheduledQueryActions.loadAll()
     );
   }, [dispatch, teamId]);
-
-  const isPremiumTier = useSelector((state: IRootState) => {
-    return state.app.config.tier === "premium";
-  });
 
   const user = useSelector(
     (state: IRootState): IUser => {


### PR DESCRIPTION
Cerra #2517 

Fixed on:
- Host details page
- Edit pack page

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
