### PR TITLE
endpoint_sessions.go: add the redirect URL in the html body text

### DIFF
--- a/server/service/endpoint_sessions.go
+++ b/server/service/endpoint_sessions.go
@@ -127,7 +127,7 @@ func makeCallbackSSOEndpoint(svc fleet.Service, urlPrefix string) endpoint.Endpo
      window.location = redirectURL;
      </script>
      <body>
-     Redirecting to Fleet...
+     Redirecting to Fleet at {{ .RedirectURL }} ...
      </body>
      </html>
     `


### PR DESCRIPTION
This makes debug easier in case the browser get stuck on the redirect page. I'm having the issue #4327 and I had to recompile fleet with this change and update my server with the new binary just to see why the redirection wasn't working.