### PR TITLE
Adding the Vanta trust report to a Fleetdm URL.

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -241,6 +241,7 @@ module.exports.routes = {
   // Things that are not webpages here (in the Sails app) yet, but could be in the future.  For now they are just
   // redirects to somewhere else EXTERNAL to the Sails app.
   'GET /security':               'https://github.com/fleetdm/fleet/security/policy',
+  'GET /trust':                  'https://app.vanta.com/fleet/trust/5i2ulsbd76k619q9leaoh0',
   'GET /hall-of-fame':           'https://github.com/fleetdm/fleet/pulse',
   'GET /apply':                  'https://fleet-device-management.breezy.hr',
   'GET /jobs':                   'https://fleet-device-management.breezy.hr',


### PR DESCRIPTION
Aligned the /security pointer to github so the file looks better too.

The /trust link points to the Vanta public facing trust report, which shows our controls, updated very rapidly, and has room for an FAQ, uploading security documents, etc. 

Once this works, I'll add a link to it from the handbook, and communicate it to sales.