### PR TITLE
Return -1 if there is no last_opened_at timestamp

### DIFF
--- a/cmd/osquery-perf/mac10.14.6.tmpl
+++ b/cmd/osquery-perf/mac10.14.6.tmpl
@@ -356,7 +356,7 @@
     {{if .LastOpenedAt}}
     "last_opened_at": "{{ .LastOpenedAt.Unix }}"
     {{else}}
-    "last_opened_at": ""
+    "last_opened_at": "-1"
     {{end}}
   }
   {{- end }}


### PR DESCRIPTION
#2316 Returning -1 is consistent with what osquery would return in case there is no timestamp (https://github.com/fleetdm/fleet/issues/2316#issuecomment-1108628451 and raised in review here: https://github.com/fleetdm/fleet/pull/5376#discussion_r859175912)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] ~~Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).~~
- [ ] ~~Documented any API changes (docs/Using-Fleet/REST-API.md)~~
- [ ] ~~Documented any permissions changes~~
- [ ] ~~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~~
- [ ] ~~Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~~
- [ ] ~~Added/updated tests~~
- [ ] ~~Manual QA for all new/changed functionality~~
