### PR TITLE
Website: upgrade marked dependency

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,7 @@
     "grunt": "1.0.4",
     "htmlhint": "0.11.0",
     "lesshint": "6.3.6",
-    "marked": "0.3.5",
+    "marked": "0.4.0",
     "sails-hook-grunt": "^4.0.0",
     "yaml": "1.10.2"
   },


### PR DESCRIPTION
Closes #4956 

This PR upgrades the version of `marked` we use for the Fleet website.

We're currently using `marked@0.3.5`, `marked@0.4.0` adds support for parenthesis in Markdown links.

I've tested `marked@0.4.0` and have confirmed that Markdown links with parenthesis display properly once converted to HTML, and that the custom HTML rendering in [`to-html.js` ](https://github.com/fleetdm/fleet/blob/main/website/api/helpers/strings/to-html.js) work as expected (adding ids and optional linebreaks to headings and removing `<pre>` tags from mermaid codeblocks) and the generated HTML is identical

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
