### PR TITLE
fix: add Apple ID and app-specific password

### DIFF
--- a/docs/01-Using-Fleet/04-Adding-hosts.md
+++ b/docs/01-Using-Fleet/04-Adding-hosts.md
@@ -35,10 +35,12 @@ The `fleetctl package` command provides suppport for signing and notarizing macO
 Check out the example below:
 
 ```sh
-  fleetctl package --type pkg --sign-identity=[PATH TO SIGN IDENTITY] --notarize --fleet-url=[YOUR FLEET URL] --enroll-secret=[YOUR ENROLLMENT SECRET]
+  AC_USERNAME=appleid@example.com AC_PASSWORD=app-specific-password fleetctl package --type pkg --sign-identity=[PATH TO SIGN IDENTITY] --notarize --fleet-url=[YOUR FLEET URL] --enroll-secret=[YOUR ENROLLMENT SECRET]
 ```
 
 The above command should be run on a macOS device as notarizing and signing of macOS osquery installers can only be done on macOS devices.
+
+Also remember to replace both `AC_USERNAME` and `AC_PASSWORD` environment variables with your Apple ID and a valid [app-specific](https://support.apple.com/en-ca/HT204397) password respectively.
 
 
 ### Adding multiple hosts


### PR DESCRIPTION
Per Avik Sengupta's great catch, this PR updates the command to notarize a macOS osquery installer by providing the needed `AC_USERNAME` and `AC_PASSWORD` environment variables with instructions on what to pass to them.
