### PR TITLE
Update OSSF Scorecard Analysis to 1.0.4

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@c8416b0b2bf627c349ca92fc8e3de51a64b005cf # v1.0.2
+        uses: ossf/scorecard-action@c1aec4ac820532bab364f02a81873c555a0ba3a1 # v1.0.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Update scorecard analysis version from 1.0.2 to 1.0.4 - has updates on how env variables are handled, need to update and see if it fixes the issue we have with the cron job.

