### PR TITLE
Disable storage of errors

### DIFF
--- a/server/errorstore/errors_test.go
+++ b/server/errorstore/errors_test.go
@@ -152,6 +152,9 @@ func TestUnwrapAll(t *testing.T) {
 }
 
 func TestErrorHandler(t *testing.T) {
+	// Skipped until error publishing is re-enabled.
+	t.Skip()
+
 	t.Run("works if the error handler is down", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // cancel immediately
@@ -288,7 +291,6 @@ func testErrorHandlerCollectsDifferentErrors(t *testing.T, pool fleet.RedisPool,
       "errorstore\.alwaysNewErrorTwo:%[1]s/errors_test\.go:\d+"
     \]
   \}`, wd)), jsonErr)
-
 		} else {
 			assert.Regexp(t, regexp.MustCompile(fmt.Sprintf(`\{
   "root": \{
@@ -301,10 +303,12 @@ func testErrorHandlerCollectsDifferentErrors(t *testing.T, pool fleet.RedisPool,
   \}`, wd)), jsonErr)
 		}
 	}
-
 }
 
 func TestHttpHandler(t *testing.T) {
+	// Skipped until error publishing is re-enabled.
+	t.Skip()
+
 	pool := redistest.SetupRedis(t, false, false, false)
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()


### PR DESCRIPTION
This is a temporary mitigation for the issue described in #3065.

The intent is to merge this, cut a 4.6.1 release, and then come up with
a more comprehensive solution for 4.7.0.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
