### PR TITLE
Policy Details/Query Details: No hover state if policy/query is not editable by RBAC

### DIFF
--- a/changes/issue-3321-spiffier-no-hover-if-not-editable
+++ b/changes/issue-3321-spiffier-no-hover-if-not-editable
@@ -1,0 +1,1 @@
+* No hover state for query or policy details if RBAC does not allow editing

--- a/cypress/integration/free/maintainer.spec.ts
+++ b/cypress/integration/free/maintainer.spec.ts
@@ -128,6 +128,7 @@ describe(
       cy.findByRole("button", { name: /save query pack/i }).click();
 
       cy.visit("/packs/manage");
+      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
 
       cy.get(".fleet-checkbox__input").check({ force: true });
 

--- a/cypress/integration/premium/admin.spec.ts
+++ b/cypress/integration/premium/admin.spec.ts
@@ -216,6 +216,8 @@ describe(
         // On the Settings pages, they should…
         // See the “Teams” navigation item and access the Settings - Teams page
         cy.visit("/settings/organization");
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+
         cy.get(".react-tabs").within(() => {
           cy.findByText(/teams/i).click();
         });
@@ -236,6 +238,8 @@ describe(
         // On the Profile page, they should…
         // See Global in the Team section and Admin in the Role section
         cy.visit("/profile");
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+
         cy.findByText(/team/i)
           .next()
           .contains(/global/i);

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
@@ -46,15 +46,10 @@
         margin: $pad-large 0;
         line-height: 2rem;
         height: 2rem;
-        cursor: pointer;
       }
       .policy-form__policy-resolve,
       .resolve-text-wrapper {
         margin-top: $pad-large;
-      }
-      .policy-form__policy-description:not(textarea),
-      .policy-form__policy-resolution-button:not(textarea) {
-        cursor: pointer;
       }
       #policy-description {
         height: 38px;

--- a/frontend/pages/queries/QueryPage/components/QueryForm/_styles.scss
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/_styles.scss
@@ -46,11 +46,9 @@
         margin-top: $pad-large;
         line-height: 2rem;
         height: 2rem;
-        cursor: pointer;
       }
       .query-form__query-description:not(textarea) {
         margin: 0.25rem 0 1rem;
-        cursor: pointer;
       }
       textarea.query-form__query-description {
         margin-top: 0.8125rem;


### PR DESCRIPTION
Cerra #3321 

- Remove superfluous cursor: pointer because it's already defined with:
`&:hover:not(.focus-visible):not(.no-hover) {
      color: $core-vibrant-blue;
      cursor: pointer;
    }`

- UI Fix: No hover state for query details if RBAC does not allow editing query
- UI Fix: No hover state for policy details if RBAC does not allow editing policy

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
~~- [ ] Added/updated tests~~
- [x] Manual QA for all new/changed functionality
