### PR TITLE
Temporarily remove export host csv button

### DIFF
--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -29,7 +29,7 @@ describe("Hosts flow", () => {
       cy.visit("/hosts/manage");
 
       cy.getAttached(".manage-hosts").within(() => {
-        cy.getAttached(".manage-hosts__export-btn").click();
+        // cy.getAttached(".manage-hosts__export-btn").click(); // Feature pushed back from 4.13 release
         cy.contains("button", /add hosts/i).click();
       });
       cy.getAttached(".react-tabs").within(() => {
@@ -47,11 +47,13 @@ describe("Hosts flow", () => {
       // before each test run (seems to be related to issues with Cypress trashAssetsBeforeRun)
       if (Cypress.platform !== "win32") {
         // windows has issues with downloads location
-        const formattedTime = format(new Date(), "yyyy-MM-dd");
-        const filename = `Hosts ${formattedTime}.csv`;
-        cy.readFile(path.join(Cypress.config("downloadsFolder"), filename), {
-          timeout: 5000,
-        });
+
+        // Feature pushed back from 4.13 release
+        // const formattedTime = format(new Date(), "yyyy-MM-dd");
+        // const filename = `Hosts ${formattedTime}.csv`;
+        // cy.readFile(path.join(Cypress.config("downloadsFolder"), filename), {
+        //   timeout: 5000,
+        // });
         cy.readFile(
           path.join(Cypress.config("downloadsFolder"), "secret.txt"),
           {

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1336,6 +1336,8 @@ const ManageHostsPage = ({
         }`}
       >
         <span>{`${count} host${count === 1 ? "" : "s"}`}</span>
+        {/* Export all columns initially in 4.13 release but feature being pushed
+        back by product until we build client side filtering to export only selected columns
         <Button
           className={`${baseClass}__export-btn`}
           onClick={onExportHostsResults}
@@ -1344,7 +1346,7 @@ const ManageHostsPage = ({
           <>
             Export hosts <img alt="" src={DownloadIcon} />
           </>
-        </Button>
+        </Button> */}
       </div>
     );
   }, [isHostCountLoading, filteredHostCount]);


### PR DESCRIPTION
Related to old ticket #2814 and new iteration ticket #5103 

Per product request, Export host CSV feature will not be available until we have client-side filtering that includes filtering columns on exported data.

- Hide Export host button on Manage Host Page

<img width="1253" alt="Screen Shot 2022-04-13 at 2 07 16 PM" src="https://user-images.githubusercontent.com/71795832/163243185-c5d8ceb7-2ba8-433f-b657-177e8d0eb430.png">

# Checklist for submitter

- [x] Manual QA for all new/changed functionality
