### PR TITLE
Update Get started page on fleetdm.com

### DIFF
--- a/website/views/pages/get-started.ejs
+++ b/website/views/pages/get-started.ejs
@@ -50,7 +50,7 @@
       <p>The Fleet UI is now available at <a href="http://localhost:1337"
           target="_blank">http://localhost:1337</a>. Use the credentials below to login.</p>
       <p class="mb-2"><strong>Email:</strong> admin@example.com</p>
-      <p><strong>Password:</strong> preview1337#</p>
+      <p><strong>Password:</strong> admin123#</p>
     </div>
     <div style="padding-top: 60px;">
       <h2 class="mb-4">Next steps</h2>


### PR DESCRIPTION
- Revert the password for the admin account back to `admin123#`
- When Fleet 4.15.0 is released (2022-05-26) the password for the `fleetctl preview` environment will change to `preview1337#` 
  - We'll make sure this change is made during the ["Releasing Fleet"](https://fleetdm.com/docs/contributing/releasing-fleet) process for 4.15.0.