### PR TITLE
allow fleetctl preview to work with docker compose v1 and v2

### DIFF
--- a/changes/issue-5746-docker-compose-v2
+++ b/changes/issue-5746-docker-compose-v2
@@ -1,0 +1,1 @@
+Fixed `fleetctl preview` to support docker compose v2.

--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -69,7 +69,7 @@ func (d dockerCompose) Command(arg ...string) *exec.Cmd {
 
 func newDockerCompose() (dockerCompose, error) {
 	// first, check if `docker compose` is available
-	if err := exec.Command("docker composef").Run(); err == nil {
+	if err := exec.Command("docker compose").Run(); err == nil {
 		return dockerCompose{dockerComposeV2}, nil
 	}
 

--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -52,7 +52,7 @@ func previewCommand() *cli.Command {
 		Name:    "preview",
 		Aliases: []string{"sandbox"},
 		Usage:   "Start a sandbox deployment of the Fleet server",
-		Description: `Start a sandbox deployment of the Fleet server using Docker and docker-compose. Docker tools must be available in the environment.
+		Description: `Start a sandbox deployment of the Fleet server using Docker and docker compose. Docker tools must be available in the environment.
 
 Use the stop and reset subcommands to manage the server and dependencies once started.`,
 		Subcommands: []*cli.Command{

--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -43,8 +43,9 @@ const (
 	updateRootKeys          = "update-roots"
 	stdQueryLibFilePath     = "std-query-lib-file-path"
 	disableOpenBrowser      = "disable-open-browser"
-	dockerComposeV1         = 1
-	dockerComposeV2         = 2
+
+	dockerComposeV1 dockerComposeVersion = 1
+	dockerComposeV2 dockerComposeVersion = 2
 )
 
 type dockerCompose struct {

--- a/cmd/fleetctl/preview_test.go
+++ b/cmd/fleetctl/preview_test.go
@@ -54,3 +54,23 @@ func TestPreview(t *testing.T) {
 	ok = strings.Contains(appConf, `databases_path: /vulndb`)
 	require.True(t, ok, appConf)
 }
+
+func TestDockerCompose(t *testing.T) {
+	t.Run("returns the right command according to the version", func(t *testing.T) {
+		v1 := dockerCompose{dockerComposeV1}
+		cmd1 := v1.Command("up")
+		require.Equal(t, []string{"docker-compose", "up"}, cmd1.Args)
+
+		v2 := dockerCompose{dockerComposeV2}
+		cmd2 := v2.Command("up")
+		require.Equal(t, []string{"docker", "compose", "up"}, cmd2.Args)
+	})
+
+	t.Run("strings according to the version", func(t *testing.T) {
+		v1 := dockerCompose{dockerComposeV1}
+		require.Equal(t, v1.String(), "`docker-compose`")
+
+		v2 := dockerCompose{dockerComposeV2}
+		require.Equal(t, v2.String(), "`docker compose`")
+	})
+}


### PR DESCRIPTION
This PR adds compatibility in `fleetctl preview` to work with `docker compose` (version 2). Since this version was released this April, we are still keeping backwards compatibility and using `docker-compose` as a fallback.

As v2 is now the recommended version and v1 is deprecated, I reworded all the prompts and help messages to say "`docker compose`".

I haven't found an image in https://github.com/actions/virtual-environments that allows us to test using `.github/workflows/fleetctl-preview-latest.yml` as all of them contain both v1 and v2 versions of docker compose, but I have tested the changes manually.

Rel: #5746

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
