### PR TITLE
wrap errors even if an error message is not provided

### DIFF
--- a/server/contexts/ctxerr/ctxerr.go
+++ b/server/contexts/ctxerr/ctxerr.go
@@ -121,8 +121,8 @@ func newError(ctx context.Context, msg string, cause error, data map[string]inte
 }
 
 func wrapError(ctx context.Context, msg string, cause error, data map[string]interface{}) error {
-	if msg == "" || cause == nil {
-		return cause
+	if cause == nil {
+		return nil
 	}
 
 	stack := newStack(2)


### PR DESCRIPTION
While I was writing integration tests for errors, I realized that not wrapping errors if an error message is provided is counter intuitive, for example I would expect `err` below to be a `*FleetError`:

```go
ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("authentication error: missing device authentication token"))
```

This is a carryover from the previous implementation, so I don't know if there are hidden gotchas about doing this that I'm not aware of, but it seems worth changing.

# Checklist for submitter

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
