### PR TITLE
Normalizing var.prefix and fleetdm->fleet

### DIFF
--- a/tools/terraform/ecs-iam.tf
+++ b/tools/terraform/ecs-iam.tf
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "main" {
-  name               = "fleetdm-role"
+  name               = "${var.prefix}fleet-role"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
@@ -81,7 +81,7 @@ resource "aws_iam_role_policy_attachment" "role_attachment" {
 }
 
 resource "aws_iam_policy" "main" {
-  name   = "fleet-iam-policy"
+  name   = "${var.prefix}fleet-iam-policy"
   policy = data.aws_iam_policy_document.fleet.json
 }
 

--- a/tools/terraform/ecs-sgs.tf
+++ b/tools/terraform/ecs-sgs.tf
@@ -1,13 +1,13 @@
 # Security group for the public internet facing load balancer
 resource "aws_security_group" "lb" {
-  name        = "${var.prefix} load balancer"
-  description = "${var.prefix} Load balancer security group"
+  name        = "${var.prefix}fleet load balancer"
+  description = "${var.prefix}fleet load balancer security group"
   vpc_id      = module.vpc.vpc_id
 }
 
 # Allow traffic from public internet
 resource "aws_security_group_rule" "lb-ingress" {
-  description = "${var.prefix}: allow traffic from public internet"
+  description = "${var.prefix}fleet: allow traffic from public internet"
   type        = "ingress"
 
   from_port   = "443"
@@ -19,7 +19,7 @@ resource "aws_security_group_rule" "lb-ingress" {
 }
 
 resource "aws_security_group_rule" "lb-http-ingress" {
-  description = "${var.prefix}: allow traffic from public internet"
+  description = "${var.prefix}fleet: allow traffic from public internet"
   type        = "ingress"
 
   from_port   = "80"
@@ -32,7 +32,7 @@ resource "aws_security_group_rule" "lb-http-ingress" {
 
 # Allow outbound traffic
 resource "aws_security_group_rule" "lb-egress" {
-  description = "${var.prefix}: allow all outbound traffic"
+  description = "${var.prefix}fleet: allow all outbound traffic"
   type        = "egress"
 
   from_port   = 0
@@ -46,15 +46,15 @@ resource "aws_security_group_rule" "lb-egress" {
 # Security group for the backends that run the application.
 # Allows traffic from the load balancer
 resource "aws_security_group" "backend" {
-  name        = "${var.prefix} backend"
-  description = "${var.prefix} Backend security group"
+  name        = "${var.prefix}fleet backend"
+  description = "${var.prefix}fleet backend security group"
   vpc_id      = module.vpc.vpc_id
 
 }
 
 # Allow traffic from the load balancer to the backends
 resource "aws_security_group_rule" "backend-ingress" {
-  description = "${var.prefix}: allow traffic from load balancer"
+  description = "${var.prefix}fleet: allow traffic from load balancer"
   type        = "ingress"
 
   from_port                = "8080"
@@ -66,7 +66,7 @@ resource "aws_security_group_rule" "backend-ingress" {
 
 # Allow outbound traffic from the backends
 resource "aws_security_group_rule" "backend-egress" {
-  description = "${var.prefix}: allow all outbound traffic"
+  description = "${var.prefix}fleet: allow all outbound traffic"
   type        = "egress"
 
   from_port   = 0

--- a/tools/terraform/firehose.tf
+++ b/tools/terraform/firehose.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "osquery-results" {
-  bucket = var.osquery_results_s3_bucket
+  bucket = "${var.prefix}fleet-osquery-results-archive"
   acl    = "private"
 
   lifecycle_rule {
@@ -19,7 +19,7 @@ resource "aws_s3_bucket" "osquery-results" {
 }
 
 resource "aws_s3_bucket" "osquery-status" {
-  bucket = var.osquery_status_s3_bucket
+  bucket = "${var.prefix}fleet-osquery-status-archive"
   acl    = "private"
 
   lifecycle_rule {
@@ -67,12 +67,12 @@ data "aws_iam_policy_document" "osquery_status_policy_doc" {
 }
 
 resource "aws_iam_policy" "firehose-results" {
-  name   = "osquery_results_firehose_policy"
+  name   = "${var.prefix}osquery-results-firehose-policy"
   policy = data.aws_iam_policy_document.osquery_results_policy_doc.json
 }
 
 resource "aws_iam_policy" "firehose-status" {
-  name   = "osquery_status_firehose_policy"
+  name   = "${var.prefix}osquery-status-firehose-policy"
   policy = data.aws_iam_policy_document.osquery_status_policy_doc.json
 }
 
@@ -106,7 +106,7 @@ data "aws_iam_policy_document" "osquery_firehose_assume_role" {
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "osquery_results" {
-  name        = "osquery_results"
+  name        = "${var.prefix}osquery-results"
   destination = "s3"
 
   s3_configuration {
@@ -116,7 +116,7 @@ resource "aws_kinesis_firehose_delivery_stream" "osquery_results" {
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "osquery_status" {
-  name        = "osquery_status"
+  name        = "${var.prefix}osquery-status"
   destination = "s3"
 
   s3_configuration {

--- a/tools/terraform/main.tf
+++ b/tools/terraform/main.tf
@@ -9,10 +9,10 @@ provider "aws" {
 terraform {
   // these values should match what is bootstrapped in ./remote-state
   backend "s3" {
-    bucket         = "fleet-terraform-remote-state"
+    bucket         = "${var.prefix}fleet-terraform-remote-state"
     region         = "us-east-2"
     key            = "fleet/"
-    dynamodb_table = "fleet-terraform-state-lock"
+    dynamodb_table = "${var.prefix}fleet-terraform-state-lock"
   }
   required_providers {
     aws = {

--- a/tools/terraform/main.tf
+++ b/tools/terraform/main.tf
@@ -9,10 +9,10 @@ provider "aws" {
 terraform {
   // these values should match what is bootstrapped in ./remote-state
   backend "s3" {
-    bucket         = "${var.prefix}fleet-terraform-remote-state"
+    bucket         = "fleet-terraform-remote-state"
     region         = "us-east-2"
     key            = "fleet/"
-    dynamodb_table = "${var.prefix}fleet-terraform-state-lock"
+    dynamodb_table = "fleet-terraform-state-lock"
   }
   required_providers {
     aws = {

--- a/tools/terraform/rds.tf
+++ b/tools/terraform/rds.tf
@@ -4,7 +4,7 @@ resource "random_password" "database_password" {
 }
 
 resource "aws_secretsmanager_secret" "database_password_secret" {
-  name = "/fleet/database/password/master"
+  name = "${var.secret_prefix}/fleet/database/password/master"
 }
 
 resource "aws_secretsmanager_secret_version" "database_password_secret_version" {
@@ -17,7 +17,7 @@ resource "aws_secretsmanager_secret_version" "database_password_secret_version" 
 //  source  = "terraform-aws-modules/rds-aurora/aws"
 //  version = "5.2.0"
 //
-//  name                   = "${local.name}-mysql"
+//  name                   = "${var.prefix}fleet-mysql"
 //  engine                 = "aurora-mysql"
 //  engine_mode            = "serverless"
 //  storage_encrypted      = true
@@ -63,7 +63,7 @@ module "aurora_mysql" {
   source  = "terraform-aws-modules/rds-aurora/aws"
   version = "5.2.0"
 
-  name                  = "${local.name}-mysql-iam"
+  name                  = "${var.prefix}fleet-mysql-iam"
   engine                = "aurora-mysql"
   engine_version        = "5.7.mysql_aurora.2.10.0"
   instance_type         = var.db_instance_type_writer
@@ -89,9 +89,9 @@ module "aurora_mysql" {
   replica_scale_max     = 3
 
   monitoring_interval           = 60
-  iam_role_name                 = "${local.name}-rds-enhanced-monitoring"
+  iam_role_name                 = "${var.prefix}fleet-rds-enhanced-monitoring"
   iam_role_use_name_prefix      = true
-  iam_role_description          = "${local.name} RDS enhanced monitoring IAM role"
+  iam_role_description          = "${var.prefix} RDS enhanced monitoring IAM role"
   iam_role_path                 = "/autoscaling/"
   iam_role_max_session_duration = 7200
 
@@ -104,13 +104,13 @@ module "aurora_mysql" {
 }
 
 resource "aws_db_parameter_group" "example_mysql" {
-  name        = "${local.name}-aurora-db-mysql-parameter-group"
+  name        = "${var.prefix}fleet-aurora-db-mysql-parameter-group"
   family      = "aurora-mysql5.7"
-  description = "${local.name}-aurora-db-mysql-parameter-group"
+  description = "${var.prefix}fleet-aurora-db-mysql-parameter-group"
 }
 
 resource "aws_rds_cluster_parameter_group" "example_mysql" {
-  name        = "${local.name}-aurora-mysql-cluster-parameter-group"
+  name        = "${var.prefix}fleet-aurora-mysql-cluster-parameter-group"
   family      = "aurora-mysql5.7"
-  description = "${local.name}-aurora-mysql-cluster-parameter-group"
+  description = "${var.prefix}fleet-aurora-mysql-cluster-parameter-group"
 }

--- a/tools/terraform/redis.tf
+++ b/tools/terraform/redis.tf
@@ -16,7 +16,7 @@ resource "aws_elasticache_replication_group" "default" {
   parameter_group_name          = "default.redis6.x"
   subnet_group_name             = module.vpc.elasticache_subnet_group_name
   security_group_ids            = [aws_security_group.redis.id]
-  replication_group_id          = "fleetdm-redis"
+  replication_group_id          = "${var.prefix}fleet-redis"
   number_cache_clusters         = var.number_cache_clusters
   node_type                     = var.redis_instance
   engine_version                = var.engine_version
@@ -27,7 +27,7 @@ resource "aws_elasticache_replication_group" "default" {
   at_rest_encryption_enabled    = false
   transit_encryption_enabled    = false
   apply_immediately             = true
-  replication_group_description = "fleetdm-redis"
+  replication_group_description = "${var.prefix}fleet-redis"
 }
 
 resource "aws_security_group" "redis" {
@@ -36,7 +36,7 @@ resource "aws_security_group" "redis" {
 }
 
 locals {
-  security_group_name = "${var.prefix}-elasticache-redis"
+  security_group_name = "${var.prefix}fleet-elasticache-redis"
 }
 
 resource "aws_security_group_rule" "ingress" {

--- a/tools/terraform/s3.tf
+++ b/tools/terraform/s3.tf
@@ -1,6 +1,6 @@
 // file carving destination
 resource "aws_s3_bucket" "osquery-carve" {
-  bucket = "osquery-carve-${terraform.workspace}"
+  bucket = "${var.prefix}fleet-osquery-carve"
   acl    = "private"
 
   lifecycle_rule {

--- a/tools/terraform/variables.tf
+++ b/tools/terraform/variables.tf
@@ -3,20 +3,20 @@ locals {
 }
 
 variable "prefix" {
-  default = "fleet"
+  description = "Used to prefix resource names to make them unique"
+  default = "fleetdm-"
+}
+
+variable "secret_prefix" {
+  description = "Used to prefix the secret names. Typically the same as var.prefix"
+  default = "/fleetdm"
 }
 
 variable "domain_fleetdm" {
   default = "dogfood.fleetdm.com"
 }
 
-variable "osquery_results_s3_bucket" {
-  default = "fleet-osquery-results-archive"
-}
 
-variable "osquery_status_s3_bucket" {
-  default = "fleet-osquery-status-archive"
-}
 
 variable "vulnerabilities_path" {
   default = "/home/fleet"

--- a/tools/terraform/vpc.tf
+++ b/tools/terraform/vpc.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
 
-  name = "fleet-vpc"
+  name = "${var.prefix}fleet-vpc"
   cidr = "10.10.0.0/16"
 
   azs                 = ["us-east-2a", "us-east-2b", "us-east-2c"]


### PR DESCRIPTION
This is an effort to unify the usage of the prefix variable across all configurations. This PR also attempts to standardize on using `fleet` instead of `fleetdm` as an identifier as it was not consistent. Most objects used the prefix, but since it wasn’t uniform, we found that it was not possible to deploy multiple environments within the same AWS account due to resource naming conflicts.

If these changes are not inline with the desired naming conventions of the project, we would be happy to modify and re-submit this PR.

Co-Authored by: @mscottblake
