### PR TITLE
Add new endpoints to retrieve device information by orbit identifier

### DIFF
--- a/changes/issue-4416-add-device-auth-endpoints
+++ b/changes/issue-4416-add-device-auth-endpoints
@@ -1,0 +1,1 @@
+* Add device-authenticated endpoints to retrieve read-only information about the current device.

--- a/server/authz/authz.go
+++ b/server/authz/authz.go
@@ -70,6 +70,20 @@ func (a *Authorizer) SkipAuthorization(ctx context.Context) {
 	}
 }
 
+// IsAlreadyAuthorized returns true if the context has already authorized. This
+// may be useful to skip authorization checks in the Service layer when e.g.
+// the current request has already been authorized due to its different
+// authentication method, such as the device authentication token which allows
+// reading the corresponding host's information even if there is no user
+// associated with the request (so typical user-based authorization checks
+// would fail).
+func (a *Authorizer) IsAlreadyAuthorized(ctx context.Context) bool {
+	if authctx, ok := authz_ctx.FromContext(ctx); ok {
+		return authctx.Checked()
+	}
+	return false
+}
+
 // Authorize checks authorization for the provided object, and action,
 // retrieving the subject from the context.
 //

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -709,8 +709,8 @@ func (ds *Datastore) EnrollHost(ctx context.Context, osqueryHostID, nodeKey stri
 	return &host, nil
 }
 
-// GetContextTryStmt will attempt to run sqlx.GetContext on a cached statement if available, resorting to ds.reader.
-func (ds *Datastore) GetContextTryStmt(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+// getContextTryStmt will attempt to run sqlx.GetContext on a cached statement if available, resorting to ds.reader.
+func (ds *Datastore) getContextTryStmt(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
 	var err error
 	//nolint the statements are closed in Datastore.Close.
 	if stmt := ds.loadOrPrepareStmt(ctx, query); stmt != nil {
@@ -727,7 +727,32 @@ func (ds *Datastore) LoadHostByNodeKey(ctx context.Context, nodeKey string) (*fl
 	query := `SELECT * FROM hosts WHERE node_key = ?`
 
 	var host fleet.Host
-	switch err := ds.GetContextTryStmt(ctx, &host, query, nodeKey); {
+	switch err := ds.getContextTryStmt(ctx, &host, query, nodeKey); {
+	case err == nil:
+		return &host, nil
+	case errors.Is(err, sql.ErrNoRows):
+		return nil, ctxerr.Wrap(ctx, notFound("Host"))
+	default:
+		return nil, ctxerr.Wrap(ctx, err, "find host")
+	}
+}
+
+// LoadHostByDeviceAuthToken loads the whole host identified by the device auth token.
+// If the token is invalid it returns a NotFoundError.
+func (ds *Datastore) LoadHostByDeviceAuthToken(ctx context.Context, authToken string) (*fleet.Host, error) {
+	const query = `
+    SELECT
+      h.*
+    FROM
+      host_device_auth hda
+    INNER JOIN
+      hosts h
+    ON
+      hda.host_id = h.id
+    WHERE hda.token = ?`
+
+	var host fleet.Host
+	switch err := sqlx.GetContext(ctx, ds.reader, &host, query, authToken); {
 	case err == nil:
 		return &host, nil
 	case errors.Is(err, sql.ErrNoRows):

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -111,6 +112,7 @@ func TestHosts(t *testing.T) {
 		{"HostLite", testHostsLite},
 		{"UpdateOsqueryIntervals", testUpdateOsqueryIntervals},
 		{"UpdateRefetchRequested", testUpdateRefetchRequested},
+		{"LoadHostByDeviceAuthToken", testHostsLoadHostByDeviceAuthToken},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -3687,4 +3689,31 @@ func testHostsSaveHostUsers(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Len(t, host.Users, 2)
 	test.ElementsMatchSkipID(t, users, host.Users)
+}
+
+func testHostsLoadHostByDeviceAuthToken(t *testing.T, ds *Datastore) {
+	host, err := ds.NewHost(context.Background(), &fleet.Host{
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now(),
+		NodeKey:         "1",
+		UUID:            "1",
+		Hostname:        "foo.local",
+		PrimaryIP:       "192.168.1.1",
+		PrimaryMac:      "30-65-EC-6F-C4-58",
+	})
+	require.NoError(t, err)
+
+	validToken := "abcd"
+	_, err = ds.writer.ExecContext(context.Background(), `INSERT INTO host_device_auth (host_id, token) VALUES (?, ?)`, host.ID, validToken)
+	require.NoError(t, err)
+
+	_, err = ds.LoadHostByDeviceAuthToken(context.Background(), "nosuchtoken")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sql.ErrNoRows)
+
+	h, err := ds.LoadHostByDeviceAuthToken(context.Background(), validToken)
+	require.NoError(t, err)
+	require.Equal(t, host.ID, h.ID)
 }

--- a/server/datastore/mysql/migrations/tables/20220307104655_AddHostDeviceAuth.go
+++ b/server/datastore/mysql/migrations/tables/20220307104655_AddHostDeviceAuth.go
@@ -16,7 +16,7 @@ func Up_20220307104655(tx *sql.Tx) error {
         host_id int(10) UNSIGNED NOT NULL,
         token VARCHAR(255) NOT NULL,
         PRIMARY KEY (host_id),
-        INDEX idx_host_device_auth_token (token)
+        UNIQUE INDEX idx_host_device_auth_token (token)
     );
 	`
 	if _, err := tx.Exec(hostDeviceAuthTable); err != nil {

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -129,7 +129,7 @@ CREATE TABLE `host_device_auth` (
   `host_id` int(10) unsigned NOT NULL,
   `token` varchar(255) NOT NULL,
   PRIMARY KEY (`host_id`),
-  KEY `idx_host_device_auth_token` (`token`)
+  UNIQUE KEY `idx_host_device_auth_token` (`token`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -202,6 +202,10 @@ type Datastore interface {
 	CountHostsInLabel(ctx context.Context, filter TeamFilter, lid uint, opt HostListOptions) (int, error)
 	ListHostDeviceMapping(ctx context.Context, id uint) ([]*HostDeviceMapping, error)
 
+	// LoadHostByDeviceAuthToken loads the host identified by the device auth token.
+	// If the token is invalid it returns a NotFoundError.
+	LoadHostByDeviceAuthToken(ctx context.Context, authToken string) (*Host, error)
+
 	// ListPoliciesForHost lists the policies that a host will check and whether they are passing
 	ListPoliciesForHost(ctx context.Context, host *Host) ([]*HostPolicy, error)
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -234,6 +234,10 @@ type Service interface {
 	///////////////////////////////////////////////////////////////////////////////
 	// HostService
 
+	// AuthenticateDevice loads host identified by the device's auth token.
+	// Returns an error if the auth token doesn't exist.
+	AuthenticateDevice(ctx context.Context, authToken string) (host *Host, debug bool, err error)
+
 	ListHosts(ctx context.Context, opt HostListOptions) (hosts []*Host, err error)
 	GetHost(ctx context.Context, id uint) (host *HostDetail, err error)
 	GetHostSummary(ctx context.Context, teamID *uint, platform *string) (summary *HostSummary, err error)

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -170,6 +170,8 @@ type CountHostsInLabelFunc func(ctx context.Context, filter fleet.TeamFilter, li
 
 type ListHostDeviceMappingFunc func(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error)
 
+type LoadHostByDeviceAuthTokenFunc func(ctx context.Context, authToken string) (*fleet.Host, error)
+
 type ListPoliciesForHostFunc func(ctx context.Context, host *fleet.Host) ([]*fleet.HostPolicy, error)
 
 type GetMunkiVersionFunc func(ctx context.Context, hostID uint) (string, error)
@@ -619,6 +621,9 @@ type DataStore struct {
 
 	ListHostDeviceMappingFunc        ListHostDeviceMappingFunc
 	ListHostDeviceMappingFuncInvoked bool
+
+	LoadHostByDeviceAuthTokenFunc        LoadHostByDeviceAuthTokenFunc
+	LoadHostByDeviceAuthTokenFuncInvoked bool
 
 	ListPoliciesForHostFunc        ListPoliciesForHostFunc
 	ListPoliciesForHostFuncInvoked bool
@@ -1332,6 +1337,11 @@ func (s *DataStore) CountHostsInLabel(ctx context.Context, filter fleet.TeamFilt
 func (s *DataStore) ListHostDeviceMapping(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
 	s.ListHostDeviceMappingFuncInvoked = true
 	return s.ListHostDeviceMappingFunc(ctx, id)
+}
+
+func (s *DataStore) LoadHostByDeviceAuthToken(ctx context.Context, authToken string) (*fleet.Host, error) {
+	s.LoadHostByDeviceAuthTokenFuncInvoked = true
+	return s.LoadHostByDeviceAuthTokenFunc(ctx, authToken)
 }
 
 func (s *DataStore) ListPoliciesForHost(ctx context.Context, host *fleet.Host) ([]*fleet.HostPolicy, error) {

--- a/server/service/carves.go
+++ b/server/service/carves.go
@@ -148,6 +148,10 @@ type carveBeginRequest struct {
 	RequestId  string `json:"request_id"`
 }
 
+func (r *carveBeginRequest) hostNodeKey() string {
+	return r.NodeKey
+}
+
 type carveBeginResponse struct {
 	SessionId string `json:"session_id"`
 	Success   bool   `json:"success,omitempty"`

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 )
 
@@ -34,4 +35,41 @@ func getDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.S
 
 	_ = req
 	return getHostResponse{Host: nil}, nil
+}
+
+// AuthenticateDevice returns the host identified by the device authentication
+// token, along with a boolean indicating if debug logging is enabled for that
+// host.
+func (svc *Service) AuthenticateDevice(ctx context.Context, authToken string) (*fleet.Host, bool, error) {
+	// skipauth: Authorization is currently for user endpoints only.
+	svc.authz.SkipAuthorization(ctx)
+
+	if authToken == "" {
+		return nil, false, ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("authentication error: missing device authentication token"))
+	}
+
+	host, err := svc.ds.LoadHostByDeviceAuthToken(ctx, authToken)
+	switch {
+	case err == nil:
+		// OK
+	case fleet.IsNotFound(err):
+		return nil, false, ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("authentication error: invalid device authentication token"))
+	default:
+		return nil, false, ctxerr.Wrap(ctx, err, "authenticate device")
+	}
+
+	// TODO: do we want that seen time update for device auth token? It's not "seen"
+	// in the sense that it's not osquery that did ping back to fleet, so I think we
+	// might want to remove that from here?
+
+	// Update the "seen" time used to calculate online status. These updates are
+	// batched for MySQL performance reasons. Because this is done
+	// asynchronously, it is possible for the server to shut down before
+	// updating the seen time for these hosts. This seems to be an acceptable
+	// tradeoff as an online host will continue to check in and quickly be
+	// marked online again.
+	svc.seenHostSet.addHostID(host.ID)
+	host.SeenTime = svc.clock.Now()
+
+	return host, svc.debugEnabledForHost(ctx, host.ID), nil
 }

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -107,3 +107,29 @@ func refetchDeviceHostEndpoint(ctx context.Context, request interface{}, svc fle
 	}
 	return refetchHostResponse{}, nil
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// List Current Device's Host Device Mappings
+////////////////////////////////////////////////////////////////////////////////
+
+type listDeviceHostDeviceMappingRequest struct {
+	Token string `url:"token"`
+}
+
+func (r *listDeviceHostDeviceMappingRequest) deviceAuthToken() string {
+	return r.Token
+}
+
+func listDeviceHostDeviceMappingEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+	host, ok := hostctx.FromContext(ctx)
+	if !ok {
+		err := ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))
+		return getHostResponse{Err: err}, nil
+	}
+
+	dms, err := svc.ListHostDeviceMapping(ctx, host.ID)
+	if err != nil {
+		return listHostDeviceMappingResponse{Err: err}, nil
+	}
+	return listHostDeviceMappingResponse{HostID: host.ID, DeviceMapping: dms}, nil
+}

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -1,0 +1,37 @@
+package service
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+)
+
+/////////////////////////////////////////////////////////////////////////////////
+// Get Current Device's Host
+/////////////////////////////////////////////////////////////////////////////////
+
+type getDeviceHostRequest struct {
+	Token string `url:"token"`
+}
+
+func (r *getDeviceHostRequest) deviceAuthToken() string {
+	return r.Token
+}
+
+func getDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+	req := request.(*getDeviceHostRequest)
+	/*
+		host, err := svc.GetHost(ctx, req.ID)
+		if err != nil {
+			return getHostResponse{Err: err}, nil
+		}
+
+		resp, err := hostDetailResponseForHost(ctx, svc, host)
+		if err != nil {
+			return getHostResponse{Err: err}, nil
+		}
+	*/
+
+	_ = req
+	return getHostResponse{Host: nil}, nil
+}

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -81,3 +81,29 @@ func (svc *Service) AuthenticateDevice(ctx context.Context, authToken string) (*
 
 	return host, svc.debugEnabledForHost(ctx, host.ID), nil
 }
+
+/////////////////////////////////////////////////////////////////////////////////
+// Refetch Current Device's Host
+/////////////////////////////////////////////////////////////////////////////////
+
+type refetchDeviceHostRequest struct {
+	Token string `url:"token"`
+}
+
+func (r *refetchDeviceHostRequest) deviceAuthToken() string {
+	return r.Token
+}
+
+func refetchDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+	host, ok := hostctx.FromContext(ctx)
+	if !ok {
+		err := ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))
+		return getHostResponse{Err: err}, nil
+	}
+
+	err := svc.RefetchHost(ctx, host.ID)
+	if err != nil {
+		return refetchHostResponse{Err: err}, nil
+	}
+	return refetchHostResponse{}, nil
+}

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -62,19 +62,6 @@ func (svc *Service) AuthenticateDevice(ctx context.Context, authToken string) (*
 		return nil, false, ctxerr.Wrap(ctx, err, "authenticate device")
 	}
 
-	// TODO: do we want that seen time update for device auth token? It's not "seen"
-	// in the sense that it's not osquery that did ping back to fleet, so I think we
-	// might want to remove that from here?
-
-	//// Update the "seen" time used to calculate online status. These updates are
-	//// batched for MySQL performance reasons. Because this is done
-	//// asynchronously, it is possible for the server to shut down before
-	//// updating the seen time for these hosts. This seems to be an acceptable
-	//// tradeoff as an online host will continue to check in and quickly be
-	//// marked online again.
-	//svc.seenHostSet.addHostID(host.ID)
-	//host.SeenTime = svc.clock.Now()
-
 	return host, svc.debugEnabledForHost(ctx, host.ID), nil
 }
 

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -66,14 +66,14 @@ func (svc *Service) AuthenticateDevice(ctx context.Context, authToken string) (*
 	// in the sense that it's not osquery that did ping back to fleet, so I think we
 	// might want to remove that from here?
 
-	// Update the "seen" time used to calculate online status. These updates are
-	// batched for MySQL performance reasons. Because this is done
-	// asynchronously, it is possible for the server to shut down before
-	// updating the seen time for these hosts. This seems to be an acceptable
-	// tradeoff as an online host will continue to check in and quickly be
-	// marked online again.
-	svc.seenHostSet.addHostID(host.ID)
-	host.SeenTime = svc.clock.Now()
+	//// Update the "seen" time used to calculate online status. These updates are
+	//// batched for MySQL performance reasons. Because this is done
+	//// asynchronously, it is possible for the server to shut down before
+	//// updating the seen time for these hosts. This seems to be an acceptable
+	//// tradeoff as an online host will continue to check in and quickly be
+	//// marked online again.
+	//svc.seenHostSet.addHostID(host.ID)
+	//host.SeenTime = svc.clock.Now()
 
 	return host, svc.debugEnabledForHost(ctx, host.ID), nil
 }

--- a/server/service/endpoint_middleware.go
+++ b/server/service/endpoint_middleware.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -43,32 +42,42 @@ func authenticatedDevice(svc fleet.Service, logger log.Logger, next endpoint.End
 		if err != nil {
 			return nil, err
 		}
+		_ = token
 
-		host, debug, err := svc.AuthenticateDevice(ctx, token)
-		if err != nil {
-			logging.WithErr(ctx, err)
-			return nil, err
-		}
+		//host, debug, err := svc.AuthenticateDevice(ctx, token)
+		//if err != nil {
+		//	logging.WithErr(ctx, err)
+		//	return nil, err
+		//}
 
-		hlogger := log.With(logger, "host-id", host.ID)
-		if debug {
-			logJSON(hlogger, request, "request")
-		}
+		//hlogger := log.With(logger, "host-id", host.ID)
+		//if debug {
+		//	logJSON(hlogger, request, "request")
+		//}
 
-		ctx = hostctx.NewContext(ctx, host)
-		instrumentHostLogger(ctx)
+		//ctx = hostctx.NewContext(ctx, host)
+		//instrumentHostLogger(ctx)
 
 		resp, err := next(ctx, request)
 		if err != nil {
 			return nil, err
 		}
 
-		if debug {
-			logJSON(hlogger, request, "response")
-		}
+		//if debug {
+		//	logJSON(hlogger, request, "response")
+		//}
 		return resp, nil
 	}
 	return logged(authDeviceFunc)
+}
+
+func getDeviceAuthToken(r interface{}) (string, error) {
+	if dat, ok := r.(interface{ deviceAuthToken() string }); ok {
+		return dat.deviceAuthToken(), nil
+	}
+	return "", osqueryError{
+		message: "request type does not implement deviceAuthToken method. This is likely a Fleet programmer error.",
+	}
 }
 
 // authenticatedHost wraps an endpoint, checks the validity of the node_key
@@ -109,29 +118,12 @@ func authenticatedHost(svc fleet.Service, logger log.Logger, next endpoint.Endpo
 }
 
 func getNodeKey(r interface{}) (string, error) {
-	// Retrieve node key by reflection (note that our options here
-	// are limited by the fact that request is an interface{})
-	v := reflect.ValueOf(r)
-	if v.Kind() == reflect.Ptr {
-		v = v.Elem()
+	if hnk, ok := r.(interface{ hostNodeKey() string }); ok {
+		return hnk.hostNodeKey(), nil
 	}
-	if v.Kind() != reflect.Struct {
-		return "", osqueryError{
-			message: "request type is not struct. This is likely a Fleet programmer error.",
-		}
+	return "", osqueryError{
+		message: "request type does not implement hostNodeKey method. This is likely a Fleet programmer error.",
 	}
-	nodeKeyField := v.FieldByName("NodeKey")
-	if !nodeKeyField.IsValid() {
-		return "", osqueryError{
-			message: "request struct missing NodeKey. This is likely a Fleet programmer error.",
-		}
-	}
-	if nodeKeyField.Kind() != reflect.String {
-		return "", osqueryError{
-			message: "NodeKey is not a string. This is likely a Fleet programmer error.",
-		}
-	}
-	return nodeKeyField.String(), nil
 }
 
 // authenticatedUser wraps an endpoint, requires that the Fleet user is

--- a/server/service/endpoint_middleware.go
+++ b/server/service/endpoint_middleware.go
@@ -42,30 +42,29 @@ func authenticatedDevice(svc fleet.Service, logger log.Logger, next endpoint.End
 		if err != nil {
 			return nil, err
 		}
-		_ = token
 
-		//host, debug, err := svc.AuthenticateDevice(ctx, token)
-		//if err != nil {
-		//	logging.WithErr(ctx, err)
-		//	return nil, err
-		//}
+		host, debug, err := svc.AuthenticateDevice(ctx, token)
+		if err != nil {
+			logging.WithErr(ctx, err)
+			return nil, err
+		}
 
-		//hlogger := log.With(logger, "host-id", host.ID)
-		//if debug {
-		//	logJSON(hlogger, request, "request")
-		//}
+		hlogger := log.With(logger, "host-id", host.ID)
+		if debug {
+			logJSON(hlogger, request, "request")
+		}
 
-		//ctx = hostctx.NewContext(ctx, host)
-		//instrumentHostLogger(ctx)
+		ctx = hostctx.NewContext(ctx, host)
+		instrumentHostLogger(ctx)
 
 		resp, err := next(ctx, request)
 		if err != nil {
 			return nil, err
 		}
 
-		//if debug {
-		//	logJSON(hlogger, request, "response")
-		//}
+		if debug {
+			logJSON(hlogger, request, "response")
+		}
 		return resp, nil
 	}
 	return logged(authDeviceFunc)
@@ -75,9 +74,7 @@ func getDeviceAuthToken(r interface{}) (string, error) {
 	if dat, ok := r.(interface{ deviceAuthToken() string }); ok {
 		return dat.deviceAuthToken(), nil
 	}
-	return "", osqueryError{
-		message: "request type does not implement deviceAuthToken method. This is likely a Fleet programmer error.",
-	}
+	return "", fleet.NewAuthRequiredError("request type does not implement deviceAuthToken method. This is likely a Fleet programmer error.")
 }
 
 // authenticatedHost wraps an endpoint, checks the validity of the node_key

--- a/server/service/endpoint_middleware_test.go
+++ b/server/service/endpoint_middleware_test.go
@@ -125,66 +125,11 @@ import (
 // 	}
 // }
 
-// TestGetNodeKey tests the reflection logic for pulling the node key from
-// various (fake) request types
-func TestGetNodeKey(t *testing.T) {
-	type Foo struct {
-		Foo     string
-		NodeKey string
-	}
-
-	type Bar struct {
-		Bar     string
-		NodeKey string
-	}
-
-	type Nope struct {
-		Nope string
-	}
-
-	type Almost struct {
-		NodeKey int
-	}
-
-	getNodeKeyTests := []struct {
-		i         interface{}
-		expectKey string
-		shouldErr bool
-	}{
-		{
-			i:         Foo{Foo: "foo", NodeKey: "fookey"},
-			expectKey: "fookey",
-			shouldErr: false,
-		},
-		{
-			i:         Bar{Bar: "bar", NodeKey: "barkey"},
-			expectKey: "barkey",
-			shouldErr: false,
-		},
-		{
-			i:         Nope{Nope: "nope"},
-			expectKey: "",
-			shouldErr: true,
-		},
-		{
-			i:         Almost{NodeKey: 10},
-			expectKey: "",
-			shouldErr: true,
-		},
-	}
-
-	for _, tt := range getNodeKeyTests {
-		t.Run("", func(t *testing.T) {
-			key, err := getNodeKey(tt.i)
-			assert.Equal(t, tt.expectKey, key)
-			if tt.shouldErr {
-				assert.IsType(t, osqueryError{}, err)
-			} else {
-				assert.Nil(t, err)
-			}
-		})
-	}
+type testNodeKeyRequest struct {
+	NodeKey string
 }
+
+func (r *testNodeKeyRequest) hostNodeKey() string { return r.NodeKey }
 
 func TestAuthenticatedHost(t *testing.T) {
 	ds := new(mock.Store)
@@ -237,7 +182,7 @@ func TestAuthenticatedHost(t *testing.T) {
 
 	for _, tt := range authenticatedHostTests {
 		t.Run("", func(t *testing.T) {
-			r := struct{ NodeKey string }{NodeKey: tt.nodeKey}
+			r := &testNodeKeyRequest{NodeKey: tt.nodeKey}
 			_, err := endpoint(context.Background(), r)
 			if tt.shouldErr {
 				assert.IsType(t, osqueryError{}, err)

--- a/server/service/endpoint_utils.go
+++ b/server/service/endpoint_utils.go
@@ -289,6 +289,19 @@ type authEndpointer struct {
 	customMiddleware  []endpoint.Middleware
 }
 
+func newDeviceAuthenticatedEndpointer(svc fleet.Service, logger log.Logger, opts []kithttp.ServerOption, r *mux.Router, versions ...string) *authEndpointer {
+	authFunc := func(svc fleet.Service, next endpoint.Endpoint) endpoint.Endpoint {
+		return authenticatedDevice(svc, logger, next)
+	}
+	return &authEndpointer{
+		svc:      svc,
+		opts:     opts,
+		r:        r,
+		authFunc: authFunc,
+		versions: versions,
+	}
+}
+
 func newUserAuthenticatedEndpointer(svc fleet.Service, opts []kithttp.ServerOption, r *mux.Router, versions ...string) *authEndpointer {
 	return &authEndpointer{
 		svc:      svc,

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -338,6 +338,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	de.GET("/api/_version_/fleet/device/{token}", getDeviceHostEndpoint, getDeviceHostRequest{})
 	de.POST("/api/_version_/fleet/device/{token}/refetch", refetchDeviceHostEndpoint, refetchDeviceHostRequest{})
 	de.GET("/api/_version_/fleet/device/{token}/device_mapping", listDeviceHostDeviceMappingEndpoint, listDeviceHostDeviceMappingRequest{})
+	de.GET("/api/latest/fleet/device/{token}/macadmins", getDeviceMacadminsDataEndpoint, getDeviceMacadminsDataRequest{})
 
 	// host-authenticated endpoints
 	he := newHostAuthenticatedEndpointer(svc, logger, opts, r, "v1")

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -333,6 +333,10 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.GET("/api/_version_/fleet/status/result_store", statusResultStoreEndpoint, nil)
 	ue.GET("/api/_version_/fleet/status/live_query", statusLiveQueryEndpoint, nil)
 
+	// device-authenticated endpoints
+	de := newDeviceAuthenticatedEndpointer(svc, logger, opts, r, "v1")
+	de.GET("/api/_version_/fleet/device/{token}", nil, nil) // TODO(mna): endpoint
+
 	// host-authenticated endpoints
 	he := newHostAuthenticatedEndpointer(svc, logger, opts, r, "v1")
 	he.POST("/api/_version_/osquery/config", getClientConfigEndpoint, getClientConfigRequest{})

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -337,6 +337,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	de := newDeviceAuthenticatedEndpointer(svc, logger, opts, r, "v1")
 	de.GET("/api/_version_/fleet/device/{token}", getDeviceHostEndpoint, getDeviceHostRequest{})
 	de.POST("/api/_version_/fleet/device/{token}/refetch", refetchDeviceHostEndpoint, refetchDeviceHostRequest{})
+	de.GET("/api/_version_/fleet/device/{token}/device_mapping", listDeviceHostDeviceMappingEndpoint, listDeviceHostDeviceMappingRequest{})
 
 	// host-authenticated endpoints
 	he := newHostAuthenticatedEndpointer(svc, logger, opts, r, "v1")

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -338,7 +338,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	de.GET("/api/_version_/fleet/device/{token}", getDeviceHostEndpoint, getDeviceHostRequest{})
 	de.POST("/api/_version_/fleet/device/{token}/refetch", refetchDeviceHostEndpoint, refetchDeviceHostRequest{})
 	de.GET("/api/_version_/fleet/device/{token}/device_mapping", listDeviceHostDeviceMappingEndpoint, listDeviceHostDeviceMappingRequest{})
-	de.GET("/api/latest/fleet/device/{token}/macadmins", getDeviceMacadminsDataEndpoint, getDeviceMacadminsDataRequest{})
+	de.GET("/api/_version_/fleet/device/{token}/macadmins", getDeviceMacadminsDataEndpoint, getDeviceMacadminsDataRequest{})
 
 	// host-authenticated endpoints
 	he := newHostAuthenticatedEndpointer(svc, logger, opts, r, "v1")

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -336,6 +336,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	// device-authenticated endpoints
 	de := newDeviceAuthenticatedEndpointer(svc, logger, opts, r, "v1")
 	de.GET("/api/_version_/fleet/device/{token}", getDeviceHostEndpoint, getDeviceHostRequest{})
+	de.POST("/api/_version_/fleet/device/{token}/refetch", refetchDeviceHostEndpoint, refetchDeviceHostRequest{})
 
 	// host-authenticated endpoints
 	he := newHostAuthenticatedEndpointer(svc, logger, opts, r, "v1")

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -335,7 +335,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 
 	// device-authenticated endpoints
 	de := newDeviceAuthenticatedEndpointer(svc, logger, opts, r, "v1")
-	de.GET("/api/_version_/fleet/device/{token}", nil, nil) // TODO(mna): endpoint
+	de.GET("/api/_version_/fleet/device/{token}", getDeviceHostEndpoint, getDeviceHostRequest{})
 
 	// host-authenticated endpoints
 	he := newHostAuthenticatedEndpointer(svc, logger, opts, r, "v1")

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	authzctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -266,12 +265,7 @@ func getHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service
 }
 
 func (svc *Service) GetHost(ctx context.Context, id uint) (*fleet.HostDetail, error) {
-	// can be already authorized if coming from device auth token endpoint
-	var alreadyAuthd bool
-	if authctx, ok := authzctx.FromContext(ctx); ok {
-		alreadyAuthd = authctx.Checked()
-	}
-
+	alreadyAuthd := svc.authz.IsAlreadyAuthorized(ctx)
 	if !alreadyAuthd {
 		// First ensure the user has access to list hosts, then check the specific
 		// host once team_id is loaded.
@@ -556,13 +550,7 @@ func refetchHostEndpoint(ctx context.Context, request interface{}, svc fleet.Ser
 }
 
 func (svc *Service) RefetchHost(ctx context.Context, id uint) error {
-	// can be already authorized if coming from device auth token endpoint
-	var alreadyAuthd bool
-	if authctx, ok := authzctx.FromContext(ctx); ok {
-		alreadyAuthd = authctx.Checked()
-	}
-
-	if !alreadyAuthd {
+	if !svc.authz.IsAlreadyAuthorized(ctx) {
 		if err := svc.authz.Authorize(ctx, &fleet.Host{}, fleet.ActionList); err != nil {
 			return err
 		}
@@ -678,13 +666,7 @@ func listHostDeviceMappingEndpoint(ctx context.Context, request interface{}, svc
 }
 
 func (svc *Service) ListHostDeviceMapping(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
-	// can be already authorized if coming from device auth token endpoint
-	var alreadyAuthd bool
-	if authctx, ok := authzctx.FromContext(ctx); ok {
-		alreadyAuthd = authctx.Checked()
-	}
-
-	if !alreadyAuthd {
+	if !svc.authz.IsAlreadyAuthorized(ctx) {
 		if err := svc.authz.Authorize(ctx, &fleet.Host{}, fleet.ActionList); err != nil {
 			return nil, err
 		}
@@ -728,13 +710,7 @@ func getMacadminsDataEndpoint(ctx context.Context, request interface{}, svc flee
 }
 
 func (svc *Service) MacadminsData(ctx context.Context, id uint) (*fleet.MacadminsData, error) {
-	// can be already authorized if coming from device auth token endpoint
-	var alreadyAuthd bool
-	if authctx, ok := authzctx.FromContext(ctx); ok {
-		alreadyAuthd = authctx.Checked()
-	}
-
-	if !alreadyAuthd {
+	if !svc.authz.IsAlreadyAuthorized(ctx) {
 		if err := svc.authz.Authorize(ctx, &fleet.Host{}, fleet.ActionList); err != nil {
 			return nil, err
 		}

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -46,13 +46,9 @@ func (s *integrationTestSuite) TearDownTest() {
 	filter := fleet.TeamFilter{User: &u}
 	hosts, err := s.ds.ListHosts(ctx, filter, fleet.HostListOptions{})
 	require.NoError(t, err)
-	var ids []uint
 	for _, host := range hosts {
-		ids = append(ids, host.ID)
 		require.NoError(t, s.ds.UpdateHostSoftware(context.Background(), host.ID, nil))
-	}
-	if len(ids) > 0 {
-		require.NoError(t, s.ds.DeleteHosts(ctx, ids))
+		require.NoError(t, s.ds.DeleteHost(ctx, host.ID))
 	}
 
 	// recalculate software counts will remove the software entries
@@ -3516,6 +3512,14 @@ func (s *integrationTestSuite) TestDeviceAuthenticatedEndpoints() {
 
 	hosts := s.createHosts(t)
 
+	// create some mappings and MDM/Munki data
+	s.ds.ReplaceHostDeviceMapping(context.Background(), hosts[0].ID, []*fleet.HostDeviceMapping{
+		{HostID: hosts[0].ID, Email: "a@b.c", Source: "google_chrome_profiles"},
+		{HostID: hosts[0].ID, Email: "b@b.c", Source: "google_chrome_profiles"},
+	})
+	require.NoError(t, s.ds.SetOrUpdateMDMData(context.Background(), hosts[0].ID, true, "url", false))
+	require.NoError(t, s.ds.SetOrUpdateMunkiVersion(context.Background(), hosts[0].ID, "1.3.0"))
+
 	// create an auth token for hosts[0]
 	token := "much_valid"
 	mysql.ExecAdhocSQL(t, s.ds, func(db sqlx.ExtContext) error {
@@ -3538,6 +3542,12 @@ func (s *integrationTestSuite) TestDeviceAuthenticatedEndpoints() {
 	res.Body.Close()
 	require.Equal(t, hosts[0].ID, getHostResp.Host.ID)
 	require.False(t, getHostResp.Host.RefetchRequested)
+	hostDevResp := getHostResp.Host
+
+	// make request for same host on the host details API endpoint, responses should match
+	getHostResp = getHostResponse{}
+	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d", hosts[0].ID), nil, http.StatusOK, &getHostResp)
+	require.Equal(t, hostDevResp, getHostResp.Host)
 
 	// request a refetch for that valid host
 	res = s.DoRawNoAuth("POST", "/api/v1/fleet/device/"+token+"/refetch", nil, http.StatusOK)
@@ -3560,14 +3570,31 @@ func (s *integrationTestSuite) TestDeviceAuthenticatedEndpoints() {
 	json.NewDecoder(res.Body).Decode(&listDMResp)
 	res.Body.Close()
 	require.Equal(t, hosts[0].ID, listDMResp.HostID)
+	require.Len(t, listDMResp.DeviceMapping, 2)
+	devDMs := listDMResp.DeviceMapping
+
+	// compare response with standard list device mapping API for that same host
+	listDMResp = listHostDeviceMappingResponse{}
+	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d/device_mapping", hosts[0].ID), nil, http.StatusOK, &listDMResp)
+	require.Equal(t, hosts[0].ID, listDMResp.HostID)
+	require.Equal(t, devDMs, listDMResp.DeviceMapping)
 
 	// list device mappings for invalid token
 	res = s.DoRawNoAuth("GET", "/api/v1/fleet/device/no_such_token/device_mapping", nil, http.StatusUnauthorized)
 	res.Body.Close()
 
 	// get macadmins for valid token
+	var getMacadm getMacadminsDataResponse
 	res = s.DoRawNoAuth("GET", "/api/v1/fleet/device/"+token+"/macadmins", nil, http.StatusOK)
+	json.NewDecoder(res.Body).Decode(&getMacadm)
 	res.Body.Close()
+	require.Equal(t, "1.3.0", getMacadm.Macadmins.Munki.Version)
+	devMacadm := getMacadm.Macadmins
+
+	// compare response with standard macadmins API for that same host
+	getMacadm = getMacadminsDataResponse{}
+	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d/macadmins", hosts[0].ID), nil, http.StatusOK, &getMacadm)
+	require.Equal(t, devMacadm, getMacadm.Macadmins)
 
 	// get macadmins for invalid token
 	res = s.DoRawNoAuth("GET", "/api/v1/fleet/device/no_such_token/macadmins", nil, http.StatusUnauthorized)

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -281,6 +281,10 @@ type getClientConfigRequest struct {
 	NodeKey string `json:"node_key"`
 }
 
+func (r *getClientConfigRequest) hostNodeKey() string {
+	return r.NodeKey
+}
+
 type getClientConfigResponse struct {
 	Config map[string]interface{}
 	Err    error `json:"error,omitempty"`
@@ -459,6 +463,10 @@ type getDistributedQueriesRequest struct {
 	NodeKey string `json:"node_key"`
 }
 
+func (r *getDistributedQueriesRequest) hostNodeKey() string {
+	return r.NodeKey
+}
+
 type getDistributedQueriesResponse struct {
 	Queries    map[string]string `json:"queries"`
 	Accelerate uint              `json:"accelerate,omitempty"`
@@ -626,6 +634,10 @@ type submitDistributedQueryResultsRequestShim struct {
 	Results  map[string]json.RawMessage `json:"queries"`
 	Statuses map[string]interface{}     `json:"statuses"`
 	Messages map[string]string          `json:"messages"`
+}
+
+func (shim *submitDistributedQueryResultsRequestShim) hostNodeKey() string {
+	return shim.NodeKey
 }
 
 func (shim *submitDistributedQueryResultsRequestShim) toRequest(ctx context.Context) (*SubmitDistributedQueryResultsRequest, error) {
@@ -1056,6 +1068,10 @@ type submitLogsRequest struct {
 	NodeKey string          `json:"node_key"`
 	LogType string          `json:"log_type"`
 	Data    json.RawMessage `json:"data"`
+}
+
+func (r *submitLogsRequest) hostNodeKey() string {
+	return r.NodeKey
 }
 
 type submitLogsResponse struct {


### PR DESCRIPTION
#4416 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [ ] ~~Documented any API changes (docs/Using-Fleet/REST-API.md)~~ (those are not endpoints to be called with an API token, so just like the osquery host-authenticated endpoints are not part of that doc, I haven't documented those new endpoints)
- [ ] ~~Documented any permissions changes~~
- [ ] ~~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~~
- [x] Added/updated tests
- [ ] ~~Manual QA for all new/changed functionality~~
