### PR TITLE
Software vulnerability automation modal

### DIFF
--- a/changes/issue-3762-software-vulnerability-webhook-modal
+++ b/changes/issue-3762-software-vulnerability-webhook-modal
@@ -1,0 +1,1 @@
+* Ability in UI to set a software vulnerability automation on Software page

--- a/cypress/integration/free/admin.spec.ts
+++ b/cypress/integration/free/admin.spec.ts
@@ -14,74 +14,83 @@ describe(
       cy.seedPolicies();
       cy.addDockerHost();
     });
-
     after(() => {
       cy.logout();
       cy.stopDockerHost();
     });
 
-    describe("Mange hosts tests", () => {
+    describe("Dashboard and navigation", () => {
+      beforeEach(() => cy.visit("/dashboard"));
+      it("displays intended global admin dashboard", () => {
+        cy.getAttached(".homepage__wrapper").within(() => {
+          cy.findByText(/all teams/i).should("exist");
+          cy.getAttached(".hosts-summary").should("exist");
+          cy.getAttached(".hosts-status").should("exist");
+          cy.getAttached(".home-software").should("exist");
+          cy.getAttached(".activity-feed").should("exist");
+        });
+      });
+      it("displays intended global admin top navigation", () => {
+        cy.getAttached(".site-nav-container").within(() => {
+          cy.findByText(/hosts/i).should("exist");
+          cy.findByText(/software/i).should("exist");
+          cy.findByText(/queries/i).should("exist");
+          cy.findByText(/schedule/i).should("exist");
+          cy.findByText(/policies/i).should("exist");
+          cy.getAttached(".user-menu").click();
+          cy.findByText(/settings/i).click();
+        });
+        cy.getAttached(".react-tabs__tab--selected").within(() => {
+          cy.findByText(/organization/i).should("exist");
+        });
+        cy.getAttached(".site-nav-container").within(() => {
+          cy.getAttached(".user-menu").click();
+          cy.findByText(/manage users/i).click();
+        });
+        cy.getAttached(".react-tabs__tab--selected").within(() => {
+          cy.findByText(/users/i).should("exist");
+        });
+      });
+    });
+    describe("Manage hosts page", () => {
       beforeEach(() => {
         cy.loginWithCySession("anna@organization.com", "user123#");
         cy.visit("/hosts/manage");
       });
-
-      it("Can verify user is on the Manage Hosts page", () => {
-        cy.getAttached(".manage-hosts").within(() => {
-          cy.findByText(/edit columns/i).should("exist");
-        });
-      });
-
-      it("Can see correct global navigation items", () => {
-        cy.getAttached("nav").within(() => {
-          cy.findByText(/hosts/i).should("exist");
-          cy.findByText(/queries/i).should("exist");
-          cy.findByText(/schedule/i).should("exist");
-          cy.findByText(/settings/i).should("exist");
-        });
-      });
-
-      it("Can verify teams is disabled", () => {
+      it("verifies teams is disabled on Manage Host page", () => {
         cy.contains(/team/i).should("not.exist");
       });
-
-      it("Can see and click the 'Generate installer' button", () => {
+      it("allows admin to see and click the 'Generate installer' button", () => {
         cy.findByRole("button", { name: /generate installer/i }).click();
         cy.contains(/team/i).should("not.exist");
         cy.contains("button", /done/i).click();
       });
-
-      it("Can manage and add enroll secret", () => {
+      it("allows admin to manage and add enroll secret", () => {
         cy.contains("button", /manage enroll secret/i).click();
         cy.contains("button", /add secret/i).click();
         cy.contains("button", /save/i).click();
         cy.contains("button", /done/i).click();
       });
-
-      it("Can open the 'Add label' form", () => {
+      it("allows admin to open the 'Add label' form", () => {
         cy.findByRole("button", { name: /add label/i }).click();
         cy.findByRole("button", { name: /cancel/i }).click();
       });
     });
-
     describe("Host details tests", () => {
       beforeEach(() => {
         cy.loginWithCySession("anna@organization.com", "user123#");
         cy.visit("/hosts/1");
       });
-
-      it("Can verify teams is disabled", () => {
+      it("verifies teams is disabled on Host Details page", () => {
         cy.findByText(/team/i).should("not.exist");
         cy.contains("button", /transfer/i).should("not.exist");
       });
-
-      it("Can delete a query", () => {
+      it("allows admin to delete a query", () => {
         cy.findByRole("button", { name: /delete/i }).click();
         cy.findByText(/delete host/i).should("exist");
         cy.findByRole("button", { name: /cancel/i }).click();
       });
-
-      it("Can create a new query", () => {
+      it("allows admin to create a new query", () => {
         cy.findByRole("button", { name: /query/i }).click();
         cy.findByRole("button", { name: /create custom query/i }).should(
           "exist"
@@ -92,17 +101,15 @@ describe(
       });
     });
 
-    describe("Queries tests", () => {
+    describe("Query pages", () => {
       beforeEach(() => {
         cy.loginWithCySession("anna@organization.com", "user123#");
         cy.visit("/queries/manage");
       });
-
-      it("Can see the 'Observer can run' column on the queries table", () => {
+      it("displays the 'Observer can run' column on the queries table", () => {
         cy.contains(/observer can run/i);
       });
-
-      it("Can add a new query", () => {
+      it("allows admin add a new query", () => {
         cy.findByRole("button", { name: /new query/i }).click();
         cy.getAttached(".ace_text-input")
           .click({ force: true })
@@ -127,8 +134,7 @@ describe(
         });
         cy.findByText(/query created/i).should("exist");
       });
-
-      it("Can edit a query", () => {
+      it("allows admin to edit a query", () => {
         cy.findByText(/cypress test query/i).click({ force: true });
         cy.getAttached(".ace_text-input")
           .click({ force: true })
@@ -139,8 +145,7 @@ describe(
         cy.findByText("Save").click(); // we have 'save as new' also
         cy.findByText(/query updated/i).should("exist");
       });
-
-      it("Can run a query", () => {
+      it("allows admin to run a query", () => {
         cy.findByText(/cypress test query/i).click({ force: true });
         cy.findByText(/run query/i).click({ force: true });
         cy.findByText(/select targets/i).should("exist");
@@ -150,26 +155,22 @@ describe(
         cy.findByText(/querying selected hosts/i).should("exist"); // target count
       });
     });
-
-    describe("Policies tests", () => {
+    describe("Manage policies page", () => {
       beforeEach(() => {
         cy.loginWithCySession("anna@organization.com", "user123#");
         cy.visit("/policies/manage");
       });
-
-      it("Can manage automations", () => {
+      it("allows admin to click 'Manage automations' button", () => {
         cy.findByRole("button", { name: /manage automations/i }).click();
         cy.findByRole("button", { name: /cancel/i }).click();
       });
-
-      it("Can add a policy", () => {
+      it("allows admin to add a new policy", () => {
         cy.findByRole("button", { name: /add a policy/i }).click();
         cy.getAttached(".modal__ex").within(() => {
           cy.findByRole("button").click();
         });
       });
-
-      it("Can delete a policy", () => {
+      it("allows admin to delete a policy", () => {
         // select checkmark on table
         cy.getAttached("tbody").within(() => {
           cy.getAttached("tr")
@@ -178,15 +179,13 @@ describe(
               cy.getAttached(".fleet-checkbox__input").check({ force: true });
             });
         });
-
         cy.findByRole("button", { name: /delete/i }).click();
         cy.getAttached(".remove-policies-modal").within(() => {
           cy.findByRole("button", { name: /delete/i }).should("exist");
           cy.findByRole("button", { name: /cancel/i }).click();
         });
       });
-
-      it("Can select a policy and verify user can run and save", () => {
+      it("allows admin to select a policy and see CTAs to run and save", () => {
         cy.getAttached(".data-table__table").within(() => {
           cy.findByRole("button", { name: /filevault enabled/i }).click();
         });
@@ -196,58 +195,48 @@ describe(
         });
       });
     });
-
-    describe("Settings tests", () => {
+    describe("Admin settings page", () => {
       // cypress tends to fail on uncaught exceptions. since we have
       // our own error handling, it's suggested to use this block to
       // suppress so the tests will keep running
       Cypress.on("uncaught:exception", () => {
         return false;
       });
-
       beforeEach(() => {
         cy.loginWithCySession("anna@organization.com", "user123#");
         cy.visit("/settings/users");
       });
-
-      it("Can verify teams is disabled on the Settings page", () => {
+      it("hides access team settings", () => {
         cy.findByText(/teams/i).should("not.exist");
       });
-
-      it("Can verify all other suboptions exist", () => {
+      it("allows admin to access other settings", () => {
         cy.getAttached(".react-tabs").within(() => {
           cy.findByText(/organization settings/i).should("exist");
           cy.findByText(/users/i).click();
         });
       });
-
-      it("Can see and click the 'Create user' button", () => {
+      it("displays the 'Create user' button", () => {
         cy.findByRole("button", { name: /create user/i }).click();
       });
-
-      it("Can verify teams is disabled for creating a user", () => {
+      it("hides assigning a user to a team", () => {
         cy.findByText(/team/i).should("not.exist");
       });
-
-      it("Can verify user is not autorized to use the Team Settings page", () => {
+      it("verifies admin is not authorized to reach the Team Settings page", () => {
         cy.visit("/settings/teams");
         cy.findByText(/you do not have permissions/i).should("exist");
       });
     });
-
-    describe("Profile tests", () => {
+    describe("User profile page", () => {
       beforeEach(() => {
         cy.loginWithCySession("anna@organization.com", "user123#");
         cy.visit("/profile");
       });
-
-      it("Can verify teams is disabled for the Profile page", () => {
+      it("verifies teams is disabled for the Profile page", () => {
         cy.getAttached(".user-settings__additional").within(() => {
           cy.findByText(/teams/i).should("not.exist");
         });
       });
-
-      it("Can verify the role of the user is admin", () => {
+      it("renders elements according to role-based access controls", () => {
         cy.getAttached(".user-settings__additional").within(() => {
           cy.findByText("Role").next().contains(/admin/i);
         });

--- a/cypress/integration/free/admin.spec.ts
+++ b/cypress/integration/free/admin.spec.ts
@@ -21,7 +21,7 @@ describe(
 
     describe("Dashboard and navigation", () => {
       beforeEach(() => cy.visit("/dashboard"));
-      it("displays intended global admin dashboard", () => {
+      it("displays intended admin dashboard", () => {
         cy.getAttached(".homepage__wrapper").within(() => {
           cy.findByText(/all teams/i).should("exist");
           cy.getAttached(".hosts-summary").should("exist");
@@ -30,7 +30,7 @@ describe(
           cy.getAttached(".activity-feed").should("exist");
         });
       });
-      it("displays intended global admin top navigation", () => {
+      it("displays intended admin top navigation", () => {
         cy.getAttached(".site-nav-container").within(() => {
           cy.findByText(/hosts/i).should("exist");
           cy.findByText(/software/i).should("exist");
@@ -100,7 +100,34 @@ describe(
         });
       });
     });
-
+    describe("Manage software page", () => {
+      beforeEach(() => {
+        cy.loginWithCySession("anna@organization.com", "user123#");
+        cy.visit("/software/manage");
+      });
+      it("allows global admin to click 'Manage automations' button", () => {
+        cy.getAttached(".manage-software-page__header-wrap").within(() => {
+          cy.getAttached(".Select").within(() => {
+            cy.findByText(/all teams/i).should("exist");
+          });
+          cy.findByRole("button", { name: /manage automations/i }).click();
+          cy.findByRole("button", { name: /cancel/i }).click();
+        });
+      });
+      it("hides manage automations button when all teams not selected", () => {
+        cy.getAttached(".manage-software-page__header-wrap").within(() => {
+          cy.getAttached(".Select").within(() => {
+            cy.getAttached(".Select-control").click();
+            cy.getAttached(".Select-menu-outer").within(() => {
+              cy.findByText(/apples/i).should("exist");
+            });
+            cy.findByRole("button", {
+              name: /manage automations/i,
+            }).should("not.exist");
+          });
+        });
+      });
+    });
     describe("Query pages", () => {
       beforeEach(() => {
         cy.loginWithCySession("anna@organization.com", "user123#");
@@ -190,6 +217,70 @@ describe(
           cy.findByRole("button", { name: /filevault enabled/i }).click();
         });
         cy.getAttached(".policy-form__button-wrap--new-policy").within(() => {
+          cy.findByRole("button", { name: /run/i }).should("exist");
+          cy.findByRole("button", { name: /save/i }).should("exist");
+        });
+      });
+    });
+    describe("Manage policies page", () => {
+      beforeEach(() => cy.visit("/policies/manage"));
+      it("allows admin to click 'Manage automations' button", () => {
+        cy.getAttached(".button-wrap")
+          .findByRole("button", { name: /manage automations/i })
+          .click();
+        cy.findByRole("button", { name: /cancel/i }).click();
+      });
+      it("allows admin to add a new policy", () => {
+        cy.getAttached(".button-wrap")
+          .findByRole("button", { name: /add a polic/i })
+          .click();
+        // Add a default policy
+        cy.findByText(/gatekeeper enabled/i).click();
+        cy.getAttached(".policy-form__button-wrap--new-policy").within(() => {
+          cy.findByRole("button", { name: /run/i }).should("exist");
+          cy.findByRole("button", { name: /save policy/i }).click();
+        });
+        cy.findByRole("button", { name: /^Save$/ }).click();
+        cy.findByText(/policy created/i).should("exist");
+      });
+      it("allows admin to delete a team policy", () => {
+        cy.visit("/policies/manage");
+        cy.getAttached(".Select-control").within(() => {
+          cy.findByText(/all teams/i).click();
+        });
+        cy.getAttached(".Select-menu")
+          .contains(/apples/i)
+          .click();
+        cy.getAttached("tbody").within(() => {
+          cy.getAttached("tr")
+            .first()
+            .within(() => {
+              cy.getAttached(".fleet-checkbox__input").check({
+                force: true,
+              });
+            });
+        });
+        cy.findByRole("button", { name: /delete/i }).click();
+        cy.getAttached(".remove-policies-modal").within(() => {
+          cy.findByRole("button", { name: /delete/i }).should("exist");
+          cy.findByRole("button", { name: /cancel/i }).click();
+        });
+      });
+      it("allows admin to edit a team policy", () => {
+        cy.visit("policies/manage");
+        cy.findByText(/all teams/i).click();
+        cy.findByText(/apples/i).click();
+        cy.getAttached("tbody").within(() => {
+          cy.getAttached("tr")
+            .first()
+            .within(() => {
+              cy.getAttached(".fleet-checkbox__input").check({
+                force: true,
+              });
+            });
+        });
+        cy.findByText(/filevault enabled/i).click();
+        cy.getAttached(".policy-form__button-wrap").within(() => {
           cy.findByRole("button", { name: /run/i }).should("exist");
           cy.findByRole("button", { name: /save/i }).should("exist");
         });

--- a/cypress/integration/free/admin.spec.ts
+++ b/cypress/integration/free/admin.spec.ts
@@ -20,10 +20,13 @@ describe(
     });
 
     describe("Dashboard and navigation", () => {
-      beforeEach(() => cy.visit("/dashboard"));
+      beforeEach(() => {
+        cy.loginWithCySession("anna@organization.com", "user123#");
+        cy.visit("/dashboard");
+      });
       it("displays intended admin dashboard", () => {
         cy.getAttached(".homepage__wrapper").within(() => {
-          cy.findByText(/all teams/i).should("exist");
+          cy.findByText(/fleet test/i).should("exist");
           cy.getAttached(".hosts-summary").should("exist");
           cy.getAttached(".hosts-status").should("exist");
           cy.getAttached(".home-software").should("exist");
@@ -107,24 +110,12 @@ describe(
       });
       it("allows global admin to click 'Manage automations' button", () => {
         cy.getAttached(".manage-software-page__header-wrap").within(() => {
-          cy.getAttached(".Select").within(() => {
-            cy.findByText(/all teams/i).should("exist");
-          });
           cy.findByRole("button", { name: /manage automations/i }).click();
-          cy.findByRole("button", { name: /cancel/i }).click();
         });
-      });
-      it("hides manage automations button when all teams not selected", () => {
-        cy.getAttached(".manage-software-page__header-wrap").within(() => {
-          cy.getAttached(".Select").within(() => {
-            cy.getAttached(".Select-control").click();
-            cy.getAttached(".Select-menu-outer").within(() => {
-              cy.findByText(/apples/i).should("exist");
-            });
-            cy.findByRole("button", {
-              name: /manage automations/i,
-            }).should("not.exist");
-          });
+        cy.getAttached(".manage-automations-modal__button-wrap").within(() => {
+          cy.findByRole("button", {
+            name: /cancel/i,
+          }).click();
         });
       });
     });
@@ -217,70 +208,6 @@ describe(
           cy.findByRole("button", { name: /filevault enabled/i }).click();
         });
         cy.getAttached(".policy-form__button-wrap--new-policy").within(() => {
-          cy.findByRole("button", { name: /run/i }).should("exist");
-          cy.findByRole("button", { name: /save/i }).should("exist");
-        });
-      });
-    });
-    describe("Manage policies page", () => {
-      beforeEach(() => cy.visit("/policies/manage"));
-      it("allows admin to click 'Manage automations' button", () => {
-        cy.getAttached(".button-wrap")
-          .findByRole("button", { name: /manage automations/i })
-          .click();
-        cy.findByRole("button", { name: /cancel/i }).click();
-      });
-      it("allows admin to add a new policy", () => {
-        cy.getAttached(".button-wrap")
-          .findByRole("button", { name: /add a polic/i })
-          .click();
-        // Add a default policy
-        cy.findByText(/gatekeeper enabled/i).click();
-        cy.getAttached(".policy-form__button-wrap--new-policy").within(() => {
-          cy.findByRole("button", { name: /run/i }).should("exist");
-          cy.findByRole("button", { name: /save policy/i }).click();
-        });
-        cy.findByRole("button", { name: /^Save$/ }).click();
-        cy.findByText(/policy created/i).should("exist");
-      });
-      it("allows admin to delete a team policy", () => {
-        cy.visit("/policies/manage");
-        cy.getAttached(".Select-control").within(() => {
-          cy.findByText(/all teams/i).click();
-        });
-        cy.getAttached(".Select-menu")
-          .contains(/apples/i)
-          .click();
-        cy.getAttached("tbody").within(() => {
-          cy.getAttached("tr")
-            .first()
-            .within(() => {
-              cy.getAttached(".fleet-checkbox__input").check({
-                force: true,
-              });
-            });
-        });
-        cy.findByRole("button", { name: /delete/i }).click();
-        cy.getAttached(".remove-policies-modal").within(() => {
-          cy.findByRole("button", { name: /delete/i }).should("exist");
-          cy.findByRole("button", { name: /cancel/i }).click();
-        });
-      });
-      it("allows admin to edit a team policy", () => {
-        cy.visit("policies/manage");
-        cy.findByText(/all teams/i).click();
-        cy.findByText(/apples/i).click();
-        cy.getAttached("tbody").within(() => {
-          cy.getAttached("tr")
-            .first()
-            .within(() => {
-              cy.getAttached(".fleet-checkbox__input").check({
-                force: true,
-              });
-            });
-        });
-        cy.findByText(/filevault enabled/i).click();
-        cy.getAttached(".policy-form__button-wrap").within(() => {
           cy.findByRole("button", { name: /run/i }).should("exist");
           cy.findByRole("button", { name: /save/i }).should("exist");
         });

--- a/cypress/integration/free/maintainer.spec.ts
+++ b/cypress/integration/free/maintainer.spec.ts
@@ -20,10 +20,13 @@ describe(
     });
 
     describe("Dashboard and navigation", () => {
-      beforeEach(() => cy.visit("/dashboard"));
+      beforeEach(() => {
+        cy.loginWithCySession("mary@organization.com", "user123#");
+        cy.visit("/dashboard");
+      });
       it("displays intended global maintainer dashboard", () => {
         cy.getAttached(".homepage__wrapper").within(() => {
-          cy.findByText(/all teams/i).should("exist");
+          cy.findByText(/fleet test/i).should("exist");
           cy.getAttached(".hosts-summary").should("exist");
           cy.getAttached(".hosts-status").should("exist");
           cy.getAttached(".home-software").should("exist");
@@ -97,28 +100,29 @@ describe(
     describe("Manage software page", () => {
       beforeEach(() => {
         cy.loginWithCySession("mary@organization.com", "user123#");
-        cy.visit("/software/manage")
+        cy.visit("/software/manage");
       });
       it("allows maintainer to click 'Manage automations' button", () => {
-      it("manages software automations when all teams selected", () => {
-        cy.getAttached(".manage-software-page__header-wrap").within(() => {
-          cy.getAttached(".Select").within(() => {
-            cy.findByText(/all teams/i).should("exist");
-          });
-          cy.findByRole("button", { name: /manage automations/i }).click();
-          cy.findByRole("button", { name: /cancel/i }).click();
-        });
-      });
-      it("hides manage automations button when all teams not selected", () => {
-        cy.getAttached(".manage-software-page__header-wrap").within(() => {
-          cy.getAttached(".Select").within(() => {
-            cy.getAttached(".Select-control").click();
-            cy.getAttached(".Select-menu-outer").within(() => {
-              cy.findByText(/apples/i).should("exist");
+        it("manages software automations when all teams selected", () => {
+          cy.getAttached(".manage-software-page__header-wrap").within(() => {
+            cy.getAttached(".Select").within(() => {
+              cy.findByText(/all teams/i).should("exist");
             });
-            cy.findByRole("button", {
-              name: /manage automations/i,
-            }).should("not.exist");
+            cy.findByRole("button", { name: /manage automations/i }).click();
+            cy.findByRole("button", { name: /cancel/i }).click();
+          });
+        });
+        it("hides manage automations button when all teams not selected", () => {
+          cy.getAttached(".manage-software-page__header-wrap").within(() => {
+            cy.getAttached(".Select").within(() => {
+              cy.getAttached(".Select-control").click();
+              cy.getAttached(".Select-menu-outer").within(() => {
+                cy.findByText(/apples/i).should("exist");
+              });
+              cy.findByRole("button", {
+                name: /manage automations/i,
+              }).should("not.exist");
+            });
           });
         });
       });
@@ -148,7 +152,9 @@ describe(
                 cy.findByLabelText(/description/i)
                   .click()
                   .type("Cypress test of create new query flow.");
-                cy.findByLabelText(/observers can run/i).click({ force: true });
+                cy.findByLabelText(/observers can run/i).click({
+                  force: true,
+                });
                 cy.findByRole("button", { name: /save query/i }).click();
               });
             });
@@ -213,7 +219,9 @@ describe(
             cy.getAttached("tr")
               .first()
               .within(() => {
-                cy.findByRole("button", { name: /filevault enabled/i }).click();
+                cy.findByRole("button", {
+                  name: /filevault enabled/i,
+                }).click();
               });
           });
         });

--- a/cypress/integration/free/maintainer.spec.ts
+++ b/cypress/integration/free/maintainer.spec.ts
@@ -14,63 +14,77 @@ describe(
       cy.seedPolicies();
       cy.addDockerHost();
     });
-
     after(() => {
       cy.logout();
       cy.stopDockerHost();
     });
 
-    describe("Mange hosts tests", () => {
+    describe("Dashboard and navigation", () => {
+      beforeEach(() => cy.visit("/dashboard"));
+      it("displays intended global maintainer dashboard", () => {
+        cy.getAttached(".homepage__wrapper").within(() => {
+          cy.findByText(/all teams/i).should("exist");
+          cy.getAttached(".hosts-summary").should("exist");
+          cy.getAttached(".hosts-status").should("exist");
+          cy.getAttached(".home-software").should("exist");
+          cy.getAttached(".activity-feed").should("exist");
+        });
+      });
+      it("displays intended global maintainer top navigation", () => {
+        cy.getAttached(".site-nav-container").within(() => {
+          cy.findByText(/hosts/i).should("exist");
+          cy.findByText(/software/i).should("exist");
+          cy.findByText(/queries/i).should("exist");
+          cy.findByText(/schedule/i).should("exist");
+          cy.findByText(/policies/i).should("exist");
+          cy.getAttached(".user-menu").click();
+          cy.findByText(/settings/i).should("not.exist");
+          cy.findByText(/manage users/i).should("not.exist");
+        });
+      });
+    });
+    describe("Manage hosts page", () => {
       beforeEach(() => {
         cy.loginWithCySession("mary@organization.com", "user123#");
         cy.visit("/hosts/manage");
       });
-
-      it("Can verify user is on the Manage Hosts page", () => {
+      it("verifies maintainer is on the Manage Hosts page", () => {
         cy.getAttached(".manage-hosts").within(() => {
           cy.findByText(/edit columns/i).should("exist");
         });
       });
-
-      it("Can verify teams is disabled", () => {
+      it("verifies teams is disabled", () => {
         cy.contains(/team/i).should("not.exist");
       });
-
-      it("Can see and click the 'Generate installer' button", () => {
+      it("allows maintainer to see and click the 'Generate installer' button", () => {
         cy.findByRole("button", { name: /generate installer/i }).click();
         cy.contains(/team/i).should("not.exist");
         cy.contains("button", /done/i).click();
       });
-
-      it("Can manage the enroll secret", () => {
+      it("allows maintainer to manage the enroll secret", () => {
         cy.contains("button", /manage enroll secret/i).click();
         cy.contains("button", /done/i).click();
       });
-
-      it("Can open the 'Add label' form", () => {
+      it("allows maintainer to open the 'Add label' form", () => {
         cy.findByRole("button", { name: /add label/i }).click();
         cy.findByRole("button", { name: /cancel/i }).click();
       });
     });
-
     describe("Host details tests", () => {
       beforeEach(() => {
         cy.loginWithCySession("mary@organization.com", "user123#");
         cy.visit("/hosts/1");
       });
-
-      it("Can verify teams is disabled", () => {
+      it("verifies teams is disabled", () => {
         cy.findByText(/team/i).should("not.exist");
         cy.contains("button", /transfer/i).should("not.exist");
       });
-
-      it("Can delete a query", () => {
+      it("allows maintainer to delete a host", () => {
         cy.findByRole("button", { name: /delete/i }).click();
         cy.findByText(/delete host/i).should("exist");
         cy.findByRole("button", { name: /cancel/i }).click();
       });
-
-      it("Can create a new query", () => {
+      it("allows maintainer to create a new query on a host", () => {
         cy.findByRole("button", { name: /query/i }).click();
         cy.findByRole("button", { name: /create custom query/i }).should(
           "exist"
@@ -80,18 +94,15 @@ describe(
         });
       });
     });
-
     describe("Queries tests", () => {
       beforeEach(() => {
         cy.loginWithCySession("mary@organization.com", "user123#");
         cy.visit("/queries/manage");
       });
-
-      it("Can see the 'Observer can run' column on the queries table", () => {
+      it("displays the 'Observer can run' column on the queries table", () => {
         cy.contains(/observer can run/i);
       });
-
-      it("Can add a new query", () => {
+      it("allows maintainer to add a new query", () => {
         cy.findByRole("button", { name: /new query/i }).click();
         cy.getAttached(".ace_text-input")
           .click({ force: true })
@@ -116,8 +127,7 @@ describe(
         });
         cy.findByText(/query created/i).should("exist");
       });
-
-      it("Can edit a query", () => {
+      it("allows maintainer to edit a query", () => {
         cy.findByText(/cypress test query/i).click({ force: true });
         cy.getAttached(".ace_text-input")
           .click({ force: true })
@@ -128,8 +138,7 @@ describe(
         cy.findByText("Save").click(); // we have 'save as new' also
         cy.findByText(/query updated/i).should("exist");
       });
-
-      it("Can run a query", () => {
+      it("allows maintainer to run a query", () => {
         cy.findByText(/cypress test query/i).click({ force: true });
         cy.findByText(/run query/i).click({ force: true });
         cy.findByText(/select targets/i).should("exist");
@@ -139,26 +148,22 @@ describe(
         cy.findByText(/querying selected hosts/i).should("exist"); // target count
       });
     });
-
-    describe("Policies tests", () => {
+    describe("Manage policies page", () => {
       beforeEach(() => {
         cy.loginWithCySession("mary@organization.com", "user123#");
         cy.visit("/policies/manage");
       });
-
-      it("Can manage automations", () => {
+      it("allows maintainer to manage automations", () => {
         cy.findByRole("button", { name: /manage automations/i }).click();
         cy.findByRole("button", { name: /cancel/i }).click();
       });
-
-      it("Can add a policy", () => {
+      it("allows maintainer to add a policy", () => {
         cy.findByRole("button", { name: /add a policy/i }).click();
         cy.getAttached(".modal__ex").within(() => {
           cy.findByRole("button").click();
         });
       });
-
-      it("Can delete a policy", () => {
+      it("allows maintainer to delete a policy", () => {
         // select checkmark on table
         cy.getAttached("tbody").within(() => {
           cy.getAttached("tr")
@@ -167,15 +172,13 @@ describe(
               cy.getAttached(".fleet-checkbox__input").check({ force: true });
             });
         });
-
         cy.findByRole("button", { name: /delete/i }).click();
         cy.getAttached(".remove-policies-modal").within(() => {
           cy.findByRole("button", { name: /delete/i }).should("exist");
           cy.findByRole("button", { name: /cancel/i }).click();
         });
       });
-
-      it("Can select a policy and verify user can run and save", () => {
+      it("allows maintainer to select a policy and see CTAs to run and save", () => {
         cy.getAttached(".data-table__table").within(() => {
           cy.getAttached("tbody").within(() => {
             cy.getAttached("tr")
@@ -191,14 +194,12 @@ describe(
         });
       });
     });
-
-    describe("Packs tests", () => {
+    describe("Manage packs page", () => {
       beforeEach(() => {
         cy.loginWithCySession("mary@organization.com", "user123#");
         cy.visit("/packs/manage");
       });
-
-      it("Can create a pack", () => {
+      it("allows maintainer to create a pack", () => {
         cy.findByRole("button", { name: /create new pack/i }).click();
         cy.findByLabelText(/name/i).click().type("Errors and crashes");
         cy.findByLabelText(/description/i)
@@ -206,8 +207,7 @@ describe(
           .type("See all user errors and window crashes.");
         cy.findByRole("button", { name: /save query pack/i }).click();
       });
-
-      it("Can delete a pack", () => {
+      it("allows maintainer to delete a pack", () => {
         // select checkmark on table
         cy.getAttached("tbody").within(() => {
           cy.getAttached("tr")
@@ -218,31 +218,26 @@ describe(
         });
         // cy.get(".fleet-checkbox__input").check({ force: true });
         cy.findByRole("button", { name: /delete/i }).click();
-
         // Can't figure out how attach findByRole onto modal button
         // Can't use findByText because delete button under modal
         cy.get(".remove-pack-modal__btn-wrap > .button--alert")
           .contains("button", /delete/i)
           .click();
-
         cy.findByText(/successfully deleted/i).should("be.visible");
         cy.findByText(/server errors/i).should("not.exist");
       });
     });
-
-    describe("Profile tests", () => {
+    describe("User profile page", () => {
       beforeEach(() => {
         cy.loginWithCySession("mary@organization.com", "user123#");
         cy.visit("/profile");
       });
-
-      it("Can verify teams is disabled for the Profile page", () => {
+      it("verifies teams is disabled for the Profile page", () => {
         cy.getAttached(".user-settings__additional").within(() => {
           cy.findByText(/teams/i).should("not.exist");
         });
       });
-
-      it("Can verify the role of the user is maintainer", () => {
+      it("renders elements according to role-based access controls", () => {
         cy.getAttached(".user-settings__additional").within(() => {
           cy.findByText("Role")
             .next()
@@ -260,12 +255,10 @@ describe(
       Cypress.on("uncaught:exception", () => {
         return false;
       });
-
       beforeEach(() => {
         cy.loginWithCySession("mary@organization.com", "user123#");
       });
-
-      it("Can verify user does not have access to settings", () => {
+      it("verifies maintainer does not have access to settings", () => {
         cy.findByText(/settings/i).should("not.exist");
         cy.visit("/settings/organization");
         cy.findByText(/you do not have permissions/i).should("exist");

--- a/cypress/integration/free/maintainer.spec.ts
+++ b/cypress/integration/free/maintainer.spec.ts
@@ -94,7 +94,36 @@ describe(
         });
       });
     });
-    describe("Queries tests", () => {
+    describe("Manage software page", () => {
+      beforeEach(() => {
+        cy.loginWithCySession("mary@organization.com", "user123#");
+        cy.visit("/software/manage")
+      });
+      it("allows maintainer to click 'Manage automations' button", () => {
+      it("manages software automations when all teams selected", () => {
+        cy.getAttached(".manage-software-page__header-wrap").within(() => {
+          cy.getAttached(".Select").within(() => {
+            cy.findByText(/all teams/i).should("exist");
+          });
+          cy.findByRole("button", { name: /manage automations/i }).click();
+          cy.findByRole("button", { name: /cancel/i }).click();
+        });
+      });
+      it("hides manage automations button when all teams not selected", () => {
+        cy.getAttached(".manage-software-page__header-wrap").within(() => {
+          cy.getAttached(".Select").within(() => {
+            cy.getAttached(".Select-control").click();
+            cy.getAttached(".Select-menu-outer").within(() => {
+              cy.findByText(/apples/i).should("exist");
+            });
+            cy.findByRole("button", {
+              name: /manage automations/i,
+            }).should("not.exist");
+          });
+        });
+      });
+    });
+    describe("Query pages", () => {
       beforeEach(() => {
         cy.loginWithCySession("mary@organization.com", "user123#");
         cy.visit("/queries/manage");

--- a/cypress/integration/free/observer.spec.ts
+++ b/cypress/integration/free/observer.spec.ts
@@ -133,12 +133,16 @@ describe("Free tier - Observer user", () => {
     });
     it("hides run, edit, or delete a policy", () => {
       cy.getAttached("tbody").within(() => {
-        cy.get("tr")
+        cy.getAttached("tr")
           .first()
           .within(() => {
             cy.get(".fleet-checkbox__input").should("not.exist");
           });
-        cy.findByText(/filevault enabled/i).click();
+      });
+      cy.getAttached(".data-table__table").within(() => {
+        cy.findByRole("button", {
+          name: /filevault enabled/i,
+        }).click();
       });
       cy.getAttached(".policy-form__wrapper").within(() => {
         cy.findByRole("button", { name: /run/i }).should("not.exist");

--- a/cypress/integration/free/observer.spec.ts
+++ b/cypress/integration/free/observer.spec.ts
@@ -15,10 +15,13 @@ describe("Free tier - Observer user", () => {
   });
 
   describe("Dashboard and navigation", () => {
-    beforeEach(() => cy.visit("/dashboard"));
+    beforeEach(() => {
+      cy.loginWithCySession("oliver@organization.com", "user123#");
+      cy.visit("/dashboard");
+    });
     it("displays intended global observer dashboard", () => {
       cy.getAttached(".homepage__wrapper").within(() => {
-        cy.findByText(/all teams/i).should("exist");
+        cy.findByText(/fleet test/i).should("exist");
         cy.getAttached(".hosts-summary").should("exist");
         cy.getAttached(".hosts-status").should("exist");
         cy.getAttached(".home-software").should("exist");
@@ -43,20 +46,19 @@ describe("Free tier - Observer user", () => {
       cy.loginWithCySession("oliver@organization.com", "user123#");
       cy.visit("/hosts/manage");
     });
-    it("verifues teams is disabled on Manage Host page", () => {
+    it("verifies teams is disabled on Manage Host page", () => {
       cy.findByText(/teams/i).should("not.exist");
     });
-    it("verifies observer cannot generate an installer", () => {
+    it("hides generate installer button", () => {
       cy.contains("button", /generate installer/i).should("not.exist");
     });
-    it("verifies observer cannot add a label", () => {
+    it("hides add a label button", () => {
       cy.contains("button", /add label/i).should("not.exist");
     });
-    it("verifies observer cannot manage the enroll secret", () => {
+    it("hides manage enroll secrets button", () => {
       cy.contains("button", /manage enroll secret/i).should("not.exist");
     });
   });
-
   describe("Host details page", () => {
     beforeEach(() => {
       cy.loginWithCySession("oliver@organization.com", "user123#");
@@ -65,17 +67,14 @@ describe("Free tier - Observer user", () => {
     it("verifies teams is disabled on Host Details page", () => {
       cy.findByText(/team/i).should("not.exist");
     });
-    it("verifies observer cannot transfer host", () => {
+    it("hides transfer host button", () => {
       cy.contains("button", /transfer/i).should("not.exist");
     });
-    it("verifies observer cannot delete host", () => {
+    it("hides delete host button", () => {
       cy.contains("button", /delete/i).should("not.exist");
     });
-    it("verifies observer cannot query host", () => {
+    it("hides query host button", () => {
       cy.contains("button", /query/i).click();
-    });
-    it("verifies observer cannot create query", () => {
-      cy.contains("button", /create custom query/i).should("not.exist");
     });
   });
   describe("Manage software page", () => {
@@ -96,12 +95,12 @@ describe("Free tier - Observer user", () => {
       cy.loginWithCySession("oliver@organization.com", "user123#");
       cy.visit("/queries/manage");
     });
-    it("verifies observer does not see 'Observer can run' column", () => {
+    it("hides 'Observer can run' column", () => {
       cy.getAttached("thead").within(() => {
         cy.findByText(/observer can run/i).should("not.exist");
       });
     });
-    it("verifies observer cannot create a query", () => {
+    it("hides create a query button", () => {
       cy.findByRole("button", { name: /create new query/i }).should(
         "not.exist"
       );
@@ -124,15 +123,15 @@ describe("Free tier - Observer user", () => {
       cy.loginWithCySession("oliver@organization.com", "user123#");
       cy.visit("/policies/manage");
     });
-    it("verifies observer cannot manage automations", () => {
+    it("hides manage automations button", () => {
       cy.findByRole("button", { name: /manage automations/i }).should(
         "not.exist"
       );
     });
-    it("verifies observer cannot add a policy", () => {
+    it("hides add a policy button", () => {
       cy.findByRole("button", { name: /add a policy/i }).should("not.exist");
     });
-    it("verifies observer cannot run, edit, or delete a policy", () => {
+    it("hides run, edit, or delete a policy", () => {
       cy.getAttached("tbody").within(() => {
         cy.get("tr")
           .first()

--- a/cypress/integration/free/observer.spec.ts
+++ b/cypress/integration/free/observer.spec.ts
@@ -78,7 +78,20 @@ describe("Free tier - Observer user", () => {
       cy.contains("button", /create custom query/i).should("not.exist");
     });
   });
-  describe("Queries tests", () => {
+  describe("Manage software page", () => {
+    beforeEach(() => {
+      cy.loginWithCySession("oliver@organization.com", "user123#");
+      cy.visit("/software/manage");
+    });
+    it("hides manage automations button", () => {
+      cy.getAttached(".manage-software-page__header-wrap").within(() => {
+        cy.findByRole("button", { name: /manage automations/i }).should(
+          "not.exist"
+        );
+      });
+    });
+  });
+  describe("Query page", () => {
     beforeEach(() => {
       cy.loginWithCySession("oliver@organization.com", "user123#");
       cy.visit("/queries/manage");

--- a/cypress/integration/free/observer.spec.ts
+++ b/cypress/integration/free/observer.spec.ts
@@ -9,100 +9,91 @@ describe("Free tier - Observer user", () => {
     cy.seedPolicies();
     cy.addDockerHost();
   });
-
   after(() => {
     cy.logout();
     cy.stopDockerHost();
   });
 
-  describe("Mange hosts tests", () => {
+  describe("Dashboard and navigation", () => {
+    beforeEach(() => cy.visit("/dashboard"));
+    it("displays intended global observer dashboard", () => {
+      cy.getAttached(".homepage__wrapper").within(() => {
+        cy.findByText(/all teams/i).should("exist");
+        cy.getAttached(".hosts-summary").should("exist");
+        cy.getAttached(".hosts-status").should("exist");
+        cy.getAttached(".home-software").should("exist");
+        cy.getAttached(".activity-feed").should("exist");
+      });
+    });
+    it("displays intended global observer top navigation", () => {
+      cy.getAttached(".site-nav-container").within(() => {
+        cy.findByText(/hosts/i).should("exist");
+        cy.findByText(/software/i).should("exist");
+        cy.findByText(/queries/i).should("exist");
+        cy.findByText(/schedule/i).should("not.exist");
+        cy.findByText(/policies/i).should("exist");
+        cy.getAttached(".user-menu").click();
+        cy.findByText(/settings/i).should("not.exist");
+        cy.findByText(/manage users/i).should("not.exist");
+      });
+    });
+  });
+  describe("Manage hosts page", () => {
     beforeEach(() => {
       cy.loginWithCySession("oliver@organization.com", "user123#");
       cy.visit("/hosts/manage");
     });
-
-    it("Can verify nav is restricted", () => {
-      // we expect a 402 error from the teams API
-      // in Cypress, we can't update the context for if we're
-      // in the premium tier, so the tests runs the teams API
-      Cypress.on("uncaught:exception", () => {
-        return false;
-      });
-
-      // Nav restrictions
-      cy.findByText(/settings/i).should("not.exist");
-      cy.findByText(/schedule/i).should("not.exist");
-      cy.visit("/settings/organization");
-      cy.findByText(/you do not have permissions/i).should("exist");
-      cy.visit("/packs/manage");
-      cy.findByText(/you do not have permissions/i).should("exist");
-      cy.visit("/schedule/manage");
-      cy.findByText(/you do not have permissions/i).should("exist");
-    });
-
-    it("Can verify teams is disabled", () => {
+    it("verifues teams is disabled on Manage Host page", () => {
       cy.findByText(/teams/i).should("not.exist");
     });
-
-    it("Can verify user cannot generate an installer", () => {
+    it("verifies observer cannot generate an installer", () => {
       cy.contains("button", /generate installer/i).should("not.exist");
     });
-
-    it("Can verify user cannot add a label", () => {
+    it("verifies observer cannot add a label", () => {
       cy.contains("button", /add label/i).should("not.exist");
     });
-
-    it("Can verify user cannot manage the enroll secret", () => {
+    it("verifies observer cannot manage the enroll secret", () => {
       cy.contains("button", /manage enroll secret/i).should("not.exist");
     });
   });
 
-  describe("Host details tests", () => {
+  describe("Host details page", () => {
     beforeEach(() => {
       cy.loginWithCySession("oliver@organization.com", "user123#");
       cy.visit("/hosts/1");
     });
-
-    it("Can verify teams is disabled", () => {
+    it("verifies teams is disabled on Host Details page", () => {
       cy.findByText(/team/i).should("not.exist");
     });
-
-    it("Can verify user cannot transfer host", () => {
+    it("verifies observer cannot transfer host", () => {
       cy.contains("button", /transfer/i).should("not.exist");
     });
-
-    it("Can verify user cannot delete host", () => {
+    it("verifies observer cannot delete host", () => {
       cy.contains("button", /delete/i).should("not.exist");
     });
-
-    it("Can verify user cannot query host", () => {
+    it("verifies observer cannot query host", () => {
       cy.contains("button", /query/i).click();
     });
-
-    it("Can verify user cannot create query", () => {
+    it("verifies observer cannot create query", () => {
       cy.contains("button", /create custom query/i).should("not.exist");
     });
   });
-
   describe("Queries tests", () => {
     beforeEach(() => {
       cy.loginWithCySession("oliver@organization.com", "user123#");
       cy.visit("/queries/manage");
     });
-
-    it("Can verify that user does not see 'Observer can run' column", () => {
+    it("verifies observer does not see 'Observer can run' column", () => {
       cy.getAttached("thead").within(() => {
         cy.findByText(/observer can run/i).should("not.exist");
       });
     });
-
-    it("Can verify that user cannot create a query", () => {
+    it("verifies observer cannot create a query", () => {
       cy.findByRole("button", { name: /create new query/i }).should(
         "not.exist"
       );
     });
-
-    it("Can verify that user can select a query and only run it", () => {
+    it("verifies observer can select a query and only run it", () => {
       cy.getAttached(".data-table__table").within(() => {
         cy.findByRole("button", { name: /detect presence/i }).click();
       });
@@ -115,24 +106,20 @@ describe("Free tier - Observer user", () => {
       cy.findByRole("button", { name: /run query/i }).should("exist");
     });
   });
-
-  describe("Policies tests", () => {
+  describe("Manage policies page", () => {
     beforeEach(() => {
       cy.loginWithCySession("oliver@organization.com", "user123#");
       cy.visit("/policies/manage");
     });
-
-    it("Can verify user cannot manage automations", () => {
+    it("verifies observer cannot manage automations", () => {
       cy.findByRole("button", { name: /manage automations/i }).should(
         "not.exist"
       );
     });
-
-    it("Can verify user cannot add a policy", () => {
+    it("verifies observer cannot add a policy", () => {
       cy.findByRole("button", { name: /add a policy/i }).should("not.exist");
     });
-
-    it("Can verify user cannot run, edit, or delete a policy", () => {
+    it("verifies observer cannot run, edit, or delete a policy", () => {
       cy.getAttached("tbody").within(() => {
         cy.get("tr")
           .first()
@@ -141,27 +128,23 @@ describe("Free tier - Observer user", () => {
           });
         cy.findByText(/filevault enabled/i).click();
       });
-
       cy.getAttached(".policy-form__wrapper").within(() => {
         cy.findByRole("button", { name: /run/i }).should("not.exist");
         cy.findByRole("button", { name: /save/i }).should("not.exist");
       });
     });
   });
-
-  describe("Profile tests", () => {
+  describe("User profile page", () => {
     beforeEach(() => {
       cy.loginWithCySession("oliver@organization.com", "user123#");
       cy.visit("/profile");
     });
-
-    it("Can verify teams is disabled for the Profile page", () => {
+    it("verifies teams is disabled for the Profile page", () => {
       cy.getAttached(".user-settings__additional").within(() => {
         cy.findByText(/teams/i).should("not.exist");
       });
     });
-
-    it("Can verify the role of the user is observer", () => {
+    it("renders elements according to role-based access controls", () => {
       cy.getAttached(".user-settings__additional").within(() => {
         cy.findByText("Role")
           .next()
@@ -179,11 +162,9 @@ describe("Free tier - Observer user", () => {
     Cypress.on("uncaught:exception", () => {
       return false;
     });
-
     beforeEach(() => {
       cy.loginWithCySession("oliver@organization.com", "user123#");
     });
-
     it("should restrict navigation according to role-based access controls", () => {
       cy.findByText(/settings/i).should("not.exist");
       cy.findByText(/schedule/i).should("not.exist");

--- a/cypress/integration/premium/admin.spec.ts
+++ b/cypress/integration/premium/admin.spec.ts
@@ -126,7 +126,11 @@ describe("Premium tier - Admin user", () => {
             cy.findByText(/all teams/i).should("exist");
           });
           cy.findByRole("button", { name: /manage automations/i }).click();
-          cy.findByRole("button", { name: /cancel/i }).click();
+        });
+        cy.getAttached(".manage-automations-modal__button-wrap").within(() => {
+          cy.findByRole("button", {
+            name: /cancel/i,
+          }).click();
         });
       });
       it("hides manage automations button when all teams not selected", () => {

--- a/cypress/integration/premium/admin.spec.ts
+++ b/cypress/integration/premium/admin.spec.ts
@@ -120,14 +120,13 @@ describe("Premium tier - Admin user", () => {
     });
     describe("Manage software page", () => {
       beforeEach(() => cy.visit("/software/manage"));
-      it("displays manage automations button when all teams selected", () => {
+      it("allows global admin to click 'Manage automations' butto", () => {
         cy.getAttached(".manage-software-page__header-wrap").within(() => {
           cy.getAttached(".Select").within(() => {
             cy.findByText(/all teams/i).should("exist");
           });
-          cy.findByRole("button", { name: /manage automations/i }).should(
-            "exist"
-          );
+          cy.findByRole("button", { name: /manage automations/i }).click();
+          cy.findByRole("button", { name: /cancel/i }).click();
         });
       });
       it("hides manage automations button when all teams not selected", () => {

--- a/cypress/integration/premium/admin.spec.ts
+++ b/cypress/integration/premium/admin.spec.ts
@@ -120,7 +120,7 @@ describe("Premium tier - Admin user", () => {
     });
     describe("Manage software page", () => {
       beforeEach(() => cy.visit("/software/manage"));
-      it("allows global admin to click 'Manage automations' butto", () => {
+      it("allows global admin to click 'Manage automations' button", () => {
         cy.getAttached(".manage-software-page__header-wrap").within(() => {
           cy.getAttached(".Select").within(() => {
             cy.findByText(/all teams/i).should("exist");

--- a/cypress/integration/premium/maintainer.spec.ts
+++ b/cypress/integration/premium/maintainer.spec.ts
@@ -113,25 +113,26 @@ describe("Premium tier - Maintainer user", () => {
     describe("Manage software page", () => {
       beforeEach(() => cy.visit("/software/manage"));
       it("allows global maintainer to click 'Manage automations' button", () => {
-      it("manages software automations when all teams selected", () => {
-        cy.getAttached(".manage-software-page__header-wrap").within(() => {
-          cy.getAttached(".Select").within(() => {
-            cy.findByText(/all teams/i).should("exist");
-          });
-          cy.findByRole("button", { name: /manage automations/i }).click();
-          cy.findByRole("button", { name: /cancel/i }).click();
-        });
-      });
-      it("hides manage automations button when all teams not selected", () => {
-        cy.getAttached(".manage-software-page__header-wrap").within(() => {
-          cy.getAttached(".Select").within(() => {
-            cy.getAttached(".Select-control").click();
-            cy.getAttached(".Select-menu-outer").within(() => {
-              cy.findByText(/apples/i).should("exist");
+        it("manages software automations when all teams selected", () => {
+          cy.getAttached(".manage-software-page__header-wrap").within(() => {
+            cy.getAttached(".Select").within(() => {
+              cy.findByText(/all teams/i).should("exist");
             });
-            cy.findByRole("button", {
-              name: /manage automations/i,
-            }).should("not.exist");
+            cy.findByRole("button", { name: /manage automations/i }).click();
+            cy.findByRole("button", { name: /cancel/i }).click();
+          });
+        });
+        it("hides manage automations button when all teams not selected", () => {
+          cy.getAttached(".manage-software-page__header-wrap").within(() => {
+            cy.getAttached(".Select").within(() => {
+              cy.getAttached(".Select-control").click();
+              cy.getAttached(".Select-menu-outer").within(() => {
+                cy.findByText(/apples/i).should("exist");
+              });
+              cy.findByRole("button", {
+                name: /manage automations/i,
+              }).should("not.exist");
+            });
           });
         });
       });

--- a/cypress/integration/premium/maintainer.spec.ts
+++ b/cypress/integration/premium/maintainer.spec.ts
@@ -112,11 +112,14 @@ describe("Premium tier - Maintainer user", () => {
     });
     describe("Manage software page", () => {
       beforeEach(() => cy.visit("/software/manage"));
-      it("displays manage automations button", () => {
+      it("allows global maintainer to click 'Manage automations' button", () => {
+      it("manages software automations when all teams selected", () => {
         cy.getAttached(".manage-software-page__header-wrap").within(() => {
-          cy.findByRole("button", { name: /manage automations/i }).should(
-            "exist"
-          );
+          cy.getAttached(".Select").within(() => {
+            cy.findByText(/all teams/i).should("exist");
+          });
+          cy.findByRole("button", { name: /manage automations/i }).click();
+          cy.findByRole("button", { name: /cancel/i }).click();
         });
       });
       it("hides manage automations button when all teams not selected", () => {

--- a/cypress/integration/premium/observer.spec.ts
+++ b/cypress/integration/premium/observer.spec.ts
@@ -199,8 +199,12 @@ describe("Premium tier - Observer user", () => {
             .first()
             .within(() => {
               cy.contains(".fleet-checkbox__input").should("not.exist");
-              cy.findByText(/filevault enabled/i).click();
             });
+        });
+        cy.getAttached(".data-table__table").within(() => {
+          cy.findByRole("button", {
+            name: /filevault enabled/i,
+          }).click();
         });
         cy.getAttached(".policy-form__wrapper").within(() => {
           cy.findByRole("button", { name: /run/i }).should("not.exist");

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -1,6 +1,10 @@
 /* Config interface is a flattened version of the fleet/config API response */
 
-import { IWebhookFailingPolicies } from "interfaces/webhook";
+import {
+  IWebhookHostStatus,
+  IWebhookFailingPolicies,
+  IWebhookSoftwareVulnerabilities,
+} from "interfaces/webhook";
 import PropTypes from "prop-types";
 
 export default PropTypes.shape({
@@ -226,13 +230,9 @@ export interface IConfigNested {
     databases_path: string;
   };
   webhook_settings: {
-    host_status_webhook: {
-      enable_host_status_webhook: boolean;
-      destination_url: string;
-      host_percentage: number;
-      days_count: number;
-    };
+    host_status_webhook: IWebhookHostStatus;
     failing_policies_webhook: IWebhookFailingPolicies;
+    vulnerabilities_webhook: IWebhookSoftwareVulnerabilities;
   };
   logging: {
     debug: boolean;

--- a/frontend/interfaces/webhook.ts
+++ b/frontend/interfaces/webhook.ts
@@ -13,3 +13,9 @@ export interface IWebhookFailingPolicies {
   enable_failing_policies_webhook?: boolean;
   host_batch_size?: number;
 }
+
+export interface IWebhookSoftwareVulnerabilities {
+  destination_url?: string;
+  enable_vulnerabilities_webhook?: boolean;
+  host_batch_size?: number;
+}

--- a/frontend/interfaces/webhook.ts
+++ b/frontend/interfaces/webhook.ts
@@ -7,6 +7,12 @@ export default PropTypes.shape({
   host_batch_size: PropTypes.number,
 });
 
+export interface IWebhookHostStatus {
+  enable_host_status_webhook?: boolean;
+  destination_url?: string;
+  host_percentage?: number;
+  days_count?: number;
+}
 export interface IWebhookFailingPolicies {
   destination_url?: string;
   policy_ids?: number[];

--- a/frontend/pages/admin/AppSettingsPage/AppSettingsPage.tsx
+++ b/frontend/pages/admin/AppSettingsPage/AppSettingsPage.tsx
@@ -26,7 +26,7 @@ export const baseClass = "app-settings";
 const AppSettingsPage = (): JSX.Element => {
   const dispatch = useDispatch();
 
-  const { config, setConfig } = useContext(AppContext);
+  const { setConfig } = useContext(AppContext);
 
   const {
     data: appConfig,

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -422,7 +422,7 @@ const ManagePolicyPage = ({
           {!!teamId && teamPoliciesError && <TableDataError />}
           {!!teamId &&
             !teamPoliciesError &&
-            (isLoadingTeamPolicies ? (
+            (isLoadingTeamPolicies && isLoadingFailingPoliciesWebhook ? (
               <Spinner />
             ) : (
               <PoliciesListWrapper

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -318,7 +318,7 @@ const ManageSoftwarePage = ({
         buttons={renderHeaderButtons}
       />
     );
-  }, [router, location]);
+  }, [router, location, isLoadingSoftwareVulnerabilitiesWebhook]);
 
   const renderSoftwareCount = useCallback(() => {
     const count = softwareCount;

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -446,7 +446,6 @@ const ManageSoftwarePage = ({
     );
   };
 
-  console.log("softwareVulnerabilitiesWebhook", softwareVulnerabilitiesWebhook);
   return !availableTeams ? (
     <Spinner />
   ) : (

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -7,8 +7,10 @@ import { useDebouncedCallback } from "use-debounce/lib";
 import formatDistanceToNowStrict from "date-fns/formatDistanceToNowStrict";
 
 import { AppContext } from "context/app";
-import { IConfigNested } from "interfaces/config";
+import { IConfig, IConfigNested } from "interfaces/config";
 import { IWebhookSoftwareVulnerabilities } from "interfaces/webhook";
+// @ts-ignore
+import { getConfig } from "redux/nodes/app/actions";
 // @ts-ignore
 import { renderFlash } from "redux/nodes/notifications/actions";
 import configAPI from "services/entities/config";
@@ -63,6 +65,7 @@ const ManageSoftwarePage = ({
     currentTeam,
     setAvailableTeams,
     setCurrentUser,
+    setConfig,
     isPremiumTier,
     isGlobalAdmin,
     isGlobalMaintainer,
@@ -260,6 +263,12 @@ const ManageSoftwarePage = ({
     } finally {
       toggleManageAutomationsModal();
       refetchSoftwareVulnerabilitiesWebhook();
+      // Config must be updated in both Redux and AppContext
+      dispatch(getConfig())
+        .then((configState: IConfig) => {
+          setConfig(configState);
+        })
+        .catch(() => false);
     }
   };
 

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -63,6 +63,7 @@ const ManageSoftwarePage = ({
     currentTeam,
     setAvailableTeams,
     setCurrentUser,
+    isPremiumTier,
     isGlobalAdmin,
     isGlobalMaintainer,
   } = useContext(AppContext);
@@ -271,7 +272,7 @@ const ManageSoftwarePage = ({
   ): JSX.Element | null => {
     if (
       canAddOrRemoveSoftwareWebhook &&
-      state.teamId === 0 &&
+      (!isPremiumTier || state.teamId === 0) &&
       !isLoadingSoftwareVulnerabilitiesWebhook
     ) {
       return (
@@ -292,7 +293,7 @@ const ManageSoftwarePage = ({
       <p>
         Search for installed software{" "}
         {canAddOrRemoveSoftwareWebhook &&
-          state.teamId === 0 &&
+          (!isPremiumTier || state.teamId === 0) &&
           "and manage automations for detected vulnerabilities (CVEs)"}{" "}
         on{" "}
         <b>

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -61,10 +61,6 @@ const ManageSoftwarePage = ({
   const {
     availableTeams,
     currentTeam,
-    isGlobalAdmin,
-    isGlobalMaintainer,
-    isTeamAdmin,
-    isTeamMaintainer,
     setAvailableTeams,
     setCurrentUser,
   } = useContext(AppContext);
@@ -281,11 +277,6 @@ const ManageSoftwarePage = ({
   const onTeamSelect = () => {
     setPageIndex(0);
   };
-
-  // TODO: Set according to Figma
-  // TODO: Look into if this is only on all teams or teams
-  // const canManageSoftwareVulnerabilityAutomations =
-  //   isGlobalAdmin || isGlobalMaintainer || isTeamMaintainer || isTeamAdmin;
 
   const renderHeaderButtons = (
     state: ITeamsDropdownState
@@ -511,8 +502,9 @@ const ManageSoftwarePage = ({
             onCreateWebhookSubmit={onCreateWebhookSubmit}
             togglePreviewPayloadModal={togglePreviewPayloadModal}
             showPreviewPayloadModal={showPreviewPayloadModal}
-            availableSoftwareAutomations={[]} // TODO: pass ManageAutomationsModal availableSoftwareAutomations
-            currentSoftwareAutomations={[]} // TODO: pass ManageAutomationsModal currentSoftwareAutomations
+            softwareVulnerabilityEnabled={
+              softwareVulnerabilitiesWebhook.enable_vulnerabilities_webhook
+            }
             currentDestinationUrl={
               (softwareVulnerabilitiesWebhook &&
                 softwareVulnerabilitiesWebhook.destination_url) ||

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -219,6 +219,7 @@ const ManageSoftwarePage = ({
       result = await configAPI
         .loadAll()
         .then((response) => response.webhook_settings.vulnerabilities_webhook);
+      console.log("result", result);
       setSoftwareVulnerabilitiesWebhook(result);
     } catch (error) {
       console.log(error);
@@ -226,6 +227,7 @@ const ManageSoftwarePage = ({
     } finally {
       setIsLoadingSoftwareVulnerabilitiesWebhook(false);
     }
+    console.log("result", result);
     return result;
   }, []);
 
@@ -454,6 +456,7 @@ const ManageSoftwarePage = ({
     );
   };
 
+  console.log("softwareVulnerabilitiesWebhook", softwareVulnerabilitiesWebhook);
   return !availableTeams ? (
     <Spinner />
   ) : (
@@ -502,7 +505,8 @@ const ManageSoftwarePage = ({
             onCreateWebhookSubmit={onCreateWebhookSubmit}
             togglePreviewPayloadModal={togglePreviewPayloadModal}
             showPreviewPayloadModal={showPreviewPayloadModal}
-            softwareVulnerabilityEnabled={
+            softwareVulnerabilityWebhookEnabled={
+              softwareVulnerabilitiesWebhook &&
               softwareVulnerabilitiesWebhook.enable_vulnerabilities_webhook
             }
             currentDestinationUrl={

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 import { useQuery } from "react-query";
 import { useDispatch } from "react-redux";
 import { InjectedRouter } from "react-router/lib/Router";

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState } from "react";
+import React, { useCallback, useContext, useState } from "react";
 import { useQuery } from "react-query";
 import { useDispatch } from "react-redux";
 import { InjectedRouter } from "react-router/lib/Router";
@@ -38,10 +38,6 @@ import QuestionIcon from "../../../../assets/images/icon-question-16x16@2x.png";
 import generateTableHeaders from "./SoftwareTableConfig";
 import ManageAutomationsModal from "./components/ManageAutomationsModal";
 import EmptySoftware from "../components/EmptySoftware";
-import {
-  isGlobalAdmin,
-  isGlobalMaintainer,
-} from "utilities/permissions/permissions";
 
 interface IManageSoftwarePageProps {
   router: InjectedRouter;
@@ -273,7 +269,11 @@ const ManageSoftwarePage = ({
   const renderHeaderButtons = (
     state: ITeamsDropdownState
   ): JSX.Element | null => {
-    if (canAddOrRemoveSoftwareWebhook && state.teamId === 0) {
+    if (
+      canAddOrRemoveSoftwareWebhook &&
+      state.teamId === 0 &&
+      !isLoadingSoftwareVulnerabilitiesWebhook
+    ) {
       return (
         <Button
           onClick={onManageAutomationsClick}

--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -17,12 +17,7 @@
   }
 
   &__manage-automations {
-<<<<<<< HEAD
     padding: $pad-small $pad-medium;
-=======
-    padding: $pad-small;
-    margin-right: $pad-small;
->>>>>>> 6b8c060b5 (Software vulnerability webhook modal components)
   }
 
   &__header {
@@ -40,34 +35,11 @@
 
   &__title {
     font-size: $large;
-<<<<<<< HEAD
-=======
-
-    .fleeticon {
-      color: $core-fleet-blue;
-      margin-right: 15px;
-    }
-
-    .fleeticon-success-check {
-      color: $ui-success;
-    }
-
-    .fleeticon-offline {
-      color: $ui-error;
-    }
-
-    .fleeticon-mia {
-      color: $core-fleet-black;
-    }
->>>>>>> 6b8c060b5 (Software vulnerability webhook modal components)
   }
 
   &__description {
     margin: 0;
-<<<<<<< HEAD
     margin-bottom: 40px;
-=======
->>>>>>> 6b8c060b5 (Software vulnerability webhook modal components)
 
     h2 {
       text-transform: uppercase;
@@ -84,14 +56,6 @@
     }
   }
 
-<<<<<<< HEAD
-=======
-  &__action-button-container {
-    display: flex;
-    align-items: flex-start;
-  }
-
->>>>>>> 6b8c060b5 (Software vulnerability webhook modal components)
   .button {
     font-size: $x-small;
 
@@ -100,79 +64,6 @@
     }
   }
 
-<<<<<<< HEAD
-=======
-  &__advanced-button {
-    margin-right: $pad-medium;
-  }
-
-  &__sandbox-info {
-    margin-top: $pad-large;
-    margin-bottom: $pad-xxlarge;
-
-    p {
-      font-size: $x-small;
-      margin: 0;
-      margin-bottom: $pad-medium;
-    }
-
-    p:last-child {
-      margin-bottom: 0;
-    }
-
-    a {
-      color: $core-vibrant-blue;
-      text-decoration: none;
-    }
-  }
-
-  &__modal-buttons {
-    width: 100%;
-    display: flex;
-    justify-content: flex-end;
-
-    .button:first-child {
-      margin-right: $pad-medium;
-    }
-  }
-
-  &__add-policy-link {
-    transition: color 150ms ease-in-out, background 150ms ease-in-out,
-      top 50ms ease-in-out, box-shadow 50ms ease-in-out, border 50ms ease-in-out;
-    position: relative;
-    color: $core-white;
-    text-decoration: none;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    padding-left: $pad-medium;
-    padding-right: $pad-medium;
-    border-radius: 4px;
-    font-size: $x-small;
-    font-family: "Nunito Sans", sans-serif;
-    font-weight: $bold;
-    display: inline-flex;
-    height: 38px;
-    top: 0;
-    border: 0;
-    cursor: pointer;
-
-    @include button-variant(
-      $core-vibrant-blue,
-      $core-vibrant-blue-over,
-      $core-vibrant-blue-down
-    );
-  }
-
-  &__inherited-policies-button {
-    padding-top: $pad-small;
-    margin: $pad-large 0 0 0;
-    color: $core-vibrant-blue;
-    font-weight: $bold;
-    font-size: $x-small;
-  }
-
->>>>>>> 6b8c060b5 (Software vulnerability webhook modal components)
   .rightcarat {
     &::before {
       content: url("../assets/images/icon-chevron-blue-16x16@2x.png");
@@ -216,7 +107,6 @@
     }
   }
 
-<<<<<<< HEAD
   .table-container {
     min-height: 435px;
   }
@@ -377,19 +267,4 @@
   .text-muted {
     color: $ui-fleet-black-50;
   }
-=======
-  &__inherited-policies-button {
-    padding-bottom: $pad-large;
-  }
-
-  &__inherited-policies-table {
-    th {
-      border-right: 1px solid #e2e4ea !important;
-    }
-
-    .table-container__header {
-      display: none;
-    }
-  }
->>>>>>> 6b8c060b5 (Software vulnerability webhook modal components)
 }

--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -17,7 +17,12 @@
   }
 
   &__manage-automations {
+<<<<<<< HEAD
     padding: $pad-small $pad-medium;
+=======
+    padding: $pad-small;
+    margin-right: $pad-small;
+>>>>>>> 6b8c060b5 (Software vulnerability webhook modal components)
   }
 
   &__header {
@@ -35,11 +40,34 @@
 
   &__title {
     font-size: $large;
+<<<<<<< HEAD
+=======
+
+    .fleeticon {
+      color: $core-fleet-blue;
+      margin-right: 15px;
+    }
+
+    .fleeticon-success-check {
+      color: $ui-success;
+    }
+
+    .fleeticon-offline {
+      color: $ui-error;
+    }
+
+    .fleeticon-mia {
+      color: $core-fleet-black;
+    }
+>>>>>>> 6b8c060b5 (Software vulnerability webhook modal components)
   }
 
   &__description {
     margin: 0;
+<<<<<<< HEAD
     margin-bottom: 40px;
+=======
+>>>>>>> 6b8c060b5 (Software vulnerability webhook modal components)
 
     h2 {
       text-transform: uppercase;
@@ -56,6 +84,14 @@
     }
   }
 
+<<<<<<< HEAD
+=======
+  &__action-button-container {
+    display: flex;
+    align-items: flex-start;
+  }
+
+>>>>>>> 6b8c060b5 (Software vulnerability webhook modal components)
   .button {
     font-size: $x-small;
 
@@ -64,6 +100,79 @@
     }
   }
 
+<<<<<<< HEAD
+=======
+  &__advanced-button {
+    margin-right: $pad-medium;
+  }
+
+  &__sandbox-info {
+    margin-top: $pad-large;
+    margin-bottom: $pad-xxlarge;
+
+    p {
+      font-size: $x-small;
+      margin: 0;
+      margin-bottom: $pad-medium;
+    }
+
+    p:last-child {
+      margin-bottom: 0;
+    }
+
+    a {
+      color: $core-vibrant-blue;
+      text-decoration: none;
+    }
+  }
+
+  &__modal-buttons {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+
+    .button:first-child {
+      margin-right: $pad-medium;
+    }
+  }
+
+  &__add-policy-link {
+    transition: color 150ms ease-in-out, background 150ms ease-in-out,
+      top 50ms ease-in-out, box-shadow 50ms ease-in-out, border 50ms ease-in-out;
+    position: relative;
+    color: $core-white;
+    text-decoration: none;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    padding-left: $pad-medium;
+    padding-right: $pad-medium;
+    border-radius: 4px;
+    font-size: $x-small;
+    font-family: "Nunito Sans", sans-serif;
+    font-weight: $bold;
+    display: inline-flex;
+    height: 38px;
+    top: 0;
+    border: 0;
+    cursor: pointer;
+
+    @include button-variant(
+      $core-vibrant-blue,
+      $core-vibrant-blue-over,
+      $core-vibrant-blue-down
+    );
+  }
+
+  &__inherited-policies-button {
+    padding-top: $pad-small;
+    margin: $pad-large 0 0 0;
+    color: $core-vibrant-blue;
+    font-weight: $bold;
+    font-size: $x-small;
+  }
+
+>>>>>>> 6b8c060b5 (Software vulnerability webhook modal components)
   .rightcarat {
     &::before {
       content: url("../assets/images/icon-chevron-blue-16x16@2x.png");
@@ -107,6 +216,7 @@
     }
   }
 
+<<<<<<< HEAD
   .table-container {
     min-height: 435px;
   }
@@ -267,4 +377,19 @@
   .text-muted {
     color: $ui-fleet-black-50;
   }
+=======
+  &__inherited-policies-button {
+    padding-bottom: $pad-large;
+  }
+
+  &__inherited-policies-table {
+    th {
+      border-right: 1px solid #e2e4ea !important;
+    }
+
+    .table-container__header {
+      display: none;
+    }
+  }
+>>>>>>> 6b8c060b5 (Software vulnerability webhook modal components)
 }

--- a/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -20,43 +20,50 @@ interface IManageAutomationsModalProps {
   onCreateWebhookSubmit: (formData: IWebhookSoftwareVulnerabilities) => void;
   togglePreviewPayloadModal: () => void;
   showPreviewPayloadModal: boolean;
-  availableSoftwareAutomations: any;
-  currentSoftwareAutomations?: number[];
+  softwareVulnerabilityWebhookEnabled?: boolean;
   currentDestinationUrl?: string;
 }
 
-interface ICheckedPolicy {
+interface ICheckedSoftwareAutomation {
   name?: string;
-  id: number;
+  accessor: string;
   isChecked: boolean;
 }
 
 const useCheckboxListStateManagement = (
-  availableSoftwareAutomations: any,
-  currentSoftwareAutomations: number[] | undefined
+  softwareVulnerabilityWebhookEnabled = false
 ) => {
+  const availableSoftwareAutomations: any = [
+    { accessor: "vulnerability", name: "Enable vulnerability automations" },
+  ];
+  const currentSoftwareAutomations: any = softwareVulnerabilityWebhookEnabled
+    ? availableSoftwareAutomations
+    : [];
+
   const [softwareAutomationsItems, setSoftwareAutomationsItems] = useState<
-    ICheckedPolicy[]
+    ICheckedSoftwareAutomation[]
   >(() => {
     return (
       availableSoftwareAutomations &&
       availableSoftwareAutomations.map((automation: any) => {
         return {
           name: automation.name,
-          id: automation.id,
+          accessor: automation.accessor,
           isChecked:
             !!currentSoftwareAutomations &&
-            currentSoftwareAutomations.includes(automation.id),
+            currentSoftwareAutomations.includes(automation.accessor),
         };
       })
     );
   });
 
-  const updateSoftwareAutomationsItems = (softwareAutomationId: number) => {
+  const updateSoftwareAutomationsItems = (
+    softwareAutomationAccessor: string
+  ) => {
     setSoftwareAutomationsItems((prevState) => {
       const selectedSoftwareAutomation = softwareAutomationsItems.find(
         (softwareAutomationItem) =>
-          softwareAutomationItem.id === softwareAutomationId
+          softwareAutomationItem.accessor === softwareAutomationAccessor
       );
 
       const updatedSoftwareAutomation = selectedSoftwareAutomation && {
@@ -65,10 +72,10 @@ const useCheckboxListStateManagement = (
           !!selectedSoftwareAutomation && !selectedSoftwareAutomation.isChecked,
       };
 
-      // this is replacing the policy object with the updatedPolicy we just created.
+      // this is replacing the softwareAutomation object with the updatedSoftwareAutomation we just created.
       const newState = prevState.map((currentSoftwareAutomation) => {
-        return currentSoftwareAutomation.id === softwareAutomationId &&
-          updatedSoftwareAutomation
+        return currentSoftwareAutomation.accessor ===
+          softwareAutomationAccessor && updatedSoftwareAutomation
           ? updatedSoftwareAutomation
           : currentSoftwareAutomation;
       });
@@ -77,8 +84,8 @@ const useCheckboxListStateManagement = (
   };
 
   return {
-    softwareAutomationsItems: softwareAutomationsItems,
-    updateSoftwareAutomationsItems: updateSoftwareAutomationsItems,
+    softwareAutomationsItems,
+    updateSoftwareAutomationsItems,
   };
 };
 
@@ -100,22 +107,22 @@ const ManageAutomationsModal = ({
   onCreateWebhookSubmit,
   togglePreviewPayloadModal,
   showPreviewPayloadModal,
-  availableSoftwareAutomations, // TODO: pass ManageAutomationsModal availableSoftwareAutomations
-  currentSoftwareAutomations, // TODO: pass ManageAutomationsModal currentSoftwareAutomations
+  softwareVulnerabilityWebhookEnabled,
   currentDestinationUrl,
 }: IManageAutomationsModalProps): JSX.Element => {
+  console.log(
+    "softwareVulnerabilityWebhookEnabled",
+    softwareVulnerabilityWebhookEnabled
+  );
   const [destination_url, setDestinationUrl] = useState<string>(
     currentDestinationUrl || ""
   );
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
 
   const {
-    softwareAutomationsItems, // TODO: update for software automations
-    updateSoftwareAutomationsItems, // TODO: update for software automations
-  } = useCheckboxListStateManagement(
-    availableSoftwareAutomations,
-    currentSoftwareAutomations
-  );
+    softwareAutomationsItems,
+    updateSoftwareAutomationsItems,
+  } = useCheckboxListStateManagement(softwareVulnerabilityWebhookEnabled);
 
   useDeepEffect(() => {
     if (destination_url) {
@@ -162,14 +169,14 @@ const ManageAutomationsModal = ({
         <div className={`${baseClass}__software-select-items`}>
           {softwareAutomationsItems && // Allows for more software automations to be set in the future
             softwareAutomationsItems.map((softwareItem: any) => {
-              const { isChecked, name, id } = softwareItem;
+              const { isChecked, name, accessor } = softwareItem;
               return (
-                <div key={id} className={`${baseClass}__team-item`}>
+                <div key={accessor} className={`${baseClass}__team-item`}>
                   <Checkbox
                     value={isChecked}
                     name={name}
                     onChange={() =>
-                      updateSoftwareAutomationsItems(softwareItem.id)
+                      updateSoftwareAutomationsItems(softwareItem.accessor)
                     }
                   >
                     {name}

--- a/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -1,0 +1,231 @@
+import React, { useState } from "react";
+
+import Modal from "components/Modal";
+import Button from "components/buttons/Button";
+// @ts-ignore
+import Checkbox from "components/forms/fields/Checkbox";
+// @ts-ignore
+import InputField from "components/forms/fields/InputField";
+import IconToolTip from "components/IconToolTip";
+import validURL from "components/forms/validators/valid_url";
+
+import { IWebhookSoftwareVulnerabilities } from "interfaces/webhook";
+import { useDeepEffect } from "utilities/hooks";
+import { size } from "lodash";
+
+import PreviewPayloadModal from "../PreviewPayloadModal";
+
+interface IManageAutomationsModalProps {
+  onCancel: () => void;
+  onCreateWebhookSubmit: (formData: IWebhookSoftwareVulnerabilities) => void;
+  togglePreviewPayloadModal: () => void;
+  showPreviewPayloadModal: boolean;
+  availableSoftwareAutomations: any;
+  currentSoftwareAutomations?: number[];
+  currentDestinationUrl?: string;
+}
+
+interface ICheckedPolicy {
+  name?: string;
+  id: number;
+  isChecked: boolean;
+}
+
+const useCheckboxListStateManagement = (
+  availableSoftwareAutomations: any,
+  currentSoftwareAutomations: number[] | undefined
+) => {
+  const [softwareAutomationsItems, setSoftwareAutomationsItems] = useState<
+    ICheckedPolicy[]
+  >(() => {
+    return (
+      availableSoftwareAutomations &&
+      availableSoftwareAutomations.map((automation: any) => {
+        return {
+          name: automation.name,
+          id: automation.id,
+          isChecked:
+            !!currentSoftwareAutomations &&
+            currentSoftwareAutomations.includes(automation.id),
+        };
+      })
+    );
+  });
+
+  const updateSoftwareAutomationsItems = (softwareAutomationId: number) => {
+    setSoftwareAutomationsItems((prevState) => {
+      const selectedSoftwareAutomation = softwareAutomationsItems.find(
+        (softwareAutomationItem) =>
+          softwareAutomationItem.id === softwareAutomationId
+      );
+
+      const updatedSoftwareAutomation = selectedSoftwareAutomation && {
+        ...selectedSoftwareAutomation,
+        isChecked:
+          !!selectedSoftwareAutomation && !selectedSoftwareAutomation.isChecked,
+      };
+
+      // this is replacing the policy object with the updatedPolicy we just created.
+      const newState = prevState.map((currentSoftwareAutomation) => {
+        return currentSoftwareAutomation.id === softwareAutomationId &&
+          updatedSoftwareAutomation
+          ? updatedSoftwareAutomation
+          : currentSoftwareAutomation;
+      });
+      return newState;
+    });
+  };
+
+  return {
+    softwareAutomationsItems: softwareAutomationsItems,
+    updateSoftwareAutomationsItems: updateSoftwareAutomationsItems,
+  };
+};
+
+const validateWebhookURL = (url: string) => {
+  const errors: { [key: string]: string } = {};
+
+  if (!validURL(url)) {
+    errors.url = "Please add a valid destination URL";
+  }
+
+  const valid = !size(errors);
+  return { valid, errors };
+};
+
+const baseClass = "manage-automations-modal";
+
+const ManageAutomationsModal = ({
+  onCancel: onReturnToApp,
+  onCreateWebhookSubmit,
+  togglePreviewPayloadModal,
+  showPreviewPayloadModal,
+  availableSoftwareAutomations, // TODO: pass ManageAutomationsModal availableSoftwareAutomations
+  currentSoftwareAutomations, // TODO: pass ManageAutomationsModal currentSoftwareAutomations
+  currentDestinationUrl,
+}: IManageAutomationsModalProps): JSX.Element => {
+  const [destination_url, setDestinationUrl] = useState<string>(
+    currentDestinationUrl || ""
+  );
+  const [errors, setErrors] = useState<{ [key: string]: string }>({});
+
+  const {
+    softwareAutomationsItems, // TODO: update for software automations
+    updateSoftwareAutomationsItems, // TODO: update for software automations
+  } = useCheckboxListStateManagement(
+    availableSoftwareAutomations,
+    currentSoftwareAutomations
+  );
+
+  useDeepEffect(() => {
+    if (destination_url) {
+      setErrors({});
+    }
+  }, [destination_url]);
+
+  const onURLChange = (value: string) => {
+    setDestinationUrl(value);
+  };
+
+  const handleSaveAutomation = (evt: React.MouseEvent<HTMLFormElement>) => {
+    evt.preventDefault();
+
+    const { valid, errors: newErrors } = validateWebhookURL(destination_url);
+    setErrors({
+      ...errors,
+      ...newErrors,
+    });
+
+    if (valid) {
+      const enable_vulnerabilities_webhook = true; // Leave nearest component in case we decide to add disabling as a UI feature
+
+      onCreateWebhookSubmit({
+        destination_url,
+        enable_vulnerabilities_webhook,
+      });
+
+      onReturnToApp();
+    }
+  };
+
+  if (showPreviewPayloadModal) {
+    return <PreviewPayloadModal onCancel={togglePreviewPayloadModal} />;
+  }
+
+  return (
+    <Modal
+      onExit={onReturnToApp}
+      title={"Manage automations"}
+      className={baseClass}
+    >
+      <div className={baseClass}>
+        <div className={`${baseClass}__software-select-items`}>
+          {softwareAutomationsItems && // Allows for more software automations to be set in the future
+            softwareAutomationsItems.map((softwareItem: any) => {
+              const { isChecked, name, id } = softwareItem;
+              return (
+                <div key={id} className={`${baseClass}__team-item`}>
+                  <Checkbox
+                    value={isChecked}
+                    name={name}
+                    onChange={() =>
+                      updateSoftwareAutomationsItems(softwareItem.id)
+                    }
+                  >
+                    {name}
+                  </Checkbox>
+                </div>
+              );
+            })}
+        </div>
+
+        <div className="tooltip-wrap tooltip-wrap--input">
+          <InputField
+            inputWrapperClass={`${baseClass}__url-input`}
+            name="webhook-url"
+            label={"Destination URL"}
+            type={"text"}
+            value={destination_url}
+            onChange={onURLChange}
+            error={errors.url}
+            hint={
+              "For each new vulnerability detected, Fleet will send a JSON payload to this URL with a list of the affected hosts."
+            }
+            placeholder={"https://server.com/example"}
+          />
+          <IconToolTip
+            isHtml
+            text={"<p>Provide a URL to deliver a<br />webhook request to.</p>"}
+          />
+        </div>
+        <Button
+          type="button"
+          variant="text-link"
+          onClick={togglePreviewPayloadModal}
+        >
+          Preview payload
+        </Button>
+
+        <div className={`${baseClass}__button-wrap`}>
+          <Button
+            className={`${baseClass}__btn`}
+            onClick={onReturnToApp}
+            variant="inverse"
+          >
+            Cancel
+          </Button>
+          <Button
+            className={`${baseClass}__btn`}
+            type="submit"
+            variant="brand"
+            onClick={handleSaveAutomation}
+          >
+            Save
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ManageAutomationsModal;

--- a/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -14,7 +14,6 @@ import { useDeepEffect } from "utilities/hooks";
 import { size } from "lodash";
 
 import PreviewPayloadModal from "../PreviewPayloadModal";
-import { createSecureContext } from "tls";
 
 interface IManageAutomationsModalProps {
   onCancel: () => void;
@@ -47,16 +46,18 @@ const useCheckboxListStateManagement = (
   >(() => {
     return (
       availableSoftwareAutomations &&
-      availableSoftwareAutomations.map((automation: any) => {
-        return {
-          name: automation.name,
-          accessor: automation.accessor,
-          isChecked: currentSoftwareAutomations.some(
-            (currentSoftwareAutomationItem: ICheckedSoftwareAutomation) =>
-              currentSoftwareAutomationItem.accessor === automation.accessor
-          ),
-        };
-      })
+      availableSoftwareAutomations.map(
+        (automation: ICheckedSoftwareAutomation) => {
+          return {
+            name: automation.name,
+            accessor: automation.accessor,
+            isChecked: currentSoftwareAutomations.some(
+              (currentSoftwareAutomationItem: ICheckedSoftwareAutomation) =>
+                currentSoftwareAutomationItem.accessor === automation.accessor
+            ),
+          };
+        }
+      )
     );
   });
 
@@ -170,23 +171,25 @@ const ManageAutomationsModal = ({
     >
       <div className={baseClass}>
         <div className={`${baseClass}__software-select-items`}>
-          {softwareAutomationsItems && // Allows for more software automations to be set in the future
-            softwareAutomationsItems.map((softwareItem: any) => {
-              const { isChecked, name, accessor } = softwareItem;
-              return (
-                <div key={accessor} className={`${baseClass}__team-item`}>
-                  <Checkbox
-                    value={isChecked}
-                    name={name}
-                    onChange={() =>
-                      updateSoftwareAutomationsItems(softwareItem.accessor)
-                    }
-                  >
-                    {name}
-                  </Checkbox>
-                </div>
-              );
-            })}
+          {softwareAutomationsItems &&
+            softwareAutomationsItems.map(
+              (softwareItem: ICheckedSoftwareAutomation) => {
+                const { isChecked, name, accessor } = softwareItem;
+                return (
+                  <div key={accessor} className={`${baseClass}__team-item`}>
+                    <Checkbox
+                      value={isChecked}
+                      name={name}
+                      onChange={() =>
+                        updateSoftwareAutomationsItems(softwareItem.accessor)
+                      }
+                    >
+                      {name}
+                    </Checkbox>
+                  </div>
+                );
+              }
+            )}
         </div>
 
         <div className="tooltip-wrap tooltip-wrap--input">

--- a/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/_styles.scss
@@ -1,0 +1,69 @@
+.manage-automations-modal {
+  width: 778px;
+
+  &__button-wrap {
+    display: flex;
+    justify-content: flex-end;
+    margin: $pad-large 0 0;
+  }
+
+  .button--inverse {
+    padding: $pad-small;
+    margin-right: $pad-small;
+  }
+
+  pre,
+  code {
+    background-color: $ui-off-white;
+    color: $core-fleet-blue;
+    border: 1px solid $ui-fleet-blue-15;
+    border-radius: 4px;
+    padding: 7px $pad-medium;
+    margin: $pad-large 0 0 44px;
+  }
+
+  &__error {
+    color: $ui-error;
+  }
+
+  .tooltip-wrap {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    margin-bottom: $pad-large;
+
+    .icon-tooltip {
+      span {
+        display: flex;
+        align-items: center;
+      }
+      p {
+        text-align: center;
+      }
+    }
+
+    .form-field--input {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      margin-right: $pad-small;
+      margin-bottom: 0;
+    }
+
+    .form-field__hint {
+      font-style: normal;
+    }
+  }
+
+  .tooltip-wrap--input {
+    .icon-tooltip {
+      span {
+        margin-top: -5px;
+      }
+    }
+  }
+
+  .form-field__label--error {
+    color: $ui-error;
+  }
+}

--- a/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/index.ts
+++ b/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ManageAutomationsModal";

--- a/frontend/pages/software/ManageSoftwarePage/components/PreviewPayloadModal/PreviewPayloadModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/PreviewPayloadModal/PreviewPayloadModal.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { syntaxHighlight } from "fleet/helpers";
+
+import Modal from "components/Modal";
+import Button from "components/buttons/Button";
+// @ts-ignore
+import FleetIcon from "components/icons/FleetIcon";
+
+const baseClass = "preview-data-modal";
+
+interface IPreviewPayloadModalProps {
+  onCancel: () => void;
+}
+
+const PreviewPayloadModal = ({
+  onCancel,
+}: IPreviewPayloadModalProps): JSX.Element => {
+  const json = {
+    timestamp: "0000-00-00T00:00:00Z",
+    vulnerability: {
+      cve: "CVE-2014-9471",
+      details_link: "https://nvd.nist.gov/vuln/detail/CVE-2014-9471",
+      hosts_affected: [
+        {
+          id: 1,
+          hostname: "macbook-1",
+          url: "https://fleet.example.com/hosts/1",
+        },
+        {
+          id: 2,
+          hostname: "macbook-2",
+          url: "https://fleet.example.com/hosts/2",
+        },
+      ],
+    },
+  };
+
+  return (
+    <Modal title={"Example payload"} onExit={onCancel} className={baseClass}>
+      <div className={`${baseClass}__preview-modal`}>
+        <p>
+          Want to learn more about how automations in Fleet work?{" "}
+          <a
+            href="https://fleetdm.com/docs/using-fleet/automations"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Check out the Fleet documentation&nbsp;
+            <FleetIcon name="external-link" />
+          </a>
+        </p>
+        <div className={`${baseClass}__payload-request-preview`}>
+          <pre>POST https://server.com/example</pre>
+        </div>
+        <div className={`${baseClass}__payload-webhook-preview`}>
+          <pre dangerouslySetInnerHTML={{ __html: syntaxHighlight(json) }} />
+        </div>
+        <div className={`${baseClass}__btn-wrap`}>
+          <Button
+            className={`${baseClass}__btn`}
+            onClick={onCancel}
+            variant="brand"
+          >
+            Done
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default PreviewPayloadModal;

--- a/frontend/pages/software/ManageSoftwarePage/components/PreviewPayloadModal/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/components/PreviewPayloadModal/_styles.scss
@@ -1,4 +1,4 @@
-.preview-data-modal {
+.preview-payload-modal {
   &__sandbox-info {
     margin-top: $pad-medium;
 

--- a/frontend/pages/software/ManageSoftwarePage/components/PreviewPayloadModal/index.ts
+++ b/frontend/pages/software/ManageSoftwarePage/components/PreviewPayloadModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PreviewPayloadModal";


### PR DESCRIPTION
Cerra #3762 

- Add appropriate parts to Software page to render Manage automation and Preview modals
- Add Manage automation modal for Software Vulnerability 
- Add Preview modal for Software Vulnerability
- Ensures `config` is being updated in states (both redux and AppContext) when updating webhook
- Update RBAC e2e tests for software page to include checking manage automations modal
- Add software vulnerability to `interface/config`
- Adds `IWebhookSoftwareVulnerabilities` to `interface/webhook.ts`

Other tech debt cleaned up in this PR:
- Remove unused CSS from similar modal
- Update RBAC free tests that were missing software page, dashboard and nav tests
- More consistency between e2e tests wording
- Adds `IWebhookHostStatus` to `interface/webhook.ts`

https://www.loom.com/share/c084bd5459864474afdbbd749d045905

<img width="1271" alt="Screen Shot 2022-02-03 at 6 57 55 PM" src="https://user-images.githubusercontent.com/71795832/152454737-07b5b61a-b958-45a9-acc1-66b2045e6e48.png">
<img width="1275" alt="Screen Shot 2022-02-03 at 6 58 02 PM" src="https://user-images.githubusercontent.com/71795832/152454733-77ebb769-7ca0-4ba6-b585-19e41808e6be.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] (Confirmed!) Documented any API changes (docs/01-Using-Fleet/03-REST-API.md) 
- [x] (Opened #4022 for product) Documented any permissions changes
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
