### PR TITLE
Bug: Issue while parsing dpkg objects with inline names

### DIFF
--- a/server/vulnerabilities/oval/input/dpkg_object.go
+++ b/server/vulnerabilities/oval/input/dpkg_object.go
@@ -2,6 +2,7 @@ package oval_input
 
 type dpkgObjectNameXML struct {
 	VarRef string `xml:"var_ref,attr"`
+	Value  string `xml:",chardata"`
 }
 
 // DpkgObjectXML see https://oval.mitre.org/language/version5.10.1/ovaldefinition/documentation/linux-definitions-schema.html#dpkginfo_object.

--- a/server/vulnerabilities/oval/mappers.go
+++ b/server/vulnerabilities/oval/mappers.go
@@ -78,7 +78,7 @@ func mapPackageState(sta oval_input.DpkgStateXML) ([]oval_parsed.ObjectStateEvrS
 		sta.Arch != nil ||
 		sta.Epoch != nil ||
 		sta.Version != nil {
-		return nil, fmt.Errorf("oval parse: only evr state definitions are supported")
+		return nil, fmt.Errorf("only evr state definitions are supported")
 	}
 
 	if sta.Evr != nil {
@@ -96,7 +96,7 @@ func mapPackageObject(obj oval_input.DpkgObjectXML, vars map[string]oval_input.C
 	var r []string
 	variable, ok := vars[obj.Name.VarRef]
 	if !ok {
-		return nil, fmt.Errorf("oval parse: variable not found %s", obj.Name.VarRef)
+		return nil, fmt.Errorf("variable not found %s", obj.Name.VarRef)
 	}
 
 	r = append(r, variable.Values...)

--- a/server/vulnerabilities/oval/mappers.go
+++ b/server/vulnerabilities/oval/mappers.go
@@ -89,16 +89,31 @@ func mapPackageState(sta oval_input.DpkgStateXML) ([]oval_parsed.ObjectStateEvrS
 }
 
 func mapPackageObject(obj oval_input.DpkgObjectXML, vars map[string]oval_input.ConstantVariableXML) ([]string, error) {
+	// Test objects can define their 'name' in one of two ways:
+	// 1. Inline:
+	// <:object ...>
+	//      <:name>software name</:name>
+	// </:object>
+	//
+	// 2. As a variable reference:
+	// <:object ...>
+	// 		<:name var_ref="var:200224390000000" var_check="at least one" />
+	// </:object>
+
+	// Check whether the name was defined inline
 	if obj.Name.Value != "" {
 		return []string{obj.Name.Value}, nil
 	}
 
 	var r []string
+	// If not, the name should be defined as a variable
 	variable, ok := vars[obj.Name.VarRef]
 	if !ok {
 		return nil, fmt.Errorf("variable not found %s", obj.Name.VarRef)
 	}
 
+	// Normally the variable for a test object contains a single value, but according to the specs,
+	// it can contain multiple values.
 	r = append(r, variable.Values...)
 
 	return r, nil

--- a/server/vulnerabilities/oval/mappers.go
+++ b/server/vulnerabilities/oval/mappers.go
@@ -78,7 +78,7 @@ func mapPackageState(sta oval_input.DpkgStateXML) ([]oval_parsed.ObjectStateEvrS
 		sta.Arch != nil ||
 		sta.Epoch != nil ||
 		sta.Version != nil {
-		return nil, fmt.Errorf("OVAL parse: only evr state definitions are supported")
+		return nil, fmt.Errorf("oval parse: only evr state definitions are supported")
 	}
 
 	if sta.Evr != nil {
@@ -96,7 +96,7 @@ func mapPackageObject(obj oval_input.DpkgObjectXML, vars map[string]oval_input.C
 	var r []string
 	variable, ok := vars[obj.Name.VarRef]
 	if !ok {
-		return nil, fmt.Errorf("OVAL parse: variable not found %s", obj.Name.VarRef)
+		return nil, fmt.Errorf("oval parse: variable not found %s", obj.Name.VarRef)
 	}
 
 	r = append(r, variable.Values...)

--- a/server/vulnerabilities/oval/mappers.go
+++ b/server/vulnerabilities/oval/mappers.go
@@ -78,7 +78,7 @@ func mapPackageState(sta oval_input.DpkgStateXML) ([]oval_parsed.ObjectStateEvrS
 		sta.Arch != nil ||
 		sta.Epoch != nil ||
 		sta.Version != nil {
-		return nil, fmt.Errorf("only evr state definitions are supported")
+		return nil, fmt.Errorf("OVAL parse: only evr state definitions are supported")
 	}
 
 	if sta.Evr != nil {
@@ -89,12 +89,16 @@ func mapPackageState(sta oval_input.DpkgStateXML) ([]oval_parsed.ObjectStateEvrS
 }
 
 func mapPackageObject(obj oval_input.DpkgObjectXML, vars map[string]oval_input.ConstantVariableXML) ([]string, error) {
-	variable, ok := vars[obj.Name.VarRef]
-	if !ok {
-		return nil, fmt.Errorf("variable not found %s", obj.Name.VarRef)
+	if obj.Name.Value != "" {
+		return []string{obj.Name.Value}, nil
 	}
 
 	var r []string
+	variable, ok := vars[obj.Name.VarRef]
+	if !ok {
+		return nil, fmt.Errorf("OVAL parse: variable not found %s", obj.Name.VarRef)
+	}
+
 	r = append(r, variable.Values...)
 
 	return r, nil

--- a/server/vulnerabilities/oval/parser.go
+++ b/server/vulnerabilities/oval/parser.go
@@ -15,27 +15,27 @@ import (
 func parseDefinitions(inputFile string, outputFile string) error {
 	r, err := os.Open(inputFile)
 	if err != nil {
-		return err
+		return fmt.Errorf("oval parser: %w", err)
 	}
 	defer r.Close()
 
 	xmlResult, err := parseXML(r)
 	if err != nil {
-		return err
+		return fmt.Errorf("oval parser: %w", err)
 	}
 
 	result, err := mapResult(xmlResult)
 	if err != nil {
-		return err
+		return fmt.Errorf("oval parser: %w", err)
 	}
 
 	payload, err := json.Marshal(result)
 	if err != nil {
-		return err
+		return fmt.Errorf("oval parser: %w", err)
 	}
 	err = ioutil.WriteFile(outputFile, payload, 0o644)
 	if err != nil {
-		return err
+		return fmt.Errorf("oval parser: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
This bug came to the surface after adding a new OVAL source for Ubuntu 19 - turns out that dpkg objects can also define their name as inline elements, not only as a variable reference.