### PR TITLE
Tool: `sails run freeze-open-pull-requests`

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -64,6 +64,8 @@ module.exports = {
 
     let GITHUB_USERNAME_OF_DRI_FOR_LABELS = 'noahtalerman';// « Used below (FUTURE: Remove this capability as Fleet has outgrown it.  2022-05-05)
 
+    let DRI_BY_PATH = sails.config.custom.githubRepoDRIByPath;// « used below
+
     if (!sails.config.custom.slackWebhookUrlForGithubBot) {
       throw new Error('No Slack webhook URL configured for the GitHub bot to notify with alerts!  (Please set `sails.config.custom.slackWebhookUrlForGithubBot`.)');
     }//•
@@ -207,37 +209,6 @@ module.exports = {
 
           let isSenderDRIForAllChangedPaths = false;
           let isSenderMaintainer = GITHUB_USERNAMES_OF_BOTS_AND_MAINTAINERS.includes(sender.login.toLowerCase());
-          let DRI_BY_PATH = {// « used below
-            'README.md': 'mike-j-thomas',// (github brandfront)
-
-            'handbook': ['desmi-dizney', 'mike-j-thomas', 'mikermcneil'],// (default for handbook)
-            'handbook/company.md': 'mikermcneil',
-            'handbook/people.md': ['eashaw', 'mike-j-thomas'],
-            'handbook/engineering.md': 'zwass',
-            'handbook/product.md': 'noahtalerman',
-            'handbook/security.md': 'guillaumeross',
-            'handbook/security-policies.md': 'guillaumeross',
-            'handbook/brand.md': 'mike-j-thomas',
-            'handbook/growth.md': 'timmy-k',
-            'handbook/customers.md': 'tgauda',
-            'handbook/community.md': ['dominuskelvin', 'ksatter'],
-            'handbook/README.md': '*',// (any fleetie can update this page and merge their change without waiting for their change to be approved)
-
-            'website': 'mikermcneil',// (default for website)
-            'website/views': 'eashaw',
-            'website/assets': 'eashaw',
-            'website/config/routes.js': ['eashaw', 'mike-j-thomas'],// (for managing website URLs)
-
-            'docs': 'zwass',// (default for docs)
-            'docs/images': ['noahtalerman', 'eashaw', 'mike-j-thomas'],
-            'docs/Using-Fleet/REST-API.md': 'lukeheath',
-            'docs/Contributing/API-for-contributors.md': 'lukeheath',
-            'docs/Deploying/FAQ.md': ['ksatter', 'dominuskelvin'],
-            'docs/Contributing/FAQ.md': ['ksatter', 'dominuskelvin'],
-            'docs/Using-Fleet/FAQ.md': ['ksatter', 'dominuskelvin'],
-
-            'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml': 'guillaumeross',// (standard query library)
-          };
 
           // [?] https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files
           let changedPaths = _.pluck(await sails.helpers.http.get(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files`, {

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -226,7 +226,7 @@ module.exports = {
           // [?] https://docs.github.com/en/rest/reference/pulls#create-a-review-for-a-pull-request
           await sails.helpers.http.post(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/reviews`, {
             event: 'REQUEST_CHANGES',
-            body: 'The repository is currently frozen for an upcoming release.  Please do not merge this change yet.  After the freeze has ended, please come back, edit your PR description, hit the spacebar a few times to make an arbitrary change, then save your PR.  You will then be able to merge your change!  In case of emergency, you can dismiss this review.'
+            body: 'The repository is currently frozen for an upcoming release.  \n> After the freeze has ended, please dismiss this review.  \n\nIn case of emergency, you can dismiss this review and merge now.'
           }, baseHeaders);
         }
 

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -67,8 +67,6 @@ module.exports = {
 
     let GITHUB_USERNAME_OF_DRI_FOR_LABELS = 'noahtalerman';// « Used below (FUTURE: Remove this capability as Fleet has outgrown it.  2022-05-05)
 
-    let DRI_BY_PATH = sails.config.custom.githubRepoDRIByPath;// « used below
-
     if (!sails.config.custom.slackWebhookUrlForGithubBot) {
       throw new Error('No Slack webhook URL configured for the GitHub bot to notify with alerts!  (Please set `sails.config.custom.slackWebhookUrlForGithubBot`.)');
     }//•

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -221,7 +221,7 @@ module.exports = {
             'handbook/growth.md': 'timmy-k',
             'handbook/customers.md': 'tgauda',
             'handbook/community.md': ['dominuskelvin', 'ksatter'],
-            'handbook/README.md': '*',// (any fleetie can update this page)
+            'handbook/README.md': '*',// (any fleetie can update this page and merge their change without waiting for their change to be approved)
 
             'website': 'mikermcneil',// (default for website)
             'website/views': 'eashaw',

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -288,34 +288,6 @@ module.exports = {
           }, baseHeaders);
         }
 
-        // And also unfreeze and re-freeze to temporarily allow merging.
-        // [?] https://github.com/fleetdm/fleet/issues/5179
-        // // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        // > Temporarily disable re-freeze logic to troubleshoot website caching issues on 2022-05-03.
-        // > (very unlikely this is a culprit, but ruling out race conditions)
-        // > ~mikermcneil
-        // // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        // if (isAutoApproved) {
-        //
-        //   let mergeFreezeReport = await sails.helpers.http.get('https://www.mergefreeze.com/api/branches/fleetdm/fleet/main', { access_token: sails.config.custom.mergeFreezeAccessToken });//eslint-disable-line camelcase
-        //   if (mergeFreezeReport.frozen) {
-        //     await sails.helpers.http.post('https://www.mergefreeze.com/api/branches/fleetdm/fleet/main', { frozen: false, access_token: sails.config.custom.mergeFreezeAccessToken, user_name: 'fleet-release' });//eslint-disable-line camelcase
-        //
-        //     // Then, in the background, 2 minutes later...
-        //     setTimeout(()=>{
-        //       sails.helpers.http.post('https://www.mergefreeze.com/api/branches/fleetdm/fleet/main', { frozen: true, access_token: sails.config.custom.mergeFreezeAccessToken, user_name: 'fleet-release' })//eslint-disable-line camelcase
-        //       .exec((err)=>{
-        //         if (err) {
-        //           sails.log.error('Background instruction failed: Unexpected error re-freezing repo (see https://github.com/fleetdm/fleet/issues/5179 for background):', err);
-        //         }
-        //         sails.log.info('Re-freeze completed successfully.');
-        //       });//_∏_
-        //     }, 2*60*1000);//_∏_
-        //   }//ﬁ
-        //
-        // }//ﬁ
-        // // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
       }
     } else if (ghNoun === 'issue_comment' && ['created'].includes(action) && (issueOrPr&&issueOrPr.state === 'open')) {
       //   ██████╗ ██████╗ ███╗   ███╗███╗   ███╗███████╗███╗   ██╗████████╗

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -26,7 +26,6 @@ module.exports = {
 
     let IS_FROZEN = true;// « Set this to `true` whenever a freeze is in effect, then set it back to `false` when the freeze ends.
 
-    let GREEN_LABEL_COLOR = 'C2E0C6';// « Used in multiple places below.
     let GITHUB_USERNAMES_OF_BOTS_AND_MAINTAINERS = [// « Used in multiple places below.
       'sailsbot',
       'fleet-release',
@@ -60,7 +59,10 @@ module.exports = {
       'juan-fdz-hawa',
       'roperzh',
     ];
-    let GITHUB_USERNAME_OF_DRI_FOR_LABELS = 'noahtalerman';// « Used below
+
+    let GREEN_LABEL_COLOR = 'C2E0C6';// « Used in multiple places below.  (FUTURE: Use the "+" prefix for this instead of color.  2022-05-05)
+
+    let GITHUB_USERNAME_OF_DRI_FOR_LABELS = 'noahtalerman';// « Used below (FUTURE: Remove this capability as Fleet has outgrown it.  2022-05-05)
 
     if (!sails.config.custom.slackWebhookUrlForGithubBot) {
       throw new Error('No Slack webhook URL configured for the GitHub bot to notify with alerts!  (Please set `sails.config.custom.slackWebhookUrlForGithubBot`.)');
@@ -205,7 +207,7 @@ module.exports = {
 
           let isSenderDRIForAllChangedPaths = false;
           let isSenderMaintainer = GITHUB_USERNAMES_OF_BOTS_AND_MAINTAINERS.includes(sender.login.toLowerCase());
-          let DRI_BY_PATH = {
+          let DRI_BY_PATH = {// « used below
             'README.md': 'mike-j-thomas',// (github brandfront)
 
             'handbook': ['desmi-dizney', 'mike-j-thomas', 'mikermcneil'],// (default for handbook)

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -7,6 +7,9 @@ module.exports = {
   description: 'Receive webhook requests and/or incoming auth redirects from GitHub.',
 
 
+  extendedDescription: 'Useful for automation, visibility of changes, and abuse monitoring.',
+
+
   inputs: {
     botSignature: { type: 'string', },
     action: { type: 'string', example: 'opened', defaultsTo: 'ping', moreInfoUrl: 'https://developer.github.com/v3/activity/events/types' },

--- a/website/api/helpers/github-automations/get-is-pr-preapproved.js
+++ b/website/api/helpers/github-automations/get-is-pr-preapproved.js
@@ -25,11 +25,10 @@ module.exports = {
   },
 
 
-  fn: async function ({prNumber, githubUserToCheck}) {
+  fn: async function ({prNumber, githubUserToCheck, isGithubUserMaintainerOrDoesntMatter}) {
 
-    let assert = require('assert');
-    assert(sails.config.custom.githubRepoDRIByPath);
-    assert(sails.config.custom.githubAccessToken);
+    require('assert')(sails.config.custom.githubRepoDRIByPath);
+    require('assert')(sails.config.custom.githubAccessToken);
 
     let DRI_BY_PATH = sails.config.custom.githubRepoDRIByPath;
     let owner = 'fleetdm';
@@ -38,8 +37,6 @@ module.exports = {
       'User-Agent': 'sails run freeze-open-pull-requests',
       'Authorization': `token ${sails.config.custom.githubAccessToken}`
     };
-
-    let isGithubUserMaintainerOrDoesntMatter = true;// « doesn't matter here because no auto-approval is happening.  Worst case, a community PR to an area with a "*" in the DRI mapping remains unfrozen.
 
     // Check the PR's author versus the intersection of DRIs for all changed files.
     return await sails.helpers.flow.build(async()=>{
@@ -54,7 +51,6 @@ module.exports = {
       isDRIForAllChangedPathsStill = _.all(changedPaths, (changedPath)=>{
         changedPath = changedPath.replace(/\/+$/,'');// « trim trailing slashes, just in case (b/c otherwise could loop forever)
 
-        require('assert')(githubUserToCheck !== undefined);
         // sails.log.verbose(`…checking DRI of changed path "${changedPath}"`);
 
         let selfMergers = DRI_BY_PATH[changedPath] ? [].concat(DRI_BY_PATH[changedPath]) : [];// « ensure array

--- a/website/api/helpers/github-automations/get-is-pr-preapproved.js
+++ b/website/api/helpers/github-automations/get-is-pr-preapproved.js
@@ -1,0 +1,87 @@
+module.exports = {
+
+
+  friendlyName: 'Get "is PR preapproved?"',
+
+
+  description: '',
+
+
+  inputs: {
+    prNumber: { type: 'number', example: 382, required: true },
+    githubUserToCheck: { type: 'string', example: 'mikermcneil', required: true },
+    isGithubUserMaintainerOrDoesntMatter: { type: 'boolean', required: true, description: 'Whether (a) the user is a maintainer, or (b) it even matters for this check whether the user is a maintainer.' },// FUTURE: « this could be replaced with an extra GitHub API call herein, but doesn't seem worth it
+  },
+
+
+  exits: {
+
+    success: {
+      outputFriendlyName: 'Is PR preapproved?',
+      outputDescription: 'Whether the provided GitHub user is the DRI for all changed paths.',
+      outputType: 'boolean',
+    },
+
+  },
+
+
+  fn: async function ({prNumber, githubUserToCheck}) {
+
+    let assert = require('assert');
+    assert(sails.config.custom.githubRepoDRIByPath);
+    assert(sails.config.custom.githubAccessToken);
+
+    let DRI_BY_PATH = sails.config.custom.githubRepoDRIByPath;
+    let owner = 'fleetdm';
+    let repo = 'fleet';
+    let baseHeaders = {
+      'User-Agent': 'sails run freeze-open-pull-requests',
+      'Authorization': `token ${sails.config.custom.githubAccessToken}`
+    };
+
+    let isGithubUserMaintainerOrDoesntMatter = true;// « doesn't matter here because no auto-approval is happening.  Worst case, a community PR to an area with a "*" in the DRI mapping remains unfrozen.
+
+    // Check the PR's author versus the intersection of DRIs for all changed files.
+    return await sails.helpers.flow.build(async()=>{
+
+      let isDRIForAllChangedPathsStill = false;
+
+      // [?] https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files
+      let changedPaths = _.pluck(await sails.helpers.http.get(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files`, {
+        per_page: 100,//eslint-disable-line camelcase
+      }, baseHeaders).retry(), 'filename');// (don't worry, it's the whole path, not the filename)
+
+      isDRIForAllChangedPathsStill = _.all(changedPaths, (changedPath)=>{
+        changedPath = changedPath.replace(/\/+$/,'');// « trim trailing slashes, just in case (b/c otherwise could loop forever)
+
+        require('assert')(githubUserToCheck !== undefined);
+        // sails.log.verbose(`…checking DRI of changed path "${changedPath}"`);
+
+        let selfMergers = DRI_BY_PATH[changedPath] ? [].concat(DRI_BY_PATH[changedPath]) : [];// « ensure array
+        if (selfMergers.includes(githubUserToCheck.toLowerCase()) || (isGithubUserMaintainerOrDoesntMatter && selfMergers.includes('*'))) {
+          return true;
+        }//•
+        let numRemainingPathsToCheck = changedPath.split('/').length;
+        while (numRemainingPathsToCheck > 0) {
+          let ancestralPath = changedPath.split('/').slice(0, -1 * numRemainingPathsToCheck).join('/');
+          // sails.log.verbose(`…checking DRI of ancestral path "${ancestralPath}" for changed path`);
+          let selfMergers = DRI_BY_PATH[ancestralPath] ? [].concat(DRI_BY_PATH[ancestralPath]) : [];// « ensure array
+          if (selfMergers.includes(githubUserToCheck.toLowerCase()) || (isGithubUserMaintainerOrDoesntMatter && selfMergers.includes('*'))) {
+            return true;
+          }//•
+          numRemainingPathsToCheck--;
+        }//∞
+      });//∞
+
+      if (isDRIForAllChangedPathsStill && changedPaths.length < 100) {
+        return true;
+      } else {
+        return false;
+      }
+    });
+
+  }
+
+
+};
+

--- a/website/api/helpers/github-automations/get-is-pr-preapproved.js
+++ b/website/api/helpers/github-automations/get-is-pr-preapproved.js
@@ -9,7 +9,7 @@ module.exports = {
 
   inputs: {
     prNumber: { type: 'number', example: 382, required: true },
-    githubUserToCheck: { type: 'string', example: 'mikermcneil', required: true },
+    githubUserToCheck: { type: 'string', example: 'mikermcneil', description: 'If excluded, then this returns `true` if all of the PRs changed paths are preapproved for SOMEONE.' },
     isGithubUserMaintainerOrDoesntMatter: { type: 'boolean', required: true, description: 'Whether (a) the user is a maintainer, or (b) it even matters for this check whether the user is a maintainer.' },// FUTURE: « this could be replaced with an extra GitHub API call herein, but doesn't seem worth it
   },
 
@@ -54,7 +54,10 @@ module.exports = {
         // sails.log.verbose(`…checking DRI of changed path "${changedPath}"`);
 
         let selfMergers = DRI_BY_PATH[changedPath] ? [].concat(DRI_BY_PATH[changedPath]) : [];// « ensure array
-        if (selfMergers.includes(githubUserToCheck.toLowerCase()) || (isGithubUserMaintainerOrDoesntMatter && selfMergers.includes('*'))) {
+        if (!githubUserToCheck && selfMergers.length >= 1) {// « not checking a user, so just make sure all these paths are preapproved for SOMEONE
+          return true;
+        }
+        if (githubUserToCheck && (selfMergers.includes(githubUserToCheck.toLowerCase()) || (isGithubUserMaintainerOrDoesntMatter && selfMergers.includes('*')))) {
           return true;
         }//•
         let numRemainingPathsToCheck = changedPath.split('/').length;
@@ -62,7 +65,10 @@ module.exports = {
           let ancestralPath = changedPath.split('/').slice(0, -1 * numRemainingPathsToCheck).join('/');
           // sails.log.verbose(`…checking DRI of ancestral path "${ancestralPath}" for changed path`);
           let selfMergers = DRI_BY_PATH[ancestralPath] ? [].concat(DRI_BY_PATH[ancestralPath]) : [];// « ensure array
-          if (selfMergers.includes(githubUserToCheck.toLowerCase()) || (isGithubUserMaintainerOrDoesntMatter && selfMergers.includes('*'))) {
+          if (!githubUserToCheck && selfMergers.length >= 1) {// « not checking a user, so just make sure all these paths are preapproved for SOMEONE
+            return true;
+          }
+          if (githubUserToCheck && (selfMergers.includes(githubUserToCheck.toLowerCase()) || (isGithubUserMaintainerOrDoesntMatter && selfMergers.includes('*')))) {
             return true;
           }//•
           numRemainingPathsToCheck--;

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -14,7 +14,7 @@ module.exports.custom = {
   *                                                                         *
   * The base URL to use during development.                                 *
   *                                                                         *
-  * • No trailing slash at the end                                          *
+  * • No trailing slash at the end                                          *
   * • `http://` or `https://` at the beginning.                             *
   *                                                                         *
   * > This is for use in custom logic that builds URLs.                     *

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -87,6 +87,48 @@ module.exports.custom = {
 
   /***************************************************************************
   *                                                                          *
+  * Directly responsible individuals (DRIs) whose changes to areas of the    *
+  * code respository (outside of the core product code) are auto-approved,   *
+  * even during code freezes.                                                *
+  *                                                                          *
+  * See api/controllers/webhooks/receive-from-github.js for context.         *
+  *                                                                          *
+  ***************************************************************************/
+  githubRepoDRIByPath: {
+    'README.md': 'mike-j-thomas',// (github brandfront)
+
+    'handbook': ['desmi-dizney', 'mike-j-thomas', 'mikermcneil'],// (default for handbook)
+    'handbook/company.md': 'mikermcneil',
+    'handbook/people.md': ['eashaw', 'mike-j-thomas'],
+    'handbook/engineering.md': 'zwass',
+    'handbook/product.md': 'noahtalerman',
+    'handbook/security.md': 'guillaumeross',
+    'handbook/security-policies.md': 'guillaumeross',
+    'handbook/brand.md': 'mike-j-thomas',
+    'handbook/growth.md': 'timmy-k',
+    'handbook/customers.md': 'tgauda',
+    'handbook/community.md': ['dominuskelvin', 'ksatter'],
+    'handbook/README.md': '*',// (any fleetie can update this page and merge their change without waiting for their change to be approved)
+
+    'website': 'mikermcneil',// (default for website)
+    'website/views': 'eashaw',
+    'website/assets': 'eashaw',
+    'website/config/routes.js': ['eashaw', 'mike-j-thomas'],// (for managing website URLs)
+
+    'docs': 'zwass',// (default for docs)
+    'docs/images': ['noahtalerman', 'eashaw', 'mike-j-thomas'],
+    'docs/Using-Fleet/REST-API.md': 'lukeheath',
+    'docs/Contributing/API-for-contributors.md': 'lukeheath',
+    'docs/Deploying/FAQ.md': ['ksatter', 'dominuskelvin'],
+    'docs/Contributing/FAQ.md': ['ksatter', 'dominuskelvin'],
+    'docs/Using-Fleet/FAQ.md': ['ksatter', 'dominuskelvin'],
+
+    'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml': 'guillaumeross',// (standard query library)
+  },
+
+
+  /***************************************************************************
+  *                                                                          *
   * Any other custom config this Sails app should use during development.    *
   * (and possibly in ALL environments, if not overridden in config/env/)     *
   *                                                                          *

--- a/website/scripts/freeze-open-pull-requests.js
+++ b/website/scripts/freeze-open-pull-requests.js
@@ -39,6 +39,7 @@ module.exports = {
 
       let prNumber = pullRequest.number;
       let prAuthor = pullRequest.user.login;
+      require('assert')(prAuthor !== undefined);
 
       // Freeze, if appropriate.
       // (Check the PR's author versus the intersection of DRIs for all changed files.)

--- a/website/scripts/freeze-open-pull-requests.js
+++ b/website/scripts/freeze-open-pull-requests.js
@@ -29,8 +29,10 @@ module.exports = {
       state: 'open',
       per_page: 100,//eslint-disable-line camelcase
     }, baseHeaders);
-    // console.log(openPullRequests.length,'PRs returned!');
 
+    let SECONDS_TO_WAIT = 5;
+    sails.log(`Examining and potentially freezing ${openPullRequests.length} PRs in ${SECONDS_TO_WAIT} seconds…  (To cancel, press CTRL+C quickly!)`);
+    await sails.helpers.flow.pause(SECONDS_TO_WAIT*1000);
 
     // For all open pull requests…
     await sails.helpers.flow.simultaneouslyForEach(openPullRequests, async(pullRequest)=>{
@@ -45,48 +47,12 @@ module.exports = {
         githubUserToCheck: prAuthor,
         isGithubUserMaintainerOrDoesntMatter: true// « doesn't matter here because no auto-approval is happening.  Worst case, a community PR to an area with a "*" in the DRI mapping remains unfrozen.
       });
-      // let isAuthorPreapproved = await sails.helpers.flow.build(async()=>{
 
-      //   let isDRIForAllChangedPathsStill = false;
-
-      //   // [?] https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files
-      //   let changedPaths = _.pluck(await sails.helpers.http.get(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files`, {
-      //     per_page: 100,//eslint-disable-line camelcase
-      //   }, baseHeaders).retry(), 'filename');// (don't worry, it's the whole path, not the filename)
-
-      //   isDRIForAllChangedPathsStill = _.all(changedPaths, (changedPath)=>{
-      //     changedPath = changedPath.replace(/\/+$/,'');// « trim trailing slashes, just in case (b/c otherwise could loop forever)
-
-      //     require('assert')(githubUserToCheck !== undefined);
-      //     // sails.log.verbose(`…checking DRI of changed path "${changedPath}"`);
-
-      //     let selfMergers = DRI_BY_PATH[changedPath] ? [].concat(DRI_BY_PATH[changedPath]) : [];// « ensure array
-      //     if (selfMergers.includes(githubUserToCheck.toLowerCase()) || (isGithubUserMaintainerOrDoesntMatter && selfMergers.includes('*'))) {
-      //       return true;
-      //     }//•
-      //     let numRemainingPathsToCheck = changedPath.split('/').length;
-      //     while (numRemainingPathsToCheck > 0) {
-      //       let ancestralPath = changedPath.split('/').slice(0, -1 * numRemainingPathsToCheck).join('/');
-      //       // sails.log.verbose(`…checking DRI of ancestral path "${ancestralPath}" for changed path`);
-      //       let selfMergers = DRI_BY_PATH[ancestralPath] ? [].concat(DRI_BY_PATH[ancestralPath]) : [];// « ensure array
-      //       if (selfMergers.includes(githubUserToCheck.toLowerCase()) || (isGithubUserMaintainerOrDoesntMatter && selfMergers.includes('*'))) {
-      //         return true;
-      //       }//•
-      //       numRemainingPathsToCheck--;
-      //     }//∞
-      //   });//∞
-
-      //   if (isDRIForAllChangedPathsStill && changedPaths.length < 100) {
-      //     return true;
-      //   } else {
-      //     return false;
-      //   }
-      // });
-
-      sails.log(`#${prNumber} by @${prAuthor}:`, isAuthorPreapproved ? 'Skipping freeze…' : 'Freezing…');
-
-      if (!isDryRun) {
-        console.log('NOT A DRY RUN!');
+      if (isDryRun) {
+        sails.log(`#${prNumber} by @${prAuthor}:`, isAuthorPreapproved ? 'Would have skipped freeze…' : 'Would have frozen…');
+      } else {
+        sails.log(`#${prNumber} by @${prAuthor}:`, isAuthorPreapproved ? 'Skipping freeze…' : 'Freezing…');
+        // TODO: uncomment when ready
         // [?] https://docs.github.com/en/rest/reference/pulls#create-a-review-for-a-pull-request
         // await sails.helpers.http.post(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/reviews`, {
         //   event: 'REQUEST_CHANGES',

--- a/website/scripts/freeze-open-pull-requests.js
+++ b/website/scripts/freeze-open-pull-requests.js
@@ -7,12 +7,22 @@ module.exports = {
   description: 'Freeze existing pull requests open on https://github.com/fleetdm/fleet, except those that consist exclusively of changes to files where the author is the DRI, according to auto-approval rules.',
 
 
+  extendedDescription: `# Usage
+
+  ## Dry run
+  sails_custom__githubAccessToken=YOUR_TOKEN_HERE sails run scripts/freeze-open-pull-requests.js --dry
+
+  ## The real deal
+  sails_custom__githubAccessToken=YOUR_TOKEN_HERE sails run scripts/freeze-open-pull-requests.js --limit=100`,
+
+
   inputs: {
     dry: { type: 'boolean', defaultsTo: false, description: 'Whether to do a dry run, and not actually freeze anything.' },
+    limit: { type: 'number', defaultsTo: 100, description: 'The max number of PRs to examine and potentially freeze. (Useful for testing.)' },
   },
 
 
-  fn: async function ({dry: isDryRun}) {
+  fn: async function ({dry: isDryRun, limit: maxNumPullRequestsToCheck }) {
 
     sails.log('Running custom shell script... (`sails run freeze-open-pull-requests`)');
 
@@ -27,11 +37,15 @@ module.exports = {
     // [?] https://docs.github.com/en/rest/pulls/pulls#list-pull-requests
     let openPullRequests = await sails.helpers.http.get(`https://api.github.com/repos/${owner}/${repo}/pulls`, {
       state: 'open',
-      per_page: 100,//eslint-disable-line camelcase
+      per_page: maxNumPullRequestsToCheck,//eslint-disable-line camelcase
     }, baseHeaders);
 
+    if (openPullRequests.length > maxNumPullRequestsToCheck) {
+      openPullRequests = openPullRequests.slice(0,maxNumPullRequestsToCheck);
+    }
+
     let SECONDS_TO_WAIT = 5;
-    sails.log(`Examining and potentially freezing ${openPullRequests.length} PRs in ${SECONDS_TO_WAIT} seconds…  (To cancel, press CTRL+C quickly!)`);
+    sails.log(`Examining and potentially freezing ${openPullRequests.length} PRs very soon…  (To cancel, press CTRL+C quickly within ${SECONDS_TO_WAIT}s!)`);
     await sails.helpers.flow.pause(SECONDS_TO_WAIT*1000);
 
     // For all open pull requests…
@@ -53,13 +67,14 @@ module.exports = {
         sails.log(`#${prNumber} by @${prAuthor}:`, isAuthorPreapproved ? 'Would have skipped freeze…' : 'Would have frozen…');
       } else {
         sails.log(`#${prNumber} by @${prAuthor}:`, isAuthorPreapproved ? 'Skipping freeze…' : 'Freezing…');
-        // TODO: uncomment when ready
-        // [?] https://docs.github.com/en/rest/reference/pulls#create-a-review-for-a-pull-request
-        // await sails.helpers.http.post(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/reviews`, {
-        //   event: 'REQUEST_CHANGES',
-        //   body: 'The repository has been frozen for an upcoming release.  In case of emergency, you can dismiss this review and merge.'
-        // }, baseHeaders);
-      }//
+        if (!isAuthorPreapproved) {
+          // [?] https://docs.github.com/en/rest/reference/pulls#create-a-review-for-a-pull-request
+          await sails.helpers.http.post(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/reviews`, {
+            event: 'REQUEST_CHANGES',
+            body: 'The repository has been frozen for an upcoming release.  In case of emergency, you can dismiss this review and merge.'
+          }, baseHeaders);
+        }//ﬁ
+      }
     });
 
   }

--- a/website/scripts/freeze-open-pull-requests.js
+++ b/website/scripts/freeze-open-pull-requests.js
@@ -56,10 +56,9 @@ module.exports = {
       require('assert')(prAuthor !== undefined);
 
       // Freeze, if appropriate.
-      // (Check the PR's author versus the intersection of DRIs for all changed files.)
+      // (Check versus the intersection of DRIs for all changed files to make sure SOMEONE is preapproved for all of them.)
       let isAuthorPreapproved = await sails.helpers.githubAutomations.getIsPrPreapproved.with({
         prNumber: prNumber,
-        githubUserToCheck: prAuthor,
         isGithubUserMaintainerOrDoesntMatter: true// « doesn't matter here because no auto-approval is happening.  Worst case, a community PR to an area with a "*" in the DRI mapping remains unfrozen.
       });
 

--- a/website/scripts/freeze-open-pull-requests.js
+++ b/website/scripts/freeze-open-pull-requests.js
@@ -1,0 +1,102 @@
+module.exports = {
+
+
+  friendlyName: 'Freeze open pull requests',
+
+
+  description: 'Freeze existing pull requests open on https://github.com/fleetdm/fleet, except those that consist exclusively of changes to files where the author is the DRI, according to auto-approval rules.',
+
+
+  inputs: {
+    dry: { type: 'boolean', defaultsTo: false, description: 'Whether to do a dry run, and not actually freeze anything.' },
+  },
+
+
+  fn: async function ({dry: isDryRun}) {
+
+    sails.log('Running custom shell script... (`sails run freeze-open-pull-requests`)');
+
+    let owner = 'fleetdm';
+    let repo = 'fleet';
+    let baseHeaders = {
+      'User-Agent': 'sails run freeze-open-pull-requests',
+      'Authorization': `token ${sails.config.custom.githubAccessToken}`
+    };
+
+    // Fetch open pull requests
+    // [?] https://docs.github.com/en/rest/pulls/pulls#list-pull-requests
+    let openPullRequests = await sails.helpers.http.get(`https://api.github.com/repos/${owner}/${repo}/pulls`, {
+      state: 'open',
+      per_page: 100,//eslint-disable-line camelcase
+    }, baseHeaders);
+    // console.log(openPullRequests.length,'PRs returned!');
+
+
+    // For all open pull requests…
+    await sails.helpers.flow.simultaneouslyForEach(openPullRequests, async(pullRequest)=>{
+
+      let prNumber = pullRequest.number;
+      let prAuthor = pullRequest.user.login;
+
+      // Freeze, if appropriate.
+      // (Check the PR's author versus the intersection of DRIs for all changed files.)
+      let isAuthorPreapproved = await sails.helpers.githubAutomations.getIsPrPreapproved.with({
+        prNumber: prNumber,
+        githubUserToCheck: prAuthor,
+        isGithubUserMaintainerOrDoesntMatter: true// « doesn't matter here because no auto-approval is happening.  Worst case, a community PR to an area with a "*" in the DRI mapping remains unfrozen.
+      });
+      // let isAuthorPreapproved = await sails.helpers.flow.build(async()=>{
+
+      //   let isDRIForAllChangedPathsStill = false;
+
+      //   // [?] https://docs.github.com/en/rest/reference/pulls#list-pull-requests-files
+      //   let changedPaths = _.pluck(await sails.helpers.http.get(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files`, {
+      //     per_page: 100,//eslint-disable-line camelcase
+      //   }, baseHeaders).retry(), 'filename');// (don't worry, it's the whole path, not the filename)
+
+      //   isDRIForAllChangedPathsStill = _.all(changedPaths, (changedPath)=>{
+      //     changedPath = changedPath.replace(/\/+$/,'');// « trim trailing slashes, just in case (b/c otherwise could loop forever)
+
+      //     require('assert')(githubUserToCheck !== undefined);
+      //     // sails.log.verbose(`…checking DRI of changed path "${changedPath}"`);
+
+      //     let selfMergers = DRI_BY_PATH[changedPath] ? [].concat(DRI_BY_PATH[changedPath]) : [];// « ensure array
+      //     if (selfMergers.includes(githubUserToCheck.toLowerCase()) || (isGithubUserMaintainerOrDoesntMatter && selfMergers.includes('*'))) {
+      //       return true;
+      //     }//•
+      //     let numRemainingPathsToCheck = changedPath.split('/').length;
+      //     while (numRemainingPathsToCheck > 0) {
+      //       let ancestralPath = changedPath.split('/').slice(0, -1 * numRemainingPathsToCheck).join('/');
+      //       // sails.log.verbose(`…checking DRI of ancestral path "${ancestralPath}" for changed path`);
+      //       let selfMergers = DRI_BY_PATH[ancestralPath] ? [].concat(DRI_BY_PATH[ancestralPath]) : [];// « ensure array
+      //       if (selfMergers.includes(githubUserToCheck.toLowerCase()) || (isGithubUserMaintainerOrDoesntMatter && selfMergers.includes('*'))) {
+      //         return true;
+      //       }//•
+      //       numRemainingPathsToCheck--;
+      //     }//∞
+      //   });//∞
+
+      //   if (isDRIForAllChangedPathsStill && changedPaths.length < 100) {
+      //     return true;
+      //   } else {
+      //     return false;
+      //   }
+      // });
+
+      sails.log(`#${prNumber} by @${prAuthor}:`, isAuthorPreapproved ? 'Skipping freeze…' : 'Freezing…');
+
+      if (!isDryRun) {
+        console.log('NOT A DRY RUN!');
+        // [?] https://docs.github.com/en/rest/reference/pulls#create-a-review-for-a-pull-request
+        // await sails.helpers.http.post(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/reviews`, {
+        //   event: 'REQUEST_CHANGES',
+        //   body: 'The repository has been frozen for an upcoming release.  In case of emergency, you can dismiss this review and merge.'
+        // }, baseHeaders);
+      }//
+    });
+
+  }
+
+
+};
+


### PR DESCRIPTION
# Usage

_From within the `website/` subdirectory…_



## Examples

## Dry run
```
sails_custom__githubAccessToken=YOUR_TOKEN_HERE sails run scripts/freeze-open-pull-requests.js --dry
```

## The real deal
```
sails_custom__githubAccessToken=YOUR_TOKEN_HERE sails run scripts/freeze-open-pull-requests.js --limit=100
```

## How to use it in practice

[mikermcneil](https://app.slack.com/team/U01A945TEDP)  [1 minute ago](https://fleetdm.slack.com/archives/C036AQYJACU/p1651814319007979?thread_ts=1651777231.167559&cid=C036AQYJACU)
To initiate a freeze of everything:
1. run that script (minus --dry)
2. change this to true instead of false: https://github.com/fleetdm/fleet/blob/5fe7fea24d3eba6334511491bfcbfcda90697aa9/website/api/controllers/webhooks/receive-from-github.js#L30

To unfreeze a PR:
1. follow the instructions that the bot commented when freezing (i.e. dismiss the review)

To unfreeze everything:
1. change this to false instead of true: https://github.com/fleetdm/fleet/blob/5fe7fea24d3eba6334511491bfcbfcda90697aa9/website/api/controllers/webhooks/receive-from-github.js#L30
2. let folks know the freeze is over and they can unfreeze their own PRs

Only PRs to areas of the code base that are never pre-approved are frozen.