### PR TITLE
Linting LaunchDaemon to fix formatting

### DIFF
--- a/orbit/pkg/packaging/macos_templates.go
+++ b/orbit/pkg/packaging/macos_templates.go
@@ -52,32 +52,52 @@ var macosLaunchdTemplate = template.Must(template.New("").Option("missingkey=err
 	`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>Label</key>
-    <string>com.fleetdm.orbit</string>
-    <key>ProgramArguments</key>
-    <array>
-       <string>/var/lib/orbit/bin/orbit/orbit</string>
-    </array>
-    <key>StandardOutPath</key>
-    <string>/var/log/orbit/orbit.stdout.log</string>
-    <key>StandardErrorPath</key>
-    <string>/var/log/orbit/orbit.stderr.log</string>
-    <key>EnvironmentVariables</key>
-    <dict>
-      <key>ORBIT_UPDATE_URL</key><string>{{ .UpdateURL }}</string>
-      <key>ORBIT_ORBIT_CHANNEL</key><string>{{ .OrbitChannel }}</string>
-      <key>ORBIT_OSQUERYD_CHANNEL</key><string>{{ .OsquerydChannel }}</string>
-      {{ if .Insecure }}<key>ORBIT_INSECURE</key><string>true</string>{{ end }}
-      {{ if .FleetURL }}<key>ORBIT_FLEET_URL</key><string>{{ .FleetURL }}</string>{{ end }}
-      {{ if .FleetCertificate }}<key>ORBIT_FLEET_CERTIFICATE</key><string>/var/lib/orbit/fleet.pem</string>{{ end }}
-      {{ if .EnrollSecret }}<key>ORBIT_ENROLL_SECRET_PATH</key><string>/var/lib/orbit/secret.txt</string>{{ end }}
-      {{ if .Debug }}<key>ORBIT_DEBUG</key><string>true</string>{{ end }}
-    </dict>
-    <key>KeepAlive</key><true/>
-    <key>RunAtLoad</key><true/>
-    <key>ThrottleInterval</key>
-    <integer>10</integer>
-  </dict>
+<dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		{{- if .Debug }}
+		<key>ORBIT_DEBUG</key>
+		<string>true</string>
+		{{- end }}
+		{{- if .Insecure }}
+		<key>ORBIT_INSECURE</key>
+		<string>true</string>
+		{{- end }}
+		{{- if .FleetCertificate }}
+		<key>ORBIT_FLEET_CERTIFICATE</key>
+		<string>/var/lib/orbit/fleet.pem</string>
+		{{- end }}
+		{{- if .EnrollSecret }}
+		<key>ORBIT_ENROLL_SECRET_PATH</key>
+		<string>/var/lib/orbit/secret.txt</string>
+		{{- end }}
+		{{- if .FleetURL }}
+		<key>ORBIT_FLEET_URL</key>
+		<string>{{ .FleetURL }}</string>
+		{{- end }}
+		<key>ORBIT_ORBIT_CHANNEL</key>
+		<string>{{ .OrbitChannel }}</string>
+		<key>ORBIT_OSQUERYD_CHANNEL</key>
+		<string>{{ .OsquerydChannel }}</string>
+		<key>ORBIT_UPDATE_URL</key>
+		<string>{{ .UpdateURL }}</string>
+	</dict>
+	<key>KeepAlive</key>
+	<true/>
+	<key>Label</key>
+	<string>com.fleetdm.orbit</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/var/lib/orbit/bin/orbit/orbit</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>/var/log/orbit/orbit.stderr.log</string>
+	<key>StandardOutPath</key>
+	<string>/var/log/orbit/orbit.stdout.log</string>
+	<key>ThrottleInterval</key>
+	<integer>10</integer>
+</dict>
 </plist>
 `))


### PR DESCRIPTION
This is the equivalent of running the command `plutil -convert xml1 com.fleetdm.orbit.plist`

- [x] Manual QA for all new/changed functionality

BEFORE Sample:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
  <dict>
    <key>Label</key>
    <string>com.fleetdm.orbit</string>
    <key>ProgramArguments</key>
    <array>
       <string>/var/lib/orbit/bin/orbit/orbit</string>
    </array>
    <key>StandardOutPath</key>
    <string>/var/log/orbit/orbit.stdout.log</string>
    <key>StandardErrorPath</key>
    <string>/var/log/orbit/orbit.stderr.log</string>
    <key>EnvironmentVariables</key>
    <dict>
      <key>ORBIT_UPDATE_URL</key><string>https://tuf.fleetctl.com</string>
      <key>ORBIT_ORBIT_CHANNEL</key><string>stable</string>
      <key>ORBIT_OSQUERYD_CHANNEL</key><string>stable</string>
      
      <key>ORBIT_FLEET_URL</key><string>https://dogfood.fleetdm.com</string>
      
      <key>ORBIT_ENROLL_SECRET_PATH</key><string>/var/lib/orbit/secret.txt</string>
      
    </dict>
    <key>KeepAlive</key><true/>
    <key>RunAtLoad</key><true/>
    <key>ThrottleInterval</key>
    <integer>10</integer>
  </dict>
</plist>
```

AFTER Sample:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>EnvironmentVariables</key>
	<dict>
		<key>ORBIT_ENROLL_SECRET_PATH</key>
		<string>/var/lib/orbit/secret.txt</string>
		<key>ORBIT_FLEET_URL</key>
		<string>https://dogfood.fleetdm.com</string>
		<key>ORBIT_ORBIT_CHANNEL</key>
		<string>stable</string>
		<key>ORBIT_OSQUERYD_CHANNEL</key>
		<string>stable</string>
		<key>ORBIT_UPDATE_URL</key>
		<string>https://tuf.fleetctl.com</string>
	</dict>
	<key>KeepAlive</key>
	<true/>
	<key>Label</key>
	<string>com.fleetdm.orbit</string>
	<key>ProgramArguments</key>
	<array>
		<string>/var/lib/orbit/bin/orbit/orbit</string>
	</array>
	<key>RunAtLoad</key>
	<true/>
	<key>StandardErrorPath</key>
	<string>/var/log/orbit/orbit.stderr.log</string>
	<key>StandardOutPath</key>
	<string>/var/log/orbit/orbit.stdout.log</string>
	<key>ThrottleInterval</key>
	<integer>10</integer>
</dict>
</plist>
```
