### PR TITLE
Add missing items to the Fleet 4.5.0 CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 * Add support for [MinIO](https://min.io/) as a file carving backend. Documentation for configuring MinIO as a file carving backend can be found [here on fleetdm.com/docs](https://fleetdm.com/docs/using-fleet/fleetctl-cli#minio). Thank you to Chandra Majumdar and Ben Edwards for adding this capability.
 
-* Add the ability to run a live query and receive results using only the Fleet REST API with a `GET /api/v1/fleet/queries/run` API route. Documentation for this new API route can be found [here on fleetdm.com/docs]().
+* Add support for generating a `.pkg` osquery installer on Linux without dependencies (beyond Docker) with the `fleetctl package` command.
+
+* Improve the performance of vulnerability processing by making the process consume less RAM. Documentation for the vulnerability processing feature can be found [here on fleetdm.com/docs](https://fleetdm.com/docs/using-fleet/vulnerability-processing).
+
+* Add the ability to run a live query and receive results using only the Fleet REST API with a `GET /api/v1/fleet/queries/run` API route. Documentation for this new API route can be found [here on fleetdm.com/docs](https://fleetdm.com/docs/using-fleet/rest-api#run-live-query).
 
 * Add ability to see whether a specific host is "Passing" or "Failing" a policy on the **Host details** page. This information is also exposed in the `GET api/v1/fleet/hosts/{id}` API route. In Fleet, a policy is a "yes" or "no" question you can ask of all your hosts.
 
@@ -33,6 +37,10 @@
 * Add ability to connect to Redis with TLS. Documentation for configuring Fleet to use a TLS connection to the Redis server can be found [here on fleetdm.com/docs](https://fleetdm.com/docs/deploying/configuration#redis-use-tls).
 
 * Add `cluster_read_from_replica` Redis to specify whether or not to prefer readying from a replica when possible. Documentation for this configuration option can be found [here on fleetdm.com/docs](https://fleetdm.com/docs/deploying/configuration#redis-cluster-read-from-replica).
+
+* Improve experience of the Fleet UI by preventing autocomplete in forms.
+
+* Fix a bug in which generating an `.msi` osquery installer on Windows would fail with a permission error.
 
 * Fix a bug in which turning on the host expiry setting did not remove expired hosts from Fleet.
 

--- a/changes/fix-2501-team-admin-policies
+++ b/changes/fix-2501-team-admin-policies
@@ -1,1 +1,0 @@
-* Bug fix: Show team admins create policy buttons

--- a/changes/fix-2653
+++ b/changes/fix-2653
@@ -1,1 +1,0 @@
-* Hide columns in query table at smaller page sizes

--- a/changes/fix-2687-team-admin-scheduled-queries
+++ b/changes/fix-2687-team-admin-scheduled-queries
@@ -1,1 +1,0 @@
-* Bug fix: Allow Team Admins to manage scheduled queries

--- a/changes/fix-2707-team-observer-delete-host
+++ b/changes/fix-2707-team-observer-delete-host
@@ -1,1 +1,0 @@
-* Bug fix: Team Observer can no longer see delete button on host details

--- a/changes/fix-msi
+++ b/changes/fix-msi
@@ -1,3 +1,0 @@
-* Fix .msi generation in `fleetctl package` on Windows.
-
-* Allow .pkg generation in `fleetctl package` on Linux without installing dependencies (beyond Docker).

--- a/changes/issue-2630-error-empty-state-activity-feed
+++ b/changes/issue-2630-error-empty-state-activity-feed
@@ -1,1 +1,0 @@
-* Cleaner error and empty state of activity feed

--- a/changes/issue-2638-restyle-button
+++ b/changes/issue-2638-restyle-button
@@ -1,2 +1,0 @@
-* Restyle UI for filter-by-software and filter-by-policy buttons on manage hosts page to localize
-clear filter click to "x" icon

--- a/changes/issue-2670-remove-autocompletes
+++ b/changes/issue-2670-remove-autocompletes
@@ -1,1 +1,0 @@
-* Forms with input fields now have autocomplete turned off

--- a/changes/issue-2701-team-validator
+++ b/changes/issue-2701-team-validator
@@ -1,1 +1,0 @@
-* Cannot click CTA to add or edit a team if the team name is blank

--- a/changes/issue-2702-cleaner-add-team-members-ui
+++ b/changes/issue-2702-cleaner-add-team-members-ui
@@ -1,1 +1,0 @@
-* Cleaner UI for adding a team member

--- a/changes/make-vuln-processing-less-intense
+++ b/changes/make-vuln-processing-less-intense
@@ -1,1 +1,0 @@
-* Make vulnerability processing consume less RAM


### PR DESCRIPTION
- Remove remaining `changes` files that were included in the 4.5.0 release
- Update CHANGELOG to include the missing changes entries
