### PR TITLE
fix duplicate hosts in vuln webhook

### DIFF
--- a/changes/issue-5595-duplicate-hosts-vuln-webhook
+++ b/changes/issue-5595-duplicate-hosts-vuln-webhook
@@ -1,0 +1,1 @@
+* Fixed an issue with duplicated hosts being sent in the vulnerability webhook payload.

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -976,7 +976,7 @@ func (ds *Datastore) CalculateHostsPerSoftware(ctx context.Context, updatedAt ti
 // matching hosts.
 func (ds *Datastore) HostsByCPEs(ctx context.Context, cpes []string) ([]*fleet.HostShort, error) {
 	queryStmt := `
-    SELECT
+    SELECT DISTINCT
       h.id,
       h.hostname
     FROM


### PR DESCRIPTION
#5594

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] ~Documented any API changes (docs/Using-Fleet/REST-API.md)~
- [ ] ~Documented any permissions changes~
- [ ] ~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
- [ ] ~Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [ ] ~Added/updated tests~
- [x] Manual QA for all new/changed functionality
