### PR TITLE
Update broken anchor links in documentation

### DIFF
--- a/docs/01-Using-Fleet/07-Security-best-practices.md
+++ b/docs/01-Using-Fleet/07-Security-best-practices.md
@@ -33,7 +33,7 @@ Passwords are never stored in plaintext in the database. We store a `bcrypt`ed h
 
 #### Authentication tokens
 
-The size and expiration time of session tokens is admin-configurable. See [The documentation on session duration](../02-Deploying/03-Configuration.md#session_duration).
+The size and expiration time of session tokens is admin-configurable. See [The documentation on session duration](../02-Deploying/03-Configuration.md#session-duration).
 
 It is possible to revoke all session tokens for a user by forcing a password reset.
 

--- a/docs/01-Using-Fleet/FAQ.md
+++ b/docs/01-Using-Fleet/FAQ.md
@@ -43,7 +43,7 @@ There is, however, a way to accomplish this even though the answer to the questi
 
 ## How often do labels refresh? Is the refresh frequency configurable?
 
-The update frequency for labels is configurable with the [—osquery_label_update_interval](../02-Deploying/03-Configuration.md#osquery_label_update_interval) flag (default 1 hour).
+The update frequency for labels is configurable with the [—osquery_label_update_interval](../02-Deploying/03-Configuration.md#osquery-label-update-interval) flag (default 1 hour).
 
 ## How do I revoke the authorization tokens for a user?
 
@@ -80,7 +80,7 @@ Live query results (executed in the web UI or `fleetctl query`) are pushed direc
 
 ### Scheduled queries
 
-Scheduled query results (queries that are scheduled to run in Packs) are typically sent to the Fleet server, and will be available on the filesystem of the server at the path configurable by [`--osquery_result_log_file`](../02-Deploying/03-Configuration.md#osquery_result_log_file). This defaults to `/tmp/osquery_result`.
+Scheduled query results (queries that are scheduled to run in Packs) are typically sent to the Fleet server, and will be available on the filesystem of the server at the path configurable by [`--osquery_result_log_file`](../02-Deploying/03-Configuration.md#osquery-result-log-file). This defaults to `/tmp/osquery_result`.
 
 It is possible to configure osqueryd to log query results outside of Fleet. For results to go to Fleet, the `--logger_plugin` flag must be set to `tls`.
 
@@ -88,7 +88,7 @@ It is possible to configure osqueryd to log query results outside of Fleet. For 
 
 Folks typically use Fleet to ship logs to data aggregation systems like Splunk, the ELK stack, and Graylog.
 
-The [logger configuration options](../02-Deploying/03-Configuration.md#osquery_status_log_plugin) allow you to select the log output plugin. Using the log outputs you can route the logs to your chosen aggregation system.
+The [logger configuration options](../02-Deploying/03-Configuration.md#osquery-status-log-plugin) allow you to select the log output plugin. Using the log outputs you can route the logs to your chosen aggregation system.
 
 ### Troubleshooting
 
@@ -98,7 +98,7 @@ Expecting results, but not seeing anything in the logs?
 - Check whether the query is scheduled in differential mode. If so, new results will only be logged when the result set changes.
 - Ensure that the query is scheduled to run on the intended platforms, and that the tables queried are supported by those platforms.
 - Use live query to `SELECT * FROM osquery_schedule` to check whether the query has been scheduled on the host.
-- Look at the status logs provided by osquery. In a standard configuration these are available on the filesystem of the Fleet server at the path configurable by [`--filesystem_status_log_file`](../02-Deploying/03-Configuration.md#filesystem_status_log_file). This defaults to `/tmp/osquery_status`. The host will output a status log each time it executes the query.
+- Look at the status logs provided by osquery. In a standard configuration these are available on the filesystem of the Fleet server at the path configurable by [`--filesystem_status_log_file`](../02-Deploying/03-Configuration.md#filesystem-status-log-file). This defaults to `/tmp/osquery_status`. The host will output a status log each time it executes the query.
 
 ## Why does the same query come back faster sometimes?
 

--- a/docs/02-Deploying/FAQ.md
+++ b/docs/02-Deploying/FAQ.md
@@ -93,13 +93,13 @@ These configurations cannot be managed centrally from Fleet.
 
 This error usually indicates that the Fleet server has run out of file descriptors. Fix this by increasing the `ulimit` on the Fleet process. See the `LimitNOFILE` setting in the [example systemd unit file](./03-Configuration.md#runing-with-systemd) for an example of how to do this with systemd.
 
-Some deployments may benefit by setting the [`--server_keepalive`](./03-Configuration.md#server_keepalive) flag to false.
+Some deployments may benefit by setting the [`--server_keepalive`](./03-Configuration.md#server-keepalive) flag to false.
 
 This was also seen as a symptom of a different issue: if you're deploying on AWS on T type instances, there are different scenarios where the activity can increase and the instances will burst. If they run out of credits, then they'll stop processing leaving the file descriptors open.
 
 ## I upgraded my database, but Fleet is still running slowly. What could be going on?
 
-This could be caused by a mismatched connection limit between the Fleet server and the MySQL server that prevents Fleet from fully utilizing the database. First [determine how many open connections your MySQL server supports](https://dev.mysql.com/doc/refman/8.0/en/too-many-connections.html). Now set the [`--mysql_max_open_conns`](./03-Configuration.md#mysql_max_open_conns) and [`--mysql_max_idle_conns`](./03-Configuration.md#mysql_max_idle_conns) flags appropriately.
+This could be caused by a mismatched connection limit between the Fleet server and the MySQL server that prevents Fleet from fully utilizing the database. First [determine how many open connections your MySQL server supports](https://dev.mysql.com/doc/refman/8.0/en/too-many-connections.html). Now set the [`--mysql_max_open_conns`](./03-Configuration.md#mysql-max-open-conns) and [`--mysql_max_idle_conns`](./03-Configuration.md#mysql-max-idle-conns) flags appropriately.
 
 ## Why am I receiving a database connection error when attempting to "prepare" the database?
 
@@ -149,7 +149,7 @@ the problem can be resolved by setting `--osquery_host_identifier=instance` (whi
 osquery generated UUID), and then delete the associated host in the Fleet UI.
 
 Find more information about
-[host identifiers here](./03-Configuration.md#osquery_host_identifier).
+[host identifiers here](./03-Configuration.md#osquery-host-identifier).
 
 ## How long are osquery enroll secrets valid?
 


### PR DESCRIPTION
Changes:
- Updated anchor links to the configuration docs to use dashes instead of underscores


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Manual QA for all new/changed functionality
