### PR TITLE
Query Results Page: Show query modal

### DIFF
--- a/changes/issue-4574-show-query-in-live-results
+++ b/changes/issue-4574-show-query-in-live-results
@@ -1,0 +1,1 @@
+* Users can view query SQL from the live query results page

--- a/cypress/integration/all/app/queryflow.spec.ts
+++ b/cypress/integration/all/app/queryflow.spec.ts
@@ -1,3 +1,6 @@
+import * as path from "path";
+import { format } from "date-fns";
+
 describe("Query flow (empty)", () => {
   before(() => {
     Cypress.session.clearAllSavedSessions();
@@ -6,7 +9,7 @@ describe("Query flow (empty)", () => {
     cy.viewport(1200, 660);
   });
   after(() => {
-    cy.logout();
+    // cy.logout();
   });
   describe("Manage queries page", () => {
     beforeEach(() => {
@@ -43,7 +46,7 @@ describe("Query flow (seeded)", () => {
     cy.viewport(1200, 660);
   });
   after(() => {
-    cy.logout();
+    // cy.logout();
   });
   describe("Manage queries page", () => {
     beforeEach(() => {
@@ -81,6 +84,30 @@ describe("Query flow (seeded)", () => {
       cy.getAttached(".button--alert.remove-query-modal__btn").click();
       cy.findByText(/successfully removed query/i).should("be.visible");
       cy.findByText(/detect linux hosts/i).should("not.exist");
+    });
+    it.only("runs a live query", () => {
+      cy.addDockerHost();
+      cy.getAttached(".name__cell .button--text-link").first().click();
+      cy.findByText(/run query/i).click();
+      cy.findByText(/all hosts/i).click();
+      cy.findByText(/hosts targeted/i).should("exist");
+      cy.findByText(/run/i).click();
+      cy.wait(10000); // wait for live query to run
+      cy.getAttached(".query-results__results-table-header").within(() => {
+        cy.findByText(/show query/i).click();
+      });
+      cy.getAttached(".show-query-modal").within(() => {
+        cy.findByText(/done/i).click();
+      });
+      cy.getAttached(".query-results__results-table-header").within(() => {
+        const formattedTime = format(new Date(), "MM-dd-yy hh-mm-ss");
+        cy.findByText(/export results/i).click();
+        const filename = `Query Results (${formattedTime}).csv`;
+        cy.readFile(path.join(Cypress.config("downloadsFolder"), filename), {
+          timeout: 5000,
+        });
+      });
+      cy.stopDockerHost();
     });
   });
   describe("Manage schedules page", () => {

--- a/cypress/integration/all/app/queryflow.spec.ts
+++ b/cypress/integration/all/app/queryflow.spec.ts
@@ -85,7 +85,7 @@ describe("Query flow (seeded)", () => {
       cy.findByText(/successfully removed query/i).should("be.visible");
       cy.findByText(/detect linux hosts/i).should("not.exist");
     });
-    it.only("runs a live query", () => {
+    it("runs a live query", () => {
       cy.addDockerHost();
       cy.getAttached(".name__cell .button--text-link").first().click();
       cy.findByText(/run query/i).click();

--- a/cypress/integration/all/app/queryflow.spec.ts
+++ b/cypress/integration/all/app/queryflow.spec.ts
@@ -9,7 +9,7 @@ describe("Query flow (empty)", () => {
     cy.viewport(1200, 660);
   });
   after(() => {
-    // cy.logout();
+    cy.logout();
   });
   describe("Manage queries page", () => {
     beforeEach(() => {
@@ -46,7 +46,7 @@ describe("Query flow (seeded)", () => {
     cy.viewport(1200, 660);
   });
   after(() => {
-    // cy.logout();
+    cy.logout();
   });
   describe("Manage queries page", () => {
     beforeEach(() => {
@@ -60,7 +60,8 @@ describe("Query flow (seeded)", () => {
       cy.findByText(/all hosts/i).click();
       cy.findByText(/hosts targeted/i).should("exist");
       cy.findByText(/run/i).click();
-      cy.wait(10000); // wait for live query to run
+      // Ensures live query runs
+      cy.wait(10000); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.getAttached(".query-results__results-table-header").within(() => {
         cy.findByText(/show query/i).click();
       });

--- a/cypress/integration/all/app/queryflow.spec.ts
+++ b/cypress/integration/all/app/queryflow.spec.ts
@@ -53,6 +53,30 @@ describe("Query flow (seeded)", () => {
       cy.loginWithCySession();
       cy.visit("/queries/manage");
     });
+    it("runs a live query", () => {
+      cy.addDockerHost();
+      cy.getAttached(".name__cell .button--text-link").first().click();
+      cy.findByText(/run query/i).click();
+      cy.findByText(/all hosts/i).click();
+      cy.findByText(/hosts targeted/i).should("exist");
+      cy.findByText(/run/i).click();
+      cy.wait(10000); // wait for live query to run
+      cy.getAttached(".query-results__results-table-header").within(() => {
+        cy.findByText(/show query/i).click();
+      });
+      cy.getAttached(".show-query-modal").within(() => {
+        cy.findByText(/done/i).click();
+      });
+      cy.getAttached(".query-results__results-table-header").within(() => {
+        const formattedTime = format(new Date(), "MM-dd-yy hh-mm-ss");
+        cy.findByText(/export results/i).click();
+        const filename = `Query Results (${formattedTime}).csv`;
+        cy.readFile(path.join(Cypress.config("downloadsFolder"), filename), {
+          timeout: 5000,
+        });
+      });
+      cy.stopDockerHost();
+    });
     it("edits an existing query", () => {
       cy.getAttached(".name__cell .button--text-link").first().click();
       cy.findByText(/run query/i).should("exist");
@@ -84,30 +108,6 @@ describe("Query flow (seeded)", () => {
       cy.getAttached(".button--alert.remove-query-modal__btn").click();
       cy.findByText(/successfully removed query/i).should("be.visible");
       cy.findByText(/detect linux hosts/i).should("not.exist");
-    });
-    it("runs a live query", () => {
-      cy.addDockerHost();
-      cy.getAttached(".name__cell .button--text-link").first().click();
-      cy.findByText(/run query/i).click();
-      cy.findByText(/all hosts/i).click();
-      cy.findByText(/hosts targeted/i).should("exist");
-      cy.findByText(/run/i).click();
-      cy.wait(10000); // wait for live query to run
-      cy.getAttached(".query-results__results-table-header").within(() => {
-        cy.findByText(/show query/i).click();
-      });
-      cy.getAttached(".show-query-modal").within(() => {
-        cy.findByText(/done/i).click();
-      });
-      cy.getAttached(".query-results__results-table-header").within(() => {
-        const formattedTime = format(new Date(), "MM-dd-yy hh-mm-ss");
-        cy.findByText(/export results/i).click();
-        const filename = `Query Results (${formattedTime}).csv`;
-        cy.readFile(path.join(Cypress.config("downloadsFolder"), filename), {
-          timeout: 5000,
-        });
-      });
-      cy.stopDockerHost();
     });
   });
   describe("Manage schedules page", () => {

--- a/cypress/integration/all/app/queryflow.spec.ts
+++ b/cypress/integration/all/app/queryflow.spec.ts
@@ -121,7 +121,7 @@ describe("Query flow (seeded)", () => {
       cy.getAttached(".no-schedule__schedule-button").click();
       cy.getAttached(".schedule-editor-modal__form").within(() => {
         cy.findByText(/select query/i).click();
-        cy.findByText(/detect presence/i).click();
+        cy.findByText(/get local/i).click();
         cy.findByText(/every day/i).click();
         cy.findByText(/every 6 hours/i).click();
         cy.findByText(/show advanced options/i).click();

--- a/cypress/integration/all/app/queryflow.spec.ts
+++ b/cypress/integration/all/app/queryflow.spec.ts
@@ -96,7 +96,7 @@ describe("Query flow (seeded)", () => {
       cy.findByText(/copy of/i).should("be.visible");
     });
     it("deletes an existing query", () => {
-      cy.findByText(/detect linux hosts/i)
+      cy.findByText(/detect presence of authorized ssh keys/i)
         .parent()
         .parent()
         .within(() => {
@@ -107,7 +107,9 @@ describe("Query flow (seeded)", () => {
       cy.findByRole("button", { name: /delete/i }).click();
       cy.getAttached(".button--alert.remove-query-modal__btn").click();
       cy.findByText(/successfully removed query/i).should("be.visible");
-      cy.findByText(/detect linux hosts/i).should("not.exist");
+      cy.findByText(/detect presence of authorized ssh keys/i).should(
+        "not.exist"
+      );
     });
   });
   describe("Manage schedules page", () => {

--- a/cypress/integration/free/admin.spec.ts
+++ b/cypress/integration/free/admin.spec.ts
@@ -263,7 +263,7 @@ describe(
         cy.findByText("Save").click(); // we have 'save as new' also
         cy.findByText(/query updated/i).should("exist");
       });
-      it.only("allows admin to run a query", () => {
+      it("allows admin to run a query", () => {
         cy.findByText(/cypress test query/i).click({ force: true });
         cy.findByText(/run query/i).click({ force: true });
         cy.findByText(/select targets/i).should("exist");

--- a/cypress/integration/free/admin.spec.ts
+++ b/cypress/integration/free/admin.spec.ts
@@ -263,7 +263,7 @@ describe(
         cy.findByText("Save").click(); // we have 'save as new' also
         cy.findByText(/query updated/i).should("exist");
       });
-      it("allows admin to run a query", () => {
+      it.only("allows admin to run a query", () => {
         cy.findByText(/cypress test query/i).click({ force: true });
         cy.findByText(/run query/i).click({ force: true });
         cy.findByText(/select targets/i).should("exist");

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -89,11 +89,11 @@ Cypress.Commands.add("seedQueries", () => {
       observer_can_run: false,
     },
     {
-      name:
-        "Detect Linux hosts with high severity vulnerable versions of OpenSSL",
+      name: "Get local user accounts",
       query:
-        "SELECT name AS name, version AS version, 'deb_packages' AS source FROM deb_packages WHERE name LIKE 'openssl%' UNION SELECT name AS name, version AS version, 'apt_sources' AS source FROM apt_sources WHERE name LIKE 'openssl%' UNION SELECT name AS name, version AS version, 'rpm_packages' AS source FROM rpm_packages WHERE name LIKE 'openssl%';",
-      description: "Retrieves the OpenSSL version.",
+        "SELECT uid, gid, username, description,directory, shell FROM users;",
+      description:
+        "Local user accounts (including domain accounts that have logged on locally (Windows)).",
       observer_can_run: false,
     },
   ];

--- a/frontend/pages/policies/PolicyPage/components/PolicyQueriesErrorsListWrapper/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyQueriesErrorsListWrapper/_styles.scss
@@ -15,7 +15,11 @@
   }
 
   .table-container {
-    margin-top: $pad-small;
+    margin-top: 0;
+  }
+
+  .data-table__wrapper {
+    margin-top: 0;
   }
 
   .table-container__header {

--- a/frontend/pages/policies/PolicyPage/components/PolicyQueriesErrorsListWrapper/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyQueriesErrorsListWrapper/_styles.scss
@@ -14,14 +14,6 @@
     margin-top: $pad-medium;
   }
 
-  .table-container {
-    margin-top: 0;
-  }
-
-  .data-table__wrapper {
-    margin-top: 0;
-  }
-
   .table-container__header {
     display: none;
   }

--- a/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
@@ -159,18 +159,22 @@ const QueryResults = ({
           Host that responded with results are marked <strong>Yes</strong>.
           Hosts that responded with no results are marked <strong>No</strong>.
         </InfoBanner>
-        <span className={`${baseClass}__results-count`}>
-          {totalRowsCount} result{totalRowsCount !== 1 && "s"}
-        </span>
-        <Button
-          className={`${baseClass}__export-btn`}
-          onClick={onExportQueryResults}
-          variant="text-link"
-        >
-          <>
-            Export results <img alt="" src={DownloadIcon} />
-          </>
-        </Button>
+        <div className={`${baseClass}__results-table-header`}>
+          <span className={`${baseClass}__results-count`}>
+            {totalRowsCount} result{totalRowsCount !== 1 && "s"}
+          </span>
+          <div className={`${baseClass}__results-cta`}>
+            <Button
+              className={`${baseClass}__export-btn`}
+              onClick={onExportQueryResults}
+              variant="text-link"
+            >
+              <>
+                Export results <img alt="" src={DownloadIcon} />
+              </>
+            </Button>
+          </div>
+        </div>
         <PolicyQueryListWrapper
           isLoading={false}
           policyHostsList={hostsOnline}
@@ -183,20 +187,24 @@ const QueryResults = ({
   const renderErrorsTable = () => {
     return (
       <div className={`${baseClass}__error-table-container`}>
-        {errors && (
-          <span className={`${baseClass}__error-count`}>
-            {errors.length} error{errors.length !== 1 && "s"}
-          </span>
-        )}
-        <Button
-          className={`${baseClass}__export-btn`}
-          onClick={onExportErrorsResults}
-          variant="text-link"
-        >
-          <>
-            Export errors <img alt="" src={DownloadIcon} />
-          </>
-        </Button>
+        <div className={`${baseClass}__errors-table-header`}>
+          {errors && (
+            <span className={`${baseClass}__error-count`}>
+              {errors.length} error{errors.length !== 1 && "s"}
+            </span>
+          )}
+          <div className={`${baseClass}__errors-cta`}>
+            <Button
+              className={`${baseClass}__export-btn`}
+              onClick={onExportErrorsResults}
+              variant="text-link"
+            >
+              <>
+                Export errors <img alt="" src={DownloadIcon} />
+              </>
+            </Button>
+          </div>
+        </div>
         <PolicyQueriesErrorsListWrapper
           isLoading={false}
           errorsList={errors}

--- a/frontend/pages/policies/PolicyPage/components/QueryResults/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/QueryResults/_styles.scss
@@ -50,6 +50,8 @@
   }
 
   .table-container {
+    margin-top: 0;
+
     &__header {
       display: none;
     }

--- a/frontend/pages/policies/PolicyPage/components/QueryResults/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/QueryResults/_styles.scss
@@ -45,7 +45,7 @@
       height: 13px;
       margin-left: 8px;
       position: relative;
-      top: -2px;
+      bottom: 2px;
     }
   }
 
@@ -79,10 +79,17 @@
     }
   }
 
+  &__results-table-header,
+  &__errors-table-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: $pad-xlarge;
+  }
+
   &__results-count,
   &__error-count {
     font-size: $x-small;
     font-weight: $bold;
-    margin-right: $pad-medium;
   }
 }

--- a/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
@@ -15,7 +15,9 @@ import Spinner from "components/Spinner";
 import TableContainer from "components/TableContainer";
 import TabsWrapper from "components/TabsWrapper";
 import TooltipWrapper from "components/TooltipWrapper";
+import ShowQueryModal from "./ShowQueryModal";
 import DownloadIcon from "../../../../../../assets/images/icon-download-12x12@2x.png";
+import EyeIcon from "../../../../../../assets/images/icon-eye-16x16@2x.png";
 
 import resultsTableHeaders from "./QueryResultsTableConfig";
 
@@ -60,6 +62,7 @@ const QueryResults = ({
     targetsRespondedPercent,
     setTargetsRespondedPercent,
   ] = useState<number>(0);
+  const [showQueryModal, setShowQueryModal] = useState<boolean>(false);
 
   useEffect(() => {
     const calculatePercent =
@@ -119,6 +122,10 @@ const QueryResults = ({
     }
   };
 
+  const onShowQueryModal = () => {
+    setShowQueryModal(!showQueryModal);
+  };
+
   const onQueryDone = () => {
     setSelectedTargets([]);
     goToQueryEditor();
@@ -169,18 +176,31 @@ const QueryResults = ({
 
     return (
       <div className={`${baseClass}__results-table-container`}>
-        <span className={`${baseClass}__results-count`}>
-          {totalRowsCount} result{totalRowsCount !== 1 && "s"}
-        </span>
-        <Button
-          className={`${baseClass}__export-btn`}
-          onClick={onExportQueryResults}
-          variant="text-link"
-        >
-          <>
-            Export results <img alt="" src={DownloadIcon} />
-          </>
-        </Button>
+        <div className={`${baseClass}__results-table-header`}>
+          <span className={`${baseClass}__results-count`}>
+            {totalRowsCount} result{totalRowsCount !== 1 && "s"}
+          </span>
+          <div className={`${baseClass}__results-cta`}>
+            <Button
+              className={`${baseClass}__show-query-btn`}
+              onClick={onShowQueryModal}
+              variant="text-link"
+            >
+              <>
+                Show query <img alt="Show query" src={EyeIcon} />
+              </>
+            </Button>
+            <Button
+              className={`${baseClass}__export-btn`}
+              onClick={onExportQueryResults}
+              variant="text-link"
+            >
+              <>
+                Export results <img alt="Export results" src={DownloadIcon} />
+              </>
+            </Button>
+          </div>
+        </div>
         {renderTable(queryResults)}
       </div>
     );
@@ -282,6 +302,12 @@ const QueryResults = ({
           <TabPanel>{renderErrorsTable()}</TabPanel>
         </Tabs>
       </TabsWrapper>
+      {showQueryModal && (
+        <ShowQueryModal
+          onCancel={onShowQueryModal}
+          liveQuery={"query string"}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
@@ -209,20 +209,33 @@ const QueryResults = ({
   const renderErrorsTable = () => {
     return (
       <div className={`${baseClass}__error-table-container`}>
-        {errors && (
-          <span className={`${baseClass}__error-count`}>
-            {errors.length} error{errors.length !== 1 && "s"}
-          </span>
-        )}
-        <Button
-          className={`${baseClass}__export-btn`}
-          onClick={onExportErrorsResults}
-          variant="text-link"
-        >
-          <>
-            Export errors <img alt="" src={DownloadIcon} />
-          </>
-        </Button>
+        <div className={`${baseClass}__errors-table-header`}>
+          {errors && (
+            <span className={`${baseClass}__error-count`}>
+              {errors.length} error{errors.length !== 1 && "s"}
+            </span>
+          )}
+          <div className={`${baseClass}__errors-cta`}>
+            <Button
+              className={`${baseClass}__show-query-btn`}
+              onClick={onShowQueryModal}
+              variant="text-link"
+            >
+              <>
+                Show query <img alt="Show query" src={EyeIcon} />
+              </>
+            </Button>
+            <Button
+              className={`${baseClass}__export-btn`}
+              onClick={onExportErrorsResults}
+              variant="text-link"
+            >
+              <>
+                Export errors <img alt="" src={DownloadIcon} />
+              </>
+            </Button>
+          </div>
+        </div>
         <div className={`${baseClass}__error-table-wrapper`}>
           {renderTable(errors)}
         </div>
@@ -302,12 +315,7 @@ const QueryResults = ({
           <TabPanel>{renderErrorsTable()}</TabPanel>
         </Tabs>
       </TabsWrapper>
-      {showQueryModal && (
-        <ShowQueryModal
-          onCancel={onShowQueryModal}
-          liveQuery={"query string"}
-        />
-      )}
+      {showQueryModal && <ShowQueryModal onCancel={onShowQueryModal} />}
     </div>
   );
 };

--- a/frontend/pages/queries/QueryPage/components/QueryResults/ShowQueryModal/ShowQueryModal.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/ShowQueryModal/ShowQueryModal.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+import Modal from "components/Modal";
+import Button from "components/buttons/Button";
+// @ts-ignore
+import YamlAce from "components/YamlAce";
+
+const baseClass = "show-query-modal";
+
+interface IShowQueryModalProps {
+  onCancel: () => void;
+  liveQuery: string;
+}
+
+const ShowQueryModal = ({
+  onCancel,
+  liveQuery,
+}: IShowQueryModalProps): JSX.Element => {
+  const handleAceInputChange = (value: string) => {};
+
+  return (
+    <Modal title={"Query"} onExit={onCancel} className={baseClass}>
+      <div className={`${baseClass}__show-query-modal`}>
+        <YamlAce
+          wrapperClassName={`${baseClass}__text-editor-wrapper`}
+          onChange={handleAceInputChange}
+          name="liveQuery"
+          value={liveQuery}
+        />
+
+        <div className={`${baseClass}__btn-wrap`}>
+          <Button
+            className={`${baseClass}__btn`}
+            onClick={onCancel}
+            variant="brand"
+          >
+            Done
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ShowQueryModal;

--- a/frontend/pages/queries/QueryPage/components/QueryResults/ShowQueryModal/ShowQueryModal.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/ShowQueryModal/ShowQueryModal.tsx
@@ -1,33 +1,28 @@
-import React from "react";
+import React, { useContext } from "react";
+import { QueryContext } from "context/query";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
-// @ts-ignore
-import YamlAce from "components/YamlAce";
+import FleetAce from "components/FleetAce";
 
 const baseClass = "show-query-modal";
 
 interface IShowQueryModalProps {
   onCancel: () => void;
-  liveQuery: string;
 }
 
-const ShowQueryModal = ({
-  onCancel,
-  liveQuery,
-}: IShowQueryModalProps): JSX.Element => {
-  const handleAceInputChange = (value: string) => {};
+const ShowQueryModal = ({ onCancel }: IShowQueryModalProps): JSX.Element => {
+  const { lastEditedQueryBody } = useContext(QueryContext);
 
   return (
     <Modal title={"Query"} onExit={onCancel} className={baseClass}>
       <div className={`${baseClass}__show-query-modal`}>
-        <YamlAce
+        <FleetAce
+          value={lastEditedQueryBody}
+          name="query editor"
           wrapperClassName={`${baseClass}__text-editor-wrapper`}
-          onChange={handleAceInputChange}
-          name="liveQuery"
-          value={liveQuery}
+          readOnly
         />
-
         <div className={`${baseClass}__btn-wrap`}>
           <Button
             className={`${baseClass}__btn`}

--- a/frontend/pages/queries/QueryPage/components/QueryResults/ShowQueryModal/_styles.scss
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/ShowQueryModal/_styles.scss
@@ -2,6 +2,7 @@
   &__btn-wrap {
     display: flex;
     flex-direction: row-reverse;
+    margin: $pad-large 0 0;
   }
 
   &__btn {

--- a/frontend/pages/queries/QueryPage/components/QueryResults/ShowQueryModal/_styles.scss
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/ShowQueryModal/_styles.scss
@@ -1,0 +1,18 @@
+.show-query-modal {
+  &__btn-wrap {
+    display: flex;
+    flex-direction: row-reverse;
+  }
+
+  &__btn {
+    margin-left: 12px;
+  }
+
+  .yaml-ace {
+    min-height: 0;
+  }
+
+  .yaml-ace__label {
+    height: 0;
+  }
+}

--- a/frontend/pages/queries/QueryPage/components/QueryResults/ShowQueryModal/index.ts
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/ShowQueryModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ShowQueryModal";

--- a/frontend/pages/queries/QueryPage/components/QueryResults/_styles.scss
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/_styles.scss
@@ -46,8 +46,6 @@
       width: 13px;
       height: 13px;
       margin-left: 8px;
-      position: relative;
-      top: -2px;
     }
   }
 

--- a/frontend/pages/queries/QueryPage/components/QueryResults/_styles.scss
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/_styles.scss
@@ -40,11 +40,17 @@
     margin-right: $pad-medium;
   }
 
-  &__export-btn,
+  &__export-btn {
+    img {
+      width: 13px;
+      margin-left: 8px;
+      position: relative;
+      bottom: 2px;
+    }
+  }
   &__show-query-btn {
     img {
       width: 13px;
-      height: 13px;
       margin-left: 8px;
     }
   }

--- a/frontend/pages/queries/QueryPage/components/QueryResults/_styles.scss
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/_styles.scss
@@ -35,9 +35,12 @@
     }
   }
 
-  &__export-btn {
-    padding-top: 28px;
+  &__results-cta > *:not(:last-child) {
+    margin-right: $pad-medium;
+  }
 
+  &__export-btn,
+  &__show-query-btn {
     img {
       width: 13px;
       height: 13px;
@@ -77,10 +80,16 @@
     }
   }
 
+  &__results-table-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: $pad-xlarge;
+  }
+
   &__results-count,
   &__error-count {
     font-size: $x-small;
     font-weight: $bold;
-    margin-right: $pad-medium;
   }
 }

--- a/frontend/pages/queries/QueryPage/components/QueryResults/_styles.scss
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/_styles.scss
@@ -35,7 +35,8 @@
     }
   }
 
-  &__results-cta > *:not(:last-child) {
+  &__results-cta > *:not(:last-child),
+  &__errors-cta > *:not(:last-child) {
     margin-right: $pad-medium;
   }
 
@@ -80,7 +81,8 @@
     }
   }
 
-  &__results-table-header {
+  &__results-table-header,
+  &__errors-table-header {
     display: flex;
     justify-content: space-between;
     align-items: center;


### PR DESCRIPTION
Cerra #4574 (4.14 next release)

- Moves CTA buttons to right side of table
- Add "Show query" button which opens modal of the query ran
- Changes on both the Results tab and the Errors tab
- Update policy tab as well to match styling (margins, position of CTA button)

Screenshots (example of Results tab, Errors tab):
<img width="1173" alt="Screen Shot 2022-04-15 at 12 41 11 PM" src="https://user-images.githubusercontent.com/71795832/163597276-83369315-10b3-4e4f-9d5b-dfcdab411a12.png">
<img width="1173" alt="Screen Shot 2022-04-15 at 12 35 32 PM" src="https://user-images.githubusercontent.com/71795832/163597003-f856b114-0757-4100-9fe5-b0e19c42f242.png">

Screenshots of updated Query Results, Query Errors, Policy Results, Policy Errors (4/20/22):
<img width="1276" alt="Screen Shot 2022-04-20 at 10 34 15 AM" src="https://user-images.githubusercontent.com/71795832/164255374-6ad317f0-ab6c-45aa-97ec-a1b8e595b39a.png">
<img width="1324" alt="Screen Shot 2022-04-20 at 10 33 51 AM" src="https://user-images.githubusercontent.com/71795832/164255381-7abe829d-0162-4993-b7ac-c6b453e7cd28.png">
<img width="1323" alt="Screen Shot 2022-04-20 at 10 27 00 AM" src="https://user-images.githubusercontent.com/71795832/164255386-16196d8a-eca7-46c7-a7dd-999568749430.png">
<img width="1321" alt="Screen Shot 2022-04-20 at 10 26 34 AM" src="https://user-images.githubusercontent.com/71795832/164255389-285cbd17-12f7-49e9-8430-e8e34e8fb8c8.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
