### PR TITLE
Add support for CA root certificate to Fleet Desktop (`fleetctl package`'s `--fleet-certificate` flag)

### DIFF
--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -64,10 +64,9 @@ func main() {
 		if os.Getenv("FLEET_DESKTOP_INSECURE") != "" {
 			insecureSkipVerify = true
 		}
+		rootCA := os.Getenv("FLEET_DESKTOP_FLEET_ROOT_CA")
 
-		// TODO: figure out the right rootCA to pass to the client
-		client, err := service.NewDeviceClient(basePath, deviceToken, insecureSkipVerify, "")
-
+		client, err := service.NewDeviceClient(basePath, deviceToken, insecureSkipVerify, rootCA)
 		if err != nil {
 			log.Fatal().Err(err).Msg("unable to initialize request client")
 		}
@@ -175,7 +174,7 @@ func setupLogs() {
 
 	dir = filepath.Join(dir, "Fleet")
 
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		log.Logger = log.Output(stderrOut)
 		log.Error().Err(err).Msg("make directories for log files")
 		return

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -31,7 +31,6 @@ func NewClient(addr string, insecureSkipVerify bool, rootCA, urlPrefix string, o
 	// TODO #265 refactor all optional parameters to functional options
 	// API breaking change, needs a major version release
 	baseClient, err := newBaseClient(addr, insecureSkipVerify, rootCA, urlPrefix)
-
 	if err != nil {
 		return nil, err
 	}

--- a/server/service/device_client.go
+++ b/server/service/device_client.go
@@ -22,7 +22,6 @@ func (dc *DeviceClient) request(verb string, path string, query string, response
 		dc.url(path, query).String(),
 		bytes.NewBuffer(bodyBytes),
 	)
-
 	if err != nil {
 		return err
 	}
@@ -37,14 +36,16 @@ func (dc *DeviceClient) request(verb string, path string, query string, response
 }
 
 // NewDeviceClient instantiates a new client to perform requests against device endpoints
-func NewDeviceClient(addr string, token string, insecureSkipVerify bool, rootCA string) (*DeviceClient, error) {
+func NewDeviceClient(addr, token string, insecureSkipVerify bool, rootCA string) (*DeviceClient, error) {
 	baseClient, err := newBaseClient(addr, insecureSkipVerify, rootCA, "")
-
 	if err != nil {
 		return nil, err
 	}
 
-	return &DeviceClient{baseClient: baseClient, token: token}, nil
+	return &DeviceClient{
+		baseClient: baseClient,
+		token:      token,
+	}, nil
 }
 
 // ListDevicePolicies fetches all policies for the device with the provided token

--- a/tools/tuf/test/README.md
+++ b/tools/tuf/test/README.md
@@ -9,20 +9,21 @@ Scripts in this directory aim to ease the testing of Orbit and the [TUF](https:/
 The `main.sh` creates and runs the TUF repository and optionally generate the installers (GENERATE_PKGS):
 ```sh
 SYSTEMS="macos windows linux" \
-PKG_FLEET_URL=https://127.0.0.1:8080 \
-PKG_TUF_URL=http://127.0.0.1:8081 \
-DEB_FLEET_URL=https://172.16.132.1:8080 \
-DEB_TUF_URL=http://172.16.132.1:8081 \
-RPM_FLEET_URL=https://172.16.132.1:8080 \
-RPM_TUF_URL=http://172.16.132.1:8081 \
-MSI_FLEET_URL=https://172.16.132.1:8080 \
-MSI_TUF_URL=http://172.16.132.1:8081 \
+PKG_FLEET_URL=https://localhost:8080 \
+PKG_TUF_URL=http://localhost:8081 \
+DEB_FLEET_URL=https://host.docker.internal:8080 \
+DEB_TUF_URL=http://host.docker.internal:8081 \
+RPM_FLEET_URL=https://host.docker.internal:8080 \
+RPM_TUF_URL=http://host.docker.internal:8081 \
+MSI_FLEET_URL=https://host.docker.internal:8080 \
+MSI_TUF_URL=http://host.docker.internal:8081 \
 GENERATE_PKG=1 \
 GENERATE_DEB=1 \
 GENERATE_RPM=1 \
 GENERATE_MSI=1 \
 ENROLL_SECRET=6/EzU/+jPkxfTamWnRv1+IJsO4T9Etju \
 FLEET_DESKTOP=1 \
+FLEET_CERTIFICATE=1 \
 ./tools/tuf/test/main.sh
 ```
 
@@ -30,7 +31,10 @@ Separate `*_FLEET_URL` and `*_TUF_URL` variables are needed for each package to 
 E.g. The values shown above assume:
 1. The script is executed on a macOS host.
 2. Fleet server also running on the same macOS host.
-3. Three VMs running on the macOS host where the access IP to host is `172.16.132.1`.
+3. All VMs (and the macOS host itself) are configured to resolve `host.docker.internal` to the macOS host IP (by modifying their `hosts` file).
+
+> PS: We use `host.docker.internal` because the testing certificate `./tools/osquery/fleet.crt`
+> has such hostname (and `localhost`) defined as SANs.
 
 # Add new updates
 

--- a/tools/tuf/test/gen_pkgs.sh
+++ b/tools/tuf/test/gen_pkgs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 # This script generates fleet-osquery packages for all supported platforms
 # using the specified TUF server.
@@ -25,6 +25,12 @@ set -e
 # ENROLL_SECRET: Fleet server enroll secret.
 # ROOT_KEYS: TUF repository root keys.
 # FLEET_DESKTOP: Whether to build with Fleet Desktop support. 
+# FLEET_CERTIFICATE: Whether to use a custom certificate bundle. If not set, then --insecure mode is used.
+
+TLS_FLAG="--insecure"
+if [ -n "$FLEET_CERTIFICATE" ]; then
+    TLS_FLAG="--fleet-certificate=./tools/osquery/fleet.crt"
+fi
 
 if [ -n "$GENERATE_PKG" ]; then
     echo "Generating pkg..."
@@ -33,7 +39,7 @@ if [ -n "$GENERATE_PKG" ]; then
         ${FLEET_DESKTOP:+--fleet-desktop} \
         --fleet-url=$PKG_FLEET_URL \
         --enroll-secret=$ENROLL_SECRET \
-        --fleet-certificate=./tools/osquery/fleet.crt \
+        ${TLS_FLAG} \
         --debug \
         --update-roots="$ROOT_KEYS" \
         --update-interval=10s \
@@ -48,7 +54,7 @@ if [ -n "$GENERATE_DEB" ]; then
         ${FLEET_DESKTOP:+--fleet-desktop} \
         --fleet-url=$DEB_FLEET_URL \
         --enroll-secret=$ENROLL_SECRET \
-        --fleet-certificate=./tools/osquery/fleet.crt \
+        ${TLS_FLAG} \
         --debug \
         --update-roots="$ROOT_KEYS" \
         --update-interval=10s \
@@ -63,7 +69,7 @@ if [ -n "$GENERATE_RPM" ]; then
         ${FLEET_DESKTOP:+--fleet-desktop} \
         --fleet-url=$RPM_FLEET_URL \
         --enroll-secret=$ENROLL_SECRET \
-        --fleet-certificate=./tools/osquery/fleet.crt \
+        ${TLS_FLAG} \
         --debug \
         --update-roots="$ROOT_KEYS" \
         --update-interval=10s \
@@ -78,7 +84,7 @@ if [ -n "$GENERATE_MSI" ]; then
         ${FLEET_DESKTOP:+--fleet-desktop} \
         --fleet-url=$MSI_FLEET_URL \
         --enroll-secret=$ENROLL_SECRET \
-        --fleet-certificate=./tools/osquery/fleet.crt \
+        ${TLS_FLAG} \
         --debug \
         --update-roots="$ROOT_KEYS" \
         --update-interval=10s \

--- a/tools/tuf/test/gen_pkgs.sh
+++ b/tools/tuf/test/gen_pkgs.sh
@@ -33,7 +33,7 @@ if [ -n "$GENERATE_PKG" ]; then
         ${FLEET_DESKTOP:+--fleet-desktop} \
         --fleet-url=$PKG_FLEET_URL \
         --enroll-secret=$ENROLL_SECRET \
-        --insecure \
+        --fleet-certificate=./tools/osquery/fleet.crt \
         --debug \
         --update-roots="$ROOT_KEYS" \
         --update-interval=10s \
@@ -48,7 +48,7 @@ if [ -n "$GENERATE_DEB" ]; then
         ${FLEET_DESKTOP:+--fleet-desktop} \
         --fleet-url=$DEB_FLEET_URL \
         --enroll-secret=$ENROLL_SECRET \
-        --insecure \
+        --fleet-certificate=./tools/osquery/fleet.crt \
         --debug \
         --update-roots="$ROOT_KEYS" \
         --update-interval=10s \
@@ -63,7 +63,7 @@ if [ -n "$GENERATE_RPM" ]; then
         ${FLEET_DESKTOP:+--fleet-desktop} \
         --fleet-url=$RPM_FLEET_URL \
         --enroll-secret=$ENROLL_SECRET \
-        --insecure \
+        --fleet-certificate=./tools/osquery/fleet.crt \
         --debug \
         --update-roots="$ROOT_KEYS" \
         --update-interval=10s \
@@ -78,7 +78,7 @@ if [ -n "$GENERATE_MSI" ]; then
         ${FLEET_DESKTOP:+--fleet-desktop} \
         --fleet-url=$MSI_FLEET_URL \
         --enroll-secret=$ENROLL_SECRET \
-        --insecure \
+        --fleet-certificate=./tools/osquery/fleet.crt \
         --debug \
         --update-roots="$ROOT_KEYS" \
         --update-interval=10s \


### PR DESCRIPTION
#6280

~- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).~
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
~- [ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality

Changes tested on CentOS 7, Ubuntu 22, Windows 10 and macOS 12.4.
Also verified that, when using `--fleet-certificate`, Fleet Desktop doesn't connect if I change Fleet's certificate.

