### PR TITLE
Team Management Page: Hide pagination for teams page

### DIFF
--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -248,6 +248,7 @@ const TeamManagementPage = (): JSX.Element => {
           showMarkAllPages={false}
           isAllPagesSelected={false}
           searchable={teams && teams.length > 0 && searchString !== ""}
+          disablePagination
         />
       )}
       {showCreateTeamModal ? (


### PR DESCRIPTION
Cerra #3786 

- No moar pagination on Team's page  ✨
<img width="1231" alt="Screen Shot 2022-01-19 at 3 23 09 PM" src="https://user-images.githubusercontent.com/71795832/150208131-6fd06bf1-72ac-4317-88e3-bbf29938f05c.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
