### PR TITLE
Dropdown UI: Fix alignment for placeholder and search text

### DIFF
--- a/changes/issue-6356-align-text
+++ b/changes/issue-6356-align-text
@@ -1,0 +1,1 @@
+- Fix dropdown placeholder and search text alignment

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -97,7 +97,7 @@
   &--single {
     > .Select-control {
       .Select-value {
-        line-height: 40px;
+        line-height: 36px;
         border: none;
         top: 1px;
         right: 1px;
@@ -223,15 +223,19 @@
   .Select-placeholder {
     color: $core-fleet-blue;
     font-size: $small;
-    line-height: 40px;
+    line-height: 36px;
     padding: 0 $pad-medium;
     box-sizing: border-box;
   }
   .Select-input {
     color: $core-fleet-blue;
     font-size: $small;
-    padding-left: 2px;
     box-sizing: border-box;
+
+    input {
+      line-height: 36px;
+      padding: 1px;
+    }
   }
 
   &.Select--multi {


### PR DESCRIPTION
Cerra #6356 

**Fixes**
- Dropdown placeholder text vertically aligned
- Dropdown search text vertically and horizontally aligned

**Screenrecording(Note: typing "users" is in the exact same spot as the placeholder "users"**
https://user-images.githubusercontent.com/71795832/176216961-3d207d7d-172a-4ffe-b1d2-6b63ff717a20.mov


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
