### PR TITLE
Bug 6391: Added new error strings to network retry logic

### DIFF
--- a/pkg/nettest/nettest.go
+++ b/pkg/nettest/nettest.go
@@ -63,7 +63,7 @@ func Retryable(err error) bool {
 	// Using the exact same error check used in:
 	// https://github.com/golang/go/blob/a5d61be040ed20b5774bff1b6b578c6d393ab332/src/net/http/serve_test.go#L1417
 	if errStr := err.Error(); (strings.Contains(errStr, "timeout") && strings.Contains(errStr, "TLS handshake")) ||
-		strings.Contains(errStr, "unexpected EOF") {
+		strings.Contains(errStr, "unexpected EOF") || strings.Contains(errStr, "connection reset by peer") || strings.Contains(errStr, "unexpected http response") {
 		return true
 	}
 	return false


### PR DESCRIPTION
Closes #6391 

This extends the `nettest` retry logic to include new retry-able network errors.