### PR TITLE
Add osquery.min_software_last_opened_at_diff configuration option

### DIFF
--- a/changes/issue-2316-add-osquery-min-last-opened-at-config
+++ b/changes/issue-2316-add-osquery-min-last-opened-at-config
@@ -1,0 +1,1 @@
+* Add the `osquery.min_software_last_opened_at_diff` configuration option.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -178,7 +178,7 @@ the way that the Fleet server works.
 			var carveStore fleet.CarveStore
 			mailService := mail.NewService()
 
-			opts := []mysql.DBOption{mysql.Logger(logger)}
+			opts := []mysql.DBOption{mysql.Logger(logger), mysql.WithFleetConfig(&config)}
 			if config.MysqlReadReplica.Address != "" {
 				opts = append(opts, mysql.Replica(&config.MysqlReadReplica))
 			}

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -1197,6 +1197,19 @@ Applies only when `osquery_enable_async_host_processing` is enabled. Order of ma
   	async_host_redis_scan_keys_count: 100
   ```
 
+##### osquery_min_software_last_opened_at_diff
+
+Minimum time difference between the software's "last opened at" timestamp reported by osquery and the last timestamp saved for that software on that host. This helps minimize the number of updates required when a host reports its installed software information, resulting in less load on the database. If there is no existing timestamp for the software on that host (or if the software was not installed on that host previously), the new timestamp is automatically saved.
+
+- Default value: 1h
+- Environment variable: `FLEET_OSQUERY_MIN_SOFTWARE_LAST_OPENED_AT_DIFF`
+- Config file format:
+
+  ```
+  osquery:
+  	min_software_last_opened_at_diff: 4h
+  ```
+
 ##### Example YAML
 
 ```yaml

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -126,6 +126,7 @@ type OsqueryConfig struct {
 	AsyncHostUpdateBatch             int           `yaml:"async_host_update_batch"`
 	AsyncHostRedisPopCount           int           `yaml:"async_host_redis_pop_count"`
 	AsyncHostRedisScanKeysCount      int           `yaml:"async_host_redis_scan_keys_count"`
+	MinSoftwareLastOpenedAtDiff      time.Duration `yaml:"min_software_last_opened_at_diff"`
 }
 
 // LoggingConfig defines configs related to logging
@@ -465,6 +466,8 @@ func (man Manager) addConfigs() {
 		"Batch size to pop items from redis in async collection")
 	man.addConfigInt("osquery.async_host_redis_scan_keys_count", 1000,
 		"Batch size to scan redis keys in async collection")
+	man.addConfigDuration("osquery.min_software_last_opened_at_diff", 1*time.Hour,
+		"Minimum time difference of the software's last opened timestamp (compared to the last one saved) to trigger an update to the database")
 
 	// Logging
 	man.addConfigBool("logging.debug", false,
@@ -682,6 +685,7 @@ func (man Manager) LoadConfig() FleetConfig {
 			AsyncHostUpdateBatch:             man.getConfigInt("osquery.async_host_update_batch"),
 			AsyncHostRedisPopCount:           man.getConfigInt("osquery.async_host_redis_pop_count"),
 			AsyncHostRedisScanKeysCount:      man.getConfigInt("osquery.async_host_redis_scan_keys_count"),
+			MinSoftwareLastOpenedAtDiff:      man.getConfigDuration("osquery.min_software_last_opened_at_diff"),
 		},
 		Logging: LoggingConfig{
 			Debug:                man.getConfigBool("logging.debug"),

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -115,7 +115,7 @@ func (ds *Datastore) SaveHost(ctx context.Context, host *fleet.Host) error {
 	}
 
 	if host.HostSoftware.Modified && ac.HostSettings.EnableSoftwareInventory && len(host.HostSoftware.Software) > 0 {
-		if err := saveHostSoftwareDB(ctx, ds.writer, host); err != nil {
+		if err := saveHostSoftwareDB(ctx, ds.writer, host, ds.minLastOpenedAtDiff); err != nil {
 			return ctxerr.Wrap(ctx, err, "failed to save host software")
 		}
 	}

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -81,12 +81,12 @@ func softwareSliceToMap(softwares []fleet.Software) map[string]fleet.Software {
 // slice, updating existing entries and inserting new entries.
 func (ds *Datastore) UpdateHostSoftware(ctx context.Context, hostID uint, software []fleet.Software) error {
 	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		return applyChangesForNewSoftwareDB(ctx, tx, hostID, software)
+		return applyChangesForNewSoftwareDB(ctx, tx, hostID, software, ds.minLastOpenedAtDiff)
 	})
 }
 
-func saveHostSoftwareDB(ctx context.Context, tx sqlx.ExtContext, host *fleet.Host) error {
-	if err := applyChangesForNewSoftwareDB(ctx, tx, host.ID, host.Software); err != nil {
+func saveHostSoftwareDB(ctx context.Context, tx sqlx.ExtContext, host *fleet.Host, minLastOpenedAtDiff time.Duration) error {
+	if err := applyChangesForNewSoftwareDB(ctx, tx, host.ID, host.Software, minLastOpenedAtDiff); err != nil {
 		return err
 	}
 
@@ -94,7 +94,7 @@ func saveHostSoftwareDB(ctx context.Context, tx sqlx.ExtContext, host *fleet.Hos
 	return nil
 }
 
-func nothingChanged(current []fleet.Software, incoming []fleet.Software) bool {
+func nothingChanged(current, incoming []fleet.Software, minLastOpenedAtDiff time.Duration) bool {
 	if len(current) != len(incoming) {
 		return false
 	}
@@ -128,15 +128,19 @@ func nothingChanged(current []fleet.Software, incoming []fleet.Software) bool {
 	return true
 }
 
-const minLastOpenedAtDiff = time.Hour
-
-func applyChangesForNewSoftwareDB(ctx context.Context, tx sqlx.ExtContext, hostID uint, software []fleet.Software) error {
+func applyChangesForNewSoftwareDB(
+	ctx context.Context,
+	tx sqlx.ExtContext,
+	hostID uint,
+	software []fleet.Software,
+	minLastOpenedAtDiff time.Duration,
+) error {
 	storedCurrentSoftware, err := listSoftwareDB(ctx, tx, &hostID, fleet.SoftwareListOptions{SkipLoadingCVEs: true})
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "loading current software for host")
 	}
 
-	if nothingChanged(storedCurrentSoftware, software) {
+	if nothingChanged(storedCurrentSoftware, software, minLastOpenedAtDiff) {
 		return nil
 	}
 
@@ -151,7 +155,7 @@ func applyChangesForNewSoftwareDB(ctx context.Context, tx sqlx.ExtContext, hostI
 		return err
 	}
 
-	if err = updateModifiedHostSoftwareDB(ctx, tx, hostID, current, incoming); err != nil {
+	if err = updateModifiedHostSoftwareDB(ctx, tx, hostID, current, incoming, minLastOpenedAtDiff); err != nil {
 		return err
 	}
 
@@ -283,6 +287,7 @@ func updateModifiedHostSoftwareDB(
 	hostID uint,
 	currentMap map[string]fleet.Software,
 	incomingMap map[string]fleet.Software,
+	minLastOpenedAtDiff time.Duration,
 ) error {
 	const stmt = `UPDATE host_software SET last_opened_at = ? WHERE host_id = ? AND software_id = ?`
 

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -378,7 +378,7 @@ func testSoftwareNothingChanged(t *testing.T, ds *Datastore) {
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
-			got := nothingChanged(c.current, c.incoming)
+			got := nothingChanged(c.current, c.incoming, defaultMinLastOpenedAtDiff)
 			if c.want {
 				require.True(t, got)
 			} else {


### PR DESCRIPTION
#2316 (specifically, the config part mentioned at the end of this comment: https://github.com/fleetdm/fleet/issues/2316#issuecomment-1110118729)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] ~~Documented any API changes (docs/Using-Fleet/REST-API.md)~~
- [ ] ~~Documented any permissions changes~~
- [ ] ~~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~~
- [ ] ~~Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~~
- [x] Added/updated tests
- [ ] ~~Manual QA for all new/changed functionality~~
