### PR TITLE
Query builder UI: Update osquery tables that report incorrect platforms

### DIFF
--- a/changes/issue-6552-update-osquery-tables
+++ b/changes/issue-6552-update-osquery-tables
@@ -1,0 +1,1 @@
+*  Update osquery tables that report incorrect platforms

--- a/frontend/osquery_tables.json
+++ b/frontend/osquery_tables.json
@@ -11287,7 +11287,7 @@
     "name": "lxd_certificates",
     "description": "LXD certificates information.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/posix/lxd_certificates.table",
-    "platforms": ["darwin", "linux"],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11329,7 +11329,7 @@
     "name": "lxd_cluster",
     "description": "LXD cluster information.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/posix/lxd_cluster.table",
-    "platforms": ["darwin", "linux"],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11395,7 +11395,7 @@
     "name": "lxd_cluster_members",
     "description": "LXD cluster members information.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/posix/lxd_cluster_members.table",
-    "platforms": ["darwin", "linux"],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11445,7 +11445,7 @@
     "name": "lxd_images",
     "description": "LXD images information.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/posix/lxd_images.table",
-    "platforms": ["darwin", "linux"],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11607,7 +11607,7 @@
     "name": "lxd_instance_config",
     "description": "LXD instance configuration information.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/posix/lxd_instance_config.table",
-    "platforms": ["darwin", "linux"],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11641,7 +11641,7 @@
     "name": "lxd_instance_devices",
     "description": "LXD instance devices information.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/posix/lxd_instance_devices.table",
-    "platforms": ["darwin", "linux"],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11691,7 +11691,7 @@
     "name": "lxd_instances",
     "description": "LXD instances information.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/posix/lxd_instances.table",
-    "platforms": ["darwin", "linux"],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11789,7 +11789,7 @@
     "name": "lxd_networks",
     "description": "LXD network information.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/posix/lxd_networks.table",
-    "platforms": ["darwin", "linux"],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11903,7 +11903,7 @@
     "name": "lxd_storage_pools",
     "description": "LXD storage pool information.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/posix/lxd_storage_pools.table",
-    "platforms": ["darwin", "linux"],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -16103,7 +16103,7 @@
     "name": "process_open_pipes",
     "description": "Pipes and partner processes for each process.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/posix/process_open_pipes.table",
-    "platforms": ["darwin", "linux"],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [


### PR DESCRIPTION
Cerra #6552 

- Updates tables to only include Linux compatibility


**Screenshot of QA**
<img width="534" alt="Screen Shot 2022-07-08 at 10 13 57 AM" src="https://user-images.githubusercontent.com/71795832/178009488-64f4b9ad-3224-4194-b5d2-9465e35dea51.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
