### PR TITLE
Fleet Desktop Device User Page: Remove unnecessary API call

### DIFF
--- a/changes/issue-6072-device-user-no-enroll-secret-api
+++ b/changes/issue-6072-device-user-no-enroll-secret-api
@@ -1,0 +1,1 @@
+* Remove unnecessary call to enroll secret API on device user page when logged in

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -84,7 +84,7 @@ const App = ({ children, location, router }: IAppProps): JSX.Element => {
   };
 
   useEffect(() => {
-    if (authToken()) {
+    if (authToken() && !location?.pathname.includes("/device/")) {
       fetchCurrentUser();
     }
   }, [location?.pathname]);

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -97,7 +97,8 @@ const App = ({ children, location, router }: IAppProps): JSX.Element => {
       typeof isOnlyObserver !== "undefined" &&
       !isOnlyObserver &&
       typeof isAnyTeamMaintainerOrTeamAdmin !== "undefined" &&
-      !isAnyTeamMaintainerOrTeamAdmin;
+      !isAnyTeamMaintainerOrTeamAdmin &&
+      !location?.pathname.includes("/device/");
 
     const getEnrollSecret = async () => {
       try {


### PR DESCRIPTION
Cerra #6072 

**Fix**
- Removes unnecessary API call to /enroll_secrets, /me, /config, when accessing device user page from a logged in user

**Screenshot**
<img width="1295" alt="Screen Shot 2022-06-29 at 11 12 23 AM" src="https://user-images.githubusercontent.com/71795832/176472160-945aeeb7-64ad-4a12-a497-505da77bdd1d.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
