### PR TITLE
Update to Slack channel list

### DIFF
--- a/handbook/product.md
+++ b/handbook/product.md
@@ -394,8 +394,12 @@ The following [Slack channels are maintained](https://fleetdm.com/handbook/compa
 
 | Slack channel                       | [DRI](https://fleetdm.com/handbook/company#group-slack-channels)    |
 |:------------------------------------|:--------------------------------------------------------------------|
-| `#g-product`                        | Noah Talerman
-| `#help-qa`                          | Reed Haynes
+| `#help-product`                     | Noah Talerman                                                       |
+| `#help-qa`                          | Reed Haynes                                                         |
+| `#g-platform`                       | Zach Wasserman                                                      |
+| `#g-interface`                      | Noah Talerman                                                       |
+| `#g-agent`                          | Mo Zhu                                                              |
+
 
 
 


### PR DESCRIPTION
Update handbook pages to reflect new slack channels.  New channels go on product page.
DRI of platform is Zach W, of interface is Noah, of agent is Mo Zhu


Rename #g-product to #help-product and include #g-agent, #g-interface, #g-platform.
