### PR TITLE
Edit Query Page: Fix UX for "Save as new" CTA

### DIFF
--- a/changes/issue-3202-improve-save-as-new-query
+++ b/changes/issue-3202-improve-save-as-new-query
@@ -1,0 +1,1 @@
+* Improved UX around "Save as new" query (Reroutes to new query on save as new, fixes duplicate name error)

--- a/cypress/integration/all/app/queryflow.spec.ts
+++ b/cypress/integration/all/app/queryflow.spec.ts
@@ -56,8 +56,17 @@ describe("Query flow (seeded)", () => {
       cy.getAttached(".ace_scroller")
         .click()
         .type("{selectall}SELECT datetime, username FROM windows_crashes;");
-      cy.getAttached(".button--brand.query-form__save").click();
+      cy.getAttached(".query-form__save").click();
       cy.findByText(/query updated/i).should("be.visible");
+    });
+    it("saves an existing query as new query", () => {
+      cy.getAttached(".name__cell .button--text-link").eq(1).click();
+      cy.findByText(/run query/i).should("exist");
+      cy.getAttached(".ace_scroller")
+        .click()
+        .type("{selectall}SELECT datetime, username FROM windows_crashes;");
+      cy.getAttached(".query-form__save-as-new").click();
+      cy.findByText(/copy of/i).should("be.visible");
     });
     it("deletes an existing query", () => {
       cy.findByText(/detect linux hosts/i)

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -458,12 +458,12 @@ const QueryForm = ({
 
   const renderForGlobalAdminOrAnyMaintainer = (
     <>
-      {isSaveAsNewLoading && (
-        <div className={`${baseClass}__loading-overlay`}>
-          <Spinner />
-        </div>
-      )}
       <form className={`${baseClass}__wrapper`} autoComplete="off">
+        {isSaveAsNewLoading && (
+          <div className={`${baseClass}__loading-overlay`}>
+            <Spinner />
+          </div>
+        )}
         <div className={`${baseClass}__title-bar`}>
           <div className="name-description">
             {renderName()}

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -499,7 +499,7 @@ const QueryForm = ({
             <>
               {isEditMode && (
                 <Button
-                  className={`${baseClass}__save`}
+                  className={`${baseClass}__save-as-new`}
                   variant="text-link"
                   onClick={promptSaveAsNewQuery()}
                   disabled={false}

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -87,6 +87,7 @@ const QueryForm = ({
   const [isEditingDescription, setIsEditingDescription] = useState<boolean>(
     false
   );
+  const [isSaveAsNewLoading, setIsSaveAsNewLoading] = useState<boolean>(false);
 
   // Note: The QueryContext values should always be used for any mutable query data such as query name
   // The storedQuery prop should only be used to access immutable metadata such as author id
@@ -195,8 +196,9 @@ const QueryForm = ({
 
     valid = isValidated;
 
-    console.log("promptSaveAsNewQuery");
     if (valid) {
+      setIsSaveAsNewLoading(true);
+
       queryAPI
         .create({
           name: lastEditedQueryName,
@@ -205,6 +207,7 @@ const QueryForm = ({
           observer_can_run: lastEditedQueryObserverCanRun,
         })
         .then((response: { query: IQuery }) => {
+          setIsSaveAsNewLoading(false);
           dispatch(push(PATHS.EDIT_QUERY(response.query)));
           dispatch(renderFlash("success", `Successfully added query.`));
         })
@@ -218,6 +221,7 @@ const QueryForm = ({
                 observer_can_run: lastEditedQueryObserverCanRun,
               })
               .then((response: { query: IQuery }) => {
+                setIsSaveAsNewLoading(false);
                 dispatch(push(PATHS.EDIT_QUERY(response.query)));
                 dispatch(
                   renderFlash(
@@ -239,8 +243,10 @@ const QueryForm = ({
                     )
                   );
                 }
+                setIsSaveAsNewLoading(false);
               });
           } else {
+            setIsSaveAsNewLoading(false);
             dispatch(
               renderFlash("error", "Could not create query. Please try again.")
             );
@@ -452,6 +458,11 @@ const QueryForm = ({
 
   const renderForGlobalAdminOrAnyMaintainer = (
     <>
+      {isSaveAsNewLoading && (
+        <div className={`${baseClass}__loading-overlay`}>
+          <Spinner />
+        </div>
+      )}
       <form className={`${baseClass}__wrapper`} autoComplete="off">
         <div className={`${baseClass}__title-bar`}>
           <div className="name-description">

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -226,9 +226,11 @@ const QueryForm = ({
                   )
                 );
               })
-              .catch((createError: any) => {
+              .catch((createCopyError: any) => {
                 if (
-                  createError.data.errors[0].reason.includes("already exists")
+                  createCopyError.data.errors[0].reason.includes(
+                    "already exists"
+                  )
                 ) {
                   dispatch(
                     renderFlash(

--- a/frontend/pages/queries/QueryPage/components/QueryForm/_styles.scss
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/_styles.scss
@@ -207,4 +207,17 @@
     display: inline-block;
     font-size: $large;
   }
+
+  &__loading-overlay {
+    display: flex;
+    flex-grow: 1;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: rgba(255, 255, 255, 0.8);
+    z-index: 1;
+    align-items: center;
+  }
 }

--- a/frontend/pages/queries/QueryPage/screens/QueryEditor.tsx
+++ b/frontend/pages/queries/QueryPage/screens/QueryEditor.tsx
@@ -113,7 +113,7 @@ const QueryEditor = ({
       dispatch(renderFlash("success", "Query updated!"));
     } catch (updateError: any) {
       console.error(updateError);
-      if (updateError.errors[0].reason.includes("Duplicate")) {
+      if (updateError.data.errors[0].reason.includes("Duplicate")) {
         dispatch(
           renderFlash("error", "A query with this name already exists.")
         );


### PR DESCRIPTION
Cerra #3202 

User flow:
- User edits a query (including editing the query name) and clicks save as new, they are prompted with a success flash message and redirected to the new query's page
- User edits a query (without editing the query name) and clicks save as new, they are prompted with a success flash message that it's renamed to "Copy of..." and redirected to the new query's page

<img width="1625" alt="Screen Shot 2022-02-16 at 11 30 22 AM" src="https://user-images.githubusercontent.com/71795832/154311245-53c32710-3883-4e1b-927b-adde01ffa759.png">
<img width="1622" alt="Screen Shot 2022-02-16 at 11 29 40 AM" src="https://user-images.githubusercontent.com/71795832/154311294-7e7c4d42-9f47-4590-9655-a1b7701e50c1.png">


Edge cases:
- User edits a query (without editing the query name) and clicks save as new even though "Copy of..." query name already exists, they are prompted with an error flash message that it's renamed "Copy of..." already exists. 
- User keeps clicking Save as new (without editing the query name), they will make multiple queries "Copy of..." "Copy of Copy of..." "Copy of Copy of Copy of..." as they are continually redirected to new queries' edit pages.

<img width="1625" alt="Screen Shot 2022-02-16 at 11 30 00 AM" src="https://user-images.githubusercontent.com/71795832/154311341-5f402cb5-a8a9-4aa0-8b31-adfc7b8a7027.png">
<img width="1625" alt="Screen Shot 2022-02-16 at 11 29 46 AM" src="https://user-images.githubusercontent.com/71795832/154311393-1fe0fc07-d706-4d07-b82c-5fb8e2483d80.png">


Related fixes:
- Loading spinner overlays form after clicking "Save as new" until redirected to new query or erroring out
- Fix typo (missing .data) to render flash message error for "Save" (not Save as new) an existing query to a duplicate name of another query


<img width="1627" alt="Screen Shot 2022-02-16 at 12 38 20 PM" src="https://user-images.githubusercontent.com/71795832/154323524-1ef192a8-ad44-4cd2-832e-8ec0c749e67c.png">
<img width="1611" alt="Screen Shot 2022-02-16 at 11 34 07 AM" src="https://user-images.githubusercontent.com/71795832/154312112-7d9ec880-fdba-4e9c-9d4d-56eff7196877.png">

Loom running through user flow, edge cases, and related fix:
https://www.loom.com/share/b3cb2c81407547c48a8eebdbfb223704

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
