### PR TITLE
Added Linkedin Insights tag

### DIFF
--- a/website/views/layouts/layout-customer.ejs
+++ b/website/views/layouts/layout-customer.ejs
@@ -124,6 +124,25 @@
 
     <%/* Stripe.js */%>
     <script src="https://js.stripe.com/v3/"></script>
+    
+    <%/* Linkedin Ads Insight tag */%>
+    <script type="text/javascript">
+    _linkedin_partner_id = "4365817";
+    window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
+    window._linkedin_data_partner_ids.push(_linkedin_partner_id);
+    </script><script type="text/javascript">
+    (function(l) {
+    if (!l){window.lintrk = function(a,b){window.lintrk.q.push([a,b])};
+    window.lintrk.q=[]}
+    var s = document.getElementsByTagName("script")[0];
+    var b = document.createElement("script");
+    b.type = "text/javascript";b.async = true;
+    b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+    s.parentNode.insertBefore(b, s);})(window.lintrk);
+    </script>
+    <noscript>
+    <img height="1" width="1" style="display:none;" alt="" src="https://px.ads.linkedin.com/collect/?pid=4365817&fmt=gif" />
+    </noscript>
 
     <% /* Delete the global `self` to help avoid client-side bugs.
     (see https://developer.mozilla.org/en-US/docs/Web/API/Window/self) */ %>


### PR DESCRIPTION
Added Linkedin Insights tag to track self service signups as conversions

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [ ] Documented any permissions changes
- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
