### PR TITLE
Alias fleetctl sandbox to fleetctl preview

### DIFF
--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -41,9 +41,10 @@ const (
 
 func previewCommand() *cli.Command {
 	return &cli.Command{
-		Name:  "preview",
-		Usage: "Start a preview deployment of the Fleet server",
-		Description: `Start a preview deployment of the Fleet server using Docker and docker-compose. Docker tools must be available in the environment.
+		Name:    "preview",
+		Aliases: []string{"sandbox"},
+		Usage:   "Start a sandbox deployment of the Fleet server",
+		Description: `Start a sandbox deployment of the Fleet server using Docker and docker-compose. Docker tools must be available in the environment.
 
 Use the stop and reset subcommands to manage the server and dependencies once started.`,
 		Subcommands: []*cli.Command{


### PR DESCRIPTION
Preparing for some work the product team is planning to rebrand preview
to sandbox.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

~- [ ] Changes file added (for user-visible changes)~
~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Added/updated tests~
- [x] Manual QA for all new/changed functionality
