### PR TITLE
Host Details Page: Policy table truncates policy name 

### DIFF
--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -160,6 +160,7 @@ $base-class: "button";
     font-size: $x-small;
     font-weight: $bold;
     cursor: pointer;
+    white-space: nowrap;
 
     img {
       transform: scale(0.5);

--- a/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/HostPoliciesTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/HostPoliciesTableConfig.tsx
@@ -63,19 +63,15 @@ const generatePolicyTableHeaders = (
       Cell: (cellProps) => {
         const { name } = cellProps.row.original;
         return (
-          <>
-            <Button
-              onClick={() => {
-                togglePolicyDetails(cellProps.row.original);
-              }}
-              variant={"text-icon"}
-            >
-              <>
-                {name}
-                <img src={ArrowIcon} alt="View policy details" />
-              </>
-            </Button>
-          </>
+          <Button
+            className={`policy-info`}
+            onClick={() => {
+              togglePolicyDetails(cellProps.row.original);
+            }}
+            variant={"text-icon"}
+          >
+            <span className={`policy-info-text`}>{name}</span>
+          </Button>
         );
       },
     },

--- a/frontend/pages/hosts/details/cards/Policies/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Policies/_styles.scss
@@ -13,7 +13,7 @@
     .data-table__table {
       thead {
         .name__header {
-          width: $col-md;
+          min-width: $col-md;
         }
         .response__header {
           width: 0;
@@ -26,7 +26,7 @@
       tbody {
         tr {
           .name__cell {
-            max-width: 0; // reset to variable width
+            max-width: 0; // sets ellipses
           }
 
           .policy-link {

--- a/frontend/pages/hosts/details/cards/Policies/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Policies/_styles.scss
@@ -25,6 +25,10 @@
       }
       tbody {
         tr {
+          .name__cell {
+            max-width: 0; // reset to variable width
+          }
+
           .policy-link {
             visibility: hidden;
             text-overflow: none;
@@ -37,6 +41,21 @@
             .policy-link {
               visibility: visible;
               text-overflow: none;
+            }
+          }
+          .policy-info {
+            width: 100%; // sets ellipses
+            justify-content: left;
+
+            .policy-info-text {
+              overflow: hidden;
+              white-space: nowrap;
+              text-overflow: ellipsis;
+            }
+
+            &::after {
+              content: url("../assets/images/icon-arrow-right-vibrant-blue-10x18@2x.png");
+              transform: scale(0.5);
             }
           }
         }


### PR DESCRIPTION
Cerra #5075 

Host details page: Policy table more responsive to 768px
- Use of ellipses for policy name

NOTE: We cannot use LinkCell for this because LinkCell is built with `<Link>` react router and paths. This is a button that just opens a modal onClick.

https://user-images.githubusercontent.com/71795832/163044019-5a91bb6b-8452-4b35-92b7-beed6eb57bca.mov



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
