### PR TITLE
Device User Page: Fix software inventory displaying disabled

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/Software.tsx
+++ b/frontend/pages/hosts/details/cards/Software/Software.tsx
@@ -82,7 +82,7 @@ const SoftwareTable = ({
     <EmptyState title="software" reason="empty-search" />
   );
 
-  if (!softwareInventoryEnabled) {
+  if (softwareInventoryEnabled === false) {
     return (
       <div className="section section--software">
         <p className="section__header">Software</p>


### PR DESCRIPTION
Cerra bug: #5622

Background:
Both HostDetailsPage.tsx and DeviceUserPage.tsx use cards/Software/Software.tsx
Only HostDetailsPage.tsx passes in the optional parameter `softwareInventoryEnabled` to render software inventory disabled empty state

- Bug: software inventory disabled message was showing when optional parameter `softwareInventoryEnabled` was not included in DeviceUserPage.tsx
- Software inventory disabled empty state should only render if optional parameter `softwareInventoryEnabled` is set to false, not if it's missing

Screenshots:
Device user UI shows software inventory returned by device user endpoint
<img width="1242" alt="Screen Shot 2022-05-06 at 11 23 33 AM" src="https://user-images.githubusercontent.com/71795832/167164026-d2ed12ea-1f57-40b8-8d78-28140211a439.png">
enable_software_inventory = true shows host details software table
<img width="1240" alt="Screen Shot 2022-05-06 at 11 23 14 AM" src="https://user-images.githubusercontent.com/71795832/167164027-ba9105b5-a76d-4fc2-b565-45bc45b73ed6.png">
enable_software_inventory = false shows host details software table
<img width="1241" alt="Screen Shot 2022-05-06 at 11 22 37 AM" src="https://user-images.githubusercontent.com/71795832/167164029-ab8303c2-a37d-43b0-bb06-eb17fcac7079.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`). No changefile as this is an issue on Main and not last release
- [x] Manual QA for all new/changed functionality
