### PR TITLE
decouple orbit and Fleet Desktop's logging

### DIFF
--- a/orbit/changes/issue-5689-decouple-orbit-logs
+++ b/orbit/changes/issue-5689-decouple-orbit-logs
@@ -1,0 +1,4 @@
+* Added log files for Fleet Desktop logs, located at:
+  - macOS:  `~/Library/Log`
+  - Linux: `$XDG_STATE_HOME`, fallback to `$HOME/.local/state`
+  - Windows: `%LocalAppData%`

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -198,7 +198,7 @@ func logDir() (string, error) {
 			return "", errors.New("%LocalAppData% is not defined")
 		}
 
-	case "darwin", "ios":
+	case "darwin":
 		dir = os.Getenv("HOME")
 		if dir == "" {
 			return "", errors.New("$HOME is not defined")

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -29,7 +29,7 @@ func main() {
 		fmt.Println("Fleet Desktop application executable")
 		return
 	}
-	log.Info().Msgf("fleet-desktop version=%s\n", version)
+	log.Info().Msgf("fleet-desktop version=%s", version)
 
 	devURL := os.Getenv("FLEET_DESKTOP_DEVICE_URL")
 	if devURL == "" {

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -165,8 +165,16 @@ func setupLogs() {
 		return
 	}
 
+	dir = filepath.Join(dir, "Fleet")
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		log.Logger = log.Output(stderrOut)
+		log.Error().Err(err).Msg("make directories for log files")
+		return
+	}
+
 	logFile := &lumberjack.Logger{
-		Filename:   filepath.Join(dir, "Fleet", "fleet-desktop.log"),
+		Filename:   filepath.Join(dir, "fleet-desktop.log"),
 		MaxSize:    25, // megabytes
 		MaxBackups: 3,
 		MaxAge:     28, // days

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 	"time"
 
@@ -165,7 +166,7 @@ func setupLogs() {
 	}
 
 	logFile := &lumberjack.Logger{
-		Filename:   path.Join(dir, "Fleet", "fleet-desktop.log"),
+		Filename:   filepath.Join(dir, "Fleet", "fleet-desktop.log"),
 		MaxSize:    25, // megabytes
 		MaxBackups: 3,
 		MaxAge:     28, // days

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -4,35 +4,40 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"log"
 	"net/url"
 	"os"
 	"path"
+	"runtime"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/open"
 	"github.com/fleetdm/fleet/v4/server/service"
 	"github.com/getlantern/systray"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 var version = "unknown"
 
 func main() {
+	setupLogs()
+
 	// Our TUF provided targets must support launching with "--help".
 	if len(os.Args) > 1 && os.Args[1] == "--help" {
 		fmt.Println("Fleet Desktop application executable")
 		return
 	}
-	log.Printf("fleet-desktop version=%s\n", version)
+	log.Info().Msgf("fleet-desktop version=%s\n", version)
 
 	devURL := os.Getenv("FLEET_DESKTOP_DEVICE_URL")
 	if devURL == "" {
-		log.Println("missing URL environment FLEET_DESKTOP_DEVICE_URL")
+		log.Fatal().Msg("missing URL environment FLEET_DESKTOP_DEVICE_URL")
 		os.Exit(1)
 	}
 	deviceURL, err := url.Parse(devURL)
 	if err != nil {
-		log.Printf("invalid URL argument: %s\n", err)
+		log.Fatal().Err(err).Msg("invalid URL argument")
 		os.Exit(1)
 	}
 
@@ -40,7 +45,7 @@ func main() {
 	deviceToken := path.Base(deviceURL.Path)
 
 	onReady := func() {
-		log.Println("ready")
+		log.Info().Msg("ready")
 
 		systray.SetTemplateIcon(icoBytes, icoBytes)
 		systray.SetTooltip("Fleet Device Management Menu.")
@@ -57,7 +62,7 @@ func main() {
 		client, err := service.NewDeviceClient(basePath, deviceToken, insecureSkipVerify, "")
 
 		if err != nil {
-			log.Printf("unable to initialize request client: %s", err)
+			log.Fatal().Err(err).Msg("unable to initialize request client")
 			os.Exit(1)
 		}
 
@@ -83,7 +88,7 @@ func main() {
 
 					// To ease troubleshooting we set the tooltip as the error.
 					myDeviceItem.SetTooltip(err.Error())
-					log.Printf("get device URL: %s", err)
+					log.Error().Err(err).Msg("get device URL")
 
 					<-ticker.C
 				}
@@ -110,7 +115,7 @@ func main() {
 				default:
 					// To ease troubleshooting we set the tooltip as the error.
 					myDeviceItem.SetTooltip(err.Error())
-					log.Printf("get device URL: %s", err)
+					log.Error().Err(err).Msg("get device URL")
 					continue
 				}
 
@@ -132,19 +137,86 @@ func main() {
 				select {
 				case <-myDeviceItem.ClickedCh:
 					if err := open.Browser(deviceURL.String()); err != nil {
-						log.Printf("open browser my device: %s", err)
+						log.Error().Err(err).Msg("open browser my device")
 					}
 				case <-transparencyItem.ClickedCh:
 					if err := open.Browser("https://fleetdm.com/transparency"); err != nil {
-						log.Printf("open browser transparency: %s", err)
+						log.Error().Err(err).Msg("open browser transparency")
 					}
 				}
 			}
 		}()
 	}
 	onExit := func() {
-		log.Println("exit")
+		log.Info().Msg("exit")
 	}
 
 	systray.Run(onReady, onExit)
+}
+
+// setupLogs configures our logging system to write logs to rolling files and
+// stderr, if for some reason we can't write a log file the logs are still
+// printed to stderr.
+func setupLogs() {
+	stderrOut := zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339Nano, NoColor: true}
+
+	dir, err := logDir()
+	if err != nil {
+		log.Logger = log.Output(stderrOut)
+		log.Error().Err(err).Msg("find directory for logs")
+		return
+	}
+
+	logFile := &lumberjack.Logger{
+		Filename:   path.Join(dir, "Fleet", "fleet-desktop.log"),
+		MaxSize:    25, // megabytes
+		MaxBackups: 3,
+		MaxAge:     28, // days
+	}
+
+	log.Logger = log.Output(zerolog.MultiLevelWriter(
+		zerolog.ConsoleWriter{Out: logFile, TimeFormat: time.RFC3339Nano, NoColor: true},
+		stderrOut,
+	))
+}
+
+// logDir returns the default root directory to use for application-level logs.
+//
+// On Unix systems, it returns $XDG_STATE_HOME as specified by
+// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html if
+// non-empty, else $HOME/.local/state.
+// On Darwin, it returns $HOME/Library/Log.
+// On Windows, it returns %LocalAppData%
+//
+// If the location cannot be determined (for example, $HOME is not defined),
+// then it will return an error.
+func logDir() (string, error) {
+	var dir string
+
+	switch runtime.GOOS {
+	case "windows":
+		dir = os.Getenv("LocalAppData")
+		if dir == "" {
+			return "", errors.New("%LocalAppData% is not defined")
+		}
+
+	case "darwin", "ios":
+		dir = os.Getenv("HOME")
+		if dir == "" {
+			return "", errors.New("$HOME is not defined")
+		}
+		dir += "/Library/Log"
+
+	default: // Unix
+		dir = os.Getenv("XDG_STATE_HOME")
+		if dir == "" {
+			dir = os.Getenv("HOME")
+			if dir == "" {
+				return "", errors.New("neither $XDG_STATE_HOME nor $HOME are defined")
+			}
+			dir += "/.local/state"
+		}
+	}
+
+	return dir, nil
 }

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -33,12 +33,10 @@ func main() {
 	devURL := os.Getenv("FLEET_DESKTOP_DEVICE_URL")
 	if devURL == "" {
 		log.Fatal().Msg("missing URL environment FLEET_DESKTOP_DEVICE_URL")
-		os.Exit(1)
 	}
 	deviceURL, err := url.Parse(devURL)
 	if err != nil {
 		log.Fatal().Err(err).Msg("invalid URL argument")
-		os.Exit(1)
 	}
 
 	basePath := deviceURL.Scheme + "://" + deviceURL.Host
@@ -63,7 +61,6 @@ func main() {
 
 		if err != nil {
 			log.Fatal().Err(err).Msg("unable to initialize request client")
-			os.Exit(1)
 		}
 
 		// Perform API test call to enable the "My device" item as soon


### PR DESCRIPTION
As described in the title, and with more detail in https://github.com/fleetdm/fleet/issues/5689.

Screenshots (because they are fun!)

#### macOS
![Screen Shot 2022-06-10 at 14 50 13](https://user-images.githubusercontent.com/4419992/173127511-39853e01-0cd8-43ce-984d-4f6c664a935c.png)

### Windows
![Screen Shot 2022-06-10 at 14 47 46](https://user-images.githubusercontent.com/4419992/173127514-acc08963-72ee-4acd-b11b-303be4d3df15.png)

### Ubuntu
![Screen Shot 2022-06-10 at 15 17 07](https://user-images.githubusercontent.com/4419992/173127506-fdfbb772-3a43-48df-86a1-e6a77ab78efe.png)

### CentOS

![image](https://user-images.githubusercontent.com/4419992/173377179-666a6181-908a-4326-a443-bb07e659046b.png)


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
