### PR TITLE
GitHub webhook: Add support for '*' DRI rule

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -220,14 +220,14 @@ module.exports = {
             'website/config/routes.js': ['eashaw', 'mike-j-thomas'],// (for managing website URLs)
 
             'docs': 'zwass',// (default for docs)
-            'docs/images': ['noahtalerman', 'eashaw', 'mike-j-thomas'],// (inline images in docs)
-            'docs/Using-Fleet/REST-API.md': 'lukeheath',// (API reference documentation)
+            'docs/images': ['noahtalerman', 'eashaw', 'mike-j-thomas'],
+            'docs/Using-Fleet/REST-API.md': 'lukeheath',
             'docs/Contributing/API-for-contributors.md': 'lukeheath',
-            'docs/Deploying/FAQ.md': ['ksatter', 'dominuskelvin'],// (FAQs)
+            'docs/Deploying/FAQ.md': ['ksatter', 'dominuskelvin'],
             'docs/Contributing/FAQ.md': ['ksatter', 'dominuskelvin'],
             'docs/Using-Fleet/FAQ.md': ['ksatter', 'dominuskelvin'],
 
-            'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml': ['guillaumeross', 'zwass'],// (standard query library)
+            'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml': 'guillaumeross',// (standard query library)
           };
 
           // [?] https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -203,16 +203,17 @@ module.exports = {
           let DRI_BY_PATH = {
             'README.md': 'mike-j-thomas',// (github brandfront)
 
-            'handbook': ['eashaw', 'mike-j-thomas', 'mikermcneil'],// (default for handbook)
-            'handbook/README.md': '*',// (any fleetie can update this page)
+            'handbook': ['desmi-dizney', 'mike-j-thomas', 'mikermcneil'],// (default for handbook)
             'handbook/company.md': 'mikermcneil',
             'handbook/people.md': ['eashaw', 'mike-j-thomas'],
             'handbook/engineering.md': 'zwass',
             'handbook/product.md': 'noahtalerman',
             'handbook/security.md': 'guillaumeross',
             'handbook/brand.md': 'mike-j-thomas',
+            'handbook/brand.md': 'timmy-k',
             'handbook/customers.md': 'tgauda',
-            'handbook/community.md': ['dominuskelvin', 'ksatter', 'mike-j-thomas'],
+            'handbook/community.md': ['dominuskelvin', 'ksatter'],
+            'handbook/README.md': '*',// (any fleetie can update this page)
 
             'website': 'mikermcneil',// (default for website)
             'website/views': 'eashaw',

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -199,10 +199,12 @@ module.exports = {
         let isAutoApproved = await sails.helpers.flow.build(async()=>{
 
           let isSenderDRIForAllChangedPaths = false;
+          let isSenderMaintainer = GITHUB_USERNAMES_OF_BOTS_AND_MAINTAINERS.includes(sender.login);
           let DRI_BY_PATH = {
             'README.md': 'mike-j-thomas',// (github brandfront)
-            'handbook': 'mikermcneil',// (default for handbook)
-            'handbook/README.md': 'mikermcneil',
+            
+            'handbook': 'eashaw',// (default for handbook)
+            'handbook/README.md': '*',// (any core maintainer can update this page)
             'handbook/company.md': 'mikermcneil',
             'handbook/people.md': 'eashaw',
             'handbook/engineering.md': 'zwass',
@@ -212,11 +214,15 @@ module.exports = {
             'handbook/customers.md': 'tgauda',
             'handbook/community.md': 'mike-j-thomas',
             'handbook/handbook.md': 'mike-j-thomas',
-            'website': 'mikermcneil',// (default for website)
+            
+            'website': 'eashaw',// (default for website)
             'website/views': 'eashaw',
             'website/assets': 'eashaw',
-            'website/config/routes.js': 'mike-j-thomas',
-            'docs': 'mike-j-thomas',
+            'website/config/routes.js': 'mike-j-thomas',// (default for URLs)
+            
+            'docs': 'mike-j-thomas',// (default for docs)
+            
+            'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml': 'guillaumeross',// (standard query library)
           };
 
           // [?] https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files
@@ -230,14 +236,14 @@ module.exports = {
 
             require('assert')(sender.login !== undefined);
             sails.log.verbose(`…checking DRI of changed path "${changedPath}"`);
-            if (sender.login === DRI_BY_PATH[changedPath]) {
+            if (sender.login === DRI_BY_PATH[changedPath] || (isSenderMaintainer && '*' === DRI_BY_PATH[changedPath])) {
               return true;
             }
             let numRemainingPathsToCheck = changedPath.split('/').length;
             while (numRemainingPathsToCheck > 0) {
               let ancestralPath = changedPath.split('/').slice(0, -1 * numRemainingPathsToCheck).join('/');
               sails.log.verbose(`…checking DRI of ancestral path "${ancestralPath}" for changed path`);
-              if (sender.login === DRI_BY_PATH[ancestralPath]) {
+              if (sender.login === DRI_BY_PATH[ancestralPath] || (isSenderMaintainer && '*' === DRI_BY_PATH[ancestralPath])) {
                 return true;
               }
               numRemainingPathsToCheck--;

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -210,7 +210,7 @@ module.exports = {
             'handbook/product.md': 'noahtalerman',
             'handbook/security.md': 'guillaumeross',
             'handbook/brand.md': 'mike-j-thomas',
-            'handbook/brand.md': 'timmy-k',
+            'handbook/growth.md': 'timmy-k',
             'handbook/customers.md': 'tgauda',
             'handbook/community.md': ['dominuskelvin', 'ksatter'],
             'handbook/README.md': '*',// (any fleetie can update this page)

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -204,7 +204,7 @@ module.exports = {
             'README.md': 'mike-j-thomas',// (github brandfront)
 
             'handbook': ['eashaw', 'mike-j-thomas', 'mikermcneil'],// (default for handbook)
-            'handbook/README.md': '*',// (any core maintainer can update this page)
+            'handbook/README.md': '*',// (any fleetie can update this page)
             'handbook/company.md': 'mikermcneil',
             'handbook/people.md': ['eashaw', 'mike-j-thomas'],
             'handbook/engineering.md': 'zwass',

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -219,7 +219,13 @@ module.exports = {
             'website/assets': 'eashaw',
             'website/config/routes.js': ['eashaw', 'mike-j-thomas'],// (for managing website URLs)
 
-            'docs': ['mike-j-thomas', 'zwass'],// (default for docs)
+            'docs': 'zwass',// (default for docs)
+            'docs/images': ['noahtalerman', 'eashaw', 'mike-j-thomas'],// (inline images in docs)
+            'docs/Using-Fleet/REST-API.md': 'lukeheath',// (API reference documentation)
+            'docs/Contributing/API-for-contributors.md': 'lukeheath',
+            'docs/Deploying/FAQ.md': ['ksatter', 'dominuskelvin'],// (FAQs)
+            'docs/Contributing/FAQ.md': ['ksatter', 'dominuskelvin'],
+            'docs/Using-Fleet/FAQ.md': ['ksatter', 'dominuskelvin'],
 
             'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml': ['guillaumeross', 'zwass'],// (standard query library)
           };

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -216,8 +216,9 @@ module.exports = {
             'handbook/handbook.md': 'mike-j-thomas',
             
             'website': 'eashaw',// (default for website)
-            'website/views': 'eashaw',
-            'website/assets': 'eashaw',
+            'website/scripts': 'mikermcneil',
+            'website/api': 'mikermcneil',
+            'website/config': 'mikermcneil',
             'website/config/routes.js': 'mike-j-thomas',// (default for URLs)
             
             'docs': 'mike-j-thomas',// (default for docs)


### PR DESCRIPTION
This allows any fleetie to edit the handbook landing page (e.g. in the event pages need to get moved around)

