### PR TITLE
Homepage & Manage Host Page: Improved empty software messages

### DIFF
--- a/changes/issue-4132-software-messaging
+++ b/changes/issue-4132-software-messaging
@@ -1,0 +1,1 @@
+* Improve software tables messages for missing software information

--- a/frontend/pages/Homepage/cards/Software/Software.tsx
+++ b/frontend/pages/Homepage/cards/Software/Software.tsx
@@ -75,7 +75,7 @@ const Software = ({
       staleTime: 30000, // TODO: Discuss a reasonable staleTime given that counts are only updated infrequently?
       onSuccess: (data) => {
         setShowSoftwareUI(true);
-        if (isSoftwareEnabled && data.software.length !== 0) {
+        if (isSoftwareEnabled && data.software?.length !== 0) {
           setTitleDetail &&
             setTitleDetail(
               renderLastUpdatedText(data.counts_updated_at, "software")

--- a/frontend/pages/Homepage/cards/Software/Software.tsx
+++ b/frontend/pages/Homepage/cards/Software/Software.tsx
@@ -75,7 +75,7 @@ const Software = ({
       staleTime: 30000, // TODO: Discuss a reasonable staleTime given that counts are only updated infrequently?
       onSuccess: (data) => {
         setShowSoftwareUI(true);
-        if (isSoftwareEnabled && software?.software.length !== 0) {
+        if (isSoftwareEnabled && data.software.length !== 0) {
           setTitleDetail &&
             setTitleDetail(
               renderLastUpdatedText(data.counts_updated_at, "software")

--- a/frontend/pages/Homepage/cards/Software/Software.tsx
+++ b/frontend/pages/Homepage/cards/Software/Software.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "react-query";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 
 import paths from "router/paths";
+import configAPI from "services/entities/config";
 import softwareAPI, { ISoftwareResponse } from "services/entities/software";
 
 import TabsWrapper from "components/TabsWrapper";
@@ -12,6 +13,7 @@ import TableDataError from "components/TableDataError"; // TODO how do we handle
 import Spinner from "components/Spinner";
 import renderLastUpdatedText from "components/LastUpdatedText/LastUpdatedText";
 import generateTableHeaders from "./SoftwareTableConfig";
+import EmptySoftware from "../../../software/components/EmptySoftware";
 
 interface ISoftwareCardProps {
   currentTeamId?: number;
@@ -26,31 +28,6 @@ const DEFAULT_SORT_HEADER = "hosts_count";
 const PAGE_SIZE = 8;
 const baseClass = "home-software";
 
-const EmptySoftware = (message: string): JSX.Element => {
-  return (
-    <div className={`${baseClass}__empty-software`}>
-      <h1>
-        No installed software{" "}
-        {message === "vulnerable"
-          ? "with detected vulnerabilities"
-          : "detected"}
-        .
-      </h1>
-      <p>
-        Expecting to see software? Check out the Fleet documentation on{" "}
-        <a
-          href="https://fleetdm.com/docs/using-fleet/vulnerability-processing#configuration"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          how to configure software inventory
-        </a>
-        .
-      </p>
-    </div>
-  );
-};
-
 const Software = ({
   currentTeamId,
   showSoftwareUI,
@@ -60,6 +37,13 @@ const Software = ({
 }: ISoftwareCardProps): JSX.Element => {
   const [navTabIndex, setNavTabIndex] = useState<number>(0);
   const [pageIndex, setPageIndex] = useState<number>(0);
+  const [isSoftwareEnabled, setIsSoftwareEnabled] = useState<boolean>();
+
+  const { data: config } = useQuery(["config"], configAPI.loadAll, {
+    onSuccess: (data) => {
+      setIsSoftwareEnabled(data?.host_settings?.enable_software_inventory);
+    },
+  });
 
   const {
     data: software,
@@ -91,13 +75,30 @@ const Software = ({
       staleTime: 30000, // TODO: Discuss a reasonable staleTime given that counts are only updated infrequently?
       onSuccess: (data) => {
         setShowSoftwareUI(true);
-        setTitleDetail &&
-          setTitleDetail(
-            renderLastUpdatedText(data.counts_updated_at, "software")
-          );
+        if (isSoftwareEnabled) {
+          setTitleDetail &&
+            setTitleDetail(
+              renderLastUpdatedText(data.counts_updated_at, "software")
+            );
+        }
+        if (software?.software.length === 0) {
+          setTitleDetail && setTitleDetail("");
+        }
       },
     }
   );
+
+  // TODO: Rework after backend is adjusted to differentiate empty search/filter results from
+  // collecting inventory
+  const isCollectingInventory =
+    !currentTeamId &&
+    !pageIndex &&
+    !software?.software &&
+    software?.counts_updated_at === null;
+
+  if (isCollectingInventory) {
+    setTitleDetail && setTitleDetail("");
+  }
 
   // NOTE: this is called once on the initial rendering. The initial render of
   // the TableContainer child component will call this handler.
@@ -149,7 +150,13 @@ const Software = ({
                   defaultSortDirection={DEFAULT_SORT_DIRECTION}
                   hideActionButton
                   resultsTitle={"software"}
-                  emptyComponent={EmptySoftware}
+                  emptyComponent={() =>
+                    EmptySoftware(
+                      (!isSoftwareEnabled && "disabled") ||
+                        (isCollectingInventory && "collecting") ||
+                        "default"
+                    )
+                  }
                   showMarkAllPages={false}
                   isAllPagesSelected={false}
                   disableCount
@@ -168,7 +175,13 @@ const Software = ({
                 defaultSortDirection={DEFAULT_SORT_DIRECTION}
                 hideActionButton
                 resultsTitle={"software"}
-                emptyComponent={() => EmptySoftware("vulnerable")}
+                emptyComponent={() =>
+                  EmptySoftware(
+                    (!isSoftwareEnabled && "disabled") ||
+                      (isCollectingInventory && "collecting") ||
+                      "default"
+                  )
+                }
                 showMarkAllPages={false}
                 isAllPagesSelected={false}
                 disableCount

--- a/frontend/pages/Homepage/cards/Software/Software.tsx
+++ b/frontend/pages/Homepage/cards/Software/Software.tsx
@@ -75,14 +75,11 @@ const Software = ({
       staleTime: 30000, // TODO: Discuss a reasonable staleTime given that counts are only updated infrequently?
       onSuccess: (data) => {
         setShowSoftwareUI(true);
-        if (isSoftwareEnabled) {
+        if (isSoftwareEnabled && software?.software.length !== 0) {
           setTitleDetail &&
             setTitleDetail(
               renderLastUpdatedText(data.counts_updated_at, "software")
             );
-        }
-        if (software?.software.length === 0) {
-          setTitleDetail && setTitleDetail("");
         }
       },
     }

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -5,10 +5,12 @@ import { InjectedRouter } from "react-router/lib/Router";
 import { useDebouncedCallback } from "use-debounce/lib";
 
 import { AppContext } from "context/app";
-import { NotificationContext } from "context/notification";
 import { IConfig, IConfigNested } from "interfaces/config";
-import { IWebhookSoftwareVulnerabilities } from "interfaces/webhook"; // @ts-ignore
+import { IWebhookSoftwareVulnerabilities } from "interfaces/webhook";
+// @ts-ignore
 import { getConfig } from "redux/nodes/app/actions";
+// @ts-ignore
+import { renderFlash } from "redux/nodes/notifications/actions";
 import configAPI from "services/entities/config";
 import softwareAPI, {
   ISoftwareResponse,
@@ -19,8 +21,10 @@ import {
   VULNERABLE_DROPDOWN_OPTIONS,
 } from "utilities/constants";
 
-import Button from "components/buttons/Button"; // @ts-ignore
-import Dropdown from "components/forms/fields/Dropdown"; // @ts-ignore
+import Button from "components/buttons/Button";
+// @ts-ignore
+import Dropdown from "components/forms/fields/Dropdown";
+// @ts-ignore
 import Spinner from "components/Spinner";
 import TableContainer, { ITableQueryData } from "components/TableContainer";
 import TableDataError from "components/TableDataError";
@@ -28,6 +32,7 @@ import TeamsDropdownHeader, {
   ITeamsDropdownState,
 } from "components/PageHeader/TeamsDropdownHeader";
 import renderLastUpdatedText from "components/LastUpdatedText";
+
 import softwareTableHeaders from "./SoftwareTableConfig";
 import ManageAutomationsModal from "./components/ManageAutomationsModal";
 import EmptySoftware from "../components/EmptySoftware";
@@ -62,7 +67,6 @@ const ManageSoftwarePage = ({
     isGlobalAdmin,
     isGlobalMaintainer,
   } = useContext(AppContext);
-  const { renderFlash } = useContext(NotificationContext);
 
   const [isSoftwareEnabled, setIsSoftwareEnabled] = useState<boolean>();
   const [filterVuln, setFilterVuln] = useState(
@@ -223,15 +227,19 @@ const ManageSoftwarePage = ({
         },
       });
       await request.then(() => {
-        renderFlash(
-          "success",
-          "Successfully updated vulnerability automations."
+        dispatch(
+          renderFlash(
+            "success",
+            "Successfully updated vulnerability automations."
+          )
         );
       });
     } catch {
-      renderFlash(
-        "error",
-        "Could not update vulnerability automations. Please try again."
+      dispatch(
+        renderFlash(
+          "error",
+          "Could not update vulnerability automations. Please try again."
+        )
       );
     } finally {
       toggleManageAutomationsModal();

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -5,12 +5,11 @@ import { InjectedRouter } from "react-router/lib/Router";
 import { useDebouncedCallback } from "use-debounce/lib";
 
 import { AppContext } from "context/app";
+import { NotificationContext } from "context/notification";
 import { IConfig, IConfigNested } from "interfaces/config";
 import { IWebhookSoftwareVulnerabilities } from "interfaces/webhook";
 // @ts-ignore
 import { getConfig } from "redux/nodes/app/actions";
-// @ts-ignore
-import { renderFlash } from "redux/nodes/notifications/actions";
 import configAPI from "services/entities/config";
 import softwareAPI, {
   ISoftwareResponse,
@@ -67,6 +66,7 @@ const ManageSoftwarePage = ({
     isGlobalAdmin,
     isGlobalMaintainer,
   } = useContext(AppContext);
+  const { renderFlash } = useContext(NotificationContext);
 
   const [isSoftwareEnabled, setIsSoftwareEnabled] = useState<boolean>();
   const [filterVuln, setFilterVuln] = useState(
@@ -227,19 +227,15 @@ const ManageSoftwarePage = ({
         },
       });
       await request.then(() => {
-        dispatch(
-          renderFlash(
-            "success",
-            "Successfully updated vulnerability automations."
-          )
+        renderFlash(
+          "success",
+          "Successfully updated vulnerability automations."
         );
       });
     } catch {
-      dispatch(
-        renderFlash(
-          "error",
-          "Could not update vulnerability automations. Please try again."
-        )
+      renderFlash(
+        "error",
+        "Could not update vulnerability automations. Please try again."
       );
     } finally {
       toggleManageAutomationsModal();

--- a/frontend/pages/software/components/EmptySoftware.tsx
+++ b/frontend/pages/software/components/EmptySoftware.tsx
@@ -1,3 +1,5 @@
+// This component is used on ManageSoftwarePage.tsx and Homepage.tsx > Software.tsx card
+
 import React from "react";
 
 import ExternalLinkIcon from "../../../../assets/images/open-new-tab-12x12@2x.png";
@@ -43,10 +45,7 @@ const EmptySoftware = (message: IEmptySoftware): JSX.Element => {
         <div className={`${baseClass}__empty-software`}>
           <div className="empty-software__inner">
             <h1>No software matches the current search criteria.</h1>
-            <p>
-              Expecting to see software? Try again in about 1 hour as the system
-              catches up.
-            </p>
+            <p>Try again in about 1 hour as the system catches up.</p>
           </div>
         </div>
       );


### PR DESCRIPTION
Cerra #4132 

Empty software on homepage matches empty software on Manage Host Page:
- Empty state
- Collecting state
- Disabled state
- Removes "Last updated at..." on homepage for all 3 of these empty states
- All wording matches Figma
- Reuse same `pages/software/components/EmptySoftware.tsx` component for Homepage and Manage Software Page

Screenshots:
<img width="820" alt="Screen Shot 2022-04-05 at 1 13 50 PM" src="https://user-images.githubusercontent.com/71795832/161814222-1ffba9ff-e438-4bbc-93d7-467c95bd3351.png">
<img width="680" alt="Screen Shot 2022-04-05 at 11 11 23 AM" src="https://user-images.githubusercontent.com/71795832/161814228-3b1c6850-a041-47f5-9c42-d71a15b04c7b.png">
<img width="691" alt="Screen Shot 2022-04-05 at 11 11 16 AM" src="https://user-images.githubusercontent.com/71795832/161814230-76054f4c-d4b2-47d8-af94-a2d0f98ad4c2.png">
<img width="850" alt="Screen Shot 2022-04-05 at 11 05 17 AM" src="https://user-images.githubusercontent.com/71795832/161814231-71d6fb63-9c2a-4d3a-b782-7a79dc294a8e.png">
<img width="806" alt="Screen Shot 2022-04-05 at 11 05 11 AM" src="https://user-images.githubusercontent.com/71795832/161814234-c487587b-914e-4b9f-aa92-e138f009bd19.png">
<img width="1342" alt="Screen Shot 2022-04-05 at 8 50 11 AM" src="https://user-images.githubusercontent.com/71795832/161814235-18579cc5-e189-4219-8ca6-6f3b35f2da7e.png">
<img width="1344" alt="Screen Shot 2022-04-05 at 8 49 48 AM" src="https://user-images.githubusercontent.com/71795832/161814238-f3ea31fc-ee27-46ba-ae79-554fddbd1c62.png">
<img width="1340" alt="Screen Shot 2022-04-05 at 8 49 21 AM" src="https://user-images.githubusercontent.com/71795832/161814239-a4a73933-f206-468d-98f1-dfa3115281bd.png">

Conversation with Product:
Will not update host details software table or device user software table during this iteration, it is planned out for another ticket

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
