### PR TITLE
Adding docker to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,16 @@
 version: 2
 updates:
 
-  # Maintain dependencies for GitHub Actions
+# Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+# Maintain dependencies for Dockerfiles
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "@fleetdm/go"
+      - "@fleetdm/infra"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Basic set up starting with github actions only
+# Basic set up for Actions and Docker. Security updates enabled via GitHub settings for other ecosystems.
 
 version: 2
 updates:


### PR DESCRIPTION
Adding the docker ecosystem to Dependabot, so PRs get auto-created when necessary.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added (for user-visible changes)
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [ ] Documented any permissions changes
- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
