### PR TITLE
add endpoint in devices API to query for api features

### DIFF
--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -436,7 +436,7 @@ type KafkaRESTConfig struct {
 	ProxyHost   string `json:"proxyhost"`
 }
 
-// DeviceApiFeatures specifies a list of features supported
+// DeviceAPIFeatures specifies a list of features supported
 // by the current API version. Each field in the struct is
 // meant to be a boolean value.
-type DeviceApiFeatures struct{}
+type DeviceAPIFeatures struct{}

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -435,3 +435,8 @@ type KafkaRESTConfig struct {
 	ResultTopic string `json:"result_topic"`
 	ProxyHost   string `json:"proxyhost"`
 }
+
+// DeviceApiFeatures specifies a list of features supported
+// by the current API version. Each field in the struct is
+// meant to be a boolean value.
+type DeviceApiFeatures struct{}

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -219,21 +219,21 @@ func (svc *Service) ListDevicePolicies(ctx context.Context, host *fleet.Host) ([
 // Device API features
 ////////////////////////////////////////////////////////////////////////////////
 
-type deviceApiFeaturesRequest struct {
+type deviceAPIFeaturesRequest struct {
 	Token string `url:"token"`
 }
 
-func (r *deviceApiFeaturesRequest) deviceAuthToken() string {
+func (r *deviceAPIFeaturesRequest) deviceAuthToken() string {
 	return r.Token
 }
 
-type deviceApiFeaturesResponse struct {
+type deviceAPIFeaturesResponse struct {
 	Err      error `json:"error,omitempty"`
-	Features fleet.DeviceApiFeatures
+	Features fleet.DeviceAPIFeatures
 }
 
-func (r deviceApiFeaturesResponse) error() error { return r.Err }
+func (r deviceAPIFeaturesResponse) error() error { return r.Err }
 
-func deviceApiFeaturesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
-	return deviceApiFeaturesResponse{Features: fleet.DeviceApiFeatures{}}, nil
+func deviceAPIFeaturesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+	return deviceAPIFeaturesResponse{Features: fleet.DeviceAPIFeatures{}}, nil
 }

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -214,3 +214,26 @@ func (svc *Service) ListDevicePolicies(ctx context.Context, host *fleet.Host) ([
 
 	return nil, fleet.ErrMissingLicense
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// Device API features
+////////////////////////////////////////////////////////////////////////////////
+
+type deviceApiFeaturesRequest struct {
+	Token string `url:"token"`
+}
+
+func (r *deviceApiFeaturesRequest) deviceAuthToken() string {
+	return r.Token
+}
+
+type deviceApiFeaturesResponse struct {
+	Err      error `json:"error,omitempty"`
+	Features fleet.DeviceApiFeatures
+}
+
+func (r deviceApiFeaturesResponse) error() error { return r.Err }
+
+func deviceApiFeaturesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+	return deviceApiFeaturesResponse{Features: fleet.DeviceApiFeatures{}}, nil
+}

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -396,6 +396,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	de.GET("/api/_version_/fleet/device/{token}/device_mapping", listDeviceHostDeviceMappingEndpoint, listDeviceHostDeviceMappingRequest{})
 	de.GET("/api/_version_/fleet/device/{token}/macadmins", getDeviceMacadminsDataEndpoint, getDeviceMacadminsDataRequest{})
 	de.GET("/api/_version_/fleet/device/{token}/policies", listDevicePoliciesEndpoint, listDevicePoliciesRequest{})
+	de.GET("/api/_version_/fleet/device/{token}/api_features", deviceApiFeaturesEndpoint, deviceApiFeaturesRequest{})
 
 	// host-authenticated endpoints
 	he := newHostAuthenticatedEndpointer(svc, logger, opts, r, apiVersions...)

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -396,7 +396,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	de.GET("/api/_version_/fleet/device/{token}/device_mapping", listDeviceHostDeviceMappingEndpoint, listDeviceHostDeviceMappingRequest{})
 	de.GET("/api/_version_/fleet/device/{token}/macadmins", getDeviceMacadminsDataEndpoint, getDeviceMacadminsDataRequest{})
 	de.GET("/api/_version_/fleet/device/{token}/policies", listDevicePoliciesEndpoint, listDevicePoliciesRequest{})
-	de.GET("/api/_version_/fleet/device/{token}/api_features", deviceApiFeaturesEndpoint, deviceApiFeaturesRequest{})
+	de.GET("/api/_version_/fleet/device/{token}/api_features", deviceAPIFeaturesEndpoint, deviceAPIFeaturesRequest{})
 
 	// host-authenticated endpoints
 	he := newHostAuthenticatedEndpointer(svc, logger, opts, r, apiVersions...)

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -4624,6 +4624,14 @@ func (s *integrationTestSuite) TestDeviceAuthenticatedEndpoints() {
 	json.NewDecoder(res.Body).Decode(&getHostResp)
 	res.Body.Close()
 	require.Nil(t, listPoliciesResp.Policies)
+
+	// get list of api features
+	apiFeaturesResp := deviceApiFeaturesResponse{}
+	res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/api_features", nil, http.StatusOK)
+	json.NewDecoder(res.Body).Decode(&apiFeaturesResp)
+	res.Body.Close()
+	require.Nil(t, apiFeaturesResp.Err)
+	require.NotNil(t, apiFeaturesResp.Features)
 }
 
 func (s *integrationTestSuite) TestModifyUser() {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -4626,7 +4626,7 @@ func (s *integrationTestSuite) TestDeviceAuthenticatedEndpoints() {
 	require.Nil(t, listPoliciesResp.Policies)
 
 	// get list of api features
-	apiFeaturesResp := deviceApiFeaturesResponse{}
+	apiFeaturesResp := deviceAPIFeaturesResponse{}
 	res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/api_features", nil, http.StatusOK)
 	json.NewDecoder(res.Body).Decode(&apiFeaturesResp)
 	res.Body.Close()


### PR DESCRIPTION
Related to https://github.com/fleetdm/fleet/issues/6063, this adds a new device API to get an object with `boolean` values that we can use as feature flags to manage backwards compatibility in Fleet Desktop.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
