### PR TITLE
Add `update-interval` configuration to `fleetctl package`

### DIFF
--- a/cmd/fleetctl/package.go
+++ b/cmd/fleetctl/package.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/packaging"
 	"github.com/rs/zerolog"
@@ -128,6 +129,12 @@ func packageCommand() *cli.Command {
 				Name:        "fleet-desktop",
 				Usage:       "Include the Fleet Desktop Application in the package",
 				Destination: &opt.Desktop,
+			},
+			&cli.DurationFlag{
+				Name:        "update-interval",
+				Usage:       "Interval that Orbit will use to check for new updates (10s, 1h, etc.)",
+				Value:       15 * time.Minute,
+				Destination: &opt.OrbitUpdateInterval,
 			},
 		},
 		Action: func(c *cli.Context) error {

--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -198,6 +198,7 @@ var envTemplate = template.Must(template.New("env").Parse(`
 ORBIT_UPDATE_URL={{ .UpdateURL }}
 ORBIT_ORBIT_CHANNEL={{ .OrbitChannel }}
 ORBIT_OSQUERYD_CHANNEL={{ .OsquerydChannel }}
+ORBIT_UPDATE_INTERVAL={{ .OrbitUpdateInterval }}
 {{ if .Insecure }}ORBIT_INSECURE=true{{ end }}
 {{ if .DisableUpdates }}ORBIT_DISABLE_UPDATES=true{{ end }}
 {{ if .FleetURL }}ORBIT_FLEET_URL={{.FleetURL}}{{ end }}

--- a/orbit/pkg/packaging/macos_templates.go
+++ b/orbit/pkg/packaging/macos_templates.go
@@ -100,6 +100,8 @@ var macosLaunchdTemplate = template.Must(template.New("").Option("missingkey=err
 		<key>ORBIT_DESKTOP_CHANNEL</key>
 		<string>{{ .DesktopChannel }}</string>
 		{{- end }}
+		<key>ORBIT_UPDATE_INTERVAL</key>
+		<string>{{ .OrbitUpdateInterval }}</string>
 	</dict>
 	<key>KeepAlive</key>
 	<true/>

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/update"
@@ -57,6 +58,8 @@ type Options struct {
 	Debug bool
 	// Desktop determines whether to package the Fleet Desktop application.
 	Desktop bool
+	// OrbitUpdateInterval is the interval that Orbit will use to check for updates.
+	OrbitUpdateInterval time.Duration
 }
 
 func initializeTempDir() (string, error) {

--- a/orbit/pkg/packaging/windows_templates.go
+++ b/orbit/pkg/packaging/windows_templates.go
@@ -47,6 +47,7 @@ var windowsWixTemplate = template.Must(template.New("").Option("missingkey=error
                 <File Source="root\bin\orbit\windows\{{ .OrbitChannel }}\orbit.exe">
                   <PermissionEx Sddl="O:SYG:SYD:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;BU)" />
                 </File>
+                <Environment Id='OrbitUpdateInterval' Name='ORBIT_UPDATE_INTERVAL' Value='{{ .OrbitUpdateInterval }}' Action='set' System='yes' />
                 <ServiceInstall
                   Name="Fleet osquery"
                   Account="NT AUTHORITY\SYSTEM"

--- a/tools/tuf/init_tuf.sh
+++ b/tools/tuf/init_tuf.sh
@@ -139,6 +139,7 @@ if [ -n "$GENERATE_PKGS" ]; then
     --insecure \
     --debug \
     --update-roots="$root_keys" \
+    --update-interval=10s \
     --update-url=http://$PKG_HOSTNAME:8081
 
   echo "Generating deb..."
@@ -149,6 +150,7 @@ if [ -n "$GENERATE_PKGS" ]; then
     --insecure \
     --debug \
     --update-roots="$root_keys" \
+    --update-interval=10s \
     --update-url=http://$DEB_HOSTNAME:8081
 
   echo "Generating rpm..."
@@ -159,6 +161,7 @@ if [ -n "$GENERATE_PKGS" ]; then
     --insecure \
     --debug \
     --update-roots="$root_keys" \
+    --update-interval=10s \
     --update-url=http://$RPM_HOSTNAME:8081
 
   echo "Generating msi..."
@@ -170,6 +173,7 @@ if [ -n "$GENERATE_PKGS" ]; then
     --insecure \
     --debug \
     --update-roots="$root_keys" \
+    --update-interval=10s \
     --update-url=http://$MSI_HOSTNAME:8081
 
   echo "Packages generated"


### PR DESCRIPTION
Adding support for setting the update-interval to `fleetctl package` too.

Mostly to ease upgrade testing (otherwise we have to wait `15m` in between tests.)


~- [] Changes file added (for user-visible changes)~
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added/updated tests~
- [x] Manual QA for all new/changed functionality
