### PR TITLE
Configure nofiles ulimit in Terraform ECS task

### DIFF
--- a/tools/terraform/ecs.tf
+++ b/tools/terraform/ecs.tf
@@ -147,6 +147,13 @@ resource "aws_ecs_task_definition" "backend" {
             awslogs-stream-prefix = "fleet"
           }
         },
+        ulimits = [
+          {
+            name      = "nofile"
+            softLimit = 999999
+            hardLimit = 999999
+          }
+        ],
         secrets = [
           {
             name      = "FLEET_MYSQL_PASSWORD"


### PR DESCRIPTION
The low default ulimit `nofiles` value (`4096`) in Fargate was observed
to cause errors when running with a large number of hosts and a small
number of servers. Each server should be able to serve more than 4096
simultaneous clients.
