### PR TITLE
Suggested change for set recovery window to 0

### DIFF
--- a/infrastructure/dogfood/terraform/aws/rds.tf
+++ b/infrastructure/dogfood/terraform/aws/rds.tf
@@ -6,6 +6,7 @@ resource "random_password" "database_password" {
 // possibility of providing this capability in the future.
 resource "aws_secretsmanager_secret" "database_password_secret" { #tfsec:ignore:aws-ssm-secret-use-customer-key:exp:2022-07-01
   name = "/fleet/database/password/master"
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "database_password_secret_version" {


### PR DESCRIPTION
Suggesting setting the key so failed builds can be re-applied without errors. If your terraform build fails and you need to destroy and re-apply, without a recovery window of 0, Secret Manager doesn't allow you to delete the secret and that named secret has to wait 7 days to be deleted.