### PR TITLE
Fix `Datastore.DeleteHosts` to delete all associated tables

### DIFF
--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -309,6 +309,23 @@ func loadHostUsersDB(ctx context.Context, db sqlx.QueryerContext, hostID uint) (
 	return users, nil
 }
 
+// hostRefs are the tables referenced by hosts.
+//
+// Defined here for testing purposes.
+var hostRefs = []string{
+	"host_seen_times",
+	"host_software",
+	"host_users",
+	"host_emails",
+	"host_additional",
+	"scheduled_query_stats",
+	"label_membership",
+	"policy_membership",
+	"host_mdm",
+	"host_munki_info",
+	"host_device_auth",
+}
+
 func (ds *Datastore) DeleteHost(ctx context.Context, hid uint) error {
 	delHostRef := func(tx sqlx.ExtContext, table string) error {
 		_, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE host_id=?`, table), hid)
@@ -322,20 +339,6 @@ func (ds *Datastore) DeleteHost(ctx context.Context, hid uint) error {
 		_, err := tx.ExecContext(ctx, `DELETE FROM hosts WHERE id = ?`, hid)
 		if err != nil {
 			return ctxerr.Wrapf(ctx, err, "delete host")
-		}
-
-		hostRefs := []string{
-			"host_seen_times",
-			"host_software",
-			"host_users",
-			"host_emails",
-			"host_additional",
-			"scheduled_query_stats",
-			"label_membership",
-			"policy_membership",
-			"host_mdm",
-			"host_munki_info",
-			"host_device_auth",
 		}
 
 		for _, table := range hostRefs {
@@ -1018,41 +1021,11 @@ func (ds *Datastore) TotalAndUnseenHostsSince(ctx context.Context, daysCount int
 }
 
 func (ds *Datastore) DeleteHosts(ctx context.Context, ids []uint) error {
-	_, err := ds.deleteEntities(ctx, hostsTable, ids)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "deleting hosts")
+	for _, id := range ids {
+		if err := ds.DeleteHost(ctx, id); err != nil {
+			return ctxerr.Wrapf(ctx, err, "delete host %d", id)
+		}
 	}
-
-	query, args, err := sqlx.In(`DELETE FROM host_seen_times WHERE host_id in (?)`, ids)
-	if err != nil {
-		return ctxerr.Wrapf(ctx, err, "building delete host_seen_times query")
-	}
-
-	_, err = ds.writer.ExecContext(ctx, query, args...)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "deleting host seen times")
-	}
-
-	query, args, err = sqlx.In(`DELETE FROM host_emails WHERE host_id in (?)`, ids)
-	if err != nil {
-		return ctxerr.Wrapf(ctx, err, "building delete host_emails query")
-	}
-
-	_, err = ds.writer.ExecContext(ctx, query, args...)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "deleting host emails")
-	}
-
-	query, args, err = sqlx.In(`DELETE FROM pack_targets WHERE type=? AND target_id in (?)`, fleet.TargetHost, ids)
-	if err != nil {
-		return ctxerr.Wrapf(ctx, err, "building delete pack_targets query")
-	}
-
-	_, err = ds.writer.ExecContext(ctx, query, args...)
-	if err != nil {
-		return ctxerr.Wrapf(ctx, err, "deleting pack_targets for hosts")
-	}
-
 	return nil
 }
 

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -196,6 +196,10 @@ type Datastore interface {
 
 	TotalAndUnseenHostsSince(ctx context.Context, daysCount int) (total int, unseen int, err error)
 
+	// DeleteHosts deletes associated tables for multiple hosts.
+	//
+	// It atomically deletes each host but if it returns an error, some of the hosts may be
+	// deleted and others not.
 	DeleteHosts(ctx context.Context, ids []uint) error
 
 	CountHosts(ctx context.Context, filter TeamFilter, opt HostListOptions) (int, error)


### PR DESCRIPTION
#4736

~- [ ] Changes file added (for user-visible changes)~
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
