### PR TITLE
Fix bug in target selector UI

### DIFF
--- a/changes/issue-3047-cancel-select-targets
+++ b/changes/issue-3047-cancel-select-targets
@@ -1,0 +1,2 @@
+* Fix UI bug in target selector for query editor and policy editor where cancel button did not reset
+selected targets

--- a/frontend/pages/policies/PolicyPage/screens/SelectTargets.tsx
+++ b/frontend/pages/policies/PolicyPage/screens/SelectTargets.tsx
@@ -182,6 +182,11 @@ const SelectTargets = ({
     }
   );
 
+  const handleClickCancel = () => {
+    setSelectedTargets([]);
+    goToQueryEditor();
+  };
+
   const handleSelectedLabels = (entity: ILabel | ITeam) => (
     e: React.MouseEvent<HTMLButtonElement>
   ): void => {
@@ -318,7 +323,7 @@ const SelectTargets = ({
       <div className={`${baseClass}__targets-button-wrap`}>
         <Button
           className={`${baseClass}__btn`}
-          onClick={goToQueryEditor}
+          onClick={handleClickCancel}
           variant="text-link"
         >
           Cancel

--- a/frontend/pages/queries/QueryPage/screens/SelectTargets.tsx
+++ b/frontend/pages/queries/QueryPage/screens/SelectTargets.tsx
@@ -99,7 +99,6 @@ const SelectTargets = ({
   goToRunQuery,
   setSelectedTargets,
 }: ISelectTargetsProps) => {
-  console.log("selectedTargets: ", selectedTargets);
   const [targetsTotalCount, setTargetsTotalCount] = useState<number | null>(
     null
   );

--- a/frontend/pages/queries/QueryPage/screens/SelectTargets.tsx
+++ b/frontend/pages/queries/QueryPage/screens/SelectTargets.tsx
@@ -99,6 +99,7 @@ const SelectTargets = ({
   goToRunQuery,
   setSelectedTargets,
 }: ISelectTargetsProps) => {
+  console.log("selectedTargets: ", selectedTargets);
   const [targetsTotalCount, setTargetsTotalCount] = useState<number | null>(
     null
   );
@@ -189,6 +190,11 @@ const SelectTargets = ({
       },
     }
   );
+
+  const handleClickCancel = () => {
+    setSelectedTargets([]);
+    goToQueryEditor();
+  };
 
   const handleSelectedLabels = (selectedLabel: ISelectTargetsEntity) => (
     e: React.MouseEvent<HTMLButtonElement>
@@ -330,7 +336,7 @@ const SelectTargets = ({
       <div className={`${baseClass}__targets-button-wrap`}>
         <Button
           className={`${baseClass}__btn`}
-          onClick={goToQueryEditor}
+          onClick={handleClickCancel}
           variant="text-link"
         >
           Cancel


### PR DESCRIPTION
Issue #3407

Fix UI bug in target selector for query editor and policy editor where cancel button did not reset selected targets

# Checklist for submitter
- [x] Changes file added (for user-visible changes)
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
