### PR TITLE
Add license object to `GET /fleet/device/{token}` response

### DIFF
--- a/changes/issue-5815-licence-info
+++ b/changes/issue-5815-licence-info
@@ -1,0 +1,1 @@
+- Added license object to `GET /fleet/device/{token}` response

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -24,6 +24,7 @@ type getDeviceHostResponse struct {
 	Host       *HostDetailResponse `json:"host"`
 	OrgLogoURL string              `json:"org_logo_url"`
 	Err        error               `json:"error,omitempty"`
+	License    fleet.LicenseInfo   `json:"license"`
 }
 
 func (r getDeviceHostResponse) error() error { return r.Err }
@@ -54,9 +55,15 @@ func getDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.S
 		return getDeviceHostResponse{Err: err}, nil
 	}
 
+	license, err := svc.License(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	return getDeviceHostResponse{
 		Host:       resp,
 		OrgLogoURL: ac.OrgInfo.OrgLogoURL,
+		License:    *license,
 	}, nil
 }
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -4594,6 +4594,14 @@ func (s *integrationTestSuite) TestDeviceAuthenticatedEndpoints() {
 	// get macadmins for invalid token
 	res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/no_such_token/macadmins", nil, http.StatusUnauthorized)
 	res.Body.Close()
+
+	// response includes license info
+	getHostResp = getDeviceHostResponse{}
+	res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token, nil, http.StatusOK)
+	json.NewDecoder(res.Body).Decode(&getHostResp)
+	res.Body.Close()
+	require.NotNil(t, getHostResp.License)
+	require.Equal(t, getHostResp.License.Tier, "free")
 }
 
 func (s *integrationTestSuite) TestModifyUser() {

--- a/server/service/service_appconfig.go
+++ b/server/service/service_appconfig.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server"
+	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -128,8 +129,10 @@ func cleanupURL(url string) string {
 }
 
 func (svc *Service) License(ctx context.Context) (*fleet.LicenseInfo, error) {
-	if err := svc.authz.Authorize(ctx, &fleet.AppConfig{}, fleet.ActionRead); err != nil {
-		return nil, err
+	if !svc.authz.IsAuthenticatedWith(ctx, authz_ctx.AuthnDeviceToken) {
+		if err := svc.authz.Authorize(ctx, &fleet.AppConfig{}, fleet.ActionRead); err != nil {
+			return nil, err
+		}
 	}
 
 	return &svc.license, nil


### PR DESCRIPTION
Issue #5815

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [ ] Documented any permissions changes
- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
