### PR TITLE
Fix Fleet Desktop opening of URL on Ubuntu 21/22

### DIFF
--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -36,6 +36,13 @@ func run(path string, opts eopts) error {
 		// multi-user/multi-session support. This assumes there's only
 		// one desktop session and belongs to the user returned in `getLoginUID'.
 		"DISPLAY=:0",
+		// DBUS_SESSION_BUS_ADDRESS sets the location of the user login session bus.
+		// Required by the libayatana-appindicator3 library to display a tray icon
+		// on the desktop session.
+		//
+		// This is required for Ubuntu 18, and not required for Ubuntu 21/22
+		// (because it's already part of the user).
+		fmt.Sprintf("DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%d/bus", user.id),
 		// Append the packaged libayatana-appindicator3 libraries path to LD_LIBRARY_PATH.
 		fmt.Sprintf("LD_LIBRARY_PATH=%s:%s", filepath.Dir(path), os.ExpandEnv("$LD_LIBRARY_PATH")),
 		path,

--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -24,19 +24,19 @@ func run(path string, opts eopts) error {
 		Int64("id", user.id).
 		Msg("running sudo")
 
-	arg := []string{"-u", user.name, "-H"}
+	// Flag `-i` is needed to run the command with the user's context, from `man sudo`:
+	// "The command is run with an environment similar to the one a user would receive at log in"
+	arg := []string{"-i", "-u", user.name, "-H"}
 	for _, nv := range opts.env {
 		arg = append(arg, fmt.Sprintf("%s=%s", nv[0], nv[1]))
 	}
+
 	arg = append(arg,
 		// TODO(lucas): Default to display 0, revisit when working on
 		// multi-user/multi-session support. This assumes there's only
 		// one desktop session and belongs to the user returned in `getLoginUID'.
 		"DISPLAY=:0",
-		// DBUS_SESSION_BUS_ADDRESS sets the location of the user login session bus.
-		// Required by the libayatana-appindicator3 library to display a tray icon
-		// on the desktop session.
-		fmt.Sprintf("DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%d/bus", user.id),
+		// Append the packaged libayatana-appindicator3 libraries path to LD_LIBRARY_PATH.
 		fmt.Sprintf("LD_LIBRARY_PATH=%s:%s", filepath.Dir(path), os.ExpandEnv("$LD_LIBRARY_PATH")),
 		path,
 	)

--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -307,10 +307,15 @@ func writePreRemove(opt Options, path string) error {
 	// We add `|| true` in case the service is not running
 	// or has been manually disabled already. Otherwise,
 	// uninstallation fails.
+	//
+	// "pkill fleet-desktop" is required because the application
+	// runs as user (separate from sudo command that launched it),
+	// so on some systems it's not killed properly.
 	if err := ioutil.WriteFile(path, []byte(`#!/bin/sh
 
 systemctl stop orbit.service || true
 systemctl disable orbit.service || true
+pkill fleet-desktop || true
 `), constant.DefaultFileMode); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}


### PR DESCRIPTION
#5716

~- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).~
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
~- [ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality
