### PR TITLE
Integration page: Can update table to empty array

### DIFF
--- a/changes/issue-5563-remove-last-integration
+++ b/changes/issue-5563-remove-last-integration
@@ -1,0 +1,1 @@
+* Bug fix: Integrations page updates to 0 integrations when the last integration is removed

--- a/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
@@ -82,6 +82,8 @@ const IntegrationsPage = (): JSX.Element => {
             return { ...integration, index };
           });
           setIntegrationsIndexed(addIndex);
+        } else {
+          setIntegrationsIndexed([]);
         }
       },
     }
@@ -195,6 +197,7 @@ const IntegrationsPage = (): JSX.Element => {
               Successfully deleted <b>{integrationEditing.url}</b>
             </>
           );
+          refetchIntegrations();
         })
         .catch(() => {
           renderFlash(
@@ -206,7 +209,6 @@ const IntegrationsPage = (): JSX.Element => {
           );
         })
         .finally(() => {
-          refetchIntegrations();
           toggleDeleteIntegrationModal();
         });
     }


### PR DESCRIPTION
Cerra #5563 

- Fix: tableData wasn't being updated if there was an empty array after deletion


https://user-images.githubusercontent.com/71795832/166971632-7b6baa48-c7eb-4f3f-b2ae-dfad766486f1.mov


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
