### PR TITLE
Website redirect updates and bug fixes

### DIFF
--- a/website/api/controllers/account/logout.js
+++ b/website/api/controllers/account/logout.js
@@ -41,7 +41,7 @@ actually logged in.  (If they weren't, then this action is just a no-op.)`,
     // > Under the covers, this persists the now-logged-out session back
     // > to the underlying session store.
     if (!this.req.wantsJSON) {
-      throw {redirect: '/'};
+      throw {redirect: '/customers/login'};
     }
 
   }

--- a/website/assets/js/pages/customers/new-license.page.js
+++ b/website/assets/js/pages/customers/new-license.page.js
@@ -83,6 +83,7 @@ parasails.registerPage('new-license', {
     clickResetForm: async function() {
       // When the "X" is clicked...
       this.formErrors = {};
+      this.formData.numberOfHosts = undefined;
       this.showBillingForm = false;
       this.numberOfHostsQuoted = undefined;
       // When the input field has been rendered back into existence, focus it for our friendly user.

--- a/website/assets/js/pages/entrance/new-password.page.js
+++ b/website/assets/js/pages/entrance/new-password.page.js
@@ -45,7 +45,7 @@ parasails.registerPage('new-password', {
       // > (Note that we re-enable the syncing state here.  This is on purpose--
       // > to make sure the spinner stays there until the page navigation finishes.)
       this.syncing = true;
-      window.location = '/';
+      window.location = '/customers/login';
     },
 
   }

--- a/website/assets/js/pages/entrance/new-password.page.js
+++ b/website/assets/js/pages/entrance/new-password.page.js
@@ -15,8 +15,8 @@ parasails.registerPage('new-password', {
 
     // Form rules
     formRules: {
-      password: {required: true},
-      confirmPassword: {required: true, sameAs: 'password'},
+      password: {required: true, minLength: 8},
+      confirmPassword: {required: true, minLength: 8, sameAs: 'password'},
     },
 
     // Server error state for the form

--- a/website/assets/styles/pages/contact.less
+++ b/website/assets/styles/pages/contact.less
@@ -27,6 +27,7 @@
   }
   .selectbox select {
     appearance: none;
+    -webkit-appearance: none;
   }
 
   @media (max-width: 575px) {

--- a/website/views/498.ejs
+++ b/website/views/498.ejs
@@ -3,8 +3,8 @@
     <h1>Sorry, that link is expired, or<br class="d-none d-sm-inline" /><span class="d-inline d-sm-none">&nbsp;</span>it has already been used.</h1>
     <hr/>
     <div>
-      <p>Need further help accessing your account?<br class="d-none d-sm-inline" /><span class="d-inline d-sm-none">&nbsp;</span>Please <a href="/contact">contact support</a> or request a new <a href="/password/forgot">password reset.</a></p>
-      <a class="btn btn-lg btn-outline-dark" href="/password/forgot">Reset password</a>
+      <p>Need further help accessing your account?<br class="d-none d-sm-inline" /><span class="d-inline d-sm-none">&nbsp;</span>Please <a href="/contact">contact support</a> or request a new <a href="/customers/forgot-password">password reset.</a></p>
+      <a class="btn btn-info" href="/customers/forgot-password">Reset password</a>
     </div>
   </div>
 </div>

--- a/website/views/pages/customers/new-license.ejs
+++ b/website/views/pages/customers/new-license.ejs
@@ -29,7 +29,7 @@
                 <strong>Order total</strong>
               </div>
               <div class="ml-auto">
-                <strong>${{!showQuotedPrice ? quotedPrice : formData.numberOfHosts * 12}}.00 /year</strong>
+                <strong>${{(!showQuotedPrice || _.isNaN(formData.numberOfHosts * 12)) ? quotedPrice : formData.numberOfHosts * 12}}.00 /year</strong>
               </div>
             </div>
             <div  :class="[showBillingForm ? 'pt-2' : '' ]" v-if="!showBillingForm">

--- a/website/views/pages/entrance/new-password.ejs
+++ b/website/views/pages/entrance/new-password.ejs
@@ -1,22 +1,27 @@
 <div id="new-password" v-cloak>
   <div style="max-width: 450px" class="container-fluid pt-5 pb-5 mx-auto">
-      <h1 class="text-left">Change your password?</h1>
+    <h1 class="text-left">Change your password?</h1>
+    <div purpose="customer-portal-form">
       <div class="card card-body order-first">
         <ajax-form action="updatePasswordAndLogin" :syncing.sync="syncing" :cloud-error.sync="cloudError" :form-data="formData" :form-rules="formRules" :form-errors.sync="formErrors" @submitted="submittedForm()">
           <div class="form-group">
             <label for="password">New password</label>
             <input class="form-control" id="password" name="password" type="password"  :class="[formErrors.password ? 'is-invalid' : '']" v-model.trim="formData.password" placeholder="••••••••" autocomplete="new-password" focus-first>
-            <div class="invalid-feedback" v-if="formErrors.password">Please enter a password.</div>
+            <div class="invalid-feedback" v-if="formErrors.password === 'required'">Please enter a password.</div>
+            <div class="invalid-feedback" v-if="formErrors.password === 'minLength'">Password too short.</div>
+            <p class="mt-2"> Minimum length is 8 characters</p>
           </div>
           <div class="form-group">
             <label for="confirm-password">Confirm password</label>
             <input class="form-control" id="confirm-password" name="confirm-password" type="password"  :class="[formErrors.confirmPassword ? 'is-invalid' : '']" v-model.trim="formData.confirmPassword" placeholder="••••••••" autocomplete="new-password">
+            <div class="invalid-feedback" v-if="formErrors.password === 'minLength'">Password too short.</div>
             <div class="invalid-feedback" v-if="formErrors.confirmPassword">Your new password and confirmation do not match.</div>
           </div>
           <cloud-error v-if="cloudError"></cloud-error>
           <ajax-button purpose="submit-button" spinner="true" type="submit" :syncing="syncing" class="btn btn-info btn-lg btn-block">Submit</ajax-button>
         </ajax-form>
       </div>
+    </div>
   </div>
 </div>
 <%- /* Expose locals as `window.SAILS_LOCALS` :: */ exposeLocalsToBrowser() %>


### PR DESCRIPTION
Changes:
closes #3736 

- Changed the behavior of `logout.js` to redirect users to the customer login screen instead of the Fleet homepage.
- Changed the behavior of the quote generator to clear the quote form input when you click the X button.
- Changed the redirect when a user resets their password.
- Fixed new-password page's styles.
- Updated the links and button styles in the "Unauthorized" response.
- Fixed the double dropdown contact form input.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
