### PR TITLE
Allow users to customize detail queries for troubleshooting purposes

### DIFF
--- a/changes/issue-6073-customize-queries
+++ b/changes/issue-6073-customize-queries
@@ -1,0 +1,1 @@
+* Allow users to customize detail queries for debugging purposes

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -864,6 +865,20 @@ func GetDetailQueries(ac *fleet.AppConfig, fleetConfig config.FleetConfig) map[s
 
 	if fleetConfig.App.EnableScheduledQueryStats {
 		generatedMap["scheduled_query_stats"] = scheduledQueryStats
+	}
+
+	for _, env := range os.Environ() {
+		prefix := "FLEET_DANGEROUS_REPLACE_"
+		if !strings.HasPrefix(env, prefix) {
+			continue
+		}
+		if i := strings.Index(env, "="); i >= 0 {
+			queryName := strings.TrimPrefix(env[:i], prefix)
+			newQuery := env[i+1:]
+			query := generatedMap[queryName]
+			query.Query = newQuery
+			generatedMap[queryName] = query
+		}
 	}
 
 	return generatedMap

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -873,7 +873,7 @@ func GetDetailQueries(ac *fleet.AppConfig, fleetConfig config.FleetConfig) map[s
 			continue
 		}
 		if i := strings.Index(env, "="); i >= 0 {
-			queryName := strings.TrimPrefix(env[:i], prefix)
+			queryName := strings.ToLower(strings.TrimPrefix(env[:i], prefix))
 			newQuery := env[i+1:]
 			query := generatedMap[queryName]
 			query.Query = newQuery

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -447,12 +447,11 @@ func TestDangerousReplaceQuery(t *testing.T) {
 	queries := GetDetailQueries(&fleet.AppConfig{HostSettings: fleet.HostSettings{EnableHostUsers: true}}, config.FleetConfig{})
 	originalQuery := queries["users"].Query
 
-	err := os.Setenv("FLEET_DANGEROUS_REPLACE_users", "select * from blah")
-	require.NoError(t, err)
+	require.NoError(t, os.Setenv("FLEET_DANGEROUS_REPLACE_USERS", "select * from blah"))
 	queries = GetDetailQueries(&fleet.AppConfig{HostSettings: fleet.HostSettings{EnableHostUsers: true}}, config.FleetConfig{})
 	assert.NotEqual(t, originalQuery, queries["users"].Query)
 
-	os.Clearenv()
+	require.NoError(t, os.Unsetenv("FLEET_DANGEROUS_REPLACE_USERS"))
 	queries = GetDetailQueries(&fleet.AppConfig{HostSettings: fleet.HostSettings{EnableHostUsers: true}}, config.FleetConfig{})
 	assert.Equal(t, originalQuery, queries["users"].Query)
 }


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- ~Documented any API changes (docs/Using-Fleet/REST-API.md)~
- ~Documented any permissions changes~
- ~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
- ~Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [x] Added/updated tests
- ~Manual QA for all new/changed functionality~
