### PR TITLE
Add slack notification

### DIFF
--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -1,5 +1,7 @@
 name: Test fleetctl preview
 
+# Tests the `fleetctl preview` command with latest npm released version of fleetctl.
+
 on:
   workflow_dispatch: # Manual
   schedule:
@@ -43,3 +45,24 @@ jobs:
         fleetctl get hosts | tee hosts.txt
         [ $( cat hosts.txt | grep online | wc -l) -eq 8 ]
       shell: bash
+
+    - name: Slack Notification
+      if: failure()
+      uses: slackapi/slack-github-action@16b6c78ee73689a627b65332b34e5d409c7299da # v1.18.0
+      with:
+        payload: |
+          {
+            "text": "${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Fleetctl preview test result: ${{ job.status }}\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_G_PLATFORM_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -452,7 +452,7 @@ spec:
   description: Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.
   resolution: "To enable Gatekeeper, on the failing device, run the following command in the Terminal app: /usr/sbin/spctl --master-enable."
   platforms: macOS
-  platform: Darwin
+  platform: darwin
   contributors: groob
 ---
 apiVersion: v1
@@ -477,7 +477,7 @@ spec:
   description: Checks to make sure that full disk encryption (FileVault) is enabled on macOS devices.
   resolution: To enable full disk encryption, on the failing device, select System Preferences > Security & Privacy > FileVault > Turn On FileVault.
   platforms: macOS
-  platform: Darwin
+  platform: darwin
   contributors: groob
 ---
 apiVersion: v1
@@ -488,7 +488,7 @@ spec:
   description: Checks if the root drive is encrypted. There are many ways to encrypt Linux systems. This is the default on distributions such as Ubuntu.
   resolution: "Ensure the image deployed to your Linux workstation includes full disk encryption."
   platforms: Linux
-  platform: Linux
+  platform: linux
   contributors: GuillaumeRoss
 ---
 apiVersion: v1
@@ -499,7 +499,7 @@ spec:
   description: Checks to make sure that the System Integrity Protection feature is enabled.
   resolution: "To enable System Integrity Protection, on the failing device, run the following command in the Terminal app: /usr/sbin/spctl --master-enable."
   platforms: macOS
-  platform: Darwin
+  platform: darwin
   contributors: groob
 ---
 apiVersion: v1
@@ -510,7 +510,7 @@ spec:
   description: "Required: You’re already enforcing a policy via Moble Device Management (MDM). Checks to make sure that the device user cannot log in to the device without a password."
   resolution: "The following example profile includes a setting to disable automatic login: https://github.com/gregneagle/profiles/blob/fecc73d66fa17b6fa78b782904cb47cdc1913aeb/loginwindow.mobileconfig#L64-L65."
   platforms: macOS
-  platform: Darwin
+  platform: darwin
   contributors: groob
 ---
 apiVersion: v1
@@ -521,7 +521,7 @@ spec:
   description: "Required: You’re already enforcing a policy via Moble Device Management (MDM). Checks to make sure that guest accounts cannot be used to log in to the device without a password."
   resolution: "The following example profile includes a setting to disable guest users: https://github.com/gregneagle/profiles/blob/fecc73d66fa17b6fa78b782904cb47cdc1913aeb/loginwindow.mobileconfig#L68-L71."
   platforms: macOS
-  platform: Darwin
+  platform: darwin
   contributors: groob
 ---
 apiVersion: v1
@@ -531,7 +531,7 @@ spec:
   query: SELECT 1 FROM managed_policies WHERE domain = 'com.apple.Terminal' AND name = 'SecureKeyboardEntry' AND value = 1 LIMIT 1;
   description: "Required: You’re already enforcing a policy via Moble Device Management (MDM). Checks to make sure that the Secure Keyboard Entry setting is enabled."
   platforms: macOS
-  platform: Darwin
+  platform: darwin
   contributors: groob
 ---
 apiVersion: v1
@@ -574,7 +574,7 @@ spec:
     Preferences > Software Update > Advanced > Turn on Install system data files and security
     updates.
   platforms: macOS
-  platform: Darwin
+  platform: darwin
   contributors: GuillaumeRoss
 ---
 apiVersion: v1
@@ -585,7 +585,7 @@ spec:
   description: Checks the status of antivirus and signature updates from the Windows Security Center. 
   resolution: "Ensure Windows Defender or your third-party antivirus is running, up to date, and visible in the Windows Security Center."
   platforms: Windows
-  platform: Windows
+  platform: windows
   contributors: GuillaumeRoss
 ---
 apiVersion: v1
@@ -596,7 +596,7 @@ spec:
   description: Checks that both ClamAV's daemon and its updater service (freshclam) are running. 
   resolution: "Ensure ClamAV and Freshclam are installed and running."
   platforms: Linux
-  platform: Linux
+  platform: linux
   contributors: GuillaumeRoss
 ---
 apiVersion: v1
@@ -607,7 +607,7 @@ spec:
   description: "Required: osquery deployed with Orbit, or manual installation of macadmins/osquery-extension. Checks that a mac is enrolled to MDM. Add a AND on identity_certificate_uuid to check for a specific MDM."
   resolution: "Enroll device to MDM"
   platforms: macOS
-  platform: Darwin
+  platform: darwin
   contributors: GuillaumeRoss
 ---
 apiVersion: v1
@@ -618,7 +618,7 @@ spec:
   description: "Checks if the application (Docker Desktop example) is installed and up to date, or not installed. Fails if the application is installed and on a lower version. You can copy this query and replace the bundle_identifier and bundle_version values to apply the same type of policy to other applications."
   resolution: "Update Docker or remove it if not used."
   platforms: macOS
-  platform: Darwin
+  platform: darwin
   contributors: GuillaumeRoss
 ---
 apiVersion: v1
@@ -629,5 +629,5 @@ spec:
   description: "Required: osquery must have Full Disk Access. Policy passes if all keys are encrypted, including if no keys are present."
   resolution: "Use this command to encrypt existing SSH keys by providing the path to the file: ssh-keygen -o -p -f /path/to/file"
   platforms: macOS, Linux, Windows
-  platform: Darwin, Linux, Windows
+  platform: darwin,linux,windows
   contributors: GuillaumeRoss


### PR DESCRIPTION
#5427 broke `fleetctl preview` for users.
Here's today's fleetctl [scheduled test run](https://github.com/fleetdm/fleet/actions/runs/2255726871).

I'll be adding automation on a separate PR to prevent this from happening.

Added a slack notification so the team is aware when our users could be hitting issues:
![Screen Shot 2022-05-02 at 08 34 24](https://user-images.githubusercontent.com/2073526/166227340-ac428a82-4777-421f-96ee-157d036b0be7.png)

