### PR TITLE
In label error state for existing query name

### DIFF
--- a/frontend/pages/queries/QueryPage/screens/QueryEditor.tsx
+++ b/frontend/pages/queries/QueryPage/screens/QueryEditor.tsx
@@ -78,7 +78,7 @@ const QueryEditor = ({
       dispatch(renderFlash("success", "Query created!"));
     } catch (createError: any) {
       console.error(createError);
-      if (createError.errors[0].reason.includes("already exists")) {
+      if (createError.data.errors[0].reason.includes("already exists")) {
         dispatch(
           renderFlash("error", "A query with this name already exists.")
         );


### PR DESCRIPTION
Cerra #3988, #3989

- Approach: Load API list of queries and check to see if query name is in list
- Alternate approach: Figure out how to send back backend API response into label state instead of flash message

This feels janky but it's 7:30 pm and I'm taking tomorrow off. If anyone has opinions on best approach, lmk!
Needs to be replicated for duplicate policy names as well.

<img width="1275" alt="Screen Shot 2022-02-03 at 7 31 26 PM" src="https://user-images.githubusercontent.com/71795832/152457657-8d19e9cf-7942-4e48-8b1c-e8d6baa57fc7.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
