### PR TITLE
Use template icon for Fleet Desktop

### DIFF
--- a/orbit/cmd/desktop/desktop_darwin.go
+++ b/orbit/cmd/desktop/desktop_darwin.go
@@ -45,7 +45,7 @@ func main() {
 	onReady := func() {
 		log.Println("ready")
 
-		systray.SetIcon(icoBytes)
+		systray.SetTemplateIcon(icoBytes, icoBytes)
 		systray.SetTooltip("Fleet Device Management Menu.")
 		myDeviceItem := systray.AddMenuItem("Initializing...", "")
 		myDeviceItem.Disable()


### PR DESCRIPTION
This enables support for light vs. dark mode.
<img width="683" alt="Screen Shot 2022-03-23 at 4 01 10 PM" src="https://user-images.githubusercontent.com/575602/159810749-93b3774c-008b-4e4a-9b57-17d7124dd9e1.png">
<img width="660" alt="Screen Shot 2022-03-23 at 4 01 02 PM" src="https://user-images.githubusercontent.com/575602/159810751-d5841157-115a-4bf1-a9e5-c690e6785b86.png">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
