### PR TITLE
Allow troubleshooting of flaky tests that use mocked live query store

### DIFF
--- a/cmd/fleetctl/query_test.go
+++ b/cmd/fleetctl/query_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	"github.com/fleetdm/fleet/v4/server/live_query"
+	"github.com/fleetdm/fleet/v4/server/live_query/live_query_mock"
 	"github.com/fleetdm/fleet/v4/server/pubsub"
 	"github.com/fleetdm/fleet/v4/server/service"
 	kitlog "github.com/go-kit/kit/log"
@@ -18,7 +18,7 @@ import (
 
 func TestLiveQuery(t *testing.T) {
 	rs := pubsub.NewInmemQueryResults()
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 
 	logger := kitlog.NewJSONLogger(os.Stdout)
 	logger = level.NewFilter(logger, level.AllowDebug())

--- a/server/live_query/live_query_mock/live_query_mock.go
+++ b/server/live_query/live_query_mock/live_query_mock.go
@@ -1,31 +1,46 @@
-package live_query
+package live_query_mock
 
 import (
+	"testing"
+
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/stretchr/testify/mock"
 )
 
+// MockLiveQuery allows mocking a live query store.
 type MockLiveQuery struct {
 	mock.Mock
 	fleet.LiveQueryStore
 }
 
+var _ fleet.LiveQueryStore = (*MockLiveQuery)(nil)
+
+// New allocates a mocked live query store.
+func New(t *testing.T) *MockLiveQuery {
+	m := new(MockLiveQuery)
+	m.Test(t)
+	return m
+}
+
+// RunQuery mocks the live query store RunQuery method.
 func (m *MockLiveQuery) RunQuery(name, sql string, hostIDs []uint) error {
 	args := m.Called(name, sql, hostIDs)
 	return args.Error(0)
 }
 
+// StopQuery mocks the live query store StopQuery method.
 func (m *MockLiveQuery) StopQuery(name string) error {
 	args := m.Called(name)
 	return args.Error(0)
-
 }
 
+// QueriesForHost mocks the live query store QueriesForHost method.
 func (m *MockLiveQuery) QueriesForHost(hostID uint) (map[string]string, error) {
 	args := m.Called(hostID)
 	return args.Get(0).(map[string]string), args.Error(1)
 }
 
+// QueryCompletedByHost mocks the live query store QueryCompletedByHost method.
 func (m *MockLiveQuery) QueryCompletedByHost(name string, hostID uint) error {
 	args := m.Called(name, hostID)
 	return args.Error(0)

--- a/server/service/integration_live_queries_test.go
+++ b/server/service/integration_live_queries_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	"github.com/fleetdm/fleet/v4/server/live_query"
+	"github.com/fleetdm/fleet/v4/server/live_query/live_query_mock"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/pubsub"
 	"github.com/stretchr/testify/assert"
@@ -31,7 +31,7 @@ type liveQueriesTestSuite struct {
 	withServer
 	suite.Suite
 
-	lq    *live_query.MockLiveQuery
+	lq    *live_query_mock.MockLiveQuery
 	hosts []*fleet.Host
 }
 
@@ -41,7 +41,7 @@ func (s *liveQueriesTestSuite) SetupSuite() {
 	s.withDS.SetupSuite("liveQueriesTestSuite")
 
 	rs := pubsub.NewInmemQueryResults()
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(s.T())
 	s.lq = lq
 
 	users, server := RunServerForTestsWithDS(s.T(), s.ds, &TestServerOpts{Lq: lq, Rs: rs})

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	"github.com/fleetdm/fleet/v4/server/live_query"
+	"github.com/fleetdm/fleet/v4/server/live_query/live_query_mock"
 	"github.com/fleetdm/fleet/v4/server/logging"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/ptr"
@@ -499,7 +499,7 @@ func TestGetDistributedQueriesMissingHost(t *testing.T) {
 func TestLabelQueries(t *testing.T) {
 	mockClock := clock.NewMockClock()
 	ds := new(mock.Store)
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 	svc := newTestServiceWithClock(t, ds, nil, lq, mockClock)
 
 	host := &fleet.Host{
@@ -658,7 +658,7 @@ func TestLabelQueries(t *testing.T) {
 func TestDetailQueriesWithEmptyStrings(t *testing.T) {
 	ds := new(mock.Store)
 	mockClock := clock.NewMockClock()
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 	svc := newTestServiceWithClock(t, ds, nil, lq, mockClock)
 
 	host := &fleet.Host{
@@ -849,7 +849,7 @@ func TestDetailQueriesWithEmptyStrings(t *testing.T) {
 func TestDetailQueries(t *testing.T) {
 	ds := new(mock.Store)
 	mockClock := clock.NewMockClock()
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 	svc := newTestServiceWithClock(t, ds, nil, lq, mockClock)
 
 	host := &fleet.Host{
@@ -1166,7 +1166,7 @@ func TestNewDistributedQueryCampaign(t *testing.T) {
 			return nil
 		},
 	}
-	lq := &live_query.MockLiveQuery{}
+	lq := live_query_mock.New(t)
 	mockClock := clock.NewMockClock()
 	svc := newTestServiceWithClock(t, ds, rs, lq, mockClock)
 
@@ -1231,7 +1231,7 @@ func TestDistributedQueryResults(t *testing.T) {
 	mockClock := clock.NewMockClock()
 	ds := new(mock.Store)
 	rs := pubsub.NewInmemQueryResults()
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 	svc := newTestServiceWithClock(t, ds, rs, lq, mockClock)
 
 	campaign := &fleet.DistributedQueryCampaign{ID: 42}
@@ -1339,7 +1339,7 @@ func TestIngestDistributedQueryParseIdError(t *testing.T) {
 	mockClock := clock.NewMockClock()
 	ds := new(mock.Store)
 	rs := pubsub.NewInmemQueryResults()
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 	svc := &Service{
 		ds:             ds,
 		resultStore:    rs,
@@ -1358,7 +1358,7 @@ func TestIngestDistributedQueryOrphanedCampaignLoadError(t *testing.T) {
 	mockClock := clock.NewMockClock()
 	ds := new(mock.Store)
 	rs := pubsub.NewInmemQueryResults()
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 	svc := &Service{
 		ds:             ds,
 		resultStore:    rs,
@@ -1384,7 +1384,7 @@ func TestIngestDistributedQueryOrphanedCampaignWaitListener(t *testing.T) {
 	mockClock := clock.NewMockClock()
 	ds := new(mock.Store)
 	rs := pubsub.NewInmemQueryResults()
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 	svc := &Service{
 		ds:             ds,
 		resultStore:    rs,
@@ -1417,7 +1417,7 @@ func TestIngestDistributedQueryOrphanedCloseError(t *testing.T) {
 	mockClock := clock.NewMockClock()
 	ds := new(mock.Store)
 	rs := pubsub.NewInmemQueryResults()
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 	svc := &Service{
 		ds:             ds,
 		resultStore:    rs,
@@ -1453,7 +1453,7 @@ func TestIngestDistributedQueryOrphanedStopError(t *testing.T) {
 	mockClock := clock.NewMockClock()
 	ds := new(mock.Store)
 	rs := pubsub.NewInmemQueryResults()
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 	svc := &Service{
 		ds:             ds,
 		resultStore:    rs,
@@ -1490,7 +1490,7 @@ func TestIngestDistributedQueryOrphanedStop(t *testing.T) {
 	mockClock := clock.NewMockClock()
 	ds := new(mock.Store)
 	rs := pubsub.NewInmemQueryResults()
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 	svc := &Service{
 		ds:             ds,
 		resultStore:    rs,
@@ -1528,7 +1528,7 @@ func TestIngestDistributedQueryRecordCompletionError(t *testing.T) {
 	mockClock := clock.NewMockClock()
 	ds := new(mock.Store)
 	rs := pubsub.NewInmemQueryResults()
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 	svc := &Service{
 		ds:             ds,
 		resultStore:    rs,
@@ -1559,7 +1559,7 @@ func TestIngestDistributedQuery(t *testing.T) {
 	mockClock := clock.NewMockClock()
 	ds := new(mock.Store)
 	rs := pubsub.NewInmemQueryResults()
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 	svc := &Service{
 		ds:             ds,
 		resultStore:    rs,
@@ -1952,7 +1952,7 @@ func TestObserversCanOnlyRunDistributedCampaigns(t *testing.T) {
 			return nil
 		},
 	}
-	lq := &live_query.MockLiveQuery{}
+	lq := live_query_mock.New(t)
 	mockClock := clock.NewMockClock()
 	svc := newTestServiceWithClock(t, ds, rs, lq, mockClock)
 
@@ -2025,7 +2025,7 @@ func TestTeamMaintainerCanRunNewDistributedCampaigns(t *testing.T) {
 			return nil
 		},
 	}
-	lq := &live_query.MockLiveQuery{}
+	lq := live_query_mock.New(t)
 	mockClock := clock.NewMockClock()
 	svc := newTestServiceWithClock(t, ds, rs, lq, mockClock)
 
@@ -2079,7 +2079,7 @@ func TestTeamMaintainerCanRunNewDistributedCampaigns(t *testing.T) {
 func TestPolicyQueries(t *testing.T) {
 	mockClock := clock.NewMockClock()
 	ds := new(mock.Store)
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 	svc := newTestServiceWithClock(t, ds, nil, lq, mockClock)
 
 	host := &fleet.Host{
@@ -2259,7 +2259,7 @@ func TestPolicyQueries(t *testing.T) {
 func TestPolicyWebhooks(t *testing.T) {
 	mockClock := clock.NewMockClock()
 	ds := new(mock.Store)
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 	pool := redistest.SetupRedis(t, t.Name(), false, false, false)
 	failingPolicySet := redis_policy_set.NewFailingTest(t, pool)
 	testConfig := config.TestConfig()
@@ -2526,7 +2526,7 @@ func TestPolicyWebhooks(t *testing.T) {
 // want hosts to get queries and continue to check in.
 func TestLiveQueriesFailing(t *testing.T) {
 	ds := new(mock.Store)
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 	cfg := config.TestConfig()
 	buf := new(bytes.Buffer)
 	logger := log.NewLogfmtLogger(buf)
@@ -2574,7 +2574,7 @@ func TestLiveQueriesFailing(t *testing.T) {
 // refetched for "orbitInfoRefetchAfterEnrollDur" after enroll.
 func TestFleetDesktopOrbitInfo(t *testing.T) {
 	ds := new(mock.Store)
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 	mockClock := clock.NewMockClock()
 	fleetConfig := config.TestConfig()
 	fleetConfig.Osquery.LabelUpdateInterval = 5 * time.Minute

--- a/server/service/service_campaign_test.go
+++ b/server/service/service_campaign_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/WatchBeam/clock"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	"github.com/fleetdm/fleet/v4/server/live_query"
+	"github.com/fleetdm/fleet/v4/server/live_query/live_query_mock"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/pubsub"
@@ -30,7 +30,7 @@ func TestStreamCampaignResultsClosesReditOnWSClose(t *testing.T) {
 
 	mockClock := clock.NewMockClock()
 	ds := new(mock.Store)
-	lq := new(live_query.MockLiveQuery)
+	lq := live_query_mock.New(t)
 	svc := newTestServiceWithClock(t, ds, store, lq, mockClock)
 
 	campaign := &fleet.DistributedQueryCampaign{ID: 42}


### PR DESCRIPTION
See failure: https://github.com/fleetdm/fleet/runs/6855043335?check_suite_focus=true

It's a bit hard to troubleshoot flaky tests if all we get is a panic:
```
panic: 
assert: mock: I don't know what to return because the method call was unexpected.
	Either do Mock.On("RunQuery").Return(...) first, or remove the RunQuery() call.
	This method was unexpected:
		RunQuery(string,string,[]uint)
		0: "5"
		1: "select 1 from osquery;"
		2: []uint{0x1, 0x2}
	at: [mock_live_query.go:14 campaigns.go:155 live_queries.go:78 asm_amd64.s:1571]
```

This should provide the Test name in the output, which will allow for troubleshooting of flaky tests.