### PR TITLE
document how to run dlv in headless mode and connect to the Redis CLI

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -62,6 +62,14 @@
             ]
         },
         {
+            "name": "Attach to a running Fleet server",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "port": 61179,
+            "host": "127.0.0.1",
+        },
+        {
             "type": "pwa-chrome",
             "name": "Fleet UI (Chrome)",
             "request": "launch",

--- a/docs/Contributing/Building-Fleet.md
+++ b/docs/Contributing/Building-Fleet.md
@@ -175,4 +175,35 @@ dlv debug --build-flags '-tags=full' ./cmd/fleet -- serve --dev
 
 It is important to pass the `-tags=full` build flag, otherwise the server will not have access to the asset files.
 
+### Attaching a debugger to a running server
+
+You can also run delve in headless mode, which allows you to attach your preferred debugger client and reuse the same session without having to restart the server:
+
+```
+dlv debug --build-flags '-tags=full' --headless \
+  --api-version=2 --accept-multiclient --continue \
+  --listen=127.0.0.1:61179 ./cmd/fleet -- serve --dev
+```
+
+- If you're using Visual Studio Code, there's a launch configuration in the repo.
+- If you're using vim with `vimspector`, you can use the following config:
+
+```
+{
+  "configurations": {
+    "Go: Attach to Fleet server": {
+      "adapter": "multi-session",
+      "variables": {
+        "port": 61179,
+        "host": "127.0.0.1"
+      },
+      "configuration": {
+        "request": "attach",
+        "mode": "remote"
+      }
+    }
+  }
+}
+```
+
 <meta name="pageOrderInSection" value="100">

--- a/docs/Contributing/Testing.md
+++ b/docs/Contributing/Testing.md
@@ -9,6 +9,7 @@
 - [Database backup/restore](#database-backuprestore)
 - [Seeding Data](./Seeding-Data.md)
 - [MySQL shell](#mysql-shell)
+- [Redis REPL](#redis-repl)
 - [Testing SSO](#testing-sso)
 - [Testing Kinesis Logging](#testing-kinesis-logging)
 
@@ -265,6 +266,14 @@ To connect via Docker:
 
 ```
 docker-compose exec mysql mysql -uroot -ptoor -Dfleet
+```
+
+## Redis REPL
+
+Connect to the `redis-cli` in REPL mode to view and interact directly with the contents stored in Redis.
+
+```
+docker-compose exec redis redis-cli
 ```
 
 ## Testing SSO


### PR DESCRIPTION
This adds two small changes to the contributing docs:

1. Instructions to connect to a local Redis REPL
2. Instructions to start `dlv` in headless mode and attach debuggers to it. I modified `.vscode/launch.json` with a new launch debug config and added instructions for vim.