### PR TITLE
chore(test): rewritten icon components test using rtl

### DIFF
--- a/frontend/components/icons/FleetIcon/FleetIcon.tests.jsx
+++ b/frontend/components/icons/FleetIcon/FleetIcon.tests.jsx
@@ -1,10 +1,13 @@
 import React from "react";
-import { mount } from "enzyme";
+import { render } from "@testing-library/react";
 
 import FleetIcon from "./FleetIcon";
 
 describe("FleetIcon - component", () => {
   it("renders", () => {
-    expect(mount(<FleetIcon name="success-check" />)).toBeTruthy();
+    const { container } = render(<FleetIcon name="success-check" />);
+    expect(
+      container.querySelector(".fleeticon-success-check")
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/components/icons/OrgLogoIcon/OrgLogoIcon.tests.jsx
+++ b/frontend/components/icons/OrgLogoIcon/OrgLogoIcon.tests.jsx
@@ -1,19 +1,23 @@
 import React from "react";
-import { mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
 
 import fleetAvatar from "../../../../assets/images/fleet-avatar-24x24@2x.png";
 import OrgLogoIcon from "./OrgLogoIcon";
 
 describe("OrgLogoIcon - component", () => {
   it("renders the Fleet Logo by default", () => {
-    const component = mount(<OrgLogoIcon />);
+    render(<OrgLogoIcon />);
 
-    expect(component.state("imageSrc")).toEqual(fleetAvatar);
+    // expect(component.state("imageSrc")).toEqual(fleetAvatar);
+    expect(screen.getByRole("img")).toHaveAttribute("src", fleetAvatar);
   });
 
   it("renders the image source when it is valid", () => {
-    const component = mount(<OrgLogoIcon src="/assets/images/avatar.svg" />);
+    render(<OrgLogoIcon src="/assets/images/avatar.svg" />);
 
-    expect(component.state("imageSrc")).toEqual("/assets/images/avatar.svg");
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "src",
+      "/assets/images/avatar.svg"
+    );
   });
 });

--- a/frontend/components/icons/PlatformIcon/PlatformIcon.tests.jsx
+++ b/frontend/components/icons/PlatformIcon/PlatformIcon.tests.jsx
@@ -1,16 +1,18 @@
 import React from "react";
-import { mount } from "enzyme";
+import { render } from "@testing-library/react";
 
 import PlatformIcon from "./PlatformIcon";
 
 describe("PlatformIcon - component", () => {
   it("renders", () => {
-    expect(mount(<PlatformIcon name="linux" />).length).toEqual(1);
+    const { container } = render(<PlatformIcon name="linux" />);
+    expect(container.querySelector(".platform-icon")).toBeInTheDocument();
   });
 
   it("renders text if no icon", () => {
-    const component = mount(<PlatformIcon name="All" />);
-
-    expect(component.find(".fleeticon-single-host").length).toEqual(1);
+    const { container } = render(<PlatformIcon name="All" />);
+    expect(
+      container.querySelector(".fleeticon-single-host")
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Checklist for submitter

This PR updates the test of the following components to use rtl

1. FleetIcon
2. OrgLogoIcon
3. PlatformIcon

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [ ] Documented any permissions changes
- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [ ] Manual QA for all new/changed functionality
