### PR TITLE
Remove unused request-id in context

### DIFF
--- a/server/service/http_auth.go
+++ b/server/service/http_auth.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"net/http"
-	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/contexts/token"
@@ -25,18 +24,8 @@ func setRequestsContexts(svc fleet.Service) kithttp.RequestFunc {
 			}
 		}
 
-		// get the user-id for request
-		if strings.Contains(r.URL.Path, "users/") {
-			ctx = withUserIDFromRequest(r, ctx)
-		}
-
 		ctx = logging.NewContext(ctx, &logging.LoggingContext{})
 		ctx = logging.WithStartTime(ctx)
 		return ctx
 	}
-}
-
-func withUserIDFromRequest(r *http.Request, ctx context.Context) context.Context {
-	id, _ := uintFromRequest(r, "id")
-	return context.WithValue(ctx, "request-id", uint(id))
 }


### PR DESCRIPTION
This seems to be left over from the older authorization system in Fleet.
I couldn't find any other reference to the `request-id` in the code.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

~- [ ] Changes file added (for user-visible changes)~
~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Added/updated tests~
- [ ] Manual QA for all new/changed functionality
