### PR TITLE
Remove platform and team from policy editing

### DIFF
--- a/docs/01-Using-Fleet/03-REST-API.md
+++ b/docs/01-Using-Fleet/03-REST-API.md
@@ -3647,8 +3647,6 @@ Where `query_id` references an existing `query`.
 | query       | string  | body | The query in SQL.                    |
 | description | string  | body | The query's description.             |
 | resolution  | string  | body | The resolution steps for the policy. |
-| platform    | string  | body | Comma-separated target platforms, currently supported values are "windows", "linux", "darwin". The default, an empty string means target all platforms. |
-
 
 #### Example Edit Policy
 
@@ -3662,7 +3660,6 @@ Where `query_id` references an existing `query`.
   "query": "SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;",
   "description": "Checks if gatekeeper is enabled on macOS devices",
   "resolution": "Resolution steps",
-  "platform": "darwin"
 }
 ```
 
@@ -3899,8 +3896,6 @@ Either `query` or `query_id` must be provided.
 | query       | string  | body | The query in SQL.                    |
 | description | string  | body | The query's description.             |
 | resolution  | string  | body | The resolution steps for the policy. |
-| platform    | string  | body | Comma-separated target platforms, currently supported values are "windows", "linux", "darwin". The default, an empty string means target all platforms. |
-
 
 #### Example Edit Policy
 
@@ -3914,7 +3909,6 @@ Either `query` or `query_id` must be provided.
   "query": "SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;",
   "description": "Checks if gatekeeper is enabled on macOS devices",
   "resolution": "Resolution steps",
-  "plarforms": "darwin"
 }
 ```
 

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -1080,16 +1080,16 @@ func testApplyPolicySpec(t *testing.T, ds *Datastore) {
 			Query:       "select 1 from updated;",
 			Description: "query1 desc updated",
 			Resolution:  "some resolution updated",
-			Team:        "",
-			Platform:    "linux",
+			Team:        "", // TODO(lucas): no effect, #3220.
+			Platform:    "", // TODO(lucas): no effect, #3220.
 		},
 		{
 			Name:        "query2",
 			Query:       "select 2 from updated;",
 			Description: "query2 desc updated",
 			Resolution:  "some other resolution updated",
-			Team:        "team1",
-			Platform:    "windows",
+			Team:        "team1",   // TODO(lucas): no effect, #3220.
+			Platform:    "windows", // TODO(lucas): no effect, #3220.
 		},
 	}))
 	policies, err = ds.ListGlobalPolicies(ctx)
@@ -1103,7 +1103,7 @@ func testApplyPolicySpec(t *testing.T, ds *Datastore) {
 	assert.Equal(t, user1.ID, *policies[0].AuthorID)
 	require.NotNil(t, policies[0].Resolution)
 	assert.Equal(t, "some resolution updated", *policies[0].Resolution)
-	assert.Equal(t, "linux", policies[0].Platform)
+	assert.Equal(t, "", policies[0].Platform)
 
 	teamPolicies, err = ds.ListTeamPolicies(ctx, team1.ID)
 	require.NoError(t, err)
@@ -1117,42 +1117,7 @@ func testApplyPolicySpec(t *testing.T, ds *Datastore) {
 	assert.Equal(t, team1.ID, *teamPolicies[0].TeamID)
 	require.NotNil(t, teamPolicies[0].Resolution)
 	assert.Equal(t, "some other resolution updated", *teamPolicies[0].Resolution)
-	assert.Equal(t, "windows", teamPolicies[0].Platform)
-
-	// The following will "move" the policy from global to a team.
-	require.NoError(t, ds.ApplyPolicySpecs(ctx, user1.ID, []*fleet.PolicySpec{
-		{
-			Name:        "query1",
-			Query:       "select 53;",
-			Description: "query1 desc team1",
-			Resolution:  "some resolution team1",
-			Team:        "team1",
-			Platform:    "linux",
-		},
-	}))
-	teamPolicies, err = ds.ListTeamPolicies(ctx, team1.ID)
-	require.NoError(t, err)
-	require.Len(t, teamPolicies, 3)
-	globalPolicies, err := ds.ListGlobalPolicies(ctx)
-	require.NoError(t, err)
-	require.Len(t, globalPolicies, 0)
-
-	// The following will "move" the policy from team to global.
-	require.NoError(t, ds.ApplyPolicySpecs(ctx, user1.ID, []*fleet.PolicySpec{
-		{
-			Name:        "query2",
-			Query:       "select 53;",
-			Description: "query2 desc global",
-			Resolution:  "some resolution global",
-			Platform:    "windows",
-		},
-	}))
-	teamPolicies, err = ds.ListTeamPolicies(ctx, team1.ID)
-	require.NoError(t, err)
-	require.Len(t, teamPolicies, 2)
-	globalPolicies, err = ds.ListGlobalPolicies(ctx)
-	require.NoError(t, err)
-	require.Len(t, globalPolicies, 1)
+	assert.Equal(t, "darwin", teamPolicies[0].Platform)
 }
 
 func testPoliciesSave(t *testing.T, ds *Datastore) {

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -99,10 +99,6 @@ type ModifyPolicyPayload struct {
 	Description *string `json:"description"`
 	// Resolution indicate the steps needed to solve a failing policy.
 	Resolution *string `json:"resolution"`
-	// Platform is a comma-separated string to indicate the target platforms.
-	//
-	// Empty string targets all platforms.
-	Platform *string `json:"platform"`
 }
 
 // Verify verifies the policy payload is valid.
@@ -114,11 +110,6 @@ func (p ModifyPolicyPayload) Verify() error {
 	}
 	if p.Query != nil {
 		if err := verifyPolicyQuery(*p.Query); err != nil {
-			return err
-		}
-	}
-	if p.Platform != nil {
-		if err := verifyPolicyPlatforms(*p.Platform); err != nil {
 			return err
 		}
 	}

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -815,7 +815,6 @@ func (s *integrationTestSuite) TestGlobalPoliciesProprietary() {
 			Query:       ptr.String("select * from osquery_info;"),
 			Description: ptr.String("Some description updated"),
 			Resolution:  ptr.String("some global resolution updated"),
-			Platform:    ptr.String(""),
 		},
 	}
 	mgpResp := modifyGlobalPolicyResponse{}
@@ -826,7 +825,7 @@ func (s *integrationTestSuite) TestGlobalPoliciesProprietary() {
 	assert.Equal(t, "Some description updated", mgpResp.Policy.Description)
 	require.NotNil(t, mgpResp.Policy.Resolution)
 	assert.Equal(t, "some global resolution updated", *mgpResp.Policy.Resolution)
-	assert.Equal(t, "", mgpResp.Policy.Platform)
+	assert.Equal(t, "darwin", mgpResp.Policy.Platform)
 
 	ggpResp := getPolicyByIDResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/global/policies/%d", gpResp.Policy.ID), getPolicyByIDRequest{}, http.StatusOK, &ggpResp)
@@ -836,7 +835,7 @@ func (s *integrationTestSuite) TestGlobalPoliciesProprietary() {
 	assert.Equal(t, "Some description updated", ggpResp.Policy.Description)
 	require.NotNil(t, ggpResp.Policy.Resolution)
 	assert.Equal(t, "some global resolution updated", *ggpResp.Policy.Resolution)
-	assert.Equal(t, "", mgpResp.Policy.Platform)
+	assert.Equal(t, "darwin", mgpResp.Policy.Platform)
 
 	policiesResponse := listGlobalPoliciesResponse{}
 	s.DoJSON("GET", "/api/v1/fleet/global/policies", nil, http.StatusOK, &policiesResponse)
@@ -846,7 +845,7 @@ func (s *integrationTestSuite) TestGlobalPoliciesProprietary() {
 	assert.Equal(t, "Some description updated", policiesResponse.Policies[0].Description)
 	require.NotNil(t, policiesResponse.Policies[0].Resolution)
 	assert.Equal(t, "some global resolution updated", *policiesResponse.Policies[0].Resolution)
-	assert.Equal(t, "", policiesResponse.Policies[0].Platform)
+	assert.Equal(t, "darwin", policiesResponse.Policies[0].Platform)
 
 	listHostsURL := fmt.Sprintf("/api/v1/fleet/hosts?policy_id=%d", policiesResponse.Policies[0].ID)
 	listHostsResp := listHostsResponse{}
@@ -931,7 +930,6 @@ func (s *integrationTestSuite) TestTeamPoliciesProprietary() {
 			Query:       ptr.String("select * from osquery_info;"),
 			Description: ptr.String("Some description updated"),
 			Resolution:  ptr.String("some team resolution updated"),
-			Platform:    ptr.String("darwin,windows"),
 		},
 	}
 	mtpResp := modifyTeamPolicyResponse{}
@@ -942,7 +940,7 @@ func (s *integrationTestSuite) TestTeamPoliciesProprietary() {
 	assert.Equal(t, "Some description updated", mtpResp.Policy.Description)
 	require.NotNil(t, mtpResp.Policy.Resolution)
 	assert.Equal(t, "some team resolution updated", *mtpResp.Policy.Resolution)
-	assert.Equal(t, "darwin,windows", mtpResp.Policy.Platform)
+	assert.Equal(t, "darwin", mtpResp.Policy.Platform)
 
 	gtpResp := getPolicyByIDResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/teams/%d/policies/%d", team1.ID, tpResp.Policy.ID), getPolicyByIDRequest{}, http.StatusOK, &gtpResp)
@@ -952,7 +950,7 @@ func (s *integrationTestSuite) TestTeamPoliciesProprietary() {
 	assert.Equal(t, "Some description updated", gtpResp.Policy.Description)
 	require.NotNil(t, gtpResp.Policy.Resolution)
 	assert.Equal(t, "some team resolution updated", *gtpResp.Policy.Resolution)
-	assert.Equal(t, "darwin,windows", gtpResp.Policy.Platform)
+	assert.Equal(t, "darwin", gtpResp.Policy.Platform)
 
 	policiesResponse := listTeamPoliciesResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/teams/%d/policies", team1.ID), nil, http.StatusOK, &policiesResponse)
@@ -962,7 +960,7 @@ func (s *integrationTestSuite) TestTeamPoliciesProprietary() {
 	assert.Equal(t, "Some description updated", policiesResponse.Policies[0].Description)
 	require.NotNil(t, policiesResponse.Policies[0].Resolution)
 	assert.Equal(t, "some team resolution updated", *policiesResponse.Policies[0].Resolution)
-	assert.Equal(t, "darwin,windows", policiesResponse.Policies[0].Platform)
+	assert.Equal(t, "darwin", policiesResponse.Policies[0].Platform)
 
 	listHostsURL := fmt.Sprintf("/api/v1/fleet/hosts?policy_id=%d", policiesResponse.Policies[0].ID)
 	listHostsResp := listHostsResponse{}
@@ -1059,13 +1057,6 @@ func (s *integrationTestSuite) TestTeamPoliciesProprietaryInvalid() {
 			name:       "Invalid query",
 			query:      "ATTACH 'foo' AS bar;",
 		},
-		{
-			tname:      "Invalid platforms",
-			testUpdate: true,
-			name:       "Some query",
-			query:      "select 42;",
-			platforms:  "linux1",
-		},
 	} {
 		t.Run(tc.tname, func(t *testing.T) {
 			tpReq := teamPolicyRequest{
@@ -1083,9 +1074,8 @@ func (s *integrationTestSuite) TestTeamPoliciesProprietaryInvalid() {
 			if testUpdate {
 				tpReq := modifyTeamPolicyRequest{
 					ModifyPolicyPayload: fleet.ModifyPolicyPayload{
-						Name:     ptr.String(tc.name),
-						Query:    ptr.String(tc.query),
-						Platform: ptr.String(tc.platforms),
+						Name:  ptr.String(tc.name),
+						Query: ptr.String(tc.query),
 					},
 				}
 				tpResp := modifyTeamPolicyResponse{}
@@ -1106,9 +1096,8 @@ func (s *integrationTestSuite) TestTeamPoliciesProprietaryInvalid() {
 			if testUpdate {
 				gpReq := modifyGlobalPolicyRequest{
 					ModifyPolicyPayload: fleet.ModifyPolicyPayload{
-						Name:     ptr.String(tc.name),
-						Query:    ptr.String(tc.query),
-						Platform: ptr.String(tc.platforms),
+						Name:  ptr.String(tc.name),
+						Query: ptr.String(tc.query),
 					},
 				}
 				gpResp := modifyGlobalPolicyResponse{}

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -262,9 +262,6 @@ func (svc Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p fl
 	if p.Resolution != nil {
 		policy.Resolution = p.Resolution
 	}
-	if p.Platform != nil {
-		policy.Platform = *p.Platform
-	}
 	logging.WithExtras(ctx, "name", policy.Name, "sql", policy.Query)
 
 	err = svc.ds.SavePolicy(ctx, policy)


### PR DESCRIPTION
Changes will be re-added properly as part of #3220.

~- [ ] Changes file added (for user-visible changes)~
- [X] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
~- [ ] Documented any permissions changes~
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
