### PR TITLE
Make Linux postinstall more permissive

### DIFF
--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -225,10 +225,10 @@ var postInstallTemplate = template.Must(template.New("postinstall").Parse(`
 set -e
 
 # If we have a systemd, daemon-reload away now
-if [ -x /bin/systemctl ] && pidof systemd ; then
-  /bin/systemctl daemon-reload 2>/dev/null 2>&1
+if which systemctl; then
+  systemctl daemon-reload 2>/dev/null 2>&1
 {{ if .StartService -}}
-  /bin/systemctl restart orbit.service 2>&1
+  systemctl restart orbit.service 2>&1
 {{- end}}
 fi
 `))


### PR DESCRIPTION
In some installations (observed on GitHub Actions), the postinstall
script would fail to start the service because the `systemctl` binary
was at a different path than expected, or the `systemd` binary was not
found running.

This change allows the service to start on these environments.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
