### PR TITLE
Host Details Page: Software vulnerability column

### DIFF
--- a/changes/issue-4214-vulnerabilities-column
+++ b/changes/issue-4214-vulnerabilities-column
@@ -1,0 +1,1 @@
+* Host details page software table now has search by vulnerabilities and a vulnerabilities column

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -171,7 +171,7 @@ describe("Hosts flow", () => {
             initialCount = parseInt(newCount[0], 10);
             expect(initialCount).to.be.at.least(1);
           });
-        cy.findByPlaceholderText(/filter software/i).type("lib");
+        cy.findByPlaceholderText(/search software/i).type("lib");
         // Ensures search completes
         cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.getAttached(".table-container__results-count")

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -132,6 +132,7 @@ const DataTable = ({
     setPageSize,
     setFilter,
     setAllFilters,
+    setGlobalFilter,
   } = useTable(
     {
       columns,
@@ -147,7 +148,7 @@ const DataTable = ({
       // Initializes as false, but changes briefly to true on successful notification
       autoResetSelectedRows: resetSelectedRows,
       // Expands the enumerated `filterTypes` for react-table
-      // (see https://github.com/tannerlinsley/react-table/blob/master/src/filterTypes.js)
+      // (see https://github.com/TanStack/react-table/blob/alpha/packages/react-table/src/filterTypes.ts)
       // with custom `filterTypes` defined for this `useTable` instance
       filterTypes: React.useMemo(
         () => ({
@@ -206,7 +207,9 @@ const DataTable = ({
         id,
         value,
       }));
+      console.log("allFilters", allFilters);
       !!allFilters.length && setAllFilters(allFilters);
+      // !!allFilters.length && setGlobalFilter(tableFilters?.name);
     }
   }, [tableFilters]);
 
@@ -214,6 +217,7 @@ const DataTable = ({
 
   const setDebouncedClientFilter = useDebouncedCallback(
     (column: string, query: string) => {
+      console.log("setDebouncedClientFilter");
       setFilter(column, query);
     },
     300
@@ -228,6 +232,7 @@ const DataTable = ({
   useEffect(() => {
     if (isClientSideFilter && searchQueryColumn) {
       setDebouncedClientFilter(searchQueryColumn, searchQuery || "");
+      console.log("searchQueryColumn", searchQueryColumn);
     }
   }, [searchQuery, searchQueryColumn]);
 

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -207,9 +207,7 @@ const DataTable = ({
         id,
         value,
       }));
-      console.log("allFilters", allFilters);
       !!allFilters.length && setAllFilters(allFilters);
-      // !!allFilters.length && setGlobalFilter(tableFilters?.name);
     }
   }, [tableFilters]);
 
@@ -217,7 +215,6 @@ const DataTable = ({
 
   const setDebouncedClientFilter = useDebouncedCallback(
     (column: string, query: string) => {
-      console.log("setDebouncedClientFilter");
       setFilter(column, query);
     },
     300
@@ -232,7 +229,6 @@ const DataTable = ({
   useEffect(() => {
     if (isClientSideFilter && searchQueryColumn) {
       setDebouncedClientFilter(searchQueryColumn, searchQuery || "");
-      console.log("searchQueryColumn", searchQueryColumn);
     }
   }, [searchQuery, searchQueryColumn]);
 

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -132,7 +132,6 @@ const DataTable = ({
     setPageSize,
     setFilter,
     setAllFilters,
-    setGlobalFilter,
   } = useTable(
     {
       columns,

--- a/frontend/fleet/helpers.ts
+++ b/frontend/fleet/helpers.ts
@@ -18,6 +18,7 @@ import {
 } from "interfaces/target";
 import { ITeam, ITeamSummary } from "interfaces/team";
 import { IUser } from "interfaces/user";
+import { IVulnerability } from "interfaces/vulnerability";
 
 import stringUtils from "utilities/strings";
 import sortUtils from "utilities/sort";
@@ -760,6 +761,21 @@ export const wrapFleetHelper = (
   return value === "---" ? value : helperFn(value);
 };
 
+export const condenseVulnColumn = (
+  vulnerabilities: IVulnerability[]
+): string[] => {
+  const condensed =
+    (vulnerabilities?.length &&
+      vulnerabilities
+        .slice(-3)
+        .map((v) => v.cve)
+        .reverse()) ||
+    [];
+  return vulnerabilities.length > 3
+    ? condensed.concat(`+${vulnerabilities.length - 3} more`)
+    : condensed;
+};
+
 export default {
   addGravatarUrlToResource,
   formatConfigDataForServer,
@@ -793,4 +809,5 @@ export default {
   getValidatedTeamId,
   normalizeEmptyValues,
   wrapFleetHelper,
+  condenseVulnColumn,
 };

--- a/frontend/pages/hosts/details/cards/Software/Software.tsx
+++ b/frontend/pages/hosts/details/cards/Software/Software.tsx
@@ -31,14 +31,12 @@ const SoftwareTable = ({
   const [filters, setFilters] = useState({
     name: searchQuery,
     vulnerabilities: filterVuln,
-    version: searchQuery,
   });
 
   useEffect(() => {
     setFilters({
       name: searchQuery,
       vulnerabilities: filterVuln,
-      version: searchQuery,
     });
   }, [searchQuery, filterVuln]);
 
@@ -91,9 +89,6 @@ const SoftwareTable = ({
                 "Search software by name or vulnerabilities (CVEs)"
               }
               onQueryChange={onQueryChange}
-              // additionalQueries={filterVuln ? "vulnerable" : ""} // additionalQueries serves as a trigger
-              // // for the useDeepEffect hook to fire onQueryChange for events happeing outside of
-              // // the TableContainer
               resultsTitle={"software items"}
               emptyComponent={EmptySoftware}
               showMarkAllPages={false}
@@ -102,7 +97,6 @@ const SoftwareTable = ({
               customControl={renderVulnFilterDropdown}
               isClientSidePagination
               isClientSideFilter
-              searchQueryColumn={"version"}
               highlightOnHover
             />
           )}

--- a/frontend/pages/hosts/details/cards/Software/Software.tsx
+++ b/frontend/pages/hosts/details/cards/Software/Software.tsx
@@ -26,20 +26,25 @@ const SoftwareTable = ({
   software,
   deviceUser,
 }: ISoftwareTableProps): JSX.Element => {
-  const [filterName, setFilterName] = useState("");
+  const [searchQuery, setSearchQuery] = useState("");
   const [filterVuln, setFilterVuln] = useState(false);
   const [filters, setFilters] = useState({
-    name: filterName,
+    name: searchQuery,
     vulnerabilities: filterVuln,
+    version: searchQuery,
   });
 
   useEffect(() => {
-    setFilters({ name: filterName, vulnerabilities: filterVuln });
-  }, [filterName, filterVuln]);
+    setFilters({
+      name: searchQuery,
+      vulnerabilities: filterVuln,
+      version: searchQuery,
+    });
+  }, [searchQuery, filterVuln]);
 
   const onQueryChange = useDebouncedCallback(
     ({ searchQuery }: { searchQuery: string }) => {
-      setFilterName(searchQuery);
+      setSearchQuery(searchQuery);
     },
     300
   );
@@ -82,8 +87,13 @@ const SoftwareTable = ({
               isLoading={isLoading}
               defaultSortHeader={"name"}
               defaultSortDirection={"asc"}
-              inputPlaceHolder={"Filter software"}
+              inputPlaceHolder={
+                "Search software by name or vulnerabilities (CVEs)"
+              }
               onQueryChange={onQueryChange}
+              // additionalQueries={filterVuln ? "vulnerable" : ""} // additionalQueries serves as a trigger
+              // // for the useDeepEffect hook to fire onQueryChange for events happeing outside of
+              // // the TableContainer
               resultsTitle={"software items"}
               emptyComponent={EmptySoftware}
               showMarkAllPages={false}
@@ -92,6 +102,7 @@ const SoftwareTable = ({
               customControl={renderVulnFilterDropdown}
               isClientSidePagination
               isClientSideFilter
+              searchQueryColumn={"version"}
               highlightOnHover
             />
           )}

--- a/frontend/pages/hosts/details/cards/Software/Software.tsx
+++ b/frontend/pages/hosts/details/cards/Software/Software.tsx
@@ -26,23 +26,23 @@ const SoftwareTable = ({
   software,
   deviceUser,
 }: ISoftwareTableProps): JSX.Element => {
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchString, setSearchString] = useState("");
   const [filterVuln, setFilterVuln] = useState(false);
   const [filters, setFilters] = useState({
-    name: searchQuery,
+    name: searchString,
     vulnerabilities: filterVuln,
   });
 
   useEffect(() => {
     setFilters({
-      name: searchQuery,
+      name: searchString,
       vulnerabilities: filterVuln,
     });
-  }, [searchQuery, filterVuln]);
+  }, [searchString, filterVuln]);
 
   const onQueryChange = useDebouncedCallback(
     ({ searchQuery }: { searchQuery: string }) => {
-      setSearchQuery(searchQuery);
+      setSearchString(searchQuery);
     },
     300
   );

--- a/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
@@ -1,18 +1,18 @@
 import React from "react";
 import { Link } from "react-router";
 import ReactTooltip from "react-tooltip";
-import { isEmpty } from "lodash";
 
 // TODO: Enable after backend has been updated to provide last_opened_at
 // import distanceInWordsToNow from "date-fns/distance_in_words_to_now";
 
+import { condenseVulnColumn } from "fleet/helpers";
 import { ISoftware } from "interfaces/software";
+import { IVulnerability } from "interfaces/vulnerability";
 
 import PATHS from "router/paths";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import TooltipWrapper from "components/TooltipWrapper";
-import IssueIcon from "../../../../../../assets/images/icon-issue-fleet-black-50-16x16@2x.png";
 import Chevron from "../../../../../../assets/images/icon-chevron-right-9x6@2x.png";
 
 interface IHeaderProps {
@@ -23,10 +23,22 @@ interface IHeaderProps {
 }
 interface ICellProps {
   cell: {
-    value: string;
+    value: number | string | IVulnerability[];
   };
   row: {
     original: ISoftware;
+  };
+}
+
+interface IStringCellProps extends ICellProps {
+  cell: {
+    value: string;
+  };
+}
+
+interface IVulnCellProps extends ICellProps {
+  cell: {
+    value: IVulnerability[];
   };
 }
 
@@ -34,7 +46,9 @@ interface IDataColumn {
   title: string;
   Header: ((props: IHeaderProps) => JSX.Element) | string;
   accessor: string;
-  Cell: (props: ICellProps) => JSX.Element;
+  Cell:
+    | ((props: IStringCellProps) => JSX.Element)
+    | ((props: IVulnCellProps) => JSX.Element);
   disableHidden?: boolean;
   disableSortBy?: boolean;
   sortType?: string;
@@ -75,46 +89,6 @@ const formatSoftwareType = (source: string) => {
 const generateSoftwareTableHeaders = (deviceUser = false): IDataColumn[] => {
   const tableHeaders: IDataColumn[] = [
     {
-      title: "Vulnerabilities",
-      Header: "",
-      disableSortBy: true,
-      accessor: "vulnerabilities",
-      Filter: () => null, // input for this column filter outside of column header
-      filter: "hasLength", // filters out rows where vulnerabilities has no length if filter value is `true`
-      Cell: (cellProps) => {
-        const vulnerabilities = cellProps.cell.value;
-        if (isEmpty(vulnerabilities)) {
-          return <></>;
-        }
-        return (
-          <>
-            <span
-              className={`vulnerabilities tooltip__tooltip-icon`}
-              data-tip
-              data-for={`vulnerabilities__${cellProps.row.original.id.toString()}`}
-              data-tip-disable={false}
-            >
-              <img alt="software vulnerabilities" src={IssueIcon} />
-            </span>
-            <ReactTooltip
-              place="bottom"
-              type="dark"
-              effect="solid"
-              backgroundColor="#3e4771"
-              id={`vulnerabilities__${cellProps.row.original.id.toString()}`}
-              data-html
-            >
-              <span className={`vulnerabilities tooltip__tooltip-text`}>
-                {vulnerabilities.length === 1
-                  ? "1 vulnerability detected"
-                  : `${vulnerabilities.length} vulnerabilities detected`}
-              </span>
-            </ReactTooltip>
-          </>
-        );
-      },
-    },
-    {
       title: "Name",
       Header: (cellProps) => (
         <HeaderCell
@@ -125,7 +99,7 @@ const generateSoftwareTableHeaders = (deviceUser = false): IDataColumn[] => {
       accessor: "name",
       Filter: () => null, // input for this column filter is rendered outside of column header
       filter: "text", // filters name text based on the user's search query
-      Cell: (cellProps) => {
+      Cell: (cellProps: IStringCellProps) => {
         const { name, bundle_identifier } = cellProps.row.original;
         if (bundle_identifier) {
           return (
@@ -149,6 +123,17 @@ const generateSoftwareTableHeaders = (deviceUser = false): IDataColumn[] => {
       sortType: "caseInsensitive",
     },
     {
+      title: "Version",
+      Header: "Version",
+      disableSortBy: true,
+      accessor: "version",
+      Filter: () => null, // input for this column filter is rendered outside of column header
+      filter: "includesString", // filters name text based on the user's search query
+      Cell: (cellProps: IStringCellProps) => {
+        return <TextCell value={cellProps.cell.value} />;
+      },
+    },
+    {
       title: "Type",
       Header: (cellProps) => (
         <HeaderCell
@@ -158,16 +143,62 @@ const generateSoftwareTableHeaders = (deviceUser = false): IDataColumn[] => {
       ),
       disableSortBy: false,
       accessor: "source",
-      Cell: (cellProps) => (
+      Cell: (cellProps: IStringCellProps) => (
         <TextCell value={cellProps.cell.value} formatter={formatSoftwareType} />
       ),
     },
     {
-      title: "Installed version",
-      Header: "Installed version",
+      title: "Vulnerabilities",
+      Header: "Vulnerabilities",
       disableSortBy: true,
-      accessor: "version",
-      Cell: (cellProps) => <TextCell value={cellProps.cell.value} />,
+      accessor: "vulnerabilities",
+      Filter: () => null, // input for this column filter is rendered outside of column header
+      filter: "text", // filters name text based on the user's search query
+      Cell: (cellProps: IVulnCellProps): JSX.Element => {
+        const vulnerabilities = cellProps.cell.value || [];
+        const tooltipText = condenseVulnColumn(vulnerabilities)?.map(
+          (value) => {
+            return (
+              <span key={`vuln_${value}`}>
+                {value}
+                <br />
+              </span>
+            );
+          }
+        );
+
+        if (!vulnerabilities?.length) {
+          return <span className="vulnerabilities text-muted">---</span>;
+        }
+        return (
+          <>
+            <span
+              className={`vulnerabilities ${
+                vulnerabilities.length > 1 ? "text-muted" : ""
+              }`}
+              data-tip
+              data-for={`vulnerabilities__${cellProps.row.original.id.toString()}`}
+              data-tip-disable={vulnerabilities.length <= 1}
+            >
+              {vulnerabilities.length === 1
+                ? vulnerabilities[0].cve
+                : `${vulnerabilities.length} vulnerabilities`}
+            </span>
+            <ReactTooltip
+              place="top"
+              type="dark"
+              effect="solid"
+              backgroundColor="#3e4771"
+              id={`vulnerabilities__${cellProps.row.original.id.toString()}`}
+              data-html
+            >
+              <span className={`vulnerabilities tooltip__tooltip-text`}>
+                {tooltipText}
+              </span>
+            </ReactTooltip>
+          </>
+        );
+      },
     },
     // TODO: Enable after backend has been updated to provide last_opened_at
     // {
@@ -202,7 +233,7 @@ const generateSoftwareTableHeaders = (deviceUser = false): IDataColumn[] => {
       Header: "",
       disableSortBy: true,
       accessor: "linkToFilteredHosts",
-      Cell: (cellProps) => {
+      Cell: (cellProps: IStringCellProps) => {
         return (
           <Link
             to={`${

--- a/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
@@ -127,8 +127,6 @@ const generateSoftwareTableHeaders = (deviceUser = false): IDataColumn[] => {
       Header: "Version",
       disableSortBy: true,
       accessor: "version",
-      Filter: () => null, // input for this column filter is rendered outside of column header
-      filter: "includesString", // filters name text based on the user's search query
       Cell: (cellProps: IStringCellProps) => {
         return <TextCell value={cellProps.cell.value} />;
       },
@@ -152,8 +150,6 @@ const generateSoftwareTableHeaders = (deviceUser = false): IDataColumn[] => {
       Header: "Vulnerabilities",
       disableSortBy: true,
       accessor: "vulnerabilities",
-      Filter: () => null, // input for this column filter is rendered outside of column header
-      filter: "text", // filters name text based on the user's search query
       Cell: (cellProps: IVulnCellProps): JSX.Element => {
         const vulnerabilities = cellProps.cell.value || [];
         const tooltipText = condenseVulnColumn(vulnerabilities)?.map(

--- a/frontend/pages/hosts/details/cards/Software/SoftwareVulnCount/SoftwareVulnCount.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareVulnCount/SoftwareVulnCount.tsx
@@ -28,12 +28,6 @@ const SoftwareVulnCount = ({
           ? "1 vulnerability detected"
           : `${vulnCount} vulnerabilities detected`}
       </div>
-      {!deviceUser && (
-        <p>
-          Click a vulnerable item below to see the associated Common
-          Vulnerabilites and Exposures (CVEs).
-        </p>
-      )}
     </div>
   ) : (
     <></>

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -6,7 +6,7 @@
     table-layout: fixed;
 
     th {
-      &:first-child(2) {
+      &:first-child {
         width: 25%;
         padding-right: 0px;
       }

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -1,14 +1,12 @@
 .section--software {
+  .table-container__search-input {
+    width: 411px;
+  }
   .data-table__table {
     table-layout: fixed;
 
     th {
-      &:first-child {
-        border-right: none;
-        width: 16px;
-        padding-right: 0px;
-      }
-      &:nth-child(2) {
+      &:first-child(2) {
         width: 25%;
         padding-right: 0px;
       }
@@ -19,10 +17,6 @@
 
       &.source__header {
         width: 20%;
-      }
-
-      &.version__header {
-        border-right: 0;
       }
     }
 
@@ -97,5 +91,8 @@
       padding-left: $pad-large;
       font-size: $small !important;
     }
+  }
+  .text-muted {
+    color: $ui-fleet-black-50;
   }
 }

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -21,13 +21,6 @@
     }
 
     tr {
-      td {
-        position: relative;
-        &:first-child {
-          padding-right: 0px;
-        }
-      }
-
       .software-link {
         visibility: hidden;
         img {

--- a/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Link } from "react-router";
 import ReactTooltip from "react-tooltip";
 
+import { condenseVulnColumn } from "fleet/helpers";
 import PATHS from "router/paths";
 import { ISoftware } from "interfaces/software";
 import { IVulnerability } from "interfaces/vulnerability";
@@ -44,19 +45,6 @@ interface IHeaderProps {
   };
 }
 
-const condense = (vulnerabilities: IVulnerability[]): string[] => {
-  const condensed =
-    (vulnerabilities?.length &&
-      vulnerabilities
-        .slice(-3)
-        .map((v) => v.cve)
-        .reverse()) ||
-    [];
-  return vulnerabilities.length > 3
-    ? condensed.concat(`+${vulnerabilities.length - 3} more`)
-    : condensed;
-};
-
 const softwareTableHeaders = [
   {
     title: "Name",
@@ -83,7 +71,7 @@ const softwareTableHeaders = [
     accessor: "vulnerabilities",
     Cell: (cellProps: IVulnCellProps): JSX.Element => {
       const vulnerabilities = cellProps.cell.value || [];
-      const tooltipText = condense(vulnerabilities)?.map((value) => {
+      const tooltipText = condenseVulnColumn(vulnerabilities)?.map((value) => {
         return (
           <span key={`vuln_${value}`}>
             {value}

--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -231,11 +231,6 @@
         .id__cell {
           padding: 0;
         }
-        .vulnerabilities__cell {
-          img {
-            transform: scale(0.5);
-          }
-        }
       }
 
       tr {


### PR DESCRIPTION
Cerra #4214 

- Host Details Software tab: Remove Vulnerability icon column and add a vulnerability column mirroring Software page

<img width="1429" alt="Screen Shot 2022-03-28 at 1 42 33 PM" src="https://user-images.githubusercontent.com/71795832/160456133-f1a77b92-2567-41d3-bb35-686ce88a3333.png">

Moved the search multiple columns using client-side table container which is not specked in #4214 into a new ticket assigned to @gillespi314: #4837

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
