### PR TITLE
Fix custom logo

### DIFF
--- a/frontend/components/side_panels/SiteTopNav/_styles.scss
+++ b/frontend/components/side_panels/SiteTopNav/_styles.scss
@@ -80,6 +80,7 @@
 }
 
 .logo {
+  height: 48px;
   transform: scale(0.5);
   position: relative;
   top: 1px;


### PR DESCRIPTION
Cerra #3763 

Fleet logo is 48px tall scaled 50%
Ensures custom logo is exactly 48px tall and scaled 50% as well

<img width="1090" alt="Screen Shot 2022-01-18 at 5 46 42 PM" src="https://user-images.githubusercontent.com/71795832/150031480-fea2100e-237b-42b6-92d5-3705ea304b0c.png">

- [x] Manual QA for all new/changed functionality
