### PR TITLE
renamed growth section in handbook

### DIFF
--- a/handbook/README.md
+++ b/handbook/README.md
@@ -40,13 +40,13 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [Feature flags](./product.md#feature-flags)
 
-### Growth
+### Brand
 
-[Website](./growth.md#website)
+[Website](./brand.md#website)
 
-[Communicating as Fleet](./growth.md#communicating-as-fleet)
+[Communicating as Fleet](./brand.md#communicating-as-fleet)
 
-[Voice and grammar guidelines](./growth.md#voice-and-grammar-guidelines)
+[Voice and grammar guidelines](./brand.md#voice-and-grammar-guidelines)
 
 ### Customers
 
@@ -60,7 +60,7 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [Posting on social media as Fleet](./community.md#posting-on-social-media-as-fleet)
 
-[Promoting blog posts on social media](./growth.md#promoting-blog-posts-on-social-media)
+[Promoting blog posts on social media](./community.md#promoting-blog-posts-on-social-media)
 
 [Press releases](./community.md#press-releases)
 

--- a/handbook/brand.md
+++ b/handbook/brand.md
@@ -1,4 +1,4 @@
-# Growth
+# Brand
 
 ## Fleet website
 

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -317,7 +317,7 @@ with customers and users.
 
 ### Blog post
 
-The product team is responsible for providing the [growth team](./growth.md) with necessary information for writing
+The product team is responsible for providing the [growth team](./brand.md) with necessary information for writing
 the release blog post. This is accomplished by filing a release blog post issue and adding
 the issue to the growth board on GitHub.
 

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -169,6 +169,7 @@ module.exports.routes = {
   'GET /try-fleet':                  '/get-started',
   'GET /docs/deploying/fleet-public-load-testing': '/docs/deploying/load-testing',
   'GET /handbook/customer-experience': '/handbook/customers',
+  'GET /handbook/growth': '/handbook/brand',
 
 
 


### PR DESCRIPTION
Renamed "Growth" section to "Brand".

# Checklist for submitter

- [x] Manual QA for all new/changed functionality
