### PR TITLE
E2e refactor: integration/all/app

### DIFF
--- a/cypress/cypress-free.json
+++ b/cypress/cypress-free.json
@@ -1,6 +1,7 @@
 {
   "baseUrl": "https://localhost:8642",
   "fixturesFolder": false,
+  "experimentalSessionSupport": true,
   "testFiles": "{all,free}/**/*.spec.ts",
   "retries": {
     "runMode": 1,

--- a/cypress/integration/all/app/activateuser.spec.ts
+++ b/cypress/integration/all/app/activateuser.spec.ts
@@ -42,7 +42,6 @@ describe("Activate user flow", () => {
         expect(response.body.items[0].To[0].Domain).to.equal("example.com");
         expect(response.body.items[0].From.Mailbox).to.equal("fleet");
         expect(response.body.items[0].From.Domain).to.equal("example.com");
-        console.log(response.body.items[0]);
         const match = response.body.items[0].Content.Body.match(regex);
         inviteLink.url = match[0];
       });

--- a/cypress/integration/all/app/activateuser.spec.ts
+++ b/cypress/integration/all/app/activateuser.spec.ts
@@ -1,88 +1,81 @@
-describe("User invite and activation", () => {
-  beforeEach(() => {
+describe("Activate user flow", () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions();
     cy.setup();
-    cy.login();
+    cy.loginWithCySession();
     cy.setupSMTP();
+    cy.viewport(1200, 660);
+  });
+  after(() => {
+    cy.logout();
   });
 
-  it("Invite and activate a user successfully", () => {
-    // Invite user
-    cy.visit("/settings/organization");
-
-    cy.getAttached(".component__tabs-wrapper").within(() => {
-      cy.findByRole("tab", { name: /^users$/i }).click();
-    });
-
-    cy.getAttached(".user-management").within(() => {
-      cy.contains("button", /create user/i).click();
-    });
-
-    cy.getAttached(".create-user-modal").within(() => {
-      cy.findByLabelText(/name/i).click().type("Ash Ketchum");
-
-      cy.findByLabelText(/email/i).click().type("ash@example.com");
-
-      cy.getAttached(".create-user-form__new-user-radios").within(() => {
-        cy.findByRole("radio", { name: "Invite user" }).parent().click();
+  describe("Users settings page", () => {
+    beforeEach(() => {
+      cy.loginWithCySession();
+      cy.visit("/settings/organization");
+      cy.getAttached(".component__tabs-wrapper").within(() => {
+        cy.findByRole("tab", { name: /^users$/i }).click();
       });
-
-      cy.findByRole("button", { name: /^create$/i }).click();
     });
-
-    // Ensure the email has been delivered
-    cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
-
-    cy.logout();
-
-    // Retrieve user invite in email
-    const inviteLink = {};
-
-    const regex = /\/login\/invites\/[a-zA-Z0-9=?%&@._-]*/gm;
-
-    cy.getEmails().then((response) => {
-      expect(response.body.items[0].To[0]).to.have.property("Domain");
-      expect(response.body.items[0].To[0].Mailbox).to.equal("ash");
-      expect(response.body.items[0].To[0].Domain).to.equal("example.com");
-      expect(response.body.items[0].From.Mailbox).to.equal("fleet");
-      expect(response.body.items[0].From.Domain).to.equal("example.com");
-      console.log(response.body.items[0]);
-      const match = response.body.items[0].Content.Body.match(regex);
-      inviteLink.url = match[0];
+    it("invites and activates a user", () => {
+      cy.getAttached(".user-management").within(() => {
+        cy.contains("button", /create user/i).click();
+      });
+      cy.getAttached(".create-user-modal").within(() => {
+        cy.findByLabelText(/name/i).click().type("Ash Ketchum");
+        cy.findByLabelText(/email/i).click().type("ash@example.com");
+        cy.getAttached(".create-user-form__new-user-radios").within(() => {
+          cy.findByRole("radio", { name: "Invite user" }).parent().click();
+        });
+        cy.findByRole("button", { name: /^create$/i }).click();
+      });
+      // Ensures the email has been delivered
+      cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.logout();
+      // Retrieves user invite in email
+      const inviteLink = {};
+      const regex = /\/login\/invites\/[a-zA-Z0-9=?%&@._-]*/gm;
+      cy.getEmails().then((response) => {
+        expect(response.body.items[0].To[0]).to.have.property("Domain");
+        expect(response.body.items[0].To[0].Mailbox).to.equal("ash");
+        expect(response.body.items[0].To[0].Domain).to.equal("example.com");
+        expect(response.body.items[0].From.Mailbox).to.equal("fleet");
+        expect(response.body.items[0].From.Domain).to.equal("example.com");
+        console.log(response.body.items[0]);
+        const match = response.body.items[0].Content.Body.match(regex);
+        inviteLink.url = match[0];
+      });
+      // Activates user
+      cy.visit(inviteLink);
+      cy.getAttached(".confirm-invite-page").within(() => {
+        cy.findByLabelText(/full name/i)
+          .clear()
+          .type("Ash Ketchum");
+        cy.findByLabelText(/^password$/i)
+          .click()
+          .type("#pikachu1");
+        cy.findByLabelText(/confirm password/i)
+          .click()
+          .type("#pikachu1");
+        cy.findByRole("button", { name: /submit/i }).click();
+      });
+      cy.getAttached(".login-form").within(() => {
+        cy.findByLabelText(/email/i).clear().type("ash@example.com");
+        cy.findByLabelText(/^password$/i)
+          .click()
+          .type("#pikachu1");
+        cy.findByRole("button", { name: /login/i }).click();
+      });
+      Cypress.session.clearAllSavedSessions(); // Switch back to admin user
     });
-
-    // Activate user
-    cy.visit(inviteLink);
-
-    cy.getAttached(".confirm-invite-page").within(() => {
-      cy.findByLabelText(/full name/i)
-        .click()
-        .type("{selectall}{backspace}Ash Ketchum");
-
-      cy.findByLabelText(/^password$/i)
-        .click()
-        .type("#pikachu1");
-
-      cy.findByLabelText(/confirm password/i)
-        .click()
-        .type("#pikachu1");
-
-      cy.findByRole("button", { name: /submit/i }).click();
+    it("shows new user in admin settings", () => {
+      cy.getAttached("tbody>tr>td")
+        .contains("Ash Ketchum")
+        .parent()
+        .next()
+        .findByText(/active/i)
+        .should("exist");
     });
-
-    // View user as admin
-    cy.login();
-
-    cy.visit("/settings/organization");
-
-    cy.getAttached(".component__tabs-wrapper").within(() => {
-      cy.findByRole("tab", { name: /^users$/i }).click();
-    });
-
-    cy.getAttached("tbody>tr>td")
-      .contains("Ash Ketchum")
-      .parent()
-      .next()
-      .findByText(/active/i)
-      .should("exist");
   });
 });

--- a/cypress/integration/all/app/activateuser.spec.ts
+++ b/cypress/integration/all/app/activateuser.spec.ts
@@ -5,29 +5,36 @@ describe("User invite and activation", () => {
     cy.setupSMTP();
   });
 
-  it("Invites and activates a user", () => {
+  it("Invite and activate a user successfully", () => {
+    // Invite user
     cy.visit("/settings/organization");
-    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
 
-    cy.findByRole("tab", { name: /^users$/i }).click();
-
-    cy.contains("button", /create user/i).click();
-
-    cy.findByLabelText(/name/i).click().type("Ash Ketchum");
-
-    cy.findByLabelText(/email/i).click().type("ash@example.com");
-
-    cy.get(".create-user-form__new-user-radios").within(() => {
-      cy.findByRole("radio", { name: "Invite user" }).parent().click();
+    cy.getAttached(".component__tabs-wrapper").within(() => {
+      cy.findByRole("tab", { name: /^users$/i }).click();
     });
 
-    cy.findByRole("button", { name: /^create$/i }).click();
+    cy.getAttached(".user-management").within(() => {
+      cy.contains("button", /create user/i).click();
+    });
+
+    cy.getAttached(".create-user-modal").within(() => {
+      cy.findByLabelText(/name/i).click().type("Ash Ketchum");
+
+      cy.findByLabelText(/email/i).click().type("ash@example.com");
+
+      cy.getAttached(".create-user-form__new-user-radios").within(() => {
+        cy.findByRole("radio", { name: "Invite user" }).parent().click();
+      });
+
+      cy.findByRole("button", { name: /^create$/i }).click();
+    });
 
     // Ensure the email has been delivered
     cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
 
     cy.logout();
 
+    // Retrieve user invite in email
     const inviteLink = {};
 
     const regex = /\/login\/invites\/[a-zA-Z0-9=?%&@._-]*/gm;
@@ -43,31 +50,35 @@ describe("User invite and activation", () => {
       inviteLink.url = match[0];
     });
 
+    // Activate user
     cy.visit(inviteLink);
 
-    cy.findByLabelText(/full name/i)
-      .click()
-      .type("{selectall}{backspace}Ash Ketchum");
+    cy.getAttached(".confirm-invite-page").within(() => {
+      cy.findByLabelText(/full name/i)
+        .click()
+        .type("{selectall}{backspace}Ash Ketchum");
 
-    // ^$ exact match
-    cy.findByLabelText(/^password$/i)
-      .click()
-      .type("#pikachu1");
+      cy.findByLabelText(/^password$/i)
+        .click()
+        .type("#pikachu1");
 
-    cy.findByLabelText(/confirm password/i)
-      .click()
-      .type("#pikachu1");
+      cy.findByLabelText(/confirm password/i)
+        .click()
+        .type("#pikachu1");
 
-    cy.findByRole("button", { name: /submit/i }).click();
+      cy.findByRole("button", { name: /submit/i }).click();
+    });
 
+    // View user as admin
     cy.login();
 
     cy.visit("/settings/organization");
-    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
 
-    cy.findByRole("tab", { name: /^users$/i }).click();
+    cy.getAttached(".component__tabs-wrapper").within(() => {
+      cy.findByRole("tab", { name: /^users$/i }).click();
+    });
 
-    cy.get("tbody>tr>td")
+    cy.getAttached("tbody>tr>td")
       .contains("Ash Ketchum")
       .parent()
       .next()

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -1,68 +1,72 @@
+import _ = require("cypress/types/lodash");
 import * as path from "path";
 
-describe(
-  "Hosts flow",
-  {
-    defaultCommandTimeout: 20000,
-  },
-  () => {
+let hostname = "";
+
+describe("Hosts flow", () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions();
+    cy.setup();
+    cy.loginWithCySession();
+    cy.addDockerHost();
+    cy.clearDownloads();
+    cy.seedQueries();
+    cy.seedPolicies();
+    cy.viewport(1200, 660);
+  });
+  after(() => {
+    cy.logout();
+    cy.stopDockerHost();
+  });
+  describe("Manage hosts page", () => {
     beforeEach(() => {
-      cy.setup();
-      cy.login();
-      cy.addDockerHost();
-      cy.clearDownloads();
-      cy.seedQueries();
-      cy.seedPolicies();
+      cy.loginWithCySession();
+      cy.visit("/hosts/manage");
     });
+    it("adds a new host", () => {
+      // Download installer
+      cy.visit("/hosts/manage");
 
-    afterEach(() => {
-      cy.stopDockerHost();
+      cy.getAttached(".manage-hosts").within(() => {
+        cy.contains("button", /generate installer/i).click();
+      });
+
+      cy.getAttached(".react-tabs").within(() => {
+        cy.findByText(/rpm/i).should("exist").click();
+      });
+
+      cy.contains("a", /download/i)
+        .first()
+        .click();
+
+      // Assert enroll secret downloaded matches the one displayed
+      // NOTE: This test often fails when the Cypress downloads folder was not cleared properly
+      // before each test run (seems to be related to issues with Cypress trashAssetsBeforeRun)
+      if (Cypress.platform !== "win32") {
+        // windows has issues with downloads location
+        cy.readFile(path.join(Cypress.config("downloadsFolder"), "fleet.pem"), {
+          timeout: 5000,
+        });
+      }
     });
-
+  });
+  describe("Manage policies page", () => {
+    beforeEach(() => {
+      cy.loginWithCySession();
+      cy.visit("/hosts/manage");
+    });
     it(
-      "Add new host, run policy on host, and delete a host successfully",
+      "runs policy on an existing host",
       {
         retries: {
           runMode: 2,
         },
+        defaultCommandTimeout: 10000,
       },
       () => {
-        let hostname = "";
-
-        // Download installer
-        cy.visit("/hosts/manage");
-
-        cy.getAttached(".manage-hosts").within(() => {
-          cy.contains("button", /generate installer/i).click();
-        });
-
-        cy.getAttached(".react-tabs").within(() => {
-          cy.findByText(/rpm/i).should("exist").click();
-        });
-
-        cy.contains("a", /download/i)
-          .first()
-          .click();
-
-        // Assert enroll secret downloaded matches the one displayed
-        // NOTE: This test often fails when the Cypress downloads folder was not cleared properly
-        // before each test run (seems to be related to issues with Cypress trashAssetsBeforeRun)
-        if (Cypress.platform !== "win32") {
-          // windows has issues with downloads location
-          cy.readFile(
-            path.join(Cypress.config("downloadsFolder"), "fleet.pem"),
-            {
-              timeout: 5000,
-            }
-          );
-        }
-
-        cy.visit("/hosts/manage");
-
         cy.getAttached("tbody").within(() => {
           cy.get(".button--text-link").first().as("hostLink");
         });
-
         cy.getAttached("@hostLink")
           // Set hostname variable for later assertions
           .then((el) => {
@@ -71,19 +75,15 @@ describe(
             return el;
           })
           .click();
-
         // Go to host details page
         cy.location("pathname").should("match", /hosts\/[0-9]/i);
         cy.getAttached(".status--online").should("exist");
-
         // Run policy on host
         let policyname = "";
         cy.contains("a", "Policies").click();
-
         cy.getAttached("tbody").within(() => {
           cy.get(".button--text-link").first().as("policyLink");
         });
-
         cy.getAttached("@policyLink")
           // Set policyname variable for later assertions
           .then((el) => {
@@ -91,70 +91,78 @@ describe(
             policyname = el.text();
             return el;
           });
-
         cy.findByText(/filevault/i)
           .should("exist")
           .click();
-
         cy.findByText(/run/i).should("exist").click();
-
         cy.findByText(/all hosts/i)
           .should("exist")
           .click()
           .then(() => {
             cy.findByText(/run/i).click();
-            cy.get(".data-table").within(() => {
-              cy.findByText(hostname).should("exist");
-            });
           });
-
-        cy.visit("/hosts/manage");
-
-        cy.getAttached("tbody").within(() => {
-          cy.get(".button--text-link").first().as("hostLink");
+        cy.getAttached(".data-table").within(() => {
+          cy.findByText(hostname).should("exist");
         });
-
-        // Select a query to run on a specified host on host details page
-        cy.getAttached("@hostLink")
-          .click()
-          .then(() => {
-            cy.findByText(/about this host/i).should("exist");
-            cy.findByText(hostname).should("exist");
-
-            cy.getAttached('img[alt="Query host icon"]').click();
-            cy.getAttached(".modal__modal_container")
-              .within(() => {
-                cy.findByText(/select a query/i).should("exist");
-                cy.findByText(/detect presence/i).click();
-              })
-              .then(() => {
-                cy.findByText(/run query/i).click();
-                cy.getAttached(".data-table").within(() => {
-                  cy.findByText(hostname).should("exist");
-                });
-              });
-          });
-
-        // Delete host
-        cy.visit("/hosts/manage");
-
-        cy.getAttached("@hostLink")
-          .click()
-          .then(() => {
-            cy.get('img[alt="Delete host icon"]').click();
-            cy.get(".modal__modal_container")
-              .within(() => {
-                cy.findByText(/delete host/i).should("exist");
-                cy.findByRole("button", { name: /delete/i }).click();
-              })
-              .then(() => {
-                cy.findByText(/add your devices to fleet/i).should("exist");
-                cy.findByText(/generate installer/i).should("exist");
-                cy.findByText(/about this host/i).should("not.exist");
-                cy.findByText(hostname).should("not.exist");
-              });
-          });
       }
     );
-  }
-);
+  });
+  describe("Host details page", () => {
+    beforeEach(() => {
+      cy.loginWithCySession();
+      cy.visit("/hosts/manage");
+      cy.getAttached("tbody").within(() => {
+        cy.getAttached(".button--text-link").first().click();
+      });
+    });
+    it(
+      "runs query on an existing host",
+      {
+        retries: {
+          runMode: 2,
+        },
+        defaultCommandTimeout: 10000,
+      },
+      () => {
+        cy.getAttached(".host-details__action-button-container").within(() => {
+          cy.getAttached('img[alt="Query host icon"]').click();
+        });
+
+        cy.getAttached(".select-query-modal__modal").within(() => {
+          cy.getAttached(".modal-query-button").eq(2).click();
+        });
+
+        cy.getAttached(".query-form__button-wrap--new-query").within(() => {
+          cy.findByText(/run query/i)
+            .should("exist")
+            .click();
+        });
+        cy.getAttached(".query-page__wrapper").within(() => {
+          cy.getAttached(".data-table").within(() => {
+            cy.findByText(hostname).should("exist");
+          });
+          cy.findByText(/run/i).click();
+        });
+      }
+    );
+    it("deletes an existing host", () => {
+      cy.getAttached(".host-details__action-button-container")
+        .within(() => {
+          cy.findByText(/delete/i).click();
+        })
+        .then(() => {
+          cy.getAttached(".modal__modal_container")
+            .within(() => {
+              cy.findByText(/delete host/i).should("exist");
+              cy.findByRole("button", { name: /delete/i }).click();
+            })
+            .then(() => {
+              cy.findByText(/add your devices to fleet/i).should("exist");
+              cy.findByText(/generate installer/i).should("exist");
+              cy.findByText(/about this host/i).should("not.exist");
+              cy.findByText(hostname).should("not.exist");
+            });
+        });
+    });
+  });
+});

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -20,7 +20,7 @@ describe(
     });
 
     it(
-      "Can add new host from manage hosts page, run policy on host, and delete a host",
+      "Add new host, run policy on host, and delete a host successfully",
       {
         retries: {
           runMode: 2,
@@ -28,11 +28,18 @@ describe(
       },
       () => {
         let hostname = "";
-        cy.visit("/hosts/manage");
-        cy.get(".manage-hosts").should("contain", /hostname/i); // Ensures page load
 
-        cy.contains("button", /generate installer/i).click();
-        cy.findByText(/rpm/i).should("exist").click();
+        // Download installer
+        cy.visit("/hosts/manage");
+
+        cy.getAttached(".manage-hosts").within(() => {
+          cy.contains("button", /generate installer/i).click();
+        });
+
+        cy.getAttached(".react-tabs").within(() => {
+          cy.findByText(/rpm/i).should("exist").click();
+        });
+
         cy.contains("a", /download/i)
           .first()
           .click();
@@ -51,14 +58,12 @@ describe(
         }
 
         cy.visit("/hosts/manage");
-        cy.location("pathname").should("match", /hosts\/manage/i);
-        cy.get(".manage-hosts").should("contain", /hostname/i); // Ensures page load
 
-        cy.get("tbody").within(() => {
+        cy.getAttached("tbody").within(() => {
           cy.get(".button--text-link").first().as("hostLink");
         });
 
-        cy.get("@hostLink")
+        cy.getAttached("@hostLink")
           // Set hostname variable for later assertions
           .then((el) => {
             console.log(el);
@@ -79,7 +84,7 @@ describe(
           cy.get(".button--text-link").first().as("policyLink");
         });
 
-        cy.get("@policyLink")
+        cy.getAttached("@policyLink")
           // Set policyname variable for later assertions
           .then((el) => {
             console.log(el);
@@ -91,7 +96,7 @@ describe(
           .should("exist")
           .click();
 
-        cy.findByText(/run/i).should("exist").click(); // Ensures page load
+        cy.findByText(/run/i).should("exist").click();
 
         cy.findByText(/all hosts/i)
           .should("exist")
@@ -109,33 +114,33 @@ describe(
           cy.get(".button--text-link").first().as("hostLink");
         });
 
-        cy.get("@hostLink")
+        // Select a query to run on a specified host on host details page
+        cy.getAttached("@hostLink")
           .click()
           .then(() => {
             cy.findByText(/about this host/i).should("exist");
             cy.findByText(hostname).should("exist");
 
-            // Open query host modal and select query
-            cy.get('img[alt="Query host icon"]').click();
-            cy.get(".modal__modal_container")
+            cy.getAttached('img[alt="Query host icon"]').click();
+            cy.getAttached(".modal__modal_container")
               .within(() => {
                 cy.findByText(/select a query/i).should("exist");
                 cy.findByText(/detect presence/i).click();
               })
               .then(() => {
                 cy.findByText(/run query/i).click();
-                cy.get(".data-table").within(() => {
+                cy.getAttached(".data-table").within(() => {
                   cy.findByText(hostname).should("exist");
                 });
               });
           });
 
+        // Delete host
         cy.visit("/hosts/manage");
 
         cy.getAttached("@hostLink")
           .click()
           .then(() => {
-            // Open delete host modal and delete host
             cy.get('img[alt="Delete host icon"]').click();
             cy.get(".modal__modal_container")
               .within(() => {

--- a/cypress/integration/all/app/labelflow.spec.ts
+++ b/cypress/integration/all/app/labelflow.spec.ts
@@ -15,63 +15,57 @@ describe(
       cy.findByRole("button", { name: /add label/i }).click();
 
       // Using class selector because third party element doesn't work with Cypress Testing Selector Library
-      cy.get(".ace_content")
+      cy.getAttached(".ace_content")
         .click()
         .type("{selectall}{backspace}SELECT * FROM users;");
 
-      cy.findByLabelText(/name/i).click().type("Show all users");
+      cy.findByLabelText(/name/i).click().type("Show all MAC users");
 
       cy.findByLabelText(/description/i)
         .click()
-        .type("Select all users across platforms.");
+        .type("Select all MAC users.");
 
-      // =========
-      // TODO: Not needed if we're selecting "All platforms"
-      // either choose a selection or leave it - otherwise
-      // blocks the "Save label" button and breaks the test
+      cy.getAttached(".label-form__form-field--platform > .Select").click();
 
-      // Cannot call cy.select on div disguised as a dropdown
-      // cy.findByText(/all platforms/i).click();
+      cy.getAttached(".Select-menu-outer").within(() => {
+        cy.findByText(/macOS/i).click();
+      });
 
       cy.findByRole("button", { name: /save label/i }).click();
-      // =========
 
       // edit custom label
-      cy.findByText(/show all users/i).click();
+      cy.getAttached(".host-side-panel").within(() => {
+        cy.findByText(/show all mac users/i).click();
+      });
 
-      cy.get(".manage-hosts__label-block button").first().click();
+      cy.getAttached(".manage-hosts__label-block button").first().click();
 
-      // Label SQL not editable to test
+      // // Label SQL not editable to test
 
-      cy.findByLabelText(/name/i)
-        .click()
-        .type("{selectall}{backspace}Show all usernames");
+      cy.findByLabelText(/name/i).clear().type("Show all mac usernames");
 
       cy.findByLabelText(/description/i)
-        .click()
-        .type("{selectall}{backspace}Select all usernames on Mac.");
+        .clear()
+        .type("Select all usernames on Mac.");
 
       cy.findByText(/select one/i).should("not.exist");
 
       cy.findByRole("button", { name: /update label/i }).click();
 
-      // Close success notification
-      cy.get(".flash-message__remove").click();
-
-      cy.visit("/hosts/manage");
-
-      cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
-      cy.findByText(/show all usernames/i).click();
+      cy.getAttached(".host-side-panel").within(() => {
+        cy.findByText(/show all mac usernames/i).click();
+      });
 
       // delete custom label
-      cy.get(".manage-hosts__label-block button").last().click();
+      cy.getAttached(".manage-hosts__label-block button").last().click();
 
-      cy.wait(4000); // eslint-disable-line cypress/no-unnecessary-waiting
-      cy.get(".manage-hosts__modal-buttons > .button--alert")
+      cy.getAttached(".manage-hosts__modal-buttons > .button--alert")
         .contains("button", /delete/i)
         .click();
 
-      cy.findByText(/show all users/i).should("not.exist");
+      cy.getAttached(".host-side-panel").within(() => {
+        cy.findByText(/show all mac usernames/i).should("not.exist");
+      });
     });
   }
 );

--- a/cypress/integration/all/app/labelflow.spec.ts
+++ b/cypress/integration/all/app/labelflow.spec.ts
@@ -15,9 +15,9 @@ describe(
       cy.findByRole("button", { name: /add label/i }).click();
 
       // Using class selector because third party element doesn't work with Cypress Testing Selector Library
-      cy.getAttached(".ace_content")
-        .click()
-        .type("{selectall}{backspace}SELECT * FROM users;");
+      cy.getAttached(".ace_content").type(
+        "{selectall}{backspace}SELECT * FROM users;"
+      );
 
       cy.findByLabelText(/name/i).click().type("Show all MAC users");
 
@@ -33,14 +33,14 @@ describe(
 
       cy.findByRole("button", { name: /save label/i }).click();
 
-      // edit custom label
+      // Edit custom label
       cy.getAttached(".host-side-panel").within(() => {
         cy.findByText(/show all mac users/i).click();
       });
 
       cy.getAttached(".manage-hosts__label-block button").first().click();
 
-      // // Label SQL not editable to test
+      // SQL and Platform are immutable fields
 
       cy.findByLabelText(/name/i).clear().type("Show all mac usernames");
 
@@ -56,7 +56,7 @@ describe(
         cy.findByText(/show all mac usernames/i).click();
       });
 
-      // delete custom label
+      // Delete custom label
       cy.getAttached(".manage-hosts__label-block button").last().click();
 
       cy.getAttached(".manage-hosts__modal-buttons > .button--alert")

--- a/cypress/integration/all/app/labelflow.spec.ts
+++ b/cypress/integration/all/app/labelflow.spec.ts
@@ -1,71 +1,60 @@
-describe(
-  "Label flow",
-  {
-    defaultCommandTimeout: 20000,
-  },
-  () => {
+describe("Labels flow", () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions();
+    cy.setup();
+    cy.loginWithCySession();
+    cy.viewport(1200, 660);
+  });
+  after(() => {
+    cy.logout();
+  });
+
+  describe("Manage hosts page", () => {
     beforeEach(() => {
-      cy.setup();
-      cy.login();
-    });
-
-    it("Create, edit, and delete a label successfully", () => {
+      cy.loginWithCySession();
       cy.visit("/hosts/manage");
-
+    });
+    it("creates a custom label", () => {
       cy.findByRole("button", { name: /add label/i }).click();
-
-      // Using class selector because third party element doesn't work with Cypress Testing Selector Library
       cy.getAttached(".ace_content").type(
         "{selectall}{backspace}SELECT * FROM users;"
       );
-
       cy.findByLabelText(/name/i).click().type("Show all MAC users");
-
       cy.findByLabelText(/description/i)
         .click()
         .type("Select all MAC users.");
-
       cy.getAttached(".label-form__form-field--platform > .Select").click();
-
       cy.getAttached(".Select-menu-outer").within(() => {
         cy.findByText(/macOS/i).click();
       });
-
       cy.findByRole("button", { name: /save label/i }).click();
-
-      // Edit custom label
+      cy.findByText(/label created/i).should("exist");
+    });
+    it("edits a custom label", () => {
       cy.getAttached(".host-side-panel").within(() => {
         cy.findByText(/show all mac users/i).click();
       });
-
       cy.getAttached(".manage-hosts__label-block button").first().click();
-
       // SQL and Platform are immutable fields
-
       cy.findByLabelText(/name/i).clear().type("Show all mac usernames");
-
       cy.findByLabelText(/description/i)
         .clear()
         .type("Select all usernames on Mac.");
-
       cy.findByText(/select one/i).should("not.exist");
-
       cy.findByRole("button", { name: /update label/i }).click();
-
+      cy.findByText(/label updated/i).should("exist");
+    });
+    it("deletes a custom label", () => {
       cy.getAttached(".host-side-panel").within(() => {
         cy.findByText(/show all mac usernames/i).click();
       });
-
-      // Delete custom label
       cy.getAttached(".manage-hosts__label-block button").last().click();
-
       cy.getAttached(".manage-hosts__modal-buttons > .button--alert")
         .contains("button", /delete/i)
         .click();
-
       cy.getAttached(".host-side-panel").within(() => {
         cy.findByText(/show all mac usernames/i).should("not.exist");
       });
     });
-  }
-);
+  });
+});

--- a/cypress/integration/all/app/manageUsers.spec.ts
+++ b/cypress/integration/all/app/manageUsers.spec.ts
@@ -5,8 +5,9 @@ describe("Manage Users", () => {
     cy.setupSMTP();
   });
 
-  it("Searching for a user", () => {
+  it("Search for, create, edit, delete a user", () => {
     cy.visit("/settings/users");
+    cy.url().should("match", /\/settings\/users$/i);
 
     cy.findByText("admin@example.com").should("exist");
     cy.findByText("maintainer@example.com").should("exist");
@@ -15,26 +16,76 @@ describe("Manage Users", () => {
 
     cy.findByPlaceholderText("Search").type("admin");
 
+    cy.getAttached("tbody>tr").should("have.length", 1);
+
     cy.findByText("admin@example.com").should("exist");
     cy.findByText("maintainer@example.com").should("not.exist");
     cy.findByText("observer@example.com").should("not.exist");
     cy.findByText("sso_user@example.com").should("not.exist");
-  });
 
-  // it('Creating a user', () => {
-  //   cy.visit('/settings/users');
-  //   cy.url().should('match', /\/settings\/users$/i);
-  //
-  //   cy.contains('button:enabled', /create user/i)
-  //     .click();
-  //
-  //   cy.findByPlaceholderText('Full name')
-  //     .type('New User');
-  //
-  //   cy.findByPlaceholderText('Email')
-  //     .type('new-user@example.com');
-  //
-  //   cy.findByRole('checkbox', { name: 'Test Team' })
-  //     .click({ force: true }); // we use `force` as the checkbox button is not fully accessible yet.
-  // });
+    cy.findByPlaceholderText("Search").clear();
+
+    cy.contains("button:enabled", /create user/i).click();
+
+    cy.findByPlaceholderText("Full name").type("New Name");
+
+    cy.findByPlaceholderText("Email").type("new-user@example.com");
+
+    cy.findByPlaceholderText("Password").type("user123#");
+
+    cy.getAttached(
+      ".create-user-form__form-field--global-role > .Select"
+    ).click();
+    cy.getAttached(".create-user-form__form-field--global-role").within(() => {
+      cy.findByText(/maintainer/i).click();
+    });
+
+    cy.getAttached(".create-user-form__btn-wrap")
+      .contains("button", /create/i)
+      .click();
+
+    cy.findByText(/new name/i).should("exist");
+
+    cy.getAttached("tbody>tr")
+      .should("have.length", 5)
+      .eq(1)
+      .within(() => {
+        cy.findByText(/action/i).click();
+        cy.findByText(/edit/i).click();
+      });
+
+    cy.findByPlaceholderText("Full name").clear().type("New Admin");
+
+    cy.findByPlaceholderText("Email").clear().type("new-admin@example.com");
+
+    cy.getAttached(
+      ".create-user-form__form-field--global-role > .Select"
+    ).click();
+    cy.getAttached(".create-user-form__form-field--global-role").within(() => {
+      cy.findByText(/admin/i).click();
+    });
+
+    cy.getAttached(".create-user-form__btn-wrap")
+      .contains("button", /save/i)
+      .click();
+
+    cy.findByText(/successfully edited/i).should("exist");
+
+    cy.getAttached("tbody>tr")
+      .eq(1)
+      .within(() => {
+        cy.findByText(/new admin/i).should("exist");
+        cy.findByText(/action/i).click();
+        cy.findByText(/delete/i).click();
+      });
+
+    cy.getAttached(".delete-user-form__btn-wrap")
+      .contains("button", /delete/i)
+      .click();
+
+    cy.findByText(/successfully deleted/i).should("exist");
+
+    cy.getAttached("tbody>tr").should("have.length", 4);
+    cy.findByText(/new-user/i).should("not.exist");
+  });
 });

--- a/cypress/integration/all/app/manageUsers.spec.ts
+++ b/cypress/integration/all/app/manageUsers.spec.ts
@@ -25,6 +25,7 @@ describe("Manage Users", () => {
 
     cy.findByPlaceholderText("Search").clear();
 
+    // Create user
     cy.contains("button:enabled", /create user/i).click();
 
     cy.findByPlaceholderText("Full name").type("New Name");
@@ -46,6 +47,7 @@ describe("Manage Users", () => {
 
     cy.findByText(/new name/i).should("exist");
 
+    // Edit user
     cy.getAttached("tbody>tr")
       .should("have.length", 5)
       .eq(1)
@@ -71,6 +73,7 @@ describe("Manage Users", () => {
 
     cy.findByText(/successfully edited/i).should("exist");
 
+    // Delete user
     cy.getAttached("tbody>tr")
       .eq(1)
       .within(() => {

--- a/cypress/integration/all/app/manageUsers.spec.ts
+++ b/cypress/integration/all/app/manageUsers.spec.ts
@@ -1,94 +1,88 @@
-describe("Manage Users", () => {
-  beforeEach(() => {
+describe("Manage users flow", () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions();
     cy.setup();
-    cy.login();
+    cy.loginWithCySession();
+    cy.viewport(1200, 660);
     cy.setupSMTP();
   });
-
-  it("Search for, create, edit, and delete a user successfully", () => {
-    cy.visit("/settings/users");
-    cy.url().should("match", /\/settings\/users$/i);
-
-    cy.findByText("admin@example.com").should("exist");
-    cy.findByText("maintainer@example.com").should("exist");
-    cy.findByText("observer@example.com").should("exist");
-    cy.findByText("sso_user@example.com").should("exist");
-
-    cy.findByPlaceholderText("Search").type("admin");
-
-    cy.getAttached("tbody>tr").should("have.length", 1);
-
-    cy.findByText("admin@example.com").should("exist");
-    cy.findByText("maintainer@example.com").should("not.exist");
-    cy.findByText("observer@example.com").should("not.exist");
-    cy.findByText("sso_user@example.com").should("not.exist");
-
-    cy.findByPlaceholderText("Search").clear();
-
-    // Create user
-    cy.contains("button:enabled", /create user/i).click();
-
-    cy.findByPlaceholderText("Full name").type("New Name");
-
-    cy.findByPlaceholderText("Email").type("new-user@example.com");
-
-    cy.findByPlaceholderText("Password").type("user123#");
-
-    cy.getAttached(
-      ".create-user-form__form-field--global-role > .Select"
-    ).click();
-    cy.getAttached(".create-user-form__form-field--global-role").within(() => {
-      cy.findByText(/maintainer/i).click();
+  after(() => {
+    cy.logout();
+  });
+  describe("User management page", () => {
+    beforeEach(() => {
+      cy.loginWithCySession();
+      cy.visit("/settings/users");
     });
+    it("searches for an existing user", () => {
+      cy.findByText("admin@example.com").should("exist");
+      cy.findByText("maintainer@example.com").should("exist");
+      cy.findByText("observer@example.com").should("exist");
+      cy.findByText("sso_user@example.com").should("exist");
 
-    cy.getAttached(".create-user-form__btn-wrap")
-      .contains("button", /create/i)
-      .click();
+      cy.findByPlaceholderText("Search").type("admin");
 
-    cy.findByText(/new name/i).should("exist");
-
-    // Edit user
-    cy.getAttached("tbody>tr")
-      .should("have.length", 5)
-      .eq(1)
-      .within(() => {
-        cy.findByText(/action/i).click();
-        cy.findByText(/edit/i).click();
-      });
-
-    cy.findByPlaceholderText("Full name").clear().type("New Admin");
-
-    cy.findByPlaceholderText("Email").clear().type("new-admin@example.com");
-
-    cy.getAttached(
-      ".create-user-form__form-field--global-role > .Select"
-    ).click();
-    cy.getAttached(".create-user-form__form-field--global-role").within(() => {
-      cy.findByText(/admin/i).click();
+      cy.getAttached("tbody>tr").should("have.length", 1);
+      cy.findByText("admin@example.com").should("exist");
+      cy.findByText("maintainer@example.com").should("not.exist");
+      cy.findByText("observer@example.com").should("not.exist");
+      cy.findByText("sso_user@example.com").should("not.exist");
     });
-
-    cy.getAttached(".create-user-form__btn-wrap")
-      .contains("button", /save/i)
-      .click();
-
-    cy.findByText(/successfully edited/i).should("exist");
-
-    // Delete user
-    cy.getAttached("tbody>tr")
-      .eq(1)
-      .within(() => {
-        cy.findByText(/new admin/i).should("exist");
-        cy.findByText(/action/i).click();
-        cy.findByText(/delete/i).click();
-      });
-
-    cy.getAttached(".delete-user-form__btn-wrap")
-      .contains("button", /delete/i)
-      .click();
-
-    cy.findByText(/successfully deleted/i).should("exist");
-
-    cy.getAttached("tbody>tr").should("have.length", 4);
-    cy.findByText(/new-user/i).should("not.exist");
+    it("creates a new user", () => {
+      cy.contains("button:enabled", /create user/i).click();
+      cy.findByPlaceholderText("Full name").type("New Name");
+      cy.findByPlaceholderText("Email").type("new-user@example.com");
+      cy.findByPlaceholderText("Password").type("user123#");
+      cy.getAttached(
+        ".create-user-form__form-field--global-role > .Select"
+      ).click();
+      cy.getAttached(".create-user-form__form-field--global-role").within(
+        () => {
+          cy.findByText(/maintainer/i).click();
+        }
+      );
+      cy.getAttached(".create-user-form__btn-wrap")
+        .contains("button", /create/i)
+        .click();
+      cy.findByText(/new name/i).should("exist");
+    });
+    it("edits an existing user", () => {
+      cy.getAttached("tbody>tr")
+        .should("have.length", 5)
+        .eq(1)
+        .within(() => {
+          cy.findByText(/action/i).click();
+          cy.findByText(/edit/i).click();
+        });
+      cy.findByPlaceholderText("Full name").clear().type("New Admin");
+      cy.findByPlaceholderText("Email").clear().type("new-admin@example.com");
+      cy.getAttached(
+        ".create-user-form__form-field--global-role > .Select"
+      ).click();
+      cy.getAttached(".create-user-form__form-field--global-role").within(
+        () => {
+          cy.findByText(/admin/i).click();
+        }
+      );
+      cy.getAttached(".create-user-form__btn-wrap")
+        .contains("button", /save/i)
+        .click();
+      cy.findByText(/successfully edited/i).should("exist");
+    });
+    it("deletes an existing user", () => {
+      cy.getAttached("tbody>tr")
+        .eq(1)
+        .within(() => {
+          cy.findByText(/new admin/i).should("exist");
+          cy.findByText(/action/i).click();
+          cy.findByText(/delete/i).click();
+        });
+      cy.getAttached(".delete-user-form__btn-wrap")
+        .contains("button", /delete/i)
+        .click();
+      cy.findByText(/successfully deleted/i).should("exist");
+      cy.getAttached("tbody>tr").should("have.length", 4);
+      cy.findByText(/new-user/i).should("not.exist");
+    });
   });
 });

--- a/cypress/integration/all/app/manageUsers.spec.ts
+++ b/cypress/integration/all/app/manageUsers.spec.ts
@@ -5,7 +5,7 @@ describe("Manage Users", () => {
     cy.setupSMTP();
   });
 
-  it("Search for, create, edit, delete a user", () => {
+  it("Search for, create, edit, and delete a user successfully", () => {
     cy.visit("/settings/users");
     cy.url().should("match", /\/settings\/users$/i);
 

--- a/cypress/integration/all/app/packflow.spec.ts
+++ b/cypress/integration/all/app/packflow.spec.ts
@@ -7,9 +7,11 @@ describe(
     beforeEach(() => {
       cy.setup();
       cy.login();
+      cy.seedQueries();
     });
 
     it("Create, edit, and delete a pack and pack query successfully", () => {
+      // Create pack
       cy.visit("/packs/manage");
 
       cy.findByRole("button", { name: /create new pack/i }).click();
@@ -22,42 +24,7 @@ describe(
 
       cy.findByRole("button", { name: /save query pack/i }).click();
 
-      cy.visit("/packs/manage");
-
-      cy.getAttached(".name__cell > .button--text-link").click();
-
-      cy.findByLabelText(/name/i).clear().type("Server errors");
-
-      cy.findByLabelText(/description/i)
-        .clear()
-        .type("See all server errors.");
-
-      cy.findByRole("button", { name: /save/i }).click();
-
-      cy.visit("/packs/manage");
-
-      cy.getAttached(".fleet-checkbox__input").check({ force: true });
-
-      cy.getAttached(".selection__header .fleet-checkbox__tick").click();
-
-      cy.visit("/queries/manage");
-
-      cy.getAttached(".queries-list-wrapper__create-button").click();
-
-      cy.getAttached(".ace_scroller")
-        .click({ force: true })
-        .type("{selectall}SELECT * FROM windows_crashes;");
-
-      cy.findByRole("button", { name: /save/i }).click();
-
-      cy.findByLabelText(/name/i).click().type("Query all window crashes");
-
-      cy.findByLabelText(/description/i)
-        .click()
-        .type("See all window crashes");
-
-      cy.findByRole("button", { name: /save query/i }).click();
-
+      // Add query to pack
       cy.visit("/packs/manage");
 
       cy.getAttached(".name__cell > .button--text-link").click();
@@ -65,7 +32,7 @@ describe(
       cy.findByRole("button", { name: /add query/i }).click();
 
       cy.findByText(/select query/i).click();
-      cy.findByText(/query all/i).click();
+      cy.findByText(/get authorized/i).click();
       cy.getAttached(
         ".pack-query-editor-modal__form-field--frequency > .input-field"
       )
@@ -85,7 +52,8 @@ describe(
         .contains("button", /add query/i)
         .click();
 
-      cy.findByText(/query all window crashes/i).should("exist");
+      // Remove query from pack
+      cy.findByText(/get authorized/i).should("exist");
       cy.getAttached(".fleet-checkbox__input").check({ force: true });
 
       cy.findByRole("button", { name: /remove/i }).click();
@@ -93,6 +61,20 @@ describe(
         .contains("button", /remove/i)
         .click();
 
+      // Edit pack
+      cy.visit("/packs/manage");
+
+      cy.getAttached(".name__cell > .button--text-link").click();
+
+      cy.findByLabelText(/name/i).clear().type("Server errors");
+
+      cy.findByLabelText(/description/i)
+        .clear()
+        .type("See all server errors.");
+
+      cy.findByRole("button", { name: /save/i }).click();
+
+      // Delete pack
       cy.visit("/packs/manage");
 
       cy.getAttached(".fleet-checkbox__input").check({ force: true });
@@ -107,7 +89,9 @@ describe(
 
       cy.visit("/packs/manage");
 
-      cy.findByText(/server errors/i).should("not.exist");
+      cy.getAttached(".table-container").within(() => {
+        cy.findByText(/server errors/i).should("not.exist");
+      });
     });
   }
 );

--- a/cypress/integration/all/app/packflow.spec.ts
+++ b/cypress/integration/all/app/packflow.spec.ts
@@ -1,19 +1,20 @@
-describe(
-  "Pack flow",
-  {
-    defaultCommandTimeout: 20000,
-  },
-  () => {
+describe("Pack flow (empty)", () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions();
+    cy.setup();
+    cy.loginWithCySession();
+    cy.viewport(1200, 660);
+  });
+  after(() => {
+    cy.logout();
+  });
+
+  describe("Manage packs page", () => {
     beforeEach(() => {
-      cy.setup();
-      cy.login();
-      cy.seedQueries();
-    });
-
-    it("Create, edit, and delete a pack and pack query successfully", () => {
-      // Create pack
+      cy.loginWithCySession();
       cy.visit("/packs/manage");
-
+    });
+    it("creates a new pack", () => {
       cy.findByRole("button", { name: /create new pack/i }).click();
 
       cy.findByLabelText(/name/i).click().type("Errors and crashes");
@@ -23,12 +24,29 @@ describe(
         .type("See all user errors and window crashes.");
 
       cy.findByRole("button", { name: /save query pack/i }).click();
+    });
+  });
+});
+describe("Pack flow (seeded)", () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions();
+    cy.setup();
+    cy.loginWithCySession();
+    cy.seedQueries();
+    cy.seedPacks();
+    cy.viewport(1200, 660);
+  });
+  after(() => {
+    cy.logout();
+  });
 
-      // Add query to pack
+  describe("Pack details page", () => {
+    beforeEach(() => {
+      cy.loginWithCySession();
       cy.visit("/packs/manage");
-
-      cy.getAttached(".name__cell > .button--text-link").click();
-
+      cy.getAttached(".name__cell > .button--text-link").first().click();
+    });
+    it("adds a query to an existing pack", () => {
       cy.findByRole("button", { name: /add query/i }).click();
 
       cy.findByText(/select query/i).click();
@@ -51,21 +69,17 @@ describe(
       cy.getAttached(".pack-query-editor-modal__btn-wrap")
         .contains("button", /add query/i)
         .click();
-
-      // Remove query from pack
       cy.findByText(/get authorized/i).should("exist");
+    });
+    it("removes a query from an existing pack", () => {
       cy.getAttached(".fleet-checkbox__input").check({ force: true });
 
       cy.findByRole("button", { name: /remove/i }).click();
       cy.getAttached(".remove-pack-query-modal__btn-wrap")
         .contains("button", /remove/i)
         .click();
-
-      // Edit pack
-      cy.visit("/packs/manage");
-
-      cy.getAttached(".name__cell > .button--text-link").click();
-
+    });
+    it("edits an existing pack", () => {
       cy.findByLabelText(/name/i).clear().type("Server errors");
 
       cy.findByLabelText(/description/i)
@@ -73,12 +87,21 @@ describe(
         .type("See all server errors.");
 
       cy.findByRole("button", { name: /save/i }).click();
-
-      // Delete pack
+    });
+  });
+  describe("Manage packs page", () => {
+    beforeEach(() => {
+      cy.loginWithCySession();
       cy.visit("/packs/manage");
-
-      cy.getAttached(".fleet-checkbox__input").check({ force: true });
-
+    });
+    it("deletes an existing pack", () => {
+      cy.getAttached("tbody").within(() => {
+        cy.getAttached("tr")
+          .first()
+          .within(() => {
+            cy.getAttached(".fleet-checkbox__input").check({ force: true });
+          });
+      });
       cy.findByRole("button", { name: /delete/i }).click();
 
       cy.getAttached(".remove-pack-modal__btn-wrap > .button--alert")
@@ -90,8 +113,8 @@ describe(
       cy.visit("/packs/manage");
 
       cy.getAttached(".table-container").within(() => {
-        cy.findByText(/server errors/i).should("not.exist");
+        cy.findByText(/windows starter pack/i).should("not.exist");
       });
     });
-  }
-);
+  });
+});

--- a/cypress/integration/all/app/packflow.spec.ts
+++ b/cypress/integration/all/app/packflow.spec.ts
@@ -26,19 +26,17 @@ describe(
 
       cy.getAttached(".name__cell > .button--text-link").click();
 
-      cy.findByLabelText(/name/i)
-        .click()
-        .type("{selectall}{backspace}Server errors");
+      cy.findByLabelText(/name/i).clear().type("Server errors");
 
       cy.findByLabelText(/description/i)
-        .click()
-        .type("{selectall}{backspace}See all server errors.");
+        .clear()
+        .type("See all server errors.");
 
       cy.findByRole("button", { name: /save/i }).click();
 
       cy.visit("/packs/manage");
 
-      cy.get(".fleet-checkbox__input").check({ force: true });
+      cy.getAttached(".fleet-checkbox__input").check({ force: true });
 
       cy.getAttached(".selection__header .fleet-checkbox__tick").click();
 

--- a/cypress/integration/all/app/packflow.spec.ts
+++ b/cypress/integration/all/app/packflow.spec.ts
@@ -16,13 +16,10 @@ describe("Pack flow (empty)", () => {
     });
     it("creates a new pack", () => {
       cy.findByRole("button", { name: /create new pack/i }).click();
-
       cy.findByLabelText(/name/i).click().type("Errors and crashes");
-
       cy.findByLabelText(/description/i)
         .click()
         .type("See all user errors and window crashes.");
-
       cy.findByRole("button", { name: /save query pack/i }).click();
     });
   });
@@ -48,7 +45,6 @@ describe("Pack flow (seeded)", () => {
     });
     it("adds a query to an existing pack", () => {
       cy.findByRole("button", { name: /add query/i }).click();
-
       cy.findByText(/select query/i).click();
       cy.findByText(/get authorized/i).click();
       cy.getAttached(
@@ -65,7 +61,6 @@ describe("Pack flow (seeded)", () => {
       )
         .click()
         .type("50");
-
       cy.getAttached(".pack-query-editor-modal__btn-wrap")
         .contains("button", /add query/i)
         .click();
@@ -73,7 +68,6 @@ describe("Pack flow (seeded)", () => {
     });
     it("removes a query from an existing pack", () => {
       cy.getAttached(".fleet-checkbox__input").check({ force: true });
-
       cy.findByRole("button", { name: /remove/i }).click();
       cy.getAttached(".remove-pack-query-modal__btn-wrap")
         .contains("button", /remove/i)
@@ -81,11 +75,9 @@ describe("Pack flow (seeded)", () => {
     });
     it("edits an existing pack", () => {
       cy.findByLabelText(/name/i).clear().type("Server errors");
-
       cy.findByLabelText(/description/i)
         .clear()
         .type("See all server errors.");
-
       cy.findByRole("button", { name: /save/i }).click();
     });
   });
@@ -103,15 +95,11 @@ describe("Pack flow (seeded)", () => {
           });
       });
       cy.findByRole("button", { name: /delete/i }).click();
-
       cy.getAttached(".remove-pack-modal__btn-wrap > .button--alert")
         .contains("button", /delete/i)
         .click({ force: true });
-
       cy.findByText(/successfully deleted/i).should("be.visible");
-
       cy.visit("/packs/manage");
-
       cy.getAttached(".table-container").within(() => {
         cy.findByText(/windows starter pack/i).should("not.exist");
       });

--- a/cypress/integration/all/app/policiesflow.spec.ts
+++ b/cypress/integration/all/app/policiesflow.spec.ts
@@ -10,15 +10,15 @@ describe(
     });
     it("Can create, update, delete a policy successfully, and turn on failing policies webhook", () => {
       cy.visit("/policies/manage");
-      cy.get(".manage-policies-page__description")
-        .should("contain", /add policies/i)
-        .and("contain", /manage automations/i); // Ensure page load
 
       // Add a policy
-      cy.findByText(/add a policy/i).click();
+      cy.getAttached(".manage-policies-page__description").within(() => {
+        cy.findByText(/add a policy/i).click();
+      });
+
       cy.findByText(/create your own policy/i).click();
 
-      cy.get(".ace_scroller")
+      cy.getAttached(".ace_scroller")
         .click({ force: true })
         .type(
           "{selectall}SELECT 1 FROM users WHERE username = 'backup' LIMIT 1;"
@@ -27,37 +27,32 @@ describe(
       cy.findByRole("button", { name: /save policy/i }).click();
 
       // save modal
-      cy.get(".policy-form__policy-save-modal-name")
+      cy.getAttached(".policy-form__policy-save-modal-name")
         .click()
         .type("Does the device have a user named 'backup'?");
 
-      cy.get(".policy-form__policy-save-modal-description")
+      cy.getAttached(".policy-form__policy-save-modal-description")
         .click()
         .type("Returns yes or no for having a user named 'backup'");
 
-      cy.get(".policy-form__policy-save-modal-resolution")
+      cy.getAttached(".policy-form__policy-save-modal-resolution")
         .click()
         .type("Create a user named 'backup'");
 
       cy.findByRole("button", { name: /^Save$/ }).click();
 
-      // Confirm that policy was added successfully
       cy.findByText(/policy created/i).should("exist");
 
-      cy.visit("/policies/manage");
-      cy.get(".manage-policies-page__description").should(
-        "contain",
-        /add policies/i
-      ); // Ensure page load
-
       // Add a default policy
-      cy.findByText(/add a policy/i).click();
+      cy.visit("/policies/manage");
+      cy.getAttached(".manage-policies-page__description").within(() => {
+        cy.findByText(/add a policy/i).click();
+      });
 
       cy.findByText(/gatekeeper enabled/i).click();
       cy.findByRole("button", { name: /save policy/i }).click();
       cy.findByRole("button", { name: /^Save$/ }).click();
 
-      // Confirm that policy was added successfully
       cy.findByText(/policy created/i).should("exist");
 
       cy.visit("/policies/manage");
@@ -70,8 +65,8 @@ describe(
           cy.getAttached(".button--text-link").click();
         });
 
-      // confirm policy functionality on manage host page
-      cy.get(".manage-hosts__policies-filter-block").within(() => {
+      // Confirm policy functionality on manage host page
+      cy.getAttached(".manage-hosts__policies-filter-block").within(() => {
         cy.findByText(/user named 'backup'/i).should("exist");
         cy.findByText(/no/i).should("exist").click();
         cy.findByText(/yes/i).should("exist");
@@ -79,9 +74,8 @@ describe(
         cy.findByText(/user named 'backup'/i).should("not.exist");
       });
 
-      cy.visit("/policies/manage");
-
       // Update policy
+      cy.visit("/policies/manage");
       cy.getAttached(".name__cell .button--text-link").last().click();
 
       cy.getAttached(".ace_scroller")
@@ -92,7 +86,6 @@ describe(
 
       cy.getAttached(".policy-form__save").click();
 
-      // Confirm that policy was added successfully
       cy.findByText(/policy updated/i).should("exist");
 
       // Delete policy

--- a/cypress/integration/all/app/policiesflow.spec.ts
+++ b/cypress/integration/all/app/policiesflow.spec.ts
@@ -1,17 +1,20 @@
-describe(
-  "Policies flow",
-  {
-    defaultCommandTimeout: 20000,
-  },
-  () => {
-    beforeEach(() => {
-      cy.setup();
-      cy.login();
-    });
-    it("Create, update, and delete a policy successfully; turn on failing policies webhook", () => {
-      cy.visit("/policies/manage");
+describe("Policies flow (empty)", () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions();
+    cy.setup();
+    cy.loginWithCySession();
+    cy.viewport(1200, 660);
+  });
+  after(() => {
+    cy.logout();
+  });
 
-      // Add a policy
+  describe("Manage policies page", () => {
+    beforeEach(() => {
+      cy.loginWithCySession();
+      cy.visit("/policies/manage");
+    });
+    it("creates a custom policy", () => {
       cy.getAttached(".manage-policies-page__header-wrap").within(() => {
         cy.findByText(/add a policy/i).click();
       });
@@ -23,58 +26,69 @@ describe(
         .type(
           "{selectall}SELECT 1 FROM users WHERE username = 'backup' LIMIT 1;"
         );
-
       cy.findByRole("button", { name: /save policy/i }).click();
 
-      // save modal
       cy.getAttached(".policy-form__policy-save-modal-name")
         .click()
         .type("Does the device have a user named 'backup'?");
-
       cy.getAttached(".policy-form__policy-save-modal-description")
         .click()
         .type("Returns yes or no for having a user named 'backup'");
-
       cy.getAttached(".policy-form__policy-save-modal-resolution")
         .click()
         .type("Create a user named 'backup'");
-
       cy.findByRole("button", { name: /^Save$/ }).click();
 
       cy.findByText(/policy created/i).should("exist");
-
-      // Add a default policy
-      cy.visit("/policies/manage");
+    });
+    it("creates a default policy", () => {
       cy.getAttached(".manage-policies-page__header-wrap").within(() => {
         cy.findByText(/add a policy/i).click();
       });
-
       cy.findByText(/gatekeeper enabled/i).click();
       cy.findByRole("button", { name: /save policy/i }).click();
       cy.findByRole("button", { name: /^Save$/ }).click();
 
       cy.findByText(/policy created/i).should("exist");
+    });
+  });
+});
 
+describe("Policies flow (seeded)", () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions();
+    cy.setup();
+    cy.loginWithCySession();
+    cy.seedPolicies();
+    cy.viewport(1200, 660);
+  });
+  after(() => {
+    cy.logout();
+  });
+
+  describe("Manage policies page", () => {
+    beforeEach(() => {
+      cy.loginWithCySession();
       cy.visit("/policies/manage");
-
-      // Policy filter diplays on manage hosts page
+    });
+    it("links to manage host page filtered by policy", () => {
       cy.getAttached(".failing_host_count__cell")
         .first()
         .within(() => {
           cy.getAttached(".button--text-link").click();
         });
 
-      // Confirm policy functionality on manage host page
+      // confirm policy functionality on manage host page
       cy.getAttached(".manage-hosts__policies-filter-block").within(() => {
-        cy.findByText(/user named 'backup'/i).should("exist");
+        cy.findByText(/filevault enabled/i).should("exist");
         cy.findByText(/no/i).should("exist").click();
         cy.findByText(/yes/i).should("exist");
         cy.get('img[alt="Remove policy filter"]').click();
-        cy.findByText(/user named 'backup'/i).should("not.exist");
+        cy.findByText(/filevault enabled'/i).should("not.exist");
       });
+    });
 
-      // Update policy
-      cy.visit("/policies/manage");
+    it("edits an existing policy", () => {
       cy.getAttached(".name__cell .button--text-link").last().click();
 
       cy.getAttached(".ace_scroller")
@@ -86,10 +100,9 @@ describe(
       cy.getAttached(".policy-form__save").click();
 
       cy.findByText(/policy updated/i).should("exist");
+    });
 
-      // Delete policy
-      cy.visit("/policies/manage");
-
+    it("deletes an existing policy", () => {
       cy.getAttached("tbody").within(() => {
         cy.getAttached("tr")
           .first()
@@ -104,8 +117,9 @@ describe(
       });
       cy.findByText(/removed policy/i).should("exist");
       cy.findByText(/backup/i).should("not.exist");
+    });
 
-      // Create failing policies webhook
+    it("creates a failing policies webhook", () => {
       cy.findByRole("button", { name: /manage automations/i }).click();
       cy.getAttached(".manage-automations-modal").within(() => {
         cy.getAttached(".fleet-checkbox__input").check({ force: true });
@@ -120,5 +134,5 @@ describe(
         cy.getAttached(".fleet-checkbox__input").should("be.checked");
       });
     });
-  }
-);
+  });
+});

--- a/cypress/integration/all/app/policiesflow.spec.ts
+++ b/cypress/integration/all/app/policiesflow.spec.ts
@@ -8,7 +8,7 @@ describe(
       cy.setup();
       cy.login();
     });
-    it("Can create, update, delete a policy successfully, and turn on failing policies webhook", () => {
+    it("Create, update, and delete a policy successfully; turn on failing policies webhook", () => {
       cy.visit("/policies/manage");
 
       // Add a policy

--- a/cypress/integration/all/app/policiesflow.spec.ts
+++ b/cypress/integration/all/app/policiesflow.spec.ts
@@ -18,16 +18,13 @@ describe("Policies flow (empty)", () => {
       cy.getAttached(".manage-policies-page__header-wrap").within(() => {
         cy.findByText(/add a policy/i).click();
       });
-
       cy.findByText(/create your own policy/i).click();
-
       cy.getAttached(".ace_scroller")
         .click({ force: true })
         .type(
           "{selectall}SELECT 1 FROM users WHERE username = 'backup' LIMIT 1;"
         );
       cy.findByRole("button", { name: /save policy/i }).click();
-
       cy.getAttached(".policy-form__policy-save-modal-name")
         .click()
         .type("Does the device have a user named 'backup'?");
@@ -38,7 +35,6 @@ describe("Policies flow (empty)", () => {
         .click()
         .type("Create a user named 'backup'");
       cy.findByRole("button", { name: /^Save$/ }).click();
-
       cy.findByText(/policy created/i).should("exist");
     });
     it("creates a default policy", () => {
@@ -77,7 +73,6 @@ describe("Policies flow (seeded)", () => {
         .within(() => {
           cy.getAttached(".button--text-link").click();
         });
-
       // confirm policy functionality on manage host page
       cy.getAttached(".manage-hosts__policies-filter-block").within(() => {
         cy.findByText(/filevault enabled/i).should("exist");
@@ -87,18 +82,14 @@ describe("Policies flow (seeded)", () => {
         cy.findByText(/filevault enabled'/i).should("not.exist");
       });
     });
-
     it("edits an existing policy", () => {
       cy.getAttached(".name__cell .button--text-link").last().click();
-
       cy.getAttached(".ace_scroller")
         .click({ force: true })
         .type(
           "{selectall}SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;"
         );
-
       cy.getAttached(".policy-form__save").click();
-
       cy.findByText(/policy updated/i).should("exist");
     });
 
@@ -118,7 +109,6 @@ describe("Policies flow (seeded)", () => {
       cy.findByText(/removed policy/i).should("exist");
       cy.findByText(/backup/i).should("not.exist");
     });
-
     it("creates a failing policies webhook", () => {
       cy.findByRole("button", { name: /manage automations/i }).click();
       cy.getAttached(".manage-automations-modal").within(() => {
@@ -126,7 +116,6 @@ describe("Policies flow (seeded)", () => {
       });
       cy.getAttached("#webhook-url").click().type("www.foo.com/bar");
       cy.findByRole("button", { name: /^Save$/ }).click();
-
       // Confirm failing policies webhook was added successfully
       cy.findByText(/updated policy automations/i).should("exist");
       cy.findByRole("button", { name: /manage automations/i }).click();

--- a/cypress/integration/all/app/policiesflow.spec.ts
+++ b/cypress/integration/all/app/policiesflow.spec.ts
@@ -12,7 +12,7 @@ describe(
       cy.visit("/policies/manage");
 
       // Add a policy
-      cy.getAttached(".manage-policies-page__description").within(() => {
+      cy.getAttached(".manage-policies-page__header-wrap").within(() => {
         cy.findByText(/add a policy/i).click();
       });
 
@@ -45,7 +45,7 @@ describe(
 
       // Add a default policy
       cy.visit("/policies/manage");
-      cy.getAttached(".manage-policies-page__description").within(() => {
+      cy.getAttached(".manage-policies-page__header-wrap").within(() => {
         cy.findByText(/add a policy/i).click();
       });
 
@@ -57,8 +57,7 @@ describe(
 
       cy.visit("/policies/manage");
 
-      // Click on link in table and confirm that policies filter block diplays as expected on manage
-      // hosts page
+      // Policy filter diplays on manage hosts page
       cy.getAttached(".failing_host_count__cell")
         .first()
         .within(() => {
@@ -114,7 +113,7 @@ describe(
       cy.getAttached("#webhook-url").click().type("www.foo.com/bar");
       cy.findByRole("button", { name: /^Save$/ }).click();
 
-      // Confirm that failing policies webhook was added successfully
+      // Confirm failing policies webhook was added successfully
       cy.findByText(/updated policy automations/i).should("exist");
       cy.findByRole("button", { name: /manage automations/i }).click();
       cy.getAttached(".manage-automations-modal").within(() => {

--- a/cypress/integration/all/app/queryflow.spec.ts
+++ b/cypress/integration/all/app/queryflow.spec.ts
@@ -9,9 +9,10 @@ describe(
       cy.login();
     });
 
-    it("Create, check, edit, and delete a query successfully and create, edit, and delete a global scheduled query successfully", () => {
+    it("Create, check, edit, and delete a query successfully and create, edit, and remove a global scheduled query successfully", () => {
       cy.visit("/queries/manage");
 
+      // Create query
       cy.getAttached(".queries-list-wrapper__create-button").click();
 
       cy.getAttached(".ace_scroller")
@@ -31,7 +32,12 @@ describe(
       cy.findByRole("button", { name: /save query/i }).click();
 
       cy.findByText(/query created/i).should("exist");
-      cy.findByText(/back to queries/i).should("exist");
+
+      cy.getAttached(".query-form__query-name").within(() => {
+        cy.findByText(/query all window crashes/i).should("exist");
+      });
+
+      // Edit query
       cy.visit("/queries/manage");
       cy.getAttached(".name__cell .button--text-link").first().click();
 
@@ -45,6 +51,89 @@ describe(
 
       cy.findByText(/query updated/i).should("be.visible");
 
+      // Create a scheduled query
+      cy.visit("/schedule/manage");
+
+      cy.getAttached(".no-schedule__cta-buttons").within(() => {
+        cy.getAttached(".no-schedule__schedule-button").click();
+      });
+
+      cy.getAttached(".schedule-editor-modal__form").within(() => {
+        cy.findByText(/select query/i).click();
+        cy.findByText(/query all/i).click();
+
+        cy.findByText(/every day/i).click();
+        cy.findByText(/every 6 hours/i).click();
+
+        cy.findByText(/show advanced options/i).click();
+        cy.findByText(/snapshot/i).click();
+        cy.findByText(/ignore removals/i).click();
+
+        cy.getAttached(".schedule-editor-modal__form-field--platform").within(
+          () => {
+            cy.findByText(/all/i).click();
+            cy.findByText(/linux/i).click();
+          }
+        );
+
+        cy.getAttached(
+          ".schedule-editor-modal__form-field--osquer-vers"
+        ).within(() => {
+          cy.findByText(/all/i).click();
+          cy.findByText(/4.6.0/i).click();
+        });
+
+        cy.getAttached(".schedule-editor-modal__form-field--shard").within(
+          () => {
+            cy.getAttached(".input-field").click().type("50");
+          }
+        );
+
+        cy.getAttached(".schedule-editor-modal__btn-wrap").within(() => {
+          cy.findByRole("button", { name: /schedule/i }).click();
+        });
+      });
+
+      cy.findByText(/successfully added/i).should("be.visible");
+
+      // Edit a scheduled query
+      cy.visit("/schedule/manage");
+
+      cy.getAttached("tbody>tr")
+        .should("have.length", 1)
+        .within(() => {
+          cy.findByText(/action/i).click();
+          cy.findByText(/edit/i).click();
+        });
+
+      cy.getAttached(".schedule-editor-modal__form").within(() => {
+        cy.findByText(/every 6 hours/i).click();
+        cy.findByText(/every day/i).click();
+
+        cy.getAttached(".schedule-editor-modal__btn-wrap").within(() => {
+          cy.findByRole("button", { name: /schedule/i }).click();
+        });
+      });
+
+      cy.findByText(/successfully updated/i).should("be.visible");
+
+      // Remove a scheduled query
+      cy.visit("/schedule/manage");
+      cy.getAttached("tbody>tr")
+        .should("have.length", 1)
+        .within(() => {
+          cy.findByText(/1 day/i).should("exist");
+          cy.findByText(/action/i).click();
+          cy.findByText(/remove/i).click();
+        });
+
+      cy.getAttached(".remove-scheduled-query-modal__btn-wrap").within(() => {
+        cy.findByRole("button", { name: /remove/i }).click();
+      });
+
+      cy.findByText(/successfully removed/i).should("be.visible");
+
+      // Delete query
       cy.visit("/queries/manage");
 
       cy.findByText(/query all window crashes/i)

--- a/cypress/integration/all/app/queryflow.spec.ts
+++ b/cypress/integration/all/app/queryflow.spec.ts
@@ -1,51 +1,38 @@
-describe(
-  "Query flow (empty)",
-  {
-    defaultCommandTimeout: 20000,
-  },
-  () => {
-    before(() => {
-      Cypress.session.clearAllSavedSessions();
-      cy.setup();
+describe("Query flow (empty)", () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions();
+    cy.setup();
+    cy.loginWithCySession();
+    cy.viewport(1200, 660);
+  });
+  after(() => {
+    cy.logout();
+  });
+  describe("Manage queries page", () => {
+    beforeEach(() => {
       cy.loginWithCySession();
-      cy.viewport(1200, 660);
+      cy.visit("/queries/manage");
     });
-    after(() => {
-      cy.logout();
-    });
-    describe("Manage queries page", () => {
-      beforeEach(() => {
-        cy.loginWithCySession();
-        cy.visit("/queries/manage");
-      });
-      it("creates a new query", () => {
-        cy.getAttached(".queries-list-wrapper__create-button").click();
-
-        cy.getAttached(".ace_scroller")
-          .click({ force: true })
-          .type("{selectall}SELECT * FROM windows_crashes;");
-
-        cy.findByRole("button", { name: /save/i }).click();
-
-        cy.getAttached(".query-form__query-save-modal-name")
-          .click()
-          .type("Query all window crashes");
-
-        cy.getAttached(".query-form__query-save-modal-description")
-          .click()
-          .type("See all window crashes");
-
-        cy.findByRole("button", { name: /save query/i }).click();
-
-        cy.findByText(/query created/i).should("exist");
-
-        cy.getAttached(".query-form__query-name").within(() => {
-          cy.findByText(/query all window crashes/i).should("exist");
-        });
+    it("creates a new query", () => {
+      cy.getAttached(".queries-list-wrapper__create-button").click();
+      cy.getAttached(".ace_scroller")
+        .click({ force: true })
+        .type("{selectall}SELECT * FROM windows_crashes;");
+      cy.findByRole("button", { name: /save/i }).click();
+      cy.getAttached(".query-form__query-save-modal-name")
+        .click()
+        .type("Query all window crashes");
+      cy.getAttached(".query-form__query-save-modal-description")
+        .click()
+        .type("See all window crashes");
+      cy.findByRole("button", { name: /save query/i }).click();
+      cy.findByText(/query created/i).should("exist");
+      cy.getAttached(".query-form__query-name").within(() => {
+        cy.findByText(/query all window crashes/i).should("exist");
       });
     });
-  }
-);
+  });
+});
 
 describe("Query flow (seeded)", () => {
   before(() => {
@@ -65,18 +52,13 @@ describe("Query flow (seeded)", () => {
     });
     it("edits an existing query", () => {
       cy.getAttached(".name__cell .button--text-link").first().click();
-
       cy.findByText(/run query/i).should("exist");
-
       cy.getAttached(".ace_scroller")
         .click()
         .type("{selectall}SELECT datetime, username FROM windows_crashes;");
-
       cy.getAttached(".button--brand.query-form__save").click();
-
       cy.findByText(/query updated/i).should("be.visible");
     });
-
     it("deletes an existing query", () => {
       cy.findByText(/detect linux hosts/i)
         .parent()
@@ -88,7 +70,6 @@ describe("Query flow (seeded)", () => {
         });
       cy.findByRole("button", { name: /delete/i }).click();
       cy.getAttached(".button--alert.remove-query-modal__btn").click();
-
       cy.findByText(/successfully removed query/i).should("be.visible");
       cy.findByText(/detect linux hosts/i).should("not.exist");
     });

--- a/cypress/integration/all/app/queryflow.spec.ts
+++ b/cypress/integration/all/app/queryflow.spec.ts
@@ -4,151 +4,164 @@ describe(
     defaultCommandTimeout: 20000,
   },
   () => {
-    beforeEach(() => {
+    before(() => {
       cy.setup();
       cy.login();
     });
+    after(() => {
+      cy.logout();
+    });
 
-    it("Create, check, edit, and delete a query successfully and create, edit, and remove a global scheduled query successfully", () => {
-      cy.visit("/queries/manage");
+    describe("Admin can successfully create, edit, and delete a query and a scheduled query", () => {
+      beforeEach(() => {
+        cy.login();
+      });
+      it("create a query successfully", () => {
+        cy.visit("/queries/manage");
 
-      // Create query
-      cy.getAttached(".queries-list-wrapper__create-button").click();
+        // Create query
+        cy.getAttached(".queries-list-wrapper__create-button").click();
 
-      cy.getAttached(".ace_scroller")
-        .click({ force: true })
-        .type("{selectall}SELECT * FROM windows_crashes;");
+        cy.getAttached(".ace_scroller")
+          .click({ force: true })
+          .type("{selectall}SELECT * FROM windows_crashes;");
 
-      cy.findByRole("button", { name: /save/i }).click();
+        cy.findByRole("button", { name: /save/i }).click();
 
-      cy.getAttached(".query-form__query-save-modal-name")
-        .click()
-        .type("Query all window crashes");
+        cy.getAttached(".query-form__query-save-modal-name")
+          .click()
+          .type("Query all window crashes");
 
-      cy.getAttached(".query-form__query-save-modal-description")
-        .click()
-        .type("See all window crashes");
+        cy.getAttached(".query-form__query-save-modal-description")
+          .click()
+          .type("See all window crashes");
 
-      cy.findByRole("button", { name: /save query/i }).click();
+        cy.findByRole("button", { name: /save query/i }).click();
 
-      cy.findByText(/query created/i).should("exist");
+        cy.findByText(/query created/i).should("exist");
 
-      cy.getAttached(".query-form__query-name").within(() => {
-        cy.findByText(/query all window crashes/i).should("exist");
+        cy.getAttached(".query-form__query-name").within(() => {
+          cy.findByText(/query all window crashes/i).should("exist");
+        });
       });
 
-      // Edit query
-      cy.visit("/queries/manage");
-      cy.getAttached(".name__cell .button--text-link").first().click();
+      it("edit a query successfully", () => {
+        cy.visit("/queries/manage");
+        cy.getAttached(".name__cell .button--text-link").first().click();
 
-      cy.findByText(/run query/i).should("exist");
+        cy.findByText(/run query/i).should("exist");
 
-      cy.getAttached(".ace_scroller")
-        .click()
-        .type("{selectall}SELECT datetime, username FROM windows_crashes;");
+        cy.getAttached(".ace_scroller")
+          .click()
+          .type("{selectall}SELECT datetime, username FROM windows_crashes;");
 
-      cy.getAttached(".button--brand.query-form__save").click();
+        cy.getAttached(".button--brand.query-form__save").click();
 
-      cy.findByText(/query updated/i).should("be.visible");
-
-      // Create a scheduled query
-      cy.visit("/schedule/manage");
-
-      cy.getAttached(".no-schedule__cta-buttons").within(() => {
-        cy.getAttached(".no-schedule__schedule-button").click();
+        cy.findByText(/query updated/i).should("be.visible");
       });
 
-      cy.getAttached(".schedule-editor-modal__form").within(() => {
-        cy.findByText(/select query/i).click();
-        cy.findByText(/query all/i).click();
+      it("schedule a query successfully", () => {
+        cy.visit("/schedule/manage");
 
-        cy.findByText(/every day/i).click();
-        cy.findByText(/every 6 hours/i).click();
+        cy.getAttached(".no-schedule__cta-buttons").within(() => {
+          cy.getAttached(".no-schedule__schedule-button").click();
+        });
 
-        cy.findByText(/show advanced options/i).click();
-        cy.findByText(/snapshot/i).click();
-        cy.findByText(/ignore removals/i).click();
+        cy.getAttached(".schedule-editor-modal__form").within(() => {
+          cy.findByText(/select query/i).click();
+          cy.findByText(/query all/i).click();
 
-        cy.getAttached(".schedule-editor-modal__form-field--platform").within(
-          () => {
+          cy.findByText(/every day/i).click();
+          cy.findByText(/every 6 hours/i).click();
+
+          cy.findByText(/show advanced options/i).click();
+          cy.findByText(/snapshot/i).click();
+          cy.findByText(/ignore removals/i).click();
+
+          cy.getAttached(".schedule-editor-modal__form-field--platform").within(
+            () => {
+              cy.findByText(/all/i).click();
+              cy.findByText(/linux/i).click();
+            }
+          );
+
+          cy.getAttached(
+            ".schedule-editor-modal__form-field--osquer-vers"
+          ).within(() => {
             cy.findByText(/all/i).click();
-            cy.findByText(/linux/i).click();
-          }
-        );
+            cy.findByText(/4.6.0/i).click();
+          });
 
-        cy.getAttached(
-          ".schedule-editor-modal__form-field--osquer-vers"
-        ).within(() => {
-          cy.findByText(/all/i).click();
-          cy.findByText(/4.6.0/i).click();
+          cy.getAttached(".schedule-editor-modal__form-field--shard").within(
+            () => {
+              cy.getAttached(".input-field").click().type("50");
+            }
+          );
+
+          cy.getAttached(".schedule-editor-modal__btn-wrap").within(() => {
+            cy.findByRole("button", { name: /schedule/i }).click();
+          });
         });
 
-        cy.getAttached(".schedule-editor-modal__form-field--shard").within(
-          () => {
-            cy.getAttached(".input-field").click().type("50");
-          }
-        );
-
-        cy.getAttached(".schedule-editor-modal__btn-wrap").within(() => {
-          cy.findByRole("button", { name: /schedule/i }).click();
-        });
+        cy.findByText(/successfully added/i).should("be.visible");
       });
 
-      cy.findByText(/successfully added/i).should("be.visible");
+      it("edit a scheduled query successfully", () => {
+        cy.visit("/schedule/manage");
 
-      // Edit a scheduled query
-      cy.visit("/schedule/manage");
+        cy.getAttached("tbody>tr")
+          .should("have.length", 1)
+          .within(() => {
+            cy.findByText(/action/i).click();
+            cy.findByText(/edit/i).click();
+          });
 
-      cy.getAttached("tbody>tr")
-        .should("have.length", 1)
-        .within(() => {
-          cy.findByText(/action/i).click();
-          cy.findByText(/edit/i).click();
+        cy.getAttached(".schedule-editor-modal__form").within(() => {
+          cy.findByText(/every 6 hours/i).click();
+          cy.findByText(/every day/i).click();
+
+          cy.getAttached(".schedule-editor-modal__btn-wrap").within(() => {
+            cy.findByRole("button", { name: /schedule/i }).click();
+          });
         });
 
-      cy.getAttached(".schedule-editor-modal__form").within(() => {
-        cy.findByText(/every 6 hours/i).click();
-        cy.findByText(/every day/i).click();
-
-        cy.getAttached(".schedule-editor-modal__btn-wrap").within(() => {
-          cy.findByRole("button", { name: /schedule/i }).click();
-        });
+        cy.findByText(/successfully updated/i).should("be.visible");
       });
 
-      cy.findByText(/successfully updated/i).should("be.visible");
+      it("remove a scheduled query successfully", () => {
+        cy.visit("/schedule/manage");
+        cy.getAttached("tbody>tr")
+          .should("have.length", 1)
+          .within(() => {
+            cy.findByText(/1 day/i).should("exist");
+            cy.findByText(/action/i).click();
+            cy.findByText(/remove/i).click();
+          });
 
-      // Remove a scheduled query
-      cy.visit("/schedule/manage");
-      cy.getAttached("tbody>tr")
-        .should("have.length", 1)
-        .within(() => {
-          cy.findByText(/1 day/i).should("exist");
-          cy.findByText(/action/i).click();
-          cy.findByText(/remove/i).click();
+        cy.getAttached(".remove-scheduled-query-modal__btn-wrap").within(() => {
+          cy.findByRole("button", { name: /remove/i }).click();
         });
 
-      cy.getAttached(".remove-scheduled-query-modal__btn-wrap").within(() => {
-        cy.findByRole("button", { name: /remove/i }).click();
+        cy.findByText(/successfully removed/i).should("be.visible");
       });
 
-      cy.findByText(/successfully removed/i).should("be.visible");
+      it("delete a query successfully", () => {
+        cy.visit("/queries/manage");
 
-      // Delete query
-      cy.visit("/queries/manage");
+        cy.findByText(/query all window crashes/i)
+          .parent()
+          .parent()
+          .within(() => {
+            cy.getAttached(".fleet-checkbox__input").check({ force: true });
+          });
 
-      cy.findByText(/query all window crashes/i)
-        .parent()
-        .parent()
-        .within(() => {
-          cy.getAttached(".fleet-checkbox__input").check({ force: true });
-        });
+        cy.findByRole("button", { name: /delete/i }).click();
 
-      cy.findByRole("button", { name: /delete/i }).click();
+        cy.getAttached(".button--alert.remove-query-modal__btn").click();
 
-      cy.getAttached(".button--alert.remove-query-modal__btn").click();
-
-      cy.findByText(/successfully removed query/i).should("be.visible");
-      cy.get(".name__cell .button--text-link").should("not.exist");
+        cy.findByText(/successfully removed query/i).should("be.visible");
+        cy.get(".name__cell .button--text-link").should("not.exist");
+      });
     });
   }
 );

--- a/cypress/integration/all/app/queryflow.spec.ts
+++ b/cypress/integration/all/app/queryflow.spec.ts
@@ -79,84 +79,84 @@ describe("Query flow (seeded)", () => {
       cy.loginWithCySession();
       cy.visit("/schedule/manage");
     });
-    // it("creates a new scheduled query", () => {
-    //   cy.getAttached(".no-schedule__cta-buttons").within(() => {
-    //     cy.getAttached(".no-schedule__schedule-button").click();
-    //   });
+    it("creates a new scheduled query", () => {
+      cy.getAttached(".no-schedule__cta-buttons").within(() => {
+        cy.getAttached(".no-schedule__schedule-button").click();
+      });
 
-    //   cy.getAttached(".schedule-editor-modal__form").within(() => {
-    //     cy.findByText(/select query/i).click();
-    //     cy.findByText(/query all/i).click();
+      cy.getAttached(".schedule-editor-modal__form").within(() => {
+        cy.findByText(/select query/i).click();
+        cy.findByText(/detect presence/i).click();
 
-    //     cy.findByText(/every day/i).click();
-    //     cy.findByText(/every 6 hours/i).click();
+        cy.findByText(/every day/i).click();
+        cy.findByText(/every 6 hours/i).click();
 
-    //     cy.findByText(/show advanced options/i).click();
-    //     cy.findByText(/snapshot/i).click();
-    //     cy.findByText(/ignore removals/i).click();
+        cy.findByText(/show advanced options/i).click();
+        cy.findByText(/snapshot/i).click();
+        cy.findByText(/ignore removals/i).click();
 
-    //     cy.getAttached(".schedule-editor-modal__form-field--platform").within(
-    //       () => {
-    //         cy.findByText(/all/i).click();
-    //         cy.findByText(/linux/i).click();
-    //       }
-    //     );
+        cy.getAttached(".schedule-editor-modal__form-field--platform").within(
+          () => {
+            cy.findByText(/all/i).click();
+            cy.findByText(/linux/i).click();
+          }
+        );
 
-    //     cy.getAttached(
-    //       ".schedule-editor-modal__form-field--osquer-vers"
-    //     ).within(() => {
-    //       cy.findByText(/all/i).click();
-    //       cy.findByText(/4.6.0/i).click();
-    //     });
+        cy.getAttached(
+          ".schedule-editor-modal__form-field--osquer-vers"
+        ).within(() => {
+          cy.findByText(/all/i).click();
+          cy.findByText(/4.6.0/i).click();
+        });
 
-    //     cy.getAttached(".schedule-editor-modal__form-field--shard").within(
-    //       () => {
-    //         cy.getAttached(".input-field").click().type("50");
-    //       }
-    //     );
+        cy.getAttached(".schedule-editor-modal__form-field--shard").within(
+          () => {
+            cy.getAttached(".input-field").click().type("50");
+          }
+        );
 
-    //     cy.getAttached(".schedule-editor-modal__btn-wrap").within(() => {
-    //       cy.findByRole("button", { name: /schedule/i }).click();
-    //     });
-    //   });
+        cy.getAttached(".schedule-editor-modal__btn-wrap").within(() => {
+          cy.findByRole("button", { name: /schedule/i }).click();
+        });
+      });
 
-    //   cy.findByText(/successfully added/i).should("be.visible");
-    // });
+      cy.findByText(/successfully added/i).should("be.visible");
+    });
 
-    // it("edit a scheduled query successfully", () => {
-    //   cy.getAttached("tbody>tr")
-    //     .should("have.length", 1)
-    //     .within(() => {
-    //       cy.findByText(/action/i).click();
-    //       cy.findByText(/edit/i).click();
-    //     });
+    it("edit a scheduled query successfully", () => {
+      cy.getAttached("tbody>tr")
+        .should("have.length", 1)
+        .within(() => {
+          cy.findByText(/action/i).click();
+          cy.findByText(/edit/i).click();
+        });
 
-    //   cy.getAttached(".schedule-editor-modal__form").within(() => {
-    //     cy.findByText(/every 6 hours/i).click();
-    //     cy.findByText(/every day/i).click();
+      cy.getAttached(".schedule-editor-modal__form").within(() => {
+        cy.findByText(/every 6 hours/i).click();
+        cy.findByText(/every day/i).click();
 
-    //     cy.getAttached(".schedule-editor-modal__btn-wrap").within(() => {
-    //       cy.findByRole("button", { name: /schedule/i }).click();
-    //     });
-    //   });
+        cy.getAttached(".schedule-editor-modal__btn-wrap").within(() => {
+          cy.findByRole("button", { name: /schedule/i }).click();
+        });
+      });
 
-    //   cy.findByText(/successfully updated/i).should("be.visible");
-    // });
+      cy.findByText(/successfully updated/i).should("be.visible");
+    });
 
-    // it("remove a scheduled query successfully", () => {
-    //   cy.getAttached("tbody>tr")
-    //     .should("have.length", 1)
-    //     .within(() => {
-    //       cy.findByText(/1 day/i).should("exist");
-    //       cy.findByText(/action/i).click();
-    //       cy.findByText(/remove/i).click();
-    //     });
+    it("remove a scheduled query successfully", () => {
+      cy.getAttached("tbody>tr")
+        .should("have.length", 1)
+        .within(() => {
+          cy.findByText(/1 day/i).should("exist");
+          cy.findByText(/action/i).click();
+          cy.findByText(/remove/i).click();
+        });
 
-    //   cy.getAttached(".remove-scheduled-query-modal__btn-wrap").within(() => {
-    //     cy.findByRole("button", { name: /remove/i }).click();
-    //   });
+      cy.getAttached(".remove-scheduled-query-modal__btn-wrap").within(() => {
+        cy.findByRole("button", { name: /remove/i }).click();
+      });
 
-    //   cy.findByText(/successfully removed/i).should("be.visible");
-    // });
+      cy.findByText(/successfully removed/i).should("be.visible");
+    });
   });
 });

--- a/cypress/integration/all/app/resetsessions.spec.ts
+++ b/cypress/integration/all/app/resetsessions.spec.ts
@@ -26,7 +26,6 @@ describe("Reset sessions", () => {
         cy.getAttached("input").invoke("val").as("token1");
       });
       cy.visit("/settings/users");
-
       cy.getAttached("div.Select-placeholder", /actions/i)
         .eq(0)
         .click();
@@ -37,16 +36,12 @@ describe("Reset sessions", () => {
         cy.findByRole("button", { name: /confirm/i }).click();
       });
       cy.findByText(/reset sessions/i).should("not.exist");
-
       // user should be logged out so log in for new API token
       cy.getAttached(".login-form__container").within(() => {
         cy.findByRole("button", { name: /login/i }).should("exist");
       });
-
       cy.login();
-
       cy.visit("/profile");
-
       cy.getAttached(".user-settings__additional").within(() => {
         cy.findByRole("button", { name: /get api token/i }).click();
       });
@@ -56,7 +51,6 @@ describe("Reset sessions", () => {
       cy.getAttached(".user-settings__secret-input").within(() => {
         cy.get("input").invoke("val").as("token2");
       });
-
       // new token should not equal old token
       cy.get("@token1").then((val1) => {
         cy.get("@token2").then((val2) => {

--- a/cypress/integration/all/app/resetsessions.spec.ts
+++ b/cypress/integration/all/app/resetsessions.spec.ts
@@ -6,7 +6,7 @@ describe("Reset user sessions flow", () => {
   });
 
   it("Resets a user's API tokens", () => {
-    // visit user's profile page and get current API token
+    // Visit user's profile page and get current API token
     cy.visit("/profile");
 
     cy.getAttached(".user-settings__additional").within(() => {
@@ -19,10 +19,10 @@ describe("Reset user sessions flow", () => {
       cy.getAttached("input").invoke("val").as("token1");
     });
 
-    // reset user sessions via the admin user management page
+    // Reset user sessions via the admin user management page
     cy.visit("/settings/users");
-    // first select the table cell with the user's email address then go back up to the containing row
-    // so we can select reset sessions from actions dropdown
+    // First select the table cell with the user's email address then go back up
+    // to the containing row so we can select reset sessions from actions dropdown
     cy.getAttached("div.Select-placeholder", /actions/i)
       .eq(0)
       .click();
@@ -34,9 +34,11 @@ describe("Reset user sessions flow", () => {
     });
     cy.findByText(/reset sessions/i).should("not.exist");
 
-    cy.wait(4000); // eslint-disable-line cypress/no-unnecessary-waiting
-    // user should be logged out now so log in again and go to profile to get new API token
-    cy.findByRole("button", { name: /login/i }).should("exist");
+    // User should be logged out now so log in again and go to profile to get new API token
+    cy.getAttached(".login-form__container").within(() => {
+      cy.findByRole("button", { name: /login/i }).should("exist");
+    });
+
     cy.login();
 
     cy.visit("/profile");

--- a/cypress/integration/all/app/resetsessions.spec.ts
+++ b/cypress/integration/all/app/resetsessions.spec.ts
@@ -1,62 +1,67 @@
-describe("Reset user sessions flow", () => {
-  beforeEach(() => {
+describe("Reset sessions", () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions();
     cy.setup();
-    cy.login();
+    cy.loginWithCySession();
     cy.setupSMTP();
+    cy.viewport(1200, 660);
+  });
+  after(() => {
+    cy.logout();
   });
 
-  it("Resets a user's API tokens", () => {
-    // Visit user's profile page and get current API token
-    cy.visit("/profile");
-
-    cy.getAttached(".user-settings__additional").within(() => {
-      cy.findByRole("button", { name: /get api token/i }).click();
+  describe("User settings page", () => {
+    beforeEach(() => {
+      cy.loginWithCySession();
     });
-    cy.getAttached(".user-settings__secret-label").within(() => {
-      cy.findByText(/reveal token/i).click();
-    });
-    cy.getAttached(".user-settings__secret-input").within(() => {
-      cy.getAttached("input").invoke("val").as("token1");
-    });
+    it("resets a user's session generating a new api token", () => {
+      cy.visit("/profile");
+      cy.getAttached(".user-settings__additional").within(() => {
+        cy.findByRole("button", { name: /get api token/i }).click();
+      });
+      cy.getAttached(".user-settings__secret-label").within(() => {
+        cy.findByText(/reveal token/i).click();
+      });
+      cy.getAttached(".user-settings__secret-input").within(() => {
+        cy.getAttached("input").invoke("val").as("token1");
+      });
+      cy.visit("/settings/users");
 
-    // Reset user sessions via the admin user management page
-    cy.visit("/settings/users");
-    // First select the table cell with the user's email address then go back up
-    // to the containing row so we can select reset sessions from actions dropdown
-    cy.getAttached("div.Select-placeholder", /actions/i)
-      .eq(0)
-      .click();
-    cy.contains(/reset sessions/i).click();
+      cy.getAttached("div.Select-placeholder", /actions/i)
+        .eq(0)
+        .click();
+      cy.contains(/reset sessions/i).click();
 
-    cy.get(".modal__modal_container").within(() => {
-      cy.findByText(/reset sessions/i).should("exist");
-      cy.findByRole("button", { name: /confirm/i }).click();
-    });
-    cy.findByText(/reset sessions/i).should("not.exist");
+      cy.get(".modal__modal_container").within(() => {
+        cy.findByText(/reset sessions/i).should("exist");
+        cy.findByRole("button", { name: /confirm/i }).click();
+      });
+      cy.findByText(/reset sessions/i).should("not.exist");
 
-    // User should be logged out now so log in again and go to profile to get new API token
-    cy.getAttached(".login-form__container").within(() => {
-      cy.findByRole("button", { name: /login/i }).should("exist");
-    });
+      // user should be logged out so log in for new API token
+      cy.getAttached(".login-form__container").within(() => {
+        cy.findByRole("button", { name: /login/i }).should("exist");
+      });
 
-    cy.login();
+      cy.login();
 
-    cy.visit("/profile");
+      cy.visit("/profile");
 
-    cy.getAttached(".user-settings__additional").within(() => {
-      cy.findByRole("button", { name: /get api token/i }).click();
-    });
-    cy.getAttached(".modal__content").within(() => {
-      cy.findByText(/reveal token/i).click();
-    });
-    cy.getAttached(".user-settings__secret-input").within(() => {
-      cy.get("input").invoke("val").as("token2");
-    });
+      cy.getAttached(".user-settings__additional").within(() => {
+        cy.findByRole("button", { name: /get api token/i }).click();
+      });
+      cy.getAttached(".modal__content").within(() => {
+        cy.findByText(/reveal token/i).click();
+      });
+      cy.getAttached(".user-settings__secret-input").within(() => {
+        cy.get("input").invoke("val").as("token2");
+      });
 
-    // new token should not equal old token
-    cy.get("@token1").then((val1) => {
-      cy.get("@token2").then((val2) => {
-        expect(val1).to.not.eq(val2);
+      // new token should not equal old token
+      cy.get("@token1").then((val1) => {
+        cy.get("@token2").then((val2) => {
+          expect(val1).to.not.eq(val2);
+        });
       });
     });
   });

--- a/cypress/integration/all/app/settingsflow.spec.ts
+++ b/cypress/integration/all/app/settingsflow.spec.ts
@@ -1,17 +1,22 @@
-describe("Settings flow", () => {
-  beforeEach(() => {
+describe("App settings flow", () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions();
     cy.setup();
-    cy.login();
+    cy.loginWithCySession();
+    cy.viewport(1200, 660);
+  });
+  after(() => {
+    cy.logout();
   });
 
-  // We're using `scrollBehavior: 'center'` as a default
-  // because the sticky header blocks the elements.
-  it(
-    "Modifies and updates all setting successfully",
-    { scrollBehavior: "center" },
-    () => {
+  describe("Teams settings page", () => {
+    beforeEach(() => {
+      cy.loginWithCySession();
       cy.visit("/settings/organization");
-
+    });
+    // We're using `scrollBehavior: 'center'` as a default
+    // because the sticky header blocks the elements.
+    it("edits existing app settings", { scrollBehavior: "center" }, () => {
       cy.getAttached(".app-config-form").within(() => {
         cy.findByLabelText(/organization name/i)
           .clear()
@@ -73,7 +78,9 @@ describe("Settings flow", () => {
         .click()
         .type("rachelspassword");
 
-      cy.findByLabelText(/enable host status webhook/i).check({ force: true });
+      cy.findByLabelText(/enable host status webhook/i).check({
+        force: true,
+      });
 
       cy.findByLabelText(/destination url/i)
         .click()
@@ -103,11 +110,11 @@ describe("Settings flow", () => {
 
       cy.findByLabelText(/disable live queries/i).check({ force: true });
 
-      // Update settings
       cy.findByRole("button", { name: /update settings/i }).click();
 
       cy.findByText(/updated settings/i).should("exist");
 
+      // confirm edits
       cy.visit("/settings/organization");
 
       cy.getAttached(".app-config-form").within(() => {
@@ -183,6 +190,6 @@ describe("Settings flow", () => {
           "Hello from Fleet"
         );
       });
-    }
-  );
+    });
+  });
 });

--- a/cypress/integration/all/app/settingsflow.spec.ts
+++ b/cypress/integration/all/app/settingsflow.spec.ts
@@ -12,17 +12,19 @@ describe("Settings flow", () => {
     () => {
       cy.visit("/settings/organization");
 
-      cy.findByLabelText(/organization name/i)
-        .click()
-        .type("{selectall}{backspace}TJ's Run");
+      cy.getAttached(".app-config-form").within(() => {
+        cy.findByLabelText(/organization name/i)
+          .clear()
+          .type("TJ's Run");
+      });
 
       cy.findByLabelText(/organization avatar url/i)
         .click()
         .type("http://tjsrun.com/img/logo.png");
 
       cy.findByLabelText(/fleet app url/i)
-        .click()
-        .type("{selectall}{backspace}https://localhost:5000");
+        .clear()
+        .type("https://localhost:5000");
 
       cy.findByLabelText(/enable single sign on/i).check({ force: true });
 
@@ -59,7 +61,7 @@ describe("Settings flow", () => {
         .click()
         .type("localhost");
 
-      cy.get("#smtpPort").click().type("{selectall}{backspace}1025");
+      cy.get("#smtpPort").clear().type("1025");
 
       cy.findByLabelText(/use ssl\/tls/i).check({ force: true });
 
@@ -91,16 +93,13 @@ describe("Settings flow", () => {
         .click()
         .type("http://www.fleetdm.com");
 
-      // can't grab button from the label because the button is a child element and doesn't have a for attribute
-      // couldn't figure out how to write a for attribute on kolide button
-      // Repeated Error Message: Timed out retrying after 4000ms: Found a label with the text of: /verify ssl certs/i, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
       cy.findByLabelText(/verify ssl certs/i).check({ force: true });
       cy.findByLabelText(/enable starttls/i).check({ force: true });
       cy.findByLabelText(/^host expiry$/i).check({ force: true });
 
       cy.findByLabelText(/host expiry window/i)
-        .click()
-        .type("{selectall}{backspace}5");
+        .clear()
+        .type("5");
 
       cy.findByLabelText(/disable live queries/i).check({ force: true });
 
@@ -111,7 +110,12 @@ describe("Settings flow", () => {
 
       cy.visit("/settings/organization");
 
-      cy.findByLabelText(/organization name/i).should("have.value", "TJ's Run");
+      cy.getAttached(".app-config-form").within(() => {
+        cy.findByLabelText(/organization name/i).should(
+          "have.value",
+          "TJ's Run"
+        );
+      });
 
       cy.findByLabelText(/organization avatar url/i).should(
         "have.value",

--- a/cypress/integration/all/sessions/sessions.spec.ts
+++ b/cypress/integration/all/sessions/sessions.spec.ts
@@ -7,19 +7,20 @@ describe("Sessions", () => {
 
   it("Logs in and out successfully", () => {
     cy.visit("/");
-    cy.contains(/forgot password/i);
+
+    cy.getAttached(".login-form__forgot-link").should("exist");
 
     // Log in
-    cy.get("input").first().type("admin@example.com");
-    cy.get("input").last().type("user123#");
-    cy.get("button").click();
+    cy.getAttached("input").first().type("admin@example.com");
+    cy.getAttached("input").last().type("user123#");
+    cy.getAttached("button").click();
 
     // Verify dashboard
     cy.url().should("include", "/dashboard");
     cy.contains("Host");
 
     // Log out
-    cy.get(".avatar").first().click();
+    cy.getAttached(".avatar").first().click();
     cy.contains("button", "Sign out").click();
 
     cy.url().should("match", /\/login$/);
@@ -27,9 +28,9 @@ describe("Sessions", () => {
 
   it("Fails login with invalid password", () => {
     cy.visit("/");
-    cy.get("input").first().type("admin@example.com");
-    cy.get("input").last().type("bad_password");
-    cy.get(".button").click();
+    cy.getAttached("input").first().type("admin@example.com");
+    cy.getAttached("input").last().type("bad_password");
+    cy.getAttached(".button").click();
 
     cy.url().should("match", /\/login$/);
     cy.contains("Authentication failed");

--- a/cypress/integration/all/sessions/sessions.spec.ts
+++ b/cypress/integration/all/sessions/sessions.spec.ts
@@ -1,44 +1,33 @@
 describe("Sessions", () => {
-  // Typically we want to use a beforeEach but not much happens in these tests
-  // so sharing some state should be okay and saves a bit of runtime.
   before(() => {
+    Cypress.session.clearAllSavedSessions();
     cy.setup();
   });
-
-  it("Logs in and out successfully", () => {
+  it("logs in and out successfully", () => {
     cy.visit("/");
-
     cy.getAttached(".login-form__forgot-link").should("exist");
-
     // Log in
     cy.getAttached("input").first().type("admin@example.com");
     cy.getAttached("input").last().type("user123#");
     cy.getAttached("button").click();
-
     // Verify dashboard
     cy.url().should("include", "/dashboard");
     cy.contains("Host");
-
     // Log out
     cy.getAttached(".avatar").first().click();
     cy.contains("button", "Sign out").click();
-
     cy.url().should("match", /\/login$/);
   });
-
-  it("Fails login with invalid password", () => {
+  it("fails login with invalid password", () => {
     cy.visit("/");
     cy.getAttached("input").first().type("admin@example.com");
     cy.getAttached("input").last().type("bad_password");
     cy.getAttached(".button").click();
-
     cy.url().should("match", /\/login$/);
     cy.contains("Authentication failed");
   });
-
-  it("Fails to access authenticated resource", () => {
+  it("fails to access authenticated resource", () => {
     cy.visit("/hosts/manage");
-
     cy.url().should("match", /\/login$/);
   });
 });

--- a/cypress/integration/all/sessions/sso.spec.ts
+++ b/cypress/integration/all/sessions/sso.spec.ts
@@ -9,11 +9,12 @@ describe("SSO Sessions", () => {
     cy.logout();
 
     cy.visit("/");
-    cy.contains(/forgot password/i);
+
+    cy.getAttached(".login-form__forgot-link").should("exist");
 
     // Log in
-    cy.get("input").first().type("admin@example.com");
-    cy.get("input").last().type("user123#");
+    cy.getAttached("input").first().type("admin@example.com");
+    cy.getAttached("input").last().type("user123#");
     cy.contains("button", "Login").click();
 
     // Verify dashboard
@@ -21,7 +22,7 @@ describe("SSO Sessions", () => {
     cy.contains("Hosts");
 
     // Log out
-    cy.get(".avatar").first().click();
+    cy.getAttached(".avatar").first().click();
     cy.contains("button", "Sign out").click();
 
     cy.url().should("match", /\/login$/);

--- a/cypress/integration/all/sessions/sso.spec.ts
+++ b/cypress/integration/all/sessions/sso.spec.ts
@@ -1,59 +1,43 @@
 describe("SSO Sessions", () => {
   beforeEach(() => {
+    Cypress.session.clearAllSavedSessions();
     cy.setup();
   });
-
-  it("Non-SSO user can login with username/password", () => {
+  it("non-SSO user can login with username/password", () => {
     cy.login();
     cy.setupSSO((enable_idp_login = true));
     cy.logout();
-
     cy.visit("/");
-
     cy.getAttached(".login-form__forgot-link").should("exist");
-
     // Log in
     cy.getAttached("input").first().type("admin@example.com");
     cy.getAttached("input").last().type("user123#");
     cy.contains("button", "Login").click();
-
     // Verify dashboard
     cy.url().should("include", "/dashboard");
     cy.contains("Hosts");
-
     // Log out
     cy.getAttached(".avatar").first().click();
     cy.contains("button", "Sign out").click();
-
     cy.url().should("match", /\/login$/);
   });
-
-  it("Can login via SSO", () => {
+  it("can login via SSO", () => {
     cy.login();
     cy.setupSSO((enable_idp_login = true));
     cy.logout();
-
     cy.visit("/");
-
     // Log in
     cy.contains("button", "Sign On With SimpleSAML");
-
     cy.loginSSO();
-
     cy.contains("Hosts");
   });
-
-  it("Fails when IdP login disabled", () => {
+  it("fails when IdP login disabled", () => {
     cy.login();
     cy.setupSSO();
     cy.logout();
-
     cy.visit("/");
-
     cy.contains("button", "Sign On With SimpleSAML");
-
     cy.loginSSO();
-
     // Log in should fail
     cy.contains("Password");
   });

--- a/cypress/integration/premium/admin.spec.ts
+++ b/cypress/integration/premium/admin.spec.ts
@@ -104,13 +104,13 @@ describe("Premium tier - Admin user", () => {
         cy.contains(".selector-name", /apples/i).should("exist");
       });
     });
-    // describe("Manage schedules page", () => {
-    //   beforeEach(() => cy.visit("/schedule/manage"));
-    //   it("shows inherited queries", () => {
-    //     cy.getAttached(".no-schedule__schedule-button").click();
-    //     // TODO: Unable to add tests because "Schedule a query" button detattaches even when using `getAttached`
-    //   });
-    // });
+    describe("Manage schedules page", () => {
+      beforeEach(() => cy.visit("/schedule/manage"));
+      it("shows inherited queries", () => {
+        cy.getAttached(".no-schedule__schedule-button").click();
+        // TODO: Unable to add tests because "Schedule a query" button detattaches even when using `getAttached`
+      });
+    });
 
     describe("Manage policies page", () => {
       beforeEach(() => cy.visit("/policies/manage"));

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -111,6 +111,31 @@ Cypress.Commands.add("seedQueries", () => {
   });
 });
 
+Cypress.Commands.add("seedPacks", () => {
+  const packs = [
+    {
+      name: "Mac starter pack",
+      description: "Run all queries weekly on Mac hosts",
+    },
+    {
+      name: "Windows starter pack",
+      description: "Run all queries weekly on Windows hosts",
+    },
+  ];
+
+  packs.forEach((packForm) => {
+    const { name, description } = packForm;
+    cy.request({
+      url: "/api/v1/fleet/packs",
+      method: "POST",
+      body: { name, description, host_ids: [], label_ids: [], team_ids: [] },
+      auth: {
+        bearer: window.localStorage.getItem("FLEET::auth_token"),
+      },
+    });
+  });
+});
+
 Cypress.Commands.add("seedPolicies", (team = "") => {
   const policies = [
     {

--- a/frontend/components/forms/LabelForm/LabelForm.tsx
+++ b/frontend/components/forms/LabelForm/LabelForm.tsx
@@ -173,14 +173,14 @@ const LabelForm = ({
       />
       {!isManual && !isEdit && (
         <div className="form-field form-field--dropdown">
-          <label className="form-field__label" htmlFor="platform">
-            Platform
-          </label>
           <Dropdown
+            label="Platform"
             name="platform"
             onChange={onPlatformChange}
             value={platform}
             options={platformOptions}
+            classname={`${baseClass}__platform-dropdown`}
+            wrapperClassName={`${baseClass}__form-field ${baseClass}__form-field--platform`}
           />
         </div>
       )}

--- a/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
@@ -11,6 +11,7 @@ interface ISelectRoleFormProps {
   currentTeam?: ITeam;
   teams: ITeam[];
   onFormChange: (teams: ITeam[]) => void;
+  label: string | string[];
 }
 
 const baseClass = "select-role-form";
@@ -59,6 +60,7 @@ const SelectRoleForm = ({
   currentTeam,
   teams,
   onFormChange,
+  label,
 }: ISelectRoleFormProps): JSX.Element => {
   const [selectedRole, setSelectedRole] = useState<string>(
     defaultTeamRole.toLowerCase()
@@ -78,6 +80,7 @@ const SelectRoleForm = ({
     <div className={baseClass}>
       <div className={`${baseClass}__select-role`}>
         <Dropdown
+          label={label}
           value={selectedRole}
           className={`${baseClass}__role-dropdown`}
           options={roles}

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -340,13 +340,14 @@ class UserForm extends Component<ICreateUserFormProps, ICreateUserFormState> {
             </a>
           </InfoBanner>
         )}
-        <p className={`${baseClass}__label`}>Role</p>
         <Dropdown
+          label="Role"
           value={global_role || "Observer"}
           className={`${baseClass}__global-role-dropdown`}
           options={globalUserRoles}
           searchable={false}
           onChange={onGlobalUserRoleChange}
+          wrapperClassName={`${baseClass}__form-field ${baseClass}__form-field--global-role`}
         />
       </>
     );
@@ -415,15 +416,13 @@ class UserForm extends Component<ICreateUserFormProps, ICreateUserFormState> {
               />
             </>
           ) : (
-            <>
-              <p className={`${baseClass}__label`}>Role</p>
-              <SelectRoleForm
-                currentTeam={currentTeam || teams[0]}
-                teams={teams}
-                defaultTeamRole={defaultTeamRole || "observer"}
-                onFormChange={onTeamRoleChange}
-              />
-            </>
+            <SelectRoleForm
+              label="Role"
+              currentTeam={currentTeam || teams[0]}
+              teams={teams}
+              defaultTeamRole={defaultTeamRole || "observer"}
+              onFormChange={onTeamRoleChange}
+            />
           ))}
         {!availableTeams.length && renderNoTeamsMessage()}
       </>

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -852,6 +852,7 @@ const ManageHostsPage = ({
     try {
       await labelsAPI.update(selectedLabel, updateAttrs);
       refetchLabels();
+      router.push(`${PATHS.MANAGE_HOSTS}/${getLabelSelected()}`);
       dispatch(
         renderFlash(
           "success",

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -422,7 +422,7 @@ const ManagePolicyPage = ({
           {!!teamId && teamPoliciesError && <TableDataError />}
           {!!teamId &&
             !teamPoliciesError &&
-            (isLoadingTeamPolicies || isLoadingFailingPoliciesWebhook ? (
+            (isLoadingTeamPolicies ? (
               <Spinner />
             ) : (
               <PoliciesListWrapper

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -422,7 +422,7 @@ const ManagePolicyPage = ({
           {!!teamId && teamPoliciesError && <TableDataError />}
           {!!teamId &&
             !teamPoliciesError &&
-            (isLoadingTeamPolicies ? (
+            (isLoadingTeamPolicies || isLoadingFailingPoliciesWebhook ? (
               <Spinner />
             ) : (
               <PoliciesListWrapper

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleListWrapper.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleListWrapper.tsx
@@ -112,7 +112,7 @@ const ScheduleListWrapper = ({
                 </>
               )}
             </p>
-            <div className={`${noScheduleClass}__-cta-buttons`}>
+            <div className={`${noScheduleClass}__cta-buttons`}>
               <Button
                 variant="brand"
                 className={`${noScheduleClass}__schedule-button`}


### PR DESCRIPTION
Cerra #3516 

Major updates:
- New e2e flow: Create, edit, delete user (_manageUsers.spec.ts_ lines: 28-92)
- New e2e flow: Create, edit, remove scheduled query (_queryflow.spec.ts_ lines: 146-159)
- New e2e flow: Query a host from host details page (_hosts.spec.ts_ lines: 118-147)
- Replaced `.get()` with `.getAttached()` and remove `.wait()`
- Utilize `.clear() `instead of `.type({selectall}{backspace})`
- Ensure fleetQueries load before users have ability to click on schedule query modal in DOM
- Ensure failingPoliciesWebhook loads before users have ability to click on manage automation in DOM
- Clean organization of e2e tests (see screenshots) for better readability mimicking @gillespi314 #3840 

<img width="413" alt="Screen Shot 2022-01-27 at 5 55 48 PM" src="https://user-images.githubusercontent.com/71795832/151456977-4a3046bd-8720-426b-ab5f-d2f608cd960e.png">
<img width="372" alt="Screen Shot 2022-01-26 at 2 44 40 PM" src="https://user-images.githubusercontent.com/71795832/151235422-299a116f-1afd-46ec-bd9a-9b6ef38756cf.png">
<img width="405" alt="Screen Shot 2022-01-26 at 2 38 28 PM" src="https://user-images.githubusercontent.com/71795832/151234868-b815d889-8923-4d90-b7ed-c30644b426b9.png">
<img width="656" alt="Screen Shot 2022-01-26 at 1 47 02 PM" src="https://user-images.githubusercontent.com/71795832/151231926-08301c8c-4045-46dd-80b6-fad51b0204b2.png">
<img width="660" alt="Screen Shot 2022-01-26 at 1 46 19 PM" src="https://user-images.githubusercontent.com/71795832/151231927-5b095f15-7ddc-406c-9e51-13c141ce510c.png">
<img width="446" alt="Screen Shot 2022-01-26 at 1 44 53 PM" src="https://user-images.githubusercontent.com/71795832/151231930-087682e3-babb-41bc-81cb-d2a2b5d2edc6.png">
<img width="327" alt="Screen Shot 2022-01-27 at 6 27 26 PM" src="https://user-images.githubusercontent.com/71795832/151460279-f24869ae-7957-4692-8a47-15448b9c26c3.png">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.


- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
