### PR TITLE
Update anonymous usage statistics to record Fleet feature adoption

### DIFF
--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -39,9 +39,17 @@ func TestMaybeSendStatistics(t *testing.T) {
 
 	ds.ShouldSendStatisticsFunc = func(ctx context.Context, frequency time.Duration, license *fleet.LicenseInfo) (fleet.StatisticsPayload, bool, error) {
 		return fleet.StatisticsPayload{
-			AnonymousIdentifier: "ident",
-			FleetVersion:        "1.2.3",
-			NumHostsEnrolled:    999,
+			AnonymousIdentifier:       "ident",
+			FleetVersion:              "1.2.3",
+			LicenseTier:               "premium",
+			NumHostsEnrolled:          999,
+			NumUsers:                  99,
+			NumTeams:                  9,
+			NumPolicies:               0,
+			SoftwareInventoryEnabled:  true,
+			VulnDetectionEnabled:      true,
+			SystemUsersEnabled:        true,
+			HostsStatusWebHookEnabled: true,
 		}, true, nil
 	}
 	recorded := false
@@ -53,7 +61,7 @@ func TestMaybeSendStatistics(t *testing.T) {
 	err := trySendStatistics(context.Background(), ds, fleet.StatisticsFrequency, ts.URL, &fleet.LicenseInfo{Tier: "premium"})
 	require.NoError(t, err)
 	assert.True(t, recorded)
-	assert.Equal(t, `{"anonymousIdentifier":"ident","fleetVersion":"1.2.3","numHostsEnrolled":999}`, requestBody)
+	assert.Equal(t, `{"anonymousIdentifier":"ident","fleetVersion":"1.2.3","licenseTier":"premium","numHostsEnrolled":999,"numUsers":99,"numTeams":9,"numPolicies":0,"softwareInventoryEnabled":true,"vulnDetectionEnabled":true,"systemUsersEnabled":true,"hostsStatusWebHookEnabled":true}`, requestBody)
 }
 
 func TestMaybeSendStatisticsSkipsSendingIfNotNeeded(t *testing.T) {

--- a/docs/01-Using-Fleet/11-Usage-statistics.md
+++ b/docs/01-Using-Fleet/11-Usage-statistics.md
@@ -12,9 +12,18 @@ Fleet Device Management Inc. periodically collects anonymous information about y
 
 ```json
 {
-  "anonymous_identifier": 1,
-  "fleet_version": "x.x.x",
-  "hosts_enrolled_count": 12345
+  "anonymousIdentifier": "9pnzNmrES3mQG66UQtd29cYTiX2+fZ4CYxDvh495720=",
+  "fleetVersion": "x.x.x",
+  "licenseTier": "free",
+  "numHostsEnrolled": 12345,
+  "numUsers": 12,
+  "numTeams": 3,
+  "numPolicies": 5,
+  "numLabels": 20,
+  "softwareInventoryEnabled": true,
+  "vulnDetectionEnabled": true,
+  "systemUsersEnabled": true,
+  "hostStatusWebhookEnabled": true,
 }
 ```
 

--- a/frontend/components/forms/admin/AppConfigForm/AppConfigForm.jsx
+++ b/frontend/components/forms/admin/AppConfigForm/AppConfigForm.jsx
@@ -288,10 +288,19 @@ class AppConfigForm extends Component {
       return null;
     }
 
-    const json = {
-      anonymous_identifier: "wmTH972f06USpahr41LHpgLKAhgZL",
-      fleet_version: "x.x.x",
-      hosts_enrolled_count: 12345,
+    const stats = {
+      anonymousIdentifier: "9pnzNmrES3mQG66UQtd29cYTiX2+fZ4CYxDvh495720=",
+      fleetVersion: "x.x.x",
+      licenseTier: "free",
+      numHostsEnrolled: 12345,
+      numUsers: 12,
+      numTeams: 3,
+      numPolicies: 5,
+      numLabels: 20,
+      softwareInventoryEnabled: true,
+      vulnDetectionEnabled: true,
+      systemUsersEnabled: true,
+      hostStatusWebhookEnabled: true,
     };
 
     return (
@@ -301,7 +310,7 @@ class AppConfigForm extends Component {
         className={`${baseClass}__usage-stats-preview-modal`}
       >
         <p>An example JSON payload sent to Fleet Device Management Inc.</p>
-        <pre dangerouslySetInnerHTML={{ __html: syntaxHighlight(json) }} />
+        <pre dangerouslySetInnerHTML={{ __html: syntaxHighlight(stats) }} />
         <div className="flex-end">
           <Button type="button" onClick={toggleUsageStatsPreviewModal}>
             Done

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -282,3 +282,12 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, specs []*fleet.Policy
 		return nil
 	})
 }
+
+func amountPoliciesDB(db sqlx.Queryer) (int, error) {
+	var amount int
+	err := sqlx.Get(db, &amount, `SELECT count(*) FROM policies`)
+	if err != nil {
+		return 0, err
+	}
+	return amount, nil
+}

--- a/server/datastore/mysql/statistics.go
+++ b/server/datastore/mysql/statistics.go
@@ -17,10 +17,26 @@ type statistics struct {
 	Identifier string `db:"anonymous_identifier"`
 }
 
-func (d *Datastore) ShouldSendStatistics(ctx context.Context, frequency time.Duration) (fleet.StatisticsPayload, bool, error) {
+func (d *Datastore) ShouldSendStatistics(ctx context.Context, frequency time.Duration, license *fleet.LicenseInfo) (fleet.StatisticsPayload, bool, error) {
 	amountEnrolledHosts, err := amountEnrolledHostsDB(d.writer)
 	if err != nil {
 		return fleet.StatisticsPayload{}, false, ctxerr.Wrap(ctx, err, "amount enrolled hosts")
+	}
+	amountUsers, err := amountUsersDB(d.writer)
+	if err != nil {
+		return fleet.StatisticsPayload{}, false, ctxerr.Wrap(ctx, err, "amount users")
+	}
+	amountTeams, err := amountTeamsDB(d.writer)
+	if err != nil {
+		return fleet.StatisticsPayload{}, false, ctxerr.Wrap(ctx, err, "amount teams")
+	}
+	amountPolicies, err := amountPoliciesDB(d.writer)
+	if err != nil {
+		return fleet.StatisticsPayload{}, false, ctxerr.Wrap(ctx, err, "amount teams")
+	}
+	appConfig, err := d.AppConfig(ctx)
+	if err != nil {
+		return fleet.StatisticsPayload{}, false, ctxerr.Wrap(ctx, err, "statistics app config")
 	}
 
 	dest := statistics{}
@@ -36,9 +52,17 @@ func (d *Datastore) ShouldSendStatistics(ctx context.Context, frequency time.Dur
 				return fleet.StatisticsPayload{}, false, ctxerr.Wrap(ctx, err, "insert statistics")
 			}
 			return fleet.StatisticsPayload{
-				AnonymousIdentifier: anonIdentifier,
-				FleetVersion:        version.Version().Version,
-				NumHostsEnrolled:    amountEnrolledHosts,
+				AnonymousIdentifier:       anonIdentifier,
+				FleetVersion:              version.Version().Version,
+				LicenseTier:               license.Tier,
+				NumHostsEnrolled:          amountEnrolledHosts,
+				NumUsers:                  amountUsers,
+				NumTeams:                  amountTeams,
+				NumPolicies:               amountPolicies,
+				SoftwareInventoryEnabled:  appConfig.HostSettings.EnableSoftwareInventory,
+				VulnDetectionEnabled:      appConfig.VulnerabilitySettings.DatabasesPath != "",
+				SystemUsersEnabled:        appConfig.HostSettings.EnableHostUsers,
+				HostsStatusWebHookEnabled: appConfig.WebhookSettings.HostStatusWebhook.Enable,
 			}, true, nil
 		}
 		return fleet.StatisticsPayload{}, false, ctxerr.Wrap(ctx, err, "get statistics")
@@ -51,9 +75,17 @@ func (d *Datastore) ShouldSendStatistics(ctx context.Context, frequency time.Dur
 		return fleet.StatisticsPayload{}, false, nil
 	}
 	return fleet.StatisticsPayload{
-		AnonymousIdentifier: dest.Identifier,
-		FleetVersion:        version.Version().Version,
-		NumHostsEnrolled:    amountEnrolledHosts,
+		AnonymousIdentifier:       dest.Identifier,
+		FleetVersion:              version.Version().Version,
+		LicenseTier:               license.Tier,
+		NumHostsEnrolled:          amountEnrolledHosts,
+		NumUsers:                  amountUsers,
+		NumTeams:                  amountTeams,
+		NumPolicies:               amountPolicies,
+		SoftwareInventoryEnabled:  appConfig.HostSettings.EnableSoftwareInventory,
+		VulnDetectionEnabled:      &appConfig.VulnerabilitySettings.DatabasesPath != nil,
+		SystemUsersEnabled:        appConfig.HostSettings.EnableHostUsers,
+		HostsStatusWebHookEnabled: appConfig.WebhookSettings.HostStatusWebhook.Enable,
 	}, true, nil
 }
 

--- a/server/datastore/mysql/statistics_test.go
+++ b/server/datastore/mysql/statistics_test.go
@@ -62,14 +62,12 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// Create new global policy for test
-	q, err := ds.NewQuery(context.Background(), &fleet.Query{
-		Name:        "query1",
-		Description: "query1 desc",
+	_, err = ds.NewGlobalPolicy(context.Background(), ptr.Uint(1), fleet.PolicyPayload{
+		Name:        "testpolicy",
 		Query:       "select 1;",
-		Saved:       true,
+		Description: "test policy desc",
+		Resolution:  "test policy resolution",
 	})
-	require.NoError(t, err)
-	_, err = ds.NewGlobalPolicy(context.Background(), &q.ID, "")
 	require.NoError(t, err)
 
 	// Create new app config for test

--- a/server/datastore/mysql/statistics_test.go
+++ b/server/datastore/mysql/statistics_test.go
@@ -69,7 +69,7 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 		Saved:       true,
 	})
 	require.NoError(t, err)
-	_, err = ds.NewGlobalPolicy(context.Background(), q.ID, "")
+	_, err = ds.NewGlobalPolicy(context.Background(), &q.ID, "")
 	require.NoError(t, err)
 
 	// Create new app config for test

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -38,7 +38,6 @@ func (d *Datastore) NewTeam(ctx context.Context, team *fleet.Team) (*fleet.Team,
 
 		return saveTeamSecretsDB(ctx, tx, team)
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +171,6 @@ func (d *Datastore) SaveTeam(ctx context.Context, team *fleet.Team) (*fleet.Team
 
 		return updateTeamScheduleDB(ctx, tx, team)
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -254,4 +252,13 @@ func (d *Datastore) TeamEnrollSecrets(ctx context.Context, teamID uint) ([]*flee
 		return nil, ctxerr.Wrap(ctx, err, "get secrets")
 	}
 	return secrets, nil
+}
+
+func amountTeamsDB(db sqlx.Queryer) (int, error) {
+	var amount int
+	err := sqlx.Get(db, &amount, `SELECT count(*) FROM teams`)
+	if err != nil {
+		return 0, err
+	}
+	return amount, nil
 }

--- a/server/datastore/mysql/users.go
+++ b/server/datastore/mysql/users.go
@@ -120,7 +120,6 @@ func (d *Datastore) ListUsers(ctx context.Context, opt fleet.UserListOptions) ([
 	}
 
 	return users, nil
-
 }
 
 func (d *Datastore) UserByEmail(ctx context.Context, email string) (*fleet.User, error) {
@@ -274,4 +273,13 @@ func saveTeamsForUserDB(ctx context.Context, tx sqlx.ExtContext, user *fleet.Use
 // DeleteUser deletes the associated user
 func (d *Datastore) DeleteUser(ctx context.Context, id uint) error {
 	return d.deleteEntity(ctx, usersTable, id)
+}
+
+func amountUsersDB(db sqlx.Queryer) (int, error) {
+	var amount int
+	err := sqlx.Get(db, &amount, `SELECT count(*) FROM users`)
+	if err != nil {
+		return 0, err
+	}
+	return amount, nil
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -348,7 +348,7 @@ type Datastore interface {
 	///////////////////////////////////////////////////////////////////////////////
 	// StatisticsStore
 
-	ShouldSendStatistics(ctx context.Context, frequency time.Duration) (StatisticsPayload, bool, error)
+	ShouldSendStatistics(ctx context.Context, frequency time.Duration, license *LicenseInfo) (StatisticsPayload, bool, error)
 	RecordStatisticsSent(ctx context.Context) error
 
 	///////////////////////////////////////////////////////////////////////////////

--- a/server/fleet/statistics.go
+++ b/server/fleet/statistics.go
@@ -3,9 +3,17 @@ package fleet
 import "time"
 
 type StatisticsPayload struct {
-	AnonymousIdentifier string `json:"anonymousIdentifier"`
-	FleetVersion        string `json:"fleetVersion"`
-	NumHostsEnrolled    int    `json:"numHostsEnrolled"`
+	AnonymousIdentifier       string `json:"anonymousIdentifier"`
+	FleetVersion              string `json:"fleetVersion"`
+	LicenseTier               string `json:"licenseTier"`
+	NumHostsEnrolled          int    `json:"numHostsEnrolled"`
+	NumUsers                  int    `json:"numUsers"`
+	NumTeams                  int    `json:"numTeams"`
+	NumPolicies               int    `json:"numPolicies"`
+	SoftwareInventoryEnabled  bool   `json:"softwareInventoryEnabled"`
+	VulnDetectionEnabled      bool   `json:"vulnDetectionEnabled"`
+	SystemUsersEnabled        bool   `json:"systemUsersEnabled"`
+	HostsStatusWebHookEnabled bool   `json:"hostsStatusWebHookEnabled"`
 }
 
 const (

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -145,7 +145,7 @@ type SerialSaveHostFunc func(ctx context.Context, host *fleet.Host) error
 
 type DeleteHostFunc func(ctx context.Context, hid uint) error
 
-type HostFunc func(ctx context.Context, id uint) (*fleet.Host, error)
+type HostFunc func(ctx context.Context, id uint, skipLoadingExtras bool) (*fleet.Host, error)
 
 type EnrollHostFunc func(ctx context.Context, osqueryHostId string, nodeKey string, teamID *uint, cooldown time.Duration) (*fleet.Host, error)
 
@@ -279,7 +279,7 @@ type NewActivityFunc func(ctx context.Context, user *fleet.User, activityType st
 
 type ListActivitiesFunc func(ctx context.Context, opt fleet.ListOptions) ([]*fleet.Activity, error)
 
-type ShouldSendStatisticsFunc func(ctx context.Context, frequency time.Duration) (fleet.StatisticsPayload, bool, error)
+type ShouldSendStatisticsFunc func(ctx context.Context, frequency time.Duration, license *fleet.LicenseInfo) (fleet.StatisticsPayload, bool, error)
 
 type RecordStatisticsSentFunc func(ctx context.Context) error
 
@@ -1125,7 +1125,7 @@ func (s *DataStore) DeleteHost(ctx context.Context, hid uint) error {
 
 func (s *DataStore) Host(ctx context.Context, id uint, skipLoadingExtras bool) (*fleet.Host, error) {
 	s.HostFuncInvoked = true
-	return s.HostFunc(ctx, id)
+	return s.HostFunc(ctx, id, skipLoadingExtras)
 }
 
 func (s *DataStore) EnrollHost(ctx context.Context, osqueryHostId string, nodeKey string, teamID *uint, cooldown time.Duration) (*fleet.Host, error) {
@@ -1458,9 +1458,9 @@ func (s *DataStore) ListActivities(ctx context.Context, opt fleet.ListOptions) (
 	return s.ListActivitiesFunc(ctx, opt)
 }
 
-func (s *DataStore) ShouldSendStatistics(ctx context.Context, frequency time.Duration) (fleet.StatisticsPayload, bool, error) {
+func (s *DataStore) ShouldSendStatistics(ctx context.Context, frequency time.Duration, license *fleet.LicenseInfo) (fleet.StatisticsPayload, bool, error) {
 	s.ShouldSendStatisticsFuncInvoked = true
-	return s.ShouldSendStatisticsFunc(ctx, frequency)
+	return s.ShouldSendStatisticsFunc(ctx, frequency, license)
 }
 
 func (s *DataStore) RecordStatisticsSent(ctx context.Context) error {

--- a/server/service/service_hosts_test.go
+++ b/server/service/service_hosts_test.go
@@ -78,7 +78,7 @@ func TestRefetchHost(t *testing.T) {
 
 	host := &fleet.Host{ID: 3}
 
-	ds.HostFunc = func(ctx context.Context, hid uint) (*fleet.Host, error) {
+	ds.HostFunc = func(ctx context.Context, hid uint, skipLoadingExtras bool) (*fleet.Host, error) {
 		return host, nil
 	}
 	ds.SaveHostFunc = func(ctx context.Context, host *fleet.Host) error {
@@ -97,7 +97,7 @@ func TestRefetchHostUserInTeams(t *testing.T) {
 
 	host := &fleet.Host{ID: 3, TeamID: ptr.Uint(4)}
 
-	ds.HostFunc = func(ctx context.Context, hid uint) (*fleet.Host, error) {
+	ds.HostFunc = func(ctx context.Context, hid uint, skipLoadingExtras bool) (*fleet.Host, error) {
 		return host, nil
 	}
 	ds.SaveHostFunc = func(ctx context.Context, host *fleet.Host) error {
@@ -111,7 +111,8 @@ func TestRefetchHostUserInTeams(t *testing.T) {
 				Team: fleet.Team{ID: 4},
 				Role: fleet.RoleMaintainer,
 			},
-		}}
+		},
+	}
 	require.NoError(t, svc.RefetchHost(test.UserContext(maintainer), host.ID))
 
 	observer := &fleet.User{
@@ -120,7 +121,8 @@ func TestRefetchHostUserInTeams(t *testing.T) {
 				Team: fleet.Team{ID: 4},
 				Role: fleet.RoleObserver,
 			},
-		}}
+		},
+	}
 	require.NoError(t, svc.RefetchHost(test.UserContext(observer), host.ID))
 }
 
@@ -196,7 +198,7 @@ func TestHostAuth(t *testing.T) {
 	ds.DeleteHostFunc = func(ctx context.Context, hid uint) error {
 		return nil
 	}
-	ds.HostFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+	ds.HostFunc = func(ctx context.Context, id uint, skipLoadingExtras bool) (*fleet.Host, error) {
 		if id == 1 {
 			return teamHost, nil
 		}
@@ -233,7 +235,7 @@ func TestHostAuth(t *testing.T) {
 		return nil
 	}
 
-	var testCases = []struct {
+	testCases := []struct {
 		name                  string
 		user                  *fleet.User
 		shouldFailGlobalWrite bool

--- a/server/service/service_osquery_test.go
+++ b/server/service/service_osquery_test.go
@@ -327,7 +327,7 @@ func TestLabelQueries(t *testing.T) {
 	ds.LabelQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
 		return map[string]string{}, nil
 	}
-	ds.HostFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+	ds.HostFunc = func(ctx context.Context, id uint, skipLoadingExtras bool) (*fleet.Host, error) {
 		return host, nil
 	}
 	ds.SaveHostFunc = func(ctx context.Context, gotHost *fleet.Host) error {
@@ -696,7 +696,7 @@ func TestDetailQueriesWithEmptyStrings(t *testing.T) {
 		return nil
 	}
 
-	ds.HostFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+	ds.HostFunc = func(ctx context.Context, id uint, skipLoadingExtras bool) (*fleet.Host, error) {
 		return &host, nil
 	}
 
@@ -908,7 +908,7 @@ func TestDetailQueries(t *testing.T) {
 		return nil
 	}
 
-	ds.HostFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+	ds.HostFunc = func(ctx context.Context, id uint, skipLoadingExtras bool) (*fleet.Host, error) {
 		return &host, nil
 	}
 
@@ -1738,7 +1738,7 @@ func TestDistributedQueriesReloadsHostIfDetailsAreIn(t *testing.T) {
 		assert.Equal(t, ip, host.PrimaryIP)
 		return nil
 	}
-	ds.HostFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+	ds.HostFunc = func(ctx context.Context, id uint, skipLoadingExtras bool) (*fleet.Host, error) {
 		require.Equal(t, uint(42), id)
 		return &fleet.Host{ID: 42, Platform: "darwin", PrimaryIP: ip}, nil
 	}
@@ -1904,7 +1904,7 @@ func TestPolicyQueries(t *testing.T) {
 	ds.LabelQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
 		return map[string]string{}, nil
 	}
-	ds.HostFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+	ds.HostFunc = func(ctx context.Context, id uint, skipLoadingExtras bool) (*fleet.Host, error) {
 		return host, nil
 	}
 	ds.SaveHostFunc = func(ctx context.Context, gotHost *fleet.Host) error {

--- a/website/api/controllers/webhooks/receive-usage-analytics.js
+++ b/website/api/controllers/webhooks/receive-usage-analytics.js
@@ -8,9 +8,18 @@ module.exports = {
 
 
   inputs: {
-    anonymousIdentifier: { required: true, type: 'string', example: '1', description: 'An anonymous identifier telling us which Fleet deployment this is.', },
+    anonymousIdentifier: { required: true, type: 'string', example: '9pnzNmrES3mQG66UQtd29cYTiX2+fZ4CYxDvh495720=', description: 'An anonymous identifier telling us which Fleet deployment this is.', },
     fleetVersion: { required: true, type: 'string', example: 'x.x.x' },
+    licenseTier: { required: true, type: 'string', example: 'free' },
     numHostsEnrolled: { required: true, type: 'number', min: 0, custom: (num) => Math.floor(num) === num },
+    numUsers: { required: true, type: 'number' },
+    numTeams: { required: true, type: 'number' },
+    numPolicies: { required: true, type: 'number' },
+    numLabels: { required: true, type: 'number' },
+    softwareInventoryEnabled: { required: true, type: 'boolean' },
+    vulnDetectionEnabled: { required: true, type: 'boolean' },
+    systemUsersEnabled: { required: true, type: 'boolean' },
+    hostStatusWebhookEnabled: { required: true, type: 'boolean' },
   },
 
 
@@ -19,12 +28,32 @@ module.exports = {
   },
 
 
-  fn: async function ({anonymousIdentifier, fleetVersion, numHostsEnrolled}) {
+  fn: async function ({
+    anonymousIdentifier,
+    fleetVersion,
+    licenseTier,
+    numHostsEnrolled,
+    numUsers,
+    numTeams,
+    numPolicies,
+    softwareInventoryEnabled,
+    vulnDetectionEnabled,
+    systemUsersEnabled,
+    hostStatusWebhookEnabled,
+  }) {
 
     await HistoricalUsageSnapshot.create({
       anonymousIdentifier,
       fleetVersion,
-      numHostsEnrolled
+      licenseTier,
+      numHostsEnrolled,
+      numUsers,
+      numTeams,
+      numPolicies,
+      softwareInventoryEnabled,
+      vulnDetectionEnabled,
+      systemUsersEnabled,
+      hostStatusWebhookEnabled,
     });
 
   }

--- a/website/api/controllers/webhooks/receive-usage-analytics.js
+++ b/website/api/controllers/webhooks/receive-usage-analytics.js
@@ -7,19 +7,19 @@ module.exports = {
   description: 'Receive anonymous usage analytics from deployments of Fleet running in production.  (Not fleetctl preview or dev-mode deployments.)',
 
 
-  inputs: {
+   inputs: {
     anonymousIdentifier: { required: true, type: 'string', example: '9pnzNmrES3mQG66UQtd29cYTiX2+fZ4CYxDvh495720=', description: 'An anonymous identifier telling us which Fleet deployment this is.', },
     fleetVersion: { required: true, type: 'string', example: 'x.x.x' },
-    licenseTier: { required: true, type: 'string', example: 'free' },
+    licenseTier: { type: 'string', isIn: ['free', 'premium', 'unknown'], defaultsTo: 'unknown' },
     numHostsEnrolled: { required: true, type: 'number', min: 0, custom: (num) => Math.floor(num) === num },
-    numUsers: { required: true, type: 'number' },
-    numTeams: { required: true, type: 'number' },
-    numPolicies: { required: true, type: 'number' },
-    numLabels: { required: true, type: 'number' },
-    softwareInventoryEnabled: { required: true, type: 'boolean' },
-    vulnDetectionEnabled: { required: true, type: 'boolean' },
-    systemUsersEnabled: { required: true, type: 'boolean' },
-    hostStatusWebhookEnabled: { required: true, type: 'boolean' },
+    numUsers: { type: 'number', defaultsTo: 0 },
+    numTeams: { type: 'number', defaultsTo: 0 },
+    numPolicies: { type: 'number', defaultsTo: 0 },
+    numLabels: { type: 'number', defaultsTo: 0 },
+    softwareInventoryEnabled: { type: 'boolean', defaultsTo: false },
+    vulnDetectionEnabled: { type: 'boolean', defaultsTo: false },
+    systemUsersEnabled: { type: 'boolean', defaultsTo: false },
+    hostStatusWebhookEnabled: { type: 'boolean', defaultsTo: false },
   },
 
 
@@ -28,33 +28,9 @@ module.exports = {
   },
 
 
-  fn: async function ({
-    anonymousIdentifier,
-    fleetVersion,
-    licenseTier,
-    numHostsEnrolled,
-    numUsers,
-    numTeams,
-    numPolicies,
-    softwareInventoryEnabled,
-    vulnDetectionEnabled,
-    systemUsersEnabled,
-    hostStatusWebhookEnabled,
-  }) {
+  fn: async function (inputs) {
 
-    await HistoricalUsageSnapshot.create({
-      anonymousIdentifier,
-      fleetVersion,
-      licenseTier,
-      numHostsEnrolled,
-      numUsers,
-      numTeams,
-      numPolicies,
-      softwareInventoryEnabled,
-      vulnDetectionEnabled,
-      systemUsersEnabled,
-      hostStatusWebhookEnabled,
-    });
+    await HistoricalUsageSnapshot.create(inputs);
 
   }
 

--- a/website/api/controllers/webhooks/receive-usage-analytics.js
+++ b/website/api/controllers/webhooks/receive-usage-analytics.js
@@ -7,7 +7,7 @@ module.exports = {
   description: 'Receive anonymous usage analytics from deployments of Fleet running in production.  (Not fleetctl preview or dev-mode deployments.)',
 
 
-   inputs: {
+  inputs: {
     anonymousIdentifier: { required: true, type: 'string', example: '9pnzNmrES3mQG66UQtd29cYTiX2+fZ4CYxDvh495720=', description: 'An anonymous identifier telling us which Fleet deployment this is.', },
     fleetVersion: { required: true, type: 'string', example: 'x.x.x' },
     licenseTier: { type: 'string', isIn: ['free', 'premium', 'unknown'], defaultsTo: 'unknown' },

--- a/website/api/models/HistoricalUsageSnapshot.js
+++ b/website/api/models/HistoricalUsageSnapshot.js
@@ -12,9 +12,18 @@ module.exports = {
     //  ╔═╗╦═╗╦╔╦╗╦╔╦╗╦╦  ╦╔═╗╔═╗
     //  ╠═╝╠╦╝║║║║║ ║ ║╚╗╔╝║╣ ╚═╗
     //  ╩  ╩╚═╩╩ ╩╩ ╩ ╩ ╚╝ ╚═╝╚═╝
-    anonymousIdentifier: { required: true, type: 'string', example: '1', description: 'An anonymous identifier telling us which Fleet deployment this is.', },
+    anonymousIdentifier: { required: true, type: 'string', example: '9pnzNmrES3mQG66UQtd29cYTiX2+fZ4CYxDvh495720=', description: 'An anonymous identifier telling us which Fleet deployment this is.', },
     fleetVersion: { required: true, type: 'string', example: 'x.x.x' },
+    licenseTier: { required: true, type: 'string', example: 'free' },
     numHostsEnrolled: { required: true, type: 'number', min: 0, custom: (num) => Math.floor(num) === num },
+    numUsers: { required: true, type: 'number' },
+    numTeams: { required: true, type: 'number' },
+    numPolicies: { required: true, type: 'number' },
+    numLabels: { required: true, type: 'number' },
+    softwareInventoryEnabled: { required: true, type: 'boolean' },
+    vulnDetectionEnabled: { required: true, type: 'boolean' },
+    systemUsersEnabled: { required: true, type: 'boolean' },
+    hostStatusWebhookEnabled: { required: true, type: 'boolean' },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗


### PR DESCRIPTION
Issue #2719

Record feature adoption for teams, software inventory, vulnerability detection, system users, hosts status webhook, and policies so that the Fleet team can be equipped to assess the success of improvements made to features in Fleet:
- licenseTier
- numUsers
- numTeams
- numPolicies
- softwareInventoryEnabled
- vulnDetectionEnabled
- systemUsersEnabled
- hostsStatusWebHookEnabled

# Checklist for submitter

- [x] Changes file added (for user-visible changes)
- [x] Added/updated tests
- [ ] Manual QA for all new/changed functionality

TODO: 
- Update https://github.com/fleetdm/fleet/blob/main/docs/01-Using-Fleet/11-Usage-statistics.md
- Update fleetdm.com to accept additional usage statistics
- Test integration with fleetdm.com
