### PR TITLE
Add integration test for fleetctl preview

### DIFF
--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -1,18 +1,21 @@
-name: Integration test
+name: Test fleetctl preview
 
 on:
-  workflow_dispatch:
   pull_request:
+  workflow_dispatch:
+  schedule:
+  - cron: '0 2 * * *' # Nightly 2AM UTC
 
 jobs:
-  run-preview:
+  test-preview:
     strategy:
       matrix:
         # Doesn't work on Windows because Linux Docker containers are not supported.
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, ubuntu-18.04, macos-10.15, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Docker
+      # Docker needs to be installed manually on macOS.
       if: matrix.os == 'macos-latest'
       # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
       run: |
@@ -29,7 +32,7 @@ jobs:
         lt --port 1337 &
         sleep 5
 
-    - name: Start Fleet server
+    - name: Test fleetctl preview
       timeout-minutes: 60
       run: |
         npm install -g fleetctl

--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -2,12 +2,13 @@ name: Test fleetctl preview
 
 on:
   pull_request:
-  workflow_dispatch:
+  workflow_dispatch: # Manual
   schedule:
   - cron: '0 2 * * *' # Nightly 2AM UTC
 
 jobs:
   test-preview:
+    timeout-minutes: 60
     strategy:
       matrix:
         # Doesn't work on Windows because Linux Docker containers are not supported.
@@ -16,7 +17,7 @@ jobs:
     steps:
     - name: Install Docker
       # Docker needs to be installed manually on macOS.
-      if: matrix.os == 'macos-latest'
+      if: contains(matrix.os, 'macos')
       # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
       run: |
         brew install --cask docker
@@ -33,7 +34,6 @@ jobs:
         sleep 5
 
     - name: Test fleetctl preview
-      timeout-minutes: 60
       run: |
         npm install -g fleetctl
         fleetctl preview

--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -1,7 +1,6 @@
 name: Test fleetctl preview
 
 on:
-  pull_request:
   workflow_dispatch: # Manual
   schedule:
   - cron: '0 2 * * *' # Nightly 2AM UTC

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,4 +24,4 @@ jobs:
         fleetctl preview
         fleetctl get hosts | tee hosts.txt
         [ $( cat hosts.txt | grep online | wc -l) -eq 8 ]
-
+      shell: bash

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Start tunnel
       run: |
         npm install -g localtunnel
-        lt --port 8080 &
+        lt --port 1337 &
         sleep 5
 
     - name: Start Fleet server

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,3 +19,6 @@ jobs:
       run: |
         npm install -g fleetctl
         fleetctl preview
+        fleetctl get hosts | tee hosts.txt
+        [ $( cat hosts.txt | grep online | wc -l) -eq 8 ]
+

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,21 @@
+name: Integration test
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  run-preview:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Start tunnel
+      run: |
+        npm install -g localtunnel
+        lt --port 8080 &
+        sleep 5
+
+    - name: Start Fleet server
+      timeout-minutes: 60
+      run: |
+        npm install -g fleetctl
+        fleetctl preview

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   run-preview:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Start tunnel
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,9 +8,21 @@ jobs:
   run-preview:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        # Doesn't work on Windows because Linux Docker containers are not supported.
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Install Docker
+      if: matrix.os == 'macos-latest'
+      # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
+      run: |
+        brew install --cask docker
+        sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
+        open -a /Applications/Docker.app --args --unattended --accept-license
+        echo "Waiting for Docker to start up..."
+        while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do sleep 1; done
+        echo "Docker is ready."
+
     - name: Start tunnel
       run: |
         npm install -g localtunnel
@@ -22,6 +34,7 @@ jobs:
       run: |
         npm install -g fleetctl
         fleetctl preview
+        sleep 10
         fleetctl get hosts | tee hosts.txt
         [ $( cat hosts.txt | grep online | wc -l) -eq 8 ]
       shell: bash


### PR DESCRIPTION
Add nightly and manual job to run `fleetctl preview` and check for enrolled hosts.

Works on macOS and Linux. Windows cannot be tested on GitHub Actions due to lack of Docker Linux support.