### PR TITLE
Omit empty device mapping from host responses where optional `device_mapping` param is missing

### DIFF
--- a/cmd/fleetctl/testdata/expectedHostDetailResponseJson.json
+++ b/cmd/fleetctl/testdata/expectedHostDetailResponseJson.json
@@ -80,7 +80,6 @@
       }
     ],
     "status": "mia",
-    "device_mapping": null,
     "display_text": "test_host"
   }
 }

--- a/cmd/fleetctl/testdata/expectedHostDetailResponseYaml.yml
+++ b/cmd/fleetctl/testdata/expectedHostDetailResponseYaml.yml
@@ -12,7 +12,6 @@ spec:
   cpu_type: ""
   created_at: "0001-01-01T00:00:00Z"
   detail_updated_at: "0001-01-01T00:00:00Z"
-  device_mapping: null
   display_text: test_host
   distributed_interval: 0
   gigs_disk_space_available: 0

--- a/cmd/fleetctl/testdata/expectedListHostsJson.json
+++ b/cmd/fleetctl/testdata/expectedListHostsJson.json
@@ -55,7 +55,6 @@
       "failing_policies_count":0
     },
     "status":"mia",
-    "device_mapping":null,
     "display_text":"test_host"
   }
 }
@@ -108,7 +107,6 @@
       "failing_policies_count":0
     },
     "status":"mia",
-    "device_mapping":null,
     "display_text":"test_host2"
   }
 }

--- a/cmd/fleetctl/testdata/expectedListHostsYaml.yml
+++ b/cmd/fleetctl/testdata/expectedListHostsYaml.yml
@@ -17,7 +17,6 @@ spec:
   cpu_type: ""
   created_at: "0001-01-01T00:00:00Z"
   detail_updated_at: "0001-01-01T00:00:00Z"
-  device_mapping: null
   display_text: test_host
   distributed_interval: 0
   gigs_disk_space_available: 0
@@ -67,7 +66,6 @@ spec:
   cpu_type: ""
   created_at: "0001-01-01T00:00:00Z"
   detail_updated_at: "0001-01-01T00:00:00Z"
-  device_mapping: null
   display_text: test_host2
   distributed_interval: 0
   gigs_disk_space_available: 0

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -384,7 +384,7 @@ func (ds *Datastore) ListHosts(ctx context.Context, filter fleet.TeamFilter, opt
 
 	if opt.DeviceMapping {
 		sql += `, 
-			dm.device_mapping
+			COALESCE(dm.device_mapping, 'null') as device_mapping
 		`
 	}
 

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -131,7 +131,7 @@ type Host struct {
 
 	HostIssues `json:"issues,omitempty" csv:"-"`
 
-	DeviceMapping *json.RawMessage `json:"device_mapping" db:"device_mapping" csv:"device_mapping"`
+	DeviceMapping *json.RawMessage `json:"device_mapping,omitempty" db:"device_mapping" csv:"device_mapping"`
 }
 
 type HostIssues struct {


### PR DESCRIPTION
Fix for QA [comment](https://github.com/fleetdm/fleet/issues/4746#issuecomment-1116248361)

# Checklist for submitter
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
