### PR TITLE
App wide: Better errors for duplicate query, policy, and team names

### DIFF
--- a/changes/issue-3113-3119-better-duplicate-error-messages
+++ b/changes/issue-3113-3119-better-duplicate-error-messages
@@ -1,0 +1,1 @@
+* Duplicating query name, policy name, or team name now renders a related error message

--- a/changes/issue-3118-enter-to-save-query-policy
+++ b/changes/issue-3118-enter-to-save-query-policy
@@ -1,0 +1,1 @@
+* Fix: Users can now use enter as a hotkey to save a new query or policy instead of canceling modal

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -347,9 +347,9 @@ const TableContainer = ({
               searchQueryColumn={searchQueryColumn}
               selectedDropdownFilter={selectedDropdownFilter}
             />
-            {!disablePagination && !isClientSidePagination && (
+            {!disablePagination && !isClientSidePagination && data && (
               <Pagination
-                resultsOnCurrentPage={data?.length || 0}
+                resultsOnCurrentPage={data.length}
                 currentPage={pageIndex}
                 resultsPerPage={pageSize}
                 onPaginationChange={onPaginationChange}

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -217,7 +217,7 @@ const TableContainer = ({
     prevSearchQuery,
   ]);
 
-  const displayCount = filteredCount || clientFilterCount || data?.length || 0;
+  const displayCount = filteredCount || clientFilterCount || data.length;
 
   return (
     <div className={wrapperClasses}>
@@ -347,7 +347,7 @@ const TableContainer = ({
               searchQueryColumn={searchQueryColumn}
               selectedDropdownFilter={selectedDropdownFilter}
             />
-            {!disablePagination && !isClientSidePagination && data && (
+            {!disablePagination && !isClientSidePagination && (
               <Pagination
                 resultsOnCurrentPage={data.length}
                 currentPage={pageIndex}

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -217,7 +217,7 @@ const TableContainer = ({
     prevSearchQuery,
   ]);
 
-  const displayCount = filteredCount || clientFilterCount || data.length;
+  const displayCount = filteredCount || clientFilterCount || data?.length || 0;
 
   return (
     <div className={wrapperClasses}>
@@ -349,7 +349,7 @@ const TableContainer = ({
             />
             {!disablePagination && !isClientSidePagination && (
               <Pagination
-                resultsOnCurrentPage={data.length}
+                resultsOnCurrentPage={data?.length || 0}
                 currentPage={pageIndex}
                 resultsPerPage={pageSize}
                 onPaginationChange={onPaginationChange}

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -93,4 +93,7 @@
       background-color: $ui-off-white;
     }
   }
+  .name__header {
+    width: 25%;
+  }
 }

--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -29,18 +29,6 @@ interface ITeamsResponse {
 const baseClass = "team-management";
 const noTeamsClass = "no-teams";
 
-const generateUpdateData = (
-  currentTeamData: ITeam,
-  formData: IEditTeamFormData
-): IEditTeamFormData | null => {
-  if (currentTeamData.name !== formData.name) {
-    return {
-      name: formData.name,
-    };
-  }
-  return null;
-};
-
 const TeamManagementPage = (): JSX.Element => {
   const dispatch = useDispatch();
   const [showCreateTeamModal, setShowCreateTeamModal] = useState(false);
@@ -151,19 +139,15 @@ const TeamManagementPage = (): JSX.Element => {
 
   const onEditSubmit = useCallback(
     (formData: IEditTeamFormData) => {
-      const updatedAttrs = generateUpdateData(teamEditing as ITeam, formData);
-      console.log("updatedAttrs", updatedAttrs);
-      // no updates, so no need for a request.
-      if (updatedAttrs === null) {
+      if (formData.name === teamEditing?.name) {
         toggleEditTeamModal();
       } else if (teamEditing) {
         teamsAPI
-          .update(teamEditing.id, updatedAttrs)
+          .update(teamEditing.id, formData)
           .then(() => {
             dispatch(
               renderFlash("success", `Successfully edited ${formData.name}.`)
             );
-            toggleEditTeamModal();
           })
           .catch((updateError) => {
             console.error(updateError);
@@ -182,6 +166,7 @@ const TeamManagementPage = (): JSX.Element => {
           })
           .finally(() => {
             refetchTeams();
+            toggleEditTeamModal();
           });
       }
     },

--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -153,7 +153,6 @@ const TeamManagementPage = (): JSX.Element => {
       // no updates, so no need for a request.
       if (updatedAttrs === null) {
         toggleEditTeamModal();
-        return;
       } else if (teamEditing) {
         teamsAPI
           .update(teamEditing.id, updatedAttrs)

--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -98,15 +98,17 @@ const TeamManagementPage = (): JSX.Element => {
 
   const onCreateSubmit = useCallback(
     (formData: ICreateTeamFormData) => {
-      dispatch(teamsAPI.create(formData))
+      teamsAPI
+        .create(formData)
         .then(() => {
           dispatch(
             renderFlash("success", `Successfully created ${formData.name}.`)
           );
+          toggleCreateTeamModal();
         })
         .catch((createError: any) => {
           console.error(createError);
-          if (createError.base.includes("Duplicate")) {
+          if (createError.errors[0].reason.includes("Duplicate")) {
             dispatch(
               renderFlash("error", "A team with this name already exists.")
             );
@@ -118,7 +120,6 @@ const TeamManagementPage = (): JSX.Element => {
         })
         .finally(() => {
           refetchTeams();
-          toggleCreateTeamModal();
         });
     },
     [dispatch, toggleCreateTeamModal]
@@ -126,7 +127,8 @@ const TeamManagementPage = (): JSX.Element => {
 
   const onDeleteSubmit = useCallback(() => {
     if (teamEditing) {
-      dispatch(teamsAPI.destroy(teamEditing.id))
+      teamsAPI
+        .destroy(teamEditing.id)
         .then(() => {
           dispatch(
             renderFlash("success", `Successfully deleted ${teamEditing.name}.`)

--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -20,7 +20,7 @@ import DeleteTeamModal from "./components/DeleteTeamModal";
 import EditTeamModal from "./components/EditTeamModal";
 import { ICreateTeamFormData } from "./components/CreateTeamModal/CreateTeamModal";
 import { IEditTeamFormData } from "./components/EditTeamModal/EditTeamModal";
-import { generateTableHeaders } from "./TeamTableConfig";
+import { generateTableHeaders, generateDataSet } from "./TeamTableConfig";
 
 interface ITeamsResponse {
   teams: ITeam[];
@@ -226,6 +226,9 @@ const TeamManagementPage = (): JSX.Element => {
     );
   };
 
+  const tableHeaders = generateTableHeaders(onActionSelection);
+  const tableData = teams ? generateDataSet(teams) : [];
+
   return (
     <div className={`${baseClass} body-wrap`}>
       <p className={`${baseClass}__page-description`}>
@@ -235,8 +238,8 @@ const TeamManagementPage = (): JSX.Element => {
         <TableDataError />
       ) : (
         <TableContainer
-          columns={generateTableHeaders(onActionSelection)}
-          data={teams || []}
+          columns={tableHeaders}
+          data={tableData}
           isLoading={isLoadingTeams}
           defaultSortHeader={"name"}
           defaultSortDirection={"asc"}

--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -234,7 +234,7 @@ const TeamManagementPage = (): JSX.Element => {
       ) : (
         <TableContainer
           columns={generateTableHeaders(onActionSelection)}
-          data={teams}
+          data={teams || []}
           isLoading={isLoadingTeams}
           defaultSortHeader={"name"}
           defaultSortDirection={"asc"}

--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -152,6 +152,7 @@ const TeamManagementPage = (): JSX.Element => {
   const onEditSubmit = useCallback(
     (formData: IEditTeamFormData) => {
       const updatedAttrs = generateUpdateData(teamEditing as ITeam, formData);
+      console.log("updatedAttrs", updatedAttrs);
       // no updates, so no need for a request.
       if (updatedAttrs === null) {
         toggleEditTeamModal();
@@ -162,18 +163,25 @@ const TeamManagementPage = (): JSX.Element => {
             dispatch(
               renderFlash("success", `Successfully edited ${formData.name}.`)
             );
+            toggleEditTeamModal();
           })
-          .catch(() => {
-            dispatch(
-              renderFlash(
-                "error",
-                `Could not edit ${teamEditing.name}. Please try again.`
-              )
-            );
+          .catch((updateError) => {
+            console.error(updateError);
+            if (updateError.errors[0].reason.includes("Duplicate")) {
+              dispatch(
+                renderFlash("error", "A team with this name already exists.")
+              );
+            } else {
+              dispatch(
+                renderFlash(
+                  "error",
+                  `Could not edit ${teamEditing.name}. Please try again.`
+                )
+              );
+            }
           })
           .finally(() => {
             refetchTeams();
-            toggleEditTeamModal();
           });
       }
     },

--- a/frontend/pages/admin/TeamManagementPage/TeamTableConfig.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamTableConfig.tsx
@@ -117,7 +117,6 @@ const enhanceTeamData = (teams: ITeam[]): ITeamTableData[] => {
 };
 
 const generateDataSet = (teams: ITeam[]): ITeamTableData[] => {
-  console.log("TEAMS", teams);
   return [...enhanceTeamData(teams)];
 };
 

--- a/frontend/pages/admin/TeamManagementPage/TeamTableConfig.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamTableConfig.tsx
@@ -103,7 +103,7 @@ const generateActionDropdownOptions = (): IDropdownOption[] => {
   ];
 };
 
-const enhanceTeamData = (teams: { [id: number]: ITeam }): ITeamTableData[] => {
+const enhanceTeamData = (teams: ITeam[]): ITeamTableData[] => {
   return Object.values(teams).map((team) => {
     return {
       description: team.description,
@@ -116,7 +116,8 @@ const enhanceTeamData = (teams: { [id: number]: ITeam }): ITeamTableData[] => {
   });
 };
 
-const generateDataSet = (teams: { [id: number]: ITeam }): ITeamTableData[] => {
+const generateDataSet = (teams: ITeam[]): ITeamTableData[] => {
+  console.log("TEAMS", teams);
   return [...enhanceTeamData(teams)];
 };
 

--- a/frontend/pages/admin/TeamManagementPage/components/EditTeamModal/EditTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/EditTeamModal/EditTeamModal.tsx
@@ -31,11 +31,10 @@ const EditTeamModal = ({
     [setName]
   );
 
-  const onFormSubmit = useCallback(() => {
-    onSubmit({
-      name,
-    });
-  }, [onSubmit, name]);
+  const onFormSubmit = (evt: React.MouseEvent<HTMLFormElement>) => {
+    evt.preventDefault();
+    onSubmit({ name });
+  };
 
   return (
     <Modal title={"Edit team"} onExit={onCancel} className={baseClass}>

--- a/frontend/pages/policies/PolicyPage/components/NewPolicyModal/NewPolicyModal.tsx
+++ b/frontend/pages/policies/PolicyPage/components/NewPolicyModal/NewPolicyModal.tsx
@@ -54,7 +54,7 @@ const NewPolicyModal = ({
     }
   }, [name]);
 
-  const handleSavePolicy = (evt: React.MouseEvent<HTMLButtonElement>) => {
+  const handleSavePolicy = (evt: React.MouseEvent<HTMLFormElement>) => {
     evt.preventDefault();
 
     const { valid, errors: newErrors } = validatePolicyName(name);
@@ -77,7 +77,11 @@ const NewPolicyModal = ({
 
   return (
     <Modal title={"Save policy"} onExit={() => setIsNewPolicyModalOpen(false)}>
-      <form className={`${baseClass}__save-modal-form`} autoComplete="off">
+      <form
+        onSubmit={handleSavePolicy}
+        className={`${baseClass}__save-modal-form`}
+        autoComplete="off"
+      >
         <InputField
           name="name"
           onChange={(value: string) => setName(value)}
@@ -116,7 +120,7 @@ const NewPolicyModal = ({
           </Button>
           <Button
             className={`${baseClass}__btn`}
-            type="button"
+            type="submit"
             variant="brand"
             onClick={handleSavePolicy}
           >

--- a/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
+++ b/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
@@ -86,14 +86,20 @@ const QueryEditor = ({
       );
       router.push(PATHS.EDIT_POLICY(policy));
       dispatch(renderFlash("success", "Policy created!"));
-    } catch (createError) {
+    } catch (createError: any) {
       console.error(createError);
-      dispatch(
-        renderFlash(
-          "error",
-          "Something went wrong creating your policy. Please try again."
-        )
-      );
+      if (createError.errors[0].reason.includes("already exists")) {
+        dispatch(
+          renderFlash("error", "A policy with this name already exists.")
+        );
+      } else {
+        dispatch(
+          renderFlash(
+            "error",
+            "Something went wrong creating your policy. Please try again."
+          )
+        );
+      }
     }
   });
 
@@ -123,14 +129,20 @@ const QueryEditor = ({
     try {
       await updateAPIRequest();
       dispatch(renderFlash("success", "Policy updated!"));
-    } catch (updateError) {
+    } catch (updateError: any) {
       console.error(updateError);
-      dispatch(
-        renderFlash(
-          "error",
-          "Something went wrong updating your policy. Please try again."
-        )
-      );
+      if (updateError.errors[0].reason.includes("Duplicate")) {
+        dispatch(
+          renderFlash("error", "A policy with this name already exists.")
+        );
+      } else {
+        dispatch(
+          renderFlash(
+            "error",
+            "Something went wrong updating your policy. Please try again."
+          )
+        );
+      }
     }
 
     return false;

--- a/frontend/pages/queries/QueryPage/components/NewQueryModal/NewQueryModal.tsx
+++ b/frontend/pages/queries/QueryPage/components/NewQueryModal/NewQueryModal.tsx
@@ -60,8 +60,6 @@ const NewQueryModal = ({
         query: queryValue,
         observer_can_run: observerCanRun,
       });
-
-      setIsSaveModalOpen(false);
     }
   };
 

--- a/frontend/pages/queries/QueryPage/components/NewQueryModal/NewQueryModal.tsx
+++ b/frontend/pages/queries/QueryPage/components/NewQueryModal/NewQueryModal.tsx
@@ -44,7 +44,7 @@ const NewQueryModal = ({
     }
   }, [name]);
 
-  const handleUpdate = (evt: React.MouseEvent<HTMLButtonElement>) => {
+  const handleUpdate = (evt: React.MouseEvent<HTMLFormElement>) => {
     evt.preventDefault();
 
     const { valid, errors: newErrors } = validateQueryName(name);
@@ -65,7 +65,11 @@ const NewQueryModal = ({
 
   return (
     <Modal title={"Save query"} onExit={() => setIsSaveModalOpen(false)}>
-      <form className={`${baseClass}__save-modal-form`} autoComplete="off">
+      <form
+        onSubmit={handleUpdate}
+        className={`${baseClass}__save-modal-form`}
+        autoComplete="off"
+      >
         <InputField
           name="name"
           onChange={(value: string) => setName(value)}
@@ -107,12 +111,7 @@ const NewQueryModal = ({
           >
             Cancel
           </Button>
-          <Button
-            className={`${baseClass}__btn`}
-            type="button"
-            variant="brand"
-            onClick={handleUpdate}
-          >
+          <Button className={`${baseClass}__btn`} type="submit" variant="brand">
             Save query
           </Button>
         </div>

--- a/frontend/pages/queries/QueryPage/screens/QueryEditor.tsx
+++ b/frontend/pages/queries/QueryPage/screens/QueryEditor.tsx
@@ -12,6 +12,7 @@ import PATHS from "router/paths"; // @ts-ignore
 import debounce from "utilities/debounce"; // @ts-ignore
 import deepDifference from "utilities/deep_difference";
 import { IQueryFormData, IQuery } from "interfaces/query";
+import { IApiError } from "interfaces/errors";
 
 import QueryForm from "pages/queries/QueryPage/components/QueryForm";
 import BackChevron from "../../../../../assets/images/icon-chevron-down-9x6@2x.png";
@@ -73,14 +74,20 @@ const QueryEditor = ({
       const { query }: { query: IQuery } = await createQuery(formData);
       router.push(PATHS.EDIT_QUERY(query));
       dispatch(renderFlash("success", "Query created!"));
-    } catch (createError) {
+    } catch (createError: any) {
       console.error(createError);
-      dispatch(
-        renderFlash(
-          "error",
-          "Something went wrong creating your query. Please try again."
-        )
-      );
+      if (createError.errors[0].reason.includes("already exists")) {
+        dispatch(
+          renderFlash("error", "A query with this name already exists.")
+        );
+      } else {
+        dispatch(
+          renderFlash(
+            "error",
+            "Something went wrong creating your query. Please try again."
+          )
+        );
+      }
     }
   });
 
@@ -99,14 +106,20 @@ const QueryEditor = ({
     try {
       await queryAPI.update(queryIdForEdit, updatedQuery);
       dispatch(renderFlash("success", "Query updated!"));
-    } catch (updateError) {
+    } catch (updateError: any) {
       console.error(updateError);
-      dispatch(
-        renderFlash(
-          "error",
-          "Something went wrong updating your query. Please try again."
-        )
-      );
+      if (updateError.errors[0].reason.includes("Duplicate")) {
+        dispatch(
+          renderFlash("error", "A query with this name already exists.")
+        );
+      } else {
+        dispatch(
+          renderFlash(
+            "error",
+            "Something went wrong updating your query. Please try again."
+          )
+        );
+      }
     }
 
     return false;

--- a/frontend/services/entities/teams.ts
+++ b/frontend/services/entities/teams.ts
@@ -23,6 +23,10 @@ interface ITeamSearchOptions {
   globalFilter?: string;
 }
 
+interface IEditTeamFormData {
+  name: string;
+}
+
 export default {
   create: (formData: ICreateTeamFormData) => {
     const { TEAMS } = endpoints;
@@ -60,7 +64,7 @@ export default {
 
     return sendRequest("GET", path);
   },
-  update: (teamId: number, updateParams: ITeam) => {
+  update: (teamId: number, updateParams: IEditTeamFormData) => {
     const { TEAMS } = endpoints;
     const path = `${TEAMS}/${teamId}`;
 

--- a/frontend/services/entities/teams.ts
+++ b/frontend/services/entities/teams.ts
@@ -68,7 +68,7 @@ export default {
     const { TEAMS } = endpoints;
     const path = `${TEAMS}/${teamId}`;
 
-    return sendRequest("PATCH", path, updateParams);
+    return sendRequest("PATCH", path, JSON.stringify(updateParams));
   },
   addMembers: (teamId: number, newMembers: INewMembersBody) => {
     const { TEAMS_MEMBERS } = endpoints;

--- a/frontend/services/entities/teams.ts
+++ b/frontend/services/entities/teams.ts
@@ -68,7 +68,7 @@ export default {
     const { TEAMS } = endpoints;
     const path = `${TEAMS}/${teamId}`;
 
-    return sendRequest("PATCH", path, JSON.stringify(updateParams));
+    return sendRequest("PATCH", path, updateParams);
   },
   addMembers: (teamId: number, newMembers: INewMembersBody) => {
     const { TEAMS_MEMBERS } = endpoints;


### PR DESCRIPTION
Cerra #3113 
Cerra #3118 
Cerra #3119 
Cerra #3032 

- Better error for trying to create or update a query to a query name that already exists
- Better error for trying to create or update a policy to a policy name that already exists
- Better error for trying to create or update a team to a team name that already exists
- Bug fix: In the creating query or creating policy modal, hitting enter saves the query/modal instead of exiting the modal
- Bug fix: In editing a team name, Teams API update method was not working in UI
- Update Dev Patterns: Removes redux from the TeamManagementPage, replace with useQuery and teamsAPI

11/29 loom: https://www.loom.com/share/159befa3bc1a432ba661277c927f8b39


Screenshots:

<img width="1585" alt="Screen Shot 2021-11-29 at 11 33 58 AM" src="https://user-images.githubusercontent.com/71795832/143907251-5c9dda0f-c7ef-423b-9777-116c56b78ac9.png">
<img width="1590" alt="Screen Shot 2021-11-29 at 11 33 47 AM" src="https://user-images.githubusercontent.com/71795832/143907254-fe93ee61-fce7-43eb-a9eb-e04dd96694e9.png">
<img width="1588" alt="Screen Shot 2021-11-29 at 11 33 32 AM" src="https://user-images.githubusercontent.com/71795832/143907258-2e1a5b4e-6e2c-4a69-b2f3-23feee2d1d35.png">
<img width="1589" alt="Screen Shot 2021-11-29 at 11 33 20 AM" src="https://user-images.githubusercontent.com/71795832/143907259-b0e19f47-d031-4ba6-83a4-0fafe697e1a5.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
