### PR TITLE
Frontend tech debt: Clean up 409 lint warnings

### DIFF
--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -80,7 +80,6 @@ describe("Hosts flow", () => {
         cy.location("pathname").should("match", /hosts\/[0-9]/i);
         cy.getAttached(".status--online").should("exist");
         // Run policy on host
-        let policyname = "";
         cy.contains("a", "Policies").click();
         cy.getAttached("tbody").within(() => {
           cy.get(".button--text-link").first().as("policyLink");
@@ -88,7 +87,7 @@ describe("Hosts flow", () => {
         cy.getAttached("@policyLink")
           // Set policyname variable for later assertions
           .then((el) => {
-            policyname = el.text();
+            console.log(el);
             return el;
           });
         cy.findByText(/filevault/i)

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -1,5 +1,3 @@
-import _ = require("cypress/types/lodash");
-import { closeSync } from "fs";
 import * as path from "path";
 
 let hostname = "";

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -2,7 +2,6 @@ import React, { useContext, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import classnames from "classnames";
 import { AxiosResponse } from "axios";
-import { RouteProps } from "react-router/lib/Route";
 
 import { QueryClient, QueryClientProvider } from "react-query";
 

--- a/frontend/components/DeleteSecretModal/DeleteSecretModal.tsx
+++ b/frontend/components/DeleteSecretModal/DeleteSecretModal.tsx
@@ -2,19 +2,12 @@ import React from "react";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 import { ITeam } from "interfaces/team";
-import { IEnrollSecret } from "interfaces/enroll_secret";
 
 interface IDeleteSecretModal {
   selectedTeam: number;
   teams: ITeam[];
   onDeleteSecret: () => void;
   toggleDeleteSecretModal: () => void;
-}
-
-interface IRootState {
-  app: {
-    enrollSecret: IEnrollSecret[];
-  };
 }
 
 const baseClass = "delete-secret-modal";

--- a/frontend/components/FlashMessage/FlashMessage.tsx
+++ b/frontend/components/FlashMessage/FlashMessage.tsx
@@ -57,7 +57,7 @@ const FlashMessage = ({
   }, [notification, alertType, isVisible, setHide]);
 
   if (hide || !isVisible) {
-    return null;
+    return <></>;
   }
 
   const alertIcon =

--- a/frontend/components/PageHeader/TeamsDropdownHeader.tsx
+++ b/frontend/components/PageHeader/TeamsDropdownHeader.tsx
@@ -38,10 +38,8 @@ const TeamsDropdownHeader = ({
 
   const {
     availableTeams,
-    config,
     currentUser,
     currentTeam,
-    enrollSecret,
     isPreviewMode,
     isFreeTier,
     isPremiumTier,
@@ -51,9 +49,6 @@ const TeamsDropdownHeader = ({
     isOnGlobalTeam,
     isAnyTeamMaintainer,
     isAnyTeamMaintainerOrTeamAdmin,
-    isTeamObserver,
-    isTeamMaintainer,
-    isTeamMaintainerOrTeamAdmin,
     isAnyTeamAdmin,
     isTeamAdmin,
     isOnlyObserver,

--- a/frontend/components/SecretEditorModal/SecretEditorModal.tsx
+++ b/frontend/components/SecretEditorModal/SecretEditorModal.tsx
@@ -37,7 +37,7 @@ const SecretEditorModal = ({
   const [enrollSecretString, setEnrollSecretString] = useState<string>(
     selectedSecret ? selectedSecret.secret : randomSecretGenerator()
   );
-  const [errors, setErrors] = useState<{ [key: string]: any }>({});
+  const [errors, setErrors] = useState<{ [key: string]: string }>({});
 
   const renderTeam = () => {
     if (typeof selectedTeam === "string") {

--- a/frontend/components/TargetsInput/TargetsInputHostsTableConfig.tsx
+++ b/frontend/components/TargetsInput/TargetsInputHostsTableConfig.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 
 import React from "react";
-import { Cell } from "react-table";
 
 import { IDataColumn } from "interfaces/datatable_config";
 

--- a/frontend/components/TargetsInput/TargetsInputHostsTableConfig.tsx
+++ b/frontend/components/TargetsInput/TargetsInputHostsTableConfig.tsx
@@ -18,7 +18,7 @@ export const generateTableHeaders = (showDelete: boolean): IDataColumn[] => {
         {
           id: "delete",
           Header: "",
-          Cell: (cellProps: Cell): JSX.Element => (
+          Cell: (): JSX.Element => (
             <div>
               <img alt="Remove" src={RemoveIcon} />
             </div>

--- a/frontend/components/forms/ConfigurePackQueryForm/ConfigurePackQueryForm.jsx
+++ b/frontend/components/forms/ConfigurePackQueryForm/ConfigurePackQueryForm.jsx
@@ -9,7 +9,6 @@ import formFieldInterface from "interfaces/form_field";
 import InputField from "components/forms/fields/InputField";
 import validate from "components/forms/ConfigurePackQueryForm/validate";
 import {
-  FREQUENCY_DROPDOWN_OPTIONS,
   PLATFORM_DROPDOWN_OPTIONS,
   LOGGING_TYPE_OPTIONS,
   MIN_OSQUERY_VERSION_OPTIONS,

--- a/frontend/components/forms/packs/EditPackForm/EditPackForm.tsx
+++ b/frontend/components/forms/packs/EditPackForm/EditPackForm.tsx
@@ -25,30 +25,11 @@ interface IEditPackForm {
   onAddPackQuery: () => void;
   onEditPackQuery: (selectedQuery: IScheduledQuery) => void;
   onRemovePackQueries: (selectedTableQueryIds: number[]) => void;
-  onPackQueryFormSubmit: (
-    formData: IPackQueryFormData,
-    editQuery: IScheduledQuery | undefined
-  ) => boolean;
-  packId: number;
-  packTargets?: ITarget[];
   targetsCount?: number;
   isPremiumTier?: boolean;
   formData: IEditPackFormData;
   scheduledQueries: IScheduledQuery[];
   isLoadingPackQueries: boolean;
-}
-
-interface IPackQueryFormData {
-  interval: number;
-  name?: string;
-  shard: number;
-  query?: string;
-  query_id?: number;
-  removed: boolean;
-  snapshot: boolean;
-  pack_id: number;
-  platform: string;
-  version: string;
 }
 
 interface IEditPackFormData {
@@ -65,8 +46,6 @@ const EditPackForm = ({
   onAddPackQuery,
   onEditPackQuery,
   onRemovePackQueries,
-  onPackQueryFormSubmit,
-  packId,
   scheduledQueries,
   isLoadingPackQueries,
   targetsCount,
@@ -153,9 +132,7 @@ const EditPackForm = ({
         onAddPackQuery={onAddPackQuery}
         onEditPackQuery={onEditPackQuery}
         onRemovePackQueries={onRemovePackQueries}
-        onPackQueryFormSubmit={onPackQueryFormSubmit}
         scheduledQueries={scheduledQueries}
-        packId={packId}
         isLoadingPackQueries={isLoadingPackQueries}
       />
       <div className={`${baseClass}__pack-buttons`}>

--- a/frontend/components/forms/packs/EditPackForm/EditPackForm.tsx
+++ b/frontend/components/forms/packs/EditPackForm/EditPackForm.tsx
@@ -52,7 +52,7 @@ const EditPackForm = ({
   isPremiumTier,
   formData,
 }: IEditPackForm): JSX.Element => {
-  const [errors, setErrors] = useState<{ [key: string]: any }>({});
+  const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const [packName, setPackName] = useState<string>(formData.name);
   const [packDescription, setPackDescription] = useState<string>(
     formData.description

--- a/frontend/components/forms/packs/PackForm/PackForm.tsx
+++ b/frontend/components/forms/packs/PackForm/PackForm.tsx
@@ -20,7 +20,6 @@ interface IPackForm {
   ) => boolean;
   selectedTargetsCount?: number;
   isPremiumTier?: boolean;
-  formData: IEditPackFormData;
   baseError: any;
 }
 
@@ -28,10 +27,6 @@ interface IEditPackFormData {
   name: string;
   description: string;
   targets: ITarget[];
-}
-
-interface IFormErrors {
-  name?: string;
 }
 
 const EditPackForm = ({

--- a/frontend/components/forms/packs/PackForm/PackForm.tsx
+++ b/frontend/components/forms/packs/PackForm/PackForm.tsx
@@ -37,7 +37,7 @@ const EditPackForm = ({
   isPremiumTier,
   baseError,
 }: IPackForm): JSX.Element => {
-  const [errors, setErrors] = useState<{ [key: string]: any }>({});
+  const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const [packName, setPackName] = useState<string>("");
   const [packDescription, setPackDescription] = useState<string>("");
   const [packFormTargets, setPackFormTargets] = useState<ITarget[] | []>([]);

--- a/frontend/components/queries/PackQueriesListWrapper/PackQueriesListWrapper.tsx
+++ b/frontend/components/queries/PackQueriesListWrapper/PackQueriesListWrapper.tsx
@@ -1,5 +1,4 @@
-import React, { Component, useState } from "react";
-import PropTypes from "prop-types";
+import React, { useState } from "react";
 // @ts-ignore
 import simpleSearch from "utilities/simple_search";
 import TableContainer, { ITableQueryData } from "components/TableContainer";
@@ -15,29 +14,11 @@ import AddQueryIcon from "../../../../assets/images/icon-plus-16x16@2x.png";
 
 const baseClass = "pack-queries-list-wrapper";
 
-interface IFormData {
-  interval: number;
-  name?: string;
-  shard: number;
-  query?: string;
-  query_id?: number;
-  snapshot: boolean;
-  removed: boolean;
-  platform: string;
-  version: string;
-  pack_id: number;
-}
-
 interface IPackQueriesListWrapperProps {
   onAddPackQuery: () => void;
   onEditPackQuery: (selectedQuery: IScheduledQuery) => void;
   onRemovePackQueries: (selectedTableQueryIds: number[]) => void;
-  onPackQueryFormSubmit: (
-    formData: IFormData,
-    editQuery: IScheduledQuery | undefined
-  ) => void;
   scheduledQueries: IScheduledQuery[] | undefined;
-  packId: number;
   isLoadingPackQueries: boolean;
 }
 

--- a/frontend/components/queries/PackQueriesListWrapper/PackQueriesTable/PackQueriesTableConfig.tsx
+++ b/frontend/components/queries/PackQueriesListWrapper/PackQueriesTable/PackQueriesTableConfig.tsx
@@ -16,6 +16,9 @@ import { IDropdownOption } from "interfaces/dropdownOption";
 interface IGetToggleAllRowsSelectedProps {
   checked: boolean;
   indeterminate: boolean;
+  title: string;
+  onChange: () => any;
+  style: { cursor: string };
 }
 interface IHeaderProps {
   column: {
@@ -32,7 +35,7 @@ interface ICellProps {
   };
   row: {
     original: IScheduledQuery;
-    getToggleRowSelectedProps: () => any; // TODO: do better with types
+    getToggleRowSelectedProps: () => IGetToggleAllRowsSelectedProps;
     toggleRowSelected: () => void;
   };
 }
@@ -61,6 +64,8 @@ const generateTableHeaders = (
       id: "selection",
       Header: (cellProps: IHeaderProps): JSX.Element => {
         const props = cellProps.getToggleAllRowsSelectedProps();
+        console.log("props", props);
+        console.log("props.onChange", props.onChange);
         const checkboxProps = {
           value: props.checked,
           indeterminate: props.indeterminate,

--- a/frontend/components/queries/PackQueriesListWrapper/PackQueriesTable/PackQueriesTableConfig.tsx
+++ b/frontend/components/queries/PackQueriesListWrapper/PackQueriesTable/PackQueriesTableConfig.tsx
@@ -13,12 +13,16 @@ import TextCell from "components/TableContainer/DataTable/TextCell";
 import { IScheduledQuery } from "interfaces/scheduled_query";
 import { IDropdownOption } from "interfaces/dropdownOption";
 
+interface IGetToggleAllRowsSelectedProps {
+  checked: boolean;
+  indeterminate: boolean;
+}
 interface IHeaderProps {
   column: {
     title: string;
     isSortedDesc: boolean;
   };
-  getToggleAllRowsSelectedProps: () => any; // TODO: do better with types
+  getToggleAllRowsSelectedProps: () => IGetToggleAllRowsSelectedProps;
   toggleAllRowsSelected: () => void;
 }
 

--- a/frontend/components/queries/PackQueriesListWrapper/PackQueriesTable/PackQueriesTableConfig.tsx
+++ b/frontend/components/queries/PackQueriesListWrapper/PackQueriesTable/PackQueriesTableConfig.tsx
@@ -64,8 +64,6 @@ const generateTableHeaders = (
       id: "selection",
       Header: (cellProps: IHeaderProps): JSX.Element => {
         const props = cellProps.getToggleAllRowsSelectedProps();
-        console.log("props", props);
-        console.log("props.onChange", props.onChange);
         const checkboxProps = {
           value: props.checked,
           indeterminate: props.indeterminate,

--- a/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tsx
+++ b/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tsx
@@ -25,7 +25,7 @@ const QuerySidePanel = ({
   selectedOsqueryTable,
   onOsqueryTableSelect,
   onClose,
-}: IQuerySidePanel) => {
+}: IQuerySidePanel): JSX.Element => {
   const displayTypeForDataType = (dataType: string) => {
     switch (dataType) {
       case "TEXT_TYPE":

--- a/frontend/components/top_nav/SiteTopNav/SiteTopNav.tsx
+++ b/frontend/components/top_nav/SiteTopNav/SiteTopNav.tsx
@@ -21,8 +21,8 @@ import PacksIcon from "../../../../assets/images/icon-main-packs@2x-16x16@2x.png
 import PoliciesIcon from "../../../../assets/images/icon-main-policies-16x16@2x.png";
 
 interface ISiteTopNavProps {
-  onLogoutUser: () => any;
-  onNavItemClick: () => any;
+  onLogoutUser: () => void;
+  onNavItemClick: (path: string) => void;
   pathname: string;
   currentUser: IUser;
   config: IConfig;

--- a/frontend/components/top_nav/SiteTopNav/navItems.ts
+++ b/frontend/components/top_nav/SiteTopNav/navItems.ts
@@ -20,7 +20,7 @@ export default (
   isAnyTeamMaintainer = false,
   isGlobalMaintainer = false,
   isNoAccess = false
-) => {
+): INavItem[] => {
   if (!user) {
     return [];
   }

--- a/frontend/fleet/entities/teams.ts
+++ b/frontend/fleet/entities/teams.ts
@@ -1,7 +1,6 @@
 import endpoints from "fleet/endpoints";
 import { INewMembersBody, IRemoveMembersBody, ITeam } from "interfaces/team";
 import { ICreateTeamFormData } from "pages/admin/TeamManagementPage/components/CreateTeamModal/CreateTeamModal";
-import { getEnrollSecrets } from "../../redux/nodes/entities/teams/actions";
 
 interface ILoadAllTeamsResponse {
   teams: ITeam[];

--- a/frontend/fleet/helpers.ts
+++ b/frontend/fleet/helpers.ts
@@ -182,6 +182,7 @@ export const frontendFormattedConfig = (config: any) => {
     webhook_settings: { host_status_webhook: webhookSettings }, // unnested to frontend
     update_interval: updateInterval,
     license,
+    logging,
   } = config;
 
   if (config.agent_options) {
@@ -197,6 +198,7 @@ export const frontendFormattedConfig = (config: any) => {
     ...webhookSettings,
     ...updateInterval,
     ...license,
+    ...logging,
     agent_options: config.agent_options,
   };
 };

--- a/frontend/fleet/helpers.ts
+++ b/frontend/fleet/helpers.ts
@@ -32,7 +32,7 @@ export const addGravatarUrlToResource = (resource: any): any => {
   };
 };
 
-const labelSlug = (label: any): string => {
+const labelSlug = (label: ILabel): string => {
   const { id, name } = label;
 
   if (name === "All Hosts") {

--- a/frontend/fleet/helpers.ts
+++ b/frontend/fleet/helpers.ts
@@ -3,7 +3,9 @@ import md5 from "js-md5";
 import moment from "moment";
 import yaml from "js-yaml";
 
+import { IConfigNested } from "interfaces/config";
 import { ILabel } from "interfaces/label";
+import { IPack } from "interfaces/pack";
 import { ITeam, ITeamSummary } from "interfaces/team";
 import { IUser } from "interfaces/user";
 import { IPackQueryFormData } from "interfaces/scheduled_query";
@@ -172,7 +174,7 @@ export const formatConfigDataForServer = (config: any): any => {
 };
 
 // TODO: Finalize interface for config - see frontend\interfaces\config.ts
-export const frontendFormattedConfig = (config: any) => {
+export const frontendFormattedConfig = (config: IConfigNested) => {
   const {
     org_info: orgInfo,
     server_settings: serverSettings,
@@ -204,7 +206,7 @@ export const frontendFormattedConfig = (config: any) => {
 };
 
 const formatLabelResponse = (response: any): ILabel[] => {
-  const labels = response.labels.map((label: any) => {
+  const labels = response.labels.map((label: ILabel) => {
     return {
       ...label,
       slug: labelSlug(label),
@@ -420,14 +422,14 @@ export const formatTeamScheduledQueryForClient = (scheduledQuery: any): any => {
   return scheduledQuery;
 };
 
-export const formatTeamForClient = (team: any): any => {
+export const formatTeamForClient = (team: ITeam): ITeam => {
   if (team.display_text === undefined) {
     team.display_text = team.name;
   }
   return team;
 };
 
-export const formatPackForClient = (pack: any): any => {
+export const formatPackForClient = (pack: IPack): IPack => {
   pack.host_ids ||= [];
   pack.label_ids ||= [];
   pack.team_ids ||= [];

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -125,14 +125,14 @@ export interface IConfig {
         enable_log_compression: boolean;
       };
     };
-    status: {
-      plugin: string;
-      config: {
-        status_log_file: string;
-        result_log_file: string;
-        enable_log_rotation: boolean;
-        enable_log_compression: boolean;
-      };
+  };
+  status: {
+    plugin: string;
+    config: {
+      status_log_file: string;
+      result_log_file: string;
+      enable_log_rotation: boolean;
+      enable_log_compression: boolean;
     };
   };
   webhook_settings: {

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -113,17 +113,15 @@ export interface IConfig {
   destination_url: string;
   host_percentage: number;
   days_count: number;
-  logging?: {
-    debug: boolean;
-    json: boolean;
-    result: {
-      plugin: string;
-      config: {
-        status_log_file: string;
-        result_log_file: string;
-        enable_log_rotation: boolean;
-        enable_log_compression: boolean;
-      };
+  debug: boolean;
+  json: boolean;
+  result: {
+    plugin: string;
+    config: {
+      status_log_file: string;
+      result_log_file: string;
+      enable_log_rotation: boolean;
+      enable_log_compression: boolean;
     };
   };
   status: {

--- a/frontend/interfaces/label.ts
+++ b/frontend/interfaces/label.ts
@@ -1,4 +1,4 @@
-import PropTypes, { string } from "prop-types";
+import PropTypes from "prop-types";
 
 export default PropTypes.shape({
   created_at: PropTypes.string,

--- a/frontend/interfaces/label.ts
+++ b/frontend/interfaces/label.ts
@@ -28,7 +28,7 @@ export interface ILabel {
   display_text: string;
   count: number; // seems to be a repeat of hosts_count issue #1618
   host_ids: number[] | null;
-  type: "custom" | "platform" | "status" | "all";
+  type?: "custom" | "platform" | "status" | "all";
   slug?: string; // e.g., "labels/13" | "online"
   target_type?: string; // e.g., "labels"
   platform: string;

--- a/frontend/interfaces/scheduled_query_stats.ts
+++ b/frontend/interfaces/scheduled_query_stats.ts
@@ -1,4 +1,4 @@
-import PropTypes, { number } from "prop-types";
+import PropTypes from "prop-types";
 
 export default PropTypes.shape({
   user_time_p50: PropTypes.number,

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -85,7 +85,7 @@ const Homepage = (): JSX.Element => {
       }),
     {
       select: (data: IHostSummary) => data,
-      onSuccess: (data: any) => {
+      onSuccess: (data: IHostSummary) => {
         setOnlineCount(data.online_count.toLocaleString("en-US"));
         setOfflineCount(data.offline_count.toLocaleString("en-US"));
         setNewCount(data.new_count.toLocaleString("en-US"));

--- a/frontend/pages/Homepage/components/LastUpdatedText/LastUpdatedText.tsx
+++ b/frontend/pages/Homepage/components/LastUpdatedText/LastUpdatedText.tsx
@@ -8,7 +8,7 @@ import QuestionIcon from "../../../../../assets/images/icon-question-16x16@2x.pn
 const renderLastUpdatedText = (
   lastUpdatedAt: string,
   whatToRetrieve: string
-) => {
+): JSX.Element => {
   if (!lastUpdatedAt || lastUpdatedAt === "0001-01-01T00:00:00Z") {
     lastUpdatedAt = "never";
   } else {

--- a/frontend/pages/LoginPage/PreviewLoginPage.tsx
+++ b/frontend/pages/LoginPage/PreviewLoginPage.tsx
@@ -21,7 +21,7 @@ interface ILoginData {
   password: string;
 }
 
-const PreviewLoginPage = () => {
+const PreviewLoginPage = (): JSX.Element => {
   const dispatch = useDispatch();
   const { isPreviewMode, setAvailableTeams, setCurrentUser } = useContext(
     AppContext

--- a/frontend/pages/admin/AppSettingsPage/AppSettingsPage.tsx
+++ b/frontend/pages/admin/AppSettingsPage/AppSettingsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect } from "react";
+import React, { useCallback, useContext } from "react";
 import { useDispatch } from "react-redux";
 import { useQuery } from "react-query";
 // @ts-ignore

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { useQuery } from "react-query";
 import { useErrorHandler } from "react-error-boundary";
 import yaml from "js-yaml";
@@ -59,7 +59,9 @@ const AgentOptionsPage = ({
     }
   );
 
-  const onSaveOsqueryOptionsFormSubmit = (updatedForm: any): void | false => {
+  const onSaveOsqueryOptionsFormSubmit = (updatedForm: {
+    osquery_options: string;
+  }): void | false => {
     const { TEAMS_AGENT_OPTIONS } = endpoints;
     const { error } = validateYaml(updatedForm.osquery_options);
     if (error) {

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
@@ -77,7 +77,7 @@ const AgentOptionsPage = ({
       .then(() => {
         dispatch(renderFlash("success", "Successfully saved agent options"));
       })
-      .catch((errors: { [key: string]: any }) => {
+      .catch((errors: { [key: string]: string }) => {
         dispatch(renderFlash("error", errors.stack));
       });
   };

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/MembersPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/MembersPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState } from "react";
+import React, { useCallback, useContext, useState } from "react";
 import { useDispatch } from "react-redux";
 import { useQuery } from "react-query";
 

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/components/AddMemberModal/AddMemberModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/components/AddMemberModal/AddMemberModal.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useState } from "react";
 
 import { INewMembersBody, ITeam } from "interfaces/team";
-import { IUser } from "interfaces/user";
 import endpoints from "fleet/endpoints";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useContext } from "react";
+import React, { useState, useCallback, useContext } from "react";
 import { useDispatch } from "react-redux";
 import { useQuery } from "react-query";
 import { useErrorHandler } from "react-error-boundary";

--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -96,8 +96,7 @@ const TeamManagementPage = (): JSX.Element => {
           toggleCreateTeamModal();
         })
         .catch((createError: any) => {
-          console.error(createError);
-          if (createError.errors[0].reason.includes("Duplicate")) {
+          if (createError.data.errors[0].reason.includes("Duplicate")) {
             dispatch(
               renderFlash("error", "A team with this name already exists.")
             );

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.tsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.tsx
@@ -64,8 +64,6 @@ const UserManagementPage = (): JSX.Element => {
   });
   const [querySearchText, setQuerySearchText] = useState<string>("");
 
-  console.log("userEditing", userEditing);
-
   // API CALLS
   const {
     data: teams,

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.tsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.tsx
@@ -421,7 +421,7 @@ const UserManagementPage = (): JSX.Element => {
     const isResettingCurrentUser = currentUser?.id === userEditing.id;
 
     usersAPI
-      .deleteSessions(userEditing.id, isResettingCurrentUser)
+      .deleteSessions(userEditing.id)
       .then(() => {
         if (isResettingCurrentUser) {
           dispatch({ type: "LOGOUT_SUCCESS" });

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.tsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.tsx
@@ -64,6 +64,8 @@ const UserManagementPage = (): JSX.Element => {
   });
   const [querySearchText, setQuerySearchText] = useState<string>("");
 
+  console.log("userEditing", userEditing);
+
   // API CALLS
   const {
     data: teams,

--- a/frontend/pages/admin/UserManagementPage/components/CreateUserModal/CreateUserModal.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/CreateUserModal/CreateUserModal.tsx
@@ -22,7 +22,6 @@ interface ICreateUserModalProps {
   isModifiedByGlobalAdmin?: boolean | false;
   isFormSubmitting?: boolean | false;
   serverErrors?: { base: string; email: string };
-  userErrors?: { base: string; email: string };
   createUserErrors?: IUserFormErrors;
 }
 

--- a/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
@@ -82,8 +82,6 @@ const updateFormState = (
   newValue: any,
   updateType: string
 ): ITeamCheckboxListItem[] => {
-  console.log("newValue", newValue);
-
   const prevItemIndex = prevTeamItems.findIndex((item) => item.id === teamId);
   const prevItem = prevTeamItems[prevItemIndex];
 

--- a/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
@@ -82,6 +82,8 @@ const updateFormState = (
   newValue: any,
   updateType: string
 ): ITeamCheckboxListItem[] => {
+  console.log("newValue", newValue);
+
   const prevItemIndex = prevTeamItems.findIndex((item) => item.id === teamId);
   const prevItem = prevTeamItems[prevItemIndex];
 

--- a/frontend/pages/errors/Fleet500/Fleet500.jsx
+++ b/frontend/pages/errors/Fleet500/Fleet500.jsx
@@ -18,7 +18,6 @@ const baseClass = "fleet-500";
 
 class Fleet500 extends Component {
   static propTypes = {
-    errors: errorsInterface,
     dispatch: PropTypes.func,
   };
 

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState, useCallback, useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { Link } from "react-router";
-import { Params } from "react-router/lib/Router";
+import { Params, InjectedRouter } from "react-router/lib/Router";
 import { useQuery } from "react-query";
 import { useErrorHandler } from "react-error-boundary";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
@@ -88,7 +88,7 @@ import TransferIcon from "../../../../assets/images/icon-action-transfer-16x16@2
 const baseClass = "host-details";
 
 interface IHostDetailsProps {
-  router: any;
+  router: InjectedRouter; // v3
   params: Params;
 }
 
@@ -102,6 +102,13 @@ interface ITeamsResponse {
 
 interface IHostResponse {
   host: IHost;
+}
+interface ISearchQueryData {
+  searchQuery: string;
+  sortHeader: string;
+  sortDirection: string;
+  pageSize: number;
+  pageIndex: number;
 }
 
 const TAGGED_TEMPLATES = {
@@ -514,10 +521,14 @@ const HostDetailsPage = ({
     }
   };
 
-  const onUsersTableSearchChange = useCallback((queryData: any) => {
-    const { searchQuery } = queryData;
-    setUsersSearchString(searchQuery);
-  }, []);
+  const onUsersTableSearchChange = useCallback(
+    (queryData: ISearchQueryData) => {
+      console.log("queryData", queryData);
+      const { searchQuery } = queryData;
+      setUsersSearchString(searchQuery);
+    },
+    []
+  );
 
   const renderOsPolicyLabel = () => {
     const onCopyOsPolicy = (evt: React.MouseEvent) => {

--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.tsx
@@ -523,7 +523,6 @@ const HostDetailsPage = ({
 
   const onUsersTableSearchChange = useCallback(
     (queryData: ISearchQueryData) => {
-      console.log("queryData", queryData);
       const { searchQuery } = queryData;
       setUsersSearchString(searchQuery);
     },

--- a/frontend/pages/hosts/HostDetailsPage/SelectQueryModal/SelectQueryModal.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/SelectQueryModal/SelectQueryModal.tsx
@@ -32,7 +32,7 @@ const SelectQueryModal = ({
   queries,
   queryErrors,
   isOnlyObserver,
-}: ISelectQueryModalProps) => {
+}: ISelectQueryModalProps): JSX.Element => {
   let queriesAvailableToRun = queries;
 
   const [queriesFilter, setQueriesFilter] = useState("");

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -24,12 +24,16 @@ import PATHS from "router/paths";
 import permissionUtils from "utilities/permissions";
 import IssueIcon from "../../../../assets/images/icon-issue-fleet-black-16x16@2x.png";
 
+interface IGetToggleAllRowsSelectedProps {
+  checked: boolean;
+  indeterminate: boolean;
+}
 interface IHeaderProps {
   column: {
     title: string;
     isSortedDesc: boolean;
   };
-  getToggleAllRowsSelectedProps: () => any; // TODO: do better with types
+  getToggleAllRowsSelectedProps: () => IGetToggleAllRowsSelectedProps;
   toggleAllRowsSelected: () => void;
 }
 

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -27,6 +27,9 @@ import IssueIcon from "../../../../assets/images/icon-issue-fleet-black-16x16@2x
 interface IGetToggleAllRowsSelectedProps {
   checked: boolean;
   indeterminate: boolean;
+  title: string;
+  onChange: () => any;
+  style: { cursor: string };
 }
 interface IHeaderProps {
   column: {
@@ -43,7 +46,7 @@ interface ICellProps {
   };
   row: {
     original: IHost;
-    getToggleRowSelectedProps: () => any; // TODO: do better with types
+    getToggleRowSelectedProps: () => IGetToggleAllRowsSelectedProps;
     toggleRowSelected: () => void;
   };
 }

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -730,7 +730,7 @@ const ManageHostsPage = ({
       }
 
       // Rebuild queryParams to dispatch new browser location to react-router
-      const newQueryParams: { [key: string]: any } = {};
+      const newQueryParams: { [key: string]: string | number } = {};
       if (!isEmpty(searchText)) {
         newQueryParams.query = searchText;
       }

--- a/frontend/pages/hosts/ManageHostsPage/helpers.ts
+++ b/frontend/pages/hosts/ManageHostsPage/helpers.ts
@@ -48,7 +48,7 @@ export const HOST_SELECT_STATUSES = [
   },
 ];
 
-export const isAcceptableStatus = (filter: string) => {
+export const isAcceptableStatus = (filter: string): boolean => {
   return (
     filter === "new" ||
     filter === "online" ||
@@ -57,7 +57,7 @@ export const isAcceptableStatus = (filter: string) => {
   );
 };
 
-export const isValidPolicyResponse = (filter: string) => {
+export const isValidPolicyResponse = (filter: string): boolean => {
   return filter === "pass" || filter === "fail";
 };
 

--- a/frontend/pages/packs/EditPackPage/EditPackPage.tsx
+++ b/frontend/pages/packs/EditPackPage/EditPackPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useContext } from "react";
 import { useQuery } from "react-query";
-import { Params } from "react-router/lib/Router";
+import { InjectedRouter, Params } from "react-router/lib/Router";
 
 import { useDispatch } from "react-redux";
 import { push } from "react-router-redux";
@@ -29,7 +29,7 @@ import PackQueryEditorModal from "./components/PackQueryEditorModal";
 import RemovePackQueryModal from "./components/RemovePackQueryModal";
 
 interface IEditPacksPageProps {
-  router: any;
+  router: InjectedRouter; // v3
   params: Params;
 }
 

--- a/frontend/pages/packs/EditPackPage/EditPackPage.tsx
+++ b/frontend/pages/packs/EditPackPage/EditPackPage.tsx
@@ -249,9 +249,7 @@ const EditPacksPage = ({
           onAddPackQuery={togglePackQueryEditorModal}
           onEditPackQuery={onEditPackQueryClick}
           onRemovePackQueries={onRemovePackQueriesClick}
-          onPackQueryFormSubmit={onPackQueryEditorSubmit}
           scheduledQueries={storedPackQueries}
-          packId={packId}
           isLoadingPackQueries={isStoredPackQueriesLoading}
         />
       )}

--- a/frontend/pages/packs/EditPackPage/components/PackQueryEditorModal/PackQueryEditorModal.tsx
+++ b/frontend/pages/packs/EditPackPage/components/PackQueryEditorModal/PackQueryEditorModal.tsx
@@ -65,10 +65,6 @@ const PackQueryEditorModal = ({
   editQuery,
   packId,
 }: IPackQueryEditorModalProps): JSX.Element => {
-  const [loggingConfig, setLoggingConfig] = useState("");
-  const [isLoading, setIsLoading] = useState(true);
-  const [isLoadingError, setIsLoadingError] = useState(false);
-
   const [selectedQuery, setSelectedQuery] = useState<
     IScheduledQuery | INoQueryOption
   >();
@@ -95,20 +91,6 @@ const PackQueryEditorModal = ({
   const [selectedShard, setSelectedShard] = useState<string>(
     editQuery?.shard ? editQuery?.shard.toString() : ""
   );
-
-  useEffect((): void => {
-    const getConfigDestination = async (): Promise<void> => {
-      try {
-        const responseConfig = await Fleet.config.loadAll();
-        setIsLoading(false);
-        setLoggingConfig(responseConfig.logging.result.plugin);
-      } catch (err) {
-        setIsLoadingError(true);
-        setIsLoading(false);
-      }
-    };
-    getConfigDestination();
-  }, []);
 
   const createQueryDropdownOptions = () => {
     const queryOptions = allQueries.map((q) => {

--- a/frontend/pages/packs/EditPackPage/components/PackQueryEditorModal/PackQueryEditorModal.tsx
+++ b/frontend/pages/packs/EditPackPage/components/PackQueryEditorModal/PackQueryEditorModal.tsx
@@ -1,8 +1,6 @@
 /* This component is used for creating and editing pack queries */
 
-import React, { useState, useEffect } from "react";
-// @ts-ignore
-import Fleet from "fleet";
+import React, { useState } from "react";
 import { pull } from "lodash";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";

--- a/frontend/pages/packs/ManagePacksPage/ManagePacksPage.tsx
+++ b/frontend/pages/packs/ManagePacksPage/ManagePacksPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useContext } from "react";
 import { useDispatch } from "react-redux";
 import { useQuery } from "react-query";
+import { InjectedRouter } from "react-router/lib/Router";
 
 import { IPack } from "interfaces/pack";
 import { IError } from "interfaces/errors";
@@ -22,7 +23,7 @@ import RemovePackModal from "./components/RemovePackModal";
 const baseClass = "manage-packs-page";
 
 interface IManagePacksPageProps {
-  router: any;
+  router: InjectedRouter; // v3
 }
 
 interface IPacksResponse {
@@ -30,9 +31,9 @@ interface IPacksResponse {
 }
 
 const renderTable = (
-  onRemovePackClick: React.MouseEventHandler<HTMLButtonElement>,
-  onEnablePackClick: React.MouseEventHandler<HTMLButtonElement>,
-  onDisablePackClick: React.MouseEventHandler<HTMLButtonElement>,
+  onRemovePackClick: (selectedTablePackIds: number[]) => void,
+  onEnablePackClick: (selectedTablePackIds: number[]) => void,
+  onDisablePackClick: (selectedTablePackIds: number[]) => void,
   onCreatePackClick: React.MouseEventHandler<HTMLButtonElement>,
   packs: IPack[] | undefined,
   packsError: IError | null,
@@ -88,7 +89,7 @@ const ManagePacksPage = ({ router }: IManagePacksPageProps): JSX.Element => {
     setShowRemovePackModal(!showRemovePackModal);
   }, [showRemovePackModal, setShowRemovePackModal]);
 
-  const onRemovePackClick = (selectedTablePackIds: any) => {
+  const onRemovePackClick = (selectedTablePackIds: number[]) => {
     toggleRemovePackModal();
     setSelectedPackIds(selectedTablePackIds);
   };
@@ -121,7 +122,7 @@ const ManagePacksPage = ({ router }: IManagePacksPageProps): JSX.Element => {
   }, [dispatch, refetchPacks, selectedPackIds, toggleRemovePackModal]);
 
   const onEnableDisablePackSubmit = useCallback(
-    (selectedTablePackIds: any, disablePack: boolean) => {
+    (selectedTablePackIds: number[], disablePack: boolean) => {
       const packOrPacks = selectedPackIds.length === 1 ? "pack" : "packs";
       const enableOrDisable = disablePack ? "disabled" : "enabled";
 
@@ -153,12 +154,12 @@ const ManagePacksPage = ({ router }: IManagePacksPageProps): JSX.Element => {
     [dispatch, refetchPacks, selectedPackIds]
   );
 
-  const onEnablePackClick = (selectedTablePackIds: any) => {
+  const onEnablePackClick = (selectedTablePackIds: number[]) => {
     setSelectedPackIds(selectedTablePackIds);
     onEnableDisablePackSubmit(selectedTablePackIds, false);
   };
 
-  const onDisablePackClick = (selectedTablePackIds: any) => {
+  const onDisablePackClick = (selectedTablePackIds: number[]) => {
     setSelectedPackIds(selectedTablePackIds);
     onEnableDisablePackSubmit(selectedTablePackIds, true);
   };

--- a/frontend/pages/packs/ManagePacksPage/components/PacksListWrapper/PacksListWrapper.tsx
+++ b/frontend/pages/packs/ManagePacksPage/components/PacksListWrapper/PacksListWrapper.tsx
@@ -1,10 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { useSelector } from "react-redux";
 
 import { IPack } from "interfaces/pack";
-import { IUser } from "interfaces/user";
 import Button from "components/buttons/Button";
-import permissionUtils from "utilities/permissions";
 
 import TableContainer from "components/TableContainer";
 import { IActionButtonProps } from "components/TableContainer/DataTable/ActionButton";

--- a/frontend/pages/packs/ManagePacksPage/components/PacksListWrapper/PacksListWrapper.tsx
+++ b/frontend/pages/packs/ManagePacksPage/components/PacksListWrapper/PacksListWrapper.tsx
@@ -22,12 +22,6 @@ interface IPacksListWrapperProps {
   isLoading: boolean;
 }
 
-interface IRootState {
-  auth: {
-    user: IUser;
-  };
-}
-
 const PacksListWrapper = ({
   onRemovePackClick,
   onEnablePackClick,
@@ -36,9 +30,6 @@ const PacksListWrapper = ({
   packs,
   isLoading,
 }: IPacksListWrapperProps): JSX.Element => {
-  const currentUser = useSelector((state: IRootState) => state.auth.user);
-  const isOnlyObserver = permissionUtils.isOnlyObserver(currentUser);
-
   const [filteredPacks, setFilteredPacks] = useState<IPack[] | undefined>(
     packs
   );
@@ -99,7 +90,7 @@ const PacksListWrapper = ({
     );
   }, [searchString]);
 
-  const tableHeaders = generateTableHeaders(isOnlyObserver);
+  const tableHeaders = generateTableHeaders();
 
   const secondarySelectActions: IActionButtonProps[] = [
     {

--- a/frontend/pages/packs/ManagePacksPage/components/PacksListWrapper/PacksTableConfig.tsx
+++ b/frontend/pages/packs/ManagePacksPage/components/PacksListWrapper/PacksTableConfig.tsx
@@ -19,6 +19,9 @@ import { IPack } from "interfaces/pack";
 interface IGetToggleAllRowsSelectedProps {
   checked: boolean;
   indeterminate: boolean;
+  title: string;
+  onChange: () => any;
+  style: { cursor: string };
 }
 
 interface IHeaderProps {
@@ -36,7 +39,7 @@ interface ICellProps {
   };
   row: {
     original: IPack;
-    getToggleRowSelectedProps: () => any; // TODO: do better with types
+    getToggleRowSelectedProps: () => IGetToggleAllRowsSelectedProps;
     toggleRowSelected: () => void;
   };
 }
@@ -68,6 +71,7 @@ const generateTableHeaders = (): IDataColumn[] => {
       id: "selection",
       Header: (cellProps: IHeaderProps): JSX.Element => {
         const props = cellProps.getToggleAllRowsSelectedProps();
+        console.log("props", props);
         const checkboxProps = {
           value: props.checked,
           indeterminate: props.indeterminate,

--- a/frontend/pages/packs/ManagePacksPage/components/PacksListWrapper/PacksTableConfig.tsx
+++ b/frontend/pages/packs/ManagePacksPage/components/PacksListWrapper/PacksTableConfig.tsx
@@ -71,7 +71,6 @@ const generateTableHeaders = (): IDataColumn[] => {
       id: "selection",
       Header: (cellProps: IHeaderProps): JSX.Element => {
         const props = cellProps.getToggleAllRowsSelectedProps();
-        console.log("props", props);
         const checkboxProps = {
           value: props.checked,
           indeterminate: props.indeterminate,

--- a/frontend/pages/packs/ManagePacksPage/components/PacksListWrapper/PacksTableConfig.tsx
+++ b/frontend/pages/packs/ManagePacksPage/components/PacksListWrapper/PacksTableConfig.tsx
@@ -57,7 +57,7 @@ interface IPackTableData {
 
 // NOTE: cellProps come from react-table
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
-const generateTableHeaders = (isOnlyObserver = true): IDataColumn[] => {
+const generateTableHeaders = (): IDataColumn[] => {
   const tableHeaders: IDataColumn[] = [
     {
       id: "selection",

--- a/frontend/pages/packs/ManagePacksPage/components/PacksListWrapper/PacksTableConfig.tsx
+++ b/frontend/pages/packs/ManagePacksPage/components/PacksListWrapper/PacksTableConfig.tsx
@@ -16,12 +16,17 @@ import PATHS from "router/paths";
 
 import { IPack } from "interfaces/pack";
 
+interface IGetToggleAllRowsSelectedProps {
+  checked: boolean;
+  indeterminate: boolean;
+}
+
 interface IHeaderProps {
   column: {
     title: string;
     isSortedDesc: boolean;
   };
-  getToggleAllRowsSelectedProps: () => any; // TODO: do better with types
+  getToggleAllRowsSelectedProps: () => IGetToggleAllRowsSelectedProps;
   toggleAllRowsSelected: () => void;
 }
 

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -77,8 +77,6 @@ const ManagePolicyPage = ({
     ? parseInt(location?.query?.team_id, 10)
     : 0;
 
-  console.log("teamId", teamId);
-
   const {
     setLastEditedQueryName,
     setLastEditedQueryDescription,

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useContext, useEffect, useState } from "react";
 import { useQuery } from "react-query";
 import { useDispatch } from "react-redux";
+import { InjectedRouter } from "react-router/lib/Router";
 import { noop } from "lodash";
 
 import { AppContext } from "context/app";
@@ -33,8 +34,15 @@ import AddPolicyModal from "./components/AddPolicyModal";
 import RemovePoliciesModal from "./components/RemovePoliciesModal";
 
 interface IManagePoliciesPageProps {
-  router: any;
-  location: any;
+  router: InjectedRouter; // v3
+  location: {
+    action: string;
+    hash: string;
+    key: string;
+    pathname: string;
+    query: { team_id?: string };
+    search: string;
+  };
 }
 
 const baseClass = "manage-policies-page";
@@ -65,7 +73,11 @@ const ManagePolicyPage = ({
     setConfig,
   } = useContext(AppContext);
 
-  const teamId = parseInt(location?.query?.team_id, 10) || 0;
+  const teamId = location?.query?.team_id
+    ? parseInt(location?.query?.team_id, 10)
+    : 0;
+
+  console.log("teamId", teamId);
 
   const {
     setLastEditedQueryName,

--- a/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useContext } from "react";
 import PATHS from "router/paths";
+import { InjectedRouter } from "react-router/lib/Router";
 
 import { DEFAULT_POLICIES } from "utilities/constants";
 
@@ -13,7 +14,7 @@ import Modal from "components/Modal";
 
 export interface IAddPolicyModalProps {
   onCancel: () => void;
-  router: any;
+  router: InjectedRouter; // v3
   teamId: number;
   teamName?: string;
 }

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesListWrapper/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesListWrapper/PoliciesTableConfig.tsx
@@ -31,6 +31,9 @@ const TAGGED_TEMPLATES = {
 interface IGetToggleAllRowsSelectedProps {
   checked: boolean;
   indeterminate: boolean;
+  title: string;
+  onChange: () => any;
+  style: { cursor: string };
 }
 interface IHeaderProps {
   column: {
@@ -47,7 +50,7 @@ interface ICellProps {
   };
   row: {
     original: IPolicyStats;
-    getToggleRowSelectedProps: () => any; // TODO: do better with types
+    getToggleRowSelectedProps: () => IGetToggleAllRowsSelectedProps;
     toggleRowSelected: () => void;
   };
 }

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesListWrapper/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesListWrapper/PoliciesTableConfig.tsx
@@ -27,12 +27,17 @@ const TAGGED_TEMPLATES = {
     }`;
   },
 };
+
+interface IGetToggleAllRowsSelectedProps {
+  checked: boolean;
+  indeterminate: boolean;
+}
 interface IHeaderProps {
   column: {
     title: string;
     isSortedDesc: boolean;
   };
-  getToggleAllRowsSelectedProps: () => any; // TODO: do better with types
+  getToggleAllRowsSelectedProps: () => IGetToggleAllRowsSelectedProps;
   toggleAllRowsSelected: () => void;
 }
 

--- a/frontend/pages/policies/PolicyPage/PolicyPage.tsx
+++ b/frontend/pages/policies/PolicyPage/PolicyPage.tsx
@@ -24,7 +24,7 @@ import ExternalURLIcon from "../../../../assets/images/icon-external-url-12x12@2
 interface IPolicyPageProps {
   router: InjectedRouter;
   params: Params;
-  location: any; // no type in react-router v3
+  location: any; // TODO: type query: URLQuerySearch with host_ids
 }
 
 interface IStoredPolicyResponse {

--- a/frontend/pages/policies/PolicyPage/screens/RunQuery.tsx
+++ b/frontend/pages/policies/PolicyPage/screens/RunQuery.tsx
@@ -20,7 +20,6 @@ import QueryResults from "../components/QueryResults";
 interface IRunQueryProps {
   storedPolicy: IPolicy | undefined;
   selectedTargets: ITarget[];
-  policyIdForEdit: number | null;
   setSelectedTargets: (value: ITarget[]) => void;
   goToQueryEditor: () => void;
 }
@@ -28,7 +27,6 @@ interface IRunQueryProps {
 const RunQuery = ({
   storedPolicy,
   selectedTargets,
-  policyIdForEdit,
   setSelectedTargets,
   goToQueryEditor,
 }: IRunQueryProps): JSX.Element => {

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -133,7 +133,7 @@ const ManageQueriesPage = (): JSX.Element => {
     setShowRemoveQueryModal(!showRemoveQueryModal);
   }, [showRemoveQueryModal, setShowRemoveQueryModal]);
 
-  const onRemoveQueryClick = (selectedTableQueryIds: any) => {
+  const onRemoveQueryClick = (selectedTableQueryIds: number[]) => {
     toggleRemoveQueryModal();
     setSelectedQueryIds(selectedTableQueryIds);
   };

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesListWrapper.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesListWrapper.tsx
@@ -18,7 +18,7 @@ interface IQueryTableData extends IQuery {
 interface IQueriesListWrapperProps {
   queriesList: IQueryTableData[] | null;
   isLoading: boolean;
-  onRemoveQueryClick: any;
+  onRemoveQueryClick: (selectedTableQueryIds: number[]) => void;
   onCreateQueryClick: () => void;
   searchable: boolean;
   customControl?: () => JSX.Element;

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesTableConfig.tsx
@@ -30,6 +30,9 @@ interface IQueryRow {
 interface IGetToggleAllRowsSelectedProps {
   checked: boolean;
   indeterminate: boolean;
+  title: string;
+  onChange: () => any;
+  style: { cursor: string };
 }
 interface IHeaderProps {
   column: {
@@ -49,7 +52,7 @@ interface ICellProps {
   };
   row: {
     original: IQuery;
-    getToggleRowSelectedProps: () => any; // TODO: do better with types
+    getToggleRowSelectedProps: () => IGetToggleAllRowsSelectedProps;
     toggleRowSelected: () => void;
   };
   toggleRowSelected: (id: string, value: boolean) => void;

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesTableConfig.tsx
@@ -26,12 +26,17 @@ interface IQueryRow {
   id: string;
   original: IQuery;
 }
+
+interface IGetToggleAllRowsSelectedProps {
+  checked: boolean;
+  indeterminate: boolean;
+}
 interface IHeaderProps {
   column: {
     title: string;
     isSortedDesc: boolean;
   };
-  getToggleAllRowsSelectedProps: () => any; // TODO: do better with types
+  getToggleAllRowsSelectedProps: () => IGetToggleAllRowsSelectedProps;
   toggleAllRowsSelected: () => void;
   toggleRowSelected: (id: string, value?: boolean) => void;
   rows: IQueryRow[];

--- a/frontend/pages/queries/QueryPage/QueryPage.tsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.tsx
@@ -22,7 +22,9 @@ import ExternalURLIcon from "../../../../assets/images/icon-external-url-12x12@2
 interface IQueryPageProps {
   router: InjectedRouter;
   params: Params;
-  location: any; // no type in react-router v3
+  location: {
+    query: { host_ids: string };
+  };
 }
 
 interface IStoredQueryResponse {

--- a/frontend/pages/queries/QueryPage/components/NewQueryModal/NewQueryModal.tsx
+++ b/frontend/pages/queries/QueryPage/components/NewQueryModal/NewQueryModal.tsx
@@ -18,7 +18,7 @@ export interface INewQueryModalProps {
 }
 
 const validateQueryName = (name: string) => {
-  const errors: { [key: string]: any } = {};
+  const errors: { [key: string]: string } = {};
 
   if (!name) {
     errors.name = "Query name must be present";

--- a/frontend/pages/queries/QueryPage/components/NewQueryModal/NewQueryModal.tsx
+++ b/frontend/pages/queries/QueryPage/components/NewQueryModal/NewQueryModal.tsx
@@ -34,7 +34,7 @@ const NewQueryModal = ({
   onCreateQuery,
   setIsSaveModalOpen,
   backendValidators,
-}: INewQueryModalProps) => {
+}: INewQueryModalProps): JSX.Element => {
   const [name, setName] = useState<string>("");
   const [description, setDescription] = useState<string>("");
   const [observerCanRun, setObserverCanRun] = useState<boolean>(false);

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -1,6 +1,10 @@
 /* Conditionally renders global schedule and team schedules */
 
+<<<<<<< HEAD
 import React, { useCallback, useContext, useEffect, useState } from "react";
+=======
+import React, { useState, useCallback, useContext } from "react";
+>>>>>>> 88e3567ac (Clean up 38 lint warnings, mostly unused variables)
 import { useQuery } from "react-query";
 import { useDispatch } from "react-redux";
 import { AppContext } from "context/app";

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -1,10 +1,6 @@
 /* Conditionally renders global schedule and team schedules */
 
-<<<<<<< HEAD
 import React, { useCallback, useContext, useEffect, useState } from "react";
-=======
-import React, { useState, useCallback, useContext } from "react";
->>>>>>> 88e3567ac (Clean up 38 lint warnings, mostly unused variables)
 import { useQuery } from "react-query";
 import { useDispatch } from "react-redux";
 import { AppContext } from "context/app";

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
@@ -1,6 +1,6 @@
 /* This component is used for creating and editing both global and team scheduled queries */
 
-import React, { useState, useCallback, useEffect, useContext } from "react";
+import React, { useState, useCallback, useContext } from "react";
 import { pull } from "lodash";
 import { AppContext } from "context/app";
 

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
@@ -1,9 +1,13 @@
 /* This component is used for creating and editing both global and team scheduled queries */
 
-import React, { useState, useCallback, useEffect } from "react";
-// @ts-ignore
-import Fleet from "fleet";
+import React, { useState, useCallback, useEffect, useContext } from "react";
 import { pull } from "lodash";
+import { AppContext } from "context/app";
+
+import { IQuery } from "interfaces/query";
+import { IGlobalScheduledQuery } from "interfaces/global_scheduled_query";
+import { ITeamScheduledQuery } from "interfaces/team_scheduled_query";
+
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 import InfoBanner from "components/InfoBanner/InfoBanner";
@@ -11,9 +15,6 @@ import InfoBanner from "components/InfoBanner/InfoBanner";
 import Dropdown from "components/forms/fields/Dropdown";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
-import { IQuery } from "interfaces/query";
-import { IGlobalScheduledQuery } from "interfaces/global_scheduled_query";
-import { ITeamScheduledQuery } from "interfaces/team_scheduled_query";
 import {
   FREQUENCY_DROPDOWN_OPTIONS,
   PLATFORM_DROPDOWN_OPTIONS,
@@ -92,23 +93,9 @@ const ScheduleEditorModal = ({
   togglePreviewDataModal,
   showPreviewDataModal,
 }: IScheduleEditorModalProps): JSX.Element => {
-  const [loggingConfig, setLoggingConfig] = useState("");
-  const [isLoading, setIsLoading] = useState(true);
-  const [isLoadingError, setIsLoadingError] = useState(false);
+  const { config } = useContext(AppContext);
 
-  useEffect((): void => {
-    const getConfigDestination = async (): Promise<void> => {
-      try {
-        const responseConfig = await Fleet.config.loadAll();
-        setIsLoading(false);
-        setLoggingConfig(responseConfig.logging.result.plugin);
-      } catch (err) {
-        setIsLoadingError(true);
-        setIsLoading(false);
-      }
-    };
-    getConfigDestination();
-  }, []);
+  const loggingConfig = config?.result.plugin || "unknown";
 
   const [showAdvancedOptions, setShowAdvancedOptions] = useState<boolean>(
     false
@@ -268,8 +255,10 @@ const ScheduleEditorModal = ({
             Your configured log destination is <b>{loggingConfig}</b>.
           </p>
           <p>
-            This means that when this query is run on your hosts, the data will
-            be sent to {generateLoggingDestination(loggingConfig)}.
+            {loggingConfig === "unknown"
+              ? ""
+              : `This means that when this query is run on your hosts, the data will
+            be sent to ${generateLoggingDestination(loggingConfig)}.`}
           </p>
           <p>
             Check out the Fleet documentation on&nbsp;

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleListWrapper.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleListWrapper.tsx
@@ -41,18 +41,6 @@ interface IScheduleListWrapperProps {
   loadingInheritedQueriesTableData: boolean;
   loadingTeamQueriesTableData: boolean;
 }
-interface IRootState {
-  entities: {
-    global_scheduled_queries: {
-      isLoading: boolean;
-      data: IGlobalScheduledQuery[];
-    };
-    team_scheduled_queries: {
-      isLoading: boolean;
-      data: ITeamScheduledQuery[];
-    };
-  };
-}
 
 const ScheduleListWrapper = ({
   onRemoveScheduledQueryClick,

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleTableConfig.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleTableConfig.tsx
@@ -13,12 +13,16 @@ import { IDropdownOption } from "interfaces/dropdownOption";
 import { IGlobalScheduledQuery } from "interfaces/global_scheduled_query";
 import { ITeamScheduledQuery } from "interfaces/team_scheduled_query";
 
+interface IGetToggleAllRowsSelectedProps {
+  checked: boolean;
+  indeterminate: boolean;
+}
 interface IHeaderProps {
   column: {
     title: string;
     isSortedDesc: boolean;
   };
-  getToggleAllRowsSelectedProps: () => any; // TODO: do better with types
+  getToggleAllRowsSelectedProps: () => IGetToggleAllRowsSelectedProps;
   toggleAllRowsSelected: () => void;
 }
 

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleTableConfig.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleTableConfig.tsx
@@ -16,6 +16,9 @@ import { ITeamScheduledQuery } from "interfaces/team_scheduled_query";
 interface IGetToggleAllRowsSelectedProps {
   checked: boolean;
   indeterminate: boolean;
+  title: string;
+  onChange: () => any;
+  style: { cursor: string };
 }
 interface IHeaderProps {
   column: {
@@ -32,7 +35,7 @@ interface ICellProps {
   };
   row: {
     original: IGlobalScheduledQuery | ITeamScheduledQuery;
-    getToggleRowSelectedProps: () => any; // TODO: do better with types
+    getToggleRowSelectedProps: () => IGetToggleAllRowsSelectedProps;
     toggleRowSelected: () => void;
   };
 }

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -66,10 +66,7 @@ const ManageSoftwarePage = ({
   const {
     availableTeams,
     currentTeam,
-    setAvailableTeams,
-    setCurrentUser,
     setConfig,
-    isPremiumTier,
     isGlobalAdmin,
     isGlobalMaintainer,
   } = useContext(AppContext);

--- a/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
@@ -53,7 +53,7 @@ interface IDataColumn {
   disableSortBy?: boolean;
 }
 
-const condense = (vulnerabilities: IVulnerability[]) => {
+const condense = (vulnerabilities: IVulnerability[]): string[] => {
   const condensed =
     (vulnerabilities?.length &&
       vulnerabilities
@@ -72,7 +72,7 @@ const softwareTableHeaders = [
     Header: "Name",
     disableSortBy: true,
     accessor: "name",
-    Cell: (cellProps: IStringCellProps) => (
+    Cell: (cellProps: IStringCellProps): JSX.Element => (
       <TextCell value={cellProps.cell.value} />
     ),
   },
@@ -81,7 +81,7 @@ const softwareTableHeaders = [
     Header: "Version",
     disableSortBy: true,
     accessor: "version",
-    Cell: (cellProps: IStringCellProps) => (
+    Cell: (cellProps: IStringCellProps): JSX.Element => (
       <TextCell value={cellProps.cell.value} />
     ),
   },
@@ -90,7 +90,7 @@ const softwareTableHeaders = [
     Header: "Vulnerabilities",
     disableSortBy: true,
     accessor: "vulnerabilities",
-    Cell: (cellProps: IVulnCellProps) => {
+    Cell: (cellProps: IVulnCellProps): JSX.Element => {
       const vulnerabilities = cellProps.cell.value || [];
       const tooltipText = condense(vulnerabilities)?.map((value) => {
         return (
@@ -136,7 +136,7 @@ const softwareTableHeaders = [
   },
   {
     title: "Hosts",
-    Header: (cellProps: IHeaderProps) => (
+    Header: (cellProps: IHeaderProps): JSX.Element => (
       <HeaderCell
         value={cellProps.column.title}
         isSortedDesc={cellProps.column.isSortedDesc}
@@ -144,7 +144,7 @@ const softwareTableHeaders = [
     ),
     disableSortBy: false,
     accessor: "hosts_count",
-    Cell: (cellProps: INumberCellProps) => (
+    Cell: (cellProps: INumberCellProps): JSX.Element => (
       <TextCell value={cellProps.cell.value} />
     ),
   },
@@ -153,7 +153,7 @@ const softwareTableHeaders = [
     Header: "",
     disableSortBy: true,
     accessor: "id",
-    Cell: (cellProps: INumberCellProps) => {
+    Cell: (cellProps: INumberCellProps): JSX.Element => {
       return (
         <Link
           to={`${PATHS.MANAGE_HOSTS}?software_id=${cellProps.cell.value}`}

--- a/frontend/redux/nodes/app/actions.js
+++ b/frontend/redux/nodes/app/actions.js
@@ -1,5 +1,4 @@
 import Fleet from "fleet";
-import yaml from "js-yaml";
 
 import formatApiErrors from "utilities/format_api_errors";
 import { frontendFormattedConfig } from "fleet/helpers";

--- a/frontend/redux/nodes/entities/hosts/actions.ts
+++ b/frontend/redux/nodes/entities/hosts/actions.ts
@@ -2,6 +2,7 @@ import { IHost } from "interfaces/host";
 // @ts-ignore
 // ignore TS error for now until these are rewritten in ts.
 import Fleet from "fleet";
+import { Dispatch } from "redux";
 // @ts-ignore
 import { formatErrorResponse } from "redux/nodes/entities/base/helpers";
 import { IApiError } from "interfaces/errors";
@@ -26,7 +27,7 @@ export const transferHostsFailure = (errors: any) => {
 };
 
 const transferToTeam = (teamId: number | null, hostIds: number[]): any => {
-  return (dispatch: any) => {
+  return (dispatch: Dispatch) => {
     dispatch(loadRequest());
     return Fleet.hosts
       .transferToTeam(teamId, hostIds)
@@ -47,7 +48,7 @@ const transferToTeamByFilter = (
   status: string,
   labelId: number | null
 ): any => {
-  return (dispatch: any) => {
+  return (dispatch: Dispatch) => {
     dispatch(loadRequest());
     return Fleet.hosts
       .transferToTeamByFilter(teamId, query, status, labelId)
@@ -64,7 +65,7 @@ const transferToTeamByFilter = (
 
 export const LOAD_PAGINATED = "LOAD_PAGINATED";
 export const loadPaginated = (): any => {
-  return (dispatch: any) => {
+  return (dispatch: Dispatch) => {
     dispatch(loadRequest());
 
     return Fleet.hosts;
@@ -83,7 +84,7 @@ export const refetchHostFailure = (errors: any) => {
 
 export const REFETCH_HOST_START = "REFETCH_HOST_START";
 export const refetchHostStart = (host: IHost): any => {
-  return (dispatch: any) => {
+  return (dispatch: Dispatch) => {
     return Fleet.hosts
       .refetch(host)
       .then((data: any) => {

--- a/frontend/redux/nodes/entities/teams/actions.ts
+++ b/frontend/redux/nodes/entities/teams/actions.ts
@@ -3,6 +3,7 @@ import { IEnrollSecret } from "interfaces/enroll_secret";
 // ignore TS error for now until these are rewritten in ts.
 // @ts-ignore
 import Fleet from "fleet";
+import { Dispatch } from "redux";
 // @ts-ignore
 import { formatErrorResponse } from "redux/nodes/entities/base/helpers";
 import {
@@ -36,7 +37,7 @@ export const addMembers = (
   teamId: number,
   newMembers: INewMembersBody
 ): any => {
-  return (dispatch: any) => {
+  return (dispatch: Dispatch) => {
     dispatch(loadRequest());
     return Fleet.teams
       .addMembers(teamId, newMembers)
@@ -55,7 +56,7 @@ export const removeMembers = (
   teamId: number,
   removedMembers: IRemoveMembersBody
 ) => {
-  return (dispatch: any) => {
+  return (dispatch: Dispatch) => {
     dispatch(loadRequest());
     return Fleet.teams
       .removeMembers(teamId, removedMembers)
@@ -71,7 +72,7 @@ export const removeMembers = (
 };
 
 export const transferHosts = (teamId: number, hostIds: number[]): any => {
-  return (dispatch: any) => {
+  return (dispatch: Dispatch) => {
     dispatch(loadRequest()); // TODO: ensure works when API is implemented
     return Fleet.teams
       .transferHosts(teamId, hostIds)
@@ -90,12 +91,12 @@ export const getEnrollSecrets = (team?: ITeam | null): any => {
   // This case happens when the 'No Team' options is selected. We want to
   // just call the default getEnrollSecret in this case
   if (team === null || team === undefined) {
-    return (dispatch: any) => {
+    return (dispatch: Dispatch) => {
       return dispatch(getEnrollSecret());
     };
   }
 
-  return (dispatch: any) => {
+  return (dispatch: Dispatch) => {
     return Fleet.teams
       .getEnrollSecrets(team.id)
       .then((secrets: IEnrollSecret[]) => {

--- a/frontend/services/entities/enroll_secret.ts
+++ b/frontend/services/entities/enroll_secret.ts
@@ -4,12 +4,6 @@ import teamsAPI from "services/entities/teams";
 
 import { IEnrollSecret } from "interfaces/enroll_secret";
 
-interface IEnrollSecretSpec {
-  spec: {
-    secrets: IEnrollSecret[];
-  };
-}
-
 export default {
   getGlobalEnrollSecrets: () => {
     return specAPI.getEnrollSecretSpec().then((res) => res.spec);

--- a/frontend/services/entities/global_scheduled_queries.ts
+++ b/frontend/services/entities/global_scheduled_queries.ts
@@ -1,6 +1,5 @@
 /* eslint-disable  @typescript-eslint/explicit-module-boundary-types */
 import sendRequest from "services";
-import { omit } from "lodash";
 
 import endpoints from "fleet/endpoints";
 import { IGlobalScheduledQuery } from "interfaces/global_scheduled_query";

--- a/frontend/services/entities/packs.ts
+++ b/frontend/services/entities/packs.ts
@@ -3,7 +3,6 @@ import sendRequest from "services";
 import { omit } from "lodash";
 
 import endpoints from "fleet/endpoints";
-import { IPack } from "interfaces/pack";
 import { ITargets } from "interfaces/target";
 import helpers from "fleet/helpers";
 

--- a/frontend/services/entities/queries.ts
+++ b/frontend/services/entities/queries.ts
@@ -61,7 +61,7 @@ export default {
       throw new Error("Could not run query.");
     }
   },
-  update: (id: number, updateParams: any) => {
+  update: (id: number, updateParams: IQueryFormData) => {
     const { QUERIES } = endpoints;
     const path = `${QUERIES}/${id}`;
 

--- a/frontend/services/entities/queries.ts
+++ b/frontend/services/entities/queries.ts
@@ -1,7 +1,7 @@
 /* eslint-disable  @typescript-eslint/explicit-module-boundary-types */
 import sendRequest from "services";
 import endpoints from "fleet/endpoints";
-import { IQueryFormData, IQuery } from "interfaces/query";
+import { IQueryFormData } from "interfaces/query";
 
 export default {
   create: ({ description, name, query, observer_can_run }: IQueryFormData) => {

--- a/frontend/services/entities/scheduled_queries.ts
+++ b/frontend/services/entities/scheduled_queries.ts
@@ -1,6 +1,5 @@
 /* eslint-disable  @typescript-eslint/explicit-module-boundary-types */
 import sendRequest from "services";
-import { omit } from "lodash";
 
 import endpoints from "fleet/endpoints";
 import {

--- a/frontend/services/entities/team_scheduled_queries.ts
+++ b/frontend/services/entities/team_scheduled_queries.ts
@@ -5,8 +5,19 @@ import endpoints from "fleet/endpoints";
 import { ITeamScheduledQuery } from "interfaces/team_scheduled_query";
 import helpers from "fleet/helpers";
 
+interface ICreateTeamScheduledQueryFormData {
+  interval: number;
+  logging_type: string;
+  name?: string;
+  platform: string;
+  query_id?: number;
+  shard: number;
+  team_id?: number;
+  version: string;
+}
+
 export default {
-  create: (formData: any) => {
+  create: (formData: ICreateTeamScheduledQueryFormData) => {
     const { TEAM_SCHEDULE } = endpoints;
 
     const {
@@ -33,7 +44,7 @@ export default {
       team_id: Number(teamID),
     };
 
-    return sendRequest("POST", TEAM_SCHEDULE(teamID), params);
+    return sendRequest("POST", TEAM_SCHEDULE(teamID || 0), params);
   },
   destroy: (teamID: number, queryID: number) => {
     const { TEAM_SCHEDULE } = endpoints;
@@ -48,6 +59,7 @@ export default {
     return sendRequest("GET", path);
   },
   update: (teamScheduledQuery: ITeamScheduledQuery, updatedAttributes: any) => {
+    console.log("updatedAttributes", updatedAttributes);
     const { team_id } = updatedAttributes;
     const { TEAM_SCHEDULE } = endpoints;
     const path = `${TEAM_SCHEDULE(team_id)}/${teamScheduledQuery.id}`;

--- a/frontend/services/entities/team_scheduled_queries.ts
+++ b/frontend/services/entities/team_scheduled_queries.ts
@@ -59,7 +59,6 @@ export default {
     return sendRequest("GET", path);
   },
   update: (teamScheduledQuery: ITeamScheduledQuery, updatedAttributes: any) => {
-    console.log("updatedAttributes", updatedAttributes);
     const { team_id } = updatedAttributes;
     const { TEAM_SCHEDULE } = endpoints;
     const path = `${TEAM_SCHEDULE(team_id)}/${teamScheduledQuery.id}`;

--- a/frontend/services/entities/team_scheduled_queries.ts
+++ b/frontend/services/entities/team_scheduled_queries.ts
@@ -1,6 +1,5 @@
 /* eslint-disable  @typescript-eslint/explicit-module-boundary-types */
 import sendRequest from "services";
-import { omit } from "lodash";
 
 import endpoints from "fleet/endpoints";
 import { ITeamScheduledQuery } from "interfaces/team_scheduled_query";

--- a/frontend/services/entities/teams.ts
+++ b/frontend/services/entities/teams.ts
@@ -1,21 +1,9 @@
 /* eslint-disable  @typescript-eslint/explicit-module-boundary-types */
 import sendRequest from "services";
 import endpoints from "fleet/endpoints";
-import { INewMembersBody, IRemoveMembersBody, ITeam } from "interfaces/team";
+import { INewMembersBody, IRemoveMembersBody } from "interfaces/team";
 import { ICreateTeamFormData } from "pages/admin/TeamManagementPage/components/CreateTeamModal/CreateTeamModal";
 import { IEnrollSecret } from "interfaces/enroll_secret";
-
-interface ILoadAllTeamsResponse {
-  teams: ITeam[];
-}
-
-interface ILoadTeamResponse {
-  team: ITeam;
-}
-
-interface ITeamEnrollSecretsResponse {
-  secrets: IEnrollSecret[];
-}
 
 interface ITeamSearchOptions {
   page?: number;

--- a/frontend/services/entities/users.ts
+++ b/frontend/services/entities/users.ts
@@ -7,7 +7,6 @@ import {
   IUpdateUserFormData,
   IUser,
 } from "interfaces/user";
-import { IInvite } from "interfaces/invite";
 import { ITeamSummary } from "interfaces/team";
 
 interface IUserSearchOptions {
@@ -39,7 +38,7 @@ export default {
       helpers.addGravatarUrlToResource(response.user)
     );
   },
-  deleteSessions: (userId: number, isResettingCurrentUser: boolean) => {
+  deleteSessions: (userId: number) => {
     const { USER_SESSIONS } = endpoints;
     const path = USER_SESSIONS(userId);
 


### PR DESCRIPTION
Round 1 Focus: Remove as many unused variables as possible, missing return types on functions.

~~Original number of lint warnings: 409~~
~~Number of lint warnings fixed: 81~~
~~Lint warnings left: 328~~

Update: 2/14/22
Number of lint warnings on Main: 434
Lint warnings left after rebasing on Main: 316

Pages that removed several major unused variables, and should QA:
- [x] EditPackForm (QA submitting pack query)
- [x] UserManagementPage (QA delete sessions)
- [x] PacksListWrapper (QA view for Observer only)-- lol why did we even have isOnlyObserver on here when they don't even have access to packs! 😆
- [x] Packs remove query (QA click and submit) -- fixed on main by #3976, works on here too
- [x] Policy (QA Run policy)
- [x] Appwide: Table select all checkboxes
- [x] Query form: Update query data

Future rounds focus: Address typescript type: `any`, missing returns on functions, 


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
