### PR TITLE
Host Details Page: Fix software column widths

### DIFF
--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -480,7 +480,7 @@
         padding-right: 0px;
       }
       &:last-child {
-        width: 200px;
+        width: 150px;
         padding: 0px;
         overflow: none;
       }
@@ -491,10 +491,6 @@
 
       &.source__header {
         width: 20%;
-      }
-
-      &.version__header {
-        width: 10%;
       }
     }
     tr {


### PR DESCRIPTION
Cerra #2958

- Fixes Install version using percentage width that was stretching vulnerabilities column and CTA column
- Per @noahtalerman, Fleetwide minimum UI width is 1200px and software table renders perfectly at this minimum width. View actually not compromised until under 900px.


1200 pixels:
<img width="1200" alt="Screen Shot 2021-11-22 at 12 25 31 PM" src="https://user-images.githubusercontent.com/71795832/142922874-c97731f5-5133-4233-8ec7-a81bed968930.png">


900 pixels:
<img width="893" alt="Screen Shot 2021-11-22 at 12 25 16 PM" src="https://user-images.githubusercontent.com/71795832/142922881-3f8dfa00-2c83-4bdb-b21f-29bb142f68d1.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.
- [x] Manual QA for all new/changed functionality
