### PR TITLE
Tweak output for `fleetctl login --help`

### DIFF
--- a/cmd/fleetctl/login.go
+++ b/cmd/fleetctl/login.go
@@ -23,7 +23,7 @@ fleetctl login [options]
 
 Interactively prompts for email and password if not specified in the flags or environment variables.
 
-Trying to login with SSO? First, login to the Fleet UI and retrieve your API token from the "My account" page. Then set your API token with the fleetctl set config --token <your-api-token-here> command. You're now logged in to fleetctl.
+Trying to login with SSO? First, login to the Fleet UI and retrieve your API token from the "My account" page. Then set your API token with the fleetctl config set --token <your-api-token-here> command. You're now logged in to fleetctl.
 `,
 		Flags: []cli.Flag{
 			&cli.StringFlag{


### PR DESCRIPTION
I think this fix should be merged prior to the 4.12 release 

- Switch position of 'set' and 'config' so that the help output prints the correct `fleetctl config set` command.
  - It looks like [the issue](https://github.com/fleetdm/fleet/issues/3598), that specified the addition of the help text, specified the incorrect command. I think this is a whoops from me :)
