### PR TITLE
On the "New policy" page, update default policy

### DIFF
--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -81,9 +81,9 @@ export const DEFAULT_QUERY = {
 
 export const DEFAULT_POLICY = {
   id: 1,
-  name: "Gatekeeper enabled",
-  query: "SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;",
-  description: "Checks if gatekeeper is enabled on macOS devices",
+  name: "Is osquery running?",
+  query: "SELECT 1 FROM osquery_info WHERE start_time > 1;",
+  description: "Checks if the osquery process has started on the host.",
   author_id: 42,
   author_name: "John",
   author_email: "john@example.com",


### PR DESCRIPTION
- Update default policy from "Gatekeeper enabled" to "Is osquery running?" 
  - The "Is osquery running?" policy applies to all platforms (macOS, Linux, Windows).
  - The "Is osquery running?" policy is similar to the default query on the "New query" page. This query is `SELECT * FROM osquery_info;`
