### PR TITLE
UI: Sort live queries/policies

### DIFF
--- a/changes/issue-4572-sort-live-queries
+++ b/changes/issue-4572-sort-live-queries
@@ -1,0 +1,1 @@
+* Users can sort all columns of live queries and live policies in the UI

--- a/frontend/pages/policies/PolicyPage/components/PolicyQueriesListWrapper/PolicyQueriesListWrapper.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyQueriesListWrapper/PolicyQueriesListWrapper.tsx
@@ -45,7 +45,6 @@ const PoliciesListWrapper = ({
         isLoading={isLoading}
         defaultSortHeader={"name"}
         defaultSortDirection={"asc"}
-        manualSortBy
         showMarkAllPages={false}
         isAllPagesSelected={false}
         disablePagination

--- a/frontend/pages/policies/PolicyPage/components/PolicyQueriesListWrapper/PolicyQueriesTableConfig.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyQueriesListWrapper/PolicyQueriesTableConfig.tsx
@@ -4,8 +4,11 @@
 import React from "react";
 import { memoize } from "lodash";
 
-// @ts-ignore
+import { ColumnInstance } from "react-table";
+
 import TextCell from "components/TableContainer/DataTable/TextCell/TextCell";
+import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";
+
 import { IHostPolicyQuery } from "interfaces/host";
 import sortUtils from "utilities/sort";
 import PassIcon from "../../../../../../assets/images/icon-check-circle-green-16x16@2x.png";
@@ -14,10 +17,7 @@ import FailIcon from "../../../../../../assets/images/icon-exclamation-circle-re
 // TODO functions for paths math e.g., path={PATHS.MANAGE_HOSTS + getParams(cellProps.row.original)}
 
 interface IHeaderProps {
-  column: {
-    host: string;
-    isSortedDesc: boolean;
-  };
+  column: ColumnInstance & IDataColumn;
 }
 
 interface ICellProps {
@@ -45,17 +45,28 @@ const generateTableHeaders = (): IDataColumn[] => {
   const tableHeaders: IDataColumn[] = [
     {
       title: "Host",
-      Header: "Host",
-      disableSortBy: true,
+      Header: (headerProps: IHeaderProps): JSX.Element => (
+        <HeaderCell
+          value={headerProps.column.title || headerProps.column.id}
+          isSortedDesc={headerProps.column.isSortedDesc}
+          disableSortBy={false}
+        />
+      ),
       accessor: "hostname",
       Cell: (cellProps: ICellProps): JSX.Element => (
         <TextCell value={cellProps.cell.value} />
       ),
+      disableSortBy: false,
     },
     {
       title: "Status",
-      Header: "Status",
-      disableSortBy: true,
+      Header: (headerProps: IHeaderProps) => (
+        <HeaderCell
+          value={headerProps.column.title || headerProps.column.id}
+          isSortedDesc={headerProps.column.isSortedDesc}
+          disableSortBy={false}
+        />
+      ),
       accessor: "query_results",
       Cell: (cellProps: ICellProps): JSX.Element => (
         <>
@@ -72,6 +83,7 @@ const generateTableHeaders = (): IDataColumn[] => {
           )}
         </>
       ),
+      disableSortBy: false,
     },
   ];
   return tableHeaders;

--- a/frontend/pages/queries/QueryPage/components/QueryResults/QueryResultsTableConfig.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/QueryResultsTableConfig.tsx
@@ -60,6 +60,7 @@ const resultsTableHeaders = (results: ICampaignQueryResult[]): Column[] => {
       Cell: (cellProps: ICellProps) => cellProps?.cell?.value || null,
       Filter: DefaultColumnFilter,
       // filterType: "text",
+      disableSortBy: false,
     };
   });
   return _unshiftHostname(headers);


### PR DESCRIPTION
Cerra #4572 

- Ability to sort by all columns of a live query and a live policy

Screenshots of live query and live policy sort:
<img width="1628" alt="Screen Shot 2022-04-11 at 3 54 44 PM" src="https://user-images.githubusercontent.com/71795832/162819591-a96fac95-1690-4c83-8cf6-dca6d419882b.png">
<img width="1628" alt="Screen Shot 2022-04-11 at 3 55 15 PM" src="https://user-images.githubusercontent.com/71795832/162819578-0ad321ad-197a-4b0e-8dc8-bbadcc18dc07.png">
<img width="1622" alt="Screen Shot 2022-04-11 at 3 55 09 PM" src="https://user-images.githubusercontent.com/71795832/162819587-1446fe69-2ea4-4cf4-86ee-8391dc86732d.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
