### PR TITLE
Fleet Desktop: Refetch uses device API not host API

### DIFF
--- a/frontend/pages/hosts/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/DeviceUserPage/DeviceUserPage.tsx
@@ -202,22 +202,24 @@ const DeviceUserPage = ({
   }, [showInfoModal, setShowInfoModal]);
 
   const onRefetchHost = async () => {
-    // Once the user clicks to refetch, the refetch loading spinner should continue spinning
-    // unless there is an error. The spinner state is also controlled in the fullyReloadHost
-    // method.
-    setShowRefetchSpinner(true);
-    try {
-      await deviceUserAPI.refetch(deviceAuthToken).then(() => {
-        setRefetchStartTime(Date.now());
-        setTimeout(() => {
-          refetchHostDetails();
-          refetchExtensions();
-        }, 1000);
-      });
-    } catch (error) {
-      console.log(error);
-      dispatch(renderFlash("error", `Host "${host.hostname}" refetch error`));
-      setShowRefetchSpinner(false);
+    if (host) {
+      // Once the user clicks to refetch, the refetch loading spinner should continue spinning
+      // unless there is an error. The spinner state is also controlled in the fullyReloadHost
+      // method.
+      setShowRefetchSpinner(true);
+      try {
+        await deviceUserAPI.refetch(deviceAuthToken).then(() => {
+          setRefetchStartTime(Date.now());
+          setTimeout(() => {
+            refetchHostDetails();
+            refetchExtensions();
+          }, 1000);
+        });
+      } catch (error) {
+        console.log(error);
+        dispatch(renderFlash("error", `Host "${host.hostname}" refetch error`));
+        setShowRefetchSpinner(false);
+      }
     }
   };
 

--- a/frontend/pages/hosts/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/DeviceUserPage/DeviceUserPage.tsx
@@ -9,7 +9,6 @@ import classnames from "classnames";
 import { isEmpty, pick, reduce } from "lodash";
 
 import deviceUserAPI from "services/entities/device_user";
-import hostAPI from "services/entities/hosts";
 import { IHost, IDeviceMappingResponse } from "interfaces/host";
 import { ISoftware } from "interfaces/software";
 // @ts-ignore
@@ -203,24 +202,22 @@ const DeviceUserPage = ({
   }, [showInfoModal, setShowInfoModal]);
 
   const onRefetchHost = async () => {
-    if (host) {
-      // Once the user clicks to refetch, the refetch loading spinner should continue spinning
-      // unless there is an error. The spinner state is also controlled in the fullyReloadHost
-      // method.
-      setShowRefetchSpinner(true);
-      try {
-        await hostAPI.refetch(host).then(() => {
-          setRefetchStartTime(Date.now());
-          setTimeout(() => {
-            refetchHostDetails();
-            refetchExtensions();
-          }, 1000);
-        });
-      } catch (error) {
-        console.log(error);
-        dispatch(renderFlash("error", `Host "${host.hostname}" refetch error`));
-        setShowRefetchSpinner(false);
-      }
+    // Once the user clicks to refetch, the refetch loading spinner should continue spinning
+    // unless there is an error. The spinner state is also controlled in the fullyReloadHost
+    // method.
+    setShowRefetchSpinner(true);
+    try {
+      await deviceUserAPI.refetch(deviceAuthToken).then(() => {
+        setRefetchStartTime(Date.now());
+        setTimeout(() => {
+          refetchHostDetails();
+          refetchExtensions();
+        }, 1000);
+      });
+    } catch (error) {
+      console.log(error);
+      dispatch(renderFlash("error", `Host "${host.hostname}" refetch error`));
+      setShowRefetchSpinner(false);
     }
   };
 


### PR DESCRIPTION
Cerra #4767 

- Endpoint and entities BE&FE was already built out for device user refetch, just needed to point to it.

<img width="1193" alt="Screen Shot 2022-03-23 at 2 13 58 PM" src="https://user-images.githubusercontent.com/71795832/159767999-637b342d-9350-425e-b806-f85cdaf7585b.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.
- [x] Manual QA for all new/changed functionality
