### PR TITLE
Settings Page: Render SMTP port error

### DIFF
--- a/changes/issue-4187-render-smtp-error
+++ b/changes/issue-4187-render-smtp-error
@@ -1,0 +1,1 @@
+* Render more helpful SMTP error when cannot configure SMTP server

--- a/frontend/pages/admin/AppSettingsPage/AppSettingsPage.tsx
+++ b/frontend/pages/admin/AppSettingsPage/AppSettingsPage.tsx
@@ -59,7 +59,6 @@ const AppSettingsPage = (): JSX.Element => {
           dispatch(renderFlash("success", "Successfully updated settings."));
         })
         .catch((response: any) => {
-          console.log("response", response);
           if (
             response.data.errors[0].reason.includes("could not dial smtp host")
           ) {
@@ -70,7 +69,12 @@ const AppSettingsPage = (): JSX.Element => {
               )
             );
           } else if (response.data.errors) {
-            dispatch(renderFlash("error", response.data.errors[0].reason));
+            dispatch(
+              renderFlash(
+                "error",
+                `Could not update settings. ${response.data.errors[0].reason}`
+              )
+            );
           }
         })
         .finally(() => {

--- a/frontend/pages/admin/AppSettingsPage/AppSettingsPage.tsx
+++ b/frontend/pages/admin/AppSettingsPage/AppSettingsPage.tsx
@@ -58,9 +58,19 @@ const AppSettingsPage = (): JSX.Element => {
         .then(() => {
           dispatch(renderFlash("success", "Successfully updated settings."));
         })
-        .catch((errors: any) => {
-          if (errors.base) {
-            dispatch(renderFlash("error", errors.base));
+        .catch((response: any) => {
+          console.log("response", response);
+          if (
+            response.data.errors[0].reason.includes("could not dial smtp host")
+          ) {
+            dispatch(
+              renderFlash(
+                "error",
+                "Could not connect to SMTP server. Please try again."
+              )
+            );
+          } else if (response.data.errors) {
+            dispatch(renderFlash("error", response.data.errors[0].reason));
           }
         })
         .finally(() => {


### PR DESCRIPTION
Cerra #4187 

- Renders more helpful error when SMTP port cannot connect
- Renders backend error in flash message if some other backend error returns

<img width="1622" alt="Screen Shot 2022-02-16 at 12 54 04 PM" src="https://user-images.githubusercontent.com/71795832/154326953-6aca9bfe-218b-49b4-853e-68cfc6d12cf3.png">
<img width="1626" alt="Screen Shot 2022-02-16 at 1 03 04 PM" src="https://user-images.githubusercontent.com/71795832/154327558-36f84831-3aa4-4f38-80dc-c83d8f3a7c35.png">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
