### PR TITLE
Update Fleet host detail query so `os_version` for Ubuntu hosts reflects accurate patch number in point release

### DIFF
--- a/changes/issue-4816-ubuntu-patch-id
+++ b/changes/issue-4816-ubuntu-patch-id
@@ -1,0 +1,2 @@
+- Update Fleet host detail query so `os_version` for Ubuntu hosts reflects the accurate patch number in the
+  point release

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -130,7 +130,7 @@ var hostDetailQueries = map[string]DetailQuery{
 				return nil
 			}
 
-			if rows[0]["name"] == "Ubuntu" {
+			if strings.Contains(strings.ToLower(rows[0]["name"]), "ubuntu") {
 				// Ubuntu takes a different approach to updating patch IDs so we instead use
 				// the version string provided after removing the code name
 				regx := regexp.MustCompile(`\(.*\)`)

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -129,7 +130,17 @@ var hostDetailQueries = map[string]DetailQuery{
 				return nil
 			}
 
-			if rows[0]["major"] != "0" || rows[0]["minor"] != "0" || rows[0]["patch"] != "0" {
+			if rows[0]["name"] == "Ubuntu" {
+				// Ubuntu takes a different approach to updating patch IDs so we instead use
+				// the version string provided after removing the code name
+				regx := regexp.MustCompile(`\(.*\)`)
+				vers := regx.ReplaceAllString(rows[0]["version"], "")
+				host.OSVersion = fmt.Sprintf(
+					"%s %s",
+					rows[0]["name"],
+					strings.TrimSpace(vers),
+				)
+			} else if rows[0]["major"] != "0" || rows[0]["minor"] != "0" || rows[0]["patch"] != "0" {
 				host.OSVersion = fmt.Sprintf(
 					"%s %s.%s.%s",
 					rows[0]["name"],

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -371,6 +371,27 @@ func TestDetailQueriesOSVersion(t *testing.T) {
 
 	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, rows))
 	assert.Equal(t, "Arch Linux 1.2.3", host.OSVersion)
+
+	// Simulate Ubuntu host with incorrect `patch`` number
+	require.NoError(t, json.Unmarshal([]byte(`
+[{
+    "hostname": "kube2",
+    "arch": "x86_64",
+    "build": "",
+    "codename": "bionic",
+    "major": "18",
+    "minor": "4",
+    "name": "Ubuntu",
+    "patch": "0",
+    "platform": "ubuntu",
+    "platform_like": "debian",
+    "version": "18.04.5 LTS (Bionic Beaver)"
+}]`),
+		&rows,
+	))
+
+	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, rows))
+	assert.Equal(t, "Ubuntu 18.04.5 LTS", host.OSVersion)
 }
 
 func TestDirectIngestMDM(t *testing.T) {


### PR DESCRIPTION
Issue #4816

# Checklist for submitter
- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
