### PR TITLE
Fix styling of errors tab for live policy results page

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
@@ -266,10 +266,12 @@ const QueryResults = ({
           <TabList>
             <Tab className={firstTabClass}>{NAV_TITLES.RESULTS}</Tab>
             <Tab disabled={!errors?.length}>
-              {errors?.length > 0 && (
-                <span className="count">{errors.length}</span>
-              )}
-              {NAV_TITLES.ERRORS}
+              <span>
+                {errors?.length > 0 && (
+                  <span className="count">{errors.length}</span>
+                )}
+                {NAV_TITLES.ERRORS}
+              </span>
             </Tab>
           </TabList>
           <TabPanel>{renderTable()}</TabPanel>


### PR DESCRIPTION
Cerra #4543 

- Error count lines up with errors in the tab (Exact same work as #4599 but for live policy page)

Screenshot of fix:
<img width="1193" alt="Screen Shot 2022-03-23 at 1 05 44 PM" src="https://user-images.githubusercontent.com/71795832/159756000-3af513e2-52b0-42ae-b5d5-b6c03abc4112.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
