### PR TITLE
Policy flow: Fix cta button verbage to match Figma

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -514,7 +514,7 @@ const PolicyForm = ({
                     !hasTeamMaintainerPermissions
                   }
                 >
-                  Save
+                  <>Save{!isEditMode && " policy"}</>
                 </Button>
               </div>{" "}
               <ReactTooltip
@@ -540,7 +540,7 @@ const PolicyForm = ({
             variant="blue-green"
             onClick={goToSelectTargets}
           >
-            Run query
+            Run
           </Button>
         </div>
       </form>


### PR DESCRIPTION
#2595 

- Policy flow "Save" and "Run query" buttons renamed to match Figma scratchpad #2595 

Screenshots:
<img width="1199" alt="Screen Shot 2021-12-07 at 11 30 42 AM" src="https://user-images.githubusercontent.com/71795832/145077860-7e8aa1d0-c623-476b-a981-32c182c276ce.png">
<img width="1207" alt="Screen Shot 2021-12-07 at 11 29 14 AM" src="https://user-images.githubusercontent.com/71795832/145077873-82af2065-83c8-4f17-ab83-aa3d6849eaef.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

~~- [ ] Changes file added (for user-visible changes)~~
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
