### PR TITLE
Revert "Fix typo in receive-from-github.js"

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -217,7 +217,7 @@ module.exports = {
           };
 
           // [?] https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files
-          let changedPaths = _.pluck(await sails.helpers.http.get(`https://api.github.com/repos/${owner}/${repo}/pull/${prNumber}/files`, {
+          let changedPaths = _.pluck(await sails.helpers.http.get(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files`, {
             per_page: 100,//eslint-disable-line camelcase
           }, baseHeaders), 'filename');// (don't worry, it's the whole path, not the filename)
           sails.log.verbose(`Received notice that a new PR (#${prNumber}) was opened that changes the following paths:`, changedPaths);


### PR DESCRIPTION
Reverts fleetdm/fleet#4278

~~[mikermcneil](https://app.slack.com/team/U01A945TEDP):walking:  [1 minute ago](https://fleetdm.slack.com/archives/C01GQUZ91TN/p1645132586356039?thread_ts=1645126135.013729&cid=C01GQUZ91TN)
Thanks.  You are very much correct.  Bizarre that this was working properly last night (I literally watched it work and auto-approve 5 PRs)
e.g. https://github.com/fleetdm/fleet/pull/4258#pullrequestreview-885786053
I must have made the typo at the last second or something~~

[mikermcneil](https://app.slack.com/team/U01A945TEDP):walking:  [< 1 minute ago](https://fleetdm.slack.com/archives/C01GQUZ91TN/p1645132658094369?thread_ts=1645126135.013729&cid=C01GQUZ91TN)
Actually nevermind Eric, this is not the reason.  The correct URL is pulls/

[mikermcneil](https://app.slack.com/team/U01A945TEDP):walking:  [< 1 minute ago](https://fleetdm.slack.com/archives/C01GQUZ91TN/p1645132677623469?thread_ts=1645126135.013729&cid=C01GQUZ91TN)
Example: https://api.github.com/repos/fleetdm/fleet/pulls/1/files