### PR TITLE
chore(test): rewritten reset password form test using rtl

### DIFF
--- a/frontend/components/forms/ResetPasswordForm/ResetPasswordForm.tests.jsx
+++ b/frontend/components/forms/ResetPasswordForm/ResetPasswordForm.tests.jsx
@@ -1,116 +1,112 @@
 import React from "react";
-import { mount } from "enzyme";
-import { noop } from "lodash";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import ResetPasswordForm from "./ResetPasswordForm";
-import { fillInFormInput } from "../../../test/helpers";
 
 describe("ResetPasswordForm - component", () => {
   const newPassword = "p@ssw0rd";
+  const submitSpy = jest.fn();
+  it("renders correctly", () => {
+    render(<ResetPasswordForm handleSubmit={submitSpy} />);
 
-  it("updates component state when the new_password field is changed", () => {
-    const form = mount(<ResetPasswordForm handleSubmit={noop} />);
+    expect(screen.getByLabelText("New password")).toBeInTheDocument();
+    expect(screen.getByLabelText("Confirm password")).toBeInTheDocument();
 
-    const newPasswordField = form.find({ name: "new_password" });
-    fillInFormInput(newPasswordField, newPassword);
-
-    const { formData } = form.state();
-    expect(formData).toMatchObject({ new_password: newPassword });
+    expect(
+      screen.getByRole("button", { name: "Reset password" })
+    ).toBeInTheDocument();
   });
 
-  it("updates component state when the new_password_confirmation field is changed", () => {
-    const form = mount(<ResetPasswordForm handleSubmit={noop} />);
+  it("it does not submit the form when the new form fields have not been filled out", async () => {
+    render(<ResetPasswordForm handleSubmit={submitSpy} />);
 
-    const newPasswordField = form.find({ name: "new_password_confirmation" });
-    fillInFormInput(newPasswordField, newPassword);
-
-    const { formData } = form.state();
-    expect(formData).toMatchObject({ new_password_confirmation: newPassword });
-  });
-
-  it("it does not submit the form when the form fields have not been filled out", () => {
-    const submitSpy = jest.fn();
-    const form = mount(<ResetPasswordForm handleSubmit={submitSpy} />);
-    const submitBtn = form.find("button");
-
-    submitBtn.simulate("submit");
-
-    const { errors } = form.state();
-    expect(errors.new_password).toEqual("New password field must be completed");
+    // when
+    fireEvent.click(screen.getByRole("button", { name: "Reset password" }));
+    // then
+    expect(
+      await screen.findByText("New password field must be completed")
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        "New password confirmation field must be completed"
+      )
+    ).toBeInTheDocument();
     expect(submitSpy).not.toHaveBeenCalled();
   });
 
-  it("it does not submit the form when only the new password field has been filled out", () => {
-    const submitSpy = jest.fn();
-    const form = mount(<ResetPasswordForm handleSubmit={submitSpy} />);
-    const newPasswordField = form.find({ name: "new_password" });
-    fillInFormInput(newPasswordField, newPassword);
-    const submitBtn = form.find("button");
+  it("it does not submit the form when only the new password field has been filled out", async () => {
+    render(<ResetPasswordForm handleSubmit={submitSpy} />);
 
-    submitBtn.simulate("submit");
+    // when
+    userEvent.type(screen.getByLabelText("New password"), newPassword);
+    fireEvent.click(screen.getByRole("button", { name: "Reset password" }));
+    // then
+    expect(
+      await screen.findByText(
+        "New password confirmation field must be completed"
+      )
+    ).toBeInTheDocument();
+    expect(submitSpy).not.toHaveBeenCalled();
+  });
 
-    const { errors } = form.state();
-    expect(errors.new_password_confirmation).toEqual(
-      "New password confirmation field must be completed"
+  it("it does not submit the form when only the new confirmation password field has been filled out", async () => {
+    render(<ResetPasswordForm handleSubmit={submitSpy} />);
+
+    // when
+    userEvent.type(screen.getByLabelText("Confirm password"), newPassword);
+    fireEvent.click(screen.getByRole("button", { name: "Reset password" }));
+    // then
+    expect(
+      await screen.findByText("New password field must be completed")
+    ).toBeInTheDocument();
+    expect(submitSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not submit the form if the new password confirmation does not match", async () => {
+    render(<ResetPasswordForm handleSubmit={submitSpy} />);
+
+    // when
+    userEvent.type(screen.getByLabelText("New password"), newPassword);
+    userEvent.type(
+      screen.getByLabelText("Confirm password"),
+      "not my new password"
     );
+    fireEvent.click(screen.getByRole("button", { name: "Reset password" }));
+    // then
+    expect(
+      await screen.findByText("Passwords do not match")
+    ).toBeInTheDocument();
     expect(submitSpy).not.toHaveBeenCalled();
   });
 
-  it("submits the form data when the form is submitted", () => {
-    const submitSpy = jest.fn();
-    const form = mount(<ResetPasswordForm handleSubmit={submitSpy} />);
-    const newPasswordField = form.find({ name: "new_password" });
-    const newPasswordConfirmationField = form.find({
-      name: "new_password_confirmation",
-    });
-    const submitBtn = form.find("button");
+  it("does not submit the form if the password is invalid", async () => {
+    const invalidPassword = "invalid";
 
-    fillInFormInput(newPasswordField, newPassword);
-    fillInFormInput(newPasswordConfirmationField, newPassword);
-    submitBtn.simulate("submit");
+    render(<ResetPasswordForm handleSubmit={submitSpy} />);
 
+    // when
+    userEvent.type(screen.getByLabelText("New password"), invalidPassword);
+    userEvent.type(screen.getByLabelText("Confirm password"), invalidPassword);
+    fireEvent.click(screen.getByRole("button", { name: "Reset password" }));
+    // then
+    expect(
+      await screen.findByText("Password must meet the criteria below")
+    ).toBeInTheDocument();
+    expect(submitSpy).not.toHaveBeenCalled();
+  });
+
+  it("submits the form data when the form is submitted", async () => {
+    render(<ResetPasswordForm handleSubmit={submitSpy} />);
+
+    // when
+    userEvent.type(screen.getByLabelText("New password"), newPassword);
+    userEvent.type(screen.getByLabelText("Confirm password"), newPassword);
+    fireEvent.click(screen.getByRole("button", { name: "Reset password" }));
+    // then
     expect(submitSpy).toHaveBeenCalledWith({
       new_password: newPassword,
       new_password_confirmation: newPassword,
-    });
-  });
-
-  it("does not submit the form if the new password confirmation does not match", () => {
-    const submitSpy = jest.fn();
-    const form = mount(<ResetPasswordForm handleSubmit={submitSpy} />);
-    const newPasswordField = form.find({ name: "new_password" });
-    const newPasswordConfirmationField = form.find({
-      name: "new_password_confirmation",
-    });
-    const submitBtn = form.find("button");
-
-    fillInFormInput(newPasswordField, newPassword);
-    fillInFormInput(newPasswordConfirmationField, "not my new password");
-    submitBtn.simulate("submit");
-
-    expect(submitSpy).not.toHaveBeenCalled();
-    expect(form.state().errors).toMatchObject({
-      new_password_confirmation: "Passwords do not match",
-    });
-  });
-
-  it("does not submit the form if the password is invalid", () => {
-    const submitSpy = jest.fn();
-    const form = mount(<ResetPasswordForm handleSubmit={submitSpy} />);
-    const newPasswordField = form.find({ name: "new_password" });
-    const newPasswordConfirmationField = form.find({
-      name: "new_password_confirmation",
-    });
-    const submitBtn = form.find("button");
-    const invalidPassword = "invalid";
-
-    fillInFormInput(newPasswordField, invalidPassword);
-    fillInFormInput(newPasswordConfirmationField, invalidPassword);
-    submitBtn.simulate("submit");
-
-    expect(submitSpy).not.toHaveBeenCalled();
-    expect(form.state().errors).toMatchObject({
-      new_password: "Password must meet the criteria below",
     });
   });
 });


### PR DESCRIPTION
# Checklist for submitter
Updated `resetPasswordForm` component test to use `rtl`

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)
- [ ] Documented any permissions changes
- [x] Added/updated tests
- [ ] Manual QA for all new/changed functionality
