### PR TITLE
disable transparency menu item until the device is fully connected

### DIFF
--- a/orbit/changes/issue-6438-disable-transparency-until-connected
+++ b/orbit/changes/issue-6438-disable-transparency-until-connected
@@ -1,0 +1,1 @@
+* Disabled the 'Transparency' menu item in Fleet Desktop until the device is successfully connected to the Fleet server.

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -59,6 +59,7 @@ func main() {
 		myDeviceItem := systray.AddMenuItem("Initializing...", "")
 		myDeviceItem.Disable()
 		transparencyItem := systray.AddMenuItem("Transparency", "")
+		transparencyItem.Disable()
 
 		var insecureSkipVerify bool
 		if os.Getenv("FLEET_DESKTOP_INSECURE") != "" {
@@ -104,6 +105,7 @@ func main() {
 
 		go func() {
 			<-deviceEnabledChan
+			transparencyItem.Enable()
 			tic := time.NewTicker(5 * time.Minute)
 			defer tic.Stop()
 

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -89,6 +89,7 @@ func main() {
 						myDeviceItem.SetTitle("My device")
 						myDeviceItem.Enable()
 						myDeviceItem.SetTooltip("")
+						transparencyItem.Enable()
 						return
 					}
 
@@ -105,7 +106,6 @@ func main() {
 
 		go func() {
 			<-deviceEnabledChan
-			transparencyItem.Enable()
 			tic := time.NewTicker(5 * time.Minute)
 			defer tic.Stop()
 


### PR DESCRIPTION
Related to #6438, the whole process looks like:

**When the device is connecting**

![Screen Shot 2022-06-29 at 15 18 41](https://user-images.githubusercontent.com/4419992/176508553-18fefed4-2afc-4166-b1be-89f347d3cf24.png)

**On successful connection**

![Screen Shot 2022-06-29 at 15 19 00](https://user-images.githubusercontent.com/4419992/176508545-4a33212b-ff48-4b8e-b472-3a79160d174e.png)


# Checklist for submitter

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
