### PR TITLE
Loading/error state for Fleet certificate match Figma

### DIFF
--- a/changes/issue-4304-loading-error-certificate
+++ b/changes/issue-4304-loading-error-certificate
@@ -1,0 +1,1 @@
+* Fix loading / error state for retreiving Fleet certificate

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -251,12 +251,17 @@ const PlatformWrapper = ({
               <p className={`${baseClass}__advanced--heading`}>
                 Download your Fleet certificate:
               </p>
-              <p>
-                Prove the TLS certificate used by the Fleet server to enable
-                secure connections from osquery:
-                <br />
-                {!isFetchingCertificate &&
-                  (certificate ? (
+              {isFetchingCertificate && (
+                <p className={`${baseClass}__certificate-loading`}>
+                  Loading your certificate
+                </p>
+              )}
+              {!isFetchingCertificate &&
+                (certificate ? (
+                  <p>
+                    Prove the TLS certificate used by the Fleet server to enable
+                    secure connections from osquery:
+                    <br />
                     <a
                       href="#downloadCertificate"
                       className={`${baseClass}__fleet-certificate-download`}
@@ -265,17 +270,17 @@ const PlatformWrapper = ({
                       Download
                       <img src={DownloadIcon} alt="download" />
                     </a>
-                  ) : (
-                    <p className={`${baseClass}__certificate-error`}>
-                      <em>Fleet failed to load your certificate.</em>
-                      <span>
-                        If you&apos;re able to access Fleet at a private or
-                        secure (HTTPS) IP address, please log into Fleet at this
-                        address to load your certificate.
-                      </span>
-                    </p>
-                  ))}
-              </p>
+                  </p>
+                ) : (
+                  <p className={`${baseClass}__certificate-error`}>
+                    <em>Fleet failed to load your certificate.</em>
+                    <span>
+                      If you&apos;re able to access Fleet at a private or secure
+                      (HTTPS) IP address, please log into Fleet at this address
+                      to load your certificate.
+                    </span>
+                  </p>
+                ))}
             </div>
             <div className={`${baseClass}__advanced--enroll-secrets`}>
               <p className={`${baseClass}__advanced--heading`}>

--- a/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
+++ b/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
@@ -109,14 +109,13 @@
   &__certificate-loading {
     color: $ui-fleet-black-50;
     padding-top: $pad-xsmall;
-    margin: 0;
   }
 
   &__certificate-error {
     span,
     em {
       display: block;
-      padding-top: $pad-xsmall;
+      padding: $pad-xsmall 0;
     }
     em {
       color: $ui-error;


### PR DESCRIPTION
Cerra #4304 

- Add loading state line
- Remove "Prove the TLS certificate used by the Fleet server to enable secure connections from osquery:" from error state

https://www.loom.com/share/687a3279df2e40a9937945c939bd70fc

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
