### PR TITLE
Restrict non-global user access to activities

### DIFF
--- a/changes/issue-rbac-activities
+++ b/changes/issue-rbac-activities
@@ -1,0 +1,1 @@
+* Restrict non-global users from reading activities

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -141,9 +141,9 @@ allow {
 # Activities
 ##
 
-# All users can read activities
+# All global users can read activities
 allow {
-  not is_null(subject)
+  not is_null(subject.global_role)
   object.type == "activity"
   action == read
 }

--- a/server/service/activities_test.go
+++ b/server/service/activities_test.go
@@ -15,6 +15,9 @@ func TestListActivities(t *testing.T) {
 	ds := new(mock.Store)
 	svc := newTestService(t, ds, nil, nil)
 
+	globalUsers := []*fleet.User{test.UserAdmin, test.UserMaintainer, test.UserObserver}
+	teamUsers := []*fleet.User{test.UserTeamAdminTeam1, test.UserTeamMaintainerTeam1, test.UserTeamObserverTeam1}
+
 	ds.ListActivitiesFunc = func(ctx context.Context, opts fleet.ListOptions) ([]*fleet.Activity, error) {
 		return []*fleet.Activity{
 			{ID: 1},
@@ -22,15 +25,24 @@ func TestListActivities(t *testing.T) {
 		}, nil
 	}
 
-	// admin user
-	activities, err := svc.ListActivities(test.UserContext(test.UserAdmin), fleet.ListOptions{})
-	require.NoError(t, err)
-	require.Len(t, activities, 2)
+	// any global user can read activities
+	for _, u := range globalUsers {
+		activities, err := svc.ListActivities(test.UserContext(u), fleet.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, activities, 2)
+	}
 
-	// anyone can read activities
-	activities, err = svc.ListActivities(test.UserContext(test.UserNoRoles), fleet.ListOptions{})
-	require.NoError(t, err)
-	require.Len(t, activities, 2)
+	// team users cannot read activities
+	for _, u := range teamUsers {
+		_, err := svc.ListActivities(test.UserContext(u), fleet.ListOptions{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), authz.ForbiddenErrorMessage)
+	}
+
+	// user with no roles cannot read activities
+	_, err := svc.ListActivities(test.UserContext(test.UserNoRoles), fleet.ListOptions{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), authz.ForbiddenErrorMessage)
 
 	// no user in context
 	_, err = svc.ListActivities(context.Background(), fleet.ListOptions{})


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [ ] Documented any permissions changes
- ~~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~~
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
