### PR TITLE
Fleet setup: Overflow fix

### DIFF
--- a/changes/issue-2923-setup-overflow-info
+++ b/changes/issue-2923-setup-overflow-info
@@ -1,0 +1,1 @@
+* Fix: Fleet Setup confirmation overflow

--- a/frontend/components/forms/RegistrationForm/ConfirmationPage/ConfirmationPage.tsx
+++ b/frontend/components/forms/RegistrationForm/ConfirmationPage/ConfirmationPage.tsx
@@ -78,7 +78,7 @@ const ConfirmationPage = ({
             </tr>
             <tr>
               <th>Email:</th>
-              <td>{email}</td>
+              <td className={`${baseClass}__table-email`}>{email}</td>
             </tr>
             <tr>
               <th>Organization:</th>

--- a/frontend/components/forms/RegistrationForm/ConfirmationPage/_styles.scss
+++ b/frontend/components/forms/RegistrationForm/ConfirmationPage/_styles.scss
@@ -52,7 +52,7 @@
       font-size: $small;
       font-weight: $bold;
       text-align: left;
-      padding-right: 108px;
+      padding-right: 20px;
     }
 
     td {
@@ -61,8 +61,15 @@
     }
   }
 
+  &__table-email {
+    max-width: 292px;
+    word-wrap: break-word;
+  }
+
   &__table-url {
-    @include ellipsis(100%);
+    display: inline-block;
+    max-width: 292px;
+    word-wrap: break-word;
     font-family: "SourceCodePro", $monospace;
     vertical-align: bottom;
     font-weight: 600;


### PR DESCRIPTION
Cerra #2923 

- Email address is wrapped instead of overflowing the table
- Fleet URL is wrapped instead of overflowing the table

<img width="1307" alt="Screen Shot 2021-11-15 at 2 26 22 PM" src="https://user-images.githubusercontent.com/71795832/141842368-d421cf2f-717c-495c-841d-bf135ccf331d.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
