### PR TITLE
Add `gotestfmt` to improve test output and fix some flaky tests

### DIFF
--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -68,6 +68,7 @@ jobs:
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
     - name: Get fleet logs
+      if: always()
       run: |
         FLEET_LICENSE_KEY=foo docker compose -f ~/.fleet/preview/docker-compose.yml logs fleet01 fleet02 > fleet-logs.txt
         # Copying logs, otherwise the upload-artifact action uploads the logs in a hidden folder (.fleet)

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -36,6 +36,9 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
 
+    - name: Set up gotestfmt
+      run: go install github.com/haveyoudebuggedit/gotestfmt/v2/cmd/gotestfmt@v2.3.2
+
     - name: Checkout Code
       uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
@@ -61,7 +64,12 @@ jobs:
 
     - name: Run Go Tests
       run: |
-        TEST_LOCK_FILE_PATH=$(pwd)/lock NETWORK_TEST=1 REDIS_TEST=1 MYSQL_TEST=1 RACE_ENABLED=$RACE_ENABLED GO_TEST_TIMEOUT=$GO_TEST_TIMEOUT make test-go
+        GO_TEST_EXTRA_FLAGS="-v -json -race=$RACE_ENABLED -timeout=$GO_TEST_TIMEOUT" \
+          TEST_LOCK_FILE_PATH=$(pwd)/lock \
+          NETWORK_TEST=1 \
+          REDIS_TEST=1 \
+          MYSQL_TEST=1 \
+          make test-go 2>&1 | tee /tmp/gotest.log | gotestfmt
 
     - name: Upload to Codecov
       uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378
@@ -88,3 +96,11 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_G_PLATFORM_WEBHOOK_URL }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+    - name: Upload test log
+      if: always()
+      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v2
+      with:
+        name: test-log
+        path: /tmp/gotest.log
+        if-no-files-found: error

--- a/cmd/fleetctl/preview_test.go
+++ b/cmd/fleetctl/preview_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -23,12 +24,21 @@ func TestPreview(t *testing.T) {
 		require.Equal(t, "", runAppForTest(t, []string{"preview", "--config", configPath, "stop"}))
 	})
 
-	output := runAppForTest(t, []string{"preview", "--config", configPath, "--tag", "main", "--disable-open-browser"})
+	var output *bytes.Buffer
+	nettest.RunWithNetRetry(t, func() error {
+		var err error
+		output, err = runAppNoChecks([]string{
+			"preview", "--config", configPath,
+			"--tag", "main",
+			"--disable-open-browser",
+		})
+		return err
+	})
 
 	queriesRe := regexp.MustCompile(`applied ([0-9]+) queries`)
 	policiesRe := regexp.MustCompile(`applied ([0-9]+) policies`)
-	require.True(t, queriesRe.MatchString(output))
-	require.True(t, policiesRe.MatchString(output))
+	require.True(t, queriesRe.MatchString(output.String()))
+	require.True(t, policiesRe.MatchString(output.String()))
 
 	// run some sanity checks on the preview environment
 

--- a/pkg/nettest/nettest.go
+++ b/pkg/nettest/nettest.go
@@ -62,8 +62,11 @@ func Retryable(err error) bool {
 	}
 	// Using the exact same error check used in:
 	// https://github.com/golang/go/blob/a5d61be040ed20b5774bff1b6b578c6d393ab332/src/net/http/serve_test.go#L1417
+	//
+	// Also we use raw string matching because this method is used on raw error strings (returned by commands).
 	if errStr := err.Error(); (strings.Contains(errStr, "timeout") && strings.Contains(errStr, "TLS handshake")) ||
-		strings.Contains(errStr, "unexpected EOF") || strings.Contains(errStr, "connection reset by peer") || strings.Contains(errStr, "unexpected http response") {
+		strings.Contains(errStr, "unexpected EOF") || strings.Contains(errStr, "connection reset by peer") ||
+		strings.Contains(errStr, "unexpected http response") || strings.Contains(errStr, "context deadline exceeded") {
 		return true
 	}
 	return false


### PR DESCRIPTION
Adds https://github.com/haveyoudebuggedit/gotestfmt to our [test-go.yaml](https://github.com/fleetdm/fleet/blob/main/.github/workflows/test-go.yaml) action.

It will hopefully ease the finding of failing tests and troubleshooting.

![Screen Shot 2022-07-07 at 08 58 49](https://user-images.githubusercontent.com/2073526/177768053-ae568dfd-d7db-46d0-8ff8-f0583029482f.png)
