### PR TITLE
Show failed policies count in Fleet Desktop

### DIFF
--- a/orbit/changes/issue-6161-show-failing-policy-count-in-fleet-desktop
+++ b/orbit/changes/issue-6161-show-failing-policy-count-in-fleet-desktop
@@ -1,0 +1,1 @@
+* Updated the dropdown in Fleet Desktop to now show the number of failing policies along with the status

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -124,15 +124,18 @@ func main() {
 					continue
 				}
 
-				status := "🟢"
+				failedPolicyCount := 0
 				for _, policy := range policies {
 					if policy.Response != "pass" {
-						status = "🔴"
-						break
+						failedPolicyCount++
 					}
 				}
 
-				myDeviceItem.SetTitle(status + " My device")
+				if failedPolicyCount > 0 {
+					myDeviceItem.SetTitle("🔴 My device " + fmt.Sprintf("(%d)", failedPolicyCount))
+				} else {
+					myDeviceItem.SetTitle("🟢 My device")
+				}
 				myDeviceItem.Enable()
 			}
 		}()

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -132,7 +132,7 @@ func main() {
 				}
 
 				if failedPolicyCount > 0 {
-					myDeviceItem.SetTitle("🔴 My device " + fmt.Sprintf("(%d)", failedPolicyCount))
+					myDeviceItem.SetTitle(fmt.Sprintf("🔴 My device (%d)", failedPolicyCount))
 				} else {
 					myDeviceItem.SetTitle("🟢 My device")
 				}


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality

Implements #6168 