### PR TITLE
pin api version in DeviceClient.ListDevicePolicies

### DIFF
--- a/server/service/device_client.go
+++ b/server/service/device_client.go
@@ -49,7 +49,7 @@ func NewDeviceClient(addr string, token string, insecureSkipVerify bool, rootCA 
 
 // ListDevicePolicies fetches all policies for the device with the provided token
 func (dc *DeviceClient) ListDevicePolicies() ([]*fleet.HostPolicy, error) {
-	verb, path := "GET", "/api/latest/fleet/device/"+dc.token+"/policies"
+	verb, path := "GET", "/api/2022-04/fleet/device/"+dc.token+"/policies"
 	var responseBody listDevicePoliciesResponse
 	err := dc.request(verb, path, "", &responseBody)
 	if err != nil {


### PR DESCRIPTION
As part of https://github.com/fleetdm/fleet/issues/6063, we want to ensure backwards compatibility between Fleet Desktop and Fleet servers in both directions.

This change pins the API version that `DeviceClient.ListDevicePolicies` is using to `2022-04`.

I decided to pin the version in the client because:

- Every time we compile a new Desktop version it will have all the API versions pinned
- Different endpoints can use different API versions (which would be harder if this is a client config)
- The code consuming the client doesn't have to worry about this vs. having to specify the API version on every function call

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
