### PR TITLE
Refactor async host processing to avoid redis SCAN keys (for labels only)

### DIFF
--- a/changes/issue-3422-async-labels-avoid-scan
+++ b/changes/issue-3422-async-labels-avoid-scan
@@ -1,0 +1,1 @@
+* Refactor async host processing (`--enable_async_host_processing`) to avoid relying on slow redis SCAN keys.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -276,6 +276,7 @@ the way that the Fleet server works.
 				UpdateBatch:        config.Osquery.AsyncHostUpdateBatch,
 				RedisPopCount:      config.Osquery.AsyncHostRedisPopCount,
 				RedisScanKeysCount: config.Osquery.AsyncHostRedisScanKeysCount,
+				CollectorInterval:  config.Osquery.AsyncHostCollectInterval,
 			}
 			svc, err := service.NewService(ds, task, resultStore, logger, osqueryLogger, config, mailService, clock.C, ssoSessionStore, liveQueryStore, carveStore, *license, failingPolicySet)
 			if err != nil {
@@ -532,8 +533,7 @@ func runCrons(ds fleet.Datastore, task *async.Task, logger kitlog.Logger, config
 	}
 
 	// StartCollectors starts a goroutine per collector, using ctx to cancel.
-	task.StartCollectors(ctx, config.Osquery.AsyncHostCollectInterval,
-		config.Osquery.AsyncHostCollectMaxJitterPercent, kitlog.With(logger, "cron", "async_task"))
+	task.StartCollectors(ctx, config.Osquery.AsyncHostCollectMaxJitterPercent, kitlog.With(logger, "cron", "async_task"))
 
 	go cronCleanups(ctx, ds, kitlog.With(logger, "cron", "cleanups"), ourIdentifier, license)
 	go cronVulnerabilities(

--- a/server/service/async/async.go
+++ b/server/service/async/async.go
@@ -86,6 +86,14 @@ func (t *Task) RecordLabelQueryExecutions(ctx context.Context, host *fleet.Host,
 		return t.Datastore.RecordLabelQueryExecutions(ctx, host, results, ts, false)
 	}
 
+	// TODO(mna): regarding migrations of previous version to this one, first of
+	// all I believe we don't know of any user that activated the feature, but in
+	// any case, given that we use the same key names, just that we maintain an
+	// additional set of sets, there is no migration required - when the hosts
+	// start reporting new results, we will update their existing keys, set the
+	// new TTLs and insert the host IDs in the set of sets, resulting in the
+	// pending data being collected.
+
 	keySet := fmt.Sprintf(labelMembershipHostKey, host.ID)
 	keyTs := fmt.Sprintf(labelMembershipReportedKey, host.ID)
 

--- a/server/service/async/async.go
+++ b/server/service/async/async.go
@@ -85,15 +85,6 @@ func (t *Task) RecordLabelQueryExecutions(ctx context.Context, host *fleet.Host,
 		return t.Datastore.RecordLabelQueryExecutions(ctx, host, results, ts, false)
 	}
 
-	// TODO(mna): regarding migrations of previous version to this one, first of
-	// all I believe we don't know of any user that activated the feature, but in
-	// any case, given that we use the same key names, just that we maintain an
-	// additional set of sets, there is no migration required - when the hosts
-	// start reporting new results, we will update their existing keys, set the
-	// new TTLs and insert the host IDs in the set of sets, resulting in the
-	// pending data being collected. The only edge case would be if that host
-	// never checks in again, those keys would stick around (no TTL set before).
-
 	keySet := fmt.Sprintf(labelMembershipHostKey, host.ID)
 	keyTs := fmt.Sprintf(labelMembershipReportedKey, host.ID)
 


### PR DESCRIPTION
#3422  

**NOTE**: regarding migrating keys of previous implementation to this one, first of all I believe we don't know of any user that activated the feature, but in any case, given that we use the same key names, just that we maintain an additional set of sets, there is no migration required - when the hosts start reporting new results, we will update their existing keys, set the new TTLs and insert the host IDs in the set of sets, resulting in the pending data being collected. The only edge case would be if that host never checks in again, those keys would stick around (no TTL set before).

This adds a new sorted set `label_membership:active_host_ids` that keeps track of the host IDs that reported label results. When added to the set, the host ID is associated with its "reported-at" timestamp, stored as its score in the sorted set. This is so that we can safely remove processed host IDs from the set after a collection (i.e. after the redis data has been persisted to mysql) if and only if the score is still the same as when it was read (at the start of the collection), otherwise it means that new data has been reported for that host and it still belongs in the set. This is an important feature otherwise on each collection, we would need to query the data for every host that is still active, even if it did not report any new data since the last collection.

Next, the PR adds a TTL for both the host's label results key and the host's reported-at key, so that obsolete hosts don't use redis memory forever. That TTL is on the safe side - 1 week or 10 times the async collection interval, whichever is longest, and it is reset each time the host reports new data. This is so that the collector has more than enough time to persist the reported data, and the keys are highly unlikely to expire without being persisted.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [ ] ~~Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
- [ ] ~~Documented any permissions changes~~
- [x] Added/updated tests
- [ ] Manual QA for all new/changed functionality <-- to be done in load testing env.
