### PR TITLE
DeviceUserPage: Remove vuln count detail for device user, fix padding/margins

### DIFF
--- a/frontend/pages/hosts/SoftwareTab/SoftwareTab.tsx
+++ b/frontend/pages/hosts/SoftwareTab/SoftwareTab.tsx
@@ -68,7 +68,12 @@ const SoftwareTable = ({
 
       {software?.length ? (
         <>
-          {software && <SoftwareVulnCount softwareList={software} />}
+          {software && (
+            <SoftwareVulnCount
+              softwareList={software}
+              deviceUser={deviceUser}
+            />
+          )}
           {software && (
             <TableContainer
               columns={tableHeaders}

--- a/frontend/pages/hosts/SoftwareTab/SoftwareVulnCount/SoftwareVulnCount.tsx
+++ b/frontend/pages/hosts/SoftwareTab/SoftwareVulnCount/SoftwareVulnCount.tsx
@@ -7,11 +7,13 @@ const baseClass = "software-vuln-count";
 
 interface ISoftwareVulnCountProps {
   softwareList: ISoftware[];
+  deviceUser?: boolean;
 }
 
 const SoftwareVulnCount = ({
   softwareList,
-}: ISoftwareVulnCountProps): JSX.Element | null => {
+  deviceUser,
+}: ISoftwareVulnCountProps): JSX.Element => {
   const vulnCount = softwareList.reduce((sum, software) => {
     return software.vulnerabilities
       ? sum + software.vulnerabilities.length
@@ -26,12 +28,16 @@ const SoftwareVulnCount = ({
           ? "1 vulnerability detected"
           : `${vulnCount} vulnerabilities detected`}
       </div>
-      <p>
-        Click a vulnerable item below to see the associated Common
-        Vulnerabilites and Exposures (CVEs).
-      </p>
+      {!deviceUser && (
+        <p>
+          Click a vulnerable item below to see the associated Common
+          Vulnerabilites and Exposures (CVEs).
+        </p>
+      )}
     </div>
-  ) : null;
+  ) : (
+    <></>
+  );
 };
 
 export default SoftwareVulnCount;

--- a/frontend/pages/hosts/SoftwareTab/SoftwareVulnCount/_styles.scss
+++ b/frontend/pages/hosts/SoftwareTab/SoftwareVulnCount/_styles.scss
@@ -7,12 +7,11 @@
   overflow: auto;
   margin-bottom: $pad-large;
   padding: $pad-large;
-  padding-bottom: $pad-small;
 
   p {
     padding-left: $pad-large;
     margin-top: $pad-medium;
-    margin-bottom: $pad-medium;
+    margin-bottom: 0;
   }
 
   img {


### PR DESCRIPTION
Cerra #4092

Bug fix for comment (no issue filed): https://github.com/fleetdm/fleet/issues/4092#issuecomment-1075587016

QA fix:
- Remove vuln count detail for device user
- Fix padding/margin of software vuln count

Screenshot of HostDetailsPage vs. DeviceUserPage
<img width="1344" alt="Screen Shot 2022-03-22 at 4 31 48 PM" src="https://user-images.githubusercontent.com/71795832/159570928-b4bd506f-a48d-482b-af1d-757df99d6e4b.png">
<img width="1336" alt="Screen Shot 2022-03-22 at 4 31 08 PM" src="https://user-images.githubusercontent.com/71795832/159570932-5d108422-58f1-4f0c-850a-d70dc59c61ab.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
