### PR TITLE
Login UI: Center vertical alignment, align with forgot password box

### DIFF
--- a/changes/issue-6355-login-alignment
+++ b/changes/issue-6355-login-alignment
@@ -1,0 +1,1 @@
+*  Fix alignment on login page

--- a/frontend/components/AuthenticationFormWrapper/_styles.scss
+++ b/frontend/components/AuthenticationFormWrapper/_styles.scss
@@ -4,6 +4,7 @@
   justify-content: center;
   flex-grow: 1;
   padding: $pad-medium 0;
+  height: 100vh;
 
   &__logo {
     width: 120px;

--- a/frontend/components/StackedWhiteBoxes/_styles.scss
+++ b/frontend/components/StackedWhiteBoxes/_styles.scss
@@ -21,7 +21,7 @@
     min-height: 360px;
     box-sizing: border-box;
     padding: $pad-xxlarge;
-    font-weight: 300;
+    font-weight: $regular;
     position: relative;
 
     &-text {

--- a/frontend/components/forms/LoginForm/_styles.scss
+++ b/frontend/components/forms/LoginForm/_styles.scss
@@ -1,8 +1,7 @@
 .login-form {
   transition: opacity 300ms ease-in;
-  transform: translateY(-150px);
   opacity: 1;
-  width: 500px;
+  width: 516px;
   align-self: center;
   border-radius: 10px;
   overflow: hidden;
@@ -15,12 +14,14 @@
     display: flex;
     align-items: center;
     background-color: $core-white;
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
+    border-radius: 10px;
+    min-height: 360px;
     box-sizing: border-box;
     flex-direction: column;
     padding: $pad-xxlarge;
+    margin: $pad-xxlarge 0;
     font-weight: $regular;
+    width: 516px;
   }
 
   &__submit-btn {

--- a/frontend/pages/LoginPage/LoginPage.tsx
+++ b/frontend/pages/LoginPage/LoginPage.tsx
@@ -138,7 +138,6 @@ const LoginPage = ({ router, location }: ILoginPageProps) => {
 
   return (
     <AuthenticationFormWrapper>
-      <LoginSuccessfulPage />
       <LoginForm
         onChangeFunc={onChange}
         handleSubmit={onSubmit}


### PR DESCRIPTION
Cerra #6355 

**Fixes (Self QA on Chrome, Firefox, Safari)**
- Center vertical alignment of login
- Align width and location of login box with forgot password box

**Other tech debt addressed**
- Removed successful login since it's not being rendered

**Screenshots:**
<img width="937" alt="Screen Shot 2022-06-28 at 12 44 09 PM" src="https://user-images.githubusercontent.com/71795832/176235117-becfef34-7041-4261-9211-52ae259087d7.png">
<img width="938" alt="Screen Shot 2022-06-28 at 12 44 03 PM" src="https://user-images.githubusercontent.com/71795832/176235131-3d7e29d1-534a-4071-8f68-5b80a7048770.png">


QA question: Should we be rendering successful login at some point?


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
