### PR TITLE
`fleetctl preview` to use `api/v1/setup` path, to support prev versions of Fleet

### DIFF
--- a/server/service/client_setup.go
+++ b/server/service/client_setup.go
@@ -23,9 +23,9 @@ func (c *Client) Setup(email, name, password, org string) (string, error) {
 		ServerURL: &c.addr,
 	}
 
-	response, err := c.Do("POST", "/api/setup", "", params)
+	response, err := c.Do("POST", "/api/v1/setup", "", params)
 	if err != nil {
-		return "", fmt.Errorf("POST /api/setup: %w", err)
+		return "", fmt.Errorf("POST /api/v1/setup: %w", err)
 	}
 	defer response.Body.Close()
 


### PR DESCRIPTION
[Integration tests](https://github.com/fleetdm/fleet/runs/6122419627?check_suite_focus=true) were failing consistently with:
```
Downloading dependencies from production into /home/runner/.fleet/preview...
Pulling Docker dependencies...
Starting Docker containers...
Waiting for server to start up...
Initializing server...
Error: fleetctl login failed: The Fleet instance is not set up yet
Error: Process completed with exit code 1.
```

fleetctl fetches a fleet version (4.13.X) that does not handle `/api/setup` (it handles `/api/v1/setup`).

~- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).~
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality
