### PR TITLE
Dashboard UI: Update error states

### DIFF
--- a/changes/issue-5086-dashboard-error-states
+++ b/changes/issue-5086-dashboard-error-states
@@ -1,0 +1,1 @@
+- Improve error states on dashboard

--- a/frontend/components/DataError/DataError.tsx
+++ b/frontend/components/DataError/DataError.tsx
@@ -8,10 +8,14 @@ import ErrorIcon from "../../../assets/images/icon-error-16x16@2x.png";
 
 const baseClass = "data-error";
 
-const DataError = (): JSX.Element => {
+interface IDataErrorProps {
+  noMargin?: boolean;
+}
+
+const DataError = ({ noMargin }: IDataErrorProps): JSX.Element => {
   return (
     <div className={`${baseClass}`}>
-      <div className={`${baseClass}__inner`}>
+      <div className={`${baseClass}__${noMargin ? "no-margin" : "inner"}`}>
         <div className="info">
           <span className="info__header">
             <img src={ErrorIcon} alt="error icon" id="error-icon" />

--- a/frontend/components/DataError/DataError.tsx
+++ b/frontend/components/DataError/DataError.tsx
@@ -25,7 +25,7 @@ const DataError = ({ card }: IDataErrorProps): JSX.Element => {
           <span className="info__data">
             If this keeps happening, please&nbsp;
             <a
-              href="https://github.com/fleetdm/fleet/issues"
+              href="https://github.com/fleetdm/fleet/issues/new/choose"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/frontend/components/DataError/DataError.tsx
+++ b/frontend/components/DataError/DataError.tsx
@@ -9,13 +9,13 @@ import ErrorIcon from "../../../assets/images/icon-error-16x16@2x.png";
 const baseClass = "data-error";
 
 interface IDataErrorProps {
-  noMargin?: boolean;
+  card?: boolean;
 }
 
-const DataError = ({ noMargin }: IDataErrorProps): JSX.Element => {
+const DataError = ({ card }: IDataErrorProps): JSX.Element => {
   return (
     <div className={`${baseClass}`}>
-      <div className={`${baseClass}__${noMargin ? "no-margin" : "inner"}`}>
+      <div className={`${baseClass}__${card ? "card" : "inner"}`}>
         <div className="info">
           <span className="info__header">
             <img src={ErrorIcon} alt="error icon" id="error-icon" />

--- a/frontend/components/DataError/_styles.scss
+++ b/frontend/components/DataError/_styles.scss
@@ -23,7 +23,7 @@
     text-decoration: none;
   }
 
-  &__no-margin {
+  &__card {
     display: flex;
     flex-direction: row;
     margin: $pad-large 0 0;

--- a/frontend/components/DataError/_styles.scss
+++ b/frontend/components/DataError/_styles.scss
@@ -2,7 +2,6 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: $pad-xxxlarge 0;
 
   #error-icon {
     height: 12px;
@@ -24,9 +23,16 @@
     text-decoration: none;
   }
 
+  &__no-margin {
+    display: flex;
+    flex-direction: row;
+    margin: $pad-large 0 0;
+  }
+
   &__inner {
     display: flex;
     flex-direction: row;
+    margin: $pad-xxxlarge 0;
   }
 
   .info {

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -58,7 +58,6 @@ const Homepage = (): JSX.Element => {
     false
   );
   const [showHostsUI, setShowHostsUI] = useState<boolean>(false); // Hides UI on first load only
-  const [showHostsError, setShowHostsError] = useState<boolean>(false);
 
   const { data: teams } = useQuery<ILoadTeamsResponse, Error, ITeam[]>(
     ["teams"],
@@ -75,11 +74,11 @@ const Homepage = (): JSX.Element => {
     }
   );
 
-  const { data: hostSummaryData, isFetching: isHostSummaryFetching } = useQuery<
-    IHostSummary,
-    Error,
-    IHostSummary
-  >(
+  const {
+    data: hostSummaryData,
+    isFetching: isHostSummaryFetching,
+    error: errorHosts,
+  } = useQuery<IHostSummary, Error, IHostSummary>(
     ["host summary", currentTeam, selectedPlatform],
     () =>
       hostSummaryAPI.getSummary({
@@ -106,9 +105,6 @@ const Homepage = (): JSX.Element => {
         setLinuxCount(data.all_linux_count);
         setShowHostsUI(true);
       },
-      onError: () => {
-        setShowHostsError(true);
-      },
     }
   );
 
@@ -124,7 +120,7 @@ const Homepage = (): JSX.Element => {
       text: "View all hosts",
     },
     total_host_count: (() => {
-      if (!isHostSummaryFetching && !showHostsError) {
+      if (!isHostSummaryFetching && !errorHosts) {
         return `${hostSummaryData?.totals_hosts_count}` || undefined;
       }
 
@@ -141,7 +137,7 @@ const Homepage = (): JSX.Element => {
         showHostsUI={showHostsUI}
         selectedPlatform={selectedPlatform}
         labels={labels}
-        showHostsError={showHostsError}
+        errorHosts={!!errorHosts}
       />
     ),
   });

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -58,6 +58,7 @@ const Homepage = (): JSX.Element => {
     false
   );
   const [showHostsUI, setShowHostsUI] = useState<boolean>(false); // Hides UI on first load only
+  const [showHostsError, setShowHostsError] = useState<boolean>(false);
 
   const { data: teams } = useQuery<ILoadTeamsResponse, Error, ITeam[]>(
     ["teams"],
@@ -105,6 +106,9 @@ const Homepage = (): JSX.Element => {
         setLinuxCount(data.all_linux_count);
         setShowHostsUI(true);
       },
+      onError: () => {
+        setShowHostsError(true);
+      },
     }
   );
 
@@ -120,7 +124,7 @@ const Homepage = (): JSX.Element => {
       text: "View all hosts",
     },
     total_host_count: (() => {
-      if (!isHostSummaryFetching) {
+      if (!isHostSummaryFetching && !showHostsError) {
         return `${hostSummaryData?.totals_hosts_count}` || undefined;
       }
 
@@ -137,6 +141,7 @@ const Homepage = (): JSX.Element => {
         showHostsUI={showHostsUI}
         selectedPlatform={selectedPlatform}
         labels={labels}
+        showHostsError={showHostsError}
       />
     ),
   });

--- a/frontend/pages/Homepage/cards/ActivityFeed/ActivityFeed.tsx
+++ b/frontend/pages/Homepage/cards/ActivityFeed/ActivityFeed.tsx
@@ -102,6 +102,9 @@ const ActivityFeed = ({
           setShowMore(false);
         }
       },
+      onError: () => {
+        setShowActivityFeedTitle(true);
+      },
     }
   );
 

--- a/frontend/pages/Homepage/cards/ActivityFeed/ActivityFeed.tsx
+++ b/frontend/pages/Homepage/cards/ActivityFeed/ActivityFeed.tsx
@@ -138,7 +138,7 @@ const ActivityFeed = ({
   };
 
   const renderError = () => {
-    return <DataError />;
+    return <DataError card />;
   };
 
   const renderNoActivities = () => {

--- a/frontend/pages/Homepage/cards/HostsSummary/HostsSummary.tsx
+++ b/frontend/pages/Homepage/cards/HostsSummary/HostsSummary.tsx
@@ -19,7 +19,7 @@ interface IHostSummaryProps {
   linuxCount: number;
   isLoadingHostsSummary: boolean;
   showHostsUI: boolean;
-  showHostsError: boolean;
+  errorHosts: boolean;
   selectedPlatform: string;
   labels?: ILabelSummary[];
   setActionURL?: (url: string) => void;
@@ -32,7 +32,7 @@ const HostsSummary = ({
   linuxCount,
   isLoadingHostsSummary,
   showHostsUI,
-  showHostsError,
+  errorHosts,
   selectedPlatform,
   labels,
   setActionURL,
@@ -134,7 +134,7 @@ const HostsSummary = ({
     }
   };
 
-  if (showHostsError && !isLoadingHostsSummary) {
+  if (errorHosts && !isLoadingHostsSummary) {
     return <DataError card />;
   }
 

--- a/frontend/pages/Homepage/cards/HostsSummary/HostsSummary.tsx
+++ b/frontend/pages/Homepage/cards/HostsSummary/HostsSummary.tsx
@@ -4,6 +4,8 @@ import paths from "router/paths";
 import { ILabelSummary } from "interfaces/label";
 import { PLATFORM_NAME_TO_LABEL_NAME } from "utilities/constants";
 
+import DataError from "components/DataError";
+
 import WindowsIcon from "../../../../../assets/images/icon-windows-48x48@2x.png";
 import LinuxIcon from "../../../../../assets/images/icon-linux-48x48@2x.png";
 import MacIcon from "../../../../../assets/images/icon-mac-48x48@2x.png";
@@ -17,6 +19,7 @@ interface IHostSummaryProps {
   linuxCount: number;
   isLoadingHostsSummary: boolean;
   showHostsUI: boolean;
+  showHostsError: boolean;
   selectedPlatform: string;
   labels?: ILabelSummary[];
   setActionURL?: (url: string) => void;
@@ -29,6 +32,7 @@ const HostsSummary = ({
   linuxCount,
   isLoadingHostsSummary,
   showHostsUI,
+  showHostsError,
   selectedPlatform,
   labels,
   setActionURL,
@@ -129,6 +133,10 @@ const HostsSummary = ({
         );
     }
   };
+
+  if (showHostsError) {
+    return <DataError noMargin />;
+  }
 
   return (
     <div

--- a/frontend/pages/Homepage/cards/HostsSummary/HostsSummary.tsx
+++ b/frontend/pages/Homepage/cards/HostsSummary/HostsSummary.tsx
@@ -135,7 +135,7 @@ const HostsSummary = ({
   };
 
   if (showHostsError) {
-    return <DataError noMargin />;
+    return <DataError card />;
   }
 
   return (

--- a/frontend/pages/Homepage/cards/HostsSummary/HostsSummary.tsx
+++ b/frontend/pages/Homepage/cards/HostsSummary/HostsSummary.tsx
@@ -134,7 +134,7 @@ const HostsSummary = ({
     }
   };
 
-  if (showHostsError) {
+  if (showHostsError && !isLoadingHostsSummary) {
     return <DataError card />;
   }
 

--- a/frontend/pages/Homepage/cards/MDM/MDM.tsx
+++ b/frontend/pages/Homepage/cards/MDM/MDM.tsx
@@ -6,6 +6,7 @@ import { IMacadminAggregate, IDataTableMDMFormat } from "interfaces/macadmins";
 
 import TableContainer from "components/TableContainer";
 import Spinner from "components/Spinner";
+import TableDataError from "components/DataError";
 import renderLastUpdatedText from "components/LastUpdatedText";
 import generateTableHeaders from "./MDMTableConfig";
 
@@ -47,6 +48,7 @@ const MDM = ({
   const [formattedMDMData, setFormattedMDMData] = useState<
     IDataTableMDMFormat[]
   >([]);
+  const [showMDMError, setShowMDMError] = useState<boolean>(false);
 
   const { isFetching: isMDMFetching } = useQuery<IMacadminAggregate, Error>(
     ["MDM", currentTeamId],
@@ -81,6 +83,10 @@ const MDM = ({
           { status: "Unenrolled", hosts: unenrolled_hosts_count },
         ]);
       },
+      onError: () => {
+        setShowMDMUI(true);
+        setShowMDMError(true);
+      },
     }
   );
 
@@ -97,22 +103,26 @@ const MDM = ({
         </div>
       )}
       <div style={opacity}>
-        <TableContainer
-          columns={tableHeaders}
-          data={formattedMDMData}
-          isLoading={isMDMFetching}
-          defaultSortHeader={DEFAULT_SORT_HEADER}
-          defaultSortDirection={DEFAULT_SORT_DIRECTION}
-          hideActionButton
-          resultsTitle={"MDM"}
-          emptyComponent={EmptyMDM}
-          showMarkAllPages={false}
-          isAllPagesSelected={false}
-          disableCount
-          disableActionButton
-          disablePagination
-          pageSize={PAGE_SIZE}
-        />
+        {showMDMError ? (
+          <TableDataError card />
+        ) : (
+          <TableContainer
+            columns={tableHeaders}
+            data={formattedMDMData}
+            isLoading={isMDMFetching}
+            defaultSortHeader={DEFAULT_SORT_HEADER}
+            defaultSortDirection={DEFAULT_SORT_DIRECTION}
+            hideActionButton
+            resultsTitle={"MDM"}
+            emptyComponent={EmptyMDM}
+            showMarkAllPages={false}
+            isAllPagesSelected={false}
+            disableCount
+            disableActionButton
+            disablePagination
+            pageSize={PAGE_SIZE}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/pages/Homepage/cards/MDM/MDM.tsx
+++ b/frontend/pages/Homepage/cards/MDM/MDM.tsx
@@ -48,47 +48,44 @@ const MDM = ({
   const [formattedMDMData, setFormattedMDMData] = useState<
     IDataTableMDMFormat[]
   >([]);
-  const [showMDMError, setShowMDMError] = useState<boolean>(false);
 
-  const { isFetching: isMDMFetching } = useQuery<IMacadminAggregate, Error>(
-    ["MDM", currentTeamId],
-    () => macadminsAPI.loadAll(currentTeamId),
-    {
-      keepPreviousData: true,
-      onSuccess: (data) => {
-        const {
-          counts_updated_at,
-          mobile_device_management_enrollment_status,
-        } = data.macadmins;
-        const {
-          enrolled_manual_hosts_count,
-          enrolled_automated_hosts_count,
-          unenrolled_hosts_count,
-        } = mobile_device_management_enrollment_status;
+  const { isFetching: isMDMFetching, error: errorMDM } = useQuery<
+    IMacadminAggregate,
+    Error
+  >(["MDM", currentTeamId], () => macadminsAPI.loadAll(currentTeamId), {
+    keepPreviousData: true,
+    onSuccess: (data) => {
+      const {
+        counts_updated_at,
+        mobile_device_management_enrollment_status,
+      } = data.macadmins;
+      const {
+        enrolled_manual_hosts_count,
+        enrolled_automated_hosts_count,
+        unenrolled_hosts_count,
+      } = mobile_device_management_enrollment_status;
 
-        setShowMDMUI(true);
-        setTitleDetail &&
-          setTitleDetail(
-            renderLastUpdatedText(counts_updated_at, "MDM enrollment")
-          );
-        setFormattedMDMData([
-          {
-            status: "Enrolled (manual)",
-            hosts: enrolled_manual_hosts_count,
-          },
-          {
-            status: "Enrolled (automatic)",
-            hosts: enrolled_automated_hosts_count,
-          },
-          { status: "Unenrolled", hosts: unenrolled_hosts_count },
-        ]);
-      },
-      onError: () => {
-        setShowMDMUI(true);
-        setShowMDMError(true);
-      },
-    }
-  );
+      setShowMDMUI(true);
+      setTitleDetail &&
+        setTitleDetail(
+          renderLastUpdatedText(counts_updated_at, "MDM enrollment")
+        );
+      setFormattedMDMData([
+        {
+          status: "Enrolled (manual)",
+          hosts: enrolled_manual_hosts_count,
+        },
+        {
+          status: "Enrolled (automatic)",
+          hosts: enrolled_automated_hosts_count,
+        },
+        { status: "Unenrolled", hosts: unenrolled_hosts_count },
+      ]);
+    },
+    onError: () => {
+      setShowMDMUI(true);
+    },
+  });
 
   const tableHeaders = generateTableHeaders();
 
@@ -103,7 +100,7 @@ const MDM = ({
         </div>
       )}
       <div style={opacity}>
-        {showMDMError ? (
+        {errorMDM ? (
           <TableDataError card />
         ) : (
           <TableContainer

--- a/frontend/pages/Homepage/cards/Munki/Munki.tsx
+++ b/frontend/pages/Homepage/cards/Munki/Munki.tsx
@@ -46,29 +46,26 @@ const Munki = ({
   setTitleDetail,
 }: IMunkiCardProps): JSX.Element => {
   const [munkiData, setMunkiData] = useState<IMunkiAggregate[]>([]);
-  const [showMunkiError, setShowMunkiError] = useState<boolean>(false);
 
-  const { isFetching: isMunkiFetching } = useQuery<IMacadminAggregate, Error>(
-    ["munki", currentTeamId],
-    () => macadminsAPI.loadAll(currentTeamId),
-    {
-      keepPreviousData: true,
-      onSuccess: (data) => {
-        const { counts_updated_at, munki_versions } = data.macadmins;
+  const { isFetching: isMunkiFetching, error: errorMunki } = useQuery<
+    IMacadminAggregate,
+    Error
+  >(["munki", currentTeamId], () => macadminsAPI.loadAll(currentTeamId), {
+    keepPreviousData: true,
+    onSuccess: (data) => {
+      const { counts_updated_at, munki_versions } = data.macadmins;
 
-        setMunkiData(munki_versions);
-        setShowMunkiUI(true);
-        setTitleDetail &&
-          setTitleDetail(
-            renderLastUpdatedText(counts_updated_at, "Munki versions")
-          );
-      },
-      onError: () => {
-        setShowMunkiUI(true);
-        setShowMunkiError(true);
-      },
-    }
-  );
+      setMunkiData(munki_versions);
+      setShowMunkiUI(true);
+      setTitleDetail &&
+        setTitleDetail(
+          renderLastUpdatedText(counts_updated_at, "Munki versions")
+        );
+    },
+    onError: () => {
+      setShowMunkiUI(true);
+    },
+  });
 
   const tableHeaders = generateTableHeaders();
 
@@ -83,7 +80,7 @@ const Munki = ({
         </div>
       )}
       <div style={opacity}>
-        {showMunkiError ? (
+        {errorMunki ? (
           <TableDataError card />
         ) : (
           <TableContainer

--- a/frontend/pages/Homepage/cards/Munki/Munki.tsx
+++ b/frontend/pages/Homepage/cards/Munki/Munki.tsx
@@ -6,6 +6,7 @@ import { IMacadminAggregate, IMunkiAggregate } from "interfaces/macadmins";
 
 import TableContainer from "components/TableContainer";
 import Spinner from "components/Spinner";
+import TableDataError from "components/DataError";
 import renderLastUpdatedText from "components/LastUpdatedText";
 import generateTableHeaders from "./MunkiTableConfig";
 
@@ -45,6 +46,7 @@ const Munki = ({
   setTitleDetail,
 }: IMunkiCardProps): JSX.Element => {
   const [munkiData, setMunkiData] = useState<IMunkiAggregate[]>([]);
+  const [showMunkiError, setShowMunkiError] = useState<boolean>(false);
 
   const { isFetching: isMunkiFetching } = useQuery<IMacadminAggregate, Error>(
     ["munki", currentTeamId],
@@ -60,6 +62,10 @@ const Munki = ({
           setTitleDetail(
             renderLastUpdatedText(counts_updated_at, "Munki versions")
           );
+      },
+      onError: () => {
+        setShowMunkiUI(true);
+        setShowMunkiError(true);
       },
     }
   );
@@ -77,22 +83,26 @@ const Munki = ({
         </div>
       )}
       <div style={opacity}>
-        <TableContainer
-          columns={tableHeaders}
-          data={munkiData || []}
-          isLoading={isMunkiFetching}
-          defaultSortHeader={DEFAULT_SORT_HEADER}
-          defaultSortDirection={DEFAULT_SORT_DIRECTION}
-          hideActionButton
-          resultsTitle={"Munki"}
-          emptyComponent={EmptyMunki}
-          showMarkAllPages={false}
-          isAllPagesSelected={false}
-          disableCount
-          disableActionButton
-          disablePagination
-          pageSize={PAGE_SIZE}
-        />
+        {showMunkiError ? (
+          <TableDataError card />
+        ) : (
+          <TableContainer
+            columns={tableHeaders}
+            data={munkiData || []}
+            isLoading={isMunkiFetching}
+            defaultSortHeader={DEFAULT_SORT_HEADER}
+            defaultSortDirection={DEFAULT_SORT_DIRECTION}
+            hideActionButton
+            resultsTitle={"Munki"}
+            emptyComponent={EmptyMunki}
+            showMarkAllPages={false}
+            isAllPagesSelected={false}
+            disableCount
+            disableActionButton
+            disablePagination
+            pageSize={PAGE_SIZE}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/pages/Homepage/cards/OperatingSystems/OperatingSystems.tsx
+++ b/frontend/pages/Homepage/cards/OperatingSystems/OperatingSystems.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useQuery } from "react-query";
 
 import { IOsqueryPlatform } from "interfaces/platform";
@@ -9,6 +9,7 @@ import { PLATFORM_DISPLAY_NAMES } from "utilities/constants";
 
 import TableContainer from "components/TableContainer";
 import Spinner from "components/Spinner";
+import TableDataError from "components/DataError";
 import renderLastUpdatedText from "components/LastUpdatedText";
 
 import generateTableHeaders from "./OperatingSystemsTableConfig";
@@ -48,6 +49,8 @@ const OperatingSystems = ({
   setShowOperatingSystemsUI,
   setTitleDetail,
 }: IOperatingSystemsCardProps): JSX.Element => {
+  const [showOSError, setShowOSError] = useState<boolean>(false);
+
   const { data: osInfo, error, isFetching } = useQuery<
     IOperatingSystemsResponse,
     Error,
@@ -81,6 +84,10 @@ const OperatingSystems = ({
             renderLastUpdatedText(data.counts_updated_at, "operating systems")
           );
       },
+      onError: () => {
+        setShowOperatingSystemsUI(true);
+        setShowOSError(true);
+      },
     }
   );
 
@@ -91,28 +98,32 @@ const OperatingSystems = ({
 
   return (
     <div className={baseClass}>
-      {!showOperatingSystemsUI && (
+      {!showOperatingSystemsUI && !showOSError && (
         <div className="spinner">
           <Spinner />
         </div>
       )}
       <div style={opacity}>
-        <TableContainer
-          columns={tableHeaders}
-          data={osInfo?.os_versions || []}
-          isLoading={isFetching}
-          defaultSortHeader={DEFAULT_SORT_HEADER}
-          defaultSortDirection={DEFAULT_SORT_DIRECTION}
-          hideActionButton
-          resultsTitle={"Operating systems"}
-          emptyComponent={() => EmptyOperatingSystems(selectedPlatform)}
-          showMarkAllPages={false}
-          isAllPagesSelected={false}
-          disableCount
-          disableActionButton
-          isClientSidePagination
-          pageSize={PAGE_SIZE}
-        />
+        {showOSError ? (
+          <TableDataError card />
+        ) : (
+          <TableContainer
+            columns={tableHeaders}
+            data={osInfo?.os_versions || []}
+            isLoading={isFetching}
+            defaultSortHeader={DEFAULT_SORT_HEADER}
+            defaultSortDirection={DEFAULT_SORT_DIRECTION}
+            hideActionButton
+            resultsTitle={"Operating systems"}
+            emptyComponent={() => EmptyOperatingSystems(selectedPlatform)}
+            showMarkAllPages={false}
+            isAllPagesSelected={false}
+            disableCount
+            disableActionButton
+            isClientSidePagination
+            pageSize={PAGE_SIZE}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/pages/Homepage/cards/OperatingSystems/OperatingSystems.tsx
+++ b/frontend/pages/Homepage/cards/OperatingSystems/OperatingSystems.tsx
@@ -49,9 +49,7 @@ const OperatingSystems = ({
   setShowOperatingSystemsUI,
   setTitleDetail,
 }: IOperatingSystemsCardProps): JSX.Element => {
-  const [showOSError, setShowOSError] = useState<boolean>(false);
-
-  const { data: osInfo, error, isFetching } = useQuery<
+  const { data: osInfo, error: errorOS, isFetching } = useQuery<
     IOperatingSystemsResponse,
     Error,
     IOperatingSystemsResponse,
@@ -86,7 +84,6 @@ const OperatingSystems = ({
       },
       onError: () => {
         setShowOperatingSystemsUI(true);
-        setShowOSError(true);
       },
     }
   );
@@ -98,13 +95,13 @@ const OperatingSystems = ({
 
   return (
     <div className={baseClass}>
-      {!showOperatingSystemsUI && !showOSError && (
+      {!showOperatingSystemsUI && !errorOS && (
         <div className="spinner">
           <Spinner />
         </div>
       )}
       <div style={opacity}>
-        {showOSError ? (
+        {errorOS ? (
           <TableDataError card />
         ) : (
           <TableContainer

--- a/frontend/pages/Homepage/cards/Software/Software.tsx
+++ b/frontend/pages/Homepage/cards/Software/Software.tsx
@@ -89,6 +89,9 @@ const Software = ({
             );
         }
       },
+      onError: () => {
+        setShowSoftwareUI(true);
+      },
     }
   );
 
@@ -128,6 +131,7 @@ const Software = ({
   // Renders opaque information as host information is loading
   const opacity = showSoftwareUI ? { opacity: 1 } : { opacity: 0 };
 
+  console.log("showSoftwareUI", showSoftwareUI);
   return (
     <div className={baseClass}>
       {!showSoftwareUI && (

--- a/frontend/pages/Homepage/cards/Software/Software.tsx
+++ b/frontend/pages/Homepage/cards/Software/Software.tsx
@@ -9,7 +9,7 @@ import softwareAPI, { ISoftwareResponse } from "services/entities/software";
 
 import TabsWrapper from "components/TabsWrapper";
 import TableContainer, { ITableQueryData } from "components/TableContainer";
-import TableDataError from "components/DataError"; // TODO how do we handle errors? UI just keeps spinning?
+import TableDataError from "components/DataError";
 import Spinner from "components/Spinner";
 import renderLastUpdatedText from "components/LastUpdatedText/LastUpdatedText";
 import generateTableHeaders from "./SoftwareTableConfig";
@@ -131,7 +131,6 @@ const Software = ({
   // Renders opaque information as host information is loading
   const opacity = showSoftwareUI ? { opacity: 1 } : { opacity: 0 };
 
-  console.log("showSoftwareUI", showSoftwareUI);
   return (
     <div className={baseClass}>
       {!showSoftwareUI && (

--- a/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
@@ -95,7 +95,6 @@ const WelcomeHost = (): JSX.Element => {
       },
       onError: (error) => {
         console.error(error);
-        renderFlash("error", `Unable to load host. Please try again.`);
       },
     }
   );

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.tsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.tsx
@@ -566,7 +566,7 @@ const UserManagementPage = ({ router }: IUserManagementProps): JSX.Element => {
     loadingUsersError || loadingInvitesError || loadingTeamsError;
 
   let tableData: unknown = [];
-  if (!loadingTableData) {
+  if (!loadingTableData && !tableDataError) {
     tableData = combineUsersAndInvites(users, invites, currentUser?.id);
   }
 

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -43,9 +43,10 @@ const renderTable = (
   isOnGlobalTeam: boolean,
   selectedTeamData: ITeam | undefined,
   isFetchingGlobalScheduledQueries: boolean,
-  isLoadingTeamScheduledQueries: boolean
+  isLoadingTeamScheduledQueries: boolean,
+  errorQueries: Error | null
 ): JSX.Element => {
-  return allScheduledQueriesError ? (
+  return allScheduledQueriesError || errorQueries ? (
     <TableDataError />
   ) : (
     <ScheduleListWrapper
@@ -156,15 +157,15 @@ const ManageSchedulePage = ({
     }
   );
 
-  const { data: fleetQueries, isLoading: isLoadingFleetQueries } = useQuery(
-    ["fleetQueries"],
-    () => fleetQueriesAPI.loadAll(),
-    {
-      refetchOnMount: false,
-      refetchOnWindowFocus: false,
-      select: (data) => data.queries,
-    }
-  );
+  const {
+    data: fleetQueries,
+    isLoading: isLoadingFleetQueries,
+    error: errorQueries,
+  } = useQuery(["fleetQueries"], () => fleetQueriesAPI.loadAll(), {
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    select: (data) => data.queries,
+  });
 
   const {
     data: globalScheduledQueries,
@@ -502,7 +503,8 @@ const ManageSchedulePage = ({
               isOnGlobalTeam || false,
               selectedTeamData,
               isFetchingGlobalScheduledQueries,
-              isLoadingTeamScheduledQueries
+              isLoadingTeamScheduledQueries,
+              errorQueries
             )
           )}
         </div>

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -9,6 +9,7 @@ import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import deepDifference from "utilities/deep_difference";
 import { ITeam } from "interfaces/team";
+import { IQuery } from "interfaces/query";
 import {
   IScheduledQuery,
   IEditScheduledQuery,
@@ -32,6 +33,10 @@ import ScheduleEditorModal from "./components/ScheduleEditorModal";
 import RemoveScheduledQueryModal from "./components/RemoveScheduledQueryModal";
 
 const baseClass = "manage-schedule-page";
+
+interface IFleetQueriesResponse {
+  queries: IQuery[];
+}
 
 const renderTable = (
   router: InjectedRouter,
@@ -161,11 +166,15 @@ const ManageSchedulePage = ({
     data: fleetQueries,
     isLoading: isLoadingFleetQueries,
     error: errorQueries,
-  } = useQuery(["fleetQueries"], () => fleetQueriesAPI.loadAll(), {
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    select: (data) => data.queries,
-  });
+  } = useQuery<IFleetQueriesResponse, Error, IQuery[]>(
+    ["fleetQueries"],
+    () => fleetQueriesAPI.loadAll(),
+    {
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      select: (data) => data.queries,
+    }
+  );
 
   const {
     data: globalScheduledQueries,
@@ -535,7 +544,7 @@ const ManageSchedulePage = ({
             isFetchingGlobalScheduledQueries,
             isLoadingTeamScheduledQueries
           )}
-        {showScheduleEditorModal && (
+        {showScheduleEditorModal && fleetQueries && (
           <ScheduleEditorModal
             onClose={toggleScheduleEditorModal}
             onScheduleSubmit={onAddScheduledQuerySubmit}


### PR DESCRIPTION
Cerra #5086 

**Fixes: Dashboard card error states**
- Hosts Summary Card: Remove undefined host count on error
- Hosts Summary Card: Show error message on error
- Software Card: Show error message on error
- Activity Card: Show Activity title on error
- Mac Operating Systems Card: Show error message on error
- Mac Munki Card: Show error message on error
- Mac MDM Card: Show error message on error
- All Cards: Error state has top padding of 24px and no bottom padding, vs. page error state has top and bottom padding of 80px
- Fleetctl preview: Remove error flash message

**Other tech debt addressed: Page error states**
- External link to file an issue directs to https://github.com/fleetdm/fleet/issues/new/choose instead of a list of issues https://github.com/fleetdm/fleet/issues
- User Management page now reaches correct error message instead of original 500 page because of array map error when user/invites/teams API returns error
- Manage Schedule page now reaches correct error message instead of original 500 from clicking "Schedule a query" when query API returns error

**QA: To reproduce error states**
- Mock 500 errors for the endpoints: /host_summary, /software, /activities, /macadmins, /os_versions, /users, /teams, /invites

**Screenshots of fixes**
<img width="1111" alt="Screen Shot 2022-06-27 at 12 17 40 PM" src="https://user-images.githubusercontent.com/71795832/175988444-282aef3e-3e1c-4362-aecd-69a9d0a8940d.png">
<img width="1115" alt="Screen Shot 2022-06-27 at 12 08 44 PM" src="https://user-images.githubusercontent.com/71795832/175988447-afece1f6-f983-4227-826d-e19cfe3f5220.png">
<img width="1118" alt="Screen Shot 2022-06-27 at 12 08 23 PM" src="https://user-images.githubusercontent.com/71795832/175988448-d952fc7f-b8e6-4c44-9382-53a37872f824.png">
<img width="1115" alt="Screen Shot 2022-06-27 at 12 07 56 PM" src="https://user-images.githubusercontent.com/71795832/175988451-e61e2bfb-33d3-48e3-b7a0-25229724df70.png">
<img width="1118" alt="Screen Shot 2022-06-27 at 12 07 44 PM" src="https://user-images.githubusercontent.com/71795832/175988454-d05b8409-d327-4294-bfd5-09f164135d83.png">
<img width="1109" alt="Screen Shot 2022-06-27 at 12 05 04 PM" src="https://user-images.githubusercontent.com/71795832/175988456-601c60e8-d4fd-41e5-b80c-c87ffa575e81.png">
<img width="1121" alt="Screen Shot 2022-06-27 at 12 04 32 PM" src="https://user-images.githubusercontent.com/71795832/175988459-02954ab3-15b5-4d8d-a298-a4dffd59f61a.png">
<img width="1116" alt="Screen Shot 2022-06-27 at 3 38 56 PM" src="https://user-images.githubusercontent.com/71795832/176023348-d92c6da3-1e2b-4db9-992c-0497e65afbdd.png">
<img width="1117" alt="Screen Shot 2022-06-27 at 3 14 33 PM" src="https://user-images.githubusercontent.com/71795832/176023352-030be706-4b46-4075-9177-d5eb74a1f465.png">
<img width="1118" alt="Screen Shot 2022-06-27 at 3 47 14 PM" src="https://user-images.githubusercontent.com/71795832/176023521-e4ec90c7-cb01-45f7-9852-ad8cf67938e1.png">


Fleetctl preview:
<img width="1104" alt="Screen Shot 2022-06-27 at 2 48 16 PM" src="https://user-images.githubusercontent.com/71795832/176014408-9476cb4f-c163-4c94-94ce-d40e93b3d2c7.png">
Screenshot of flash message that was removed:
<img width="1118" alt="Screen Shot 2022-06-27 at 2 35 44 PM" src="https://user-images.githubusercontent.com/71795832/176014356-d46d13dd-5984-4be9-9182-b0563f121aef.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
