### PR TITLE
Fix scrollbar on Firefox (on windows)

### DIFF
--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -547,7 +547,7 @@
         height: fit-content;
         [purpose='subtopics'] {
           max-height: calc(~'80vh - 90px'); //To prevent the sidenav being anchored to the bottom of the page if it has overflow.
-          overflow-y: scroll;
+          overflow-y: auto;
           color: @core-fleet-black;
           padding-top: 4px;
           padding-bottom: 4px;


### PR DESCRIPTION
Changes: 
- Changed the overflow behavior of the right sidebar from `scroll` to `auto` to hide the scrollbar when the content isn't scrollable



- [x] Manual QA for all new/changed functionality
