### PR TITLE
Manage host page: Remove flash of spinner to no spinner to spinner

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1436,7 +1436,7 @@ const ManageHostsPage = ({
       selectedFilters.length === 0 ||
       selectedLabel === undefined
     ) {
-      return null;
+      return <Spinner />;
     }
 
     if (hasHostErrors || hasHostCountErrors) {
@@ -1591,7 +1591,7 @@ const ManageHostsPage = ({
                 {renderSoftwareVulnerabilities()}
               </div>
             ))}
-          {config && (!isPremiumTier || teams) ? renderTable() : <Spinner />}
+          {renderTable()}
         </div>
       )}
       {renderSidePanel()}


### PR DESCRIPTION
Cerra #3792 

- Issue fixed: The ManageHostPage was rendering null for split second due to the the renderTable() being able to render null

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
