### PR TITLE
Update community.md

### DIFF
--- a/handbook/community.md
+++ b/handbook/community.md
@@ -28,7 +28,7 @@ Fleet's users and broader audience are spread across many different online commu
 - [reddit.com/r/sysadmins](https://www.reddit.com/r/sysadmin/)
 - [reddit.com/r/SysAdminBlogs](https://www.reddit.com/r/SysAdminBlogs/)
 - [r/sysadmin Discord](https://discord.gg/sysadmin)
-- [Hackernews](https://news.ycombinator.com/)
+- [HackerNews](https://news.ycombinator.com/)
 
 ## Community contributions (pull requests)
 

--- a/handbook/community.md
+++ b/handbook/community.md
@@ -17,6 +17,18 @@ Once a blog post has been written, approved, and published, please ensure that i
 
 If we are doing a press release, we are probably pitching it to one or more reporters as an exclusive story, if they choose to take it.  Consider not sharing or publicizing any information related to the upcoming press release before the announcement.  See also https://www.quora.com/What-is-a-press-exclusive-and-how-does-it-work
 
+## Communities
+
+Fleet's users and broader audience are spread across many different online communities and platforms.  Here are the most active communities where each of Fleet's developer relations and social media team members participate at least once (and usually much more often) every weekday:
+
+- [Osquery Slack](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw) (`#fleet` channel)
+- [MacAdmins Slack](https://www.macadmins.org/) (`#fleet` channel)
+- [osquery discussions on LinkedIn](https://www.linkedin.com/search/results/all/?keywords=osquery)
+- [osquery discussions on Twitter](https://twitter.com/search?q=osquery&src=typed_query)
+- [reddit.com/r/sysadmins](https://www.reddit.com/r/sysadmin/)
+- [reddit.com/r/SysAdminBlogs](https://www.reddit.com/r/SysAdminBlogs/)
+- [r/sysadmin Discord](https://discord.gg/sysadmin)
+- [Hackernews](https://news.ycombinator.com/)
 
 ## Community contributions (pull requests)
 

--- a/handbook/community.md
+++ b/handbook/community.md
@@ -19,7 +19,7 @@ If we are doing a press release, we are probably pitching it to one or more repo
 
 ## Communities
 
-Fleet's users and broader audience are spread across many different online communities and platforms.  Here are the most active communities where each of Fleet's developer relations and social media team members participate at least once (and usually much more often) every weekday:
+Fleet's users and broader audience are spread across many online platforms.  Here are the most active communities where Fleet's developer relations and social media team members participate at least once every weekday:
 
 - [Osquery Slack](https://join.slack.com/t/osquery/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw) (`#fleet` channel)
 - [MacAdmins Slack](https://www.macadmins.org/) (`#fleet` channel)


### PR DESCRIPTION
Added new PR request to reflect Communities within the handbook.

Closed previous PR in order to direct users to MacAdmins slack #fleet channel instead of #osquery channel.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
