### PR TITLE
Ritual Heading with OKR planning subheading

### DIFF
--- a/handbook/people.md
+++ b/handbook/people.md
@@ -263,6 +263,13 @@ These are the Slack channels the digital experience team maintains. If the chann
 
 ### OKR Planning
 
+OKRs help inform what to prioritize, and communicate company goals while encouraging cross team collaboration.
+
+At the end of the quarter, and at key points throughout the quarter (every 3 weeks), we review the status of each OKR (depending on the KR, either 100% or ≥70% completion is considered "success")
+
+- Review topdown and departmental OKRs as they are turned in.
+- OKRs they are finalized 1 week from when topdown OKRs were initially reviewed.
+- Finalized OKRs are shared company-wide and at "all hands" and, at least to some degree, become public.
 
 
 

--- a/handbook/people.md
+++ b/handbook/people.md
@@ -248,17 +248,6 @@ When the final signature is added to an envelope in Docusign, it is marked as co
       link: drive.google.com/[destinationFolderID]
    ```
 
-## Slack channels
-
-These are the Slack channels the digital experience team maintains. If the channel has a [directly responsible individual](#directly-resonsible-individuals) (**DRI**), they will be specified. These people are responsible for keeping up with all new messages, even if they aren't mentioned. 
-
-- **#g-digital-experience** - **DRI**: Mike Thomas
-- **#peepops** - **DRI**: Eric Shaw
-- **#help-onboarding** - **DRI**: Eric Shaw
-- **#oooh-automation** - **DRI**: Mike McNeil
-
-**Who should have these channels unmuted?** Members of this group, everyone else is encouraged to mute them.
-
 ## Rituals
 
 ### OKR Planning
@@ -271,6 +260,15 @@ At the end of the quarter, and at key points throughout the quarter (every 3 wee
 - OKRs they are finalized 1 week from when topdown OKRs were initially reviewed.
 - Finalized OKRs are shared company-wide and at "all hands" and, at least to some degree, become public.
 
+## Slack channels
 
+These are the Slack channels the digital experience team maintains. If the channel has a [directly responsible individual](#directly-resonsible-individuals) (**DRI**), they will be specified. These people are responsible for keeping up with all new messages, even if they aren't mentioned. 
+
+- **#g-digital-experience** - **DRI**: Mike Thomas
+- **#peepops** - **DRI**: Eric Shaw
+- **#help-onboarding** - **DRI**: Eric Shaw
+- **#oooh-automation** - **DRI**: Mike McNeil
+
+**Who should have these channels unmuted?** Members of this group, everyone else is encouraged to mute them.
 
 <meta name="maintainedBy" value="eashaw">

--- a/handbook/people.md
+++ b/handbook/people.md
@@ -259,4 +259,11 @@ These are the Slack channels the digital experience team maintains. If the chann
 
 **Who should have these channels unmuted?** Members of this group, everyone else is encouraged to mute them.
 
+## Rituals
+
+### OKR Planning
+
+
+
+
 <meta name="maintainedBy" value="eashaw">


### PR DESCRIPTION
Proposing to add the ritual heading to handbook/people in line with [https://github.com/fleetdm/confidential/issues/1013] and [https://github.com/fleetdm/fleet/issues/4671].

cc: @hollidayn

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [x] Documented any permissions changes
- [x] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
