### PR TITLE
automatically add host and viewer information to errors

### DIFF
--- a/server/contexts/ctxerr/ctxerr.go
+++ b/server/contexts/ctxerr/ctxerr.go
@@ -18,6 +18,9 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/host"
+	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 )
 
 type key int
@@ -76,8 +79,25 @@ func setMetadata(ctx context.Context, data map[string]interface{}) map[string]in
 		data = map[string]interface{}{}
 	}
 
-	// TODO: add more metadata from ctx
 	data["timestamp"] = nowFn().Format(time.RFC3339)
+
+	if h, ok := host.FromContext(ctx); ok {
+		data["host"] = map[string]interface{}{
+			"platform":        h.Platform,
+			"osquery_version": h.OsqueryVersion,
+		}
+	}
+
+	if v, ok := viewer.FromContext(ctx); ok {
+		vdata := map[string]interface{}{}
+		data["viewer"] = vdata
+		vdata["is_logged_in"] = v.IsLoggedIn()
+
+		if v.User != nil {
+			vdata["sso_enabled"] = v.User.SSOEnabled
+		}
+	}
+
 	return data
 }
 


### PR DESCRIPTION
This PR enhances the logic to automatically attach additional metadata to the root `FleetError` in the chain by pulling from the provided `ctx` (if available):

- Host platform and osquery version
- Information about if the viewer is logged in and is using SSO to authenticate

Related to: [#5516](https://github.com/fleetdm/fleet/issues/5516)

# Checklist for submitter

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
