### PR TITLE
Fix some go lint warnings

### DIFF
--- a/cmd/fleetctl/debug.go
+++ b/cmd/fleetctl/debug.go
@@ -551,7 +551,7 @@ Such migrations can be applied via "fleet prepare db" before running "fleet serv
 
 func debugErrorsCommand() *cli.Command {
 	var (
-		name  string = "errors"
+		name  = "errors"
 		flush bool
 	)
 	return &cli.Command{

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -91,6 +91,7 @@ func main() {
 
 			tr := http.DefaultTransport.(*http.Transport)
 			if os.Getenv("FLEET_DESKTOP_INSECURE") != "" {
+				// #nosec
 				tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 			}
 			client := &http.Client{
@@ -122,6 +123,7 @@ func main() {
 
 			tr := http.DefaultTransport.(*http.Transport)
 			if os.Getenv("FLEET_DESKTOP_INSECURE") != "" {
+				// #nosec
 				tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 			}
 			client := &http.Client{
@@ -202,7 +204,6 @@ func parseLicenseAndPoliciesFromResponse(resp *http.Response) (licensePass bool,
 			}
 		}
 		return licensePass, true, nil
-	} else {
-		return false, false, nil
 	}
+	return false, false, nil
 }

--- a/server/contexts/ctxerr/ctxerr.go
+++ b/server/contexts/ctxerr/ctxerr.go
@@ -187,7 +187,7 @@ func Cause(err error) error {
 // FleetCause is similar to Cause, but returns the root-most
 // FleetError in the chain
 func FleetCause(err error) *FleetError {
-	var ferr, aux *FleetError = nil, nil
+	var ferr, aux *FleetError
 	var ok bool
 
 	for err != nil {

--- a/server/contexts/ctxerr/ctxerr_test.go
+++ b/server/contexts/ctxerr/ctxerr_test.go
@@ -301,7 +301,7 @@ func TestFleetCause(t *testing.T) {
 	ctx, cleanup := setup()
 	defer cleanup()
 
-	var nilErr *FleetError = nil
+	var nilErr *FleetError
 	errNew := errors.New("a")
 	errWrapRoot := Wrap(ctx, errNew, "wrapRoot")
 	errWrap1 := Wrap(ctx, errWrapRoot, "wrap1")

--- a/server/errorstore/errors.go
+++ b/server/errorstore/errors.go
@@ -142,7 +142,7 @@ func hashError(err error) string {
 
 	// hash the stack trace of the root FleetError in the chain
 	if ferr != nil {
-		fmt.Fprintf(&sb, strings.Join(ferr.Stack(), "\n"))
+		fmt.Fprint(&sb, strings.Join(ferr.Stack(), "\n"))
 	}
 
 	return sha256b64(sb.String())

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -237,7 +237,7 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte) (*fleet.AppCo
 			}
 		}
 		appConfig.SMTPSettings.SMTPConfigured = true
-	} else if appConfig.SMTPSettings.SMTPEnabled {
+	} else {
 		appConfig.SMTPSettings.SMTPConfigured = false
 	}
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -4851,7 +4851,10 @@ func (s *integrationTestSuite) TestHostsReportDownload() {
 	require.Len(t, rows[0], 44)        // total number of cols
 	t.Log(rows[0])
 
-	const idCol, issuesCol, deviceCol = 2, 40, 41
+	const (
+		idCol     = 2
+		issuesCol = 40
+	)
 
 	// find the row for hosts[1], it should have issues=1 (1 failing policy)
 	for _, row := range rows[1:] {
@@ -4892,6 +4895,7 @@ func (s *integrationTestSuite) TestHostsReportDownload() {
 	// with device mapping results
 	res = s.DoRaw("GET", "/api/latest/fleet/hosts/report", nil, http.StatusOK, "format", "csv", "columns", "id,hostname,device_mapping")
 	rawCSV, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
 	require.Contains(t, string(rawCSV), `"a@b.c,b@b.c"`) // inside quotes because it contains a comma
 	rows, err = csv.NewReader(bytes.NewReader(rawCSV)).ReadAll()
 	res.Body.Close()

--- a/server/service/service_appconfig.go
+++ b/server/service/service_appconfig.go
@@ -84,7 +84,7 @@ func (svc *Service) sendTestEmail(ctx context.Context, config *fleet.AppConfig) 
 
 func (svc *Service) makeTestJiraRequest(ctx context.Context, jiraSettings *fleet.JiraIntegration) error {
 	if jiraSettings.APIToken == "" || jiraSettings.APIToken == "********" {
-		return &badRequestError{message: fmt.Sprintf("jira integration request failed: missing or invalid API token")}
+		return &badRequestError{message: "jira integration request failed: missing or invalid API token"}
 	}
 	client, err := externalsvc.NewJiraClient(&externalsvc.JiraOptions{
 		BaseURL:           jiraSettings.URL,
@@ -103,7 +103,7 @@ func (svc *Service) makeTestJiraRequest(ctx context.Context, jiraSettings *fleet
 
 func (svc *Service) makeTestZendeskRequest(ctx context.Context, zendeskSettings *fleet.ZendeskIntegration) error {
 	if zendeskSettings.APIToken == "" || zendeskSettings.APIToken == "********" {
-		return &badRequestError{message: fmt.Sprintf("zendesk integration request failed: missing or invalid API token")}
+		return &badRequestError{message: "zendesk integration request failed: missing or invalid API token"}
 	}
 	client, err := externalsvc.NewZendeskClient(&externalsvc.ZendeskOptions{
 		URL:      zendeskSettings.URL,


### PR DESCRIPTION
Fixing the following warnings:

```
make lint-go
[...]
server/service/integration_core_test.go:4854:26: const `deviceCol` is unused (unused)
        const idCol, issuesCol, deviceCol = 2, 40, 41
                                ^
server/service/integration_core_test.go:4894:10: ineffectual assignment to err (ineffassign)
        rawCSV, err := io.ReadAll(res.Body)
                ^
cmd/fleetctl/debug.go:554:9: var-declaration: should omit type string from declaration of var name; it will be inferred from the right-hand side (revive)
                name  string = "errors"
                      ^
server/contexts/ctxerr/ctxerr_test.go:304:27: var-declaration: should drop = nil from declaration of var nilErr; it is the zero value (revive)
        var nilErr *FleetError = nil
                                 ^
server/contexts/ctxerr/ctxerr.go:190:12: ineffectual assignment to aux (ineffassign)
        var ferr, aux *FleetError = nil, nil
                  ^
orbit/cmd/desktop/desktop.go:94:38: G402: TLS InsecureSkipVerify set true. (gosec)
                                tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
                                                                 ^
orbit/cmd/desktop/desktop.go:125:38: G402: TLS InsecureSkipVerify set true. (gosec)
                                tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
                                                                 ^
orbit/cmd/desktop/desktop.go:205:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
        } else {
                return false, false, nil
        }
make: *** [lint-go] Error 1
```

```
$ staticcheck -tests=false ./... | rg -v unused | rg -v capitalized | rg -v "punctuation"
[...]
server/errorstore/errors.go:145:3: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
server/service/appconfig.go:240:12: this condition occurs multiple times in this if/else if chain (SA4014)
```