### PR TITLE
Handbook: Rename Slack channel, suggest DRI for #help-golang

### DIFF
--- a/handbook/engineering.md
+++ b/handbook/engineering.md
@@ -148,9 +148,9 @@ The following [Slack channels are maintained](https://fleetdm.com/handbook/compa
 
 | Slack channel                       | [DRI](https://fleetdm.com/handbook/company#group-slack-channels)    |
 |:------------------------------------|:--------------------------------------------------------------------|
-| `#g-core-engineering`               | Zach Wasserman
+| `#help-engineering`                 | Zach Wasserman
 | `#help-oncall`                      | Zach Wasserman
-| `#help-golang`                      | Zach Wasserman
+| `#help-golang`                      | Tomas Touceda
 | `#help-frontend`                    | Luke Heath
 | `#_pov-environments`                | Ben Edwards
 

--- a/handbook/engineering.md
+++ b/handbook/engineering.md
@@ -150,8 +150,6 @@ The following [Slack channels are maintained](https://fleetdm.com/handbook/compa
 |:------------------------------------|:--------------------------------------------------------------------|
 | `#help-engineering`                 | Zach Wasserman
 | `#help-oncall`                      | Zach Wasserman
-| `#help-golang`                      | Tomas Touceda
-| `#help-frontend`                    | Luke Heath
 | `#_pov-environments`                | Ben Edwards
 
 


### PR DESCRIPTION
- Rename Slack channel to #help-engineering
- suggest DRI for #help-golang