### PR TITLE
Team Details Page: Add new CTA buttons to e2e team flow

### DIFF
--- a/cypress/integration/premium/teamflow.spec.ts
+++ b/cypress/integration/premium/teamflow.spec.ts
@@ -43,28 +43,30 @@ describe("Teams flow (seeded)", () => {
       cy.loginWithCySession();
       cy.visit("/settings/teams");
     });
-    it("edits an existing team", () => {
+    it("edit name of an existing team", () => {
       cy.getAttached(".table-container").within(() => {
-        cy.contains("Apples").click({ force: true });
+        cy.contains("Apples");
+        cy.getAttached("tbody").within(() => {
+          cy.getAttached("tr")
+            .first()
+            .within(() => {
+              cy.getAttached(".Select-arrow-zone").click();
+              cy.findByText(/edit/i).click({ force: true });
+            });
+        });
       });
-      cy.findByText(/agent options/i).click();
-      cy.contains(".ace_content", "config:");
-      cy.get(".ace_text-input")
-        .first()
-        .focus()
-        .type("{selectall}{backspace}config:\n  options:");
-
-      cy.findByRole("button", { name: /save options/i }).click();
-
-      cy.contains("span", /successfully saved/i).should("exist");
-      cy.visit("/settings/teams/1/options");
-
-      cy.contains(/config:/i).should("be.visible");
-      cy.contains(/options:/i).should("be.visible");
+      cy.getAttached(".edit-team-modal").within(() => {
+        cy.findByLabelText(/team name/i)
+          .clear()
+          .type("Bananas");
+        cy.findByRole("button", { name: /save/i }).click();
+      });
+      cy.findByText(/successfully edited/i).should("be.visible");
+      cy.findByText(/apples/i).should("not.exist");
     });
     it("deletes an existing team", () => {
       cy.getAttached(".table-container").within(() => {
-        cy.contains("Apples");
+        cy.contains("Bananas");
         cy.getAttached("tbody").within(() => {
           cy.getAttached("tr")
             .first()
@@ -78,7 +80,7 @@ describe("Teams flow (seeded)", () => {
         cy.findByRole("button", { name: /delete/i }).click();
       });
       cy.findByText(/successfully deleted/i).should("be.visible");
-      cy.findByText(/apples/i).should("not.exist");
+      cy.findByText(/bananas/i).should("not.exist");
     });
   });
   // describe("Manage schedules page", () => {
@@ -91,4 +93,49 @@ describe("Teams flow (seeded)", () => {
   //     // TODO: Unable to add tests because "Schedule a query" button detattaches even when using `getAttached`
   //   });
   // });
+  describe("Team details page", () => {
+    beforeEach(() => {
+      cy.loginWithCySession();
+      cy.visit("/settings/teams");
+      cy.getAttached(".table-container").within(() => {
+        cy.contains("Oranges").click({ force: true });
+      });
+    });
+    it("allows to add new enroll secret to team", () => {
+      cy.getAttached(".team-details__team-actions")
+        .contains("button", /manage enroll secret/i)
+        .click();
+      cy.getAttached(".enroll-secret-modal__add-secret")
+        .contains("button", /add secret/i)
+        .click();
+      cy.getAttached(".secret-editor-modal__button-wrap")
+        .contains("button", /save/i)
+        .click();
+      cy.getAttached(".enroll-secret-modal__button-wrap")
+        .contains("button", /done/i)
+        .click();
+    });
+    it("allows to see and click generate installer", () => {
+      cy.getAttached(".team-details__team-actions")
+        .contains("button", /generate installer/i)
+        .click();
+      cy.getAttached(".modal__content").contains("button", /done/i).click();
+    });
+    it("edit agent options an existing team", () => {
+      cy.findByText(/agent options/i).click();
+      cy.contains(".ace_content", "config:");
+      cy.get(".ace_text-input")
+        .first()
+        .focus()
+        .type("{selectall}{backspace}config:\n  options:");
+
+      cy.findByRole("button", { name: /save options/i }).click();
+
+      cy.contains("span", /successfully saved/i).should("exist");
+      cy.visit("/settings/teams/2/options");
+
+      cy.contains(/config:/i).should("be.visible");
+      cy.contains(/options:/i).should("be.visible");
+    });
+  });
 });

--- a/cypress/integration/premium/teamflow.spec.ts
+++ b/cypress/integration/premium/teamflow.spec.ts
@@ -43,7 +43,7 @@ describe("Teams flow (seeded)", () => {
       cy.loginWithCySession();
       cy.visit("/settings/teams");
     });
-    it("edit name of an existing team", () => {
+    it("edits name of an existing team", () => {
       cy.getAttached(".table-container").within(() => {
         cy.contains("Apples");
         cy.getAttached("tbody").within(() => {
@@ -121,10 +121,10 @@ describe("Teams flow (seeded)", () => {
         .click();
       cy.getAttached(".modal__content").contains("button", /done/i).click();
     });
-    it("edit agent options of an existing team", () => {
+    it("edits agent options of an existing team", () => {
       cy.findByText(/agent options/i).click();
       cy.contains(".ace_content", "config:");
-      cy.get(".ace_text-input")
+      cy.getAttached(".ace_text-input")
         .first()
         .focus()
         .type("{selectall}{backspace}config:\n  options:");

--- a/cypress/integration/premium/teamflow.spec.ts
+++ b/cypress/integration/premium/teamflow.spec.ts
@@ -121,7 +121,7 @@ describe("Teams flow (seeded)", () => {
         .click();
       cy.getAttached(".modal__content").contains("button", /done/i).click();
     });
-    it("edit agent options an existing team", () => {
+    it("edit agent options of an existing team", () => {
       cy.findByText(/agent options/i).click();
       cy.contains(".ace_content", "config:");
       cy.get(".ace_text-input")


### PR DESCRIPTION
- E2e test for feature work #3029 
- Built upon E2e work merged for #3518 

Added:
- team details page allows to add new enroll secret to team
- team details pageallows to see and click generate installer
- team settings page edit name of an existing team

Reorganized:
- team settings page edit an existing team now organized as team details page edit agent options of an existing team 

<img width="643" alt="Screen Shot 2022-01-26 at 11 50 56 AM" src="https://user-images.githubusercontent.com/71795832/151209166-a934ae1e-6631-4b61-bafc-6df16761e46e.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
