### PR TITLE
Include an error code as query string in /sso/callback response in case of failure

### DIFF
--- a/changes/issue-6098-add-sso-error-code-in-redirect-to-login
+++ b/changes/issue-6098-add-sso-error-code-in-redirect-to-login
@@ -1,0 +1,1 @@
+* Added `status` query string parameter in redirect to `/login` on SSO authentication failure, to assist the frontend in displaying a helpful error message.

--- a/server/service/service_errors.go
+++ b/server/service/service_errors.go
@@ -22,7 +22,9 @@ func (a alreadyExistsError) IsExists() bool {
 	return true
 }
 
-// ssoErrCode defines a code for the type of SSO error that occurred.
+// ssoErrCode defines a code for the type of SSO error that occurred. This is
+// used to indicate to the frontend why the SSO login attempt failed so that
+// it can provide a helpful and appropriate error message.
 type ssoErrCode string
 
 // List of valid SSO error codes.

--- a/server/service/service_errors.go
+++ b/server/service/service_errors.go
@@ -30,6 +30,7 @@ const (
 	ssoOtherError      ssoErrCode = "error"
 	ssoOrgDisabled     ssoErrCode = "org_disabled"
 	ssoAccountDisabled ssoErrCode = "account_disabled"
+	ssoAccountInvalid  ssoErrCode = "account_invalid"
 )
 
 // ssoError is an error that occurs during the Single-Sign-On flow. Its code

--- a/server/service/service_errors.go
+++ b/server/service/service_errors.go
@@ -21,3 +21,28 @@ func (a alreadyExistsError) Error() string {
 func (a alreadyExistsError) IsExists() bool {
 	return true
 }
+
+// ssoErrCode defines a code for the type of SSO error that occurred.
+type ssoErrCode string
+
+// List of valid SSO error codes.
+const (
+	ssoOtherError      ssoErrCode = "error"
+	ssoOrgDisabled     ssoErrCode = "org_disabled"
+	ssoAccountDisabled ssoErrCode = "account_disabled"
+)
+
+// ssoError is an error that occurs during the Single-Sign-On flow. Its code
+// indicates the type of error.
+type ssoError struct {
+	err  error
+	code ssoErrCode
+}
+
+func (e ssoError) Error() string {
+	return string(e.code) + ": " + e.err.Error()
+}
+
+func (e ssoError) Unwrap() error {
+	return e.err
+}

--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -397,6 +397,11 @@ func (svc *Service) CallbackSSO(ctx context.Context, auth fleet.Auth) (*fleet.SS
 		return nil, ctxerr.Wrap(ctx, err, "get config for sso")
 	}
 
+	if !appConfig.SSOSettings.EnableSSO {
+		err := ctxerr.New(ctx, "organization not configured to use sso")
+		return nil, ctxerr.Wrap(ctx, ssoError{err: err, code: ssoOrgDisabled})
+	}
+
 	// Load the request metadata if available
 
 	// localhost:9080/simplesaml/saml2/idp/SSOService.php?spentityid=https://localhost:8080
@@ -454,7 +459,8 @@ func (svc *Service) CallbackSSO(ctx context.Context, auth fleet.Auth) (*fleet.SS
 	}
 	// if the user is not sso enabled they are not authorized
 	if !user.SSOEnabled {
-		return nil, ctxerr.Wrap(ctx, ssoError{err: errors.New("user not configured to use sso"), code: ssoAccountDisabled})
+		err := ctxerr.New(ctx, "user not configured to use sso")
+		return nil, ctxerr.Wrap(ctx, ssoError{err: err, code: ssoAccountDisabled})
 	}
 	session, err := svc.makeSession(ctx, user.ID)
 	if err != nil {

--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -460,6 +460,10 @@ func (svc *Service) CallbackSSO(ctx context.Context, auth fleet.Auth) (*fleet.SS
 	// Get and log in user
 	user, err := svc.ds.UserByEmail(ctx, auth.UserID())
 	if err != nil {
+		var nfe notFoundErrorInterface
+		if errors.As(err, &nfe) {
+			return nil, ctxerr.Wrap(ctx, ssoError{err: err, code: ssoAccountInvalid})
+		}
 		return nil, ctxerr.Wrap(ctx, err, "find user in sso callback")
 	}
 	// if the user is not sso enabled they are not authorized


### PR DESCRIPTION
#6098 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] ~~Documented any API changes (docs/Using-Fleet/REST-API.md)~~
- [ ] ~~Documented any permissions changes~~
- [x] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [ ] ~~Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~~
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality (tested locally with SimpleSAML and curl: valid sso user, sso user unknown in fleet, sso user known in fleet but with SSO disabled, calling callback with SSO disabled for fleet)
