### PR TITLE
update DRIs

### DIFF
--- a/handbook/product.md
+++ b/handbook/product.md
@@ -7,14 +7,17 @@ Below is a table of [directly responsible individuals (DRIs)](./people.md#direct
 | Wireframes (figma)	 										| Noah Talerman	|
 | How the product works 										| Noah Talerman |
 | fleetctl CLI interface (and other tools) 						| Tomás Touceda |
-| REST API interface, REST API docs 							| Luke Heath	|
-| Postman 											| Ben Edwards (transitioning to Luke Heath) 	|
+| REST API interface design 							| Luke Heath	|
+| [REST API docs](https://fleetdm.com/docs/using-fleet/rest-api) | Luke Heath | 
+| Postman 											| Luke Heath 	|
 | Terraform 											| Ben Edwards 	|
-| Customer deployments like acme.fleetdm.com 				| Ben Edwards 	|
+| Customer PoV deployments like acme.fleetdm.com 				| Ben Edwards 	|
 | dogfood.fleetdm.com 											| Ben Edwards  	|
 | Quality of core product UI 									| Luke Heath 	|
 | Quality of tickets after Noah's done with them   				| Luke Heath 	|
-| Quality of core product API 									| Tomás Touceda |
+| ["Escaped work"](https://docs.google.com/document/d/1vXL_WSUqASJWuNnQhUVrkudIeG4zlaiOCqJEa7xB2do/edit) | Luke Heath |
+| Customer Slack channels | Tony Gauda |
+| Quality of core product backend 									| Tomás Touceda |
 | Quality of fleetctl (and other tools)							| Tomás Touceda |
 | Final cut of what goes into each release 						| Zach Wasserman|
 | When we cut a release, version numbers, and whether to release| Zach Wasserman|


### PR DESCRIPTION
update DRIs to cover "escaped work", add tony as DRI of customer slack channels based on today's conversation, etc