### PR TITLE
docs: add description for /translate endpoint

### DIFF
--- a/docs/01-Using-Fleet/03-REST-API.md
+++ b/docs/01-Using-Fleet/03-REST-API.md
@@ -5770,6 +5770,8 @@ _Available in Fleet Premium_
 
 ### Translate IDs
 
+Transforms a host name into a host id. For example, the Fleet UI use this endpoint when sending live queries to a set of hosts.
+
 `POST /api/v1/fleet/translate`
 
 #### Parameters


### PR DESCRIPTION
Add description for `/translate` endpoint to satisfy [this](https://github.com/fleetdm/fleet/issues/2942) issue
