### PR TITLE
Fix SSO paths to always use `/v1/` instead of `/latest/`

### DIFF
--- a/changes/issue-5244-revert-sso-paths-to-v1
+++ b/changes/issue-5244-revert-sso-paths-to-v1
@@ -1,0 +1,1 @@
+* Revert SSO-related URLs to use `/api/v1` instead of `/api/latest`.

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -313,7 +313,7 @@ Cypress.Commands.add("loginSSO", () => {
 
         // Load the callback URL with the response from the IdP
         cy.visit({
-          url: "/api/latest/fleet/sso/callback",
+          url: "/api/v1/fleet/sso/callback",
           method: "POST",
           body: {
             SAMLResponse: saml,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
     image: fleetdm/docker-idp:latest
     environment:
       SIMPLESAMLPHP_SP_ENTITY_ID: "https://localhost:8080"
-      SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE: "https://localhost:8080/api/latest/fleet/sso/callback"
+      SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE: "https://localhost:8080/api/v1/fleet/sso/callback"
     volumes:
       - ./tools/saml/users.php:/var/www/simplesamlphp/config/authsources.php
     ports:

--- a/frontend/fleet/endpoints.ts
+++ b/frontend/fleet/endpoints.ts
@@ -44,7 +44,7 @@ export default {
   },
   SETUP: `/v1/setup`, // not a typo - hasn't been updated yet
   SOFTWARE: `/${API_VERSION}/fleet/software`,
-  SSO: `/${API_VERSION}/fleet/sso`,
+  SSO: `/v1/fleet/sso`,
   STATUS_LABEL_COUNTS: `/${API_VERSION}/fleet/host_summary`,
   STATUS_LIVE_QUERY: `/${API_VERSION}/fleet/status/live_query`,
   STATUS_RESULT_STORE: `/${API_VERSION}/fleet/status/result_store`,

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -443,9 +443,9 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ne.GET("/api/_version_/fleet/invites/{token}", verifyInviteEndpoint, verifyInviteRequest{})
 	ne.POST("/api/_version_/fleet/reset_password", resetPasswordEndpoint, resetPasswordRequest{})
 	ne.POST("/api/_version_/fleet/logout", logoutEndpoint, nil)
-	ne.POST("/api/_version_/fleet/sso", initiateSSOEndpoint, initiateSSORequest{})
-	ne.POST("/api/_version_/fleet/sso/callback", makeCallbackSSOEndpoint(config.Server.URLPrefix), callbackSSORequest{})
-	ne.GET("/api/_version_/fleet/sso", settingsSSOEndpoint, nil)
+	ne.POST("/api/v1/fleet/sso", initiateSSOEndpoint, initiateSSORequest{})
+	ne.POST("/api/v1/fleet/sso/callback", makeCallbackSSOEndpoint(config.Server.URLPrefix), callbackSSORequest{})
+	ne.GET("/api/v1/fleet/sso", settingsSSOEndpoint, nil)
 
 	limiter := ratelimit.NewMiddleware(limitStore)
 	ne.

--- a/server/service/integration_sso_test.go
+++ b/server/service/integration_sso_test.go
@@ -61,12 +61,12 @@ func (s *integrationSSOTestSuite) TestGetSSOSettings() {
 
 	// double-check the settings
 	var resGet ssoSettingsResponse
-	s.DoJSON("GET", "/api/latest/fleet/sso", nil, http.StatusOK, &resGet)
+	s.DoJSON("GET", "/api/v1/fleet/sso", nil, http.StatusOK, &resGet)
 	require.True(t, resGet.Settings.SSOEnabled)
 
 	// initiate an SSO auth
 	var resIni initiateSSOResponse
-	s.DoJSON("POST", "/api/latest/fleet/sso", map[string]string{}, http.StatusOK, &resIni)
+	s.DoJSON("POST", "/api/v1/fleet/sso", map[string]string{}, http.StatusOK, &resIni)
 	require.NotEmpty(t, resIni.URL)
 
 	parsed, err := url.Parse(resIni.URL)

--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -286,7 +286,7 @@ func (svc *Service) InitiateSSO(ctx context.Context, redirectURL string) (string
 	settings := sso.Settings{
 		Metadata: metadata,
 		// Construct call back url to send to idp
-		AssertionConsumerServiceURL: serverURL + svc.config.Server.URLPrefix + "/api/latest/fleet/sso/callback",
+		AssertionConsumerServiceURL: serverURL + svc.config.Server.URLPrefix + "/api/v1/fleet/sso/callback",
 		SessionStore:                svc.ssoSessionStore,
 		OriginalURL:                 redirectURL,
 	}
@@ -425,7 +425,7 @@ func (svc *Service) CallbackSSO(ctx context.Context, auth fleet.Auth) (*fleet.SS
 	validator, err := sso.NewValidator(*metadata, sso.WithExpectedAudience(
 		appConfig.SSOSettings.EntityID,
 		appConfig.ServerSettings.ServerURL,
-		appConfig.ServerSettings.ServerURL+svc.config.Server.URLPrefix+"/api/latest/fleet/sso/callback", // ACS
+		appConfig.ServerSettings.ServerURL+svc.config.Server.URLPrefix+"/api/v1/fleet/sso/callback", // ACS
 	))
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "create validator from metadata")

--- a/server/service/transport.go
+++ b/server/service/transport.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
-	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/gorilla/mux"
@@ -24,11 +23,6 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response interfa
 	// The has to happen first, if an error happens we'll redirect to an error
 	// page and the error will be logged
 	if page, ok := response.(htmlPage); ok {
-		// if the response is also an errorer and has an error, log it
-		if e, ok := response.(errorer); ok && e.error() != nil {
-			logging.WithErr(ctx, e.error())
-		}
-
 		w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 		_, err := io.WriteString(w, page.html())
 		return err

--- a/server/service/transport.go
+++ b/server/service/transport.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/gorilla/mux"
@@ -23,6 +24,11 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response interfa
 	// The has to happen first, if an error happens we'll redirect to an error
 	// page and the error will be logged
 	if page, ok := response.(htmlPage); ok {
+		// if the response is also an errorer and has an error, log it
+		if e, ok := response.(errorer); ok && e.error() != nil {
+			logging.WithErr(ctx, e.error())
+		}
+
 		w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 		_, err := io.WriteString(w, page.html())
 		return err

--- a/server/sso/authorization_request_test.go
+++ b/server/sso/authorization_request_test.go
@@ -34,7 +34,7 @@ func TestCreateAuthorizationRequest(t *testing.T) {
 			},
 		},
 		// Construct call back url to send to idp
-		AssertionConsumerServiceURL: "http://localhost:8001/api/latest/fleet/sso/callback",
+		AssertionConsumerServiceURL: "http://localhost:8001/api/v1/fleet/sso/callback",
 		SessionStore:                store,
 		OriginalURL:                 "/redir",
 	}

--- a/tools/app/authtest.html
+++ b/tools/app/authtest.html
@@ -81,7 +81,7 @@
 
         $.ajax({
           type: "POST",
-          url: "https://localhost:8080/api/latest/fleet/sso",
+          url: "https://localhost:8080/api/v1/fleet/sso",
           data: JSON.stringify({
             // supply the url of the resource user was trying to access when
             // prompted for login


### PR DESCRIPTION
#5244 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] ~~Documented any API changes (docs/Using-Fleet/REST-API.md)~~
- [ ] ~~Documented any permissions changes~~
- [ ] ~~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~~
- [x] Added/updated tests
- [ ] ~~Manual QA for all new/changed functionality~~ (will be tested in dogfood)
