### PR TITLE
Fix UI warnings when running make generate-dev

### DIFF
--- a/frontend/redux/nodes/auth/reducer.js
+++ b/frontend/redux/nodes/auth/reducer.js
@@ -4,7 +4,6 @@ import {
   LOGIN_REQUEST,
   LOGIN_SUCCESS,
   UPDATE_USER_FAILURE,
-  UPDATE_USER_REQUEST,
   UPDATE_USER_SUCCESS,
   LOGOUT_FAILURE,
   LOGOUT_REQUEST,
@@ -38,7 +37,6 @@ const reducer = (state = initialState, action) => {
       };
     case LOGIN_REQUEST:
     case LOGOUT_REQUEST:
-    case UPDATE_USER_REQUEST:
     case SSO_REDIRECT_REQUEST:
     case SSO_SETTINGS_REQUEST:
       return {

--- a/frontend/redux/nodes/entities/campaigns/config.js
+++ b/frontend/redux/nodes/entities/campaigns/config.js
@@ -15,3 +15,5 @@ export default new Config({
   entityName: "campaigns",
   schema,
 });
+
+export const initialState = Object.assign({}, Config.initialState);

--- a/frontend/redux/nodes/entities/campaigns/config.js
+++ b/frontend/redux/nodes/entities/campaigns/config.js
@@ -1,4 +1,7 @@
-import { destroyFunc, update } from "redux/nodes/entities/campaigns/helpers";
+import {
+  destroyFunc,
+  updateCampaignState,
+} from "redux/nodes/entities/campaigns/helpers";
 import Fleet from "fleet";
 import Config from "redux/nodes/entities/base/config";
 import schemas from "redux/nodes/entities/base/schemas";
@@ -8,7 +11,7 @@ const { CAMPAIGNS: schema } = schemas;
 export default new Config({
   createFunc: Fleet.queries.run,
   destroyFunc,
-  updateFunc: update,
+  updateFunc: updateCampaignState,
   entityName: "campaigns",
   schema,
 });

--- a/frontend/redux/nodes/entities/users/config.js
+++ b/frontend/redux/nodes/entities/users/config.js
@@ -12,3 +12,5 @@ export default new Config({
   schema: USERS,
   updateFunc: Fleet.users.update,
 });
+
+export const initialState = Object.assign({}, Config.initialState);


### PR DESCRIPTION
This PR removes all warnings generated by the bundler when running `make generate-dev`. 

- e00c574bb3a421daa511eaa7a785b1d1fc03d021 removes an nonexistent action being imported
- 8661c9c31b70ba7360e1531ac0e04b4327b4af01 uses the right import name for the update function in `entities/campaign/config.js` I believe this reducer is not used anyway (`updateCampaignState` is called directly) but I made the change for consistency
- ed4e2cfe19dc84821af782c2e9ba02abd0de113d adds an `initialState` export that was being requested by the sibling `reducer.js` file of both configs.

# Checklist for submitter

- [x] Manual QA for all new/changed functionality
