### PR TITLE
Update operating system policy

### DIFF
--- a/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/HostDetailsPage.tsx
@@ -388,8 +388,8 @@ const HostDetailsPage = ({
   const operatingSystemVersion = host?.os_version.slice(
     host?.os_version.lastIndexOf(" ") + 1
   );
-  const osPolicyLabel = `Is ${operatingSystem}, version ${operatingSystemVersion} installed?`;
-  const osPolicy = `SELECT 1 from os_version WHERE name = '${operatingSystem}' AND major || '.' || minor || '.' || patch = '${operatingSystemVersion}';`;
+  const osPolicyLabel = `Is ${operatingSystem}, version ${operatingSystemVersion} or later, installed?`;
+  const osPolicy = `SELECT 1 from os_version WHERE name = '${operatingSystem}' AND major || '.' || minor || '.' || patch >= '${operatingSystemVersion}';`;
 
   const aboutData = normalizeEmptyValues(
     pick(host, [
@@ -434,7 +434,7 @@ const HostDetailsPage = ({
       : setLastEditedQueryName(osPolicyLabel);
     setPolicyTeamId(host?.team_id ? host?.team_id : 0);
     setLastEditedQueryDescription(
-      "Checks to see if the exact operating system and version are installed on a host."
+      "Checks to see if the required mimimum operating system version is installed."
     );
     setLastEditedQueryBody(osPolicy);
     setLastEditedQueryResolution("");


### PR DESCRIPTION
Note: This is a PR to the `release-candidate-4.9.0` branch. These changes were originally included in the following PR to the `main` branch: #3778 

- Update policy's query to check for operating system versions greater than or equal to
  - New query: `SELECT 1 from os_version WHERE name = '${operatingSystem}' AND major || '.' || minor || '.' || patch >= '${operatingSystemVersion}';`
  - New name: `Is ${operatingSystem}, version ${operatingSystemVersion} or later, installed?`
  - New description: `Checks to see if the required mimimum operating system version is installed.`
 
![Screen Shot 2022-01-18 at 2 27 58 PM](https://user-images.githubusercontent.com/47070608/150005276-3340dce5-975a-4df8-98fa-7289fcc327ec.png)


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
