### PR TITLE
Add link to the docs of retrieving live query result over web socket in the run live query doc

### DIFF
--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -2675,6 +2675,8 @@ load balancer timeout.
 
 > WARNING: This API endpoint collects responses in-memory (RAM) on the Fleet compute instance handling this request, which can overflow if the result set is large enough.  This has the potential to crash the process and/or cause an autoscaling event in your cloud provider, depending on how Fleet is deployed.
 
+Note: You can also retrieve live queries result over [websocket](https://fleetdm.com/docs/contributing/api-for-contributors#retrieve-live-query-results-standard-web-socket-api)
+
 `GET /api/latest/fleet/queries/run`
 
 #### Parameters

--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -2675,7 +2675,7 @@ load balancer timeout.
 
 > WARNING: This API endpoint collects responses in-memory (RAM) on the Fleet compute instance handling this request, which can overflow if the result set is large enough.  This has the potential to crash the process and/or cause an autoscaling event in your cloud provider, depending on how Fleet is deployed.
 
-Note: You can also retrieve live queries result over [websocket](https://fleetdm.com/docs/contributing/api-for-contributors#retrieve-live-query-results-standard-web-socket-api)
+Note: You can also retrieve live queries results over [websocket](https://fleetdm.com/docs/contributing/api-for-contributors#retrieve-live-query-results-standard-web-socket-api).
 
 `GET /api/latest/fleet/queries/run`
 


### PR DESCRIPTION
There are two ways to run live queries: using the `GET` endpoint and over WebSocket. This PR adds a note in the run live query API docs to the WebSocket docs for also retrieving results for live queries.

This resolves issue [#3512](https://github.com/fleetdm/fleet/issues/3512)