### PR TITLE
Hide sidebar links on handbook landing page

### DIFF
--- a/website/views/pages/handbook/basic-handbook.ejs
+++ b/website/views/pages/handbook/basic-handbook.ejs
@@ -8,13 +8,15 @@
           <img class="maintainer-image" alt="The page maintainer's github profile picture" :src="'https://github.com/'+thisPage.meta.maintainedBy+'.png?size=200'">
           <a style="margin-top: 24px;" :href="'https://github.com/fleetdm/fleet/edit/main/handbook/'+thisPage.sectionRelativeRepoPath"> Edit this page</a>
         </div>
-        <h4 class="font-weight-bold pb-2 m-0 mb-2" v-if="!_.isEmpty(subtopics)">On this page:</h4>
-        <div purpose="subtopics">
-          <ul class="p-0 m-0">
-            <li v-for="(subtopic, index) in subtopics" class="subtopic" :key="index">
-              <a :href="subtopic.url" :class="_isCurrentSection(subtopic, this.window.location) ? 'active' : 'pl-md-3'" @click="forceRender()">{{subtopic.title}}</a>
-            </li>
-          </ul>
+        <div v-if="!isHandbookLandingPage">
+          <h4 class="font-weight-bold pb-2 m-0 mb-2" v-if="!_.isEmpty(subtopics)">On this page:</h4>
+          <div purpose="subtopics">
+            <ul class="p-0 m-0">
+              <li v-for="(subtopic, index) in subtopics" class="subtopic" :key="index">
+                <a :href="subtopic.url" :class="_isCurrentSection(subtopic, this.window.location) ? 'active' : 'pl-md-3'" @click="forceRender()">{{subtopic.title}}</a>
+              </li>
+            </ul>
+          </div>
         </div>
         <div class="border-bottom py-3 d-flex d-md-none"></div>
       </div>
@@ -65,13 +67,15 @@
             <img class="maintainer-image" alt="The page maintainer's github profile picture" :src="'https://github.com/'+thisPage.meta.maintainedBy+'.png?size=200'">
             <a style="margin-top: 24px;" :href="'https://github.com/fleetdm/fleet/tree/main/handbook/'+thisPage.sectionRelativeRepoPath"> Edit this page</a>
           </div>
-          <h4 class="font-weight-bold pb-2 m-0 mb-2" v-if="!_.isEmpty(subtopics)">On this page:</h4>
-          <div purpose="subtopics">
-            <ul class="p-0 m-0">
-              <li v-for="(subtopic, index) in subtopics" class="subtopic" :key="index">
-                <a :href="subtopic.url" :class="_isCurrentSection(subtopic, this.window.location) ? 'active' : 'pl-md-3'" @click="forceRender()">{{subtopic.title}}</a>
-              </li>
-            </ul>
+          <div v-if="!isHandbookLandingPage">
+            <h4 class="font-weight-bold pb-2 m-0 mb-2" v-if="!_.isEmpty(subtopics)">On this page:</h4>
+            <div purpose="subtopics">
+              <ul class="p-0 m-0">
+                <li v-for="(subtopic, index) in subtopics" class="subtopic" :key="index">
+                  <a :href="subtopic.url" :class="_isCurrentSection(subtopic, this.window.location) ? 'active' : 'pl-md-3'" @click="forceRender()">{{subtopic.title}}</a>
+                </li>
+              </ul>
+            </div>
           </div>
           <div class="border-bottom py-3 d-flex d-md-none"></div>
         </div>


### PR DESCRIPTION
Closes #3279 

Changes: 

- Updated the "On this page" links in the handbook to be hidden on the handbook landing page.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
