### PR TITLE
Fix issue count display

### DIFF
--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -7,7 +7,6 @@ import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import classnames from "classnames";
 import { pick } from "lodash";
 
-import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import deviceUserAPI from "services/entities/device_user";
 import { IHost, IDeviceMappingResponse } from "interfaces/host";
@@ -248,7 +247,7 @@ const DeviceUserPage = ({
                     <Tab>
                       <div>
                         {titleData.issues.failing_policies_count > 0 && (
-                          <span className="fail-count">
+                          <span className="count">
                             {titleData.issues.failing_policies_count}
                           </span>
                         )}

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -275,20 +275,6 @@
     .section {
       margin-top: $pad-medium;
     }
-
-    .fail-count {
-      background-color: $ui-error;
-      border-radius: 45%;
-      color: $core-white;
-      display: inline-block;
-      padding: 0 10px;
-      font-size: 0.75rem;
-      font-weight: bold;
-      line-height: 1.75;
-      margin: 0 8px -8px 0;
-      position: relative;
-      top: -1px;
-    }
   }
 
   .col-50 {

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -158,9 +158,13 @@ const HostSummary = ({
             {titleData.status}
           </span>
         </div>
-        {titleData.issues?.total_issues_count > 0 && deviceUser
-          ? isPremiumTier && renderIssues()
-          : renderIssues()}
+        {titleData.issues?.total_issues_count > 0 &&
+          deviceUser &&
+          isPremiumTier &&
+          renderIssues()}
+        {titleData.issues?.total_issues_count > 0 &&
+          !deviceUser &&
+          renderIssues()}
         {!deviceUser && isPremiumTier && renderHostTeam()}
         <div className="info-flex__item info-flex__item--title">
           <span className="info-flex__header">Disk space</span>


### PR DESCRIPTION
This fixes a bug where the "Issues" count on the device page and host details was displaying with a value of 0. Unfortunately this can't be tested without manually changing the values until #5870 is resolved.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
