### PR TITLE
GitHub webhook: Fixes #4825 to support multiple "self mergers"

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -243,16 +243,16 @@ module.exports = {
             require('assert')(sender.login !== undefined);
             sails.log.verbose(`…checking DRI of changed path "${changedPath}"`);
 
-            let rule = DRI_BY_PATH[changedPath] ? [].concat(DRI_BY_PATH[changedPath]) : undefined;// « ensure array
-            if (sender.login === rule || (isSenderMaintainer && '*' === rule)) {
+            let selfMergers = DRI_BY_PATH[changedPath] ? [].concat(DRI_BY_PATH[changedPath]) : undefined;// « ensure array
+            if (selfMergers.includes(sender.login) || (isSenderMaintainer && selfMergers.includes('*'))) {
               return true;
             }//•
             let numRemainingPathsToCheck = changedPath.split('/').length;
             while (numRemainingPathsToCheck > 0) {
               let ancestralPath = changedPath.split('/').slice(0, -1 * numRemainingPathsToCheck).join('/');
               sails.log.verbose(`…checking DRI of ancestral path "${ancestralPath}" for changed path`);
-              let rule = DRI_BY_PATH[ancestralPath] ? [].concat(DRI_BY_PATH[ancestralPath]) : undefined;// « ensure array
-              if (sender.login === rule || (isSenderMaintainer && '*' === rule)) {
+              let selfMergers = DRI_BY_PATH[ancestralPath] ? [].concat(DRI_BY_PATH[ancestralPath]) : undefined;// « ensure array
+              if (selfMergers.includes(sender.login) || (isSenderMaintainer && selfMergers.includes('*'))) {
                 return true;
               }//•
               numRemainingPathsToCheck--;


### PR DESCRIPTION
fixes unfinished logic from https://github.com/fleetdm/fleet/pull/4825

as proven by https://github.com/fleetdm/fleet/pull/4826/files, #4825 doesn't work because it's not properly handling arrays.  Now it does.