### PR TITLE
UI bug fix: Mac details > Software tooltip shows correctly on hover

### DIFF
--- a/changes/issue-5469-fix-mac-software-tooltip
+++ b/changes/issue-5469-fix-mac-software-tooltip
@@ -1,0 +1,1 @@
+* Bundle identifier tooltip shows on mac details > software

--- a/frontend/components/TooltipWrapper/_styles.scss
+++ b/frontend/components/TooltipWrapper/_styles.scss
@@ -1,4 +1,5 @@
 .component__tooltip-wrapper {
+  display: inline-flex;
   position: relative;
   cursor: help;
 

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -67,7 +67,6 @@
       tbody {
         .name__cell,
         .version__cell {
-          overflow: hidden;
           white-space: nowrap;
           text-overflow: ellipsis;
         }


### PR DESCRIPTION
Cerra #5469 

Bug only on Mac hosts (bundle identifier tooltip)

- Not a `z-index` issue but a `overflow: hidden` issue
- Also fixed the white space to the right of the text not to trigger the tooltip

<img width="1314" alt="Screen Shot 2022-05-05 at 2 17 13 PM" src="https://user-images.githubusercontent.com/71795832/166993010-c58e7bd9-5b45-42c8-974c-6cff4a22ec4f.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
(QAd tooltip across app)
