### PR TITLE
More room for software names and keep tooltips visible

### DIFF
--- a/changes/fix-2726-long-software-names
+++ b/changes/fix-2726-long-software-names
@@ -1,0 +1,1 @@
+* Provide more room for software names and ensure tooltip is visible at smaller screen sizes

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -83,6 +83,13 @@
           max-width: 140px;
         }
       }
+
+      &.active-selection th {
+        border: 0;
+        .fleet-checkbox {
+          opacity: 0;
+        }
+      }
     }
 
     .Select.is-focused:not(.is-open) > .Select-control {

--- a/frontend/pages/hosts/HostDetailsPage/SoftwareTable/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/SoftwareTable/SoftwareTableConfig.tsx
@@ -117,7 +117,7 @@ const generateSoftwareTableHeaders = (): IDataColumn[] => {
         const { name, bundle_identifier } = cellProps.row.original;
         if (bundle_identifier) {
           return (
-            <span>
+            <span className="name-container">
               {name}
               <span
                 className={`software-name tooltip__tooltip-icon`}

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -442,8 +442,6 @@
 
   .section--software {
     th {
-      width: 200px;
-
       &:first-child {
         border-right: none;
         width: 16px;
@@ -458,11 +456,28 @@
       &:nth-last-child(2) {
         border-right: 0 !important;
       }
+
+      &.source__header {
+        width: 20%;
+      }
+
+      &.version__header {
+        width: 10%;
+      }
     }
     tr {
       td {
+        position: relative;
         &:first-child {
           padding-right: 0px;
+        }
+        .name-container {
+          .tooltip__tooltip-icon {
+            @include breakpoint(ltdesktop) {
+              position: absolute;
+              right: 0.5rem;
+            }
+          }
         }
       }
 


### PR DESCRIPTION
For #2726
&
For #2764 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Documented any permissions changes
- [ ] Manual QA for all new/changed functionality

---

I adjusted the software table columns to use percentage widths so that they resized on smaller screens and provided more room for the software name. I also positioned the bundle tooltip `absolute right` below 1200px to ensure it doesn't get cut off with the name. 

![image](https://user-images.githubusercontent.com/2495927/141046448-f87c55f7-402f-4ff1-a55e-49b65d8d5343.png)

-

![image](https://user-images.githubusercontent.com/2495927/141046512-5c58adab-3941-4332-bf5c-b3130195027c.png)
