### PR TITLE
improve messaging of fleetctl debug errors and archive commands

### DIFF
--- a/changes/issue-5504-improve-debug-output
+++ b/changes/issue-5504-improve-debug-output
@@ -1,0 +1,1 @@
+* Improve the output of `fleetclt debug errors` and add the ability to print the errors to stdout via the `-stdout` flag.

--- a/cmd/fleetctl/debug.go
+++ b/cmd/fleetctl/debug.go
@@ -22,6 +22,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var nowFn = time.Now
+
 func debugCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "debug",
@@ -58,7 +60,11 @@ func writeFile(filename string, bytes []byte, mode os.FileMode) error {
 }
 
 func outfileName(name string) string {
-	return fmt.Sprintf("fleet-%s-%s", name, time.Now().Format(time.RFC3339))
+	return fmt.Sprintf("fleet-%s-%s", name, nowFn().Format(time.RFC3339))
+}
+
+func outfileNameWithExt(name string, ext string) string {
+	return fmt.Sprintf("%s.%s", outfileName(name), ext)
 }
 
 func debugProfileCommand() *cli.Command {
@@ -285,11 +291,10 @@ func debugArchiveCommand() *cli.Command {
 				"db-process-list",
 			}
 
-			outpath := getOutfile(c)
-			if outpath == "" {
-				outpath = outfileName("profiles-archive")
+			outfile := getOutfile(c)
+			if outfile == "" {
+				outfile = outfileNameWithExt("profiles-archive", "tar.gz")
 			}
-			outfile := outpath + ".tar.gz"
 
 			f, err := secure.OpenFile(outfile, os.O_CREATE|os.O_WRONLY, defaultFileMode)
 			if err != nil {
@@ -334,7 +339,7 @@ func debugArchiveCommand() *cli.Command {
 
 				if err := tarwriter.WriteHeader(
 					&tar.Header{
-						Name: outpath + "/" + profile,
+						Name: outfile + "/" + profile,
 						Size: int64(len(res)),
 						Mode: defaultFileMode,
 					},

--- a/cmd/fleetctl/debug.go
+++ b/cmd/fleetctl/debug.go
@@ -347,7 +347,14 @@ func debugArchiveCommand() *cli.Command {
 				}
 			}
 
-			fmt.Fprintf(os.Stderr, "Archive written to %s\n", outfile)
+			fmt.Fprintf(os.Stderr, "################################################################################\n"+
+				"# WARNING:\n"+
+				"#   The files in the generated archive may contain sensitive data.\n"+
+				"#   Please redact them before sharing.\n"+
+				"#\n"+
+				"#   Archive written to: %s\n"+
+				"################################################################################\n",
+				outfile)
 
 			return nil
 		},

--- a/cmd/fleetctl/debug.go
+++ b/cmd/fleetctl/debug.go
@@ -356,7 +356,7 @@ func debugArchiveCommand() *cli.Command {
 			fmt.Fprintf(os.Stderr, "################################################################################\n"+
 				"# WARNING:\n"+
 				"#   The files in the generated archive may contain sensitive data.\n"+
-				"#   Please redact them before sharing.\n"+
+				"#   Please review them before sharing.\n"+
 				"#\n"+
 				"#   Archive written to: %s\n"+
 				"################################################################################\n",
@@ -585,7 +585,7 @@ func debugErrorsCommand() *cli.Command {
 				fmt.Fprintf(os.Stderr, "################################################################################\n"+
 					"# WARNING:\n"+
 					"#   The generated file may contain sensitive data.\n"+
-					"#   Please redact the file before sharing.\n"+
+					"#   Please review the file before sharing.\n"+
 					"#\n"+
 					"#   Output written to: %s\n"+
 					"################################################################################\n",

--- a/cmd/fleetctl/debug.go
+++ b/cmd/fleetctl/debug.go
@@ -542,6 +542,7 @@ func debugErrorsCommand() *cli.Command {
 			configFlag(),
 			contextFlag(),
 			debugFlag(),
+			stdoutFlag(),
 		},
 		Action: func(c *cli.Context) error {
 			fleet, err := clientFromCLI(c)

--- a/cmd/fleetctl/debug.go
+++ b/cmd/fleetctl/debug.go
@@ -22,6 +22,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// Defining here for testing purposes
 var nowFn = time.Now
 
 func debugCommand() *cli.Command {

--- a/cmd/fleetctl/debug.go
+++ b/cmd/fleetctl/debug.go
@@ -552,9 +552,18 @@ func debugErrorsCommand() *cli.Command {
 				return err
 			}
 			if err := f.Close(); err != nil {
+
 				return fmt.Errorf("write errors to file: %w", err)
 			}
-			fmt.Fprintf(os.Stderr, "Output written to %s\n", outfile)
+
+			fmt.Fprintf(os.Stderr, "################################################################################\n"+
+				"# WARNING:\n"+
+				"#   The generated file may contain sensitive data.\n"+
+				"#   Please redact the file before sharing.\n"+
+				"#\n"+
+				"#   Output written to: %s\n"+
+				"################################################################################\n",
+				outfile)
 
 			return nil
 		},

--- a/cmd/fleetctl/debug_test.go
+++ b/cmd/fleetctl/debug_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -199,4 +200,22 @@ func TestDebugResolveHostname(t *testing.T) {
 
 	err = resolveHostname(context.Background(), timeout, noSuchHost)
 	require.Error(t, err)
+}
+
+func TestFilenameFunctions(t *testing.T) {
+	nowFn = func() time.Time {
+		now, _ := time.Parse(time.RFC3339, "1969-06-19T21:44:05Z")
+		return now
+	}
+	defer func() { nowFn = time.Now }()
+
+	t.Run("outfileName builds a file name using the name provided + current time ", func(t *testing.T) {
+		name := outfileName("test")
+		assert.Equal(t, name, "fleet-test-1969-06-19T21:44:05Z")
+	})
+
+	t.Run("outfileNameWithExt builds a file name using the name and extension provided + current time ", func(t *testing.T) {
+		name := outfileNameWithExt("test", "go")
+		assert.Equal(t, name, "fleet-test-1969-06-19T21:44:05Z.go")
+	})
 }

--- a/cmd/fleetctl/flags.go
+++ b/cmd/fleetctl/flags.go
@@ -6,6 +6,7 @@ const (
 	outfileFlagName          = "outfile"
 	debugFlagName            = "debug"
 	fleetCertificateFlagName = "fleet-certificate"
+	stdoutFlagName           = "stdout"
 )
 
 func outfileFlag() cli.Flag {
@@ -43,4 +44,16 @@ func fleetCertificateFlag() cli.Flag {
 
 func getFleetCertificate(c *cli.Context) string {
 	return c.String(fleetCertificateFlagName)
+}
+
+func stdoutFlag() cli.Flag {
+	return &cli.BoolFlag{
+		Name:    stdoutFlagName,
+		EnvVars: []string{"STDOUT"},
+		Usage:   "Print contents to stdout",
+	}
+}
+
+func getStdout(c *cli.Context) bool {
+	return c.Bool(stdoutFlagName)
 }

--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -24,7 +24,6 @@ const (
 	jsonFlagName                = "json"
 	withQueriesFlagName         = "with-queries"
 	expiredFlagName             = "expired"
-	stdoutFlagName              = "stdout"
 	includeServerConfigFlagName = "include-server-config"
 )
 
@@ -753,10 +752,7 @@ func getCarveCommand() *cli.Command {
 		Name:  "carve",
 		Usage: "Retrieve details for a carve by ID",
 		Flags: []cli.Flag{
-			&cli.BoolFlag{
-				Name:  stdoutFlagName,
-				Usage: "Print carve contents to stdout",
-			},
+			stdoutFlag(),
 			configFlag(),
 			contextFlag(),
 			outfileFlag(),


### PR DESCRIPTION
Related to https://github.com/fleetdm/fleet/issues/5504, this PR attempts to improve the output of the `fleetctl debug errors` command by:

- Adding a warning message to redact sensitive data (not sure if the copy is on point)
- Adding a `json` extension to the output file
- Allowing to stream the output to stdout via the `-stdout` flag or the `STDOUT` env var

The output after this changes is:

```
~/projects/fleet $ ./build/fleetctl debug errors
################################################################################
# WARNING:
#   The generated file may contain sensitive data.
#   Please redact the file before sharing.
#
#   Output written to: fleet-errors-2022-05-05T12:46:42-03:00.json
################################################################################
```

I've also modified the output of `fleetctl debug archive`

```
################################################################################
# WARNING:
#   The files in the generated archive may contain sensitive data.
#   Please redact them before sharing.
#
#   Archive written to: fleet-profiles-archive-2022-05-05T12:46:59-03:00.tar.gz
################################################################################
```

I couldn't find tests for those commands and I think it's because the storage mechanism for the errors is a bit different than for the rest of the app, so we can't use some of the test helpers we have.

I'm open to adding base tests in this PR, but I thought it was better to submit this and tackle adding tests as part of #5507 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
