### PR TITLE
Certificate FleetCTL bug: Do not render if 500 error

### DIFF
--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -257,7 +257,7 @@ const PlatformWrapper = ({
                 </p>
               )}
               {!isFetchingCertificate &&
-                (certificate ? (
+                (certificate && !fetchCertificateError ? (
                   <p>
                     Prove the TLS certificate used by the Fleet server to enable
                     secure connections from osquery:

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -257,7 +257,7 @@ const PlatformWrapper = ({
                 </p>
               )}
               {!isFetchingCertificate &&
-                (certificate && !fetchCertificateError ? (
+                (!fetchCertificateError ? (
                   <p>
                     Prove the TLS certificate used by the Fleet server to enable
                     secure connections from osquery:

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -62,7 +62,7 @@ const PlatformWrapper = ({
   selectedTeam,
   onCancel,
 }: IPlatformWrapperProp): JSX.Element => {
-  const { config } = useContext(AppContext);
+  const { config, isPreviewMode } = useContext(AppContext);
   const [copyMessage, setCopyMessage] = useState<string>("");
 
   const dispatch = useDispatch();
@@ -75,6 +75,7 @@ const PlatformWrapper = ({
     ["certificate"],
     () => configAPI.loadCertificate(),
     {
+      enabled: !isPreviewMode,
       refetchOnWindowFocus: false,
     }
   );
@@ -257,7 +258,7 @@ const PlatformWrapper = ({
                 </p>
               )}
               {!isFetchingCertificate &&
-                (!fetchCertificateError ? (
+                (certificate ? (
                   <p>
                     Prove the TLS certificate used by the Fleet server to enable
                     secure connections from osquery:


### PR DESCRIPTION
Cerra #4304 

- Fixed fleetctl preview mode to not 500 error by disabling the call to api/v1/fleet/certificate if isPreviewMode

![Screen Shot 2022-03-01 at 2 51 52 PM](https://user-images.githubusercontent.com/71795832/156238720-72e5cd25-5cb9-485a-b89c-1531c21cf56c.png)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
