### PR TITLE
Website: sticky "On this page" navigation

### DIFF
--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -543,7 +543,7 @@
         min-width: 190px;
         max-width: 210px;
         position: sticky;
-        top: 90px;
+        top: 94px;
         height: fit-content;
         [purpose='subtopics'] {
           max-height: calc(~'80vh - 90px'); //To prevent the sidenav being anchored to the bottom of the page if it has overflow.

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -542,8 +542,13 @@
       [purpose='right-sidebar'] {
         min-width: 190px;
         max-width: 210px;
-
+        position: sticky;
+        top: 40px;
+        height: fit-content;
         [purpose='subtopics'] {
+          max-height: 80vh;
+          // height: auto;
+          overflow-y: scroll;
           color: @core-fleet-black;
           padding-top: 4px;
           padding-bottom: 4px;

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -543,11 +543,10 @@
         min-width: 190px;
         max-width: 210px;
         position: sticky;
-        top: 40px;
+        top: 90px;
         height: fit-content;
         [purpose='subtopics'] {
-          max-height: 80vh;
-          // height: auto;
+          max-height: calc(~'80vh - 90px'); //To prevent the sidenav being anchored to the bottom of the page if it has overflow.
           overflow-y: scroll;
           color: @core-fleet-black;
           padding-top: 4px;


### PR DESCRIPTION
Closes #4398 
Changes:
- Updated the "On this page" navigation on documentation pages with `position: sticky`

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
