### PR TITLE
Add page script for '/get-started'

### DIFF
--- a/website/assets/js/pages/get-started.page.js
+++ b/website/assets/js/pages/get-started.page.js
@@ -1,0 +1,30 @@
+parasails.registerPage('get-started', {
+  //  ╦╔╗╔╦╔╦╗╦╔═╗╦    ╔═╗╔╦╗╔═╗╔╦╗╔═╗
+  //  ║║║║║ ║ ║╠═╣║    ╚═╗ ║ ╠═╣ ║ ║╣
+  //  ╩╝╚╝╩ ╩ ╩╩ ╩╩═╝  ╚═╝ ╩ ╩ ╩ ╩ ╚═╝
+  data: {
+    //…
+  },
+
+  //  ╦  ╦╔═╗╔═╗╔═╗╦ ╦╔═╗╦  ╔═╗
+  //  ║  ║╠╣ ║╣ ║  ╚╦╝║  ║  ║╣
+  //  ╩═╝╩╚  ╚═╝╚═╝ ╩ ╚═╝╩═╝╚═╝
+  beforeMount: function() {
+
+    // If the user navigated to this page from the 'try it now' button, we'll strip the '?tryitnow' from the url.
+    if(window.location.search && window.location.pathname === '/get-started'){
+      // https://caniuse.com/mdn-api_history_replacestate
+      window.history.replaceState({}, document.title, '/get-started' );
+    }
+  },
+  mounted: async function() {
+    //…
+  },
+
+  //  ╦╔╗╔╔╦╗╔═╗╦═╗╔═╗╔═╗╔╦╗╦╔═╗╔╗╔╔═╗
+  //  ║║║║ ║ ║╣ ╠╦╝╠═╣║   ║ ║║ ║║║║╚═╗
+  //  ╩╝╚╝ ╩ ╚═╝╩╚═╩ ╩╚═╝ ╩ ╩╚═╝╝╚╝╚═╝
+  methods: {
+    //…
+  }
+});

--- a/website/assets/js/pages/get-started.page.js
+++ b/website/assets/js/pages/get-started.page.js
@@ -12,7 +12,7 @@ parasails.registerPage('get-started', {
   beforeMount: function() {
 
     // If the user navigated to this page from the 'try it now' button, we'll strip the '?tryitnow' from the url.
-    if(window.location.search && window.location.pathname === '/get-started'){
+    if(window.location.search){
       // https://caniuse.com/mdn-api_history_replacestate
       window.history.replaceState({}, document.title, '/get-started' );
     }

--- a/website/views/layouts/layout-customer.ejs
+++ b/website/views/layouts/layout-customer.ejs
@@ -152,6 +152,7 @@
     <script src="/js/pages/entrance/new-password.page.js"></script>
     <script src="/js/pages/entrance/signup.page.js"></script>
     <script src="/js/pages/faq.page.js"></script>
+    <script src="/js/pages/get-started.page.js"></script>
     <script src="/js/pages/handbook/basic-handbook.page.js"></script>
     <script src="/js/pages/homepage.page.js"></script>
     <script src="/js/pages/legal/privacy.page.js"></script>

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -307,6 +307,7 @@
     <script src="/js/pages/entrance/new-password.page.js"></script>
     <script src="/js/pages/entrance/signup.page.js"></script>
     <script src="/js/pages/faq.page.js"></script>
+    <script src="/js/pages/get-started.page.js"></script>
     <script src="/js/pages/handbook/basic-handbook.page.js"></script>
     <script src="/js/pages/homepage.page.js"></script>
     <script src="/js/pages/legal/privacy.page.js"></script>


### PR DESCRIPTION
Changes: 
- Added a page script for the 'Get started' page on fleetdm.com
- Added code to clean up the URL of the 'get started' page

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
