### PR TITLE
Update handbook index links and remove /handbook/growth redirect

### DIFF
--- a/handbook/README.md
+++ b/handbook/README.md
@@ -46,9 +46,9 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [Feature flags](./product.md#feature-flags)
 
-[Slack channels](./product.md#slack-channels)
-
 [Competition](./product.md#competition)
+
+[Slack channels](./product.md#slack-channels)
 
 ### Security
 
@@ -80,17 +80,23 @@ The Fleet handbook is the central guide for how we run the company. As part of o
 
 [Slack channels](./customers.md#slack-channels)
 
+### Growth
+
+[Posting on social media as Fleet](./growth.md#posting-on-social-media-as-fleet)
+
+[Promoting blog posts on social media](./growth.md#promoting-blog-posts-on-social-media)
+
+[Press releases](./growth.md#press-releases)
+
+[Sponsoring events](./growth.md#sponsoring-events)
+
+[Slack channels](./growth.md#slack-channels)
+
 ### Community
 
 [Communities](./community.md#communities)
 
-[Posting on social media as Fleet](./community.md#posting-on-social-media-as-fleet)
-
-[Promoting blog posts on social media](./community.md#promoting-blog-posts-on-social-media)
-
 [Fleet docs](./community.md#fleet-docs)
-
-[Press releases](./community.md#press-releases)
 
 [Community contributions (pull requests)](./community.md#community-contributions-pull-requests)
 

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -169,7 +169,6 @@ module.exports.routes = {
   'GET /try-fleet':                  '/get-started',
   'GET /docs/deploying/fleet-public-load-testing': '/docs/deploying/load-testing',
   'GET /handbook/customer-experience': '/handbook/customers',
-  'GET /handbook/growth': '/handbook/brand',
 
 
 


### PR DESCRIPTION
Changes:
- Added index links for the new Growth handbook page.
- reordered the Product handbook links so the "Slack channels" link is at the end
- Removed the `/handbook/growth` redirect

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
