### PR TITLE
Bug Fix: Show observer query compatibility, remove awkward space with no label

### DIFF
--- a/changes/issue-4095-observer-view-compatibility
+++ b/changes/issue-4095-observer-view-compatibility
@@ -1,0 +1,1 @@
+* An observer can view a query's operating system compatibility

--- a/frontend/components/FleetAce/FleetAce.tsx
+++ b/frontend/components/FleetAce/FleetAce.tsx
@@ -80,6 +80,10 @@ const FleetAce = ({
       [`${baseClass}__label--with-action`]: !!labelActionComponent,
     });
 
+    if (!label) {
+      return <></>;
+    }
+
     return (
       <div className={labelClassName}>
         <p>{labelText}</p>

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -351,6 +351,9 @@ const QueryForm = ({
           readOnly
         />
       )}
+      <span className={`${baseClass}__platform-compatibility`}>
+        {renderPlatformCompatibility()}
+      </span>
       {renderLiveQueryWarning()}
       {lastEditedQueryObserverCanRun && (
         <div


### PR DESCRIPTION
Cerra #4095 

- Observer can see OS compatibility for queries
- Removes awkward extra space for Query and Policy SQL that doesn't have a label above it

<img width="1304" alt="Screen Shot 2022-02-09 at 5 55 15 PM" src="https://user-images.githubusercontent.com/71795832/153310659-fafcce0d-99e9-4074-8b3c-f1b196ef2250.png">
<img width="1304" alt="Screen Shot 2022-02-09 at 5 55 06 PM" src="https://user-images.githubusercontent.com/71795832/153310661-f04291a6-5810-4329-99a2-c941b859674e.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
