### PR TITLE
App Settings Page: Remove viewing enroll secrets from this page

### DIFF
--- a/changes/issue-3573-remove-enroll-secrets-from-settings-page
+++ b/changes/issue-3573-remove-enroll-secrets-from-settings-page
@@ -1,0 +1,1 @@
+* Global enroll secrets not viewable on the settings page (viewable and modifable on Manage Hosts page and Team Details page only)

--- a/frontend/components/forms/admin/AppConfigForm/AppConfigForm.tsx
+++ b/frontend/components/forms/admin/AppConfigForm/AppConfigForm.tsx
@@ -11,7 +11,6 @@ import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
-import EnrollSecretTable from "components/EnrollSecretTable";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
 // @ts-ignore
@@ -42,7 +41,6 @@ const baseClass = "app-config-form";
 
 const AppConfigFormFunctional = ({
   appConfig,
-  enrollSecret,
   handleSubmit,
 }: IAppConfigFormProps): JSX.Element => {
   // STATE
@@ -627,22 +625,6 @@ const AppConfigFormFunctional = ({
     );
   };
 
-  const renderOsqueryEnrollmentSecretsSection = () => {
-    return (
-      <div className={`${baseClass}__section`}>
-        <h2>
-          <a id="osquery-enrollment-secrets">Osquery enrollment secrets</a>
-        </h2>
-        <div className={`${baseClass}__inputs`}>
-          <p className={`${baseClass}__enroll-secret-label`}>
-            Manage secrets with <code>fleetctl</code>. Active secrets:
-          </p>
-          <EnrollSecretTable secrets={enrollSecret} />
-        </div>
-      </div>
-    );
-  };
-
   const renderGlobalAgentOptionsSection = () => {
     return (
       <div className={`${baseClass}__section`}>
@@ -977,7 +959,6 @@ const AppConfigFormFunctional = ({
         {renderFleetWebAddressSection()}
         {renderSAMLSingleSignOnOptionsSection()}
         {renderSMTPOptionsSection()}
-        {renderOsqueryEnrollmentSecretsSection()}
         {renderGlobalAgentOptionsSection()}
         {renderHostStatusWebhookSection()}
         {renderUsageStatistics()}

--- a/frontend/components/forms/admin/AppConfigForm/constants.ts
+++ b/frontend/components/forms/admin/AppConfigForm/constants.ts
@@ -1,9 +1,7 @@
 import { IConfigNested } from "interfaces/config";
-import { IEnrollSecret } from "interfaces/enroll_secret";
 
 export interface IAppConfigFormProps {
   appConfig: IConfigNested;
-  enrollSecret: IEnrollSecret[] | undefined;
   handleSubmit: any;
 }
 

--- a/frontend/pages/admin/AppSettingsPage/AppSettingsPage.tsx
+++ b/frontend/pages/admin/AppSettingsPage/AppSettingsPage.tsx
@@ -5,17 +5,12 @@ import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification"; // @ts-ignore
 import { getConfig } from "redux/nodes/app/actions";
 
-import enrollSecretsAPI from "services/entities/enroll_secret";
 import configAPI from "services/entities/config";
 
 // @ts-ignore
 import deepDifference from "utilities/deep_difference";
 import { IConfig, IConfigNested } from "interfaces/config";
 import { IApiError } from "interfaces/errors";
-import {
-  IEnrollSecret,
-  IEnrollSecretsResponse,
-} from "interfaces/enroll_secret";
 
 // @ts-ignore
 import AppConfigForm from "components/forms/admin/AppConfigForm";
@@ -39,15 +34,6 @@ const AppSettingsPage = (): JSX.Element => {
       select: (data: IConfigNested) => data,
     }
   );
-
-  const { data: globalSecrets } = useQuery<
-    IEnrollSecretsResponse,
-    Error,
-    IEnrollSecret[]
-  >(["global secrets"], () => enrollSecretsAPI.getGlobalEnrollSecrets(), {
-    enabled: true,
-    select: (data: IEnrollSecretsResponse) => data.secrets,
-  });
 
   const onFormSubmit = useCallback(
     (formData: IConfigNested) => {
@@ -104,8 +90,7 @@ const AppSettingsPage = (): JSX.Element => {
   return (
     <div className={`${baseClass} body-wrap`}>
       <p className={`${baseClass}__page-description`}>
-        Set your organization information, Configure SAML and SMTP, and view
-        host enroll secrets.
+        Set your organization information and configure SAML and SMTP.
       </p>
       <div className={`${baseClass}__settings-form`}>
         <nav>
@@ -129,11 +114,6 @@ const AppSettingsPage = (): JSX.Element => {
               <a onClick={() => scrollInto("smtp")}>SMTP options</a>
             </li>
             <li>
-              <a onClick={() => scrollInto("osquery-enrollment-secrets")}>
-                Osquery enrollment secrets
-              </a>
-            </li>
-            <li>
               <a onClick={() => scrollInto("agent-options")}>
                 Global agent options
               </a>
@@ -154,11 +134,7 @@ const AppSettingsPage = (): JSX.Element => {
           </ul>
         </nav>
         {!isLoadingConfig && appConfig && (
-          <AppConfigForm
-            appConfig={appConfig}
-            handleSubmit={onFormSubmit}
-            enrollSecret={globalSecrets}
-          />
+          <AppConfigForm appConfig={appConfig} handleSubmit={onFormSubmit} />
         )}
       </div>
     </div>


### PR DESCRIPTION
Cerra #3573 

View and modify enroll secrets is available in a modal on Manage Host page and Team Details page
- Removed unnecessary view enroll secrets from App Settings page

<img width="1240" alt="Screen Shot 2022-04-01 at 9 55 55 AM" src="https://user-images.githubusercontent.com/71795832/161277996-6aa7a6f6-872c-4ef6-a340-0325ca904795.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
