### PR TITLE
fix rename tmp file

### DIFF
--- a/changes/issue-4792-download-tmp
+++ b/changes/issue-4792-download-tmp
@@ -1,0 +1,1 @@
+* Fix issue when renaming temporary files to another filesystem

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -17,7 +17,7 @@ import (
 
 // Decompressed downloads and decompresses a file from a URL to a local path.
 //
-// It supports gz, bz2 and gz compressed files.
+// It supports gz, bz2 and xz compressed files.
 func Decompressed(client *http.Client, u url.URL, path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/ulikunitz/xz"
 )
 
@@ -85,7 +84,7 @@ func Decompressed(client *http.Client, u url.URL, path string) error {
 
 	// Writes are not synchronous. Handle errors from writes returned by Close.
 	if err := tmpFile.Close(); err != nil {
-		return errors.Wrapf(err, "write and close temporary file")
+		return fmt.Errorf("write and close temporary file: %w", err)
 	}
 
 	if err := os.Rename(tmpFile.Name(), path); err != nil {


### PR DESCRIPTION
#4792

Renaming a temporary file to the final destination does not always work.
Specifically, if the source and destination paths are on different file
systems, you will get the following error

 invalid cross-device link

Instead, create and write to the desitination file directly.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [ ] ~Documented any API changes (docs/Using-Fleet/REST-API.md)~
- [ ] ~Documented any permissions changes~
- [ ] ~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
- [ ] ~Added/updated tests~
- [x] Manual QA for all new/changed functionality
