### PR TITLE
Make `fleetctl apply -f` fail with unknown `kind: config` fields

### DIFF
--- a/changes/fleetctl-apply-to-fail-unknown-fields
+++ b/changes/fleetctl-apply-to-fail-unknown-fields
@@ -1,0 +1,1 @@
+* Make `fleetctl apply` fail if there's an unknown field.


### PR DESCRIPTION
- [X] Changes file added (for user-visible changes)
- [X] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
~- [ ] Documented any permissions changes~
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality

Currently, the following happens:
```bash
$ cat config.json
---
apiVersion: v1
kind: config
spec:
  server_settings:
    live_query_disable: false # note the missing "d" at the end.

$ fleetctl apply -f config.json
[+] applied fleet config
$

# all looks ok, but the actual config change was not applied.
```

With the changes in this PR the user would get:
```bash
$ fleetctl apply -f config.json
applying fleet config: apply config received status 400 Bad request: json: unknown field "live_query_disable"
```

If this makes sense to everyone, I'll submit a test.