### PR TITLE
users table to cached_users to improve performance

### DIFF
--- a/changes/fix-software-inventory-query-linux
+++ b/changes/fix-software-inventory-query-linux
@@ -1,0 +1,1 @@
+* Fix software inventory query for linux hosts to improve performance when getting atom packages.

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -424,7 +424,7 @@ SELECT
   version AS version,
   'Package (Atom)' AS type,
   'atom_packages' AS source
-FROM users CROSS JOIN atom_packages USING (uid)
+FROM cached_users CROSS JOIN atom_packages USING (uid)
 UNION
 SELECT
   name AS name,


### PR DESCRIPTION
I guess someone forgot to edit this line when changing to `cached_users`