### PR TITLE
Ignore FleetDM GitHub project URLs when checking Markdown links

### DIFF
--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -41,6 +41,9 @@
     },
     {
       "pattern": "angel.co"
+    },
+    {
+      "pattern": "github.com/orgs/fleetdm/projects"
     }
   ],
   "retryOn429": true,

--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -43,7 +43,7 @@
       "pattern": "angel.co"
     },
     {
-      "pattern": "github.com/orgs/fleetdm/projects"
+      "pattern": "github.com/orgs/fleetdm/projects/(34|31|30|28|26|23|22|21|19|16|14|13|12|11|9|4|3|1)(\D|$)"
     }
   ],
   "retryOn429": true,


### PR DESCRIPTION
Changes: 
- Added Fleet's GitHub project boards to the Markdown link check's `ignorePatterns`
