### PR TITLE
Query UI Bug: Query checkbox now reset on delete

### DIFF
--- a/changes/issue-3196-fix-query-checkbox-bug
+++ b/changes/issue-3196-fix-query-checkbox-bug
@@ -1,0 +1,3 @@
+* Policies now have proprietary queries and are managed independently from the saved queries.
+  * Amended policy creation API to support proprietary queries.
+  * Bug fix: Query checkboxes now reset upon deleting a query

--- a/frontend/pages/packs/EditPackPage/components/RemovePackQueryModal/RemovePackQueryModal.tsx
+++ b/frontend/pages/packs/EditPackPage/components/RemovePackQueryModal/RemovePackQueryModal.tsx
@@ -30,7 +30,7 @@ const RemovePackQueryModal = ({
           <Button
             className={`${baseClass}__btn`}
             onClick={onCancel}
-            variant="inverse"
+            variant="inverse-alert"
           >
             Cancel
           </Button>

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -144,7 +144,7 @@ const ManageQueriesPage = (): JSX.Element => {
     const queryOrQueries = selectedQueryIds.length === 1 ? "query" : "queries";
 
     const promises = selectedQueryIds.map((id: number) => {
-      return fleetQueriesAPI.destroy(id);
+      fleetQueriesAPI.destroy(id);
     });
 
     return Promise.all(promises)

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -145,6 +145,7 @@ const ManageQueriesPage = (): JSX.Element => {
 
     const promises = selectedQueryIds.map((id: number) => {
       fleetQueriesAPI.destroy(id);
+      return null;
     });
 
     return Promise.all(promises)

--- a/frontend/pages/queries/ManageQueriesPage/components/RemoveQueryModal/RemoveQueryModal.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/RemoveQueryModal/RemoveQueryModal.tsx
@@ -21,18 +21,18 @@ const RemoveQueryModal = ({
         <div className={`${baseClass}__btn-wrap`}>
           <Button
             className={`${baseClass}__btn`}
-            onClick={onCancel}
-            variant="inverse-alert"
-          >
-            Cancel
-          </Button>
-          <Button
-            className={`${baseClass}__btn`}
             type="button"
             variant="alert"
             onClick={onSubmit}
           >
             Delete
+          </Button>
+          <Button
+            className={`${baseClass}__btn`}
+            onClick={onCancel}
+            variant="inverse-alert"
+          >
+            Cancel
           </Button>
         </div>
       </div>

--- a/frontend/pages/queries/ManageQueriesPage/components/RemoveQueryModal/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/components/RemoveQueryModal/_styles.scss
@@ -3,7 +3,7 @@
 
   &__btn-wrap {
     display: flex;
-    justify-content: flex-end;
+    justify-content: row-reverse;
     margin-top: $pad-xxlarge;
   }
 


### PR DESCRIPTION
Cerra #3196 

***Lots of poking before realizing there was a return statement with the new API pattern which only works with dispatch and not the new API calls (That causes weird state errors I've seen before and apparently errors with checkbox states)
 
- Fixes deleting a query bug which now resets checkboxes on Manage Query Page
- Fixes deleting a query modal rendering CTA buttons on left side (now properly rendering on right side)
- Fixes removing a query from a pack modal rendering purple font for cancel button and red button for Remove (consistently both red like other UI remove/delete modal UI)


<img width="1287" alt="Screen Shot 2021-12-05 at 5 07 49 PM" src="https://user-images.githubusercontent.com/71795832/144767711-a1af0eec-8df9-4a37-b1a2-a89262041b44.png">
<img width="1303" alt="Screen Shot 2021-12-05 at 5 05 52 PM" src="https://user-images.githubusercontent.com/71795832/144767715-d19d3de5-9c21-45c0-a3ec-315a42470467.png">
<img width="1298" alt="Screen Shot 2021-12-05 at 5 03 45 PM" src="https://user-images.githubusercontent.com/71795832/144767718-d4d83b40-bb9b-4722-ba20-8c6f8f15028e.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
