### PR TITLE
store count alongside unique error instances in Redis

### DIFF
--- a/changes/add-count-to-errors
+++ b/changes/add-count-to-errors
@@ -1,0 +1,1 @@
+* Added a count value to errors retrieved by the `/debug/errors` API, with the number of times the error occurred.

--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -6454,18 +6454,24 @@ The server only stores and returns a single instance of each error.
 
 ```json
 [
-  {
-    "external": "example error",
-    "root": {
-      "message": "timestamp: 2022-05-06T11:40:32-03:00",
-      "stack": [
-        "http.initALPNRequest.ServeHTTP:/usr/local/Cellar/go/1.17.6/libexec/src/net/http/server.go:3480",
-        "http.serverHandler.ServeHTTP:/usr/local/Cellar/go/1.17.6/libexec/src/net/http/server.go:2879",
-        "service.(*authEndpointer).makeEndpoint.func1:/Users/robertodip/projects/fleet/server/service/endpoint_utils.go:439",
-        "...",
-        "service.listSoftwareEndpoint:/Users/robertodip/projects/fleet/server/service/software.go:30",
-        "ctxerr.New:/Users/robertodip/projects/fleet/server/contexts/ctxerr/ctxerr.go:67",
-        "ctxerr.ensureCommonMetadata:/Users/robertodip/projects/fleet/server/contexts/ctxerr/ctxerr.go:112"
+ {
+    "count": "3",
+    "error": {
+      "cause": {
+        "message": "Authorization header required"
+      },
+      "wraps": [
+        {
+          "message": "missing FleetError in chain",
+          "data": {
+            "timestamp": "2022-06-03T14:16:01-03:00"
+          },
+          "stack": [
+            "github.com/fleetdm/fleet/v4/server/contexts/ctxerr.Handle (ctxerr.go:262)",
+            "github.com/fleetdm/fleet/v4/server/service.encodeError (transport_error.go:80)",
+            "github.com/go-kit/kit/transport/http.Server.ServeHTTP (server.go:124)"
+          ]
+        }
       ]
     }
   }

--- a/server/errorstore/errors.go
+++ b/server/errorstore/errors.go
@@ -43,6 +43,13 @@ type Handler struct {
 	testOnStart func()      // if set, called once the handler is running
 }
 
+// storedError represents the structure we use to de-serialize errors and
+// counts stored in Redis
+type storedError struct {
+	Count int             `json:"count"`
+	Error json.RawMessage `json:"error"`
+}
+
 // NewHandler creates an error handler using the provided pool and logger,
 // storing unique instances of errors in Redis using the pool. It stops storing
 // errors when ctx is cancelled. Errors are kept for the duration of ttl.
@@ -87,33 +94,46 @@ func runHandler(ctx context.Context, eh *Handler) {
 //
 // If flush is `true`, performs a destructive read - the errors are removed
 // from Redis on return.
-func (h *Handler) Retrieve(flush bool) ([]string, error) {
-	errorKeys, err := redis.ScanKeys(h.pool, "error:*", 100)
+func (h *Handler) Retrieve(flush bool) ([]*storedError, error) {
+	// scanning only the error:*:json keys as json and count are both tagged keys
+	// and should hash to the same Redis slot
+	errorKeys, err := redis.ScanKeys(h.pool, "error:*:json", 100)
 	if err != nil {
 		return nil, err
 	}
 
 	keysBySlot := redis.SplitKeysBySlot(h.pool, errorKeys...)
-	var errors []string
+	var rawErrs []interface{}
 	for _, qkeys := range keysBySlot {
 		if len(qkeys) > 0 {
 			gotErrors, err := h.collectBatchErrors(qkeys, flush)
 			if err != nil {
 				return nil, err
 			}
-			errors = append(errors, gotErrors...)
+			rawErrs = append(rawErrs, gotErrors...)
 		}
 	}
-	return errors, nil
+
+	errorList := []*storedError{}
+	if err := redigo.ScanSlice(rawErrs, &errorList); err != nil {
+		return nil, err
+	}
+	return errorList, nil
 }
 
-func (h *Handler) collectBatchErrors(errorKeys []string, flush bool) ([]string, error) {
+func (h *Handler) collectBatchErrors(errorKeys []string, flush bool) ([]interface{}, error) {
 	conn := redis.ConfigureDoer(h.pool, h.pool.Get())
 	defer conn.Close()
 
 	var args redigo.Args
-	args = args.AddFlat(errorKeys)
-	errorList, err := redigo.Strings(conn.Do("MGET", args...))
+	for _, ek := range errorKeys {
+		// note: the order in which the keys are requested must match the order in
+		// which the struct fields are declared (due to how redigo.ScanSlice works)
+		args = args.Add(strings.Replace(ek, ":json", ":count", 1))
+		args = args.Add(ek)
+	}
+
+	errorList, err := redigo.Values(conn.Do("MGET", args...))
 	if err != nil {
 		return nil, err
 	}
@@ -185,22 +205,28 @@ func (h *Handler) storeError(ctx context.Context, err error) {
 		}
 		return
 	}
-	jsonKey := fmt.Sprintf("error:%s:json", errorHash)
 
-	conn := redis.ConfigureDoer(h.pool, h.pool.Get())
+	// not using a connection that follows redirections here
+	// in order to do pipeline commands
+	conn := h.pool.Get()
 	defer conn.Close()
 
-	var args redigo.Args
-	args = args.Add(jsonKey, errorJson)
+	jsonKey := fmt.Sprintf("error:{%s}:json", errorHash)
+	countKey := fmt.Sprintf("error:{%s}:count", errorHash)
+
+	conn.Send("SET", jsonKey, errorJson)
+	conn.Send("INCR", countKey)
+
 	if h.ttl > 0 {
 		secs := int(h.ttl.Seconds())
 		if secs <= 0 {
-			secs = 1 // SET EX fails if ttl is <= 0
+			secs = 1 // EXPIRE fails if ttl is <= 0
 		}
-		args = args.Add("EX", secs)
+		conn.Send("EXPIRE", jsonKey, secs)
+		conn.Send("EXPIRE", countKey, secs)
 	}
 
-	if _, err := conn.Do("SET", args...); err != nil {
+	if _, err := conn.Do(""); err != nil {
 		level.Error(h.logger).Log("err", err, "msg", "redis SET failed")
 		if h.testOnStore != nil {
 			h.testOnStore(err)
@@ -261,15 +287,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// each string returned by eh.Retrieve is already JSON-encoded, so to prevent
-	// double-marshaling while still marshaling the list of errors as a JSON
-	// array, treat them as raw json messages.
-	raw := make([]json.RawMessage, len(errors))
-	for i, s := range errors {
-		raw[i] = json.RawMessage(s)
-	}
-
-	bytes, err := json.Marshal(raw)
+	bytes, err := json.Marshal(errors)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/server/errorstore/errors.go
+++ b/server/errorstore/errors.go
@@ -114,7 +114,7 @@ func (h *Handler) Retrieve(flush bool) ([]*storedError, error) {
 		}
 	}
 
-	errorList := []*storedError{}
+	errorList := make([]*storedError, 0, len(rawErrs))
 	if err := redigo.ScanSlice(rawErrs, &errorList); err != nil {
 		return nil, err
 	}

--- a/server/errorstore/errors_test.go
+++ b/server/errorstore/errors_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -246,7 +247,7 @@ func testErrorHandlerCollectsErrors(t *testing.T, pool fleet.RedisPool, wd strin
       ".+",
       ".+"
     \]
-  \}`), errors[0])
+  \}`), string(errors[0].Error))
 
 	errors, err = eh.Retrieve(flush)
 	require.NoError(t, err)
@@ -303,7 +304,8 @@ func testErrorHandlerCollectsDifferentErrors(t *testing.T, pool fleet.RedisPool,
 
 	// order is not guaranteed by scan keys
 	for _, jsonErr := range errors {
-		if strings.Contains(jsonErr, "new errors two") {
+		msg := string(jsonErr.Error)
+		if strings.Contains(msg, "new errors two") {
 			assert.Regexp(t, regexp.MustCompile(`\{
   "cause": \{
     "message": "always new errors two",
@@ -317,7 +319,7 @@ func testErrorHandlerCollectsDifferentErrors(t *testing.T, pool fleet.RedisPool,
       ".+",
       ".+"
     \]
-  \}`), jsonErr)
+  \}`), msg)
 		} else {
 			assert.Regexp(t, regexp.MustCompile(`\{
   "cause": \{
@@ -332,7 +334,7 @@ func testErrorHandlerCollectsDifferentErrors(t *testing.T, pool fleet.RedisPool,
       ".+",
       ".+"
     \]
-  \}`), jsonErr)
+  \}`), msg)
 		}
 	}
 
@@ -347,7 +349,7 @@ func TestHttpHandler(t *testing.T) {
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		defer cancelFunc()
 
-		var storeCalls int32 = 2
+		var storeCalls int32 = 3
 
 		chGo, chDone := make(chan struct{}), make(chan struct{})
 		testOnStart := func() {
@@ -363,12 +365,35 @@ func TestHttpHandler(t *testing.T) {
 		eh := newTestHandler(ctx, pool, kitlog.NewNopLogger(), time.Minute, testOnStart, testOnStore)
 
 		<-chGo
-		// store two errors
-		alwaysNewError(eh)
-		alwaysNewErrorTwo(eh)
+		// simulate two errors, one happening twice
+		err1 := ctxerr.New(ctx, "err1")
+		err2 := ctxerr.New(ctx, "err2")
+		eh.Store(err1)
+		eh.Store(err2)
+		eh.Store(err1)
 		<-chDone
 
 		return eh
+	}
+
+	type errResp struct {
+		Count int
+		Error struct {
+			Cause struct {
+				Message string
+			}
+			Wrap []struct {
+				Message string
+			}
+		}
+	}
+
+	var errs []errResp
+
+	sortByCount := func(errs []errResp) {
+		sort.Slice(errs, func(i, j int) bool {
+			return errs[i].Count > errs[j].Count
+		})
 	}
 
 	t.Run("retrieves errors", func(t *testing.T) {
@@ -378,18 +403,14 @@ func TestHttpHandler(t *testing.T) {
 		eh.ServeHTTP(res, req)
 
 		require.Equal(t, res.Code, 200)
-		var errs []struct {
-			Cause struct {
-				Message string
-			}
-			Wrap []struct {
-				Message string
-			}
-		}
 		require.NoError(t, json.Unmarshal(res.Body.Bytes(), &errs))
 		require.Len(t, errs, 2)
-		require.NotEmpty(t, errs[0].Cause.Message)
-		require.NotEmpty(t, errs[1].Cause.Message)
+		require.NotEmpty(t, errs[0].Error.Cause.Message)
+		require.NotEmpty(t, errs[1].Error.Cause.Message)
+
+		sortByCount(errs)
+		require.Equal(t, 2, errs[0].Count)
+		require.Equal(t, 1, errs[1].Count)
 	})
 
 	t.Run("flushes errors after retrieving if the flush flag is true", func(t *testing.T) {
@@ -399,18 +420,14 @@ func TestHttpHandler(t *testing.T) {
 		eh.ServeHTTP(res, req)
 
 		require.Equal(t, res.Code, 200)
-		var errs []struct {
-			Cause struct {
-				Message string
-			}
-			Wrap []struct {
-				Message string
-			}
-		}
 		require.NoError(t, json.Unmarshal(res.Body.Bytes(), &errs))
 		require.Len(t, errs, 2)
-		require.NotEmpty(t, errs[0].Cause.Message)
-		require.NotEmpty(t, errs[1].Cause.Message)
+		require.NotEmpty(t, errs[0].Error.Cause.Message)
+		require.NotEmpty(t, errs[1].Error.Cause.Message)
+
+		sortByCount(errs)
+		require.Equal(t, 2, errs[0].Count)
+		require.Equal(t, 1, errs[1].Count)
 
 		req = httptest.NewRequest("GET", "/?flush=true", nil)
 		res = httptest.NewRecorder()


### PR DESCRIPTION
Related to https://github.com/fleetdm/fleet/issues/4972, this adds a new key, `error:<hash>:count` to Redis in order to keep track of how many times each instance of an error occurred.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
