### PR TITLE
Fixed spacing for manage hosts filter blocks

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -161,6 +161,10 @@
     margin-bottom: $pad-medium;
   }
 
+  &__labels-active-filter-wrap {
+    margin-bottom: $pad-medium;
+  }
+
   &__policies-filter-block {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Relates to #2826

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] ~Changes file added (for user-visible changes)~
- [ ] ~Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
- [ ] ~Documented any permissions changes~
- [ ] ~Added/updated tests~
- [x] Manual QA for all new/changed functionality

# QA Steps
- Start the app with software enabled
- Visit `/hosts/manage/?order_key=hostname&order_direction=asc&software_id=2`
- Verify the software label block has spacing beneath