### PR TITLE
Spiffier UI: Team dropdown, back to teams

### DIFF
--- a/cypress/integration/free/maintainer.spec.ts
+++ b/cypress/integration/free/maintainer.spec.ts
@@ -72,6 +72,7 @@ describe(
 
       // Queries pages: Can create, edit, and run query
       cy.visit("/queries/manage");
+      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
       // cy.get("thead").within(() => {
       //   cy.findByText(/observer can run/i).should("exist");
       // });
@@ -114,7 +115,7 @@ describe(
 
       // Packs pages: Can create, edit, delete a pack
       cy.visit("/packs/manage");
-
+      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.findByRole("button", { name: /create new pack/i }).click();
 
       cy.findByLabelText(/name/i).click().type("Errors and crashes");

--- a/frontend/components/TeamsDropdown/_styles.scss
+++ b/frontend/components/TeamsDropdown/_styles.scss
@@ -13,12 +13,19 @@
     }
   }
 
+  .Select-menu {
+    padding-right: $pad-small; // moves scrollbar to edge of dropdown
+    padding-bottom: $pad-medium;
+  }
+
   .Select-menu-outer {
     position: absolute;
     width: 330px;
     min-width: 125px;
     left: -12px;
+    top: 36px;
     border-radius: 6px;
+    padding-right: 0;
   }
 
   .Select-control {
@@ -39,12 +46,16 @@
 
     .Select-arrow-zone {
       height: 32px;
-      padding-left: $pad-small;
+      padding-left: 15px;
 
       .Select-arrow {
-        top: 2px !important;
+        top: 0 !important;
         margin-top: 0 !important;
       }
+    }
+
+    .is-open > .Select-arrow {
+      top: 0 !important;
     }
 
     .Select-multi-value-wrapper {

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/_styles.scss
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/_styles.scss
@@ -19,6 +19,7 @@
     color: $core-vibrant-blue;
     font-weight: $bold;
     text-decoration: none;
+    margin: $pad-medium 0;
   }
 
   #back-chevron {


### PR DESCRIPTION
Cerra #3222 , repeat #3294
Cerra #3296 

- Teams dropdown scroll bar now renders on very edge
- Teams dropdown does not cut off the last team option
- Teams dropdown arrow has increase padding to 15px between team name and arrow (per Figma)
- Teams dropdown increase top margin by 4px to not crowd team name 
- Add 16px vertical margin for "Back to teams" link on Teams Details Page

<img width="808" alt="Screen Shot 2021-12-13 at 12 25 56 AM" src="https://user-images.githubusercontent.com/71795832/145777791-90cfbda6-99f6-419b-8718-71d05516b642.png">

<img width="914" alt="Screen Shot 2021-12-13 at 12 22 29 AM" src="https://user-images.githubusercontent.com/71795832/145777794-143ad637-e913-4844-aa5b-8b3f6192f7c7.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
