### PR TITLE
Spiffier UI: Dashboard and Manage Host Page loading states

### DIFF
--- a/changes/issue-3051-update-loading-states
+++ b/changes/issue-3051-update-loading-states
@@ -1,0 +1,1 @@
+* Better loading states for dashboard and manage host page

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -205,6 +205,8 @@ const TableContainer = ({
     return data.length;
   }, [filteredCount, clientFilterCount, data]);
 
+  const opacity = isLoading ? { opacity: 0.4 } : { opacity: 1 };
+
   return (
     <div className={wrapperClasses}>
       {wideSearch && searchable && (
@@ -217,10 +219,12 @@ const TableContainer = ({
       )}
       <div className={`${baseClass}__header`}>
         {renderCount && (
-          <p className={`${baseClass}__results-count`}>{renderCount()}</p>
+          <p className={`${baseClass}__results-count`} style={opacity}>
+            {renderCount()}
+          </p>
         )}
         {!renderCount && data && displayCount() && !disableCount ? (
-          <p className={`${baseClass}__results-count`}>
+          <p className={`${baseClass}__results-count`} style={opacity}>
             {TableContainerUtils.generateResultsCountText(
               resultsTitle,
               displayCount()

--- a/frontend/components/side_panels/HostSidePanel/HostSidePanel.tsx
+++ b/frontend/components/side_panels/HostSidePanel/HostSidePanel.tsx
@@ -36,13 +36,6 @@ const HostSidePanel = ({
   canAddNewLabel,
   isLabelsLoading,
 }: IHostSidePanelProps): JSX.Element => {
-  if (isLabelsLoading || !labels) {
-    return (
-      <SecondarySidePanelContainer className={`${baseClass}`}>
-        <Spinner />
-      </SecondarySidePanelContainer>
-    );
-  }
   const [labelFilter, setLabelFilter] = useState<string>("");
 
   const onFilterLabels = useCallback(
@@ -51,6 +44,14 @@ const HostSidePanel = ({
     },
     [setLabelFilter]
   );
+
+  if (isLabelsLoading || !labels) {
+    return (
+      <SecondarySidePanelContainer className={`${baseClass}`}>
+        <Spinner />
+      </SecondarySidePanelContainer>
+    );
+  }
 
   const allHostLabels = filter(labels, { type: "all" });
 

--- a/frontend/components/side_panels/HostSidePanel/HostSidePanel.tsx
+++ b/frontend/components/side_panels/HostSidePanel/HostSidePanel.tsx
@@ -1,6 +1,10 @@
 import React, { useState, useCallback } from "react";
 import { filter } from "lodash";
 
+import { ILabel } from "interfaces/label";
+import { PLATFORM_LABEL_DISPLAY_ORDER } from "utilities/constants";
+
+import Spinner from "components/Spinner";
 import Button from "components/buttons/Button";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
@@ -8,21 +12,20 @@ import InputField from "components/forms/fields/InputField";
 import PanelGroup from "components/side_panels/HostSidePanel/PanelGroup";
 // @ts-ignore
 import SecondarySidePanelContainer from "components/side_panels/SecondarySidePanelContainer";
-import { ILabel } from "interfaces/label";
-import { PLATFORM_LABEL_DISPLAY_ORDER } from "utilities/constants";
 
 import PlusIcon from "../../../../assets/images/icon-plus-16x16@2x.png";
 
 const baseClass = "host-side-panel";
 
 interface IHostSidePanelProps {
-  labels: ILabel[];
+  labels?: ILabel[];
   onAddLabelClick: (evt: React.MouseEvent<HTMLButtonElement>) => void;
   onLabelClick: (
     selectedLabel: ILabel
   ) => (evt: React.MouseEvent<HTMLButtonElement>) => void;
   selectedFilter: string | undefined;
   canAddNewLabel: boolean;
+  isLabelsLoading: boolean;
 }
 
 const HostSidePanel = ({
@@ -31,7 +34,15 @@ const HostSidePanel = ({
   onLabelClick,
   selectedFilter,
   canAddNewLabel,
+  isLabelsLoading,
 }: IHostSidePanelProps): JSX.Element => {
+  if (isLabelsLoading || !labels) {
+    return (
+      <SecondarySidePanelContainer className={`${baseClass}`}>
+        <Spinner />
+      </SecondarySidePanelContainer>
+    );
+  }
   const [labelFilter, setLabelFilter] = useState<string>("");
 
   const onFilterLabels = useCallback(

--- a/frontend/components/side_panels/HostSidePanel/HostSidePanel.tsx
+++ b/frontend/components/side_panels/HostSidePanel/HostSidePanel.tsx
@@ -36,7 +36,7 @@ const HostSidePanel = ({
   canAddNewLabel,
   isLabelsLoading,
 }: IHostSidePanelProps): JSX.Element => {
-  if (isLabelsLoading || !labels) {
+  if (isLabelsLoading) {
     return (
       <SecondarySidePanelContainer className={`${baseClass}`}>
         <Spinner />

--- a/frontend/components/side_panels/HostSidePanel/HostSidePanel.tsx
+++ b/frontend/components/side_panels/HostSidePanel/HostSidePanel.tsx
@@ -36,7 +36,7 @@ const HostSidePanel = ({
   canAddNewLabel,
   isLabelsLoading,
 }: IHostSidePanelProps): JSX.Element => {
-  if (isLabelsLoading) {
+  if (isLabelsLoading || !labels) {
     return (
       <SecondarySidePanelContainer className={`${baseClass}`}>
         <Spinner />

--- a/frontend/components/side_panels/HostSidePanel/_styles.scss
+++ b/frontend/components/side_panels/HostSidePanel/_styles.scss
@@ -1,6 +1,10 @@
 .host-side-panel {
   color: $core-fleet-black;
 
+  .loading-spinner {
+    margin-top: 155px; // line up with host table loading spinner
+  }
+
   .input-icon-field {
     margin-top: 0;
 

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -57,9 +57,10 @@ const Homepage = (): JSX.Element => {
   const [showActivityFeedTitle, setShowActivityFeedTitle] = useState<boolean>(
     false
   );
+  const [showHostsData, setShowHostsData] = useState<boolean>(false); // Hides UI on first load only
   const [isLoadingHostsSummary, setIsLoadingHostsSummary] = useState<boolean>(
     true
-  );
+  ); // Opaque UI on subsequent loads
 
   const { data: teams } = useQuery<ITeamsResponse, Error, ITeam[]>(
     ["teams"],
@@ -103,6 +104,7 @@ const Homepage = (): JSX.Element => {
         ) || { platform: "windows", hosts_count: 0 };
         setWindowsCount(windowsHosts.hosts_count.toLocaleString("en-US"));
         setIsLoadingHostsSummary(false);
+        setShowHostsData(true);
       },
     }
   );
@@ -162,6 +164,7 @@ const Homepage = (): JSX.Element => {
                   windowsCount={windowsCount}
                   setIsLoadingHostsSummary={setIsLoadingHostsSummary}
                   isLoadingHostsSummary={isLoadingHostsSummary}
+                  showHostsData={showHostsData}
                 />
               </InfoCard>
             </div>
@@ -172,6 +175,7 @@ const Homepage = (): JSX.Element => {
                   offlineCount={offlineCount}
                   newCount={newCount}
                   isLoadingHosts={isLoadingHostsSummary}
+                  showHostsData={showHostsData}
                 />
               </InfoCard>
             </div>

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -53,11 +53,11 @@ const Homepage = (): JSX.Element => {
   const [onlineCount, setOnlineCount] = useState<string | undefined>();
   const [offlineCount, setOfflineCount] = useState<string | undefined>();
   const [newCount, setNewCount] = useState<string | undefined>();
-  const [showSoftwareTitle, setShowSoftwareTitle] = useState<boolean>(false);
   const [showActivityFeedTitle, setShowActivityFeedTitle] = useState<boolean>(
     false
   );
-  const [showHostsData, setShowHostsData] = useState<boolean>(false); // Hides UI on first load only
+  const [showSoftwareUI, setShowSoftwareUI] = useState<boolean>(false);
+  const [showHostsUI, setShowHostsUI] = useState<boolean>(false); // Hides UI on first load only
   const [isLoadingHostsSummary, setIsLoadingHostsSummary] = useState<boolean>(
     true
   ); // Opaque UI on subsequent loads
@@ -104,7 +104,7 @@ const Homepage = (): JSX.Element => {
         ) || { platform: "windows", hosts_count: 0 };
         setWindowsCount(windowsHosts.hosts_count.toLocaleString("en-US"));
         setIsLoadingHostsSummary(false);
-        setShowHostsData(true);
+        setShowHostsUI(true);
       },
     }
   );
@@ -164,7 +164,7 @@ const Homepage = (): JSX.Element => {
                   windowsCount={windowsCount}
                   setIsLoadingHostsSummary={setIsLoadingHostsSummary}
                   isLoadingHostsSummary={isLoadingHostsSummary}
-                  showHostsData={showHostsData}
+                  showHostsUI={showHostsUI}
                 />
               </InfoCard>
             </div>
@@ -175,7 +175,7 @@ const Homepage = (): JSX.Element => {
                   offlineCount={offlineCount}
                   newCount={newCount}
                   isLoadingHosts={isLoadingHostsSummary}
-                  showHostsData={showHostsData}
+                  showHostsUI={showHostsUI}
                 />
               </InfoCard>
             </div>
@@ -204,13 +204,14 @@ const Homepage = (): JSX.Element => {
               text: "View all software",
               onClick: () => setIsSoftwareModalOpen(true),
             }}
-            showTitle={showSoftwareTitle}
+            showTitle={showSoftwareUI}
           >
             <Software
               currentTeamId={currentTeam?.id}
               isModalOpen={isSoftwareModalOpen}
               setIsSoftwareModalOpen={setIsSoftwareModalOpen}
-              setShowSoftwareTitle={setShowSoftwareTitle}
+              setShowSoftwareUI={setShowSoftwareUI}
+              showSoftwareUI={showSoftwareUI}
             />
           </InfoCard>
           {!isPreviewMode && !currentTeam && isOnGlobalTeam && (

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -11,6 +11,7 @@ import { ITeam } from "interfaces/team";
 import sortUtils from "utilities/sort";
 
 import TeamsDropdown from "components/TeamsDropdown";
+import Spinner from "components/Spinner";
 import InfoCard from "./components/InfoCard";
 import HostsStatus from "./cards/HostsStatus";
 import HostsSummary from "./cards/HostsSummary";
@@ -18,7 +19,6 @@ import ActivityFeed from "./cards/ActivityFeed";
 import Software from "./cards/Software";
 import LearnFleet from "./cards/LearnFleet";
 import WelcomeHost from "./cards/WelcomeHost";
-import Spinner from "components/Spinner";
 
 interface ITeamsResponse {
   teams: ITeam[];

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -52,6 +52,13 @@ const Homepage = (): JSX.Element => {
   const [onlineCount, setOnlineCount] = useState<string | undefined>();
   const [offlineCount, setOfflineCount] = useState<string | undefined>();
   const [newCount, setNewCount] = useState<string | undefined>();
+  const [isLoadingSoftware, setIsLoadingSoftware] = useState<boolean>(true);
+  const [isLoadingActivityFeed, setIsLoadingActivityFeed] = useState<boolean>(
+    true
+  );
+
+  console.log("isLoadingSoftware", isLoadingSoftware);
+  console.log("isLoadingActivityFeed", isLoadingActivityFeed);
 
   const { data: teams } = useQuery<ITeamsResponse, Error, ITeam[]>(
     ["teams"],
@@ -135,6 +142,7 @@ const Homepage = (): JSX.Element => {
               text: "View all hosts",
             }}
             total_host_count={totalCount}
+            showTitle
           >
             <HostsSummary
               currentTeamId={currentTeam?.id}
@@ -175,16 +183,27 @@ const Homepage = (): JSX.Element => {
               text: "View all software",
               onClick: () => setIsSoftwareModalOpen(true),
             }}
+            isLoadingSoftware={isLoadingSoftware}
+            showTitle={!isLoadingSoftware}
           >
             <Software
               currentTeamId={currentTeam?.id}
               isModalOpen={isSoftwareModalOpen}
               setIsSoftwareModalOpen={setIsSoftwareModalOpen}
+              isLoadingSoftware={isLoadingSoftware}
+              setIsLoadingSoftware={setIsLoadingSoftware}
             />
           </InfoCard>
           {!isPreviewMode && !currentTeam && isOnGlobalTeam && (
-            <InfoCard title="Activity">
-              <ActivityFeed />
+            <InfoCard
+              title="Activity"
+              isLoadingActivityFeed={isLoadingActivityFeed}
+              showTitle={!isLoadingActivityFeed}
+            >
+              <ActivityFeed
+                isLoadingActivityFeed={isLoadingActivityFeed}
+                setIsLoadingActivityFeed={setIsLoadingActivityFeed}
+              />
             </InfoCard>
           )}
         </div>

--- a/frontend/pages/Homepage/_styles.scss
+++ b/frontend/pages/Homepage/_styles.scss
@@ -67,4 +67,19 @@
       }
     }
   }
+
+  .host-sections {
+    position: relative;
+  }
+
+  .spinner {
+    z-index: 11;
+    opacity: 1;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 }

--- a/frontend/pages/Homepage/cards/ActivityFeed/ActivityFeed.tsx
+++ b/frontend/pages/Homepage/cards/ActivityFeed/ActivityFeed.tsx
@@ -84,7 +84,6 @@ const ActivityFeed = ({
         }
         setShowActivityFeedTitle(true);
         setIsLoadingActivityFeed(false);
-        console.log("should be set to false!");
       } catch (err) {
         setIsLoadingError(true);
         setIsLoadingActivityFeed(false);

--- a/frontend/pages/Homepage/cards/ActivityFeed/ActivityFeed.tsx
+++ b/frontend/pages/Homepage/cards/ActivityFeed/ActivityFeed.tsx
@@ -20,8 +20,7 @@ import OpenNewTabIcon from "../../../../../assets/images/open-new-tab-12x12@2x.p
 const baseClass = "activity-feed";
 
 interface IActvityCardProps {
-  isLoadingActivityFeed: boolean;
-  setIsLoadingActivityFeed: (isLoading: boolean) => void;
+  setShowActivityFeedTitle: (showActivityFeedTitle: boolean) => void;
 }
 
 const DEFAULT_GRAVATAR_URL =
@@ -61,13 +60,15 @@ const TAGGED_TEMPLATES = {
 };
 
 const ActivityFeed = ({
-  isLoadingActivityFeed,
-  setIsLoadingActivityFeed,
+  setShowActivityFeedTitle,
 }: IActvityCardProps): JSX.Element => {
-  const [activities, setActivities] = useState([]);
-  const [isLoadingError, setIsLoadingError] = useState(false);
-  const [pageIndex, setPageIndex] = useState(0);
-  const [showMore, setShowMore] = useState(true);
+  const [activities, setActivities] = useState<IActivity[] | []>([]);
+  const [isLoadingError, setIsLoadingError] = useState<boolean>(false);
+  const [pageIndex, setPageIndex] = useState<number>(0);
+  const [showMore, setShowMore] = useState<boolean>(true);
+  const [isLoadingActivityFeed, setIsLoadingActivityFeed] = useState<boolean>(
+    true
+  );
 
   useEffect((): void => {
     const getActivities = async (): Promise<void> => {
@@ -81,7 +82,7 @@ const ActivityFeed = ({
         } else {
           setShowMore(false);
         }
-
+        setShowActivityFeedTitle(true);
         setIsLoadingActivityFeed(false);
         console.log("should be set to false!");
       } catch (err) {
@@ -187,15 +188,24 @@ const ActivityFeed = ({
     renderActivityBlock(activity, i)
   );
 
+  // Renders opaque information as activity feed is loading
+  const opacity = isLoadingActivityFeed ? { opacity: 0.4 } : { opacity: 1 };
+
   return (
     <div className={baseClass}>
       {isLoadingError && renderError()}
       {!isLoadingError && !isLoadingActivityFeed && isEmpty(activities) ? (
         renderNoActivities()
       ) : (
-        <div>{renderActivities}</div>
+        <>
+          {isLoadingActivityFeed && (
+            <div className="spinner">
+              <Spinner />
+            </div>
+          )}
+          <div style={opacity}>{renderActivities}</div>
+        </>
       )}
-      {isLoadingActivityFeed && <Spinner />}
       {!isLoadingError && !isEmpty(activities) && (
         <div className={`${baseClass}__pagination`}>
           <Button

--- a/frontend/pages/Homepage/cards/ActivityFeed/ActivityFeed.tsx
+++ b/frontend/pages/Homepage/cards/ActivityFeed/ActivityFeed.tsx
@@ -19,6 +19,11 @@ import OpenNewTabIcon from "../../../../../assets/images/open-new-tab-12x12@2x.p
 
 const baseClass = "activity-feed";
 
+interface IActvityCardProps {
+  isLoadingActivityFeed: boolean;
+  setIsLoadingActivityFeed: (isLoading: boolean) => void;
+}
+
 const DEFAULT_GRAVATAR_URL =
   "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=blank&size=200";
 
@@ -55,9 +60,11 @@ const TAGGED_TEMPLATES = {
   },
 };
 
-const ActivityFeed = (): JSX.Element => {
+const ActivityFeed = ({
+  isLoadingActivityFeed,
+  setIsLoadingActivityFeed,
+}: IActvityCardProps): JSX.Element => {
   const [activities, setActivities] = useState([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [isLoadingError, setIsLoadingError] = useState(false);
   const [pageIndex, setPageIndex] = useState(0);
   const [showMore, setShowMore] = useState(true);
@@ -75,10 +82,11 @@ const ActivityFeed = (): JSX.Element => {
           setShowMore(false);
         }
 
-        setIsLoading(false);
+        setIsLoadingActivityFeed(false);
+        console.log("should be set to false!");
       } catch (err) {
         setIsLoadingError(true);
-        setIsLoading(false);
+        setIsLoadingActivityFeed(false);
       }
     };
 
@@ -86,13 +94,13 @@ const ActivityFeed = (): JSX.Element => {
   }, [pageIndex]);
 
   const onLoadPrevious = () => {
-    setIsLoading(true);
+    setIsLoadingActivityFeed(true);
     setShowMore(true);
     setPageIndex(pageIndex - 1);
   };
 
   const onLoadNext = () => {
-    setIsLoading(true);
+    setIsLoadingActivityFeed(true);
     setPageIndex(pageIndex + 1);
   };
 
@@ -182,16 +190,16 @@ const ActivityFeed = (): JSX.Element => {
   return (
     <div className={baseClass}>
       {isLoadingError && renderError()}
-      {!isLoadingError && !isLoading && isEmpty(activities) ? (
+      {!isLoadingError && !isLoadingActivityFeed && isEmpty(activities) ? (
         renderNoActivities()
       ) : (
         <div>{renderActivities}</div>
       )}
-      {isLoading && <Spinner />}
+      {isLoadingActivityFeed && <Spinner />}
       {!isLoadingError && !isEmpty(activities) && (
         <div className={`${baseClass}__pagination`}>
           <Button
-            disabled={isLoading || pageIndex === 0}
+            disabled={isLoadingActivityFeed || pageIndex === 0}
             onClick={onLoadPrevious}
             variant="unstyled"
             className={`${baseClass}__load-activities-button`}
@@ -201,7 +209,7 @@ const ActivityFeed = (): JSX.Element => {
             </>
           </Button>
           <Button
-            disabled={isLoading || !showMore}
+            disabled={isLoadingActivityFeed || !showMore}
             onClick={onLoadNext}
             variant="unstyled"
             className={`${baseClass}__load-activities-button`}

--- a/frontend/pages/Homepage/cards/ActivityFeed/_styles.scss
+++ b/frontend/pages/Homepage/cards/ActivityFeed/_styles.scss
@@ -158,9 +158,10 @@
     opacity: 1;
     position: absolute;
     width: 100%;
-    height: 90%;
+    height: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
+    margin-top: 40px; // Aligns with software table spinner
   }
 }

--- a/frontend/pages/Homepage/cards/ActivityFeed/_styles.scss
+++ b/frontend/pages/Homepage/cards/ActivityFeed/_styles.scss
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   position: relative;
+  min-height: 400px;
 
   &__header-wrap {
     .form-field {
@@ -59,12 +60,15 @@
   }
 
   &__pagination {
-    display: flex;
-    justify-content: flex-end;
+    position: absolute;
+    bottom: 0px;
+    right: 0px;
   }
 
   &__load-activities-button {
     color: $core-vibrant-blue;
+    height: 20px;
+    vertical-align: bottom;
 
     .fleeticon-chevronleft,
     .fleeticon-chevronright {

--- a/frontend/pages/Homepage/cards/ActivityFeed/_styles.scss
+++ b/frontend/pages/Homepage/cards/ActivityFeed/_styles.scss
@@ -2,6 +2,7 @@
   margin-top: $pad-large;
   display: flex;
   flex-direction: column;
+  position: relative;
 
   &__header-wrap {
     .form-field {
@@ -146,5 +147,16 @@
         margin-top: 10px;
       }
     }
+  }
+
+  .spinner {
+    z-index: 11;
+    opacity: 1;
+    position: absolute;
+    width: 100%;
+    height: 90%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 }

--- a/frontend/pages/Homepage/cards/HostsStatus/HostsStatus.tsx
+++ b/frontend/pages/Homepage/cards/HostsStatus/HostsStatus.tsx
@@ -7,7 +7,7 @@ interface IHostSummaryProps {
   offlineCount: string | undefined;
   newCount: string | undefined;
   isLoadingHosts: boolean;
-  showHostsData: boolean;
+  showHostsUI: boolean;
 }
 
 const HostsStatus = ({
@@ -15,11 +15,11 @@ const HostsStatus = ({
   offlineCount,
   newCount,
   isLoadingHosts,
-  showHostsData,
+  showHostsUI,
 }: IHostSummaryProps): JSX.Element => {
   // Renders opaque information as host information is loading
   let opacity = { opacity: 0 };
-  if (showHostsData) {
+  if (showHostsUI) {
     opacity = isLoadingHosts ? { opacity: 0.4 } : { opacity: 1 };
   }
 

--- a/frontend/pages/Homepage/cards/HostsStatus/HostsStatus.tsx
+++ b/frontend/pages/Homepage/cards/HostsStatus/HostsStatus.tsx
@@ -6,15 +6,20 @@ interface IHostSummaryProps {
   onlineCount: string | undefined;
   offlineCount: string | undefined;
   newCount: string | undefined;
+  isLoadingHosts: boolean;
 }
 
 const HostsStatus = ({
   onlineCount,
   offlineCount,
   newCount,
+  isLoadingHosts,
 }: IHostSummaryProps): JSX.Element => {
+  // Renders opaque information as host information is loading
+  const opacity = isLoadingHosts ? { opacity: 0.4 } : { opacity: 1 };
+
   return (
-    <div className={baseClass}>
+    <div className={baseClass} style={opacity}>
       <div className={`${baseClass}__tile online-tile`}>
         <div>
           <div

--- a/frontend/pages/Homepage/cards/HostsStatus/HostsStatus.tsx
+++ b/frontend/pages/Homepage/cards/HostsStatus/HostsStatus.tsx
@@ -7,6 +7,7 @@ interface IHostSummaryProps {
   offlineCount: string | undefined;
   newCount: string | undefined;
   isLoadingHosts: boolean;
+  showHostsData: boolean;
 }
 
 const HostsStatus = ({
@@ -14,9 +15,13 @@ const HostsStatus = ({
   offlineCount,
   newCount,
   isLoadingHosts,
+  showHostsData,
 }: IHostSummaryProps): JSX.Element => {
   // Renders opaque information as host information is loading
-  const opacity = isLoadingHosts ? { opacity: 0.4 } : { opacity: 1 };
+  let opacity = { opacity: 0 };
+  if (showHostsData) {
+    opacity = isLoadingHosts ? { opacity: 0.4 } : { opacity: 1 };
+  }
 
   return (
     <div className={baseClass} style={opacity}>

--- a/frontend/pages/Homepage/cards/HostsSummary/HostsSummary.tsx
+++ b/frontend/pages/Homepage/cards/HostsSummary/HostsSummary.tsx
@@ -15,6 +15,8 @@ interface IHostSummaryProps {
   currentTeamId: number | undefined;
   macCount: string | undefined;
   windowsCount: string | undefined;
+  setIsLoadingHostsSummary: (isLoadingHostSummary: boolean) => void;
+  isLoadingHostsSummary: boolean;
 }
 
 interface ILabelsResponse {
@@ -29,6 +31,8 @@ const HostsSummary = ({
   currentTeamId,
   macCount,
   windowsCount,
+  setIsLoadingHostsSummary,
+  isLoadingHostsSummary,
 }: IHostSummaryProps): JSX.Element => {
   const [linuxCount, setLinuxCount] = useState<string | undefined>();
 
@@ -39,9 +43,16 @@ const HostsSummary = ({
   };
   const { data: labels } = useQuery<ILabelsResponse, Error, ILabel[]>(
     ["labels"],
-    () => labelsAPI.loadAll(),
+    () => {
+      setIsLoadingHostsSummary(true);
+      return labelsAPI.loadAll();
+    },
     {
       select: (data: ILabelsResponse) => data.labels,
+      onSuccess: () => {
+        setIsLoadingHostsSummary(false);
+        console.log("should be reset to false");
+      },
     }
   );
 
@@ -63,8 +74,11 @@ const HostsSummary = ({
     }
   );
 
+  // Renders opaque information as host information is loading
+  const opacity = isLoadingHostsSummary ? { opacity: 0.4 } : { opacity: 1 };
+
   return (
-    <div className={baseClass}>
+    <div className={baseClass} style={opacity}>
       <div className={`${baseClass}__tile mac-tile`}>
         <div className={`${baseClass}__tile-icon`}>
           <img src={MacIcon} alt="mac icon" id="mac-icon" />

--- a/frontend/pages/Homepage/cards/HostsSummary/HostsSummary.tsx
+++ b/frontend/pages/Homepage/cards/HostsSummary/HostsSummary.tsx
@@ -17,6 +17,7 @@ interface IHostSummaryProps {
   windowsCount: string | undefined;
   setIsLoadingHostsSummary: (isLoadingHostSummary: boolean) => void;
   isLoadingHostsSummary: boolean;
+  showHostsData: boolean;
 }
 
 interface ILabelsResponse {
@@ -33,6 +34,7 @@ const HostsSummary = ({
   windowsCount,
   setIsLoadingHostsSummary,
   isLoadingHostsSummary,
+  showHostsData,
 }: IHostSummaryProps): JSX.Element => {
   const [linuxCount, setLinuxCount] = useState<string | undefined>();
 
@@ -51,7 +53,6 @@ const HostsSummary = ({
       select: (data: ILabelsResponse) => data.labels,
       onSuccess: () => {
         setIsLoadingHostsSummary(false);
-        console.log("should be reset to false");
       },
     }
   );
@@ -75,7 +76,10 @@ const HostsSummary = ({
   );
 
   // Renders opaque information as host information is loading
-  const opacity = isLoadingHostsSummary ? { opacity: 0.4 } : { opacity: 1 };
+  let opacity = { opacity: 0 };
+  if (showHostsData) {
+    opacity = isLoadingHostsSummary ? { opacity: 0.4 } : { opacity: 1 };
+  }
 
   return (
     <div className={baseClass} style={opacity}>

--- a/frontend/pages/Homepage/cards/HostsSummary/HostsSummary.tsx
+++ b/frontend/pages/Homepage/cards/HostsSummary/HostsSummary.tsx
@@ -17,7 +17,7 @@ interface IHostSummaryProps {
   windowsCount: string | undefined;
   setIsLoadingHostsSummary: (isLoadingHostSummary: boolean) => void;
   isLoadingHostsSummary: boolean;
-  showHostsData: boolean;
+  showHostsUI: boolean;
 }
 
 interface ILabelsResponse {
@@ -34,7 +34,7 @@ const HostsSummary = ({
   windowsCount,
   setIsLoadingHostsSummary,
   isLoadingHostsSummary,
-  showHostsData,
+  showHostsUI,
 }: IHostSummaryProps): JSX.Element => {
   const [linuxCount, setLinuxCount] = useState<string | undefined>();
 
@@ -77,7 +77,7 @@ const HostsSummary = ({
 
   // Renders opaque information as host information is loading
   let opacity = { opacity: 0 };
-  if (showHostsData) {
+  if (showHostsUI) {
     opacity = isLoadingHostsSummary ? { opacity: 0.4 } : { opacity: 1 };
   }
 

--- a/frontend/pages/Homepage/cards/Software/Software.tsx
+++ b/frontend/pages/Homepage/cards/Software/Software.tsx
@@ -31,8 +31,7 @@ interface ISoftwareCardProps {
   currentTeamId?: number;
   isModalOpen: boolean;
   setIsSoftwareModalOpen: (isOpen: boolean) => void;
-  isLoadingSoftware: boolean;
-  setIsLoadingSoftware: (isLoading: boolean) => void;
+  setShowSoftwareTitle: (showSoftwareTitle: boolean) => void;
 }
 
 const VULNERABLE_OPTIONS = [
@@ -109,8 +108,7 @@ const Software = ({
   currentTeamId,
   isModalOpen,
   setIsSoftwareModalOpen,
-  isLoadingSoftware,
-  setIsLoadingSoftware,
+  setShowSoftwareTitle,
 }: ISoftwareCardProps): JSX.Element => {
   const [softwarePageIndex, setSoftwarePageIndex] = useState<number>(0);
   const [vSoftwarePageIndex, setVSoftwarePageIndex] = useState<number>(0);
@@ -137,6 +135,7 @@ const Software = ({
     isLoadingModalSoftwareCount,
     setIsLoadingModalSoftwareCount,
   ] = useState<boolean>(true);
+  const [isLoadingSoftware, setIsLoadingSoftware] = useState<boolean>(true);
 
   const { data: software } = useQuery<ISoftware[], Error>(
     ["software", softwarePageIndex, currentTeamId],
@@ -157,6 +156,7 @@ const Software = ({
       // So we manage our own load states
       keepPreviousData: true,
       onSuccess: () => {
+        setShowSoftwareTitle(true);
         setIsLoadingSoftware(false);
         console.log("should be reset to false");
       },
@@ -317,9 +317,7 @@ const Software = ({
 
   const tableHeaders = generateTableHeaders();
 
-  return isLoadingSoftware ? (
-    <Spinner />
-  ) : (
+  return (
     <div className={baseClass}>
       <TabsWrapper>
         <Tabs selectedIndex={navTabIndex} onSelect={(i) => setNavTabIndex(i)}>

--- a/frontend/pages/Homepage/cards/Software/Software.tsx
+++ b/frontend/pages/Homepage/cards/Software/Software.tsx
@@ -31,7 +31,8 @@ interface ISoftwareCardProps {
   currentTeamId?: number;
   isModalOpen: boolean;
   setIsSoftwareModalOpen: (isOpen: boolean) => void;
-  setShowSoftwareTitle: (showSoftwareTitle: boolean) => void;
+  setShowSoftwareUI: (showSoftwareTitle: boolean) => void;
+  showSoftwareUI: boolean;
 }
 
 const VULNERABLE_OPTIONS = [
@@ -108,7 +109,8 @@ const Software = ({
   currentTeamId,
   isModalOpen,
   setIsSoftwareModalOpen,
-  setShowSoftwareTitle,
+  setShowSoftwareUI,
+  showSoftwareUI,
 }: ISoftwareCardProps): JSX.Element => {
   const [softwarePageIndex, setSoftwarePageIndex] = useState<number>(0);
   const [vSoftwarePageIndex, setVSoftwarePageIndex] = useState<number>(0);
@@ -156,7 +158,7 @@ const Software = ({
       // So we manage our own load states
       keepPreviousData: true,
       onSuccess: () => {
-        setShowSoftwareTitle(true);
+        setShowSoftwareUI(true);
         setIsLoadingSoftware(false);
       },
       // TODO: error UX?
@@ -316,88 +318,98 @@ const Software = ({
 
   const tableHeaders = generateTableHeaders();
 
+  // Renders opaque information as host information is loading
+  const opacity = showSoftwareUI ? { opacity: 1 } : { opacity: 0 };
+
   return (
     <div className={baseClass}>
-      <TabsWrapper>
-        <Tabs selectedIndex={navTabIndex} onSelect={(i) => setNavTabIndex(i)}>
-          <TabList>
-            <Tab>All</Tab>
-            <Tab>Vulnerable</Tab>
-          </TabList>
-          <TabPanel>
-            <TableContainer
-              columns={tableHeaders}
-              data={software || []}
-              isLoading={isLoadingSoftware}
-              defaultSortHeader={"name"}
-              defaultSortDirection={"asc"}
-              hideActionButton
-              resultsTitle={"software"}
-              emptyComponent={EmptySoftware}
-              showMarkAllPages={false}
-              isAllPagesSelected={false}
-              disableCount
-              disableActionButton
-              pageSize={PAGE_SIZE}
-              onQueryChange={onAllSoftwareQueryChange}
-            />
-          </TabPanel>
-          <TabPanel>
-            <TableContainer
-              columns={tableHeaders}
-              data={vulnerableSoftware || []}
-              isLoading={isLoadingVulnerableSoftware}
-              defaultSortHeader={"name"}
-              defaultSortDirection={"asc"}
-              hideActionButton
-              resultsTitle={"software"}
-              emptyComponent={() => EmptySoftware("vulnerable")}
-              showMarkAllPages={false}
-              isAllPagesSelected={false}
-              disableCount
-              disableActionButton
-              pageSize={PAGE_SIZE}
-              onQueryChange={onVulnerableSoftwareQueryChange}
-            />
-          </TabPanel>
-        </Tabs>
-      </TabsWrapper>
-      {isModalOpen && (
-        <Modal
-          title="Software"
-          onExit={() => setIsSoftwareModalOpen(false)}
-          className={`${baseClass}__software-modal`}
-        >
-          <>
-            <p>
-              Search for a specific software version to find the hosts that have
-              it installed.
-            </p>
-            <TableContainer
-              columns={generateModalSoftwareTableHeaders()}
-              data={modalSoftware || []}
-              isLoading={isLoadingModalSoftware}
-              defaultSortHeader={"name"}
-              defaultSortDirection={"asc"}
-              hideActionButton
-              resultsTitle={"software items"}
-              emptyComponent={() =>
-                EmptySoftware(
-                  modalSoftwareSearchText === "" ? "modal" : "search"
-                )
-              }
-              showMarkAllPages={false}
-              isAllPagesSelected={false}
-              searchable
-              disableActionButton
-              pageSize={MODAL_PAGE_SIZE}
-              onQueryChange={onModalSoftwareQueryChange}
-              customControl={renderStatusDropdown}
-              renderCount={renderModalSoftwareCount}
-            />
-          </>
-        </Modal>
+      {!showSoftwareUI && (
+        <div className="spinner">
+          <Spinner />
+        </div>
       )}
+      <div style={opacity}>
+        <TabsWrapper>
+          <Tabs selectedIndex={navTabIndex} onSelect={(i) => setNavTabIndex(i)}>
+            <TabList>
+              <Tab>All</Tab>
+              <Tab>Vulnerable</Tab>
+            </TabList>
+            <TabPanel>
+              <TableContainer
+                columns={tableHeaders}
+                data={software || []}
+                isLoading={isLoadingSoftware}
+                defaultSortHeader={"name"}
+                defaultSortDirection={"asc"}
+                hideActionButton
+                resultsTitle={"software"}
+                emptyComponent={EmptySoftware}
+                showMarkAllPages={false}
+                isAllPagesSelected={false}
+                disableCount
+                disableActionButton
+                pageSize={PAGE_SIZE}
+                onQueryChange={onAllSoftwareQueryChange}
+              />
+            </TabPanel>
+            <TabPanel>
+              <TableContainer
+                columns={tableHeaders}
+                data={vulnerableSoftware || []}
+                isLoading={isLoadingVulnerableSoftware}
+                defaultSortHeader={"name"}
+                defaultSortDirection={"asc"}
+                hideActionButton
+                resultsTitle={"software"}
+                emptyComponent={() => EmptySoftware("vulnerable")}
+                showMarkAllPages={false}
+                isAllPagesSelected={false}
+                disableCount
+                disableActionButton
+                pageSize={PAGE_SIZE}
+                onQueryChange={onVulnerableSoftwareQueryChange}
+              />
+            </TabPanel>
+          </Tabs>
+        </TabsWrapper>
+        {isModalOpen && (
+          <Modal
+            title="Software"
+            onExit={() => setIsSoftwareModalOpen(false)}
+            className={`${baseClass}__software-modal`}
+          >
+            <>
+              <p>
+                Search for a specific software version to find the hosts that
+                have it installed.
+              </p>
+              <TableContainer
+                columns={generateModalSoftwareTableHeaders()}
+                data={modalSoftware || []}
+                isLoading={isLoadingModalSoftware}
+                defaultSortHeader={"name"}
+                defaultSortDirection={"asc"}
+                hideActionButton
+                resultsTitle={"software items"}
+                emptyComponent={() =>
+                  EmptySoftware(
+                    modalSoftwareSearchText === "" ? "modal" : "search"
+                  )
+                }
+                showMarkAllPages={false}
+                isAllPagesSelected={false}
+                searchable
+                disableActionButton
+                pageSize={MODAL_PAGE_SIZE}
+                onQueryChange={onModalSoftwareQueryChange}
+                customControl={renderStatusDropdown}
+                renderCount={renderModalSoftwareCount}
+              />
+            </>
+          </Modal>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/pages/Homepage/cards/Software/Software.tsx
+++ b/frontend/pages/Homepage/cards/Software/Software.tsx
@@ -12,6 +12,7 @@ import Modal from "components/Modal";
 import TabsWrapper from "components/TabsWrapper";
 import TableContainer from "components/TableContainer"; // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
+import Spinner from "components/Spinner";
 
 import {
   generateTableHeaders,
@@ -30,6 +31,8 @@ interface ISoftwareCardProps {
   currentTeamId?: number;
   isModalOpen: boolean;
   setIsSoftwareModalOpen: (isOpen: boolean) => void;
+  isLoadingSoftware: boolean;
+  setIsLoadingSoftware: (isLoading: boolean) => void;
 }
 
 const VULNERABLE_OPTIONS = [
@@ -106,6 +109,8 @@ const Software = ({
   currentTeamId,
   isModalOpen,
   setIsSoftwareModalOpen,
+  isLoadingSoftware,
+  setIsLoadingSoftware,
 }: ISoftwareCardProps): JSX.Element => {
   const [softwarePageIndex, setSoftwarePageIndex] = useState<number>(0);
   const [vSoftwarePageIndex, setVSoftwarePageIndex] = useState<number>(0);
@@ -121,7 +126,6 @@ const Software = ({
     setIsModalSoftwareVulnerable,
   ] = useState<boolean>(false);
   const [navTabIndex, setNavTabIndex] = useState<number>(0);
-  const [isLoadingSoftware, setIsLoadingSoftware] = useState<boolean>(true);
   const [
     isLoadingVulnerableSoftware,
     setIsLoadingVulnerableSoftware,
@@ -154,6 +158,7 @@ const Software = ({
       keepPreviousData: true,
       onSuccess: () => {
         setIsLoadingSoftware(false);
+        console.log("should be reset to false");
       },
       // TODO: error UX?
       onError: () => {
@@ -312,7 +317,9 @@ const Software = ({
 
   const tableHeaders = generateTableHeaders();
 
-  return (
+  return isLoadingSoftware ? (
+    <Spinner />
+  ) : (
     <div className={baseClass}>
       <TabsWrapper>
         <Tabs selectedIndex={navTabIndex} onSelect={(i) => setNavTabIndex(i)}>

--- a/frontend/pages/Homepage/cards/Software/Software.tsx
+++ b/frontend/pages/Homepage/cards/Software/Software.tsx
@@ -158,7 +158,6 @@ const Software = ({
       onSuccess: () => {
         setShowSoftwareTitle(true);
         setIsLoadingSoftware(false);
-        console.log("should be reset to false");
       },
       // TODO: error UX?
       onError: () => {

--- a/frontend/pages/Homepage/cards/Software/_styles.scss
+++ b/frontend/pages/Homepage/cards/Software/_styles.scss
@@ -1,5 +1,6 @@
 .home-software {
   margin-top: $pad-large;
+  position: relative;
 
   .software-link {
     img {

--- a/frontend/pages/Homepage/components/InfoCard/InfoCard.tsx
+++ b/frontend/pages/Homepage/components/InfoCard/InfoCard.tsx
@@ -19,6 +19,9 @@ interface IInfoCardProps {
         onClick?: () => void;
       };
   total_host_count?: string;
+  isLoadingSoftware?: boolean;
+  isLoadingActivityFeed?: boolean;
+  showTitle?: boolean;
 }
 
 const baseClass = "homepage-info-card";
@@ -28,6 +31,9 @@ const InfoCard = ({
   children,
   action,
   total_host_count,
+  isLoadingSoftware,
+  isLoadingActivityFeed,
+  showTitle,
 }: IInfoCardProps) => {
   const renderAction = () => {
     if (action) {
@@ -57,15 +63,18 @@ const InfoCard = ({
     return null;
   };
 
+  const ok = false;
   return (
     <div className={baseClass}>
-      <div className={`${baseClass}__section-title-cta`}>
-        <div className={`${baseClass}__section-title`}>
-          <h2>{title}</h2>
-          {total_host_count && <span>{total_host_count}</span>}
+      {showTitle && (
+        <div className={`${baseClass}__section-title-cta`}>
+          <div className={`${baseClass}__section-title`}>
+            <h2>{title}</h2>
+            {total_host_count && <span>{total_host_count}</span>}
+          </div>
+          {renderAction()}
         </div>
-        {renderAction()}
-      </div>
+      )}
       {children}
     </div>
   );

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1586,6 +1586,7 @@ const ManageHostsPage = ({
               </div>
             ))}
           {config && (!isPremiumTier || teams) ? renderTable() : <Spinner />}
+          {/* TODO: Check out spinner here */}
         </div>
       )}
       {renderSidePanel()}

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1383,10 +1383,6 @@ const ManageHostsPage = ({
   };
 
   const renderSidePanel = () => {
-    if (!labels) {
-      return null;
-    }
-
     let SidePanel;
 
     if (isAddLabel) {
@@ -1406,6 +1402,7 @@ const ManageHostsPage = ({
           onLabelClick={onLabelClick}
           selectedFilter={getLabelSelected() || getStatusSelected()}
           canAddNewLabel={canAddNewLabels as boolean}
+          isLabelsLoading={isLabelsLoading}
         />
       );
     }
@@ -1591,7 +1588,7 @@ const ManageHostsPage = ({
           {config && (!isPremiumTier || teams) ? renderTable() : <Spinner />}
         </div>
       )}
-      {!isLabelsLoading && renderSidePanel()}
+      {renderSidePanel()}
       {renderDeleteSecretModal()}
       {renderSecretEditorModal()}
       {renderEnrollSecretModal()}

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1586,7 +1586,6 @@ const ManageHostsPage = ({
               </div>
             ))}
           {config && (!isPremiumTier || teams) ? renderTable() : <Spinner />}
-          {/* TODO: Check out spinner here */}
         </div>
       )}
       {renderSidePanel()}


### PR DESCRIPTION
Cerra #3051 

- 3 loading states for dashboard (1 across 2 hosts cards, 1 for software table, 1 for activity table)
- 2 loading states for manage host page (1 for side panel for labels and 1 for manage hosts data table)
- New loading state for count on tables (count is greyed out if `isLoading`)

https://www.loom.com/share/ccd5c711443e42e7828ea2e611b9de23


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
