### PR TITLE
Revert orbit's remote osquery paths to use legacy `v1`

### DIFF
--- a/orbit/changes/fix-orbit-fleet-path-breaking-change
+++ b/orbit/changes/fix-orbit-fleet-path-breaking-change
@@ -1,0 +1,1 @@
+* Revert Orbit osquery remote paths to use `v1`.

--- a/orbit/pkg/osquery/flags.go
+++ b/orbit/pkg/osquery/flags.go
@@ -12,9 +12,9 @@ func FleetFlags(fleetURL *url.URL) []string {
 		// Use uuid as the default identifier -- users can override this in their flagfile
 		"--host_identifier=uuid",
 		"--tls_hostname=" + hostname,
-		"--enroll_tls_endpoint=" + path.Join(prefix, "/api/osquery/enroll"),
+		"--enroll_tls_endpoint=" + path.Join(prefix, "/api/v1/osquery/enroll"),
 		"--config_plugin=tls",
-		"--config_tls_endpoint=" + path.Join(prefix, "/api/osquery/config"),
+		"--config_tls_endpoint=" + path.Join(prefix, "/api/v1/osquery/config"),
 		// Osquery defaults config_refresh to 0 which is probably not ideal for
 		// a client connected to Fleet. Users can always override this in the
 		// config they serve via Fleet.
@@ -22,16 +22,16 @@ func FleetFlags(fleetURL *url.URL) []string {
 		"--disable_distributed=false",
 		"--distributed_plugin=tls",
 		"--distributed_tls_max_attempts=10",
-		"--distributed_tls_read_endpoint=" + path.Join(prefix, "/api/osquery/distributed/read"),
-		"--distributed_tls_write_endpoint=" + path.Join(prefix, "/api/osquery/distributed/write"),
+		"--distributed_tls_read_endpoint=" + path.Join(prefix, "/api/v1/osquery/distributed/read"),
+		"--distributed_tls_write_endpoint=" + path.Join(prefix, "/api/v1/osquery/distributed/write"),
 		"--logger_plugin=tls,filesystem",
-		"--logger_tls_endpoint=" + path.Join(prefix, "/api/osquery/log"),
+		"--logger_tls_endpoint=" + path.Join(prefix, "/api/v1/osquery/log"),
 		"--disable_carver=false",
 		// carver_disable_function is separate from disable_carver as it controls the use of file
 		// carving as a SQL function (eg. `SELECT carve(path) FROM processes`).
 		"--carver_disable_function=false",
-		"--carver_start_endpoint=" + path.Join(prefix, "/api/osquery/carve/begin"),
-		"--carver_continue_endpoint=" + path.Join(prefix, "/api/osquery/carve/block"),
+		"--carver_start_endpoint=" + path.Join(prefix, "/api/v1/osquery/carve/begin"),
+		"--carver_continue_endpoint=" + path.Join(prefix, "/api/v1/osquery/carve/block"),
 		"--carver_block_size=2000000",
 	}
 }


### PR DESCRIPTION
#5367

- [X] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).

~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added/updated tests~

Automation will be added in #5370.

- [X] Manual QA for all new/changed functionality

Verified the fix the following way:
1. Run Fleet server version `fleet-v4.12.1`.
2. On `main` run:
```sh
GENERATE_PKGS=1 ENROLL_SECRET=<...> ./tools/tuf/init_tuf.sh
```
3. Install generated packages (all targets with version `42.0.0`). The hosts won't enroll due to the issue (you can see the `Cannot parse JSON` errors in the logs).
4. Checkout this branch and run (to auto-update Orbit with the fix):
```sh
GOOS=darwin go build -o orbit-darwin ./orbit/cmd/orbit
./tools/tuf/push_target.sh macos orbit orbit-darwin 43

GOOS=windows go build -o orbit.exe ./orbit/cmd/orbit
./tools/tuf/push_target.sh windows orbit orbit.exe 43

GOOS=linux go build -o orbit-linux ./orbit/cmd/orbit
./tools/tuf/push_target.sh linux orbit orbit-linux 43
```
5. Hosts successfully enroll after auto-updating.