### PR TITLE
Fix `Datastore.HostByIdentifier` to set `SeenTime`

### DIFF
--- a/changes/issue-6481-host-by-identifier-seen-time
+++ b/changes/issue-6481-host-by-identifier-seen-time
@@ -1,0 +1,1 @@
+* Fixed `/api/_version_/fleet/hosts/identifier/{identifier}` to return the correct value for `host.status`.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -917,8 +917,11 @@ func (ds *Datastore) HostIDsByName(ctx context.Context, filter fleet.TeamFilter,
 
 func (ds *Datastore) HostByIdentifier(ctx context.Context, identifier string) (*fleet.Host, error) {
 	stmt := `
-		SELECT * FROM hosts
-		WHERE ? IN (hostname, osquery_host_id, node_key, uuid)
+		SELECT h.*, COALESCE(hst.seen_time, h.created_at) AS seen_time
+		FROM hosts h
+		LEFT JOIN host_seen_times hst
+		ON (h.id = hst.host_id)
+		WHERE ? IN (h.hostname, h.osquery_host_id, h.node_key, h.uuid)
 		LIMIT 1
 	`
 	host := &fleet.Host{}

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -1583,12 +1583,13 @@ func testHostsAdditional(t *testing.T, ds *Datastore) {
 }
 
 func testHostsByIdentifier(t *testing.T, ds *Datastore) {
+	now := time.Now().UTC().Truncate(time.Second)
 	for i := 1; i <= 10; i++ {
 		_, err := ds.NewHost(context.Background(), &fleet.Host{
-			DetailUpdatedAt: time.Now(),
-			LabelUpdatedAt:  time.Now(),
-			PolicyUpdatedAt: time.Now(),
-			SeenTime:        time.Now(),
+			DetailUpdatedAt: now,
+			LabelUpdatedAt:  now,
+			PolicyUpdatedAt: now,
+			SeenTime:        now,
 			OsqueryHostID:   fmt.Sprintf("osquery_host_id_%d", i),
 			NodeKey:         fmt.Sprintf("node_key_%d", i),
 			UUID:            fmt.Sprintf("uuid_%d", i),
@@ -1604,21 +1605,26 @@ func testHostsByIdentifier(t *testing.T, ds *Datastore) {
 	h, err = ds.HostByIdentifier(context.Background(), "uuid_1")
 	require.NoError(t, err)
 	assert.Equal(t, uint(1), h.ID)
+	assert.Equal(t, now.UTC(), h.SeenTime)
 
 	h, err = ds.HostByIdentifier(context.Background(), "osquery_host_id_2")
 	require.NoError(t, err)
 	assert.Equal(t, uint(2), h.ID)
+	assert.Equal(t, now.UTC(), h.SeenTime)
 
 	h, err = ds.HostByIdentifier(context.Background(), "node_key_4")
 	require.NoError(t, err)
 	assert.Equal(t, uint(4), h.ID)
+	assert.Equal(t, now.UTC(), h.SeenTime)
 
 	h, err = ds.HostByIdentifier(context.Background(), "hostname_7")
 	require.NoError(t, err)
 	assert.Equal(t, uint(7), h.ID)
+	assert.Equal(t, now.UTC(), h.SeenTime)
 
 	h, err = ds.HostByIdentifier(context.Background(), "foobar")
 	require.Error(t, err)
+	require.Nil(t, h)
 }
 
 func testHostsAddToTeam(t *testing.T, ds *Datastore) {

--- a/tools/tuf/test/gen_pkgs.sh
+++ b/tools/tuf/test/gen_pkgs.sh
@@ -93,3 +93,7 @@ if [ -n "$GENERATE_MSI" ]; then
 fi
 
 echo "Packages generated."
+
+if [[ $OSTYPE == 'darwin'* && -n "$INSTALL_PKG" ]]; then
+    sudo installer -pkg fleet-osquery.pkg -target /
+fi


### PR DESCRIPTION
See #6481.

- [X] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality

Manually QA with:
```
# GET /api/v1/fleet/hosts/{id} returns the correct status:

➜ curl -k --silent -X GET \
  -H "Authorization: Bearer $AUTH_TOKEN" \
  https://localhost:8080/api/v1/fleet/hosts/10 | jq '."host"."status"'
"online"

# GET /api/v1/fleet/hosts/identifier/{identifier} should now return the same value as the GET above:

➜ curl -k --silent -X GET \
  -H "Authorization: Bearer $AUTH_TOKEN" \
  https://localhost:8080/api/v1/fleet/hosts/identifier/$IDENTIFIER | jq '."host"."status"'
"online"
```
