### PR TITLE
Use a debug mux to support both fleet-authenticated and token-auth debug paths

### DIFF
--- a/changes/issue-5268-fix-fleet-serve-panic
+++ b/changes/issue-5268-fix-fleet-serve-panic
@@ -1,0 +1,1 @@
+* Fix a panic when running `fleet serve --debug` due to duplicate registration of `/debug/` paths.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -451,7 +451,11 @@ the way that the Fleet server works.
 
 			rootMux.Handle("/api/", apiHandler)
 			rootMux.Handle("/", frontendHandler)
-			rootMux.Handle("/debug/", service.MakeDebugHandler(svc, config, logger, eh, ds))
+
+			debugHandler := &debugMux{
+				fleetAuthenticatedHandler: service.MakeDebugHandler(svc, config, logger, eh, ds),
+			}
+			rootMux.Handle("/debug/", debugHandler)
 
 			if path, ok := os.LookupEnv("FLEET_TEST_PAGE_PATH"); ok {
 				// test that we can load this
@@ -477,7 +481,7 @@ the way that the Fleet server works.
 				if err != nil {
 					initFatal(err, "generating debug token")
 				}
-				rootMux.Handle("/debug/", http.StripPrefix("/debug/", netbug.AuthHandler(debugToken)))
+				debugHandler.tokenAuthenticatedHandler = http.StripPrefix("/debug/", netbug.AuthHandler(debugToken))
 				fmt.Printf("*** Debug mode enabled ***\nAccess the debug endpoints at /debug/?token=%s\n", url.QueryEscape(debugToken))
 			}
 
@@ -759,4 +763,23 @@ func argsToString(args []driver.NamedValue) string {
 	}
 	allArgs.WriteString("}")
 	return allArgs.String()
+}
+
+// The debugMux directs the request to either the fleet-authenticated handler,
+// which is the standard handler for debug endpoints (using a Fleet
+// authorization bearer token), or to the token-authenticated handler if a
+// query-string token is provided and such a handler is set. The only wayt to
+// set this handler is if the --debug flag was provided to the fleet serve
+// command.
+type debugMux struct {
+	fleetAuthenticatedHandler http.Handler
+	tokenAuthenticatedHandler http.Handler
+}
+
+func (m *debugMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Has("token") && m.tokenAuthenticatedHandler != nil {
+		m.tokenAuthenticatedHandler.ServeHTTP(w, r)
+		return
+	}
+	m.fleetAuthenticatedHandler.ServeHTTP(w, r)
 }


### PR DESCRIPTION
#5268 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] ~~Documented any API changes (docs/Using-Fleet/REST-API.md)~~
- [ ] ~~Documented any permissions changes~~
- [ ] ~~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~~
- [ ] ~~Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~~
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

## With `--debug` flag set:

```
# using the debug token
$ curl --insecure https://localhost:8080/debug/?token=GOODTOKEN
<html>
  <head>
    <title>Debug Information</title>
  </head>
... output truncated ...
```

```
# using an invalid debug token
$ curl --insecure https://localhost:8080/debug/?token=BADTOKEN
Unauthorized.
```

```
# using a valid fleet authorization token
$ curl --insecure -H 'Authorization: Bearer GOODTOKEN' https://localhost:8080/debug/pprof/
<html>
<head>
<title>/debug/pprof/</title>
... output truncated ...
```

```
# using an invalid fleet authorization token
$ curl --insecure -H 'Authorization: Bearer BADTOKEN' https://localhost:8080/debug/pprof/
Invalid authentication
```

## Without `--debug` flag set

```
# using a debug token
$ curl --insecure https://localhost:8080/debug/pprof/?token=SOMETOKEN
Please authenticate
```

```
# using a valid fleet authorization token
$ curl --insecure -H 'Authorization: Bearer GOODTOKEN' https://localhost:8080/debug/pprof/
<html>
<head>
<title>/debug/pprof/</title>
... output truncated ...
```

```
# using an invalid fleet authorization token
$ curl --insecure -H 'Authorization: Bearer BADTOKEN' https://localhost:8080/debug/pprof/
Invalid authentication
```