### PR TITLE
Update vercel bot name in list of github maintainers and bots

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -43,7 +43,7 @@ module.exports = {
       'alphabrevity',
       'eashaw',
       'drewbakerfdm',
-      'vercel'
+      'vercel[bot]'
     ];
     let GITHUB_USERNAME_OF_DRI_FOR_LABELS = 'rlynnj11';// « Used below
 


### PR DESCRIPTION
changes:
 - changed 'vercel' to 'vercel[bot]'

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
