### PR TITLE
Fix broken link in README.md

### DIFF
--- a/handbook/README.md
+++ b/handbook/README.md
@@ -54,7 +54,7 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [How we protect end-user devices](./security.md#how-we-protect-end-user-devices)
 
-[How we secure GitHub](./security.md#github-security)
+[How we secure GitHub](./security.md#git-hub-security)
 
 [Google Workspace security](./security.md#google-workspace-security)
 


### PR DESCRIPTION
Since headings from markdown in the handbook have snake-case IDs, GitHub becomes git-hub.