### PR TITLE
Website: Make all documentation navigation on fleetdm.com sticky

### DIFF
--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -16,6 +16,7 @@ parasails.registerPage('basic-documentation', {
     pagesBySectionSlug: {},
     subtopics: [],
     relatedTopics: [],
+    scrollDistance: 0,
 
   },
 
@@ -75,6 +76,8 @@ parasails.registerPage('basic-documentation', {
 
       return pagesBySectionSlug;
     })();
+    // Adding scroll event listener for scrolling sidebars with the header
+    window.addEventListener('scroll', this.scrollSideNavigationWithHeader());
   },
 
   mounted: async function() {
@@ -245,6 +248,36 @@ parasails.registerPage('basic-documentation', {
     setSearchString: function () {
       this.searchString = this.inputTextValue;
     },
+
+    scrollSideNavigationWithHeader: function () {
+      console.log('scrolled :)')
+      var rightNavBar = document.querySelector('div[purpose="right-sidebar"]');
+      var leftNavBar = document.querySelector('div[purpose="left-sidebar"]');
+      var scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+      if(rightNavBar) {
+        if (scrollTop > this.scrollDistance && scrollTop > window.innerHeight * 1.5) {
+          rightNavBar.classList.add('header-hidden', 'scrolled');
+        } else {
+          if(scrollTop === 0) {
+            rightNavBar.classList.remove('header-hidden', 'scrolled');
+          } else {
+            rightNavBar.classList.remove('header-hidden');
+          }
+        }
+      }
+      if(leftNavBar) {
+        if (scrollTop > this.scrollDistance && scrollTop > window.innerHeight * 1.5) {
+          leftNavBar.classList.add('header-hidden', 'scrolled');
+        } else {
+          if(scrollTop === 0) {
+            leftNavBar.classList.remove('header-hidden', 'scrolled');
+          } else {
+            leftNavBar.classList.remove('header-hidden');
+          }
+        }
+      }
+      this.scrollDistance = scrollTop;
+    }
 
   }
 

--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -76,8 +76,8 @@ parasails.registerPage('basic-documentation', {
 
       return pagesBySectionSlug;
     })();
-    // Adding scroll event listener for scrolling sidebars with the header
-    window.addEventListener('scroll', this.scrollSideNavigationWithHeader());
+    // Adding scroll event listener for scrolling sidebars with the header.
+    window.addEventListener('scroll', this.scrollSideNavigationWithHeader);
   },
 
   mounted: async function() {

--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -250,7 +250,6 @@ parasails.registerPage('basic-documentation', {
     },
 
     scrollSideNavigationWithHeader: function () {
-      console.log('scrolled :)')
       var rightNavBar = document.querySelector('div[purpose="right-sidebar"]');
       var leftNavBar = document.querySelector('div[purpose="left-sidebar"]');
       var scrollTop = window.pageYOffset || document.documentElement.scrollTop;

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -545,7 +545,7 @@
         transition-property: all;
         transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
         transition-duration: 500ms;
-        z-index: 2
+        z-index: 2;
       }
 
       [purpose='left-sidebar'] {

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -542,9 +542,12 @@
 
       }
 
-      .translate-y-0 { // for scrolling with the sticky header
+      .header-hidden { // For scrolling the sidebars with the sticky header
         transform: translateY(-60px);
         max-height: calc(~'100vh - 80px');
+      }
+      .scrolled:not(.header-hidden) { // For when the page has been scrolled and the header is visible
+        max-height: calc(~'100vh - 170px');
       }
       [purpose='left-sidebar'] {
         position: sticky;
@@ -554,12 +557,15 @@
         transition-property: all;
         transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
         transition-duration: 500ms;
-        &:not(.translate-y-0) {
-          max-height: calc(~'100vh - 120px'); //To prevent the sidenav being anchored to the bottom of the page if it has overflow.
+        &:not(.scrolled) {
+          max-height: calc(~'100vh - 205px'); // Using a calculated max-height to allow the sidebars to be fully scrollable before the content is scrolled
         }
       }
 
       [purpose='right-sidebar'] {
+        p {
+          line-height: 21px;
+        }
         min-width: 190px;
         max-width: 210px;
         position: sticky;
@@ -585,9 +591,9 @@
             }
           }
         }
-        &:not(.translate-y-0) {
+        &:not(.scrolled) {
           [purpose='subtopics'] {
-            max-height: calc(~'100vh - 165px'); // To prevent the sidenav being anchored to the bottom of the page if it has overflow.
+            max-height: calc(~'100vh - 225px'); // Using a calculated max-height to allow the sidebars to be fully scrollable before the content is scrolled
           }
         }
       }

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -558,7 +558,7 @@
         transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
         transition-duration: 500ms;
         &:not(.scrolled) {
-          max-height: calc(~'100vh - 205px'); // Using a calculated max-height to allow the sidebars to be fully scrollable before the content is scrolled
+          max-height: calc(~'100vh - 205px'); // Using a calculated max-height to allow the sidebars to be fully scrollable before the content is scrolled.
         }
       }
 
@@ -593,7 +593,7 @@
         }
         &:not(.scrolled) {
           [purpose='subtopics'] {
-            max-height: calc(~'100vh - 225px'); // Using a calculated max-height to allow the sidebars to be fully scrollable before the content is scrolled
+            max-height: calc(~'100vh - 225px'); // Using a calculated max-height to allow the sidebars to be fully scrollable before the content is scrolled.
           }
         }
       }

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -538,12 +538,29 @@
         }
 
       }
+      [purpose='breadcrumbs-and-search'] {
+        position: sticky;
+        background-color: #FFF;
+        top: 94px;
+        transition-property: all;
+        transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+        transition-duration: 500ms;
+        z-index: 2
+      }
+
+      [purpose='left-sidebar'] {
+        position: sticky;
+        top: 188px;
+        height: fit-content;
+        max-height: 90vh;
+        overflow-y: auto;
+      }
 
       [purpose='right-sidebar'] {
         min-width: 190px;
         max-width: 210px;
         position: sticky;
-        top: 94px;
+        top: 188px;
         height: fit-content;
         [purpose='subtopics'] {
           max-height: calc(~'80vh - 90px'); //To prevent the sidenav being anchored to the bottom of the page if it has overflow.

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -370,6 +370,9 @@
 
     [purpose='content'] {
 
+      .markdown-heading {
+        scroll-margin-top: 55px;
+      }
       hr {
         margin: 0px;
         padding: 0px;
@@ -538,50 +541,55 @@
         }
 
       }
-      [purpose='breadcrumbs-and-search'] {
+
+      .translate-y-0 { // for scrolling with the sticky header
+        transform: translateY(-60px);
+        max-height: calc(~'100vh - 80px');
+      }
+      [purpose='left-sidebar'] {
         position: sticky;
-        background-color: #FFF;
-        top: 94px;
+        top: 118px;
+        height: fit-content;
+        overflow-y: auto;
         transition-property: all;
         transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
         transition-duration: 500ms;
-        z-index: 2;
-      }
-
-      [purpose='left-sidebar'] {
-        position: sticky;
-        top: 188px;
-        height: fit-content;
-        max-height: 90vh;
-        overflow-y: auto;
+        &:not(.translate-y-0) {
+          max-height: calc(~'100vh - 120px'); //To prevent the sidenav being anchored to the bottom of the page if it has overflow.
+        }
       }
 
       [purpose='right-sidebar'] {
         min-width: 190px;
         max-width: 210px;
         position: sticky;
-        top: 188px;
+        top: 118px;
         height: fit-content;
+        overflow-y: auto;
+        transition-property: all;
+        transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+        transition-duration: 500ms;
+
         [purpose='subtopics'] {
-          max-height: calc(~'80vh - 90px'); //To prevent the sidenav being anchored to the bottom of the page if it has overflow.
+          max-height: 100vh;
           overflow-y: auto;
           color: @core-fleet-black;
           padding-top: 4px;
           padding-bottom: 4px;
           border-left: 1px solid @core-vibrant-blue-25;
-
           a {
             color: @core-fleet-black;
             text-decoration: none;
-
             &:hover {
               color: @core-vibrant-blue;
             }
-
           }
-
         }
-
+        &:not(.translate-y-0) {
+          [purpose='subtopics'] {
+            max-height: calc(~'100vh - 165px'); // To prevent the sidenav being anchored to the bottom of the page if it has overflow.
+          }
+        }
       }
 
       [purpose='content'] {

--- a/website/assets/styles/pages/handbook/basic-handbook.less
+++ b/website/assets/styles/pages/handbook/basic-handbook.less
@@ -122,6 +122,9 @@
   }
 
   [purpose='content'] {
+    .markdown-heading {
+      scroll-margin-top: 55px;
+    }
     h1 {
       padding-bottom: 16px;
       margin-top: 24px;

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -312,8 +312,8 @@
             if (scrollTop > lastScrollTop && scrollTop > window.innerHeight * 1.5) {
                 header.classList.add('translate-y-0');
                 if(rightNavBar && leftNavBar) {
-                  docsRightNav.classList.add('translate-y-0');
-                  docsLeftNav.classList.add('translate-y-0');
+                  rightNavBar.classList.add('translate-y-0');
+                  leftNavBar.classList.add('translate-y-0');
                 }
              } else {
                 if(header.classList.contains('homepage-header') && scrollTop > header.clientHeight) {
@@ -324,8 +324,8 @@
                 }
                 header.classList.remove('translate-y-0');
                 if(rightNavBar && leftNavBar) {
-                  docsRightNav.classList.remove('translate-y-0');
-                  docsLeftNav.classList.remove('translate-y-0');
+                  rightNavBar.classList.remove('translate-y-0');
+                  leftNavBar.classList.remove('translate-y-0');
                 }
             }
             lastScrollTop = scrollTop

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -295,8 +295,6 @@
         window.addEventListener('scroll', windowScrolled)
 
         function windowScrolled() {
-            var rightNavBar = document.querySelector('div[purpose="right-sidebar"]');
-            var leftNavBar = document.querySelector('div[purpose="left-sidebar"]');
             var scrollTop = window.pageYOffset || document.documentElement.scrollTop
             var fleetLogo = header.querySelector('img')
             var hamburgerMenuIcon = header.querySelector('.btn.btn-link > img')
@@ -311,10 +309,6 @@
             }
             if (scrollTop > lastScrollTop && scrollTop > window.innerHeight * 1.5) {
                 header.classList.add('translate-y-0');
-                if(rightNavBar && leftNavBar) {
-                  rightNavBar.classList.add('translate-y-0');
-                  leftNavBar.classList.add('translate-y-0');
-                }
              } else {
                 if(header.classList.contains('homepage-header') && scrollTop > header.clientHeight) {
                     header.classList.add('sticky')
@@ -323,10 +317,6 @@
                     hamburgerMenuIcon.src="/images/icon-hamburger-blue-16x14@2x.png"
                 }
                 header.classList.remove('translate-y-0');
-                if(rightNavBar && leftNavBar) {
-                  rightNavBar.classList.remove('translate-y-0');
-                  leftNavBar.classList.remove('translate-y-0');
-                }
             }
             lastScrollTop = scrollTop
         }

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -295,7 +295,8 @@
         window.addEventListener('scroll', windowScrolled)
 
         function windowScrolled() {
-            var docsTopNav = document.querySelector('div[purpose="breadcrumbs-and-search"]');
+            var rightNavBar = document.querySelector('div[purpose="right-sidebar"]');
+            var leftNavBar = document.querySelector('div[purpose="left-sidebar"]');
             var scrollTop = window.pageYOffset || document.documentElement.scrollTop
             var fleetLogo = header.querySelector('img')
             var hamburgerMenuIcon = header.querySelector('.btn.btn-link > img')
@@ -310,8 +311,9 @@
             }
             if (scrollTop > lastScrollTop && scrollTop > window.innerHeight * 1.5) {
                 header.classList.add('translate-y-0');
-                if(docsTopNav) {
-                  docsTopNav.classList.add('translate-y-0');
+                if(rightNavBar && leftNavBar) {
+                  docsRightNav.classList.add('translate-y-0');
+                  docsLeftNav.classList.add('translate-y-0');
                 }
              } else {
                 if(header.classList.contains('homepage-header') && scrollTop > header.clientHeight) {
@@ -321,8 +323,9 @@
                     hamburgerMenuIcon.src="/images/icon-hamburger-blue-16x14@2x.png"
                 }
                 header.classList.remove('translate-y-0');
-                if(docsTopNav) {
-                  docsTopNav.classList.remove('translate-y-0');
+                if(rightNavBar && leftNavBar) {
+                  docsRightNav.classList.remove('translate-y-0');
+                  docsLeftNav.classList.remove('translate-y-0');
                 }
             }
             lastScrollTop = scrollTop

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -299,11 +299,13 @@
             var scrollTop = window.pageYOffset || document.documentElement.scrollTop
             var fleetLogo = header.querySelector('img')
             var hamburgerMenuIcon = header.querySelector('.btn.btn-link > img')
+
             if(scrollTop == 0 && header.classList.contains('homepage-header')) {
                 header.classList.remove('sticky')
                 fleetLogo.src = '/images/logo-white-118x48@2x.png'
                 fleetLogo.style = 'width: 118px; height: 48px;'
                 hamburgerMenuIcon.src = '/images/icon-hamburger-16x14@2x.png'
+
                 return;
             }
             if (scrollTop > lastScrollTop && scrollTop > window.innerHeight * 1.5) {

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -295,20 +295,22 @@
         window.addEventListener('scroll', windowScrolled)
 
         function windowScrolled() {
+            var docsTopNav = document.querySelector('div[purpose="breadcrumbs-and-search"]');
             var scrollTop = window.pageYOffset || document.documentElement.scrollTop
             var fleetLogo = header.querySelector('img')
             var hamburgerMenuIcon = header.querySelector('.btn.btn-link > img')
-
             if(scrollTop == 0 && header.classList.contains('homepage-header')) {
                 header.classList.remove('sticky')
                 fleetLogo.src = '/images/logo-white-118x48@2x.png'
                 fleetLogo.style = 'width: 118px; height: 48px;'
                 hamburgerMenuIcon.src = '/images/icon-hamburger-16x14@2x.png'
-
                 return;
             }
             if (scrollTop > lastScrollTop && scrollTop > window.innerHeight * 1.5) {
-                header.classList.add('translate-y-0')
+                header.classList.add('translate-y-0');
+                if(docsTopNav) {
+                  docsTopNav.classList.add('translate-y-0');
+                }
              } else {
                 if(header.classList.contains('homepage-header') && scrollTop > header.clientHeight) {
                     header.classList.add('sticky')
@@ -316,7 +318,10 @@
                     fleetLogo.style = 'height: 92px; width: 162px;'
                     hamburgerMenuIcon.src="/images/icon-hamburger-blue-16x14@2x.png"
                 }
-                header.classList.remove('translate-y-0')
+                header.classList.remove('translate-y-0');
+                if(docsTopNav) {
+                  docsTopNav.classList.remove('translate-y-0');
+                }
             }
             lastScrollTop = scrollTop
         }


### PR DESCRIPTION
Closes #5650 

Changes:
- updated the docs navigation to use `position: sticky`
- Updated the script in `layout.ejs` to scroll the top docs navigation when the header is hidden
