### PR TITLE
E2e testing: Fix attached DOM issues

### DIFF
--- a/cypress/integration/all/app/queryflow.spec.ts
+++ b/cypress/integration/all/app/queryflow.spec.ts
@@ -88,7 +88,11 @@ describe("Query flow (seeded)", () => {
       cy.findByText(/query updated/i).should("be.visible");
     });
     it("saves an existing query as new query", () => {
-      cy.getAttached(".name__cell .button--text-link").eq(1).click();
+      cy.getAttached(".name__cell .button--text-link")
+        .eq(1)
+        .within(() => {
+          cy.findByText(/get authorized/i).click();
+        });
       cy.findByText(/run query/i).should("exist");
       cy.getAttached(".ace_scroller")
         .click()

--- a/cypress/integration/premium/admin.spec.ts
+++ b/cypress/integration/premium/admin.spec.ts
@@ -636,7 +636,11 @@ describe("Premium tier - Global Admin user", () => {
       });
       // Access the Settings - Team details page
       cy.getAttached("tbody").within(() => {
-        cy.findByText(/apples/i).click();
+        cy.getAttached(".name__cell .button--text-link")
+          .eq(0)
+          .within(() => {
+            cy.findByText(/apples/i).click();
+          });
       });
       cy.findByText(/apples/i).should("exist");
       cy.findByText(/manage users with global access here/i).should("exist");

--- a/cypress/integration/premium/team_admin.spec.ts
+++ b/cypress/integration/premium/team_admin.spec.ts
@@ -237,6 +237,7 @@ describe("Premium tier - Team Admin user", () => {
       cy.findByText(/advanced/i).should("not.exist");
     });
     it("creates a new team scheduled query", () => {
+      cy.getAttached(".no-schedule__cta-buttons").should("exist");
       cy.getAttached(".no-schedule__schedule-button").click();
       cy.getAttached(".schedule-editor-modal__form").within(() => {
         cy.findByText(/select query/i).click();
@@ -271,6 +272,8 @@ describe("Premium tier - Team Admin user", () => {
           cy.findByText(/6 hours/i).should("exist");
           cy.getAttached(".Select-placeholder").within(() => {
             cy.findByText(/action/i).click();
+          });
+          cy.getAttached(".Select-menu").within(() => {
             cy.findByText(/remove/i).click();
           });
         });

--- a/cypress/integration/premium/team_admin.spec.ts
+++ b/cypress/integration/premium/team_admin.spec.ts
@@ -269,8 +269,10 @@ describe("Premium tier - Team Admin user", () => {
         .should("have.length", 1)
         .within(() => {
           cy.findByText(/6 hours/i).should("exist");
-          cy.findByText(/action/i).click();
-          cy.findByText(/remove/i).click();
+          cy.getAttached(".Select-placeholder").within(() => {
+            cy.findByText(/action/i).click();
+            cy.findByText(/remove/i).click();
+          });
         });
       cy.getAttached(".remove-scheduled-query-modal .modal-cta-wrap").within(
         () => {

--- a/cypress/integration/premium/team_admin.spec.ts
+++ b/cypress/integration/premium/team_admin.spec.ts
@@ -249,6 +249,7 @@ describe("Premium tier - Team Admin user", () => {
       cy.findByText(/successfully added/i).should("be.visible");
     });
     it("edit a team's scheduled query successfully", () => {
+      cy.getAttached(".manage-schedule-page");
       cy.getAttached("tbody>tr")
         .should("have.length", 1)
         .within(() => {
@@ -266,6 +267,7 @@ describe("Premium tier - Team Admin user", () => {
       cy.findByText(/successfully updated/i).should("be.visible");
     });
     it("remove a team's scheduled query successfully", () => {
+      cy.getAttached(".manage-schedule-page");
       cy.getAttached("tbody>tr")
         .should("have.length", 1)
         .within(() => {

--- a/cypress/integration/premium/team_maintainer_observer.spec.ts
+++ b/cypress/integration/premium/team_maintainer_observer.spec.ts
@@ -204,7 +204,7 @@ describe("Premium tier - Team observer/maintainer user", () => {
       cy.visit("/hosts/manage");
     });
     describe("Manage hosts page", () => {
-      it.only("should render elements according to role-based access controls", () => {
+      it("should render elements according to role-based access controls", () => {
         // Hosts table includes teams column
         cy.getAttached(".data-table__table th")
           .contains("Team")

--- a/cypress/integration/premium/team_maintainer_observer.spec.ts
+++ b/cypress/integration/premium/team_maintainer_observer.spec.ts
@@ -251,10 +251,10 @@ describe("Premium tier - Team observer/maintainer user", () => {
       it("should render elements according to role-based access controls", () => {
         cy.visit("/schedule/manage");
         cy.contains(/oranges/i).should("exist");
-        cy.contains(/advanced/i).should("not.exist");
         cy.getAttached(".no-schedule__cta-buttons").within(() => {
-          cy.findByRole("button", { name: /schedule a query/i }).click();
+          cy.contains(/advanced/i).should("not.exist");
         });
+        cy.getAttached(".no-schedule__schedule-button").click();
         // Schedule a query on maintaining team
         cy.getAttached(".schedule-editor-modal__form").within(() => {
           cy.findByText(/select query/i).click();

--- a/cypress/integration/premium/team_maintainer_observer.spec.ts
+++ b/cypress/integration/premium/team_maintainer_observer.spec.ts
@@ -204,7 +204,7 @@ describe("Premium tier - Team observer/maintainer user", () => {
       cy.visit("/hosts/manage");
     });
     describe("Manage hosts page", () => {
-      it("should render elements according to role-based access controls", () => {
+      it.only("should render elements according to role-based access controls", () => {
         // Hosts table includes teams column
         cy.getAttached(".data-table__table th")
           .contains("Team")
@@ -215,6 +215,9 @@ describe("Premium tier - Team observer/maintainer user", () => {
         cy.getAttached(".manage-hosts__header").within(() => {
           cy.contains("Apples").click({ force: true });
           cy.contains("Oranges").click({ force: true });
+        });
+        cy.getAttached(".team_name__cell").within(() => {
+          cy.findByText(/oranges/i).should("exist");
         });
         cy.contains(/oranges/i);
         cy.getAttached(".button-wrap")

--- a/cypress/integration/premium/team_maintainer_observer.spec.ts
+++ b/cypress/integration/premium/team_maintainer_observer.spec.ts
@@ -219,7 +219,6 @@ describe("Premium tier - Team observer/maintainer user", () => {
         cy.getAttached(".team_name__cell").within(() => {
           cy.findByText(/oranges/i).should("exist");
         });
-        cy.contains(/oranges/i);
         cy.getAttached(".button-wrap")
           .contains("button", /add hosts/i)
           .click();

--- a/cypress/integration/premium/teamflow.spec.ts
+++ b/cypress/integration/premium/teamflow.spec.ts
@@ -4,6 +4,7 @@ describe("Teams flow (empty)", () => {
     cy.setup();
     cy.loginWithCySession();
     cy.viewport(1200, 660);
+    cy.seedQueries();
   });
   after(() => {
     cy.logout();
@@ -87,7 +88,6 @@ describe("Teams flow (seeded)", () => {
     beforeEach(() => {
       cy.loginWithCySession();
       cy.visit("/schedule/manage");
-      cy.seedQueries();
     });
     it("adds a query to team schedule", () => {
       cy.getAttached(".manage-schedule-page__header").within(() => {

--- a/cypress/integration/premium/teamflow.spec.ts
+++ b/cypress/integration/premium/teamflow.spec.ts
@@ -4,7 +4,6 @@ describe("Teams flow (empty)", () => {
     cy.setup();
     cy.loginWithCySession();
     cy.viewport(1200, 660);
-    cy.seedQueries();
   });
   after(() => {
     cy.logout();
@@ -87,6 +86,7 @@ describe("Teams flow (seeded)", () => {
   describe("Manage schedules page", () => {
     beforeEach(() => {
       cy.loginWithCySession();
+      cy.seedQueries();
       cy.visit("/schedule/manage");
     });
     it("adds a query to team schedule", () => {


### PR DESCRIPTION
Cerra #5552 

_queryflow.spec.ts_
- ensure table's text link is in DOM before clicking

_premium/admin.spec.ts_
- ensure table's text link is in DOM before clicking

_team_admin.spec.ts_
-  ensure "Action" dropdown and "Remove" option is in DOM before clicking
- ensure "Schedule a query" schedule button is in DOM before clicking
- ensure Manage schedule page loads before looking for table in DOM

_team_maintainer_observer.ts_
- ensure manage host page switches teams and tables before looking for team Oranges in DOM 
- ensure "Schedule a query" schedule button is in DOM before clicking

_premium/teamflow.spec.ts_
- seedQueries before going to the schedules page to ensure that queries are flowed into modal and ready to be scheduled in modal

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- no change file for dev only e2e tests
- [x] Manual QA for all new/changed functionality
