### PR TITLE
add slack directory to handbook pages

### DIFF
--- a/handbook/README.md
+++ b/handbook/README.md
@@ -26,13 +26,13 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [People ops](./people.md#people-ops)
 
-[Slack directory](./people.md#slack-directory)
+[Slack channels](./people.md#slack-channels)
 
 ### Engineering
 
 [Release process](./engineering.md#release-process)
 
-[Slack directory](./engineering.md#slack-directory)
+[Slack channels](./engineering.md#slack-channels)
 
 ### Product
 
@@ -46,7 +46,7 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [Feature flags](./product.md#feature-flags)
 
-[Slack directory](./product.md#slack-directory)
+[Slack channels](./product.md#slack-channels)
 
 ### Security
 
@@ -56,7 +56,7 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [Vulnerability management in Fleet](./security.md#vulnerability-management)
 
-[Slack directory](./security.md#slack-directory)
+[Slack channels](./security.md#slack-channels)
 
 ### Brand
 
@@ -74,7 +74,7 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [Support process](./customers.md#support-process)
 
-[Slack directory](./customers.md#slack-directory)
+[Slack channels](./customers.md#slack-channels)
 
 ### Community
 
@@ -92,7 +92,7 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [Fleet swag](./community.md#fleet-swag)
 
-[Slack directory](./community.md#slack-directory)
+[Slack channels](./community.md#slack-channels)
 
 ### Handbook
 

--- a/handbook/README.md
+++ b/handbook/README.md
@@ -26,9 +26,13 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [People ops](./people.md#people-ops)
 
+[Slack directory](./people.md#slack-directory)
+
 ### Engineering
 
 [Release process](./engineering.md#release-process)
+
+[Slack directory](./engineering.md#slack-directory)
 
 ### Product
 
@@ -42,6 +46,8 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [Feature flags](./product.md#feature-flags)
 
+[Slack directory](./product.md#slack-directory)
+
 ### Security
 
 [How we protect end-user devices](./security.md#how-we-protect-end-user-devices)
@@ -50,6 +56,7 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [Vulnerability management in Fleet](./security.md#vulnerability-management)
 
+[Slack directory](./security.md#slack-directory)
 
 ### Brand
 
@@ -67,6 +74,8 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [Support process](./customers.md#support-process)
 
+[Slack directory](./customers.md#slack-directory)
+
 ### Community
 
 [Communities](./community.md#communities)
@@ -82,6 +91,8 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 [Community contributions (pull requests)](./community.md#community-contributions-pull-requests)
 
 [Fleet swag](./community.md#fleet-swag)
+
+[Slack directory](./community.md#slack-directory)
 
 ### Handbook
 

--- a/handbook/community.md
+++ b/handbook/community.md
@@ -209,11 +209,11 @@ We want to recognize and congratulate community members for their contributions 
 
 4. If available through the ordering process, add a thank you note for their contribution and "Feel free to tag us on Twitter."
 
-## Slack directory
+## Slack channels
 
 These are the Slack channels the growth team maintains. If the channel has a [directly responsible individual](./people.md#directly-resonsible-individuals) (**DRI**), they will be specified. These people are responsible for keeping up with all new messages, even if they aren't mentioned. 
 
-- **#g-growth** **DRI**: Mike Thomas
+- **#g-growth** **DRI**: Tim Kern
 - **#help-swag** **DRI**: Drew Baker
 
 **Who should have these channels unmuted?** Members of this group, everyone else is encouraged to mute them.

--- a/handbook/community.md
+++ b/handbook/community.md
@@ -209,4 +209,13 @@ We want to recognize and congratulate community members for their contributions 
 
 4. If available through the ordering process, add a thank you note for their contribution and "Feel free to tag us on Twitter."
 
+## Slack directory
+
+These are the Slack channels the growth team maintains. If the channel has a [directly responsible individual](./people.md#directly-resonsible-individuals) (**DRI**), they will be specified. These people are responsible for keeping up with all new messages, even if they aren't mentioned. 
+
+- **#g-growth** **DRI**: Mike Thomas
+- **#help-swag** **DRI**: Drew Baker
+
+**Who should have these channels unmuted?** Members of this group, everyone else is encouraged to mute them.
+
 <meta name="maintainedBy" value="mike-j-thomas">

--- a/handbook/customers.md
+++ b/handbook/customers.md
@@ -74,5 +74,16 @@ Fleet's self-service license dispenser is the best way to generate trial license
 
 To generate a trial license key for a larger deployment, [create an opportunity issue](https://github.com/fleetdm/confidential/issues/new/choose) for the customer and follow the instructions in the issue for generating a trial license key.
 
+## Slack directory
+
+These are the Slack channels the customer engineering team maintains. If the channel has a [directly responsible individual](./people.md#directly-resonsible-individuals) (**DRI**), they will be specified. These people are responsible for keeping up with all new messages, even if they aren't mentioned. 
+
+- **#g-cutomer-engineering** - **DRI**: Tony Gauda
+- **#_from-prospective-customers** - **DRI**: Andrew Bare
+- **#help-sell**
+- **#help-leadgen**
+
+**Who should have these channels unmuted?** Members of this group, everyone else is encouraged to mute them.
+
 <meta name="maintainedBy" value="tgauda">
 

--- a/handbook/customers.md
+++ b/handbook/customers.md
@@ -74,14 +74,13 @@ Fleet's self-service license dispenser is the best way to generate trial license
 
 To generate a trial license key for a larger deployment, [create an opportunity issue](https://github.com/fleetdm/confidential/issues/new/choose) for the customer and follow the instructions in the issue for generating a trial license key.
 
-## Slack directory
+## Slack channels
 
 These are the Slack channels the customer engineering team maintains. If the channel has a [directly responsible individual](./people.md#directly-resonsible-individuals) (**DRI**), they will be specified. These people are responsible for keeping up with all new messages, even if they aren't mentioned. 
 
 - **#g-cutomer-engineering** - **DRI**: Tony Gauda
 - **#_from-prospective-customers** - **DRI**: Andrew Bare
-- **#help-sell**
-- **#help-leadgen**
+- **#help-sell** - **DRI**: Andrew Bare
 
 **Who should have these channels unmuted?** Members of this group, everyone else is encouraged to mute them.
 

--- a/handbook/engineering.md
+++ b/handbook/engineering.md
@@ -117,16 +117,16 @@ There are several locations in Fleet's public and internal documentation that ca
 
 2. The [Internal FAQ](https://docs.google.com/document/d/1I6pJ3vz0EE-qE13VmpE2G3gd5zA1m3bb_u8Q2G3Gmp0/edit#heading=h.ltavvjy511qv) document.
 
-## Slack directory
+## Slack channels
 
 These are the Slack channels the core engineering team maintains. If the channel has a [directly responsible individual](./people.md#directly-resonsible-individuals) (**DRI**), they will be specified. These people are responsible for keeping up with all new messages, even if they aren't mentioned. 
 
 - **#g-core-engineering** - **DRI**: Zach Wasserman
-- **#help-oncall**
-- **#help-golang**
-- **#help-qa**
-- **#help-frontend**
-- **#_pov-environments**
+- **#help-oncall** - **DRI**: Zach Wasserman
+- **#help-golang** - **DRI**: Zach Wasserman
+- **#help-qa** - **DRI**: Reed Haynes
+- **#help-frontend** - **DRI**: Luke Heath
+- **#_pov-environments** - **DRI**: Ben Edwards
 
 **Who should have these channels unmuted?** Members of this group, everyone else is encouraged to mute them.
 

--- a/handbook/engineering.md
+++ b/handbook/engineering.md
@@ -117,5 +117,19 @@ There are several locations in Fleet's public and internal documentation that ca
 
 2. The [Internal FAQ](https://docs.google.com/document/d/1I6pJ3vz0EE-qE13VmpE2G3gd5zA1m3bb_u8Q2G3Gmp0/edit#heading=h.ltavvjy511qv) document.
 
+## Slack directory
+
+These are the Slack channels the core engineering team maintains. If the channel has a [directly responsible individual](./people.md#directly-resonsible-individuals) (**DRI**), they will be specified. These people are responsible for keeping up with all new messages, even if they aren't mentioned. 
+
+- **#g-core-engineering** - **DRI**: Zach Wasserman
+- **#help-oncall**
+- **#help-golang**
+- **#help-qa**
+- **#help-frontend**
+- **#_pov-environments**
+
+**Who should have these channels unmuted?** Members of this group, everyone else is encouraged to mute them.
+
+
 <meta name="maintainedBy" value="zwass">
 

--- a/handbook/people.md
+++ b/handbook/people.md
@@ -250,4 +250,15 @@ When the final signature is added to an envelope in Docusign, it is marked as co
       [email subject]
       link: drive.google.com/[destinationFolderID]
    ```
+
+## Slack directory
+
+These are the Slack channels the digital experience team maintains. If the channel has a [directly responsible individual](#directly-resonsible-individuals) (**DRI**), they will be specified. These people are responsible for keeping up with all new messages, even if they aren't mentioned. 
+
+- **#g-digital-experience** - **DRI**: Mike McNeil
+- **#peepops** - **DRI**: Eric Shaw
+- **#help-onboarding** - **DRI**: Eric Shaw
+
+**Who should have these channels unmuted?** Members of this group, everyone else is encouraged to mute them.
+
 <meta name="maintainedBy" value="eashaw">

--- a/handbook/people.md
+++ b/handbook/people.md
@@ -148,7 +148,7 @@ We use threads in Slack as much as possible. Threads help limit noise for other 
 
 We configure our working hours in Slack to ensure everyone knows when they can get in touch with others.
 
-### Slack channels
+### Slack channel prefixes
 
 We have specific channels for various topics, but we also have more general channels for the teams at Fleet.
 
@@ -251,11 +251,11 @@ When the final signature is added to an envelope in Docusign, it is marked as co
       link: drive.google.com/[destinationFolderID]
    ```
 
-## Slack directory
+## Slack channels
 
 These are the Slack channels the digital experience team maintains. If the channel has a [directly responsible individual](#directly-resonsible-individuals) (**DRI**), they will be specified. These people are responsible for keeping up with all new messages, even if they aren't mentioned. 
 
-- **#g-digital-experience** - **DRI**: Mike McNeil
+- **#g-digital-experience** - **DRI**: Mike Thomas
 - **#peepops** - **DRI**: Eric Shaw
 - **#help-onboarding** - **DRI**: Eric Shaw
 

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -319,9 +319,6 @@ We have certain design conventions that we include in Fleet. We will document mo
 
 Use `---`, with color `$ui-fleet-black-50` as the default UI for empty columns.
 
-
-<meta name="maintainedBy" value="noahtalerman">
-
 ## Release 
 
 This section outlines the communication between the product team and growth team and product team
@@ -367,3 +364,15 @@ The following highlights should be considered when deciding if feature flags sho
 - The feature flag will not be advertised. For example, advertising in the documentation on fleetdm.com/docs, release notes, release blog posts, and Twitter.
 
 Fleet's feature flag guidelines borrows from GitLab's ["When to use feature flags" section](https://about.gitlab.com/handbook/product-development-flow/feature-flag-lifecycle/#when-to-use-feature-flags) of their handbook. Check out [GitLab's "Feature flags only when needed" video](https://www.youtube.com/watch?v=DQaGqyolOd8) for an explanation on the costs of introducing feature flags.
+
+
+## Slack directory
+
+These are the Slack channels the product team maintains. If the channel has a [directly responsible individual](./people.md#directly-resonsible-individuals) (**DRI**), they will be specified. These people are responsible for keeping up with all new messages, even if they aren't mentioned. 
+
+- **#g-product** - **DRI**: - Noah Talerman
+
+**Who should have these channels unmuted?** Members of this group, everyone else is encouraged to mute them.
+
+
+<meta name="maintainedBy" value="noahtalerman">

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -366,7 +366,7 @@ The following highlights should be considered when deciding if feature flags sho
 Fleet's feature flag guidelines borrows from GitLab's ["When to use feature flags" section](https://about.gitlab.com/handbook/product-development-flow/feature-flag-lifecycle/#when-to-use-feature-flags) of their handbook. Check out [GitLab's "Feature flags only when needed" video](https://www.youtube.com/watch?v=DQaGqyolOd8) for an explanation on the costs of introducing feature flags.
 
 
-## Slack directory
+## Slack channels
 
 These are the Slack channels the product team maintains. If the channel has a [directly responsible individual](./people.md#directly-resonsible-individuals) (**DRI**), they will be specified. These people are responsible for keeping up with all new messages, even if they aren't mentioned. 
 

--- a/handbook/security.md
+++ b/handbook/security.md
@@ -551,7 +551,12 @@ We use [Dependabot](https://github.com/dependabot) to create pull requests to up
 
 We ensure the fixes to vulnerable dependencies are also performed according to our remediation timeline. We fix as many dependencies as possible in a single release.
 
+## Slack directory
 
+These are the Slack channels the security team maintains. If the channel has a [directly responsible individual](./people.md#directly-resonsible-individuals) (**DRI**), they will be specified. These people are responsible for keeping up with all new messages, even if they aren't mentioned. 
 
+- **#help-login** - **DRI**: Guillame Ross
+
+**Who should have these channels unmuted?** Members of this group, everyone else is encouraged to mute them.
 
 <meta name="maintainedBy" value="GuillaumeRoss">

--- a/handbook/security.md
+++ b/handbook/security.md
@@ -551,7 +551,7 @@ We use [Dependabot](https://github.com/dependabot) to create pull requests to up
 
 We ensure the fixes to vulnerable dependencies are also performed according to our remediation timeline. We fix as many dependencies as possible in a single release.
 
-## Slack directory
+## Slack channels
 
 These are the Slack channels the security team maintains. If the channel has a [directly responsible individual](./people.md#directly-resonsible-individuals) (**DRI**), they will be specified. These people are responsible for keeping up with all new messages, even if they aren't mentioned. 
 


### PR DESCRIPTION
Closes #4036 
changes:
 - Added a slack directory section to the bottom of each team's handbook page

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [ ] Documented any permissions changes
- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
