### PR TITLE
Add wait on orbit for osquery extension socket to exist

### DIFF
--- a/changes/issue-3522-increase-extension-register-timeout
+++ b/changes/issue-3522-increase-extension-register-timeout
@@ -1,0 +1,1 @@
+* Increase orbit extension timeout from 3 seconds to one minute.

--- a/changes/issue-3522-increase-extension-register-timeout
+++ b/changes/issue-3522-increase-extension-register-timeout
@@ -1,1 +1,1 @@
-* Increase orbit extension timeout from 3 seconds to one minute.
+* Add wait on orbit for osquery extension socket.

--- a/orbit/README.md
+++ b/orbit/README.md
@@ -190,6 +190,10 @@ Following are the destination of logs for each platform (to access such location
 - macOS: `/private/var/log/orbit/orbit.std{out|err}.log`.
 - Windows: `C:\Windows\system32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.lg` (the log file is rotated).
 
+#### Debug
+
+You can use the `--debug` option in `fleetctl package` to generate installers in "debug mode". Such mode increases the verbosity of logging for orbit and osqueryd (log DEBUG level).
+
 ### Uninstall
 #### Windows
 

--- a/orbit/cmd/orbit/shell.go
+++ b/orbit/cmd/orbit/shell.go
@@ -79,7 +79,6 @@ var shellCommand = &cli.Command{
 		)
 		g.Add(r.Execute, r.Interrupt)
 
-		// Extension tables not yet supported on Windows.
 		ext := table.NewRunner(r.ExtensionSocketPath())
 		g.Add(ext.Execute, ext.Interrupt)
 

--- a/orbit/pkg/packaging/windows_templates.go
+++ b/orbit/pkg/packaging/windows_templates.go
@@ -52,7 +52,7 @@ var windowsWixTemplate = template.Must(template.New("").Option("missingkey=error
                   ErrorControl="ignore"
                   Start="auto"
                   Type="ownProcess"
-                  Arguments='--root-dir "[ORBITROOT]." --log-file "[System64Folder]config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log" {{ if .FleetURL }}--fleet-url "{{ .FleetURL }}"{{ end }} {{ if .FleetCertificate }}--fleet-certificate "[ORBITROOT]fleet.pem"{{ end }} {{ if .EnrollSecret }}--enroll-secret-path "[ORBITROOT]secret.txt"{{ end }} {{if .Insecure }}--insecure{{ end }} {{ if .UpdateURL }}--update-url "{{ .UpdateURL }}" {{ end }} --orbit-channel "{{ .OrbitChannel }}" --osqueryd-channel "{{ .OsquerydChannel }}"'
+                  Arguments='--root-dir "[ORBITROOT]." --log-file "[System64Folder]config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log" {{ if .FleetURL }}--fleet-url "{{ .FleetURL }}"{{ end }} {{ if .FleetCertificate }}--fleet-certificate "[ORBITROOT]fleet.pem"{{ end }} {{ if .EnrollSecret }}--enroll-secret-path "[ORBITROOT]secret.txt"{{ end }} {{if .Insecure }}--insecure{{ end }} {{ if .Debug }}--debug{{ end }} {{ if .UpdateURL }}--update-url "{{ .UpdateURL }}" {{ end }} --orbit-channel "{{ .OrbitChannel }}" --osqueryd-channel "{{ .OsquerydChannel }}"'
                 >
                   <util:ServiceConfig
                     FirstFailureActionType="restart"

--- a/orbit/pkg/table/extension.go
+++ b/orbit/pkg/table/extension.go
@@ -2,6 +2,7 @@ package table
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/macadmins/osquery-extension/tables/chromeuserprofiles"
 	"github.com/macadmins/osquery-extension/tables/fileline"
 	"github.com/macadmins/osquery-extension/tables/puppet"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
 
@@ -29,8 +29,8 @@ func NewRunner(socket string) *Runner {
 
 // Execute creates an osquery extension manager server and registers osquery plugins.
 func (r *Runner) Execute() error {
-	if err := waitForSocket(r.socket, 1*time.Minute); err != nil {
-		return errors.Wrapf(err, "waiting for socket to be available: %s", r.socket)
+	if err := waitForSocket(r.socket, 3*time.Second); err != nil {
+		return err
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -103,7 +103,7 @@ func waitForSocket(sockPath string, timeout time.Duration) error {
 			case os.IsNotExist(err):
 				continue
 			default:
-				return errors.Wrapf(err, "stat socket: %s", sockPath)
+				return fmt.Errorf("stat socket %s failed: %w", sockPath, err)
 			}
 		}
 	}

--- a/orbit/pkg/table/extension.go
+++ b/orbit/pkg/table/extension.go
@@ -29,7 +29,7 @@ func NewRunner(socket string) *Runner {
 
 // Execute creates an osquery extension manager server and registers osquery plugins.
 func (r *Runner) Execute() error {
-	if err := waitForSocket(r.socket, 3*time.Second); err != nil {
+	if err := waitForSocket(r.socket, 1*time.Minute); err != nil {
 		return err
 	}
 

--- a/orbit/pkg/table/extension.go
+++ b/orbit/pkg/table/extension.go
@@ -2,6 +2,7 @@ package table
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/kolide/osquery-go"
@@ -9,6 +10,7 @@ import (
 	"github.com/macadmins/osquery-extension/tables/chromeuserprofiles"
 	"github.com/macadmins/osquery-extension/tables/fileline"
 	"github.com/macadmins/osquery-extension/tables/puppet"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
 
@@ -27,6 +29,10 @@ func NewRunner(socket string) *Runner {
 
 // Execute creates an osquery extension manager server and registers osquery plugins.
 func (r *Runner) Execute() error {
+	if err := waitForSocket(r.socket, 1*time.Minute); err != nil {
+		return errors.Wrapf(err, "waiting for socket to be available: %s", r.socket)
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	r.cancel = cancel
 
@@ -74,5 +80,31 @@ func (r *Runner) Interrupt(err error) {
 
 	if r.srv != nil {
 		r.srv.Shutdown(context.Background())
+	}
+}
+
+// waitForSocket waits for the osquery socket to exist.
+//
+// This method was copied from osquery-go because we can't rely on option.ServerTimeout.
+// Such timeout is used both for waiting for the socket and for the thrift transport.
+func waitForSocket(sockPath string, timeout time.Duration) error {
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			switch _, err := os.Stat(sockPath); {
+			case err == nil:
+				return nil
+			case os.IsNotExist(err):
+				continue
+			default:
+				return errors.Wrapf(err, "stat socket: %s", sockPath)
+			}
+		}
 	}
 }


### PR DESCRIPTION
#3522

Orbit was sporadically failing on Windows/Ubuntu with:
```
2022-01-03T20:17:22-03:00 ERR unexpected exit error="registering extension: i/o timeout"
```
It seems 3 seconds of wait for the extension socket to be set up was maybe too low.

- [X] Changes file added (for user-visible changes)
~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
~- [ ] Documented any permissions changes~
- [x] Added/updated tests
- [X] Manual QA for all new/changed functionality
