### PR TITLE
Bug fix: Get failing policies webhook on load

### DIFF
--- a/changes/issue-3991-fix-get-failing-policies-webhook
+++ b/changes/issue-3991-fix-get-failing-policies-webhook
@@ -1,0 +1,1 @@
+* Bug fix in UI: Loading current failing policies webhooks data

--- a/cypress/integration/all/app/settingsflow.spec.ts
+++ b/cypress/integration/all/app/settingsflow.spec.ts
@@ -66,7 +66,7 @@ describe("App settings flow", () => {
         .click()
         .type("localhost");
 
-      cy.get("#smtpPort").clear().type("1025");
+      cy.getAttached("#smtpPort").clear().type("1025");
 
       cy.findByLabelText(/use ssl\/tls/i).check({ force: true });
 
@@ -86,13 +86,15 @@ describe("App settings flow", () => {
         .click()
         .type("http://server.com/example");
 
-      cy.get(".app-config-form__host-percentage").click();
+      cy.getAttached(".app-config-form__host-percentage").click();
 
-      cy.get(".app-config-form__host-percentage").contains(/5%/i).click();
+      cy.getAttached(".app-config-form__host-percentage")
+        .contains(/5%/i)
+        .click();
 
-      cy.get(".app-config-form__days-count").click();
+      cy.getAttached(".app-config-form__days-count").click();
 
-      cy.get(".app-config-form__days-count")
+      cy.getAttached(".app-config-form__days-count")
         .contains(/7 days/i)
         .click();
 
@@ -160,7 +162,7 @@ describe("App settings flow", () => {
 
       cy.findByLabelText(/smtp server/i).should("have.value", "localhost");
 
-      cy.get("#smtpPort").should("have.value", "1025");
+      cy.getAttached("#smtpPort").should("have.value", "1025");
 
       cy.findByLabelText(/smtp username/i).should(
         "have.value",

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -131,7 +131,7 @@ export interface IConfig {
       };
     };
   };
-  webhook_settings?: {
+  webhook_settings: {
     failing_policies_webhook: IWebhookFailingPolicies;
   };
 }

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -9,7 +9,9 @@ import { TableContext } from "context/table";
 import { inMilliseconds, secondsToHms } from "fleet/helpers";
 import { IPolicyStats, ILoadAllPoliciesResponse } from "interfaces/policy";
 import { IWebhookFailingPolicies } from "interfaces/webhook";
-import { IConfigNested } from "interfaces/config";
+import { IConfig, IConfigNested } from "interfaces/config";
+// @ts-ignore
+import { getConfig } from "redux/nodes/app/actions";
 // @ts-ignore
 import { renderFlash } from "redux/nodes/notifications/actions";
 import PATHS from "router/paths";
@@ -60,6 +62,7 @@ const ManagePolicyPage = ({
     setAvailableTeams,
     setCurrentUser,
     setCurrentTeam,
+    setConfig,
   } = useContext(AppContext);
 
   const teamId = parseInt(location?.query?.team_id, 10) || 0;
@@ -221,6 +224,12 @@ const ManagePolicyPage = ({
     } finally {
       toggleManageAutomationsModal();
       refetchFailingPoliciesWebhook();
+      // Config must be updated in both Redux and AppContext
+      dispatch(getConfig())
+        .then((configState: IConfig) => {
+          setConfig(configState);
+        })
+        .catch(() => false);
     }
   };
 

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -9,6 +9,7 @@ import { TableContext } from "context/table";
 import { inMilliseconds, secondsToHms } from "fleet/helpers";
 import { IPolicyStats, ILoadAllPoliciesResponse } from "interfaces/policy";
 import { IWebhookFailingPolicies } from "interfaces/webhook";
+import { IConfigNested } from "interfaces/config";
 // @ts-ignore
 import { renderFlash } from "redux/nodes/notifications/actions";
 import PATHS from "router/paths";
@@ -81,18 +82,6 @@ const ManagePolicyPage = ({
   const [showAddPolicyModal, setShowAddPolicyModal] = useState(false);
   const [showRemovePoliciesModal, setShowRemovePoliciesModal] = useState(false);
   const [showInheritedPolicies, setShowInheritedPolicies] = useState(false);
-
-  const [
-    isLoadingFailingPoliciesWebhook,
-    setIsLoadingFailingPoliciesWebhook,
-  ] = useState(true);
-  const [
-    isFailingPoliciesWebhookError,
-    setIsFailingPoliciesWebhookError,
-  ] = useState(false);
-  const [failingPoliciesWebhook, setFailingPoliciesWebhook] = useState<
-    IWebhookFailingPolicies | undefined
-  >();
   const [currentAutomatedPolicies, setCurrentAutomatedPolicies] = useState<
     number[]
   >();
@@ -137,6 +126,26 @@ const ManagePolicyPage = ({
     }
   );
 
+  const canAddOrRemovePolicy =
+    isGlobalAdmin || isGlobalMaintainer || isTeamMaintainer || isTeamAdmin;
+
+  const {
+    data: failingPoliciesWebhook,
+    isLoading: isLoadingFailingPoliciesWebhook,
+    refetch: refetchFailingPoliciesWebhook,
+  } = useQuery<IConfigNested, Error, IWebhookFailingPolicies>(
+    ["config"],
+    () => configAPI.loadAll(),
+    {
+      enabled: canAddOrRemovePolicy,
+      select: (data: IConfigNested) =>
+        data.webhook_settings.failing_policies_webhook,
+      onSuccess: (data) => {
+        setCurrentAutomatedPolicies(data.policy_ids);
+      },
+    }
+  );
+
   const refetchPolicies = (id?: number) => {
     refetchGlobalPolicies();
     if (id) {
@@ -162,25 +171,6 @@ const ManagePolicyPage = ({
     setCurrentTeam(selectedTeam);
     isStaleGlobalPolicies && refetchGlobalPolicies();
   };
-
-  const getFailingPoliciesWebhook = useCallback(async () => {
-    setIsLoadingFailingPoliciesWebhook(true);
-    setIsFailingPoliciesWebhookError(false);
-    let result;
-    try {
-      result = await configAPI
-        .loadAll()
-        .then((response) => response.webhook_settings.failing_policies_webhook);
-      setFailingPoliciesWebhook(result);
-      setCurrentAutomatedPolicies(result.policy_ids);
-    } catch (error) {
-      console.log(error);
-      setIsFailingPoliciesWebhookError(true);
-    } finally {
-      setIsLoadingFailingPoliciesWebhook(false);
-    }
-    return result;
-  }, []);
 
   const toggleManageAutomationsModal = () =>
     setShowManageAutomationsModal(!showManageAutomationsModal);
@@ -230,7 +220,7 @@ const ManagePolicyPage = ({
       );
     } finally {
       toggleManageAutomationsModal();
-      getFailingPoliciesWebhook();
+      refetchFailingPoliciesWebhook();
     }
   };
 
@@ -288,9 +278,6 @@ const ManagePolicyPage = ({
       count > 1 ? "policies" : "policy"
     }`;
   };
-
-  const canAddOrRemovePolicy =
-    isGlobalAdmin || isGlobalMaintainer || isTeamMaintainer || isTeamAdmin;
 
   const policyUpdateInterval =
     secondsToHms(inMilliseconds(config?.osquery_policy || 0) / 1000) ||


### PR DESCRIPTION
Cerra #3991 

- Change getFailingPolicyWebhook call to useQuery pattern
- Fixes initial call for failing policies API
- Ensures config is being updated in states (both redux and AppContext) when updating webhook

Other frontend tech debt addressed:
- Fix getAttached for settingsflow.spec.ts

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
