### PR TITLE
[FIX] change fleet to uppercase to conform to style guide in fleetctl

### DIFF
--- a/cmd/fleetctl/config.go
+++ b/cmd/fleetctl/config.go
@@ -226,7 +226,7 @@ func configSetCommand() *cli.Command {
 				EnvVars:     []string{"ROOTCA"},
 				Value:       "",
 				Destination: &flRootCA,
-				Usage:       "Specify RootCA chain used to communicate with fleet",
+				Usage:       "Specify RootCA chain used to communicate with Fleet",
 			},
 			&cli.StringFlag{
 				Name:        "url-prefix",


### PR DESCRIPTION
 A tiny fix. In the rootca option usage description, Fleet was spelled as fleet and this PR fixes that.