### PR TITLE
Spiffier UI: Allow opening nav items in new tab

### DIFF
--- a/changes/issue-340-nav-open-new-tab
+++ b/changes/issue-340-nav-open-new-tab
@@ -1,0 +1,1 @@
+* Nav items can be opened in a new tab or window

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -69,7 +69,7 @@ describe(
 
         // Go to host details page
         cy.location("pathname").should("match", /hosts\/[0-9]/i);
-        cy.get("span.status").should("contain", /online/i);
+        cy.getAttached("span.status").should("contain", /online/i);
 
         // Run policy on host
         let policyname = "";

--- a/frontend/components/side_panels/SiteTopNav/SiteTopNav.jsx
+++ b/frontend/components/side_panels/SiteTopNav/SiteTopNav.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { Link } from "react-router";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 
@@ -50,12 +51,12 @@ class SiteTopNav extends Component {
     if (iconName === "logo") {
       return (
         <li className={navItemClasses} key={`nav-item-${name}`}>
-          <a
+          <Link
             className={`${navItemBaseClass}__link`}
-            href={navItem.location.pathname}
+            to={navItem.location.pathname}
           >
             <OrgLogoIcon className="logo" src={orgLogoURL} />
-          </a>
+          </Link>
         </li>
       );
     }
@@ -81,9 +82,9 @@ class SiteTopNav extends Component {
 
     return (
       <li className={navItemClasses} key={`nav-item-${name}`}>
-        <a
+        <Link
           className={`${navItemBaseClass}__link`}
-          href={navItem.location.pathname}
+          to={navItem.location.pathname}
         >
           {icon}
           <span
@@ -92,7 +93,7 @@ class SiteTopNav extends Component {
           >
             {name}
           </span>
-        </a>
+        </Link>
       </li>
     );
   };

--- a/frontend/components/side_panels/SiteTopNav/SiteTopNav.jsx
+++ b/frontend/components/side_panels/SiteTopNav/SiteTopNav.jsx
@@ -35,7 +35,6 @@ class SiteTopNav extends Component {
   renderNavItem = (navItem) => {
     const { name, iconName } = navItem;
     const {
-      onNavItemClick,
       pathname,
       config: { org_logo_url: orgLogoURL },
     } = this.props;
@@ -53,7 +52,7 @@ class SiteTopNav extends Component {
         <li className={navItemClasses} key={`nav-item-${name}`}>
           <a
             className={`${navItemBaseClass}__link`}
-            onClick={onNavItemClick(navItem.location.pathname)}
+            href={navItem.location.pathname}
           >
             <OrgLogoIcon className="logo" src={orgLogoURL} />
           </a>
@@ -84,7 +83,7 @@ class SiteTopNav extends Component {
       <li className={navItemClasses} key={`nav-item-${name}`}>
         <a
           className={`${navItemBaseClass}__link`}
-          onClick={onNavItemClick(navItem.location.pathname)}
+          href={navItem.location.pathname}
         >
           {icon}
           <span

--- a/frontend/components/side_panels/SiteTopNav/_styles.scss
+++ b/frontend/components/side_panels/SiteTopNav/_styles.scss
@@ -67,6 +67,7 @@
     display: flex;
     align-items: center;
     padding: 14px 20px 17px;
+    text-decoration: none;
   }
 
   &--active {


### PR DESCRIPTION
Customer Request, closes #430 

- Control + click (or right click) opens option to opened nav items on a new tab or new window
- Command + click opens in a new tab

Tested on Chrome and Firefox:
<img width="1349" alt="Screen Shot 2021-12-28 at 12 56 24 PM" src="https://user-images.githubusercontent.com/71795832/147593916-f4362581-3081-4614-b1a9-a980e0498b98.png">
<img width="1204" alt="Screen Shot 2021-12-28 at 1 01 44 PM" src="https://user-images.githubusercontent.com/71795832/147594110-7bb5e3fc-6341-4302-95aa-81a3875a5577.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
