### PR TITLE
[DO NOT MERGE] perf testing multiple failing hosts

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -548,8 +548,8 @@ func (a *agent) DistributedWrite(queries map[string]string) {
 	const hostPolicyQueryPrefix = "fleet_policy_query_"
 	const hostDetailQueryPrefix = "fleet_detail_query_"
 	for name := range queries {
-		r.Results[name] = defaultQueryResult
-		r.Statuses[name] = fleet.StatusOK
+		r.Results[name] = nil
+		r.Statuses[name] = 1
 		if strings.HasPrefix(name, hostPolicyQueryPrefix) {
 			r.Results[name] = a.runPolicy(queries[name])
 			continue
@@ -559,21 +559,21 @@ func (a *agent) DistributedWrite(queries map[string]string) {
 			continue
 		}
 		if name == hostDetailQueryPrefix+"mdm" {
-			r.Statuses[name] = fleet.OsqueryStatus(rand.Intn(2))
+			r.Statuses[name] = 1
 			r.Results[name] = nil
 			if r.Statuses[name] == fleet.StatusOK {
 				r.Results[name] = a.mdm()
 			}
 		}
 		if name == hostDetailQueryPrefix+"munki_info" {
-			r.Statuses[name] = fleet.OsqueryStatus(rand.Intn(2))
+			r.Statuses[name] = 1
 			r.Results[name] = nil
 			if r.Statuses[name] == fleet.StatusOK {
 				r.Results[name] = a.munkiInfo()
 			}
 		}
 		if name == hostDetailQueryPrefix+"google_chrome_profiles" {
-			r.Statuses[name] = fleet.OsqueryStatus(rand.Intn(2))
+			r.Statuses[name] = 1
 			r.Results[name] = nil
 			if r.Statuses[name] == fleet.StatusOK {
 				r.Results[name] = a.googleChromeProfiles()

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -822,8 +822,10 @@ func (svc *Service) SubmitDistributedQueryResults(
 		}
 
 		if err != nil {
-			logging.WithErr(ctx, ctxerr.New(ctx, "error in query ingestion"))
-			logging.WithExtras(ctx, "ingestion-err", err)
+			werr := ctxerr.New(ctx, "error in query ingestion")
+			logging.WithErr(ctx, werr)
+			logging.WithExtras(ctx, "ingestion-err", werr)
+			ctxerr.Handle(ctx, werr)
 		}
 	}
 


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [ ] Documented any permissions changes
- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
