### PR TITLE
Add policies to the standard query library on fleetdm.com

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -516,3 +516,33 @@ spec:
   query: select * from shimcache
   purpose: Informational
   contributors: puffyCid
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Is Gatekeeper enabled on macOS devices?
+  query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;
+  platforms: macOS
+  description: Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.
+  resolution: "Run the following command in the Terminal app: /usr/sbin/spctl --master-enable"
+  contributors: groob
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Are Windows devices encrypted?
+  query: SELECT 1 FROM bitlocker_info where protection_status = 1;
+  platforms: Windows
+  description: Checks to make sure that device encryption is enabled on Windows devices.
+  resolution: "Option 1: Select the Start button. Select Settings  > Update & Security  > Device encryption. If Device encryption doesn't appear, skip to Option 2. If device encryption is turned off, select Turn on. Option 2: Select the Start button. Under Windows System, select Control Panel. Select System and Security. Under BitLocker Drive Encryption, select Manage BitLocker. Select Turn on BitLocker and then follow the instructions."
+  contributors: zwass
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Is Filevault enabled on macOS devices?
+  query: SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT “” AND filevault_status = ‘on’ LIMIT 1;
+  platforms: macOS
+  description: Checks to make sure that the Filevault feature is enabled on macOS devices.
+  resolution: "Choose Apple menu > System Preferences, then click Security & Privacy. Click the FileVault tab. Click the Lock icon, then enter an administrator name and password. Click Turn On FileVault."
+  contributors: groob

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -516,33 +516,3 @@ spec:
   query: select * from shimcache
   purpose: Informational
   contributors: puffyCid
----
-apiVersion: v1
-kind: policy
-spec:
-  name: Is Gatekeeper enabled on macOS devices?
-  query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;
-  platforms: macOS
-  description: Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.
-  resolution: "Run the following command in the Terminal app: /usr/sbin/spctl --master-enable"
-  contributors: groob
----
-apiVersion: v1
-kind: policy
-spec:
-  name: Are Windows devices encrypted?
-  query: SELECT 1 FROM bitlocker_info where protection_status = 1;
-  platforms: Windows
-  description: Checks to make sure that device encryption is enabled on Windows devices.
-  resolution: "Option 1: Select the Start button. Select Settings  > Update & Security  > Device encryption. If Device encryption doesn't appear, skip to Option 2. If device encryption is turned off, select Turn on. Option 2: Select the Start button. Under Windows System, select Control Panel. Select System and Security. Under BitLocker Drive Encryption, select Manage BitLocker. Select Turn on BitLocker and then follow the instructions."
-  contributors: zwass
----
-apiVersion: v1
-kind: policy
-spec:
-  name: Is Filevault enabled on macOS devices?
-  query: SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT “” AND filevault_status = ‘on’ LIMIT 1;
-  platforms: macOS
-  description: Checks to make sure that the Filevault feature is enabled on macOS devices.
-  resolution: "Choose Apple menu > System Preferences, then click Security & Privacy. Click the FileVault tab. Click the Lock icon, then enter an administrator name and password. Click Turn On FileVault."
-  contributors: groob

--- a/website/assets/js/pages/query-library.page.js
+++ b/website/assets/js/pages/query-library.page.js
@@ -6,7 +6,7 @@ parasails.registerPage('query-library', {
     inputTextValue: '',
     inputTimers: {},
     searchString: '', // The user input string to be searched against the query library
-    selectedPurpose: 'all queries', // Initially set to all, the user may select a different option to filter queries by purpose (e.g., "all queries", "information", "detection")
+    selectedKind: 'all queries', // Initially set to all, the user may select a different option to filter queries by purpose (e.g., "all queries", "information", "policies")
     selectedPlatform: 'all platforms', // Initially set to all, the user may select a different option to filter queries by platform (e.g., "all platforms", "macOS", "Windows", "Linux")
   },
 
@@ -15,7 +15,7 @@ parasails.registerPage('query-library', {
       return this.queries.filter(
         (query) =>
           this._isIncluded(query.platforms, this.selectedPlatform) &&
-          this._isIncluded(query.purpose, this.selectedPurpose)
+          this._isIncluded(query.kind, this.selectedKind)
       );
     },
 
@@ -42,8 +42,8 @@ parasails.registerPage('query-library', {
   //  ║║║║ ║ ║╣ ╠╦╝╠═╣║   ║ ║║ ║║║║╚═╗
   //  ╩╝╚╝ ╩ ╚═╝╩╚═╩ ╩╚═╝ ╩ ╩╚═╝╝╚╝╚═╝
   methods: {
-    clickSelectPurpose(purpose) {
-      this.selectedPurpose = purpose;
+    clickSelectKind(purpose) {
+      this.selectedKind = purpose;
     },
 
     clickSelectPlatform(platform) {

--- a/website/assets/js/pages/query-library.page.js
+++ b/website/assets/js/pages/query-library.page.js
@@ -42,8 +42,8 @@ parasails.registerPage('query-library', {
   //  ║║║║ ║ ║╣ ╠╦╝╠═╣║   ║ ║║ ║║║║╚═╗
   //  ╩╝╚╝ ╩ ╚═╝╩╚═╩ ╩╚═╝ ╩ ╩╚═╝╝╚╝╚═╝
   methods: {
-    clickSelectKind(purpose) {
-      this.selectedKind = purpose;
+    clickSelectKind(kind) {
+      this.selectedKind = kind;
     },
 
     clickSelectPlatform(platform) {

--- a/website/assets/js/pages/query-library.page.js
+++ b/website/assets/js/pages/query-library.page.js
@@ -6,7 +6,7 @@ parasails.registerPage('query-library', {
     inputTextValue: '',
     inputTimers: {},
     searchString: '', // The user input string to be searched against the query library
-    selectedKind: 'all queries', // Initially set to all, the user may select a different option to filter queries by purpose (e.g., "all queries", "information", "policies")
+    selectedKind: 'all queries', // Initially set to all, the user may select a different option to filter queries by purpose (e.g., "all queries", "informational", "policies")
     selectedPlatform: 'all platforms', // Initially set to all, the user may select a different option to filter queries by platform (e.g., "all platforms", "macOS", "Windows", "Linux")
   },
 

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -32,6 +32,7 @@ module.exports = {
         let queriesWithProblematicContributors = [];
         let queries = YAML.parseAllDocuments(yaml).map((yamlDocument)=>{
           let query = yamlDocument.toJSON().spec;
+          query.purpose = yamlDocument.toJSON().kind;
           query.slug = _.kebabCase(query.name);// « unique slug to use for routing to this query's detail page
           if (false) {
           // if ((query.remediation !== undefined && !_.isString(query.remediation)) || (query.purpose !== 'Detection' && _.isString(query.remediation))) {  TODO: maybe bring this back later

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -32,7 +32,7 @@ module.exports = {
         let queriesWithProblematicContributors = [];
         let queries = YAML.parseAllDocuments(yaml).map((yamlDocument)=>{
           let query = yamlDocument.toJSON().spec;
-          query.purpose = yamlDocument.toJSON().kind;
+          query.kind = yamlDocument.toJSON().kind;
           query.slug = _.kebabCase(query.name);// « unique slug to use for routing to this query's detail page
           if (false) {
           // if ((query.remediation !== undefined && !_.isString(query.remediation)) || (query.purpose !== 'Detection' && _.isString(query.remediation))) {  TODO: maybe bring this back later

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -28,19 +28,19 @@ module.exports = {
         let RELATIVE_PATH_TO_QUERY_LIBRARY_YML_IN_FLEET_REPO = 'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml';
         let yaml = await sails.helpers.fs.read(path.join(topLvlRepoPath, RELATIVE_PATH_TO_QUERY_LIBRARY_YML_IN_FLEET_REPO)).intercept('doesNotExist', (err)=>new Error(`Could not find standard query library YAML file at "${RELATIVE_PATH_TO_QUERY_LIBRARY_YML_IN_FLEET_REPO}".  Was it accidentally moved?  Raw error: `+err.message));
 
-        let queriesWithProblematicRemediations = [];
+        let queriesWithProblematicResolutions = [];
         let queriesWithProblematicContributors = [];
         let queries = YAML.parseAllDocuments(yaml).map((yamlDocument)=>{
           let query = yamlDocument.toJSON().spec;
           query.kind = yamlDocument.toJSON().kind;
           query.slug = _.kebabCase(query.name);// « unique slug to use for routing to this query's detail page
           if (false) {
-          // if ((query.remediation !== undefined && !_.isString(query.remediation)) || (query.purpose !== 'Detection' && _.isString(query.remediation))) {  TODO: maybe bring this back later
-            // console.log(typeof query.remediation);
-            queriesWithProblematicRemediations.push(query);
-          // } else if (query.remediation === undefined) {
-          } else { // « For now set remediation to N/A for all queries until we reinstate checks that are commented out above.  TODO: finish that
-            query.remediation = 'N/A';// « We set this to a string here so that the data type is always string.  We use N/A so folks can see there's no remediation and contribute if desired.
+          // if ((query.resolution !== undefined && !_.isString(query.resolution)) || (query.kind !== 'policy' && _.isString(query.resolution))) { TODO: maybe bring this back later
+            // console.log(typeof query.resolution);
+            queriesWithProblematicResolutions.push(query);
+          // } else if (query.resolution === undefined) {
+          } else { // « For now set resolution to N/A for all queries until we reinstate checks that are commented out above.  TODO: finish that
+            query.resolution = 'N/A';// « We set this to a string here so that the data type is always string.  We use N/A so folks can see there's no remediation and contribute if desired.
           }
 
           // GitHub usernames may only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen.
@@ -51,8 +51,8 @@ module.exports = {
           return query;
         });
         // Report any errors that were detected along the way in one fell swoop to avoid endless resubmitting of PRs.
-        if (queriesWithProblematicRemediations.length >= 1) {
-          throw new Error('Failed parsing YAML for query library: The "remediation" of a query should either be absent (undefined) or a single string (not a list of strings).  And "remediation" should only be present when a query\'s purpose is "Detection".  But one or more queries have an invalid "remediation": ' + _.pluck(queriesWithProblematicRemediations, 'slug').sort());
+        if (queriesWithProblematicResolutions.length >= 1) {
+          throw new Error('Failed parsing YAML for query library: The "resolution" of a query should either be absent (undefined) or a single string (not a list of strings).  And "resolution" should only be present when a query\'s kind is "policy".  But one or more queries have an invalid "resolution": ' + _.pluck(queriesWithProblematicResolutions, 'slug').sort());
         }//•
         // Assert uniqueness of slugs.
         if (queries.length !== _.uniq(_.pluck(queries, 'slug')).length) {

--- a/website/views/pages/query-detail.ejs
+++ b/website/views/pages/query-detail.ejs
@@ -22,10 +22,10 @@
             <h3 class="pb-4 mb-3 m-0">Query</h3>
             <code class="pb-3">{{query.query ? query.query : '--'}}</code>  
           </div>
-          <!-- <div purpose="remediation" v-if="query.purpose === 'Detection' && query.remediation">
-            <h3 class="pt-5 pb-3">Remediation</h3>
-            <p>{{query.remediation ? query.remediation : 'N/A'}}</p>
-          </div>   -->
+          <div purpose="resolution" v-if="query.kind === 'policy' && query.resolution">
+            <h3 class="pt-5 pb-3">Resolve</h3>
+            <p>{{query.resolution}}</p>
+          </div>
         </div>
       </div>
       <div purpose="summary-sidebar" class="col-md-4 order-first order-md-last p-0 pl-md-3 pt-md-4">
@@ -44,7 +44,7 @@
         <div class="border-top py-2">
           <div class="d-flex flex-md-column justify-content-between justify-content-md-start align-items-center align-items-md-start py-1 py-md-3">
             <h5 class="pb-md-2 m-0">Purpose</h5>
-            <p class="m-0">{{query.purpose ? query.purpose : '--'}}</p>
+            <p class="m-0">{{query.kind === 'policy' ? 'Policy' : query.kind === 'query' ? 'Informational' : '--'}}</p>
           </div>
         </div>
         <div class="border-top py-2 pb-md-4">

--- a/website/views/pages/query-library.ejs
+++ b/website/views/pages/query-library.ejs
@@ -20,7 +20,7 @@
           <div class="d-flex select-mobile">
             <div class="select-mobile-border">
               <select class="select-purpose mobile font-weight-bold" v-model="selectedKind">
-                <option value="all queries" selected >All queries</option>
+                <option value="all queries" selected>All queries</option>
                 <option value="query">Informational queries</option>
                 <option value="policy">Policies</option>
               </select>

--- a/website/views/pages/query-library.ejs
+++ b/website/views/pages/query-library.ejs
@@ -19,10 +19,10 @@
           </div>
           <div class="d-flex select-mobile">
             <div class="select-mobile-border">
-              <select class="select-purpose mobile font-weight-bold" v-model="selectedPurpose">
-                <option value="all queries" selected>All queries</option>
-                <option value="informational">Informational queries</option>
-                <option value="policies">Policies</option>
+              <select class="select-purpose mobile font-weight-bold" v-model="selectedKind">
+                <option value="all queries" selected >All queries</option>
+                <option value="query">Informational queries</option>
+                <option value="policy">Policies</option>
               </select>
             </div>
           </div>
@@ -46,15 +46,15 @@
                 <p class="d-inline-flex mb-0 pr-1">Show</p>
                 <button class="btn btn-secondary btn-sm dropdown-toggle p-0" type="button"
                   id="dropdownMenuSelectPurpose" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  {{selectedPurpose}}
+                  {{ selectedKind === 'query' ? 'informational' : selectedKind === 'policy' ? 'policies' : 'all queries'}}
                 </button>
                 <div class="dropdown-menu p-2" aria-labelledby="dropdownMenuSelectPurpose">
-                  <button class="dropdown-item" type="button" @click="clickSelectPurpose('all queries')">all
-                    queries</button>
                   <button class="dropdown-item" type="button"
-                    @click="clickSelectPurpose('informational')">informational</button>
+                    @click="clickSelectKind('all queries')">all queries</button>
+                    <button class="dropdown-item" type="button"
+                    @click="clickSelectKind('query')">informational</button>
                   <button class="dropdown-item" type="button"
-                    @click="clickSelectPurpose('policies')">policies</button>
+                    @click="clickSelectKind('policy')">policies</button>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Closes #2472 
# Checklist for submitter
Changes:
- Updated the build-static-content script to set a new attribute, `kind` for queries and policies
- Updated the query library's filters to filter by `kind` (the options are still "all queries", "informational", and "policies"; it just uses the `kind` attribute instead of `purpose`)
- Added a "Resolve" section for policies on the query details page
- Updated the "Purpose" section of the query details page to use the queries `kind` ('informational' for queries, 'policy' for policies)
- Added the 3 Policies from [this issue](https://github.com/fleetdm/fleet/issues/2472) to `standard-query-library.yml`

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
