### PR TITLE
Refresh user and config on every route change

### DIFF
--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -4,7 +4,6 @@ import { InjectedRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "react-query";
 import classnames from "classnames";
 
-import PATHS from "router/paths";
 import TableProvider from "context/table";
 import QueryProvider from "context/query";
 import PolicyProvider from "context/policy";
@@ -28,9 +27,11 @@ import Spinner from "components/Spinner";
 interface IAppProps {
   children: JSX.Element;
   router: InjectedRouter;
-  location: {
-    pathname: string;
-  };
+  location:
+    | {
+        pathname: string;
+      }
+    | undefined;
 }
 
 const App = ({ children, location, router }: IAppProps): JSX.Element => {
@@ -79,7 +80,7 @@ const App = ({ children, location, router }: IAppProps): JSX.Element => {
     if (authToken()) {
       fetchCurrentUser();
     }
-  }, [location.pathname]);
+  }, [location?.pathname]);
 
   useDeepEffect(() => {
     const canGetEnrollSecret =

--- a/frontend/components/PageHeader/TeamsDropdownHeader.tsx
+++ b/frontend/components/PageHeader/TeamsDropdownHeader.tsx
@@ -1,9 +1,7 @@
 import React, { useCallback, useContext, useEffect } from "react";
-import { useQuery } from "react-query";
 import { InjectedRouter } from "react-router/lib/Router";
 
 import { AppContext, IAppContext } from "context/app";
-import usersAPI, { IGetMeResponse } from "services/entities/users";
 
 import TeamsDropdown from "../TeamsDropdown/TeamsDropdown";
 
@@ -79,13 +77,6 @@ const TeamsDropdownHeader = ({
     isTeamAdmin,
     isOnlyObserver,
   };
-
-  useQuery(["me"], () => usersAPI.me(), {
-    onSuccess: ({ user, available_teams }: IGetMeResponse) => {
-      setCurrentUser(user);
-      setAvailableTeams(available_teams);
-    },
-  });
 
   const findAvailableTeam = (id: number) => {
     return availableTeams?.find((t) => t.id === id);

--- a/frontend/pages/LoginPage/LoginPage.tsx
+++ b/frontend/pages/LoginPage/LoginPage.tsx
@@ -82,7 +82,7 @@ const LoginPage = ({ router }: ILoginPageProps) => {
       if (user.force_password_reset) {
         return router.push(RESET_PASSWORD);
       }
-
+      console.log("go home");
       return router.push(redirectLocation || HOME);
     } catch (response) {
       const errorObject = formatErrorResponse(response);

--- a/frontend/pages/LoginPage/LoginPage.tsx
+++ b/frontend/pages/LoginPage/LoginPage.tsx
@@ -82,7 +82,6 @@ const LoginPage = ({ router }: ILoginPageProps) => {
       if (user.force_password_reset) {
         return router.push(RESET_PASSWORD);
       }
-      console.log("go home");
       return router.push(redirectLocation || HOME);
     } catch (response) {
       const errorObject = formatErrorResponse(response);

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -131,6 +131,7 @@ const TeamDetailsWrapper = ({
   }>({});
 
   const { refetch: refetchMe } = useQuery(["me"], () => usersAPI.me(), {
+    enabled: false,
     onSuccess: ({ user, available_teams }: IGetMeResponse) => {
       setCurrentUser(user);
       setAvailableTeams(available_teams);

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -10,7 +10,6 @@ import FileSaver from "file-saver";
 import enrollSecretsAPI from "services/entities/enroll_secret";
 import labelsAPI from "services/entities/labels";
 import teamsAPI from "services/entities/teams";
-import usersAPI, { IGetMeResponse } from "services/entities/users";
 import globalPoliciesAPI from "services/entities/global_policies";
 import teamPoliciesAPI from "services/entities/team_policies";
 import hostsAPI, {
@@ -146,32 +145,24 @@ const ManageHostsPage = ({
     isOnlyObserver,
     isPremiumTier,
     isFreeTier,
-    setAvailableTeams,
     setCurrentTeam,
-    setCurrentUser,
   } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 
-  useQuery(["me"], () => usersAPI.me(), {
-    onSuccess: ({ user, available_teams }: IGetMeResponse) => {
-      setCurrentUser(user);
-      setAvailableTeams(available_teams);
-      if (queryParams.team_id) {
-        const teamIdParam = parseInt(queryParams.team_id, 10);
-        if (
-          isNaN(teamIdParam) ||
-          (teamIdParam &&
-            available_teams &&
-            !available_teams.find((t) => t.id === teamIdParam))
-        ) {
-          router.replace({
-            pathname: location.pathname,
-            query: omit(queryParams, "team_id"),
-          });
-        }
-      }
-    },
-  });
+  if (queryParams.team_id) {
+    const teamIdParam = parseInt(queryParams.team_id, 10);
+    if (
+      isNaN(teamIdParam) ||
+      (teamIdParam &&
+        availableTeams &&
+        !availableTeams.find((team) => team.id === teamIdParam))
+    ) {
+      router.replace({
+        pathname: location.pathname,
+        query: omit(queryParams, "team_id"),
+      });
+    }
+  }
 
   const { selectedOsqueryTable, setSelectedOsqueryTable } = useContext(
     QueryContext

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -17,7 +17,6 @@ import configAPI from "services/entities/config";
 import globalPoliciesAPI from "services/entities/global_policies";
 import teamPoliciesAPI from "services/entities/team_policies";
 import teamsAPI from "services/entities/teams";
-import usersAPI, { IGetMeResponse } from "services/entities/users";
 
 import Button from "components/buttons/Button";
 import RevealButton from "components/buttons/RevealButton";
@@ -30,7 +29,7 @@ import AddPolicyModal from "./components/AddPolicyModal";
 import RemovePoliciesModal from "./components/RemovePoliciesModal";
 
 interface IManagePoliciesPageProps {
-  router: InjectedRouter; // v3
+  router: InjectedRouter;
   location: {
     action: string;
     hash: string;
@@ -96,13 +95,6 @@ const ManagePolicyPage = ({
   useEffect(() => {
     setLastEditedQueryPlatform(null);
   }, []);
-
-  useQuery(["me"], () => usersAPI.me(), {
-    onSuccess: ({ user, available_teams }: IGetMeResponse) => {
-      setCurrentUser(user);
-      setAvailableTeams(available_teams);
-    },
-  });
 
   const {
     data: globalPolicies,

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -19,7 +19,6 @@ import fleetQueriesAPI from "services/entities/queries";
 import globalScheduledQueriesAPI from "services/entities/global_scheduled_queries";
 import teamScheduledQueriesAPI from "services/entities/team_scheduled_queries";
 import teamsAPI from "services/entities/teams";
-import usersAPI, { IGetMeResponse } from "services/entities/users";
 import sortUtils from "utilities/sort";
 import paths from "router/paths";
 
@@ -122,8 +121,6 @@ const ManageSchedulePage = ({
     isPremiumTier,
     isFreeTier,
     currentTeam,
-    setAvailableTeams,
-    setCurrentUser,
     setCurrentTeam,
   } = useContext(AppContext);
 
@@ -143,13 +140,6 @@ const ManageSchedulePage = ({
 
     return filteredSortedTeams;
   };
-
-  useQuery(["me"], () => usersAPI.me(), {
-    onSuccess: ({ user, available_teams }: IGetMeResponse) => {
-      setCurrentUser(user);
-      setAvailableTeams(available_teams);
-    },
-  });
 
   const { data: teams, isLoading: isLoadingTeams } = useQuery(
     ["teams"],

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -56,13 +56,18 @@ import RoutingProvider from "context/routing";
 interface IAppWrapperProps {
   children: JSX.Element;
   router: InjectedRouter;
+  location?: {
+    pathname: string;
+  };
 }
 
 // App.tsx needs the context for user and config
-const AppWrapper = ({ children, router }: IAppWrapperProps) => (
+const AppWrapper = ({ children, router, location }: IAppWrapperProps) => (
   <AppProvider>
     <RoutingProvider>
-      <App router={router}>{children}</App>
+      <App router={router} location={location}>
+        {children}
+      </App>
     </RoutingProvider>
   </AppProvider>
 );


### PR DESCRIPTION
Issue #5293 

Please give this thorough manual testing since it is changing global state on every route.

Part of the testing should include confirming what happens when the auth token becomes invalid. To do that log in normally and open the dev console in Chrome and select the "Application" tab, then "Local Sotrage". Find the `FLEET::auth_token` and set it to something invalid. Then, click on a link to load another route without reloading the page. It should catch the invalid auth token and redirect you to /login. 

![image](https://user-images.githubusercontent.com/2495927/165626163-fdfa3eeb-9b8b-469f-9b67-699371c0eddd.png)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
