### PR TITLE
Bug fix: Whitespace on remaining label tooltips

### DIFF
--- a/changes/issue-4408-fix-whitespace-tooltips
+++ b/changes/issue-4408-fix-whitespace-tooltips
@@ -1,0 +1,1 @@
+* Fix whitespace of tooltips on form labels

--- a/frontend/components/forms/UserSettingsForm/_styles.scss
+++ b/frontend/components/forms/UserSettingsForm/_styles.scss
@@ -3,11 +3,11 @@
     width: 100%;
   }
 
-  .form-field {
-    &__label {
-      font-size: $x-small;
-      font-weight: $bold;
-    }
+  .form-field__label {
+    font-size: $x-small;
+    font-weight: $bold;
+    // so tooltips won't be triggered with whitespace
+    display: inline-block;
   }
 
   &__email-hint {

--- a/frontend/pages/admin/TeamManagementPage/components/CreateTeamModal/CreateTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/CreateTeamModal/CreateTeamModal.tsx
@@ -4,7 +4,7 @@ import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 import InfoBanner from "components/InfoBanner/InfoBanner";
 // @ts-ignore
-import InputFieldWithIcon from "components/forms/fields/InputFieldWithIcon";
+import InputField from "components/forms/fields/InputField";
 
 const baseClass = "create-team-modal";
 
@@ -57,10 +57,11 @@ const CreateTeamModal = ({
         onSubmit={onFormSubmit}
         autoComplete="off"
       >
-        <InputFieldWithIcon
+        <InputField
           autofocus
           name="name"
           onChange={onInputChange}
+          label="Team name"
           placeholder="Team name"
           value={name}
           error={errors.name}

--- a/frontend/pages/admin/TeamManagementPage/components/EditTeamModal/EditTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/EditTeamModal/EditTeamModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useEffect } from "react";
 
 import Modal from "components/Modal";
 // @ts-ignore
-import InputFieldWithIcon from "components/forms/fields/InputFieldWithIcon";
+import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
 
 const baseClass = "edit-team-modal";
@@ -53,10 +53,11 @@ const EditTeamModal = ({
         onSubmit={onFormSubmit}
         autoComplete="off"
       >
-        <InputFieldWithIcon
+        <InputField
           autofocus
           name="name"
           onChange={onInputChange}
+          label="Team name"
           placeholder="Team name"
           value={name}
           error={errors.name}

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -366,7 +366,8 @@ const UserForm = ({
   return (
     <form className={baseClass} autoComplete="off">
       {/* {baseError && <div className="form__base-error">{baseError}</div>} */}
-      <InputFieldWithIcon
+      <InputField
+        label="Full name"
         autofocus
         error={errors.name}
         name="name"
@@ -377,7 +378,7 @@ const UserForm = ({
           maxLength: "80",
         }}
       />
-      <InputFieldWithIcon
+      <InputField
         label="Email"
         error={errors.email || serverErrors?.email}
         name="email"

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -11,8 +11,7 @@ import Button from "components/buttons/Button";
 import validatePresence from "components/forms/validators/validate_presence";
 import validEmail from "components/forms/validators/valid_email"; // @ts-ignore
 import validPassword from "components/forms/validators/valid_password"; // @ts-ignore
-import InputField from "components/forms/fields/InputField"; // @ts-ignore
-import InputFieldWithIcon from "components/forms/fields/InputFieldWithIcon";
+import InputField from "components/forms/fields/InputField";
 import Checkbox from "components/forms/fields/Checkbox"; // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
 import Radio from "components/forms/fields/Radio";

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
@@ -132,4 +132,9 @@
   &__tooltip-text {
     width: 300px;
   }
+
+  // so tooltips won't be triggered with whitespace
+  .form-field__label {
+    display: inline-block;
+  }
 }

--- a/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/_styles.scss
@@ -43,8 +43,7 @@
     }
 
     .form-field--input {
-      display: flex;
-      flex-direction: column;
+      display: block;
       width: 100%;
       margin-right: $pad-small;
       margin-bottom: 0;
@@ -61,6 +60,11 @@
         margin-top: -5px;
       }
     }
+  }
+
+  // so tooltips won't be triggered with whitespace
+  .form-field__label {
+    display: inline-block;
   }
 
   .form-field__label--error {

--- a/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/_styles.scss
@@ -49,8 +49,7 @@
     }
 
     .form-field--input {
-      display: flex;
-      flex-direction: column;
+      display: block;
       width: 100%;
       margin-right: $pad-small;
       margin-bottom: 0;
@@ -67,6 +66,11 @@
         margin-top: -5px;
       }
     }
+  }
+
+  // so tooltips won't be triggered with whitespace
+  .form-field__label {
+    display: inline-block;
   }
 
   .form-field__label--error {


### PR DESCRIPTION
Cerra #4408 

Fixes tooltip showing on whitespace on the following components' form labels:
- Manage software automations modal - Destination URL
- Manage failing policy automations modal - Destination URL
- Create / edit user modal - Email
- My Account page - Email

Other tech debt addressed:
- Refactor from `InputFieldWithIcon` to `InputField` for any typescript form inputs that do not have icons next to them (old jsx class components modify CSS if we refactor so remaining jsx ones should be done with the whole jsx>tsx migration)



Screenshots for QA:
<img width="437" alt="Screen Shot 2022-03-04 at 10 51 01 AM" src="https://user-images.githubusercontent.com/71795832/156795757-80412512-b290-4fde-8f66-89806e0c39b4.png">
<img width="737" alt="Screen Shot 2022-03-04 at 10 50 49 AM" src="https://user-images.githubusercontent.com/71795832/156795760-d129ea15-6a89-4bb2-9979-fcd02a1ad954.png">
<img width="895" alt="Screen Shot 2022-03-04 at 10 50 33 AM" src="https://user-images.githubusercontent.com/71795832/156795764-36b67f7b-b55d-4d2e-80d9-dc35d672df7d.png">
<img width="914" alt="Screen Shot 2022-03-04 at 10 50 25 AM" src="https://user-images.githubusercontent.com/71795832/156795766-a080b3d9-a31a-4ed7-aeb6-b7b573dcafa0.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
