### PR TITLE
Schedules Page: Remove redux, fix buggy API calls

### DIFF
--- a/changes/issue-3854-fix-schedules-api-calls
+++ b/changes/issue-3854-fix-schedules-api-calls
@@ -1,0 +1,2 @@
+* Bug fix: Team schedules properly render
+* Rplace redux in global and team schedules with new patterns

--- a/frontend/interfaces/global_scheduled_query.ts
+++ b/frontend/interfaces/global_scheduled_query.ts
@@ -41,3 +41,7 @@ export interface IGlobalScheduledQuery {
   denylist?: boolean;
   stats?: IScheduledQueryStats;
 }
+
+export interface ILoadAllGlobalScheduledQueriesResponse {
+  global_schedule: IGlobalScheduledQuery[];
+}

--- a/frontend/interfaces/team_scheduled_query.ts
+++ b/frontend/interfaces/team_scheduled_query.ts
@@ -41,3 +41,7 @@ export interface ITeamScheduledQuery {
   denylist?: boolean;
   stats?: IScheduledQueryStats;
 }
+
+export interface ILoadAllTeamScheduledQueriesResponse {
+  scheduled: ITeamScheduledQuery[];
+}

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -48,7 +48,9 @@ const renderTable = (
   allScheduledQueriesError: Error | null,
   toggleScheduleEditorModal: () => void,
   isOnGlobalTeam: boolean,
-  selectedTeamData: ITeam | undefined
+  selectedTeamData: ITeam | undefined,
+  isLoadingGlobalScheduledQueries: boolean,
+  isLoadingTeamScheduledQueries: boolean
 ): JSX.Element => {
   return allScheduledQueriesError ? (
     <TableDataError />
@@ -60,6 +62,8 @@ const renderTable = (
       toggleScheduleEditorModal={toggleScheduleEditorModal}
       isOnGlobalTeam={isOnGlobalTeam}
       selectedTeamData={selectedTeamData}
+      loadingInheritedQueriesTableData={isLoadingGlobalScheduledQueries}
+      loadingTeamQueriesTableData={isLoadingTeamScheduledQueries}
     />
   );
 };
@@ -466,7 +470,9 @@ const ManageSchedulePage = ({
               allScheduledQueriesError,
               toggleScheduleEditorModal,
               isOnGlobalTeam || false,
-              selectedTeamData
+              selectedTeamData,
+              isLoadingGlobalScheduledQueries,
+              isLoadingTeamScheduledQueries
             )
           )}
         </div>

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -4,7 +4,7 @@ import React, { useState, useCallback, useContext } from "react";
 import { useQuery } from "react-query";
 import { useDispatch } from "react-redux";
 import { AppContext } from "context/app";
-import { push } from "react-router-redux";
+import { InjectedRouter } from "react-router/lib/Router";
 import { find } from "lodash";
 
 // @ts-ignore

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -88,6 +88,7 @@ interface ITeamSchedulesPageProps {
   params: {
     team_id: string;
   };
+  router: InjectedRouter; // v3
 }
 interface IFormData {
   interval: number;
@@ -103,10 +104,11 @@ interface IFormData {
 
 const ManageSchedulePage = ({
   params: { team_id },
+  router,
 }: ITeamSchedulesPageProps): JSX.Element => {
   const dispatch = useDispatch();
   const { MANAGE_PACKS, MANAGE_SCHEDULE, MANAGE_TEAM_SCHEDULE } = paths;
-  const handleAdvanced = () => dispatch(push(MANAGE_PACKS));
+  const handleAdvanced = () => router.push(MANAGE_PACKS);
 
   const {
     availableTeams,
@@ -216,9 +218,9 @@ const ManageSchedulePage = ({
 
   const handleTeamSelect = (teamId: number) => {
     if (teamId) {
-      dispatch(push(MANAGE_TEAM_SCHEDULE(teamId)));
+      router.push(MANAGE_TEAM_SCHEDULE(teamId));
     } else {
-      dispatch(push(MANAGE_SCHEDULE));
+      router.push(MANAGE_SCHEDULE);
     }
     const selectedTeam = find(teams, ["id", teamId]);
     setCurrentTeam(selectedTeam);

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -83,6 +83,8 @@ const renderAllTeamsTable = (
         allScheduledQueriesList={allTeamsScheduledQueriesList}
         isOnGlobalTeam={isOnGlobalTeam}
         selectedTeamData={selectedTeamData}
+        loadingInheritedQueriesTableData={isLoadingGlobalScheduledQueries}
+        loadingTeamQueriesTableData={isLoadingTeamScheduledQueries}
       />
     </div>
   );

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -72,7 +72,9 @@ const renderAllTeamsTable = (
   allTeamsScheduledQueriesList: IGlobalScheduledQuery[],
   allTeamsScheduledQueriesError: Error | null,
   isOnGlobalTeam: boolean,
-  selectedTeamData: ITeam | undefined
+  selectedTeamData: ITeam | undefined,
+  isLoadingGlobalScheduledQueries: boolean,
+  isLoadingTeamScheduledQueries: boolean
 ): JSX.Element => {
   return allTeamsScheduledQueriesError ? (
     <TableDataError />
@@ -513,7 +515,9 @@ const ManageSchedulePage = ({
             inheritedScheduledQueriesList,
             inheritedScheduledQueriesError,
             isOnGlobalTeam || false,
-            selectedTeamData
+            selectedTeamData,
+            isLoadingGlobalScheduledQueries,
+            isLoadingTeamScheduledQueries
           )}
         {showScheduleEditorModal && (
           <ScheduleEditorModal

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -204,6 +204,7 @@ const ManageSchedulePage = ({
     select: (data) => data.global_schedule,
   });
 
+  console.log("teamId", teamId);
   const {
     data: teamScheduledQueries,
     error: teamScheduledQueriesError,
@@ -233,6 +234,13 @@ const ManageSchedulePage = ({
     selectedTeamId = team_id ? parseInt(team_id, 10) : 0;
   }
 
+  const refetchScheduledQueries = () => {
+    refetchGlobalScheduledQueries();
+    if (teamId !== 0) {
+      refetchTeamScheduledQueries();
+    }
+  };
+
   const handleTeamSelect = (teamId: number) => {
     if (teamId) {
       dispatch(push(MANAGE_TEAM_SCHEDULE(teamId)));
@@ -246,15 +254,6 @@ const ManageSchedulePage = ({
   if (!isOnGlobalTeam && !selectedTeamId && teams) {
     handleTeamSelect(teams[0].id);
   }
-
-  const allScheduledQueries = useSelector((state: IRootState) => {
-    if (selectedTeamId) {
-      return state.entities.team_scheduled_queries;
-    }
-    return state.entities.global_scheduled_queries;
-  });
-
-  console.log("allScheduledQueries", allScheduledQueries);
 
   const allScheduledQueriesList =
     (teamId ? teamScheduledQueries : globalScheduledQueries) || [];
@@ -322,11 +321,9 @@ const ManageSchedulePage = ({
 
   const onRemoveScheduledQuerySubmit = useCallback(() => {
     const promises = selectedQueryIds.map((id: number) => {
-      return dispatch(
-        selectedTeamId
-          ? teamScheduledQueryActions.destroy(selectedTeamId, id)
-          : globalScheduledQueryActions.destroy({ id })
-      );
+      selectedTeamId
+        ? teamScheduledQueriesAPI.destroy(selectedTeamId, id)
+        : globalScheduledQueriesAPI.destroy({ id });
     });
     const queryOrQueries = selectedQueryIds.length === 1 ? "query" : "queries";
     return Promise.all(promises)
@@ -338,11 +335,7 @@ const ManageSchedulePage = ({
           )
         );
         toggleRemoveScheduledQueryModal();
-        dispatch(
-          selectedTeamId
-            ? teamScheduledQueryActions.loadAll(selectedTeamId)
-            : globalScheduledQueryActions.loadAll()
-        );
+        refetchScheduledQueries();
       })
       .catch(() => {
         dispatch(
@@ -379,11 +372,8 @@ const ManageSchedulePage = ({
                 `Successfully updated ${formData.name} in the schedule.`
               )
             );
-            dispatch(
-              selectedTeamId
-                ? teamScheduledQueryActions.loadAll(selectedTeamId)
-                : globalScheduledQueryActions.loadAll()
-            );
+            console.log("editQuery onAddScheduledQuerySubmit firing!!!");
+            refetchScheduledQueries();
           })
           .catch(() => {
             dispatch(
@@ -406,11 +396,8 @@ const ManageSchedulePage = ({
                 `Successfully added ${formData.name} to the schedule.`
               )
             );
-            dispatch(
-              selectedTeamId
-                ? teamScheduledQueryActions.loadAll(selectedTeamId)
-                : globalScheduledQueryActions.loadAll()
-            );
+            console.log("onAddScheduledQuerySubmit added query firing!!!");
+            refetchScheduledQueries();
           })
           .catch(() => {
             dispatch(

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -1,6 +1,6 @@
 /* Conditionally renders global schedule and team schedules */
 
-import React, { useState, useCallback, useEffect, useContext } from "react";
+import React, { useState, useCallback, useContext } from "react";
 import { useQuery } from "react-query";
 import { useDispatch } from "react-redux";
 import { AppContext } from "context/app";
@@ -120,8 +120,6 @@ const ManageSchedulePage = ({
     setCurrentTeam,
   } = useContext(AppContext);
 
-  const teamId = parseInt(team_id, 10) || 0;
-
   const filterAndSortTeamOptions = (allTeams: ITeam[], userTeams: ITeam[]) => {
     const filteredSortedTeams = allTeams
       .sort((teamA: ITeam, teamB: ITeam) =>
@@ -183,7 +181,6 @@ const ManageSchedulePage = ({
     select: (data) => data.global_schedule,
   });
 
-  console.log("teamId", teamId);
   const {
     data: teamScheduledQueries,
     error: teamScheduledQueriesError,
@@ -194,10 +191,10 @@ const ManageSchedulePage = ({
     Error,
     ITeamScheduledQuery[]
   >(
-    ["teamScheduledQueries", teamId],
-    () => teamScheduledQueriesAPI.loadAll(teamId),
+    ["teamScheduledQueries", team_id],
+    () => teamScheduledQueriesAPI.loadAll(parseInt(team_id, 10)),
     {
-      enabled: !!availableTeams && isPremiumTier && !!teamId,
+      enabled: !!availableTeams && isPremiumTier && !!team_id,
       select: (data) => data.scheduled,
     }
   );
@@ -212,7 +209,7 @@ const ManageSchedulePage = ({
 
   const refetchScheduledQueries = () => {
     refetchGlobalScheduledQueries();
-    if (teamId !== 0) {
+    if (selectedTeamId !== 0) {
       refetchTeamScheduledQueries();
     }
   };
@@ -232,8 +229,8 @@ const ManageSchedulePage = ({
   }
 
   const allScheduledQueriesList =
-    (teamId ? teamScheduledQueries : globalScheduledQueries) || [];
-  const allScheduledQueriesError = teamId
+    (team_id ? teamScheduledQueries : globalScheduledQueries) || [];
+  const allScheduledQueriesError = team_id
     ? teamScheduledQueriesError
     : globalScheduledQueriesError;
 
@@ -297,7 +294,7 @@ const ManageSchedulePage = ({
 
   const onRemoveScheduledQuerySubmit = useCallback(() => {
     const promises = selectedQueryIds.map((id: number) => {
-      selectedTeamId
+      return selectedTeamId
         ? teamScheduledQueriesAPI.destroy(selectedTeamId, id)
         : globalScheduledQueriesAPI.destroy({ id });
     });

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -343,11 +343,11 @@ const ManageSchedulePage = ({
       if (editQuery) {
         const updatedAttributes = deepDifference(formData, editQuery);
 
-        const edit = selectedTeamId
+        const editResponse = selectedTeamId
           ? teamScheduledQueriesAPI.update(editQuery, updatedAttributes)
           : globalScheduledQueriesAPI.update(editQuery, updatedAttributes);
 
-        edit
+        editResponse
           .then(() => {
             dispatch(
               renderFlash(
@@ -366,11 +366,11 @@ const ManageSchedulePage = ({
             );
           });
       } else {
-        const create = selectedTeamId
+        const createResponse = selectedTeamId
           ? teamScheduledQueriesAPI.create({ ...formData })
           : globalScheduledQueriesAPI.create({ ...formData });
 
-        create
+        createResponse
           .then(() => {
             dispatch(
               renderFlash(

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
@@ -4,8 +4,6 @@ import React, { useState, useCallback, useEffect } from "react";
 // @ts-ignore
 import Fleet from "fleet";
 import { pull } from "lodash";
-// @ts-ignore
-import FleetIcon from "components/icons/FleetIcon";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 import InfoBanner from "components/InfoBanner/InfoBanner";

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleListWrapper.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleListWrapper.tsx
@@ -1,8 +1,8 @@
 /**
  * Component when there is an error retrieving schedule set up in fleet
  */
-import React, { useCallback } from "react";
-import { useSelector, useDispatch } from "react-redux";
+import React from "react";
+import { useDispatch } from "react-redux";
 import { push } from "react-router-redux";
 import paths from "router/paths";
 
@@ -10,8 +10,6 @@ import Button from "components/buttons/Button";
 import { IGlobalScheduledQuery } from "interfaces/global_scheduled_query";
 import { ITeamScheduledQuery } from "interfaces/team_scheduled_query";
 import { ITeam } from "interfaces/team";
-// @ts-ignore
-import globalScheduledQueryActions from "redux/nodes/entities/global_scheduled_queries/actions";
 
 import TableContainer from "components/TableContainer";
 import {
@@ -40,6 +38,8 @@ interface IScheduleListWrapperProps {
   inheritedQueries?: boolean;
   isOnGlobalTeam: boolean;
   selectedTeamData: ITeam | undefined;
+  loadingInheritedQueriesTableData: boolean;
+  loadingTeamQueriesTableData: boolean;
 }
 interface IRootState {
   entities: {
@@ -62,6 +62,8 @@ const ScheduleListWrapper = ({
   inheritedQueries,
   isOnGlobalTeam,
   selectedTeamData,
+  loadingInheritedQueriesTableData,
+  loadingTeamQueriesTableData,
 }: IScheduleListWrapperProps): JSX.Element => {
   const dispatch = useDispatch();
   const { MANAGE_PACKS, MANAGE_HOSTS } = paths;
@@ -153,31 +155,9 @@ const ScheduleListWrapper = ({
   };
 
   const tableHeaders = generateTableHeaders(onActionSelection);
-  const loadingTableData = useSelector((state: IRootState) => {
-    if (selectedTeamData?.id) {
-      return state.entities.team_scheduled_queries.isLoading;
-    }
-    return state.entities.global_scheduled_queries.isLoading;
-  });
-
-  // Search functionality disabled, needed if enabled
-  const onQueryChange = useCallback(
-    (queryData) => {
-      const { pageIndex, pageSize, searchQuery } = queryData;
-      dispatch(
-        globalScheduledQueryActions.loadAll({
-          page: pageIndex,
-          perPage: pageSize,
-          globalFilter: searchQuery,
-        })
-      );
-    },
-    [dispatch]
-  );
-
-  const loadingInheritedQueriesTableData = useSelector((state: IRootState) => {
-    return state.entities.global_scheduled_queries.isLoading;
-  });
+  const loadingTableData = selectedTeamData?.id
+    ? loadingTeamQueriesTableData
+    : loadingInheritedQueriesTableData;
 
   if (inheritedQueries) {
     const inheritedQueriesTableHeaders = generateInheritedQueriesTableHeaders();
@@ -213,7 +193,6 @@ const ScheduleListWrapper = ({
         defaultSortDirection={"desc"}
         showMarkAllPages={false}
         isAllPagesSelected={false}
-        onQueryChange={onQueryChange}
         inputPlaceHolder="Search"
         searchable={false}
         disablePagination

--- a/frontend/services/entities/global_scheduled_queries.ts
+++ b/frontend/services/entities/global_scheduled_queries.ts
@@ -1,0 +1,63 @@
+/* eslint-disable  @typescript-eslint/explicit-module-boundary-types */
+import sendRequest from "services";
+import { omit } from "lodash";
+
+import endpoints from "fleet/endpoints";
+import {
+  // IPackQueryFormData,
+  IGlobalScheduledQuery,
+} from "interfaces/global_scheduled_query";
+import helpers from "fleet/helpers";
+
+export default {
+  create: (formData: any) => {
+    const { GLOBAL_SCHEDULE } = endpoints;
+
+    const {
+      interval,
+      logging_type: loggingType,
+      platform,
+      query_id: queryID,
+      shard,
+      version,
+    } = formData;
+
+    const removed = loggingType === "differential";
+    const snapshot = loggingType === "snapshot";
+
+    const params = {
+      interval: Number(interval),
+      platform,
+      query_id: Number(queryID),
+      removed,
+      snapshot,
+      shard: Number(shard),
+      version,
+    };
+
+    return sendRequest("POST", GLOBAL_SCHEDULE, params);
+  },
+  destroy: ({ id }: { id: number }) => {
+    const { GLOBAL_SCHEDULE } = endpoints;
+    const path = `${GLOBAL_SCHEDULE}/${id}`;
+
+    return sendRequest("DELETE", path);
+  },
+  loadAll: () => {
+    const { GLOBAL_SCHEDULE } = endpoints;
+    const path = GLOBAL_SCHEDULE;
+
+    console.log("global scheduled queries loadAll called");
+    return sendRequest("GET", path);
+  },
+  update: (
+    globalScheduledQuery: IGlobalScheduledQuery,
+    updatedAttributes: any
+  ) => {
+    const { GLOBAL_SCHEDULE } = endpoints;
+    const path = `${GLOBAL_SCHEDULE}/${globalScheduledQuery.id}`;
+    const params = helpers.formatScheduledQueryForServer(updatedAttributes);
+
+    return sendRequest("PATCH", path, params);
+  },
+};

--- a/frontend/services/entities/global_scheduled_queries.ts
+++ b/frontend/services/entities/global_scheduled_queries.ts
@@ -47,7 +47,6 @@ export default {
     const { GLOBAL_SCHEDULE } = endpoints;
     const path = GLOBAL_SCHEDULE;
 
-    console.log("global scheduled queries loadAll called");
     return sendRequest("GET", path);
   },
   update: (

--- a/frontend/services/entities/global_scheduled_queries.ts
+++ b/frontend/services/entities/global_scheduled_queries.ts
@@ -3,10 +3,7 @@ import sendRequest from "services";
 import { omit } from "lodash";
 
 import endpoints from "fleet/endpoints";
-import {
-  // IPackQueryFormData,
-  IGlobalScheduledQuery,
-} from "interfaces/global_scheduled_query";
+import { IGlobalScheduledQuery } from "interfaces/global_scheduled_query";
 import helpers from "fleet/helpers";
 
 export default {

--- a/frontend/services/entities/team_scheduled_queries.ts
+++ b/frontend/services/entities/team_scheduled_queries.ts
@@ -1,0 +1,62 @@
+/* eslint-disable  @typescript-eslint/explicit-module-boundary-types */
+import sendRequest from "services";
+import { omit } from "lodash";
+
+import endpoints from "fleet/endpoints";
+import {
+  // IPackQueryFormData,
+  ITeamScheduledQuery,
+} from "interfaces/team_scheduled_query";
+import helpers from "fleet/helpers";
+
+export default {
+  create: (formData: any) => {
+    const { TEAM_SCHEDULE } = endpoints;
+
+    const {
+      interval,
+      logging_type: loggingType,
+      platform,
+      query_id: queryID,
+      shard,
+      version,
+      team_id: teamID,
+    } = formData;
+
+    const removed = loggingType === "differential";
+    const snapshot = loggingType === "snapshot";
+
+    const params = {
+      interval: Number(interval),
+      platform,
+      query_id: Number(queryID),
+      removed,
+      snapshot,
+      shard: Number(shard),
+      version,
+      team_id: Number(teamID),
+    };
+
+    return sendRequest("POST", TEAM_SCHEDULE(teamID), params);
+  },
+  destroy: (teamID: number, queryID: number) => {
+    const { TEAM_SCHEDULE } = endpoints;
+    const path = `${TEAM_SCHEDULE(teamID)}/${queryID}`;
+
+    return sendRequest("DELETE", path);
+  },
+  loadAll: (teamID: number) => {
+    const { TEAM_SCHEDULE } = endpoints;
+    const path = TEAM_SCHEDULE(teamID);
+
+    return sendRequest("GET", path);
+  },
+  update: (teamScheduledQuery: ITeamScheduledQuery, updatedAttributes: any) => {
+    const { team_id } = updatedAttributes;
+    const { TEAM_SCHEDULE } = endpoints;
+    const path = `${TEAM_SCHEDULE(team_id)}/${teamScheduledQuery.id}`;
+    const params = helpers.formatScheduledQueryForServer(updatedAttributes);
+
+    return sendRequest("PATCH", path, params);
+  },
+};

--- a/frontend/services/entities/team_scheduled_queries.ts
+++ b/frontend/services/entities/team_scheduled_queries.ts
@@ -3,10 +3,7 @@ import sendRequest from "services";
 import { omit } from "lodash";
 
 import endpoints from "fleet/endpoints";
-import {
-  // IPackQueryFormData,
-  ITeamScheduledQuery,
-} from "interfaces/team_scheduled_query";
+import { ITeamScheduledQuery } from "interfaces/team_scheduled_query";
 import helpers from "fleet/helpers";
 
 export default {


### PR DESCRIPTION
Cerra #3854 

Addresses some of #3492 (remove redux) and #3516 (buggy button based on redux not using isLoading)

- Fixes team scheduled queries being correctly displayed
- Create `global_scheduled_queries.ts` and all necessary API calls to remove from redux
- Create `team_scheduled_queries.ts` and all necessary API calls to remove from redux
- Refactor `ManageSchedulePage.tsx` to remove all redux calls

# Checklist for submitter

Tested Global schedules:
- [x] Create
- [x] Update
- [x] Remove
- [x] Get
- [x] Refetch

Tested Team schedules:
- [x] Create
- [x] Update
- [x] Remove
- [x] Get
- [x] Refetch

Tested:
- [x] Toggling between pages
- [x] Inherited queries
 
If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
