### PR TITLE
Fleet desktop: Fix device user cannot "view all hosts" on software table

### DIFF
--- a/frontend/pages/hosts/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/DeviceUserPage/DeviceUserPage.tsx
@@ -255,7 +255,13 @@ const DeviceUserPage = ({
   };
 
   const renderSoftware = () => {
-    return <SoftwareTab isLoading={isLoadingHost} software={hostSoftware} />;
+    return (
+      <SoftwareTab
+        isLoading={isLoadingHost}
+        software={hostSoftware}
+        deviceUser
+      />
+    );
   };
 
   const renderRefetch = () => {

--- a/frontend/pages/hosts/SoftwareTab/SoftwareTab.tsx
+++ b/frontend/pages/hosts/SoftwareTab/SoftwareTab.tsx
@@ -18,11 +18,13 @@ const baseClass = "host-details";
 interface ISoftwareTableProps {
   isLoading: boolean;
   software: ISoftware[];
+  deviceUser?: boolean;
 }
 
 const SoftwareTable = ({
   isLoading,
   software,
+  deviceUser,
 }: ISoftwareTableProps): JSX.Element => {
   const [filterName, setFilterName] = useState("");
   const [filterVuln, setFilterVuln] = useState(false);
@@ -58,7 +60,7 @@ const SoftwareTable = ({
     );
   };
 
-  const tableHeaders = generateSoftwareTableHeaders();
+  const tableHeaders = generateSoftwareTableHeaders(deviceUser);
 
   return (
     <div className="section section--software">

--- a/frontend/pages/hosts/SoftwareTab/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/SoftwareTab/SoftwareTableConfig.tsx
@@ -72,8 +72,8 @@ const formatSoftwareType = (source: string) => {
 
 // NOTE: cellProps come from react-table
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
-const generateSoftwareTableHeaders = (): IDataColumn[] => {
-  return [
+const generateSoftwareTableHeaders = (deviceUser = false): IDataColumn[] => {
+  const tableHeaders: IDataColumn[] = [
     {
       title: "Vulnerabilities",
       Header: "",
@@ -218,6 +218,13 @@ const generateSoftwareTableHeaders = (): IDataColumn[] => {
       disableHidden: true,
     },
   ];
+
+  // Device user cannot view all hosts software
+  if (deviceUser) {
+    tableHeaders.pop();
+  }
+
+  return tableHeaders;
 };
 
 export default generateSoftwareTableHeaders;


### PR DESCRIPTION
Cerra #4092

- Device user: Remove link on software table to view all hosts with that software

Screenshot of fix:
<img width="1411" alt="Screen Shot 2022-03-21 at 12 08 31 PM" src="https://user-images.githubusercontent.com/71795832/159302879-73e0c17f-4418-4131-a780-b3f8f685f464.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
