### PR TITLE
Exact same styling as manage schedule page

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/_styles.scss
@@ -57,6 +57,7 @@
 
   &__description {
     margin: 0;
+    margin-bottom: $pad-xxlarge;
 
     h2 {
       text-transform: uppercase;


### PR DESCRIPTION
Cerra #5084 

- Fix margin-bottom under page description for Manage Policies Page to match Manage Schedules Page

https://user-images.githubusercontent.com/71795832/163045640-ecbafa5e-34b2-40ea-afd9-3203effeacd6.mov

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
