### PR TITLE
move info about maintaining docs under "community"

### DIFF
--- a/handbook/README.md
+++ b/handbook/README.md
@@ -34,8 +34,6 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [Product quality](./product.md#product-quality)
 
-[Fleet docs](./product.md#fleet-docs)
-
 [UI design](./product.md#ui-design)
 
 [Release](./product.md#release)
@@ -69,6 +67,8 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 [Posting on social media as Fleet](./community.md#posting-on-social-media-as-fleet)
 
 [Promoting blog posts on social media](./community.md#promoting-blog-posts-on-social-media)
+
+[Fleet docs](./product.md#fleet-docs)
 
 [Press releases](./community.md#press-releases)
 

--- a/handbook/community.md
+++ b/handbook/community.md
@@ -25,6 +25,64 @@ Great brands are [magnanimous](https://en.wikipedia.org/wiki/Magnanimity).
 
 Once a blog post has been written, approved, and published, please ensure that it has been promoted on social media. Please refer to our [Publishing as Fleet](https://docs.google.com/document/d/1cmyVgUAqAWKZj1e_Sgt6eY-nNySAYHH3qoEnhQusph0/edit?usp=sharing) guide for more detailed information. 
 
+## Fleet docs
+
+### Docs style guide
+
+#### Headings
+
+Headings help readers scan content to easily find what they need. Organize page content using clear headings, specific to the topic they describe.
+
+Keep headings brief and organize them in a logical order:
+
+* H1: Page title
+* H2: Main headings
+* H3: Subheadings
+* H4: Sub-subheadings (headings nested under subheadings)
+
+Try to stay within 3 or 4 heading levels. Complicated documents may use more, but pages with a simpler structure are easier to read.
+
+### Adding a link to the Fleet docs
+You can link documentation pages to each other using relative paths. For example, in `docs/01-Using-Fleet/01-Fleet-UI.md`, you can link to `docs/01-Using-Fleet/09-Permissions.md` by writing `[permissions](./09-Permissions.md)`. This will be automatically transformed into the appropriate URL for `fleetdm.com/docs`.
+
+However, the `fleetdm.com/docs` compilation process does not account for relative links to directories **outside** of `/docs`.
+Therefore, when adding a link to Fleet docs, it is important to always use the absolute file path.
+
+When directly linking to a specific section within a page in the Fleet documentation, always format the spaces within a section name to use a hyphen `-` instead of an underscore `_`. For example, when linking to the `osquery_result_log_plugin` section of the configuration reference docs, use a relative link like the following: `./02-Configuration.md#osquery-result-log-plugin`.
+
+### Linking to a location on GitHub
+When adding a link to a location on GitHub that is outside of `/docs`, be sure to use the canonical form of the URL.
+
+To do this, navigate to the file's location on GitHub, and press "y" to transform the URL into its canonical form.
+
+### How to fix a broken link
+For instances in which a broken link is discovered on fleetdm.com, check if the link is a relative link to a directory outside of `/docs`. 
+
+An example of a link that lives outside of `/docs` is:
+
+```
+../../tools/app/prometheus
+```
+
+If the link lives outside `/docs`, head to the file's location on GitHub (in this case, [https://github.com/fleetdm/fleet/blob/main/tools/app/prometheus.yml)](https://github.com/fleetdm/fleet/blob/main/tools/app/prometheus.yml)), and press "y" to transform the URL into its canonical form ([https://github.com/fleetdm/fleet/blob/194ad5963b0d55bdf976aa93f3de6cabd590c97a/tools/app/prometheus.yml](https://github.com/fleetdm/fleet/blob/194ad5963b0d55bdf976aa93f3de6cabd590c97a/tools/app/prometheus.yml)). Replace the relative link with this link in the markdown file.
+
+> Note that the instructions above also apply to adding links in the Fleet handbook.
+
+### Adding an image to the Fleet docs
+Try to keep images in the docs at a minimum. Images can be a quick way to help a user understand a concept or direct them towards a specific UI element, but too many can make the documentation feel cluttered and more difficult to maintain.
+
+When adding images to the Fleet documentation, follow these guidelines:
+- Keep the images as simple as possible to maintain (screenshots can get out of date quickly as UIs change)
+- Exclude unnecessary images. An image should be used to help emphasize information in the docs, not replace it.
+- Minimize images per doc page. More than one or two per page can get overwhelming, for doc maintainers and users.
+- The goal is for the docs to look good on every form factor, from 320px window width all the way up to infinity and beyond. Full window screenshots and images with too much padding on the sides will be less than the width of the user's screen. When adding a large image, make sure that it is easily readable at all widths.
+
+Images can be added to the docs using the Markdown image link format, e.g. `![Schedule Query Sidebar](https://raw.githubusercontent.com/fleetdm/fleet/main/docs/images/schedule-query-sidebar.png)`
+The images used in the docs live in `docs/images/`. Note that you must provide the url of the image in the Fleet Github repo for it to display properly on both Github and the Fleet website.
+
+> Note that the instructions above also apply to adding images in the Fleet handbook.
+
+
 ## Press releases
 
 If we are doing a press release, we are probably pitching it to one or more reporters as an exclusive story, if they choose to take it.  Consider not sharing or publicizing any information related to the upcoming press release before the announcement.  See also https://www.quora.com/What-is-a-press-exclusive-and-how-does-it-work

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -216,62 +216,6 @@ Create a new user by running the `fleetctl user create` command.
 
 Logout of your current user and log in with the newly created user.
 
-## Fleet docs
-
-### Docs style guide
-
-#### Headings
-
-Headings help readers scan content to easily find what they need. Organize page content using clear headings, specific to the topic they describe.
-
-Keep headings brief and organize them in a logical order:
-
-* H1: Page title
-* H2: Main headings
-* H3: Subheadings
-* H4: Sub-subheadings (headings nested under subheadings)
-
-Try to stay within 3 or 4 heading levels. Complicated documents may use more, but pages with a simpler structure are easier to read.
-
-### Adding a link to the Fleet docs
-You can link documentation pages to each other using relative paths. For example, in `docs/01-Using-Fleet/01-Fleet-UI.md`, you can link to `docs/01-Using-Fleet/09-Permissions.md` by writing `[permissions](./09-Permissions.md)`. This will be automatically transformed into the appropriate URL for `fleetdm.com/docs`.
-
-However, the `fleetdm.com/docs` compilation process does not account for relative links to directories **outside** of `/docs`.
-Therefore, when adding a link to Fleet docs, it is important to always use the absolute file path.
-
-When directly linking to a specific section within a page in the Fleet documentation, always format the spaces within a section name to use a hyphen `-` instead of an underscore `_`. For example, when linking to the `osquery_result_log_plugin` section of the configuration reference docs, use a relative link like the following: `./02-Configuration.md#osquery-result-log-plugin`.
-
-### Linking to a location on GitHub
-When adding a link to a location on GitHub that is outside of `/docs`, be sure to use the canonical form of the URL.
-
-To do this, navigate to the file's location on GitHub, and press "y" to transform the URL into its canonical form.
-
-### How to fix a broken link
-For instances in which a broken link is discovered on fleetdm.com, check if the link is a relative link to a directory outside of `/docs`. 
-
-An example of a link that lives outside of `/docs` is:
-
-```
-../../tools/app/prometheus
-```
-
-If the link lives outside `/docs`, head to the file's location on GitHub (in this case, [https://github.com/fleetdm/fleet/blob/main/tools/app/prometheus.yml)](https://github.com/fleetdm/fleet/blob/main/tools/app/prometheus.yml)), and press "y" to transform the URL into its canonical form ([https://github.com/fleetdm/fleet/blob/194ad5963b0d55bdf976aa93f3de6cabd590c97a/tools/app/prometheus.yml](https://github.com/fleetdm/fleet/blob/194ad5963b0d55bdf976aa93f3de6cabd590c97a/tools/app/prometheus.yml)). Replace the relative link with this link in the markdown file.
-
-> Note that the instructions above also apply to adding links in the Fleet handbook.
-
-### Adding an image to the Fleet docs
-Try to keep images in the docs at a minimum. Images can be a quick way to help a user understand a concept or direct them towards a specific UI element, but too many can make the documentation feel cluttered and more difficult to maintain.
-
-When adding images to the Fleet documentation, follow these guidelines:
-- Keep the images as simple as possible to maintain (screenshots can get out of date quickly as UIs change)
-- Exclude unnecessary images. An image should be used to help emphasize information in the docs, not replace it.
-- Minimize images per doc page. More than one or two per page can get overwhelming, for doc maintainers and users.
-- The goal is for the docs to look good on every form factor, from 320px window width all the way up to infinity and beyond. Full window screenshots and images with too much padding on the sides will be less than the width of the user's screen. When adding a large image, make sure that it is easily readable at all widths.
-
-Images can be added to the docs using the Markdown image link format, e.g. `![Schedule Query Sidebar](https://raw.githubusercontent.com/fleetdm/fleet/main/docs/images/schedule-query-sidebar.png)`
-The images used in the docs live in `docs/images/`. Note that you must provide the url of the image in the Fleet Github repo for it to display properly on both Github and the Fleet website.
-
-> Note that the instructions above also apply to adding images in the Fleet handbook.
 
 ## UI design
 


### PR DESCRIPTION
This change moves the info on docs from the "Product" handbook page to the "Community" page.

## What about the redirect?
I don't have a great solution for doing this redirect quickly.  (Because [URL fragments don't get sent to the server](https://stackoverflow.com/a/43280710), we'd have to deal with client-side redirects.  They are possible to do, and not all that hard, but it would add some maintenance burden, plus more moving parts to remember.)  Not worth messing w/ IMO.