### PR TITLE
Create/Edit pack UX: Pack save redirects to manage packs page, fix flash message

### DIFF
--- a/changes/issue-2749-save-pack-redirect
+++ b/changes/issue-2749-save-pack-redirect
@@ -1,0 +1,1 @@
+* Saving a pack redirects to the Manage Packs Page, fix flash render after creating pack

--- a/frontend/pages/packs/EditPackPage/EditPackPage.tsx
+++ b/frontend/pages/packs/EditPackPage/EditPackPage.tsx
@@ -36,6 +36,7 @@ import PackQueryEditorModal from "./components/PackQueryEditorModal";
 import RemovePackQueryModal from "./components/RemovePackQueryModal";
 
 interface IEditPacksPageProps {
+  router: any;
   params: Params;
 }
 
@@ -71,6 +72,7 @@ interface IFormData {
 const baseClass = "edit-pack-page";
 
 const EditPacksPage = ({
+  router,
   params: { id: paramsPackId },
 }: IEditPacksPageProps): JSX.Element => {
   const { isPremiumTier } = useContext(AppContext);
@@ -225,8 +227,7 @@ const EditPacksPage = ({
     packsAPI
       .update(packId, updatedPack)
       .then(() => {
-        refetchStoredPack();
-        window.scrollTo(0, 0);
+        router.push(PATHS.MANAGE_PACKS);
         dispatch(renderFlash("success", `Successfully updated this pack.`));
       })
       .catch((response) => {

--- a/frontend/pages/packs/EditPackPage/EditPackPage.tsx
+++ b/frontend/pages/packs/EditPackPage/EditPackPage.tsx
@@ -104,13 +104,13 @@ const EditPacksPage = ({
     }
   );
 
-  const { data: storedPack, refetch: refetchStoredPack } = useQuery<
-    IStoredPackResponse,
-    Error,
-    IPack
-  >(["stored pack"], () => packsAPI.load(packId), {
-    select: (data: IStoredPackResponse) => data.pack,
-  });
+  const { data: storedPack } = useQuery<IStoredPackResponse, Error, IPack>(
+    ["stored pack"],
+    () => packsAPI.load(packId),
+    {
+      select: (data: IStoredPackResponse) => data.pack,
+    }
+  );
 
   const {
     data: storedPackQueries,

--- a/frontend/pages/packs/PackComposerPage/PackComposerPage.jsx
+++ b/frontend/pages/packs/PackComposerPage/PackComposerPage.jsx
@@ -41,25 +41,20 @@ export class PackComposerPage extends Component {
     return false;
   };
 
-  visitPackPage = (packID) => {
-    const { dispatch } = this.props;
-
-    dispatch(push(PATHS.PACK(packID)));
-
-    return false;
-  };
-
   handleSubmit = (formData) => {
     const { create } = packActions;
     const { dispatch } = this.props;
-    const { visitPackPage } = this;
 
     return dispatch(create(formData))
       .then((pack) => {
         const { id: packID } = pack;
-
-        dispatch(renderFlash("success", `Pack successfully created.`));
-        visitPackPage(packID);
+        dispatch(push(PATHS.PACK(packID)));
+        dispatch(
+          renderFlash(
+            "success",
+            "Pack successfully created. Add queries to your pack."
+          )
+        );
       })
       .catch((response) => {
         if (response.base.slice(0, 27) === "Error 1062: Duplicate entry") {


### PR DESCRIPTION
Cerra #2749 

- Saving an edited pack redirects to Manage Packs Page
- Saving a new pack renders a flash message

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
