### PR TITLE
Add top level links to "Contributing" section and move up Load testing "Results"

### DIFF
--- a/docs/02-Deploying/05-Load-testing.md
+++ b/docs/02-Deploying/05-Load-testing.md
@@ -2,42 +2,15 @@
 
 The following document outlines the most recent results of a semi-annual load test of the Fleet server. These tests are conducted by the Fleet team. 
 
-Fleet uses [osquery-perf](https://github.com/fleetdm/fleet/tree/main/cmd/osquery-perf), a free and open source tool, to generate realistic traffic to the Fleet server.
-
 A test is deemed successful when the Fleet server is able to receive and make requests to the specified number of hosts without over utilizing the specified resources. In addition, a successful test must report that the Fleet server can run a live query against the specified number of hosts.
 
-This document reports the minimum resources for successfully running Fleet with 1,000 hosts and 150,000 hosts. 
+This document reports the minimum resources for successfully running Fleet with 1,000 hosts and 150,000 hosts.
+
+Fleet uses [osquery-perf](https://github.com/fleetdm/fleet/tree/main/cmd/osquery-perf), a free and open source tool, to generate realistic traffic to the Fleet server.
 
 ## Test parameters
 
 The Fleet load tests are conducted with a Fleet server that contains 2 packs, with ~6 queries each, and 6 labels.
-
-## How we are simulating osquery
-
-The simulation is run by using [osquery-perf](https://github.com/fleetdm/fleet/tree/main/cmd/osquery-perf).
-
-The following command enrolls and simulates 150,000 hosts on Fleet:
-
-```bash
-go run cmd/osquery-perf/agent.go -enroll_secret <secret here> -host_count 150000 -server_url <server URL here> -node_key_file nodekeys
-```
-
-After the hosts have been enrolled, you can add `-only_already_enrolled` to make sure the node keys from the file are used and no enrollment happens. This resumes the execution of all the simulated hosts.
-
-## Infrastructure setup
-
-The deployment of Fleet was done through the example [terraform provided in the repo](https://github.com/fleetdm/fleet/tree/main/tools/terraform) with the following command:
-
-```bash
-terraform apply \ 
-  -var domain_fleetctl=<your domain here> \
-  -var domain_fleetdm=<alternative domain here> \ 
-  -var s3_bucket=<log bucket name> \
-  -var fleet_image="fleetdm/fleet:<tag targeted>" \
-  -var vulnerabilities_path="" \
-  -var fleet_max_capacity=100 \ 
-  -var fleet_min_capacity=5
-```
 
 ## Results
 
@@ -76,6 +49,33 @@ MySQL:
 - Instance: db.r5.4xlarge
 
 The above setup auto scaled based on CPU usage. After a while, the task count ended up in 25 instances even while live querying or adding a new label. 
+
+## How we are simulating osquery
+
+The simulation is run by using [osquery-perf](https://github.com/fleetdm/fleet/tree/main/cmd/osquery-perf).
+
+The following command enrolls and simulates 150,000 hosts on Fleet:
+
+```bash
+go run cmd/osquery-perf/agent.go -enroll_secret <secret here> -host_count 150000 -server_url <server URL here> -node_key_file nodekeys
+```
+
+After the hosts have been enrolled, you can add `-only_already_enrolled` to make sure the node keys from the file are used and no enrollment happens. This resumes the execution of all the simulated hosts.
+
+## Infrastructure setup
+
+The deployment of Fleet was done through the example [terraform provided in the repo](https://github.com/fleetdm/fleet/tree/main/tools/terraform) with the following command:
+
+```bash
+terraform apply \ 
+  -var domain_fleetctl=<your domain here> \
+  -var domain_fleetdm=<alternative domain here> \ 
+  -var s3_bucket=<log bucket name> \
+  -var fleet_image="fleetdm/fleet:<tag targeted>" \
+  -var vulnerabilities_path="" \
+  -var fleet_max_capacity=100 \ 
+  -var fleet_min_capacity=5
+```
 
 ## Limitations
 

--- a/docs/03-Contributing/README.md
+++ b/docs/03-Contributing/README.md
@@ -15,5 +15,11 @@ Contains information about how to merge changes into the codebase
 ### [Releasing Fleet](./05-Releasing-Fleet.md) 
 Provides a guide for Fleet's release process
 
+### [Seeding Data](./06-Seeding-Data.md) 
+Provides a guide for adding fake data to your development instance
+
+### [API for contributors](./07-API-for-contributors.md) 
+Provides documentation for Fleet API routes that are helpful when developing or contributing to Fleet
+
 ### [FAQ](./FAQ.md) 
 Includes commonly asked questions and answers about contributing to Fleet from the Fleet community


### PR DESCRIPTION
- Add top level links to the "Seeding Data" and "API for contributors" doc pages
- Move "Results" section in "Loading testing" closer to the top of document
