### PR TITLE
Handbook: Digital Experience Slack channels

### DIFF
--- a/handbook/brand.md
+++ b/handbook/brand.md
@@ -245,12 +245,12 @@ These groups maintain the following [Slack channels](https://fleetdm.com/handboo
 
 | Slack channel               | [DRI](https://fleetdm.com/handbook/company#group-slack-channels)    |
 |:----------------------------|:--------------------------------------------------------------------|
-| `#g-digital-experience`     | Mike Thomas
+| `#g-digital-experience`     | Mike Thomas and Eric Shaw _(multiple DRIs, for the sake of timezones)_
 | `#oooh-websites`            | Mike Thomas
 | `#oooh-automation`          | Mike McNeil
-| `#g-people`                 | Eric Shaw
-| `#help-onboarding`          | Eric Shaw
-| `#help-finance`             | Eric Shaw
+| `#g-people`                 | Charlie Chance
+| `#help-onboarding`          | Charlie Chance
+| `#help-finance`             | Nathan Holliday
 | `#help-brex-memos`          | Nathan Holliday
 
 


### PR DESCRIPTION
This changes which channels Nathan, Charlie, and Eric are responsible for.