### PR TITLE
New query and new policy: Identify optional fields to users

### DIFF
--- a/changes/issue-3912-display-optional-fields-as-optional
+++ b/changes/issue-3912-display-optional-fields-as-optional
@@ -1,0 +1,1 @@
+* UI hints that fields are optional for new query and new policy

--- a/docs/01-Using-Fleet/standard-query-library/README.md
+++ b/docs/01-Using-Fleet/standard-query-library/README.md
@@ -22,7 +22,7 @@ Want to add your own query?
   spec:
     name: What is your query called? Please use a human readable query name.
     platforms: What operating systems support your query? This can usually be determined by the osquery tables included in your query. Heading to the https://osquery.io/schema webpage to see which operating systems are supported by the tables you include.
-    description: Describe your query. What does information does your query reveal?
+    description: Describe your query. What does information does your query reveal? (optional)
     query: Insert query here
     purpose: What is the goal of running your query? Ex. Detection
     remediation: Are there any remediation steps to resolve the detection triggered by your query? If not, insert "N/A."

--- a/frontend/components/forms/LabelForm/LabelForm.tsx
+++ b/frontend/components/forms/LabelForm/LabelForm.tsx
@@ -219,6 +219,7 @@ const LabelForm = ({
         value={name}
         inputClassName={`${baseClass}__label-title`}
         label="Name"
+        placeholder="Label name"
       />
       <InputField
         name="description"
@@ -227,6 +228,7 @@ const LabelForm = ({
         inputClassName={`${baseClass}__label-description`}
         label="Description"
         type="textarea"
+        placeholder="Label description (optional)"
       />
       {!isManual && !isEdit && (
         <div className="form-field form-field--dropdown">

--- a/frontend/pages/policies/PolicyPage/components/NewPolicyModal/NewPolicyModal.tsx
+++ b/frontend/pages/policies/PolicyPage/components/NewPolicyModal/NewPolicyModal.tsx
@@ -118,7 +118,7 @@ const NewPolicyModal = ({
           value={description}
           inputClassName={`${baseClass}__policy-save-modal-description`}
           label="Description"
-          placeholder="Add a description here"
+          placeholder="Add a description here (optional)"
         />
         <InputField
           name="resolution"
@@ -127,7 +127,7 @@ const NewPolicyModal = ({
           inputClassName={`${baseClass}__policy-save-modal-resolution`}
           label="Resolution"
           type="textarea"
-          placeholder="What are the steps a device owner should take to resolve a host that fails this policy?"
+          placeholder="What are the steps a device owner should take to resolve a host that fails this policy? (optional)"
         />
         {platformSelector.render()}
         <div

--- a/frontend/pages/queries/QueryPage/components/NewQueryModal/NewQueryModal.tsx
+++ b/frontend/pages/queries/QueryPage/components/NewQueryModal/NewQueryModal.tsx
@@ -94,7 +94,7 @@ const NewQueryModal = ({
           inputClassName={`${baseClass}__query-save-modal-description`}
           label="Description"
           type="textarea"
-          placeholder="What information does your query reveal?"
+          placeholder="What information does your query reveal? (optional)"
         />
         <Checkbox
           name="observerCanRun"


### PR DESCRIPTION
Cerra #3912 (4.14 next release)

- Add "(optional)" to input placeholders that are optional

<img width="1013" alt="Screen Shot 2022-04-15 at 1 09 35 PM" src="https://user-images.githubusercontent.com/71795832/163600132-a1ed26d4-9899-4394-ab5c-ff2980c7a08f.png">
<img width="1017" alt="Screen Shot 2022-04-15 at 1 09 02 PM" src="https://user-images.githubusercontent.com/71795832/163600140-4d2e672f-1491-40c5-81bf-f7bc1e5b355d.png">
<img width="1324" alt="Screen Shot 2022-04-19 at 2 24 48 PM" src="https://user-images.githubusercontent.com/71795832/164070637-e22a2b27-146f-47f8-964d-83a40070f085.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added (for user-visible changes)
- [x] Manual QA for all new/changed functionality
