### PR TITLE
Spiffier App UX: Replace github docs with fleetdm docs

### DIFF
--- a/changes/issue-4457-external-docs-link-to-fleetdmcom
+++ b/changes/issue-4457-external-docs-link-to-fleetdmcom
@@ -1,0 +1,1 @@
+* Replace any github documentation references with fleetdm.com/docs/

--- a/frontend/components/forms/admin/AppConfigForm/AppConfigForm.tsx
+++ b/frontend/components/forms/admin/AppConfigForm/AppConfigForm.tsx
@@ -662,7 +662,7 @@ const AppConfigFormFunctional = ({
             How do global agent options interact with team-level agent
             options?&nbsp;
             <a
-              href="https://github.com/fleetdm/fleet/blob/2f42c281f98e39a72ab4a5125ecd26d303a16a6b/docs/1-Using-Fleet/1-Fleet-UI.md#configuring-agent-options"
+              href="https://fleetdm.com/docs/using-fleet/fleet-ui#configuring-agent-options"
               className={`${baseClass}__learn-more ${baseClass}__learn-more--inline`}
               target="_blank"
               rel="noopener noreferrer"
@@ -788,7 +788,7 @@ const AppConfigFormFunctional = ({
           <br />
           <br />
           <a
-            href="https://github.com/fleetdm/fleet/blob/2f42c281f98e39a72ab4a5125ecd26d303a16a6b/docs/1-Using-Fleet/11-Usage-statistics.md"
+            href="https://fleetdm.com/docs/using-fleet/usage-statistics#usage-statistics"
             className={`${baseClass}__learn-more`}
             target="_blank"
             rel="noopener noreferrer"

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
@@ -92,7 +92,7 @@ const AgentOptionsPage = ({
         See Fleet documentation for an example file that includes the overrides
         option.{" "}
         <a
-          href="https://github.com/fleetdm/fleet/tree/2f42c281f98e39a72ab4a5125ecd26d303a16a6b/docs/1-Using-Fleet/configuration-files#overrides-option"
+          href="https://fleetdm.com/docs/using-fleet/configuration-files#overrides-option"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
@@ -263,7 +263,7 @@ const ScheduleEditorModal = ({
           <p>
             Check out the Fleet documentation on&nbsp;
             <a
-              href="https://github.com/fleetdm/fleet/blob/6649d08a05799811f6fb0566947946edbfebf63e/docs/2-Deploying/2-Configuration.md#osquery_result_log_plugin"
+              href="https://fleetdm.com/docs/deploying/configuration#osquery-result-log-plugin"
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
Cerra #4457 

Replace 4 external links in the app that were pointing to the github documentation with links to  fleetdm.com/docs/
- AppSettingsPage - Configuring agent options
- AppSettingsPage - Usage statistics
- Team agent options - Overrides options
- ScheduleEditorModal - Configuring osquery result log plugin

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
