### PR TITLE
UI: Vuln max age

### DIFF
--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -169,6 +169,7 @@ export interface IConfig {
     cve_feed_prefix_url: string;
     current_instance_checks: string;
     disable_data_sync: boolean;
+    recent_vulnerability_max_age: number;
   };
   // Note: `vulnerability_settings` is deprecated and should not be used
   // vulnerability_settings: {

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -79,6 +79,10 @@ const ManageSoftwarePage = ({
     isVulnerabilityAutomationsEnabled,
     setIsVulnerabilityAutomationsEnabled,
   ] = useState<boolean>();
+  const [
+    recentVulnerabilityMaxAge,
+    setRecentVulnerabilityMaxAge,
+  ] = useState<number>();
   const [filterVuln, setFilterVuln] = useState(
     location?.query?.vulnerable || false
   );
@@ -112,6 +116,12 @@ const ManageSoftwarePage = ({
       setIsVulnerabilityAutomationsEnabled(
         data?.webhook_settings?.vulnerabilities_webhook
           .enable_vulnerabilities_webhook || jiraIntegrationEnabled
+      );
+      // Convert from nanosecond to nearest day
+      setRecentVulnerabilityMaxAge(
+        Math.round(
+          data?.vulnerabilities?.recent_vulnerability_max_age / 86400000000000
+        )
       );
     },
   });
@@ -495,6 +505,7 @@ const ManageSoftwarePage = ({
                 softwareVulnerabilitiesWebhook.destination_url) ||
               ""
             }
+            recentVulnerabilityMaxAge={recentVulnerabilityMaxAge}
           />
         )}
       </div>

--- a/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -43,7 +43,7 @@ interface IManageAutomationsModalProps {
   softwareVulnerabilityAutomationEnabled?: boolean;
   softwareVulnerabilityWebhookEnabled?: boolean;
   currentDestinationUrl?: string;
-  recentVulnerabilityMaxAge: number;
+  recentVulnerabilityMaxAge?: number;
 }
 
 const validateWebhookURL = (url: string) => {
@@ -228,7 +228,7 @@ const ManageAutomationsModal = ({
           <p>
             A ticket will be created in your <b>Integration</b> if a detected
             vulnerability (CVE) was published in the last{" "}
-            {recentVulnerabilityMaxAge} days.
+            {recentVulnerabilityMaxAge || "30"} days.
           </p>
         </div>
         {integrationsIndexed && integrationsIndexed.length > 0 ? (
@@ -269,8 +269,8 @@ const ManageAutomationsModal = ({
         <div className={`${baseClass}__software-automation-description`}>
           <p>
             A request will be sent to your configured <b>Destination URL</b> if
-            a detected vulnerability (CVE) was published in the last
-            {recentVulnerabilityMaxAge} days.
+            a detected vulnerability (CVE) was published in the last{" "}
+            {recentVulnerabilityMaxAge || "30"} days.
           </p>
         </div>
         <InputField

--- a/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -43,6 +43,7 @@ interface IManageAutomationsModalProps {
   softwareVulnerabilityAutomationEnabled?: boolean;
   softwareVulnerabilityWebhookEnabled?: boolean;
   currentDestinationUrl?: string;
+  recentVulnerabilityMaxAge: number;
 }
 
 const validateWebhookURL = (url: string) => {
@@ -66,6 +67,7 @@ const ManageAutomationsModal = ({
   softwareVulnerabilityAutomationEnabled,
   softwareVulnerabilityWebhookEnabled,
   currentDestinationUrl,
+  recentVulnerabilityMaxAge,
 }: IManageAutomationsModalProps): JSX.Element => {
   const [destination_url, setDestinationUrl] = useState<string>(
     currentDestinationUrl || ""
@@ -225,7 +227,8 @@ const ManageAutomationsModal = ({
         <div className={`${baseClass}__software-automation-description`}>
           <p>
             A ticket will be created in your <b>Integration</b> if a detected
-            vulnerability (CVE) was published in the last 30 days.
+            vulnerability (CVE) was published in the last{" "}
+            {recentVulnerabilityMaxAge} days.
           </p>
         </div>
         {integrationsIndexed && integrationsIndexed.length > 0 ? (
@@ -266,7 +269,8 @@ const ManageAutomationsModal = ({
         <div className={`${baseClass}__software-automation-description`}>
           <p>
             A request will be sent to your configured <b>Destination URL</b> if
-            a detected vulnerability (CVE) was published in the last 30 days.
+            a detected vulnerability (CVE) was published in the last
+            {recentVulnerabilityMaxAge} days.
           </p>
         </div>
         <InputField


### PR DESCRIPTION
Cerra #5106 

- Configurable recent vulnerability max age shown in UI
- Converting nanoseconds to nearest day for UI readability
- Defaults to 30 days

<img width="954" alt="Screen Shot 2022-04-13 at 1 02 54 PM" src="https://user-images.githubusercontent.com/71795832/163233341-b120c612-5536-4677-8a4d-82bcd032ac54.png">
<img width="959" alt="Screen Shot 2022-04-13 at 1 02 47 PM" src="https://user-images.githubusercontent.com/71795832/163233346-c960b935-b27c-42ca-8549-cd9afe54341f.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Documented any API changes (docs/Using-Fleet/REST-API.md) (Martin's PR)
- [x] Manual QA for all new/changed functionality
