### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Basic set up starting with github actions only
+
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Part of #4198 - creating an explicit dependabot.yml file so we do not have to rely on the defaults of using dependabot alerts only. Starting with Github actions for minimal impact / avoid creating a thousand PRs until we have a good handle on how dependabot works.
