### PR TITLE
Migrate client setup api call used by fleetctl to use versionless path

### DIFF
--- a/server/service/client_setup.go
+++ b/server/service/client_setup.go
@@ -23,9 +23,9 @@ func (c *Client) Setup(email, name, password, org string) (string, error) {
 		ServerURL: &c.addr,
 	}
 
-	response, err := c.Do("POST", "/api/v1/setup", "", params)
+	response, err := c.Do("POST", "/api/setup", "", params)
 	if err != nil {
-		return "", fmt.Errorf("POST /api/v1/setup: %w", err)
+		return "", fmt.Errorf("POST /api/setup: %w", err)
 	}
 	defer response.Body.Close()
 


### PR DESCRIPTION
#4514 (follow up to #5104, see comment https://github.com/fleetdm/fleet/pull/5104#issuecomment-1104234939)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] ~~Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).~~
- [ ] ~~Documented any API changes (docs/Using-Fleet/REST-API.md)~~
- [ ] ~~Documented any permissions changes~~
- [ ] ~~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~~
- [ ] ~~Added/updated tests~~
- [ ] ~~Manual QA for all new/changed functionality~~
