### PR TITLE
Spiffier UI: Fix tabs spacing

### DIFF
--- a/cypress/integration/all/app/activateuser.spec.ts
+++ b/cypress/integration/all/app/activateuser.spec.ts
@@ -7,6 +7,7 @@ describe("User invite and activation", () => {
 
   it("Invites and activates a user", () => {
     cy.visit("/settings/organization");
+    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
 
     cy.findByRole("tab", { name: /^users$/i }).click();
 

--- a/cypress/integration/free/maintainer.spec.ts
+++ b/cypress/integration/free/maintainer.spec.ts
@@ -114,6 +114,7 @@ describe(
 
       // Packs pages: Can create, edit, delete a pack
       cy.visit("/packs/manage");
+      cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
 
       cy.findByRole("button", { name: /create new pack/i }).click();
 

--- a/frontend/components/TabsWrapper/_styles.scss
+++ b/frontend/components/TabsWrapper/_styles.scss
@@ -9,19 +9,20 @@
       border-bottom: 1px solid $ui-gray;
     }
     &__tab {
-      padding-bottom: $pad-small;
+      padding: $pad-small 0;
+      margin-right: $pad-xxlarge;
       font-size: $x-small;
       border: none;
-      
+
       &:focus {
         box-shadow: none;
         outline: 0;
       }
       &--selected {
         text-shadow: -0.3px 0 #192147, 0.3px 0 #192147;
-  
+
         &::after {
-          content: '';
+          content: "";
           width: 100%;
           height: 0;
           border-bottom: 1px solid #6a67fe;
@@ -51,7 +52,7 @@
         margin-top: $pad-xxlarge;
         font-size: $small;
         font-weight: $bold;
-  
+
         span {
           margin-top: $pad-medium;
           font-size: $x-small;


### PR DESCRIPTION
Cerra #3295

Tabs styling matches Figma:
- 40 px spacing between tab labels
- Tab labels do not have padding around them (aligning label name left and purple underline same length as label name)

Screenshot:
<img width="1131" alt="Screen Shot 2021-12-13 at 12 38 51 AM" src="https://user-images.githubusercontent.com/71795832/145779570-44d09b9f-abf1-4109-b314-3c3c382f5017.png">



- [x] Manual QA for all new/changed functionality
