### PR TITLE
Use `LocalSystem` user instead of `NT AUTHORITY\SYSTEM` on MSI packaging

### DIFF
--- a/changes/issue-use-local-system-user-on-msi
+++ b/changes/issue-use-local-system-user-on-msi
@@ -1,0 +1,1 @@
+* Use `LocalSystem` on fleet-osquery `msi` installer instead of `NT AUTHORITY\SYSTEM`.

--- a/orbit/pkg/packaging/windows_templates.go
+++ b/orbit/pkg/packaging/windows_templates.go
@@ -48,12 +48,18 @@ var windowsWixTemplate = template.Must(template.New("").Option("missingkey=error
                   <PermissionEx Sddl="O:SYG:SYD:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;BU)" />
                 </File>
                 <Environment Id='OrbitUpdateInterval' Name='ORBIT_UPDATE_INTERVAL' Value='{{ .OrbitUpdateInterval }}' Action='set' System='yes' />
+                <!--
+                  ##############################################################################################
+                  NOTE: We've seen some system fail to install the MSI when using Account="NT AUTHORITY\SYSTEM"
+                  ##############################################################################################
+                  -->
                 <ServiceInstall
                   Name="Fleet osquery"
-                  Account="NT AUTHORITY\SYSTEM"
+                  Account="LocalSystem"
                   ErrorControl="ignore"
                   Start="auto"
                   Type="ownProcess"
+                  Description="This service runs Fleet's osquery runtime and autoupdater (Orbit)."
                   Arguments='--root-dir "[ORBITROOT]." --log-file "[System64Folder]config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log"{{ if .FleetURL }} --fleet-url "{{ .FleetURL }}"{{ end }}{{ if .FleetCertificate }} --fleet-certificate "[ORBITROOT]fleet.pem"{{ end }}{{ if .EnrollSecret }} --enroll-secret-path "[ORBITROOT]secret.txt"{{ end }}{{if .Insecure }} --insecure{{ end }}{{ if .Debug }} --debug{{ end }}{{ if .UpdateURL }} --update-url "{{ .UpdateURL }}"{{ end }}{{ if .DisableUpdates }} --disable-updates{{ end }}{{ if .Desktop }} --fleet-desktop --desktop-channel {{ .DesktopChannel }}{{ end }} --orbit-channel "{{ .OrbitChannel }}" --osqueryd-channel "{{ .OsquerydChannel }}"'
                 >
                   <util:ServiceConfig


### PR DESCRIPTION
- [X] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
~- [ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality

![Screen Shot 2022-05-12 at 19 15 46](https://user-images.githubusercontent.com/2073526/168178117-d73f4857-b55f-4440-9f34-7a0345809f2d.png)
