### PR TITLE
Use id instead of seen time/created_at to sort hosts

### DIFF
--- a/changes/use-index-for-sorting-hosts
+++ b/changes/use-index-for-sorting-hosts
@@ -1,0 +1,1 @@
+* Improve performance of sorting hosts in certain scenarios.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -816,7 +816,7 @@ func (d *Datastore) SearchHosts(ctx context.Context, filter fleet.TeamFilter, qu
 	args = append(args, in)
 	sqlb.WriteString(" id NOT IN (?) AND ")
 	sqlb.WriteString(d.whereFilterHostsByTeams(filter, "h"))
-	sqlb.WriteString(` ORDER BY COALESCE(hst.seen_time, h.created_at) DESC LIMIT 10`)
+	sqlb.WriteString(` ORDER BY h.id DESC LIMIT 10`)
 
 	sql, args, err := sqlx.In(sqlb.String(), args...)
 	if err != nil {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -1017,6 +1017,13 @@ func testHostsSearch(t *testing.T, ds *Datastore) {
 	assert.Nil(t, err)
 	require.Len(t, hosts, 1)
 	assert.Equal(t, hosts[0].ID, h2.ID)
+
+	// sorted by ids desc
+	filter = fleet.TeamFilter{User: userObs, IncludeObserver: true}
+	hits, err = ds.SearchHosts(context.Background(), filter, "")
+	require.NoError(t, err)
+	assert.Len(t, hits, 3)
+	assert.Equal(t, []uint{h3.ID, h2.ID, h1.ID}, []uint{hits[0].ID, hits[1].ID, hits[2].ID})
 }
 
 func testHostsSearchLimit(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- ~Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
- ~Documented any permissions changes~
- ~Added/updated tests~
- [x] Manual QA for all new/changed functionality
