### PR TITLE
Add DRI section to the Fleet handbook

### DIFF
--- a/handbook/README.md
+++ b/handbook/README.md
@@ -22,13 +22,15 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [Fleet docs](./product.md#fleet-docs)
 
+[Directly responsible individuals](./product.md#directly-responsible-individuals)
+
 [Manual QA](./product.md#manual-qa)
 
 [Release process](./product.md#release-process)
 
 [Support process](./product.md#support-process)
 
-[Product design](./product.md#product-design)
+[UI design](./product.md#ui-design)
 
 ### Growth
 

--- a/handbook/README.md
+++ b/handbook/README.md
@@ -22,6 +22,8 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 ### Product
 
+[Product DRIs](./product.md#product-dris)
+
 [Fleet docs](./product.md#fleet-docs)
 
 [Manual QA](./product.md#manual-qa)

--- a/handbook/README.md
+++ b/handbook/README.md
@@ -14,6 +14,8 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 ### People
 
+[Directly responsible individuals](./people.md#directly-resonsible-individuals)
+
 [Spending company money](./people.md#spending-company-money)
 
 [Meetings](./people.md#meetings)
@@ -21,8 +23,6 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 ### Product
 
 [Fleet docs](./product.md#fleet-docs)
-
-[Directly responsible individuals](./product.md#directly-responsible-individuals)
 
 [Manual QA](./product.md#manual-qa)
 

--- a/handbook/README.md
+++ b/handbook/README.md
@@ -26,9 +26,9 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [Release process](./product.md#release-process)
 
-[Support process](./product.md#release-process)
+[Support process](./product.md#support-process)
 
-[UI design](./product.md#ui-design)
+[Product design](./product.md#product-design)
 
 ### Growth
 

--- a/handbook/people.md
+++ b/handbook/people.md
@@ -1,3 +1,12 @@
+## Directly responsible individuals
+
+At Fleet we use the concept of directly responsible individuals (**DRI**s), a person who is singularly responsible for a given aspect of the open source project, the product, or the company.
+
+This person is responsible for accomplishing goals and making decisions about a particular aspect of Fleet.
+
+DRIs help us collaborate efficiently by knowing exactly who is responsible, and can make decisions about the work they're doing.
+
+>You can read more about directly responsible individuals in [Gitlab's handbook](https://about.gitlab.com/handbook/people-group/directly-responsible-individuals/)
 
 ## Spending company money
 As we continue to expand our own company policies, we use [GitLab's open expense policy](https://about.gitlab.com/handbook/spending-company-money/) as a guide for company spending.

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -361,16 +361,21 @@ Use `---`, with color `$ui-fleet-black-50` as the default UI for empty columns.
 
 ### Directly responsible individuals
 
-At Fleet, we belive in the concept of directly responsible individuals (**DRIs**), a person who is singularly responsible for a given aspect of the product. These people will make the final decisions about the part of the product that they're responsible for, and 
+At Fleet we utilize the concept of directly responsible individuals (**DRI**s), a person who is singularly responsible for a given aspect of the product.
 
-Below is a table of DRIs for aspects of the Fleet product.
+These people will be responsible for ensuring that their team has the resources they need to acomplish their goal, and will make the final decisions about that aspect of the product. 
+
+DRIs help us collaberate efficiently by knowing exactly who is responsible, and can make decisions about the work they're doing.
+
+
+Below is a table of DRIs for aspects of Fleet
 
 |    Aspect              										| DRI     		|
 | ------------------------------------------------------------- | ------------- |
 | Wireframes (figma)	 										| Noah			|
 | How the product works 										| Noah 			|
 | fleetctl CLI interface (and other tools) 						| Tomas 		|
-| REST API interface, REST API docs 							| Luke  		|
+| REST API interface, REST API docs 							| Luke	 		|
 | Terraform, Postman 											| Ben Edwards 	|
 | Customer deployments like expedia.fleetdm.com 				| Ben Edwards 	|
 | dogfood.fleetdm.com 											| Ben Edwards  	|
@@ -384,7 +389,7 @@ Below is a table of DRIs for aspects of the Fleet product.
 | Release notes 												| Noah  		|
 | Publishing release blog post, and promoting releases 			| Mike Thomas  	|
 
-
+>You can read more about in directly responsible individuals in [Gitlab's handbook](https://about.gitlab.com/handbook/people-group/directly-responsible-individuals/)
 
 <meta name="maintainedBy" value="mike-j-thomas">
 

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -359,6 +359,31 @@ We have certain design conventions that we include in Fleet. We will document mo
 
 Use `---`, with color `$ui-fleet-black-50` as the default UI for empty columns.
 
+## Directly responsible individual
+
+At Fleet, we belive in the concept of directly responsible individuals (**DRIs**), a person who is singularly responsible for a given aspect of the product. By having someone that
+
+Below is a table of DRIs for aspects of the Fleet product.
+
+|    Aspect              | DRI      |
+| ---------------------- | -------- |
+| Wireframes (figma)	 | Noah |
+| How the product works| Noah |
+| fleetctl CLI interface (and other tools)|   Tomas  |
+| REST API interface, REST API docs|  Luke  |
+| Terraform, Postman| Ben Edwards  |
+| Customer deployments like expedia.fleetdm.com| Ben Edwards |
+| dogfood.fleetdm.com| Ben Edwards  |
+| Quality of core product UI |  Luke |
+| Quality of tickets after Noah's done with em| Luke |
+| Quality of core product API| Tomas |
+| Customer deployments like expedia.fleetdm.com| Tomas |
+| Quality of fleetctl (and other tools)| Tomas  |
+| Final cut of what goes into each release| Zach |
+| When we cut a release, version numbers, and whether to release| Zach |
+| Release notes| Noah |
+| Publishing release blog post, and promoting releases| Mike Thomas |
+
 
 
 <meta name="maintainedBy" value="mike-j-thomas">

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -1,4 +1,4 @@
-## Product
+## Product DRIs
 
 Below is a table of [directly responsible individuals (DRIs)](./people.md#directly-resonsible-individuals) for aspects of the Fleet product:
 

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -1,6 +1,6 @@
 ## Product
 
-Below is a table of [directly responsible individuals](./people.md#directly-resonsible-individuals) for aspects of the Fleet product:
+Below is a table of [directly responsible individuals (DRIs)](./people.md#directly-resonsible-individuals) for aspects of the Fleet product:
 
 |    Aspect              										| DRI     		|
 | ------------------------------------------------------------- | ------------- |

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -362,7 +362,7 @@ There are several locations in Fleet's public and internal documentation that ca
 2. The [Internal FAQ](https://docs.google.com/document/d/1I6pJ3vz0EE-qE13VmpE2G3gd5zA1m3bb_u8Q2G3Gmp0/edit#heading=h.ltavvjy511qv) document.
 
 
-## Product Design
+## UI Design
 
 ### Communicating design changes to Engineering
 For something NEW that has been added to [Figma Fleet EE (current, dev-ready)](https://www.figma.com/file/qpdty1e2n22uZntKUZKEJl/?node-id=0%3A1):

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -330,7 +330,7 @@ There are several locations in Fleet's public and internal documentation that ca
 2. The [Internal FAQ](https://docs.google.com/document/d/1I6pJ3vz0EE-qE13VmpE2G3gd5zA1m3bb_u8Q2G3Gmp0/edit#heading=h.ltavvjy511qv) document.
 
 
-## UI Design
+## Product Design
 
 ### Communicating design changes to Engineering
 For something NEW that has been added to [Figma Fleet EE (current, dev-ready)](https://www.figma.com/file/qpdty1e2n22uZntKUZKEJl/?node-id=0%3A1):
@@ -359,30 +359,30 @@ We have certain design conventions that we include in Fleet. We will document mo
 
 Use `---`, with color `$ui-fleet-black-50` as the default UI for empty columns.
 
-## Directly responsible individual
+### Directly responsible individuals
 
-At Fleet, we belive in the concept of directly responsible individuals (**DRIs**), a person who is singularly responsible for a given aspect of the product. By having someone that
+At Fleet, we belive in the concept of directly responsible individuals (**DRIs**), a person who is singularly responsible for a given aspect of the product. These people will make the final decisions about the part of the product that they're responsible for, and 
 
 Below is a table of DRIs for aspects of the Fleet product.
 
-|    Aspect              | DRI      |
-| ---------------------- | -------- |
-| Wireframes (figma)	 | Noah |
-| How the product works| Noah |
-| fleetctl CLI interface (and other tools)|   Tomas  |
-| REST API interface, REST API docs|  Luke  |
-| Terraform, Postman| Ben Edwards  |
-| Customer deployments like expedia.fleetdm.com| Ben Edwards |
-| dogfood.fleetdm.com| Ben Edwards  |
-| Quality of core product UI |  Luke |
-| Quality of tickets after Noah's done with em| Luke |
-| Quality of core product API| Tomas |
-| Customer deployments like expedia.fleetdm.com| Tomas |
-| Quality of fleetctl (and other tools)| Tomas  |
-| Final cut of what goes into each release| Zach |
-| When we cut a release, version numbers, and whether to release| Zach |
-| Release notes| Noah |
-| Publishing release blog post, and promoting releases| Mike Thomas |
+|    Aspect              										| DRI     		|
+| ------------------------------------------------------------- | ------------- |
+| Wireframes (figma)	 										| Noah			|
+| How the product works 										| Noah 			|
+| fleetctl CLI interface (and other tools) 						| Tomas 		|
+| REST API interface, REST API docs 							| Luke  		|
+| Terraform, Postman 											| Ben Edwards 	|
+| Customer deployments like expedia.fleetdm.com 				| Ben Edwards 	|
+| dogfood.fleetdm.com 											| Ben Edwards  	|
+| Quality of core product UI 									| Luke 			|
+| Quality of tickets after Noah's done with them   				| Luke 			|
+| Quality of core product API 									| Tomas 		|
+| Customer deployments like expedia.fleetdm.com 				| Tomas 		|
+| Quality of fleetctl (and other tools)							| Tomas  		|
+| Final cut of what goes into each release 						| Zach 			|
+| When we cut a release, version numbers, and whether to release| Zach 			|
+| Release notes 												| Noah  		|
+| Publishing release blog post, and promoting releases 			| Mike Thomas  	|
 
 
 

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -39,6 +39,38 @@ The images used in the docs live in `docs/images/`. Note that you must provide t
 
 > Note that the instructions above also apply to adding images in the Fleet handbook.
 
+## Directly responsible individuals
+
+At Fleet we utilize the concept of directly responsible individuals (**DRI**s), a person who is singularly responsible for a given aspect of the product.
+
+These people will be responsible for ensuring that their team has the resources they need to acomplish their goal, and will make the final decisions about that aspect of the product. 
+
+DRIs help us collaberate efficiently by knowing exactly who is responsible, and can make decisions about the work they're doing.
+
+
+Below is a table of DRIs for aspects of Fleet
+
+|    Aspect              										| DRI     		|
+| ------------------------------------------------------------- | ------------- |
+| Wireframes (figma)	 										| Noah			|
+| How the product works 										| Noah 			|
+| fleetctl CLI interface (and other tools) 						| Tomas 		|
+| REST API interface, REST API docs 							| Luke	 		|
+| Terraform, Postman 											| Ben Edwards 	|
+| Customer deployments like expedia.fleetdm.com 				| Ben Edwards 	|
+| dogfood.fleetdm.com 											| Ben Edwards  	|
+| Quality of core product UI 									| Luke 			|
+| Quality of tickets after Noah's done with them   				| Luke 			|
+| Quality of core product API 									| Tomas 		|
+| Customer deployments like expedia.fleetdm.com 				| Tomas 		|
+| Quality of fleetctl (and other tools)							| Tomas  		|
+| Final cut of what goes into each release 						| Zach 			|
+| When we cut a release, version numbers, and whether to release| Zach 			|
+| Release notes 												| Noah  		|
+| Publishing release blog post, and promoting releases 			| Mike Thomas  	|
+
+>You can read more about in directly responsible individuals in [Gitlab's handbook](https://about.gitlab.com/handbook/people-group/directly-responsible-individuals/)
+
 ## Manual QA
 
 This living document outlines the manual quality assurance process conducted to ensure each release of Fleet meets organization standards.
@@ -359,37 +391,6 @@ We have certain design conventions that we include in Fleet. We will document mo
 
 Use `---`, with color `$ui-fleet-black-50` as the default UI for empty columns.
 
-### Directly responsible individuals
-
-At Fleet we utilize the concept of directly responsible individuals (**DRI**s), a person who is singularly responsible for a given aspect of the product.
-
-These people will be responsible for ensuring that their team has the resources they need to acomplish their goal, and will make the final decisions about that aspect of the product. 
-
-DRIs help us collaberate efficiently by knowing exactly who is responsible, and can make decisions about the work they're doing.
-
-
-Below is a table of DRIs for aspects of Fleet
-
-|    Aspect              										| DRI     		|
-| ------------------------------------------------------------- | ------------- |
-| Wireframes (figma)	 										| Noah			|
-| How the product works 										| Noah 			|
-| fleetctl CLI interface (and other tools) 						| Tomas 		|
-| REST API interface, REST API docs 							| Luke	 		|
-| Terraform, Postman 											| Ben Edwards 	|
-| Customer deployments like expedia.fleetdm.com 				| Ben Edwards 	|
-| dogfood.fleetdm.com 											| Ben Edwards  	|
-| Quality of core product UI 									| Luke 			|
-| Quality of tickets after Noah's done with them   				| Luke 			|
-| Quality of core product API 									| Tomas 		|
-| Customer deployments like expedia.fleetdm.com 				| Tomas 		|
-| Quality of fleetctl (and other tools)							| Tomas  		|
-| Final cut of what goes into each release 						| Zach 			|
-| When we cut a release, version numbers, and whether to release| Zach 			|
-| Release notes 												| Noah  		|
-| Publishing release blog post, and promoting releases 			| Mike Thomas  	|
-
->You can read more about in directly responsible individuals in [Gitlab's handbook](https://about.gitlab.com/handbook/people-group/directly-responsible-individuals/)
 
 <meta name="maintainedBy" value="mike-j-thomas">
 

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -41,35 +41,33 @@ The images used in the docs live in `docs/images/`. Note that you must provide t
 
 ## Directly responsible individuals
 
-At Fleet we utilize the concept of directly responsible individuals (**DRI**s), a person who is singularly responsible for a given aspect of the product.
+At Fleet we use the concept of directly responsible individuals (**DRI**s), a person who is singularly responsible for a given aspect of the open source project, the product, or the company.
 
-These people will be responsible for ensuring that their team has the resources they need to acomplish their goal, and will make the final decisions about that aspect of the product. 
+This person is responsible for accomplishing goals and making decisions about a particular aspect of Fleet.
 
-DRIs help us collaberate efficiently by knowing exactly who is responsible, and can make decisions about the work they're doing.
+DRIs help us collaborate efficiently by knowing exactly who is responsible, and can make decisions about the work they're doing.
 
-
-Below is a table of DRIs for aspects of Fleet
+Below is a table of DRIs for aspects of Fleet:
 
 |    Aspect              										| DRI     		|
 | ------------------------------------------------------------- | ------------- |
-| Wireframes (figma)	 										| Noah			|
-| How the product works 										| Noah 			|
-| fleetctl CLI interface (and other tools) 						| Tomas 		|
-| REST API interface, REST API docs 							| Luke	 		|
+| Wireframes (figma)	 										| Noah Talerman	|
+| How the product works 										| Noah Talerman |
+| fleetctl CLI interface (and other tools) 						| Tomás Touceda |
+| REST API interface, REST API docs 							| Luke Heath	|
 | Terraform, Postman 											| Ben Edwards 	|
 | Customer deployments like expedia.fleetdm.com 				| Ben Edwards 	|
 | dogfood.fleetdm.com 											| Ben Edwards  	|
-| Quality of core product UI 									| Luke 			|
-| Quality of tickets after Noah's done with them   				| Luke 			|
-| Quality of core product API 									| Tomas 		|
-| Customer deployments like expedia.fleetdm.com 				| Tomas 		|
-| Quality of fleetctl (and other tools)							| Tomas  		|
-| Final cut of what goes into each release 						| Zach 			|
-| When we cut a release, version numbers, and whether to release| Zach 			|
-| Release notes 												| Noah  		|
+| Quality of core product UI 									| Luke Heath 	|
+| Quality of tickets after Noah's done with them   				| Luke Heath 	|
+| Quality of core product API 									| Tomás Touceda |
+| Quality of fleetctl (and other tools)							| Tomás Touceda |
+| Final cut of what goes into each release 						| Zach Wasserman|
+| When we cut a release, version numbers, and whether to release| Zach Wasserman|
+| Release notes 												| Noah Talerman |
 | Publishing release blog post, and promoting releases 			| Mike Thomas  	|
 
->You can read more about in directly responsible individuals in [Gitlab's handbook](https://about.gitlab.com/handbook/people-group/directly-responsible-individuals/)
+>You can read more about directly responsible individuals in [Gitlab's handbook](https://about.gitlab.com/handbook/people-group/directly-responsible-individuals/)
 
 ## Manual QA
 

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -1,3 +1,24 @@
+## Product
+
+Below is a table of [directly responsible individuals](./people.md#directly-resonsible-individuals) for aspects of the Fleet product:
+
+|    Aspect              										| DRI     		|
+| ------------------------------------------------------------- | ------------- |
+| Wireframes (figma)	 										| Noah Talerman	|
+| How the product works 										| Noah Talerman |
+| fleetctl CLI interface (and other tools) 						| Tomás Touceda |
+| REST API interface, REST API docs 							| Luke Heath	|
+| Terraform, Postman 											| Ben Edwards 	|
+| Customer deployments like expedia.fleetdm.com 				| Ben Edwards 	|
+| dogfood.fleetdm.com 											| Ben Edwards  	|
+| Quality of core product UI 									| Luke Heath 	|
+| Quality of tickets after Noah's done with them   				| Luke Heath 	|
+| Quality of core product API 									| Tomás Touceda |
+| Quality of fleetctl (and other tools)							| Tomás Touceda |
+| Final cut of what goes into each release 						| Zach Wasserman|
+| When we cut a release, version numbers, and whether to release| Zach Wasserman|
+| Release notes 												| Noah Talerman |
+| Publishing release blog post, and promoting releases 			| Mike Thomas  	|
 
 ## Fleet docs
 
@@ -38,36 +59,6 @@ Images can be added to the docs using the Markdown image link format, e.g. `![Sc
 The images used in the docs live in `docs/images/`. Note that you must provide the url of the image in the Fleet Github repo for it to display properly on both Github and the Fleet website.
 
 > Note that the instructions above also apply to adding images in the Fleet handbook.
-
-## Directly responsible individuals
-
-At Fleet we use the concept of directly responsible individuals (**DRI**s), a person who is singularly responsible for a given aspect of the open source project, the product, or the company.
-
-This person is responsible for accomplishing goals and making decisions about a particular aspect of Fleet.
-
-DRIs help us collaborate efficiently by knowing exactly who is responsible, and can make decisions about the work they're doing.
-
-Below is a table of DRIs for aspects of Fleet:
-
-|    Aspect              										| DRI     		|
-| ------------------------------------------------------------- | ------------- |
-| Wireframes (figma)	 										| Noah Talerman	|
-| How the product works 										| Noah Talerman |
-| fleetctl CLI interface (and other tools) 						| Tomás Touceda |
-| REST API interface, REST API docs 							| Luke Heath	|
-| Terraform, Postman 											| Ben Edwards 	|
-| Customer deployments like expedia.fleetdm.com 				| Ben Edwards 	|
-| dogfood.fleetdm.com 											| Ben Edwards  	|
-| Quality of core product UI 									| Luke Heath 	|
-| Quality of tickets after Noah's done with them   				| Luke Heath 	|
-| Quality of core product API 									| Tomás Touceda |
-| Quality of fleetctl (and other tools)							| Tomás Touceda |
-| Final cut of what goes into each release 						| Zach Wasserman|
-| When we cut a release, version numbers, and whether to release| Zach Wasserman|
-| Release notes 												| Noah Talerman |
-| Publishing release blog post, and promoting releases 			| Mike Thomas  	|
-
->You can read more about directly responsible individuals in [Gitlab's handbook](https://about.gitlab.com/handbook/people-group/directly-responsible-individuals/)
 
 ## Manual QA
 

--- a/website/assets/styles/pages/handbook/basic-handbook.less
+++ b/website/assets/styles/pages/handbook/basic-handbook.less
@@ -222,6 +222,26 @@
         margin: 16px 0px 40px;
       }
     }
+    table {
+      border: 1px solid @border-lt-gray;
+      border-collapse: collapse;
+      font-size: 16px;
+      line-height: 24px;
+      margin-bottom: 16px;
+
+      th {
+        font-weight: @bold;
+        font-family: @header-font;
+        border: 1px solid @border-lt-gray;
+        padding: 8px 7px 7px 8px;
+      }
+
+      td {
+        font-family: @main-font;
+        border: 1px solid @border-lt-gray;
+        padding: 8px 7px 7px 8px;
+      }
+    }
   }
 
 


### PR DESCRIPTION
Closes #2734 

Changes:
- Added a handbook section about directly responsible individuals
- Updated links in the handbook readme
- Added table styles to the handbook

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
