### PR TITLE
Make edit page links open in a new tab

### DIFF
--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -143,7 +143,7 @@
 
       <div purpose="edit-button-container">
         <div purpose="edit-button">
-          <a :href="'https://github.com/fleetdm/fleet/edit/main/docs/'+thisPage.sectionRelativeRepoPath"><i class="fa fa-pencil"></i>Edit page</a>
+          <a :href="'https://github.com/fleetdm/fleet/edit/main/docs/'+thisPage.sectionRelativeRepoPath" target="_blank"><i class="fa fa-pencil"></i>Edit page</a>
         </div>
       </div>
 
@@ -224,7 +224,7 @@
           <div class="d-block" v-else>
             <h3 class="pb-4 m-0">Is there something missing?</h3>
             <p>
-              If you notice something we’ve missed, or that could be improved, please click <a :href="'https://github.com/fleetdm/fleet/edit/main/docs/'+thisPage.sectionRelativeRepoPath">here</a> to edit this page.
+              If you notice something we’ve missed, or that could be improved, please click <a :href="'https://github.com/fleetdm/fleet/edit/main/docs/'+thisPage.sectionRelativeRepoPath" target="_blank">here</a> to edit this page.
             </p>
           </div>
 

--- a/website/views/pages/handbook/basic-handbook.ejs
+++ b/website/views/pages/handbook/basic-handbook.ejs
@@ -6,7 +6,7 @@
         <div purpose="maintainer" class="mb-lg-3">
           <h4>Maintained by:</h4>
           <img alt="The page maintainer's github profile picture" :src="'https://github.com/'+thisPage.meta.maintainedBy+'.png?size=200'">
-          <a style="margin-top: 24px;" :href="'https://github.com/fleetdm/fleet/edit/main/handbook/'+thisPage.sectionRelativeRepoPath"> Edit this page</a>
+          <a style="margin-top: 24px;" :href="'https://github.com/fleetdm/fleet/edit/main/handbook/'+thisPage.sectionRelativeRepoPath" target="_blank"> Edit this page</a>
         </div>
         <div v-if="!isHandbookLandingPage">
           <h4 class="font-weight-bold pb-2 m-0 mb-2" v-if="!_.isEmpty(subtopics)">On this page:</h4>
@@ -65,7 +65,7 @@
           <div purpose="maintainer" class="mb-lg-3">
             <h4>Maintained by:</h4>
             <img alt="The page maintainer's github profile picture" :src="'https://github.com/'+thisPage.meta.maintainedBy+'.png?size=200'">
-            <a style="margin-top: 24px;" :href="'https://github.com/fleetdm/fleet/tree/main/handbook/'+thisPage.sectionRelativeRepoPath"> Edit this page</a>
+            <a style="margin-top: 24px;" :href="'https://github.com/fleetdm/fleet/tree/main/handbook/'+thisPage.sectionRelativeRepoPath" target="_blank"> Edit this page</a>
           </div>
           <div v-if="!isHandbookLandingPage">
             <h4 class="font-weight-bold pb-2 m-0 mb-2" v-if="!_.isEmpty(subtopics)">On this page:</h4>


### PR DESCRIPTION
A better contributor experience(I think) to open the GitHub edit in a new tab so contributors can still go on reading the docs/handbook at the point they dropped off.
