### PR TITLE
Add team_id to host summary when filtered for a specific team

### DIFF
--- a/docs/01-Using-Fleet/03-REST-API.md
+++ b/docs/01-Using-Fleet/03-REST-API.md
@@ -621,6 +621,7 @@ Returns the count of all hosts organized by status. `online_count` includes all 
 
 ```json
 {
+  "team_id": 1,
   "totals_hosts_count": 2408,
   "platforms": [
     {

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -540,7 +540,7 @@ func (d *Datastore) GenerateHostStatusStatistics(ctx context.Context, filter fle
 			LIMIT 1;
 		`, fleet.OnlineIntervalBuffer, fleet.OnlineIntervalBuffer, whereClause)
 
-	var summary fleet.HostSummary
+	summary := fleet.HostSummary{TeamID: filter.TeamID}
 	err := sqlx.GetContext(ctx, d.reader, &summary, sqlStatement, now, now, now, now, now)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, ctxerr.Wrap(ctx, err, "generating host statistics")

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -907,6 +907,7 @@ func testHostsGenerateStatusStatistics(t *testing.T, ds *Datastore) {
 
 	summary, err := ds.GenerateHostStatusStatistics(context.Background(), filter, mockClock.Now())
 	assert.Nil(t, err)
+	assert.Nil(t, summary.TeamID)
 	assert.Equal(t, uint(0), summary.TotalsHostsCount)
 	assert.Equal(t, uint(0), summary.OnlineCount)
 	assert.Equal(t, uint(0), summary.OfflineCount)

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -159,6 +159,7 @@ const (
 // set of hosts in the database. This structure is returned by the HostService
 // method GetHostSummary
 type HostSummary struct {
+	TeamID           *uint                  `json:"team_id,omitempty"`
 	TotalsHostsCount uint                   `json:"totals_hosts_count" db:"total"`
 	Platforms        []*HostSummaryPlatform `json:"platforms"`
 	OnlineCount      uint                   `json:"online_count" db:"online"`

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -53,6 +53,7 @@ func TestGetHostSummary(t *testing.T) {
 
 	summary, err := svc.GetHostSummary(test.UserContext(test.UserAdmin), nil)
 	require.NoError(t, err)
+	require.Nil(t, summary.TeamID)
 	require.Equal(t, uint(1), summary.OnlineCount)
 	require.Equal(t, uint(2), summary.OfflineCount)
 	require.Equal(t, uint(3), summary.MIACount)

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -651,11 +651,13 @@ func (s *integrationTestSuite) TestGetHostSummary() {
 	require.Len(t, resp.Platforms, 1)
 	require.Equal(t, "linux", resp.Platforms[0].Platform)
 	require.Equal(t, uint(len(hosts)), resp.Platforms[0].HostsCount)
+	require.Nil(t, resp.TeamID)
 
 	// team filter, no host
 	s.DoJSON("GET", "/api/v1/fleet/host_summary", nil, http.StatusOK, &resp, "team_id", fmt.Sprint(team2.ID))
 	require.Equal(t, resp.TotalsHostsCount, uint(0))
 	require.Len(t, resp.Platforms, 0)
+	require.Equal(t, team2.ID, *resp.TeamID)
 
 	// team filter, one host
 	s.DoJSON("GET", "/api/v1/fleet/host_summary", nil, http.StatusOK, &resp, "team_id", fmt.Sprint(team1.ID))
@@ -663,4 +665,5 @@ func (s *integrationTestSuite) TestGetHostSummary() {
 	require.Len(t, resp.Platforms, 1)
 	require.Equal(t, "linux", resp.Platforms[0].Platform)
 	require.Equal(t, uint(1), resp.Platforms[0].HostsCount)
+	require.Equal(t, team1.ID, *resp.TeamID)
 }


### PR DESCRIPTION
As discussed here: https://github.com/fleetdm/fleet/pull/2845/files#r745092020

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] ~~Changes file added (for user-visible changes)~~ (part of the same change as the previous PR)
- [x] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] ~~Documented any permissions changes~~
- [x] Added/updated tests
- [ ] ~~Manual QA for all new/changed functionality~~
