### PR TITLE
Create integration UI: FE validation for https protocol

### DIFF
--- a/changes/issue-5437-validate-https-jira
+++ b/changes/issue-5437-validate-https-jira
@@ -1,0 +1,1 @@
+* Jira integration UI validates URL protocol to use https

--- a/frontend/pages/admin/IntegrationsPage/components/IntegrationForm/IntegrationForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/components/IntegrationForm/IntegrationForm.tsx
@@ -39,11 +39,22 @@ const IntegrationForm = ({
     enableSoftwareVulnerabilities:
       integrationEditing?.enable_software_vulnerabilities || false,
   });
+  const [urlError, setUrlError] = useState<string | null>(null);
 
   const { url, username, apiToken, projectKey } = formData;
 
   const onInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });
+  };
+
+  const validateForm = () => {
+    let error = null;
+
+    if (url.slice(0, 8) !== "https://") {
+      error = "URL must begin with https://";
+    }
+
+    setUrlError(error);
   };
 
   // IntegrationForm component can be used to create a new jira integration or edit an existing jira integration so submitData will be assembled accordingly
@@ -94,6 +105,8 @@ const IntegrationForm = ({
         placeholder="https://jira.example.com"
         parseTarget
         value={url}
+        error={urlError}
+        onBlur={validateForm}
       />
       <InputField
         name="username"
@@ -139,6 +152,7 @@ const IntegrationForm = ({
           data-tip-disable={
             !(
               formData.url === "" ||
+              formData.url.slice(0, 8) !== "https://" ||
               formData.username === "" ||
               formData.apiToken === "" ||
               formData.projectKey === ""
@@ -151,6 +165,7 @@ const IntegrationForm = ({
             variant="brand"
             disabled={
               formData.url === "" ||
+              formData.url.slice(0, 8) !== "https://" ||
               formData.username === "" ||
               formData.apiToken === "" ||
               formData.projectKey === ""


### PR DESCRIPTION
Cerra #5437 

- URL must begin with https:// in order to create an integration

<img width="1218" alt="Screen Shot 2022-05-05 at 11 03 22 AM" src="https://user-images.githubusercontent.com/71795832/166953448-977333f9-e25d-4d2b-a34a-95614a02ddaa.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
