### PR TITLE
Remove html comments from code blocks on fleetdm.com/docs

### DIFF
--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -196,12 +196,12 @@ module.exports = {
                   /(<code)([^>]*)(>\s*)(\&lt;!-- __LANG=\%\%__ --\&gt;)\s*/gm,
                   '$1 class="nohighlight"$2$3'
                 )
-                .replace(//nab the rest, leaving the code language as-is.
+                .replace(// Nab the rest, leaving the code language as-is.
                   // $1     $2     $3   $4               $5    $6
                   /(<code)([^>]*)(>\s*)(\&lt;!-- __LANG=\%)([^%]+)(\%__ --\&gt;)\s*/gm,
                   '$1 class="$5"$2$3'
                 )
-                .replace(// Handle "LANG" markers that have been added inside of code block (e.g. nested code blocks)
+                .replace(// Finally, remove any "LANG" markers that have been added inside of a nested code block
                   /(```)\n\&lt;\!\-+\s\_+LANG\=\%+\_+\s\-+\&gt;/gm,
                   '$1'
                 )

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -196,10 +196,14 @@ module.exports = {
                   /(<code)([^>]*)(>\s*)(\&lt;!-- __LANG=\%\%__ --\&gt;)\s*/gm,
                   '$1 class="nohighlight"$2$3'
                 )
-                .replace(// Finally, nab the rest, leaving the code language as-is.
+                .replace(//nab the rest, leaving the code language as-is.
                   // $1     $2     $3   $4               $5    $6
                   /(<code)([^>]*)(>\s*)(\&lt;!-- __LANG=\%)([^%]+)(\%__ --\&gt;)\s*/gm,
                   '$1 class="$5"$2$3'
+                )
+                .replace(// Handle "LANG" markers that have been added inside of codeblocks (e.g. nested code blocks)
+                  /\n\&lt;\!\-+\s\_+LANG\=\%+\_+\s\-+\&gt;/gm,
+                  ''
                 )
               );
               htmlString = htmlString.replace(/\(\(([^())]*)\)\)/g, '<bubble type="$1" class="colors"><span is="bubble-heart"></span></bubble>');// « Replace ((bubble))s with HTML. For more background, see https://github.com/fleetdm/fleet/issues/706#issuecomment-884622252

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -201,9 +201,9 @@ module.exports = {
                   /(<code)([^>]*)(>\s*)(\&lt;!-- __LANG=\%)([^%]+)(\%__ --\&gt;)\s*/gm,
                   '$1 class="$5"$2$3'
                 )
-                .replace(// Handle "LANG" markers that have been added inside of codeblocks (e.g. nested code blocks)
-                  /\n\&lt;\!\-+\s\_+LANG\=\%+\_+\s\-+\&gt;/gm,
-                  ''
+                .replace(// Handle "LANG" markers that have been added inside of code block (e.g. nested code blocks)
+                  /(```)\n\&lt;\!\-+\s\_+LANG\=\%+\_+\s\-+\&gt;/gm,
+                  '$1'
                 )
               );
               htmlString = htmlString.replace(/\(\(([^())]*)\)\)/g, '<bubble type="$1" class="colors"><span is="bubble-heart"></span></bubble>');// « Replace ((bubble))s with HTML. For more background, see https://github.com/fleetdm/fleet/issues/706#issuecomment-884622252


### PR DESCRIPTION
Closes #2887 

Changes:
- updated `build-static-content.js` to remove any HTML "LANG" markers that get added to nested code blocks during markdown compilation.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
