### PR TITLE
Hide footer on fleetdm.com until the page is loaded

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -123,7 +123,7 @@
 
       <%- body %>
 
-      <%/* Note: footer is hidden until the page is loaded. See <script> tag at the bottom of this file. */%>
+      <%/* Note: footer is hidden until the page is loaded. See «script» tag at the bottom of this file. */%>
       <div style="background-color: #182147;" class="invisible" purpose="page-footer" data-hide-until-rendered>
         <div style="max-width: 1248px;" purpose="footer-container" class="container-fluid d-flex flex-column flex-sm-row align-items-sm-end justify-content-center justify-content-sm-between">
           <div class="d-flex flex-column order-first justify-content-start">

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -123,7 +123,7 @@
 
       <%- body %>
 
-
+      <%/* Note: footer is hidden until the page is loaded. See <script> tag at the bottom of this file. */%>
       <div style="background-color: #182147;" class="invisible" purpose="page-footer" data-hide-until-rendered>
         <div style="max-width: 1248px;" purpose="footer-container" class="container-fluid d-flex flex-column flex-sm-row align-items-sm-end justify-content-center justify-content-sm-between">
           <div class="d-flex flex-column order-first justify-content-start">
@@ -332,12 +332,12 @@
       }
     })();
     </script>
+
+    <% /* Keep footer hidden until the document is ready (prevents flicker that is especially unattractive on mobile) */ %>
     <script>
-      if($) {
-        $(function() {
-          $('[data-hide-until-rendered]').removeClass('invisible');
-        });
-      }
+    $(function() {
+      $('[data-hide-until-rendered]').removeClass('invisible'); // Note: invisible is a bootstrap 4 class
+    });
     </script>
 
   </body>

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -123,7 +123,8 @@
 
       <%- body %>
 
-      <div style="background-color: #182147;" purpose="page-footer">
+
+      <div style="background-color: #182147;" class="invisible" purpose="page-footer" data-hide-until-rendered>
         <div style="max-width: 1248px;" purpose="footer-container" class="container-fluid d-flex flex-column flex-sm-row align-items-sm-end justify-content-center justify-content-sm-between">
           <div class="d-flex flex-column order-first justify-content-start">
             <div class="d-flex pb-4 pr-4">
@@ -330,6 +331,13 @@
         }
       }
     })();
+    </script>
+    <script>
+      if($) {
+        $(function() {
+          $('[data-hide-until-rendered]').removeClass('invisible');
+        });
+      }
     </script>
 
   </body>


### PR DESCRIPTION
Changes:
- Added the `invisible` bootstrap 4 class and a `data-hide-until-rendered` attribute to the website footer.
- Added a script tag to `layout.ejs` that uses jQuery to remove the invisible class from the footer once the page is fully loaded.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
