### PR TITLE
Orbit to cleanup extension socket at startup

### DIFF
--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Generate and bundle go & js code
       run: make generate
 
-    - name: Build fleet and fleetctl"
+    - name: Build fleet and fleetctl
       # fleet-dev builds fleet with "race" enabled.
       run: make fleet-dev fleetctl
 

--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -81,8 +81,9 @@ jobs:
     - name: Generate and bundle go & js code
       run: make generate
 
-    - name: Build fleet and fleetctl
-      run: make fleet fleetctl
+    - name: Build fleet and fleetctl"
+      # fleet-dev builds fleet with "race" enabled.
+      run: make fleet-dev fleetctl
 
     - name: Run Fleet server
       env:

--- a/orbit/changes/issue-orbit-cleanup-ext-socket-startup
+++ b/orbit/changes/issue-orbit-cleanup-ext-socket-startup
@@ -1,0 +1,1 @@
+* Added cleanup of osquery extension socket to Orbit at startup.


### PR DESCRIPTION
@noahtalerman and @zwass reported seeing an issue of a leftover `/opt/orbit/orbit-osquery.em` extension socket file. Manually removing it fixed the restart loop for them. This PR makes Orbit try to remove it before starting osqueryd.

- [X] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
~- [ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality
