### PR TITLE
e2e test: Move seedQueries so call can never be repeated

### DIFF
--- a/cypress/integration/premium/teamflow.spec.ts
+++ b/cypress/integration/premium/teamflow.spec.ts
@@ -33,6 +33,7 @@ describe("Teams flow (seeded)", () => {
     cy.setup();
     cy.loginWithCySession();
     cy.seedPremium();
+    cy.seedQueries();
     cy.viewport(1200, 660);
   });
   after(() => {
@@ -86,7 +87,6 @@ describe("Teams flow (seeded)", () => {
   describe("Manage schedules page", () => {
     beforeEach(() => {
       cy.loginWithCySession();
-      cy.seedQueries();
       cy.visit("/schedule/manage");
     });
     it("adds a query to team schedule", () => {


### PR DESCRIPTION
Flakey teamflow.spec.ts test is somehow calling seedQueries() more than once

Having a seedQueries() in a beforeEach() call causes an automatic failure if the e2e test called twice for any reason

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
