### PR TITLE
Bug fix: No matching hosts message

### DIFF
--- a/changes/issue-3291-empty-host-message-bug
+++ b/changes/issue-3291-empty-host-message-bug
@@ -1,0 +1,1 @@
+* Fix empty host message when no hosts match search criteria

--- a/frontend/pages/hosts/ManageHostsPage/components/EmptyHosts/EmptyHosts.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/EmptyHosts/EmptyHosts.tsx
@@ -10,7 +10,6 @@ interface IEmptyHostsProps {
 }
 
 const EmptyHosts = ({ pageIndex }: IEmptyHostsProps): JSX.Element => {
-  console.log("pageIndex", pageIndex);
   return (
     <div className={`${baseClass}`}>
       <div className={`${baseClass}__inner`}>

--- a/frontend/pages/hosts/ManageHostsPage/components/EmptyHosts/EmptyHosts.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/EmptyHosts/EmptyHosts.tsx
@@ -5,7 +5,12 @@ import React from "react";
 
 const baseClass = "empty-hosts";
 
-const EmptyHosts = (pageIndex: number): JSX.Element => {
+interface IEmptyHostsProps {
+  pageIndex: number;
+}
+
+const EmptyHosts = ({ pageIndex }: IEmptyHostsProps): JSX.Element => {
+  console.log("pageIndex", pageIndex);
   return (
     <div className={`${baseClass}`}>
       <div className={`${baseClass}__inner`}>


### PR DESCRIPTION
For #3291 

# Checklist for submitter

<img width="1489" alt="Screen Shot 2022-01-12 at 11 02 11 AM" src="https://user-images.githubusercontent.com/71795832/149176253-a2123078-18a1-4ae4-a568-3fddd3ed7aa6.png">

- Fix props for EmptyHosts component so pageIndex === 0 renders "No hosts match the current criteria" message.


If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
