### PR TITLE
Manage Schedule Page: Create/Edit schedule preview modal

### DIFF
--- a/changes/issue-2858-preview-schedule-modal
+++ b/changes/issue-2858-preview-schedule-modal
@@ -1,0 +1,1 @@
+* Users can preview a schedule response in the create/edit schedule modal

--- a/frontend/fleet/helpers.ts
+++ b/frontend/fleet/helpers.ts
@@ -646,7 +646,7 @@ export const secondsToDhms = (d: number): string => {
   return dDisplay + hDisplay + mDisplay + sDisplay;
 };
 
-export const syntaxHighlight = (json: JSON): string => {
+export const syntaxHighlight = (json: any): string => {
   let jsonStr: string = JSON.stringify(json, undefined, 2);
   jsonStr = jsonStr
     .replace(/&/g, "&amp;")

--- a/frontend/fleet/helpers.ts
+++ b/frontend/fleet/helpers.ts
@@ -646,7 +646,7 @@ export const secondsToDhms = (d: number): string => {
   return dDisplay + hDisplay + mDisplay + sDisplay;
 };
 
-export const syntaxHighlight = (json: any): string => {
+export const syntaxHighlight = (json: JSON): string => {
   let jsonStr: string = JSON.stringify(json, undefined, 2);
   jsonStr = jsonStr
     .replace(/&/g, "&amp;")

--- a/frontend/fleet/helpers.ts
+++ b/frontend/fleet/helpers.ts
@@ -646,7 +646,8 @@ export const secondsToDhms = (d: number): string => {
   return dDisplay + hDisplay + mDisplay + sDisplay;
 };
 
-export const syntaxHighlight = (json: JSON): string => {
+// TODO: Type any because ts files missing the following properties from type 'JSON': parse, stringify, [Symbol.toStringTag]
+export const syntaxHighlight = (json: any): string => {
   let jsonStr: string = JSON.stringify(json, undefined, 2);
   jsonStr = jsonStr
     .replace(/&/g, "&amp;")

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -30,6 +30,7 @@ import IconToolTip from "components/IconToolTip";
 import TableDataError from "components/TableDataError";
 import ScheduleListWrapper from "./components/ScheduleListWrapper";
 import ScheduleEditorModal from "./components/ScheduleEditorModal";
+import PreviewDataModal from "./components/PreviewDataModal";
 import RemoveScheduledQueryModal from "./components/RemoveScheduledQueryModal";
 
 const baseClass = "manage-schedule-page";
@@ -242,6 +243,7 @@ const ManageSchedulePage = ({
     false
   );
   const [showScheduleEditorModal, setShowScheduleEditorModal] = useState(false);
+  const [showPreviewDataModal, setShowPreviewDataModal] = useState(false);
   const [
     showRemoveScheduledQueryModal,
     setShowRemoveScheduledQueryModal,
@@ -256,6 +258,16 @@ const ManageSchedulePage = ({
   const toggleInheritedQueries = () => {
     setShowInheritedQueries(!showInheritedQueries);
   };
+
+  const togglePreviewDataModal = useCallback(() => {
+    setShowPreviewDataModal(!showPreviewDataModal);
+    setShowScheduleEditorModal(!showScheduleEditorModal);
+  }, [
+    showScheduleEditorModal,
+    setShowScheduleEditorModal,
+    setShowPreviewDataModal,
+    showPreviewDataModal,
+  ]);
 
   const toggleScheduleEditorModal = useCallback(() => {
     setSelectedScheduledQuery(undefined); // create modal renders
@@ -551,7 +563,11 @@ const ManageSchedulePage = ({
             allQueries={fleetQueries}
             editQuery={selectedScheduledQuery}
             teamId={teamId}
+            togglePreviewDataModal={togglePreviewDataModal}
           />
+        )}
+        {showPreviewDataModal && (
+          <PreviewDataModal onCancel={togglePreviewDataModal} />
         )}
         {showRemoveScheduledQueryModal && (
           <RemoveScheduledQueryModal

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -30,7 +30,6 @@ import IconToolTip from "components/IconToolTip";
 import TableDataError from "components/TableDataError";
 import ScheduleListWrapper from "./components/ScheduleListWrapper";
 import ScheduleEditorModal from "./components/ScheduleEditorModal";
-import PreviewDataModal from "./components/PreviewDataModal";
 import RemoveScheduledQueryModal from "./components/RemoveScheduledQueryModal";
 
 const baseClass = "manage-schedule-page";
@@ -261,13 +260,7 @@ const ManageSchedulePage = ({
 
   const togglePreviewDataModal = useCallback(() => {
     setShowPreviewDataModal(!showPreviewDataModal);
-    setShowScheduleEditorModal(!showScheduleEditorModal);
-  }, [
-    showScheduleEditorModal,
-    setShowScheduleEditorModal,
-    setShowPreviewDataModal,
-    showPreviewDataModal,
-  ]);
+  }, [setShowPreviewDataModal, showPreviewDataModal]);
 
   const toggleScheduleEditorModal = useCallback(() => {
     setSelectedScheduledQuery(undefined); // create modal renders
@@ -564,11 +557,12 @@ const ManageSchedulePage = ({
             editQuery={selectedScheduledQuery}
             teamId={teamId}
             togglePreviewDataModal={togglePreviewDataModal}
+            showPreviewDataModal={showPreviewDataModal}
           />
         )}
-        {showPreviewDataModal && (
+        {/* {showPreviewDataModal && (
           <PreviewDataModal onCancel={togglePreviewDataModal} />
-        )}
+        )} */}
         {showRemoveScheduledQueryModal && (
           <RemoveScheduledQueryModal
             onCancel={toggleRemoveScheduledQueryModal}

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -560,9 +560,6 @@ const ManageSchedulePage = ({
             showPreviewDataModal={showPreviewDataModal}
           />
         )}
-        {/* {showPreviewDataModal && (
-          <PreviewDataModal onCancel={togglePreviewDataModal} />
-        )} */}
         {showRemoveScheduledQueryModal && (
           <RemoveScheduledQueryModal
             onCancel={toggleRemoveScheduledQueryModal}

--- a/frontend/pages/schedule/ManageSchedulePage/components/PreviewDataModal/PreviewDataModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/PreviewDataModal/PreviewDataModal.tsx
@@ -1,0 +1,87 @@
+/* This component is used for creating and editing both global and team scheduled queries */
+
+import React from "react";
+import { syntaxHighlight } from "fleet/helpers";
+
+import ReactTooltip from "react-tooltip";
+import Modal from "components/Modal";
+import Button from "components/buttons/Button";
+
+import QuestionIcon from "../../../../../../assets/images/icon-question-16x16@2x.png";
+
+const baseClass = "preview-data-modal";
+
+interface IPreviewDataModalProps {
+  onCancel: () => void;
+}
+
+const PreviewDataModal = ({
+  onCancel,
+}: IPreviewDataModalProps): JSX.Element => {
+  const json = {
+    action: "snapshot",
+    snapshot: [
+      {
+        remote_address: "0.0.0.0",
+        remote_port: "0",
+        cmdline: "/usr/sbin/syslogd",
+      },
+    ],
+    name: "xxxxxxx",
+    hostIdentifier: "xxxxxxx",
+    calendarTime: "xxx xxx  x xx:xx:xx xxxx UTC",
+    unixTime: "xxxxxxxxx",
+    epoch: "xxxxxxxxx",
+    counter: "x",
+    numerics: "x",
+  };
+
+  return (
+    <Modal title={"Example data"} onExit={onCancel} className={baseClass}>
+      <div className={`${baseClass}__preview-modal`}>
+        <p>
+          The data sent to your configured log destination will look similar to
+          the following JSON:{" "}
+          <span
+            className={`tooltip__tooltip-icon`}
+            data-tip
+            data-for={"preview-tooltip"}
+            data-tip-disable={false}
+          >
+            <img alt="preview schedule" src={QuestionIcon} />
+          </span>
+          <ReactTooltip
+            place="bottom"
+            type="dark"
+            effect="solid"
+            backgroundColor="#3e4771"
+            id={"preview-tooltip"}
+            data-html
+          >
+            <span className={`software-name tooltip__tooltip-text`}>
+              <p>
+                The "snapshot" key includes the query's
+                <br />
+                results. These will be unique to your query.
+              </p>
+            </span>
+          </ReactTooltip>
+        </p>
+        <div className={`${baseClass}__host-status-webhook-preview`}>
+          <pre dangerouslySetInnerHTML={{ __html: syntaxHighlight(json) }} />
+        </div>
+        <div className={`${baseClass}__btn-wrap`}>
+          <Button
+            className={`${baseClass}__btn`}
+            onClick={onCancel}
+            variant="brand"
+          >
+            Done
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default PreviewDataModal;

--- a/frontend/pages/schedule/ManageSchedulePage/components/PreviewDataModal/PreviewDataModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/PreviewDataModal/PreviewDataModal.tsx
@@ -60,7 +60,7 @@ const PreviewDataModal = ({
           >
             <span className={`software-name tooltip__tooltip-text`}>
               <p>
-                The "snapshot" key includes the query's
+                The &quot;snapshot&quot; key includes the query&apos;s
                 <br />
                 results. These will be unique to your query.
               </p>

--- a/frontend/pages/schedule/ManageSchedulePage/components/PreviewDataModal/_styles.scss
+++ b/frontend/pages/schedule/ManageSchedulePage/components/PreviewDataModal/_styles.scss
@@ -1,4 +1,4 @@
-.schedule-editor-modal {
+.preview-data-modal {
   &__sandbox-info {
     margin-top: $pad-medium;
 
@@ -25,10 +25,6 @@
 
   &__btn-wrap {
     display: flex;
-    justify-content: space-between;
-  }
-
-  &__cta-btn-wrap {
     flex-direction: row-reverse;
   }
 
@@ -70,5 +66,13 @@
 
   .Select-value-label {
     font-size: $small;
+  }
+
+  .tooltip__tooltip-icon {
+    img {
+      width: 16px;
+      height: 16px;
+      vertical-align: top;
+    }
   }
 }

--- a/frontend/pages/schedule/ManageSchedulePage/components/PreviewDataModal/index.ts
+++ b/frontend/pages/schedule/ManageSchedulePage/components/PreviewDataModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PreviewDataModal";

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
@@ -23,6 +23,8 @@ import {
   MIN_OSQUERY_VERSION_OPTIONS,
 } from "utilities/constants";
 
+import PreviewDataModal from "../PreviewDataModal";
+
 const baseClass = "schedule-editor-modal";
 
 interface IFormData {
@@ -47,6 +49,7 @@ interface IScheduleEditorModalProps {
   editQuery?: IGlobalScheduledQuery | ITeamScheduledQuery;
   teamId?: number;
   togglePreviewDataModal: () => void;
+  showPreviewDataModal: boolean;
 }
 interface INoQueryOption {
   id: number;
@@ -89,6 +92,7 @@ const ScheduleEditorModal = ({
   editQuery,
   teamId,
   togglePreviewDataModal,
+  showPreviewDataModal,
 }: IScheduleEditorModalProps): JSX.Element => {
   const [loggingConfig, setLoggingConfig] = useState("");
   const [isLoading, setIsLoading] = useState(true);
@@ -230,6 +234,10 @@ const ScheduleEditorModal = ({
       editQuery
     );
   };
+
+  if (showPreviewDataModal) {
+    return <PreviewDataModal onCancel={togglePreviewDataModal} />;
+  }
 
   return (
     <Modal

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
@@ -46,6 +46,7 @@ interface IScheduleEditorModalProps {
   ) => void;
   editQuery?: IGlobalScheduledQuery | ITeamScheduledQuery;
   teamId?: number;
+  togglePreviewDataModal: () => void;
 }
 interface INoQueryOption {
   id: number;
@@ -87,6 +88,7 @@ const ScheduleEditorModal = ({
   allQueries,
   editQuery,
   teamId,
+  togglePreviewDataModal,
 }: IScheduleEditorModalProps): JSX.Element => {
   const [loggingConfig, setLoggingConfig] = useState("");
   const [isLoading, setIsLoading] = useState(true);
@@ -324,24 +326,34 @@ const ScheduleEditorModal = ({
             </div>
           )}
         </div>
-
         <div className={`${baseClass}__btn-wrap`}>
-          <Button
-            className={`${baseClass}__btn`}
-            type="button"
-            variant="brand"
-            onClick={onFormSubmit}
-            disabled={!selectedQuery && !editQuery}
-          >
-            Schedule
-          </Button>
-          <Button
-            className={`${baseClass}__btn`}
-            onClick={onCancel}
-            variant="inverse"
-          >
-            Cancel
-          </Button>
+          <div className={`${baseClass}__preview-btn-wrap`}>
+            <Button
+              type="button"
+              variant="inverse"
+              onClick={togglePreviewDataModal}
+            >
+              Preview data
+            </Button>
+          </div>
+          <div className={`${baseClass}__cta-btn-wrap`}>
+            <Button
+              className={`${baseClass}__btn`}
+              onClick={onCancel}
+              variant="inverse"
+            >
+              Cancel
+            </Button>
+            <Button
+              className={`${baseClass}__btn`}
+              type="button"
+              variant="brand"
+              onClick={onFormSubmit}
+              disabled={!selectedQuery && !editQuery}
+            >
+              Schedule
+            </Button>
+          </div>
         </div>
       </form>
     </Modal>


### PR DESCRIPTION
Cerra #2858 

- Adds a preview modal to the create schedule modal and edit schedule modal
- Form data persists when opening and closing the preview modal

Loom:
https://www.loom.com/share/4f430f958ff54c0299177de4a8bc55f2

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
