### PR TITLE
Adding tfsec for all *.tf pushes

### DIFF
--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - '**.tf'
-    workflow_dispatch: # Manual dispatch
+  workflow_dispatch: # Manual dispatch
 jobs:
   tfsec:
     name: tfsec sarif report

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -1,0 +1,31 @@
+name: tfsec
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.tf'
+  pull_request:
+    paths:
+      - '**.tf'
+    workflow_dispatch: # Manual dispatch
+jobs:
+  tfsec:
+    name: tfsec sarif report
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 
+
+      - name: tfsec
+        uses: tfsec/tfsec-sarif-action@7ae00b384bff7f14cfa52cc3c73a5e6807a41398 
+        with:
+          sarif_file: tfsec.sarif
+          config_file: tfsec.conf
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@883476649888a9e8e219d5b2e6b789dc024f690c # v1
+        with:
+          # Path to SARIF file relative to the root of the repository
+          sarif_file: tfsec.sarif  

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -22,7 +22,6 @@ jobs:
         uses: tfsec/tfsec-sarif-action@7ae00b384bff7f14cfa52cc3c73a5e6807a41398 
         with:
           sarif_file: tfsec.sarif
-          config_file: tfsec.conf
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@883476649888a9e8e219d5b2e6b789dc024f690c # v1


### PR DESCRIPTION
This relates to #4762.

I will create a more detailed configuration, but to be able to run the workflow manually in a branch it at least needs to exist in main, so this is a minimal configuration that should work OK, and I will tweak from there in another branch and submit another PR.