### PR TITLE
Allow Orbit shell to run while daemon is running

### DIFF
--- a/orbit/changes/fix-shell
+++ b/orbit/changes/fix-shell
@@ -1,0 +1,1 @@
+* Fix `orbit shell` command to successfully run when Orbit is already running as daemon.

--- a/orbit/cmd/orbit/shell.go
+++ b/orbit/cmd/orbit/shell.go
@@ -80,7 +80,7 @@ var shellCommand = &cli.Command{
 		r, _ := osquery.NewRunner(
 			osquerydPath,
 			osquery.WithShell(),
-			osquery.WithDataPath(c.String("root-dir")),
+			osquery.WithDataPath(filepath.Join(c.String("root-dir"), "shell")),
 			// Handle additional args after --
 			osquery.WithFlags(c.Args().Slice()),
 		)


### PR DESCRIPTION
Use a different data path so that the new osquery instance doesn't try
to use the same pidfile, db file, extension socket, etc.

For #4769

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
