### PR TITLE
Update SQL syntax highlighting in UI to display `last` as osquery table rather than keyword

### DIFF
--- a/changes/issue-6289-fix-table-name-collision-UI
+++ b/changes/issue-6289-fix-table-name-collision-UI
@@ -1,0 +1,1 @@
+- Update UI SQL syntax highlighting to display `last` as an osquery table rather than keyword

--- a/frontend/components/FleetAce/mode.ts
+++ b/frontend/components/FleetAce/mode.ts
@@ -25,8 +25,10 @@ ace.define(
 
       var builtinConstants = "true|false";
 
+      // Note: `last` was removed from the list of built-in functions because it collides with the
+      // `last` table available in osquery
       var builtinFunctions =
-        "avg|count|first|last|max|min|sum|ucase|lcase|mid|len|round|rank|now|format|" +
+        "avg|count|first|max|min|sum|ucase|lcase|mid|len|round|rank|now|format|" +
         "coalesce|ifnull|isnull|nvl";
 
       var dataTypes =


### PR DESCRIPTION
Issue #6269

# Checklist for submitter
- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
