### PR TITLE
Update handbook page script to scroll to anchor links

### DIFF
--- a/website/assets/js/pages/handbook/basic-handbook.page.js
+++ b/website/assets/js/pages/handbook/basic-handbook.page.js
@@ -36,6 +36,16 @@ parasails.registerPage('basic-handbook', {
       },
     });
 
+    // Handle hashes in urls when coming from an external page.
+    if(window.location.hash){
+      let possibleHashToScrollTo = _.trimLeft(window.location.hash, '#');
+      let hashToScrollTo = document.getElementById(possibleHashToScrollTo);
+      // If the hash matches a header's ID, we'll scroll to that section.
+      if(hashToScrollTo){
+        hashToScrollTo.scrollIntoView();
+      }
+    }
+
     this.subtopics = (() => {
       let subtopics;
       if(!this.isHandbookLandingPage){


### PR DESCRIPTION
Firefox currently does not scroll to anchor links (e.g. `#values`) when navigating from a different page.

Changes: 
- Updated the handbook's page script to handle anchor links in URLs when coming from a different page.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
