### PR TITLE
Dashboard: Show software count in dashboard's software modal

### DIFF
--- a/changes/issue-2935-show-software-count
+++ b/changes/issue-2935-show-software-count
@@ -1,0 +1,1 @@
+* Software modal on homepage shows exact software count with filterability

--- a/frontend/pages/Homepage/cards/Software/Software.tsx
+++ b/frontend/pages/Homepage/cards/Software/Software.tsx
@@ -10,7 +10,10 @@ import TabsWrapper from "components/TabsWrapper";
 import TableContainer from "components/TableContainer"; // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
 
-import { generateTableHeaders } from "./SoftwareTableConfig";
+import {
+  generateTableHeaders,
+  generateModalSoftwareTableHeaders,
+} from "./SoftwareTableConfig";
 
 interface ITableQueryProps {
   pageIndex: number;
@@ -312,7 +315,7 @@ const Software = ({
               it installed.
             </p>
             <TableContainer
-              columns={tableHeaders}
+              columns={generateModalSoftwareTableHeaders()}
               data={modalSoftwareState}
               isLoading={isLoadingModalSoftware}
               defaultSortHeader={"name"}

--- a/frontend/pages/Homepage/cards/Software/Software.tsx
+++ b/frontend/pages/Homepage/cards/Software/Software.tsx
@@ -3,7 +3,8 @@ import { useQuery } from "react-query";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 
 import softwareAPI from "services/entities/software";
-import { ISoftware } from "interfaces/software";
+import { ISoftware } from "interfaces/software"; // @ts-ignore
+import debounce from "utilities/debounce";
 
 import Modal from "components/Modal";
 import TabsWrapper from "components/TabsWrapper";
@@ -220,16 +221,16 @@ const Software = ({
     }
   };
 
-  const onModalSoftwareQueryChange = async ({
-    pageIndex,
-    searchQuery,
-  }: ITableQueryProps) => {
-    setModalSoftwareSearchText(searchQuery);
+  const onModalSoftwareQueryChange = debounce(
+    async ({ pageIndex, searchQuery }: ITableQueryProps) => {
+      setModalSoftwareSearchText(searchQuery);
 
-    if (pageIndex !== modalSoftwarePageIndex) {
-      setModalSoftwarePageIndex(pageIndex);
-    }
-  };
+      if (pageIndex !== modalSoftwarePageIndex) {
+        setModalSoftwarePageIndex(pageIndex);
+      }
+    },
+    { leading: false, trailing: true }
+  );
 
   useEffect(() => {
     setModalSoftwareState(() => {

--- a/frontend/pages/Homepage/cards/Software/Software.tsx
+++ b/frontend/pages/Homepage/cards/Software/Software.tsx
@@ -230,14 +230,13 @@ const Software = ({
 
   useEffect(() => {
     setModalSoftwareState(() => {
-      const modalSoftwareExtra =
+      return (
         modalSoftware?.filter((softwareItem) => {
           return softwareItem.name
             .toLowerCase()
             .includes(modalSoftwareSearchText.toLowerCase());
-        }) || [];
-      console.log("modalSoftwareExtra", modalSoftwareExtra);
-      return modalSoftwareExtra;
+        }) || []
+      );
     });
   }, [modalSoftware, modalSoftwareSearchText]);
 

--- a/frontend/pages/Homepage/cards/Software/Software.tsx
+++ b/frontend/pages/Homepage/cards/Software/Software.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useQuery } from "react-query";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 
@@ -114,6 +114,7 @@ const Software = ({
     isModalSoftwareVulnerable,
     setIsModalSoftwareVulnerable,
   ] = useState<boolean>(false);
+  const [modalSoftwareState, setModalSoftwareState] = useState<ISoftware[]>([]);
   const [navTabIndex, setNavTabIndex] = useState<number>(0);
   const [isLoadingSoftware, setIsLoadingSoftware] = useState<boolean>(true);
   const [
@@ -183,7 +184,6 @@ const Software = ({
       setIsLoadingModalSoftware(true);
       return softwareAPI.load({
         page: modalSoftwarePageIndex,
-        perPage: MODAL_PAGE_SIZE,
         query: modalSoftwareSearchText,
         orderKey: "id",
         orderDir: "desc",
@@ -227,6 +227,19 @@ const Software = ({
       setModalSoftwarePageIndex(pageIndex);
     }
   };
+
+  useEffect(() => {
+    setModalSoftwareState(() => {
+      const modalSoftwareExtra =
+        modalSoftware?.filter((softwareItem) => {
+          return softwareItem.name
+            .toLowerCase()
+            .includes(modalSoftwareSearchText.toLowerCase());
+        }) || [];
+      console.log("modalSoftwareExtra", modalSoftwareExtra);
+      return modalSoftwareExtra;
+    });
+  }, [modalSoftware, modalSoftwareSearchText]);
 
   const renderStatusDropdown = () => {
     return (
@@ -301,11 +314,12 @@ const Software = ({
             </p>
             <TableContainer
               columns={tableHeaders}
-              data={modalSoftware || []}
+              data={modalSoftwareState}
               isLoading={isLoadingModalSoftware}
               defaultSortHeader={"name"}
               defaultSortDirection={"asc"}
               hideActionButton
+              filteredCount={modalSoftwareState.length}
               resultsTitle={"software items"}
               emptyComponent={() =>
                 EmptySoftware(
@@ -319,6 +333,8 @@ const Software = ({
               pageSize={MODAL_PAGE_SIZE}
               onQueryChange={onModalSoftwareQueryChange}
               customControl={renderStatusDropdown}
+              isClientSidePagination
+              isClientSideSearch
             />
           </>
         </Modal>

--- a/frontend/pages/Homepage/cards/Software/Software.tsx
+++ b/frontend/pages/Homepage/cards/Software/Software.tsx
@@ -315,7 +315,6 @@ const Software = ({
               showMarkAllPages={false}
               isAllPagesSelected={false}
               searchable
-              disableCount
               disableActionButton
               pageSize={MODAL_PAGE_SIZE}
               onQueryChange={onModalSoftwareQueryChange}

--- a/frontend/pages/Homepage/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/Homepage/cards/Software/SoftwareTableConfig.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { Link } from "react-router";
+import ReactTooltip from "react-tooltip";
+import { isEmpty } from "lodash";
+
 import PATHS from "router/paths";
 
 import { ISoftware } from "interfaces/software";
 
-import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import Chevron from "../../../../../assets/images/icon-chevron-blue-16x16@2x.png";
+import IssueIcon from "../../../../../assets/images/icon-issue-fleet-black-50-16x16@2x.png";
 
 interface IHeaderProps {
   column: {
@@ -33,41 +36,88 @@ interface IDataColumn {
   disableSortBy?: boolean;
 }
 
+const vulnerabilityTableHeader = [
+  {
+    title: "Vulnerabilities",
+    Header: "",
+    disableSortBy: true,
+    accessor: "vulnerabilities",
+    Cell: (cellProps: ICellProps) => {
+      const vulnerabilities = cellProps.cell.value;
+      if (isEmpty(vulnerabilities)) {
+        return <></>;
+      }
+      return (
+        <>
+          <span
+            className={`vulnerabilities tooltip__tooltip-icon`}
+            data-tip
+            data-for={`vulnerabilities__${cellProps.row.original.id.toString()}`}
+            data-tip-disable={false}
+          >
+            <img alt="software vulnerabilities" src={IssueIcon} />
+          </span>
+          <ReactTooltip
+            place="bottom"
+            type="dark"
+            effect="solid"
+            backgroundColor="#3e4771"
+            id={`vulnerabilities__${cellProps.row.original.id.toString()}`}
+            data-html
+          >
+            <span className={`vulnerabilities tooltip__tooltip-text`}>
+              {vulnerabilities.length === 1
+                ? "1 vulnerability detected"
+                : `${vulnerabilities.length} vulnerabilities detected`}
+            </span>
+          </ReactTooltip>
+        </>
+      );
+    },
+  },
+];
+
+const softwareTableHeaders = [
+  {
+    title: "Name",
+    Header: "Name",
+    disableSortBy: true,
+    accessor: "name",
+    Cell: (cellProps: ICellProps) => <TextCell value={cellProps.cell.value} />,
+  },
+  {
+    title: "Version",
+    Header: "Version",
+    disableSortBy: true,
+    accessor: "version",
+    Cell: (cellProps: ICellProps) => <TextCell value={cellProps.cell.value} />,
+  },
+  {
+    title: "Actions",
+    Header: "",
+    disableSortBy: true,
+    accessor: "id",
+    Cell: (cellProps: ICellProps) => {
+      return (
+        <Link
+          to={`${PATHS.MANAGE_HOSTS}?software_id=${cellProps.cell.value}`}
+          className="software-link"
+        >
+          <img alt="link to hosts filtered by software ID" src={Chevron} />
+        </Link>
+      );
+    },
+  },
+];
+
 // NOTE: cellProps come from react-table
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
-export const generateTableHeaders = (): IDataColumn[] => {
-  return [
-    {
-      title: "Name",
-      Header: "Name",
-      disableSortBy: true,
-      accessor: "name",
-      Cell: (cellProps) => <TextCell value={cellProps.cell.value} />,
-    },
-    {
-      title: "Version",
-      Header: "Version",
-      disableSortBy: true,
-      accessor: "version",
-      Cell: (cellProps) => <TextCell value={cellProps.cell.value} />,
-    },
-    {
-      title: "Actions",
-      Header: "",
-      disableSortBy: true,
-      accessor: "id",
-      Cell: (cellProps) => {
-        return (
-          <Link
-            to={`${PATHS.MANAGE_HOSTS}?software_id=${cellProps.cell.value}`}
-            className="software-link"
-          >
-            <img alt="link to hosts filtered by software ID" src={Chevron} />
-          </Link>
-        );
-      },
-    },
-  ];
+const generateTableHeaders = (): IDataColumn[] => {
+  return softwareTableHeaders;
 };
 
-export default generateTableHeaders;
+const generateModalSoftwareTableHeaders = (): IDataColumn[] => {
+  return vulnerabilityTableHeader.concat(softwareTableHeaders);
+};
+
+export { generateTableHeaders, generateModalSoftwareTableHeaders };

--- a/frontend/pages/Homepage/cards/Software/_styles.scss
+++ b/frontend/pages/Homepage/cards/Software/_styles.scss
@@ -91,8 +91,13 @@
       table-layout: fixed;
 
       thead {
+        .vulnerabilities__header {
+          width: 4%;
+          border-right: 0;
+          padding-right: 0;
+        }
         .name__header {
-          width: 70%;
+          width: 60%;
         }
         .version__header {
           width: 30%;
@@ -113,7 +118,8 @@
       }
 
       tbody {
-        td {
+        .name__cell,
+        .version__cell {
           overflow: hidden;
           white-space: nowrap;
           text-overflow: ellipsis;
@@ -121,6 +127,11 @@
         .id__cell {
           padding: 0;
           width: 40px;
+        }
+        .vulnerabilities__cell {
+          img {
+            transform: scale(0.5);
+          }
         }
       }
     }

--- a/frontend/pages/Homepage/cards/Software/_styles.scss
+++ b/frontend/pages/Homepage/cards/Software/_styles.scss
@@ -22,6 +22,8 @@
     display: none;
   }
   &__software-modal {
+    width: 780px;
+
     .data-table__wrapper {
       margin-top: $pad-large;
     }

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -4,7 +4,7 @@ import { ISoftware } from "interfaces/software";
 
 interface IGetSoftwareProps {
   page: number;
-  perPage: number;
+  perPage?: number;
   orderKey: string;
   orderDir: "asc" | "desc";
   query: string;
@@ -32,7 +32,7 @@ export default {
     teamId,
   }: ISoftwareParams): Promise<ISoftware[]> => {
     const { SOFTWARE } = endpoints;
-    const pagination = `page=${page}&per_page=${perPage}`;
+    const pagination = perPage ? `page=${page}&per_page=${perPage}` : "";
     const sort = `order_key=${orderKey}&order_direction=${orderDir}`;
     let path = `${SOFTWARE}?${pagination}&${sort}`;
 


### PR DESCRIPTION
#2935 

- Users can view the software table count on the dashboard's software table modal
- Software filters on query
- Vulnerable software filters correctly 
- Add vulnerability tooltip column to software modal
- Add 1 second debounce to software search

Latest screenshots (with vulnerability icon UI):
<img width="1425" alt="Screen Shot 2021-12-08 at 10 20 11 AM" src="https://user-images.githubusercontent.com/71795832/145263404-5aed1ec1-403f-41ec-9e5a-05f17d89a1c9.png">
<img width="1425" alt="Screen Shot 2021-12-08 at 10 19 55 AM" src="https://user-images.githubusercontent.com/71795832/145263410-58d54041-e74e-4f70-9969-b9e9dcea860f.png">


Watch loom (without vulnerability icon UI):
https://www.loom.com/share/ea909e4f347944238612ed014f933187

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
