### PR TITLE
Add next steps to "learn how to use fleet" docs

### DIFF
--- a/docs/01-Using-Fleet/00-Learn-how-to-use-Fleet.md
+++ b/docs/01-Using-Fleet/00-Learn-how-to-use-Fleet.md
@@ -40,6 +40,3 @@ When the query has finished, you should see several columns in the "Results" tab
 - The "name" column answers: which operating system is installed on my device? 
 
 - The "version" column answers: which version of the installed operating system is my device running?"
-
-<meta name="nextStepsHref" value="/docs/deploying/installation">
-<meta name="nextStepsButtonText" value="Learn how to deploy Fleet">

--- a/docs/01-Using-Fleet/00-Learn-how-to-use-Fleet.md
+++ b/docs/01-Using-Fleet/00-Learn-how-to-use-Fleet.md
@@ -41,3 +41,5 @@ When the query has finished, you should see several columns in the "Results" tab
 
 - The "version" column answers: which version of the installed operating system is my device running?"
 
+<meta name="nextStepsHref" value="/docs/deploying/installation">
+<meta name="nextStepsButtonText" value="Learn how to deploy Fleet">

--- a/docs/01-Using-Fleet/00-Learn-how-to-use-Fleet.md
+++ b/docs/01-Using-Fleet/00-Learn-how-to-use-Fleet.md
@@ -40,3 +40,4 @@ When the query has finished, you should see several columns in the "Results" tab
 - The "name" column answers: which operating system is installed on my device? 
 
 - The "version" column answers: which version of the installed operating system is my device running?"
+

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -473,6 +473,40 @@
       ol {
         padding-inline-start: 16px;
       }
+      [purpose='next-steps-buttons'] {
+
+
+        .btn {
+          font-size: 16px;
+          line-height: 25px;
+          padding: 16px 32px;
+        }
+
+        .btn-primary {
+          color: #fff;
+          &:active {
+            background: @core-vibrant-red;
+            border-color: @core-vibrant-red;
+          }
+        }
+        .btn-slack {
+          color: @core-fleet-black;
+          img {
+            display: inline;
+            height: 24px;
+            width: auto;
+            padding-top: 0px;
+            padding-bottom: 0px;
+            margin: 0px;
+          }
+          &:focus {
+            box-shadow: none;
+          }
+          a {
+            font-color: @core-fleet-black;
+          }
+        }
+      }
 
     }
 

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -502,8 +502,15 @@
           &:focus {
             box-shadow: none;
           }
-          a {
-            font-color: @core-fleet-black;
+        }
+        .btn-outline-secondary {
+          color: @core-fleet-black;
+          border: 1px solid #C5C7D1;
+          &:hover {
+            background: #fff;
+          }
+          &:focus {
+            box-shadow: none;
           }
         }
       }

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -210,7 +210,7 @@
           ) %>
 
           <div class="d-block pb-3" purpose="next-steps-buttons" v-if="thisPage.title === 'Learn how to use Fleet'">
-            <h2>Next steps</h2>
+            <h3 style="font-size: 24px;line-height: 28px;">Next steps</h3>
             <div class="d-sm-flex">
               <a href="/docs/deploying" class="d-flex btn btn-primary btn-md justify-content-center mr-sm-3">
                 Learn how to deploy Fleet
@@ -221,7 +221,7 @@
               </a>
             </div>
           </div>
-          <div class="d-block">
+          <div class="d-block" v-else>
             <h3 class="pb-4 m-0">Is there something missing?</h3>
             <p>
               If you notice something we’ve missed, or that could be improved, please click <a :href="'https://github.com/fleetdm/fleet/edit/main/docs/'+thisPage.sectionRelativeRepoPath">here</a> to edit this page.

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -209,11 +209,11 @@
             )
           ) %>
 
-          <div class="d-block pb-3" purpose="next-steps-buttons" v-if="thisPage.meta.nextStepsHref && thisPage.meta.nextStepsButtonText">
+          <div class="d-block pb-3" purpose="next-steps-buttons" v-if="thisPage.title === 'Learn how to use Fleet'">
             <h2>Next steps</h2>
             <div class="d-sm-flex">
-              <a :href="thisPage.meta.nextStepsHref" class="d-flex btn btn-primary btn-md justify-content-center mr-sm-3">
-                {{thisPage.meta.nextStepsButtonText}}
+              <a href="/docs/deploying" class="d-flex btn btn-primary btn-md justify-content-center mr-sm-3">
+                Learn how to deploy Fleet
               </a>
               <a href="https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/" target="_blank" class="d-flex btn btn-md btn-outline-secondary btn-slack justify-content-center align-items-center mt-3 mt-sm-0">
                 <img class="pr-3" alt="Slack logo" src="/images/logo-slack-24x24@2x.png"/>

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -209,6 +209,18 @@
             )
           ) %>
 
+          <div class="d-block pb-3" purpose="next-steps-buttons" v-if="thisPage.meta.nextStepsHref && thisPage.meta.nextStepsButtonText">
+            <h2>Next steps</h2>
+            <div class="d-sm-flex">
+              <a :href="thisPage.meta.nextStepsHref" class="d-flex btn btn-primary btn-md justify-content-center mr-sm-3">
+                {{thisPage.meta.nextStepsButtonText}}
+              </a>
+              <a href="https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/" target="_blank" class="d-flex btn btn-md btn-outline-secondary btn-slack justify-content-center align-items-center mt-3 mt-sm-0">
+                <img class="pr-3" alt="Slack logo" src="/images/logo-slack-24x24@2x.png"/>
+                Ask for help on Slack
+              </a>
+            </div>
+          </div>
           <div class="d-block">
             <h3 class="pb-4 m-0">Is there something missing?</h3>
             <p>


### PR DESCRIPTION
closes #2616 
Changes: 
- Added A next steps section to the "Learn how to use Fleet" docs with buttons leading to the deployment docs and the osquery slack
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
