### PR TITLE
Bug fix: Toggle disappearing on Focus

### DIFF
--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -281,12 +281,6 @@ $base-class: "button";
     &:focus {
       outline: none;
     }
-
-    &:hover,
-    &:focus {
-      background-color: transparent;
-      box-shadow: none;
-    }
   }
 
   &--unstyled-modal-query {


### PR DESCRIPTION
Cerra #5085 

- Fix toggle to still show on focus
- Applied to all on focus unstyled buttons

<img width="1561" alt="Screen Shot 2022-04-12 at 4 32 06 PM" src="https://user-images.githubusercontent.com/71795832/163048916-40c45033-e71f-42e4-9e9d-b1b7bbdbb3f7.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
