### PR TITLE
store count alongside unique error instances in Redis

### DIFF
--- a/changes/add-count-to-errors
+++ b/changes/add-count-to-errors
@@ -1,0 +1,1 @@
+* Added a count value to errors retrieved by the `/debug/errors` API, with the number of times the error occurred.

--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -6406,18 +6406,24 @@ The server only stores and returns a single instance of each error.
 
 ```json
 [
-  {
-    "external": "example error",
-    "root": {
-      "message": "timestamp: 2022-05-06T11:40:32-03:00",
-      "stack": [
-        "http.initALPNRequest.ServeHTTP:/usr/local/Cellar/go/1.17.6/libexec/src/net/http/server.go:3480",
-        "http.serverHandler.ServeHTTP:/usr/local/Cellar/go/1.17.6/libexec/src/net/http/server.go:2879",
-        "service.(*authEndpointer).makeEndpoint.func1:/Users/robertodip/projects/fleet/server/service/endpoint_utils.go:439",
-        "...",
-        "service.listSoftwareEndpoint:/Users/robertodip/projects/fleet/server/service/software.go:30",
-        "ctxerr.New:/Users/robertodip/projects/fleet/server/contexts/ctxerr/ctxerr.go:67",
-        "ctxerr.ensureCommonMetadata:/Users/robertodip/projects/fleet/server/contexts/ctxerr/ctxerr.go:112"
+ {
+    "count": "3",
+    "error": {
+      "cause": {
+        "message": "Authorization header required"
+      },
+      "wraps": [
+        {
+          "message": "missing FleetError in chain",
+          "data": {
+            "timestamp": "2022-06-03T14:16:01-03:00"
+          },
+          "stack": [
+            "github.com/fleetdm/fleet/v4/server/contexts/ctxerr.Handle (ctxerr.go:262)",
+            "github.com/fleetdm/fleet/v4/server/service.encodeError (transport_error.go:80)",
+            "github.com/go-kit/kit/transport/http.Server.ServeHTTP (server.go:124)"
+          ]
+        }
       ]
     }
   }

--- a/server/errorstore/errors.go
+++ b/server/errorstore/errors.go
@@ -87,6 +87,8 @@ type storedError struct {
 	Error json.RawMessage `json:"error"`
 }
 
+// RedisScan implements the redigo.Scanner interface to control how `storedError`
+// is interpreted when read from Redis.
 func (s *storedError) RedisScan(src interface{}) error {
 	vals, err := redigo.Strings(redigo.Values(src, nil))
 

--- a/server/errorstore/errors_test.go
+++ b/server/errorstore/errors_test.go
@@ -191,13 +191,13 @@ func TestErrorHandler(t *testing.T) {
 	wd = regexp.QuoteMeta(wd)
 
 	t.Run("standalone", func(t *testing.T) {
-		pool := redistest.SetupRedis(t, "error:", false, false, false)
+		pool := redistest.SetupRedis(t, errKeyRoot, false, false, false)
 		t.Run("collects errors", func(t *testing.T) { testErrorHandlerCollectsErrors(t, pool, wd, false) })
 		t.Run("collects different errors", func(t *testing.T) { testErrorHandlerCollectsDifferentErrors(t, pool, wd, false) })
 	})
 
 	t.Run("cluster", func(t *testing.T) {
-		pool := redistest.SetupRedis(t, "error:", true, true, false)
+		pool := redistest.SetupRedis(t, errKeyRoot, true, true, false)
 		t.Run("collects errors", func(t *testing.T) { testErrorHandlerCollectsErrors(t, pool, wd, false) })
 		t.Run("collects different errors", func(t *testing.T) { testErrorHandlerCollectsDifferentErrors(t, pool, wd, false) })
 	})
@@ -344,7 +344,7 @@ func testErrorHandlerCollectsDifferentErrors(t *testing.T, pool fleet.RedisPool,
 
 func TestHttpHandler(t *testing.T) {
 	setupTest := func(t *testing.T) *Handler {
-		pool := redistest.SetupRedis(t, "error:", false, false, false)
+		pool := redistest.SetupRedis(t, errKeyRoot, false, false, false)
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		defer cancelFunc()
 


### PR DESCRIPTION
Related to #4972, this changes the way errors are stored in Redis in order to keep track of how many times each instance of an error occurred.

I have also modified the responses of `/debug/errors` to include this information, since I think it might be useful to have it.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
