### PR TITLE
Detect the NOPERM error to mean redis cluster is disabled

### DIFF
--- a/changes/issue-5048-detect-noperm-redis-standalone
+++ b/changes/issue-5048-detect-noperm-redis-standalone
@@ -1,0 +1,1 @@
+* Support Redis in standalone mode when CLUSTER commands are disabled via ACL.

--- a/server/datastore/redis/redis.go
+++ b/server/datastore/redis/redis.go
@@ -336,7 +336,8 @@ func newCluster(conf PoolConfig) (*redisc.Cluster, error) {
 }
 
 func isClusterDisabled(err error) bool {
-	return strings.Contains(err.Error(), "ERR This instance has cluster support disabled")
+	return strings.Contains(err.Error(), "ERR This instance has cluster support disabled") ||
+		strings.Contains(err.Error(), "NOPERM this user has no permissions to run the 'cluster' command")
 }
 
 // On GCP Memorystore the CLUSTER command is entirely unavailable and fails with


### PR DESCRIPTION
#5048 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [ ] ~~Documented any API changes (docs/Using-Fleet/REST-API.md)~~
- [ ] ~~Documented any permissions changes~~
- [ ] ~~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~~
- [ ] ~~Added/updated tests~~
- [x] Manual QA for all new/changed functionality (tested the error manually as ACL requires Redis 6+)
