### PR TITLE
Added "?tryitnow" to first get started button

### DIFF
--- a/website/views/pages/landing.ejs
+++ b/website/views/pages/landing.ejs
@@ -7,7 +7,7 @@
           <h4>One agent, any platform, up-to-the-minute data</h4>
           <p>Fleet allows you to harness the power of osquery to stream accurate, real-time data from all of your devices. It’s easy to deploy at scale, granular and open source.</p>
           <div class="flex-row row justify-content-around mx-md-0 mx-4 pt-2">
-            <a href="/get-started" class="btn btn-primary col-md-6 col-12">Try it out</a>
+            <a href="/get-started?tryitnow" class="btn btn-primary col-md-6 col-12">Try it out</a>
             <a purpose="demo-btn-white" style="color:#F9FAFC;" class="btn col-md-6 col-12" href="https://calendly.com/fleetdm/demo?utm_source=landing+demo+banner" target="_blank">
               Schedule a demo
             </a>


### PR DESCRIPTION
Button in above the fold hero area did not include this. We use it to track conversions for these button clicks in GA and on ad networks.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md)
- [ ] Documented any permissions changes
- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
