### PR TITLE
Schedule page bug: Fix missing carat/bounciness

### DIFF
--- a/changes/issue-4415-fix-inherited-dropdown
+++ b/changes/issue-4415-fix-inherited-dropdown
@@ -1,0 +1,1 @@
+* Fix missing carat in inherited scheduled query dropdown

--- a/frontend/pages/schedule/ManageSchedulePage/_styles.scss
+++ b/frontend/pages/schedule/ManageSchedulePage/_styles.scss
@@ -127,22 +127,6 @@
     }
   }
 
-  .upcarat {
-    &::before {
-      content: url("../assets/images/icon-chevron-blue-16x16@2x.png");
-      transform: scale(0.5) rotate(180deg);
-      width: 16px;
-      border-radius: 0px;
-      padding: 0px;
-      padding-right: 2px;
-      margin-right: $pad-small;
-      margin-top: 5px;
-      position: relative;
-      top: -4px;
-      left: 6px;
-    }
-  }
-
   &__details {
     display: inline-flex;
     vertical-align: middle;

--- a/frontend/pages/schedule/ManageSchedulePage/_styles.scss
+++ b/frontend/pages/schedule/ManageSchedulePage/_styles.scss
@@ -111,6 +111,38 @@
     }
   }
 
+  .upcarat {
+    &::before {
+      content: url("../assets/images/icon-chevron-blue-16x16@2x.png");
+      transform: scale(0.5) rotate(180deg);
+      width: 16px;
+      border-radius: 0px;
+      padding: 0px;
+      padding-right: 2px;
+      margin-right: $pad-small;
+      margin-top: 5px;
+      position: relative;
+      top: -4px;
+      left: 6px;
+    }
+  }
+
+  .upcarat {
+    &::before {
+      content: url("../assets/images/icon-chevron-blue-16x16@2x.png");
+      transform: scale(0.5) rotate(180deg);
+      width: 16px;
+      border-radius: 0px;
+      padding: 0px;
+      padding-right: 2px;
+      margin-right: $pad-small;
+      margin-top: 5px;
+      position: relative;
+      top: -4px;
+      left: 6px;
+    }
+  }
+
   &__details {
     display: inline-flex;
     vertical-align: middle;

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
@@ -275,7 +275,7 @@ const ScheduleEditorModal = ({
         <div>
           <Button
             variant="unstyled"
-            className={`${showAdvancedOptions ? "upcarat" : "downcarat"} 
+            className={`${showAdvancedOptions ? "afterupcarat" : "downcarat"} 
                ${baseClass}__advanced-options-button`}
             onClick={toggleAdvancedOptions}
           >

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/_styles.scss
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/_styles.scss
@@ -55,7 +55,7 @@
     }
   }
 
-  .upcarat {
+  .afterupcarat {
     &::after {
       content: url("../assets/images/icon-chevron-blue-16x16@2x.png");
       transform: scale(0.5) rotate(180deg);


### PR DESCRIPTION
Cerra #4415

Problem: Two different dropdown buttons on the ManageSchedulePage.tsx used `className: upcarat`, parent component styled CSS `::before` and child component` ScheduleEditorModal.tsx` with CSS `::after`. When fixing the child component bug that was rendering both, accidentally removed the parent's `::before` style.

Fix:
- Reintroduced parent level `.upcarat`
- This fixed "bounciness" issue since its CSS aligns with the `.downcarat` used on the same page
- Renamed child level `.upcarat` to `.afterupcarat` so both styles won't be applied to child component

Screenshots of both "upcarats" being properly displayed:
<img width="549" alt="Screen Shot 2022-03-03 at 4 09 27 PM" src="https://user-images.githubusercontent.com/71795832/156653402-3f51cb9c-63e7-47d2-a4cf-0810fa3f30d6.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
