### PR TITLE
fix host count on teams details page

### DIFF
--- a/frontend/interfaces/team.ts
+++ b/frontend/interfaces/team.ts
@@ -20,6 +20,7 @@ export interface ITeamSummary {
   id: number;
   name: string;
   description?: string;
+  host_count: number;
 }
 
 /**

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -350,8 +350,9 @@ const TeamDetailsWrapper = ({
     );
   }
 
-  const hostsCount = teams?.length || 1;
-  const hostsTotalDisplay = hostsCount === 1 ? "1 host" : `${hostsCount} hosts`;
+  const hostCount = currentTeam.host_count;
+  const hostsTotalDisplay =
+    hostCount >= 2 ? `${hostCount} hosts` : `${hostCount} host`;
   const userAdminTeams = userTeams.filter(
     (thisTeam) => thisTeam.role === "admin"
   );


### PR DESCRIPTION
# Checklist for submitter

This PR fixes #4102 where we are showing the no of teams instead of showing no of `hosts` in a team.

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
