### PR TITLE
Changes to support running `fleetctl preview` with custom TUF server

### DIFF
--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -186,7 +186,6 @@ jobs:
         go run github.com/fleetdm/fleet/v4/orbit/cmd/orbit \
           --debug \
           --dev-mode \
-          --dev-darwin-legacy-targets \
           --disable-updates \
           --root-dir /tmp/orbit \
           --fleet-url ${{ needs.gen.outputs.address }} \

--- a/changes/fleetctl-preview-support-custom-tuf
+++ b/changes/fleetctl-preview-support-custom-tuf
@@ -1,0 +1,1 @@
+* Support `fleetctl preview` running with custom TUF server.

--- a/cmd/fleetctl/package.go
+++ b/cmd/fleetctl/package.go
@@ -16,7 +16,10 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var opt packaging.Options
+var (
+	opt               packaging.Options
+	disableOpenFolder bool
+)
 
 func packageCommand() *cli.Command {
 	return &cli.Command{
@@ -136,6 +139,11 @@ func packageCommand() *cli.Command {
 				Value:       15 * time.Minute,
 				Destination: &opt.OrbitUpdateInterval,
 			},
+			&cli.BoolFlag{
+				Name:        "disable-open-folder",
+				Usage:       "Disable opening the folder at the end",
+				Destination: &disableOpenFolder,
+			},
 		},
 		Action: func(c *cli.Context) error {
 			if opt.FleetURL != "" || opt.EnrollSecret != "" {
@@ -191,7 +199,9 @@ To add this device to Fleet, double-click to open your installer.
 
 To add other devices to Fleet, distribute this installer using Chef, Ansible, Jamf, or Puppet. Learn how: https://fleetdm.com/docs/using-fleet/adding-hosts
 `, path)
-			open.Start(filepath.Dir(path))
+			if !disableOpenFolder {
+				open.Start(filepath.Dir(path))
+			}
 			return nil
 		},
 	}

--- a/orbit/changes/orbit-legacy-targets
+++ b/orbit/changes/orbit-legacy-targets
@@ -1,0 +1,1 @@
+* Remove support for Orbit to use the legacy osqueryd target on macOS.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -135,10 +135,6 @@ func main() {
 			Usage: "Log to this file path in addition to stderr",
 		},
 		&cli.BoolFlag{
-			Name:  "dev-darwin-legacy-targets",
-			Usage: "Use darwin legacy target (flag only used on darwin)",
-		},
-		&cli.BoolFlag{
 			Name:    "fleet-desktop",
 			Usage:   "Launch Fleet Desktop application (flag currently only used on darwin)",
 			EnvVars: []string{"ORBIT_FLEET_DESKTOP"},
@@ -217,10 +213,6 @@ func main() {
 		}
 
 		opt := update.DefaultOptions
-
-		if runtime.GOOS == "darwin" && c.Bool("dev-darwin-legacy-targets") {
-			opt.Targets = update.DarwinLegacyTargets
-		}
 
 		if c.Bool("fleet-desktop") {
 			switch runtime.GOOS {

--- a/orbit/pkg/update/options.go
+++ b/orbit/pkg/update/options.go
@@ -21,19 +21,6 @@ var (
 		},
 	}
 
-	DarwinLegacyTargets = Targets{
-		"orbit": TargetInfo{
-			Platform:   "macos",
-			Channel:    "stable",
-			TargetFile: "orbit",
-		},
-		"osqueryd": TargetInfo{
-			Platform:   "macos",
-			Channel:    "stable",
-			TargetFile: "osqueryd",
-		},
-	}
-
 	LinuxTargets = Targets{
 		"orbit": TargetInfo{
 			Platform:   "linux",

--- a/tools/tuf/init_tuf.sh
+++ b/tools/tuf/init_tuf.sh
@@ -140,6 +140,7 @@ if [ -n "$GENERATE_PKGS" ]; then
     --debug \
     --update-roots="$root_keys" \
     --update-interval=10s \
+    --disable-open-folder \
     --update-url=http://$PKG_HOSTNAME:8081
 
   echo "Generating deb..."
@@ -151,6 +152,7 @@ if [ -n "$GENERATE_PKGS" ]; then
     --debug \
     --update-roots="$root_keys" \
     --update-interval=10s \
+    --disable-open-folder \
     --update-url=http://$DEB_HOSTNAME:8081
 
   echo "Generating rpm..."
@@ -162,6 +164,7 @@ if [ -n "$GENERATE_PKGS" ]; then
     --debug \
     --update-roots="$root_keys" \
     --update-interval=10s \
+    --disable-open-folder \
     --update-url=http://$RPM_HOSTNAME:8081
 
   echo "Generating msi..."
@@ -174,6 +177,7 @@ if [ -n "$GENERATE_PKGS" ]; then
     --debug \
     --update-roots="$root_keys" \
     --update-interval=10s \
+    --disable-open-folder \
     --update-url=http://$MSI_HOSTNAME:8081
 
   echo "Packages generated"


### PR DESCRIPTION
# Why?

We need this to test new orbit changes won't break `fleetctl preview` when they are pushed to our TUF server.
In particular, with these changes we can verify that we won't break `fleetctl preview` when we release #5335 to our TUF server.

Also, now that `osquery.app.tar.gz` is available in `edge` and `stable`, this PR also removes the support for legacy targets.

E.g. (after running `./tools/tuf/init_tuf.sh`)
```
fleetctl preview \
  --update-roots='[{"keytype":"ed25519","scheme":"ed25519","keyid_hash_algorithms":["sha256","sha512"],"keyval":{"public":"8cbe231e4d61d5b797e7d21ffc73430fe8ca59a11baef621958d599072c93620"}}]' \
  --update-url=http://localhost:8081
```

- [X] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
~- [ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality
