### PR TITLE
Website: fix article images height on safari

### DIFF
--- a/website/assets/styles/pages/articles/basic-article.less
+++ b/website/assets/styles/pages/articles/basic-article.less
@@ -39,7 +39,8 @@
     img {
       max-width: 100%;
       width: auto;
-      height: 100%;
+      height: auto;
+      max-height: 100%;
       margin-left: auto;
       margin-right: auto;
       padding: 24px 0px 40px 0px;


### PR DESCRIPTION
Changes:
- Updated images on article pages to use `height: auto` 