### PR TITLE
Fix lint issue in Orbit test

### DIFF
--- a/ee/fleetctl/updates_test.go
+++ b/ee/fleetctl/updates_test.go
@@ -129,7 +129,7 @@ func assertFileExists(t *testing.T, path string) {
 	assert.True(t, st.Mode().IsRegular(), "should be regular file: %s", path)
 }
 
-func assertVersion(t *testing.T, expected int, versionFunc func() (int, error)) {
+func assertVersion(t *testing.T, expected int64, versionFunc func() (int64, error)) {
 	t.Helper()
 	actual, err := versionFunc()
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes issue introduced by #5894.

This was missed due to distraction from other (typical) CI failures on dependabot PRs.
