### PR TITLE
App Settings Page: Align global secret buttons

### DIFF
--- a/changes/issue-4499-align-buttons
+++ b/changes/issue-4499-align-buttons
@@ -1,0 +1,1 @@
+* Fix misaligned buttons on app settings page

--- a/frontend/components/forms/admin/AppConfigForm/_styles.scss
+++ b/frontend/components/forms/admin/AppConfigForm/_styles.scss
@@ -50,9 +50,12 @@
   }
 
   .form-field {
+    width: 100%;
+
     &__label {
       font-weight: $bold;
       margin-bottom: $pad-xsmall;
+      width: 100%;
     }
 
     &__hint {

--- a/frontend/pages/admin/AppSettingsPage/_styles.scss
+++ b/frontend/pages/admin/AppSettingsPage/_styles.scss
@@ -61,6 +61,15 @@
 
   // so tooltips won't be triggered with whitespace
   .form-field__label {
-    display: inline-block; 
+    display: inline-block;
+
+    .buttons {
+      top: 22px;
+    }
+    .enroll-secrets__secret-input {
+      .input-field {
+        width: 100%;
+      }
+    }
   }
 }


### PR DESCRIPTION
Cerra #4499 

`display: inline-block` of AppSettingsPage.tsx  created misalignment between buttons on AppSettingsPage and on EnrollSecretModal (that doesn't use inline-block).

- Fix AppSettingsPage global secret buttons vertical alignment
- Improvement: Make the buttons sticky to right side of form-field and not at an absolute horizontal position

Video:
https://user-images.githubusercontent.com/71795832/157314826-7080b819-22f7-4be2-99e6-ef186c402144.mov


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
