### PR TITLE
Update triggers for link check Action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,12 @@
 name: Check for bad links in documentation
 
-on: [ pull_request]
+on:
+  pull_request:
+    paths:
+    - '**.md'
+  workflow_dispatch: # Manual
+  schedule:
+  - cron: '0 6 * * *' # Nightly 6AM UTC
 
 jobs:
   markdown-link-check:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,7 @@ name: Check for bad links in documentation
 on:
   pull_request:
     paths:
+    # Only run on changes to .md files -- this check is too flakey to run on every PR
     - '**.md'
   workflow_dispatch: # Manual
   schedule:


### PR DESCRIPTION
Only check on changes to .md files, nightly, and on manual trigger.

This was generating a lot of false positives in CI.