### PR TITLE
New Policy UI: Add policy resolution to create and edit policy

### DIFF
--- a/changes/issue-2227-policy-resolution
+++ b/changes/issue-2227-policy-resolution
@@ -1,0 +1,1 @@
+* Users can create and edit instructions to resolve a failing policy

--- a/frontend/components/Modal/_styles.scss
+++ b/frontend/components/Modal/_styles.scss
@@ -14,6 +14,11 @@
 
     .input-field {
       width: 100%;
+
+      &::placeholder {
+        font-style: italic;
+        font-size: $x-small;
+      }
     }
   }
 

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -10,8 +10,8 @@
   box-sizing: border-box;
   height: 40px;
 
-  ::placeholder {
-    color: $core-fleet-blue;
+  &::placeholder {
+    color: $ui-fleet-black-50;
   }
 
   &:focus {

--- a/frontend/context/policy.tsx
+++ b/frontend/context/policy.tsx
@@ -5,6 +5,7 @@ import { find } from "lodash";
 import { osqueryTables } from "utilities/osquery_tables";
 import { DEFAULT_POLICY } from "utilities/constants";
 import { IOsqueryTable } from "interfaces/osquery_table";
+import { StringifyOptions } from "querystring";
 
 type Props = {
   children: ReactNode;
@@ -14,12 +15,14 @@ type InitialStateType = {
   lastEditedQueryName: string;
   lastEditedQueryDescription: string;
   lastEditedQueryBody: string;
+  lastEditedQueryResolution: string;
   setLastEditedQueryName: (value: string) => void;
   setLastEditedQueryDescription: (value: string) => void;
   setLastEditedQueryBody: (value: string) => void;
   policyTeamId: number;
   setPolicyTeamId: (id: number) => void;
   selectedOsqueryTable: IOsqueryTable;
+  setLastEditedQueryResolution: (value: string) => void;
   setSelectedOsqueryTable: (tableName: string) => void;
 };
 
@@ -27,12 +30,14 @@ const initialState = {
   lastEditedQueryName: DEFAULT_POLICY.name,
   lastEditedQueryDescription: DEFAULT_POLICY.description,
   lastEditedQueryBody: DEFAULT_POLICY.query,
+  lastEditedQueryResolution: DEFAULT_POLICY.resolution,
   setLastEditedQueryName: () => null,
   setLastEditedQueryDescription: () => null,
   setLastEditedQueryBody: () => null,
   policyTeamId: 0,
   setPolicyTeamId: () => null,
   selectedOsqueryTable: find(osqueryTables, { name: "users" }),
+  setLastEditedQueryResolution: () => null,
   setSelectedOsqueryTable: () => null,
 };
 
@@ -69,6 +74,10 @@ const reducer = (state: any, action: any) => {
           typeof action.lastEditedQueryBody === "undefined"
             ? state.lastEditedQueryBody
             : action.lastEditedQueryBody,
+        lastEditedQueryResolution:
+          typeof action.lastEditedQueryResolution === "undefined"
+            ? state.lastEditedQueryResolution
+            : action.lastEditedQueryResolution,
       };
     default:
       return state;
@@ -84,6 +93,7 @@ const PolicyProvider = ({ children }: Props) => {
     lastEditedQueryName: state.lastEditedQueryName,
     lastEditedQueryDescription: state.lastEditedQueryDescription,
     lastEditedQueryBody: state.lastEditedQueryBody,
+    lastEditedQueryResolution: state.lastEditedQueryResolution,
     setLastEditedQueryName: (lastEditedQueryName: string) => {
       dispatch({
         type: actions.SET_LAST_EDITED_QUERY_INFO,
@@ -107,6 +117,12 @@ const PolicyProvider = ({ children }: Props) => {
       dispatch({ type: actions.SET_POLICY_TEAM_ID, id });
     },
     selectedOsqueryTable: state.selectedOsqueryTable,
+    setLastEditedQueryResolution: (lastEditedQueryResolution: string) => {
+      dispatch({
+        type: actions.SET_LAST_EDITED_QUERY_INFO,
+        lastEditedQueryResolution,
+      });
+    },
     setSelectedOsqueryTable: (tableName: string) => {
       dispatch({ type: actions.SET_SELECTED_OSQUERY_TABLE, tableName });
     },

--- a/frontend/context/policy.tsx
+++ b/frontend/context/policy.tsx
@@ -27,10 +27,10 @@ type InitialStateType = {
 };
 
 const initialState = {
-  lastEditedQueryName: DEFAULT_POLICY.name,
+  lastEditedQueryName: "",
   lastEditedQueryDescription: DEFAULT_POLICY.description,
-  lastEditedQueryBody: DEFAULT_POLICY.query,
-  lastEditedQueryResolution: DEFAULT_POLICY.resolution,
+  lastEditedQueryBody: "",
+  lastEditedQueryResolution: "",
   setLastEditedQueryName: () => null,
   setLastEditedQueryDescription: () => null,
   setLastEditedQueryBody: () => null,

--- a/frontend/interfaces/policy.ts
+++ b/frontend/interfaces/policy.ts
@@ -43,6 +43,7 @@ export interface IHostPolicy extends IPolicy {
 
 export interface IPolicyFormData {
   description?: string | number | boolean | any[] | undefined;
+  resolution?: string | number | boolean | any[] | undefined;
   name?: string | number | boolean | any[] | undefined;
   query?: string | number | boolean | any[] | undefined;
   team_id?: number;

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -9,6 +9,7 @@ import { renderFlash } from "redux/nodes/notifications/actions";
 
 import PATHS from "router/paths";
 
+import { DEFAULT_POLICY } from "utilities/constants";
 import { IPolicy, IPolicyStats } from "interfaces/policy";
 import { ITeam } from "interfaces/team";
 import { IUser } from "interfaces/user";
@@ -68,7 +69,12 @@ const ManagePolicyPage = (managePoliciesPageProps: {
     isPremiumTier,
   } = useContext(AppContext);
 
-  const { setPolicyTeamId } = useContext(PolicyContext);
+  const {
+    setLastEditedQueryName,
+    setLastEditedQueryDescription,
+    setLastEditedQueryBody,
+    setPolicyTeamId,
+  } = useContext(PolicyContext);
 
   const { isTeamMaintainer, isTeamAdmin } = permissionsUtils;
   const canAddOrRemovePolicy = (user: IUser | null, teamId: number | null) =>
@@ -180,6 +186,13 @@ const ManagePolicyPage = (managePoliciesPageProps: {
 
   const toggleShowInheritedPolicies = () =>
     setShowInheritedPolicies(!showInheritedPolicies);
+
+  const onAddPolicyClick = () => {
+    setLastEditedQueryName("");
+    setLastEditedQueryDescription("");
+    setLastEditedQueryBody(DEFAULT_POLICY.query);
+    router.push(PATHS.NEW_POLICY);
+  };
 
   const onRemovePoliciesClick = (selectedTableIds: number[]): void => {
     toggleRemovePoliciesModal();
@@ -342,12 +355,13 @@ const ManagePolicyPage = (managePoliciesPageProps: {
           </div>
           {canAddOrRemovePolicy(currentUser, selectedTeamId) && (
             <div className={`${baseClass}__action-button-container`}>
-              <Link
-                to={PATHS.NEW_POLICY}
-                className={`${baseClass}__add-policy-link`}
+              <Button
+                variant="brand"
+                className={`${baseClass}__add-policy-btn`}
+                onClick={onAddPolicyClick}
               >
                 Add a policy
-              </Link>
+              </Button>
             </div>
           )}
         </div>

--- a/frontend/pages/policies/PolicyPage/PolicyPage.tsx
+++ b/frontend/pages/policies/PolicyPage/PolicyPage.tsx
@@ -56,6 +56,7 @@ const PolicyPage = ({
     setLastEditedQueryName,
     setLastEditedQueryDescription,
     setLastEditedQueryBody,
+    setLastEditedQueryResolution,
   } = useContext(PolicyContext);
 
   const [step, setStep] = useState<string>(QUERIES_PAGE_STEPS[1]);
@@ -85,6 +86,7 @@ const PolicyPage = ({
         setLastEditedQueryName(returnedQuery.name);
         setLastEditedQueryDescription(returnedQuery.description);
         setLastEditedQueryBody(returnedQuery.query);
+        setLastEditedQueryResolution(returnedQuery.resolution);
       },
     }
   );
@@ -126,6 +128,11 @@ const PolicyPage = ({
 
     detectIsFleetQueryRunnable();
     !!policyIdForEdit && refetchStoredPolicy();
+    // TODO: IS THIS NEEDED?
+    setLastEditedQueryName(DEFAULT_POLICY.name);
+    setLastEditedQueryDescription(DEFAULT_POLICY.description);
+    setLastEditedQueryBody(DEFAULT_POLICY.query);
+    setLastEditedQueryResolution(DEFAULT_POLICY.resolution);
   }, []);
 
   useEffect(() => {

--- a/frontend/pages/policies/PolicyPage/PolicyPage.tsx
+++ b/frontend/pages/policies/PolicyPage/PolicyPage.tsx
@@ -6,7 +6,7 @@ import { InjectedRouter, Params } from "react-router/lib/Router";
 import Fleet from "fleet"; // @ts-ignore
 import { AppContext } from "context/app";
 import { PolicyContext } from "context/policy";
-import { QUERIES_PAGE_STEPS, DEFAULT_POLICY } from "utilities/constants";
+import { QUERIES_PAGE_STEPS } from "utilities/constants";
 import globalPoliciesAPI from "services/entities/global_policies"; // @ts-ignore
 import teamPoliciesAPI from "services/entities/team_policies"; // @ts-ignore
 import hostAPI from "services/entities/hosts"; // @ts-ignore
@@ -128,7 +128,6 @@ const PolicyPage = ({
 
     detectIsFleetQueryRunnable();
     !!policyIdForEdit && refetchStoredPolicy();
-    setLastEditedQueryBody(DEFAULT_POLICY.query);
   }, []);
 
   useEffect(() => {

--- a/frontend/pages/policies/PolicyPage/PolicyPage.tsx
+++ b/frontend/pages/policies/PolicyPage/PolicyPage.tsx
@@ -128,11 +128,7 @@ const PolicyPage = ({
 
     detectIsFleetQueryRunnable();
     !!policyIdForEdit && refetchStoredPolicy();
-    // TODO: IS THIS NEEDED?
-    setLastEditedQueryName(DEFAULT_POLICY.name);
-    setLastEditedQueryDescription(DEFAULT_POLICY.description);
     setLastEditedQueryBody(DEFAULT_POLICY.query);
-    setLastEditedQueryResolution(DEFAULT_POLICY.resolution);
   }, []);
 
   useEffect(() => {

--- a/frontend/pages/policies/PolicyPage/components/NewPolicyModal/NewPolicyModal.tsx
+++ b/frontend/pages/policies/PolicyPage/components/NewPolicyModal/NewPolicyModal.tsx
@@ -41,6 +41,7 @@ const NewPolicyModal = ({
   const [description, setDescription] = useState<string>(
     lastEditedQueryDescription || ""
   );
+  const [resolution, setResolution] = useState<string>("");
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
 
   useDeepEffect(() => {
@@ -63,6 +64,7 @@ const NewPolicyModal = ({
         description,
         name,
         query: queryValue,
+        resolution,
       });
 
       setIsNewPolicyModalOpen(false);
@@ -87,8 +89,16 @@ const NewPolicyModal = ({
           value={description}
           inputClassName={`${baseClass}__policy-save-modal-description`}
           label="Description"
-          type="textarea"
           placeholder="What information does your policy reveal?"
+        />
+        <InputField
+          name="resolution"
+          onChange={(value: string) => setResolution(value)}
+          value={resolution}
+          inputClassName={`${baseClass}__policy-save-modal-resolution`}
+          label="Resolution"
+          type="textarea"
+          placeholder="What are the steps a divice owner should take to resolve a host that fails this policy?"
         />
         <div
           className={`${baseClass}__button-wrap ${baseClass}__button-wrap--modal`}

--- a/frontend/pages/policies/PolicyPage/components/NewPolicyModal/NewPolicyModal.tsx
+++ b/frontend/pages/policies/PolicyPage/components/NewPolicyModal/NewPolicyModal.tsx
@@ -37,8 +37,10 @@ const NewPolicyModal = ({
     PolicyContext
   );
 
-  const [name, setName] = useState<string>("");
-  const [description, setDescription] = useState<string>("");
+  const [name, setName] = useState<string>(lastEditedQueryName);
+  const [description, setDescription] = useState<string>(
+    lastEditedQueryDescription
+  );
   const [resolution, setResolution] = useState<string>("");
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
 

--- a/frontend/pages/policies/PolicyPage/components/NewPolicyModal/NewPolicyModal.tsx
+++ b/frontend/pages/policies/PolicyPage/components/NewPolicyModal/NewPolicyModal.tsx
@@ -37,10 +37,8 @@ const NewPolicyModal = ({
     PolicyContext
   );
 
-  const [name, setName] = useState<string>(lastEditedQueryName || "");
-  const [description, setDescription] = useState<string>(
-    lastEditedQueryDescription || ""
-  );
+  const [name, setName] = useState<string>("");
+  const [description, setDescription] = useState<string>("");
   const [resolution, setResolution] = useState<string>("");
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
 
@@ -81,7 +79,7 @@ const NewPolicyModal = ({
           error={errors.name}
           inputClassName={`${baseClass}__policy-save-modal-name`}
           label="Name"
-          placeholder="What is your policy called?"
+          placeholder="What yes or no question does your policy ask about your devices?"
         />
         <InputField
           name="description"
@@ -89,7 +87,7 @@ const NewPolicyModal = ({
           value={description}
           inputClassName={`${baseClass}__policy-save-modal-description`}
           label="Description"
-          placeholder="What information does your policy reveal?"
+          placeholder="Add a description here"
         />
         <InputField
           name="resolution"
@@ -98,7 +96,7 @@ const NewPolicyModal = ({
           inputClassName={`${baseClass}__policy-save-modal-resolution`}
           label="Resolution"
           type="textarea"
-          placeholder="What are the steps a divice owner should take to resolve a host that fails this policy?"
+          placeholder="What are the steps a device owner should take to resolve a host that fails this policy?"
         />
         <div
           className={`${baseClass}__button-wrap ${baseClass}__button-wrap--modal`}
@@ -116,7 +114,7 @@ const NewPolicyModal = ({
             variant="brand"
             onClick={handleSavePolicy}
           >
-            Save policy
+            Save
           </Button>
         </div>
       </form>

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -75,6 +75,9 @@ const PolicyForm = ({
   const [isEditingDescription, setIsEditingDescription] = useState<boolean>(
     false
   );
+  const [isEditingResolution, setIsEditingResolution] = useState<boolean>(
+    false
+  );
 
   // Note: The PolicyContext values should always be used for any mutable policy data such as query name
   // The storedPolicy prop should only be used to access immutable metadata such as author id
@@ -82,9 +85,11 @@ const PolicyForm = ({
     lastEditedQueryName,
     lastEditedQueryDescription,
     lastEditedQueryBody,
+    lastEditedQueryResolution,
     setLastEditedQueryName,
     setLastEditedQueryDescription,
     setLastEditedQueryBody,
+    setLastEditedQueryResolution,
   } = useContext(PolicyContext);
 
   const {
@@ -174,6 +179,7 @@ const PolicyForm = ({
 
       setIsEditingName(false);
       setIsEditingDescription(false);
+      setIsEditingResolution(false);
     }
 
     return null;
@@ -363,9 +369,62 @@ const PolicyForm = ({
         className={`${baseClass}__policy-description`}
         onClick={() => setIsEditingDescription(true)}
         >
-          {lastEditedQueryDescription}
+          {lastEditedQueryDescription || "Add description here."}
           <img alt="Edit description" src={PencilIcon} />
         </span>
+      );
+      /* eslint-enable */
+    }
+
+    return null;
+  };
+
+  const renderResolution = () => {
+    if (isEditMode) {
+      if (isEditingResolution) {
+        return (
+          <div className={`${baseClass}__policy-resolve`}>
+            {" "}
+            <b>Resolve:</b> <br />
+            <InputField
+              id="policy-resolution"
+              type="textarea"
+              name="policy-resolution"
+              value={lastEditedQueryResolution}
+              placeholder="Add resolution here."
+              inputClassName={`${baseClass}__policy-resolution`}
+              onChange={setLastEditedQueryResolution}
+              inputOptions={{
+                autoFocus: true,
+              }}
+            />
+          </div>
+        );
+      }
+
+      /* eslint-disable */
+      // eslint complains about the button role
+      // applied to span - this is needed to avoid
+      // using a real button
+      // prettier-ignore
+      return (
+        <div>
+          <b>Resolve:</b> {" "}
+          <span
+            role="button"
+            className={`${baseClass}__policy-resolution`}
+            onClick={() => setIsEditingResolution(true)}
+          >
+            <img alt="Edit resolution" src={PencilIcon} />
+          </span><br/>
+          <span
+            role="button"
+            className={`${baseClass}__policy-resolution`}
+            onClick={() => setIsEditingResolution(true)}
+          >
+            {lastEditedQueryResolution || "Add resolution here."}
+          </span>
+        </div>
       );
       /* eslint-enable */
     }
@@ -376,7 +435,7 @@ const PolicyForm = ({
   const renderRunForObserver = (
     <form className={`${baseClass}__wrapper`}>
       <div className={`${baseClass}__title-bar`}>
-        <div className="name-description">
+        <div className="name-description-resolve">
           <h1 className={`${baseClass}__policy-name no-hover`}>
             {lastEditedQueryName}
           </h1>
@@ -410,9 +469,10 @@ const PolicyForm = ({
     <>
       <form className={`${baseClass}__wrapper`} autoComplete="off">
         <div className={`${baseClass}__title-bar`}>
-          <div className="name-description">
+          <div className="name-description-resolve">
             {renderName()}
             {renderDescription()}
+            {renderResolution()}
           </div>
           <div className="author">{isEditMode && renderAuthor()}</div>
         </div>

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
@@ -39,7 +39,7 @@
       scrollbar-width: none; /* Firefox */
     }
 
-    .name-description {
+    .name-description-resolve {
       flex-grow: 1;
       margin-right: 24px;
       .policy-form__policy-name {
@@ -48,9 +48,14 @@
         height: 2rem;
         cursor: pointer;
       }
-      .policy-form__policy-description:not(textarea) {
+      .policy-form__policy-description:not(textarea),
+      .policy-form__policy-resolution:not(textarea) {
         margin: 0.25rem 0 1rem;
         cursor: pointer;
+      }
+      #policy-description {
+        height: 20px;
+        padding-top: 1px;
       }
       textarea.policy-form__policy-description {
         margin-top: 0.8125rem;
@@ -84,8 +89,13 @@
     }
   }
 
+  &__policy-resolve {
+    margin-top: 14px;
+  }
+
   &__policy-name,
-  &__policy-description {
+  &__policy-description,
+  &__policy-resolution {
     width: 100%;
     margin: 0;
     padding: 0;
@@ -103,6 +113,10 @@
     }
   }
 
+  &__policy-resolution {
+    margin-top: $pad-small;
+  }
+
   &__policy-name {
     margin-top: $pad-large;
     font-size: $large;
@@ -112,7 +126,8 @@
     }
   }
 
-  &__policy-description {
+  &__policy-description,
+  &__policy-resolution {
     margin-top: 0;
     font-size: $x-small;
   }


### PR DESCRIPTION
Cerra #2227 

- Users can create a policy resolution in the Create policy modal
- Users can edit a policy resolution on the Policy page

Screenshot: Create policy now has Resolution text area:
<img width="1293" alt="Screen Shot 2021-11-30 at 1 50 11 PM" src="https://user-images.githubusercontent.com/71795832/144109611-73b09b56-de61-4768-b368-f1c43842960e.png">
Screenshot: Clickable/hoverable text and pencil icon to modify policy resolution
<img width="1290" alt="Screen Shot 2021-11-30 at 1 49 54 PM" src="https://user-images.githubusercontent.com/71795832/144109615-3536f693-32d2-4a2c-9dd2-9161b9e451cc.png">
Screenshot: If no resolution, grayed out "Add resolution here" placeholder text that is editable
<img width="1287" alt="Screen Shot 2021-11-30 at 1 49 02 PM" src="https://user-images.githubusercontent.com/71795832/144109617-6675fb57-84e4-4079-bd91-1832bf803956.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [] Added/updated tests~~ - Created new issue because entire test in main is commented out #3127
- [x] Manual QA for all new/changed functionality
