### PR TITLE
Remove before carat in schedule modal advance options

### DIFF
--- a/frontend/pages/schedule/ManageSchedulePage/_styles.scss
+++ b/frontend/pages/schedule/ManageSchedulePage/_styles.scss
@@ -111,22 +111,6 @@
     }
   }
 
-  .upcarat {
-    &::before {
-      content: url("../assets/images/icon-chevron-blue-16x16@2x.png");
-      transform: scale(0.5) rotate(180deg);
-      width: 16px;
-      border-radius: 0px;
-      padding: 0px;
-      padding-right: 2px;
-      margin-right: $pad-small;
-      margin-top: 5px;
-      position: relative;
-      top: -4px;
-      left: 6px;
-    }
-  }
-
   &__details {
     display: inline-flex;
     vertical-align: middle;


### PR DESCRIPTION
Cerra #4116 

- Removes the superfluous ::before carat from the Hide advanced options button

<img width="1679" alt="Screen Shot 2022-02-09 at 1 27 06 PM" src="https://user-images.githubusercontent.com/71795832/153275656-4d6f8677-b57a-4532-8493-b82e9b16e885.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
