### PR TITLE
Add TeamsDropdown to ManageSchedulePage

### DIFF
--- a/changes/fix-2996-schedule-dropdown
+++ b/changes/fix-2996-schedule-dropdown
@@ -1,0 +1,1 @@
+* Fix manage schedule page teams dropdown cutting off in some cases

--- a/frontend/components/side_panels/SiteTopNav/navItems.js
+++ b/frontend/components/side_panels/SiteTopNav/navItems.js
@@ -1,6 +1,7 @@
 import PATHS from "router/paths";
 import URL_PREFIX from "router/url_prefix";
 import permissionUtils from "utilities/permissions";
+import { getSortedTeamOptions } from "fleet/helpers";
 
 export default (currentUser) => {
   const logo = [
@@ -67,6 +68,7 @@ export default (currentUser) => {
     const userAdminTeams = currentUser.teams.filter(
       (thisTeam) => thisTeam.role === "admin"
     );
+    const sortedTeams = getSortedTeamOptions(userAdminTeams);
     const adminNavItems = [
       {
         icon: "settings",
@@ -77,7 +79,7 @@ export default (currentUser) => {
           pathname:
             currentUser.global_role === "admin"
               ? PATHS.ADMIN_SETTINGS
-              : `${PATHS.ADMIN_TEAMS}/${userAdminTeams[0].id}/members`,
+              : `${PATHS.ADMIN_TEAMS}/${sortedTeams[0].value}/members`,
         },
       },
     ];

--- a/frontend/fleet/helpers.ts
+++ b/frontend/fleet/helpers.ts
@@ -674,7 +674,7 @@ export const syntaxHighlight = (json: JSON): string => {
   /* eslint-enable no-useless-escape */
 };
 
-const getSortedTeamOptions = memoize((teams: ITeam[]) =>
+export const getSortedTeamOptions = memoize((teams: ITeam[]) =>
   teams
     .map((team) => {
       return {

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -1,18 +1,15 @@
 import React, { useContext, useState } from "react";
 import { useQuery } from "react-query";
 import paths from "router/paths";
-import { Link } from "react-router";
 import { AppContext } from "context/app";
 import { find } from "lodash";
 
 import hostSummaryAPI from "services/entities/host_summary";
 import teamsAPI from "services/entities/teams";
 import { IHostSummary, IHostSummaryPlatforms } from "interfaces/host_summary";
-import { ISoftware } from "interfaces/software";
 import { ITeam } from "interfaces/team";
 
 import TeamsDropdown from "components/TeamsDropdown";
-import Button from "components/buttons/Button";
 import InfoCard from "./components/InfoCard";
 import HostsStatus from "./cards/HostsStatus";
 import HostsSummary from "./cards/HostsSummary";
@@ -20,7 +17,6 @@ import ActivityFeed from "./cards/ActivityFeed";
 import Software from "./cards/Software";
 import LearnFleet from "./cards/LearnFleet";
 import WelcomeHost from "./cards/WelcomeHost";
-import LinkArrow from "../../../assets/images/icon-arrow-right-vibrant-blue-10x18@2x.png";
 
 interface ITeamsResponse {
   teams: ITeam[];
@@ -41,6 +37,7 @@ const Homepage = (): JSX.Element => {
     currentTeam,
     isPremiumTier,
     isPreviewMode,
+    isOnGlobalTeam,
     setCurrentTeam,
   } = useContext(AppContext);
 
@@ -61,6 +58,11 @@ const Homepage = (): JSX.Element => {
   >(["teams"], () => teamsAPI.loadAll(), {
     enabled: !!isPremiumTier,
     select: (data: ITeamsResponse) => data.teams,
+    onSuccess: (responseTeams) => {
+      if (!isOnGlobalTeam) {
+        setCurrentTeam(responseTeams[0]);
+      }
+    },
   });
 
   const handleTeamSelect = (teamId: number) => {
@@ -101,6 +103,7 @@ const Homepage = (): JSX.Element => {
               currentTeamId={currentTeam?.id || 0}
               isLoading={isLoadingTeams}
               teams={teams || []}
+              hideAllTeamsOption={!isOnGlobalTeam}
               onChange={(newSelectedValue: number) =>
                 handleTeamSelect(newSelectedValue)
               }
@@ -155,7 +158,7 @@ const Homepage = (): JSX.Element => {
         ${currentTeam ? "one" : "two"}-column
       `}
       >
-        {!currentTeam && (
+        {!currentTeam && isOnGlobalTeam && (
           <InfoCard
             title="Software"
             action={{
@@ -170,7 +173,7 @@ const Homepage = (): JSX.Element => {
             />
           </InfoCard>
         )}
-        {!isPreviewMode && !currentTeam && (
+        {!isPreviewMode && !currentTeam && isOnGlobalTeam && (
           <InfoCard title="Activity">
             <ActivityFeed />
           </InfoCard>

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -8,6 +8,7 @@ import hostSummaryAPI from "services/entities/host_summary";
 import teamsAPI from "services/entities/teams";
 import { IHostSummary, IHostSummaryPlatforms } from "interfaces/host_summary";
 import { ITeam } from "interfaces/team";
+import { getSortedTeamOptions } from "fleet/helpers";
 
 import TeamsDropdown from "components/TeamsDropdown";
 import InfoCard from "./components/InfoCard";
@@ -60,7 +61,12 @@ const Homepage = (): JSX.Element => {
     select: (data: ITeamsResponse) => data.teams,
     onSuccess: (responseTeams) => {
       if (!isOnGlobalTeam) {
-        setCurrentTeam(responseTeams[0]);
+        // TODO: Review this after merging the teamsDropdown components. May no longer be needed.
+        const sortedTeams = getSortedTeamOptions(responseTeams);
+        const firstTeamOption = responseTeams.find(
+          (responseTeam) => responseTeam.id === sortedTeams[0].value
+        );
+        setCurrentTeam(firstTeamOption);
       }
     },
   });

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -5,13 +5,13 @@ import { useQuery } from "react-query";
 import { useDispatch, useSelector } from "react-redux";
 import { AppContext } from "context/app";
 import { push } from "react-router-redux";
-import { find } from "lodash";
 
 // @ts-ignore
 import deepDifference from "utilities/deep_difference";
 import { ITeam } from "interfaces/team";
 import { IGlobalScheduledQuery } from "interfaces/global_scheduled_query";
 import { ITeamScheduledQuery } from "interfaces/team_scheduled_query";
+import { toNumber } from "lodash";
 // @ts-ignore
 import globalScheduledQueryActions from "redux/nodes/entities/global_scheduled_queries/actions";
 // @ts-ignore
@@ -25,7 +25,6 @@ import permissionUtils from "utilities/permissions";
 import paths from "router/paths";
 import Button from "components/buttons/Button";
 // @ts-ignore
-import Dropdown from "components/forms/fields/Dropdown";
 import TeamsDropdown from "components/TeamsDropdown";
 import IconToolTip from "components/IconToolTip";
 import TableDataError from "components/TableDataError";
@@ -118,12 +117,6 @@ interface IFormData {
   team_id?: number;
 }
 
-interface ITeamOptions {
-  disabled: boolean;
-  label: string;
-  value: string | number;
-}
-
 const ManageSchedulePage = ({
   params: { team_id },
 }: ITeamSchedulesPageProps): JSX.Element => {
@@ -131,14 +124,7 @@ const ManageSchedulePage = ({
   const { MANAGE_PACKS, MANAGE_SCHEDULE, MANAGE_TEAM_SCHEDULE } = paths;
   const handleAdvanced = () => dispatch(push(MANAGE_PACKS));
 
-  const {
-    currentUser,
-    currentTeam,
-    isOnGlobalTeam,
-    isFreeTier,
-    isPremiumTier,
-    isAnyTeamMaintainerOrTeamAdmin,
-  } = useContext(AppContext);
+  const { currentUser, isOnGlobalTeam, isPremiumTier } = useContext(AppContext);
 
   const { data: teams, isLoading: isLoadingTeams } = useQuery(
     ["teams"],
@@ -409,9 +395,10 @@ const ManageSchedulePage = ({
               <div>
                 {isPremiumTier ? (
                   <TeamsDropdown
-                    currentTeamId={currentTeam?.id || 0}
+                    currentTeamId={toNumber(team_id) || 0}
                     isLoading={isLoadingTeams}
                     teams={teams || []}
+                    hideAllTeamsOption={!isOnGlobalTeam}
                     onChange={(newSelectedValue: number) =>
                       handleTeamSelect(newSelectedValue)
                     }


### PR DESCRIPTION
For #2996 

- The manage schedule page was the only page still building up its own `DropDown` component for the teams dropdown, instead of using the `TeamsDropdown` component, which I believe was causing the issues. I've transitioned to the new global `TeamsDropdown` so we can determine if that fixes the issue.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
