### PR TITLE
Updated Brand Slack channels

### DIFF
--- a/handbook/brand.md
+++ b/handbook/brand.md
@@ -232,7 +232,6 @@ These groups maintain the following [Slack channels](https://fleetdm.com/handboo
 | `#g-digital-experience`     | Mike Thomas
 | `#oooh-websites`            | Mike Thomas
 | `#oooh-automation`          | Mike McNeil
-| `#g-community`              | Kathy Satterlee
 | `#g-people`                 | Eric Shaw
 | `#help-onboarding`          | Eric Shaw
 | `#help-finance`             | Eric Shaw


### PR DESCRIPTION
I have removed the #g-community Slack channel from this group.

# Checklist for submitter
- [x] Manual QA for all new/changed functionality
