### PR TITLE
Handbook: Update product rituals

### DIFF
--- a/handbook/product.md
+++ b/handbook/product.md
@@ -394,11 +394,11 @@ The following rituals are engaged in by the  directly responsible individual (DR
 
 | Ritual                       | Frequency                | Description                                         | DRI               |
 |:-----------------------------|:-----------------------------|:----------------------------------------------------|-------------------|
-| Product huddle | Daily | "In progress" issues are discussed and any issues "ready for review" are placed on the list for the product design review call. On Mondays, issues are broken down into a week's work and added into "ready." Issues are moved out of "delivered" every Friday. | Noah Talerman |
+| 🎙 Product huddle | Daily | "In progress" issues are discussed and any issues "ready for review" are placed on the list for the product design review call. On Mondays, issues are broken down into a week's work and added into "ready." Issues are moved out of "delivered" every Friday. | Noah Talerman |
 | 🗣 Product office hours  | Weekly (Tuesdays) | Decision is made regarding which customer and community feature requests can be committed to in the next six weeks. Issues are created for any requests that don't already have one. | Noah Talerman |
-| 🎨UI/UX office hours      | Weekly (Wednesdays) | Decision is made regarding which community UX requests can be committed to in the next six weeks. Community UX questions are discussed, as are questions from the Slack community and internal Fleet team with the intention of providing answers to the question's originator.    | Noah Talerman |
-| ✨Product design review  | Weekly (Thursdays) | Product team discusses "ready for review" items and the decision is made on whether the UI changes are ready for engineering specification, and later, implementation. | Noah Talerman |
-| 👀Product review      | Every three weeks | Features and improvements in the upcoming release are presented. Bugs, fixes and changes that should be made prior to release are discussed.  | Noah Talerman |
+| 🎨 UI/UX huddle      | Weekly (Wednesdays) | "In progress" issues are discussed and any issues "ready for review" are placed on the list for the product design review call. Separate time from 🎙 Product huddle so Mike Thomas can make it.    | Noah Talerman |
+| ✨ Product design review  | Weekly (Thursdays) | Product team discusses "ready for review" items and the decision is made on whether the UI changes are ready for engineering specification, and later, implementation. | Noah Talerman |
+| 👀 Product review      | Every three weeks | Features and improvements in the upcoming release are presented. Bugs, fixes and changes that should be made prior to release are discussed.  | Noah Talerman |
 
 
 ## Slack channels


### PR DESCRIPTION
-  Updated the “:art:UI/UX office hours” meet’s name to “:art:UI/UX huddle.”
  - The agenda for this weekly call is now…
    - Review wireframes (UI changes) that are “Ready for review”
    - Discuss drafts and research that are “In progress”
- Separate time from 🎙 Product huddle so Mike Thomas can make it.