### PR TITLE
Fix broken link and sentence casing in UI

### DIFF
--- a/docs/01-Using-Fleet/02-fleetctl-CLI.md
+++ b/docs/01-Using-Fleet/02-fleetctl-CLI.md
@@ -130,7 +130,7 @@ Once your local context is configured, you can use the above `fleetctl` normally
 
 Users that authenticate to Fleet via SSO should retrieve their API token from the UI and set it manually in their `fleetctl` configuration (instead of logging in via `fleetctl login`).
 
-1. Go to the "My account" page in Fleet (https://fleet.corp.example.com/profile). Click the "Get API Token" button to bring up a modal with the API token.
+1. Go to the "My account" page in Fleet (https://fleet.corp.example.com/profile). Click the "Get API token" button to bring up a modal with the API token.
 
 2. Set the API token in the `~/.fleet/config` file. The file should look like the following:
 

--- a/frontend/pages/Homepage/cards/MDM/MDM.tsx
+++ b/frontend/pages/Homepage/cards/MDM/MDM.tsx
@@ -28,7 +28,7 @@ const EmptyMDM = (): JSX.Element => (
     <p>
       To see MDM versions, deploy&nbsp;
       <a
-        href="https://fleetdm.com/docs/deploying/configuration#software-inventory"
+        href="https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/frontend/pages/Homepage/cards/Munki/Munki.tsx
+++ b/frontend/pages/Homepage/cards/Munki/Munki.tsx
@@ -28,7 +28,7 @@ const EmptyMunki = (): JSX.Element => (
     <p>
       To see Munki versions, deploy&nbsp;
       <a
-        href="https://fleetdm.com/docs/deploying/configuration#software-inventory"
+        href="https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/frontend/pages/Homepage/cards/Software/Software.tsx
+++ b/frontend/pages/Homepage/cards/Software/Software.tsx
@@ -39,7 +39,7 @@ const EmptySoftware = (message: string): JSX.Element => {
       <p>
         Expecting to see software? Check out the Fleet documentation on{" "}
         <a
-          href="https://fleetdm.com/docs/deploying/configuration#software-inventory"
+          href="https://fleetdm.com/docs/using-fleet/vulnerability-processing#configuration"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.jsx
@@ -278,7 +278,7 @@ export class UserSettingsPage extends Component {
     return (
       <Modal title="Get API token" onExit={onToggleApiTokenModal}>
         <p className={`${baseClass}__secret-label`}>
-          Your API Token:
+          Your API token:
           <a
             href="#revealSecret"
             onClick={onToggleSecret}

--- a/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -156,7 +156,7 @@ const ManageAutomationsModal = ({
       <div className={baseClass}>
         {availablePolicies && availablePolicies.length > 0 ? (
           <div className={`${baseClass}__policy-select-items`}>
-            <p> Choose which policy you would like to listen to:</p>
+            <p> Choose which policies you would like to listen to:</p>
             {policyItems &&
               policyItems.map((policyItem) => {
                 const { isChecked, name, id } = policyItem;

--- a/frontend/pages/software/components/EmptySoftware.tsx
+++ b/frontend/pages/software/components/EmptySoftware.tsx
@@ -16,7 +16,7 @@ const EmptySoftware = (message: IEmptySoftware): JSX.Element => {
             <p>
               Check out the Fleet documentation on{" "}
               <a
-                href="using-fleet/vulnerability-processing#configuration"
+                href="https://fleetdm.com/docs/using-fleet/vulnerability-processing#configuration"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/frontend/pages/software/components/EmptySoftware.tsx
+++ b/frontend/pages/software/components/EmptySoftware.tsx
@@ -16,7 +16,7 @@ const EmptySoftware = (message: IEmptySoftware): JSX.Element => {
             <p>
               Check out the Fleet documentation on{" "}
               <a
-                href="https://fleetdm.com/docs/using-fleet/vulnerability-processing#configuration"
+                href="using-fleet/vulnerability-processing#configuration"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
- Fix broken link in the empty state for the "Software" card on Home page
  - #4109 
- Update "API Token" to sentence case "API token"

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Manual QA for all new/changed functionality
