### PR TITLE
User Settings Page: Link to privacy policy

### DIFF
--- a/changes/issue-2859-privacy-policy-link
+++ b/changes/issue-2859-privacy-policy-link
@@ -1,0 +1,1 @@
+* App links users to Fleet's privacy policy

--- a/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
@@ -402,6 +402,15 @@ export class UserSettingsPage extends Component {
           <span
             className={`${baseClass}__version`}
           >{`Fleet ${version.version} • Go ${version.go_version}`}</span>
+          <span className={`${baseClass}__privacy-policy`}>
+            <a
+              href="https://fleetdm.com/legal/privacy"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Privacy policy
+            </a>
+          </span>
         </div>
         {renderEmailModal()}
         {renderPasswordModal()}

--- a/frontend/pages/UserSettingsPage/_styles.scss
+++ b/frontend/pages/UserSettingsPage/_styles.scss
@@ -153,7 +153,20 @@
     font-size: $xx-small;
     text-align: center;
     display: block;
-    margin-top: $pad-xxlarge;
+    margin-top: $pad-large;
+  }
+
+  &__privacy-policy {
+    text-align: center;
+    display: block;
+    margin-top: $pad-xlarge;
+
+    a {
+      font-size: $x-small;
+      color: $core-vibrant-blue;
+      font-weight: $bold;
+      text-decoration: none;
+    }
   }
 
   .grey-cell {


### PR DESCRIPTION
Cerra #2859 

- User Settings Page: Add link to Fleet's privacy policy that opens in a new tab

<img width="1395" alt="Screen Shot 2022-01-03 at 12 33 12 PM" src="https://user-images.githubusercontent.com/71795832/147961325-798e23cb-712c-44cc-a40d-1fd2049531c3.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
