### PR TITLE
Fleet UI: Host details / Device user page last restart time bug

### DIFF
--- a/changes/issue-6467-fix-last-restarted-report-date
+++ b/changes/issue-6467-fix-last-restarted-report-date
@@ -1,0 +1,1 @@
+* Fix last restarted report date to be the sum of last updated at date and uptime

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -179,6 +179,7 @@ const DeviceUserPage = ({
       "primary_ip",
       "public_ip",
       "batteries",
+      "detail_updated_at",
     ])
   );
 

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -343,6 +343,7 @@ const HostDetailsPage = ({
       "public_ip",
       "geolocation",
       "batteries",
+      "detail_updated_at",
     ])
   );
 

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import ReactTooltip from "react-tooltip";
 
 import { IMDMData, IMunkiData, IDeviceUser } from "interfaces/host";
-import { humanHostUptime, humanHostEnrolled } from "utilities/helpers";
+import { humanHostLastRestart, humanHostEnrolled } from "utilities/helpers";
 
 interface IAboutProps {
   aboutData: { [key: string]: any };
@@ -159,7 +159,10 @@ const About = ({
           <div className="info-grid__block">
             <span className="info-grid__header">Last restarted</span>
             <span className="info-grid__data">
-              {wrapFleetHelper(humanHostUptime, aboutData.uptime)}
+              {humanHostLastRestart(
+                aboutData.detail_updated_at,
+                aboutData.uptime
+              )}
             </span>
           </div>
           <div className="info-grid__block">
@@ -193,7 +196,10 @@ const About = ({
         <div className="info-grid__block">
           <span className="info-grid__header">Last restarted</span>
           <span className="info-grid__data">
-            {wrapFleetHelper(humanHostUptime, aboutData.uptime)}
+            {humanHostLastRestart(
+              aboutData.detail_updated_at,
+              aboutData.uptime
+            )}
           </span>
         </div>
         <div className="info-grid__block">

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -591,6 +591,26 @@ export const humanHostUptime = (uptimeInNanoseconds: number): string => {
   return formatDistanceToNow(new Date(restartDate), { addSuffix: true });
 };
 
+export const humanHostLastRestart = (
+  detailUpdatedAt: string,
+  uptime: number
+): string => {
+  const currentDate = new Date();
+  const updatedDate = new Date(detailUpdatedAt);
+  const millisecondsLastUpdated = currentDate.getTime() - updatedDate.getTime();
+
+  // Sum of calculated milliseconds since last updated with uptime
+  const millisecondsLastRestart =
+    millisecondsLastUpdated + uptime / NANOSECONDS_PER_MILLISECOND;
+
+  const restartDate = new Date();
+  restartDate.setMilliseconds(
+    restartDate.getMilliseconds() - millisecondsLastRestart
+  );
+
+  return formatDistanceToNow(new Date(restartDate), { addSuffix: true });
+};
+
 export const humanHostLastSeen = (lastSeen: string): string => {
   return format(new Date(lastSeen), "MMM d yyyy, HH:mm:ss");
 };


### PR DESCRIPTION
Cerra #6467 

Last restart time incorrectly shows uptime (nanoseconds) as a measurement from current date

**Fix**
- Last restart time correctly shows the sum of two consecutive periods of time: 1) current date to last updated date (`last_updated_at`) which needs the measurement calculated and 2) last updated date to last restart date (measured already in nanoseconds as `uptime`)
- New function finds the length between current date and last restart date using the sum of these two times in milliseconds and converts it into human-readable text

**Screenshot: Last fetched 4 days ago + uptime = Fixed last restarted**
<img width="1286" alt="Screen Shot 2022-07-05 at 4 56 53 PM" src="https://user-images.githubusercontent.com/71795832/177415195-ec8ece56-d5f7-4a57-8be5-02b0ee3af494.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
