### PR TITLE
Policies page: Fix copy in "Manage automations" modal

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -164,8 +164,8 @@ const ManageAutomationsModal = ({
             onChange={() =>
               setPolicyAutomationEnabled(!policyAutomationEnabled)
             }
-            inactiveText={"Vulnerability automations disabled"}
-            activeText={"Vulnerability automations enabled"}
+            inactiveText={"Policy automations disabled"}
+            activeText={"Policy automations enabled"}
           />
         </div>
         <div className={`${baseClass}__overlay-container`}>


### PR DESCRIPTION
- Fix a bug on **Policies > Manage automations**, in which "Vulnerability automations" copy was used instead of "Policy automations" copy

If some of the following don't apply, delete the relevant line.

- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
