### PR TITLE
Fix root dir detection when using orbit shell

### DIFF
--- a/changes/issue-5734-fix-orbit-shell-root
+++ b/changes/issue-5734-fix-orbit-shell-root
@@ -1,0 +1,1 @@
+* Fixed an issue with detecting root directory when using `orbit shell`.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -135,12 +135,7 @@ func main() {
 			EnvVars: []string{"ORBIT_FLEET_DESKTOP"},
 		},
 	}
-	app.Action = func(c *cli.Context) error {
-		if c.Bool("version") {
-			fmt.Println("orbit " + build.Version)
-			return nil
-		}
-
+	app.Before = func(c *cli.Context) error {
 		// handle old installations, which had default root dir set to /var/lib/orbit
 		if c.String("root-dir") == "" {
 			rootDir := update.DefaultOptions.RootDirectory
@@ -153,6 +148,14 @@ func main() {
 				rootDir = "/var/lib/orbit"
 			}
 			c.Set("root-dir", rootDir)
+		}
+
+		return nil
+	}
+	app.Action = func(c *cli.Context) error {
+		if c.Bool("version") {
+			fmt.Println("orbit " + build.Version)
+			return nil
 		}
 
 		var logFile io.Writer


### PR DESCRIPTION
#5734

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] ~Documented any API changes (docs/Using-Fleet/REST-API.md)~
- [ ] ~Documented any permissions changes~
- [ ] ~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
- [ ] ~Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [ ] ~Added/updated tests~
- [x] Manual QA for all new/changed functionality
