### PR TITLE
Remove policies from `standard-query-library.yml`

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -633,30 +633,3 @@ spec:
   query: SELECT * FROM apps WHERE path LIKE '/Applications/%' AND name IN ("Photoshop.app", "Adobe XD.app", "Sketch.app", "Illustrator.app") AND last_opened_time < (( SELECT unix_time FROM time ) - 2592000000000 );
   purpose: Informational
   contributors: DominusKelvin
----
-apiVersion: v1
-kind: policy
-spec:
-  name: Is Gatekeeper enabled on macOS devices?
-  query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;
-  description: Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.
-  resolution: "Run the following command in the Terminal app: /usr/sbin/spctl --master-enable"
-  platform: darwin
----
-apiVersion: v1
-kind: policy
-spec:
-  name: Is disk encryption enabled on Windows devices?
-  query: SELECT 1 FROM bitlocker_info where protection_status = 1;
-  description: Checks to make sure that device encryption is enabled on Windows devices.
-  resolution: "Option 1: Select the Start button. Select Settings  > Update & Security  > Device encryption. If Device encryption doesn't appear, skip to Option 2. If device encryption is turned off, select Turn on. Option 2: Select the Start button. Under Windows System, select Control Panel. Select System and Security. Under BitLocker Drive Encryption, select Manage BitLocker. Select Turn on BitLocker and then follow the instructions."
-  platform: windows
----
-apiVersion: v1
-kind: policy
-spec:
-  name: Is Filevault enabled on macOS devices?
-  query: SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT “” AND filevault_status = ‘on’ LIMIT 1;
-  description: Checks to make sure that the Filevault feature is enabled on macOS devices.
-  resolution: "Choose Apple menu > System Preferences, then click Security & Privacy. Click the FileVault tab. Click the Lock icon, then enter an administrator name and password. Click Turn On FileVault."
-  platform: darwin


### PR DESCRIPTION
- For now, remove policies from `standard-query-library.yml` so that the `fleetctl preview` command does not fail with the following error:
```
failed to parse standard query library: unknown kind "policy"
```

#### More info

The policies (removed in this PR) will be added to the standard query library when support for the `policy` yaml document is included in a stable release. The `policy` yaml document will be released in Fleet 4.8.0.