### PR TITLE
Agent options bug

### DIFF
--- a/changes/issue-4470-global-agent-options-update
+++ b/changes/issue-4470-global-agent-options-update
@@ -1,0 +1,1 @@
+* Fix bug with global agent options overriding with difference

--- a/frontend/pages/admin/AppSettingsPage/AppSettingsPage.tsx
+++ b/frontend/pages/admin/AppSettingsPage/AppSettingsPage.tsx
@@ -52,6 +52,8 @@ const AppSettingsPage = (): JSX.Element => {
   const onFormSubmit = useCallback(
     (formData: IConfigNested) => {
       const diff = deepDifference(formData, appConfig);
+      // send all formData.agent_options because diff overrides all agent options
+      diff.agent_options = formData.agent_options;
 
       configAPI
         .update(diff)


### PR DESCRIPTION
Cerra #4470

Difference being used to make the config request smaller was finding the difference in agent_options and overriding it.
- Fix: agent_options sending the entire YAML on every update

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
