### PR TITLE
Query Empty Search: Fix count and empty state

### DIFF
--- a/changes/issue-3237-fix-clientside-count-search
+++ b/changes/issue-3237-fix-clientside-count-search
@@ -1,0 +1,1 @@
+* Fix client side filter and search used on Queries page to show appropriate count and empty state

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -186,6 +186,8 @@ const TableContainer = ({
 
     // Something besides the pageIndex has changed; we want to set it back to 0.
     if (onQueryChange) {
+      console.log("isClientSideFilter", isClientSideFilter);
+      console.log("isClientSideSearch", isClientSideSearch);
       if (!hasPageIndexChangedRef.current && !isClientSideSearch) {
         const updateQueryData = {
           ...queryData,
@@ -200,6 +202,10 @@ const TableContainer = ({
             onQueryChange(updateQueryData);
           }
           setPageIndex(0);
+        } else {
+          console.log("This hit");
+          console.log("updateQueryData", updateQueryData);
+          onQueryChange(updateQueryData);
         }
       } else if (!isClientSideFilter) {
         onQueryChange(queryData);

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -220,11 +220,12 @@ const TableContainer = ({
   ]);
 
   const displayCount = useCallback((): number => {
-    if (typeof filteredCount == "number") {
+    if (typeof filteredCount === "number") {
       return filteredCount;
-    } else if (typeof clientFilterCount == "number") {
+    } else if (typeof clientFilterCount === "number") {
       return clientFilterCount;
-    } else return data.length;
+    }
+    return data.length;
   }, [filteredCount, clientFilterCount, data]);
 
   return (

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -217,7 +217,18 @@ const TableContainer = ({
     prevSearchQuery,
   ]);
 
-  const displayCount = filteredCount || clientFilterCount || data.length;
+  const displayCount = useCallback((): number => {
+    if (typeof filteredCount == "number") {
+      return filteredCount;
+    } else if (typeof clientFilterCount == "number") {
+      return clientFilterCount;
+    } else return data.length;
+  }, [filteredCount, clientFilterCount, data]);
+
+  console.log("\n\nfilteredCount", filteredCount);
+  console.log("clientFilterCount", clientFilterCount);
+  console.log("data.length", data.length);
+  console.log("displayCount()", displayCount());
 
   return (
     <div className={wrapperClasses}>
@@ -237,7 +248,7 @@ const TableContainer = ({
           <p className={`${baseClass}__results-count`}>
             {TableContainerUtils.generateResultsCountText(
               resultsTitle,
-              displayCount
+              displayCount()
             )}
             {resultsHtml}
           </p>

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -186,8 +186,6 @@ const TableContainer = ({
 
     // Something besides the pageIndex has changed; we want to set it back to 0.
     if (onQueryChange) {
-      console.log("isClientSideFilter", isClientSideFilter);
-      console.log("isClientSideSearch", isClientSideSearch);
       if (!hasPageIndexChangedRef.current && !isClientSideSearch) {
         const updateQueryData = {
           ...queryData,
@@ -203,8 +201,6 @@ const TableContainer = ({
           }
           setPageIndex(0);
         } else {
-          console.log("This hit");
-          console.log("updateQueryData", updateQueryData);
           onQueryChange(updateQueryData);
         }
       } else if (!isClientSideFilter) {
@@ -230,11 +226,6 @@ const TableContainer = ({
       return clientFilterCount;
     } else return data.length;
   }, [filteredCount, clientFilterCount, data]);
-
-  console.log("\n\nfilteredCount", filteredCount);
-  console.log("clientFilterCount", clientFilterCount);
-  console.log("data.length", data.length);
-  console.log("displayCount()", displayCount());
 
   return (
     <div className={wrapperClasses}>
@@ -334,44 +325,57 @@ const TableContainer = ({
           </>
         ) : (
           <>
-            <DataTable
-              isLoading={isLoading}
-              columns={columns}
-              data={data}
-              manualSortBy={manualSortBy}
-              sortHeader={sortHeader}
-              sortDirection={sortDirection}
-              onSort={onSortChange}
-              disableMultiRowSelect={disableMultiRowSelect}
-              showMarkAllPages={showMarkAllPages}
-              isAllPagesSelected={isAllPagesSelected}
-              toggleAllPagesSelected={toggleAllPagesSelected}
-              resultsTitle={resultsTitle}
-              defaultPageSize={pageSize}
-              primarySelectActionButtonVariant={
-                primarySelectActionButtonVariant
-              }
-              primarySelectActionButtonIcon={primarySelectActionButtonIcon}
-              primarySelectActionButtonText={primarySelectActionButtonText}
-              onPrimarySelectActionClick={onPrimarySelectActionClick}
-              secondarySelectActions={secondarySelectActions}
-              onSelectSingleRow={onSelectSingleRow}
-              onResultsCountChange={onResultsCountChange}
-              isClientSidePagination={isClientSidePagination}
-              isClientSideFilter={isClientSideFilter}
-              highlightOnHover={highlightOnHover}
-              searchQuery={searchQuery}
-              searchQueryColumn={searchQueryColumn}
-              selectedDropdownFilter={selectedDropdownFilter}
-            />
-            {!disablePagination && !isClientSidePagination && (
-              <Pagination
-                resultsOnCurrentPage={data.length}
-                currentPage={pageIndex}
-                resultsPerPage={pageSize}
-                onPaginationChange={onPaginationChange}
-              />
+            {/* TODO: Fix this hacky solution to clientside search being 0 rendering emptycomponent but
+            no longer accesses rows.length because DataTable is not rendered */}
+            {clientFilterCount === 0 && (
+              <EmptyComponent pageIndex={pageIndex} />
             )}
+            <div
+              className={
+                isClientSideFilter
+                  ? `client-result-count-${clientFilterCount}`
+                  : ""
+              }
+            >
+              <DataTable
+                isLoading={isLoading}
+                columns={columns}
+                data={data}
+                manualSortBy={manualSortBy}
+                sortHeader={sortHeader}
+                sortDirection={sortDirection}
+                onSort={onSortChange}
+                disableMultiRowSelect={disableMultiRowSelect}
+                showMarkAllPages={showMarkAllPages}
+                isAllPagesSelected={isAllPagesSelected}
+                toggleAllPagesSelected={toggleAllPagesSelected}
+                resultsTitle={resultsTitle}
+                defaultPageSize={pageSize}
+                primarySelectActionButtonVariant={
+                  primarySelectActionButtonVariant
+                }
+                primarySelectActionButtonIcon={primarySelectActionButtonIcon}
+                primarySelectActionButtonText={primarySelectActionButtonText}
+                onPrimarySelectActionClick={onPrimarySelectActionClick}
+                secondarySelectActions={secondarySelectActions}
+                onSelectSingleRow={onSelectSingleRow}
+                onResultsCountChange={onResultsCountChange}
+                isClientSidePagination={isClientSidePagination}
+                isClientSideFilter={isClientSideFilter}
+                highlightOnHover={highlightOnHover}
+                searchQuery={searchQuery}
+                searchQueryColumn={searchQueryColumn}
+                selectedDropdownFilter={selectedDropdownFilter}
+              />
+              {!disablePagination && !isClientSidePagination && (
+                <Pagination
+                  resultsOnCurrentPage={data.length}
+                  currentPage={pageIndex}
+                  resultsPerPage={pageSize}
+                  onPaginationChange={onPaginationChange}
+                />
+              )}
+            </div>
           </>
         )}
       </div>

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -242,7 +242,7 @@ const TableContainer = ({
         </div>
       )}
       <div className={`${baseClass}__header`}>
-        {data && data.length && !disableCount ? (
+        {data && displayCount() && !disableCount ? (
           <p className={`${baseClass}__results-count`}>
             {TableContainerUtils.generateResultsCountText(
               resultsTitle,

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -1,4 +1,9 @@
 .table-container {
+  // TODO: Fix hacky solution to clientside search being 0 no longer accessing rows.length
+  .client-result-count-0 {
+    display: none;
+  }
+
   &__header {
     display: flex;
     align-items: center;

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesListWrapper.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesListWrapper.tsx
@@ -84,6 +84,15 @@ const QueriesListWrapper = ({
 
   const tableHeaders = currentUser && generateTableHeaders(currentUser);
 
+  // Queries have not been created
+  if (!isLoading && queriesList?.length === 0) {
+    return (
+      <div className={`${baseClass}`}>
+        <NoQueriesComponent />
+      </div>
+    );
+  }
+
   return tableHeaders && !isLoading ? (
     <div className={`${baseClass}`}>
       <TableContainer


### PR DESCRIPTION
Cerra #3237 

- Fixed falsy bug: Client side filter count is now correct when returning 0
- Empty state renders when display count is 0

Completely empty state (now hides platform dropdown and search bar):
<img width="1264" alt="Screen Shot 2021-12-09 at 2 17 27 PM" src="https://user-images.githubusercontent.com/71795832/145484639-bc743362-1b6c-416b-821c-92bb7378822f.png">
4 queries:
<img width="1269" alt="Screen Shot 2021-12-09 at 2 02 01 PM" src="https://user-images.githubusercontent.com/71795832/145482914-6c0bc5ab-2e11-4d15-9bb5-67db6610d2b9.png">
4 queries, 2 matching search query:
<img width="1272" alt="Screen Shot 2021-12-09 at 2 01 55 PM" src="https://user-images.githubusercontent.com/71795832/145482917-f04fc035-ab8f-4b6d-8b66-c7c75ba17769.png">
4 queries, none matching search query (count disappears):
<img width="1269" alt="Screen Shot 2021-12-09 at 2 02 11 PM" src="https://user-images.githubusercontent.com/71795832/145482913-b0928017-b3de-4a2a-be04-632d68867784.png">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
