### PR TITLE
E2e tests failing: Fix 2 recent e2e detached doms

### DIFF
--- a/cypress/integration/all/app/resetsessions.spec.ts
+++ b/cypress/integration/all/app/resetsessions.spec.ts
@@ -8,6 +8,7 @@ describe("Reset user sessions flow", () => {
   it("Resets a user's API tokens", () => {
     // visit user's profile page and get current API token
     cy.visit("/profile");
+    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
 
     cy.findByRole("button", { name: /get api token/i }).click();
     cy.findByText(/reveal token/i).click();
@@ -17,6 +18,7 @@ describe("Reset user sessions flow", () => {
 
     // reset user sessions via the admin user management page
     cy.visit("/settings/users");
+    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
 
     // first select the table cell with the user's email address then go back up to the containing row
     // so we can select reset sessions from actions dropdown
@@ -37,6 +39,8 @@ describe("Reset user sessions flow", () => {
     cy.login();
 
     cy.visit("/profile");
+    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+
     cy.findByRole("button", { name: /get api token/i }).click();
     cy.findByText(/reveal token/i).click();
     cy.get(".user-settings__secret-input").within(() => {

--- a/cypress/integration/free/admin.spec.ts
+++ b/cypress/integration/free/admin.spec.ts
@@ -116,6 +116,7 @@ describe(
       // On the Settings pages, they should…
       // See everything except for the “Teams” pages
       cy.visit("/settings/organization");
+      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.findByText(/teams/i).should("not.exist");
       cy.get(".react-tabs").within(() => {
         cy.findByText(/organization settings/i).should("exist");
@@ -129,6 +130,7 @@ describe(
       // On the Profile page, they should…
       // See Admin in Role section, and no Team section
       cy.visit("/profile");
+      cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.findByText(/teams/i).should("not.exist");
       cy.findByText("Role").next().contains(/admin/i);
     });

--- a/cypress/integration/premium/admin.spec.ts
+++ b/cypress/integration/premium/admin.spec.ts
@@ -219,6 +219,8 @@ describe(
         cy.get(".react-tabs").within(() => {
           cy.findByText(/teams/i).click();
         });
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+
         // Access the Settings - Team details page
         cy.findByText(/apples/i).click();
         cy.findByText(/apples/i).should("exist");


### PR DESCRIPTION
Sifted through failing e2e tests on recent (non front end) commits on main and recent pull requests and added waits for any detached dom issues.

- 1 sec waits on resetsessions.spec.ts
- 1 sec wait on free/admin.spec.ts
- 1 sec wait on premium/admin.spec.ts

Per @lukeheath and my conversation yesterday, this is a temporary solution until we have the time to explore using as and more variable waits.

2 solutions in this article:
https://www.cypress.io/blog/2020/07/22/do-not-get-too-detached/

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

~~- [ ] Changes file added (for user-visible changes)~~
~~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
~~- [ ] Documented any permissions changes~~
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
