### PR TITLE
App Settings Page: Styling fixes

### DIFF
--- a/frontend/pages/admin/AppSettingsPage/_styles.scss
+++ b/frontend/pages/admin/AppSettingsPage/_styles.scss
@@ -177,6 +177,10 @@
     .app-config-form__section-description {
       width: initial;
     }
+
+    h2 {
+      max-width: initial;
+    }
   }
 
   &__inputs {

--- a/frontend/pages/admin/AppSettingsPage/_styles.scss
+++ b/frontend/pages/admin/AppSettingsPage/_styles.scss
@@ -193,12 +193,16 @@
       margin: 0 0 $pad-medium;
 
       .form-field {
-        width: 18%;
+        width: 29%;
         float: right;
 
         &:first-child {
           float: left;
-          width: 78%;
+          width: 69%;
+        }
+
+        &:nth-child(2) {
+          padding-top: 10px;
         }
 
         &--checkbox {

--- a/frontend/pages/admin/AppSettingsPage/cards/Agents/Agents.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/Agents/Agents.tsx
@@ -64,8 +64,8 @@ const Agents = ({
   return (
     <form className={baseClass} onSubmit={onFormSubmit} autoComplete="off">
       <div className={`${baseClass}__section`}>
-        <h2>Global agent options</h2>
         <div className={`${baseClass}__yaml`}>
+          <h2>Global agent options</h2>
           <p className={`${baseClass}__section-description`}>
             This code will be used by osquery when it checks for configuration
             options.


### PR DESCRIPTION
Cerra #5415 

- Align port number with server
- 4 digit Port number not cut off with 768px screen
- Widen heading of global agent options

<img width="694" alt="Screen Shot 2022-04-29 at 10 20 39 AM" src="https://user-images.githubusercontent.com/71795832/165963864-d45443b9-e9da-4917-8c58-dd1444bc35cb.png">
<img width="1141" alt="Screen Shot 2022-04-29 at 10 20 16 AM" src="https://user-images.githubusercontent.com/71795832/165963867-b604eb10-765d-4514-b257-53cc3584d032.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- No change file as this is iterations on a release issue #1308 
- [x] Manual QA for all new/changed functionality
