### PR TITLE
Fix mdm direct query ingestion for non-mdm hosts

### DIFF
--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -655,8 +655,8 @@ func directIngestMDM(ctx context.Context, logger log.Logger, host *fleet.Host, d
 		return ctxerr.Wrap(ctx, err, "parsing enrolled")
 	}
 	if !enrolled {
-		// TODO(lucas): Do we want to create a host_mdm entry when enrolled is false?
-		// When enrolled is false, all other columns are empty.
+		// A row with enrolled=false and all other columns empty is a host with the osquery
+		// MDM table extensions installed (e.g. Orbit) but MDM unconfigured/disabled.
 		return nil
 	}
 	installedFromDep, err := strconv.ParseBool(rows[0]["installed_from_dep"])

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -646,14 +646,22 @@ func directIngestMDM(ctx context.Context, logger log.Logger, host *fleet.Host, d
 		logger.Log("component", "service", "method", "ingestMDM", "warn",
 			fmt.Sprintf("mdm expected single result got %d", len(rows)))
 	}
-
+	enrolledVal := rows[0]["enrolled"]
+	if enrolledVal == "" {
+		return ctxerr.Wrap(ctx, fmt.Errorf("missing mdm.enrolled value: %d", host.ID))
+	}
+	enrolled, err := strconv.ParseBool(enrolledVal)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "parsing enrolled")
+	}
+	if !enrolled {
+		// TODO(lucas): Do we want to create a host_mdm entry when enrolled is false?
+		// When enrolled is false, all other columns are empty.
+		return nil
+	}
 	installedFromDep, err := strconv.ParseBool(rows[0]["installed_from_dep"])
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "parsing installed_from_dep")
-	}
-	enrolled, err := strconv.ParseBool(rows[0]["enrolled"])
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "parsing enrolled")
 	}
 
 	return ds.SetOrUpdateMDMData(ctx, host.ID, enrolled, rows[0]["server_url"], installedFromDep)

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -1,6 +1,7 @@
 package osquery_utils
 
 import (
+	"context"
 	"encoding/json"
 	"sort"
 	"testing"
@@ -300,4 +301,20 @@ func TestGetDetailQueries(t *testing.T) {
 	require.Len(t, queriesWithUsersAndSoftware, 16)
 	sortedKeysCompare(t, queriesWithUsersAndSoftware,
 		append(baseQueries, "users", "software_macos", "software_linux", "software_windows"))
+}
+
+func TestDirectIngestMDM(t *testing.T) {
+	var host fleet.Host
+
+	err := directIngestMDM(context.Background(), log.NewNopLogger(), &host, nil, []map[string]string{}, true)
+	require.NoError(t, err)
+
+	err = directIngestMDM(context.Background(), log.NewNopLogger(), &host, nil, []map[string]string{
+		{
+			"enrolled":           "false",
+			"installed_from_dep": "",
+			"server_url":         "",
+		},
+	}, false)
+	require.NoError(t, err)
 }

--- a/server/service/service_osquery.go
+++ b/server/service/service_osquery.go
@@ -760,7 +760,7 @@ func (svc *Service) SubmitDistributedQueryResults(
 		}
 
 		if err != nil {
-			logging.WithErr(ctx, ctxerr.New(ctx, "error in live query ingestion"))
+			logging.WithErr(ctx, ctxerr.New(ctx, "error in query ingestion"))
 			logging.WithExtras(ctx, "ingestion-err", err)
 		}
 	}


### PR DESCRIPTION
This PR is fixing the following error in the logs for my workstation host:
```
level=error ts=2021-12-23T14:27:54.444168Z component=http method=POST uri=/api/v1/osquery/distributed/write took=992.098084ms ip_addr=[::1]:58628 x_for_ip_addr=127.0.0.1
ingestion-err="ingesting query mdm: parsing installed_from_dep: 
timestamp: 2021-12-23T11:27:53-03:00: strconv.ParseBool: parsing \"\": invalid syntax" err="timestamp: 2
021-12-23T11:27:53-03:00: error in live query ingestion"
```

~- [ ] Changes file added (for user-visible changes)~
~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
~- [ ] Documented any permissions changes~
- [ ] Added/updated tests
- [X] Manual QA for all new/changed functionality
