### PR TITLE
Host details page: e2e test (software, schedule, policy, users)

### DIFF
--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -72,7 +72,6 @@ describe("Hosts flow", () => {
         cy.getAttached("@hostLink")
           // Set hostname variable for later assertions
           .then((el) => {
-            console.log(el);
             hostname = el.text();
             return el;
           })
@@ -89,7 +88,6 @@ describe("Hosts flow", () => {
         cy.getAttached("@policyLink")
           // Set policyname variable for later assertions
           .then((el) => {
-            console.log(el);
             policyname = el.text();
             return el;
           });
@@ -161,7 +159,6 @@ describe("Hosts flow", () => {
             const pattern = /[0-9]+/g;
             const newCount = fullText.match(pattern);
             initialCount = parseInt(newCount[0], 10);
-            console.log("softwareCount", initialCount);
             expect(initialCount).to.be.at.least(1);
           });
         cy.findByPlaceholderText(/filter software/i).type("lib");

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -1,4 +1,5 @@
 import _ = require("cypress/types/lodash");
+import { closeSync } from "fs";
 import * as path from "path";
 
 let hostname = "";
@@ -16,8 +17,8 @@ describe("Hosts flow", () => {
     cy.viewport(1200, 660);
   });
   after(() => {
-    // cy.logout();
-    // cy.stopDockerHost();
+    cy.logout();
+    cy.stopDockerHost();
   });
   describe("Manage hosts page", () => {
     beforeEach(() => {
@@ -116,170 +117,134 @@ describe("Hosts flow", () => {
         cy.getAttached(".button--text-link").first().click();
       });
     });
-    it(
-      "runs query on an existing host",
-      {
-        retries: {
-          runMode: 2,
-        },
-        defaultCommandTimeout: 10000,
-      },
-      () => {
-        cy.getAttached(".host-details__action-button-container").within(() => {
-          cy.getAttached('img[alt="Query host icon"]').click();
-        });
+    it("runs query on an existing host", () => {
+      cy.getAttached(".host-details__action-button-container").within(() => {
+        cy.getAttached('img[alt="Query host icon"]').click();
+      });
 
-        cy.getAttached(".select-query-modal__modal").within(() => {
-          cy.getAttached(".modal-query-button").eq(2).click();
-        });
+      cy.getAttached(".select-query-modal__modal").within(() => {
+        cy.getAttached(".modal-query-button").eq(2).click();
+      });
 
-        cy.getAttached(".query-form__button-wrap--new-query").within(() => {
-          cy.findByText(/run query/i)
-            .should("exist")
-            .click();
-        });
-        cy.getAttached(".query-page__wrapper").within(() => {
-          cy.getAttached(".data-table").within(() => {
-            cy.findByText(hostname).should("exist");
-          });
-          cy.findByText(/run/i).click();
-        });
-      }
-    );
-    it(
-      "renders and searches the host's users",
-      {
-        retries: {
-          runMode: 2,
-        },
-        defaultCommandTimeout: 10000,
-      },
-      () => {
-        cy.getAttached(".section--users").within(() => {
-          cy.getAttached("tbody>tr").should("have.length.greaterThan", 0);
-          cy.findByPlaceholderText(/search/i).type("Ash");
-          cy.getAttached("tbody>tr").should("have.length", 0);
-          cy.getAttached(".empty-users").within(() => {
-            cy.findByText(/no users matched/i).should("exist");
-          });
-        });
-      }
-    );
-    it(
-      "renders and searches the host's software,  links to filter hosts by software",
-      {
-        retries: {
-          runMode: 2,
-        },
-        defaultCommandTimeout: 10000,
-      },
-      () => {
-        cy.getAttached(".react-tabs__tab-list").within(() => {
-          cy.findByText(/software/i).click();
-        });
-        let initialCount = 0;
-        cy.getAttached(".section--software").within(() => {
-          cy.getAttached(".table-container__results-count")
-            .invoke("text")
-            .then((text) => {
-              const fullText = text;
-              const pattern = /[0-9]+/g;
-              const newCount = fullText.match(pattern);
-              initialCount = parseInt(newCount[0]);
-              console.log("softwareCount", initialCount);
-              expect(initialCount).to.be.at.least(1);
-            });
-          cy.findByPlaceholderText(/filter software/i).type("lib");
-          console.log("softwareCount", initialCount);
-          // Ensures search completes
-          cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
-          cy.getAttached(".table-container__results-count")
-            .invoke("text")
-            .then((text) => {
-              const fullText = text;
-              const pattern = /[0-9]+/g;
-              const newCount = fullText.match(pattern);
-              const searchCount = parseInt(newCount[0]);
-              expect(searchCount).to.be.lessThan(initialCount);
-            });
-          cy.getAttached(".software-link").first().click({ force: true });
-          cy.getAttached(".manage-hosts__software-filter-block").within(() => {
-            cy.getAttached(".manage-hosts__software-filter-name-card").should(
-              "exist"
-            );
-            cy.getAttached(".data-table").within(() => {
-              cy.findByText(hostname).should("exist");
-            });
-          });
-          cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
-          cy.getAttached(".manage-hosts__software-filter-block").within(() => {
-            cy.getAttached(".manage-hosts__software-filter-name-card").should(
-              "exist"
-            );
-            cy.getAttached(".data-table").within(() => {
-              cy.findByText(hostname).should("exist");
-            });
-          });
-        });
-      }
-    );
-    it(
-      "renders host's schedule",
-      {
-        retries: {
-          runMode: 2,
-        },
-        defaultCommandTimeout: 10000,
-      },
-      () => {
-        cy.getAttached(".react-tabs__tab-list").within(() => {
-          cy.findByText(/schedule/i).click();
-        });
+      cy.getAttached(".query-form__button-wrap--new-query").within(() => {
+        cy.findByText(/run query/i)
+          .should("exist")
+          .click();
+      });
+      cy.getAttached(".query-page__wrapper").within(() => {
         cy.getAttached(".data-table").within(() => {
-          cy.findByText(/query name/i).should("exist");
+          cy.findByText(hostname).should("exist");
         });
-      }
-    );
-    it(
-      "renders host's policies and links to filter hosts by policy status",
-      {
-        retries: {
-          runMode: 2,
-        },
-        defaultCommandTimeout: 10000,
-      },
-      () => {
-        cy.getAttached(".react-tabs__tab-list").within(() => {
-          cy.findByText(/policies/i).click();
+        cy.findByText(/run/i).click();
+      });
+    });
+    it("renders and searches the host's users", () => {
+      cy.getAttached(".section--users").within(() => {
+        cy.getAttached("tbody>tr").should("have.length.greaterThan", 0);
+        cy.findByPlaceholderText(/search/i).type("Ash");
+        cy.getAttached("tbody>tr").should("have.length", 0);
+        cy.getAttached(".empty-users").within(() => {
+          cy.findByText(/no users matched/i).should("exist");
         });
-        cy.getAttached(".section--policies").within(() => {
-          cy.findByText(/failing 1 policy/i).should("exist");
-          cy.getAttached(".policy-link").first().click({ force: true });
-          cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
-          cy.getAttached(".manage-hosts__policies-filter-name-card").should(
-            "exist"
-          );
-        });
-      }
-    );
+      });
+    });
+    it("renders and searches the host's software,  links to filter hosts by software", () => {
+      cy.getAttached(".react-tabs__tab-list").within(() => {
+        cy.findByText(/software/i).click();
+      });
+      let initialCount = 0;
+      cy.getAttached(".section--software").within(() => {
+        cy.getAttached(".table-container__results-count")
+          .invoke("text")
+          .then((text) => {
+            const fullText = text;
+            const pattern = /[0-9]+/g;
+            const newCount = fullText.match(pattern);
+            initialCount = parseInt(newCount[0]);
+            console.log("softwareCount", initialCount);
+            expect(initialCount).to.be.at.least(1);
+          });
+        cy.findByPlaceholderText(/filter software/i).type("lib");
+        // Ensures search completes
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.getAttached(".table-container__results-count")
+          .invoke("text")
+          .then((text) => {
+            const fullText = text;
+            const pattern = /[0-9]+/g;
+            const newCount = fullText.match(pattern);
+            const searchCount = parseInt(newCount[0]);
+            expect(searchCount).to.be.lessThan(initialCount);
+          });
+        cy.getAttached(".software-link").first().click({ force: true });
+      });
+      cy.getAttached(".manage-hosts__software-filter-block").within(() => {
+        cy.getAttached(".manage-hosts__software-filter-name-card").should(
+          "exist"
+        );
+      });
+      cy.getAttached(".data-table").within(() => {
+        cy.findByText(hostname).should("exist");
+      });
+    });
+    it("renders host's schedule", () => {
+      cy.getAttached(".react-tabs__tab-list").within(() => {
+        cy.findByText(/schedule/i).click();
+      });
+      cy.getAttached(".data-table").within(() => {
+        cy.findByText(/query name/i).should("exist");
+      });
+    });
+    it("renders host's policies and links to filter hosts by policy status", () => {
+      cy.getAttached(".react-tabs__tab-list").within(() => {
+        cy.findByText(/policies/i).click();
+      });
+      cy.getAttached(".section--policies").within(() => {
+        cy.findByText(/failing 1 policy/i).should("exist");
+        cy.getAttached(".policy-link").first().click({ force: true });
+      });
+      cy.getAttached(".manage-hosts__policies-filter-name-card").should(
+        "exist"
+      );
+      cy.getAttached(".data-table").within(() => {
+        cy.findByText(hostname).should("exist");
+      });
+    });
     it(
       "refetches host vitals",
       {
         retries: {
           runMode: 2,
         },
-        defaultCommandTimeout: 10000,
+        defaultCommandTimeout: 15000,
       },
       () => {
         cy.getAttached(".hostname-container").within(() => {
           cy.contains("button", /refetch/i).click();
           cy.findByText(/fetching/i).should("exist");
-          // Ensures fetching completes
-          cy.wait(5000); // eslint-disable-line cypress/no-unnecessary-waiting
           cy.contains("button", /refetch/i).should("exist");
           cy.findByText(/few seconds/i).should("exist");
         });
       }
     );
+    it("deletes an existing host", () => {
+      cy.getAttached(".host-details__action-button-container")
+        .within(() => {
+          cy.findByText(/delete/i).click();
+        })
+        .then(() => {
+          cy.getAttached(".modal__modal_container")
+            .within(() => {
+              cy.findByText(/delete host/i).should("exist");
+              cy.findByRole("button", { name: /delete/i }).click();
+            })
+            .then(() => {
+              cy.findByText(/add your devices to fleet/i).should("exist");
+              cy.findByText(/generate installer/i).should("exist");
+              cy.findByText(/about this host/i).should("not.exist");
+              cy.findByText(hostname).should("not.exist");
+            });
+        });
+    });
   });
 });

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -160,7 +160,7 @@ describe("Hosts flow", () => {
             const fullText = text;
             const pattern = /[0-9]+/g;
             const newCount = fullText.match(pattern);
-            initialCount = parseInt(newCount[0]);
+            initialCount = parseInt(newCount[0], 10);
             console.log("softwareCount", initialCount);
             expect(initialCount).to.be.at.least(1);
           });
@@ -173,7 +173,7 @@ describe("Hosts flow", () => {
             const fullText = text;
             const pattern = /[0-9]+/g;
             const newCount = fullText.match(pattern);
-            const searchCount = parseInt(newCount[0]);
+            const searchCount = parseInt(newCount[0], 10);
             expect(searchCount).to.be.lessThan(initialCount);
           });
         cy.getAttached(".software-link").first().click({ force: true });

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -11,8 +11,8 @@ describe("Hosts flow", () => {
     cy.addDockerHost();
     cy.clearDownloads();
     cy.seedQueries();
+    cy.seedSchedule();
     cy.seedPolicies();
-    // TODO: cy.seedSchedule();
     cy.viewport(1200, 660);
   });
   after(() => {

--- a/cypress/integration/premium/team_maintainer_observer.spec.ts
+++ b/cypress/integration/premium/team_maintainer_observer.spec.ts
@@ -164,7 +164,9 @@ describe("Premium tier - Team observer/maintainer user", () => {
         cy.visit("/schedule/manage");
         cy.contains(/oranges/i).should("exist");
         cy.contains(/advanced/i).should("not.exist");
-        cy.findByRole("button", { name: /schedule a query/i }).click();
+        cy.getAttached(".no-schedule__cta-buttons").within(() => {
+          cy.findByRole("button", { name: /schedule a query/i }).click();
+        });
         // Schedule a query on maintaining team
         cy.getAttached(".schedule-editor-modal__form").within(() => {
           cy.findByText(/select query/i).click();

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -111,6 +111,49 @@ Cypress.Commands.add("seedQueries", () => {
   });
 });
 
+Cypress.Commands.add("seedSchedule", () => {
+  const scheduledQueries = [
+    {
+      interval: 86400,
+      platform: "",
+      query_id: 1,
+      removed: false,
+      shard: null,
+      snapshot: true,
+      version: "",
+    },
+    {
+      interval: 604800,
+      platform: "linux",
+      query_id: 2,
+      removed: true,
+      shard: 50,
+      snapshot: false,
+      version: "4.6.0",
+    },
+  ];
+
+  scheduledQueries.forEach((scheduleForm) => {
+    const {
+      interval,
+      platform,
+      query_id,
+      removed,
+      shard,
+      snapshot,
+      version,
+    } = scheduleForm;
+    cy.request({
+      url: "/api/v1/fleet/global/schedule",
+      method: "POST",
+      body: { interval, platform, query_id, removed, shard, snapshot, version },
+      auth: {
+        bearer: window.localStorage.getItem("FLEET::auth_token"),
+      },
+    });
+  });
+});
+
 Cypress.Commands.add("seedPacks", () => {
   const packs = [
     {

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -30,7 +30,12 @@ declare namespace Cypress {
     seedQueries(): Chainable<Element>;
 
     /**
-     * Custom command to add new queries by default.
+     * Custom command to add new scheduled queries by default.
+     */
+    seedSchedule(): Chainable<Element>;
+
+    /**
+     * Custom command to add new policies by default.
      */
     seedPolicies(): Chainable<Element>;
 


### PR DESCRIPTION
Cerra #2557 

Tests added to Host Details Page on _hosts.spec.ts_:
- render and searches the host's users
- renders and searches the host's software, links to filter hosts by software
- renders host's schedule
- renders host's policies and links to filter hosts by policy status
- refetch host vitals

Other tech debt addressed:
- Fixes attachment issues with **Schedule a query** button on _team_maintainer_observer.spec.ts_

<img width="696" alt="Screen Shot 2022-02-10 at 3 19 13 PM" src="https://user-images.githubusercontent.com/71795832/153498432-6fbdc34b-f76e-46ea-b451-3147a04a3e2d.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
