### PR TITLE
chore(test): rewritten registration form page's test  using rtl

### DIFF
--- a/frontend/components/forms/RegistrationForm/FleetDetails/FleetDetails.tests.jsx
+++ b/frontend/components/forms/RegistrationForm/FleetDetails/FleetDetails.tests.jsx
@@ -1,76 +1,58 @@
 import React from "react";
-import { mount } from "enzyme";
-import { noop } from "lodash";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import FleetDetails from "components/forms/RegistrationForm/FleetDetails";
-import { fillInFormInput } from "test/helpers";
 
 describe("FleetDetails - form", () => {
-  describe("fleet web address input", () => {
-    it("renders an input field", () => {
-      const form = mount(<FleetDetails handleSubmit={noop} />);
-      const fleetWebAddressField = form.find({ name: "server_url" });
+  const handleSubmitSpy = jest.fn();
+  it("renders", () => {
+    render(<FleetDetails handleSubmit={handleSubmitSpy} />);
 
-      expect(fleetWebAddressField.length).toBeGreaterThan(0);
-    });
-
-    it("updates state when the field changes", () => {
-      const form = mount(<FleetDetails handleSubmit={noop} />);
-      const serverAddressField = form
-        .find({ name: "server_url" })
-        .find("input");
-
-      fillInFormInput(serverAddressField, "https://gnar.Fleet.co");
-
-      expect(form.state().formData).toMatchObject({
-        server_url: "https://gnar.Fleet.co",
-      });
-    });
+    expect(
+      screen.getByRole("textbox", { name: "Fleet web address" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument();
   });
 
-  describe("submitting the form", () => {
-    it("validates the presence of the fleet web address field", () => {
-      const handleSubmitSpy = jest.fn();
-      const form = mount(<FleetDetails handleSubmit={handleSubmitSpy} />);
-      const htmlForm = form.find("form");
+  it("validates the presence of the fleet web address field", () => {
+    render(<FleetDetails handleSubmit={handleSubmitSpy} currentPage />);
 
-      htmlForm.simulate("submit");
+    // when
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    // then
+    expect(handleSubmitSpy).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("Fleet web address must be completed")
+    ).toBeInTheDocument();
+  });
 
-      expect(handleSubmitSpy).not.toHaveBeenCalled();
-      expect(form.state().errors).toMatchObject({
-        server_url: "Fleet web address must be completed",
-      });
-    });
+  it("validates the fleet web address field starts with https://", () => {
+    render(<FleetDetails handleSubmit={handleSubmitSpy} currentPage />);
+    // when
+    userEvent.type(
+      screen.getByRole("textbox", { name: "Fleet web address" }),
+      "http://gnar.Fleet.co"
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    // then
+    expect(handleSubmitSpy).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("Fleet web address must start with https://")
+    ).toBeInTheDocument();
+  });
 
-    it("validates the fleet web address field starts with https://", () => {
-      const handleSubmitSpy = jest.fn();
-      const form = mount(<FleetDetails handleSubmit={handleSubmitSpy} />);
-      const fleetWebAddressField = form
-        .find({ name: "server_url" })
-        .find("input");
-      const htmlForm = form.find("form");
-
-      fillInFormInput(fleetWebAddressField, "http://gnar.Fleet.co");
-      htmlForm.simulate("submit");
-
-      expect(handleSubmitSpy).not.toHaveBeenCalled();
-      expect(form.state().errors).toMatchObject({
-        server_url: "Fleet web address must start with https://",
-      });
-    });
-
-    it("submits the form when valid", () => {
-      const handleSubmitSpy = jest.fn();
-      const form = mount(<FleetDetails handleSubmit={handleSubmitSpy} />);
-      const fleetWebAddressField = form
-        .find({ name: "server_url" })
-        .find("input");
-      const htmlForm = form.find("form");
-
-      fillInFormInput(fleetWebAddressField, "https://gnar.Fleet.co");
-      htmlForm.simulate("submit");
-
-      expect(handleSubmitSpy).toHaveBeenCalled();
+  it("submits the form when valid", () => {
+    render(<FleetDetails handleSubmit={handleSubmitSpy} currentPage />);
+    // when
+    userEvent.type(
+      screen.getByRole("textbox", { name: "Fleet web address" }),
+      "https://gnar.Fleet.co"
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    // then
+    expect(handleSubmitSpy).toHaveBeenCalledWith({
+      server_url: "https://gnar.Fleet.co",
     });
   });
 });


### PR DESCRIPTION
# Checklist for submitter

Rewritten below component test using rtl which comes under the `RegistrationForm`.
1. AdminDetails
2. FleetDetails
3. OrgDetails


- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [ ] Documented any permissions changes
- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [ ] Manual QA for all new/changed functionality
