### PR TITLE
Trimming vuln software json to fix on windows

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -44,8 +44,8 @@ func init() {
 			continue
 		}
 		vulnerableSoftware = append(vulnerableSoftware, fleet.Software{
-			Name:    string(parts[0]),
-			Version: string(parts[1]),
+			Name:    strings.TrimSpace(string(parts[0])),
+			Version: strings.TrimSpace(string(parts[1])),
 			Source:  "apps",
 		})
 	}


### PR DESCRIPTION
Unexpected PR to fix issue on Windows where the JSON for vulnerable software was broken.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] ~Changes file added (for user-visible changes)~
- [ ] ~Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
- [ ] ~Documented any permissions changes~
- [ ] ~Added/updated tests~
- [x] Manual QA for all new/changed functionality
