### PR TITLE
Fix flaky e2e policies

### DIFF
--- a/cypress/integration/all/app/policiesflow.spec.ts
+++ b/cypress/integration/all/app/policiesflow.spec.ts
@@ -110,7 +110,9 @@ describe("Policies flow (seeded)", () => {
       cy.findByText(/backup/i).should("not.exist");
     });
     it("creates a failing policies webhook", () => {
-      cy.findByRole("button", { name: /manage automations/i }).click();
+      cy.getAttached(".button-wrap").within(() => {
+        cy.findByRole("button", { name: /manage automations/i }).click();
+      });
       cy.getAttached(".manage-automations-modal").within(() => {
         cy.getAttached(".fleet-checkbox__input").check({ force: true });
       });
@@ -118,7 +120,9 @@ describe("Policies flow (seeded)", () => {
       cy.findByRole("button", { name: /^Save$/ }).click();
       // Confirm failing policies webhook was added successfully
       cy.findByText(/updated policy automations/i).should("exist");
-      cy.findByRole("button", { name: /manage automations/i }).click();
+      cy.getAttached(".button-wrap").within(() => {
+        cy.findByRole("button", { name: /manage automations/i }).click();
+      });
       cy.getAttached(".manage-automations-modal").within(() => {
         cy.getAttached(".fleet-checkbox__input").should("be.checked");
       });

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -450,7 +450,7 @@ const ManagePolicyPage = ({
               />
             ))}
         </div>
-        {showInheritedPoliciesButton && (
+        {showInheritedPoliciesButton && globalPolicies && (
           <span>
             <Button
               variant="unstyled"

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -362,15 +362,18 @@ const ManagePolicyPage = ({
             </div>
           </div>
           <div className={`${baseClass} button-wrap`}>
-            {canAddOrRemovePolicy && teamId === 0 && (
-              <Button
-                onClick={() => onManageAutomationsClick()}
-                className={`${baseClass}__manage-automations button`}
-                variant="inverse"
-              >
-                <span>Manage automations</span>
-              </Button>
-            )}
+            {canAddOrRemovePolicy &&
+              teamId === 0 &&
+              !isLoadingFailingPoliciesWebhook &&
+              !isLoadingGlobalPolicies && (
+                <Button
+                  onClick={() => onManageAutomationsClick()}
+                  className={`${baseClass}__manage-automations button`}
+                  variant="inverse"
+                >
+                  <span>Manage automations</span>
+                </Button>
+              )}
             {canAddOrRemovePolicy && (
               <div className={`${baseClass}__action-button-container`}>
                 <Button


### PR DESCRIPTION
Hunch is that you can open the "Manage automations" modal before the data to create the checkboxes is loaded, causing the detached issue

- Fix: Do not render CTA button to open manage automation modal until after the needed data !isLoading

Addresses GitHub e2e test error on #4189 :
<img width="1417" alt="Screen Shot 2022-02-14 at 12 58 28 PM" src="https://user-images.githubusercontent.com/71795832/153921746-29e345d3-f15c-4816-9ec2-454111317111.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests

