### PR TITLE
Update the columns and elements the Fleet UI shows/hides at breakpoints

### DIFF
--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/_styles.scss
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/_styles.scss
@@ -25,11 +25,6 @@
           border-right: none;
         }
 
-        .email__header {
-          display: none;
-          width: 0;
-        }
-
         .actions__header {
           width: auto;
         }
@@ -37,12 +32,6 @@
         @media (min-width: $break-1400) {
           .role__header {
             border-right: 1px solid $ui-fleet-blue-15;
-          }
-
-          .email__header {
-            display: table-cell;
-            width: $col-lg;
-            border-right: none;
           }
         }
       }
@@ -56,19 +45,8 @@
           max-width: $col-md;
         }
 
-        .email__cell {
-          display: none;
-        }
-
         .actions__cell {
           width: auto;
-        }
-
-        @media (min-width: $break-1400) {
-          .email__cell {
-            display: table-cell;
-            max-width: $col-lg;
-          }
         }
       }
     }

--- a/frontend/pages/admin/TeamManagementPage/_styles.scss
+++ b/frontend/pages/admin/TeamManagementPage/_styles.scss
@@ -18,11 +18,6 @@
           border-right: none;
         }
 
-        .user_count__header {
-          display: none;
-          width: 0;
-        }
-
         .actions__header {
           width: auto;
         }
@@ -30,12 +25,6 @@
         @media (min-width: $break-990) {
           .host_count__header {
             border-right: 1px solid $ui-fleet-blue-15;
-          }
-
-          .user_count__header {
-            display: table-cell;
-            width: $col-md;
-            border-right: none;
           }
         }
       }
@@ -49,19 +38,8 @@
           max-width: $col-md;
         }
 
-        .user_count__cell {
-          display: none;
-        }
-
         .actions__cell {
           width: auto;
-        }
-
-        @media (min-width: $break-990) {
-          .user_count__cell {
-            display: table-cell;
-            max-width: $col-md;
-          }
         }
       }
     }

--- a/frontend/pages/admin/UserManagementPage/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/_styles.scss
@@ -74,10 +74,6 @@
           display: none;
           width: 0;
         }
-        .email__header {
-          display: none;
-          width: 0;
-        }
         .actions__header {
           width: auto;
         }
@@ -105,11 +101,6 @@
           .teams__header {
             border-right: 1px solid $ui-fleet-blue-15;
           }
-          .email__header {
-            display: table-cell;
-            width: $col-lg;
-            border-right: none;
-          }
         }
       }
       tbody {
@@ -131,10 +122,6 @@
           display: none;
           max-width: $col-md;
         }
-        .email__cell {
-          display: none;
-          max-width: $col-md;
-        }
         .actions__cell {
           width: auto;
         }
@@ -145,11 +132,6 @@
         }
         @media (min-width: $break-1400) {
           .status__cell {
-            display: table-cell;
-          }
-        }
-        @media (min-width: $break-1600) {
-          .email__cell {
             display: table-cell;
           }
         }

--- a/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
@@ -41,12 +41,6 @@
       display: flex;
       flex-wrap: wrap;
 
-      @media screen and (max-width: 960px) {
-        div:nth-child(n + 5) {
-          display: none;
-        }
-      }
-
       .info-flex__item--title {
         margin-bottom: 2.5rem;
       }

--- a/frontend/pages/hosts/details/cards/Packs/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Packs/_styles.scss
@@ -16,17 +16,9 @@
           display: none;
           width: 0;
         }
-        .performance__header {
-          display: none;
-          width: 0;
-        }
         @media (min-width: $break-990) {
           .last_run__header {
             display: table-cell;
-          }
-          .performance__header {
-            display: table-cell;
-            width: $col-md;
           }
         }
       }
@@ -41,17 +33,9 @@
           display: none;
           width: 0;
         }
-        .performance__cell {
-          display: none;
-          width: 0;
-        }
         @media (min-width: $break-990) {
           .last_run__cell {
             display: table-cell;
-          }
-          .performance__cell {
-            display: table-cell;
-            width: $col-md;
           }
         }
       }

--- a/frontend/pages/hosts/details/cards/Schedule/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Schedule/_styles.scss
@@ -15,16 +15,6 @@
         .frequency__header {
           width: $col-md;
         }
-        .performance__header {
-          display: none;
-          width: 0;
-        }
-        @media (min-width: $break-990) {
-          .performance__header {
-            display: table-cell;
-            width: $col-md;
-          }
-        }
       }
       tbody {
         .query_name__cell {
@@ -32,16 +22,6 @@
         }
         .frequency__cell {
           width: $col-md;
-        }
-        .performance__cell {
-          display: none;
-          width: 0;
-        }
-        @media (min-width: $break-990) {
-          .performance__cell {
-            display: table-cell;
-            width: $col-md;
-          }
         }
       }
     }

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -48,19 +48,12 @@
           display: none;
           width: 0px;
         }
-        .vulnerabilities__header {
-          display: none;
-          width: 0px;
-        }
         .hosts_count__header {
           border-right: 0;
         }
         @media (min-width: $break-990) {
           .version__header {
             width: $col-md;
-          }
-          .vulnerabilities__header {
-            display: table-cell;
           }
         }
         @media (min-width: $break-1400) {
@@ -82,10 +75,6 @@
           display: none;
           width: 0px;
         }
-        .vulnerabilities__cell {
-          width: 0px;
-          display: none;
-        }
         .hosts_count__cell {
           .hosts-cell__wrapper {
             display: flex;
@@ -96,11 +85,6 @@
             .hosts-cell__link {
               display: flex;
             }
-          }
-        }
-        @media (min-width: $break-990) {
-          .vulnerabilities__cell {
-            display: table-cell;
           }
         }
         @media (min-width: $break-1400) {

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -129,10 +129,6 @@
             display: none;
             width: 0;
           }
-          .performance__header {
-            display: none;
-            width: 0;
-          }
           .updated_at__header {
             display: none;
             width: 0;
@@ -148,15 +144,6 @@
           }
           @media (min-width: $break-1400) {
             .author_name__header {
-              width: $col-md;
-            }
-            .performance__header {
-              display: table-cell;
-              width: auto;
-            }
-          }
-          @media (min-width: $break-1600) {
-            .performance__header {
               width: $col-md;
             }
             .updated_at__header {
@@ -188,10 +175,6 @@
               display: block;
             }
           }
-          .performance__cell {
-            display: none;
-            max-width: $col-md;
-          }
           .updated_at__cell {
             display: none;
             max-width: $col-md;
@@ -202,11 +185,6 @@
             }
           }
           @media (min-width: $break-1400) {
-            .performance__cell {
-              display: table-cell;
-            }
-          }
-          @media (min-width: $break-1600) {
             .updated_at__cell {
               display: table-cell;
             }

--- a/frontend/pages/schedule/ManageSchedulePage/_styles.scss
+++ b/frontend/pages/schedule/ManageSchedulePage/_styles.scss
@@ -102,21 +102,12 @@
           .interval__header {
             width: auto;
           }
-          .performance__header {
-            display: none;
-            width: 0;
-          }
           .actions__header {
             width: auto;
           }
           @media (min-width: $break-1400) {
             .interval__header {
               width: 0;
-            }
-            .performance__header {
-              display: table-cell;
-              width: $col-lg;
-              border-left: 1px solid $ui-fleet-blue-15;
             }
           }
         }
@@ -127,20 +118,12 @@
           .interval__cell {
             width: auto;
           }
-          .performance__cell {
-            display: none;
-            width: 0;
-          }
           .actions__cell {
             width: auto;
           }
           @media (min-width: $break-1400) {
             .interval_cell {
               width: 0;
-            }
-            .performance__cell {
-              display: table-cell;
-              width: $col-lg;
             }
           }
         }

--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -232,7 +232,6 @@
                 width: 0;
               }
               .vulnerabilities__cell {
- 
                 .text-muted {
                   color: $ui-fleet-black-50;
                 }

--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -204,10 +204,6 @@
                 display: none;
                 width: 0;
               }
-              .vulnerabilities__header {
-                display: none;
-                width: 0;
-              }
               .hosts_count__header {
                 width: auto;
                 border-right: 0;
@@ -215,9 +211,6 @@
               @media (min-width: $break-990) {
                 .version__header {
                   width: $col-md;
-                }
-                .vulnerabilities__header {
-                  display: table-cell;
                 }
               }
               @media (min-width: $break-1400) {
@@ -239,9 +232,7 @@
                 width: 0;
               }
               .vulnerabilities__cell {
-                width: 0;
-                display: none;
-
+ 
                 .text-muted {
                   color: $ui-fleet-black-50;
                 }
@@ -251,9 +242,6 @@
                 .hosts-cell__wrapper {
                   display: flex;
                   justify-content: space-between;
-                  .hosts-cell__count {
-                    display: none;
-                  }
                   .hosts-cell__link {
                     display: flex;
                   }
@@ -262,16 +250,6 @@
               @media (min-width: $break-990) {
                 .version_cell {
                   width: $col-md;
-                }
-                .vulnerabilities__cell {
-                  display: table-cell;
-                }
-                .hosts_count__cell {
-                  .hosts-cell__wrapper {
-                    .hosts-cell__count {
-                      display: flex;
-                    }
-                  }
                 }
               }
               @media (min-width: $break-1400) {


### PR DESCRIPTION
This PR includes revisions to the specification in the "Make table behavior in the Fleet UI consistent down to 768px" issue: #3052

These revisions were made because the original specification asked to, at certain screen widths, hide information when it wasn't necessary. This concern was raised by the engineering team at Fleet.

The following revisions will also be made in the Figma page linked in the above issue: https://www.figma.com/file/hdALBDsrti77QuDNSzLdkx/?node-id=3540%3A93005

- Update top card on **Host details** to wrap elements instead of hiding elements
  - This change reverts the changes made in the following PR: #5154 
  - This change means the bug reported in the following issue is no longer a bug: #5091. This issue will be closed.
- Update **Queries** to hide "Last modified" column at 1400px
- Update **Queries** to always show "Performance impact" column
- Update **Schedule** to always show "Performance impact" column
- Update **Host details > Software** to always show "Vulnerabilities" column
- Update **Host details > Schedule** to always show "Performance impact" column
- Update **Host details > Packs** to always show "Performance impact" column
- Update **Users** to always show "Email" column
- Update **Teams** to always show "Members" column
- Update **Team details** to always show "Email" column
- Update **Software** to always show "Vulnerabilities" column

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
