### PR TITLE
Remove view all hosts links from device user page

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1329,8 +1329,6 @@ const ManageHostsPage = ({
         }`}
       >
         <span>{`${count} host${count === 1 ? "" : "s"}`}</span>
-        {/* Export all columns initially in 4.13 release but feature being pushed
-        back by product until we build client side filtering to export only selected columns
         <Button
           className={`${baseClass}__export-btn`}
           onClick={onExportHostsResults}
@@ -1339,7 +1337,7 @@ const ManageHostsPage = ({
           <>
             Export hosts <img alt="" src={DownloadIcon} />
           </>
-        </Button> */}
+        </Button>
       </div>
     );
   }, [isHostCountLoading, filteredHostCount]);
@@ -1494,14 +1492,19 @@ const ManageHostsPage = ({
       },
     ];
 
+    const tableColumns = generateVisibleTableColumns(
+      hiddenColumns,
+      config,
+      currentUser,
+      currentTeam
+    );
+
+    const columnAccessors = tableColumns.map((column) => column.accessor);
+    columnAccessors.shift();
+
     return (
       <TableContainer
-        columns={generateVisibleTableColumns(
-          hiddenColumns,
-          config,
-          currentUser,
-          currentTeam
-        )}
+        columns={tableColumns}
         data={hosts}
         isLoading={isHostsLoading || isHostCountLoading}
         manualSortBy

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -437,6 +437,10 @@
   .form-field--dropdown {
     margin: 0;
   }
+
+  .section--policies .data-table-block .data-table__table thead .response__header {
+    width: $col-md;
+  }
 }
 
 .site-nav-item {

--- a/frontend/pages/hosts/details/cards/Policies/Policies.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/Policies.tsx
@@ -42,9 +42,11 @@ const Policies = ({
     );
   }
 
-  console.log("policies: ", policies);
-
   const tableHeaders = generatePolicyTableHeaders(togglePolicyDetailsModal);
+  if (deviceUser) {
+    // Remove view all hosts link
+    tableHeaders.pop();
+  }
   const noResponses: IHostPolicy[] =
     policies.filter(
       (policy: IHostPolicy) => !isValidPolicyResponse(policy.response)

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -18,6 +18,7 @@ export interface ILoadHostsOptions {
   policyId?: number;
   policyResponse?: string;
   softwareId?: number;
+  columns?: string;
 }
 
 export type ILoadHostDetailsExtension = "device_mapping" | "macadmins";
@@ -59,6 +60,7 @@ export default {
     const policyId = options?.policyId || null;
     const policyResponse = options?.policyResponse || null;
     const softwareId = options?.softwareId || null;
+    const columns = options?.columns || null;
 
     let orderKeyParam = "";
     let orderDirection = "";
@@ -129,6 +131,7 @@ export default {
     const policyId = options?.policyId || null;
     const policyResponse = options?.policyResponse || null;
     const softwareId = options?.softwareId || null;
+    const columns = options?.columns || null;
 
     // TODO: add this query param logic to client class
     const pagination = `page=${page}&per_page=${perPage}`;
@@ -185,6 +188,10 @@ export default {
     // TODO: consider how to check for mutually exclusive scenarios with label, policy and software
     if (!label && !policyId && softwareId) {
       path += `&software_id=${softwareId}`;
+    }
+
+    if (columns) {
+      path += `&columns=${columns}`;
     }
 
     return sendRequest("GET", path);


### PR DESCRIPTION
Quick bug fix. I noticed I forgot to remove the "view all hosts" links that appear when hovering the policies table.