### PR TITLE
Linking to "Using Figma" on Brand page

### DIFF
--- a/handbook/product.md
+++ b/handbook/product.md
@@ -94,7 +94,9 @@ policies that any organization needs(Miss).
 
 The product team is responsible for product design tasks. These include drafting
 changes to the Fleet product, reviewing and collecting feedback from engineering, sales, customer success, and marketing counterparts, and delivering
-these changes to the engineering team.
+these changes to the engineering team. 
+
+Look here for more information about [Using Figma](https://fleetdm.com/handbook/brand#fleet-website).
 
 ### Drafting
 


### PR DESCRIPTION
As per:
- https://github.com/fleetdm/confidential/issues/214

@noahtalerman, We are just linking to this for now rather than duplicating it. The handbook's format will eventually change and this will be included in a new way. 