### PR TITLE
fix fleetctl debug commands on Windows

### DIFF
--- a/changes/issue-6127-fleet-debug-windows
+++ b/changes/issue-6127-fleet-debug-windows
@@ -1,0 +1,1 @@
+* Fixed the `fleetctl debug` `archive` and `errors` commands on Windows.

--- a/cmd/fleetctl/debug.go
+++ b/cmd/fleetctl/debug.go
@@ -66,8 +66,8 @@ func writeFile(filename string, bytes []byte, mode os.FileMode) error {
 }
 
 func outfileName(name string) string {
-	time := strings.Replace(nowFn().Format(time.RFC3339), ":", "-", -1)
-	return fmt.Sprintf("fleet-%s-%s", name, time)
+	tf := strings.Replace(nowFn().Format(time.RFC3339), ":", "-", -1)
+	return fmt.Sprintf("fleet-%s-%s", name, tf)
 }
 
 func outfileNameWithExt(name string, ext string) string {

--- a/cmd/fleetctl/debug.go
+++ b/cmd/fleetctl/debug.go
@@ -66,8 +66,7 @@ func writeFile(filename string, bytes []byte, mode os.FileMode) error {
 }
 
 func outfileName(name string) string {
-	tf := strings.Replace(nowFn().Format(time.RFC3339), ":", "-", -1)
-	return fmt.Sprintf("fleet-%s-%s", name, tf)
+	return fmt.Sprintf("fleet-%s-%s", name, nowFn().Format("20060102150405Z"))
 }
 
 func outfileNameWithExt(name string, ext string) string {

--- a/cmd/fleetctl/debug.go
+++ b/cmd/fleetctl/debug.go
@@ -66,7 +66,8 @@ func writeFile(filename string, bytes []byte, mode os.FileMode) error {
 }
 
 func outfileName(name string) string {
-	return fmt.Sprintf("fleet-%s-%s", name, nowFn().Format(time.RFC3339))
+	time := strings.Replace(nowFn().Format(time.RFC3339), ":", "-", -1)
+	return fmt.Sprintf("fleet-%s-%s", name, time)
 }
 
 func outfileNameWithExt(name string, ext string) string {

--- a/cmd/fleetctl/debug_test.go
+++ b/cmd/fleetctl/debug_test.go
@@ -211,11 +211,11 @@ func TestFilenameFunctions(t *testing.T) {
 
 	t.Run("outfileName builds a file name using the name provided + current time ", func(t *testing.T) {
 		name := outfileName("test")
-		assert.Equal(t, name, "fleet-test-1969-06-19T21-44-05Z")
+		assert.Equal(t, "fleet-test-19690619214405Z", name)
 	})
 
 	t.Run("outfileNameWithExt builds a file name using the name and extension provided + current time ", func(t *testing.T) {
 		name := outfileNameWithExt("test", "go")
-		assert.Equal(t, name, "fleet-test-1969-06-19T21-44-05Z.go")
+		assert.Equal(t, "fleet-test-19690619214405Z.go", name)
 	})
 }

--- a/cmd/fleetctl/debug_test.go
+++ b/cmd/fleetctl/debug_test.go
@@ -211,11 +211,11 @@ func TestFilenameFunctions(t *testing.T) {
 
 	t.Run("outfileName builds a file name using the name provided + current time ", func(t *testing.T) {
 		name := outfileName("test")
-		assert.Equal(t, name, "fleet-test-1969-06-19T21:44:05Z")
+		assert.Equal(t, name, "fleet-test-1969-06-19T21-44-05Z")
 	})
 
 	t.Run("outfileNameWithExt builds a file name using the name and extension provided + current time ", func(t *testing.T) {
 		name := outfileNameWithExt("test", "go")
-		assert.Equal(t, name, "fleet-test-1969-06-19T21:44:05Z.go")
+		assert.Equal(t, name, "fleet-test-1969-06-19T21-44-05Z.go")
 	})
 }


### PR DESCRIPTION
As reported in #6127, the `fleetctl debug` `archive` and `errors` commands were failing on Windows because filenames are not allowed to contain colons `:`.

This changeset replaces `:` with `-` in the filename of the archives generated by both commands.

![image](https://user-images.githubusercontent.com/4419992/173158619-b5829337-1938-461c-9a1e-51508377f70b.png)


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
