### PR TITLE
Amend `fleetctl package` to support `/var/lib` legacy orbit (legacy would mean <= 0.0.11)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -206,6 +206,18 @@ jobs:
           sudo systemctl status orbit.service || true
           sleep 1
         done
+        sudo journalctl -u orbit.service > orbit-logs
+
+    - name: Upload Orbit logs
+      if: always()
+      uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v2
+      with:
+        name: orbit-${{ matrix.orbit-channel }}-${{ matrix.osqueryd-channel }}-logs
+        path: |
+          orbit-logs
+
+    - name: Uninstall Orbit
+      run: |
         sudo apt remove fleet-osquery -y
 
   orbit-windows-build:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -166,8 +166,20 @@ jobs:
           sleep 1
         done
 
+    - name: Upload Orbit logs
+      if: always()
+      uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v2
+      with:
+        name: orbit-macos-${{ matrix.orbit-channel }}-${{ matrix.osqueryd-channel }}-logs
+        path: |
+          /var/log/orbit
+
+    - name: Uninstall Orbit
+      run: |
+        ./orbit/tools/cleanup/cleanup_macos.sh
+
   orbit-ubuntu:
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         orbit-channel: [ 'stable', 'edge' ]
@@ -216,7 +228,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v2
       with:
-        name: orbit-${{ matrix.orbit-channel }}-${{ matrix.osqueryd-channel }}-logs
+        name: orbit-ubuntu-${{ matrix.orbit-channel }}-${{ matrix.osqueryd-channel }}-logs
         path: |
           orbit-logs
 
@@ -225,7 +237,7 @@ jobs:
         sudo apt remove fleet-osquery -y
 
   orbit-windows-build:
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         orbit-channel: [ 'stable', 'edge' ]
@@ -260,7 +272,7 @@ jobs:
       uses: mxschmitt/action-tmate@8b4e4ac71822ed7e0ad5fb3d1c33483e9e8fb270 # v3
 
   orbit-windows:
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         orbit-channel: [ 'stable', 'edge' ]
@@ -289,3 +301,11 @@ jobs:
     # We can't very accurately check the install on these Windows hosts since the hostnames tend to
     # overlap and we can't control the hostnames. Instead we just return and have the run-server job
     # wait until the expected number of hosts enroll.
+
+    - name: Upload Orbit logs
+      if: always()
+      uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v2
+      with:
+        name: orbit-windows-${{ matrix.orbit-channel }}-${{ matrix.osqueryd-channel }}-logs
+        path: |
+          C:\Windows\system32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -145,6 +145,9 @@ jobs:
     runs-on: macos-latest
     needs: [gen, login]
     steps:
+    - name: Checkout Code
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+
     - name: Install dependencies
       run: |
         npm install -g fleetctl

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -166,13 +166,20 @@ jobs:
           sleep 1
         done
 
+    - name: Collect orbit logs
+      if: always()
+      run: |
+        mkdir orbit-logs
+        sudo cp /var/log/orbit/orbit.stdout.log orbit-logs/
+        sudo cp /var/log/orbit/orbit.stderr.log orbit-logs/
+
     - name: Upload Orbit logs
       if: always()
       uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v2
       with:
         name: orbit-macos-${{ matrix.orbit-channel }}-${{ matrix.osqueryd-channel }}-logs
         path: |
-          /var/log/orbit
+          orbit-logs
 
     - name: Uninstall Orbit
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -166,15 +166,14 @@ jobs:
         until fleetctl get hosts | grep -iF $(hostname -s);
         do
           echo "Awaiting enrollment..."
-          sleep 1
+          sleep 10
         done
 
     - name: Collect orbit logs
       if: always()
       run: |
         mkdir orbit-logs
-        sudo cp /var/log/orbit/orbit.stdout.log orbit-logs/
-        sudo cp /var/log/orbit/orbit.stderr.log orbit-logs/
+        sudo cp /var/log/orbit/* orbit-logs/
 
     - name: Upload Orbit logs
       if: always()
@@ -202,14 +201,16 @@ jobs:
         npm install -g fleetctl
         fleetctl config set --address ${{ needs.gen.outputs.address }} --token ${{ needs.login.outputs.token }}
 
-    - name: Download binaries
-      uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39 #v2.16.0
+    - name: Install Go
+      uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2
       with:
-        workflow: build-binaries.yaml
-        branch: main
-        name: build
-        path: build
-        check_artifacts: true
+        go-version: ${{ matrix.go-version }}
+
+    - name: Checkout Code
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+
+    - name: Build Fleetctl
+      run: make fleetctl
 
     - name: Install Orbit
       run: |
@@ -226,7 +227,7 @@ jobs:
         do
           echo "Awaiting enrollment..."
           sudo systemctl status orbit.service || true
-          sleep 1
+          sleep 10
         done
 
     - name: Collect orbit logs

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -167,7 +167,7 @@ jobs:
         done
 
   orbit-ubuntu:
-    timeout-minutes: 15
+    timeout-minutes: 10
     strategy:
       matrix:
         orbit-channel: [ 'stable', 'edge' ]
@@ -206,6 +206,10 @@ jobs:
           sudo systemctl status orbit.service || true
           sleep 1
         done
+
+    - name: Collect orbit logs
+      if: always()
+      run: |
         sudo journalctl -u orbit.service > orbit-logs
 
     - name: Upload Orbit logs
@@ -221,7 +225,7 @@ jobs:
         sudo apt remove fleet-osquery -y
 
   orbit-windows-build:
-    timeout-minutes: 15
+    timeout-minutes: 10
     strategy:
       matrix:
         orbit-channel: [ 'stable', 'edge' ]
@@ -256,7 +260,7 @@ jobs:
       uses: mxschmitt/action-tmate@8b4e4ac71822ed7e0ad5fb3d1c33483e9e8fb270 # v3
 
   orbit-windows:
-    timeout-minutes: 15
+    timeout-minutes: 10
     strategy:
       matrix:
         orbit-channel: [ 'stable', 'edge' ]

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/pubsub v1.16.0
 	github.com/AbGuthrie/goquery/v2 v2.0.1
 	github.com/DATA-DOG/go-sqlmock v1.5.0
+	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/PuerkitoBio/goquery v1.8.0 // indirect
 	github.com/VividCortex/gohistogram v1.0.0 // indirect

--- a/orbit/pkg/packaging/macos.go
+++ b/orbit/pkg/packaging/macos.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/Masterminds/semver"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/update"
 	"github.com/fleetdm/fleet/v4/pkg/file"
@@ -68,6 +69,13 @@ func BuildPkg(opt Options) (string, error) {
 		// We set the package version to orbit's latest version.
 		opt.Version = updatesData.OrbitVersion
 	}
+
+	if orbitSemVer, err := semver.NewVersion(updatesData.OrbitVersion); err == nil {
+		if orbitSemVer.LessThan(semver.MustParse("0.0.11")) {
+			opt.LegacyVarLibSymlink = true
+		}
+	}
+	// If err != nil we assume non-legacy Orbit.
 
 	// Write files
 

--- a/orbit/pkg/packaging/macos_templates.go
+++ b/orbit/pkg/packaging/macos_templates.go
@@ -35,6 +35,10 @@ var macosPostinstallTemplate = template.Must(template.New("").Option("missingkey
 
 ln -sf /opt/orbit/bin/orbit/macos/{{.OrbitChannel}}/orbit /opt/orbit/bin/orbit/orbit
 ln -sf /opt/orbit/bin/orbit/orbit /usr/local/bin/orbit
+{{ if .LegacyVarLibSymlink }}
+# Symlink needed to support old versions of orbit.
+ln -sf /opt/orbit /var/lib/orbit
+{{- end }}
 
 {{ if .StartService -}}
 DAEMON_LABEL="com.fleetdm.orbit"

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -60,6 +60,9 @@ type Options struct {
 	Desktop bool
 	// OrbitUpdateInterval is the interval that Orbit will use to check for updates.
 	OrbitUpdateInterval time.Duration
+	// LegacyVarLibSymlink indicates whether Orbit is legacy (< 0.0.11),
+	// which assumes it is installed under /var/lib.
+	LegacyVarLibSymlink bool
 }
 
 func initializeTempDir() (string, error) {

--- a/orbit/tools/cleanup/cleanup_macos.sh
+++ b/orbit/tools/cleanup/cleanup_macos.sh
@@ -4,4 +4,4 @@ sudo launchctl stop com.fleetdm.orbit
 sudo launchctl unload /Library/LaunchDaemons/com.fleetdm.orbit.plist
 
 sudo pkill fleet-desktop || true
-sudo rm -rf /Library/LaunchDaemons/com.fleetdm.orbit.plist /var/lib/orbit/ /usr/local/bin/orbit /var/log/orbit /opt/orbit/
+sudo rm -rf /Library/LaunchDaemons/com.fleetdm.orbit.plist /var/lib/orbit /usr/local/bin/orbit /var/log/orbit /opt/orbit/


### PR DESCRIPTION
Fix for [integration.yml](https://github.com/fleetdm/fleet/actions/runs/2263181813) Github Actions.

Issue:
1. Latest `fleetctl` (to be released in `v4.14.0`) was installing at new root directory in `/opt/orbit`.
2. Orbit target from the default TUF ([tuf.fleetctl.com](http://tuf.fleetctl.com/)), latest released orbit (`v0.0.10`), doesn't understand a root directory other than `/var/lib/orbit` (it's hardcoded).