### PR TITLE
Orbit: Fix deprecation warning message on `fleetctl package` for `deb`/`rpm`

### DIFF
--- a/changes/fix-fleetctl-package-deb-rpm-deprecation-warn
+++ b/changes/fix-fleetctl-package-deb-rpm-deprecation-warn
@@ -1,0 +1,1 @@
+* Fix deprecation warning message when generating `deb` and `rpm` packages with `fleetctl package`.

--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -121,8 +121,15 @@ func buildNFPM(opt Options, pkger nfpm.Packager) (string, error) {
 		log.Debug().Interface("file", c).Msg("added file")
 	}
 
-	// Build package
+	// Add empty folders to be created.
+	for _, emptyFolder := range []string{"/var/log/osquery", "/var/log/orbit"} {
+		contents = append(contents, (&files.Content{
+			Destination: emptyFolder,
+			Type:        "dir",
+		}).WithFileInfoDefaults())
+	}
 
+	// Build package
 	info := &nfpm.Info{
 		Name:        "fleet-osquery",
 		Version:     opt.Version,
@@ -132,10 +139,6 @@ func buildNFPM(opt Options, pkger nfpm.Packager) (string, error) {
 		Homepage:    "https://fleetdm.com",
 		Overridables: nfpm.Overridables{
 			Contents: contents,
-			EmptyFolders: []string{
-				"/var/log/osquery",
-				"/var/log/orbit",
-			},
 			Scripts: nfpm.Scripts{
 				PostInstall: postInstallPath,
 			},


### PR DESCRIPTION
Currently (in `main`) for both `deb` and `rpm`:
```sh
$ fleetctl package --type=deb --fleet-url=https://172.16.132.1:8080 --enroll-secret=ViKqEj1P3Cp5tJKCbd7Kk2kLnEzQjfi4 --insecure

Generating your osquery installer...
DEPRECATION WARNING: 'empty_folders' is deprecated and will be removed in a future version, create content with type 'dir' and directoy name as 'dst' instead

Success! You generated an osquery installer at /Users/luk/fleetdm/git/fleet/fleet-osquery_0.0.8_amd64.deb

To add this device to Fleet, double-click to open your installer.

To add other devices to Fleet, distribute this installer using Chef, Ansible, Jamf, or Puppet. Learn how: https://fleetdm.com/docs/using-fleet/adding-hosts
```

With the change in this PR:
```sh
$ fleetctl package --type=deb --fleet-url=https://172.16.132.1:8080 --enroll-secret=ViKqEj1P3Cp5tJKCbd7Kk2kLnEzQjfi4 --insecure

Generating your osquery installer...

Success! You generated an osquery installer at /Users/luk/fleetdm/git/fleet/fleet-osquery_0.0.8_amd64.deb

To add this device to Fleet, double-click to open your installer.

To add other devices to Fleet, distribute this installer using Chef, Ansible, Jamf, or Puppet. Learn how: https://fleetdm.com/docs/using-fleet/adding-hosts
```

I'm basically mimicking nfpm's following code:
https://github.com/goreleaser/nfpm/blob/8937b55499afad001db77aaf5269637d2b281898/nfpm.go#L392-L408

- [X] Changes file added (for user-visible changes)
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality
