### PR TITLE
Fix race condition in tests when using global var loginRateLimit

### DIFF
--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -75,8 +75,33 @@ func checkLicenseExpiration(svc fleet.Service) func(context.Context, http.Respon
 	}
 }
 
+type extraHandlerOpts struct {
+	loginRateLimit *throttled.Rate
+}
+
+// ExtraHandlerOption allows adding extra configuration to the HTTP handler.
+type ExtraHandlerOption func(*extraHandlerOpts)
+
+// WithLoginRateLimit configures the rate limit for the login endpoint.
+func WithLoginRateLimit(r throttled.Rate) ExtraHandlerOption {
+	return func(o *extraHandlerOpts) {
+		o.loginRateLimit = &r
+	}
+}
+
 // MakeHandler creates an HTTP handler for the Fleet server endpoints.
-func MakeHandler(svc fleet.Service, config config.FleetConfig, logger kitlog.Logger, limitStore throttled.GCRAStore) http.Handler {
+func MakeHandler(
+	svc fleet.Service,
+	config config.FleetConfig,
+	logger kitlog.Logger,
+	limitStore throttled.GCRAStore,
+	extra ...ExtraHandlerOption,
+) http.Handler {
+	var eopts extraHandlerOpts
+	for _, fn := range extra {
+		fn(&eopts)
+	}
+
 	fleetAPIOptions := []kithttp.ServerOption{
 		kithttp.ServerBefore(
 			kithttp.PopulateRequestContext, // populate the request context with common fields
@@ -98,7 +123,7 @@ func MakeHandler(svc fleet.Service, config config.FleetConfig, logger kitlog.Log
 
 	r.Use(publicIP)
 
-	attachFleetAPIRoutes(r, svc, config, logger, limitStore, fleetAPIOptions)
+	attachFleetAPIRoutes(r, svc, config, logger, limitStore, fleetAPIOptions, eopts)
 
 	// Results endpoint is handled different due to websockets use
 
@@ -203,14 +228,9 @@ func addMetrics(r *mux.Router) {
 	r.Walk(walkFn)
 }
 
-var (
-	// those are conceptually constants, but var so they can be changed in tests
-	forgotPasswordRateLimit = throttled.PerHour(10)
-	loginRateLimit          = throttled.PerMin(10)
-)
-
 func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetConfig,
 	logger kitlog.Logger, limitStore throttled.GCRAStore, opts []kithttp.ServerOption,
+	extra extraHandlerOpts,
 ) {
 	apiVersions := []string{"v1", "2022-04"}
 
@@ -413,8 +433,8 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ne.WithAltPaths("/api/v1/osquery/enroll").
 		POST("/api/osquery/enroll", enrollAgentEndpoint, enrollAgentRequest{})
 
-		// For some reason osquery does not provide a node key with the block data.
-		// Instead the carve session ID should be verified in the service method.
+	// For some reason osquery does not provide a node key with the block data.
+	// Instead the carve session ID should be verified in the service method.
 	ne.WithAltPaths("/api/v1/osquery/carve/block").
 		POST("/api/osquery/carve/block", carveBlockEndpoint, carveBlockRequest{})
 
@@ -429,11 +449,15 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 
 	limiter := ratelimit.NewMiddleware(limitStore)
 	ne.
-		WithCustomMiddleware(limiter.Limit("forgot_password", throttled.RateQuota{MaxRate: forgotPasswordRateLimit, MaxBurst: 9})).
+		WithCustomMiddleware(limiter.Limit("forgot_password", throttled.RateQuota{MaxRate: throttled.PerHour(10), MaxBurst: 9})).
 		POST("/api/_version_/fleet/forgot_password", forgotPasswordEndpoint, forgotPasswordRequest{})
 
-	ne.
-		WithCustomMiddleware(limiter.Limit("login", throttled.RateQuota{MaxRate: loginRateLimit, MaxBurst: 9})).
+	loginRateLimit := throttled.PerMin(10)
+	if extra.loginRateLimit != nil {
+		loginRateLimit = *extra.loginRateLimit
+	}
+
+	ne.WithCustomMiddleware(limiter.Limit("login", throttled.RateQuota{MaxRate: loginRateLimit, MaxBurst: 9})).
 		POST("/api/_version_/fleet/login", loginEndpoint, loginRequest{})
 }
 

--- a/server/service/testing_client.go
+++ b/server/service/testing_client.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/throttled/throttled/v2"
 )
 
 type withDS struct {
@@ -46,7 +45,6 @@ type withServer struct {
 func (ts *withServer) SetupSuite(dbName string) {
 	ts.withDS.SetupSuite(dbName)
 
-	loginRateLimit = throttled.PerMin(100)
 	rs := pubsub.NewInmemQueryResults()
 	users, server := RunServerForTestsWithDS(ts.s.T(), ts.ds, TestServerOpts{Rs: rs})
 	ts.server = server
@@ -149,7 +147,7 @@ func (ts *withServer) getTestToken(email string, password string) string {
 	defer resp.Body.Close()
 	assert.Equal(ts.s.T(), http.StatusOK, resp.StatusCode)
 
-	var jsn = struct {
+	jsn := struct {
 		User  *fleet.User         `json:"user"`
 		Token string              `json:"token"`
 		Err   []map[string]string `json:"errors,omitempty"`

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -22,6 +22,7 @@ import (
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/throttled/throttled/v2"
 	"github.com/throttled/throttled/v2/store/memstore"
 )
 
@@ -177,7 +178,7 @@ func RunServerForTestsWithDS(t *testing.T, ds fleet.Datastore, opts ...TestServe
 	}
 
 	limitStore, _ := memstore.New(0)
-	r := MakeHandler(svc, config.FleetConfig{}, logger, limitStore)
+	r := MakeHandler(svc, config.FleetConfig{}, logger, limitStore, WithLoginRateLimit(throttled.PerMin(100)))
 	server := httptest.NewServer(r)
 	t.Cleanup(func() {
 		server.Close()


### PR DESCRIPTION
This is attempting to fix a race in tests when using a global variable, see https://github.com/fleetdm/fleet/actions/runs/2182143056.

I wasn't able to reproduce in macOS, but it happens consistently on Github CI linux hosts.

Race happens due to the write of the global variable in line 49: https://github.com/fleetdm/fleet/blob/f55bafb5e3f58bae6f39de2396c6ed81b49cb2b4/server/service/testing_client.go#L46-L56

The fix is to not use a global variable and use options instead.

```
WARNING: DATA RACE
Write at 0x0000032f1dc0 by goroutine 15:
  github.com/fleetdm/fleet/v4/server/service.(*withServer).SetupSuite()
      /home/runner/work/fleet/fleet/server/service/testing_client.go:49 +0x8b
  github.com/fleetdm/fleet/v4/server/service.(*integrationTestSuite).SetupSuite()
      /home/runner/work/fleet/fleet/server/service/integration_core_test.go:40 +0x44

--

Previous read at 0x0000032f1dc0 by goroutine 67:
  [failed to restore the stack]

Goroutine 15 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.18.0/x64/src/testing/testing.go:1486 +0x724
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.18.0/x64/src/testing/testing.go:1839 +0x99
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.0/x64/src/testing/testing.go:1439 +0x213
  testing.runTests()
      /opt/hostedtoolcache/go/1.18.0/x64/src/testing/testing.go:1837 +0x7e4
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.18.0/x64/src/testing/testing.go:1719 +0xa71
  main.main()
      _testmain.go:537 +0x3a9

Goroutine 67 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.18.0/x64/src/testing/testing.go:1486 +0x724
  github.com/stretchr/testify/suite.(*Suite).Run()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.7.1/suite/suite.go:75 +0x1ad
  github.com/fleetdm/fleet/v4/server/service.(*integrationDSTestSuite).TestLicenseExpiration()
      /home/runner/work/fleet/fleet/server/service/integration_ds_only_test.go:43 +0x44d
  runtime.call16()
```

~- [ ] Changes file added (for user-visible changes)~
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added/updated tests~
~- [ ] Manual QA for all new/changed functionality~
