### PR TITLE
"Releasing Fleet" docs: Add instructions for "Performance" section

### DIFF
--- a/changes/3660-hosts-filter-state
+++ b/changes/3660-hosts-filter-state
@@ -1,1 +1,0 @@
-- Modified no hosts message for software and policy filter

--- a/changes/3695-manage-policies-ui
+++ b/changes/3695-manage-policies-ui
@@ -1,2 +1,0 @@
-* Migrate manage policies page to use react-query for policies endpoints
-* Incorporate `available_teams` into app context for UI

--- a/changes/issue-2477-3487-app-settings-config-revamp
+++ b/changes/issue-2477-3487-app-settings-config-revamp
@@ -1,1 +1,0 @@
-* App Settings Page uses new frontend patterns and removes flattening of config object

--- a/changes/issue-3077-block-autocomplete
+++ b/changes/issue-3077-block-autocomplete
@@ -1,1 +1,0 @@
-* Block autocomplete for username and password in SMTP settings

--- a/changes/issue-3473-add-sentry
+++ b/changes/issue-3473-add-sentry
@@ -1,1 +1,0 @@
-* Add config to use Sentry for catching errors in fleet

--- a/changes/issue-3557-browser-extensions
+++ b/changes/issue-3557-browser-extensions
@@ -1,1 +1,0 @@
-* Include Chrome and Firefox extensions in software inventory.

--- a/changes/issue-3697-better-jitter
+++ b/changes/issue-3697-better-jitter
@@ -1,1 +1,0 @@
-* Improve how fleet distributes hosts checking in to balance the load on the server.

--- a/changes/issue-3704-non-empty-packs-queries-policies
+++ b/changes/issue-3704-non-empty-packs-queries-policies
@@ -1,1 +1,0 @@
-* Return 400 when trying to create queries, packs and policies with empty names.

--- a/changes/issue-3707-clean-targets-on-delete
+++ b/changes/issue-3707-clean-targets-on-delete
@@ -1,1 +1,0 @@
-* Cleanup pack targets when deleting hosts, labels, and teams

--- a/changes/issue-3722-team-observer-can-read-global-policies
+++ b/changes/issue-3722-team-observer-can-read-global-policies
@@ -1,1 +1,0 @@
-* Team observers can read global policies (aka inherited policies).

--- a/changes/list-team-policies-team-doesnt-exist
+++ b/changes/list-team-policies-team-doesnt-exist
@@ -1,1 +1,0 @@
-* Return 404 when listing policies of a team that doesn't exist.

--- a/changes/optimize-users-query
+++ b/changes/optimize-users-query
@@ -1,1 +1,0 @@
-* Optimize users detail query to improve performance when running on system with a large number of users (particularly Windows Domain Controllers).

--- a/changes/query-timeout
+++ b/changes/query-timeout
@@ -1,1 +1,0 @@
-* Reduce the default period of the "simple" live query API (`/api/v1/queries/run`) to 25 seconds to remain below load balancer timeouts.

--- a/docs/03-Contributing/05-Releasing-Fleet.md
+++ b/docs/03-Contributing/05-Releasing-Fleet.md
@@ -8,6 +8,10 @@ Note: Please prefix versions with `fleet-v` (eg. `fleet-v4.0.0`) in git tags, He
    tone and syntax of the written language match throughout. `make changelog` will stage all changes
    file entries for deletion with the commit.
 
+Add a "Performance" section below the list of changes. This section should summarize the number of
+hosts the Fleet server can handle, call out if this number has
+changed since the last release, and the list infrastructure used in the load testing environment.
+
 Update the NPM [package.json](../../tools/fleetctl-npm/package.json) with the new version number (do
 not yet `npm publish`). Update the [Helm chart](../../charts/fleet/Chart.yaml) and [values
 file](../../charts/fleet/values.yaml) with the new version number.

--- a/docs/03-Contributing/05-Releasing-Fleet.md
+++ b/docs/03-Contributing/05-Releasing-Fleet.md
@@ -9,8 +9,8 @@ Note: Please prefix versions with `fleet-v` (eg. `fleet-v4.0.0`) in git tags, He
    file entries for deletion with the commit.
 
 Add a "Performance" section below the list of changes. This section should summarize the number of
-hosts the Fleet server can handle, call out if this number has
-changed since the last release, and the list infrastructure used in the load testing environment.
+hosts that the Fleet server can handle, call out if this number has
+changed since the last release, and list the infrastructure used in the load testing environment.
 
 Update the NPM [package.json](../../tools/fleetctl-npm/package.json) with the new version number (do
 not yet `npm publish`). Update the [Helm chart](../../charts/fleet/Chart.yaml) and [values


### PR DESCRIPTION
- Add instructions for adding a "Performance" section to the CHANGELOG when releasing Fleet. This addresses #3709 
- Remove changes files that were carried over from the `release-candidate-4.9.0` branch
