### PR TITLE
UI Revert empty state for host details users/software

### DIFF
--- a/frontend/pages/hosts/details/cards/EmptyState/EmptyState.tsx
+++ b/frontend/pages/hosts/details/cards/EmptyState/EmptyState.tsx
@@ -61,19 +61,12 @@ const EmptyState = ({ title, reason }: IEmptyStateProps): JSX.Element => {
           <div className={`${baseClass}__inner`}>
             <div className={`${baseClass}__empty-list`}>
               <h1>
-                <img alt="Disable icon" src={DisableIcon} />
-                No {title} collected from this host.
+                No {title === "software" ? "installed software" : title}{" "}
+                detected on this host.
               </h1>
               <p>
-                Check out the Fleet documentation on{" "}
-                <a
-                  href="https://fleetdm.com/docs/using-fleet/faq#why-is-my-host-not-returning-vitals"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  how to troubleshoot{" "}
-                  <img alt="External link" src={ExternalLinkIcon} />
-                </a>
+                Expecting to see {title}? Try again in a few seconds as the
+                system catches up.
               </p>
             </div>
           </div>

--- a/frontend/pages/hosts/details/cards/EmptyState/EmptyState.tsx
+++ b/frontend/pages/hosts/details/cards/EmptyState/EmptyState.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import ExternalLinkIcon from "../../../../../../assets/images/open-new-tab-12x12@2x.png";
-import DisableIcon from "../../../../../../assets/images/icon-action-disable-red-16x16@2x.png";
 
 const baseClass = "empty-state";
 

--- a/frontend/pages/hosts/details/cards/EmptyState/_styles.scss
+++ b/frontend/pages/hosts/details/cards/EmptyState/_styles.scss
@@ -44,6 +44,12 @@
     }
   }
 
+  &__empty-list {
+    h1 {
+      font-size: $small;
+    }
+  }
+
   &__empty-filter-results {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Cerra #3124 
Re: https://github.com/fleetdm/fleet/pull/5294#issuecomment-1115031053

- Product's request to revert release's empty state for software/users on host details page

<img width="1128" alt="Screen Shot 2022-05-02 at 11 47 34 AM" src="https://user-images.githubusercontent.com/71795832/166264836-6dc580f9-5639-4c8a-b56e-d28a697e6da9.png">
<img width="1130" alt="Screen Shot 2022-05-02 at 11 47 46 AM" src="https://user-images.githubusercontent.com/71795832/166264833-f15d6d0c-6dd4-4966-8971-c690f28f7c87.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- Changes file added for user-visible changes (unneeded since change is in release)
- [x] Manual QA for all new/changed functionality
