### PR TITLE
UI Styling: Resize dropdown font, do not resize twice button icons inside headers

### DIFF
--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -53,10 +53,20 @@
       text-align: left;
       border-bottom: 1px solid $ui-fleet-blue-15;
 
+      // resize header icons
       img {
         width: 16px;
         height: 16px;
         vertical-align: sub;
+      }
+
+      // do not resize button icons inside headers
+      .button {
+        img {
+          width: initial;
+          height: initial;
+          vertical-align: initial;
+        }
       }
 
       .header-icon-text {

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -50,7 +50,7 @@
     height: 40px;
 
     .Select-value {
-      font-size: $x-small;
+      font-size: $small;
       border-radius: 4px;
       background-color: $ui-off-white;
       border: solid 1px $core-dark-blue-grey;
@@ -62,7 +62,7 @@
   }
 
   .Select-value {
-    font-size: $x-small;
+    font-size: $small;
     border-radius: $border-radius;
     background-color: $ui-off-white;
     border: solid 1px $core-dark-blue-grey;
@@ -92,7 +92,7 @@
     }
 
     .Select-value-label {
-      font-size: $xx-small;
+      font-size: $small;
       color: $core-fleet-black;
       line-height: 28px;
     }
@@ -168,7 +168,7 @@
       .Select-value {
         .Select-value-label {
           color: $core-fleet-black;
-          font-size: $xx-small;
+          font-size: $small;
         }
       }
     }
@@ -250,6 +250,10 @@
 
       .Select-value {
         margin-top: 2px;
+
+        .Select-value-label {
+          font-size: $x-small;
+        }
       }
     }
 


### PR DESCRIPTION
Cerra #2962 
Cerra #2963 

- Resize x-small dropdown font to small (ensuring to keep x-small for multi select label dropdown)
- Resize button icons inside headers to be the initial size (ensuring to keep other header icons the correct size)

Dropdown fonts:
<img width="947" alt="Screen Shot 2021-11-16 at 4 11 39 PM" src="https://user-images.githubusercontent.com/71795832/142066554-f6c0e2d8-765d-409e-8ebb-d1168529f9fd.png">
<img width="1101" alt="Screen Shot 2021-11-16 at 4 13 49 PM" src="https://user-images.githubusercontent.com/71795832/142066656-05fc18f1-202a-4c74-a1a4-b378ed5d2f1a.png">

Header icons:
<img width="718" alt="Screen Shot 2021-11-16 at 4 12 12 PM" src="https://user-images.githubusercontent.com/71795832/142066487-256d772a-ed13-4f39-8d49-b9db2cb7ce2d.png">
<img width="1061" alt="Screen Shot 2021-11-16 at 4 11 58 PM" src="https://user-images.githubusercontent.com/71795832/142066489-f5e13839-e196-4078-8653-1e8eb4a71bf3.png">
<img width="1066" alt="Screen Shot 2021-11-16 at 4 11 51 PM" src="https://user-images.githubusercontent.com/71795832/142066490-f64e5142-4baa-43c2-91e3-41bfa448cda2.png">
<img width="954" alt="Screen Shot 2021-11-16 at 4 11 45 PM" src="https://user-images.githubusercontent.com/71795832/142066492-5e3feede-122a-42d7-a44c-5eb1e10d6e16.png">
<img width="947" alt="Screen Shot 2021-11-16 at 4 11 39 PM" src="https://user-images.githubusercontent.com/71795832/142066493-e13a217e-5348-4359-aa16-ddcbfb5f34e5.png">

- [x] Manual QA for all new/changed functionality
