### PR TITLE
Allow hosts to check in even if Redis is down

### DIFF
--- a/changes/issue-3503-if-redis-down-host-can-check-in
+++ b/changes/issue-3503-if-redis-down-host-can-check-in
@@ -1,0 +1,1 @@
+* Allow hosts to check in even if Redis is down.


### PR DESCRIPTION
#3503

- [X] Changes file added (for user-visible changes)
~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
~- [ ] Documented any permissions changes~
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
