### PR TITLE
Website: Ignore top level gitignore when deploying

### DIFF
--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -52,7 +52,7 @@ jobs:
     # > And, as a change to the top-level fleetdm/fleet .gitignore on May 2, 2022 revealed,
     # > we also need to delete the top level .gitignore file too, so that its rules don't
     # > interfere with the committing and force-pushing we're doing as part of our deploy
-    # > script here.  For more info, see: TODO
+    # > script here.  For more info, see: https://github.com/fleetdm/fleet/pull/5549
     - run: rm -f .gitignore
 
     # Download dependencies (including dev deps)

--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -49,6 +49,11 @@ jobs:
     # > Turns out there's a similar issue with how eslint plugins are looked up, so we
     # > delete the top level .eslintrc file too.
     - run: rm -f .eslintrc.js
+    # > And, as a change to the top-level fleetdm/fleet .gitignore on May 2, 2022 revealed,
+    # > we also need to delete the top level .gitignore file too, so that its rules don't
+    # > interfere with the committing and force-pushing we're doing as part of our deploy
+    # > script here.  For more info, see: TODO
+    - run: rm -f .gitignore
 
     # Download dependencies (including dev deps)
     - run: cd website/ && npm install


### PR DESCRIPTION
Website: Ignore top level gitignore when deploying

See https://github.com/fleetdm/confidential/issues/1204 for more background on this and the pasted conversation.

(Next time, we will make it public.  Just moving too fast and didn't want to paste any credentials that may have been included in the conversation.)