### PR TITLE
Update Fleet 4.15.0 blog post title

### DIFF
--- a/articles/fleet-4.15.0.md
+++ b/articles/fleet-4.15.0.md
@@ -79,5 +79,5 @@ Visit our [Update guide](https://fleetdm.com/docs/deploying/upgrading-fleet) in 
 <meta name="authorFullName" value="Kathy Satterlee">
 <meta name="authorGitHubUsername" value="ksatter">
 <meta name="publishedOn" value="2022-05-26">
-<meta name="articleTitle" value="Fleet 4.15.0 adds beta support for self-service, increases trasparency, and brings Zendesk to the party.">
+<meta name="articleTitle" value="Fleet 4.15.0 adds beta support for Self-service, Scope transparency, and brings Zendesk to the party.">
 <meta name="articleImageUrl" value="../website/assets/images/articles/fleet-4.15.0-cover-1600x900@2x.jpg">


### PR DESCRIPTION
- Update `meta` tag so that the title displayed on fleetdm.com is updated to the latest version.
