### PR TITLE
Add tags to standard query library and fleetdm.com/queries

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/README.md
+++ b/docs/01-Using-Fleet/standard-query-library/README.md
@@ -27,6 +27,7 @@ Want to add your own query?
     purpose: What is the goal of running your query? Ex. Detection
     remediation: Are there any remediation steps to resolve the detection triggered by your query? If not, insert "N/A."
     contributors: zwass,mike-j-thomas
+    tags: Keywords that can help users find other relevant queries, each tag should be seperated by a comma. (e.g., "foo,bar")
   ```
 
 2. Replace each field and submit a pull request to the fleetdm/fleet GitHub repository.

--- a/website/assets/js/pages/query-library.page.js
+++ b/website/assets/js/pages/query-library.page.js
@@ -8,6 +8,7 @@ parasails.registerPage('query-library', {
     searchString: '', // The user input string to be searched against the query library
     selectedKind: 'all queries', // Initially set to all, the user may select a different option to filter queries by purpose (e.g., "all queries", "informational", "policies")
     selectedPlatform: 'all platforms', // Initially set to all, the user may select a different option to filter queries by platform (e.g., "all platforms", "macOS", "Windows", "Linux")
+    selectedTag: '', // Initially set to a blank string, the user may select a tag filter queries by.
   },
 
   computed: {
@@ -15,7 +16,8 @@ parasails.registerPage('query-library', {
       return this.queries.filter(
         (query) =>
           this._isIncluded(query.platforms, this.selectedPlatform) &&
-          this._isIncluded(query.kind, this.selectedKind)
+          this._isIncluded(query.kind, this.selectedKind) &&
+          this._isIncluded(query.tags, this.selectedTag)
       );
     },
 
@@ -48,6 +50,10 @@ parasails.registerPage('query-library', {
 
     clickSelectPlatform(platform) {
       this.selectedPlatform = platform;
+    },
+
+    clickSelectTag(tag) {
+      this.selectedTag = tag;
     },
 
     clickCard: function (querySlug) {
@@ -109,6 +115,11 @@ parasails.registerPage('query-library', {
         if (query.contributors) {
           query.contributors.forEach((contributor) => {
             textToSearch += ', ' + normalize(contributor.name) + ', ' + normalize(contributor.handle);
+          });
+        }
+        if (query.tags) {
+          query.tags.forEach((tag) => {
+            textToSearch += ', ' + normalize(tag);
           });
         }
         return (searchTerms.some((term) => textToSearch.includes(term)));

--- a/website/assets/styles/pages/query-detail.less
+++ b/website/assets/styles/pages/query-detail.less
@@ -32,7 +32,7 @@
     font-weight: 700;
     padding: 4px 8px;
     border-radius: 20px;
-    background-color: #DBE3E5;
+    background-color: #E2E4EA;
   }
 
   [purpose='remediation'] {

--- a/website/assets/styles/pages/query-detail.less
+++ b/website/assets/styles/pages/query-detail.less
@@ -28,9 +28,8 @@
   }
 
   [purpose='query-tag'] {
-    font-size: 14px;
+    font-size: 12px;
     font-weight: 700;
-    line-height: 20px;
     padding: 4px 8px;
     border-radius: 20px;
     background-color: #DBE3E5;

--- a/website/assets/styles/pages/query-detail.less
+++ b/website/assets/styles/pages/query-detail.less
@@ -27,7 +27,7 @@
     border-color: #E2E4EA;
   }
 
-  [purpose="query-tag"] {
+  [purpose='query-tag'] {
     font-size: 14px;
     font-weight: 700;
     line-height: 20px;

--- a/website/assets/styles/pages/query-detail.less
+++ b/website/assets/styles/pages/query-detail.less
@@ -27,6 +27,15 @@
     border-color: #E2E4EA;
   }
 
+  [purpose="query-tag"] {
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 20px;
+    padding: 4px 8px;
+    border-radius: 20px;
+    background-color: #DBE3E5;
+  }
+
   [purpose='remediation'] {
     overflow-wrap: break-word;
     word-wrap: break-word;

--- a/website/assets/styles/pages/query-library.less
+++ b/website/assets/styles/pages/query-library.less
@@ -36,7 +36,7 @@
     }
   }
 
-  [purpose="query-tag"] {
+  [purpose='query-tag'] {
     font-size: 14px;
     font-weight: 700;
     line-height: 20px;
@@ -45,7 +45,7 @@
     background-color: #DBE3E5;
   }
 
-  [purpose="selected-tag"] {
+  [purpose='selected-tag'] {
     background: #F1F0FF;
     border: 1px solid #D9D9FE;
     box-sizing: border-box;

--- a/website/assets/styles/pages/query-library.less
+++ b/website/assets/styles/pages/query-library.less
@@ -36,6 +36,23 @@
     }
   }
 
+  [purpose="query-tag"] {
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 20px;
+    padding: 4px 8px;
+    border-radius: 20px;
+    background-color: #DBE3E5;
+  }
+
+  [purpose="selected-tag"] {
+    background: #F1F0FF;
+    border: 1px solid #D9D9FE;
+    box-sizing: border-box;
+    border-radius: 8px;
+    padding: 16px 24px;
+  }
+
   .input-group {
     &.search {
       width: 250px;
@@ -221,6 +238,10 @@
     box-shadow: 0 4px 16px 0 rgba(0, 0, 0, 0.1);
     margin-bottom: 90px;
     width: 100%;
+    padding: 40px;
+    p {
+      margin-block-end: 0px;
+    }
   }
 
   .card-body {

--- a/website/assets/styles/pages/query-library.less
+++ b/website/assets/styles/pages/query-library.less
@@ -41,15 +41,18 @@
     font-weight: 700;
     padding: 4px 8px;
     border-radius: 20px;
-    background-color: #DBE3E5;
+    background-color: #E2E4EA;
   }
 
   [purpose='selected-tag'] {
-    background: #F1F0FF;
-    border: 1px solid #D9D9FE;
-    box-sizing: border-box;
-    border-radius: 8px;
-    padding: 16px 24px;
+    border-bottom: 1px solid #e1e4e9;
+    padding: 16px 0;
+    margin-left: 30px;
+    margin-right: 30px;
+    p {
+      margin-bottom: 0;
+      line-height: 18px;
+    }
   }
 
   .input-group {
@@ -221,7 +224,7 @@
     border-radius: 8px;
     &:hover {
       .query-card {
-        background-color: #f1f0ff;
+        background-color: #F8F7FF;
         box-shadow: none;
         border: none;
         border-radius: 8px;
@@ -292,8 +295,11 @@
     }
 
     [purpose='selected-tag'] {
-      margin-left: 45px;
-      margin-right: 45px;
+      margin-left: 30px;
+      margin-right: 30px;
+      [purpose='query-tag'] {
+      margin-top: 8px;
+      }
     }
 
     .results {

--- a/website/assets/styles/pages/query-library.less
+++ b/website/assets/styles/pages/query-library.less
@@ -242,6 +242,9 @@
     p {
       margin-block-end: 0px;
     }
+    a {
+      font-size: 16px;
+    }
   }
 
   .card-body {

--- a/website/assets/styles/pages/query-library.less
+++ b/website/assets/styles/pages/query-library.less
@@ -37,9 +37,8 @@
   }
 
   [purpose='query-tag'] {
-    font-size: 14px;
+    font-size: 12px;
     font-weight: 700;
-    line-height: 20px;
     padding: 4px 8px;
     border-radius: 20px;
     background-color: #DBE3E5;

--- a/website/assets/styles/pages/query-library.less
+++ b/website/assets/styles/pages/query-library.less
@@ -289,6 +289,11 @@
       margin-bottom: 0px;
     }
 
+    [purpose='selected-tag'] {
+      margin-left: 45px;
+      margin-right: 45px;
+    }
+
     .results {
       margin-top: 16px;
     }

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -41,21 +41,22 @@ module.exports = {
           } else if (query.resolution === undefined) {
             query.resolution = 'N/A';// « We set this to a string here so that the data type is always string.  We use N/A so folks can see there's no remediation and contribute if desired.
           }
-          if (query.tags){
+          if (query.tags) {
             if(!_.isString(query.tags)) {
               queriesWithProblematicTags.push(query);
-            }
-            // Splitting tags into an array to format them.
-            let tagsToFormat = query.tags.split(',');
-            let formattedTags = [];
-            tagsToFormat.forEach((tag)=>{
-              if(tag !== '') {// « Ignoring any blank tags caused by trailing commas in the YAML.
-                // Formatting tags in sentence case, and removing any extra whitespace.
-                formattedTags.push(_.capitalize(_.trim(tag)));
+            } else {
+              // Splitting tags into an array to format them.
+              let tagsToFormat = query.tags.split(',');
+              let formattedTags = [];
+              for (let tag of tagsToFormat) {
+                if(tag !== '') {// « Ignoring any blank tags caused by trailing commas in the YAML.
+                  // Formatting tags in sentence case, and removing any extra whitespace.
+                  formattedTags.push(_.capitalize(_.trim(tag)));
+                }
               }
-            });
-            // Removing any duplicate tags.
-            query.tags = _.uniq(formattedTags);
+              // Removing any duplicate tags.
+              query.tags = _.uniq(formattedTags);
+            }
           }
 
           // GitHub usernames may only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen.

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -57,6 +57,8 @@ module.exports = {
               // Removing any duplicate tags.
               query.tags = _.uniq(formattedTags);
             }
+          } else {
+            query.tags = []; // « if there are no tags, we set query.tags to an empty array so it is always the same data type.
           }
 
           // GitHub usernames may only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen.

--- a/website/views/pages/query-detail.ejs
+++ b/website/views/pages/query-detail.ejs
@@ -41,6 +41,17 @@
             </div>
           </div>
         </div>
+        <div class="border-top py-2 pb-md-4">
+          <div class="d-flex flex-md-column justify-content-between justify-content-md-start align-items-center align-items-md-start py-1 pt-md-3">
+            <h5 class="pb-md-2 m-0">Labels</h5>
+            <div class="d-flex flex-wrap align-items-center">
+              <span class="mb-1" v-if="!query.tags || !query.tags.length">--</span>
+              <div purpose="query-tag" class="mr-2 mb-2" v-for="tag in query.tags">
+                {{tag}}
+              </div>
+            </div>
+          </div>
+        </div>
         <div class="border-top py-2">
           <div class="d-flex flex-md-column justify-content-between justify-content-md-start align-items-center align-items-md-start py-1 py-md-3">
             <h5 class="pb-md-2 m-0">Purpose</h5>

--- a/website/views/pages/query-detail.ejs
+++ b/website/views/pages/query-detail.ejs
@@ -42,11 +42,11 @@
           </div>
         </div>
         <div class="border-top py-2 pb-md-4">
-          <div class="d-flex flex-md-column justify-content-between justify-content-md-start align-items-center align-items-md-start py-1 pt-md-3">
+          <div class="d-flex flex-md-column justify-content-between justify-content-md-start align-items-center align-items-md-start pt-md-3">
             <h5 class="pb-md-2 m-0">Labels</h5>
-            <div class="d-flex flex-wrap align-items-center">
+            <div :class="[query.tags.length > 2 ? 'mt-1' : '']"  class="d-flex flex-wrap align-items-center justify-content-end justify-content-sm-start">
               <span class="mb-1" v-if="!query.tags || !query.tags.length">--</span>
-              <div purpose="query-tag" class="mr-2 mb-2" v-for="tag in query.tags">
+              <div purpose="query-tag" class="mr-md-1 ml-1 ml-md-0" :class="[query.tags.length > 2 ? 'mb-1' : '']" v-for="tag in query.tags">
                 {{tag}}
               </div>
             </div>

--- a/website/views/pages/query-detail.ejs
+++ b/website/views/pages/query-detail.ejs
@@ -43,7 +43,7 @@
         </div>
         <div class="border-top py-2 pb-md-4">
           <div class="d-flex flex-md-column justify-content-between justify-content-md-start align-items-center align-items-md-start pt-md-3">
-            <h5 class="pb-md-2 m-0">Labels</h5>
+            <h5 class="pb-md-2 m-0">Tags</h5>
             <div :class="[query.tags.length > 2 ? 'mt-1' : '']"  class="d-flex flex-wrap align-items-center justify-content-end justify-content-sm-start">
               <span class="mb-1" v-if="!query.tags || !query.tags.length">--</span>
               <div purpose="query-tag" class="mr-md-1 ml-1 ml-md-0" :class="[query.tags.length > 2 ? 'mb-1' : '']" v-for="tag in query.tags">

--- a/website/views/pages/query-library.ejs
+++ b/website/views/pages/query-library.ejs
@@ -92,10 +92,8 @@
         </div>
       </div>
       <div class="results">
-        <div style="min-height: 0px;" class="row justify-content-center">
-          <div purpose="selected-tag" class="mb-3" v-if="selectedTag">
-            <strong>Showing {{ selectedKind === 'query' ? 'informational queries' : selectedKind === 'policy' ? 'policies' : 'all queries'}} with the "{{selectedTag}}" label.<span style="color: #FF5C83; cursor: pointer;" class="fa fa-times-circle pl-2" @click="clickSelectTag('')"></span></strong>
-          </div>
+        <div purpose="selected-tag" class="mb-3" v-if="selectedTag">
+          <p>Showing {{ selectedKind === 'query' ? 'informational queries' : selectedKind === 'policy' ? 'policies' : 'all queries'}} for <span purpose="query-tag" class="d-inline-block" style="cursor: pointer;" @click="clickSelectTag('')">{{selectedTag}}<span style="color: #8b8fa2;" class="fa fa-times-circle pl-2"></span></span></p>
         </div>
         <div class="category__informational">
           <div v-for="query of queriesList">

--- a/website/views/pages/query-library.ejs
+++ b/website/views/pages/query-library.ejs
@@ -154,8 +154,7 @@
         <h3 class="mb-3">Contributors</h3>
         <p><strong>Want to add your own query?</strong> Please submit a pull request
           <a href="https://github.com/fleetdm/fleet/edit/main/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml">
-            over on GitHub
-          </a>.
+            over on GitHub</a>.
         </p>
       </div>
     </div>

--- a/website/views/pages/query-library.ejs
+++ b/website/views/pages/query-library.ejs
@@ -92,18 +92,30 @@
         </div>
       </div>
       <div class="results">
+        <div class="row justify-content-center">
+          <div purpose="selected-tag" class="mb-3" v-if="selectedTag">
+            <strong>Showing {{ selectedKind === 'query' ? 'informational queries' : selectedKind === 'policy' ? 'policies' : 'all queries'}} with the "{{selectedTag}}" label.<span style="color: #FF5C83; cursor: pointer;" class="fa fa-times-circle pl-2" @click="clickSelectTag('')"></span></strong>
+          </div>
+        </div>
         <div class="category__informational">
           <div v-for="query of queriesList">
             <div class="card results" @click="clickCard(query.slug)">
               <div class="card-body">
                 <div class="row justify-content-between align-items-center query-card">
+                  <div class="col-12">
+                    <div class="d-block d-sm-flex flex-wrap">
+                      <h5 class="card-title m-0 mb-1 mr-sm-2">{{query.name}}</h5>
+                      <div class="my-2 my-sm-0">
+                        <span class="mr-2" purpose="query-tag" v-for="tag in query.tags" @click.stop="clickSelectTag(tag)">{{tag}}</span>
+                      </div>
+                    </div>
+                  </div>
                   <div class="col-sm-9 col-md-9">
-                    <h5 class="card-title m-0">{{query.name}}</h5>
                     <p class="font-italic mb-1 p-0 description">{{query.description}}</p>
                     <div class="contributors" v-if="query.contributors && query.contributors.length">
                       <div class="d-flex mb-2 mb-sm-1 align-items-center">
                         <div v-for="contributor in query.contributors">
-                          <div class="d-flex m-1 avatar-frame" @click="clickAvatar(contributor)">
+                          <div class="d-flex m-1 avatar-frame" @click.stop="clickAvatar(contributor)">
                             <img alt="a GitHub user avatar" :alt="contributor" :src="contributor.avatarUrl" />
                           </div>
                         </div>
@@ -138,7 +150,7 @@
   </div>
   <div class="d-flex justify-content-center p-3">
     <div class="card call-to-action col-6-grow my-5 library">
-      <div class="card-body">
+      <div class="card-body px-0">
         <h3 class="mb-3">Contributors</h3>
         <p><strong>Want to add your own query?</strong> Please submit a pull request
           <a href="https://github.com/fleetdm/fleet/edit/main/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml">

--- a/website/views/pages/query-library.ejs
+++ b/website/views/pages/query-library.ejs
@@ -92,7 +92,7 @@
         </div>
       </div>
       <div class="results">
-        <div purpose="selected-tag" class="mb-3" v-if="selectedTag">
+        <div purpose="selected-tag" v-if="selectedTag">
           <p>Showing {{ selectedKind === 'query' ? 'informational queries' : selectedKind === 'policy' ? 'policies' : 'all queries'}} for <span purpose="query-tag" class="d-inline-block" style="cursor: pointer;" @click="clickSelectTag('')">{{selectedTag}}<span style="color: #8b8fa2;" class="fa fa-times-circle pl-2"></span></span></p>
         </div>
         <div class="category__informational">
@@ -121,7 +121,7 @@
                       </div>
                     </div>
                   </div>
-                  <div class="col-sm-3 col-md-auto">
+                  <div class="col-sm-3 col-md-auto align-self-start">
                     <div class="text-sm-right m-0">
                       <img class="d-inline-flex mr-1 mr-sm-0 ml-sm-1 ml-md-2 logo"
                         src="/images/os-macos-black-16x16@2x.png" alt="macOS"

--- a/website/views/pages/query-library.ejs
+++ b/website/views/pages/query-library.ejs
@@ -92,7 +92,7 @@
         </div>
       </div>
       <div class="results">
-        <div class="row justify-content-center">
+        <div style="min-height: 0px;" class="row justify-content-center">
           <div purpose="selected-tag" class="mb-3" v-if="selectedTag">
             <strong>Showing {{ selectedKind === 'query' ? 'informational queries' : selectedKind === 'policy' ? 'policies' : 'all queries'}} with the "{{selectedTag}}" label.<span style="color: #FF5C83; cursor: pointer;" class="fa fa-times-circle pl-2" @click="clickSelectTag('')"></span></strong>
           </div>
@@ -105,8 +105,8 @@
                   <div class="col-12">
                     <div class="d-block d-sm-flex flex-wrap">
                       <h5 class="card-title m-0 mb-1 mr-sm-2">{{query.name}}</h5>
-                      <div class="my-2 my-sm-0">
-                        <span class="mr-2" purpose="query-tag" v-for="tag in query.tags" @click.stop="clickSelectTag(tag)">{{tag}}</span>
+                      <div class="my-2 my-sm-0 flex-wrap">
+                        <span class="mr-2 mb-1 text-nowrap d-inline-block" purpose="query-tag" v-for="tag in query.tags" @click.stop="clickSelectTag(tag)">{{tag}}</span>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
Closes #1486 

Changes:
- Added a new attribute to the query spec, `tags`. Tags must be a single string, with commas separating individual tags. (e.g., `Tags: foo,bar`) 
- Added tags to the standard query library readme
- Added tags to fleetdm.com/queries and query details page.
- Updated the query search to include query tags
- Added the ability to click on tags in the query library to filter queries by tag.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Manual QA for all new/changed functionality
