### PR TITLE
Spiffier: Center logo in nav bar

### DIFF
--- a/changes/issue-3532-center-logo
+++ b/changes/issue-3532-center-logo
@@ -1,0 +1,1 @@
+* Fleet logo centered in nav bar

--- a/frontend/components/side_panels/SiteTopNav/SiteTopNav.jsx
+++ b/frontend/components/side_panels/SiteTopNav/SiteTopNav.jsx
@@ -52,7 +52,7 @@ class SiteTopNav extends Component {
       return (
         <li className={navItemClasses} key={`nav-item-${name}`}>
           <Link
-            className={`${navItemBaseClass}__link`}
+            className={`${navItemBaseClass}__logo`}
             to={navItem.location.pathname}
           >
             <OrgLogoIcon className="logo" src={orgLogoURL} />

--- a/frontend/components/side_panels/SiteTopNav/_styles.scss
+++ b/frontend/components/side_panels/SiteTopNav/_styles.scss
@@ -15,12 +15,6 @@
     &:hover {
       background-color: transparent;
     }
-
-    .site-nav-item__link {
-      border-right: 3px solid $core-vibrant-blue;
-      background-color: $core-fleet-black;
-      height: 50px;
-    }
   }
 
   &__icon {
@@ -30,13 +24,6 @@
     width: 16px;
     height: 16px;
     vertical-align: sub;
-  }
-
-  .logo {
-    @include size(48px);
-    border-radius: 20%;
-    padding: 0;
-    margin: -12px -15px 0;
   }
 
   &__name {
@@ -61,13 +48,20 @@
     }
   }
 
-  a {
+  &__link {
     color: $core-white;
     text-align: center;
     display: flex;
     align-items: center;
     padding: 14px 20px 17px;
     text-decoration: none;
+  }
+
+  &__logo {
+    text-align: center;
+    display: table-cell;
+    vertical-align: middle;
+    width: 64px;
   }
 
   &--active {

--- a/frontend/components/side_panels/SiteTopNav/_styles.scss
+++ b/frontend/components/side_panels/SiteTopNav/_styles.scss
@@ -81,6 +81,8 @@
 
 .logo {
   transform: scale(0.5);
+  position: relative;
+  top: 1px;
 }
 
 .site-nav-container {


### PR DESCRIPTION
Cerra #3466 

- Center logo in nav bar
- Logo nav item 64px by 50px to match Figma

QA-ed on Safari, Firefox, and Chrome:
<img width="624" alt="Screen Shot 2022-01-07 at 11 07 35 AM" src="https://user-images.githubusercontent.com/71795832/148572053-d4ea1da1-4fd0-44b5-9af4-3e1a41715898.png">
<img width="560" alt="Screen Shot 2022-01-07 at 11 07 21 AM" src="https://user-images.githubusercontent.com/71795832/148572058-0b1b22a5-ec39-4ceb-a196-8d1a9107fab3.png">
<img width="448" alt="Screen Shot 2022-01-07 at 11 07 03 AM" src="https://user-images.githubusercontent.com/71795832/148572059-5d4722f0-a99e-439b-8ca6-c7b4f1cdfd74.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)

- [x] Manual QA for all new/changed functionality
