### PR TITLE
Host Details Page: Same naming convention for info as device user page

### DIFF
--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -176,7 +176,7 @@ const About = ({
       <p className="section__header">About</p>
       <div className="info-grid">
         <div className="info-grid__block">
-          <span className="info-grid__header">First enrolled</span>
+          <span className="info-grid__header">Added to Fleet</span>
           <span className="info-grid__data">
             {wrapFleetHelper(humanHostEnrolled, aboutData.last_enrolled_at)}
           </span>

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -149,7 +149,7 @@ const HostSummary = ({
     return <span className="info-flex__data">No data available</span>;
   };
 
-  const renderDeviceUserSummary = () => {
+  const renderSummary = () => {
     return (
       <div className="info-flex">
         <div className="info-flex__item info-flex__item--title">
@@ -158,6 +158,10 @@ const HostSummary = ({
             {titleData.status}
           </span>
         </div>
+        {!deviceUser &&
+          titleData.issues?.total_issues_count > 0 &&
+          renderIssues()}
+        {!deviceUser && isPremiumTier && renderHostTeam()}
         <div className="info-flex__item info-flex__item--title">
           <span className="info-flex__header">Disk Space</span>
           {renderDiskSpace()}
@@ -174,41 +178,8 @@ const HostSummary = ({
         </div>
         <div className="info-flex__item info-flex__item--title">
           <span className="info-flex__header">Operating system</span>
-          <span className="info-flex__data">{titleData.os_version}</span>
-        </div>
-      </div>
-    );
-  };
-
-  const renderHostDetailsSummary = () => {
-    return (
-      <div className="info-flex">
-        <div className="info-flex__item info-flex__item--title">
-          <span className="info-flex__header">Status</span>
-          <span className={`${statusClassName} info-flex__data`}>
-            {titleData.status}
-          </span>
-        </div>
-        {titleData.issues?.total_issues_count > 0 && renderIssues()}
-        {isPremiumTier && renderHostTeam()}
-        <div className="info-flex__item info-flex__item--title">
-          <span className="info-flex__header">Disk Space</span>
-          {renderDiskSpace()}
-        </div>
-        <div className="info-flex__item info-flex__item--title">
-          <span className="info-flex__header">RAM</span>
           <span className="info-flex__data">
-            {wrapFleetHelper(humanHostMemory, titleData.memory)}
-          </span>
-        </div>
-        <div className="info-flex__item info-flex__item--title">
-          <span className="info-flex__header">CPU</span>
-          <span className="info-flex__data">{titleData.cpu_type}</span>
-        </div>
-        <div className="info-flex__item info-flex__item--title">
-          <span className="info-flex__header">OS</span>
-          <span className="info-flex__data">
-            {isOnlyObserver ? (
+            {isOnlyObserver || deviceUser ? (
               `${titleData.os_version}`
             ) : (
               <Button
@@ -221,10 +192,12 @@ const HostSummary = ({
             )}
           </span>
         </div>
-        <div className="info-flex__item info-flex__item--title">
-          <span className="info-flex__header">Osquery</span>
-          <span className="info-flex__data">{titleData.osquery_version}</span>
-        </div>
+        {!deviceUser && (
+          <div className="info-flex__item info-flex__item--title">
+            <span className="info-flex__header">Osquery</span>
+            <span className="info-flex__data">{titleData.osquery_version}</span>
+          </div>
+        )}
       </div>
     );
   };
@@ -249,9 +222,7 @@ const HostSummary = ({
         {renderActionButtons()}
       </div>
       <div className="section title">
-        <div className="title__inner">
-          {deviceUser ? renderDeviceUserSummary() : renderHostDetailsSummary()}
-        </div>
+        <div className="title__inner">{renderSummary()}</div>
       </div>
     </>
   );

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -163,7 +163,7 @@ const HostSummary = ({
           renderIssues()}
         {!deviceUser && isPremiumTier && renderHostTeam()}
         <div className="info-flex__item info-flex__item--title">
-          <span className="info-flex__header">Disk Space</span>
+          <span className="info-flex__header">Disk space</span>
           {renderDiskSpace()}
         </div>
         <div className="info-flex__item info-flex__item--title">


### PR DESCRIPTION
https://www.figma.com/file/hdALBDsrti77QuDNSzLdkx/%F0%9F%9A%A7-Fleet-EE-(dev-ready%2C-scratchpad)?node-id=4803%3A179031

Iteration of Host Details page lingo per product's QA:
- Rename headings: RAM, CPU, OS, and First enrolled to Memory, Processor type, Operating system, and Added to Fleet respectively to match Device user page
- Refactor to combine `renderDeviceUserSummary()` and `renderHostDetailsSummary()` since now there are only subtle differences in displayed information
- Sentence case "Disk space"

Screenshot of new wording:
<img width="1153" alt="Screen Shot 2022-03-25 at 3 01 47 PM" src="https://user-images.githubusercontent.com/71795832/160188119-2e3e23b4-e34c-4835-a225-0fc170e18cca.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.
- [x] Manual QA for all new/changed functionality
