### PR TITLE
Using '@' in target search causes 422 error response

### DIFF
--- a/changes/issue-4852-search-labels-breaks-with-atsign
+++ b/changes/issue-4852-search-labels-breaks-with-atsign
@@ -1,0 +1,1 @@
+- Properly handle '@' characters when searching for a target host.

--- a/server/datastore/mysql/fulltext.go
+++ b/server/datastore/mysql/fulltext.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-var mysqlFTSSymbolRegexp = regexp.MustCompile("[-+]+")
+var mysqlFTSSymbolRegexp = regexp.MustCompile("[-+@]+")
 
 // queryMinLength returns true if the query argument is longer than a "short" word.
 // What defines a "short" word is MySQL's "ft_min_word_len" VARIABLE, generally set

--- a/server/datastore/mysql/fulltext_test.go
+++ b/server/datastore/mysql/fulltext_test.go
@@ -16,6 +16,7 @@ func TestTransformQuery(t *testing.T) {
 		{"f%5", "f%5*"},
 		{"f-o-o-b-a-r", "f o o b a r*"},
 		{"f-o+o-b--+a-r+", "f o o b a r*"},
+		{"gandalf@the_white.com", "gandalf the_white.com*"},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
#4852 

When searching for Labels, breakdown query strings containing '@' in multiple search terms to avoid issues with MySQL FTS.

# Checklist for submitter
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality