### PR TITLE
Replace uses of ansi quotes (") in SQL statements

### DIFF
--- a/server/datastore/mysql/aggregated_stats_test.go
+++ b/server/datastore/mysql/aggregated_stats_test.go
@@ -3,12 +3,11 @@ package mysql
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"strings"
-	"time"
-
-	"math"
 	"testing"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/stretchr/testify/assert"
@@ -114,11 +113,11 @@ func TestAggregatedStats(t *testing.T) {
 					`
 select 
        id, 
-       JSON_EXTRACT(json_value, "$.user_time_p50") as user_time_p50, 
-       JSON_EXTRACT(json_value, "$.user_time_p95") as user_time_p95,
-       JSON_EXTRACT(json_value, "$.system_time_p50") as system_time_p50, 
-       JSON_EXTRACT(json_value, "$.system_time_p95") as system_time_p95,
-       JSON_EXTRACT(json_value, "$.total_executions") as total_executions
+       JSON_EXTRACT(json_value, '$.user_time_p50') as user_time_p50, 
+       JSON_EXTRACT(json_value, '$.user_time_p95') as user_time_p95,
+       JSON_EXTRACT(json_value, '$.system_time_p50') as system_time_p50, 
+       JSON_EXTRACT(json_value, '$.system_time_p95') as system_time_p95,
+       JSON_EXTRACT(json_value, '$.total_executions') as total_executions
 from aggregated_stats where type=?`, tt.aggregate))
 
 			require.True(t, len(stats) > 0)

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1074,7 +1074,7 @@ func (ds *Datastore) ListPoliciesForHost(ctx context.Context, host *fleet.Host) 
 	LEFT JOIN policy_membership pm ON (p.id=pm.policy_id AND host_id=?)
 	LEFT JOIN users u ON p.author_id = u.id
 	WHERE (p.team_id IS NULL OR p.team_id = (select team_id from hosts WHERE id = ?))
-	AND (p.platforms IS NULL OR p.platforms = "" OR FIND_IN_SET(?, p.platforms) != 0)`
+	AND (p.platforms IS NULL OR p.platforms = '' OR FIND_IN_SET(?, p.platforms) != 0)`
 
 	var policies []*fleet.HostPolicy
 	if err := sqlx.SelectContext(ctx, ds.reader, &policies, query, host.ID, host.ID, host.FleetPlatform()); err != nil {

--- a/server/datastore/mysql/migrations/tables/20171116163618_CreateTableOsqueryOptions.go
+++ b/server/datastore/mysql/migrations/tables/20171116163618_CreateTableOsqueryOptions.go
@@ -46,7 +46,7 @@ func Up_20171116163618(tx *sql.Tx) error {
 		// Insert default options
 		_, err = tx.Exec("INSERT INTO `osquery_options`" +
 			"(override_type, override_identifier, options)" +
-			`VALUES (0, "", '{"options": {"logger_plugin": "tls", "pack_delimiter": "/", "logger_tls_period": 10, "distributed_plugin": "tls", "disable_distributed": false, "logger_tls_endpoint": "/api/v1/osquery/log", "distributed_interval": 10, "distributed_tls_max_attempts": 3}, "decorators": {"load": ["SELECT uuid AS host_uuid FROM system_info;", "SELECT hostname AS hostname FROM system_info;"]}}')`,
+			`VALUES (0, '', '{"options": {"logger_plugin": "tls", "pack_delimiter": "/", "logger_tls_period": 10, "distributed_plugin": "tls", "disable_distributed": false, "logger_tls_endpoint": "/api/v1/osquery/log", "distributed_interval": 10, "distributed_tls_max_attempts": 3}, "decorators": {"load": ["SELECT uuid AS host_uuid FROM system_info;", "SELECT hostname AS hostname FROM system_info;"]}}')`,
 		)
 		if err != nil {
 			return errors.Wrap(err, "insert options")
@@ -73,7 +73,7 @@ func migrateOptions(tx *sql.Tx) error {
 	query := `
 		SELECT *
 		FROM options
-		WHERE value != "null"
+		WHERE value != 'null'
 	`
 	// Intentionally initialize empty instead of nil so that we generate a
 	// config with empty options rather than a null value.

--- a/server/datastore/mysql/migrations/tables/20211116184030_PolicyWithProprietaryQuery.go
+++ b/server/datastore/mysql/migrations/tables/20211116184030_PolicyWithProprietaryQuery.go
@@ -59,7 +59,7 @@ func Up_20211116184030(tx *sql.Tx) error {
 	}
 	query, args, err := sqlx.In(`
         UPDATE policies
-		SET name = CONCAT(name, " (", CONVERT(id, CHAR) ,")")
+		SET name = CONCAT(name, ' (', CONVERT(id, CHAR) ,')')
 		WHERE query_id IN (?)`,
 		queryIDs,
 	)

--- a/server/datastore/mysql/queries.go
+++ b/server/datastore/mysql/queries.go
@@ -179,14 +179,14 @@ func (ds *Datastore) ListQueries(ctx context.Context, opt fleet.ListQueryOptions
 		       q.*,
 		       COALESCE(u.name, '<deleted>') AS author_name,
 		       COALESCE(u.email, '') AS author_email,
-		       JSON_EXTRACT(json_value, "$.user_time_p50") as user_time_p50,
-		       JSON_EXTRACT(json_value, "$.user_time_p95") as user_time_p95,
-		       JSON_EXTRACT(json_value, "$.system_time_p50") as system_time_p50,
-		       JSON_EXTRACT(json_value, "$.system_time_p95") as system_time_p95,
-					 JSON_EXTRACT(json_value, "$.total_executions") as total_executions
+		       JSON_EXTRACT(json_value, '$.user_time_p50') as user_time_p50,
+		       JSON_EXTRACT(json_value, '$.user_time_p95') as user_time_p95,
+		       JSON_EXTRACT(json_value, '$.system_time_p50') as system_time_p50,
+		       JSON_EXTRACT(json_value, '$.system_time_p95') as system_time_p95,
+					 JSON_EXTRACT(json_value, '$.total_executions') as total_executions
 		FROM queries q
 		LEFT JOIN users u ON (q.author_id = u.id)
-		LEFT JOIN aggregated_stats ag ON (ag.id=q.id AND ag.type="query")
+		LEFT JOIN aggregated_stats ag ON (ag.id=q.id AND ag.type='query')
 		WHERE saved = true
 	`
 	if opt.OnlyObserverCanRun {

--- a/server/datastore/mysql/scheduled_queries.go
+++ b/server/datastore/mysql/scheduled_queries.go
@@ -28,14 +28,14 @@ func (ds *Datastore) ListScheduledQueriesInPackWithStats(ctx context.Context, id
 			sq.denylist,
 			q.query,
 			q.id AS query_id,
-			JSON_EXTRACT(ag.json_value, "$.user_time_p50") as user_time_p50,
-			JSON_EXTRACT(ag.json_value, "$.user_time_p95") as user_time_p95,
-			JSON_EXTRACT(ag.json_value, "$.system_time_p50") as system_time_p50,
-			JSON_EXTRACT(ag.json_value, "$.system_time_p95") as system_time_p95,
-			JSON_EXTRACT(ag.json_value, "$.total_executions") as total_executions
+			JSON_EXTRACT(ag.json_value, '$.user_time_p50') as user_time_p50,
+			JSON_EXTRACT(ag.json_value, '$.user_time_p95') as user_time_p95,
+			JSON_EXTRACT(ag.json_value, '$.system_time_p50') as system_time_p50,
+			JSON_EXTRACT(ag.json_value, '$.system_time_p95') as system_time_p95,
+			JSON_EXTRACT(ag.json_value, '$.total_executions') as total_executions
 		FROM scheduled_queries sq
 		JOIN queries q ON (sq.query_name = q.name)
-		LEFT JOIN aggregated_stats ag ON (ag.id=sq.id AND ag.type="scheduled_query")
+		LEFT JOIN aggregated_stats ag ON (ag.id=sq.id AND ag.type='scheduled_query')
 		WHERE sq.pack_id = ?
 	`
 	query = appendListOptionsToSQL(query, opts)


### PR DESCRIPTION
I ran into some issues around the use of `"` in SQL statements after migrating our database to a Digitalocean managed MySQL 8 database which, by default, enables the `ANSI_QUOTES` SQL mode. This was leading to issues loading Queries and Hosts (The hosts information pages were failing to load due to issues looking up queries) pages.

This PR, I believe, replaces the use of double quotes with single quotes for all the SQL statements that were quoting values. I did some grepping and manual auditing of all the various `datastore/mysql/*` files and believe I got all of them.

Also, This open issue (#3176) mentions this behavior occurring when running DB migrations (which I did encounter after dropping and attempting to recreate our DB) and I was able to find all of the affected migrations and update them. The changes were tested by performing the `fleetctl prepare db` against a MySQL 8 database with ansi_quotes mode enabled.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [X] Manual QA for all new/changed functionality
