### PR TITLE
fix schema dump and migrations

### DIFF
--- a/server/datastore/mysql/migrations/tables/20210927143116_AddBundleIdentifierColumn.go
+++ b/server/datastore/mysql/migrations/tables/20210927143116_AddBundleIdentifierColumn.go
@@ -10,19 +10,6 @@ func init() {
 	MigrationClient.AddMigration(Up_20210927143116, Down_20210927143116)
 }
 
-func columnExists(tx *sql.Tx, table, column string) bool {
-	var count int
-	err := tx.QueryRow(
-		`SELECT count(*) FROM information_schema.columns WHERE COLUMN_NAME = ? AND table_name = ? LIMIT 1;`,
-		column, table,
-	).Scan(&count)
-	if err != nil {
-		return false
-	}
-
-	return count == 1
-}
-
 func Up_20210927143116(tx *sql.Tx) error {
 	if columnExists(tx, "software", "bundle_identifier") {
 		return nil

--- a/server/datastore/mysql/migrations/tables/migration.go
+++ b/server/datastore/mysql/migrations/tables/migration.go
@@ -1,7 +1,33 @@
 package tables
 
-import "github.com/fleetdm/goose"
+import (
+	"database/sql"
+
+	"github.com/fleetdm/goose"
+)
 
 var (
 	MigrationClient = goose.New("migration_status_tables", goose.MySqlDialect{})
 )
+
+func columnExists(tx *sql.Tx, table, column string) bool {
+	var count int
+	err := tx.QueryRow(
+		`
+SELECT
+    count(*)
+FROM
+    information_schema.columns
+WHERE
+    TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = ?
+    AND COLUMN_NAME = ?
+`,
+		table, column,
+	).Scan(&count)
+	if err != nil {
+		return false
+	}
+
+	return count > 0
+}


### PR DESCRIPTION
This fixes an issue where migrations were not being applied properly, and led to an invalid schema dump generation. When checking if the column exists, we should make sure that we check the schema for the currently selected database.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] ~Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).~
- [ ] ~Documented any API changes (docs/Using-Fleet/REST-API.md)~
- [ ] ~Documented any permissions changes~
- [ ] ~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
- [ ] ~Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [ ] ~Added/updated tests~
- [ ] ~Manual QA for all new/changed functionality~
