### PR TITLE
Delete unused `Datastore.SaveHost` and `{Host|HostSoftware}.Modified` fields

### DIFF
--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -96,48 +96,6 @@ func (ds *Datastore) SerialUpdateHost(ctx context.Context, host *fleet.Host) err
 	}
 }
 
-func (ds *Datastore) SaveHost(ctx context.Context, host *fleet.Host) error {
-	if err := ds.UpdateHost(ctx, host); err != nil {
-		return err
-	}
-
-	// Save host pack stats only if it is non-nil. Empty stats should be
-	// represented by an empty slice.
-	if host.PackStats != nil {
-		if err := saveHostPackStatsDB(ctx, ds.writer, host.ID, host.PackStats); err != nil {
-			return err
-		}
-	}
-
-	ac, err := ds.AppConfig(ctx)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "failed to get app config to see if we need to update host users and inventory")
-	}
-
-	if host.HostSoftware.Modified && ac.HostSettings.EnableSoftwareInventory && len(host.HostSoftware.Software) > 0 {
-		if err := saveHostSoftwareDB(ctx, ds.writer, host); err != nil {
-			return ctxerr.Wrap(ctx, err, "failed to save host software")
-		}
-	}
-
-	if host.Modified {
-		if host.Additional != nil {
-			if err := saveHostAdditionalDB(ctx, ds.writer, host.ID, host.Additional); err != nil {
-				return ctxerr.Wrap(ctx, err, "failed to save host additional")
-			}
-		}
-
-		if ac.HostSettings.EnableHostUsers && len(host.Users) > 0 {
-			if err := saveHostUsersDB(ctx, ds.writer, host.ID, host.Users); err != nil {
-				return ctxerr.Wrap(ctx, err, "failed to save host users")
-			}
-		}
-	}
-
-	host.Modified = false
-	return nil
-}
-
 func (ds *Datastore) SaveHostPackStats(ctx context.Context, hostID uint, stats []fleet.PackStats) error {
 	return saveHostPackStatsDB(ctx, ds.writer, hostID, stats)
 }

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -79,8 +79,10 @@ func testLabelsAddAllHosts(deferred bool, t *testing.T, db *Datastore) {
 		require.Nil(t, err, "enrollment should succeed")
 		hosts = append(hosts, *host)
 	}
+
 	host.Platform = "darwin"
-	require.NoError(t, db.SaveHost(context.Background(), host))
+	err = db.UpdateHost(context.Background(), host)
+	require.NoError(t, err)
 
 	// No labels to check
 	queries, err := db.LabelQueriesForHost(context.Background(), host)
@@ -706,10 +708,12 @@ func testLabelsSave(t *testing.T, db *Datastore) {
 
 func testLabelsQueriesForCentOSHost(t *testing.T, db *Datastore) {
 	host, err := db.EnrollHost(context.Background(), "0", "0", nil, 0)
-	require.Nil(t, err, "enrollment should succeed")
+	require.NoError(t, err, "enrollment should succeed")
+
 	host.Platform = "rhel"
 	host.OSVersion = "CentOS 6"
-	require.NoError(t, db.SaveHost(context.Background(), host))
+	err = db.UpdateHost(context.Background(), host)
+	require.NoError(t, err)
 
 	label, err := db.NewLabel(context.Background(), &fleet.Label{
 		UpdateCreateTimestamps: fleet.UpdateCreateTimestamps{

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -85,15 +85,6 @@ func (ds *Datastore) UpdateHostSoftware(ctx context.Context, hostID uint, softwa
 	})
 }
 
-func saveHostSoftwareDB(ctx context.Context, tx sqlx.ExtContext, host *fleet.Host) error {
-	if err := applyChangesForNewSoftwareDB(ctx, tx, host.ID, host.Software); err != nil {
-		return err
-	}
-
-	host.HostSoftware.Modified = false
-	return nil
-}
-
 func nothingChanged(current []fleet.Software, incoming []fleet.Software) bool {
 	if len(current) != len(incoming) {
 		return false
@@ -519,7 +510,6 @@ func loadCVEsBySoftware(
 }
 
 func (ds *Datastore) LoadHostSoftware(ctx context.Context, host *fleet.Host) error {
-	host.HostSoftware = fleet.HostSoftware{Modified: false}
 	software, err := listSoftwareDB(ctx, ds.reader, &host.ID, fleet.SoftwareListOptions{})
 	if err != nil {
 		return err

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -66,7 +66,6 @@ func testSoftwareSaveHost(t *testing.T, ds *Datastore) {
 	require.NoError(t, ds.UpdateHostSoftware(context.Background(), host2.ID, software2))
 
 	require.NoError(t, ds.LoadHostSoftware(context.Background(), host1))
-	assert.False(t, host1.HostSoftware.Modified)
 	test.ElementsMatchSkipIDAndHostCount(t, software1, host1.HostSoftware.Software)
 
 	soft1ByID, err := ds.SoftwareByID(context.Background(), host1.HostSoftware.Software[0].ID)
@@ -75,7 +74,6 @@ func testSoftwareSaveHost(t *testing.T, ds *Datastore) {
 	assert.Equal(t, host1.HostSoftware.Software[0], *soft1ByID)
 
 	require.NoError(t, ds.LoadHostSoftware(context.Background(), host2))
-	assert.False(t, host2.HostSoftware.Modified)
 	test.ElementsMatchSkipIDAndHostCount(t, software2, host2.HostSoftware.Software)
 
 	software1 = []fleet.Software{
@@ -89,11 +87,9 @@ func testSoftwareSaveHost(t *testing.T, ds *Datastore) {
 	require.NoError(t, ds.UpdateHostSoftware(context.Background(), host2.ID, software2))
 
 	require.NoError(t, ds.LoadHostSoftware(context.Background(), host1))
-	assert.False(t, host1.HostSoftware.Modified)
 	test.ElementsMatchSkipIDAndHostCount(t, software1, host1.HostSoftware.Software)
 
 	require.NoError(t, ds.LoadHostSoftware(context.Background(), host2))
-	assert.False(t, host2.HostSoftware.Modified)
 	test.ElementsMatchSkipIDAndHostCount(t, software2, host2.HostSoftware.Software)
 
 	software1 = []fleet.Software{
@@ -104,7 +100,6 @@ func testSoftwareSaveHost(t *testing.T, ds *Datastore) {
 	require.NoError(t, ds.UpdateHostSoftware(context.Background(), host1.ID, software1))
 
 	require.NoError(t, ds.LoadHostSoftware(context.Background(), host1))
-	assert.False(t, host1.HostSoftware.Modified)
 	test.ElementsMatchSkipIDAndHostCount(t, software1, host1.HostSoftware.Software)
 
 	software2 = []fleet.Software{
@@ -115,7 +110,6 @@ func testSoftwareSaveHost(t *testing.T, ds *Datastore) {
 	}
 	require.NoError(t, ds.UpdateHostSoftware(context.Background(), host2.ID, software2))
 	require.NoError(t, ds.LoadHostSoftware(context.Background(), host2))
-	assert.False(t, host2.HostSoftware.Modified)
 	test.ElementsMatchSkipIDAndHostCount(t, software2, host2.HostSoftware.Software)
 
 	software2 = []fleet.Software{
@@ -126,7 +120,6 @@ func testSoftwareSaveHost(t *testing.T, ds *Datastore) {
 	}
 	require.NoError(t, ds.UpdateHostSoftware(context.Background(), host2.ID, software2))
 	require.NoError(t, ds.LoadHostSoftware(context.Background(), host2))
-	assert.False(t, host2.HostSoftware.Modified)
 	test.ElementsMatchSkipIDAndHostCount(t, software2, host2.HostSoftware.Software)
 }
 

--- a/server/datastore/mysql/targets_test.go
+++ b/server/datastore/mysql/targets_test.go
@@ -257,7 +257,7 @@ func testTargetsHostStatus(t *testing.T, ds *Datastore) {
 			// Save interval values
 			h.DistributedInterval = tt.distributedInterval
 			h.ConfigTLSRefresh = tt.configTLSRefresh
-			require.NoError(t, ds.SaveHost(context.Background(), h))
+			require.NoError(t, ds.UpdateHost(context.Background(), h))
 
 			// Mark seen
 			require.NoError(t, ds.MarkHostsSeen(context.Background(), []uint{h.ID}, tt.seenTime))

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -173,7 +173,6 @@ type Datastore interface {
 
 	// NewHost is deprecated and will be removed. Hosts should always be enrolled via EnrollHost.
 	NewHost(ctx context.Context, host *Host) (*Host, error)
-	SaveHost(ctx context.Context, host *Host) error
 	DeleteHost(ctx context.Context, hid uint) error
 	Host(ctx context.Context, id uint, skipLoadingExtras bool) (*Host, error)
 	ListHosts(ctx context.Context, filter TeamFilter, opt HostListOptions) ([]*Host, error)

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -127,8 +127,6 @@ type Host struct {
 	PercentDiskSpaceAvailable float64 `json:"percent_disk_space_available" db:"percent_disk_space_available" csv:"percent_disk_space_available"`
 
 	HostIssues `json:"issues,omitempty" csv:"-"`
-
-	Modified bool `json:"-" csv:"-"`
 }
 
 type HostIssues struct {

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -64,11 +64,6 @@ type VulnerabilitiesSlice []SoftwareCVE
 type HostSoftware struct {
 	// Software is the software information.
 	Software []Software `json:"software,omitempty" csv:"-"`
-	// Modified is a boolean indicating whether this has been modified since
-	// loading. If Modified is true, datastore implementations should save the
-	// data. We track this here because saving the software set is likely to be
-	// an expensive operation.
-	Modified bool `json:"-" csv:"-"`
 }
 
 type SoftwareIterator interface {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -138,8 +138,6 @@ type AsyncBatchUpdateLabelTimestampFunc func(ctx context.Context, ids []uint, ts
 
 type NewHostFunc func(ctx context.Context, host *fleet.Host) (*fleet.Host, error)
 
-type SaveHostFunc func(ctx context.Context, host *fleet.Host) error
-
 type DeleteHostFunc func(ctx context.Context, hid uint) error
 
 type HostFunc func(ctx context.Context, id uint, skipLoadingExtras bool) (*fleet.Host, error)
@@ -587,9 +585,6 @@ type DataStore struct {
 
 	NewHostFunc        NewHostFunc
 	NewHostFuncInvoked bool
-
-	SaveHostFunc        SaveHostFunc
-	SaveHostFuncInvoked bool
 
 	DeleteHostFunc        DeleteHostFunc
 	DeleteHostFuncInvoked bool
@@ -1292,11 +1287,6 @@ func (s *DataStore) AsyncBatchUpdateLabelTimestamp(ctx context.Context, ids []ui
 func (s *DataStore) NewHost(ctx context.Context, host *fleet.Host) (*fleet.Host, error) {
 	s.NewHostFuncInvoked = true
 	return s.NewHostFunc(ctx, host)
-}
-
-func (s *DataStore) SaveHost(ctx context.Context, host *fleet.Host) error {
-	s.SaveHostFuncInvoked = true
-	return s.SaveHostFunc(ctx, host)
 }
 
 func (s *DataStore) DeleteHost(ctx context.Context, hid uint) error {

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -99,9 +99,6 @@ func TestHostAuth(t *testing.T) {
 	ds.AddHostsToTeamFunc = func(ctx context.Context, teamID *uint, hostIDs []uint) error {
 		return nil
 	}
-	ds.SaveHostFunc = func(ctx context.Context, host *fleet.Host) error {
-		return nil
-	}
 	ds.ListPoliciesForHostFunc = func(ctx context.Context, host *fleet.Host) ([]*fleet.HostPolicy, error) {
 		return nil, nil
 	}

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -1170,9 +1170,6 @@ func TestNewDistributedQueryCampaign(t *testing.T) {
 	ds.LabelQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
 		return map[string]string{}, nil
 	}
-	ds.SaveHostFunc = func(ctx context.Context, host *fleet.Host) error {
-		return nil
-	}
 	var gotQuery *fleet.Query
 	ds.NewQueryFunc = func(ctx context.Context, query *fleet.Query, opts ...fleet.OptionalArg) (*fleet.Query, error) {
 		gotQuery = query
@@ -1997,7 +1994,6 @@ func TestObserversCanOnlyRunDistributedCampaigns(t *testing.T) {
 	ds.LabelQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
 		return map[string]string{}, nil
 	}
-	ds.SaveHostFunc = func(ctx context.Context, host *fleet.Host) error { return nil }
 	ds.NewDistributedQueryCampaignFunc = func(ctx context.Context, camp *fleet.DistributedQueryCampaign) (*fleet.DistributedQueryCampaign, error) {
 		camp.ID = 21
 		return camp, nil

--- a/server/service/service_campaign_test.go
+++ b/server/service/service_campaign_test.go
@@ -38,9 +38,6 @@ func TestStreamCampaignResultsClosesReditOnWSClose(t *testing.T) {
 	ds.LabelQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
 		return map[string]string{}, nil
 	}
-	ds.SaveHostFunc = func(ctx context.Context, host *fleet.Host) error {
-		return nil
-	}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &fleet.AppConfig{}, nil
 	}


### PR DESCRIPTION
This PR removes the unused Datastore.SaveHost

~- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).~
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
- [X] Added/updated tests
- [x] Manual QA for all new/changed functionality
