### PR TITLE
implement a docker image to package orbit natively in Linux

### DIFF
--- a/.github/workflows/test-native-tooling-packaging.yml
+++ b/.github/workflows/test-native-tooling-packaging.yml
@@ -1,0 +1,75 @@
+name: Test native tooling packaging
+
+# This workflow tests packaging of Fleet-osquery with the
+# `fleetdm/fleetctl` Docker image. 
+
+on:
+  push:
+    branches:
+      - main
+      - patch-*
+  pull_request:
+    paths:
+      - '**.go'
+      - 'tools/fleetctl-docker/**'
+      - 'tools/wix-docker/**'
+      - 'tools/bomutils-docker/**'
+      - '.github/workflows/test-native-tooling-packaging.yml'
+  workflow_dispatch: # Manual
+
+permissions:
+  contents: read
+
+jobs:
+  test-packaging:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        go-version: ['^1.17.8']
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Checkout Code
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+
+    - name: Install Go Dependencies
+      run: make deps-go
+
+    - name: Build fleetctl
+      run: make xp-fleetctl
+
+    # TODO: pull the image from the registry instead once it's published 
+    - name: Build fleetdm/fleetctl
+      run: docker build -t fleetdm/fleetctl --platform=linux/amd64 -f tools/fleetctl-docker/Dockerfile .
+
+    - name: Build DEB
+      run: docker run fleetdm/fleetctl package --type deb --enroll-secret=foo --fleet-url=https://localhost:8080
+    - name: Build DEB
+      run: docker run fleetdm/fleetctl package --type deb --enroll-secret=foo --fleet-url=https://localhost:8080
+
+    - name: Build DEB with Fleet Desktop
+      run: docker run fleetdm/fleetctl package --type deb --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop
+      
+    - name: Build RPM
+      run: docker run fleetdm/fleetctl --type rpm --enroll-secret=foo --fleet-url=https://localhost:8080
+      
+    - name: Build RPM with Fleet Desktop
+      run: docker run fleetdm/fleetctl package --type rpm --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop
+
+    - name: Build MSI
+      run: docker run fleetdm/fleetctl package --type msi --enroll-secret=foo --fleet-url=https://localhost:8080
+
+    - name: Build MSI with Fleet Desktop
+      run: docker run fleetdm/fleetctl package --type msi --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop
+
+    - name: Build PKG
+      run: docker run fleetdm/fleetctl package --type pkg --enroll-secret=foo --fleet-url=https://localhost:8080
+
+    - name: Build PKG with Fleet Desktop
+      run: docker run fleetdm/fleetctl package --type pkg --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop

--- a/.github/workflows/test-native-tooling-packaging.yml
+++ b/.github/workflows/test-native-tooling-packaging.yml
@@ -41,12 +41,8 @@ jobs:
     - name: Install Go Dependencies
       run: make deps-go
 
-    - name: Build fleetctl
-      run: make xp-fleetctl
-
-    # TODO: pull the image from the registry instead once it's published 
     - name: Build fleetdm/fleetctl
-      run: docker build -t fleetdm/fleetctl --platform=linux/amd64 -f tools/fleetctl-docker/Dockerfile .
+      run: make fleetctl-docker
 
     - name: Build DEB
       run: docker run -v "$(pwd):/build" fleetdm/fleetctl package --type deb --enroll-secret=foo --fleet-url=https://localhost:8080

--- a/.github/workflows/test-native-tooling-packaging.yml
+++ b/.github/workflows/test-native-tooling-packaging.yml
@@ -50,8 +50,6 @@ jobs:
 
     - name: Build DEB
       run: docker run -v "$(pwd):/build" fleetdm/fleetctl package --type deb --enroll-secret=foo --fleet-url=https://localhost:8080
-    - name: Build DEB
-      run: docker run fleetdm/fleetctl package --type deb --enroll-secret=foo --fleet-url=https://localhost:8080
 
     - name: Build DEB with Fleet Desktop
       run: docker run -v "$(pwd):/build" fleetdm/fleetctl package --type deb --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop

--- a/.github/workflows/test-native-tooling-packaging.yml
+++ b/.github/workflows/test-native-tooling-packaging.yml
@@ -49,27 +49,27 @@ jobs:
       run: docker build -t fleetdm/fleetctl --platform=linux/amd64 -f tools/fleetctl-docker/Dockerfile .
 
     - name: Build DEB
-      run: docker run fleetdm/fleetctl package --type deb --enroll-secret=foo --fleet-url=https://localhost:8080
+      run: docker run -v "$(pwd):/build" fleetdm/fleetctl package --type deb --enroll-secret=foo --fleet-url=https://localhost:8080
     - name: Build DEB
       run: docker run fleetdm/fleetctl package --type deb --enroll-secret=foo --fleet-url=https://localhost:8080
 
     - name: Build DEB with Fleet Desktop
-      run: docker run fleetdm/fleetctl package --type deb --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop
+      run: docker run -v "$(pwd):/build" fleetdm/fleetctl package --type deb --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop
       
     - name: Build RPM
-      run: docker run fleetdm/fleetctl --type rpm --enroll-secret=foo --fleet-url=https://localhost:8080
+      run: docker run -v "$(pwd):/build" fleetdm/fleetctl --type rpm --enroll-secret=foo --fleet-url=https://localhost:8080
       
     - name: Build RPM with Fleet Desktop
-      run: docker run fleetdm/fleetctl package --type rpm --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop
+      run: docker run -v "$(pwd):/build" fleetdm/fleetctl package --type rpm --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop
 
     - name: Build MSI
-      run: docker run fleetdm/fleetctl package --type msi --enroll-secret=foo --fleet-url=https://localhost:8080
+      run: docker run -v "$(pwd):/build" fleetdm/fleetctl package --type msi --enroll-secret=foo --fleet-url=https://localhost:8080
 
     - name: Build MSI with Fleet Desktop
-      run: docker run fleetdm/fleetctl package --type msi --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop
+      run: docker run -v "$(pwd):/build" fleetdm/fleetctl package --type msi --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop
 
     - name: Build PKG
-      run: docker run fleetdm/fleetctl package --type pkg --enroll-secret=foo --fleet-url=https://localhost:8080
+      run: docker run -v "$(pwd):/build" fleetdm/fleetctl package --type pkg --enroll-secret=foo --fleet-url=https://localhost:8080
 
     - name: Build PKG with Fleet Desktop
-      run: docker run fleetdm/fleetctl package --type pkg --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop
+      run: docker run -v "$(pwd):/build" fleetdm/fleetctl package --type pkg --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -13,8 +13,6 @@ on:
   pull_request:
     paths:
       - '**.go'
-      - 'tools/wix-docker/**'
-      - 'tools/bomutils-docker/**'
       - '.github/workflows/test-packaging.yml'
   workflow_dispatch: # Manual
 

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -13,7 +13,6 @@ on:
   pull_request:
     paths:
       - '**.go'
-      - 'tools/fleetctl-docker/**'
       - 'tools/wix-docker/**'
       - 'tools/bomutils-docker/**'
       - '.github/workflows/test-packaging.yml'

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -1,7 +1,7 @@
 name: Test packaging
 
 # This workflow tests packaging of Fleet-osquery with the
-# `fleetctl package' command. It fetches the targets: orbit,
+# `fleetctl package` command. It fetches the targets: orbit,
 # osquery and fleet-desktop from the default (Fleet's) TUF server,
 # https://tuf.fleetctl.com.
 
@@ -13,6 +13,9 @@ on:
   pull_request:
     paths:
       - '**.go'
+      - 'tools/fleetctl-docker/**'
+      - 'tools/wix-docker/**'
+      - 'tools/bomutils-docker/**'
       - '.github/workflows/test-packaging.yml'
   workflow_dispatch: # Manual
 

--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ docker-push-release: docker-build-release
 	docker push fleetdm/fleet:${VERSION}
 	docker push fleetdm/fleet:latest
 
-fleetcl-docker: xp-fleetctl
+fleetctl-docker: xp-fleetctl
 	docker build -t fleetdm/fleetctl --platform=linux/amd64 -f tools/fleetctl-docker/Dockerfile .
 
 .pre-binary-bundle:

--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,9 @@ docker-push-release: docker-build-release
 	docker push fleetdm/fleet:${VERSION}
 	docker push fleetdm/fleet:latest
 
+fleetcl-docker: xp-fleetctl
+	docker build -t fleetdm/fleetctl --platform=linux/amd64 -f tools/fleetctl-docker/Dockerfile .
+
 .pre-binary-bundle:
 	rm -rf build/binary-bundle
 	mkdir -p build/binary-bundle/linux

--- a/cmd/fleetctl/package.go
+++ b/cmd/fleetctl/package.go
@@ -144,6 +144,12 @@ func packageCommand() *cli.Command {
 				Usage:       "Disable opening the folder at the end",
 				Destination: &disableOpenFolder,
 			},
+			&cli.BoolFlag{
+				Name:        "native-tooling",
+				Usage:       "Build the package using native tooling (only available in Linux)",
+				EnvVars:     []string{"FLEETCTL_NATIVE_TOOLING"},
+				Destination: &opt.NativeTooling,
+			},
 		},
 		Action: func(c *cli.Context) error {
 			if opt.FleetURL != "" || opt.EnrollSecret != "" {
@@ -158,6 +164,10 @@ func packageCommand() *cli.Command {
 
 			if runtime.GOOS == "windows" && c.String("type") != "msi" {
 				return errors.New("Windows can only build MSI packages.")
+			}
+
+			if opt.NativeTooling && runtime.GOOS != "linux" {
+				return errors.New("native tooling is only available in Linux")
 			}
 
 			if opt.FleetCertificate != "" {

--- a/cmd/fleetctl/package_test.go
+++ b/cmd/fleetctl/package_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/packaging"
@@ -37,6 +38,10 @@ func TestPackage(t *testing.T) {
 	err = ioutil.WriteFile(fleetCertificate, []byte("undefined"), os.FileMode(0o644))
 	require.NoError(t, err)
 	runAppCheckErr(t, []string{"package", "--type=deb", fmt.Sprintf("--fleet-certificate=%s", fleetCertificate)}, fmt.Sprintf("failed to read certificate %q: invalid PEM file", fleetCertificate))
+
+	if runtime.GOOS != "linux" {
+		runAppCheckErr(t, []string{"package", "--type=msi", "--native-tooling"}, "native on non-linux platforms fails")
+	}
 
 	t.Run("deb", func(t *testing.T) {
 		runAppForTest(t, []string{"package", "--type=deb", "--insecure", "--disable-open-folder"})

--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -184,6 +184,9 @@ func buildNFPM(opt Options, pkger nfpm.Packager) (string, error) {
 		},
 	}
 	filename := pkger.ConventionalFileName(info)
+	if opt.NativeTooling {
+		filename = filepath.Join("build", filename)
+	}
 
 	out, err := secure.OpenFile(filename, os.O_CREATE|os.O_RDWR, constant.DefaultFileMode)
 	if err != nil {

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -63,6 +63,9 @@ type Options struct {
 	// LegacyVarLibSymlink indicates whether Orbit is legacy (< 0.0.11),
 	// which assumes it is installed under /var/lib.
 	LegacyVarLibSymlink bool
+	// Native tooling is used to determine if the package should be build
+	// natively instead of via Docker images.
+	NativeTooling bool
 }
 
 func initializeTempDir() (string, error) {

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -63,7 +63,7 @@ type Options struct {
 	// LegacyVarLibSymlink indicates whether Orbit is legacy (< 0.0.11),
 	// which assumes it is installed under /var/lib.
 	LegacyVarLibSymlink bool
-	// Native tooling is used to determine if the package should be build
+	// Native tooling is used to determine if the package should be built
 	// natively instead of via Docker images.
 	NativeTooling bool
 }

--- a/orbit/pkg/packaging/windows.go
+++ b/orbit/pkg/packaging/windows.go
@@ -100,7 +100,7 @@ func BuildMSI(opt Options) (string, error) {
 		}
 	}
 
-	if err := wix.Heat(tmpDir); err != nil {
+	if err := wix.Heat(tmpDir, opt.NativeTooling); err != nil {
 		return "", fmt.Errorf("package root files: %w", err)
 	}
 
@@ -108,15 +108,18 @@ func BuildMSI(opt Options) (string, error) {
 		return "", fmt.Errorf("transform heat: %w", err)
 	}
 
-	if err := wix.Candle(tmpDir); err != nil {
+	if err := wix.Candle(tmpDir, opt.NativeTooling); err != nil {
 		return "", fmt.Errorf("build package: %w", err)
 	}
 
-	if err := wix.Light(tmpDir); err != nil {
+	if err := wix.Light(tmpDir, opt.NativeTooling); err != nil {
 		return "", fmt.Errorf("build package: %w", err)
 	}
 
 	filename := "fleet-osquery.msi"
+	if opt.NativeTooling {
+		filename = filepath.Join("build", filename)
+	}
 	if err := file.Copy(filepath.Join(tmpDir, "orbit.msi"), filename, constant.DefaultFileMode); err != nil {
 		return "", fmt.Errorf("rename msi: %w", err)
 	}

--- a/orbit/pkg/packaging/wix/wix_test.go
+++ b/orbit/pkg/packaging/wix/wix_test.go
@@ -1,0 +1,23 @@
+package wix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWindowsJoin(t *testing.T) {
+	cases := []struct {
+		in  []string
+		out string
+	}{
+		{[]string{"one\\two", "three"}, "one\\two\\three"},
+		{[]string{"one/two/three", "four.txt"}, "one\\two\\three\\four.txt"},
+		{[]string{"one", "two", "three"}, "one\\two\\three"},
+		{[]string{"one/two/three", "four/five.txt"}, "one\\two\\three\\four\\five.txt"},
+	}
+
+	for _, c := range cases {
+		require.Equal(t, c.out, windowsJoin(c.in...))
+	}
+}

--- a/tools/fleetctl-docker/Dockerfile
+++ b/tools/fleetctl-docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM debian:stable-slim
+
+RUN apt-get update \
+  && dpkg --add-architecture i386 \
+  && apt update \
+  && apt install -y --no-install-recommends ca-certificates cpio libxml2 wine wine32 libgtk-3-0 \
+  && rm -rf /var/lib/apt/lists/* 
+
+# copy macOS dependencies
+COPY --from=fleetdm/bomutils:latest /usr/bin/mkbom /usr/local/bin/xar /usr/bin/
+COPY --from=fleetdm/bomutils:latest /usr/local/lib /usr/local/lib/
+
+# copy Windows dependencies
+COPY --from=fleetdm/wix:latest /home/wine /home/wine
+
+# copy fleetctl
+COPY build/binary-bundle/linux/fleetctl /usr/bin/fleetctl
+
+ENV FLEETCTL_NATIVE_TOOLING=1 WINEPREFIX=/home/wine/.wine WINEARCH=win32 PATH="/home/wine/bin:$PATH" WINEDEBUG=-all
+
+ENTRYPOINT ["fleetctl"]

--- a/tools/fleetctl-docker/README.md
+++ b/tools/fleetctl-docker/README.md
@@ -1,0 +1,26 @@
+## fleetdm/fleetctl
+
+This docker image allows to run `fleetctl` in a Linux environment that has all
+the necessary dependencies to package `msi`, `pkg`, `deb` and `rpm` packages.
+
+### Usage
+
+```
+docker run fleetdm/fleetctl command [flags]
+```
+
+Build artifacts are generated at `/build`. To get a package using this image:
+
+```
+docker run -v "$(pwd):/build" fleetdm/fleetctl package --type=msi
+```
+
+### Building
+
+This image needs to be built from the root of the repo in order for the build
+context to have access to the `fleetctl` binary. To build the image, run:
+
+```
+make xp-fleetctl
+docker build -t fleetdm/fleetctl --platform=linux/amd64 -f tools/fleetctl-docker/Dockerfile .
+```

--- a/tools/fleetctl-docker/README.md
+++ b/tools/fleetctl-docker/README.md
@@ -21,6 +21,5 @@ This image needs to be built from the root of the repo in order for the build
 context to have access to the `fleetctl` binary. To build the image, run:
 
 ```
-make xp-fleetctl
-docker build -t fleetdm/fleetctl --platform=linux/amd64 -f tools/fleetctl-docker/Dockerfile .
+make fleetcl-docker
 ```

--- a/tools/fleetctl-docker/README.md
+++ b/tools/fleetctl-docker/README.md
@@ -21,5 +21,5 @@ This image needs to be built from the root of the repo in order for the build
 context to have access to the `fleetctl` binary. To build the image, run:
 
 ```
-make fleetcl-docker
+make fleetctl-docker
 ```


### PR DESCRIPTION
Related to [#6364](https://github.com/fleetdm/fleet/issues/6364) and #6363, this:

- Adds a new Docker image, `fleetdm/fleetctl` equipped with all necessary dependencies to build Fleet-osquery binaries for all platforms
- Modifies the package generation logic to special case this scenario via an environment variable `FLEETCTL_NATIVE_TOOLING`
- Adds a new GitHub workflow to test this

There are more details in the README, but part of the special-casing logic is in place to output the binaries to a folder named `build` when they are run with `FLEETCTL_NATIVE_TOOLING`, this is so we can persist the binary generated by the docker container via a bind mount:

```bash
docker run -v "$(pwd):/build" fleetdm/fleetctl package --type=msi
```

To test this changeset, I have generated packages for all platforms, both via the new Docker image and via the classic `fleetctl package`.

**Note**: a follow-up PR will add notarization for macOS binaries with native tooling, there's already too much going on here.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
