### PR TITLE
Manage Policies Page:  Pass fail UI

### DIFF
--- a/changes/issue-2593-yes-no-policies
+++ b/changes/issue-2593-yes-no-policies
@@ -1,0 +1,1 @@
+* Policies UI replaces Passing/Failing with Yes/No for improved readability

--- a/cypress/integration/all/app/policiesflow.spec.ts
+++ b/cypress/integration/all/app/policiesflow.spec.ts
@@ -48,7 +48,7 @@
 //       cy.findByText(/select query/i).should("not.exist");
 //       cy.get(".policies-list-wrapper").within(() => {
 //         cy.findByText(/1 query/i).should("exist");
-//         cy.findByText(/passing/i).should("exist");
+//         cy.findByText(/yes/i).should("exist");
 //         cy.findByText(
 //           /Detect Linux hosts with high severity vulnerable versions of OpenSSL/i
 //         ).should("exist");
@@ -66,11 +66,11 @@
 //         cy.findByText(
 //           /Detect Linux hosts with high severity vulnerable versions of OpenSSL/i
 //         ).should("exist");
-//         cy.findByText(/passing/i).should("not.exist");
+//         cy.findByText(/yes/i).should("not.exist");
 //         cy.findByText(/failing/i)
 //           .should("exist")
 //           .click();
-//         cy.findByText(/passing/i).should("exist");
+//         cy.findByText(/yes/i).should("exist");
 //         cy.get('img[alt="Remove policy filter"]').click();
 //         cy.findByText(
 //           /Detect Linux hosts with high severity vulnerable versions of OpenSSL/i

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -218,8 +218,8 @@
         border-radius: 100%;
         content: " ";
         display: inline-block;
-        height: 8px;
         margin-right: $pad-small;
+        height: 8px;
         width: 8px;
         margin-bottom: 1px;
       }
@@ -233,6 +233,20 @@
       &--disabled:before,
       &--mia:before {
         background-color: $ui-offline;
+      }
+
+      &--yes:before {
+        padding-right: 10px;
+        content: url(../assets/images/icon-check-circle-green-16x16@2x.png);
+        transform: scale(0.5);
+        vertical-align: text-top;
+      }
+
+      &--no:before {
+        padding-right: 10px;
+        content: url(../assets/images/icon-exclamation-circle-red-16x16@2x.png);
+        transform: scale(0.5);
+        vertical-align: text-top;
       }
 
       &--mia {

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -53,6 +53,16 @@
       text-align: left;
       border-bottom: 1px solid $ui-fleet-blue-15;
 
+      img {
+        width: 16px;
+        height: 16px;
+        vertical-align: sub;
+      }
+
+      .header-icon-text {
+        margin-left: 10px;
+      }
+
       th {
         padding: $pad-medium 27px;
         white-space: nowrap;

--- a/frontend/pages/hosts/HostDetailsPage/HostPoliciesTable/HostPoliciesTableConfig.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostPoliciesTable/HostPoliciesTableConfig.tsx
@@ -42,9 +42,9 @@ interface IDataColumn {
 
 const getPolicyStatus = (policy: IHostPolicy): string => {
   if (policy.response === "pass") {
-    return "Passing";
+    return "Yes";
   } else if (policy.response === "fail") {
-    return "Failing";
+    return "No";
   }
   return "---";
 };

--- a/frontend/pages/hosts/HostDetailsPage/HostPoliciesTable/HostPoliciesTableConfig.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostPoliciesTable/HostPoliciesTableConfig.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router";
 import PATHS from "router/paths";
-import TextCell from "components/TableContainer/DataTable/TextCell";
+import StatusCell from "components/TableContainer/DataTable/StatusCell";
 import Button from "components/buttons/Button";
 import { IHostPolicy } from "interfaces/host_policy";
 import { PolicyResponse } from "utilities/constants";
@@ -85,7 +85,7 @@ const generatePolicyTableHeaders = (
       accessor: "response",
       disableSortBy: true,
       Cell: (cellProps) => {
-        return <TextCell value={getPolicyStatus(cellProps.row.original)} />;
+        return <StatusCell value={getPolicyStatus(cellProps.row.original)} />;
       },
     },
     {

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -386,12 +386,15 @@
     .linkToFilteredHosts__header {
       width: 0;
     }
+
     .policy-link img {
       width: 16px;
     }
+
     .table-container__header {
       display: none;
     }
+
     .info-banner {
       margin-bottom: 1rem;
       p {
@@ -402,6 +405,14 @@
         text-decoration: none;
         font-weight: bold;
       }
+    }
+
+    th:first-child {
+      width: 70%;
+    }
+
+    th:nth-last-child(2) {
+      border-right: none !important;
     }
   }
 

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -214,7 +214,6 @@
     margin-right: $pad-small;
   }
 
-  .issues__header,
   .host-issue {
     img {
       width: 16px;

--- a/frontend/pages/hosts/ManageHostsPage/components/PoliciesFilter/PoliciesFilter.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/PoliciesFilter/PoliciesFilter.tsx
@@ -14,15 +14,13 @@ const baseClass = "policies-filter";
 const POLICY_RESPONSE_OPTIONS = [
   {
     disabled: false,
-    label: "Passing",
+    label: "Yes",
     value: PolicyResponse.PASSING,
-    helpText: "Hosts that passed the last time they checked into Fleet.",
   },
   {
     disabled: false,
-    label: "Failing",
+    label: "No",
     value: PolicyResponse.FAILING,
-    helpText: "Hosts that failed the last time they checked into Fleet.",
   },
 ];
 

--- a/frontend/pages/hosts/ManageHostsPage/components/PoliciesFilter/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/PoliciesFilter/_styles.scss
@@ -4,14 +4,18 @@
   align-items: center;
 
   &__status_dropdown {
-    width: 159px;
+    width: 114px;
 
     .Select-menu-outer {
-      width: 364px;
+      width: 114px;
       max-height: 310px;
 
       .Select-menu {
         max-height: none;
+
+        .dropdown__option {
+          font-size: $small !important;
+        }
       }
     }
     .Select-value {
@@ -31,6 +35,7 @@
     }
     .Select-value-label {
       padding-left: $pad-large;
+      font-size: $small !important;
     }
   }
 }

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesListWrapper/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesListWrapper/PoliciesTableConfig.tsx
@@ -12,6 +12,8 @@ import { IPolicy } from "interfaces/policy";
 import PATHS from "router/paths";
 import sortUtils from "utilities/sort";
 import { PolicyResponse } from "utilities/constants";
+import PassIcon from "../../../../../../assets/images/icon-check-circle-green-16x16@2x.png";
+import FailIcon from "../../../../../../assets/images/icon-exclamation-circle-red-16x16@2x.png";
 
 // TODO functions for paths math e.g., path={PATHS.MANAGE_HOSTS + getParams(cellProps.row.original)}
 
@@ -91,8 +93,13 @@ const generateTableHeaders = (options: {
           ),
         },
         {
-          title: "Passing",
-          Header: "Passing",
+          title: "Yes",
+          Header: () => (
+            <>
+              <img alt="host passing" src={PassIcon} />
+              <span className="header-icon-text">Yes</span>
+            </>
+          ),
           disableSortBy: true,
           accessor: "passing_host_count",
           Cell: (cellProps: ICellProps): JSX.Element => (
@@ -110,8 +117,13 @@ const generateTableHeaders = (options: {
           ),
         },
         {
-          title: "Failing",
-          Header: "Failing",
+          title: "No",
+          Header: () => (
+            <>
+              <img alt="host passing" src={FailIcon} />
+              <span className="header-icon-text">No</span>
+            </>
+          ),
           disableSortBy: true,
           accessor: "failing_host_count",
           Cell: (cellProps: ICellProps): JSX.Element => (


### PR DESCRIPTION
Cerra #2593 

- Updates language around policies to Yes/No

Host Details Page
<img width="1170" alt="Screen Shot 2021-11-02 at 2 11 58 PM" src="https://user-images.githubusercontent.com/71795832/139921904-edcca68c-7a5f-424a-a150-74a2dbc1393a.png">

Manage Policies Page
<img width="1185" alt="Screen Shot 2021-11-02 at 1 19 53 PM" src="https://user-images.githubusercontent.com/71795832/139921809-c2634ff0-de8c-4769-b9dc-3069dc098919.png">

Manage Hosts Page with Policy Filter
<img width="1184" alt="Screen Shot 2021-11-02 at 1 19 38 PM" src="https://user-images.githubusercontent.com/71795832/139921848-a1c9b9a9-b31e-4f53-b567-5fd64289a0cd.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
