### PR TITLE
Build Docker images on push to any branch

### DIFF
--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -1,11 +1,6 @@
 name: Docker publish
 
-on:
-  push:
-    branches:
-      - main
-      - patch-*
-  pull_request:
+on: push
 
 jobs:
   # This check-secrets job is used to gate execution of the main job. External PRs will not have


### PR DESCRIPTION
Allows for testing release branches and any others.