### PR TITLE
Remove recursion and return `doRetryErr` on `getOrGenerateSoftwareIdDB`

### DIFF
--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -2136,14 +2136,6 @@ func testHostsSaveTonsOfUsers(t *testing.T, ds *Datastore) {
 			host1.Users = []fleet.HostUser{u1, u2}
 			host1.SeenTime = time.Now()
 			host1.Modified = true
-			soft := fleet.HostSoftware{
-				Modified: true,
-				Software: []fleet.Software{
-					{Name: "foo", Version: "0.0.1", Source: "chrome_extensions"},
-					{Name: "foo", Version: "0.0.3", Source: "chrome_extensions"},
-				},
-			}
-			host1.HostSoftware = soft
 			additional := json.RawMessage(`{"some":"thing"}`)
 			host1.Additional = &additional
 
@@ -2152,6 +2144,17 @@ func testHostsSaveTonsOfUsers(t *testing.T, ds *Datastore) {
 				errCh <- err
 				return
 			}
+
+			host1Software := []fleet.Software{
+				{Name: "foo", Version: "0.0.1", Source: "chrome_extensions"},
+				{Name: "foo", Version: "0.0.3", Source: "chrome_extensions"},
+			}
+			err = ds.UpdateHostSoftware(context.Background(), host1.ID, host1Software)
+			if err != nil {
+				errCh <- err
+				return
+			}
+
 			if atomic.AddInt32(&count1, 1) >= 100 {
 				return
 			}
@@ -2191,14 +2194,6 @@ func testHostsSaveTonsOfUsers(t *testing.T, ds *Datastore) {
 			host2.Users = []fleet.HostUser{u1, u2}
 			host2.SeenTime = time.Now()
 			host2.Modified = true
-			soft := fleet.HostSoftware{
-				Modified: true,
-				Software: []fleet.Software{
-					{Name: "foo", Version: "0.0.1", Source: "chrome_extensions"},
-					{Name: "foo4", Version: "0.0.3", Source: "chrome_extensions"},
-				},
-			}
-			host2.HostSoftware = soft
 			additional := json.RawMessage(`{"some":"thing"}`)
 			host2.Additional = &additional
 
@@ -2207,6 +2202,17 @@ func testHostsSaveTonsOfUsers(t *testing.T, ds *Datastore) {
 				errCh <- err
 				return
 			}
+
+			host2Software := []fleet.Software{
+				{Name: "foo", Version: "0.0.1", Source: "chrome_extensions"},
+				{Name: "foo4", Version: "0.0.3", Source: "chrome_extensions"},
+			}
+			err = ds.UpdateHostSoftware(context.Background(), host2.ID, host2Software)
+			if err != nil {
+				errCh <- err
+				return
+			}
+
 			if atomic.AddInt32(&count2, 1) >= 100 {
 				return
 			}
@@ -2219,7 +2225,7 @@ func testHostsSaveTonsOfUsers(t *testing.T, ds *Datastore) {
 		}
 	}()
 
-	ticker := time.NewTicker(10 * time.Second)
+	ticker := time.NewTicker(30 * time.Second)
 	go func() {
 		wg.Wait()
 		cancelFunc()

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -113,6 +113,8 @@ var (
 	usersTable    = entity{"users"}
 )
 
+var doRetryErr = errors.New("fleet datastore retry")
+
 // retryableError determines whether a MySQL error can be retried. By default
 // errors are considered non-retryable. Only errors that we know have a
 // possibility of succeeding on a retry should return true in this function.
@@ -124,6 +126,9 @@ func retryableError(err error) bool {
 		case mysqlerr.ER_LOCK_DEADLOCK, mysqlerr.ER_LOCK_WAIT_TIMEOUT:
 			return true
 		}
+	}
+	if errors.Is(err, doRetryErr) {
+		return true
 	}
 
 	return false


### PR DESCRIPTION
Found this issue while troubleshooting other changes.

If I leave `getOrGenerateSoftwareIdDB` unmodified (current `main` version which uses recursion) then when running `testHostsSaveTonsOfUsers` it will recurse *forever*. I am not sure why... That said, IMO it does make sense to remove the recursion and retry the transaction if the ID is not found after the `INSERT`...

The update of the `testHostsSaveTonsOfUsers` test to use `ds.UpdateHostSoftware` makes sense because that's what we use to update software from the osquery hosts, not `SaveHost` (which I will remove in a separate PR as it's not being used anymore).

~- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).~
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
