### PR TITLE
Improve detection of CPEs for macOS apps

### DIFF
--- a/server/vulnerabilities/cpe.go
+++ b/server/vulnerabilities/cpe.go
@@ -143,7 +143,6 @@ func CPEFromSoftware(db *sqlx.DB, software *fleet.Software) (string, error) {
 	targetSW := ""
 	switch software.Source {
 	case "apps":
-		targetSW = "macos"
 	case "python_packages":
 		targetSW = "python"
 	case "chrome_extensions":


### PR DESCRIPTION
In #5470 I noticed many macOS apps were missing CPEs. It seems that for many of these, the `target` value is not set in the CPE database.

This still needs more testing, but it looks like it should improve detection on macOS for many of the missed apps.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [ ] Documented any permissions changes
- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
