### PR TITLE
Allow disabling auto updates in `fleetctl package` and `orbit`

### DIFF
--- a/changes/issue-3658-orbit-allow-disable-updates
+++ b/changes/issue-3658-orbit-allow-disable-updates
@@ -1,0 +1,1 @@
+* Add flag to `fleetctl package` and `orbit` to disable auto updates.

--- a/cmd/fleetctl/apply_test.go
+++ b/cmd/fleetctl/apply_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -286,7 +286,7 @@ func TestApplyPolicies(t *testing.T) {
 		if name == "Team1" {
 			return &fleet.Team{ID: 123}, nil
 		}
-		return nil, fmt.Errorf("unexpected team name!")
+		return nil, errors.New("unexpected team name!")
 	}
 	ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activityType string, details *map[string]interface{}) error {
 		return nil

--- a/cmd/fleetctl/package.go
+++ b/cmd/fleetctl/package.go
@@ -76,6 +76,11 @@ func packageCommand() *cli.Command {
 				Usage:       "Whether to notarize macOS packages",
 				Destination: &opt.Notarize,
 			},
+			&cli.BoolFlag{
+				Name:        "disable-updates",
+				Usage:       "Disable auto updates on the generated package",
+				Destination: &opt.DisableUpdates,
+			},
 			&cli.StringFlag{
 				Name:        "osqueryd-channel",
 				Usage:       "Update channel of osqueryd to use",

--- a/cmd/fleetctl/package.go
+++ b/cmd/fleetctl/package.go
@@ -76,11 +76,6 @@ func packageCommand() *cli.Command {
 				Usage:       "Whether to notarize macOS packages",
 				Destination: &opt.Notarize,
 			},
-			&cli.BoolFlag{
-				Name:        "disable-updates",
-				Usage:       "Disable auto updates on the generated package",
-				Destination: &opt.DisableUpdates,
-			},
 			&cli.StringFlag{
 				Name:        "osqueryd-channel",
 				Usage:       "Update channel of osqueryd to use",
@@ -92,6 +87,11 @@ func packageCommand() *cli.Command {
 				Usage:       "Update channel of Orbit to use",
 				Value:       "stable",
 				Destination: &opt.OrbitChannel,
+			},
+			&cli.BoolFlag{
+				Name:        "disable-updates",
+				Usage:       "Disable auto updates on the generated package",
+				Destination: &opt.DisableUpdates,
 			},
 			&cli.StringFlag{
 				Name:        "update-url",

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/quasilyte/go-ruleguard/dsl v0.3.17 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
 	github.com/rotisserie/eris v0.5.1
 	github.com/rs/zerolog v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -986,6 +986,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/quasilyte/go-ruleguard/dsl v0.3.17 h1:L5xf3nifnRIdYe9vyMuY2sDnZHIgQol/fDq74FQz7ZY=
+github.com/quasilyte/go-ruleguard/dsl v0.3.17/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 h1:MkV+77GLUNo5oJ0jf870itWm3D0Sjh7+Za9gazKc5LQ=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/orbit/README.md
+++ b/orbit/README.md
@@ -182,9 +182,26 @@ Press Enter to continue, or Control-c to exit.
 
 If you want to run orbit from source directly, you can do the following:
 
-```sh 
-go run github.com/fleetdm/fleet/v4/orbit/cmd/orbit --root-dir /tmp/orbit -- --flagfile=flagfile.txt --verbose
+```sh
+go run github.com/fleetdm/fleet/v4/orbit/cmd/orbit \
+    --dev-mode \
+    --disable-updates \
+    --root-dir /tmp/orbit \
+    --fleet-url https://localhost:8080 \
+    --insecure \
+    --enroll-secret Pz3zC0NMDdZfb3FtqiLgwoexItojrYh/ \
+    -- --verbose
 ```
+
+Or, using a `flagfile.txt` for osqueryd:
+```sh 
+go run github.com/fleetdm/fleet/v4/orbit/cmd/orbit \
+    --dev-mode \
+    --disable-updates \
+    --root-dir /tmp/orbit \
+    -- --flagfile=flagfile.txt --verbose
+```
+
 
 ### Troubleshooting
 

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -102,6 +102,11 @@ func main() {
 			EnvVars: []string{"ORBIT_DISABLE_UPDATES"},
 		},
 		&cli.BoolFlag{
+			Name:    "dev-mode",
+			Usage:   "Runs in development mode",
+			EnvVars: []string{"ORBIT_DEV_MODE"},
+		},
+		&cli.BoolFlag{
 			Name:    "debug",
 			Usage:   "Enable debug logging",
 			EnvVars: []string{"ORBIT_DEBUG"},
@@ -185,8 +190,15 @@ func main() {
 		// Get the default osqueryd path from the installation/configuration.
 		osquerydPath := update.LocalPath(c.String("root-dir"), "osqueryd", c.String("osqueryd-channel"), constant.PlatformName)
 
+		if c.Bool("disable-updates") {
+			log.Info().Msg("running with auto updates disabled")
+		}
+
 		var updater *update.Updater
-		if !c.Bool("disabe-updates") {
+		if !c.Bool("disable-updates") ||
+			// When running in dev-mode, even if `disable-updates` is set, fetch osqueryd once as part
+			// of initialization.
+			c.Bool("dev-mode") {
 			// Initialize updater and get expected version of osqueryd.
 			opt := update.DefaultOptions
 			opt.RootDirectory = c.String("root-dir")

--- a/orbit/pkg/osquery/osquery.go
+++ b/orbit/pkg/osquery/osquery.go
@@ -3,6 +3,7 @@ package osquery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -35,6 +36,15 @@ type Option func(*Runner) error
 
 // NewRunner creates a new osquery runner given the provided functional options.
 func NewRunner(path string, options ...Option) (*Runner, error) {
+	switch _, err := os.Stat(path); {
+	case err == nil:
+		// OK
+	case errors.Is(err, os.ErrNotExist):
+		return nil, fmt.Errorf("osqueryd doesn't exist at path %q", path)
+	default:
+		return nil, fmt.Errorf("failed to check for osqueryd file: %w", err)
+	}
+
 	r := &Runner{}
 
 	cmd := exec.Command(path)

--- a/orbit/pkg/osquery/osquery.go
+++ b/orbit/pkg/osquery/osquery.go
@@ -31,8 +31,10 @@ type Runner struct {
 	cancel   func()
 }
 
+type Option func(*Runner) error
+
 // NewRunner creates a new osquery runner given the provided functional options.
-func NewRunner(path string, options ...func(*Runner) error) (*Runner, error) {
+func NewRunner(path string, options ...Option) (*Runner, error) {
 	r := &Runner{}
 
 	cmd := exec.Command(path)
@@ -53,7 +55,7 @@ func NewRunner(path string, options ...func(*Runner) error) (*Runner, error) {
 }
 
 // WithFlags adds additional flags to the osqueryd invocation.
-func WithFlags(flags []string) func(*Runner) error {
+func WithFlags(flags []string) Option {
 	return func(r *Runner) error {
 		r.cmd.Args = append(r.cmd.Args, flags...)
 		return nil
@@ -62,7 +64,7 @@ func WithFlags(flags []string) func(*Runner) error {
 
 // WithEnv adds additional environment variables to the osqueryd invocation.
 // Inputs should be in the form "KEY=VAL".
-func WithEnv(env []string) func(*Runner) error {
+func WithEnv(env []string) Option {
 	return func(r *Runner) error {
 		r.cmd.Env = append(r.cmd.Env, env...)
 		return nil
@@ -78,7 +80,7 @@ func WithShell() func(*Runner) error {
 	}
 }
 
-func WithDataPath(path string) func(*Runner) error {
+func WithDataPath(path string) Option {
 	return func(r *Runner) error {
 		r.dataPath = path
 
@@ -96,14 +98,14 @@ func WithDataPath(path string) func(*Runner) error {
 }
 
 // WithStderr sets the runner's cmd's stderr to the given writer.
-func WithStderr(w io.Writer) func(*Runner) error {
+func WithStderr(w io.Writer) Option {
 	return func(r *Runner) error {
 		r.cmd.Stderr = w
 		return nil
 	}
 }
 
-func WithLogPath(path string) func(*Runner) error {
+func WithLogPath(path string) Option {
 	return func(r *Runner) error {
 		if err := secure.MkdirAll(path, constant.DefaultDirMode); err != nil {
 			return fmt.Errorf("initialize osquery log path: %w", err)

--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -196,6 +196,7 @@ ORBIT_UPDATE_URL={{ .UpdateURL }}
 ORBIT_ORBIT_CHANNEL={{ .OrbitChannel }}
 ORBIT_OSQUERYD_CHANNEL={{ .OsquerydChannel }}
 {{ if .Insecure }}ORBIT_INSECURE=true{{ end }}
+{{ if .DisableUpdates }}ORBIT_DISABLE_UPDATES=true{{ end }}
 {{ if .FleetURL }}ORBIT_FLEET_URL={{.FleetURL}}{{ end }}
 {{ if .FleetCertificate }}ORBIT_FLEET_CERTIFICATE=/var/lib/orbit/fleet.pem{{ end }}
 {{ if .EnrollSecret }}ORBIT_ENROLL_SECRET={{.EnrollSecret}}{{ end }}

--- a/orbit/pkg/packaging/macos_templates.go
+++ b/orbit/pkg/packaging/macos_templates.go
@@ -84,6 +84,10 @@ var macosLaunchdTemplate = template.Must(template.New("").Option("missingkey=err
 		<key>ORBIT_FLEET_URL</key>
 		<string>{{ .FleetURL }}</string>
 		{{- end }}
+		{{- if .DisableUpdates }}
+		<key>ORBIT_DISABLE_UPDATES</key>
+		<string>true</string>
+		{{- end }}
 		<key>ORBIT_ORBIT_CHANNEL</key>
 		<string>{{ .OrbitChannel }}</string>
 		<key>ORBIT_OSQUERYD_CHANNEL</key>

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -39,6 +39,8 @@ type Options struct {
 	Notarize bool
 	// FleetCertificate is a path to a server certificate to include in the package.
 	FleetCertificate string
+	// DisableUpdates disables auto updates on the generated package.
+	DisableUpdates bool
 	// OrbitChannel is the update channel to use for Orbit.
 	OrbitChannel string
 	// OsquerydChannel is the update channel to use for Osquery (osqueryd).

--- a/orbit/pkg/packaging/windows_templates.go
+++ b/orbit/pkg/packaging/windows_templates.go
@@ -53,7 +53,7 @@ var windowsWixTemplate = template.Must(template.New("").Option("missingkey=error
                   ErrorControl="ignore"
                   Start="auto"
                   Type="ownProcess"
-                  Arguments='--root-dir "[ORBITROOT]." --log-file "[System64Folder]config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log" {{ if .FleetURL }}--fleet-url "{{ .FleetURL }}"{{ end }} {{ if .FleetCertificate }}--fleet-certificate "[ORBITROOT]fleet.pem"{{ end }} {{ if .EnrollSecret }}--enroll-secret-path "[ORBITROOT]secret.txt"{{ end }} {{if .Insecure }}--insecure{{ end }} {{ if .Debug }}--debug{{ end }} {{ if .UpdateURL }}--update-url "{{ .UpdateURL }}" {{ end }} --orbit-channel "{{ .OrbitChannel }}" --osqueryd-channel "{{ .OsquerydChannel }}"'
+                  Arguments='--root-dir "[ORBITROOT]." --log-file "[System64Folder]config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log"{{ if .FleetURL }} --fleet-url "{{ .FleetURL }}"{{ end }}{{ if .FleetCertificate }} --fleet-certificate "[ORBITROOT]fleet.pem"{{ end }}{{ if .EnrollSecret }} --enroll-secret-path "[ORBITROOT]secret.txt"{{ end }}{{if .Insecure }} --insecure{{ end }}{{ if .Debug }} --debug{{ end }}{{ if .UpdateURL }} --update-url "{{ .UpdateURL }}"{{ end }}{{ if .DisableUpdates }} --disable-updates{{ end }} --orbit-channel "{{ .OrbitChannel }}" --osqueryd-channel "{{ .OsquerydChannel }}"'
                 >
                   <util:ServiceConfig
                     FirstFailureActionType="restart"

--- a/orbit/pkg/update/update.go
+++ b/orbit/pkg/update/update.go
@@ -125,8 +125,13 @@ func (u *Updater) RepoPath(target, channel string) string {
 	return path.Join(target, u.opt.Platform, channel, target+constant.ExecutableExtension(u.opt.Platform))
 }
 
+// LocalPath defines the local file path of a target.
+func LocalPath(rootDir, target, channel, platform string) string {
+	return filepath.Join(rootDir, binDir, target, platform, channel, target+constant.ExecutableExtension(platform))
+}
+
 func (u *Updater) LocalPath(target, channel string) string {
-	return u.pathFromRoot(filepath.Join(binDir, target, u.opt.Platform, channel, target+constant.ExecutableExtension(u.opt.Platform)))
+	return LocalPath(u.opt.RootDirectory, target, channel, u.opt.Platform)
 }
 
 // Lookup looks up the provided target in the local target metadata. This should
@@ -300,13 +305,9 @@ func (u *Updater) Download(repoPath, localPath string) error {
 	return nil
 }
 
-func (u *Updater) pathFromRoot(parts ...string) string {
-	return filepath.Join(append([]string{u.opt.RootDirectory}, parts...)...)
-}
-
 func (u *Updater) initializeDirectories() error {
 	for _, dir := range []string{
-		u.pathFromRoot(binDir),
+		filepath.Join(u.opt.RootDirectory, binDir),
 	} {
 		err := secure.MkdirAll(dir, constant.DefaultDirMode)
 		if err != nil {


### PR DESCRIPTION
#3658

- [X] Changes file added (for user-visible changes)
~- [ ] Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality

PS: This change will be useful for automated tests of `fleetctl`/`orbit` (to prevent auto updates and use a custom binary for `orbit`).