### PR TITLE
Feature 5796: Sent OVAL vulnerability results to third party integrations

### DIFF
--- a/changes/feature-5796-oval-third-party-integration
+++ b/changes/feature-5796-oval-third-party-integration
@@ -1,0 +1,1 @@
+Allow OVAL vulnerability results to be sent to third-party integrations.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -330,10 +330,13 @@ func checkOvalVulnerabilities(
 
 	// Analyze all supported os versions using the synched OVAL definitions.
 	for _, version := range versions.OSVersions {
+
 		start := time.Now()
-		_, err := oval.Analyze(ctx, ds, version, vulnPath)
+		r, err := oval.Analyze(ctx, ds, version, vulnPath, collectVulns)
 		elapsed := time.Since(start)
 		level.Debug(logger).Log("msg", "oval-analysis-done", "platform", version.Name, "elapsed", elapsed)
+
+		results = append(results, r...)
 
 		if err != nil {
 			level.Error(logger).Log("msg", "analyzing oval definitions", "err", err)

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -345,7 +345,7 @@ func checkNVDVulnerabilities(
 	logger kitlog.Logger,
 	vulnPath string,
 	config config.FleetConfig,
-	collectRecentVulns bool,
+	collectVulns bool,
 ) map[string][]string {
 	if !config.Vulnerabilities.DisableDataSync {
 		err := vulnerabilities.Sync(vulnPath, config.Vulnerabilities.CPEDatabaseURL)
@@ -370,7 +370,7 @@ func checkNVDVulnerabilities(
 		return nil
 	}
 
-	recentVulns, err := vulnerabilities.TranslateCPEToCVE(ctx, ds, vulnPath, logger, collectRecentVulns, config.Vulnerabilities.RecentVulnerabilityMaxAge)
+	recentVulns, err := vulnerabilities.TranslateCPEToCVE(ctx, ds, vulnPath, logger, collectVulns, config.Vulnerabilities.RecentVulnerabilityMaxAge)
 	if err != nil {
 		level.Error(logger).Log("msg", "analyzing vulnerable software: CPE->CVE", "err", err)
 		sentry.CaptureException(err)

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -378,14 +378,15 @@ func checkOvalVulnerabilities(
 
 	// Analyze all supported os versions using the synched OVAL definitions.
 	for _, version := range versions.OSVersions {
-
 		start := time.Now()
 		r, err := oval.Analyze(ctx, ds, version, vulnPath, collectVulns)
 		elapsed := time.Since(start)
-		level.Debug(logger).Log("msg", "oval-analysis-done", "platform", version.Name, "elapsed", elapsed)
-
+		level.Debug(logger).Log(
+			"msg", "oval-analysis-done",
+			"platform", version.Name,
+			"elapsed", elapsed,
+			"found new", len(r))
 		results = append(results, r...)
-
 		if err != nil {
 			level.Error(logger).Log("msg", "analyzing oval definitions", "err", err)
 			sentry.CaptureException(err)

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -227,7 +227,8 @@ func cronVulnerabilities(
 			}
 			level.Debug(logger).Log("vulnAutomationEnabled", vulnAutomationEnabled)
 
-			recentVulns := checkNVDVulnerabilities(ctx, ds, logger, vulnPath, config, (vulnAutomationEnabled != ""))
+			collectVulns := vulnAutomationEnabled != ""
+			recentVulns := checkNVDVulnerabilities(ctx, ds, logger, vulnPath, config, collectVulns)
 
 			// TODO: merge results
 			checkOvalVulnerabilities(ctx, ds, logger, vulnPath, config)

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -326,12 +326,12 @@ func filterRecentVulns(
 	filtered := make(map[string]fleet.SoftwareVulnerability)
 	for _, v := range nvdVulns {
 		if _, ok := lookup[v.CVE]; ok {
-			filtered[v.String()] = v
+			filtered[v.Key()] = v
 		}
 	}
 	for _, v := range ovalVulns {
 		if _, ok := lookup[v.CVE]; ok {
-			filtered[v.String()] = v
+			filtered[v.Key()] = v
 		}
 	}
 

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -307,6 +307,10 @@ func filterRecentVulns(
 	ovalVulns []fleet.SoftwareVulnerability,
 	maxAge time.Duration,
 ) []fleet.SoftwareVulnerability {
+	if len(nvdVulns) == 0 && len(ovalVulns) == 0 {
+		return nil
+	}
+
 	recent, err := ds.ListCVEs(ctx, maxAge)
 	if err != nil {
 		level.Error(logger).Log("msg", "could not fetch recent CVEs", "err", err)

--- a/cmd/fleet/cron_test.go
+++ b/cmd/fleet/cron_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterRecentVulns(t *testing.T) {
+	t.Run("no NVD nor OVAL vulns", func(t *testing.T) {
+		ctx := context.Background()
+		ds := new(mock.Store)
+		logger := kitlog.NewNopLogger()
+
+		result := filterRecentVulns(ctx, ds, logger, nil, nil, 2*time.Hour)
+		require.Empty(t, result)
+	})
+
+	t.Run("filters both NVD and OVAL vulns based on max age", func(t *testing.T) {
+		ctx := context.Background()
+		ds := new(mock.Store)
+		logger := kitlog.NewNopLogger()
+
+		ds.ListCVEsFunc = func(ctx context.Context, maxAge time.Duration) ([]fleet.CVEMeta, error) {
+			return []fleet.CVEMeta{
+				{CVE: "cve-recent-1"},
+				{CVE: "cve-recent-2"},
+				{CVE: "cve-recent-3"},
+			}, nil
+		}
+
+		ovalVulns := []fleet.SoftwareVulnerability{
+			{CVE: "cve-recent-1"},
+			{CVE: "cve-recent-2"},
+			{CVE: "cve-outdated-1"},
+		}
+
+		nvdVulns := []fleet.SoftwareVulnerability{
+			{CVE: "cve-recent-1"},
+			{CVE: "cve-recent-3"},
+			{CVE: "cve-outdated-2"},
+			{CVE: "cve-outdated-3"},
+		}
+
+		maxAge := 30 * 24 * time.Hour
+
+		expected := []string{
+			"cve-recent-1",
+			"cve-recent-2",
+			"cve-recent-3",
+		}
+
+		var actual []string
+		result := filterRecentVulns(ctx, ds, logger, nvdVulns, ovalVulns, maxAge)
+		for _, r := range result {
+			actual = append(actual, r.CVE)
+		}
+
+		require.ElementsMatch(t, expected, actual)
+	})
+}

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -739,7 +739,7 @@ func main() {
 	rand.Seed(*randSeed)
 
 	templateNames := []string{
-		"mac10.14.6.tml",
+		"mac10.14.6.tmpl",
 
 		// Uncomment this to add ubuntu hosts with vulnerable software
 		// "ubuntu_16.04.tmpl",

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -968,9 +968,8 @@ func (ds *Datastore) CalculateHostsPerSoftware(ctx context.Context, updatedAt ti
 	return nil
 }
 
-// HostsBySoftwareIDs returns a list of all hosts that have the software corresponding
-// to at least one of the Software installed. It returns a minimal represention of
-// matching hosts.
+// HostsBySoftwareIDs returns a list of all hosts that have at least one of the specified Software
+// installed. It returns a minimal represention of matching hosts.
 func (ds *Datastore) HostsBySoftwareIDs(ctx context.Context, softwareIDs []uint) ([]*fleet.HostShort, error) {
 	queryStmt := `
     SELECT 
@@ -1175,6 +1174,7 @@ func (ds *Datastore) ListSoftwareForVulnDetection(
 	return result, nil
 }
 
+// ListCVEs returns all cve_meta rows published after 'maxAge'
 func (ds *Datastore) ListCVEs(ctx context.Context, maxAge time.Duration) ([]fleet.CVEMeta, error) {
 	var result []fleet.CVEMeta
 

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -968,12 +968,12 @@ func (ds *Datastore) CalculateHostsPerSoftware(ctx context.Context, updatedAt ti
 	return nil
 }
 
-// HostsByCPEs returns a list of all hosts that have the software corresponding
-// to at least one of the CPEs installed. It returns a minimal represention of
+// HostsBySoftwareIDs returns a list of all hosts that have the software corresponding
+// to at least one of the Software installed. It returns a minimal represention of
 // matching hosts.
-func (ds *Datastore) HostsByCPEs(ctx context.Context, cpes []string) ([]*fleet.HostShort, error) {
+func (ds *Datastore) HostsBySoftwareIDs(ctx context.Context, softwareIDs []uint) ([]*fleet.HostShort, error) {
 	queryStmt := `
-    SELECT DISTINCT
+    SELECT 
       h.id,
       h.hostname
     FROM
@@ -982,16 +982,13 @@ func (ds *Datastore) HostsByCPEs(ctx context.Context, cpes []string) ([]*fleet.H
       host_software hs
     ON
       h.id = hs.host_id
-    INNER JOIN
-      software_cpe scp
-    ON
-      hs.software_id = scp.software_id
     WHERE
-      scp.cpe IN (?)
+      hs.software_id IN (?)
+	GROUP BY h.id, h.hostname
     ORDER BY
       h.id`
 
-	stmt, args, err := sqlx.In(queryStmt, cpes)
+	stmt, args, err := sqlx.In(queryStmt, softwareIDs)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "building query args")
 	}

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -1111,7 +1111,7 @@ func (ds *Datastore) InsertVulnerabilities(
 	}
 	res, err := ds.writer.ExecContext(ctx, sql, args...)
 	if err != nil {
-		return 0, ctxerr.Wrap(ctx, err, "insert software cve")
+		return 0, ctxerr.Wrap(ctx, err, "insert software vulnerabilities")
 	}
 	count, _ := res.RowsAffected()
 

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -660,7 +660,7 @@ func addCPEForSoftwareDB(ctx context.Context, exec sqlx.ExecerContext, software 
 	return uint(id), nil
 }
 
-func (ds *Datastore) AllCPEs(ctx context.Context, excludedPlatforms []string) ([]fleet.SoftwareCPE, error) {
+func (ds *Datastore) ListSoftwareCPEs(ctx context.Context, excludedPlatforms []string) ([]fleet.SoftwareCPE, error) {
 	var result []fleet.SoftwareCPE
 
 	var err error

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -660,12 +660,13 @@ func addCPEForSoftwareDB(ctx context.Context, exec sqlx.ExecerContext, software 
 	return uint(id), nil
 }
 
-func (ds *Datastore) AllCPEs(ctx context.Context, excludedPlatforms []string) ([]string, error) {
-	var cpes []string
+func (ds *Datastore) AllCPEs(ctx context.Context, excludedPlatforms []string) ([]fleet.SoftwareCPE, error) {
+	var result []fleet.SoftwareCPE
+
 	var err error
 	var args []interface{}
 
-	stmt := `SELECT cpe FROM software_cpe`
+	stmt := `SELECT id, software_id, cpe FROM software_cpe`
 
 	if excludedPlatforms != nil {
 		stmt += ` WHERE software_id NOT IN (
@@ -680,12 +681,12 @@ func (ds *Datastore) AllCPEs(ctx context.Context, excludedPlatforms []string) ([
 			return nil, ctxerr.Wrap(ctx, err, "loads cpes")
 		}
 	}
-	err = sqlx.SelectContext(ctx, ds.reader, &cpes, stmt, args...)
+	err = sqlx.SelectContext(ctx, ds.reader, &result, stmt, args...)
 
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "loads cpes")
 	}
-	return cpes, nil
+	return result, nil
 }
 
 // InsertCVEForCPE inserts the cve into software_cve, linking it to all the

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -1145,7 +1145,6 @@ func (ds *Datastore) ListSoftwareVulnerabilities(
 		Select(
 			goqu.I("hs.host_id").As("host_id"),
 			goqu.I("cpe.software_id"),
-			goqu.C("cpe"),
 			goqu.C("cpe_id"),
 			goqu.C("cve"),
 		).

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -689,6 +689,7 @@ func (ds *Datastore) ListSoftwareCPEs(ctx context.Context, excludedPlatforms []s
 	return result, nil
 }
 
+// TODO (juan): Optimize this, we don't need to look at the cpe_id anymore
 // InsertCVEForCPE inserts the cve into software_cve, linking it to all the
 // provided cpes. It returns the number of new rows inserted or an error. If
 // the CVE already existed for all CPEs, it would return 0, nil.

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -1178,7 +1178,7 @@ func (ds *Datastore) ListSoftwareForVulnDetection(
 func (ds *Datastore) ListCVEs(ctx context.Context, maxAge time.Duration) ([]fleet.CVEMeta, error) {
 	var result []fleet.CVEMeta
 
-	maxAgeDate := time.Now().UTC().Add(-1 * maxAge)
+	maxAgeDate := time.Now().Add(-1 * maxAge)
 	stmt := dialect.From(goqu.T("cve_meta")).
 		Select(
 			goqu.C("cve"),

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -1177,3 +1177,7 @@ func (ds *Datastore) ListSoftwareForVulnDetection(
 
 	return result, nil
 }
+
+func (ds *Datastore) ListCVEs(ctx context.Context, maxAge time.Duration) ([]fleet.CVEMeta, error) {
+	panic("not implemented")
+}

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -1178,7 +1178,7 @@ func (ds *Datastore) ListSoftwareForVulnDetection(
 func (ds *Datastore) ListCVEs(ctx context.Context, maxAge time.Duration) ([]fleet.CVEMeta, error) {
 	var result []fleet.CVEMeta
 
-	now := time.Now().UTC().Add(-1 * maxAge)
+	maxAgeDate := time.Now().UTC().Add(-1 * maxAge)
 	stmt := dialect.From(goqu.T("cve_meta")).
 		Select(
 			goqu.C("cve"),
@@ -1187,7 +1187,7 @@ func (ds *Datastore) ListCVEs(ctx context.Context, maxAge time.Duration) ([]flee
 			goqu.C("cisa_known_exploit"),
 			goqu.C("published"),
 		).
-		Where(goqu.C("published").Gte(now))
+		Where(goqu.C("published").Gte(maxAgeDate))
 
 	sql, args, err := stmt.ToSQL()
 	if err != nil {

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -1552,6 +1552,7 @@ func testListCVEs(t *testing.T, ds *Datastore) {
 		{CVE: "cve-1", Published: &threeDaysAgo},
 		{CVE: "cve-2", Published: &twoWeeksAgo},
 		{CVE: "cve-3", Published: &twoMonthsAgo},
+		{CVE: "cve-4"},
 	}
 
 	err := ds.InsertCVEMeta(ctx, testCases)

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -35,7 +35,7 @@ func TestSoftware(t *testing.T) {
 		{"ListVulnerableSoftwareBySource", testListVulnerableSoftwareBySource},
 		{"DeleteVulnerabilitiesByCPECVE", testDeleteVulnerabilitiesByCPECVE},
 		{"HostsByCVE", testHostsByCVE},
-		{"HostsByCPEs", testHostsByCPEs},
+		{"HostsBySoftwareIDs", testHostsBySoftwareIDs},
 		{"UpdateHostSoftware", testUpdateHostSoftware},
 		{"ListSoftwareByHostIDShort", testListSoftwareByHostIDShort},
 		{"ListSoftwareVulnerabilities", testListSoftwareVulnerabilities},
@@ -1244,28 +1244,43 @@ func testHostsByCVE(t *testing.T, ds *Datastore) {
 	require.Equal(t, hosts[0].Hostname, "host2")
 }
 
-func testHostsByCPEs(t *testing.T, ds *Datastore) {
+func testHostsBySoftwareIDs(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
 
-	hosts, err := ds.HostsByCPEs(ctx, []string{"cpe_foo_chrome_3"})
+	hosts, err := ds.HostsBySoftwareIDs(ctx, []uint{0})
 	require.NoError(t, err)
 	require.Len(t, hosts, 0)
 
 	insertVulnSoftwareForTest(t, ds)
 
-	hosts, err = ds.HostsByCPEs(ctx, []string{"cpe_foo_chrome_3"})
+	allSoftware, err := ds.ListSoftware(ctx, fleet.SoftwareListOptions{})
+
+	var chrome3 fleet.Software
+	var barRpm fleet.Software
+
+	for _, s := range allSoftware {
+		if s.GenerateCPE == "cpe_foo_chrome_3" {
+			chrome3 = s
+		}
+
+		if s.GenerateCPE == "cpe_bar_rpm" {
+			barRpm = s
+		}
+	}
+
+	hosts, err = ds.HostsBySoftwareIDs(ctx, []uint{chrome3.ID})
 	require.NoError(t, err)
 	require.Len(t, hosts, 2)
 	require.Equal(t, hosts[0].Hostname, "host1")
 	require.Equal(t, hosts[1].Hostname, "host2")
 
-	hosts, err = ds.HostsByCPEs(ctx, []string{"cpe_bar_rpm"})
+	hosts, err = ds.HostsBySoftwareIDs(ctx, []uint{barRpm.ID})
 	require.NoError(t, err)
 	require.Len(t, hosts, 1)
 	require.Equal(t, hosts[0].Hostname, "host2")
 
 	// Duplicates should not be returned if cpes are found on the same host ie host2 should only appear once
-	hosts, err = ds.HostsByCPEs(ctx, []string{"cpe_foo_chrome_3", "cpe_bar_rpm"})
+	hosts, err = ds.HostsBySoftwareIDs(ctx, []uint{chrome3.ID, barRpm.ID})
 	require.NoError(t, err)
 	require.Len(t, hosts, 2)
 	require.Equal(t, hosts[0].Hostname, "host1")

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -321,14 +321,28 @@ func testSoftwareAllCPEs(t *testing.T, ds *Datastore) {
 
 	t.Run("without excludedPlatforms", func(t *testing.T) {
 		cpes, err := ds.AllCPEs(ctx, nil)
+		expected := []string{
+			"cpe1", "cpe2", "cpe3", "cpe4",
+		}
+		var actual []string
+		for _, v := range cpes {
+			actual = append(actual, v.CPE)
+		}
 		require.NoError(t, err)
-		assert.ElementsMatch(t, cpes, []string{"cpe1", "cpe2", "cpe3", "cpe4"})
+		assert.ElementsMatch(t, actual, expected)
 	})
 
 	t.Run("with excludedPlatforms", func(t *testing.T) {
 		cpes, err := ds.AllCPEs(ctx, []string{"ubuntu"})
+		expected := []string{
+			"cpe1", "cpe2",
+		}
+		var actual []string
+		for _, v := range cpes {
+			actual = append(actual, v.CPE)
+		}
 		require.NoError(t, err)
-		assert.ElementsMatch(t, cpes, []string{"cpe1", "cpe2"})
+		assert.ElementsMatch(t, actual, expected)
 	})
 }
 

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -1351,20 +1351,16 @@ func testListSoftwareVulnerabilities(t *testing.T, ds *Datastore) {
 	_, err = ds.InsertCVEForCPE(ctx, "cve-456", []string{"bar_cpe"})
 	require.NoError(t, err)
 
-	expectedCPEs := []string{"foo_cpe", "bar_cpe"}
 	expectedCVEs := []string{"cve-123", "cve-456"}
 
-	actualCPEs := make([]string, 0)
 	actualCVEs := make([]string, 0)
 
 	result, err := ds.ListSoftwareVulnerabilities(ctx, []uint{hostOne.ID})
 	for _, r := range result[hostOne.ID] {
-		actualCPEs = append(actualCPEs, r.CPE)
 		actualCVEs = append(actualCVEs, r.CVE)
 	}
 
 	require.NoError(t, err)
-	require.ElementsMatch(t, expectedCPEs, actualCPEs)
 	require.ElementsMatch(t, expectedCVEs, actualCVEs)
 
 	for _, r := range result[hostOne.ID] {

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -28,7 +28,7 @@ func TestSoftware(t *testing.T) {
 		{"InsertCVEs", testSoftwareInsertCVEs},
 		{"HostDuplicates", testSoftwareHostDuplicates},
 		{"LoadVulnerabilities", testSoftwareLoadVulnerabilities},
-		{"AllCPEs", testSoftwareAllCPEs},
+		{"ListSoftwareCPEs", testListSoftwareCPEs},
 		{"NothingChanged", testSoftwareNothingChanged},
 		{"LoadSupportsTonsOfCVEs", testSoftwareLoadSupportsTonsOfCVEs},
 		{"List", testSoftwareList},
@@ -290,7 +290,7 @@ func testSoftwareLoadVulnerabilities(t *testing.T, ds *Datastore) {
 	require.Len(t, host.Software[1].Vulnerabilities, 0)
 }
 
-func testSoftwareAllCPEs(t *testing.T, ds *Datastore) {
+func testListSoftwareCPEs(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
 
 	debian := test.NewHost(t, ds, "host3", "", "host3key", "host3uuid", time.Now())
@@ -320,7 +320,7 @@ func testSoftwareAllCPEs(t *testing.T, ds *Datastore) {
 	require.NoError(t, ds.AddCPEForSoftware(ctx, ubuntu.Software[1], "cpe4"))
 
 	t.Run("without excludedPlatforms", func(t *testing.T) {
-		cpes, err := ds.AllCPEs(ctx, nil)
+		cpes, err := ds.ListSoftwareCPEs(ctx, nil)
 		expected := []string{
 			"cpe1", "cpe2", "cpe3", "cpe4",
 		}
@@ -333,7 +333,7 @@ func testSoftwareAllCPEs(t *testing.T, ds *Datastore) {
 	})
 
 	t.Run("with excludedPlatforms", func(t *testing.T) {
-		cpes, err := ds.AllCPEs(ctx, []string{"ubuntu"})
+		cpes, err := ds.ListSoftwareCPEs(ctx, []string{"ubuntu"})
 		expected := []string{
 			"cpe1", "cpe2",
 		}

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -350,6 +350,7 @@ type Datastore interface {
 	// InsertVulnerabilities inserts the given vulnerabilities in the datastore, returns the number
 	// of rows inserted. If a vulnerability already exists in the datastore, then it will be ignored.
 	InsertVulnerabilities(ctx context.Context, vulns []SoftwareVulnerability, source VulnerabilitySource) (int64, error)
+	// TODO (juan): Remove this
 	InsertCVEForCPE(ctx context.Context, cve string, cpes []string) (int64, error)
 	SoftwareByID(ctx context.Context, id uint, includeCVEScores bool) (*Software, error)
 	// ListSoftwareByHostIDShort lists software by host ID, but does not include CPEs or vulnerabilites.

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -361,7 +361,7 @@ type Datastore interface {
 	// After aggregation, it cleans up unused software (e.g. software installed
 	// on removed hosts, software uninstalled on hosts, etc.)
 	CalculateHostsPerSoftware(ctx context.Context, updatedAt time.Time) error
-	HostsByCPEs(ctx context.Context, cpes []string) ([]*HostShort, error)
+	HostsBySoftwareIDs(ctx context.Context, softwareIDs []uint) ([]*HostShort, error)
 	HostsByCVE(ctx context.Context, cve string) ([]*HostShort, error)
 	InsertCVEMeta(ctx context.Context, cveMeta []CVEMeta) error
 	ListCVEs(ctx context.Context, maxAge time.Duration) ([]CVEMeta, error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -364,6 +364,7 @@ type Datastore interface {
 	HostsByCPEs(ctx context.Context, cpes []string) ([]*HostShort, error)
 	HostsByCVE(ctx context.Context, cve string) ([]*HostShort, error)
 	InsertCVEMeta(ctx context.Context, cveMeta []CVEMeta) error
+	ListCVEs(ctx context.Context, maxAge time.Duration) ([]CVEMeta, error)
 
 	///////////////////////////////////////////////////////////////////////////////
 	// ActivitiesStore

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -350,8 +350,6 @@ type Datastore interface {
 	// InsertVulnerabilities inserts the given vulnerabilities in the datastore, returns the number
 	// of rows inserted. If a vulnerability already exists in the datastore, then it will be ignored.
 	InsertVulnerabilities(ctx context.Context, vulns []SoftwareVulnerability, source VulnerabilitySource) (int64, error)
-	// TODO (juan): Remove this
-	InsertCVEForCPE(ctx context.Context, cve string, cpes []string) (int64, error)
 	SoftwareByID(ctx context.Context, id uint, includeCVEScores bool) (*Software, error)
 	// ListSoftwareByHostIDShort lists software by host ID, but does not include CPEs or vulnerabilites.
 	// It is meant to be used when only minimal software fields are required eg when updating host software.

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -346,7 +346,7 @@ type Datastore interface {
 	LoadHostSoftware(ctx context.Context, host *Host, opts SoftwareListOptions, includeCVEScores bool) error
 	AllSoftwareWithoutCPEIterator(ctx context.Context) (SoftwareIterator, error)
 	AddCPEForSoftware(ctx context.Context, software Software, cpe string) error
-	AllCPEs(ctx context.Context, excludedPlatforms []string) ([]string, error)
+	AllCPEs(ctx context.Context, excludedPlatforms []string) ([]SoftwareCPE, error)
 	// InsertVulnerabilities inserts the given vulnerabilities in the datastore, returns the number
 	// of rows inserted. If a vulnerability already exists in the datastore, then it will be ignored.
 	InsertVulnerabilities(ctx context.Context, vulns []SoftwareVulnerability, source VulnerabilitySource) (int64, error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -346,7 +346,7 @@ type Datastore interface {
 	LoadHostSoftware(ctx context.Context, host *Host, opts SoftwareListOptions, includeCVEScores bool) error
 	AllSoftwareWithoutCPEIterator(ctx context.Context) (SoftwareIterator, error)
 	AddCPEForSoftware(ctx context.Context, software Software, cpe string) error
-	AllCPEs(ctx context.Context, excludedPlatforms []string) ([]SoftwareCPE, error)
+	ListSoftwareCPEs(ctx context.Context, excludedPlatforms []string) ([]SoftwareCPE, error)
 	// InsertVulnerabilities inserts the given vulnerabilities in the datastore, returns the number
 	// of rows inserted. If a vulnerability already exists in the datastore, then it will be ignored.
 	InsertVulnerabilities(ctx context.Context, vulns []SoftwareVulnerability, source VulnerabilitySource) (int64, error)

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -119,7 +119,7 @@ type SoftwareListOptions struct {
 	WithHostCounts bool
 }
 
-// SoftwareVulnerability identifies a vulnerability on a specific software (CPE).
+// SoftwareVulnerability identifies a vulnerability on a specific software.
 type SoftwareVulnerability struct {
 	SoftwareID uint   `db:"software_id"`
 	CPEID      uint   `db:"cpe_id"`

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -135,7 +135,7 @@ type SoftwareVulnerability struct {
 
 // String implements fmt.Stringer.
 func (sv SoftwareVulnerability) String() string {
-	return fmt.Sprintf("{%d,%s}", sv.CPEID, sv.CVE)
+	return fmt.Sprintf("{%d,%s}", sv.SoftwareID, sv.CVE)
 }
 
 // SoftwareWithCPE holds a software piece alongside its CPE ID.

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -122,7 +122,6 @@ type SoftwareListOptions struct {
 // SoftwareVulnerability identifies a vulnerability on a specific software (CPE).
 type SoftwareVulnerability struct {
 	SoftwareID uint   `db:"software_id"`
-	CPE        string `db:"cpe"`
 	CPEID      uint   `db:"cpe_id"`
 	CVE        string `db:"cve"`
 }

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -119,6 +119,13 @@ type SoftwareListOptions struct {
 	WithHostCounts bool
 }
 
+// SoftwareCPE represents an entry in the `software_cpe` table
+type SoftwareCPE struct {
+	ID         uint   `db:"id"`
+	SoftwareID uint   `db:"software_id"`
+	CPE        string `db:"cpe"`
+}
+
 // SoftwareVulnerability identifies a vulnerability on a specific software.
 type SoftwareVulnerability struct {
 	SoftwareID uint   `db:"software_id"`

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -138,6 +138,11 @@ func (sv SoftwareVulnerability) String() string {
 	return fmt.Sprintf("{%d,%s}", sv.SoftwareID, sv.CVE)
 }
 
+// Key returns a string representation of the SoftwareVulnerability
+func (sv *SoftwareVulnerability) Key() string {
+	return fmt.Sprintf("%d:%s", sv.SoftwareID, sv.CVE)
+}
+
 // SoftwareWithCPE holds a software piece alongside its CPE ID.
 type SoftwareWithCPE struct {
 	// Software holds the software data.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -280,7 +280,7 @@ type AllSoftwareWithoutCPEIteratorFunc func(ctx context.Context) (fleet.Software
 
 type AddCPEForSoftwareFunc func(ctx context.Context, software fleet.Software, cpe string) error
 
-type AllCPEsFunc func(ctx context.Context, excludedPlatforms []string) ([]string, error)
+type AllCPEsFunc func(ctx context.Context, excludedPlatforms []string) ([]fleet.SoftwareCPE, error)
 
 type InsertVulnerabilitiesFunc func(ctx context.Context, vulns []fleet.SoftwareVulnerability, source fleet.VulnerabilitySource) (int64, error)
 
@@ -1679,7 +1679,7 @@ func (s *DataStore) AddCPEForSoftware(ctx context.Context, software fleet.Softwa
 	return s.AddCPEForSoftwareFunc(ctx, software, cpe)
 }
 
-func (s *DataStore) AllCPEs(ctx context.Context, excludedPlatforms []string) ([]string, error) {
+func (s *DataStore) AllCPEs(ctx context.Context, excludedPlatforms []string) ([]fleet.SoftwareCPE, error) {
 	s.AllCPEsFuncInvoked = true
 	return s.AllCPEsFunc(ctx, excludedPlatforms)
 }

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -290,7 +290,7 @@ type ListSoftwareByHostIDShortFunc func(ctx context.Context, hostID uint) ([]fle
 
 type CalculateHostsPerSoftwareFunc func(ctx context.Context, updatedAt time.Time) error
 
-type HostsByCPEsFunc func(ctx context.Context, cpes []string) ([]*fleet.HostShort, error)
+type HostsBySoftwareIDsFunc func(ctx context.Context, softwareIDs []uint) ([]*fleet.HostShort, error)
 
 type HostsByCVEFunc func(ctx context.Context, cve string) ([]*fleet.HostShort, error)
 
@@ -828,8 +828,8 @@ type DataStore struct {
 	CalculateHostsPerSoftwareFunc        CalculateHostsPerSoftwareFunc
 	CalculateHostsPerSoftwareFuncInvoked bool
 
-	HostsByCPEsFunc        HostsByCPEsFunc
-	HostsByCPEsFuncInvoked bool
+	HostsBySoftwareIDsFunc        HostsBySoftwareIDsFunc
+	HostsBySoftwareIDsFuncInvoked bool
 
 	HostsByCVEFunc        HostsByCVEFunc
 	HostsByCVEFuncInvoked bool
@@ -1704,9 +1704,9 @@ func (s *DataStore) CalculateHostsPerSoftware(ctx context.Context, updatedAt tim
 	return s.CalculateHostsPerSoftwareFunc(ctx, updatedAt)
 }
 
-func (s *DataStore) HostsByCPEs(ctx context.Context, cpes []string) ([]*fleet.HostShort, error) {
-	s.HostsByCPEsFuncInvoked = true
-	return s.HostsByCPEsFunc(ctx, cpes)
+func (s *DataStore) HostsBySoftwareIDs(ctx context.Context, softwareIDs []uint) ([]*fleet.HostShort, error) {
+	s.HostsBySoftwareIDsFuncInvoked = true
+	return s.HostsBySoftwareIDsFunc(ctx, softwareIDs)
 }
 
 func (s *DataStore) HostsByCVE(ctx context.Context, cve string) ([]*fleet.HostShort, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -284,8 +284,6 @@ type ListSoftwareCPEsFunc func(ctx context.Context, excludedPlatforms []string) 
 
 type InsertVulnerabilitiesFunc func(ctx context.Context, vulns []fleet.SoftwareVulnerability, source fleet.VulnerabilitySource) (int64, error)
 
-type InsertCVEForCPEFunc func(ctx context.Context, cve string, cpes []string) (int64, error)
-
 type SoftwareByIDFunc func(ctx context.Context, id uint, includeCVEScores bool) (*fleet.Software, error)
 
 type ListSoftwareByHostIDShortFunc func(ctx context.Context, hostID uint) ([]fleet.Software, error)
@@ -818,9 +816,6 @@ type DataStore struct {
 
 	InsertVulnerabilitiesFunc        InsertVulnerabilitiesFunc
 	InsertVulnerabilitiesFuncInvoked bool
-
-	InsertCVEForCPEFunc        InsertCVEForCPEFunc
-	InsertCVEForCPEFuncInvoked bool
 
 	SoftwareByIDFunc        SoftwareByIDFunc
 	SoftwareByIDFuncInvoked bool
@@ -1687,11 +1682,6 @@ func (s *DataStore) ListSoftwareCPEs(ctx context.Context, excludedPlatforms []st
 func (s *DataStore) InsertVulnerabilities(ctx context.Context, vulns []fleet.SoftwareVulnerability, source fleet.VulnerabilitySource) (int64, error) {
 	s.InsertVulnerabilitiesFuncInvoked = true
 	return s.InsertVulnerabilitiesFunc(ctx, vulns, source)
-}
-
-func (s *DataStore) InsertCVEForCPE(ctx context.Context, cve string, cpes []string) (int64, error) {
-	s.InsertCVEForCPEFuncInvoked = true
-	return s.InsertCVEForCPEFunc(ctx, cve, cpes)
 }
 
 func (s *DataStore) SoftwareByID(ctx context.Context, id uint, includeCVEScores bool) (*fleet.Software, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -280,7 +280,7 @@ type AllSoftwareWithoutCPEIteratorFunc func(ctx context.Context) (fleet.Software
 
 type AddCPEForSoftwareFunc func(ctx context.Context, software fleet.Software, cpe string) error
 
-type AllCPEsFunc func(ctx context.Context, excludedPlatforms []string) ([]fleet.SoftwareCPE, error)
+type ListSoftwareCPEsFunc func(ctx context.Context, excludedPlatforms []string) ([]fleet.SoftwareCPE, error)
 
 type InsertVulnerabilitiesFunc func(ctx context.Context, vulns []fleet.SoftwareVulnerability, source fleet.VulnerabilitySource) (int64, error)
 
@@ -813,8 +813,8 @@ type DataStore struct {
 	AddCPEForSoftwareFunc        AddCPEForSoftwareFunc
 	AddCPEForSoftwareFuncInvoked bool
 
-	AllCPEsFunc        AllCPEsFunc
-	AllCPEsFuncInvoked bool
+	ListSoftwareCPEsFunc        ListSoftwareCPEsFunc
+	ListSoftwareCPEsFuncInvoked bool
 
 	InsertVulnerabilitiesFunc        InsertVulnerabilitiesFunc
 	InsertVulnerabilitiesFuncInvoked bool
@@ -1679,9 +1679,9 @@ func (s *DataStore) AddCPEForSoftware(ctx context.Context, software fleet.Softwa
 	return s.AddCPEForSoftwareFunc(ctx, software, cpe)
 }
 
-func (s *DataStore) AllCPEs(ctx context.Context, excludedPlatforms []string) ([]fleet.SoftwareCPE, error) {
-	s.AllCPEsFuncInvoked = true
-	return s.AllCPEsFunc(ctx, excludedPlatforms)
+func (s *DataStore) ListSoftwareCPEs(ctx context.Context, excludedPlatforms []string) ([]fleet.SoftwareCPE, error) {
+	s.ListSoftwareCPEsFuncInvoked = true
+	return s.ListSoftwareCPEsFunc(ctx, excludedPlatforms)
 }
 
 func (s *DataStore) InsertVulnerabilities(ctx context.Context, vulns []fleet.SoftwareVulnerability, source fleet.VulnerabilitySource) (int64, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -296,6 +296,8 @@ type HostsByCVEFunc func(ctx context.Context, cve string) ([]*fleet.HostShort, e
 
 type InsertCVEMetaFunc func(ctx context.Context, cveMeta []fleet.CVEMeta) error
 
+type ListCVEsFunc func(ctx context.Context, maxAge time.Duration) ([]fleet.CVEMeta, error)
+
 type NewActivityFunc func(ctx context.Context, user *fleet.User, activityType string, details *map[string]interface{}) error
 
 type ListActivitiesFunc func(ctx context.Context, opt fleet.ListOptions) ([]*fleet.Activity, error)
@@ -834,6 +836,9 @@ type DataStore struct {
 
 	InsertCVEMetaFunc        InsertCVEMetaFunc
 	InsertCVEMetaFuncInvoked bool
+
+	ListCVEsFunc        ListCVEsFunc
+	ListCVEsFuncInvoked bool
 
 	NewActivityFunc        NewActivityFunc
 	NewActivityFuncInvoked bool
@@ -1712,6 +1717,11 @@ func (s *DataStore) HostsByCVE(ctx context.Context, cve string) ([]*fleet.HostSh
 func (s *DataStore) InsertCVEMeta(ctx context.Context, cveMeta []fleet.CVEMeta) error {
 	s.InsertCVEMetaFuncInvoked = true
 	return s.InsertCVEMetaFunc(ctx, cveMeta)
+}
+
+func (s *DataStore) ListCVEs(ctx context.Context, maxAge time.Duration) ([]fleet.CVEMeta, error) {
+	s.ListCVEsFuncInvoked = true
+	return s.ListCVEsFunc(ctx, maxAge)
 }
 
 func (s *DataStore) NewActivity(ctx context.Context, user *fleet.User, activityType string, details *map[string]interface{}) error {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -478,11 +478,21 @@ func (s *integrationTestSuite) TestVulnerableSoftware() {
 	}
 
 	require.NoError(t, s.ds.AddCPEForSoftware(context.Background(), soft1, "somecpe"))
+
+	// Reload software so that 'GeneratedCPEID is set.
 	require.NoError(t, s.ds.LoadHostSoftware(context.Background(), host, fleet.SoftwareListOptions{}, false))
+	soft1 = host.Software[0]
+	if soft1.Name != "bar" {
+		soft1 = host.Software[1]
+	}
 
 	n, err := s.ds.InsertVulnerabilities(
 		context.Background(), []fleet.SoftwareVulnerability{
-			{SoftwareID: soft1.ID, CPEID: soft1.GeneratedCPEID, CVE: "cve-123-123-132"},
+			{
+				SoftwareID: soft1.ID,
+				CPEID:      soft1.GeneratedCPEID,
+				CVE:        "cve-123-123-132",
+			},
 		}, fleet.NVD,
 	)
 	require.NoError(t, err)
@@ -4089,20 +4099,23 @@ func (s *integrationTestSuite) TestPaginateListSoftware() {
 	for i, sw := range sws {
 		cpe := "somecpe" + strconv.Itoa(i)
 		require.NoError(t, s.ds.AddCPEForSoftware(context.Background(), sw, cpe))
-
-		var vulns []fleet.SoftwareVulnerability
-		if i < 10 {
-			vulns = append(vulns, fleet.SoftwareVulnerability{
-				SoftwareID: sw.ID,
-				CPEID:      sw.GeneratedCPEID,
-				CVE:        fmt.Sprintf("cve-123-123-%03d", i),
-			})
-		}
-		// add CVEs for the first 10 software, which are the least used (lower hosts_count)
-		n, err := s.ds.InsertVulnerabilities(context.Background(), vulns, fleet.NVD)
-		require.NoError(t, err)
-		require.Equal(t, 10, int(n))
 	}
+
+	// Reload software to load GeneratedCPEID
+	require.NoError(t, s.ds.LoadHostSoftware(context.Background(), hosts[0], fleet.SoftwareListOptions{}, false))
+	var vulns []fleet.SoftwareVulnerability
+	for i, sw := range hosts[0].Software[:10] {
+		vulns = append(vulns, fleet.SoftwareVulnerability{
+			SoftwareID: sw.ID,
+			CPEID:      sw.GeneratedCPEID,
+			CVE:        fmt.Sprintf("cve-123-123-%03d", i),
+		})
+	}
+
+	// add CVEs for the first 10 software, which are the least used (lower hosts_count)
+	n, err := s.ds.InsertVulnerabilities(context.Background(), vulns, fleet.NVD)
+	require.NoError(t, err)
+	require.Equal(t, 10, int(n))
 
 	// create a team and make the last 3 hosts part of it (meaning 3 that use
 	// sws[19], 2 for sws[18], and 1 for sws[17])

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -478,6 +478,8 @@ func (s *integrationTestSuite) TestVulnerableSoftware() {
 	}
 
 	require.NoError(t, s.ds.AddCPEForSoftware(context.Background(), soft1, "somecpe"))
+	require.NoError(t, s.ds.LoadHostSoftware(context.Background(), host, fleet.SoftwareListOptions{}, false))
+
 	n, err := s.ds.InsertVulnerabilities(
 		context.Background(), []fleet.SoftwareVulnerability{
 			{SoftwareID: soft1.ID, CPEID: soft1.GeneratedCPEID, CVE: "cve-123-123-132"},

--- a/server/vulnerabilities/cve.go
+++ b/server/vulnerabilities/cve.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/WatchBeam/clock"
 	"github.com/facebookincubator/nvdtools/cvefeed"
 	feednvd "github.com/facebookincubator/nvdtools/cvefeed/nvd"
 	"github.com/facebookincubator/nvdtools/providers/nvd"
@@ -64,13 +63,7 @@ func DownloadNVDCVEFeed(vulnPath string, cveFeedPrefixURL string) error {
 
 const publishedDateFmt = "2006-01-02T15:04Z" // not quite RFC3339
 
-var (
-	rxNVDCVEArchive = regexp.MustCompile(`nvdcve.*\.gz$`)
-
-	// this allows mocking the time package for tests, by default it is equivalent
-	// to the time functions, e.g. theClock.Now() == time.Now().
-	theClock clock.Clock = clock.C
-)
+var rxNVDCVEArchive = regexp.MustCompile(`nvdcve.*\.gz$`)
 
 func getNVDCVEFeedFiles(vulnPath string) ([]string, error) {
 	var files []string
@@ -99,7 +92,7 @@ func getNVDCVEFeedFiles(vulnPath string) ([]string, error) {
 }
 
 type softwareCPEWithNVDMeta struct {
-	*fleet.SoftwareCPE
+	fleet.SoftwareCPE
 	meta *wfn.Attributes
 }
 
@@ -139,7 +132,7 @@ func TranslateCPEToCVE(
 			return nil, err
 		}
 		parsed = append(parsed, softwareCPEWithNVDMeta{
-			SoftwareCPE: &CPE,
+			SoftwareCPE: CPE,
 			meta:        attr,
 		})
 	}

--- a/server/vulnerabilities/cve.go
+++ b/server/vulnerabilities/cve.go
@@ -107,7 +107,7 @@ func TranslateCPEToCVE(
 	ds fleet.Datastore,
 	vulnPath string,
 	logger kitlog.Logger,
-	collectRecentVulns bool,
+	collectVulns bool,
 	recentVulnerabilityMaxAge time.Duration,
 ) (map[string][]string, error) {
 	files, err := getNVDCVEFeedFiles(vulnPath)
@@ -125,7 +125,8 @@ func TranslateCPEToCVE(
 	}
 
 	cpes := make([]*wfn.Attributes, 0, len(cpeList))
-	for _, uri := range cpeList {
+	for _, cpe := range cpeList {
+		uri := cpe.CPE
 		// Skip dummy CPEs
 		if strings.HasPrefix(uri, "none") {
 			continue
@@ -143,7 +144,7 @@ func TranslateCPEToCVE(
 	}
 
 	var recentVulns map[string][]string
-	if collectRecentVulns {
+	if collectVulns {
 		recentVulns = make(map[string][]string)
 	}
 	for _, file := range files {

--- a/server/vulnerabilities/cve.go
+++ b/server/vulnerabilities/cve.go
@@ -99,7 +99,7 @@ func getNVDCVEFeedFiles(vulnPath string) ([]string, error) {
 }
 
 type softwareCPEWithNVDMeta struct {
-	fleet.SoftwareCPE
+	*fleet.SoftwareCPE
 	meta *wfn.Attributes
 }
 
@@ -139,7 +139,7 @@ func TranslateCPEToCVE(
 			return nil, err
 		}
 		parsed = append(parsed, softwareCPEWithNVDMeta{
-			SoftwareCPE: CPE,
+			SoftwareCPE: &CPE,
 			meta:        attr,
 		})
 	}

--- a/server/vulnerabilities/cve_test.go
+++ b/server/vulnerabilities/cve_test.go
@@ -47,10 +47,10 @@ type threadSafeDSMock struct {
 	*mock.Store
 }
 
-func (d *threadSafeDSMock) AllCPEs(ctx context.Context, excludedPlatforms []string) ([]fleet.SoftwareCPE, error) {
+func (d *threadSafeDSMock) ListSoftwareCPEs(ctx context.Context, excludedPlatforms []string) ([]fleet.SoftwareCPE, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	return d.Store.AllCPEs(ctx, excludedPlatforms)
+	return d.Store.ListSoftwareCPEs(ctx, excludedPlatforms)
 }
 
 func (d *threadSafeDSMock) InsertCVEForCPE(ctx context.Context, cve string, cpes []string) (int64, error) {
@@ -89,7 +89,7 @@ func TestTranslateCPEToCVE(t *testing.T) {
 
 	for _, tt := range cvetests {
 		t.Run(tt.cpe, func(t *testing.T) {
-			ds.AllCPEsFunc = func(ctx context.Context, excludedPlatforms []string) ([]fleet.SoftwareCPE, error) {
+			ds.ListSoftwareCPEsFunc = func(ctx context.Context, excludedPlatforms []string) ([]fleet.SoftwareCPE, error) {
 				return []fleet.SoftwareCPE{
 					{CPE: tt.cpe},
 				}, nil
@@ -127,7 +127,7 @@ func TestTranslateCPEToCVE(t *testing.T) {
 
 		safeDS := &threadSafeDSMock{Store: ds}
 
-		ds.AllCPEsFunc = func(ctx context.Context, excludedPlatforms []string) ([]fleet.SoftwareCPE, error) {
+		ds.ListSoftwareCPEsFunc = func(ctx context.Context, excludedPlatforms []string) ([]fleet.SoftwareCPE, error) {
 			return []fleet.SoftwareCPE{
 					{CPE: googleChromeCPE}, {CPE: mozillaFirefoxCPE}, {CPE: curlCPE},
 				},

--- a/server/vulnerabilities/oval/analyzer.go
+++ b/server/vulnerabilities/oval/analyzer.go
@@ -77,10 +77,10 @@ func Analyze(
 		for _, hId := range hIds {
 			insrt, del := vulnsDelta(foundInBatch[hId], existingInBatch[hId])
 			for _, i := range insrt {
-				toInsertSet[i.String()] = i
+				toInsertSet[i.Key()] = i
 			}
 			for _, d := range del {
-				toDeleteSet[d.String()] = d
+				toDeleteSet[d.Key()] = d
 			}
 		}
 	}
@@ -159,22 +159,22 @@ func vulnsDelta(
 
 	existingSet := make(map[string]bool)
 	for _, e := range existing {
-		existingSet[e.String()] = true
+		existingSet[e.Key()] = true
 	}
 
 	foundSet := make(map[string]bool)
 	for _, f := range found {
-		foundSet[f.String()] = true
+		foundSet[f.Key()] = true
 	}
 
 	for _, e := range existing {
-		if _, ok := foundSet[e.String()]; !ok {
+		if _, ok := foundSet[e.Key()]; !ok {
 			toDelete = append(toDelete, e)
 		}
 	}
 
 	for _, f := range found {
-		if _, ok := existingSet[f.String()]; !ok {
+		if _, ok := existingSet[f.Key()]; !ok {
 			toInsert = append(toInsert, f)
 		}
 	}

--- a/server/vulnerabilities/oval/analyzer.go
+++ b/server/vulnerabilities/oval/analyzer.go
@@ -21,12 +21,6 @@ const (
 	vulnBatchSize  = 500
 )
 
-func vulnKey(v fleet.SoftwareVulnerability) string {
-	return fmt.Sprintf("%d:%s", v.SoftwareID, v.CVE)
-}
-
-// TODO (juan): Do we need to even compute a delta??
-
 // Analyze scans all hosts for vulnerabilities based on the OVAL definitions for their platform,
 // inserting any new vulnerabilities and deleting anything patched.
 func Analyze(
@@ -83,10 +77,10 @@ func Analyze(
 		for _, hId := range hIds {
 			insrt, del := vulnsDelta(foundInBatch[hId], existingInBatch[hId])
 			for _, i := range insrt {
-				toInsertSet[vulnKey(i)] = i
+				toInsertSet[i.String()] = i
 			}
 			for _, d := range del {
-				toDeleteSet[vulnKey(d)] = d
+				toDeleteSet[d.String()] = d
 			}
 		}
 	}
@@ -165,22 +159,22 @@ func vulnsDelta(
 
 	existingSet := make(map[string]bool)
 	for _, e := range existing {
-		existingSet[vulnKey(e)] = true
+		existingSet[e.String()] = true
 	}
 
 	foundSet := make(map[string]bool)
 	for _, f := range found {
-		foundSet[vulnKey(f)] = true
+		foundSet[f.String()] = true
 	}
 
 	for _, e := range existing {
-		if _, ok := foundSet[vulnKey(e)]; !ok {
+		if _, ok := foundSet[e.String()]; !ok {
 			toDelete = append(toDelete, e)
 		}
 	}
 
 	for _, f := range found {
-		if _, ok := existingSet[vulnKey(f)]; !ok {
+		if _, ok := existingSet[f.String()]; !ok {
 			toInsert = append(toInsert, f)
 		}
 	}

--- a/server/vulnerabilities/oval/analyzer_test.go
+++ b/server/vulnerabilities/oval/analyzer_test.go
@@ -236,17 +236,17 @@ func TestOvalAnalyzer(t *testing.T) {
 
 		t.Run("existing match found", func(t *testing.T) {
 			found := []fleet.SoftwareVulnerability{
-				{CPE: "cpe_1", CPEID: 1, CVE: "cve_1"},
-				{CPE: "cpe_1", CPEID: 1, CVE: "cve_2"},
-				{CPE: "cpe_2", CPEID: 2, CVE: "cve_3"},
-				{CPE: "cpe_2", CPEID: 2, CVE: "cve_4"},
+				{CPEID: 1, CVE: "cve_1"},
+				{CPEID: 1, CVE: "cve_2"},
+				{CPEID: 2, CVE: "cve_3"},
+				{CPEID: 2, CVE: "cve_4"},
 			}
 
 			existing := []fleet.SoftwareVulnerability{
-				{CPE: "cpe_1", CPEID: 1, CVE: "cve_1"},
-				{CPE: "cpe_1", CPEID: 1, CVE: "cve_2"},
-				{CPE: "cpe_2", CPEID: 2, CVE: "cve_3"},
-				{CPE: "cpe_2", CPEID: 2, CVE: "cve_4"},
+				{CPEID: 1, CVE: "cve_1"},
+				{CPEID: 1, CVE: "cve_2"},
+				{CPEID: 2, CVE: "cve_3"},
+				{CPEID: 2, CVE: "cve_4"},
 			}
 
 			toInsert, toDelete := vulnsDelta(found, existing)
@@ -256,27 +256,27 @@ func TestOvalAnalyzer(t *testing.T) {
 
 		t.Run("existing differ from found", func(t *testing.T) {
 			found := []fleet.SoftwareVulnerability{
-				{CPE: "cpe_1", CPEID: 1, CVE: "cve_1"},
-				{CPE: "cpe_1", CPEID: 1, CVE: "cve_2"},
-				{CPE: "cpe_3", CPEID: 3, CVE: "cve_5"},
-				{CPE: "cpe_3", CPEID: 3, CVE: "cve_6"},
+				{CPEID: 1, CVE: "cve_1"},
+				{CPEID: 1, CVE: "cve_2"},
+				{CPEID: 3, CVE: "cve_5"},
+				{CPEID: 3, CVE: "cve_6"},
 			}
 
 			existing := []fleet.SoftwareVulnerability{
-				{CPE: "cpe_1", CPEID: 1, CVE: "cve_1"},
-				{CPE: "cpe_1", CPEID: 1, CVE: "cve_2"},
-				{CPE: "cpe_2", CPEID: 2, CVE: "cve_3"},
-				{CPE: "cpe_2", CPEID: 2, CVE: "cve_4"},
+				{CPEID: 1, CVE: "cve_1"},
+				{CPEID: 1, CVE: "cve_2"},
+				{CPEID: 2, CVE: "cve_3"},
+				{CPEID: 2, CVE: "cve_4"},
 			}
 
 			expectedToInsert := []fleet.SoftwareVulnerability{
-				{CPE: "cpe_3", CPEID: 3, CVE: "cve_5"},
-				{CPE: "cpe_3", CPEID: 3, CVE: "cve_6"},
+				{CPEID: 3, CVE: "cve_5"},
+				{CPEID: 3, CVE: "cve_6"},
 			}
 
 			expectedToDelete := []fleet.SoftwareVulnerability{
-				{CPE: "cpe_2", CPEID: 2, CVE: "cve_3"},
-				{CPE: "cpe_2", CPEID: 2, CVE: "cve_4"},
+				{CPEID: 2, CVE: "cve_3"},
+				{CPEID: 2, CVE: "cve_4"},
 			}
 
 			toInsert, toDelete := vulnsDelta(found, existing)
@@ -288,10 +288,10 @@ func TestOvalAnalyzer(t *testing.T) {
 			var found []fleet.SoftwareVulnerability
 
 			existing := []fleet.SoftwareVulnerability{
-				{CPE: "cpe_1", CPEID: 1, CVE: "cve_1"},
-				{CPE: "cpe_1", CPEID: 1, CVE: "cve_2"},
-				{CPE: "cpe_2", CPEID: 2, CVE: "cve_3"},
-				{CPE: "cpe_2", CPEID: 2, CVE: "cve_4"},
+				{CPEID: 1, CVE: "cve_1"},
+				{CPEID: 1, CVE: "cve_2"},
+				{CPEID: 2, CVE: "cve_3"},
+				{CPEID: 2, CVE: "cve_4"},
 			}
 
 			toInsert, toDelete := vulnsDelta(found, existing)

--- a/server/vulnerabilities/oval/analyzer_test.go
+++ b/server/vulnerabilities/oval/analyzer_test.go
@@ -145,7 +145,7 @@ func BenchmarkTestOvalAnalyzer(b *testing.B) {
 			withTestFixture(v, vulnPath, ds, func(h *fleet.Host) {
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					_, err = Analyze(context.Background(), ds, v, vulnPath)
+					_, err = Analyze(context.Background(), ds, v, vulnPath, true)
 					require.NoError(b, err)
 				}
 			}, b)
@@ -215,7 +215,7 @@ func TestOvalAnalyzer(t *testing.T) {
 
 		for _, v := range systems {
 			withTestFixture(v, vulnPath, ds, func(h *fleet.Host) {
-				_, err = Analyze(ctx, ds, v, vulnPath)
+				_, err = Analyze(ctx, ds, v, vulnPath, true)
 				require.NoError(t, err)
 
 				p := NewPlatform(v.Platform, v.Name)

--- a/server/vulnerabilities/oval/parsed/ubuntu_result.go
+++ b/server/vulnerabilities/oval/parsed/ubuntu_result.go
@@ -45,7 +45,6 @@ func (r UbuntuResult) Eval(software []fleet.Software) []fleet.SoftwareVulnerabil
 				for _, v := range d.Vulnerabilities {
 					vuln = append(vuln, fleet.SoftwareVulnerability{
 						SoftwareID: software.ID,
-						CPE:        software.GenerateCPE,
 						CPEID:      software.GeneratedCPEID,
 						CVE:        v,
 					})

--- a/server/webhooks/vulnerabilities.go
+++ b/server/webhooks/vulnerabilities.go
@@ -39,13 +39,13 @@ func TriggerVulnerabilitiesWebhook(
 	targetURL := vulnConfig.DestinationURL
 	batchSize := vulnConfig.HostBatchSize
 
-	softwareIDGroupbedByCVE := make(map[string][]uint)
+	softwareIDsGroupedByCVE := make(map[string][]uint)
 	for _, v := range recentVulns {
-		softwareIDGroupbedByCVE[v.CVE] = append(softwareIDGroupbedByCVE[v.CVE], v.SoftwareID)
+		softwareIDsGroupedByCVE[v.CVE] = append(softwareIDsGroupedByCVE[v.CVE], v.SoftwareID)
 	}
 
 	for _, v := range recentVulns {
-		softwareIDs := softwareIDGroupbedByCVE[v.CVE]
+		softwareIDs := softwareIDsGroupedByCVE[v.CVE]
 
 		hosts, err := ds.HostsBySoftwareIDs(ctx, softwareIDs)
 		if err != nil {

--- a/server/webhooks/vulnerabilities.go
+++ b/server/webhooks/vulnerabilities.go
@@ -20,7 +20,7 @@ func TriggerVulnerabilitiesWebhook(
 	ctx context.Context,
 	ds fleet.Datastore,
 	logger kitlog.Logger,
-	recentVulns map[string][]string,
+	recentVulns []fleet.SoftwareVulnerability,
 	appConfig *fleet.AppConfig,
 	now time.Time,
 ) error {
@@ -39,8 +39,15 @@ func TriggerVulnerabilitiesWebhook(
 	targetURL := vulnConfig.DestinationURL
 	batchSize := vulnConfig.HostBatchSize
 
-	for cve, cpes := range recentVulns {
-		hosts, err := ds.HostsByCPEs(ctx, cpes)
+	softwareIDGroupbedByCVE := make(map[string][]uint)
+	for _, v := range recentVulns {
+		softwareIDGroupbedByCVE[v.CVE] = append(softwareIDGroupbedByCVE[v.CVE], v.SoftwareID)
+	}
+
+	for _, v := range recentVulns {
+		softwareIDs := softwareIDGroupbedByCVE[v.CVE]
+
+		hosts, err := ds.HostsBySoftwareIDs(ctx, softwareIDs)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "get hosts by CPE")
 		}
@@ -50,7 +57,7 @@ func TriggerVulnerabilitiesWebhook(
 			if batchSize > 0 && len(hosts) > batchSize {
 				limit = batchSize
 			}
-			if err := sendVulnerabilityHostBatch(ctx, targetURL, cve, serverURL, hosts[:limit], now); err != nil {
+			if err := sendVulnerabilityHostBatch(ctx, targetURL, v.CVE, serverURL, hosts[:limit], now); err != nil {
 				return ctxerr.Wrap(ctx, err, "send vulnerability host batch")
 			}
 			hosts = hosts[limit:]

--- a/server/webhooks/vulnerabilities_test.go
+++ b/server/webhooks/vulnerabilities_test.go
@@ -34,8 +34,9 @@ func TestTriggerVulnerabilitiesWebhook(t *testing.T) {
 		},
 	}
 
-	recentVulns := map[string][]string{
-		"CVE-2012-1234": {"cpe1", "cpe2"},
+	recentVulns := []fleet.SoftwareVulnerability{
+		{CPEID: 1, SoftwareID: 1, CVE: "CVE-2012-1234"},
+		{CPEID: 2, SoftwareID: 2, CVE: "CVE-2012-1234"},
 	}
 
 	t.Run("disabled", func(t *testing.T) {
@@ -83,37 +84,37 @@ func TestTriggerVulnerabilitiesWebhook(t *testing.T) {
 
 		cases := []struct {
 			name  string
-			vulns map[string][]string
+			vulns []fleet.SoftwareVulnerability
 			hosts []*fleet.HostShort
 			want  string
 		}{
 			{
 				"1 vuln, 1 host",
-				map[string][]string{cves[0]: {"cpe1"}},
+				[]fleet.SoftwareVulnerability{{CVE: cves[0], CPEID: 1}},
 				hosts[:1],
 				fmt.Sprintf("%s[%s]}}", jsonCVE1, jsonH1),
 			},
 			{
 				"1 vuln, 2 hosts",
-				map[string][]string{cves[0]: {"cpe1"}},
+				[]fleet.SoftwareVulnerability{{CVE: cves[0], CPEID: 1}},
 				hosts[:2],
 				fmt.Sprintf("%s[%s,%s]}}", jsonCVE1, jsonH1, jsonH2),
 			},
 			{
 				"1 vuln, 3 hosts",
-				map[string][]string{cves[0]: {"cpe1"}},
+				[]fleet.SoftwareVulnerability{{CVE: cves[0], CPEID: 1}},
 				hosts[:3],
 				fmt.Sprintf("%s[%s,%s]}}\n%s[%s]}}", jsonCVE1, jsonH1, jsonH2, jsonCVE1, jsonH3), // 2 requests, batch of 2 max
 			},
 			{
 				"1 vuln, 4 hosts",
-				map[string][]string{cves[0]: {"cpe1"}},
+				[]fleet.SoftwareVulnerability{{CVE: cves[0], CPEID: 1}},
 				hosts[:4],
 				fmt.Sprintf("%s[%s,%s]}}\n%s[%s,%s]}}", jsonCVE1, jsonH1, jsonH2, jsonCVE1, jsonH3, jsonH4), // 2 requests, batch of 2 max
 			},
 			{
 				"2 vulns, 1 host each",
-				map[string][]string{cves[0]: {"cpe1"}, cves[1]: {"cpe2"}},
+				[]fleet.SoftwareVulnerability{{CVE: cves[0], CPEID: 1}, {CVE: cves[1], CPEID: 2}},
 				hosts[:1],
 				fmt.Sprintf("%s[%s]}}\n%s[%s]}}", jsonCVE1, jsonH1, jsonCVE2, jsonH1),
 			},
@@ -131,7 +132,7 @@ func TestTriggerVulnerabilitiesWebhook(t *testing.T) {
 				}))
 				defer srv.Close()
 
-				ds.HostsByCPEsFunc = func(ctx context.Context, cpes []string) ([]*fleet.HostShort, error) {
+				ds.HostsBySoftwareIDsFunc = func(ctx context.Context, softwareIDs []uint) ([]*fleet.HostShort, error) {
 					return c.hosts, nil
 				}
 
@@ -140,8 +141,8 @@ func TestTriggerVulnerabilitiesWebhook(t *testing.T) {
 				err := TriggerVulnerabilitiesWebhook(ctx, ds, logger, c.vulns, &appCfg, now)
 				require.NoError(t, err)
 
-				assert.True(t, ds.HostsByCPEsFuncInvoked)
-				ds.HostsByCPEsFuncInvoked = false
+				assert.True(t, ds.HostsBySoftwareIDsFuncInvoked)
+				ds.HostsBySoftwareIDsFuncInvoked = false
 
 				want := strings.Split(c.want, "\n")
 				assert.ElementsMatch(t, want, requests)

--- a/server/worker/jira.go
+++ b/server/worker/jira.go
@@ -136,21 +136,21 @@ func (j *Jira) Run(ctx context.Context, argsJSON json.RawMessage) error {
 
 // QueueJiraJobs queues the Jira vulnerability jobs to process asynchronously
 // via the worker.
-func QueueJiraJobs(ctx context.Context, ds fleet.Datastore, logger kitlog.Logger, recentVulns map[string][]string) error {
+func QueueJiraJobs(ctx context.Context, ds fleet.Datastore, logger kitlog.Logger, recentVulns []fleet.SoftwareVulnerability) error {
 	level.Info(logger).Log("enabled", "true", "recentVulns", len(recentVulns))
 
 	// for troubleshooting, log in debug level the CVEs that we will process
 	// (cannot be done in the loop below as we want to add the debug log
 	// _before_ we start processing them).
 	cves := make([]string, 0, len(recentVulns))
-	for cve := range recentVulns {
-		cves = append(cves, cve)
+	for _, vuln := range recentVulns {
+		cves = append(cves, vuln.CVE)
 	}
 	sort.Strings(cves)
 	level.Debug(logger).Log("recent_cves", fmt.Sprintf("%v", cves))
 
-	for cve := range recentVulns {
-		job, err := QueueJob(ctx, ds, jiraName, JiraArgs{CVE: cve})
+	for _, vuln := range recentVulns {
+		job, err := QueueJob(ctx, ds, jiraName, JiraArgs{CVE: vuln.CVE})
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "queueing job")
 		}

--- a/server/worker/jira_test.go
+++ b/server/worker/jira_test.go
@@ -80,7 +80,7 @@ func TestJiraQueueJobs(t *testing.T) {
 		ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
 			return job, nil
 		}
-		err := QueueJiraJobs(ctx, ds, logger, map[string][]string{"CVE-1234-5678": nil})
+		err := QueueJiraJobs(ctx, ds, logger, []fleet.SoftwareVulnerability{{CVE: "CVE-1234-5678"}})
 		require.NoError(t, err)
 		require.True(t, ds.NewJobFuncInvoked)
 	})
@@ -89,7 +89,7 @@ func TestJiraQueueJobs(t *testing.T) {
 		ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
 			return nil, io.EOF
 		}
-		err := QueueJiraJobs(ctx, ds, logger, map[string][]string{"CVE-1234-5678": nil})
+		err := QueueJiraJobs(ctx, ds, logger, []fleet.SoftwareVulnerability{{CVE: "CVE-1234-5678"}})
 		require.Error(t, err)
 		require.ErrorIs(t, err, io.EOF)
 		require.True(t, ds.NewJobFuncInvoked)

--- a/server/worker/zendesk.go
+++ b/server/worker/zendesk.go
@@ -127,21 +127,21 @@ func (z *Zendesk) Run(ctx context.Context, argsJSON json.RawMessage) error {
 
 // QueueZendeskJobs queues the Zendesk vulnerability jobs to process asynchronously
 // via the worker.
-func QueueZendeskJobs(ctx context.Context, ds fleet.Datastore, logger kitlog.Logger, recentVulns map[string][]string) error {
+func QueueZendeskJobs(ctx context.Context, ds fleet.Datastore, logger kitlog.Logger, recentVulns []fleet.SoftwareVulnerability) error {
 	level.Info(logger).Log("enabled", "true", "recentVulns", len(recentVulns))
 
 	// for troubleshooting, log in debug level the CVEs that we will process
 	// (cannot be done in the loop below as we want to add the debug log
 	// _before_ we start processing them).
 	cves := make([]string, 0, len(recentVulns))
-	for cve := range recentVulns {
-		cves = append(cves, cve)
+	for _, vuln := range recentVulns {
+		cves = append(cves, vuln.CVE)
 	}
 	sort.Strings(cves)
 	level.Debug(logger).Log("recent_cves", fmt.Sprintf("%v", cves))
 
-	for cve := range recentVulns {
-		job, err := QueueJob(ctx, ds, zendeskName, ZendeskArgs{CVE: cve})
+	for _, vuln := range recentVulns {
+		job, err := QueueJob(ctx, ds, zendeskName, ZendeskArgs{CVE: vuln.CVE})
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "queueing job")
 		}

--- a/server/worker/zendesk_test.go
+++ b/server/worker/zendesk_test.go
@@ -70,7 +70,7 @@ func TestZendeskQueueJobs(t *testing.T) {
 		ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
 			return job, nil
 		}
-		err := QueueZendeskJobs(ctx, ds, logger, map[string][]string{"CVE-1234-5678": nil})
+		err := QueueZendeskJobs(ctx, ds, logger, []fleet.SoftwareVulnerability{{CVE: "CVE-1234-5678"}})
 		require.NoError(t, err)
 		require.True(t, ds.NewJobFuncInvoked)
 	})
@@ -79,7 +79,7 @@ func TestZendeskQueueJobs(t *testing.T) {
 		ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
 			return nil, io.EOF
 		}
-		err := QueueZendeskJobs(ctx, ds, logger, map[string][]string{"CVE-1234-5678": nil})
+		err := QueueZendeskJobs(ctx, ds, logger, []fleet.SoftwareVulnerability{{CVE: "CVE-1234-5678"}})
 		require.Error(t, err)
 		require.ErrorIs(t, err, io.EOF)
 		require.True(t, ds.NewJobFuncInvoked)


### PR DESCRIPTION
#5796 

Allow OVAL vulnerability results to be sent to third-party integrations. Did some refactoring, to remove duplicated functionality and to make sure that both the OVAL and the NVD modules use the same types.

# Checklist
- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
