### PR TITLE
Make universal binary for Desktop on macOS

### DIFF
--- a/changes/desktop-universal-binary
+++ b/changes/desktop-universal-binary
@@ -1,0 +1,1 @@
+* Make Fleet Desktop a macOS Universal Binary (native M1 support).

--- a/tools/desktop/desktop.go
+++ b/tools/desktop/desktop.go
@@ -177,9 +177,9 @@ func createMacOSApp(version, authority string, notarize bool) error {
 	buildExec.Stderr = os.Stderr
 	buildExec.Stdout = os.Stdout
 
-	zlog.Info().Str("command", buildExec.String()).Msg("Build fleet-desktop executable amd64")
+	zlog.Info().Str("command", buildExec.String()).Msg("Build fleet-desktop executable arm64")
 	if err := buildExec.Run(); err != nil {
-		return fmt.Errorf("compile for amd64: %w", err)
+		return fmt.Errorf("compile for arm64: %w", err)
 	}
 
 	// Make the fat exe and remove the separate binaries
@@ -338,12 +338,11 @@ func makeFatExecutable(outPath string, inPaths ...string) error {
 	// Decide on whether we're doing fat32 or fat64.
 	sixtyfour := false
 	if inputs[len(inputs)-1].offset >= 1<<32 || len(inputs[len(inputs)-1].data) >= 1<<32 {
-		sixtyfour = true
 		// fat64 doesn't seem to work:
 		//   - the resulting binary won't run.
 		//   - the resulting binary is parseable by lipo, but reports that the contained files are "hidden".
 		//   - the native OSX lipo can't make a fat64.
-		return fmt.Errorf("files too large to fit into a fat binary")
+		return errors.New("files too large to fit into a fat binary")
 	}
 
 	// Make output file.

--- a/tools/desktop/desktop.go
+++ b/tools/desktop/desktop.go
@@ -4,6 +4,8 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
+	"debug/macho"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -79,7 +81,7 @@ func macos() *cli.Command {
 				EnvVars: []string{"FLEET_DESKTOP_APPLE_AUTHORITY"},
 			},
 			&cli.BoolFlag{
-				Name:    "notarize",
+				Name:    "`notarize`",
 				Usage:   "If true, the generated application will be notarized and stapled. Requires the `AC_USERNAME` and `AC_PASSWORD` to be set in the environment",
 				EnvVars: []string{"FLEET_DESKTOP_NOTARIZE"},
 			},
@@ -146,20 +148,49 @@ func createMacOSApp(version, authority string, notarize bool) error {
 		return fmt.Errorf("create Info.plist file %q: %w", infoFile, err)
 	}
 
+	binaryPath := filepath.Join(macOSDir, constant.DesktopAppExecName)
+
+	amdBinaryPath := binaryPath + "_amd64"
 	/* #nosec G204 -- arguments are actually well defined */
 	buildExec := exec.Command("go", "build",
-		"-o", filepath.Join(macOSDir, constant.DesktopAppExecName),
+		"-o", amdBinaryPath,
 		"-ldflags", os.ExpandEnv("-X=main.version=$FLEET_DESKTOP_VERSION"),
 		"./"+filepath.Join("orbit", "cmd", "desktop"),
 	)
-	buildExec.Env = append(os.Environ(), "CGO_ENABLED=1")
+	buildExec.Env = append(os.Environ(), "CGO_ENABLED=1", "GOOS=darwin", "GOARCH=amd64")
 	buildExec.Stderr = os.Stderr
 	buildExec.Stdout = os.Stdout
 
-	zlog.Info().Str("command", buildExec.String()).Msg("Build fleet-desktop executable")
-
+	zlog.Info().Str("command", buildExec.String()).Msg("Build fleet-desktop executable amd64")
 	if err := buildExec.Run(); err != nil {
-		return fmt.Errorf("compile application: %w", err)
+		return fmt.Errorf("compile for amd64: %w", err)
+	}
+
+	armBinaryPath := binaryPath + "_arm64"
+	/* #nosec G204 -- arguments are actually well defined */
+	buildExec = exec.Command("go", "build",
+		"-o", armBinaryPath,
+		"-ldflags", os.ExpandEnv("-X=main.version=$FLEET_DESKTOP_VERSION"),
+		"./"+filepath.Join("orbit", "cmd", "desktop"),
+	)
+	buildExec.Env = append(os.Environ(), "CGO_ENABLED=1", "GOOS=darwin", "GOARCH=arm64")
+	buildExec.Stderr = os.Stderr
+	buildExec.Stdout = os.Stdout
+
+	zlog.Info().Str("command", buildExec.String()).Msg("Build fleet-desktop executable amd64")
+	if err := buildExec.Run(); err != nil {
+		return fmt.Errorf("compile for amd64: %w", err)
+	}
+
+	// Make the fat exe and remove the separate binaries
+	if err := makeFatExecutable(binaryPath, amdBinaryPath, armBinaryPath); err != nil {
+		return fmt.Errorf("make fat exectuable: %w", err)
+	}
+	if err := os.Remove(amdBinaryPath); err != nil {
+		return fmt.Errorf("remove amd64 binary: %w", err)
+	}
+	if err := os.Remove(armBinaryPath); err != nil {
+		return fmt.Errorf("remove arm64 binary: %w", err)
 	}
 
 	if authority != "" {
@@ -259,6 +290,126 @@ func compressDir(outPath, dirPath string) error {
 	}
 	if err := out.Close(); err != nil {
 		return fmt.Errorf("close file: %w", err)
+	}
+
+	return nil
+}
+
+// Adapted from Unlicensed https://github.com/randall77/makefat/blob/master/makefat.go
+const (
+	MagicFat64 = macho.MagicFat + 1 // TODO: add to stdlib (...when it works)
+
+	// Alignment wanted for each sub-file.
+	// amd64 needs 12 bits, arm64 needs 14. We choose the max of all requirements here.
+	alignBits = 14
+	align     = 1 << alignBits
+)
+
+func makeFatExecutable(outPath string, inPaths ...string) error {
+	// Read input files.
+	type input struct {
+		data   []byte
+		cpu    uint32
+		subcpu uint32
+		offset int64
+	}
+	var inputs []input
+	offset := int64(align)
+	for _, i := range inPaths {
+		data, err := ioutil.ReadFile(i)
+		if err != nil {
+			return err
+		}
+		if len(data) < 12 {
+			return fmt.Errorf("file %s too small", i)
+		}
+		// All currently supported mac archs (386,amd64,arm,arm64) are little endian.
+		magic := binary.LittleEndian.Uint32(data[0:4])
+		if magic != macho.Magic32 && magic != macho.Magic64 {
+			return fmt.Errorf("input %s is not a macho file, magic=%x", i, magic)
+		}
+		cpu := binary.LittleEndian.Uint32(data[4:8])
+		subcpu := binary.LittleEndian.Uint32(data[8:12])
+		inputs = append(inputs, input{data: data, cpu: cpu, subcpu: subcpu, offset: offset})
+		offset += int64(len(data))
+		offset = (offset + align - 1) / align * align
+	}
+
+	// Decide on whether we're doing fat32 or fat64.
+	sixtyfour := false
+	if inputs[len(inputs)-1].offset >= 1<<32 || len(inputs[len(inputs)-1].data) >= 1<<32 {
+		sixtyfour = true
+		// fat64 doesn't seem to work:
+		//   - the resulting binary won't run.
+		//   - the resulting binary is parseable by lipo, but reports that the contained files are "hidden".
+		//   - the native OSX lipo can't make a fat64.
+		return fmt.Errorf("files too large to fit into a fat binary")
+	}
+
+	// Make output file.
+	out, err := os.Create(outPath)
+	if err != nil {
+		return err
+	}
+	err = out.Chmod(0o755)
+	if err != nil {
+		return err
+	}
+
+	// Build a fat_header.
+	var hdr []uint32
+	if sixtyfour {
+		hdr = append(hdr, MagicFat64)
+	} else {
+		hdr = append(hdr, macho.MagicFat)
+	}
+	hdr = append(hdr, uint32(len(inputs)))
+
+	// Build a fat_arch for each input file.
+	for _, i := range inputs {
+		hdr = append(hdr, i.cpu)
+		hdr = append(hdr, i.subcpu)
+		if sixtyfour {
+			hdr = append(hdr, uint32(i.offset>>32)) // big endian
+		}
+		hdr = append(hdr, uint32(i.offset))
+		if sixtyfour {
+			hdr = append(hdr, uint32(len(i.data)>>32)) // big endian
+		}
+		hdr = append(hdr, uint32(len(i.data)))
+		hdr = append(hdr, alignBits)
+		if sixtyfour {
+			hdr = append(hdr, 0) // reserved
+		}
+	}
+
+	// Write header.
+	// Note that the fat binary header is big-endian, regardless of the
+	// endianness of the contained files.
+	err = binary.Write(out, binary.BigEndian, hdr)
+	if err != nil {
+		return err
+	}
+	offset = int64(4 * len(hdr))
+
+	// Write each contained file.
+	for _, i := range inputs {
+		if offset < i.offset {
+			_, err = out.Write(make([]byte, i.offset-offset))
+			if err != nil {
+				return err
+			}
+			offset = i.offset
+		}
+		_, err := out.Write(i.data)
+		if err != nil {
+			return err
+		}
+		offset += int64(len(i.data))
+	}
+	err = out.Close()
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
#4420

Uses Unlicensed code from randall77 to do the "lipo".

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
~- [ ] Added/updated tests~
- [x] Manual QA for all new/changed functionality
