### PR TITLE
Handle error retrieving license info in `getDeviceHostResponse` 

### DIFF
--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -57,7 +57,7 @@ func getDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.S
 
 	license, err := svc.License(ctx)
 	if err != nil {
-		return nil, err
+		return getDeviceHostResponse{Err: err}, nil
 	}
 
 	return getDeviceHostResponse{


### PR DESCRIPTION
Fix for PR [5820](https://github.com/fleetdm/fleet/pull/5820#discussion_r877563558) 
