### PR TITLE
Add distributed discovery query support for detail queries, add orbit…

### DIFF
--- a/changes/issue-3914-fleet-desktop-orbit-table
+++ b/changes/issue-3914-fleet-desktop-orbit-table
@@ -1,0 +1,3 @@
+* Fleet to start using distributed discovery query feature.
+* Fleet will query `google_chrome_profiles` on all hosts via the distributed discovery feature.
+* Fleet will query `orbit_info` on all hosts via the distributed discovery feature.

--- a/changes/issue-3914-fleet-desktop-orbit-table
+++ b/changes/issue-3914-fleet-desktop-orbit-table
@@ -1,3 +1,1 @@
-* Fleet to start using distributed discovery query feature.
-* Fleet will query `google_chrome_profiles` on all hosts via the distributed discovery feature.
-* Fleet will query `orbit_info` on all hosts via the distributed discovery feature.
+* Reduce osquery status log verbosity by only running detail queries when the relevant tables exist.

--- a/orbit/cmd/orbit/orbit_info.go
+++ b/orbit/cmd/orbit/orbit_info.go
@@ -28,7 +28,7 @@ func (o orbitInfoExtension) Columns() []table.ColumnDefinition {
 }
 
 // GenerateFunc partially implements orbit_table.Extension.
-func (o orbitInfoExtension) GenerateFunc(ctx context.Context, _ table.QueryContext) ([]map[string]string, error) {
+func (o orbitInfoExtension) GenerateFunc(_ context.Context, _ table.QueryContext) ([]map[string]string, error) {
 	v := version
 	if v == "" {
 		v = "unknown"

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -762,6 +762,16 @@ func (ds *Datastore) LoadHostByDeviceAuthToken(ctx context.Context, authToken st
 	}
 }
 
+// SetOrUpdateDeviceAuthToken inserts or updates the auth token for a host.
+func (ds *Datastore) SetOrUpdateDeviceAuthToken(ctx context.Context, hostID uint, authToken string) error {
+	return ds.updateOrInsert(
+		ctx,
+		`UPDATE host_device_auth SET token=? WHERE host_id=?`,
+		`INSERT INTO host_device_auth(token, host_id) VALUES (?,?)`,
+		authToken, hostID,
+	)
+}
+
 func (ds *Datastore) MarkHostsSeen(ctx context.Context, hostIDs []uint, t time.Time) error {
 	if len(hostIDs) == 0 {
 		return nil

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -113,6 +113,7 @@ func TestHosts(t *testing.T) {
 		{"UpdateOsqueryIntervals", testUpdateOsqueryIntervals},
 		{"UpdateRefetchRequested", testUpdateRefetchRequested},
 		{"LoadHostByDeviceAuthToken", testHostsLoadHostByDeviceAuthToken},
+		{"SetOrUpdateDeviceAuthToken", testHostsSetOrUpdateDeviceAuthToken},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -3706,7 +3707,7 @@ func testHostsLoadHostByDeviceAuthToken(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	validToken := "abcd"
-	_, err = ds.writer.ExecContext(context.Background(), `INSERT INTO host_device_auth (host_id, token) VALUES (?, ?)`, host.ID, validToken)
+	err = ds.SetOrUpdateDeviceAuthToken(context.Background(), host.ID, validToken)
 	require.NoError(t, err)
 
 	_, err = ds.LoadHostByDeviceAuthToken(context.Background(), "nosuchtoken")
@@ -3716,4 +3717,65 @@ func testHostsLoadHostByDeviceAuthToken(t *testing.T, ds *Datastore) {
 	h, err := ds.LoadHostByDeviceAuthToken(context.Background(), validToken)
 	require.NoError(t, err)
 	require.Equal(t, host.ID, h.ID)
+}
+
+func testHostsSetOrUpdateDeviceAuthToken(t *testing.T, ds *Datastore) {
+	host, err := ds.NewHost(context.Background(), &fleet.Host{
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now(),
+		NodeKey:         "1",
+		UUID:            "1",
+		OsqueryHostID:   "1",
+		Hostname:        "foo.local",
+		PrimaryIP:       "192.168.1.1",
+		PrimaryMac:      "30-65-EC-6F-C4-58",
+	})
+	require.NoError(t, err)
+	host2, err := ds.NewHost(context.Background(), &fleet.Host{
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now(),
+		NodeKey:         "2",
+		UUID:            "2",
+		OsqueryHostID:   "2",
+		Hostname:        "foo.local2",
+		PrimaryIP:       "192.168.1.2",
+		PrimaryMac:      "30-65-EC-6F-C4-59",
+	})
+	require.NoError(t, err)
+
+	token1 := "token1"
+	err = ds.SetOrUpdateDeviceAuthToken(context.Background(), host.ID, token1)
+	require.NoError(t, err)
+
+	token2 := "token2"
+	err = ds.SetOrUpdateDeviceAuthToken(context.Background(), host2.ID, token2)
+	require.NoError(t, err)
+
+	h, err := ds.LoadHostByDeviceAuthToken(context.Background(), token1)
+	require.NoError(t, err)
+	require.Equal(t, host.ID, h.ID)
+
+	h, err = ds.LoadHostByDeviceAuthToken(context.Background(), token2)
+	require.NoError(t, err)
+	require.Equal(t, host2.ID, h.ID)
+
+	token2Updated := "token2_updated"
+	err = ds.SetOrUpdateDeviceAuthToken(context.Background(), host2.ID, token2Updated)
+	require.NoError(t, err)
+
+	h, err = ds.LoadHostByDeviceAuthToken(context.Background(), token1)
+	require.NoError(t, err)
+	require.Equal(t, host.ID, h.ID)
+
+	h, err = ds.LoadHostByDeviceAuthToken(context.Background(), token2Updated)
+	require.NoError(t, err)
+	require.Equal(t, host2.ID, h.ID)
+
+	h, err = ds.LoadHostByDeviceAuthToken(context.Background(), token2)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sql.ErrNoRows)
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -205,6 +205,8 @@ type Datastore interface {
 	// LoadHostByDeviceAuthToken loads the host identified by the device auth token.
 	// If the token is invalid it returns a NotFoundError.
 	LoadHostByDeviceAuthToken(ctx context.Context, authToken string) (*Host, error)
+	// SetOrUpdateDeviceAuthToken inserts or updates the auth token for a host.
+	SetOrUpdateDeviceAuthToken(ctx context.Context, hostID uint, authToken string) error
 
 	// ListPoliciesForHost lists the policies that a host will check and whether they are passing
 	ListPoliciesForHost(ctx context.Context, host *Host) ([]*HostPolicy, error)

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -27,7 +27,7 @@ type OsqueryService interface {
 	//
 	// To enable the osquery "accelerated checkins" feature, a positive integer (number of seconds to activate for)
 	// should be returned. Returning 0 for this will not activate the feature.
-	GetDistributedQueries(ctx context.Context) (queries map[string]string, accelerate uint, err error)
+	GetDistributedQueries(ctx context.Context) (queries map[string]string, discovery map[string]string, accelerate uint, err error)
 	SubmitDistributedQueryResults(
 		ctx context.Context,
 		results OsqueryDistributedQueryResults,

--- a/server/launcher/launcher.go
+++ b/server/launcher/launcher.go
@@ -73,13 +73,14 @@ func (svc *launcherWrapper) RequestQueries(ctx context.Context, nodeKey string) 
 		return nil, invalid, err
 	}
 
-	queryMap, accelerate, err := svc.tls.GetDistributedQueries(newCtx)
+	queryMap, discoveryMap, accelerate, err := svc.tls.GetDistributedQueries(newCtx)
 	if err != nil {
 		return nil, false, ctxerr.Wrap(ctx, err, "get queries for launcher")
 	}
 
 	result := &distributed.GetQueriesResult{
 		Queries:           queryMap,
+		Discovery:         discoveryMap,
 		AccelerateSeconds: int(accelerate),
 	}
 

--- a/server/launcher/launcher_test.go
+++ b/server/launcher/launcher_test.go
@@ -136,9 +136,12 @@ func newTLSService(t *testing.T) *mock.TLSService {
 
 		GetDistributedQueriesFunc: func(
 			ctx context.Context,
-		) (queries map[string]string, accelerate uint, err error) {
+		) (queries map[string]string, discovery map[string]string, accelerate uint, err error) {
 			queries = map[string]string{
 				"noop": `{"key": "value"}`,
+			}
+			discovery = map[string]string{
+				"noop": `select 1`,
 			}
 			return
 		},

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -172,6 +172,8 @@ type ListHostDeviceMappingFunc func(ctx context.Context, id uint) ([]*fleet.Host
 
 type LoadHostByDeviceAuthTokenFunc func(ctx context.Context, authToken string) (*fleet.Host, error)
 
+type SetOrUpdateDeviceAuthTokenFunc func(ctx context.Context, hostID uint, authToken string) error
+
 type ListPoliciesForHostFunc func(ctx context.Context, host *fleet.Host) ([]*fleet.HostPolicy, error)
 
 type GetMunkiVersionFunc func(ctx context.Context, hostID uint) (string, error)
@@ -624,6 +626,9 @@ type DataStore struct {
 
 	LoadHostByDeviceAuthTokenFunc        LoadHostByDeviceAuthTokenFunc
 	LoadHostByDeviceAuthTokenFuncInvoked bool
+
+	SetOrUpdateDeviceAuthTokenFunc        SetOrUpdateDeviceAuthTokenFunc
+	SetOrUpdateDeviceAuthTokenFuncInvoked bool
 
 	ListPoliciesForHostFunc        ListPoliciesForHostFunc
 	ListPoliciesForHostFuncInvoked bool
@@ -1342,6 +1347,11 @@ func (s *DataStore) ListHostDeviceMapping(ctx context.Context, id uint) ([]*flee
 func (s *DataStore) LoadHostByDeviceAuthToken(ctx context.Context, authToken string) (*fleet.Host, error) {
 	s.LoadHostByDeviceAuthTokenFuncInvoked = true
 	return s.LoadHostByDeviceAuthTokenFunc(ctx, authToken)
+}
+
+func (s *DataStore) SetOrUpdateDeviceAuthToken(ctx context.Context, hostID uint, authToken string) error {
+	s.SetOrUpdateDeviceAuthTokenFuncInvoked = true
+	return s.SetOrUpdateDeviceAuthTokenFunc(ctx, hostID, authToken)
 }
 
 func (s *DataStore) ListPoliciesForHost(ctx context.Context, host *fleet.Host) ([]*fleet.HostPolicy, error) {

--- a/server/service/endpoint_middleware.go
+++ b/server/service/endpoint_middleware.go
@@ -107,7 +107,7 @@ func authenticatedHost(svc fleet.Service, logger log.Logger, next endpoint.Endpo
 		}
 
 		if debug {
-			logJSON(hlogger, request, "response")
+			logJSON(hlogger, resp, "response")
 		}
 		return resp, nil
 	}

--- a/server/service/mock/service_osquery.go
+++ b/server/service/mock/service_osquery.go
@@ -17,7 +17,7 @@ type AuthenticateHostFunc func(ctx context.Context, nodeKey string) (host *fleet
 
 type GetClientConfigFunc func(ctx context.Context) (config map[string]interface{}, err error)
 
-type GetDistributedQueriesFunc func(ctx context.Context) (queries map[string]string, accelerate uint, err error)
+type GetDistributedQueriesFunc func(ctx context.Context) (queries map[string]string, discovery map[string]string, accelerate uint, err error)
 
 type SubmitDistributedQueryResultsFunc func(ctx context.Context, results fleet.OsqueryDistributedQueryResults, statuses map[string]fleet.OsqueryStatus, messages map[string]string) (err error)
 
@@ -63,7 +63,7 @@ func (s *TLSService) GetClientConfig(ctx context.Context) (config map[string]int
 	return s.GetClientConfigFunc(ctx)
 }
 
-func (s *TLSService) GetDistributedQueries(ctx context.Context) (queries map[string]string, accelerate uint, err error) {
+func (s *TLSService) GetDistributedQueries(ctx context.Context) (queries map[string]string, discovery map[string]string, accelerate uint, err error) {
 	s.GetDistributedQueriesFuncInvoked = true
 	return s.GetDistributedQueriesFunc(ctx)
 }

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -469,6 +469,7 @@ func (r *getDistributedQueriesRequest) hostNodeKey() string {
 
 type getDistributedQueriesResponse struct {
 	Queries    map[string]string `json:"queries"`
+	Discovery  map[string]string `json:"discovery"`
 	Accelerate uint              `json:"accelerate,omitempty"`
 	Err        error             `json:"error,omitempty"`
 }
@@ -476,35 +477,43 @@ type getDistributedQueriesResponse struct {
 func (r getDistributedQueriesResponse) error() error { return r.Err }
 
 func getDistributedQueriesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
-	queries, accelerate, err := svc.GetDistributedQueries(ctx)
+	queries, discovery, accelerate, err := svc.GetDistributedQueries(ctx)
 	if err != nil {
 		return getDistributedQueriesResponse{Err: err}, nil
 	}
-	return getDistributedQueriesResponse{Queries: queries, Accelerate: accelerate}, nil
+	return getDistributedQueriesResponse{
+		Queries:    queries,
+		Discovery:  discovery,
+		Accelerate: accelerate,
+	}, nil
 }
 
-func (svc *Service) GetDistributedQueries(ctx context.Context) (map[string]string, uint, error) {
+func (svc *Service) GetDistributedQueries(ctx context.Context) (queries map[string]string, discovery map[string]string, accelerate uint, err error) {
 	// skipauth: Authorization is currently for user endpoints only.
 	svc.authz.SkipAuthorization(ctx)
 
 	host, ok := hostctx.FromContext(ctx)
 	if !ok {
-		return nil, 0, osqueryError{message: "internal error: missing host from request context"}
+		return nil, nil, 0, osqueryError{message: "internal error: missing host from request context"}
 	}
 
-	queries := make(map[string]string)
+	queries = make(map[string]string)
+	discovery = make(map[string]string)
 
-	detailQueries, err := svc.detailQueriesForHost(ctx, host)
+	detailQueries, detailDiscovery, err := svc.detailQueriesForHost(ctx, host)
 	if err != nil {
-		return nil, 0, osqueryError{message: err.Error()}
+		return nil, nil, 0, osqueryError{message: err.Error()}
 	}
 	for name, query := range detailQueries {
 		queries[name] = query
 	}
+	for name, query := range detailDiscovery {
+		discovery[name] = query
+	}
 
 	labelQueries, err := svc.labelQueriesForHost(ctx, host)
 	if err != nil {
-		return nil, 0, osqueryError{message: err.Error()}
+		return nil, nil, 0, osqueryError{message: err.Error()}
 	}
 	for name, query := range labelQueries {
 		queries[hostLabelQueryPrefix+name] = query
@@ -523,13 +532,13 @@ func (svc *Service) GetDistributedQueries(ctx context.Context) (map[string]strin
 
 	policyQueries, err := svc.policyQueriesForHost(ctx, host)
 	if err != nil {
-		return nil, 0, osqueryError{message: err.Error()}
+		return nil, nil, 0, osqueryError{message: err.Error()}
 	}
 	for name, query := range policyQueries {
 		queries[hostPolicyQueryPrefix+name] = query
 	}
 
-	accelerate := uint(0)
+	accelerate = uint(0)
 	if host.Hostname == "" || host.Platform == "" {
 		// Assume this host is just enrolling, and accelerate checkins
 		// (to allow for platform restricted labels to run quickly
@@ -537,44 +546,70 @@ func (svc *Service) GetDistributedQueries(ctx context.Context) (map[string]strin
 		accelerate = 10
 	}
 
-	return queries, accelerate, nil
+	// The way osquery's distributed "discovery" queries work is:
+	// If len(discovery) > 0, then only those queries that have a "discovery"
+	// query and return more than one row are executed on the host.
+	//
+	// Thus, we set the alwaysTrueQuery for all queries, except for those where we set
+	// an explicit discovery query (e.g. orbit_info, google_chrome_profiles).
+	for name := range queries {
+		discoveryQuery := discovery[name]
+		if discoveryQuery == "" {
+			discoveryQuery = alwaysTrueQuery
+		}
+		discovery[name] = discoveryQuery
+	}
+
+	return queries, discovery, accelerate, nil
 }
+
+const alwaysTrueQuery = "SELECT 1"
 
 // detailQueriesForHost returns the map of detail+additional queries that should be executed by
 // osqueryd to fill in the host details.
-func (svc *Service) detailQueriesForHost(ctx context.Context, host *fleet.Host) (map[string]string, error) {
+func (svc *Service) detailQueriesForHost(ctx context.Context, host *fleet.Host) (queries map[string]string, discovery map[string]string, err error) {
 	if !svc.shouldUpdate(host.DetailUpdatedAt, svc.config.Osquery.DetailUpdateInterval, host.ID) && !host.RefetchRequested {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	config, err := svc.ds.AppConfig(ctx)
 	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "read app config")
+		return nil, nil, ctxerr.Wrap(ctx, err, "read app config")
 	}
 
-	queries := make(map[string]string)
+	queries = make(map[string]string)
+	discovery = make(map[string]string)
+
 	detailQueries := osquery_utils.GetDetailQueries(config, svc.config)
 	for name, query := range detailQueries {
 		if query.RunsForPlatform(host.Platform) {
-			queries[hostDetailQueryPrefix+name] = query.Query
+			queryName := hostDetailQueryPrefix + name
+			queries[queryName] = query.Query
+			discoveryQuery := query.Discovery
+			if discoveryQuery == "" {
+				discoveryQuery = alwaysTrueQuery
+			}
+			discovery[queryName] = discoveryQuery
 		}
 	}
 
 	if config.HostSettings.AdditionalQueries == nil {
 		// No additional queries set
-		return queries, nil
+		return queries, discovery, nil
 	}
 
 	var additionalQueries map[string]string
 	if err := json.Unmarshal(*config.HostSettings.AdditionalQueries, &additionalQueries); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "unmarshal additional queries")
+		return nil, nil, ctxerr.Wrap(ctx, err, "unmarshal additional queries")
 	}
 
 	for name, query := range additionalQueries {
-		queries[hostAdditionalQueryPrefix+name] = query
+		queryName := hostAdditionalQueryPrefix + name
+		queries[queryName] = query
+		discovery[queryName] = alwaysTrueQuery
 	}
 
-	return queries, nil
+	return queries, discovery, nil
 }
 
 func (svc *Service) shouldUpdate(lastUpdated time.Time, interval time.Duration, hostID uint) bool {


### PR DESCRIPTION
#3914

This PR is introducing support for "distributed discovery queries" to Fleet, that we can use for queries/tables that are only implemented on some hosts. (See https://github.com/fleetdm/fleet/issues/3918#issuecomment-1035109379.)
This is the case for `orbit_info`, only available on Fleet-osquery/Orbit agents.
If we don't do this, then osquery will fill up the status logs with "no such table" errors, see: #4123:
```
{"hostIdentifier":"...","calendarTime":"Tue Mar 15 12:02:12 2022 UTC","unixTime":"1647345732","severity":"2","filename":"distributed.cpp","line":"131","message":"Error executing distributed query: fleet_detail_query_google_chrome_profiles: no such table: google_chrome_profiles","version":"4.9.0"}
```

See how osquery implements "distributed discovery queries" here: https://github.com/osquery/osquery/blob/84f8b948cae58dfec13b699667a1595957f45c16/osquery/distributed/distributed.cpp#L186-L236

We should ask in #osquery Slack channel if they need help documenting such feature. I didn't find any docs about them (the ones that are documented are the discovery queries for packs).

I just added support for "distributed discovery queries" for **detail** queries, but in the future we can provide UI support for e.g. "Discovery Query" in "Policies". Which would be an extra query that will check if a policy needs to run on a host.

Sample of a `distributed/read` response:
```json
{
    "queries": {

        "fleet_detail_query_disk_space_unix":"\\nSELECT (blocks_available * 100 / blocks)...",
        "fleet_detail_query_google_chrome_profiles":"SELECT email FROM google_chrome_profiles WHERE NOT ephemeral",
        "fleet_detail_query_mdm":"select ... mdm;",
        "fleet_detail_query_munki_info":"select version from munki_info;",
        "fleet_detail_query_network_interface":"select address, ... + obytes) desc",
        "fleet_detail_query_orbit_info":"SELECT * FROM orbit_info",
        "fleet_detail_query_os_version":"select * from os_version limit 1",
        "fleet_detail_query_osquery_flags":"select name, value from osquery_flags ...", 
        "fleet_detail_query_osquery_info":"select * from osquery_info limit 1",
        "fleet_detail_query_scheduled_query_stats":"\\n\\t\\t\\tSELECT ...",
        "fleet_detail_query_software_macos":"\\nW...",
        "fleet_detail_query_system_info":"select * from system_info limit 1",
        "fleet_detail_query_uptime":"select *... 1",
        "fleet_detail_query_users":"...bin/sync')",
        "fleet_label_query_10":"select 1 from os_version where platform = 'windows';",
        "fleet_label_query_11":"SELECT 1 FROM os_version WHERE name LIKE '%red hat%'",
        "fleet_label_query_12":"SELECT 1 FROM osquery_info ...",
        "fleet_label_query_6":"select 1;",
        "fleet_label_query_7":"select 1 from os_v...",
        "fleet_label_query_8":"select 1 from os_version where platform = 'ubuntu';",
        "fleet_label_query_9":"select 1 from os_ver...",
        "fleet_policy_query_2":"SELECT 1 FROM managed_policies ..."}
    },
    "discovery": {
        "fleet_detail_query_disk_space_unix":"select 1",
        "fleet_detail_query_google_chrome_profiles":"SELECT 1 FROM osquery_registry WHERE active = true AND registry = 'table' AND name = 'google_chrome_profiles';",
        "fleet_detail_query_mdm":"select 1",
        "fleet_detail_query_munki_info":"select 1",
        "fleet_detail_query_network_interface":"select 1",
        "fleet_detail_query_orbit_info": "SELECT 1 FROM osquery_registry WHERE active = true AND registry = 'table' AND name = 'orbit_info';",
        "fleet_detail_query_os_version":"select 1",
        "fleet_detail_query_osquery_flags":"select 1",
        "fleet_detail_query_osquery_info":"select 1",
        "fleet_detail_query_scheduled_query_stats":"select 1",
        "fleet_detail_query_software_macos":"select 1",
        "fleet_detail_query_system_info":"select 1",
        "fleet_detail_query_uptime":"select 1",
        "fleet_detail_query_users":"select 1",
        "fleet_label_query_10":"select 1",
        "fleet_label_query_11":"select 1",
        "fleet_label_query_12":"select 1",
        "fleet_label_query_6":"select 1",
        "fleet_label_query_7":"select 1",
        "fleet_label_query_8":"select 1",
        "fleet_label_query_9":"select 1",
        "fleet_policy_query_2":"select 1",
        "fleet_policy_query_3":"select 1"
    }
}
```

- [X] Changes file added (for user-visible changes)
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
