### PR TITLE
linux_shared.go: update postinstall script

### DIFF
--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -231,10 +231,11 @@ var postInstallTemplate = template.Must(template.New("postinstall").Parse(`
 set -e
 
 # If we have a systemd, daemon-reload away now
-if which systemctl; then
-  systemctl daemon-reload 2>/dev/null 2>&1
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl daemon-reload >/dev/null 2>&1
 {{ if .StartService -}}
   systemctl restart orbit.service 2>&1
+  systemctl enable orbit.service 2>&1
 {{- end}}
 fi
 `))


### PR DESCRIPTION
1. In sh, `which` is actually a binary usually located at `/usr/bin`, but not every GNU/Linux distribution comes with it installed by default. Whereas, `command` is a built-in shell tool, hence, it's safer to use it instead of which to verify if a binary is present in the machine
2. I believe there was a typo in the redirections in the `systemctl daemon-reload 2>/dev/null 2>&1` line
3. The `systemctl enable` command is necessary because the service is created, but not activated, meaning when the user reboots his machine orbit won't automatically relaunch

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
