### PR TITLE
Add contributors to policies in standard query library

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -642,6 +642,7 @@ spec:
   description: Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.
   resolution: "Run the following command in the Terminal app: /usr/sbin/spctl --master-enable"
   platform: darwin
+  contributors: groob
 ---
 apiVersion: v1
 kind: policy
@@ -651,6 +652,7 @@ spec:
   description: Checks to make sure that device encryption is enabled on Windows devices.
   resolution: "Option 1: Select the Start button. Select Settings  > Update & Security  > Device encryption. If Device encryption doesn't appear, skip to Option 2. If device encryption is turned off, select Turn on. Option 2: Select the Start button. Under Windows System, select Control Panel. Select System and Security. Under BitLocker Drive Encryption, select Manage BitLocker. Select Turn on BitLocker and then follow the instructions."
   platform: windows
+  contributors: defensivedepth
 ---
 apiVersion: v1
 kind: policy
@@ -660,3 +662,4 @@ spec:
   description: Checks to make sure that the Filevault feature is enabled on macOS devices.
   resolution: "Choose Apple menu > System Preferences, then click Security & Privacy. Click the FileVault tab. Click the Lock icon, then enter an administrator name and password. Click Turn On FileVault."
   platform: darwin
+  contributors: groob


### PR DESCRIPTION
- Resolve failing "Deploy Fleet Website" CI task. 
  - If a query in the `standard-query-library.yml` file does not include the `contributors` property, the task returns the following error:
```
Error: Failed parsing YAML for query library: The "contributors" of a query should be a single string of valid GitHub user names (e.g. "zwass", or "zwass,noahtalerman,mikermcneil").  But one or more queries have an invalid "contributors" value: is-disk-encryption-enabled-on-windows-devices,is-filevault-enabled-on-mac-os-devices,is-gatekeeper-enabled-on-mac-os-devices
``` 
