### PR TITLE
Remove escaped parethesis

### DIFF
--- a/cmd/osquery-perf/vulnerable.software
+++ b/cmd/osquery-perf/vulnerable.software
@@ -60,7 +60,7 @@ realplayer##12.0.1.1738
 foxmail##1.2
 purevpn##6.0.1
 hipchat##4.30
-jabber##12.9\(3\)
+jabber##12.9(3)
 quicken_2018##5.2.2
 shimo##4.1.5.1
 evernote##8.3.2


### PR DESCRIPTION
This was causing issues (on the osquery perf side) when running osquery perf against our loadtest env.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- ~Changes file added (for user-visible changes)~
- ~Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
- ~Documented any permissions changes~
- ~Added/updated tests~
- [x] Manual QA for all new/changed functionality
