### PR TITLE
Spiffier UI: Checkbox and radio button styling

### DIFF
--- a/changes/issue-3476-checkboxes-radio-buttons
+++ b/changes/issue-3476-checkboxes-radio-buttons
@@ -1,0 +1,1 @@
+*Spiffier UI: Checkboxes and radio buttons styling consistent across browsers

--- a/frontend/components/forms/FormField/_styles.scss
+++ b/frontend/components/forms/FormField/_styles.scss
@@ -28,4 +28,8 @@
       font-family: "SourceCodePro", $monospace;
     }
   }
+
+  &--checkbox {
+    margin-bottom: $pad-medium;
+  }
 }

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -5,6 +5,10 @@
 
   &__input {
     opacity: 0;
+    width: 16px;
+    height: 16px;
+    margin: 2px;
+    transform: translateY(3px);
 
     &:focus + .fleet-checkbox__tick {
       &::after {

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -41,7 +41,7 @@
   &__tick {
     @include size(20px);
     @include position(absolute, 50% null null 0);
-    transform: translateY(-10px);
+    transform: translateY(-8px);
     display: inline-block;
 
     &::after {

--- a/frontend/components/forms/fields/Radio/_styles.scss
+++ b/frontend/components/forms/fields/Radio/_styles.scss
@@ -22,8 +22,8 @@
         height: 10px;
         box-shadow: inset 1em 1em $core-vibrant-blue;
         border-radius: 50%;
-        top: 5px;
-        left: 5px;
+        top: 3px;
+        left: 3px;
         transition: 180ms transform ease-in-out;
         transform: scale(0);
       }
@@ -41,15 +41,15 @@
   &__control {
     position: relative;
     display: flex;
-    width: 20px;
-    height: 20px;
+    width: 16px;
+    height: 16px;
     border-radius: 50%;
     border: 2px solid $ui-fleet-blue-15;
     transform: translateY(-0.05em);
   }
 
   &__label {
-    margin-left: $pad-xsmall;
+    margin-left: $pad-small;
     line-height: 1;
   }
 }

--- a/frontend/components/forms/fields/Radio/_styles.scss
+++ b/frontend/components/forms/fields/Radio/_styles.scss
@@ -13,7 +13,7 @@
       opacity: 0;
       width: 0;
       height: 0;
-      display: none;
+      position: absolute;
 
       & + .radio__control::before {
         position: absolute;

--- a/frontend/components/forms/fields/Radio/_styles.scss
+++ b/frontend/components/forms/fields/Radio/_styles.scss
@@ -13,7 +13,7 @@
       opacity: 0;
       width: 0;
       height: 0;
-      margin: 0;
+      display: none;
 
       & + .radio__control::before {
         position: absolute;

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
@@ -28,7 +28,6 @@
         font-size: $x-small;
         font-weight: $bold;
         color: $core-fleet-black;
-        padding-left: 12px;
       }
     }
   }


### PR DESCRIPTION
Cerra #3476

- Radio button width including border fixed to 20px instead of 24px (aligned perfectly with checkboxes)
- Fix radio button margin between label and radio button  to 8px
- Safari only issue: Fix margin between label and checkbox to 8px
- Firefox only issue: Fix left margin of radio button to be flushed with parent component

Chrome:
<img width="1397" alt="Screen Shot 2022-01-03 at 11 35 05 AM" src="https://user-images.githubusercontent.com/71795832/147957600-d6f95489-18ca-4e19-a110-40d7bced0be5.png">
<img width="1397" alt="Screen Shot 2022-01-03 at 11 34 11 AM" src="https://user-images.githubusercontent.com/71795832/147957601-2d7ca3e3-2ba2-46f9-a81b-fdd133540aa7.png">
Firefox:
<img width="1204" alt="Screen Shot 2022-01-03 at 11 48 26 AM" src="https://user-images.githubusercontent.com/71795832/147957591-5156cba3-94a6-42ed-adaf-ff070d53773d.png">
<img width="1207" alt="Screen Shot 2022-01-03 at 11 47 41 AM" src="https://user-images.githubusercontent.com/71795832/147957595-98d5673c-fda1-4a44-83e1-f6a6c3c52ba7.png">
Safari:
<img width="1323" alt="Screen Shot 2022-01-03 at 11 59 55 AM" src="https://user-images.githubusercontent.com/71795832/147958154-49136cf8-1fb1-47cf-8310-e3c41c8f0c90.png">
<img width="1326" alt="Screen Shot 2022-01-03 at 11 59 02 AM" src="https://user-images.githubusercontent.com/71795832/147958157-96fadb69-9ad4-44e5-809b-2eb4b0072bb7.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
