### PR TITLE
[DO NOT MERGE] Disable last_opened_at ingestion if testing not completed for release

### DIFF
--- a/changes/issue-2316-add-osquery-min-last-opened-at-config
+++ b/changes/issue-2316-add-osquery-min-last-opened-at-config
@@ -1,1 +1,0 @@
-* Add the `osquery.min_software_last_opened_at_diff` configuration option.

--- a/changes/issue-2316-expose-last-opened-at-software
+++ b/changes/issue-2316-expose-last-opened-at-software
@@ -1,1 +1,0 @@
-* Expose the "last opened at" information about software on the host details API endpoint (macOS only).

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -1197,19 +1197,6 @@ Applies only when `osquery_enable_async_host_processing` is enabled. Order of ma
   	async_host_redis_scan_keys_count: 100
   ```
 
-##### osquery_min_software_last_opened_at_diff
-
-The minimum time difference between the software's "last opened at" timestamp reported by osquery and the last timestamp saved for that software on that host helps minimize the number of updates required when a host reports its installed software information, resulting in less load on the database. If there is no existing timestamp for the software on that host (or if the software was not installed on that host previously), the new timestamp is automatically saved.
-
-- Default value: 1h
-- Environment variable: `FLEET_OSQUERY_MIN_SOFTWARE_LAST_OPENED_AT_DIFF`
-- Config file format:
-
-  ```
-  osquery:
-  	min_software_last_opened_at_diff: 4h
-  ```
-
 ##### Example YAML
 
 ```yaml

--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -1956,7 +1956,6 @@ If the scheduled queries haven't run on the host yet, the stats have zero values
         "version": "1.0",
         "source": "apps",
         "bundle_identifier": "com.some.app",
-        "last_opened_at": "2021-08-18T21:14:00Z",
         "generated_cpe": "",
         "vulnerabilities": null
       }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -126,7 +126,7 @@ type OsqueryConfig struct {
 	AsyncHostUpdateBatch             int           `yaml:"async_host_update_batch"`
 	AsyncHostRedisPopCount           int           `yaml:"async_host_redis_pop_count"`
 	AsyncHostRedisScanKeysCount      int           `yaml:"async_host_redis_scan_keys_count"`
-	MinSoftwareLastOpenedAtDiff      time.Duration `yaml:"min_software_last_opened_at_diff"`
+	//MinSoftwareLastOpenedAtDiff      time.Duration `yaml:"min_software_last_opened_at_diff"`
 }
 
 // LoggingConfig defines configs related to logging
@@ -466,8 +466,8 @@ func (man Manager) addConfigs() {
 		"Batch size to pop items from redis in async collection")
 	man.addConfigInt("osquery.async_host_redis_scan_keys_count", 1000,
 		"Batch size to scan redis keys in async collection")
-	man.addConfigDuration("osquery.min_software_last_opened_at_diff", 1*time.Hour,
-		"Minimum time difference of the software's last opened timestamp (compared to the last one saved) to trigger an update to the database")
+	//man.addConfigDuration("osquery.min_software_last_opened_at_diff", 1*time.Hour,
+	//	"Minimum time difference of the software's last opened timestamp (compared to the last one saved) to trigger an update to the database")
 
 	// Logging
 	man.addConfigBool("logging.debug", false,
@@ -685,7 +685,7 @@ func (man Manager) LoadConfig() FleetConfig {
 			AsyncHostUpdateBatch:             man.getConfigInt("osquery.async_host_update_batch"),
 			AsyncHostRedisPopCount:           man.getConfigInt("osquery.async_host_redis_pop_count"),
 			AsyncHostRedisScanKeysCount:      man.getConfigInt("osquery.async_host_redis_scan_keys_count"),
-			MinSoftwareLastOpenedAtDiff:      man.getConfigDuration("osquery.min_software_last_opened_at_diff"),
+			//MinSoftwareLastOpenedAtDiff:      man.getConfigDuration("osquery.min_software_last_opened_at_diff"),
 		},
 		Logging: LoggingConfig{
 			Debug:                man.getConfigBool("logging.debug"),

--- a/server/datastore/mysql/config.go
+++ b/server/datastore/mysql/config.go
@@ -71,7 +71,7 @@ func TracingEnabled(lconfig *config.LoggingConfig) DBOption {
 // that must be used in the datastore layer can be captured here.
 func WithFleetConfig(conf *config.FleetConfig) DBOption {
 	return func(o *dbOptions) error {
-		o.minLastOpenedAtDiff = conf.Osquery.MinSoftwareLastOpenedAtDiff
+		//o.minLastOpenedAtDiff = conf.Osquery.MinSoftwareLastOpenedAtDiff
 		return nil
 	}
 }

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -716,19 +716,21 @@ func directIngestSoftware(ctx context.Context, logger log.Logger, host *fleet.Ho
 		}
 
 		var lastOpenedAt time.Time
-		if lastOpenedRaw := row["last_opened_at"]; lastOpenedRaw != "" {
-			if lastOpenedEpoch, err := strconv.ParseFloat(lastOpenedRaw, 64); err != nil {
-				level.Debug(logger).Log(
-					"msg", "host reported software with invalid last opened timestamp",
-					"host", host.Hostname,
-					"version", version,
-					"name", name,
-					"last_opened_at", lastOpenedRaw,
-				)
-			} else if lastOpenedEpoch > 0 {
-				lastOpenedAt = time.Unix(int64(lastOpenedEpoch), 0).UTC()
+		/*
+			if lastOpenedRaw := row["last_opened_at"]; lastOpenedRaw != "" {
+				if lastOpenedEpoch, err := strconv.ParseFloat(lastOpenedRaw, 64); err != nil {
+					level.Debug(logger).Log(
+						"msg", "host reported software with invalid last opened timestamp",
+						"host", host.Hostname,
+						"version", version,
+						"name", name,
+						"last_opened_at", lastOpenedRaw,
+					)
+				} else if lastOpenedEpoch > 0 {
+					lastOpenedAt = time.Unix(int64(lastOpenedEpoch), 0).UTC()
+				}
 			}
-		}
+		*/
 
 		s := fleet.Software{
 			Name:             name,


### PR DESCRIPTION
Disables the minimum amount of code and documentation to remove the `last_opened_at` software information in case the load testing cannot be completed in time for the release or the performance degradation is too important.

This removes the ingestion of the `last_opened_at` timestamp (so it will always be NULL in the table, so never returned in the payload either), and the mention of that new field in the documentation and changes file, as well as the new configuration option for the minimum `last_opened_at` diff interval.

Waiting for Wed May 4th to decide whether we merge this (disabling the feature) or we ship the feature.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] ~~Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).~~
- [ ] ~~Documented any API changes (docs/Using-Fleet/REST-API.md)~~
- [ ] ~~Documented any permissions changes~~
- [ ] ~~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~~
- [ ] ~~Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~~
- [ ] ~~Added/updated tests~~
- [ ] ~~Manual QA for all new/changed functionality~~
