### PR TITLE
add documentation for debug tools

### DIFF
--- a/changes/issue-5505-add-proper-extensions-to-fleetctl-debug
+++ b/changes/issue-5505-add-proper-extensions-to-fleetctl-debug
@@ -1,0 +1,1 @@
+Set the correct file extensions to the output of all `fleetctl debug` commands.

--- a/cmd/fleetctl/debug.go
+++ b/cmd/fleetctl/debug.go
@@ -25,6 +25,11 @@ import (
 // Defining here for testing purposes
 var nowFn = time.Now
 
+const (
+	profileExtension = "prof"
+	jsonExtension    = "json"
+)
+
 func debugCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "debug",
@@ -92,7 +97,7 @@ func debugProfileCommand() *cli.Command {
 
 			outfile := getOutfile(c)
 			if outfile == "" {
-				outfile = outfileNameWithExt("profile", "pb")
+				outfile = outfileNameWithExt("profile", profileExtension)
 			}
 
 			if err := writeFile(outfile, profile, defaultFileMode); err != nil {
@@ -174,7 +179,7 @@ func debugHeapCommand() *cli.Command {
 
 			outfile := getOutfile(c)
 			if outfile == "" {
-				outfile = outfileNameWithExt(name, "pb")
+				outfile = outfileNameWithExt(name, profileExtension)
 			}
 
 			if err := writeFile(outfile, profile, defaultFileMode); err != nil {
@@ -211,7 +216,7 @@ func debugGoroutineCommand() *cli.Command {
 
 			outfile := getOutfile(c)
 			if outfile == "" {
-				outfile = outfileNameWithExt(name, "pb")
+				outfile = outfileNameWithExt(name, profileExtension)
 			}
 
 			if err := writeFile(outfile, profile, defaultFileMode); err != nil {
@@ -248,7 +253,7 @@ func debugTraceCommand() *cli.Command {
 
 			outfile := getOutfile(c)
 			if outfile == "" {
-				outfile = outfileNameWithExt(name, "pb")
+				outfile = outfileNameWithExt(name, profileExtension)
 			}
 
 			if err := writeFile(outfile, profile, defaultFileMode); err != nil {
@@ -314,24 +319,24 @@ func debugArchiveCommand() *cli.Command {
 				switch profile {
 				case "errors":
 					var buf bytes.Buffer
-					ext = "json"
+					ext = jsonExtension
 					err = fleet.DebugErrors(&buf, false)
 					if err == nil {
 						res = buf.Bytes()
 					}
 
 				case "db-locks":
-					ext = "json"
+					ext = jsonExtension
 					res, err = fleet.DebugDBLocks()
 				case "db-innodb-status":
-					ext = "json"
+					ext = jsonExtension
 					res, err = fleet.DebugInnoDBStatus()
 				case "db-process-list":
-					ext = "json"
+					ext = jsonExtension
 					res, err = fleet.DebugProcessList()
 
 				default:
-					ext = "pb"
+					ext = profileExtension
 					res, err = fleet.DebugPprof(profile)
 				}
 
@@ -583,7 +588,7 @@ func debugErrorsCommand() *cli.Command {
 
 			if !stdout {
 				if outfile == "" {
-					outfile = outfileNameWithExt(name, "json")
+					outfile = outfileNameWithExt(name, jsonExtension)
 				}
 
 				f, err := os.OpenFile(outfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, defaultFileMode)

--- a/cmd/fleetctl/debug.go
+++ b/cmd/fleetctl/debug.go
@@ -354,18 +354,19 @@ func debugArchiveCommand() *cli.Command {
 					outname = profile + "." + ext
 				}
 
+				tarName := outfile + "/" + outname
 				if err := tarwriter.WriteHeader(
 					&tar.Header{
-						Name: outfile + "/" + outname,
+						Name: tarName,
 						Size: int64(len(res)),
 						Mode: defaultFileMode,
 					},
 				); err != nil {
-					return fmt.Errorf("write %s header: %w", outname, err)
+					return fmt.Errorf("write %s header: %w", tarName, err)
 				}
 
 				if _, err := tarwriter.Write(res); err != nil {
-					return fmt.Errorf("write %s contents: %w", outname, err)
+					return fmt.Errorf("write %s contents: %w", tarName, err)
 				}
 			}
 

--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -6382,6 +6382,8 @@ Deletes the selected user's sessions in Fleet. Also deletes the user's API token
 ## Debug
 
 - [Get a summary of errors](#get-a-summary-of-errors)
+- [Get database information](#get-database-information)
+- [Get profiling information](#get-profiling-information)
 
 The Fleet server exposes a handful of API endpoints to retrieve debug information about the server itself in order to help troubleshooting. All the following endpoints require prior authentication meaning you must first log in successfully before calling any of the endpoints documented below.
 
@@ -6426,6 +6428,32 @@ The server only stores and returns a single instance of each error.
   }
 ]
 ```
+
+### Get database information
+
+Returns information about the current state of the database, valid keys are:
+
+- `locks`: returns transaction locking information.
+- `innodb-status`: returns InnoDB status information.
+- `process-list`: returns running processes (queries, etc).
+
+`GET /debug/db/{key}`
+
+#### Parameters
+
+None.
+
+### Get profiling information
+
+Returns runtime profiling data of the server in the format expected by `go tools pprof`. The responses are equivalent to those returned by the Go `http/pprof` package.
+
+Valid keys are: `cmdline`, `profile`, `symbol` and `trace`.
+
+`GET /debug/pprof/{key}`
+
+#### Parameters
+
+None.
 
 ---
 <meta name="pageOrderInSection" value="400">

--- a/docs/Using-Fleet/fleetctl-CLI.md
+++ b/docs/Using-Fleet/fleetctl-CLI.md
@@ -435,4 +435,24 @@ The value must be small enough that HTTP requests do not time out.
 
 Start with a default of 2MiB for MySQL (2097152 bytes), and 5MiB for S3/Minio (5242880 bytes).
 
+## Debugging Fleet
+
+`fleetctl` provides debugging capabilities about the running Fleet server via the `debug` command. To see a complete list of all the options run:
+
+```
+fleetctl debug --help
+```
+
+To generate a full debugging archive, run:
+
+```
+fleetctl debug archive
+```
+
+This will generate a `tar.gz` file with:
+
+- `pb` archives that can be inspected via `go tools pprof <archive_name_here>`.
+- A file containing a set of all the errors that happened in the server during the interval of time defined by the [logging_error_retention_period](../Deploying/Configuration.md#logging-error-retention-period) configuration.
+- Files containing database specific information.
+
 <meta name="pageOrderInSection" value="300">

--- a/docs/Using-Fleet/fleetctl-CLI.md
+++ b/docs/Using-Fleet/fleetctl-CLI.md
@@ -451,7 +451,7 @@ fleetctl debug archive
 
 This will generate a `tar.gz` file with:
 
-- `pb` archives that can be inspected via `go tools pprof <archive_name_here>`.
+- `prof` archives that can be inspected via `go tools pprof <archive_name_here>`.
 - A file containing a set of all the errors that happened in the server during the interval of time defined by the [logging_error_retention_period](../Deploying/Configuration.md#logging-error-retention-period) configuration.
 - Files containing database specific information.
 


### PR DESCRIPTION
This PR adds documentation about our debugging endpoints and a brief excerpt about the `fleetctl debug` command with instructions to generate the archive so we have a place with instructions to which we can direct people. 

It also adds the `.pb` file extension to profiling files, which hopefully clarifies that they are meant to be used by `go tool pprof`.

Related to: [#5505](https://github.com/fleetdm/fleet/issues/5505)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [x] Manual QA for all new/changed functionality
