### PR TITLE
Handbook - Add time off

### DIFF
--- a/handbook/README.md
+++ b/handbook/README.md
@@ -20,6 +20,8 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [Spending company money](./people.md#spending-company-money)
 
+[Taking time off](./people.md#taking-time-off)
+
 [Meetings](./people.md#meetings)
 
 [People ops](./people.md#people-ops)

--- a/handbook/people.md
+++ b/handbook/people.md
@@ -43,6 +43,14 @@ In brief, this means that as a Fleet team member, you may:
 
 For more developed thoughts about __spending guidelines and limits__, please read [GitLab's open expense policy](https://about.gitlab.com/handbook/spending-company-money/).
 
+## Taking time off
+
+Taking time off is essential to maintaining a healthy work-life balance. Fleet's unlimited vacation policy encourages team members to schedule time off to avoid burnout.
+
+When a team member takes time off at Fleet, they should create an "Out of office" (OOO) event in Google Calendar for the days they will be out. 
+
+If you're taking time off, you should plan who will cover your responsibilities for those days. Make sure to take your scheduled meetings into consideration, especially those where you're the event organizer. Communicate with your manager and other team members to ensure they can cover those meetings and that any Zoom links will still work for attendees.
+
 ## Meetings
 
 * At Fleet, meetings start whether you're there or not. Nevertheless, being even a few minutes late can make a big difference and slow your meeting counterparts down. When in doubt, show up a couple of minutes early.


### PR DESCRIPTION
Changes: 
- Added a section about taking time off to the people page
- added a link to the handbook index

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
