### PR TITLE
Add Host Modal: Generate fleet installer with fleet desktop

### DIFF
--- a/changes/issue-4093-fleet-desktop-checkbox
+++ b/changes/issue-4093-fleet-desktop-checkbox
@@ -1,0 +1,1 @@
+* Add ability in UI to generate a Fleet installer that includes Fleet Desktop

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -16,6 +16,8 @@ import { IEnrollSecret } from "interfaces/enroll_secret";
 import Button from "components/buttons/Button";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
+import Checkbox from "components/forms/fields/Checkbox";
+import TooltipWrapper from "components/TooltipWrapper";
 import TabsWrapper from "components/TabsWrapper";
 
 import { isValidPemCertificate } from "../../../pages/hosts/ManageHostsPage/helpers";
@@ -64,6 +66,9 @@ const PlatformWrapper = ({
 }: IPlatformWrapperProp): JSX.Element => {
   const { config, isPreviewMode } = useContext(AppContext);
   const [copyMessage, setCopyMessage] = useState<string>("");
+  const [includeFleetDesktop, setIncludeFleetDesktop] = useState<boolean>(
+    false
+  );
 
   const dispatch = useDispatch();
 
@@ -173,7 +178,9 @@ const PlatformWrapper = ({
   const renderInstallerString = (platform: string) => {
     return platform === "advanced"
       ? "osqueryd --flagfile=flagfile.txt --verbose"
-      : `fleetctl package --type=${platform} --fleet-url=${config?.server_url} --enroll-secret=${enrollSecret}`;
+      : `fleetctl package --type=${platform} ${
+          includeFleetDesktop && "--fleet-desktop"
+        } --fleet-url=${config?.server_url} --enroll-secret=${enrollSecret}`;
   };
 
   const renderLabel = (platform: string, installerString: string) => {
@@ -193,18 +200,20 @@ const PlatformWrapper = ({
     return (
       <>
         {platform !== "advanced" && (
-          <span className={`${baseClass}__cta`}>
-            With the{" "}
-            <a
-              href="https://fleetdm.com/get-started"
-              target="_blank"
-              rel="noopener noreferrer"
-              className={`${baseClass}__command-line-tool`}
-            >
-              Fleet command-line tool
-            </a>{" "}
-            installed:
-          </span>
+          <>
+            <span className={`${baseClass}__cta`}>
+              With the{" "}
+              <a
+                href="https://fleetdm.com/get-started"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`${baseClass}__command-line-tool`}
+              >
+                Fleet command-line tool
+              </a>{" "}
+              installed:
+            </span>
+          </>
         )}{" "}
         <span className={`${baseClass}__name`}>
           <span className="buttons">
@@ -335,6 +344,22 @@ const PlatformWrapper = ({
     }
     return (
       <>
+        <Checkbox
+          name="include-fleet-desktop"
+          onChange={() => setIncludeFleetDesktop(!includeFleetDesktop)}
+          value={includeFleetDesktop}
+        >
+          <>
+            Include&nbsp;
+            <TooltipWrapper
+              tipContent={
+                "<p>Lightweight application that allows end users to see information about their device.</p>"
+              }
+            >
+              Fleet Desktop
+            </TooltipWrapper>
+          </>
+        </Checkbox>
         <InputField
           disabled
           inputWrapperClass={`${baseClass}__installer-input ${baseClass}__installer-input-${platform}`}

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -179,8 +179,8 @@ const PlatformWrapper = ({
     return platform === "advanced"
       ? "osqueryd --flagfile=flagfile.txt --verbose"
       : `fleetctl package --type=${platform} ${
-          includeFleetDesktop && "--fleet-desktop"
-        } --fleet-url=${config?.server_url} --enroll-secret=${enrollSecret}`;
+          includeFleetDesktop ? "--fleet-desktop " : ""
+        }--fleet-url=${config?.server_url} --enroll-secret=${enrollSecret}`;
   };
 
   const renderLabel = (platform: string, installerString: string) => {

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -200,20 +200,18 @@ const PlatformWrapper = ({
     return (
       <>
         {platform !== "advanced" && (
-          <>
-            <span className={`${baseClass}__cta`}>
-              With the{" "}
-              <a
-                href="https://fleetdm.com/get-started"
-                target="_blank"
-                rel="noopener noreferrer"
-                className={`${baseClass}__command-line-tool`}
-              >
-                Fleet command-line tool
-              </a>{" "}
-              installed:
-            </span>
-          </>
+          <span className={`${baseClass}__cta`}>
+            With the{" "}
+            <a
+              href="https://fleetdm.com/get-started"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`${baseClass}__command-line-tool`}
+            >
+              Fleet command-line tool
+            </a>{" "}
+            installed:
+          </span>
         )}{" "}
         <span className={`${baseClass}__name`}>
           <span className="buttons">

--- a/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
+++ b/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
@@ -28,13 +28,17 @@
   }
 
   &__info {
-    margin-top: $pad-small;
+    margin-top: $pad-medium;
   }
 
   &__cta {
     font-weight: $bold;
     padding-top: $pad-xsmall;
     margin: 0;
+  }
+
+  .fleet-checkbox {
+    display: flex;
   }
 
   .form-field {

--- a/frontend/components/TabsWrapper/_styles.scss
+++ b/frontend/components/TabsWrapper/_styles.scss
@@ -39,7 +39,7 @@
           content: "";
           width: 100%;
           height: 0;
-          border-bottom: 1px solid #6a67fe;
+          border-bottom: 2px solid #6a67fe;
           position: absolute;
           bottom: 0;
           left: 0;


### PR DESCRIPTION
Cerra #4093 

- Checkbox that generates fleet desktop flag

Other code addressed:
- Fixed purple tab indication line to be 2px instead of 1px

I thought we were building this for Macs only, I followed the specs to put it on all 4 tabs, but it seems silly if we're not allowing it on all platforms

<img width="1283" alt="Screen Shot 2022-03-08 at 4 45 36 PM" src="https://user-images.githubusercontent.com/71795832/157330731-5f510f31-0713-48fb-b9f0-260754527d26.png">
<img width="1284" alt="Screen Shot 2022-03-08 at 4 45 30 PM" src="https://user-images.githubusercontent.com/71795832/157330732-fffced78-457d-4a20-8489-395d81d4c06e.png">
<img width="1285" alt="Screen Shot 2022-03-08 at 4 45 45 PM" src="https://user-images.githubusercontent.com/71795832/157330728-d34452a5-309a-44a1-9521-f2888c36c750.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
