### PR TITLE
update image alt text on fleetdm.com/get-started

### DIFF
--- a/website/views/pages/get-started.ejs
+++ b/website/views/pages/get-started.ejs
@@ -18,7 +18,7 @@
           Get Docker
         </a>
       </div>
-      <p class="pt-4"><img alt="A small circle with an "I" inside of it"
+      <p class="pt-4"><img alt="A small circle with an 'I' inside of it"
           style="width: 16px; display: inline; margin-right: 8px; margin-bottom: 3px" src="/images/info-16x16@2x.png">We
         use NPM to install <code>fleetctl</code>. It can also be installed via the <a
           href="https://github.com/fleetdm/fleet/releases" target="_blank">release page</a> or <a
@@ -33,10 +33,10 @@
         <p class="comment"># Run a local demo of the Fleet server</p>
         <p class="command">sudo fleetctl preview</p>
       </div>
-      <p class="mb-0"><img alt="A small circle with an "I" inside of it"
+      <p class="mb-0"><img alt="A small circle with an 'I' inside of it"
           style="width: 16px; display: inline; margin-right: 8px; margin-bottom: 3px"
           src="/images/info-16x16@2x.png">Windows users can omit <code>sudo</code>, and should run the command in <code>Cmd</code>/<code>PowerShell</code> as administrators.</p>
-      <p class="mb-0"><img alt="A small circle with an "I" inside of it"
+      <p class="mb-0"><img alt="A small circle with an 'I' inside of it"
           style="width: 16px; display: inline; margin-right: 8px; margin-bottom: 3px"
       src="/images/info-16x16@2x.png">M1 Macs users need to have <a href="https://support.apple.com/en-us/HT211861" target="_blank">Rosetta</a> installed in order to
       run fleet preview successfully.</p>


### PR DESCRIPTION
Changes:
- Updated the alt text on images on `/get-started`

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
