### PR TITLE
Handbook: Add intake process to product section

### DIFF
--- a/handbook/product.md
+++ b/handbook/product.md
@@ -402,16 +402,16 @@ The following rituals are engaged in by the  directly responsible individual (DR
 
 ### Intake process
 
-Intake for new product ideas (feature requests) happens at the "Product office hours" meeting.
+Intake for new product ideas (requests) happens at the "Product office hours" meeting.
 
-At the "Product office hours" meeting, all feature requests are weighed. When a feature request is
+At the "Product office hours" meeting, all requests are weighed. When a request is
 weighed, it is prioritized or ejected.
 
-A feature request is prioritized when perceived as an important near-term priority by the business.
-When this happens, the feature request is set to be released into the hands of the Fleet community
+A request is prioritized when perceived as an important near-term priority by the business.
+When this happens, the request is set to be released into the hands of the Fleet community
 within 6 weeks.
 
-A feature request is ejected when competing priorities are perceived as a more important near-term priority by the business.
+A request is ejected when competing priorities are perceived as a more important near-term priority by the business.
 
 #### Why this way?
 
@@ -419,30 +419,26 @@ At Fleet, we use objectives and key results (OKRs) to align the organization wit
 These OKRs fill up a large portion, but not all, of planning (drafting, wireframing, spec'ing, etc.) and
 engineering capacity. 
 
-This means that there is always some capacity to prioritize feature requests advocated for by customers, Fleet team members, and members of the
+This means that there is always some capacity to prioritize requests advocated for by customers, Fleet team members, and members of the
 greater Fleet community.
 
 > Note that bugs are always prioritized.
 
-At Fleet, the requestor is told whether their feature
+At Fleet, the requestor is told whether their
 request is prioritized or ejected within 1 business day from when the request is weighed.
 
-The "Product office hours" meeting is a recurring ritual to make sure that everyone receives a
-response within this timeframe.
+The "Product office hours" meeting is a recurring ritual to make sure that all requests are weighed.
 
-#### Making a feature request
+#### Making a request
 
-To make a feature request, or advocate for a feature request from a customer or community member, all members of the Fleet organization are asked to add their name and a description of the
-feature request to the list in the ["Product office hours" Google
+To make a request, or advocate for a request from a customer or community member, all members of the Fleet organization are asked to add their name and a description of the request to the list in the ["Product office hours" Google
 doc](https://docs.google.com/document/d/10B4eDXHjM9lFob6VcBDFEzYR424QRH3EuTpRLbhWyzM/edit#heading=h.w2b5x42h9sgy),
 then attend the next scheduled "Product office hours" meeting.
 
-All members of the Fleet organization are welcome to attend the "Product office hours meeting." Feature requests will be
-discussed from top to bottom while prioritizing attendee feature requests. 
+All members of the Fleet organization are welcome to attend the "Product office hours meeting." Requests will be
+discussed from top to bottom while prioritizing attendee requests. 
 
-This
-means that, if the individual that added a feature request is
-not in attendance, the feature request will discussed towards the end of the call if there's time.
+This means that, if the individual that added a feature request is not in attendance, the feature request will discussed towards the end of the call if there's time.
 
 All "Product office hours" meetings are recorded and uploaded to the shared Google drive.
 

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -404,10 +404,12 @@ The following rituals are engaged in by the  directly responsible individual (DR
 
 Intake for new product ideas (feature requests) happens at the "Product office hours" meeting.
 
-At the "Product office hours" meeting, all feature requests are discussed and either prioritized or ejected.
+At the "Product office hours" meeting, all feature requests are weighed. When a feature request is
+weighed, it is prioritized or ejected.
 
 A feature request is prioritized when perceived as an important near-term priority by the business.
-When this happens, a release date is tentatively set (within 6 weeks).
+When this happens, the feature request is set to be released into the hands of the Fleet community
+within 6 weeks.
 
 A feature request is ejected when competing priorities are perceived as a more important near-term priority by the business.
 
@@ -422,8 +424,8 @@ greater Fleet community.
 
 > Note that bugs are always prioritized.
 
-At Fleet, we'd like to be able to tell everyone if their feature
-request is prioritized or ejected within 1 week of the request.
+At Fleet, the requestor is told whether their feature
+request is prioritized or ejected within 1 business day from when the request is weighed.
 
 The "Product office hours" meeting is a recurring ritual to make sure that everyone receives a
 response within this timeframe.

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -402,22 +402,19 @@ The following rituals are engaged in by the  directly responsible individual (DR
 
 ### Intake process
 
-Intake for new product ideas (requests) happens at the "Product office hours" meeting.
+Intake for new product ideas (requests) happens at the 🗣 Product office hours meeting.
 
-At the "Product office hours" meeting, all requests are weighed. When a request is
-weighed, it is prioritized or ejected.
+At the 🗣 Product office hours meeting, all requests are weighed. When a request is weighed, it is prioritized or ejected.
 
-A request is prioritized when perceived as an important near-term priority by the business.
-When this happens, the request is set to be released into the hands of the Fleet community
-within 6 weeks.
+A request is prioritized when perceived as an important near-term priority by the business. When this happens, the request is set to be estimated or deferred within the next 5 business days.
 
 A request is ejected when competing priorities are perceived as a more important near-term priority by the business.
 
 #### Why this way?
 
 At Fleet, we use objectives and key results (OKRs) to align the organization with measurable goals.
-These OKRs fill up a large portion, but not all, of planning (drafting, wireframing, spec'ing, etc.) and
-engineering capacity. 
+These OKRs fill up a large portion, but not all, of planning (drafting, wireframing, spec'ing, etc.)
+and engineering capacity. 
 
 This means that there is always some capacity to prioritize requests advocated for by customers, Fleet team members, and members of the
 greater Fleet community.
@@ -427,20 +424,22 @@ greater Fleet community.
 At Fleet, the requestor is told whether their
 request is prioritized or ejected within 1 business day from when the request is weighed.
 
-The "Product office hours" meeting is a recurring ritual to make sure that all requests are weighed.
+The 🗣 Product office hours meeting is a recurring ritual to make sure that all requests are weighed.
 
 #### Making a request
 
-To make a request, or advocate for a request from a customer or community member, all members of the Fleet organization are asked to add their name and a description of the request to the list in the ["Product office hours" Google
-doc](https://docs.google.com/document/d/10B4eDXHjM9lFob6VcBDFEzYR424QRH3EuTpRLbhWyzM/edit#heading=h.w2b5x42h9sgy),
-then attend the next scheduled "Product office hours" meeting.
+To make a request, or advocate for a request from a customer or community member, all members of the Fleet organization are asked to add their name and a description of the request to the list in the [🗣 Product office hours Google
+doc](https://docs.google.com/document/d/1mwu5WfdWBWwJ2C3zFDOMSUC9QCyYuKP4LssO_sIHDd0/edit#heading=h.zahrflvvks7q),
+then attend the next scheduled 🗣 Product office hours meeting.
 
-All members of the Fleet organization are welcome to attend the "Product office hours meeting." Requests will be
-discussed from top to bottom while prioritizing attendee requests. 
+All members of the Fleet organization are welcome to attend the 🗣 Product office hours meeting. Requests will be
+weighed from top to bottom while prioritizing attendee requests. 
 
 This means that, if the individual that added a feature request is not in attendance, the feature request will discussed towards the end of the call if there's time.
 
-All "Product office hours" meetings are recorded and uploaded to the shared Google drive.
+All 🗣 Product office hours meetings are recorded and uploaded to the [🗣 Product office hours
+folder](https://drive.google.com/drive/folders/1nsjqDyX5WDQ0HJhg_2yOaqBu4J-hqRIW) in the shared
+Google drive.
 
 
 ## Slack channels

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -402,9 +402,9 @@ The following rituals are engaged in by the  directly responsible individual (DR
 
 ### Intake process
 
-Intake for new product ideas (feature requests) happens at the 🗣 Product office hours ritual.
+Intake for new product ideas (feature requests) happens at the "Product office hours" meeting.
 
-At 🗣 Product office hours, all feature requests are discussed and either prioritized or ejected.
+At the "Product office hours" meeting, all feature requests are discussed and either prioritized or ejected.
 
 A feature request is prioritized when perceived as an important near-term priority by the business.
 When this happens, a release date is tentatively set (within 6 weeks).
@@ -425,23 +425,24 @@ greater Fleet community.
 At Fleet, we'd like to be able to tell everyone if their feature
 request is prioritized or ejected within 1 week of the request.
 
-The 🗣 Product office hours acts as a recurring ritual to make sure that everyone receives a
+The "Product office hours" meeting is a recurring ritual to make sure that everyone receives a
 response within this timeframe.
 
 #### Making a feature request
 
 To make a feature request, or advocate for a feature request from a customer or community member, all members of the Fleet organization are asked to add their name and a description of the
-feature request to the list in the 🗣 Product office hours section of the following Google doc:
-https://docs.google.com/document/d/10B4eDXHjM9lFob6VcBDFEzYR424QRH3EuTpRLbhWyzM/edit#heading=h.w2b5x42h9sgy
+feature request to the list in the ["Product office hours" Google
+doc](https://docs.google.com/document/d/10B4eDXHjM9lFob6VcBDFEzYR424QRH3EuTpRLbhWyzM/edit#heading=h.w2b5x42h9sgy),
+then attend the next scheduled "Product office hours" meeting.
 
-Everyone is encouraged to attend the 🗣 Product office hours call. Feature requests will be
+All members of the Fleet organization are welcome to attend the "Product office hours meeting." Feature requests will be
 discussed from top to bottom while prioritizing attendee feature requests. 
 
 This
 means that, if the individual that added a feature request is
-not in attendance, the feature request will discussed towards the end of the call if there's time..
+not in attendance, the feature request will discussed towards the end of the call if there's time.
 
-All 🗣 Product office hours are recorded and uploaded to the shared Google drive.
+All "Product office hours" meetings are recorded and uploaded to the shared Google drive.
 
 
 ## Slack channels

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -400,6 +400,49 @@ The following rituals are engaged in by the  directly responsible individual (DR
 | ✨ Product design review  | Weekly (Thursdays) | Product team discusses "ready for review" items and the decision is made on whether the UI changes are ready for engineering specification, and later, implementation. | Noah Talerman |
 | 👀 Product review      | Every three weeks | Features and improvements in the upcoming release are presented. Bugs, fixes and changes that should be made prior to release are discussed.  | Noah Talerman |
 
+### Intake process
+
+Intake for new product ideas (feature requests) happens at the 🗣 Product office hours ritual.
+
+At 🗣 Product office hours, all feature requests are discussed and either prioritized or ejected.
+
+A feature request is prioritized when perceived as an important near-term priority by the business.
+When this happens, a release date is tentatively set (within 6 weeks).
+
+A feature request is ejected when competing priorities are perceived as a more important near-term priority by the business.
+
+#### Why this way?
+
+At Fleet, we use objectives and key results (OKRs) to align the organization with measurable goals.
+These OKRs fill up a large portion, but not all, of planning (drafting, wireframing, spec'ing, etc.) and
+engineering capacity. 
+
+This means that there is always some capacity to prioritize feature requests advocated for by customers, Fleet team members, and members of the
+greater Fleet community.
+
+> Note that bugs are always prioritized.
+
+At Fleet, we'd like to be able to tell everyone if their feature
+request is prioritized or ejected within 1 week of the request.
+
+The 🗣 Product office hours acts as a recurring ritual to make sure that everyone receives a
+response within this timeframe.
+
+#### Making a feature request
+
+To make a feature request, or advocate for a feature request from a customer or community member, all members of the Fleet organization are asked to add their name and a description of the
+feature request to the list in the 🗣 Product office hours section of the following Google doc:
+https://docs.google.com/document/d/10B4eDXHjM9lFob6VcBDFEzYR424QRH3EuTpRLbhWyzM/edit#heading=h.w2b5x42h9sgy
+
+Everyone is encouraged to attend the 🗣 Product office hours call. Feature requests will be
+discussed from top to bottom while prioritizing attendee feature requests. 
+
+This
+means that, if the individual that added a feature request is
+not in attendance, the feature request will discussed towards the end of the call if there's time..
+
+All 🗣 Product office hours are recorded and uploaded to the shared Google drive.
+
 
 ## Slack channels
 


### PR DESCRIPTION
- Document the proposed intake process for new product ideas (feature requests)
  - This process would replace the current process of combing through "idea" issues to fulfill the promise of a 2 week response

Why the new process?
  - Problem: There are currently too many good ideas to keep up with and fulfill the 2 week response.
    - A good response includes both a "yes/no" to prioritization and, in the case of "no," an adequate explanation on what we're prioritizing instead.
  - Solution: The proposed process encourages the most incentivized to bring the highest value feature requests.
    - This may be a member of the customer engineering team who is incentivized to provide a great customer experience for the business.
    - This may be a member of the devrel team who is incentivized to provide a great brand experience to the greater community.
    - This may be a member of the Fleet team who is incentivized to advocate for their great idea.
