### PR TITLE
Add clarification to run `fleetctl preview` on Windows as administrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ sudo npm install -g fleetctl
 sudo fleetctl preview
 ```
 
-> Windows users can omit `sudo`.
+> Windows users can omit `sudo`, and should run the command in `Cmd`/`PowerShell` as administrators.
 
 The Fleet UI is now available at http://localhost:1337.
 

--- a/website/views/pages/get-started.ejs
+++ b/website/views/pages/get-started.ejs
@@ -35,7 +35,7 @@
       </div>
       <p class="mb-0"><img alt="A small circle with an I inside of it"
           style="width: 16px; display: inline; margin-right: 8px; margin-bottom: 3px"
-          src="/images/info-16x16@2x.png">Windows users can omit <code>sudo</code> .</p>
+          src="/images/info-16x16@2x.png">Windows users can omit <code>sudo</code>, and should run the command in <code>Cmd</code>/<code>PowerShell</code> as administrators.</p>
     </div>
     <div style="padding-top: 60px;">
       <h2 class="mb-3">3. Log in to Fleet</h2>


### PR DESCRIPTION
`fleetctl preview` on Windows was failing for me with:
```
C:\Users\Lucas Rodriguez>fleetctl preview
Downloading dependencies from production into C:\Users\Lucas Rodriguez\.fleet\preview...
Pulling Docker dependencies...
Starting Docker containers...
Waiting for server to start up...
Initializing server...
Loading standard query library...
Applying Policies...
Fleet will now enroll your device and log you into the UI automatically.
You can also open the UI at this URL: http://localhost:1337/previewlogin.
Email: admin@example.com
Password: admin123#
Downloading Orbit and osqueryd...
Trying to clear orbit and osquery directories...
2022/01/19 17:38:02 root pinning is not supported in Spec 1.0.19
{"level":"debug","error":"CreateFile C:\\Users\\Lucas Rodriguez\\.fleet\\preview\\bin\\osqueryd\\windows\\stable\\osqueryd.exe: The system cannot find the path specified.","time":"2022-01-19T17:38:02-03:00","message":"stat file"}
downloading orbit and osqueryd: initialize updates: failed to get osqueryd: open temp file for download: open C:\Users\Lucas Rodriguez\.fleet\preview\staging\osqueryd.exe: Access is denied.
```
The issue was fixed by running `cmd` as administrator (also Zach mentioned being used to run the command on an admin powershell).