### PR TITLE
Moved GitHub Labels

### DIFF
--- a/handbook/company.md
+++ b/handbook/company.md
@@ -402,13 +402,6 @@ When Kolide's attention shifted away from Fleet and towards their separate, user
 ### 2020: Fleet was incorporated
 Zach partnered with our CEO, Mike McNeil, to found a new, independent company: Fleet Device Management Inc.  In November 2020, we [announced](https://medium.com/fleetdm/a-new-fleet-d4096c7de978) the transition and kicked off the logistics of moving the GitHub repository.
 
-## Rituals
-
-|Ritual |Frequency | Description | DRI|
-|-------|:---------|:------------|:---|
-| Weekly update reminder | Weekly | On Thursday, Charlie starts a thread in the `#help-manage` channel and asks managers to reply to the thread with a summary of what their team did in the past week. | Charlie Chance |
-| Weekly update | Weekly | On Friday, Charlie updates the KPIs in the ["🌈 Weekly updates" spreadsheet](https://docs.google.com/spreadsheets/d/1Hso0LxqwrRVINCyW_n436bNHmoqhoLhC8bcbvLPOs9A/edit#gid=0), combines the updates from managers into a single message, and adds any hiring announcements. Charlie posts the company update in the `#general` channel. | Charlie Chance |
-
 ## GitHub labels
 
 We use special characters to define different types of GitHub labels. By combining labels, we
@@ -422,6 +415,13 @@ maintaining an expressive labelling system. For example, instead of a label call
 | `:`               | Verb        | One or more  | `:dev`, `:research`, `:design`
 | `~`               | Adjective   | One or more  | `~blocked`, `~frontend`, `~backend`
 | `!`               | OKR         | One only     | `!vuln`, `!desktop`, `!upgrade`
+
+## Rituals
+
+|Ritual |Frequency | Description | DRI|
+|-------|:---------|:------------|:---|
+| Weekly update reminder | Weekly | On Thursday, Charlie starts a thread in the `#help-manage` channel and asks managers to reply to the thread with a summary of what their team did in the past week. | Charlie Chance |
+| Weekly update | Weekly | On Friday, Charlie updates the KPIs in the ["🌈 Weekly updates" spreadsheet](https://docs.google.com/spreadsheets/d/1Hso0LxqwrRVINCyW_n436bNHmoqhoLhC8bcbvLPOs9A/edit#gid=0), combines the updates from managers into a single message, and adds any hiring announcements. Charlie posts the company update in the `#general` channel. | Charlie Chance |
 
 ## Slack channels
 


### PR DESCRIPTION
I moved this section up since Slack channels is always at the bottom, and Rituals should be right above Slack channels.