### PR TITLE
Add details to software automation modal

### DIFF
--- a/changes/issue-4118-software-automation-details
+++ b/changes/issue-4118-software-automation-details
@@ -1,0 +1,1 @@
+* Add software automation details to UI modal

--- a/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -191,7 +191,12 @@ const ManageAutomationsModal = ({
               }
             )}
         </div>
-
+        <div className={`${baseClass}__software-automation-description`}>
+          <p>
+            A request will be sent to your configured <b>Destination URL</b> if
+            a detected vulnerability (CVE) was published in the last 2 days.
+          </p>
+        </div>
         <div className="tooltip-wrap tooltip-wrap--input">
           <InputField
             inputWrapperClass={`${baseClass}__url-input`}

--- a/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/_styles.scss
@@ -26,6 +26,12 @@
     color: $ui-error;
   }
 
+  &__software-automation-description {
+    p {
+      margin: $pad-large 0;
+    }
+  }
+
   .tooltip-wrap {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Cerra #4118 

- Add missing line to software automation modal

<img width="1637" alt="Screen Shot 2022-02-09 at 1 16 09 PM" src="https://user-images.githubusercontent.com/71795832/153273943-419bc6e8-6db9-468a-9f3b-82688e2c93c2.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
