### PR TITLE
Add feature flag guidelines to Fleet's public handbook

### DIFF
--- a/handbook/product.md
+++ b/handbook/product.md
@@ -21,7 +21,7 @@ Below is a table of [directly responsible individuals (DRIs)](./people.md#direct
 | Publishing release blog post, and promoting releases 			| Mike Thomas  	|
 
 ## Feature flags
-In Fleet, features are placed behind flags if the changes could affect Fleet's availability of existing functionalities.
+In Fleet, features are placed behind feature flags if the changes could affect Fleet's availability of existing functionalities.
 
 The following highlights should be considered when deciding if feature flags should be leveraged:
 

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -27,7 +27,7 @@ The following highlights should be considered when deciding if feature flags sho
 
 - The feature flag must be disabled by default.
 - The feature flag will not be permanent. This means that the individual who decides that a feature flag should be introduced is responsible for creating an issue to track the feature's progress towards removing the feature flag and including the feature in a stable release.
-- The feature flag will not be advertised. This includes, and is not limited to, advertising in the documentation on fleetdm.com/docs, release notes, release blog posts, and Twitter.
+- The feature flag will not be advertised. For example, advertising in the documentation on fleetdm.com/docs, release notes, release blog posts, and Twitter.
 
 Fleet's feature flag guidelines borrows from GitLab's ["When to use feature flags" section](https://about.gitlab.com/handbook/product-development-flow/feature-flag-lifecycle/#when-to-use-feature-flags) of their handbook. Check out [GitLab's "Feature flags only when needed" video](https://www.youtube.com/watch?v=DQaGqyolOd8) for an explanation on the costs of introducing feature flags.
 

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -20,6 +20,17 @@ Below is a table of [directly responsible individuals (DRIs)](./people.md#direct
 | Release notes 												| Noah Talerman |
 | Publishing release blog post, and promoting releases 			| Mike Thomas  	|
 
+## Feature flags
+In Fleet, features are placed behind flags if the changes could affect Fleet's availability of existing functionalities.
+
+The following highlights should be considered when deciding if feature flags should be leveraged:
+
+- The feature flag must be disabled by default.
+- The feature flag will not be permanent. This means that the individual who decides that a feature flag should be introduced is responsible for creating an issue to track the feature's progress towards removing the feature flag and including the feature in a stable release.
+- The feature flag will not be advertised. This includes, and is not limited to, advertising in the documentation on fleetdm.com/docs, release notes, release blog posts, and Twitter.
+
+Fleet's feature flag guidelines borrows from GitLab's ["When to use feature flags" section](https://about.gitlab.com/handbook/product-development-flow/feature-flag-lifecycle/#when-to-use-feature-flags) of their handbook. Check out [GitLab's "Feature flags only when needed" video](https://www.youtube.com/watch?v=DQaGqyolOd8) for an explanation on the costs of introducing feature flags.
+
 ## Fleet docs
 
 ### Adding a link to the Fleet docs


### PR DESCRIPTION
- Add outline for when a feature is placed behind a feature flag in the Fleet product
- Add items to consider when deciding if feature flags should be leveraged

The introduction of this section is the result of learnings from placing the Software inventory and Vulnerability processing features behind feature flags.
