### PR TITLE
Host Details UI: Fix software table column width, caret alignment

### DIFF
--- a/changes/issue-6388-host-details-software-alignment
+++ b/changes/issue-6388-host-details-software-alignment
@@ -1,0 +1,1 @@
+- Fix alignment of software table of host details page

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -60,6 +60,9 @@
         .last_opened_at__header {
           display: none;
         }
+        .linkToFilteredHosts__header {
+          min-width: 110px;
+        }
         @media (min-width: $break-990) {
           .version__header {
             width: $col-md;
@@ -128,6 +131,7 @@
             height: 16px;
             width: 16px;
             vertical-align: middle;
+            margin-bottom: 4px;
           }
 
           .link-text {


### PR DESCRIPTION
Cerra #6388 

**Fixes**
- Min width 110px to accommodate the link being on a single line
- Align caret higher to line up with text

**Screenrecording of fix with responsive UI**
https://user-images.githubusercontent.com/71795832/176283535-59e9781a-9708-49df-b7d0-441d7e5800cd.mov

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
