### PR TITLE
feat(api): add endpoint to get team by id

### DIFF
--- a/changes/issue-3904-get-team-by-id-api
+++ b/changes/issue-3904-get-team-by-id-api
@@ -1,0 +1,1 @@
+* Add new endpoint get team by id

--- a/docs/01-Using-Fleet/03-REST-API.md
+++ b/docs/01-Using-Fleet/03-REST-API.md
@@ -5562,6 +5562,62 @@ _Available in Fleet Premium_
 }
 ```
 
+### Get team
+
+_Available in Fleet Premium_
+
+`GET /api/v1/fleet/teams/{id}`
+
+#### Parameters
+
+| Name | Type   | In   | Description                          |
+| ---- | ------ | ---- | ------------------------------------ |
+| id   | string | body | **Required.** The desired team's ID. |
+
+#### Example
+
+`GET /api/v1/fleet/teams/1`
+
+##### Default response
+
+`Status: 200`
+
+```json
+{
+  "team": {
+    "name": "Workstations",
+    "id": 1,
+    "user_ids": [1, 17, 22, 32],
+    "host_ids": [],
+    "user_count": 4,
+    "host_count": 0,
+    "agent_options": {
+      "spec": {
+        "config": {
+          "options": {
+            "logger_plugin": "tls",
+            "pack_delimiter": "/",
+            "logger_tls_period": 10,
+            "distributed_plugin": "tls",
+            "disable_distributed": false,
+            "logger_tls_endpoint": "/api/v1/osquery/log",
+            "distributed_interval": 10,
+            "distributed_tls_max_attempts": 3
+          },
+          "decorators": {
+            "load": [
+              "SELECT uuid AS host_uuid FROM system_info;",
+              "SELECT hostname AS hostname FROM system_info;"
+            ]
+          }
+        },
+        "overrides": {}
+      }
+    }
+  }
+}
+```
+
 ### Create team
 
 _Available in Fleet Premium_

--- a/ee/server/service/service_teams.go
+++ b/ee/server/service/service_teams.go
@@ -259,6 +259,16 @@ func (svc *Service) DeleteTeam(ctx context.Context, teamID uint) error {
 	)
 }
 
+func (svc *Service) GetTeam(ctx context.Context, teamID uint) (*fleet.Team, error) {
+	if err := svc.authz.Authorize(ctx, &fleet.Team{ID: teamID}, fleet.ActionRead); err != nil {
+		return nil, err
+	}
+
+	logging.WithExtras(ctx, "id", teamID)
+
+	return svc.ds.Team(ctx, teamID)
+}
+
 func (svc *Service) TeamEnrollSecrets(ctx context.Context, teamID uint) ([]*fleet.EnrollSecret, error) {
 	if err := svc.authz.Authorize(ctx, &fleet.Team{ID: teamID}, fleet.ActionRead); err != nil {
 		return nil, err

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -361,6 +361,8 @@ type Service interface {
 
 	// NewTeam creates a new team.
 	NewTeam(ctx context.Context, p TeamPayload) (*Team, error)
+	// GetTeam returns a existing team.
+	GetTeam(ctx context.Context, id uint) (*Team, error)
 	// ModifyTeam modifies an existing team (besides agent options).
 	ModifyTeam(ctx context.Context, id uint, payload TeamPayload) (*Team, error)
 	// ModifyTeamAgentOptions modifies agent options for a team.

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -380,6 +380,7 @@ func attachNewStyleFleetAPIRoutes(r *mux.Router, svc fleet.Service, opts []kitht
 	e.PATCH("/api/_version_/fleet/teams/{team_id:[0-9]+}/secrets", modifyTeamEnrollSecretsEndpoint, modifyTeamEnrollSecretsRequest{})
 	e.POST("/api/_version_/fleet/teams", createTeamEndpoint, createTeamRequest{})
 	e.GET("/api/_version_/fleet/teams", listTeamsEndpoint, listTeamsRequest{})
+	e.GET("/api/_version_/fleet/teams/{id:[0-9]+}", getTeamEndpoint, getTeamRequest{})
 	e.PATCH("/api/_version_/fleet/teams/{id:[0-9]+}", modifyTeamEndpoint, modifyTeamRequest{})
 	e.DELETE("/api/_version_/fleet/teams/{id:[0-9]+}", deleteTeamEndpoint, deleteTeamRequest{})
 	e.POST("/api/_version_/fleet/teams/{id:[0-9]+}/agent_options", modifyTeamAgentOptionsEndpoint, modifyTeamAgentOptionsRequest{})

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -2313,6 +2313,11 @@ func (s *integrationTestSuite) TestTeamsEndpointsWithoutLicense() {
 	s.DoJSON("GET", "/api/v1/fleet/teams", nil, http.StatusPaymentRequired, &listResp)
 	assert.Len(t, listResp.Teams, 0)
 
+	// get team
+	var getResp getTeamResponse
+	s.DoJSON("GET", "/api/v1/fleet/teams/123", nil, http.StatusPaymentRequired, &getResp)
+	assert.Nil(t, getResp.Team)
+
 	// create team
 	var tmResp teamResponse
 	s.DoJSON("POST", "/api/v1/fleet/teams", &createTeamRequest{}, http.StatusPaymentRequired, &tmResp)

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -355,8 +355,13 @@ func (s *integrationEnterpriseTestSuite) TestTeamEndpoints() {
 	var listResp listTeamsResponse
 	s.DoJSON("GET", "/api/v1/fleet/teams", nil, http.StatusOK, &listResp, "query", name, "per_page", "2")
 	require.Len(t, listResp.Teams, 1)
-	require.Equal(t, team.Name, listResp.Teams[0].Name)
+	assert.Equal(t, team.Name, listResp.Teams[0].Name)
 	tm1ID := listResp.Teams[0].ID
+
+	// get team
+	var getResp getTeamResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/teams/%d", tm1ID), nil, http.StatusOK, &getResp)
+	assert.Equal(t, team.Name, getResp.Team.Name)
 
 	// modify team
 	team.Description = "Alt " + team.Description

--- a/server/service/teams.go
+++ b/server/service/teams.go
@@ -53,7 +53,7 @@ type getTeamRequest struct {
 }
 
 type getTeamResponse struct {
-	Team *fleet.Team `json:"teams"`
+	Team *fleet.Team `json:"team"`
 	Err  error       `json:"error,omitempty"`
 }
 

--- a/server/service/teams.go
+++ b/server/service/teams.go
@@ -45,6 +45,38 @@ func (svc *Service) ListTeams(ctx context.Context, opt fleet.ListOptions) ([]*fl
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Get Team
+////////////////////////////////////////////////////////////////////////////////
+
+type getTeamRequest struct {
+	ID uint `url:"id"`
+}
+
+type getTeamResponse struct {
+	Team *fleet.Team `json:"teams"`
+	Err  error       `json:"error,omitempty"`
+}
+
+func (r getTeamResponse) error() error { return r.Err }
+
+func getTeamEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+	req := request.(*getTeamRequest)
+	team, err := svc.GetTeam(ctx, req.ID)
+	if err != nil {
+		return getTeamResponse{Err: err}, nil
+	}
+	return getTeamResponse{Team: team}, nil
+}
+
+func (svc *Service) GetTeam(ctx context.Context, tid uint) (*fleet.Team, error) {
+	// skipauth: No authorization check needed due to implementation returning
+	// only license error.
+	svc.authz.SkipAuthorization(ctx)
+
+	return nil, fleet.ErrMissingLicense
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Create Team
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/server/service/teams_test.go
+++ b/server/service/teams_test.go
@@ -161,6 +161,9 @@ func TestTeamAuth(t *testing.T) {
 			_, err = svc.ListTeams(ctx, fleet.ListOptions{})
 			checkAuthErr(t, false, err) // everybody can do this
 
+			_, err = svc.GetTeam(ctx, 1)
+			checkAuthErr(t, tt.shouldFailRead, err)
+
 			err = svc.DeleteTeam(ctx, 1)
 			checkAuthErr(t, tt.shouldFailTeamWrite, err)
 


### PR DESCRIPTION
# Checklist for submitter

As per #3904 comment. This PR introduces get teams by id API endpoint

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [x] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [x] Added/updated tests
- [ ] Manual QA for all new/changed functionality
