### PR TITLE
Orbit Packaging: Add support for distros without systemd

### DIFF
--- a/orbit/changes/add-support-for-distros-without-systemd
+++ b/orbit/changes/add-support-for-distros-without-systemd
@@ -1,0 +1,2 @@
+* Added /etc/init.d/orbit init script to the package
+* Corrected pre-remove and post-remove files to handle absense of systemctl

--- a/orbit/pkg/constant/constant.go
+++ b/orbit/pkg/constant/constant.go
@@ -7,6 +7,8 @@ const (
 	DefaultFileMode = 0o600
 	// DefaultSystemdUnitMode is the required file mode to systemd unit files.
 	DefaultSystemdUnitMode = 0o644
+	// DefaultInitScriptMode is the required file mode to init.d script files.
+	DefaultInitScriptMode = 0o755
 	// DesktopAppExecName is the name of Fleet's Desktop executable.
 	//
 	// We use fleet-desktop as name to properly identify the process when listing

--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -202,6 +202,130 @@ func buildNFPM(opt Options, pkger nfpm.Packager) (string, error) {
 	return filename, nil
 }
 
+func writeInitScript(opt Options, rootPath string) error {
+	systemdRoot := filepath.Join(rootPath, "etc", "init.d")
+	if err := secure.MkdirAll(systemdRoot, constant.DefaultDirMode); err != nil {
+		return fmt.Errorf("create systemd dir: %w", err)
+	}
+	if err := ioutil.WriteFile(
+		filepath.Join(systemdRoot, "orbit"),
+		[]byte(`#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          orbit
+# Required-Start:    $remote_fs $network
+# Required-Stop:     $remote_fs $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: orbit osquery control daemon
+# Description:       This is a daemon that controls the orbit osquery
+### END INIT INFO
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin:/opt/orbit/bin/orbit/linux/stable
+DESC="orbit osquery control daemon"
+NAME=orbit
+DAEMON=/opt/orbit/bin/orbit/linux/stable/orbit
+DAEMON_ARGS=""
+PIDFILE=/opt/orbit/osquery.pid
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 0
+
+set -a
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+. /lib/lsb/init-functions
+
+set +a
+
+do_start() {
+    # Return
+    #   0 if daemon has been started
+    #   1 if daemon was already running
+    #   2 if daemon could not be started
+    pid=$(pidofproc -p $PIDFILE $DAEMON)
+    if [ -n "$pid" ] ; then
+        return 1
+    fi
+
+    start-stop-daemon --start --quiet --background --pidfile $PIDFILE --exec $DAEMON -- \
+            $DAEMON_ARGS \
+            || return 2
+}
+
+do_stop() {
+    # Return
+    #   0 if daemon has been stopped
+    #   1 if daemon was already stopped
+    #   2 if daemon could not be stopped
+    #   other if a failure occurred
+    start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE
+    RETVAL="$?"
+    [ "$RETVAL" = 2 ] && return 2
+    rm -f $PIDFILE
+    return "$RETVAL"
+}
+
+case "$1" in
+    start)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+        do_start
+        case "$?" in
+            0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+              2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+        esac
+        ;;
+    stop)
+        [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+        do_stop
+        case "$?" in
+            0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+              2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+        esac
+        ;;
+    status)
+        status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+        ;;
+    #reload)
+        # not implemented
+        #;;
+    restart|force-reload)
+        log_daemon_msg "Restarting $DESC" "$NAME"
+        do_stop
+        case "$?" in
+          0|1)
+              do_start
+              case "$?" in
+                  0) log_end_msg 0 ;;
+                  1) log_end_msg 1 ;; # Old process is still running
+                  *) log_end_msg 1 ;; # Failed to start
+              esac
+              ;;
+          *)
+              # Failed to stop
+              log_end_msg 1
+              ;;
+        esac
+        ;;
+    *)
+        echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+        exit 3
+        ;;
+esac
+
+exit 0
+
+`),
+		constant.DefaultInitScriptMode,
+	); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+
+	return nil
+}
+
 func writeSystemdUnit(opt Options, rootPath string) error {
 	systemdRoot := filepath.Join(rootPath, "usr", "lib", "systemd", "system")
 	if err := secure.MkdirAll(systemdRoot, constant.DefaultDirMode); err != nil {
@@ -287,6 +411,12 @@ if command -v systemctl >/dev/null 2>&1; then
   systemctl restart orbit.service 2>&1
   systemctl enable orbit.service 2>&1
 {{- end}}
+else
+    update-rc.d -f orbit defaults 2>&1
+    update-rc.d -f orbit enable 2>&1
+	{{ if .StartService -}}
+    service orbit start 2>&1
+	{{- end}}
 fi
 `))
 
@@ -308,9 +438,14 @@ func writePreRemove(opt Options, path string) error {
 	// or has been manually disabled already. Otherwise,
 	// uninstallation fails.
 	if err := ioutil.WriteFile(path, []byte(`#!/bin/sh
-
-systemctl stop orbit.service || true
-systemctl disable orbit.service || true
+if command -v systemctl >/dev/null 2>&1; then
+	systemctl stop orbit.service || true
+	systemctl disable orbit.service || true
+else
+	service orbit stop
+	update-rc.d orbit disable
+	update-rc.d orbit remove
+fi
 `), constant.DefaultFileMode); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}


### PR DESCRIPTION
* Added /etc/init.d/orbit init script to the generated package
* Corrected pre-remove and post-install scripts to handle absense of systemctl 
