### PR TITLE
Handle Team Admin removing self from team

### DIFF
--- a/changes/fix-2883-handle-team-admin-remove-self
+++ b/changes/fix-2883-handle-team-admin-remove-self
@@ -1,0 +1,1 @@
+* Handle a Team Admin removing self from team or removing admin status

--- a/frontend/components/Avatar/_styles.scss
+++ b/frontend/components/Avatar/_styles.scss
@@ -1,6 +1,5 @@
 .avatar {
   @include size(120px);
-  border: solid 1px $ui-fleet-blue-15;
   display: block;
   background-size: cover;
   border-radius: 50%;

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPagePage/MembersPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPagePage/MembersPage.tsx
@@ -173,6 +173,11 @@ const MembersPage = ({
         dispatch(
           renderFlash("success", `Successfully removed ${userEditing?.name}`)
         );
+        // If user removes self from team,
+        // redirect to home
+        if (currentUser && currentUser.id === removedUsers.users[0].id) {
+          window.location.href = "/";
+        }
       })
       .catch(() =>
         dispatch(
@@ -319,7 +324,18 @@ const MembersPage = ({
       dispatch(userActions.update(userEditing, updatedAttrs))
         .then(() => {
           dispatch(renderFlash("success", `Successfully edited ${userName}.`));
-          fetchUsers(tableQueryData);
+          if (currentUser && userEditing && currentUser.id === userEditing.id) {
+            // If user edits self and removes "admin" role,
+            // redirect to home
+            const currentTeam = formData.teams.filter(
+              (thisTeam) => thisTeam.id === teamId
+            );
+            if (currentTeam && currentTeam[0].role !== "admin") {
+              window.location.href = "/";
+            }
+          } else {
+            fetchUsers(tableQueryData);
+          }
         })
         .catch(() => {
           dispatch(

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -27,7 +27,6 @@ import InfoBanner from "components/InfoBanner/InfoBanner";
 import SelectedTeamsForm from "../SelectedTeamsForm/SelectedTeamsForm";
 import OpenNewTabIcon from "../../../../../../assets/images/open-new-tab-12x12@2x.png";
 import SelectRoleForm from "../SelectRoleForm/SelectRoleForm";
-import teams from "fleet/entities/teams";
 
 const baseClass = "create-user-form";
 

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -27,6 +27,7 @@ import InfoBanner from "components/InfoBanner/InfoBanner";
 import SelectedTeamsForm from "../SelectedTeamsForm/SelectedTeamsForm";
 import OpenNewTabIcon from "../../../../../../assets/images/open-new-tab-12x12@2x.png";
 import SelectRoleForm from "../SelectRoleForm/SelectRoleForm";
+import teams from "fleet/entities/teams";
 
 const baseClass = "create-user-form";
 
@@ -299,13 +300,9 @@ class UserForm extends Component<ICreateUserFormProps, ICreateUserFormState> {
   renderGlobalRoleForm = (): JSX.Element => {
     const { onGlobalUserRoleChange } = this;
     const {
-      formData: { global_role, teams },
+      formData: { global_role },
     } = this.state;
-    const {
-      availableTeams,
-      isModifiedByGlobalAdmin,
-      isPremiumTier,
-    } = this.props;
+    const { isPremiumTier } = this.props;
     return (
       <>
         {isPremiumTier && (
@@ -430,6 +427,7 @@ class UserForm extends Component<ICreateUserFormProps, ICreateUserFormState> {
       currentTeam,
       isModifiedByGlobalAdmin,
       serverErrors,
+      availableTeams,
     } = this.props;
     const {
       onFormSubmit,
@@ -646,6 +644,7 @@ class UserForm extends Component<ICreateUserFormProps, ICreateUserFormState> {
                     value={UserTeamType.AssignTeams}
                     name={"userTeamType"}
                     onChange={onIsGlobalUserChange}
+                    disabled={!availableTeams.length}
                   />
                 </>
               ) : (

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleListWrapper.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleListWrapper.tsx
@@ -68,8 +68,6 @@ const ScheduleListWrapper = ({
 
   const handleAdvanced = () => dispatch(push(MANAGE_PACKS));
 
-  console.log("selectedTeamData.id", selectedTeamData?.id);
-
   const NoScheduledQueries = () => {
     return (
       <div


### PR DESCRIPTION
For #2883 

This handles two cases: 

1. Team Admin removes self from team entirely. 
2. Team Admin changes role to something other than admin. 

In both cases, the user no longer has access to the page they are on, and we want to redirect them to the dashboard. 

# Checklist for submitter

- [ ] Changes file added (for user-visible changes)
- [ ] Manual QA for all new/changed functionality
