### PR TITLE
Add user agent to Orbit HTTP client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 build
 vendor
 node_modules
+dist
 
 # generated artifacts
 assets/bundle*.*

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/VividCortex/mysqlerr v0.0.0-20170204212430-6c6b55f8796f
 	github.com/WatchBeam/clock v0.0.0-20170901150240-b08e6b4da7ea
 	github.com/XSAM/otelsql v0.10.0
-	github.com/andygrunwald/go-jira v1.15.1 // indirect
+	github.com/andygrunwald/go-jira v1.15.1
 	github.com/antchfx/htmlquery v1.2.4 // indirect
 	github.com/antchfx/xmlquery v1.3.9 // indirect
 	github.com/aws/aws-sdk-go v1.40.34

--- a/go.sum
+++ b/go.sum
@@ -527,7 +527,6 @@ github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
-github.com/golang-jwt/jwt/v4 v4.0.0 h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.3.0 h1:kHL1vqdqWNfATmA0FNMdmZNMyZI1U6O31X4rlIPoBog=
 github.com/golang-jwt/jwt/v4 v4.3.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
@@ -1266,7 +1265,6 @@ github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQ
 github.com/zclconf/go-cty v1.1.0 h1:uJwc9HiBOCpoKIObTQaLR+tsEXx1HBHnOsOOpcdhZgw=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
-github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 github.com/zwass/kit v0.0.0-20210625184505-ec5b5c5cce9c h1:TWQ2UvXPkhPxI2KmApKBOCaV6yD2N4mlvqFQ/DlPtpQ=
 github.com/zwass/kit v0.0.0-20210625184505-ec5b5c5cce9c/go.mod h1:OYYulo9tUqRadRLwB0+LE914sa1ui2yL7OrcU3Q/1XY=

--- a/orbit/.goreleaser.yml
+++ b/orbit/.goreleaser.yml
@@ -19,7 +19,9 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser
+      - -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version={{.Version}}
+      - -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Commit={{.Commit}}
+      - -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Date={{.Date}}
     hooks:
       post: ./orbit/tools/build/sign-macos.sh {{ .Path }}
 

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/orbit/pkg/build"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/execuser"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/insecure"
@@ -32,13 +33,6 @@ import (
 	gopsutil_process "github.com/shirou/gopsutil/v3/process"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/natefinch/lumberjack.v2"
-)
-
-var (
-	// Flags set by goreleaser during build
-	version = ""
-	commit  = ""
-	date    = ""
 )
 
 func main() {
@@ -146,7 +140,7 @@ func main() {
 	}
 	app.Action = func(c *cli.Context) error {
 		if c.Bool("version") {
-			fmt.Println("orbit " + version)
+			fmt.Println("orbit " + build.Version)
 			return nil
 		}
 
@@ -677,9 +671,9 @@ var versionCommand = &cli.Command{
 	Usage: "Get the orbit version",
 	Flags: []cli.Flag{},
 	Action: func(c *cli.Context) error {
-		fmt.Println("orbit " + version)
-		fmt.Println("commit - " + commit)
-		fmt.Println("date - " + date)
+		fmt.Println("orbit " + build.Version)
+		fmt.Println("commit - " + build.Commit)
+		fmt.Println("date - " + build.Date)
 		return nil
 	},
 }

--- a/orbit/cmd/orbit/orbit_info.go
+++ b/orbit/cmd/orbit/orbit_info.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 
+	"github.com/fleetdm/fleet/v4/orbit/pkg/build"
 	orbit_table "github.com/fleetdm/fleet/v4/orbit/pkg/table"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -29,7 +30,7 @@ func (o orbitInfoExtension) Columns() []table.ColumnDefinition {
 
 // GenerateFunc partially implements orbit_table.Extension.
 func (o orbitInfoExtension) GenerateFunc(_ context.Context, _ table.QueryContext) ([]map[string]string, error) {
-	v := version
+	v := build.Version
 	if v == "" {
 		v = "unknown"
 	}

--- a/orbit/pkg/build/build.go
+++ b/orbit/pkg/build/build.go
@@ -1,0 +1,13 @@
+// package build provides build metadata through variables set at build time
+// (with -ldflags="-X ...")
+package build
+
+var (
+	// Version is the commit tag version number for release builds, or a
+	// generated version for untagged builds.
+	Version string
+	// Commit is the commit SHA.
+	Commit string
+	// Date is the date of the build.
+	Date string
+)

--- a/orbit/pkg/update/update.go
+++ b/orbit/pkg/update/update.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/build"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/platform"
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
@@ -97,7 +98,10 @@ func New(opt Options) (*Updater, error) {
 		InsecureSkipVerify: opt.InsecureTransport,
 	}))
 
-	remoteStore, err := client.HTTPRemoteStore(opt.ServerURL, nil, httpClient)
+	remoteOpt := &client.HTTPRemoteOptions{
+		UserAgent: fmt.Sprintf("orbit/%s (%s %s)", build.Version, runtime.GOOS, runtime.GOARCH),
+	}
+	remoteStore, err := client.HTTPRemoteStore(opt.ServerURL, remoteOpt, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("init remote store: %w", err)
 	}


### PR DESCRIPTION
Allows identification of which Orbit versions are in use from the update
server.

Refactored the build information into a separate `package build` to
support importing it from multiple places.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

~- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).~
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
~- [ ] Added/updated tests~
- [x] Manual QA for all new/changed functionality
