### PR TITLE
Fix sentence casing on login

### DIFF
--- a/cypress/integration/all/sessions/sso.spec.ts
+++ b/cypress/integration/all/sessions/sso.spec.ts
@@ -27,7 +27,7 @@ describe("SSO Sessions", () => {
     cy.logout();
     cy.visit("/");
     // Log in
-    cy.contains("button", "Sign On With SimpleSAML");
+    cy.contains("button", "Sign on with SimpleSAML");
     cy.loginSSO();
     cy.contains("Hosts");
   });
@@ -36,7 +36,7 @@ describe("SSO Sessions", () => {
     cy.setupSSO();
     cy.logout();
     cy.visit("/");
-    cy.contains("button", "Sign On With SimpleSAML");
+    cy.contains("button", "Sign on with SimpleSAML");
     cy.loginSSO();
     // Log in should fail
     cy.contains("Password");

--- a/docs/Contributing/Testing.md
+++ b/docs/Contributing/Testing.md
@@ -294,7 +294,7 @@ Email: sso_user2@example.com
 Password: user123#
 ```
 
-Use the Fleet UI to invite one of these users with the associated email. Be sure the "Enable single sign on" box is checked for that user. Now after accepting the invitation, you should be able to log in as that user by clicking "Sign On with SimpleSAML" on the login page.
+Use the Fleet UI to invite one of these users with the associated email. Be sure the "Enable single sign on" box is checked for that user. Now after accepting the invitation, you should be able to log in as that user by clicking "Sign on with SimpleSAML" on the login page.
 
 To add additional users, modify [tools/saml/users.php](https://github.com/fleetdm/fleet/tree/main/tools/saml/users.php) and restart the `simplesaml` container.
 

--- a/frontend/components/forms/LoginForm/LoginForm.jsx
+++ b/frontend/components/forms/LoginForm/LoginForm.jsx
@@ -47,7 +47,7 @@ class LoginForm extends Component {
 
     let legend = "Single sign on";
     if (idpName !== "") {
-      legend = `Sign On With ${idpName}`;
+      legend = `Sign on with ${idpName}`;
     }
     if (imageURL !== "") {
       legend = showLegendWithImage(imageURL, idpName);
@@ -96,7 +96,7 @@ class LoginForm extends Component {
               className={`${baseClass}__forgot-link`}
               to={paths.FORGOT_PASSWORD}
             >
-              Forgot Password?
+              Forgot password?
             </Link>
           </div>
           <Button


### PR DESCRIPTION
Cerra #4721 

- Fix sentence casing in "Forgot password?"
- Fix sentence casing in "Sign on with ${idpName}"
- Fix related docs

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
