### PR TITLE
Cleanup unused software after calculating the count of hosts

### DIFF
--- a/changes/issue-3086-cleanup-unused-software
+++ b/changes/issue-3086-cleanup-unused-software
@@ -1,0 +1,1 @@
+* Cleanup unused `software` entries after having calculated the count of hosts

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -56,9 +56,8 @@ type RedisConfig struct {
 	TLSCA                     string        `yaml:"tls_ca"`
 	TLSServerName             string        `yaml:"tls_server_name"`
 	TLSHandshakeTimeout       time.Duration `yaml:"tls_handshake_timeout"`
-	// TODO(mna): should we allow insecure skip verify option?
-	MaxIdleConns int `yaml:"max_idle_conns"`
-	MaxOpenConns int `yaml:"max_open_conns"`
+	MaxIdleConns              int           `yaml:"max_idle_conns"`
+	MaxOpenConns              int           `yaml:"max_open_conns"`
 	// this config is an int on MysqlConfig, but it should be a time.Duration.
 	ConnMaxLifetime time.Duration `yaml:"conn_max_lifetime"`
 	IdleTimeout     time.Duration `yaml:"idle_timeout"`

--- a/server/datastore/mysql/software_bench_test.go
+++ b/server/datastore/mysql/software_bench_test.go
@@ -42,6 +42,21 @@ func BenchmarkCalculateHostsPerSoftware(b *testing.B) {
 			}
 		})
 	})
+	b.Run("CalculateHostsPerSoftware", func(b *testing.B) {
+		for _, c := range cases {
+			b.Run(fmt.Sprintf("%d:%d", c.hs, c.sws), func(b *testing.B) {
+				ctx := context.Background()
+				ds := CreateMySQLDS(b)
+				generateHostsWithSoftware(b, ds, c.hs, c.sws)
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					require.NoError(b, ds.CalculateHostsPerSoftware(ctx, ts))
+				}
+				checkCountsAgg(b, ds, c.hs, c.sws)
+			})
+		}
+	})
 }
 
 func checkCountsAgg(b *testing.B, ds *Datastore, hs, sws int) {


### PR DESCRIPTION
Follow-up to #3873 , as discussed in this comment: https://github.com/fleetdm/fleet/pull/3873#discussion_r792062805

This cleans up unused `software` entries right after computing the host counts, as any software without a host count > 0 is now unused.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [ ] ~~Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
- [ ] ~~Documented any permissions changes~~
- [x] Added/updated tests
- [ ] ~~Manual QA for all new/changed functionality~~
