### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/orbit/pkg/update/filestore/filestore_test.go
+++ b/orbit/pkg/update/filestore/filestore_test.go
@@ -2,7 +2,6 @@ package filestore
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,9 +14,7 @@ import (
 func TestFileStorePathError(t *testing.T) {
 	t.Parallel()
 
-	tmpDir, err := ioutil.TempDir("", "filestore-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "metadata.json"), constant.DefaultDirMode))
 

--- a/server/logging/filesystem_test.go
+++ b/server/logging/filesystem_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -84,16 +83,11 @@ func TestFilesystemLoggerPermission(t *testing.T) {
 
 func BenchmarkFilesystemLogger(b *testing.B) {
 	ctx := context.Background()
-	tempPath, err := ioutil.TempDir("", "test")
-	if err != nil {
-		b.Fatal("temp dir failed", err)
-	}
-	fileName := filepath.Join(tempPath, "filesystemLogWriter")
+	fileName := filepath.Join(b.TempDir(), "filesystemLogWriter")
 	lgr, err := NewFilesystemLogWriter(fileName, log.NewNopLogger(), false, false)
 	if err != nil {
 		b.Fatal("new failed ", err)
 	}
-	defer os.Remove(fileName)
 
 	var logs []json.RawMessage
 	for i := 0; i < 50; i++ {
@@ -125,16 +119,11 @@ func BenchmarkLumberjackWithCompression(b *testing.B) {
 
 func benchLumberjack(b *testing.B, compression bool) {
 	ctx := context.Background()
-	tempPath, err := ioutil.TempDir("", "test")
-	if err != nil {
-		b.Fatal("temp dir failed", err)
-	}
-	fileName := filepath.Join(tempPath, "lumberjack")
+	fileName := filepath.Join(b.TempDir(), "lumberjack")
 	lgr, err := NewFilesystemLogWriter(fileName, log.NewNopLogger(), true, compression)
 	if err != nil {
 		b.Fatal("new failed ", err)
 	}
-	defer os.Remove(fileName)
 
 	var logs []json.RawMessage
 	for i := 0; i < 50; i++ {

--- a/server/vulnerabilities/cpe_test.go
+++ b/server/vulnerabilities/cpe_test.go
@@ -143,9 +143,7 @@ func (f *fakeSoftwareIterator) Close() error { f.closed = true; return nil }
 func TestTranslateSoftwareToCPE(t *testing.T) {
 	nettest.Run(t)
 
-	tempDir, err := os.MkdirTemp(os.TempDir(), "TestTranslateSoftwareToCPE-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	ds := new(mock.Store)
 


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

A testing cleanup. 

This pull request replaces the remaining `ioutil.TempDir` / `os.MkdirTemp` with `t.TempDir`.