### PR TITLE
Manage Queries Page: No queries does not show create new query cta for observers

### DIFF
--- a/changes/issue-3157-observers-cannot-see-create-new-query
+++ b/changes/issue-3157-observers-cannot-see-create-new-query
@@ -1,0 +1,1 @@
+* No queries UI hides the Create new query button from global and team observers

--- a/cypress/integration/all/app/activateuser.spec.ts
+++ b/cypress/integration/all/app/activateuser.spec.ts
@@ -63,6 +63,7 @@ describe("User invite and activation", () => {
     cy.login();
 
     cy.visit("/settings/organization");
+    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
 
     cy.findByRole("tab", { name: /^users$/i }).click();
 

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -240,6 +240,7 @@ const ManageQueriesPage = (): JSX.Element => {
               searchable={!!queriesList}
               customControl={renderPlatformDropdown}
               selectedDropdownFilter={selectedDropdownFilter}
+              isOnlyObserver={isOnlyObserver}
             />
           )}
         </div>

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesListWrapper.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesListWrapper.tsx
@@ -23,6 +23,7 @@ interface IQueriesListWrapperProps {
   searchable: boolean;
   customControl?: () => JSX.Element;
   selectedDropdownFilter: string;
+  isOnlyObserver?: boolean;
 }
 
 const QueriesListWrapper = ({
@@ -33,6 +34,7 @@ const QueriesListWrapper = ({
   searchable,
   customControl,
   selectedDropdownFilter,
+  isOnlyObserver,
 }: IQueriesListWrapperProps): JSX.Element | null => {
   const { currentUser } = useContext(AppContext);
   const [searchString, setSearchString] = useState<string>("");
@@ -52,20 +54,24 @@ const QueriesListWrapper = ({
                 <p>
                   A query is a specific question you can ask about your devices.
                 </p>
-                <p>
-                  Create a new query, or go to GitHub to{" "}
-                  <a href="https://fleetdm.com/docs/using-fleet/standard-query-library">
-                    import Fleet’s standard query library
-                  </a>
-                  .
-                </p>
-                <Button
-                  variant="brand"
-                  className={`${baseClass}__create-button`}
-                  onClick={onCreateQueryClick}
-                >
-                  Create new query
-                </Button>
+                {!isOnlyObserver && (
+                  <>
+                    <p>
+                      Create a new query, or go to GitHub to{" "}
+                      <a href="https://fleetdm.com/docs/using-fleet/standard-query-library">
+                        import Fleet’s standard query library
+                      </a>
+                      .
+                    </p>
+                    <Button
+                      variant="brand"
+                      className={`${baseClass}__create-button`}
+                      onClick={onCreateQueryClick}
+                    >
+                      Create new query
+                    </Button>
+                  </>
+                )}
               </>
             ) : (
               <>


### PR DESCRIPTION
Cerra #3157 

New NoQueries UI for global or team observers that have no queries (matches updated Figma):
<img width="1117" alt="Screen Shot 2021-12-13 at 3 17 56 PM" src="https://user-images.githubusercontent.com/71795832/145904806-f84a648a-1a3d-45da-91ff-c95dc792a792.png">

Default NoQueries UI for admin and maintainers:
<img width="1117" alt="Screen Shot 2021-12-13 at 3 18 17 PM" src="https://user-images.githubusercontent.com/71795832/145904865-90a35419-7d86-406d-89b6-5b73d24e9f04.png">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
