### PR TITLE
Securing desktop github workflow

### DIFF
--- a/.github/workflows/generate-desktop-app-tar-gz.yml
+++ b/.github/workflows/generate-desktop-app-tar-gz.yml
@@ -16,17 +16,20 @@ on:
 env:
   FLEET_DESKTOP_VERSION: 0.0.1
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: macos-latest
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: '^1.17.0'
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
       - name: Import signing keys
         env:
@@ -42,7 +45,6 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $KEYCHAIN_PASSWORD build.keychain
           security find-identity -vv
           rm certificate.p12
-
       - name: Generate desktop.app.tar.gz
         env:
           AC_USERNAME: ${{ secrets.APPLE_USERNAME }}
@@ -54,9 +56,8 @@ jobs:
           FLEET_DESKTOP_APPLE_AUTHORITY=$CODESIGN_IDENTITY \
           FLEET_DESKTOP_VERSION=$FLEET_DESKTOP_VERSION \
           make desktop-app-tar-gz
-
       - name: Upload desktop.app.tar.gz
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: desktop.app.tar.gz
           path: desktop.app.tar.gz


### PR DESCRIPTION
Pinning the dependencies and putting an explicit read only permission on the new desktop github workflow
