### PR TITLE
Queries and Scheduled Queries UI: Performance impact tooltips

### DIFF
--- a/changes/issue-2750-performance-impact-information
+++ b/changes/issue-2750-performance-impact-information
@@ -1,0 +1,1 @@
+* UI clarifies performance impact of a query and its potential undetermined impact

--- a/frontend/components/TableContainer/DataTable/PillCell/PillCell.tsx
+++ b/frontend/components/TableContainer/DataTable/PillCell/PillCell.tsx
@@ -7,7 +7,7 @@ import ReactTooltip from "react-tooltip";
 interface IPillCellProps {
   value: [string, number];
   customIdPrefix?: string;
-  page?: string;
+  hostDetails?: boolean;
 }
 
 const generateClassTag = (rawValue: string): string => {
@@ -17,7 +17,7 @@ const generateClassTag = (rawValue: string): string => {
 const PillCell = ({
   value,
   customIdPrefix,
-  page,
+  hostDetails,
 }: IPillCellProps): JSX.Element => {
   const [pillText, id] = value;
 
@@ -73,18 +73,11 @@ const PillCell = ({
           </>
         );
       case "Undetermined":
-        if (page === "host details") {
-          return (
-            <>
-              To see performance <br /> impact, this query must <br /> run as a
-              scheduled query <br /> on this host.
-            </>
-          );
-        }
         return (
           <>
             To see performance <br /> impact, this query must <br /> run as a
-            scheduled query <br /> on at least one host.
+            scheduled query <br /> on {hostDetails ? "this" : "at least one"}{" "}
+            host.
           </>
         );
       default:

--- a/frontend/components/TableContainer/DataTable/PillCell/PillCell.tsx
+++ b/frontend/components/TableContainer/DataTable/PillCell/PillCell.tsx
@@ -7,13 +7,18 @@ import ReactTooltip from "react-tooltip";
 interface IPillCellProps {
   value: [string, number];
   customIdPrefix?: string;
+  page?: string;
 }
 
 const generateClassTag = (rawValue: string): string => {
   return rawValue.replace(" ", "-").toLowerCase();
 };
 
-const PillCell = ({ value, customIdPrefix }: IPillCellProps): JSX.Element => {
+const PillCell = ({
+  value,
+  customIdPrefix,
+  page,
+}: IPillCellProps): JSX.Element => {
   const [pillText, id] = value;
 
   const pillClassName = classnames(
@@ -28,6 +33,8 @@ const PillCell = ({ value, customIdPrefix }: IPillCellProps): JSX.Element => {
       case "Considerable":
         return false;
       case "Excessive":
+        return false;
+      case "Undetermined":
         return false;
       default:
         return true;
@@ -63,6 +70,21 @@ const PillCell = ({ value, customIdPrefix }: IPillCellProps): JSX.Element => {
           <>
             This query has been <br /> stopped from running <br /> because of
             excessive <br /> resource consumption.
+          </>
+        );
+      case "Undetermined":
+        if (page === "host details") {
+          return (
+            <>
+              To see performance <br /> impact, this query must <br /> run as a
+              scheduled query <br /> on this host.
+            </>
+          );
+        }
+        return (
+          <>
+            To see performance <br /> impact, this query must <br /> run as a
+            scheduled query <br /> on at least one host.
           </>
         );
       default:

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -57,7 +57,7 @@
       img {
         width: 16px;
         height: 16px;
-        vertical-align: sub;
+        vertical-align: top;
       }
 
       // do not resize button icons inside headers

--- a/frontend/components/queries/PackQueriesListWrapper/PackQueriesTable/PackQueriesTableConfig.tsx
+++ b/frontend/components/queries/PackQueriesListWrapper/PackQueriesTable/PackQueriesTableConfig.tsx
@@ -117,7 +117,9 @@ const generateTableHeaders = (
       Header: () => {
         return (
           <div>
-            <span>Performance impact</span>
+            <span className="queries-table__performance-impact-header">
+              Performance impact
+            </span>
             <span
               data-tip
               data-for="queries-table__performance-impact-tooltip"

--- a/frontend/components/queries/PackQueriesListWrapper/PackQueriesTable/PackQueriesTableConfig.tsx
+++ b/frontend/components/queries/PackQueriesListWrapper/PackQueriesTable/PackQueriesTableConfig.tsx
@@ -2,6 +2,7 @@
 // disable this rule as it was throwing an error in Header and Cell component
 // definitions for the selection row for some reason when we dont really need it.
 import React from "react";
+import ReactTooltip from "react-tooltip";
 import { find } from "lodash";
 
 import { performanceIndicator } from "fleet/helpers";
@@ -12,6 +13,7 @@ import PillCell from "components/TableContainer/DataTable/PillCell";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import { IScheduledQuery } from "interfaces/scheduled_query";
 import { IDropdownOption } from "interfaces/dropdownOption";
+import QuestionIcon from "../../../../../assets/images/icon-question-16x16@2x.png";
 
 interface IHeaderProps {
   column: {
@@ -112,7 +114,36 @@ const generateTableHeaders = (
     },
     {
       title: "Performance impact",
-      Header: "Performance impact",
+      Header: () => {
+        return (
+          <div>
+            <span>Performance impact</span>
+            <span
+              data-tip
+              data-for="queries-table__performance-impact-tooltip"
+              data-tip-disable={false}
+            >
+              <img alt="question icon" src={QuestionIcon} />
+            </span>
+            <ReactTooltip
+              className="queries-table__performance-impact-tooltip"
+              place="bottom"
+              type="dark"
+              effect="solid"
+              backgroundColor="#3e4771"
+              id="queries-table__performance-impact-tooltip"
+              data-html
+            >
+              <div style={{ textAlign: "center" }}>
+                This is the average <br />
+                performance impact <br />
+                across all hosts where this <br />
+                query was scheduled.
+              </div>
+            </ReactTooltip>
+          </div>
+        );
+      },
       disableSortBy: true,
       accessor: "performance",
       Cell: (cellProps) => <PillCell value={cellProps.cell.value} />,

--- a/frontend/components/queries/PackQueriesListWrapper/_styles.scss
+++ b/frontend/components/queries/PackQueriesListWrapper/_styles.scss
@@ -41,7 +41,7 @@
     font-weight: $bold;
   }
 
-  span {
+  .queries-table__performance-impact-header {
     margin-right: $pad-small;
   }
 

--- a/frontend/components/queries/PackQueriesListWrapper/_styles.scss
+++ b/frontend/components/queries/PackQueriesListWrapper/_styles.scss
@@ -40,4 +40,12 @@
     font-size: $x-small;
     font-weight: $bold;
   }
+
+  span {
+    margin-right: $pad-small;
+  }
+
+  .queries-table__performance-impact-tooltip {
+    font-weight: 400;
+  }
 }

--- a/frontend/pages/hosts/HostDetailsPage/PackTable/PackTableConfig.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/PackTable/PackTableConfig.tsx
@@ -97,7 +97,7 @@ const generatePackTableHeaders = (): IDataColumn[] => {
         <PillCell
           value={cellProps.cell.value}
           customIdPrefix="query-perf-pill"
-          page="host details"
+          hostDetails
         />
       ),
     },

--- a/frontend/pages/hosts/HostDetailsPage/PackTable/PackTableConfig.tsx
+++ b/frontend/pages/hosts/HostDetailsPage/PackTable/PackTableConfig.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import ReactTooltip from "react-tooltip";
 import { uniqueId } from "lodash";
 
 import TextCell from "components/TableContainer/DataTable/TextCell";
@@ -79,13 +80,24 @@ const generatePackTableHeaders = (): IDataColumn[] => {
     },
     {
       title: "Performance impact",
-      Header: "Performance impact",
+      Header: () => {
+        return (
+          <>
+            Performance impact
+            <IconToolTip
+              isHtml
+              text={`This is the performance <br />impact on this host.`}
+            />
+          </>
+        );
+      },
       disableSortBy: true,
       accessor: "performance",
       Cell: (cellProps) => (
         <PillCell
           value={cellProps.cell.value}
           customIdPrefix="query-perf-pill"
+          page="host details"
         />
       ),
     },

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesTableConfig.tsx
@@ -102,7 +102,9 @@ const generateTableHeaders = (currentUser: IUser): IDataColumn[] => {
       Header: () => {
         return (
           <div>
-            <span>Performance impact</span>
+            <span className="queries-table__performance-impact-header">
+              Performance impact
+            </span>
             <span
               data-tip
               data-for="queries-table__performance-impact-tooltip"

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesTableConfig.tsx
@@ -21,6 +21,7 @@ import PATHS from "router/paths";
 import { IQuery } from "interfaces/query";
 import { IUser } from "interfaces/user";
 import { addGravatarUrlToResource } from "fleet/helpers";
+import QuestionIcon from "../../../../../../assets/images/icon-question-16x16@2x.png";
 
 interface IQueryRow {
   id: string;
@@ -98,7 +99,36 @@ const generateTableHeaders = (currentUser: IUser): IDataColumn[] => {
     },
     {
       title: "Performance impact",
-      Header: "Performance impact",
+      Header: () => {
+        return (
+          <div>
+            <span>Performance impact</span>
+            <span
+              data-tip
+              data-for="queries-table__performance-impact-tooltip"
+              data-tip-disable={false}
+            >
+              <img alt="question icon" src={QuestionIcon} />
+            </span>
+            <ReactTooltip
+              className="queries-table__performance-impact-tooltip"
+              place="bottom"
+              type="dark"
+              effect="solid"
+              backgroundColor="#3e4771"
+              id="queries-table__performance-impact-tooltip"
+              data-html
+            >
+              <div style={{ textAlign: "center" }}>
+                This is the average <br />
+                performance impact <br />
+                across all hosts where this <br />
+                query was scheduled.
+              </div>
+            </ReactTooltip>
+          </div>
+        );
+      },
       disableSortBy: true,
       accessor: "performance",
       Cell: (cellProps) => (

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/_styles.scss
@@ -34,7 +34,7 @@
     color: $core-fleet-black;
   }
 
-  span {
+  .queries-table__performance-impact-header {
     margin-right: $pad-small;
   }
 

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/_styles.scss
@@ -33,6 +33,14 @@
     font-size: $x-small;
     color: $core-fleet-black;
   }
+
+  span {
+    margin-right: $pad-small;
+  }
+
+  .queries-table__performance-impact-tooltip {
+    font-weight: 400;
+  }
 }
 
 .no-queries {

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleTableConfig.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleTableConfig.tsx
@@ -105,7 +105,9 @@ const generateTableHeaders = (
       Header: () => {
         return (
           <div>
-            <span>Performance impact</span>
+            <span className="queries-table__performance-impact-header">
+              Performance impact
+            </span>
             <span
               data-tip
               data-for="queries-table__performance-impact-tooltip"

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleTableConfig.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/ScheduleTableConfig.tsx
@@ -2,6 +2,7 @@
 // disable this rule as it was throwing an error in Header and Cell component
 // definitions for the selection row for some reason when we dont really need it.
 import React from "react";
+import ReactTooltip from "react-tooltip";
 import { performanceIndicator, secondsToDhms } from "fleet/helpers";
 
 // @ts-ignore
@@ -12,6 +13,7 @@ import PillCell from "components/TableContainer/DataTable/PillCell";
 import { IDropdownOption } from "interfaces/dropdownOption";
 import { IGlobalScheduledQuery } from "interfaces/global_scheduled_query";
 import { ITeamScheduledQuery } from "interfaces/team_scheduled_query";
+import QuestionIcon from "../../../../../../assets/images/icon-question-16x16@2x.png";
 
 interface IHeaderProps {
   column: {
@@ -100,7 +102,36 @@ const generateTableHeaders = (
     },
     {
       title: "Performance impact",
-      Header: "Performance impact",
+      Header: () => {
+        return (
+          <div>
+            <span>Performance impact</span>
+            <span
+              data-tip
+              data-for="queries-table__performance-impact-tooltip"
+              data-tip-disable={false}
+            >
+              <img alt="question icon" src={QuestionIcon} />
+            </span>
+            <ReactTooltip
+              className="queries-table__performance-impact-tooltip"
+              place="bottom"
+              type="dark"
+              effect="solid"
+              backgroundColor="#3e4771"
+              id="queries-table__performance-impact-tooltip"
+              data-html
+            >
+              <div style={{ textAlign: "center" }}>
+                This is the average <br />
+                performance impact <br />
+                across all hosts where this <br />
+                query was scheduled.
+              </div>
+            </ReactTooltip>
+          </div>
+        );
+      },
       disableSortBy: true,
       accessor: "performance",
       Cell: (cellProps) => <PillCell value={cellProps.cell.value} />,

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/_styles.scss
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/_styles.scss
@@ -69,6 +69,14 @@
     margin: 0 12px 0 0;
     display: inline-block;
   }
+
+  span {
+    margin-right: $pad-small;
+  }
+
+  .queries-table__performance-impact-tooltip {
+    font-weight: 400;
+  }
 }
 
 .no-schedule {

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/_styles.scss
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleListWrapper/_styles.scss
@@ -70,7 +70,7 @@
     display: inline-block;
   }
 
-  span {
+  .queries-table__performance-impact-header {
     margin-right: $pad-small;
   }
 


### PR DESCRIPTION
Cerra #2750

Note: #344 in this sprint will be refactoring these tooltips to fresher code and UI

Tooltips added: 
1. Host details page Performance impact tooltip and Undetermined tooltip (custom tooltip wording compared to the other 3 pages)
2. Queries page Performance impact tooltip and Undetermined tooltip
3. Schedule page Performance impact tooltip and Undetermined tooltip
4. Packs page Performance impact tooltip and Undetermined tooltip

Respective order:
<img width="1290" alt="Screen Shot 2022-02-14 at 2 44 42 PM" src="https://user-images.githubusercontent.com/71795832/153956088-bb5e3606-d6fe-4da0-a90a-4d8c2185cbd1.png">
<img width="1292" alt="Screen Shot 2022-02-14 at 2 45 07 PM" src="https://user-images.githubusercontent.com/71795832/153956086-bbd821f9-4bf9-4bea-83aa-e885eaf5be8d.png">
<img width="1291" alt="Screen Shot 2022-02-14 at 2 44 24 PM" src="https://user-images.githubusercontent.com/71795832/153956090-87650435-c8a9-4c32-9f7b-c88216c25a09.png">
<img width="1291" alt="Screen Shot 2022-02-14 at 2 44 16 PM" src="https://user-images.githubusercontent.com/71795832/153956092-d7ab47ca-b158-4d41-85c1-e5e8ecc49ff0.png">
<img width="1289" alt="Screen Shot 2022-02-14 at 2 54 37 PM" src="https://user-images.githubusercontent.com/71795832/153956080-2e6aa33e-f56f-4891-9531-86897c2a50af.png">
<img width="1289" alt="Screen Shot 2022-02-14 at 2 54 46 PM" src="https://user-images.githubusercontent.com/71795832/153956075-a17b3c76-6d4a-4aa5-ba5f-114c5a4446a6.png">
<img width="1292" alt="Screen Shot 2022-02-14 at 2 53 41 PM" src="https://user-images.githubusercontent.com/71795832/153956084-818ac556-665f-4fe8-bb21-bee87048147f.png">
<img width="1284" alt="Screen Shot 2022-02-14 at 2 53 50 PM" src="https://user-images.githubusercontent.com/71795832/153956082-6c24178b-4af3-489d-9926-c8fc81d03266.png">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
