### PR TITLE
Fix broken link in "Osquery logs" documentation

### DIFF
--- a/docs/01-Using-Fleet/05-Osquery-logs.md
+++ b/docs/01-Using-Fleet/05-Osquery-logs.md
@@ -2,7 +2,7 @@
 
 This document provides instructions for working with each of the following log destinations in Fleet.
 
-To configure each log destination, you must set the correct osquery logging configuration options in Fleet. Check out the reference documentation for osquery logging configuration options [here in the Fleet documentation](../02-Deploying/02-Configuration.md#osquery_status_log_plugin).
+To configure each log destination, you must set the correct osquery logging configuration options in Fleet. Check out the reference documentation for osquery logging configuration options [here in the Fleet documentation](../02-Deploying/02-Configuration.md#osquery-status-log-plugin).
 
 - [Firehose](#firehose)
 - [Snowflake](#snowflake)
@@ -42,7 +42,7 @@ With Fleet configured to send logs to Firehose, you then want to load the data f
 
 If you're using Fleet's [terraform reference architecture](https://github.com/fleetdm/fleet/blob/main/tools/terraform), you want to replace the S3 destination with a Splunk destination. Hashicorp provides instructions on how to send Firehose data to Splunk [here in the Terraform documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream#splunk-destination).
 
-Splunk provides instructions on how to prepare the Splunk platform for Firehose data [here in the Splunk documentation](https://docs.splunk.com/Documentation/AddOns/latest/Firehose/ConfigureFirehose)
+Splunk provides instructions on how to prepare the Splunk platform for Firehose data [here in the Splunk documentation](https://docs.splunk.com/Documentation/AddOns/latest/Firehose/ConfigureFirehose).
 
 ### Kinesis
 

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -40,6 +40,8 @@ You can link documentation pages to each other using relative paths. For example
 However, the `fleetdm.com/docs` compilation process does not account for relative links to directories **outside** of `/docs`.
 Therefore, when adding a link to Fleet docs, it is important to always use the absolute file path.
 
+When directly linking to a specific section within a page in the Fleet documentation, always format the spaces within a section name to use a hyphen (`-`) instead of an underscore (`_`). For example, when linking to the `osquery_result_log_plugin` section of the configuration reference docs, use a relative link like the following: `./02-Configuration.md#osquery-result-log-plugin`.
+
 ### Linking to a location on GitHub
 When adding a link to a location on GitHub that is outside of `/docs`, be sure to use the canonical form of the URL.
 

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -40,7 +40,7 @@ You can link documentation pages to each other using relative paths. For example
 However, the `fleetdm.com/docs` compilation process does not account for relative links to directories **outside** of `/docs`.
 Therefore, when adding a link to Fleet docs, it is important to always use the absolute file path.
 
-When directly linking to a specific section within a page in the Fleet documentation, always format the spaces within a section name to use a hyphen (`-`) instead of an underscore (`_`). For example, when linking to the `osquery_result_log_plugin` section of the configuration reference docs, use a relative link like the following: `./02-Configuration.md#osquery-result-log-plugin`.
+When directly linking to a specific section within a page in the Fleet documentation, always format the spaces within a section name to use a hyphen `-` instead of an underscore `_`. For example, when linking to the `osquery_result_log_plugin` section of the configuration reference docs, use a relative link like the following: `./02-Configuration.md#osquery-result-log-plugin`.
 
 ### Linking to a location on GitHub
 When adding a link to a location on GitHub that is outside of `/docs`, be sure to use the canonical form of the URL.


### PR DESCRIPTION
- Fix a broken link in the summary of the "Osquery logs" documentation
- Update instructions for linking to a specific section within a page in the Fleet documentation in product handbook