### PR TITLE
Update website slack links to point to osquery.fleetdm.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Documentation for Fleet can be found [here](https://fleetdm.com/docs).
 
 #### Chat
 
-Please join us in the #fleet channel on [osquery Slack](https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/).
+Please join us in the #fleet channel on [osquery Slack](https://fleetdm.com/slack).
 
 #### Contributing
 

--- a/docs/Contributing/Releasing-Fleet.md
+++ b/docs/Contributing/Releasing-Fleet.md
@@ -78,7 +78,7 @@ Note: Please prefix versions with `fleet-v` (eg. `fleet-v4.0.0`) in git tags, He
 > download, is still the latest _official_ release.
 
 5. Announce the release in the #fleet channel of [osquery
-   Slack](https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/) and
+   Slack](https://fleetdm.com/slack) and
    update the channel's topic with the link to this release. Using `@here` requires admin
    permissions, so typically this announcement will be done by `@zwass`.
 

--- a/docs/Deploying/FAQ.md
+++ b/docs/Deploying/FAQ.md
@@ -25,7 +25,7 @@
 
 For bug reports, please use the [Github issue tracker](https://github.com/fleetdm/fleet/issues).
 
-For questions and discussion, please join us in the #fleet channel of [osquery Slack](https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/).
+For questions and discussion, please join us in the #fleet channel of [osquery Slack](https://fleetdm.com/slack).
 
 ## Can multiple instances of the Fleet server be run behind a load-balancer?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,4 +13,4 @@ If you're interested in interacting with the Fleet source code, you'll find info
 
 ---
 
-If you have any questions, please don't hesitate to [File a GitHub issue](https://github.com/fleetdm/fleet/issues) or [join us on Slack](https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/). You can find us in the `#fleet` channel.
+If you have any questions, please don't hesitate to [File a GitHub issue](https://github.com/fleetdm/fleet/issues) or [join us on Slack](https://fleetdm.com/slack). You can find us in the `#fleet` channel.

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -193,6 +193,7 @@ module.exports.routes = {
   'GET /legal':                      '/legal/terms',
   'GET /terms':                      '/legal/terms',
   'GET /login':                      '/customers/login',
+  'GET /slack':                      'https://osquery.fleetdm.com/channel/f0d7aeb6-ac7c-41ba-a0c1-0d2abe931efa',
 
   // Sitemap
   // =============================================================================================================

--- a/website/views/layouts/layout-email.ejs
+++ b/website/views/layouts/layout-email.ejs
@@ -9,7 +9,7 @@
     <div style="display:  inline-flex; padding-top: 32px;">
       <a href="https://fleetdm.com"><img style="height: 20px; width: 20px; margin-right: 24px;" alt="Fleet logo" src="<%= url.resolve(sails.config.custom.baseUrl,'/images/logo-fleet-20x20@2x.png')%>"></a>
       <a href="https://twitter.com/fleetctl"><img style="height: 20px; width: 24px; margin-right: 24px;" alt="Follow Fleet on Twitter" src="<%= url.resolve(sails.config.custom.baseUrl,'images/logo-twitter-50x44@2x.png')%>"></a>
-      <a href="https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/"><img style="height: 20px; width: 20px;" alt="Join the osquery Slack community" src="<%= url.resolve(sails.config.custom.baseUrl,'images/logo-slack-24x24@2x.png')%>"></a>
+      <a href="https://fleetdm.com/slack"><img style="height: 20px; width: 20px;" alt="Join the osquery Slack community" src="<%= url.resolve(sails.config.custom.baseUrl,'images/logo-slack-24x24@2x.png')%>"></a>
     </div>
     <div style="text-align: left; padding-top: 15px; font-size: 12px; color: #3E4771;">
       <p>© 2022 Fleet Device Management Inc. All trademarks, service marks, and company names are the property of their respective owners.</p>

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -231,7 +231,7 @@
               <a href="https://www.youtube.com/channel/UCZyoqZ4exJvoibmTKJrQ-dQ">
                 <img alt="Youtube logo" src="/images/logo-youtube-57x40@2x.png" style="height: 20px; width: auto; margin-top:2px" class="pr-4" />
               </a>
-              <a href="https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/">
+              <a href="/slack">
                 <img alt="Slack logo" src="/images/logo-slack-24x24@2x.png" style="height: 20px; width: auto; margin-top:2px" class="pr-4" />
               </a>
               <a href="https://github.com/fleetdm/fleet">

--- a/website/views/pages/customers/dashboard.ejs
+++ b/website/views/pages/customers/dashboard.ejs
@@ -97,7 +97,7 @@
         <a class="btn btn-info btn-sm btn-md-block mr-md-3 mb-3 mb-md-0" purpose="deploy-button" href="/docs/deploying/introduction">
           How to deploy Fleet
         </a>
-        <a class="btn btn-outline-secondary btn-sm btn-md-block" purpose="slack-button" href="https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/" target="_blank">
+        <a class="btn btn-outline-secondary btn-sm btn-md-block" purpose="slack-button" href="/slack" target="_blank">
           <img alt="Slack logo" src="/images/logo-slack-24x24@2x.png"/>
           Ask for help on Slack
         </a>

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -215,7 +215,7 @@
               <a href="/docs/deploying" class="d-flex btn btn-primary btn-md justify-content-center mr-sm-3">
                 Learn how to deploy Fleet
               </a>
-              <a href="https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/" target="_blank" class="d-flex btn btn-md btn-outline-secondary btn-slack justify-content-center align-items-center mt-3 mt-sm-0">
+              <a href="/slack" target="_blank" class="d-flex btn btn-md btn-outline-secondary btn-slack justify-content-center align-items-center mt-3 mt-sm-0">
                 <img class="pr-3" alt="Slack logo" src="/images/logo-slack-24x24@2x.png"/>
                 Ask for help on Slack
               </a>

--- a/website/views/pages/get-started.ejs
+++ b/website/views/pages/get-started.ejs
@@ -51,7 +51,7 @@
           class="d-flex btn btn-primary btn-md justify-content-center mr-sm-3">
           Learn how to use Fleet
         </a>
-        <a href="https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/" target="_blank"
+        <a href="/slack" target="_blank"
           class="d-flex btn btn-md btn-outline-secondary btn-slack justify-content-center align-items-center mt-3 mt-sm-0">
           <img class="pr-3" alt="Slack logo" src="/images/logo-slack-24x24@2x.png" />
           Ask for help on Slack

--- a/website/views/pages/platform.ejs
+++ b/website/views/pages/platform.ejs
@@ -229,7 +229,7 @@
         <img class="mx-auto" style="width: 40px; height: 40px; margin-bottom: 16px;" alt="Slack logo" src="/images/logo-slack-24x24@2x.png">
         <h3>Join the community</h3>
         <p>Join the conversation or ask for help in our Slack channel.</p>
-        <a href="https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/" target="_blank" class="mt-auto">Join on Slack<img alt="A vibrant blue arrow pointing right" src="/images/platform/icon-right-arrow-vibrant-blue-16x16@2x.png"></a>
+        <a href="/slack" target="_blank" class="mt-auto">Join on Slack<img alt="A vibrant blue arrow pointing right" src="/images/platform/icon-right-arrow-vibrant-blue-16x16@2x.png"></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
closes https://github.com/fleetdm/confidential/issues/960

Changes:
- Added a redirect at `/slack` that points to the `#fleet` channel on osquery.fleetdm.com
- Updated slack links on fleetdm.com and in documentation files to use the new redirect
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
