### PR TITLE
Add support for Amazon Linux 2

### DIFF
--- a/changes/issue-4555_add_support_for_amazon_linux_2
+++ b/changes/issue-4555_add_support_for_amazon_linux_2
@@ -1,0 +1,1 @@
+* Added support for Amazon Linux 2

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -218,7 +218,7 @@ func (h *Host) FleetPlatform() string {
 
 // HostLinuxOSs are the possible linux values for Host.Platform.
 var HostLinuxOSs = []string{
-	"linux", "ubuntu", "debian", "rhel", "centos", "sles", "kali", "gentoo",
+	"linux", "ubuntu", "debian", "rhel", "centos", "sles", "kali", "gentoo", "amzn",
 }
 
 func isLinux(hostPlatform string) bool {


### PR DESCRIPTION
Even though OSQuery and Fleet can support Amazon Linux 2 (since it's a regular CentOS like distro), the 'platform' is not mapped in Fleet [here](https://github.com/fleetdm/fleet/blob/2ee98e1fa1a20cb3bb9b6a83b9d7c6896caa50fc/server/fleet/hosts.go#L221), which then makes [`PlatformFromHost`](https://github.com/fleetdm/fleet/blob/2ee98e1fa1a20cb3bb9b6a83b9d7c6896caa50fc/server/fleet/hosts.go#L239) return an empty string, which then makes Fleet print the following log line:

```
level=error ts=2022-03-10T21:05:23.191929625Z err="host 1 with empty platform"
``` 

and some functionality like policies doesn't work as expected.

# Checklist

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
