### PR TITLE
Fix label search crashing app on special character input

### DIFF
--- a/changes/issue-3872-fix-label-search
+++ b/changes/issue-3872-fix-label-search
@@ -1,0 +1,1 @@
+* Fix label search crashing app on special character input

--- a/cypress/integration/all/app/labelflow.spec.ts
+++ b/cypress/integration/all/app/labelflow.spec.ts
@@ -56,5 +56,27 @@ describe("Labels flow", () => {
         cy.findByText(/show all mac usernames/i).should("not.exist");
       });
     });
+    it("creates labels with special characters", () => {
+      cy.findByRole("button", { name: /add label/i }).click();
+      cy.getAttached(".ace_content").type(
+        "{selectall}{backspace}SELECT * FROM users;"
+      );
+      cy.findByLabelText(/name/i)
+        .click()
+        .type("** Special label (Mac / Users)");
+      cy.findByLabelText(/description/i)
+        .click()
+        .type("Select all MAC users using special characters.");
+      cy.getAttached(".label-form__form-field--platform > .Select").click();
+      cy.getAttached(".Select-menu-outer").within(() => {
+        cy.findByText(/macOS/i).click();
+      });
+      cy.findByRole("button", { name: /save label/i }).click();
+      cy.findByText(/label created/i).should("exist");
+    });
+    it("searches labels with special characters", () => {
+      cy.getAttached("#tags-filter").type("{selectall}{backspace}**");
+      cy.findByText(/Special label/i).should("exist");
+    });
   });
 });

--- a/frontend/components/side_panels/HostSidePanel/HostSidePanel.tsx
+++ b/frontend/components/side_panels/HostSidePanel/HostSidePanel.tsx
@@ -3,6 +3,7 @@ import { filter } from "lodash";
 
 import { ILabel } from "interfaces/label";
 import { PLATFORM_LABEL_DISPLAY_ORDER } from "utilities/constants";
+import { escapeRegEx } from "utilities/regex";
 
 import Spinner from "components/Spinner";
 import Button from "components/buttons/Button";
@@ -76,7 +77,10 @@ const HostSidePanel = ({
   const customLabels = filter(labels, (label) => {
     const lowerDisplayText = label.display_text.toLowerCase();
 
-    return label.type === "custom" && lowerDisplayText.match(labelFilter);
+    return (
+      label.type === "custom" &&
+      lowerDisplayText.match(escapeRegEx(labelFilter))
+    );
   });
 
   return (

--- a/frontend/utilities/regex/index.ts
+++ b/frontend/utilities/regex/index.ts
@@ -1,0 +1,1 @@
+export * from "./regEx";

--- a/frontend/utilities/regex/regEx.ts
+++ b/frontend/utilities/regex/regEx.ts
@@ -1,0 +1,5 @@
+export const escapeRegEx = (text: string): string => {
+  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+};
+
+export default escapeRegEx;


### PR DESCRIPTION
For #3872 

Notes: 

- String was not being escaped before matching, which caused an unhandled regex error. 
- Added new regex special character escaping utility function. 
- Added E2E tests to validate ability to create and search special characters in labels.

# Checklist for submitter 

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
