### PR TITLE
Exclude old data migration from the migrations check

### DIFF
--- a/changes/issue-3371-ignore-old-data-migration
+++ b/changes/issue-3371-ignore-old-data-migration
@@ -1,0 +1,1 @@
+* Ignore old data migration to avoid showing a warning message on old installations of fleet.

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -401,7 +401,12 @@ var (
 		// timestamp was changed in fleet-v4.4.1.
 		20210924114500: {},
 	}
-	knownUnknownDataMigrations = map[int64]struct{}{}
+	knownUnknownDataMigrations = map[int64]struct{}{
+		// This migration was present in 2.0.0, and was removed on a subsequent release.
+		// Was basically running `DELETE FROM packs WHERE deleted = 1`, (such `deleted`
+		// column doesn't exist anymore).
+		20171212182459: {},
+	}
 )
 
 func unknownUnknowns(in []int64, knownUnknowns map[int64]struct{}) []int64 {


### PR DESCRIPTION
#3371

- [X] Changes file added (for user-visible changes)
~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality

Tested by manually inserting the old data migration (`insert into migration_status_data (version_id, is_applied) VALUES (20171212182459, 1);`).

I don't think this requires a point release, as `serve`/`prepare` are only showing a warning message (it only exits if running with `--dev`).
