### PR TITLE
In label error state for duplicate query/policy name

### DIFF
--- a/changes/issue-3988-3989-query-policy-validations
+++ b/changes/issue-3988-3989-query-policy-validations
@@ -1,0 +1,1 @@
+* Return backend validation in the label of query/policy creation form

--- a/frontend/pages/policies/PolicyPage/components/NewPolicyModal/NewPolicyModal.tsx
+++ b/frontend/pages/policies/PolicyPage/components/NewPolicyModal/NewPolicyModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from "react";
+import React, { useState, useContext, useEffect } from "react";
 import { size } from "lodash";
 
 import { IPolicyFormData } from "interfaces/policy";
@@ -16,6 +16,7 @@ export interface INewPolicyModalProps {
   platform: IQueryPlatform;
   onCreatePolicy: (formData: IPolicyFormData) => void;
   setIsNewPolicyModalOpen: (isOpen: boolean) => void;
+  backendValidators: { [key: string]: string };
 }
 
 const validatePolicyName = (name: string) => {
@@ -35,6 +36,7 @@ const NewPolicyModal = ({
   platform,
   onCreatePolicy,
   setIsNewPolicyModalOpen,
+  backendValidators,
 }: INewPolicyModalProps): JSX.Element => {
   const {
     lastEditedQueryName,
@@ -49,13 +51,19 @@ const NewPolicyModal = ({
   const [resolution, setResolution] = useState<string>(
     lastEditedQueryResolution
   );
-  const [errors, setErrors] = useState<{ [key: string]: string }>({});
+  const [errors, setErrors] = useState<{ [key: string]: string }>(
+    backendValidators
+  );
 
   useDeepEffect(() => {
     if (name) {
       setErrors({});
     }
   }, [name]);
+
+  useEffect(() => {
+    setErrors(backendValidators);
+  }, [backendValidators]);
 
   const handleSavePolicy = (evt: React.MouseEvent<HTMLFormElement>) => {
     evt.preventDefault();
@@ -74,8 +82,6 @@ const NewPolicyModal = ({
         resolution,
         platform,
       });
-
-      setIsNewPolicyModalOpen(false);
     }
   };
 

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -20,8 +20,6 @@ import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 import Spinner from "components/Spinner";
 import AutoSizeInputField from "components/forms/fields/AutoSizeInputField";
-// @ts-ignore
-import InputField from "components/forms/fields/InputField";
 import NewPolicyModal from "../NewPolicyModal";
 import InfoIcon from "../../../../../../assets/images/icon-info-purple-14x14@2x.png";
 import QuestionIcon from "../../../../../../assets/images/icon-question-16x16@2x.png";
@@ -40,6 +38,7 @@ interface IPolicyFormProps {
   onUpdate: (formData: IPolicyFormData) => void;
   onOpenSchemaSidebar: () => void;
   renderLiveQueryWarning: () => JSX.Element | null;
+  backendValidators: { [key: string]: string };
 }
 
 const PolicyForm = ({
@@ -53,6 +52,7 @@ const PolicyForm = ({
   onUpdate,
   onOpenSchemaSidebar,
   renderLiveQueryWarning,
+  backendValidators,
 }: IPolicyFormProps): JSX.Element => {
   const [errors, setErrors] = useState<{ [key: string]: any }>({});
   const [isNewPolicyModalOpen, setIsNewPolicyModalOpen] = useState<boolean>(
@@ -521,6 +521,7 @@ const PolicyForm = ({
           onCreatePolicy={onCreatePolicy}
           setIsNewPolicyModalOpen={setIsNewPolicyModalOpen}
           platform={lastEditedQueryPlatform}
+          backendValidators={backendValidators}
         />
       )}
     </>

--- a/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
+++ b/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Link } from "react-router";
 import { useDispatch } from "react-redux";
 import { InjectedRouter } from "react-router/lib/Router";
@@ -70,6 +70,10 @@ const QueryEditor = ({
     }
   }, []);
 
+  const [backendValidators, setBackendValidators] = useState<{
+    [key: string]: string;
+  }>({});
+
   const onCreatePolicy = debounce(async (formData: IPolicyFormData) => {
     if (policyTeamId) {
       formData.team_id = policyTeamId;
@@ -83,10 +87,10 @@ const QueryEditor = ({
       dispatch(renderFlash("success", "Policy created!"));
     } catch (createError: any) {
       console.error(createError);
-      if (createError.errors[0].reason.includes("already exists")) {
-        dispatch(
-          renderFlash("error", "A policy with this name already exists.")
-        );
+      if (createError.data.errors[0].reason.includes("already exists")) {
+        setBackendValidators({
+          name: "A policy with this name already exists",
+        });
       } else {
         dispatch(
           renderFlash(
@@ -128,7 +132,7 @@ const QueryEditor = ({
       dispatch(renderFlash("success", "Policy updated!"));
     } catch (updateError: any) {
       console.error(updateError);
-      if (updateError.errors[0].reason.includes("Duplicate")) {
+      if (updateError.data.errors[0].reason.includes("Duplicate")) {
         dispatch(
           renderFlash("error", "A policy with this name already exists.")
         );
@@ -171,6 +175,7 @@ const QueryEditor = ({
         showOpenSchemaActionText={showOpenSchemaActionText}
         onOpenSchemaSidebar={onOpenSchemaSidebar}
         renderLiveQueryWarning={renderLiveQueryWarning}
+        backendValidators={backendValidators}
       />
     </div>
   );

--- a/frontend/pages/queries/QueryPage/components/NewQueryModal/NewQueryModal.tsx
+++ b/frontend/pages/queries/QueryPage/components/NewQueryModal/NewQueryModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { size } from "lodash";
 
 import { IQueryFormData } from "interfaces/query";
@@ -14,6 +14,7 @@ export interface INewQueryModalProps {
   queryValue: string;
   onCreateQuery: (formData: IQueryFormData) => void;
   setIsSaveModalOpen: (isOpen: boolean) => void;
+  backendValidators: { [key: string]: string };
 }
 
 const validateQueryName = (name: string) => {
@@ -32,17 +33,24 @@ const NewQueryModal = ({
   queryValue,
   onCreateQuery,
   setIsSaveModalOpen,
+  backendValidators,
 }: INewQueryModalProps) => {
   const [name, setName] = useState<string>("");
   const [description, setDescription] = useState<string>("");
   const [observerCanRun, setObserverCanRun] = useState<boolean>(false);
-  const [errors, setErrors] = useState<{ [key: string]: any }>({});
+  const [errors, setErrors] = useState<{ [key: string]: string }>(
+    backendValidators
+  );
 
   useDeepEffect(() => {
     if (name) {
       setErrors({});
     }
   }, [name]);
+
+  useEffect(() => {
+    setErrors(backendValidators);
+  }, [backendValidators]);
 
   const handleUpdate = (evt: React.MouseEvent<HTMLFormElement>) => {
     evt.preventDefault();
@@ -60,8 +68,6 @@ const NewQueryModal = ({
         query: queryValue,
         observer_can_run: observerCanRun,
       });
-
-      setIsSaveModalOpen(false);
     }
   };
 

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -40,6 +40,7 @@ interface IQueryFormProps {
   onUpdate: (formData: IQueryFormData) => void;
   onOpenSchemaSidebar: () => void;
   renderLiveQueryWarning: () => JSX.Element | null;
+  backendValidators: { [key: string]: string };
 }
 
 const validateQuerySQL = (query: string) => {
@@ -65,6 +66,7 @@ const QueryForm = ({
   onUpdate,
   onOpenSchemaSidebar,
   renderLiveQueryWarning,
+  backendValidators,
 }: IQueryFormProps): JSX.Element => {
   const isEditMode = !!queryIdForEdit;
   const [errors, setErrors] = useState<{ [key: string]: any }>({});
@@ -478,6 +480,7 @@ const QueryForm = ({
           queryValue={lastEditedQueryBody}
           onCreateQuery={onCreateQuery}
           setIsSaveModalOpen={setIsSaveModalOpen}
+          backendValidators={backendValidators}
         />
       )}
     </>

--- a/frontend/pages/queries/QueryPage/screens/QueryEditor.tsx
+++ b/frontend/pages/queries/QueryPage/screens/QueryEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Link } from "react-router";
 import { useDispatch } from "react-redux";
 import { InjectedRouter } from "react-router/lib/Router";
@@ -71,17 +71,20 @@ const QueryEditor = ({
     }
   }, []);
 
+  const [backendValidators, setBackendValidators] = useState<{
+    [key: string]: string;
+  }>({});
+
   const onSaveQueryFormSubmit = debounce(async (formData: IQueryFormData) => {
     try {
       const { query }: { query: IQuery } = await createQuery(formData);
       router.push(PATHS.EDIT_QUERY(query));
       dispatch(renderFlash("success", "Query created!"));
+      setBackendValidators({});
     } catch (createError: any) {
       console.error(createError);
-      if (createError.errors[0].reason.includes("already exists")) {
-        dispatch(
-          renderFlash("error", "A query with this name already exists.")
-        );
+      if (createError.data.errors[0].reason.includes("already exists")) {
+        setBackendValidators({ name: "A query with this name already exists" });
       } else {
         dispatch(
           renderFlash(
@@ -148,6 +151,7 @@ const QueryEditor = ({
         showOpenSchemaActionText={showOpenSchemaActionText}
         onOpenSchemaSidebar={onOpenSchemaSidebar}
         renderLiveQueryWarning={renderLiveQueryWarning}
+        backendValidators={backendValidators}
       />
     </div>
   );


### PR DESCRIPTION
Cerra #3988, #3989

Refactor of original PR #4024

When CREATING a new query and a new policy:
- Sends API response 409 "duplicate entry" into label error state instead of error flash message

Other tech debt addressed:
- Bug fix: UPDATING a policy to a duplicate name wasn't rendering the error flash message like it should because of a typo (missing `.data`)


<img width="1790" alt="Screen Shot 2022-02-07 at 9 45 25 AM" src="https://user-images.githubusercontent.com/71795832/152822265-1e6e549d-ac87-4107-a570-8d48c903070e.png">
<img width="1787" alt="Screen Shot 2022-02-07 at 9 45 06 AM" src="https://user-images.githubusercontent.com/71795832/152822339-a1219641-910a-4faf-9736-f7f3df06b7ce.png">

Other tech debt addressed: 
<img width="1789" alt="Screen Shot 2022-02-07 at 9 45 43 AM" src="https://user-images.githubusercontent.com/71795832/152822302-90abde55-45fe-4cf4-b670-fc49c9275567.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
