### PR TITLE
Added explicit read permissions + tweaked permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch: # Manual
   schedule:
   - cron: '0 6 * * *' # Nightly 6AM UTC
+    
+permissions:
+  contents: read
 
 jobs:
   markdown-link-check:

--- a/.github/workflows/generate-osqueryd-app-tar-gz.yml
+++ b/.github/workflows/generate-osqueryd-app-tar-gz.yml
@@ -16,6 +16,9 @@ on:
 env:
   OSQUERY_VERSION: 5.2.2
 
+permissions:
+  contents: read
+
 jobs:
   generate:
     runs-on: macos-latest

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -6,12 +6,14 @@ on:
       - 'fleet-*'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     environment: Docker Hub
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2

--- a/.github/workflows/goreleaser-orbit.yaml
+++ b/.github/workflows/goreleaser-orbit.yaml
@@ -6,12 +6,14 @@ on:
      - 'orbit-*'
      
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   goreleaser:
     runs-on: macos-latest
     environment: Docker Hub
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -2,6 +2,9 @@ name: Docker publish
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     # Only run it when the push is to the fleetdm/fleet repo. Otherwise the secrets for pushing to

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,6 +11,9 @@ on:
   workflow_dispatch: # Manual
   schedule:
   - cron: '0 2 * * *' # Nightly 2AM UTC
+    
+permissions:
+  contents: read
 
 jobs:
   gen:

--- a/.github/workflows/pr-helm.yaml
+++ b/.github/workflows/pr-helm.yaml
@@ -6,6 +6,9 @@ on:
     - '.github/workflows/pr-helm.yaml'
     - '.github/scripts/helm-check-expected.sh'
     - 'tools/ci/helm-values/**'
+    - 
+permissions:
+  contents: read
 
 jobs:
   sanity-check:

--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -4,11 +4,14 @@ on:
     types: [released] # don't trigger on pre-releases
   workflow_dispatch: # allow manual trigger
 
+
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   publish-chart:
+    permissions:
+      contents: write  # to push helm charts
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -14,6 +14,9 @@ on:
   schedule:
     - cron: '0 4 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   test-go:
     strategy:

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -9,8 +9,14 @@ on:
     paths:
       - '**.tf'
   workflow_dispatch: # Manual dispatch
+permissions:
+  contents: read
+
 jobs:
   tfsec:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
     name: tfsec sarif report
     runs-on: ubuntu-latest
 

--- a/.github/workflows/update-certs.yml
+++ b/.github/workflows/update-certs.yml
@@ -5,12 +5,15 @@ on:
   schedule:
   - cron: '0 6 * * *' # Nightly 6AM UTC
 
+
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   update-certs:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code


### PR DESCRIPTION
As a part of #4698 - this should fix the remaining warnings we get from the OSSF scorecard in relation to github workflows. They now all have explicit read permissions with more granular permissions granted in jobs.

@zwass Should be a little more straight forward than the first batch!