### PR TITLE
Add no-hosts option to `fleetctl preview`

### DIFF
--- a/handbook/product.md
+++ b/handbook/product.md
@@ -73,9 +73,11 @@ The images used in the docs live in `docs/images/`. Note that you must provide t
 
 Fleet uses a human-oriented quality assurance (QA) process to ensure the product meets the standards of users and organizations.
 
-To try stuff out with Fleet locally for QA purposes, you can run `fleetctl preview`, which defaults to running the latest stable release.
+To try Fleet locally for QA purposes, run `fleetctl preview`, which defaults to running the latest stable release.
 
-To target a different version of Fleet, you can use the `--tag` argument to target any tag in [Docker Hub](https://hub.docker.com/r/fleetdm/fleet/tags?page=1&ordering=last_updated), including any git commit hash or branch name.  For example, to QA the latest code on the `main` branch of fleetdm/fleet, you can run: `fleetctl preview --tag='main'`
+To target a different version of Fleet, use the `--tag` flag to target any tag in [Docker Hub](https://hub.docker.com/r/fleetdm/fleet/tags?page=1&ordering=last_updated), including any git commit hash or branch name.  For example, to QA the latest code on the `main` branch of fleetdm/fleet, you can run: `fleetctl preview --tag=main`
+
+To start preview without starting the simulated hosts, use the `--no-hosts` flag (eg. `fleetctl preview --no-hosts`).
 
 ### Why human-oriented QA?
 


### PR DESCRIPTION
Intended mostly for testing, this is documented only in the Fleet
handbook.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

~- [ ] Changes file added (for user-visible changes)~
~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Added/updated tests~
- [x] Manual QA for all new/changed functionality
