### PR TITLE
Fix flaky TestSoftware/filters_by_team_and_paginates

### DIFF
--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -245,26 +245,26 @@ func testSoftwareHostDuplicates(t *testing.T, ds *Datastore) {
 
 	longName := strings.Repeat("a", 260)
 
-	incoming := make(map[string]bool)
+	incoming := make(map[string]struct{})
 	soft2Key := softwareToUniqueString(fleet.Software{
 		Name:    longName + "b",
 		Version: "0.0.1",
 		Source:  "chrome_extension",
 	})
-	incoming[soft2Key] = true
+	incoming[soft2Key] = struct{}{}
 
 	tx, err := ds.writer.Beginx()
 	require.NoError(t, err)
 	require.NoError(t, insertNewInstalledHostSoftwareDB(context.Background(), tx, host1.ID, make(map[string]uint), incoming))
 	require.NoError(t, tx.Commit())
 
-	incoming = make(map[string]bool)
+	incoming = make(map[string]struct{})
 	soft3Key := softwareToUniqueString(fleet.Software{
 		Name:    longName + "c",
 		Version: "0.0.1",
 		Source:  "chrome_extension",
 	})
-	incoming[soft3Key] = true
+	incoming[soft3Key] = struct{}{}
 
 	tx, err = ds.writer.Beginx()
 	require.NoError(t, err)
@@ -422,6 +422,7 @@ func testSoftwareList(t *testing.T, ds *Datastore) {
 		},
 	}
 	host1.HostSoftware = soft1
+
 	soft2 := fleet.HostSoftware{
 		Modified: true,
 		Software: []fleet.Software{
@@ -501,7 +502,14 @@ func testSoftwareList(t *testing.T, ds *Datastore) {
 		require.NoError(t, err)
 		require.NoError(t, ds.AddHostsToTeam(context.Background(), &team1.ID, []uint{host1.ID}))
 
-		software, err := ds.ListSoftware(context.Background(), fleet.SoftwareListOptions{ListOptions: fleet.ListOptions{PerPage: 1, Page: 1, OrderKey: "id"}, TeamID: &team1.ID})
+		software, err := ds.ListSoftware(context.Background(), fleet.SoftwareListOptions{
+			ListOptions: fleet.ListOptions{
+				PerPage:  1,
+				Page:     1,
+				OrderKey: "id",
+			},
+			TeamID: &team1.ID,
+		})
 		require.NoError(t, err)
 
 		require.Len(t, software, 1)


### PR DESCRIPTION
By design, golang map iteration has random ordering.
`TestSoftware/List/filters_by_team_and_paginates` was testing software listing by `id` (order `ASC`). Given that the software insertion was random, therefore the test was flaky. 

The fix: IMO storing the new (incoming) software "in order" provides better reproducibility in case of issues/bugs.

~- [ ] Changes file added (for user-visible changes)~
~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Added/updated tests~
~- [ ] Manual QA for all new/changed functionality~
