### PR TITLE
Orbit: Remove functionality superseeded by local TUF test scripts

### DIFF
--- a/orbit/README.md
+++ b/orbit/README.md
@@ -182,18 +182,9 @@ If the `logger_path` configuration is set to `filesystem`, Orbit will store osqu
 
 #### Orbit Development
 
-For ease of development of Orbit, `fleetctl package` allows the generation of a package with a
-custom orbit executable using the `FLEETCTL_ORBIT_DEV_BUILD_PATH` environment variable:
-```sh
-FLEETCTL_ORBIT_DEV_BUILD_PATH=$(pwd)/orbit.exe ./build/fleetctl package --type=msi --fleet-url=https://localhost:8080 --enroll-secret=the_secret_value
-Generating your osquery installer...
-2022/01/03 20:31:10 root pinning is not supported in Spec 1.0.19
-WARNING: You are attempting to override orbit with a dev build.
-Press Enter to continue, or Control-c to exit.
-[...]
-```
+##### Run Orbit From Source
 
-If you want to run orbit from source directly, you can do the following:
+To execute orbit from source directly, run the following command:
 
 ```sh
 go run github.com/fleetdm/fleet/v4/orbit/cmd/orbit \
@@ -215,6 +206,12 @@ go run github.com/fleetdm/fleet/v4/orbit/cmd/orbit \
     -- --flagfile=flagfile.txt --verbose
 ```
 
+##### Generate Installer Packages from Orbit Source
+
+The `fleetctl package` command generate installers by fetching the targets/executables from a [TUF](https://theupdateframework.io/) repository.
+To generate an installer that contains an Orbit built from source you need to setup a local TUF repository.
+The following document explains how you can generate such TUF repository, and how to generate installers
+that use it [tools/tuf/test](../tools/tuf/test/README.md).
 
 ### Troubleshooting
 

--- a/orbit/README.md
+++ b/orbit/README.md
@@ -208,10 +208,9 @@ go run github.com/fleetdm/fleet/v4/orbit/cmd/orbit \
 
 ##### Generate Installer Packages from Orbit Source
 
-The `fleetctl package` command generate installers by fetching the targets/executables from a [TUF](https://theupdateframework.io/) repository.
+The `fleetctl package` command generates installers by fetching the targets/executables from a [TUF](https://theupdateframework.io/) repository.
 To generate an installer that contains an Orbit built from source you need to setup a local TUF repository.
-The following document explains how you can generate such TUF repository, and how to generate installers
-that use it [tools/tuf/test](../tools/tuf/test/README.md).
+The following document explains how you can generate a TUF repository, and installers that use it [tools/tuf/test](../tools/tuf/test/README.md).
 
 ### Troubleshooting
 

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -165,10 +165,6 @@ func InitializeUpdates(updateOpt update.Options) (*UpdatesData, error) {
 		}
 	}
 
-	if devBuildPath := os.Getenv("FLEETCTL_ORBIT_DEV_BUILD_PATH"); devBuildPath != "" {
-		updater.CopyDevBuild("orbit", devBuildPath)
-	}
-
 	return &UpdatesData{
 		OrbitPath:    orbitPath,
 		OrbitVersion: orbitCustom.Version,

--- a/orbit/pkg/update/update.go
+++ b/orbit/pkg/update/update.go
@@ -3,7 +3,6 @@ package update
 
 import (
 	"archive/tar"
-	"bufio"
 	"compress/gzip"
 	"crypto/tls"
 	"encoding/json"
@@ -17,7 +16,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/fatih/color"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/build"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/platform"
@@ -325,49 +323,6 @@ func (u *Updater) Get(target string) (*LocalTarget, error) {
 	}
 
 	return localTarget, nil
-}
-
-func writeDevWarningBanner(w io.Writer) {
-	warningColor := color.New(color.FgWhite, color.Bold, color.BgRed)
-	warningColor.Fprintf(w, "WARNING: You are attempting to override orbit with a dev build.\nPress Enter to continue, or Control-c to exit.")
-	// We need to disable color and print a new line to make it look somewhat neat, otherwise colors continue to the
-	// next line
-	warningColor.DisableColor()
-	warningColor.Fprintln(w)
-	bufio.NewScanner(os.Stdin).Scan()
-}
-
-// CopyDevBuilds uses a development build for the given target+channel.
-//
-// This is just for development, must not be used in production.
-func (u *Updater) CopyDevBuild(target, devBuildPath string) {
-	writeDevWarningBanner(os.Stderr)
-
-	localPath, err := u.ExecutableLocalPath(target)
-	if err != nil {
-		panic(err)
-	}
-	if err := secure.MkdirAll(filepath.Dir(localPath), constant.DefaultDirMode); err != nil {
-		panic(err)
-	}
-	dst, err := secure.OpenFile(localPath, os.O_CREATE|os.O_WRONLY, constant.DefaultExecutableMode)
-	if err != nil {
-		panic(err)
-	}
-	defer dst.Close()
-
-	src, err := secure.OpenFile(devBuildPath, os.O_RDONLY, constant.DefaultExecutableMode)
-	if err != nil {
-		panic(err)
-	}
-	defer src.Close()
-
-	if _, err := src.Stat(); err != nil {
-		panic(err)
-	}
-	if _, err := io.Copy(dst, src); err != nil {
-		panic(err)
-	}
 }
 
 // download downloads the target to the provided path. The file is deleted and

--- a/tools/tuf/test/README.md
+++ b/tools/tuf/test/README.md
@@ -41,7 +41,7 @@ E.g. to add a new version of `orbit` for Windows:
 GOOS=windows GOARCH=amd64 go build -o orbit-windows.exe ./orbit/cmd/orbit
 
 # Push the compiled Orbit as a new version:
-./tools/tuf/push_target.sh windows orbit orbit-windows.exe 43
+./tools/tuf/test/push_target.sh windows orbit orbit-windows.exe 43
 ```
 
 E.g. to add a new version of `osqueryd` for macOS:
@@ -50,5 +50,5 @@ E.g. to add a new version of `osqueryd` for macOS:
 curl --output osqueryd https://tuf.fleetctl.com/targets/osqueryd/macos/5.0.1/osqueryd
 
 # Push the osqueryd target as a new version:
-./tools/tuf/push_target.sh macos osqueryd osqueryd 43
+./tools/tuf/test/push_target.sh macos osqueryd osqueryd 43
 ```


### PR DESCRIPTION
Previously we didn't have a way to generate Orbit installers "from source" (with local changes in Orbit).
At the time we introduced a `FLEETCTL_ORBIT_DEV_BUILD_PATH` to allow such a thing.

With the recent scripts added to `tools/tuf/test` we can generate installers "from source" by using a local "test" TUF repository.
