### PR TITLE
Run network test serially to prevent timeouts on Github CI

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -61,8 +61,7 @@ jobs:
 
     - name: Run Go Tests
       run: |
-        # Changing below values to test if the PR helps with the flaky tests.
-        TEST_LOCK_FILE_PATH=$(pwd)/lock NETWORK_TEST=1 REDIS_TEST=1 MYSQL_TEST=1 RACE_ENABLED=true GO_TEST_TIMEOUT=1h make test-go
+        TEST_LOCK_FILE_PATH=$(pwd)/lock NETWORK_TEST=1 REDIS_TEST=1 MYSQL_TEST=1 RACE_ENABLED=$RACE_ENABLED GO_TEST_TIMEOUT=$GO_TEST_TIMEOUT make test-go
 
     - name: Upload to Codecov
       uses: codecov/codecov-action@e3c560433a6cc60aec8812599b7844a7b4fa0d71

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -61,7 +61,8 @@ jobs:
 
     - name: Run Go Tests
       run: |
-        NETWORK_TEST=1 REDIS_TEST=1 MYSQL_TEST=1 RACE_ENABLED=$RACE_ENABLED GO_TEST_TIMEOUT=$GO_TEST_TIMEOUT make test-go
+        # Changing below values to test if the PR helps with the flaky tests.
+        NETWORK_TEST=1 REDIS_TEST=1 MYSQL_TEST=1 RACE_ENABLED=true GO_TEST_TIMEOUT=1h make test-go
 
     - name: Upload to Codecov
       uses: codecov/codecov-action@e3c560433a6cc60aec8812599b7844a7b4fa0d71

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -62,7 +62,7 @@ jobs:
     - name: Run Go Tests
       run: |
         # Changing below values to test if the PR helps with the flaky tests.
-        NETWORK_TEST=1 REDIS_TEST=1 MYSQL_TEST=1 RACE_ENABLED=true GO_TEST_TIMEOUT=1h make test-go
+        TEST_LOCK_FILE_PATH=$(pwd)/lock NETWORK_TEST=1 REDIS_TEST=1 MYSQL_TEST=1 RACE_ENABLED=true GO_TEST_TIMEOUT=1h make test-go
 
     - name: Upload to Codecov
       uses: codecov/codecov-action@e3c560433a6cc60aec8812599b7844a7b4fa0d71

--- a/cmd/fleetctl/get_test.go
+++ b/cmd/fleetctl/get_test.go
@@ -605,7 +605,7 @@ spec:
 	})
 }
 
-func TestGetSoftawre(t *testing.T) {
+func TestGetSoftware(t *testing.T) {
 	_, ds := runServerWithMockedDS(t)
 
 	foo001 := fleet.Software{

--- a/cmd/fleetctl/package_test.go
+++ b/cmd/fleetctl/package_test.go
@@ -9,13 +9,12 @@ import (
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/packaging"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/update"
+	"github.com/fleetdm/fleet/v4/pkg/nettest"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPackage(t *testing.T) {
-	if os.Getenv("NETWORK_TEST") == "" {
-		t.Skip("set environment variable NETWORK_TEST=1 to run")
-	}
+	nettest.RunSerial(t)
 
 	updateOpt := update.DefaultOptions
 	updateOpt.RootDirectory = t.TempDir()
@@ -35,7 +34,7 @@ func TestPackage(t *testing.T) {
 	// Test invalid PEM file provided in --fleet-certificate.
 	certDir := t.TempDir()
 	fleetCertificate := filepath.Join(certDir, "fleet.pem")
-	err = ioutil.WriteFile(fleetCertificate, []byte("undefined"), os.FileMode(0644))
+	err = ioutil.WriteFile(fleetCertificate, []byte("undefined"), os.FileMode(0o644))
 	require.NoError(t, err)
 	runAppCheckErr(t, []string{"package", "--type=deb", fmt.Sprintf("--fleet-certificate=%s", fleetCertificate)}, fmt.Sprintf("failed to read certificate %q: invalid PEM file", fleetCertificate))
 

--- a/cmd/fleetctl/package_test.go
+++ b/cmd/fleetctl/package_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestPackage(t *testing.T) {
-	nettest.RunSerial(t)
+	nettest.Run(t)
 
 	updateOpt := update.DefaultOptions
 	updateOpt.RootDirectory = t.TempDir()
@@ -39,14 +39,14 @@ func TestPackage(t *testing.T) {
 	runAppCheckErr(t, []string{"package", "--type=deb", fmt.Sprintf("--fleet-certificate=%s", fleetCertificate)}, fmt.Sprintf("failed to read certificate %q: invalid PEM file", fleetCertificate))
 
 	t.Run("deb", func(t *testing.T) {
-		runAppForTest(t, []string{"package", "--type=deb", "--insecure"})
+		runAppForTest(t, []string{"package", "--type=deb", "--insecure", "--disable-open-folder"})
 		info, err := os.Stat(fmt.Sprintf("fleet-osquery_%s_amd64.deb", updatesData.OrbitVersion))
 		require.NoError(t, err)
 		require.Greater(t, info.Size(), int64(0)) // TODO verify contents
 	})
 
 	t.Run("rpm", func(t *testing.T) {
-		runAppForTest(t, []string{"package", "--type=rpm", "--insecure"})
+		runAppForTest(t, []string{"package", "--type=rpm", "--insecure", "--disable-open-folder"})
 		info, err := os.Stat(fmt.Sprintf("fleet-osquery-%s.x86_64.rpm", updatesData.OrbitVersion))
 		require.NoError(t, err)
 		require.Greater(t, info.Size(), int64(0)) // TODO verify contents

--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -40,6 +40,7 @@ const (
 	updateURL               = "update-url"
 	updateRootKeys          = "update-roots"
 	stdQueryLibFilePath     = "std-query-lib-file-path"
+	disableOpenBrowser      = "disable-open-browser"
 )
 
 func previewCommand() *cli.Command {
@@ -101,6 +102,10 @@ Use the stop and reset subcommands to manage the server and dependencies once st
 				Name:  stdQueryLibFilePath,
 				Usage: "Use custom standard query library yml file",
 				Value: "",
+			},
+			&cli.BoolFlag{
+				Name:  disableOpenBrowser,
+				Usage: "Disable opening the browser",
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -297,8 +302,10 @@ Use the stop and reset subcommands to manage the server and dependencies once st
 					return fmt.Errorf("wait for current host: %w", err)
 				}
 
-				if err := open.Browser("http://localhost:1337/previewlogin"); err != nil {
-					fmt.Println("Automatic browser open failed. Please navigate to http://localhost:1337/previewlogin.")
+				if !c.Bool(disableOpenBrowser) {
+					if err := open.Browser("http://localhost:1337/previewlogin"); err != nil {
+						fmt.Println("Automatic browser open failed. Please navigate to http://localhost:1337/previewlogin.")
+					}
 				}
 
 				fmt.Println("Starting simulated Linux hosts...")
@@ -314,8 +321,10 @@ Use the stop and reset subcommands to manage the server and dependencies once st
 					return errors.New("Failed to run docker-compose")
 				}
 			} else {
-				if err := open.Browser("http://localhost:1337/previewlogin"); err != nil {
-					fmt.Println("Automatic browser open failed. Please navigate to http://localhost:1337/previewlogin.")
+				if !c.Bool(disableOpenBrowser) {
+					if err := open.Browser("http://localhost:1337/previewlogin"); err != nil {
+						fmt.Println("Automatic browser open failed. Please navigate to http://localhost:1337/previewlogin.")
+					}
 				}
 			}
 

--- a/cmd/fleetctl/preview_test.go
+++ b/cmd/fleetctl/preview_test.go
@@ -7,13 +7,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/fleetdm/fleet/v4/pkg/nettest"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPreview(t *testing.T) {
-	if os.Getenv("NETWORK_TEST") == "" {
-		t.Skip("set environment variable NETWORK_TEST=1 to run")
-	}
+	nettest.RunSerial(t)
 
 	os.Setenv("FLEET_SERVER_ADDRESS", "https://localhost:8412")
 	testOverridePreviewDirectory = t.TempDir()

--- a/cmd/fleetctl/preview_test.go
+++ b/cmd/fleetctl/preview_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPreview(t *testing.T) {
-	nettest.RunSerial(t)
+	nettest.Run(t)
 
 	os.Setenv("FLEET_SERVER_ADDRESS", "https://localhost:8412")
 	testOverridePreviewDirectory = t.TempDir()
@@ -23,7 +23,7 @@ func TestPreview(t *testing.T) {
 		require.Equal(t, "", runAppForTest(t, []string{"preview", "--config", configPath, "stop"}))
 	})
 
-	output := runAppForTest(t, []string{"preview", "--config", configPath, "--tag", "main"})
+	output := runAppForTest(t, []string{"preview", "--config", configPath, "--tag", "main", "--disable-open-browser"})
 
 	queriesRe := regexp.MustCompile(`applied ([0-9]+) queries`)
 	policiesRe := regexp.MustCompile(`applied ([0-9]+) policies`)

--- a/cmd/fleetctl/vulnerability_data_stream_test.go
+++ b/cmd/fleetctl/vulnerability_data_stream_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestVulnerabilityDataStream(t *testing.T) {
-	nettest.RunSerial(t)
+	nettest.Run(t)
 
 	runAppCheckErr(t, []string{"vulnerability-data-stream"}, "No directory provided")
 

--- a/cmd/fleetctl/vulnerability_data_stream_test.go
+++ b/cmd/fleetctl/vulnerability_data_stream_test.go
@@ -7,14 +7,13 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/fleetdm/fleet/v4/pkg/nettest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestVulnerabilityDataStream(t *testing.T) {
-	if os.Getenv("NETWORK_TEST") == "" {
-		t.Skip("set environment variable NETWORK_TEST=1 to run")
-	}
+	nettest.RunSerial(t)
 
 	runAppCheckErr(t, []string{"vulnerability-data-stream"}, "No directory provided")
 

--- a/pkg/nettest/nettest.go
+++ b/pkg/nettest/nettest.go
@@ -60,7 +60,8 @@ func Retryable(err error) bool {
 			return true
 		}
 	}
-	// https://github.com/golang/go/blob/a5d61be040ed20b5774bff1b6b578c6d393ab332/src/net/http/serve_test.go
+	// Using the exact same error check used in:
+	// https://github.com/golang/go/blob/a5d61be040ed20b5774bff1b6b578c6d393ab332/src/net/http/serve_test.go#L1417
 	if errStr := err.Error(); strings.Contains(errStr, "timeout") && strings.Contains(errStr, "TLS handshake") {
 		return true
 	}

--- a/pkg/nettest/nettest.go
+++ b/pkg/nettest/nettest.go
@@ -1,0 +1,30 @@
+// Package nettest provides functionality to run tests that access the public network.
+package nettest
+
+import (
+	"os"
+	"sync"
+	"testing"
+)
+
+var m sync.Mutex
+
+func runSerial(t *testing.T) {
+	m.Lock()
+	t.Logf("network test start: %s", t.Name())
+
+	t.Cleanup(func() {
+		t.Logf("network test done: %s", t.Name())
+		m.Unlock()
+	})
+}
+
+// RunSerial makes sure a caller test runs serially (accross packages).
+func RunSerial(t *testing.T) {
+	if os.Getenv("NETWORK_TEST") == "" {
+		t.Skip("set environment variable NETWORK_TEST=1 to run")
+		return
+	}
+
+	runSerial(t)
+}

--- a/server/vulnerabilities/cpe_test.go
+++ b/server/vulnerabilities/cpe_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dnaeon/go-vcr/v2/recorder"
 	"github.com/facebookincubator/nvdtools/cpedict"
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
+	"github.com/fleetdm/fleet/v4/pkg/nettest"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
@@ -54,9 +55,7 @@ func TestCpeFromSoftware(t *testing.T) {
 }
 
 func TestSyncCPEDatabase(t *testing.T) {
-	if os.Getenv("NETWORK_TEST") == "" {
-		t.Skip("set environment variable NETWORK_TEST=1 to run")
-	}
+	nettest.RunSerial(t)
 
 	client := fleethttp.NewClient()
 	// Disabling vcr because the resulting file exceeds the 100mb limit for github
@@ -102,7 +101,7 @@ func TestSyncCPEDatabase(t *testing.T) {
 	require.Error(t, err)
 
 	// and we make the db older than the release
-	newTime := time.Date(2000, 01, 01, 01, 01, 01, 01, time.UTC)
+	newTime := time.Date(2000, 0o1, 0o1, 0o1, 0o1, 0o1, 0o1, time.UTC)
 	err = os.Chtimes(dbPath, newTime, newTime)
 	require.NoError(t, err)
 
@@ -155,9 +154,7 @@ func (f *fakeSoftwareIterator) Err() error   { return nil }
 func (f *fakeSoftwareIterator) Close() error { f.closed = true; return nil }
 
 func TestTranslateSoftwareToCPE(t *testing.T) {
-	if os.Getenv("NETWORK_TEST") == "" {
-		t.Skip("set environment variable NETWORK_TEST=1 to run")
-	}
+	nettest.RunSerial(t)
 
 	tempDir, err := os.MkdirTemp(os.TempDir(), "TestTranslateSoftwareToCPE-*")
 	require.NoError(t, err)

--- a/server/vulnerabilities/cpe_test.go
+++ b/server/vulnerabilities/cpe_test.go
@@ -101,7 +101,7 @@ func TestSyncCPEDatabase(t *testing.T) {
 	require.Error(t, err)
 
 	// and we make the db older than the release
-	newTime := time.Date(2000, 0o1, 0o1, 0o1, 0o1, 0o1, 0o1, time.UTC)
+	newTime := time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC)
 	err = os.Chtimes(dbPath, newTime, newTime)
 	require.NoError(t, err)
 

--- a/server/vulnerabilities/cpe_test.go
+++ b/server/vulnerabilities/cpe_test.go
@@ -55,7 +55,7 @@ func TestCpeFromSoftware(t *testing.T) {
 }
 
 func TestSyncCPEDatabase(t *testing.T) {
-	nettest.RunSerial(t)
+	nettest.Run(t)
 
 	client := fleethttp.NewClient()
 	// Disabling vcr because the resulting file exceeds the 100mb limit for github
@@ -154,7 +154,7 @@ func (f *fakeSoftwareIterator) Err() error   { return nil }
 func (f *fakeSoftwareIterator) Close() error { f.closed = true; return nil }
 
 func TestTranslateSoftwareToCPE(t *testing.T) {
-	nettest.RunSerial(t)
+	nettest.Run(t)
 
 	tempDir, err := os.MkdirTemp(os.TempDir(), "TestTranslateSoftwareToCPE-*")
 	require.NoError(t, err)

--- a/server/vulnerabilities/cve.go
+++ b/server/vulnerabilities/cve.go
@@ -48,7 +48,12 @@ func SyncCVEData(vulnPath string, config config.FleetConfig) error {
 		LocalDir: vulnPath,
 	}
 
-	ctx, cancelFunc := context.WithTimeout(context.Background(), 5*time.Minute)
+	syncTimeout := 5 * time.Minute
+	if os.Getenv("NETWORK_TEST") != "" {
+		syncTimeout = 10 * time.Minute
+	}
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), syncTimeout)
 	defer cancelFunc()
 
 	return dfs.Do(ctx)
@@ -138,7 +143,6 @@ func checkCVEs(
 	recentVulns map[string][]string,
 	recentVulnMaxAge time.Duration,
 ) error {
-
 	dict, err := cvefeed.LoadJSONDictionary(file)
 	if err != nil {
 		return err

--- a/server/vulnerabilities/cve_test.go
+++ b/server/vulnerabilities/cve_test.go
@@ -109,7 +109,7 @@ func TestTranslateCPEToCVE(t *testing.T) {
 		curlCPE := "cpe:2.3:a:haxx:curl:-:*:*:*:*:*:*:*"
 
 		// consider recent vulnerabilities to be anything published in 2018
-		theClock = clock.NewMockClock(time.Date(2019, 0o1, 0o1, 0, 0, 0, 0, time.UTC))
+		theClock = clock.NewMockClock(time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC))
 		defer func() { theClock = clock.C }()
 
 		safeDS := &threadSafeDSMock{Store: ds}

--- a/server/vulnerabilities/cve_test.go
+++ b/server/vulnerabilities/cve_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/WatchBeam/clock"
+	"github.com/fleetdm/fleet/v4/pkg/nettest"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	kitlog "github.com/go-kit/kit/log"
@@ -61,9 +62,7 @@ func (d *threadSafeDSMock) InsertCVEForCPE(ctx context.Context, cve string, cpes
 }
 
 func TestTranslateCPEToCVE(t *testing.T) {
-	if os.Getenv("NETWORK_TEST") == "" {
-		t.Skip("set environment variable NETWORK_TEST=1 to run")
-	}
+	nettest.RunSerial(t)
 
 	tempDir := t.TempDir()
 
@@ -110,7 +109,7 @@ func TestTranslateCPEToCVE(t *testing.T) {
 		curlCPE := "cpe:2.3:a:haxx:curl:-:*:*:*:*:*:*:*"
 
 		// consider recent vulnerabilities to be anything published in 2018
-		theClock = clock.NewMockClock(time.Date(2019, 01, 01, 0, 0, 0, 0, time.UTC))
+		theClock = clock.NewMockClock(time.Date(2019, 0o1, 0o1, 0, 0, 0, 0, time.UTC))
 		defer func() { theClock = clock.C }()
 
 		safeDS := &threadSafeDSMock{Store: ds}

--- a/server/vulnerabilities/cve_test.go
+++ b/server/vulnerabilities/cve_test.go
@@ -62,7 +62,7 @@ func (d *threadSafeDSMock) InsertCVEForCPE(ctx context.Context, cve string, cpes
 }
 
 func TestTranslateCPEToCVE(t *testing.T) {
-	nettest.RunSerial(t)
+	nettest.Run(t)
 
 	tempDir := t.TempDir()
 
@@ -93,8 +93,14 @@ func TestTranslateCPEToCVE(t *testing.T) {
 				return 0, nil
 			}
 
-			_, err := TranslateCPEToCVE(ctx, ds, tempDir, kitlog.NewLogfmtLogger(os.Stdout), cfg, false)
-			require.NoError(t, err)
+			for {
+				_, err := TranslateCPEToCVE(ctx, ds, tempDir, kitlog.NewLogfmtLogger(os.Stdout), cfg, false)
+				if err != nil && nettest.Retryable(err) {
+					continue
+				}
+				require.NoError(t, err)
+				break
+			}
 
 			printMemUsage()
 

--- a/server/vulnerabilities/vuln_centos/centos_test.go
+++ b/server/vulnerabilities/vuln_centos/centos_test.go
@@ -49,7 +49,7 @@ func TestCentOSPkgSetAdd(t *testing.T) {
 }
 
 func TestParseCentOSRepository(t *testing.T) {
-	nettest.RunSerial(t)
+	nettest.Run(t)
 
 	// Parse a subset of the CentOS repository.
 	pkgs, err := ParseCentOSRepository(WithRoot("/centos/7/os/x86_64/repodata/"))

--- a/server/vulnerabilities/vuln_centos/centos_test.go
+++ b/server/vulnerabilities/vuln_centos/centos_test.go
@@ -3,9 +3,9 @@ package vuln_centos
 import (
 	"context"
 	"database/sql"
-	"os"
 	"testing"
 
+	"github.com/fleetdm/fleet/v4/pkg/nettest"
 	"github.com/go-kit/kit/log"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/require"
@@ -49,9 +49,7 @@ func TestCentOSPkgSetAdd(t *testing.T) {
 }
 
 func TestParseCentOSRepository(t *testing.T) {
-	if os.Getenv("NETWORK_TEST") == "" {
-		t.Skip("set environment variable NETWORK_TEST=1 to run")
-	}
+	nettest.RunSerial(t)
 
 	// Parse a subset of the CentOS repository.
 	pkgs, err := ParseCentOSRepository(WithRoot("/centos/7/os/x86_64/repodata/"))


### PR DESCRIPTION
https://github.com/fleetdm/fleet/actions/runs/2267683784 is basically failing almost every day (with network errors being the cause):

Some samples:
```
--- FAIL: TestVulnerabilityDataStream (333.52s)
    testing_utils.go:58: 
        	Error Trace:	testing_utils.go:58
        	            				vulnerability_data_stream_test.go:28
        	Error:      	Received unexpected error:
        	            	1 synchronisation error:
        	            		context deadline exceeded
        	Test:       	TestVulnerabilityDataStream
```
```
--- FAIL: TestVulnerabilityDataStream (278.52s)
    testing_utils.go:58: 
            Error Trace:    testing_utils.go:58
                                        vulnerability_data_stream_test.go:28
            Error:          Received unexpected error:
                            1 synchronisation error:
                                unexpected EOF
            Test:           TestVulnerabilityDataStream

```
```
--- FAIL: TestTranslateCPEToCVE (300.02s)
    cve_test.go:76: 
            Error Trace:    cve_test.go:76
            Error:          Received unexpected error:
                            1 synchronisation error:
                                context deadline exceeded
            Test:           TestTranslateCPEToCVE
```
```
--- FAIL: TestTranslateCPEToCVE (15.16s)
    cve_test.go:76: 
            Error Trace:    cve_test.go:76
            Error:          Received unexpected error:
                            1 synchronisation error:
                                Get "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2002.meta": net/http: TLS handshake timeout
            Test:           TestTranslateCPEToCVE
```

This PR attempts to run them serially (go test is invoked with `go test [...] ./cmd/... ./ee/... ./orbit/... ./pkg/... ./server/... ./tools/...`, and tests from different packages are run in parallel).