### PR TITLE
4620 pin action dependencies

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -7,21 +7,24 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-binaries:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: 1.17
 
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
     - name: JS Dependency Cache
       id: js-cache
-      uses: actions/cache@v2
+      uses: actions/cache@661fd3eb7f2f20d8c7c84bc2b0509efd7a826628 # v2
       with:
         path: |
           **/node_modules
@@ -33,7 +36,7 @@ jobs:
 
     - name: Go Cache
       id: go-cache
-      uses: actions/cache@v2
+      uses: actions/cache@661fd3eb7f2f20d8c7c84bc2b0509efd7a826628 # v2
       with:
         # In order:
         # * Module download cache
@@ -65,7 +68,7 @@ jobs:
     - name: Build binaries
       run: make
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
       with:
         name: build
         path: build/

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,14 +41,14 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@883476649888a9e8e219d5b2e6b789dc024f690c # v1
       with:
         languages: ${{ matrix.language }}
         config-file: .github/workflows/config/codeql.yml
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@883476649888a9e8e219d5b2e6b789dc024f690c # v1

--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -19,7 +19,7 @@ jobs:
         node-version: [14.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
     # Configure our access credentials for the Heroku CLI
     - uses: akhileshns/heroku-deploy@cdd8fc68da4ad96ca0384cfa50d9e3eb2a6f6c1b # v3.6.8
@@ -32,7 +32,7 @@ jobs:
 
     # Set the Node.js version
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
     - uses: gaurav-nelson/github-action-markdown-link-check@9710f0fec812ce0a3b98bef4c9d842fc1f39d976 # v1.0.13
       with:
         use-quiet-mode: 'yes'

--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -42,12 +42,12 @@ jobs:
     steps:
 
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
     - name: Start tunnel
       env: 
@@ -111,7 +111,7 @@ jobs:
 
     - name: Upload fleet logs
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
       with:
         name: fleet-logs
         path: |
@@ -128,12 +128,12 @@ jobs:
     steps:
 
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
     - name: Build Fleetctl
       run: make fleetctl
@@ -166,12 +166,12 @@ jobs:
     steps:
 
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
     - name: Build and Run Orbit
       run: |
@@ -200,7 +200,7 @@ jobs:
 
     - name: Upload orbit logs
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
       with:
         name: orbit-${{ matrix.os }}-logs-${{ matrix.osqueryd-channel }}
         path: |
@@ -218,12 +218,12 @@ jobs:
     steps:
     
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
     - name: Build and Run Orbit
       shell: bash
@@ -250,7 +250,7 @@ jobs:
 
     - name: Upload orbit logs
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
       with:
         name: orbit-windows-logs-${{ matrix.osqueryd-channel }}
         path: |

--- a/.github/workflows/generate-osqueryd-app-tar-gz.yml
+++ b/.github/workflows/generate-osqueryd-app-tar-gz.yml
@@ -21,14 +21,14 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
       - name: Generate osqueryd.app.tar.gz
         run: |
           make osqueryd-app-tar-gz out-path=. version=$OSQUERY_VERSION
 
       - name: Upload osqueryd.app.tar.gz
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: osqueryd.app.tar.gz
           path: osqueryd.app.tar.gz

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -14,7 +14,7 @@ jobs:
     environment: Docker Hub
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
         with:
           fetch-depth: 0 # Needed for goreleaser
 
@@ -25,7 +25,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: 1.17.7
 

--- a/.github/workflows/goreleaser-orbit.yaml
+++ b/.github/workflows/goreleaser-orbit.yaml
@@ -14,7 +14,7 @@ jobs:
     environment: Docker Hub
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
       # Note that goreleaser does not like the orbit- prefixed flag unless you use the closed-source
       # paid version. We pay for goreleaser, but using the closed source build would weaken our
@@ -38,7 +38,7 @@ jobs:
           rm certificate.p12
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: 1.17
 

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -11,7 +11,7 @@ jobs:
     environment: Docker Hub
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
       - name: Login to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9 # v1.10.0
@@ -20,7 +20,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: 1.17.2
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -209,14 +209,14 @@ jobs:
         mv fleet-osquery.msi orbit-${{ matrix.orbit-channel }}-osqueryd-${{ matrix.osqueryd-channel }}.msi
 
     - name: Upload MSI
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
       with:
         name: orbit-${{ matrix.orbit-channel }}-osqueryd-${{ matrix.osqueryd-channel }}.msi
         path: orbit-${{ matrix.orbit-channel }}-osqueryd-${{ matrix.osqueryd-channel }}.msi
 
     - name: Debug on failure
       if: failure()
-      uses: mxschmitt/action-tmate@v3
+      uses: mxschmitt/action-tmate@8b4e4ac71822ed7e0ad5fb3d1c33483e9e8fb270 # v3
 
   orbit-windows:
     timeout-minutes: 15
@@ -235,7 +235,7 @@ jobs:
 
     - name: Download MSI
       id: download
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@f023be2c48cc18debc3bacd34cb396e0295e2869 # v2
       with:
         name: orbit-${{ matrix.orbit-channel }}-osqueryd-${{ matrix.osqueryd-channel }}.msi
     

--- a/.github/workflows/pr-helm.yaml
+++ b/.github/workflows/pr-helm.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: create temp dir
       run: mkdir -p helm-temp
     - name: helm template -- default values
@@ -40,7 +40,7 @@ jobs:
           > helm-temp/${FILE}
         done
     - name: kubeval sanity check
-      uses: instrumenta/kubeval-action@master
+      uses: instrumenta/kubeval-action@5915e4adba5adccac07cb156b82e54c3fed74921 # master
       with:
         files: helm-temp
         version: ${{ matrix.kube-version }}

--- a/.github/workflows/push-osquery-perf-to-ecr.yml
+++ b/.github/workflows/push-osquery-perf-to-ecr.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
         
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2 # v1
         with:
           aws-access-key-id: ${{ secrets.LOADTEST_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.LOADTEST_AWS_SECRET_ACCESS_KEY }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@aaf69d68aa3fb14c1d5a6be9ac61fe15b48453a2 # v1
 
       - name: Build, tag, and push image to Amazon ECR
         env:

--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -11,7 +11,7 @@ jobs:
   publish-chart:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - uses: stefanprodan/helm-gh-pages@f1701eb82e4d4b82016e7965501c8b6d79feaec9
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semgrep-analysis.yml
+++ b/.github/workflows/semgrep-analysis.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout project source
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
       # Scan code using project's configuration on https://semgrep.dev/manage
-      - uses: returntocorp/semgrep-action@v1
+      - uses: returntocorp/semgrep-action@b4ae418326a5e8bd4fc3b0b658695aee09ca0e2a # v1
         with:
           publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
           publishDeployment: ${{ secrets.SEMGREP_DEPLOYMENT_ID }}

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
     # Pre-starting dependencies here means they are ready to go when we need them.
     - name: Start Infra Dependencies
@@ -61,13 +61,13 @@ jobs:
         NETWORK_TEST=1 REDIS_TEST=1 MYSQL_TEST=1 RACE_ENABLED=$RACE_ENABLED GO_TEST_TIMEOUT=$GO_TEST_TIMEOUT make test-go
 
     - name: Upload to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2
       with:
         files: coverage.txt
 
     - name: Slack Notification
       if: github.event.schedule == '0 4 * * *' && failure()
-      uses: slackapi/slack-github-action@v1.18.0
+      uses: slackapi/slack-github-action@16b6c78ee73689a627b65332b34e5d409c7299da # v1.18.0
       with:
         payload: |
           {

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -35,12 +35,12 @@ jobs:
       run: docker pull fleetdm/wix:latest &
 
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
     # It seems faster not to cache Go dependencies
     - name: Install Go Dependencies

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -16,11 +16,11 @@ jobs:
         node-version: [14.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
     # Set the Node.js version
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,15 +33,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
       with:
         node-version: '14'
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
     # Pre-starting dependencies here means they are ready to go when we need them.
     - name: Start Infra Dependencies
@@ -50,7 +50,7 @@ jobs:
 
     - name: JS Dependency Cache
       id: js-cache
-      uses: actions/cache@v2
+      uses: actions/cache@661fd3eb7f2f20d8c7c84bc2b0509efd7a826628 # v2
       with:
         path: |
           **/node_modules
@@ -63,7 +63,7 @@ jobs:
 
     - name: Go Cache
       id: go-cache
-      uses: actions/cache@v2
+      uses: actions/cache@661fd3eb7f2f20d8c7c84bc2b0509efd7a826628 # v2
       with:
         # In order:
         # * Module download cache
@@ -105,7 +105,7 @@ jobs:
 
     - name: Upload artifacts
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
       with:
         name: cypress
         path: |
@@ -121,11 +121,11 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
     - name: JS Dependency Cache
       id: js-cache
-      uses: actions/cache@v2
+      uses: actions/cache@661fd3eb7f2f20d8c7c84bc2b0509efd7a826628 # v2
       with:
         path: |
           **/node_modules
@@ -151,11 +151,11 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
     - name: JS Dependency Cache
       id: js-cache
-      uses: actions/cache@v2
+      uses: actions/cache@661fd3eb7f2f20d8c7c84bc2b0509efd7a826628 # v2
       with:
         path: |
           **/node_modules


### PR DESCRIPTION
I have edited pretty much every GitHub workflow to pin dependencies with a hash.

Putting multiple reviewers on this one - for example @eashaw will be more interested and able to review those that relate to the website, but I don't expect @eashaw to review all of them, so I will not merge until I get at least 2-3 reviews.

This closes #4620 - and once this is done, I will move on to reducing the permissions workflows have, and tracking any harder things to fix with individual issues.
