### PR TITLE
App Settings Page: fix checkbox/dropdown validations

### DIFF
--- a/changes/issue-5595-settings-validated
+++ b/changes/issue-5595-settings-validated
@@ -1,0 +1,1 @@
+* Fix settings validations for checkboxes/dropdowns

--- a/frontend/pages/admin/AppSettingsPage/cards/Advanced/Advanced.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/Advanced/Advanced.tsx
@@ -42,10 +42,6 @@ const Advanced = ({
     setFormData({ ...formData, [name]: value });
   };
 
-  useEffect(() => {
-    validateForm();
-  }, [enableHostExpiry]);
-
   const validateForm = () => {
     const errors: IAppConfigFormErrors = {};
 
@@ -58,6 +54,10 @@ const Advanced = ({
 
     setFormErrors(errors);
   };
+
+  useEffect(() => {
+    validateForm();
+  }, [enableHostExpiry]);
 
   const onFormSubmit = (evt: React.MouseEvent<HTMLFormElement>) => {
     evt.preventDefault();

--- a/frontend/pages/admin/AppSettingsPage/cards/Advanced/Advanced.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/Advanced/Advanced.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
@@ -41,6 +41,10 @@ const Advanced = ({
   const handleInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });
   };
+
+  useEffect(() => {
+    validateForm();
+  }, [enableHostExpiry]);
 
   const validateForm = () => {
     const errors: IAppConfigFormErrors = {};

--- a/frontend/pages/admin/AppSettingsPage/cards/HostStatusWebhook/HostStatusWebhook.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/HostStatusWebhook/HostStatusWebhook.tsx
@@ -63,7 +63,6 @@ const HostStatusWebhook = ({
     setFormErrors(errors);
   };
 
-  // Validates forms when certain information is changed
   useEffect(() => {
     validateForm();
   }, [enableHostStatusWebhook]);

--- a/frontend/pages/admin/AppSettingsPage/cards/Smtp/Smtp.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/Smtp/Smtp.tsx
@@ -54,10 +54,6 @@ const Smtp = ({
     setFormData({ ...formData, [name]: value });
   };
 
-  useEffect(() => {
-    validateForm();
-  }, [smtpAuthenticationType]);
-
   const validateForm = () => {
     const errors: IAppConfigFormErrors = {};
 
@@ -91,6 +87,10 @@ const Smtp = ({
 
     setFormErrors(errors);
   };
+
+  useEffect(() => {
+    validateForm();
+  }, [smtpAuthenticationType]);
 
   const onFormSubmit = (evt: React.MouseEvent<HTMLFormElement>) => {
     evt.preventDefault();

--- a/frontend/pages/admin/AppSettingsPage/cards/Smtp/Smtp.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/Smtp/Smtp.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
@@ -53,6 +53,10 @@ const Smtp = ({
   const handleInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });
   };
+
+  useEffect(() => {
+    validateForm();
+  }, [smtpAuthenticationType]);
 
   const validateForm = () => {
     const errors: IAppConfigFormErrors = {};

--- a/frontend/pages/admin/AppSettingsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/Sso/Sso.tsx
@@ -43,10 +43,6 @@ const Sso = ({ appConfig, handleSubmit }: IAppConfigFormProps): JSX.Element => {
     setFormData({ ...formData, [name]: value });
   };
 
-  useEffect(() => {
-    validateForm();
-  }, [enableSSO]);
-
   const validateForm = () => {
     const errors: IAppConfigFormErrors = {};
 
@@ -74,6 +70,10 @@ const Sso = ({ appConfig, handleSubmit }: IAppConfigFormProps): JSX.Element => {
 
     setFormErrors(errors);
   };
+
+  useEffect(() => {
+    validateForm();
+  }, [enableSSO]);
 
   const onFormSubmit = (evt: React.MouseEvent<HTMLFormElement>) => {
     evt.preventDefault();

--- a/frontend/pages/admin/AppSettingsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/Sso/Sso.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
@@ -42,6 +42,10 @@ const Sso = ({ appConfig, handleSubmit }: IAppConfigFormProps): JSX.Element => {
   const handleInputChange = ({ name, value }: IFormField) => {
     setFormData({ ...formData, [name]: value });
   };
+
+  useEffect(() => {
+    validateForm();
+  }, [enableSSO]);
 
   const validateForm = () => {
     const errors: IAppConfigFormErrors = {};


### PR DESCRIPTION
Cerra #5595

Fix UI validations to only show when required, dropdown and checkboxes do not have onBlur, using useEffect to check for changes and run validateForm()

- SSO section: Fix enable SSO checkbox
- SMTP section: Fix enable SMTP checkbox, authentication type dropdown
- Advanced section: Fix enable host expiry checkbox

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
