### PR TITLE
Host Details Page: No CTA for policies that have unknown status

### DIFF
--- a/changes/issue-2809-host-details-policy-unknown-no-cta
+++ b/changes/issue-2809-host-details-policy-unknown-no-cta
@@ -1,0 +1,1 @@
+* When a host's policy status is unknown, there is no CTA to filter hosts by unknown policy status

--- a/frontend/pages/hosts/HostDetailsPage/HostPoliciesTable/HostPoliciesTableConfig.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostPoliciesTable/HostPoliciesTableConfig.tsx
@@ -95,21 +95,25 @@ const generatePolicyTableHeaders = (
       disableSortBy: true,
       Cell: (cellProps) => {
         return (
-          <Link
-            to={
-              PATHS.MANAGE_HOSTS +
-              TAGGED_TEMPLATES.hostsByPolicyRoute(
-                cellProps.row.original.id,
-                cellProps.row.original.response === "pass"
-                  ? PolicyResponse.PASSING
-                  : PolicyResponse.FAILING
-              )
-            }
-            className={`policy-link`}
-          >
-            View all hosts{" "}
-            <img alt="link to hosts filtered by policy ID" src={Chevron} />
-          </Link>
+          <>
+            {cellProps.row.original.response && (
+              <Link
+                to={
+                  PATHS.MANAGE_HOSTS +
+                  TAGGED_TEMPLATES.hostsByPolicyRoute(
+                    cellProps.row.original.id,
+                    cellProps.row.original.response === "pass"
+                      ? PolicyResponse.PASSING
+                      : PolicyResponse.FAILING
+                  )
+                }
+                className={`policy-link`}
+              >
+                View all hosts{" "}
+                <img alt="link to hosts filtered by policy ID" src={Chevron} />
+              </Link>
+            )}
+          </>
         );
       },
     },

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -434,6 +434,10 @@
     th:first-child {
       width: 70%;
     }
+
+    .response__header {
+      border-right: none;
+    }
   }
 
   .section--software {


### PR DESCRIPTION
Cerra #2809 

-No "View all hosts" CTA for policies that have unknown status
-Style fix: no border between status header cell and cta header cell

Screenshots of "---" status, "Yes" status CTA, and "No" status CTA:
<img width="1416" alt="Screen Shot 2021-11-08 at 10 38 06 AM" src="https://user-images.githubusercontent.com/71795832/140798834-59d9509b-8da1-4436-8742-de6d318d3ebd.png">
<img width="1415" alt="Screen Shot 2021-11-08 at 10 38 01 AM" src="https://user-images.githubusercontent.com/71795832/140798835-b28493d5-4702-4384-9096-aa27fea2fbc3.png">
<img width="1401" alt="Screen Shot 2021-11-08 at 10 37 56 AM" src="https://user-images.githubusercontent.com/71795832/140798837-68a4c0d5-7ec8-4908-b0d5-780a79493756.png">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
