### PR TITLE
Fix mock tests set test name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "2"
 services:
   # To test with MariaDB, set FLEET_MYSQL_IMAGE to mariadb:10.6 or the like.
   mysql:
-    image: ${FLEET_MYSQL_IMAGE:-mysql:5.7.21}
+    image: ${FLEET_MYSQL_IMAGE:-mysql:5.7}
     platform: linux/x86_64
     volumes:
       - mysql-persistent-volume:/tmp
@@ -25,7 +25,7 @@ services:
       - "3306:3306"
 
   mysql_test:
-    image: ${FLEET_MYSQL_IMAGE:-mysql:5.7.21}
+    image: ${FLEET_MYSQL_IMAGE:-mysql:5.7}
     platform: linux/x86_64
     # innodb-file-per-table=OFF gives ~20% speedup for test runs.
     command: [

--- a/server/service/integration_live_queries_test.go
+++ b/server/service/integration_live_queries_test.go
@@ -35,6 +35,12 @@ type liveQueriesTestSuite struct {
 	hosts []*fleet.Host
 }
 
+// SetupTest partially implements suite.SetupTestSuite.
+func (s *liveQueriesTestSuite) SetupTest() {
+	s.lq.Mock.Test(s.T())
+}
+
+// SetupSuite partially implements suite.SetupAllSuite.
 func (s *liveQueriesTestSuite) SetupSuite() {
 	require.NoError(s.T(), os.Setenv("FLEET_LIVE_QUERY_REST_PERIOD", "5s"))
 
@@ -66,6 +72,7 @@ func (s *liveQueriesTestSuite) SetupSuite() {
 	}
 }
 
+// TearDownTest partially implements suite.TearDownTestSuite.
 func (s *liveQueriesTestSuite) TearDownTest() {
 	// reset the mock
 	s.lq.Mock = mock.Mock{}


### PR DESCRIPTION
- On #6197 I missed setting the `*testing.T` on each test.
- On my macOS I have to always change the docker-compose.yml to use 5.7 (5.7.21 doesn't work for me.). I believe this is a-ok as CI tests with the point version: 
https://github.com/fleetdm/fleet/blob/c8e07fdc6f801e295bd2a888bc8200c680dee32e/.github/workflows/test-go.yaml#L20-L27