### PR TITLE
QA find: Add tooltip to Save button if no Integrations found

### DIFF
--- a/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -358,36 +358,46 @@ const ManageAutomationsModal = ({
             data-for="save-automation-button"
             data-tip-disable={
               !(
-                integrationsIndexed && integrationsIndexed.length === 0 && jiraEnabled && softwareAutomationsEnabled
+                integrationsIndexed &&
+                integrationsIndexed.length === 0 &&
+                jiraEnabled &&
+                softwareAutomationsEnabled
               )
             }
           >
-          <Button
-            className={`${baseClass}__btn`}
-            type="submit"
-            variant="brand"
-            onClick={handleSaveAutomation}
-            disabled={softwareAutomationsEnabled && jiraEnabled && !selectedIntegration || softwareAutomationsEnabled && !jiraEnabled && destinationUrl === ""}
-          >
-            Save
-          </Button>
+            <Button
+              className={`${baseClass}__btn`}
+              type="submit"
+              variant="brand"
+              onClick={handleSaveAutomation}
+              disabled={
+                (softwareAutomationsEnabled &&
+                  jiraEnabled &&
+                  !selectedIntegration) ||
+                (softwareAutomationsEnabled &&
+                  !jiraEnabled &&
+                  destinationUrl === "")
+              }
+            >
+              Save
+            </Button>
           </div>
-                          <ReactTooltip
-                  className={`save-automation-button-tooltip`}
-                  place="bottom"
-                  type="dark"
-                  effect="solid"
-                  backgroundColor="#3e4771"
-                  id="save-automation-button"
-                  data-html
-                >
-                  <div
-                    className={`tooltip`}
-                    style={{ width: "152px", textAlign: "center" }}
-                  >
-                    Add an integration to create tickets for vulnerability automations
-                  </div>
-                </ReactTooltip>
+          <ReactTooltip
+            className={`save-automation-button-tooltip`}
+            place="bottom"
+            type="dark"
+            effect="solid"
+            backgroundColor="#3e4771"
+            id="save-automation-button"
+            data-html
+          >
+            <div
+              className={`tooltip`}
+              style={{ width: "152px", textAlign: "center" }}
+            >
+              Add an integration to create tickets for vulnerability automations
+            </div>
+          </ReactTooltip>
         </div>
       </div>
     </Modal>

--- a/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -68,7 +68,7 @@ const ManageAutomationsModal = ({
   softwareVulnerabilityWebhookEnabled,
   currentDestinationUrl,
 }: IManageAutomationsModalProps): JSX.Element => {
-  const [destination_url, setDestinationUrl] = useState<string>(
+  const [destinationUrl, setDestinationUrl] = useState<string>(
     currentDestinationUrl || ""
   );
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
@@ -88,10 +88,10 @@ const ManageAutomationsModal = ({
   ] = useState<IJiraIntegration>();
 
   useDeepEffect(() => {
-    if (destination_url) {
+    if (destinationUrl) {
       setErrors({});
     }
-  }, [destination_url]);
+  }, [destinationUrl]);
 
   const { data: integrations } = useQuery<IConfig, Error, IJiraIntegration[]>(
     ["integrations"],
@@ -125,7 +125,7 @@ const ManageAutomationsModal = ({
     evt.preventDefault();
 
     const { valid: validUrl, errors: newErrors } = validateWebhookURL(
-      destination_url
+      destinationUrl
     );
     setErrors({
       ...errors,
@@ -136,7 +136,7 @@ const ManageAutomationsModal = ({
     const configSoftwareAutomations: ISoftwareAutomations = {
       webhook_settings: {
         vulnerabilities_webhook: {
-          destination_url,
+          destination_url: destinationUrl,
           enable_vulnerabilities_webhook: softwareVulnerabilityWebhookEnabled,
         },
       },
@@ -275,7 +275,7 @@ const ManageAutomationsModal = ({
           name="webhook-url"
           label={"Destination URL"}
           type={"text"}
-          value={destination_url}
+          value={destinationUrl}
           onChange={onURLChange}
           error={errors.url}
           hint={
@@ -358,7 +358,7 @@ const ManageAutomationsModal = ({
             data-for="save-automation-button"
             data-tip-disable={
               !(
-                integrationsIndexed && integrationsIndexed.length === 0 && jiraEnabled
+                integrationsIndexed && integrationsIndexed.length === 0 && jiraEnabled && softwareAutomationsEnabled
               )
             }
           >
@@ -367,7 +367,7 @@ const ManageAutomationsModal = ({
             type="submit"
             variant="brand"
             onClick={handleSaveAutomation}
-            disabled={jiraEnabled && !selectedIntegration}
+            disabled={softwareAutomationsEnabled && jiraEnabled && !selectedIntegration || softwareAutomationsEnabled && !jiraEnabled && destinationUrl === ""}
           >
             Save
           </Button>

--- a/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -11,6 +11,7 @@ import {
 import { IConfig } from "interfaces/config";
 import configAPI from "services/entities/config";
 
+import ReactTooltip from "react-tooltip";
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
 import Modal from "components/Modal";
@@ -352,6 +353,15 @@ const ManageAutomationsModal = ({
           >
             Cancel
           </Button>
+          <div
+            data-tip
+            data-for="save-automation-button"
+            data-tip-disable={
+              !(
+                integrationsIndexed && integrationsIndexed.length === 0 && jiraEnabled
+              )
+            }
+          >
           <Button
             className={`${baseClass}__btn`}
             type="submit"
@@ -361,6 +371,23 @@ const ManageAutomationsModal = ({
           >
             Save
           </Button>
+          </div>
+                          <ReactTooltip
+                  className={`save-automation-button-tooltip`}
+                  place="bottom"
+                  type="dark"
+                  effect="solid"
+                  backgroundColor="#3e4771"
+                  id="save-automation-button"
+                  data-html
+                >
+                  <div
+                    className={`tooltip`}
+                    style={{ width: "152px", textAlign: "center" }}
+                  >
+                    Add an integration to create tickets for vulnerability automations
+                  </div>
+                </ReactTooltip>
         </div>
       </div>
     </Modal>


### PR DESCRIPTION
QA on #2936 

- Tooltip only renders if there are no integration and the user selected to use Jira ticket for managing software vulnerability automations
- Wording matches figma
- Fix bug: If jira is selected but integration is not selected (intended behavior: should not able to save), and then a user disables vulnerability automation with slider, user can now Save because vulnerability automation are off

<img width="1295" alt="Screen Shot 2022-04-13 at 5 03 40 PM" src="https://user-images.githubusercontent.com/71795832/163270305-291971fe-0d51-47b3-896d-a7c52c99f992.png">
<img width="1291" alt="Screen Shot 2022-04-13 at 5 02 13 PM" src="https://user-images.githubusercontent.com/71795832/163270307-7f9f7047-77b1-4033-9202-47255fb3d997.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
