### PR TITLE
Fix team packs rego policy rules

### DIFF
--- a/changes/issue-3353-team-packs-rego-rules
+++ b/changes/issue-3353-team-packs-rego-rules
@@ -1,0 +1,1 @@
+* Fix rego rules for team members and packs.

--- a/changes/issue-3353-team-packs-rego-rules
+++ b/changes/issue-3353-team-packs-rego-rules
@@ -1,1 +1,1 @@
-* Fix rego rules for team members and packs.
+* Fleet Premium: Fix permissions to prevent team observers from editing packs.

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -362,15 +362,10 @@ allow {
 # Packs
 ##
 
-# Global admins and maintainers and team maintainers can read/write packs
+# Global admins and maintainers can read/write all packs
 allow {
   object.type == "pack"
-  subject.global_role == admin
-  action == [read, write][_]
-}
-allow {
-  object.type == "pack"
-  subject.global_role == maintainer
+  subject.global_role == [admin,maintainer][_]
   action == [read, write][_]
 }
 
@@ -382,11 +377,10 @@ allow {
   action == read
 }
 
-# Team admins and maintainers can read their team packs
+# Team admins and maintainers can read/write their team packs
 allow {
-  object.team_ids[_] == subject.teams[_].id
   object.type == "pack"
-  team_role(subject, subject.teams[_].id) == [admin,maintainer][_]
+  team_role(subject, object.team_ids[_]) == [admin,maintainer][_]
   action == [read, write][_]
 }
 

--- a/server/authz/policy_test.go
+++ b/server/authz/policy_test.go
@@ -450,6 +450,79 @@ func TestAuthorizePacks(t *testing.T) {
 	})
 }
 
+func TestAuthorizeTeamPacks(t *testing.T) {
+	t.Parallel()
+
+	runTestCases(t, []authTestCase{
+		// Team maintainer can read packs of the team.
+		{
+			user: test.UserTeamMaintainerTeam1,
+			object: &fleet.Pack{
+				TeamIDs: []uint{1},
+			},
+			action: read,
+			allow:  true,
+		},
+		// Team observer cannot read packs of the team.
+		{
+			user: test.UserTeamObserverTeam1TeamAdminTeam2,
+			object: &fleet.Pack{
+				TeamIDs: []uint{1},
+			},
+			action: read,
+			allow:  false,
+		},
+		// Team observer cannot write packs of the team.
+		{
+			user: test.UserTeamObserverTeam1TeamAdminTeam2,
+			object: &fleet.Pack{
+				TeamIDs: []uint{1},
+			},
+			action: write,
+			allow:  false,
+		},
+		// Members of a team cannot read packs of another team.
+		{
+			user: test.UserTeamAdminTeam1,
+			object: &fleet.Pack{
+				TeamIDs: []uint{2},
+			},
+			action: read,
+			allow:  false,
+		},
+		// Members of a team cannot read packs of another team.
+		{
+			user: test.UserTeamAdminTeam1,
+			object: &fleet.Pack{
+				TeamIDs: []uint{2},
+			},
+			action: read,
+			allow:  false,
+		},
+		// Team maintainers can read global packs.
+		{
+			user:   test.UserTeamMaintainerTeam1,
+			object: &fleet.Pack{},
+			action: read,
+			allow:  true,
+		},
+		// Team admins can read global packs.
+		{
+			user:   test.UserTeamAdminTeam1,
+			object: &fleet.Pack{},
+			action: read,
+			allow:  true,
+		},
+		// Team admins cannot write global packs.
+		{
+			user:   test.UserTeamAdminTeam1,
+			object: &fleet.Pack{},
+			action: write,
+			allow:  false,
+		},
+	})
+}
+
 func TestAuthorizeCarves(t *testing.T) {
 	t.Parallel()
 

--- a/server/test/users.go
+++ b/server/test/users.go
@@ -75,4 +75,17 @@ var (
 			},
 		},
 	}
+	UserTeamObserverTeam1TeamAdminTeam2 = &fleet.User{
+		ID: 11,
+		Teams: []fleet.UserTeam{
+			{
+				Team: fleet.Team{ID: 1},
+				Role: fleet.RoleObserver,
+			},
+			{
+				Team: fleet.Team{ID: 2},
+				Role: fleet.RoleAdmin,
+			},
+		},
+	}
 )


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added (for user-visible changes)
~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
~- [ ] Documented any permissions changes~
- [X] Added/updated tests
- [ ] Manual QA for all new/changed functionality

This change cannot be tested with the browser because it looks like team admins cannot see packs at all? (Not sure if a bug or expected behavior):

Currently logged in user is admin of t1, t1 has a pack, but it's not allowing listing the packs ("advanced" option):

![Screen Shot 2021-12-13 at 19 24 57](https://user-images.githubusercontent.com/2073526/145898664-da851b71-a4bf-4ca8-a781-88b26c445f51.png)

