### PR TITLE
add jq to docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk --update add ca-certificates
 RUN apk --no-cache add jq
 
 # Create FleetDM group and user
-RUN addgroup -S fleet && adduser -S -G fleet fleet
+RUN addgroup -S fleet && adduser -S fleet -G fleet
 
 COPY ./build/binary-bundle/linux/fleet ./build/binary-bundle/linux/fleetctl /usr/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 LABEL maintainer="Fleet Developers <hello@fleetdm.com>"
 
-RUN apk --update add ca-certificates
+RUN apk --update add ca-certificates jq
 
 # Create FleetDM group and user
 RUN addgroup -S fleet && adduser -S fleet -G fleet

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine
 LABEL maintainer="Fleet Developers <hello@fleetdm.com>"
 
-RUN apk --update add ca-certificates jq
+RUN apk --update add ca-certificates
+RUN apk --no-cache add jq
 
 # Create FleetDM group and user
 RUN addgroup -S fleet && adduser -S -G fleet fleet

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Fleet Developers <hello@fleetdm.com>"
 RUN apk --update add ca-certificates jq
 
 # Create FleetDM group and user
-RUN addgroup -S fleet && adduser -S fleet -G fleet
+RUN addgroup -S fleet && adduser -S -G fleet fleet
 
 COPY ./build/binary-bundle/linux/fleet ./build/binary-bundle/linux/fleetctl /usr/bin/
 

--- a/tools/docker/fleet.Dockerfile
+++ b/tools/docker/fleet.Dockerfile
@@ -2,6 +2,7 @@ FROM alpine
 LABEL maintainer="Fleet Developers <hello@fleetdm.com>"
 
 RUN apk --update add ca-certificates
+RUN apk --no-cache add jq
 
 # Create fleet group and user
 RUN addgroup -S fleet && adduser -S fleet -G fleet

--- a/tools/docker/fleetctl.Dockerfile
+++ b/tools/docker/fleetctl.Dockerfile
@@ -2,6 +2,7 @@ FROM alpine
 LABEL maintainer="Fleet Developers <hello@fleetdm.com>"
 
 RUN apk --update add ca-certificates
+RUN apk --no-cache add jq
 
 # Create fleet group and user
 RUN addgroup -S fleet && adduser -S fleet -G fleet


### PR DESCRIPTION
This change installs `jq` into the Fleet docker image for both Fleet server and `fleetctl`. This is mainly to enable the parsing of `VCAP_SERVICES` env var which is injected into container image deploys in CloudFoundry. More details can be found [here](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES)

The typical use case involves parsing `VCAP_SERVICES` for details on other "binded" services like databases, caches, etc.

This might look something like:

```yaml
applications:
- name: fleetdm
  memory: 512m
  disk_quota: 2g
  instances: 1
  stack: cflinuxfs3
  timeout: 120
  command: |
    fleet prepare --no-prompt=true db && \
    fleet serve
  docker:
    image: fleetdm/fleet:latest
  services:
    - fleetdm-db
    - fleetdm-mysql
  env:
    FLEET_LOGGING_JSON: true
    FLEET_LOGGING_DEBUG: true
    FLEET_SERVER_TLS: false
    FLEET_MYSQL_USERNAME: $( echo $VCAP_SERVICES | jq -r '.system_env_json.VCAP_SERVICES["aws-rds"][].credentials.username')
    # mysql address is in the form of <host:port> for example localhost:3306
    FLEET_MYSQL_ADDRESS: $( echo $VCAP_SERVICES | jq -r '.system_env_json.VCAP_SERVICES["aws-rds"][].credentials.host'):$( echo $VCAP_SERVICES | jq -r '.system_env_json.VCAP_SERVICES["aws-rds"][].credentials.port')
    FLEET_MYSQL_DATABASE: $( echo $VCAP_SERVICES | jq -r '.system_env_json.VCAP_SERVICES["aws-rds"][].credentials.db_name')
    FLEET_MYSQL_PASSWORD: $( echo $VCAP_SERVICES | jq -r '.system_env_json.VCAP_SERVICES["aws-rds"][].credentials.password')
    # redis address is in the form of <host:port> for example localhost:6379
    FLEET_REDIS_ADDRESS: <elasticache_host>:<elasticache_port>
```