### PR TITLE
Update "Operating sytem" modal on the Host details page

### DIFF
--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.tsx
@@ -353,7 +353,7 @@ const HostDetailsPage = ({
     host?.os_version.lastIndexOf(" ") + 1
   );
   const osPolicyLabel = `Is ${operatingSystem}, version ${operatingSystemVersion} installed?`;
-  const osPolicy = `SELECT 1 from os_version WHERE name = '${operatingSystem}' AND major || ',' || minor || '.' || patch = '${operatingSystemVersion}';`;
+  const osPolicy = `SELECT 1 from os_version WHERE name = '${operatingSystem}' AND major || '.' || minor || '.' || patch = '${operatingSystemVersion}';`;
 
   const aboutData = normalizeEmptyValues(
     pick(host, [
@@ -603,7 +603,7 @@ const HostDetailsPage = ({
             Create new policy
           </Button>
           <Button onClick={() => setShowOSPolicyModal(false)} variant="inverse">
-            Cancel
+            Close
           </Button>
         </div>
       </>

--- a/frontend/pages/hosts/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/HostDetailsPage/_styles.scss
@@ -725,6 +725,7 @@
   }
 
   &__os-modal-title {
+    padding-right: $pad-medium;
     font-size: $medium;
     font-weight: $bold;
   }
@@ -736,6 +737,8 @@
     font-weight: $bold;
   }
   &__os-policy {
+    padding-top: $pad-medium;
+
     .form-field__label {
       font-weight: normal;
     }


### PR DESCRIPTION
The new "Operating system" modal is will be part of the Fleet 4.7.0 release. The following changes were caught during a QA pass on the modal:
- Update the example policy to use a period `.` instead of a comma `,`
- Update the secondary button text to use "Close" instead of "Cancel"
- Adjust padding

![Screen Shot 2021-12-01 at 1 56 00 PM](https://user-images.githubusercontent.com/47070608/144296286-c0e98c6f-e890-4086-a5bb-8328e4036774.png)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
