### PR TITLE
Fix TestPackage version

### DIFF
--- a/cmd/fleetctl/package_test.go
+++ b/cmd/fleetctl/package_test.go
@@ -25,12 +25,12 @@ func TestPackage(t *testing.T) {
 	// run package tests, each should output their respective package type
 	// fleet-osquery_0.0.3_amd64.deb
 	runAppForTest(t, []string{"package", "--type=deb", "--insecure"})
-	info, err := os.Stat("fleet-osquery_0.0.3_amd64.deb")
+	info, err := os.Stat("fleet-osquery_0.0.5_amd64.deb")
 	require.NoError(t, err)
 	require.Greater(t, info.Size(), int64(0)) // TODO verify contents
 	// fleet-osquery-0.0.3.x86_64.rpm
 	runAppForTest(t, []string{"package", "--type=rpm", "--insecure"})
-	info, err = os.Stat("fleet-osquery-0.0.3.x86_64.rpm")
+	info, err = os.Stat("fleet-osquery-0.0.5.x86_64.rpm")
 	require.NoError(t, err)
 	require.Greater(t, info.Size(), int64(0)) // TODO verify contents
 	// fleet-osquery.msi


### PR DESCRIPTION
```
=== RUN   TestPackage
2021/12/23 12:41:06 root pinning is not supported in Spec 1.0.19
DEPRECATION WARNING: 'empty_folders' is deprecated and will be removed in a future version, create content with type 'dir' and directoy name as 'dst' instead
    package_test.go:29:
                Error Trace:    package_test.go:29
                Error:          Received unexpected error:
                                stat fleet-osquery_0.0.3_amd64.deb: no such file or directory
                Test:           TestPackage
--- FAIL: TestPackage (98.21s)
```

Didn't find a good place (package) to define the current version (looks like we use goreleaser to set the version?)

~- [ ] Changes file added (for user-visible changes)~
~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
~- [ ] Documented any permissions changes~
- [X] Added/updated tests
~- [ ] Manual QA for all new/changed functionality~
