### PR TITLE
Update Google Site Tag for UA property

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -27,9 +27,9 @@
     Google Analytics, should only be included in production: */
     if (sails.config.environment === 'production') { %>
     <% /* Google Analytics, Google Tag Manager, Snitcher etc. */ %>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JC3DRNY1GV"></script>
-    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-JC3DRNY1GV');</script>
+   <!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-182153798-1"></script>
+<script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'UA-182153798-1');</script>
     <%/* Snitcher analytics code */%>
     <script>
         !function(s,n,i,t,c,h){s.SnitchObject=i;s[i]||(s[i]=function(){

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -27,9 +27,9 @@
     Google Analytics, should only be included in production: */
     if (sails.config.environment === 'production') { %>
     <% /* Google Analytics, Google Tag Manager, Snitcher etc. */ %>
-   <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-182153798-1"></script>
-<script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'UA-182153798-1');</script>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-182153798-1"></script>
+    <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'UA-182153798-1');</script>
     <%/* Snitcher analytics code */%>
     <script>
         !function(s,n,i,t,c,h){s.SnitchObject=i;s[i]||(s[i]=function(){


### PR DESCRIPTION
Switching over our Google Analytics tag to send data to our UA property instead of the previous GA4 property.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
