### PR TITLE
Integrations Page: Remove edit integration from UI, Render duplicate error message, Unique integration naming convention

### DIFF
--- a/changes/issue-5565-sunset-edit-integration
+++ b/changes/issue-5565-sunset-edit-integration
@@ -1,0 +1,1 @@
+* Remove the ability to edit a Jira integration as integrations fields are unique to each integration

--- a/cypress/integration/all/app/settingsflow.spec.ts
+++ b/cypress/integration/all/app/settingsflow.spec.ts
@@ -174,35 +174,6 @@ const createConfig = {
   },
 };
 
-const editConfig = {
-  ...getConfig,
-  integrations: {
-    jira: [
-      {
-        url: "https://fleetdm.atlassian.com",
-        username: "jira1@example.com",
-        api_token: "jira123",
-        project_key: "PROJECT 1",
-        enable_software_vulnerabilities: false,
-      },
-      {
-        url: "https://fleetdm.atlassian.com",
-        username: "jira0@example.com",
-        api_token: "jira0123",
-        project_key: "PROJECT 0",
-        enable_software_vulnerabilities: false,
-      },
-      {
-        url: "https://fleetdm.atlassian.com",
-        username: "jira3@example.com",
-        api_token: "jira123",
-        project_key: "PROJECT 3",
-        enable_software_vulnerabilities: false,
-      },
-    ],
-  },
-};
-
 const deleteConfig = {
   ...getConfig,
   integrations: {
@@ -562,51 +533,6 @@ describe("App settings flow", () => {
       cy.wait("@getIntegrations").then((configStub) => {
         cy.log(JSON.stringify(configStub));
         console.log(JSON.stringify(configStub));
-      });
-    });
-    it("edits jira integration", () => {
-      cy.getAttached("tbody>tr")
-        .should("have.length", 3)
-        .eq(1)
-        .within(() => {
-          cy.findByText(/action/i).click();
-          cy.findByText(/edit/i).click();
-        });
-      cy.findByLabelText(/jira site url/i)
-        .clear()
-        .type("https://fleetdm.atlassian.com");
-      cy.findByLabelText(/jira username/i)
-        .clear()
-        .type("jira0@example.com");
-      cy.findByLabelText(/jira api token/i)
-        .clear()
-        .type("jira0123");
-      cy.findByLabelText(/jira project key/i)
-        .clear()
-        .type("PROJECT 0");
-      cy.intercept("PATCH", "/api/latest/fleet/config", editConfig).as(
-        "editIntegration"
-      );
-      cy.intercept("GET", "/api/latest/fleet/config", editConfig).as(
-        "editedIntegration"
-      );
-      cy.getAttached(".integration-form__btn-wrap")
-        .contains("button", /save/i)
-        .click();
-      cy.wait("@editIntegration").then((configStub) => {
-        cy.log(JSON.stringify(configStub));
-        console.log(JSON.stringify(configStub));
-      });
-      cy.wait("@editedIntegration").then((configStub) => {
-        cy.log(JSON.stringify(configStub));
-        console.log(JSON.stringify(configStub));
-        cy.findByText(/successfully edited/i).should("exist");
-        cy.getAttached("tbody>tr")
-          .should("have.length", 3)
-          .eq(0)
-          .within(() => {
-            cy.findByText(/fleetdm.atlassian.com - project 0/i).should("exist");
-          });
       });
     });
     it("deletes jira integration", () => {

--- a/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
@@ -143,6 +143,12 @@ const IntegrationsPage = (): JSX.Element => {
                   jiraIntegrationSubmitData[
                     jiraIntegrationSubmitData.length - 1
                   ].url
+                }{" "}
+                -{" "}
+                {
+                  jiraIntegrationSubmitData[
+                    jiraIntegrationSubmitData.length - 1
+                  ].project_key
                 }
               </b>
             </>
@@ -154,11 +160,36 @@ const IntegrationsPage = (): JSX.Element => {
         .catch((createError: { data: IApiError }) => {
           if (createError.data.message.includes("Validation Failed")) {
             renderFlash("error", VALIDATION_FAILED_ERROR);
-          }
-          if (createError.data.message.includes("Bad request")) {
-            renderFlash("error", BAD_REQUEST_ERROR);
-          }
-          if (createError.data.message.includes("Unknown Error")) {
+          } else if (createError.data.message.includes("Bad request")) {
+            if (
+              createError.data.errors[0].reason.includes(
+                "duplicate Jira integration for project key"
+              )
+            ) {
+              renderFlash(
+                "error",
+                <>
+                  Could not add add{" "}
+                  <b>
+                    {
+                      jiraIntegrationSubmitData[
+                        jiraIntegrationSubmitData.length - 1
+                      ].url
+                    }{" "}
+                    -{" "}
+                    {
+                      jiraIntegrationSubmitData[
+                        jiraIntegrationSubmitData.length - 1
+                      ].project_key
+                    }
+                  </b>
+                  . This integration already exists
+                </>
+              );
+            } else {
+              renderFlash("error", BAD_REQUEST_ERROR);
+            }
+          } else if (createError.data.message.includes("Unknown Error")) {
             renderFlash("error", UNKNOWN_ERROR);
           } else {
             renderFlash(
@@ -194,7 +225,10 @@ const IntegrationsPage = (): JSX.Element => {
           renderFlash(
             "success",
             <>
-              Successfully deleted <b>{integrationEditing.url}</b>
+              Successfully deleted{" "}
+              <b>
+                {integrationEditing.url} - {integrationEditing.project_key}
+              </b>
             </>
           );
           refetchIntegrations();
@@ -203,8 +237,11 @@ const IntegrationsPage = (): JSX.Element => {
           renderFlash(
             "error",
             <>
-              Could not delete <b>{integrationEditing.url}</b>. Please try
-              again.
+              Could not delete{" "}
+              <b>
+                {integrationEditing.url} - {integrationEditing.project_key}
+              </b>
+              . Please try again.
             </>
           );
         })
@@ -226,7 +263,11 @@ const IntegrationsPage = (): JSX.Element => {
               <>
                 Successfully edited{" "}
                 <b>
-                  {jiraIntegrationSubmitData[integrationEditing?.index].url}
+                  {jiraIntegrationSubmitData[integrationEditing?.index].url} -{" "}
+                  {
+                    jiraIntegrationSubmitData[integrationEditing?.index]
+                      .project_key
+                  }
                 </b>
               </>
             );
@@ -248,8 +289,12 @@ const IntegrationsPage = (): JSX.Element => {
               renderFlash(
                 "error",
                 <>
-                  Could not edit <b>{integrationEditing?.url}</b>. Please try
-                  again.
+                  Could not edit{" "}
+                  <b>
+                    {integrationEditing?.url} -{" "}
+                    {integrationEditing?.project_key}
+                  </b>
+                  . Please try again.
                 </>
               );
             }
@@ -356,6 +401,7 @@ const IntegrationsPage = (): JSX.Element => {
           onCancel={toggleDeleteIntegrationModal}
           onSubmit={onDeleteSubmit}
           url={integrationEditing?.url || ""}
+          projectKey={integrationEditing?.project_key || ""}
         />
       )}
       {showEditIntegrationModal && (

--- a/frontend/pages/admin/IntegrationsPage/IntegrationsTableConfig.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationsTableConfig.tsx
@@ -101,11 +101,6 @@ const generateTableHeaders = (
 const generateActionDropdownOptions = (): IDropdownOption[] => {
   return [
     {
-      label: "Edit",
-      disabled: false,
-      value: "edit",
-    },
-    {
       label: "Delete",
       disabled: false,
       value: "delete",

--- a/frontend/pages/admin/IntegrationsPage/components/DeleteIntegrationModal/DeleteIntegrationModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/components/DeleteIntegrationModal/DeleteIntegrationModal.tsx
@@ -7,12 +7,14 @@ const baseClass = "delete-integration-modal";
 
 interface IDeleteIntegrationModalProps {
   url: string;
+  projectKey: string;
   onSubmit: () => void;
   onCancel: () => void;
 }
 
 const DeleteIntegrationModal = ({
   url,
+  projectKey,
   onSubmit,
   onCancel,
 }: IDeleteIntegrationModalProps): JSX.Element => {
@@ -34,7 +36,10 @@ const DeleteIntegrationModal = ({
       <form className={`${baseClass}__form`}>
         <p>
           This action will delete the{" "}
-          <span className={`${baseClass}__url`}>{url}</span> integration.
+          <span className={`${baseClass}__url`}>
+            {url} - {projectKey}
+          </span>{" "}
+          integration.
         </p>
         <p>The automations that use this integration will be turned off.</p>
         <div className="modal-cta-wrap">


### PR DESCRIPTION
Cerra #5565 
Cerra #5352

Conversation around editing led to the realization that edit integration feature isn't helpful to our users as most of the fields are unique to the specific integration, so editing is unnecessary. That uniqueness makes it difficult to edit the integration instead of deleting a current integration and creating a new one.

**4.14 bug fixes originally part of larger Zendesk ticket that won't be merged in until 4.15**

- Fixes error with edit integration by removing it all together (Hidden in UI, code is left in the frontend in case we eventually find a user need to edit an integration (with Jira, Zendesk, etc...))
- Render duplicate error flash message for 4.14 backend duplicate validation 
- Fix bug if/else logic rendering wrong error message (was if, if, if/else instead of if/else if/ else if/ else)
- Fix naming convention in UI to be unique (URL is not unique, URL - Project key is unique)


Screenshots:
Remove editing
<img width="1216" alt="Screen Shot 2022-05-04 at 5 34 52 PM" src="https://user-images.githubusercontent.com/71795832/166829773-d5830e38-347c-44d8-ac4f-dd8d3dd2daa7.png">
Delete modal wording is unique with URL - Project key
<img width="1388" alt="Screen Shot 2022-05-06 at 9 57 37 AM" src="https://user-images.githubusercontent.com/71795832/167148671-779bea56-9aff-4539-821d-3cce359fe553.png">
Delete flash message wording is unique with URL - Project key
<img width="1384" alt="Screen Shot 2022-05-06 at 9 57 48 AM" src="https://user-images.githubusercontent.com/71795832/167148667-c4d4e729-c742-4f48-bd47-0d7adbd308db.png">
Add flash message wording is unique with URL - Project key
<img width="1381" alt="Screen Shot 2022-05-06 at 9 57 26 AM" src="https://user-images.githubusercontent.com/71795832/167148673-da086a1a-4628-4b82-a0f0-70a46f826a7f.png">
New Add flash message error for duplicate error
<img width="1385" alt="Screen Shot 2022-05-06 at 9 54 18 AM" src="https://user-images.githubusercontent.com/71795832/167148680-1008bd33-7aea-4d23-85a2-f7c9aa971b7b.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
