### PR TITLE
App up to date or not installed + no unencrypted SSH keys

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -607,4 +607,4 @@ spec:
   resolution: "Enroll device to MDM"
   platforms: macOS
   contributors: GuillaumeRoss
-  
+ 

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -603,8 +603,17 @@ kind: policy
 spec:
   name: Application is up to date or not present (macOS) (Docker example)
   query: SELECT 1 WHERE EXISTS (SELECT 1 FROM apps a1 WHERE a1.bundle_identifier = 'com.electron.dockerdesktop' AND a1.bundle_short_version>='4.6.1') OR NOT EXISTS (SELECT 1 FROM apps a2 WHERE a2.bundle_identifier = 'com.electron.dockerdesktop');
-  description: "Required: osquery deployed with Orbit, or manual installation of macadmins/osquery-extension. Checks that a Mac is enrolled to MDM. Add a AND on identity_certificate_uuid to check for a specific MDM."
-  resolution: "Enroll device to MDM"
+  description: "Checks if Docker is installed and at version 4.6.1 or above, or not installed. Fails if Docker is installed and on a lower version."
+  resolution: "Update Docker or remove it if not used."
   platforms: macOS
   contributors: GuillaumeRoss
- 
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: No unencrypted SSH keys are present
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM users CROSS JOIN user_ssh_keys USING (uid) WHERE encrypted='0');
+  description: "Required: osquery must have Full Disk Access. Policy passes if no unencrypted SSH keys are found in the ~/.ssh of users on the system."
+  resolution: "Use this command to encrypt existing SSH keys: ssh-keygen -o -p -f keyfile"
+  platforms: macOS, Linux, Windows
+  contributors: GuillaumeRoss

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -597,3 +597,14 @@ spec:
   resolution: "Enroll device to MDM"
   platforms: macOS
   contributors: GuillaumeRoss
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Application is up to date or not present (macOS) (Docker example)
+  query: SELECT 1 WHERE EXISTS (SELECT 1 FROM apps a1 WHERE a1.bundle_identifier = 'com.electron.dockerdesktop' AND a1.bundle_short_version>='4.6.1') OR NOT EXISTS (SELECT 1 FROM apps a2 WHERE a2.bundle_identifier = 'com.electron.dockerdesktop');
+  description: "Required: osquery deployed with Orbit, or manual installation of macadmins/osquery-extension. Checks that a Mac is enrolled to MDM. Add a AND on identity_certificate_uuid to check for a specific MDM."
+  resolution: "Enroll device to MDM"
+  platforms: macOS
+  contributors: GuillaumeRoss
+  

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -603,7 +603,7 @@ kind: policy
 spec:
   name: Application is up to date or not present (macOS)
   query: SELECT 1 WHERE EXISTS (SELECT 1 FROM apps a1 WHERE a1.bundle_identifier = 'com.electron.dockerdesktop' AND a1.bundle_short_version>='4.6.1') OR NOT EXISTS (SELECT 1 FROM apps a2 WHERE a2.bundle_identifier = 'com.electron.dockerdesktop');
-  description: "Checks if the application (Docker Desktop example) is installed and up to date, or not installed. Fails if the application is installed and on a lower version. To check a different application, in the 'Query', replace the bundle_identifier value and the bundle_short_version value."
+  description: "Checks if the application (Docker Desktop example) is installed and up to date, or not installed. Fails if the application is installed and on a lower version. To check a different application, in the 'Query', replace the bundle_identifier value and the bundle_short_version value. You can copy this query and replace the bundle_identifier and bundle_version values to apply the same type of policy to other applications."
   resolution: "Update Docker or remove it if not used."
   platforms: macOS
   contributors: GuillaumeRoss
@@ -613,7 +613,7 @@ kind: policy
 spec:
   name: SSH keys encrypted
   query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM users CROSS JOIN user_ssh_keys USING (uid) WHERE encrypted='0');
-  description: "Required: osquery must have Full Disk Access. Policy passes if no unencrypted SSH keys are found in the ~/.ssh of users on the system."
-  resolution: "Use this command to encrypt existing SSH keys: ssh-keygen -o -p -f keyfile"
+  description: "Required: osquery must have Full Disk Access. Policy passes if all keys are encrypted, including if no keys are present."
+  resolution: "Use this command to encrypt existing SSH keys by providing the path to the file: ssh-keygen -o -p -f /path/to/file"
   platforms: macOS, Linux, Windows
   contributors: GuillaumeRoss

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -601,7 +601,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: Application is up to date or not present (macOS) (Docker example)
+  name: Application is up to date or not present (macOS)
   query: SELECT 1 WHERE EXISTS (SELECT 1 FROM apps a1 WHERE a1.bundle_identifier = 'com.electron.dockerdesktop' AND a1.bundle_short_version>='4.6.1') OR NOT EXISTS (SELECT 1 FROM apps a2 WHERE a2.bundle_identifier = 'com.electron.dockerdesktop');
   description: "Checks if Docker is installed and at version 4.6.1 or above, or not installed. Fails if Docker is installed and on a lower version."
   resolution: "Update Docker or remove it if not used."

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -603,7 +603,7 @@ kind: policy
 spec:
   name: Application is up to date or not present (macOS)
   query: SELECT 1 WHERE EXISTS (SELECT 1 FROM apps a1 WHERE a1.bundle_identifier = 'com.electron.dockerdesktop' AND a1.bundle_short_version>='4.6.1') OR NOT EXISTS (SELECT 1 FROM apps a2 WHERE a2.bundle_identifier = 'com.electron.dockerdesktop');
-  description: "Checks if Docker is installed and at version 4.6.1 or above, or not installed. Fails if Docker is installed and on a lower version."
+  description: "Checks if the application (Docker Desktop example) is installed and up to date, or not installed. Fails if the application is installed and on a lower version. To check a different application, in the 'Query', replace the bundle_identifier value and the bundle_short_version value."
   resolution: "Update Docker or remove it if not used."
   platforms: macOS
   contributors: GuillaumeRoss

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -603,7 +603,7 @@ kind: policy
 spec:
   name: Application is up to date or not present (macOS)
   query: SELECT 1 WHERE EXISTS (SELECT 1 FROM apps a1 WHERE a1.bundle_identifier = 'com.electron.dockerdesktop' AND a1.bundle_short_version>='4.6.1') OR NOT EXISTS (SELECT 1 FROM apps a2 WHERE a2.bundle_identifier = 'com.electron.dockerdesktop');
-  description: "Checks if the application (Docker Desktop example) is installed and up to date, or not installed. Fails if the application is installed and on a lower version. To check a different application, in the 'Query', replace the bundle_identifier value and the bundle_short_version value. You can copy this query and replace the bundle_identifier and bundle_version values to apply the same type of policy to other applications."
+  description: "Checks if the application (Docker Desktop example) is installed and up to date, or not installed. Fails if the application is installed and on a lower version. You can copy this query and replace the bundle_identifier and bundle_version values to apply the same type of policy to other applications."
   resolution: "Update Docker or remove it if not used."
   platforms: macOS
   contributors: GuillaumeRoss

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -611,7 +611,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: No unencrypted SSH keys are present
+  name: SSH keys encrypted
   query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM users CROSS JOIN user_ssh_keys USING (uid) WHERE encrypted='0');
   description: "Required: osquery must have Full Disk Access. Policy passes if no unencrypted SSH keys are found in the ~/.ssh of users on the system."
   resolution: "Use this command to encrypt existing SSH keys: ssh-keygen -o -p -f keyfile"


### PR DESCRIPTION
Adding "App installed and up to date OR not present" example + policy query to detect unencrypted SSH keys.

This closes #4967 and #4990