### PR TITLE
Remove host counts column from software table when team filter is applied

### DIFF
--- a/changes/issue-4268-hide-hosts-count-team-software
+++ b/changes/issue-4268-hide-hosts-count-team-software
@@ -1,0 +1,3 @@
+* Hide hosts count column on software page if team filter is selected (this temporary fix is being
+deployed because currently the hosts count for individual software items is only captured at the
+global level and not available on a per-team basis)

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -470,7 +470,13 @@ const ManageSoftwarePage = ({
           <TableDataError />
         ) : (
           <TableContainer
-            columns={softwareTableHeaders}
+            columns={
+              currentTeam?.id
+                ? softwareTableHeaders.filter(
+                    (h) => h.accessor !== "hosts_count"
+                  )
+                : softwareTableHeaders
+            }
             data={(isSoftwareEnabled && software?.software) || []}
             isLoading={isFetchingSoftware || isFetchingCount}
             resultsTitle={"software items"}

--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -230,6 +230,9 @@
         .id__header {
           width: 180px;
         }
+        .vulnerabilities__header:nth-last-child(2) {
+          border-right: 0;
+        }
       }
 
       tbody {


### PR DESCRIPTION
Issue #4268

- Hide hosts count column on software page if team filter is selected

Note: This is a temporary fix and is being deployed because currently the hosts count for individual software items is only captured at the global level and not available on a per-team basis.

# Checklist for submitter
- [x] Changes file added (for user-visible changes)
- ~~Documented any API changes (docs/01-Using-Fleet/03-REST-API.md)~~
- ~~Documented any permissions changes~~
- ~~Added/updated tests~~
- [x] Manual QA for all new/changed functionality
