### PR TITLE
Live query percent fix

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
@@ -66,10 +66,8 @@ const QueryResults = ({
 
   useEffect(() => {
     const calculatePercent =
-      campaign.totals && campaign.totals.online !== 0
-        ? Math.round(
-            (campaign.hosts_count.total / campaign.totals.online) * 100
-          )
+      targetsTotalCount !== 0
+        ? Math.round((campaign.hosts_count.total / targetsTotalCount) * 100)
         : 0;
     setTargetsRespondedPercent(calculatePercent);
   }, [campaign]);
@@ -252,8 +250,7 @@ const QueryResults = ({
         <h1>{pageTitle}</h1>
         <div className={`${baseClass}__text-wrapper`}>
           <span>{targetsTotalCount}</span>&nbsp;hosts targeted&nbsp; (
-          {targetsRespondedPercent}% of{" "}
-          {campaign.totals ? campaign.totals.online : 0} online hosts&nbsp;
+          {targetsRespondedPercent}%&nbsp;
           <TooltipWrapper
             tipContent={`
                 Hosts that respond may<br /> return results, errors, or <br />no results`}
@@ -269,10 +266,12 @@ const QueryResults = ({
           <TabList>
             <Tab className={firstTabClass}>{NAV_TITLES.RESULTS}</Tab>
             <Tab disabled={!errors?.length}>
-              {errors?.length > 0 && (
-                <span className="count">{errors.length}</span>
-              )}
-              {NAV_TITLES.ERRORS}
+              <span>
+                {errors?.length > 0 && (
+                  <span className="count">{errors.length}</span>
+                )}
+                {NAV_TITLES.ERRORS}
+              </span>
             </Tab>
           </TabList>
           <TabPanel>{renderTable()}</TabPanel>

--- a/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
@@ -64,11 +64,15 @@ const QueryResults = ({
     setTargetsRespondedPercent,
   ] = useState<number>(0);
 
+  console.log("campaign", campaign);
+
   useEffect(() => {
     const calculatePercent =
-      Math.round(
-        ((totalRowsCount + errors?.length) / targetsTotalCount) * 100
-      ) || 0;
+      campaign.totals && campaign.totals.online !== 0
+        ? Math.round(
+            (campaign.hosts_count.successful / campaign.totals.online) * 100
+          )
+        : 0;
     setTargetsRespondedPercent(calculatePercent);
   }, [totalRowsCount, errors]);
 
@@ -250,7 +254,8 @@ const QueryResults = ({
         <h1>{pageTitle}</h1>
         <div className={`${baseClass}__text-wrapper`}>
           <span>{targetsTotalCount}</span>&nbsp;hosts targeted&nbsp; (
-          {targetsRespondedPercent}%&nbsp;
+          {targetsRespondedPercent}% of{" "}
+          {campaign.totals ? campaign.totals.online : 0} online hosts&nbsp;
           <TooltipWrapper
             tipContent={`
                 Hosts that respond may<br /> return results, errors, or <br />no results`}

--- a/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
@@ -68,7 +68,7 @@ const QueryResults = ({
     const calculatePercent =
       campaign.totals && campaign.totals.online !== 0
         ? Math.round(
-            (campaign.hosts_count.successful / campaign.totals.online) * 100
+            (campaign.hosts_count.total / campaign.totals.online) * 100
           )
         : 0;
     setTargetsRespondedPercent(calculatePercent);

--- a/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
@@ -64,8 +64,6 @@ const QueryResults = ({
     setTargetsRespondedPercent,
   ] = useState<number>(0);
 
-  console.log("campaign", campaign);
-
   useEffect(() => {
     const calculatePercent =
       campaign.totals && campaign.totals.online !== 0
@@ -74,7 +72,7 @@ const QueryResults = ({
           )
         : 0;
     setTargetsRespondedPercent(calculatePercent);
-  }, [totalRowsCount, errors]);
+  }, [campaign]);
 
   useEffect(() => {
     if (isQueryFinished) {

--- a/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
@@ -61,8 +61,6 @@ const QueryResults = ({
     setTargetsRespondedPercent,
   ] = useState<number>(0);
 
-  console.log("campaign", campaign);
-
   useEffect(() => {
     const calculatePercent =
       campaign.totals && campaign.totals.online !== 0
@@ -71,7 +69,7 @@ const QueryResults = ({
           )
         : 0;
     setTargetsRespondedPercent(calculatePercent);
-  }, [totalRowsCount, errors]);
+  }, [campaign]);
 
   useEffect(() => {
     if (isQueryFinished) {

--- a/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
@@ -63,10 +63,8 @@ const QueryResults = ({
 
   useEffect(() => {
     const calculatePercent =
-      campaign.totals && campaign.totals.online !== 0
-        ? Math.round(
-            (campaign.hosts_count.total / campaign.totals.online) * 100
-          )
+      targetsTotalCount !== 0
+        ? Math.round((campaign.hosts_count.total / targetsTotalCount) * 100)
         : 0;
     setTargetsRespondedPercent(calculatePercent);
   }, [campaign]);
@@ -256,8 +254,7 @@ const QueryResults = ({
         <h1>{pageTitle}</h1>
         <div className={`${baseClass}__text-wrapper`}>
           <span>{targetsTotalCount}</span>&nbsp;hosts targeted&nbsp; (
-          {targetsRespondedPercent}% of{" "}
-          {campaign.totals ? campaign.totals.online : 0} online hosts&nbsp;
+          {targetsRespondedPercent}%&nbsp;
           <TooltipWrapper
             tipContent={`
                 Hosts that respond may<br /> return results, errors, or <br />no results`}

--- a/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
@@ -65,7 +65,7 @@ const QueryResults = ({
     const calculatePercent =
       campaign.totals && campaign.totals.online !== 0
         ? Math.round(
-            (campaign.hosts_count.successful / campaign.totals.online) * 100
+            (campaign.hosts_count.total / campaign.totals.online) * 100
           )
         : 0;
     setTargetsRespondedPercent(calculatePercent);

--- a/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
@@ -61,11 +61,15 @@ const QueryResults = ({
     setTargetsRespondedPercent,
   ] = useState<number>(0);
 
+  console.log("campaign", campaign);
+
   useEffect(() => {
     const calculatePercent =
-      Math.round(
-        ((totalRowsCount + errors?.length) / targetsTotalCount) * 100
-      ) || 0;
+      campaign.totals && campaign.totals.online !== 0
+        ? Math.round(
+            (campaign.hosts_count.successful / campaign.totals.online) * 100
+          )
+        : 0;
     setTargetsRespondedPercent(calculatePercent);
   }, [totalRowsCount, errors]);
 
@@ -254,7 +258,8 @@ const QueryResults = ({
         <h1>{pageTitle}</h1>
         <div className={`${baseClass}__text-wrapper`}>
           <span>{targetsTotalCount}</span>&nbsp;hosts targeted&nbsp; (
-          {targetsRespondedPercent}%&nbsp;
+          {targetsRespondedPercent}% of{" "}
+          {campaign.totals ? campaign.totals.online : 0} online hosts&nbsp;
           <TooltipWrapper
             tipContent={`
                 Hosts that respond may<br /> return results, errors, or <br />no results`}


### PR DESCRIPTION
Cerra unreleased bug #4756 
Related to #3432 

- Fixes are made to both the live query page and the live policy page

Final iteration per product request which the % will only reach the % of hosts online and read:
20 hosts targeted (**65% responded**)
because the percent of hosts online is 13/20 and 20 total host targeted is used to calculate the final percent

Query page example without live result errors:
https://user-images.githubusercontent.com/71795832/159763479-e2c8562b-9cfe-4428-a0c1-fec36c769eb4.mov

Policy page example with live result errors:
https://user-images.githubusercontent.com/71795832/159760039-e1de821a-9685-4a70-bdc1-16708ea61db9.mov



# Checklist for submitter


If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
