### PR TITLE
Add "Jobs" to website footer links

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -148,7 +148,7 @@
               <div class="flex-column">
                 <a href="/handbook" class="d-block pr-lg-2 pl-md-5 pl-sm-3 pb-2">Handbook</a>
                 <a href="/docs/contributing" class="d-block pr-lg-2 pl-md-5 pl-sm-3 pb-2">Contribute</a>
-                <a href="/hall-of-fame" class="d-block pr-lg-2 pl-md-5 pl-sm-3 pb-2 pb-xl-0">Hall of fame</a>
+                <a href="/apply" class="d-block pr-lg-2 pl-md-5 pl-sm-3 pb-2 pb-xl-0">Jobs</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Closes https://github.com/fleetdm/confidential/issues/660

Changes:
- Replaced the "Hall of fame" link in the website footer with a link to fleetdm.com/apply
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
