### PR TITLE
Performance improvements & bug fixes

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -304,18 +304,15 @@ func checkOvalVulnerabilities(
 		return
 	}
 
-	// Get Platforms/OS Versions
+	// Get Platforms
 	versions, err := ds.OSVersions(ctx, nil, nil)
 	if err != nil {
 		level.Error(logger).Log("msg", "updating oval definitions", "err", err)
 		sentry.CaptureException(err)
 		return
 	}
-	for _, os := range versions.OSVersions {
-		level.Debug(logger).Log("oval-updating", "Found OS Version", "platform", os.Platform, "version", os.Name)
-	}
 
-	// Sync
+	// Sync on disk OVAL definitions with current OS Versions.
 	client := fleethttp.NewClient()
 	downloaded, err := oval.Refresh(ctx, client, versions, vulnPath)
 	if err != nil {
@@ -323,14 +320,16 @@ func checkOvalVulnerabilities(
 		sentry.CaptureException(err)
 	}
 	for _, d := range downloaded {
-		level.Debug(logger).Log("oval-updating", "Downloaded new definitions", d)
+		level.Debug(logger).Log("oval-sync-downloaded", d)
 	}
 
-	// Analyze
-	_, err = oval.Analyze(ctx, ds, versions, vulnPath)
-	if err != nil {
-		level.Error(logger).Log("msg", "analyzing oval definitions", "err", err)
-		sentry.CaptureException(err)
+	// Analyze all supported os versions using the synched OVAL definitions.
+	for _, version := range versions.OSVersions {
+		_, err := oval.Analyze(ctx, ds, version, vulnPath)
+		if err != nil {
+			level.Error(logger).Log("msg", "analyzing oval definitions", "err", err)
+			sentry.CaptureException(err)
+		}
 	}
 }
 

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -325,7 +325,11 @@ func checkOvalVulnerabilities(
 
 	// Analyze all supported os versions using the synched OVAL definitions.
 	for _, version := range versions.OSVersions {
+		start := time.Now()
 		_, err := oval.Analyze(ctx, ds, version, vulnPath)
+		elapsed := time.Since(start)
+		level.Debug(logger).Log("msg", "oval-analysis-done", "platfrom", version.Name, "elapsed", elapsed)
+
 		if err != nil {
 			level.Error(logger).Log("msg", "analyzing oval definitions", "err", err)
 			sentry.CaptureException(err)

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -328,7 +328,7 @@ func checkOvalVulnerabilities(
 		start := time.Now()
 		_, err := oval.Analyze(ctx, ds, version, vulnPath)
 		elapsed := time.Since(start)
-		level.Debug(logger).Log("msg", "oval-analysis-done", "platfrom", version.Name, "elapsed", elapsed)
+		level.Debug(logger).Log("msg", "oval-analysis-done", "platform", version.Name, "elapsed", elapsed)
 
 		if err != nil {
 			level.Error(logger).Log("msg", "analyzing oval definitions", "err", err)

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -410,13 +410,13 @@ func loadUbuntuSoftware(ver string) []fleet.Software {
 	var software []softwareJSON
 	contents, err := ioutil.ReadFile(fmt.Sprintf("ubuntu_%s-vulnerable_software.json", ver))
 	if err != nil {
-		log.Println("reading vuln software for ubuntu 16.04:", err)
+		log.Printf("reading vuln software for ubuntu %s: %s\n", ver, err)
 		return nil
 	}
 
 	err = json.Unmarshal(contents, &software)
 	if err != nil {
-		log.Println("unmarshalling vuln software for ubuntu 16.04:", err)
+		log.Printf("unmarshalling vuln software for ubuntu %s:%s", ver, err)
 		return nil
 	}
 

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -697,12 +697,14 @@ func main() {
 
 	templateNames := []string{
 		"mac10.14.6.tml",
-		"ubuntu_16.04.tmpl",
-		"ubuntu_18.04.tmpl",
-		"ubuntu_20.04.tmpl",
-		"ubuntu_21.04.tmpl",
-		"ubuntu_21.10.tmpl",
-		"ubuntu_22.04.tmpl",
+
+		// Uncomment this to add ubuntu hosts with vulnerable software
+		// "ubuntu_16.04.tmpl",
+		// "ubuntu_18.04.tmpl",
+		// "ubuntu_20.04.tmpl",
+		// "ubuntu_21.04.tmpl",
+		// "ubuntu_21.10.tmpl",
+		// "ubuntu_22.04.tmpl",
 	}
 
 	var tmpls []*template.Template

--- a/cmd/osquery-perf/ubuntu_16.04.tmpl
+++ b/cmd/osquery-perf/ubuntu_16.04.tmpl
@@ -1,0 +1,364 @@
+{{ define "enroll" -}}
+{
+    "enroll_secret": "{{ .EnrollSecret  }}",
+    "host_details": {
+        "os_version": {
+            "build": "",
+            "major": "",
+            "minor": "",
+            "name": "Ubuntu 16.4.0",
+            "patch": "",
+            "platform": "ubuntu",
+            "platform_like": "ubuntu",
+            "version": "Ubuntu 16.4.0"
+        },
+        "osquery_info": {
+            "build_distro": "16.04",
+            "build_platform": "linux",
+            "config_hash": "",
+            "config_valid": "0",
+            "extensions": "inactive",
+            "instance_id": "{{ .UUID }}",
+            "pid": "12947",
+            "platform_mask": "21",
+            "start_time": "1580931224",
+            "uuid": "{{ .UUID }}",
+            "version": "4.6.0",
+            "watcher": "12946"
+        },
+        "platform_info": {
+            "address": "0xff990000",
+            "date": "12/16/2019 ",
+            "extra": "MBP114; 196.0.0.0.0; root@xapp160; Mon Dec 16 15:55:18 PST 2019; 196 (B&I); F000_B00; Official Build, Release; Apple LLVM version 5.0 (clang-500.0.68) (based on LLVM 3.3svn)",
+            "revision": "196 (B&I)",
+            "size": "8388608",
+            "vendor": "Apple Inc. ",
+            "version": "196.0.0.0.0 ",
+            "volume_size": "1507328"
+        },
+        "system_info": {
+            "computer_name": "{{ .CachedString "hostname" }}",
+            "cpu_brand": "Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+            "cpu_logical_cores": "8",
+            "cpu_physical_cores": "4",
+            "cpu_subtype": "Intel x86-64h Haswell",
+            "cpu_type": "x86_64h",
+            "hardware_model": "MacBookPro11,4",
+            "hardware_serial": "D02R835DG8WK",
+            "hardware_vendor": "Apple Inc.",
+            "hardware_version": "1.0",
+            "hostname": "{{ .CachedString "hostname" }}",
+            "local_hostname": "{{ .CachedString "hostname" }}",
+            "physical_memory": "17179869184",
+            "uuid": "{{ .UUID }}"
+        }
+    },
+    "host_identifier": "{{ .CachedString "hostname" }}",
+    "platform_type": "16"
+}
+{{- end }}
+
+{{ define "fleet_detail_query_network_interface" -}}
+[
+  {
+    "point_to_point":"",
+    "address":"fe80::8cb:112d:ff51:1e5d%en0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"en0",
+    "mac":"f8:2d:88:93:56:5c",
+    "type":"6",
+    "mtu":"1500",
+    "metric":"0",
+    "ipackets":"278493",
+    "opackets":"206238",
+    "ibytes":"275799040",
+    "obytes":"37720064",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582848084"
+  },
+  {
+    "point_to_point":"",
+    "address":"192.168.1.3",
+    "mask":"255.255.255.0",
+    "broadcast":"192.168.1.255",
+    "interface":"en0",
+    "mac":"f5:5a:80:92:52:5b",
+    "type":"6",
+    "mtu":"1500",
+    "metric":"0",
+    "ipackets":"278493",
+    "opackets":"206238",
+    "ibytes":"275799040",
+    "obytes":"37720064",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582848084"
+  },
+  {
+    "point_to_point":"127.0.0.1",
+    "address":"127.0.0.1",
+    "mask":"255.0.0.0",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"::1",
+    "address":"::1",
+    "mask":"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::1%lo0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::3a:84ff:fe6b:bf75%awdl0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"awdl0",
+    "mac":"03:3b:94:5b:be:75",
+    "type":"6",
+    "mtu":"1484",
+    "metric":"0",
+    "ipackets":"0",
+    "opackets":"16",
+    "ibytes":"0",
+    "obytes":"3072",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582842892"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::6eaf:9721:3476:b691%utun0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"utun0",
+    "mac":"00:00:00:00:00:00",
+    "type":"1",
+    "mtu":"2000",
+    "metric":"0",
+    "ipackets":"0",
+    "opackets":"2",
+    "ibytes":"0",
+    "obytes":"0",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840897"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_os_version" -}}
+[
+  {
+    "name":"Ubuntu",
+    "version":"Ubuntu 16.4.0",
+    "major":"16",
+    "minor":"4",
+    "patch":"0",
+    "build":"18G3020",
+    "platform":"ubuntu",
+    "platform_like":"ubuntu",
+    "codename":""
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_flags" -}}
+[
+  {
+    "name":"config_refresh",
+    "value":"{{ printf "%.0f" .ConfigInterval.Seconds }}"
+  },
+  {
+    "name":"distributed_interval",
+    "value":"{{ printf "%.0f" .QueryInterval.Seconds }}"
+  },
+  {
+    "name":"logger_tls_period",
+    "value":"99999"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_info" -}}
+[
+  {
+    "pid":"11287",
+    "uuid":"{{ .UUID }}",
+    "instance_id":"{{ .UUID }}",
+    "version":"4.1.2",
+    "config_hash":"b01efbf375ac6767f259ae98751154fef727ce35",
+    "config_valid":"1",
+    "extensions":"inactive",
+    "build_platform":"ubuntu",
+    "build_distro":"16.4.0",
+    "start_time":"1582857555",
+    "watcher":"11286",
+    "platform_mask":"21"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_system_info" -}}
+[
+  {
+    "hostname":"{{ .CachedString "hostname" }}",
+    "uuid":"4740D59F-699E-5B29-960B-979AAF9BBEEB",
+    "cpu_type":"x86_64h",
+    "cpu_subtype":"Intel x86-64h Haswell",
+    "cpu_brand":"Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz",
+    "cpu_physical_cores":"4",
+    "cpu_logical_cores":"8",
+    "cpu_microcode":"",
+    "physical_memory":"17179869184",
+    "hardware_vendor":"Apple Inc.",
+    "hardware_model":"MacBookPro11,4",
+    "hardware_version":"1.0",
+    "hardware_serial":"C02R262BM8LN",
+    "computer_name":"{{ .CachedString "hostname" }}",
+    "local_hostname":"{{ .CachedString "hostname" }}"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_uptime" -}}
+[
+  {
+    "days":"0",
+    "hours":"4",
+    "minutes":"38",
+    "seconds":"11",
+    "total_seconds":"16691"
+  }
+]
+{{- end }}
+
+{{ define "fleet_detail_query_users" -}}
+[
+  {{ range $index, $item := .HostUsersMacOS }}
+  {{if $index}},{{end}}
+  {
+    "uid": "{{ .Uid }}",
+    "username": "{{ .Username }}",
+    "type": "{{ .Type }}",
+    "groupname": "{{ .GroupName }}",
+    "shell": "{{ .Shell }}"
+  }
+  {{- end }}
+]
+{{- end }}
+
+{{/* all hosts */}}
+{{ define "fleet_label_query_6" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All macOS hosts */}}
+{{ define "fleet_label_query_7" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All Ubuntu hosts */}}
+{{ define "fleet_label_query_8" -}}
+[]
+{{- end }}
+
+{{/* All CentOS hosts */}}
+{{ define "fleet_label_query_9" -}}
+[]
+{{- end }}
+
+{{/* All Windows hosts */}}
+{{ define "fleet_label_query_10" -}}
+[]
+{{- end }}
+
+{{/* All Red Hat hosts */}}
+{{ define "fleet_label_query_11" -}}
+[]
+{{- end }}
+
+{{/* All Linux distributions */}}
+{{ define "fleet_label_query_12" -}}
+[]
+{{- end }}
+
+{{ define "fleet_detail_query_software_linux" -}}
+[
+  {{ range $index, $item := .SoftwareUbuntu1604 }}
+  {{if $index}},{{end}}
+  {
+    "name": "{{ .Name }}",
+    "version": "{{ .Version }}",
+    "type": "Application",
+    "bundle_identifier": "{{ .BundleIdentifier }}",
+    "source": "apps",
+    {{/* Note that in Go < 1.18, `{{ or (and .LastOpendedAt .LastOpenedAt.Unix) "" }}` won't work as expected because "and" and "or" don't short circuit. This was changed in Go 1.18 */}}
+    {{if .LastOpenedAt}}
+    "last_opened_at": "{{ .LastOpenedAt.Unix }}"
+    {{else}}
+    "last_opened_at": "-1"
+    {{end}}
+  }
+  {{- end }}
+]
+{{- end }}

--- a/cmd/osquery-perf/ubuntu_1604-vulnerable_software.json
+++ b/cmd/osquery-perf/ubuntu_1604-vulnerable_software.json
@@ -1,0 +1,7126 @@
+[
+  {
+    "name": "defer",
+    "version": "1.0.6"
+  },
+  {
+    "name": "grub-gfxpayload-lists",
+    "version": "0.7"
+  },
+  {
+    "name": "language-selector",
+    "version": "0.1"
+  },
+  {
+    "name": "ubuntu-drivers-common",
+    "version": "0.0.0"
+  },
+  {
+    "name": "unattended-upgrades",
+    "version": "0.1"
+  },
+  {
+    "name": "osquery",
+    "version": "5.2.3-1.linux"
+  },
+  {
+    "name": "libjpeg8",
+    "version": "8c-2ubuntu8"
+  },
+  {
+    "name": "Firefox Screenshots",
+    "version": "39.0.0"
+  },
+  {
+    "name": "Form Autofill",
+    "version": "1.0"
+  },
+  {
+    "name": "libxcb-image0",
+    "version": "0.4.0-1build1"
+  },
+  {
+    "name": "alsa-base",
+    "version": "1.0.25+dfsg-0ubuntu5"
+  },
+  {
+    "name": "fonts-guru",
+    "version": "2:1.2"
+  },
+  {
+    "name": "fonts-khmeros-core",
+    "version": "5.0-7ubuntu1"
+  },
+  {
+    "name": "fonts-lklug-sinhala",
+    "version": "0.6-3"
+  },
+  {
+    "name": "fonts-tibetan-machine",
+    "version": "1.901b-5"
+  },
+  {
+    "name": "libauthen-sasl-perl",
+    "version": "2.1600-1"
+  },
+  {
+    "name": "libencode-locale-perl",
+    "version": "1.05-1"
+  },
+  {
+    "name": "libfile-desktopentry-perl",
+    "version": "0.22-1"
+  },
+  {
+    "name": "libfile-listing-perl",
+    "version": "6.04-1"
+  },
+  {
+    "name": "libio-html-perl",
+    "version": "1.001-1"
+  },
+  {
+    "name": "libtie-ixhash-perl",
+    "version": "1.23-2"
+  },
+  {
+    "name": "libx11-protocol-perl",
+    "version": "0.56-7"
+  },
+  {
+    "name": "libxaw7",
+    "version": "2:1.0.13-1"
+  },
+  {
+    "name": "libxcb-util1",
+    "version": "0.4.0-0ubuntu3"
+  },
+  {
+    "name": "linux-sound-base",
+    "version": "1.0.25+dfsg-0ubuntu5"
+  },
+  {
+    "name": "xbitmaps",
+    "version": "1.1.1-2"
+  },
+  {
+    "name": "xfonts-scalable",
+    "version": "1:1.0.3-1.1"
+  },
+  {
+    "name": "acpi-support",
+    "version": "0.142"
+  },
+  {
+    "name": "app-install-data-partner",
+    "version": "16.04"
+  },
+  {
+    "name": "apport-symptoms",
+    "version": "0.20"
+  },
+  {
+    "name": "emacsen-common",
+    "version": "2.0.8"
+  },
+  {
+    "name": "fonts-sil-abyssinica",
+    "version": "1.500-1"
+  },
+  {
+    "name": "intltool-debian",
+    "version": "0.35.0+20060710.4"
+  },
+  {
+    "name": "libdaemon0",
+    "version": "0.14-6"
+  },
+  {
+    "name": "libdigest-hmac-perl",
+    "version": "1.03+dfsg-1"
+  },
+  {
+    "name": "libfile-basedir-perl",
+    "version": "0.07-1"
+  },
+  {
+    "name": "libfontenc1",
+    "version": "1:1.1.3-1"
+  },
+  {
+    "name": "libhtml-form-perl",
+    "version": "6.03-1"
+  },
+  {
+    "name": "libhttp-daemon-perl",
+    "version": "6.01-1"
+  },
+  {
+    "name": "libhttp-date-perl",
+    "version": "6.02-1"
+  },
+  {
+    "name": "libhttp-negotiate-perl",
+    "version": "6.00-2"
+  },
+  {
+    "name": "libilmbase12",
+    "version": "2.2.0-11ubuntu2"
+  },
+  {
+    "name": "libio-socket-inet6-perl",
+    "version": "2.72-2"
+  },
+  {
+    "name": "libio-string-perl",
+    "version": "1.08-3"
+  },
+  {
+    "name": "liblwp-mediatypes-perl",
+    "version": "6.02-1"
+  },
+  {
+    "name": "liblzo2-2",
+    "version": "2.08-1.2"
+  },
+  {
+    "name": "libnet-ip-perl",
+    "version": "1.26-1"
+  },
+  {
+    "name": "libnfnetlink0",
+    "version": "1.0.1-3"
+  },
+  {
+    "name": "libogg0",
+    "version": "1.3.2-1"
+  },
+  {
+    "name": "libopus0",
+    "version": "1.1.2-1ubuntu1"
+  },
+  {
+    "name": "libsm6",
+    "version": "2:1.2.2-1"
+  },
+  {
+    "name": "libtext-levenshtein-perl",
+    "version": "0.13-1"
+  },
+  {
+    "name": "libtext-wrapi18n-perl",
+    "version": "0.06-7.1"
+  },
+  {
+    "name": "libtimedate-perl",
+    "version": "2.3000-2"
+  },
+  {
+    "name": "libwww-robotrules-perl",
+    "version": "6.01-1"
+  },
+  {
+    "name": "libxcb-icccm4",
+    "version": "0.4.1-1ubuntu1"
+  },
+  {
+    "name": "libxcb-keysyms1",
+    "version": "0.4.0-1"
+  },
+  {
+    "name": "libxcb-render-util0",
+    "version": "0.3.9-1"
+  },
+  {
+    "name": "libxext6",
+    "version": "2:1.3.3-1"
+  },
+  {
+    "name": "libxft2",
+    "version": "2.3.2-1"
+  },
+  {
+    "name": "libxinerama1",
+    "version": "2:1.1.3-1"
+  },
+  {
+    "name": "libxmu6",
+    "version": "2:1.1.2-2"
+  },
+  {
+    "name": "libxmuu1",
+    "version": "2:1.1.2-2"
+  },
+  {
+    "name": "libxss1",
+    "version": "1:1.2.2-1"
+  },
+  {
+    "name": "libxxf86dga1",
+    "version": "2:1.1.4-1"
+  },
+  {
+    "name": "libxxf86vm1",
+    "version": "1:1.1.4-1"
+  },
+  {
+    "name": "lsof",
+    "version": "4.89+dfsg-0.1"
+  },
+  {
+    "name": "memtest86+",
+    "version": "5.01-3ubuntu2"
+  },
+  {
+    "name": "pppoeconf",
+    "version": "1.21ubuntu1"
+  },
+  {
+    "name": "python3-defer",
+    "version": "1.0.6-2build1"
+  },
+  {
+    "name": "python3-xkit",
+    "version": "0.5.0ubuntu2"
+  },
+  {
+    "name": "ubuntu-sounds",
+    "version": "0.13"
+  },
+  {
+    "name": "xcursor-themes",
+    "version": "1.0.4-1"
+  },
+  {
+    "name": "xfonts-base",
+    "version": "1:1.0.4+nmu1"
+  },
+  {
+    "name": "xfonts-encodings",
+    "version": "1:1.0.4-2"
+  },
+  {
+    "name": "Amazon.com",
+    "version": "1.1"
+  },
+  {
+    "name": "Bing",
+    "version": "1.1"
+  },
+  {
+    "name": "Dark",
+    "version": "1.0"
+  },
+  {
+    "name": "Default",
+    "version": "1.0"
+  },
+  {
+    "name": "DoH Roll-Out",
+    "version": "1.3.0"
+  },
+  {
+    "name": "DuckDuckGo",
+    "version": "1.0"
+  },
+  {
+    "name": "English (CA) Language Pack",
+    "version": "79.0buildid20200720193547"
+  },
+  {
+    "name": "English (GB) Language Pack",
+    "version": "79.0buildid20200720193547"
+  },
+  {
+    "name": "Google",
+    "version": "1.0"
+  },
+  {
+    "name": "Jinja2",
+    "version": "2.8"
+  },
+  {
+    "name": "Light",
+    "version": "1.0"
+  },
+  {
+    "name": "Mako",
+    "version": "1.0.3"
+  },
+  {
+    "name": "MarkupSafe",
+    "version": "0.23"
+  },
+  {
+    "name": "Pillow",
+    "version": "3.1.2"
+  },
+  {
+    "name": "PyJWT",
+    "version": "1.3.0"
+  },
+  {
+    "name": "Web Compat",
+    "version": "12.0.0"
+  },
+  {
+    "name": "WebCompat Reporter",
+    "version": "1.3.0"
+  },
+  {
+    "name": "Wikipedia (en)",
+    "version": "1.0"
+  },
+  {
+    "name": "a11y-profile-manager-indicator",
+    "version": "0.1.10-0ubuntu3"
+  },
+  {
+    "name": "account-plugin-facebook",
+    "version": "0.12+16.04.20160126-0ubuntu1"
+  },
+  {
+    "name": "account-plugin-flickr",
+    "version": "0.12+16.04.20160126-0ubuntu1"
+  },
+  {
+    "name": "account-plugin-google",
+    "version": "0.12+16.04.20160126-0ubuntu1"
+  },
+  {
+    "name": "accountsservice",
+    "version": "0.6.40-2ubuntu11.3"
+  },
+  {
+    "name": "acl",
+    "version": "2.2.52-3"
+  },
+  {
+    "name": "acpid",
+    "version": "1:2.0.26-1ubuntu2"
+  },
+  {
+    "name": "activity-log-manager",
+    "version": "0.9.7-0ubuntu23.16.04.1"
+  },
+  {
+    "name": "adduser",
+    "version": "3.113+nmu3ubuntu4"
+  },
+  {
+    "name": "adium-theme-ubuntu",
+    "version": "0.3.4-0ubuntu1.1"
+  },
+  {
+    "name": "adwaita-icon-theme",
+    "version": "3.18.0-2ubuntu3.1"
+  },
+  {
+    "name": "aisleriot",
+    "version": "1:3.18.2-1ubuntu1"
+  },
+  {
+    "name": "alsa-utils",
+    "version": "1.1.0-0ubuntu5"
+  },
+  {
+    "name": "amd64-microcode",
+    "version": "3.20191021.1+really3.20180524.1~ubuntu0.16.04.2"
+  },
+  {
+    "name": "anacron",
+    "version": "2.3-23"
+  },
+  {
+    "name": "apg",
+    "version": "2.2.3.dfsg.1-2ubuntu1"
+  },
+  {
+    "name": "app-install-data",
+    "version": "15.10"
+  },
+  {
+    "name": "apparmor",
+    "version": "2.10.95-0ubuntu2.11"
+  },
+  {
+    "name": "appmenu-qt",
+    "version": "0.2.7+14.04.20140305-0ubuntu2"
+  },
+  {
+    "name": "appmenu-qt5",
+    "version": "0.3.0+16.04.20170216-0ubuntu1"
+  },
+  {
+    "name": "apport",
+    "version": "2.20.1-0ubuntu2.24"
+  },
+  {
+    "name": "apport-gtk",
+    "version": "2.20.1-0ubuntu2.24"
+  },
+  {
+    "name": "appstream",
+    "version": "0.9.4-1ubuntu4"
+  },
+  {
+    "name": "apt",
+    "version": "1.2.32ubuntu0.1"
+  },
+  {
+    "name": "apt-transport-https",
+    "version": "1.2.32ubuntu0.1"
+  },
+  {
+    "name": "apt-utils",
+    "version": "1.2.32ubuntu0.1"
+  },
+  {
+    "name": "aptdaemon",
+    "version": "1.1.1+bzr982-0ubuntu14.3"
+  },
+  {
+    "name": "aptdaemon-data",
+    "version": "1.1.1+bzr982-0ubuntu14.3"
+  },
+  {
+    "name": "apturl",
+    "version": "0.5.2ubuntu11.2"
+  },
+  {
+    "name": "apturl-common",
+    "version": "0.5.2ubuntu11.2"
+  },
+  {
+    "name": "aspell",
+    "version": "0.60.7~20110707-3ubuntu0.1"
+  },
+  {
+    "name": "aspell-en",
+    "version": "7.1-0-1.1"
+  },
+  {
+    "name": "at-spi2-core",
+    "version": "2.18.3-4ubuntu1"
+  },
+  {
+    "name": "avahi-autoipd",
+    "version": "0.6.32~rc+dfsg-1ubuntu2.3"
+  },
+  {
+    "name": "avahi-daemon",
+    "version": "0.6.32~rc+dfsg-1ubuntu2.3"
+  },
+  {
+    "name": "avahi-utils",
+    "version": "0.6.32~rc+dfsg-1ubuntu2.3"
+  },
+  {
+    "name": "bamfdaemon",
+    "version": "0.5.3~bzr0+16.04.20180209-0ubuntu1"
+  },
+  {
+    "name": "baobab",
+    "version": "3.18.1-1ubuntu1"
+  },
+  {
+    "name": "base-files",
+    "version": "9.4ubuntu4.12"
+  },
+  {
+    "name": "base-passwd",
+    "version": "3.5.39"
+  },
+  {
+    "name": "bash",
+    "version": "4.3-14ubuntu1.4"
+  },
+  {
+    "name": "bash-completion",
+    "version": "1:2.1-4.2ubuntu1.1"
+  },
+  {
+    "name": "bc",
+    "version": "1.06.95-9build1"
+  },
+  {
+    "name": "beautifulsoup4",
+    "version": "4.4.1"
+  },
+  {
+    "name": "bind9-host",
+    "version": "1:9.10.3.dfsg.P4-8ubuntu1.16"
+  },
+  {
+    "name": "binutils",
+    "version": "2.26.1-1ubuntu1~16.04.8"
+  },
+  {
+    "name": "bluez",
+    "version": "5.37-0ubuntu5.3"
+  },
+  {
+    "name": "bluez-cups",
+    "version": "5.37-0ubuntu5.3"
+  },
+  {
+    "name": "bluez-obexd",
+    "version": "5.37-0ubuntu5.3"
+  },
+  {
+    "name": "branding-ubuntu",
+    "version": "0.8"
+  },
+  {
+    "name": "brltty",
+    "version": "5.3.1-2ubuntu2.1"
+  },
+  {
+    "name": "bsdmainutils",
+    "version": "9.0.6ubuntu3"
+  },
+  {
+    "name": "bsdutils",
+    "version": "1:2.27.1-6ubuntu3.10"
+  },
+  {
+    "name": "build-essential",
+    "version": "12.1ubuntu2"
+  },
+  {
+    "name": "busybox-initramfs",
+    "version": "1:1.22.0-15ubuntu1.4"
+  },
+  {
+    "name": "busybox-static",
+    "version": "1:1.22.0-15ubuntu1.4"
+  },
+  {
+    "name": "bzip2",
+    "version": "1.0.6-8ubuntu0.2"
+  },
+  {
+    "name": "ca-certificates",
+    "version": "20190110~16.04.1"
+  },
+  {
+    "name": "chardet",
+    "version": "2.3.0"
+  },
+  {
+    "name": "checkbox-converged",
+    "version": "1.2.4-0ubuntu1"
+  },
+  {
+    "name": "checkbox-gui",
+    "version": "1.2.4-0ubuntu1"
+  },
+  {
+    "name": "checkbox-support",
+    "version": "0.22"
+  },
+  {
+    "name": "cheese",
+    "version": "3.18.1-2ubuntu3"
+  },
+  {
+    "name": "cheese-common",
+    "version": "3.18.1-2ubuntu3"
+  },
+  {
+    "name": "colord",
+    "version": "1.2.12-1ubuntu1"
+  },
+  {
+    "name": "colord-data",
+    "version": "1.2.12-1ubuntu1"
+  },
+  {
+    "name": "command-not-found",
+    "version": "0.3ubuntu16.04.2"
+  },
+  {
+    "name": "command-not-found-data",
+    "version": "0.3ubuntu16.04.2"
+  },
+  {
+    "name": "compiz",
+    "version": "1:0.9.12.3+16.04.20180221-0ubuntu1"
+  },
+  {
+    "name": "compiz-core",
+    "version": "1:0.9.12.3+16.04.20180221-0ubuntu1"
+  },
+  {
+    "name": "compiz-gnome",
+    "version": "1:0.9.12.3+16.04.20180221-0ubuntu1"
+  },
+  {
+    "name": "compiz-plugins-default",
+    "version": "1:0.9.12.3+16.04.20180221-0ubuntu1"
+  },
+  {
+    "name": "console-setup",
+    "version": "1.108ubuntu15.5"
+  },
+  {
+    "name": "console-setup-linux",
+    "version": "1.108ubuntu15.5"
+  },
+  {
+    "name": "coreutils",
+    "version": "8.25-2ubuntu3~16.04"
+  },
+  {
+    "name": "cpio",
+    "version": "2.11+dfsg-5ubuntu1.1"
+  },
+  {
+    "name": "cpp",
+    "version": "4:5.3.1-1ubuntu1"
+  },
+  {
+    "name": "cpp-5",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "cracklib-runtime",
+    "version": "2.9.2-1ubuntu1"
+  },
+  {
+    "name": "crda",
+    "version": "3.13-1"
+  },
+  {
+    "name": "cron",
+    "version": "3.0pl1-128ubuntu2"
+  },
+  {
+    "name": "cryptography",
+    "version": "1.2.3"
+  },
+  {
+    "name": "cups",
+    "version": "2.1.3-4ubuntu0.11"
+  },
+  {
+    "name": "cups-browsed",
+    "version": "1.8.3-2ubuntu3.5"
+  },
+  {
+    "name": "cups-bsd",
+    "version": "2.1.3-4ubuntu0.11"
+  },
+  {
+    "name": "cups-client",
+    "version": "2.1.3-4ubuntu0.11"
+  },
+  {
+    "name": "cups-common",
+    "version": "2.1.3-4ubuntu0.11"
+  },
+  {
+    "name": "cups-core-drivers",
+    "version": "2.1.3-4ubuntu0.11"
+  },
+  {
+    "name": "cups-daemon",
+    "version": "2.1.3-4ubuntu0.11"
+  },
+  {
+    "name": "cups-filters",
+    "version": "1.8.3-2ubuntu3.5"
+  },
+  {
+    "name": "cups-filters-core-drivers",
+    "version": "1.8.3-2ubuntu3.5"
+  },
+  {
+    "name": "cups-pk-helper",
+    "version": "0.2.5-2ubuntu2"
+  },
+  {
+    "name": "cups-ppdc",
+    "version": "2.1.3-4ubuntu0.11"
+  },
+  {
+    "name": "cups-server-common",
+    "version": "2.1.3-4ubuntu0.11"
+  },
+  {
+    "name": "dash",
+    "version": "0.5.8-2.1ubuntu2"
+  },
+  {
+    "name": "dbus",
+    "version": "1.10.6-1ubuntu3.6"
+  },
+  {
+    "name": "dbus-x11",
+    "version": "1.10.6-1ubuntu3.6"
+  },
+  {
+    "name": "dc",
+    "version": "1.06.95-9build1"
+  },
+  {
+    "name": "dconf-cli",
+    "version": "0.24.0-2"
+  },
+  {
+    "name": "dconf-gsettings-backend",
+    "version": "0.24.0-2"
+  },
+  {
+    "name": "dconf-service",
+    "version": "0.24.0-2"
+  },
+  {
+    "name": "debconf",
+    "version": "1.5.58ubuntu2"
+  },
+  {
+    "name": "debconf-i18n",
+    "version": "1.5.58ubuntu2"
+  },
+  {
+    "name": "debianutils",
+    "version": "4.7"
+  },
+  {
+    "name": "deja-dup",
+    "version": "34.2-0ubuntu1.1"
+  },
+  {
+    "name": "desktop-file-utils",
+    "version": "0.22-1ubuntu5.2"
+  },
+  {
+    "name": "dh-python",
+    "version": "2.20151103ubuntu1.2"
+  },
+  {
+    "name": "dictionaries-common",
+    "version": "1.26.3"
+  },
+  {
+    "name": "diffstat",
+    "version": "1.61-1"
+  },
+  {
+    "name": "diffutils",
+    "version": "1:3.3-3"
+  },
+  {
+    "name": "dirmngr",
+    "version": "2.1.11-6ubuntu2.1"
+  },
+  {
+    "name": "distro-info-data",
+    "version": "0.28ubuntu0.14"
+  },
+  {
+    "name": "dmidecode",
+    "version": "3.0-2ubuntu0.2"
+  },
+  {
+    "name": "dmz-cursor-theme",
+    "version": "0.4.4ubuntu1"
+  },
+  {
+    "name": "dns-root-data",
+    "version": "2018013001~16.04.1"
+  },
+  {
+    "name": "dnsmasq-base",
+    "version": "2.75-1ubuntu0.16.04.5"
+  },
+  {
+    "name": "dnsutils",
+    "version": "1:9.10.3.dfsg.P4-8ubuntu1.16"
+  },
+  {
+    "name": "doc-base",
+    "version": "0.10.7"
+  },
+  {
+    "name": "dosfstools",
+    "version": "3.0.28-2ubuntu0.1"
+  },
+  {
+    "name": "dpkg",
+    "version": "1.18.4ubuntu1.6"
+  },
+  {
+    "name": "dpkg-dev",
+    "version": "1.18.4ubuntu1.6"
+  },
+  {
+    "name": "e2fslibs",
+    "version": "1.42.13-1ubuntu1.2"
+  },
+  {
+    "name": "e2fsprogs",
+    "version": "1.42.13-1ubuntu1.2"
+  },
+  {
+    "name": "ed",
+    "version": "1.10-2"
+  },
+  {
+    "name": "efibootmgr",
+    "version": "0.12-4"
+  },
+  {
+    "name": "eject",
+    "version": "2.1.5+deb1+cvs20081104-13.1ubuntu0.16.04.1"
+  },
+  {
+    "name": "enchant",
+    "version": "1.6.0-10.1build2"
+  },
+  {
+    "name": "eog",
+    "version": "3.18.2-1ubuntu2.1"
+  },
+  {
+    "name": "espeak-data",
+    "version": "1.48.04+dfsg-2"
+  },
+  {
+    "name": "ethtool",
+    "version": "1:4.5-1"
+  },
+  {
+    "name": "evince",
+    "version": "3.18.2-1ubuntu4.6"
+  },
+  {
+    "name": "evince-common",
+    "version": "3.18.2-1ubuntu4.6"
+  },
+  {
+    "name": "evolution-data-server",
+    "version": "3.18.5-1ubuntu1.3"
+  },
+  {
+    "name": "evolution-data-server-common",
+    "version": "3.18.5-1ubuntu1.3"
+  },
+  {
+    "name": "evolution-data-server-online-accounts",
+    "version": "3.18.5-1ubuntu1.3"
+  },
+  {
+    "name": "example-content",
+    "version": "49"
+  },
+  {
+    "name": "fakeroot",
+    "version": "1.20.2-1ubuntu1"
+  },
+  {
+    "name": "feedparser",
+    "version": "5.1.3"
+  },
+  {
+    "name": "file",
+    "version": "1:5.25-2ubuntu1.4"
+  },
+  {
+    "name": "file-roller",
+    "version": "3.16.5-0ubuntu1.4"
+  },
+  {
+    "name": "findutils",
+    "version": "4.6.0+git+20160126-2"
+  },
+  {
+    "name": "firefox",
+    "version": "79.0+build1-0ubuntu0.16.04.2"
+  },
+  {
+    "name": "firefox-locale-en",
+    "version": "79.0+build1-0ubuntu0.16.04.2"
+  },
+  {
+    "name": "fontconfig",
+    "version": "2.11.94-0ubuntu1.1"
+  },
+  {
+    "name": "fontconfig-config",
+    "version": "2.11.94-0ubuntu1.1"
+  },
+  {
+    "name": "fonts-dejavu-core",
+    "version": "2.35-1"
+  },
+  {
+    "name": "fonts-freefont-ttf",
+    "version": "20120503-4"
+  },
+  {
+    "name": "fonts-guru-extra",
+    "version": "2.0-3"
+  },
+  {
+    "name": "fonts-kacst",
+    "version": "2.01+mry-12"
+  },
+  {
+    "name": "fonts-kacst-one",
+    "version": "5.0+svn11846-7"
+  },
+  {
+    "name": "fonts-lao",
+    "version": "0.0.20060226-9"
+  },
+  {
+    "name": "fonts-liberation",
+    "version": "1.07.4-1"
+  },
+  {
+    "name": "fonts-lohit-guru",
+    "version": "2.5.3-2"
+  },
+  {
+    "name": "fonts-nanum",
+    "version": "20140930-1"
+  },
+  {
+    "name": "fonts-noto-cjk",
+    "version": "1:1.004+repack2-1~ubuntu1"
+  },
+  {
+    "name": "fonts-opensymbol",
+    "version": "2:102.7+LibO5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "fonts-sil-padauk",
+    "version": "2.80-2"
+  },
+  {
+    "name": "fonts-stix",
+    "version": "1.1.1-4"
+  },
+  {
+    "name": "fonts-symbola",
+    "version": "2.59-1"
+  },
+  {
+    "name": "fonts-takao-pgothic",
+    "version": "003.02.01-9ubuntu3"
+  },
+  {
+    "name": "fonts-thai-tlwg",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-garuda",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-garuda-ttf",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-kinnari",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-kinnari-ttf",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-laksaman",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-laksaman-ttf",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-loma",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-loma-ttf",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-mono",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-mono-ttf",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-norasi",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-norasi-ttf",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-purisa",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-purisa-ttf",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-sawasdee",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-sawasdee-ttf",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-typewriter",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-typewriter-ttf",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-typist",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-typist-ttf",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-typo",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-typo-ttf",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-umpush",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-umpush-ttf",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-waree",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "fonts-tlwg-waree-ttf",
+    "version": "1:0.6.2-2.1"
+  },
+  {
+    "name": "foomatic-db-compressed-ppds",
+    "version": "20160212-0ubuntu1"
+  },
+  {
+    "name": "friendly-recovery",
+    "version": "0.2.31ubuntu2.1"
+  },
+  {
+    "name": "ftp",
+    "version": "0.17-33"
+  },
+  {
+    "name": "fuse",
+    "version": "2.9.4-1ubuntu3.1"
+  },
+  {
+    "name": "fwupd",
+    "version": "0.8.3-0ubuntu5.1"
+  },
+  {
+    "name": "fwupdate",
+    "version": "0.5-2ubuntu7"
+  },
+  {
+    "name": "fwupdate-signed",
+    "version": "1.11.3+0.5-2ubuntu7"
+  },
+  {
+    "name": "g++",
+    "version": "4:5.3.1-1ubuntu1"
+  },
+  {
+    "name": "g++-5",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "gcc",
+    "version": "4:5.3.1-1ubuntu1"
+  },
+  {
+    "name": "gcc-5",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "gcc-5-base",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "gcc-6-base",
+    "version": "6.0.1-0ubuntu1"
+  },
+  {
+    "name": "gconf-service",
+    "version": "3.2.6-3ubuntu6"
+  },
+  {
+    "name": "gconf-service-backend",
+    "version": "3.2.6-3ubuntu6"
+  },
+  {
+    "name": "gconf2",
+    "version": "3.2.6-3ubuntu6"
+  },
+  {
+    "name": "gconf2-common",
+    "version": "3.2.6-3ubuntu6"
+  },
+  {
+    "name": "gcr",
+    "version": "3.18.0-1ubuntu1"
+  },
+  {
+    "name": "gdb",
+    "version": "7.11.1-0ubuntu1~16.5"
+  },
+  {
+    "name": "gdbserver",
+    "version": "7.11.1-0ubuntu1~16.5"
+  },
+  {
+    "name": "gdisk",
+    "version": "1.0.1-1build1"
+  },
+  {
+    "name": "gedit",
+    "version": "3.18.3-0ubuntu4"
+  },
+  {
+    "name": "gedit-common",
+    "version": "3.18.3-0ubuntu4"
+  },
+  {
+    "name": "genisoimage",
+    "version": "9:1.1.11-3ubuntu1"
+  },
+  {
+    "name": "geoclue",
+    "version": "0.12.99-4ubuntu1"
+  },
+  {
+    "name": "geoclue-ubuntu-geoip",
+    "version": "1.0.2+14.04.20131125-0ubuntu2.16.04.1"
+  },
+  {
+    "name": "geoip-database",
+    "version": "20160408-1"
+  },
+  {
+    "name": "gettext",
+    "version": "0.19.7-2ubuntu3.1"
+  },
+  {
+    "name": "gettext-base",
+    "version": "0.19.7-2ubuntu3.1"
+  },
+  {
+    "name": "ghostscript",
+    "version": "9.26~dfsg+0-0ubuntu0.16.04.12"
+  },
+  {
+    "name": "ghostscript-x",
+    "version": "9.26~dfsg+0-0ubuntu0.16.04.12"
+  },
+  {
+    "name": "gir1.2-accounts-1.0",
+    "version": "1.21+16.04.20160222-0ubuntu1"
+  },
+  {
+    "name": "gir1.2-appindicator3-0.1",
+    "version": "12.10.1+16.04.20170215-0ubuntu1"
+  },
+  {
+    "name": "gir1.2-atk-1.0",
+    "version": "2.18.0-1"
+  },
+  {
+    "name": "gir1.2-atspi-2.0",
+    "version": "2.18.3-4ubuntu1"
+  },
+  {
+    "name": "gir1.2-dbusmenu-glib-0.4",
+    "version": "16.04.1+16.04.20160927-0ubuntu1"
+  },
+  {
+    "name": "gir1.2-dee-1.0",
+    "version": "1.2.7+15.04.20150304-0ubuntu2"
+  },
+  {
+    "name": "gir1.2-freedesktop",
+    "version": "1.46.0-3ubuntu1"
+  },
+  {
+    "name": "gir1.2-gdata-0.0",
+    "version": "0.17.4-1"
+  },
+  {
+    "name": "gir1.2-gdkpixbuf-2.0",
+    "version": "2.32.2-1ubuntu1.6"
+  },
+  {
+    "name": "gir1.2-glib-2.0",
+    "version": "1.46.0-3ubuntu1"
+  },
+  {
+    "name": "gir1.2-gnomekeyring-1.0",
+    "version": "3.12.0-1build1"
+  },
+  {
+    "name": "gir1.2-goa-1.0",
+    "version": "3.18.3-1ubuntu2"
+  },
+  {
+    "name": "gir1.2-gst-plugins-base-1.0",
+    "version": "1.8.3-1ubuntu0.3"
+  },
+  {
+    "name": "gir1.2-gstreamer-1.0",
+    "version": "1.8.3-1~ubuntu0.1"
+  },
+  {
+    "name": "gir1.2-gtk-3.0",
+    "version": "3.18.9-1ubuntu3.3"
+  },
+  {
+    "name": "gir1.2-gtksource-3.0",
+    "version": "3.18.2-1"
+  },
+  {
+    "name": "gir1.2-gudev-1.0",
+    "version": "1:230-2"
+  },
+  {
+    "name": "gir1.2-ibus-1.0",
+    "version": "1.5.11-1ubuntu2.4"
+  },
+  {
+    "name": "gir1.2-javascriptcoregtk-4.0",
+    "version": "2.20.5-0ubuntu0.16.04.1"
+  },
+  {
+    "name": "gir1.2-json-1.0",
+    "version": "1.1.2-0ubuntu1"
+  },
+  {
+    "name": "gir1.2-notify-0.7",
+    "version": "0.7.6-2svn1"
+  },
+  {
+    "name": "gir1.2-packagekitglib-1.0",
+    "version": "0.8.17-4ubuntu6~gcc5.4ubuntu1.4"
+  },
+  {
+    "name": "gir1.2-pango-1.0",
+    "version": "1.38.1-1"
+  },
+  {
+    "name": "gir1.2-peas-1.0",
+    "version": "1.16.0-1ubuntu2"
+  },
+  {
+    "name": "gir1.2-rb-3.0",
+    "version": "3.3-1ubuntu7"
+  },
+  {
+    "name": "gir1.2-secret-1",
+    "version": "0.18.4-1ubuntu2"
+  },
+  {
+    "name": "gir1.2-signon-1.0",
+    "version": "1.13+16.04.20151209.1-0ubuntu1"
+  },
+  {
+    "name": "gir1.2-soup-2.4",
+    "version": "2.52.2-1ubuntu0.3"
+  },
+  {
+    "name": "gir1.2-totem-1.0",
+    "version": "3.18.1-1ubuntu4"
+  },
+  {
+    "name": "gir1.2-totem-plparser-1.0",
+    "version": "3.10.6-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-udisks-2.0",
+    "version": "2.1.7-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-unity-5.0",
+    "version": "7.1.4+16.04.20180209.1-0ubuntu1"
+  },
+  {
+    "name": "gir1.2-vte-2.91",
+    "version": "0.42.5-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-webkit2-4.0",
+    "version": "2.20.5-0ubuntu0.16.04.1"
+  },
+  {
+    "name": "gir1.2-wnck-3.0",
+    "version": "3.14.1-2"
+  },
+  {
+    "name": "gkbd-capplet",
+    "version": "3.6.0-1ubuntu2"
+  },
+  {
+    "name": "glib-networking",
+    "version": "2.48.2-1~ubuntu16.04.2"
+  },
+  {
+    "name": "glib-networking-common",
+    "version": "2.48.2-1~ubuntu16.04.2"
+  },
+  {
+    "name": "glib-networking-services",
+    "version": "2.48.2-1~ubuntu16.04.2"
+  },
+  {
+    "name": "gnome-accessibility-themes",
+    "version": "3.18.0-2ubuntu2"
+  },
+  {
+    "name": "gnome-bluetooth",
+    "version": "3.18.2-1ubuntu2"
+  },
+  {
+    "name": "gnome-calculator",
+    "version": "1:3.18.3-0ubuntu1.16.04.1"
+  },
+  {
+    "name": "gnome-calendar",
+    "version": "3.20.4-0ubuntu0.1"
+  },
+  {
+    "name": "gnome-desktop3-data",
+    "version": "3.18.2-1ubuntu1"
+  },
+  {
+    "name": "gnome-disk-utility",
+    "version": "3.18.3.1-1ubuntu1.1"
+  },
+  {
+    "name": "gnome-font-viewer",
+    "version": "3.16.2-1ubuntu1"
+  },
+  {
+    "name": "gnome-keyring",
+    "version": "3.18.3-0ubuntu2.1"
+  },
+  {
+    "name": "gnome-mahjongg",
+    "version": "1:3.18.0-1"
+  },
+  {
+    "name": "gnome-menus",
+    "version": "3.13.3-6ubuntu3.1"
+  },
+  {
+    "name": "gnome-mines",
+    "version": "1:3.18.2-2"
+  },
+  {
+    "name": "gnome-orca",
+    "version": "3.18.2-1ubuntu3"
+  },
+  {
+    "name": "gnome-power-manager",
+    "version": "3.18.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-screensaver",
+    "version": "3.6.1-7ubuntu4"
+  },
+  {
+    "name": "gnome-screenshot",
+    "version": "3.18.0-1ubuntu2"
+  },
+  {
+    "name": "gnome-session-bin",
+    "version": "3.18.1.2-1ubuntu1.16.04.2"
+  },
+  {
+    "name": "gnome-session-canberra",
+    "version": "0.30-2.1ubuntu1"
+  },
+  {
+    "name": "gnome-session-common",
+    "version": "3.18.1.2-1ubuntu1.16.04.2"
+  },
+  {
+    "name": "gnome-settings-daemon-schemas",
+    "version": "3.18.2-0ubuntu3.1"
+  },
+  {
+    "name": "gnome-software",
+    "version": "3.20.5-0ubuntu0.16.04.13"
+  },
+  {
+    "name": "gnome-software-common",
+    "version": "3.20.5-0ubuntu0.16.04.13"
+  },
+  {
+    "name": "gnome-sudoku",
+    "version": "1:3.18.4-0ubuntu2"
+  },
+  {
+    "name": "gnome-system-log",
+    "version": "3.9.90-4"
+  },
+  {
+    "name": "gnome-system-monitor",
+    "version": "3.18.2-1ubuntu1"
+  },
+  {
+    "name": "gnome-terminal",
+    "version": "3.18.3-1ubuntu1"
+  },
+  {
+    "name": "gnome-terminal-data",
+    "version": "3.18.3-1ubuntu1"
+  },
+  {
+    "name": "gnome-user-guide",
+    "version": "3.18.1-1"
+  },
+  {
+    "name": "gnome-user-share",
+    "version": "3.14.2-2ubuntu4"
+  },
+  {
+    "name": "gnome-video-effects",
+    "version": "0.4.1-3ubuntu1"
+  },
+  {
+    "name": "gnupg",
+    "version": "1.4.20-1ubuntu3.3"
+  },
+  {
+    "name": "gnupg-agent",
+    "version": "2.1.11-6ubuntu2.1"
+  },
+  {
+    "name": "gnupg2",
+    "version": "2.1.11-6ubuntu2.1"
+  },
+  {
+    "name": "gpgv",
+    "version": "1.4.20-1ubuntu3.3"
+  },
+  {
+    "name": "grep",
+    "version": "2.25-1~16.04.1"
+  },
+  {
+    "name": "grilo-plugins-0.2-base",
+    "version": "0.2.17-0ubuntu2"
+  },
+  {
+    "name": "groff-base",
+    "version": "1.22.3-7"
+  },
+  {
+    "name": "grub-common",
+    "version": "2.02~beta2-36ubuntu3.27"
+  },
+  {
+    "name": "grub-pc",
+    "version": "2.02~beta2-36ubuntu3.27"
+  },
+  {
+    "name": "grub-pc-bin",
+    "version": "2.02~beta2-36ubuntu3.27"
+  },
+  {
+    "name": "grub2-common",
+    "version": "2.02~beta2-36ubuntu3.27"
+  },
+  {
+    "name": "gsettings-desktop-schemas",
+    "version": "3.18.1-1ubuntu1"
+  },
+  {
+    "name": "gsettings-ubuntu-schemas",
+    "version": "0.0.5+16.04.20160307-0ubuntu1"
+  },
+  {
+    "name": "gsfonts",
+    "version": "1:8.11+urwcyr1.0.7~pre44-4.2ubuntu1"
+  },
+  {
+    "name": "gstreamer1.0-alsa",
+    "version": "1.8.3-1ubuntu0.3"
+  },
+  {
+    "name": "gstreamer1.0-clutter-3.0",
+    "version": "3.0.18-1"
+  },
+  {
+    "name": "gstreamer1.0-plugins-base",
+    "version": "1.8.3-1ubuntu0.3"
+  },
+  {
+    "name": "gstreamer1.0-plugins-base-apps",
+    "version": "1.8.3-1ubuntu0.3"
+  },
+  {
+    "name": "gstreamer1.0-plugins-good",
+    "version": "1.8.3-1ubuntu0.4"
+  },
+  {
+    "name": "gstreamer1.0-pulseaudio",
+    "version": "1.8.3-1ubuntu0.4"
+  },
+  {
+    "name": "gstreamer1.0-tools",
+    "version": "1.8.3-1~ubuntu0.1"
+  },
+  {
+    "name": "gstreamer1.0-x",
+    "version": "1.8.3-1ubuntu0.3"
+  },
+  {
+    "name": "gtk2-engines-murrine",
+    "version": "0.98.2-0ubuntu2.2"
+  },
+  {
+    "name": "guacamole",
+    "version": "0.9.2"
+  },
+  {
+    "name": "gucharmap",
+    "version": "1:3.18.2-1ubuntu1"
+  },
+  {
+    "name": "guile-2.0-libs",
+    "version": "2.0.11+1-10ubuntu0.1"
+  },
+  {
+    "name": "gvfs",
+    "version": "1.28.2-1ubuntu1~16.04.3"
+  },
+  {
+    "name": "gvfs-backends",
+    "version": "1.28.2-1ubuntu1~16.04.3"
+  },
+  {
+    "name": "gvfs-bin",
+    "version": "1.28.2-1ubuntu1~16.04.3"
+  },
+  {
+    "name": "gvfs-common",
+    "version": "1.28.2-1ubuntu1~16.04.3"
+  },
+  {
+    "name": "gvfs-daemons",
+    "version": "1.28.2-1ubuntu1~16.04.3"
+  },
+  {
+    "name": "gvfs-fuse",
+    "version": "1.28.2-1ubuntu1~16.04.3"
+  },
+  {
+    "name": "gvfs-libs",
+    "version": "1.28.2-1ubuntu1~16.04.3"
+  },
+  {
+    "name": "gzip",
+    "version": "1.6-4ubuntu1"
+  },
+  {
+    "name": "hardening-includes",
+    "version": "2.7ubuntu2"
+  },
+  {
+    "name": "hdparm",
+    "version": "9.48+ds-1ubuntu0.1"
+  },
+  {
+    "name": "hicolor-icon-theme",
+    "version": "0.15-0ubuntu1.1"
+  },
+  {
+    "name": "hostname",
+    "version": "3.16ubuntu2"
+  },
+  {
+    "name": "hplip",
+    "version": "3.16.3+repack0-1"
+  },
+  {
+    "name": "hplip-data",
+    "version": "3.16.3+repack0-1"
+  },
+  {
+    "name": "html5lib",
+    "version": "0.999"
+  },
+  {
+    "name": "hud",
+    "version": "14.10+16.04.20160415-0ubuntu1"
+  },
+  {
+    "name": "humanity-icon-theme",
+    "version": "0.6.10.1"
+  },
+  {
+    "name": "hunspell-en-us",
+    "version": "20070829-6ubuntu3"
+  },
+  {
+    "name": "hwdata",
+    "version": "0.267-1ubuntu2"
+  },
+  {
+    "name": "hyphen-en-us",
+    "version": "2.8.8-2ubuntu1"
+  },
+  {
+    "name": "ibus",
+    "version": "1.5.11-1ubuntu2.4"
+  },
+  {
+    "name": "ibus-gtk",
+    "version": "1.5.11-1ubuntu2.4"
+  },
+  {
+    "name": "ibus-gtk3",
+    "version": "1.5.11-1ubuntu2.4"
+  },
+  {
+    "name": "ibus-table",
+    "version": "1.9.1-3ubuntu2"
+  },
+  {
+    "name": "idna",
+    "version": "2.0"
+  },
+  {
+    "name": "ifupdown",
+    "version": "0.8.10ubuntu1.4"
+  },
+  {
+    "name": "im-config",
+    "version": "0.29-1ubuntu12.4"
+  },
+  {
+    "name": "imagemagick",
+    "version": "8:6.8.9.9-7ubuntu5.15"
+  },
+  {
+    "name": "imagemagick-6.q16",
+    "version": "8:6.8.9.9-7ubuntu5.15"
+  },
+  {
+    "name": "imagemagick-common",
+    "version": "8:6.8.9.9-7ubuntu5.15"
+  },
+  {
+    "name": "indicator-application",
+    "version": "12.10.1+16.04.20170120-0ubuntu1"
+  },
+  {
+    "name": "indicator-appmenu",
+    "version": "15.02.0+16.04.20151104-0ubuntu1"
+  },
+  {
+    "name": "indicator-bluetooth",
+    "version": "0.0.6+16.04.20160526-0ubuntu1"
+  },
+  {
+    "name": "indicator-datetime",
+    "version": "15.10+16.04.20160406-0ubuntu1"
+  },
+  {
+    "name": "indicator-keyboard",
+    "version": "0.0.0+16.04.20151125-0ubuntu1"
+  },
+  {
+    "name": "indicator-messages",
+    "version": "13.10.1+15.10.20150505-0ubuntu1"
+  },
+  {
+    "name": "indicator-power",
+    "version": "12.10.6+16.04.20160105-0ubuntu1"
+  },
+  {
+    "name": "indicator-printers",
+    "version": "0.1.7+15.04.20150220-0ubuntu2"
+  },
+  {
+    "name": "indicator-session",
+    "version": "12.10.5+16.04.20160412-0ubuntu1"
+  },
+  {
+    "name": "indicator-sound",
+    "version": "12.10.2+16.04.20160406-0ubuntu1"
+  },
+  {
+    "name": "info",
+    "version": "6.1.0.dfsg.1-5"
+  },
+  {
+    "name": "init",
+    "version": "1.29ubuntu4"
+  },
+  {
+    "name": "init-system-helpers",
+    "version": "1.29ubuntu4"
+  },
+  {
+    "name": "initramfs-tools",
+    "version": "0.122ubuntu8.16"
+  },
+  {
+    "name": "initramfs-tools-bin",
+    "version": "0.122ubuntu8.16"
+  },
+  {
+    "name": "initramfs-tools-core",
+    "version": "0.122ubuntu8.16"
+  },
+  {
+    "name": "initscripts",
+    "version": "2.88dsf-59.3ubuntu2"
+  },
+  {
+    "name": "inputattach",
+    "version": "1:1.4.9-1"
+  },
+  {
+    "name": "insserv",
+    "version": "1.14.0-5ubuntu3"
+  },
+  {
+    "name": "install-info",
+    "version": "6.1.0.dfsg.1-5"
+  },
+  {
+    "name": "intel-gpu-tools",
+    "version": "1.14-1"
+  },
+  {
+    "name": "intel-microcode",
+    "version": "3.20200609.0ubuntu0.16.04.1"
+  },
+  {
+    "name": "ippusbxd",
+    "version": "1.23-1"
+  },
+  {
+    "name": "iproute2",
+    "version": "4.3.0-1ubuntu3.16.04.5"
+  },
+  {
+    "name": "iptables",
+    "version": "1.6.0-2ubuntu3"
+  },
+  {
+    "name": "iputils-arping",
+    "version": "3:20121221-5ubuntu2"
+  },
+  {
+    "name": "iputils-ping",
+    "version": "3:20121221-5ubuntu2"
+  },
+  {
+    "name": "iputils-tracepath",
+    "version": "3:20121221-5ubuntu2"
+  },
+  {
+    "name": "irqbalance",
+    "version": "1.1.0-2ubuntu1"
+  },
+  {
+    "name": "isc-dhcp-client",
+    "version": "4.3.3-5ubuntu12.10"
+  },
+  {
+    "name": "isc-dhcp-common",
+    "version": "4.3.3-5ubuntu12.10"
+  },
+  {
+    "name": "iso-codes",
+    "version": "3.65-1"
+  },
+  {
+    "name": "iucode-tool",
+    "version": "1.5.1-1ubuntu0.1"
+  },
+  {
+    "name": "iw",
+    "version": "3.17-1"
+  },
+  {
+    "name": "jayatana",
+    "version": "2.7-0ubuntu5"
+  },
+  {
+    "name": "kbd",
+    "version": "1.15.5-1ubuntu5"
+  },
+  {
+    "name": "kerneloops-daemon",
+    "version": "0.12+git20140509-2ubuntu1"
+  },
+  {
+    "name": "keyboard-configuration",
+    "version": "1.108ubuntu15.5"
+  },
+  {
+    "name": "klibc-utils",
+    "version": "2.0.4-8ubuntu1.16.04.4"
+  },
+  {
+    "name": "kmod",
+    "version": "22-1ubuntu5.2"
+  },
+  {
+    "name": "krb5-locales",
+    "version": "1.13.2+dfsg-5ubuntu2.1"
+  },
+  {
+    "name": "language-pack-en",
+    "version": "1:16.04+20161009"
+  },
+  {
+    "name": "language-pack-en-base",
+    "version": "1:16.04+20160627"
+  },
+  {
+    "name": "language-pack-gnome-en",
+    "version": "1:16.04+20161009"
+  },
+  {
+    "name": "language-pack-gnome-en-base",
+    "version": "1:16.04+20160627"
+  },
+  {
+    "name": "language-selector-common",
+    "version": "0.165.4"
+  },
+  {
+    "name": "language-selector-gnome",
+    "version": "0.165.4"
+  },
+  {
+    "name": "laptop-detect",
+    "version": "0.13.7ubuntu2"
+  },
+  {
+    "name": "less",
+    "version": "481-2.1ubuntu0.2"
+  },
+  {
+    "name": "liba11y-profile-manager-0.1-0",
+    "version": "0.1.10-0ubuntu3"
+  },
+  {
+    "name": "liba11y-profile-manager-data",
+    "version": "0.1.10-0ubuntu3"
+  },
+  {
+    "name": "libaa1",
+    "version": "1.4p5-44build1"
+  },
+  {
+    "name": "libabw-0.1-1v5",
+    "version": "0.1.1-2ubuntu2"
+  },
+  {
+    "name": "libaccount-plugin-1.0-0",
+    "version": "0.1.8+16.04.20160201-0ubuntu1"
+  },
+  {
+    "name": "libaccount-plugin-generic-oauth",
+    "version": "0.12+16.04.20160126-0ubuntu1"
+  },
+  {
+    "name": "libaccount-plugin-google",
+    "version": "0.12+16.04.20160126-0ubuntu1"
+  },
+  {
+    "name": "libaccounts-glib0",
+    "version": "1.21+16.04.20160222-0ubuntu1"
+  },
+  {
+    "name": "libaccounts-qt5-1",
+    "version": "1.14+16.04.20151106.1-0ubuntu1"
+  },
+  {
+    "name": "libaccountsservice0",
+    "version": "0.6.40-2ubuntu11.3"
+  },
+  {
+    "name": "libacl1",
+    "version": "2.2.52-3"
+  },
+  {
+    "name": "libalgorithm-diff-perl",
+    "version": "1.19.03-1"
+  },
+  {
+    "name": "libalgorithm-diff-xs-perl",
+    "version": "0.04-4build1"
+  },
+  {
+    "name": "libalgorithm-merge-perl",
+    "version": "0.08-3"
+  },
+  {
+    "name": "libandroid-properties1",
+    "version": "0.1.0+git20151016+6d424c9-0ubuntu7"
+  },
+  {
+    "name": "libao-common",
+    "version": "1.1.0-3ubuntu1"
+  },
+  {
+    "name": "libao4",
+    "version": "1.1.0-3ubuntu1"
+  },
+  {
+    "name": "libapparmor-perl",
+    "version": "2.10.95-0ubuntu2.11"
+  },
+  {
+    "name": "libapparmor1",
+    "version": "2.10.95-0ubuntu2.11"
+  },
+  {
+    "name": "libappindicator3-1",
+    "version": "12.10.1+16.04.20170215-0ubuntu1"
+  },
+  {
+    "name": "libappstream-glib8",
+    "version": "0.5.13-1ubuntu6"
+  },
+  {
+    "name": "libappstream3",
+    "version": "0.9.4-1ubuntu4"
+  },
+  {
+    "name": "libapt-inst2.0",
+    "version": "1.2.32ubuntu0.1"
+  },
+  {
+    "name": "libapt-pkg-perl",
+    "version": "0.1.29build7"
+  },
+  {
+    "name": "libapt-pkg5.0",
+    "version": "1.2.32ubuntu0.1"
+  },
+  {
+    "name": "libarchive-zip-perl",
+    "version": "1.56-2ubuntu0.1"
+  },
+  {
+    "name": "libarchive13",
+    "version": "3.1.2-11ubuntu0.16.04.8"
+  },
+  {
+    "name": "libart-2.0-2",
+    "version": "2.3.21-2"
+  },
+  {
+    "name": "libasan2",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "libasn1-8-heimdal",
+    "version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1"
+  },
+  {
+    "name": "libasound2",
+    "version": "1.1.0-0ubuntu1"
+  },
+  {
+    "name": "libasound2-data",
+    "version": "1.1.0-0ubuntu1"
+  },
+  {
+    "name": "libasound2-plugins",
+    "version": "1.1.0-0ubuntu1"
+  },
+  {
+    "name": "libaspell15",
+    "version": "0.60.7~20110707-3ubuntu0.1"
+  },
+  {
+    "name": "libasprintf-dev",
+    "version": "0.19.7-2ubuntu3.1"
+  },
+  {
+    "name": "libasprintf0v5",
+    "version": "0.19.7-2ubuntu3.1"
+  },
+  {
+    "name": "libassuan0",
+    "version": "2.4.2-2"
+  },
+  {
+    "name": "libasyncns0",
+    "version": "0.8-5build1"
+  },
+  {
+    "name": "libatasmart4",
+    "version": "0.19-3"
+  },
+  {
+    "name": "libatk-adaptor",
+    "version": "2.18.1-2ubuntu1"
+  },
+  {
+    "name": "libatk-bridge2.0-0",
+    "version": "2.18.1-2ubuntu1"
+  },
+  {
+    "name": "libatk1.0-0",
+    "version": "2.18.0-1"
+  },
+  {
+    "name": "libatk1.0-data",
+    "version": "2.18.0-1"
+  },
+  {
+    "name": "libatkmm-1.6-1v5",
+    "version": "2.24.2-1"
+  },
+  {
+    "name": "libatm1",
+    "version": "1:2.5.1-1.5"
+  },
+  {
+    "name": "libatomic1",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "libatspi2.0-0",
+    "version": "2.18.3-4ubuntu1"
+  },
+  {
+    "name": "libattr1",
+    "version": "1:2.4.47-2"
+  },
+  {
+    "name": "libaudio2",
+    "version": "1.9.4-4"
+  },
+  {
+    "name": "libaudit-common",
+    "version": "1:2.4.5-1ubuntu2.1"
+  },
+  {
+    "name": "libaudit1",
+    "version": "1:2.4.5-1ubuntu2.1"
+  },
+  {
+    "name": "libavahi-client3",
+    "version": "0.6.32~rc+dfsg-1ubuntu2.3"
+  },
+  {
+    "name": "libavahi-common-data",
+    "version": "0.6.32~rc+dfsg-1ubuntu2.3"
+  },
+  {
+    "name": "libavahi-common3",
+    "version": "0.6.32~rc+dfsg-1ubuntu2.3"
+  },
+  {
+    "name": "libavahi-core7",
+    "version": "0.6.32~rc+dfsg-1ubuntu2.3"
+  },
+  {
+    "name": "libavahi-glib1",
+    "version": "0.6.32~rc+dfsg-1ubuntu2.3"
+  },
+  {
+    "name": "libavahi-ui-gtk3-0",
+    "version": "0.6.32~rc+dfsg-1ubuntu2.3"
+  },
+  {
+    "name": "libavc1394-0",
+    "version": "0.5.4-4"
+  },
+  {
+    "name": "libbabeltrace-ctf1",
+    "version": "1.3.2-1"
+  },
+  {
+    "name": "libbabeltrace1",
+    "version": "1.3.2-1"
+  },
+  {
+    "name": "libbamf3-2",
+    "version": "0.5.3~bzr0+16.04.20180209-0ubuntu1"
+  },
+  {
+    "name": "libbind9-140",
+    "version": "1:9.10.3.dfsg.P4-8ubuntu1.16"
+  },
+  {
+    "name": "libblkid1",
+    "version": "2.27.1-6ubuntu3.10"
+  },
+  {
+    "name": "libbluetooth3",
+    "version": "5.37-0ubuntu5.3"
+  },
+  {
+    "name": "libboost-date-time1.58.0",
+    "version": "1.58.0+dfsg-5ubuntu3.1"
+  },
+  {
+    "name": "libboost-filesystem1.58.0",
+    "version": "1.58.0+dfsg-5ubuntu3.1"
+  },
+  {
+    "name": "libboost-iostreams1.58.0",
+    "version": "1.58.0+dfsg-5ubuntu3.1"
+  },
+  {
+    "name": "libboost-system1.58.0",
+    "version": "1.58.0+dfsg-5ubuntu3.1"
+  },
+  {
+    "name": "libbrlapi0.6",
+    "version": "5.3.1-2ubuntu2.1"
+  },
+  {
+    "name": "libbsd0",
+    "version": "0.8.2-1ubuntu0.1"
+  },
+  {
+    "name": "libbz2-1.0",
+    "version": "1.0.6-8ubuntu0.2"
+  },
+  {
+    "name": "libc-bin",
+    "version": "2.23-0ubuntu11.2"
+  },
+  {
+    "name": "libc-dev-bin",
+    "version": "2.23-0ubuntu11.2"
+  },
+  {
+    "name": "libc6",
+    "version": "2.23-0ubuntu11.2"
+  },
+  {
+    "name": "libc6-dbg",
+    "version": "2.23-0ubuntu11.2"
+  },
+  {
+    "name": "libc6-dev",
+    "version": "2.23-0ubuntu11.2"
+  },
+  {
+    "name": "libcaca0",
+    "version": "0.99.beta19-2ubuntu0.16.04.1"
+  },
+  {
+    "name": "libcairo-gobject2",
+    "version": "1.14.6-1"
+  },
+  {
+    "name": "libcairo-perl",
+    "version": "1.106-1build1"
+  },
+  {
+    "name": "libcairo2",
+    "version": "1.14.6-1"
+  },
+  {
+    "name": "libcairomm-1.0-1v5",
+    "version": "1.12.0-1"
+  },
+  {
+    "name": "libcamel-1.2-54",
+    "version": "3.18.5-1ubuntu1.3"
+  },
+  {
+    "name": "libcanberra-gtk-module",
+    "version": "0.30-2.1ubuntu1"
+  },
+  {
+    "name": "libcanberra-gtk0",
+    "version": "0.30-2.1ubuntu1"
+  },
+  {
+    "name": "libcanberra-gtk3-0",
+    "version": "0.30-2.1ubuntu1"
+  },
+  {
+    "name": "libcanberra-gtk3-module",
+    "version": "0.30-2.1ubuntu1"
+  },
+  {
+    "name": "libcanberra-pulse",
+    "version": "0.30-2.1ubuntu1"
+  },
+  {
+    "name": "libcanberra0",
+    "version": "0.30-2.1ubuntu1"
+  },
+  {
+    "name": "libcap-ng0",
+    "version": "0.7.7-1"
+  },
+  {
+    "name": "libcap2",
+    "version": "1:2.24-12"
+  },
+  {
+    "name": "libcap2-bin",
+    "version": "1:2.24-12"
+  },
+  {
+    "name": "libcapnp-0.5.3",
+    "version": "0.5.3-2ubuntu1.1"
+  },
+  {
+    "name": "libcc1-0",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "libcdio-cdda1",
+    "version": "0.83-4.2ubuntu1"
+  },
+  {
+    "name": "libcdio-paranoia1",
+    "version": "0.83-4.2ubuntu1"
+  },
+  {
+    "name": "libcdio13",
+    "version": "0.83-4.2ubuntu1"
+  },
+  {
+    "name": "libcdparanoia0",
+    "version": "3.10.2+debian-11"
+  },
+  {
+    "name": "libcdr-0.1-1",
+    "version": "0.1.2-2ubuntu2"
+  },
+  {
+    "name": "libcgi-fast-perl",
+    "version": "1:2.10-1"
+  },
+  {
+    "name": "libcgi-pm-perl",
+    "version": "4.26-1"
+  },
+  {
+    "name": "libcgmanager0",
+    "version": "0.39-2ubuntu5"
+  },
+  {
+    "name": "libcheese-gtk25",
+    "version": "3.18.1-2ubuntu3"
+  },
+  {
+    "name": "libcheese8",
+    "version": "3.18.1-2ubuntu3"
+  },
+  {
+    "name": "libcilkrts5",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "libclass-accessor-perl",
+    "version": "0.34-1"
+  },
+  {
+    "name": "libclone-perl",
+    "version": "0.38-1build1"
+  },
+  {
+    "name": "libclucene-contribs1v5",
+    "version": "2.3.3.4-4.1"
+  },
+  {
+    "name": "libclucene-core1v5",
+    "version": "2.3.3.4-4.1"
+  },
+  {
+    "name": "libclutter-1.0-0",
+    "version": "1.24.2-1"
+  },
+  {
+    "name": "libclutter-1.0-common",
+    "version": "1.24.2-1"
+  },
+  {
+    "name": "libclutter-gst-3.0-0",
+    "version": "3.0.18-1"
+  },
+  {
+    "name": "libclutter-gtk-1.0-0",
+    "version": "1.6.6-1"
+  },
+  {
+    "name": "libcmis-0.5-5v5",
+    "version": "0.5.1-2ubuntu2"
+  },
+  {
+    "name": "libcogl-common",
+    "version": "1.22.0-2"
+  },
+  {
+    "name": "libcogl-pango20",
+    "version": "1.22.0-2"
+  },
+  {
+    "name": "libcogl-path20",
+    "version": "1.22.0-2"
+  },
+  {
+    "name": "libcogl20",
+    "version": "1.22.0-2"
+  },
+  {
+    "name": "libcolamd2.9.1",
+    "version": "1:4.4.6-1"
+  },
+  {
+    "name": "libcolord2",
+    "version": "1.2.12-1ubuntu1"
+  },
+  {
+    "name": "libcolorhug2",
+    "version": "1.2.12-1ubuntu1"
+  },
+  {
+    "name": "libcolumbus1-common",
+    "version": "1.1.0+15.10.20150806-0ubuntu4"
+  },
+  {
+    "name": "libcolumbus1v5",
+    "version": "1.1.0+15.10.20150806-0ubuntu4"
+  },
+  {
+    "name": "libcomerr2",
+    "version": "1.42.13-1ubuntu1.2"
+  },
+  {
+    "name": "libcompizconfig0",
+    "version": "1:0.9.12.3+16.04.20180221-0ubuntu1"
+  },
+  {
+    "name": "libcrack2",
+    "version": "2.9.2-1ubuntu1"
+  },
+  {
+    "name": "libcroco3",
+    "version": "0.6.11-1"
+  },
+  {
+    "name": "libcryptsetup4",
+    "version": "2:1.6.6-5ubuntu2.1"
+  },
+  {
+    "name": "libcups2",
+    "version": "2.1.3-4ubuntu0.11"
+  },
+  {
+    "name": "libcupscgi1",
+    "version": "2.1.3-4ubuntu0.11"
+  },
+  {
+    "name": "libcupsfilters1",
+    "version": "1.8.3-2ubuntu3.5"
+  },
+  {
+    "name": "libcupsimage2",
+    "version": "2.1.3-4ubuntu0.11"
+  },
+  {
+    "name": "libcupsmime1",
+    "version": "2.1.3-4ubuntu0.11"
+  },
+  {
+    "name": "libcupsppdc1",
+    "version": "2.1.3-4ubuntu0.11"
+  },
+  {
+    "name": "libcurl3",
+    "version": "7.47.0-1ubuntu2.15"
+  },
+  {
+    "name": "libcurl3-gnutls",
+    "version": "7.47.0-1ubuntu2.15"
+  },
+  {
+    "name": "libdata-alias-perl",
+    "version": "1.20-1build1"
+  },
+  {
+    "name": "libdatrie1",
+    "version": "0.2.10-2"
+  },
+  {
+    "name": "libdb5.3",
+    "version": "5.3.28-11ubuntu0.2"
+  },
+  {
+    "name": "libdbus-1-3",
+    "version": "1.10.6-1ubuntu3.6"
+  },
+  {
+    "name": "libdbus-glib-1-2",
+    "version": "0.106-1"
+  },
+  {
+    "name": "libdbusmenu-glib4",
+    "version": "16.04.1+16.04.20160927-0ubuntu1"
+  },
+  {
+    "name": "libdbusmenu-gtk3-4",
+    "version": "16.04.1+16.04.20160927-0ubuntu1"
+  },
+  {
+    "name": "libdbusmenu-gtk4",
+    "version": "16.04.1+16.04.20160927-0ubuntu1"
+  },
+  {
+    "name": "libdbusmenu-qt2",
+    "version": "0.9.3+16.04.20160218-0ubuntu1"
+  },
+  {
+    "name": "libdbusmenu-qt5",
+    "version": "0.9.3+16.04.20160218-0ubuntu1"
+  },
+  {
+    "name": "libdconf1",
+    "version": "0.24.0-2"
+  },
+  {
+    "name": "libdebconfclient0",
+    "version": "0.198ubuntu1"
+  },
+  {
+    "name": "libdecoration0",
+    "version": "1:0.9.12.3+16.04.20180221-0ubuntu1"
+  },
+  {
+    "name": "libdee-1.0-4",
+    "version": "1.2.7+15.04.20150304-0ubuntu2"
+  },
+  {
+    "name": "libdevmapper1.02.1",
+    "version": "2:1.02.110-1ubuntu10"
+  },
+  {
+    "name": "libdfu1",
+    "version": "0.8.3-0ubuntu5.1"
+  },
+  {
+    "name": "libdjvulibre-text",
+    "version": "3.5.27.1-5ubuntu0.1"
+  },
+  {
+    "name": "libdjvulibre21",
+    "version": "3.5.27.1-5ubuntu0.1"
+  },
+  {
+    "name": "libdmapsharing-3.0-2",
+    "version": "2.9.34-1"
+  },
+  {
+    "name": "libdns-export162",
+    "version": "1:9.10.3.dfsg.P4-8ubuntu1.16"
+  },
+  {
+    "name": "libdns162",
+    "version": "1:9.10.3.dfsg.P4-8ubuntu1.16"
+  },
+  {
+    "name": "libdotconf0",
+    "version": "1.3-0.2"
+  },
+  {
+    "name": "libdouble-conversion1v5",
+    "version": "2.0.1-3ubuntu2"
+  },
+  {
+    "name": "libdpkg-perl",
+    "version": "1.18.4ubuntu1.6"
+  },
+  {
+    "name": "libdrm-amdgpu1",
+    "version": "2.4.91-2~16.04.1"
+  },
+  {
+    "name": "libdrm-common",
+    "version": "2.4.91-2~16.04.1"
+  },
+  {
+    "name": "libdrm-intel1",
+    "version": "2.4.91-2~16.04.1"
+  },
+  {
+    "name": "libdrm-nouveau2",
+    "version": "2.4.91-2~16.04.1"
+  },
+  {
+    "name": "libdrm-radeon1",
+    "version": "2.4.91-2~16.04.1"
+  },
+  {
+    "name": "libdrm2",
+    "version": "2.4.91-2~16.04.1"
+  },
+  {
+    "name": "libdv4",
+    "version": "1.0.0-7"
+  },
+  {
+    "name": "libe-book-0.1-1",
+    "version": "0.1.2-2ubuntu1"
+  },
+  {
+    "name": "libebackend-1.2-10",
+    "version": "3.18.5-1ubuntu1.3"
+  },
+  {
+    "name": "libebook-1.2-16",
+    "version": "3.18.5-1ubuntu1.3"
+  },
+  {
+    "name": "libebook-contacts-1.2-2",
+    "version": "3.18.5-1ubuntu1.3"
+  },
+  {
+    "name": "libecal-1.2-19",
+    "version": "3.18.5-1ubuntu1.3"
+  },
+  {
+    "name": "libedata-book-1.2-25",
+    "version": "3.18.5-1ubuntu1.3"
+  },
+  {
+    "name": "libedata-cal-1.2-28",
+    "version": "3.18.5-1ubuntu1.3"
+  },
+  {
+    "name": "libedataserver-1.2-21",
+    "version": "3.18.5-1ubuntu1.3"
+  },
+  {
+    "name": "libedataserverui-1.2-1",
+    "version": "3.18.5-1ubuntu1.3"
+  },
+  {
+    "name": "libedit2",
+    "version": "3.1-20150325-1ubuntu2"
+  },
+  {
+    "name": "libefivar0",
+    "version": "0.23-2"
+  },
+  {
+    "name": "libegl1-mesa",
+    "version": "18.0.5-0ubuntu0~16.04.1"
+  },
+  {
+    "name": "libelf1",
+    "version": "0.165-3ubuntu1.2"
+  },
+  {
+    "name": "libemail-valid-perl",
+    "version": "1.198-1"
+  },
+  {
+    "name": "libenchant1c2a",
+    "version": "1.6.0-10.1build2"
+  },
+  {
+    "name": "libeot0",
+    "version": "0.01-3ubuntu1"
+  },
+  {
+    "name": "libepoxy0",
+    "version": "1.3.1-1ubuntu0.16.04.2"
+  },
+  {
+    "name": "libespeak1",
+    "version": "1.48.04+dfsg-2"
+  },
+  {
+    "name": "libestr0",
+    "version": "0.1.10-1"
+  },
+  {
+    "name": "libetonyek-0.1-1",
+    "version": "0.1.6-1ubuntu1"
+  },
+  {
+    "name": "libevdev2",
+    "version": "1.4.6+dfsg-1"
+  },
+  {
+    "name": "libevdocument3-4",
+    "version": "3.18.2-1ubuntu4.6"
+  },
+  {
+    "name": "libevent-2.0-5",
+    "version": "2.0.21-stable-2ubuntu0.16.04.1"
+  },
+  {
+    "name": "libevview3-3",
+    "version": "3.18.2-1ubuntu4.6"
+  },
+  {
+    "name": "libexempi3",
+    "version": "2.2.2-2ubuntu0.1"
+  },
+  {
+    "name": "libexif12",
+    "version": "0.6.21-2ubuntu0.5"
+  },
+  {
+    "name": "libexiv2-14",
+    "version": "0.25-2.1ubuntu16.04.6"
+  },
+  {
+    "name": "libexpat1",
+    "version": "2.1.0-7ubuntu0.16.04.5"
+  },
+  {
+    "name": "libexporter-tiny-perl",
+    "version": "0.042-1"
+  },
+  {
+    "name": "libexttextcat-2.0-0",
+    "version": "3.4.4-1ubuntu3"
+  },
+  {
+    "name": "libexttextcat-data",
+    "version": "3.4.4-1ubuntu3"
+  },
+  {
+    "name": "libfakeroot",
+    "version": "1.20.2-1ubuntu1"
+  },
+  {
+    "name": "libfcgi-perl",
+    "version": "0.77-1build1"
+  },
+  {
+    "name": "libfcitx-config4",
+    "version": "1:4.2.9.1-1ubuntu1.16.04.2"
+  },
+  {
+    "name": "libfcitx-gclient0",
+    "version": "1:4.2.9.1-1ubuntu1.16.04.2"
+  },
+  {
+    "name": "libfcitx-utils0",
+    "version": "1:4.2.9.1-1ubuntu1.16.04.2"
+  },
+  {
+    "name": "libfdisk1",
+    "version": "2.27.1-6ubuntu3.10"
+  },
+  {
+    "name": "libffi6",
+    "version": "3.2.1-4"
+  },
+  {
+    "name": "libfftw3-double3",
+    "version": "3.3.4-2ubuntu1"
+  },
+  {
+    "name": "libfftw3-single3",
+    "version": "3.3.4-2ubuntu1"
+  },
+  {
+    "name": "libfile-copy-recursive-perl",
+    "version": "0.38-1"
+  },
+  {
+    "name": "libfile-fcntllock-perl",
+    "version": "0.22-3"
+  },
+  {
+    "name": "libfile-mimeinfo-perl",
+    "version": "0.27-1"
+  },
+  {
+    "name": "libflac8",
+    "version": "1.3.1-4"
+  },
+  {
+    "name": "libfont-afm-perl",
+    "version": "1.20-1"
+  },
+  {
+    "name": "libfontconfig1",
+    "version": "2.11.94-0ubuntu1.1"
+  },
+  {
+    "name": "libfontembed1",
+    "version": "1.8.3-2ubuntu3.5"
+  },
+  {
+    "name": "libframe6",
+    "version": "2.5.0daily13.06.05+16.04.20160809-0ubuntu1"
+  },
+  {
+    "name": "libfreehand-0.1-1",
+    "version": "0.1.1-1ubuntu1"
+  },
+  {
+    "name": "libfreerdp-cache1.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libfreerdp-client1.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libfreerdp-codec1.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libfreerdp-common1.1.0",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libfreerdp-core1.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libfreerdp-crypto1.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libfreerdp-gdi1.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libfreerdp-locale1.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libfreerdp-plugins-standard",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libfreerdp-primitives1.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libfreerdp-utils1.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libfreetype6",
+    "version": "2.6.1-0.1ubuntu2.4"
+  },
+  {
+    "name": "libfribidi0",
+    "version": "0.19.7-1"
+  },
+  {
+    "name": "libfuse2",
+    "version": "2.9.4-1ubuntu3.1"
+  },
+  {
+    "name": "libfwup0",
+    "version": "0.5-2ubuntu7"
+  },
+  {
+    "name": "libfwupd1",
+    "version": "0.8.3-0ubuntu5.1"
+  },
+  {
+    "name": "libgail-3-0",
+    "version": "3.18.9-1ubuntu3.3"
+  },
+  {
+    "name": "libgail-common",
+    "version": "2.24.30-1ubuntu1.16.04.2"
+  },
+  {
+    "name": "libgail18",
+    "version": "2.24.30-1ubuntu1.16.04.2"
+  },
+  {
+    "name": "libgbm1",
+    "version": "18.0.5-0ubuntu0~16.04.1"
+  },
+  {
+    "name": "libgc1c2",
+    "version": "1:7.4.2-7.3ubuntu0.1"
+  },
+  {
+    "name": "libgcab-1.0-0",
+    "version": "0.7-1ubuntu0.1"
+  },
+  {
+    "name": "libgcc-5-dev",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "libgcc1",
+    "version": "1:6.0.1-0ubuntu1"
+  },
+  {
+    "name": "libgck-1-0",
+    "version": "3.18.0-1ubuntu1"
+  },
+  {
+    "name": "libgconf-2-4",
+    "version": "3.2.6-3ubuntu6"
+  },
+  {
+    "name": "libgcr-3-common",
+    "version": "3.18.0-1ubuntu1"
+  },
+  {
+    "name": "libgcr-base-3-1",
+    "version": "3.18.0-1ubuntu1"
+  },
+  {
+    "name": "libgcr-ui-3-1",
+    "version": "3.18.0-1ubuntu1"
+  },
+  {
+    "name": "libgcrypt20",
+    "version": "1.6.5-2ubuntu0.6"
+  },
+  {
+    "name": "libgd3",
+    "version": "2.1.1-4ubuntu0.16.04.12"
+  },
+  {
+    "name": "libgdata-common",
+    "version": "0.17.4-1"
+  },
+  {
+    "name": "libgdata22",
+    "version": "0.17.4-1"
+  },
+  {
+    "name": "libgdbm3",
+    "version": "1.8.3-13.1"
+  },
+  {
+    "name": "libgdk-pixbuf2.0-0",
+    "version": "2.32.2-1ubuntu1.6"
+  },
+  {
+    "name": "libgdk-pixbuf2.0-common",
+    "version": "2.32.2-1ubuntu1.6"
+  },
+  {
+    "name": "libgee-0.8-2",
+    "version": "0.18.0-1"
+  },
+  {
+    "name": "libgeis1",
+    "version": "2.2.17+16.04.20160126-0ubuntu1"
+  },
+  {
+    "name": "libgeoclue0",
+    "version": "0.12.99-4ubuntu1"
+  },
+  {
+    "name": "libgeocode-glib0",
+    "version": "3.18.2-1"
+  },
+  {
+    "name": "libgeoip1",
+    "version": "1.6.9-1"
+  },
+  {
+    "name": "libgeonames0",
+    "version": "0.2+16.04.20160321-0ubuntu1"
+  },
+  {
+    "name": "libgettextpo-dev",
+    "version": "0.19.7-2ubuntu3.1"
+  },
+  {
+    "name": "libgettextpo0",
+    "version": "0.19.7-2ubuntu3.1"
+  },
+  {
+    "name": "libgexiv2-2",
+    "version": "0.10.3-2"
+  },
+  {
+    "name": "libgirepository-1.0-1",
+    "version": "1.46.0-3ubuntu1"
+  },
+  {
+    "name": "libgl1-mesa-dri",
+    "version": "18.0.5-0ubuntu0~16.04.1"
+  },
+  {
+    "name": "libgl1-mesa-glx",
+    "version": "18.0.5-0ubuntu0~16.04.1"
+  },
+  {
+    "name": "libglapi-mesa",
+    "version": "18.0.5-0ubuntu0~16.04.1"
+  },
+  {
+    "name": "libglew1.13",
+    "version": "1.13.0-2"
+  },
+  {
+    "name": "libglewmx1.13",
+    "version": "1.13.0-2"
+  },
+  {
+    "name": "libglib-perl",
+    "version": "3:1.320-2"
+  },
+  {
+    "name": "libglib2.0-0",
+    "version": "2.48.2-0ubuntu4.6"
+  },
+  {
+    "name": "libglib2.0-bin",
+    "version": "2.48.2-0ubuntu4.6"
+  },
+  {
+    "name": "libglib2.0-data",
+    "version": "2.48.2-0ubuntu4.6"
+  },
+  {
+    "name": "libglibmm-2.4-1v5",
+    "version": "2.46.3-1"
+  },
+  {
+    "name": "libglu1-mesa",
+    "version": "9.0.0-2.1"
+  },
+  {
+    "name": "libgmime-2.6-0",
+    "version": "2.6.20-1"
+  },
+  {
+    "name": "libgmp10",
+    "version": "2:6.1.0+dfsg-2"
+  },
+  {
+    "name": "libgnome-bluetooth13",
+    "version": "3.18.2-1ubuntu2"
+  },
+  {
+    "name": "libgnome-desktop-3-12",
+    "version": "3.18.2-1ubuntu1"
+  },
+  {
+    "name": "libgnome-keyring-common",
+    "version": "3.12.0-1build1"
+  },
+  {
+    "name": "libgnome-keyring0",
+    "version": "3.12.0-1build1"
+  },
+  {
+    "name": "libgnome-menu-3-0",
+    "version": "3.13.3-6ubuntu3.1"
+  },
+  {
+    "name": "libgnomekbd-common",
+    "version": "3.6.0-1ubuntu2"
+  },
+  {
+    "name": "libgnomekbd8",
+    "version": "3.6.0-1ubuntu2"
+  },
+  {
+    "name": "libgnutls-openssl27",
+    "version": "3.4.10-4ubuntu1.8"
+  },
+  {
+    "name": "libgnutls30",
+    "version": "3.4.10-4ubuntu1.8"
+  },
+  {
+    "name": "libgoa-1.0-0b",
+    "version": "3.18.3-1ubuntu2"
+  },
+  {
+    "name": "libgoa-1.0-common",
+    "version": "3.18.3-1ubuntu2"
+  },
+  {
+    "name": "libgom-1.0-0",
+    "version": "0.3.1-1"
+  },
+  {
+    "name": "libgom-1.0-common",
+    "version": "0.3.1-1"
+  },
+  {
+    "name": "libgomp1",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "libgpg-error0",
+    "version": "1.21-2ubuntu1"
+  },
+  {
+    "name": "libgpgme11",
+    "version": "1.6.0-1"
+  },
+  {
+    "name": "libgphoto2-6",
+    "version": "2.5.9-3"
+  },
+  {
+    "name": "libgphoto2-l10n",
+    "version": "2.5.9-3"
+  },
+  {
+    "name": "libgphoto2-port12",
+    "version": "2.5.9-3"
+  },
+  {
+    "name": "libgpm2",
+    "version": "1.20.4-6.1"
+  },
+  {
+    "name": "libgpod-common",
+    "version": "0.8.3-6ubuntu2"
+  },
+  {
+    "name": "libgpod4",
+    "version": "0.8.3-6ubuntu2"
+  },
+  {
+    "name": "libgrail6",
+    "version": "3.1.0+16.04.20160125-0ubuntu1"
+  },
+  {
+    "name": "libgraphite2-3",
+    "version": "1.3.10-0ubuntu0.16.04.1"
+  },
+  {
+    "name": "libgrilo-0.2-1",
+    "version": "0.2.15-1"
+  },
+  {
+    "name": "libgs9",
+    "version": "9.26~dfsg+0-0ubuntu0.16.04.12"
+  },
+  {
+    "name": "libgs9-common",
+    "version": "9.26~dfsg+0-0ubuntu0.16.04.12"
+  },
+  {
+    "name": "libgsettings-qt1",
+    "version": "0.1+16.04.20160329-0ubuntu1"
+  },
+  {
+    "name": "libgssapi-krb5-2",
+    "version": "1.13.2+dfsg-5ubuntu2.1"
+  },
+  {
+    "name": "libgssapi3-heimdal",
+    "version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1"
+  },
+  {
+    "name": "libgstreamer-plugins-base1.0-0",
+    "version": "1.8.3-1ubuntu0.3"
+  },
+  {
+    "name": "libgstreamer-plugins-good1.0-0",
+    "version": "1.8.3-1ubuntu0.4"
+  },
+  {
+    "name": "libgstreamer1.0-0",
+    "version": "1.8.3-1~ubuntu0.1"
+  },
+  {
+    "name": "libgtk-3-0",
+    "version": "3.18.9-1ubuntu3.3"
+  },
+  {
+    "name": "libgtk-3-bin",
+    "version": "3.18.9-1ubuntu3.3"
+  },
+  {
+    "name": "libgtk-3-common",
+    "version": "3.18.9-1ubuntu3.3"
+  },
+  {
+    "name": "libgtk2-perl",
+    "version": "2:1.2498-1"
+  },
+  {
+    "name": "libgtk2.0-0",
+    "version": "2.24.30-1ubuntu1.16.04.2"
+  },
+  {
+    "name": "libgtk2.0-bin",
+    "version": "2.24.30-1ubuntu1.16.04.2"
+  },
+  {
+    "name": "libgtk2.0-common",
+    "version": "2.24.30-1ubuntu1.16.04.2"
+  },
+  {
+    "name": "libgtkmm-3.0-1v5",
+    "version": "3.18.0-1"
+  },
+  {
+    "name": "libgtksourceview-3.0-1",
+    "version": "3.18.2-1"
+  },
+  {
+    "name": "libgtksourceview-3.0-common",
+    "version": "3.18.2-1"
+  },
+  {
+    "name": "libgtkspell3-3-0",
+    "version": "3.0.7-2"
+  },
+  {
+    "name": "libgtop-2.0-10",
+    "version": "2.32.0-1"
+  },
+  {
+    "name": "libgtop2-common",
+    "version": "2.32.0-1"
+  },
+  {
+    "name": "libgucharmap-2-90-7",
+    "version": "1:3.18.2-1ubuntu1"
+  },
+  {
+    "name": "libgudev-1.0-0",
+    "version": "1:230-2"
+  },
+  {
+    "name": "libgusb2",
+    "version": "0.2.9-0ubuntu1"
+  },
+  {
+    "name": "libgutenprint2",
+    "version": "5.2.11-1"
+  },
+  {
+    "name": "libgweather-3-6",
+    "version": "3.18.2-0ubuntu0.2"
+  },
+  {
+    "name": "libgweather-common",
+    "version": "3.18.2-0ubuntu0.2"
+  },
+  {
+    "name": "libgxps2",
+    "version": "0.2.3.2-1"
+  },
+  {
+    "name": "libhardware2",
+    "version": "0.1.0+git20151016+6d424c9-0ubuntu7"
+  },
+  {
+    "name": "libharfbuzz-icu0",
+    "version": "1.0.1-1ubuntu0.1"
+  },
+  {
+    "name": "libharfbuzz0b",
+    "version": "1.0.1-1ubuntu0.1"
+  },
+  {
+    "name": "libhcrypto4-heimdal",
+    "version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1"
+  },
+  {
+    "name": "libheimbase1-heimdal",
+    "version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1"
+  },
+  {
+    "name": "libheimntlm0-heimdal",
+    "version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1"
+  },
+  {
+    "name": "libhogweed4",
+    "version": "3.2-1ubuntu0.16.04.1"
+  },
+  {
+    "name": "libhpmud0",
+    "version": "3.16.3+repack0-1"
+  },
+  {
+    "name": "libhtml-format-perl",
+    "version": "2.11-2"
+  },
+  {
+    "name": "libhtml-parser-perl",
+    "version": "3.72-1"
+  },
+  {
+    "name": "libhtml-tagset-perl",
+    "version": "3.20-2"
+  },
+  {
+    "name": "libhtml-tree-perl",
+    "version": "5.03-2"
+  },
+  {
+    "name": "libhttp-cookies-perl",
+    "version": "6.01-1"
+  },
+  {
+    "name": "libhttp-message-perl",
+    "version": "6.11-1"
+  },
+  {
+    "name": "libhud2",
+    "version": "14.10+16.04.20160415-0ubuntu1"
+  },
+  {
+    "name": "libhunspell-1.3-0",
+    "version": "1.3.3-4ubuntu1"
+  },
+  {
+    "name": "libhx509-5-heimdal",
+    "version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1"
+  },
+  {
+    "name": "libhybris",
+    "version": "0.1.0+git20151016+6d424c9-0ubuntu7"
+  },
+  {
+    "name": "libhybris-common1",
+    "version": "0.1.0+git20151016+6d424c9-0ubuntu7"
+  },
+  {
+    "name": "libhyphen0",
+    "version": "2.8.8-2ubuntu1"
+  },
+  {
+    "name": "libibus-1.0-5",
+    "version": "1.5.11-1ubuntu2.4"
+  },
+  {
+    "name": "libical1a",
+    "version": "1.0.1-0ubuntu2"
+  },
+  {
+    "name": "libice6",
+    "version": "2:1.0.9-1"
+  },
+  {
+    "name": "libicu55",
+    "version": "55.1-7ubuntu0.5"
+  },
+  {
+    "name": "libidn11",
+    "version": "1.32-3ubuntu1.2"
+  },
+  {
+    "name": "libido3-0.1-0",
+    "version": "13.10.0+16.04.20161028-0ubuntu1"
+  },
+  {
+    "name": "libiec61883-0",
+    "version": "1.2.0-0.2"
+  },
+  {
+    "name": "libieee1284-3",
+    "version": "0.2.11-12"
+  },
+  {
+    "name": "libijs-0.35",
+    "version": "0.35-12"
+  },
+  {
+    "name": "libimobiledevice6",
+    "version": "1.2.0+dfsg-3~ubuntu0.2"
+  },
+  {
+    "name": "libindicator3-7",
+    "version": "12.10.2+16.04.20151208-0ubuntu1"
+  },
+  {
+    "name": "libinput-bin",
+    "version": "1.6.3-1ubuntu1~16.04.1"
+  },
+  {
+    "name": "libinput10",
+    "version": "1.6.3-1ubuntu1~16.04.1"
+  },
+  {
+    "name": "libio-pty-perl",
+    "version": "1:1.08-1.1build1"
+  },
+  {
+    "name": "libio-socket-ssl-perl",
+    "version": "2.024-1"
+  },
+  {
+    "name": "libipc-run-perl",
+    "version": "0.94-1"
+  },
+  {
+    "name": "libipc-system-simple-perl",
+    "version": "1.25-3"
+  },
+  {
+    "name": "libisc-export160",
+    "version": "1:9.10.3.dfsg.P4-8ubuntu1.16"
+  },
+  {
+    "name": "libisc160",
+    "version": "1:9.10.3.dfsg.P4-8ubuntu1.16"
+  },
+  {
+    "name": "libisccc140",
+    "version": "1:9.10.3.dfsg.P4-8ubuntu1.16"
+  },
+  {
+    "name": "libisccfg140",
+    "version": "1:9.10.3.dfsg.P4-8ubuntu1.16"
+  },
+  {
+    "name": "libisl15",
+    "version": "0.16.1-1"
+  },
+  {
+    "name": "libitm1",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "libiw30",
+    "version": "30~pre9-8ubuntu1"
+  },
+  {
+    "name": "libjack-jackd2-0",
+    "version": "1.9.10+20150825git1ed50c92~dfsg-1ubuntu1"
+  },
+  {
+    "name": "libjasper1",
+    "version": "1.900.1-debian1-2.4ubuntu1.2"
+  },
+  {
+    "name": "libjavascriptcoregtk-4.0-18",
+    "version": "2.20.5-0ubuntu0.16.04.1"
+  },
+  {
+    "name": "libjbig0",
+    "version": "2.1-3.1"
+  },
+  {
+    "name": "libjbig2dec0",
+    "version": "0.12+20150918-1ubuntu0.1"
+  },
+  {
+    "name": "libjpeg-turbo8",
+    "version": "1.4.2-0ubuntu3.4"
+  },
+  {
+    "name": "libjson-c2",
+    "version": "0.11-4ubuntu2.6"
+  },
+  {
+    "name": "libjson-glib-1.0-0",
+    "version": "1.1.2-0ubuntu1"
+  },
+  {
+    "name": "libjson-glib-1.0-common",
+    "version": "1.1.2-0ubuntu1"
+  },
+  {
+    "name": "libk5crypto3",
+    "version": "1.13.2+dfsg-5ubuntu2.1"
+  },
+  {
+    "name": "libkeyutils1",
+    "version": "1.5.9-8ubuntu1"
+  },
+  {
+    "name": "libklibc",
+    "version": "2.0.4-8ubuntu1.16.04.4"
+  },
+  {
+    "name": "libkmod2",
+    "version": "22-1ubuntu5.2"
+  },
+  {
+    "name": "libkpathsea6",
+    "version": "2015.20160222.37495-1ubuntu0.1"
+  },
+  {
+    "name": "libkrb5-26-heimdal",
+    "version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1"
+  },
+  {
+    "name": "libkrb5-3",
+    "version": "1.13.2+dfsg-5ubuntu2.1"
+  },
+  {
+    "name": "libkrb5support0",
+    "version": "1.13.2+dfsg-5ubuntu2.1"
+  },
+  {
+    "name": "libksba8",
+    "version": "1.3.3-1ubuntu0.16.04.1"
+  },
+  {
+    "name": "liblangtag-common",
+    "version": "0.5.7-2ubuntu1"
+  },
+  {
+    "name": "liblangtag1",
+    "version": "0.5.7-2ubuntu1"
+  },
+  {
+    "name": "liblcms2-2",
+    "version": "2.6-3ubuntu2.1"
+  },
+  {
+    "name": "liblcms2-utils",
+    "version": "2.6-3ubuntu2.1"
+  },
+  {
+    "name": "libldap-2.4-2",
+    "version": "2.4.42+dfsg-2ubuntu3.9"
+  },
+  {
+    "name": "libldb1",
+    "version": "2:1.1.24-1ubuntu3.1"
+  },
+  {
+    "name": "liblightdm-gobject-1-0",
+    "version": "1.18.3-0ubuntu1.1"
+  },
+  {
+    "name": "liblircclient0",
+    "version": "0.9.0-0ubuntu6"
+  },
+  {
+    "name": "liblist-moreutils-perl",
+    "version": "0.413-1build1"
+  },
+  {
+    "name": "libllvm3.8",
+    "version": "1:3.8-2ubuntu4"
+  },
+  {
+    "name": "libllvm6.0",
+    "version": "1:6.0-1ubuntu2~16.04.1"
+  },
+  {
+    "name": "liblocale-gettext-perl",
+    "version": "1.07-1build1"
+  },
+  {
+    "name": "liblouis-data",
+    "version": "2.6.4-2ubuntu0.4"
+  },
+  {
+    "name": "liblouis9",
+    "version": "2.6.4-2ubuntu0.4"
+  },
+  {
+    "name": "liblouisutdml-bin",
+    "version": "2.5.0-3"
+  },
+  {
+    "name": "liblouisutdml-data",
+    "version": "2.5.0-3"
+  },
+  {
+    "name": "liblouisutdml6",
+    "version": "2.5.0-3"
+  },
+  {
+    "name": "liblqr-1-0",
+    "version": "0.4.2-2"
+  },
+  {
+    "name": "liblsan0",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "libltdl7",
+    "version": "2.4.6-0.1"
+  },
+  {
+    "name": "liblua5.2-0",
+    "version": "5.2.4-1ubuntu1"
+  },
+  {
+    "name": "liblwp-protocol-https-perl",
+    "version": "6.06-2"
+  },
+  {
+    "name": "liblwres141",
+    "version": "1:9.10.3.dfsg.P4-8ubuntu1.16"
+  },
+  {
+    "name": "liblz4-1",
+    "version": "0.0~r131-2ubuntu2"
+  },
+  {
+    "name": "liblzma5",
+    "version": "5.1.1alpha+20120614-2ubuntu2"
+  },
+  {
+    "name": "libmagic1",
+    "version": "1:5.25-2ubuntu1.4"
+  },
+  {
+    "name": "libmagickcore-6.q16-2",
+    "version": "8:6.8.9.9-7ubuntu5.15"
+  },
+  {
+    "name": "libmagickcore-6.q16-2-extra",
+    "version": "8:6.8.9.9-7ubuntu5.15"
+  },
+  {
+    "name": "libmagickwand-6.q16-2",
+    "version": "8:6.8.9.9-7ubuntu5.15"
+  },
+  {
+    "name": "libmailtools-perl",
+    "version": "2.13-1"
+  },
+  {
+    "name": "libmbim-glib4",
+    "version": "1.14.0-1ubuntu0.16.04.1"
+  },
+  {
+    "name": "libmbim-proxy",
+    "version": "1.14.0-1ubuntu0.16.04.1"
+  },
+  {
+    "name": "libmedia1",
+    "version": "0.1.0+git20151016+6d424c9-0ubuntu7"
+  },
+  {
+    "name": "libmediaart-2.0-0",
+    "version": "1.9.0-2"
+  },
+  {
+    "name": "libmessaging-menu0",
+    "version": "13.10.1+15.10.20150505-0ubuntu1"
+  },
+  {
+    "name": "libmetacity-private3a",
+    "version": "1:3.18.7-0ubuntu0.3"
+  },
+  {
+    "name": "libmhash2",
+    "version": "0.9.9.9-7"
+  },
+  {
+    "name": "libminiupnpc10",
+    "version": "1.9.20140610-2ubuntu2.16.04.2"
+  },
+  {
+    "name": "libmirclient9",
+    "version": "0.26.3+16.04.20170605-0ubuntu1.1"
+  },
+  {
+    "name": "libmircommon5",
+    "version": "0.21.0+16.04.20160330-0ubuntu1"
+  },
+  {
+    "name": "libmircommon7",
+    "version": "0.26.3+16.04.20170605-0ubuntu1.1"
+  },
+  {
+    "name": "libmircore1",
+    "version": "0.26.3+16.04.20170605-0ubuntu1.1"
+  },
+  {
+    "name": "libmirprotobuf3",
+    "version": "0.26.3+16.04.20170605-0ubuntu1.1"
+  },
+  {
+    "name": "libmm-glib0",
+    "version": "1.6.4-1ubuntu0.16.04.1"
+  },
+  {
+    "name": "libmng2",
+    "version": "2.0.2-0ubuntu3"
+  },
+  {
+    "name": "libmnl0",
+    "version": "1.0.3-5"
+  },
+  {
+    "name": "libmount1",
+    "version": "2.27.1-6ubuntu3.10"
+  },
+  {
+    "name": "libmpc3",
+    "version": "1.0.3-1"
+  },
+  {
+    "name": "libmpdec2",
+    "version": "2.4.2-1"
+  },
+  {
+    "name": "libmpfr4",
+    "version": "3.1.4-1"
+  },
+  {
+    "name": "libmpx0",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "libmspub-0.1-1",
+    "version": "0.1.2-2ubuntu1"
+  },
+  {
+    "name": "libmtdev1",
+    "version": "1.1.5-1ubuntu2"
+  },
+  {
+    "name": "libmtp-common",
+    "version": "1.1.10-2ubuntu1"
+  },
+  {
+    "name": "libmtp-runtime",
+    "version": "1.1.10-2ubuntu1"
+  },
+  {
+    "name": "libmtp9",
+    "version": "1.1.10-2ubuntu1"
+  },
+  {
+    "name": "libmwaw-0.3-3",
+    "version": "0.3.7-1ubuntu2.1"
+  },
+  {
+    "name": "libmythes-1.2-0",
+    "version": "2:1.2.4-1ubuntu3"
+  },
+  {
+    "name": "libnatpmp1",
+    "version": "20110808-4"
+  },
+  {
+    "name": "libnautilus-extension1a",
+    "version": "1:3.18.4.is.3.14.3-0ubuntu6"
+  },
+  {
+    "name": "libncurses5",
+    "version": "6.0+20160213-1ubuntu1"
+  },
+  {
+    "name": "libncursesw5",
+    "version": "6.0+20160213-1ubuntu1"
+  },
+  {
+    "name": "libndp0",
+    "version": "1.4-2ubuntu0.16.04.1"
+  },
+  {
+    "name": "libneon27-gnutls",
+    "version": "0.30.1-3build1"
+  },
+  {
+    "name": "libnet-dbus-perl",
+    "version": "1.1.0-3build1"
+  },
+  {
+    "name": "libnet-dns-perl",
+    "version": "0.81-2build1"
+  },
+  {
+    "name": "libnet-domain-tld-perl",
+    "version": "1.73-1"
+  },
+  {
+    "name": "libnet-http-perl",
+    "version": "6.09-1"
+  },
+  {
+    "name": "libnet-libidn-perl",
+    "version": "0.12.ds-2build2"
+  },
+  {
+    "name": "libnet-smtp-ssl-perl",
+    "version": "1.03-1"
+  },
+  {
+    "name": "libnet-ssleay-perl",
+    "version": "1.72-1build1"
+  },
+  {
+    "name": "libnetfilter-conntrack3",
+    "version": "1.0.5-1"
+  },
+  {
+    "name": "libnetpbm10",
+    "version": "2:10.0-15.3"
+  },
+  {
+    "name": "libnettle6",
+    "version": "3.2-1ubuntu0.16.04.1"
+  },
+  {
+    "name": "libnewt0.52",
+    "version": "0.52.18-1ubuntu2"
+  },
+  {
+    "name": "libnih-dbus1",
+    "version": "1.0.3-4.3ubuntu1"
+  },
+  {
+    "name": "libnih1",
+    "version": "1.0.3-4.3ubuntu1"
+  },
+  {
+    "name": "libnl-3-200",
+    "version": "3.2.27-1ubuntu0.16.04.1"
+  },
+  {
+    "name": "libnl-genl-3-200",
+    "version": "3.2.27-1ubuntu0.16.04.1"
+  },
+  {
+    "name": "libnm-glib-vpn1",
+    "version": "1.2.6-0ubuntu0.16.04.3"
+  },
+  {
+    "name": "libnm-glib4",
+    "version": "1.2.6-0ubuntu0.16.04.3"
+  },
+  {
+    "name": "libnm-gtk-common",
+    "version": "1.2.6-0ubuntu0.16.04.4"
+  },
+  {
+    "name": "libnm-gtk0",
+    "version": "1.2.6-0ubuntu0.16.04.4"
+  },
+  {
+    "name": "libnm-util2",
+    "version": "1.2.6-0ubuntu0.16.04.3"
+  },
+  {
+    "name": "libnm0",
+    "version": "1.2.6-0ubuntu0.16.04.3"
+  },
+  {
+    "name": "libnma-common",
+    "version": "1.2.6-0ubuntu0.16.04.4"
+  },
+  {
+    "name": "libnma0",
+    "version": "1.2.6-0ubuntu0.16.04.4"
+  },
+  {
+    "name": "libnotify-bin",
+    "version": "0.7.6-2svn1"
+  },
+  {
+    "name": "libnotify4",
+    "version": "0.7.6-2svn1"
+  },
+  {
+    "name": "libnpth0",
+    "version": "1.2-3"
+  },
+  {
+    "name": "libnspr4",
+    "version": "2:4.13.1-0ubuntu0.16.04.1"
+  },
+  {
+    "name": "libnss-mdns",
+    "version": "0.10-7"
+  },
+  {
+    "name": "libnss3",
+    "version": "2:3.28.4-0ubuntu0.16.04.12"
+  },
+  {
+    "name": "libnss3-nssdb",
+    "version": "2:3.28.4-0ubuntu0.16.04.12"
+  },
+  {
+    "name": "libnuma1",
+    "version": "2.0.11-1ubuntu1.1"
+  },
+  {
+    "name": "libnux-4.0-0",
+    "version": "4.0.8+16.04.20180622.2-0ubuntu1"
+  },
+  {
+    "name": "libnux-4.0-common",
+    "version": "4.0.8+16.04.20180622.2-0ubuntu1"
+  },
+  {
+    "name": "liboauth0",
+    "version": "1.0.3-0ubuntu2"
+  },
+  {
+    "name": "libodfgen-0.1-1",
+    "version": "0.1.6-1ubuntu2"
+  },
+  {
+    "name": "libopenexr22",
+    "version": "2.2.0-10ubuntu2.3"
+  },
+  {
+    "name": "libopenscap8",
+    "version": "1.2.8-1"
+  },
+  {
+    "name": "liborc-0.4-0",
+    "version": "1:0.4.25-1"
+  },
+  {
+    "name": "liborcus-0.10-0v5",
+    "version": "0.9.2-4ubuntu2"
+  },
+  {
+    "name": "liboxideqt-qmlplugin",
+    "version": "1.21.5-0ubuntu0.16.04.1"
+  },
+  {
+    "name": "liboxideqtcore0",
+    "version": "1.21.5-0ubuntu0.16.04.1"
+  },
+  {
+    "name": "liboxideqtquick0",
+    "version": "1.21.5-0ubuntu0.16.04.1"
+  },
+  {
+    "name": "libp11-kit-gnome-keyring",
+    "version": "3.18.3-0ubuntu2.1"
+  },
+  {
+    "name": "libp11-kit0",
+    "version": "0.23.2-5~ubuntu16.04.1"
+  },
+  {
+    "name": "libpackagekit-glib2-16",
+    "version": "0.8.17-4ubuntu6~gcc5.4ubuntu1.4"
+  },
+  {
+    "name": "libpagemaker-0.0-0",
+    "version": "0.0.3-1ubuntu1"
+  },
+  {
+    "name": "libpam-gnome-keyring",
+    "version": "3.18.3-0ubuntu2.1"
+  },
+  {
+    "name": "libpam-modules",
+    "version": "1.1.8-3.2ubuntu2.1"
+  },
+  {
+    "name": "libpam-modules-bin",
+    "version": "1.1.8-3.2ubuntu2.1"
+  },
+  {
+    "name": "libpam-runtime",
+    "version": "1.1.8-3.2ubuntu2.1"
+  },
+  {
+    "name": "libpam-systemd",
+    "version": "229-4ubuntu21.28"
+  },
+  {
+    "name": "libpam0g",
+    "version": "1.1.8-3.2ubuntu2.1"
+  },
+  {
+    "name": "libpango-1.0-0",
+    "version": "1.38.1-1"
+  },
+  {
+    "name": "libpango-perl",
+    "version": "1.227-1"
+  },
+  {
+    "name": "libpango1.0-0",
+    "version": "1.38.1-1"
+  },
+  {
+    "name": "libpangocairo-1.0-0",
+    "version": "1.38.1-1"
+  },
+  {
+    "name": "libpangoft2-1.0-0",
+    "version": "1.38.1-1"
+  },
+  {
+    "name": "libpangomm-1.4-1v5",
+    "version": "2.38.1-1"
+  },
+  {
+    "name": "libpangox-1.0-0",
+    "version": "0.0.2-5"
+  },
+  {
+    "name": "libpangoxft-1.0-0",
+    "version": "1.38.1-1"
+  },
+  {
+    "name": "libpaper-utils",
+    "version": "1.1.24+nmu4ubuntu1"
+  },
+  {
+    "name": "libpaper1",
+    "version": "1.1.24+nmu4ubuntu1"
+  },
+  {
+    "name": "libparse-debianchangelog-perl",
+    "version": "1.2.0-8"
+  },
+  {
+    "name": "libparted2",
+    "version": "3.2-15ubuntu0.1"
+  },
+  {
+    "name": "libpcap0.8",
+    "version": "1.7.4-2ubuntu0.1"
+  },
+  {
+    "name": "libpci3",
+    "version": "1:3.3.1-1.1ubuntu1.3"
+  },
+  {
+    "name": "libpciaccess0",
+    "version": "0.13.4-1"
+  },
+  {
+    "name": "libpcre16-3",
+    "version": "2:8.38-3.1"
+  },
+  {
+    "name": "libpcre3",
+    "version": "2:8.38-3.1"
+  },
+  {
+    "name": "libpcsclite1",
+    "version": "1.8.14-1ubuntu1.16.04.1"
+  },
+  {
+    "name": "libpeas-1.0-0",
+    "version": "1.16.0-1ubuntu2"
+  },
+  {
+    "name": "libpeas-1.0-0-python3loader",
+    "version": "1.16.0-1ubuntu2"
+  },
+  {
+    "name": "libpeas-common",
+    "version": "1.16.0-1ubuntu2"
+  },
+  {
+    "name": "libperl5.22",
+    "version": "5.22.1-9ubuntu0.6"
+  },
+  {
+    "name": "libperlio-gzip-perl",
+    "version": "0.19-1build1"
+  },
+  {
+    "name": "libpipeline1",
+    "version": "1.4.1-2"
+  },
+  {
+    "name": "libpixman-1-0",
+    "version": "0.33.6-1"
+  },
+  {
+    "name": "libplist3",
+    "version": "1.12-3.1ubuntu0.16.04.1"
+  },
+  {
+    "name": "libplymouth4",
+    "version": "0.9.2-3ubuntu13.5"
+  },
+  {
+    "name": "libpng12-0",
+    "version": "1.2.54-1ubuntu1.1"
+  },
+  {
+    "name": "libpolkit-agent-1-0",
+    "version": "0.105-14.1ubuntu0.5"
+  },
+  {
+    "name": "libpolkit-backend-1-0",
+    "version": "0.105-14.1ubuntu0.5"
+  },
+  {
+    "name": "libpolkit-gobject-1-0",
+    "version": "0.105-14.1ubuntu0.5"
+  },
+  {
+    "name": "libpoppler-glib8",
+    "version": "0.41.0-0ubuntu1.14"
+  },
+  {
+    "name": "libpoppler58",
+    "version": "0.41.0-0ubuntu1.14"
+  },
+  {
+    "name": "libpopt0",
+    "version": "1.16-10"
+  },
+  {
+    "name": "libportaudio2",
+    "version": "19+svn20140130-1build1"
+  },
+  {
+    "name": "libprocps4",
+    "version": "2:3.3.10-4ubuntu2.5"
+  },
+  {
+    "name": "libprotobuf-lite9v5",
+    "version": "2.6.1-1.3"
+  },
+  {
+    "name": "libprotobuf9v5",
+    "version": "2.6.1-1.3"
+  },
+  {
+    "name": "libproxy1-plugin-gsettings",
+    "version": "0.4.11-5ubuntu1"
+  },
+  {
+    "name": "libproxy1-plugin-networkmanager",
+    "version": "0.4.11-5ubuntu1"
+  },
+  {
+    "name": "libproxy1v5",
+    "version": "0.4.11-5ubuntu1"
+  },
+  {
+    "name": "libpulse-mainloop-glib0",
+    "version": "1:8.0-0ubuntu3.12"
+  },
+  {
+    "name": "libpulse0",
+    "version": "1:8.0-0ubuntu3.12"
+  },
+  {
+    "name": "libpulsedsp",
+    "version": "1:8.0-0ubuntu3.12"
+  },
+  {
+    "name": "libpwquality-common",
+    "version": "1.3.0-0ubuntu1"
+  },
+  {
+    "name": "libpwquality1",
+    "version": "1.3.0-0ubuntu1"
+  },
+  {
+    "name": "libpython-stdlib",
+    "version": "2.7.12-1~16.04"
+  },
+  {
+    "name": "libpython2.7",
+    "version": "2.7.12-1ubuntu0~16.04.12"
+  },
+  {
+    "name": "libpython2.7-minimal",
+    "version": "2.7.12-1ubuntu0~16.04.12"
+  },
+  {
+    "name": "libpython2.7-stdlib",
+    "version": "2.7.12-1ubuntu0~16.04.12"
+  },
+  {
+    "name": "libpython3-stdlib",
+    "version": "3.5.1-3"
+  },
+  {
+    "name": "libpython3.5",
+    "version": "3.5.2-2ubuntu0~16.04.11"
+  },
+  {
+    "name": "libpython3.5-minimal",
+    "version": "3.5.2-2ubuntu0~16.04.11"
+  },
+  {
+    "name": "libpython3.5-stdlib",
+    "version": "3.5.2-2ubuntu0~16.04.11"
+  },
+  {
+    "name": "libqmi-glib1",
+    "version": "1.12.6-1"
+  },
+  {
+    "name": "libqmi-glib5",
+    "version": "1.16.2-1ubuntu0.16.04.1"
+  },
+  {
+    "name": "libqmi-proxy",
+    "version": "1.16.2-1ubuntu0.16.04.1"
+  },
+  {
+    "name": "libqpdf17",
+    "version": "6.0.0-2"
+  },
+  {
+    "name": "libqpdf21",
+    "version": "8.0.2-3~16.04.1"
+  },
+  {
+    "name": "libqqwing2v5",
+    "version": "1.3.4-1"
+  },
+  {
+    "name": "libqt4-dbus",
+    "version": "4:4.8.7+dfsg-5ubuntu2"
+  },
+  {
+    "name": "libqt4-declarative",
+    "version": "4:4.8.7+dfsg-5ubuntu2"
+  },
+  {
+    "name": "libqt4-network",
+    "version": "4:4.8.7+dfsg-5ubuntu2"
+  },
+  {
+    "name": "libqt4-script",
+    "version": "4:4.8.7+dfsg-5ubuntu2"
+  },
+  {
+    "name": "libqt4-sql",
+    "version": "4:4.8.7+dfsg-5ubuntu2"
+  },
+  {
+    "name": "libqt4-sql-sqlite",
+    "version": "4:4.8.7+dfsg-5ubuntu2"
+  },
+  {
+    "name": "libqt4-xml",
+    "version": "4:4.8.7+dfsg-5ubuntu2"
+  },
+  {
+    "name": "libqt4-xmlpatterns",
+    "version": "4:4.8.7+dfsg-5ubuntu2"
+  },
+  {
+    "name": "libqt5core5a",
+    "version": "5.5.1+dfsg-16ubuntu7.7"
+  },
+  {
+    "name": "libqt5dbus5",
+    "version": "5.5.1+dfsg-16ubuntu7.7"
+  },
+  {
+    "name": "libqt5feedback5",
+    "version": "5.0~git20130529-0ubuntu13"
+  },
+  {
+    "name": "libqt5gui5",
+    "version": "5.5.1+dfsg-16ubuntu7.7"
+  },
+  {
+    "name": "libqt5multimedia5",
+    "version": "5.5.1-4ubuntu2"
+  },
+  {
+    "name": "libqt5network5",
+    "version": "5.5.1+dfsg-16ubuntu7.7"
+  },
+  {
+    "name": "libqt5opengl5",
+    "version": "5.5.1+dfsg-16ubuntu7.7"
+  },
+  {
+    "name": "libqt5organizer5",
+    "version": "5.0~git20140515~29475884-0ubuntu20"
+  },
+  {
+    "name": "libqt5positioning5",
+    "version": "5.5.1-3ubuntu1"
+  },
+  {
+    "name": "libqt5printsupport5",
+    "version": "5.5.1+dfsg-16ubuntu7.7"
+  },
+  {
+    "name": "libqt5qml5",
+    "version": "5.5.1-2ubuntu6"
+  },
+  {
+    "name": "libqt5quick5",
+    "version": "5.5.1-2ubuntu6"
+  },
+  {
+    "name": "libqt5quicktest5",
+    "version": "5.5.1-2ubuntu6"
+  },
+  {
+    "name": "libqt5sql5",
+    "version": "5.5.1+dfsg-16ubuntu7.7"
+  },
+  {
+    "name": "libqt5sql5-sqlite",
+    "version": "5.5.1+dfsg-16ubuntu7.7"
+  },
+  {
+    "name": "libqt5svg5",
+    "version": "5.5.1-2build1"
+  },
+  {
+    "name": "libqt5test5",
+    "version": "5.5.1+dfsg-16ubuntu7.7"
+  },
+  {
+    "name": "libqt5webkit5",
+    "version": "5.5.1+dfsg-2ubuntu1"
+  },
+  {
+    "name": "libqt5widgets5",
+    "version": "5.5.1+dfsg-16ubuntu7.7"
+  },
+  {
+    "name": "libqt5xml5",
+    "version": "5.5.1+dfsg-16ubuntu7.7"
+  },
+  {
+    "name": "libqtcore4",
+    "version": "4:4.8.7+dfsg-5ubuntu2"
+  },
+  {
+    "name": "libqtdbus4",
+    "version": "4:4.8.7+dfsg-5ubuntu2"
+  },
+  {
+    "name": "libqtgui4",
+    "version": "4:4.8.7+dfsg-5ubuntu2"
+  },
+  {
+    "name": "libquadmath0",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "libquvi-scripts",
+    "version": "0.4.21-2"
+  },
+  {
+    "name": "libquvi7",
+    "version": "0.4.1-3"
+  },
+  {
+    "name": "libraptor2-0",
+    "version": "2.0.14-1"
+  },
+  {
+    "name": "librasqal3",
+    "version": "0.9.32-1"
+  },
+  {
+    "name": "libraw1394-11",
+    "version": "2.1.1-2"
+  },
+  {
+    "name": "libraw15",
+    "version": "0.17.1-1ubuntu0.5"
+  },
+  {
+    "name": "librdf0",
+    "version": "1.0.17-1build1"
+  },
+  {
+    "name": "libreadline6",
+    "version": "6.3-8ubuntu2"
+  },
+  {
+    "name": "libreoffice-avmedia-backend-gstreamer",
+    "version": "1:5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "libreoffice-base-core",
+    "version": "1:5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "libreoffice-calc",
+    "version": "1:5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "libreoffice-common",
+    "version": "1:5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "libreoffice-core",
+    "version": "1:5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "libreoffice-draw",
+    "version": "1:5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "libreoffice-gnome",
+    "version": "1:5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "libreoffice-gtk",
+    "version": "1:5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "libreoffice-help-en-us",
+    "version": "1:5.1.4-0ubuntu1"
+  },
+  {
+    "name": "libreoffice-impress",
+    "version": "1:5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "libreoffice-math",
+    "version": "1:5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "libreoffice-ogltrans",
+    "version": "1:5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "libreoffice-pdfimport",
+    "version": "1:5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "libreoffice-style-breeze",
+    "version": "1:5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "libreoffice-style-galaxy",
+    "version": "1:5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "libreoffice-writer",
+    "version": "1:5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "librest-0.7-0",
+    "version": "0.7.93-1"
+  },
+  {
+    "name": "librevenge-0.0-0",
+    "version": "0.0.4-4ubuntu1"
+  },
+  {
+    "name": "librhythmbox-core9",
+    "version": "3.3-1ubuntu7"
+  },
+  {
+    "name": "libroken18-heimdal",
+    "version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1"
+  },
+  {
+    "name": "librsvg2-2",
+    "version": "2.40.13-3ubuntu0.2"
+  },
+  {
+    "name": "librsvg2-common",
+    "version": "2.40.13-3ubuntu0.2"
+  },
+  {
+    "name": "librtmp1",
+    "version": "2.4+20151223.gitfa8646d-1ubuntu0.1"
+  },
+  {
+    "name": "libsamplerate0",
+    "version": "0.1.8-8"
+  },
+  {
+    "name": "libsane",
+    "version": "1.0.25+git20150528-1ubuntu2.16.04.1"
+  },
+  {
+    "name": "libsane-common",
+    "version": "1.0.25+git20150528-1ubuntu2.16.04.1"
+  },
+  {
+    "name": "libsane-hpaio",
+    "version": "3.16.3+repack0-1"
+  },
+  {
+    "name": "libsasl2-2",
+    "version": "2.1.26.dfsg1-14ubuntu0.2"
+  },
+  {
+    "name": "libsasl2-modules",
+    "version": "2.1.26.dfsg1-14ubuntu0.2"
+  },
+  {
+    "name": "libsasl2-modules-db",
+    "version": "2.1.26.dfsg1-14ubuntu0.2"
+  },
+  {
+    "name": "libsbc1",
+    "version": "1.3-1"
+  },
+  {
+    "name": "libseccomp2",
+    "version": "2.4.3-1ubuntu3.16.04.3"
+  },
+  {
+    "name": "libsecret-1-0",
+    "version": "0.18.4-1ubuntu2"
+  },
+  {
+    "name": "libsecret-common",
+    "version": "0.18.4-1ubuntu2"
+  },
+  {
+    "name": "libselinux1",
+    "version": "2.4-3build2"
+  },
+  {
+    "name": "libsemanage-common",
+    "version": "2.3-1build3"
+  },
+  {
+    "name": "libsemanage1",
+    "version": "2.3-1build3"
+  },
+  {
+    "name": "libsensors4",
+    "version": "1:3.4.0-2"
+  },
+  {
+    "name": "libsepol1",
+    "version": "2.4-2"
+  },
+  {
+    "name": "libsgutils2-2",
+    "version": "1.40-0ubuntu1"
+  },
+  {
+    "name": "libshout3",
+    "version": "2.3.1-3"
+  },
+  {
+    "name": "libsigc++-2.0-0v5",
+    "version": "2.6.2-1"
+  },
+  {
+    "name": "libsignon-extension1",
+    "version": "8.58+16.04.20151106-0ubuntu1"
+  },
+  {
+    "name": "libsignon-glib1",
+    "version": "1.13+16.04.20151209.1-0ubuntu1"
+  },
+  {
+    "name": "libsignon-plugins-common1",
+    "version": "8.58+16.04.20151106-0ubuntu1"
+  },
+  {
+    "name": "libsignon-qt5-1",
+    "version": "8.58+16.04.20151106-0ubuntu1"
+  },
+  {
+    "name": "libslang2",
+    "version": "2.3.0-2ubuntu1.1"
+  },
+  {
+    "name": "libsmartcols1",
+    "version": "2.27.1-6ubuntu3.10"
+  },
+  {
+    "name": "libsmbclient",
+    "version": "2:4.3.11+dfsg-0ubuntu0.16.04.28"
+  },
+  {
+    "name": "libsnapd-glib1",
+    "version": "1.49-0ubuntu0.16.04.2"
+  },
+  {
+    "name": "libsndfile1",
+    "version": "1.0.25-10ubuntu0.16.04.2"
+  },
+  {
+    "name": "libsnmp-base",
+    "version": "5.7.3+dfsg-1ubuntu4.4"
+  },
+  {
+    "name": "libsnmp30",
+    "version": "5.7.3+dfsg-1ubuntu4.4"
+  },
+  {
+    "name": "libsocket6-perl",
+    "version": "0.25-1build2"
+  },
+  {
+    "name": "libsonic0",
+    "version": "0.2.0-3"
+  },
+  {
+    "name": "libsoup-gnome2.4-1",
+    "version": "2.52.2-1ubuntu0.3"
+  },
+  {
+    "name": "libsoup2.4-1",
+    "version": "2.52.2-1ubuntu0.3"
+  },
+  {
+    "name": "libspectre1",
+    "version": "0.2.7-3ubuntu2"
+  },
+  {
+    "name": "libspeechd2",
+    "version": "0.8.3-1ubuntu3"
+  },
+  {
+    "name": "libspeex1",
+    "version": "1.2~rc1.2-1ubuntu1"
+  },
+  {
+    "name": "libspeexdsp1",
+    "version": "1.2~rc1.2-1ubuntu1"
+  },
+  {
+    "name": "libsqlite3-0",
+    "version": "3.11.0-1ubuntu1.5"
+  },
+  {
+    "name": "libss2",
+    "version": "1.42.13-1ubuntu1.2"
+  },
+  {
+    "name": "libssh-4",
+    "version": "0.6.3-4.3ubuntu0.6"
+  },
+  {
+    "name": "libssl1.0.0",
+    "version": "1.0.2g-1ubuntu4.16"
+  },
+  {
+    "name": "libstartup-notification0",
+    "version": "0.12-4build1"
+  },
+  {
+    "name": "libstdc++-5-dev",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "libstdc++6",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "libsub-name-perl",
+    "version": "0.14-1build1"
+  },
+  {
+    "name": "libsuitesparseconfig4.4.6",
+    "version": "1:4.4.6-1"
+  },
+  {
+    "name": "libsystemd0",
+    "version": "229-4ubuntu21.28"
+  },
+  {
+    "name": "libtag1v5",
+    "version": "1.9.1-2.4ubuntu1"
+  },
+  {
+    "name": "libtag1v5-vanilla",
+    "version": "1.9.1-2.4ubuntu1"
+  },
+  {
+    "name": "libtalloc2",
+    "version": "2.1.5-2"
+  },
+  {
+    "name": "libtasn1-6",
+    "version": "4.7-3ubuntu0.16.04.3"
+  },
+  {
+    "name": "libtcl8.6",
+    "version": "8.6.5+dfsg-2"
+  },
+  {
+    "name": "libtdb1",
+    "version": "1.3.8-2"
+  },
+  {
+    "name": "libtelepathy-glib0",
+    "version": "0.24.1-1.1"
+  },
+  {
+    "name": "libtevent0",
+    "version": "0.9.28-0ubuntu0.16.04.1"
+  },
+  {
+    "name": "libtext-charwidth-perl",
+    "version": "0.04-7build5"
+  },
+  {
+    "name": "libtext-iconv-perl",
+    "version": "1.7-5build4"
+  },
+  {
+    "name": "libthai-data",
+    "version": "0.1.24-2"
+  },
+  {
+    "name": "libthai0",
+    "version": "0.1.24-2"
+  },
+  {
+    "name": "libtheora0",
+    "version": "1.1.1+dfsg.1-8"
+  },
+  {
+    "name": "libtiff5",
+    "version": "4.0.6-1ubuntu0.7"
+  },
+  {
+    "name": "libtimezonemap-data",
+    "version": "0.4.5"
+  },
+  {
+    "name": "libtimezonemap1",
+    "version": "0.4.5"
+  },
+  {
+    "name": "libtinfo5",
+    "version": "6.0+20160213-1ubuntu1"
+  },
+  {
+    "name": "libtk8.6",
+    "version": "8.6.5-1"
+  },
+  {
+    "name": "libtotem-plparser-common",
+    "version": "3.10.6-1ubuntu1"
+  },
+  {
+    "name": "libtotem-plparser18",
+    "version": "3.10.6-1ubuntu1"
+  },
+  {
+    "name": "libtotem0",
+    "version": "3.18.1-1ubuntu4"
+  },
+  {
+    "name": "libtracker-sparql-1.0-0",
+    "version": "1.6.2-0ubuntu1.1"
+  },
+  {
+    "name": "libtsan0",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "libtxc-dxtn-s2tc0",
+    "version": "0~git20131104-1.1"
+  },
+  {
+    "name": "libubsan0",
+    "version": "5.4.0-6ubuntu1~16.04.12"
+  },
+  {
+    "name": "libubuntugestures5",
+    "version": "1.3.1918+16.04.20160404-0ubuntu1"
+  },
+  {
+    "name": "libubuntutoolkit5",
+    "version": "1.3.1918+16.04.20160404-0ubuntu1"
+  },
+  {
+    "name": "libudev1",
+    "version": "229-4ubuntu21.28"
+  },
+  {
+    "name": "libudisks2-0",
+    "version": "2.1.7-1ubuntu1"
+  },
+  {
+    "name": "libunistring0",
+    "version": "0.9.3-5.2ubuntu1"
+  },
+  {
+    "name": "libunity-action-qt1",
+    "version": "1.1.0+14.04.20140304-0ubuntu2~gcc5.1"
+  },
+  {
+    "name": "libunity-control-center1",
+    "version": "15.04.0+16.04.20171130-0ubuntu1"
+  },
+  {
+    "name": "libunity-core-6.0-9",
+    "version": "7.4.5+16.04.20190312-0ubuntu1"
+  },
+  {
+    "name": "libunity-gtk2-parser0",
+    "version": "0.0.0+15.04.20150118-0ubuntu2"
+  },
+  {
+    "name": "libunity-gtk3-parser0",
+    "version": "0.0.0+15.04.20150118-0ubuntu2"
+  },
+  {
+    "name": "libunity-misc4",
+    "version": "4.0.5+14.04.20140115-0ubuntu1"
+  },
+  {
+    "name": "libunity-protocol-private0",
+    "version": "7.1.4+16.04.20180209.1-0ubuntu1"
+  },
+  {
+    "name": "libunity-scopes-json-def-desktop",
+    "version": "7.1.4+16.04.20180209.1-0ubuntu1"
+  },
+  {
+    "name": "libunity-settings-daemon1",
+    "version": "15.04.1+16.04.20160701-0ubuntu3"
+  },
+  {
+    "name": "libunity-webapps0",
+    "version": "2.5.0~+16.04.20160201-0ubuntu1"
+  },
+  {
+    "name": "libunity9",
+    "version": "7.1.4+16.04.20180209.1-0ubuntu1"
+  },
+  {
+    "name": "libunwind8",
+    "version": "1.1-4.1"
+  },
+  {
+    "name": "libupower-glib3",
+    "version": "0.99.4-2ubuntu0.3"
+  },
+  {
+    "name": "liburi-perl",
+    "version": "1.71-1"
+  },
+  {
+    "name": "liburl-dispatcher1",
+    "version": "0.1+16.04.20151110-0ubuntu2"
+  },
+  {
+    "name": "libusb-0.1-4",
+    "version": "2:0.1.12-28"
+  },
+  {
+    "name": "libusb-1.0-0",
+    "version": "2:1.0.20-1"
+  },
+  {
+    "name": "libusbmuxd4",
+    "version": "1.0.10-2ubuntu0.1"
+  },
+  {
+    "name": "libustr-1.0-1",
+    "version": "1.0.4-5"
+  },
+  {
+    "name": "libutempter0",
+    "version": "1.1.6-3"
+  },
+  {
+    "name": "libuuid-perl",
+    "version": "0.24-1build1"
+  },
+  {
+    "name": "libuuid1",
+    "version": "2.27.1-6ubuntu3.10"
+  },
+  {
+    "name": "libv4l-0",
+    "version": "1.10.0-1"
+  },
+  {
+    "name": "libv4lconvert0",
+    "version": "1.10.0-1"
+  },
+  {
+    "name": "libvisio-0.1-1",
+    "version": "0.1.5-1ubuntu1"
+  },
+  {
+    "name": "libvisual-0.4-0",
+    "version": "0.4.0-8"
+  },
+  {
+    "name": "libvncclient1",
+    "version": "0.9.10+dfsg-3ubuntu0.16.04.5"
+  },
+  {
+    "name": "libvorbis0a",
+    "version": "1.3.5-3ubuntu0.2"
+  },
+  {
+    "name": "libvorbisenc2",
+    "version": "1.3.5-3ubuntu0.2"
+  },
+  {
+    "name": "libvorbisfile3",
+    "version": "1.3.5-3ubuntu0.2"
+  },
+  {
+    "name": "libvpx3",
+    "version": "1.5.0-2ubuntu1.1"
+  },
+  {
+    "name": "libvte-2.91-0",
+    "version": "0.42.5-1ubuntu1"
+  },
+  {
+    "name": "libvte-2.91-common",
+    "version": "0.42.5-1ubuntu1"
+  },
+  {
+    "name": "libwacom-bin",
+    "version": "0.22-1~ubuntu16.04.1"
+  },
+  {
+    "name": "libwacom-common",
+    "version": "0.22-1~ubuntu16.04.1"
+  },
+  {
+    "name": "libwacom2",
+    "version": "0.22-1~ubuntu16.04.1"
+  },
+  {
+    "name": "libwavpack1",
+    "version": "4.75.2-2ubuntu0.2"
+  },
+  {
+    "name": "libwayland-client0",
+    "version": "1.12.0-1~ubuntu16.04.3"
+  },
+  {
+    "name": "libwayland-cursor0",
+    "version": "1.12.0-1~ubuntu16.04.3"
+  },
+  {
+    "name": "libwayland-egl1-mesa",
+    "version": "18.0.5-0ubuntu0~16.04.1"
+  },
+  {
+    "name": "libwayland-server0",
+    "version": "1.12.0-1~ubuntu16.04.3"
+  },
+  {
+    "name": "libwbclient0",
+    "version": "2:4.3.11+dfsg-0ubuntu0.16.04.28"
+  },
+  {
+    "name": "libwebkit2gtk-4.0-37",
+    "version": "2.20.5-0ubuntu0.16.04.1"
+  },
+  {
+    "name": "libwebkit2gtk-4.0-37-gtk2",
+    "version": "2.20.5-0ubuntu0.16.04.1"
+  },
+  {
+    "name": "libwebp5",
+    "version": "0.4.4-1"
+  },
+  {
+    "name": "libwebpdemux1",
+    "version": "0.4.4-1"
+  },
+  {
+    "name": "libwebpmux1",
+    "version": "0.4.4-1"
+  },
+  {
+    "name": "libwebrtc-audio-processing-0",
+    "version": "0.1-3ubuntu1~gcc5.1"
+  },
+  {
+    "name": "libwhoopsie-preferences0",
+    "version": "0.18"
+  },
+  {
+    "name": "libwhoopsie0",
+    "version": "0.2.52.5ubuntu0.5"
+  },
+  {
+    "name": "libwind0-heimdal",
+    "version": "1.7~git20150920+dfsg-4ubuntu1.16.04.1"
+  },
+  {
+    "name": "libwinpr-crt0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwinpr-dsparse0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwinpr-environment0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwinpr-file0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwinpr-handle0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwinpr-heap0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwinpr-input0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwinpr-interlocked0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwinpr-library0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwinpr-path0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwinpr-pool0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwinpr-registry0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwinpr-rpc0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwinpr-sspi0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwinpr-synch0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwinpr-sysinfo0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwinpr-thread0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwinpr-utils0.1",
+    "version": "1.1.0~git20140921.1.440916e+dfsg1-5ubuntu1.4"
+  },
+  {
+    "name": "libwmf0.2-7",
+    "version": "0.2.8.4-10.5ubuntu1"
+  },
+  {
+    "name": "libwmf0.2-7-gtk",
+    "version": "0.2.8.4-10.5ubuntu1"
+  },
+  {
+    "name": "libwnck-3-0",
+    "version": "3.14.1-2"
+  },
+  {
+    "name": "libwnck-3-common",
+    "version": "3.14.1-2"
+  },
+  {
+    "name": "libwpd-0.10-10",
+    "version": "0.10.1-1ubuntu1"
+  },
+  {
+    "name": "libwpg-0.3-3",
+    "version": "0.3.1-1ubuntu1"
+  },
+  {
+    "name": "libwps-0.4-4",
+    "version": "0.4.3-1ubuntu1"
+  },
+  {
+    "name": "libwrap0",
+    "version": "7.6.q-25"
+  },
+  {
+    "name": "libwww-perl",
+    "version": "6.15-1"
+  },
+  {
+    "name": "libx11-6",
+    "version": "2:1.6.3-1ubuntu2.1"
+  },
+  {
+    "name": "libx11-data",
+    "version": "2:1.6.3-1ubuntu2.1"
+  },
+  {
+    "name": "libx11-xcb1",
+    "version": "2:1.6.3-1ubuntu2.1"
+  },
+  {
+    "name": "libx86-1",
+    "version": "1.1+ds1-10"
+  },
+  {
+    "name": "libxapian22v5",
+    "version": "1.2.22-2"
+  },
+  {
+    "name": "libxatracker2",
+    "version": "18.0.5-0ubuntu0~16.04.1"
+  },
+  {
+    "name": "libxau6",
+    "version": "1:1.0.8-1"
+  },
+  {
+    "name": "libxcb-dri2-0",
+    "version": "1.11.1-1ubuntu1"
+  },
+  {
+    "name": "libxcb-dri3-0",
+    "version": "1.11.1-1ubuntu1"
+  },
+  {
+    "name": "libxcb-glx0",
+    "version": "1.11.1-1ubuntu1"
+  },
+  {
+    "name": "libxcb-present0",
+    "version": "1.11.1-1ubuntu1"
+  },
+  {
+    "name": "libxcb-randr0",
+    "version": "1.11.1-1ubuntu1"
+  },
+  {
+    "name": "libxcb-render0",
+    "version": "1.11.1-1ubuntu1"
+  },
+  {
+    "name": "libxcb-shape0",
+    "version": "1.11.1-1ubuntu1"
+  },
+  {
+    "name": "libxcb-shm0",
+    "version": "1.11.1-1ubuntu1"
+  },
+  {
+    "name": "libxcb-sync1",
+    "version": "1.11.1-1ubuntu1"
+  },
+  {
+    "name": "libxcb-xfixes0",
+    "version": "1.11.1-1ubuntu1"
+  },
+  {
+    "name": "libxcb-xkb1",
+    "version": "1.11.1-1ubuntu1"
+  },
+  {
+    "name": "libxcb1",
+    "version": "1.11.1-1ubuntu1"
+  },
+  {
+    "name": "libxcomposite1",
+    "version": "1:0.4.4-1"
+  },
+  {
+    "name": "libxcursor1",
+    "version": "1:1.1.14-1ubuntu0.16.04.2"
+  },
+  {
+    "name": "libxdamage1",
+    "version": "1:1.1.4-2"
+  },
+  {
+    "name": "libxdmcp6",
+    "version": "1:1.1.2-1.1"
+  },
+  {
+    "name": "libxfixes3",
+    "version": "1:5.0.1-2"
+  },
+  {
+    "name": "libxfont1",
+    "version": "1:1.5.1-1ubuntu0.16.04.4"
+  },
+  {
+    "name": "libxfont2",
+    "version": "1:2.0.1-3~ubuntu16.04.3"
+  },
+  {
+    "name": "libxi6",
+    "version": "2:1.7.6-1"
+  },
+  {
+    "name": "libxkbcommon-x11-0",
+    "version": "0.5.0-1ubuntu2.1"
+  },
+  {
+    "name": "libxkbcommon0",
+    "version": "0.5.0-1ubuntu2.1"
+  },
+  {
+    "name": "libxkbfile1",
+    "version": "1:1.0.9-0ubuntu1"
+  },
+  {
+    "name": "libxklavier16",
+    "version": "5.4-0ubuntu2"
+  },
+  {
+    "name": "libxml-parser-perl",
+    "version": "2.44-1build1"
+  },
+  {
+    "name": "libxml-twig-perl",
+    "version": "1:3.48-1"
+  },
+  {
+    "name": "libxml-xpathengine-perl",
+    "version": "0.13-1"
+  },
+  {
+    "name": "libxml2",
+    "version": "2.9.3+dfsg1-1ubuntu0.7"
+  },
+  {
+    "name": "libxpm4",
+    "version": "1:3.5.11-1ubuntu0.16.04.1"
+  },
+  {
+    "name": "libxrandr2",
+    "version": "2:1.5.0-1"
+  },
+  {
+    "name": "libxrender1",
+    "version": "1:0.9.9-0ubuntu1"
+  },
+  {
+    "name": "libxres1",
+    "version": "2:1.0.7-1"
+  },
+  {
+    "name": "libxshmfence1",
+    "version": "1.2-1"
+  },
+  {
+    "name": "libxslt1.1",
+    "version": "1.1.28-2.1ubuntu0.3"
+  },
+  {
+    "name": "libxt6",
+    "version": "1:1.1.5-0ubuntu1"
+  },
+  {
+    "name": "libxtables11",
+    "version": "1.6.0-2ubuntu3"
+  },
+  {
+    "name": "libxtst6",
+    "version": "2:1.2.2-1"
+  },
+  {
+    "name": "libxv1",
+    "version": "2:1.0.10-1"
+  },
+  {
+    "name": "libxvmc1",
+    "version": "2:1.0.9-1ubuntu1"
+  },
+  {
+    "name": "libyajl2",
+    "version": "2.1.0-2"
+  },
+  {
+    "name": "libyaml-0-2",
+    "version": "0.1.6-3"
+  },
+  {
+    "name": "libyaml-libyaml-perl",
+    "version": "0.41-6build1"
+  },
+  {
+    "name": "libyaml-tiny-perl",
+    "version": "1.69-1"
+  },
+  {
+    "name": "libyelp0",
+    "version": "3.18.1-1ubuntu4"
+  },
+  {
+    "name": "libzeitgeist-1.0-1",
+    "version": "0.3.18-1ubuntu3"
+  },
+  {
+    "name": "libzeitgeist-2.0-0",
+    "version": "0.9.16-0ubuntu4"
+  },
+  {
+    "name": "light-themes",
+    "version": "14.04+16.04.20180326-0ubuntu1"
+  },
+  {
+    "name": "lightdm",
+    "version": "1.18.3-0ubuntu1.1"
+  },
+  {
+    "name": "lintian",
+    "version": "2.5.43ubuntu0.1"
+  },
+  {
+    "name": "linux-base",
+    "version": "4.5ubuntu1.2~16.04.1"
+  },
+  {
+    "name": "linux-firmware",
+    "version": "1.157.23"
+  },
+  {
+    "name": "linux-generic-hwe-16.04",
+    "version": "4.15.0.112.114"
+  },
+  {
+    "name": "linux-headers-4.15.0-112",
+    "version": "4.15.0-112.113~16.04.1"
+  },
+  {
+    "name": "linux-headers-4.15.0-112-generic",
+    "version": "4.15.0-112.113~16.04.1"
+  },
+  {
+    "name": "linux-headers-generic-hwe-16.04",
+    "version": "4.15.0.112.114"
+  },
+  {
+    "name": "linux-image-4.15.0-112-generic",
+    "version": "4.15.0-112.113~16.04.1"
+  },
+  {
+    "name": "linux-image-generic-hwe-16.04",
+    "version": "4.15.0.112.114"
+  },
+  {
+    "name": "linux-libc-dev",
+    "version": "4.4.0-186.216"
+  },
+  {
+    "name": "linux-modules-4.15.0-112-generic",
+    "version": "4.15.0-112.113~16.04.1"
+  },
+  {
+    "name": "linux-modules-extra-4.15.0-112-generic",
+    "version": "4.15.0-112.113~16.04.1"
+  },
+  {
+    "name": "locales",
+    "version": "2.23-0ubuntu11.2"
+  },
+  {
+    "name": "login",
+    "version": "1:4.2-3.1ubuntu5.4"
+  },
+  {
+    "name": "logrotate",
+    "version": "3.8.7-2ubuntu2.16.04.2"
+  },
+  {
+    "name": "lp-solve",
+    "version": "5.5.0.13-7build2"
+  },
+  {
+    "name": "lsb-base",
+    "version": "9.20160110ubuntu0.2"
+  },
+  {
+    "name": "lsb-release",
+    "version": "9.20160110ubuntu0.2"
+  },
+  {
+    "name": "lshw",
+    "version": "02.17-1.1ubuntu3.6"
+  },
+  {
+    "name": "ltrace",
+    "version": "0.7.3-5.1ubuntu4"
+  },
+  {
+    "name": "lxml",
+    "version": "3.5.0"
+  },
+  {
+    "name": "make",
+    "version": "4.1-6"
+  },
+  {
+    "name": "makedev",
+    "version": "2.3.1-93ubuntu2~ubuntu16.04.1"
+  },
+  {
+    "name": "man-db",
+    "version": "2.7.5-1"
+  },
+  {
+    "name": "manpages",
+    "version": "4.04-2"
+  },
+  {
+    "name": "manpages-dev",
+    "version": "4.04-2"
+  },
+  {
+    "name": "mawk",
+    "version": "1.3.3-17ubuntu2"
+  },
+  {
+    "name": "media-player-info",
+    "version": "22-2"
+  },
+  {
+    "name": "metacity-common",
+    "version": "1:3.18.7-0ubuntu0.3"
+  },
+  {
+    "name": "mime-support",
+    "version": "3.59ubuntu1"
+  },
+  {
+    "name": "mlocate",
+    "version": "0.26-1ubuntu2"
+  },
+  {
+    "name": "mobile-broadband-provider-info",
+    "version": "20140317-1"
+  },
+  {
+    "name": "modemmanager",
+    "version": "1.6.4-1ubuntu0.16.04.1"
+  },
+  {
+    "name": "mount",
+    "version": "2.27.1-6ubuntu3.10"
+  },
+  {
+    "name": "mountall",
+    "version": "2.54ubuntu1"
+  },
+  {
+    "name": "mousetweaks",
+    "version": "3.12.0-1ubuntu2"
+  },
+  {
+    "name": "mscompress",
+    "version": "0.4-3"
+  },
+  {
+    "name": "mtools",
+    "version": "4.0.18-2ubuntu0.16.04"
+  },
+  {
+    "name": "mtr-tiny",
+    "version": "0.86-1ubuntu0.1"
+  },
+  {
+    "name": "multiarch-support",
+    "version": "2.23-0ubuntu11.2"
+  },
+  {
+    "name": "mythes-en-us",
+    "version": "1:5.1.0-1ubuntu2.2"
+  },
+  {
+    "name": "nano",
+    "version": "2.5.3-2ubuntu2"
+  },
+  {
+    "name": "nautilus",
+    "version": "1:3.18.4.is.3.14.3-0ubuntu6"
+  },
+  {
+    "name": "nautilus-data",
+    "version": "1:3.18.4.is.3.14.3-0ubuntu6"
+  },
+  {
+    "name": "nautilus-sendto",
+    "version": "3.8.2-1ubuntu1"
+  },
+  {
+    "name": "nautilus-share",
+    "version": "0.7.3-2ubuntu1"
+  },
+  {
+    "name": "ncurses-base",
+    "version": "6.0+20160213-1ubuntu1"
+  },
+  {
+    "name": "ncurses-bin",
+    "version": "6.0+20160213-1ubuntu1"
+  },
+  {
+    "name": "net-tools",
+    "version": "1.60-26ubuntu1"
+  },
+  {
+    "name": "netbase",
+    "version": "5.3"
+  },
+  {
+    "name": "netcat-openbsd",
+    "version": "1.105-7ubuntu1"
+  },
+  {
+    "name": "netpbm",
+    "version": "2:10.0-15.3"
+  },
+  {
+    "name": "network-manager",
+    "version": "1.2.6-0ubuntu0.16.04.3"
+  },
+  {
+    "name": "network-manager-gnome",
+    "version": "1.2.6-0ubuntu0.16.04.4"
+  },
+  {
+    "name": "network-manager-pptp",
+    "version": "1.1.93-1ubuntu1"
+  },
+  {
+    "name": "network-manager-pptp-gnome",
+    "version": "1.1.93-1ubuntu1"
+  },
+  {
+    "name": "notify-osd",
+    "version": "0.9.35+16.04.20160415-0ubuntu1"
+  },
+  {
+    "name": "notify-osd-icons",
+    "version": "0.8+15.10.20151016.2-0ubuntu1"
+  },
+  {
+    "name": "ntfs-3g",
+    "version": "1:2015.3.14AR.1-1ubuntu0.3"
+  },
+  {
+    "name": "nux-tools",
+    "version": "4.0.8+16.04.20180622.2-0ubuntu1"
+  },
+  {
+    "name": "oauthlib",
+    "version": "1.0.3"
+  },
+  {
+    "name": "onboard",
+    "version": "1.2.0-0ubuntu5"
+  },
+  {
+    "name": "onboard-data",
+    "version": "1.2.0-0ubuntu5"
+  },
+  {
+    "name": "openoffice.org-hyphenation",
+    "version": "0.9"
+  },
+  {
+    "name": "openprinting-ppds",
+    "version": "20160212-0ubuntu1"
+  },
+  {
+    "name": "openssh-client",
+    "version": "1:7.2p2-4ubuntu2.10"
+  },
+  {
+    "name": "openssl",
+    "version": "1.0.2g-1ubuntu4.16"
+  },
+  {
+    "name": "os-prober",
+    "version": "1.70ubuntu3.3"
+  },
+  {
+    "name": "overlay-scrollbar",
+    "version": "0.2.17.1+16.04.20151117-0ubuntu1.16.04.1"
+  },
+  {
+    "name": "overlay-scrollbar-gtk2",
+    "version": "0.2.17.1+16.04.20151117-0ubuntu1.16.04.1"
+  },
+  {
+    "name": "oxideqt-codecs",
+    "version": "1.21.5-0ubuntu0.16.04.1"
+  },
+  {
+    "name": "p11-kit",
+    "version": "0.23.2-5~ubuntu16.04.1"
+  },
+  {
+    "name": "p11-kit-modules",
+    "version": "0.23.2-5~ubuntu16.04.1"
+  },
+  {
+    "name": "padme",
+    "version": "1.1.1"
+  },
+  {
+    "name": "parted",
+    "version": "3.2-15ubuntu0.1"
+  },
+  {
+    "name": "passwd",
+    "version": "1:4.2-3.1ubuntu5.4"
+  },
+  {
+    "name": "patch",
+    "version": "2.7.5-1ubuntu0.16.04.2"
+  },
+  {
+    "name": "patchutils",
+    "version": "0.3.4-1"
+  },
+  {
+    "name": "pciutils",
+    "version": "1:3.3.1-1.1ubuntu1.3"
+  },
+  {
+    "name": "pcmciautils",
+    "version": "018-8"
+  },
+  {
+    "name": "perl",
+    "version": "5.22.1-9ubuntu0.6"
+  },
+  {
+    "name": "perl-base",
+    "version": "5.22.1-9ubuntu0.6"
+  },
+  {
+    "name": "perl-modules-5.22",
+    "version": "5.22.1-9ubuntu0.6"
+  },
+  {
+    "name": "pinentry-curses",
+    "version": "0.9.7-3"
+  },
+  {
+    "name": "pinentry-gnome3",
+    "version": "0.9.7-3"
+  },
+  {
+    "name": "pkg-config",
+    "version": "0.29.1-0ubuntu1"
+  },
+  {
+    "name": "plainbox",
+    "version": "0.25"
+  },
+  {
+    "name": "plainbox-provider-checkbox",
+    "version": "0.25-1"
+  },
+  {
+    "name": "plainbox-provider-resource-generic",
+    "version": "0.23-1"
+  },
+  {
+    "name": "plainbox-secure-policy",
+    "version": "0.25-1"
+  },
+  {
+    "name": "plymouth",
+    "version": "0.9.2-3ubuntu13.5"
+  },
+  {
+    "name": "plymouth-label",
+    "version": "0.9.2-3ubuntu13.5"
+  },
+  {
+    "name": "plymouth-theme-ubuntu-logo",
+    "version": "0.9.2-3ubuntu13.5"
+  },
+  {
+    "name": "plymouth-theme-ubuntu-text",
+    "version": "0.9.2-3ubuntu13.5"
+  },
+  {
+    "name": "pm-utils",
+    "version": "1.4.1-16"
+  },
+  {
+    "name": "policykit-1",
+    "version": "0.105-14.1ubuntu0.5"
+  },
+  {
+    "name": "policykit-1-gnome",
+    "version": "0.105-2ubuntu2"
+  },
+  {
+    "name": "policykit-desktop-privileges",
+    "version": "0.20ubuntu16.04.1"
+  },
+  {
+    "name": "poppler-data",
+    "version": "0.4.7-7"
+  },
+  {
+    "name": "poppler-utils",
+    "version": "0.41.0-0ubuntu1.14"
+  },
+  {
+    "name": "popularity-contest",
+    "version": "1.64ubuntu2"
+  },
+  {
+    "name": "powermgmt-base",
+    "version": "1.31+nmu1"
+  },
+  {
+    "name": "ppp",
+    "version": "2.4.7-1+2ubuntu1.16.04.3"
+  },
+  {
+    "name": "pppconfig",
+    "version": "2.3.22"
+  },
+  {
+    "name": "pptp-linux",
+    "version": "1.8.0-1"
+  },
+  {
+    "name": "printer-driver-brlaser",
+    "version": "3-5~ubuntu1"
+  },
+  {
+    "name": "printer-driver-c2esp",
+    "version": "27-2"
+  },
+  {
+    "name": "printer-driver-foo2zjs",
+    "version": "20151024dfsg0-1ubuntu1"
+  },
+  {
+    "name": "printer-driver-foo2zjs-common",
+    "version": "20151024dfsg0-1ubuntu1"
+  },
+  {
+    "name": "printer-driver-gutenprint",
+    "version": "5.2.11-1"
+  },
+  {
+    "name": "printer-driver-hpcups",
+    "version": "3.16.3+repack0-1"
+  },
+  {
+    "name": "printer-driver-min12xxw",
+    "version": "0.0.9-9"
+  },
+  {
+    "name": "printer-driver-pnm2ppa",
+    "version": "1.13+nondbs-0ubuntu5"
+  },
+  {
+    "name": "printer-driver-postscript-hp",
+    "version": "3.16.3+repack0-1"
+  },
+  {
+    "name": "printer-driver-ptouch",
+    "version": "1.4-1"
+  },
+  {
+    "name": "printer-driver-pxljr",
+    "version": "1.4+repack0-4"
+  },
+  {
+    "name": "printer-driver-sag-gdi",
+    "version": "0.1-4ubuntu1"
+  },
+  {
+    "name": "printer-driver-splix",
+    "version": "2.0.0+svn315-4fakesync1"
+  },
+  {
+    "name": "procps",
+    "version": "2:3.3.10-4ubuntu2.5"
+  },
+  {
+    "name": "psmisc",
+    "version": "22.21-2.1ubuntu0.1"
+  },
+  {
+    "name": "pulseaudio",
+    "version": "1:8.0-0ubuntu3.12"
+  },
+  {
+    "name": "pulseaudio-module-bluetooth",
+    "version": "1:8.0-0ubuntu3.12"
+  },
+  {
+    "name": "pulseaudio-module-x11",
+    "version": "1:8.0-0ubuntu3.12"
+  },
+  {
+    "name": "pulseaudio-utils",
+    "version": "1:8.0-0ubuntu3.12"
+  },
+  {
+    "name": "pyasn1",
+    "version": "0.1.9"
+  },
+  {
+    "name": "pyotherside",
+    "version": "1.4.0-2"
+  },
+  {
+    "name": "pyparsing",
+    "version": "2.0.3"
+  },
+  {
+    "name": "python",
+    "version": "2.7.12-1~16.04"
+  },
+  {
+    "name": "python-apt-common",
+    "version": "1.1.0~beta1ubuntu0.16.04.9"
+  },
+  {
+    "name": "python-debian",
+    "version": "0.1.27"
+  },
+  {
+    "name": "python-minimal",
+    "version": "2.7.12-1~16.04"
+  },
+  {
+    "name": "python-talloc",
+    "version": "2.1.5-2"
+  },
+  {
+    "name": "python2.7",
+    "version": "2.7.12-1ubuntu0~16.04.12"
+  },
+  {
+    "name": "python2.7-minimal",
+    "version": "2.7.12-1ubuntu0~16.04.12"
+  },
+  {
+    "name": "python3",
+    "version": "3.5.1-3"
+  },
+  {
+    "name": "python3-apport",
+    "version": "2.20.1-0ubuntu2.24"
+  },
+  {
+    "name": "python3-apt",
+    "version": "1.1.0~beta1ubuntu0.16.04.9"
+  },
+  {
+    "name": "python3-aptdaemon",
+    "version": "1.1.1+bzr982-0ubuntu14.3"
+  },
+  {
+    "name": "python3-aptdaemon.gtk3widgets",
+    "version": "1.1.1+bzr982-0ubuntu14.3"
+  },
+  {
+    "name": "python3-aptdaemon.pkcompat",
+    "version": "1.1.1+bzr982-0ubuntu14.3"
+  },
+  {
+    "name": "python3-blinker",
+    "version": "1.3.dfsg2-1build1"
+  },
+  {
+    "name": "python3-brlapi",
+    "version": "5.3.1-2ubuntu2.1"
+  },
+  {
+    "name": "python3-bs4",
+    "version": "4.4.1-1"
+  },
+  {
+    "name": "python3-cairo",
+    "version": "1.10.0+dfsg-5build1"
+  },
+  {
+    "name": "python3-cffi-backend",
+    "version": "1.5.2-1ubuntu1"
+  },
+  {
+    "name": "python3-chardet",
+    "version": "2.3.0-2"
+  },
+  {
+    "name": "python3-checkbox-support",
+    "version": "0.22-1"
+  },
+  {
+    "name": "python3-commandnotfound",
+    "version": "0.3ubuntu16.04.2"
+  },
+  {
+    "name": "python3-cryptography",
+    "version": "1.2.3-1ubuntu0.2"
+  },
+  {
+    "name": "python3-cups",
+    "version": "1.9.73-0ubuntu2"
+  },
+  {
+    "name": "python3-cupshelpers",
+    "version": "1.5.7+20160212-0ubuntu2"
+  },
+  {
+    "name": "python3-dbus",
+    "version": "1.2.0-3"
+  },
+  {
+    "name": "python3-debian",
+    "version": "0.1.27ubuntu2"
+  },
+  {
+    "name": "python3-distupgrade",
+    "version": "1:16.04.30"
+  },
+  {
+    "name": "python3-feedparser",
+    "version": "5.1.3-3build1"
+  },
+  {
+    "name": "python3-gdbm",
+    "version": "3.5.1-1"
+  },
+  {
+    "name": "python3-gi",
+    "version": "3.20.0-0ubuntu1"
+  },
+  {
+    "name": "python3-gi-cairo",
+    "version": "3.20.0-0ubuntu1"
+  },
+  {
+    "name": "python3-guacamole",
+    "version": "0.9.2-1"
+  },
+  {
+    "name": "python3-html5lib",
+    "version": "0.999-4"
+  },
+  {
+    "name": "python3-httplib2",
+    "version": "0.9.1+dfsg-1"
+  },
+  {
+    "name": "python3-idna",
+    "version": "2.0-3"
+  },
+  {
+    "name": "python3-jinja2",
+    "version": "2.8-1ubuntu0.1"
+  },
+  {
+    "name": "python3-jwt",
+    "version": "1.3.0-1ubuntu0.1"
+  },
+  {
+    "name": "python3-louis",
+    "version": "2.6.4-2ubuntu0.4"
+  },
+  {
+    "name": "python3-lxml",
+    "version": "3.5.0-1ubuntu0.1"
+  },
+  {
+    "name": "python3-mako",
+    "version": "1.0.3+ds1-1ubuntu1"
+  },
+  {
+    "name": "python3-markupsafe",
+    "version": "0.23-2build2"
+  },
+  {
+    "name": "python3-minimal",
+    "version": "3.5.1-3"
+  },
+  {
+    "name": "python3-oauthlib",
+    "version": "1.0.3-1"
+  },
+  {
+    "name": "python3-padme",
+    "version": "1.1.1-2"
+  },
+  {
+    "name": "python3-pexpect",
+    "version": "4.0.1-1"
+  },
+  {
+    "name": "python3-pil",
+    "version": "3.1.2-0ubuntu1.4"
+  },
+  {
+    "name": "python3-pkg-resources",
+    "version": "20.7.0-1"
+  },
+  {
+    "name": "python3-plainbox",
+    "version": "0.25-1"
+  },
+  {
+    "name": "python3-problem-report",
+    "version": "2.20.1-0ubuntu2.24"
+  },
+  {
+    "name": "python3-ptyprocess",
+    "version": "0.5-1"
+  },
+  {
+    "name": "python3-pyasn1",
+    "version": "0.1.9-1"
+  },
+  {
+    "name": "python3-pyatspi",
+    "version": "2.18.0+dfsg-3"
+  },
+  {
+    "name": "python3-pycurl",
+    "version": "7.43.0-1ubuntu1"
+  },
+  {
+    "name": "python3-pyparsing",
+    "version": "2.0.3+dfsg1-1ubuntu0.1"
+  },
+  {
+    "name": "python3-renderpm",
+    "version": "3.3.0-1ubuntu0.1"
+  },
+  {
+    "name": "python3-reportlab",
+    "version": "3.3.0-1ubuntu0.1"
+  },
+  {
+    "name": "python3-reportlab-accel",
+    "version": "3.3.0-1ubuntu0.1"
+  },
+  {
+    "name": "python3-requests",
+    "version": "2.9.1-3ubuntu0.1"
+  },
+  {
+    "name": "python3-six",
+    "version": "1.10.0-3"
+  },
+  {
+    "name": "python3-software-properties",
+    "version": "0.96.20.9"
+  },
+  {
+    "name": "python3-speechd",
+    "version": "0.8.3-1ubuntu3"
+  },
+  {
+    "name": "python3-systemd",
+    "version": "231-2build1"
+  },
+  {
+    "name": "python3-uno",
+    "version": "1:5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "python3-update-manager",
+    "version": "1:16.04.17"
+  },
+  {
+    "name": "python3-urllib3",
+    "version": "1.13.1-2ubuntu0.16.04.3"
+  },
+  {
+    "name": "python3-xdg",
+    "version": "0.25-4"
+  },
+  {
+    "name": "python3-xlsxwriter",
+    "version": "0.7.3-1"
+  },
+  {
+    "name": "python3.5",
+    "version": "3.5.2-2ubuntu0~16.04.11"
+  },
+  {
+    "name": "python3.5-minimal",
+    "version": "3.5.2-2ubuntu0~16.04.11"
+  },
+  {
+    "name": "qdbus",
+    "version": "4:4.8.7+dfsg-5ubuntu2"
+  },
+  {
+    "name": "qml-module-io-thp-pyotherside",
+    "version": "1.4.0-2"
+  },
+  {
+    "name": "qml-module-qt-labs-folderlistmodel",
+    "version": "5.5.1-2ubuntu6"
+  },
+  {
+    "name": "qml-module-qt-labs-settings",
+    "version": "5.5.1-2ubuntu6"
+  },
+  {
+    "name": "qml-module-qtfeedback",
+    "version": "5.0~git20130529-0ubuntu13"
+  },
+  {
+    "name": "qml-module-qtgraphicaleffects",
+    "version": "5.5.1-1ubuntu1"
+  },
+  {
+    "name": "qml-module-qtquick-layouts",
+    "version": "5.5.1-1ubuntu1"
+  },
+  {
+    "name": "qml-module-qtquick-window2",
+    "version": "5.5.1-2ubuntu6"
+  },
+  {
+    "name": "qml-module-qtquick2",
+    "version": "5.5.1-2ubuntu6"
+  },
+  {
+    "name": "qml-module-qttest",
+    "version": "5.5.1-2ubuntu6"
+  },
+  {
+    "name": "qml-module-ubuntu-components",
+    "version": "1.3.1918+16.04.20160404-0ubuntu1"
+  },
+  {
+    "name": "qml-module-ubuntu-layouts",
+    "version": "1.3.1918+16.04.20160404-0ubuntu1"
+  },
+  {
+    "name": "qml-module-ubuntu-onlineaccounts",
+    "version": "0.6+16.04.20151106-0ubuntu1"
+  },
+  {
+    "name": "qml-module-ubuntu-performancemetrics",
+    "version": "1.3.1918+16.04.20160404-0ubuntu1"
+  },
+  {
+    "name": "qml-module-ubuntu-test",
+    "version": "1.3.1918+16.04.20160404-0ubuntu1"
+  },
+  {
+    "name": "qml-module-ubuntu-web",
+    "version": "0.23+16.04.20161028-0ubuntu2"
+  },
+  {
+    "name": "qmlscene",
+    "version": "5.5.1-2ubuntu6"
+  },
+  {
+    "name": "qpdf",
+    "version": "8.0.2-3~16.04.1"
+  },
+  {
+    "name": "qt-at-spi",
+    "version": "0.4.0-3"
+  },
+  {
+    "name": "qtchooser",
+    "version": "52-gae5eeef-2build1~gcc5.2"
+  },
+  {
+    "name": "qtcore4-l10n",
+    "version": "4:4.8.7+dfsg-5ubuntu2"
+  },
+  {
+    "name": "qtdeclarative5-accounts-plugin",
+    "version": "0.6+16.04.20151106-0ubuntu1"
+  },
+  {
+    "name": "qtdeclarative5-dev-tools",
+    "version": "5.5.1-2ubuntu6"
+  },
+  {
+    "name": "qtdeclarative5-qtquick2-plugin",
+    "version": "5.5.1-2ubuntu6"
+  },
+  {
+    "name": "qtdeclarative5-test-plugin",
+    "version": "5.5.1-2ubuntu6"
+  },
+  {
+    "name": "qtdeclarative5-ubuntu-ui-toolkit-plugin",
+    "version": "1.3.1918+16.04.20160404-0ubuntu1"
+  },
+  {
+    "name": "qtdeclarative5-unity-action-plugin",
+    "version": "1.1.0+14.04.20140304-0ubuntu2~gcc5.1"
+  },
+  {
+    "name": "qttranslations5-l10n",
+    "version": "5.5.1-2build1"
+  },
+  {
+    "name": "readline-common",
+    "version": "6.3-8ubuntu2"
+  },
+  {
+    "name": "remmina",
+    "version": "1.1.2-3ubuntu1"
+  },
+  {
+    "name": "remmina-common",
+    "version": "1.1.2-3ubuntu1"
+  },
+  {
+    "name": "remmina-plugin-rdp",
+    "version": "1.1.2-3ubuntu1"
+  },
+  {
+    "name": "remmina-plugin-vnc",
+    "version": "1.1.2-3ubuntu1"
+  },
+  {
+    "name": "rename",
+    "version": "0.20-4"
+  },
+  {
+    "name": "requests",
+    "version": "2.9.1"
+  },
+  {
+    "name": "resolvconf",
+    "version": "1.78ubuntu7"
+  },
+  {
+    "name": "rfkill",
+    "version": "0.5-1ubuntu3.1"
+  },
+  {
+    "name": "rhythmbox",
+    "version": "3.3-1ubuntu7"
+  },
+  {
+    "name": "rhythmbox-data",
+    "version": "3.3-1ubuntu7"
+  },
+  {
+    "name": "rhythmbox-plugin-zeitgeist",
+    "version": "3.3-1ubuntu7"
+  },
+  {
+    "name": "rhythmbox-plugins",
+    "version": "3.3-1ubuntu7"
+  },
+  {
+    "name": "rsync",
+    "version": "3.1.1-3ubuntu1.3"
+  },
+  {
+    "name": "rsyslog",
+    "version": "8.16.0-1ubuntu3.1"
+  },
+  {
+    "name": "rtkit",
+    "version": "0.11-4"
+  },
+  {
+    "name": "samba-libs",
+    "version": "2:4.3.11+dfsg-0ubuntu0.16.04.28"
+  },
+  {
+    "name": "sane-utils",
+    "version": "1.0.25+git20150528-1ubuntu2.16.04.1"
+  },
+  {
+    "name": "sbsigntool",
+    "version": "0.6-0ubuntu10.1"
+  },
+  {
+    "name": "seahorse",
+    "version": "3.18.0-2ubuntu1"
+  },
+  {
+    "name": "secureboot-db",
+    "version": "1.4~ubuntu0.16.04.1"
+  },
+  {
+    "name": "sed",
+    "version": "4.2.2-7"
+  },
+  {
+    "name": "sensible-utils",
+    "version": "0.0.9ubuntu0.16.04.1"
+  },
+  {
+    "name": "session-migration",
+    "version": "0.2.3"
+  },
+  {
+    "name": "session-shortcuts",
+    "version": "1.2ubuntu0.16.04.1"
+  },
+  {
+    "name": "sessioninstaller",
+    "version": "0.20+bzr150-0ubuntu4.1"
+  },
+  {
+    "name": "sgml-base",
+    "version": "1.26+nmu4ubuntu1"
+  },
+  {
+    "name": "shared-mime-info",
+    "version": "1.5-2ubuntu0.2"
+  },
+  {
+    "name": "shotwell",
+    "version": "0.22.0+git20160108.r1.f2fb1f7-0ubuntu1.1"
+  },
+  {
+    "name": "shotwell-common",
+    "version": "0.22.0+git20160108.r1.f2fb1f7-0ubuntu1.1"
+  },
+  {
+    "name": "signon-keyring-extension",
+    "version": "0.6+14.10.20140513-0ubuntu2"
+  },
+  {
+    "name": "signon-plugin-oauth2",
+    "version": "0.23+16.04.20151209-0ubuntu1"
+  },
+  {
+    "name": "signon-plugin-password",
+    "version": "8.58+16.04.20151106-0ubuntu1"
+  },
+  {
+    "name": "signon-ui",
+    "version": "0.17+16.04.20151125-0ubuntu1"
+  },
+  {
+    "name": "signon-ui-service",
+    "version": "0.17+16.04.20151125-0ubuntu1"
+  },
+  {
+    "name": "signon-ui-x11",
+    "version": "0.17+16.04.20151125-0ubuntu1"
+  },
+  {
+    "name": "signond",
+    "version": "8.58+16.04.20151106-0ubuntu1"
+  },
+  {
+    "name": "simple-scan",
+    "version": "3.20.0-0ubuntu1"
+  },
+  {
+    "name": "six",
+    "version": "1.10.0"
+  },
+  {
+    "name": "snapd",
+    "version": "2.45.1ubuntu0.2"
+  },
+  {
+    "name": "sni-qt",
+    "version": "0.2.7+16.04.20170217.1-0ubuntu1"
+  },
+  {
+    "name": "software-properties-common",
+    "version": "0.96.20.9"
+  },
+  {
+    "name": "software-properties-gtk",
+    "version": "0.96.20.9"
+  },
+  {
+    "name": "sound-theme-freedesktop",
+    "version": "0.8-1"
+  },
+  {
+    "name": "speech-dispatcher",
+    "version": "0.8.3-1ubuntu3"
+  },
+  {
+    "name": "speech-dispatcher-audio-plugins",
+    "version": "0.8.3-1ubuntu3"
+  },
+  {
+    "name": "squashfs-tools",
+    "version": "1:4.3-3ubuntu2.16.04.3"
+  },
+  {
+    "name": "ssl-cert",
+    "version": "1.0.37"
+  },
+  {
+    "name": "strace",
+    "version": "4.11-1ubuntu3"
+  },
+  {
+    "name": "sudo",
+    "version": "1.8.16-0ubuntu1.9"
+  },
+  {
+    "name": "suru-icon-theme",
+    "version": "14.04+16.04.20180326-0ubuntu1"
+  },
+  {
+    "name": "syslinux",
+    "version": "3:6.03+dfsg-11ubuntu1"
+  },
+  {
+    "name": "syslinux-common",
+    "version": "3:6.03+dfsg-11ubuntu1"
+  },
+  {
+    "name": "syslinux-legacy",
+    "version": "2:3.63+dfsg-2ubuntu8"
+  },
+  {
+    "name": "system-config-printer-common",
+    "version": "1.5.7+20160212-0ubuntu2"
+  },
+  {
+    "name": "system-config-printer-gnome",
+    "version": "1.5.7+20160212-0ubuntu2"
+  },
+  {
+    "name": "system-config-printer-udev",
+    "version": "1.5.7+20160212-0ubuntu2"
+  },
+  {
+    "name": "systemd",
+    "version": "229-4ubuntu21.28"
+  },
+  {
+    "name": "systemd-sysv",
+    "version": "229-4ubuntu21.28"
+  },
+  {
+    "name": "sysv-rc",
+    "version": "2.88dsf-59.3ubuntu2"
+  },
+  {
+    "name": "sysvinit-utils",
+    "version": "2.88dsf-59.3ubuntu2"
+  },
+  {
+    "name": "t1utils",
+    "version": "1.39-2"
+  },
+  {
+    "name": "tar",
+    "version": "1.28-2.1ubuntu0.1"
+  },
+  {
+    "name": "tcl",
+    "version": "8.6.0+9"
+  },
+  {
+    "name": "tcl8.6",
+    "version": "8.6.5+dfsg-2"
+  },
+  {
+    "name": "tcpd",
+    "version": "7.6.q-25"
+  },
+  {
+    "name": "tcpdump",
+    "version": "4.9.3-0ubuntu0.16.04.1"
+  },
+  {
+    "name": "telnet",
+    "version": "0.17-40"
+  },
+  {
+    "name": "thermald",
+    "version": "1.5-2ubuntu4"
+  },
+  {
+    "name": "thunderbird",
+    "version": "1:68.10.0+build1-0ubuntu0.16.04.1"
+  },
+  {
+    "name": "thunderbird-gnome-support",
+    "version": "1:68.10.0+build1-0ubuntu0.16.04.1"
+  },
+  {
+    "name": "thunderbird-locale-en",
+    "version": "1:68.10.0+build1-0ubuntu0.16.04.1"
+  },
+  {
+    "name": "thunderbird-locale-en-us",
+    "version": "1:68.10.0+build1-0ubuntu0.16.04.1"
+  },
+  {
+    "name": "time",
+    "version": "1.7-25.1"
+  },
+  {
+    "name": "tk",
+    "version": "8.6.0+9"
+  },
+  {
+    "name": "tk8.6",
+    "version": "8.6.5-1"
+  },
+  {
+    "name": "toshset",
+    "version": "1.76-4"
+  },
+  {
+    "name": "totem",
+    "version": "3.18.1-1ubuntu4"
+  },
+  {
+    "name": "totem-common",
+    "version": "3.18.1-1ubuntu4"
+  },
+  {
+    "name": "totem-plugins",
+    "version": "3.18.1-1ubuntu4"
+  },
+  {
+    "name": "transmission-common",
+    "version": "2.84-3ubuntu3.1"
+  },
+  {
+    "name": "transmission-gtk",
+    "version": "2.84-3ubuntu3.1"
+  },
+  {
+    "name": "ttf-ancient-fonts-symbola",
+    "version": "2.59-1"
+  },
+  {
+    "name": "ttf-ubuntu-font-family",
+    "version": "1:0.83-0ubuntu2"
+  },
+  {
+    "name": "tzdata",
+    "version": "2020a-0ubuntu0.16.04"
+  },
+  {
+    "name": "ubuntu-advantage-tools",
+    "version": "10ubuntu0.16.04.1"
+  },
+  {
+    "name": "ubuntu-artwork",
+    "version": "1:14.04+16.04.20180326-0ubuntu1"
+  },
+  {
+    "name": "ubuntu-core-launcher",
+    "version": "2.45.1ubuntu0.2"
+  },
+  {
+    "name": "ubuntu-desktop",
+    "version": "1.361.4"
+  },
+  {
+    "name": "ubuntu-docs",
+    "version": "16.04.4"
+  },
+  {
+    "name": "ubuntu-drivers-common",
+    "version": "1:0.4.17.7"
+  },
+  {
+    "name": "ubuntu-keyring",
+    "version": "2012.05.19.1"
+  },
+  {
+    "name": "ubuntu-minimal",
+    "version": "1.361.4"
+  },
+  {
+    "name": "ubuntu-mobile-icons",
+    "version": "14.04+16.04.20180326-0ubuntu1"
+  },
+  {
+    "name": "ubuntu-mono",
+    "version": "14.04+16.04.20180326-0ubuntu1"
+  },
+  {
+    "name": "ubuntu-release-upgrader-core",
+    "version": "1:16.04.30"
+  },
+  {
+    "name": "ubuntu-release-upgrader-gtk",
+    "version": "1:16.04.30"
+  },
+  {
+    "name": "ubuntu-session",
+    "version": "3.18.1.2-1ubuntu1.16.04.2"
+  },
+  {
+    "name": "ubuntu-settings",
+    "version": "15.10.8"
+  },
+  {
+    "name": "ubuntu-software",
+    "version": "3.20.5-0ubuntu0.16.04.13"
+  },
+  {
+    "name": "ubuntu-standard",
+    "version": "1.361.4"
+  },
+  {
+    "name": "ubuntu-system-service",
+    "version": "0.3"
+  },
+  {
+    "name": "ubuntu-touch-sounds",
+    "version": "15.08"
+  },
+  {
+    "name": "ubuntu-ui-toolkit-theme",
+    "version": "1.3.1918+16.04.20160404-0ubuntu1"
+  },
+  {
+    "name": "ubuntu-wallpapers",
+    "version": "16.04.1-0ubuntu1"
+  },
+  {
+    "name": "ubuntu-wallpapers-xenial",
+    "version": "16.04.1-0ubuntu1"
+  },
+  {
+    "name": "ucf",
+    "version": "3.0036"
+  },
+  {
+    "name": "udev",
+    "version": "229-4ubuntu21.28"
+  },
+  {
+    "name": "udisks2",
+    "version": "2.1.7-1ubuntu1"
+  },
+  {
+    "name": "ufw",
+    "version": "0.35-0ubuntu2"
+  },
+  {
+    "name": "unattended-upgrades",
+    "version": "1.1ubuntu1.18.04.7~16.04.6"
+  },
+  {
+    "name": "unity",
+    "version": "7.4.5+16.04.20190312-0ubuntu1"
+  },
+  {
+    "name": "unity-accessibility-profiles",
+    "version": "0.1.10-0ubuntu3"
+  },
+  {
+    "name": "unity-asset-pool",
+    "version": "0.8.24+15.04.20141217-0ubuntu2"
+  },
+  {
+    "name": "unity-control-center",
+    "version": "15.04.0+16.04.20171130-0ubuntu1"
+  },
+  {
+    "name": "unity-control-center-faces",
+    "version": "15.04.0+16.04.20171130-0ubuntu1"
+  },
+  {
+    "name": "unity-control-center-signon",
+    "version": "0.1.8+16.04.20160201-0ubuntu1"
+  },
+  {
+    "name": "unity-greeter",
+    "version": "16.04.2-0ubuntu1"
+  },
+  {
+    "name": "unity-gtk-module-common",
+    "version": "0.0.0+15.04.20150118-0ubuntu2"
+  },
+  {
+    "name": "unity-gtk2-module",
+    "version": "0.0.0+15.04.20150118-0ubuntu2"
+  },
+  {
+    "name": "unity-gtk3-module",
+    "version": "0.0.0+15.04.20150118-0ubuntu2"
+  },
+  {
+    "name": "unity-lens-applications",
+    "version": "7.1.0+16.04.20160701-0ubuntu1"
+  },
+  {
+    "name": "unity-lens-files",
+    "version": "7.1.0+16.04.20151217-0ubuntu1"
+  },
+  {
+    "name": "unity-lens-music",
+    "version": "6.9.1+16.04-0ubuntu1"
+  },
+  {
+    "name": "unity-lens-photos",
+    "version": "1.0+14.04.20140318-0ubuntu1"
+  },
+  {
+    "name": "unity-lens-video",
+    "version": "0.3.15+16.04.20160212.1-0ubuntu1"
+  },
+  {
+    "name": "unity-schemas",
+    "version": "7.4.5+16.04.20190312-0ubuntu1"
+  },
+  {
+    "name": "unity-scope-calculator",
+    "version": "0.1+14.04.20140328-0ubuntu1"
+  },
+  {
+    "name": "unity-scope-chromiumbookmarks",
+    "version": "0.1+13.10.20130723-0ubuntu1"
+  },
+  {
+    "name": "unity-scope-colourlovers",
+    "version": "0.1+13.10.20130723-0ubuntu1"
+  },
+  {
+    "name": "unity-scope-devhelp",
+    "version": "0.1+14.04.20140328-0ubuntu1"
+  },
+  {
+    "name": "unity-scope-firefoxbookmarks",
+    "version": "0.1+13.10.20130809.1-0ubuntu1"
+  },
+  {
+    "name": "unity-scope-gdrive",
+    "version": "0.9+16.04.20151125-0ubuntu1"
+  },
+  {
+    "name": "unity-scope-home",
+    "version": "6.8.2+16.04.20160212.1-0ubuntu1"
+  },
+  {
+    "name": "unity-scope-manpages",
+    "version": "3.0+14.04.20140324-0ubuntu1"
+  },
+  {
+    "name": "unity-scope-openclipart",
+    "version": "0.1+13.10.20130723-0ubuntu1"
+  },
+  {
+    "name": "unity-scope-texdoc",
+    "version": "0.1+14.04.20140328-0ubuntu1"
+  },
+  {
+    "name": "unity-scope-tomboy",
+    "version": "0.1+13.10.20130723-0ubuntu1"
+  },
+  {
+    "name": "unity-scope-video-remote",
+    "version": "0.3.15+16.04.20160212.1-0ubuntu1"
+  },
+  {
+    "name": "unity-scope-virtualbox",
+    "version": "0.1+13.10.20130723-0ubuntu1"
+  },
+  {
+    "name": "unity-scope-yelp",
+    "version": "0.1+13.10.20130723-0ubuntu1"
+  },
+  {
+    "name": "unity-scope-zotero",
+    "version": "0.1+13.10.20130723-0ubuntu1"
+  },
+  {
+    "name": "unity-scopes-master-default",
+    "version": "6.8.2+16.04.20160212.1-0ubuntu1"
+  },
+  {
+    "name": "unity-scopes-runner",
+    "version": "7.1.4+16.04.20180209.1-0ubuntu1"
+  },
+  {
+    "name": "unity-services",
+    "version": "7.4.5+16.04.20190312-0ubuntu1"
+  },
+  {
+    "name": "unity-settings-daemon",
+    "version": "15.04.1+16.04.20160701-0ubuntu3"
+  },
+  {
+    "name": "unity-webapps-common",
+    "version": "2.4.17+15.10.20150616-0ubuntu2"
+  },
+  {
+    "name": "unity-webapps-qml",
+    "version": "0.1+16.04.20160114-0ubuntu1"
+  },
+  {
+    "name": "unity-webapps-service",
+    "version": "2.5.0~+16.04.20160201-0ubuntu1"
+  },
+  {
+    "name": "uno-libs3",
+    "version": "5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "unzip",
+    "version": "6.0-20ubuntu1"
+  },
+  {
+    "name": "update-inetd",
+    "version": "4.43"
+  },
+  {
+    "name": "update-manager",
+    "version": "1:16.04.17"
+  },
+  {
+    "name": "update-manager-core",
+    "version": "1:16.04.17"
+  },
+  {
+    "name": "update-notifier",
+    "version": "3.168.10"
+  },
+  {
+    "name": "update-notifier-common",
+    "version": "3.168.10"
+  },
+  {
+    "name": "upower",
+    "version": "0.99.4-2ubuntu0.3"
+  },
+  {
+    "name": "upstart",
+    "version": "1.13.2-0ubuntu21.1"
+  },
+  {
+    "name": "ure",
+    "version": "5.1.6~rc2-0ubuntu1~xenial10"
+  },
+  {
+    "name": "ureadahead",
+    "version": "0.100.0-19.1"
+  },
+  {
+    "name": "urllib3",
+    "version": "1.13.1"
+  },
+  {
+    "name": "usb-creator-common",
+    "version": "0.3.2ubuntu16.04.2"
+  },
+  {
+    "name": "usb-creator-gtk",
+    "version": "0.3.2ubuntu16.04.2"
+  },
+  {
+    "name": "usb-modeswitch",
+    "version": "2.2.5+repack0-1ubuntu1"
+  },
+  {
+    "name": "usb-modeswitch-data",
+    "version": "20151101-1"
+  },
+  {
+    "name": "usbmuxd",
+    "version": "1.1.0-2"
+  },
+  {
+    "name": "usbutils",
+    "version": "1:007-4"
+  },
+  {
+    "name": "util-linux",
+    "version": "2.27.1-6ubuntu3.10"
+  },
+  {
+    "name": "uuid-runtime",
+    "version": "2.27.1-6ubuntu3.10"
+  },
+  {
+    "name": "vbetool",
+    "version": "1.1-3"
+  },
+  {
+    "name": "vim-common",
+    "version": "2:7.4.1689-3ubuntu1.4"
+  },
+  {
+    "name": "vim-tiny",
+    "version": "2:7.4.1689-3ubuntu1.4"
+  },
+  {
+    "name": "vino",
+    "version": "3.8.1-0ubuntu9.2"
+  },
+  {
+    "name": "wamerican",
+    "version": "7.1-1"
+  },
+  {
+    "name": "wbritish",
+    "version": "7.1-1"
+  },
+  {
+    "name": "webapp-container",
+    "version": "0.23+16.04.20161028-0ubuntu2"
+  },
+  {
+    "name": "webbrowser-app",
+    "version": "0.23+16.04.20161028-0ubuntu2"
+  },
+  {
+    "name": "wget",
+    "version": "1.17.1-1ubuntu1.5"
+  },
+  {
+    "name": "whiptail",
+    "version": "0.52.18-1ubuntu2"
+  },
+  {
+    "name": "whoopsie",
+    "version": "0.2.52.5ubuntu0.5"
+  },
+  {
+    "name": "whoopsie-preferences",
+    "version": "0.18"
+  },
+  {
+    "name": "wireless-regdb",
+    "version": "2018.05.09-0ubuntu1~16.04.1"
+  },
+  {
+    "name": "wireless-tools",
+    "version": "30~pre9-8ubuntu1"
+  },
+  {
+    "name": "wpasupplicant",
+    "version": "2.4-0ubuntu6.6"
+  },
+  {
+    "name": "x11-apps",
+    "version": "7.7+5+nmu1ubuntu1"
+  },
+  {
+    "name": "x11-common",
+    "version": "1:7.7+13ubuntu3.1"
+  },
+  {
+    "name": "x11-session-utils",
+    "version": "7.7+2"
+  },
+  {
+    "name": "x11-utils",
+    "version": "7.7+3"
+  },
+  {
+    "name": "x11-xkb-utils",
+    "version": "7.7+2"
+  },
+  {
+    "name": "x11-xserver-utils",
+    "version": "7.7+7"
+  },
+  {
+    "name": "xauth",
+    "version": "1:1.0.9-1ubuntu2"
+  },
+  {
+    "name": "xbrlapi",
+    "version": "5.3.1-2ubuntu2.1"
+  },
+  {
+    "name": "xdg-desktop-portal",
+    "version": "1.0.3-0ubuntu0.0"
+  },
+  {
+    "name": "xdg-desktop-portal-gtk",
+    "version": "1.0.2-0ubuntu0.0"
+  },
+  {
+    "name": "xdg-user-dirs",
+    "version": "0.15-2ubuntu6.16.04.1"
+  },
+  {
+    "name": "xdg-user-dirs-gtk",
+    "version": "0.10-1ubuntu1"
+  },
+  {
+    "name": "xdg-utils",
+    "version": "1.1.1-1ubuntu1.16.04.3"
+  },
+  {
+    "name": "xdiagnose",
+    "version": "3.8.4.1"
+  },
+  {
+    "name": "xfonts-utils",
+    "version": "1:7.7+3ubuntu0.16.04.2"
+  },
+  {
+    "name": "xinit",
+    "version": "1.3.4-3ubuntu0.1"
+  },
+  {
+    "name": "xinput",
+    "version": "1.6.2-1"
+  },
+  {
+    "name": "xkb-data",
+    "version": "2.16-1ubuntu1"
+  },
+  {
+    "name": "xml-core",
+    "version": "0.13+nmu2"
+  },
+  {
+    "name": "xorg",
+    "version": "1:7.7+13ubuntu3.1"
+  },
+  {
+    "name": "xorg-docs-core",
+    "version": "1:1.7.1-1ubuntu1"
+  },
+  {
+    "name": "xserver-common",
+    "version": "2:1.18.4-0ubuntu0.8"
+  },
+  {
+    "name": "xserver-xorg-core-hwe-16.04",
+    "version": "2:1.19.6-1ubuntu4.1~16.04.2"
+  },
+  {
+    "name": "xserver-xorg-hwe-16.04",
+    "version": "1:7.7+16ubuntu3~16.04.1"
+  },
+  {
+    "name": "xserver-xorg-input-all-hwe-16.04",
+    "version": "1:7.7+16ubuntu3~16.04.1"
+  },
+  {
+    "name": "xserver-xorg-input-evdev-hwe-16.04",
+    "version": "1:2.10.5-1ubuntu1~16.04.1"
+  },
+  {
+    "name": "xserver-xorg-input-synaptics-hwe-16.04",
+    "version": "1.9.0-1ubuntu1~16.04.1"
+  },
+  {
+    "name": "xserver-xorg-input-wacom-hwe-16.04",
+    "version": "1:0.34.0-0ubuntu2~16.04.1"
+  },
+  {
+    "name": "xserver-xorg-legacy-hwe-16.04",
+    "version": "2:1.19.6-1ubuntu4.1~16.04.2"
+  },
+  {
+    "name": "xserver-xorg-video-all-hwe-16.04",
+    "version": "1:7.7+16ubuntu3~16.04.1"
+  },
+  {
+    "name": "xserver-xorg-video-amdgpu-hwe-16.04",
+    "version": "18.0.1-1~16.04.1"
+  },
+  {
+    "name": "xserver-xorg-video-ati-hwe-16.04",
+    "version": "1:18.0.1-1~16.04.1"
+  },
+  {
+    "name": "xserver-xorg-video-fbdev-hwe-16.04",
+    "version": "1:0.4.4-1build6~16.04.1"
+  },
+  {
+    "name": "xserver-xorg-video-intel-hwe-16.04",
+    "version": "2:2.99.917+git20171229-1~16.04.1"
+  },
+  {
+    "name": "xserver-xorg-video-nouveau-hwe-16.04",
+    "version": "1:1.0.15-2~16.04.1"
+  },
+  {
+    "name": "xserver-xorg-video-qxl-hwe-16.04",
+    "version": "0.1.5-2build1~16.04.1"
+  },
+  {
+    "name": "xserver-xorg-video-radeon-hwe-16.04",
+    "version": "1:18.0.1-1~16.04.1"
+  },
+  {
+    "name": "xserver-xorg-video-vesa-hwe-16.04",
+    "version": "1:2.3.4-1build3~16.04.1"
+  },
+  {
+    "name": "xserver-xorg-video-vmware-hwe-16.04",
+    "version": "1:13.2.1-1build1~16.04.1"
+  },
+  {
+    "name": "xterm",
+    "version": "322-1ubuntu1"
+  },
+  {
+    "name": "xul-ext-ubufox",
+    "version": "3.4-0ubuntu0.16.04.2"
+  },
+  {
+    "name": "xz-utils",
+    "version": "5.1.1alpha+20120614-2ubuntu2"
+  },
+  {
+    "name": "yelp",
+    "version": "3.18.1-1ubuntu4"
+  },
+  {
+    "name": "yelp-xsl",
+    "version": "3.18.1-1"
+  },
+  {
+    "name": "zeitgeist-core",
+    "version": "0.9.16-0ubuntu4"
+  },
+  {
+    "name": "zeitgeist-datahub",
+    "version": "0.9.16-0ubuntu4"
+  },
+  {
+    "name": "zenity",
+    "version": "3.18.1.1-1ubuntu2"
+  },
+  {
+    "name": "zenity-common",
+    "version": "3.18.1.1-1ubuntu2"
+  },
+  {
+    "name": "zip",
+    "version": "3.0-11"
+  },
+  {
+    "name": "zlib1g",
+    "version": "1:1.2.8.dfsg-2ubuntu4.3"
+  }
+]

--- a/cmd/osquery-perf/ubuntu_18.04.tmpl
+++ b/cmd/osquery-perf/ubuntu_18.04.tmpl
@@ -1,0 +1,364 @@
+{{ define "enroll" -}}
+{
+    "enroll_secret": "{{ .EnrollSecret  }}",
+    "host_details": {
+        "os_version": {
+            "build": "",
+            "major": "",
+            "minor": "",
+            "name": "",
+            "patch": "",
+            "platform": "ubuntu",
+            "platform_like": "ubuntu",
+            "version": "Ubuntu 18.4.0"
+        },
+        "osquery_info": {
+            "build_distro": "18.04",
+            "build_platform": "linux",
+            "config_hash": "",
+            "config_valid": "0",
+            "extensions": "inactive",
+            "instance_id": "{{ .UUID }}",
+            "pid": "12947",
+            "platform_mask": "21",
+            "start_time": "1580931224",
+            "uuid": "{{ .UUID }}",
+            "version": "4.6.0",
+            "watcher": "12946"
+        },
+        "platform_info": {
+            "address": "0xff990000",
+            "date": "12/16/2019 ",
+            "extra": "MBP114; 196.0.0.0.0; root@xapp160; Mon Dec 16 15:55:18 PST 2019; 196 (B&I); F000_B00; Official Build, Release; Apple LLVM version 5.0 (clang-500.0.68) (based on LLVM 3.3svn)",
+            "revision": "196 (B&I)",
+            "size": "8388608",
+            "vendor": "Apple Inc. ",
+            "version": "196.0.0.0.0 ",
+            "volume_size": "1507328"
+        },
+        "system_info": {
+            "computer_name": "{{ .CachedString "hostname" }}",
+            "cpu_brand": "Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+            "cpu_logical_cores": "8",
+            "cpu_physical_cores": "4",
+            "cpu_subtype": "Intel x86-64h Haswell",
+            "cpu_type": "x86_64h",
+            "hardware_model": "MacBookPro11,4",
+            "hardware_serial": "D02R835DG8WK",
+            "hardware_vendor": "Apple Inc.",
+            "hardware_version": "1.0",
+            "hostname": "{{ .CachedString "hostname" }}",
+            "local_hostname": "{{ .CachedString "hostname" }}",
+            "physical_memory": "17179869184",
+            "uuid": "{{ .UUID }}"
+        }
+    },
+    "host_identifier": "{{ .CachedString "hostname" }}",
+    "platform_type": "16"
+}
+{{- end }}
+
+{{ define "fleet_detail_query_network_interface" -}}
+[
+  {
+    "point_to_point":"",
+    "address":"fe80::8cb:112d:ff51:1e5d%en0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"en0",
+    "mac":"f8:2d:88:93:56:5c",
+    "type":"6",
+    "mtu":"1500",
+    "metric":"0",
+    "ipackets":"278493",
+    "opackets":"206238",
+    "ibytes":"275799040",
+    "obytes":"37720064",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582848084"
+  },
+  {
+    "point_to_point":"",
+    "address":"192.168.1.3",
+    "mask":"255.255.255.0",
+    "broadcast":"192.168.1.255",
+    "interface":"en0",
+    "mac":"f5:5a:80:92:52:5b",
+    "type":"6",
+    "mtu":"1500",
+    "metric":"0",
+    "ipackets":"278493",
+    "opackets":"206238",
+    "ibytes":"275799040",
+    "obytes":"37720064",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582848084"
+  },
+  {
+    "point_to_point":"127.0.0.1",
+    "address":"127.0.0.1",
+    "mask":"255.0.0.0",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"::1",
+    "address":"::1",
+    "mask":"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::1%lo0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::3a:84ff:fe6b:bf75%awdl0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"awdl0",
+    "mac":"03:3b:94:5b:be:75",
+    "type":"6",
+    "mtu":"1484",
+    "metric":"0",
+    "ipackets":"0",
+    "opackets":"16",
+    "ibytes":"0",
+    "obytes":"3072",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582842892"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::6eaf:9721:3476:b691%utun0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"utun0",
+    "mac":"00:00:00:00:00:00",
+    "type":"1",
+    "mtu":"2000",
+    "metric":"0",
+    "ipackets":"0",
+    "opackets":"2",
+    "ibytes":"0",
+    "obytes":"0",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840897"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_os_version" -}}
+[
+  {
+    "name":"Ubuntu 18.4.0",
+    "version":"Ubuntu 18.4.0",
+    "major":"",
+    "minor":"",
+    "patch":"",
+    "build":"",
+    "platform":"ubuntu",
+    "platform_like":"ubuntu",
+    "codename":""
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_flags" -}}
+[
+  {
+    "name":"config_refresh",
+    "value":"{{ printf "%.0f" .ConfigInterval.Seconds }}"
+  },
+  {
+    "name":"distributed_interval",
+    "value":"{{ printf "%.0f" .QueryInterval.Seconds }}"
+  },
+  {
+    "name":"logger_tls_period",
+    "value":"99999"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_info" -}}
+[
+  {
+    "pid":"11287",
+    "uuid":"{{ .UUID }}",
+    "instance_id":"{{ .UUID }}",
+    "version":"4.1.2",
+    "config_hash":"b01efbf375ac6767f259ae98751154fef727ce35",
+    "config_valid":"1",
+    "extensions":"inactive",
+    "build_platform":"ubuntu",
+    "build_distro":"Ubuntu 18.4.0",
+    "start_time":"1582857555",
+    "watcher":"11286",
+    "platform_mask":"21"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_system_info" -}}
+[
+  {
+    "hostname":"{{ .CachedString "hostname" }}",
+    "uuid":"4740D59F-699E-5B29-960B-979AAF9BBEEB",
+    "cpu_type":"x86_64h",
+    "cpu_subtype":"Intel x86-64h Haswell",
+    "cpu_brand":"Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz",
+    "cpu_physical_cores":"4",
+    "cpu_logical_cores":"8",
+    "cpu_microcode":"",
+    "physical_memory":"17179869184",
+    "hardware_vendor":"Apple Inc.",
+    "hardware_model":"MacBookPro11,4",
+    "hardware_version":"1.0",
+    "hardware_serial":"C02R262BM8LN",
+    "computer_name":"{{ .CachedString "hostname" }}",
+    "local_hostname":"{{ .CachedString "hostname" }}"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_uptime" -}}
+[
+  {
+    "days":"0",
+    "hours":"4",
+    "minutes":"38",
+    "seconds":"11",
+    "total_seconds":"16691"
+  }
+]
+{{- end }}
+
+{{ define "fleet_detail_query_users" -}}
+[
+  {{ range $index, $item := .HostUsersMacOS }}
+  {{if $index}},{{end}}
+  {
+    "uid": "{{ .Uid }}",
+    "username": "{{ .Username }}",
+    "type": "{{ .Type }}",
+    "groupname": "{{ .GroupName }}",
+    "shell": "{{ .Shell }}"
+  }
+  {{- end }}
+]
+{{- end }}
+
+{{/* all hosts */}}
+{{ define "fleet_label_query_6" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All macOS hosts */}}
+{{ define "fleet_label_query_7" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All Ubuntu hosts */}}
+{{ define "fleet_label_query_8" -}}
+[]
+{{- end }}
+
+{{/* All CentOS hosts */}}
+{{ define "fleet_label_query_9" -}}
+[]
+{{- end }}
+
+{{/* All Windows hosts */}}
+{{ define "fleet_label_query_10" -}}
+[]
+{{- end }}
+
+{{/* All Red Hat hosts */}}
+{{ define "fleet_label_query_11" -}}
+[]
+{{- end }}
+
+{{/* All Linux distributions */}}
+{{ define "fleet_label_query_12" -}}
+[]
+{{- end }}
+
+{{ define "fleet_detail_query_software_linux" -}}
+[
+  {{ range $index, $item := .SoftwareUbuntu1804 }}
+  {{if $index}},{{end}}
+  {
+    "name": "{{ .Name }}",
+    "version": "{{ .Version }}",
+    "type": "Application",
+    "bundle_identifier": "{{ .BundleIdentifier }}",
+    "source": "apps",
+    {{/* Note that in Go < 1.18, `{{ or (and .LastOpendedAt .LastOpenedAt.Unix) "" }}` won't work as expected because "and" and "or" don't short circuit. This was changed in Go 1.18 */}}
+    {{if .LastOpenedAt}}
+    "last_opened_at": "{{ .LastOpenedAt.Unix }}"
+    {{else}}
+    "last_opened_at": "-1"
+    {{end}}
+  }
+  {{- end }}
+]
+{{- end }}

--- a/cmd/osquery-perf/ubuntu_1804-vulnerable_software.json
+++ b/cmd/osquery-perf/ubuntu_1804-vulnerable_software.json
@@ -1,0 +1,6214 @@
+[
+  {
+    "name": "defer",
+    "version": "1.0.6"
+  },
+  {
+    "name": "dmz-cursor-theme",
+    "version": "0.4.5ubuntu1"
+  },
+  {
+    "name": "grub-gfxpayload-lists",
+    "version": "0.7"
+  },
+  {
+    "name": "hicolor-icon-theme",
+    "version": "0.17-2"
+  },
+  {
+    "name": "language-selector",
+    "version": "0.1"
+  },
+  {
+    "name": "laptop-detect",
+    "version": "0.16"
+  },
+  {
+    "name": "libnet-smtp-ssl-perl",
+    "version": "1.04-1"
+  },
+  {
+    "name": "libxml-xpathengine-perl",
+    "version": "0.14-1"
+  },
+  {
+    "name": "pymacaroons",
+    "version": "0.13.0"
+  },
+  {
+    "name": "sound-theme-freedesktop",
+    "version": "0.8-2ubuntu1"
+  },
+  {
+    "name": "ubuntu-drivers-common",
+    "version": "0.0.0"
+  },
+  {
+    "name": "unattended-upgrades",
+    "version": "0.1"
+  },
+  {
+    "name": "osquery",
+    "version": "5.2.3-1.linux"
+  },
+  {
+    "name": "humanity-icon-theme",
+    "version": "0.6.15"
+  },
+  {
+    "name": "libjbig0",
+    "version": "2.1-3.1build1"
+  },
+  {
+    "name": "libjpeg8",
+    "version": "8c-2ubuntu8"
+  },
+  {
+    "name": "libtry-tiny-perl",
+    "version": "0.30-1"
+  },
+  {
+    "name": "libxpm4",
+    "version": "1:3.5.12-1"
+  },
+  {
+    "name": "libxv1",
+    "version": "2:1.0.11-1"
+  },
+  {
+    "name": "ubuntu-advantage-tools",
+    "version": "27.2"
+  },
+  {
+    "name": "Amazon.com",
+    "version": "1.3"
+  },
+  {
+    "name": "Bing",
+    "version": "1.3"
+  },
+  {
+    "name": "DoH Roll-Out",
+    "version": "2.0.0"
+  },
+  {
+    "name": "DuckDuckGo",
+    "version": "1.1"
+  },
+  {
+    "name": "Google",
+    "version": "1.1"
+  },
+  {
+    "name": "Proxy Failover",
+    "version": "1.0.1"
+  },
+  {
+    "name": "Wikipedia (en)",
+    "version": "1.1"
+  },
+  {
+    "name": "apg",
+    "version": "2.2.3.dfsg.1-5"
+  },
+  {
+    "name": "gnome-accessibility-themes",
+    "version": "3.28-1ubuntu1"
+  },
+  {
+    "name": "gnome-themes-extra",
+    "version": "3.28-1ubuntu1"
+  },
+  {
+    "name": "gnome-themes-extra-data",
+    "version": "3.28-1ubuntu1"
+  },
+  {
+    "name": "gsettings-ubuntu-schemas",
+    "version": "0.0.7+17.10.20170922-0ubuntu1"
+  },
+  {
+    "name": "iucode-tool",
+    "version": "2.3.1-1"
+  },
+  {
+    "name": "libao-common",
+    "version": "1.2.2+20180113-1ubuntu1"
+  },
+  {
+    "name": "libao4",
+    "version": "1.2.2+20180113-1ubuntu1"
+  },
+  {
+    "name": "libasyncns0",
+    "version": "0.8-6"
+  },
+  {
+    "name": "libdotconf0",
+    "version": "1.3-0.3fakesync1"
+  },
+  {
+    "name": "libxcb-image0",
+    "version": "0.4.0-1build1"
+  },
+  {
+    "name": "nautilus-share",
+    "version": "0.7.3-2ubuntu3"
+  },
+  {
+    "name": "printer-driver-pxljr",
+    "version": "1.4+repack0-5"
+  },
+  {
+    "name": "xfonts-utils",
+    "version": "1:7.7+6"
+  },
+  {
+    "name": "xul-ext-ubufox",
+    "version": "3.4-0ubuntu1.17.10.1"
+  },
+  {
+    "name": "Dark",
+    "version": "1.2"
+  },
+  {
+    "name": "Firefox Alpenglow",
+    "version": "1.4"
+  },
+  {
+    "name": "Firefox Screenshots",
+    "version": "39.0.1"
+  },
+  {
+    "name": "Form Autofill",
+    "version": "1.0.1"
+  },
+  {
+    "name": "Light",
+    "version": "1.2"
+  },
+  {
+    "name": "Picture-In-Picture",
+    "version": "1.0.0"
+  },
+  {
+    "name": "SecretStorage",
+    "version": "2.3.1"
+  },
+  {
+    "name": "WebCompat Reporter",
+    "version": "1.4.2"
+  },
+  {
+    "name": "alsa-base",
+    "version": "1.0.25+dfsg-0ubuntu5"
+  },
+  {
+    "name": "chardet",
+    "version": "3.0.4"
+  },
+  {
+    "name": "crda",
+    "version": "3.18-1build1"
+  },
+  {
+    "name": "fonts-beng",
+    "version": "2:1.2"
+  },
+  {
+    "name": "fonts-dejavu-core",
+    "version": "2.37-1"
+  },
+  {
+    "name": "fonts-deva",
+    "version": "2:1.2"
+  },
+  {
+    "name": "fonts-droid-fallback",
+    "version": "1:6.0.1r16-1.1"
+  },
+  {
+    "name": "fonts-gargi",
+    "version": "2.0-4"
+  },
+  {
+    "name": "fonts-gubbi",
+    "version": "1.3-3"
+  },
+  {
+    "name": "fonts-guru",
+    "version": "2:1.2"
+  },
+  {
+    "name": "fonts-kacst",
+    "version": "2.01+mry-14"
+  },
+  {
+    "name": "fonts-khmeros-core",
+    "version": "5.0-7ubuntu1"
+  },
+  {
+    "name": "fonts-knda",
+    "version": "2:1.2"
+  },
+  {
+    "name": "fonts-lao",
+    "version": "0.0.20060226-9ubuntu1"
+  },
+  {
+    "name": "fonts-lklug-sinhala",
+    "version": "0.6-3"
+  },
+  {
+    "name": "fonts-lohit-beng-assamese",
+    "version": "2.91.5-1"
+  },
+  {
+    "name": "fonts-lohit-beng-bengali",
+    "version": "2.91.5-1"
+  },
+  {
+    "name": "fonts-lohit-guru",
+    "version": "2.91.2-1"
+  },
+  {
+    "name": "fonts-lohit-mlym",
+    "version": "2.92.2-1"
+  },
+  {
+    "name": "fonts-lohit-orya",
+    "version": "2.91.2-1"
+  },
+  {
+    "name": "fonts-lohit-taml",
+    "version": "2.91.3-1"
+  },
+  {
+    "name": "fonts-lohit-taml-classical",
+    "version": "2.5.4-1"
+  },
+  {
+    "name": "fonts-lohit-telu",
+    "version": "2.5.5-1"
+  },
+  {
+    "name": "fonts-mlym",
+    "version": "2:1.2"
+  },
+  {
+    "name": "fonts-nakula",
+    "version": "1.0-3"
+  },
+  {
+    "name": "fonts-navilu",
+    "version": "1.2-2"
+  },
+  {
+    "name": "fonts-orya",
+    "version": "2:1.2"
+  },
+  {
+    "name": "fonts-pagul",
+    "version": "1.0-7"
+  },
+  {
+    "name": "fonts-sahadeva",
+    "version": "1.0-4"
+  },
+  {
+    "name": "fonts-samyak-deva",
+    "version": "1.2.2-4"
+  },
+  {
+    "name": "fonts-samyak-gujr",
+    "version": "1.2.2-4"
+  },
+  {
+    "name": "fonts-samyak-mlym",
+    "version": "1.2.2-4"
+  },
+  {
+    "name": "fonts-samyak-taml",
+    "version": "1.2.2-4"
+  },
+  {
+    "name": "fonts-sarai",
+    "version": "1.0-2"
+  },
+  {
+    "name": "fonts-taml",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-telu",
+    "version": "2:1.2"
+  },
+  {
+    "name": "fonts-telu-extra",
+    "version": "2.0-4"
+  },
+  {
+    "name": "fonts-tibetan-machine",
+    "version": "1.901b-5"
+  },
+  {
+    "name": "kerneloops",
+    "version": "0.12+git20140509-6ubuntu2"
+  },
+  {
+    "name": "lazr.uri",
+    "version": "1.0.3"
+  },
+  {
+    "name": "libauthen-sasl-perl",
+    "version": "2.1600-1"
+  },
+  {
+    "name": "libcdparanoia0",
+    "version": "3.10.2+debian-13"
+  },
+  {
+    "name": "libdata-dump-perl",
+    "version": "1.23-1"
+  },
+  {
+    "name": "libencode-locale-perl",
+    "version": "1.05-1"
+  },
+  {
+    "name": "libestr0",
+    "version": "0.1.10-2.1"
+  },
+  {
+    "name": "libfastjson4",
+    "version": "0.99.8-2"
+  },
+  {
+    "name": "libfile-desktopentry-perl",
+    "version": "0.22-1"
+  },
+  {
+    "name": "libfile-listing-perl",
+    "version": "6.04-1"
+  },
+  {
+    "name": "libfont-afm-perl",
+    "version": "1.20-2"
+  },
+  {
+    "name": "libgpm2",
+    "version": "1.20.7-5"
+  },
+  {
+    "name": "libhtml-format-perl",
+    "version": "2.12-1"
+  },
+  {
+    "name": "libio-html-perl",
+    "version": "1.001-1"
+  },
+  {
+    "name": "libksba8",
+    "version": "1.3.5-2"
+  },
+  {
+    "name": "libmnl0",
+    "version": "1.0.4-2"
+  },
+  {
+    "name": "libmpc3",
+    "version": "1.1.0-1"
+  },
+  {
+    "name": "libraw1394-11",
+    "version": "2.1.2-1"
+  },
+  {
+    "name": "libtie-ixhash-perl",
+    "version": "1.23-2"
+  },
+  {
+    "name": "libx11-protocol-perl",
+    "version": "0.56-7"
+  },
+  {
+    "name": "libxaw7",
+    "version": "2:1.0.13-1"
+  },
+  {
+    "name": "libxcb-util1",
+    "version": "0.4.0-0ubuntu3"
+  },
+  {
+    "name": "libxfont2",
+    "version": "1:2.0.3-1"
+  },
+  {
+    "name": "libxrender1",
+    "version": "1:0.9.10-1"
+  },
+  {
+    "name": "libxshmfence1",
+    "version": "1.3-1"
+  },
+  {
+    "name": "libxt6",
+    "version": "1:1.1.5-1"
+  },
+  {
+    "name": "libxtst6",
+    "version": "2:1.2.3-1"
+  },
+  {
+    "name": "linux-sound-base",
+    "version": "1.0.25+dfsg-0ubuntu5"
+  },
+  {
+    "name": "netifaces",
+    "version": "0.10.4"
+  },
+  {
+    "name": "printer-driver-pnm2ppa",
+    "version": "1.13+nondbs-0ubuntu6"
+  },
+  {
+    "name": "printer-driver-ptouch",
+    "version": "1.4.2-3"
+  },
+  {
+    "name": "ssl-cert",
+    "version": "1.0.39"
+  },
+  {
+    "name": "time",
+    "version": "1.7-25.1build1"
+  },
+  {
+    "name": "xbitmaps",
+    "version": "1.1.1-2"
+  },
+  {
+    "name": "xfonts-scalable",
+    "version": "1:1.0.3-1.1"
+  },
+  {
+    "name": "xorg-docs-core",
+    "version": "1:1.7.1-1.1"
+  },
+  {
+    "name": "zip",
+    "version": "3.0-11build1"
+  },
+  {
+    "name": "Add-ons Search Detection",
+    "version": "1.0.1"
+  },
+  {
+    "name": "English (CA) Language Pack",
+    "version": "92.0buildid20210903235534"
+  },
+  {
+    "name": "English (GB) Language Pack",
+    "version": "92.0buildid20210903235534"
+  },
+  {
+    "name": "Mako",
+    "version": "1.0.7"
+  },
+  {
+    "name": "MarkupSafe",
+    "version": "1.0"
+  },
+  {
+    "name": "Pillow",
+    "version": "5.1.0"
+  },
+  {
+    "name": "PyNaCl",
+    "version": "1.1.2"
+  },
+  {
+    "name": "System theme",
+    "version": "1.2"
+  },
+  {
+    "name": "Web Compatibility Interventions",
+    "version": "25.4.0"
+  },
+  {
+    "name": "accountsservice",
+    "version": "0.6.45-1ubuntu1.3"
+  },
+  {
+    "name": "acl",
+    "version": "2.2.52-3build1"
+  },
+  {
+    "name": "acpi-support",
+    "version": "0.142"
+  },
+  {
+    "name": "acpid",
+    "version": "1:2.0.28-1ubuntu1"
+  },
+  {
+    "name": "adduser",
+    "version": "3.116ubuntu1"
+  },
+  {
+    "name": "adium-theme-ubuntu",
+    "version": "0.3.4-0ubuntu4"
+  },
+  {
+    "name": "adwaita-icon-theme",
+    "version": "3.28.0-1ubuntu1"
+  },
+  {
+    "name": "alsa-utils",
+    "version": "1.1.3-1ubuntu1"
+  },
+  {
+    "name": "amd64-microcode",
+    "version": "3.20191021.1+really3.20181128.1~ubuntu0.18.04.1"
+  },
+  {
+    "name": "anacron",
+    "version": "2.3-24"
+  },
+  {
+    "name": "app-install-data-partner",
+    "version": "16.04"
+  },
+  {
+    "name": "apparmor",
+    "version": "2.12-4ubuntu5.1"
+  },
+  {
+    "name": "apport",
+    "version": "2.20.9-0ubuntu7.26"
+  },
+  {
+    "name": "apport-gtk",
+    "version": "2.20.9-0ubuntu7.26"
+  },
+  {
+    "name": "apport-symptoms",
+    "version": "0.20"
+  },
+  {
+    "name": "appstream",
+    "version": "0.12.0-3ubuntu1"
+  },
+  {
+    "name": "apt",
+    "version": "1.6.14"
+  },
+  {
+    "name": "apt-config-icons",
+    "version": "0.12.0-3ubuntu1"
+  },
+  {
+    "name": "apt-utils",
+    "version": "1.6.14"
+  },
+  {
+    "name": "aptdaemon",
+    "version": "1.1.1+bzr982-0ubuntu19.5"
+  },
+  {
+    "name": "aptdaemon-data",
+    "version": "1.1.1+bzr982-0ubuntu19.5"
+  },
+  {
+    "name": "apturl",
+    "version": "0.5.2ubuntu14.2"
+  },
+  {
+    "name": "apturl-common",
+    "version": "0.5.2ubuntu14.2"
+  },
+  {
+    "name": "asn1crypto",
+    "version": "0.24.0"
+  },
+  {
+    "name": "aspell",
+    "version": "0.60.7~20110707-4ubuntu0.2"
+  },
+  {
+    "name": "aspell-en",
+    "version": "2017.08.24-0-0.1"
+  },
+  {
+    "name": "at-spi2-core",
+    "version": "2.28.0-1"
+  },
+  {
+    "name": "avahi-autoipd",
+    "version": "0.7-3.1ubuntu1.3"
+  },
+  {
+    "name": "avahi-daemon",
+    "version": "0.7-3.1ubuntu1.3"
+  },
+  {
+    "name": "avahi-utils",
+    "version": "0.7-3.1ubuntu1.3"
+  },
+  {
+    "name": "base-files",
+    "version": "10.1ubuntu2.11"
+  },
+  {
+    "name": "base-passwd",
+    "version": "3.5.44"
+  },
+  {
+    "name": "bash",
+    "version": "4.4.18-2ubuntu1.2"
+  },
+  {
+    "name": "bash-completion",
+    "version": "1:2.8-1ubuntu1"
+  },
+  {
+    "name": "bc",
+    "version": "1.07.1-2"
+  },
+  {
+    "name": "bind9-host",
+    "version": "1:9.11.3+dfsg-1ubuntu1.15"
+  },
+  {
+    "name": "binutils",
+    "version": "2.30-21ubuntu1~18.04.5"
+  },
+  {
+    "name": "binutils-common",
+    "version": "2.30-21ubuntu1~18.04.5"
+  },
+  {
+    "name": "binutils-x86-64-linux-gnu",
+    "version": "2.30-21ubuntu1~18.04.5"
+  },
+  {
+    "name": "bluez",
+    "version": "5.48-0ubuntu3.5"
+  },
+  {
+    "name": "bluez-cups",
+    "version": "5.48-0ubuntu3.5"
+  },
+  {
+    "name": "bluez-obexd",
+    "version": "5.48-0ubuntu3.5"
+  },
+  {
+    "name": "bolt",
+    "version": "0.5-0ubuntu0.18.04.1"
+  },
+  {
+    "name": "brltty",
+    "version": "5.5-4ubuntu2.0.1"
+  },
+  {
+    "name": "bsdmainutils",
+    "version": "11.1.2ubuntu1"
+  },
+  {
+    "name": "bsdutils",
+    "version": "1:2.31.1-0.4ubuntu3.7"
+  },
+  {
+    "name": "bubblewrap",
+    "version": "0.2.1-1ubuntu0.1"
+  },
+  {
+    "name": "busybox-initramfs",
+    "version": "1:1.27.2-2ubuntu3.3"
+  },
+  {
+    "name": "busybox-static",
+    "version": "1:1.27.2-2ubuntu3.3"
+  },
+  {
+    "name": "bzip2",
+    "version": "1.0.6-8.1ubuntu0.2"
+  },
+  {
+    "name": "ca-certificates",
+    "version": "20210119~18.04.1"
+  },
+  {
+    "name": "certifi",
+    "version": "2018.1.18"
+  },
+  {
+    "name": "cheese-common",
+    "version": "3.28.0-1ubuntu1"
+  },
+  {
+    "name": "click",
+    "version": "6.7"
+  },
+  {
+    "name": "colorama",
+    "version": "0.3.7"
+  },
+  {
+    "name": "colord",
+    "version": "1.3.3-2build1"
+  },
+  {
+    "name": "colord-data",
+    "version": "1.3.3-2build1"
+  },
+  {
+    "name": "command-not-found",
+    "version": "18.04.5"
+  },
+  {
+    "name": "command-not-found-data",
+    "version": "18.04.5"
+  },
+  {
+    "name": "console-setup",
+    "version": "1.178ubuntu2.9"
+  },
+  {
+    "name": "console-setup-linux",
+    "version": "1.178ubuntu2.9"
+  },
+  {
+    "name": "coreutils",
+    "version": "8.28-1ubuntu1"
+  },
+  {
+    "name": "cpio",
+    "version": "2.12+dfsg-6ubuntu0.18.04.4"
+  },
+  {
+    "name": "cpp",
+    "version": "4:7.4.0-1ubuntu2.3"
+  },
+  {
+    "name": "cpp-7",
+    "version": "7.5.0-3ubuntu1~18.04"
+  },
+  {
+    "name": "cracklib-runtime",
+    "version": "2.9.2-5build1"
+  },
+  {
+    "name": "cron",
+    "version": "3.0pl1-128.1ubuntu1"
+  },
+  {
+    "name": "cryptography",
+    "version": "2.1.4"
+  },
+  {
+    "name": "cups",
+    "version": "2.2.7-1ubuntu2.8"
+  },
+  {
+    "name": "cups-browsed",
+    "version": "1.20.2-0ubuntu3.1"
+  },
+  {
+    "name": "cups-bsd",
+    "version": "2.2.7-1ubuntu2.8"
+  },
+  {
+    "name": "cups-client",
+    "version": "2.2.7-1ubuntu2.8"
+  },
+  {
+    "name": "cups-common",
+    "version": "2.2.7-1ubuntu2.8"
+  },
+  {
+    "name": "cups-core-drivers",
+    "version": "2.2.7-1ubuntu2.8"
+  },
+  {
+    "name": "cups-daemon",
+    "version": "2.2.7-1ubuntu2.8"
+  },
+  {
+    "name": "cups-filters",
+    "version": "1.20.2-0ubuntu3.1"
+  },
+  {
+    "name": "cups-filters-core-drivers",
+    "version": "1.20.2-0ubuntu3.1"
+  },
+  {
+    "name": "cups-ipp-utils",
+    "version": "2.2.7-1ubuntu2.8"
+  },
+  {
+    "name": "cups-pk-helper",
+    "version": "0.2.6-1ubuntu1.2"
+  },
+  {
+    "name": "cups-ppdc",
+    "version": "2.2.7-1ubuntu2.8"
+  },
+  {
+    "name": "cups-server-common",
+    "version": "2.2.7-1ubuntu2.8"
+  },
+  {
+    "name": "dash",
+    "version": "0.5.8-2.10"
+  },
+  {
+    "name": "dbus",
+    "version": "1.12.2-1ubuntu1.2"
+  },
+  {
+    "name": "dbus-user-session",
+    "version": "1.12.2-1ubuntu1.2"
+  },
+  {
+    "name": "dbus-x11",
+    "version": "1.12.2-1ubuntu1.2"
+  },
+  {
+    "name": "dc",
+    "version": "1.07.1-2"
+  },
+  {
+    "name": "dconf-cli",
+    "version": "0.26.0-2ubuntu3"
+  },
+  {
+    "name": "dconf-gsettings-backend",
+    "version": "0.26.0-2ubuntu3"
+  },
+  {
+    "name": "dconf-service",
+    "version": "0.26.0-2ubuntu3"
+  },
+  {
+    "name": "debconf",
+    "version": "1.5.66ubuntu1"
+  },
+  {
+    "name": "debconf-i18n",
+    "version": "1.5.66ubuntu1"
+  },
+  {
+    "name": "debianutils",
+    "version": "4.8.4"
+  },
+  {
+    "name": "desktop-file-utils",
+    "version": "0.23-1ubuntu3.18.04.2"
+  },
+  {
+    "name": "dictionaries-common",
+    "version": "1.27.2"
+  },
+  {
+    "name": "diffstat",
+    "version": "1.61-1build1"
+  },
+  {
+    "name": "diffutils",
+    "version": "1:3.6-1"
+  },
+  {
+    "name": "dirmngr",
+    "version": "2.2.4-1ubuntu1.4"
+  },
+  {
+    "name": "distro-info",
+    "version": "0.18ubuntu0.18.04.1"
+  },
+  {
+    "name": "distro-info",
+    "version": "0.18ubuntu0.18.04.1"
+  },
+  {
+    "name": "distro-info-data",
+    "version": "0.37ubuntu0.11"
+  },
+  {
+    "name": "dmidecode",
+    "version": "3.1-1ubuntu0.1"
+  },
+  {
+    "name": "dmsetup",
+    "version": "2:1.02.145-4.1ubuntu3.18.04.3"
+  },
+  {
+    "name": "dns-root-data",
+    "version": "2018013001"
+  },
+  {
+    "name": "dnsmasq-base",
+    "version": "2.79-1ubuntu0.4"
+  },
+  {
+    "name": "dnsutils",
+    "version": "1:9.11.3+dfsg-1ubuntu1.15"
+  },
+  {
+    "name": "dosfstools",
+    "version": "4.1-1"
+  },
+  {
+    "name": "dpkg",
+    "version": "1.19.0.5ubuntu2.3"
+  },
+  {
+    "name": "e2fsprogs",
+    "version": "1.44.1-1ubuntu1.3"
+  },
+  {
+    "name": "ed",
+    "version": "1.10-2.1"
+  },
+  {
+    "name": "efibootmgr",
+    "version": "15-1"
+  },
+  {
+    "name": "eject",
+    "version": "2.1.5+deb1+cvs20081104-13.2"
+  },
+  {
+    "name": "emacsen-common",
+    "version": "2.0.8"
+  },
+  {
+    "name": "enchant",
+    "version": "1.6.0-11.1"
+  },
+  {
+    "name": "eog",
+    "version": "3.28.1-1"
+  },
+  {
+    "name": "espeak-ng-data",
+    "version": "1.49.2+dfsg-1"
+  },
+  {
+    "name": "evince",
+    "version": "3.28.4-0ubuntu1.2"
+  },
+  {
+    "name": "evince-common",
+    "version": "3.28.4-0ubuntu1.2"
+  },
+  {
+    "name": "evolution-data-server",
+    "version": "3.28.5-0ubuntu0.18.04.3"
+  },
+  {
+    "name": "evolution-data-server-common",
+    "version": "3.28.5-0ubuntu0.18.04.3"
+  },
+  {
+    "name": "fdisk",
+    "version": "2.31.1-0.4ubuntu3.7"
+  },
+  {
+    "name": "file",
+    "version": "1:5.32-2ubuntu0.4"
+  },
+  {
+    "name": "file-roller",
+    "version": "3.28.0-1ubuntu1.3"
+  },
+  {
+    "name": "findutils",
+    "version": "4.6.0+git+20170828-2"
+  },
+  {
+    "name": "firefox",
+    "version": "92.0+build3-0ubuntu0.18.04.1"
+  },
+  {
+    "name": "firefox-locale-en",
+    "version": "92.0+build3-0ubuntu0.18.04.1"
+  },
+  {
+    "name": "fontconfig",
+    "version": "2.12.6-0ubuntu2"
+  },
+  {
+    "name": "fontconfig-config",
+    "version": "2.12.6-0ubuntu2"
+  },
+  {
+    "name": "fonts-beng-extra",
+    "version": "1.0-6ubuntu0.1"
+  },
+  {
+    "name": "fonts-deva-extra",
+    "version": "3.0-4ubuntu0.1"
+  },
+  {
+    "name": "fonts-freefont-ttf",
+    "version": "20120503-7"
+  },
+  {
+    "name": "fonts-gujr",
+    "version": "2:1.2"
+  },
+  {
+    "name": "fonts-gujr-extra",
+    "version": "1.0-6ubuntu0.1"
+  },
+  {
+    "name": "fonts-guru-extra",
+    "version": "2.0-4ubuntu0.1"
+  },
+  {
+    "name": "fonts-indic",
+    "version": "2:1.2"
+  },
+  {
+    "name": "fonts-kacst-one",
+    "version": "5.0+svn11846-9"
+  },
+  {
+    "name": "fonts-kalapi",
+    "version": "1.0-2"
+  },
+  {
+    "name": "fonts-liberation",
+    "version": "1:1.07.4-7~18.04.1"
+  },
+  {
+    "name": "fonts-liberation2",
+    "version": "2.00.1-7~18.04.2"
+  },
+  {
+    "name": "fonts-lohit-deva",
+    "version": "2.95.4-2"
+  },
+  {
+    "name": "fonts-lohit-gujr",
+    "version": "2.92.4-2"
+  },
+  {
+    "name": "fonts-lohit-knda",
+    "version": "2.5.4-1"
+  },
+  {
+    "name": "fonts-noto-cjk",
+    "version": "1:20190409+repack1-0ubuntu0.18.04"
+  },
+  {
+    "name": "fonts-noto-color-emoji",
+    "version": "0~20180810-0ubuntu1"
+  },
+  {
+    "name": "fonts-noto-mono",
+    "version": "20171026-2"
+  },
+  {
+    "name": "fonts-opensymbol",
+    "version": "2:102.10+LibO6.0.7-0ubuntu0.18.04.10"
+  },
+  {
+    "name": "fonts-orya-extra",
+    "version": "2.0-5ubuntu0.1"
+  },
+  {
+    "name": "fonts-sil-abyssinica",
+    "version": "1.500-1"
+  },
+  {
+    "name": "fonts-sil-padauk",
+    "version": "3.003-1"
+  },
+  {
+    "name": "fonts-smc",
+    "version": "1:7.0"
+  },
+  {
+    "name": "fonts-smc-anjalioldlipi",
+    "version": "7.0-2"
+  },
+  {
+    "name": "fonts-smc-chilanka",
+    "version": "1.2.0-2"
+  },
+  {
+    "name": "fonts-smc-dyuthi",
+    "version": "2.0-1"
+  },
+  {
+    "name": "fonts-smc-karumbi",
+    "version": "1.0-1"
+  },
+  {
+    "name": "fonts-smc-keraleeyam",
+    "version": "2.0-1"
+  },
+  {
+    "name": "fonts-smc-manjari",
+    "version": "1.5.1-1"
+  },
+  {
+    "name": "fonts-smc-meera",
+    "version": "7.0-2"
+  },
+  {
+    "name": "fonts-smc-rachana",
+    "version": "7.0-2"
+  },
+  {
+    "name": "fonts-smc-raghumalayalamsans",
+    "version": "2.1.1-2"
+  },
+  {
+    "name": "fonts-smc-suruma",
+    "version": "3.2.1-1"
+  },
+  {
+    "name": "fonts-smc-uroob",
+    "version": "2.0-1"
+  },
+  {
+    "name": "fonts-thai-tlwg",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-garuda",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-garuda-ttf",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-kinnari",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-kinnari-ttf",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-laksaman",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-laksaman-ttf",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-loma",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-loma-ttf",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-mono",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-mono-ttf",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-norasi",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-norasi-ttf",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-purisa",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-purisa-ttf",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-sawasdee",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-sawasdee-ttf",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-typewriter",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-typewriter-ttf",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-typist",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-typist-ttf",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-typo",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-typo-ttf",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-umpush",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-umpush-ttf",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-waree",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-tlwg-waree-ttf",
+    "version": "1:0.6.4-2"
+  },
+  {
+    "name": "fonts-ubuntu",
+    "version": "0.83-2"
+  },
+  {
+    "name": "foomatic-db-compressed-ppds",
+    "version": "20180306-1"
+  },
+  {
+    "name": "friendly-recovery",
+    "version": "0.2.38ubuntu1.2"
+  },
+  {
+    "name": "ftp",
+    "version": "0.17-34"
+  },
+  {
+    "name": "fuse",
+    "version": "2.9.7-1ubuntu1"
+  },
+  {
+    "name": "fwupd",
+    "version": "1.2.14-0~18.04.2"
+  },
+  {
+    "name": "fwupd-signed",
+    "version": "1.10~ubuntu18.04.6+1.2.14-0~18.04.2"
+  },
+  {
+    "name": "fwupdate",
+    "version": "12-7~ubuntu18.04.3"
+  },
+  {
+    "name": "fwupdate-signed",
+    "version": "12-7~ubuntu18.04.3"
+  },
+  {
+    "name": "gcc-7-base",
+    "version": "7.5.0-3ubuntu1~18.04"
+  },
+  {
+    "name": "gcc-8-base",
+    "version": "8.4.0-1ubuntu1~18.04"
+  },
+  {
+    "name": "gcr",
+    "version": "3.28.0-1"
+  },
+  {
+    "name": "gdb",
+    "version": "8.1.1-0ubuntu1"
+  },
+  {
+    "name": "gdbserver",
+    "version": "8.1.1-0ubuntu1"
+  },
+  {
+    "name": "gdisk",
+    "version": "1.0.3-1"
+  },
+  {
+    "name": "gdm3",
+    "version": "3.28.3-0ubuntu18.04.6"
+  },
+  {
+    "name": "gedit",
+    "version": "3.28.1-1ubuntu1.2"
+  },
+  {
+    "name": "gedit-common",
+    "version": "3.28.1-1ubuntu1.2"
+  },
+  {
+    "name": "genisoimage",
+    "version": "9:1.1.11-3ubuntu2"
+  },
+  {
+    "name": "geoclue-2.0",
+    "version": "2.4.7-1ubuntu1"
+  },
+  {
+    "name": "geoip-database",
+    "version": "20180315-1"
+  },
+  {
+    "name": "gettext",
+    "version": "0.19.8.1-6ubuntu0.3"
+  },
+  {
+    "name": "gettext-base",
+    "version": "0.19.8.1-6ubuntu0.3"
+  },
+  {
+    "name": "ghostscript",
+    "version": "9.26~dfsg+0-0ubuntu0.18.04.14"
+  },
+  {
+    "name": "ghostscript-x",
+    "version": "9.26~dfsg+0-0ubuntu0.18.04.14"
+  },
+  {
+    "name": "gir1.2-accountsservice-1.0",
+    "version": "0.6.45-1ubuntu1.3"
+  },
+  {
+    "name": "gir1.2-atk-1.0",
+    "version": "2.28.1-1"
+  },
+  {
+    "name": "gir1.2-atspi-2.0",
+    "version": "2.28.0-1"
+  },
+  {
+    "name": "gir1.2-dbusmenu-glib-0.4",
+    "version": "16.04.1+18.04.20171206-0ubuntu2"
+  },
+  {
+    "name": "gir1.2-dee-1.0",
+    "version": "1.2.7+17.10.20170616-0ubuntu4"
+  },
+  {
+    "name": "gir1.2-freedesktop",
+    "version": "1.56.1-1"
+  },
+  {
+    "name": "gir1.2-gck-1",
+    "version": "3.28.0-1"
+  },
+  {
+    "name": "gir1.2-gcr-3",
+    "version": "3.28.0-1"
+  },
+  {
+    "name": "gir1.2-gdesktopenums-3.0",
+    "version": "3.28.0-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-gdkpixbuf-2.0",
+    "version": "2.36.11-2"
+  },
+  {
+    "name": "gir1.2-gdm-1.0",
+    "version": "3.28.3-0ubuntu18.04.6"
+  },
+  {
+    "name": "gir1.2-geoclue-2.0",
+    "version": "2.4.7-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-geocodeglib-1.0",
+    "version": "3.25.4.1-4ubuntu0.18.04.1"
+  },
+  {
+    "name": "gir1.2-glib-2.0",
+    "version": "1.56.1-1"
+  },
+  {
+    "name": "gir1.2-gmenu-3.0",
+    "version": "3.13.3-11ubuntu1.1"
+  },
+  {
+    "name": "gir1.2-gnomebluetooth-1.0",
+    "version": "3.28.0-2ubuntu0.2"
+  },
+  {
+    "name": "gir1.2-gnomedesktop-3.0",
+    "version": "3.28.2-0ubuntu1.5"
+  },
+  {
+    "name": "gir1.2-goa-1.0",
+    "version": "3.28.0-0ubuntu2.1"
+  },
+  {
+    "name": "gir1.2-gst-plugins-base-1.0",
+    "version": "1.14.5-0ubuntu1~18.04.3"
+  },
+  {
+    "name": "gir1.2-gstreamer-1.0",
+    "version": "1.14.5-0ubuntu1~18.04.2"
+  },
+  {
+    "name": "gir1.2-gtk-3.0",
+    "version": "3.22.30-1ubuntu4"
+  },
+  {
+    "name": "gir1.2-gtksource-3.0",
+    "version": "3.24.7-1"
+  },
+  {
+    "name": "gir1.2-gudev-1.0",
+    "version": "1:232-2"
+  },
+  {
+    "name": "gir1.2-gweather-3.0",
+    "version": "3.28.2-1~ubuntu18.04.1"
+  },
+  {
+    "name": "gir1.2-ibus-1.0",
+    "version": "1.5.17-3ubuntu5.3"
+  },
+  {
+    "name": "gir1.2-javascriptcoregtk-4.0",
+    "version": "2.32.3-0ubuntu0.18.04.1"
+  },
+  {
+    "name": "gir1.2-json-1.0",
+    "version": "1.4.2-3ubuntu0.18.04.1"
+  },
+  {
+    "name": "gir1.2-mutter-2",
+    "version": "3.28.4+git20200505-0ubuntu18.04.2"
+  },
+  {
+    "name": "gir1.2-nm-1.0",
+    "version": "1.10.6-2ubuntu1.4"
+  },
+  {
+    "name": "gir1.2-nma-1.0",
+    "version": "1.8.10-2ubuntu3"
+  },
+  {
+    "name": "gir1.2-notify-0.7",
+    "version": "0.7.7-3"
+  },
+  {
+    "name": "gir1.2-packagekitglib-1.0",
+    "version": "1.1.9-1ubuntu2.18.04.6"
+  },
+  {
+    "name": "gir1.2-pango-1.0",
+    "version": "1.40.14-1ubuntu0.1"
+  },
+  {
+    "name": "gir1.2-peas-1.0",
+    "version": "1.22.0-2"
+  },
+  {
+    "name": "gir1.2-polkit-1.0",
+    "version": "0.105-20ubuntu0.18.04.5"
+  },
+  {
+    "name": "gir1.2-rsvg-2.0",
+    "version": "2.40.20-2ubuntu0.2"
+  },
+  {
+    "name": "gir1.2-secret-1",
+    "version": "0.18.6-1"
+  },
+  {
+    "name": "gir1.2-snapd-1",
+    "version": "1.58-0ubuntu0.18.04.0"
+  },
+  {
+    "name": "gir1.2-soup-2.4",
+    "version": "2.62.1-1ubuntu0.4"
+  },
+  {
+    "name": "gir1.2-udisks-2.0",
+    "version": "2.7.6-3ubuntu0.2"
+  },
+  {
+    "name": "gir1.2-unity-5.0",
+    "version": "7.1.4+18.04.20180209.1-0ubuntu2"
+  },
+  {
+    "name": "gir1.2-upowerglib-1.0",
+    "version": "0.99.7-2ubuntu0.18.04.1"
+  },
+  {
+    "name": "gir1.2-vte-2.91",
+    "version": "0.52.2-1ubuntu1~18.04.2"
+  },
+  {
+    "name": "gir1.2-webkit2-4.0",
+    "version": "2.32.3-0ubuntu0.18.04.1"
+  },
+  {
+    "name": "gir1.2-wnck-3.0",
+    "version": "3.24.1-2"
+  },
+  {
+    "name": "gjs",
+    "version": "1.52.5-0ubuntu18.04.1"
+  },
+  {
+    "name": "gkbd-capplet",
+    "version": "3.26.0-3ubuntu0.18.04.1"
+  },
+  {
+    "name": "glib-networking",
+    "version": "2.56.0-1ubuntu0.1"
+  },
+  {
+    "name": "glib-networking-common",
+    "version": "2.56.0-1ubuntu0.1"
+  },
+  {
+    "name": "glib-networking-services",
+    "version": "2.56.0-1ubuntu0.1"
+  },
+  {
+    "name": "gnome-bluetooth",
+    "version": "3.28.0-2ubuntu0.2"
+  },
+  {
+    "name": "gnome-control-center",
+    "version": "1:3.28.2-0ubuntu0.18.04.6"
+  },
+  {
+    "name": "gnome-control-center-data",
+    "version": "1:3.28.2-0ubuntu0.18.04.6"
+  },
+  {
+    "name": "gnome-control-center-faces",
+    "version": "1:3.28.2-0ubuntu0.18.04.6"
+  },
+  {
+    "name": "gnome-desktop3-data",
+    "version": "3.28.2-0ubuntu1.5"
+  },
+  {
+    "name": "gnome-disk-utility",
+    "version": "3.28.3-0ubuntu1~18.04.1"
+  },
+  {
+    "name": "gnome-font-viewer",
+    "version": "3.28.0-1"
+  },
+  {
+    "name": "gnome-getting-started-docs",
+    "version": "3.28.2-0ubuntu0.1"
+  },
+  {
+    "name": "gnome-initial-setup",
+    "version": "3.28.0-2ubuntu6.16.04.6"
+  },
+  {
+    "name": "gnome-keyring",
+    "version": "3.28.0.2-1ubuntu1.18.04.1"
+  },
+  {
+    "name": "gnome-keyring-pkcs11",
+    "version": "3.28.0.2-1ubuntu1.18.04.1"
+  },
+  {
+    "name": "gnome-menus",
+    "version": "3.13.3-11ubuntu1.1"
+  },
+  {
+    "name": "gnome-online-accounts",
+    "version": "3.28.0-0ubuntu2.1"
+  },
+  {
+    "name": "gnome-power-manager",
+    "version": "3.26.0-1"
+  },
+  {
+    "name": "gnome-screenshot",
+    "version": "3.25.0-0ubuntu2"
+  },
+  {
+    "name": "gnome-session-bin",
+    "version": "3.28.1-0ubuntu3"
+  },
+  {
+    "name": "gnome-session-canberra",
+    "version": "0.30-5ubuntu1"
+  },
+  {
+    "name": "gnome-session-common",
+    "version": "3.28.1-0ubuntu3"
+  },
+  {
+    "name": "gnome-settings-daemon",
+    "version": "3.28.1-0ubuntu1.3"
+  },
+  {
+    "name": "gnome-settings-daemon-schemas",
+    "version": "3.28.1-0ubuntu1.3"
+  },
+  {
+    "name": "gnome-shell",
+    "version": "3.28.4-0ubuntu18.04.7"
+  },
+  {
+    "name": "gnome-shell-common",
+    "version": "3.28.4-0ubuntu18.04.7"
+  },
+  {
+    "name": "gnome-shell-extension-appindicator",
+    "version": "18.04.1"
+  },
+  {
+    "name": "gnome-shell-extension-ubuntu-dock",
+    "version": "0.9.1ubuntu18.04.3"
+  },
+  {
+    "name": "gnome-software",
+    "version": "3.28.1-0ubuntu4.18.04.15"
+  },
+  {
+    "name": "gnome-software-common",
+    "version": "3.28.1-0ubuntu4.18.04.15"
+  },
+  {
+    "name": "gnome-software-plugin-snap",
+    "version": "3.28.1-0ubuntu4.18.04.15"
+  },
+  {
+    "name": "gnome-startup-applications",
+    "version": "3.28.1-0ubuntu3"
+  },
+  {
+    "name": "gnome-terminal",
+    "version": "3.28.2-1ubuntu1~18.04.1"
+  },
+  {
+    "name": "gnome-terminal-data",
+    "version": "3.28.2-1ubuntu1~18.04.1"
+  },
+  {
+    "name": "gnome-user-docs",
+    "version": "3.28.2+git20180715-0ubuntu0.1"
+  },
+  {
+    "name": "gnome-user-guide",
+    "version": "3.28.2+git20180715-0ubuntu0.1"
+  },
+  {
+    "name": "gnupg",
+    "version": "2.2.4-1ubuntu1.4"
+  },
+  {
+    "name": "gnupg-l10n",
+    "version": "2.2.4-1ubuntu1.4"
+  },
+  {
+    "name": "gnupg-utils",
+    "version": "2.2.4-1ubuntu1.4"
+  },
+  {
+    "name": "gpg",
+    "version": "2.2.4-1ubuntu1.4"
+  },
+  {
+    "name": "gpg-agent",
+    "version": "2.2.4-1ubuntu1.4"
+  },
+  {
+    "name": "gpg-wks-client",
+    "version": "2.2.4-1ubuntu1.4"
+  },
+  {
+    "name": "gpg-wks-server",
+    "version": "2.2.4-1ubuntu1.4"
+  },
+  {
+    "name": "gpgconf",
+    "version": "2.2.4-1ubuntu1.4"
+  },
+  {
+    "name": "gpgsm",
+    "version": "2.2.4-1ubuntu1.4"
+  },
+  {
+    "name": "gpgv",
+    "version": "2.2.4-1ubuntu1.4"
+  },
+  {
+    "name": "grep",
+    "version": "3.1-2build1"
+  },
+  {
+    "name": "grilo-plugins-0.3-base",
+    "version": "0.3.5-1ubuntu1"
+  },
+  {
+    "name": "groff-base",
+    "version": "1.22.3-10"
+  },
+  {
+    "name": "grub-common",
+    "version": "2.02-2ubuntu8.23"
+  },
+  {
+    "name": "grub-pc",
+    "version": "2.02-2ubuntu8.23"
+  },
+  {
+    "name": "grub-pc-bin",
+    "version": "2.02-2ubuntu8.23"
+  },
+  {
+    "name": "grub2-common",
+    "version": "2.02-2ubuntu8.23"
+  },
+  {
+    "name": "gsettings-desktop-schemas",
+    "version": "3.28.0-1ubuntu1"
+  },
+  {
+    "name": "gsfonts",
+    "version": "1:8.11+urwcyr1.0.7~pre44-4.4"
+  },
+  {
+    "name": "gstreamer1.0-alsa",
+    "version": "1.14.5-0ubuntu1~18.04.3"
+  },
+  {
+    "name": "gstreamer1.0-clutter-3.0",
+    "version": "3.0.26-1"
+  },
+  {
+    "name": "gstreamer1.0-gl",
+    "version": "1.14.5-0ubuntu1~18.04.3"
+  },
+  {
+    "name": "gstreamer1.0-gtk3",
+    "version": "1.14.5-0ubuntu1~18.04.2"
+  },
+  {
+    "name": "gstreamer1.0-packagekit",
+    "version": "1.1.9-1ubuntu2.18.04.6"
+  },
+  {
+    "name": "gstreamer1.0-plugins-base",
+    "version": "1.14.5-0ubuntu1~18.04.3"
+  },
+  {
+    "name": "gstreamer1.0-plugins-base-apps",
+    "version": "1.14.5-0ubuntu1~18.04.3"
+  },
+  {
+    "name": "gstreamer1.0-plugins-good",
+    "version": "1.14.5-0ubuntu1~18.04.2"
+  },
+  {
+    "name": "gstreamer1.0-pulseaudio",
+    "version": "1.14.5-0ubuntu1~18.04.2"
+  },
+  {
+    "name": "gstreamer1.0-tools",
+    "version": "1.14.5-0ubuntu1~18.04.2"
+  },
+  {
+    "name": "gstreamer1.0-x",
+    "version": "1.14.5-0ubuntu1~18.04.3"
+  },
+  {
+    "name": "gtk-update-icon-cache",
+    "version": "3.22.30-1ubuntu4"
+  },
+  {
+    "name": "gtk2-engines-murrine",
+    "version": "0.98.2-2ubuntu1"
+  },
+  {
+    "name": "gtk2-engines-pixbuf",
+    "version": "2.24.32-1ubuntu1"
+  },
+  {
+    "name": "gvfs",
+    "version": "1.36.1-0ubuntu1.3.3"
+  },
+  {
+    "name": "gvfs-backends",
+    "version": "1.36.1-0ubuntu1.3.3"
+  },
+  {
+    "name": "gvfs-bin",
+    "version": "1.36.1-0ubuntu1.3.3"
+  },
+  {
+    "name": "gvfs-common",
+    "version": "1.36.1-0ubuntu1.3.3"
+  },
+  {
+    "name": "gvfs-daemons",
+    "version": "1.36.1-0ubuntu1.3.3"
+  },
+  {
+    "name": "gvfs-fuse",
+    "version": "1.36.1-0ubuntu1.3.3"
+  },
+  {
+    "name": "gvfs-libs",
+    "version": "1.36.1-0ubuntu1.3.3"
+  },
+  {
+    "name": "gzip",
+    "version": "1.6-5ubuntu1.1"
+  },
+  {
+    "name": "hdparm",
+    "version": "9.54+ds-1"
+  },
+  {
+    "name": "hostname",
+    "version": "3.20"
+  },
+  {
+    "name": "hplip",
+    "version": "3.17.10+repack0-5"
+  },
+  {
+    "name": "hplip-data",
+    "version": "3.17.10+repack0-5"
+  },
+  {
+    "name": "hunspell-en-us",
+    "version": "1:2017.08.24"
+  },
+  {
+    "name": "ibus",
+    "version": "1.5.17-3ubuntu5.3"
+  },
+  {
+    "name": "ibus-gtk",
+    "version": "1.5.17-3ubuntu5.3"
+  },
+  {
+    "name": "ibus-gtk3",
+    "version": "1.5.17-3ubuntu5.3"
+  },
+  {
+    "name": "ibus-table",
+    "version": "1.9.14-3"
+  },
+  {
+    "name": "idna",
+    "version": "2.6"
+  },
+  {
+    "name": "ifupdown",
+    "version": "0.8.17ubuntu1.1"
+  },
+  {
+    "name": "iio-sensor-proxy",
+    "version": "2.4-2"
+  },
+  {
+    "name": "im-config",
+    "version": "0.34-1ubuntu1.3"
+  },
+  {
+    "name": "imagemagick",
+    "version": "8:6.9.7.4+dfsg-16ubuntu6.11"
+  },
+  {
+    "name": "imagemagick-6-common",
+    "version": "8:6.9.7.4+dfsg-16ubuntu6.11"
+  },
+  {
+    "name": "imagemagick-6.q16",
+    "version": "8:6.9.7.4+dfsg-16ubuntu6.11"
+  },
+  {
+    "name": "info",
+    "version": "6.5.0.dfsg.1-2"
+  },
+  {
+    "name": "init",
+    "version": "1.51"
+  },
+  {
+    "name": "init-system-helpers",
+    "version": "1.51"
+  },
+  {
+    "name": "initramfs-tools",
+    "version": "0.130ubuntu3.13"
+  },
+  {
+    "name": "initramfs-tools-bin",
+    "version": "0.130ubuntu3.13"
+  },
+  {
+    "name": "initramfs-tools-core",
+    "version": "0.130ubuntu3.13"
+  },
+  {
+    "name": "inputattach",
+    "version": "1:1.6.0-2"
+  },
+  {
+    "name": "install-info",
+    "version": "6.5.0.dfsg.1-2"
+  },
+  {
+    "name": "intel-microcode",
+    "version": "3.20210608.0ubuntu0.18.04.1"
+  },
+  {
+    "name": "intltool-debian",
+    "version": "0.35.0+20060710.4"
+  },
+  {
+    "name": "ippusbxd",
+    "version": "1.32-2"
+  },
+  {
+    "name": "iproute2",
+    "version": "4.15.0-2ubuntu1.3"
+  },
+  {
+    "name": "iptables",
+    "version": "1.6.1-2ubuntu2"
+  },
+  {
+    "name": "iputils-arping",
+    "version": "3:20161105-1ubuntu3"
+  },
+  {
+    "name": "iputils-ping",
+    "version": "3:20161105-1ubuntu3"
+  },
+  {
+    "name": "iputils-tracepath",
+    "version": "3:20161105-1ubuntu3"
+  },
+  {
+    "name": "irqbalance",
+    "version": "1.3.0-0.1ubuntu0.18.04.1"
+  },
+  {
+    "name": "isc-dhcp-client",
+    "version": "4.3.5-3ubuntu7.3"
+  },
+  {
+    "name": "isc-dhcp-common",
+    "version": "4.3.5-3ubuntu7.3"
+  },
+  {
+    "name": "iso-codes",
+    "version": "3.79-1"
+  },
+  {
+    "name": "iw",
+    "version": "4.14-0.1"
+  },
+  {
+    "name": "kbd",
+    "version": "2.0.4-2ubuntu1"
+  },
+  {
+    "name": "keyboard-configuration",
+    "version": "1.178ubuntu2.9"
+  },
+  {
+    "name": "keyring",
+    "version": "10.6.0"
+  },
+  {
+    "name": "keyrings.alt",
+    "version": "3.0"
+  },
+  {
+    "name": "klibc-utils",
+    "version": "2.0.4-9ubuntu2"
+  },
+  {
+    "name": "kmod",
+    "version": "24-1ubuntu3.5"
+  },
+  {
+    "name": "krb5-locales",
+    "version": "1.16-2ubuntu0.2"
+  },
+  {
+    "name": "language-pack-en",
+    "version": "1:18.04+20190718"
+  },
+  {
+    "name": "language-pack-en-base",
+    "version": "1:18.04+20180712"
+  },
+  {
+    "name": "language-pack-gnome-en",
+    "version": "1:18.04+20190718"
+  },
+  {
+    "name": "language-pack-gnome-en-base",
+    "version": "1:18.04+20180712"
+  },
+  {
+    "name": "language-selector-common",
+    "version": "0.188.3"
+  },
+  {
+    "name": "language-selector-gnome",
+    "version": "0.188.3"
+  },
+  {
+    "name": "launchpadlib",
+    "version": "1.10.6"
+  },
+  {
+    "name": "lazr.restfulclient",
+    "version": "0.13.5"
+  },
+  {
+    "name": "less",
+    "version": "487-0.1"
+  },
+  {
+    "name": "libaa1",
+    "version": "1.4p5-44build2"
+  },
+  {
+    "name": "libaccountsservice0",
+    "version": "0.6.45-1ubuntu1.3"
+  },
+  {
+    "name": "libacl1",
+    "version": "2.2.52-3build1"
+  },
+  {
+    "name": "libapparmor1",
+    "version": "2.12-4ubuntu5.1"
+  },
+  {
+    "name": "libappindicator3-1",
+    "version": "12.10.1+18.04.20200408.1-0ubuntu1"
+  },
+  {
+    "name": "libappstream-glib8",
+    "version": "0.7.7-2"
+  },
+  {
+    "name": "libappstream4",
+    "version": "0.12.0-3ubuntu1"
+  },
+  {
+    "name": "libapt-inst2.0",
+    "version": "1.6.14"
+  },
+  {
+    "name": "libapt-pkg-perl",
+    "version": "0.1.33build1"
+  },
+  {
+    "name": "libapt-pkg5.0",
+    "version": "1.6.14"
+  },
+  {
+    "name": "libarchive-zip-perl",
+    "version": "1.60-1ubuntu0.1"
+  },
+  {
+    "name": "libarchive13",
+    "version": "3.2.2-3.1ubuntu0.7"
+  },
+  {
+    "name": "libargon2-0",
+    "version": "0~20161029-1.1"
+  },
+  {
+    "name": "libart-2.0-2",
+    "version": "2.3.21-3"
+  },
+  {
+    "name": "libasn1-8-heimdal",
+    "version": "7.5.0+dfsg-1"
+  },
+  {
+    "name": "libasound2",
+    "version": "1.1.3-5ubuntu0.6"
+  },
+  {
+    "name": "libasound2-data",
+    "version": "1.1.3-5ubuntu0.6"
+  },
+  {
+    "name": "libasound2-plugins",
+    "version": "1.1.1-1ubuntu1"
+  },
+  {
+    "name": "libaspell15",
+    "version": "0.60.7~20110707-4ubuntu0.2"
+  },
+  {
+    "name": "libassuan0",
+    "version": "2.5.1-2"
+  },
+  {
+    "name": "libatasmart4",
+    "version": "0.19-4"
+  },
+  {
+    "name": "libatk-adaptor",
+    "version": "2.26.2-1"
+  },
+  {
+    "name": "libatk-bridge2.0-0",
+    "version": "2.26.2-1"
+  },
+  {
+    "name": "libatk1.0-0",
+    "version": "2.28.1-1"
+  },
+  {
+    "name": "libatk1.0-data",
+    "version": "2.28.1-1"
+  },
+  {
+    "name": "libatm1",
+    "version": "1:2.5.1-2build1"
+  },
+  {
+    "name": "libatspi2.0-0",
+    "version": "2.28.0-1"
+  },
+  {
+    "name": "libattr1",
+    "version": "1:2.4.47-2build1"
+  },
+  {
+    "name": "libaudio2",
+    "version": "1.9.4-6"
+  },
+  {
+    "name": "libaudit-common",
+    "version": "1:2.8.2-1ubuntu1.1"
+  },
+  {
+    "name": "libaudit1",
+    "version": "1:2.8.2-1ubuntu1.1"
+  },
+  {
+    "name": "libavahi-client3",
+    "version": "0.7-3.1ubuntu1.3"
+  },
+  {
+    "name": "libavahi-common-data",
+    "version": "0.7-3.1ubuntu1.3"
+  },
+  {
+    "name": "libavahi-common3",
+    "version": "0.7-3.1ubuntu1.3"
+  },
+  {
+    "name": "libavahi-core7",
+    "version": "0.7-3.1ubuntu1.3"
+  },
+  {
+    "name": "libavahi-glib1",
+    "version": "0.7-3.1ubuntu1.3"
+  },
+  {
+    "name": "libavc1394-0",
+    "version": "0.5.4-4build1"
+  },
+  {
+    "name": "libbabeltrace1",
+    "version": "1.5.5-1"
+  },
+  {
+    "name": "libbind9-160",
+    "version": "1:9.11.3+dfsg-1ubuntu1.15"
+  },
+  {
+    "name": "libbinutils",
+    "version": "2.30-21ubuntu1~18.04.5"
+  },
+  {
+    "name": "libblkid1",
+    "version": "2.31.1-0.4ubuntu3.7"
+  },
+  {
+    "name": "libblockdev-crypto2",
+    "version": "2.16-2"
+  },
+  {
+    "name": "libblockdev-fs2",
+    "version": "2.16-2"
+  },
+  {
+    "name": "libblockdev-loop2",
+    "version": "2.16-2"
+  },
+  {
+    "name": "libblockdev-part-err2",
+    "version": "2.16-2"
+  },
+  {
+    "name": "libblockdev-part2",
+    "version": "2.16-2"
+  },
+  {
+    "name": "libblockdev-swap2",
+    "version": "2.16-2"
+  },
+  {
+    "name": "libblockdev-utils2",
+    "version": "2.16-2"
+  },
+  {
+    "name": "libblockdev2",
+    "version": "2.16-2"
+  },
+  {
+    "name": "libbluetooth3",
+    "version": "5.48-0ubuntu3.5"
+  },
+  {
+    "name": "libboost-date-time1.65.1",
+    "version": "1.65.1+dfsg-0ubuntu5"
+  },
+  {
+    "name": "libboost-filesystem1.65.1",
+    "version": "1.65.1+dfsg-0ubuntu5"
+  },
+  {
+    "name": "libboost-iostreams1.65.1",
+    "version": "1.65.1+dfsg-0ubuntu5"
+  },
+  {
+    "name": "libboost-locale1.65.1",
+    "version": "1.65.1+dfsg-0ubuntu5"
+  },
+  {
+    "name": "libboost-system1.65.1",
+    "version": "1.65.1+dfsg-0ubuntu5"
+  },
+  {
+    "name": "libboost-thread1.65.1",
+    "version": "1.65.1+dfsg-0ubuntu5"
+  },
+  {
+    "name": "libbrlapi0.6",
+    "version": "5.5-4ubuntu2.0.1"
+  },
+  {
+    "name": "libbrotli1",
+    "version": "1.0.3-1ubuntu1.3"
+  },
+  {
+    "name": "libbsd0",
+    "version": "0.8.7-1ubuntu0.1"
+  },
+  {
+    "name": "libbz2-1.0",
+    "version": "1.0.6-8.1ubuntu0.2"
+  },
+  {
+    "name": "libc-bin",
+    "version": "2.27-3ubuntu1.4"
+  },
+  {
+    "name": "libc6",
+    "version": "2.27-3ubuntu1.4"
+  },
+  {
+    "name": "libc6-dbg",
+    "version": "2.27-3ubuntu1.4"
+  },
+  {
+    "name": "libcaca0",
+    "version": "0.99.beta19-2ubuntu0.18.04.2"
+  },
+  {
+    "name": "libcairo-gobject-perl",
+    "version": "1.004-2build3"
+  },
+  {
+    "name": "libcairo-gobject2",
+    "version": "1.15.10-2ubuntu0.1"
+  },
+  {
+    "name": "libcairo-perl",
+    "version": "1.106-2build2"
+  },
+  {
+    "name": "libcairo2",
+    "version": "1.15.10-2ubuntu0.1"
+  },
+  {
+    "name": "libcamel-1.2-61",
+    "version": "3.28.5-0ubuntu0.18.04.3"
+  },
+  {
+    "name": "libcanberra-gtk3-0",
+    "version": "0.30-5ubuntu1"
+  },
+  {
+    "name": "libcanberra-gtk3-module",
+    "version": "0.30-5ubuntu1"
+  },
+  {
+    "name": "libcanberra-pulse",
+    "version": "0.30-5ubuntu1"
+  },
+  {
+    "name": "libcanberra0",
+    "version": "0.30-5ubuntu1"
+  },
+  {
+    "name": "libcap-ng0",
+    "version": "0.7.7-3.1"
+  },
+  {
+    "name": "libcap2",
+    "version": "1:2.25-1.2"
+  },
+  {
+    "name": "libcap2-bin",
+    "version": "1:2.25-1.2"
+  },
+  {
+    "name": "libcc1-0",
+    "version": "8.4.0-1ubuntu1~18.04"
+  },
+  {
+    "name": "libcdio-cdda2",
+    "version": "10.2+0.94+2-2build1"
+  },
+  {
+    "name": "libcdio-paranoia2",
+    "version": "10.2+0.94+2-2build1"
+  },
+  {
+    "name": "libcdio17",
+    "version": "1.0.0-2ubuntu2"
+  },
+  {
+    "name": "libcdr-0.1-1",
+    "version": "0.1.4-1build1"
+  },
+  {
+    "name": "libcgi-fast-perl",
+    "version": "1:2.13-1"
+  },
+  {
+    "name": "libcgi-pm-perl",
+    "version": "4.38-1"
+  },
+  {
+    "name": "libcheese-gtk25",
+    "version": "3.28.0-1ubuntu1"
+  },
+  {
+    "name": "libcheese8",
+    "version": "3.28.0-1ubuntu1"
+  },
+  {
+    "name": "libclass-accessor-perl",
+    "version": "0.51-1"
+  },
+  {
+    "name": "libclone-perl",
+    "version": "0.39-1"
+  },
+  {
+    "name": "libclucene-contribs1v5",
+    "version": "2.3.3.4+dfsg-1"
+  },
+  {
+    "name": "libclucene-core1v5",
+    "version": "2.3.3.4+dfsg-1"
+  },
+  {
+    "name": "libclutter-1.0-0",
+    "version": "1.26.2+dfsg-4"
+  },
+  {
+    "name": "libclutter-1.0-common",
+    "version": "1.26.2+dfsg-4"
+  },
+  {
+    "name": "libclutter-gst-3.0-0",
+    "version": "3.0.26-1"
+  },
+  {
+    "name": "libclutter-gtk-1.0-0",
+    "version": "1.8.4-3"
+  },
+  {
+    "name": "libcmis-0.5-5v5",
+    "version": "0.5.1+git20160603-3build2"
+  },
+  {
+    "name": "libcogl-common",
+    "version": "1.22.2-3ubuntu1"
+  },
+  {
+    "name": "libcogl-pango20",
+    "version": "1.22.2-3ubuntu1"
+  },
+  {
+    "name": "libcogl-path20",
+    "version": "1.22.2-3ubuntu1"
+  },
+  {
+    "name": "libcogl20",
+    "version": "1.22.2-3ubuntu1"
+  },
+  {
+    "name": "libcolamd2",
+    "version": "1:5.1.2-2"
+  },
+  {
+    "name": "libcolord-gtk1",
+    "version": "0.1.26-2"
+  },
+  {
+    "name": "libcolord2",
+    "version": "1.3.3-2build1"
+  },
+  {
+    "name": "libcolorhug2",
+    "version": "1.3.3-2build1"
+  },
+  {
+    "name": "libcom-err2",
+    "version": "1.44.1-1ubuntu1.3"
+  },
+  {
+    "name": "libcrack2",
+    "version": "2.9.2-5build1"
+  },
+  {
+    "name": "libcroco3",
+    "version": "0.6.12-2"
+  },
+  {
+    "name": "libcryptsetup12",
+    "version": "2:2.0.2-1ubuntu1.2"
+  },
+  {
+    "name": "libcups2",
+    "version": "2.2.7-1ubuntu2.8"
+  },
+  {
+    "name": "libcupscgi1",
+    "version": "2.2.7-1ubuntu2.8"
+  },
+  {
+    "name": "libcupsfilters1",
+    "version": "1.20.2-0ubuntu3.1"
+  },
+  {
+    "name": "libcupsimage2",
+    "version": "2.2.7-1ubuntu2.8"
+  },
+  {
+    "name": "libcupsmime1",
+    "version": "2.2.7-1ubuntu2.8"
+  },
+  {
+    "name": "libcupsppdc1",
+    "version": "2.2.7-1ubuntu2.8"
+  },
+  {
+    "name": "libcurl3-gnutls",
+    "version": "7.58.0-2ubuntu3.15"
+  },
+  {
+    "name": "libcurl4",
+    "version": "7.58.0-2ubuntu3"
+  },
+  {
+    "name": "libdaemon0",
+    "version": "0.14-6"
+  },
+  {
+    "name": "libdatrie1",
+    "version": "0.2.10-7"
+  },
+  {
+    "name": "libdazzle-1.0-0",
+    "version": "3.28.1-1"
+  },
+  {
+    "name": "libdb5.3",
+    "version": "5.3.28-13.1ubuntu1.1"
+  },
+  {
+    "name": "libdbus-1-3",
+    "version": "1.12.2-1ubuntu1.2"
+  },
+  {
+    "name": "libdbus-glib-1-2",
+    "version": "0.110-2"
+  },
+  {
+    "name": "libdbusmenu-glib4",
+    "version": "16.04.1+18.04.20171206-0ubuntu2"
+  },
+  {
+    "name": "libdbusmenu-gtk3-4",
+    "version": "16.04.1+18.04.20171206-0ubuntu2"
+  },
+  {
+    "name": "libdbusmenu-gtk4",
+    "version": "16.04.1+18.04.20171206-0ubuntu2"
+  },
+  {
+    "name": "libdconf1",
+    "version": "0.26.0-2ubuntu3"
+  },
+  {
+    "name": "libdebconfclient0",
+    "version": "0.213ubuntu1"
+  },
+  {
+    "name": "libdee-1.0-4",
+    "version": "1.2.7+17.10.20170616-0ubuntu4"
+  },
+  {
+    "name": "libdevmapper1.02.1",
+    "version": "2:1.02.145-4.1ubuntu3.18.04.3"
+  },
+  {
+    "name": "libdigest-hmac-perl",
+    "version": "1.03+dfsg-1"
+  },
+  {
+    "name": "libdjvulibre-text",
+    "version": "3.5.27.1-8ubuntu0.4"
+  },
+  {
+    "name": "libdjvulibre21",
+    "version": "3.5.27.1-8ubuntu0.4"
+  },
+  {
+    "name": "libdns-export1100",
+    "version": "1:9.11.3+dfsg-1ubuntu1.15"
+  },
+  {
+    "name": "libdns1100",
+    "version": "1:9.11.3+dfsg-1ubuntu1.15"
+  },
+  {
+    "name": "libdpkg-perl",
+    "version": "1.19.0.5ubuntu2.3"
+  },
+  {
+    "name": "libdrm-amdgpu1",
+    "version": "2.4.101-2~18.04.1"
+  },
+  {
+    "name": "libdrm-common",
+    "version": "2.4.101-2~18.04.1"
+  },
+  {
+    "name": "libdrm-intel1",
+    "version": "2.4.101-2~18.04.1"
+  },
+  {
+    "name": "libdrm-nouveau2",
+    "version": "2.4.101-2~18.04.1"
+  },
+  {
+    "name": "libdrm-radeon1",
+    "version": "2.4.101-2~18.04.1"
+  },
+  {
+    "name": "libdrm2",
+    "version": "2.4.101-2~18.04.1"
+  },
+  {
+    "name": "libdv4",
+    "version": "1.0.0-11"
+  },
+  {
+    "name": "libdw1",
+    "version": "0.170-0.4ubuntu0.1"
+  },
+  {
+    "name": "libe-book-0.1-1",
+    "version": "0.1.3-1"
+  },
+  {
+    "name": "libebackend-1.2-10",
+    "version": "3.28.5-0ubuntu0.18.04.3"
+  },
+  {
+    "name": "libebook-1.2-19",
+    "version": "3.28.5-0ubuntu0.18.04.3"
+  },
+  {
+    "name": "libebook-contacts-1.2-2",
+    "version": "3.28.5-0ubuntu0.18.04.3"
+  },
+  {
+    "name": "libecal-1.2-19",
+    "version": "3.28.5-0ubuntu0.18.04.3"
+  },
+  {
+    "name": "libedata-book-1.2-25",
+    "version": "3.28.5-0ubuntu0.18.04.3"
+  },
+  {
+    "name": "libedata-cal-1.2-28",
+    "version": "3.28.5-0ubuntu0.18.04.3"
+  },
+  {
+    "name": "libedataserver-1.2-23",
+    "version": "3.28.5-0ubuntu0.18.04.3"
+  },
+  {
+    "name": "libedataserverui-1.2-2",
+    "version": "3.28.5-0ubuntu0.18.04.3"
+  },
+  {
+    "name": "libedit2",
+    "version": "3.1-20170329-1"
+  },
+  {
+    "name": "libefiboot1",
+    "version": "34-1"
+  },
+  {
+    "name": "libefivar1",
+    "version": "34-1"
+  },
+  {
+    "name": "libegl-mesa0",
+    "version": "20.0.8-0ubuntu1~18.04.1"
+  },
+  {
+    "name": "libegl1",
+    "version": "1.0.0-2ubuntu2.3"
+  },
+  {
+    "name": "libegl1-mesa",
+    "version": "20.0.8-0ubuntu1~18.04.1"
+  },
+  {
+    "name": "libelf1",
+    "version": "0.170-0.4ubuntu0.1"
+  },
+  {
+    "name": "libemail-valid-perl",
+    "version": "1.202-1"
+  },
+  {
+    "name": "libenchant1c2a",
+    "version": "1.6.0-11.1"
+  },
+  {
+    "name": "libeot0",
+    "version": "0.01-5"
+  },
+  {
+    "name": "libepoxy0",
+    "version": "1.4.3-1"
+  },
+  {
+    "name": "libepubgen-0.1-1",
+    "version": "0.1.0-2ubuntu1"
+  },
+  {
+    "name": "libespeak-ng1",
+    "version": "1.49.2+dfsg-1"
+  },
+  {
+    "name": "libetonyek-0.1-1",
+    "version": "0.1.7-3"
+  },
+  {
+    "name": "libevdev2",
+    "version": "1.5.8+dfsg-1ubuntu0.1"
+  },
+  {
+    "name": "libevdocument3-4",
+    "version": "3.28.4-0ubuntu1.2"
+  },
+  {
+    "name": "libevent-2.1-6",
+    "version": "2.1.8-stable-4build1"
+  },
+  {
+    "name": "libevview3-3",
+    "version": "3.28.4-0ubuntu1.2"
+  },
+  {
+    "name": "libexempi3",
+    "version": "2.4.5-2"
+  },
+  {
+    "name": "libexif12",
+    "version": "0.6.21-4ubuntu0.6"
+  },
+  {
+    "name": "libexiv2-14",
+    "version": "0.25-3.1ubuntu0.18.04.11"
+  },
+  {
+    "name": "libexpat1",
+    "version": "2.2.5-3ubuntu0.2"
+  },
+  {
+    "name": "libexporter-tiny-perl",
+    "version": "1.000000-2"
+  },
+  {
+    "name": "libext2fs2",
+    "version": "1.44.1-1ubuntu1.3"
+  },
+  {
+    "name": "libfcgi-perl",
+    "version": "0.78-2build1"
+  },
+  {
+    "name": "libfdisk1",
+    "version": "2.31.1-0.4ubuntu3.7"
+  },
+  {
+    "name": "libffi6",
+    "version": "3.2.1-8"
+  },
+  {
+    "name": "libfftw3-double3",
+    "version": "3.3.7-1"
+  },
+  {
+    "name": "libfftw3-single3",
+    "version": "3.3.7-1"
+  },
+  {
+    "name": "libfile-basedir-perl",
+    "version": "0.07-1"
+  },
+  {
+    "name": "libfile-copy-recursive-perl",
+    "version": "0.40-1"
+  },
+  {
+    "name": "libfile-fcntllock-perl",
+    "version": "0.22-3build2"
+  },
+  {
+    "name": "libfile-mimeinfo-perl",
+    "version": "0.28-1"
+  },
+  {
+    "name": "libflac8",
+    "version": "1.3.2-1"
+  },
+  {
+    "name": "libfontconfig1",
+    "version": "2.12.6-0ubuntu2"
+  },
+  {
+    "name": "libfontembed1",
+    "version": "1.20.2-0ubuntu3.1"
+  },
+  {
+    "name": "libfontenc1",
+    "version": "1:1.1.3-1"
+  },
+  {
+    "name": "libfreerdp-client2-2",
+    "version": "2.2.0+dfsg1-0ubuntu0.18.04.1"
+  },
+  {
+    "name": "libfreerdp2-2",
+    "version": "2.2.0+dfsg1-0ubuntu0.18.04.1"
+  },
+  {
+    "name": "libfreetype6",
+    "version": "2.8.1-2ubuntu2.1"
+  },
+  {
+    "name": "libfribidi0",
+    "version": "0.19.7-2"
+  },
+  {
+    "name": "libfuse2",
+    "version": "2.9.7-1ubuntu1"
+  },
+  {
+    "name": "libfwup1",
+    "version": "12-3bionic2"
+  },
+  {
+    "name": "libfwupd2",
+    "version": "1.2.14-0~18.04.2"
+  },
+  {
+    "name": "libgail-3-0",
+    "version": "3.22.30-1ubuntu4"
+  },
+  {
+    "name": "libgail-common",
+    "version": "2.24.32-1ubuntu1"
+  },
+  {
+    "name": "libgail18",
+    "version": "2.24.32-1ubuntu1"
+  },
+  {
+    "name": "libgbm1",
+    "version": "20.0.8-0ubuntu1~18.04.1"
+  },
+  {
+    "name": "libgc1c2",
+    "version": "1:7.4.2-8ubuntu1"
+  },
+  {
+    "name": "libgcab-1.0-0",
+    "version": "1.1-2"
+  },
+  {
+    "name": "libgcc1",
+    "version": "1:8.4.0-1ubuntu1~18.04"
+  },
+  {
+    "name": "libgck-1-0",
+    "version": "3.28.0-1"
+  },
+  {
+    "name": "libgcr-base-3-1",
+    "version": "3.28.0-1"
+  },
+  {
+    "name": "libgcr-ui-3-1",
+    "version": "3.28.0-1"
+  },
+  {
+    "name": "libgcrypt20",
+    "version": "1.8.1-4ubuntu1.2"
+  },
+  {
+    "name": "libgd3",
+    "version": "2.2.5-4ubuntu0.5"
+  },
+  {
+    "name": "libgdata-common",
+    "version": "0.17.9-2"
+  },
+  {
+    "name": "libgdata22",
+    "version": "0.17.9-2"
+  },
+  {
+    "name": "libgdbm-compat4",
+    "version": "1.14.1-6"
+  },
+  {
+    "name": "libgdbm5",
+    "version": "1.14.1-6"
+  },
+  {
+    "name": "libgdk-pixbuf2.0-0",
+    "version": "2.36.11-2"
+  },
+  {
+    "name": "libgdk-pixbuf2.0-bin",
+    "version": "2.36.11-2"
+  },
+  {
+    "name": "libgdk-pixbuf2.0-common",
+    "version": "2.36.11-2"
+  },
+  {
+    "name": "libgdm1",
+    "version": "3.28.3-0ubuntu18.04.6"
+  },
+  {
+    "name": "libgee-0.8-2",
+    "version": "0.20.1-1"
+  },
+  {
+    "name": "libgeoclue-2-0",
+    "version": "2.4.7-1ubuntu1"
+  },
+  {
+    "name": "libgeocode-glib0",
+    "version": "3.25.4.1-4ubuntu0.18.04.1"
+  },
+  {
+    "name": "libgeoip1",
+    "version": "1.6.12-1"
+  },
+  {
+    "name": "libgexiv2-2",
+    "version": "0.10.8-1"
+  },
+  {
+    "name": "libgirepository-1.0-1",
+    "version": "1.56.1-1"
+  },
+  {
+    "name": "libgjs0g",
+    "version": "1.52.5-0ubuntu18.04.1"
+  },
+  {
+    "name": "libgl1",
+    "version": "1.0.0-2ubuntu2.3"
+  },
+  {
+    "name": "libgl1-mesa-dri",
+    "version": "20.0.8-0ubuntu1~18.04.1"
+  },
+  {
+    "name": "libgl1-mesa-glx",
+    "version": "20.0.8-0ubuntu1~18.04.1"
+  },
+  {
+    "name": "libglapi-mesa",
+    "version": "20.0.8-0ubuntu1~18.04.1"
+  },
+  {
+    "name": "libgles2",
+    "version": "1.0.0-2ubuntu2.3"
+  },
+  {
+    "name": "libglib-object-introspection-perl",
+    "version": "0.044-2"
+  },
+  {
+    "name": "libglib-perl",
+    "version": "3:1.326-1build1"
+  },
+  {
+    "name": "libglib2.0-0",
+    "version": "2.56.4-0ubuntu0.18.04.8"
+  },
+  {
+    "name": "libglib2.0-bin",
+    "version": "2.56.4-0ubuntu0.18.04.8"
+  },
+  {
+    "name": "libglib2.0-data",
+    "version": "2.56.4-0ubuntu0.18.04.8"
+  },
+  {
+    "name": "libglu1-mesa",
+    "version": "9.0.0-2.1build1"
+  },
+  {
+    "name": "libglvnd0",
+    "version": "1.0.0-2ubuntu2.3"
+  },
+  {
+    "name": "libglx-mesa0",
+    "version": "20.0.8-0ubuntu1~18.04.1"
+  },
+  {
+    "name": "libglx0",
+    "version": "1.0.0-2ubuntu2.3"
+  },
+  {
+    "name": "libgmime-3.0-0",
+    "version": "3.2.0-1"
+  },
+  {
+    "name": "libgmp10",
+    "version": "2:6.1.2+dfsg-2"
+  },
+  {
+    "name": "libgnome-autoar-0-0",
+    "version": "0.2.3-1ubuntu0.4"
+  },
+  {
+    "name": "libgnome-bluetooth13",
+    "version": "3.28.0-2ubuntu0.2"
+  },
+  {
+    "name": "libgnome-desktop-3-17",
+    "version": "3.28.2-0ubuntu1.5"
+  },
+  {
+    "name": "libgnome-menu-3-0",
+    "version": "3.13.3-11ubuntu1.1"
+  },
+  {
+    "name": "libgnomekbd-common",
+    "version": "3.26.0-3ubuntu0.18.04.1"
+  },
+  {
+    "name": "libgnomekbd8",
+    "version": "3.26.0-3ubuntu0.18.04.1"
+  },
+  {
+    "name": "libgnutls30",
+    "version": "3.5.18-1ubuntu1.5"
+  },
+  {
+    "name": "libgoa-1.0-0b",
+    "version": "3.28.0-0ubuntu2.1"
+  },
+  {
+    "name": "libgoa-1.0-common",
+    "version": "3.28.0-0ubuntu2.1"
+  },
+  {
+    "name": "libgoa-backend-1.0-1",
+    "version": "3.28.0-0ubuntu2.1"
+  },
+  {
+    "name": "libgom-1.0-0",
+    "version": "0.3.3-4"
+  },
+  {
+    "name": "libgomp1",
+    "version": "8.4.0-1ubuntu1~18.04"
+  },
+  {
+    "name": "libgpg-error0",
+    "version": "1.27-6"
+  },
+  {
+    "name": "libgpgme11",
+    "version": "1.10.0-1ubuntu2"
+  },
+  {
+    "name": "libgpgmepp6",
+    "version": "1.10.0-1ubuntu2"
+  },
+  {
+    "name": "libgphoto2-6",
+    "version": "2.5.16-2"
+  },
+  {
+    "name": "libgphoto2-l10n",
+    "version": "2.5.16-2"
+  },
+  {
+    "name": "libgphoto2-port12",
+    "version": "2.5.16-2"
+  },
+  {
+    "name": "libgpod-common",
+    "version": "0.8.3-11"
+  },
+  {
+    "name": "libgpod4",
+    "version": "0.8.3-11"
+  },
+  {
+    "name": "libgraphene-1.0-0",
+    "version": "1.8.0-1"
+  },
+  {
+    "name": "libgraphite2-3",
+    "version": "1.3.11-2"
+  },
+  {
+    "name": "libgrilo-0.3-0",
+    "version": "0.3.4-1ubuntu0.1"
+  },
+  {
+    "name": "libgs9",
+    "version": "9.26~dfsg+0-0ubuntu0.18.04.14"
+  },
+  {
+    "name": "libgs9-common",
+    "version": "9.26~dfsg+0-0ubuntu0.18.04.14"
+  },
+  {
+    "name": "libgspell-1-1",
+    "version": "1.6.1-1"
+  },
+  {
+    "name": "libgspell-1-common",
+    "version": "1.6.1-1"
+  },
+  {
+    "name": "libgssapi-krb5-2",
+    "version": "1.16-2ubuntu0.2"
+  },
+  {
+    "name": "libgssapi3-heimdal",
+    "version": "7.5.0+dfsg-1"
+  },
+  {
+    "name": "libgstreamer-gl1.0-0",
+    "version": "1.14.5-0ubuntu1~18.04.3"
+  },
+  {
+    "name": "libgstreamer-plugins-base1.0-0",
+    "version": "1.14.5-0ubuntu1~18.04.3"
+  },
+  {
+    "name": "libgstreamer-plugins-good1.0-0",
+    "version": "1.14.5-0ubuntu1~18.04.2"
+  },
+  {
+    "name": "libgstreamer1.0-0",
+    "version": "1.14.5-0ubuntu1~18.04.2"
+  },
+  {
+    "name": "libgtk-3-0",
+    "version": "3.22.30-1ubuntu4"
+  },
+  {
+    "name": "libgtk-3-bin",
+    "version": "3.22.30-1ubuntu4"
+  },
+  {
+    "name": "libgtk-3-common",
+    "version": "3.22.30-1ubuntu4"
+  },
+  {
+    "name": "libgtk2.0-0",
+    "version": "2.24.32-1ubuntu1"
+  },
+  {
+    "name": "libgtk2.0-bin",
+    "version": "2.24.32-1ubuntu1"
+  },
+  {
+    "name": "libgtk2.0-common",
+    "version": "2.24.32-1ubuntu1"
+  },
+  {
+    "name": "libgtk3-perl",
+    "version": "0.032-1"
+  },
+  {
+    "name": "libgtksourceview-3.0-1",
+    "version": "3.24.7-1"
+  },
+  {
+    "name": "libgtksourceview-3.0-common",
+    "version": "3.24.7-1"
+  },
+  {
+    "name": "libgtop-2.0-11",
+    "version": "2.38.0-2ubuntu0.18.04.1"
+  },
+  {
+    "name": "libgtop2-common",
+    "version": "2.38.0-2ubuntu0.18.04.1"
+  },
+  {
+    "name": "libgudev-1.0-0",
+    "version": "1:232-2"
+  },
+  {
+    "name": "libgusb2",
+    "version": "0.2.11-1"
+  },
+  {
+    "name": "libgutenprint2",
+    "version": "5.2.13-2"
+  },
+  {
+    "name": "libgweather-3-15",
+    "version": "3.28.2-1~ubuntu18.04.1"
+  },
+  {
+    "name": "libgweather-common",
+    "version": "3.28.2-1~ubuntu18.04.1"
+  },
+  {
+    "name": "libgxps2",
+    "version": "0.3.0-2"
+  },
+  {
+    "name": "libharfbuzz-icu0",
+    "version": "1.7.2-1ubuntu1"
+  },
+  {
+    "name": "libharfbuzz0b",
+    "version": "1.7.2-1ubuntu1"
+  },
+  {
+    "name": "libhcrypto4-heimdal",
+    "version": "7.5.0+dfsg-1"
+  },
+  {
+    "name": "libheimbase1-heimdal",
+    "version": "7.5.0+dfsg-1"
+  },
+  {
+    "name": "libheimntlm0-heimdal",
+    "version": "7.5.0+dfsg-1"
+  },
+  {
+    "name": "libhogweed4",
+    "version": "3.4.1-0ubuntu0.18.04.1"
+  },
+  {
+    "name": "libhpmud0",
+    "version": "3.17.10+repack0-5"
+  },
+  {
+    "name": "libhtml-form-perl",
+    "version": "6.03-1"
+  },
+  {
+    "name": "libhtml-parser-perl",
+    "version": "3.72-3build1"
+  },
+  {
+    "name": "libhtml-tagset-perl",
+    "version": "3.20-3"
+  },
+  {
+    "name": "libhtml-tree-perl",
+    "version": "5.07-1"
+  },
+  {
+    "name": "libhttp-cookies-perl",
+    "version": "6.04-1"
+  },
+  {
+    "name": "libhttp-daemon-perl",
+    "version": "6.01-1"
+  },
+  {
+    "name": "libhttp-date-perl",
+    "version": "6.02-1"
+  },
+  {
+    "name": "libhttp-message-perl",
+    "version": "6.14-1"
+  },
+  {
+    "name": "libhttp-negotiate-perl",
+    "version": "6.00-2"
+  },
+  {
+    "name": "libhunspell-1.6-0",
+    "version": "1.6.2-1"
+  },
+  {
+    "name": "libhx509-5-heimdal",
+    "version": "7.5.0+dfsg-1"
+  },
+  {
+    "name": "libhyphen0",
+    "version": "2.8.8-5"
+  },
+  {
+    "name": "libibus-1.0-5",
+    "version": "1.5.17-3ubuntu5.3"
+  },
+  {
+    "name": "libical3",
+    "version": "3.0.1-5"
+  },
+  {
+    "name": "libice6",
+    "version": "2:1.0.9-2"
+  },
+  {
+    "name": "libicu60",
+    "version": "60.2-3ubuntu3.1"
+  },
+  {
+    "name": "libidn11",
+    "version": "1.33-2.1ubuntu1.2"
+  },
+  {
+    "name": "libidn2-0",
+    "version": "2.0.4-1.1ubuntu0.2"
+  },
+  {
+    "name": "libiec61883-0",
+    "version": "1.2.0-2"
+  },
+  {
+    "name": "libieee1284-3",
+    "version": "0.2.11-13"
+  },
+  {
+    "name": "libijs-0.35",
+    "version": "0.35-13"
+  },
+  {
+    "name": "libilmbase12",
+    "version": "2.2.0-11ubuntu2"
+  },
+  {
+    "name": "libimobiledevice6",
+    "version": "1.2.1~git20171128.5a854327+dfsg-0.1"
+  },
+  {
+    "name": "libindicator3-7",
+    "version": "16.10.0+18.04.20180321.1-0ubuntu1"
+  },
+  {
+    "name": "libinput-bin",
+    "version": "1.10.4-1ubuntu0.18.04.2"
+  },
+  {
+    "name": "libinput10",
+    "version": "1.10.4-1ubuntu0.18.04.2"
+  },
+  {
+    "name": "libio-pty-perl",
+    "version": "1:1.08-1.1build4"
+  },
+  {
+    "name": "libio-socket-inet6-perl",
+    "version": "2.72-2"
+  },
+  {
+    "name": "libio-socket-ssl-perl",
+    "version": "2.060-3~ubuntu18.04.1"
+  },
+  {
+    "name": "libio-string-perl",
+    "version": "1.08-3"
+  },
+  {
+    "name": "libip4tc0",
+    "version": "1.6.1-2ubuntu2"
+  },
+  {
+    "name": "libip6tc0",
+    "version": "1.6.1-2ubuntu2"
+  },
+  {
+    "name": "libipc-run-perl",
+    "version": "0.96-1"
+  },
+  {
+    "name": "libipc-system-simple-perl",
+    "version": "1.25-4"
+  },
+  {
+    "name": "libiptc0",
+    "version": "1.6.1-2ubuntu2"
+  },
+  {
+    "name": "libirs160",
+    "version": "1:9.11.3+dfsg-1ubuntu1.15"
+  },
+  {
+    "name": "libisc-export169",
+    "version": "1:9.11.3+dfsg-1ubuntu1.15"
+  },
+  {
+    "name": "libisc169",
+    "version": "1:9.11.3+dfsg-1ubuntu1.15"
+  },
+  {
+    "name": "libisccc160",
+    "version": "1:9.11.3+dfsg-1ubuntu1.15"
+  },
+  {
+    "name": "libisccfg160",
+    "version": "1:9.11.3+dfsg-1ubuntu1.15"
+  },
+  {
+    "name": "libisl19",
+    "version": "0.19-1"
+  },
+  {
+    "name": "libiw30",
+    "version": "30~pre9-12ubuntu1"
+  },
+  {
+    "name": "libjack-jackd2-0",
+    "version": "1.9.12~dfsg-2"
+  },
+  {
+    "name": "libjansson4",
+    "version": "2.11-1"
+  },
+  {
+    "name": "libjavascriptcoregtk-4.0-18",
+    "version": "2.32.3-0ubuntu0.18.04.1"
+  },
+  {
+    "name": "libjbig2dec0",
+    "version": "0.13-6"
+  },
+  {
+    "name": "libjpeg-turbo8",
+    "version": "1.5.2-0ubuntu5.18.04.4"
+  },
+  {
+    "name": "libjson-c3",
+    "version": "0.12.1-1.3ubuntu0.3"
+  },
+  {
+    "name": "libjson-glib-1.0-0",
+    "version": "1.4.2-3ubuntu0.18.04.1"
+  },
+  {
+    "name": "libjson-glib-1.0-common",
+    "version": "1.4.2-3ubuntu0.18.04.1"
+  },
+  {
+    "name": "libk5crypto3",
+    "version": "1.16-2ubuntu0.2"
+  },
+  {
+    "name": "libkeyutils1",
+    "version": "1.5.9-9.2ubuntu2"
+  },
+  {
+    "name": "libklibc",
+    "version": "2.0.4-9ubuntu2"
+  },
+  {
+    "name": "libkmod2",
+    "version": "24-1ubuntu3.5"
+  },
+  {
+    "name": "libkpathsea6",
+    "version": "2017.20170613.44572-8ubuntu0.1"
+  },
+  {
+    "name": "libkrb5-26-heimdal",
+    "version": "7.5.0+dfsg-1"
+  },
+  {
+    "name": "libkrb5-3",
+    "version": "1.16-2ubuntu0.2"
+  },
+  {
+    "name": "libkrb5support0",
+    "version": "1.16-2ubuntu0.2"
+  },
+  {
+    "name": "liblangtag-common",
+    "version": "0.6.2-1"
+  },
+  {
+    "name": "liblangtag1",
+    "version": "0.6.2-1"
+  },
+  {
+    "name": "liblcms2-2",
+    "version": "2.9-1ubuntu0.1"
+  },
+  {
+    "name": "liblcms2-utils",
+    "version": "2.9-1ubuntu0.1"
+  },
+  {
+    "name": "libldap-2.4-2",
+    "version": "2.4.45+dfsg-1ubuntu1.10"
+  },
+  {
+    "name": "libldap-common",
+    "version": "2.4.45+dfsg-1ubuntu1.10"
+  },
+  {
+    "name": "libldb1",
+    "version": "2:1.2.3-1ubuntu0.2"
+  },
+  {
+    "name": "liblirc-client0",
+    "version": "0.10.0-2"
+  },
+  {
+    "name": "liblist-moreutils-perl",
+    "version": "0.416-1build3"
+  },
+  {
+    "name": "libllvm10",
+    "version": "1:10.0.0-4ubuntu1~18.04.2"
+  },
+  {
+    "name": "libllvm6.0",
+    "version": "1:6.0-1ubuntu2"
+  },
+  {
+    "name": "liblocale-gettext-perl",
+    "version": "1.07-3build2"
+  },
+  {
+    "name": "liblouis-data",
+    "version": "3.5.0-1ubuntu0.3"
+  },
+  {
+    "name": "liblouis14",
+    "version": "3.5.0-1ubuntu0.3"
+  },
+  {
+    "name": "liblouisutdml-bin",
+    "version": "2.7.0-1"
+  },
+  {
+    "name": "liblouisutdml-data",
+    "version": "2.7.0-1"
+  },
+  {
+    "name": "liblouisutdml8",
+    "version": "2.7.0-1"
+  },
+  {
+    "name": "liblqr-1-0",
+    "version": "0.4.2-2.1"
+  },
+  {
+    "name": "libltdl7",
+    "version": "2.4.6-2"
+  },
+  {
+    "name": "liblua5.3-0",
+    "version": "5.3.3-1ubuntu0.18.04.1"
+  },
+  {
+    "name": "liblwp-mediatypes-perl",
+    "version": "6.02-1"
+  },
+  {
+    "name": "liblwp-protocol-https-perl",
+    "version": "6.07-2"
+  },
+  {
+    "name": "liblwres160",
+    "version": "1:9.11.3+dfsg-1ubuntu1.15"
+  },
+  {
+    "name": "liblz4-1",
+    "version": "0.0~r131-2ubuntu3.1"
+  },
+  {
+    "name": "liblzma5",
+    "version": "5.2.2-1.3"
+  },
+  {
+    "name": "liblzo2-2",
+    "version": "2.08-1.2"
+  },
+  {
+    "name": "libmagic-mgc",
+    "version": "1:5.32-2ubuntu0.4"
+  },
+  {
+    "name": "libmagic1",
+    "version": "1:5.32-2ubuntu0.4"
+  },
+  {
+    "name": "libmagickcore-6.q16-3",
+    "version": "8:6.9.7.4+dfsg-16ubuntu6.11"
+  },
+  {
+    "name": "libmagickcore-6.q16-3-extra",
+    "version": "8:6.9.7.4+dfsg-16ubuntu6.11"
+  },
+  {
+    "name": "libmagickwand-6.q16-3",
+    "version": "8:6.9.7.4+dfsg-16ubuntu6.11"
+  },
+  {
+    "name": "libmailtools-perl",
+    "version": "2.18-1"
+  },
+  {
+    "name": "libmbim-glib4",
+    "version": "1.18.0-1~ubuntu18.04.1"
+  },
+  {
+    "name": "libmbim-proxy",
+    "version": "1.18.0-1~ubuntu18.04.1"
+  },
+  {
+    "name": "libmediaart-2.0-0",
+    "version": "1.9.4-1"
+  },
+  {
+    "name": "libmm-glib0",
+    "version": "1.10.0-1~ubuntu18.04.2"
+  },
+  {
+    "name": "libmount1",
+    "version": "2.31.1-0.4ubuntu3.7"
+  },
+  {
+    "name": "libmozjs-52-0",
+    "version": "52.9.1-0ubuntu0.18.04.1"
+  },
+  {
+    "name": "libmp3lame0",
+    "version": "3.100-2"
+  },
+  {
+    "name": "libmpdec2",
+    "version": "2.4.2-1ubuntu1"
+  },
+  {
+    "name": "libmpfr6",
+    "version": "4.0.1-1"
+  },
+  {
+    "name": "libmpg123-0",
+    "version": "1.25.10-1"
+  },
+  {
+    "name": "libmspub-0.1-1",
+    "version": "0.1.4-1"
+  },
+  {
+    "name": "libmtdev1",
+    "version": "1.1.5-1ubuntu3"
+  },
+  {
+    "name": "libmtp-common",
+    "version": "1.1.13-1"
+  },
+  {
+    "name": "libmtp-runtime",
+    "version": "1.1.13-1"
+  },
+  {
+    "name": "libmtp9",
+    "version": "1.1.13-1"
+  },
+  {
+    "name": "libmutter-2-0",
+    "version": "3.28.4+git20200505-0ubuntu18.04.2"
+  },
+  {
+    "name": "libnautilus-extension1a",
+    "version": "1:3.26.4-0~ubuntu18.04.5"
+  },
+  {
+    "name": "libncurses5",
+    "version": "6.1-1ubuntu1.18.04"
+  },
+  {
+    "name": "libncursesw5",
+    "version": "6.1-1ubuntu1.18.04"
+  },
+  {
+    "name": "libndp0",
+    "version": "1.6-1"
+  },
+  {
+    "name": "libnet-dbus-perl",
+    "version": "1.1.0-4build2"
+  },
+  {
+    "name": "libnet-dns-perl",
+    "version": "1.10-2"
+  },
+  {
+    "name": "libnet-domain-tld-perl",
+    "version": "1.75-1"
+  },
+  {
+    "name": "libnet-http-perl",
+    "version": "6.17-1"
+  },
+  {
+    "name": "libnet-ip-perl",
+    "version": "1.26-1"
+  },
+  {
+    "name": "libnet-libidn-perl",
+    "version": "0.12.ds-2build4"
+  },
+  {
+    "name": "libnet-ssleay-perl",
+    "version": "1.84-1ubuntu0.2"
+  },
+  {
+    "name": "libnetfilter-conntrack3",
+    "version": "1.0.6-2"
+  },
+  {
+    "name": "libnetpbm10",
+    "version": "2:10.0-15.3build1"
+  },
+  {
+    "name": "libnetplan0",
+    "version": "0.99-0ubuntu3~18.04.4"
+  },
+  {
+    "name": "libnettle6",
+    "version": "3.4.1-0ubuntu0.18.04.1"
+  },
+  {
+    "name": "libnewt0.52",
+    "version": "0.52.20-1ubuntu1"
+  },
+  {
+    "name": "libnfnetlink0",
+    "version": "1.0.1-3"
+  },
+  {
+    "name": "libnghttp2-14",
+    "version": "1.30.0-1ubuntu1"
+  },
+  {
+    "name": "libnih1",
+    "version": "1.0.3-6ubuntu2"
+  },
+  {
+    "name": "libnl-3-200",
+    "version": "3.2.29-0ubuntu3"
+  },
+  {
+    "name": "libnl-genl-3-200",
+    "version": "3.2.29-0ubuntu3"
+  },
+  {
+    "name": "libnm0",
+    "version": "1.10.6-2ubuntu1.4"
+  },
+  {
+    "name": "libnma0",
+    "version": "1.8.10-2ubuntu3"
+  },
+  {
+    "name": "libnotify-bin",
+    "version": "0.7.7-3"
+  },
+  {
+    "name": "libnotify4",
+    "version": "0.7.7-3"
+  },
+  {
+    "name": "libnpth0",
+    "version": "1.5-3"
+  },
+  {
+    "name": "libnspr4",
+    "version": "2:4.18-1ubuntu1"
+  },
+  {
+    "name": "libnss-mdns",
+    "version": "0.10-8ubuntu1"
+  },
+  {
+    "name": "libnss-myhostname",
+    "version": "237-3ubuntu10.52"
+  },
+  {
+    "name": "libnss-systemd",
+    "version": "237-3ubuntu10.52"
+  },
+  {
+    "name": "libnss3",
+    "version": "2:3.35-2ubuntu2.12"
+  },
+  {
+    "name": "libntfs-3g88",
+    "version": "1:2017.3.23-2ubuntu0.18.04.3"
+  },
+  {
+    "name": "libnuma1",
+    "version": "2.0.11-2.1ubuntu0.1"
+  },
+  {
+    "name": "liboauth0",
+    "version": "1.0.3-1"
+  },
+  {
+    "name": "libodfgen-0.1-1",
+    "version": "0.1.6-2"
+  },
+  {
+    "name": "libogg0",
+    "version": "1.3.2-1"
+  },
+  {
+    "name": "libopenexr22",
+    "version": "2.2.0-11.1ubuntu1.7"
+  },
+  {
+    "name": "libopenscap8",
+    "version": "1.2.15-1build1"
+  },
+  {
+    "name": "libopus0",
+    "version": "1.1.2-1ubuntu1"
+  },
+  {
+    "name": "liborc-0.4-0",
+    "version": "1:0.4.28-1"
+  },
+  {
+    "name": "libp11-kit0",
+    "version": "0.23.9-2ubuntu0.1"
+  },
+  {
+    "name": "libpackagekit-glib2-18",
+    "version": "1.1.9-1ubuntu2.18.04.6"
+  },
+  {
+    "name": "libpam-cap",
+    "version": "1:2.25-1.2"
+  },
+  {
+    "name": "libpam-gnome-keyring",
+    "version": "3.28.0.2-1ubuntu1.18.04.1"
+  },
+  {
+    "name": "libpam-modules",
+    "version": "1.1.8-3.6ubuntu2.18.04.3"
+  },
+  {
+    "name": "libpam-modules-bin",
+    "version": "1.1.8-3.6ubuntu2.18.04.3"
+  },
+  {
+    "name": "libpam-runtime",
+    "version": "1.1.8-3.6ubuntu2.18.04.3"
+  },
+  {
+    "name": "libpam-systemd",
+    "version": "237-3ubuntu10.52"
+  },
+  {
+    "name": "libpam0g",
+    "version": "1.1.8-3.6ubuntu2.18.04.3"
+  },
+  {
+    "name": "libpango-1.0-0",
+    "version": "1.40.14-1ubuntu0.1"
+  },
+  {
+    "name": "libpangocairo-1.0-0",
+    "version": "1.40.14-1ubuntu0.1"
+  },
+  {
+    "name": "libpangoft2-1.0-0",
+    "version": "1.40.14-1ubuntu0.1"
+  },
+  {
+    "name": "libpangoxft-1.0-0",
+    "version": "1.40.14-1ubuntu0.1"
+  },
+  {
+    "name": "libpaper-utils",
+    "version": "1.1.24+nmu5ubuntu1"
+  },
+  {
+    "name": "libpaper1",
+    "version": "1.1.24+nmu5ubuntu1"
+  },
+  {
+    "name": "libparse-debianchangelog-perl",
+    "version": "1.2.0-12"
+  },
+  {
+    "name": "libparted-fs-resize0",
+    "version": "3.2-20ubuntu0.2"
+  },
+  {
+    "name": "libparted2",
+    "version": "3.2-20ubuntu0.2"
+  },
+  {
+    "name": "libpcap0.8",
+    "version": "1.8.1-6ubuntu1.18.04.2"
+  },
+  {
+    "name": "libpcaudio0",
+    "version": "1.0-1"
+  },
+  {
+    "name": "libpci3",
+    "version": "1:3.5.2-1ubuntu1.1"
+  },
+  {
+    "name": "libpciaccess0",
+    "version": "0.14-1"
+  },
+  {
+    "name": "libpcre3",
+    "version": "2:8.39-9"
+  },
+  {
+    "name": "libpcsclite1",
+    "version": "1.8.23-1"
+  },
+  {
+    "name": "libpeas-1.0-0",
+    "version": "1.22.0-2"
+  },
+  {
+    "name": "libpeas-common",
+    "version": "1.22.0-2"
+  },
+  {
+    "name": "libperl5.26",
+    "version": "5.26.1-6ubuntu0.5"
+  },
+  {
+    "name": "libperlio-gzip-perl",
+    "version": "0.19-1build3"
+  },
+  {
+    "name": "libphonenumber7",
+    "version": "7.1.0-5ubuntu5"
+  },
+  {
+    "name": "libpipeline1",
+    "version": "1.5.0-1"
+  },
+  {
+    "name": "libpixman-1-0",
+    "version": "0.34.0-2"
+  },
+  {
+    "name": "libplist3",
+    "version": "2.0.0-2ubuntu1"
+  },
+  {
+    "name": "libplymouth4",
+    "version": "0.9.3-1ubuntu7.18.04.2"
+  },
+  {
+    "name": "libpng16-16",
+    "version": "1.6.34-1ubuntu0.18.04.2"
+  },
+  {
+    "name": "libpolkit-agent-1-0",
+    "version": "0.105-20ubuntu0.18.04.5"
+  },
+  {
+    "name": "libpolkit-backend-1-0",
+    "version": "0.105-20ubuntu0.18.04.5"
+  },
+  {
+    "name": "libpolkit-gobject-1-0",
+    "version": "0.105-20ubuntu0.18.04.5"
+  },
+  {
+    "name": "libpoppler-glib8",
+    "version": "0.62.0-2ubuntu2.12"
+  },
+  {
+    "name": "libpoppler73",
+    "version": "0.62.0-2ubuntu2.12"
+  },
+  {
+    "name": "libpopt0",
+    "version": "1.16-11"
+  },
+  {
+    "name": "libprocps6",
+    "version": "2:3.3.12-3ubuntu1.2"
+  },
+  {
+    "name": "libprotobuf10",
+    "version": "3.0.0-9.1ubuntu1"
+  },
+  {
+    "name": "libproxy1-plugin-gsettings",
+    "version": "0.4.15-1ubuntu0.2"
+  },
+  {
+    "name": "libproxy1-plugin-networkmanager",
+    "version": "0.4.15-1ubuntu0.2"
+  },
+  {
+    "name": "libproxy1v5",
+    "version": "0.4.15-1ubuntu0.2"
+  },
+  {
+    "name": "libpsl5",
+    "version": "0.19.1-5build1"
+  },
+  {
+    "name": "libpulse-mainloop-glib0",
+    "version": "1:11.1-1ubuntu7.11"
+  },
+  {
+    "name": "libpulse0",
+    "version": "1:11.1-1ubuntu7.11"
+  },
+  {
+    "name": "libpulsedsp",
+    "version": "1:11.1-1ubuntu7.11"
+  },
+  {
+    "name": "libpwquality-common",
+    "version": "1.4.0-2"
+  },
+  {
+    "name": "libpwquality1",
+    "version": "1.4.0-2"
+  },
+  {
+    "name": "libpython2.7",
+    "version": "2.7.17-1~18.04ubuntu1.6"
+  },
+  {
+    "name": "libpython2.7-minimal",
+    "version": "2.7.17-1~18.04ubuntu1.6"
+  },
+  {
+    "name": "libpython2.7-stdlib",
+    "version": "2.7.17-1~18.04ubuntu1.6"
+  },
+  {
+    "name": "libpython3-stdlib",
+    "version": "3.6.7-1~18.04"
+  },
+  {
+    "name": "libpython3.6",
+    "version": "3.6.9-1~18.04ubuntu1.4"
+  },
+  {
+    "name": "libpython3.6-minimal",
+    "version": "3.6.9-1~18.04ubuntu1.4"
+  },
+  {
+    "name": "libpython3.6-stdlib",
+    "version": "3.6.9-1~18.04ubuntu1.4"
+  },
+  {
+    "name": "libqmi-glib5",
+    "version": "1.22.0-1.2~ubuntu18.04.1"
+  },
+  {
+    "name": "libqmi-proxy",
+    "version": "1.22.0-1.2~ubuntu18.04.1"
+  },
+  {
+    "name": "libqpdf21",
+    "version": "8.0.2-3ubuntu0.1"
+  },
+  {
+    "name": "libqqwing2v5",
+    "version": "1.3.4-1.1"
+  },
+  {
+    "name": "libraw16",
+    "version": "0.18.8-1ubuntu0.3"
+  },
+  {
+    "name": "libreadline7",
+    "version": "7.0-3"
+  },
+  {
+    "name": "librest-0.7-0",
+    "version": "0.8.0-2"
+  },
+  {
+    "name": "librevenge-0.0-0",
+    "version": "0.0.4-6ubuntu2"
+  },
+  {
+    "name": "libroken18-heimdal",
+    "version": "7.5.0+dfsg-1"
+  },
+  {
+    "name": "librsvg2-2",
+    "version": "2.40.20-2ubuntu0.2"
+  },
+  {
+    "name": "librsvg2-common",
+    "version": "2.40.20-2ubuntu0.2"
+  },
+  {
+    "name": "librtmp1",
+    "version": "2.4+20151223.gitfa8646d.1-1"
+  },
+  {
+    "name": "libsamplerate0",
+    "version": "0.1.9-1"
+  },
+  {
+    "name": "libsane-common",
+    "version": "1.0.27-1~experimental3ubuntu2.4"
+  },
+  {
+    "name": "libsane-hpaio",
+    "version": "3.17.10+repack0-5"
+  },
+  {
+    "name": "libsane1",
+    "version": "1.0.27-1~experimental3ubuntu2.4"
+  },
+  {
+    "name": "libsasl2-2",
+    "version": "2.1.27~101-g0780600+dfsg-3ubuntu2.3"
+  },
+  {
+    "name": "libsasl2-modules",
+    "version": "2.1.27~101-g0780600+dfsg-3ubuntu2.3"
+  },
+  {
+    "name": "libsasl2-modules-db",
+    "version": "2.1.27~101-g0780600+dfsg-3ubuntu2.3"
+  },
+  {
+    "name": "libsbc1",
+    "version": "1.3-2"
+  },
+  {
+    "name": "libseccomp2",
+    "version": "2.5.1-1ubuntu1~18.04.1"
+  },
+  {
+    "name": "libsecret-1-0",
+    "version": "0.18.6-1"
+  },
+  {
+    "name": "libsecret-common",
+    "version": "0.18.6-1"
+  },
+  {
+    "name": "libselinux1",
+    "version": "2.7-2build2"
+  },
+  {
+    "name": "libsemanage-common",
+    "version": "2.7-2build2"
+  },
+  {
+    "name": "libsemanage1",
+    "version": "2.7-2build2"
+  },
+  {
+    "name": "libsensors4",
+    "version": "1:3.4.0-4"
+  },
+  {
+    "name": "libsepol1",
+    "version": "2.7-1"
+  },
+  {
+    "name": "libsgutils2-2",
+    "version": "1.42-2ubuntu1.18.04.2"
+  },
+  {
+    "name": "libshout3",
+    "version": "2.4.1-2build1"
+  },
+  {
+    "name": "libslang2",
+    "version": "2.3.1a-3ubuntu1"
+  },
+  {
+    "name": "libsm6",
+    "version": "2:1.2.2-1"
+  },
+  {
+    "name": "libsmartcols1",
+    "version": "2.31.1-0.4ubuntu3.7"
+  },
+  {
+    "name": "libsmbclient",
+    "version": "2:4.7.6+dfsg~ubuntu-0ubuntu2.23"
+  },
+  {
+    "name": "libsmbios-c2",
+    "version": "2.4.1-1"
+  },
+  {
+    "name": "libsnapd-glib1",
+    "version": "1.58-0ubuntu0.18.04.0"
+  },
+  {
+    "name": "libsndfile1",
+    "version": "1.0.28-4ubuntu0.18.04.2"
+  },
+  {
+    "name": "libsnmp-base",
+    "version": "5.7.3+dfsg-1.8ubuntu3.6"
+  },
+  {
+    "name": "libsnmp30",
+    "version": "5.7.3+dfsg-1.8ubuntu3.6"
+  },
+  {
+    "name": "libsocket6-perl",
+    "version": "0.27-1build2"
+  },
+  {
+    "name": "libsodium23",
+    "version": "1.0.16-2"
+  },
+  {
+    "name": "libsonic0",
+    "version": "0.2.0-6"
+  },
+  {
+    "name": "libsoup-gnome2.4-1",
+    "version": "2.62.1-1ubuntu0.4"
+  },
+  {
+    "name": "libsoup2.4-1",
+    "version": "2.62.1-1ubuntu0.4"
+  },
+  {
+    "name": "libspectre1",
+    "version": "0.2.8-1"
+  },
+  {
+    "name": "libspeechd2",
+    "version": "0.8.8-1ubuntu1"
+  },
+  {
+    "name": "libspeex1",
+    "version": "1.2~rc1.2-1ubuntu2"
+  },
+  {
+    "name": "libspeexdsp1",
+    "version": "1.2~rc1.2-1ubuntu2"
+  },
+  {
+    "name": "libsqlite3-0",
+    "version": "3.22.0-1ubuntu0.4"
+  },
+  {
+    "name": "libss2",
+    "version": "1.44.1-1ubuntu1.3"
+  },
+  {
+    "name": "libssh-4",
+    "version": "0.8.0~20170825.94fa1e38-1ubuntu0.7"
+  },
+  {
+    "name": "libssl1.0.0",
+    "version": "1.0.2n-1ubuntu5.7"
+  },
+  {
+    "name": "libssl1.1",
+    "version": "1.1.1-1ubuntu2.1~18.04.13"
+  },
+  {
+    "name": "libstartup-notification0",
+    "version": "0.12-5"
+  },
+  {
+    "name": "libstdc++6",
+    "version": "8.4.0-1ubuntu1~18.04"
+  },
+  {
+    "name": "libstemmer0d",
+    "version": "0+svn585-1build1"
+  },
+  {
+    "name": "libsub-name-perl",
+    "version": "0.21-1build1"
+  },
+  {
+    "name": "libsuitesparseconfig5",
+    "version": "1:5.1.2-2"
+  },
+  {
+    "name": "libsysmetrics1",
+    "version": "1.3.2"
+  },
+  {
+    "name": "libsystemd0",
+    "version": "237-3ubuntu10.52"
+  },
+  {
+    "name": "libtag1v5",
+    "version": "1.11.1+dfsg.1-0.2build2"
+  },
+  {
+    "name": "libtag1v5-vanilla",
+    "version": "1.11.1+dfsg.1-0.2build2"
+  },
+  {
+    "name": "libtalloc2",
+    "version": "2.1.10-2ubuntu1"
+  },
+  {
+    "name": "libtasn1-6",
+    "version": "4.13-2"
+  },
+  {
+    "name": "libtdb1",
+    "version": "1.3.15-2"
+  },
+  {
+    "name": "libteamdctl0",
+    "version": "1.26-1"
+  },
+  {
+    "name": "libtevent0",
+    "version": "0.9.34-1"
+  },
+  {
+    "name": "libtext-charwidth-perl",
+    "version": "0.04-7.1"
+  },
+  {
+    "name": "libtext-iconv-perl",
+    "version": "1.7-5build6"
+  },
+  {
+    "name": "libtext-levenshtein-perl",
+    "version": "0.13-1"
+  },
+  {
+    "name": "libtext-wrapi18n-perl",
+    "version": "0.06-7.1"
+  },
+  {
+    "name": "libthai-data",
+    "version": "0.1.27-2"
+  },
+  {
+    "name": "libthai0",
+    "version": "0.1.27-2"
+  },
+  {
+    "name": "libtheora0",
+    "version": "1.1.1+dfsg.1-14"
+  },
+  {
+    "name": "libtiff5",
+    "version": "4.0.9-5ubuntu0.4"
+  },
+  {
+    "name": "libtimedate-perl",
+    "version": "2.3000-2"
+  },
+  {
+    "name": "libtinfo5",
+    "version": "6.1-1ubuntu1.18.04"
+  },
+  {
+    "name": "libtotem-plparser-common",
+    "version": "3.26.0-1ubuntu2"
+  },
+  {
+    "name": "libtotem-plparser18",
+    "version": "3.26.0-1ubuntu2"
+  },
+  {
+    "name": "libtracker-sparql-2.0-0",
+    "version": "2.0.3-1ubuntu4"
+  },
+  {
+    "name": "libtwolame0",
+    "version": "0.3.13-3"
+  },
+  {
+    "name": "libu2f-udev",
+    "version": "1.1.4-1ubuntu0.1"
+  },
+  {
+    "name": "libudev1",
+    "version": "237-3ubuntu10.52"
+  },
+  {
+    "name": "libudisks2-0",
+    "version": "2.7.6-3ubuntu0.2"
+  },
+  {
+    "name": "libunistring2",
+    "version": "0.9.9-0ubuntu2"
+  },
+  {
+    "name": "libunity-protocol-private0",
+    "version": "7.1.4+18.04.20180209.1-0ubuntu2"
+  },
+  {
+    "name": "libunity-scopes-json-def-desktop",
+    "version": "7.1.4+18.04.20180209.1-0ubuntu2"
+  },
+  {
+    "name": "libunity9",
+    "version": "7.1.4+18.04.20180209.1-0ubuntu2"
+  },
+  {
+    "name": "libunwind8",
+    "version": "1.2.1-8"
+  },
+  {
+    "name": "libupower-glib3",
+    "version": "0.99.7-2ubuntu0.18.04.1"
+  },
+  {
+    "name": "liburi-perl",
+    "version": "1.73-1"
+  },
+  {
+    "name": "libusb-1.0-0",
+    "version": "2:1.0.21-2"
+  },
+  {
+    "name": "libusbmuxd4",
+    "version": "1.1.0~git20171206.c724e70f-0.1"
+  },
+  {
+    "name": "libuuid1",
+    "version": "2.31.1-0.4ubuntu3.7"
+  },
+  {
+    "name": "libv4l-0",
+    "version": "1.14.2-1"
+  },
+  {
+    "name": "libv4lconvert0",
+    "version": "1.14.2-1"
+  },
+  {
+    "name": "libvisual-0.4-0",
+    "version": "0.4.0-11"
+  },
+  {
+    "name": "libvncclient1",
+    "version": "0.9.11+dfsg-1ubuntu1.4"
+  },
+  {
+    "name": "libvolume-key1",
+    "version": "0.3.9-4"
+  },
+  {
+    "name": "libvorbis0a",
+    "version": "1.3.5-4.2"
+  },
+  {
+    "name": "libvorbisenc2",
+    "version": "1.3.5-4.2"
+  },
+  {
+    "name": "libvorbisfile3",
+    "version": "1.3.5-4.2"
+  },
+  {
+    "name": "libvpx5",
+    "version": "1.7.0-3ubuntu0.18.04.1"
+  },
+  {
+    "name": "libvte-2.91-0",
+    "version": "0.52.2-1ubuntu1~18.04.2"
+  },
+  {
+    "name": "libvte-2.91-common",
+    "version": "0.52.2-1ubuntu1~18.04.2"
+  },
+  {
+    "name": "libwacom-bin",
+    "version": "0.29-1"
+  },
+  {
+    "name": "libwacom-common",
+    "version": "0.29-1"
+  },
+  {
+    "name": "libwacom2",
+    "version": "0.29-1"
+  },
+  {
+    "name": "libwavpack1",
+    "version": "5.1.0-2ubuntu1.5"
+  },
+  {
+    "name": "libwayland-client0",
+    "version": "1.16.0-1ubuntu1.1~18.04.3"
+  },
+  {
+    "name": "libwayland-cursor0",
+    "version": "1.16.0-1ubuntu1.1~18.04.3"
+  },
+  {
+    "name": "libwayland-egl1",
+    "version": "1.16.0-1ubuntu1.1~18.04.3"
+  },
+  {
+    "name": "libwayland-egl1-mesa",
+    "version": "20.0.8-0ubuntu1~18.04.1"
+  },
+  {
+    "name": "libwayland-server0",
+    "version": "1.16.0-1ubuntu1.1~18.04.3"
+  },
+  {
+    "name": "libwbclient0",
+    "version": "2:4.7.6+dfsg~ubuntu-0ubuntu2.23"
+  },
+  {
+    "name": "libwebkit2gtk-4.0-37",
+    "version": "2.32.3-0ubuntu0.18.04.1"
+  },
+  {
+    "name": "libwebp6",
+    "version": "0.6.1-2ubuntu0.18.04.1"
+  },
+  {
+    "name": "libwebpdemux2",
+    "version": "0.6.1-2ubuntu0.18.04.1"
+  },
+  {
+    "name": "libwebpmux3",
+    "version": "0.6.1-2ubuntu0.18.04.1"
+  },
+  {
+    "name": "libwebrtc-audio-processing1",
+    "version": "0.3-1"
+  },
+  {
+    "name": "libwhoopsie-preferences0",
+    "version": "0.19"
+  },
+  {
+    "name": "libwhoopsie0",
+    "version": "0.2.62ubuntu0.6"
+  },
+  {
+    "name": "libwind0-heimdal",
+    "version": "7.5.0+dfsg-1"
+  },
+  {
+    "name": "libwinpr2-2",
+    "version": "2.2.0+dfsg1-0ubuntu0.18.04.1"
+  },
+  {
+    "name": "libwmf0.2-7",
+    "version": "0.2.8.4-12"
+  },
+  {
+    "name": "libwmf0.2-7-gtk",
+    "version": "0.2.8.4-12"
+  },
+  {
+    "name": "libwnck-3-0",
+    "version": "3.24.1-2"
+  },
+  {
+    "name": "libwnck-3-common",
+    "version": "3.24.1-2"
+  },
+  {
+    "name": "libwoff1",
+    "version": "1.0.2-1build0.1"
+  },
+  {
+    "name": "libwrap0",
+    "version": "7.6.q-27"
+  },
+  {
+    "name": "libwww-perl",
+    "version": "6.31-1ubuntu0.1"
+  },
+  {
+    "name": "libwww-robotrules-perl",
+    "version": "6.01-1"
+  },
+  {
+    "name": "libx11-6",
+    "version": "2:1.6.4-3ubuntu0.4"
+  },
+  {
+    "name": "libx11-data",
+    "version": "2:1.6.4-3ubuntu0.4"
+  },
+  {
+    "name": "libx11-xcb1",
+    "version": "2:1.6.4-3ubuntu0.4"
+  },
+  {
+    "name": "libxapian30",
+    "version": "1.4.5-1ubuntu0.1"
+  },
+  {
+    "name": "libxatracker2",
+    "version": "20.0.8-0ubuntu1~18.04.1"
+  },
+  {
+    "name": "libxau6",
+    "version": "1:1.0.8-1ubuntu1"
+  },
+  {
+    "name": "libxcb-dri2-0",
+    "version": "1.13-2~ubuntu18.04"
+  },
+  {
+    "name": "libxcb-dri3-0",
+    "version": "1.13-2~ubuntu18.04"
+  },
+  {
+    "name": "libxcb-glx0",
+    "version": "1.13-2~ubuntu18.04"
+  },
+  {
+    "name": "libxcb-icccm4",
+    "version": "0.4.1-1ubuntu1"
+  },
+  {
+    "name": "libxcb-keysyms1",
+    "version": "0.4.0-1"
+  },
+  {
+    "name": "libxcb-present0",
+    "version": "1.13-2~ubuntu18.04"
+  },
+  {
+    "name": "libxcb-randr0",
+    "version": "1.13-2~ubuntu18.04"
+  },
+  {
+    "name": "libxcb-render-util0",
+    "version": "0.3.9-1"
+  },
+  {
+    "name": "libxcb-render0",
+    "version": "1.13-2~ubuntu18.04"
+  },
+  {
+    "name": "libxcb-res0",
+    "version": "1.13-2~ubuntu18.04"
+  },
+  {
+    "name": "libxcb-shape0",
+    "version": "1.13-2~ubuntu18.04"
+  },
+  {
+    "name": "libxcb-shm0",
+    "version": "1.13-2~ubuntu18.04"
+  },
+  {
+    "name": "libxcb-sync1",
+    "version": "1.13-2~ubuntu18.04"
+  },
+  {
+    "name": "libxcb-xfixes0",
+    "version": "1.13-2~ubuntu18.04"
+  },
+  {
+    "name": "libxcb-xkb1",
+    "version": "1.13-2~ubuntu18.04"
+  },
+  {
+    "name": "libxcb-xv0",
+    "version": "1.13-2~ubuntu18.04"
+  },
+  {
+    "name": "libxcb1",
+    "version": "1.13-2~ubuntu18.04"
+  },
+  {
+    "name": "libxcomposite1",
+    "version": "1:0.4.4-2"
+  },
+  {
+    "name": "libxcursor1",
+    "version": "1:1.1.15-1"
+  },
+  {
+    "name": "libxdamage1",
+    "version": "1:1.1.4-3"
+  },
+  {
+    "name": "libxdmcp6",
+    "version": "1:1.1.2-3"
+  },
+  {
+    "name": "libxext6",
+    "version": "2:1.3.3-1"
+  },
+  {
+    "name": "libxfixes3",
+    "version": "1:5.0.3-1"
+  },
+  {
+    "name": "libxft2",
+    "version": "2.3.2-1"
+  },
+  {
+    "name": "libxi6",
+    "version": "2:1.7.9-1"
+  },
+  {
+    "name": "libxinerama1",
+    "version": "2:1.1.3-1"
+  },
+  {
+    "name": "libxkbcommon-x11-0",
+    "version": "0.8.2-1~ubuntu18.04.1"
+  },
+  {
+    "name": "libxkbcommon0",
+    "version": "0.8.2-1~ubuntu18.04.1"
+  },
+  {
+    "name": "libxkbfile1",
+    "version": "1:1.0.9-2"
+  },
+  {
+    "name": "libxklavier16",
+    "version": "5.4-3"
+  },
+  {
+    "name": "libxml-libxml-perl",
+    "version": "2.0128+dfsg-5"
+  },
+  {
+    "name": "libxml-namespacesupport-perl",
+    "version": "1.12-1"
+  },
+  {
+    "name": "libxml-parser-perl",
+    "version": "2.44-2build3"
+  },
+  {
+    "name": "libxml-sax-base-perl",
+    "version": "1.09-1"
+  },
+  {
+    "name": "libxml-sax-expat-perl",
+    "version": "0.40-2"
+  },
+  {
+    "name": "libxml-sax-perl",
+    "version": "0.99+dfsg-2ubuntu1"
+  },
+  {
+    "name": "libxml-simple-perl",
+    "version": "2.24-1"
+  },
+  {
+    "name": "libxml-twig-perl",
+    "version": "1:3.50-1"
+  },
+  {
+    "name": "libxml2",
+    "version": "2.9.4+dfsg1-6.1ubuntu1.4"
+  },
+  {
+    "name": "libxmlb1",
+    "version": "0.1.8-1~ubuntu18.04.2"
+  },
+  {
+    "name": "libxmlsec1",
+    "version": "1.2.25-1build1"
+  },
+  {
+    "name": "libxmlsec1-nss",
+    "version": "1.2.25-1build1"
+  },
+  {
+    "name": "libxmu6",
+    "version": "2:1.1.2-2"
+  },
+  {
+    "name": "libxmuu1",
+    "version": "2:1.1.2-2"
+  },
+  {
+    "name": "libxrandr2",
+    "version": "2:1.5.1-1"
+  },
+  {
+    "name": "libxres1",
+    "version": "2:1.2.0-2"
+  },
+  {
+    "name": "libxslt1.1",
+    "version": "1.1.29-5ubuntu0.2"
+  },
+  {
+    "name": "libxss1",
+    "version": "1:1.2.2-1"
+  },
+  {
+    "name": "libxtables12",
+    "version": "1.6.1-2ubuntu2"
+  },
+  {
+    "name": "libxvmc1",
+    "version": "2:1.0.10-1"
+  },
+  {
+    "name": "libxxf86dga1",
+    "version": "2:1.1.4-1"
+  },
+  {
+    "name": "libxxf86vm1",
+    "version": "1:1.1.4-1"
+  },
+  {
+    "name": "libyaml-0-2",
+    "version": "0.1.7-2ubuntu3"
+  },
+  {
+    "name": "libyaml-libyaml-perl",
+    "version": "0.69+repack-1"
+  },
+  {
+    "name": "libyelp0",
+    "version": "3.26.0-1ubuntu2"
+  },
+  {
+    "name": "libzeitgeist-2.0-0",
+    "version": "1.0-0.1ubuntu1"
+  },
+  {
+    "name": "libzstd1",
+    "version": "1.3.3+dfsg-2ubuntu1.2"
+  },
+  {
+    "name": "light-themes",
+    "version": "16.10+18.04.20181005-0ubuntu1"
+  },
+  {
+    "name": "lintian",
+    "version": "2.5.81ubuntu1"
+  },
+  {
+    "name": "linux-base",
+    "version": "4.5ubuntu1.6"
+  },
+  {
+    "name": "linux-firmware",
+    "version": "1.173.20"
+  },
+  {
+    "name": "linux-generic-hwe-18.04",
+    "version": "5.4.0.84.94~18.04.75"
+  },
+  {
+    "name": "linux-headers-5.4.0-84-generic",
+    "version": "5.4.0-84.94~18.04.1"
+  },
+  {
+    "name": "linux-headers-generic-hwe-18.04",
+    "version": "5.4.0.84.94~18.04.75"
+  },
+  {
+    "name": "linux-hwe-5.4-headers-5.4.0-84",
+    "version": "5.4.0-84.94~18.04.1"
+  },
+  {
+    "name": "linux-image-5.4.0-84-generic",
+    "version": "5.4.0-84.94~18.04.1"
+  },
+  {
+    "name": "linux-image-generic-hwe-18.04",
+    "version": "5.4.0.84.94~18.04.75"
+  },
+  {
+    "name": "linux-modules-5.4.0-84-generic",
+    "version": "5.4.0-84.94~18.04.1"
+  },
+  {
+    "name": "linux-modules-extra-5.4.0-84-generic",
+    "version": "5.4.0-84.94~18.04.1"
+  },
+  {
+    "name": "locales",
+    "version": "2.27-3ubuntu1.4"
+  },
+  {
+    "name": "login",
+    "version": "1:4.5-1ubuntu2"
+  },
+  {
+    "name": "logrotate",
+    "version": "3.11.0-0.1ubuntu1"
+  },
+  {
+    "name": "lp-solve",
+    "version": "5.5.0.15-4build1"
+  },
+  {
+    "name": "lsb-base",
+    "version": "9.20170808ubuntu1"
+  },
+  {
+    "name": "lsb-release",
+    "version": "9.20170808ubuntu1"
+  },
+  {
+    "name": "lshw",
+    "version": "02.18-0.1ubuntu6.18.04.2"
+  },
+  {
+    "name": "lsof",
+    "version": "4.89+dfsg-0.1"
+  },
+  {
+    "name": "ltrace",
+    "version": "0.7.3-6ubuntu1"
+  },
+  {
+    "name": "macaroonbakery",
+    "version": "1.1.3"
+  },
+  {
+    "name": "man-db",
+    "version": "2.8.3-2ubuntu0.1"
+  },
+  {
+    "name": "manpages",
+    "version": "4.15-1"
+  },
+  {
+    "name": "mawk",
+    "version": "1.3.3-17ubuntu3"
+  },
+  {
+    "name": "media-player-info",
+    "version": "23-1"
+  },
+  {
+    "name": "memtest86+",
+    "version": "5.01-3ubuntu2"
+  },
+  {
+    "name": "mime-support",
+    "version": "3.60ubuntu1"
+  },
+  {
+    "name": "mlocate",
+    "version": "0.26-2ubuntu3.1"
+  },
+  {
+    "name": "mobile-broadband-provider-info",
+    "version": "20170903-1"
+  },
+  {
+    "name": "modemmanager",
+    "version": "1.10.0-1~ubuntu18.04.2"
+  },
+  {
+    "name": "mount",
+    "version": "2.31.1-0.4ubuntu3.7"
+  },
+  {
+    "name": "mousetweaks",
+    "version": "3.12.0-4"
+  },
+  {
+    "name": "mscompress",
+    "version": "0.4-3build1"
+  },
+  {
+    "name": "mtools",
+    "version": "4.0.18-2ubuntu1"
+  },
+  {
+    "name": "mtr-tiny",
+    "version": "0.92-1"
+  },
+  {
+    "name": "multiarch-support",
+    "version": "2.27-3ubuntu1.4"
+  },
+  {
+    "name": "mutter",
+    "version": "3.28.4+git20200505-0ubuntu18.04.2"
+  },
+  {
+    "name": "mutter-common",
+    "version": "3.28.4+git20200505-0ubuntu18.04.2"
+  },
+  {
+    "name": "nano",
+    "version": "2.9.3-2"
+  },
+  {
+    "name": "nautilus",
+    "version": "1:3.26.4-0~ubuntu18.04.5"
+  },
+  {
+    "name": "nautilus-data",
+    "version": "1:3.26.4-0~ubuntu18.04.5"
+  },
+  {
+    "name": "nautilus-extension-gnome-terminal",
+    "version": "3.28.2-1ubuntu1~18.04.1"
+  },
+  {
+    "name": "nautilus-sendto",
+    "version": "3.8.6-2"
+  },
+  {
+    "name": "ncurses-base",
+    "version": "6.1-1ubuntu1.18.04"
+  },
+  {
+    "name": "ncurses-bin",
+    "version": "6.1-1ubuntu1.18.04"
+  },
+  {
+    "name": "netbase",
+    "version": "5.4"
+  },
+  {
+    "name": "netcat-openbsd",
+    "version": "1.187-1ubuntu0.1"
+  },
+  {
+    "name": "netpbm",
+    "version": "2:10.0-15.3build1"
+  },
+  {
+    "name": "netplan.io",
+    "version": "0.99-0ubuntu3~18.04.4"
+  },
+  {
+    "name": "network-manager",
+    "version": "1.10.6-2ubuntu1.4"
+  },
+  {
+    "name": "network-manager-config-connectivity-ubuntu",
+    "version": "1.10.6-2ubuntu1.4"
+  },
+  {
+    "name": "network-manager-gnome",
+    "version": "1.8.10-2ubuntu3"
+  },
+  {
+    "name": "network-manager-pptp",
+    "version": "1.2.6-1"
+  },
+  {
+    "name": "network-manager-pptp-gnome",
+    "version": "1.2.6-1"
+  },
+  {
+    "name": "networkd-dispatcher",
+    "version": "1.7-0ubuntu3.3"
+  },
+  {
+    "name": "notification-daemon",
+    "version": "3.20.0-3"
+  },
+  {
+    "name": "nplan",
+    "version": "0.99-0ubuntu3~18.04.4"
+  },
+  {
+    "name": "ntfs-3g",
+    "version": "1:2017.3.23-2ubuntu0.18.04.3"
+  },
+  {
+    "name": "oauth",
+    "version": "1.0.1"
+  },
+  {
+    "name": "olefile",
+    "version": "0.45.1"
+  },
+  {
+    "name": "openprinting-ppds",
+    "version": "20180306-1"
+  },
+  {
+    "name": "openssh-client",
+    "version": "1:7.6p1-4ubuntu0.5"
+  },
+  {
+    "name": "openssl",
+    "version": "1.1.1-1ubuntu2.1~18.04.13"
+  },
+  {
+    "name": "orca",
+    "version": "3.28.0-3ubuntu1"
+  },
+  {
+    "name": "os-prober",
+    "version": "1.74ubuntu1"
+  },
+  {
+    "name": "p11-kit",
+    "version": "0.23.9-2ubuntu0.1"
+  },
+  {
+    "name": "p11-kit-modules",
+    "version": "0.23.9-2ubuntu0.1"
+  },
+  {
+    "name": "packagekit",
+    "version": "1.1.9-1ubuntu2.18.04.6"
+  },
+  {
+    "name": "packagekit-tools",
+    "version": "1.1.9-1ubuntu2.18.04.6"
+  },
+  {
+    "name": "parted",
+    "version": "3.2-20ubuntu0.2"
+  },
+  {
+    "name": "passwd",
+    "version": "1:4.5-1ubuntu2"
+  },
+  {
+    "name": "patch",
+    "version": "2.7.6-2ubuntu1.1"
+  },
+  {
+    "name": "patchutils",
+    "version": "0.3.4-2"
+  },
+  {
+    "name": "pciutils",
+    "version": "1:3.5.2-1ubuntu1.1"
+  },
+  {
+    "name": "pcmciautils",
+    "version": "018-8build1"
+  },
+  {
+    "name": "perl",
+    "version": "5.26.1-6ubuntu0.5"
+  },
+  {
+    "name": "perl-base",
+    "version": "5.26.1-6ubuntu0.5"
+  },
+  {
+    "name": "perl-modules-5.26",
+    "version": "5.26.1-6ubuntu0.5"
+  },
+  {
+    "name": "perl-openssl-defaults",
+    "version": "3build1"
+  },
+  {
+    "name": "pinentry-curses",
+    "version": "1.1.0-1"
+  },
+  {
+    "name": "pinentry-gnome3",
+    "version": "1.1.0-1"
+  },
+  {
+    "name": "plymouth",
+    "version": "0.9.3-1ubuntu7.18.04.2"
+  },
+  {
+    "name": "plymouth-label",
+    "version": "0.9.3-1ubuntu7.18.04.2"
+  },
+  {
+    "name": "plymouth-theme-ubuntu-logo",
+    "version": "0.9.3-1ubuntu7.18.04.2"
+  },
+  {
+    "name": "plymouth-theme-ubuntu-text",
+    "version": "0.9.3-1ubuntu7.18.04.2"
+  },
+  {
+    "name": "policykit-1",
+    "version": "0.105-20ubuntu0.18.04.5"
+  },
+  {
+    "name": "policykit-desktop-privileges",
+    "version": "0.20ubuntu18.04.1"
+  },
+  {
+    "name": "poppler-data",
+    "version": "0.4.8-2"
+  },
+  {
+    "name": "poppler-utils",
+    "version": "0.62.0-2ubuntu2.12"
+  },
+  {
+    "name": "popularity-contest",
+    "version": "1.66ubuntu1"
+  },
+  {
+    "name": "powermgmt-base",
+    "version": "1.33"
+  },
+  {
+    "name": "ppp",
+    "version": "2.4.7-2+2ubuntu1.3"
+  },
+  {
+    "name": "pppconfig",
+    "version": "2.3.23"
+  },
+  {
+    "name": "pppoeconf",
+    "version": "1.21ubuntu1"
+  },
+  {
+    "name": "pptp-linux",
+    "version": "1.9.0+ds-2"
+  },
+  {
+    "name": "printer-driver-brlaser",
+    "version": "4-1"
+  },
+  {
+    "name": "printer-driver-c2esp",
+    "version": "27-4"
+  },
+  {
+    "name": "printer-driver-foo2zjs",
+    "version": "20170320dfsg0-4"
+  },
+  {
+    "name": "printer-driver-foo2zjs-common",
+    "version": "20170320dfsg0-4"
+  },
+  {
+    "name": "printer-driver-gutenprint",
+    "version": "5.2.13-2"
+  },
+  {
+    "name": "printer-driver-hpcups",
+    "version": "3.17.10+repack0-5"
+  },
+  {
+    "name": "printer-driver-m2300w",
+    "version": "0.51-13"
+  },
+  {
+    "name": "printer-driver-min12xxw",
+    "version": "0.0.9-10"
+  },
+  {
+    "name": "printer-driver-postscript-hp",
+    "version": "3.17.10+repack0-5"
+  },
+  {
+    "name": "printer-driver-sag-gdi",
+    "version": "0.1-5"
+  },
+  {
+    "name": "printer-driver-splix",
+    "version": "2.0.0+svn315-6fakesync1"
+  },
+  {
+    "name": "procps",
+    "version": "2:3.3.12-3ubuntu1.2"
+  },
+  {
+    "name": "protobuf",
+    "version": "3.0.0"
+  },
+  {
+    "name": "psmisc",
+    "version": "23.1-1ubuntu0.1"
+  },
+  {
+    "name": "publicsuffix",
+    "version": "20180223.1310-1"
+  },
+  {
+    "name": "pulseaudio",
+    "version": "1:11.1-1ubuntu7.11"
+  },
+  {
+    "name": "pulseaudio-module-bluetooth",
+    "version": "1:11.1-1ubuntu7.11"
+  },
+  {
+    "name": "pulseaudio-utils",
+    "version": "1:11.1-1ubuntu7.11"
+  },
+  {
+    "name": "pyRFC3339",
+    "version": "1.0"
+  },
+  {
+    "name": "python-apt-common",
+    "version": "1.6.5ubuntu0.7"
+  },
+  {
+    "name": "python-dateutil",
+    "version": "2.6.1"
+  },
+  {
+    "name": "python-debian",
+    "version": "0.1.32"
+  },
+  {
+    "name": "python-talloc",
+    "version": "2.1.10-2ubuntu1"
+  },
+  {
+    "name": "python3",
+    "version": "3.6.7-1~18.04"
+  },
+  {
+    "name": "python3-apport",
+    "version": "2.20.9-0ubuntu7.26"
+  },
+  {
+    "name": "python3-apt",
+    "version": "1.6.5ubuntu0.7"
+  },
+  {
+    "name": "python3-aptdaemon",
+    "version": "1.1.1+bzr982-0ubuntu19.5"
+  },
+  {
+    "name": "python3-aptdaemon.gtk3widgets",
+    "version": "1.1.1+bzr982-0ubuntu19.5"
+  },
+  {
+    "name": "python3-asn1crypto",
+    "version": "0.24.0-1"
+  },
+  {
+    "name": "python3-brlapi",
+    "version": "5.5-4ubuntu2.0.1"
+  },
+  {
+    "name": "python3-cairo",
+    "version": "1.16.2-1"
+  },
+  {
+    "name": "python3-certifi",
+    "version": "2018.1.18-2"
+  },
+  {
+    "name": "python3-cffi-backend",
+    "version": "1.11.5-1"
+  },
+  {
+    "name": "python3-chardet",
+    "version": "3.0.4-1"
+  },
+  {
+    "name": "python3-click",
+    "version": "6.7-3"
+  },
+  {
+    "name": "python3-colorama",
+    "version": "0.3.7-1"
+  },
+  {
+    "name": "python3-commandnotfound",
+    "version": "18.04.5"
+  },
+  {
+    "name": "python3-crypto",
+    "version": "2.6.1-8ubuntu2"
+  },
+  {
+    "name": "python3-cryptography",
+    "version": "2.1.4-1ubuntu1.4"
+  },
+  {
+    "name": "python3-cups",
+    "version": "1.9.73-2"
+  },
+  {
+    "name": "python3-cupshelpers",
+    "version": "1.5.11-1ubuntu2"
+  },
+  {
+    "name": "python3-dateutil",
+    "version": "2.6.1-1"
+  },
+  {
+    "name": "python3-dbus",
+    "version": "1.2.6-1"
+  },
+  {
+    "name": "python3-debconf",
+    "version": "1.5.66ubuntu1"
+  },
+  {
+    "name": "python3-debian",
+    "version": "0.1.32"
+  },
+  {
+    "name": "python3-defer",
+    "version": "1.0.6-2build1"
+  },
+  {
+    "name": "python3-distro-info",
+    "version": "0.18ubuntu0.18.04.1"
+  },
+  {
+    "name": "python3-distupgrade",
+    "version": "1:18.04.45"
+  },
+  {
+    "name": "python3-gdbm",
+    "version": "3.6.9-1~18.04"
+  },
+  {
+    "name": "python3-gi",
+    "version": "3.26.1-2ubuntu1"
+  },
+  {
+    "name": "python3-gi-cairo",
+    "version": "3.26.1-2ubuntu1"
+  },
+  {
+    "name": "python3-httplib2",
+    "version": "0.9.2+dfsg-1ubuntu0.3"
+  },
+  {
+    "name": "python3-idna",
+    "version": "2.6-1"
+  },
+  {
+    "name": "python3-keyring",
+    "version": "10.6.0-1"
+  },
+  {
+    "name": "python3-keyrings.alt",
+    "version": "3.0-1"
+  },
+  {
+    "name": "python3-launchpadlib",
+    "version": "1.10.6-1"
+  },
+  {
+    "name": "python3-lazr.restfulclient",
+    "version": "0.13.5-1"
+  },
+  {
+    "name": "python3-lazr.uri",
+    "version": "1.0.3-2build1"
+  },
+  {
+    "name": "python3-louis",
+    "version": "3.5.0-1ubuntu0.3"
+  },
+  {
+    "name": "python3-macaroonbakery",
+    "version": "1.1.3-1"
+  },
+  {
+    "name": "python3-mako",
+    "version": "1.0.7+ds1-1"
+  },
+  {
+    "name": "python3-markupsafe",
+    "version": "1.0-1build1"
+  },
+  {
+    "name": "python3-minimal",
+    "version": "3.6.7-1~18.04"
+  },
+  {
+    "name": "python3-nacl",
+    "version": "1.1.2-1build1"
+  },
+  {
+    "name": "python3-netifaces",
+    "version": "0.10.4-0.1build4"
+  },
+  {
+    "name": "python3-oauth",
+    "version": "1.0.1-5"
+  },
+  {
+    "name": "python3-olefile",
+    "version": "0.45.1-1"
+  },
+  {
+    "name": "python3-pexpect",
+    "version": "4.2.1-1"
+  },
+  {
+    "name": "python3-pil",
+    "version": "5.1.0-1ubuntu0.6"
+  },
+  {
+    "name": "python3-pkg-resources",
+    "version": "39.0.1-2"
+  },
+  {
+    "name": "python3-problem-report",
+    "version": "2.20.9-0ubuntu7.26"
+  },
+  {
+    "name": "python3-protobuf",
+    "version": "3.0.0-9.1ubuntu1"
+  },
+  {
+    "name": "python3-ptyprocess",
+    "version": "0.5.2-1"
+  },
+  {
+    "name": "python3-pyatspi",
+    "version": "2.26.0+dfsg-1"
+  },
+  {
+    "name": "python3-pymacaroons",
+    "version": "0.13.0-1"
+  },
+  {
+    "name": "python3-renderpm",
+    "version": "3.4.0-3ubuntu0.1"
+  },
+  {
+    "name": "python3-reportlab",
+    "version": "3.4.0-3ubuntu0.1"
+  },
+  {
+    "name": "python3-reportlab-accel",
+    "version": "3.4.0-3ubuntu0.1"
+  },
+  {
+    "name": "python3-requests",
+    "version": "2.18.4-2ubuntu0.1"
+  },
+  {
+    "name": "python3-requests-unixsocket",
+    "version": "0.1.5-3"
+  },
+  {
+    "name": "python3-rfc3339",
+    "version": "1.0-4"
+  },
+  {
+    "name": "python3-secretstorage",
+    "version": "2.3.1-2"
+  },
+  {
+    "name": "python3-simplejson",
+    "version": "3.13.2-1"
+  },
+  {
+    "name": "python3-six",
+    "version": "1.11.0-2"
+  },
+  {
+    "name": "python3-software-properties",
+    "version": "0.96.24.32.14"
+  },
+  {
+    "name": "python3-speechd",
+    "version": "0.8.8-1ubuntu1"
+  },
+  {
+    "name": "python3-systemd",
+    "version": "234-1build1"
+  },
+  {
+    "name": "python3-tz",
+    "version": "2018.3-2"
+  },
+  {
+    "name": "python3-update-manager",
+    "version": "1:18.04.11.13"
+  },
+  {
+    "name": "python3-urllib3",
+    "version": "1.22-1ubuntu0.18.04.2"
+  },
+  {
+    "name": "python3-wadllib",
+    "version": "1.3.2-3ubuntu0.18.04.1"
+  },
+  {
+    "name": "python3-xdg",
+    "version": "0.25-4ubuntu1.1"
+  },
+  {
+    "name": "python3-xkit",
+    "version": "0.5.0ubuntu2"
+  },
+  {
+    "name": "python3-yaml",
+    "version": "3.12-1build2"
+  },
+  {
+    "name": "python3-zope.interface",
+    "version": "4.3.2-1build2"
+  },
+  {
+    "name": "python3.6",
+    "version": "3.6.9-1~18.04ubuntu1.4"
+  },
+  {
+    "name": "python3.6-minimal",
+    "version": "3.6.9-1~18.04ubuntu1.4"
+  },
+  {
+    "name": "pytz",
+    "version": "2018.3"
+  },
+  {
+    "name": "qpdf",
+    "version": "8.0.2-3ubuntu0.1"
+  },
+  {
+    "name": "readline-common",
+    "version": "7.0-3"
+  },
+  {
+    "name": "reportlab",
+    "version": "3.4.0"
+  },
+  {
+    "name": "requests",
+    "version": "2.18.4"
+  },
+  {
+    "name": "requests-unixsocket",
+    "version": "0.1.5"
+  },
+  {
+    "name": "rfkill",
+    "version": "2.31.1-0.4ubuntu3.7"
+  },
+  {
+    "name": "rsync",
+    "version": "3.1.2-2.1ubuntu1.1"
+  },
+  {
+    "name": "rsyslog",
+    "version": "8.32.0-1ubuntu4"
+  },
+  {
+    "name": "rtkit",
+    "version": "0.11-6"
+  },
+  {
+    "name": "samba-libs",
+    "version": "2:4.7.6+dfsg~ubuntu-0ubuntu2.23"
+  },
+  {
+    "name": "sane-utils",
+    "version": "1.0.27-1~experimental3ubuntu2.4"
+  },
+  {
+    "name": "sbsigntool",
+    "version": "0.9.2-2ubuntu1~18.04.1"
+  },
+  {
+    "name": "seahorse",
+    "version": "3.20.0-5"
+  },
+  {
+    "name": "secureboot-db",
+    "version": "1.4~ubuntu0.18.04.1"
+  },
+  {
+    "name": "sed",
+    "version": "4.4-2"
+  },
+  {
+    "name": "sensible-utils",
+    "version": "0.0.12"
+  },
+  {
+    "name": "session-migration",
+    "version": "0.3.3"
+  },
+  {
+    "name": "shared-mime-info",
+    "version": "1.9-2"
+  },
+  {
+    "name": "six",
+    "version": "1.11.0"
+  },
+  {
+    "name": "snapd",
+    "version": "2.49.2+18.04"
+  },
+  {
+    "name": "software-properties-common",
+    "version": "0.96.24.32.14"
+  },
+  {
+    "name": "software-properties-gtk",
+    "version": "0.96.24.32.14"
+  },
+  {
+    "name": "sound-icons",
+    "version": "0.1-6"
+  },
+  {
+    "name": "speech-dispatcher",
+    "version": "0.8.8-1ubuntu1"
+  },
+  {
+    "name": "speech-dispatcher-audio-plugins",
+    "version": "0.8.8-1ubuntu1"
+  },
+  {
+    "name": "speech-dispatcher-espeak-ng",
+    "version": "0.8.8-1ubuntu1"
+  },
+  {
+    "name": "spice-vdagent",
+    "version": "0.17.0-1ubuntu2.2"
+  },
+  {
+    "name": "squashfs-tools",
+    "version": "1:4.3-6ubuntu0.18.04.4"
+  },
+  {
+    "name": "strace",
+    "version": "4.21-1ubuntu1"
+  },
+  {
+    "name": "sudo",
+    "version": "1.8.21p2-3ubuntu1.4"
+  },
+  {
+    "name": "syslinux",
+    "version": "3:6.03+dfsg1-2"
+  },
+  {
+    "name": "syslinux-common",
+    "version": "3:6.03+dfsg1-2"
+  },
+  {
+    "name": "syslinux-legacy",
+    "version": "2:3.63+dfsg-2ubuntu9"
+  },
+  {
+    "name": "system-config-printer",
+    "version": "1.5.11-1ubuntu2"
+  },
+  {
+    "name": "system-config-printer-common",
+    "version": "1.5.11-1ubuntu2"
+  },
+  {
+    "name": "system-config-printer-udev",
+    "version": "1.5.11-1ubuntu2"
+  },
+  {
+    "name": "systemd",
+    "version": "237-3ubuntu10.52"
+  },
+  {
+    "name": "systemd-sysv",
+    "version": "237-3ubuntu10.52"
+  },
+  {
+    "name": "sysvinit-utils",
+    "version": "2.88dsf-59.10ubuntu1"
+  },
+  {
+    "name": "t1utils",
+    "version": "1.41-2"
+  },
+  {
+    "name": "tar",
+    "version": "1.29b-2ubuntu0.2"
+  },
+  {
+    "name": "tcpdump",
+    "version": "4.9.3-0ubuntu0.18.04.1"
+  },
+  {
+    "name": "telnet",
+    "version": "0.17-41"
+  },
+  {
+    "name": "thermald",
+    "version": "1.7.0-5ubuntu5"
+  },
+  {
+    "name": "tzdata",
+    "version": "2021a-0ubuntu0.18.04"
+  },
+  {
+    "name": "ubuntu-advantage-tools",
+    "version": "27.2.2~18.04.1"
+  },
+  {
+    "name": "ubuntu-artwork",
+    "version": "1:16.10+18.04.20181005-0ubuntu1"
+  },
+  {
+    "name": "ubuntu-desktop",
+    "version": "1.417.5"
+  },
+  {
+    "name": "ubuntu-docs",
+    "version": "18.04.4"
+  },
+  {
+    "name": "ubuntu-drivers-common",
+    "version": "1:0.8.6.3~0.18.04.2"
+  },
+  {
+    "name": "ubuntu-keyring",
+    "version": "2018.09.18.1~18.04.2"
+  },
+  {
+    "name": "ubuntu-minimal",
+    "version": "1.417.5"
+  },
+  {
+    "name": "ubuntu-mono",
+    "version": "16.10+18.04.20181005-0ubuntu1"
+  },
+  {
+    "name": "ubuntu-release-upgrader-core",
+    "version": "1:18.04.45"
+  },
+  {
+    "name": "ubuntu-release-upgrader-gtk",
+    "version": "1:18.04.45"
+  },
+  {
+    "name": "ubuntu-report",
+    "version": "1.3.2"
+  },
+  {
+    "name": "ubuntu-session",
+    "version": "3.28.1-0ubuntu3"
+  },
+  {
+    "name": "ubuntu-settings",
+    "version": "18.04.7"
+  },
+  {
+    "name": "ubuntu-software",
+    "version": "3.28.1-0ubuntu4.18.04.15"
+  },
+  {
+    "name": "ubuntu-sounds",
+    "version": "0.13"
+  },
+  {
+    "name": "ubuntu-standard",
+    "version": "1.417.5"
+  },
+  {
+    "name": "ubuntu-system-service",
+    "version": "0.3.1"
+  },
+  {
+    "name": "ubuntu-wallpapers",
+    "version": "18.04.1-0ubuntu1"
+  },
+  {
+    "name": "ubuntu-wallpapers-bionic",
+    "version": "18.04.1-0ubuntu1"
+  },
+  {
+    "name": "ucf",
+    "version": "3.0038"
+  },
+  {
+    "name": "udev",
+    "version": "237-3ubuntu10.52"
+  },
+  {
+    "name": "udisks2",
+    "version": "2.7.6-3ubuntu0.2"
+  },
+  {
+    "name": "ufw",
+    "version": "0.36-0ubuntu0.18.04.1"
+  },
+  {
+    "name": "unattended-upgrades",
+    "version": "1.1ubuntu1.18.04.14"
+  },
+  {
+    "name": "unzip",
+    "version": "6.0-21ubuntu1.1"
+  },
+  {
+    "name": "update-inetd",
+    "version": "4.44"
+  },
+  {
+    "name": "update-manager",
+    "version": "1:18.04.11.13"
+  },
+  {
+    "name": "update-manager-core",
+    "version": "1:18.04.11.13"
+  },
+  {
+    "name": "update-notifier",
+    "version": "3.192.1.12"
+  },
+  {
+    "name": "update-notifier-common",
+    "version": "3.192.1.12"
+  },
+  {
+    "name": "upower",
+    "version": "0.99.7-2ubuntu0.18.04.1"
+  },
+  {
+    "name": "ureadahead",
+    "version": "0.100.0-21"
+  },
+  {
+    "name": "urllib3",
+    "version": "1.22"
+  },
+  {
+    "name": "usb-creator-common",
+    "version": "0.3.5ubuntu18.04.2"
+  },
+  {
+    "name": "usb-modeswitch",
+    "version": "2.5.2+repack0-2ubuntu1"
+  },
+  {
+    "name": "usb-modeswitch-data",
+    "version": "20170806-2"
+  },
+  {
+    "name": "usbmuxd",
+    "version": "1.1.0-2ubuntu0.1"
+  },
+  {
+    "name": "usbutils",
+    "version": "1:007-4build1"
+  },
+  {
+    "name": "util-linux",
+    "version": "2.31.1-0.4ubuntu3.7"
+  },
+  {
+    "name": "uuid-runtime",
+    "version": "2.31.1-0.4ubuntu3.7"
+  },
+  {
+    "name": "vim-common",
+    "version": "2:8.0.1453-1ubuntu1.4"
+  },
+  {
+    "name": "vim-tiny",
+    "version": "2:8.0.1453-1ubuntu1.4"
+  },
+  {
+    "name": "wadllib",
+    "version": "1.3.2"
+  },
+  {
+    "name": "wamerican",
+    "version": "2017.08.24-1"
+  },
+  {
+    "name": "wbritish",
+    "version": "2017.08.24-1"
+  },
+  {
+    "name": "wget",
+    "version": "1.19.4-1ubuntu2.2"
+  },
+  {
+    "name": "whiptail",
+    "version": "0.52.20-1ubuntu1"
+  },
+  {
+    "name": "whoopsie",
+    "version": "0.2.62ubuntu0.6"
+  },
+  {
+    "name": "whoopsie-preferences",
+    "version": "0.19"
+  },
+  {
+    "name": "wireless-regdb",
+    "version": "2021.08.28-0ubuntu1~18.04.1"
+  },
+  {
+    "name": "wireless-tools",
+    "version": "30~pre9-12ubuntu1"
+  },
+  {
+    "name": "wpasupplicant",
+    "version": "2:2.6-15ubuntu2.8"
+  },
+  {
+    "name": "x11-apps",
+    "version": "7.7+6ubuntu1"
+  },
+  {
+    "name": "x11-common",
+    "version": "1:7.7+19ubuntu7.1"
+  },
+  {
+    "name": "x11-session-utils",
+    "version": "7.7+2build1"
+  },
+  {
+    "name": "x11-utils",
+    "version": "7.7+3build1"
+  },
+  {
+    "name": "x11-xkb-utils",
+    "version": "7.7+3ubuntu0.18.04.1"
+  },
+  {
+    "name": "x11-xserver-utils",
+    "version": "7.7+7build1"
+  },
+  {
+    "name": "xauth",
+    "version": "1:1.0.10-1"
+  },
+  {
+    "name": "xbrlapi",
+    "version": "5.5-4ubuntu2.0.1"
+  },
+  {
+    "name": "xcursor-themes",
+    "version": "1.0.4-1"
+  },
+  {
+    "name": "xdg-desktop-portal",
+    "version": "1.0.3-0ubuntu0.2"
+  },
+  {
+    "name": "xdg-desktop-portal-gtk",
+    "version": "1.0.2-0ubuntu1.1"
+  },
+  {
+    "name": "xdg-user-dirs",
+    "version": "0.17-1ubuntu1"
+  },
+  {
+    "name": "xdg-user-dirs-gtk",
+    "version": "0.10-2"
+  },
+  {
+    "name": "xdg-utils",
+    "version": "1.1.2-1ubuntu2.5"
+  },
+  {
+    "name": "xfonts-base",
+    "version": "1:1.0.4+nmu1"
+  },
+  {
+    "name": "xfonts-encodings",
+    "version": "1:1.0.4-2"
+  },
+  {
+    "name": "xinit",
+    "version": "1.3.4-3ubuntu3"
+  },
+  {
+    "name": "xinput",
+    "version": "1.6.2-1build1"
+  },
+  {
+    "name": "xkb-data",
+    "version": "2.23.1-1ubuntu1.18.04.1"
+  },
+  {
+    "name": "xorg",
+    "version": "1:7.7+19ubuntu7.1"
+  },
+  {
+    "name": "xserver-common",
+    "version": "2:1.19.6-1ubuntu4.9"
+  },
+  {
+    "name": "xserver-xephyr",
+    "version": "2:1.19.6-1ubuntu4.9"
+  },
+  {
+    "name": "xserver-xorg-core-hwe-18.04",
+    "version": "2:1.20.8-2ubuntu2.2~18.04.5"
+  },
+  {
+    "name": "xserver-xorg-hwe-18.04",
+    "version": "1:7.7+19ubuntu8~18.04.3"
+  },
+  {
+    "name": "xserver-xorg-input-all-hwe-18.04",
+    "version": "1:7.7+19ubuntu8~18.04.3"
+  },
+  {
+    "name": "xserver-xorg-input-libinput-hwe-18.04",
+    "version": "0.28.1-1~18.04.1"
+  },
+  {
+    "name": "xserver-xorg-input-wacom-hwe-18.04",
+    "version": "1:0.36.1-0ubuntu1~18.04.1"
+  },
+  {
+    "name": "xserver-xorg-legacy-hwe-18.04",
+    "version": "2:1.20.8-2ubuntu2.2~18.04.5"
+  },
+  {
+    "name": "xserver-xorg-video-all-hwe-18.04",
+    "version": "1:7.7+19ubuntu8~18.04.3"
+  },
+  {
+    "name": "xserver-xorg-video-amdgpu-hwe-18.04",
+    "version": "19.1.0-1~18.04.1"
+  },
+  {
+    "name": "xserver-xorg-video-ati-hwe-18.04",
+    "version": "1:19.1.0-1~18.04.1"
+  },
+  {
+    "name": "xserver-xorg-video-fbdev-hwe-18.04",
+    "version": "1:0.5.0-1ubuntu1~18.04.1"
+  },
+  {
+    "name": "xserver-xorg-video-intel-hwe-18.04",
+    "version": "2:2.99.917+git20171229-1ubuntu1~18.04.1"
+  },
+  {
+    "name": "xserver-xorg-video-nouveau-hwe-18.04",
+    "version": "1:1.0.16-1~18.04.1"
+  },
+  {
+    "name": "xserver-xorg-video-qxl-hwe-18.04",
+    "version": "0.1.5-2build2~18.04.1"
+  },
+  {
+    "name": "xserver-xorg-video-radeon-hwe-18.04",
+    "version": "1:19.1.0-1~18.04.1"
+  },
+  {
+    "name": "xserver-xorg-video-vesa-hwe-18.04",
+    "version": "1:2.4.0-1~18.04.1"
+  },
+  {
+    "name": "xserver-xorg-video-vmware-hwe-18.04",
+    "version": "1:13.3.0-2build1~18.04.1"
+  },
+  {
+    "name": "xwayland",
+    "version": "2:1.19.6-1ubuntu4.9"
+  },
+  {
+    "name": "xxd",
+    "version": "2:8.0.1453-1ubuntu1.4"
+  },
+  {
+    "name": "xz-utils",
+    "version": "5.2.2-1.3"
+  },
+  {
+    "name": "yelp",
+    "version": "3.26.0-1ubuntu2"
+  },
+  {
+    "name": "yelp-xsl",
+    "version": "3.20.1-4"
+  },
+  {
+    "name": "zenity",
+    "version": "3.28.1-1"
+  },
+  {
+    "name": "zenity-common",
+    "version": "3.28.1-1"
+  },
+  {
+    "name": "zlib1g",
+    "version": "1:1.2.11.dfsg-0ubuntu2"
+  },
+  {
+    "name": "zope.interface",
+    "version": "4.3.2"
+  }
+]

--- a/cmd/osquery-perf/ubuntu_20.04.tmpl
+++ b/cmd/osquery-perf/ubuntu_20.04.tmpl
@@ -1,0 +1,364 @@
+{{ define "enroll" -}}
+{
+    "enroll_secret": "{{ .EnrollSecret  }}",
+    "host_details": {
+        "os_version": {
+            "build": "",
+            "major": "",
+            "minor": "",
+            "name": "",
+            "patch": "",
+            "platform": "ubuntu",
+            "platform_like": "ubuntu",
+            "version": "Ubuntu 20.4.0"
+        },
+        "osquery_info": {
+            "build_distro": "20.4.0",
+            "build_platform": "linux",
+            "config_hash": "",
+            "config_valid": "0",
+            "extensions": "inactive",
+            "instance_id": "{{ .UUID }}",
+            "pid": "12947",
+            "platform_mask": "21",
+            "start_time": "1580931224",
+            "uuid": "{{ .UUID }}",
+            "version": "4.6.0",
+            "watcher": "12946"
+        },
+        "platform_info": {
+            "address": "0xff990000",
+            "date": "12/16/2019 ",
+            "extra": "MBP114; 196.0.0.0.0; root@xapp160; Mon Dec 16 15:55:18 PST 2019; 196 (B&I); F000_B00; Official Build, Release; Apple LLVM version 5.0 (clang-500.0.68) (based on LLVM 3.3svn)",
+            "revision": "196 (B&I)",
+            "size": "8388608",
+            "vendor": "Apple Inc. ",
+            "version": "196.0.0.0.0 ",
+            "volume_size": "1507328"
+        },
+        "system_info": {
+            "computer_name": "{{ .CachedString "hostname" }}",
+            "cpu_brand": "Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+            "cpu_logical_cores": "8",
+            "cpu_physical_cores": "4",
+            "cpu_subtype": "Intel x86-64h Haswell",
+            "cpu_type": "x86_64h",
+            "hardware_model": "MacBookPro11,4",
+            "hardware_serial": "D02R835DG8WK",
+            "hardware_vendor": "Apple Inc.",
+            "hardware_version": "1.0",
+            "hostname": "{{ .CachedString "hostname" }}",
+            "local_hostname": "{{ .CachedString "hostname" }}",
+            "physical_memory": "17179869184",
+            "uuid": "{{ .UUID }}"
+        }
+    },
+    "host_identifier": "{{ .CachedString "hostname" }}",
+    "platform_type": "16"
+}
+{{- end }}
+
+{{ define "fleet_detail_query_network_interface" -}}
+[
+  {
+    "point_to_point":"",
+    "address":"fe80::8cb:112d:ff51:1e5d%en0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"en0",
+    "mac":"f8:2d:88:93:56:5c",
+    "type":"6",
+    "mtu":"1500",
+    "metric":"0",
+    "ipackets":"278493",
+    "opackets":"206238",
+    "ibytes":"275799040",
+    "obytes":"37720064",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582848084"
+  },
+  {
+    "point_to_point":"",
+    "address":"192.168.1.3",
+    "mask":"255.255.255.0",
+    "broadcast":"192.168.1.255",
+    "interface":"en0",
+    "mac":"f5:5a:80:92:52:5b",
+    "type":"6",
+    "mtu":"1500",
+    "metric":"0",
+    "ipackets":"278493",
+    "opackets":"206238",
+    "ibytes":"275799040",
+    "obytes":"37720064",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582848084"
+  },
+  {
+    "point_to_point":"127.0.0.1",
+    "address":"127.0.0.1",
+    "mask":"255.0.0.0",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"::1",
+    "address":"::1",
+    "mask":"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::1%lo0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::3a:84ff:fe6b:bf75%awdl0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"awdl0",
+    "mac":"03:3b:94:5b:be:75",
+    "type":"6",
+    "mtu":"1484",
+    "metric":"0",
+    "ipackets":"0",
+    "opackets":"16",
+    "ibytes":"0",
+    "obytes":"3072",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582842892"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::6eaf:9721:3476:b691%utun0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"utun0",
+    "mac":"00:00:00:00:00:00",
+    "type":"1",
+    "mtu":"2000",
+    "metric":"0",
+    "ipackets":"0",
+    "opackets":"2",
+    "ibytes":"0",
+    "obytes":"0",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840897"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_os_version" -}}
+[
+  {
+    "name":"Ubuntu 20.4.0",
+    "version":"Ubuntu 20.4.0",
+    "major":"",
+    "minor":"",
+    "patch":"",
+    "build":"",
+    "platform":"ubuntu",
+    "platform_like":"ubuntu",
+    "codename":""
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_flags" -}}
+[
+  {
+    "name":"config_refresh",
+    "value":"{{ printf "%.0f" .ConfigInterval.Seconds }}"
+  },
+  {
+    "name":"distributed_interval",
+    "value":"{{ printf "%.0f" .QueryInterval.Seconds }}"
+  },
+  {
+    "name":"logger_tls_period",
+    "value":"99999"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_info" -}}
+[
+  {
+    "pid":"11287",
+    "uuid":"{{ .UUID }}",
+    "instance_id":"{{ .UUID }}",
+    "version":"4.1.2",
+    "config_hash":"b01efbf375ac6767f259ae98751154fef727ce35",
+    "config_valid":"1",
+    "extensions":"inactive",
+    "build_platform":"ubuntu",
+    "build_distro":"20.4.0",
+    "start_time":"1582857555",
+    "watcher":"11286",
+    "platform_mask":"21"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_system_info" -}}
+[
+  {
+    "hostname":"{{ .CachedString "hostname" }}",
+    "uuid":"4740D59F-699E-5B29-960B-979AAF9BBEEB",
+    "cpu_type":"x86_64h",
+    "cpu_subtype":"Intel x86-64h Haswell",
+    "cpu_brand":"Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz",
+    "cpu_physical_cores":"4",
+    "cpu_logical_cores":"8",
+    "cpu_microcode":"",
+    "physical_memory":"17179869184",
+    "hardware_vendor":"Apple Inc.",
+    "hardware_model":"MacBookPro11,4",
+    "hardware_version":"1.0",
+    "hardware_serial":"C02R262BM8LN",
+    "computer_name":"{{ .CachedString "hostname" }}",
+    "local_hostname":"{{ .CachedString "hostname" }}"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_uptime" -}}
+[
+  {
+    "days":"0",
+    "hours":"4",
+    "minutes":"38",
+    "seconds":"11",
+    "total_seconds":"16691"
+  }
+]
+{{- end }}
+
+{{ define "fleet_detail_query_users" -}}
+[
+  {{ range $index, $item := .HostUsersMacOS }}
+  {{if $index}},{{end}}
+  {
+    "uid": "{{ .Uid }}",
+    "username": "{{ .Username }}",
+    "type": "{{ .Type }}",
+    "groupname": "{{ .GroupName }}",
+    "shell": "{{ .Shell }}"
+  }
+  {{- end }}
+]
+{{- end }}
+
+{{/* all hosts */}}
+{{ define "fleet_label_query_6" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All macOS hosts */}}
+{{ define "fleet_label_query_7" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All Ubuntu hosts */}}
+{{ define "fleet_label_query_8" -}}
+[]
+{{- end }}
+
+{{/* All CentOS hosts */}}
+{{ define "fleet_label_query_9" -}}
+[]
+{{- end }}
+
+{{/* All Windows hosts */}}
+{{ define "fleet_label_query_10" -}}
+[]
+{{- end }}
+
+{{/* All Red Hat hosts */}}
+{{ define "fleet_label_query_11" -}}
+[]
+{{- end }}
+
+{{/* All Linux distributions */}}
+{{ define "fleet_label_query_12" -}}
+[]
+{{- end }}
+
+{{ define "fleet_detail_query_software_linux" -}}
+[
+  {{ range $index, $item := .SoftwareUbuntu2004 }}
+  {{if $index}},{{end}}
+  {
+    "name": "{{ .Name }}",
+    "version": "{{ .Version }}",
+    "type": "Application",
+    "bundle_identifier": "{{ .BundleIdentifier }}",
+    "source": "apps",
+    {{/* Note that in Go < 1.18, `{{ or (and .LastOpendedAt .LastOpenedAt.Unix) "" }}` won't work as expected because "and" and "or" don't short circuit. This was changed in Go 1.18 */}}
+    {{if .LastOpenedAt}}
+    "last_opened_at": "{{ .LastOpenedAt.Unix }}"
+    {{else}}
+    "last_opened_at": "-1"
+    {{end}}
+  }
+  {{- end }}
+]
+{{- end }}

--- a/cmd/osquery-perf/ubuntu_2004-vulnerable_software.json
+++ b/cmd/osquery-perf/ubuntu_2004-vulnerable_software.json
@@ -1,0 +1,5974 @@
+[
+  {
+    "name": "defer",
+    "version": "1.0.6"
+  },
+  {
+    "name": "dmz-cursor-theme",
+    "version": "0.4.5ubuntu1"
+  },
+  {
+    "name": "grub-gfxpayload-lists",
+    "version": "0.7"
+  },
+  {
+    "name": "hicolor-icon-theme",
+    "version": "0.17-2"
+  },
+  {
+    "name": "language-selector",
+    "version": "0.1"
+  },
+  {
+    "name": "laptop-detect",
+    "version": "0.16"
+  },
+  {
+    "name": "libnet-smtp-ssl-perl",
+    "version": "1.04-1"
+  },
+  {
+    "name": "libxml-xpathengine-perl",
+    "version": "0.14-1"
+  },
+  {
+    "name": "pymacaroons",
+    "version": "0.13.0"
+  },
+  {
+    "name": "sound-theme-freedesktop",
+    "version": "0.8-2ubuntu1"
+  },
+  {
+    "name": "ubuntu-drivers-common",
+    "version": "0.0.0"
+  },
+  {
+    "name": "unattended-upgrades",
+    "version": "0.1"
+  },
+  {
+    "name": "aspell-en",
+    "version": "2018.04.16-0-1"
+  },
+  {
+    "name": "emacsen-common",
+    "version": "3.0.4"
+  },
+  {
+    "name": "fonts-deva-extra",
+    "version": "3.0-5"
+  },
+  {
+    "name": "fonts-gujr-extra",
+    "version": "1.0.1-1"
+  },
+  {
+    "name": "fonts-guru-extra",
+    "version": "2.0-5"
+  },
+  {
+    "name": "fonts-kacst-one",
+    "version": "5.0+svn11846-10"
+  },
+  {
+    "name": "fonts-liberation",
+    "version": "1:1.07.4-11"
+  },
+  {
+    "name": "fonts-lohit-deva",
+    "version": "2.95.4-4"
+  },
+  {
+    "name": "fonts-lohit-gujr",
+    "version": "2.92.4-4"
+  },
+  {
+    "name": "fonts-orya-extra",
+    "version": "2.0-6"
+  },
+  {
+    "name": "fonts-smc-meera",
+    "version": "7.0.3-1"
+  },
+  {
+    "name": "fonts-smc-raghumalayalamsans",
+    "version": "2.2.1-1"
+  },
+  {
+    "name": "fonts-smc-suruma",
+    "version": "3.2.3-1"
+  },
+  {
+    "name": "fonts-smc-uroob",
+    "version": "2.0.2-1"
+  },
+  {
+    "name": "libhtml-form-perl",
+    "version": "6.07-1"
+  },
+  {
+    "name": "libhtml-tagset-perl",
+    "version": "3.20-4"
+  },
+  {
+    "name": "libhtml-tree-perl",
+    "version": "5.07-2"
+  },
+  {
+    "name": "libhttp-date-perl",
+    "version": "6.05-1"
+  },
+  {
+    "name": "libhttp-negotiate-perl",
+    "version": "6.01-1"
+  },
+  {
+    "name": "libio-stringy-perl",
+    "version": "2.111-3"
+  },
+  {
+    "name": "liblwp-mediatypes-perl",
+    "version": "6.04-1"
+  },
+  {
+    "name": "libmailtools-perl",
+    "version": "2.21-1"
+  },
+  {
+    "name": "libtext-wrapi18n-perl",
+    "version": "0.06-9"
+  },
+  {
+    "name": "libwww-robotrules-perl",
+    "version": "6.02-1"
+  },
+  {
+    "name": "macaroonbakery",
+    "version": "1.3.1"
+  },
+  {
+    "name": "olefile",
+    "version": "0.46"
+  },
+  {
+    "name": "osquery",
+    "version": "5.2.3-1.linux"
+  },
+  {
+    "name": "policykit-desktop-privileges",
+    "version": "0.21"
+  },
+  {
+    "name": "powermgmt-base",
+    "version": "1.36"
+  },
+  {
+    "name": "pyRFC3339",
+    "version": "1.1"
+  },
+  {
+    "name": "xcursor-themes",
+    "version": "1.0.6-0ubuntu1"
+  },
+  {
+    "name": "xfonts-base",
+    "version": "1:1.0.5"
+  },
+  {
+    "name": "xml-core",
+    "version": "0.18+nmu1"
+  },
+  {
+    "name": "nessusagent",
+    "version": "10.1.3"
+  },
+  {
+    "name": "PyJWT",
+    "version": "1.7.1"
+  },
+  {
+    "name": "dbus-python",
+    "version": "1.2.16"
+  },
+  {
+    "name": "docbook-xml",
+    "version": "4.5-9"
+  },
+  {
+    "name": "fonts-beng-extra",
+    "version": "1.0-7"
+  },
+  {
+    "name": "gir1.2-gmenu-3.0",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-menus",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "humanity-icon-theme",
+    "version": "0.6.15"
+  },
+  {
+    "name": "launchpadlib",
+    "version": "1.10.13"
+  },
+  {
+    "name": "lazr.restfulclient",
+    "version": "0.14.2"
+  },
+  {
+    "name": "libatasmart4",
+    "version": "0.19-5"
+  },
+  {
+    "name": "libextutils-depends-perl",
+    "version": "0.8000-1"
+  },
+  {
+    "name": "libfile-basedir-perl",
+    "version": "0.08-1"
+  },
+  {
+    "name": "libglu1-mesa",
+    "version": "9.0.1-1build1"
+  },
+  {
+    "name": "libgnome-menu-3-0",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "libhyphen0",
+    "version": "2.8.8-7"
+  },
+  {
+    "name": "libjbig0",
+    "version": "2.1-3.1build1"
+  },
+  {
+    "name": "libjpeg8",
+    "version": "8c-2ubuntu8"
+  },
+  {
+    "name": "liblmdb0",
+    "version": "0.9.24-1"
+  },
+  {
+    "name": "libnfnetlink0",
+    "version": "1.0.1-3build1"
+  },
+  {
+    "name": "libnfs13",
+    "version": "4.0.0-1"
+  },
+  {
+    "name": "libtasn1-6",
+    "version": "4.16.0-2"
+  },
+  {
+    "name": "libtheora0",
+    "version": "1.1.1+dfsg.1-15ubuntu2"
+  },
+  {
+    "name": "libtry-tiny-perl",
+    "version": "0.30-1"
+  },
+  {
+    "name": "libxcomposite1",
+    "version": "1:0.4.5-1"
+  },
+  {
+    "name": "libxdamage1",
+    "version": "1:1.1.5-2"
+  },
+  {
+    "name": "libxmu6",
+    "version": "2:1.1.3-0ubuntu1"
+  },
+  {
+    "name": "libxmuu1",
+    "version": "2:1.1.3-0ubuntu1"
+  },
+  {
+    "name": "libxpm4",
+    "version": "1:3.5.12-1"
+  },
+  {
+    "name": "libxrandr2",
+    "version": "2:1.5.2-0ubuntu1"
+  },
+  {
+    "name": "libxslt1.1",
+    "version": "1.1.34-4"
+  },
+  {
+    "name": "libxss1",
+    "version": "1:1.2.3-1"
+  },
+  {
+    "name": "libxv1",
+    "version": "2:1.0.11-1"
+  },
+  {
+    "name": "libxxf86vm1",
+    "version": "1:1.1.4-1build1"
+  },
+  {
+    "name": "libyaml-0-2",
+    "version": "0.2.2-1"
+  },
+  {
+    "name": "mawk",
+    "version": "1.3.4.20200120-2"
+  },
+  {
+    "name": "oauthlib",
+    "version": "3.1.0"
+  },
+  {
+    "name": "python3-defer",
+    "version": "1.0.6-2.1"
+  },
+  {
+    "name": "python3-jwt",
+    "version": "1.7.1-2ubuntu2"
+  },
+  {
+    "name": "python3-launchpadlib",
+    "version": "1.10.13-1"
+  },
+  {
+    "name": "python3-lazr.restfulclient",
+    "version": "0.14.2-2build1"
+  },
+  {
+    "name": "python3-macaroonbakery",
+    "version": "1.3.1-1"
+  },
+  {
+    "name": "python3-rfc3339",
+    "version": "1.1-2"
+  },
+  {
+    "name": "python3-xkit",
+    "version": "0.5.0ubuntu4"
+  },
+  {
+    "name": "sound-icons",
+    "version": "0.1-7"
+  },
+  {
+    "name": "usb-modeswitch-data",
+    "version": "20191128-3"
+  },
+  {
+    "name": "x11-apps",
+    "version": "7.7+8"
+  },
+  {
+    "name": "xfonts-encodings",
+    "version": "1:1.0.5-0ubuntu1"
+  },
+  {
+    "name": "xserver-xorg-video-vmware",
+    "version": "1:13.3.0-3"
+  },
+  {
+    "name": "Amazon.com",
+    "version": "1.3"
+  },
+  {
+    "name": "Bing",
+    "version": "1.3"
+  },
+  {
+    "name": "DoH Roll-Out",
+    "version": "2.0.0"
+  },
+  {
+    "name": "DuckDuckGo",
+    "version": "1.1"
+  },
+  {
+    "name": "Google",
+    "version": "1.1"
+  },
+  {
+    "name": "Wikipedia (en)",
+    "version": "1.1"
+  },
+  {
+    "name": "acpi-support",
+    "version": "0.143"
+  },
+  {
+    "name": "acpid",
+    "version": "1:2.0.32-1ubuntu1"
+  },
+  {
+    "name": "amd64-microcode",
+    "version": "3.20191218.1ubuntu1"
+  },
+  {
+    "name": "apg",
+    "version": "2.2.3.dfsg.1-5"
+  },
+  {
+    "name": "app-install-data-partner",
+    "version": "19.04"
+  },
+  {
+    "name": "cups-pk-helper",
+    "version": "0.2.6-1ubuntu3"
+  },
+  {
+    "name": "gir1.2-dbusmenu-glib-0.4",
+    "version": "16.04.1+18.10.20180917-0ubuntu6"
+  },
+  {
+    "name": "gir1.2-wnck-3.0",
+    "version": "3.36.0-1"
+  },
+  {
+    "name": "gkbd-capplet",
+    "version": "3.26.1-1"
+  },
+  {
+    "name": "gnome-accessibility-themes",
+    "version": "3.28-1ubuntu1"
+  },
+  {
+    "name": "gnome-keyring",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-keyring-pkcs11",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-power-manager",
+    "version": "3.32.0-2"
+  },
+  {
+    "name": "gnome-themes-extra",
+    "version": "3.28-1ubuntu1"
+  },
+  {
+    "name": "gnome-themes-extra-data",
+    "version": "3.28-1ubuntu1"
+  },
+  {
+    "name": "gsettings-ubuntu-schemas",
+    "version": "0.0.7+17.10.20170922-0ubuntu1"
+  },
+  {
+    "name": "gtk2-engines-murrine",
+    "version": "0.98.2-3"
+  },
+  {
+    "name": "hostname",
+    "version": "3.23"
+  },
+  {
+    "name": "iucode-tool",
+    "version": "2.3.1-1"
+  },
+  {
+    "name": "libao-common",
+    "version": "1.2.2+20180113-1ubuntu1"
+  },
+  {
+    "name": "libao4",
+    "version": "1.2.2+20180113-1ubuntu1"
+  },
+  {
+    "name": "libasyncns0",
+    "version": "0.8-6"
+  },
+  {
+    "name": "libatm1",
+    "version": "1:2.5.1-4"
+  },
+  {
+    "name": "libavc1394-0",
+    "version": "0.5.4-5"
+  },
+  {
+    "name": "libcairomm-1.0-1v5",
+    "version": "1.12.2-4build1"
+  },
+  {
+    "name": "libclutter-gtk-1.0-0",
+    "version": "1.8.4-4"
+  },
+  {
+    "name": "libcolord-gtk1",
+    "version": "0.2.0-0ubuntu1"
+  },
+  {
+    "name": "libdbusmenu-glib4",
+    "version": "16.04.1+18.10.20180917-0ubuntu6"
+  },
+  {
+    "name": "libdbusmenu-gtk3-4",
+    "version": "16.04.1+18.10.20180917-0ubuntu6"
+  },
+  {
+    "name": "libdotconf0",
+    "version": "1.3-0.3fakesync1"
+  },
+  {
+    "name": "libgeocode-glib0",
+    "version": "3.26.2-2"
+  },
+  {
+    "name": "libgnomekbd-common",
+    "version": "3.26.1-1"
+  },
+  {
+    "name": "libgnomekbd8",
+    "version": "3.26.1-1"
+  },
+  {
+    "name": "libgupnp-av-1.0-2",
+    "version": "0.12.11-2"
+  },
+  {
+    "name": "libgupnp-dlna-2.0-3",
+    "version": "0.10.5-4"
+  },
+  {
+    "name": "libijs-0.35",
+    "version": "0.35-15"
+  },
+  {
+    "name": "libimagequant0",
+    "version": "2.12.2-1.1"
+  },
+  {
+    "name": "libmp3lame0",
+    "version": "3.100-3"
+  },
+  {
+    "name": "libndp0",
+    "version": "1.7-0ubuntu1"
+  },
+  {
+    "name": "libpam-gnome-keyring",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "libpaper-utils",
+    "version": "1.1.28"
+  },
+  {
+    "name": "libpaper1",
+    "version": "1.1.28"
+  },
+  {
+    "name": "libsm6",
+    "version": "2:1.2.3-1"
+  },
+  {
+    "name": "libsmbios-c2",
+    "version": "2.4.3-1"
+  },
+  {
+    "name": "libsodium23",
+    "version": "1.0.18-1"
+  },
+  {
+    "name": "libstartup-notification0",
+    "version": "0.12-6"
+  },
+  {
+    "name": "libtwolame0",
+    "version": "0.4.0-2"
+  },
+  {
+    "name": "libvisual-0.4-0",
+    "version": "0.4.0-17"
+  },
+  {
+    "name": "libwebrtc-audio-processing1",
+    "version": "0.3.1-0ubuntu3"
+  },
+  {
+    "name": "libwhoopsie-preferences0",
+    "version": "22"
+  },
+  {
+    "name": "libwmf0.2-7",
+    "version": "0.2.8.4-17ubuntu1"
+  },
+  {
+    "name": "libwmf0.2-7-gtk",
+    "version": "0.2.8.4-17ubuntu1"
+  },
+  {
+    "name": "libwnck-3-0",
+    "version": "3.36.0-1"
+  },
+  {
+    "name": "libwnck-3-common",
+    "version": "3.36.0-1"
+  },
+  {
+    "name": "libwoff1",
+    "version": "1.0.2-1build2"
+  },
+  {
+    "name": "libxcb-icccm4",
+    "version": "0.4.1-1.1"
+  },
+  {
+    "name": "libxcb-image0",
+    "version": "0.4.0-1build1"
+  },
+  {
+    "name": "libxcb-keysyms1",
+    "version": "0.4.0-1build1"
+  },
+  {
+    "name": "libxcb-render-util0",
+    "version": "0.3.9-1build1"
+  },
+  {
+    "name": "libxklavier16",
+    "version": "5.4-4"
+  },
+  {
+    "name": "libxres1",
+    "version": "2:1.2.0-4"
+  },
+  {
+    "name": "libxvmc1",
+    "version": "2:1.0.12-2"
+  },
+  {
+    "name": "libxxf86dga1",
+    "version": "2:1.1.5-0ubuntu1"
+  },
+  {
+    "name": "lsb-base",
+    "version": "11.1.0ubuntu2"
+  },
+  {
+    "name": "lsb-release",
+    "version": "11.1.0ubuntu2"
+  },
+  {
+    "name": "nautilus-share",
+    "version": "0.7.3-2ubuntu3"
+  },
+  {
+    "name": "pptp-linux",
+    "version": "1.10.0-1build1"
+  },
+  {
+    "name": "printer-driver-brlaser",
+    "version": "6-1build1"
+  },
+  {
+    "name": "printer-driver-m2300w",
+    "version": "0.51-14"
+  },
+  {
+    "name": "printer-driver-min12xxw",
+    "version": "0.0.9-11"
+  },
+  {
+    "name": "printer-driver-pxljr",
+    "version": "1.4+repack0-5"
+  },
+  {
+    "name": "printer-driver-sag-gdi",
+    "version": "0.1-7"
+  },
+  {
+    "name": "printer-driver-splix",
+    "version": "2.0.0+svn315-7fakesync1build1"
+  },
+  {
+    "name": "session-migration",
+    "version": "0.3.5"
+  },
+  {
+    "name": "whoopsie-preferences",
+    "version": "22"
+  },
+  {
+    "name": "x11-session-utils",
+    "version": "7.7+4"
+  },
+  {
+    "name": "x11-utils",
+    "version": "7.7+5"
+  },
+  {
+    "name": "x11-xserver-utils",
+    "version": "7.7+8"
+  },
+  {
+    "name": "xdg-user-dirs-gtk",
+    "version": "0.10-3"
+  },
+  {
+    "name": "xfonts-utils",
+    "version": "1:7.7+6"
+  },
+  {
+    "name": "xinit",
+    "version": "1.4.1-0ubuntu2"
+  },
+  {
+    "name": "xinput",
+    "version": "1.6.3-1"
+  },
+  {
+    "name": "xserver-xorg-input-wacom",
+    "version": "1:0.39.0-0ubuntu1"
+  },
+  {
+    "name": "xserver-xorg-video-qxl",
+    "version": "0.1.5+git20200331-1"
+  },
+  {
+    "name": "xul-ext-ubufox",
+    "version": "3.4-0ubuntu1.17.10.1"
+  },
+  {
+    "name": "Add-ons Search Detection",
+    "version": "2.0.0"
+  },
+  {
+    "name": "Click",
+    "version": "7.0"
+  },
+  {
+    "name": "Dark",
+    "version": "1.2"
+  },
+  {
+    "name": "English (CA) Language Pack",
+    "version": "97.0buildid20220202.182137"
+  },
+  {
+    "name": "English (GB) Language Pack",
+    "version": "97.0buildid20220202.182137"
+  },
+  {
+    "name": "Firefox Alpenglow",
+    "version": "1.4"
+  },
+  {
+    "name": "Firefox Screenshots",
+    "version": "39.0.1"
+  },
+  {
+    "name": "Form Autofill",
+    "version": "1.0.1"
+  },
+  {
+    "name": "Light",
+    "version": "1.2"
+  },
+  {
+    "name": "Picture-In-Picture",
+    "version": "1.0.0"
+  },
+  {
+    "name": "Pillow",
+    "version": "7.0.0"
+  },
+  {
+    "name": "PyGObject",
+    "version": "3.36.0"
+  },
+  {
+    "name": "PyNaCl",
+    "version": "1.3.0"
+  },
+  {
+    "name": "SecretStorage",
+    "version": "2.3.1"
+  },
+  {
+    "name": "System theme — auto",
+    "version": "1.3"
+  },
+  {
+    "name": "Web Compatibility Interventions",
+    "version": "29.7.0"
+  },
+  {
+    "name": "WebCompat Reporter",
+    "version": "1.4.2"
+  },
+  {
+    "name": "accountsservice",
+    "version": "0.6.55-0ubuntu12~20.04.5"
+  },
+  {
+    "name": "acl",
+    "version": "2.2.53-6"
+  },
+  {
+    "name": "adduser",
+    "version": "3.118ubuntu2"
+  },
+  {
+    "name": "adwaita-icon-theme",
+    "version": "3.36.1-2ubuntu0.20.04.2"
+  },
+  {
+    "name": "alsa-base",
+    "version": "1.0.25+dfsg-0ubuntu5"
+  },
+  {
+    "name": "alsa-topology-conf",
+    "version": "1.2.2-1"
+  },
+  {
+    "name": "alsa-ucm-conf",
+    "version": "1.2.2-1ubuntu0.11"
+  },
+  {
+    "name": "alsa-utils",
+    "version": "1.2.2-1ubuntu2.1"
+  },
+  {
+    "name": "anacron",
+    "version": "2.3-29"
+  },
+  {
+    "name": "apparmor",
+    "version": "2.13.3-7ubuntu5.1"
+  },
+  {
+    "name": "apport",
+    "version": "2.20.11-0ubuntu27.21"
+  },
+  {
+    "name": "apport-gtk",
+    "version": "2.20.11-0ubuntu27.21"
+  },
+  {
+    "name": "apport-symptoms",
+    "version": "0.23"
+  },
+  {
+    "name": "appstream",
+    "version": "0.12.10-2"
+  },
+  {
+    "name": "apt",
+    "version": "2.0.6"
+  },
+  {
+    "name": "apt-config-icons",
+    "version": "0.12.10-2"
+  },
+  {
+    "name": "apt-config-icons-hidpi",
+    "version": "0.12.10-2"
+  },
+  {
+    "name": "apt-utils",
+    "version": "2.0.6"
+  },
+  {
+    "name": "aptdaemon",
+    "version": "1.1.1+bzr982-0ubuntu32.3"
+  },
+  {
+    "name": "aptdaemon-data",
+    "version": "1.1.1+bzr982-0ubuntu32.3"
+  },
+  {
+    "name": "apturl",
+    "version": "0.5.2ubuntu19"
+  },
+  {
+    "name": "apturl-common",
+    "version": "0.5.2ubuntu19"
+  },
+  {
+    "name": "aspell",
+    "version": "0.60.8-1ubuntu0.1"
+  },
+  {
+    "name": "at-spi2-core",
+    "version": "2.36.0-2"
+  },
+  {
+    "name": "avahi-autoipd",
+    "version": "0.7-4ubuntu7.1"
+  },
+  {
+    "name": "avahi-daemon",
+    "version": "0.7-4ubuntu7.1"
+  },
+  {
+    "name": "avahi-utils",
+    "version": "0.7-4ubuntu7.1"
+  },
+  {
+    "name": "base-files",
+    "version": "11ubuntu5.5"
+  },
+  {
+    "name": "base-passwd",
+    "version": "3.5.47"
+  },
+  {
+    "name": "bash",
+    "version": "5.0-6ubuntu1.1"
+  },
+  {
+    "name": "bash-completion",
+    "version": "1:2.10-1ubuntu1"
+  },
+  {
+    "name": "bc",
+    "version": "1.07.1-2build1"
+  },
+  {
+    "name": "bind9-dnsutils",
+    "version": "1:9.16.1-0ubuntu2.9"
+  },
+  {
+    "name": "bind9-host",
+    "version": "1:9.16.1-0ubuntu2.9"
+  },
+  {
+    "name": "bind9-libs",
+    "version": "1:9.16.1-0ubuntu2.9"
+  },
+  {
+    "name": "bluez",
+    "version": "5.53-0ubuntu3.5"
+  },
+  {
+    "name": "bluez-cups",
+    "version": "5.53-0ubuntu3.5"
+  },
+  {
+    "name": "bluez-obexd",
+    "version": "5.53-0ubuntu3.5"
+  },
+  {
+    "name": "bolt",
+    "version": "0.8-4ubuntu1"
+  },
+  {
+    "name": "brltty",
+    "version": "6.0+dfsg-4ubuntu6"
+  },
+  {
+    "name": "bsdmainutils",
+    "version": "11.1.2ubuntu3"
+  },
+  {
+    "name": "bsdutils",
+    "version": "1:2.34-0.1ubuntu9.3"
+  },
+  {
+    "name": "bubblewrap",
+    "version": "0.4.0-1ubuntu4"
+  },
+  {
+    "name": "busybox-initramfs",
+    "version": "1:1.30.1-4ubuntu6.4"
+  },
+  {
+    "name": "busybox-static",
+    "version": "1:1.30.1-4ubuntu6.4"
+  },
+  {
+    "name": "bzip2",
+    "version": "1.0.8-2"
+  },
+  {
+    "name": "ca-certificates",
+    "version": "20210119~20.04.2"
+  },
+  {
+    "name": "certifi",
+    "version": "2019.11.28"
+  },
+  {
+    "name": "chardet",
+    "version": "3.0.4"
+  },
+  {
+    "name": "cheese-common",
+    "version": "3.34.0-1ubuntu1"
+  },
+  {
+    "name": "colorama",
+    "version": "0.4.3"
+  },
+  {
+    "name": "colord",
+    "version": "1.4.4-2"
+  },
+  {
+    "name": "colord-data",
+    "version": "1.4.4-2"
+  },
+  {
+    "name": "command-not-found",
+    "version": "20.04.5"
+  },
+  {
+    "name": "console-setup",
+    "version": "1.194ubuntu3"
+  },
+  {
+    "name": "console-setup-linux",
+    "version": "1.194ubuntu3"
+  },
+  {
+    "name": "coreutils",
+    "version": "8.30-3ubuntu2"
+  },
+  {
+    "name": "cpio",
+    "version": "2.13+dfsg-2ubuntu0.3"
+  },
+  {
+    "name": "cpp",
+    "version": "4:9.3.0-1ubuntu2"
+  },
+  {
+    "name": "cpp-9",
+    "version": "9.3.0-17ubuntu1~20.04"
+  },
+  {
+    "name": "cracklib-runtime",
+    "version": "2.9.6-3.2"
+  },
+  {
+    "name": "crda",
+    "version": "3.18-1build1"
+  },
+  {
+    "name": "cron",
+    "version": "3.0pl1-136ubuntu1"
+  },
+  {
+    "name": "cryptography",
+    "version": "2.8"
+  },
+  {
+    "name": "cups",
+    "version": "2.3.1-9ubuntu1.1"
+  },
+  {
+    "name": "cups-browsed",
+    "version": "1.27.4-1"
+  },
+  {
+    "name": "cups-bsd",
+    "version": "2.3.1-9ubuntu1.1"
+  },
+  {
+    "name": "cups-client",
+    "version": "2.3.1-9ubuntu1.1"
+  },
+  {
+    "name": "cups-common",
+    "version": "2.3.1-9ubuntu1.1"
+  },
+  {
+    "name": "cups-core-drivers",
+    "version": "2.3.1-9ubuntu1.1"
+  },
+  {
+    "name": "cups-daemon",
+    "version": "2.3.1-9ubuntu1.1"
+  },
+  {
+    "name": "cups-filters",
+    "version": "1.27.4-1"
+  },
+  {
+    "name": "cups-filters-core-drivers",
+    "version": "1.27.4-1"
+  },
+  {
+    "name": "cups-ipp-utils",
+    "version": "2.3.1-9ubuntu1.1"
+  },
+  {
+    "name": "cups-ppdc",
+    "version": "2.3.1-9ubuntu1.1"
+  },
+  {
+    "name": "cups-server-common",
+    "version": "2.3.1-9ubuntu1.1"
+  },
+  {
+    "name": "dash",
+    "version": "0.5.10.2-6"
+  },
+  {
+    "name": "dbus",
+    "version": "1.12.16-2ubuntu2.1"
+  },
+  {
+    "name": "dbus-user-session",
+    "version": "1.12.16-2ubuntu2.1"
+  },
+  {
+    "name": "dbus-x11",
+    "version": "1.12.16-2ubuntu2.1"
+  },
+  {
+    "name": "dc",
+    "version": "1.07.1-2build1"
+  },
+  {
+    "name": "dconf-cli",
+    "version": "0.36.0-1"
+  },
+  {
+    "name": "dconf-gsettings-backend",
+    "version": "0.36.0-1"
+  },
+  {
+    "name": "dconf-service",
+    "version": "0.36.0-1"
+  },
+  {
+    "name": "debconf",
+    "version": "1.5.73"
+  },
+  {
+    "name": "debconf-i18n",
+    "version": "1.5.73"
+  },
+  {
+    "name": "debianutils",
+    "version": "4.9.1"
+  },
+  {
+    "name": "desktop-file-utils",
+    "version": "0.24-1ubuntu3"
+  },
+  {
+    "name": "dictionaries-common",
+    "version": "1.28.1"
+  },
+  {
+    "name": "diffutils",
+    "version": "1:3.7-3"
+  },
+  {
+    "name": "dirmngr",
+    "version": "2.2.19-3ubuntu2.1"
+  },
+  {
+    "name": "distro",
+    "version": "1.4.0"
+  },
+  {
+    "name": "distro-info",
+    "version": "0.23ubuntu1"
+  },
+  {
+    "name": "distro-info",
+    "version": "0.23ubuntu1"
+  },
+  {
+    "name": "distro-info-data",
+    "version": "0.43ubuntu1.9"
+  },
+  {
+    "name": "dmidecode",
+    "version": "3.2-3"
+  },
+  {
+    "name": "dmsetup",
+    "version": "2:1.02.167-1ubuntu1"
+  },
+  {
+    "name": "dns-root-data",
+    "version": "2019052802"
+  },
+  {
+    "name": "dnsmasq-base",
+    "version": "2.80-1.1ubuntu1.4"
+  },
+  {
+    "name": "dosfstools",
+    "version": "4.1-2"
+  },
+  {
+    "name": "dpkg",
+    "version": "1.19.7ubuntu3"
+  },
+  {
+    "name": "e2fsprogs",
+    "version": "1.45.5-2ubuntu1"
+  },
+  {
+    "name": "ed",
+    "version": "1.16-1"
+  },
+  {
+    "name": "eject",
+    "version": "2.1.5+deb1+cvs20081104-14"
+  },
+  {
+    "name": "enchant-2",
+    "version": "2.2.8-1ubuntu0.20.04.1"
+  },
+  {
+    "name": "eog",
+    "version": "3.36.3-0ubuntu1"
+  },
+  {
+    "name": "espeak-ng-data",
+    "version": "1.50+dfsg-6"
+  },
+  {
+    "name": "evince",
+    "version": "3.36.10-0ubuntu1"
+  },
+  {
+    "name": "evince-common",
+    "version": "3.36.10-0ubuntu1"
+  },
+  {
+    "name": "evolution-data-server",
+    "version": "3.36.5-0ubuntu1"
+  },
+  {
+    "name": "evolution-data-server-common",
+    "version": "3.36.5-0ubuntu1"
+  },
+  {
+    "name": "fdisk",
+    "version": "2.34-0.1ubuntu9.3"
+  },
+  {
+    "name": "file",
+    "version": "1:5.38-4"
+  },
+  {
+    "name": "file-roller",
+    "version": "3.36.3-0ubuntu1.1"
+  },
+  {
+    "name": "findutils",
+    "version": "4.7.0-1ubuntu1"
+  },
+  {
+    "name": "firefox",
+    "version": "97.0+build2-0ubuntu0.20.04.1"
+  },
+  {
+    "name": "firefox-locale-en",
+    "version": "97.0+build2-0ubuntu0.20.04.1"
+  },
+  {
+    "name": "fontconfig",
+    "version": "2.13.1-2ubuntu3"
+  },
+  {
+    "name": "fontconfig-config",
+    "version": "2.13.1-2ubuntu3"
+  },
+  {
+    "name": "fonts-beng",
+    "version": "2:1.2"
+  },
+  {
+    "name": "fonts-dejavu-core",
+    "version": "2.37-1"
+  },
+  {
+    "name": "fonts-deva",
+    "version": "2:1.2"
+  },
+  {
+    "name": "fonts-droid-fallback",
+    "version": "1:6.0.1r16-1.1"
+  },
+  {
+    "name": "fonts-freefont-ttf",
+    "version": "20120503-10"
+  },
+  {
+    "name": "fonts-gargi",
+    "version": "2.0-4"
+  },
+  {
+    "name": "fonts-gubbi",
+    "version": "1.3-3"
+  },
+  {
+    "name": "fonts-gujr",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-guru",
+    "version": "2:1.2"
+  },
+  {
+    "name": "fonts-indic",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-kacst",
+    "version": "2.01+mry-14"
+  },
+  {
+    "name": "fonts-kalapi",
+    "version": "1.0-3"
+  },
+  {
+    "name": "fonts-khmeros-core",
+    "version": "5.0-7ubuntu1"
+  },
+  {
+    "name": "fonts-knda",
+    "version": "2:1.2"
+  },
+  {
+    "name": "fonts-lao",
+    "version": "0.0.20060226-9ubuntu1"
+  },
+  {
+    "name": "fonts-liberation2",
+    "version": "2.1.0-1"
+  },
+  {
+    "name": "fonts-lklug-sinhala",
+    "version": "0.6-3"
+  },
+  {
+    "name": "fonts-lohit-beng-assamese",
+    "version": "2.91.5-1"
+  },
+  {
+    "name": "fonts-lohit-beng-bengali",
+    "version": "2.91.5-1"
+  },
+  {
+    "name": "fonts-lohit-guru",
+    "version": "2.91.2-1"
+  },
+  {
+    "name": "fonts-lohit-knda",
+    "version": "2.5.4-2"
+  },
+  {
+    "name": "fonts-lohit-mlym",
+    "version": "2.92.2-1"
+  },
+  {
+    "name": "fonts-lohit-orya",
+    "version": "2.91.2-1"
+  },
+  {
+    "name": "fonts-lohit-taml",
+    "version": "2.91.3-1"
+  },
+  {
+    "name": "fonts-lohit-taml-classical",
+    "version": "2.5.4-1"
+  },
+  {
+    "name": "fonts-lohit-telu",
+    "version": "2.5.5-1"
+  },
+  {
+    "name": "fonts-mlym",
+    "version": "2:1.2"
+  },
+  {
+    "name": "fonts-nakula",
+    "version": "1.0-3"
+  },
+  {
+    "name": "fonts-navilu",
+    "version": "1.2-2"
+  },
+  {
+    "name": "fonts-noto-cjk",
+    "version": "1:20190410+repack1-2"
+  },
+  {
+    "name": "fonts-noto-color-emoji",
+    "version": "0~20200916-1~ubuntu20.04.1"
+  },
+  {
+    "name": "fonts-noto-mono",
+    "version": "20200323-1build1~ubuntu20.04.1"
+  },
+  {
+    "name": "fonts-opensymbol",
+    "version": "2:102.11+LibO6.4.7-0ubuntu0.20.04.2"
+  },
+  {
+    "name": "fonts-orya",
+    "version": "2:1.2"
+  },
+  {
+    "name": "fonts-pagul",
+    "version": "1.0-7"
+  },
+  {
+    "name": "fonts-sahadeva",
+    "version": "1.0-4"
+  },
+  {
+    "name": "fonts-samyak-deva",
+    "version": "1.2.2-4"
+  },
+  {
+    "name": "fonts-samyak-gujr",
+    "version": "1.2.2-4"
+  },
+  {
+    "name": "fonts-samyak-mlym",
+    "version": "1.2.2-4"
+  },
+  {
+    "name": "fonts-samyak-taml",
+    "version": "1.2.2-4"
+  },
+  {
+    "name": "fonts-sarai",
+    "version": "1.0-2"
+  },
+  {
+    "name": "fonts-sil-abyssinica",
+    "version": "2.000-1"
+  },
+  {
+    "name": "fonts-sil-padauk",
+    "version": "4.000-1"
+  },
+  {
+    "name": "fonts-smc",
+    "version": "1:7.1"
+  },
+  {
+    "name": "fonts-smc-anjalioldlipi",
+    "version": "7.1.2-1"
+  },
+  {
+    "name": "fonts-smc-chilanka",
+    "version": "1.400-1"
+  },
+  {
+    "name": "fonts-smc-dyuthi",
+    "version": "3.0.2-1"
+  },
+  {
+    "name": "fonts-smc-gayathri",
+    "version": "1.100-1"
+  },
+  {
+    "name": "fonts-smc-karumbi",
+    "version": "1.1.2-1"
+  },
+  {
+    "name": "fonts-smc-keraleeyam",
+    "version": "3.0.2-1"
+  },
+  {
+    "name": "fonts-smc-manjari",
+    "version": "1.710-1"
+  },
+  {
+    "name": "fonts-smc-rachana",
+    "version": "7.0.2-1"
+  },
+  {
+    "name": "fonts-taml",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-telu",
+    "version": "2:1.2"
+  },
+  {
+    "name": "fonts-telu-extra",
+    "version": "2.0-4"
+  },
+  {
+    "name": "fonts-thai-tlwg",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tibetan-machine",
+    "version": "1.901b-5"
+  },
+  {
+    "name": "fonts-tlwg-garuda",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-garuda-ttf",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-kinnari",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-kinnari-ttf",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-laksaman",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-laksaman-ttf",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-loma",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-loma-ttf",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-mono",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-mono-ttf",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-norasi",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-norasi-ttf",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-purisa",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-purisa-ttf",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-sawasdee",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-sawasdee-ttf",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-typewriter",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-typewriter-ttf",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-typist",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-typist-ttf",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-typo",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-typo-ttf",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-umpush",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-umpush-ttf",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-waree",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-tlwg-waree-ttf",
+    "version": "1:0.7.1-3"
+  },
+  {
+    "name": "fonts-ubuntu",
+    "version": "0.83-4ubuntu1"
+  },
+  {
+    "name": "fonts-urw-base35",
+    "version": "20170801.1-3"
+  },
+  {
+    "name": "fonts-yrsa-rasa",
+    "version": "1.002-2"
+  },
+  {
+    "name": "foomatic-db-compressed-ppds",
+    "version": "20200401-1"
+  },
+  {
+    "name": "fprintd",
+    "version": "1.90.9-1~ubuntu20.04.1"
+  },
+  {
+    "name": "friendly-recovery",
+    "version": "0.2.41ubuntu0.20.04.1"
+  },
+  {
+    "name": "ftp",
+    "version": "0.17-34.1"
+  },
+  {
+    "name": "fuse",
+    "version": "2.9.9-3"
+  },
+  {
+    "name": "fwupd",
+    "version": "1.5.11-0ubuntu1~20.04.2"
+  },
+  {
+    "name": "fwupd-signed",
+    "version": "1.27.1ubuntu5+1.5.11-0ubuntu1~20.04.2"
+  },
+  {
+    "name": "gamemode",
+    "version": "1.5.1-0ubuntu3.1"
+  },
+  {
+    "name": "gcc-10-base",
+    "version": "10.3.0-1ubuntu1~20.04"
+  },
+  {
+    "name": "gcc-9-base",
+    "version": "9.3.0-17ubuntu1~20.04"
+  },
+  {
+    "name": "gcr",
+    "version": "3.36.0-2build1"
+  },
+  {
+    "name": "gdb",
+    "version": "9.2-0ubuntu1~20.04.1"
+  },
+  {
+    "name": "gdbserver",
+    "version": "9.2-0ubuntu1~20.04.1"
+  },
+  {
+    "name": "gdisk",
+    "version": "1.0.5-1"
+  },
+  {
+    "name": "gdm3",
+    "version": "3.36.3-0ubuntu0.20.04.4"
+  },
+  {
+    "name": "gedit",
+    "version": "3.36.2-0ubuntu1"
+  },
+  {
+    "name": "gedit-common",
+    "version": "3.36.2-0ubuntu1"
+  },
+  {
+    "name": "genisoimage",
+    "version": "9:1.1.11-3.1ubuntu1"
+  },
+  {
+    "name": "geoclue-2.0",
+    "version": "2.5.6-0ubuntu1"
+  },
+  {
+    "name": "gettext-base",
+    "version": "0.19.8.1-10build1"
+  },
+  {
+    "name": "ghostscript",
+    "version": "9.50~dfsg-5ubuntu4.5"
+  },
+  {
+    "name": "ghostscript-x",
+    "version": "9.50~dfsg-5ubuntu4.5"
+  },
+  {
+    "name": "gir1.2-accountsservice-1.0",
+    "version": "0.6.55-0ubuntu12~20.04.5"
+  },
+  {
+    "name": "gir1.2-atk-1.0",
+    "version": "2.35.1-1ubuntu2"
+  },
+  {
+    "name": "gir1.2-atspi-2.0",
+    "version": "2.36.0-2"
+  },
+  {
+    "name": "gir1.2-clutter-1.0",
+    "version": "1.26.4+dfsg-1"
+  },
+  {
+    "name": "gir1.2-clutter-gst-3.0",
+    "version": "3.0.27-1"
+  },
+  {
+    "name": "gir1.2-cogl-1.0",
+    "version": "1.22.6-1"
+  },
+  {
+    "name": "gir1.2-coglpango-1.0",
+    "version": "1.22.6-1"
+  },
+  {
+    "name": "gir1.2-dee-1.0",
+    "version": "1.2.7+17.10.20170616-4ubuntu6"
+  },
+  {
+    "name": "gir1.2-freedesktop",
+    "version": "1.64.1-1~ubuntu20.04.1"
+  },
+  {
+    "name": "gir1.2-gck-1",
+    "version": "3.36.0-2build1"
+  },
+  {
+    "name": "gir1.2-gcr-3",
+    "version": "3.36.0-2build1"
+  },
+  {
+    "name": "gir1.2-gdesktopenums-3.0",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-gdkpixbuf-2.0",
+    "version": "2.40.0+dfsg-3ubuntu0.2"
+  },
+  {
+    "name": "gir1.2-gdm-1.0",
+    "version": "3.36.3-0ubuntu0.20.04.4"
+  },
+  {
+    "name": "gir1.2-geoclue-2.0",
+    "version": "2.5.6-0ubuntu1"
+  },
+  {
+    "name": "gir1.2-glib-2.0",
+    "version": "1.64.1-1~ubuntu20.04.1"
+  },
+  {
+    "name": "gir1.2-gnomebluetooth-1.0",
+    "version": "3.34.3-0ubuntu1"
+  },
+  {
+    "name": "gir1.2-gnomedesktop-3.0",
+    "version": "3.36.8-0ubuntu1"
+  },
+  {
+    "name": "gir1.2-goa-1.0",
+    "version": "3.36.1-0ubuntu1"
+  },
+  {
+    "name": "gir1.2-graphene-1.0",
+    "version": "1.10.0-1build2"
+  },
+  {
+    "name": "gir1.2-gst-plugins-base-1.0",
+    "version": "1.16.2-4ubuntu0.1"
+  },
+  {
+    "name": "gir1.2-gstreamer-1.0",
+    "version": "1.16.2-2"
+  },
+  {
+    "name": "gir1.2-gtk-3.0",
+    "version": "3.24.20-0ubuntu1"
+  },
+  {
+    "name": "gir1.2-gtkclutter-1.0",
+    "version": "1.8.4-4"
+  },
+  {
+    "name": "gir1.2-gtksource-4",
+    "version": "4.6.0-1"
+  },
+  {
+    "name": "gir1.2-gweather-3.0",
+    "version": "3.36.1-1~ubuntu20.04.1"
+  },
+  {
+    "name": "gir1.2-ibus-1.0",
+    "version": "1.5.22-2ubuntu2.1"
+  },
+  {
+    "name": "gir1.2-javascriptcoregtk-4.0",
+    "version": "2.34.4-0ubuntu0.20.04.1"
+  },
+  {
+    "name": "gir1.2-json-1.0",
+    "version": "1.4.4-2ubuntu2"
+  },
+  {
+    "name": "gir1.2-mutter-6",
+    "version": "3.36.9-0ubuntu0.20.04.2"
+  },
+  {
+    "name": "gir1.2-nm-1.0",
+    "version": "1.22.10-1ubuntu2.3"
+  },
+  {
+    "name": "gir1.2-nma-1.0",
+    "version": "1.8.24-1ubuntu3"
+  },
+  {
+    "name": "gir1.2-notify-0.7",
+    "version": "0.7.9-1ubuntu2"
+  },
+  {
+    "name": "gir1.2-packagekitglib-1.0",
+    "version": "1.1.13-2ubuntu1.1"
+  },
+  {
+    "name": "gir1.2-pango-1.0",
+    "version": "1.44.7-2ubuntu4"
+  },
+  {
+    "name": "gir1.2-peas-1.0",
+    "version": "1.26.0-2"
+  },
+  {
+    "name": "gir1.2-polkit-1.0",
+    "version": "0.105-26ubuntu1.2"
+  },
+  {
+    "name": "gir1.2-rsvg-2.0",
+    "version": "2.48.9-1ubuntu0.20.04.1"
+  },
+  {
+    "name": "gir1.2-secret-1",
+    "version": "0.20.4-0ubuntu1"
+  },
+  {
+    "name": "gir1.2-snapd-1",
+    "version": "1.58-0ubuntu0.20.04.0"
+  },
+  {
+    "name": "gir1.2-soup-2.4",
+    "version": "2.70.0-1"
+  },
+  {
+    "name": "gir1.2-unity-5.0",
+    "version": "7.1.4+19.04.20190319-0ubuntu3"
+  },
+  {
+    "name": "gir1.2-upowerglib-1.0",
+    "version": "0.99.11-1build2"
+  },
+  {
+    "name": "gir1.2-vte-2.91",
+    "version": "0.60.3-0ubuntu1~20.04"
+  },
+  {
+    "name": "gir1.2-webkit2-4.0",
+    "version": "2.34.4-0ubuntu0.20.04.1"
+  },
+  {
+    "name": "gjs",
+    "version": "1.64.5-0ubuntu0.20.04.01"
+  },
+  {
+    "name": "glib-networking",
+    "version": "2.64.2-1ubuntu0.1"
+  },
+  {
+    "name": "glib-networking-common",
+    "version": "2.64.2-1ubuntu0.1"
+  },
+  {
+    "name": "glib-networking-services",
+    "version": "2.64.2-1ubuntu0.1"
+  },
+  {
+    "name": "gnome-bluetooth",
+    "version": "3.34.3-0ubuntu1"
+  },
+  {
+    "name": "gnome-calculator",
+    "version": "1:3.36.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-characters",
+    "version": "3.34.0-1"
+  },
+  {
+    "name": "gnome-control-center",
+    "version": "1:3.36.5-0ubuntu3"
+  },
+  {
+    "name": "gnome-control-center-data",
+    "version": "1:3.36.5-0ubuntu3"
+  },
+  {
+    "name": "gnome-control-center-faces",
+    "version": "1:3.36.5-0ubuntu3"
+  },
+  {
+    "name": "gnome-desktop3-data",
+    "version": "3.36.8-0ubuntu1"
+  },
+  {
+    "name": "gnome-disk-utility",
+    "version": "3.36.3-0ubuntu1"
+  },
+  {
+    "name": "gnome-font-viewer",
+    "version": "3.34.0-2"
+  },
+  {
+    "name": "gnome-getting-started-docs",
+    "version": "3.36.2-0ubuntu0.1"
+  },
+  {
+    "name": "gnome-initial-setup",
+    "version": "3.36.2-0ubuntu2"
+  },
+  {
+    "name": "gnome-logs",
+    "version": "3.34.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-online-accounts",
+    "version": "3.36.1-0ubuntu1"
+  },
+  {
+    "name": "gnome-screenshot",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-session-bin",
+    "version": "3.36.0-2ubuntu1"
+  },
+  {
+    "name": "gnome-session-canberra",
+    "version": "0.30-7ubuntu1"
+  },
+  {
+    "name": "gnome-session-common",
+    "version": "3.36.0-2ubuntu1"
+  },
+  {
+    "name": "gnome-settings-daemon",
+    "version": "3.36.1-0ubuntu1.1"
+  },
+  {
+    "name": "gnome-settings-daemon-common",
+    "version": "3.36.1-0ubuntu1.1"
+  },
+  {
+    "name": "gnome-shell",
+    "version": "3.36.9-0ubuntu0.20.04.2"
+  },
+  {
+    "name": "gnome-shell-common",
+    "version": "3.36.9-0ubuntu0.20.04.2"
+  },
+  {
+    "name": "gnome-shell-extension-appindicator",
+    "version": "33.1-0ubuntu0.20.04.2"
+  },
+  {
+    "name": "gnome-shell-extension-desktop-icons",
+    "version": "20.04.0-3~ubuntu20.04.6"
+  },
+  {
+    "name": "gnome-shell-extension-ubuntu-dock",
+    "version": "68ubuntu1~20.04.1"
+  },
+  {
+    "name": "gnome-startup-applications",
+    "version": "3.36.0-2ubuntu1"
+  },
+  {
+    "name": "gnome-system-monitor",
+    "version": "3.36.1-0ubuntu0.20.04.1"
+  },
+  {
+    "name": "gnome-terminal",
+    "version": "3.36.2-1ubuntu1~20.04"
+  },
+  {
+    "name": "gnome-terminal-data",
+    "version": "3.36.2-1ubuntu1~20.04"
+  },
+  {
+    "name": "gnome-user-docs",
+    "version": "3.36.2+git20200704-0ubuntu0.1"
+  },
+  {
+    "name": "gnupg",
+    "version": "2.2.19-3ubuntu2.1"
+  },
+  {
+    "name": "gnupg-l10n",
+    "version": "2.2.19-3ubuntu2.1"
+  },
+  {
+    "name": "gnupg-utils",
+    "version": "2.2.19-3ubuntu2.1"
+  },
+  {
+    "name": "gpg",
+    "version": "2.2.19-3ubuntu2.1"
+  },
+  {
+    "name": "gpg-agent",
+    "version": "2.2.19-3ubuntu2.1"
+  },
+  {
+    "name": "gpg-wks-client",
+    "version": "2.2.19-3ubuntu2.1"
+  },
+  {
+    "name": "gpg-wks-server",
+    "version": "2.2.19-3ubuntu2.1"
+  },
+  {
+    "name": "gpgconf",
+    "version": "2.2.19-3ubuntu2.1"
+  },
+  {
+    "name": "gpgsm",
+    "version": "2.2.19-3ubuntu2.1"
+  },
+  {
+    "name": "gpgv",
+    "version": "2.2.19-3ubuntu2.1"
+  },
+  {
+    "name": "grep",
+    "version": "3.4-1"
+  },
+  {
+    "name": "groff-base",
+    "version": "1.22.4-4build1"
+  },
+  {
+    "name": "grub-common",
+    "version": "2.04-1ubuntu26.13"
+  },
+  {
+    "name": "grub-pc",
+    "version": "2.04-1ubuntu26.13"
+  },
+  {
+    "name": "grub-pc-bin",
+    "version": "2.04-1ubuntu26.13"
+  },
+  {
+    "name": "grub2-common",
+    "version": "2.04-1ubuntu26.13"
+  },
+  {
+    "name": "gsettings-desktop-schemas",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "gstreamer1.0-alsa",
+    "version": "1.16.2-4ubuntu0.1"
+  },
+  {
+    "name": "gstreamer1.0-clutter-3.0",
+    "version": "3.0.27-1"
+  },
+  {
+    "name": "gstreamer1.0-gl",
+    "version": "1.16.2-4ubuntu0.1"
+  },
+  {
+    "name": "gstreamer1.0-packagekit",
+    "version": "1.1.13-2ubuntu1.1"
+  },
+  {
+    "name": "gstreamer1.0-plugins-base",
+    "version": "1.16.2-4ubuntu0.1"
+  },
+  {
+    "name": "gstreamer1.0-plugins-base-apps",
+    "version": "1.16.2-4ubuntu0.1"
+  },
+  {
+    "name": "gstreamer1.0-plugins-good",
+    "version": "1.16.2-1ubuntu2.1"
+  },
+  {
+    "name": "gstreamer1.0-pulseaudio",
+    "version": "1.16.2-1ubuntu2.1"
+  },
+  {
+    "name": "gstreamer1.0-tools",
+    "version": "1.16.2-2"
+  },
+  {
+    "name": "gstreamer1.0-x",
+    "version": "1.16.2-4ubuntu0.1"
+  },
+  {
+    "name": "gtk-update-icon-cache",
+    "version": "3.24.20-0ubuntu1"
+  },
+  {
+    "name": "gtk2-engines-pixbuf",
+    "version": "2.24.32-4ubuntu4"
+  },
+  {
+    "name": "gvfs",
+    "version": "1.44.1-1ubuntu1"
+  },
+  {
+    "name": "gvfs-backends",
+    "version": "1.44.1-1ubuntu1"
+  },
+  {
+    "name": "gvfs-bin",
+    "version": "1.44.1-1ubuntu1"
+  },
+  {
+    "name": "gvfs-common",
+    "version": "1.44.1-1ubuntu1"
+  },
+  {
+    "name": "gvfs-daemons",
+    "version": "1.44.1-1ubuntu1"
+  },
+  {
+    "name": "gvfs-fuse",
+    "version": "1.44.1-1ubuntu1"
+  },
+  {
+    "name": "gvfs-libs",
+    "version": "1.44.1-1ubuntu1"
+  },
+  {
+    "name": "gzip",
+    "version": "1.10-0ubuntu4"
+  },
+  {
+    "name": "hdparm",
+    "version": "9.58+ds-4"
+  },
+  {
+    "name": "hplip",
+    "version": "3.20.3+dfsg0-2"
+  },
+  {
+    "name": "hplip-data",
+    "version": "3.20.3+dfsg0-2"
+  },
+  {
+    "name": "httplib2",
+    "version": "0.14.0"
+  },
+  {
+    "name": "hunspell-en-us",
+    "version": "1:2018.04.16-1"
+  },
+  {
+    "name": "ibus",
+    "version": "1.5.22-2ubuntu2.1"
+  },
+  {
+    "name": "ibus-data",
+    "version": "1.5.22-2ubuntu2.1"
+  },
+  {
+    "name": "ibus-gtk",
+    "version": "1.5.22-2ubuntu2.1"
+  },
+  {
+    "name": "ibus-gtk3",
+    "version": "1.5.22-2ubuntu2.1"
+  },
+  {
+    "name": "ibus-table",
+    "version": "1.9.25-1"
+  },
+  {
+    "name": "idna",
+    "version": "2.8"
+  },
+  {
+    "name": "iio-sensor-proxy",
+    "version": "2.8-1ubuntu1"
+  },
+  {
+    "name": "im-config",
+    "version": "0.44-1ubuntu1.3"
+  },
+  {
+    "name": "info",
+    "version": "6.7.0.dfsg.2-5"
+  },
+  {
+    "name": "init",
+    "version": "1.57"
+  },
+  {
+    "name": "init-system-helpers",
+    "version": "1.57"
+  },
+  {
+    "name": "initramfs-tools",
+    "version": "0.136ubuntu6.7"
+  },
+  {
+    "name": "initramfs-tools-bin",
+    "version": "0.136ubuntu6.7"
+  },
+  {
+    "name": "initramfs-tools-core",
+    "version": "0.136ubuntu6.7"
+  },
+  {
+    "name": "inputattach",
+    "version": "1:1.7.0-1"
+  },
+  {
+    "name": "install-info",
+    "version": "6.7.0.dfsg.2-5"
+  },
+  {
+    "name": "intel-microcode",
+    "version": "3.20210608.0ubuntu0.20.04.1"
+  },
+  {
+    "name": "ippusbxd",
+    "version": "1.34-2ubuntu1"
+  },
+  {
+    "name": "iproute2",
+    "version": "5.5.0-1ubuntu1"
+  },
+  {
+    "name": "iptables",
+    "version": "1.8.4-3ubuntu2"
+  },
+  {
+    "name": "iputils-ping",
+    "version": "3:20190709-3"
+  },
+  {
+    "name": "iputils-tracepath",
+    "version": "3:20190709-3"
+  },
+  {
+    "name": "irqbalance",
+    "version": "1.6.0-3ubuntu1"
+  },
+  {
+    "name": "isc-dhcp-client",
+    "version": "4.4.1-2.1ubuntu5.20.04.2"
+  },
+  {
+    "name": "isc-dhcp-common",
+    "version": "4.4.1-2.1ubuntu5.20.04.2"
+  },
+  {
+    "name": "iso-codes",
+    "version": "4.4-1"
+  },
+  {
+    "name": "iw",
+    "version": "5.4-1"
+  },
+  {
+    "name": "kbd",
+    "version": "2.0.4-4ubuntu2"
+  },
+  {
+    "name": "kerneloops",
+    "version": "0.12+git20140509-6ubuntu2"
+  },
+  {
+    "name": "keyboard-configuration",
+    "version": "1.194ubuntu3"
+  },
+  {
+    "name": "keyring",
+    "version": "18.0.1"
+  },
+  {
+    "name": "klibc-utils",
+    "version": "2.0.7-1ubuntu5"
+  },
+  {
+    "name": "kmod",
+    "version": "27-1ubuntu2"
+  },
+  {
+    "name": "krb5-locales",
+    "version": "1.17-6ubuntu4.1"
+  },
+  {
+    "name": "language-pack-en",
+    "version": "1:20.04+20220211"
+  },
+  {
+    "name": "language-pack-en-base",
+    "version": "1:20.04+20220211"
+  },
+  {
+    "name": "language-pack-gnome-en",
+    "version": "1:20.04+20210802"
+  },
+  {
+    "name": "language-pack-gnome-en-base",
+    "version": "1:20.04+20210802"
+  },
+  {
+    "name": "language-selector-common",
+    "version": "0.204.2"
+  },
+  {
+    "name": "language-selector-gnome",
+    "version": "0.204.2"
+  },
+  {
+    "name": "lazr.uri",
+    "version": "1.0.3"
+  },
+  {
+    "name": "less",
+    "version": "551-1ubuntu0.1"
+  },
+  {
+    "name": "libaa1",
+    "version": "1.4p5-46"
+  },
+  {
+    "name": "libaccountsservice0",
+    "version": "0.6.55-0ubuntu12~20.04.5"
+  },
+  {
+    "name": "libacl1",
+    "version": "2.2.53-6"
+  },
+  {
+    "name": "libamtk-5-0",
+    "version": "5.0.2-1build1"
+  },
+  {
+    "name": "libamtk-5-common",
+    "version": "5.0.2-1build1"
+  },
+  {
+    "name": "libapparmor1",
+    "version": "2.13.3-7ubuntu5.1"
+  },
+  {
+    "name": "libappindicator3-1",
+    "version": "12.10.1+20.04.20200408.1-0ubuntu1"
+  },
+  {
+    "name": "libappstream4",
+    "version": "0.12.10-2"
+  },
+  {
+    "name": "libapt-pkg6.0",
+    "version": "2.0.6"
+  },
+  {
+    "name": "libarchive13",
+    "version": "3.4.0-2ubuntu1.1"
+  },
+  {
+    "name": "libargon2-1",
+    "version": "0~20171227-0.2"
+  },
+  {
+    "name": "libasn1-8-heimdal",
+    "version": "7.7.0+dfsg-1ubuntu1"
+  },
+  {
+    "name": "libasound2",
+    "version": "1.2.2-2.1ubuntu2.5"
+  },
+  {
+    "name": "libasound2-data",
+    "version": "1.2.2-2.1ubuntu2.5"
+  },
+  {
+    "name": "libasound2-plugins",
+    "version": "1.2.2-1ubuntu1"
+  },
+  {
+    "name": "libaspell15",
+    "version": "0.60.8-1ubuntu0.1"
+  },
+  {
+    "name": "libassuan0",
+    "version": "2.5.3-7ubuntu2"
+  },
+  {
+    "name": "libatk-adaptor",
+    "version": "2.34.2-0ubuntu2~20.04.1"
+  },
+  {
+    "name": "libatk-bridge2.0-0",
+    "version": "2.34.2-0ubuntu2~20.04.1"
+  },
+  {
+    "name": "libatk1.0-0",
+    "version": "2.35.1-1ubuntu2"
+  },
+  {
+    "name": "libatk1.0-data",
+    "version": "2.35.1-1ubuntu2"
+  },
+  {
+    "name": "libatkmm-1.6-1v5",
+    "version": "2.28.0-2build1"
+  },
+  {
+    "name": "libatopology2",
+    "version": "1.2.2-2.1ubuntu2.5"
+  },
+  {
+    "name": "libatspi2.0-0",
+    "version": "2.36.0-2"
+  },
+  {
+    "name": "libattr1",
+    "version": "1:2.4.48-5"
+  },
+  {
+    "name": "libaudit-common",
+    "version": "1:2.8.5-2ubuntu6"
+  },
+  {
+    "name": "libaudit1",
+    "version": "1:2.8.5-2ubuntu6"
+  },
+  {
+    "name": "libauthen-sasl-perl",
+    "version": "2.1600-1"
+  },
+  {
+    "name": "libavahi-client3",
+    "version": "0.7-4ubuntu7.1"
+  },
+  {
+    "name": "libavahi-common-data",
+    "version": "0.7-4ubuntu7.1"
+  },
+  {
+    "name": "libavahi-common3",
+    "version": "0.7-4ubuntu7.1"
+  },
+  {
+    "name": "libavahi-core7",
+    "version": "0.7-4ubuntu7.1"
+  },
+  {
+    "name": "libavahi-glib1",
+    "version": "0.7-4ubuntu7.1"
+  },
+  {
+    "name": "libbabeltrace1",
+    "version": "1.5.8-1build1"
+  },
+  {
+    "name": "libblkid1",
+    "version": "2.34-0.1ubuntu9.3"
+  },
+  {
+    "name": "libblockdev-crypto2",
+    "version": "2.23-2ubuntu3"
+  },
+  {
+    "name": "libblockdev-fs2",
+    "version": "2.23-2ubuntu3"
+  },
+  {
+    "name": "libblockdev-loop2",
+    "version": "2.23-2ubuntu3"
+  },
+  {
+    "name": "libblockdev-part-err2",
+    "version": "2.23-2ubuntu3"
+  },
+  {
+    "name": "libblockdev-part2",
+    "version": "2.23-2ubuntu3"
+  },
+  {
+    "name": "libblockdev-swap2",
+    "version": "2.23-2ubuntu3"
+  },
+  {
+    "name": "libblockdev-utils2",
+    "version": "2.23-2ubuntu3"
+  },
+  {
+    "name": "libblockdev2",
+    "version": "2.23-2ubuntu3"
+  },
+  {
+    "name": "libbluetooth3",
+    "version": "5.53-0ubuntu3.5"
+  },
+  {
+    "name": "libboost-thread1.71.0",
+    "version": "1.71.0-6ubuntu6"
+  },
+  {
+    "name": "libbrlapi0.7",
+    "version": "6.0+dfsg-4ubuntu6"
+  },
+  {
+    "name": "libbrotli1",
+    "version": "1.0.7-6ubuntu0.1"
+  },
+  {
+    "name": "libbsd0",
+    "version": "0.10.0-1"
+  },
+  {
+    "name": "libbz2-1.0",
+    "version": "1.0.8-2"
+  },
+  {
+    "name": "libc-bin",
+    "version": "2.31-0ubuntu9.2"
+  },
+  {
+    "name": "libc6",
+    "version": "2.31-0ubuntu9.2"
+  },
+  {
+    "name": "libc6-dbg",
+    "version": "2.31-0ubuntu9.2"
+  },
+  {
+    "name": "libcaca0",
+    "version": "0.99.beta19-2.1ubuntu1.20.04.2"
+  },
+  {
+    "name": "libcairo-gobject-perl",
+    "version": "1.005-2"
+  },
+  {
+    "name": "libcairo-gobject2",
+    "version": "1.16.0-4ubuntu1"
+  },
+  {
+    "name": "libcairo-perl",
+    "version": "1.107-1"
+  },
+  {
+    "name": "libcairo2",
+    "version": "1.16.0-4ubuntu1"
+  },
+  {
+    "name": "libcamel-1.2-62",
+    "version": "3.36.5-0ubuntu1"
+  },
+  {
+    "name": "libcanberra-gtk3-0",
+    "version": "0.30-7ubuntu1"
+  },
+  {
+    "name": "libcanberra-gtk3-module",
+    "version": "0.30-7ubuntu1"
+  },
+  {
+    "name": "libcanberra-pulse",
+    "version": "0.30-7ubuntu1"
+  },
+  {
+    "name": "libcanberra0",
+    "version": "0.30-7ubuntu1"
+  },
+  {
+    "name": "libcap-ng0",
+    "version": "0.7.9-2.1build1"
+  },
+  {
+    "name": "libcap2",
+    "version": "1:2.32-1"
+  },
+  {
+    "name": "libcap2-bin",
+    "version": "1:2.32-1"
+  },
+  {
+    "name": "libcbor0.6",
+    "version": "0.6.0-0ubuntu1"
+  },
+  {
+    "name": "libcc1-0",
+    "version": "10.3.0-1ubuntu1~20.04"
+  },
+  {
+    "name": "libcdio-cdda2",
+    "version": "10.2+2.0.0-1"
+  },
+  {
+    "name": "libcdio-paranoia2",
+    "version": "10.2+2.0.0-1"
+  },
+  {
+    "name": "libcdio18",
+    "version": "2.0.0-2"
+  },
+  {
+    "name": "libcdparanoia0",
+    "version": "3.10.2+debian-13"
+  },
+  {
+    "name": "libcheese-gtk25",
+    "version": "3.34.0-1ubuntu1"
+  },
+  {
+    "name": "libcheese8",
+    "version": "3.34.0-1ubuntu1"
+  },
+  {
+    "name": "libclutter-1.0-0",
+    "version": "1.26.4+dfsg-1"
+  },
+  {
+    "name": "libclutter-1.0-common",
+    "version": "1.26.4+dfsg-1"
+  },
+  {
+    "name": "libclutter-gst-3.0-0",
+    "version": "3.0.27-1"
+  },
+  {
+    "name": "libcogl-common",
+    "version": "1.22.6-1"
+  },
+  {
+    "name": "libcogl-pango20",
+    "version": "1.22.6-1"
+  },
+  {
+    "name": "libcogl-path20",
+    "version": "1.22.6-1"
+  },
+  {
+    "name": "libcogl20",
+    "version": "1.22.6-1"
+  },
+  {
+    "name": "libcolord2",
+    "version": "1.4.4-2"
+  },
+  {
+    "name": "libcolorhug2",
+    "version": "1.4.4-2"
+  },
+  {
+    "name": "libcom-err2",
+    "version": "1.45.5-2ubuntu1"
+  },
+  {
+    "name": "libcrack2",
+    "version": "2.9.6-3.2"
+  },
+  {
+    "name": "libcrypt1",
+    "version": "1:4.4.10-10ubuntu4"
+  },
+  {
+    "name": "libcryptsetup12",
+    "version": "2:2.2.2-3ubuntu2.4"
+  },
+  {
+    "name": "libcue2",
+    "version": "2.2.1-2"
+  },
+  {
+    "name": "libcups2",
+    "version": "2.3.1-9ubuntu1.1"
+  },
+  {
+    "name": "libcupsfilters1",
+    "version": "1.27.4-1"
+  },
+  {
+    "name": "libcupsimage2",
+    "version": "2.3.1-9ubuntu1.1"
+  },
+  {
+    "name": "libcurl3-gnutls",
+    "version": "7.68.0-1ubuntu2.7"
+  },
+  {
+    "name": "libcurl4",
+    "version": "7.68.0-1ubuntu2.11"
+  },
+  {
+    "name": "libdaemon0",
+    "version": "0.14-7"
+  },
+  {
+    "name": "libdata-dump-perl",
+    "version": "1.23-1"
+  },
+  {
+    "name": "libdatrie1",
+    "version": "0.2.12-3"
+  },
+  {
+    "name": "libdb5.3",
+    "version": "5.3.28+dfsg1-0.6ubuntu2"
+  },
+  {
+    "name": "libdbus-1-3",
+    "version": "1.12.16-2ubuntu2.1"
+  },
+  {
+    "name": "libdbus-glib-1-2",
+    "version": "0.110-5fakssync1"
+  },
+  {
+    "name": "libdconf1",
+    "version": "0.36.0-1"
+  },
+  {
+    "name": "libdebconfclient0",
+    "version": "0.251ubuntu1"
+  },
+  {
+    "name": "libdee-1.0-4",
+    "version": "1.2.7+17.10.20170616-4ubuntu6"
+  },
+  {
+    "name": "libdevmapper1.02.1",
+    "version": "2:1.02.167-1ubuntu1"
+  },
+  {
+    "name": "libdjvulibre-text",
+    "version": "3.5.27.1-14ubuntu0.1"
+  },
+  {
+    "name": "libdjvulibre21",
+    "version": "3.5.27.1-14ubuntu0.1"
+  },
+  {
+    "name": "libdns-export1109",
+    "version": "1:9.11.16+dfsg-3~ubuntu1"
+  },
+  {
+    "name": "libdpkg-perl",
+    "version": "1.19.7ubuntu3"
+  },
+  {
+    "name": "libdrm-amdgpu1",
+    "version": "2.4.107-8ubuntu1~20.04.1"
+  },
+  {
+    "name": "libdrm-common",
+    "version": "2.4.107-8ubuntu1~20.04.1"
+  },
+  {
+    "name": "libdrm-intel1",
+    "version": "2.4.107-8ubuntu1~20.04.1"
+  },
+  {
+    "name": "libdrm-nouveau2",
+    "version": "2.4.107-8ubuntu1~20.04.1"
+  },
+  {
+    "name": "libdrm-radeon1",
+    "version": "2.4.107-8ubuntu1~20.04.1"
+  },
+  {
+    "name": "libdrm2",
+    "version": "2.4.107-8ubuntu1~20.04.1"
+  },
+  {
+    "name": "libdv4",
+    "version": "1.0.0-12"
+  },
+  {
+    "name": "libdw1",
+    "version": "0.176-1.1build1"
+  },
+  {
+    "name": "libebackend-1.2-10",
+    "version": "3.36.5-0ubuntu1"
+  },
+  {
+    "name": "libebook-1.2-20",
+    "version": "3.36.5-0ubuntu1"
+  },
+  {
+    "name": "libebook-contacts-1.2-3",
+    "version": "3.36.5-0ubuntu1"
+  },
+  {
+    "name": "libecal-2.0-1",
+    "version": "3.36.5-0ubuntu1"
+  },
+  {
+    "name": "libedata-book-1.2-26",
+    "version": "3.36.5-0ubuntu1"
+  },
+  {
+    "name": "libedata-cal-2.0-1",
+    "version": "3.36.5-0ubuntu1"
+  },
+  {
+    "name": "libedataserver-1.2-24",
+    "version": "3.36.5-0ubuntu1"
+  },
+  {
+    "name": "libedataserverui-1.2-2",
+    "version": "3.36.5-0ubuntu1"
+  },
+  {
+    "name": "libedit2",
+    "version": "3.1-20191231-1"
+  },
+  {
+    "name": "libefiboot1",
+    "version": "37-2ubuntu2.2"
+  },
+  {
+    "name": "libefivar1",
+    "version": "37-2ubuntu2.2"
+  },
+  {
+    "name": "libegl-mesa0",
+    "version": "21.2.6-0ubuntu0.1~20.04.1"
+  },
+  {
+    "name": "libegl1",
+    "version": "1.3.2-1~ubuntu0.20.04.1"
+  },
+  {
+    "name": "libelf1",
+    "version": "0.176-1.1build1"
+  },
+  {
+    "name": "libenchant-2-2",
+    "version": "2.2.8-1ubuntu0.20.04.1"
+  },
+  {
+    "name": "libencode-locale-perl",
+    "version": "1.05-1"
+  },
+  {
+    "name": "libepoxy0",
+    "version": "1.5.4-1"
+  },
+  {
+    "name": "libespeak-ng1",
+    "version": "1.50+dfsg-6"
+  },
+  {
+    "name": "libestr0",
+    "version": "0.1.10-2.1"
+  },
+  {
+    "name": "libevdev2",
+    "version": "1.9.0+dfsg-1ubuntu0.1"
+  },
+  {
+    "name": "libevdocument3-4",
+    "version": "3.36.10-0ubuntu1"
+  },
+  {
+    "name": "libevview3-3",
+    "version": "3.36.10-0ubuntu1"
+  },
+  {
+    "name": "libexempi8",
+    "version": "2.5.1-1build1"
+  },
+  {
+    "name": "libexif12",
+    "version": "0.6.21-6ubuntu0.4"
+  },
+  {
+    "name": "libexiv2-27",
+    "version": "0.27.2-8ubuntu2.7"
+  },
+  {
+    "name": "libexpat1",
+    "version": "2.2.9-1ubuntu0.2"
+  },
+  {
+    "name": "libext2fs2",
+    "version": "1.45.5-2ubuntu1"
+  },
+  {
+    "name": "libextutils-pkgconfig-perl",
+    "version": "1.16-1"
+  },
+  {
+    "name": "libfastjson4",
+    "version": "0.99.8-2"
+  },
+  {
+    "name": "libfdisk1",
+    "version": "2.34-0.1ubuntu9.3"
+  },
+  {
+    "name": "libffi7",
+    "version": "3.3-4"
+  },
+  {
+    "name": "libfftw3-single3",
+    "version": "3.3.8-2ubuntu1"
+  },
+  {
+    "name": "libfido2-1",
+    "version": "1.3.1-1ubuntu2"
+  },
+  {
+    "name": "libfile-desktopentry-perl",
+    "version": "0.22-1"
+  },
+  {
+    "name": "libfile-fcntllock-perl",
+    "version": "0.22-3build4"
+  },
+  {
+    "name": "libfile-listing-perl",
+    "version": "6.04-1"
+  },
+  {
+    "name": "libfile-mimeinfo-perl",
+    "version": "0.29-1"
+  },
+  {
+    "name": "libflac8",
+    "version": "1.3.3-1build1"
+  },
+  {
+    "name": "libfont-afm-perl",
+    "version": "1.20-2"
+  },
+  {
+    "name": "libfontconfig1",
+    "version": "2.13.1-2ubuntu3"
+  },
+  {
+    "name": "libfontembed1",
+    "version": "1.27.4-1"
+  },
+  {
+    "name": "libfontenc1",
+    "version": "1:1.1.4-0ubuntu1"
+  },
+  {
+    "name": "libfprint-2-2",
+    "version": "1:1.90.2+tod1-0ubuntu1~20.04.6"
+  },
+  {
+    "name": "libfprint-2-tod1",
+    "version": "1:1.90.2+tod1-0ubuntu1~20.04.6"
+  },
+  {
+    "name": "libfreetype6",
+    "version": "2.10.1-2ubuntu0.1"
+  },
+  {
+    "name": "libfribidi0",
+    "version": "1.0.8-2"
+  },
+  {
+    "name": "libfuse2",
+    "version": "2.9.9-3"
+  },
+  {
+    "name": "libfwupd2",
+    "version": "1.5.11-0ubuntu1~20.04.2"
+  },
+  {
+    "name": "libfwupdplugin1",
+    "version": "1.5.11-0ubuntu1~20.04.2"
+  },
+  {
+    "name": "libgail-common",
+    "version": "2.24.32-4ubuntu4"
+  },
+  {
+    "name": "libgail18",
+    "version": "2.24.32-4ubuntu4"
+  },
+  {
+    "name": "libgamemode0",
+    "version": "1.5.1-0ubuntu3.1"
+  },
+  {
+    "name": "libgamemodeauto0",
+    "version": "1.5.1-0ubuntu3.1"
+  },
+  {
+    "name": "libgbm1",
+    "version": "21.2.6-0ubuntu0.1~20.04.1"
+  },
+  {
+    "name": "libgcab-1.0-0",
+    "version": "1.4-1"
+  },
+  {
+    "name": "libgcc-s1",
+    "version": "10.3.0-1ubuntu1~20.04"
+  },
+  {
+    "name": "libgck-1-0",
+    "version": "3.36.0-2build1"
+  },
+  {
+    "name": "libgcr-base-3-1",
+    "version": "3.36.0-2build1"
+  },
+  {
+    "name": "libgcr-ui-3-1",
+    "version": "3.36.0-2build1"
+  },
+  {
+    "name": "libgcrypt20",
+    "version": "1.8.5-5ubuntu1.1"
+  },
+  {
+    "name": "libgd3",
+    "version": "2.2.5-5.2ubuntu2.1"
+  },
+  {
+    "name": "libgdata-common",
+    "version": "0.17.12-1"
+  },
+  {
+    "name": "libgdata22",
+    "version": "0.17.12-1"
+  },
+  {
+    "name": "libgdbm-compat4",
+    "version": "1.18.1-5"
+  },
+  {
+    "name": "libgdbm6",
+    "version": "1.18.1-5"
+  },
+  {
+    "name": "libgdk-pixbuf2.0-0",
+    "version": "2.40.0+dfsg-3ubuntu0.2"
+  },
+  {
+    "name": "libgdk-pixbuf2.0-bin",
+    "version": "2.40.0+dfsg-3ubuntu0.2"
+  },
+  {
+    "name": "libgdk-pixbuf2.0-common",
+    "version": "2.40.0+dfsg-3ubuntu0.2"
+  },
+  {
+    "name": "libgdm1",
+    "version": "3.36.3-0ubuntu0.20.04.4"
+  },
+  {
+    "name": "libgee-0.8-2",
+    "version": "0.20.3-1"
+  },
+  {
+    "name": "libgeoclue-2-0",
+    "version": "2.5.6-0ubuntu1"
+  },
+  {
+    "name": "libgexiv2-2",
+    "version": "0.12.0-2"
+  },
+  {
+    "name": "libgif7",
+    "version": "5.1.9-1"
+  },
+  {
+    "name": "libgirepository-1.0-1",
+    "version": "1.64.1-1~ubuntu20.04.1"
+  },
+  {
+    "name": "libgjs0g",
+    "version": "1.64.5-0ubuntu0.20.04.01"
+  },
+  {
+    "name": "libgl1",
+    "version": "1.3.2-1~ubuntu0.20.04.1"
+  },
+  {
+    "name": "libgl1-mesa-dri",
+    "version": "21.2.6-0ubuntu0.1~20.04.1"
+  },
+  {
+    "name": "libglapi-mesa",
+    "version": "21.2.6-0ubuntu0.1~20.04.1"
+  },
+  {
+    "name": "libgles2",
+    "version": "1.3.2-1~ubuntu0.20.04.1"
+  },
+  {
+    "name": "libglib-object-introspection-perl",
+    "version": "0.048-2build1"
+  },
+  {
+    "name": "libglib-perl",
+    "version": "3:1.329.2-1"
+  },
+  {
+    "name": "libglib2.0-0",
+    "version": "2.64.6-1~ubuntu20.04.4"
+  },
+  {
+    "name": "libglib2.0-bin",
+    "version": "2.64.6-1~ubuntu20.04.4"
+  },
+  {
+    "name": "libglib2.0-data",
+    "version": "2.64.6-1~ubuntu20.04.4"
+  },
+  {
+    "name": "libglibmm-2.4-1v5",
+    "version": "2.64.2-1"
+  },
+  {
+    "name": "libglvnd0",
+    "version": "1.3.2-1~ubuntu0.20.04.1"
+  },
+  {
+    "name": "libglx-mesa0",
+    "version": "21.2.6-0ubuntu0.1~20.04.1"
+  },
+  {
+    "name": "libglx0",
+    "version": "1.3.2-1~ubuntu0.20.04.1"
+  },
+  {
+    "name": "libgmp10",
+    "version": "2:6.2.0+dfsg-4"
+  },
+  {
+    "name": "libgnome-autoar-0-0",
+    "version": "0.2.3-2ubuntu0.4"
+  },
+  {
+    "name": "libgnome-bluetooth13",
+    "version": "3.34.3-0ubuntu1"
+  },
+  {
+    "name": "libgnome-desktop-3-19",
+    "version": "3.36.8-0ubuntu1"
+  },
+  {
+    "name": "libgnutls30",
+    "version": "3.6.13-2ubuntu1.6"
+  },
+  {
+    "name": "libgoa-1.0-0b",
+    "version": "3.36.1-0ubuntu1"
+  },
+  {
+    "name": "libgoa-1.0-common",
+    "version": "3.36.1-0ubuntu1"
+  },
+  {
+    "name": "libgoa-backend-1.0-1",
+    "version": "3.36.1-0ubuntu1"
+  },
+  {
+    "name": "libgomp1",
+    "version": "10.3.0-1ubuntu1~20.04"
+  },
+  {
+    "name": "libgpg-error0",
+    "version": "1.37-1"
+  },
+  {
+    "name": "libgpgme11",
+    "version": "1.13.1-7ubuntu2"
+  },
+  {
+    "name": "libgphoto2-6",
+    "version": "2.5.25-0ubuntu0.1"
+  },
+  {
+    "name": "libgphoto2-l10n",
+    "version": "2.5.25-0ubuntu0.1"
+  },
+  {
+    "name": "libgphoto2-port12",
+    "version": "2.5.25-0ubuntu0.1"
+  },
+  {
+    "name": "libgpm2",
+    "version": "1.20.7-5"
+  },
+  {
+    "name": "libgraphene-1.0-0",
+    "version": "1.10.0-1build2"
+  },
+  {
+    "name": "libgraphite2-3",
+    "version": "1.3.13-11build1"
+  },
+  {
+    "name": "libgs9",
+    "version": "9.50~dfsg-5ubuntu4.5"
+  },
+  {
+    "name": "libgs9-common",
+    "version": "9.50~dfsg-5ubuntu4.5"
+  },
+  {
+    "name": "libgsf-1-114",
+    "version": "1.14.46-1"
+  },
+  {
+    "name": "libgsf-1-common",
+    "version": "1.14.46-1"
+  },
+  {
+    "name": "libgsound0",
+    "version": "1.0.2-4"
+  },
+  {
+    "name": "libgspell-1-2",
+    "version": "1.8.3-1"
+  },
+  {
+    "name": "libgspell-1-common",
+    "version": "1.8.3-1"
+  },
+  {
+    "name": "libgssapi-krb5-2",
+    "version": "1.17-6ubuntu4.1"
+  },
+  {
+    "name": "libgssapi3-heimdal",
+    "version": "7.7.0+dfsg-1ubuntu1"
+  },
+  {
+    "name": "libgssdp-1.2-0",
+    "version": "1.2.3-0ubuntu0.20.04.1"
+  },
+  {
+    "name": "libgstreamer-gl1.0-0",
+    "version": "1.16.2-4ubuntu0.1"
+  },
+  {
+    "name": "libgstreamer-plugins-base1.0-0",
+    "version": "1.16.2-4ubuntu0.1"
+  },
+  {
+    "name": "libgstreamer-plugins-good1.0-0",
+    "version": "1.16.2-1ubuntu2.1"
+  },
+  {
+    "name": "libgstreamer1.0-0",
+    "version": "1.16.2-2"
+  },
+  {
+    "name": "libgtk-3-0",
+    "version": "3.24.20-0ubuntu1"
+  },
+  {
+    "name": "libgtk-3-bin",
+    "version": "3.24.20-0ubuntu1"
+  },
+  {
+    "name": "libgtk-3-common",
+    "version": "3.24.20-0ubuntu1"
+  },
+  {
+    "name": "libgtk2.0-0",
+    "version": "2.24.32-4ubuntu4"
+  },
+  {
+    "name": "libgtk2.0-bin",
+    "version": "2.24.32-4ubuntu4"
+  },
+  {
+    "name": "libgtk2.0-common",
+    "version": "2.24.32-4ubuntu4"
+  },
+  {
+    "name": "libgtk3-perl",
+    "version": "0.037-1"
+  },
+  {
+    "name": "libgtkmm-3.0-1v5",
+    "version": "3.24.2-1build1"
+  },
+  {
+    "name": "libgtksourceview-4-0",
+    "version": "4.6.0-1"
+  },
+  {
+    "name": "libgtksourceview-4-common",
+    "version": "4.6.0-1"
+  },
+  {
+    "name": "libgtop-2.0-11",
+    "version": "2.40.0-2"
+  },
+  {
+    "name": "libgtop2-common",
+    "version": "2.40.0-2"
+  },
+  {
+    "name": "libgudev-1.0-0",
+    "version": "1:233-1"
+  },
+  {
+    "name": "libgupnp-1.2-0",
+    "version": "1.2.4-0ubuntu1"
+  },
+  {
+    "name": "libgusb2",
+    "version": "0.3.4-0.1"
+  },
+  {
+    "name": "libgweather-3-16",
+    "version": "3.36.1-1~ubuntu20.04.1"
+  },
+  {
+    "name": "libgweather-common",
+    "version": "3.36.1-1~ubuntu20.04.1"
+  },
+  {
+    "name": "libgxps2",
+    "version": "0.3.1-1"
+  },
+  {
+    "name": "libhandy-0.0-0",
+    "version": "0.0.13-1"
+  },
+  {
+    "name": "libharfbuzz-icu0",
+    "version": "2.6.4-1ubuntu4"
+  },
+  {
+    "name": "libharfbuzz0b",
+    "version": "2.6.4-1ubuntu4"
+  },
+  {
+    "name": "libhcrypto4-heimdal",
+    "version": "7.7.0+dfsg-1ubuntu1"
+  },
+  {
+    "name": "libheimbase1-heimdal",
+    "version": "7.7.0+dfsg-1ubuntu1"
+  },
+  {
+    "name": "libheimntlm0-heimdal",
+    "version": "7.7.0+dfsg-1ubuntu1"
+  },
+  {
+    "name": "libhogweed5",
+    "version": "3.5.1+really3.5.1-2ubuntu0.2"
+  },
+  {
+    "name": "libhpmud0",
+    "version": "3.20.3+dfsg0-2"
+  },
+  {
+    "name": "libhtml-format-perl",
+    "version": "2.12-1"
+  },
+  {
+    "name": "libhtml-parser-perl",
+    "version": "3.72-5"
+  },
+  {
+    "name": "libhttp-cookies-perl",
+    "version": "6.08-1"
+  },
+  {
+    "name": "libhttp-daemon-perl",
+    "version": "6.06-1"
+  },
+  {
+    "name": "libhttp-message-perl",
+    "version": "6.22-1"
+  },
+  {
+    "name": "libhunspell-1.7-0",
+    "version": "1.7.0-2build2"
+  },
+  {
+    "name": "libhx509-5-heimdal",
+    "version": "7.7.0+dfsg-1ubuntu1"
+  },
+  {
+    "name": "libibus-1.0-5",
+    "version": "1.5.22-2ubuntu2.1"
+  },
+  {
+    "name": "libical3",
+    "version": "3.0.8-1"
+  },
+  {
+    "name": "libice6",
+    "version": "2:1.0.10-0ubuntu1"
+  },
+  {
+    "name": "libicu66",
+    "version": "66.1-2ubuntu2.1"
+  },
+  {
+    "name": "libidn11",
+    "version": "1.33-2.2ubuntu2"
+  },
+  {
+    "name": "libidn2-0",
+    "version": "2.2.0-2"
+  },
+  {
+    "name": "libiec61883-0",
+    "version": "1.2.0-3"
+  },
+  {
+    "name": "libieee1284-3",
+    "version": "0.2.11-13build1"
+  },
+  {
+    "name": "libimobiledevice6",
+    "version": "1.2.1~git20191129.9f79242-1build1"
+  },
+  {
+    "name": "libinput-bin",
+    "version": "1.15.5-1ubuntu0.2"
+  },
+  {
+    "name": "libinput10",
+    "version": "1.15.5-1ubuntu0.2"
+  },
+  {
+    "name": "libio-html-perl",
+    "version": "1.001-1"
+  },
+  {
+    "name": "libio-socket-ssl-perl",
+    "version": "2.067-1"
+  },
+  {
+    "name": "libip4tc2",
+    "version": "1.8.4-3ubuntu2"
+  },
+  {
+    "name": "libip6tc2",
+    "version": "1.8.4-3ubuntu2"
+  },
+  {
+    "name": "libipc-system-simple-perl",
+    "version": "1.26-1"
+  },
+  {
+    "name": "libisc-export1105",
+    "version": "1:9.11.16+dfsg-3~ubuntu1"
+  },
+  {
+    "name": "libisl22",
+    "version": "0.22.1-1"
+  },
+  {
+    "name": "libiw30",
+    "version": "30~pre9-13ubuntu1"
+  },
+  {
+    "name": "libjack-jackd2-0",
+    "version": "1.9.12~dfsg-2ubuntu2"
+  },
+  {
+    "name": "libjansson4",
+    "version": "2.12-1build1"
+  },
+  {
+    "name": "libjavascriptcoregtk-4.0-18",
+    "version": "2.34.4-0ubuntu0.20.04.1"
+  },
+  {
+    "name": "libjbig2dec0",
+    "version": "0.18-1ubuntu1"
+  },
+  {
+    "name": "libjcat1",
+    "version": "0.1.3-2~ubuntu20.04.1"
+  },
+  {
+    "name": "libjpeg-turbo8",
+    "version": "2.0.3-0ubuntu1.20.04.1"
+  },
+  {
+    "name": "libjson-c4",
+    "version": "0.13.1+dfsg-7ubuntu0.3"
+  },
+  {
+    "name": "libjson-glib-1.0-0",
+    "version": "1.4.4-2ubuntu2"
+  },
+  {
+    "name": "libjson-glib-1.0-common",
+    "version": "1.4.4-2ubuntu2"
+  },
+  {
+    "name": "libk5crypto3",
+    "version": "1.17-6ubuntu4.1"
+  },
+  {
+    "name": "libkeyutils1",
+    "version": "1.6-6ubuntu1"
+  },
+  {
+    "name": "libklibc",
+    "version": "2.0.7-1ubuntu5"
+  },
+  {
+    "name": "libkmod2",
+    "version": "27-1ubuntu2"
+  },
+  {
+    "name": "libkpathsea6",
+    "version": "2019.20190605.51237-3build2"
+  },
+  {
+    "name": "libkrb5-26-heimdal",
+    "version": "7.7.0+dfsg-1ubuntu1"
+  },
+  {
+    "name": "libkrb5-3",
+    "version": "1.17-6ubuntu4.1"
+  },
+  {
+    "name": "libkrb5support0",
+    "version": "1.17-6ubuntu4.1"
+  },
+  {
+    "name": "libksba8",
+    "version": "1.3.5-2"
+  },
+  {
+    "name": "liblcms2-2",
+    "version": "2.9-4"
+  },
+  {
+    "name": "liblcms2-utils",
+    "version": "2.9-4"
+  },
+  {
+    "name": "libldap-2.4-2",
+    "version": "2.4.49+dfsg-2ubuntu1.8"
+  },
+  {
+    "name": "libldap-common",
+    "version": "2.4.49+dfsg-2ubuntu1.8"
+  },
+  {
+    "name": "libldb2",
+    "version": "2:2.2.3-0ubuntu0.20.04.2"
+  },
+  {
+    "name": "libllvm12",
+    "version": "1:12.0.0-3ubuntu1~20.04.4"
+  },
+  {
+    "name": "libllvm9",
+    "version": "1:9.0.1-12"
+  },
+  {
+    "name": "liblocale-gettext-perl",
+    "version": "1.07-4"
+  },
+  {
+    "name": "liblouis-data",
+    "version": "3.12.0-3"
+  },
+  {
+    "name": "liblouis20",
+    "version": "3.12.0-3"
+  },
+  {
+    "name": "liblouisutdml-bin",
+    "version": "2.8.0-3"
+  },
+  {
+    "name": "liblouisutdml-data",
+    "version": "2.8.0-3"
+  },
+  {
+    "name": "liblouisutdml9",
+    "version": "2.8.0-3"
+  },
+  {
+    "name": "libltdl7",
+    "version": "2.4.6-14"
+  },
+  {
+    "name": "liblwp-protocol-https-perl",
+    "version": "6.07-2ubuntu2"
+  },
+  {
+    "name": "liblz4-1",
+    "version": "1.9.2-2ubuntu0.20.04.1"
+  },
+  {
+    "name": "liblzma5",
+    "version": "5.2.4-1ubuntu1"
+  },
+  {
+    "name": "liblzo2-2",
+    "version": "2.10-2"
+  },
+  {
+    "name": "libmagic-mgc",
+    "version": "1:5.38-4"
+  },
+  {
+    "name": "libmagic1",
+    "version": "1:5.38-4"
+  },
+  {
+    "name": "libmaxminddb0",
+    "version": "1.4.2-0ubuntu1.20.04.1"
+  },
+  {
+    "name": "libmbim-glib4",
+    "version": "1.24.8-1~20.04"
+  },
+  {
+    "name": "libmbim-proxy",
+    "version": "1.24.8-1~20.04"
+  },
+  {
+    "name": "libmediaart-2.0-0",
+    "version": "1.9.4-2"
+  },
+  {
+    "name": "libmm-glib0",
+    "version": "1.16.6-2~20.04.1"
+  },
+  {
+    "name": "libmnl0",
+    "version": "1.0.4-2"
+  },
+  {
+    "name": "libmount1",
+    "version": "2.34-0.1ubuntu9.3"
+  },
+  {
+    "name": "libmozjs-68-0",
+    "version": "68.6.0-1ubuntu1"
+  },
+  {
+    "name": "libmpc3",
+    "version": "1.1.0-1"
+  },
+  {
+    "name": "libmpdec2",
+    "version": "2.4.2-3"
+  },
+  {
+    "name": "libmpfr6",
+    "version": "4.0.2-1"
+  },
+  {
+    "name": "libmpg123-0",
+    "version": "1.25.13-1"
+  },
+  {
+    "name": "libmtdev1",
+    "version": "1.1.5-1.1"
+  },
+  {
+    "name": "libmtp-common",
+    "version": "1.1.17-3"
+  },
+  {
+    "name": "libmtp-runtime",
+    "version": "1.1.17-3"
+  },
+  {
+    "name": "libmtp9",
+    "version": "1.1.17-3"
+  },
+  {
+    "name": "libmutter-6-0",
+    "version": "3.36.9-0ubuntu0.20.04.2"
+  },
+  {
+    "name": "libmysqlclient21",
+    "version": "8.0.28-0ubuntu0.20.04.3"
+  },
+  {
+    "name": "libnautilus-extension1a",
+    "version": "1:3.36.3-0ubuntu1.20.04.1"
+  },
+  {
+    "name": "libncurses6",
+    "version": "6.2-0ubuntu2"
+  },
+  {
+    "name": "libncursesw6",
+    "version": "6.2-0ubuntu2"
+  },
+  {
+    "name": "libnet-dbus-perl",
+    "version": "1.2.0-1"
+  },
+  {
+    "name": "libnet-http-perl",
+    "version": "6.19-1"
+  },
+  {
+    "name": "libnet-ssleay-perl",
+    "version": "1.88-2ubuntu1"
+  },
+  {
+    "name": "libnetfilter-conntrack3",
+    "version": "1.0.7-2"
+  },
+  {
+    "name": "libnetplan0",
+    "version": "0.103-0ubuntu5~20.04.5"
+  },
+  {
+    "name": "libnettle7",
+    "version": "3.5.1+really3.5.1-2ubuntu0.2"
+  },
+  {
+    "name": "libnewt0.52",
+    "version": "0.52.21-4ubuntu2"
+  },
+  {
+    "name": "libnftnl11",
+    "version": "1.1.5-1"
+  },
+  {
+    "name": "libnghttp2-14",
+    "version": "1.40.0-1build1"
+  },
+  {
+    "name": "libnl-3-200",
+    "version": "3.4.0-1"
+  },
+  {
+    "name": "libnl-genl-3-200",
+    "version": "3.4.0-1"
+  },
+  {
+    "name": "libnl-route-3-200",
+    "version": "3.4.0-1"
+  },
+  {
+    "name": "libnm0",
+    "version": "1.22.10-1ubuntu2.3"
+  },
+  {
+    "name": "libnma0",
+    "version": "1.8.24-1ubuntu3"
+  },
+  {
+    "name": "libnotify-bin",
+    "version": "0.7.9-1ubuntu2"
+  },
+  {
+    "name": "libnotify4",
+    "version": "0.7.9-1ubuntu2"
+  },
+  {
+    "name": "libnpth0",
+    "version": "1.6-1"
+  },
+  {
+    "name": "libnspr4",
+    "version": "2:4.25-1"
+  },
+  {
+    "name": "libnss-mdns",
+    "version": "0.14.1-1ubuntu1"
+  },
+  {
+    "name": "libnss-systemd",
+    "version": "245.4-4ubuntu3.15"
+  },
+  {
+    "name": "libnss3",
+    "version": "2:3.49.1-1ubuntu1.6"
+  },
+  {
+    "name": "libntfs-3g883",
+    "version": "1:2017.3.23AR.3-3ubuntu1.1"
+  },
+  {
+    "name": "libnuma1",
+    "version": "2.0.12-1"
+  },
+  {
+    "name": "libogg0",
+    "version": "1.3.4-0ubuntu1"
+  },
+  {
+    "name": "libopenjp2-7",
+    "version": "2.3.1-1ubuntu4.20.04.1"
+  },
+  {
+    "name": "libopenscap8",
+    "version": "1.2.16-2ubuntu3.2"
+  },
+  {
+    "name": "libopus0",
+    "version": "1.3.1-0ubuntu1"
+  },
+  {
+    "name": "liborc-0.4-0",
+    "version": "1:0.4.31-1"
+  },
+  {
+    "name": "libp11-kit0",
+    "version": "0.23.20-1ubuntu0.1"
+  },
+  {
+    "name": "libpackagekit-glib2-18",
+    "version": "1.1.13-2ubuntu1.1"
+  },
+  {
+    "name": "libpam-cap",
+    "version": "1:2.32-1"
+  },
+  {
+    "name": "libpam-fprintd",
+    "version": "1.90.9-1~ubuntu20.04.1"
+  },
+  {
+    "name": "libpam-modules",
+    "version": "1.3.1-5ubuntu4.3"
+  },
+  {
+    "name": "libpam-modules-bin",
+    "version": "1.3.1-5ubuntu4.3"
+  },
+  {
+    "name": "libpam-runtime",
+    "version": "1.3.1-5ubuntu4.3"
+  },
+  {
+    "name": "libpam-systemd",
+    "version": "245.4-4ubuntu3.15"
+  },
+  {
+    "name": "libpam0g",
+    "version": "1.3.1-5ubuntu4.3"
+  },
+  {
+    "name": "libpango-1.0-0",
+    "version": "1.44.7-2ubuntu4"
+  },
+  {
+    "name": "libpangocairo-1.0-0",
+    "version": "1.44.7-2ubuntu4"
+  },
+  {
+    "name": "libpangoft2-1.0-0",
+    "version": "1.44.7-2ubuntu4"
+  },
+  {
+    "name": "libpangomm-1.4-1v5",
+    "version": "2.42.0-2build1"
+  },
+  {
+    "name": "libpangoxft-1.0-0",
+    "version": "1.44.7-2ubuntu4"
+  },
+  {
+    "name": "libparted-fs-resize0",
+    "version": "3.3-4ubuntu0.20.04.1"
+  },
+  {
+    "name": "libparted2",
+    "version": "3.3-4ubuntu0.20.04.1"
+  },
+  {
+    "name": "libpcap0.8",
+    "version": "1.9.1-3"
+  },
+  {
+    "name": "libpcaudio0",
+    "version": "1.1-4"
+  },
+  {
+    "name": "libpci3",
+    "version": "1:3.6.4-1ubuntu0.20.04.1"
+  },
+  {
+    "name": "libpciaccess0",
+    "version": "0.16-0ubuntu1"
+  },
+  {
+    "name": "libpcre2-32-0",
+    "version": "10.34-7"
+  },
+  {
+    "name": "libpcre2-8-0",
+    "version": "10.34-7"
+  },
+  {
+    "name": "libpcre3",
+    "version": "2:8.39-12build1"
+  },
+  {
+    "name": "libpcsclite1",
+    "version": "1.8.26-3"
+  },
+  {
+    "name": "libpeas-1.0-0",
+    "version": "1.26.0-2"
+  },
+  {
+    "name": "libpeas-common",
+    "version": "1.26.0-2"
+  },
+  {
+    "name": "libperl5.30",
+    "version": "5.30.0-9ubuntu0.2"
+  },
+  {
+    "name": "libphonenumber7",
+    "version": "7.1.0-5ubuntu11"
+  },
+  {
+    "name": "libpipeline1",
+    "version": "1.5.2-2build1"
+  },
+  {
+    "name": "libpixman-1-0",
+    "version": "0.38.4-0ubuntu1"
+  },
+  {
+    "name": "libpkcs11-helper1",
+    "version": "1.26-1"
+  },
+  {
+    "name": "libplist3",
+    "version": "2.1.0-4build2"
+  },
+  {
+    "name": "libplymouth5",
+    "version": "0.9.4git20200323-0ubuntu6.2"
+  },
+  {
+    "name": "libpng16-16",
+    "version": "1.6.37-2"
+  },
+  {
+    "name": "libpolkit-agent-1-0",
+    "version": "0.105-26ubuntu1.2"
+  },
+  {
+    "name": "libpolkit-gobject-1-0",
+    "version": "0.105-26ubuntu1.2"
+  },
+  {
+    "name": "libpoppler-cpp0v5",
+    "version": "0.86.1-0ubuntu1"
+  },
+  {
+    "name": "libpoppler-glib8",
+    "version": "0.86.1-0ubuntu1"
+  },
+  {
+    "name": "libpoppler97",
+    "version": "0.86.1-0ubuntu1"
+  },
+  {
+    "name": "libpopt0",
+    "version": "1.16-14"
+  },
+  {
+    "name": "libprocps8",
+    "version": "2:3.3.16-1ubuntu2.3"
+  },
+  {
+    "name": "libprotobuf17",
+    "version": "3.6.1.3-2ubuntu5"
+  },
+  {
+    "name": "libproxy1-plugin-gsettings",
+    "version": "0.4.15-10ubuntu1.2"
+  },
+  {
+    "name": "libproxy1-plugin-networkmanager",
+    "version": "0.4.15-10ubuntu1.2"
+  },
+  {
+    "name": "libproxy1v5",
+    "version": "0.4.15-10ubuntu1.2"
+  },
+  {
+    "name": "libpsl5",
+    "version": "0.21.0-1ubuntu1"
+  },
+  {
+    "name": "libpulse-mainloop-glib0",
+    "version": "1:13.99.1-1ubuntu3.13"
+  },
+  {
+    "name": "libpulse0",
+    "version": "1:13.99.1-1ubuntu3.13"
+  },
+  {
+    "name": "libpulsedsp",
+    "version": "1:13.99.1-1ubuntu3.13"
+  },
+  {
+    "name": "libpwquality-common",
+    "version": "1.4.2-1build1"
+  },
+  {
+    "name": "libpwquality1",
+    "version": "1.4.2-1build1"
+  },
+  {
+    "name": "libpython3-stdlib",
+    "version": "3.8.2-0ubuntu2"
+  },
+  {
+    "name": "libpython3.8",
+    "version": "3.8.10-0ubuntu1~20.04.2"
+  },
+  {
+    "name": "libpython3.8-minimal",
+    "version": "3.8.10-0ubuntu1~20.04.2"
+  },
+  {
+    "name": "libpython3.8-stdlib",
+    "version": "3.8.10-0ubuntu1~20.04.2"
+  },
+  {
+    "name": "libqmi-glib5",
+    "version": "1.28.6-1~20.04.1"
+  },
+  {
+    "name": "libqmi-proxy",
+    "version": "1.28.6-1~20.04.1"
+  },
+  {
+    "name": "libqpdf26",
+    "version": "9.1.1-1ubuntu0.1"
+  },
+  {
+    "name": "libraw1394-11",
+    "version": "2.1.2-1"
+  },
+  {
+    "name": "libreadline8",
+    "version": "8.0-4"
+  },
+  {
+    "name": "librest-0.7-0",
+    "version": "0.8.1-1"
+  },
+  {
+    "name": "libroken18-heimdal",
+    "version": "7.7.0+dfsg-1ubuntu1"
+  },
+  {
+    "name": "librsvg2-2",
+    "version": "2.48.9-1ubuntu0.20.04.1"
+  },
+  {
+    "name": "librsvg2-common",
+    "version": "2.48.9-1ubuntu0.20.04.1"
+  },
+  {
+    "name": "librtmp1",
+    "version": "2.4+20151223.gitfa8646d.1-2build1"
+  },
+  {
+    "name": "librygel-core-2.6-2",
+    "version": "0.38.3-1ubuntu1"
+  },
+  {
+    "name": "librygel-db-2.6-2",
+    "version": "0.38.3-1ubuntu1"
+  },
+  {
+    "name": "librygel-renderer-2.6-2",
+    "version": "0.38.3-1ubuntu1"
+  },
+  {
+    "name": "librygel-server-2.6-2",
+    "version": "0.38.3-1ubuntu1"
+  },
+  {
+    "name": "libsamplerate0",
+    "version": "0.1.9-2"
+  },
+  {
+    "name": "libsane",
+    "version": "1.0.29-0ubuntu5.2"
+  },
+  {
+    "name": "libsane-common",
+    "version": "1.0.29-0ubuntu5.2"
+  },
+  {
+    "name": "libsane-hpaio",
+    "version": "3.20.3+dfsg0-2"
+  },
+  {
+    "name": "libsasl2-2",
+    "version": "2.1.27+dfsg-2ubuntu0.1"
+  },
+  {
+    "name": "libsasl2-modules",
+    "version": "2.1.27+dfsg-2ubuntu0.1"
+  },
+  {
+    "name": "libsasl2-modules-db",
+    "version": "2.1.27+dfsg-2ubuntu0.1"
+  },
+  {
+    "name": "libsbc1",
+    "version": "1.4-1"
+  },
+  {
+    "name": "libseccomp2",
+    "version": "2.5.1-1ubuntu1~20.04.2"
+  },
+  {
+    "name": "libsecret-1-0",
+    "version": "0.20.4-0ubuntu1"
+  },
+  {
+    "name": "libsecret-common",
+    "version": "0.20.4-0ubuntu1"
+  },
+  {
+    "name": "libselinux1",
+    "version": "3.0-1build2"
+  },
+  {
+    "name": "libsemanage-common",
+    "version": "3.0-1build2"
+  },
+  {
+    "name": "libsemanage1",
+    "version": "3.0-1build2"
+  },
+  {
+    "name": "libsensors-config",
+    "version": "1:3.6.0-2ubuntu1"
+  },
+  {
+    "name": "libsensors5",
+    "version": "1:3.6.0-2ubuntu1"
+  },
+  {
+    "name": "libsepol1",
+    "version": "3.0-1"
+  },
+  {
+    "name": "libshout3",
+    "version": "2.4.3-1"
+  },
+  {
+    "name": "libsigc++-2.0-0v5",
+    "version": "2.10.2-1build1"
+  },
+  {
+    "name": "libslang2",
+    "version": "2.3.2-4"
+  },
+  {
+    "name": "libsmartcols1",
+    "version": "2.34-0.1ubuntu9.3"
+  },
+  {
+    "name": "libsmbclient",
+    "version": "2:4.13.17~dfsg-0ubuntu0.21.04.1"
+  },
+  {
+    "name": "libsnapd-glib1",
+    "version": "1.58-0ubuntu0.20.04.0"
+  },
+  {
+    "name": "libsndfile1",
+    "version": "1.0.28-7ubuntu0.1"
+  },
+  {
+    "name": "libsnmp-base",
+    "version": "5.8+dfsg-2ubuntu2.3"
+  },
+  {
+    "name": "libsnmp35",
+    "version": "5.8+dfsg-2ubuntu2.3"
+  },
+  {
+    "name": "libsonic0",
+    "version": "0.2.0-8"
+  },
+  {
+    "name": "libsoup-gnome2.4-1",
+    "version": "2.70.0-1"
+  },
+  {
+    "name": "libsoup2.4-1",
+    "version": "2.70.0-1"
+  },
+  {
+    "name": "libsoxr0",
+    "version": "0.1.3-2build1"
+  },
+  {
+    "name": "libspectre1",
+    "version": "0.2.8-2"
+  },
+  {
+    "name": "libspeechd2",
+    "version": "0.9.1-4"
+  },
+  {
+    "name": "libspeex1",
+    "version": "1.2~rc1.2-1.1ubuntu1.20.04.1"
+  },
+  {
+    "name": "libspeexdsp1",
+    "version": "1.2~rc1.2-1.1ubuntu1.20.04.1"
+  },
+  {
+    "name": "libsqlite3-0",
+    "version": "3.31.1-4ubuntu0.2"
+  },
+  {
+    "name": "libss2",
+    "version": "1.45.5-2ubuntu1"
+  },
+  {
+    "name": "libssh-4",
+    "version": "0.9.3-2ubuntu2.2"
+  },
+  {
+    "name": "libssl1.1",
+    "version": "1.1.1f-1ubuntu2.10"
+  },
+  {
+    "name": "libstdc++6",
+    "version": "10.3.0-1ubuntu1~20.04"
+  },
+  {
+    "name": "libstemmer0d",
+    "version": "0+svn585-2"
+  },
+  {
+    "name": "libsynctex2",
+    "version": "2019.20190605.51237-3build2"
+  },
+  {
+    "name": "libsysmetrics1",
+    "version": "1.6.1"
+  },
+  {
+    "name": "libsystemd0",
+    "version": "245.4-4ubuntu3.15"
+  },
+  {
+    "name": "libtag1v5",
+    "version": "1.11.1+dfsg.1-0.3ubuntu2"
+  },
+  {
+    "name": "libtag1v5-vanilla",
+    "version": "1.11.1+dfsg.1-0.3ubuntu2"
+  },
+  {
+    "name": "libtalloc2",
+    "version": "2.3.1-0ubuntu0.20.04.1"
+  },
+  {
+    "name": "libtdb1",
+    "version": "1.4.3-0ubuntu0.20.04.1"
+  },
+  {
+    "name": "libteamdctl0",
+    "version": "1.30-1"
+  },
+  {
+    "name": "libtepl-4-0",
+    "version": "4.4.0-1"
+  },
+  {
+    "name": "libtevent0",
+    "version": "0.10.2-0ubuntu0.20.04.1"
+  },
+  {
+    "name": "libtext-charwidth-perl",
+    "version": "0.04-10"
+  },
+  {
+    "name": "libtext-iconv-perl",
+    "version": "1.7-7"
+  },
+  {
+    "name": "libthai-data",
+    "version": "0.1.28-3"
+  },
+  {
+    "name": "libthai0",
+    "version": "0.1.28-3"
+  },
+  {
+    "name": "libtie-ixhash-perl",
+    "version": "1.23-2"
+  },
+  {
+    "name": "libtiff5",
+    "version": "4.1.0+git191117-2ubuntu0.20.04.2"
+  },
+  {
+    "name": "libtimedate-perl",
+    "version": "2.3200-1"
+  },
+  {
+    "name": "libtinfo6",
+    "version": "6.2-0ubuntu2"
+  },
+  {
+    "name": "libtotem-plparser-common",
+    "version": "3.26.5-1ubuntu1"
+  },
+  {
+    "name": "libtotem-plparser18",
+    "version": "3.26.5-1ubuntu1"
+  },
+  {
+    "name": "libtracker-control-2.0-0",
+    "version": "2.3.6-0ubuntu1"
+  },
+  {
+    "name": "libtracker-miner-2.0-0",
+    "version": "2.3.6-0ubuntu1"
+  },
+  {
+    "name": "libtracker-sparql-2.0-0",
+    "version": "2.3.6-0ubuntu1"
+  },
+  {
+    "name": "libtss2-esys0",
+    "version": "2.3.2-1"
+  },
+  {
+    "name": "libu2f-udev",
+    "version": "1.1.10-1"
+  },
+  {
+    "name": "libuchardet0",
+    "version": "0.0.6-3build1"
+  },
+  {
+    "name": "libudev1",
+    "version": "245.4-4ubuntu3.15"
+  },
+  {
+    "name": "libudisks2-0",
+    "version": "2.8.4-1ubuntu2"
+  },
+  {
+    "name": "libunistring2",
+    "version": "0.9.10-2"
+  },
+  {
+    "name": "libunity-protocol-private0",
+    "version": "7.1.4+19.04.20190319-0ubuntu3"
+  },
+  {
+    "name": "libunity-scopes-json-def-desktop",
+    "version": "7.1.4+19.04.20190319-0ubuntu3"
+  },
+  {
+    "name": "libunity9",
+    "version": "7.1.4+19.04.20190319-0ubuntu3"
+  },
+  {
+    "name": "libunwind8",
+    "version": "1.2.1-9build1"
+  },
+  {
+    "name": "libupower-glib3",
+    "version": "0.99.11-1build2"
+  },
+  {
+    "name": "liburi-perl",
+    "version": "1.76-2"
+  },
+  {
+    "name": "libusb-1.0-0",
+    "version": "2:1.0.23-2build1"
+  },
+  {
+    "name": "libusbmuxd6",
+    "version": "2.0.1-2"
+  },
+  {
+    "name": "libuuid1",
+    "version": "2.34-0.1ubuntu9.3"
+  },
+  {
+    "name": "libuv1",
+    "version": "1.34.2-1ubuntu1.3"
+  },
+  {
+    "name": "libv4l-0",
+    "version": "1.18.0-2build1"
+  },
+  {
+    "name": "libv4lconvert0",
+    "version": "1.18.0-2build1"
+  },
+  {
+    "name": "libvolume-key1",
+    "version": "0.3.12-3.1"
+  },
+  {
+    "name": "libvorbis0a",
+    "version": "1.3.6-2ubuntu1"
+  },
+  {
+    "name": "libvorbisenc2",
+    "version": "1.3.6-2ubuntu1"
+  },
+  {
+    "name": "libvorbisfile3",
+    "version": "1.3.6-2ubuntu1"
+  },
+  {
+    "name": "libvpx6",
+    "version": "1.8.2-1build1"
+  },
+  {
+    "name": "libvte-2.91-0",
+    "version": "0.60.3-0ubuntu1~20.04"
+  },
+  {
+    "name": "libvte-2.91-common",
+    "version": "0.60.3-0ubuntu1~20.04"
+  },
+  {
+    "name": "libvulkan1",
+    "version": "1.2.131.2-1"
+  },
+  {
+    "name": "libwacom-bin",
+    "version": "1.3-2ubuntu3"
+  },
+  {
+    "name": "libwacom-common",
+    "version": "1.3-2ubuntu3"
+  },
+  {
+    "name": "libwacom2",
+    "version": "1.3-2ubuntu3"
+  },
+  {
+    "name": "libwavpack1",
+    "version": "5.2.0-1ubuntu0.1"
+  },
+  {
+    "name": "libwayland-client0",
+    "version": "1.18.0-1"
+  },
+  {
+    "name": "libwayland-cursor0",
+    "version": "1.18.0-1"
+  },
+  {
+    "name": "libwayland-egl1",
+    "version": "1.18.0-1"
+  },
+  {
+    "name": "libwayland-server0",
+    "version": "1.18.0-1"
+  },
+  {
+    "name": "libwbclient0",
+    "version": "2:4.13.17~dfsg-0ubuntu0.21.04.1"
+  },
+  {
+    "name": "libwebkit2gtk-4.0-37",
+    "version": "2.34.4-0ubuntu0.20.04.1"
+  },
+  {
+    "name": "libwebp6",
+    "version": "0.6.1-2ubuntu0.20.04.1"
+  },
+  {
+    "name": "libwebpdemux2",
+    "version": "0.6.1-2ubuntu0.20.04.1"
+  },
+  {
+    "name": "libwebpmux3",
+    "version": "0.6.1-2ubuntu0.20.04.1"
+  },
+  {
+    "name": "libwhoopsie0",
+    "version": "0.2.69ubuntu0.3"
+  },
+  {
+    "name": "libwind0-heimdal",
+    "version": "7.7.0+dfsg-1ubuntu1"
+  },
+  {
+    "name": "libwrap0",
+    "version": "7.6.q-30"
+  },
+  {
+    "name": "libwww-perl",
+    "version": "6.43-1"
+  },
+  {
+    "name": "libx11-6",
+    "version": "2:1.6.9-2ubuntu1.2"
+  },
+  {
+    "name": "libx11-data",
+    "version": "2:1.6.9-2ubuntu1.2"
+  },
+  {
+    "name": "libx11-protocol-perl",
+    "version": "0.56-7"
+  },
+  {
+    "name": "libx11-xcb1",
+    "version": "2:1.6.9-2ubuntu1.2"
+  },
+  {
+    "name": "libxatracker2",
+    "version": "21.2.6-0ubuntu0.1~20.04.1"
+  },
+  {
+    "name": "libxau6",
+    "version": "1:1.0.9-0ubuntu1"
+  },
+  {
+    "name": "libxaw7",
+    "version": "2:1.0.13-1"
+  },
+  {
+    "name": "libxcb-dri2-0",
+    "version": "1.14-2"
+  },
+  {
+    "name": "libxcb-dri3-0",
+    "version": "1.14-2"
+  },
+  {
+    "name": "libxcb-glx0",
+    "version": "1.14-2"
+  },
+  {
+    "name": "libxcb-present0",
+    "version": "1.14-2"
+  },
+  {
+    "name": "libxcb-randr0",
+    "version": "1.14-2"
+  },
+  {
+    "name": "libxcb-render0",
+    "version": "1.14-2"
+  },
+  {
+    "name": "libxcb-res0",
+    "version": "1.14-2"
+  },
+  {
+    "name": "libxcb-shape0",
+    "version": "1.14-2"
+  },
+  {
+    "name": "libxcb-shm0",
+    "version": "1.14-2"
+  },
+  {
+    "name": "libxcb-sync1",
+    "version": "1.14-2"
+  },
+  {
+    "name": "libxcb-util1",
+    "version": "0.4.0-0ubuntu3"
+  },
+  {
+    "name": "libxcb-xfixes0",
+    "version": "1.14-2"
+  },
+  {
+    "name": "libxcb-xkb1",
+    "version": "1.14-2"
+  },
+  {
+    "name": "libxcb-xv0",
+    "version": "1.14-2"
+  },
+  {
+    "name": "libxcb1",
+    "version": "1.14-2"
+  },
+  {
+    "name": "libxcursor1",
+    "version": "1:1.2.0-2"
+  },
+  {
+    "name": "libxdmcp6",
+    "version": "1:1.1.3-0ubuntu1"
+  },
+  {
+    "name": "libxext6",
+    "version": "2:1.3.4-0ubuntu1"
+  },
+  {
+    "name": "libxfixes3",
+    "version": "1:5.0.3-2"
+  },
+  {
+    "name": "libxfont2",
+    "version": "1:2.0.3-1"
+  },
+  {
+    "name": "libxft2",
+    "version": "2.3.3-0ubuntu1"
+  },
+  {
+    "name": "libxi6",
+    "version": "2:1.7.10-0ubuntu1"
+  },
+  {
+    "name": "libxinerama1",
+    "version": "2:1.1.4-2"
+  },
+  {
+    "name": "libxkbcommon-x11-0",
+    "version": "0.10.0-1"
+  },
+  {
+    "name": "libxkbcommon0",
+    "version": "0.10.0-1"
+  },
+  {
+    "name": "libxkbfile1",
+    "version": "1:1.1.0-1"
+  },
+  {
+    "name": "libxml-parser-perl",
+    "version": "2.46-1"
+  },
+  {
+    "name": "libxml-twig-perl",
+    "version": "1:3.50-2"
+  },
+  {
+    "name": "libxml2",
+    "version": "2.9.10+dfsg-5ubuntu0.20.04.1"
+  },
+  {
+    "name": "libxmlb1",
+    "version": "0.1.15-2ubuntu1~20.04.1"
+  },
+  {
+    "name": "libxrender1",
+    "version": "1:0.9.10-1"
+  },
+  {
+    "name": "libxshmfence1",
+    "version": "1.3-1"
+  },
+  {
+    "name": "libxt6",
+    "version": "1:1.1.5-1"
+  },
+  {
+    "name": "libxtables12",
+    "version": "1.8.4-3ubuntu2"
+  },
+  {
+    "name": "libxtst6",
+    "version": "2:1.2.3-1"
+  },
+  {
+    "name": "libyelp0",
+    "version": "3.36.2-0ubuntu1"
+  },
+  {
+    "name": "libzstd1",
+    "version": "1.4.4+dfsg-3ubuntu0.1"
+  },
+  {
+    "name": "linux-base",
+    "version": "4.5ubuntu3.7"
+  },
+  {
+    "name": "linux-firmware",
+    "version": "1.187.26"
+  },
+  {
+    "name": "linux-generic-hwe-20.04",
+    "version": "5.13.0.30.33~20.04.17"
+  },
+  {
+    "name": "linux-headers-5.13.0-30-generic",
+    "version": "5.13.0-30.33~20.04.1"
+  },
+  {
+    "name": "linux-headers-generic-hwe-20.04",
+    "version": "5.13.0.30.33~20.04.17"
+  },
+  {
+    "name": "linux-hwe-5.13-headers-5.13.0-30",
+    "version": "5.13.0-30.33~20.04.1"
+  },
+  {
+    "name": "linux-image-5.13.0-30-generic",
+    "version": "5.13.0-30.33~20.04.1"
+  },
+  {
+    "name": "linux-image-generic-hwe-20.04",
+    "version": "5.13.0.30.33~20.04.17"
+  },
+  {
+    "name": "linux-modules-5.13.0-30-generic",
+    "version": "5.13.0-30.33~20.04.1"
+  },
+  {
+    "name": "linux-modules-extra-5.13.0-30-generic",
+    "version": "5.13.0-30.33~20.04.1"
+  },
+  {
+    "name": "linux-sound-base",
+    "version": "1.0.25+dfsg-0ubuntu5"
+  },
+  {
+    "name": "locales",
+    "version": "2.31-0ubuntu9.2"
+  },
+  {
+    "name": "login",
+    "version": "1:4.8.1-1ubuntu5.20.04.1"
+  },
+  {
+    "name": "logrotate",
+    "version": "3.14.0-4ubuntu3"
+  },
+  {
+    "name": "logsave",
+    "version": "1.45.5-2ubuntu1"
+  },
+  {
+    "name": "lshw",
+    "version": "02.18.85-0.3ubuntu2.20.04.1"
+  },
+  {
+    "name": "lsof",
+    "version": "4.93.2+dfsg-1ubuntu0.20.04.1"
+  },
+  {
+    "name": "ltrace",
+    "version": "0.7.3-6.1ubuntu1"
+  },
+  {
+    "name": "lz4",
+    "version": "1.9.2-2ubuntu0.20.04.1"
+  },
+  {
+    "name": "man-db",
+    "version": "2.9.1-1"
+  },
+  {
+    "name": "manpages",
+    "version": "5.05-1"
+  },
+  {
+    "name": "memtest86+",
+    "version": "5.01-3.1ubuntu2.1"
+  },
+  {
+    "name": "mesa-vulkan-drivers",
+    "version": "21.2.6-0ubuntu0.1~20.04.1"
+  },
+  {
+    "name": "mime-support",
+    "version": "3.64ubuntu1"
+  },
+  {
+    "name": "mobile-broadband-provider-info",
+    "version": "20190618-3"
+  },
+  {
+    "name": "modemmanager",
+    "version": "1.16.6-2~20.04.1"
+  },
+  {
+    "name": "mount",
+    "version": "2.34-0.1ubuntu9.3"
+  },
+  {
+    "name": "mousetweaks",
+    "version": "3.32.0-2"
+  },
+  {
+    "name": "mscompress",
+    "version": "0.4-7"
+  },
+  {
+    "name": "mtools",
+    "version": "4.0.24-1"
+  },
+  {
+    "name": "mtr-tiny",
+    "version": "0.93-1"
+  },
+  {
+    "name": "mutter",
+    "version": "3.36.9-0ubuntu0.20.04.2"
+  },
+  {
+    "name": "mutter-common",
+    "version": "3.36.9-0ubuntu0.20.04.2"
+  },
+  {
+    "name": "mysql-common",
+    "version": "5.8+1.0.5ubuntu2"
+  },
+  {
+    "name": "nano",
+    "version": "4.8-1ubuntu1"
+  },
+  {
+    "name": "nautilus",
+    "version": "1:3.36.3-0ubuntu1.20.04.1"
+  },
+  {
+    "name": "nautilus-data",
+    "version": "1:3.36.3-0ubuntu1.20.04.1"
+  },
+  {
+    "name": "nautilus-extension-gnome-terminal",
+    "version": "3.36.2-1ubuntu1~20.04"
+  },
+  {
+    "name": "nautilus-sendto",
+    "version": "3.8.6-3ubuntu0.20.04.1"
+  },
+  {
+    "name": "ncurses-base",
+    "version": "6.2-0ubuntu2"
+  },
+  {
+    "name": "ncurses-bin",
+    "version": "6.2-0ubuntu2"
+  },
+  {
+    "name": "netbase",
+    "version": "6.1"
+  },
+  {
+    "name": "netcat-openbsd",
+    "version": "1.206-1ubuntu1"
+  },
+  {
+    "name": "netifaces",
+    "version": "0.10.4"
+  },
+  {
+    "name": "netplan.io",
+    "version": "0.103-0ubuntu5~20.04.5"
+  },
+  {
+    "name": "network-manager",
+    "version": "1.22.10-1ubuntu2.3"
+  },
+  {
+    "name": "network-manager-config-connectivity-ubuntu",
+    "version": "1.22.10-1ubuntu2.3"
+  },
+  {
+    "name": "network-manager-gnome",
+    "version": "1.8.24-1ubuntu3"
+  },
+  {
+    "name": "network-manager-openvpn",
+    "version": "1.8.12-1"
+  },
+  {
+    "name": "network-manager-openvpn-gnome",
+    "version": "1.8.12-1"
+  },
+  {
+    "name": "network-manager-pptp",
+    "version": "1.2.8-2"
+  },
+  {
+    "name": "network-manager-pptp-gnome",
+    "version": "1.2.8-2"
+  },
+  {
+    "name": "networkd-dispatcher",
+    "version": "2.1-2~ubuntu20.04.1"
+  },
+  {
+    "name": "ntfs-3g",
+    "version": "1:2017.3.23AR.3-3ubuntu1.1"
+  },
+  {
+    "name": "openprinting-ppds",
+    "version": "20200401-1"
+  },
+  {
+    "name": "openssh-client",
+    "version": "1:8.2p1-4ubuntu0.4"
+  },
+  {
+    "name": "openssl",
+    "version": "1.1.1f-1ubuntu2.10"
+  },
+  {
+    "name": "openvpn",
+    "version": "2.4.7-1ubuntu2.20.04.3"
+  },
+  {
+    "name": "orca",
+    "version": "3.36.2-1ubuntu1~20.04.1"
+  },
+  {
+    "name": "os-prober",
+    "version": "1.74ubuntu2"
+  },
+  {
+    "name": "p11-kit",
+    "version": "0.23.20-1ubuntu0.1"
+  },
+  {
+    "name": "p11-kit-modules",
+    "version": "0.23.20-1ubuntu0.1"
+  },
+  {
+    "name": "packagekit",
+    "version": "1.1.13-2ubuntu1.1"
+  },
+  {
+    "name": "packagekit-tools",
+    "version": "1.1.13-2ubuntu1.1"
+  },
+  {
+    "name": "parted",
+    "version": "3.3-4ubuntu0.20.04.1"
+  },
+  {
+    "name": "passwd",
+    "version": "1:4.8.1-1ubuntu5.20.04.1"
+  },
+  {
+    "name": "patch",
+    "version": "2.7.6-6"
+  },
+  {
+    "name": "pci.ids",
+    "version": "0.0~2020.03.20-1"
+  },
+  {
+    "name": "pciutils",
+    "version": "1:3.6.4-1ubuntu0.20.04.1"
+  },
+  {
+    "name": "pcmciautils",
+    "version": "018-11"
+  },
+  {
+    "name": "perl",
+    "version": "5.30.0-9ubuntu0.2"
+  },
+  {
+    "name": "perl-base",
+    "version": "5.30.0-9ubuntu0.2"
+  },
+  {
+    "name": "perl-modules-5.30",
+    "version": "5.30.0-9ubuntu0.2"
+  },
+  {
+    "name": "perl-openssl-defaults",
+    "version": "4"
+  },
+  {
+    "name": "pinentry-curses",
+    "version": "1.1.0-3build1"
+  },
+  {
+    "name": "pinentry-gnome3",
+    "version": "1.1.0-3build1"
+  },
+  {
+    "name": "pkg-config",
+    "version": "0.29.1-0ubuntu4"
+  },
+  {
+    "name": "plymouth",
+    "version": "0.9.4git20200323-0ubuntu6.2"
+  },
+  {
+    "name": "plymouth-label",
+    "version": "0.9.4git20200323-0ubuntu6.2"
+  },
+  {
+    "name": "plymouth-theme-spinner",
+    "version": "0.9.4git20200323-0ubuntu6.2"
+  },
+  {
+    "name": "plymouth-theme-ubuntu-text",
+    "version": "0.9.4git20200323-0ubuntu6.2"
+  },
+  {
+    "name": "policykit-1",
+    "version": "0.105-26ubuntu1.2"
+  },
+  {
+    "name": "poppler-data",
+    "version": "0.4.9-2"
+  },
+  {
+    "name": "poppler-utils",
+    "version": "0.86.1-0ubuntu1"
+  },
+  {
+    "name": "popularity-contest",
+    "version": "1.69ubuntu1"
+  },
+  {
+    "name": "ppp",
+    "version": "2.4.7-2+4.1ubuntu5.1"
+  },
+  {
+    "name": "printer-driver-c2esp",
+    "version": "27-6"
+  },
+  {
+    "name": "printer-driver-foo2zjs",
+    "version": "20171202dfsg0-4"
+  },
+  {
+    "name": "printer-driver-foo2zjs-common",
+    "version": "20171202dfsg0-4"
+  },
+  {
+    "name": "printer-driver-hpcups",
+    "version": "3.20.3+dfsg0-2"
+  },
+  {
+    "name": "printer-driver-pnm2ppa",
+    "version": "1.13+nondbs-0ubuntu6"
+  },
+  {
+    "name": "printer-driver-postscript-hp",
+    "version": "3.20.3+dfsg0-2"
+  },
+  {
+    "name": "printer-driver-ptouch",
+    "version": "1.4.2-3"
+  },
+  {
+    "name": "procps",
+    "version": "2:3.3.16-1ubuntu2.3"
+  },
+  {
+    "name": "protobuf",
+    "version": "3.6.1"
+  },
+  {
+    "name": "psmisc",
+    "version": "23.3-1"
+  },
+  {
+    "name": "publicsuffix",
+    "version": "20200303.0012-1"
+  },
+  {
+    "name": "pulseaudio",
+    "version": "1:13.99.1-1ubuntu3.13"
+  },
+  {
+    "name": "pulseaudio-module-bluetooth",
+    "version": "1:13.99.1-1ubuntu3.13"
+  },
+  {
+    "name": "pulseaudio-utils",
+    "version": "1:13.99.1-1ubuntu3.13"
+  },
+  {
+    "name": "python-apt",
+    "version": "2.0.0+ubuntu0.20.4.7"
+  },
+  {
+    "name": "python-apt-common",
+    "version": "2.0.0ubuntu0.20.04.7"
+  },
+  {
+    "name": "python-dateutil",
+    "version": "2.7.3"
+  },
+  {
+    "name": "python-debian",
+    "version": "0.1.36ubuntu1"
+  },
+  {
+    "name": "python3",
+    "version": "3.8.2-0ubuntu2"
+  },
+  {
+    "name": "python3-apport",
+    "version": "2.20.11-0ubuntu27.21"
+  },
+  {
+    "name": "python3-apt",
+    "version": "2.0.0ubuntu0.20.04.7"
+  },
+  {
+    "name": "python3-aptdaemon",
+    "version": "1.1.1+bzr982-0ubuntu32.3"
+  },
+  {
+    "name": "python3-aptdaemon.gtk3widgets",
+    "version": "1.1.1+bzr982-0ubuntu32.3"
+  },
+  {
+    "name": "python3-blinker",
+    "version": "1.4+dfsg1-0.3ubuntu1"
+  },
+  {
+    "name": "python3-brlapi",
+    "version": "6.0+dfsg-4ubuntu6"
+  },
+  {
+    "name": "python3-cairo",
+    "version": "1.16.2-2ubuntu2"
+  },
+  {
+    "name": "python3-certifi",
+    "version": "2019.11.28-1"
+  },
+  {
+    "name": "python3-cffi-backend",
+    "version": "1.14.0-1build1"
+  },
+  {
+    "name": "python3-chardet",
+    "version": "3.0.4-4build1"
+  },
+  {
+    "name": "python3-click",
+    "version": "7.0-3"
+  },
+  {
+    "name": "python3-colorama",
+    "version": "0.4.3-1build1"
+  },
+  {
+    "name": "python3-commandnotfound",
+    "version": "20.04.5"
+  },
+  {
+    "name": "python3-cryptography",
+    "version": "2.8-3ubuntu0.1"
+  },
+  {
+    "name": "python3-cups",
+    "version": "1.9.73-3build1"
+  },
+  {
+    "name": "python3-cupshelpers",
+    "version": "1.5.12-0ubuntu1.1"
+  },
+  {
+    "name": "python3-dateutil",
+    "version": "2.7.3-3ubuntu1"
+  },
+  {
+    "name": "python3-dbus",
+    "version": "1.2.16-1build1"
+  },
+  {
+    "name": "python3-debconf",
+    "version": "1.5.73"
+  },
+  {
+    "name": "python3-debian",
+    "version": "0.1.36ubuntu1"
+  },
+  {
+    "name": "python3-distro",
+    "version": "1.4.0-1"
+  },
+  {
+    "name": "python3-distro-info",
+    "version": "0.23ubuntu1"
+  },
+  {
+    "name": "python3-distupgrade",
+    "version": "1:20.04.37"
+  },
+  {
+    "name": "python3-entrypoints",
+    "version": "0.3-2ubuntu1"
+  },
+  {
+    "name": "python3-gdbm",
+    "version": "3.8.10-0ubuntu1~20.04"
+  },
+  {
+    "name": "python3-gi",
+    "version": "3.36.0-1"
+  },
+  {
+    "name": "python3-gi-cairo",
+    "version": "3.36.0-1"
+  },
+  {
+    "name": "python3-httplib2",
+    "version": "0.14.0-1ubuntu1"
+  },
+  {
+    "name": "python3-ibus-1.0",
+    "version": "1.5.22-2ubuntu2.1"
+  },
+  {
+    "name": "python3-idna",
+    "version": "2.8-1"
+  },
+  {
+    "name": "python3-keyring",
+    "version": "18.0.1-2ubuntu1"
+  },
+  {
+    "name": "python3-lazr.uri",
+    "version": "1.0.3-4build1"
+  },
+  {
+    "name": "python3-ldb",
+    "version": "2:2.2.3-0ubuntu0.20.04.2"
+  },
+  {
+    "name": "python3-louis",
+    "version": "3.12.0-3"
+  },
+  {
+    "name": "python3-minimal",
+    "version": "3.8.2-0ubuntu2"
+  },
+  {
+    "name": "python3-nacl",
+    "version": "1.3.0-5"
+  },
+  {
+    "name": "python3-netifaces",
+    "version": "0.10.4-1ubuntu4"
+  },
+  {
+    "name": "python3-oauthlib",
+    "version": "3.1.0-1ubuntu2"
+  },
+  {
+    "name": "python3-olefile",
+    "version": "0.46-2"
+  },
+  {
+    "name": "python3-pexpect",
+    "version": "4.6.0-1build1"
+  },
+  {
+    "name": "python3-pil",
+    "version": "7.0.0-4ubuntu0.5"
+  },
+  {
+    "name": "python3-pkg-resources",
+    "version": "45.2.0-1"
+  },
+  {
+    "name": "python3-problem-report",
+    "version": "2.20.11-0ubuntu27.21"
+  },
+  {
+    "name": "python3-protobuf",
+    "version": "3.6.1.3-2ubuntu5"
+  },
+  {
+    "name": "python3-ptyprocess",
+    "version": "0.6.0-1ubuntu1"
+  },
+  {
+    "name": "python3-pyatspi",
+    "version": "2.36.0-1"
+  },
+  {
+    "name": "python3-pymacaroons",
+    "version": "0.13.0-3"
+  },
+  {
+    "name": "python3-renderpm",
+    "version": "3.5.34-1ubuntu1"
+  },
+  {
+    "name": "python3-reportlab",
+    "version": "3.5.34-1ubuntu1"
+  },
+  {
+    "name": "python3-reportlab-accel",
+    "version": "3.5.34-1ubuntu1"
+  },
+  {
+    "name": "python3-requests",
+    "version": "2.22.0-2ubuntu1"
+  },
+  {
+    "name": "python3-requests-unixsocket",
+    "version": "0.2.0-2"
+  },
+  {
+    "name": "python3-secretstorage",
+    "version": "2.3.1-2ubuntu1"
+  },
+  {
+    "name": "python3-simplejson",
+    "version": "3.16.0-2ubuntu2"
+  },
+  {
+    "name": "python3-six",
+    "version": "1.14.0-2"
+  },
+  {
+    "name": "python3-software-properties",
+    "version": "0.99.9.8"
+  },
+  {
+    "name": "python3-speechd",
+    "version": "0.9.1-4"
+  },
+  {
+    "name": "python3-systemd",
+    "version": "234-3build2"
+  },
+  {
+    "name": "python3-talloc",
+    "version": "2.3.1-0ubuntu0.20.04.1"
+  },
+  {
+    "name": "python3-tz",
+    "version": "2019.3-1"
+  },
+  {
+    "name": "python3-update-manager",
+    "version": "1:20.04.10.10"
+  },
+  {
+    "name": "python3-urllib3",
+    "version": "1.25.8-2ubuntu0.1"
+  },
+  {
+    "name": "python3-wadllib",
+    "version": "1.3.3-3build1"
+  },
+  {
+    "name": "python3-xdg",
+    "version": "0.26-1ubuntu1"
+  },
+  {
+    "name": "python3-yaml",
+    "version": "5.3.1-1ubuntu0.1"
+  },
+  {
+    "name": "python3.8",
+    "version": "3.8.10-0ubuntu1~20.04.2"
+  },
+  {
+    "name": "python3.8-minimal",
+    "version": "3.8.10-0ubuntu1~20.04.2"
+  },
+  {
+    "name": "pytz",
+    "version": "2019.3"
+  },
+  {
+    "name": "readline-common",
+    "version": "8.0-4"
+  },
+  {
+    "name": "reportlab",
+    "version": "3.5.34"
+  },
+  {
+    "name": "requests",
+    "version": "2.22.0"
+  },
+  {
+    "name": "requests-unixsocket",
+    "version": "0.2.0"
+  },
+  {
+    "name": "rfkill",
+    "version": "2.34-0.1ubuntu9.3"
+  },
+  {
+    "name": "rsync",
+    "version": "3.1.3-8ubuntu0.1"
+  },
+  {
+    "name": "rsyslog",
+    "version": "8.2001.0-1ubuntu1.1"
+  },
+  {
+    "name": "rtkit",
+    "version": "0.12-4"
+  },
+  {
+    "name": "rygel",
+    "version": "0.38.3-1ubuntu1"
+  },
+  {
+    "name": "samba-libs",
+    "version": "2:4.13.17~dfsg-0ubuntu0.21.04.1"
+  },
+  {
+    "name": "sane-utils",
+    "version": "1.0.29-0ubuntu5.2"
+  },
+  {
+    "name": "sbsigntool",
+    "version": "0.9.2-2ubuntu1"
+  },
+  {
+    "name": "seahorse",
+    "version": "3.36-1"
+  },
+  {
+    "name": "secureboot-db",
+    "version": "1.5"
+  },
+  {
+    "name": "sed",
+    "version": "4.7-1"
+  },
+  {
+    "name": "sensible-utils",
+    "version": "0.0.12+nmu1"
+  },
+  {
+    "name": "sgml-base",
+    "version": "1.29.1"
+  },
+  {
+    "name": "sgml-data",
+    "version": "2.0.11"
+  },
+  {
+    "name": "shared-mime-info",
+    "version": "1.15-1"
+  },
+  {
+    "name": "six",
+    "version": "1.14.0"
+  },
+  {
+    "name": "snapd",
+    "version": "2.54.3+20.04.1ubuntu0.1"
+  },
+  {
+    "name": "software-properties-common",
+    "version": "0.99.9.8"
+  },
+  {
+    "name": "software-properties-gtk",
+    "version": "0.99.9.8"
+  },
+  {
+    "name": "speech-dispatcher",
+    "version": "0.9.1-4"
+  },
+  {
+    "name": "speech-dispatcher-audio-plugins",
+    "version": "0.9.1-4"
+  },
+  {
+    "name": "speech-dispatcher-espeak-ng",
+    "version": "0.9.1-4"
+  },
+  {
+    "name": "spice-vdagent",
+    "version": "0.19.0-2ubuntu0.2"
+  },
+  {
+    "name": "squashfs-tools",
+    "version": "1:4.4-1ubuntu0.3"
+  },
+  {
+    "name": "ssl-cert",
+    "version": "1.0.39"
+  },
+  {
+    "name": "strace",
+    "version": "5.5-3ubuntu1"
+  },
+  {
+    "name": "sudo",
+    "version": "1.8.31-1ubuntu1.2"
+  },
+  {
+    "name": "switcheroo-control",
+    "version": "2.1-1"
+  },
+  {
+    "name": "system-config-printer",
+    "version": "1.5.12-0ubuntu1.1"
+  },
+  {
+    "name": "system-config-printer-common",
+    "version": "1.5.12-0ubuntu1.1"
+  },
+  {
+    "name": "system-config-printer-udev",
+    "version": "1.5.12-0ubuntu1.1"
+  },
+  {
+    "name": "systemd",
+    "version": "245.4-4ubuntu3.15"
+  },
+  {
+    "name": "systemd-sysv",
+    "version": "245.4-4ubuntu3.15"
+  },
+  {
+    "name": "systemd-timesyncd",
+    "version": "245.4-4ubuntu3.15"
+  },
+  {
+    "name": "sysvinit-utils",
+    "version": "2.96-2.1ubuntu1"
+  },
+  {
+    "name": "tar",
+    "version": "1.30+dfsg-7ubuntu0.20.04.1"
+  },
+  {
+    "name": "tcpdump",
+    "version": "4.9.3-4"
+  },
+  {
+    "name": "telnet",
+    "version": "0.17-41.2build1"
+  },
+  {
+    "name": "thermald",
+    "version": "1.9.1-1ubuntu0.6"
+  },
+  {
+    "name": "time",
+    "version": "1.7-25.1build1"
+  },
+  {
+    "name": "tpm-udev",
+    "version": "0.4"
+  },
+  {
+    "name": "tracker",
+    "version": "2.3.6-0ubuntu1"
+  },
+  {
+    "name": "tracker-extract",
+    "version": "2.3.3-2"
+  },
+  {
+    "name": "tracker-miner-fs",
+    "version": "2.3.3-2"
+  },
+  {
+    "name": "tzdata",
+    "version": "2021e-0ubuntu0.20.04"
+  },
+  {
+    "name": "ubuntu-advantage-tools",
+    "version": "27.6"
+  },
+  {
+    "name": "ubuntu-advantage-tools",
+    "version": "27.6~20.04.1"
+  },
+  {
+    "name": "ubuntu-desktop",
+    "version": "1.450.2"
+  },
+  {
+    "name": "ubuntu-desktop-minimal",
+    "version": "1.450.2"
+  },
+  {
+    "name": "ubuntu-docs",
+    "version": "20.04.3"
+  },
+  {
+    "name": "ubuntu-drivers-common",
+    "version": "1:0.9.0~0.20.04.5"
+  },
+  {
+    "name": "ubuntu-keyring",
+    "version": "2020.02.11.4"
+  },
+  {
+    "name": "ubuntu-minimal",
+    "version": "1.450.2"
+  },
+  {
+    "name": "ubuntu-mono",
+    "version": "19.04-0ubuntu3"
+  },
+  {
+    "name": "ubuntu-release-upgrader-core",
+    "version": "1:20.04.37"
+  },
+  {
+    "name": "ubuntu-release-upgrader-gtk",
+    "version": "1:20.04.37"
+  },
+  {
+    "name": "ubuntu-report",
+    "version": "1.6.1"
+  },
+  {
+    "name": "ubuntu-session",
+    "version": "3.36.0-2ubuntu1"
+  },
+  {
+    "name": "ubuntu-settings",
+    "version": "20.04.6"
+  },
+  {
+    "name": "ubuntu-standard",
+    "version": "1.450.2"
+  },
+  {
+    "name": "ubuntu-wallpapers",
+    "version": "20.04.2-0ubuntu1"
+  },
+  {
+    "name": "ubuntu-wallpapers-focal",
+    "version": "20.04.2-0ubuntu1"
+  },
+  {
+    "name": "ucf",
+    "version": "3.0038+nmu1"
+  },
+  {
+    "name": "udev",
+    "version": "245.4-4ubuntu3.15"
+  },
+  {
+    "name": "udisks2",
+    "version": "2.8.4-1ubuntu2"
+  },
+  {
+    "name": "ufw",
+    "version": "0.36-6ubuntu1"
+  },
+  {
+    "name": "unattended-upgrades",
+    "version": "2.3ubuntu0.1"
+  },
+  {
+    "name": "unzip",
+    "version": "6.0-25ubuntu1"
+  },
+  {
+    "name": "update-inetd",
+    "version": "4.50"
+  },
+  {
+    "name": "update-manager",
+    "version": "1:20.04.10.10"
+  },
+  {
+    "name": "update-manager-core",
+    "version": "1:20.04.10.10"
+  },
+  {
+    "name": "update-notifier",
+    "version": "3.192.30.10"
+  },
+  {
+    "name": "update-notifier-common",
+    "version": "3.192.30.10"
+  },
+  {
+    "name": "upower",
+    "version": "0.99.11-1build2"
+  },
+  {
+    "name": "urllib3",
+    "version": "1.25.8"
+  },
+  {
+    "name": "usb-modeswitch",
+    "version": "2.5.2+repack0-2ubuntu3"
+  },
+  {
+    "name": "usb.ids",
+    "version": "2020.03.19-1"
+  },
+  {
+    "name": "usbmuxd",
+    "version": "1.1.1~git20191130.9af2b12-1"
+  },
+  {
+    "name": "usbutils",
+    "version": "1:012-2"
+  },
+  {
+    "name": "util-linux",
+    "version": "2.34-0.1ubuntu9.3"
+  },
+  {
+    "name": "uuid-runtime",
+    "version": "2.34-0.1ubuntu9.3"
+  },
+  {
+    "name": "vim-common",
+    "version": "2:8.1.2269-1ubuntu5.7"
+  },
+  {
+    "name": "vim-tiny",
+    "version": "2:8.1.2269-1ubuntu5.7"
+  },
+  {
+    "name": "wadllib",
+    "version": "1.3.3"
+  },
+  {
+    "name": "wamerican",
+    "version": "2018.04.16-1"
+  },
+  {
+    "name": "wbritish",
+    "version": "2018.04.16-1"
+  },
+  {
+    "name": "wget",
+    "version": "1.20.3-1ubuntu2"
+  },
+  {
+    "name": "whiptail",
+    "version": "0.52.21-4ubuntu2"
+  },
+  {
+    "name": "whoopsie",
+    "version": "0.2.69ubuntu0.3"
+  },
+  {
+    "name": "wireless-regdb",
+    "version": "2021.08.28-0ubuntu1~20.04.1"
+  },
+  {
+    "name": "wireless-tools",
+    "version": "30~pre9-13ubuntu1"
+  },
+  {
+    "name": "wpasupplicant",
+    "version": "2:2.9-1ubuntu4.3"
+  },
+  {
+    "name": "x11-common",
+    "version": "1:7.7+19ubuntu14"
+  },
+  {
+    "name": "x11-xkb-utils",
+    "version": "7.7+5"
+  },
+  {
+    "name": "xauth",
+    "version": "1:1.1-0ubuntu1"
+  },
+  {
+    "name": "xbitmaps",
+    "version": "1.1.1-2"
+  },
+  {
+    "name": "xbrlapi",
+    "version": "6.0+dfsg-4ubuntu6"
+  },
+  {
+    "name": "xdg-dbus-proxy",
+    "version": "0.1.2-1"
+  },
+  {
+    "name": "xdg-desktop-portal",
+    "version": "1.6.0-1"
+  },
+  {
+    "name": "xdg-desktop-portal-gtk",
+    "version": "1.6.0-1build1"
+  },
+  {
+    "name": "xdg-user-dirs",
+    "version": "0.17-2ubuntu1"
+  },
+  {
+    "name": "xdg-utils",
+    "version": "1.1.3-2ubuntu1.20.04.2"
+  },
+  {
+    "name": "xfonts-scalable",
+    "version": "1:1.0.3-1.1"
+  },
+  {
+    "name": "xkb-data",
+    "version": "2.29-2"
+  },
+  {
+    "name": "xorg",
+    "version": "1:7.7+19ubuntu14"
+  },
+  {
+    "name": "xorg-docs-core",
+    "version": "1:1.7.1-1.1"
+  },
+  {
+    "name": "xserver-common",
+    "version": "2:1.20.13-1ubuntu1~20.04.2"
+  },
+  {
+    "name": "xserver-xephyr",
+    "version": "2:1.20.13-1ubuntu1~20.04.2"
+  },
+  {
+    "name": "xserver-xorg",
+    "version": "1:7.7+19ubuntu14"
+  },
+  {
+    "name": "xserver-xorg-core",
+    "version": "2:1.20.13-1ubuntu1~20.04.2"
+  },
+  {
+    "name": "xserver-xorg-input-all",
+    "version": "1:7.7+19ubuntu14"
+  },
+  {
+    "name": "xserver-xorg-input-libinput",
+    "version": "0.29.0-1"
+  },
+  {
+    "name": "xserver-xorg-legacy",
+    "version": "2:1.20.13-1ubuntu1~20.04.2"
+  },
+  {
+    "name": "xserver-xorg-video-all",
+    "version": "1:7.7+19ubuntu14"
+  },
+  {
+    "name": "xserver-xorg-video-amdgpu",
+    "version": "19.1.0-1"
+  },
+  {
+    "name": "xserver-xorg-video-ati",
+    "version": "1:19.1.0-1"
+  },
+  {
+    "name": "xserver-xorg-video-fbdev",
+    "version": "1:0.5.0-1ubuntu1"
+  },
+  {
+    "name": "xserver-xorg-video-intel",
+    "version": "2:2.99.917+git20200226-1"
+  },
+  {
+    "name": "xserver-xorg-video-nouveau",
+    "version": "1:1.0.16-1"
+  },
+  {
+    "name": "xserver-xorg-video-radeon",
+    "version": "1:19.1.0-1"
+  },
+  {
+    "name": "xserver-xorg-video-vesa",
+    "version": "1:2.4.0-2"
+  },
+  {
+    "name": "xwayland",
+    "version": "2:1.20.13-1ubuntu1~20.04.2"
+  },
+  {
+    "name": "xxd",
+    "version": "2:8.1.2269-1ubuntu5.7"
+  },
+  {
+    "name": "xz-utils",
+    "version": "5.2.4-1ubuntu1"
+  },
+  {
+    "name": "yaru-theme-gnome-shell",
+    "version": "20.04.11.1"
+  },
+  {
+    "name": "yaru-theme-gtk",
+    "version": "20.04.11.1"
+  },
+  {
+    "name": "yaru-theme-icon",
+    "version": "20.04.11.1"
+  },
+  {
+    "name": "yaru-theme-sound",
+    "version": "20.04.11.1"
+  },
+  {
+    "name": "yelp",
+    "version": "3.36.2-0ubuntu1"
+  },
+  {
+    "name": "yelp-xsl",
+    "version": "3.36.0-1"
+  },
+  {
+    "name": "zenity",
+    "version": "3.32.0-5"
+  },
+  {
+    "name": "zenity-common",
+    "version": "3.32.0-5"
+  },
+  {
+    "name": "zip",
+    "version": "3.0-11build1"
+  },
+  {
+    "name": "zlib1g",
+    "version": "1:1.2.11.dfsg-2ubuntu1.2"
+  }
+]

--- a/cmd/osquery-perf/ubuntu_21.04.tmpl
+++ b/cmd/osquery-perf/ubuntu_21.04.tmpl
@@ -1,0 +1,364 @@
+{{ define "enroll" -}}
+{
+    "enroll_secret": "{{ .EnrollSecret  }}",
+    "host_details": {
+        "os_version": {
+            "build": "",
+            "major": "",
+            "minor": "",
+            "name": "",
+            "patch": "",
+            "platform": "ubuntu",
+            "platform_like": "ubuntu",
+            "version": "Ubuntu 21.4.0"
+        },
+        "osquery_info": {
+            "build_distro": "21.4.0",
+            "build_platform": "linux",
+            "config_hash": "",
+            "config_valid": "0",
+            "extensions": "inactive",
+            "instance_id": "{{ .UUID }}",
+            "pid": "12947",
+            "platform_mask": "21",
+            "start_time": "1580931224",
+            "uuid": "{{ .UUID }}",
+            "version": "4.6.0",
+            "watcher": "12946"
+        },
+        "platform_info": {
+            "address": "0xff990000",
+            "date": "12/16/2019 ",
+            "extra": "MBP114; 196.0.0.0.0; root@xapp160; Mon Dec 16 15:55:18 PST 2019; 196 (B&I); F000_B00; Official Build, Release; Apple LLVM version 5.0 (clang-500.0.68) (based on LLVM 3.3svn)",
+            "revision": "196 (B&I)",
+            "size": "8388608",
+            "vendor": "Apple Inc. ",
+            "version": "196.0.0.0.0 ",
+            "volume_size": "1507328"
+        },
+        "system_info": {
+            "computer_name": "{{ .CachedString "hostname" }}",
+            "cpu_brand": "Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+            "cpu_logical_cores": "8",
+            "cpu_physical_cores": "4",
+            "cpu_subtype": "Intel x86-64h Haswell",
+            "cpu_type": "x86_64h",
+            "hardware_model": "MacBookPro11,4",
+            "hardware_serial": "D02R835DG8WK",
+            "hardware_vendor": "Apple Inc.",
+            "hardware_version": "1.0",
+            "hostname": "{{ .CachedString "hostname" }}",
+            "local_hostname": "{{ .CachedString "hostname" }}",
+            "physical_memory": "17179869184",
+            "uuid": "{{ .UUID }}"
+        }
+    },
+    "host_identifier": "{{ .CachedString "hostname" }}",
+    "platform_type": "16"
+}
+{{- end }}
+
+{{ define "fleet_detail_query_network_interface" -}}
+[
+  {
+    "point_to_point":"",
+    "address":"fe80::8cb:112d:ff51:1e5d%en0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"en0",
+    "mac":"f8:2d:88:93:56:5c",
+    "type":"6",
+    "mtu":"1500",
+    "metric":"0",
+    "ipackets":"278493",
+    "opackets":"206238",
+    "ibytes":"275799040",
+    "obytes":"37720064",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582848084"
+  },
+  {
+    "point_to_point":"",
+    "address":"192.168.1.3",
+    "mask":"255.255.255.0",
+    "broadcast":"192.168.1.255",
+    "interface":"en0",
+    "mac":"f5:5a:80:92:52:5b",
+    "type":"6",
+    "mtu":"1500",
+    "metric":"0",
+    "ipackets":"278493",
+    "opackets":"206238",
+    "ibytes":"275799040",
+    "obytes":"37720064",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582848084"
+  },
+  {
+    "point_to_point":"127.0.0.1",
+    "address":"127.0.0.1",
+    "mask":"255.0.0.0",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"::1",
+    "address":"::1",
+    "mask":"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::1%lo0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::3a:84ff:fe6b:bf75%awdl0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"awdl0",
+    "mac":"03:3b:94:5b:be:75",
+    "type":"6",
+    "mtu":"1484",
+    "metric":"0",
+    "ipackets":"0",
+    "opackets":"16",
+    "ibytes":"0",
+    "obytes":"3072",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582842892"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::6eaf:9721:3476:b691%utun0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"utun0",
+    "mac":"00:00:00:00:00:00",
+    "type":"1",
+    "mtu":"2000",
+    "metric":"0",
+    "ipackets":"0",
+    "opackets":"2",
+    "ibytes":"0",
+    "obytes":"0",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840897"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_os_version" -}}
+[
+  {
+    "name":"Ubuntu 21.4.0",
+    "version":"Ubuntu 21.4.0",
+    "major":"",
+    "minor":"",
+    "patch":"",
+    "build":"",
+    "platform":"ubuntu",
+    "platform_like":"ubuntu",
+    "codename":""
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_flags" -}}
+[
+  {
+    "name":"config_refresh",
+    "value":"{{ printf "%.0f" .ConfigInterval.Seconds }}"
+  },
+  {
+    "name":"distributed_interval",
+    "value":"{{ printf "%.0f" .QueryInterval.Seconds }}"
+  },
+  {
+    "name":"logger_tls_period",
+    "value":"99999"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_info" -}}
+[
+  {
+    "pid":"11287",
+    "uuid":"{{ .UUID }}",
+    "instance_id":"{{ .UUID }}",
+    "version":"4.1.2",
+    "config_hash":"b01efbf375ac6767f259ae98751154fef727ce35",
+    "config_valid":"1",
+    "extensions":"inactive",
+    "build_platform":"ubuntu",
+    "build_distro":"10.12",
+    "start_time":"1582857555",
+    "watcher":"11286",
+    "platform_mask":"21"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_system_info" -}}
+[
+  {
+    "hostname":"{{ .CachedString "hostname" }}",
+    "uuid":"4740D59F-699E-5B29-960B-979AAF9BBEEB",
+    "cpu_type":"x86_64h",
+    "cpu_subtype":"Intel x86-64h Haswell",
+    "cpu_brand":"Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz",
+    "cpu_physical_cores":"4",
+    "cpu_logical_cores":"8",
+    "cpu_microcode":"",
+    "physical_memory":"17179869184",
+    "hardware_vendor":"Apple Inc.",
+    "hardware_model":"MacBookPro11,4",
+    "hardware_version":"1.0",
+    "hardware_serial":"C02R262BM8LN",
+    "computer_name":"{{ .CachedString "hostname" }}",
+    "local_hostname":"{{ .CachedString "hostname" }}"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_uptime" -}}
+[
+  {
+    "days":"0",
+    "hours":"4",
+    "minutes":"38",
+    "seconds":"11",
+    "total_seconds":"16691"
+  }
+]
+{{- end }}
+
+{{ define "fleet_detail_query_users" -}}
+[
+  {{ range $index, $item := .HostUsersMacOS }}
+  {{if $index}},{{end}}
+  {
+    "uid": "{{ .Uid }}",
+    "username": "{{ .Username }}",
+    "type": "{{ .Type }}",
+    "groupname": "{{ .GroupName }}",
+    "shell": "{{ .Shell }}"
+  }
+  {{- end }}
+]
+{{- end }}
+
+{{/* all hosts */}}
+{{ define "fleet_label_query_6" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All macOS hosts */}}
+{{ define "fleet_label_query_7" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All Ubuntu hosts */}}
+{{ define "fleet_label_query_8" -}}
+[]
+{{- end }}
+
+{{/* All CentOS hosts */}}
+{{ define "fleet_label_query_9" -}}
+[]
+{{- end }}
+
+{{/* All Windows hosts */}}
+{{ define "fleet_label_query_10" -}}
+[]
+{{- end }}
+
+{{/* All Red Hat hosts */}}
+{{ define "fleet_label_query_11" -}}
+[]
+{{- end }}
+
+{{/* All Linux distributions */}}
+{{ define "fleet_label_query_12" -}}
+[]
+{{- end }}
+
+{{ define "fleet_detail_query_software_linux" -}}
+[
+  {{ range $index, $item := .SoftwareUbuntu2104 }}
+  {{if $index}},{{end}}
+  {
+    "name": "{{ .Name }}",
+    "version": "{{ .Version }}",
+    "type": "Application",
+    "bundle_identifier": "{{ .BundleIdentifier }}",
+    "source": "apps",
+    {{/* Note that in Go < 1.18, `{{ or (and .LastOpendedAt .LastOpenedAt.Unix) "" }}` won't work as expected because "and" and "or" don't short circuit. This was changed in Go 1.18 */}}
+    {{if .LastOpenedAt}}
+    "last_opened_at": "{{ .LastOpenedAt.Unix }}"
+    {{else}}
+    "last_opened_at": "-1"
+    {{end}}
+  }
+  {{- end }}
+]
+{{- end }}

--- a/cmd/osquery-perf/ubuntu_21.10.tmpl
+++ b/cmd/osquery-perf/ubuntu_21.10.tmpl
@@ -1,0 +1,364 @@
+{{ define "enroll" -}}
+{
+    "enroll_secret": "{{ .EnrollSecret  }}",
+    "host_details": {
+        "os_version": {
+            "build": "",
+            "major": "",
+            "minor": "",
+            "name": "Ubuntu 21.10.0",
+            "patch": "",
+            "platform": "ubuntu",
+            "platform_like": "ubuntu",
+            "version": "Ubuntu 21.10.0"
+        },
+        "osquery_info": {
+            "build_distro": "21.10.0",
+            "build_platform": "ubuntu",
+            "config_hash": "",
+            "config_valid": "0",
+            "extensions": "inactive",
+            "instance_id": "{{ .UUID }}",
+            "pid": "12947",
+            "platform_mask": "21",
+            "start_time": "1580931224",
+            "uuid": "{{ .UUID }}",
+            "version": "4.6.0",
+            "watcher": "12946"
+        },
+        "platform_info": {
+            "address": "0xff990000",
+            "date": "12/16/2019 ",
+            "extra": "MBP114; 196.0.0.0.0; root@xapp160; Mon Dec 16 15:55:18 PST 2019; 196 (B&I); F000_B00; Official Build, Release; Apple LLVM version 5.0 (clang-500.0.68) (based on LLVM 3.3svn)",
+            "revision": "196 (B&I)",
+            "size": "8388608",
+            "vendor": "Apple Inc. ",
+            "version": "196.0.0.0.0 ",
+            "volume_size": "1507328"
+        },
+        "system_info": {
+            "computer_name": "{{ .CachedString "hostname" }}",
+            "cpu_brand": "Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+            "cpu_logical_cores": "8",
+            "cpu_physical_cores": "4",
+            "cpu_subtype": "Intel x86-64h Haswell",
+            "cpu_type": "x86_64h",
+            "hardware_model": "MacBookPro11,4",
+            "hardware_serial": "D02R835DG8WK",
+            "hardware_vendor": "Apple Inc.",
+            "hardware_version": "1.0",
+            "hostname": "{{ .CachedString "hostname" }}",
+            "local_hostname": "{{ .CachedString "hostname" }}",
+            "physical_memory": "17179869184",
+            "uuid": "{{ .UUID }}"
+        }
+    },
+    "host_identifier": "{{ .CachedString "hostname" }}",
+    "platform_type": "16"
+}
+{{- end }}
+
+{{ define "fleet_detail_query_network_interface" -}}
+[
+  {
+    "point_to_point":"",
+    "address":"fe80::8cb:112d:ff51:1e5d%en0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"en0",
+    "mac":"f8:2d:88:93:56:5c",
+    "type":"6",
+    "mtu":"1500",
+    "metric":"0",
+    "ipackets":"278493",
+    "opackets":"206238",
+    "ibytes":"275799040",
+    "obytes":"37720064",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582848084"
+  },
+  {
+    "point_to_point":"",
+    "address":"192.168.1.3",
+    "mask":"255.255.255.0",
+    "broadcast":"192.168.1.255",
+    "interface":"en0",
+    "mac":"f5:5a:80:92:52:5b",
+    "type":"6",
+    "mtu":"1500",
+    "metric":"0",
+    "ipackets":"278493",
+    "opackets":"206238",
+    "ibytes":"275799040",
+    "obytes":"37720064",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582848084"
+  },
+  {
+    "point_to_point":"127.0.0.1",
+    "address":"127.0.0.1",
+    "mask":"255.0.0.0",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"::1",
+    "address":"::1",
+    "mask":"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::1%lo0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::3a:84ff:fe6b:bf75%awdl0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"awdl0",
+    "mac":"03:3b:94:5b:be:75",
+    "type":"6",
+    "mtu":"1484",
+    "metric":"0",
+    "ipackets":"0",
+    "opackets":"16",
+    "ibytes":"0",
+    "obytes":"3072",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582842892"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::6eaf:9721:3476:b691%utun0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"utun0",
+    "mac":"00:00:00:00:00:00",
+    "type":"1",
+    "mtu":"2000",
+    "metric":"0",
+    "ipackets":"0",
+    "opackets":"2",
+    "ibytes":"0",
+    "obytes":"0",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840897"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_os_version" -}}
+[
+  {
+    "name":"Ubuntu 21.10.0",
+    "version":"Ubuntu 21.10.0",
+    "major":"",
+    "minor":"",
+    "patch":"",
+    "build":"",
+    "platform":"ubuntu",
+    "platform_like":"ubuntu",
+    "codename":""
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_flags" -}}
+[
+  {
+    "name":"config_refresh",
+    "value":"{{ printf "%.0f" .ConfigInterval.Seconds }}"
+  },
+  {
+    "name":"distributed_interval",
+    "value":"{{ printf "%.0f" .QueryInterval.Seconds }}"
+  },
+  {
+    "name":"logger_tls_period",
+    "value":"99999"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_info" -}}
+[
+  {
+    "pid":"11287",
+    "uuid":"{{ .UUID }}",
+    "instance_id":"{{ .UUID }}",
+    "version":"4.1.2",
+    "config_hash":"b01efbf375ac6767f259ae98751154fef727ce35",
+    "config_valid":"1",
+    "extensions":"inactive",
+    "build_platform":"ubuntu",
+    "build_distro":"21.10.0",
+    "start_time":"1582857555",
+    "watcher":"11286",
+    "platform_mask":"21"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_system_info" -}}
+[
+  {
+    "hostname":"{{ .CachedString "hostname" }}",
+    "uuid":"4740D59F-699E-5B29-960B-979AAF9BBEEB",
+    "cpu_type":"x86_64h",
+    "cpu_subtype":"Intel x86-64h Haswell",
+    "cpu_brand":"Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz",
+    "cpu_physical_cores":"4",
+    "cpu_logical_cores":"8",
+    "cpu_microcode":"",
+    "physical_memory":"17179869184",
+    "hardware_vendor":"Apple Inc.",
+    "hardware_model":"MacBookPro11,4",
+    "hardware_version":"1.0",
+    "hardware_serial":"C02R262BM8LN",
+    "computer_name":"{{ .CachedString "hostname" }}",
+    "local_hostname":"{{ .CachedString "hostname" }}"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_uptime" -}}
+[
+  {
+    "days":"0",
+    "hours":"4",
+    "minutes":"38",
+    "seconds":"11",
+    "total_seconds":"16691"
+  }
+]
+{{- end }}
+
+{{ define "fleet_detail_query_users" -}}
+[
+  {{ range $index, $item := .HostUsersMacOS }}
+  {{if $index}},{{end}}
+  {
+    "uid": "{{ .Uid }}",
+    "username": "{{ .Username }}",
+    "type": "{{ .Type }}",
+    "groupname": "{{ .GroupName }}",
+    "shell": "{{ .Shell }}"
+  }
+  {{- end }}
+]
+{{- end }}
+
+{{/* all hosts */}}
+{{ define "fleet_label_query_6" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All macOS hosts */}}
+{{ define "fleet_label_query_7" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All Ubuntu hosts */}}
+{{ define "fleet_label_query_8" -}}
+[]
+{{- end }}
+
+{{/* All CentOS hosts */}}
+{{ define "fleet_label_query_9" -}}
+[]
+{{- end }}
+
+{{/* All Windows hosts */}}
+{{ define "fleet_label_query_10" -}}
+[]
+{{- end }}
+
+{{/* All Red Hat hosts */}}
+{{ define "fleet_label_query_11" -}}
+[]
+{{- end }}
+
+{{/* All Linux distributions */}}
+{{ define "fleet_label_query_12" -}}
+[]
+{{- end }}
+
+{{ define "fleet_detail_query_software_linux" -}}
+[
+  {{ range $index, $item := .SoftwareUbuntu2110 }}
+  {{if $index}},{{end}}
+  {
+    "name": "{{ .Name }}",
+    "version": "{{ .Version }}",
+    "type": "Application",
+    "bundle_identifier": "{{ .BundleIdentifier }}",
+    "source": "apps",
+    {{/* Note that in Go < 1.18, `{{ or (and .LastOpendedAt .LastOpenedAt.Unix) "" }}` won't work as expected because "and" and "or" don't short circuit. This was changed in Go 1.18 */}}
+    {{if .LastOpenedAt}}
+    "last_opened_at": "{{ .LastOpenedAt.Unix }}"
+    {{else}}
+    "last_opened_at": "-1"
+    {{end}}
+  }
+  {{- end }}
+]
+{{- end }}

--- a/cmd/osquery-perf/ubuntu_2104-vulnerable_software.json
+++ b/cmd/osquery-perf/ubuntu_2104-vulnerable_software.json
@@ -1,0 +1,6098 @@
+[
+  {
+    "name": "defer",
+    "version": "1.0.6"
+  },
+  {
+    "name": "dmz-cursor-theme",
+    "version": "0.4.5ubuntu1"
+  },
+  {
+    "name": "grub-gfxpayload-lists",
+    "version": "0.7"
+  },
+  {
+    "name": "hicolor-icon-theme",
+    "version": "0.17-2"
+  },
+  {
+    "name": "language-selector",
+    "version": "0.1"
+  },
+  {
+    "name": "laptop-detect",
+    "version": "0.16"
+  },
+  {
+    "name": "libnet-smtp-ssl-perl",
+    "version": "1.04-1"
+  },
+  {
+    "name": "libxml-xpathengine-perl",
+    "version": "0.14-1"
+  },
+  {
+    "name": "pymacaroons",
+    "version": "0.13.0"
+  },
+  {
+    "name": "sound-theme-freedesktop",
+    "version": "0.8-2ubuntu1"
+  },
+  {
+    "name": "ubuntu-drivers-common",
+    "version": "0.0.0"
+  },
+  {
+    "name": "unattended-upgrades",
+    "version": "0.1"
+  },
+  {
+    "name": "aspell-en",
+    "version": "2018.04.16-0-1"
+  },
+  {
+    "name": "emacsen-common",
+    "version": "3.0.4"
+  },
+  {
+    "name": "fonts-deva-extra",
+    "version": "3.0-5"
+  },
+  {
+    "name": "fonts-gujr-extra",
+    "version": "1.0.1-1"
+  },
+  {
+    "name": "fonts-guru-extra",
+    "version": "2.0-5"
+  },
+  {
+    "name": "fonts-kacst-one",
+    "version": "5.0+svn11846-10"
+  },
+  {
+    "name": "fonts-liberation",
+    "version": "1:1.07.4-11"
+  },
+  {
+    "name": "fonts-lohit-deva",
+    "version": "2.95.4-4"
+  },
+  {
+    "name": "fonts-lohit-gujr",
+    "version": "2.92.4-4"
+  },
+  {
+    "name": "fonts-orya-extra",
+    "version": "2.0-6"
+  },
+  {
+    "name": "fonts-smc-meera",
+    "version": "7.0.3-1"
+  },
+  {
+    "name": "fonts-smc-raghumalayalamsans",
+    "version": "2.2.1-1"
+  },
+  {
+    "name": "fonts-smc-suruma",
+    "version": "3.2.3-1"
+  },
+  {
+    "name": "fonts-smc-uroob",
+    "version": "2.0.2-1"
+  },
+  {
+    "name": "libhtml-form-perl",
+    "version": "6.07-1"
+  },
+  {
+    "name": "libhtml-tagset-perl",
+    "version": "3.20-4"
+  },
+  {
+    "name": "libhtml-tree-perl",
+    "version": "5.07-2"
+  },
+  {
+    "name": "libhttp-date-perl",
+    "version": "6.05-1"
+  },
+  {
+    "name": "libhttp-negotiate-perl",
+    "version": "6.01-1"
+  },
+  {
+    "name": "libio-stringy-perl",
+    "version": "2.111-3"
+  },
+  {
+    "name": "liblwp-mediatypes-perl",
+    "version": "6.04-1"
+  },
+  {
+    "name": "libmailtools-perl",
+    "version": "2.21-1"
+  },
+  {
+    "name": "libtext-wrapi18n-perl",
+    "version": "0.06-9"
+  },
+  {
+    "name": "libwww-robotrules-perl",
+    "version": "6.02-1"
+  },
+  {
+    "name": "macaroonbakery",
+    "version": "1.3.1"
+  },
+  {
+    "name": "olefile",
+    "version": "0.46"
+  },
+  {
+    "name": "osquery",
+    "version": "5.2.3-1.linux"
+  },
+  {
+    "name": "policykit-desktop-privileges",
+    "version": "0.21"
+  },
+  {
+    "name": "powermgmt-base",
+    "version": "1.36"
+  },
+  {
+    "name": "pyRFC3339",
+    "version": "1.1"
+  },
+  {
+    "name": "xcursor-themes",
+    "version": "1.0.6-0ubuntu1"
+  },
+  {
+    "name": "xfonts-base",
+    "version": "1:1.0.5"
+  },
+  {
+    "name": "xml-core",
+    "version": "0.18+nmu1"
+  },
+  {
+    "name": "SecretStorage",
+    "version": "3.3.1"
+  },
+  {
+    "name": "adduser",
+    "version": "3.118ubuntu5"
+  },
+  {
+    "name": "alsa-base",
+    "version": "1.0.25+dfsg-0ubuntu7"
+  },
+  {
+    "name": "apport-symptoms",
+    "version": "0.24"
+  },
+  {
+    "name": "certifi",
+    "version": "2020.6.20"
+  },
+  {
+    "name": "chardet",
+    "version": "4.0.0"
+  },
+  {
+    "name": "colorama",
+    "version": "0.4.4"
+  },
+  {
+    "name": "dns-root-data",
+    "version": "2021011101"
+  },
+  {
+    "name": "fonts-beng",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-dejavu-core",
+    "version": "2.37-2build1"
+  },
+  {
+    "name": "fonts-deva",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-droid-fallback",
+    "version": "1:6.0.1r16-1.1build1"
+  },
+  {
+    "name": "fonts-freefont-ttf",
+    "version": "20120503-10build1"
+  },
+  {
+    "name": "fonts-gargi",
+    "version": "2.0-5"
+  },
+  {
+    "name": "fonts-gubbi",
+    "version": "1.3-5build1"
+  },
+  {
+    "name": "fonts-gujr",
+    "version": "2:1.4"
+  },
+  {
+    "name": "fonts-guru",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-indic",
+    "version": "2:1.4"
+  },
+  {
+    "name": "fonts-kacst",
+    "version": "2.01+mry-15"
+  },
+  {
+    "name": "fonts-kalapi",
+    "version": "1.0-4"
+  },
+  {
+    "name": "fonts-knda",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-lao",
+    "version": "0.0.20060226-10ubuntu2"
+  },
+  {
+    "name": "fonts-lohit-beng-assamese",
+    "version": "2.91.5-2"
+  },
+  {
+    "name": "fonts-lohit-beng-bengali",
+    "version": "2.91.5-2"
+  },
+  {
+    "name": "fonts-lohit-guru",
+    "version": "2.91.2-2build1"
+  },
+  {
+    "name": "fonts-lohit-knda",
+    "version": "2.5.4-3"
+  },
+  {
+    "name": "fonts-lohit-mlym",
+    "version": "2.92.2-2"
+  },
+  {
+    "name": "fonts-lohit-orya",
+    "version": "2.91.2-2"
+  },
+  {
+    "name": "fonts-lohit-taml",
+    "version": "2.91.3-2"
+  },
+  {
+    "name": "fonts-lohit-taml-classical",
+    "version": "2.5.4-2"
+  },
+  {
+    "name": "fonts-lohit-telu",
+    "version": "2.5.5-2build1"
+  },
+  {
+    "name": "fonts-mlym",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-nakula",
+    "version": "1.0-4"
+  },
+  {
+    "name": "fonts-navilu",
+    "version": "1.2-3"
+  },
+  {
+    "name": "fonts-noto-mono",
+    "version": "20201225-1build1"
+  },
+  {
+    "name": "fonts-orya",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-pagul",
+    "version": "1.0-8"
+  },
+  {
+    "name": "fonts-sahadeva",
+    "version": "1.0-5"
+  },
+  {
+    "name": "fonts-samyak-deva",
+    "version": "1.2.2-5build1"
+  },
+  {
+    "name": "fonts-samyak-gujr",
+    "version": "1.2.2-5build1"
+  },
+  {
+    "name": "fonts-samyak-mlym",
+    "version": "1.2.2-5build1"
+  },
+  {
+    "name": "fonts-samyak-taml",
+    "version": "1.2.2-5build1"
+  },
+  {
+    "name": "fonts-sarai",
+    "version": "1.0-3"
+  },
+  {
+    "name": "fonts-smc",
+    "version": "1:7.2"
+  },
+  {
+    "name": "fonts-smc-anjalioldlipi",
+    "version": "7.1.2-2"
+  },
+  {
+    "name": "fonts-smc-dyuthi",
+    "version": "3.0.2-2"
+  },
+  {
+    "name": "fonts-smc-karumbi",
+    "version": "1.1.2-2"
+  },
+  {
+    "name": "fonts-smc-keraleeyam",
+    "version": "3.0.2-2"
+  },
+  {
+    "name": "fonts-smc-rachana",
+    "version": "7.0.2-1build1"
+  },
+  {
+    "name": "fonts-taml",
+    "version": "2:1.4"
+  },
+  {
+    "name": "fonts-telu",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-telu-extra",
+    "version": "2.0-5"
+  },
+  {
+    "name": "fonts-teluguvijayam",
+    "version": "2.1-1"
+  },
+  {
+    "name": "fonts-urw-base35",
+    "version": "20200910-1"
+  },
+  {
+    "name": "friendly-recovery",
+    "version": "0.2.42"
+  },
+  {
+    "name": "libauthen-sasl-perl",
+    "version": "2.1600-1.1"
+  },
+  {
+    "name": "libencode-locale-perl",
+    "version": "1.05-1.1"
+  },
+  {
+    "name": "libfile-desktopentry-perl",
+    "version": "0.22-2"
+  },
+  {
+    "name": "libfile-listing-perl",
+    "version": "6.14-1"
+  },
+  {
+    "name": "libfont-afm-perl",
+    "version": "1.20-3"
+  },
+  {
+    "name": "libgtk3-perl",
+    "version": "0.038-1"
+  },
+  {
+    "name": "libhtml-format-perl",
+    "version": "2.12-1.1"
+  },
+  {
+    "name": "libhttp-cookies-perl",
+    "version": "6.10-1"
+  },
+  {
+    "name": "libio-html-perl",
+    "version": "1.004-2"
+  },
+  {
+    "name": "libipc-system-simple-perl",
+    "version": "1.30-1"
+  },
+  {
+    "name": "liblwp-protocol-https-perl",
+    "version": "6.10-1"
+  },
+  {
+    "name": "libtie-ixhash-perl",
+    "version": "1.23-2.1"
+  },
+  {
+    "name": "libtimedate-perl",
+    "version": "2.3300-2"
+  },
+  {
+    "name": "libx11-protocol-perl",
+    "version": "0.56-7.1"
+  },
+  {
+    "name": "libxml-twig-perl",
+    "version": "1:3.52-1"
+  },
+  {
+    "name": "linux-sound-base",
+    "version": "1.0.25+dfsg-0ubuntu7"
+  },
+  {
+    "name": "mime-support",
+    "version": "3.66"
+  },
+  {
+    "name": "nessusagent",
+    "version": "10.1.3"
+  },
+  {
+    "name": "protobuf",
+    "version": "3.12.4"
+  },
+  {
+    "name": "python-dateutil",
+    "version": "2.8.1"
+  },
+  {
+    "name": "python3-certifi",
+    "version": "2020.6.20-1"
+  },
+  {
+    "name": "python3-chardet",
+    "version": "4.0.0-1"
+  },
+  {
+    "name": "python3-colorama",
+    "version": "0.4.4-1"
+  },
+  {
+    "name": "python3-olefile",
+    "version": "0.46-3"
+  },
+  {
+    "name": "python3-pymacaroons",
+    "version": "0.13.0-4"
+  },
+  {
+    "name": "python3-requests",
+    "version": "2.25.1+dfsg-2"
+  },
+  {
+    "name": "python3-secretstorage",
+    "version": "3.3.1-1"
+  },
+  {
+    "name": "python3-xdg",
+    "version": "0.27-2"
+  },
+  {
+    "name": "pyxdg",
+    "version": "0.27"
+  },
+  {
+    "name": "requests",
+    "version": "2.25.1"
+  },
+  {
+    "name": "secureboot-db",
+    "version": "1.8"
+  },
+  {
+    "name": "sgml-base",
+    "version": "1.30"
+  },
+  {
+    "name": "sgml-data",
+    "version": "2.0.11+nmu1"
+  },
+  {
+    "name": "ubuntu-keyring",
+    "version": "2021.03.26"
+  },
+  {
+    "name": "ucf",
+    "version": "3.0043"
+  },
+  {
+    "name": "update-inetd",
+    "version": "4.51"
+  },
+  {
+    "name": "xorg-docs-core",
+    "version": "1:1.7.1-1.2"
+  },
+  {
+    "name": "Pillow",
+    "version": "8.1.2"
+  },
+  {
+    "name": "PyJWT",
+    "version": "1.7.1"
+  },
+  {
+    "name": "PyNaCl",
+    "version": "1.4.0"
+  },
+  {
+    "name": "aptdaemon",
+    "version": "1.1.1+bzr982-0ubuntu36"
+  },
+  {
+    "name": "aptdaemon-data",
+    "version": "1.1.1+bzr982-0ubuntu36"
+  },
+  {
+    "name": "bash-completion",
+    "version": "1:2.11-2ubuntu1"
+  },
+  {
+    "name": "bzip2",
+    "version": "1.0.8-4ubuntu3"
+  },
+  {
+    "name": "click",
+    "version": "7.1.2"
+  },
+  {
+    "name": "coreutils",
+    "version": "8.32-4ubuntu2"
+  },
+  {
+    "name": "cracklib-runtime",
+    "version": "2.9.6-3.4build1"
+  },
+  {
+    "name": "cryptography",
+    "version": "3.3.2"
+  },
+  {
+    "name": "dbus-python",
+    "version": "1.2.16"
+  },
+  {
+    "name": "debianutils",
+    "version": "4.11.2"
+  },
+  {
+    "name": "dictionaries-common",
+    "version": "1.28.4"
+  },
+  {
+    "name": "distro",
+    "version": "1.5.0"
+  },
+  {
+    "name": "distro-info",
+    "version": "1.0"
+  },
+  {
+    "name": "docbook-xml",
+    "version": "4.5-9"
+  },
+  {
+    "name": "ed",
+    "version": "1.17-1"
+  },
+  {
+    "name": "file",
+    "version": "1:5.39-3"
+  },
+  {
+    "name": "fontconfig",
+    "version": "2.13.1-4.2ubuntu3"
+  },
+  {
+    "name": "fontconfig-config",
+    "version": "2.13.1-4.2ubuntu3"
+  },
+  {
+    "name": "fonts-beng-extra",
+    "version": "1.0-7"
+  },
+  {
+    "name": "fonts-noto-cjk",
+    "version": "1:20201206-cjk+repack1-1"
+  },
+  {
+    "name": "fonts-sil-abyssinica",
+    "version": "2.000-1build1"
+  },
+  {
+    "name": "fonts-sil-padauk",
+    "version": "4.000-1build1"
+  },
+  {
+    "name": "fonts-smc-chilanka",
+    "version": "1.530-1"
+  },
+  {
+    "name": "fonts-smc-gayathri",
+    "version": "1.100-2"
+  },
+  {
+    "name": "fonts-smc-manjari",
+    "version": "1.920-1"
+  },
+  {
+    "name": "fonts-thai-tlwg",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tibetan-machine",
+    "version": "1.901b-5.1build1"
+  },
+  {
+    "name": "fonts-tlwg-garuda",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-garuda-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-kinnari",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-kinnari-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-laksaman",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-laksaman-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-loma",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-loma-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-mono",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-mono-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-norasi",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-norasi-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-purisa",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-purisa-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-sawasdee",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-sawasdee-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-typewriter",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-typewriter-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-typist",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-typist-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-typo",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-typo-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-umpush",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-umpush-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-waree",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-waree-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-ubuntu",
+    "version": "0.83-4ubuntu2"
+  },
+  {
+    "name": "ftp",
+    "version": "0.17-34.1.1"
+  },
+  {
+    "name": "gamemode",
+    "version": "1.6.1-1"
+  },
+  {
+    "name": "gamemode-daemon",
+    "version": "1.6.1-1"
+  },
+  {
+    "name": "gir1.2-gmenu-3.0",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-harfbuzz-0.0",
+    "version": "2.7.4-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-json-1.0",
+    "version": "1.6.2-1"
+  },
+  {
+    "name": "gir1.2-secret-1",
+    "version": "0.20.4-2"
+  },
+  {
+    "name": "gir1.2-snapd-1",
+    "version": "1.58-0ubuntu2"
+  },
+  {
+    "name": "gir1.2-unity-7.0",
+    "version": "7.1.4+19.04.20190319-5"
+  },
+  {
+    "name": "gnome-menus",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-session-canberra",
+    "version": "0.30-7ubuntu2"
+  },
+  {
+    "name": "gvfs",
+    "version": "1.47.91-1ubuntu1"
+  },
+  {
+    "name": "gvfs-backends",
+    "version": "1.47.91-1ubuntu1"
+  },
+  {
+    "name": "gvfs-common",
+    "version": "1.47.91-1ubuntu1"
+  },
+  {
+    "name": "gvfs-daemons",
+    "version": "1.47.91-1ubuntu1"
+  },
+  {
+    "name": "gvfs-fuse",
+    "version": "1.47.91-1ubuntu1"
+  },
+  {
+    "name": "gvfs-libs",
+    "version": "1.47.91-1ubuntu1"
+  },
+  {
+    "name": "httplib2",
+    "version": "0.18.1"
+  },
+  {
+    "name": "humanity-icon-theme",
+    "version": "0.6.15"
+  },
+  {
+    "name": "hunspell-en-us",
+    "version": "1:2019.10.06-1"
+  },
+  {
+    "name": "ibus-table",
+    "version": "1.12.4-1"
+  },
+  {
+    "name": "idna",
+    "version": "2.10"
+  },
+  {
+    "name": "info",
+    "version": "6.7.0.dfsg.2-6"
+  },
+  {
+    "name": "install-info",
+    "version": "6.7.0.dfsg.2-6"
+  },
+  {
+    "name": "iproute2",
+    "version": "5.10.0-4ubuntu1"
+  },
+  {
+    "name": "iptables",
+    "version": "1.8.7-1ubuntu2"
+  },
+  {
+    "name": "iputils-ping",
+    "version": "3:20210202-1"
+  },
+  {
+    "name": "iputils-tracepath",
+    "version": "3:20210202-1"
+  },
+  {
+    "name": "iso-codes",
+    "version": "4.6.0-1"
+  },
+  {
+    "name": "iw",
+    "version": "5.9-3"
+  },
+  {
+    "name": "launchpadlib",
+    "version": "1.10.13"
+  },
+  {
+    "name": "lazr.restfulclient",
+    "version": "0.14.2"
+  },
+  {
+    "name": "lazr.uri",
+    "version": "1.0.5"
+  },
+  {
+    "name": "less",
+    "version": "551-2"
+  },
+  {
+    "name": "libarchive13",
+    "version": "3.4.3-2"
+  },
+  {
+    "name": "libargon2-1",
+    "version": "0~20171227-0.2build21.04.0"
+  },
+  {
+    "name": "libatasmart4",
+    "version": "0.19-5"
+  },
+  {
+    "name": "libbsd0",
+    "version": "0.11.3-1ubuntu2"
+  },
+  {
+    "name": "libbz2-1.0",
+    "version": "1.0.8-4ubuntu3"
+  },
+  {
+    "name": "libcairo-gobject2",
+    "version": "1.16.0-5ubuntu1"
+  },
+  {
+    "name": "libcairo-perl",
+    "version": "1.109-1"
+  },
+  {
+    "name": "libcairo2",
+    "version": "1.16.0-5ubuntu1"
+  },
+  {
+    "name": "libcanberra-gtk3-0",
+    "version": "0.30-7ubuntu2"
+  },
+  {
+    "name": "libcanberra-gtk3-module",
+    "version": "0.30-7ubuntu2"
+  },
+  {
+    "name": "libcanberra-pulse",
+    "version": "0.30-7ubuntu2"
+  },
+  {
+    "name": "libcanberra0",
+    "version": "0.30-7ubuntu2"
+  },
+  {
+    "name": "libcap-ng0",
+    "version": "0.7.9-2.2build1"
+  },
+  {
+    "name": "libcap2",
+    "version": "1:2.44-1build1"
+  },
+  {
+    "name": "libcap2-bin",
+    "version": "1:2.44-1build1"
+  },
+  {
+    "name": "libcbor0.6",
+    "version": "0.6.0-0ubuntu3"
+  },
+  {
+    "name": "libcdio19",
+    "version": "2.1.0-2"
+  },
+  {
+    "name": "libclone-perl",
+    "version": "0.45-1build1"
+  },
+  {
+    "name": "libcrack2",
+    "version": "2.9.6-3.4build1"
+  },
+  {
+    "name": "libdata-dump-perl",
+    "version": "1.23-1.1"
+  },
+  {
+    "name": "libdatrie1",
+    "version": "0.2.13-1ubuntu2"
+  },
+  {
+    "name": "libdebconfclient0",
+    "version": "0.256ubuntu3"
+  },
+  {
+    "name": "libevdev2",
+    "version": "1.11.0+dfsg-1build1"
+  },
+  {
+    "name": "libexif12",
+    "version": "0.6.22-3"
+  },
+  {
+    "name": "libextutils-depends-perl",
+    "version": "0.8000-1"
+  },
+  {
+    "name": "libextutils-pkgconfig-perl",
+    "version": "1.16-1.1"
+  },
+  {
+    "name": "libfile-basedir-perl",
+    "version": "0.08-1"
+  },
+  {
+    "name": "libfile-fcntllock-perl",
+    "version": "0.22-3build5"
+  },
+  {
+    "name": "libfile-mimeinfo-perl",
+    "version": "0.30-1"
+  },
+  {
+    "name": "libflac8",
+    "version": "1.3.3-2"
+  },
+  {
+    "name": "libfontconfig1",
+    "version": "2.13.1-4.2ubuntu3"
+  },
+  {
+    "name": "libfreetype6",
+    "version": "2.10.4+dfsg-1build1"
+  },
+  {
+    "name": "libgamemode0",
+    "version": "1.6.1-1"
+  },
+  {
+    "name": "libgamemodeauto0",
+    "version": "1.6.1-1"
+  },
+  {
+    "name": "libgdbm-compat4",
+    "version": "1.19-2"
+  },
+  {
+    "name": "libgdbm6",
+    "version": "1.19-2"
+  },
+  {
+    "name": "libglib-perl",
+    "version": "3:1.329.3-1build1"
+  },
+  {
+    "name": "libglu1-mesa",
+    "version": "9.0.1-1build1"
+  },
+  {
+    "name": "libgmp10",
+    "version": "2:6.2.1+dfsg-1ubuntu2"
+  },
+  {
+    "name": "libgnome-menu-3-0",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "libgpg-error0",
+    "version": "1.38-2build1"
+  },
+  {
+    "name": "libgraphite2-3",
+    "version": "1.3.14-1"
+  },
+  {
+    "name": "libharfbuzz-icu0",
+    "version": "2.7.4-1ubuntu1"
+  },
+  {
+    "name": "libharfbuzz0b",
+    "version": "2.7.4-1ubuntu1"
+  },
+  {
+    "name": "libhttp-daemon-perl",
+    "version": "6.12-1"
+  },
+  {
+    "name": "libhunspell-1.7-0",
+    "version": "1.7.0-3"
+  },
+  {
+    "name": "libhyphen0",
+    "version": "2.8.8-7"
+  },
+  {
+    "name": "libidn11",
+    "version": "1.33-3"
+  },
+  {
+    "name": "libimobiledevice6",
+    "version": "1.3.0-6"
+  },
+  {
+    "name": "libio-socket-ssl-perl",
+    "version": "2.069-1"
+  },
+  {
+    "name": "libip4tc2",
+    "version": "1.8.7-1ubuntu2"
+  },
+  {
+    "name": "libip6tc2",
+    "version": "1.8.7-1ubuntu2"
+  },
+  {
+    "name": "libjansson4",
+    "version": "2.13.1-1.1build1"
+  },
+  {
+    "name": "libjbig0",
+    "version": "2.1-3.1build1"
+  },
+  {
+    "name": "libjpeg-turbo8",
+    "version": "2.0.6-0ubuntu2"
+  },
+  {
+    "name": "libjpeg8",
+    "version": "8c-2ubuntu8"
+  },
+  {
+    "name": "libjson-c5",
+    "version": "0.15-2build2"
+  },
+  {
+    "name": "libjson-glib-1.0-0",
+    "version": "1.6.2-1"
+  },
+  {
+    "name": "libjson-glib-1.0-common",
+    "version": "1.6.2-1"
+  },
+  {
+    "name": "libkeyutils1",
+    "version": "1.6.1-2ubuntu1"
+  },
+  {
+    "name": "libkpathsea6",
+    "version": "2020.20200327.54578-7"
+  },
+  {
+    "name": "liblcms2-2",
+    "version": "2.12~rc1-2"
+  },
+  {
+    "name": "liblcms2-utils",
+    "version": "2.12~rc1-2"
+  },
+  {
+    "name": "liblmdb0",
+    "version": "0.9.24-1"
+  },
+  {
+    "name": "liblocale-gettext-perl",
+    "version": "1.07-4build1"
+  },
+  {
+    "name": "libltdl7",
+    "version": "2.4.6-15"
+  },
+  {
+    "name": "liblzo2-2",
+    "version": "2.10-2build1"
+  },
+  {
+    "name": "libmagic-mgc",
+    "version": "1:5.39-3"
+  },
+  {
+    "name": "libmagic1",
+    "version": "1:5.39-3"
+  },
+  {
+    "name": "libmaxminddb0",
+    "version": "1.5.2-1"
+  },
+  {
+    "name": "libmd0",
+    "version": "1.0.3-3build1"
+  },
+  {
+    "name": "libmnl0",
+    "version": "1.0.4-3"
+  },
+  {
+    "name": "libmpc3",
+    "version": "1.2.0-1build1"
+  },
+  {
+    "name": "libmpfr6",
+    "version": "4.1.0-3build1"
+  },
+  {
+    "name": "libmtp-common",
+    "version": "1.1.18-1"
+  },
+  {
+    "name": "libmtp-runtime",
+    "version": "1.1.18-1"
+  },
+  {
+    "name": "libmtp9",
+    "version": "1.1.18-1"
+  },
+  {
+    "name": "libncurses6",
+    "version": "6.2+20201114-2build1"
+  },
+  {
+    "name": "libncursesw6",
+    "version": "6.2+20201114-2build1"
+  },
+  {
+    "name": "libnet-dbus-perl",
+    "version": "1.2.0-1build1"
+  },
+  {
+    "name": "libnet-http-perl",
+    "version": "6.20-1"
+  },
+  {
+    "name": "libnet-ssleay-perl",
+    "version": "1.88-3ubuntu1"
+  },
+  {
+    "name": "libnetfilter-conntrack3",
+    "version": "1.0.8-3"
+  },
+  {
+    "name": "libnfnetlink0",
+    "version": "1.0.1-3build1"
+  },
+  {
+    "name": "libnfs13",
+    "version": "4.0.0-1"
+  },
+  {
+    "name": "libnftnl11",
+    "version": "1.1.9-1"
+  },
+  {
+    "name": "libnghttp2-14",
+    "version": "1.43.0-1"
+  },
+  {
+    "name": "libnl-3-200",
+    "version": "3.4.0-1build2"
+  },
+  {
+    "name": "libnl-genl-3-200",
+    "version": "3.4.0-1build2"
+  },
+  {
+    "name": "libnl-route-3-200",
+    "version": "3.4.0-1build2"
+  },
+  {
+    "name": "libnpth0",
+    "version": "1.6-3"
+  },
+  {
+    "name": "libnuma1",
+    "version": "2.0.14-0ubuntu2"
+  },
+  {
+    "name": "libopenjp2-7",
+    "version": "2.3.1-1ubuntu5"
+  },
+  {
+    "name": "libopus0",
+    "version": "1.3.1-0.1"
+  },
+  {
+    "name": "liborc-0.4-0",
+    "version": "1:0.4.32-1"
+  },
+  {
+    "name": "libpam-cap",
+    "version": "1:2.44-1build1"
+  },
+  {
+    "name": "libpam-pwquality",
+    "version": "1.4.4-1"
+  },
+  {
+    "name": "libparted-fs-resize0",
+    "version": "3.4-1"
+  },
+  {
+    "name": "libparted2",
+    "version": "3.4-1"
+  },
+  {
+    "name": "libpci3",
+    "version": "1:3.7.0-5ubuntu2"
+  },
+  {
+    "name": "libpcre3",
+    "version": "2:8.39-13build3"
+  },
+  {
+    "name": "libpixman-1-0",
+    "version": "0.40.0-1build2"
+  },
+  {
+    "name": "libpkcs11-helper1",
+    "version": "1.27-1"
+  },
+  {
+    "name": "libpopt0",
+    "version": "1.18-2build2"
+  },
+  {
+    "name": "libproxy1-plugin-gsettings",
+    "version": "0.4.17-1"
+  },
+  {
+    "name": "libproxy1-plugin-networkmanager",
+    "version": "0.4.17-1"
+  },
+  {
+    "name": "libproxy1v5",
+    "version": "0.4.17-1"
+  },
+  {
+    "name": "libpsl5",
+    "version": "0.21.0-1.2"
+  },
+  {
+    "name": "libpwquality-common",
+    "version": "1.4.4-1"
+  },
+  {
+    "name": "libpwquality1",
+    "version": "1.4.4-1"
+  },
+  {
+    "name": "libsamplerate0",
+    "version": "0.2.1+ds0-1"
+  },
+  {
+    "name": "libseccomp2",
+    "version": "2.5.1-1ubuntu1"
+  },
+  {
+    "name": "libsecret-1-0",
+    "version": "0.20.4-2"
+  },
+  {
+    "name": "libsecret-common",
+    "version": "0.20.4-2"
+  },
+  {
+    "name": "libsensors-config",
+    "version": "1:3.6.0-7"
+  },
+  {
+    "name": "libsensors5",
+    "version": "1:3.6.0-7"
+  },
+  {
+    "name": "libslang2",
+    "version": "2.3.2-5build2"
+  },
+  {
+    "name": "libsnapd-glib1",
+    "version": "1.58-0ubuntu2"
+  },
+  {
+    "name": "libsonic0",
+    "version": "0.2.0-10"
+  },
+  {
+    "name": "libspeex1",
+    "version": "1.2~rc1.2-1.1ubuntu1"
+  },
+  {
+    "name": "libspeexdsp1",
+    "version": "1.2~rc1.2-1.1ubuntu1"
+  },
+  {
+    "name": "libstemmer0d",
+    "version": "2.1.0-1"
+  },
+  {
+    "name": "libsynctex2",
+    "version": "2020.20200327.54578-7"
+  },
+  {
+    "name": "libtasn1-6",
+    "version": "4.16.0-2"
+  },
+  {
+    "name": "libtcl8.6",
+    "version": "8.6.11+dfsg-1"
+  },
+  {
+    "name": "libtdb1",
+    "version": "1.4.3-1build1"
+  },
+  {
+    "name": "libtext-charwidth-perl",
+    "version": "0.04-10build1"
+  },
+  {
+    "name": "libtext-iconv-perl",
+    "version": "1.7-7build1"
+  },
+  {
+    "name": "libtheora0",
+    "version": "1.1.1+dfsg.1-15ubuntu2"
+  },
+  {
+    "name": "libtinfo6",
+    "version": "6.2+20201114-2build1"
+  },
+  {
+    "name": "libtry-tiny-perl",
+    "version": "0.30-1"
+  },
+  {
+    "name": "libtss2-esys-3.0.2-0",
+    "version": "3.0.3-2ubuntu1"
+  },
+  {
+    "name": "libtss2-mu0",
+    "version": "3.0.3-2ubuntu1"
+  },
+  {
+    "name": "libtss2-sys1",
+    "version": "3.0.3-2ubuntu1"
+  },
+  {
+    "name": "libtss2-tcti-cmd0",
+    "version": "3.0.3-2ubuntu1"
+  },
+  {
+    "name": "libtss2-tcti-device0",
+    "version": "3.0.3-2ubuntu1"
+  },
+  {
+    "name": "libtss2-tcti-mssim0",
+    "version": "3.0.3-2ubuntu1"
+  },
+  {
+    "name": "libtss2-tcti-swtpm0",
+    "version": "3.0.3-2ubuntu1"
+  },
+  {
+    "name": "libunity-protocol-private0",
+    "version": "7.1.4+19.04.20190319-5"
+  },
+  {
+    "name": "libunity-scopes-json-def-desktop",
+    "version": "7.1.4+19.04.20190319-5"
+  },
+  {
+    "name": "libunity9",
+    "version": "7.1.4+19.04.20190319-5"
+  },
+  {
+    "name": "libunwind8",
+    "version": "1.3.2-2"
+  },
+  {
+    "name": "libusb-1.0-0",
+    "version": "2:1.0.24-3"
+  },
+  {
+    "name": "libvorbis0a",
+    "version": "1.3.7-1"
+  },
+  {
+    "name": "libvorbisenc2",
+    "version": "1.3.7-1"
+  },
+  {
+    "name": "libvorbisfile3",
+    "version": "1.3.7-1"
+  },
+  {
+    "name": "libwrap0",
+    "version": "7.6.q-31"
+  },
+  {
+    "name": "libxau6",
+    "version": "1:1.0.9-1build3"
+  },
+  {
+    "name": "libxaw7",
+    "version": "2:1.0.13-1.1"
+  },
+  {
+    "name": "libxcb-dri2-0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-dri3-0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-glx0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-present0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-randr0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-render0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-res0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-shape0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-shm0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-sync1",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-xfixes0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-xkb1",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-xv0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb1",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcomposite1",
+    "version": "1:0.4.5-1"
+  },
+  {
+    "name": "libxcursor1",
+    "version": "1:1.2.0-2build2"
+  },
+  {
+    "name": "libxdamage1",
+    "version": "1:1.1.5-2"
+  },
+  {
+    "name": "libxext6",
+    "version": "2:1.3.4-0ubuntu3"
+  },
+  {
+    "name": "libxfixes3",
+    "version": "1:5.0.3-2build1"
+  },
+  {
+    "name": "libxi6",
+    "version": "2:1.7.10-1build2"
+  },
+  {
+    "name": "libxinerama1",
+    "version": "2:1.1.4-2build2"
+  },
+  {
+    "name": "libxkbfile1",
+    "version": "1:1.1.0-1build1"
+  },
+  {
+    "name": "libxml-parser-perl",
+    "version": "2.46-2"
+  },
+  {
+    "name": "libxmlb1",
+    "version": "0.1.15-2ubuntu1"
+  },
+  {
+    "name": "libxmu6",
+    "version": "2:1.1.3-0ubuntu1"
+  },
+  {
+    "name": "libxmuu1",
+    "version": "2:1.1.3-0ubuntu1"
+  },
+  {
+    "name": "libxpm4",
+    "version": "1:3.5.12-1"
+  },
+  {
+    "name": "libxrandr2",
+    "version": "2:1.5.2-0ubuntu1"
+  },
+  {
+    "name": "libxrender1",
+    "version": "1:0.9.10-1build2"
+  },
+  {
+    "name": "libxslt1.1",
+    "version": "1.1.34-4"
+  },
+  {
+    "name": "libxss1",
+    "version": "1:1.2.3-1"
+  },
+  {
+    "name": "libxt6",
+    "version": "1:1.2.0-1"
+  },
+  {
+    "name": "libxtables12",
+    "version": "1.8.7-1ubuntu2"
+  },
+  {
+    "name": "libxtst6",
+    "version": "2:1.2.3-1build2"
+  },
+  {
+    "name": "libxv1",
+    "version": "2:1.0.11-1"
+  },
+  {
+    "name": "libxxf86vm1",
+    "version": "1:1.1.4-1build1"
+  },
+  {
+    "name": "libyaml-0-2",
+    "version": "0.2.2-1"
+  },
+  {
+    "name": "lsof",
+    "version": "4.93.2+dfsg-1.1"
+  },
+  {
+    "name": "man-db",
+    "version": "2.9.4-2"
+  },
+  {
+    "name": "mawk",
+    "version": "1.3.4.20200120-2"
+  },
+  {
+    "name": "media-types",
+    "version": "4.0.0"
+  },
+  {
+    "name": "ncurses-base",
+    "version": "6.2+20201114-2build1"
+  },
+  {
+    "name": "ncurses-bin",
+    "version": "6.2+20201114-2build1"
+  },
+  {
+    "name": "netcat-openbsd",
+    "version": "1.217-3ubuntu1"
+  },
+  {
+    "name": "netifaces",
+    "version": "0.10.9"
+  },
+  {
+    "name": "oauthlib",
+    "version": "3.1.0"
+  },
+  {
+    "name": "parted",
+    "version": "3.4-1"
+  },
+  {
+    "name": "patch",
+    "version": "2.7.6-7"
+  },
+  {
+    "name": "pciutils",
+    "version": "1:3.7.0-5ubuntu2"
+  },
+  {
+    "name": "perl-openssl-defaults",
+    "version": "5"
+  },
+  {
+    "name": "pkg-config",
+    "version": "0.29.2-1ubuntu1"
+  },
+  {
+    "name": "psmisc",
+    "version": "23.4-2build1"
+  },
+  {
+    "name": "publicsuffix",
+    "version": "20210108.1309-1"
+  },
+  {
+    "name": "python3-aptdaemon",
+    "version": "1.1.1+bzr982-0ubuntu36"
+  },
+  {
+    "name": "python3-aptdaemon.gtk3widgets",
+    "version": "1.1.1+bzr982-0ubuntu36"
+  },
+  {
+    "name": "python3-blinker",
+    "version": "1.4+dfsg1-0.3ubuntu2"
+  },
+  {
+    "name": "python3-cairo",
+    "version": "1.16.2-4build2"
+  },
+  {
+    "name": "python3-click",
+    "version": "7.1.2-1"
+  },
+  {
+    "name": "python3-cryptography",
+    "version": "3.3.2-1"
+  },
+  {
+    "name": "python3-cups",
+    "version": "2.0.1-4build1"
+  },
+  {
+    "name": "python3-dbus",
+    "version": "1.2.16-5"
+  },
+  {
+    "name": "python3-defer",
+    "version": "1.0.6-2.1"
+  },
+  {
+    "name": "python3-distro",
+    "version": "1.5.0-1"
+  },
+  {
+    "name": "python3-distro-info",
+    "version": "1.0"
+  },
+  {
+    "name": "python3-idna",
+    "version": "2.10-1"
+  },
+  {
+    "name": "python3-jwt",
+    "version": "1.7.1-2ubuntu2"
+  },
+  {
+    "name": "python3-launchpadlib",
+    "version": "1.10.13-1"
+  },
+  {
+    "name": "python3-lazr.restfulclient",
+    "version": "0.14.2-2build1"
+  },
+  {
+    "name": "python3-lazr.uri",
+    "version": "1.0.5-1"
+  },
+  {
+    "name": "python3-macaroonbakery",
+    "version": "1.3.1-1"
+  },
+  {
+    "name": "python3-nacl",
+    "version": "1.4.0-1build1"
+  },
+  {
+    "name": "python3-netifaces",
+    "version": "0.10.9-0.2"
+  },
+  {
+    "name": "python3-oauthlib",
+    "version": "3.1.0-2"
+  },
+  {
+    "name": "python3-ptyprocess",
+    "version": "0.7.0-1"
+  },
+  {
+    "name": "python3-pyatspi",
+    "version": "2.38.1-1"
+  },
+  {
+    "name": "python3-renderpm",
+    "version": "3.5.66-1"
+  },
+  {
+    "name": "python3-reportlab",
+    "version": "3.5.66-1"
+  },
+  {
+    "name": "python3-reportlab-accel",
+    "version": "3.5.66-1"
+  },
+  {
+    "name": "python3-rfc3339",
+    "version": "1.1-2"
+  },
+  {
+    "name": "python3-simplejson",
+    "version": "3.17.2-1"
+  },
+  {
+    "name": "python3-systemd",
+    "version": "234-3build4"
+  },
+  {
+    "name": "python3-tz",
+    "version": "2021.1-1"
+  },
+  {
+    "name": "python3-wadllib",
+    "version": "1.3.5-1"
+  },
+  {
+    "name": "python3-xkit",
+    "version": "0.5.0ubuntu4"
+  },
+  {
+    "name": "pytz",
+    "version": "2021.1"
+  },
+  {
+    "name": "reportlab",
+    "version": "3.5.66"
+  },
+  {
+    "name": "rtkit",
+    "version": "0.13-4"
+  },
+  {
+    "name": "sed",
+    "version": "4.7-1ubuntu1"
+  },
+  {
+    "name": "sensible-utils",
+    "version": "0.0.14"
+  },
+  {
+    "name": "sound-icons",
+    "version": "0.1-7"
+  },
+  {
+    "name": "tar",
+    "version": "1.34+dfsg-1build1"
+  },
+  {
+    "name": "tcl8.6",
+    "version": "8.6.11+dfsg-1"
+  },
+  {
+    "name": "telnet",
+    "version": "0.17-42"
+  },
+  {
+    "name": "time",
+    "version": "1.9-0.1"
+  },
+  {
+    "name": "tpm-udev",
+    "version": "0.5"
+  },
+  {
+    "name": "ubuntu-mono",
+    "version": "20.10-0ubuntu1"
+  },
+  {
+    "name": "unattended-upgrades",
+    "version": "2.8"
+  },
+  {
+    "name": "unzip",
+    "version": "6.0-26ubuntu1"
+  },
+  {
+    "name": "usb-modeswitch-data",
+    "version": "20191128-3"
+  },
+  {
+    "name": "wadllib",
+    "version": "1.3.5"
+  },
+  {
+    "name": "wamerican",
+    "version": "2019.10.06-1"
+  },
+  {
+    "name": "wbritish",
+    "version": "2019.10.06-1"
+  },
+  {
+    "name": "wget",
+    "version": "1.21-1ubuntu3"
+  },
+  {
+    "name": "x11-apps",
+    "version": "7.7+8"
+  },
+  {
+    "name": "xauth",
+    "version": "1:1.1-1"
+  },
+  {
+    "name": "xbitmaps",
+    "version": "1.1.1-2.1"
+  },
+  {
+    "name": "xdg-utils",
+    "version": "1.1.3-2ubuntu2"
+  },
+  {
+    "name": "xfonts-encodings",
+    "version": "1:1.0.5-0ubuntu1"
+  },
+  {
+    "name": "xfonts-scalable",
+    "version": "1:1.0.3-1.2"
+  },
+  {
+    "name": "xkb-data",
+    "version": "2.29-2build1"
+  },
+  {
+    "name": "xserver-xorg-video-vmware",
+    "version": "1:13.3.0-3"
+  },
+  {
+    "name": "Amazon.com",
+    "version": "1.3"
+  },
+  {
+    "name": "Bing",
+    "version": "1.3"
+  },
+  {
+    "name": "Dark",
+    "version": "1.1"
+  },
+  {
+    "name": "Default",
+    "version": "1.1"
+  },
+  {
+    "name": "DoH Roll-Out",
+    "version": "2.0.0"
+  },
+  {
+    "name": "DuckDuckGo",
+    "version": "1.1"
+  },
+  {
+    "name": "English (CA) Language Pack",
+    "version": "87.0buildid20210318103112"
+  },
+  {
+    "name": "English (GB) Language Pack",
+    "version": "87.0buildid20210318103112"
+  },
+  {
+    "name": "Firefox Alpenglow",
+    "version": "1.2"
+  },
+  {
+    "name": "Firefox Screenshots",
+    "version": "39.0.0"
+  },
+  {
+    "name": "Form Autofill",
+    "version": "1.0"
+  },
+  {
+    "name": "Google",
+    "version": "1.1"
+  },
+  {
+    "name": "Light",
+    "version": "1.1"
+  },
+  {
+    "name": "Proxy Failover",
+    "version": "1.0.1"
+  },
+  {
+    "name": "PyGObject",
+    "version": "3.38.0"
+  },
+  {
+    "name": "Web Compatibility Interventions",
+    "version": "20.1.0"
+  },
+  {
+    "name": "WebCompat Reporter",
+    "version": "1.4.0"
+  },
+  {
+    "name": "Wikipedia (en)",
+    "version": "1.1"
+  },
+  {
+    "name": "accountsservice",
+    "version": "0.6.55-0ubuntu13.2"
+  },
+  {
+    "name": "acl",
+    "version": "2.2.53-10ubuntu1"
+  },
+  {
+    "name": "acpi-support",
+    "version": "0.143"
+  },
+  {
+    "name": "acpid",
+    "version": "1:2.0.32-1ubuntu1"
+  },
+  {
+    "name": "adwaita-icon-theme",
+    "version": "3.38.0-1ubuntu2"
+  },
+  {
+    "name": "alsa-topology-conf",
+    "version": "1.2.4-1"
+  },
+  {
+    "name": "alsa-ucm-conf",
+    "version": "1.2.4-2ubuntu1"
+  },
+  {
+    "name": "alsa-utils",
+    "version": "1.2.4-1ubuntu3"
+  },
+  {
+    "name": "amd64-microcode",
+    "version": "3.20191218.1ubuntu1"
+  },
+  {
+    "name": "anacron",
+    "version": "2.3-30ubuntu2"
+  },
+  {
+    "name": "apg",
+    "version": "2.2.3.dfsg.1-5"
+  },
+  {
+    "name": "app-install-data-partner",
+    "version": "19.04"
+  },
+  {
+    "name": "apparmor",
+    "version": "3.0.0-0ubuntu7"
+  },
+  {
+    "name": "apport",
+    "version": "2.20.11-0ubuntu65"
+  },
+  {
+    "name": "apport-gtk",
+    "version": "2.20.11-0ubuntu65"
+  },
+  {
+    "name": "appstream",
+    "version": "0.14.1-1"
+  },
+  {
+    "name": "apt",
+    "version": "2.2.3"
+  },
+  {
+    "name": "apt-config-icons",
+    "version": "0.14.1-1"
+  },
+  {
+    "name": "apt-config-icons-hidpi",
+    "version": "0.14.1-1"
+  },
+  {
+    "name": "apt-utils",
+    "version": "2.2.3"
+  },
+  {
+    "name": "apturl",
+    "version": "0.5.2ubuntu20"
+  },
+  {
+    "name": "apturl-common",
+    "version": "0.5.2ubuntu20"
+  },
+  {
+    "name": "aspell",
+    "version": "0.60.8-2"
+  },
+  {
+    "name": "at-spi2-core",
+    "version": "2.40.0-1"
+  },
+  {
+    "name": "avahi-autoipd",
+    "version": "0.8-5ubuntu3"
+  },
+  {
+    "name": "avahi-daemon",
+    "version": "0.8-5ubuntu3"
+  },
+  {
+    "name": "avahi-utils",
+    "version": "0.8-5ubuntu3"
+  },
+  {
+    "name": "base-files",
+    "version": "11ubuntu19"
+  },
+  {
+    "name": "base-passwd",
+    "version": "3.5.49"
+  },
+  {
+    "name": "bash",
+    "version": "5.1-2ubuntu1"
+  },
+  {
+    "name": "bc",
+    "version": "1.07.1-2build2"
+  },
+  {
+    "name": "bind9-dnsutils",
+    "version": "1:9.16.8-1ubuntu3"
+  },
+  {
+    "name": "bind9-host",
+    "version": "1:9.16.8-1ubuntu3"
+  },
+  {
+    "name": "bind9-libs",
+    "version": "1:9.16.8-1ubuntu3"
+  },
+  {
+    "name": "bluez",
+    "version": "5.56-0ubuntu4"
+  },
+  {
+    "name": "bluez-cups",
+    "version": "5.56-0ubuntu4"
+  },
+  {
+    "name": "bluez-obexd",
+    "version": "5.56-0ubuntu4"
+  },
+  {
+    "name": "bolt",
+    "version": "0.9.1-1"
+  },
+  {
+    "name": "brltty",
+    "version": "6.3+dfsg-1ubuntu1"
+  },
+  {
+    "name": "bsdextrautils",
+    "version": "2.36.1-7ubuntu2"
+  },
+  {
+    "name": "bsdutils",
+    "version": "1:2.36.1-7ubuntu2"
+  },
+  {
+    "name": "bubblewrap",
+    "version": "0.4.1-3"
+  },
+  {
+    "name": "busybox-initramfs",
+    "version": "1:1.30.1-6ubuntu2"
+  },
+  {
+    "name": "busybox-static",
+    "version": "1:1.30.1-6ubuntu2"
+  },
+  {
+    "name": "ca-certificates",
+    "version": "20210119build1"
+  },
+  {
+    "name": "cheese-common",
+    "version": "3.38.0-3"
+  },
+  {
+    "name": "colord",
+    "version": "1.4.5-3"
+  },
+  {
+    "name": "colord-data",
+    "version": "1.4.5-3"
+  },
+  {
+    "name": "command-not-found",
+    "version": "20.10.1"
+  },
+  {
+    "name": "console-setup",
+    "version": "1.201ubuntu2"
+  },
+  {
+    "name": "console-setup-linux",
+    "version": "1.201ubuntu2"
+  },
+  {
+    "name": "cpio",
+    "version": "2.13+dfsg-4"
+  },
+  {
+    "name": "cpp",
+    "version": "4:10.3.0-1ubuntu1"
+  },
+  {
+    "name": "cpp-10",
+    "version": "10.3.0-1ubuntu1"
+  },
+  {
+    "name": "crda",
+    "version": "4.14+git20191112.9856751-1"
+  },
+  {
+    "name": "cron",
+    "version": "3.0pl1-136ubuntu2"
+  },
+  {
+    "name": "cups",
+    "version": "2.3.3op2-3ubuntu3"
+  },
+  {
+    "name": "cups-browsed",
+    "version": "1.28.8-0ubuntu1"
+  },
+  {
+    "name": "cups-bsd",
+    "version": "2.3.3op2-3ubuntu3"
+  },
+  {
+    "name": "cups-client",
+    "version": "2.3.3op2-3ubuntu3"
+  },
+  {
+    "name": "cups-common",
+    "version": "2.3.3op2-3ubuntu3"
+  },
+  {
+    "name": "cups-core-drivers",
+    "version": "2.3.3op2-3ubuntu3"
+  },
+  {
+    "name": "cups-daemon",
+    "version": "2.3.3op2-3ubuntu3"
+  },
+  {
+    "name": "cups-filters",
+    "version": "1.28.8-0ubuntu1"
+  },
+  {
+    "name": "cups-filters-core-drivers",
+    "version": "1.28.8-0ubuntu1"
+  },
+  {
+    "name": "cups-ipp-utils",
+    "version": "2.3.3op2-3ubuntu3"
+  },
+  {
+    "name": "cups-pk-helper",
+    "version": "0.2.6-1ubuntu3"
+  },
+  {
+    "name": "cups-ppdc",
+    "version": "2.3.3op2-3ubuntu3"
+  },
+  {
+    "name": "cups-server-common",
+    "version": "2.3.3op2-3ubuntu3"
+  },
+  {
+    "name": "dash",
+    "version": "0.5.11+git20200708+dd9ef66+really0.5.11+git20200708+dd9ef66-5ubuntu1"
+  },
+  {
+    "name": "dbus",
+    "version": "1.12.20-1ubuntu3"
+  },
+  {
+    "name": "dbus-user-session",
+    "version": "1.12.20-1ubuntu3"
+  },
+  {
+    "name": "dbus-x11",
+    "version": "1.12.20-1ubuntu3"
+  },
+  {
+    "name": "dc",
+    "version": "1.07.1-2build2"
+  },
+  {
+    "name": "dconf-cli",
+    "version": "0.38.0-2"
+  },
+  {
+    "name": "dconf-gsettings-backend",
+    "version": "0.38.0-2"
+  },
+  {
+    "name": "dconf-service",
+    "version": "0.38.0-2"
+  },
+  {
+    "name": "debconf",
+    "version": "1.5.74"
+  },
+  {
+    "name": "debconf-i18n",
+    "version": "1.5.74"
+  },
+  {
+    "name": "desktop-file-utils",
+    "version": "0.26-1ubuntu1"
+  },
+  {
+    "name": "diffutils",
+    "version": "1:3.7-3ubuntu1"
+  },
+  {
+    "name": "dirmngr",
+    "version": "2.2.20-1ubuntu3"
+  },
+  {
+    "name": "distro-info-data",
+    "version": "0.46"
+  },
+  {
+    "name": "dmidecode",
+    "version": "3.3-1build1"
+  },
+  {
+    "name": "dmsetup",
+    "version": "2:1.02.175-2ubuntu4"
+  },
+  {
+    "name": "dnsmasq-base",
+    "version": "2.84-1ubuntu2"
+  },
+  {
+    "name": "dosfstools",
+    "version": "4.2-1build1"
+  },
+  {
+    "name": "dpkg",
+    "version": "1.20.9ubuntu1"
+  },
+  {
+    "name": "e2fsprogs",
+    "version": "1.45.7-1ubuntu2"
+  },
+  {
+    "name": "efibootmgr",
+    "version": "17-1"
+  },
+  {
+    "name": "eject",
+    "version": "2.36.1-7ubuntu2"
+  },
+  {
+    "name": "enchant-2",
+    "version": "2.2.15-1"
+  },
+  {
+    "name": "eog",
+    "version": "40.0-1"
+  },
+  {
+    "name": "espeak-ng-data",
+    "version": "1.50+dfsg-7build1"
+  },
+  {
+    "name": "evince",
+    "version": "40.1-1"
+  },
+  {
+    "name": "evince-common",
+    "version": "40.1-1"
+  },
+  {
+    "name": "evolution-data-server",
+    "version": "3.40.0-1ubuntu1"
+  },
+  {
+    "name": "evolution-data-server-common",
+    "version": "3.40.0-1ubuntu1"
+  },
+  {
+    "name": "fdisk",
+    "version": "2.36.1-7ubuntu2"
+  },
+  {
+    "name": "file-roller",
+    "version": "3.38.1-1"
+  },
+  {
+    "name": "findutils",
+    "version": "4.8.0-1ubuntu1"
+  },
+  {
+    "name": "firefox",
+    "version": "87.0+build3-0ubuntu4"
+  },
+  {
+    "name": "firefox-locale-en",
+    "version": "87.0+build3-0ubuntu4"
+  },
+  {
+    "name": "fonts-khmeros-core",
+    "version": "5.0-7.1ubuntu2"
+  },
+  {
+    "name": "fonts-liberation2",
+    "version": "2.1.2-2"
+  },
+  {
+    "name": "fonts-lklug-sinhala",
+    "version": "0.6-3.1build1"
+  },
+  {
+    "name": "fonts-noto-color-emoji",
+    "version": "0~20200916-1"
+  },
+  {
+    "name": "fonts-opensymbol",
+    "version": "2:102.12+LibO7.1.2~rc2-0ubuntu2"
+  },
+  {
+    "name": "fonts-yrsa-rasa",
+    "version": "1.002-3"
+  },
+  {
+    "name": "foomatic-db-compressed-ppds",
+    "version": "20200820-1"
+  },
+  {
+    "name": "fprintd",
+    "version": "1.90.9-1"
+  },
+  {
+    "name": "fuse",
+    "version": "2.9.9-4ubuntu2"
+  },
+  {
+    "name": "fwupd",
+    "version": "1.5.8-0ubuntu1"
+  },
+  {
+    "name": "fwupd-signed",
+    "version": "1.38+1.5.8-0ubuntu1"
+  },
+  {
+    "name": "gcc-10-base",
+    "version": "10.3.0-1ubuntu1"
+  },
+  {
+    "name": "gcc-11-base",
+    "version": "11-20210417-1ubuntu1"
+  },
+  {
+    "name": "gcr",
+    "version": "3.38.1-2"
+  },
+  {
+    "name": "gdb",
+    "version": "10.1-2ubuntu2"
+  },
+  {
+    "name": "gdisk",
+    "version": "1.0.6-1.1"
+  },
+  {
+    "name": "gdm3",
+    "version": "3.38.2.1-2ubuntu1"
+  },
+  {
+    "name": "gedit",
+    "version": "3.38.1-1"
+  },
+  {
+    "name": "gedit-common",
+    "version": "3.38.1-1"
+  },
+  {
+    "name": "geoclue-2.0",
+    "version": "2.5.7-2ubuntu1"
+  },
+  {
+    "name": "gettext-base",
+    "version": "0.21-3ubuntu2"
+  },
+  {
+    "name": "ghostscript",
+    "version": "9.53.3~dfsg-7"
+  },
+  {
+    "name": "ghostscript-x",
+    "version": "9.53.3~dfsg-7"
+  },
+  {
+    "name": "gir1.2-accountsservice-1.0",
+    "version": "0.6.55-0ubuntu13.2"
+  },
+  {
+    "name": "gir1.2-atk-1.0",
+    "version": "2.36.0-0ubuntu2"
+  },
+  {
+    "name": "gir1.2-atspi-2.0",
+    "version": "2.40.0-1"
+  },
+  {
+    "name": "gir1.2-dbusmenu-glib-0.4",
+    "version": "16.04.1+18.10.20180917-0ubuntu6"
+  },
+  {
+    "name": "gir1.2-dee-1.0",
+    "version": "1.2.7+17.10.20170616-6ubuntu1"
+  },
+  {
+    "name": "gir1.2-freedesktop",
+    "version": "1.66.1-1build1"
+  },
+  {
+    "name": "gir1.2-gck-1",
+    "version": "3.38.1-2"
+  },
+  {
+    "name": "gir1.2-gcr-3",
+    "version": "3.38.1-2"
+  },
+  {
+    "name": "gir1.2-gdesktopenums-3.0",
+    "version": "3.38.0-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-gdkpixbuf-2.0",
+    "version": "2.42.2+dfsg-1build1"
+  },
+  {
+    "name": "gir1.2-gdm-1.0",
+    "version": "3.38.2.1-2ubuntu1"
+  },
+  {
+    "name": "gir1.2-geoclue-2.0",
+    "version": "2.5.7-2ubuntu1"
+  },
+  {
+    "name": "gir1.2-glib-2.0",
+    "version": "1.66.1-1build1"
+  },
+  {
+    "name": "gir1.2-gnomebluetooth-1.0",
+    "version": "3.34.5-1"
+  },
+  {
+    "name": "gir1.2-gnomedesktop-3.0",
+    "version": "3.38.5-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-goa-1.0",
+    "version": "3.38.1-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-graphene-1.0",
+    "version": "1.10.4+dfsg1-1"
+  },
+  {
+    "name": "gir1.2-gstreamer-1.0",
+    "version": "1.18.4-1"
+  },
+  {
+    "name": "gir1.2-gtk-3.0",
+    "version": "3.24.25-1ubuntu4"
+  },
+  {
+    "name": "gir1.2-gtksource-4",
+    "version": "4.8.1-1"
+  },
+  {
+    "name": "gir1.2-gweather-3.0",
+    "version": "3.36.1-2"
+  },
+  {
+    "name": "gir1.2-handy-1",
+    "version": "1.2.0-1"
+  },
+  {
+    "name": "gir1.2-ibus-1.0",
+    "version": "1.5.24-1"
+  },
+  {
+    "name": "gir1.2-javascriptcoregtk-4.0",
+    "version": "2.32.0-1ubuntu3"
+  },
+  {
+    "name": "gir1.2-mutter-7",
+    "version": "3.38.4-1ubuntu2"
+  },
+  {
+    "name": "gir1.2-nm-1.0",
+    "version": "1.30.0-1ubuntu3"
+  },
+  {
+    "name": "gir1.2-nma-1.0",
+    "version": "1.8.30-1"
+  },
+  {
+    "name": "gir1.2-notify-0.7",
+    "version": "0.7.9-3ubuntu2"
+  },
+  {
+    "name": "gir1.2-packagekitglib-1.0",
+    "version": "1.2.2-2ubuntu1"
+  },
+  {
+    "name": "gir1.2-pango-1.0",
+    "version": "1.48.2-1build2"
+  },
+  {
+    "name": "gir1.2-peas-1.0",
+    "version": "1.30.0-1"
+  },
+  {
+    "name": "gir1.2-polkit-1.0",
+    "version": "0.105-30"
+  },
+  {
+    "name": "gir1.2-rsvg-2.0",
+    "version": "2.50.3+dfsg-1"
+  },
+  {
+    "name": "gir1.2-soup-2.4",
+    "version": "2.72.0-3"
+  },
+  {
+    "name": "gir1.2-upowerglib-1.0",
+    "version": "0.99.11-2"
+  },
+  {
+    "name": "gir1.2-vte-2.91",
+    "version": "0.62.3-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-webkit2-4.0",
+    "version": "2.32.0-1ubuntu3"
+  },
+  {
+    "name": "gir1.2-wnck-3.0",
+    "version": "3.36.0-1"
+  },
+  {
+    "name": "gjs",
+    "version": "1.67.2-2ubuntu1"
+  },
+  {
+    "name": "gkbd-capplet",
+    "version": "3.26.1-1"
+  },
+  {
+    "name": "glib-networking",
+    "version": "2.66.0-2"
+  },
+  {
+    "name": "glib-networking-common",
+    "version": "2.66.0-2"
+  },
+  {
+    "name": "glib-networking-services",
+    "version": "2.66.0-2"
+  },
+  {
+    "name": "gnome-accessibility-themes",
+    "version": "3.28-1ubuntu1"
+  },
+  {
+    "name": "gnome-bluetooth",
+    "version": "3.34.5-1"
+  },
+  {
+    "name": "gnome-calculator",
+    "version": "1:40.0-2ubuntu1"
+  },
+  {
+    "name": "gnome-characters",
+    "version": "40.0-1"
+  },
+  {
+    "name": "gnome-control-center",
+    "version": "1:3.38.5-1ubuntu1"
+  },
+  {
+    "name": "gnome-control-center-data",
+    "version": "1:3.38.5-1ubuntu1"
+  },
+  {
+    "name": "gnome-control-center-faces",
+    "version": "1:3.38.5-1ubuntu1"
+  },
+  {
+    "name": "gnome-desktop3-data",
+    "version": "3.38.5-1ubuntu1"
+  },
+  {
+    "name": "gnome-disk-utility",
+    "version": "40.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-font-viewer",
+    "version": "40.0-1"
+  },
+  {
+    "name": "gnome-getting-started-docs",
+    "version": "3.36.2+git20201004.1-0ubuntu1"
+  },
+  {
+    "name": "gnome-initial-setup",
+    "version": "3.38.4-1ubuntu1"
+  },
+  {
+    "name": "gnome-keyring",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-keyring-pkcs11",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-logs",
+    "version": "3.36.0-2"
+  },
+  {
+    "name": "gnome-online-accounts",
+    "version": "3.38.1-1ubuntu1"
+  },
+  {
+    "name": "gnome-power-manager",
+    "version": "3.32.0-2"
+  },
+  {
+    "name": "gnome-screenshot",
+    "version": "3.38.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-session-bin",
+    "version": "3.38.0-3ubuntu2"
+  },
+  {
+    "name": "gnome-session-common",
+    "version": "3.38.0-3ubuntu2"
+  },
+  {
+    "name": "gnome-settings-daemon",
+    "version": "3.38.1-3ubuntu3"
+  },
+  {
+    "name": "gnome-settings-daemon-common",
+    "version": "3.38.1-3ubuntu3"
+  },
+  {
+    "name": "gnome-shell",
+    "version": "3.38.4-1ubuntu2"
+  },
+  {
+    "name": "gnome-shell-common",
+    "version": "3.38.4-1ubuntu2"
+  },
+  {
+    "name": "gnome-shell-extension-appindicator",
+    "version": "35-1"
+  },
+  {
+    "name": "gnome-shell-extension-desktop-icons-ng",
+    "version": "0.15.0-0ubuntu4"
+  },
+  {
+    "name": "gnome-shell-extension-ubuntu-dock",
+    "version": "69ubuntu1"
+  },
+  {
+    "name": "gnome-startup-applications",
+    "version": "3.38.0-3ubuntu2"
+  },
+  {
+    "name": "gnome-system-monitor",
+    "version": "40.0-2"
+  },
+  {
+    "name": "gnome-terminal",
+    "version": "3.38.1-1ubuntu1"
+  },
+  {
+    "name": "gnome-terminal-data",
+    "version": "3.38.1-1ubuntu1"
+  },
+  {
+    "name": "gnome-themes-extra",
+    "version": "3.28-1ubuntu1"
+  },
+  {
+    "name": "gnome-themes-extra-data",
+    "version": "3.28-1ubuntu1"
+  },
+  {
+    "name": "gnome-user-docs",
+    "version": "3.38.2+git20210212-0ubuntu1"
+  },
+  {
+    "name": "gnupg",
+    "version": "2.2.20-1ubuntu3"
+  },
+  {
+    "name": "gnupg-l10n",
+    "version": "2.2.20-1ubuntu3"
+  },
+  {
+    "name": "gnupg-utils",
+    "version": "2.2.20-1ubuntu3"
+  },
+  {
+    "name": "gpg",
+    "version": "2.2.20-1ubuntu3"
+  },
+  {
+    "name": "gpg-agent",
+    "version": "2.2.20-1ubuntu3"
+  },
+  {
+    "name": "gpg-wks-client",
+    "version": "2.2.20-1ubuntu3"
+  },
+  {
+    "name": "gpg-wks-server",
+    "version": "2.2.20-1ubuntu3"
+  },
+  {
+    "name": "gpgconf",
+    "version": "2.2.20-1ubuntu3"
+  },
+  {
+    "name": "gpgsm",
+    "version": "2.2.20-1ubuntu3"
+  },
+  {
+    "name": "gpgv",
+    "version": "2.2.20-1ubuntu3"
+  },
+  {
+    "name": "grep",
+    "version": "3.6-1"
+  },
+  {
+    "name": "groff-base",
+    "version": "1.22.4-6"
+  },
+  {
+    "name": "grub-common",
+    "version": "2.04-1ubuntu45"
+  },
+  {
+    "name": "grub-efi-amd64-bin",
+    "version": "2.04-1ubuntu45"
+  },
+  {
+    "name": "grub-efi-amd64-signed",
+    "version": "1.169+2.04-1ubuntu45"
+  },
+  {
+    "name": "grub-pc",
+    "version": "2.04-1ubuntu45"
+  },
+  {
+    "name": "grub-pc-bin",
+    "version": "2.04-1ubuntu45"
+  },
+  {
+    "name": "grub2-common",
+    "version": "2.04-1ubuntu45"
+  },
+  {
+    "name": "gsettings-desktop-schemas",
+    "version": "3.38.0-1ubuntu1"
+  },
+  {
+    "name": "gsettings-ubuntu-schemas",
+    "version": "0.0.7+17.10.20170922-0ubuntu1"
+  },
+  {
+    "name": "gstreamer1.0-alsa",
+    "version": "1.18.4-1"
+  },
+  {
+    "name": "gstreamer1.0-clutter-3.0",
+    "version": "3.0.27-2"
+  },
+  {
+    "name": "gstreamer1.0-gl",
+    "version": "1.18.4-1"
+  },
+  {
+    "name": "gstreamer1.0-packagekit",
+    "version": "1.2.2-2ubuntu1"
+  },
+  {
+    "name": "gstreamer1.0-pipewire",
+    "version": "0.3.24-3"
+  },
+  {
+    "name": "gstreamer1.0-plugins-base",
+    "version": "1.18.4-1"
+  },
+  {
+    "name": "gstreamer1.0-plugins-base-apps",
+    "version": "1.18.4-1"
+  },
+  {
+    "name": "gstreamer1.0-plugins-good",
+    "version": "1.18.4-1ubuntu1"
+  },
+  {
+    "name": "gstreamer1.0-pulseaudio",
+    "version": "1.18.4-1ubuntu1"
+  },
+  {
+    "name": "gstreamer1.0-tools",
+    "version": "1.18.4-1"
+  },
+  {
+    "name": "gstreamer1.0-x",
+    "version": "1.18.4-1"
+  },
+  {
+    "name": "gtk-update-icon-cache",
+    "version": "3.24.25-1ubuntu4"
+  },
+  {
+    "name": "gtk2-engines-murrine",
+    "version": "0.98.2-3"
+  },
+  {
+    "name": "gtk2-engines-pixbuf",
+    "version": "2.24.33-1ubuntu2"
+  },
+  {
+    "name": "gzip",
+    "version": "1.10-2ubuntu3"
+  },
+  {
+    "name": "hdparm",
+    "version": "9.60+ds-1build1"
+  },
+  {
+    "name": "hostname",
+    "version": "3.23"
+  },
+  {
+    "name": "hplip",
+    "version": "3.21.2+dfsg1-2"
+  },
+  {
+    "name": "hplip-data",
+    "version": "3.21.2+dfsg1-2"
+  },
+  {
+    "name": "ibus",
+    "version": "1.5.24-1"
+  },
+  {
+    "name": "ibus-data",
+    "version": "1.5.24-1"
+  },
+  {
+    "name": "ibus-gtk",
+    "version": "1.5.24-1"
+  },
+  {
+    "name": "ibus-gtk3",
+    "version": "1.5.24-1"
+  },
+  {
+    "name": "iio-sensor-proxy",
+    "version": "3.0-2"
+  },
+  {
+    "name": "im-config",
+    "version": "0.46-1"
+  },
+  {
+    "name": "init",
+    "version": "1.60"
+  },
+  {
+    "name": "init-system-helpers",
+    "version": "1.60"
+  },
+  {
+    "name": "initramfs-tools",
+    "version": "0.139ubuntu3"
+  },
+  {
+    "name": "initramfs-tools-bin",
+    "version": "0.139ubuntu3"
+  },
+  {
+    "name": "initramfs-tools-core",
+    "version": "0.139ubuntu3"
+  },
+  {
+    "name": "inputattach",
+    "version": "1:1.7.1-1"
+  },
+  {
+    "name": "intel-microcode",
+    "version": "3.20201110.0ubuntu1"
+  },
+  {
+    "name": "ipp-usb",
+    "version": "0.9.17-3ubuntu1"
+  },
+  {
+    "name": "irqbalance",
+    "version": "1.7.0-1"
+  },
+  {
+    "name": "isc-dhcp-client",
+    "version": "4.4.1-2.2ubuntu6"
+  },
+  {
+    "name": "isc-dhcp-common",
+    "version": "4.4.1-2.2ubuntu6"
+  },
+  {
+    "name": "iucode-tool",
+    "version": "2.3.1-1"
+  },
+  {
+    "name": "jeepney",
+    "version": "0.6.0"
+  },
+  {
+    "name": "kbd",
+    "version": "2.3.0-3ubuntu2"
+  },
+  {
+    "name": "kerneloops",
+    "version": "0.12+git20140509-6ubuntu3"
+  },
+  {
+    "name": "keyboard-configuration",
+    "version": "1.201ubuntu2"
+  },
+  {
+    "name": "keyring",
+    "version": "22.2.0"
+  },
+  {
+    "name": "klibc-utils",
+    "version": "2.0.8-5ubuntu1"
+  },
+  {
+    "name": "kmod",
+    "version": "28-1ubuntu2"
+  },
+  {
+    "name": "krb5-locales",
+    "version": "1.18.3-4"
+  },
+  {
+    "name": "language-pack-en",
+    "version": "1:21.04+20210415"
+  },
+  {
+    "name": "language-pack-en-base",
+    "version": "1:21.04+20210415"
+  },
+  {
+    "name": "language-pack-gnome-en",
+    "version": "1:21.04+20210415"
+  },
+  {
+    "name": "language-pack-gnome-en-base",
+    "version": "1:21.04+20210415"
+  },
+  {
+    "name": "language-selector-common",
+    "version": "0.211"
+  },
+  {
+    "name": "language-selector-gnome",
+    "version": "0.211"
+  },
+  {
+    "name": "libaa1",
+    "version": "1.4p5-48"
+  },
+  {
+    "name": "libaccountsservice0",
+    "version": "0.6.55-0ubuntu13.2"
+  },
+  {
+    "name": "libacl1",
+    "version": "2.2.53-10ubuntu1"
+  },
+  {
+    "name": "libamtk-5-0",
+    "version": "5.2.0-1"
+  },
+  {
+    "name": "libamtk-5-common",
+    "version": "5.2.0-1"
+  },
+  {
+    "name": "libao-common",
+    "version": "1.2.2+20180113-1ubuntu1"
+  },
+  {
+    "name": "libao4",
+    "version": "1.2.2+20180113-1ubuntu1"
+  },
+  {
+    "name": "libapparmor1",
+    "version": "3.0.0-0ubuntu7"
+  },
+  {
+    "name": "libappindicator3-1",
+    "version": "12.10.1+20.10.20200706.1-0ubuntu1"
+  },
+  {
+    "name": "libappstream4",
+    "version": "0.14.1-1"
+  },
+  {
+    "name": "libapt-pkg6.0",
+    "version": "2.2.3"
+  },
+  {
+    "name": "libasn1-8-heimdal",
+    "version": "7.7.0+dfsg-2"
+  },
+  {
+    "name": "libasound2",
+    "version": "1.2.4-1.1ubuntu2"
+  },
+  {
+    "name": "libasound2-data",
+    "version": "1.2.4-1.1ubuntu2"
+  },
+  {
+    "name": "libasound2-plugins",
+    "version": "1.2.2-2"
+  },
+  {
+    "name": "libaspell15",
+    "version": "0.60.8-2"
+  },
+  {
+    "name": "libassuan0",
+    "version": "2.5.4-1ubuntu1"
+  },
+  {
+    "name": "libasyncns0",
+    "version": "0.8-6"
+  },
+  {
+    "name": "libatk-adaptor",
+    "version": "2.38.0-1build1"
+  },
+  {
+    "name": "libatk-bridge2.0-0",
+    "version": "2.38.0-1build1"
+  },
+  {
+    "name": "libatk1.0-0",
+    "version": "2.36.0-0ubuntu2"
+  },
+  {
+    "name": "libatk1.0-data",
+    "version": "2.36.0-0ubuntu2"
+  },
+  {
+    "name": "libatkmm-1.6-1v5",
+    "version": "2.28.0-3"
+  },
+  {
+    "name": "libatm1",
+    "version": "1:2.5.1-4"
+  },
+  {
+    "name": "libatopology2",
+    "version": "1.2.4-1.1ubuntu2"
+  },
+  {
+    "name": "libatspi2.0-0",
+    "version": "2.40.0-1"
+  },
+  {
+    "name": "libattr1",
+    "version": "1:2.4.48-6build1"
+  },
+  {
+    "name": "libaudit-common",
+    "version": "1:3.0-2ubuntu1"
+  },
+  {
+    "name": "libaudit1",
+    "version": "1:3.0-2ubuntu1"
+  },
+  {
+    "name": "libavahi-client3",
+    "version": "0.8-5ubuntu3"
+  },
+  {
+    "name": "libavahi-common-data",
+    "version": "0.8-5ubuntu3"
+  },
+  {
+    "name": "libavahi-common3",
+    "version": "0.8-5ubuntu3"
+  },
+  {
+    "name": "libavahi-core7",
+    "version": "0.8-5ubuntu3"
+  },
+  {
+    "name": "libavahi-glib1",
+    "version": "0.8-5ubuntu3"
+  },
+  {
+    "name": "libavc1394-0",
+    "version": "0.5.4-5"
+  },
+  {
+    "name": "libbabeltrace1",
+    "version": "1.5.8-1build3"
+  },
+  {
+    "name": "libblkid1",
+    "version": "2.36.1-7ubuntu2"
+  },
+  {
+    "name": "libblockdev-crypto2",
+    "version": "2.25-2"
+  },
+  {
+    "name": "libblockdev-fs2",
+    "version": "2.25-2"
+  },
+  {
+    "name": "libblockdev-loop2",
+    "version": "2.25-2"
+  },
+  {
+    "name": "libblockdev-part-err2",
+    "version": "2.25-2"
+  },
+  {
+    "name": "libblockdev-part2",
+    "version": "2.25-2"
+  },
+  {
+    "name": "libblockdev-swap2",
+    "version": "2.25-2"
+  },
+  {
+    "name": "libblockdev-utils2",
+    "version": "2.25-2"
+  },
+  {
+    "name": "libblockdev2",
+    "version": "2.25-2"
+  },
+  {
+    "name": "libbluetooth3",
+    "version": "5.56-0ubuntu4"
+  },
+  {
+    "name": "libboost-regex1.74.0",
+    "version": "1.74.0-8ubuntu2"
+  },
+  {
+    "name": "libbpf0",
+    "version": "1:0.3-2ubuntu1"
+  },
+  {
+    "name": "libbrlapi0.8",
+    "version": "6.3+dfsg-1ubuntu1"
+  },
+  {
+    "name": "libbrotli1",
+    "version": "1.0.9-2build2"
+  },
+  {
+    "name": "libc-bin",
+    "version": "2.33-0ubuntu5"
+  },
+  {
+    "name": "libc6",
+    "version": "2.33-0ubuntu5"
+  },
+  {
+    "name": "libc6-dbg",
+    "version": "2.33-0ubuntu5"
+  },
+  {
+    "name": "libcaca0",
+    "version": "0.99.beta19-2.2ubuntu1"
+  },
+  {
+    "name": "libcairo-gobject-perl",
+    "version": "1.005-2build1"
+  },
+  {
+    "name": "libcairomm-1.0-1v5",
+    "version": "1.12.2-4build1"
+  },
+  {
+    "name": "libcamel-1.2-62",
+    "version": "3.40.0-1ubuntu1"
+  },
+  {
+    "name": "libcdio-cdda2",
+    "version": "10.2+2.0.0-1build1"
+  },
+  {
+    "name": "libcdio-paranoia2",
+    "version": "10.2+2.0.0-1build1"
+  },
+  {
+    "name": "libcdparanoia0",
+    "version": "3.10.2+debian-13.1"
+  },
+  {
+    "name": "libcheese-gtk25",
+    "version": "3.38.0-3"
+  },
+  {
+    "name": "libcheese8",
+    "version": "3.38.0-3"
+  },
+  {
+    "name": "libclutter-1.0-0",
+    "version": "1.26.4+dfsg-2"
+  },
+  {
+    "name": "libclutter-1.0-common",
+    "version": "1.26.4+dfsg-2"
+  },
+  {
+    "name": "libclutter-gst-3.0-0",
+    "version": "3.0.27-2"
+  },
+  {
+    "name": "libclutter-gtk-1.0-0",
+    "version": "1.8.4-4"
+  },
+  {
+    "name": "libcogl-common",
+    "version": "1.22.8-2"
+  },
+  {
+    "name": "libcogl-pango20",
+    "version": "1.22.8-2"
+  },
+  {
+    "name": "libcogl-path20",
+    "version": "1.22.8-2"
+  },
+  {
+    "name": "libcogl20",
+    "version": "1.22.8-2"
+  },
+  {
+    "name": "libcolord-gtk1",
+    "version": "0.2.0-0ubuntu1"
+  },
+  {
+    "name": "libcolord2",
+    "version": "1.4.5-3"
+  },
+  {
+    "name": "libcolorhug2",
+    "version": "1.4.5-3"
+  },
+  {
+    "name": "libcom-err2",
+    "version": "1.45.7-1ubuntu2"
+  },
+  {
+    "name": "libcrypt1",
+    "version": "1:4.4.17-1ubuntu3"
+  },
+  {
+    "name": "libcryptsetup12",
+    "version": "2:2.3.4-1ubuntu3"
+  },
+  {
+    "name": "libcue2",
+    "version": "2.2.1-3build1"
+  },
+  {
+    "name": "libcups2",
+    "version": "2.3.3op2-3ubuntu3"
+  },
+  {
+    "name": "libcupsfilters1",
+    "version": "1.28.8-0ubuntu1"
+  },
+  {
+    "name": "libcupsimage2",
+    "version": "2.3.3op2-3ubuntu3"
+  },
+  {
+    "name": "libcurl3-gnutls",
+    "version": "7.74.0-1ubuntu2"
+  },
+  {
+    "name": "libcurl4",
+    "version": "7.74.0-1ubuntu2"
+  },
+  {
+    "name": "libdaemon0",
+    "version": "0.14-7.1ubuntu1"
+  },
+  {
+    "name": "libdb5.3",
+    "version": "5.3.28+dfsg1-0.6ubuntu4"
+  },
+  {
+    "name": "libdbus-1-3",
+    "version": "1.12.20-1ubuntu3"
+  },
+  {
+    "name": "libdbus-glib-1-2",
+    "version": "0.110-6fakesync1"
+  },
+  {
+    "name": "libdbusmenu-glib4",
+    "version": "16.04.1+18.10.20180917-0ubuntu6"
+  },
+  {
+    "name": "libdbusmenu-gtk3-4",
+    "version": "16.04.1+18.10.20180917-0ubuntu6"
+  },
+  {
+    "name": "libdconf1",
+    "version": "0.38.0-2"
+  },
+  {
+    "name": "libdebuginfod-common",
+    "version": "0.183-8"
+  },
+  {
+    "name": "libdebuginfod1",
+    "version": "0.183-8"
+  },
+  {
+    "name": "libdee-1.0-4",
+    "version": "1.2.7+17.10.20170616-6ubuntu1"
+  },
+  {
+    "name": "libdeflate0",
+    "version": "1.7-1ubuntu1"
+  },
+  {
+    "name": "libdevmapper1.02.1",
+    "version": "2:1.02.175-2ubuntu4"
+  },
+  {
+    "name": "libdjvulibre-text",
+    "version": "3.5.28-1"
+  },
+  {
+    "name": "libdjvulibre21",
+    "version": "3.5.28-1"
+  },
+  {
+    "name": "libdns-export1110",
+    "version": "1:9.11.19+dfsg-2ubuntu2"
+  },
+  {
+    "name": "libdotconf0",
+    "version": "1.3-0.3fakesync1"
+  },
+  {
+    "name": "libdpkg-perl",
+    "version": "1.20.9ubuntu1"
+  },
+  {
+    "name": "libdrm-amdgpu1",
+    "version": "2.4.104-1build1"
+  },
+  {
+    "name": "libdrm-common",
+    "version": "2.4.104-1build1"
+  },
+  {
+    "name": "libdrm-intel1",
+    "version": "2.4.104-1build1"
+  },
+  {
+    "name": "libdrm-nouveau2",
+    "version": "2.4.104-1build1"
+  },
+  {
+    "name": "libdrm-radeon1",
+    "version": "2.4.104-1build1"
+  },
+  {
+    "name": "libdrm2",
+    "version": "2.4.104-1build1"
+  },
+  {
+    "name": "libdv4",
+    "version": "1.0.0-13"
+  },
+  {
+    "name": "libdw1",
+    "version": "0.183-8"
+  },
+  {
+    "name": "libebackend-1.2-10",
+    "version": "3.40.0-1ubuntu1"
+  },
+  {
+    "name": "libebook-1.2-20",
+    "version": "3.40.0-1ubuntu1"
+  },
+  {
+    "name": "libebook-contacts-1.2-3",
+    "version": "3.40.0-1ubuntu1"
+  },
+  {
+    "name": "libecal-2.0-1",
+    "version": "3.40.0-1ubuntu1"
+  },
+  {
+    "name": "libedata-book-1.2-26",
+    "version": "3.40.0-1ubuntu1"
+  },
+  {
+    "name": "libedata-cal-2.0-1",
+    "version": "3.40.0-1ubuntu1"
+  },
+  {
+    "name": "libedataserver-1.2-26",
+    "version": "3.40.0-1ubuntu1"
+  },
+  {
+    "name": "libedataserverui-1.2-3",
+    "version": "3.40.0-1ubuntu1"
+  },
+  {
+    "name": "libedit2",
+    "version": "3.1-20191231-2"
+  },
+  {
+    "name": "libefiboot1",
+    "version": "37-6ubuntu1"
+  },
+  {
+    "name": "libefivar1",
+    "version": "37-6ubuntu1"
+  },
+  {
+    "name": "libegl-mesa0",
+    "version": "21.0.1-2"
+  },
+  {
+    "name": "libegl1",
+    "version": "1.3.2-1"
+  },
+  {
+    "name": "libelf1",
+    "version": "0.183-8"
+  },
+  {
+    "name": "libenchant-2-2",
+    "version": "2.2.15-1"
+  },
+  {
+    "name": "libepoxy0",
+    "version": "1.5.5-1build1"
+  },
+  {
+    "name": "libespeak-ng1",
+    "version": "1.50+dfsg-7build1"
+  },
+  {
+    "name": "libestr0",
+    "version": "0.1.10-2.1build1"
+  },
+  {
+    "name": "libevdocument3-4",
+    "version": "40.1-1"
+  },
+  {
+    "name": "libevview3-3",
+    "version": "40.1-1"
+  },
+  {
+    "name": "libexempi8",
+    "version": "2.5.2-1"
+  },
+  {
+    "name": "libexiv2-27",
+    "version": "0.27.3-3ubuntu1"
+  },
+  {
+    "name": "libexpat1",
+    "version": "2.2.10-2"
+  },
+  {
+    "name": "libext2fs2",
+    "version": "1.45.7-1ubuntu2"
+  },
+  {
+    "name": "libfastjson4",
+    "version": "0.99.9-1"
+  },
+  {
+    "name": "libfdisk1",
+    "version": "2.36.1-7ubuntu2"
+  },
+  {
+    "name": "libffi8ubuntu1",
+    "version": "3.4~20200819gead65ca871-0ubuntu5"
+  },
+  {
+    "name": "libfftw3-single3",
+    "version": "3.3.8-2ubuntu6"
+  },
+  {
+    "name": "libfido2-1",
+    "version": "1.6.0-2"
+  },
+  {
+    "name": "libfontembed1",
+    "version": "1.28.8-0ubuntu1"
+  },
+  {
+    "name": "libfontenc1",
+    "version": "1:1.1.4-1build1"
+  },
+  {
+    "name": "libfprint-2-2",
+    "version": "1:1.90.7+git20210222+tod1-0ubuntu2"
+  },
+  {
+    "name": "libfribidi0",
+    "version": "1.0.8-2ubuntu1"
+  },
+  {
+    "name": "libfuse2",
+    "version": "2.9.9-4ubuntu2"
+  },
+  {
+    "name": "libfwupd2",
+    "version": "1.5.8-0ubuntu1"
+  },
+  {
+    "name": "libfwupdplugin1",
+    "version": "1.5.8-0ubuntu1"
+  },
+  {
+    "name": "libgail-common",
+    "version": "2.24.33-1ubuntu2"
+  },
+  {
+    "name": "libgail18",
+    "version": "2.24.33-1ubuntu2"
+  },
+  {
+    "name": "libgbm1",
+    "version": "21.0.1-2"
+  },
+  {
+    "name": "libgcab-1.0-0",
+    "version": "1.4-3"
+  },
+  {
+    "name": "libgcc-s1",
+    "version": "11-20210417-1ubuntu1"
+  },
+  {
+    "name": "libgck-1-0",
+    "version": "3.38.1-2"
+  },
+  {
+    "name": "libgcr-base-3-1",
+    "version": "3.38.1-2"
+  },
+  {
+    "name": "libgcr-ui-3-1",
+    "version": "3.38.1-2"
+  },
+  {
+    "name": "libgcrypt20",
+    "version": "1.8.7-2ubuntu2"
+  },
+  {
+    "name": "libgd3",
+    "version": "2.3.0-2"
+  },
+  {
+    "name": "libgdata-common",
+    "version": "0.18.1-1"
+  },
+  {
+    "name": "libgdata22",
+    "version": "0.18.1-1"
+  },
+  {
+    "name": "libgdk-pixbuf-2.0-0",
+    "version": "2.42.2+dfsg-1build1"
+  },
+  {
+    "name": "libgdk-pixbuf-xlib-2.0-0",
+    "version": "2.40.2-2build2"
+  },
+  {
+    "name": "libgdk-pixbuf2.0-0",
+    "version": "2.40.2-2build2"
+  },
+  {
+    "name": "libgdk-pixbuf2.0-bin",
+    "version": "2.42.2+dfsg-1build1"
+  },
+  {
+    "name": "libgdk-pixbuf2.0-common",
+    "version": "2.42.2+dfsg-1build1"
+  },
+  {
+    "name": "libgdm1",
+    "version": "3.38.2.1-2ubuntu1"
+  },
+  {
+    "name": "libgee-0.8-2",
+    "version": "0.20.4-1"
+  },
+  {
+    "name": "libgeoclue-2-0",
+    "version": "2.5.7-2ubuntu1"
+  },
+  {
+    "name": "libgeocode-glib0",
+    "version": "3.26.2-2"
+  },
+  {
+    "name": "libgexiv2-2",
+    "version": "0.12.1-1"
+  },
+  {
+    "name": "libgif7",
+    "version": "5.1.9-2"
+  },
+  {
+    "name": "libgirepository-1.0-1",
+    "version": "1.66.1-1build1"
+  },
+  {
+    "name": "libgjs0g",
+    "version": "1.67.2-2ubuntu1"
+  },
+  {
+    "name": "libgl1",
+    "version": "1.3.2-1"
+  },
+  {
+    "name": "libgl1-mesa-dri",
+    "version": "21.0.1-2"
+  },
+  {
+    "name": "libglapi-mesa",
+    "version": "21.0.1-2"
+  },
+  {
+    "name": "libgles2",
+    "version": "1.3.2-1"
+  },
+  {
+    "name": "libglib-object-introspection-perl",
+    "version": "0.049-1build1"
+  },
+  {
+    "name": "libglib2.0-0",
+    "version": "2.68.0-1"
+  },
+  {
+    "name": "libglib2.0-bin",
+    "version": "2.68.0-1"
+  },
+  {
+    "name": "libglib2.0-data",
+    "version": "2.68.0-1"
+  },
+  {
+    "name": "libglibmm-2.4-1v5",
+    "version": "2.64.2-2"
+  },
+  {
+    "name": "libglvnd0",
+    "version": "1.3.2-1"
+  },
+  {
+    "name": "libglx-mesa0",
+    "version": "21.0.1-2"
+  },
+  {
+    "name": "libglx0",
+    "version": "1.3.2-1"
+  },
+  {
+    "name": "libgnome-autoar-0-0",
+    "version": "0.3.1-1"
+  },
+  {
+    "name": "libgnome-bluetooth13",
+    "version": "3.34.5-1"
+  },
+  {
+    "name": "libgnome-desktop-3-19",
+    "version": "3.38.5-1ubuntu1"
+  },
+  {
+    "name": "libgnomekbd-common",
+    "version": "3.26.1-1"
+  },
+  {
+    "name": "libgnomekbd8",
+    "version": "3.26.1-1"
+  },
+  {
+    "name": "libgnutls30",
+    "version": "3.7.1-3ubuntu1"
+  },
+  {
+    "name": "libgoa-1.0-0b",
+    "version": "3.38.1-1ubuntu1"
+  },
+  {
+    "name": "libgoa-1.0-common",
+    "version": "3.38.1-1ubuntu1"
+  },
+  {
+    "name": "libgoa-backend-1.0-1",
+    "version": "3.38.1-1ubuntu1"
+  },
+  {
+    "name": "libgomp1",
+    "version": "11-20210417-1ubuntu1"
+  },
+  {
+    "name": "libgpgme11",
+    "version": "1.14.0-1ubuntu3"
+  },
+  {
+    "name": "libgphoto2-6",
+    "version": "2.5.26-2"
+  },
+  {
+    "name": "libgphoto2-l10n",
+    "version": "2.5.26-2"
+  },
+  {
+    "name": "libgphoto2-port12",
+    "version": "2.5.26-2"
+  },
+  {
+    "name": "libgpm2",
+    "version": "1.20.7-8"
+  },
+  {
+    "name": "libgraphene-1.0-0",
+    "version": "1.10.4+dfsg1-1"
+  },
+  {
+    "name": "libgs9",
+    "version": "9.53.3~dfsg-7"
+  },
+  {
+    "name": "libgs9-common",
+    "version": "9.53.3~dfsg-7"
+  },
+  {
+    "name": "libgsf-1-114",
+    "version": "1.14.47-1"
+  },
+  {
+    "name": "libgsf-1-common",
+    "version": "1.14.47-1"
+  },
+  {
+    "name": "libgsound0",
+    "version": "1.0.2-5"
+  },
+  {
+    "name": "libgspell-1-2",
+    "version": "1.8.4-1"
+  },
+  {
+    "name": "libgspell-1-common",
+    "version": "1.8.4-1"
+  },
+  {
+    "name": "libgssapi-krb5-2",
+    "version": "1.18.3-4"
+  },
+  {
+    "name": "libgssapi3-heimdal",
+    "version": "7.7.0+dfsg-2"
+  },
+  {
+    "name": "libgssdp-1.2-0",
+    "version": "1.2.3-2"
+  },
+  {
+    "name": "libgstreamer-gl1.0-0",
+    "version": "1.18.4-1"
+  },
+  {
+    "name": "libgstreamer-plugins-base1.0-0",
+    "version": "1.18.4-1"
+  },
+  {
+    "name": "libgstreamer-plugins-good1.0-0",
+    "version": "1.18.4-1ubuntu1"
+  },
+  {
+    "name": "libgstreamer1.0-0",
+    "version": "1.18.4-1"
+  },
+  {
+    "name": "libgtk-3-0",
+    "version": "3.24.25-1ubuntu4"
+  },
+  {
+    "name": "libgtk-3-bin",
+    "version": "3.24.25-1ubuntu4"
+  },
+  {
+    "name": "libgtk-3-common",
+    "version": "3.24.25-1ubuntu4"
+  },
+  {
+    "name": "libgtk2.0-0",
+    "version": "2.24.33-1ubuntu2"
+  },
+  {
+    "name": "libgtk2.0-bin",
+    "version": "2.24.33-1ubuntu2"
+  },
+  {
+    "name": "libgtk2.0-common",
+    "version": "2.24.33-1ubuntu2"
+  },
+  {
+    "name": "libgtkmm-3.0-1v5",
+    "version": "3.24.2-2"
+  },
+  {
+    "name": "libgtksourceview-4-0",
+    "version": "4.8.1-1"
+  },
+  {
+    "name": "libgtksourceview-4-common",
+    "version": "4.8.1-1"
+  },
+  {
+    "name": "libgtop-2.0-11",
+    "version": "2.40.0-2build1"
+  },
+  {
+    "name": "libgtop2-common",
+    "version": "2.40.0-2build1"
+  },
+  {
+    "name": "libgudev-1.0-0",
+    "version": "1:234-1"
+  },
+  {
+    "name": "libgupnp-1.2-0",
+    "version": "1.2.4-1"
+  },
+  {
+    "name": "libgupnp-av-1.0-2",
+    "version": "0.12.11-2"
+  },
+  {
+    "name": "libgupnp-dlna-2.0-3",
+    "version": "0.10.5-4"
+  },
+  {
+    "name": "libgusb2",
+    "version": "0.3.5-1"
+  },
+  {
+    "name": "libgweather-3-16",
+    "version": "3.36.1-2"
+  },
+  {
+    "name": "libgweather-common",
+    "version": "3.36.1-2"
+  },
+  {
+    "name": "libgxps2",
+    "version": "0.3.2-1"
+  },
+  {
+    "name": "libhandy-1-0",
+    "version": "1.2.0-1"
+  },
+  {
+    "name": "libhcrypto4-heimdal",
+    "version": "7.7.0+dfsg-2"
+  },
+  {
+    "name": "libheimbase1-heimdal",
+    "version": "7.7.0+dfsg-2"
+  },
+  {
+    "name": "libheimntlm0-heimdal",
+    "version": "7.7.0+dfsg-2"
+  },
+  {
+    "name": "libhogweed6",
+    "version": "3.7-2.1ubuntu1"
+  },
+  {
+    "name": "libhpmud0",
+    "version": "3.21.2+dfsg1-2"
+  },
+  {
+    "name": "libhtml-parser-perl",
+    "version": "3.75-1build1"
+  },
+  {
+    "name": "libhttp-message-perl",
+    "version": "6.28-1"
+  },
+  {
+    "name": "libhx509-5-heimdal",
+    "version": "7.7.0+dfsg-2"
+  },
+  {
+    "name": "libibus-1.0-5",
+    "version": "1.5.24-1"
+  },
+  {
+    "name": "libical3",
+    "version": "3.0.9-2"
+  },
+  {
+    "name": "libice6",
+    "version": "2:1.0.10-1"
+  },
+  {
+    "name": "libicu67",
+    "version": "67.1-6ubuntu2"
+  },
+  {
+    "name": "libidn2-0",
+    "version": "2.3.0-5"
+  },
+  {
+    "name": "libiec61883-0",
+    "version": "1.2.0-4build1"
+  },
+  {
+    "name": "libieee1284-3",
+    "version": "0.2.11-14"
+  },
+  {
+    "name": "libijs-0.35",
+    "version": "0.35-15"
+  },
+  {
+    "name": "libimagequant0",
+    "version": "2.12.2-1.1"
+  },
+  {
+    "name": "libinih1",
+    "version": "50-1ubuntu4"
+  },
+  {
+    "name": "libinput-bin",
+    "version": "1.16.4-3ubuntu2"
+  },
+  {
+    "name": "libinput10",
+    "version": "1.16.4-3ubuntu2"
+  },
+  {
+    "name": "libipt2",
+    "version": "2.0.3-1"
+  },
+  {
+    "name": "libisc-export1105",
+    "version": "1:9.11.19+dfsg-2ubuntu2"
+  },
+  {
+    "name": "libisl23",
+    "version": "0.23-1build1"
+  },
+  {
+    "name": "libiw30",
+    "version": "30~pre9-13.1ubuntu2"
+  },
+  {
+    "name": "libjack-jackd2-0",
+    "version": "1.9.17~dfsg-1"
+  },
+  {
+    "name": "libjavascriptcoregtk-4.0-18",
+    "version": "2.32.0-1ubuntu3"
+  },
+  {
+    "name": "libjbig2dec0",
+    "version": "0.19-2"
+  },
+  {
+    "name": "libjcat1",
+    "version": "0.1.3-2"
+  },
+  {
+    "name": "libk5crypto3",
+    "version": "1.18.3-4"
+  },
+  {
+    "name": "libklibc",
+    "version": "2.0.8-5ubuntu1"
+  },
+  {
+    "name": "libkmod2",
+    "version": "28-1ubuntu2"
+  },
+  {
+    "name": "libkrb5-26-heimdal",
+    "version": "7.7.0+dfsg-2"
+  },
+  {
+    "name": "libkrb5-3",
+    "version": "1.18.3-4"
+  },
+  {
+    "name": "libkrb5support0",
+    "version": "1.18.3-4"
+  },
+  {
+    "name": "libksba8",
+    "version": "1.5.0-3"
+  },
+  {
+    "name": "libldap-2.4-2",
+    "version": "2.4.57+dfsg-2ubuntu1"
+  },
+  {
+    "name": "libldap-common",
+    "version": "2.4.57+dfsg-2ubuntu1"
+  },
+  {
+    "name": "libldb2",
+    "version": "2:2.2.0-3ubuntu2"
+  },
+  {
+    "name": "libllvm11",
+    "version": "1:11.0.1-2ubuntu4"
+  },
+  {
+    "name": "liblouis-data",
+    "version": "3.16.0-1"
+  },
+  {
+    "name": "liblouis20",
+    "version": "3.16.0-1"
+  },
+  {
+    "name": "liblouisutdml-bin",
+    "version": "2.9.0-1"
+  },
+  {
+    "name": "liblouisutdml-data",
+    "version": "2.9.0-1"
+  },
+  {
+    "name": "liblouisutdml9",
+    "version": "2.9.0-1"
+  },
+  {
+    "name": "liblz4-1",
+    "version": "1.9.3-1build1"
+  },
+  {
+    "name": "liblzma5",
+    "version": "5.2.5-1.0build2"
+  },
+  {
+    "name": "libmbim-glib4",
+    "version": "1.24.6-0.1"
+  },
+  {
+    "name": "libmbim-proxy",
+    "version": "1.24.6-0.1"
+  },
+  {
+    "name": "libmediaart-2.0-0",
+    "version": "1.9.4-3"
+  },
+  {
+    "name": "libmm-glib0",
+    "version": "1.14.10-0.1"
+  },
+  {
+    "name": "libmount1",
+    "version": "2.36.1-7ubuntu2"
+  },
+  {
+    "name": "libmozjs-78-0",
+    "version": "78.4.0-2"
+  },
+  {
+    "name": "libmp3lame0",
+    "version": "3.100-3"
+  },
+  {
+    "name": "libmpdec3",
+    "version": "2.5.1-2"
+  },
+  {
+    "name": "libmpg123-0",
+    "version": "1.26.4-1"
+  },
+  {
+    "name": "libmtdev1",
+    "version": "1.1.6-1build2"
+  },
+  {
+    "name": "libmutter-7-0",
+    "version": "3.38.4-1ubuntu2"
+  },
+  {
+    "name": "libnautilus-extension1a",
+    "version": "1:3.38.2-1ubuntu1"
+  },
+  {
+    "name": "libndp0",
+    "version": "1.7-0ubuntu1"
+  },
+  {
+    "name": "libnetplan0",
+    "version": "0.102-0ubuntu2"
+  },
+  {
+    "name": "libnettle8",
+    "version": "3.7-2.1ubuntu1"
+  },
+  {
+    "name": "libnewt0.52",
+    "version": "0.52.21-4ubuntu6"
+  },
+  {
+    "name": "libnm0",
+    "version": "1.30.0-1ubuntu3"
+  },
+  {
+    "name": "libnma-common",
+    "version": "1.8.30-1"
+  },
+  {
+    "name": "libnma0",
+    "version": "1.8.30-1"
+  },
+  {
+    "name": "libnotify-bin",
+    "version": "0.7.9-3ubuntu2"
+  },
+  {
+    "name": "libnotify4",
+    "version": "0.7.9-3ubuntu2"
+  },
+  {
+    "name": "libnsl2",
+    "version": "1.3.0-0ubuntu3"
+  },
+  {
+    "name": "libnspr4",
+    "version": "2:4.29-1"
+  },
+  {
+    "name": "libnss-mdns",
+    "version": "0.14.1-2"
+  },
+  {
+    "name": "libnss-systemd",
+    "version": "247.3-3ubuntu3"
+  },
+  {
+    "name": "libnss3",
+    "version": "2:3.61-1ubuntu2"
+  },
+  {
+    "name": "libntfs-3g883",
+    "version": "1:2017.3.23AR.3-3ubuntu4"
+  },
+  {
+    "name": "libogg0",
+    "version": "1.3.4-0.1"
+  },
+  {
+    "name": "libopenscap8",
+    "version": "1.2.17-0.1ubuntu4"
+  },
+  {
+    "name": "libp11-kit0",
+    "version": "0.23.22-1"
+  },
+  {
+    "name": "libpackagekit-glib2-18",
+    "version": "1.2.2-2ubuntu1"
+  },
+  {
+    "name": "libpam-fprintd",
+    "version": "1.90.9-1"
+  },
+  {
+    "name": "libpam-gnome-keyring",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "libpam-modules",
+    "version": "1.3.1-5ubuntu6"
+  },
+  {
+    "name": "libpam-modules-bin",
+    "version": "1.3.1-5ubuntu6"
+  },
+  {
+    "name": "libpam-runtime",
+    "version": "1.3.1-5ubuntu6"
+  },
+  {
+    "name": "libpam-sss",
+    "version": "2.4.0-1ubuntu6"
+  },
+  {
+    "name": "libpam-systemd",
+    "version": "247.3-3ubuntu3"
+  },
+  {
+    "name": "libpam0g",
+    "version": "1.3.1-5ubuntu6"
+  },
+  {
+    "name": "libpango-1.0-0",
+    "version": "1.48.2-1build2"
+  },
+  {
+    "name": "libpangocairo-1.0-0",
+    "version": "1.48.2-1build2"
+  },
+  {
+    "name": "libpangoft2-1.0-0",
+    "version": "1.48.2-1build2"
+  },
+  {
+    "name": "libpangomm-1.4-1v5",
+    "version": "2.42.1-1"
+  },
+  {
+    "name": "libpangoxft-1.0-0",
+    "version": "1.48.2-1build2"
+  },
+  {
+    "name": "libpaper-utils",
+    "version": "1.1.28"
+  },
+  {
+    "name": "libpaper1",
+    "version": "1.1.28"
+  },
+  {
+    "name": "libpcap0.8",
+    "version": "1.10.0-2"
+  },
+  {
+    "name": "libpcaudio0",
+    "version": "1.1-6"
+  },
+  {
+    "name": "libpciaccess0",
+    "version": "0.16-1build2"
+  },
+  {
+    "name": "libpcre2-32-0",
+    "version": "10.36-2ubuntu5"
+  },
+  {
+    "name": "libpcre2-8-0",
+    "version": "10.36-2ubuntu5"
+  },
+  {
+    "name": "libpcsclite1",
+    "version": "1.9.1-1"
+  },
+  {
+    "name": "libpeas-1.0-0",
+    "version": "1.30.0-1"
+  },
+  {
+    "name": "libpeas-common",
+    "version": "1.30.0-1"
+  },
+  {
+    "name": "libperl5.32",
+    "version": "5.32.1-3ubuntu2"
+  },
+  {
+    "name": "libphonenumber8",
+    "version": "8.12.16-4build1"
+  },
+  {
+    "name": "libpipeline1",
+    "version": "1.5.3-1"
+  },
+  {
+    "name": "libpipewire-0.3-0",
+    "version": "0.3.24-3"
+  },
+  {
+    "name": "libpipewire-0.3-modules",
+    "version": "0.3.24-3"
+  },
+  {
+    "name": "libplist3",
+    "version": "2.2.0-6"
+  },
+  {
+    "name": "libplymouth5",
+    "version": "0.9.5-0ubuntu3"
+  },
+  {
+    "name": "libpng16-16",
+    "version": "1.6.37-3build3"
+  },
+  {
+    "name": "libpolkit-agent-1-0",
+    "version": "0.105-30"
+  },
+  {
+    "name": "libpolkit-gobject-1-0",
+    "version": "0.105-30"
+  },
+  {
+    "name": "libpoppler-cpp0v5",
+    "version": "21.02.0-1"
+  },
+  {
+    "name": "libpoppler-glib8",
+    "version": "21.02.0-1"
+  },
+  {
+    "name": "libpoppler107",
+    "version": "21.02.0-1"
+  },
+  {
+    "name": "libprocps8",
+    "version": "2:3.3.16-5ubuntu3"
+  },
+  {
+    "name": "libprotobuf23",
+    "version": "3.12.4-1ubuntu2"
+  },
+  {
+    "name": "libpulse-mainloop-glib0",
+    "version": "1:14.2-1ubuntu1"
+  },
+  {
+    "name": "libpulse0",
+    "version": "1:14.2-1ubuntu1"
+  },
+  {
+    "name": "libpulsedsp",
+    "version": "1:14.2-1ubuntu1"
+  },
+  {
+    "name": "libpython3-stdlib",
+    "version": "3.9.4-1"
+  },
+  {
+    "name": "libpython3.9",
+    "version": "3.9.4-1"
+  },
+  {
+    "name": "libpython3.9-minimal",
+    "version": "3.9.4-1"
+  },
+  {
+    "name": "libpython3.9-stdlib",
+    "version": "3.9.4-1"
+  },
+  {
+    "name": "libqmi-glib5",
+    "version": "1.26.10-0.1"
+  },
+  {
+    "name": "libqmi-proxy",
+    "version": "1.26.10-0.1"
+  },
+  {
+    "name": "libqpdf28",
+    "version": "10.3.1-1"
+  },
+  {
+    "name": "libraw1394-11",
+    "version": "2.1.2-2"
+  },
+  {
+    "name": "libreadline8",
+    "version": "8.1-1"
+  },
+  {
+    "name": "librest-0.7-0",
+    "version": "0.8.1-1.1"
+  },
+  {
+    "name": "libroken18-heimdal",
+    "version": "7.7.0+dfsg-2"
+  },
+  {
+    "name": "librsvg2-2",
+    "version": "2.50.3+dfsg-1"
+  },
+  {
+    "name": "librsvg2-common",
+    "version": "2.50.3+dfsg-1"
+  },
+  {
+    "name": "librtmp1",
+    "version": "2.4+20151223.gitfa8646d.1-2build2"
+  },
+  {
+    "name": "librygel-core-2.6-2",
+    "version": "0.40.0-1ubuntu1"
+  },
+  {
+    "name": "librygel-db-2.6-2",
+    "version": "0.40.0-1ubuntu1"
+  },
+  {
+    "name": "librygel-renderer-2.6-2",
+    "version": "0.40.0-1ubuntu1"
+  },
+  {
+    "name": "librygel-server-2.6-2",
+    "version": "0.40.0-1ubuntu1"
+  },
+  {
+    "name": "libsane-common",
+    "version": "1.0.32-0ubuntu2"
+  },
+  {
+    "name": "libsane-hpaio",
+    "version": "3.21.2+dfsg1-2"
+  },
+  {
+    "name": "libsane1",
+    "version": "1.0.32-0ubuntu2"
+  },
+  {
+    "name": "libsasl2-2",
+    "version": "2.1.27+dfsg-2ubuntu1"
+  },
+  {
+    "name": "libsasl2-modules",
+    "version": "2.1.27+dfsg-2ubuntu1"
+  },
+  {
+    "name": "libsasl2-modules-db",
+    "version": "2.1.27+dfsg-2ubuntu1"
+  },
+  {
+    "name": "libsasl2-modules-gssapi-mit",
+    "version": "2.1.27+dfsg-2ubuntu1"
+  },
+  {
+    "name": "libsbc1",
+    "version": "1.5-3"
+  },
+  {
+    "name": "libselinux1",
+    "version": "3.1-3build1"
+  },
+  {
+    "name": "libsemanage-common",
+    "version": "3.1-1ubuntu1"
+  },
+  {
+    "name": "libsemanage1",
+    "version": "3.1-1ubuntu1"
+  },
+  {
+    "name": "libsepol1",
+    "version": "3.1-1ubuntu1"
+  },
+  {
+    "name": "libshout3",
+    "version": "2.4.5-1"
+  },
+  {
+    "name": "libsigc++-2.0-0v5",
+    "version": "2.10.4-2ubuntu1"
+  },
+  {
+    "name": "libsm6",
+    "version": "2:1.2.3-1"
+  },
+  {
+    "name": "libsmartcols1",
+    "version": "2.36.1-7ubuntu2"
+  },
+  {
+    "name": "libsmbclient",
+    "version": "2:4.13.3+dfsg-1ubuntu2"
+  },
+  {
+    "name": "libsmbios-c2",
+    "version": "2.4.3-1"
+  },
+  {
+    "name": "libsndfile1",
+    "version": "1.0.31-1ubuntu1"
+  },
+  {
+    "name": "libsnmp-base",
+    "version": "5.9+dfsg-3ubuntu1"
+  },
+  {
+    "name": "libsnmp40",
+    "version": "5.9+dfsg-3ubuntu1"
+  },
+  {
+    "name": "libsodium23",
+    "version": "1.0.18-1"
+  },
+  {
+    "name": "libsoup-gnome2.4-1",
+    "version": "2.72.0-3"
+  },
+  {
+    "name": "libsoup2.4-1",
+    "version": "2.72.0-3"
+  },
+  {
+    "name": "libsource-highlight-common",
+    "version": "3.1.9-3build1"
+  },
+  {
+    "name": "libsource-highlight4v5",
+    "version": "3.1.9-3build1"
+  },
+  {
+    "name": "libsoxr0",
+    "version": "0.1.3-4"
+  },
+  {
+    "name": "libspa-0.2-modules",
+    "version": "0.3.24-3"
+  },
+  {
+    "name": "libspectre1",
+    "version": "0.2.9-1"
+  },
+  {
+    "name": "libspeechd2",
+    "version": "0.10.2-2"
+  },
+  {
+    "name": "libsqlite3-0",
+    "version": "3.34.1-3"
+  },
+  {
+    "name": "libss2",
+    "version": "1.45.7-1ubuntu2"
+  },
+  {
+    "name": "libssh-4",
+    "version": "0.9.5-1"
+  },
+  {
+    "name": "libssl1.1",
+    "version": "1.1.1j-1ubuntu3"
+  },
+  {
+    "name": "libstartup-notification0",
+    "version": "0.12-6"
+  },
+  {
+    "name": "libstdc++6",
+    "version": "11-20210417-1ubuntu1"
+  },
+  {
+    "name": "libsysmetrics1",
+    "version": "1.6.4"
+  },
+  {
+    "name": "libsystemd0",
+    "version": "247.3-3ubuntu3"
+  },
+  {
+    "name": "libtag1v5",
+    "version": "1.11.1+dfsg.1-3ubuntu1"
+  },
+  {
+    "name": "libtag1v5-vanilla",
+    "version": "1.11.1+dfsg.1-3ubuntu1"
+  },
+  {
+    "name": "libtalloc2",
+    "version": "2.3.1-2ubuntu1"
+  },
+  {
+    "name": "libteamdctl0",
+    "version": "1.31-1"
+  },
+  {
+    "name": "libtepl-5-0",
+    "version": "5.0.1-1"
+  },
+  {
+    "name": "libtevent0",
+    "version": "0.10.2-1"
+  },
+  {
+    "name": "libthai-data",
+    "version": "0.1.28-4"
+  },
+  {
+    "name": "libthai0",
+    "version": "0.1.28-4"
+  },
+  {
+    "name": "libtiff5",
+    "version": "4.2.0-1build1"
+  },
+  {
+    "name": "libtirpc-common",
+    "version": "1.3.1-1build1"
+  },
+  {
+    "name": "libtirpc3",
+    "version": "1.3.1-1build1"
+  },
+  {
+    "name": "libtotem-plparser-common",
+    "version": "3.26.5-5ubuntu1"
+  },
+  {
+    "name": "libtotem-plparser18",
+    "version": "3.26.5-5ubuntu1"
+  },
+  {
+    "name": "libtracker-control-2.0-0",
+    "version": "2.3.6-2"
+  },
+  {
+    "name": "libtracker-miner-2.0-0",
+    "version": "2.3.6-2"
+  },
+  {
+    "name": "libtracker-sparql-2.0-0",
+    "version": "2.3.6-2"
+  },
+  {
+    "name": "libtwolame0",
+    "version": "0.4.0-2"
+  },
+  {
+    "name": "libu2f-udev",
+    "version": "1.1.10-3"
+  },
+  {
+    "name": "libuchardet0",
+    "version": "0.0.7-1"
+  },
+  {
+    "name": "libudev1",
+    "version": "247.3-3ubuntu3"
+  },
+  {
+    "name": "libudisks2-0",
+    "version": "2.9.2-1"
+  },
+  {
+    "name": "libunistring2",
+    "version": "0.9.10-4"
+  },
+  {
+    "name": "libupower-glib3",
+    "version": "0.99.11-2"
+  },
+  {
+    "name": "liburi-perl",
+    "version": "5.07-1"
+  },
+  {
+    "name": "libusbmuxd6",
+    "version": "2.0.2-3"
+  },
+  {
+    "name": "libuuid1",
+    "version": "2.36.1-7ubuntu2"
+  },
+  {
+    "name": "libuv1",
+    "version": "1.40.0-1"
+  },
+  {
+    "name": "libv4l-0",
+    "version": "1.20.0-3"
+  },
+  {
+    "name": "libv4lconvert0",
+    "version": "1.20.0-3"
+  },
+  {
+    "name": "libvisual-0.4-0",
+    "version": "0.4.0-17"
+  },
+  {
+    "name": "libvolume-key1",
+    "version": "0.3.12-3.1build1"
+  },
+  {
+    "name": "libvpx6",
+    "version": "1.9.0-1"
+  },
+  {
+    "name": "libvte-2.91-0",
+    "version": "0.62.3-1ubuntu1"
+  },
+  {
+    "name": "libvte-2.91-common",
+    "version": "0.62.3-1ubuntu1"
+  },
+  {
+    "name": "libvulkan1",
+    "version": "1.2.162.0-1"
+  },
+  {
+    "name": "libwacom-bin",
+    "version": "1.8-2ubuntu1"
+  },
+  {
+    "name": "libwacom-common",
+    "version": "1.8-2ubuntu1"
+  },
+  {
+    "name": "libwacom2",
+    "version": "1.8-2ubuntu1"
+  },
+  {
+    "name": "libwavpack1",
+    "version": "5.4.0-1"
+  },
+  {
+    "name": "libwayland-client0",
+    "version": "1.18.0-2~exp1.1"
+  },
+  {
+    "name": "libwayland-cursor0",
+    "version": "1.18.0-2~exp1.1"
+  },
+  {
+    "name": "libwayland-egl1",
+    "version": "1.18.0-2~exp1.1"
+  },
+  {
+    "name": "libwayland-server0",
+    "version": "1.18.0-2~exp1.1"
+  },
+  {
+    "name": "libwbclient0",
+    "version": "2:4.13.3+dfsg-1ubuntu2"
+  },
+  {
+    "name": "libwebkit2gtk-4.0-37",
+    "version": "2.32.0-1ubuntu3"
+  },
+  {
+    "name": "libwebp6",
+    "version": "0.6.1-2"
+  },
+  {
+    "name": "libwebpdemux2",
+    "version": "0.6.1-2"
+  },
+  {
+    "name": "libwebpmux3",
+    "version": "0.6.1-2"
+  },
+  {
+    "name": "libwebrtc-audio-processing1",
+    "version": "0.3.1-0ubuntu3"
+  },
+  {
+    "name": "libwhoopsie-preferences0",
+    "version": "22"
+  },
+  {
+    "name": "libwhoopsie0",
+    "version": "0.2.76"
+  },
+  {
+    "name": "libwind0-heimdal",
+    "version": "7.7.0+dfsg-2"
+  },
+  {
+    "name": "libwmf0.2-7",
+    "version": "0.2.8.4-17ubuntu1"
+  },
+  {
+    "name": "libwmf0.2-7-gtk",
+    "version": "0.2.8.4-17ubuntu1"
+  },
+  {
+    "name": "libwnck-3-0",
+    "version": "3.36.0-1"
+  },
+  {
+    "name": "libwnck-3-common",
+    "version": "3.36.0-1"
+  },
+  {
+    "name": "libwoff1",
+    "version": "1.0.2-1build2"
+  },
+  {
+    "name": "libwww-perl",
+    "version": "6.52-1"
+  },
+  {
+    "name": "libx11-6",
+    "version": "2:1.7.0-2build2"
+  },
+  {
+    "name": "libx11-data",
+    "version": "2:1.7.0-2build2"
+  },
+  {
+    "name": "libx11-xcb1",
+    "version": "2:1.7.0-2build2"
+  },
+  {
+    "name": "libxatracker2",
+    "version": "21.0.1-2"
+  },
+  {
+    "name": "libxcb-icccm4",
+    "version": "0.4.1-1.1"
+  },
+  {
+    "name": "libxcb-image0",
+    "version": "0.4.0-1build1"
+  },
+  {
+    "name": "libxcb-keysyms1",
+    "version": "0.4.0-1build1"
+  },
+  {
+    "name": "libxcb-render-util0",
+    "version": "0.3.9-1build1"
+  },
+  {
+    "name": "libxcb-util1",
+    "version": "0.4.0-1"
+  },
+  {
+    "name": "libxdmcp6",
+    "version": "1:1.1.3-0ubuntu3"
+  },
+  {
+    "name": "libxfont2",
+    "version": "1:2.0.4-1build2"
+  },
+  {
+    "name": "libxft2",
+    "version": "2.3.3-0ubuntu3"
+  },
+  {
+    "name": "libxkbcommon-x11-0",
+    "version": "1.0.3-2"
+  },
+  {
+    "name": "libxkbcommon0",
+    "version": "1.0.3-2"
+  },
+  {
+    "name": "libxkbregistry0",
+    "version": "1.0.3-2"
+  },
+  {
+    "name": "libxklavier16",
+    "version": "5.4-4"
+  },
+  {
+    "name": "libxml2",
+    "version": "2.9.10+dfsg-6.3build2"
+  },
+  {
+    "name": "libxres1",
+    "version": "2:1.2.0-4"
+  },
+  {
+    "name": "libxshmfence1",
+    "version": "1.3-1build2"
+  },
+  {
+    "name": "libxvmc1",
+    "version": "2:1.0.12-2"
+  },
+  {
+    "name": "libxxf86dga1",
+    "version": "2:1.1.5-0ubuntu1"
+  },
+  {
+    "name": "libxxhash0",
+    "version": "0.8.0-2"
+  },
+  {
+    "name": "libyelp0",
+    "version": "40.stable-1"
+  },
+  {
+    "name": "libzstd1",
+    "version": "1.4.8+dfsg-2build2"
+  },
+  {
+    "name": "linux-base",
+    "version": "4.5ubuntu5"
+  },
+  {
+    "name": "linux-firmware",
+    "version": "1.197"
+  },
+  {
+    "name": "linux-generic-hwe-20.04",
+    "version": "5.11.0.16.17"
+  },
+  {
+    "name": "linux-headers-5.11.0-16",
+    "version": "5.11.0-16.17"
+  },
+  {
+    "name": "linux-headers-5.11.0-16-generic",
+    "version": "5.11.0-16.17"
+  },
+  {
+    "name": "linux-headers-generic-hwe-20.04",
+    "version": "5.11.0.16.17"
+  },
+  {
+    "name": "linux-image-5.11.0-16-generic",
+    "version": "5.11.0-16.17"
+  },
+  {
+    "name": "linux-image-generic-hwe-20.04",
+    "version": "5.11.0.16.17"
+  },
+  {
+    "name": "linux-modules-5.11.0-16-generic",
+    "version": "5.11.0-16.17"
+  },
+  {
+    "name": "linux-modules-extra-5.11.0-16-generic",
+    "version": "5.11.0-16.17"
+  },
+  {
+    "name": "locales",
+    "version": "2.33-0ubuntu5"
+  },
+  {
+    "name": "login",
+    "version": "1:4.8.1-1ubuntu8"
+  },
+  {
+    "name": "logrotate",
+    "version": "3.18.0-1ubuntu1"
+  },
+  {
+    "name": "logsave",
+    "version": "1.45.7-1ubuntu2"
+  },
+  {
+    "name": "lsb-base",
+    "version": "11.1.0ubuntu2"
+  },
+  {
+    "name": "lsb-release",
+    "version": "11.1.0ubuntu2"
+  },
+  {
+    "name": "lshw",
+    "version": "02.18.85-0.6ubuntu1"
+  },
+  {
+    "name": "ltrace",
+    "version": "0.7.3-6.1ubuntu2"
+  },
+  {
+    "name": "lz4",
+    "version": "1.9.3-1build1"
+  },
+  {
+    "name": "mailcap",
+    "version": "3.68ubuntu1"
+  },
+  {
+    "name": "manpages",
+    "version": "5.10-1"
+  },
+  {
+    "name": "memtest86+",
+    "version": "5.01-3.1ubuntu4"
+  },
+  {
+    "name": "mesa-vulkan-drivers",
+    "version": "21.0.1-2"
+  },
+  {
+    "name": "mobile-broadband-provider-info",
+    "version": "20201225-1"
+  },
+  {
+    "name": "modemmanager",
+    "version": "1.14.10-0.1"
+  },
+  {
+    "name": "mokutil",
+    "version": "0.3.0+1538710437.fb6250f-1"
+  },
+  {
+    "name": "mount",
+    "version": "2.36.1-7ubuntu2"
+  },
+  {
+    "name": "mousetweaks",
+    "version": "3.32.0-3"
+  },
+  {
+    "name": "mscompress",
+    "version": "0.4-8"
+  },
+  {
+    "name": "mtr-tiny",
+    "version": "0.94-1"
+  },
+  {
+    "name": "mutter-common",
+    "version": "3.38.4-1ubuntu2"
+  },
+  {
+    "name": "nano",
+    "version": "5.4-2build1"
+  },
+  {
+    "name": "nautilus",
+    "version": "1:3.38.2-1ubuntu1"
+  },
+  {
+    "name": "nautilus-data",
+    "version": "1:3.38.2-1ubuntu1"
+  },
+  {
+    "name": "nautilus-extension-gnome-terminal",
+    "version": "3.38.1-1ubuntu1"
+  },
+  {
+    "name": "nautilus-sendto",
+    "version": "3.8.6-3.1"
+  },
+  {
+    "name": "nautilus-share",
+    "version": "0.7.3-2ubuntu3"
+  },
+  {
+    "name": "netbase",
+    "version": "6.2"
+  },
+  {
+    "name": "netplan.io",
+    "version": "0.102-0ubuntu2"
+  },
+  {
+    "name": "network-manager",
+    "version": "1.30.0-1ubuntu3"
+  },
+  {
+    "name": "network-manager-config-connectivity-ubuntu",
+    "version": "1.30.0-1ubuntu3"
+  },
+  {
+    "name": "network-manager-gnome",
+    "version": "1.18.0-1ubuntu2"
+  },
+  {
+    "name": "network-manager-openvpn",
+    "version": "1.8.12-2ubuntu1"
+  },
+  {
+    "name": "network-manager-openvpn-gnome",
+    "version": "1.8.12-2ubuntu1"
+  },
+  {
+    "name": "network-manager-pptp",
+    "version": "1.2.8-3"
+  },
+  {
+    "name": "network-manager-pptp-gnome",
+    "version": "1.2.8-3"
+  },
+  {
+    "name": "networkd-dispatcher",
+    "version": "2.1-1"
+  },
+  {
+    "name": "ntfs-3g",
+    "version": "1:2017.3.23AR.3-3ubuntu4"
+  },
+  {
+    "name": "openprinting-ppds",
+    "version": "20200820-1"
+  },
+  {
+    "name": "openssh-client",
+    "version": "1:8.4p1-5ubuntu1"
+  },
+  {
+    "name": "openssl",
+    "version": "1.1.1j-1ubuntu3"
+  },
+  {
+    "name": "openvpn",
+    "version": "2.5.1-1ubuntu1"
+  },
+  {
+    "name": "orca",
+    "version": "3.38.0-1ubuntu1"
+  },
+  {
+    "name": "os-prober",
+    "version": "1.77ubuntu3"
+  },
+  {
+    "name": "p11-kit",
+    "version": "0.23.22-1"
+  },
+  {
+    "name": "p11-kit-modules",
+    "version": "0.23.22-1"
+  },
+  {
+    "name": "packagekit",
+    "version": "1.2.2-2ubuntu1"
+  },
+  {
+    "name": "packagekit-tools",
+    "version": "1.2.2-2ubuntu1"
+  },
+  {
+    "name": "passwd",
+    "version": "1:4.8.1-1ubuntu8"
+  },
+  {
+    "name": "pci.ids",
+    "version": "0.0~2021.02.08-1"
+  },
+  {
+    "name": "pcmciautils",
+    "version": "018-12build1"
+  },
+  {
+    "name": "perl",
+    "version": "5.32.1-3ubuntu2"
+  },
+  {
+    "name": "perl-base",
+    "version": "5.32.1-3ubuntu2"
+  },
+  {
+    "name": "perl-modules-5.32",
+    "version": "5.32.1-3ubuntu2"
+  },
+  {
+    "name": "pinentry-curses",
+    "version": "1.1.0-4build1"
+  },
+  {
+    "name": "pinentry-gnome3",
+    "version": "1.1.0-4build1"
+  },
+  {
+    "name": "pipewire",
+    "version": "0.3.24-3"
+  },
+  {
+    "name": "pipewire-bin",
+    "version": "0.3.24-3"
+  },
+  {
+    "name": "plymouth",
+    "version": "0.9.5-0ubuntu3"
+  },
+  {
+    "name": "plymouth-label",
+    "version": "0.9.5-0ubuntu3"
+  },
+  {
+    "name": "plymouth-theme-spinner",
+    "version": "0.9.5-0ubuntu3"
+  },
+  {
+    "name": "plymouth-theme-ubuntu-text",
+    "version": "0.9.5-0ubuntu3"
+  },
+  {
+    "name": "policykit-1",
+    "version": "0.105-30"
+  },
+  {
+    "name": "poppler-data",
+    "version": "0.4.10-1"
+  },
+  {
+    "name": "poppler-utils",
+    "version": "21.02.0-1"
+  },
+  {
+    "name": "power-profiles-daemon",
+    "version": "0.1-5"
+  },
+  {
+    "name": "ppp",
+    "version": "2.4.7-2+4.1ubuntu8"
+  },
+  {
+    "name": "pptp-linux",
+    "version": "1.10.0-1build1"
+  },
+  {
+    "name": "printer-driver-brlaser",
+    "version": "6-1build1"
+  },
+  {
+    "name": "printer-driver-c2esp",
+    "version": "27-8"
+  },
+  {
+    "name": "printer-driver-foo2zjs",
+    "version": "20200505dfsg0-1"
+  },
+  {
+    "name": "printer-driver-foo2zjs-common",
+    "version": "20200505dfsg0-1"
+  },
+  {
+    "name": "printer-driver-hpcups",
+    "version": "3.21.2+dfsg1-2"
+  },
+  {
+    "name": "printer-driver-m2300w",
+    "version": "0.51-14"
+  },
+  {
+    "name": "printer-driver-min12xxw",
+    "version": "0.0.9-11"
+  },
+  {
+    "name": "printer-driver-pnm2ppa",
+    "version": "1.13+nondbs-0ubuntu7"
+  },
+  {
+    "name": "printer-driver-postscript-hp",
+    "version": "3.21.2+dfsg1-2"
+  },
+  {
+    "name": "printer-driver-ptouch",
+    "version": "1.5.1-2"
+  },
+  {
+    "name": "printer-driver-pxljr",
+    "version": "1.4+repack0-5"
+  },
+  {
+    "name": "printer-driver-sag-gdi",
+    "version": "0.1-7"
+  },
+  {
+    "name": "printer-driver-splix",
+    "version": "2.0.0+svn315-7fakesync1build1"
+  },
+  {
+    "name": "procps",
+    "version": "2:3.3.16-5ubuntu3"
+  },
+  {
+    "name": "pulseaudio",
+    "version": "1:14.2-1ubuntu1"
+  },
+  {
+    "name": "pulseaudio-module-bluetooth",
+    "version": "1:14.2-1ubuntu1"
+  },
+  {
+    "name": "pulseaudio-utils",
+    "version": "1:14.2-1ubuntu1"
+  },
+  {
+    "name": "python-apt",
+    "version": "2.1.7+ubuntu2"
+  },
+  {
+    "name": "python-apt-common",
+    "version": "2.1.7ubuntu2"
+  },
+  {
+    "name": "python-debian",
+    "version": "0.1.39"
+  },
+  {
+    "name": "python3",
+    "version": "3.9.4-1"
+  },
+  {
+    "name": "python3-apport",
+    "version": "2.20.11-0ubuntu65"
+  },
+  {
+    "name": "python3-apt",
+    "version": "2.1.7ubuntu2"
+  },
+  {
+    "name": "python3-brlapi",
+    "version": "6.3+dfsg-1ubuntu1"
+  },
+  {
+    "name": "python3-cffi-backend",
+    "version": "1.14.5-1"
+  },
+  {
+    "name": "python3-commandnotfound",
+    "version": "20.10.1"
+  },
+  {
+    "name": "python3-cupshelpers",
+    "version": "1.5.15-0ubuntu1"
+  },
+  {
+    "name": "python3-dateutil",
+    "version": "2.8.1-5"
+  },
+  {
+    "name": "python3-debconf",
+    "version": "1.5.74"
+  },
+  {
+    "name": "python3-debian",
+    "version": "0.1.39"
+  },
+  {
+    "name": "python3-distupgrade",
+    "version": "1:21.04.10"
+  },
+  {
+    "name": "python3-gdbm",
+    "version": "3.9.4-0ubuntu1"
+  },
+  {
+    "name": "python3-gi",
+    "version": "3.38.0-4"
+  },
+  {
+    "name": "python3-gi-cairo",
+    "version": "3.38.0-4"
+  },
+  {
+    "name": "python3-httplib2",
+    "version": "0.18.1-3"
+  },
+  {
+    "name": "python3-ibus-1.0",
+    "version": "1.5.24-1"
+  },
+  {
+    "name": "python3-jeepney",
+    "version": "0.6.0-1"
+  },
+  {
+    "name": "python3-keyring",
+    "version": "22.2.0-1"
+  },
+  {
+    "name": "python3-ldb",
+    "version": "2:2.2.0-3ubuntu2"
+  },
+  {
+    "name": "python3-louis",
+    "version": "3.16.0-1"
+  },
+  {
+    "name": "python3-minimal",
+    "version": "3.9.4-1"
+  },
+  {
+    "name": "python3-pexpect",
+    "version": "4.8.0-1ubuntu1"
+  },
+  {
+    "name": "python3-pil",
+    "version": "8.1.2-1"
+  },
+  {
+    "name": "python3-pkg-resources",
+    "version": "52.0.0-3"
+  },
+  {
+    "name": "python3-problem-report",
+    "version": "2.20.11-0ubuntu65"
+  },
+  {
+    "name": "python3-protobuf",
+    "version": "3.12.4-1ubuntu2"
+  },
+  {
+    "name": "python3-six",
+    "version": "1.15.0-2"
+  },
+  {
+    "name": "python3-software-properties",
+    "version": "0.99.10"
+  },
+  {
+    "name": "python3-speechd",
+    "version": "0.10.2-2"
+  },
+  {
+    "name": "python3-talloc",
+    "version": "2.3.1-2ubuntu1"
+  },
+  {
+    "name": "python3-update-manager",
+    "version": "1:21.04.8"
+  },
+  {
+    "name": "python3-urllib3",
+    "version": "1.26.2-1ubuntu1"
+  },
+  {
+    "name": "python3-yaml",
+    "version": "5.3.1-3ubuntu1"
+  },
+  {
+    "name": "python3.9",
+    "version": "3.9.4-1"
+  },
+  {
+    "name": "python3.9-minimal",
+    "version": "3.9.4-1"
+  },
+  {
+    "name": "readline-common",
+    "version": "8.1-1"
+  },
+  {
+    "name": "rfkill",
+    "version": "2.36.1-7ubuntu2"
+  },
+  {
+    "name": "rsync",
+    "version": "3.2.3-3ubuntu1"
+  },
+  {
+    "name": "rsyslog",
+    "version": "8.2102.0-2ubuntu1"
+  },
+  {
+    "name": "rygel",
+    "version": "0.40.0-1ubuntu1"
+  },
+  {
+    "name": "samba-libs",
+    "version": "2:4.13.3+dfsg-1ubuntu2"
+  },
+  {
+    "name": "sane-airscan",
+    "version": "0.99.25-0ubuntu1"
+  },
+  {
+    "name": "sane-utils",
+    "version": "1.0.32-0ubuntu2"
+  },
+  {
+    "name": "sbsigntool",
+    "version": "0.9.2-2ubuntu4"
+  },
+  {
+    "name": "seahorse",
+    "version": "40.0-1"
+  },
+  {
+    "name": "session-migration",
+    "version": "0.3.5"
+  },
+  {
+    "name": "shared-mime-info",
+    "version": "2.0-1"
+  },
+  {
+    "name": "shim-signed",
+    "version": "1.46+15.4-0ubuntu1"
+  },
+  {
+    "name": "six",
+    "version": "1.15.0"
+  },
+  {
+    "name": "snapd",
+    "version": "2.49.2+21.04ubuntu1"
+  },
+  {
+    "name": "software-properties-common",
+    "version": "0.99.10"
+  },
+  {
+    "name": "software-properties-gtk",
+    "version": "0.99.10"
+  },
+  {
+    "name": "speech-dispatcher",
+    "version": "0.10.2-2"
+  },
+  {
+    "name": "speech-dispatcher-audio-plugins",
+    "version": "0.10.2-2"
+  },
+  {
+    "name": "speech-dispatcher-espeak-ng",
+    "version": "0.10.2-2"
+  },
+  {
+    "name": "spice-vdagent",
+    "version": "0.20.0-2"
+  },
+  {
+    "name": "squashfs-tools",
+    "version": "1:4.4-2"
+  },
+  {
+    "name": "ssl-cert",
+    "version": "1.1.0"
+  },
+  {
+    "name": "strace",
+    "version": "5.11-0ubuntu1"
+  },
+  {
+    "name": "sudo",
+    "version": "1.9.5p2-2ubuntu3"
+  },
+  {
+    "name": "switcheroo-control",
+    "version": "2.4-3"
+  },
+  {
+    "name": "system-config-printer",
+    "version": "1.5.15-0ubuntu1"
+  },
+  {
+    "name": "system-config-printer-common",
+    "version": "1.5.15-0ubuntu1"
+  },
+  {
+    "name": "system-config-printer-udev",
+    "version": "1.5.15-0ubuntu1"
+  },
+  {
+    "name": "systemd",
+    "version": "247.3-3ubuntu3"
+  },
+  {
+    "name": "systemd-sysv",
+    "version": "247.3-3ubuntu3"
+  },
+  {
+    "name": "systemd-timesyncd",
+    "version": "247.3-3ubuntu3"
+  },
+  {
+    "name": "sysvinit-utils",
+    "version": "2.96-6ubuntu1"
+  },
+  {
+    "name": "tcl",
+    "version": "8.6.11"
+  },
+  {
+    "name": "tcpdump",
+    "version": "4.9.3-7"
+  },
+  {
+    "name": "thermald",
+    "version": "2.4.3-1"
+  },
+  {
+    "name": "tracker",
+    "version": "2.3.6-2"
+  },
+  {
+    "name": "tracker-extract",
+    "version": "2.3.5-2ubuntu1"
+  },
+  {
+    "name": "tracker-miner-fs",
+    "version": "2.3.5-2ubuntu1"
+  },
+  {
+    "name": "tzdata",
+    "version": "2021a-1ubuntu1"
+  },
+  {
+    "name": "ubuntu-advantage-tools",
+    "version": "24.4"
+  },
+  {
+    "name": "ubuntu-advantage-tools",
+    "version": "26.2"
+  },
+  {
+    "name": "ubuntu-desktop",
+    "version": "1.469"
+  },
+  {
+    "name": "ubuntu-desktop-minimal",
+    "version": "1.469"
+  },
+  {
+    "name": "ubuntu-docs",
+    "version": "21.04.1"
+  },
+  {
+    "name": "ubuntu-drivers-common",
+    "version": "1:0.8.9.1"
+  },
+  {
+    "name": "ubuntu-minimal",
+    "version": "1.469"
+  },
+  {
+    "name": "ubuntu-release-upgrader-core",
+    "version": "1:21.04.10"
+  },
+  {
+    "name": "ubuntu-release-upgrader-gtk",
+    "version": "1:21.04.10"
+  },
+  {
+    "name": "ubuntu-report",
+    "version": "1.6.4"
+  },
+  {
+    "name": "ubuntu-session",
+    "version": "3.38.0-3ubuntu2"
+  },
+  {
+    "name": "ubuntu-settings",
+    "version": "21.04.3"
+  },
+  {
+    "name": "ubuntu-standard",
+    "version": "1.469"
+  },
+  {
+    "name": "ubuntu-wallpapers",
+    "version": "21.04.1-0ubuntu1"
+  },
+  {
+    "name": "ubuntu-wallpapers-hirsute",
+    "version": "21.04.1-0ubuntu1"
+  },
+  {
+    "name": "udev",
+    "version": "247.3-3ubuntu3"
+  },
+  {
+    "name": "udisks2",
+    "version": "2.9.2-1"
+  },
+  {
+    "name": "ufw",
+    "version": "0.36-7.1"
+  },
+  {
+    "name": "update-manager",
+    "version": "1:21.04.8"
+  },
+  {
+    "name": "update-manager-core",
+    "version": "1:21.04.8"
+  },
+  {
+    "name": "update-notifier",
+    "version": "3.192.40"
+  },
+  {
+    "name": "update-notifier-common",
+    "version": "3.192.40"
+  },
+  {
+    "name": "upower",
+    "version": "0.99.11-2"
+  },
+  {
+    "name": "urllib3",
+    "version": "1.26.2"
+  },
+  {
+    "name": "usb-modeswitch",
+    "version": "2.6.1-1ubuntu3"
+  },
+  {
+    "name": "usb.ids",
+    "version": "2021.01.29-1"
+  },
+  {
+    "name": "usbmuxd",
+    "version": "1.1.1-2"
+  },
+  {
+    "name": "usbutils",
+    "version": "1:013-3"
+  },
+  {
+    "name": "usrmerge",
+    "version": "24ubuntu3"
+  },
+  {
+    "name": "util-linux",
+    "version": "2.36.1-7ubuntu2"
+  },
+  {
+    "name": "uuid-runtime",
+    "version": "2.36.1-7ubuntu2"
+  },
+  {
+    "name": "vim-common",
+    "version": "2:8.2.2434-1ubuntu1"
+  },
+  {
+    "name": "vim-tiny",
+    "version": "2:8.2.2434-1ubuntu1"
+  },
+  {
+    "name": "whiptail",
+    "version": "0.52.21-4ubuntu6"
+  },
+  {
+    "name": "whoopsie",
+    "version": "0.2.76"
+  },
+  {
+    "name": "whoopsie-preferences",
+    "version": "22"
+  },
+  {
+    "name": "wireless-regdb",
+    "version": "2020.11.20-0ubuntu1"
+  },
+  {
+    "name": "wireless-tools",
+    "version": "30~pre9-13.1ubuntu2"
+  },
+  {
+    "name": "wpasupplicant",
+    "version": "2:2.9.0-21"
+  },
+  {
+    "name": "x11-common",
+    "version": "1:7.7+22ubuntu1"
+  },
+  {
+    "name": "x11-session-utils",
+    "version": "7.7+4"
+  },
+  {
+    "name": "x11-utils",
+    "version": "7.7+5"
+  },
+  {
+    "name": "x11-xkb-utils",
+    "version": "7.7+5build2"
+  },
+  {
+    "name": "x11-xserver-utils",
+    "version": "7.7+8"
+  },
+  {
+    "name": "xbrlapi",
+    "version": "6.3+dfsg-1ubuntu1"
+  },
+  {
+    "name": "xdg-dbus-proxy",
+    "version": "0.1.2-2"
+  },
+  {
+    "name": "xdg-desktop-portal",
+    "version": "1.8.1-1"
+  },
+  {
+    "name": "xdg-desktop-portal-gtk",
+    "version": "1.8.0-1"
+  },
+  {
+    "name": "xdg-user-dirs",
+    "version": "0.17-2ubuntu2"
+  },
+  {
+    "name": "xdg-user-dirs-gtk",
+    "version": "0.10-3"
+  },
+  {
+    "name": "xfonts-utils",
+    "version": "1:7.7+6"
+  },
+  {
+    "name": "xinit",
+    "version": "1.4.1-0ubuntu2"
+  },
+  {
+    "name": "xinput",
+    "version": "1.6.3-1"
+  },
+  {
+    "name": "xorg",
+    "version": "1:7.7+22ubuntu1"
+  },
+  {
+    "name": "xserver-common",
+    "version": "2:1.20.11-1ubuntu1"
+  },
+  {
+    "name": "xserver-xephyr",
+    "version": "2:1.20.11-1ubuntu1"
+  },
+  {
+    "name": "xserver-xorg",
+    "version": "1:7.7+22ubuntu1"
+  },
+  {
+    "name": "xserver-xorg-core",
+    "version": "2:1.20.11-1ubuntu1"
+  },
+  {
+    "name": "xserver-xorg-input-all",
+    "version": "1:7.7+22ubuntu1"
+  },
+  {
+    "name": "xserver-xorg-input-libinput",
+    "version": "0.30.0-1build1"
+  },
+  {
+    "name": "xserver-xorg-input-wacom",
+    "version": "1:0.39.0-0ubuntu1"
+  },
+  {
+    "name": "xserver-xorg-legacy",
+    "version": "2:1.20.11-1ubuntu1"
+  },
+  {
+    "name": "xserver-xorg-video-all",
+    "version": "1:7.7+22ubuntu1"
+  },
+  {
+    "name": "xserver-xorg-video-amdgpu",
+    "version": "19.1.0-2"
+  },
+  {
+    "name": "xserver-xorg-video-ati",
+    "version": "1:19.1.0-2"
+  },
+  {
+    "name": "xserver-xorg-video-fbdev",
+    "version": "1:0.5.0-1ubuntu2"
+  },
+  {
+    "name": "xserver-xorg-video-intel",
+    "version": "2:2.99.917+git20200714-1ubuntu1"
+  },
+  {
+    "name": "xserver-xorg-video-nouveau",
+    "version": "1:1.0.17-1"
+  },
+  {
+    "name": "xserver-xorg-video-qxl",
+    "version": "0.1.5+git20200331-1"
+  },
+  {
+    "name": "xserver-xorg-video-radeon",
+    "version": "1:19.1.0-2"
+  },
+  {
+    "name": "xserver-xorg-video-vesa",
+    "version": "1:2.5.0-1build1"
+  },
+  {
+    "name": "xul-ext-ubufox",
+    "version": "3.4-0ubuntu1.17.10.1"
+  },
+  {
+    "name": "xwayland",
+    "version": "2:21.1.1-0ubuntu1"
+  },
+  {
+    "name": "xxd",
+    "version": "2:8.2.2434-1ubuntu1"
+  },
+  {
+    "name": "xz-utils",
+    "version": "5.2.5-1.0build2"
+  },
+  {
+    "name": "yaru-theme-gnome-shell",
+    "version": "21.04.1"
+  },
+  {
+    "name": "yaru-theme-gtk",
+    "version": "21.04.1"
+  },
+  {
+    "name": "yaru-theme-icon",
+    "version": "21.04.1"
+  },
+  {
+    "name": "yaru-theme-sound",
+    "version": "21.04.1"
+  },
+  {
+    "name": "yelp",
+    "version": "40.stable-1"
+  },
+  {
+    "name": "yelp-xsl",
+    "version": "40.0-1"
+  },
+  {
+    "name": "zenity",
+    "version": "3.32.0-6"
+  },
+  {
+    "name": "zenity-common",
+    "version": "3.32.0-6"
+  },
+  {
+    "name": "zip",
+    "version": "3.0-12"
+  },
+  {
+    "name": "zlib1g",
+    "version": "1:1.2.11.dfsg-2ubuntu6"
+  }
+]

--- a/cmd/osquery-perf/ubuntu_2110-vulnerable_software.json
+++ b/cmd/osquery-perf/ubuntu_2110-vulnerable_software.json
@@ -1,0 +1,6022 @@
+[
+  {
+    "name": "defer",
+    "version": "1.0.6"
+  },
+  {
+    "name": "dmz-cursor-theme",
+    "version": "0.4.5ubuntu1"
+  },
+  {
+    "name": "grub-gfxpayload-lists",
+    "version": "0.7"
+  },
+  {
+    "name": "hicolor-icon-theme",
+    "version": "0.17-2"
+  },
+  {
+    "name": "language-selector",
+    "version": "0.1"
+  },
+  {
+    "name": "laptop-detect",
+    "version": "0.16"
+  },
+  {
+    "name": "libnet-smtp-ssl-perl",
+    "version": "1.04-1"
+  },
+  {
+    "name": "libxml-xpathengine-perl",
+    "version": "0.14-1"
+  },
+  {
+    "name": "pymacaroons",
+    "version": "0.13.0"
+  },
+  {
+    "name": "sound-theme-freedesktop",
+    "version": "0.8-2ubuntu1"
+  },
+  {
+    "name": "ubuntu-drivers-common",
+    "version": "0.0.0"
+  },
+  {
+    "name": "unattended-upgrades",
+    "version": "0.1"
+  },
+  {
+    "name": "aspell-en",
+    "version": "2018.04.16-0-1"
+  },
+  {
+    "name": "emacsen-common",
+    "version": "3.0.4"
+  },
+  {
+    "name": "fonts-deva-extra",
+    "version": "3.0-5"
+  },
+  {
+    "name": "fonts-gujr-extra",
+    "version": "1.0.1-1"
+  },
+  {
+    "name": "fonts-guru-extra",
+    "version": "2.0-5"
+  },
+  {
+    "name": "fonts-kacst-one",
+    "version": "5.0+svn11846-10"
+  },
+  {
+    "name": "fonts-liberation",
+    "version": "1:1.07.4-11"
+  },
+  {
+    "name": "fonts-lohit-deva",
+    "version": "2.95.4-4"
+  },
+  {
+    "name": "fonts-lohit-gujr",
+    "version": "2.92.4-4"
+  },
+  {
+    "name": "fonts-orya-extra",
+    "version": "2.0-6"
+  },
+  {
+    "name": "fonts-smc-meera",
+    "version": "7.0.3-1"
+  },
+  {
+    "name": "fonts-smc-raghumalayalamsans",
+    "version": "2.2.1-1"
+  },
+  {
+    "name": "fonts-smc-suruma",
+    "version": "3.2.3-1"
+  },
+  {
+    "name": "fonts-smc-uroob",
+    "version": "2.0.2-1"
+  },
+  {
+    "name": "libhtml-form-perl",
+    "version": "6.07-1"
+  },
+  {
+    "name": "libhtml-tagset-perl",
+    "version": "3.20-4"
+  },
+  {
+    "name": "libhtml-tree-perl",
+    "version": "5.07-2"
+  },
+  {
+    "name": "libhttp-date-perl",
+    "version": "6.05-1"
+  },
+  {
+    "name": "libhttp-negotiate-perl",
+    "version": "6.01-1"
+  },
+  {
+    "name": "libio-stringy-perl",
+    "version": "2.111-3"
+  },
+  {
+    "name": "liblwp-mediatypes-perl",
+    "version": "6.04-1"
+  },
+  {
+    "name": "libmailtools-perl",
+    "version": "2.21-1"
+  },
+  {
+    "name": "libtext-wrapi18n-perl",
+    "version": "0.06-9"
+  },
+  {
+    "name": "libwww-robotrules-perl",
+    "version": "6.02-1"
+  },
+  {
+    "name": "macaroonbakery",
+    "version": "1.3.1"
+  },
+  {
+    "name": "olefile",
+    "version": "0.46"
+  },
+  {
+    "name": "osquery",
+    "version": "5.2.3-1.linux"
+  },
+  {
+    "name": "policykit-desktop-privileges",
+    "version": "0.21"
+  },
+  {
+    "name": "powermgmt-base",
+    "version": "1.36"
+  },
+  {
+    "name": "pyRFC3339",
+    "version": "1.1"
+  },
+  {
+    "name": "xcursor-themes",
+    "version": "1.0.6-0ubuntu1"
+  },
+  {
+    "name": "xfonts-base",
+    "version": "1:1.0.5"
+  },
+  {
+    "name": "xml-core",
+    "version": "0.18+nmu1"
+  },
+  {
+    "name": "SecretStorage",
+    "version": "3.3.1"
+  },
+  {
+    "name": "adduser",
+    "version": "3.118ubuntu5"
+  },
+  {
+    "name": "alsa-base",
+    "version": "1.0.25+dfsg-0ubuntu7"
+  },
+  {
+    "name": "alsa-topology-conf",
+    "version": "1.2.5.1-2"
+  },
+  {
+    "name": "amd64-microcode",
+    "version": "3.20191218.1ubuntu2"
+  },
+  {
+    "name": "apport-symptoms",
+    "version": "0.24"
+  },
+  {
+    "name": "certifi",
+    "version": "2020.6.20"
+  },
+  {
+    "name": "chardet",
+    "version": "4.0.0"
+  },
+  {
+    "name": "colorama",
+    "version": "0.4.4"
+  },
+  {
+    "name": "cpp",
+    "version": "4:11.2.0-1ubuntu1"
+  },
+  {
+    "name": "dmidecode",
+    "version": "3.3-3"
+  },
+  {
+    "name": "dns-root-data",
+    "version": "2021011101"
+  },
+  {
+    "name": "efibootmgr",
+    "version": "17-1ubuntu2"
+  },
+  {
+    "name": "fonts-beng",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-dejavu-core",
+    "version": "2.37-2build1"
+  },
+  {
+    "name": "fonts-deva",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-droid-fallback",
+    "version": "1:6.0.1r16-1.1build1"
+  },
+  {
+    "name": "fonts-freefont-ttf",
+    "version": "20120503-10build1"
+  },
+  {
+    "name": "fonts-gargi",
+    "version": "2.0-5"
+  },
+  {
+    "name": "fonts-gubbi",
+    "version": "1.3-5build1"
+  },
+  {
+    "name": "fonts-gujr",
+    "version": "2:1.4"
+  },
+  {
+    "name": "fonts-guru",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-indic",
+    "version": "2:1.4"
+  },
+  {
+    "name": "fonts-kacst",
+    "version": "2.01+mry-15"
+  },
+  {
+    "name": "fonts-kalapi",
+    "version": "1.0-4"
+  },
+  {
+    "name": "fonts-khmeros-core",
+    "version": "5.0-9ubuntu1"
+  },
+  {
+    "name": "fonts-knda",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-lao",
+    "version": "0.0.20060226-10ubuntu2"
+  },
+  {
+    "name": "fonts-lklug-sinhala",
+    "version": "0.6-4"
+  },
+  {
+    "name": "fonts-lohit-beng-assamese",
+    "version": "2.91.5-2"
+  },
+  {
+    "name": "fonts-lohit-beng-bengali",
+    "version": "2.91.5-2"
+  },
+  {
+    "name": "fonts-lohit-guru",
+    "version": "2.91.2-2build1"
+  },
+  {
+    "name": "fonts-lohit-knda",
+    "version": "2.5.4-3"
+  },
+  {
+    "name": "fonts-lohit-mlym",
+    "version": "2.92.2-2"
+  },
+  {
+    "name": "fonts-lohit-orya",
+    "version": "2.91.2-2"
+  },
+  {
+    "name": "fonts-lohit-taml",
+    "version": "2.91.3-2"
+  },
+  {
+    "name": "fonts-lohit-taml-classical",
+    "version": "2.5.4-2"
+  },
+  {
+    "name": "fonts-lohit-telu",
+    "version": "2.5.5-2build1"
+  },
+  {
+    "name": "fonts-mlym",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-nakula",
+    "version": "1.0-4"
+  },
+  {
+    "name": "fonts-navilu",
+    "version": "1.2-3"
+  },
+  {
+    "name": "fonts-noto-mono",
+    "version": "20201225-1build1"
+  },
+  {
+    "name": "fonts-orya",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-pagul",
+    "version": "1.0-8"
+  },
+  {
+    "name": "fonts-sahadeva",
+    "version": "1.0-5"
+  },
+  {
+    "name": "fonts-samyak-deva",
+    "version": "1.2.2-5build1"
+  },
+  {
+    "name": "fonts-samyak-gujr",
+    "version": "1.2.2-5build1"
+  },
+  {
+    "name": "fonts-samyak-mlym",
+    "version": "1.2.2-5build1"
+  },
+  {
+    "name": "fonts-samyak-taml",
+    "version": "1.2.2-5build1"
+  },
+  {
+    "name": "fonts-sarai",
+    "version": "1.0-3"
+  },
+  {
+    "name": "fonts-smc",
+    "version": "1:7.2"
+  },
+  {
+    "name": "fonts-smc-anjalioldlipi",
+    "version": "7.1.2-2"
+  },
+  {
+    "name": "fonts-smc-dyuthi",
+    "version": "3.0.2-2"
+  },
+  {
+    "name": "fonts-smc-karumbi",
+    "version": "1.1.2-2"
+  },
+  {
+    "name": "fonts-smc-keraleeyam",
+    "version": "3.0.2-2"
+  },
+  {
+    "name": "fonts-smc-rachana",
+    "version": "7.0.2-1build1"
+  },
+  {
+    "name": "fonts-taml",
+    "version": "2:1.4"
+  },
+  {
+    "name": "fonts-telu",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-telu-extra",
+    "version": "2.0-5"
+  },
+  {
+    "name": "fonts-teluguvijayam",
+    "version": "2.1-1"
+  },
+  {
+    "name": "fonts-urw-base35",
+    "version": "20200910-1"
+  },
+  {
+    "name": "friendly-recovery",
+    "version": "0.2.42"
+  },
+  {
+    "name": "intel-microcode",
+    "version": "3.20210608.2ubuntu1"
+  },
+  {
+    "name": "iucode-tool",
+    "version": "2.3.1-1build1"
+  },
+  {
+    "name": "jeepney",
+    "version": "0.7.1"
+  },
+  {
+    "name": "libauthen-sasl-perl",
+    "version": "2.1600-1.1"
+  },
+  {
+    "name": "libefiboot1",
+    "version": "37-6ubuntu2"
+  },
+  {
+    "name": "libefivar1",
+    "version": "37-6ubuntu2"
+  },
+  {
+    "name": "libencode-locale-perl",
+    "version": "1.05-1.1"
+  },
+  {
+    "name": "libexempi8",
+    "version": "2.5.2-1build1"
+  },
+  {
+    "name": "libfile-desktopentry-perl",
+    "version": "0.22-2"
+  },
+  {
+    "name": "libfile-listing-perl",
+    "version": "6.14-1"
+  },
+  {
+    "name": "libfont-afm-perl",
+    "version": "1.20-3"
+  },
+  {
+    "name": "libgtk3-perl",
+    "version": "0.038-1"
+  },
+  {
+    "name": "libhtml-format-perl",
+    "version": "2.12-1.1"
+  },
+  {
+    "name": "libhttp-cookies-perl",
+    "version": "6.10-1"
+  },
+  {
+    "name": "libio-html-perl",
+    "version": "1.004-2"
+  },
+  {
+    "name": "libipc-system-simple-perl",
+    "version": "1.30-1"
+  },
+  {
+    "name": "liblwp-protocol-https-perl",
+    "version": "6.10-1"
+  },
+  {
+    "name": "libsmbios-c2",
+    "version": "2.4.3-1build1"
+  },
+  {
+    "name": "libtie-ixhash-perl",
+    "version": "1.23-2.1"
+  },
+  {
+    "name": "libtimedate-perl",
+    "version": "2.3300-2"
+  },
+  {
+    "name": "libx11-protocol-perl",
+    "version": "0.56-7.1"
+  },
+  {
+    "name": "libxml-twig-perl",
+    "version": "1:3.52-1"
+  },
+  {
+    "name": "linux-base",
+    "version": "4.5ubuntu9"
+  },
+  {
+    "name": "linux-sound-base",
+    "version": "1.0.25+dfsg-0ubuntu7"
+  },
+  {
+    "name": "manpages",
+    "version": "5.10-1ubuntu1"
+  },
+  {
+    "name": "mime-support",
+    "version": "3.66"
+  },
+  {
+    "name": "nessusagent",
+    "version": "10.1.3"
+  },
+  {
+    "name": "netbase",
+    "version": "6.3"
+  },
+  {
+    "name": "networkd-dispatcher",
+    "version": "2.1-2"
+  },
+  {
+    "name": "poppler-data",
+    "version": "0.4.11-1"
+  },
+  {
+    "name": "printer-driver-sag-gdi",
+    "version": "0.1-8"
+  },
+  {
+    "name": "protobuf",
+    "version": "3.12.4"
+  },
+  {
+    "name": "python-dateutil",
+    "version": "2.8.1"
+  },
+  {
+    "name": "python3-certifi",
+    "version": "2020.6.20-1"
+  },
+  {
+    "name": "python3-chardet",
+    "version": "4.0.0-1"
+  },
+  {
+    "name": "python3-colorama",
+    "version": "0.4.4-1"
+  },
+  {
+    "name": "python3-dateutil",
+    "version": "2.8.1-6"
+  },
+  {
+    "name": "python3-olefile",
+    "version": "0.46-3"
+  },
+  {
+    "name": "python3-pexpect",
+    "version": "4.8.0-2ubuntu1"
+  },
+  {
+    "name": "python3-pymacaroons",
+    "version": "0.13.0-4"
+  },
+  {
+    "name": "python3-requests",
+    "version": "2.25.1+dfsg-2"
+  },
+  {
+    "name": "python3-secretstorage",
+    "version": "3.3.1-1"
+  },
+  {
+    "name": "python3-urllib3",
+    "version": "1.26.5-1~exp1"
+  },
+  {
+    "name": "python3-xdg",
+    "version": "0.27-2"
+  },
+  {
+    "name": "python3-zipp",
+    "version": "1.0.0-3"
+  },
+  {
+    "name": "pyxdg",
+    "version": "0.27"
+  },
+  {
+    "name": "requests",
+    "version": "2.25.1"
+  },
+  {
+    "name": "secureboot-db",
+    "version": "1.8"
+  },
+  {
+    "name": "sgml-base",
+    "version": "1.30"
+  },
+  {
+    "name": "sgml-data",
+    "version": "2.0.11+nmu1"
+  },
+  {
+    "name": "shim-signed",
+    "version": "1.51+15.4-0ubuntu9"
+  },
+  {
+    "name": "six",
+    "version": "1.16.0"
+  },
+  {
+    "name": "ubuntu-keyring",
+    "version": "2021.03.26"
+  },
+  {
+    "name": "ucf",
+    "version": "3.0043"
+  },
+  {
+    "name": "update-inetd",
+    "version": "4.51"
+  },
+  {
+    "name": "urllib3",
+    "version": "1.26.5"
+  },
+  {
+    "name": "wireless-regdb",
+    "version": "2021.08.28-0ubuntu1"
+  },
+  {
+    "name": "xorg-docs-core",
+    "version": "1:1.7.1-1.2"
+  },
+  {
+    "name": "zipp",
+    "version": "1.0.0"
+  },
+  {
+    "name": "Pillow",
+    "version": "8.1.2"
+  },
+  {
+    "name": "PyGObject",
+    "version": "3.40.1"
+  },
+  {
+    "name": "PyJWT",
+    "version": "1.7.1"
+  },
+  {
+    "name": "PyNaCl",
+    "version": "1.4.0"
+  },
+  {
+    "name": "accountsservice",
+    "version": "0.6.55-0ubuntu14"
+  },
+  {
+    "name": "acl",
+    "version": "2.2.53-10ubuntu2"
+  },
+  {
+    "name": "acpi-support",
+    "version": "0.143build1"
+  },
+  {
+    "name": "acpid",
+    "version": "1:2.0.32-1ubuntu2"
+  },
+  {
+    "name": "adwaita-icon-theme",
+    "version": "40.1.1-1ubuntu1"
+  },
+  {
+    "name": "alsa-ucm-conf",
+    "version": "1.2.4-2ubuntu4"
+  },
+  {
+    "name": "alsa-utils",
+    "version": "1.2.4-1ubuntu4"
+  },
+  {
+    "name": "anacron",
+    "version": "2.3-30ubuntu3"
+  },
+  {
+    "name": "apg",
+    "version": "2.2.3.dfsg.1-5build1"
+  },
+  {
+    "name": "app-install-data-partner",
+    "version": "21.10"
+  },
+  {
+    "name": "apparmor",
+    "version": "3.0.3-0ubuntu1"
+  },
+  {
+    "name": "apport",
+    "version": "2.20.11-0ubuntu70"
+  },
+  {
+    "name": "apport-gtk",
+    "version": "2.20.11-0ubuntu70"
+  },
+  {
+    "name": "appstream",
+    "version": "0.14.5-1"
+  },
+  {
+    "name": "apt",
+    "version": "2.3.9"
+  },
+  {
+    "name": "apt-config-icons",
+    "version": "0.14.5-1"
+  },
+  {
+    "name": "apt-config-icons-hidpi",
+    "version": "0.14.5-1"
+  },
+  {
+    "name": "apt-utils",
+    "version": "2.3.9"
+  },
+  {
+    "name": "aptdaemon",
+    "version": "1.1.1+bzr982-0ubuntu36"
+  },
+  {
+    "name": "aptdaemon-data",
+    "version": "1.1.1+bzr982-0ubuntu36"
+  },
+  {
+    "name": "apturl",
+    "version": "0.5.2ubuntu21"
+  },
+  {
+    "name": "apturl-common",
+    "version": "0.5.2ubuntu21"
+  },
+  {
+    "name": "aspell",
+    "version": "0.60.8-3"
+  },
+  {
+    "name": "at-spi2-core",
+    "version": "2.42.0-1"
+  },
+  {
+    "name": "avahi-autoipd",
+    "version": "0.8-5ubuntu4"
+  },
+  {
+    "name": "avahi-daemon",
+    "version": "0.8-5ubuntu4"
+  },
+  {
+    "name": "avahi-utils",
+    "version": "0.8-5ubuntu4"
+  },
+  {
+    "name": "base-files",
+    "version": "11.1ubuntu5"
+  },
+  {
+    "name": "base-passwd",
+    "version": "3.5.51"
+  },
+  {
+    "name": "bash",
+    "version": "5.1-3ubuntu2"
+  },
+  {
+    "name": "bash-completion",
+    "version": "1:2.11-2ubuntu1"
+  },
+  {
+    "name": "bc",
+    "version": "1.07.1-2build3"
+  },
+  {
+    "name": "bind9-dnsutils",
+    "version": "1:9.16.15-1ubuntu1"
+  },
+  {
+    "name": "bind9-host",
+    "version": "1:9.16.15-1ubuntu1"
+  },
+  {
+    "name": "bind9-libs",
+    "version": "1:9.16.15-1ubuntu1"
+  },
+  {
+    "name": "bluez",
+    "version": "5.60-0ubuntu2"
+  },
+  {
+    "name": "bluez-cups",
+    "version": "5.60-0ubuntu2"
+  },
+  {
+    "name": "bluez-obexd",
+    "version": "5.60-0ubuntu2"
+  },
+  {
+    "name": "bolt",
+    "version": "0.9.1-2"
+  },
+  {
+    "name": "brltty",
+    "version": "6.3+dfsg-1ubuntu2"
+  },
+  {
+    "name": "bsdextrautils",
+    "version": "2.36.1-8ubuntu1"
+  },
+  {
+    "name": "bsdutils",
+    "version": "1:2.36.1-8ubuntu1"
+  },
+  {
+    "name": "bubblewrap",
+    "version": "0.4.1-3build1"
+  },
+  {
+    "name": "busybox-initramfs",
+    "version": "1:1.30.1-6ubuntu3"
+  },
+  {
+    "name": "busybox-static",
+    "version": "1:1.30.1-6ubuntu3"
+  },
+  {
+    "name": "bzip2",
+    "version": "1.0.8-4ubuntu3"
+  },
+  {
+    "name": "ca-certificates",
+    "version": "20210119ubuntu1"
+  },
+  {
+    "name": "cheese-common",
+    "version": "3.38.0-4"
+  },
+  {
+    "name": "click",
+    "version": "7.1.2"
+  },
+  {
+    "name": "colord",
+    "version": "1.4.5-3build1"
+  },
+  {
+    "name": "colord-data",
+    "version": "1.4.5-3build1"
+  },
+  {
+    "name": "command-not-found",
+    "version": "21.10.0"
+  },
+  {
+    "name": "console-setup",
+    "version": "1.205ubuntu1"
+  },
+  {
+    "name": "console-setup-linux",
+    "version": "1.205ubuntu1"
+  },
+  {
+    "name": "coreutils",
+    "version": "8.32-4ubuntu2"
+  },
+  {
+    "name": "cpio",
+    "version": "2.13+dfsg-4ubuntu4"
+  },
+  {
+    "name": "cpp-11",
+    "version": "11.2.0-7ubuntu2"
+  },
+  {
+    "name": "cracklib-runtime",
+    "version": "2.9.6-3.4build1"
+  },
+  {
+    "name": "crda",
+    "version": "4.14+git20191112.9856751-1build1"
+  },
+  {
+    "name": "cron",
+    "version": "3.0pl1-137ubuntu2"
+  },
+  {
+    "name": "cryptography",
+    "version": "3.3.2"
+  },
+  {
+    "name": "cups",
+    "version": "2.3.3op2-7ubuntu2"
+  },
+  {
+    "name": "cups-browsed",
+    "version": "1.28.10-2"
+  },
+  {
+    "name": "cups-bsd",
+    "version": "2.3.3op2-7ubuntu2"
+  },
+  {
+    "name": "cups-client",
+    "version": "2.3.3op2-7ubuntu2"
+  },
+  {
+    "name": "cups-common",
+    "version": "2.3.3op2-7ubuntu2"
+  },
+  {
+    "name": "cups-core-drivers",
+    "version": "2.3.3op2-7ubuntu2"
+  },
+  {
+    "name": "cups-daemon",
+    "version": "2.3.3op2-7ubuntu2"
+  },
+  {
+    "name": "cups-filters",
+    "version": "1.28.10-2"
+  },
+  {
+    "name": "cups-filters-core-drivers",
+    "version": "1.28.10-2"
+  },
+  {
+    "name": "cups-ipp-utils",
+    "version": "2.3.3op2-7ubuntu2"
+  },
+  {
+    "name": "cups-pk-helper",
+    "version": "0.2.6-1ubuntu4"
+  },
+  {
+    "name": "cups-ppdc",
+    "version": "2.3.3op2-7ubuntu2"
+  },
+  {
+    "name": "cups-server-common",
+    "version": "2.3.3op2-7ubuntu2"
+  },
+  {
+    "name": "dash",
+    "version": "0.5.11+git20210120+802ebd4-1build1"
+  },
+  {
+    "name": "dbus",
+    "version": "1.12.20-2ubuntu2"
+  },
+  {
+    "name": "dbus-python",
+    "version": "1.2.16"
+  },
+  {
+    "name": "dbus-user-session",
+    "version": "1.12.20-2ubuntu2"
+  },
+  {
+    "name": "dbus-x11",
+    "version": "1.12.20-2ubuntu2"
+  },
+  {
+    "name": "dc",
+    "version": "1.07.1-2build3"
+  },
+  {
+    "name": "dconf-cli",
+    "version": "0.40.0-1"
+  },
+  {
+    "name": "dconf-gsettings-backend",
+    "version": "0.40.0-1"
+  },
+  {
+    "name": "dconf-service",
+    "version": "0.40.0-1"
+  },
+  {
+    "name": "debconf",
+    "version": "1.5.77"
+  },
+  {
+    "name": "debconf-i18n",
+    "version": "1.5.77"
+  },
+  {
+    "name": "debianutils",
+    "version": "4.11.2"
+  },
+  {
+    "name": "desktop-file-utils",
+    "version": "0.26-1ubuntu2"
+  },
+  {
+    "name": "dictionaries-common",
+    "version": "1.28.4"
+  },
+  {
+    "name": "diffutils",
+    "version": "1:3.8-0ubuntu1"
+  },
+  {
+    "name": "dirmngr",
+    "version": "2.2.20-1ubuntu4"
+  },
+  {
+    "name": "distro",
+    "version": "1.5.0"
+  },
+  {
+    "name": "distro-info",
+    "version": "1.0"
+  },
+  {
+    "name": "distro-info",
+    "version": "1.0"
+  },
+  {
+    "name": "distro-info-data",
+    "version": "0.51ubuntu1"
+  },
+  {
+    "name": "dmsetup",
+    "version": "2:1.02.175-2.1ubuntu3"
+  },
+  {
+    "name": "dnsmasq-base",
+    "version": "2.85-1ubuntu2"
+  },
+  {
+    "name": "docbook-xml",
+    "version": "4.5-9"
+  },
+  {
+    "name": "dosfstools",
+    "version": "4.2-1build2"
+  },
+  {
+    "name": "dpkg",
+    "version": "1.20.9ubuntu2"
+  },
+  {
+    "name": "e2fsprogs",
+    "version": "1.46.3-1ubuntu3"
+  },
+  {
+    "name": "ed",
+    "version": "1.17-1"
+  },
+  {
+    "name": "eject",
+    "version": "2.36.1-8ubuntu1"
+  },
+  {
+    "name": "enchant-2",
+    "version": "2.3.1-1"
+  },
+  {
+    "name": "eog",
+    "version": "41.0-1"
+  },
+  {
+    "name": "espeak-ng-data",
+    "version": "1.50+dfsg-7build2"
+  },
+  {
+    "name": "evince",
+    "version": "40.4-2"
+  },
+  {
+    "name": "evince-common",
+    "version": "40.4-2"
+  },
+  {
+    "name": "evolution-data-server",
+    "version": "3.40.4-1"
+  },
+  {
+    "name": "evolution-data-server-common",
+    "version": "3.40.4-1"
+  },
+  {
+    "name": "fdisk",
+    "version": "2.36.1-8ubuntu1"
+  },
+  {
+    "name": "file",
+    "version": "1:5.39-3"
+  },
+  {
+    "name": "file-roller",
+    "version": "3.40.0-2"
+  },
+  {
+    "name": "findutils",
+    "version": "4.8.0-1ubuntu2"
+  },
+  {
+    "name": "fontconfig",
+    "version": "2.13.1-4.2ubuntu3"
+  },
+  {
+    "name": "fontconfig-config",
+    "version": "2.13.1-4.2ubuntu3"
+  },
+  {
+    "name": "fonts-beng-extra",
+    "version": "1.0-7"
+  },
+  {
+    "name": "fonts-liberation2",
+    "version": "2.1.3-1"
+  },
+  {
+    "name": "fonts-noto-cjk",
+    "version": "1:20201206-cjk+repack1-1"
+  },
+  {
+    "name": "fonts-noto-color-emoji",
+    "version": "2.028-1"
+  },
+  {
+    "name": "fonts-opensymbol",
+    "version": "2:102.12+LibO7.2.1-0ubuntu3"
+  },
+  {
+    "name": "fonts-sil-abyssinica",
+    "version": "2.000-1build1"
+  },
+  {
+    "name": "fonts-sil-padauk",
+    "version": "4.000-1build1"
+  },
+  {
+    "name": "fonts-smc-chilanka",
+    "version": "1.530-1"
+  },
+  {
+    "name": "fonts-smc-gayathri",
+    "version": "1.100-2"
+  },
+  {
+    "name": "fonts-smc-manjari",
+    "version": "1.920-1"
+  },
+  {
+    "name": "fonts-thai-tlwg",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tibetan-machine",
+    "version": "1.901b-5.1build1"
+  },
+  {
+    "name": "fonts-tlwg-garuda",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-garuda-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-kinnari",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-kinnari-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-laksaman",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-laksaman-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-loma",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-loma-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-mono",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-mono-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-norasi",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-norasi-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-purisa",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-purisa-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-sawasdee",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-sawasdee-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-typewriter",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-typewriter-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-typist",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-typist-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-typo",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-typo-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-umpush",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-umpush-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-waree",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-tlwg-waree-ttf",
+    "version": "1:0.7.2-1build1"
+  },
+  {
+    "name": "fonts-ubuntu",
+    "version": "0.83-4ubuntu2"
+  },
+  {
+    "name": "fonts-yrsa-rasa",
+    "version": "2.001-1"
+  },
+  {
+    "name": "foomatic-db-compressed-ppds",
+    "version": "20210824-1"
+  },
+  {
+    "name": "fprintd",
+    "version": "1.90.9-1build1"
+  },
+  {
+    "name": "ftp",
+    "version": "0.17-34.1.1"
+  },
+  {
+    "name": "fuse",
+    "version": "2.9.9-5ubuntu2"
+  },
+  {
+    "name": "fwupd",
+    "version": "1.5.11-0ubuntu2"
+  },
+  {
+    "name": "fwupd-signed",
+    "version": "1.40+1.5.11-0ubuntu2"
+  },
+  {
+    "name": "gamemode",
+    "version": "1.6.1-1"
+  },
+  {
+    "name": "gamemode-daemon",
+    "version": "1.6.1-1"
+  },
+  {
+    "name": "gcc-11-base",
+    "version": "11.2.0-7ubuntu2"
+  },
+  {
+    "name": "gcr",
+    "version": "3.40.0-3"
+  },
+  {
+    "name": "gdb",
+    "version": "11.1-0ubuntu2"
+  },
+  {
+    "name": "gdisk",
+    "version": "1.0.8-1"
+  },
+  {
+    "name": "gdm3",
+    "version": "41~rc-0ubuntu2"
+  },
+  {
+    "name": "gedit",
+    "version": "40.1-1"
+  },
+  {
+    "name": "gedit-common",
+    "version": "40.1-1"
+  },
+  {
+    "name": "geoclue-2.0",
+    "version": "2.5.7-3ubuntu2"
+  },
+  {
+    "name": "gettext-base",
+    "version": "0.21-4ubuntu3"
+  },
+  {
+    "name": "ghostscript",
+    "version": "9.54.0~dfsg1-0ubuntu2"
+  },
+  {
+    "name": "ghostscript-x",
+    "version": "9.54.0~dfsg1-0ubuntu2"
+  },
+  {
+    "name": "gir1.2-accountsservice-1.0",
+    "version": "0.6.55-0ubuntu14"
+  },
+  {
+    "name": "gir1.2-atk-1.0",
+    "version": "2.36.0-0ubuntu3"
+  },
+  {
+    "name": "gir1.2-atspi-2.0",
+    "version": "2.42.0-1"
+  },
+  {
+    "name": "gir1.2-dbusmenu-glib-0.4",
+    "version": "16.04.1+18.10.20180917-0ubuntu7"
+  },
+  {
+    "name": "gir1.2-dee-1.0",
+    "version": "1.2.7+17.10.20170616-6ubuntu2"
+  },
+  {
+    "name": "gir1.2-freedesktop",
+    "version": "1.68.0-1build2"
+  },
+  {
+    "name": "gir1.2-gck-1",
+    "version": "3.40.0-3"
+  },
+  {
+    "name": "gir1.2-gcr-3",
+    "version": "3.40.0-3"
+  },
+  {
+    "name": "gir1.2-gdesktopenums-3.0",
+    "version": "40.0-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-gdkpixbuf-2.0",
+    "version": "2.42.6+dfsg-1build2"
+  },
+  {
+    "name": "gir1.2-gdm-1.0",
+    "version": "41~rc-0ubuntu2"
+  },
+  {
+    "name": "gir1.2-geoclue-2.0",
+    "version": "2.5.7-3ubuntu2"
+  },
+  {
+    "name": "gir1.2-glib-2.0",
+    "version": "1.68.0-1build2"
+  },
+  {
+    "name": "gir1.2-gmenu-3.0",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-gnomebluetooth-1.0",
+    "version": "3.34.5-3"
+  },
+  {
+    "name": "gir1.2-gnomedesktop-3.0",
+    "version": "40.4-2ubuntu1"
+  },
+  {
+    "name": "gir1.2-goa-1.0",
+    "version": "3.40.0-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-graphene-1.0",
+    "version": "1.10.4+dfsg1-1build1"
+  },
+  {
+    "name": "gir1.2-gstreamer-1.0",
+    "version": "1.18.5-1"
+  },
+  {
+    "name": "gir1.2-gtk-3.0",
+    "version": "3.24.30-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-gtk-4.0",
+    "version": "4.4.0+ds1-5"
+  },
+  {
+    "name": "gir1.2-gtksource-4",
+    "version": "4.8.2-1"
+  },
+  {
+    "name": "gir1.2-gweather-3.0",
+    "version": "40.0-3"
+  },
+  {
+    "name": "gir1.2-handy-1",
+    "version": "1.2.3-1"
+  },
+  {
+    "name": "gir1.2-harfbuzz-0.0",
+    "version": "2.7.4-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-ibus-1.0",
+    "version": "1.5.25-2build1"
+  },
+  {
+    "name": "gir1.2-javascriptcoregtk-4.0",
+    "version": "2.34.0-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-json-1.0",
+    "version": "1.6.2-1"
+  },
+  {
+    "name": "gir1.2-mutter-8",
+    "version": "40.5-1ubuntu2"
+  },
+  {
+    "name": "gir1.2-nm-1.0",
+    "version": "1.32.12-0ubuntu1"
+  },
+  {
+    "name": "gir1.2-nma-1.0",
+    "version": "1.8.32-1"
+  },
+  {
+    "name": "gir1.2-notify-0.7",
+    "version": "0.7.9-3ubuntu3"
+  },
+  {
+    "name": "gir1.2-packagekitglib-1.0",
+    "version": "1.2.2-2ubuntu3"
+  },
+  {
+    "name": "gir1.2-pango-1.0",
+    "version": "1.48.10+ds1-1"
+  },
+  {
+    "name": "gir1.2-peas-1.0",
+    "version": "1.30.0-3"
+  },
+  {
+    "name": "gir1.2-polkit-1.0",
+    "version": "0.105-31"
+  },
+  {
+    "name": "gir1.2-rsvg-2.0",
+    "version": "2.50.7+dfsg-1"
+  },
+  {
+    "name": "gir1.2-secret-1",
+    "version": "0.20.4-2"
+  },
+  {
+    "name": "gir1.2-snapd-1",
+    "version": "1.58-0ubuntu2"
+  },
+  {
+    "name": "gir1.2-soup-2.4",
+    "version": "2.72.0-3ubuntu3"
+  },
+  {
+    "name": "gir1.2-unity-7.0",
+    "version": "7.1.4+19.04.20190319-5"
+  },
+  {
+    "name": "gir1.2-upowerglib-1.0",
+    "version": "0.99.11-2build1"
+  },
+  {
+    "name": "gir1.2-vte-2.91",
+    "version": "0.64.2-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-webkit2-4.0",
+    "version": "2.34.0-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-wnck-3.0",
+    "version": "40.0-1"
+  },
+  {
+    "name": "gjs",
+    "version": "1.68.4-1"
+  },
+  {
+    "name": "gkbd-capplet",
+    "version": "3.26.1-1build1"
+  },
+  {
+    "name": "glib-networking",
+    "version": "2.68.2-2"
+  },
+  {
+    "name": "glib-networking-common",
+    "version": "2.68.2-2"
+  },
+  {
+    "name": "glib-networking-services",
+    "version": "2.68.2-2"
+  },
+  {
+    "name": "gnome-accessibility-themes",
+    "version": "3.28-1ubuntu2"
+  },
+  {
+    "name": "gnome-bluetooth",
+    "version": "3.34.5-3"
+  },
+  {
+    "name": "gnome-calculator",
+    "version": "1:40.1-1ubuntu2"
+  },
+  {
+    "name": "gnome-characters",
+    "version": "41.0-1"
+  },
+  {
+    "name": "gnome-control-center",
+    "version": "1:40.0-1ubuntu5"
+  },
+  {
+    "name": "gnome-control-center-data",
+    "version": "1:40.0-1ubuntu5"
+  },
+  {
+    "name": "gnome-control-center-faces",
+    "version": "1:40.0-1ubuntu5"
+  },
+  {
+    "name": "gnome-desktop3-data",
+    "version": "40.4-2ubuntu1"
+  },
+  {
+    "name": "gnome-disk-utility",
+    "version": "41.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-font-viewer",
+    "version": "41.0-1"
+  },
+  {
+    "name": "gnome-initial-setup",
+    "version": "40.4-1ubuntu1"
+  },
+  {
+    "name": "gnome-keyring",
+    "version": "40.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-keyring-pkcs11",
+    "version": "40.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-logs",
+    "version": "3.36.0-2build1"
+  },
+  {
+    "name": "gnome-menus",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-online-accounts",
+    "version": "3.40.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-power-manager",
+    "version": "3.32.0-2build1"
+  },
+  {
+    "name": "gnome-screenshot",
+    "version": "40~beta-1ubuntu1"
+  },
+  {
+    "name": "gnome-session-bin",
+    "version": "40.1.1-1ubuntu1"
+  },
+  {
+    "name": "gnome-session-canberra",
+    "version": "0.30-7ubuntu2"
+  },
+  {
+    "name": "gnome-session-common",
+    "version": "40.1.1-1ubuntu1"
+  },
+  {
+    "name": "gnome-settings-daemon",
+    "version": "40.0.1-1ubuntu3"
+  },
+  {
+    "name": "gnome-settings-daemon-common",
+    "version": "40.0.1-1ubuntu3"
+  },
+  {
+    "name": "gnome-shell",
+    "version": "40.5-1ubuntu2"
+  },
+  {
+    "name": "gnome-shell-common",
+    "version": "40.5-1ubuntu2"
+  },
+  {
+    "name": "gnome-shell-extension-appindicator",
+    "version": "40-1"
+  },
+  {
+    "name": "gnome-shell-extension-desktop-icons-ng",
+    "version": "20-0ubuntu3"
+  },
+  {
+    "name": "gnome-shell-extension-ubuntu-dock",
+    "version": "70~ubuntu3"
+  },
+  {
+    "name": "gnome-startup-applications",
+    "version": "40.1.1-1ubuntu1"
+  },
+  {
+    "name": "gnome-system-monitor",
+    "version": "41.0-1"
+  },
+  {
+    "name": "gnome-terminal",
+    "version": "3.38.1-1ubuntu2"
+  },
+  {
+    "name": "gnome-terminal-data",
+    "version": "3.38.1-1ubuntu2"
+  },
+  {
+    "name": "gnome-themes-extra",
+    "version": "3.28-1ubuntu2"
+  },
+  {
+    "name": "gnome-themes-extra-data",
+    "version": "3.28-1ubuntu2"
+  },
+  {
+    "name": "gnome-user-docs",
+    "version": "40.5-1ubuntu1"
+  },
+  {
+    "name": "gnupg",
+    "version": "2.2.20-1ubuntu4"
+  },
+  {
+    "name": "gnupg-l10n",
+    "version": "2.2.20-1ubuntu4"
+  },
+  {
+    "name": "gnupg-utils",
+    "version": "2.2.20-1ubuntu4"
+  },
+  {
+    "name": "gpg",
+    "version": "2.2.20-1ubuntu4"
+  },
+  {
+    "name": "gpg-agent",
+    "version": "2.2.20-1ubuntu4"
+  },
+  {
+    "name": "gpg-wks-client",
+    "version": "2.2.20-1ubuntu4"
+  },
+  {
+    "name": "gpg-wks-server",
+    "version": "2.2.20-1ubuntu4"
+  },
+  {
+    "name": "gpgconf",
+    "version": "2.2.20-1ubuntu4"
+  },
+  {
+    "name": "gpgsm",
+    "version": "2.2.20-1ubuntu4"
+  },
+  {
+    "name": "gpgv",
+    "version": "2.2.20-1ubuntu4"
+  },
+  {
+    "name": "grep",
+    "version": "3.7-0ubuntu1"
+  },
+  {
+    "name": "groff-base",
+    "version": "1.22.4-7"
+  },
+  {
+    "name": "grub-common",
+    "version": "2.04-1ubuntu47"
+  },
+  {
+    "name": "grub-efi-amd64-bin",
+    "version": "2.04-1ubuntu47"
+  },
+  {
+    "name": "grub-efi-amd64-signed",
+    "version": "1.173+2.04-1ubuntu47"
+  },
+  {
+    "name": "grub-pc",
+    "version": "2.04-1ubuntu47"
+  },
+  {
+    "name": "grub-pc-bin",
+    "version": "2.04-1ubuntu47"
+  },
+  {
+    "name": "grub2-common",
+    "version": "2.04-1ubuntu47"
+  },
+  {
+    "name": "gsettings-desktop-schemas",
+    "version": "40.0-1ubuntu1"
+  },
+  {
+    "name": "gsettings-ubuntu-schemas",
+    "version": "0.0.7+21.10.20210712-0ubuntu1"
+  },
+  {
+    "name": "gstreamer1.0-alsa",
+    "version": "1.18.5-1"
+  },
+  {
+    "name": "gstreamer1.0-clutter-3.0",
+    "version": "3.0.27-2build1"
+  },
+  {
+    "name": "gstreamer1.0-gl",
+    "version": "1.18.5-1"
+  },
+  {
+    "name": "gstreamer1.0-packagekit",
+    "version": "1.2.2-2ubuntu3"
+  },
+  {
+    "name": "gstreamer1.0-pipewire",
+    "version": "0.3.32-1"
+  },
+  {
+    "name": "gstreamer1.0-plugins-base",
+    "version": "1.18.5-1"
+  },
+  {
+    "name": "gstreamer1.0-plugins-base-apps",
+    "version": "1.18.5-1"
+  },
+  {
+    "name": "gstreamer1.0-plugins-good",
+    "version": "1.18.5-1ubuntu2"
+  },
+  {
+    "name": "gstreamer1.0-pulseaudio",
+    "version": "1.18.5-1ubuntu2"
+  },
+  {
+    "name": "gstreamer1.0-tools",
+    "version": "1.18.5-1"
+  },
+  {
+    "name": "gstreamer1.0-x",
+    "version": "1.18.5-1"
+  },
+  {
+    "name": "gtk-update-icon-cache",
+    "version": "3.24.30-1ubuntu1"
+  },
+  {
+    "name": "gtk2-engines-murrine",
+    "version": "0.98.2-3build1"
+  },
+  {
+    "name": "gtk2-engines-pixbuf",
+    "version": "2.24.33-2ubuntu1"
+  },
+  {
+    "name": "gvfs",
+    "version": "1.47.91-1ubuntu1"
+  },
+  {
+    "name": "gvfs-backends",
+    "version": "1.47.91-1ubuntu1"
+  },
+  {
+    "name": "gvfs-common",
+    "version": "1.47.91-1ubuntu1"
+  },
+  {
+    "name": "gvfs-daemons",
+    "version": "1.47.91-1ubuntu1"
+  },
+  {
+    "name": "gvfs-fuse",
+    "version": "1.47.91-1ubuntu1"
+  },
+  {
+    "name": "gvfs-libs",
+    "version": "1.47.91-1ubuntu1"
+  },
+  {
+    "name": "gzip",
+    "version": "1.10-4ubuntu1"
+  },
+  {
+    "name": "hdparm",
+    "version": "9.60+ds-1build2"
+  },
+  {
+    "name": "hostname",
+    "version": "3.23ubuntu1"
+  },
+  {
+    "name": "hplip",
+    "version": "3.21.6+dfsg0-0ubuntu1"
+  },
+  {
+    "name": "hplip-data",
+    "version": "3.21.6+dfsg0-0ubuntu1"
+  },
+  {
+    "name": "httplib2",
+    "version": "0.18.1"
+  },
+  {
+    "name": "humanity-icon-theme",
+    "version": "0.6.15"
+  },
+  {
+    "name": "hunspell-en-us",
+    "version": "1:2019.10.06-1"
+  },
+  {
+    "name": "ibus",
+    "version": "1.5.25-2build1"
+  },
+  {
+    "name": "ibus-data",
+    "version": "1.5.25-2build1"
+  },
+  {
+    "name": "ibus-gtk",
+    "version": "1.5.25-2build1"
+  },
+  {
+    "name": "ibus-gtk3",
+    "version": "1.5.25-2build1"
+  },
+  {
+    "name": "ibus-gtk4",
+    "version": "1.5.25-2build1"
+  },
+  {
+    "name": "ibus-table",
+    "version": "1.12.4-1"
+  },
+  {
+    "name": "idna",
+    "version": "2.10"
+  },
+  {
+    "name": "iio-sensor-proxy",
+    "version": "3.3-0ubuntu3.2"
+  },
+  {
+    "name": "im-config",
+    "version": "0.47-1"
+  },
+  {
+    "name": "importlib-metadata",
+    "version": "4.0.1"
+  },
+  {
+    "name": "info",
+    "version": "6.7.0.dfsg.2-6"
+  },
+  {
+    "name": "init",
+    "version": "1.60build1"
+  },
+  {
+    "name": "init-system-helpers",
+    "version": "1.60build1"
+  },
+  {
+    "name": "initramfs-tools",
+    "version": "0.140ubuntu6"
+  },
+  {
+    "name": "initramfs-tools-bin",
+    "version": "0.140ubuntu6"
+  },
+  {
+    "name": "initramfs-tools-core",
+    "version": "0.140ubuntu6"
+  },
+  {
+    "name": "inputattach",
+    "version": "1:1.7.1-1build1"
+  },
+  {
+    "name": "install-info",
+    "version": "6.7.0.dfsg.2-6"
+  },
+  {
+    "name": "ipp-usb",
+    "version": "0.9.19-2ubuntu1"
+  },
+  {
+    "name": "iproute2",
+    "version": "5.10.0-4ubuntu1"
+  },
+  {
+    "name": "iptables",
+    "version": "1.8.7-1ubuntu2"
+  },
+  {
+    "name": "iputils-ping",
+    "version": "3:20210202-1"
+  },
+  {
+    "name": "iputils-tracepath",
+    "version": "3:20210202-1"
+  },
+  {
+    "name": "irqbalance",
+    "version": "1.7.0-1build1"
+  },
+  {
+    "name": "isc-dhcp-client",
+    "version": "4.4.1-2.3ubuntu1"
+  },
+  {
+    "name": "isc-dhcp-common",
+    "version": "4.4.1-2.3ubuntu1"
+  },
+  {
+    "name": "iso-codes",
+    "version": "4.6.0-1"
+  },
+  {
+    "name": "iw",
+    "version": "5.9-3"
+  },
+  {
+    "name": "kbd",
+    "version": "2.3.0-3ubuntu3"
+  },
+  {
+    "name": "kerneloops",
+    "version": "0.12+git20140509-6ubuntu4"
+  },
+  {
+    "name": "keyboard-configuration",
+    "version": "1.205ubuntu1"
+  },
+  {
+    "name": "keyring",
+    "version": "23.0.1"
+  },
+  {
+    "name": "klibc-utils",
+    "version": "2.0.8-6.1ubuntu2"
+  },
+  {
+    "name": "kmod",
+    "version": "28-1ubuntu4"
+  },
+  {
+    "name": "language-pack-en",
+    "version": "1:21.10+20211008"
+  },
+  {
+    "name": "language-pack-en-base",
+    "version": "1:21.10+20211008"
+  },
+  {
+    "name": "language-pack-gnome-en",
+    "version": "1:21.10+20211008"
+  },
+  {
+    "name": "language-pack-gnome-en-base",
+    "version": "1:21.10+20211008"
+  },
+  {
+    "name": "language-selector-common",
+    "version": "0.216"
+  },
+  {
+    "name": "language-selector-gnome",
+    "version": "0.216"
+  },
+  {
+    "name": "launchpadlib",
+    "version": "1.10.13"
+  },
+  {
+    "name": "lazr.restfulclient",
+    "version": "0.14.2"
+  },
+  {
+    "name": "lazr.uri",
+    "version": "1.0.5"
+  },
+  {
+    "name": "less",
+    "version": "551-2"
+  },
+  {
+    "name": "libaa1",
+    "version": "1.4p5-48build1"
+  },
+  {
+    "name": "libaccountsservice0",
+    "version": "0.6.55-0ubuntu14"
+  },
+  {
+    "name": "libacl1",
+    "version": "2.2.53-10ubuntu2"
+  },
+  {
+    "name": "libao-common",
+    "version": "1.2.2+20180113-1.1ubuntu1"
+  },
+  {
+    "name": "libao4",
+    "version": "1.2.2+20180113-1.1ubuntu1"
+  },
+  {
+    "name": "libapparmor1",
+    "version": "3.0.3-0ubuntu1"
+  },
+  {
+    "name": "libappstream4",
+    "version": "0.14.5-1"
+  },
+  {
+    "name": "libapt-pkg6.0",
+    "version": "2.3.9"
+  },
+  {
+    "name": "libarchive13",
+    "version": "3.4.3-2"
+  },
+  {
+    "name": "libargon2-1",
+    "version": "0~20171227-0.2build21.04.0"
+  },
+  {
+    "name": "libasound2",
+    "version": "1.2.4-1.1ubuntu3"
+  },
+  {
+    "name": "libasound2-data",
+    "version": "1.2.4-1.1ubuntu3"
+  },
+  {
+    "name": "libasound2-plugins",
+    "version": "1.2.2-2ubuntu1"
+  },
+  {
+    "name": "libaspell15",
+    "version": "0.60.8-3"
+  },
+  {
+    "name": "libassuan0",
+    "version": "2.5.5-1"
+  },
+  {
+    "name": "libasyncns0",
+    "version": "0.8-6build1"
+  },
+  {
+    "name": "libatasmart4",
+    "version": "0.19-5"
+  },
+  {
+    "name": "libatk-adaptor",
+    "version": "2.38.0-2"
+  },
+  {
+    "name": "libatk-bridge2.0-0",
+    "version": "2.38.0-2"
+  },
+  {
+    "name": "libatk1.0-0",
+    "version": "2.36.0-0ubuntu3"
+  },
+  {
+    "name": "libatk1.0-data",
+    "version": "2.36.0-0ubuntu3"
+  },
+  {
+    "name": "libatkmm-1.6-1v5",
+    "version": "2.28.2-1"
+  },
+  {
+    "name": "libatm1",
+    "version": "1:2.5.1-4build1"
+  },
+  {
+    "name": "libatopology2",
+    "version": "1.2.4-1.1ubuntu3"
+  },
+  {
+    "name": "libatspi2.0-0",
+    "version": "2.42.0-1"
+  },
+  {
+    "name": "libattr1",
+    "version": "1:2.4.48-6build2"
+  },
+  {
+    "name": "libaudit-common",
+    "version": "1:3.0-2ubuntu2"
+  },
+  {
+    "name": "libaudit1",
+    "version": "1:3.0-2ubuntu2"
+  },
+  {
+    "name": "libavahi-client3",
+    "version": "0.8-5ubuntu4"
+  },
+  {
+    "name": "libavahi-common-data",
+    "version": "0.8-5ubuntu4"
+  },
+  {
+    "name": "libavahi-common3",
+    "version": "0.8-5ubuntu4"
+  },
+  {
+    "name": "libavahi-core7",
+    "version": "0.8-5ubuntu4"
+  },
+  {
+    "name": "libavahi-glib1",
+    "version": "0.8-5ubuntu4"
+  },
+  {
+    "name": "libavc1394-0",
+    "version": "0.5.4-5build1"
+  },
+  {
+    "name": "libayatana-appindicator3-1",
+    "version": "0.5.5-3"
+  },
+  {
+    "name": "libayatana-ido3-0.4-0",
+    "version": "0.8.2-2build1"
+  },
+  {
+    "name": "libayatana-indicator3-7",
+    "version": "0.8.4-1build1"
+  },
+  {
+    "name": "libbabeltrace1",
+    "version": "1.5.8-1build4"
+  },
+  {
+    "name": "libblkid1",
+    "version": "2.36.1-8ubuntu1"
+  },
+  {
+    "name": "libblockdev-crypto2",
+    "version": "2.25-2build1"
+  },
+  {
+    "name": "libblockdev-fs2",
+    "version": "2.25-2build1"
+  },
+  {
+    "name": "libblockdev-loop2",
+    "version": "2.25-2build1"
+  },
+  {
+    "name": "libblockdev-part-err2",
+    "version": "2.25-2build1"
+  },
+  {
+    "name": "libblockdev-part2",
+    "version": "2.25-2build1"
+  },
+  {
+    "name": "libblockdev-swap2",
+    "version": "2.25-2build1"
+  },
+  {
+    "name": "libblockdev-utils2",
+    "version": "2.25-2build1"
+  },
+  {
+    "name": "libblockdev2",
+    "version": "2.25-2build1"
+  },
+  {
+    "name": "libbluetooth3",
+    "version": "5.60-0ubuntu2"
+  },
+  {
+    "name": "libboost-regex1.74.0",
+    "version": "1.74.0-8ubuntu6"
+  },
+  {
+    "name": "libbpf0",
+    "version": "1:0.4.0-1ubuntu1"
+  },
+  {
+    "name": "libbrlapi0.8",
+    "version": "6.3+dfsg-1ubuntu2"
+  },
+  {
+    "name": "libbrotli1",
+    "version": "1.0.9-2build3"
+  },
+  {
+    "name": "libbsd0",
+    "version": "0.11.3-1ubuntu2"
+  },
+  {
+    "name": "libbz2-1.0",
+    "version": "1.0.8-4ubuntu3"
+  },
+  {
+    "name": "libc-bin",
+    "version": "2.34-0ubuntu3"
+  },
+  {
+    "name": "libc6",
+    "version": "2.34-0ubuntu3"
+  },
+  {
+    "name": "libc6-dbg",
+    "version": "2.34-0ubuntu3"
+  },
+  {
+    "name": "libcaca0",
+    "version": "0.99.beta19-2.2ubuntu2"
+  },
+  {
+    "name": "libcairo-gobject-perl",
+    "version": "1.005-2build2"
+  },
+  {
+    "name": "libcairo-gobject2",
+    "version": "1.16.0-5ubuntu1"
+  },
+  {
+    "name": "libcairo-perl",
+    "version": "1.109-1"
+  },
+  {
+    "name": "libcairo-script-interpreter2",
+    "version": "1.16.0-5ubuntu1"
+  },
+  {
+    "name": "libcairo2",
+    "version": "1.16.0-5ubuntu1"
+  },
+  {
+    "name": "libcairomm-1.0-1v5",
+    "version": "1.12.2-4build2"
+  },
+  {
+    "name": "libcamel-1.2-62",
+    "version": "3.40.4-1"
+  },
+  {
+    "name": "libcanberra-gtk3-0",
+    "version": "0.30-7ubuntu2"
+  },
+  {
+    "name": "libcanberra-gtk3-module",
+    "version": "0.30-7ubuntu2"
+  },
+  {
+    "name": "libcanberra-pulse",
+    "version": "0.30-7ubuntu2"
+  },
+  {
+    "name": "libcanberra0",
+    "version": "0.30-7ubuntu2"
+  },
+  {
+    "name": "libcap-ng0",
+    "version": "0.7.9-2.2build1"
+  },
+  {
+    "name": "libcap2",
+    "version": "1:2.44-1build1"
+  },
+  {
+    "name": "libcap2-bin",
+    "version": "1:2.44-1build1"
+  },
+  {
+    "name": "libcbor0.6",
+    "version": "0.6.0-0ubuntu3"
+  },
+  {
+    "name": "libcdio-cdda2",
+    "version": "10.2+2.0.0-1build2"
+  },
+  {
+    "name": "libcdio-paranoia2",
+    "version": "10.2+2.0.0-1build2"
+  },
+  {
+    "name": "libcdio19",
+    "version": "2.1.0-2"
+  },
+  {
+    "name": "libcdparanoia0",
+    "version": "3.10.2+debian-14build1"
+  },
+  {
+    "name": "libcheese-gtk25",
+    "version": "3.38.0-4"
+  },
+  {
+    "name": "libcheese8",
+    "version": "3.38.0-4"
+  },
+  {
+    "name": "libclone-perl",
+    "version": "0.45-1build1"
+  },
+  {
+    "name": "libclutter-1.0-0",
+    "version": "1.26.4+dfsg-2build1"
+  },
+  {
+    "name": "libclutter-1.0-common",
+    "version": "1.26.4+dfsg-2build1"
+  },
+  {
+    "name": "libclutter-gst-3.0-0",
+    "version": "3.0.27-2build1"
+  },
+  {
+    "name": "libclutter-gtk-1.0-0",
+    "version": "1.8.4-4build1"
+  },
+  {
+    "name": "libcogl-common",
+    "version": "1.22.8-2build1"
+  },
+  {
+    "name": "libcogl-pango20",
+    "version": "1.22.8-2build1"
+  },
+  {
+    "name": "libcogl-path20",
+    "version": "1.22.8-2build1"
+  },
+  {
+    "name": "libcogl20",
+    "version": "1.22.8-2build1"
+  },
+  {
+    "name": "libcolord-gtk1",
+    "version": "0.2.0-0ubuntu2"
+  },
+  {
+    "name": "libcolord2",
+    "version": "1.4.5-3build1"
+  },
+  {
+    "name": "libcolorhug2",
+    "version": "1.4.5-3build1"
+  },
+  {
+    "name": "libcom-err2",
+    "version": "1.46.3-1ubuntu3"
+  },
+  {
+    "name": "libcrack2",
+    "version": "2.9.6-3.4build1"
+  },
+  {
+    "name": "libcrypt1",
+    "version": "1:4.4.18-4ubuntu1"
+  },
+  {
+    "name": "libcryptsetup12",
+    "version": "2:2.3.6-0ubuntu1"
+  },
+  {
+    "name": "libcue2",
+    "version": "2.2.1-3build2"
+  },
+  {
+    "name": "libcups2",
+    "version": "2.3.3op2-7ubuntu2"
+  },
+  {
+    "name": "libcupsfilters1",
+    "version": "1.28.10-2"
+  },
+  {
+    "name": "libcupsimage2",
+    "version": "2.3.3op2-7ubuntu2"
+  },
+  {
+    "name": "libcurl3-gnutls",
+    "version": "7.74.0-1.3ubuntu2"
+  },
+  {
+    "name": "libcurl4",
+    "version": "7.74.0-1.3ubuntu2"
+  },
+  {
+    "name": "libdaemon0",
+    "version": "0.14-7.1ubuntu2"
+  },
+  {
+    "name": "libdata-dump-perl",
+    "version": "1.23-1.1"
+  },
+  {
+    "name": "libdatrie1",
+    "version": "0.2.13-1ubuntu2"
+  },
+  {
+    "name": "libdb5.3",
+    "version": "5.3.28+dfsg1-0.8ubuntu1"
+  },
+  {
+    "name": "libdbus-1-3",
+    "version": "1.12.20-2ubuntu2"
+  },
+  {
+    "name": "libdbus-glib-1-2",
+    "version": "0.112-1build1"
+  },
+  {
+    "name": "libdbusmenu-glib4",
+    "version": "16.04.1+18.10.20180917-0ubuntu7"
+  },
+  {
+    "name": "libdbusmenu-gtk3-4",
+    "version": "16.04.1+18.10.20180917-0ubuntu7"
+  },
+  {
+    "name": "libdconf1",
+    "version": "0.40.0-1"
+  },
+  {
+    "name": "libdebconfclient0",
+    "version": "0.256ubuntu3"
+  },
+  {
+    "name": "libdebuginfod-common",
+    "version": "0.185-1build1"
+  },
+  {
+    "name": "libdebuginfod1",
+    "version": "0.185-1build1"
+  },
+  {
+    "name": "libdee-1.0-4",
+    "version": "1.2.7+17.10.20170616-6ubuntu2"
+  },
+  {
+    "name": "libdeflate0",
+    "version": "1.7-2ubuntu2"
+  },
+  {
+    "name": "libdevmapper1.02.1",
+    "version": "2:1.02.175-2.1ubuntu3"
+  },
+  {
+    "name": "libdjvulibre-text",
+    "version": "3.5.28-2build1"
+  },
+  {
+    "name": "libdjvulibre21",
+    "version": "3.5.28-2build1"
+  },
+  {
+    "name": "libdns-export1110",
+    "version": "1:9.11.19+dfsg-2.1ubuntu1"
+  },
+  {
+    "name": "libdotconf0",
+    "version": "1.3-0.3fakesync1build1"
+  },
+  {
+    "name": "libdpkg-perl",
+    "version": "1.20.9ubuntu2"
+  },
+  {
+    "name": "libdrm-amdgpu1",
+    "version": "2.4.107-8ubuntu1"
+  },
+  {
+    "name": "libdrm-common",
+    "version": "2.4.107-8ubuntu1"
+  },
+  {
+    "name": "libdrm-intel1",
+    "version": "2.4.107-8ubuntu1"
+  },
+  {
+    "name": "libdrm-nouveau2",
+    "version": "2.4.107-8ubuntu1"
+  },
+  {
+    "name": "libdrm-radeon1",
+    "version": "2.4.107-8ubuntu1"
+  },
+  {
+    "name": "libdrm2",
+    "version": "2.4.107-8ubuntu1"
+  },
+  {
+    "name": "libdv4",
+    "version": "1.0.0-13build1"
+  },
+  {
+    "name": "libdw1",
+    "version": "0.185-1build1"
+  },
+  {
+    "name": "libebackend-1.2-10",
+    "version": "3.40.4-1"
+  },
+  {
+    "name": "libebook-1.2-20",
+    "version": "3.40.4-1"
+  },
+  {
+    "name": "libebook-contacts-1.2-3",
+    "version": "3.40.4-1"
+  },
+  {
+    "name": "libecal-2.0-1",
+    "version": "3.40.4-1"
+  },
+  {
+    "name": "libedata-book-1.2-26",
+    "version": "3.40.4-1"
+  },
+  {
+    "name": "libedata-cal-2.0-1",
+    "version": "3.40.4-1"
+  },
+  {
+    "name": "libedataserver-1.2-26",
+    "version": "3.40.4-1"
+  },
+  {
+    "name": "libedataserverui-1.2-3",
+    "version": "3.40.4-1"
+  },
+  {
+    "name": "libedit2",
+    "version": "3.1-20191231-2build1"
+  },
+  {
+    "name": "libegl-mesa0",
+    "version": "21.2.2-1ubuntu1"
+  },
+  {
+    "name": "libegl1",
+    "version": "1.3.3-1"
+  },
+  {
+    "name": "libelf1",
+    "version": "0.185-1build1"
+  },
+  {
+    "name": "libenchant-2-2",
+    "version": "2.3.1-1"
+  },
+  {
+    "name": "libepoxy0",
+    "version": "1.5.8-1"
+  },
+  {
+    "name": "libespeak-ng1",
+    "version": "1.50+dfsg-7build2"
+  },
+  {
+    "name": "libestr0",
+    "version": "0.1.10-2.1build2"
+  },
+  {
+    "name": "libevdev2",
+    "version": "1.11.0+dfsg-1build1"
+  },
+  {
+    "name": "libevdocument3-4",
+    "version": "40.4-2"
+  },
+  {
+    "name": "libevview3-3",
+    "version": "40.4-2"
+  },
+  {
+    "name": "libexif12",
+    "version": "0.6.22-3"
+  },
+  {
+    "name": "libexiv2-27",
+    "version": "0.27.3-3ubuntu4"
+  },
+  {
+    "name": "libexpat1",
+    "version": "2.4.1-2"
+  },
+  {
+    "name": "libext2fs2",
+    "version": "1.46.3-1ubuntu3"
+  },
+  {
+    "name": "libextutils-depends-perl",
+    "version": "0.8000-1"
+  },
+  {
+    "name": "libextutils-pkgconfig-perl",
+    "version": "1.16-1.1"
+  },
+  {
+    "name": "libfastjson4",
+    "version": "0.99.9-1build1"
+  },
+  {
+    "name": "libfdisk1",
+    "version": "2.36.1-8ubuntu1"
+  },
+  {
+    "name": "libffi8",
+    "version": "3.4.2-1ubuntu5"
+  },
+  {
+    "name": "libfftw3-single3",
+    "version": "3.3.8-2ubuntu7"
+  },
+  {
+    "name": "libfido2-1",
+    "version": "1.6.0-2build1"
+  },
+  {
+    "name": "libfile-basedir-perl",
+    "version": "0.08-1"
+  },
+  {
+    "name": "libfile-fcntllock-perl",
+    "version": "0.22-3build5"
+  },
+  {
+    "name": "libfile-mimeinfo-perl",
+    "version": "0.30-1"
+  },
+  {
+    "name": "libflac8",
+    "version": "1.3.3-2"
+  },
+  {
+    "name": "libflashrom1",
+    "version": "1.2-5"
+  },
+  {
+    "name": "libfontconfig1",
+    "version": "2.13.1-4.2ubuntu3"
+  },
+  {
+    "name": "libfontembed1",
+    "version": "1.28.10-2"
+  },
+  {
+    "name": "libfontenc1",
+    "version": "1:1.1.4-1build2"
+  },
+  {
+    "name": "libfprint-2-2",
+    "version": "1:1.90.7+git20210222+tod1-0ubuntu3"
+  },
+  {
+    "name": "libfreetype6",
+    "version": "2.10.4+dfsg-1build1"
+  },
+  {
+    "name": "libfribidi0",
+    "version": "1.0.8-2ubuntu2"
+  },
+  {
+    "name": "libftdi1-2",
+    "version": "1.5-5build1"
+  },
+  {
+    "name": "libfuse2",
+    "version": "2.9.9-5ubuntu2"
+  },
+  {
+    "name": "libfwupd2",
+    "version": "1.5.11-0ubuntu2"
+  },
+  {
+    "name": "libfwupdplugin1",
+    "version": "1.5.11-0ubuntu2"
+  },
+  {
+    "name": "libgail-common",
+    "version": "2.24.33-2ubuntu1"
+  },
+  {
+    "name": "libgail18",
+    "version": "2.24.33-2ubuntu1"
+  },
+  {
+    "name": "libgamemode0",
+    "version": "1.6.1-1"
+  },
+  {
+    "name": "libgamemodeauto0",
+    "version": "1.6.1-1"
+  },
+  {
+    "name": "libgbm1",
+    "version": "21.2.2-1ubuntu1"
+  },
+  {
+    "name": "libgcab-1.0-0",
+    "version": "1.4-3build1"
+  },
+  {
+    "name": "libgcc-s1",
+    "version": "11.2.0-7ubuntu2"
+  },
+  {
+    "name": "libgck-1-0",
+    "version": "3.40.0-3"
+  },
+  {
+    "name": "libgcr-base-3-1",
+    "version": "3.40.0-3"
+  },
+  {
+    "name": "libgcr-ui-3-1",
+    "version": "3.40.0-3"
+  },
+  {
+    "name": "libgcrypt20",
+    "version": "1.8.7-5ubuntu2"
+  },
+  {
+    "name": "libgd3",
+    "version": "2.3.0-2ubuntu1"
+  },
+  {
+    "name": "libgdata-common",
+    "version": "0.18.1-1build1"
+  },
+  {
+    "name": "libgdata22",
+    "version": "0.18.1-1build1"
+  },
+  {
+    "name": "libgdbm-compat4",
+    "version": "1.19-2"
+  },
+  {
+    "name": "libgdbm6",
+    "version": "1.19-2"
+  },
+  {
+    "name": "libgdk-pixbuf-2.0-0",
+    "version": "2.42.6+dfsg-1build2"
+  },
+  {
+    "name": "libgdk-pixbuf2.0-bin",
+    "version": "2.42.6+dfsg-1build2"
+  },
+  {
+    "name": "libgdk-pixbuf2.0-common",
+    "version": "2.42.6+dfsg-1build2"
+  },
+  {
+    "name": "libgdm1",
+    "version": "41~rc-0ubuntu2"
+  },
+  {
+    "name": "libgee-0.8-2",
+    "version": "0.20.4-1build1"
+  },
+  {
+    "name": "libgeoclue-2-0",
+    "version": "2.5.7-3ubuntu2"
+  },
+  {
+    "name": "libgeocode-glib0",
+    "version": "3.26.2-2build1"
+  },
+  {
+    "name": "libgexiv2-2",
+    "version": "0.12.1-1build1"
+  },
+  {
+    "name": "libgif7",
+    "version": "5.1.9-2build1"
+  },
+  {
+    "name": "libgirepository-1.0-1",
+    "version": "1.68.0-1build2"
+  },
+  {
+    "name": "libgjs0g",
+    "version": "1.68.4-1"
+  },
+  {
+    "name": "libgl1",
+    "version": "1.3.3-1"
+  },
+  {
+    "name": "libgl1-mesa-dri",
+    "version": "21.2.2-1ubuntu1"
+  },
+  {
+    "name": "libglapi-mesa",
+    "version": "21.2.2-1ubuntu1"
+  },
+  {
+    "name": "libgles2",
+    "version": "1.3.3-1"
+  },
+  {
+    "name": "libglib-object-introspection-perl",
+    "version": "0.049-1build1.1"
+  },
+  {
+    "name": "libglib-perl",
+    "version": "3:1.329.3-1build1"
+  },
+  {
+    "name": "libglib2.0-0",
+    "version": "2.68.4-1ubuntu1"
+  },
+  {
+    "name": "libglib2.0-bin",
+    "version": "2.68.4-1ubuntu1"
+  },
+  {
+    "name": "libglib2.0-data",
+    "version": "2.68.4-1ubuntu1"
+  },
+  {
+    "name": "libglibmm-2.4-1v5",
+    "version": "2.64.2-2build1"
+  },
+  {
+    "name": "libglu1-mesa",
+    "version": "9.0.1-1build1"
+  },
+  {
+    "name": "libglvnd0",
+    "version": "1.3.3-1"
+  },
+  {
+    "name": "libglx-mesa0",
+    "version": "21.2.2-1ubuntu1"
+  },
+  {
+    "name": "libglx0",
+    "version": "1.3.3-1"
+  },
+  {
+    "name": "libgmp10",
+    "version": "2:6.2.1+dfsg-1ubuntu2"
+  },
+  {
+    "name": "libgnome-autoar-0-0",
+    "version": "0.4.0-1"
+  },
+  {
+    "name": "libgnome-bluetooth13",
+    "version": "3.34.5-3"
+  },
+  {
+    "name": "libgnome-desktop-3-19",
+    "version": "40.4-2ubuntu1"
+  },
+  {
+    "name": "libgnome-menu-3-0",
+    "version": "3.36.0-1ubuntu1"
+  },
+  {
+    "name": "libgnomekbd-common",
+    "version": "3.26.1-1build1"
+  },
+  {
+    "name": "libgnomekbd8",
+    "version": "3.26.1-1build1"
+  },
+  {
+    "name": "libgnutls30",
+    "version": "3.7.1-5ubuntu1"
+  },
+  {
+    "name": "libgoa-1.0-0b",
+    "version": "3.40.0-1ubuntu1"
+  },
+  {
+    "name": "libgoa-1.0-common",
+    "version": "3.40.0-1ubuntu1"
+  },
+  {
+    "name": "libgoa-backend-1.0-1",
+    "version": "3.40.0-1ubuntu1"
+  },
+  {
+    "name": "libgomp1",
+    "version": "11.2.0-7ubuntu2"
+  },
+  {
+    "name": "libgpg-error0",
+    "version": "1.38-2build1"
+  },
+  {
+    "name": "libgpgme11",
+    "version": "1.14.0-1ubuntu4"
+  },
+  {
+    "name": "libgphoto2-6",
+    "version": "2.5.27-1"
+  },
+  {
+    "name": "libgphoto2-l10n",
+    "version": "2.5.27-1"
+  },
+  {
+    "name": "libgphoto2-port12",
+    "version": "2.5.27-1"
+  },
+  {
+    "name": "libgpm2",
+    "version": "1.20.7-8build1"
+  },
+  {
+    "name": "libgraphene-1.0-0",
+    "version": "1.10.4+dfsg1-1build1"
+  },
+  {
+    "name": "libgraphite2-3",
+    "version": "1.3.14-1"
+  },
+  {
+    "name": "libgs9",
+    "version": "9.54.0~dfsg1-0ubuntu2"
+  },
+  {
+    "name": "libgs9-common",
+    "version": "9.54.0~dfsg1-0ubuntu2"
+  },
+  {
+    "name": "libgsf-1-114",
+    "version": "1.14.47-1build1"
+  },
+  {
+    "name": "libgsf-1-common",
+    "version": "1.14.47-1build1"
+  },
+  {
+    "name": "libgsound0",
+    "version": "1.0.3-2"
+  },
+  {
+    "name": "libgspell-1-2",
+    "version": "1.8.4-1build1"
+  },
+  {
+    "name": "libgspell-1-common",
+    "version": "1.8.4-1build1"
+  },
+  {
+    "name": "libgssapi-krb5-2",
+    "version": "1.18.3-6"
+  },
+  {
+    "name": "libgssdp-1.2-0",
+    "version": "1.2.3-2build1"
+  },
+  {
+    "name": "libgstreamer-gl1.0-0",
+    "version": "1.18.5-1"
+  },
+  {
+    "name": "libgstreamer-plugins-base1.0-0",
+    "version": "1.18.5-1"
+  },
+  {
+    "name": "libgstreamer-plugins-good1.0-0",
+    "version": "1.18.5-1ubuntu2"
+  },
+  {
+    "name": "libgstreamer1.0-0",
+    "version": "1.18.5-1"
+  },
+  {
+    "name": "libgtk-3-0",
+    "version": "3.24.30-1ubuntu1"
+  },
+  {
+    "name": "libgtk-3-bin",
+    "version": "3.24.30-1ubuntu1"
+  },
+  {
+    "name": "libgtk-3-common",
+    "version": "3.24.30-1ubuntu1"
+  },
+  {
+    "name": "libgtk-4-1",
+    "version": "4.4.0+ds1-5"
+  },
+  {
+    "name": "libgtk-4-bin",
+    "version": "4.4.0+ds1-5"
+  },
+  {
+    "name": "libgtk-4-common",
+    "version": "4.4.0+ds1-5"
+  },
+  {
+    "name": "libgtk2.0-0",
+    "version": "2.24.33-2ubuntu1"
+  },
+  {
+    "name": "libgtk2.0-bin",
+    "version": "2.24.33-2ubuntu1"
+  },
+  {
+    "name": "libgtk2.0-common",
+    "version": "2.24.33-2ubuntu1"
+  },
+  {
+    "name": "libgtkmm-3.0-1v5",
+    "version": "3.24.5-1"
+  },
+  {
+    "name": "libgtksourceview-4-0",
+    "version": "4.8.2-1"
+  },
+  {
+    "name": "libgtksourceview-4-common",
+    "version": "4.8.2-1"
+  },
+  {
+    "name": "libgtop-2.0-11",
+    "version": "2.40.0-2build2"
+  },
+  {
+    "name": "libgtop2-common",
+    "version": "2.40.0-2build2"
+  },
+  {
+    "name": "libgudev-1.0-0",
+    "version": "1:237-2"
+  },
+  {
+    "name": "libgupnp-1.2-0",
+    "version": "1.2.7-1"
+  },
+  {
+    "name": "libgupnp-av-1.0-2",
+    "version": "0.12.11-3"
+  },
+  {
+    "name": "libgupnp-dlna-2.0-3",
+    "version": "0.10.5-4build1"
+  },
+  {
+    "name": "libgusb2",
+    "version": "0.3.5-1build1"
+  },
+  {
+    "name": "libgweather-3-16",
+    "version": "40.0-3"
+  },
+  {
+    "name": "libgweather-common",
+    "version": "40.0-3"
+  },
+  {
+    "name": "libgxps2",
+    "version": "0.3.2-1build1"
+  },
+  {
+    "name": "libhandy-1-0",
+    "version": "1.2.3-1"
+  },
+  {
+    "name": "libharfbuzz-icu0",
+    "version": "2.7.4-1ubuntu1"
+  },
+  {
+    "name": "libharfbuzz0b",
+    "version": "2.7.4-1ubuntu1"
+  },
+  {
+    "name": "libhogweed6",
+    "version": "3.7.3-1"
+  },
+  {
+    "name": "libhpmud0",
+    "version": "3.21.6+dfsg0-0ubuntu1"
+  },
+  {
+    "name": "libhtml-parser-perl",
+    "version": "3.76-1"
+  },
+  {
+    "name": "libhttp-daemon-perl",
+    "version": "6.12-1"
+  },
+  {
+    "name": "libhttp-message-perl",
+    "version": "6.29-1"
+  },
+  {
+    "name": "libhunspell-1.7-0",
+    "version": "1.7.0-3"
+  },
+  {
+    "name": "libhyphen0",
+    "version": "2.8.8-7"
+  },
+  {
+    "name": "libibus-1.0-5",
+    "version": "1.5.25-2build1"
+  },
+  {
+    "name": "libical3",
+    "version": "3.0.10-1"
+  },
+  {
+    "name": "libice6",
+    "version": "2:1.0.10-1build1"
+  },
+  {
+    "name": "libicu67",
+    "version": "67.1-7ubuntu1"
+  },
+  {
+    "name": "libidn11",
+    "version": "1.33-3"
+  },
+  {
+    "name": "libidn2-0",
+    "version": "2.3.1-1"
+  },
+  {
+    "name": "libiec61883-0",
+    "version": "1.2.0-4build2"
+  },
+  {
+    "name": "libieee1284-3",
+    "version": "0.2.11-14build1"
+  },
+  {
+    "name": "libijs-0.35",
+    "version": "0.35-15build1"
+  },
+  {
+    "name": "libimagequant0",
+    "version": "2.12.2-1.1build1"
+  },
+  {
+    "name": "libimobiledevice6",
+    "version": "1.3.0-6"
+  },
+  {
+    "name": "libinih1",
+    "version": "53-1ubuntu1"
+  },
+  {
+    "name": "libinput-bin",
+    "version": "1.18.1-1"
+  },
+  {
+    "name": "libinput10",
+    "version": "1.18.1-1"
+  },
+  {
+    "name": "libio-socket-ssl-perl",
+    "version": "2.069-1"
+  },
+  {
+    "name": "libip4tc2",
+    "version": "1.8.7-1ubuntu2"
+  },
+  {
+    "name": "libip6tc2",
+    "version": "1.8.7-1ubuntu2"
+  },
+  {
+    "name": "libipt2",
+    "version": "2.0.3-1build1"
+  },
+  {
+    "name": "libisc-export1105",
+    "version": "1:9.11.19+dfsg-2.1ubuntu1"
+  },
+  {
+    "name": "libisl23",
+    "version": "0.24-1"
+  },
+  {
+    "name": "libiw30",
+    "version": "30~pre9-13.1ubuntu3"
+  },
+  {
+    "name": "libjack-jackd2-0",
+    "version": "1.9.19~dfsg-2ubuntu1"
+  },
+  {
+    "name": "libjansson4",
+    "version": "2.13.1-1.1build1"
+  },
+  {
+    "name": "libjavascriptcoregtk-4.0-18",
+    "version": "2.34.0-1ubuntu1"
+  },
+  {
+    "name": "libjbig0",
+    "version": "2.1-3.1build1"
+  },
+  {
+    "name": "libjbig2dec0",
+    "version": "0.19-3"
+  },
+  {
+    "name": "libjcat1",
+    "version": "0.1.3-2build1"
+  },
+  {
+    "name": "libjpeg-turbo8",
+    "version": "2.0.6-0ubuntu2"
+  },
+  {
+    "name": "libjpeg8",
+    "version": "8c-2ubuntu8"
+  },
+  {
+    "name": "libjson-c5",
+    "version": "0.15-2build2"
+  },
+  {
+    "name": "libjson-glib-1.0-0",
+    "version": "1.6.2-1"
+  },
+  {
+    "name": "libjson-glib-1.0-common",
+    "version": "1.6.2-1"
+  },
+  {
+    "name": "libk5crypto3",
+    "version": "1.18.3-6"
+  },
+  {
+    "name": "libkeyutils1",
+    "version": "1.6.1-2ubuntu1"
+  },
+  {
+    "name": "libklibc",
+    "version": "2.0.8-6.1ubuntu2"
+  },
+  {
+    "name": "libkmod2",
+    "version": "28-1ubuntu4"
+  },
+  {
+    "name": "libkpathsea6",
+    "version": "2020.20200327.54578-7"
+  },
+  {
+    "name": "libkrb5-3",
+    "version": "1.18.3-6"
+  },
+  {
+    "name": "libkrb5support0",
+    "version": "1.18.3-6"
+  },
+  {
+    "name": "libksba8",
+    "version": "1.5.1-1"
+  },
+  {
+    "name": "liblcms2-2",
+    "version": "2.12~rc1-2"
+  },
+  {
+    "name": "liblcms2-utils",
+    "version": "2.12~rc1-2"
+  },
+  {
+    "name": "libldap-2.5-0",
+    "version": "2.5.6+dfsg-1~exp1ubuntu1"
+  },
+  {
+    "name": "libldap-common",
+    "version": "2.5.6+dfsg-1~exp1ubuntu1"
+  },
+  {
+    "name": "libldb2",
+    "version": "2:2.2.0-3.1"
+  },
+  {
+    "name": "libllvm12",
+    "version": "1:12.0.1-8build1"
+  },
+  {
+    "name": "liblmdb0",
+    "version": "0.9.24-1"
+  },
+  {
+    "name": "liblocale-gettext-perl",
+    "version": "1.07-4build1"
+  },
+  {
+    "name": "liblouis-data",
+    "version": "3.18.0-1"
+  },
+  {
+    "name": "liblouis20",
+    "version": "3.18.0-1"
+  },
+  {
+    "name": "liblouisutdml-bin",
+    "version": "2.10.0-1"
+  },
+  {
+    "name": "liblouisutdml-data",
+    "version": "2.10.0-1"
+  },
+  {
+    "name": "liblouisutdml9",
+    "version": "2.10.0-1"
+  },
+  {
+    "name": "libltdl7",
+    "version": "2.4.6-15"
+  },
+  {
+    "name": "liblz4-1",
+    "version": "1.9.3-2"
+  },
+  {
+    "name": "liblzma5",
+    "version": "5.2.5-2"
+  },
+  {
+    "name": "liblzo2-2",
+    "version": "2.10-2build1"
+  },
+  {
+    "name": "libmagic-mgc",
+    "version": "1:5.39-3"
+  },
+  {
+    "name": "libmagic1",
+    "version": "1:5.39-3"
+  },
+  {
+    "name": "libmanette-0.2-0",
+    "version": "0.2.6-2build1"
+  },
+  {
+    "name": "libmaxminddb0",
+    "version": "1.5.2-1"
+  },
+  {
+    "name": "libmbim-glib4",
+    "version": "1.24.8-1"
+  },
+  {
+    "name": "libmbim-proxy",
+    "version": "1.24.8-1"
+  },
+  {
+    "name": "libmd0",
+    "version": "1.0.3-3build1"
+  },
+  {
+    "name": "libmediaart-2.0-0",
+    "version": "1.9.4-3build1"
+  },
+  {
+    "name": "libmm-glib0",
+    "version": "1.16.6-2"
+  },
+  {
+    "name": "libmnl0",
+    "version": "1.0.4-3"
+  },
+  {
+    "name": "libmount1",
+    "version": "2.36.1-8ubuntu1"
+  },
+  {
+    "name": "libmozjs-78-0",
+    "version": "78.13.0-1"
+  },
+  {
+    "name": "libmp3lame0",
+    "version": "3.100-3build1"
+  },
+  {
+    "name": "libmpc3",
+    "version": "1.2.0-1build1"
+  },
+  {
+    "name": "libmpdec3",
+    "version": "2.5.1-2build1"
+  },
+  {
+    "name": "libmpfr6",
+    "version": "4.1.0-3build1"
+  },
+  {
+    "name": "libmpg123-0",
+    "version": "1.28.2-2"
+  },
+  {
+    "name": "libmtdev1",
+    "version": "1.1.6-1build3"
+  },
+  {
+    "name": "libmtp-common",
+    "version": "1.1.18-1"
+  },
+  {
+    "name": "libmtp-runtime",
+    "version": "1.1.18-1"
+  },
+  {
+    "name": "libmtp9",
+    "version": "1.1.18-1"
+  },
+  {
+    "name": "libmutter-8-0",
+    "version": "40.5-1ubuntu2"
+  },
+  {
+    "name": "libnautilus-extension1a",
+    "version": "1:40.2-1ubuntu1"
+  },
+  {
+    "name": "libncurses6",
+    "version": "6.2+20201114-2build1"
+  },
+  {
+    "name": "libncursesw6",
+    "version": "6.2+20201114-2build1"
+  },
+  {
+    "name": "libndp0",
+    "version": "1.8-0ubuntu2"
+  },
+  {
+    "name": "libnet-dbus-perl",
+    "version": "1.2.0-1build1"
+  },
+  {
+    "name": "libnet-http-perl",
+    "version": "6.20-1"
+  },
+  {
+    "name": "libnet-ssleay-perl",
+    "version": "1.88-3ubuntu1"
+  },
+  {
+    "name": "libnetfilter-conntrack3",
+    "version": "1.0.8-3"
+  },
+  {
+    "name": "libnetplan0",
+    "version": "0.103-0ubuntu7"
+  },
+  {
+    "name": "libnettle8",
+    "version": "3.7.3-1"
+  },
+  {
+    "name": "libnewt0.52",
+    "version": "0.52.21-4ubuntu7"
+  },
+  {
+    "name": "libnfnetlink0",
+    "version": "1.0.1-3build1"
+  },
+  {
+    "name": "libnfs13",
+    "version": "4.0.0-1"
+  },
+  {
+    "name": "libnftnl11",
+    "version": "1.1.9-1"
+  },
+  {
+    "name": "libnghttp2-14",
+    "version": "1.43.0-1"
+  },
+  {
+    "name": "libnl-3-200",
+    "version": "3.4.0-1build2"
+  },
+  {
+    "name": "libnl-genl-3-200",
+    "version": "3.4.0-1build2"
+  },
+  {
+    "name": "libnl-route-3-200",
+    "version": "3.4.0-1build2"
+  },
+  {
+    "name": "libnm0",
+    "version": "1.32.12-0ubuntu1"
+  },
+  {
+    "name": "libnma-common",
+    "version": "1.8.32-1"
+  },
+  {
+    "name": "libnma0",
+    "version": "1.8.32-1"
+  },
+  {
+    "name": "libnotify-bin",
+    "version": "0.7.9-3ubuntu3"
+  },
+  {
+    "name": "libnotify4",
+    "version": "0.7.9-3ubuntu3"
+  },
+  {
+    "name": "libnpth0",
+    "version": "1.6-3"
+  },
+  {
+    "name": "libnsl2",
+    "version": "1.3.0-2build1"
+  },
+  {
+    "name": "libnspr4",
+    "version": "2:4.32-1"
+  },
+  {
+    "name": "libnss-mdns",
+    "version": "0.14.1-2build1"
+  },
+  {
+    "name": "libnss-systemd",
+    "version": "248.3-1ubuntu8"
+  },
+  {
+    "name": "libnss3",
+    "version": "2:3.68-1ubuntu1"
+  },
+  {
+    "name": "libntfs-3g883",
+    "version": "1:2017.3.23AR.3-3ubuntu5"
+  },
+  {
+    "name": "libnuma1",
+    "version": "2.0.14-0ubuntu2"
+  },
+  {
+    "name": "libogg0",
+    "version": "1.3.5-0ubuntu1"
+  },
+  {
+    "name": "libopenjp2-7",
+    "version": "2.3.1-1ubuntu5"
+  },
+  {
+    "name": "libopenscap8",
+    "version": "1.2.17-0.1ubuntu5"
+  },
+  {
+    "name": "libopus0",
+    "version": "1.3.1-0.1"
+  },
+  {
+    "name": "liborc-0.4-0",
+    "version": "1:0.4.32-1"
+  },
+  {
+    "name": "libp11-kit0",
+    "version": "0.23.22-1build1"
+  },
+  {
+    "name": "libpackagekit-glib2-18",
+    "version": "1.2.2-2ubuntu3"
+  },
+  {
+    "name": "libpam-cap",
+    "version": "1:2.44-1build1"
+  },
+  {
+    "name": "libpam-fprintd",
+    "version": "1.90.9-1build1"
+  },
+  {
+    "name": "libpam-gnome-keyring",
+    "version": "40.0-1ubuntu1"
+  },
+  {
+    "name": "libpam-modules",
+    "version": "1.3.1-5ubuntu11"
+  },
+  {
+    "name": "libpam-modules-bin",
+    "version": "1.3.1-5ubuntu11"
+  },
+  {
+    "name": "libpam-pwquality",
+    "version": "1.4.4-1"
+  },
+  {
+    "name": "libpam-runtime",
+    "version": "1.3.1-5ubuntu11"
+  },
+  {
+    "name": "libpam-sss",
+    "version": "2.4.1-2ubuntu4"
+  },
+  {
+    "name": "libpam-systemd",
+    "version": "248.3-1ubuntu8"
+  },
+  {
+    "name": "libpam0g",
+    "version": "1.3.1-5ubuntu11"
+  },
+  {
+    "name": "libpango-1.0-0",
+    "version": "1.48.10+ds1-1"
+  },
+  {
+    "name": "libpangocairo-1.0-0",
+    "version": "1.48.10+ds1-1"
+  },
+  {
+    "name": "libpangoft2-1.0-0",
+    "version": "1.48.10+ds1-1"
+  },
+  {
+    "name": "libpangomm-1.4-1v5",
+    "version": "2.46.1-1"
+  },
+  {
+    "name": "libpangoxft-1.0-0",
+    "version": "1.48.10+ds1-1"
+  },
+  {
+    "name": "libpaper-utils",
+    "version": "1.1.28build1"
+  },
+  {
+    "name": "libpaper1",
+    "version": "1.1.28build1"
+  },
+  {
+    "name": "libparted-fs-resize0",
+    "version": "3.4-1"
+  },
+  {
+    "name": "libparted2",
+    "version": "3.4-1"
+  },
+  {
+    "name": "libpcap0.8",
+    "version": "1.10.0-2build1"
+  },
+  {
+    "name": "libpcaudio0",
+    "version": "1.1-6build1"
+  },
+  {
+    "name": "libpci3",
+    "version": "1:3.7.0-5ubuntu2"
+  },
+  {
+    "name": "libpciaccess0",
+    "version": "0.16-1build3"
+  },
+  {
+    "name": "libpcre2-32-0",
+    "version": "10.37-0ubuntu2"
+  },
+  {
+    "name": "libpcre2-8-0",
+    "version": "10.37-0ubuntu2"
+  },
+  {
+    "name": "libpcre3",
+    "version": "2:8.39-13build3"
+  },
+  {
+    "name": "libpcsclite1",
+    "version": "1.9.3-2"
+  },
+  {
+    "name": "libpeas-1.0-0",
+    "version": "1.30.0-3"
+  },
+  {
+    "name": "libpeas-common",
+    "version": "1.30.0-3"
+  },
+  {
+    "name": "libperl5.32",
+    "version": "5.32.1-3ubuntu3"
+  },
+  {
+    "name": "libphonenumber8",
+    "version": "8.12.16-4build2"
+  },
+  {
+    "name": "libpipeline1",
+    "version": "1.5.3-1build1"
+  },
+  {
+    "name": "libpipewire-0.3-0",
+    "version": "0.3.32-1"
+  },
+  {
+    "name": "libpipewire-0.3-common",
+    "version": "0.3.32-1"
+  },
+  {
+    "name": "libpipewire-0.3-modules",
+    "version": "0.3.32-1"
+  },
+  {
+    "name": "libpixman-1-0",
+    "version": "0.40.0-1build2"
+  },
+  {
+    "name": "libpkcs11-helper1",
+    "version": "1.27-1"
+  },
+  {
+    "name": "libplist3",
+    "version": "2.2.0-6build1"
+  },
+  {
+    "name": "libplymouth5",
+    "version": "0.9.5git20210406-0ubuntu2"
+  },
+  {
+    "name": "libpng16-16",
+    "version": "1.6.37-3build4"
+  },
+  {
+    "name": "libpolkit-agent-1-0",
+    "version": "0.105-31"
+  },
+  {
+    "name": "libpolkit-gobject-1-0",
+    "version": "0.105-31"
+  },
+  {
+    "name": "libpoppler-cpp0v5",
+    "version": "21.06.1-1"
+  },
+  {
+    "name": "libpoppler-glib8",
+    "version": "21.06.1-1"
+  },
+  {
+    "name": "libpoppler111",
+    "version": "21.06.1-1"
+  },
+  {
+    "name": "libpopt0",
+    "version": "1.18-2build2"
+  },
+  {
+    "name": "libprocps8",
+    "version": "2:3.3.17-5ubuntu3"
+  },
+  {
+    "name": "libprotobuf23",
+    "version": "3.12.4-1ubuntu3"
+  },
+  {
+    "name": "libproxy1-plugin-gsettings",
+    "version": "0.4.17-1"
+  },
+  {
+    "name": "libproxy1-plugin-networkmanager",
+    "version": "0.4.17-1"
+  },
+  {
+    "name": "libproxy1v5",
+    "version": "0.4.17-1"
+  },
+  {
+    "name": "libpsl5",
+    "version": "0.21.0-1.2"
+  },
+  {
+    "name": "libpulse-mainloop-glib0",
+    "version": "1:15.0+dfsg1-1ubuntu2"
+  },
+  {
+    "name": "libpulse0",
+    "version": "1:15.0+dfsg1-1ubuntu2"
+  },
+  {
+    "name": "libpulsedsp",
+    "version": "1:15.0+dfsg1-1ubuntu2"
+  },
+  {
+    "name": "libpwquality-common",
+    "version": "1.4.4-1"
+  },
+  {
+    "name": "libpwquality1",
+    "version": "1.4.4-1"
+  },
+  {
+    "name": "libpython3-stdlib",
+    "version": "3.9.4-1build1"
+  },
+  {
+    "name": "libpython3.9",
+    "version": "3.9.7-2build1"
+  },
+  {
+    "name": "libpython3.9-minimal",
+    "version": "3.9.7-2build1"
+  },
+  {
+    "name": "libpython3.9-stdlib",
+    "version": "3.9.7-2build1"
+  },
+  {
+    "name": "libqmi-glib5",
+    "version": "1.28.6-1"
+  },
+  {
+    "name": "libqmi-proxy",
+    "version": "1.28.6-1"
+  },
+  {
+    "name": "libqpdf28",
+    "version": "10.3.2-1"
+  },
+  {
+    "name": "libraw1394-11",
+    "version": "2.1.2-2build1"
+  },
+  {
+    "name": "libreadline8",
+    "version": "8.1-2"
+  },
+  {
+    "name": "librest-0.7-0",
+    "version": "0.8.1-1.1build1"
+  },
+  {
+    "name": "librsvg2-2",
+    "version": "2.50.7+dfsg-1"
+  },
+  {
+    "name": "librsvg2-common",
+    "version": "2.50.7+dfsg-1"
+  },
+  {
+    "name": "librtmp1",
+    "version": "2.4+20151223.gitfa8646d.1-2build3"
+  },
+  {
+    "name": "librygel-core-2.6-2",
+    "version": "0.40.1-3ubuntu1"
+  },
+  {
+    "name": "librygel-db-2.6-2",
+    "version": "0.40.1-3ubuntu1"
+  },
+  {
+    "name": "librygel-renderer-2.6-2",
+    "version": "0.40.1-3ubuntu1"
+  },
+  {
+    "name": "librygel-server-2.6-2",
+    "version": "0.40.1-3ubuntu1"
+  },
+  {
+    "name": "libsamplerate0",
+    "version": "0.2.1+ds0-1"
+  },
+  {
+    "name": "libsane-common",
+    "version": "1.0.32-3ubuntu1"
+  },
+  {
+    "name": "libsane-hpaio",
+    "version": "3.21.6+dfsg0-0ubuntu1"
+  },
+  {
+    "name": "libsane1",
+    "version": "1.0.32-3ubuntu1"
+  },
+  {
+    "name": "libsasl2-2",
+    "version": "2.1.27+dfsg-2.1build1"
+  },
+  {
+    "name": "libsasl2-modules",
+    "version": "2.1.27+dfsg-2.1build1"
+  },
+  {
+    "name": "libsasl2-modules-db",
+    "version": "2.1.27+dfsg-2.1build1"
+  },
+  {
+    "name": "libsasl2-modules-gssapi-mit",
+    "version": "2.1.27+dfsg-2.1build1"
+  },
+  {
+    "name": "libsbc1",
+    "version": "1.5-3build1"
+  },
+  {
+    "name": "libseccomp2",
+    "version": "2.5.1-1ubuntu1"
+  },
+  {
+    "name": "libsecret-1-0",
+    "version": "0.20.4-2"
+  },
+  {
+    "name": "libsecret-common",
+    "version": "0.20.4-2"
+  },
+  {
+    "name": "libselinux1",
+    "version": "3.1-3build2"
+  },
+  {
+    "name": "libsemanage-common",
+    "version": "3.1-1ubuntu2"
+  },
+  {
+    "name": "libsemanage1",
+    "version": "3.1-1ubuntu2"
+  },
+  {
+    "name": "libsensors-config",
+    "version": "1:3.6.0-7"
+  },
+  {
+    "name": "libsensors5",
+    "version": "1:3.6.0-7"
+  },
+  {
+    "name": "libsepol1",
+    "version": "3.1-1ubuntu2"
+  },
+  {
+    "name": "libshout3",
+    "version": "2.4.5-1build1"
+  },
+  {
+    "name": "libsigc++-2.0-0v5",
+    "version": "2.10.4-2ubuntu2"
+  },
+  {
+    "name": "libslang2",
+    "version": "2.3.2-5build2"
+  },
+  {
+    "name": "libsm6",
+    "version": "2:1.2.3-1build1"
+  },
+  {
+    "name": "libsmartcols1",
+    "version": "2.36.1-8ubuntu1"
+  },
+  {
+    "name": "libsmbclient",
+    "version": "2:4.13.5+dfsg-2ubuntu2"
+  },
+  {
+    "name": "libsnapd-glib1",
+    "version": "1.58-0ubuntu2"
+  },
+  {
+    "name": "libsndfile1",
+    "version": "1.0.31-2"
+  },
+  {
+    "name": "libsnmp-base",
+    "version": "5.9+dfsg-3ubuntu2"
+  },
+  {
+    "name": "libsnmp40",
+    "version": "5.9+dfsg-3ubuntu2"
+  },
+  {
+    "name": "libsodium23",
+    "version": "1.0.18-1build1"
+  },
+  {
+    "name": "libsonic0",
+    "version": "0.2.0-10"
+  },
+  {
+    "name": "libsoup-gnome2.4-1",
+    "version": "2.72.0-3ubuntu3"
+  },
+  {
+    "name": "libsoup2.4-1",
+    "version": "2.72.0-3ubuntu3"
+  },
+  {
+    "name": "libsource-highlight-common",
+    "version": "3.1.9-3ubuntu1"
+  },
+  {
+    "name": "libsource-highlight4v5",
+    "version": "3.1.9-3ubuntu1"
+  },
+  {
+    "name": "libsoxr0",
+    "version": "0.1.3-4build1"
+  },
+  {
+    "name": "libspa-0.2-modules",
+    "version": "0.3.32-1"
+  },
+  {
+    "name": "libspectre1",
+    "version": "0.2.9-1build1"
+  },
+  {
+    "name": "libspeechd2",
+    "version": "0.10.2-2build1"
+  },
+  {
+    "name": "libspeex1",
+    "version": "1.2~rc1.2-1.1ubuntu1"
+  },
+  {
+    "name": "libspeexdsp1",
+    "version": "1.2~rc1.2-1.1ubuntu1"
+  },
+  {
+    "name": "libsqlite3-0",
+    "version": "3.35.5-1"
+  },
+  {
+    "name": "libss2",
+    "version": "1.46.3-1ubuntu3"
+  },
+  {
+    "name": "libssh-4",
+    "version": "0.9.6-1"
+  },
+  {
+    "name": "libssl1.1",
+    "version": "1.1.1l-1ubuntu1"
+  },
+  {
+    "name": "libstartup-notification0",
+    "version": "0.12-6build1"
+  },
+  {
+    "name": "libstdc++6",
+    "version": "11.2.0-7ubuntu2"
+  },
+  {
+    "name": "libstemmer0d",
+    "version": "2.1.0-1"
+  },
+  {
+    "name": "libsynctex2",
+    "version": "2020.20200327.54578-7"
+  },
+  {
+    "name": "libsysmetrics1",
+    "version": "1.6.5"
+  },
+  {
+    "name": "libsystemd0",
+    "version": "248.3-1ubuntu8"
+  },
+  {
+    "name": "libtag1v5",
+    "version": "1.11.1+dfsg.1-3ubuntu2"
+  },
+  {
+    "name": "libtag1v5-vanilla",
+    "version": "1.11.1+dfsg.1-3ubuntu2"
+  },
+  {
+    "name": "libtalloc2",
+    "version": "2.3.1-2ubuntu2"
+  },
+  {
+    "name": "libtasn1-6",
+    "version": "4.16.0-2"
+  },
+  {
+    "name": "libtcl8.6",
+    "version": "8.6.11+dfsg-1"
+  },
+  {
+    "name": "libtdb1",
+    "version": "1.4.3-1build1"
+  },
+  {
+    "name": "libteamdctl0",
+    "version": "1.31-1build1"
+  },
+  {
+    "name": "libtevent0",
+    "version": "0.10.2-1build1"
+  },
+  {
+    "name": "libtext-charwidth-perl",
+    "version": "0.04-10build1"
+  },
+  {
+    "name": "libtext-iconv-perl",
+    "version": "1.7-7build1"
+  },
+  {
+    "name": "libthai-data",
+    "version": "0.1.28-4.1"
+  },
+  {
+    "name": "libthai0",
+    "version": "0.1.28-4.1"
+  },
+  {
+    "name": "libtheora0",
+    "version": "1.1.1+dfsg.1-15ubuntu2"
+  },
+  {
+    "name": "libtiff5",
+    "version": "4.3.0-1"
+  },
+  {
+    "name": "libtinfo6",
+    "version": "6.2+20201114-2build1"
+  },
+  {
+    "name": "libtirpc-common",
+    "version": "1.3.2-2"
+  },
+  {
+    "name": "libtirpc3",
+    "version": "1.3.2-2"
+  },
+  {
+    "name": "libtotem-plparser-common",
+    "version": "3.26.6-1"
+  },
+  {
+    "name": "libtotem-plparser18",
+    "version": "3.26.6-1"
+  },
+  {
+    "name": "libtracker-sparql-3.0-0",
+    "version": "3.1.2-3"
+  },
+  {
+    "name": "libtry-tiny-perl",
+    "version": "0.30-1"
+  },
+  {
+    "name": "libtss2-esys-3.0.2-0",
+    "version": "3.0.3-2ubuntu1"
+  },
+  {
+    "name": "libtss2-mu0",
+    "version": "3.0.3-2ubuntu1"
+  },
+  {
+    "name": "libtss2-sys1",
+    "version": "3.0.3-2ubuntu1"
+  },
+  {
+    "name": "libtss2-tcti-cmd0",
+    "version": "3.0.3-2ubuntu1"
+  },
+  {
+    "name": "libtss2-tcti-device0",
+    "version": "3.0.3-2ubuntu1"
+  },
+  {
+    "name": "libtss2-tcti-mssim0",
+    "version": "3.0.3-2ubuntu1"
+  },
+  {
+    "name": "libtss2-tcti-swtpm0",
+    "version": "3.0.3-2ubuntu1"
+  },
+  {
+    "name": "libtwolame0",
+    "version": "0.4.0-2build1"
+  },
+  {
+    "name": "libu2f-udev",
+    "version": "1.1.10-3build1"
+  },
+  {
+    "name": "libuchardet0",
+    "version": "0.0.7-1build1"
+  },
+  {
+    "name": "libudev1",
+    "version": "248.3-1ubuntu8"
+  },
+  {
+    "name": "libudisks2-0",
+    "version": "2.9.4-1"
+  },
+  {
+    "name": "libunistring2",
+    "version": "0.9.10-6"
+  },
+  {
+    "name": "libunity-protocol-private0",
+    "version": "7.1.4+19.04.20190319-5"
+  },
+  {
+    "name": "libunity-scopes-json-def-desktop",
+    "version": "7.1.4+19.04.20190319-5"
+  },
+  {
+    "name": "libunity9",
+    "version": "7.1.4+19.04.20190319-5"
+  },
+  {
+    "name": "libunwind8",
+    "version": "1.3.2-2"
+  },
+  {
+    "name": "libupower-glib3",
+    "version": "0.99.11-2build1"
+  },
+  {
+    "name": "liburi-perl",
+    "version": "5.08-1"
+  },
+  {
+    "name": "libusb-1.0-0",
+    "version": "2:1.0.24-3"
+  },
+  {
+    "name": "libusbmuxd6",
+    "version": "2.0.2-3build1"
+  },
+  {
+    "name": "libuuid1",
+    "version": "2.36.1-8ubuntu1"
+  },
+  {
+    "name": "libuv1",
+    "version": "1.40.0-2ubuntu1"
+  },
+  {
+    "name": "libv4l-0",
+    "version": "1.20.0-4"
+  },
+  {
+    "name": "libv4lconvert0",
+    "version": "1.20.0-4"
+  },
+  {
+    "name": "libvisual-0.4-0",
+    "version": "0.4.0-17build1"
+  },
+  {
+    "name": "libvolume-key1",
+    "version": "0.3.12-3.1build2"
+  },
+  {
+    "name": "libvorbis0a",
+    "version": "1.3.7-1"
+  },
+  {
+    "name": "libvorbisenc2",
+    "version": "1.3.7-1"
+  },
+  {
+    "name": "libvorbisfile3",
+    "version": "1.3.7-1"
+  },
+  {
+    "name": "libvpx6",
+    "version": "1.9.0-1ubuntu1"
+  },
+  {
+    "name": "libvte-2.91-0",
+    "version": "0.64.2-1ubuntu1"
+  },
+  {
+    "name": "libvte-2.91-common",
+    "version": "0.64.2-1ubuntu1"
+  },
+  {
+    "name": "libvulkan1",
+    "version": "1.2.162.0-1build1"
+  },
+  {
+    "name": "libwacom-bin",
+    "version": "1.8-2ubuntu2"
+  },
+  {
+    "name": "libwacom-common",
+    "version": "1.8-2ubuntu2"
+  },
+  {
+    "name": "libwacom2",
+    "version": "1.8-2ubuntu2"
+  },
+  {
+    "name": "libwavpack1",
+    "version": "5.4.0-1build1"
+  },
+  {
+    "name": "libwayland-client0",
+    "version": "1.19.0-2build1"
+  },
+  {
+    "name": "libwayland-cursor0",
+    "version": "1.19.0-2build1"
+  },
+  {
+    "name": "libwayland-egl1",
+    "version": "1.19.0-2build1"
+  },
+  {
+    "name": "libwayland-server0",
+    "version": "1.19.0-2build1"
+  },
+  {
+    "name": "libwbclient0",
+    "version": "2:4.13.5+dfsg-2ubuntu2"
+  },
+  {
+    "name": "libwebkit2gtk-4.0-37",
+    "version": "2.34.0-1ubuntu1"
+  },
+  {
+    "name": "libwebp6",
+    "version": "0.6.1-2.1"
+  },
+  {
+    "name": "libwebpdemux2",
+    "version": "0.6.1-2.1"
+  },
+  {
+    "name": "libwebpmux3",
+    "version": "0.6.1-2.1"
+  },
+  {
+    "name": "libwebrtc-audio-processing1",
+    "version": "0.3.1-0ubuntu4"
+  },
+  {
+    "name": "libwhoopsie-preferences0",
+    "version": "22build1"
+  },
+  {
+    "name": "libwhoopsie0",
+    "version": "0.2.76build1"
+  },
+  {
+    "name": "libwmf0.2-7",
+    "version": "0.2.8.4-17ubuntu2"
+  },
+  {
+    "name": "libwmf0.2-7-gtk",
+    "version": "0.2.8.4-17ubuntu2"
+  },
+  {
+    "name": "libwnck-3-0",
+    "version": "40.0-1"
+  },
+  {
+    "name": "libwnck-3-common",
+    "version": "40.0-1"
+  },
+  {
+    "name": "libwoff1",
+    "version": "1.0.2-1build3"
+  },
+  {
+    "name": "libwrap0",
+    "version": "7.6.q-31"
+  },
+  {
+    "name": "libwww-perl",
+    "version": "6.53-1"
+  },
+  {
+    "name": "libx11-6",
+    "version": "2:1.7.2-1"
+  },
+  {
+    "name": "libx11-data",
+    "version": "2:1.7.2-1"
+  },
+  {
+    "name": "libx11-xcb1",
+    "version": "2:1.7.2-1"
+  },
+  {
+    "name": "libxatracker2",
+    "version": "21.2.2-1ubuntu1"
+  },
+  {
+    "name": "libxau6",
+    "version": "1:1.0.9-1build3"
+  },
+  {
+    "name": "libxaw7",
+    "version": "2:1.0.13-1.1"
+  },
+  {
+    "name": "libxcb-dri2-0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-dri3-0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-glx0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-icccm4",
+    "version": "0.4.1-1.1build1"
+  },
+  {
+    "name": "libxcb-image0",
+    "version": "0.4.0-1build2"
+  },
+  {
+    "name": "libxcb-keysyms1",
+    "version": "0.4.0-1build2"
+  },
+  {
+    "name": "libxcb-present0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-randr0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-render-util0",
+    "version": "0.3.9-1build2"
+  },
+  {
+    "name": "libxcb-render0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-res0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-shape0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-shm0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-sync1",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-util1",
+    "version": "0.4.0-1build1"
+  },
+  {
+    "name": "libxcb-xfixes0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-xkb1",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb-xv0",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcb1",
+    "version": "1.14-3ubuntu1"
+  },
+  {
+    "name": "libxcomposite1",
+    "version": "1:0.4.5-1"
+  },
+  {
+    "name": "libxcursor1",
+    "version": "1:1.2.0-2build2"
+  },
+  {
+    "name": "libxdamage1",
+    "version": "1:1.1.5-2"
+  },
+  {
+    "name": "libxdmcp6",
+    "version": "1:1.1.3-0ubuntu4"
+  },
+  {
+    "name": "libxext6",
+    "version": "2:1.3.4-0ubuntu3"
+  },
+  {
+    "name": "libxfixes3",
+    "version": "1:5.0.3-2build1"
+  },
+  {
+    "name": "libxfont2",
+    "version": "1:2.0.4-1build3"
+  },
+  {
+    "name": "libxft2",
+    "version": "2.3.3-0ubuntu4"
+  },
+  {
+    "name": "libxi6",
+    "version": "2:1.7.10-1build2"
+  },
+  {
+    "name": "libxinerama1",
+    "version": "2:1.1.4-2build2"
+  },
+  {
+    "name": "libxkbcommon-x11-0",
+    "version": "1.3.0-1"
+  },
+  {
+    "name": "libxkbcommon0",
+    "version": "1.3.0-1"
+  },
+  {
+    "name": "libxkbfile1",
+    "version": "1:1.1.0-1build1"
+  },
+  {
+    "name": "libxkbregistry0",
+    "version": "1.3.0-1"
+  },
+  {
+    "name": "libxklavier16",
+    "version": "5.4-4build1"
+  },
+  {
+    "name": "libxml-parser-perl",
+    "version": "2.46-2"
+  },
+  {
+    "name": "libxml2",
+    "version": "2.9.12+dfsg-4"
+  },
+  {
+    "name": "libxmlb1",
+    "version": "0.1.15-2ubuntu1"
+  },
+  {
+    "name": "libxmu6",
+    "version": "2:1.1.3-0ubuntu1"
+  },
+  {
+    "name": "libxmuu1",
+    "version": "2:1.1.3-0ubuntu1"
+  },
+  {
+    "name": "libxpm4",
+    "version": "1:3.5.12-1"
+  },
+  {
+    "name": "libxrandr2",
+    "version": "2:1.5.2-0ubuntu1"
+  },
+  {
+    "name": "libxrender1",
+    "version": "1:0.9.10-1build2"
+  },
+  {
+    "name": "libxres1",
+    "version": "2:1.2.0-4build1"
+  },
+  {
+    "name": "libxshmfence1",
+    "version": "1.3-1build3"
+  },
+  {
+    "name": "libxslt1.1",
+    "version": "1.1.34-4"
+  },
+  {
+    "name": "libxss1",
+    "version": "1:1.2.3-1"
+  },
+  {
+    "name": "libxt6",
+    "version": "1:1.2.0-1"
+  },
+  {
+    "name": "libxtables12",
+    "version": "1.8.7-1ubuntu2"
+  },
+  {
+    "name": "libxtst6",
+    "version": "2:1.2.3-1build2"
+  },
+  {
+    "name": "libxv1",
+    "version": "2:1.0.11-1"
+  },
+  {
+    "name": "libxvmc1",
+    "version": "2:1.0.12-2build1"
+  },
+  {
+    "name": "libxxf86dga1",
+    "version": "2:1.1.5-0ubuntu2"
+  },
+  {
+    "name": "libxxf86vm1",
+    "version": "1:1.1.4-1build1"
+  },
+  {
+    "name": "libxxhash0",
+    "version": "0.8.0-2build1"
+  },
+  {
+    "name": "libyaml-0-2",
+    "version": "0.2.2-1"
+  },
+  {
+    "name": "libyelp0",
+    "version": "40.stable-1build1"
+  },
+  {
+    "name": "libzstd1",
+    "version": "1.4.8+dfsg-2.1"
+  },
+  {
+    "name": "linux-firmware",
+    "version": "1.201"
+  },
+  {
+    "name": "linux-generic-hwe-20.04",
+    "version": "5.13.0.19.30"
+  },
+  {
+    "name": "linux-headers-5.13.0-19",
+    "version": "5.13.0-19.19"
+  },
+  {
+    "name": "linux-headers-5.13.0-19-generic",
+    "version": "5.13.0-19.19"
+  },
+  {
+    "name": "linux-headers-generic-hwe-20.04",
+    "version": "5.13.0.19.30"
+  },
+  {
+    "name": "linux-image-5.13.0-19-generic",
+    "version": "5.13.0-19.19"
+  },
+  {
+    "name": "linux-image-generic-hwe-20.04",
+    "version": "5.13.0.19.30"
+  },
+  {
+    "name": "linux-modules-5.13.0-19-generic",
+    "version": "5.13.0-19.19"
+  },
+  {
+    "name": "linux-modules-extra-5.13.0-19-generic",
+    "version": "5.13.0-19.19"
+  },
+  {
+    "name": "locales",
+    "version": "2.34-0ubuntu3"
+  },
+  {
+    "name": "login",
+    "version": "1:4.8.1-1ubuntu9"
+  },
+  {
+    "name": "logrotate",
+    "version": "3.18.0-2ubuntu1"
+  },
+  {
+    "name": "logsave",
+    "version": "1.46.3-1ubuntu3"
+  },
+  {
+    "name": "lsb-base",
+    "version": "11.1.0ubuntu3"
+  },
+  {
+    "name": "lsb-release",
+    "version": "11.1.0ubuntu3"
+  },
+  {
+    "name": "lshw",
+    "version": "02.18.85-0.7ubuntu1"
+  },
+  {
+    "name": "lsof",
+    "version": "4.93.2+dfsg-1.1"
+  },
+  {
+    "name": "ltrace",
+    "version": "0.7.3-6.1ubuntu3"
+  },
+  {
+    "name": "mailcap",
+    "version": "3.69ubuntu1"
+  },
+  {
+    "name": "man-db",
+    "version": "2.9.4-2"
+  },
+  {
+    "name": "mawk",
+    "version": "1.3.4.20200120-2"
+  },
+  {
+    "name": "media-types",
+    "version": "4.0.0"
+  },
+  {
+    "name": "memtest86+",
+    "version": "5.01-3.1ubuntu5"
+  },
+  {
+    "name": "mesa-vulkan-drivers",
+    "version": "21.2.2-1ubuntu1"
+  },
+  {
+    "name": "mobile-broadband-provider-info",
+    "version": "20210805-1"
+  },
+  {
+    "name": "modemmanager",
+    "version": "1.16.6-2"
+  },
+  {
+    "name": "mokutil",
+    "version": "0.4.0-1ubuntu1"
+  },
+  {
+    "name": "more-itertools",
+    "version": "4.2.0"
+  },
+  {
+    "name": "mount",
+    "version": "2.36.1-8ubuntu1"
+  },
+  {
+    "name": "mousetweaks",
+    "version": "3.32.0-3build1"
+  },
+  {
+    "name": "mscompress",
+    "version": "0.4-8build1"
+  },
+  {
+    "name": "mtr-tiny",
+    "version": "0.94-1build1"
+  },
+  {
+    "name": "mutter-common",
+    "version": "40.5-1ubuntu2"
+  },
+  {
+    "name": "nano",
+    "version": "5.6.1-1build1"
+  },
+  {
+    "name": "nautilus",
+    "version": "1:40.2-1ubuntu1"
+  },
+  {
+    "name": "nautilus-data",
+    "version": "1:40.2-1ubuntu1"
+  },
+  {
+    "name": "nautilus-extension-gnome-terminal",
+    "version": "3.38.1-1ubuntu2"
+  },
+  {
+    "name": "nautilus-sendto",
+    "version": "3.8.6-3.1build1"
+  },
+  {
+    "name": "nautilus-share",
+    "version": "0.7.3-2ubuntu4"
+  },
+  {
+    "name": "ncurses-base",
+    "version": "6.2+20201114-2build1"
+  },
+  {
+    "name": "ncurses-bin",
+    "version": "6.2+20201114-2build1"
+  },
+  {
+    "name": "netcat-openbsd",
+    "version": "1.217-3ubuntu1"
+  },
+  {
+    "name": "netifaces",
+    "version": "0.10.9"
+  },
+  {
+    "name": "netplan.io",
+    "version": "0.103-0ubuntu7"
+  },
+  {
+    "name": "network-manager",
+    "version": "1.32.12-0ubuntu1"
+  },
+  {
+    "name": "network-manager-config-connectivity-ubuntu",
+    "version": "1.32.12-0ubuntu1"
+  },
+  {
+    "name": "network-manager-gnome",
+    "version": "1.24.0-1ubuntu1"
+  },
+  {
+    "name": "network-manager-openvpn",
+    "version": "1.8.14-1"
+  },
+  {
+    "name": "network-manager-openvpn-gnome",
+    "version": "1.8.14-1"
+  },
+  {
+    "name": "network-manager-pptp",
+    "version": "1.2.8-3build1"
+  },
+  {
+    "name": "network-manager-pptp-gnome",
+    "version": "1.2.8-3build1"
+  },
+  {
+    "name": "ntfs-3g",
+    "version": "1:2017.3.23AR.3-3ubuntu5"
+  },
+  {
+    "name": "oauthlib",
+    "version": "3.1.0"
+  },
+  {
+    "name": "openprinting-ppds",
+    "version": "20210824-1"
+  },
+  {
+    "name": "openssh-client",
+    "version": "1:8.4p1-6ubuntu2"
+  },
+  {
+    "name": "openssl",
+    "version": "1.1.1l-1ubuntu1"
+  },
+  {
+    "name": "openvpn",
+    "version": "2.5.1-3ubuntu1"
+  },
+  {
+    "name": "orca",
+    "version": "40.0-1ubuntu1"
+  },
+  {
+    "name": "os-prober",
+    "version": "1.79ubuntu1"
+  },
+  {
+    "name": "p11-kit",
+    "version": "0.23.22-1build1"
+  },
+  {
+    "name": "p11-kit-modules",
+    "version": "0.23.22-1build1"
+  },
+  {
+    "name": "packagekit",
+    "version": "1.2.2-2ubuntu3"
+  },
+  {
+    "name": "packagekit-tools",
+    "version": "1.2.2-2ubuntu3"
+  },
+  {
+    "name": "parted",
+    "version": "3.4-1"
+  },
+  {
+    "name": "passwd",
+    "version": "1:4.8.1-1ubuntu9"
+  },
+  {
+    "name": "patch",
+    "version": "2.7.6-7"
+  },
+  {
+    "name": "pci.ids",
+    "version": "0.0~2021.08.22-1"
+  },
+  {
+    "name": "pciutils",
+    "version": "1:3.7.0-5ubuntu2"
+  },
+  {
+    "name": "pcmciautils",
+    "version": "018-13"
+  },
+  {
+    "name": "perl",
+    "version": "5.32.1-3ubuntu3"
+  },
+  {
+    "name": "perl-base",
+    "version": "5.32.1-3ubuntu3"
+  },
+  {
+    "name": "perl-modules-5.32",
+    "version": "5.32.1-3ubuntu3"
+  },
+  {
+    "name": "perl-openssl-defaults",
+    "version": "5"
+  },
+  {
+    "name": "pinentry-curses",
+    "version": "1.1.1-1"
+  },
+  {
+    "name": "pinentry-gnome3",
+    "version": "1.1.1-1"
+  },
+  {
+    "name": "pipewire",
+    "version": "0.3.32-1"
+  },
+  {
+    "name": "pipewire-bin",
+    "version": "0.3.32-1"
+  },
+  {
+    "name": "pipewire-media-session",
+    "version": "0.3.32-1"
+  },
+  {
+    "name": "pkg-config",
+    "version": "0.29.2-1ubuntu1"
+  },
+  {
+    "name": "plymouth",
+    "version": "0.9.5git20210406-0ubuntu2"
+  },
+  {
+    "name": "plymouth-label",
+    "version": "0.9.5git20210406-0ubuntu2"
+  },
+  {
+    "name": "plymouth-theme-spinner",
+    "version": "0.9.5git20210406-0ubuntu2"
+  },
+  {
+    "name": "plymouth-theme-ubuntu-text",
+    "version": "0.9.5git20210406-0ubuntu2"
+  },
+  {
+    "name": "policykit-1",
+    "version": "0.105-31"
+  },
+  {
+    "name": "poppler-utils",
+    "version": "21.06.1-1"
+  },
+  {
+    "name": "power-profiles-daemon",
+    "version": "0.8.1-1"
+  },
+  {
+    "name": "ppp",
+    "version": "2.4.9-1+1ubuntu1"
+  },
+  {
+    "name": "pptp-linux",
+    "version": "1.10.0-1build2"
+  },
+  {
+    "name": "printer-driver-brlaser",
+    "version": "6-2"
+  },
+  {
+    "name": "printer-driver-c2esp",
+    "version": "27-10"
+  },
+  {
+    "name": "printer-driver-foo2zjs",
+    "version": "20200505dfsg0-2ubuntu1"
+  },
+  {
+    "name": "printer-driver-foo2zjs-common",
+    "version": "20200505dfsg0-2ubuntu1"
+  },
+  {
+    "name": "printer-driver-hpcups",
+    "version": "3.21.6+dfsg0-0ubuntu1"
+  },
+  {
+    "name": "printer-driver-m2300w",
+    "version": "0.51-15"
+  },
+  {
+    "name": "printer-driver-min12xxw",
+    "version": "0.0.9-11build1"
+  },
+  {
+    "name": "printer-driver-pnm2ppa",
+    "version": "1.13+nondbs-0ubuntu8"
+  },
+  {
+    "name": "printer-driver-postscript-hp",
+    "version": "3.21.6+dfsg0-0ubuntu1"
+  },
+  {
+    "name": "printer-driver-ptouch",
+    "version": "1.6-2"
+  },
+  {
+    "name": "printer-driver-pxljr",
+    "version": "1.4+repack0-6"
+  },
+  {
+    "name": "printer-driver-splix",
+    "version": "2.0.0+svn315-7fakesync1build2"
+  },
+  {
+    "name": "procps",
+    "version": "2:3.3.17-5ubuntu3"
+  },
+  {
+    "name": "psmisc",
+    "version": "23.4-2build1"
+  },
+  {
+    "name": "publicsuffix",
+    "version": "20210108.1309-1"
+  },
+  {
+    "name": "pulseaudio",
+    "version": "1:15.0+dfsg1-1ubuntu2"
+  },
+  {
+    "name": "pulseaudio-module-bluetooth",
+    "version": "1:15.0+dfsg1-1ubuntu2"
+  },
+  {
+    "name": "pulseaudio-utils",
+    "version": "1:15.0+dfsg1-1ubuntu2"
+  },
+  {
+    "name": "python-apt",
+    "version": "2.2.1"
+  },
+  {
+    "name": "python-apt-common",
+    "version": "2.2.1"
+  },
+  {
+    "name": "python-debian",
+    "version": "0.1.39ubuntu1"
+  },
+  {
+    "name": "python3",
+    "version": "3.9.4-1build1"
+  },
+  {
+    "name": "python3-apport",
+    "version": "2.20.11-0ubuntu70"
+  },
+  {
+    "name": "python3-apt",
+    "version": "2.2.1"
+  },
+  {
+    "name": "python3-aptdaemon",
+    "version": "1.1.1+bzr982-0ubuntu36"
+  },
+  {
+    "name": "python3-aptdaemon.gtk3widgets",
+    "version": "1.1.1+bzr982-0ubuntu36"
+  },
+  {
+    "name": "python3-blinker",
+    "version": "1.4+dfsg1-0.3ubuntu2"
+  },
+  {
+    "name": "python3-brlapi",
+    "version": "6.3+dfsg-1ubuntu2"
+  },
+  {
+    "name": "python3-cairo",
+    "version": "1.16.2-4build2"
+  },
+  {
+    "name": "python3-cffi-backend",
+    "version": "1.14.6-1build1"
+  },
+  {
+    "name": "python3-click",
+    "version": "7.1.2-1"
+  },
+  {
+    "name": "python3-commandnotfound",
+    "version": "21.10.0"
+  },
+  {
+    "name": "python3-cryptography",
+    "version": "3.3.2-1"
+  },
+  {
+    "name": "python3-cups",
+    "version": "2.0.1-4build1"
+  },
+  {
+    "name": "python3-cupshelpers",
+    "version": "1.5.15-0ubuntu2"
+  },
+  {
+    "name": "python3-dbus",
+    "version": "1.2.16-5"
+  },
+  {
+    "name": "python3-debconf",
+    "version": "1.5.77"
+  },
+  {
+    "name": "python3-debian",
+    "version": "0.1.39ubuntu1"
+  },
+  {
+    "name": "python3-defer",
+    "version": "1.0.6-2.1"
+  },
+  {
+    "name": "python3-distro",
+    "version": "1.5.0-1"
+  },
+  {
+    "name": "python3-distro-info",
+    "version": "1.0"
+  },
+  {
+    "name": "python3-distupgrade",
+    "version": "1:21.10.8"
+  },
+  {
+    "name": "python3-gdbm",
+    "version": "3.9.7-1"
+  },
+  {
+    "name": "python3-gi",
+    "version": "3.40.1-1build1"
+  },
+  {
+    "name": "python3-gi-cairo",
+    "version": "3.40.1-1build1"
+  },
+  {
+    "name": "python3-httplib2",
+    "version": "0.18.1-3ubuntu1"
+  },
+  {
+    "name": "python3-ibus-1.0",
+    "version": "1.5.25-2build1"
+  },
+  {
+    "name": "python3-idna",
+    "version": "2.10-1"
+  },
+  {
+    "name": "python3-importlib-metadata",
+    "version": "4.0.1-1"
+  },
+  {
+    "name": "python3-jeepney",
+    "version": "0.7.1-1"
+  },
+  {
+    "name": "python3-jwt",
+    "version": "1.7.1-2ubuntu2"
+  },
+  {
+    "name": "python3-keyring",
+    "version": "23.0.1-1"
+  },
+  {
+    "name": "python3-launchpadlib",
+    "version": "1.10.13-1"
+  },
+  {
+    "name": "python3-lazr.restfulclient",
+    "version": "0.14.2-2build1"
+  },
+  {
+    "name": "python3-lazr.uri",
+    "version": "1.0.5-1"
+  },
+  {
+    "name": "python3-ldb",
+    "version": "2:2.2.0-3.1"
+  },
+  {
+    "name": "python3-louis",
+    "version": "3.18.0-1"
+  },
+  {
+    "name": "python3-macaroonbakery",
+    "version": "1.3.1-1"
+  },
+  {
+    "name": "python3-minimal",
+    "version": "3.9.4-1build1"
+  },
+  {
+    "name": "python3-more-itertools",
+    "version": "4.2.0-3"
+  },
+  {
+    "name": "python3-nacl",
+    "version": "1.4.0-1build1"
+  },
+  {
+    "name": "python3-netifaces",
+    "version": "0.10.9-0.2"
+  },
+  {
+    "name": "python3-oauthlib",
+    "version": "3.1.0-2"
+  },
+  {
+    "name": "python3-pil",
+    "version": "8.1.2+dfsg-0.3"
+  },
+  {
+    "name": "python3-pkg-resources",
+    "version": "52.0.0-4"
+  },
+  {
+    "name": "python3-problem-report",
+    "version": "2.20.11-0ubuntu70"
+  },
+  {
+    "name": "python3-protobuf",
+    "version": "3.12.4-1ubuntu3"
+  },
+  {
+    "name": "python3-ptyprocess",
+    "version": "0.7.0-1"
+  },
+  {
+    "name": "python3-pyatspi",
+    "version": "2.38.1-1"
+  },
+  {
+    "name": "python3-renderpm",
+    "version": "3.5.66-1"
+  },
+  {
+    "name": "python3-reportlab",
+    "version": "3.5.66-1"
+  },
+  {
+    "name": "python3-reportlab-accel",
+    "version": "3.5.66-1"
+  },
+  {
+    "name": "python3-rfc3339",
+    "version": "1.1-2"
+  },
+  {
+    "name": "python3-simplejson",
+    "version": "3.17.2-1"
+  },
+  {
+    "name": "python3-six",
+    "version": "1.16.0-2"
+  },
+  {
+    "name": "python3-software-properties",
+    "version": "0.99.13"
+  },
+  {
+    "name": "python3-speechd",
+    "version": "0.10.2-2build1"
+  },
+  {
+    "name": "python3-systemd",
+    "version": "234-3build4"
+  },
+  {
+    "name": "python3-talloc",
+    "version": "2.3.1-2ubuntu2"
+  },
+  {
+    "name": "python3-tz",
+    "version": "2021.1-1"
+  },
+  {
+    "name": "python3-update-manager",
+    "version": "1:21.10.4"
+  },
+  {
+    "name": "python3-wadllib",
+    "version": "1.3.5-1"
+  },
+  {
+    "name": "python3-xkit",
+    "version": "0.5.0ubuntu4"
+  },
+  {
+    "name": "python3-yaml",
+    "version": "5.3.1-5"
+  },
+  {
+    "name": "python3.9",
+    "version": "3.9.7-2build1"
+  },
+  {
+    "name": "python3.9-minimal",
+    "version": "3.9.7-2build1"
+  },
+  {
+    "name": "pytz",
+    "version": "2021.1"
+  },
+  {
+    "name": "readline-common",
+    "version": "8.1-2"
+  },
+  {
+    "name": "reportlab",
+    "version": "3.5.66"
+  },
+  {
+    "name": "rfkill",
+    "version": "2.36.1-8ubuntu1"
+  },
+  {
+    "name": "rsync",
+    "version": "3.2.3-4ubuntu1"
+  },
+  {
+    "name": "rsyslog",
+    "version": "8.2102.0-2ubuntu2"
+  },
+  {
+    "name": "rtkit",
+    "version": "0.13-4"
+  },
+  {
+    "name": "rygel",
+    "version": "0.40.1-3ubuntu1"
+  },
+  {
+    "name": "samba-libs",
+    "version": "2:4.13.5+dfsg-2ubuntu2"
+  },
+  {
+    "name": "sane-airscan",
+    "version": "0.99.26-2ubuntu1"
+  },
+  {
+    "name": "sane-utils",
+    "version": "1.0.32-3ubuntu1"
+  },
+  {
+    "name": "sbsigntool",
+    "version": "0.9.4-2ubuntu1"
+  },
+  {
+    "name": "seahorse",
+    "version": "40.0-2"
+  },
+  {
+    "name": "sed",
+    "version": "4.7-1ubuntu1"
+  },
+  {
+    "name": "sensible-utils",
+    "version": "0.0.14"
+  },
+  {
+    "name": "session-migration",
+    "version": "0.3.5build1"
+  },
+  {
+    "name": "shared-mime-info",
+    "version": "2.1-1"
+  },
+  {
+    "name": "snapd",
+    "version": "2.53+21.10ubuntu1"
+  },
+  {
+    "name": "software-properties-common",
+    "version": "0.99.13"
+  },
+  {
+    "name": "software-properties-gtk",
+    "version": "0.99.13"
+  },
+  {
+    "name": "sound-icons",
+    "version": "0.1-7"
+  },
+  {
+    "name": "speech-dispatcher",
+    "version": "0.10.2-2build1"
+  },
+  {
+    "name": "speech-dispatcher-audio-plugins",
+    "version": "0.10.2-2build1"
+  },
+  {
+    "name": "speech-dispatcher-espeak-ng",
+    "version": "0.10.2-2build1"
+  },
+  {
+    "name": "spice-vdagent",
+    "version": "0.20.0-2build1"
+  },
+  {
+    "name": "squashfs-tools",
+    "version": "1:4.4-2ubuntu2"
+  },
+  {
+    "name": "ssl-cert",
+    "version": "1.1.0+nmu1"
+  },
+  {
+    "name": "strace",
+    "version": "5.13-0ubuntu1"
+  },
+  {
+    "name": "sudo",
+    "version": "1.9.5p2-3ubuntu2"
+  },
+  {
+    "name": "switcheroo-control",
+    "version": "2.4-3build1"
+  },
+  {
+    "name": "system-config-printer",
+    "version": "1.5.15-0ubuntu2"
+  },
+  {
+    "name": "system-config-printer-common",
+    "version": "1.5.15-0ubuntu2"
+  },
+  {
+    "name": "system-config-printer-udev",
+    "version": "1.5.15-0ubuntu2"
+  },
+  {
+    "name": "systemd",
+    "version": "248.3-1ubuntu8"
+  },
+  {
+    "name": "systemd-sysv",
+    "version": "248.3-1ubuntu8"
+  },
+  {
+    "name": "systemd-timesyncd",
+    "version": "248.3-1ubuntu8"
+  },
+  {
+    "name": "sysvinit-utils",
+    "version": "2.96-7ubuntu1"
+  },
+  {
+    "name": "tar",
+    "version": "1.34+dfsg-1build1"
+  },
+  {
+    "name": "tcl",
+    "version": "8.6.11+1build1"
+  },
+  {
+    "name": "tcl8.6",
+    "version": "8.6.11+dfsg-1"
+  },
+  {
+    "name": "tcpdump",
+    "version": "4.99.0-2"
+  },
+  {
+    "name": "telnet",
+    "version": "0.17-42"
+  },
+  {
+    "name": "thermald",
+    "version": "2.4.6-3"
+  },
+  {
+    "name": "time",
+    "version": "1.9-0.1"
+  },
+  {
+    "name": "tpm-udev",
+    "version": "0.5"
+  },
+  {
+    "name": "tracker",
+    "version": "3.1.2-3"
+  },
+  {
+    "name": "tracker-extract",
+    "version": "3.1.3-1"
+  },
+  {
+    "name": "tracker-miner-fs",
+    "version": "3.1.3-1"
+  },
+  {
+    "name": "tzdata",
+    "version": "2021a-2ubuntu1"
+  },
+  {
+    "name": "ubuntu-advantage-tools",
+    "version": "27.2"
+  },
+  {
+    "name": "ubuntu-advantage-tools",
+    "version": "27.2.2~21.10.1"
+  },
+  {
+    "name": "ubuntu-desktop",
+    "version": "1.472"
+  },
+  {
+    "name": "ubuntu-desktop-minimal",
+    "version": "1.472"
+  },
+  {
+    "name": "ubuntu-docs",
+    "version": "21.10.3"
+  },
+  {
+    "name": "ubuntu-drivers-common",
+    "version": "1:0.9.2.2"
+  },
+  {
+    "name": "ubuntu-minimal",
+    "version": "1.472"
+  },
+  {
+    "name": "ubuntu-mono",
+    "version": "20.10-0ubuntu1"
+  },
+  {
+    "name": "ubuntu-release-upgrader-core",
+    "version": "1:21.10.8"
+  },
+  {
+    "name": "ubuntu-release-upgrader-gtk",
+    "version": "1:21.10.8"
+  },
+  {
+    "name": "ubuntu-report",
+    "version": "1.6.5"
+  },
+  {
+    "name": "ubuntu-session",
+    "version": "40.1.1-1ubuntu1"
+  },
+  {
+    "name": "ubuntu-settings",
+    "version": "21.10.4"
+  },
+  {
+    "name": "ubuntu-standard",
+    "version": "1.472"
+  },
+  {
+    "name": "ubuntu-wallpapers",
+    "version": "21.10.1-0ubuntu1"
+  },
+  {
+    "name": "ubuntu-wallpapers-impish",
+    "version": "21.10.1-0ubuntu1"
+  },
+  {
+    "name": "udev",
+    "version": "248.3-1ubuntu8"
+  },
+  {
+    "name": "udisks2",
+    "version": "2.9.4-1"
+  },
+  {
+    "name": "ufw",
+    "version": "0.36.1-1"
+  },
+  {
+    "name": "unattended-upgrades",
+    "version": "2.8"
+  },
+  {
+    "name": "unzip",
+    "version": "6.0-26ubuntu1"
+  },
+  {
+    "name": "update-manager",
+    "version": "1:21.10.4"
+  },
+  {
+    "name": "update-manager-core",
+    "version": "1:21.10.4"
+  },
+  {
+    "name": "update-notifier",
+    "version": "3.192.45"
+  },
+  {
+    "name": "update-notifier-common",
+    "version": "3.192.45"
+  },
+  {
+    "name": "upower",
+    "version": "0.99.11-2build1"
+  },
+  {
+    "name": "usb-modeswitch",
+    "version": "2.6.1-1ubuntu4"
+  },
+  {
+    "name": "usb-modeswitch-data",
+    "version": "20191128-3"
+  },
+  {
+    "name": "usb.ids",
+    "version": "2021.07.19-1"
+  },
+  {
+    "name": "usbmuxd",
+    "version": "1.1.1-2build1"
+  },
+  {
+    "name": "usbutils",
+    "version": "1:013-3build1"
+  },
+  {
+    "name": "usrmerge",
+    "version": "25ubuntu1"
+  },
+  {
+    "name": "util-linux",
+    "version": "2.36.1-8ubuntu1"
+  },
+  {
+    "name": "uuid-runtime",
+    "version": "2.36.1-8ubuntu1"
+  },
+  {
+    "name": "vim-common",
+    "version": "2:8.2.2434-3ubuntu3"
+  },
+  {
+    "name": "vim-tiny",
+    "version": "2:8.2.2434-3ubuntu3"
+  },
+  {
+    "name": "wadllib",
+    "version": "1.3.5"
+  },
+  {
+    "name": "wamerican",
+    "version": "2019.10.06-1"
+  },
+  {
+    "name": "wbritish",
+    "version": "2019.10.06-1"
+  },
+  {
+    "name": "wget",
+    "version": "1.21-1ubuntu3"
+  },
+  {
+    "name": "whiptail",
+    "version": "0.52.21-4ubuntu7"
+  },
+  {
+    "name": "whoopsie",
+    "version": "0.2.76build1"
+  },
+  {
+    "name": "whoopsie-preferences",
+    "version": "22build1"
+  },
+  {
+    "name": "wireless-tools",
+    "version": "30~pre9-13.1ubuntu3"
+  },
+  {
+    "name": "wpasupplicant",
+    "version": "2:2.9.0-21build1"
+  },
+  {
+    "name": "x11-apps",
+    "version": "7.7+8"
+  },
+  {
+    "name": "x11-common",
+    "version": "1:7.7+22ubuntu2"
+  },
+  {
+    "name": "x11-session-utils",
+    "version": "7.7+4build1"
+  },
+  {
+    "name": "x11-utils",
+    "version": "7.7+5build1"
+  },
+  {
+    "name": "x11-xkb-utils",
+    "version": "7.7+5build3"
+  },
+  {
+    "name": "x11-xserver-utils",
+    "version": "7.7+8build1"
+  },
+  {
+    "name": "xauth",
+    "version": "1:1.1-1"
+  },
+  {
+    "name": "xbitmaps",
+    "version": "1.1.1-2.1"
+  },
+  {
+    "name": "xbrlapi",
+    "version": "6.3+dfsg-1ubuntu2"
+  },
+  {
+    "name": "xdg-dbus-proxy",
+    "version": "0.1.2-2build1"
+  },
+  {
+    "name": "xdg-desktop-portal",
+    "version": "1.8.1-1build1"
+  },
+  {
+    "name": "xdg-desktop-portal-gtk",
+    "version": "1.8.0-1build1"
+  },
+  {
+    "name": "xdg-user-dirs",
+    "version": "0.17-2ubuntu3"
+  },
+  {
+    "name": "xdg-user-dirs-gtk",
+    "version": "0.10-3build1"
+  },
+  {
+    "name": "xdg-utils",
+    "version": "1.1.3-2ubuntu2"
+  },
+  {
+    "name": "xfonts-encodings",
+    "version": "1:1.0.5-0ubuntu1"
+  },
+  {
+    "name": "xfonts-scalable",
+    "version": "1:1.0.3-1.2"
+  },
+  {
+    "name": "xfonts-utils",
+    "version": "1:7.7+6build1"
+  },
+  {
+    "name": "xinit",
+    "version": "1.4.1-0ubuntu3"
+  },
+  {
+    "name": "xinput",
+    "version": "1.6.3-1build1"
+  },
+  {
+    "name": "xkb-data",
+    "version": "2.29-2build1"
+  },
+  {
+    "name": "xorg",
+    "version": "1:7.7+22ubuntu2"
+  },
+  {
+    "name": "xserver-common",
+    "version": "2:1.20.13-1ubuntu1"
+  },
+  {
+    "name": "xserver-xephyr",
+    "version": "2:1.20.13-1ubuntu1"
+  },
+  {
+    "name": "xserver-xorg",
+    "version": "1:7.7+22ubuntu2"
+  },
+  {
+    "name": "xserver-xorg-core",
+    "version": "2:1.20.13-1ubuntu1"
+  },
+  {
+    "name": "xserver-xorg-input-all",
+    "version": "1:7.7+22ubuntu2"
+  },
+  {
+    "name": "xserver-xorg-input-libinput",
+    "version": "1.1.0-1"
+  },
+  {
+    "name": "xserver-xorg-input-wacom",
+    "version": "1:0.39.0-0ubuntu2"
+  },
+  {
+    "name": "xserver-xorg-legacy",
+    "version": "2:1.20.13-1ubuntu1"
+  },
+  {
+    "name": "xserver-xorg-video-all",
+    "version": "1:7.7+22ubuntu2"
+  },
+  {
+    "name": "xserver-xorg-video-amdgpu",
+    "version": "21.0.0-1"
+  },
+  {
+    "name": "xserver-xorg-video-ati",
+    "version": "1:19.1.0-2build1"
+  },
+  {
+    "name": "xserver-xorg-video-fbdev",
+    "version": "1:0.5.0-1ubuntu3"
+  },
+  {
+    "name": "xserver-xorg-video-intel",
+    "version": "2:2.99.917+git20200714-1ubuntu2"
+  },
+  {
+    "name": "xserver-xorg-video-nouveau",
+    "version": "1:1.0.17-1build1"
+  },
+  {
+    "name": "xserver-xorg-video-qxl",
+    "version": "0.1.5+git20200331-1build1"
+  },
+  {
+    "name": "xserver-xorg-video-radeon",
+    "version": "1:19.1.0-2build1"
+  },
+  {
+    "name": "xserver-xorg-video-vesa",
+    "version": "1:2.5.0-1build2"
+  },
+  {
+    "name": "xserver-xorg-video-vmware",
+    "version": "1:13.3.0-3"
+  },
+  {
+    "name": "xwayland",
+    "version": "2:21.1.2-0ubuntu1"
+  },
+  {
+    "name": "xxd",
+    "version": "2:8.2.2434-3ubuntu3"
+  },
+  {
+    "name": "xz-utils",
+    "version": "5.2.5-2"
+  },
+  {
+    "name": "yaru-theme-gnome-shell",
+    "version": "21.10.2"
+  },
+  {
+    "name": "yaru-theme-gtk",
+    "version": "21.10.2"
+  },
+  {
+    "name": "yaru-theme-icon",
+    "version": "21.10.2"
+  },
+  {
+    "name": "yaru-theme-sound",
+    "version": "21.10.2"
+  },
+  {
+    "name": "yelp",
+    "version": "40.stable-1build1"
+  },
+  {
+    "name": "yelp-xsl",
+    "version": "40.2-2"
+  },
+  {
+    "name": "zenity",
+    "version": "3.32.0-7build1"
+  },
+  {
+    "name": "zenity-common",
+    "version": "3.32.0-7build1"
+  },
+  {
+    "name": "zip",
+    "version": "3.0-12build1"
+  },
+  {
+    "name": "zlib1g",
+    "version": "1:1.2.11.dfsg-2ubuntu7"
+  },
+  {
+    "name": "zstd",
+    "version": "1.4.8+dfsg-2.1"
+  }
+]

--- a/cmd/osquery-perf/ubuntu_22.04.tmpl
+++ b/cmd/osquery-perf/ubuntu_22.04.tmpl
@@ -1,0 +1,364 @@
+{{ define "enroll" -}}
+{
+    "enroll_secret": "{{ .EnrollSecret  }}",
+    "host_details": {
+        "os_version": {
+            "build": "",
+            "major": "",
+            "minor": "",
+            "name": "Ubuntu 22.4.0",
+            "patch": "",
+            "platform": "ubuntu",
+            "platform_like": "ubuntu",
+            "version": "Ubuntu 22.4.0"
+        },
+        "osquery_info": {
+            "build_distro": "22.4.0",
+            "build_platform": "linux",
+            "config_hash": "",
+            "config_valid": "0",
+            "extensions": "inactive",
+            "instance_id": "{{ .UUID }}",
+            "pid": "12947",
+            "platform_mask": "21",
+            "start_time": "1580931224",
+            "uuid": "{{ .UUID }}",
+            "version": "4.6.0",
+            "watcher": "12946"
+        },
+        "platform_info": {
+            "address": "0xff990000",
+            "date": "12/16/2019 ",
+            "extra": "MBP114; 196.0.0.0.0; root@xapp160; Mon Dec 16 15:55:18 PST 2019; 196 (B&I); F000_B00; Official Build, Release; Apple LLVM version 5.0 (clang-500.0.68) (based on LLVM 3.3svn)",
+            "revision": "196 (B&I)",
+            "size": "8388608",
+            "vendor": "Apple Inc. ",
+            "version": "196.0.0.0.0 ",
+            "volume_size": "1507328"
+        },
+        "system_info": {
+            "computer_name": "{{ .CachedString "hostname" }}",
+            "cpu_brand": "Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+            "cpu_logical_cores": "8",
+            "cpu_physical_cores": "4",
+            "cpu_subtype": "Intel x86-64h Haswell",
+            "cpu_type": "x86_64h",
+            "hardware_model": "MacBookPro11,4",
+            "hardware_serial": "D02R835DG8WK",
+            "hardware_vendor": "Apple Inc.",
+            "hardware_version": "1.0",
+            "hostname": "{{ .CachedString "hostname" }}",
+            "local_hostname": "{{ .CachedString "hostname" }}",
+            "physical_memory": "17179869184",
+            "uuid": "{{ .UUID }}"
+        }
+    },
+    "host_identifier": "{{ .CachedString "hostname" }}",
+    "platform_type": "16"
+}
+{{- end }}
+
+{{ define "fleet_detail_query_network_interface" -}}
+[
+  {
+    "point_to_point":"",
+    "address":"fe80::8cb:112d:ff51:1e5d%en0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"en0",
+    "mac":"f8:2d:88:93:56:5c",
+    "type":"6",
+    "mtu":"1500",
+    "metric":"0",
+    "ipackets":"278493",
+    "opackets":"206238",
+    "ibytes":"275799040",
+    "obytes":"37720064",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582848084"
+  },
+  {
+    "point_to_point":"",
+    "address":"192.168.1.3",
+    "mask":"255.255.255.0",
+    "broadcast":"192.168.1.255",
+    "interface":"en0",
+    "mac":"f5:5a:80:92:52:5b",
+    "type":"6",
+    "mtu":"1500",
+    "metric":"0",
+    "ipackets":"278493",
+    "opackets":"206238",
+    "ibytes":"275799040",
+    "obytes":"37720064",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582848084"
+  },
+  {
+    "point_to_point":"127.0.0.1",
+    "address":"127.0.0.1",
+    "mask":"255.0.0.0",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"::1",
+    "address":"::1",
+    "mask":"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::1%lo0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"lo0",
+    "mac":"00:00:00:00:00:00",
+    "type":"24",
+    "mtu":"16384",
+    "metric":"0",
+    "ipackets":"132952",
+    "opackets":"132952",
+    "ibytes":"67053568",
+    "obytes":"67053568",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840871"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::3a:84ff:fe6b:bf75%awdl0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"awdl0",
+    "mac":"03:3b:94:5b:be:75",
+    "type":"6",
+    "mtu":"1484",
+    "metric":"0",
+    "ipackets":"0",
+    "opackets":"16",
+    "ibytes":"0",
+    "obytes":"3072",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582842892"
+  },
+  {
+    "point_to_point":"",
+    "address":"fe80::6eaf:9721:3476:b691%utun0",
+    "mask":"ffff:ffff:ffff:ffff::",
+    "broadcast":"",
+    "interface":"utun0",
+    "mac":"00:00:00:00:00:00",
+    "type":"1",
+    "mtu":"2000",
+    "metric":"0",
+    "ipackets":"0",
+    "opackets":"2",
+    "ibytes":"0",
+    "obytes":"0",
+    "ierrors":"0",
+    "oerrors":"0",
+    "idrops":"0",
+    "odrops":"0",
+    "last_change":"1582840897"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_os_version" -}}
+[
+  {
+    "name":"Ubuntu 22.4.0",
+    "version":"Ubuntu 22.4.0",
+    "major":"",
+    "minor":"",
+    "patch":"",
+    "build":"",
+    "platform":"ubuntu",
+    "platform_like":"ubuntu",
+    "codename":""
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_flags" -}}
+[
+  {
+    "name":"config_refresh",
+    "value":"{{ printf "%.0f" .ConfigInterval.Seconds }}"
+  },
+  {
+    "name":"distributed_interval",
+    "value":"{{ printf "%.0f" .QueryInterval.Seconds }}"
+  },
+  {
+    "name":"logger_tls_period",
+    "value":"99999"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_osquery_info" -}}
+[
+  {
+    "pid":"11287",
+    "uuid":"{{ .UUID }}",
+    "instance_id":"{{ .UUID }}",
+    "version":"4.1.2",
+    "config_hash":"b01efbf375ac6767f259ae98751154fef727ce35",
+    "config_valid":"1",
+    "extensions":"inactive",
+    "build_platform":"linux",
+    "build_distro":"22.4.0",
+    "start_time":"1582857555",
+    "watcher":"11286",
+    "platform_mask":"21"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_system_info" -}}
+[
+  {
+    "hostname":"{{ .CachedString "hostname" }}",
+    "uuid":"4740D59F-699E-5B29-960B-979AAF9BBEEB",
+    "cpu_type":"x86_64h",
+    "cpu_subtype":"Intel x86-64h Haswell",
+    "cpu_brand":"Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz",
+    "cpu_physical_cores":"4",
+    "cpu_logical_cores":"8",
+    "cpu_microcode":"",
+    "physical_memory":"17179869184",
+    "hardware_vendor":"Apple Inc.",
+    "hardware_model":"MacBookPro11,4",
+    "hardware_version":"1.0",
+    "hardware_serial":"C02R262BM8LN",
+    "computer_name":"{{ .CachedString "hostname" }}",
+    "local_hostname":"{{ .CachedString "hostname" }}"
+  }
+]
+{{- end }}
+{{ define "fleet_detail_query_uptime" -}}
+[
+  {
+    "days":"0",
+    "hours":"4",
+    "minutes":"38",
+    "seconds":"11",
+    "total_seconds":"16691"
+  }
+]
+{{- end }}
+
+{{ define "fleet_detail_query_users" -}}
+[
+  {{ range $index, $item := .HostUsersMacOS }}
+  {{if $index}},{{end}}
+  {
+    "uid": "{{ .Uid }}",
+    "username": "{{ .Username }}",
+    "type": "{{ .Type }}",
+    "groupname": "{{ .GroupName }}",
+    "shell": "{{ .Shell }}"
+  }
+  {{- end }}
+]
+{{- end }}
+
+{{/* all hosts */}}
+{{ define "fleet_label_query_6" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All macOS hosts */}}
+{{ define "fleet_label_query_7" -}}
+[
+  {
+    "1": "1"
+  }
+]
+{{- end }}
+
+{{/* All Ubuntu hosts */}}
+{{ define "fleet_label_query_8" -}}
+[]
+{{- end }}
+
+{{/* All CentOS hosts */}}
+{{ define "fleet_label_query_9" -}}
+[]
+{{- end }}
+
+{{/* All Windows hosts */}}
+{{ define "fleet_label_query_10" -}}
+[]
+{{- end }}
+
+{{/* All Red Hat hosts */}}
+{{ define "fleet_label_query_11" -}}
+[]
+{{- end }}
+
+{{/* All Linux distributions */}}
+{{ define "fleet_label_query_12" -}}
+[]
+{{- end }}
+
+{{ define "fleet_detail_query_software_linux" -}}
+[
+  {{ range $index, $item := .SoftwareUbuntu2204 }}
+  {{if $index}},{{end}}
+  {
+    "name": "{{ .Name }}",
+    "version": "{{ .Version }}",
+    "type": "Application (macOS)",
+    "bundle_identifier": "{{ .BundleIdentifier }}",
+    "source": "apps",
+    {{/* Note that in Go < 1.18, `{{ or (and .LastOpendedAt .LastOpenedAt.Unix) "" }}` won't work as expected because "and" and "or" don't short circuit. This was changed in Go 1.18 */}}
+    {{if .LastOpenedAt}}
+    "last_opened_at": "{{ .LastOpenedAt.Unix }}"
+    {{else}}
+    "last_opened_at": "-1"
+    {{end}}
+  }
+  {{- end }}
+]
+{{- end }}

--- a/cmd/osquery-perf/ubuntu_2204-vulnerable_software.json
+++ b/cmd/osquery-perf/ubuntu_2204-vulnerable_software.json
@@ -1,0 +1,6762 @@
+[
+  {
+    "name": "branding-ubuntu",
+    "version": "0.10"
+  },
+  {
+    "name": "defer",
+    "version": "1.0.6"
+  },
+  {
+    "name": "dmz-cursor-theme",
+    "version": "0.4.5ubuntu1"
+  },
+  {
+    "name": "grub-gfxpayload-lists",
+    "version": "0.7"
+  },
+  {
+    "name": "hicolor-icon-theme",
+    "version": "0.17-2"
+  },
+  {
+    "name": "language-selector",
+    "version": "0.1"
+  },
+  {
+    "name": "laptop-detect",
+    "version": "0.16"
+  },
+  {
+    "name": "libnet-smtp-ssl-perl",
+    "version": "1.04-1"
+  },
+  {
+    "name": "libxml-xpathengine-perl",
+    "version": "0.14-1"
+  },
+  {
+    "name": "pymacaroons",
+    "version": "0.13.0"
+  },
+  {
+    "name": "sound-theme-freedesktop",
+    "version": "0.8-2ubuntu1"
+  },
+  {
+    "name": "ubuntu-drivers-common",
+    "version": "0.0.0"
+  },
+  {
+    "name": "unattended-upgrades",
+    "version": "0.1"
+  },
+  {
+    "name": "aspell-en",
+    "version": "2018.04.16-0-1"
+  },
+  {
+    "name": "emacsen-common",
+    "version": "3.0.4"
+  },
+  {
+    "name": "fonts-deva-extra",
+    "version": "3.0-5"
+  },
+  {
+    "name": "fonts-gujr-extra",
+    "version": "1.0.1-1"
+  },
+  {
+    "name": "fonts-guru-extra",
+    "version": "2.0-5"
+  },
+  {
+    "name": "fonts-kacst-one",
+    "version": "5.0+svn11846-10"
+  },
+  {
+    "name": "fonts-liberation",
+    "version": "1:1.07.4-11"
+  },
+  {
+    "name": "fonts-lohit-deva",
+    "version": "2.95.4-4"
+  },
+  {
+    "name": "fonts-lohit-gujr",
+    "version": "2.92.4-4"
+  },
+  {
+    "name": "fonts-orya-extra",
+    "version": "2.0-6"
+  },
+  {
+    "name": "fonts-smc-meera",
+    "version": "7.0.3-1"
+  },
+  {
+    "name": "fonts-smc-raghumalayalamsans",
+    "version": "2.2.1-1"
+  },
+  {
+    "name": "fonts-smc-suruma",
+    "version": "3.2.3-1"
+  },
+  {
+    "name": "fonts-smc-uroob",
+    "version": "2.0.2-1"
+  },
+  {
+    "name": "libhtml-form-perl",
+    "version": "6.07-1"
+  },
+  {
+    "name": "libhtml-tagset-perl",
+    "version": "3.20-4"
+  },
+  {
+    "name": "libhtml-tree-perl",
+    "version": "5.07-2"
+  },
+  {
+    "name": "libhttp-date-perl",
+    "version": "6.05-1"
+  },
+  {
+    "name": "libhttp-negotiate-perl",
+    "version": "6.01-1"
+  },
+  {
+    "name": "libio-stringy-perl",
+    "version": "2.111-3"
+  },
+  {
+    "name": "liblwp-mediatypes-perl",
+    "version": "6.04-1"
+  },
+  {
+    "name": "libmailtools-perl",
+    "version": "2.21-1"
+  },
+  {
+    "name": "libtext-wrapi18n-perl",
+    "version": "0.06-9"
+  },
+  {
+    "name": "libwww-robotrules-perl",
+    "version": "6.02-1"
+  },
+  {
+    "name": "macaroonbakery",
+    "version": "1.3.1"
+  },
+  {
+    "name": "olefile",
+    "version": "0.46"
+  },
+  {
+    "name": "osquery",
+    "version": "5.2.3-1.linux"
+  },
+  {
+    "name": "policykit-desktop-privileges",
+    "version": "0.21"
+  },
+  {
+    "name": "powermgmt-base",
+    "version": "1.36"
+  },
+  {
+    "name": "pyRFC3339",
+    "version": "1.1"
+  },
+  {
+    "name": "xcursor-themes",
+    "version": "1.0.6-0ubuntu1"
+  },
+  {
+    "name": "xfonts-base",
+    "version": "1:1.0.5"
+  },
+  {
+    "name": "xml-core",
+    "version": "0.18+nmu1"
+  },
+  {
+    "name": "Mako",
+    "version": "1.1.3"
+  },
+  {
+    "name": "MarkupSafe",
+    "version": "2.0.1"
+  },
+  {
+    "name": "Pillow",
+    "version": "9.0.1"
+  },
+  {
+    "name": "PyGObject",
+    "version": "3.42.0"
+  },
+  {
+    "name": "PyJWT",
+    "version": "2.3.0"
+  },
+  {
+    "name": "PyNaCl",
+    "version": "1.5.0"
+  },
+  {
+    "name": "PyYAML",
+    "version": "5.4.1"
+  },
+  {
+    "name": "SecretStorage",
+    "version": "3.3.1"
+  },
+  {
+    "name": "accountsservice",
+    "version": "22.07.5-2ubuntu1"
+  },
+  {
+    "name": "acl",
+    "version": "2.3.1-1"
+  },
+  {
+    "name": "acpi-support",
+    "version": "0.144"
+  },
+  {
+    "name": "acpid",
+    "version": "1:2.0.33-1ubuntu1"
+  },
+  {
+    "name": "adduser",
+    "version": "3.118ubuntu5"
+  },
+  {
+    "name": "adwaita-icon-theme",
+    "version": "41.0-1ubuntu1"
+  },
+  {
+    "name": "aisleriot",
+    "version": "1:3.22.22-1"
+  },
+  {
+    "name": "alsa-base",
+    "version": "1.0.25+dfsg-0ubuntu7"
+  },
+  {
+    "name": "alsa-topology-conf",
+    "version": "1.2.5.1-2"
+  },
+  {
+    "name": "alsa-ucm-conf",
+    "version": "1.2.6.3-1ubuntu1"
+  },
+  {
+    "name": "alsa-utils",
+    "version": "1.2.6-1ubuntu1"
+  },
+  {
+    "name": "amd64-microcode",
+    "version": "3.20191218.1ubuntu2"
+  },
+  {
+    "name": "anacron",
+    "version": "2.3-31ubuntu2"
+  },
+  {
+    "name": "apg",
+    "version": "2.2.3.dfsg.1-5build2"
+  },
+  {
+    "name": "apparmor",
+    "version": "3.0.4-2ubuntu2"
+  },
+  {
+    "name": "apport",
+    "version": "2.20.11-0ubuntu82"
+  },
+  {
+    "name": "apport-gtk",
+    "version": "2.20.11-0ubuntu82"
+  },
+  {
+    "name": "apport-symptoms",
+    "version": "0.24"
+  },
+  {
+    "name": "appstream",
+    "version": "0.15.2-2"
+  },
+  {
+    "name": "apt",
+    "version": "2.4.5"
+  },
+  {
+    "name": "apt-config-icons",
+    "version": "0.15.2-2"
+  },
+  {
+    "name": "apt-config-icons-hidpi",
+    "version": "0.15.2-2"
+  },
+  {
+    "name": "apt-utils",
+    "version": "2.4.5"
+  },
+  {
+    "name": "aptdaemon",
+    "version": "1.1.1+bzr982-0ubuntu39"
+  },
+  {
+    "name": "aptdaemon-data",
+    "version": "1.1.1+bzr982-0ubuntu39"
+  },
+  {
+    "name": "apturl",
+    "version": "0.5.2ubuntu22"
+  },
+  {
+    "name": "apturl-common",
+    "version": "0.5.2ubuntu22"
+  },
+  {
+    "name": "aspell",
+    "version": "0.60.8-4build1"
+  },
+  {
+    "name": "at-spi2-core",
+    "version": "2.44.0-3"
+  },
+  {
+    "name": "avahi-autoipd",
+    "version": "0.8-5ubuntu5"
+  },
+  {
+    "name": "avahi-daemon",
+    "version": "0.8-5ubuntu5"
+  },
+  {
+    "name": "avahi-utils",
+    "version": "0.8-5ubuntu5"
+  },
+  {
+    "name": "baobab",
+    "version": "41.0-2"
+  },
+  {
+    "name": "base-files",
+    "version": "12ubuntu4"
+  },
+  {
+    "name": "base-passwd",
+    "version": "3.5.52build1"
+  },
+  {
+    "name": "bash",
+    "version": "5.1-6ubuntu1"
+  },
+  {
+    "name": "bash-completion",
+    "version": "1:2.11-5ubuntu1"
+  },
+  {
+    "name": "bc",
+    "version": "1.07.1-3build1"
+  },
+  {
+    "name": "bcrypt",
+    "version": "3.2.0"
+  },
+  {
+    "name": "bind9-dnsutils",
+    "version": "1:9.18.1-1ubuntu1"
+  },
+  {
+    "name": "bind9-host",
+    "version": "1:9.18.1-1ubuntu1"
+  },
+  {
+    "name": "bind9-libs",
+    "version": "1:9.18.1-1ubuntu1"
+  },
+  {
+    "name": "bluez",
+    "version": "5.64-0ubuntu1"
+  },
+  {
+    "name": "bluez-cups",
+    "version": "5.64-0ubuntu1"
+  },
+  {
+    "name": "bluez-obexd",
+    "version": "5.64-0ubuntu1"
+  },
+  {
+    "name": "bolt",
+    "version": "0.9.2-1"
+  },
+  {
+    "name": "brltty",
+    "version": "6.4-4ubuntu2"
+  },
+  {
+    "name": "bsdextrautils",
+    "version": "2.37.2-4ubuntu3"
+  },
+  {
+    "name": "bsdutils",
+    "version": "1:2.37.2-4ubuntu3"
+  },
+  {
+    "name": "bubblewrap",
+    "version": "0.6.1-1"
+  },
+  {
+    "name": "busybox-initramfs",
+    "version": "1:1.30.1-7ubuntu3"
+  },
+  {
+    "name": "busybox-static",
+    "version": "1:1.30.1-7ubuntu3"
+  },
+  {
+    "name": "bzip2",
+    "version": "1.0.8-5build1"
+  },
+  {
+    "name": "ca-certificates",
+    "version": "20211016"
+  },
+  {
+    "name": "certifi",
+    "version": "2020.6.20"
+  },
+  {
+    "name": "chardet",
+    "version": "4.0.0"
+  },
+  {
+    "name": "cheese",
+    "version": "41.1-1build1"
+  },
+  {
+    "name": "cheese-common",
+    "version": "41.1-1build1"
+  },
+  {
+    "name": "click",
+    "version": "8.0.3"
+  },
+  {
+    "name": "colorama",
+    "version": "0.4.4"
+  },
+  {
+    "name": "colord",
+    "version": "1.4.6-1"
+  },
+  {
+    "name": "colord-data",
+    "version": "1.4.6-1"
+  },
+  {
+    "name": "command-not-found",
+    "version": "22.04.0"
+  },
+  {
+    "name": "console-setup",
+    "version": "1.205ubuntu3"
+  },
+  {
+    "name": "console-setup-linux",
+    "version": "1.205ubuntu3"
+  },
+  {
+    "name": "coreutils",
+    "version": "8.32-4.1ubuntu1"
+  },
+  {
+    "name": "cpio",
+    "version": "2.13+dfsg-7"
+  },
+  {
+    "name": "cpp",
+    "version": "4:11.2.0-1ubuntu1"
+  },
+  {
+    "name": "cpp-11",
+    "version": "11.2.0-19ubuntu1"
+  },
+  {
+    "name": "cracklib-runtime",
+    "version": "2.9.6-3.4build4"
+  },
+  {
+    "name": "cron",
+    "version": "3.0pl1-137ubuntu3"
+  },
+  {
+    "name": "cryptography",
+    "version": "3.4.8"
+  },
+  {
+    "name": "cups",
+    "version": "2.4.1op1-1ubuntu4"
+  },
+  {
+    "name": "cups-browsed",
+    "version": "1.28.15-0ubuntu1"
+  },
+  {
+    "name": "cups-bsd",
+    "version": "2.4.1op1-1ubuntu4"
+  },
+  {
+    "name": "cups-client",
+    "version": "2.4.1op1-1ubuntu4"
+  },
+  {
+    "name": "cups-common",
+    "version": "2.4.1op1-1ubuntu4"
+  },
+  {
+    "name": "cups-core-drivers",
+    "version": "2.4.1op1-1ubuntu4"
+  },
+  {
+    "name": "cups-daemon",
+    "version": "2.4.1op1-1ubuntu4"
+  },
+  {
+    "name": "cups-filters",
+    "version": "1.28.15-0ubuntu1"
+  },
+  {
+    "name": "cups-filters-core-drivers",
+    "version": "1.28.15-0ubuntu1"
+  },
+  {
+    "name": "cups-ipp-utils",
+    "version": "2.4.1op1-1ubuntu4"
+  },
+  {
+    "name": "cups-pk-helper",
+    "version": "0.2.6-1ubuntu5"
+  },
+  {
+    "name": "cups-ppdc",
+    "version": "2.4.1op1-1ubuntu4"
+  },
+  {
+    "name": "cups-server-common",
+    "version": "2.4.1op1-1ubuntu4"
+  },
+  {
+    "name": "dash",
+    "version": "0.5.11+git20210903+057cd650a4ed-3build1"
+  },
+  {
+    "name": "dbus",
+    "version": "1.12.20-2ubuntu4"
+  },
+  {
+    "name": "dbus-python",
+    "version": "1.2.18"
+  },
+  {
+    "name": "dbus-user-session",
+    "version": "1.12.20-2ubuntu4"
+  },
+  {
+    "name": "dc",
+    "version": "1.07.1-3build1"
+  },
+  {
+    "name": "dconf-cli",
+    "version": "0.40.0-3"
+  },
+  {
+    "name": "dconf-gsettings-backend",
+    "version": "0.40.0-3"
+  },
+  {
+    "name": "dconf-service",
+    "version": "0.40.0-3"
+  },
+  {
+    "name": "debconf",
+    "version": "1.5.79ubuntu1"
+  },
+  {
+    "name": "debconf-i18n",
+    "version": "1.5.79ubuntu1"
+  },
+  {
+    "name": "debianutils",
+    "version": "5.5-1ubuntu2"
+  },
+  {
+    "name": "deja-dup",
+    "version": "42.9-1ubuntu2"
+  },
+  {
+    "name": "desktop-file-utils",
+    "version": "0.26-1ubuntu3"
+  },
+  {
+    "name": "dictionaries-common",
+    "version": "1.28.14"
+  },
+  {
+    "name": "diffutils",
+    "version": "1:3.8-0ubuntu2"
+  },
+  {
+    "name": "dirmngr",
+    "version": "2.2.27-3ubuntu2"
+  },
+  {
+    "name": "distro",
+    "version": "1.7.0"
+  },
+  {
+    "name": "distro-info",
+    "version": "1.1build1"
+  },
+  {
+    "name": "distro-info",
+    "version": "1.1build1"
+  },
+  {
+    "name": "distro-info-data",
+    "version": "0.52"
+  },
+  {
+    "name": "dmidecode",
+    "version": "3.3-3"
+  },
+  {
+    "name": "dmsetup",
+    "version": "2:1.02.175-2.1ubuntu4"
+  },
+  {
+    "name": "dns-root-data",
+    "version": "2021011101"
+  },
+  {
+    "name": "dnsmasq-base",
+    "version": "2.86-1.1"
+  },
+  {
+    "name": "docbook-xml",
+    "version": "4.5-11"
+  },
+  {
+    "name": "dosfstools",
+    "version": "4.2-1build3"
+  },
+  {
+    "name": "dpkg",
+    "version": "1.21.1ubuntu2"
+  },
+  {
+    "name": "duplicity",
+    "version": "0.8.21"
+  },
+  {
+    "name": "duplicity",
+    "version": "0.8.21-1build1"
+  },
+  {
+    "name": "e2fsprogs",
+    "version": "1.46.5-2ubuntu1"
+  },
+  {
+    "name": "ed",
+    "version": "1.18-1"
+  },
+  {
+    "name": "efibootmgr",
+    "version": "17-1ubuntu2"
+  },
+  {
+    "name": "eject",
+    "version": "2.37.2-4ubuntu3"
+  },
+  {
+    "name": "enchant-2",
+    "version": "2.3.2-1ubuntu2"
+  },
+  {
+    "name": "eog",
+    "version": "42.0-1"
+  },
+  {
+    "name": "espeak-ng-data",
+    "version": "1.50+dfsg-10"
+  },
+  {
+    "name": "evince",
+    "version": "42.1-3"
+  },
+  {
+    "name": "evince-common",
+    "version": "42.1-3"
+  },
+  {
+    "name": "evolution-data-server",
+    "version": "3.44.0-2"
+  },
+  {
+    "name": "evolution-data-server-common",
+    "version": "3.44.0-2"
+  },
+  {
+    "name": "fasteners",
+    "version": "0.14.1"
+  },
+  {
+    "name": "fdisk",
+    "version": "2.37.2-4ubuntu3"
+  },
+  {
+    "name": "file",
+    "version": "1:5.41-3"
+  },
+  {
+    "name": "file-roller",
+    "version": "3.42.0-1"
+  },
+  {
+    "name": "findutils",
+    "version": "4.8.0-1ubuntu3"
+  },
+  {
+    "name": "firmware-sof-signed",
+    "version": "2.0-1ubuntu2"
+  },
+  {
+    "name": "fontconfig",
+    "version": "2.13.1-4.2ubuntu5"
+  },
+  {
+    "name": "fontconfig-config",
+    "version": "2.13.1-4.2ubuntu5"
+  },
+  {
+    "name": "fonts-beng",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-beng-extra",
+    "version": "3.2.1-1"
+  },
+  {
+    "name": "fonts-dejavu-core",
+    "version": "2.37-2build1"
+  },
+  {
+    "name": "fonts-deva",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-droid-fallback",
+    "version": "1:6.0.1r16-1.1build1"
+  },
+  {
+    "name": "fonts-freefont-ttf",
+    "version": "20120503-10build1"
+  },
+  {
+    "name": "fonts-gargi",
+    "version": "2.0-5"
+  },
+  {
+    "name": "fonts-gubbi",
+    "version": "1.3-5build1"
+  },
+  {
+    "name": "fonts-gujr",
+    "version": "2:1.4"
+  },
+  {
+    "name": "fonts-guru",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-indic",
+    "version": "2:1.4"
+  },
+  {
+    "name": "fonts-kacst",
+    "version": "2.01+mry-15"
+  },
+  {
+    "name": "fonts-kalapi",
+    "version": "1.0-4"
+  },
+  {
+    "name": "fonts-khmeros-core",
+    "version": "5.0-9ubuntu1"
+  },
+  {
+    "name": "fonts-knda",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-lao",
+    "version": "0.0.20060226-10ubuntu2"
+  },
+  {
+    "name": "fonts-liberation2",
+    "version": "2.1.5-1"
+  },
+  {
+    "name": "fonts-lklug-sinhala",
+    "version": "0.6-4"
+  },
+  {
+    "name": "fonts-lohit-beng-assamese",
+    "version": "2.91.5-2"
+  },
+  {
+    "name": "fonts-lohit-beng-bengali",
+    "version": "2.91.5-2"
+  },
+  {
+    "name": "fonts-lohit-guru",
+    "version": "2.91.2-2build1"
+  },
+  {
+    "name": "fonts-lohit-knda",
+    "version": "2.5.4-3"
+  },
+  {
+    "name": "fonts-lohit-mlym",
+    "version": "2.92.2-2"
+  },
+  {
+    "name": "fonts-lohit-orya",
+    "version": "2.91.2-2"
+  },
+  {
+    "name": "fonts-lohit-taml",
+    "version": "2.91.3-2"
+  },
+  {
+    "name": "fonts-lohit-taml-classical",
+    "version": "2.5.4-2"
+  },
+  {
+    "name": "fonts-lohit-telu",
+    "version": "2.5.5-2build1"
+  },
+  {
+    "name": "fonts-mlym",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-nakula",
+    "version": "1.0-4"
+  },
+  {
+    "name": "fonts-navilu",
+    "version": "1.2-3"
+  },
+  {
+    "name": "fonts-noto-cjk",
+    "version": "1:20220127+repack1-1"
+  },
+  {
+    "name": "fonts-noto-color-emoji",
+    "version": "2.034-1"
+  },
+  {
+    "name": "fonts-noto-mono",
+    "version": "20201225-1build1"
+  },
+  {
+    "name": "fonts-opensymbol",
+    "version": "2:102.12+LibO7.3.2-0ubuntu2"
+  },
+  {
+    "name": "fonts-orya",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-pagul",
+    "version": "1.0-8"
+  },
+  {
+    "name": "fonts-sahadeva",
+    "version": "1.0-5"
+  },
+  {
+    "name": "fonts-samyak-deva",
+    "version": "1.2.2-5build1"
+  },
+  {
+    "name": "fonts-samyak-gujr",
+    "version": "1.2.2-5build1"
+  },
+  {
+    "name": "fonts-samyak-mlym",
+    "version": "1.2.2-5build1"
+  },
+  {
+    "name": "fonts-samyak-taml",
+    "version": "1.2.2-5build1"
+  },
+  {
+    "name": "fonts-sarai",
+    "version": "1.0-3"
+  },
+  {
+    "name": "fonts-sil-abyssinica",
+    "version": "2.100-3"
+  },
+  {
+    "name": "fonts-sil-padauk",
+    "version": "5.000-3"
+  },
+  {
+    "name": "fonts-smc",
+    "version": "1:7.2"
+  },
+  {
+    "name": "fonts-smc-anjalioldlipi",
+    "version": "7.1.2-2"
+  },
+  {
+    "name": "fonts-smc-chilanka",
+    "version": "1.540-1"
+  },
+  {
+    "name": "fonts-smc-dyuthi",
+    "version": "3.0.2-2"
+  },
+  {
+    "name": "fonts-smc-gayathri",
+    "version": "1.110-2-1"
+  },
+  {
+    "name": "fonts-smc-karumbi",
+    "version": "1.1.2-2"
+  },
+  {
+    "name": "fonts-smc-keraleeyam",
+    "version": "3.0.2-2"
+  },
+  {
+    "name": "fonts-smc-manjari",
+    "version": "2.000-3"
+  },
+  {
+    "name": "fonts-smc-rachana",
+    "version": "7.0.2-1build1"
+  },
+  {
+    "name": "fonts-taml",
+    "version": "2:1.4"
+  },
+  {
+    "name": "fonts-telu",
+    "version": "2:1.3"
+  },
+  {
+    "name": "fonts-telu-extra",
+    "version": "2.0-5"
+  },
+  {
+    "name": "fonts-teluguvijayam",
+    "version": "2.1-1"
+  },
+  {
+    "name": "fonts-thai-tlwg",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tibetan-machine",
+    "version": "1.901b-6"
+  },
+  {
+    "name": "fonts-tlwg-garuda",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-garuda-ttf",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-kinnari",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-kinnari-ttf",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-laksaman",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-laksaman-ttf",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-loma",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-loma-ttf",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-mono",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-mono-ttf",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-norasi",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-norasi-ttf",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-purisa",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-purisa-ttf",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-sawasdee",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-sawasdee-ttf",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-typewriter",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-typewriter-ttf",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-typist",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-typist-ttf",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-typo",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-typo-ttf",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-umpush",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-umpush-ttf",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-waree",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-tlwg-waree-ttf",
+    "version": "1:0.7.3-1"
+  },
+  {
+    "name": "fonts-ubuntu",
+    "version": "0.83-6ubuntu1"
+  },
+  {
+    "name": "fonts-urw-base35",
+    "version": "20200910-1"
+  },
+  {
+    "name": "fonts-yrsa-rasa",
+    "version": "2.005-1"
+  },
+  {
+    "name": "foomatic-db-compressed-ppds",
+    "version": "20220223-0ubuntu1"
+  },
+  {
+    "name": "fprintd",
+    "version": "1.94.2-1"
+  },
+  {
+    "name": "friendly-recovery",
+    "version": "0.2.42"
+  },
+  {
+    "name": "ftp",
+    "version": "20210827-4build1"
+  },
+  {
+    "name": "fuse3",
+    "version": "3.10.5-1build1"
+  },
+  {
+    "name": "future",
+    "version": "0.18.2"
+  },
+  {
+    "name": "fwupd",
+    "version": "1.7.5-3"
+  },
+  {
+    "name": "fwupd-signed",
+    "version": "1.44+1.2-3"
+  },
+  {
+    "name": "gamemode",
+    "version": "1.6.1-1build2"
+  },
+  {
+    "name": "gamemode-daemon",
+    "version": "1.6.1-1build2"
+  },
+  {
+    "name": "gcc-11-base",
+    "version": "11.2.0-19ubuntu1"
+  },
+  {
+    "name": "gcc-12-base",
+    "version": "12-20220319-1ubuntu1"
+  },
+  {
+    "name": "gcr",
+    "version": "3.40.0-4"
+  },
+  {
+    "name": "gdb",
+    "version": "12.0.90-0ubuntu1"
+  },
+  {
+    "name": "gdisk",
+    "version": "1.0.8-4build1"
+  },
+  {
+    "name": "gdm3",
+    "version": "42.0-1ubuntu6"
+  },
+  {
+    "name": "gedit",
+    "version": "41.0-3"
+  },
+  {
+    "name": "gedit-common",
+    "version": "41.0-3"
+  },
+  {
+    "name": "genisoimage",
+    "version": "9:1.1.11-3.2ubuntu1"
+  },
+  {
+    "name": "geoclue-2.0",
+    "version": "2.5.7-3ubuntu3"
+  },
+  {
+    "name": "gettext-base",
+    "version": "0.21-4ubuntu4"
+  },
+  {
+    "name": "ghostscript",
+    "version": "9.55.0~dfsg1-0ubuntu5"
+  },
+  {
+    "name": "ghostscript-x",
+    "version": "9.55.0~dfsg1-0ubuntu5"
+  },
+  {
+    "name": "gir1.2-accountsservice-1.0",
+    "version": "22.07.5-2ubuntu1"
+  },
+  {
+    "name": "gir1.2-adw-1",
+    "version": "1.1.0-1ubuntu2"
+  },
+  {
+    "name": "gir1.2-atk-1.0",
+    "version": "2.36.0-3build1"
+  },
+  {
+    "name": "gir1.2-atspi-2.0",
+    "version": "2.44.0-3"
+  },
+  {
+    "name": "gir1.2-dbusmenu-glib-0.4",
+    "version": "16.04.1+18.10.20180917-0ubuntu8"
+  },
+  {
+    "name": "gir1.2-dee-1.0",
+    "version": "1.2.7+17.10.20170616-6ubuntu4"
+  },
+  {
+    "name": "gir1.2-freedesktop",
+    "version": "1.72.0-1"
+  },
+  {
+    "name": "gir1.2-gck-1",
+    "version": "3.40.0-4"
+  },
+  {
+    "name": "gir1.2-gcr-3",
+    "version": "3.40.0-4"
+  },
+  {
+    "name": "gir1.2-gdesktopenums-3.0",
+    "version": "42.0-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-gdkpixbuf-2.0",
+    "version": "2.42.8+dfsg-1"
+  },
+  {
+    "name": "gir1.2-gdm-1.0",
+    "version": "42.0-1ubuntu6"
+  },
+  {
+    "name": "gir1.2-geoclue-2.0",
+    "version": "2.5.7-3ubuntu3"
+  },
+  {
+    "name": "gir1.2-glib-2.0",
+    "version": "1.72.0-1"
+  },
+  {
+    "name": "gir1.2-gmenu-3.0",
+    "version": "3.36.0-1ubuntu3"
+  },
+  {
+    "name": "gir1.2-gnomebluetooth-3.0",
+    "version": "42.0-5"
+  },
+  {
+    "name": "gir1.2-gnomedesktop-3.0",
+    "version": "42.0-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-goa-1.0",
+    "version": "3.44.0-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-graphene-1.0",
+    "version": "1.10.8-1"
+  },
+  {
+    "name": "gir1.2-gst-plugins-base-1.0",
+    "version": "1.20.1-1"
+  },
+  {
+    "name": "gir1.2-gstreamer-1.0",
+    "version": "1.20.1-1"
+  },
+  {
+    "name": "gir1.2-gtk-3.0",
+    "version": "3.24.33-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-gtk-4.0",
+    "version": "4.6.2+ds-1ubuntu2"
+  },
+  {
+    "name": "gir1.2-gtksource-4",
+    "version": "4.8.3-1"
+  },
+  {
+    "name": "gir1.2-gudev-1.0",
+    "version": "1:237-2build1"
+  },
+  {
+    "name": "gir1.2-gweather-3.0",
+    "version": "40.0-5build1"
+  },
+  {
+    "name": "gir1.2-handy-1",
+    "version": "1.6.1-1"
+  },
+  {
+    "name": "gir1.2-harfbuzz-0.0",
+    "version": "2.7.4-1ubuntu3"
+  },
+  {
+    "name": "gir1.2-ibus-1.0",
+    "version": "1.5.26-4"
+  },
+  {
+    "name": "gir1.2-javascriptcoregtk-4.0",
+    "version": "2.36.0-2ubuntu1"
+  },
+  {
+    "name": "gir1.2-json-1.0",
+    "version": "1.6.6-1build1"
+  },
+  {
+    "name": "gir1.2-mutter-10",
+    "version": "42.0-3ubuntu2"
+  },
+  {
+    "name": "gir1.2-nm-1.0",
+    "version": "1.36.4-2ubuntu1"
+  },
+  {
+    "name": "gir1.2-nma-1.0",
+    "version": "1.8.34-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-notify-0.7",
+    "version": "0.7.9-3ubuntu5"
+  },
+  {
+    "name": "gir1.2-packagekitglib-1.0",
+    "version": "1.2.5-2ubuntu2"
+  },
+  {
+    "name": "gir1.2-pango-1.0",
+    "version": "1.50.6+ds-2"
+  },
+  {
+    "name": "gir1.2-peas-1.0",
+    "version": "1.32.0-1"
+  },
+  {
+    "name": "gir1.2-polkit-1.0",
+    "version": "0.105-33"
+  },
+  {
+    "name": "gir1.2-rb-3.0",
+    "version": "3.4.4-5ubuntu1"
+  },
+  {
+    "name": "gir1.2-rsvg-2.0",
+    "version": "2.52.5+dfsg-3"
+  },
+  {
+    "name": "gir1.2-secret-1",
+    "version": "0.20.5-2"
+  },
+  {
+    "name": "gir1.2-snapd-1",
+    "version": "1.60-0ubuntu1"
+  },
+  {
+    "name": "gir1.2-soup-2.4",
+    "version": "2.74.2-3"
+  },
+  {
+    "name": "gir1.2-totem-1.0",
+    "version": "42.0-1ubuntu1"
+  },
+  {
+    "name": "gir1.2-totemplparser-1.0",
+    "version": "3.26.6-1build1"
+  },
+  {
+    "name": "gir1.2-udisks-2.0",
+    "version": "2.9.4-1ubuntu2"
+  },
+  {
+    "name": "gir1.2-unity-7.0",
+    "version": "7.1.4+19.04.20190319-6build1"
+  },
+  {
+    "name": "gir1.2-upowerglib-1.0",
+    "version": "0.99.17-1"
+  },
+  {
+    "name": "gir1.2-vte-2.91",
+    "version": "0.68.0-1"
+  },
+  {
+    "name": "gir1.2-webkit2-4.0",
+    "version": "2.36.0-2ubuntu1"
+  },
+  {
+    "name": "gir1.2-wnck-3.0",
+    "version": "40.1-1"
+  },
+  {
+    "name": "gjs",
+    "version": "1.72.0-1"
+  },
+  {
+    "name": "gkbd-capplet",
+    "version": "3.26.1-2"
+  },
+  {
+    "name": "glib-networking",
+    "version": "2.72.0-1"
+  },
+  {
+    "name": "glib-networking-common",
+    "version": "2.72.0-1"
+  },
+  {
+    "name": "glib-networking-services",
+    "version": "2.72.0-1"
+  },
+  {
+    "name": "gnome-accessibility-themes",
+    "version": "3.28-1ubuntu3"
+  },
+  {
+    "name": "gnome-bluetooth",
+    "version": "3.34.5-8"
+  },
+  {
+    "name": "gnome-bluetooth-3-common",
+    "version": "42.0-5"
+  },
+  {
+    "name": "gnome-bluetooth-common",
+    "version": "3.34.5-8"
+  },
+  {
+    "name": "gnome-calculator",
+    "version": "1:41.1-2ubuntu2"
+  },
+  {
+    "name": "gnome-calendar",
+    "version": "41.2-3"
+  },
+  {
+    "name": "gnome-characters",
+    "version": "41.0-4"
+  },
+  {
+    "name": "gnome-control-center",
+    "version": "1:41.4-1ubuntu12"
+  },
+  {
+    "name": "gnome-control-center-data",
+    "version": "1:41.4-1ubuntu12"
+  },
+  {
+    "name": "gnome-control-center-faces",
+    "version": "1:41.4-1ubuntu12"
+  },
+  {
+    "name": "gnome-desktop3-data",
+    "version": "42.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-disk-utility",
+    "version": "42.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-font-viewer",
+    "version": "41.0-2"
+  },
+  {
+    "name": "gnome-initial-setup",
+    "version": "42.0.1-1ubuntu2"
+  },
+  {
+    "name": "gnome-keyring",
+    "version": "40.0-3ubuntu2"
+  },
+  {
+    "name": "gnome-keyring-pkcs11",
+    "version": "40.0-3ubuntu2"
+  },
+  {
+    "name": "gnome-logs",
+    "version": "42.0-1"
+  },
+  {
+    "name": "gnome-mahjongg",
+    "version": "1:3.38.3-2"
+  },
+  {
+    "name": "gnome-menus",
+    "version": "3.36.0-1ubuntu3"
+  },
+  {
+    "name": "gnome-mines",
+    "version": "1:40.1-1"
+  },
+  {
+    "name": "gnome-online-accounts",
+    "version": "3.44.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-power-manager",
+    "version": "3.32.0-2build2"
+  },
+  {
+    "name": "gnome-remote-desktop",
+    "version": "42.0-4ubuntu1"
+  },
+  {
+    "name": "gnome-session-bin",
+    "version": "42.0-1ubuntu2"
+  },
+  {
+    "name": "gnome-session-canberra",
+    "version": "0.30-10ubuntu1"
+  },
+  {
+    "name": "gnome-session-common",
+    "version": "42.0-1ubuntu2"
+  },
+  {
+    "name": "gnome-settings-daemon",
+    "version": "42.1-1ubuntu2"
+  },
+  {
+    "name": "gnome-settings-daemon-common",
+    "version": "42.1-1ubuntu2"
+  },
+  {
+    "name": "gnome-shell",
+    "version": "42.0-2ubuntu1"
+  },
+  {
+    "name": "gnome-shell-common",
+    "version": "42.0-2ubuntu1"
+  },
+  {
+    "name": "gnome-shell-extension-appindicator",
+    "version": "42-2~fakesync1"
+  },
+  {
+    "name": "gnome-shell-extension-desktop-icons-ng",
+    "version": "43-2"
+  },
+  {
+    "name": "gnome-shell-extension-ubuntu-dock",
+    "version": "72~ubuntu5"
+  },
+  {
+    "name": "gnome-startup-applications",
+    "version": "42.0-1ubuntu2"
+  },
+  {
+    "name": "gnome-sudoku",
+    "version": "1:42.0-1"
+  },
+  {
+    "name": "gnome-system-monitor",
+    "version": "42.0-1"
+  },
+  {
+    "name": "gnome-terminal",
+    "version": "3.44.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-terminal-data",
+    "version": "3.44.0-1ubuntu1"
+  },
+  {
+    "name": "gnome-themes-extra",
+    "version": "3.28-1ubuntu3"
+  },
+  {
+    "name": "gnome-themes-extra-data",
+    "version": "3.28-1ubuntu3"
+  },
+  {
+    "name": "gnome-todo",
+    "version": "3.28.1-6ubuntu1"
+  },
+  {
+    "name": "gnome-todo-common",
+    "version": "3.28.1-6ubuntu1"
+  },
+  {
+    "name": "gnome-user-docs",
+    "version": "41.5-1ubuntu2"
+  },
+  {
+    "name": "gnome-video-effects",
+    "version": "0.5.0-1ubuntu1"
+  },
+  {
+    "name": "gnupg",
+    "version": "2.2.27-3ubuntu2"
+  },
+  {
+    "name": "gnupg-l10n",
+    "version": "2.2.27-3ubuntu2"
+  },
+  {
+    "name": "gnupg-utils",
+    "version": "2.2.27-3ubuntu2"
+  },
+  {
+    "name": "gpg",
+    "version": "2.2.27-3ubuntu2"
+  },
+  {
+    "name": "gpg-agent",
+    "version": "2.2.27-3ubuntu2"
+  },
+  {
+    "name": "gpg-wks-client",
+    "version": "2.2.27-3ubuntu2"
+  },
+  {
+    "name": "gpg-wks-server",
+    "version": "2.2.27-3ubuntu2"
+  },
+  {
+    "name": "gpgconf",
+    "version": "2.2.27-3ubuntu2"
+  },
+  {
+    "name": "gpgsm",
+    "version": "2.2.27-3ubuntu2"
+  },
+  {
+    "name": "gpgv",
+    "version": "2.2.27-3ubuntu2"
+  },
+  {
+    "name": "grep",
+    "version": "3.7-1build1"
+  },
+  {
+    "name": "grilo-plugins-0.3-base",
+    "version": "0.3.14-1ubuntu2"
+  },
+  {
+    "name": "groff-base",
+    "version": "1.22.4-8build1"
+  },
+  {
+    "name": "grub-common",
+    "version": "2.06-2ubuntu7"
+  },
+  {
+    "name": "grub-efi-amd64-bin",
+    "version": "2.06-2ubuntu7"
+  },
+  {
+    "name": "grub-efi-amd64-signed",
+    "version": "1.180+2.06-2ubuntu7"
+  },
+  {
+    "name": "grub-pc",
+    "version": "2.06-2ubuntu7"
+  },
+  {
+    "name": "grub-pc-bin",
+    "version": "2.06-2ubuntu7"
+  },
+  {
+    "name": "grub2-common",
+    "version": "2.06-2ubuntu7"
+  },
+  {
+    "name": "gsettings-desktop-schemas",
+    "version": "42.0-1ubuntu1"
+  },
+  {
+    "name": "gsettings-ubuntu-schemas",
+    "version": "0.0.7+21.10.20210712-0ubuntu2"
+  },
+  {
+    "name": "gstreamer1.0-alsa",
+    "version": "1.20.1-1"
+  },
+  {
+    "name": "gstreamer1.0-clutter-3.0",
+    "version": "3.0.27-2build2"
+  },
+  {
+    "name": "gstreamer1.0-gl",
+    "version": "1.20.1-1"
+  },
+  {
+    "name": "gstreamer1.0-gtk3",
+    "version": "1.20.1-1ubuntu1"
+  },
+  {
+    "name": "gstreamer1.0-packagekit",
+    "version": "1.2.5-2ubuntu2"
+  },
+  {
+    "name": "gstreamer1.0-pipewire",
+    "version": "0.3.48-1ubuntu1"
+  },
+  {
+    "name": "gstreamer1.0-plugins-base",
+    "version": "1.20.1-1"
+  },
+  {
+    "name": "gstreamer1.0-plugins-base-apps",
+    "version": "1.20.1-1"
+  },
+  {
+    "name": "gstreamer1.0-plugins-good",
+    "version": "1.20.1-1ubuntu1"
+  },
+  {
+    "name": "gstreamer1.0-pulseaudio",
+    "version": "1.20.1-1ubuntu1"
+  },
+  {
+    "name": "gstreamer1.0-tools",
+    "version": "1.20.1-1"
+  },
+  {
+    "name": "gstreamer1.0-x",
+    "version": "1.20.1-1"
+  },
+  {
+    "name": "gtk-update-icon-cache",
+    "version": "3.24.33-1ubuntu1"
+  },
+  {
+    "name": "gtk2-engines-murrine",
+    "version": "0.98.2-3build2"
+  },
+  {
+    "name": "gtk2-engines-pixbuf",
+    "version": "2.24.33-2ubuntu2"
+  },
+  {
+    "name": "guile-2.2-libs",
+    "version": "2.2.7+1-6build2"
+  },
+  {
+    "name": "gvfs",
+    "version": "1.48.1-4"
+  },
+  {
+    "name": "gvfs-backends",
+    "version": "1.48.1-4"
+  },
+  {
+    "name": "gvfs-common",
+    "version": "1.48.1-4"
+  },
+  {
+    "name": "gvfs-daemons",
+    "version": "1.48.1-4"
+  },
+  {
+    "name": "gvfs-fuse",
+    "version": "1.48.1-4"
+  },
+  {
+    "name": "gvfs-libs",
+    "version": "1.48.1-4"
+  },
+  {
+    "name": "gzip",
+    "version": "1.10-4ubuntu4"
+  },
+  {
+    "name": "hdparm",
+    "version": "9.60+ds-1build3"
+  },
+  {
+    "name": "hostname",
+    "version": "3.23ubuntu2"
+  },
+  {
+    "name": "hplip",
+    "version": "3.21.12+dfsg0-1"
+  },
+  {
+    "name": "hplip-data",
+    "version": "3.21.12+dfsg0-1"
+  },
+  {
+    "name": "httplib2",
+    "version": "0.20.2"
+  },
+  {
+    "name": "humanity-icon-theme",
+    "version": "0.6.16"
+  },
+  {
+    "name": "hunspell-en-us",
+    "version": "1:2020.12.07-2"
+  },
+  {
+    "name": "hyphen-en-us",
+    "version": "2.8.8-7build2"
+  },
+  {
+    "name": "ibus",
+    "version": "1.5.26-4"
+  },
+  {
+    "name": "ibus-data",
+    "version": "1.5.26-4"
+  },
+  {
+    "name": "ibus-gtk",
+    "version": "1.5.26-4"
+  },
+  {
+    "name": "ibus-gtk3",
+    "version": "1.5.26-4"
+  },
+  {
+    "name": "ibus-gtk4",
+    "version": "1.5.26-4"
+  },
+  {
+    "name": "ibus-table",
+    "version": "1.16.7-1"
+  },
+  {
+    "name": "idna",
+    "version": "3.3"
+  },
+  {
+    "name": "iio-sensor-proxy",
+    "version": "3.3-0ubuntu6"
+  },
+  {
+    "name": "im-config",
+    "version": "0.50-2"
+  },
+  {
+    "name": "importlib-metadata",
+    "version": "4.6.4"
+  },
+  {
+    "name": "info",
+    "version": "6.8-4build1"
+  },
+  {
+    "name": "init",
+    "version": "1.62"
+  },
+  {
+    "name": "init-system-helpers",
+    "version": "1.62"
+  },
+  {
+    "name": "initramfs-tools",
+    "version": "0.140ubuntu13"
+  },
+  {
+    "name": "initramfs-tools-bin",
+    "version": "0.140ubuntu13"
+  },
+  {
+    "name": "initramfs-tools-core",
+    "version": "0.140ubuntu13"
+  },
+  {
+    "name": "inputattach",
+    "version": "1:1.7.1-1build2"
+  },
+  {
+    "name": "install-info",
+    "version": "6.8-4build1"
+  },
+  {
+    "name": "intel-microcode",
+    "version": "3.20210608.2ubuntu1"
+  },
+  {
+    "name": "ipp-usb",
+    "version": "0.9.20-1"
+  },
+  {
+    "name": "iproute2",
+    "version": "5.15.0-1ubuntu2"
+  },
+  {
+    "name": "iptables",
+    "version": "1.8.7-1ubuntu5"
+  },
+  {
+    "name": "iputils-ping",
+    "version": "3:20211215-1"
+  },
+  {
+    "name": "iputils-tracepath",
+    "version": "3:20211215-1"
+  },
+  {
+    "name": "irqbalance",
+    "version": "1.8.0-1build1"
+  },
+  {
+    "name": "isc-dhcp-client",
+    "version": "4.4.1-2.3ubuntu2"
+  },
+  {
+    "name": "isc-dhcp-common",
+    "version": "4.4.1-2.3ubuntu2"
+  },
+  {
+    "name": "iso-codes",
+    "version": "4.9.0-1"
+  },
+  {
+    "name": "iucode-tool",
+    "version": "2.3.1-1build1"
+  },
+  {
+    "name": "jeepney",
+    "version": "0.7.1"
+  },
+  {
+    "name": "kbd",
+    "version": "2.3.0-3ubuntu4"
+  },
+  {
+    "name": "kerneloops",
+    "version": "0.12+git20140509-6ubuntu5"
+  },
+  {
+    "name": "keyboard-configuration",
+    "version": "1.205ubuntu3"
+  },
+  {
+    "name": "keyring",
+    "version": "23.5.0"
+  },
+  {
+    "name": "klibc-utils",
+    "version": "2.0.10-4"
+  },
+  {
+    "name": "kmod",
+    "version": "29-1ubuntu1"
+  },
+  {
+    "name": "language-pack-en",
+    "version": "1:22.04+20220415"
+  },
+  {
+    "name": "language-pack-en-base",
+    "version": "1:22.04+20220415"
+  },
+  {
+    "name": "language-pack-gnome-en",
+    "version": "1:22.04+20220415"
+  },
+  {
+    "name": "language-pack-gnome-en-base",
+    "version": "1:22.04+20220415"
+  },
+  {
+    "name": "language-selector-common",
+    "version": "0.219"
+  },
+  {
+    "name": "language-selector-gnome",
+    "version": "0.219"
+  },
+  {
+    "name": "launchpadlib",
+    "version": "1.10.16"
+  },
+  {
+    "name": "lazr.restfulclient",
+    "version": "0.14.4"
+  },
+  {
+    "name": "lazr.uri",
+    "version": "1.0.6"
+  },
+  {
+    "name": "less",
+    "version": "590-1build1"
+  },
+  {
+    "name": "libaa1",
+    "version": "1.4p5-50build1"
+  },
+  {
+    "name": "libabsl20210324",
+    "version": "0~20210324.2-2"
+  },
+  {
+    "name": "libabw-0.1-1",
+    "version": "0.1.3-1build3"
+  },
+  {
+    "name": "libaccountsservice0",
+    "version": "22.07.5-2ubuntu1"
+  },
+  {
+    "name": "libacl1",
+    "version": "2.3.1-1"
+  },
+  {
+    "name": "libadwaita-1-0",
+    "version": "1.1.0-1ubuntu2"
+  },
+  {
+    "name": "libao-common",
+    "version": "1.2.2+20180113-1.1ubuntu3"
+  },
+  {
+    "name": "libao4",
+    "version": "1.2.2+20180113-1.1ubuntu3"
+  },
+  {
+    "name": "libapparmor1",
+    "version": "3.0.4-2ubuntu2"
+  },
+  {
+    "name": "libappstream4",
+    "version": "0.15.2-2"
+  },
+  {
+    "name": "libapt-pkg6.0",
+    "version": "2.4.5"
+  },
+  {
+    "name": "libarchive13",
+    "version": "3.6.0-1ubuntu1"
+  },
+  {
+    "name": "libargon2-1",
+    "version": "0~20171227-0.3"
+  },
+  {
+    "name": "libasound2",
+    "version": "1.2.6.1-1ubuntu1"
+  },
+  {
+    "name": "libasound2-data",
+    "version": "1.2.6.1-1ubuntu1"
+  },
+  {
+    "name": "libasound2-plugins",
+    "version": "1.2.6-1"
+  },
+  {
+    "name": "libaspell15",
+    "version": "0.60.8-4build1"
+  },
+  {
+    "name": "libassuan0",
+    "version": "2.5.5-1build1"
+  },
+  {
+    "name": "libasyncns0",
+    "version": "0.8-6build2"
+  },
+  {
+    "name": "libatasmart4",
+    "version": "0.19-5build2"
+  },
+  {
+    "name": "libatk-adaptor",
+    "version": "2.38.0-3"
+  },
+  {
+    "name": "libatk-bridge2.0-0",
+    "version": "2.38.0-3"
+  },
+  {
+    "name": "libatk1.0-0",
+    "version": "2.36.0-3build1"
+  },
+  {
+    "name": "libatk1.0-data",
+    "version": "2.36.0-3build1"
+  },
+  {
+    "name": "libatkmm-1.6-1v5",
+    "version": "2.28.2-1build1"
+  },
+  {
+    "name": "libatm1",
+    "version": "1:2.5.1-4build2"
+  },
+  {
+    "name": "libatopology2",
+    "version": "1.2.6.1-1ubuntu1"
+  },
+  {
+    "name": "libatspi2.0-0",
+    "version": "2.44.0-3"
+  },
+  {
+    "name": "libattr1",
+    "version": "1:2.5.1-1build1"
+  },
+  {
+    "name": "libaudit-common",
+    "version": "1:3.0.7-1build1"
+  },
+  {
+    "name": "libaudit1",
+    "version": "1:3.0.7-1build1"
+  },
+  {
+    "name": "libauthen-sasl-perl",
+    "version": "2.1600-1.1"
+  },
+  {
+    "name": "libavahi-client3",
+    "version": "0.8-5ubuntu5"
+  },
+  {
+    "name": "libavahi-common-data",
+    "version": "0.8-5ubuntu5"
+  },
+  {
+    "name": "libavahi-common3",
+    "version": "0.8-5ubuntu5"
+  },
+  {
+    "name": "libavahi-core7",
+    "version": "0.8-5ubuntu5"
+  },
+  {
+    "name": "libavahi-glib1",
+    "version": "0.8-5ubuntu5"
+  },
+  {
+    "name": "libavahi-ui-gtk3-0",
+    "version": "0.8-5ubuntu5"
+  },
+  {
+    "name": "libavc1394-0",
+    "version": "0.5.4-5build2"
+  },
+  {
+    "name": "libayatana-appindicator3-1",
+    "version": "0.5.90-7ubuntu2"
+  },
+  {
+    "name": "libayatana-ido3-0.4-0",
+    "version": "0.9.1-1"
+  },
+  {
+    "name": "libayatana-indicator3-7",
+    "version": "0.9.1-1"
+  },
+  {
+    "name": "libbabeltrace1",
+    "version": "1.5.8-2build1"
+  },
+  {
+    "name": "libblkid1",
+    "version": "2.37.2-4ubuntu3"
+  },
+  {
+    "name": "libblockdev-crypto2",
+    "version": "2.26-1"
+  },
+  {
+    "name": "libblockdev-fs2",
+    "version": "2.26-1"
+  },
+  {
+    "name": "libblockdev-loop2",
+    "version": "2.26-1"
+  },
+  {
+    "name": "libblockdev-part-err2",
+    "version": "2.26-1"
+  },
+  {
+    "name": "libblockdev-part2",
+    "version": "2.26-1"
+  },
+  {
+    "name": "libblockdev-swap2",
+    "version": "2.26-1"
+  },
+  {
+    "name": "libblockdev-utils2",
+    "version": "2.26-1"
+  },
+  {
+    "name": "libblockdev2",
+    "version": "2.26-1"
+  },
+  {
+    "name": "libbluetooth3",
+    "version": "5.64-0ubuntu1"
+  },
+  {
+    "name": "libboost-filesystem1.74.0",
+    "version": "1.74.0-14ubuntu3"
+  },
+  {
+    "name": "libboost-iostreams1.74.0",
+    "version": "1.74.0-14ubuntu3"
+  },
+  {
+    "name": "libboost-locale1.74.0",
+    "version": "1.74.0-14ubuntu3"
+  },
+  {
+    "name": "libboost-regex1.74.0",
+    "version": "1.74.0-14ubuntu3"
+  },
+  {
+    "name": "libboost-thread1.74.0",
+    "version": "1.74.0-14ubuntu3"
+  },
+  {
+    "name": "libbpf0",
+    "version": "1:0.5.0-1"
+  },
+  {
+    "name": "libbrlapi0.8",
+    "version": "6.4-4ubuntu2"
+  },
+  {
+    "name": "libbrotli1",
+    "version": "1.0.9-2build6"
+  },
+  {
+    "name": "libbsd0",
+    "version": "0.11.5-1"
+  },
+  {
+    "name": "libbz2-1.0",
+    "version": "1.0.8-5build1"
+  },
+  {
+    "name": "libc-bin",
+    "version": "2.35-0ubuntu3"
+  },
+  {
+    "name": "libc6",
+    "version": "2.35-0ubuntu3"
+  },
+  {
+    "name": "libc6-dbg",
+    "version": "2.35-0ubuntu3"
+  },
+  {
+    "name": "libcaca0",
+    "version": "0.99.beta19-2.2ubuntu4"
+  },
+  {
+    "name": "libcairo-gobject-perl",
+    "version": "1.005-3build1"
+  },
+  {
+    "name": "libcairo-gobject2",
+    "version": "1.16.0-5ubuntu2"
+  },
+  {
+    "name": "libcairo-perl",
+    "version": "1.109-2build1"
+  },
+  {
+    "name": "libcairo-script-interpreter2",
+    "version": "1.16.0-5ubuntu2"
+  },
+  {
+    "name": "libcairo2",
+    "version": "1.16.0-5ubuntu2"
+  },
+  {
+    "name": "libcairomm-1.0-1v5",
+    "version": "1.12.2-4build3"
+  },
+  {
+    "name": "libcamel-1.2-63",
+    "version": "3.44.0-2"
+  },
+  {
+    "name": "libcanberra-gtk3-0",
+    "version": "0.30-10ubuntu1"
+  },
+  {
+    "name": "libcanberra-gtk3-module",
+    "version": "0.30-10ubuntu1"
+  },
+  {
+    "name": "libcanberra-pulse",
+    "version": "0.30-10ubuntu1"
+  },
+  {
+    "name": "libcanberra0",
+    "version": "0.30-10ubuntu1"
+  },
+  {
+    "name": "libcap-ng0",
+    "version": "0.7.9-2.2build3"
+  },
+  {
+    "name": "libcap2",
+    "version": "1:2.44-1build3"
+  },
+  {
+    "name": "libcap2-bin",
+    "version": "1:2.44-1build3"
+  },
+  {
+    "name": "libcbor0.8",
+    "version": "0.8.0-2ubuntu1"
+  },
+  {
+    "name": "libcdio-cdda2",
+    "version": "10.2+2.0.0-1build3"
+  },
+  {
+    "name": "libcdio-paranoia2",
+    "version": "10.2+2.0.0-1build3"
+  },
+  {
+    "name": "libcdio19",
+    "version": "2.1.0-3build1"
+  },
+  {
+    "name": "libcdparanoia0",
+    "version": "3.10.2+debian-14build2"
+  },
+  {
+    "name": "libcdr-0.1-1",
+    "version": "0.1.6-2build2"
+  },
+  {
+    "name": "libcheese-gtk25",
+    "version": "41.1-1build1"
+  },
+  {
+    "name": "libcheese8",
+    "version": "41.1-1build1"
+  },
+  {
+    "name": "libclone-perl",
+    "version": "0.45-1build3"
+  },
+  {
+    "name": "libclucene-contribs1v5",
+    "version": "2.3.3.4+dfsg-1ubuntu5"
+  },
+  {
+    "name": "libclucene-core1v5",
+    "version": "2.3.3.4+dfsg-1ubuntu5"
+  },
+  {
+    "name": "libclutter-1.0-0",
+    "version": "1.26.4+dfsg-4build1"
+  },
+  {
+    "name": "libclutter-1.0-common",
+    "version": "1.26.4+dfsg-4build1"
+  },
+  {
+    "name": "libclutter-gst-3.0-0",
+    "version": "3.0.27-2build2"
+  },
+  {
+    "name": "libclutter-gtk-1.0-0",
+    "version": "1.8.4-4build2"
+  },
+  {
+    "name": "libcogl-common",
+    "version": "1.22.8-3build1"
+  },
+  {
+    "name": "libcogl-pango20",
+    "version": "1.22.8-3build1"
+  },
+  {
+    "name": "libcogl-path20",
+    "version": "1.22.8-3build1"
+  },
+  {
+    "name": "libcogl20",
+    "version": "1.22.8-3build1"
+  },
+  {
+    "name": "libcolamd2",
+    "version": "1:5.10.1+dfsg-4build1"
+  },
+  {
+    "name": "libcolord-gtk1",
+    "version": "0.3.0-1"
+  },
+  {
+    "name": "libcolord2",
+    "version": "1.4.6-1"
+  },
+  {
+    "name": "libcolorhug2",
+    "version": "1.4.6-1"
+  },
+  {
+    "name": "libcom-err2",
+    "version": "1.46.5-2ubuntu1"
+  },
+  {
+    "name": "libcrack2",
+    "version": "2.9.6-3.4build4"
+  },
+  {
+    "name": "libcrypt1",
+    "version": "1:4.4.27-1"
+  },
+  {
+    "name": "libcryptsetup12",
+    "version": "2:2.4.3-1ubuntu1"
+  },
+  {
+    "name": "libcue2",
+    "version": "2.2.1-3build3"
+  },
+  {
+    "name": "libcups2",
+    "version": "2.4.1op1-1ubuntu4"
+  },
+  {
+    "name": "libcupsfilters1",
+    "version": "1.28.15-0ubuntu1"
+  },
+  {
+    "name": "libcupsimage2",
+    "version": "2.4.1op1-1ubuntu4"
+  },
+  {
+    "name": "libcurl3-gnutls",
+    "version": "7.81.0-1"
+  },
+  {
+    "name": "libcurl4",
+    "version": "7.81.0-1"
+  },
+  {
+    "name": "libdaemon0",
+    "version": "0.14-7.1ubuntu3"
+  },
+  {
+    "name": "libdata-dump-perl",
+    "version": "1.25-1"
+  },
+  {
+    "name": "libdatrie1",
+    "version": "0.2.13-2"
+  },
+  {
+    "name": "libdazzle-1.0-0",
+    "version": "3.44.0-1"
+  },
+  {
+    "name": "libdazzle-common",
+    "version": "3.44.0-1"
+  },
+  {
+    "name": "libdb5.3",
+    "version": "5.3.28+dfsg1-0.8ubuntu3"
+  },
+  {
+    "name": "libdbus-1-3",
+    "version": "1.12.20-2ubuntu4"
+  },
+  {
+    "name": "libdbus-glib-1-2",
+    "version": "0.112-2build1"
+  },
+  {
+    "name": "libdbusmenu-glib4",
+    "version": "16.04.1+18.10.20180917-0ubuntu8"
+  },
+  {
+    "name": "libdbusmenu-gtk3-4",
+    "version": "16.04.1+18.10.20180917-0ubuntu8"
+  },
+  {
+    "name": "libdconf1",
+    "version": "0.40.0-3"
+  },
+  {
+    "name": "libdebconfclient0",
+    "version": "0.261ubuntu1"
+  },
+  {
+    "name": "libdebuginfod-common",
+    "version": "0.186-1build1"
+  },
+  {
+    "name": "libdebuginfod1",
+    "version": "0.186-1build1"
+  },
+  {
+    "name": "libdee-1.0-4",
+    "version": "1.2.7+17.10.20170616-6ubuntu4"
+  },
+  {
+    "name": "libdeflate0",
+    "version": "1.10-2"
+  },
+  {
+    "name": "libdevmapper1.02.1",
+    "version": "2:1.02.175-2.1ubuntu4"
+  },
+  {
+    "name": "libdjvulibre-text",
+    "version": "3.5.28-2build2"
+  },
+  {
+    "name": "libdjvulibre21",
+    "version": "3.5.28-2build2"
+  },
+  {
+    "name": "libdmapsharing-3.0-2",
+    "version": "2.9.41-3build2"
+  },
+  {
+    "name": "libdns-export1110",
+    "version": "1:9.11.19+dfsg-2.1ubuntu3"
+  },
+  {
+    "name": "libdotconf0",
+    "version": "1.3-0.3fakesync1build2"
+  },
+  {
+    "name": "libdrm-amdgpu1",
+    "version": "2.4.110-1ubuntu1"
+  },
+  {
+    "name": "libdrm-common",
+    "version": "2.4.110-1ubuntu1"
+  },
+  {
+    "name": "libdrm-intel1",
+    "version": "2.4.110-1ubuntu1"
+  },
+  {
+    "name": "libdrm-nouveau2",
+    "version": "2.4.110-1ubuntu1"
+  },
+  {
+    "name": "libdrm-radeon1",
+    "version": "2.4.110-1ubuntu1"
+  },
+  {
+    "name": "libdrm2",
+    "version": "2.4.110-1ubuntu1"
+  },
+  {
+    "name": "libdv4",
+    "version": "1.0.0-14build1"
+  },
+  {
+    "name": "libdw1",
+    "version": "0.186-1build1"
+  },
+  {
+    "name": "libe-book-0.1-1",
+    "version": "0.1.3-2build2"
+  },
+  {
+    "name": "libebackend-1.2-10",
+    "version": "3.44.0-2"
+  },
+  {
+    "name": "libebook-1.2-20",
+    "version": "3.44.0-2"
+  },
+  {
+    "name": "libebook-contacts-1.2-3",
+    "version": "3.44.0-2"
+  },
+  {
+    "name": "libecal-2.0-1",
+    "version": "3.44.0-2"
+  },
+  {
+    "name": "libedata-book-1.2-26",
+    "version": "3.44.0-2"
+  },
+  {
+    "name": "libedata-cal-2.0-1",
+    "version": "3.44.0-2"
+  },
+  {
+    "name": "libedataserver-1.2-26",
+    "version": "3.44.0-2"
+  },
+  {
+    "name": "libedataserverui-1.2-3",
+    "version": "3.44.0-2"
+  },
+  {
+    "name": "libedit2",
+    "version": "3.1-20210910-1build1"
+  },
+  {
+    "name": "libefiboot1",
+    "version": "37-6ubuntu2"
+  },
+  {
+    "name": "libefivar1",
+    "version": "37-6ubuntu2"
+  },
+  {
+    "name": "libegl-mesa0",
+    "version": "22.0.1-1ubuntu2"
+  },
+  {
+    "name": "libegl1",
+    "version": "1.4.0-1"
+  },
+  {
+    "name": "libelf1",
+    "version": "0.186-1build1"
+  },
+  {
+    "name": "libenchant-2-2",
+    "version": "2.3.2-1ubuntu2"
+  },
+  {
+    "name": "libencode-locale-perl",
+    "version": "1.05-1.1"
+  },
+  {
+    "name": "libeot0",
+    "version": "0.01-5build2"
+  },
+  {
+    "name": "libepoxy0",
+    "version": "1.5.10-1"
+  },
+  {
+    "name": "libepubgen-0.1-1",
+    "version": "0.1.1-1ubuntu5"
+  },
+  {
+    "name": "libespeak-ng1",
+    "version": "1.50+dfsg-10"
+  },
+  {
+    "name": "libestr0",
+    "version": "0.1.10-2.1build3"
+  },
+  {
+    "name": "libetonyek-0.1-1",
+    "version": "0.1.10-3build1"
+  },
+  {
+    "name": "libevdev2",
+    "version": "1.12.1+dfsg-1"
+  },
+  {
+    "name": "libevdocument3-4",
+    "version": "42.1-3"
+  },
+  {
+    "name": "libevent-2.1-7",
+    "version": "2.1.12-stable-1build3"
+  },
+  {
+    "name": "libevview3-3",
+    "version": "42.1-3"
+  },
+  {
+    "name": "libexempi8",
+    "version": "2.5.2-1build1"
+  },
+  {
+    "name": "libexif12",
+    "version": "0.6.24-1build1"
+  },
+  {
+    "name": "libexiv2-27",
+    "version": "0.27.5-3ubuntu1"
+  },
+  {
+    "name": "libexpat1",
+    "version": "2.4.7-1"
+  },
+  {
+    "name": "libext2fs2",
+    "version": "1.46.5-2ubuntu1"
+  },
+  {
+    "name": "libexttextcat-2.0-0",
+    "version": "3.4.5-1build2"
+  },
+  {
+    "name": "libexttextcat-data",
+    "version": "3.4.5-1build2"
+  },
+  {
+    "name": "libextutils-depends-perl",
+    "version": "0.8001-1"
+  },
+  {
+    "name": "libfastjson4",
+    "version": "0.99.9-1build2"
+  },
+  {
+    "name": "libfdisk1",
+    "version": "2.37.2-4ubuntu3"
+  },
+  {
+    "name": "libffi8",
+    "version": "3.4.2-4"
+  },
+  {
+    "name": "libfftw3-single3",
+    "version": "3.3.8-2ubuntu8"
+  },
+  {
+    "name": "libfido2-1",
+    "version": "1.10.0-1"
+  },
+  {
+    "name": "libfile-basedir-perl",
+    "version": "0.09-1"
+  },
+  {
+    "name": "libfile-desktopentry-perl",
+    "version": "0.22-2"
+  },
+  {
+    "name": "libfile-listing-perl",
+    "version": "6.14-1"
+  },
+  {
+    "name": "libfile-mimeinfo-perl",
+    "version": "0.31-1"
+  },
+  {
+    "name": "libflac8",
+    "version": "1.3.3-2build2"
+  },
+  {
+    "name": "libflashrom1",
+    "version": "1.2-5build1"
+  },
+  {
+    "name": "libfont-afm-perl",
+    "version": "1.20-3"
+  },
+  {
+    "name": "libfontconfig1",
+    "version": "2.13.1-4.2ubuntu5"
+  },
+  {
+    "name": "libfontembed1",
+    "version": "1.28.15-0ubuntu1"
+  },
+  {
+    "name": "libfontenc1",
+    "version": "1:1.1.4-1build3"
+  },
+  {
+    "name": "libfprint-2-2",
+    "version": "1:1.94.3+tod1-0ubuntu1"
+  },
+  {
+    "name": "libfreehand-0.1-1",
+    "version": "0.1.2-3build2"
+  },
+  {
+    "name": "libfreerdp-client2-2",
+    "version": "2.6.1+dfsg1-3ubuntu1"
+  },
+  {
+    "name": "libfreerdp-server2-2",
+    "version": "2.6.1+dfsg1-3ubuntu1"
+  },
+  {
+    "name": "libfreerdp2-2",
+    "version": "2.6.1+dfsg1-3ubuntu1"
+  },
+  {
+    "name": "libfreetype6",
+    "version": "2.11.1+dfsg-1build1"
+  },
+  {
+    "name": "libfribidi0",
+    "version": "1.0.8-2ubuntu3"
+  },
+  {
+    "name": "libftdi1-2",
+    "version": "1.5-5build3"
+  },
+  {
+    "name": "libfuse3-3",
+    "version": "3.10.5-1build1"
+  },
+  {
+    "name": "libfwupd2",
+    "version": "1.7.5-3"
+  },
+  {
+    "name": "libfwupdplugin5",
+    "version": "1.7.5-3"
+  },
+  {
+    "name": "libgail-common",
+    "version": "2.24.33-2ubuntu2"
+  },
+  {
+    "name": "libgail18",
+    "version": "2.24.33-2ubuntu2"
+  },
+  {
+    "name": "libgamemode0",
+    "version": "1.6.1-1build2"
+  },
+  {
+    "name": "libgamemodeauto0",
+    "version": "1.6.1-1build2"
+  },
+  {
+    "name": "libgbm1",
+    "version": "22.0.1-1ubuntu2"
+  },
+  {
+    "name": "libgc1",
+    "version": "1:8.0.6-1.1build1"
+  },
+  {
+    "name": "libgcab-1.0-0",
+    "version": "1.4-3build2"
+  },
+  {
+    "name": "libgcc-s1",
+    "version": "12-20220319-1ubuntu1"
+  },
+  {
+    "name": "libgck-1-0",
+    "version": "3.40.0-4"
+  },
+  {
+    "name": "libgcr-base-3-1",
+    "version": "3.40.0-4"
+  },
+  {
+    "name": "libgcr-ui-3-1",
+    "version": "3.40.0-4"
+  },
+  {
+    "name": "libgcrypt20",
+    "version": "1.9.4-3ubuntu3"
+  },
+  {
+    "name": "libgd3",
+    "version": "2.3.0-2ubuntu2"
+  },
+  {
+    "name": "libgdata-common",
+    "version": "0.18.1-2build1"
+  },
+  {
+    "name": "libgdata22",
+    "version": "0.18.1-2build1"
+  },
+  {
+    "name": "libgdbm-compat4",
+    "version": "1.23-1"
+  },
+  {
+    "name": "libgdbm6",
+    "version": "1.23-1"
+  },
+  {
+    "name": "libgdk-pixbuf-2.0-0",
+    "version": "2.42.8+dfsg-1"
+  },
+  {
+    "name": "libgdk-pixbuf2.0-bin",
+    "version": "2.42.8+dfsg-1"
+  },
+  {
+    "name": "libgdk-pixbuf2.0-common",
+    "version": "2.42.8+dfsg-1"
+  },
+  {
+    "name": "libgdm1",
+    "version": "42.0-1ubuntu6"
+  },
+  {
+    "name": "libgee-0.8-2",
+    "version": "0.20.5-2"
+  },
+  {
+    "name": "libgeoclue-2-0",
+    "version": "2.5.7-3ubuntu3"
+  },
+  {
+    "name": "libgeocode-glib0",
+    "version": "3.26.2-2build2"
+  },
+  {
+    "name": "libgexiv2-2",
+    "version": "0.14.0-1build1"
+  },
+  {
+    "name": "libgif7",
+    "version": "5.1.9-2build2"
+  },
+  {
+    "name": "libgirepository-1.0-1",
+    "version": "1.72.0-1"
+  },
+  {
+    "name": "libgjs0g",
+    "version": "1.72.0-1"
+  },
+  {
+    "name": "libgl1",
+    "version": "1.4.0-1"
+  },
+  {
+    "name": "libgl1-amber-dri",
+    "version": "21.3.7-0ubuntu1"
+  },
+  {
+    "name": "libgl1-mesa-dri",
+    "version": "22.0.1-1ubuntu2"
+  },
+  {
+    "name": "libglapi-mesa",
+    "version": "22.0.1-1ubuntu2"
+  },
+  {
+    "name": "libgles2",
+    "version": "1.4.0-1"
+  },
+  {
+    "name": "libglib-object-introspection-perl",
+    "version": "0.049-1+build2"
+  },
+  {
+    "name": "libglib-perl",
+    "version": "3:1.329.3-2build1"
+  },
+  {
+    "name": "libglib2.0-0",
+    "version": "2.72.1-1"
+  },
+  {
+    "name": "libglib2.0-bin",
+    "version": "2.72.1-1"
+  },
+  {
+    "name": "libglib2.0-data",
+    "version": "2.72.1-1"
+  },
+  {
+    "name": "libglibmm-2.4-1v5",
+    "version": "2.66.2-2"
+  },
+  {
+    "name": "libglu1-mesa",
+    "version": "9.0.2-1"
+  },
+  {
+    "name": "libglvnd0",
+    "version": "1.4.0-1"
+  },
+  {
+    "name": "libglx-mesa0",
+    "version": "22.0.1-1ubuntu2"
+  },
+  {
+    "name": "libglx0",
+    "version": "1.4.0-1"
+  },
+  {
+    "name": "libgmp10",
+    "version": "2:6.2.1+dfsg-3ubuntu1"
+  },
+  {
+    "name": "libgnome-autoar-0-0",
+    "version": "0.4.3-1"
+  },
+  {
+    "name": "libgnome-bg-4-1",
+    "version": "42.0-1ubuntu1"
+  },
+  {
+    "name": "libgnome-bluetooth-3.0-13",
+    "version": "42.0-5"
+  },
+  {
+    "name": "libgnome-bluetooth13",
+    "version": "3.34.5-8"
+  },
+  {
+    "name": "libgnome-desktop-3-19",
+    "version": "42.0-1ubuntu1"
+  },
+  {
+    "name": "libgnome-desktop-4-1",
+    "version": "42.0-1ubuntu1"
+  },
+  {
+    "name": "libgnome-games-support-1-3",
+    "version": "1.8.2-1build1"
+  },
+  {
+    "name": "libgnome-games-support-common",
+    "version": "1.8.2-1build1"
+  },
+  {
+    "name": "libgnome-menu-3-0",
+    "version": "3.36.0-1ubuntu3"
+  },
+  {
+    "name": "libgnome-todo",
+    "version": "3.28.1-6ubuntu1"
+  },
+  {
+    "name": "libgnomekbd-common",
+    "version": "3.26.1-2"
+  },
+  {
+    "name": "libgnomekbd8",
+    "version": "3.26.1-2"
+  },
+  {
+    "name": "libgnutls30",
+    "version": "3.7.3-4ubuntu1"
+  },
+  {
+    "name": "libgoa-1.0-0b",
+    "version": "3.44.0-1ubuntu1"
+  },
+  {
+    "name": "libgoa-1.0-common",
+    "version": "3.44.0-1ubuntu1"
+  },
+  {
+    "name": "libgoa-backend-1.0-1",
+    "version": "3.44.0-1ubuntu1"
+  },
+  {
+    "name": "libgom-1.0-0",
+    "version": "0.4-1build2"
+  },
+  {
+    "name": "libgomp1",
+    "version": "12-20220319-1ubuntu1"
+  },
+  {
+    "name": "libgpg-error0",
+    "version": "1.43-3"
+  },
+  {
+    "name": "libgpgme11",
+    "version": "1.16.0-1.2ubuntu4"
+  },
+  {
+    "name": "libgpgmepp6",
+    "version": "1.16.0-1.2ubuntu4"
+  },
+  {
+    "name": "libgphoto2-6",
+    "version": "2.5.27-1build2"
+  },
+  {
+    "name": "libgphoto2-l10n",
+    "version": "2.5.27-1build2"
+  },
+  {
+    "name": "libgphoto2-port12",
+    "version": "2.5.27-1build2"
+  },
+  {
+    "name": "libgpm2",
+    "version": "1.20.7-10build1"
+  },
+  {
+    "name": "libgpod-common",
+    "version": "0.8.3-16build2"
+  },
+  {
+    "name": "libgpod4",
+    "version": "0.8.3-16build2"
+  },
+  {
+    "name": "libgraphene-1.0-0",
+    "version": "1.10.8-1"
+  },
+  {
+    "name": "libgraphite2-3",
+    "version": "1.3.14-1build2"
+  },
+  {
+    "name": "libgrilo-0.3-0",
+    "version": "0.3.14-1build1"
+  },
+  {
+    "name": "libgs9",
+    "version": "9.55.0~dfsg1-0ubuntu5"
+  },
+  {
+    "name": "libgs9-common",
+    "version": "9.55.0~dfsg1-0ubuntu5"
+  },
+  {
+    "name": "libgsf-1-114",
+    "version": "1.14.47-1build2"
+  },
+  {
+    "name": "libgsf-1-common",
+    "version": "1.14.47-1build2"
+  },
+  {
+    "name": "libgsound0",
+    "version": "1.0.3-2build1"
+  },
+  {
+    "name": "libgspell-1-2",
+    "version": "1.9.1-4"
+  },
+  {
+    "name": "libgspell-1-common",
+    "version": "1.9.1-4"
+  },
+  {
+    "name": "libgssapi-krb5-2",
+    "version": "1.19.2-2"
+  },
+  {
+    "name": "libgssdp-1.2-0",
+    "version": "1.4.0.1-2build1"
+  },
+  {
+    "name": "libgstreamer-gl1.0-0",
+    "version": "1.20.1-1"
+  },
+  {
+    "name": "libgstreamer-plugins-base1.0-0",
+    "version": "1.20.1-1"
+  },
+  {
+    "name": "libgstreamer-plugins-good1.0-0",
+    "version": "1.20.1-1ubuntu1"
+  },
+  {
+    "name": "libgstreamer1.0-0",
+    "version": "1.20.1-1"
+  },
+  {
+    "name": "libgtk-3-0",
+    "version": "3.24.33-1ubuntu1"
+  },
+  {
+    "name": "libgtk-3-bin",
+    "version": "3.24.33-1ubuntu1"
+  },
+  {
+    "name": "libgtk-3-common",
+    "version": "3.24.33-1ubuntu1"
+  },
+  {
+    "name": "libgtk-4-1",
+    "version": "4.6.2+ds-1ubuntu2"
+  },
+  {
+    "name": "libgtk-4-bin",
+    "version": "4.6.2+ds-1ubuntu2"
+  },
+  {
+    "name": "libgtk-4-common",
+    "version": "4.6.2+ds-1ubuntu2"
+  },
+  {
+    "name": "libgtk2.0-0",
+    "version": "2.24.33-2ubuntu2"
+  },
+  {
+    "name": "libgtk2.0-bin",
+    "version": "2.24.33-2ubuntu2"
+  },
+  {
+    "name": "libgtk2.0-common",
+    "version": "2.24.33-2ubuntu2"
+  },
+  {
+    "name": "libgtk3-perl",
+    "version": "0.038-1"
+  },
+  {
+    "name": "libgtkmm-3.0-1v5",
+    "version": "3.24.5-1build1"
+  },
+  {
+    "name": "libgtksourceview-4-0",
+    "version": "4.8.3-1"
+  },
+  {
+    "name": "libgtksourceview-4-common",
+    "version": "4.8.3-1"
+  },
+  {
+    "name": "libgtop-2.0-11",
+    "version": "2.40.0-2build3"
+  },
+  {
+    "name": "libgtop2-common",
+    "version": "2.40.0-2build3"
+  },
+  {
+    "name": "libgudev-1.0-0",
+    "version": "1:237-2build1"
+  },
+  {
+    "name": "libgupnp-1.2-1",
+    "version": "1.4.3-1"
+  },
+  {
+    "name": "libgupnp-av-1.0-3",
+    "version": "0.14.0-3"
+  },
+  {
+    "name": "libgupnp-dlna-2.0-4",
+    "version": "0.12.0-3"
+  },
+  {
+    "name": "libgusb2",
+    "version": "0.3.10-1"
+  },
+  {
+    "name": "libgweather-3-16",
+    "version": "40.0-5build1"
+  },
+  {
+    "name": "libgweather-common",
+    "version": "40.0-5build1"
+  },
+  {
+    "name": "libgxps2",
+    "version": "0.3.2-2"
+  },
+  {
+    "name": "libhandy-1-0",
+    "version": "1.6.1-1"
+  },
+  {
+    "name": "libharfbuzz-icu0",
+    "version": "2.7.4-1ubuntu3"
+  },
+  {
+    "name": "libharfbuzz0b",
+    "version": "2.7.4-1ubuntu3"
+  },
+  {
+    "name": "libhogweed6",
+    "version": "3.7.3-1build2"
+  },
+  {
+    "name": "libhpmud0",
+    "version": "3.21.12+dfsg0-1"
+  },
+  {
+    "name": "libhtml-format-perl",
+    "version": "2.12-1.1"
+  },
+  {
+    "name": "libhtml-parser-perl",
+    "version": "3.76-1build2"
+  },
+  {
+    "name": "libhttp-cookies-perl",
+    "version": "6.10-1"
+  },
+  {
+    "name": "libhttp-daemon-perl",
+    "version": "6.13-1"
+  },
+  {
+    "name": "libhttp-message-perl",
+    "version": "6.36-1"
+  },
+  {
+    "name": "libhunspell-1.7-0",
+    "version": "1.7.0-4build1"
+  },
+  {
+    "name": "libhyphen0",
+    "version": "2.8.8-7build2"
+  },
+  {
+    "name": "libibus-1.0-5",
+    "version": "1.5.26-4"
+  },
+  {
+    "name": "libical3",
+    "version": "3.0.14-1build1"
+  },
+  {
+    "name": "libice6",
+    "version": "2:1.0.10-1build2"
+  },
+  {
+    "name": "libicu70",
+    "version": "70.1-2"
+  },
+  {
+    "name": "libidn12",
+    "version": "1.38-4build1"
+  },
+  {
+    "name": "libidn2-0",
+    "version": "2.3.2-2build1"
+  },
+  {
+    "name": "libiec61883-0",
+    "version": "1.2.0-4build3"
+  },
+  {
+    "name": "libieee1284-3",
+    "version": "0.2.11-14build2"
+  },
+  {
+    "name": "libijs-0.35",
+    "version": "0.35-15build2"
+  },
+  {
+    "name": "libimagequant0",
+    "version": "2.17.0-1"
+  },
+  {
+    "name": "libimobiledevice6",
+    "version": "1.3.0-6build3"
+  },
+  {
+    "name": "libinih1",
+    "version": "53-1ubuntu3"
+  },
+  {
+    "name": "libinput-bin",
+    "version": "1.20.0-1"
+  },
+  {
+    "name": "libinput10",
+    "version": "1.20.0-1"
+  },
+  {
+    "name": "libio-html-perl",
+    "version": "1.004-2"
+  },
+  {
+    "name": "libio-socket-ssl-perl",
+    "version": "2.074-2"
+  },
+  {
+    "name": "libip4tc2",
+    "version": "1.8.7-1ubuntu5"
+  },
+  {
+    "name": "libip6tc2",
+    "version": "1.8.7-1ubuntu5"
+  },
+  {
+    "name": "libipc-system-simple-perl",
+    "version": "1.30-1"
+  },
+  {
+    "name": "libipt2",
+    "version": "2.0.5-1"
+  },
+  {
+    "name": "libisc-export1105",
+    "version": "1:9.11.19+dfsg-2.1ubuntu3"
+  },
+  {
+    "name": "libisl23",
+    "version": "0.24-2build1"
+  },
+  {
+    "name": "libiw30",
+    "version": "30~pre9-13.1ubuntu4"
+  },
+  {
+    "name": "libjack-jackd2-0",
+    "version": "1.9.20~dfsg-1"
+  },
+  {
+    "name": "libjansson4",
+    "version": "2.13.1-1.1build3"
+  },
+  {
+    "name": "libjavascriptcoregtk-4.0-18",
+    "version": "2.36.0-2ubuntu1"
+  },
+  {
+    "name": "libjbig0",
+    "version": "2.1-3.1build3"
+  },
+  {
+    "name": "libjbig2dec0",
+    "version": "0.19-3build2"
+  },
+  {
+    "name": "libjcat1",
+    "version": "0.1.9-1"
+  },
+  {
+    "name": "libjpeg-turbo8",
+    "version": "2.1.2-0ubuntu1"
+  },
+  {
+    "name": "libjpeg8",
+    "version": "8c-2ubuntu10"
+  },
+  {
+    "name": "libjson-c5",
+    "version": "0.15-2build4"
+  },
+  {
+    "name": "libjson-glib-1.0-0",
+    "version": "1.6.6-1build1"
+  },
+  {
+    "name": "libjson-glib-1.0-common",
+    "version": "1.6.6-1build1"
+  },
+  {
+    "name": "libk5crypto3",
+    "version": "1.19.2-2"
+  },
+  {
+    "name": "libkeyutils1",
+    "version": "1.6.1-2ubuntu3"
+  },
+  {
+    "name": "libklibc",
+    "version": "2.0.10-4"
+  },
+  {
+    "name": "libkmod2",
+    "version": "29-1ubuntu1"
+  },
+  {
+    "name": "libkpathsea6",
+    "version": "2021.20210626.59705-1build1"
+  },
+  {
+    "name": "libkrb5-3",
+    "version": "1.19.2-2"
+  },
+  {
+    "name": "libkrb5support0",
+    "version": "1.19.2-2"
+  },
+  {
+    "name": "libksba8",
+    "version": "1.6.0-2build1"
+  },
+  {
+    "name": "liblangtag-common",
+    "version": "0.6.3-2ubuntu1"
+  },
+  {
+    "name": "liblangtag1",
+    "version": "0.6.3-2ubuntu1"
+  },
+  {
+    "name": "liblcms2-2",
+    "version": "2.12~rc1-2build2"
+  },
+  {
+    "name": "liblcms2-utils",
+    "version": "2.12~rc1-2build2"
+  },
+  {
+    "name": "libldap-2.5-0",
+    "version": "2.5.11+dfsg-1~exp1ubuntu3"
+  },
+  {
+    "name": "libldap-common",
+    "version": "2.5.11+dfsg-1~exp1ubuntu3"
+  },
+  {
+    "name": "libldb2",
+    "version": "2:2.4.2-0ubuntu1"
+  },
+  {
+    "name": "liblirc-client0",
+    "version": "0.10.1-6.3ubuntu1"
+  },
+  {
+    "name": "libllvm13",
+    "version": "1:13.0.1-2ubuntu2"
+  },
+  {
+    "name": "liblmdb0",
+    "version": "0.9.24-1build2"
+  },
+  {
+    "name": "liblocale-gettext-perl",
+    "version": "1.07-4build3"
+  },
+  {
+    "name": "liblouis-data",
+    "version": "3.20.0-2"
+  },
+  {
+    "name": "liblouis20",
+    "version": "3.20.0-2"
+  },
+  {
+    "name": "liblouisutdml-bin",
+    "version": "2.10.0-4"
+  },
+  {
+    "name": "liblouisutdml-data",
+    "version": "2.10.0-4"
+  },
+  {
+    "name": "liblouisutdml9",
+    "version": "2.10.0-4"
+  },
+  {
+    "name": "libltdl7",
+    "version": "2.4.6-15build2"
+  },
+  {
+    "name": "liblua5.3-0",
+    "version": "5.3.6-1build1"
+  },
+  {
+    "name": "liblwp-protocol-https-perl",
+    "version": "6.10-1"
+  },
+  {
+    "name": "liblz4-1",
+    "version": "1.9.3-2build2"
+  },
+  {
+    "name": "liblzma5",
+    "version": "5.2.5-2ubuntu1"
+  },
+  {
+    "name": "liblzo2-2",
+    "version": "2.10-2build3"
+  },
+  {
+    "name": "libmagic-mgc",
+    "version": "1:5.41-3"
+  },
+  {
+    "name": "libmagic1",
+    "version": "1:5.41-3"
+  },
+  {
+    "name": "libmanette-0.2-0",
+    "version": "0.2.6-3build1"
+  },
+  {
+    "name": "libmaxminddb0",
+    "version": "1.5.2-1build2"
+  },
+  {
+    "name": "libmbim-glib4",
+    "version": "1.26.2-1build1"
+  },
+  {
+    "name": "libmbim-proxy",
+    "version": "1.26.2-1build1"
+  },
+  {
+    "name": "libmd0",
+    "version": "1.0.4-1build1"
+  },
+  {
+    "name": "libmediaart-2.0-0",
+    "version": "1.9.5-2build1"
+  },
+  {
+    "name": "libmessaging-menu0",
+    "version": "22.2.0-1"
+  },
+  {
+    "name": "libmhash2",
+    "version": "0.9.9.9-9build2"
+  },
+  {
+    "name": "libminiupnpc17",
+    "version": "2.2.3-1build1"
+  },
+  {
+    "name": "libmm-glib0",
+    "version": "1.18.6-1"
+  },
+  {
+    "name": "libmnl0",
+    "version": "1.0.4-3build2"
+  },
+  {
+    "name": "libmount1",
+    "version": "2.37.2-4ubuntu3"
+  },
+  {
+    "name": "libmozjs-91-0",
+    "version": "91.7.0-2"
+  },
+  {
+    "name": "libmp3lame0",
+    "version": "3.100-3build2"
+  },
+  {
+    "name": "libmpc3",
+    "version": "1.2.1-2build1"
+  },
+  {
+    "name": "libmpdec3",
+    "version": "2.5.1-2build2"
+  },
+  {
+    "name": "libmpfr6",
+    "version": "4.1.0-3build3"
+  },
+  {
+    "name": "libmpg123-0",
+    "version": "1.29.3-1build1"
+  },
+  {
+    "name": "libmspub-0.1-1",
+    "version": "0.1.4-3build3"
+  },
+  {
+    "name": "libmtdev1",
+    "version": "1.1.6-1build4"
+  },
+  {
+    "name": "libmtp-common",
+    "version": "1.1.19-1build1"
+  },
+  {
+    "name": "libmtp-runtime",
+    "version": "1.1.19-1build1"
+  },
+  {
+    "name": "libmtp9",
+    "version": "1.1.19-1build1"
+  },
+  {
+    "name": "libmutter-10-0",
+    "version": "42.0-3ubuntu2"
+  },
+  {
+    "name": "libmwaw-0.3-3",
+    "version": "0.3.21-1build1"
+  },
+  {
+    "name": "libmythes-1.2-0",
+    "version": "2:1.2.4-4build1"
+  },
+  {
+    "name": "libnatpmp1",
+    "version": "20150609-7.1build2"
+  },
+  {
+    "name": "libnautilus-extension1a",
+    "version": "1:42.0-1ubuntu2"
+  },
+  {
+    "name": "libncurses6",
+    "version": "6.3-2"
+  },
+  {
+    "name": "libncursesw6",
+    "version": "6.3-2"
+  },
+  {
+    "name": "libndp0",
+    "version": "1.8-0ubuntu3"
+  },
+  {
+    "name": "libnet-dbus-perl",
+    "version": "1.2.0-1build3"
+  },
+  {
+    "name": "libnet-http-perl",
+    "version": "6.22-1"
+  },
+  {
+    "name": "libnet-ssleay-perl",
+    "version": "1.92-1build2"
+  },
+  {
+    "name": "libnetfilter-conntrack3",
+    "version": "1.0.9-1"
+  },
+  {
+    "name": "libnetplan0",
+    "version": "0.104-0ubuntu2"
+  },
+  {
+    "name": "libnettle8",
+    "version": "3.7.3-1build2"
+  },
+  {
+    "name": "libnewt0.52",
+    "version": "0.52.21-5ubuntu2"
+  },
+  {
+    "name": "libnfnetlink0",
+    "version": "1.0.1-3build3"
+  },
+  {
+    "name": "libnfs13",
+    "version": "4.0.0-1build2"
+  },
+  {
+    "name": "libnftables1",
+    "version": "1.0.2-1ubuntu2"
+  },
+  {
+    "name": "libnftnl11",
+    "version": "1.2.1-1build1"
+  },
+  {
+    "name": "libnghttp2-14",
+    "version": "1.43.0-1build3"
+  },
+  {
+    "name": "libnl-3-200",
+    "version": "3.5.0-0.1"
+  },
+  {
+    "name": "libnl-genl-3-200",
+    "version": "3.5.0-0.1"
+  },
+  {
+    "name": "libnl-route-3-200",
+    "version": "3.5.0-0.1"
+  },
+  {
+    "name": "libnm0",
+    "version": "1.36.4-2ubuntu1"
+  },
+  {
+    "name": "libnma-common",
+    "version": "1.8.34-1ubuntu1"
+  },
+  {
+    "name": "libnma0",
+    "version": "1.8.34-1ubuntu1"
+  },
+  {
+    "name": "libnotify-bin",
+    "version": "0.7.9-3ubuntu5"
+  },
+  {
+    "name": "libnotify4",
+    "version": "0.7.9-3ubuntu5"
+  },
+  {
+    "name": "libnpth0",
+    "version": "1.6-3build2"
+  },
+  {
+    "name": "libnsl2",
+    "version": "1.3.0-2build2"
+  },
+  {
+    "name": "libnspr4",
+    "version": "2:4.32-3build1"
+  },
+  {
+    "name": "libnss-mdns",
+    "version": "0.15.1-1ubuntu1"
+  },
+  {
+    "name": "libnss-systemd",
+    "version": "249.11-0ubuntu3"
+  },
+  {
+    "name": "libnss3",
+    "version": "2:3.68.2-0ubuntu1"
+  },
+  {
+    "name": "libntfs-3g89",
+    "version": "1:2021.8.22-3ubuntu1"
+  },
+  {
+    "name": "libnuma1",
+    "version": "2.0.14-3ubuntu2"
+  },
+  {
+    "name": "libodfgen-0.1-1",
+    "version": "0.1.8-2build2"
+  },
+  {
+    "name": "libogg0",
+    "version": "1.3.5-0ubuntu3"
+  },
+  {
+    "name": "libopengl0",
+    "version": "1.4.0-1"
+  },
+  {
+    "name": "libopenjp2-7",
+    "version": "2.4.0-6"
+  },
+  {
+    "name": "libopenscap8",
+    "version": "1.2.17-0.1ubuntu7"
+  },
+  {
+    "name": "libopus0",
+    "version": "1.3.1-0.1build2"
+  },
+  {
+    "name": "liborc-0.4-0",
+    "version": "1:0.4.32-2"
+  },
+  {
+    "name": "liborcus-0.17-0",
+    "version": "0.17.2-2"
+  },
+  {
+    "name": "liborcus-parser-0.17-0",
+    "version": "0.17.2-2"
+  },
+  {
+    "name": "libp11-kit0",
+    "version": "0.24.0-6build1"
+  },
+  {
+    "name": "libpackagekit-glib2-18",
+    "version": "1.2.5-2ubuntu2"
+  },
+  {
+    "name": "libpagemaker-0.0-0",
+    "version": "0.0.4-1build3"
+  },
+  {
+    "name": "libpam-cap",
+    "version": "1:2.44-1build3"
+  },
+  {
+    "name": "libpam-fprintd",
+    "version": "1.94.2-1"
+  },
+  {
+    "name": "libpam-gnome-keyring",
+    "version": "40.0-3ubuntu2"
+  },
+  {
+    "name": "libpam-modules",
+    "version": "1.4.0-11ubuntu2"
+  },
+  {
+    "name": "libpam-modules-bin",
+    "version": "1.4.0-11ubuntu2"
+  },
+  {
+    "name": "libpam-pwquality",
+    "version": "1.4.4-1build2"
+  },
+  {
+    "name": "libpam-runtime",
+    "version": "1.4.0-11ubuntu2"
+  },
+  {
+    "name": "libpam-sss",
+    "version": "2.6.3-1ubuntu3"
+  },
+  {
+    "name": "libpam-systemd",
+    "version": "249.11-0ubuntu3"
+  },
+  {
+    "name": "libpam0g",
+    "version": "1.4.0-11ubuntu2"
+  },
+  {
+    "name": "libpango-1.0-0",
+    "version": "1.50.6+ds-2"
+  },
+  {
+    "name": "libpangocairo-1.0-0",
+    "version": "1.50.6+ds-2"
+  },
+  {
+    "name": "libpangoft2-1.0-0",
+    "version": "1.50.6+ds-2"
+  },
+  {
+    "name": "libpangomm-1.4-1v5",
+    "version": "2.46.2-1"
+  },
+  {
+    "name": "libpangoxft-1.0-0",
+    "version": "1.50.6+ds-2"
+  },
+  {
+    "name": "libpaper-utils",
+    "version": "1.1.28build2"
+  },
+  {
+    "name": "libpaper1",
+    "version": "1.1.28build2"
+  },
+  {
+    "name": "libparted-fs-resize0",
+    "version": "3.4-2build1"
+  },
+  {
+    "name": "libparted2",
+    "version": "3.4-2build1"
+  },
+  {
+    "name": "libpcap0.8",
+    "version": "1.10.1-4build1"
+  },
+  {
+    "name": "libpcaudio0",
+    "version": "1.1-6build2"
+  },
+  {
+    "name": "libpci3",
+    "version": "1:3.7.0-6"
+  },
+  {
+    "name": "libpciaccess0",
+    "version": "0.16-3"
+  },
+  {
+    "name": "libpcre2-32-0",
+    "version": "10.39-3build1"
+  },
+  {
+    "name": "libpcre2-8-0",
+    "version": "10.39-3build1"
+  },
+  {
+    "name": "libpcsclite1",
+    "version": "1.9.5-3"
+  },
+  {
+    "name": "libpeas-1.0-0",
+    "version": "1.32.0-1"
+  },
+  {
+    "name": "libpeas-common",
+    "version": "1.32.0-1"
+  },
+  {
+    "name": "libperl5.34",
+    "version": "5.34.0-3ubuntu1"
+  },
+  {
+    "name": "libphonenumber8",
+    "version": "8.12.44-1"
+  },
+  {
+    "name": "libpipeline1",
+    "version": "1.5.5-1"
+  },
+  {
+    "name": "libpipewire-0.3-0",
+    "version": "0.3.48-1ubuntu1"
+  },
+  {
+    "name": "libpipewire-0.3-common",
+    "version": "0.3.48-1ubuntu1"
+  },
+  {
+    "name": "libpipewire-0.3-modules",
+    "version": "0.3.48-1ubuntu1"
+  },
+  {
+    "name": "libpixman-1-0",
+    "version": "0.40.0-1build4"
+  },
+  {
+    "name": "libpkcs11-helper1",
+    "version": "1.28-1"
+  },
+  {
+    "name": "libplist3",
+    "version": "2.2.0-6build2"
+  },
+  {
+    "name": "libplymouth5",
+    "version": "0.9.5+git20211018-1ubuntu3"
+  },
+  {
+    "name": "libpng16-16",
+    "version": "1.6.37-3build5"
+  },
+  {
+    "name": "libpolkit-agent-1-0",
+    "version": "0.105-33"
+  },
+  {
+    "name": "libpolkit-gobject-1-0",
+    "version": "0.105-33"
+  },
+  {
+    "name": "libpoppler-cpp0v5",
+    "version": "22.02.0-2"
+  },
+  {
+    "name": "libpoppler-glib8",
+    "version": "22.02.0-2"
+  },
+  {
+    "name": "libpoppler118",
+    "version": "22.02.0-2"
+  },
+  {
+    "name": "libpopt0",
+    "version": "1.18-3build1"
+  },
+  {
+    "name": "libprocps8",
+    "version": "2:3.3.17-6ubuntu2"
+  },
+  {
+    "name": "libprotobuf23",
+    "version": "3.12.4-1ubuntu7"
+  },
+  {
+    "name": "libproxy1-plugin-gsettings",
+    "version": "0.4.17-2"
+  },
+  {
+    "name": "libproxy1-plugin-networkmanager",
+    "version": "0.4.17-2"
+  },
+  {
+    "name": "libproxy1v5",
+    "version": "0.4.17-2"
+  },
+  {
+    "name": "libpsl5",
+    "version": "0.21.0-1.2build2"
+  },
+  {
+    "name": "libpulse-mainloop-glib0",
+    "version": "1:15.99.1+dfsg1-1ubuntu1"
+  },
+  {
+    "name": "libpulse0",
+    "version": "1:15.99.1+dfsg1-1ubuntu1"
+  },
+  {
+    "name": "libpulsedsp",
+    "version": "1:15.99.1+dfsg1-1ubuntu1"
+  },
+  {
+    "name": "libpwquality-common",
+    "version": "1.4.4-1build2"
+  },
+  {
+    "name": "libpwquality1",
+    "version": "1.4.4-1build2"
+  },
+  {
+    "name": "libpython3-stdlib",
+    "version": "3.10.4-0ubuntu2"
+  },
+  {
+    "name": "libpython3.10",
+    "version": "3.10.4-3"
+  },
+  {
+    "name": "libpython3.10-minimal",
+    "version": "3.10.4-3"
+  },
+  {
+    "name": "libpython3.10-stdlib",
+    "version": "3.10.4-3"
+  },
+  {
+    "name": "libqmi-glib5",
+    "version": "1.30.4-1"
+  },
+  {
+    "name": "libqmi-proxy",
+    "version": "1.30.4-1"
+  },
+  {
+    "name": "libqpdf28",
+    "version": "10.6.3-1"
+  },
+  {
+    "name": "libqqwing2v5",
+    "version": "1.3.4-1.1ubuntu3"
+  },
+  {
+    "name": "libraptor2-0",
+    "version": "2.0.15-0ubuntu4"
+  },
+  {
+    "name": "libraqm0",
+    "version": "0.7.0-4ubuntu1"
+  },
+  {
+    "name": "librasqal3",
+    "version": "0.9.33-0.2ubuntu1"
+  },
+  {
+    "name": "libraw1394-11",
+    "version": "2.1.2-2build2"
+  },
+  {
+    "name": "libraw20",
+    "version": "0.20.2-2ubuntu2"
+  },
+  {
+    "name": "librdf0",
+    "version": "1.0.17-1.1ubuntu3"
+  },
+  {
+    "name": "libreadline8",
+    "version": "8.1.2-1"
+  },
+  {
+    "name": "libreoffice-base-core",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libreoffice-calc",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libreoffice-common",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libreoffice-core",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libreoffice-draw",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libreoffice-gnome",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libreoffice-gtk3",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libreoffice-help-common",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libreoffice-help-en-us",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libreoffice-impress",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libreoffice-math",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libreoffice-ogltrans",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libreoffice-pdfimport",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libreoffice-style-breeze",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libreoffice-style-colibre",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libreoffice-style-elementary",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libreoffice-style-yaru",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libreoffice-writer",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "librest-0.7-0",
+    "version": "0.8.1-1.1build2"
+  },
+  {
+    "name": "librevenge-0.0-0",
+    "version": "0.0.4-6ubuntu7"
+  },
+  {
+    "name": "librhythmbox-core10",
+    "version": "3.4.4-5ubuntu1"
+  },
+  {
+    "name": "librsvg2-2",
+    "version": "2.52.5+dfsg-3"
+  },
+  {
+    "name": "librsvg2-common",
+    "version": "2.52.5+dfsg-3"
+  },
+  {
+    "name": "librsync2",
+    "version": "2.3.2-1ubuntu1"
+  },
+  {
+    "name": "librtmp1",
+    "version": "2.4+20151223.gitfa8646d.1-2build4"
+  },
+  {
+    "name": "librygel-core-2.6-2",
+    "version": "0.40.3-1ubuntu2"
+  },
+  {
+    "name": "librygel-db-2.6-2",
+    "version": "0.40.3-1ubuntu2"
+  },
+  {
+    "name": "librygel-renderer-2.6-2",
+    "version": "0.40.3-1ubuntu2"
+  },
+  {
+    "name": "librygel-server-2.6-2",
+    "version": "0.40.3-1ubuntu2"
+  },
+  {
+    "name": "libsamplerate0",
+    "version": "0.2.2-1build1"
+  },
+  {
+    "name": "libsane-common",
+    "version": "1.1.1-5"
+  },
+  {
+    "name": "libsane-hpaio",
+    "version": "3.21.12+dfsg0-1"
+  },
+  {
+    "name": "libsane1",
+    "version": "1.1.1-5"
+  },
+  {
+    "name": "libsasl2-2",
+    "version": "2.1.27+dfsg2-3ubuntu1"
+  },
+  {
+    "name": "libsasl2-modules",
+    "version": "2.1.27+dfsg2-3ubuntu1"
+  },
+  {
+    "name": "libsasl2-modules-db",
+    "version": "2.1.27+dfsg2-3ubuntu1"
+  },
+  {
+    "name": "libsasl2-modules-gssapi-mit",
+    "version": "2.1.27+dfsg2-3ubuntu1"
+  },
+  {
+    "name": "libsbc1",
+    "version": "1.5-3build2"
+  },
+  {
+    "name": "libseccomp2",
+    "version": "2.5.3-2ubuntu2"
+  },
+  {
+    "name": "libsecret-1-0",
+    "version": "0.20.5-2"
+  },
+  {
+    "name": "libsecret-common",
+    "version": "0.20.5-2"
+  },
+  {
+    "name": "libselinux1",
+    "version": "3.3-1build2"
+  },
+  {
+    "name": "libsemanage-common",
+    "version": "3.3-1build2"
+  },
+  {
+    "name": "libsemanage2",
+    "version": "3.3-1build2"
+  },
+  {
+    "name": "libsensors-config",
+    "version": "1:3.6.0-7ubuntu1"
+  },
+  {
+    "name": "libsensors5",
+    "version": "1:3.6.0-7ubuntu1"
+  },
+  {
+    "name": "libsepol2",
+    "version": "3.3-1build1"
+  },
+  {
+    "name": "libsgutils2-2",
+    "version": "1.46-1build1"
+  },
+  {
+    "name": "libshout3",
+    "version": "2.4.5-1build3"
+  },
+  {
+    "name": "libsigc++-2.0-0v5",
+    "version": "2.10.4-2ubuntu3"
+  },
+  {
+    "name": "libslang2",
+    "version": "2.3.2-5build4"
+  },
+  {
+    "name": "libsm6",
+    "version": "2:1.2.3-1build2"
+  },
+  {
+    "name": "libsmartcols1",
+    "version": "2.37.2-4ubuntu3"
+  },
+  {
+    "name": "libsmbclient",
+    "version": "2:4.15.5~dfsg-0ubuntu5"
+  },
+  {
+    "name": "libsmbios-c2",
+    "version": "2.4.3-1build1"
+  },
+  {
+    "name": "libsnapd-glib1",
+    "version": "1.60-0ubuntu1"
+  },
+  {
+    "name": "libsndfile1",
+    "version": "1.0.31-2build1"
+  },
+  {
+    "name": "libsnmp-base",
+    "version": "5.9.1+dfsg-1ubuntu2"
+  },
+  {
+    "name": "libsnmp40",
+    "version": "5.9.1+dfsg-1ubuntu2"
+  },
+  {
+    "name": "libsodium23",
+    "version": "1.0.18-1build2"
+  },
+  {
+    "name": "libsonic0",
+    "version": "0.2.0-11build1"
+  },
+  {
+    "name": "libsoup-gnome2.4-1",
+    "version": "2.74.2-3"
+  },
+  {
+    "name": "libsoup2.4-1",
+    "version": "2.74.2-3"
+  },
+  {
+    "name": "libsoup2.4-common",
+    "version": "2.74.2-3"
+  },
+  {
+    "name": "libsource-highlight-common",
+    "version": "3.1.9-4.1build2"
+  },
+  {
+    "name": "libsource-highlight4v5",
+    "version": "3.1.9-4.1build2"
+  },
+  {
+    "name": "libsoxr0",
+    "version": "0.1.3-4build2"
+  },
+  {
+    "name": "libspa-0.2-modules",
+    "version": "0.3.48-1ubuntu1"
+  },
+  {
+    "name": "libspectre1",
+    "version": "0.2.10-1"
+  },
+  {
+    "name": "libspeechd2",
+    "version": "0.11.1-1"
+  },
+  {
+    "name": "libspeex1",
+    "version": "1.2~rc1.2-1.1ubuntu3"
+  },
+  {
+    "name": "libspeexdsp1",
+    "version": "1.2~rc1.2-1.1ubuntu3"
+  },
+  {
+    "name": "libsqlite3-0",
+    "version": "3.37.2-2"
+  },
+  {
+    "name": "libss2",
+    "version": "1.46.5-2ubuntu1"
+  },
+  {
+    "name": "libssh-4",
+    "version": "0.9.6-2build1"
+  },
+  {
+    "name": "libssl3",
+    "version": "3.0.2-0ubuntu1"
+  },
+  {
+    "name": "libstartup-notification0",
+    "version": "0.12-6build2"
+  },
+  {
+    "name": "libstdc++6",
+    "version": "12-20220319-1ubuntu1"
+  },
+  {
+    "name": "libstemmer0d",
+    "version": "2.2.0-1build1"
+  },
+  {
+    "name": "libsuitesparseconfig5",
+    "version": "1:5.10.1+dfsg-4build1"
+  },
+  {
+    "name": "libsynctex2",
+    "version": "2021.20210626.59705-1build1"
+  },
+  {
+    "name": "libsysmetrics1",
+    "version": "1.7.1"
+  },
+  {
+    "name": "libsystemd0",
+    "version": "249.11-0ubuntu3"
+  },
+  {
+    "name": "libtag1v5",
+    "version": "1.11.1+dfsg.1-3ubuntu3"
+  },
+  {
+    "name": "libtag1v5-vanilla",
+    "version": "1.11.1+dfsg.1-3ubuntu3"
+  },
+  {
+    "name": "libtalloc2",
+    "version": "2.3.3-2build1"
+  },
+  {
+    "name": "libtasn1-6",
+    "version": "4.18.0-4build1"
+  },
+  {
+    "name": "libtcl8.6",
+    "version": "8.6.12+dfsg-1build1"
+  },
+  {
+    "name": "libtdb1",
+    "version": "1.4.5-2build1"
+  },
+  {
+    "name": "libteamdctl0",
+    "version": "1.31-1build2"
+  },
+  {
+    "name": "libtevent0",
+    "version": "0.11.0-1build1"
+  },
+  {
+    "name": "libtext-charwidth-perl",
+    "version": "0.04-10build3"
+  },
+  {
+    "name": "libtext-iconv-perl",
+    "version": "1.7-7build3"
+  },
+  {
+    "name": "libthai-data",
+    "version": "0.1.29-1build1"
+  },
+  {
+    "name": "libthai0",
+    "version": "0.1.29-1build1"
+  },
+  {
+    "name": "libtheora0",
+    "version": "1.1.1+dfsg.1-15ubuntu4"
+  },
+  {
+    "name": "libtie-ixhash-perl",
+    "version": "1.23-2.1"
+  },
+  {
+    "name": "libtiff5",
+    "version": "4.3.0-6"
+  },
+  {
+    "name": "libtimedate-perl",
+    "version": "2.3300-2"
+  },
+  {
+    "name": "libtinfo6",
+    "version": "6.3-2"
+  },
+  {
+    "name": "libtirpc-common",
+    "version": "1.3.2-2build1"
+  },
+  {
+    "name": "libtirpc3",
+    "version": "1.3.2-2build1"
+  },
+  {
+    "name": "libtotem-plparser-common",
+    "version": "3.26.6-1build1"
+  },
+  {
+    "name": "libtotem-plparser18",
+    "version": "3.26.6-1build1"
+  },
+  {
+    "name": "libtotem0",
+    "version": "42.0-1ubuntu1"
+  },
+  {
+    "name": "libtracker-sparql-3.0-0",
+    "version": "3.3.0-1"
+  },
+  {
+    "name": "libtry-tiny-perl",
+    "version": "0.31-1"
+  },
+  {
+    "name": "libtss2-esys-3.0.2-0",
+    "version": "3.2.0-1ubuntu1"
+  },
+  {
+    "name": "libtss2-mu0",
+    "version": "3.2.0-1ubuntu1"
+  },
+  {
+    "name": "libtss2-sys1",
+    "version": "3.2.0-1ubuntu1"
+  },
+  {
+    "name": "libtss2-tcti-cmd0",
+    "version": "3.2.0-1ubuntu1"
+  },
+  {
+    "name": "libtss2-tcti-device0",
+    "version": "3.2.0-1ubuntu1"
+  },
+  {
+    "name": "libtss2-tcti-mssim0",
+    "version": "3.2.0-1ubuntu1"
+  },
+  {
+    "name": "libtss2-tcti-swtpm0",
+    "version": "3.2.0-1ubuntu1"
+  },
+  {
+    "name": "libtwolame0",
+    "version": "0.4.0-2build2"
+  },
+  {
+    "name": "libu2f-udev",
+    "version": "1.1.10-3build2"
+  },
+  {
+    "name": "libuchardet0",
+    "version": "0.0.7-1build2"
+  },
+  {
+    "name": "libudev1",
+    "version": "249.11-0ubuntu3"
+  },
+  {
+    "name": "libudisks2-0",
+    "version": "2.9.4-1ubuntu2"
+  },
+  {
+    "name": "libunistring2",
+    "version": "1.0-1"
+  },
+  {
+    "name": "libunity-protocol-private0",
+    "version": "7.1.4+19.04.20190319-6build1"
+  },
+  {
+    "name": "libunity-scopes-json-def-desktop",
+    "version": "7.1.4+19.04.20190319-6build1"
+  },
+  {
+    "name": "libunity9",
+    "version": "7.1.4+19.04.20190319-6build1"
+  },
+  {
+    "name": "libuno-cppu3",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libuno-cppuhelpergcc3-3",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libuno-purpenvhelpergcc3-3",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libuno-sal3",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libuno-salhelpergcc3-3",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "libunwind8",
+    "version": "1.3.2-2build2"
+  },
+  {
+    "name": "libupower-glib3",
+    "version": "0.99.17-1"
+  },
+  {
+    "name": "liburi-perl",
+    "version": "5.10-1"
+  },
+  {
+    "name": "libusb-1.0-0",
+    "version": "2:1.0.25-1ubuntu1"
+  },
+  {
+    "name": "libusbmuxd6",
+    "version": "2.0.2-3build2"
+  },
+  {
+    "name": "libuuid1",
+    "version": "2.37.2-4ubuntu3"
+  },
+  {
+    "name": "libuv1",
+    "version": "1.43.0-1"
+  },
+  {
+    "name": "libv4l-0",
+    "version": "1.22.1-2build1"
+  },
+  {
+    "name": "libv4lconvert0",
+    "version": "1.22.1-2build1"
+  },
+  {
+    "name": "libvisio-0.1-1",
+    "version": "0.1.7-1build5"
+  },
+  {
+    "name": "libvisual-0.4-0",
+    "version": "0.4.0-17build2"
+  },
+  {
+    "name": "libvncclient1",
+    "version": "0.9.13+dfsg-3build2"
+  },
+  {
+    "name": "libvncserver1",
+    "version": "0.9.13+dfsg-3build2"
+  },
+  {
+    "name": "libvolume-key1",
+    "version": "0.3.12-3.1build3"
+  },
+  {
+    "name": "libvorbis0a",
+    "version": "1.3.7-1build2"
+  },
+  {
+    "name": "libvorbisenc2",
+    "version": "1.3.7-1build2"
+  },
+  {
+    "name": "libvorbisfile3",
+    "version": "1.3.7-1build2"
+  },
+  {
+    "name": "libvpx7",
+    "version": "1.11.0-2ubuntu2"
+  },
+  {
+    "name": "libvte-2.91-0",
+    "version": "0.68.0-1"
+  },
+  {
+    "name": "libvte-2.91-common",
+    "version": "0.68.0-1"
+  },
+  {
+    "name": "libvulkan1",
+    "version": "1.3.204.1-2"
+  },
+  {
+    "name": "libwacom-bin",
+    "version": "2.2.0-1"
+  },
+  {
+    "name": "libwacom-common",
+    "version": "2.2.0-1"
+  },
+  {
+    "name": "libwacom9",
+    "version": "2.2.0-1"
+  },
+  {
+    "name": "libwavpack1",
+    "version": "5.4.0-1build2"
+  },
+  {
+    "name": "libwayland-client0",
+    "version": "1.20.0-1"
+  },
+  {
+    "name": "libwayland-cursor0",
+    "version": "1.20.0-1"
+  },
+  {
+    "name": "libwayland-egl1",
+    "version": "1.20.0-1"
+  },
+  {
+    "name": "libwayland-server0",
+    "version": "1.20.0-1"
+  },
+  {
+    "name": "libwbclient0",
+    "version": "2:4.15.5~dfsg-0ubuntu5"
+  },
+  {
+    "name": "libwebkit2gtk-4.0-37",
+    "version": "2.36.0-2ubuntu1"
+  },
+  {
+    "name": "libwebp7",
+    "version": "1.2.2-2"
+  },
+  {
+    "name": "libwebpdemux2",
+    "version": "1.2.2-2"
+  },
+  {
+    "name": "libwebpmux3",
+    "version": "1.2.2-2"
+  },
+  {
+    "name": "libwebrtc-audio-processing1",
+    "version": "0.3.1-0ubuntu5"
+  },
+  {
+    "name": "libwhoopsie-preferences0",
+    "version": "23"
+  },
+  {
+    "name": "libwhoopsie0",
+    "version": "0.2.77"
+  },
+  {
+    "name": "libwinpr2-2",
+    "version": "2.6.1+dfsg1-3ubuntu1"
+  },
+  {
+    "name": "libwmf-0.2-7",
+    "version": "0.2.12-5ubuntu1"
+  },
+  {
+    "name": "libwmf-0.2-7-gtk",
+    "version": "0.2.12-5ubuntu1"
+  },
+  {
+    "name": "libwmf0.2-7-gtk",
+    "version": "0.2.12-5ubuntu1"
+  },
+  {
+    "name": "libwmflite-0.2-7",
+    "version": "0.2.12-5ubuntu1"
+  },
+  {
+    "name": "libwnck-3-0",
+    "version": "40.1-1"
+  },
+  {
+    "name": "libwnck-3-common",
+    "version": "40.1-1"
+  },
+  {
+    "name": "libwoff1",
+    "version": "1.0.2-1build4"
+  },
+  {
+    "name": "libwpd-0.10-10",
+    "version": "0.10.3-2build1"
+  },
+  {
+    "name": "libwpg-0.3-3",
+    "version": "0.3.3-1build3"
+  },
+  {
+    "name": "libwps-0.4-4",
+    "version": "0.4.12-2build1"
+  },
+  {
+    "name": "libwrap0",
+    "version": "7.6.q-31build2"
+  },
+  {
+    "name": "libwww-perl",
+    "version": "6.61-1"
+  },
+  {
+    "name": "libx11-6",
+    "version": "2:1.7.5-1"
+  },
+  {
+    "name": "libx11-data",
+    "version": "2:1.7.5-1"
+  },
+  {
+    "name": "libx11-protocol-perl",
+    "version": "0.56-7.1"
+  },
+  {
+    "name": "libx11-xcb1",
+    "version": "2:1.7.5-1"
+  },
+  {
+    "name": "libxatracker2",
+    "version": "22.0.1-1ubuntu2"
+  },
+  {
+    "name": "libxau6",
+    "version": "1:1.0.9-1build5"
+  },
+  {
+    "name": "libxaw7",
+    "version": "2:1.0.14-1"
+  },
+  {
+    "name": "libxcb-dri2-0",
+    "version": "1.14-3ubuntu3"
+  },
+  {
+    "name": "libxcb-dri3-0",
+    "version": "1.14-3ubuntu3"
+  },
+  {
+    "name": "libxcb-glx0",
+    "version": "1.14-3ubuntu3"
+  },
+  {
+    "name": "libxcb-icccm4",
+    "version": "0.4.1-1.1build2"
+  },
+  {
+    "name": "libxcb-image0",
+    "version": "0.4.0-2"
+  },
+  {
+    "name": "libxcb-keysyms1",
+    "version": "0.4.0-1build3"
+  },
+  {
+    "name": "libxcb-present0",
+    "version": "1.14-3ubuntu3"
+  },
+  {
+    "name": "libxcb-randr0",
+    "version": "1.14-3ubuntu3"
+  },
+  {
+    "name": "libxcb-render-util0",
+    "version": "0.3.9-1build3"
+  },
+  {
+    "name": "libxcb-render0",
+    "version": "1.14-3ubuntu3"
+  },
+  {
+    "name": "libxcb-res0",
+    "version": "1.14-3ubuntu3"
+  },
+  {
+    "name": "libxcb-shape0",
+    "version": "1.14-3ubuntu3"
+  },
+  {
+    "name": "libxcb-shm0",
+    "version": "1.14-3ubuntu3"
+  },
+  {
+    "name": "libxcb-sync1",
+    "version": "1.14-3ubuntu3"
+  },
+  {
+    "name": "libxcb-util1",
+    "version": "0.4.0-1build2"
+  },
+  {
+    "name": "libxcb-xfixes0",
+    "version": "1.14-3ubuntu3"
+  },
+  {
+    "name": "libxcb-xkb1",
+    "version": "1.14-3ubuntu3"
+  },
+  {
+    "name": "libxcb-xv0",
+    "version": "1.14-3ubuntu3"
+  },
+  {
+    "name": "libxcb1",
+    "version": "1.14-3ubuntu3"
+  },
+  {
+    "name": "libxcomposite1",
+    "version": "1:0.4.5-1build2"
+  },
+  {
+    "name": "libxcursor1",
+    "version": "1:1.2.0-2build4"
+  },
+  {
+    "name": "libxcvt0",
+    "version": "0.1.1-3"
+  },
+  {
+    "name": "libxdamage1",
+    "version": "1:1.1.5-2build2"
+  },
+  {
+    "name": "libxdmcp6",
+    "version": "1:1.1.3-0ubuntu5"
+  },
+  {
+    "name": "libxext6",
+    "version": "2:1.3.4-1build1"
+  },
+  {
+    "name": "libxfixes3",
+    "version": "1:6.0.0-1"
+  },
+  {
+    "name": "libxfont2",
+    "version": "1:2.0.5-1build1"
+  },
+  {
+    "name": "libxft2",
+    "version": "2.3.4-1"
+  },
+  {
+    "name": "libxi6",
+    "version": "2:1.8-1build1"
+  },
+  {
+    "name": "libxinerama1",
+    "version": "2:1.1.4-3"
+  },
+  {
+    "name": "libxkbcommon-x11-0",
+    "version": "1.4.0-1"
+  },
+  {
+    "name": "libxkbcommon0",
+    "version": "1.4.0-1"
+  },
+  {
+    "name": "libxkbfile1",
+    "version": "1:1.1.0-1build3"
+  },
+  {
+    "name": "libxkbregistry0",
+    "version": "1.4.0-1"
+  },
+  {
+    "name": "libxklavier16",
+    "version": "5.4-4build2"
+  },
+  {
+    "name": "libxml-parser-perl",
+    "version": "2.46-3build1"
+  },
+  {
+    "name": "libxml-twig-perl",
+    "version": "1:3.52-1"
+  },
+  {
+    "name": "libxml2",
+    "version": "2.9.13+dfsg-1build1"
+  },
+  {
+    "name": "libxmlb2",
+    "version": "0.3.6-2build1"
+  },
+  {
+    "name": "libxmlsec1",
+    "version": "1.2.33-1build2"
+  },
+  {
+    "name": "libxmlsec1-nss",
+    "version": "1.2.33-1build2"
+  },
+  {
+    "name": "libxmu6",
+    "version": "2:1.1.3-3"
+  },
+  {
+    "name": "libxmuu1",
+    "version": "2:1.1.3-3"
+  },
+  {
+    "name": "libxpm4",
+    "version": "1:3.5.12-1build2"
+  },
+  {
+    "name": "libxrandr2",
+    "version": "2:1.5.2-1build1"
+  },
+  {
+    "name": "libxrender1",
+    "version": "1:0.9.10-1build4"
+  },
+  {
+    "name": "libxres1",
+    "version": "2:1.2.1-1"
+  },
+  {
+    "name": "libxshmfence1",
+    "version": "1.3-1build4"
+  },
+  {
+    "name": "libxslt1.1",
+    "version": "1.1.34-4build2"
+  },
+  {
+    "name": "libxss1",
+    "version": "1:1.2.3-1build2"
+  },
+  {
+    "name": "libxt6",
+    "version": "1:1.2.1-1"
+  },
+  {
+    "name": "libxtables12",
+    "version": "1.8.7-1ubuntu5"
+  },
+  {
+    "name": "libxtst6",
+    "version": "2:1.2.3-1build4"
+  },
+  {
+    "name": "libxv1",
+    "version": "2:1.0.11-1build2"
+  },
+  {
+    "name": "libxvmc1",
+    "version": "2:1.0.12-2build2"
+  },
+  {
+    "name": "libxxf86dga1",
+    "version": "2:1.1.5-0ubuntu3"
+  },
+  {
+    "name": "libxxf86vm1",
+    "version": "1:1.1.4-1build3"
+  },
+  {
+    "name": "libxxhash0",
+    "version": "0.8.1-1"
+  },
+  {
+    "name": "libyajl2",
+    "version": "2.1.0-3build2"
+  },
+  {
+    "name": "libyaml-0-2",
+    "version": "0.2.2-1build2"
+  },
+  {
+    "name": "libyelp0",
+    "version": "42.1-1"
+  },
+  {
+    "name": "libzstd1",
+    "version": "1.4.8+dfsg-3build1"
+  },
+  {
+    "name": "linux-base",
+    "version": "4.5ubuntu9"
+  },
+  {
+    "name": "linux-firmware",
+    "version": "20220329.git681281e4-0ubuntu1"
+  },
+  {
+    "name": "linux-generic-hwe-22.04",
+    "version": "5.15.0.25.27"
+  },
+  {
+    "name": "linux-headers-5.15.0-25",
+    "version": "5.15.0-25.25"
+  },
+  {
+    "name": "linux-headers-5.15.0-25-generic",
+    "version": "5.15.0-25.25"
+  },
+  {
+    "name": "linux-headers-generic-hwe-22.04",
+    "version": "5.15.0.25.27"
+  },
+  {
+    "name": "linux-image-5.15.0-25-generic",
+    "version": "5.15.0-25.25"
+  },
+  {
+    "name": "linux-image-generic-hwe-22.04",
+    "version": "5.15.0.25.27"
+  },
+  {
+    "name": "linux-modules-5.15.0-25-generic",
+    "version": "5.15.0-25.25"
+  },
+  {
+    "name": "linux-modules-extra-5.15.0-25-generic",
+    "version": "5.15.0-25.25"
+  },
+  {
+    "name": "linux-sound-base",
+    "version": "1.0.25+dfsg-0ubuntu7"
+  },
+  {
+    "name": "locales",
+    "version": "2.35-0ubuntu3"
+  },
+  {
+    "name": "lockfile",
+    "version": "0.12.2"
+  },
+  {
+    "name": "login",
+    "version": "1:4.8.1-2ubuntu2"
+  },
+  {
+    "name": "logrotate",
+    "version": "3.19.0-1ubuntu1"
+  },
+  {
+    "name": "logsave",
+    "version": "1.46.5-2ubuntu1"
+  },
+  {
+    "name": "lp-solve",
+    "version": "5.5.2.5-2build2"
+  },
+  {
+    "name": "lsb-base",
+    "version": "11.1.0ubuntu4"
+  },
+  {
+    "name": "lsb-release",
+    "version": "11.1.0ubuntu4"
+  },
+  {
+    "name": "lshw",
+    "version": "02.19.git.2021.06.19.996aaad9c7-2build1"
+  },
+  {
+    "name": "lsof",
+    "version": "4.93.2+dfsg-1.1build2"
+  },
+  {
+    "name": "mailcap",
+    "version": "3.70+nmu1ubuntu1"
+  },
+  {
+    "name": "man-db",
+    "version": "2.10.2-1"
+  },
+  {
+    "name": "manpages",
+    "version": "5.10-1ubuntu1"
+  },
+  {
+    "name": "mawk",
+    "version": "1.3.4.20200120-3"
+  },
+  {
+    "name": "media-player-info",
+    "version": "24-2"
+  },
+  {
+    "name": "media-types",
+    "version": "7.0.0"
+  },
+  {
+    "name": "memtest86+",
+    "version": "5.31b+dfsg-4"
+  },
+  {
+    "name": "mesa-vulkan-drivers",
+    "version": "22.0.1-1ubuntu2"
+  },
+  {
+    "name": "mime-support",
+    "version": "3.66"
+  },
+  {
+    "name": "mobile-broadband-provider-info",
+    "version": "20220315-1"
+  },
+  {
+    "name": "modemmanager",
+    "version": "1.18.6-1"
+  },
+  {
+    "name": "mokutil",
+    "version": "0.4.0-1ubuntu2"
+  },
+  {
+    "name": "monotonic",
+    "version": "1.6"
+  },
+  {
+    "name": "more-itertools",
+    "version": "8.10.0"
+  },
+  {
+    "name": "mount",
+    "version": "2.37.2-4ubuntu3"
+  },
+  {
+    "name": "mousetweaks",
+    "version": "3.32.0-3build2"
+  },
+  {
+    "name": "mscompress",
+    "version": "0.4-9build1"
+  },
+  {
+    "name": "mtr-tiny",
+    "version": "0.95-1"
+  },
+  {
+    "name": "mutter-common",
+    "version": "42.0-3ubuntu2"
+  },
+  {
+    "name": "mythes-en-us",
+    "version": "1:7.2.0-2"
+  },
+  {
+    "name": "nano",
+    "version": "6.2-1"
+  },
+  {
+    "name": "nautilus",
+    "version": "1:42.0-1ubuntu2"
+  },
+  {
+    "name": "nautilus-data",
+    "version": "1:42.0-1ubuntu2"
+  },
+  {
+    "name": "nautilus-extension-gnome-terminal",
+    "version": "3.44.0-1ubuntu1"
+  },
+  {
+    "name": "nautilus-sendto",
+    "version": "3.8.6-4"
+  },
+  {
+    "name": "nautilus-share",
+    "version": "0.7.3-2ubuntu6"
+  },
+  {
+    "name": "ncurses-base",
+    "version": "6.3-2"
+  },
+  {
+    "name": "ncurses-bin",
+    "version": "6.3-2"
+  },
+  {
+    "name": "nessusagent",
+    "version": "10.1.3"
+  },
+  {
+    "name": "netbase",
+    "version": "6.3"
+  },
+  {
+    "name": "netcat-openbsd",
+    "version": "1.218-4ubuntu1"
+  },
+  {
+    "name": "netifaces",
+    "version": "0.11.0"
+  },
+  {
+    "name": "netplan.io",
+    "version": "0.104-0ubuntu2"
+  },
+  {
+    "name": "network-manager",
+    "version": "1.36.4-2ubuntu1"
+  },
+  {
+    "name": "network-manager-config-connectivity-ubuntu",
+    "version": "1.36.4-2ubuntu1"
+  },
+  {
+    "name": "network-manager-gnome",
+    "version": "1.24.0-1ubuntu3"
+  },
+  {
+    "name": "network-manager-openvpn",
+    "version": "1.8.18-1"
+  },
+  {
+    "name": "network-manager-openvpn-gnome",
+    "version": "1.8.18-1"
+  },
+  {
+    "name": "network-manager-pptp",
+    "version": "1.2.10-1"
+  },
+  {
+    "name": "network-manager-pptp-gnome",
+    "version": "1.2.10-1"
+  },
+  {
+    "name": "networkd-dispatcher",
+    "version": "2.1-2"
+  },
+  {
+    "name": "nftables",
+    "version": "1.0.2-1ubuntu2"
+  },
+  {
+    "name": "ntfs-3g",
+    "version": "1:2021.8.22-3ubuntu1"
+  },
+  {
+    "name": "oauthlib",
+    "version": "3.2.0"
+  },
+  {
+    "name": "openprinting-ppds",
+    "version": "20220223-0ubuntu1"
+  },
+  {
+    "name": "openssh-client",
+    "version": "1:8.9p1-3"
+  },
+  {
+    "name": "openssl",
+    "version": "3.0.2-0ubuntu1"
+  },
+  {
+    "name": "openvpn",
+    "version": "2.5.5-1ubuntu3"
+  },
+  {
+    "name": "orca",
+    "version": "42.0-1ubuntu1"
+  },
+  {
+    "name": "os-prober",
+    "version": "1.79ubuntu2"
+  },
+  {
+    "name": "p11-kit",
+    "version": "0.24.0-6build1"
+  },
+  {
+    "name": "p11-kit-modules",
+    "version": "0.24.0-6build1"
+  },
+  {
+    "name": "packagekit",
+    "version": "1.2.5-2ubuntu2"
+  },
+  {
+    "name": "packagekit-tools",
+    "version": "1.2.5-2ubuntu2"
+  },
+  {
+    "name": "paramiko",
+    "version": "2.9.3"
+  },
+  {
+    "name": "parted",
+    "version": "3.4-2build1"
+  },
+  {
+    "name": "passwd",
+    "version": "1:4.8.1-2ubuntu2"
+  },
+  {
+    "name": "patch",
+    "version": "2.7.6-7build2"
+  },
+  {
+    "name": "pci.ids",
+    "version": "0.0~2022.01.22-1"
+  },
+  {
+    "name": "pciutils",
+    "version": "1:3.7.0-6"
+  },
+  {
+    "name": "pcmciautils",
+    "version": "018-13build1"
+  },
+  {
+    "name": "perl",
+    "version": "5.34.0-3ubuntu1"
+  },
+  {
+    "name": "perl-base",
+    "version": "5.34.0-3ubuntu1"
+  },
+  {
+    "name": "perl-modules-5.34",
+    "version": "5.34.0-3ubuntu1"
+  },
+  {
+    "name": "perl-openssl-defaults",
+    "version": "5build2"
+  },
+  {
+    "name": "pinentry-curses",
+    "version": "1.1.1-1build2"
+  },
+  {
+    "name": "pinentry-gnome3",
+    "version": "1.1.1-1build2"
+  },
+  {
+    "name": "pipewire",
+    "version": "0.3.48-1ubuntu1"
+  },
+  {
+    "name": "pipewire-bin",
+    "version": "0.3.48-1ubuntu1"
+  },
+  {
+    "name": "pipewire-media-session",
+    "version": "0.4.1-2ubuntu1"
+  },
+  {
+    "name": "pkexec",
+    "version": "0.105-33"
+  },
+  {
+    "name": "plymouth",
+    "version": "0.9.5+git20211018-1ubuntu3"
+  },
+  {
+    "name": "plymouth-label",
+    "version": "0.9.5+git20211018-1ubuntu3"
+  },
+  {
+    "name": "plymouth-theme-spinner",
+    "version": "0.9.5+git20211018-1ubuntu3"
+  },
+  {
+    "name": "plymouth-theme-ubuntu-text",
+    "version": "0.9.5+git20211018-1ubuntu3"
+  },
+  {
+    "name": "policykit-1",
+    "version": "0.105-33"
+  },
+  {
+    "name": "polkitd",
+    "version": "0.105-33"
+  },
+  {
+    "name": "poppler-data",
+    "version": "0.4.11-1"
+  },
+  {
+    "name": "poppler-utils",
+    "version": "22.02.0-2"
+  },
+  {
+    "name": "power-profiles-daemon",
+    "version": "0.10.1-3"
+  },
+  {
+    "name": "ppp",
+    "version": "2.4.9-1+1ubuntu3"
+  },
+  {
+    "name": "pptp-linux",
+    "version": "1.10.0-1build3"
+  },
+  {
+    "name": "printer-driver-brlaser",
+    "version": "6-3"
+  },
+  {
+    "name": "printer-driver-c2esp",
+    "version": "27-11build1"
+  },
+  {
+    "name": "printer-driver-foo2zjs",
+    "version": "20200505dfsg0-2ubuntu2"
+  },
+  {
+    "name": "printer-driver-foo2zjs-common",
+    "version": "20200505dfsg0-2ubuntu2"
+  },
+  {
+    "name": "printer-driver-hpcups",
+    "version": "3.21.12+dfsg0-1"
+  },
+  {
+    "name": "printer-driver-m2300w",
+    "version": "0.51-15build1"
+  },
+  {
+    "name": "printer-driver-min12xxw",
+    "version": "0.0.9-11build2"
+  },
+  {
+    "name": "printer-driver-pnm2ppa",
+    "version": "1.13+nondbs-0ubuntu9"
+  },
+  {
+    "name": "printer-driver-postscript-hp",
+    "version": "3.21.12+dfsg0-1"
+  },
+  {
+    "name": "printer-driver-ptouch",
+    "version": "1.6-2build1"
+  },
+  {
+    "name": "printer-driver-pxljr",
+    "version": "1.4+repack0-6build1"
+  },
+  {
+    "name": "printer-driver-sag-gdi",
+    "version": "0.1-8"
+  },
+  {
+    "name": "printer-driver-splix",
+    "version": "2.0.0+svn315-7fakesync1build3"
+  },
+  {
+    "name": "procps",
+    "version": "2:3.3.17-6ubuntu2"
+  },
+  {
+    "name": "protobuf",
+    "version": "3.12.4"
+  },
+  {
+    "name": "psmisc",
+    "version": "23.4-2build3"
+  },
+  {
+    "name": "ptyprocess",
+    "version": "0.7.0"
+  },
+  {
+    "name": "publicsuffix",
+    "version": "20211207.1025-1"
+  },
+  {
+    "name": "pulseaudio",
+    "version": "1:15.99.1+dfsg1-1ubuntu1"
+  },
+  {
+    "name": "pulseaudio-module-bluetooth",
+    "version": "1:15.99.1+dfsg1-1ubuntu1"
+  },
+  {
+    "name": "pulseaudio-utils",
+    "version": "1:15.99.1+dfsg1-1ubuntu1"
+  },
+  {
+    "name": "pyparsing",
+    "version": "2.4.7"
+  },
+  {
+    "name": "python-apt",
+    "version": "2.3.0+ubuntu2"
+  },
+  {
+    "name": "python-apt-common",
+    "version": "2.3.0ubuntu2"
+  },
+  {
+    "name": "python-dateutil",
+    "version": "2.8.1"
+  },
+  {
+    "name": "python-debian",
+    "version": "0.1.43ubuntu1"
+  },
+  {
+    "name": "python3",
+    "version": "3.10.4-0ubuntu2"
+  },
+  {
+    "name": "python3-apport",
+    "version": "2.20.11-0ubuntu82"
+  },
+  {
+    "name": "python3-apt",
+    "version": "2.3.0ubuntu2"
+  },
+  {
+    "name": "python3-aptdaemon",
+    "version": "1.1.1+bzr982-0ubuntu39"
+  },
+  {
+    "name": "python3-aptdaemon.gtk3widgets",
+    "version": "1.1.1+bzr982-0ubuntu39"
+  },
+  {
+    "name": "python3-bcrypt",
+    "version": "3.2.0-1build1"
+  },
+  {
+    "name": "python3-blinker",
+    "version": "1.4+dfsg1-0.4"
+  },
+  {
+    "name": "python3-brlapi",
+    "version": "6.4-4ubuntu2"
+  },
+  {
+    "name": "python3-cairo",
+    "version": "1.20.1-3build1"
+  },
+  {
+    "name": "python3-certifi",
+    "version": "2020.6.20-1"
+  },
+  {
+    "name": "python3-cffi-backend",
+    "version": "1.15.0-1build2"
+  },
+  {
+    "name": "python3-chardet",
+    "version": "4.0.0-1"
+  },
+  {
+    "name": "python3-click",
+    "version": "8.0.3-1"
+  },
+  {
+    "name": "python3-colorama",
+    "version": "0.4.4-1"
+  },
+  {
+    "name": "python3-commandnotfound",
+    "version": "22.04.0"
+  },
+  {
+    "name": "python3-cryptography",
+    "version": "3.4.8-1ubuntu2"
+  },
+  {
+    "name": "python3-cups",
+    "version": "2.0.1-5build1"
+  },
+  {
+    "name": "python3-cupshelpers",
+    "version": "1.5.16-0ubuntu3"
+  },
+  {
+    "name": "python3-dateutil",
+    "version": "2.8.1-6"
+  },
+  {
+    "name": "python3-dbus",
+    "version": "1.2.18-3build1"
+  },
+  {
+    "name": "python3-debconf",
+    "version": "1.5.79ubuntu1"
+  },
+  {
+    "name": "python3-debian",
+    "version": "0.1.43ubuntu1"
+  },
+  {
+    "name": "python3-defer",
+    "version": "1.0.6-2.1ubuntu1"
+  },
+  {
+    "name": "python3-distro",
+    "version": "1.7.0-1"
+  },
+  {
+    "name": "python3-distro-info",
+    "version": "1.1build1"
+  },
+  {
+    "name": "python3-distupgrade",
+    "version": "1:22.04.10"
+  },
+  {
+    "name": "python3-fasteners",
+    "version": "0.14.1-2"
+  },
+  {
+    "name": "python3-future",
+    "version": "0.18.2-5"
+  },
+  {
+    "name": "python3-gdbm",
+    "version": "3.10.4-0ubuntu1"
+  },
+  {
+    "name": "python3-gi",
+    "version": "3.42.0-3build1"
+  },
+  {
+    "name": "python3-gi-cairo",
+    "version": "3.42.0-3build1"
+  },
+  {
+    "name": "python3-httplib2",
+    "version": "0.20.2-2"
+  },
+  {
+    "name": "python3-ibus-1.0",
+    "version": "1.5.26-4"
+  },
+  {
+    "name": "python3-idna",
+    "version": "3.3-1"
+  },
+  {
+    "name": "python3-importlib-metadata",
+    "version": "4.6.4-1"
+  },
+  {
+    "name": "python3-jeepney",
+    "version": "0.7.1-3"
+  },
+  {
+    "name": "python3-jwt",
+    "version": "2.3.0-1"
+  },
+  {
+    "name": "python3-keyring",
+    "version": "23.5.0-1"
+  },
+  {
+    "name": "python3-launchpadlib",
+    "version": "1.10.16-1"
+  },
+  {
+    "name": "python3-lazr.restfulclient",
+    "version": "0.14.4-1"
+  },
+  {
+    "name": "python3-lazr.uri",
+    "version": "1.0.6-2"
+  },
+  {
+    "name": "python3-ldb",
+    "version": "2:2.4.2-0ubuntu1"
+  },
+  {
+    "name": "python3-lib2to3",
+    "version": "3.10.4-0ubuntu1"
+  },
+  {
+    "name": "python3-lockfile",
+    "version": "1:0.12.2-2.2"
+  },
+  {
+    "name": "python3-louis",
+    "version": "3.20.0-2"
+  },
+  {
+    "name": "python3-macaroonbakery",
+    "version": "1.3.1-2"
+  },
+  {
+    "name": "python3-mako",
+    "version": "1.1.3+ds1-2"
+  },
+  {
+    "name": "python3-markupsafe",
+    "version": "2.0.1-2build1"
+  },
+  {
+    "name": "python3-minimal",
+    "version": "3.10.4-0ubuntu2"
+  },
+  {
+    "name": "python3-monotonic",
+    "version": "1.6-2"
+  },
+  {
+    "name": "python3-more-itertools",
+    "version": "8.10.0-2"
+  },
+  {
+    "name": "python3-nacl",
+    "version": "1.5.0-2"
+  },
+  {
+    "name": "python3-netifaces",
+    "version": "0.11.0-1build2"
+  },
+  {
+    "name": "python3-oauthlib",
+    "version": "3.2.0-1"
+  },
+  {
+    "name": "python3-olefile",
+    "version": "0.46-3"
+  },
+  {
+    "name": "python3-paramiko",
+    "version": "2.9.3-0ubuntu1"
+  },
+  {
+    "name": "python3-pexpect",
+    "version": "4.8.0-2ubuntu1"
+  },
+  {
+    "name": "python3-pil",
+    "version": "9.0.1-1build1"
+  },
+  {
+    "name": "python3-pkg-resources",
+    "version": "59.6.0-1.2"
+  },
+  {
+    "name": "python3-problem-report",
+    "version": "2.20.11-0ubuntu82"
+  },
+  {
+    "name": "python3-protobuf",
+    "version": "3.12.4-1ubuntu7"
+  },
+  {
+    "name": "python3-ptyprocess",
+    "version": "0.7.0-3"
+  },
+  {
+    "name": "python3-pyatspi",
+    "version": "2.38.2-1"
+  },
+  {
+    "name": "python3-pymacaroons",
+    "version": "0.13.0-4"
+  },
+  {
+    "name": "python3-pyparsing",
+    "version": "2.4.7-1"
+  },
+  {
+    "name": "python3-renderpm",
+    "version": "3.6.8-1"
+  },
+  {
+    "name": "python3-reportlab",
+    "version": "3.6.8-1"
+  },
+  {
+    "name": "python3-reportlab-accel",
+    "version": "3.6.8-1"
+  },
+  {
+    "name": "python3-requests",
+    "version": "2.25.1+dfsg-2"
+  },
+  {
+    "name": "python3-rfc3339",
+    "version": "1.1-3"
+  },
+  {
+    "name": "python3-secretstorage",
+    "version": "3.3.1-1"
+  },
+  {
+    "name": "python3-six",
+    "version": "1.16.0-3ubuntu1"
+  },
+  {
+    "name": "python3-software-properties",
+    "version": "0.99.22"
+  },
+  {
+    "name": "python3-speechd",
+    "version": "0.11.1-1"
+  },
+  {
+    "name": "python3-systemd",
+    "version": "234-3ubuntu2"
+  },
+  {
+    "name": "python3-talloc",
+    "version": "2.3.3-2build1"
+  },
+  {
+    "name": "python3-tz",
+    "version": "2022.1-1"
+  },
+  {
+    "name": "python3-uno",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "python3-update-manager",
+    "version": "1:22.04.9"
+  },
+  {
+    "name": "python3-urllib3",
+    "version": "1.26.5-1~exp1"
+  },
+  {
+    "name": "python3-wadllib",
+    "version": "1.3.6-1"
+  },
+  {
+    "name": "python3-xdg",
+    "version": "0.27-2"
+  },
+  {
+    "name": "python3-xkit",
+    "version": "0.5.0ubuntu5"
+  },
+  {
+    "name": "python3-yaml",
+    "version": "5.4.1-1ubuntu1"
+  },
+  {
+    "name": "python3-zipp",
+    "version": "1.0.0-3"
+  },
+  {
+    "name": "python3.10",
+    "version": "3.10.4-3"
+  },
+  {
+    "name": "python3.10-minimal",
+    "version": "3.10.4-3"
+  },
+  {
+    "name": "pytz",
+    "version": "2022.1"
+  },
+  {
+    "name": "pyxdg",
+    "version": "0.27"
+  },
+  {
+    "name": "readline-common",
+    "version": "8.1.2-1"
+  },
+  {
+    "name": "remmina",
+    "version": "1.4.25+dfsg-1"
+  },
+  {
+    "name": "remmina-common",
+    "version": "1.4.25+dfsg-1"
+  },
+  {
+    "name": "remmina-plugin-rdp",
+    "version": "1.4.25+dfsg-1"
+  },
+  {
+    "name": "remmina-plugin-secret",
+    "version": "1.4.25+dfsg-1"
+  },
+  {
+    "name": "remmina-plugin-vnc",
+    "version": "1.4.25+dfsg-1"
+  },
+  {
+    "name": "reportlab",
+    "version": "3.6.8"
+  },
+  {
+    "name": "requests",
+    "version": "2.25.1"
+  },
+  {
+    "name": "rfkill",
+    "version": "2.37.2-4ubuntu3"
+  },
+  {
+    "name": "rhythmbox",
+    "version": "3.4.4-5ubuntu1"
+  },
+  {
+    "name": "rhythmbox-data",
+    "version": "3.4.4-5ubuntu1"
+  },
+  {
+    "name": "rhythmbox-plugin-alternative-toolbar",
+    "version": "0.20.2-1"
+  },
+  {
+    "name": "rhythmbox-plugins",
+    "version": "3.4.4-5ubuntu1"
+  },
+  {
+    "name": "rsync",
+    "version": "3.2.3-8ubuntu3"
+  },
+  {
+    "name": "rsyslog",
+    "version": "8.2112.0-2ubuntu2"
+  },
+  {
+    "name": "rtkit",
+    "version": "0.13-4build2"
+  },
+  {
+    "name": "rygel",
+    "version": "0.40.3-1ubuntu2"
+  },
+  {
+    "name": "samba-libs",
+    "version": "2:4.15.5~dfsg-0ubuntu5"
+  },
+  {
+    "name": "sane-airscan",
+    "version": "0.99.27-1build1"
+  },
+  {
+    "name": "sane-utils",
+    "version": "1.1.1-5"
+  },
+  {
+    "name": "sbsigntool",
+    "version": "0.9.4-2ubuntu2"
+  },
+  {
+    "name": "seahorse",
+    "version": "41.0-2"
+  },
+  {
+    "name": "secureboot-db",
+    "version": "1.8"
+  },
+  {
+    "name": "sed",
+    "version": "4.8-1ubuntu2"
+  },
+  {
+    "name": "sensible-utils",
+    "version": "0.0.17"
+  },
+  {
+    "name": "session-migration",
+    "version": "0.3.6"
+  },
+  {
+    "name": "sgml-base",
+    "version": "1.30"
+  },
+  {
+    "name": "sgml-data",
+    "version": "2.0.11+nmu1"
+  },
+  {
+    "name": "shared-mime-info",
+    "version": "2.1-2"
+  },
+  {
+    "name": "shim-signed",
+    "version": "1.51+15.4-0ubuntu9"
+  },
+  {
+    "name": "shotwell",
+    "version": "0.30.14-1ubuntu5"
+  },
+  {
+    "name": "shotwell-common",
+    "version": "0.30.14-1ubuntu5"
+  },
+  {
+    "name": "simple-scan",
+    "version": "42.0-1"
+  },
+  {
+    "name": "six",
+    "version": "1.16.0"
+  },
+  {
+    "name": "snapd",
+    "version": "2.55.3+22.04"
+  },
+  {
+    "name": "software-properties-common",
+    "version": "0.99.22"
+  },
+  {
+    "name": "software-properties-gtk",
+    "version": "0.99.22"
+  },
+  {
+    "name": "sound-icons",
+    "version": "0.1-8"
+  },
+  {
+    "name": "speech-dispatcher",
+    "version": "0.11.1-1"
+  },
+  {
+    "name": "speech-dispatcher-audio-plugins",
+    "version": "0.11.1-1"
+  },
+  {
+    "name": "speech-dispatcher-espeak-ng",
+    "version": "0.11.1-1"
+  },
+  {
+    "name": "spice-vdagent",
+    "version": "0.22.1-1"
+  },
+  {
+    "name": "squashfs-tools",
+    "version": "1:4.5-3build1"
+  },
+  {
+    "name": "ssl-cert",
+    "version": "1.1.2"
+  },
+  {
+    "name": "strace",
+    "version": "5.16-0ubuntu3"
+  },
+  {
+    "name": "sudo",
+    "version": "1.9.9-1ubuntu2"
+  },
+  {
+    "name": "switcheroo-control",
+    "version": "2.4-3build2"
+  },
+  {
+    "name": "system-config-printer",
+    "version": "1.5.16-0ubuntu3"
+  },
+  {
+    "name": "system-config-printer-common",
+    "version": "1.5.16-0ubuntu3"
+  },
+  {
+    "name": "system-config-printer-udev",
+    "version": "1.5.16-0ubuntu3"
+  },
+  {
+    "name": "systemd",
+    "version": "249.11-0ubuntu3"
+  },
+  {
+    "name": "systemd-oomd",
+    "version": "249.11-0ubuntu3"
+  },
+  {
+    "name": "systemd-sysv",
+    "version": "249.11-0ubuntu3"
+  },
+  {
+    "name": "systemd-timesyncd",
+    "version": "249.11-0ubuntu3"
+  },
+  {
+    "name": "sysvinit-utils",
+    "version": "3.01-1ubuntu1"
+  },
+  {
+    "name": "tar",
+    "version": "1.34+dfsg-1build3"
+  },
+  {
+    "name": "tcl",
+    "version": "8.6.11+1build2"
+  },
+  {
+    "name": "tcl8.6",
+    "version": "8.6.12+dfsg-1build1"
+  },
+  {
+    "name": "tcpdump",
+    "version": "4.99.1-3build2"
+  },
+  {
+    "name": "telnet",
+    "version": "0.17-44build1"
+  },
+  {
+    "name": "thermald",
+    "version": "2.4.9-1"
+  },
+  {
+    "name": "thunderbird",
+    "version": "1:91.8.0+build2-0ubuntu1"
+  },
+  {
+    "name": "thunderbird-gnome-support",
+    "version": "1:91.8.0+build2-0ubuntu1"
+  },
+  {
+    "name": "thunderbird-locale-en",
+    "version": "1:91.8.0+build2-0ubuntu1"
+  },
+  {
+    "name": "thunderbird-locale-en-us",
+    "version": "1:91.8.0+build2-0ubuntu1"
+  },
+  {
+    "name": "time",
+    "version": "1.9-0.1build2"
+  },
+  {
+    "name": "tnftp",
+    "version": "20210827-4build1"
+  },
+  {
+    "name": "totem",
+    "version": "42.0-1ubuntu1"
+  },
+  {
+    "name": "totem-common",
+    "version": "42.0-1ubuntu1"
+  },
+  {
+    "name": "totem-plugins",
+    "version": "42.0-1ubuntu1"
+  },
+  {
+    "name": "tpm-udev",
+    "version": "0.6"
+  },
+  {
+    "name": "tracker",
+    "version": "3.3.0-1"
+  },
+  {
+    "name": "tracker-extract",
+    "version": "3.3.0-1"
+  },
+  {
+    "name": "tracker-miner-fs",
+    "version": "3.3.0-1"
+  },
+  {
+    "name": "transmission-common",
+    "version": "3.00-2ubuntu2"
+  },
+  {
+    "name": "transmission-gtk",
+    "version": "3.00-2ubuntu2"
+  },
+  {
+    "name": "tzdata",
+    "version": "2022a-0ubuntu1"
+  },
+  {
+    "name": "ubuntu-advantage-desktop-daemon",
+    "version": "1.8"
+  },
+  {
+    "name": "ubuntu-advantage-tools",
+    "version": "27.7"
+  },
+  {
+    "name": "ubuntu-advantage-tools",
+    "version": "27.7~22.04.1"
+  },
+  {
+    "name": "ubuntu-desktop",
+    "version": "1.481"
+  },
+  {
+    "name": "ubuntu-desktop-minimal",
+    "version": "1.481"
+  },
+  {
+    "name": "ubuntu-docs",
+    "version": "22.04.4"
+  },
+  {
+    "name": "ubuntu-drivers-common",
+    "version": "1:0.9.6.1"
+  },
+  {
+    "name": "ubuntu-keyring",
+    "version": "2021.03.26"
+  },
+  {
+    "name": "ubuntu-minimal",
+    "version": "1.481"
+  },
+  {
+    "name": "ubuntu-mono",
+    "version": "20.10-0ubuntu2"
+  },
+  {
+    "name": "ubuntu-release-upgrader-core",
+    "version": "1:22.04.10"
+  },
+  {
+    "name": "ubuntu-release-upgrader-gtk",
+    "version": "1:22.04.10"
+  },
+  {
+    "name": "ubuntu-report",
+    "version": "1.7.1"
+  },
+  {
+    "name": "ubuntu-session",
+    "version": "42.0-1ubuntu2"
+  },
+  {
+    "name": "ubuntu-settings",
+    "version": "22.04.6"
+  },
+  {
+    "name": "ubuntu-standard",
+    "version": "1.481"
+  },
+  {
+    "name": "ubuntu-wallpapers",
+    "version": "22.04.4-0ubuntu1"
+  },
+  {
+    "name": "ubuntu-wallpapers-jammy",
+    "version": "22.04.4-0ubuntu1"
+  },
+  {
+    "name": "ucf",
+    "version": "3.0043"
+  },
+  {
+    "name": "udev",
+    "version": "249.11-0ubuntu3"
+  },
+  {
+    "name": "udisks2",
+    "version": "2.9.4-1ubuntu2"
+  },
+  {
+    "name": "ufw",
+    "version": "0.36.1-4build1"
+  },
+  {
+    "name": "unattended-upgrades",
+    "version": "2.8ubuntu1"
+  },
+  {
+    "name": "uno-libs-private",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "unzip",
+    "version": "6.0-26ubuntu3"
+  },
+  {
+    "name": "update-inetd",
+    "version": "4.51"
+  },
+  {
+    "name": "update-manager",
+    "version": "1:22.04.9"
+  },
+  {
+    "name": "update-manager-core",
+    "version": "1:22.04.9"
+  },
+  {
+    "name": "update-notifier",
+    "version": "3.192.54"
+  },
+  {
+    "name": "update-notifier-common",
+    "version": "3.192.54"
+  },
+  {
+    "name": "upower",
+    "version": "0.99.17-1"
+  },
+  {
+    "name": "ure",
+    "version": "1:7.3.2-0ubuntu2"
+  },
+  {
+    "name": "urllib3",
+    "version": "1.26.5"
+  },
+  {
+    "name": "usb-creator-common",
+    "version": "0.3.13"
+  },
+  {
+    "name": "usb-creator-gtk",
+    "version": "0.3.13"
+  },
+  {
+    "name": "usb-modeswitch",
+    "version": "2.6.1-3ubuntu2"
+  },
+  {
+    "name": "usb-modeswitch-data",
+    "version": "20191128-4"
+  },
+  {
+    "name": "usb.ids",
+    "version": "2022.04.02-1"
+  },
+  {
+    "name": "usbmuxd",
+    "version": "1.1.1-2build2"
+  },
+  {
+    "name": "usbutils",
+    "version": "1:014-1build1"
+  },
+  {
+    "name": "usrmerge",
+    "version": "25ubuntu2"
+  },
+  {
+    "name": "util-linux",
+    "version": "2.37.2-4ubuntu3"
+  },
+  {
+    "name": "uuid-runtime",
+    "version": "2.37.2-4ubuntu3"
+  },
+  {
+    "name": "vim-common",
+    "version": "2:8.2.3995-1ubuntu2"
+  },
+  {
+    "name": "vim-tiny",
+    "version": "2:8.2.3995-1ubuntu2"
+  },
+  {
+    "name": "wadllib",
+    "version": "1.3.6"
+  },
+  {
+    "name": "wamerican",
+    "version": "2020.12.07-2"
+  },
+  {
+    "name": "wbritish",
+    "version": "2020.12.07-2"
+  },
+  {
+    "name": "wget",
+    "version": "1.21.2-2ubuntu1"
+  },
+  {
+    "name": "whiptail",
+    "version": "0.52.21-5ubuntu2"
+  },
+  {
+    "name": "whoopsie",
+    "version": "0.2.77"
+  },
+  {
+    "name": "whoopsie-preferences",
+    "version": "23"
+  },
+  {
+    "name": "wireless-regdb",
+    "version": "2021.08.28-0ubuntu1"
+  },
+  {
+    "name": "wireless-tools",
+    "version": "30~pre9-13.1ubuntu4"
+  },
+  {
+    "name": "wpasupplicant",
+    "version": "2:2.10-6"
+  },
+  {
+    "name": "x11-apps",
+    "version": "7.7+8build2"
+  },
+  {
+    "name": "x11-common",
+    "version": "1:7.7+23ubuntu2"
+  },
+  {
+    "name": "x11-session-utils",
+    "version": "7.7+4build2"
+  },
+  {
+    "name": "x11-utils",
+    "version": "7.7+5build2"
+  },
+  {
+    "name": "x11-xkb-utils",
+    "version": "7.7+5build4"
+  },
+  {
+    "name": "x11-xserver-utils",
+    "version": "7.7+9build1"
+  },
+  {
+    "name": "xauth",
+    "version": "1:1.1-1build2"
+  },
+  {
+    "name": "xbitmaps",
+    "version": "1.1.1-2.1ubuntu1"
+  },
+  {
+    "name": "xbrlapi",
+    "version": "6.4-4ubuntu2"
+  },
+  {
+    "name": "xcvt",
+    "version": "0.1.1-3"
+  },
+  {
+    "name": "xdg-dbus-proxy",
+    "version": "0.1.3-1"
+  },
+  {
+    "name": "xdg-desktop-portal",
+    "version": "1.14.3-0ubuntu2"
+  },
+  {
+    "name": "xdg-desktop-portal-gnome",
+    "version": "42.0.1-1ubuntu2"
+  },
+  {
+    "name": "xdg-desktop-portal-gtk",
+    "version": "1.14.0-1build1"
+  },
+  {
+    "name": "xdg-user-dirs",
+    "version": "0.17-2ubuntu4"
+  },
+  {
+    "name": "xdg-user-dirs-gtk",
+    "version": "0.10-3build2"
+  },
+  {
+    "name": "xdg-utils",
+    "version": "1.1.3-4.1ubuntu1"
+  },
+  {
+    "name": "xfonts-encodings",
+    "version": "1:1.0.5-0ubuntu2"
+  },
+  {
+    "name": "xfonts-scalable",
+    "version": "1:1.0.3-1.2ubuntu1"
+  },
+  {
+    "name": "xfonts-utils",
+    "version": "1:7.7+6build2"
+  },
+  {
+    "name": "xinit",
+    "version": "1.4.1-0ubuntu4"
+  },
+  {
+    "name": "xinput",
+    "version": "1.6.3-1build2"
+  },
+  {
+    "name": "xkb-data",
+    "version": "2.33-1"
+  },
+  {
+    "name": "xorg",
+    "version": "1:7.7+23ubuntu2"
+  },
+  {
+    "name": "xorg-docs-core",
+    "version": "1:1.7.1-1.2"
+  },
+  {
+    "name": "xserver-common",
+    "version": "2:21.1.3-2ubuntu2"
+  },
+  {
+    "name": "xserver-xephyr",
+    "version": "2:21.1.3-2ubuntu2"
+  },
+  {
+    "name": "xserver-xorg",
+    "version": "1:7.7+23ubuntu2"
+  },
+  {
+    "name": "xserver-xorg-core",
+    "version": "2:21.1.3-2ubuntu2"
+  },
+  {
+    "name": "xserver-xorg-input-all",
+    "version": "1:7.7+23ubuntu2"
+  },
+  {
+    "name": "xserver-xorg-input-libinput",
+    "version": "1.2.1-1"
+  },
+  {
+    "name": "xserver-xorg-input-wacom",
+    "version": "1:1.0.0-3ubuntu1"
+  },
+  {
+    "name": "xserver-xorg-legacy",
+    "version": "2:21.1.3-2ubuntu2"
+  },
+  {
+    "name": "xserver-xorg-video-all",
+    "version": "1:7.7+23ubuntu2"
+  },
+  {
+    "name": "xserver-xorg-video-amdgpu",
+    "version": "22.0.0-1build1"
+  },
+  {
+    "name": "xserver-xorg-video-ati",
+    "version": "1:19.1.0-2build3"
+  },
+  {
+    "name": "xserver-xorg-video-fbdev",
+    "version": "1:0.5.0-2build1"
+  },
+  {
+    "name": "xserver-xorg-video-intel",
+    "version": "2:2.99.917+git20210115-1"
+  },
+  {
+    "name": "xserver-xorg-video-nouveau",
+    "version": "1:1.0.17-2build1"
+  },
+  {
+    "name": "xserver-xorg-video-qxl",
+    "version": "0.1.5+git20200331-3"
+  },
+  {
+    "name": "xserver-xorg-video-radeon",
+    "version": "1:19.1.0-2build3"
+  },
+  {
+    "name": "xserver-xorg-video-vesa",
+    "version": "1:2.5.0-1build4"
+  },
+  {
+    "name": "xserver-xorg-video-vmware",
+    "version": "1:13.3.0-3build1"
+  },
+  {
+    "name": "xwayland",
+    "version": "2:22.1.1-1"
+  },
+  {
+    "name": "xxd",
+    "version": "2:8.2.3995-1ubuntu2"
+  },
+  {
+    "name": "xz-utils",
+    "version": "5.2.5-2ubuntu1"
+  },
+  {
+    "name": "yaru-theme-gnome-shell",
+    "version": "22.04.4"
+  },
+  {
+    "name": "yaru-theme-gtk",
+    "version": "22.04.4"
+  },
+  {
+    "name": "yaru-theme-icon",
+    "version": "22.04.4"
+  },
+  {
+    "name": "yaru-theme-sound",
+    "version": "22.04.4"
+  },
+  {
+    "name": "yelp",
+    "version": "42.1-1"
+  },
+  {
+    "name": "yelp-xsl",
+    "version": "42.0-1"
+  },
+  {
+    "name": "zenity",
+    "version": "3.42.0-1"
+  },
+  {
+    "name": "zenity-common",
+    "version": "3.42.0-1"
+  },
+  {
+    "name": "zip",
+    "version": "3.0-12build2"
+  },
+  {
+    "name": "zipp",
+    "version": "1.0.0"
+  },
+  {
+    "name": "zlib1g",
+    "version": "1:1.2.11.dfsg-2ubuntu9"
+  },
+  {
+    "name": "zstd",
+    "version": "1.4.8+dfsg-3build1"
+  },
+  {
+    "name": "libpcre3",
+    "version": "2:8.39-13ubuntu0.22.04.1"
+  },
+  {
+    "name": "vim",
+    "version": "2:8.2.3995-1ubuntu2"
+  },
+  {
+    "name": "vim-runtime",
+    "version": "2:8.2.3995-1ubuntu2"
+  }
+]

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1714,22 +1714,19 @@ ON DUPLICATE KEY UPDATE
 	return nil
 }
 
-func (ds *Datastore) HostIDsByPlatform(
+func (ds *Datastore) HostIDsByOsVersion(
 	ctx context.Context,
-	platform *string,
-	osVersion *string,
+	osVersion fleet.OSVersion,
+	offset int,
+	limit int,
 ) ([]uint, error) {
 	var ids []uint
 	var filters []goqu.Expression
 
 	stmt := dialect.From("hosts").Select("id")
-	if platform != nil {
-		filters = append(filters, goqu.C("platform").Eq(platform))
-	}
-	if osVersion != nil {
-		filters = append(filters, goqu.C("os_version").Eq(osVersion))
-	}
-	stmt = stmt.Where(filters...).Order(goqu.I("id").Desc())
+	filters = append(filters, goqu.C("platform").Eq(osVersion.Platform))
+	filters = append(filters, goqu.C("os_version").Eq(osVersion.Name))
+	stmt = stmt.Where(filters...).Order(goqu.I("id").Desc()).Offset(uint(offset)).Limit(uint(limit))
 
 	sql, args, err := stmt.ToSQL()
 	if err != nil {

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1714,7 +1714,7 @@ ON DUPLICATE KEY UPDATE
 	return nil
 }
 
-func (ds *Datastore) HostIDsByOsVersion(
+func (ds *Datastore) HostIDsByOSVersion(
 	ctx context.Context,
 	osVersion fleet.OSVersion,
 	offset int,

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1721,12 +1721,15 @@ func (ds *Datastore) HostIDsByOSVersion(
 	limit int,
 ) ([]uint, error) {
 	var ids []uint
-	var filters []goqu.Expression
 
-	stmt := dialect.From("hosts").Select("id")
-	filters = append(filters, goqu.C("platform").Eq(osVersion.Platform))
-	filters = append(filters, goqu.C("os_version").Eq(osVersion.Name))
-	stmt = stmt.Where(filters...).Order(goqu.I("id").Desc()).Offset(uint(offset)).Limit(uint(limit))
+	stmt := dialect.From("hosts").
+		Select("id").
+		Where(
+			goqu.C("platform").Eq(osVersion.Platform),
+			goqu.C("os_version").Eq(osVersion.Name)).
+		Order(goqu.I("id").Desc()).
+		Offset(uint(offset)).
+		Limit(uint(limit))
 
 	sql, args, err := stmt.ToSQL()
 	if err != nil {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -4194,36 +4194,16 @@ func testHostIDsByPlatform(t *testing.T, ds *Datastore) {
 		hosts[i] = h
 	}
 
-	t.Run("no platform nor version filters", func(t *testing.T) {
-		result, err := ds.HostIDsByPlatform(ctx, nil, nil)
-		require.NoError(t, err)
-		require.Len(t, result, 10)
-	})
-
-	t.Run("filtering by platform", func(t *testing.T) {
-		platform := "ubuntu"
-		result, err := ds.HostIDsByPlatform(ctx, &platform, nil)
-		require.NoError(t, err)
-		require.Len(t, result, 5)
-		for _, id := range result {
-			r, err := ds.HostLite(ctx, id)
-			require.NoError(t, err)
-			require.Equal(t, r.Platform, "ubuntu")
-		}
-	})
-
 	t.Run("no match", func(t *testing.T) {
-		platform := "asdfas"
-		version := "sdfasw"
-		none, err := ds.HostIDsByPlatform(ctx, &platform, &version)
+		osVersion := fleet.OSVersion{Platform: "asdfas", Name: "sdfasw"}
+		none, err := ds.HostIDsByOsVersion(ctx, osVersion, 0, 1)
 		require.NoError(t, err)
 		require.Len(t, none, 0)
 	})
 
 	t.Run("filtering by platform and version", func(t *testing.T) {
-		platform := "ubuntu"
-		version := "20.4.0"
-		result, err := ds.HostIDsByPlatform(ctx, &platform, &version)
+		osVersion := fleet.OSVersion{Platform: "ubuntu", Name: "20.4.0"}
+		result, err := ds.HostIDsByOsVersion(ctx, osVersion, 0, 1)
 		require.NoError(t, err)
 		require.Len(t, result, 1)
 		for _, id := range result {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -4168,7 +4168,7 @@ func testHostsDeleteHosts(t *testing.T, ds *Datastore) {
 	}
 }
 
-func testHostIDsByPlatform(t *testing.T, ds *Datastore) {
+func testHostIDsByOSVersion(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
 	hosts := make([]*fleet.Host, 10)
 	getPlatform := func(i int) string {
@@ -4196,14 +4196,14 @@ func testHostIDsByPlatform(t *testing.T, ds *Datastore) {
 
 	t.Run("no match", func(t *testing.T) {
 		osVersion := fleet.OSVersion{Platform: "asdfas", Name: "sdfasw"}
-		none, err := ds.HostIDsByOsVersion(ctx, osVersion, 0, 1)
+		none, err := ds.HostIDsByOSVersion(ctx, osVersion, 0, 1)
 		require.NoError(t, err)
 		require.Len(t, none, 0)
 	})
 
 	t.Run("filtering by platform and version", func(t *testing.T) {
 		osVersion := fleet.OSVersion{Platform: "ubuntu", Name: "20.4.0"}
-		result, err := ds.HostIDsByOsVersion(ctx, osVersion, 0, 1)
+		result, err := ds.HostIDsByOSVersion(ctx, osVersion, 0, 1)
 		require.NoError(t, err)
 		require.Len(t, result, 1)
 		for _, id := range result {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -116,7 +116,7 @@ func TestHosts(t *testing.T) {
 		{"SetOrUpdateDeviceAuthToken", testHostsSetOrUpdateDeviceAuthToken},
 		{"OSVersions", testOSVersions},
 		{"DeleteHosts", testHostsDeleteHosts},
-		{"HostIDsByPlatform", testHostIDsByPlatform},
+		{"HostIDsByOSVersion", testHostIDsByOSVersion},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -4195,13 +4195,13 @@ func testHostIDsByOSVersion(t *testing.T, ds *Datastore) {
 	}
 
 	t.Run("no match", func(t *testing.T) {
-		osVersion := fleet.OSVersion{Platform: "asdfas", Name: "sdfasw"}
+		osVersion := fleet.OSVersion{Platform: "ubuntu", Name: "sdfasw"}
 		none, err := ds.HostIDsByOSVersion(ctx, osVersion, 0, 1)
 		require.NoError(t, err)
 		require.Len(t, none, 0)
 	})
 
-	t.Run("filtering by platform and version", func(t *testing.T) {
+	t.Run("filtering by os version", func(t *testing.T) {
 		osVersion := fleet.OSVersion{Platform: "ubuntu", Name: "20.4.0"}
 		result, err := ds.HostIDsByOSVersion(ctx, osVersion, 0, 1)
 		require.NoError(t, err)

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -1155,12 +1155,7 @@ func (ds *Datastore) ListSoftwareVulnerabilities(
 	}
 
 	for _, r := range queryR {
-		result[r.HostId] = append(result[r.HostId], fleet.SoftwareVulnerability{
-			SoftwareID: r.SoftwareID,
-			CPE:        r.CPE,
-			CPEID:      r.CPEID,
-			CVE:        r.CVE,
-		})
+		result[r.HostId] = append(result[r.HostId], r.SoftwareVulnerability)
 	}
 
 	return result, nil

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -1147,11 +1147,11 @@ func (ds *Datastore) ListSoftwareVulnerabilities(
 
 	sql, args, err := stmt.ToSQL()
 	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "ListSoftwareVulnerabilities")
+		return nil, ctxerr.Wrap(ctx, err, "error generating SQL statement")
 	}
 
 	if err := sqlx.SelectContext(ctx, ds.reader, &queryR, sql, args...); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "ListSoftwareVulnerabilities")
+		return nil, ctxerr.Wrap(ctx, err, "error executing SQL statement")
 	}
 
 	for _, r := range queryR {
@@ -1197,11 +1197,11 @@ func (ds *Datastore) ListSoftwareForVulnDetection(
 
 	sql, args, err := stmt.ToSQL()
 	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "ListSoftwareForVulnDetection")
+		return nil, ctxerr.Wrap(ctx, err, "error generating SQL statement")
 	}
 
 	if err := sqlx.SelectContext(ctx, ds.reader, &result, sql, args...); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "ListSoftwareForVulnDetection")
+		return nil, ctxerr.Wrap(ctx, err, "error executing SQL statement")
 	}
 
 	return result, nil

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -1414,10 +1414,10 @@ func testInsertVulnerabilities(t *testing.T, ds *Datastore) {
 		require.NoError(t, err)
 		require.Equal(t, 0, int(n))
 
-		storedVulns, err := ds.ListSoftwareVulnerabilities(ctx, host.ID)
+		storedVulns, err := ds.ListSoftwareVulnerabilities(ctx, []uint{host.ID})
 
 		occurrence := make(map[string]int)
-		for _, v := range storedVulns {
+		for _, v := range storedVulns[host.ID] {
 			occurrence[v.CVE] = occurrence[v.CVE] + 1
 		}
 		require.Equal(t, 1, occurrence["cve-1"])

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -1341,8 +1341,8 @@ func testListSoftwareVulnerabilities(t *testing.T, ds *Datastore) {
 	actualCPEs := make([]string, 0)
 	actualCVEs := make([]string, 0)
 
-	result, err := ds.ListSoftwareVulnerabilities(ctx, hostOne.ID)
-	for _, r := range result {
+	result, err := ds.ListSoftwareVulnerabilities(ctx, []uint{hostOne.ID})
+	for _, r := range result[hostOne.ID] {
 		actualCPEs = append(actualCPEs, r.CPE)
 		actualCVEs = append(actualCVEs, r.CVE)
 	}
@@ -1351,7 +1351,7 @@ func testListSoftwareVulnerabilities(t *testing.T, ds *Datastore) {
 	require.ElementsMatch(t, expectedCPEs, actualCPEs)
 	require.ElementsMatch(t, expectedCVEs, actualCVEs)
 
-	for _, r := range result {
+	for _, r := range result[hostOne.ID] {
 		require.NotEqual(t, r.SoftwareID, 0)
 		require.NotEqual(t, r.CPEID, 0)
 	}
@@ -1384,11 +1384,11 @@ func testInsertVulnerabilities(t *testing.T, ds *Datastore) {
 		require.NoError(t, err)
 		require.Equal(t, 1, int(n))
 
-		storedVulns, err := ds.ListSoftwareVulnerabilities(ctx, host.ID)
+		storedVulns, err := ds.ListSoftwareVulnerabilities(ctx, []uint{host.ID})
 		require.NoError(t, err)
 
 		occurrence := make(map[string]int)
-		for _, v := range storedVulns {
+		for _, v := range storedVulns[host.ID] {
 			occurrence[v.CVE] = occurrence[v.CVE] + 1
 		}
 		require.Equal(t, 1, occurrence["cve-1"])

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -342,7 +342,7 @@ type Datastore interface {
 	// ListSoftwareForVulnDetection returns all software for the given hostID with only the fields
 	// used for vulnerability detection populated (id, name, version, cpe_id, cpe)
 	ListSoftwareForVulnDetection(ctx context.Context, hostID uint) ([]Software, error)
-	ListSoftwareVulnerabilities(ctx context.Context, hostID uint) ([]SoftwareVulnerability, error)
+	ListSoftwareVulnerabilities(ctx context.Context, hostIDs []uint) (map[uint][]SoftwareVulnerability, error)
 	LoadHostSoftware(ctx context.Context, host *Host, opts SoftwareListOptions) error
 	AllSoftwareWithoutCPEIterator(ctx context.Context) (SoftwareIterator, error)
 	AddCPEForSoftware(ctx context.Context, software Software, cpe string) error

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -188,8 +188,8 @@ type Datastore interface {
 	GenerateHostStatusStatistics(ctx context.Context, filter TeamFilter, now time.Time, platform *string) (*HostSummary, error)
 	// HostIDsByName Retrieve the IDs associated with the given hostnames
 	HostIDsByName(ctx context.Context, filter TeamFilter, hostnames []string) ([]uint, error)
-	// HostIDsByOsVersion retrieves the IDs of all host matching osVersion
-	HostIDsByOsVersion(ctx context.Context, osVersion OSVersion, offset int, limit int) ([]uint, error)
+	// HostIDsByOSVersion retrieves the IDs of all host matching osVersion
+	HostIDsByOSVersion(ctx context.Context, osVersion OSVersion, offset int, limit int) ([]uint, error)
 	// HostByIdentifier returns one host matching the provided identifier. Possible matches can be on
 	// osquery_host_identifier, node_key, UUID, or hostname.
 	HostByIdentifier(ctx context.Context, identifier string) (*Host, error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -188,8 +188,8 @@ type Datastore interface {
 	GenerateHostStatusStatistics(ctx context.Context, filter TeamFilter, now time.Time, platform *string) (*HostSummary, error)
 	// HostIDsByName Retrieve the IDs associated with the given hostnames
 	HostIDsByName(ctx context.Context, filter TeamFilter, hostnames []string) ([]uint, error)
-	// HostIDsByPlatform retrieves the IDs of all host matching 'platform' and/or 'os_version'
-	HostIDsByPlatform(ctx context.Context, platform *string, osVersion *string) ([]uint, error)
+	// HostIDsByOsVersion retrieves the IDs of all host matching osVersion
+	HostIDsByOsVersion(ctx context.Context, osVersion OSVersion, offset int, limit int) ([]uint, error)
 	// HostByIdentifier returns one host matching the provided identifier. Possible matches can be on
 	// osquery_host_identifier, node_key, UUID, or hostname.
 	HostByIdentifier(ctx context.Context, identifier string) (*Host, error)
@@ -339,7 +339,9 @@ type Datastore interface {
 
 	///////////////////////////////////////////////////////////////////////////////
 	// SoftwareStore
-
+	// ListSoftwareForVulnDetection returns all software for the given hostID with only the fields
+	// used for vulnerability detection populated (id, name, version, cpe_id, cpe)
+	ListSoftwareForVulnDetection(ctx context.Context, hostID uint) ([]Software, error)
 	ListSoftwareVulnerabilities(ctx context.Context, hostID uint) ([]SoftwareVulnerability, error)
 	LoadHostSoftware(ctx context.Context, host *Host, opts SoftwareListOptions) error
 	AllSoftwareWithoutCPEIterator(ctx context.Context) (SoftwareIterator, error)

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -156,7 +156,7 @@ type GenerateHostStatusStatisticsFunc func(ctx context.Context, filter fleet.Tea
 
 type HostIDsByNameFunc func(ctx context.Context, filter fleet.TeamFilter, hostnames []string) ([]uint, error)
 
-type HostIDsByOsVersionFunc func(ctx context.Context, osVersion fleet.OSVersion, offset int, limit int) ([]uint, error)
+type HostIDsByOSVersionFunc func(ctx context.Context, osVersion fleet.OSVersion, offset int, limit int) ([]uint, error)
 
 type HostByIdentifierFunc func(ctx context.Context, identifier string) (*fleet.Host, error)
 
@@ -627,8 +627,8 @@ type DataStore struct {
 	HostIDsByNameFunc        HostIDsByNameFunc
 	HostIDsByNameFuncInvoked bool
 
-	HostIDsByOsVersionFunc        HostIDsByOsVersionFunc
-	HostIDsByOsVersionFuncInvoked bool
+	HostIDsByOSVersionFunc        HostIDsByOSVersionFunc
+	HostIDsByOSVersionFuncInvoked bool
 
 	HostByIdentifierFunc        HostByIdentifierFunc
 	HostByIdentifierFuncInvoked bool
@@ -1369,9 +1369,9 @@ func (s *DataStore) HostIDsByName(ctx context.Context, filter fleet.TeamFilter, 
 	return s.HostIDsByNameFunc(ctx, filter, hostnames)
 }
 
-func (s *DataStore) HostIDsByOsVersion(ctx context.Context, osVersion fleet.OSVersion, offset int, limit int) ([]uint, error) {
-	s.HostIDsByOsVersionFuncInvoked = true
-	return s.HostIDsByOsVersionFunc(ctx, osVersion, offset, limit)
+func (s *DataStore) HostIDsByOSVersion(ctx context.Context, osVersion fleet.OSVersion, offset int, limit int) ([]uint, error) {
+	s.HostIDsByOSVersionFuncInvoked = true
+	return s.HostIDsByOSVersionFunc(ctx, osVersion, offset, limit)
 }
 
 func (s *DataStore) HostByIdentifier(ctx context.Context, identifier string) (*fleet.Host, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -156,7 +156,7 @@ type GenerateHostStatusStatisticsFunc func(ctx context.Context, filter fleet.Tea
 
 type HostIDsByNameFunc func(ctx context.Context, filter fleet.TeamFilter, hostnames []string) ([]uint, error)
 
-type HostIDsByPlatformFunc func(ctx context.Context, platform *string, osVersion *string) ([]uint, error)
+type HostIDsByOsVersionFunc func(ctx context.Context, osVersion fleet.OSVersion, offset int, limit int) ([]uint, error)
 
 type HostByIdentifierFunc func(ctx context.Context, identifier string) (*fleet.Host, error)
 
@@ -269,6 +269,8 @@ type TeamsSummaryFunc func(ctx context.Context) ([]*fleet.TeamSummary, error)
 type SearchTeamsFunc func(ctx context.Context, filter fleet.TeamFilter, matchQuery string, omit ...uint) ([]*fleet.Team, error)
 
 type TeamEnrollSecretsFunc func(ctx context.Context, teamID uint) ([]*fleet.EnrollSecret, error)
+
+type ListSoftwareForVulnDetectionFunc func(ctx context.Context, hostID uint) ([]fleet.Software, error)
 
 type ListSoftwareVulnerabilitiesFunc func(ctx context.Context, hostID uint) ([]fleet.SoftwareVulnerability, error)
 
@@ -625,8 +627,8 @@ type DataStore struct {
 	HostIDsByNameFunc        HostIDsByNameFunc
 	HostIDsByNameFuncInvoked bool
 
-	HostIDsByPlatformFunc        HostIDsByPlatformFunc
-	HostIDsByPlatformFuncInvoked bool
+	HostIDsByOsVersionFunc        HostIDsByOsVersionFunc
+	HostIDsByOsVersionFuncInvoked bool
 
 	HostByIdentifierFunc        HostByIdentifierFunc
 	HostByIdentifierFuncInvoked bool
@@ -795,6 +797,9 @@ type DataStore struct {
 
 	TeamEnrollSecretsFunc        TeamEnrollSecretsFunc
 	TeamEnrollSecretsFuncInvoked bool
+
+	ListSoftwareForVulnDetectionFunc        ListSoftwareForVulnDetectionFunc
+	ListSoftwareForVulnDetectionFuncInvoked bool
 
 	ListSoftwareVulnerabilitiesFunc        ListSoftwareVulnerabilitiesFunc
 	ListSoftwareVulnerabilitiesFuncInvoked bool
@@ -1364,9 +1369,9 @@ func (s *DataStore) HostIDsByName(ctx context.Context, filter fleet.TeamFilter, 
 	return s.HostIDsByNameFunc(ctx, filter, hostnames)
 }
 
-func (s *DataStore) HostIDsByPlatform(ctx context.Context, platform *string, osVersion *string) ([]uint, error) {
-	s.HostIDsByPlatformFuncInvoked = true
-	return s.HostIDsByPlatformFunc(ctx, platform, osVersion)
+func (s *DataStore) HostIDsByOsVersion(ctx context.Context, osVersion fleet.OSVersion, offset int, limit int) ([]uint, error) {
+	s.HostIDsByOsVersionFuncInvoked = true
+	return s.HostIDsByOsVersionFunc(ctx, osVersion, offset, limit)
 }
 
 func (s *DataStore) HostByIdentifier(ctx context.Context, identifier string) (*fleet.Host, error) {
@@ -1647,6 +1652,11 @@ func (s *DataStore) SearchTeams(ctx context.Context, filter fleet.TeamFilter, ma
 func (s *DataStore) TeamEnrollSecrets(ctx context.Context, teamID uint) ([]*fleet.EnrollSecret, error) {
 	s.TeamEnrollSecretsFuncInvoked = true
 	return s.TeamEnrollSecretsFunc(ctx, teamID)
+}
+
+func (s *DataStore) ListSoftwareForVulnDetection(ctx context.Context, hostID uint) ([]fleet.Software, error) {
+	s.ListSoftwareForVulnDetectionFuncInvoked = true
+	return s.ListSoftwareForVulnDetectionFunc(ctx, hostID)
 }
 
 func (s *DataStore) ListSoftwareVulnerabilities(ctx context.Context, hostID uint) ([]fleet.SoftwareVulnerability, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -272,7 +272,7 @@ type TeamEnrollSecretsFunc func(ctx context.Context, teamID uint) ([]*fleet.Enro
 
 type ListSoftwareForVulnDetectionFunc func(ctx context.Context, hostID uint) ([]fleet.Software, error)
 
-type ListSoftwareVulnerabilitiesFunc func(ctx context.Context, hostID uint) ([]fleet.SoftwareVulnerability, error)
+type ListSoftwareVulnerabilitiesFunc func(ctx context.Context, hostIDs []uint) (map[uint][]fleet.SoftwareVulnerability, error)
 
 type LoadHostSoftwareFunc func(ctx context.Context, host *fleet.Host, opts fleet.SoftwareListOptions) error
 
@@ -1659,9 +1659,9 @@ func (s *DataStore) ListSoftwareForVulnDetection(ctx context.Context, hostID uin
 	return s.ListSoftwareForVulnDetectionFunc(ctx, hostID)
 }
 
-func (s *DataStore) ListSoftwareVulnerabilities(ctx context.Context, hostID uint) ([]fleet.SoftwareVulnerability, error) {
+func (s *DataStore) ListSoftwareVulnerabilities(ctx context.Context, hostIDs []uint) (map[uint][]fleet.SoftwareVulnerability, error) {
 	s.ListSoftwareVulnerabilitiesFuncInvoked = true
-	return s.ListSoftwareVulnerabilitiesFunc(ctx, hostID)
+	return s.ListSoftwareVulnerabilitiesFunc(ctx, hostIDs)
 }
 
 func (s *DataStore) LoadHostSoftware(ctx context.Context, host *fleet.Host, opts fleet.SoftwareListOptions) error {

--- a/server/vulnerabilities/oval/analyzer.go
+++ b/server/vulnerabilities/oval/analyzer.go
@@ -63,25 +63,30 @@ func Analyze(
 			break
 		}
 
+		foundInBatch := make(map[uint][]fleet.SoftwareVulnerability)
+		var foundInBatchIDs []uint
+
 		for _, hId := range hIds {
 			software, err := ds.ListSoftwareForVulnDetection(ctx, hId)
 			if err != nil {
 				errR = multierror.Append(errR, err)
 				continue
 			}
-
 			found := defs.Eval(software)
-			if len(found) == 0 {
-				continue
+			if len(found) != 0 {
+				foundInBatchIDs = append(foundInBatchIDs, hId)
+				foundInBatch[hId] = found
 			}
+		}
 
-			existing, err := ds.ListSoftwareVulnerabilities(ctx, hId)
-			if err != nil {
-				errR = multierror.Append(errR, err)
-				continue
-			}
+		existingInBatch, err := ds.ListSoftwareVulnerabilities(ctx, foundInBatchIDs)
+		if err != nil {
+			errR = multierror.Append(errR, err)
+			continue
+		}
 
-			insrt, del := vulnsDelta(found, existing)
+		for hId, found := range foundInBatch {
+			insrt, del := vulnsDelta(found, existingInBatch[hId])
 			for _, i := range insrt {
 				key := fmt.Sprintf("%d:%s", i.SoftwareID, i.CVE)
 				toInsertSet[key] = i

--- a/server/vulnerabilities/oval/analyzer.go
+++ b/server/vulnerabilities/oval/analyzer.go
@@ -51,7 +51,7 @@ func Analyze(
 
 	var offset int
 	for {
-		hIds, err := ds.HostIDsByOsVersion(ctx, ver, offset, hostsBatchSize)
+		hIds, err := ds.HostIDsByOSVersion(ctx, ver, offset, hostsBatchSize)
 		offset += hostsBatchSize
 
 		if err != nil {

--- a/server/vulnerabilities/oval/analyzer.go
+++ b/server/vulnerabilities/oval/analyzer.go
@@ -127,6 +127,8 @@ func batchProcess(
 		buffer[offset] = v
 		offset++
 		i++
+
+		// Consume buffer if full or if we are at the last iteration
 		if offset == bSize || i >= len(values) {
 			err := dsFunc(buffer[:offset])
 			if err != nil {

--- a/server/vulnerabilities/oval/analyzer_test.go
+++ b/server/vulnerabilities/oval/analyzer_test.go
@@ -200,11 +200,11 @@ func TestOvalAnalyzer(t *testing.T) {
 			}
 			require.NotEmpty(t, expected)
 
-			storedVulns, err := ds.ListSoftwareVulnerabilities(ctx, h.ID)
+			storedVulns, err := ds.ListSoftwareVulnerabilities(ctx, []uint{h.ID})
 			require.NoError(t, err)
 
 			uniq := make(map[string]bool)
-			for _, v := range storedVulns {
+			for _, v := range storedVulns[h.ID] {
 				uniq[v.CVE] = true
 			}
 			actual := make([]string, 0, len(uniq))

--- a/server/vulnerabilities/oval/analyzer_test.go
+++ b/server/vulnerabilities/oval/analyzer_test.go
@@ -13,21 +13,161 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/server"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/stretchr/testify/require"
 )
+
+func withTestFixture(
+	version fleet.OSVersion,
+	vulnPath string,
+	ds *mysql.Datastore,
+	afterLoad func(h *fleet.Host),
+	checkErr func(err error),
+) {
+	type softwareFixture struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+
+	ctx := context.Background()
+
+	extract := func(src, dst string) {
+		srcF, err := os.Open(src)
+		checkErr(err)
+		defer srcF.Close()
+
+		dstF, err := os.Create(dst)
+		checkErr(err)
+		defer dstF.Close()
+
+		r := bzip2.NewReader(srcF)
+		_, err = io.Copy(dstF, r)
+		checkErr(err)
+	}
+
+	extractFixtures := func(p Platform) {
+		fixtPath := "testdata/ubuntu"
+
+		srcDefPath := filepath.Join(fixtPath, fmt.Sprintf("%s-oval_def.json.bz2", p))
+		dstDefPath := filepath.Join(vulnPath, p.ToFilename(time.Now(), "json"))
+		extract(srcDefPath, dstDefPath)
+
+		srcSoftPath := filepath.Join(fixtPath, "software", fmt.Sprintf("%s-software.json.bz2", p))
+		dstSoftPath := filepath.Join(vulnPath, fmt.Sprintf("%s-software.json", p))
+		extract(srcSoftPath, dstSoftPath)
+
+		srcCvesPath := filepath.Join(fixtPath, "software", fmt.Sprintf("%s-software_cves.csv.bz2", p))
+		dstCvesPath := filepath.Join(vulnPath, fmt.Sprintf("%s-software_cves.csv", p))
+		extract(srcCvesPath, dstCvesPath)
+	}
+
+	loadSoftware := func(p Platform, s fleet.OSVersion) *fleet.Host {
+		osqueryHostID, err := server.GenerateRandomText(10)
+		checkErr(err)
+
+		h, err := ds.NewHost(context.Background(), &fleet.Host{
+			Hostname:        string(p),
+			NodeKey:         string(p),
+			UUID:            string(p),
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now(),
+			OsqueryHostID:   osqueryHostID,
+			Platform:        s.Platform,
+			OSVersion:       s.Name,
+		})
+		checkErr(err)
+
+		var fixtures []softwareFixture
+		contents, err := ioutil.ReadFile(filepath.Join(vulnPath, fmt.Sprintf("%s-software.json", p)))
+		checkErr(err)
+
+		err = json.Unmarshal(contents, &fixtures)
+		checkErr(err)
+
+		var software []fleet.Software
+		for _, fi := range fixtures {
+			software = append(software, fleet.Software{
+				Name:    fi.Name,
+				Version: fi.Version,
+			})
+		}
+		err = ds.UpdateHostSoftware(ctx, h.ID, software)
+		checkErr(err)
+
+		err = ds.LoadHostSoftware(ctx, h, fleet.SoftwareListOptions{})
+		checkErr(err)
+
+		for _, s := range h.Software {
+			err = ds.AddCPEForSoftware(ctx, s, fmt.Sprintf("%s-%s", s.Name, s.Version))
+			checkErr(err)
+		}
+
+		return h
+	}
+
+	p := NewPlatform(version.Platform, version.Name)
+
+	extractFixtures(p)
+	h := loadSoftware(p, version)
+
+	err := ds.UpdateOSVersions(ctx)
+	checkErr(err)
+
+	afterLoad(h)
+
+	err = ds.DeleteHost(ctx, h.ID)
+	checkErr(err)
+}
+
+func BenchmarkTestOvalAnalyzer(b *testing.B) {
+	ds := mysql.CreateMySQLDS(b)
+	defer mysql.TruncateTables(b, ds)
+
+	vulnPath, err := ioutil.TempDir("", "oval_analyzer_ubuntu")
+	defer os.RemoveAll(vulnPath)
+	require.NoError(b, err)
+
+	systems := []fleet.OSVersion{
+		{Platform: "ubuntu", Name: "Ubuntu 16.4.0"},
+		{Platform: "ubuntu", Name: "Ubuntu 18.4.0"},
+		{Platform: "ubuntu", Name: "Ubuntu 20.4.0"},
+		{Platform: "ubuntu", Name: "Ubuntu 21.4.0"},
+		{Platform: "ubuntu", Name: "Ubuntu 21.10.0"},
+		{Platform: "ubuntu", Name: "Ubuntu 22.4.0"},
+	}
+
+	for _, v := range systems {
+		b.Run(fmt.Sprintf("for %s %s", v.Platform, v.Name), func(b *testing.B) {
+			withTestFixture(v, vulnPath, ds, func(h *fleet.Host) {
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					_, err = Analyze(context.Background(), ds, v, vulnPath)
+					require.NoError(b, err)
+				}
+			}, func(err error) {
+				require.NoError(b, err)
+			})
+		})
+	}
+}
 
 func TestOvalAnalyzer(t *testing.T) {
 	// For generating the vulnerability lists I used VMs and ran oscap (since it seems like oscap
 	// does not work with Docker) and extracted all installed software vulnerabilities, then I had
 	// the VMs join my local dev env, and extracted the installed software from the database.
 	t.Run("analyzing Ubuntu software", func(t *testing.T) {
-		type softwareFixture struct {
-			Name    string `json:"name"`
-			Version string `json:"version"`
-		}
+		ds := mysql.CreateMySQLDS(t)
+		defer mysql.TruncateTables(t, ds)
+
+		vulnPath, err := ioutil.TempDir("", "oval_analyzer_ubuntu")
+		defer os.RemoveAll(vulnPath)
+		require.NoError(t, err)
+
+		ctx := context.Background()
 
 		systems := []fleet.OSVersion{
 			{Platform: "ubuntu", Name: "Ubuntu 16.4.0"},
@@ -36,79 +176,6 @@ func TestOvalAnalyzer(t *testing.T) {
 			{Platform: "ubuntu", Name: "Ubuntu 21.4.0"},
 			{Platform: "ubuntu", Name: "Ubuntu 21.10.0"},
 			{Platform: "ubuntu", Name: "Ubuntu 22.4.0"},
-		}
-
-		ds := mysql.CreateMySQLDS(t)
-		defer mysql.TruncateTables(t, ds)
-		ctx := context.Background()
-
-		vulnPath, err := ioutil.TempDir("", "oval_analyzer_ubuntu")
-		defer os.RemoveAll(vulnPath)
-		require.NoError(t, err)
-
-		extract := func(src, dst string) {
-			srcF, err := os.Open(src)
-			require.NoError(t, err)
-			defer srcF.Close()
-
-			dstF, err := os.Create(dst)
-			require.NoError(t, err)
-			defer dstF.Close()
-
-			r := bzip2.NewReader(srcF)
-			_, err = io.Copy(dstF, r)
-			require.NoError(t, err)
-		}
-
-		extractFixtures := func(p Platform) {
-			fixtPath := "testdata/ubuntu"
-
-			srcDefPath := filepath.Join(fixtPath, fmt.Sprintf("%s-oval_def.json.bz2", p))
-			dstDefPath := filepath.Join(vulnPath, p.ToFilename(time.Now(), "json"))
-			extract(srcDefPath, dstDefPath)
-
-			srcSoftPath := filepath.Join(fixtPath, "software", fmt.Sprintf("%s-software.json.bz2", p))
-			dstSoftPath := filepath.Join(vulnPath, fmt.Sprintf("%s-software.json", p))
-			extract(srcSoftPath, dstSoftPath)
-
-			srcCvesPath := filepath.Join(fixtPath, "software", fmt.Sprintf("%s-software_cves.csv.bz2", p))
-			dstCvesPath := filepath.Join(vulnPath, fmt.Sprintf("%s-software_cves.csv", p))
-			extract(srcCvesPath, dstCvesPath)
-		}
-
-		loadSoftware := func(p Platform, s fleet.OSVersion) *fleet.Host {
-			h := test.NewHost(t, ds, string(p), "127.0.0.1", string(p), string(p), time.Now())
-			h.Platform = s.Platform
-			h.OSVersion = s.Name
-			err := ds.UpdateHost(ctx, h)
-			require.NoError(t, err)
-
-			var fixtures []softwareFixture
-			contents, err := ioutil.ReadFile(filepath.Join(vulnPath, fmt.Sprintf("%s-software.json", p)))
-			require.NoError(t, err)
-
-			err = json.Unmarshal(contents, &fixtures)
-			require.NoError(t, err)
-
-			var software []fleet.Software
-			for _, fi := range fixtures {
-				software = append(software, fleet.Software{
-					Name:    fi.Name,
-					Version: fi.Version,
-				})
-			}
-			err = ds.UpdateHostSoftware(ctx, h.ID, software)
-			require.NoError(t, err)
-
-			err = ds.LoadHostSoftware(ctx, h, fleet.SoftwareListOptions{})
-			require.NoError(t, err)
-
-			for _, s := range h.Software {
-				err = ds.AddCPEForSoftware(ctx, s, fmt.Sprintf("%s-%s", s.Name, s.Version))
-				require.NoError(t, err)
-			}
-
-			return h
 		}
 
 		assertVulns := func(h *fleet.Host, p Platform) {
@@ -148,25 +215,16 @@ func TestOvalAnalyzer(t *testing.T) {
 			require.ElementsMatch(t, actual, expected)
 		}
 
-		for _, s := range systems {
-			p := NewPlatform(s.Platform, s.Name)
+		for _, v := range systems {
+			withTestFixture(v, vulnPath, ds, func(h *fleet.Host) {
+				_, err = Analyze(ctx, ds, v, vulnPath)
+				require.NoError(t, err)
 
-			extractFixtures(p)
-			h := loadSoftware(p, s)
-
-			err := ds.UpdateOSVersions(ctx)
-			require.NoError(t, err)
-
-			osVersions, err := ds.OSVersions(ctx, nil, nil)
-			require.NoError(t, err)
-
-			_, err = Analyze(ctx, ds, osVersions, vulnPath)
-			require.NoError(t, err)
-
-			assertVulns(h, p)
-
-			err = ds.DeleteHost(ctx, h.ID)
-			require.NoError(t, err)
+				p := NewPlatform(v.Platform, v.Name)
+				assertVulns(h, p)
+			}, func(err error) {
+				require.NoError(t, err)
+			})
 		}
 	})
 

--- a/server/vulnerabilities/oval/analyzer_test.go
+++ b/server/vulnerabilities/oval/analyzer_test.go
@@ -287,6 +287,21 @@ func TestOvalAnalyzer(t *testing.T) {
 			require.Equal(t, expectedToInsert, toInsert)
 			require.ElementsMatch(t, expectedToDelete, toDelete)
 		})
+
+		t.Run("nothing found but vulns exist", func(t *testing.T) {
+			var found []fleet.SoftwareVulnerability
+
+			existing := []fleet.SoftwareVulnerability{
+				{CPE: "cpe_1", CPEID: 1, CVE: "cve_1"},
+				{CPE: "cpe_1", CPEID: 1, CVE: "cve_2"},
+				{CPE: "cpe_2", CPEID: 2, CVE: "cve_3"},
+				{CPE: "cpe_2", CPEID: 2, CVE: "cve_4"},
+			}
+
+			toInsert, toDelete := vulnsDelta(found, existing)
+			require.Empty(t, toInsert)
+			require.ElementsMatch(t, existing, toDelete)
+		})
 	})
 
 	t.Run("#load", func(t *testing.T) {

--- a/server/vulnerabilities/oval/oval_platform.go
+++ b/server/vulnerabilities/oval/oval_platform.go
@@ -45,7 +45,7 @@ func getMajorMinorVer(osVersion string) string {
 // Ex: ('ubuntu', 'Ubuntu 20.4.0') => 'ubuntu-20'.
 func NewPlatform(hostPlatform, hostOsVersion string) Platform {
 	nPlatform := strings.Trim(strings.ToLower(hostPlatform), " ")
-	majorVer := getMajorMinorVer(hostOsVersion)
+	majorVer := getMajorMinorVer(strings.Trim(hostOsVersion, " "))
 	return Platform(fmt.Sprintf("%s_%s", nPlatform, majorVer))
 }
 
@@ -56,7 +56,16 @@ func (op Platform) ToFilename(date time.Time, extension string) string {
 
 // IsSupported returns whether the given platform is currently supported or not.
 func (op Platform) IsSupported() bool {
-	for _, p := range SupportedHostPlatforms {
+	supported := []string{
+		"ubuntu_1404",
+		"ubuntu_1604",
+		"ubuntu_1804",
+		"ubuntu_2004",
+		"ubuntu_2104",
+		"ubuntu_2110",
+		"ubuntu_2204",
+	}
+	for _, p := range supported {
 		if strings.HasPrefix(string(op), p) {
 			return true
 		}

--- a/server/vulnerabilities/oval/oval_platform_test.go
+++ b/server/vulnerabilities/oval/oval_platform_test.go
@@ -23,6 +23,7 @@ func TestOvalPlatform(t *testing.T) {
 			{"ubuntu", "Ubuntu 16.4.0", "ubuntu_1604"},
 			{"ubuntu", "Ubuntu 18.4.0", "ubuntu_1804"},
 			{"ubuntu", "Ubuntu 18.4", "ubuntu_1804"},
+			{"ubuntu", "Ubuntu 18.4.0 ", "ubuntu_1804"},
 		}
 
 		for _, c := range cases {

--- a/server/vulnerabilities/oval/sync.go
+++ b/server/vulnerabilities/oval/sync.go
@@ -127,17 +127,19 @@ func Refresh(
 	versions *fleet.OSVersions,
 	vulnPath string,
 ) ([]Platform, error) {
-	today := time.Now()
+	now := time.Now()
 
-	existing, err := removeOldDefs(today, vulnPath)
+	existing, err := removeOldDefs(now, vulnPath)
 	if err != nil {
 		return nil, err
 	}
 
-	toDownload := whatToDownload(versions, existing, today)
-	err = Sync(client, vulnPath, toDownload)
-	if err != nil {
-		return nil, err
+	toDownload := whatToDownload(versions, existing, now)
+	if len(toDownload) > 0 {
+		err = Sync(client, vulnPath, toDownload)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return toDownload, nil


### PR DESCRIPTION
This PR includes a couple of minor bug fixes that I found while load testing this:
- The OVAL syncher was using `path.Join(...)` instead of `filepath.Join(...)`
- When checking if new OVAL definitions need to be updated, if everything was up-to-date, all definitions were being downloaded regardless.

Also included a couple of perf improvements: 
- We now avoid issuing duplicated insert/delete statements when inserting/deleting vulnerabilities.
- We now insert/delete vulnerabilities in batches.
- We now load vulnerable software in batches.

To load test this, I had to define a couple of new ubuntu hosts in `osquery-perf` all with vulnerable software only - not sure if we want to keep this in the code base after this is reviewed.

Load test results:

| Platform | # hosts | # software per host | size OVAL def | Avg mem used | Avg run time | Vulns per hosts |
|--|--|--|--|--|--|--|
| Ubuntu 16.4.0 | 837 | 1781| 968K| ~17 Mb | ~27 seg | 2124 |
| Ubuntu 18.4.0 | 251 | 1552 | 823K| ~11 Mb | ~10 seg | 856 |
| Ubuntu 20.4.0 | 236 | 1492 |435K| ~9 Mb |  ~7 seg | 366 |
| Ubuntu 21.10.0 | 834 | 1504 |122K| ~9 Mb |  ~5 seg | 574|
| Ubuntu 21.4.0 | 228 | 1524 |199K| ~9 Mb | ~3.7 seg | 1027|
| Ubuntu 22.4.0  | 830 | 1689 |22K| ~8 Mb | ~5.6 seg | 157 |

Some notes:
- The major bottleneck is the fact that we need to load all software per host and with around ~1.5k software entries per host, we should be processing hosts sequentially to avoid hitting the DB too hard.
- The `Avg mem used` and `Avg run time` totals across all hosts for the given platform.
- The `Avg run time` is clearly a subject to change but it should give us an idea of how execution time changes as a function of the oval def size, the number of software per host and the number of vulnerabilities found.
- Platforms are processed sequentially (for example, first we analyze all hosts for `Ubuntu 16.4.0` then we move to `Ubuntu 18.4.0`, etc).

A simple optimization that we can do, but that is outside the scope of this PR is to add an indexed `inserted_at` timestamp to the `host_software` table  (assuming the stored software rows are inmutable) then, wen scanning hosts, we just need to look at what new software was installed between scans.