### PR TITLE
Generate osqueryd target from DEB package

### DIFF
--- a/.github/workflows/generate-osqueryd-targets.yml
+++ b/.github/workflows/generate-osqueryd-targets.yml
@@ -44,8 +44,9 @@ jobs:
 
       - name: Download and extract osqueryd for linux
         run: |
-          curl -L https://github.com/osquery/osquery/releases/download/${{ env.OSQUERY_VERSION }}/osquery-${{ env.OSQUERY_VERSION }}_1.linux_x86_64.tar.gz --output osquery-${{ env.OSQUERY_VERSION }}_1.linux_x86_64.tar.gz
-          tar xf osquery-${{ env.OSQUERY_VERSION }}_1.linux_x86_64.tar.gz
+          curl -L https://github.com/osquery/osquery/releases/download/${{ env.OSQUERY_VERSION }}/osquery_${{ env.OSQUERY_VERSION }}-1.linux_amd64.deb --output osquery.deb
+          ar x osquery.deb
+          tar xf data.tar.gz
           chmod +x ./opt/osquery/bin/osqueryd
           ./opt/osquery/bin/osqueryd --version
 


### PR DESCRIPTION
The DEB packages have a stripped (smaller) binary rather than the
unstripped binary in the tarball.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [ ] Documented any permissions changes
- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
