### PR TITLE
Editing security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-Please report any vulnerabilities discovered in Fleet products to [fleetdm.com/company/contact](https://fleetdm.com/company/contact).
+Please report any vulnerabilities discovered in Fleet products to security **at** fleetdm.com.
 
 Fleet endeavors to acknowledge and fix any reported vulnerabilities ASAP. Acknowledgement is typically within 1 business day, and patches usually go out within 5 business days (depending on severity and timing).
 

--- a/handbook/people.md
+++ b/handbook/people.md
@@ -33,6 +33,7 @@ DRIs help us collaborate efficiently by knowing exactly who is responsible and c
 | Publishing release blog post, and promoting releases | Mike Thomas |
 | fleetdm.com | Mike Thomas |
 | Self-service Fleet Premium license dispenser | Mike Thomas |
+| Security disclosure and policy | Guillaume Ross | 
 
 *Luke Heath is backup 
 


### PR DESCRIPTION
Security disclosure should not go to the main contact form.