### PR TITLE
Fix policy rego bug with fleet policies

### DIFF
--- a/changes/issue-policy-rego-bug-in-fleet-policies
+++ b/changes/issue-policy-rego-bug-in-fleet-policies
@@ -1,0 +1,1 @@
+* Fix bug in rego policy for fleet policies.

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -405,14 +405,14 @@ allow {
 # Policies
 ##
 
-# Global Admin and Maintainer users can read and write policies
+# Global Admin can read and write policies
 allow {
   object.type == "policy"
   subject.global_role == admin
   action == [read, write][_]
 }
 
-# Global maintainer can read and write global policies
+# Global Maintainer can read and write global policies
 allow {
   is_null(object.team_id)
   object.type == "policy"
@@ -430,9 +430,10 @@ allow {
 # Team admin and maintainers can read and write policies for their teams
 allow {
   not is_null(object.team_id)
-  object.team_id == subject.teams[_].id
+  team_id := subject.teams[_].id
+  object.team_id == team_id
   object.type == "policy"
-  team_role(subject, subject.teams[_].id) == [admin,maintainer][_]
+  team_role(subject, team_id) == [admin,maintainer][_]
   action == [read, write][_]
 }
 
@@ -444,13 +445,14 @@ allow {
   action == read
 }
 
-# Team Observer can read policies
+# Team Observer can read policies for their teams
 allow {
   not is_null(object.team_id)
-  object.team_id == subject.teams[_].id
+  team_id := subject.teams[_].id
+  object.team_id == team_id
   object.type == "policy"
-  team_role(subject, subject.teams[_].id) == observer
-  action == [read][_]
+  team_role(subject, team_id) == observer
+  action == read
 }
 
 ##

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -430,10 +430,8 @@ allow {
 # Team admin and maintainers can read and write policies for their teams
 allow {
   not is_null(object.team_id)
-  team_id := subject.teams[_].id
-  object.team_id == team_id
   object.type == "policy"
-  team_role(subject, team_id) == [admin,maintainer][_]
+  team_role(subject, object.team_id) == [admin,maintainer][_]
   action == [read, write][_]
 }
 
@@ -448,10 +446,8 @@ allow {
 # Team Observer can read policies for their teams
 allow {
   not is_null(object.team_id)
-  team_id := subject.teams[_].id
-  object.team_id == team_id
   object.type == "policy"
-  team_role(subject, team_id) == observer
+  team_role(subject, object.team_id) == observer
   action == read
 }
 

--- a/server/service/global_policies_test.go
+++ b/server/service/global_policies_test.go
@@ -21,7 +21,11 @@ func TestGlobalPoliciesAuth(t *testing.T) {
 		return nil, nil
 	}
 	ds.PolicyFunc = func(ctx context.Context, id uint) (*fleet.Policy, error) {
-		return nil, nil
+		return &fleet.Policy{
+			PolicyData: fleet.PolicyData{
+				ID: id,
+			},
+		}, nil
 	}
 	ds.DeleteGlobalPoliciesFunc = func(ctx context.Context, ids []uint) ([]uint, error) {
 		return nil, nil
@@ -33,6 +37,9 @@ func TestGlobalPoliciesAuth(t *testing.T) {
 		return nil
 	}
 	ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activityType string, details *map[string]interface{}) error {
+		return nil
+	}
+	ds.SavePolicyFunc = func(ctx context.Context, p *fleet.Policy) error {
 		return nil
 	}
 
@@ -94,6 +101,9 @@ func TestGlobalPoliciesAuth(t *testing.T) {
 
 			_, err = svc.GetPolicyByIDQueries(ctx, 1)
 			checkAuthErr(t, tt.shouldFailRead, err)
+
+			_, err = svc.ModifyGlobalPolicy(ctx, 1, fleet.ModifyPolicyPayload{})
+			checkAuthErr(t, tt.shouldFailWrite, err)
 
 			_, err = svc.DeleteGlobalPolicies(ctx, []uint{1})
 			checkAuthErr(t, tt.shouldFailWrite, err)


### PR DESCRIPTION
I believe we have a similar bug with other entities, I'll take a look and create a separate PRs/issues for them.

- [X] Changes file added (for user-visible changes)
~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
~- [ ] Documented any permissions changes~
- [X] Added/updated tests
- [ ] Manual QA for all new/changed functionality

I wasn't able to test this due to a different bug when viewing policies as team observer (bug issue will be opened separately).
Also I cannot seem to edit policies that I'm not an author of. Maybe this is expected behavior?
