### PR TITLE
Manage Packs Page: Fix name column width

### DIFF
--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -98,7 +98,4 @@
       background-color: $ui-off-white;
     }
   }
-  .name__header {
-    width: 25%;
-  }
 }


### PR DESCRIPTION
Cerra #3333 

<img width="646" alt="Screen Shot 2021-12-10 at 10 58 06 AM" src="https://user-images.githubusercontent.com/71795832/145628913-2a0a005a-6d1e-441d-af6c-f5a8c992822f.png">
<img width="776" alt="Screen Shot 2021-12-10 at 10 57 56 AM" src="https://user-images.githubusercontent.com/71795832/145628916-94078b6e-9717-46f9-a1f5-00c24b543ab4.png">
<img width="1236" alt="Screen Shot 2021-12-10 at 10 57 50 AM" src="https://user-images.githubusercontent.com/71795832/145628918-5f0272b1-0f93-4a62-8130-badba85333b3.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
