### PR TITLE
Fix OSVersion to work properly when distribution does not follow symver

### DIFF
--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -112,13 +112,21 @@ var detailQueries = map[string]DetailQuery{
 				return nil
 			}
 
-			host.OSVersion = fmt.Sprintf(
-				"%s %s.%s.%s",
-				rows[0]["name"],
-				rows[0]["major"],
-				rows[0]["minor"],
-				rows[0]["patch"],
-			)
+			if rows[0]["major"] != "0" && rows[0]["minor"] != "0" && rows[0]["patch"] != "0" {
+				host.OSVersion = fmt.Sprintf(
+					"%s %s.%s.%s",
+					rows[0]["name"],
+					rows[0]["major"],
+					rows[0]["minor"],
+					rows[0]["patch"],
+				)
+			} else {
+				host.OSVersion = fmt.Sprintf(
+					"%s %s",
+					rows[0]["name"],
+					rows[0]["build"],
+				)
+			}
 			host.OSVersion = strings.Trim(host.OSVersion, ".")
 
 			if build, ok := rows[0]["build"]; ok {


### PR DESCRIPTION
Certain distros such as ClearLinux or ArchLinux do not use symver or any
dotted versioning scheme for their releases. Archlinux uses the static
string "Rolling" and ClearLinux uses a single build number such as 35550
for their versions.

In Fleet console, this shows up as a string like "Archlinux 0.0.0.0"
which makes very little sense to the user. This change makes it so that
if OSQuery cannot generate a dotted version number, we should instead
use the build id as an opaque string.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
