### PR TITLE
Update documentation for ticket destinations and Fleet Desktop

### DIFF
--- a/docs/Using-Fleet/Adding-hosts.md
+++ b/docs/Using-Fleet/Adding-hosts.md
@@ -41,7 +41,7 @@ Also remember to replace both `AC_USERNAME` and `AC_PASSWORD` environment variab
 ### Fleet Desktop
 
 > Fleet Desktop requires a Fleet version of 4.12.0 and above. To check your Fleet version, select
-> the avatar in the right-side of the top bar and select **My account**. Your Fleet version is
+> the avatar on the right side of the top bar and select **My account**. Your Fleet version is
 > displayed below the **Get API token** button.
 
 How to install Fleet Desktop on your hosts:

--- a/docs/Using-Fleet/Adding-hosts.md
+++ b/docs/Using-Fleet/Adding-hosts.md
@@ -40,6 +40,10 @@ Also remember to replace both `AC_USERNAME` and `AC_PASSWORD` environment variab
 
 ### Fleet Desktop
 
+> Fleet Desktop requires a Fleet version of 4.12.0 and above. To check your Fleet version, select
+> the avatar in the right-side of the top bar and select **My account**. Your Fleet version is
+> displayed below the **Get API token** button.
+
 How to install Fleet Desktop on your hosts:
 1. On the top bar in the Fleet UI, select **Hosts > Add hosts**.
 2. Select the **Include Fleet Desktop** checkbox.

--- a/docs/Using-Fleet/Automations.md
+++ b/docs/Using-Fleet/Automations.md
@@ -1,25 +1,27 @@
 # Automations
 
-You can configure automations in Fleet to send a webhook request if a certain condition is met.
+You can configure automations in Fleet to send a webhook request or create a ticket (Jira or Zendesk) if a certain condition is met.
 
-[Vulnerability automations](#vulnerability-automations) send a webhook request if a new vulnerability (CVE) is
+[Vulnerability automations](#vulnerability-automations) are triggered if a new vulnerability (CVE) is
 detected on at least one host.
 
-[Policy automations](#policy-automations) send a webhook request if a policy is newly failing on at
+[Policy automations](#policy-automations) are triggered if a policy is newly failing on at
 least one host.
 
-[Host status automations](#host-status-automations) send a webhook request if a configured
+[Host status automations](#host-status-automations) are triggered if a configured
 percentage of hosts have not checked in to Fleet for a configured number of days.
 
 ## Vulnerability automations
 
-Vulnerability automations send a webhook request if a new vulnerability (CVE) is
+Vulnerability automations are triggered if a new vulnerability (CVE) is
 found on at least one host.
 
 > Note that a CVE is "new" if it was published to the national vulnerability (NVD) database within
 > the last 30 days (by default).
 
-Fleet sends these webhook requests once every hour. If two new vulnerabilities are detected
+Fleet checks if its time to send these webhook requests, or create tickets (Jira or Zendesk), once every hour. 
+
+If two new vulnerabilities are detected
 within the hour, two
 webhook requests are sent. This interval can be updated with the [`vulnerabilities_periodicity` configuration option](../Deploying/Configuration.md#periodicity).
 
@@ -51,7 +53,7 @@ POST https://server.com/example
 }
 ```
 
-You can configure Fleet to create a Jira issue or Zendesk ticket instead of a webhook request.
+You can configure Fleet to create a ticket instead of a webhook request.
 
 Follow the steps below to configure Jira or Zendesk as a ticket destination:
 
@@ -67,13 +69,15 @@ The Jira and Zendesk ticket destinations are currently in beta.
 
 ## Policy automations
 
-Policy automations send a webhook request if a policy is newly failing on at
+Policy automations are triggered if a policy is newly failing on at
 least one host.
 
 > Note that a policy is "newly failing" if a host updated its response from "no response" to "failing"
 > or from "passing" to "failing."
 
-Fleet sends these webhook requests once per day. If two policies are newly failing
+Fleet checks if it's time to send these webhook requests, or create tickets (Jira or Zendesk), once every day. 
+
+If two policies are newly failing
 within the day, two webhook requests are sent. This interval can be updated with the `webhook_settings.interval`
 configuration option using the [`config` yaml document](./configuration-files/README.md#organization-settings) and the `fleetctl apply` command.
 
@@ -113,7 +117,19 @@ POST https://server.com/example
 }
 ```
 
-To enable policy automations, navigate to **Policies > Manage automations** in the Fleet UI.
+You can configure Fleet to create a ticket instead of a webhook request.
+
+Follow the steps below to configure Jira or Zendesk as a ticket destination:
+
+1. In the top bar of the Fleet UI, select your avatar and then **Settings**.
+2. Select **Integrations > Add integration**.
+3. Under **Ticket destination** select **Jira** or select **Zendesk**.
+4. Enter your ticket destination's credentials.
+5. In the top bar, select **Policies > Manage automations**.
+6. Select **Enable policy automations**, check the policies you'd like to listen to, and choose **Ticket**.
+7. Under **Ticket destination**, select your ticket destination and select **Save**.
+
+The Jira and Zendesk ticket destinations are currently in beta.
 
 ## Host status automations
 

--- a/docs/Using-Fleet/Automations.md
+++ b/docs/Using-Fleet/Automations.md
@@ -19,7 +19,7 @@ found on at least one host.
 > Note that a CVE is "new" if it was published to the national vulnerability (NVD) database within
 > the last 30 days (by default).
 
-Fleet checks if its time to send these webhook requests, or create tickets (Jira or Zendesk), once every hour. 
+Fleet checks if it's time to send these webhook requests, or create tickets (Jira or Zendesk), once every hour. 
 
 If two new vulnerabilities are detected
 within the hour, two


### PR DESCRIPTION
This PR shouldn't be merged until Fleet 4.16.0 is released.

- Add ticket destination instructions to "Policy automations" section: #5017 
- Add Fleet minimum server version that supports Fleet Desktop: #5694 
