### PR TITLE
Dashboard UI: Hosts change on team selection

### DIFF
--- a/changes/issue-2822-dashboard-host-change-on-team
+++ b/changes/issue-2822-dashboard-host-change-on-team
@@ -1,0 +1,1 @@
+* Dashboard hosts change on team selection

--- a/cypress/integration/premium/admin.spec.ts
+++ b/cypress/integration/premium/admin.spec.ts
@@ -102,6 +102,7 @@ describe(
         cy.findByText(/back to queries/i).should("exist");
         cy.visit("/queries/manage");
 
+        cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.findByText(/query all/i).click();
 
         cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -26,7 +26,7 @@ interface ITeamsResponse {
 const baseClass = "homepage";
 
 const TAGGED_TEMPLATES = {
-  hostsByTeamPRoute: (teamId: number | undefined | null) => {
+  hostsByTeamRoute: (teamId: number | undefined | null) => {
     return `${teamId ? `/?team_id=${teamId}` : ""}`;
   },
 };
@@ -85,8 +85,7 @@ const Homepage = (): JSX.Element => {
           action={{
             type: "link",
             to:
-              MANAGE_HOSTS +
-              TAGGED_TEMPLATES.hostsByTeamPRoute(currentTeam?.id),
+              MANAGE_HOSTS + TAGGED_TEMPLATES.hostsByTeamRoute(currentTeam?.id),
             text: "View all hosts",
           }}
         >

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -25,6 +25,12 @@ interface ITeamsResponse {
 
 const baseClass = "homepage";
 
+const TAGGED_TEMPLATES = {
+  hostsByTeamPRoute: (teamId: number | undefined | null) => {
+    return `${teamId ? `/?team_id=${teamId}` : ""}`;
+  },
+};
+
 const Homepage = (): JSX.Element => {
   const { MANAGE_HOSTS } = paths;
   const {
@@ -76,9 +82,15 @@ const Homepage = (): JSX.Element => {
       <div className={`${baseClass}__section one-column`}>
         <InfoCard
           title="Hosts"
-          action={{ type: "link", to: MANAGE_HOSTS, text: "View all hosts" }}
+          action={{
+            type: "link",
+            to:
+              MANAGE_HOSTS +
+              TAGGED_TEMPLATES.hostsByTeamPRoute(currentTeam?.id),
+            text: "View all hosts",
+          }}
         >
-          <HostsSummary />
+          <HostsSummary currentTeamId={currentTeam?.id} />
         </InfoCard>
       </div>
       {isPreviewMode && (

--- a/frontend/pages/Homepage/cards/HostsSummary/HostsSummary.tsx
+++ b/frontend/pages/Homepage/cards/HostsSummary/HostsSummary.tsx
@@ -1,13 +1,9 @@
-import React, { useCallback, useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { reduce } from "lodash";
+import React, { useState } from "react";
+import { useQuery } from "react-query";
 import { ILabel } from "interfaces/label";
-// @ts-ignore
-import { getLabels } from "redux/nodes/components/ManageHostsPage/actions";
 
-import hostCountAPI, {
-  IHostCountLoadOptions,
-} from "services/entities/host_count";
+import hostCountAPI from "services/entities/host_count";
+import labelsAPI from "services/entities/labels";
 
 import WindowsIcon from "../../../../../assets/images/icon-windows-48x48@2x.png";
 import LinuxIcon from "../../../../../assets/images/icon-linux-48x48@2x.png";
@@ -18,109 +14,88 @@ const baseClass = "hosts-summary";
 interface IHostsSummaryProps {
   currentTeamId: number | undefined;
 }
-interface IRootState {
-  entities: {
-    labels: {
-      isLoading: boolean;
-      data: {
-        [id: number]: ILabel;
-      };
-    };
-  };
+
+interface ILabelsResponse {
+  labels: ILabel[];
 }
 
-const PLATFORM_STRINGS = {
-  macOS: "macOS",
-  windows: "MS Windows",
-  linux: "All Linux",
-};
+interface IHostCountResponse {
+  count: number;
+}
 
 const HostsSummary = ({ currentTeamId }: IHostsSummaryProps): JSX.Element => {
-  console.log("currentTeamId", currentTeamId);
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    dispatch(getLabels());
-  }, []);
-
   const [macCount, setMacCount] = useState<string | undefined>();
   const [windowsCount, setWindowsCount] = useState<string | undefined>();
   const [linuxCount, setLinuxCount] = useState<string | undefined>();
 
-  const labels = useSelector((state: IRootState) => state.entities.labels.data);
+  const getLabel = (labelString: string, labels: ILabel[]) => {
+    return Object.values(labels).filter((label: ILabel) => {
+      return label.label_type === "builtin" && label.name === labelString;
+    });
+  };
+  const { data: labels } = useQuery<ILabelsResponse, Error, ILabel[]>(
+    ["labels"],
+    () => labelsAPI.loadAll(),
+    {
+      select: (data: ILabelsResponse) => data.labels,
+    }
+  );
 
-  if (!currentTeamId) {
-    const allTeamsHostCount = useCallback(() => {
-      // Builtin labels from state populate os counts
-      const getAllTeamsCount = (platformTitles: string) => {
-        const count = reduce(
-          Object.values(labels),
-          (total, label) => {
-            return label.label_type === "builtin" &&
-              platformTitles === label.name &&
-              label.count
-              ? total + label.count
-              : total;
-          },
-          0
-        );
-        return count;
-      };
-
-      setMacCount(
-        getAllTeamsCount(PLATFORM_STRINGS.macOS).toLocaleString("en-US")
+  useQuery<IHostCountResponse, Error, number>(
+    ["mac host count", currentTeamId],
+    () => {
+      const macOsLabel = getLabel("macOS", labels || []);
+      return (
+        hostCountAPI.load({
+          selectedLabels: [`labels/${macOsLabel[0].id}`],
+          teamId: currentTeamId,
+        }) || { count: 0 }
       );
-      setWindowsCount(
-        getAllTeamsCount(PLATFORM_STRINGS.windows).toLocaleString("en-US")
+    },
+    {
+      select: (data: IHostCountResponse) => data.count,
+      enabled: !!labels,
+      onSuccess: (data: number) => setMacCount(data.toLocaleString("en-US")),
+    }
+  );
+
+  useQuery<IHostCountResponse, Error, number>(
+    ["windows host count", currentTeamId],
+    () => {
+      const windowsLabel = getLabel("MS Windows", labels || []);
+      return (
+        hostCountAPI.load({
+          selectedLabels: [`labels/${windowsLabel[0].id}`],
+          teamId: currentTeamId,
+        }) || { count: 0 }
       );
-      setLinuxCount(
-        getAllTeamsCount(PLATFORM_STRINGS.linux).toLocaleString("en-US")
+    },
+    {
+      select: (data: IHostCountResponse) => data.count,
+      enabled: !!labels,
+      onSuccess: (data: number) =>
+        setWindowsCount(data.toLocaleString("en-US")),
+    }
+  );
+
+  useQuery<IHostCountResponse, Error, number>(
+    ["linux host count", currentTeamId],
+    () => {
+      const linuxLabel = getLabel("All Linux", labels || []);
+      return (
+        hostCountAPI.load({
+          selectedLabels: [`labels/${linuxLabel[0].id}`],
+          teamId: currentTeamId,
+        }) || { count: 0 }
       );
-    }, [currentTeamId]);
+    },
+    {
+      select: (data: IHostCountResponse) => data.count,
+      enabled: !!labels,
+      onSuccess: (data: number) => setLinuxCount(data.toLocaleString("en-US")),
+    }
+  );
 
-    allTeamsHostCount();
-  } else {
-    const teamHostCount = useCallback(() => {
-      const macOsLabel = Object.values(labels).filter((label: ILabel) => {
-        return label.label_type === "builtin" && label.name === "macOS";
-      });
-
-      const windowsLabel = Object.values(labels).filter((label: ILabel) => {
-        return label.label_type === "builtin" && label.name === "MS Windows";
-      });
-
-      const linuxLabel = Object.values(labels).filter((label: ILabel) => {
-        return label.label_type === "builtin" && label.name === "All Linux";
-      });
-
-      const retrieveHostCount = async () => {
-        try {
-          const { count: returnedTeamMacCount } = await hostCountAPI.load({
-            selectedLabels: [`labels/${macOsLabel[0].id}`],
-            teamId: currentTeamId,
-          });
-          const { count: returnedTeamWindowsCount } = await hostCountAPI.load({
-            selectedLabels: [`labels/${windowsLabel[0].id}`],
-            teamId: currentTeamId,
-          });
-          const { count: returnedTeamLinuxCount } = await hostCountAPI.load({
-            selectedLabels: [`labels/${linuxLabel[0].id}`],
-            teamId: currentTeamId,
-          });
-
-          setMacCount(returnedTeamMacCount.toLocaleString("en-US"));
-          setWindowsCount(returnedTeamWindowsCount.toLocaleString("en-US"));
-          setLinuxCount(returnedTeamLinuxCount.toLocaleString("en-US"));
-        } catch (error) {
-          console.error(error);
-        }
-
-        retrieveHostCount();
-      };
-    }, [currentTeamId]);
-
-    teamHostCount();
-  }
   return (
     <div className={baseClass}>
       <div className={`${baseClass}__tile mac-tile`}>

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -359,6 +359,8 @@ const ManageHostsPage = ({
       ),
     };
 
+    console.log("options", options);
+
     try {
       const { count: returnedHostCount } = await hostCountAPI.load(options);
       setFilteredHostCount(returnedHostCount);
@@ -665,6 +667,11 @@ const ManageHostsPage = ({
 
     if (teamId) {
       newQueryParams.team_id = teamId;
+    }
+
+    console.log("queryParams.team_id", queryParams.team_id);
+    if (queryParams.team_id) {
+      newQueryParams.team_id = queryParams.team_id;
     }
 
     if (policyId) {

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -332,6 +332,10 @@ const ManageHostsPage = ({
       ),
     };
 
+    if (queryParams.team_id) {
+      options.teamId = queryParams.team_id;
+    }
+
     try {
       const { hosts: returnedHosts, software } = await hostsAPI.loadAll(
         options

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -359,7 +359,9 @@ const ManageHostsPage = ({
       ),
     };
 
-    console.log("options", options);
+    if (queryParams.team_id) {
+      options.teamId = queryParams.team_id;
+    }
 
     try {
       const { count: returnedHostCount } = await hostCountAPI.load(options);
@@ -669,7 +671,6 @@ const ManageHostsPage = ({
       newQueryParams.team_id = teamId;
     }
 
-    console.log("queryParams.team_id", queryParams.team_id);
     if (queryParams.team_id) {
       newQueryParams.team_id = queryParams.team_id;
     }

--- a/frontend/services/entities/host_count.ts
+++ b/frontend/services/entities/host_count.ts
@@ -32,6 +32,7 @@ export default {
 
     const labelPrefix = "labels/";
 
+    console.log("selectedLabels", selectedLabels);
     // Handle multiple filters
     const label = selectedLabels.find((f) => f.includes(labelPrefix));
     const status = selectedLabels.find((f) => !f.includes(labelPrefix));

--- a/frontend/services/entities/host_count.ts
+++ b/frontend/services/entities/host_count.ts
@@ -32,7 +32,6 @@ export default {
 
     const labelPrefix = "labels/";
 
-    console.log("selectedLabels", selectedLabels);
     // Handle multiple filters
     const label = selectedLabels.find((f) => f.includes(labelPrefix));
     const status = selectedLabels.find((f) => !f.includes(labelPrefix));


### PR DESCRIPTION
Cerra #2822 

- Removes redux from HostSummary.tsx and uses new API patterns
- Use same API call for all team host count and team host count based on currentTeamId

<img width="1414" alt="Screen Shot 2021-11-08 at 10 04 15 AM" src="https://user-images.githubusercontent.com/71795832/140794925-a5b25642-7ea9-4e1e-87b5-b187fac52cd1.png">
<img width="1415" alt="Screen Shot 2021-11-08 at 10 04 05 AM" src="https://user-images.githubusercontent.com/71795832/140794932-23454880-465c-4d8a-8053-7b1c2637b4f8.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
