### PR TITLE
UI Spiffier: Fix checkbox alignment

### DIFF
--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -149,4 +149,8 @@
       }
     }
   }
+
+  .fleet-checkbox__tick {
+    top: 1px;
+  }
 }

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -40,7 +40,7 @@
 
   &__tick {
     @include size(20px);
-    @include position(absolute, 4px null null 0);
+    @include position(absolute, 3px null null 0);
     display: inline-block;
 
     &::after {

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -40,7 +40,7 @@
 
   &__tick {
     @include size(20px);
-    @include position(absolute, 5px null null 0);
+    @include position(absolute, 1px null null 0);
     display: inline-block;
 
     &::after {

--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -40,7 +40,7 @@
 
   &__tick {
     @include size(20px);
-    @include position(absolute, 1px null null 0);
+    @include position(absolute, 4px null null 0);
     display: inline-block;
 
     &::after {

--- a/frontend/pages/admin/AppSettingsPage/_styles.scss
+++ b/frontend/pages/admin/AppSettingsPage/_styles.scss
@@ -288,4 +288,8 @@
   .component__tooltip-wrapper {
     margin-bottom: $pad-xsmall;
   }
+
+  .fleet-checkbox__tick {
+    top: 4px;
+  }
 }

--- a/frontend/pages/admin/AppSettingsPage/_styles.scss
+++ b/frontend/pages/admin/AppSettingsPage/_styles.scss
@@ -288,8 +288,4 @@
   .component__tooltip-wrapper {
     margin-bottom: $pad-xsmall;
   }
-
-  .fleet-checkbox__tick {
-    top: 4px;
-  }
 }


### PR DESCRIPTION
Cerra #5397 

- Update checkboxes in table containers not to be so low in comparison to checkboxes on settings page, create user, etc


Figma of checkboxes of settings page being lower than normal checkboxes: https://www.figma.com/file/hdALBDsrti77QuDNSzLdkx/?node-id=5548%3A262655

Examples of checkbox fix:
<img width="446" alt="Screen Shot 2022-04-27 at 10 39 09 AM" src="https://user-images.githubusercontent.com/71795832/165544149-cb31f437-504e-4a24-af1d-e55efe1d778c.png">
<img width="1009" alt="Screen Shot 2022-04-27 at 10 39 00 AM" src="https://user-images.githubusercontent.com/71795832/165544153-de55f02b-3c7f-4b48-9f70-076829f88d8d.png">
<img width="1031" alt="Screen Shot 2022-04-27 at 10 38 50 AM" src="https://user-images.githubusercontent.com/71795832/165544154-ff15ac47-390d-471c-b9c8-7780f55e6cae.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

No changefile since bug was introduced in PR within this release
- [x] Manual QA for all new/changed functionality
