### PR TITLE
Select Targets API bug fix: Staletime no longer applies to on mount

### DIFF
--- a/frontend/hooks/useQueryTargets.ts
+++ b/frontend/hooks/useQueryTargets.ts
@@ -118,6 +118,7 @@ export const useQueryTargets = (
     {
       onSuccess: options.onSuccess,
       refetchOnWindowFocus: false,
+      refetchOnMount: "always",
       staleTime: options.staleTime,
     }
   );


### PR DESCRIPTION
Bug fix introduced in targets api call refactor #4349 

- When a user hits cancel and then goes back to the select targets page by clicking run query again, the API was not being called due to the stale time.
- This led to the loading spinner just sitting on the page (bug)
- This fix allows the API to be called on every onMount

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
