### PR TITLE
Fixed error handling for invalid auth token

### DIFF
--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -10,7 +10,7 @@ import QueryProvider from "context/query";
 import PolicyProvider from "context/policy";
 import NotificationProvider from "context/notification";
 import { AppContext } from "context/app";
-import { authToken } from "utilities/local"; // @ts-ignore
+import local, { authToken } from "utilities/local";
 import { useDeepEffect } from "utilities/hooks";
 
 import usersAPI from "services/entities/users";
@@ -53,11 +53,9 @@ const App = ({ children, location, router }: IAppProps): JSX.Element => {
         setAvailableTeams(available_teams);
       } catch (error) {
         console.error(error);
-        if (!location || location?.pathname === "/setup") {
-          localStorage.removeItem("auth_token");
-          return;
-        }
-        router.push(PATHS.LOGIN);
+        
+        local.removeItem("auth_token");
+        return router.push(PATHS.LOGIN);
       }
     };
 

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -53,7 +53,7 @@ const App = ({ children, location, router }: IAppProps): JSX.Element => {
         setAvailableTeams(available_teams);
       } catch (error) {
         console.error(error);
-        
+
         local.removeItem("auth_token");
         return router.push(PATHS.LOGIN);
       }


### PR DESCRIPTION
Relates to #5236.

# Checklist for submitter

- [x] Manual QA for all new/changed functionality


Reproducible steps:
- Open the app
- Open dev tools
- Visit the Application (or Storage) tab and open the local storage menu
- Add `FLEET::auth_token` with a random value
- Try visiting a url in the app