### PR TITLE
Use `filepath.Join` for proper multi-platform support

### DIFF
--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -254,7 +253,7 @@ func main() {
 
 		var options []osquery.Option
 		options = append(options, osquery.WithDataPath(c.String("root-dir")))
-		options = append(options, osquery.WithLogPath(path.Join(c.String("root-dir"), "osquery_log")))
+		options = append(options, osquery.WithLogPath(filepath.Join(c.String("root-dir"), "osquery_log")))
 
 		if logFile != nil {
 			// If set, redirect osqueryd's stderr to the logFile.


### PR DESCRIPTION
Fixes a bug introduced in #4237.

I'm also adding QA instructions to test this in all 4 supported platforms.