### PR TITLE
Form Validations: URL validation update

### DIFF
--- a/changes/issue-3507-email-url-validations
+++ b/changes/issue-3507-email-url-validations
@@ -1,0 +1,1 @@
+* Fix edge case URL validations, update all email forms to validate

--- a/frontend/components/forms/admin/AppConfigForm/AppConfigForm.tsx
+++ b/frontend/components/forms/admin/AppConfigForm/AppConfigForm.tsx
@@ -174,12 +174,8 @@ const AppConfigFormFunctional = ({
         errors.idp_image_url = `${idpImageURL} is not a valid URL`;
       }
 
-      if (metadata === "") {
-        if (metadataURL === "") {
-          errors.metadata_url = "Metadata URL must be present";
-        } else if (!validUrl(metadataURL)) {
-          errors.metadata_url = `${metadataURL} is not a valid URL`;
-        }
+      if (metadata === "" && metadataURL === "") {
+        errors.metadata_url = "Metadata URL must be present";
       }
 
       if (!entityID) {
@@ -218,15 +214,8 @@ const AppConfigFormFunctional = ({
       }
     }
 
-    if (enableHostStatusWebhook) {
-      if (!hostStatusWebhookDestinationURL) {
-        errors.destination_url = "Destination URL must be present";
-      } else if (
-        hostStatusWebhookDestinationURL &&
-        !validUrl(hostStatusWebhookDestinationURL)
-      ) {
-        errors.destination_url = `${hostStatusWebhookDestinationURL} is not a valid URL`;
-      }
+    if (enableHostStatusWebhook && !hostStatusWebhookDestinationURL) {
+      errors.destination_url = "Destination URL must be present";
     }
 
     if (enableHostExpiry) {

--- a/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -11,7 +11,6 @@ import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
-import validURL from "components/forms/validators/valid_url";
 import PreviewPayloadModal from "../PreviewPayloadModal";
 
 interface IManageAutomationsModalProps {
@@ -75,8 +74,8 @@ const useCheckboxListStateManagement = (
 const validateWebhookURL = (url: string) => {
   const errors: { [key: string]: string } = {};
 
-  if (!validURL(url)) {
-    errors.url = "Please add a valid destination URL";
+  if (url === "") {
+    errors.url = "Please add a destination URL";
   }
 
   const valid = !size(errors);
@@ -123,14 +122,15 @@ const ManageAutomationsModal = ({
       ...newErrors,
     });
 
-    if (valid) {
-      const policy_ids =
-        policyItems &&
-        policyItems
-          .filter((policy) => policy.isChecked)
-          .map((policy) => policy.id);
-      const enable_failing_policies_webhook = true; // Leave nearest component in case we decide to add disabling as a UI feature
+    const policy_ids =
+      policyItems &&
+      policyItems
+        .filter((policy) => policy.isChecked)
+        .map((policy) => policy.id);
+    const enable_failing_policies_webhook = true; // Leave nearest component in case we decide to add disabling as a UI feature
 
+    // URL validation only needed if at least one policy is checked
+    if (valid || policy_ids.length === 0) {
       onCreateWebhookSubmit({
         destination_url,
         policy_ids,

--- a/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -6,7 +6,6 @@ import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
-import validURL from "components/forms/validators/valid_url";
 
 import { IWebhookSoftwareVulnerabilities } from "interfaces/webhook";
 import { useDeepEffect } from "utilities/hooks";
@@ -95,8 +94,8 @@ const useCheckboxListStateManagement = (
 const validateWebhookURL = (url: string) => {
   const errors: { [key: string]: string } = {};
 
-  if (!validURL(url)) {
-    errors.url = "Please add a valid destination URL";
+  if (url === "") {
+    errors.url = "Please add a destination URL";
   }
 
   const valid = !size(errors);
@@ -136,19 +135,20 @@ const ManageAutomationsModal = ({
   const handleSaveAutomation = (evt: React.MouseEvent<HTMLFormElement>) => {
     evt.preventDefault();
 
+    // Ability to add future software automations
+    const vulnerabilityWebhook = softwareAutomationsItems.find(
+      (softwareAutomationItem) =>
+        softwareAutomationItem.accessor === "vulnerability"
+    );
+
     const { valid, errors: newErrors } = validateWebhookURL(destination_url);
     setErrors({
       ...errors,
       ...newErrors,
     });
 
-    if (valid) {
-      // Ability to add future software automations
-      const vulnerabilityWebhook = softwareAutomationsItems.find(
-        (softwareAutomationItem) =>
-          softwareAutomationItem.accessor === "vulnerability"
-      );
-
+    // URL validation only needed if software automation is checked
+    if (valid || !vulnerabilityWebhook?.isChecked) {
       onCreateWebhookSubmit({
         destination_url,
         enable_vulnerabilities_webhook: vulnerabilityWebhook?.isChecked,


### PR DESCRIPTION
Cerra bug #4087 
Address #3507 

- Remove email validators for Metadata URL and 3 webhook destination URLs
- Do not require webhook destination url validation if webhook is not enabled

Edge case examples causing frontend to decide (3/2/22) to remove URL regex validators all together:
1. User example for their webhook destination URL that does not fit URL regex (shown in #3507):
https://webhook.site/#!/4eb58e96-c586-4339-aea7-c4ace0f77ba9
2. Fleet testing documentation: [fleet/docs/03-Contributing/02-Testing.md](https://github.com/fleetdm/fleet/blob/578a9780f2bf495a0b41f0103063cb04bc6430c2/docs/03-Contributing/02-Testing.md?plain=1#L269-L282) Metadata URL configuration:
http://localhost:9080/simplesaml/saml2/idp/metadata.php 

Blocked: Adding email validation to registration form since RegistrationForm.jsx (along with AdminDetails.jsx) have not been refactored to the new form patterns. When frontend refactors those files to follow new patterns, we should add in the email validator

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
