### PR TITLE
Website: Disable caching of HTML to prevent issues with 404s to old bundles

### DIFF
--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -150,12 +150,12 @@ will be disabled and/or hidden in the UI.
               sails.log.info('Redirecting GET request from `'+req.hostname+'` to configured expected host (`'+configuredBaseHostname+'`)...');
               return res.redirect(sails.config.custom.baseUrl+req.url);
             }//•
-            
+
             // Prevent the browser from caching logged-in users' pages.
             // (including w/ the Chrome back button)
             // > • https://mixmax.com/blog/chrome-back-button-cache-no-store
             // > • https://madhatted.com/2013/6/16/you-do-not-understand-browser-history
-            // 
+            //
             // This also prevents an issue where webpages may be cached by browsers, and thus
             // reference an old bundle file (e.g. dist/production.min.js or dist/production.min.css),
             // which might have a different hash encoded in its filename.  This way, by preventing caching

--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -153,7 +153,7 @@ will be disabled and/or hidden in the UI.
 
             // No session? Proceed as usual.
             // (e.g. request for a static asset)
-            // Setting headers for production assets in the `/dist` folder to disable caching
+            // If the request is for production assets in the `/dist` folder, we'll set headers to disable caching.
             if (!req.session) {
               if(req.url.startsWith('/dist')) {
                 res.setHeader('Cache-Control', 'no-cache, no-store');

--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -150,14 +150,22 @@ will be disabled and/or hidden in the UI.
               sails.log.info('Redirecting GET request from `'+req.hostname+'` to configured expected host (`'+configuredBaseHostname+'`)...');
               return res.redirect(sails.config.custom.baseUrl+req.url);
             }//•
+            
+            // Prevent the browser from caching logged-in users' pages.
+            // (including w/ the Chrome back button)
+            // > • https://mixmax.com/blog/chrome-back-button-cache-no-store
+            // > • https://madhatted.com/2013/6/16/you-do-not-understand-browser-history
+            // 
+            // This also prevents an issue where webpages may be cached by browsers, and thus
+            // reference an old bundle file (e.g. dist/production.min.js or dist/production.min.css),
+            // which might have a different hash encoded in its filename.  This way, by preventing caching
+            // of the webpage itself, the HTML is always fresh, and thus always trying to load the latest,
+            // correct bundle files.
+            res.setHeader('Cache-Control', 'no-cache, no-store');
 
             // No session? Proceed as usual.
             // (e.g. request for a static asset)
-            // If the request is for production assets in the `/dist` folder, we'll set headers to disable caching.
             if (!req.session) {
-              if(req.url.startsWith('/dist')) {
-                res.setHeader('Cache-Control', 'no-cache, no-store');
-              }
               return next();
             }
 
@@ -238,12 +246,6 @@ will be disabled and/or hidden in the UI.
               res.locals.isEmailVerificationRequired = sails.config.custom.verifyEmailAddresses;
 
             }//ﬁ
-
-            // Prevent the browser from caching logged-in users' pages.
-            // (including w/ the Chrome back button)
-            // > • https://mixmax.com/blog/chrome-back-button-cache-no-store
-            // > • https://madhatted.com/2013/6/16/you-do-not-understand-browser-history
-            res.setHeader('Cache-Control', 'no-cache, no-store');
 
             return next();
           }

--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -153,7 +153,13 @@ will be disabled and/or hidden in the UI.
 
             // No session? Proceed as usual.
             // (e.g. request for a static asset)
-            if (!req.session) { return next(); }
+            // Setting headers for production assets in the `/dist` folder to disable caching
+            if (!req.session) {
+              if(req.url.startsWith('/dist')) {
+                res.setHeader('Cache-Control', 'no-cache, no-store');
+              }
+              return next();
+            }
 
             // Not logged in? Proceed as usual.
             if (!req.session.userId) { return next(); }


### PR DESCRIPTION
Changes:
 - Updated the custom hook to set the `Cache-Control` headers on files in the `/dist` folder to `no-cache, no-store`. 