### PR TITLE
increase contrast on navigation headers

### DIFF
--- a/website/assets/styles/bootstrap-overrides.less
+++ b/website/assets/styles/bootstrap-overrides.less
@@ -216,7 +216,7 @@ a.text-danger:hover, a.text-danger:focus {
     padding-left: 16px;
     padding-right: 16px;
     padding-top: 16px;
-    color: @core-fleet-black-25;
+    color: @core-fleet-black-33;
     font-size: 11px;
     line-height: 20px;
     font-weight: bold;

--- a/website/assets/styles/mixins-and-variables/colors.less
+++ b/website/assets/styles/mixins-and-variables/colors.less
@@ -5,6 +5,7 @@
 @core-fleet-black: #192147;
 @core-fleet-black-75: #515774;
 @core-fleet-black-50: #8b8fa2;
+@core-fleet-black-33: #B3B6C1;
 @core-fleet-black-25: #C5C7D1;
 
 @core-vibrant-red: #FF5C83;


### PR DESCRIPTION
I increased the contrast of the navigation headers. Fleet black 25% was too light. Fleet black 50% was too dark.

- I introduced a new color variable - Fleet black 33%

# Checklist for submitter

- [x] Manual QA for all new/changed functionality
