### PR TITLE
Schedules Page: Remove teams call on schedules for Fleet free

### DIFF
--- a/cypress/integration/premium/admin.spec.ts
+++ b/cypress/integration/premium/admin.spec.ts
@@ -95,7 +95,7 @@ describe(
         cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.findByText(/query all/i).click();
 
-        cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.findByText(/run query/i).should("exist");
 
         cy.get(".ace_scroller")

--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -26,7 +26,9 @@ type InitialStateType = {
   isAnyTeamMaintainerOrTeamAdmin: boolean | undefined;
   isTeamObserver: boolean | undefined;
   isTeamMaintainer: boolean | undefined;
+  isTeamMaintainerOrTeamAdmin: boolean | undefined;
   isAnyTeamAdmin: boolean | undefined;
+
   isTeamAdmin: boolean | undefined;
   isOnlyObserver: boolean | undefined;
   setCurrentUser: (user: IUser) => void;

--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -28,7 +28,6 @@ type InitialStateType = {
   isTeamMaintainer: boolean | undefined;
   isTeamMaintainerOrTeamAdmin: boolean | undefined;
   isAnyTeamAdmin: boolean | undefined;
-
   isTeamAdmin: boolean | undefined;
   isOnlyObserver: boolean | undefined;
   setCurrentUser: (user: IUser) => void;

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -156,7 +156,6 @@ const ManageSchedulePage = ({
   );
 
   let teamId = parseInt(team_id, 10);
-  const team = find(teams, ["id", teamId]);
 
   // isTeamMaintainerOrTeamAdmin set locally and not in AppContext
   const isTeamMaintainerOrTeamAdmin = (() => {

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -192,7 +192,7 @@ const ManageSchedulePage = ({
 
   useEffect(() => {
     dispatch(queryActions.loadAll());
-    dispatch(teamActions.loadAll());
+    isPremiumTier && dispatch(teamActions.loadAll());
     dispatch(
       teamId
         ? teamScheduledQueryActions.loadAll(teamId)

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -235,8 +235,8 @@ const ManageSchedulePage = ({
 
   const selectedTeam = isNaN(teamId) ? "global" : teamId;
 
-  const selectedTeamData = allTeamsList.find(
-    (team) => selectedTeam === team.id
+  const selectedTeamData = teams.find(
+    (team: ITeam) => selectedTeam === team.id
   );
 
   const [showInheritedQueries, setShowInheritedQueries] = useState<boolean>(
@@ -507,14 +507,8 @@ const ManageSchedulePage = ({
             allScheduledQueriesList,
             allScheduledQueriesError,
             toggleScheduleEditorModal,
-<<<<<<< HEAD
             isOnGlobalTeam || false,
             selectedTeamData
-=======
-            teamId,
-            isTeamMaintainerOrTeamAdmin || false,
-            isOnGlobalTeam || false
->>>>>>> 5d87ba70 (Refactor schedule page to new patterns except global and team scheduled queries API)
           )}
         </div>
         {/* must use ternary for NaN */}
@@ -548,14 +542,8 @@ const ManageSchedulePage = ({
           renderAllTeamsTable(
             allTeamsScheduledQueriesList,
             allTeamsScheduledQueriesError,
-<<<<<<< HEAD
             isOnGlobalTeam || false,
             selectedTeamData
-=======
-            teamId,
-            isTeamMaintainerOrTeamAdmin || false,
-            isOnGlobalTeam || false
->>>>>>> 5d87ba70 (Refactor schedule page to new patterns except global and team scheduled queries API)
           )}
         {showScheduleEditorModal && (
           <ScheduleEditorModal

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -20,6 +20,7 @@ import fleetQueriesAPI from "services/entities/queries";
 import teamsAPI from "services/entities/teams";
 // @ts-ignore
 import { renderFlash } from "redux/nodes/notifications/actions";
+import permissionUtils from "utilities/permissions";
 
 import paths from "router/paths";
 import Button from "components/buttons/Button";
@@ -134,10 +135,7 @@ const ManageSchedulePage = ({
     currentUser,
     isOnGlobalTeam,
     isPremiumTier,
-    isTeamMaintainerOrTeamAdmin,
     isAnyTeamMaintainerOrTeamAdmin,
-    setCurrentTeam,
-    currentTeam,
   } = useContext(AppContext);
 
   const { data: teams } = useQuery(["teams"], () => teamsAPI.loadAll({}), {
@@ -159,14 +157,13 @@ const ManageSchedulePage = ({
 
   let teamId = parseInt(team_id, 10);
   const team = find(teams, ["id", teamId]);
-  setCurrentTeam(team);
-  console.log("isTeamMaintainerOrTeamAdmin", isTeamMaintainerOrTeamAdmin);
-  console.log("currentTeam", currentTeam);
-  console.log("teamId", teamId);
+
+  // isTeamMaintainerOrTeamAdmin set locally and not in AppContext
+  const isTeamMaintainerOrTeamAdmin = (() => {
+    return !!permissionUtils.isTeamMaintainerOrTeamAdmin(currentUser, teamId);
+  })();
 
   const onChangeSelectedTeam = (selectedTeamId: number) => {
-    const team = find(teams, ["id", selectedTeamId]);
-    setCurrentTeam(team);
     if (isNaN(selectedTeamId)) {
       dispatch(push(MANAGE_SCHEDULE));
     } else {

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -133,6 +133,7 @@ const ManageSchedulePage = ({
     isOnGlobalTeam,
     isPremiumTier,
     isTeamMaintainerOrTeamAdmin,
+    isAnyTeamMaintainerOrTeamAdmin,
   } = useContext(AppContext);
 
   const onChangeSelectedTeam = (selectedTeamId: number) => {
@@ -260,7 +261,7 @@ const ManageSchedulePage = ({
   const generateTeamOptionsDropdownItems = (): ITeamOptions[] => {
     const teamOptions: ITeamOptions[] = [];
 
-    if (isTeamMaintainerOrTeamAdmin && currentUser) {
+    if (isAnyTeamMaintainerOrTeamAdmin && currentUser) {
       currentUser.teams.forEach((team) => {
         if (team.role === "admin" || team.role === "maintainer") {
           teamOptions.push({

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -235,9 +235,8 @@ const ManageSchedulePage = ({
 
   const selectedTeam = isNaN(teamId) ? "global" : teamId;
 
-  const selectedTeamData = teams.find(
-    (team: ITeam) => selectedTeam === team.id
-  );
+  const selectedTeamData =
+    teams?.find((team: ITeam) => selectedTeam === team.id) || undefined;
 
   const [showInheritedQueries, setShowInheritedQueries] = useState<boolean>(
     false


### PR DESCRIPTION
Cerra #2517 

Original PR bug fix:
- Fix bug found during final QA where schedules page was still calling teams on Fleet free

Updated PR another bug fix:
- Fix bug found during manual refresh of page where schedule wasn't grabbing the teams needed to render a dropdown

Updated PR refactored code: 
- Removed redux use for user, config, queries, teams
- Replaced it with AppContext (currentUser,  isTeamMaintainerOrTeamAdmin) and useQuery API calls (fleetQueriesAPI, teamsAPI)

Future work: Remove redux API calls completely from these components
https://github.com/fleetdm/fleet/issues/2856

Before:
<img width="1349" alt="Screen Shot 2021-11-08 at 12 21 14 PM" src="https://user-images.githubusercontent.com/71795832/140812319-127fc75d-977d-43a9-8f9a-828726d839e0.png">


After:
<img width="1348" alt="Screen Shot 2021-11-08 at 12 20 49 PM" src="https://user-images.githubusercontent.com/71795832/140812333-8c8fa7d8-578c-4a04-a7b0-7b711f8f072a.png">

#Checklist for submitter

If some of the following don't apply, delete the relevant line.

~~- [ ] Changes file added (for user-visible changes)~~
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
