### PR TITLE
Update and correct the macOS log destination for fleet desktop

### DIFF
--- a/orbit/changes/issue-6407-fleet-desktop-log-destination-macos
+++ b/orbit/changes/issue-6407-fleet-desktop-log-destination-macos
@@ -1,0 +1,1 @@
+* Updated and corrected the macOS logger destination for Fleet Desktop to ~/Library/Logs

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -201,7 +201,7 @@ func setupLogs() {
 // On Unix systems, it returns $XDG_STATE_HOME as specified by
 // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html if
 // non-empty, else $HOME/.local/state.
-// On Darwin, it returns $HOME/Library/Log.
+// On Darwin, it returns $HOME/Library/Logs.
 // On Windows, it returns %LocalAppData%
 //
 // If the location cannot be determined (for example, $HOME is not defined),
@@ -221,7 +221,7 @@ func logDir() (string, error) {
 		if dir == "" {
 			return "", errors.New("$HOME is not defined")
 		}
-		dir += "/Library/Log"
+		dir += "/Library/Logs"
 
 	default: // Unix
 		dir = os.Getenv("XDG_STATE_HOME")


### PR DESCRIPTION
Fixes #6407 

```
➜  Fleet stat fleet-desktop.log
16777234 17180053 -rw-r--r-- 1 sharvil staff 0 443 "Jun 28 18:37:13 2022" "Jun 28 18:36:41 2022" "Jun 28 18:36:41 2022" "Jun 28 18:36:26 2022" 4096 8 0 fleet-desktop.log
➜  Fleet pwd
/Users/sharvil/Library/Logs/Fleet
➜  Fleet file fleet-desktop.log
fleet-desktop.log: ASCII text
➜  Fleet
```

Thoughts on cleaning up log from old location? @lucasmrod @roperzh 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality

