### PR TITLE
Fix duplicate schedules and platform matching on scheduled queries

### DIFF
--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -323,7 +323,10 @@ func loadHostPackStatsDB(ctx context.Context, db sqlx.QueryerContext, hid uint, 
 		goqu.On(goqu.I("sqs.scheduled_query_id").Eq(goqu.I("sq.id"))),
 	).Where(
 		goqu.Or(
-			goqu.I("sq.platform").Eq(""), // schedule query set to run on all hosts.
+			// sq.platform empty or NULL means the scheduled query is set to
+			// run on all hosts.
+			goqu.I("sq.platform").Eq(""),
+			goqu.I("sq.platform").IsNull(),
 			// scheduled_queries.platform can be a comma-separated list of
 			// platforms, e.g. "darwin,windows".
 			goqu.L("FIND_IN_SET(?, sq.platform)", schQueryPlatformFromHost(hostPlatform)).Neq(0),

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -204,6 +204,7 @@ func testHostsSavePackStats(t *testing.T, ds *Datastore) {
 		Hostname:        "foo.local",
 		PrimaryIP:       "192.168.1.1",
 		PrimaryMac:      "30-65-EC-6F-C4-58",
+		Platform:        "darwin",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, host)
@@ -325,6 +326,7 @@ func testHostsSavePackStatsOverwrites(t *testing.T, ds *Datastore) {
 		Hostname:        "foo.local",
 		PrimaryIP:       "192.168.1.1",
 		PrimaryMac:      "30-65-EC-6F-C4-58",
+		Platform:        "darwin",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, host)
@@ -477,6 +479,7 @@ func testHostsWithTeamPackStats(t *testing.T, ds *Datastore) {
 		Hostname:        "foo.local",
 		PrimaryIP:       "192.168.1.1",
 		PrimaryMac:      "30-65-EC-6F-C4-58",
+		Platform:        "darwin",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, host)
@@ -2249,6 +2252,7 @@ func testHostsAllPackStats(t *testing.T, ds *Datastore) {
 		Hostname:        "foo.local",
 		PrimaryIP:       "192.168.1.1",
 		PrimaryMac:      "30-65-EC-6F-C4-58",
+		Platform:        "darwin",
 	})
 	require.NoError(t, err)
 	require.NotNil(t, host)

--- a/server/fleet/scheduled_queries.go
+++ b/server/fleet/scheduled_queries.go
@@ -6,22 +6,46 @@ import (
 	"gopkg.in/guregu/null.v3"
 )
 
+// ScheduledQuery is a query that runs on a schedule.
+//
+// Source of documentation for the fields:
+// https://osquery.readthedocs.io/en/stable/deployment/configuration/
 type ScheduledQuery struct {
 	UpdateCreateTimestamps
-	ID          uint    `json:"id"`
-	PackID      uint    `json:"pack_id" db:"pack_id"`
-	Name        string  `json:"name"`
-	QueryID     uint    `json:"query_id" db:"query_id"`
-	QueryName   string  `json:"query_name" db:"query_name"`
-	Query       string  `json:"query"` // populated via a join on queries
-	Description string  `json:"description,omitempty"`
-	Interval    uint    `json:"interval"`
-	Snapshot    *bool   `json:"snapshot"`
-	Removed     *bool   `json:"removed"`
-	Platform    *string `json:"platform,omitempty"`
-	Version     *string `json:"version,omitempty"`
-	Shard       *uint   `json:"shard"`
-	Denylist    *bool   `json:"denylist"`
+	ID          uint   `json:"id"`
+	PackID      uint   `json:"pack_id" db:"pack_id"`
+	Name        string `json:"name"`
+	QueryID     uint   `json:"query_id" db:"query_id"`
+	QueryName   string `json:"query_name" db:"query_name"`
+	Query       string `json:"query"` // populated via a join on queries
+	Description string `json:"description,omitempty"`
+	// Interval specifies query frequency, in seconds.
+	Interval uint  `json:"interval"`
+	Snapshot *bool `json:"snapshot"`
+	// Removed is a boolean to determine if "removed" actions
+	// should be logged default is true.
+	//
+	// When the results from a table differ from the results when the
+	// query was last executed, logs are emitted with {"action": "removed"}
+	// or {"action": "added"} for the appropriate action.
+	// References:
+	//	https://osquery.readthedocs.io/en/stable/deployment/logging/#differential-logs
+	Removed *bool `json:"removed"`
+	// Platform is a comma-separated string that indicates the target platforms
+	// for this scheduled query.
+	//
+	// Possible values are: "darwin", "linux" and "windows".
+	// An empty string or nil means the scheduled query will run on all platforms.
+	Platform *string `json:"platform,omitempty"`
+	// Version can be set to only run on osquery versions greater
+	// than or equal-to this version string.
+	Version *string `json:"version,omitempty"`
+	// Shard restricts this query to a percentage (1-100) of target hosts.
+	Shard *uint `json:"shard"`
+	// Denylist is a boolean to determine if this query may be denylisted
+	// (when stopped by the Watchdog for excessive resource consumption),
+	// default is true.
+	Denylist *bool `json:"denylist"`
 
 	AggregatedStats `json:"stats,omitempty"`
 }

--- a/server/test/new_objects.go
+++ b/server/test/new_objects.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -108,6 +109,7 @@ func NewHost(t *testing.T, ds fleet.Datastore, name, ip, key, uuid string, now t
 		PolicyUpdatedAt: now,
 		SeenTime:        now,
 		OsqueryHostID:   osqueryHostID,
+		Platform:        "darwin",
 	})
 
 	require.NoError(t, err)
@@ -144,6 +146,7 @@ func NewScheduledQuery(t *testing.T, ds fleet.Datastore, pid, qid, interval uint
 		Interval: interval,
 		Snapshot: &snapshot,
 		Removed:  &removed,
+		Platform: ptr.String("darwin"),
 	})
 	require.NoError(t, err)
 	require.NotZero(t, sq.ID)


### PR DESCRIPTION
#2964 and #2965

- [X] Changes file added (for user-visible changes)

I'm guessing we don't need a changes file because it's a bug introduced on a 4.6.0 change.

- [X] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [X] Documented any permissions changes
- [x] Added/updated tests
- [X] Manual QA for all new/changed functionality

## What

- #2964: I missed matching the platform, for osquery nodes this is not an issue because we send them the platform, and `osquery` knows to filter out queries  meant for other platforms.
- #2965: I missed adding tests for this, sorry. And my manual QA was just using one host... I will add unit tests for multiple hosts generating stats. PS: When running manual QA with the new changes it seems to work ok now.
