### PR TITLE
Refactor authz skip for device auth, add org_logo_url for frontend

### DIFF
--- a/server/authz/authz.go
+++ b/server/authz/authz.go
@@ -70,16 +70,14 @@ func (a *Authorizer) SkipAuthorization(ctx context.Context) {
 	}
 }
 
-// IsAlreadyAuthorized returns true if the context has already authorized. This
-// may be useful to skip authorization checks in the Service layer when e.g.
-// the current request has already been authorized due to its different
-// authentication method, such as the device authentication token which allows
-// reading the corresponding host's information even if there is no user
-// associated with the request (so typical user-based authorization checks
-// would fail).
-func (a *Authorizer) IsAlreadyAuthorized(ctx context.Context) bool {
+// IsAuthenticatedWith returns true if the request has been authenticated with
+// the specified authentication method, false otherwise. This is useful to avoid
+// calling Authorize if the request is authenticated with a method that doesn't
+// support granular authorizations - provided it is ok to grant access to the
+// protected data.
+func (a *Authorizer) IsAuthenticatedWith(ctx context.Context, method authz_ctx.AuthenticationMethod) bool {
 	if authctx, ok := authz_ctx.FromContext(ctx); ok {
-		return authctx.Checked()
+		return authctx.AuthnMethod() == method
 	}
 	return false
 }

--- a/server/contexts/authz/authz.go
+++ b/server/contexts/authz/authz.go
@@ -22,12 +22,24 @@ func FromContext(ctx context.Context) (*AuthorizationContext, bool) {
 	return v, ok
 }
 
+// AuthenticationMethod identifies the method used to authenticate.
+type AuthenticationMethod int
+
+// List of supported authentication methods.
+const (
+	AuthnUserToken AuthenticationMethod = iota
+	AuthnHostToken
+	AuthnDeviceToken
+)
+
 // AuthorizationContext contains the context information used for the
 // authorization check.
 type AuthorizationContext struct {
 	l sync.Mutex
 	// checked indicates whether a call was made to check authorization for the request.
 	checked bool
+	// store the authentication method, as some methods cannot have granular authorizations.
+	authnMethod AuthenticationMethod
 }
 
 func (a *AuthorizationContext) Checked() bool {
@@ -40,4 +52,16 @@ func (a *AuthorizationContext) SetChecked() {
 	a.l.Lock()
 	defer a.l.Unlock()
 	a.checked = true
+}
+
+func (a *AuthorizationContext) AuthnMethod() AuthenticationMethod {
+	a.l.Lock()
+	defer a.l.Unlock()
+	return a.authnMethod
+}
+
+func (a *AuthorizationContext) SetAuthnMethod(method AuthenticationMethod) {
+	a.l.Lock()
+	defer a.l.Unlock()
+	a.authnMethod = method
 }

--- a/server/contexts/authz/authz.go
+++ b/server/contexts/authz/authz.go
@@ -27,8 +27,17 @@ type AuthenticationMethod int
 
 // List of supported authentication methods.
 const (
+	// AuthnUserToken is when authentication is done via a user's API token,
+	// obtained via user/password login (or fleetctl for API-only users).
+	// This authentication mode supports granular authorization.
 	AuthnUserToken AuthenticationMethod = iota
+	// AuthnHostToken is when authentication is done via the osquery host
+	// authentication token. This authentication mode does not support granular
+	// authorization.
 	AuthnHostToken
+	// AuthnDeviceToken i swhen authentication is done via the orbit identifier,
+	// which only allows limited access to the device's own host information.
+	// This authentication mode does not support granular authorization.
 	AuthnDeviceToken
 )
 

--- a/server/contexts/authz/authz.go
+++ b/server/contexts/authz/authz.go
@@ -35,7 +35,7 @@ const (
 	// authentication token. This authentication mode does not support granular
 	// authorization.
 	AuthnHostToken
-	// AuthnDeviceToken i swhen authentication is done via the orbit identifier,
+	// AuthnDeviceToken is when authentication is done via the orbit identifier,
 	// which only allows limited access to the device's own host information.
 	// This authentication mode does not support granular authorization.
 	AuthnDeviceToken

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/url"
 
+	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -101,8 +102,10 @@ func getAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet.Se
 }
 
 func (svc *Service) AppConfig(ctx context.Context) (*fleet.AppConfig, error) {
-	if err := svc.authz.Authorize(ctx, &fleet.AppConfig{}, fleet.ActionRead); err != nil {
-		return nil, err
+	if !svc.authz.IsAuthenticatedWith(ctx, authz_ctx.AuthnDeviceToken) {
+		if err := svc.authz.Authorize(ctx, &fleet.AppConfig{}, fleet.ActionRead); err != nil {
+			return nil, err
+		}
 	}
 
 	return svc.ds.AppConfig(ctx)

--- a/server/service/endpoint_middleware.go
+++ b/server/service/endpoint_middleware.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-kit/kit/log/level"
 	kithttp "github.com/go-kit/kit/transport/http"
 
+	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
 	"github.com/fleetdm/fleet/v4/server/contexts/token"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
@@ -56,6 +57,9 @@ func authenticatedDevice(svc fleet.Service, logger log.Logger, next endpoint.End
 
 		ctx = hostctx.NewContext(ctx, host)
 		instrumentHostLogger(ctx)
+		if ac, ok := authz_ctx.FromContext(ctx); ok {
+			ac.SetAuthnMethod(authz_ctx.AuthnDeviceToken)
+		}
 
 		resp, err := next(ctx, request)
 		if err != nil {
@@ -100,6 +104,9 @@ func authenticatedHost(svc fleet.Service, logger log.Logger, next endpoint.Endpo
 
 		ctx = hostctx.NewContext(ctx, host)
 		instrumentHostLogger(ctx)
+		if ac, ok := authz_ctx.FromContext(ctx); ok {
+			ac.SetAuthnMethod(authz_ctx.AuthnHostToken)
+		}
 
 		resp, err := next(ctx, request)
 		if err != nil {
@@ -154,6 +161,9 @@ func authenticatedUser(svc fleet.Service, next endpoint.Endpoint) endpoint.Endpo
 		}
 
 		ctx = viewer.NewContext(ctx, *v)
+		if ac, ok := authz_ctx.FromContext(ctx); ok {
+			ac.SetAuthnMethod(authz_ctx.AuthnUserToken)
+		}
 		return next(ctx, request)
 	}
 

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/authz"
+	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
@@ -270,7 +271,7 @@ func getHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service
 }
 
 func (svc *Service) GetHost(ctx context.Context, id uint) (*fleet.HostDetail, error) {
-	alreadyAuthd := svc.authz.IsAlreadyAuthorized(ctx)
+	alreadyAuthd := svc.authz.IsAuthenticatedWith(ctx, authz_ctx.AuthnDeviceToken)
 	if !alreadyAuthd {
 		// First ensure the user has access to list hosts, then check the specific
 		// host once team_id is loaded.
@@ -555,7 +556,7 @@ func refetchHostEndpoint(ctx context.Context, request interface{}, svc fleet.Ser
 }
 
 func (svc *Service) RefetchHost(ctx context.Context, id uint) error {
-	if !svc.authz.IsAlreadyAuthorized(ctx) {
+	if !svc.authz.IsAuthenticatedWith(ctx, authz_ctx.AuthnDeviceToken) {
 		if err := svc.authz.Authorize(ctx, &fleet.Host{}, fleet.ActionList); err != nil {
 			return err
 		}
@@ -671,7 +672,7 @@ func listHostDeviceMappingEndpoint(ctx context.Context, request interface{}, svc
 }
 
 func (svc *Service) ListHostDeviceMapping(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
-	if !svc.authz.IsAlreadyAuthorized(ctx) {
+	if !svc.authz.IsAuthenticatedWith(ctx, authz_ctx.AuthnDeviceToken) {
 		if err := svc.authz.Authorize(ctx, &fleet.Host{}, fleet.ActionList); err != nil {
 			return nil, err
 		}
@@ -715,7 +716,7 @@ func getMacadminsDataEndpoint(ctx context.Context, request interface{}, svc flee
 }
 
 func (svc *Service) MacadminsData(ctx context.Context, id uint) (*fleet.MacadminsData, error) {
-	if !svc.authz.IsAlreadyAuthorized(ctx) {
+	if !svc.authz.IsAuthenticatedWith(ctx, authz_ctx.AuthnDeviceToken) {
 		if err := svc.authz.Authorize(ctx, &fleet.Host{}, fleet.ActionList); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
#4416 , following a discussion on slack, the frontend work needs the org_logo_url to render the device-authenticated page, so this adds it as part of the GET device info as it's the only config field needed. Some changes were required to how we check (or rather, skip) for authorization when the request is device-authenticated, to make it safer to do so, I'll comment inline.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] ~~Changes file added (for user-visible changes)~~ (that's part of a bigger change that already has one)
- [ ] ~~Documented any API changes (docs/Using-Fleet/REST-API.md)~~ (not an API for user consumption)
- [ ] ~~Documented any permissions changes~~
- [ ] ~~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~~
- [x] Added/updated tests
- [ ] ~~Manual QA for all new/changed functionality~~
