### PR TITLE
Fix failing policy sets for redis cluster mode

### DIFF
--- a/server/fleet/policytest/policytest.go
+++ b/server/fleet/policytest/policytest.go
@@ -9,39 +9,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func RunFailingPolicySetTests(t *testing.T, r fleet.FailingPolicySet) {
-	t.Run("basic", func(t *testing.T) {
-		testBasic(t, r)
-	})
-
-	t.Run("1000-hosts", func(t *testing.T) {
-		hosts := make([]fleet.PolicySetHost, 1000)
-		for i := range hosts {
-			hosts[i] = fleet.PolicySetHost{
-				ID:       uint(i + 1),
-				Hostname: fmt.Sprintf("test.hostname.%d", i+1),
-			}
+func RunFailing1000hosts(t *testing.T, r fleet.FailingPolicySet) {
+	hosts := make([]fleet.PolicySetHost, 1000)
+	for i := range hosts {
+		hosts[i] = fleet.PolicySetHost{
+			ID:       uint(i + 1),
+			Hostname: fmt.Sprintf("test.hostname.%d", i+1),
 		}
-		policyID1k := uint(999)
-		for i := range hosts {
-			err := r.AddHost(policyID1k, hosts[i])
-			require.NoError(t, err)
-		}
-		fetchedHosts, err := r.ListHosts(policyID1k)
+	}
+	policyID1k := uint(999)
+	for i := range hosts {
+		err := r.AddHost(policyID1k, hosts[i])
 		require.NoError(t, err)
-		sort.Slice(fetchedHosts, func(i, j int) bool {
-			return fetchedHosts[i].ID < fetchedHosts[j].ID
-		})
-		require.Equal(t, hosts, fetchedHosts)
-		err = r.RemoveHosts(policyID1k, hosts)
-		require.NoError(t, err)
-		fetchedHosts, err = r.ListHosts(policyID1k)
-		require.NoError(t, err)
-		require.Empty(t, fetchedHosts)
+	}
+	fetchedHosts, err := r.ListHosts(policyID1k)
+	require.NoError(t, err)
+	sort.Slice(fetchedHosts, func(i, j int) bool {
+		return fetchedHosts[i].ID < fetchedHosts[j].ID
 	})
+	require.Equal(t, hosts, fetchedHosts)
+	err = r.RemoveHosts(policyID1k, hosts)
+	require.NoError(t, err)
+	fetchedHosts, err = r.ListHosts(policyID1k)
+	require.NoError(t, err)
+	require.Empty(t, fetchedHosts)
 }
 
-func testBasic(t *testing.T, r fleet.FailingPolicySet) {
+func RunFailingBasic(t *testing.T, r fleet.FailingPolicySet) {
 	policyID1 := uint(1)
 
 	// Test listing policy sets with no sets.

--- a/server/service/mem_failing_policies_set_test.go
+++ b/server/service/mem_failing_policies_set_test.go
@@ -8,5 +8,6 @@ import (
 
 func TestMemFailingPolicySet(t *testing.T) {
 	m := NewMemFailingPolicySet()
-	policytest.RunFailingPolicySetTests(t, m)
+	policytest.RunFailing1000hosts(t, m)
+	policytest.RunFailingBasic(t, m)
 }

--- a/server/service/mem_failing_policies_set_test.go
+++ b/server/service/mem_failing_policies_set_test.go
@@ -9,5 +9,6 @@ import (
 func TestMemFailingPolicySet(t *testing.T) {
 	m := NewMemFailingPolicySet()
 	policytest.RunFailing1000hosts(t, m)
+	m = NewMemFailingPolicySet()
 	policytest.RunFailingBasic(t, m)
 }

--- a/server/service/redis_policy_set/redis_policy_set_test.go
+++ b/server/service/redis_policy_set/redis_policy_set_test.go
@@ -18,21 +18,29 @@ func TestRedisFailingPolicySet(t *testing.T) {
 		policytest.RunFailingPolicySetTests,
 	} {
 		t.Run(test.FunctionName(f), func(t *testing.T) {
+			testRedisKeyPrefix = t.Name() + ":"
+			t.Cleanup(func() { testRedisKeyPrefix = "" })
+
 			t.Run("standalone", func(t *testing.T) {
-				store := setupRedis(t, false)
+				store := setupRedis(t, false, false)
 				f(t, store)
 			})
 
 			t.Run("cluster", func(t *testing.T) {
-				store := setupRedis(t, true)
+				store := setupRedis(t, true, true)
+				f(t, store)
+			})
+
+			t.Run("cluster-no-redir", func(t *testing.T) {
+				store := setupRedis(t, true, false)
 				f(t, store)
 			})
 		})
 	}
 }
 
-func setupRedis(t testing.TB, cluster bool) *redisFailingPolicySet {
-	pool := redistest.SetupRedis(t, cluster, true, true)
+func setupRedis(t testing.TB, cluster, redir bool) *redisFailingPolicySet {
+	pool := redistest.SetupRedis(t, cluster, redir, true)
 	return NewFailing(pool)
 }
 
@@ -45,7 +53,7 @@ func BenchmarkFailingPolicySetClusterP10H10(b *testing.B) {
 }
 
 func benchmarkFailingPolicySet(b *testing.B, policyCount, hostCount int, cluster bool) {
-	s := setupRedis(b, cluster)
+	s := setupRedis(b, cluster, false)
 	for i := 0; i < b.N; i++ {
 		runBenchmark(b, policyCount, hostCount, s)
 	}

--- a/server/service/redis_policy_set/redis_policy_set_test.go
+++ b/server/service/redis_policy_set/redis_policy_set_test.go
@@ -15,12 +15,10 @@ import (
 
 func TestRedisFailingPolicySet(t *testing.T) {
 	for _, f := range []func(*testing.T, fleet.FailingPolicySet){
-		policytest.RunFailingPolicySetTests,
+		policytest.RunFailingBasic,
+		policytest.RunFailing1000hosts,
 	} {
 		t.Run(test.FunctionName(f), func(t *testing.T) {
-			testRedisKeyPrefix = t.Name() + ":"
-			t.Cleanup(func() { testRedisKeyPrefix = "" })
-
 			t.Run("standalone", func(t *testing.T) {
 				store := setupRedis(t, false, false)
 				f(t, store)


### PR DESCRIPTION
While trying to fix a related failing test, I noticed the way the redis connections are used would not work in cluster mode without automatic redirections. This PR adjusts this code, and tries to fix the failing 1000-hosts test.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] ~~Changes file added (for user-visible changes)~~
- [ ] ~~Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
- [ ] ~~Documented any permissions changes~~
- [x] Added/updated tests
- [ ] ~~Manual QA for all new/changed functionality~~
