### PR TITLE
Debounce, onchange, changelog

### DIFF
--- a/changes/issue-4365-sql-error-onchange
+++ b/changes/issue-4365-sql-error-onchange
@@ -1,0 +1,1 @@
+* Users are presented with debounced SQL errors on change for labels, queries, and policies

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -122,6 +122,16 @@ const QueryForm = ({
     { leading: true }
   );
 
+  const debounceSQL = useDebouncedCallback((sql: string) => {
+    let valid = true;
+    const { valid: isValidated, errors: newErrors } = validateQuerySQL(sql);
+    valid = isValidated;
+
+    setErrors({
+      ...newErrors,
+    });
+  }, 500);
+
   queryIdForEdit = queryIdForEdit || 0;
 
   useEffect(() => {
@@ -129,14 +139,7 @@ const QueryForm = ({
       debounceCompatiblePlatforms(lastEditedQueryBody);
     }
 
-    let valid = true;
-    const { valid: isValidated, errors: newErrors } = validateQuerySQL(
-      lastEditedQueryBody
-    );
-    valid = isValidated;
-    setErrors({
-      ...newErrors,
-    });
+    debounceSQL(lastEditedQueryBody);
   }, [lastEditedQueryBody, lastEditedQueryId]);
 
   const hasTeamMaintainerPermissions = isEditMode


### PR DESCRIPTION
Cerra #4365 

- Add 500 ms debounce to SQL change for labels, queries, and policies
- Add onChange validation to labels and policies
- Note this works for new label, new query, new policy, edit query, edit policy, (label SQL are immutable and cannot be edited)

https://www.loom.com/share/d7d805d531374ef384f004b7a9c76d9e

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
