### PR TITLE
Allow short IdP name in server validation

### DIFF
--- a/changes/allow-short-idp-name
+++ b/changes/allow-short-idp-name
@@ -1,0 +1,1 @@
+* Allow IdP name to be configured to a value shorter than 4 characters.

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -210,10 +210,6 @@ func validateSSOSettings(p fleet.AppConfig, existing *fleet.AppConfig, invalid *
 			if existing.SSOSettings.IDPName == "" {
 				invalid.Append("idp_name", "required")
 			}
-		} else {
-			if len(p.SSOSettings.IDPName) < 4 {
-				invalid.Append("idp_name", "must be 4 or more characters")
-			}
 		}
 	}
 }
@@ -365,7 +361,8 @@ func connectTLS(ctx context.Context, serverURL *url.URL) (*tls.Conn, error) {
 	// if that fails, use insecure
 	dial := func(insecure bool) (*tls.Conn, error) {
 		conn, err := tls.Dial("tcp", hostport, &tls.Config{
-			InsecureSkipVerify: insecure})
+			InsecureSkipVerify: insecure,
+		})
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "dial tls")
 		}

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -227,7 +227,6 @@ func TestSSONotPresent(t *testing.T) {
 	var p fleet.AppConfig
 	validateSSOSettings(p, &fleet.AppConfig{}, invalid)
 	assert.False(t, invalid.HasErrors())
-
 }
 
 func TestNeedFieldsPresent(t *testing.T) {
@@ -239,6 +238,22 @@ func TestNeedFieldsPresent(t *testing.T) {
 			IssuerURI:   "http://issuer.idp.com",
 			MetadataURL: "http://isser.metadata.com",
 			IDPName:     "onelogin",
+		},
+	}
+	validateSSOSettings(config, &fleet.AppConfig{}, invalid)
+	assert.False(t, invalid.HasErrors())
+}
+
+func TestShortIDPName(t *testing.T) {
+	invalid := &fleet.InvalidArgumentError{}
+	config := fleet.AppConfig{
+		SSOSettings: fleet.SSOSettings{
+			EnableSSO:   true,
+			EntityID:    "fleet",
+			IssuerURI:   "http://issuer.idp.com",
+			MetadataURL: "http://isser.metadata.com",
+			// A customer once found the Fleet server erroring when they used "SSO" for their IdP name.
+			IDPName: "SSO",
 		},
 	}
 	validateSSOSettings(config, &fleet.AppConfig{}, invalid)


### PR DESCRIPTION
A customer encountered an error when setting the value to "SSO" which
seems quite reasonable.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
~- [ ] Documented any permissions changes~
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
