### PR TITLE
GCP Terraform

### DIFF
--- a/tools/terraform/gcp/artifact_registry.tf
+++ b/tools/terraform/gcp/artifact_registry.tf
@@ -1,0 +1,7 @@
+resource "google_artifact_registry_repository" "my-repo" {
+  provider = google-beta
+  location = var.region
+  repository_id = "${var.prefix}-repository"
+  description = "repository to hold fleet container images for cloud run"
+  format = "DOCKER"
+}

--- a/tools/terraform/gcp/artifact_registry.tf
+++ b/tools/terraform/gcp/artifact_registry.tf
@@ -1,7 +1,7 @@
 resource "google_artifact_registry_repository" "my-repo" {
-  provider = google-beta
-  location = var.region
+  provider      = google-beta
+  location      = var.region
   repository_id = "${var.prefix}-repository"
-  description = "repository to hold fleet container images for cloud run"
-  format = "DOCKER"
+  description   = "repository to hold fleet container images for cloud run"
+  format        = "DOCKER"
 }

--- a/tools/terraform/gcp/cloud_run.tf
+++ b/tools/terraform/gcp/cloud_run.tf
@@ -1,0 +1,51 @@
+resource "google_cloud_run_service" "default" {
+  name     = "fleetdm"
+  location = var.region
+
+  template {
+    spec {
+      containers {
+        image = "us-docker.pkg.dev/cloudrun/container/hello"
+        ports {
+
+          name           = "http1"
+          container_port = 8080
+        }
+        env {
+          name  = "FLEET_MYSQL_USERNAME"
+          value = "root"
+        }
+        env {
+          name  = "FLEET_MYSQL_PASSWORD"
+          value = "root"
+        }
+        env {
+          name  = "FLEET_SERVER_TLS"
+          value = "root"
+        }
+        env {
+          name  = "FLEET_MYSQL_ADDRESS"
+          value = "root"
+        }
+        env {
+          name  = "FLEET_REDIS_ADDRESS"
+          value = "root"
+        }
+
+      }
+    }
+
+    metadata {
+      annotations = {
+        "autoscaling.knative.dev/maxScale"        = "1000"
+        "run.googleapis.com/cloudsql-instances"   = google_sql_database_instance.instance.connection_name
+        "run.googleapis.com/vpc-access-connector" = google_vpc_access_connector.connector.name
+        "run.googleapis.com/ingress"              = "internal-and-cloud-load-balancing"
+        "run.googleapis.com/ingress-status"       = "internal-and-cloud-load-balancing"
+        "run.googleapis.com/vpc-access-egress"    = "all"
+        "run.googleapis.com/client-name"          = "terraform"
+      }
+    }
+  }
+  autogenerate_revision_name = true
+}

--- a/tools/terraform/gcp/cloud_run.tf
+++ b/tools/terraform/gcp/cloud_run.tf
@@ -7,13 +7,68 @@ resource "google_compute_region_network_endpoint_group" "neg" {
   }
 }
 
+data "google_iam_policy" "noauth" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "allUsers",
+    ]
+  }
+}
+
+resource "google_cloud_run_service_iam_policy" "noauth" {
+  location = google_cloud_run_service.default.location
+  project  = google_cloud_run_service.default.project
+  service  = google_cloud_run_service.default.name
+
+  policy_data = data.google_iam_policy.noauth.policy_data
+}
+
+resource "random_pet" "suffix" {
+  length = 1
+}
+
+resource "google_secret_manager_secret" "secret" {
+  secret_id = "fleet-db-password-${random_pet.suffix.id}"
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret-version-data" {
+  secret      = google_secret_manager_secret.secret.name
+  secret_data = module.fleet-mysql.generated_user_password
+}
+
+data "google_compute_default_service_account" "default" {}
+
+resource "google_secret_manager_secret_iam_member" "secret-access" {
+  secret_id  = google_secret_manager_secret.secret.id
+  role       = "roles/secretmanager.secretAccessor"
+  member     = "serviceAccount:${data.google_compute_default_service_account.default.email}"
+  depends_on = [google_secret_manager_secret.secret]
+}
+
 resource "google_cloud_run_service" "default" {
   name     = "${var.prefix}-backend"
   location = var.region
+  metadata {
+    annotations = {
+      "run.googleapis.com/ingress"        = "internal-and-cloud-load-balancing"
+      "run.googleapis.com/ingress-status" = "internal-and-cloud-load-balancing"
+    }
+  }
+
 
   template {
     spec {
       containers {
+        resources {
+          limits = {
+            cpu    = var.fleet_cpu
+            memory = var.fleet_memory
+          }
+        }
         image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.my-repo.name}/${var.image}"
         ports {
           name           = "http1"
@@ -28,10 +83,6 @@ resource "google_cloud_run_service" "default" {
           value = var.db_name
         }
         env {
-          name  = "FLEET_MYSQL_PASSWORD"
-          value = random_password.fleet-db-user-pw.result
-        }
-        env {
           name  = "FLEET_SERVER_TLS"
           value = false
         }
@@ -41,30 +92,35 @@ resource "google_cloud_run_service" "default" {
         }
         env {
           name  = "FLEET_REDIS_ADDRESS"
-          value = google_redis_instance.cache.host
+          value = "${google_redis_instance.cache.host}:${google_redis_instance.cache.port}"
         }
         env {
-          name  = "FLEET_REDIS_PORT"
-          value = google_redis_instance.cache.port
+          name = "FLEET_MYSQL_PASSWORD"
+          value_from {
+            secret_key_ref {
+              name = google_secret_manager_secret.secret.secret_id
+              key  = "latest"
+            }
+          }
         }
-        command = ["fleet", "prepare", "--no-prompt=true", "db"]
-#        command = ["/bin/sh", "-c"]
-#        args = [
-#          "fleet prepare --no-prompt=true db && fleet serve"
-#        ]
+        command = ["/bin/sh"]
+        args = [
+          "-c",
+          "fleet prepare --no-prompt=true db; exec fleet serve"
+        ]
       }
     }
 
     metadata {
       annotations = {
+        "autoscaling.knative.dev/minScale"        = "1"
         "autoscaling.knative.dev/maxScale"        = "1000"
         "run.googleapis.com/cloudsql-instances"   = module.fleet-mysql.instance_connection_name
         "run.googleapis.com/vpc-access-connector" = tolist(module.serverless-connector.connector_ids)[0]
-        #        "run.googleapis.com/execution-environment" = "gen2"
-        "run.googleapis.com/ingress"           = "internal-and-cloud-load-balancing"
-        "run.googleapis.com/ingress-status"    = "internal-and-cloud-load-balancing"
-        "run.googleapis.com/vpc-access-egress" = "all"
-        "run.googleapis.com/client-name"       = "terraform"
+        "run.googleapis.com/vpc-access-egress"    = "all-traffic"
+        "run.googleapis.com/client-name"          = "terraform"
+        "run.googleapis.com/cpu-throttling"       = "false"
+
       }
     }
   }

--- a/tools/terraform/gcp/cloud_run.tf
+++ b/tools/terraform/gcp/cloud_run.tf
@@ -39,7 +39,7 @@ resource "google_cloud_run_service" "default" {
       annotations = {
         "autoscaling.knative.dev/maxScale"        = "1000"
         "run.googleapis.com/cloudsql-instances"   = google_sql_database_instance.instance.connection_name
-        "run.googleapis.com/vpc-access-connector" = google_vpc_access_connector.connector.name
+        "run.googleapis.com/vpc-access-connector" = module.serverless-connector.connector_ids
         "run.googleapis.com/ingress"              = "internal-and-cloud-load-balancing"
         "run.googleapis.com/ingress-status"       = "internal-and-cloud-load-balancing"
         "run.googleapis.com/vpc-access-egress"    = "all"

--- a/tools/terraform/gcp/cloud_run.tf
+++ b/tools/terraform/gcp/cloud_run.tf
@@ -14,7 +14,7 @@ resource "google_cloud_run_service" "default" {
   template {
     spec {
       containers {
-        image = "us-docker.pkg.dev/cloudrun/container/hello"
+        image = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.my-repo.name}/${var.image}"
         ports {
           name           = "http1"
           container_port = 8080
@@ -24,8 +24,12 @@ resource "google_cloud_run_service" "default" {
           value = var.db_user
         }
         env {
+          name  = "FLEET_MYSQL_DATABASE"
+          value = var.db_name
+        }
+        env {
           name  = "FLEET_MYSQL_PASSWORD"
-          value = module.safer-mysql-db.generated_user_password
+          value = random_password.fleet-db-user-pw.result
         }
         env {
           name  = "FLEET_SERVER_TLS"
@@ -33,7 +37,7 @@ resource "google_cloud_run_service" "default" {
         }
         env {
           name  = "FLEET_MYSQL_ADDRESS"
-          value = module.safer-mysql-db.instance_connection_name
+          value = module.fleet-mysql.private_ip_address
         }
         env {
           name  = "FLEET_REDIS_ADDRESS"
@@ -43,20 +47,24 @@ resource "google_cloud_run_service" "default" {
           name  = "FLEET_REDIS_PORT"
           value = google_redis_instance.cache.port
         }
-
+        command = ["fleet", "prepare", "--no-prompt=true", "db"]
+#        command = ["/bin/sh", "-c"]
+#        args = [
+#          "fleet prepare --no-prompt=true db && fleet serve"
+#        ]
       }
     }
 
     metadata {
       annotations = {
-        "autoscaling.knative.dev/maxScale"         = "1000"
-        "run.googleapis.com/cloudsql-instances"    = module.safer-mysql-db.instance_connection_name
-        "run.googleapis.com/vpc-access-connector"  = tolist(module.serverless-connector.connector_ids)[0]
-#        "run.googleapis.com/execution-environment" = "gen2"
-        "run.googleapis.com/ingress"               = "internal-and-cloud-load-balancing"
-        "run.googleapis.com/ingress-status"        = "internal-and-cloud-load-balancing"
-        "run.googleapis.com/vpc-access-egress"     = "all"
-        "run.googleapis.com/client-name"           = "terraform"
+        "autoscaling.knative.dev/maxScale"        = "1000"
+        "run.googleapis.com/cloudsql-instances"   = module.fleet-mysql.instance_connection_name
+        "run.googleapis.com/vpc-access-connector" = tolist(module.serverless-connector.connector_ids)[0]
+        #        "run.googleapis.com/execution-environment" = "gen2"
+        "run.googleapis.com/ingress"           = "internal-and-cloud-load-balancing"
+        "run.googleapis.com/ingress-status"    = "internal-and-cloud-load-balancing"
+        "run.googleapis.com/vpc-access-egress" = "all"
+        "run.googleapis.com/client-name"       = "terraform"
       }
     }
   }

--- a/tools/terraform/gcp/loadbalancer.tf
+++ b/tools/terraform/gcp/loadbalancer.tf
@@ -1,11 +1,25 @@
+resource "google_dns_managed_zone" "default" {
+  dns_name = var.dns_name
+  name     = "${var.prefix}-zone"
+}
+
+resource "google_dns_record_set" "default" {
+  managed_zone = google_dns_managed_zone.default.name
+  name         = var.dns_name
+  type         = "A"
+  ttl          = "300"
+  rrdatas      = [module.lb-http.external_ip]
+  depends_on   = [module.lb-http]
+}
+
 module "lb-http" {
-  source            = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
-  version           = "~> 6.2.0"
+  source  = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
+  version = "~> 6.2.0"
 
-  project           = var.project_id
-  name              = "${var.prefix}-load-balancer"
+  project = var.project_id
+  name    = "${var.prefix}-load-balancer"
 
-  managed_ssl_certificate_domains = ["gcp.fleetdm.com"]
+  managed_ssl_certificate_domains = [trim(var.dns_name, ".")]
   ssl                             = true
   https_redirect                  = true
 
@@ -33,9 +47,9 @@ module "lb-http" {
         oauth2_client_secret = null
       }
 
-      description             = null
-      custom_request_headers  = null
-      security_policy         = null
+      description            = null
+      custom_request_headers = null
+      security_policy        = null
     }
   }
 }

--- a/tools/terraform/gcp/loadbalancer.tf
+++ b/tools/terraform/gcp/loadbalancer.tf
@@ -2,10 +2,10 @@ module "lb-http" {
   source            = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
   version           = "~> 6.2.0"
 
-  project           = "YOUR_PROJECT_ID"
-  name              = "my-lb"
+  project           = var.project_id
+  name              = "${var.prefix}-load-balancer"
 
-  managed_ssl_certificate_domains = ["YOUR_DOMAIN.COM"]
+  managed_ssl_certificate_domains = ["gcp.fleetdm.com"]
   ssl                             = true
   https_redirect                  = true
 
@@ -14,9 +14,11 @@ module "lb-http" {
       # List your serverless NEGs, VMs, or buckets as backends
       groups = [
         {
-          group = google_compute_region_network_endpoint_group.default.id
+          group = google_compute_region_network_endpoint_group.neg.id
         }
       ]
+      custom_request_headers  = null
+      custom_response_headers = null
 
       enable_cdn = false
 

--- a/tools/terraform/gcp/main.tf
+++ b/tools/terraform/gcp/main.tf
@@ -2,13 +2,21 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.5.0"
+      version = "4.9.0"
+    }
+    google-beta = {
+      source = "hashicorp/google-beta"
     }
   }
 }
 
 provider "google" {
   # Configuration options
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
   project = var.project_id
   region  = var.region
 }

--- a/tools/terraform/gcp/main.tf
+++ b/tools/terraform/gcp/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "4.5.0"
+    }
+  }
+}
+
+provider "google" {
+  # Configuration options
+  project = var.project_id
+  region  = var.region
+}

--- a/tools/terraform/gcp/mysql.tf
+++ b/tools/terraform/gcp/mysql.tf
@@ -1,6 +1,8 @@
+resource "random_password" "fleet-db-user-pw" {
+  length = 12
+}
 
-
-module "safer-mysql-db" {
+module "fleet-mysql" {
   source               = "GoogleCloudPlatform/sql-db/google//modules/safer_mysql"
   version              = "9.0.0"
   name                 = "${var.prefix}-mysql"
@@ -9,11 +11,25 @@ module "safer-mysql-db" {
 
   deletion_protection = false
 
+  additional_users = [
+    {
+      name     = var.db_user
+      password = random_password.fleet-db-user-pw.result
+      host     = "% (any host)"
+      type     = "BUILT_IN"
+    }
+  ]
   database_version = var.db_version
   region           = var.region
   zone             = var.db_zone
   tier             = var.db_tier
-  user_name        = var.db_user
+  additional_databases = [
+    {
+      name      = var.db_name
+      charset   = "utf8mb4"
+      collation = "utf8mb4_general_ci"
+    }
+  ]
 
   vpc_network = module.vpc.network_self_link
 

--- a/tools/terraform/gcp/mysql.tf
+++ b/tools/terraform/gcp/mysql.tf
@@ -1,0 +1,22 @@
+
+
+module "safer-mysql-db" {
+  source               = "GoogleCloudPlatform/sql-db/google//modules/safer_mysql"
+  version              = "9.0.0"
+  name                 = "${var.prefix}-mysql"
+  random_instance_name = true
+  project_id           = var.project_id
+
+  deletion_protection = false
+
+  database_version = var.db_version
+  region           = var.region
+  zone             = var.db_zone
+  tier             = var.db_tier
+  user_name        = var.db_user
+
+  vpc_network = module.vpc.network_self_link
+
+  // Optional: used to enforce ordering in the creation of resources.
+  module_depends_on = [module.private-service-access.peering_completed]
+}

--- a/tools/terraform/gcp/readme.md
+++ b/tools/terraform/gcp/readme.md
@@ -1,0 +1,22 @@
+### Pushing the Fleet image into Google Artifact registry
+
+Login with gcloud helper:
+
+```shell
+gcloud auth configure-docker \
+    us-central1-docker.pkg.dev
+```
+
+Pull latest image
+
+`docker pull <latest fleet version>` for example `docker pull fleetdm/fleet:v4.9.1`
+
+Tag it
+
+```
+docker tag fleetdm/fleet:v4.9.1 us-central1-docker.pkg.dev/<project_id>/fleet-repository/fleet:v4.9.1
+```
+
+Push to Google Artifact registry
+
+`docker push us-central1-docker.pkg.dev/<project_id>/fleet-repository/fleet:v4.9.1`

--- a/tools/terraform/gcp/readme.md
+++ b/tools/terraform/gcp/readme.md
@@ -1,4 +1,23 @@
+## Fleet on GCP
+
+### Overview
+
+#### Fleet server
+The fleet webserver is running as [Google Cloud Run](https://cloud.google.com/run) containers, this is very similar to how the existing terraform for AWS runs fleet as Fargate compute.
+_NOTE: Cloud Run has [limitations](https://cloud.google.com/run/docs/deploying#images) on what container images it will run_. In our deployment we create
+and Artifact Registry and deploy the public fleet container image into Artifact Registry.
+
+#### MySQL
+We are running MySQL using [Google Cloud SQL](https://cloud.google.com/sql/docs/mysql/introduction) only reachable via [CloudSQLProxy](https://cloud.google.com/sql/docs/mysql/connect-admin-proxy) and from Cloud Run
+using [Serverless VPC Access Connector](https://cloud.google.com/sql/docs/mysql/connect-run#private-ip).
+
+#### Redis
+We are running Redis using [Google Cloud Memorystore (Redis engine)](https://cloud.google.com/memorystore). This can run in cluster mode, but by default we
+are running in standalone mode.
+
 ### Pushing the Fleet image into Google Artifact registry
+
+More details can be found [here](https://cloud.google.com/artifact-registry/docs/docker/pushing-and-pulling).
 
 Login with gcloud helper:
 
@@ -7,16 +26,22 @@ gcloud auth configure-docker \
     us-central1-docker.pkg.dev
 ```
 
-Pull latest image
+Pull latest image:
 
-`docker pull <latest fleet version>` for example `docker pull fleetdm/fleet:v4.9.1`
+`docker pull <latest fleet version>` for example `docker pull fleetdm/fleet:v4.10.0`
 
-Tag it
+Tag it:
 
 ```
-docker tag fleetdm/fleet:v4.9.1 us-central1-docker.pkg.dev/<project_id>/fleet-repository/fleet:v4.9.1
+docker tag fleetdm/fleet:v10.0.0 us-central1-docker.pkg.dev/<project_id>/fleet-repository/fleet:v10.0.0
 ```
 
-Push to Google Artifact registry
+Push to Google Artifact registry:
 
 `docker push us-central1-docker.pkg.dev/<project_id>/fleet-repository/fleet:v4.9.1`
+
+### GCP Managed Certificates
+
+In this example we are using [GCP Managed Certificates](https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs) to handle TLS and TLS termination at the LoadBalancer.
+In order for the certificate to be properly issued, you'll need to update your domain registrar with the nameserver values generated
+by the new Zone created in GCP DNS.

--- a/tools/terraform/gcp/readme.md
+++ b/tools/terraform/gcp/readme.md
@@ -1,5 +1,12 @@
 ## Fleet on GCP
 
+Required Variables:
+```terraform
+project_id = "<your project id>"
+prefix     = "fleet"
+dns_name   = "<the domain you want to host fleet at>" // eg. myfleet.fleetdm.com.
+```
+
 ### Overview
 
 #### Fleet server

--- a/tools/terraform/gcp/redis.tf
+++ b/tools/terraform/gcp/redis.tf
@@ -1,0 +1,9 @@
+resource "google_redis_instance" "cache" {
+  name               = "${var.prefix}-redis"
+  tier               = "STANDARD_HA"
+  memory_size_gb     = 1
+  authorized_network = module.vpc.network_name
+  connect_mode       = "PRIVATE_SERVICE_ACCESS"
+  display_name       = "${var.prefix}-redis"
+  depends_on         = [module.private-service-access.peering_completed]
+}

--- a/tools/terraform/gcp/redis.tf
+++ b/tools/terraform/gcp/redis.tf
@@ -1,7 +1,7 @@
 resource "google_redis_instance" "cache" {
   name               = "${var.prefix}-redis"
   tier               = "STANDARD_HA"
-  memory_size_gb     = 1
+  memory_size_gb     = var.redis_mem
   authorized_network = module.vpc.network_name
   connect_mode       = "PRIVATE_SERVICE_ACCESS"
   display_name       = "${var.prefix}-redis"

--- a/tools/terraform/gcp/serverless-neg.tf
+++ b/tools/terraform/gcp/serverless-neg.tf
@@ -1,6 +1,6 @@
 module "lb-http" {
   source            = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
-  version           = "~> 4.5"
+  version           = "~> 6.2.0"
 
   project           = "YOUR_PROJECT_ID"
   name              = "my-lb"

--- a/tools/terraform/gcp/serverless-neg.tf
+++ b/tools/terraform/gcp/serverless-neg.tf
@@ -1,0 +1,39 @@
+module "lb-http" {
+  source            = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
+  version           = "~> 4.5"
+
+  project           = "YOUR_PROJECT_ID"
+  name              = "my-lb"
+
+  managed_ssl_certificate_domains = ["YOUR_DOMAIN.COM"]
+  ssl                             = true
+  https_redirect                  = true
+
+  backends = {
+    default = {
+      # List your serverless NEGs, VMs, or buckets as backends
+      groups = [
+        {
+          group = google_compute_region_network_endpoint_group.default.id
+        }
+      ]
+
+      enable_cdn = false
+
+      log_config = {
+        enable      = true
+        sample_rate = 1.0
+      }
+
+      iap_config = {
+        enable               = false
+        oauth2_client_id     = null
+        oauth2_client_secret = null
+      }
+
+      description             = null
+      custom_request_headers  = null
+      security_policy         = null
+    }
+  }
+}

--- a/tools/terraform/gcp/services.tf
+++ b/tools/terraform/gcp/services.tf
@@ -2,3 +2,9 @@ resource "google_project_service" "vpcaccess-api" {
   project = var.project_id # Replace this with your project ID in quotes
   service = "vpcaccess.googleapis.com"
 }
+
+resource "google_project_service" "secretmanager" {
+  provider = google-beta
+  project  = var.project_id
+  service  = "secretmanager.googleapis.com"
+}

--- a/tools/terraform/gcp/services.tf
+++ b/tools/terraform/gcp/services.tf
@@ -1,0 +1,4 @@
+resource "google_project_service" "vpcaccess-api" {
+  project = var.project_id # Replace this with your project ID in quotes
+  service = "vpcaccess.googleapis.com"
+}

--- a/tools/terraform/gcp/variables.tf
+++ b/tools/terraform/gcp/variables.tf
@@ -1,6 +1,6 @@
 variable "region" {
   description = "gcp region"
-  default = "us-central1"
+  default     = "us-central1"
 }
 
 variable "db_zone" {
@@ -8,7 +8,7 @@ variable "db_zone" {
 }
 
 variable "db_user" {
-  default = "fleet"
+  default = "default"
 }
 
 variable "db_name" {
@@ -20,7 +20,23 @@ variable "db_tier" {
 }
 
 variable "db_version" {
-  default = "MYSQL_5_6"
+  default = "MYSQL_5_7"
+}
+
+variable "fleet_cpu" {
+  default = "1000m"
+}
+
+variable "fleet_memory" {
+  default = "1024Mi"
+}
+
+variable "dns_zone" {
+  default = ""
+}
+
+variable "dns_name" {
+  default = ""
 }
 
 variable "serverless_connector_min_instances" {
@@ -43,7 +59,7 @@ variable "project_id" {
 }
 
 variable "prefix" {
-  default = "fleet-"
+  default     = "fleet-"
   description = "prefix resources with this string"
 }
 

--- a/tools/terraform/gcp/variables.tf
+++ b/tools/terraform/gcp/variables.tf
@@ -3,6 +3,37 @@ variable "region" {
   default = "us-central1"
 }
 
+variable "db_zone" {
+  default = "us-central1-c"
+}
+
+variable "db_user" {
+  default = "fleet"
+}
+
+variable "db_tier" {
+  default = "db-n1-standard-1"
+}
+
+variable "db_version" {
+  default = "MYSQL_5_6"
+}
+
+variable "serverless_connector_min_instances" {
+  default = 2
+}
+variable "serverless_connector_max_instances" {
+  default = 3
+}
+
+variable "serverless_connector_instance_type" {
+  default = "f1-micro"
+}
+
+variable "vpc_subnet" {
+  default = "10.10.10.0/28"
+}
+
 variable "project_id" {
   description = "gcp project id"
 }

--- a/tools/terraform/gcp/variables.tf
+++ b/tools/terraform/gcp/variables.tf
@@ -11,6 +11,10 @@ variable "db_user" {
   default = "fleet"
 }
 
+variable "db_name" {
+  default = "fleet"
+}
+
 variable "db_tier" {
   default = "db-n1-standard-1"
 }
@@ -41,4 +45,12 @@ variable "project_id" {
 variable "prefix" {
   default = "fleet-"
   description = "prefix resources with this string"
+}
+
+variable "redis_mem" {
+  default = 1
+}
+
+variable "image" {
+  default = "fleet:v4.10.0"
 }

--- a/tools/terraform/gcp/variables.tf
+++ b/tools/terraform/gcp/variables.tf
@@ -6,3 +6,8 @@ variable "region" {
 variable "project_id" {
   description = "gcp project id"
 }
+
+variable "prefix" {
+  default = "fleet-"
+  description = "prefix resources with this string"
+}

--- a/tools/terraform/gcp/variables.tf
+++ b/tools/terraform/gcp/variables.tf
@@ -1,0 +1,8 @@
+variable "region" {
+  description = "gcp region"
+  default = "us-central1"
+}
+
+variable "project_id" {
+  description = "gcp project id"
+}

--- a/tools/terraform/gcp/vpc.tf
+++ b/tools/terraform/gcp/vpc.tf
@@ -1,0 +1,43 @@
+module "vpc" {
+  source       = "terraform-google-modules/network/google"
+  version      = "~> 3.3.0"
+  project_id   = var.project_id
+  network_name = "fleet-network"
+  mtu          = 1460
+
+  subnets = [
+    {
+      subnet_name   = "serverless-subnet"
+      subnet_ip     = "10.10.10.0/28"
+      subnet_region = "us-central1"
+    }
+  ]
+}
+
+module "serverless-connector" {
+  source     = "terraform-google-modules/network/google//modules/vpc-serverless-connector-beta"
+  project_id = var.project_id
+  vpc_connectors = [{
+    name        = "central-serverless"
+    region      = "us-central1"
+    subnet_name = module.vpc.subnets["us-central1/serverless-subnet"].name
+    # host_project_id = var.host_project_id # Specify a host_project_id for shared VPC
+    machine_type  = "e2-standard-4"
+    min_instances = 2
+    max_instances = 7
+  }
+    # Uncomment to specify an ip_cidr_range
+    #   , {
+    #     name          = "central-serverless2"
+    #     region        = "us-central1"
+    #     network       = module.test-vpc-module.network_name
+    #     ip_cidr_range = "10.10.11.0/28"
+    #     subnet_name   = null
+    #     machine_type  = "e2-standard-4"
+    #     min_instances = 2
+    #   max_instances = 7 }
+  ]
+  depends_on = [
+    google_project_service.vpcaccess-api
+  ]
+}

--- a/tools/terraform/gcp/vpc.tf
+++ b/tools/terraform/gcp/vpc.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source       = "terraform-google-modules/network/google"
-  version      = "~> 3.3.0"
+  version      = "~> 4.1.0"
   project_id   = var.project_id
   network_name = "fleet-network"
   mtu          = 1460
@@ -22,10 +22,10 @@ module "serverless-connector" {
     region      = "us-central1"
     subnet_name = module.vpc.subnets["us-central1/serverless-subnet"].name
     # host_project_id = var.host_project_id # Specify a host_project_id for shared VPC
-    machine_type  = "e2-standard-4"
-    min_instances = 2
-    max_instances = 7
-  }
+    machine_type  = "f1-micro"
+    min_instances = 1
+    max_instances = 2
+    }
     # Uncomment to specify an ip_cidr_range
     #   , {
     #     name          = "central-serverless2"
@@ -40,4 +40,18 @@ module "serverless-connector" {
   depends_on = [
     google_project_service.vpcaccess-api
   ]
+}
+
+resource "google_vpc_access_connector" "connector_beta" {
+  provider = google-beta
+  name     = "foobar"
+  project  = var.project_id
+  region   = var.region
+  subnet {
+    name       = module.vpc.subnets["us-central1/serverless-subnet"].name
+    project_id = var.project_id
+  }
+  machine_type  = "f1-micro"
+  min_instances = 1
+  max_instances = 2
 }

--- a/tools/terraform/gcp/vpc.tf
+++ b/tools/terraform/gcp/vpc.tf
@@ -1,15 +1,20 @@
+locals {
+  subnet_name        = "${var.prefix}-serverless-subnet"
+  vpc_connector_name = "${var.prefix}-serverless-con"
+}
+
 module "vpc" {
   source       = "terraform-google-modules/network/google"
   version      = "~> 4.1.0"
   project_id   = var.project_id
-  network_name = "fleet-network"
+  network_name = "${var.prefix}network"
   mtu          = 1460
 
   subnets = [
     {
-      subnet_name   = "serverless-subnet"
-      subnet_ip     = "10.10.10.0/28"
-      subnet_region = "us-central1"
+      subnet_name   = local.subnet_name
+      subnet_ip     = var.vpc_subnet
+      subnet_region = var.region
     }
   ]
 }
@@ -18,40 +23,23 @@ module "serverless-connector" {
   source     = "terraform-google-modules/network/google//modules/vpc-serverless-connector-beta"
   project_id = var.project_id
   vpc_connectors = [{
-    name        = "central-serverless"
-    region      = "us-central1"
-    subnet_name = module.vpc.subnets["us-central1/serverless-subnet"].name
-    # host_project_id = var.host_project_id # Specify a host_project_id for shared VPC
-    machine_type  = "f1-micro"
-    min_instances = 1
-    max_instances = 2
+    name          = local.vpc_connector_name
+    region        = var.region
+    subnet_name   = module.vpc.subnets["${var.region}/${local.subnet_name}"].name
+    machine_type  = var.serverless_connector_instance_type
+    min_instances = var.serverless_connector_min_instances
+    max_instances = var.serverless_connector_max_instances
     }
-    # Uncomment to specify an ip_cidr_range
-    #   , {
-    #     name          = "central-serverless2"
-    #     region        = "us-central1"
-    #     network       = module.test-vpc-module.network_name
-    #     ip_cidr_range = "10.10.11.0/28"
-    #     subnet_name   = null
-    #     machine_type  = "e2-standard-4"
-    #     min_instances = 2
-    #   max_instances = 7 }
   ]
   depends_on = [
     google_project_service.vpcaccess-api
   ]
 }
 
-resource "google_vpc_access_connector" "connector_beta" {
-  provider = google-beta
-  name     = "foobar"
-  project  = var.project_id
-  region   = var.region
-  subnet {
-    name       = module.vpc.subnets["us-central1/serverless-subnet"].name
-    project_id = var.project_id
-  }
-  machine_type  = "f1-micro"
-  min_instances = 1
-  max_instances = 2
+module "private-service-access" {
+  source      = "GoogleCloudPlatform/sql-db/google//modules/private_service_access"
+  version     = "9.0.0"
+  project_id  = var.project_id
+  vpc_network = module.vpc.network_name
+  depends_on  = [module.vpc]
 }


### PR DESCRIPTION
This PR adds terraform that can deploy fleet into GCP as a Cloud Run container with minimal effort.

the following dependencies are also handled:

MySQL
Redis
TLS -- via GCP Managed Certificates
