### PR TITLE
PoC of rate limiting distributed query writes

### DIFF
--- a/server/service/service.go
+++ b/server/service/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/service/async"
 	"github.com/fleetdm/fleet/v4/server/sso"
 	kitlog "github.com/go-kit/kit/log"
+	"github.com/throttled/throttled/v2"
 )
 
 // Service is the struct implementing fleet.Service. Create a new one with NewService.
@@ -28,6 +29,7 @@ type Service struct {
 	config         config.FleetConfig
 	clock          clock.Clock
 	license        fleet.LicenseInfo
+	limitStore     throttled.GCRAStore
 
 	osqueryLogWriter *logging.OsqueryLogger
 
@@ -53,6 +55,7 @@ func NewService(
 	lq fleet.LiveQueryStore,
 	carveStore fleet.CarveStore,
 	license fleet.LicenseInfo,
+	limitStore throttled.GCRAStore,
 ) (fleet.Service, error) {
 	var svc fleet.Service
 
@@ -76,6 +79,7 @@ func NewService(
 		seenHostSet:      newSeenHostSet(),
 		license:          license,
 		authz:            authorizer,
+		limitStore:       limitStore,
 	}
 	svc = validationMiddleware{svc, ds, sso}
 	return svc, nil

--- a/tools/app/prometheus.yml
+++ b/tools/app/prometheus.yml
@@ -1,7 +1,7 @@
 scrape_configs:
   - job_name: fleet
     scheme: https
-    scrape_interval: 5s
+    scrape_interval: 100ms
     static_configs:
       - targets: ['host.docker.internal:8080']
     tls_config:


### PR DESCRIPTION
Possible solution for https://github.com/fleetdm/fleet/issues/3271. Coded hastily and implemented only for the detail queries, the concept could be applied to labels, policies, and enrollments as well.

Adaptive rate limiting attempts to spread updates for all of the online hosts across the interval.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
