### PR TITLE
Query and Policy UI: Cursor placed at end of input field

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -316,7 +316,7 @@ const PolicyForm = ({
               autoFocus: true,
               onFocus: (e: React.FocusEvent<HTMLInputElement>) => {
                 // sets cursor to end of inputfield
-                var val = e.target.value;
+                const val = e.target.value;
                 e.target.value = "";
                 e.target.value = val;
               },
@@ -362,7 +362,7 @@ const PolicyForm = ({
               autoFocus: true,
               onFocus: (e: React.FocusEvent<HTMLInputElement>) => {
                 // sets cursor to end of inputfield
-                var val = e.target.value;
+                const val = e.target.value;
                 e.target.value = "";
                 e.target.value = val;
               },
@@ -411,7 +411,7 @@ const PolicyForm = ({
                 autoFocus: true,
                 onFocus: (e: React.FocusEvent<HTMLInputElement>) => {
                   // sets cursor to end of inputfield
-                  var val = e.target.value;
+                  const val = e.target.value;
                   e.target.value = "";
                   e.target.value = val;
                 },

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -314,6 +314,12 @@ const PolicyForm = ({
             onChange={setLastEditedQueryName}
             inputOptions={{
               autoFocus: true,
+              onFocus: (e: React.FocusEvent<HTMLInputElement>) => {
+                // sets cursor to end of inputfield
+                var val = e.target.value;
+                e.target.value = "";
+                e.target.value = val;
+              },
             }}
           />
         );
@@ -354,6 +360,12 @@ const PolicyForm = ({
             onChange={setLastEditedQueryDescription}
             inputOptions={{
               autoFocus: true,
+              onFocus: (e: React.FocusEvent<HTMLInputElement>) => {
+                // sets cursor to end of inputfield
+                var val = e.target.value;
+                e.target.value = "";
+                e.target.value = val;
+              },
             }}
           />
         );
@@ -397,6 +409,12 @@ const PolicyForm = ({
               onChange={setLastEditedQueryResolution}
               inputOptions={{
                 autoFocus: true,
+                onFocus: (e: React.FocusEvent<HTMLInputElement>) => {
+                  // sets cursor to end of inputfield
+                  var val = e.target.value;
+                  e.target.value = "";
+                  e.target.value = val;
+                },
               }}
             />
           </div>

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -307,6 +307,12 @@ const QueryForm = ({
             onChange={setLastEditedQueryName}
             inputOptions={{
               autoFocus: true,
+              onFocus: (e: React.FocusEvent<HTMLInputElement>) => {
+                // sets cursor to end of inputfield
+                var val = e.target.value;
+                e.target.value = "";
+                e.target.value = val;
+              },
             }}
           />
         );
@@ -347,6 +353,12 @@ const QueryForm = ({
             onChange={setLastEditedQueryDescription}
             inputOptions={{
               autoFocus: true,
+              onFocus: (e: React.FocusEvent<HTMLInputElement>) => {
+                // sets cursor to end of inputfield
+                var val = e.target.value;
+                e.target.value = "";
+                e.target.value = val;
+              },
             }}
           />
         );

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -309,7 +309,7 @@ const QueryForm = ({
               autoFocus: true,
               onFocus: (e: React.FocusEvent<HTMLInputElement>) => {
                 // sets cursor to end of inputfield
-                var val = e.target.value;
+                const val = e.target.value;
                 e.target.value = "";
                 e.target.value = val;
               },
@@ -355,7 +355,7 @@ const QueryForm = ({
               autoFocus: true,
               onFocus: (e: React.FocusEvent<HTMLInputElement>) => {
                 // sets cursor to end of inputfield
-                var val = e.target.value;
+                const val = e.target.value;
                 e.target.value = "";
                 e.target.value = val;
               },


### PR DESCRIPTION
Number 1 of #3195 (pushed to 4.8)

- Cursor loads at the end of the input area for both query editor and policy editor inputs


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

~~- [ ] Changes file added (for user-visible changes)~~
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
