### PR TITLE
add tf vars for cloudwatch log retention & rds snapshot backup retention

### DIFF
--- a/.github/workflows/dogfood-deploy.yml
+++ b/.github/workflows/dogfood-deploy.yml
@@ -1,3 +1,4 @@
+name: Deploy Dogfood Environment
 on:
   workflow_dispatch:
     inputs:
@@ -19,6 +20,8 @@ env:
   TF_VAR_fleet_image: ${{ github.event.inputs.IMAGE_TAG || 'fleetdm/fleet:main' }}
   TF_VAR_logging_debug: true
   TF_VAR_fleet_license: ${{ secrets.DOGFOOD_LICENSE_KEY }}
+  TF_VAR_cloudwatch_log_retention: 30
+  TF_VAR_rds_backup_retention_period: 30
 
 permissions:
   id-token: write

--- a/infrastructure/dogfood/terraform/aws/ecs.tf
+++ b/infrastructure/dogfood/terraform/aws/ecs.tf
@@ -113,7 +113,7 @@ resource "aws_ecs_service" "fleet" {
 // possibility of providing this capability in the future.
 resource "aws_cloudwatch_log_group" "backend" { #tfsec:ignore:aws-cloudwatch-log-group-customer-key:exp:2022-07-01
   name              = "fleetdm"
-  retention_in_days = 1
+  retention_in_days = var.cloudwatch_log_retention
 }
 
 resource "aws_ecs_task_definition" "backend" {

--- a/infrastructure/dogfood/terraform/aws/rds.tf
+++ b/infrastructure/dogfood/terraform/aws/rds.tf
@@ -78,6 +78,7 @@ module "aurora_mysql" {
   create_random_password              = false
   database_name                       = var.database_name
   enable_http_endpoint                = false
+  backup_retention_period = var.
   #performance_insights_enabled        = true
 
   vpc_id                = module.vpc.vpc_id

--- a/infrastructure/dogfood/terraform/aws/rds.tf
+++ b/infrastructure/dogfood/terraform/aws/rds.tf
@@ -5,7 +5,7 @@ resource "random_password" "database_password" {
 // Customer keys are not supported in our Fleet Terraforms at the moment. We will evaluate the
 // possibility of providing this capability in the future.
 resource "aws_secretsmanager_secret" "database_password_secret" { #tfsec:ignore:aws-ssm-secret-use-customer-key:exp:2022-07-01
-  name = "/fleet/database/password/master"
+  name                    = "/fleet/database/password/master"
   recovery_window_in_days = 0
 }
 
@@ -78,8 +78,8 @@ module "aurora_mysql" {
   create_random_password              = false
   database_name                       = var.database_name
   enable_http_endpoint                = false
-  backup_retention_period = var.
-  #performance_insights_enabled        = true
+  backup_retention_period             = var.rds_backup_retention_period
+  #performance_insights_enabled       = true
 
   vpc_id                = module.vpc.vpc_id
   subnets               = module.vpc.database_subnets

--- a/infrastructure/dogfood/terraform/aws/variables.tf
+++ b/infrastructure/dogfood/terraform/aws/variables.tf
@@ -105,3 +105,13 @@ variable "fleet_license" {
   description = "Fleet Premium license key"
   default     = ""
 }
+
+variable "cloudwatch_log_retention" {
+  description = "number of days to keep logs around for fleet services"
+  default = 1
+}
+
+variable "rds_backup_retention_period" {
+  description = "number of days to keep snapshot backups"
+  default = 7
+}

--- a/infrastructure/dogfood/terraform/aws/variables.tf
+++ b/infrastructure/dogfood/terraform/aws/variables.tf
@@ -108,10 +108,10 @@ variable "fleet_license" {
 
 variable "cloudwatch_log_retention" {
   description = "number of days to keep logs around for fleet services"
-  default = 1
+  default     = 1
 }
 
 variable "rds_backup_retention_period" {
   description = "number of days to keep snapshot backups"
-  default = 7
+  default     = 7
 }


### PR DESCRIPTION
Add new terraform variables for cloudwatch log retention & rds snapshot back retention, defaulting to the previous defaulted values.

Override new tf vars in dogfood enviroment.
