### PR TITLE
fix mysql tests with a regexp assertion of possible error messages

### DIFF
--- a/server/datastore/mysql/mysql_test.go
+++ b/server/datastore/mysql/mysql_test.go
@@ -778,7 +778,9 @@ func TestNewUsesRegisterTLS(t *testing.T) {
 	// This fails because the certificate mysql is using is different than the one generated here
 	_, err := newDSWithConfig(t, dbName, mysqlConfig)
 	require.Error(t, err)
-	require.Equal(t, "x509: certificate is not valid for any names, but wanted to match localhost", err.Error())
+	// TODO: we're using a Regexp because the message is different depending on the version of mysql,
+	// we should refactor and use different error types instead.
+	require.Regexp(t, "^(x509|tls)", err.Error())
 }
 
 func TestWhereFilterTeams(t *testing.T) {


### PR DESCRIPTION
this fixes #5377 by asserting that the error message starts with
"tsl" or "x509" as either of the strings represent the same error
depending on the mysql version.

we should refactor the code to avoid checking on the error messages
and probably use different error types instead.

# Checklist for submitter

- [x] Added/updated tests
