### PR TITLE
Handle undefined value for availableTeams context

### DIFF
--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -155,10 +155,10 @@ const reducer = (state: InitialStateType, action: IAction) => {
 
       return {
         ...state,
-        availableTeams: availableTeams.sort(
-          (a: ITeamSummary, b: ITeamSummary) =>
+        availableTeams:
+          availableTeams?.sort((a: ITeamSummary, b: ITeamSummary) =>
             sort.caseInsensitiveAsc(a.name, b.name)
-        ),
+          ) || [],
       };
     }
     case ACTIONS.SET_CURRENT_USER: {


### PR DESCRIPTION
Fixes bug observed on `/profile` page when attempting to update current user profile info 

TODO: Open ticket to add e2e test coverage for `/profile` page

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- ~~Changes file added (for user-visible changes)~~
- ~~Documented any API changes (docs/Using-Fleet/REST-API.md)~~
- ~~Documented any permissions changes~~
- ~~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~~
-  ~~Added/updated tests~~
- [x] Manual QA for all new/changed functionality
