### PR TITLE
Add `orbit_info` support to `osquery-perf`

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -669,7 +669,7 @@ func main() {
 	commonUserCount := flag.Int("common_user_count", 10, "Number of common host users reported to fleet")
 	uniqueUserCount := flag.Int("unique_user_count", 10, "Number of unique host users reported to fleet")
 	policyPassProb := flag.Float64("policy_pass_prob", 1.0, "Probability of policies to pass [0, 1]")
-	orbitProb := flag.Float64("orbit_prob", 1.0, "Probability of a host being identified as orbit install [0, 1]")
+	orbitProb := flag.Float64("orbit_prob", 0.5, "Probability of a host being identified as orbit install [0, 1]")
 
 	flag.Parse()
 

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -669,7 +669,7 @@ func main() {
 	commonUserCount := flag.Int("common_user_count", 10, "Number of common host users reported to fleet")
 	uniqueUserCount := flag.Int("unique_user_count", 10, "Number of unique host users reported to fleet")
 	policyPassProb := flag.Float64("policy_pass_prob", 1.0, "Probability of policies to pass [0, 1]")
-	orbitProb := flag.Float64("orbit_prob", 1.0, "Probability of a host being identifier as orbit install [0, 1]")
+	orbitProb := flag.Float64("orbit_prob", 1.0, "Probability of a host being identified as orbit install [0, 1]")
 
 	flag.Parse()
 

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -192,12 +192,13 @@ func newAgent(
 	policyPassProb float64,
 	orbitProb float64,
 ) *agent {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-	transport.DisableCompression = true
 	var deviceAuthToken *string
 	if rand.Float64() <= orbitProb {
 		deviceAuthToken = ptr.String(uuid.NewString())
+	}
+	// #nosec (osquery-perf is only used for testing)
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true,
 	}
 	return &agent{
 		agentIndex:     agentIndex,
@@ -207,7 +208,7 @@ func newAgent(
 		strings:        make(map[string]string),
 		policyPassProb: policyPassProb,
 		fastClient: fasthttp.Client{
-			TLSConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSConfig: tlsConfig,
 		},
 		templates:       templates,
 		deviceAuthToken: deviceAuthToken,


### PR DESCRIPTION
#5698 

(I took the chance to cleanup `agent.DistributedWrite`)

- [X] Manual QA for all new/changed functionality
