### PR TITLE
UI Fix padding on live policy warning

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
@@ -176,6 +176,7 @@
     display: flex;
     align-items: center;
     margin: 0;
+    margin-top: $pad-large;
 
     &--modal {
       display: flex;

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
@@ -5,7 +5,7 @@
 
     .policy-page__warning {
       margin: 0;
-      margin-top: $pad-large;
+      margin-bottom: $pad-large;
     }
 
     .form-field--input {
@@ -176,7 +176,6 @@
     display: flex;
     align-items: center;
     margin: 0;
-    margin-top: $pad-large;
 
     &--modal {
       display: flex;


### PR DESCRIPTION
Cerra #5498 

- Added 24 px padding below live policy disable banner
- Ensure padding is correct with and without banner

<img width="1080" alt="Screen Shot 2022-05-02 at 6 38 25 PM" src="https://user-images.githubusercontent.com/71795832/166338054-33bf0263-0d90-4179-96c2-09ffa5c78eca.png">
<img width="1078" alt="Screen Shot 2022-05-02 at 6 38 09 PM" src="https://user-images.githubusercontent.com/71795832/166338056-fbcaec7e-b0d8-4a46-848b-c68c10d224b4.png">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
