### PR TITLE
Orbit: Add pre and post remove scripts for `fleet-osquery`'s `rpm` and `deb` packages

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -185,6 +185,7 @@ jobs:
           sudo systemctl status orbit.service || true
           sleep 1
         done
+        sudo apt remove fleet-osquery -y
 
   orbit-windows-build:
     timeout-minutes: 15

--- a/changes/centos-ubuntu-uninstall-cleanup
+++ b/changes/centos-ubuntu-uninstall-cleanup
@@ -1,0 +1,1 @@
+* Add cleanup on `deb`/`rpm` uninstall.

--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -80,6 +80,14 @@ func buildNFPM(opt Options, pkger nfpm.Packager) (string, error) {
 	if err := writePostInstall(opt, postInstallPath); err != nil {
 		return "", fmt.Errorf("write postinstall script: %w", err)
 	}
+	preRemovePath := filepath.Join(tmpDir, "preremove.sh")
+	if err := writePreRemove(opt, preRemovePath); err != nil {
+		return "", fmt.Errorf("write preremove script: %w", err)
+	}
+	postRemovePath := filepath.Join(tmpDir, "postremove.sh")
+	if err := writePostRemove(opt, postRemovePath); err != nil {
+		return "", fmt.Errorf("write postremove script: %w", err)
+	}
 
 	if opt.FleetCertificate != "" {
 		if err := writeCertificate(opt, orbitRoot); err != nil {
@@ -138,6 +146,8 @@ func buildNFPM(opt Options, pkger nfpm.Packager) (string, error) {
 			},
 			Scripts: nfpm.Scripts{
 				PostInstall: postInstallPath,
+				PreRemove:   preRemovePath,
+				PostRemove:  postRemovePath,
 			},
 		},
 	}
@@ -252,6 +262,31 @@ func writePostInstall(opt Options, path string) error {
 	}
 
 	if err := ioutil.WriteFile(path, contents.Bytes(), constant.DefaultFileMode); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+
+	return nil
+}
+
+func writePreRemove(opt Options, path string) error {
+	if err := ioutil.WriteFile(path, []byte(`#!/bin/sh
+
+set -e
+
+systemctl stop orbit.service
+systemctl disable orbit.service
+`), constant.DefaultFileMode); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+
+	return nil
+}
+
+func writePostRemove(opt Options, path string) error {
+	if err := ioutil.WriteFile(path, []byte(`#!/bin/sh
+
+rm -rf /var/lib/orbit /var/log/orbit /usr/local/bin/orbit /etc/default/orbit /usr/lib/systemd/system/orbit.service
+`), constant.DefaultFileMode); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}
 


### PR DESCRIPTION
We need this change for proper testing of Fleet Desktop on Linux. Otherwise, the `/var/lib/orbit/identifier` is generated once and never cleaned-up on the host. Also this fixes the issue of orbit still running after uninstall.

This also fixes a `dpkg` warning:
```sh
$ sudo apt remove fleet-osquery -y
[...]
Removing fleet-osquery (0.0.8) ...
dpkg: warning: while removing fleet-osquery, directory '/var/lib/orbit' not empty so not removed
dpkg: warning: while removing fleet-osquery, directory '/usr/local' not empty so not removed
$ 
```

- [X] Changes file added (for user-visible changes)
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality