### PR TITLE
Add osquery flagfile support in Orbit

### DIFF
--- a/changes/flagfile-support
+++ b/changes/flagfile-support
@@ -1,0 +1,1 @@
+* Add support for packaging an osquery flagfile with `fleetctl package --osquery-flagfile`

--- a/cmd/fleetctl/package.go
+++ b/cmd/fleetctl/package.go
@@ -98,6 +98,11 @@ func packageCommand() *cli.Command {
 				Usage:       "Root key JSON metadata for update server (from fleetctl updates roots)",
 				Destination: &opt.UpdateRoots,
 			},
+			&cli.StringFlag{
+				Name:        "osquery-flagfile",
+				Usage:       "Flagfile to package and provide to osquery",
+				Destination: &opt.OsqueryFlagfile,
+			},
 			&cli.BoolFlag{
 				Name:        "debug",
 				Usage:       "Enable debug logging in orbit",

--- a/orbit/changes/flagfile-support
+++ b/orbit/changes/flagfile-support
@@ -1,0 +1,1 @@
+* Add support for osquery flagfile (loaded automatically if it exists in the Orbit root).

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -232,12 +232,6 @@ func main() {
 		var options []func(*osquery.Runner) error
 		options = append(options, osquery.WithDataPath(c.String("root-dir")))
 
-		// Provide the flagfile to osquery if it exists.
-		flagfilePath := filepath.Join(c.String("root-dir"), "osquery.flags")
-		if exists, err := file.Exists(flagfilePath); err == nil && exists {
-			options = append(options, osquery.WithFlags([]string{"--flagfile", flagfilePath}))
-		}
-
 		fleetURL := c.String("fleet-url")
 		if !strings.HasPrefix(fleetURL, "http") {
 			fleetURL = "https://" + fleetURL
@@ -350,7 +344,17 @@ func main() {
 			)
 		}
 
-		// Handle additional args after --
+		// Provide the flagfile to osquery if it exists. This comes after the other flags set by
+		// Orbit so that users can override those flags. Note this means users may unintentionally
+		// break things by overriding Orbit flags in incompatible ways. That's the price to pay for
+		// flexibility.
+		flagfilePath := filepath.Join(c.String("root-dir"), "osquery.flags")
+		if exists, err := file.Exists(flagfilePath); err == nil && exists {
+			options = append(options, osquery.WithFlags([]string{"--flagfile", flagfilePath}))
+		}
+
+		// Handle additional args after '--' in the command line. These are added last and should
+		// override all other flags and flagfile entries.
 		options = append(options, osquery.WithFlags(c.Args().Slice()))
 
 		// Create an osquery runner with the provided options

--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -59,6 +59,10 @@ func buildNFPM(opt Options, pkger nfpm.Packager) (string, error) {
 		return "", errors.Wrap(err, "write env file")
 	}
 
+	if err := writeOsqueryFlagfile(opt, orbitRoot); err != nil {
+		return "", errors.Wrap(err, "write flagfile")
+	}
+
 	postInstallPath := filepath.Join(tmpDir, "postinstall.sh")
 	if err := writePostInstall(opt, postInstallPath); err != nil {
 		return "", errors.Wrap(err, "write postinstall script")

--- a/orbit/pkg/packaging/macos.go
+++ b/orbit/pkg/packaging/macos.go
@@ -68,6 +68,9 @@ func BuildPkg(opt Options) (string, error) {
 	if err := writeSecret(opt, orbitRoot); err != nil {
 		return "", errors.Wrap(err, "write enroll secret")
 	}
+	if err := writeOsqueryFlagfile(opt, orbitRoot); err != nil {
+		return "", errors.Wrap(err, "write flagfile")
+	}
 	if opt.StartService {
 		if err := writeLaunchd(opt, filesystemRoot); err != nil {
 			return "", errors.Wrap(err, "write launchd")

--- a/orbit/pkg/packaging/windows.go
+++ b/orbit/pkg/packaging/windows.go
@@ -57,6 +57,10 @@ func BuildMSI(opt Options) (string, error) {
 		return "", errors.Wrap(err, "write enroll secret")
 	}
 
+	if err := writeOsqueryFlagfile(opt, orbitRoot); err != nil {
+		return "", errors.Wrap(err, "write flagfile")
+	}
+
 	if opt.FleetCertificate != "" {
 		if err := writeCertificate(opt, orbitRoot); err != nil {
 			return "", errors.Wrap(err, "write fleet certificate")

--- a/orbit/pkg/table/extension.go
+++ b/orbit/pkg/table/extension.go
@@ -72,5 +72,7 @@ func (r *Runner) Interrupt(err error) {
 	log.Debug().Msg("interrupt osquery extension")
 	r.cancel()
 
-	r.srv.Shutdown(context.Background())
+	if r.srv != nil {
+		r.srv.Shutdown(context.Background())
+	}
 }


### PR DESCRIPTION
- Orbit automatically loads the flagfile when it exists in the orbit
  root.
- Add packaging support to include flagfile with package.
- Fix a panic when osquery fails to start up.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
