### PR TITLE
Fix false negatives for os version policies generated by UI 

### DIFF
--- a/changes/issue-6373-os-version-policy-sql
+++ b/changes/issue-6373-os-version-policy-sql
@@ -1,0 +1,1 @@
+- Fixed SQL generated for OS version policies to reduce false negatice

--- a/changes/issue-6373-os-version-policy-sql
+++ b/changes/issue-6373-os-version-policy-sql
@@ -1,1 +1,1 @@
-- Fixed SQL generated for OS version policies to reduce false negatice
+- Fixed SQL generated for OS version policies to reduce false negatives

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -54,6 +54,8 @@ import PolicyDetailsModal from "../cards/Policies/HostPoliciesTable/PolicyDetail
 import DeleteHostModal from "./modals/DeleteHostModal";
 import RenderOSPolicyModal from "./modals/OSPolicyModal";
 
+import parseOsVersion from "./modals/OSPolicyModal/helpers";
+
 import BackChevron from "../../../../../assets/images/icon-chevron-down-9x6@2x.png";
 import DeleteIcon from "../../../../../assets/images/icon-action-delete-14x14@2x.png";
 import QueryIcon from "../../../../../assets/images/icon-action-query-16x16@2x.png";
@@ -328,15 +330,7 @@ const HostDetailsPage = ({
     ])
   );
 
-  const operatingSystem = host?.os_version.slice(
-    0,
-    host?.os_version.lastIndexOf(" ")
-  );
-  const operatingSystemVersion = host?.os_version.slice(
-    host?.os_version.lastIndexOf(" ") + 1
-  );
-  const osPolicyLabel = `Is ${operatingSystem}, version ${operatingSystemVersion} or later, installed?`;
-  const osPolicy = `SELECT 1 from os_version WHERE name = '${operatingSystem}' AND major || '.' || minor || '.' || patch >= '${operatingSystemVersion}';`;
+  const [osPolicyLabel, osPolicyQuery] = parseOsVersion(host?.os_version);
 
   const aboutData = normalizeEmptyValues(
     pick(host, [
@@ -385,7 +379,7 @@ const HostDetailsPage = ({
     setLastEditedQueryDescription(
       "Checks to see if the required minimum operating system version is installed."
     );
-    setLastEditedQueryBody(osPolicy);
+    setLastEditedQueryBody(osPolicyQuery);
     setLastEditedQueryResolution("");
     router.replace(NEW_POLICY);
   };
@@ -648,7 +642,7 @@ const HostDetailsPage = ({
           onCancel={() => setShowOSPolicyModal(false)}
           onCreateNewPolicy={onCreateNewPolicy}
           titleData={titleData}
-          osPolicy={osPolicy}
+          osPolicy={osPolicyQuery}
           osPolicyLabel={osPolicyLabel}
         />
       )}

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/OSPolicyModal/helpers.ts
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/OSPolicyModal/helpers.ts
@@ -1,0 +1,41 @@
+/**
+ * parseOsVersion accepts an `os_version` string (e.g., "Ubuntu 16.04.7" or "CentOS 8.3.2011") and
+ * returns the label text and SQL strings expected by the `OSPolicyModal`.
+ */
+export const parseOsVersion = (os_version = ""): string[] => {
+  let name = "";
+  let version = "";
+
+  if (os_version.startsWith("Ubuntu")) {
+    // Ubuntu `os_version` may contain additional text after the point release (e.g., "Ubuntu
+    // 16.04.7 LTS")
+    name = "Ubuntu";
+    version = os_version
+      .replace("Ubuntu ", "")
+      .slice(0, os_version.indexOf(" ") + 1)
+      .trim();
+  } else {
+    name = os_version.slice(0, os_version.lastIndexOf(" "));
+    version = os_version.slice(os_version.lastIndexOf(" ") + 1);
+  }
+
+  // Each component of the point release must be compared as a number because simple string comparisons
+  // yield unexpected results (e.g., the string "10.0.0" is considered less than "9.0.0")
+  const [major, minor, patch] = version
+    .split(".")
+    .map((str) => parseInt(str, 10) || str || 0); // parseInt if possible, else use the string value, or use zero if empty or undefined
+
+  const policyLabel = `Is ${name}, version ${version} or later, installed?`;
+
+  const policyQuery = `SELECT 1 from os_version WHERE instr(lower(name), '${name.toLowerCase()}') AND (major > ${major} OR (major = ${major} AND (minor > ${minor} OR (minor = ${minor} AND ${
+    // For Ubuntu, the osquery `patch` field is not updated so we need to parse the `version` string
+    // using more complicated SQLite dialect
+    name !== "Ubuntu"
+      ? `patch >= ${patch}`
+      : `cast(replace(substr(substr(version, instr(version, '.')+1), instr(substr(version, instr(version, '.')+1), '.')+1), substr(version, instr(version, ' ')), '') as integer) >= ${patch}`
+  }))));`;
+
+  return [policyLabel, policyQuery];
+};
+
+export default parseOsVersion;


### PR DESCRIPTION
Issue #6373 

Fix false negatives in SQL generated by UI for OS version policies (e.g., "Is Ubuntu, version 16.04.7 or later, installed?")
- Each component of the point release must be compared as a number because simple string comparisons yield unexpected results (e.g., the string "10.0.0" is considered less than "9.0.0")
- For Ubuntu, the osquery `patch` field is not updated so we need to parse the `version` string using more complicated SQLite dialect


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [ ] Documented any permissions changes
- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
