### PR TITLE
Policy Flow: Default policy renders on refresh of new policy page

### DIFF
--- a/changes/issue-3240-refresh-new-policy-defaults
+++ b/changes/issue-3240-refresh-new-policy-defaults
@@ -1,0 +1,1 @@
+* Default policy renders if user refreshes the policy creation page

--- a/frontend/pages/policies/PolicyPage/PolicyPage.tsx
+++ b/frontend/pages/policies/PolicyPage/PolicyPage.tsx
@@ -6,7 +6,7 @@ import { InjectedRouter, Params } from "react-router/lib/Router";
 import Fleet from "fleet"; // @ts-ignore
 import { AppContext } from "context/app";
 import { PolicyContext } from "context/policy";
-import { QUERIES_PAGE_STEPS } from "utilities/constants";
+import { QUERIES_PAGE_STEPS, DEFAULT_POLICY } from "utilities/constants";
 import globalPoliciesAPI from "services/entities/global_policies"; // @ts-ignore
 import teamPoliciesAPI from "services/entities/team_policies"; // @ts-ignore
 import hostAPI from "services/entities/hosts"; // @ts-ignore
@@ -58,6 +58,12 @@ const PolicyPage = ({
     setLastEditedQueryBody,
     setLastEditedQueryResolution,
   } = useContext(PolicyContext);
+
+  useEffect(() => {
+    if (lastEditedQueryBody === "") {
+      setLastEditedQueryBody(DEFAULT_POLICY.query);
+    }
+  }, []);
 
   const [step, setStep] = useState<string>(QUERIES_PAGE_STEPS[1]);
   const [selectedTargets, setSelectedTargets] = useState<ITarget[]>([]);


### PR DESCRIPTION
Cerra #3240 

- Default policy renders on refresh of new policy page

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
