### PR TITLE
Add policies to standard query library

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -641,7 +641,7 @@ spec:
   query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;
   description: Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.
   resolution: "Run the following command in the Terminal app: /usr/sbin/spctl --master-enable"
-  platforms: darwin
+  platforms: macOS
   contributors: groob
 ---
 apiVersion: v1
@@ -651,7 +651,7 @@ spec:
   query: SELECT 1 FROM bitlocker_info where protection_status = 1;
   description: Checks to make sure that device encryption is enabled on Windows devices.
   resolution: "Option 1: Select the Start button. Select Settings  > Update & Security  > Device encryption. If Device encryption doesn't appear, skip to Option 2. If device encryption is turned off, select Turn on. Option 2: Select the Start button. Under Windows System, select Control Panel. Select System and Security. Under BitLocker Drive Encryption, select Manage BitLocker. Select Turn on BitLocker and then follow the instructions."
-  platforms: windows
+  platforms: Windows
   contributors: defensivedepth
 ---
 apiVersion: v1
@@ -661,5 +661,5 @@ spec:
   query: SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT “” AND filevault_status = ‘on’ LIMIT 1;
   description: Checks to make sure that the Filevault feature is enabled on macOS devices.
   resolution: "Choose Apple menu > System Preferences, then click Security & Privacy. Click the FileVault tab. Click the Lock icon, then enter an administrator name and password. Click Turn On FileVault."
-  platforms: darwin
+  platforms: macOS
   contributors: groob

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -641,7 +641,7 @@ spec:
   query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;
   description: Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.
   resolution: "Run the following command in the Terminal app: /usr/sbin/spctl --master-enable"
-  platform: darwin
+  platforms: macOS
   contributors: groob
 ---
 apiVersion: v1
@@ -651,7 +651,7 @@ spec:
   query: SELECT 1 FROM bitlocker_info where protection_status = 1;
   description: Checks to make sure that device encryption is enabled on Windows devices.
   resolution: "Option 1: Select the Start button. Select Settings  > Update & Security  > Device encryption. If Device encryption doesn't appear, skip to Option 2. If device encryption is turned off, select Turn on. Option 2: Select the Start button. Under Windows System, select Control Panel. Select System and Security. Under BitLocker Drive Encryption, select Manage BitLocker. Select Turn on BitLocker and then follow the instructions."
-  platform: windows
+  platforms: Windows
   contributors: defensivedepth
 ---
 apiVersion: v1
@@ -661,5 +661,5 @@ spec:
   query: SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT “” AND filevault_status = ‘on’ LIMIT 1;
   description: Checks to make sure that the Filevault feature is enabled on macOS devices.
   resolution: "Choose Apple menu > System Preferences, then click Security & Privacy. Click the FileVault tab. Click the Lock icon, then enter an administrator name and password. Click Turn On FileVault."
-  platform: darwin
+  platforms: macOS
   contributors: groob

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -641,7 +641,7 @@ spec:
   query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;
   description: Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.
   resolution: "Run the following command in the Terminal app: /usr/sbin/spctl --master-enable"
-  platform: darwin
+  platforms: darwin
   contributors: groob
 ---
 apiVersion: v1
@@ -651,7 +651,7 @@ spec:
   query: SELECT 1 FROM bitlocker_info where protection_status = 1;
   description: Checks to make sure that device encryption is enabled on Windows devices.
   resolution: "Option 1: Select the Start button. Select Settings  > Update & Security  > Device encryption. If Device encryption doesn't appear, skip to Option 2. If device encryption is turned off, select Turn on. Option 2: Select the Start button. Under Windows System, select Control Panel. Select System and Security. Under BitLocker Drive Encryption, select Manage BitLocker. Select Turn on BitLocker and then follow the instructions."
-  platform: windows
+  platforms: windows
   contributors: defensivedepth
 ---
 apiVersion: v1
@@ -661,5 +661,5 @@ spec:
   query: SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT “” AND filevault_status = ‘on’ LIMIT 1;
   description: Checks to make sure that the Filevault feature is enabled on macOS devices.
   resolution: "Choose Apple menu > System Preferences, then click Security & Privacy. Click the FileVault tab. Click the Lock icon, then enter an administrator name and password. Click Turn On FileVault."
-  platform: darwin
+  platforms: darwin
   contributors: groob

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -640,7 +640,7 @@ spec:
   name: Is Gatekeeper enabled on macOS devices?
   query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;
   description: Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.
-  resolution: "To enable Gatekeeper, one the failing device, run the following command in the Terminal app: /usr/sbin/spctl --master-enable."
+  resolution: "To enable Gatekeeper, on the failing device, run the following command in the Terminal app: /usr/sbin/spctl --master-enable."
   platforms: macOS
   contributors: groob
 ---

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -633,3 +633,33 @@ spec:
   query: SELECT * FROM apps WHERE path LIKE '/Applications/%' AND name IN ("Photoshop.app", "Adobe XD.app", "Sketch.app", "Illustrator.app") AND last_opened_time < (( SELECT unix_time FROM time ) - 2592000000000 );
   purpose: Informational
   contributors: DominusKelvin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Is Gatekeeper enabled on macOS devices?
+  query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;
+  description: Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.
+  resolution: "Run the following command in the Terminal app: /usr/sbin/spctl --master-enable"
+  platform: darwin
+  contributors: groob
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Is disk encryption enabled on Windows devices?
+  query: SELECT 1 FROM bitlocker_info where protection_status = 1;
+  description: Checks to make sure that device encryption is enabled on Windows devices.
+  resolution: "Option 1: Select the Start button. Select Settings  > Update & Security  > Device encryption. If Device encryption doesn't appear, skip to Option 2. If device encryption is turned off, select Turn on. Option 2: Select the Start button. Under Windows System, select Control Panel. Select System and Security. Under BitLocker Drive Encryption, select Manage BitLocker. Select Turn on BitLocker and then follow the instructions."
+  platform: windows
+  contributors: defensivedepth
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Is Filevault enabled on macOS devices?
+  query: SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT “” AND filevault_status = ‘on’ LIMIT 1;
+  description: Checks to make sure that the Filevault feature is enabled on macOS devices.
+  resolution: "Choose Apple menu > System Preferences, then click Security & Privacy. Click the FileVault tab. Click the Lock icon, then enter an administrator name and password. Click Turn On FileVault."
+  platform: darwin
+  contributors: groob

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -640,7 +640,7 @@ spec:
   name: Is Gatekeeper enabled on macOS devices?
   query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;
   description: Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.
-  resolution: "Run the following command in the Terminal app: /usr/sbin/spctl --master-enable"
+  resolution: "To enable Gatekeeper, one the failing device, run the following command in the Terminal app: /usr/sbin/spctl --master-enable."
   platforms: macOS
   contributors: groob
 ---
@@ -650,7 +650,10 @@ spec:
   name: Is disk encryption enabled on Windows devices?
   query: SELECT 1 FROM bitlocker_info where protection_status = 1;
   description: Checks to make sure that device encryption is enabled on Windows devices.
-  resolution: "Option 1: Select the Start button. Select Settings  > Update & Security  > Device encryption. If Device encryption doesn't appear, skip to Option 2. If device encryption is turned off, select Turn on. Option 2: Select the Start button. Under Windows System, select Control Panel. Select System and Security. Under BitLocker Drive Encryption, select Manage BitLocker. Select Turn on BitLocker and then follow the instructions."
+  resolution: "To get additional information, run the following osquery query on the failing device: SELECT * FROM bitlocker_info. In the
+  query results, if protection_status is 2, then the status cannot be determined. If it is 0, it is
+  considered unprotected. Use the additional results (percent_encrypted, conversion_status, etc.) to
+  help narrow down the specific reason why Windows considers the volume unprotected."
   platforms: Windows
   contributors: defensivedepth
 ---
@@ -658,8 +661,9 @@ apiVersion: v1
 kind: policy
 spec:
   name: Is Filevault enabled on macOS devices?
-  query: SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT “” AND filevault_status = ‘on’ LIMIT 1;
+  query: SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT "" AND filevault_status = 'on' LIMIT 1;
   description: Checks to make sure that the Filevault feature is enabled on macOS devices.
-  resolution: "Choose Apple menu > System Preferences, then click Security & Privacy. Click the FileVault tab. Click the Lock icon, then enter an administrator name and password. Click Turn On FileVault."
+  resolution: "To enable Filevailt, on the failing device, select System Preferences >
+  Security & Privacy > FileVault > Turn On FileVault."
   platforms: macOS
   contributors: groob

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -660,10 +660,10 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: Is Filevault enabled on macOS devices?
+  name: Is FileVault enabled on macOS devices?
   query: SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT "" AND filevault_status = 'on' LIMIT 1;
   description: Checks to make sure that the Filevault feature is enabled on macOS devices.
-  resolution: "To enable Filevailt, on the failing device, select System Preferences >
+  resolution: "To enable FileVault, on the failing device, select System Preferences >
   Security & Privacy > FileVault > Turn On FileVault."
   platforms: macOS
   contributors: groob

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -17,11 +17,11 @@ export const DEFAULT_POLICIES = [
   {
     key: 1,
     query: `SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT "" AND filevault_status = 'on' LIMIT 1`,
-    name: "Is Filevault enabled on macOS devices?",
+    name: "Is FileVault enabled on macOS devices?",
     description:
       "Checks to make sure that the Filevault feature is enabled on macOS devices.",
     resolution:
-      "Choose Apple menu > System Preferences, then click Security & Privacy. Click the FileVault tab. Click the Lock icon, then enter an administrator name and password. Click Turn On FileVault.",
+      "To enable FileVault, on the failing device, select System Preferences > Security & Privacy > FileVault > Turn On FileVault.",
     platform: "darwin",
   },
   {
@@ -31,7 +31,7 @@ export const DEFAULT_POLICIES = [
     description:
       "Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.",
     resolution:
-      "On the failing device, run the following command in the Terminal app: /usr/sbin / spctl--master- enable",
+      "To enable Gatekeeper, one the failing device, run the following command in the Terminal app: /usr/sbin/spctl --master-enable.",
     platform: "darwin",
   },
   {
@@ -41,7 +41,7 @@ export const DEFAULT_POLICIES = [
     description:
       "Checks to make sure that device encryption is enabled on Windows devices.",
     resolution:
-      "Option 1: Select the Start button. Select Settings > Update & Security > Device encryption. If Device encryption doesn't appear, skip to Option 2. If device encryption is turned off, select Turn on. Option 2: Select the Start button. Under Windows System, select Control Panel. Select System and Security. Under BitLocker Drive Encryption, select Manage BitLocker. Select Turn on BitLocker and then follow the instructions.",
+      "To get additional information, run the following osquery query on the failing device: SELECT * FROM bitlocker_info. In the query results, if protection_status is 2, then the status cannot be determined. If it is 0, it is considered unprotected. Use the additional results (percent_encrypted, conversion_status, etc.) to help narrow down the specific reason why Windows considers the volume unprotected.",
     platform: "windows",
   },
   {

--- a/website/.sailsrc
+++ b/website/.sailsrc
@@ -11,208 +11,96 @@
       {
         "url": "/docs",
         "title": "Readme.md",
-        "lastModifiedAt": 1624049901000,
-        "htmlId": "docs--readme--27004f4448",
+        "lastModifiedAt": 1632328105000,
+        "htmlId": "docs--readme--604f50259c",
         "sectionRelativeRepoPath": "README.md",
         "meta": {}
       },
       {
-        "url": "/docs/deploying/installation",
-        "title": "Installation",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--01-installation--c1f7b7262d",
-        "sectionRelativeRepoPath": "02-Deploying/01-Installation.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/deploying/configuration",
-        "title": "Configuration",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--02-configuration--25bb47a163",
-        "sectionRelativeRepoPath": "02-Deploying/02-Configuration.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/deploying/example-deployment-scenarios",
-        "title": "Example deployment scenarios",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--03-example-deploymen--1d32b988ab",
-        "sectionRelativeRepoPath": "02-Deploying/03-Example-deployment-scenarios.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/deploying/fleetctl-agent-updates",
-        "title": "Fleetctl agent updates",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--04-fleetctl-agent-up--92c6890fa9",
-        "sectionRelativeRepoPath": "02-Deploying/04-fleetctl-agent-updates.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/deploying/faq",
-        "title": "FAQ",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--faq--3ad91393ce",
-        "sectionRelativeRepoPath": "02-Deploying/FAQ.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/deploying",
-        "title": "Deploying",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--readme--fb635b427f",
-        "sectionRelativeRepoPath": "02-Deploying/README.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/contributing/building-fleet",
-        "title": "Building Fleet",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--01-building-fleet--abcea456d8",
-        "sectionRelativeRepoPath": "03-Contributing/01-Building-Fleet.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/contributing/testing",
-        "title": "Testing",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--02-testing--2f307719a6",
-        "sectionRelativeRepoPath": "03-Contributing/02-Testing.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/contributing/migrations",
-        "title": "Migrations",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--03-migrations--b553b6254f",
-        "sectionRelativeRepoPath": "03-Contributing/03-Migrations.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/contributing/committing-changes",
-        "title": "Committing changes",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--04-committing-change--9b92fdc560",
-        "sectionRelativeRepoPath": "03-Contributing/04-Committing-Changes.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/contributing/releasing-fleet",
-        "title": "Releasing Fleet",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--05-releasing-fleet--1f39f77c64",
-        "sectionRelativeRepoPath": "03-Contributing/05-Releasing-Fleet.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/contributing/seeding-data",
-        "title": "Seeding data",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--06-seeding-data--af5ac86a99",
-        "sectionRelativeRepoPath": "03-Contributing/06-Seeding-Data.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/contributing/faq",
-        "title": "FAQ",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--faq--1b33e57806",
-        "sectionRelativeRepoPath": "03-Contributing/FAQ.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/contributing",
-        "title": "Contributing",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--readme--6de1bc799d",
-        "sectionRelativeRepoPath": "03-Contributing/README.md",
+        "url": "/docs/using-fleet/learn-how-to-use-fleet",
+        "title": "Learn how to use Fleet",
+        "lastModifiedAt": 1635391919000,
+        "htmlId": "docs--00-learn-how-to-use---c147ffcf6b",
+        "sectionRelativeRepoPath": "01-Using-Fleet/00-Learn-how-to-use-Fleet.md",
         "meta": {}
       },
       {
         "url": "/docs/using-fleet/fleet-ui",
         "title": "Fleet UI",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--01-fleet-ui--4b5755ee58",
+        "lastModifiedAt": 1632328105000,
+        "htmlId": "docs--01-fleet-ui--1c2ccb6c0e",
         "sectionRelativeRepoPath": "01-Using-Fleet/01-Fleet-UI.md",
         "meta": {}
       },
       {
         "url": "/docs/using-fleet/fleetctl-cli",
         "title": "Fleetctl CLI",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--02-fleetctl-cli--2a521b49d6",
+        "lastModifiedAt": 1639072763000,
+        "htmlId": "docs--02-fleetctl-cli--dc52271221",
         "sectionRelativeRepoPath": "01-Using-Fleet/02-fleetctl-CLI.md",
         "meta": {}
       },
       {
         "url": "/docs/using-fleet/rest-api",
         "title": "REST API",
-        "lastModifiedAt": 1632174198000,
-        "htmlId": "docs--03-rest-api--f0b4e26bae",
+        "lastModifiedAt": 1642784818000,
+        "htmlId": "docs--03-rest-api--fdb9d6d72c",
         "sectionRelativeRepoPath": "01-Using-Fleet/03-REST-API.md",
         "meta": {}
       },
       {
         "url": "/docs/using-fleet/adding-hosts",
         "title": "Adding hosts",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--04-adding-hosts--9ffccb2221",
+        "lastModifiedAt": 1642440618000,
+        "htmlId": "docs--04-adding-hosts--3641d1fd39",
         "sectionRelativeRepoPath": "01-Using-Fleet/04-Adding-hosts.md",
         "meta": {}
       },
       {
         "url": "/docs/using-fleet/osquery-logs",
         "title": "Osquery logs",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--05-osquery-logs--7fbf2c5c5a",
+        "lastModifiedAt": 1642615196000,
+        "htmlId": "docs--05-osquery-logs--201be3b05e",
         "sectionRelativeRepoPath": "01-Using-Fleet/05-Osquery-logs.md",
         "meta": {}
       },
       {
         "url": "/docs/using-fleet/monitoring-fleet",
         "title": "Monitoring Fleet",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--06-monitoring-fleet--83f7cca9f9",
+        "lastModifiedAt": 1642559146000,
+        "htmlId": "docs--06-monitoring-fleet--c890baaa1a",
         "sectionRelativeRepoPath": "01-Using-Fleet/06-Monitoring-Fleet.md",
         "meta": {}
       },
       {
         "url": "/docs/using-fleet/security-best-practices",
         "title": "Security best practices",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--07-security-best-pra--7ba1af6048",
+        "lastModifiedAt": 1639002215000,
+        "htmlId": "docs--07-security-best-pra--61e84d88ec",
         "sectionRelativeRepoPath": "01-Using-Fleet/07-Security-best-practices.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/using-fleet/updating-fleet",
-        "title": "Updating Fleet",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--08-updating-fleet--3b4e821ee3",
-        "sectionRelativeRepoPath": "01-Using-Fleet/08-Updating-Fleet.md",
         "meta": {}
       },
       {
         "url": "/docs/using-fleet/permissions",
         "title": "Permissions",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--09-permissions--eb9ac05ff5",
+        "lastModifiedAt": 1642522720000,
+        "htmlId": "docs--09-permissions--da3d0fa7c1",
         "sectionRelativeRepoPath": "01-Using-Fleet/09-Permissions.md",
         "meta": {}
       },
       {
         "url": "/docs/using-fleet/teams",
         "title": "Teams",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--10-teams--bd0bdf9444",
+        "lastModifiedAt": 1637332681000,
+        "htmlId": "docs--10-teams--d8c655deb6",
         "sectionRelativeRepoPath": "01-Using-Fleet/10-Teams.md",
         "meta": {}
       },
       {
         "url": "/docs/using-fleet/usage-statistics",
         "title": "Usage statistics",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--11-usage-statistics--ccd73f532c",
+        "lastModifiedAt": 1638823140000,
+        "htmlId": "docs--11-usage-statistics--f7a6821dca",
         "sectionRelativeRepoPath": "01-Using-Fleet/11-Usage-statistics.md",
         "meta": {}
       },
@@ -220,64 +108,306 @@
         "url": "/docs/using-fleet/supported-browsers",
         "title": "Supported browsers",
         "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--12-supported-browser--c3a9c18d40",
+        "htmlId": "docs--12-supported-browser--17af809146",
         "sectionRelativeRepoPath": "01-Using-Fleet/12-Supported-browsers.md",
         "meta": {}
       },
       {
         "url": "/docs/using-fleet/vulnerability-processing",
         "title": "Vulnerability processing",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--13-vulnerability-pro--7a9b62b621",
+        "lastModifiedAt": 1641910549000,
+        "htmlId": "docs--13-vulnerability-pro--23acf63ab7",
         "sectionRelativeRepoPath": "01-Using-Fleet/13-Vulnerability-Processing.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/using-fleet/automations",
+        "title": "Automations",
+        "lastModifiedAt": 1640904627000,
+        "htmlId": "docs--14-automations--60b6e2ad4f",
+        "sectionRelativeRepoPath": "01-Using-Fleet/14-Automations.md",
         "meta": {}
       },
       {
         "url": "/docs/using-fleet/faq",
         "title": "FAQ",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--faq--75e099695e",
+        "lastModifiedAt": 1642633631000,
+        "htmlId": "docs--faq--66f7e563df",
         "sectionRelativeRepoPath": "01-Using-Fleet/FAQ.md",
         "meta": {}
       },
       {
         "url": "/docs/using-fleet",
         "title": "Using Fleet",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--readme--0b226f5257",
+        "lastModifiedAt": 1642559146000,
+        "htmlId": "docs--readme--801014ddc2",
         "sectionRelativeRepoPath": "01-Using-Fleet/README.md",
         "meta": {}
       },
       {
-        "url": "/docs/using-fleet/learn-how-to-use-fleet",
-        "title": "Learn how to use Fleet",
+        "url": "/docs/deploying/introduction",
+        "title": "Introduction",
+        "lastModifiedAt": 1639268622000,
+        "htmlId": "docs--01-introduction--83a1c8790d",
+        "sectionRelativeRepoPath": "02-Deploying/01-Introduction.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/deploying/server-installation",
+        "title": "Server installation",
+        "lastModifiedAt": 1642005077000,
+        "htmlId": "docs--02-server-installati--2724fd584e",
+        "sectionRelativeRepoPath": "02-Deploying/02-Server-Installation.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/deploying/configuration",
+        "title": "Configuration",
+        "lastModifiedAt": 1642707662000,
+        "htmlId": "docs--03-configuration--dbcbe166b7",
+        "sectionRelativeRepoPath": "02-Deploying/03-Configuration.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/deploying/fleetctl-agent-updates",
+        "title": "Fleetctl agent updates",
+        "lastModifiedAt": 1642181150000,
+        "htmlId": "docs--04-fleetctl-agent-up--df0f243234",
+        "sectionRelativeRepoPath": "02-Deploying/04-fleetctl-agent-updates.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/deploying/load-testing",
+        "title": "Load testing",
+        "lastModifiedAt": 1637117313000,
+        "htmlId": "docs--05-load-testing--11cd618690",
+        "sectionRelativeRepoPath": "02-Deploying/05-Load-testing.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/deploying/reference-architectures",
+        "title": "Reference architectures",
+        "lastModifiedAt": 1642811275000,
+        "htmlId": "docs--06-reference-archite--72d044b212",
+        "sectionRelativeRepoPath": "02-Deploying/06-Reference-Architectures.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/deploying/upgrading-fleet",
+        "title": "Upgrading Fleet",
+        "lastModifiedAt": 1642615196000,
+        "htmlId": "docs--06-upgrading-fleet--8b39675167",
+        "sectionRelativeRepoPath": "02-Deploying/06-Upgrading-Fleet.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/deploying/faq",
+        "title": "FAQ",
+        "lastModifiedAt": 1642559146000,
+        "htmlId": "docs--faq--5cf230e766",
+        "sectionRelativeRepoPath": "02-Deploying/FAQ.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/deploying",
+        "title": "Deploying",
+        "lastModifiedAt": 1642559146000,
+        "htmlId": "docs--readme--c9a2b1d089",
+        "sectionRelativeRepoPath": "02-Deploying/README.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/contributing/building-fleet",
+        "title": "Building Fleet",
+        "lastModifiedAt": 1636342002000,
+        "htmlId": "docs--01-building-fleet--323b13a8a3",
+        "sectionRelativeRepoPath": "03-Contributing/01-Building-Fleet.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/contributing/testing",
+        "title": "Testing",
+        "lastModifiedAt": 1641336649000,
+        "htmlId": "docs--02-testing--e9364452cf",
+        "sectionRelativeRepoPath": "03-Contributing/02-Testing.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/contributing/migrations",
+        "title": "Migrations",
         "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--00-learn-how-to-use---95b515dfd1",
-        "sectionRelativeRepoPath": "01-Using-Fleet/00-Learn-how-to-use-Fleet.md",
+        "htmlId": "docs--03-migrations--0aa6a303a0",
+        "sectionRelativeRepoPath": "03-Contributing/03-Migrations.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/contributing/committing-changes",
+        "title": "Committing changes",
+        "lastModifiedAt": 1633617622000,
+        "htmlId": "docs--04-committing-change--a1e2443ae8",
+        "sectionRelativeRepoPath": "03-Contributing/04-Committing-Changes.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/contributing/releasing-fleet",
+        "title": "Releasing Fleet",
+        "lastModifiedAt": 1636424262000,
+        "htmlId": "docs--05-releasing-fleet--9720ea852e",
+        "sectionRelativeRepoPath": "03-Contributing/05-Releasing-Fleet.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/contributing/seeding-data",
+        "title": "Seeding data",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--06-seeding-data--fef459d10b",
+        "sectionRelativeRepoPath": "03-Contributing/06-Seeding-Data.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/contributing/api-for-contributors",
+        "title": "API for contributors",
+        "lastModifiedAt": 1641909869000,
+        "htmlId": "docs--07-api-for-contribut--be248c1626",
+        "sectionRelativeRepoPath": "03-Contributing/07-API-for-contributors.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/contributing/api-versioning",
+        "title": "API versioning",
+        "lastModifiedAt": 1640100192000,
+        "htmlId": "docs--08-api-versioning--14b02b7872",
+        "sectionRelativeRepoPath": "03-Contributing/08-API-Versioning.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/contributing/faq",
+        "title": "FAQ",
+        "lastModifiedAt": 1637092915000,
+        "htmlId": "docs--faq--0568c0d1be",
+        "sectionRelativeRepoPath": "03-Contributing/FAQ.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/contributing",
+        "title": "Contributing",
+        "lastModifiedAt": 1636120985000,
+        "htmlId": "docs--readme--f7c5242035",
+        "sectionRelativeRepoPath": "03-Contributing/README.md",
         "meta": {}
       },
       {
         "url": "/docs/using-fleet/configuration-files",
         "title": "Configuration files",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--readme--dc5df431cb",
+        "lastModifiedAt": 1642517803000,
+        "htmlId": "docs--readme--1600a75384",
         "sectionRelativeRepoPath": "01-Using-Fleet/configuration-files/README.md",
         "meta": {}
       },
       {
         "url": "/docs/using-fleet/standard-query-library",
         "title": "Standard query library",
-        "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--readme--db16aa6f37",
+        "lastModifiedAt": 1638803705000,
+        "htmlId": "docs--readme--e996808f7b",
         "sectionRelativeRepoPath": "01-Using-Fleet/standard-query-library/README.md",
         "meta": {}
+      },
+      {
+        "url": "/handbook",
+        "title": "Readme.md",
+        "lastModifiedAt": 1642446791000,
+        "htmlId": "handbook--readme--200fed8efb",
+        "sectionRelativeRepoPath": "README.md",
+        "meta": {
+          "maintainedBy": "mikermcneil"
+        }
+      },
+      {
+        "url": "/handbook/community",
+        "title": "Community",
+        "lastModifiedAt": 1642175041000,
+        "htmlId": "handbook--community--0964c343ec",
+        "sectionRelativeRepoPath": "community.md",
+        "meta": {
+          "maintainedBy": "zwass"
+        }
+      },
+      {
+        "url": "/handbook/customers",
+        "title": "Customers",
+        "lastModifiedAt": 1642446791000,
+        "htmlId": "handbook--customers--e8df9d479f",
+        "sectionRelativeRepoPath": "customers.md",
+        "meta": {
+          "maintainedBy": "tgauda"
+        }
+      },
+      {
+        "url": "/handbook/company",
+        "title": "Company",
+        "lastModifiedAt": 1642614403000,
+        "htmlId": "handbook--company--72edb6ad0e",
+        "sectionRelativeRepoPath": "company.md",
+        "meta": {
+          "maintainedBy": "mikermcneil"
+        }
+      },
+      {
+        "url": "/handbook/growth",
+        "title": "Growth",
+        "lastModifiedAt": 1642645417000,
+        "htmlId": "handbook--growth--8dc99b84b7",
+        "sectionRelativeRepoPath": "growth.md",
+        "meta": {
+          "maintainedBy": "mike-j-thomas"
+        }
+      },
+      {
+        "url": "/handbook/engineering",
+        "title": "Engineering",
+        "lastModifiedAt": 1642446791000,
+        "htmlId": "handbook--engineering--5dd72277c1",
+        "sectionRelativeRepoPath": "engineering.md",
+        "meta": {
+          "maintainedBy": "zwass"
+        }
+      },
+      {
+        "url": "/handbook/handbook",
+        "title": "Handbook",
+        "lastModifiedAt": 1642145590000,
+        "htmlId": "handbook--handbook--59cc5b205c",
+        "sectionRelativeRepoPath": "handbook.md",
+        "meta": {
+          "maintainedBy": "mike-j-thomas"
+        }
+      },
+      {
+        "url": "/handbook/people",
+        "title": "People",
+        "lastModifiedAt": 1642546792000,
+        "htmlId": "handbook--people--fc26a0f11e",
+        "sectionRelativeRepoPath": "people.md",
+        "meta": {
+          "maintainedBy": "eashaw"
+        }
+      },
+      {
+        "url": "/handbook/product",
+        "title": "Product",
+        "lastModifiedAt": 1642446791000,
+        "htmlId": "handbook--product--4bcfbe9e78",
+        "sectionRelativeRepoPath": "product.md",
+        "meta": {
+          "maintainedBy": "noahtalerman"
+        }
       }
     ],
     "queries": [
       {
         "name": "Count Apple applications installed",
         "platforms": "macOS",
-        "description": "Count the number of Apple applications installed on the machine.",
+        "description": "Get the total number of Apple applications installed on the host system.",
         "query": "SELECT COUNT(*) FROM apps WHERE bundle_identifier LIKE 'com.apple.%';",
         "purpose": "Informational",
         "contributors": [
@@ -288,7 +418,7 @@
             "htmlUrl": "https://github.com/mike-j-thomas"
           },
           {
-            "name": null,
+            "name": "Noah Talerman",
             "handle": "noahtalerman",
             "avatarUrl": "https://avatars.githubusercontent.com/u/47070608?v=4",
             "htmlUrl": "https://github.com/noahtalerman"
@@ -300,8 +430,9 @@
             "htmlUrl": "https://github.com/mikermcneil"
           }
         ],
+        "kind": "query",
         "slug": "count-apple-applications-installed",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get OpenSSL versions",
@@ -317,8 +448,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-open-ssl-versions",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get whether Gatekeeper is disabled",
@@ -334,8 +466,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-whether-gatekeeper-is-disabled",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get authorized SSH keys",
@@ -343,7 +476,7 @@
         "description": "Presence of authorized SSH keys may be unusual on laptops. Could be completely normal on servers, but may be worth auditing for unusual keys and/or changes.",
         "query": "SELECT username, authorized_keys. * FROM users CROSS JOIN authorized_keys USING (uid);",
         "purpose": "Informational",
-        "remediation": "N/A",
+        "remediation": "Check out the linked table (https://github.com/fleetdm/fleet/blob/32b4d53e7f1428ce43b0f9fa52838cbe7b413eed/handbook/queries/detect-hosts-with-high-severity-vulnerable-versions-of-openssl.md#table-of-vulnerable-openssl-versions) to determine if the installed version is a high severity vulnerability and view the corresponding CVE(s)",
         "contributors": [
           {
             "name": "Mike Thomas",
@@ -352,7 +485,9 @@
             "htmlUrl": "https://github.com/mike-j-thomas"
           }
         ],
-        "slug": "get-authorized-ssh-keys"
+        "kind": "query",
+        "slug": "get-authorized-ssh-keys",
+        "resolution": "N/A"
       },
       {
         "name": "Get authorized keys for Local Accounts",
@@ -368,8 +503,9 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
+        "kind": "query",
         "slug": "get-authorized-keys-for-local-accounts",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get authorized keys for Domain Joined Accounts",
@@ -385,8 +521,9 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
+        "kind": "query",
         "slug": "get-authorized-keys-for-domain-joined-accounts",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get crashes",
@@ -402,8 +539,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-crashes",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get installed Chrome Extensions",
@@ -419,8 +557,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-installed-chrome-extensions",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get installed FreeBSD software",
@@ -436,8 +575,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-installed-free-bsd-software",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get Homebrew Packages",
@@ -453,8 +593,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-homebrew-packages",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get installed Linux software",
@@ -470,8 +611,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-installed-linux-software",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get installed macOS software",
@@ -487,8 +629,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-installed-mac-os-software",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get installed Safari extensions",
@@ -504,14 +647,15 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-installed-safari-extensions",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get installed Windows software",
         "platforms": "Windows",
         "description": "Get all software installed on a Windows computer, including programs, browser plugins, and installed packages. Note, this does not included other running processes in the processes table.",
-        "query": "SELECT name AS name, version AS version, 'Program (Windows)' AS type, 'programs' AS source FROM programs UNION SELECT name AS name, version AS version, 'Package (Python)' AS type, 'python_packages' AS source FROM python_packages UNION SELECT name AS name, version AS version, 'Browser plugin (IE)' AS type, 'ie_extensions' AS source FROM ie_extensions UNION SELECT name AS name, version AS version, 'Browser plugin (Chrome)' AS type, 'chrome_extensions' AS source FROM chrome_extensions UNION SELECT name AS name, version AS version, 'Browser plugin (Firefox)' AS type, 'firefox_addons' AS source FROM firefox_addons UNION SELECT name AS name, version AS version, 'Package (Chocolatey)' AS type, 'chocolatey_packages' AS source FROM chocolatey_packages UNION SELECT name AS name, version AS version, 'Package (Atom)' AS type, 'atom_packages' AS source FROM atom_packages UNION SELECT name AS name, version AS version, 'Package (Python)' AS type, 'python_packages' AS source FROM python_packages;",
+        "query": "SELECT name AS name, version AS version, 'Program (Windows)' AS type, 'programs' AS source FROM programs UNION SELECT name AS name, version AS version, 'Package (Python)' AS type, 'python_packages' AS source FROM python_packages UNION SELECT name AS name, version AS version, 'Browser plugin (IE)' AS type, 'ie_extensions' AS source FROM ie_extensions UNION SELECT name AS name, version AS version, 'Browser plugin (Chrome)' AS type, 'chrome_extensions' AS source FROM chrome_extensions UNION SELECT name AS name, version AS version, 'Browser plugin (Firefox)' AS type, 'firefox_addons' AS source FROM firefox_addons UNION SELECT name AS name, version AS version, 'Package (Chocolatey)' AS type, 'chocolatey_packages' AS source FROM chocolatey_packages UNION SELECT name AS name, version AS version, 'Package (Atom)' AS type, 'atom_packages' AS source FROM atom_packages;",
         "purpose": "Informational",
         "contributors": [
           {
@@ -521,13 +665,14 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-installed-windows-software",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get laptops with failing batteries",
         "platforms": "macOS",
-        "description": null,
+        "description": "Lists all laptops with under-performing or failing batteries.",
         "query": "SELECT * FROM battery WHERE health != 'Good' AND condition NOT IN ('', 'Normal');",
         "purpose": "Informational",
         "contributors": [
@@ -538,8 +683,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-laptops-with-failing-batteries",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get macOS disk free space percentage",
@@ -555,8 +701,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-mac-os-disk-free-space-percentage",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get mounts",
@@ -572,13 +719,14 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-mounts",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get the version of the resident operating system",
         "platforms": "macOS, Linux, Windows, FreeBSD",
-        "description": "Shows system mounted devices and filesystems (not process specific).",
+        "description": "Retrieves the version of the host(s) operating system(s).",
         "query": "SELECT * FROM os_version;",
         "purpose": "Informational",
         "contributors": [
@@ -589,8 +737,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-the-version-of-the-resident-operating-system",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get platform info",
@@ -606,8 +755,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-platform-info",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get startup items",
@@ -623,8 +773,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-startup-items",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get system logins and logouts",
@@ -640,8 +791,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-system-logins-and-logouts",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get current users with active shell/console on the system",
@@ -657,8 +809,9 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
+        "kind": "query",
         "slug": "get-current-users-with-active-shell-console-on-the-system",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get system uptime",
@@ -674,8 +827,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-system-uptime",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get USB devices",
@@ -691,8 +845,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-usb-devices",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get wifi status",
@@ -708,13 +863,14 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-wifi-status",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get Windows machines with unencrypted hard disks",
         "platforms": "Windows",
-        "description": null,
+        "description": "List all Windows machines with unencrypted hard disks.",
         "query": "SELECT * FROM bitlocker_info WHERE protection_status = 0;",
         "purpose": "Informational",
         "contributors": [
@@ -725,8 +881,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-windows-machines-with-unencrypted-hard-disks",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get disk encryption status",
@@ -742,8 +899,9 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
+        "kind": "query",
         "slug": "get-disk-encryption-status",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get unencrypted SSH keys for local accounts",
@@ -751,7 +909,7 @@
         "description": "Identify SSH keys created without a passphrase which can be used in Lateral Movement (MITRE. TA0008)",
         "query": "SELECT uid, username, description, path, encrypted FROM users CROSS JOIN user_ssh_keys using (uid) WHERE encrypted=0;",
         "purpose": "Informational",
-        "remediation": "N/A",
+        "remediation": "First, make the user aware about the impact of SSH keys.  Then rotate the unencrypted keys detected.",
         "contributors": [
           {
             "name": "Ahmed Elshaer",
@@ -760,7 +918,9 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "slug": "get-unencrypted-ssh-keys-for-local-accounts"
+        "kind": "query",
+        "slug": "get-unencrypted-ssh-keys-for-local-accounts",
+        "resolution": "N/A"
       },
       {
         "name": "Get unencrypted SSH keys for domain joined accounts",
@@ -768,7 +928,7 @@
         "description": "Identify SSH keys created without a passphrase which can be used in Lateral Movement (MITRE. TA0008)",
         "query": "SELECT uid, username, description, path, encrypted FROM users CROSS JOIN user_ssh_keys using (uid) WHERE encrypted=0 and username in (SELECT distinct(username) FROM last);",
         "purpose": "Informational",
-        "remediation": "N/A",
+        "remediation": "First, make the user aware about the impact of SSH keys.  Then rotate the unencrypted keys detected.",
         "contributors": [
           {
             "name": "Ahmed Elshaer",
@@ -777,7 +937,9 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "slug": "get-unencrypted-ssh-keys-for-domain-joined-accounts"
+        "kind": "query",
+        "slug": "get-unencrypted-ssh-keys-for-domain-joined-accounts",
+        "resolution": "N/A"
       },
       {
         "name": "Get crontab jobs",
@@ -793,8 +955,9 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
+        "kind": "query",
         "slug": "get-crontab-jobs",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get suid binaries",
@@ -810,8 +973,9 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
+        "kind": "query",
         "slug": "get-suid-binaries",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get dynamic linker hijacking on Linux (MITRE. T1574.006)",
@@ -819,7 +983,7 @@
         "description": "Detect any processes that run with LD_PRELOAD environment variable",
         "query": "SELECT env.pid, env.key, env.value, p.name,p.path, p.cmdline, p.cwd FROM process_envs env join processes p USING (pid) WHERE key='LD_PRELOAD';",
         "purpose": "Informational",
-        "remediation": "N/A",
+        "remediation": "Identify the process/binary detected and confirm with the system's owner.",
         "contributors": [
           {
             "name": "Ahmed Elshaer",
@@ -828,7 +992,9 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "slug": "get-dynamic-linker-hijacking-on-linux-mitre-t-1574-006"
+        "kind": "query",
+        "slug": "get-dynamic-linker-hijacking-on-linux-mitre-t-1574-006",
+        "resolution": "N/A"
       },
       {
         "name": "Get dynamic linker hijacking on macOS (MITRE. T1574.006)",
@@ -836,7 +1002,7 @@
         "description": "Detect any processes that run with DYLD_INSERT_LIBRARIES environment variable",
         "query": "SELECT env.pid, env.key, env.value, p.name,p.path, p.cmdline, p.cwd FROM process_envs env join processes p USING (pid) WHERE key='DYLD_INSERT_LIBRARIES';",
         "purpose": "Informational",
-        "remediation": "N/A",
+        "remediation": "Identify the process/binary detected and confirm with the system's owner.",
         "contributors": [
           {
             "name": "Ahmed Elshaer",
@@ -845,7 +1011,9 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "slug": "get-dynamic-linker-hijacking-on-mac-os-mitre-t-1574-006"
+        "kind": "query",
+        "slug": "get-dynamic-linker-hijacking-on-mac-os-mitre-t-1574-006",
+        "resolution": "N/A"
       },
       {
         "name": "Get etc hosts entries",
@@ -861,8 +1029,9 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
+        "kind": "query",
         "slug": "get-etc-hosts-entries",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get network interfaces",
@@ -878,8 +1047,9 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
+        "kind": "query",
         "slug": "get-network-interfaces",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get local user accounts",
@@ -895,8 +1065,9 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
+        "kind": "query",
         "slug": "get-local-user-accounts",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get active user accounts on servers",
@@ -912,8 +1083,9 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
+        "kind": "query",
         "slug": "get-active-user-accounts-on-servers",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get Nmap scanner",
@@ -929,8 +1101,9 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
+        "kind": "query",
         "slug": "get-nmap-scanner",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get docker images on a system",
@@ -946,8 +1119,9 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
+        "kind": "query",
         "slug": "get-docker-images-on-a-system",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get docker running containers on a system",
@@ -963,8 +1137,9 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
+        "kind": "query",
         "slug": "get-docker-running-containers-on-a-system",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get docker running process on a system",
@@ -980,8 +1155,9 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
+        "kind": "query",
         "slug": "get-docker-running-process-on-a-system",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get Windows print spooler remote code execution vulnerability",
@@ -997,8 +1173,9 @@
             "htmlUrl": "https://github.com/maravedi"
           }
         ],
+        "kind": "query",
         "slug": "get-windows-print-spooler-remote-code-execution-vulnerability",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get local users and their privileges",
@@ -1008,14 +1185,15 @@
         "purpose": "Informational",
         "contributors": [
           {
-            "name": null,
+            "name": "Noah Talerman",
             "handle": "noahtalerman",
             "avatarUrl": "https://avatars.githubusercontent.com/u/47070608?v=4",
             "htmlUrl": "https://github.com/noahtalerman"
           }
         ],
+        "kind": "query",
         "slug": "get-local-users-and-their-privileges",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get processes that no longer exist on disk",
@@ -1031,14 +1209,15 @@
             "htmlUrl": "https://github.com/alphabrevity"
           }
         ],
+        "kind": "query",
         "slug": "get-processes-that-no-longer-exist-on-disk",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get user files matching a specific hash",
         "platforms": "macOS, Linux",
         "description": "Looks for specific hash in the Users/ directories for files that are less than 50MB (osquery file size limitation.)",
-        "query": "SELECT path,sha256 FROM hash WHERE path in (SELECT path FROM file WHERE size < 50000000 AND path LIKE \"\"/Users/%/Documents/%%\"\") AND sha256 = \"\"16d28cd1d78b823c4f961a6da78d67a8975d66cde68581798778ed1f98a56d75\"\";",
+        "query": "SELECT path, sha256 FROM hash WHERE path IN (SELECT path FROM file WHERE size < 50000000 AND path LIKE '/Users/%/Documents/%%') AND sha256 = '16d28cd1d78b823c4f961a6da78d67a8975d66cde68581798778ed1f98a56d75';",
         "purpose": "Informational",
         "contributors": [
           {
@@ -1048,8 +1227,9 @@
             "htmlUrl": "https://github.com/alphabrevity"
           }
         ],
+        "kind": "query",
         "slug": "get-user-files-matching-a-specific-hash",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get local administrator accounts on macOS",
@@ -1065,8 +1245,9 @@
             "htmlUrl": "https://github.com/alphabrevity"
           }
         ],
+        "kind": "query",
         "slug": "get-local-administrator-accounts-on-mac-os",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get all listening ports, by process",
@@ -1082,8 +1263,9 @@
             "htmlUrl": "https://github.com/alphabrevity"
           }
         ],
+        "kind": "query",
         "slug": "get-all-listening-ports-by-process",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get whether TeamViewer is installed/running",
@@ -1099,14 +1281,15 @@
             "htmlUrl": "https://github.com/alphabrevity"
           }
         ],
+        "kind": "query",
         "slug": "get-whether-team-viewer-is-installed-running",
-        "remediation": "N/A"
+        "resolution": "N/A"
       },
       {
         "name": "Get malicious Python backdoors",
         "platforms": "macOS, Linux, Windows",
         "description": "Watches for the backdoored Python packages installed on system. See (http://www.nbu.gov.sk/skcsirt-sa-20170909-pypi/index.html)",
-        "query": "select case cnt when 0 then \"NONE_INSTALLED\" else \"INSTALLED\" end as \"Malicious Python Packages\",package_name,package_version from (select count(name) as  cnt,nameas package_name,version as package_version,path as package_pathfrom python_packages where package_name in ('acqusition','apidev-coop','bzip','crypt','django-server','pwd','setup-tools','telnet','urlib3','urllib'));",
+        "query": "SELECT CASE cnt WHEN 0 THEN \"NONE_INSTALLED\" ELSE \"INSTALLED\" END AS \"Malicious Python Packages\", package_name, package_version FROM (SELECT COUNT(name) AS cnt, name AS package_name, version AS package_version, path AS package_path FROM python_packages WHERE package_name IN ('acqusition', 'apidev-coop', 'bzip', 'crypt', 'django-server', 'pwd', 'setup-tools', 'telnet', 'urlib3', 'urllib'));",
         "purpose": "Informational",
         "contributors": [
           {
@@ -1116,8 +1299,246 @@
             "htmlUrl": "https://github.com/alphabrevity"
           }
         ],
+        "kind": "query",
         "slug": "get-malicious-python-backdoors",
-        "remediation": "N/A"
+        "resolution": "N/A"
+      },
+      {
+        "name": "Check for artifacts of the Floxif trojan",
+        "platforms": "Windows",
+        "description": "Checks for artifacts from the Floxif trojan on Windows machines.",
+        "query": "SELECT * FROM registry WHERE path LIKE 'HKEY_LOCAL_MACHINE\\\\SOFTWARE\\\\Piriform\\\\Agomo%';",
+        "purpose": "Informational",
+        "contributors": [
+          {
+            "name": "Babatunde Micheal Okutubo",
+            "handle": "micheal-o",
+            "avatarUrl": "https://avatars.githubusercontent.com/u/22627292?v=4",
+            "htmlUrl": "https://github.com/micheal-o"
+          }
+        ],
+        "kind": "query",
+        "slug": "check-for-artifacts-of-the-floxif-trojan",
+        "resolution": "N/A"
+      },
+      {
+        "name": "Get shimcache table",
+        "platforms": "Windows",
+        "description": "Returns forensic data showing evidence of likely file execution, in addition to the last modified timestamp of the file, order of execution, full file path order of execution, and the order in which files were executed.",
+        "query": "select * from shimcache",
+        "purpose": "Informational",
+        "contributors": [
+          {
+            "name": null,
+            "handle": "puffyCid",
+            "avatarUrl": "https://avatars.githubusercontent.com/u/16283453?v=4",
+            "htmlUrl": "https://github.com/puffyCid"
+          }
+        ],
+        "kind": "query",
+        "slug": "get-shimcache-table",
+        "resolution": "N/A"
+      },
+      {
+        "name": "Get running docker containers",
+        "platforms": "macOS, Linux",
+        "description": "Returns the running Docker containers",
+        "query": "SELECT id, name, image, image_id, state, status FROM docker_containers WHERE state = \"running\";",
+        "purpose": "Informational",
+        "contributors": [
+          {
+            "name": "Kelvin Oghenerhoro Omereshone",
+            "handle": "DominusKelvin",
+            "avatarUrl": "https://avatars.githubusercontent.com/u/24433274?v=4",
+            "htmlUrl": "https://github.com/DominusKelvin"
+          }
+        ],
+        "kind": "query",
+        "slug": "get-running-docker-containers",
+        "resolution": "N/A"
+      },
+      {
+        "name": "Get applications hogging memory",
+        "platforms": "macOS, Linux, Windows",
+        "description": "Returns top 10 applications or processes hogging memory the most.",
+        "query": "SELECT pid, name, ROUND((total_size * '10e-7'), 2) AS memory_used FROM processes ORDER BY total_size DESC LIMIT 10;",
+        "purpose": "Informational",
+        "contributors": [
+          {
+            "name": "Kelvin Oghenerhoro Omereshone",
+            "handle": "DominusKelvin",
+            "avatarUrl": "https://avatars.githubusercontent.com/u/24433274?v=4",
+            "htmlUrl": "https://github.com/DominusKelvin"
+          }
+        ],
+        "kind": "query",
+        "slug": "get-applications-hogging-memory",
+        "resolution": "N/A"
+      },
+      {
+        "name": "Get Mac and Linux machines with unencrypted primary disks",
+        "platforms": "macOS, Linux",
+        "description": null,
+        "query": "SELECT * FROM mounts m, disk_encryption d WHERE m.path= \"/\" AND m.device = d.name AND d.encrypted = 0;",
+        "purpose": "Informational",
+        "contributors": [
+          {
+            "name": "Kelvin Oghenerhoro Omereshone",
+            "handle": "DominusKelvin",
+            "avatarUrl": "https://avatars.githubusercontent.com/u/24433274?v=4",
+            "htmlUrl": "https://github.com/DominusKelvin"
+          }
+        ],
+        "kind": "query",
+        "slug": "get-mac-and-linux-machines-with-unencrypted-primary-disks",
+        "resolution": "N/A"
+      },
+      {
+        "name": "Get servers with root login in the last 24 hours",
+        "platforms": "macOS, Linux, Windows",
+        "description": "Returns servers with root login in the last 24 hours and the time the users where logged in.",
+        "query": "SELECT * FROM last WHERE username = \"root\" AND time > (( SELECT unix_time FROM time ) - 86400 );",
+        "purpose": "Informational",
+        "contributors": [
+          {
+            "name": "Kelvin Oghenerhoro Omereshone",
+            "handle": "DominusKelvin",
+            "avatarUrl": "https://avatars.githubusercontent.com/u/24433274?v=4",
+            "htmlUrl": "https://github.com/DominusKelvin"
+          }
+        ],
+        "kind": "query",
+        "slug": "get-servers-with-root-login-in-the-last-24-hours",
+        "resolution": "N/A"
+      },
+      {
+        "name": "Detect active processes with Log4j running",
+        "platforms": "macOS, Linux",
+        "description": "Returns a list of active processes and the Jar paths which are using Log4j. Version numbers are usually within the Jar filename.",
+        "query": "WITH target_jars AS (\n  SELECT DISTINCT path\n  FROM (\n      WITH split(word, str) AS(\n        SELECT '', cmdline || ' '\n        FROM processes\n        UNION ALL\n        SELECT substr(str, 0, instr(str, ' ')), substr(str, instr(str, ' ') + 1)\n        FROM split\n        WHERE str != '')\n      SELECT word AS path\n      FROM split\n      WHERE word LIKE '%.jar'\n    UNION ALL\n      SELECT path\n      FROM process_open_files\n      WHERE path LIKE '%.jar'\n  )\n)\nSELECT path, matches\nFROM yara\nWHERE path IN (SELECT path FROM target_jars)\n  AND count > 0\n  AND sigrule IN (\n    'rule log4jJndiLookup {\n      strings:\n        $jndilookup = \"JndiLookup\"\n      condition:\n        $jndilookup\n    }',\n    'rule log4jJavaClass {\n      strings:\n        $javaclass = \"org/apache/logging/log4j\"\n      condition:\n        $javaclass\n    }'\n  );\n",
+        "purpose": "Detection",
+        "contributors": [
+          {
+            "name": "Zach Wasserman",
+            "handle": "zwass",
+            "avatarUrl": "https://avatars.githubusercontent.com/u/575602?v=4",
+            "htmlUrl": "https://github.com/zwass"
+          },
+          {
+            "name": "Tony Gauda",
+            "handle": "tgauda",
+            "avatarUrl": "https://avatars.githubusercontent.com/u/5620541?v=4",
+            "htmlUrl": "https://github.com/tgauda"
+          }
+        ],
+        "kind": "query",
+        "slug": "detect-active-processes-with-log-4-j-running",
+        "resolution": "N/A"
+      },
+      {
+        "name": "Get applications that were opened within the last 24 hours",
+        "platforms": "macOS",
+        "description": "Returns applications that were opened within the last 24 hours starting with the last opened application.",
+        "query": "SELECT * FROM apps WHERE last_opened_time > (( SELECT unix_time FROM time ) - 86400 ) ORDER BY last_opened_time DESC;",
+        "purpose": "Informational",
+        "contributors": [
+          {
+            "name": "Kelvin Oghenerhoro Omereshone",
+            "handle": "DominusKelvin",
+            "avatarUrl": "https://avatars.githubusercontent.com/u/24433274?v=4",
+            "htmlUrl": "https://github.com/DominusKelvin"
+          }
+        ],
+        "kind": "query",
+        "slug": "get-applications-that-were-opened-within-the-last-24-hours",
+        "resolution": "N/A"
+      },
+      {
+        "name": "Get applications that are not in the Applications directory",
+        "platforms": "macOS",
+        "description": "Returns applications that are not in the `/Applications` directory",
+        "query": "SELECT * FROM apps WHERE path NOT LIKE '/Applications/%';",
+        "purpose": "Informational",
+        "contributors": [
+          {
+            "name": "Kelvin Oghenerhoro Omereshone",
+            "handle": "DominusKelvin",
+            "avatarUrl": "https://avatars.githubusercontent.com/u/24433274?v=4",
+            "htmlUrl": "https://github.com/DominusKelvin"
+          }
+        ],
+        "kind": "query",
+        "slug": "get-applications-that-are-not-in-the-applications-directory",
+        "resolution": "N/A"
+      },
+      {
+        "name": "Get subscription-based applications that have not been opened for the last 30 days",
+        "platforms": "macOS",
+        "description": "Returns applications that are subscription-based and have not been opened for the last 30 days. You can replace the list of applications with those specific to your use case.",
+        "query": "SELECT * FROM apps WHERE path LIKE '/Applications/%' AND name IN (\"Photoshop.app\", \"Adobe XD.app\", \"Sketch.app\", \"Illustrator.app\") AND last_opened_time < (( SELECT unix_time FROM time ) - 2592000000000 );",
+        "purpose": "Informational",
+        "contributors": [
+          {
+            "name": "Kelvin Oghenerhoro Omereshone",
+            "handle": "DominusKelvin",
+            "avatarUrl": "https://avatars.githubusercontent.com/u/24433274?v=4",
+            "htmlUrl": "https://github.com/DominusKelvin"
+          }
+        ],
+        "kind": "query",
+        "slug": "get-subscription-based-applications-that-have-not-been-opened-for-the-last-30-days",
+        "resolution": "N/A"
+      },
+      {
+        "name": "Is Gatekeeper enabled on macOS devices?",
+        "query": "SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;",
+        "description": "Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.",
+        "resolution": "To enable Gatekeeper, one the failing device, run the following command in the Terminal app: /usr/sbin/spctl --master-enable",
+        "platforms": "macOS",
+        "contributors": [
+          {
+            "name": "Victor Vrantchan",
+            "handle": "groob",
+            "avatarUrl": "https://avatars.githubusercontent.com/u/1526945?v=4",
+            "htmlUrl": "https://github.com/groob"
+          }
+        ],
+        "kind": "policy",
+        "slug": "is-gatekeeper-enabled-on-mac-os-devices"
+      },
+      {
+        "name": "Is disk encryption enabled on Windows devices?",
+        "query": "SELECT 1 FROM bitlocker_info where protection_status = 1;",
+        "description": "Checks to make sure that device encryption is enabled on Windows devices.",
+        "resolution": "To get additional information, run the following osquery query on the failing device: SELECT * FROM bitlocker_info. In the query results, if protection_status is 2, then the status cannot be determined. If it is 0, it is considered unprotected. Use the additional results (percent_encrypted, conversion_status, etc.) to help narrow down the specific reason why Windows considers the volume unprotected.",
+        "platforms": "Windows",
+        "contributors": [
+          {
+            "name": "Josh Brower",
+            "handle": "defensivedepth",
+            "avatarUrl": "https://avatars.githubusercontent.com/u/954732?v=4",
+            "htmlUrl": "https://github.com/defensivedepth"
+          }
+        ],
+        "kind": "policy",
+        "slug": "is-disk-encryption-enabled-on-windows-devices"
+      },
+      {
+        "name": "Is Filevault enabled on macOS devices?",
+        "query": "SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT “” AND filevault_status = ‘on’ LIMIT 1;",
+        "description": "Checks to make sure that the Filevault feature is enabled on macOS devices.",
+        "resolution": "To enable Filevailt, on the failing device, select System Preferences > Security & Privacy > FileVault > Turn On FileVault.",
+        "platforms": "macOS",
+        "contributors": [
+          {
+            "name": "Victor Vrantchan",
+            "handle": "groob",
+            "avatarUrl": "https://avatars.githubusercontent.com/u/1526945?v=4",
+            "htmlUrl": "https://github.com/groob"
+          }
+        ],
+        "kind": "policy",
+        "slug": "is-filevault-enabled-on-mac-os-devices"
       }
     ],
     "queryLibraryYmlRepoPath": "docs/01-Using-Fleet/standard-query-library/standard-query-library.yml",

--- a/website/.sailsrc
+++ b/website/.sailsrc
@@ -11,224 +11,72 @@
       {
         "url": "/docs",
         "title": "Readme.md",
-        "lastModifiedAt": 1632328105000,
-        "htmlId": "docs--readme--604f50259c",
+        "lastModifiedAt": 1624049901000,
+        "htmlId": "docs--readme--27004f4448",
         "sectionRelativeRepoPath": "README.md",
         "meta": {}
       },
       {
-        "url": "/docs/using-fleet/learn-how-to-use-fleet",
-        "title": "Learn how to use Fleet",
-        "lastModifiedAt": 1635391919000,
-        "htmlId": "docs--00-learn-how-to-use---c147ffcf6b",
-        "sectionRelativeRepoPath": "01-Using-Fleet/00-Learn-how-to-use-Fleet.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/using-fleet/fleet-ui",
-        "title": "Fleet UI",
-        "lastModifiedAt": 1632328105000,
-        "htmlId": "docs--01-fleet-ui--1c2ccb6c0e",
-        "sectionRelativeRepoPath": "01-Using-Fleet/01-Fleet-UI.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/using-fleet/fleetctl-cli",
-        "title": "Fleetctl CLI",
-        "lastModifiedAt": 1639072763000,
-        "htmlId": "docs--02-fleetctl-cli--dc52271221",
-        "sectionRelativeRepoPath": "01-Using-Fleet/02-fleetctl-CLI.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/using-fleet/rest-api",
-        "title": "REST API",
-        "lastModifiedAt": 1642784818000,
-        "htmlId": "docs--03-rest-api--fdb9d6d72c",
-        "sectionRelativeRepoPath": "01-Using-Fleet/03-REST-API.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/using-fleet/adding-hosts",
-        "title": "Adding hosts",
-        "lastModifiedAt": 1642440618000,
-        "htmlId": "docs--04-adding-hosts--3641d1fd39",
-        "sectionRelativeRepoPath": "01-Using-Fleet/04-Adding-hosts.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/using-fleet/osquery-logs",
-        "title": "Osquery logs",
-        "lastModifiedAt": 1642615196000,
-        "htmlId": "docs--05-osquery-logs--201be3b05e",
-        "sectionRelativeRepoPath": "01-Using-Fleet/05-Osquery-logs.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/using-fleet/monitoring-fleet",
-        "title": "Monitoring Fleet",
-        "lastModifiedAt": 1642559146000,
-        "htmlId": "docs--06-monitoring-fleet--c890baaa1a",
-        "sectionRelativeRepoPath": "01-Using-Fleet/06-Monitoring-Fleet.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/using-fleet/security-best-practices",
-        "title": "Security best practices",
-        "lastModifiedAt": 1639002215000,
-        "htmlId": "docs--07-security-best-pra--61e84d88ec",
-        "sectionRelativeRepoPath": "01-Using-Fleet/07-Security-best-practices.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/using-fleet/permissions",
-        "title": "Permissions",
-        "lastModifiedAt": 1642522720000,
-        "htmlId": "docs--09-permissions--da3d0fa7c1",
-        "sectionRelativeRepoPath": "01-Using-Fleet/09-Permissions.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/using-fleet/teams",
-        "title": "Teams",
-        "lastModifiedAt": 1637332681000,
-        "htmlId": "docs--10-teams--d8c655deb6",
-        "sectionRelativeRepoPath": "01-Using-Fleet/10-Teams.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/using-fleet/usage-statistics",
-        "title": "Usage statistics",
-        "lastModifiedAt": 1638823140000,
-        "htmlId": "docs--11-usage-statistics--f7a6821dca",
-        "sectionRelativeRepoPath": "01-Using-Fleet/11-Usage-statistics.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/using-fleet/supported-browsers",
-        "title": "Supported browsers",
+        "url": "/docs/deploying/installation",
+        "title": "Installation",
         "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--12-supported-browser--17af809146",
-        "sectionRelativeRepoPath": "01-Using-Fleet/12-Supported-browsers.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/using-fleet/vulnerability-processing",
-        "title": "Vulnerability processing",
-        "lastModifiedAt": 1641910549000,
-        "htmlId": "docs--13-vulnerability-pro--23acf63ab7",
-        "sectionRelativeRepoPath": "01-Using-Fleet/13-Vulnerability-Processing.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/using-fleet/automations",
-        "title": "Automations",
-        "lastModifiedAt": 1640904627000,
-        "htmlId": "docs--14-automations--60b6e2ad4f",
-        "sectionRelativeRepoPath": "01-Using-Fleet/14-Automations.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/using-fleet/faq",
-        "title": "FAQ",
-        "lastModifiedAt": 1642633631000,
-        "htmlId": "docs--faq--66f7e563df",
-        "sectionRelativeRepoPath": "01-Using-Fleet/FAQ.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/using-fleet",
-        "title": "Using Fleet",
-        "lastModifiedAt": 1642559146000,
-        "htmlId": "docs--readme--801014ddc2",
-        "sectionRelativeRepoPath": "01-Using-Fleet/README.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/deploying/introduction",
-        "title": "Introduction",
-        "lastModifiedAt": 1639268622000,
-        "htmlId": "docs--01-introduction--83a1c8790d",
-        "sectionRelativeRepoPath": "02-Deploying/01-Introduction.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/deploying/server-installation",
-        "title": "Server installation",
-        "lastModifiedAt": 1642005077000,
-        "htmlId": "docs--02-server-installati--2724fd584e",
-        "sectionRelativeRepoPath": "02-Deploying/02-Server-Installation.md",
+        "htmlId": "docs--01-installation--c1f7b7262d",
+        "sectionRelativeRepoPath": "02-Deploying/01-Installation.md",
         "meta": {}
       },
       {
         "url": "/docs/deploying/configuration",
         "title": "Configuration",
-        "lastModifiedAt": 1642707662000,
-        "htmlId": "docs--03-configuration--dbcbe166b7",
-        "sectionRelativeRepoPath": "02-Deploying/03-Configuration.md",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--02-configuration--25bb47a163",
+        "sectionRelativeRepoPath": "02-Deploying/02-Configuration.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/deploying/example-deployment-scenarios",
+        "title": "Example deployment scenarios",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--03-example-deploymen--1d32b988ab",
+        "sectionRelativeRepoPath": "02-Deploying/03-Example-deployment-scenarios.md",
         "meta": {}
       },
       {
         "url": "/docs/deploying/fleetctl-agent-updates",
         "title": "Fleetctl agent updates",
-        "lastModifiedAt": 1642181150000,
-        "htmlId": "docs--04-fleetctl-agent-up--df0f243234",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--04-fleetctl-agent-up--92c6890fa9",
         "sectionRelativeRepoPath": "02-Deploying/04-fleetctl-agent-updates.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/deploying/load-testing",
-        "title": "Load testing",
-        "lastModifiedAt": 1637117313000,
-        "htmlId": "docs--05-load-testing--11cd618690",
-        "sectionRelativeRepoPath": "02-Deploying/05-Load-testing.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/deploying/reference-architectures",
-        "title": "Reference architectures",
-        "lastModifiedAt": 1642811275000,
-        "htmlId": "docs--06-reference-archite--72d044b212",
-        "sectionRelativeRepoPath": "02-Deploying/06-Reference-Architectures.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/deploying/upgrading-fleet",
-        "title": "Upgrading Fleet",
-        "lastModifiedAt": 1642615196000,
-        "htmlId": "docs--06-upgrading-fleet--8b39675167",
-        "sectionRelativeRepoPath": "02-Deploying/06-Upgrading-Fleet.md",
         "meta": {}
       },
       {
         "url": "/docs/deploying/faq",
         "title": "FAQ",
-        "lastModifiedAt": 1642559146000,
-        "htmlId": "docs--faq--5cf230e766",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--faq--3ad91393ce",
         "sectionRelativeRepoPath": "02-Deploying/FAQ.md",
         "meta": {}
       },
       {
         "url": "/docs/deploying",
         "title": "Deploying",
-        "lastModifiedAt": 1642559146000,
-        "htmlId": "docs--readme--c9a2b1d089",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--readme--fb635b427f",
         "sectionRelativeRepoPath": "02-Deploying/README.md",
         "meta": {}
       },
       {
         "url": "/docs/contributing/building-fleet",
         "title": "Building Fleet",
-        "lastModifiedAt": 1636342002000,
-        "htmlId": "docs--01-building-fleet--323b13a8a3",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--01-building-fleet--abcea456d8",
         "sectionRelativeRepoPath": "03-Contributing/01-Building-Fleet.md",
         "meta": {}
       },
       {
         "url": "/docs/contributing/testing",
         "title": "Testing",
-        "lastModifiedAt": 1641336649000,
-        "htmlId": "docs--02-testing--e9364452cf",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--02-testing--2f307719a6",
         "sectionRelativeRepoPath": "03-Contributing/02-Testing.md",
         "meta": {}
       },
@@ -236,23 +84,23 @@
         "url": "/docs/contributing/migrations",
         "title": "Migrations",
         "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--03-migrations--0aa6a303a0",
+        "htmlId": "docs--03-migrations--b553b6254f",
         "sectionRelativeRepoPath": "03-Contributing/03-Migrations.md",
         "meta": {}
       },
       {
         "url": "/docs/contributing/committing-changes",
         "title": "Committing changes",
-        "lastModifiedAt": 1633617622000,
-        "htmlId": "docs--04-committing-change--a1e2443ae8",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--04-committing-change--9b92fdc560",
         "sectionRelativeRepoPath": "03-Contributing/04-Committing-Changes.md",
         "meta": {}
       },
       {
         "url": "/docs/contributing/releasing-fleet",
         "title": "Releasing Fleet",
-        "lastModifiedAt": 1636424262000,
-        "htmlId": "docs--05-releasing-fleet--9720ea852e",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--05-releasing-fleet--1f39f77c64",
         "sectionRelativeRepoPath": "03-Contributing/05-Releasing-Fleet.md",
         "meta": {}
       },
@@ -260,154 +108,176 @@
         "url": "/docs/contributing/seeding-data",
         "title": "Seeding data",
         "lastModifiedAt": 1632163704000,
-        "htmlId": "docs--06-seeding-data--fef459d10b",
+        "htmlId": "docs--06-seeding-data--af5ac86a99",
         "sectionRelativeRepoPath": "03-Contributing/06-Seeding-Data.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/contributing/api-for-contributors",
-        "title": "API for contributors",
-        "lastModifiedAt": 1641909869000,
-        "htmlId": "docs--07-api-for-contribut--be248c1626",
-        "sectionRelativeRepoPath": "03-Contributing/07-API-for-contributors.md",
-        "meta": {}
-      },
-      {
-        "url": "/docs/contributing/api-versioning",
-        "title": "API versioning",
-        "lastModifiedAt": 1640100192000,
-        "htmlId": "docs--08-api-versioning--14b02b7872",
-        "sectionRelativeRepoPath": "03-Contributing/08-API-Versioning.md",
         "meta": {}
       },
       {
         "url": "/docs/contributing/faq",
         "title": "FAQ",
-        "lastModifiedAt": 1637092915000,
-        "htmlId": "docs--faq--0568c0d1be",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--faq--1b33e57806",
         "sectionRelativeRepoPath": "03-Contributing/FAQ.md",
         "meta": {}
       },
       {
         "url": "/docs/contributing",
         "title": "Contributing",
-        "lastModifiedAt": 1636120985000,
-        "htmlId": "docs--readme--f7c5242035",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--readme--6de1bc799d",
         "sectionRelativeRepoPath": "03-Contributing/README.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/using-fleet/fleet-ui",
+        "title": "Fleet UI",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--01-fleet-ui--4b5755ee58",
+        "sectionRelativeRepoPath": "01-Using-Fleet/01-Fleet-UI.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/using-fleet/fleetctl-cli",
+        "title": "Fleetctl CLI",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--02-fleetctl-cli--2a521b49d6",
+        "sectionRelativeRepoPath": "01-Using-Fleet/02-fleetctl-CLI.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/using-fleet/rest-api",
+        "title": "REST API",
+        "lastModifiedAt": 1632174198000,
+        "htmlId": "docs--03-rest-api--f0b4e26bae",
+        "sectionRelativeRepoPath": "01-Using-Fleet/03-REST-API.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/using-fleet/adding-hosts",
+        "title": "Adding hosts",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--04-adding-hosts--9ffccb2221",
+        "sectionRelativeRepoPath": "01-Using-Fleet/04-Adding-hosts.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/using-fleet/osquery-logs",
+        "title": "Osquery logs",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--05-osquery-logs--7fbf2c5c5a",
+        "sectionRelativeRepoPath": "01-Using-Fleet/05-Osquery-logs.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/using-fleet/monitoring-fleet",
+        "title": "Monitoring Fleet",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--06-monitoring-fleet--83f7cca9f9",
+        "sectionRelativeRepoPath": "01-Using-Fleet/06-Monitoring-Fleet.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/using-fleet/security-best-practices",
+        "title": "Security best practices",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--07-security-best-pra--7ba1af6048",
+        "sectionRelativeRepoPath": "01-Using-Fleet/07-Security-best-practices.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/using-fleet/updating-fleet",
+        "title": "Updating Fleet",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--08-updating-fleet--3b4e821ee3",
+        "sectionRelativeRepoPath": "01-Using-Fleet/08-Updating-Fleet.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/using-fleet/permissions",
+        "title": "Permissions",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--09-permissions--eb9ac05ff5",
+        "sectionRelativeRepoPath": "01-Using-Fleet/09-Permissions.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/using-fleet/teams",
+        "title": "Teams",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--10-teams--bd0bdf9444",
+        "sectionRelativeRepoPath": "01-Using-Fleet/10-Teams.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/using-fleet/usage-statistics",
+        "title": "Usage statistics",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--11-usage-statistics--ccd73f532c",
+        "sectionRelativeRepoPath": "01-Using-Fleet/11-Usage-statistics.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/using-fleet/supported-browsers",
+        "title": "Supported browsers",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--12-supported-browser--c3a9c18d40",
+        "sectionRelativeRepoPath": "01-Using-Fleet/12-Supported-browsers.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/using-fleet/vulnerability-processing",
+        "title": "Vulnerability processing",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--13-vulnerability-pro--7a9b62b621",
+        "sectionRelativeRepoPath": "01-Using-Fleet/13-Vulnerability-Processing.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/using-fleet/faq",
+        "title": "FAQ",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--faq--75e099695e",
+        "sectionRelativeRepoPath": "01-Using-Fleet/FAQ.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/using-fleet",
+        "title": "Using Fleet",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--readme--0b226f5257",
+        "sectionRelativeRepoPath": "01-Using-Fleet/README.md",
+        "meta": {}
+      },
+      {
+        "url": "/docs/using-fleet/learn-how-to-use-fleet",
+        "title": "Learn how to use Fleet",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--00-learn-how-to-use---95b515dfd1",
+        "sectionRelativeRepoPath": "01-Using-Fleet/00-Learn-how-to-use-Fleet.md",
         "meta": {}
       },
       {
         "url": "/docs/using-fleet/configuration-files",
         "title": "Configuration files",
-        "lastModifiedAt": 1642517803000,
-        "htmlId": "docs--readme--1600a75384",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--readme--dc5df431cb",
         "sectionRelativeRepoPath": "01-Using-Fleet/configuration-files/README.md",
         "meta": {}
       },
       {
         "url": "/docs/using-fleet/standard-query-library",
         "title": "Standard query library",
-        "lastModifiedAt": 1638803705000,
-        "htmlId": "docs--readme--e996808f7b",
+        "lastModifiedAt": 1632163704000,
+        "htmlId": "docs--readme--db16aa6f37",
         "sectionRelativeRepoPath": "01-Using-Fleet/standard-query-library/README.md",
         "meta": {}
-      },
-      {
-        "url": "/handbook",
-        "title": "Readme.md",
-        "lastModifiedAt": 1642446791000,
-        "htmlId": "handbook--readme--200fed8efb",
-        "sectionRelativeRepoPath": "README.md",
-        "meta": {
-          "maintainedBy": "mikermcneil"
-        }
-      },
-      {
-        "url": "/handbook/community",
-        "title": "Community",
-        "lastModifiedAt": 1642175041000,
-        "htmlId": "handbook--community--0964c343ec",
-        "sectionRelativeRepoPath": "community.md",
-        "meta": {
-          "maintainedBy": "zwass"
-        }
-      },
-      {
-        "url": "/handbook/customers",
-        "title": "Customers",
-        "lastModifiedAt": 1642446791000,
-        "htmlId": "handbook--customers--e8df9d479f",
-        "sectionRelativeRepoPath": "customers.md",
-        "meta": {
-          "maintainedBy": "tgauda"
-        }
-      },
-      {
-        "url": "/handbook/company",
-        "title": "Company",
-        "lastModifiedAt": 1642614403000,
-        "htmlId": "handbook--company--72edb6ad0e",
-        "sectionRelativeRepoPath": "company.md",
-        "meta": {
-          "maintainedBy": "mikermcneil"
-        }
-      },
-      {
-        "url": "/handbook/growth",
-        "title": "Growth",
-        "lastModifiedAt": 1642645417000,
-        "htmlId": "handbook--growth--8dc99b84b7",
-        "sectionRelativeRepoPath": "growth.md",
-        "meta": {
-          "maintainedBy": "mike-j-thomas"
-        }
-      },
-      {
-        "url": "/handbook/engineering",
-        "title": "Engineering",
-        "lastModifiedAt": 1642446791000,
-        "htmlId": "handbook--engineering--5dd72277c1",
-        "sectionRelativeRepoPath": "engineering.md",
-        "meta": {
-          "maintainedBy": "zwass"
-        }
-      },
-      {
-        "url": "/handbook/handbook",
-        "title": "Handbook",
-        "lastModifiedAt": 1642145590000,
-        "htmlId": "handbook--handbook--59cc5b205c",
-        "sectionRelativeRepoPath": "handbook.md",
-        "meta": {
-          "maintainedBy": "mike-j-thomas"
-        }
-      },
-      {
-        "url": "/handbook/people",
-        "title": "People",
-        "lastModifiedAt": 1642546792000,
-        "htmlId": "handbook--people--fc26a0f11e",
-        "sectionRelativeRepoPath": "people.md",
-        "meta": {
-          "maintainedBy": "eashaw"
-        }
-      },
-      {
-        "url": "/handbook/product",
-        "title": "Product",
-        "lastModifiedAt": 1642446791000,
-        "htmlId": "handbook--product--4bcfbe9e78",
-        "sectionRelativeRepoPath": "product.md",
-        "meta": {
-          "maintainedBy": "noahtalerman"
-        }
       }
     ],
     "queries": [
       {
         "name": "Count Apple applications installed",
         "platforms": "macOS",
-        "description": "Get the total number of Apple applications installed on the host system.",
+        "description": "Count the number of Apple applications installed on the machine.",
         "query": "SELECT COUNT(*) FROM apps WHERE bundle_identifier LIKE 'com.apple.%';",
         "purpose": "Informational",
         "contributors": [
@@ -418,7 +288,7 @@
             "htmlUrl": "https://github.com/mike-j-thomas"
           },
           {
-            "name": "Noah Talerman",
+            "name": null,
             "handle": "noahtalerman",
             "avatarUrl": "https://avatars.githubusercontent.com/u/47070608?v=4",
             "htmlUrl": "https://github.com/noahtalerman"
@@ -430,9 +300,8 @@
             "htmlUrl": "https://github.com/mikermcneil"
           }
         ],
-        "kind": "query",
         "slug": "count-apple-applications-installed",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get OpenSSL versions",
@@ -448,9 +317,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-open-ssl-versions",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get whether Gatekeeper is disabled",
@@ -466,9 +334,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-whether-gatekeeper-is-disabled",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get authorized SSH keys",
@@ -476,7 +343,7 @@
         "description": "Presence of authorized SSH keys may be unusual on laptops. Could be completely normal on servers, but may be worth auditing for unusual keys and/or changes.",
         "query": "SELECT username, authorized_keys. * FROM users CROSS JOIN authorized_keys USING (uid);",
         "purpose": "Informational",
-        "remediation": "Check out the linked table (https://github.com/fleetdm/fleet/blob/32b4d53e7f1428ce43b0f9fa52838cbe7b413eed/handbook/queries/detect-hosts-with-high-severity-vulnerable-versions-of-openssl.md#table-of-vulnerable-openssl-versions) to determine if the installed version is a high severity vulnerability and view the corresponding CVE(s)",
+        "remediation": "N/A",
         "contributors": [
           {
             "name": "Mike Thomas",
@@ -485,9 +352,7 @@
             "htmlUrl": "https://github.com/mike-j-thomas"
           }
         ],
-        "kind": "query",
-        "slug": "get-authorized-ssh-keys",
-        "resolution": "N/A"
+        "slug": "get-authorized-ssh-keys"
       },
       {
         "name": "Get authorized keys for Local Accounts",
@@ -503,9 +368,8 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "kind": "query",
         "slug": "get-authorized-keys-for-local-accounts",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get authorized keys for Domain Joined Accounts",
@@ -521,9 +385,8 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "kind": "query",
         "slug": "get-authorized-keys-for-domain-joined-accounts",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get crashes",
@@ -539,9 +402,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-crashes",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get installed Chrome Extensions",
@@ -557,9 +419,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-installed-chrome-extensions",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get installed FreeBSD software",
@@ -575,9 +436,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-installed-free-bsd-software",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get Homebrew Packages",
@@ -593,9 +453,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-homebrew-packages",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get installed Linux software",
@@ -611,9 +470,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-installed-linux-software",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get installed macOS software",
@@ -629,9 +487,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-installed-mac-os-software",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get installed Safari extensions",
@@ -647,15 +504,14 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-installed-safari-extensions",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get installed Windows software",
         "platforms": "Windows",
         "description": "Get all software installed on a Windows computer, including programs, browser plugins, and installed packages. Note, this does not included other running processes in the processes table.",
-        "query": "SELECT name AS name, version AS version, 'Program (Windows)' AS type, 'programs' AS source FROM programs UNION SELECT name AS name, version AS version, 'Package (Python)' AS type, 'python_packages' AS source FROM python_packages UNION SELECT name AS name, version AS version, 'Browser plugin (IE)' AS type, 'ie_extensions' AS source FROM ie_extensions UNION SELECT name AS name, version AS version, 'Browser plugin (Chrome)' AS type, 'chrome_extensions' AS source FROM chrome_extensions UNION SELECT name AS name, version AS version, 'Browser plugin (Firefox)' AS type, 'firefox_addons' AS source FROM firefox_addons UNION SELECT name AS name, version AS version, 'Package (Chocolatey)' AS type, 'chocolatey_packages' AS source FROM chocolatey_packages UNION SELECT name AS name, version AS version, 'Package (Atom)' AS type, 'atom_packages' AS source FROM atom_packages;",
+        "query": "SELECT name AS name, version AS version, 'Program (Windows)' AS type, 'programs' AS source FROM programs UNION SELECT name AS name, version AS version, 'Package (Python)' AS type, 'python_packages' AS source FROM python_packages UNION SELECT name AS name, version AS version, 'Browser plugin (IE)' AS type, 'ie_extensions' AS source FROM ie_extensions UNION SELECT name AS name, version AS version, 'Browser plugin (Chrome)' AS type, 'chrome_extensions' AS source FROM chrome_extensions UNION SELECT name AS name, version AS version, 'Browser plugin (Firefox)' AS type, 'firefox_addons' AS source FROM firefox_addons UNION SELECT name AS name, version AS version, 'Package (Chocolatey)' AS type, 'chocolatey_packages' AS source FROM chocolatey_packages UNION SELECT name AS name, version AS version, 'Package (Atom)' AS type, 'atom_packages' AS source FROM atom_packages UNION SELECT name AS name, version AS version, 'Package (Python)' AS type, 'python_packages' AS source FROM python_packages;",
         "purpose": "Informational",
         "contributors": [
           {
@@ -665,14 +521,13 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-installed-windows-software",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get laptops with failing batteries",
         "platforms": "macOS",
-        "description": "Lists all laptops with under-performing or failing batteries.",
+        "description": null,
         "query": "SELECT * FROM battery WHERE health != 'Good' AND condition NOT IN ('', 'Normal');",
         "purpose": "Informational",
         "contributors": [
@@ -683,9 +538,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-laptops-with-failing-batteries",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get macOS disk free space percentage",
@@ -701,9 +555,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-mac-os-disk-free-space-percentage",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get mounts",
@@ -719,14 +572,13 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-mounts",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get the version of the resident operating system",
         "platforms": "macOS, Linux, Windows, FreeBSD",
-        "description": "Retrieves the version of the host(s) operating system(s).",
+        "description": "Shows system mounted devices and filesystems (not process specific).",
         "query": "SELECT * FROM os_version;",
         "purpose": "Informational",
         "contributors": [
@@ -737,9 +589,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-the-version-of-the-resident-operating-system",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get platform info",
@@ -755,9 +606,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-platform-info",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get startup items",
@@ -773,9 +623,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-startup-items",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get system logins and logouts",
@@ -791,9 +640,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-system-logins-and-logouts",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get current users with active shell/console on the system",
@@ -809,9 +657,8 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "kind": "query",
         "slug": "get-current-users-with-active-shell-console-on-the-system",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get system uptime",
@@ -827,9 +674,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-system-uptime",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get USB devices",
@@ -845,9 +691,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-usb-devices",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get wifi status",
@@ -863,14 +708,13 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-wifi-status",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get Windows machines with unencrypted hard disks",
         "platforms": "Windows",
-        "description": "List all Windows machines with unencrypted hard disks.",
+        "description": null,
         "query": "SELECT * FROM bitlocker_info WHERE protection_status = 0;",
         "purpose": "Informational",
         "contributors": [
@@ -881,9 +725,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-windows-machines-with-unencrypted-hard-disks",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get disk encryption status",
@@ -899,9 +742,8 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "kind": "query",
         "slug": "get-disk-encryption-status",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get unencrypted SSH keys for local accounts",
@@ -909,7 +751,7 @@
         "description": "Identify SSH keys created without a passphrase which can be used in Lateral Movement (MITRE. TA0008)",
         "query": "SELECT uid, username, description, path, encrypted FROM users CROSS JOIN user_ssh_keys using (uid) WHERE encrypted=0;",
         "purpose": "Informational",
-        "remediation": "First, make the user aware about the impact of SSH keys.  Then rotate the unencrypted keys detected.",
+        "remediation": "N/A",
         "contributors": [
           {
             "name": "Ahmed Elshaer",
@@ -918,9 +760,7 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "kind": "query",
-        "slug": "get-unencrypted-ssh-keys-for-local-accounts",
-        "resolution": "N/A"
+        "slug": "get-unencrypted-ssh-keys-for-local-accounts"
       },
       {
         "name": "Get unencrypted SSH keys for domain joined accounts",
@@ -928,7 +768,7 @@
         "description": "Identify SSH keys created without a passphrase which can be used in Lateral Movement (MITRE. TA0008)",
         "query": "SELECT uid, username, description, path, encrypted FROM users CROSS JOIN user_ssh_keys using (uid) WHERE encrypted=0 and username in (SELECT distinct(username) FROM last);",
         "purpose": "Informational",
-        "remediation": "First, make the user aware about the impact of SSH keys.  Then rotate the unencrypted keys detected.",
+        "remediation": "N/A",
         "contributors": [
           {
             "name": "Ahmed Elshaer",
@@ -937,9 +777,7 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "kind": "query",
-        "slug": "get-unencrypted-ssh-keys-for-domain-joined-accounts",
-        "resolution": "N/A"
+        "slug": "get-unencrypted-ssh-keys-for-domain-joined-accounts"
       },
       {
         "name": "Get crontab jobs",
@@ -955,9 +793,8 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "kind": "query",
         "slug": "get-crontab-jobs",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get suid binaries",
@@ -973,9 +810,8 @@
             "htmlUrl": "https://github.com/zwass"
           }
         ],
-        "kind": "query",
         "slug": "get-suid-binaries",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get dynamic linker hijacking on Linux (MITRE. T1574.006)",
@@ -983,7 +819,7 @@
         "description": "Detect any processes that run with LD_PRELOAD environment variable",
         "query": "SELECT env.pid, env.key, env.value, p.name,p.path, p.cmdline, p.cwd FROM process_envs env join processes p USING (pid) WHERE key='LD_PRELOAD';",
         "purpose": "Informational",
-        "remediation": "Identify the process/binary detected and confirm with the system's owner.",
+        "remediation": "N/A",
         "contributors": [
           {
             "name": "Ahmed Elshaer",
@@ -992,9 +828,7 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "kind": "query",
-        "slug": "get-dynamic-linker-hijacking-on-linux-mitre-t-1574-006",
-        "resolution": "N/A"
+        "slug": "get-dynamic-linker-hijacking-on-linux-mitre-t-1574-006"
       },
       {
         "name": "Get dynamic linker hijacking on macOS (MITRE. T1574.006)",
@@ -1002,7 +836,7 @@
         "description": "Detect any processes that run with DYLD_INSERT_LIBRARIES environment variable",
         "query": "SELECT env.pid, env.key, env.value, p.name,p.path, p.cmdline, p.cwd FROM process_envs env join processes p USING (pid) WHERE key='DYLD_INSERT_LIBRARIES';",
         "purpose": "Informational",
-        "remediation": "Identify the process/binary detected and confirm with the system's owner.",
+        "remediation": "N/A",
         "contributors": [
           {
             "name": "Ahmed Elshaer",
@@ -1011,9 +845,7 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "kind": "query",
-        "slug": "get-dynamic-linker-hijacking-on-mac-os-mitre-t-1574-006",
-        "resolution": "N/A"
+        "slug": "get-dynamic-linker-hijacking-on-mac-os-mitre-t-1574-006"
       },
       {
         "name": "Get etc hosts entries",
@@ -1029,9 +861,8 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "kind": "query",
         "slug": "get-etc-hosts-entries",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get network interfaces",
@@ -1047,9 +878,8 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "kind": "query",
         "slug": "get-network-interfaces",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get local user accounts",
@@ -1065,9 +895,8 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "kind": "query",
         "slug": "get-local-user-accounts",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get active user accounts on servers",
@@ -1083,9 +912,8 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "kind": "query",
         "slug": "get-active-user-accounts-on-servers",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get Nmap scanner",
@@ -1101,9 +929,8 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "kind": "query",
         "slug": "get-nmap-scanner",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get docker images on a system",
@@ -1119,9 +946,8 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "kind": "query",
         "slug": "get-docker-images-on-a-system",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get docker running containers on a system",
@@ -1137,9 +963,8 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "kind": "query",
         "slug": "get-docker-running-containers-on-a-system",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get docker running process on a system",
@@ -1155,9 +980,8 @@
             "htmlUrl": "https://github.com/anelshaer"
           }
         ],
-        "kind": "query",
         "slug": "get-docker-running-process-on-a-system",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get Windows print spooler remote code execution vulnerability",
@@ -1173,9 +997,8 @@
             "htmlUrl": "https://github.com/maravedi"
           }
         ],
-        "kind": "query",
         "slug": "get-windows-print-spooler-remote-code-execution-vulnerability",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get local users and their privileges",
@@ -1185,15 +1008,14 @@
         "purpose": "Informational",
         "contributors": [
           {
-            "name": "Noah Talerman",
+            "name": null,
             "handle": "noahtalerman",
             "avatarUrl": "https://avatars.githubusercontent.com/u/47070608?v=4",
             "htmlUrl": "https://github.com/noahtalerman"
           }
         ],
-        "kind": "query",
         "slug": "get-local-users-and-their-privileges",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get processes that no longer exist on disk",
@@ -1209,15 +1031,14 @@
             "htmlUrl": "https://github.com/alphabrevity"
           }
         ],
-        "kind": "query",
         "slug": "get-processes-that-no-longer-exist-on-disk",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get user files matching a specific hash",
         "platforms": "macOS, Linux",
         "description": "Looks for specific hash in the Users/ directories for files that are less than 50MB (osquery file size limitation.)",
-        "query": "SELECT path, sha256 FROM hash WHERE path IN (SELECT path FROM file WHERE size < 50000000 AND path LIKE '/Users/%/Documents/%%') AND sha256 = '16d28cd1d78b823c4f961a6da78d67a8975d66cde68581798778ed1f98a56d75';",
+        "query": "SELECT path,sha256 FROM hash WHERE path in (SELECT path FROM file WHERE size < 50000000 AND path LIKE \"\"/Users/%/Documents/%%\"\") AND sha256 = \"\"16d28cd1d78b823c4f961a6da78d67a8975d66cde68581798778ed1f98a56d75\"\";",
         "purpose": "Informational",
         "contributors": [
           {
@@ -1227,9 +1048,8 @@
             "htmlUrl": "https://github.com/alphabrevity"
           }
         ],
-        "kind": "query",
         "slug": "get-user-files-matching-a-specific-hash",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get local administrator accounts on macOS",
@@ -1245,9 +1065,8 @@
             "htmlUrl": "https://github.com/alphabrevity"
           }
         ],
-        "kind": "query",
         "slug": "get-local-administrator-accounts-on-mac-os",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get all listening ports, by process",
@@ -1263,9 +1082,8 @@
             "htmlUrl": "https://github.com/alphabrevity"
           }
         ],
-        "kind": "query",
         "slug": "get-all-listening-ports-by-process",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get whether TeamViewer is installed/running",
@@ -1281,15 +1099,14 @@
             "htmlUrl": "https://github.com/alphabrevity"
           }
         ],
-        "kind": "query",
         "slug": "get-whether-team-viewer-is-installed-running",
-        "resolution": "N/A"
+        "remediation": "N/A"
       },
       {
         "name": "Get malicious Python backdoors",
         "platforms": "macOS, Linux, Windows",
         "description": "Watches for the backdoored Python packages installed on system. See (http://www.nbu.gov.sk/skcsirt-sa-20170909-pypi/index.html)",
-        "query": "SELECT CASE cnt WHEN 0 THEN \"NONE_INSTALLED\" ELSE \"INSTALLED\" END AS \"Malicious Python Packages\", package_name, package_version FROM (SELECT COUNT(name) AS cnt, name AS package_name, version AS package_version, path AS package_path FROM python_packages WHERE package_name IN ('acqusition', 'apidev-coop', 'bzip', 'crypt', 'django-server', 'pwd', 'setup-tools', 'telnet', 'urlib3', 'urllib'));",
+        "query": "select case cnt when 0 then \"NONE_INSTALLED\" else \"INSTALLED\" end as \"Malicious Python Packages\",package_name,package_version from (select count(name) as  cnt,nameas package_name,version as package_version,path as package_pathfrom python_packages where package_name in ('acqusition','apidev-coop','bzip','crypt','django-server','pwd','setup-tools','telnet','urlib3','urllib'));",
         "purpose": "Informational",
         "contributors": [
           {
@@ -1299,246 +1116,8 @@
             "htmlUrl": "https://github.com/alphabrevity"
           }
         ],
-        "kind": "query",
         "slug": "get-malicious-python-backdoors",
-        "resolution": "N/A"
-      },
-      {
-        "name": "Check for artifacts of the Floxif trojan",
-        "platforms": "Windows",
-        "description": "Checks for artifacts from the Floxif trojan on Windows machines.",
-        "query": "SELECT * FROM registry WHERE path LIKE 'HKEY_LOCAL_MACHINE\\\\SOFTWARE\\\\Piriform\\\\Agomo%';",
-        "purpose": "Informational",
-        "contributors": [
-          {
-            "name": "Babatunde Micheal Okutubo",
-            "handle": "micheal-o",
-            "avatarUrl": "https://avatars.githubusercontent.com/u/22627292?v=4",
-            "htmlUrl": "https://github.com/micheal-o"
-          }
-        ],
-        "kind": "query",
-        "slug": "check-for-artifacts-of-the-floxif-trojan",
-        "resolution": "N/A"
-      },
-      {
-        "name": "Get shimcache table",
-        "platforms": "Windows",
-        "description": "Returns forensic data showing evidence of likely file execution, in addition to the last modified timestamp of the file, order of execution, full file path order of execution, and the order in which files were executed.",
-        "query": "select * from shimcache",
-        "purpose": "Informational",
-        "contributors": [
-          {
-            "name": null,
-            "handle": "puffyCid",
-            "avatarUrl": "https://avatars.githubusercontent.com/u/16283453?v=4",
-            "htmlUrl": "https://github.com/puffyCid"
-          }
-        ],
-        "kind": "query",
-        "slug": "get-shimcache-table",
-        "resolution": "N/A"
-      },
-      {
-        "name": "Get running docker containers",
-        "platforms": "macOS, Linux",
-        "description": "Returns the running Docker containers",
-        "query": "SELECT id, name, image, image_id, state, status FROM docker_containers WHERE state = \"running\";",
-        "purpose": "Informational",
-        "contributors": [
-          {
-            "name": "Kelvin Oghenerhoro Omereshone",
-            "handle": "DominusKelvin",
-            "avatarUrl": "https://avatars.githubusercontent.com/u/24433274?v=4",
-            "htmlUrl": "https://github.com/DominusKelvin"
-          }
-        ],
-        "kind": "query",
-        "slug": "get-running-docker-containers",
-        "resolution": "N/A"
-      },
-      {
-        "name": "Get applications hogging memory",
-        "platforms": "macOS, Linux, Windows",
-        "description": "Returns top 10 applications or processes hogging memory the most.",
-        "query": "SELECT pid, name, ROUND((total_size * '10e-7'), 2) AS memory_used FROM processes ORDER BY total_size DESC LIMIT 10;",
-        "purpose": "Informational",
-        "contributors": [
-          {
-            "name": "Kelvin Oghenerhoro Omereshone",
-            "handle": "DominusKelvin",
-            "avatarUrl": "https://avatars.githubusercontent.com/u/24433274?v=4",
-            "htmlUrl": "https://github.com/DominusKelvin"
-          }
-        ],
-        "kind": "query",
-        "slug": "get-applications-hogging-memory",
-        "resolution": "N/A"
-      },
-      {
-        "name": "Get Mac and Linux machines with unencrypted primary disks",
-        "platforms": "macOS, Linux",
-        "description": null,
-        "query": "SELECT * FROM mounts m, disk_encryption d WHERE m.path= \"/\" AND m.device = d.name AND d.encrypted = 0;",
-        "purpose": "Informational",
-        "contributors": [
-          {
-            "name": "Kelvin Oghenerhoro Omereshone",
-            "handle": "DominusKelvin",
-            "avatarUrl": "https://avatars.githubusercontent.com/u/24433274?v=4",
-            "htmlUrl": "https://github.com/DominusKelvin"
-          }
-        ],
-        "kind": "query",
-        "slug": "get-mac-and-linux-machines-with-unencrypted-primary-disks",
-        "resolution": "N/A"
-      },
-      {
-        "name": "Get servers with root login in the last 24 hours",
-        "platforms": "macOS, Linux, Windows",
-        "description": "Returns servers with root login in the last 24 hours and the time the users where logged in.",
-        "query": "SELECT * FROM last WHERE username = \"root\" AND time > (( SELECT unix_time FROM time ) - 86400 );",
-        "purpose": "Informational",
-        "contributors": [
-          {
-            "name": "Kelvin Oghenerhoro Omereshone",
-            "handle": "DominusKelvin",
-            "avatarUrl": "https://avatars.githubusercontent.com/u/24433274?v=4",
-            "htmlUrl": "https://github.com/DominusKelvin"
-          }
-        ],
-        "kind": "query",
-        "slug": "get-servers-with-root-login-in-the-last-24-hours",
-        "resolution": "N/A"
-      },
-      {
-        "name": "Detect active processes with Log4j running",
-        "platforms": "macOS, Linux",
-        "description": "Returns a list of active processes and the Jar paths which are using Log4j. Version numbers are usually within the Jar filename.",
-        "query": "WITH target_jars AS (\n  SELECT DISTINCT path\n  FROM (\n      WITH split(word, str) AS(\n        SELECT '', cmdline || ' '\n        FROM processes\n        UNION ALL\n        SELECT substr(str, 0, instr(str, ' ')), substr(str, instr(str, ' ') + 1)\n        FROM split\n        WHERE str != '')\n      SELECT word AS path\n      FROM split\n      WHERE word LIKE '%.jar'\n    UNION ALL\n      SELECT path\n      FROM process_open_files\n      WHERE path LIKE '%.jar'\n  )\n)\nSELECT path, matches\nFROM yara\nWHERE path IN (SELECT path FROM target_jars)\n  AND count > 0\n  AND sigrule IN (\n    'rule log4jJndiLookup {\n      strings:\n        $jndilookup = \"JndiLookup\"\n      condition:\n        $jndilookup\n    }',\n    'rule log4jJavaClass {\n      strings:\n        $javaclass = \"org/apache/logging/log4j\"\n      condition:\n        $javaclass\n    }'\n  );\n",
-        "purpose": "Detection",
-        "contributors": [
-          {
-            "name": "Zach Wasserman",
-            "handle": "zwass",
-            "avatarUrl": "https://avatars.githubusercontent.com/u/575602?v=4",
-            "htmlUrl": "https://github.com/zwass"
-          },
-          {
-            "name": "Tony Gauda",
-            "handle": "tgauda",
-            "avatarUrl": "https://avatars.githubusercontent.com/u/5620541?v=4",
-            "htmlUrl": "https://github.com/tgauda"
-          }
-        ],
-        "kind": "query",
-        "slug": "detect-active-processes-with-log-4-j-running",
-        "resolution": "N/A"
-      },
-      {
-        "name": "Get applications that were opened within the last 24 hours",
-        "platforms": "macOS",
-        "description": "Returns applications that were opened within the last 24 hours starting with the last opened application.",
-        "query": "SELECT * FROM apps WHERE last_opened_time > (( SELECT unix_time FROM time ) - 86400 ) ORDER BY last_opened_time DESC;",
-        "purpose": "Informational",
-        "contributors": [
-          {
-            "name": "Kelvin Oghenerhoro Omereshone",
-            "handle": "DominusKelvin",
-            "avatarUrl": "https://avatars.githubusercontent.com/u/24433274?v=4",
-            "htmlUrl": "https://github.com/DominusKelvin"
-          }
-        ],
-        "kind": "query",
-        "slug": "get-applications-that-were-opened-within-the-last-24-hours",
-        "resolution": "N/A"
-      },
-      {
-        "name": "Get applications that are not in the Applications directory",
-        "platforms": "macOS",
-        "description": "Returns applications that are not in the `/Applications` directory",
-        "query": "SELECT * FROM apps WHERE path NOT LIKE '/Applications/%';",
-        "purpose": "Informational",
-        "contributors": [
-          {
-            "name": "Kelvin Oghenerhoro Omereshone",
-            "handle": "DominusKelvin",
-            "avatarUrl": "https://avatars.githubusercontent.com/u/24433274?v=4",
-            "htmlUrl": "https://github.com/DominusKelvin"
-          }
-        ],
-        "kind": "query",
-        "slug": "get-applications-that-are-not-in-the-applications-directory",
-        "resolution": "N/A"
-      },
-      {
-        "name": "Get subscription-based applications that have not been opened for the last 30 days",
-        "platforms": "macOS",
-        "description": "Returns applications that are subscription-based and have not been opened for the last 30 days. You can replace the list of applications with those specific to your use case.",
-        "query": "SELECT * FROM apps WHERE path LIKE '/Applications/%' AND name IN (\"Photoshop.app\", \"Adobe XD.app\", \"Sketch.app\", \"Illustrator.app\") AND last_opened_time < (( SELECT unix_time FROM time ) - 2592000000000 );",
-        "purpose": "Informational",
-        "contributors": [
-          {
-            "name": "Kelvin Oghenerhoro Omereshone",
-            "handle": "DominusKelvin",
-            "avatarUrl": "https://avatars.githubusercontent.com/u/24433274?v=4",
-            "htmlUrl": "https://github.com/DominusKelvin"
-          }
-        ],
-        "kind": "query",
-        "slug": "get-subscription-based-applications-that-have-not-been-opened-for-the-last-30-days",
-        "resolution": "N/A"
-      },
-      {
-        "name": "Is Gatekeeper enabled on macOS devices?",
-        "query": "SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;",
-        "description": "Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.",
-        "resolution": "To enable Gatekeeper, one the failing device, run the following command in the Terminal app: /usr/sbin/spctl --master-enable",
-        "platforms": "macOS",
-        "contributors": [
-          {
-            "name": "Victor Vrantchan",
-            "handle": "groob",
-            "avatarUrl": "https://avatars.githubusercontent.com/u/1526945?v=4",
-            "htmlUrl": "https://github.com/groob"
-          }
-        ],
-        "kind": "policy",
-        "slug": "is-gatekeeper-enabled-on-mac-os-devices"
-      },
-      {
-        "name": "Is disk encryption enabled on Windows devices?",
-        "query": "SELECT 1 FROM bitlocker_info where protection_status = 1;",
-        "description": "Checks to make sure that device encryption is enabled on Windows devices.",
-        "resolution": "To get additional information, run the following osquery query on the failing device: SELECT * FROM bitlocker_info. In the query results, if protection_status is 2, then the status cannot be determined. If it is 0, it is considered unprotected. Use the additional results (percent_encrypted, conversion_status, etc.) to help narrow down the specific reason why Windows considers the volume unprotected.",
-        "platforms": "Windows",
-        "contributors": [
-          {
-            "name": "Josh Brower",
-            "handle": "defensivedepth",
-            "avatarUrl": "https://avatars.githubusercontent.com/u/954732?v=4",
-            "htmlUrl": "https://github.com/defensivedepth"
-          }
-        ],
-        "kind": "policy",
-        "slug": "is-disk-encryption-enabled-on-windows-devices"
-      },
-      {
-        "name": "Is Filevault enabled on macOS devices?",
-        "query": "SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT “” AND filevault_status = ‘on’ LIMIT 1;",
-        "description": "Checks to make sure that the Filevault feature is enabled on macOS devices.",
-        "resolution": "To enable Filevailt, on the failing device, select System Preferences > Security & Privacy > FileVault > Turn On FileVault.",
-        "platforms": "macOS",
-        "contributors": [
-          {
-            "name": "Victor Vrantchan",
-            "handle": "groob",
-            "avatarUrl": "https://avatars.githubusercontent.com/u/1526945?v=4",
-            "htmlUrl": "https://github.com/groob"
-          }
-        ],
-        "kind": "policy",
-        "slug": "is-filevault-enabled-on-mac-os-devices"
+        "remediation": "N/A"
       }
     ],
     "queryLibraryYmlRepoPath": "docs/01-Using-Fleet/standard-query-library/standard-query-library.yml",

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -34,12 +34,10 @@ module.exports = {
           let query = yamlDocument.toJSON().spec;
           query.kind = yamlDocument.toJSON().kind;
           query.slug = _.kebabCase(query.name);// « unique slug to use for routing to this query's detail page
-          if (false) {
-          // if ((query.resolution !== undefined && !_.isString(query.resolution)) || (query.kind !== 'policy' && _.isString(query.resolution))) { TODO: maybe bring this back later
+          if ((query.resolution !== undefined && !_.isString(query.resolution)) || (query.kind !== 'policy' && _.isString(query.resolution))) {
             // console.log(typeof query.resolution);
             queriesWithProblematicResolutions.push(query);
-          // } else if (query.resolution === undefined) {
-          } else { // « For now set resolution to N/A for all queries until we reinstate checks that are commented out above.  TODO: finish that
+          } else if (query.resolution === undefined) {
             query.resolution = 'N/A';// « We set this to a string here so that the data type is always string.  We use N/A so folks can see there's no remediation and contribute if desired.
           }
 


### PR DESCRIPTION
- Add policies to `standard-query-library.yml`
  - When this PR is merged, the `fleetctl preview` command will not complete successfully with any version other than 4.9.0. In these cases, the `unknown kind: policy` error will occur.
  - When this PR is merged, these policies will be automatically added to preview environments when `fleetctl preview` command is run  
  - When this PR is merged, these policies will be automatically added to fleetdm.com/queries
- Update standard policy templates in the Fleet UI to reflect the changes to the standard policies