### PR TITLE
Made changes so that we have a per-environment internal load balancer

### DIFF
--- a/infrastructure/loadtesting/terraform/alb.tf
+++ b/infrastructure/loadtesting/terraform/alb.tf
@@ -1,9 +1,30 @@
+resource "aws_lb" "internal" {
+  name                       = "${local.prefix}-internal"
+  internal                   = true
+  security_groups            = [data.terraform_remote_state.shared.outputs.alb_security_group.id]
+  subnets                    = data.terraform_remote_state.shared.outputs.vpc.private_subnets
+  idle_timeout               = 600
+  drop_invalid_header_fields = true
+  #checkov:skip=CKV_AWS_150:don't like it
+}
+
+resource "aws_lb_listener" "internal" {
+  load_balancer_arn = aws_lb.internal.arn
+  port              = 80
+  protocol          = "HTTP" #tfsec:ignore:aws-elb-http-not-used
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.internal.arn
+  }
+}
+
 resource "aws_lb_listener_rule" "main" {
   listener_arn = data.terraform_remote_state.shared.outputs.alb-listener.arn
 
   action {
     type             = "forward"
-    target_group_arn = aws_alb_target_group.main.arn
+    target_group_arn = aws_lb_target_group.main.arn
   }
 
   condition {
@@ -13,22 +34,7 @@ resource "aws_lb_listener_rule" "main" {
   }
 }
 
-resource "aws_lb_listener_rule" "internal" {
-  listener_arn = data.terraform_remote_state.shared.outputs.alb-listener-internal.arn
-
-  action {
-    type             = "forward"
-    target_group_arn = aws_alb_target_group.internal.arn
-  }
-
-  condition {
-    host_header {
-      values = ["${terraform.workspace}.loadtest.fleetdm.com"]
-    }
-  }
-}
-
-resource "aws_alb_target_group" "internal" {
+resource "aws_lb_target_group" "internal" {
   name                 = "${local.prefix}-internal"
   protocol             = "HTTP"
   target_type          = "ip"
@@ -48,7 +54,7 @@ resource "aws_alb_target_group" "internal" {
   }
 }
 
-resource "aws_alb_target_group" "main" {
+resource "aws_lb_target_group" "main" {
   name                 = local.prefix
   protocol             = "HTTP"
   target_type          = "ip"

--- a/infrastructure/loadtesting/terraform/ecs.tf
+++ b/infrastructure/loadtesting/terraform/ecs.tf
@@ -12,19 +12,19 @@ resource "aws_ecs_service" "fleet" {
   launch_type                        = "FARGATE"
   cluster                            = aws_ecs_cluster.fleet.id
   task_definition                    = aws_ecs_task_definition.backend.arn
-  desired_count                      = var.scale_down ? 0 : 10
+  desired_count                      = 10
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 30
 
   load_balancer {
-    target_group_arn = aws_alb_target_group.internal.arn
+    target_group_arn = aws_lb_target_group.internal.arn
     container_name   = "fleet"
     container_port   = 8080
   }
 
   load_balancer {
-    target_group_arn = aws_alb_target_group.main.arn
+    target_group_arn = aws_lb_target_group.main.arn
     container_name   = "fleet"
     container_port   = 8080
   }
@@ -280,8 +280,8 @@ resource "aws_ecs_task_definition" "migration" {
 }
 
 resource "aws_appautoscaling_target" "ecs_target" {
-  max_capacity       = var.scale_down ? 0 : 10
-  min_capacity       = var.scale_down ? 0 : 10
+  max_capacity       = 10
+  min_capacity       = 10
   resource_id        = "service/${aws_ecs_cluster.fleet.name}/${aws_ecs_service.fleet.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"

--- a/infrastructure/loadtesting/terraform/loadtesting.tf
+++ b/infrastructure/loadtesting/terraform/loadtesting.tf
@@ -3,7 +3,7 @@ resource "aws_ecs_service" "loadtest" {
   launch_type                        = "FARGATE"
   cluster                            = aws_ecs_cluster.fleet.id
   task_definition                    = aws_ecs_task_definition.loadtest.arn
-  desired_count                      = var.scale_down ? 0 : var.loadtest_containers
+  desired_count                      = var.loadtest_containers
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
 
@@ -52,7 +52,7 @@ resource "aws_ecs_task_definition" "loadtest" {
           "go", "run", "/go/fleet/cmd/osquery-perf/agent.go",
           "-enroll_secret", data.aws_secretsmanager_secret_version.enroll_secret.secret_string,
           "-host_count", "5000",
-          "-server_url", "http://${data.terraform_remote_state.shared.outputs.alb-internal.dns_name}",
+          "-server_url", "http://${aws_lb.internal.dns_name}",
           "-node_key_file", "nodekeys",
           "--policy_pass_prob", "0.5",
           "--start_period", "5m",

--- a/infrastructure/loadtesting/terraform/rds.tf
+++ b/infrastructure/loadtesting/terraform/rds.tf
@@ -43,10 +43,10 @@ module "aurora_mysql" { #tfsec:ignore:aws-rds-enable-performance-insights-encryp
   create_security_group  = true
   allowed_cidr_blocks    = data.terraform_remote_state.shared.outputs.vpc.private_subnets_cidr_blocks
 
-  replica_count         = var.scale_down ? 0 : 1
+  replica_count         = 1
   replica_scale_enabled = true
-  replica_scale_min     = var.scale_down ? 0 : 1
-  replica_scale_max     = var.scale_down ? 0 : 3
+  replica_scale_min     = 1
+  replica_scale_max     = 1
   snapshot_identifier   = "arn:aws:rds:us-east-2:917007347864:cluster-snapshot:cleaned"
 
   monitoring_interval           = 60

--- a/infrastructure/loadtesting/terraform/shared/alb.tf
+++ b/infrastructure/loadtesting/terraform/shared/alb.tf
@@ -41,31 +41,6 @@ resource "aws_alb_listener" "http" {
   }
 }
 
-resource "aws_alb" "internal" {
-  name                       = "fleetdm-internal"
-  internal                   = true
-  security_groups            = [aws_security_group.lb.id]
-  subnets                    = module.vpc.private_subnets
-  idle_timeout               = 600
-  drop_invalid_header_fields = true
-  #checkov:skip=CKV_AWS_150:don't like it
-}
-
-resource "aws_alb_listener" "https-fleetdm-internal" {
-  load_balancer_arn = aws_alb.internal.arn
-  port              = 80
-  protocol          = "HTTP" #tfsec:ignore:aws-elb-http-not-used
-
-  default_action {
-    type = "fixed-response"
-    fixed_response {
-      content_type = "text/plain"
-      message_body = "moved to subdomains, try https://default.loadtesting.fleetdm.com"
-      status_code  = "404"
-    }
-  }
-}
-
 # Security group for the public internet facing load balancer
 resource "aws_security_group" "lb" {
   name        = "${local.prefix} load balancer"

--- a/infrastructure/loadtesting/terraform/shared/output.tf
+++ b/infrastructure/loadtesting/terraform/shared/output.tf
@@ -6,16 +6,8 @@ output "alb" {
   value = aws_alb.main
 }
 
-output "alb-internal" {
-  value = aws_alb.internal
-}
-
 output "alb-listener" {
   value = aws_alb_listener.https-fleetdm
-}
-
-output "alb-listener-internal" {
-  value = aws_alb_listener.https-fleetdm-internal
 }
 
 output "vpc" {

--- a/infrastructure/loadtesting/terraform/variables.tf
+++ b/infrastructure/loadtesting/terraform/variables.tf
@@ -8,12 +8,6 @@ variable "fleet_config" {
   default     = {}
 }
 
-variable "scale_down" {
-  description = "Whether to scale down the environment"
-  type        = bool
-  default     = false
-}
-
 variable "loadtest_containers" {
   description = "The number of containers to loadtest with"
   type        = number


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [ ] Documented any permissions changes
- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
