### PR TITLE
Ignore software_id = 0 when calculating hosts count

### DIFF
--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -579,6 +579,7 @@ func (ds *Datastore) CalculateHostsPerSoftware(ctx context.Context, updatedAt ti
 	queryStmt := `
     SELECT count(*), software_id
     FROM host_software
+    WHERE software_id > 0
     GROUP BY software_id`
 
 	insertStmt := `


### PR DESCRIPTION
#4058 

The reason the pagination is sometimes out of sync is that somehow, there's a row that gets inserted in `host_software` with `software_id = 0`, and that ends up in generating that row in `aggregated_stats` when calculating hosts count is executed. Since that row has no corresponding parent row in `software`, it makes it look as if the requested page of results is 1 short of the limit, even if there are more rows to return. Instead of figuring out everywhere where that software_id = 0 could come from (this gets reproduced when recreating a local env from an empty db with osquery-perf on macOS, I couldn't reproduce on Linux), this is a simple fix in the calculation that ignores any 0 id for software.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] ~~Changes file added (for user-visible changes)~~
- [ ] ~~Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
- [ ] ~~Documented any permissions changes~~
- [ ] ~~Added/updated tests~~
- [ ] ~~Manual QA for all new/changed functionality~~
