### PR TITLE
Bug fix: Display query name when editing a schedule

### DIFF
--- a/changes/issue-5005-bug-fix-query-name-for-schedule
+++ b/changes/issue-5005-bug-fix-query-name-for-schedule
@@ -1,0 +1,1 @@
+* Bug fix: Display query name for editing a schedule

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
@@ -239,7 +239,7 @@ const ScheduleEditorModal = ({
 
   return (
     <Modal
-      title={editQuery?.name || "Schedule editor"}
+      title={editQuery?.query_name || "Schedule editor"}
       onExit={onCancel}
       className={baseClass}
     >


### PR DESCRIPTION
Cerra #5005 
 After changing a query's name, a scheduled query name changes. However, the edit schedule is the original name

- Fix shows the new name of the query instead of the original name

Example screenshot of fix (e.g. added !! to the query name, now shows up on schedule editor as well):
<img width="1352" alt="Screen Shot 2022-04-26 at 2 11 07 PM" src="https://user-images.githubusercontent.com/71795832/165365059-713de5ab-d7d4-4b2a-8356-e72b614abeaf.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
