### PR TITLE
Fix manage packs UI for async API calls

### DIFF
--- a/frontend/pages/packs/ManagePacksPage/ManagePacksPage.tsx
+++ b/frontend/pages/packs/ManagePacksPage/ManagePacksPage.tsx
@@ -71,7 +71,7 @@ const ManagePacksPage = ({ router }: IManagePacksPageProps): JSX.Element => {
   const {
     data: packs,
     error: packsError,
-    isLoading: isLoadingPacks,
+    isFetching: isLoadingPacks,
     refetch: refetchPacks,
   } = useQuery<IPacksResponse, IError, IPack[]>(
     "packs",
@@ -97,8 +97,7 @@ const ManagePacksPage = ({ router }: IManagePacksPageProps): JSX.Element => {
     const packOrPacks = selectedPackIds.length === 1 ? "pack" : "packs";
 
     const promises = selectedPackIds.map((id: number) => {
-      packsAPI.destroy(id);
-      return null;
+      return packsAPI.destroy(id);
     });
 
     return Promise.all(promises)
@@ -127,8 +126,7 @@ const ManagePacksPage = ({ router }: IManagePacksPageProps): JSX.Element => {
       const enableOrDisable = disablePack ? "disabled" : "enabled";
 
       const promises = selectedTablePackIds.map((id: number) => {
-        packsAPI.update(id, { disabled: disablePack });
-        return null;
+        return packsAPI.update(id, { disabled: disablePack });
       });
 
       return Promise.all(promises)


### PR DESCRIPTION
Issue #3976

Fix use of `Promise.all` so that it works as intended by mapping the selected ids to an array of promises (rather just calling the async operation and then returning null, which `Promise.all` will resolve immediately thereby triggering the `finally` before the async operations actually finish)

Notes for QA: Changes impact both delete packs as well as enable/disable packs. QA should include selecting a single pack as well as multiple packs.

# Checklist for submitter
- [x] Manual QA for all new/changed functionality
