### PR TITLE
Docs: fix whitespace issue in REST API docs

### DIFF
--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -1232,6 +1232,7 @@ Replaces all existing global enroll secrets.
 | Name      | Type    | In   | Description                                                        |
 | --------- | ------- | ---- | ------------------------------------------------------------------ |
 | spec      | object  | body | **Required**. Attribute "secrets" must be a list of enroll secrets |
+
 #### Example
 
 Replace all global enroll secrets with a new enroll secret.


### PR DESCRIPTION
Changes: 
- added a newline to prevent the "example" heading from being added to the table above it.
<img width="751" alt="image" src="https://user-images.githubusercontent.com/7445991/167518108-c7ab9de2-762f-4c19-81ee-cc9a8bfe384c.png">
