### PR TITLE
Fleetctl preview to clean up osquery socket before starting orbit

### DIFF
--- a/changes/4711-fleetctl-preview-cleanup-osquery-socket
+++ b/changes/4711-fleetctl-preview-cleanup-osquery-socket
@@ -1,0 +1,1 @@
+* Fleetctl preview to clean up osquery socket files before running fleet-osquery.

--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -689,7 +689,7 @@ func cleanUpSocketFiles(path string) error {
 			continue
 		}
 		entryPath := filepath.Join(path, entry.Name())
-		if err := os.RemoveAll(entryPath); err != nil {
+		if err := os.Remove(entryPath); err != nil {
 			return fmt.Errorf("remove %q: %w", entryPath, err)
 		}
 	}


### PR DESCRIPTION
#4711 is hard to reproduce (it's sporadic AFAICS), but once you hit the issue, this version of `fleetctl` that performs the cleanup solves the issue.

- [X] Changes file added (for user-visible changes)
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality

