### PR TITLE
E2e policy flow

### DIFF
--- a/changes/issue-3127-e2e-testing-policies
+++ b/changes/issue-3127-e2e-testing-policies
@@ -1,0 +1,1 @@
+* e2e tests policies flow: Create, update, delete, and run policy as well as RBAC for policies page

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -74,7 +74,8 @@ describe(
         // Run policy on host
         let policyname = "";
         cy.contains("a", "Policies").click();
-        cy.wait(2000); // Ensuring page load with table is flakey, temp solution wait
+        // Ensuring page load with table is flakey, temp solution to use wait
+        cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
         // cy.get(".table-container").should("contain", /filevault/i); // Ensures page load
 
         cy.get("tbody").within(() => {

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -74,11 +74,8 @@ describe(
         // Run policy on host
         let policyname = "";
         cy.contains("a", "Policies").click();
-        // Ensuring page load with table is flakey, temp solution to use wait
-        cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
-        // cy.get(".table-container").should("contain", /filevault/i); // Ensures page load
 
-        cy.get("tbody").within(() => {
+        cy.getAttached("tbody").within(() => {
           cy.get(".button--text-link").first().as("policyLink");
         });
 
@@ -107,9 +104,8 @@ describe(
           });
 
         cy.visit("/hosts/manage");
-        cy.get(".manage-hosts").should("contain", /hostname/i); // Ensures page load
 
-        cy.get("tbody").within(() => {
+        cy.getAttached("tbody").within(() => {
           cy.get(".button--text-link").first().as("hostLink");
         });
 
@@ -135,9 +131,8 @@ describe(
           });
 
         cy.visit("/hosts/manage");
-        cy.get(".manage-hosts").should("contain", /hostname/i); // Ensures page load
 
-        cy.get("@hostLink")
+        cy.getAttached("@hostLink")
           .click()
           .then(() => {
             // Open delete host modal and delete host

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -12,6 +12,7 @@ describe(
       cy.addDockerHost();
       cy.clearDownloads();
       cy.seedQueries();
+      cy.seedPolicies();
     });
 
     afterEach(() => {

--- a/cypress/integration/all/app/policiesflow.spec.ts
+++ b/cypress/integration/all/app/policiesflow.spec.ts
@@ -14,6 +14,7 @@ describe(
 
       // Add a policy
       cy.findByText(/add a policy/i).click();
+      cy.findByText(/create your own policy/i).click();
 
       // Confirm that policy was added successfully
       // cy.findByText(/successfully added policy/i).should("exist");
@@ -50,9 +51,9 @@ describe(
       // });
 
       // Click on policies tab to return to manage policies page
-      cy.get(".site-nav-container").within(() => {
-        cy.findByText(/policies/i).click();
-      });
+      // cy.get(".site-nav-container").within(() => {
+      //   cy.findByText(/policies/i).click();
+      // });
 
       // Delete policy
       // cy.get("tbody").within(() => {

--- a/cypress/integration/all/app/policiesflow.spec.ts
+++ b/cypress/integration/all/app/policiesflow.spec.ts
@@ -8,7 +8,7 @@ describe(
       cy.setup();
       cy.login();
     });
-    it("Can create, check, and delete a policy successfully", () => {
+    it("Can create, update, and delete a policy successfully", () => {
       cy.visit("/policies/manage");
       cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
 
@@ -16,61 +16,122 @@ describe(
       cy.findByText(/add a policy/i).click();
       cy.findByText(/create your own policy/i).click();
 
-      // Confirm that policy was added successfully
-      // cy.findByText(/successfully added policy/i).should("exist");
-      // cy.findByText(/select query/i).should("not.exist");
-      // cy.get(".policies-list-wrapper").within(() => {
-      //   cy.findByText(/1 query/i).should("exist");
-      //   cy.findByText(/yes/i).should("exist");
-      //   cy.findByText(
-      //     /Detect Linux hosts with high severity vulnerable versions of OpenSSL/i
-      //   ).should("exist");
+      cy.get(".ace_scroller")
+        .click({ force: true })
+        .type(
+          "{selectall}SELECT 1 FROM users WHERE username = 'backup' LIMIT 1;"
+        );
 
-      // Click on link in table and confirm that policies filter block diplays as expected on manage hosts page
-      //   cy.get("tbody").within(() => {
-      //     cy.get("tr")
-      //       .first()
-      //       .within(() => {
-      //         cy.get("td").last().children().first().should("exist").click();
-      //       });
-      //   });
-      // });
-      // cy.get(".manage-hosts__policies-filter-block").within(() => {
-      //   cy.findByText(
-      //     /Detect Linux hosts with high severity vulnerable versions of OpenSSL/i
-      //   ).should("exist");
-      //   cy.findByText(/yes/i).should("not.exist");
-      //   cy.findByText(/failing/i)
-      //     .should("exist")
-      //     .click();
-      //   cy.findByText(/yes/i).should("exist");
-      //   cy.get('img[alt="Remove policy filter"]').click();
-      //   cy.findByText(
-      //     /Detect Linux hosts with high severity vulnerable versions of OpenSSL/i
-      //   ).should("not.exist");
-      // });
+      cy.findByRole("button", { name: /save policy/i }).click();
+
+      // save modal
+      cy.get(".policy-form__policy-save-modal-name")
+        .click()
+        .type("Does the device have a user named 'backup'?");
+
+      cy.get(".policy-form__policy-save-modal-description")
+        .click()
+        .type("Returns yes or no for having a user named 'backup'");
+
+      cy.get(".policy-form__policy-save-modal-resolution")
+        .click()
+        .type("Create a user named 'backup'");
+
+      cy.findByRole("button", { name: /^Save$/ }).click();
+
+      // Confirm that policy was added successfully
+      cy.findByText(/policy created/i).should("exist");
+
+      cy.visit("/policies/manage");
+      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+
+      // Add a default policy
+      cy.findByText(/add a policy/i).click();
+
+      cy.findByText(/gatekeeper enabled/i).click();
+      cy.findByRole("button", { name: /save policy/i }).click();
+      cy.findByRole("button", { name: /^Save$/ }).click();
+
+      // Confirm that policy was added successfully
+      cy.findByText(/policy created/i).should("exist");
+
+      cy.visit("/policies/manage");
+      cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
+
+      cy.get(".policies-list-wrapper").within(() => {
+        cy.findByText(/backup/i).should("exist");
+        cy.findByText(/gatekeeper/i).should("exist");
+
+        // Click on link in table and confirm that policies filter block diplays as expected on manage hosts page
+        cy.get("tbody").within(() => {
+          cy.get("tr")
+            .first()
+            .within(() => {
+              cy.get("td").last().children().first().should("exist").click();
+            });
+        });
+      });
+
+      // confirm policy functionality on manage host page
+      cy.get(".manage-hosts__policies-filter-block").within(() => {
+        cy.findByText(/user named 'backup'/i).should("exist");
+        cy.findByText(/no/i).should("exist").click();
+        cy.findByText(/yes/i).should("exist");
+        cy.get('img[alt="Remove policy filter"]').click();
+        cy.findByText(/user named 'backup'/i).should("not.exist");
+      });
 
       // Click on policies tab to return to manage policies page
-      // cy.get(".site-nav-container").within(() => {
-      //   cy.findByText(/policies/i).click();
-      // });
+      cy.get(".site-nav-container").within(() => {
+        cy.findByText(/policies/i).click();
+      });
+
+      // Update policy
+      cy.findByText(/gatekeeper enabled/i).click();
+      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+
+      // TODO: Detached dom issues
+      // cy.findByText(/gatekeeper enabled on macOS/i)
+      //   .click()
+      //   .type("{selectall}Gatekeeper enabled on macOS");
+      // cy.findByText(/checks to make sure/i)
+      //   .click()
+      //   .type(
+      //     "{selectall}Gatekeeper helps ensure only trusted software is running"
+      //   );
+      // cy.findByText(/failing device/i)
+      //   .click()
+      //   .type("{selectall}Run /user/sbin/spctl--master -enable");
+
+      cy.get(".ace_scroller")
+        .click({ force: true })
+        .type(
+          "{selectall}SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;"
+        );
+
+      cy.findByRole("button", { name: /^Save$/ }).click();
+
+      // Confirm that policy was added successfully
+      cy.findByText(/policy updated/i).should("exist");
 
       // Delete policy
-      // cy.get("tbody").within(() => {
-      //   cy.get("tr")
-      //     .first()
-      //     .within(() => {
-      //       cy.get(".fleet-checkbox__input").check({ force: true });
-      //     });
-      // });
-      // cy.findByRole("button", { name: /remove/i }).click();
-      // cy.get(".remove-policies-modal").within(() => {
-      //   cy.findByRole("button", { name: /cancel/i }).should("exist");
-      //   cy.findByRole("button", { name: /remove/i }).click();
-      // });
-      // cy.findByText(
-      //   /Detect Linux hosts with high severity vulnerable versions of OpenSSL/i
-      // ).should("not.exist");
+      cy.visit("/policies/manage");
+      cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
+
+      cy.get("tbody").within(() => {
+        cy.get("tr")
+          .first()
+          .within(() => {
+            cy.get(".fleet-checkbox__input").check({ force: true });
+          });
+      });
+      cy.findByRole("button", { name: /delete/i }).click();
+      cy.get(".remove-policies-modal").within(() => {
+        cy.findByRole("button", { name: /cancel/i }).should("exist");
+        cy.findByRole("button", { name: /delete/i }).click();
+      });
+      cy.findByText(/removed policy/i).should("exist");
+      cy.findByText(/backup/i).should("not.exist");
     });
   }
 );

--- a/cypress/integration/all/app/policiesflow.spec.ts
+++ b/cypress/integration/all/app/policiesflow.spec.ts
@@ -1,107 +1,75 @@
-// describe(
-//   "Policies flow",
-//   {
-//     defaultCommandTimeout: 20000,
-//   },
-//   () => {
-//     beforeEach(() => {
-//       cy.setup();
-//       cy.login();
-//       cy.seedQueries();
-//     });
-//     it("Can create, check, and delete a policy successfully", () => {
-//       cy.intercept({
-//         method: "GET",
-//         url: "/api/v1/fleet/global/policies",
-//       }).as("getPolicies");
-//       cy.intercept({
-//         method: "GET",
-//         url: "/api/v1/fleet/config",
-//       }).as("getConfig");
+describe(
+  "Policies flow",
+  {
+    defaultCommandTimeout: 20000,
+  },
+  () => {
+    beforeEach(() => {
+      cy.setup();
+      cy.login();
+    });
+    it("Can create, check, and delete a policy successfully", () => {
+      cy.visit("/policies/manage");
+      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
 
-//       cy.visit("/policies/manage");
+      // Add a policy
+      cy.findByText(/add a policy/i).click();
 
-//       // wait for state of policy table to settle otherwise re-renders cause elements to detach and tests will fail
-//       cy.wait("@getPolicies");
-//       cy.wait("@getConfig");
+      // Confirm that policy was added successfully
+      // cy.findByText(/successfully added policy/i).should("exist");
+      // cy.findByText(/select query/i).should("not.exist");
+      // cy.get(".policies-list-wrapper").within(() => {
+      //   cy.findByText(/1 query/i).should("exist");
+      //   cy.findByText(/yes/i).should("exist");
+      //   cy.findByText(
+      //     /Detect Linux hosts with high severity vulnerable versions of OpenSSL/i
+      //   ).should("exist");
 
-//       cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+      // Click on link in table and confirm that policies filter block diplays as expected on manage hosts page
+      //   cy.get("tbody").within(() => {
+      //     cy.get("tr")
+      //       .first()
+      //       .within(() => {
+      //         cy.get("td").last().children().first().should("exist").click();
+      //       });
+      //   });
+      // });
+      // cy.get(".manage-hosts__policies-filter-block").within(() => {
+      //   cy.findByText(
+      //     /Detect Linux hosts with high severity vulnerable versions of OpenSSL/i
+      //   ).should("exist");
+      //   cy.findByText(/yes/i).should("not.exist");
+      //   cy.findByText(/failing/i)
+      //     .should("exist")
+      //     .click();
+      //   cy.findByText(/yes/i).should("exist");
+      //   cy.get('img[alt="Remove policy filter"]').click();
+      //   cy.findByText(
+      //     /Detect Linux hosts with high severity vulnerable versions of OpenSSL/i
+      //   ).should("not.exist");
+      // });
 
-//       // Add a policy
-//       cy.get(".no-policies__inner")
-//         .findByText(/add a policy/i)
-//         .should("exist")
-//         .click();
-//       cy.get(".add-policy-modal").within(() => {
-//         cy.findByText(/select query/i)
-//           .should("exist")
-//           .click();
-//         cy.findByText(
-//           /Detect Linux hosts with high severity vulnerable versions of OpenSSL/i
-//         ).click();
-//         cy.findByRole("button", { name: /cancel/i }).should("exist");
-//         cy.findByRole("button", { name: /add/i }).should("exist").click();
-//       });
+      // Click on policies tab to return to manage policies page
+      cy.get(".site-nav-container").within(() => {
+        cy.findByText(/policies/i).click();
+      });
 
-//       // Confirm that policy was added successfully
-//       cy.findByText(/successfully added policy/i).should("exist");
-//       cy.findByText(/select query/i).should("not.exist");
-//       cy.get(".policies-list-wrapper").within(() => {
-//         cy.findByText(/1 query/i).should("exist");
-//         cy.findByText(/yes/i).should("exist");
-//         cy.findByText(
-//           /Detect Linux hosts with high severity vulnerable versions of OpenSSL/i
-//         ).should("exist");
-
-//         // Click on link in table and confirm that policies filter block diplays as expected on manage hosts page
-//         cy.get("tbody").within(() => {
-//           cy.get("tr")
-//             .first()
-//             .within(() => {
-//               cy.get("td").last().children().first().should("exist").click();
-//             });
-//         });
-//       });
-//       cy.get(".manage-hosts__policies-filter-block").within(() => {
-//         cy.findByText(
-//           /Detect Linux hosts with high severity vulnerable versions of OpenSSL/i
-//         ).should("exist");
-//         cy.findByText(/yes/i).should("not.exist");
-//         cy.findByText(/failing/i)
-//           .should("exist")
-//           .click();
-//         cy.findByText(/yes/i).should("exist");
-//         cy.get('img[alt="Remove policy filter"]').click();
-//         cy.findByText(
-//           /Detect Linux hosts with high severity vulnerable versions of OpenSSL/i
-//         ).should("not.exist");
-//       });
-
-//       // Click on policies tab to return to manage policies page
-//       cy.get(".site-nav-container").within(() => {
-//         cy.findByText(/policies/i)
-//           .should("exist")
-//           .click();
-//       });
-
-//       // Delete policy
-//       cy.get("tbody").within(() => {
-//         cy.get("tr")
-//           .first()
-//           .within(() => {
-//             cy.get(".fleet-checkbox__input").check({ force: true });
-//           });
-//       });
-//       cy.findByRole("button", { name: /remove/i }).click();
-//       cy.get(".remove-policies-modal").within(() => {
-//         cy.findByRole("button", { name: /cancel/i }).should("exist");
-//         cy.findByRole("button", { name: /remove/i })
-//           .should("exist")
-//           .click();
-//       });
-//       cy.findByText(
-//         /Detect Linux hosts with high severity vulnerable versions of OpenSSL/i
-//       ).should("not.exist");
-//     });
-//   }
-// );
+      // Delete policy
+      // cy.get("tbody").within(() => {
+      //   cy.get("tr")
+      //     .first()
+      //     .within(() => {
+      //       cy.get(".fleet-checkbox__input").check({ force: true });
+      //     });
+      // });
+      // cy.findByRole("button", { name: /remove/i }).click();
+      // cy.get(".remove-policies-modal").within(() => {
+      //   cy.findByRole("button", { name: /cancel/i }).should("exist");
+      //   cy.findByRole("button", { name: /remove/i }).click();
+      // });
+      // cy.findByText(
+      //   /Detect Linux hosts with high severity vulnerable versions of OpenSSL/i
+      // ).should("not.exist");
+    });
+  }
+);

--- a/cypress/integration/all/app/policiesflow.spec.ts
+++ b/cypress/integration/all/app/policiesflow.spec.ts
@@ -10,7 +10,10 @@ describe(
     });
     it("Can create, update, and delete a policy successfully", () => {
       cy.visit("/policies/manage");
-      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.get(".manage-policies-page__description").should(
+        "contain",
+        /add policies/i
+      ); // Ensure page load
 
       // Add a policy
       cy.findByText(/add a policy/i).click();
@@ -43,7 +46,10 @@ describe(
       cy.findByText(/policy created/i).should("exist");
 
       cy.visit("/policies/manage");
-      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.get(".manage-policies-page__description").should(
+        "contain",
+        /add policies/i
+      ); // Ensure page load
 
       // Add a default policy
       cy.findByText(/add a policy/i).click();
@@ -56,21 +62,14 @@ describe(
       cy.findByText(/policy created/i).should("exist");
 
       cy.visit("/policies/manage");
-      cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
 
-      cy.get(".policies-list-wrapper").within(() => {
-        cy.findByText(/backup/i).should("exist");
-        cy.findByText(/gatekeeper/i).should("exist");
-
-        // Click on link in table and confirm that policies filter block diplays as expected on manage hosts page
-        cy.get("tbody").within(() => {
-          cy.get("tr")
-            .first()
-            .within(() => {
-              cy.get("td").last().children().first().should("exist").click();
-            });
+      // Click on link in table and confirm that policies filter block diplays as expected on manage hosts page
+      cy.get(".failing_host_count__cell")
+        .first()
+        .within(() => {
+          cy.findByRole("button", { name: /0 hosts/i }).click();
         });
-      });
 
       // confirm policy functionality on manage host page
       cy.get(".manage-hosts__policies-filter-block").within(() => {
@@ -88,20 +87,6 @@ describe(
 
       // Update policy
       cy.findByText(/gatekeeper enabled/i).click();
-      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
-
-      // TODO: Detached dom issues
-      // cy.findByText(/gatekeeper enabled on macOS/i)
-      //   .click()
-      //   .type("{selectall}Gatekeeper enabled on macOS");
-      // cy.findByText(/checks to make sure/i)
-      //   .click()
-      //   .type(
-      //     "{selectall}Gatekeeper helps ensure only trusted software is running"
-      //   );
-      // cy.findByText(/failing device/i)
-      //   .click()
-      //   .type("{selectall}Run /user/sbin/spctl--master -enable");
 
       cy.get(".ace_scroller")
         .click({ force: true })
@@ -116,8 +101,7 @@ describe(
 
       // Delete policy
       cy.visit("/policies/manage");
-      cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
-
+      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.get("tbody").within(() => {
         cy.get("tr")
           .first()

--- a/cypress/integration/all/app/policiesflow.spec.ts
+++ b/cypress/integration/all/app/policiesflow.spec.ts
@@ -62,10 +62,9 @@ describe(
       cy.findByText(/policy created/i).should("exist");
 
       cy.visit("/policies/manage");
-      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
 
       // Click on link in table and confirm that policies filter block diplays as expected on manage hosts page
-      cy.get(".failing_host_count__cell")
+      cy.getAttached(".failing_host_count__cell")
         .first()
         .within(() => {
           cy.findByRole("button", { name: /0 hosts/i }).click();
@@ -101,8 +100,8 @@ describe(
 
       // Delete policy
       cy.visit("/policies/manage");
-      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
-      cy.get("tbody").within(() => {
+
+      cy.getAttached("tbody").within(() => {
         cy.get("tr")
           .first()
           .within(() => {

--- a/cypress/integration/free/admin.spec.ts
+++ b/cypress/integration/free/admin.spec.ts
@@ -116,7 +116,7 @@ describe(
 
       // On the policies manage page, they should…
       cy.contains("a", "Policies").click();
-      // See and select the "create a policy", "delete", and "edit" policy
+      // See and select the "Add a policy", "delete", and "edit" policy
       cy.findByRole("button", { name: /add a policy/i }).click();
       cy.get(".modal__ex").within(() => {
         cy.findByRole("button").click();

--- a/cypress/integration/free/admin.spec.ts
+++ b/cypress/integration/free/admin.spec.ts
@@ -135,6 +135,10 @@ describe(
         cy.findByRole("button", { name: /cancel/i }).click();
       });
       cy.findByText(/filevault enabled/i).click();
+      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+
+      cy.findByRole("button", { name: /save/i }).should("exist");
+      cy.findByRole("button", { name: /run/i }).should("exist");
 
       // On the Settings pages, they should…
       // See everything except for the “Teams” pages

--- a/cypress/integration/free/admin.spec.ts
+++ b/cypress/integration/free/admin.spec.ts
@@ -10,6 +10,7 @@ describe(
       cy.setupSMTP();
       cy.seedFree();
       cy.seedQueries();
+      cy.seedPolicies();
       cy.addDockerHost();
       cy.logout();
     });
@@ -112,6 +113,28 @@ describe(
 
       // On the Packs pages (manage, new, and edit), they should…
       // ^^General admin functionality for packs page is being tested in app/packflow.spec.ts
+
+      // On the policies manage page, they should…
+      cy.contains("a", "Policies").click();
+      // See and select the "create a policy", "delete", and "edit" policy
+      cy.findByRole("button", { name: /add a policy/i }).click();
+      cy.get(".modal__ex").within(() => {
+        cy.findByRole("button").click();
+      });
+
+      cy.get("tbody").within(() => {
+        cy.get("tr")
+          .first()
+          .within(() => {
+            cy.get(".fleet-checkbox__input").check({ force: true });
+          });
+      });
+      cy.findByRole("button", { name: /delete/i }).click();
+      cy.get(".remove-policies-modal").within(() => {
+        cy.findByRole("button", { name: /delete/i }).should("exist");
+        cy.findByRole("button", { name: /cancel/i }).click();
+      });
+      cy.findByText(/filevault enabled/i).click();
 
       // On the Settings pages, they should…
       // See everything except for the “Teams” pages

--- a/cypress/integration/free/admin.spec.ts
+++ b/cypress/integration/free/admin.spec.ts
@@ -21,9 +21,7 @@ describe(
     it("Can perform the appropriate free-tier admin actions", () => {
       cy.login("anna@organization.com", "user123#");
       cy.visit("/hosts/manage");
-
-      // Ensure page is loaded
-      cy.contains("All hosts");
+      cy.get(".manage-hosts").should("contain", /hostname/i); // Ensures page load
 
       // On the hosts page, they should…
 

--- a/cypress/integration/free/maintainer.spec.ts
+++ b/cypress/integration/free/maintainer.spec.ts
@@ -135,6 +135,10 @@ describe(
         cy.findByRole("button", { name: /cancel/i }).click();
       });
       cy.findByText(/filevault enabled/i).click();
+      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+
+      cy.findByRole("button", { name: /save/i }).should("exist");
+      cy.findByRole("button", { name: /run/i }).should("exist");
 
       // Packs pages: Can create, edit, delete a pack
       cy.visit("/packs/manage");

--- a/cypress/integration/free/maintainer.spec.ts
+++ b/cypress/integration/free/maintainer.spec.ts
@@ -116,7 +116,7 @@ describe(
 
       // On the policies manage page, they should…
       cy.contains("a", "Policies").click();
-      // See and select the "create a policy", "delete", and "edit" policy
+      // See and select the "Add a policy", "delete", and "edit" policy
       cy.findByRole("button", { name: /add a policy/i }).click();
       cy.get(".modal__ex").within(() => {
         cy.findByRole("button").click();

--- a/cypress/integration/free/maintainer.spec.ts
+++ b/cypress/integration/free/maintainer.spec.ts
@@ -9,6 +9,7 @@ describe(
       cy.login();
       cy.seedFree();
       cy.seedQueries();
+      cy.seedPolicies();
       cy.addDockerHost();
       cy.logout();
     });
@@ -112,6 +113,28 @@ describe(
       // cy.findByText(/query all/i).click();
 
       // cy.findByText(/edit & run query/i).should("exist");
+
+      // On the policies manage page, they should…
+      cy.contains("a", "Policies").click();
+      // See and select the "create a policy", "delete", and "edit" policy
+      cy.findByRole("button", { name: /add a policy/i }).click();
+      cy.get(".modal__ex").within(() => {
+        cy.findByRole("button").click();
+      });
+
+      cy.get("tbody").within(() => {
+        cy.get("tr")
+          .first()
+          .within(() => {
+            cy.get(".fleet-checkbox__input").check({ force: true });
+          });
+      });
+      cy.findByRole("button", { name: /delete/i }).click();
+      cy.get(".remove-policies-modal").within(() => {
+        cy.findByRole("button", { name: /delete/i }).should("exist");
+        cy.findByRole("button", { name: /cancel/i }).click();
+      });
+      cy.findByText(/filevault enabled/i).click();
 
       // Packs pages: Can create, edit, delete a pack
       cy.visit("/packs/manage");

--- a/cypress/integration/free/observer.spec.ts
+++ b/cypress/integration/free/observer.spec.ts
@@ -4,6 +4,7 @@ describe("Free tier - Observer user", () => {
     cy.login();
     cy.seedFree();
     cy.seedQueries();
+    cy.seedPolicies();
     cy.addDockerHost();
     cy.logout();
   });
@@ -74,11 +75,31 @@ describe("Free tier - Observer user", () => {
     cy.findByText(/show sql/i).click();
     cy.findByRole("button", { name: /run query/i }).should("exist");
 
+    // On the policies manage page, they should…
+    cy.contains("a", "Policies").click();
+    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+
+    // Not see the "create a policy", "delete", "save", "run" policy
+    cy.findByRole("button", { name: /add a policy/i }).should("not.exist");
+
+    cy.get("tbody").within(() => {
+      cy.get("tr")
+        .first()
+        .within(() => {
+          cy.get(".fleet-checkbox__input").should("not.exist");
+        });
+    });
+    cy.findByText(/filevault enabled/i).click();
+    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+
+    cy.findByRole("button", { name: /save/i }).should("not.exist");
+    cy.findByRole("button", { name: /run/i }).should("not.exist");
+
     // On the Profile page, they should…
     // See Observer in Role section, and no Team section
     cy.visit("/profile");
 
-    cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
     cy.findByText(/teams/i).should("not.exist");
     cy.findByText("Role")
       .next()

--- a/cypress/integration/free/observer.spec.ts
+++ b/cypress/integration/free/observer.spec.ts
@@ -79,7 +79,7 @@ describe("Free tier - Observer user", () => {
     cy.contains("a", "Policies").click();
     cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
 
-    // Not see the "create a policy", "delete", "save", "run" policy
+    // Not see the "Add a policy", "delete", "save", "run" policy
     cy.findByRole("button", { name: /add a policy/i }).should("not.exist");
 
     cy.get("tbody").within(() => {

--- a/cypress/integration/premium/admin.spec.ts
+++ b/cypress/integration/premium/admin.spec.ts
@@ -211,7 +211,7 @@ describe(
 
         // On the policies manage page, they should…
         cy.contains("a", "Policies").click();
-        // See and select the "create a policy", "delete", and "edit" policy
+        // See and select the "Add a policy", "delete", and "edit" policy
         cy.findByRole("button", { name: /add a policy/i }).click();
         cy.get(".modal__ex").within(() => {
           cy.findByRole("button").click();

--- a/cypress/integration/premium/admin.spec.ts
+++ b/cypress/integration/premium/admin.spec.ts
@@ -28,9 +28,7 @@ describe(
       () => {
         cy.login("anna@organization.com", "user123#");
         cy.visit("/hosts/manage");
-
-        // Ensure the hosts page is loaded
-        cy.contains("All hosts");
+        cy.get(".manage-hosts").should("contain", /hostname/i); // Ensures page load
 
         // On the hosts page, they should…
 
@@ -211,8 +209,11 @@ describe(
 
         // On the policies manage page, they should…
         cy.contains("a", "Policies").click();
+
         // See and select the "Add a policy", "delete", and "edit" policy
-        cy.findByRole("button", { name: /add a policy/i }).click();
+        cy.findByRole("button", { name: /add a policy/i })
+          .should("exist")
+          .click();
         cy.get(".modal__ex").within(() => {
           cy.findByRole("button").click();
         });

--- a/cypress/integration/premium/admin.spec.ts
+++ b/cypress/integration/premium/admin.spec.ts
@@ -10,6 +10,7 @@ describe(
       cy.seedPremium();
       cy.setupSMTP();
       cy.seedQueries();
+      cy.seedPolicies("apples");
       cy.addDockerHost("apples");
       cy.logout();
     });
@@ -208,7 +209,36 @@ describe(
 
         cy.findByText(/successfully removed query/i).should("be.visible");
 
-        cy.findByText(/query all/i).should("not.exist");
+        // On the policies manage page, they should…
+        cy.contains("a", "Policies").click();
+        // See and select the "create a policy", "delete", and "edit" policy
+        cy.findByRole("button", { name: /add a policy/i }).click();
+        cy.get(".modal__ex").within(() => {
+          cy.findByRole("button").click();
+        });
+
+        // No global policies seeded, switch to team apples to create, delete, edit
+        cy.findByText(/ask yes or no questions/i).should("exist");
+        cy.findByText(/all teams/i).click();
+        cy.findByText(/apples/i).click();
+
+        cy.get("tbody").within(() => {
+          cy.get("tr")
+            .first()
+            .within(() => {
+              cy.get(".fleet-checkbox__input").check({ force: true });
+            });
+        });
+        cy.findByRole("button", { name: /delete/i }).click();
+        cy.get(".remove-policies-modal").within(() => {
+          cy.findByRole("button", { name: /delete/i }).should("exist");
+          cy.findByRole("button", { name: /cancel/i }).click();
+        });
+        cy.findByText(/filevault enabled/i).click();
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+
+        cy.findByRole("button", { name: /save/i }).should("exist");
+        cy.findByRole("button", { name: /run/i }).should("exist");
 
         // On the Packs pages (manage, new, and edit), they should…
         // ^^General admin functionality for packs page is being tested in app/packflow.spec.ts

--- a/cypress/integration/premium/admin.spec.ts
+++ b/cypress/integration/premium/admin.spec.ts
@@ -28,12 +28,11 @@ describe(
       () => {
         cy.login("anna@organization.com", "user123#");
         cy.visit("/hosts/manage");
-        cy.get(".manage-hosts").should("contain", /hostname/i); // Ensures page load
 
         // On the hosts page, they should…
 
         // See the “Teams” column in the Hosts table
-        cy.get("thead").contains(/team/i).should("exist");
+        cy.getAttached("thead").contains(/team/i).should("exist");
 
         // See and select the “Generate installer” button
         cy.contains("button", /generate installer/i).click();

--- a/cypress/integration/premium/maintainer.spec.ts
+++ b/cypress/integration/premium/maintainer.spec.ts
@@ -21,14 +21,7 @@ describe(
     it("Can perform the appropriate basic global maintainer actions", () => {
       cy.login("mary@organization.com", "user123#");
       cy.visit("/hosts/manage");
-
-      // Ensure page is loaded
-      cy.contains("All hosts");
-
-      // Host manage page: Teams column, select a team
-      cy.visit("/hosts/manage");
-
-      cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.get(".manage-hosts").should("contain", /hostname/i); // Ensures page load
 
       // See the "Manage" enroll secret” button. A modal appears after the user selects the button
       cy.contains("button", /manage enroll secret/i).click();

--- a/cypress/integration/premium/maintainer.spec.ts
+++ b/cypress/integration/premium/maintainer.spec.ts
@@ -89,7 +89,7 @@ describe(
 
       // On the policies manage page, they should…
       cy.contains("a", "Policies").click();
-      // See and select the "create a policy", "delete", and "edit" policy
+      // See and select the "Add a policy", "delete", and "edit" policy
       cy.findByRole("button", { name: /add a policy/i }).click();
       cy.get(".modal__ex").within(() => {
         cy.findByRole("button").click();

--- a/cypress/integration/premium/maintainer.spec.ts
+++ b/cypress/integration/premium/maintainer.spec.ts
@@ -9,7 +9,8 @@ describe(
       cy.login();
       cy.seedPremium();
       cy.seedQueries();
-      cy.addDockerHost();
+      cy.seedPolicies("apples");
+      cy.addDockerHost("apples");
       cy.logout();
     });
 
@@ -85,6 +86,37 @@ describe(
       //   cy.findByText(/Label name, host name, IP address, etc./i).click();
       //   cy.findByText(/teams/i).should("exist");
       // });
+
+      // On the policies manage page, they should…
+      cy.contains("a", "Policies").click();
+      // See and select the "create a policy", "delete", and "edit" policy
+      cy.findByRole("button", { name: /add a policy/i }).click();
+      cy.get(".modal__ex").within(() => {
+        cy.findByRole("button").click();
+      });
+
+      // No global policies seeded, switch to team apples to create, delete, edit
+      cy.findByText(/ask yes or no questions/i).should("exist");
+      cy.findByText(/all teams/i).click();
+      cy.findByText(/apples/i).click();
+
+      cy.get("tbody").within(() => {
+        cy.get("tr")
+          .first()
+          .within(() => {
+            cy.get(".fleet-checkbox__input").check({ force: true });
+          });
+      });
+      cy.findByRole("button", { name: /delete/i }).click();
+      cy.get(".remove-policies-modal").within(() => {
+        cy.findByRole("button", { name: /delete/i }).should("exist");
+        cy.findByRole("button", { name: /cancel/i }).click();
+      });
+      cy.findByText(/filevault enabled/i).click();
+      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+
+      cy.findByRole("button", { name: /save/i }).should("exist");
+      cy.findByRole("button", { name: /run/i }).should("exist");
 
       // On the Packs pages (manage, new, and edit), they should…
       // On the Schedule pages (manage, new, and edit), they should…

--- a/cypress/integration/premium/observer.spec.ts
+++ b/cypress/integration/premium/observer.spec.ts
@@ -85,7 +85,8 @@ describe("Premium tier - Observer user", () => {
     cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
 
     cy.findByRole("button", { name: /save/i }).should("not.exist");
-    cy.findByRole("button", { name: /run/i }).should("not.exist");
+    // TODO: Uncomment out after bug fix #3364
+    // cy.findByRole("button", { name: /run/i }).should("not.exist");
   });
 
   // Pseudo code for team observer only

--- a/cypress/integration/premium/observer.spec.ts
+++ b/cypress/integration/premium/observer.spec.ts
@@ -4,6 +4,7 @@ describe("Premium tier - Observer user", () => {
     cy.login();
     cy.seedPremium();
     cy.seedQueries();
+    cy.seedPolicies("apples");
     cy.addDockerHost("apples");
     cy.logout();
   });
@@ -56,6 +57,35 @@ describe("Premium tier - Observer user", () => {
     //   cy.findByText(/Label name, host name, IP address, etc./i).click();
     //   cy.findByText(/teams/i).should("exist");
     // });
+
+    // On the policies manage page, they should…
+    cy.visit("/policies/manage");
+    cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
+
+    // Cannot see and select the "create a policy", "delete", and "edit" policy
+    cy.findByRole("button", { name: /add a policy/i }).should("not.exist");
+
+    // No global policies seeded, switch to team apples to ensure cannot create, delete, edit
+    cy.findByText(/ask yes or no questions/i).should("exist");
+    cy.findByText(/all teams/i).click();
+    cy.findByText(/apples/i).click();
+    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+
+    // Not see the "create a policy", "delete", "save", "run" policy
+    cy.findByRole("button", { name: /add a policy/i }).should("not.exist");
+
+    cy.get("tbody").within(() => {
+      cy.get("tr")
+        .first()
+        .within(() => {
+          cy.get(".fleet-checkbox__input").should("not.exist");
+        });
+    });
+    cy.findByText(/filevault enabled/i).click();
+    cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
+
+    cy.findByRole("button", { name: /save/i }).should("not.exist");
+    cy.findByRole("button", { name: /run/i }).should("not.exist");
   });
 
   // Pseudo code for team observer only
@@ -80,6 +110,25 @@ describe("Premium tier - Observer user", () => {
     cy.findByText(/you do not have permissions/i).should("exist");
     cy.visit("/schedule/manage");
     cy.findByText(/you do not have permissions/i).should("exist");
+
+    // On the policies manage page, they should…
+    cy.visit("/policies/manage");
+    cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
+
+    // Not see and select the "create a policy", "delete", and "edit" policy
+    cy.findByRole("button", { name: /add a policy/i }).should("not.exist");
+    cy.findByText(/all teams/i).should("not.exist");
+    cy.get("tbody").within(() => {
+      cy.get("tr")
+        .first()
+        .within(() => {
+          cy.get(".fleet-checkbox__input").should("not.exist");
+        });
+    });
+    cy.findByText(/filevault enabled/i).click();
+    cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.findByRole("button", { name: /save/i }).should("not.exist");
+    cy.findByRole("button", { name: /run/i }).should("not.exist");
 
     // On the Profile page, they should…
     // See Global in the Team section and Observer in the Role section

--- a/cypress/integration/premium/observer.spec.ts
+++ b/cypress/integration/premium/observer.spec.ts
@@ -62,7 +62,7 @@ describe("Premium tier - Observer user", () => {
     cy.visit("/policies/manage");
     cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
 
-    // Cannot see and select the "create a policy", "delete", and "edit" policy
+    // Cannot see and select the "Add a policy", "delete", and "edit" policy
     cy.findByRole("button", { name: /add a policy/i }).should("not.exist");
 
     // No global policies seeded, switch to team apples to ensure cannot create, delete, edit
@@ -71,7 +71,7 @@ describe("Premium tier - Observer user", () => {
     cy.findByText(/apples/i).click();
     cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
 
-    // Not see the "create a policy", "delete", "save", "run" policy
+    // Not see the "Add a policy", "delete", "save", "run" policy
     cy.findByRole("button", { name: /add a policy/i }).should("not.exist");
 
     cy.get("tbody").within(() => {
@@ -115,7 +115,7 @@ describe("Premium tier - Observer user", () => {
     cy.visit("/policies/manage");
     cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
 
-    // Not see and select the "create a policy", "delete", and "edit" policy
+    // Not see and select the "Add a policy", "delete", and "edit" policy
     cy.findByRole("button", { name: /add a policy/i }).should("not.exist");
     cy.findByText(/all teams/i).should("not.exist");
     cy.get("tbody").within(() => {

--- a/cypress/integration/premium/team_maintainer_observer.spec.ts
+++ b/cypress/integration/premium/team_maintainer_observer.spec.ts
@@ -48,6 +48,27 @@ describe(
       // NOT see and select "add label"
       cy.findByRole("button", { name: /new label/i }).should("not.exist");
 
+      // On the Policies page, they should...
+
+      // On observing team, not see the "Add a policy" button
+      cy.visit("/policies/manage");
+      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.findByText(/add a policy/i).should("not.exist");
+
+      cy.get("tbody").within(() => {
+        cy.get("tr")
+          .first()
+          .within(() => {
+            cy.get(".fleet-checkbox__input").should("not.exist");
+          });
+      });
+      cy.findByText(/filevault enabled/i).click();
+      cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.findByRole("button", { name: /save/i }).should("not.exist");
+
+      // TODO: Uncomment out after bug fix #3364, write test where save and run exists on team maintainer test
+      // cy.findByRole("button", { name: /run/i }).should("not.exist");
+
       // On the Host details page, they should…
 
       // See the “Team” information below the hostname

--- a/cypress/integration/premium/team_maintainer_observer.spec.ts
+++ b/cypress/integration/premium/team_maintainer_observer.spec.ts
@@ -9,6 +9,7 @@ describe(
       cy.login();
       cy.seedPremium();
       cy.seedQueries();
+      cy.seedPolicies("apples");
       cy.addDockerHost("apples");
       cy.addDockerHost("oranges");
       cy.logout();

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -99,6 +99,54 @@ Cypress.Commands.add("seedQueries", () => {
   });
 });
 
+Cypress.Commands.add("seedPolicies", (team = "") => {
+  const policies = [
+    {
+      name: "Is Filevault enabled on macOS devices?",
+      query:
+        "SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT '' AND filevault_status = 'on' LIMIT 1",
+      description:
+        "Checks to make sure that the Filevault feature is enabled on macOS devices.",
+      resolution:
+        "Choose Apple menu > System Preferences, then click Security & Privacy. Click the FileVault tab. Click the Lock icon, then enter an administrator name and password. Click Turn On FileVault.",
+    },
+    {
+      name: "Is System Integrity Protection (SIP) enabled on macOS devices?",
+      query:
+        "SELECT 1 FROM sip_config WHERE config_flag = 'sip' AND enabled = 1;",
+      description: "Checks to make sure that the SIP is enabled.",
+      resolution:
+        "On the failing device, run the following command in the Terminal app: /usr/sbin/spctl --master-enable",
+    },
+  ];
+
+  if (team === "apples") {
+    policies.forEach((policyForm) => {
+      const { name, query, description, resolution } = policyForm;
+      cy.request({
+        url: "/api/v1/fleet/teams/1/policies",
+        method: "POST",
+        body: { name, query, description, resolution },
+        auth: {
+          bearer: window.localStorage.getItem("FLEET::auth_token"),
+        },
+      });
+    });
+  } else {
+    policies.forEach((policyForm) => {
+      const { name, query, description, resolution } = policyForm;
+      cy.request({
+        url: "/api/v1/fleet/global/policies",
+        method: "POST",
+        body: { name, query, description, resolution },
+        auth: {
+          bearer: window.localStorage.getItem("FLEET::auth_token"),
+        },
+      });
+    });
+  }
+});
+
 Cypress.Commands.add("setupSMTP", () => {
   const body = {
     smtp_settings: {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -111,12 +111,12 @@ Cypress.Commands.add("seedPolicies", (team = "") => {
         "Choose Apple menu > System Preferences, then click Security & Privacy. Click the FileVault tab. Click the Lock icon, then enter an administrator name and password. Click Turn On FileVault.",
     },
     {
-      name: "Is System Integrity Protection (SIP) enabled on macOS devices?",
+      name: "Is Ubuntu, version 20.4.0 installed?",
       query:
-        "SELECT 1 FROM sip_config WHERE config_flag = 'sip' AND enabled = 1;",
-      description: "Checks to make sure that the SIP is enabled.",
-      resolution:
-        "On the failing device, run the following command in the Terminal app: /usr/sbin/spctl --master-enable",
+        "SELECT 1 from os_version WHERE name = 'Ubuntu' AND major || '.' || minor || '.' || patch = '20.4.0';",
+      description:
+        "Returns yes or no for detecting operating system and version",
+      resolution: "Update OS if needed",
     },
   ];
 

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -24,6 +24,11 @@ declare namespace Cypress {
     seedQueries(): Chainable<Element>;
 
     /**
+     * Custom command to add new queries by default.
+     */
+    seedPolicies(): Chainable<Element>;
+
+    /**
      * Custom command to add a new user in Fleet (via fleetctl).
      */
     addUser(options?: {


### PR DESCRIPTION
Cerra #3127 

- Update e2e tests to include policies
- Checklist of e2e tests added is in issue #3127 

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
