### PR TITLE
Fixed COO typo

### DIFF
--- a/handbook/security-policies.md
+++ b/handbook/security-policies.md
@@ -140,7 +140,7 @@ Fleet policy requires that:
 
 #### Line of Succession
 
-The following order of succession to make sure that decision-making authority for the Fleet Contingency Plan is uninterrupted. The Chief Operating Officer (CEO) is responsible for ensuring the safety of personnel and the execution of procedures documented within this Fleet Contingency Plan. The CTO is responsible for the recovery of Fleet technical environments. If the CEO or Head of Engineering cannot function as the overall authority or choose to delegate this responsibility to a successor, the board of directors shall serve as that authority or choose an alternative delegate. 
+The following order of succession to make sure that decision-making authority for the Fleet Contingency Plan is uninterrupted. The Chief Executive Officer (CEO) is responsible for ensuring the safety of personnel and the execution of procedures documented within this Fleet Contingency Plan. The CTO is responsible for the recovery of Fleet technical environments. If the CEO or Head of Engineering cannot function as the overall authority or choose to delegate this responsibility to a successor, the board of directors shall serve as that authority or choose an alternative delegate. 
 
 ### Response Teams and Responsibilities
 


### PR DESCRIPTION
Policy referred to the CEO but spelled out as Chief Operating Officer. Fixed!
