### PR TITLE
Add rate limits for device authed endpoints

### DIFF
--- a/changes/rate-limit-device-authed
+++ b/changes/rate-limit-device-authed
@@ -1,0 +1,1 @@
+* Rate limit device authenticated endpoints when there's a failure

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -397,6 +397,8 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 
 	// device-authenticated endpoints
 	de := newDeviceAuthenticatedEndpointer(svc, logger, opts, r, apiVersions...)
+	// We allow a quota of 720 because in the onboarding of a Fleet Desktop takes a few tries until it authenticates
+	// properly
 	desktopQuota := throttled.RateQuota{MaxRate: throttled.PerHour(720), MaxBurst: 100}
 	de.WithCustomMiddleware(
 		errorLimiter.Limit("get_device_host", desktopQuota),

--- a/server/service/middleware/ratelimit/ratelimit.go
+++ b/server/service/middleware/ratelimit/ratelimit.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/go-kit/kit/endpoint"
+	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/throttled/throttled/v2"
 )
 
@@ -43,6 +44,53 @@ func (m *Middleware) Limit(keyName string, quota throttled.RateQuota) endpoint.M
 			}
 
 			return next(ctx, req)
+		}
+	}
+}
+
+// ErrorMiddleware is a rate limiter that performs limits only when there is an error in the request
+type ErrorMiddleware struct {
+	store throttled.GCRAStore
+}
+
+// NewErrorMiddleware creates a new instance of ErrorMiddleware
+func NewErrorMiddleware(store throttled.GCRAStore) *ErrorMiddleware {
+	if store == nil {
+		panic("nil store")
+	}
+
+	return &ErrorMiddleware{store: store}
+}
+
+// Limit returns a new middleware function enforcing the provided quota only when errors occur in the next middleware
+func (m *ErrorMiddleware) Limit(keyName string, quota throttled.RateQuota) endpoint.Middleware {
+	return func(next endpoint.Endpoint) endpoint.Endpoint {
+		limiter, err := throttled.NewGCRARateLimiter(m.store, quota)
+		if err != nil {
+			panic(err)
+		}
+
+		return func(ctx context.Context, req interface{}) (response interface{}, err error) {
+			xForwardedFor, _ := ctx.Value(kithttp.ContextKeyRequestXForwardedFor).(string)
+			ipKeyName := fmt.Sprintf("%s-%s", keyName, xForwardedFor)
+
+			// RateLimit with quantity 0 will never get limited=true, so we check result.Remaining instead
+			_, result, err := limiter.RateLimit(ipKeyName, 0)
+			if err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "check rate limit")
+			}
+			if result.Remaining == 0 {
+				return nil, ctxerr.Wrap(ctx, &ratelimitError{result: result})
+			}
+
+			resp, err := next(ctx, req)
+			if err != nil {
+				_, _, rateErr := limiter.RateLimit(ipKeyName, 1)
+				if rateErr != nil {
+					return nil, ctxerr.Wrap(ctx, err, "check rate limit")
+				}
+			}
+			return resp, err
 		}
 	}
 }

--- a/server/service/middleware/ratelimit/ratelimit_test.go
+++ b/server/service/middleware/ratelimit/ratelimit_test.go
@@ -34,6 +34,16 @@ func TestLimit(t *testing.T) {
 	assert.True(t, errors.As(err, &rle))
 }
 
+func TestNewErrorMiddlewarePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+	}()
+
+	NewErrorMiddleware(nil)
+}
+
 func TestLimitOnlyWhenError(t *testing.T) {
 	t.Parallel()
 

--- a/server/service/middleware/ratelimit/ratelimit_test.go
+++ b/server/service/middleware/ratelimit/ratelimit_test.go
@@ -3,7 +3,6 @@ package ratelimit
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,7 +50,7 @@ func TestLimitOnlyWhenError(t *testing.T) {
 	_, err = wrapped(context.Background(), struct{}{})
 	assert.NoError(t, err)
 
-	failingEndpoint := func(context.Context, interface{}) (interface{}, error) { return nil, fmt.Errorf("error") }
+	failingEndpoint := func(context.Context, interface{}) (interface{}, error) { return nil, errors.New("error") }
 	wrappedFailer := limiter.Limit(
 		"test_limit", throttled.RateQuota{MaxRate: throttled.PerHour(1), MaxBurst: 0},
 	)(failingEndpoint)

--- a/server/service/middleware/ratelimit/ratelimit_test.go
+++ b/server/service/middleware/ratelimit/ratelimit_test.go
@@ -60,13 +60,14 @@ func TestLimitOnlyWhenError(t *testing.T) {
 	_, err = wrapped(context.Background(), struct{}{})
 	assert.NoError(t, err)
 
-	failingEndpoint := func(context.Context, interface{}) (interface{}, error) { return nil, errors.New("error") }
+	expectedError := errors.New("error")
+	failingEndpoint := func(context.Context, interface{}) (interface{}, error) { return nil, expectedError }
 	wrappedFailer := limiter.Limit(
 		"test_limit", throttled.RateQuota{MaxRate: throttled.PerHour(1), MaxBurst: 0},
 	)(failingEndpoint)
 
 	_, err = wrappedFailer(context.Background(), struct{}{})
-	assert.NoError(t, err)
+	assert.ErrorIs(t, err, expectedError)
 
 	// Hits rate limit now that it fails
 	_, err = wrappedFailer(context.Background(), struct{}{})


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- ~Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~Documented any permissions changes~
- ~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
- ~Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [x] Added/updated tests
- ~Manual QA for all new/changed functionality~
