### PR TITLE
Use UUID as default host identifier for Orbit

### DIFF
--- a/orbit/changes/uuid-identifier
+++ b/orbit/changes/uuid-identifier
@@ -1,0 +1,1 @@
+* Use UUID as the default host identifier for osquery.

--- a/orbit/pkg/osquery/flags.go
+++ b/orbit/pkg/osquery/flags.go
@@ -9,6 +9,8 @@ import (
 func FleetFlags(fleetURL *url.URL) []string {
 	hostname, prefix := fleetURL.Host, fleetURL.Path
 	return []string{
+		// Use uuid as the default identifier -- users can override this in their flagfile
+		"--host_identifier=uuid",
 		"--tls_hostname=" + hostname,
 		"--enroll_tls_endpoint=" + path.Join(prefix, "/api/v1/osquery/enroll"),
 		"--config_plugin=tls",


### PR DESCRIPTION
This matches the default identifier used in Fleet's prior recommended
osquery installation, easing migration for users. It can still be
overridden via a flagfile.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
