### PR TITLE
User Management Page: Flash messages for reseting password and session

### DIFF
--- a/changes/issue-3634-user-actions-flash-messages
+++ b/changes/issue-3634-user-actions-flash-messages
@@ -1,0 +1,1 @@
+* Success and error messages for resetting a user's password and session

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.tsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.tsx
@@ -452,11 +452,7 @@ const UserManagementPage = (): JSX.Element => {
       .requirePasswordReset(user.id, { require: true })
       .then(() => {
         dispatch(
-          renderFlash(
-            "success",
-            "Successfully required a password reset.",
-            usersAPI.requirePasswordReset(user.id, { require: false }) // this is an undo action.
-          )
+          renderFlash("success", "Successfully required a password reset.")
         );
       })
       .catch(() => {

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.tsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.tsx
@@ -435,16 +435,11 @@ const UserManagementPage = (): JSX.Element => {
           dispatch({ type: "LOGOUT_SUCCESS" });
           return;
         }
-        dispatch(
-          renderFlash("success", "Sessions reset for the selected user.")
-        );
+        dispatch(renderFlash("success", "Successfully reset sessions."));
       })
       .catch(() => {
         dispatch(
-          renderFlash(
-            "error",
-            "Could not reset sessions for the selected user. Please try again."
-          )
+          renderFlash("error", "Could not reset sessions. Please try again.")
         );
       })
       .finally(() => {
@@ -459,10 +454,20 @@ const UserManagementPage = (): JSX.Element => {
         dispatch(
           renderFlash(
             "success",
-            "User required to reset password",
+            "Successfully required a password reset.",
             usersAPI.requirePasswordReset(user.id, { require: false }) // this is an undo action.
           )
         );
+      })
+      .catch(() => {
+        dispatch(
+          renderFlash(
+            "error",
+            "Could not require a password reset. Please try again."
+          )
+        );
+      })
+      .finally(() => {
         toggleResetPasswordUserModal();
       });
   };


### PR DESCRIPTION
Cerra #3634 

- Update flash messages wording on user management page according to Figma
- Remove the UNDO action for requiring a password reset

<img width="1339" alt="Screen Shot 2022-01-24 at 11 50 04 AM" src="https://user-images.githubusercontent.com/71795832/150828991-08a32c4a-3348-4f0f-8f41-165d31eb1c58.png">
<img width="1333" alt="Screen Shot 2022-01-24 at 11 49 49 AM" src="https://user-images.githubusercontent.com/71795832/150828994-73c3accc-2d2e-44ac-9321-1cf065829aa8.png">
<img width="1342" alt="Screen Shot 2022-01-24 at 11 49 39 AM" src="https://user-images.githubusercontent.com/71795832/150828995-78a4e73e-0aee-4ceb-bb63-92679f9d1884.png">
<img width="1334" alt="Screen Shot 2022-01-24 at 11 58 34 AM" src="https://user-images.githubusercontent.com/71795832/150828988-db0f7bbd-7371-4a15-af4f-7ea16befa81d.png">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality


