### PR TITLE
Add Kathy as API docs codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,4 +13,8 @@ go.mod @fleetdm/go
 # GitHub settings + actions
 /.github/ @zwass
 
+# Changelog
 CHANGELOG.md @noahtalerman
+
+# API documentation
+/docs/Using-Fleet/REST-API.md @ksatter


### PR DESCRIPTION
- Add Kathy as codeowner of the API docs so that DevRel is added as a reviewer anytime the docs are updated
  - This way, the API docs start to use consistent voice and examples
