### PR TITLE
Handbook Changes

### DIFF
--- a/handbook/customers.md
+++ b/handbook/customers.md
@@ -100,7 +100,7 @@ Fleet's subscription agreement is available at [fleetdm.com/terms](https://fleet
 
 Fleeties can find a summary of contract terms in the relevant [customer's Salesforce opportunity.](https://fleetdm.lightning.force.com/lightning/o/Opportunity/list?filterName=Recent)
 
-## Contract Glossary
+## Contract glossary
 
 | Term           | Definition                                                |
 |:---------------|:----------------------------------------------------------|

--- a/handbook/customers.md
+++ b/handbook/customers.md
@@ -100,6 +100,14 @@ Fleet's subscription agreement is available at [fleetdm.com/terms](https://fleet
 
 Fleeties can find a summary of contract terms in the relevant [customer's Salesforce opportunity.](https://fleetdm.lightning.force.com/lightning/o/Opportunity/list?filterName=Recent)
 
+## Contract Glossary
+
+| Term           | Definition                                                |
+|:---------------|:----------------------------------------------------------|
+| Effective date | The start date for the subscription service. |
+| Close date | The date the last party to the contract signed the agreement. |
+| Invoice date | The date that Fleet sent the invoice to the customer. |
+
 ## Rituals
 
 The following table lists the Customer's group's rituals, frequency, and Directly Responsible Individual (DRI).

--- a/handbook/customers.md
+++ b/handbook/customers.md
@@ -98,7 +98,7 @@ Occasionally, users will email or Slack questions about product usage. We will t
 ## Customer contracts
 Fleet's subscription agreement is available at [fleetdm.com/terms](https://fleetdm.com/terms). 
 
-Fleet employees can find a summary of contract terms [here](https://docs.google.com/spreadsheets/d/1gAenC948YWG2NwcaVHleUvX0LzS8suyMFpjaBqxHQNg/edit?usp=sharing).
+Fleeties can find a summary of contract terms in the relevant [customer's Salesforce opportunity.](https://fleetdm.lightning.force.com/lightning/o/Opportunity/list?filterName=Recent)
 
 ## Rituals
 


### PR DESCRIPTION
Changed the link directing Fleeties to the key contract terms spreadsheet in Google Drive to the relevant customer's Salesforce opportunity for a summary/information about contract terms as required in GitHub issue #1430.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [ ] Documented any permissions changes
- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
