### PR TITLE
Update "Usage statistics" docs, /pricing page, and Product handbook

### DIFF
--- a/docs/Using-Fleet/Usage-statistics.md
+++ b/docs/Using-Fleet/Usage-statistics.md
@@ -23,7 +23,68 @@ Fleet Device Management Inc. periodically collects anonymous information about y
   "softwareInventoryEnabled": true,
   "vulnDetectionEnabled": true,
   "systemUsersEnabled": true,
-  "hostStatusWebhookEnabled": true
+  "hostStatusWebhookEnabled": true,
+  "hostsEnrolledByOperatingSystem": {
+    "macos": [
+      {
+        "version": "12.3.1",
+        "numEnrolled": 999
+      },
+      ...
+    ],
+    "windows": [
+      {
+        "version": "10, version 21H2 (W)",
+        "numEnrolled": 999
+      },
+      ...
+    ],
+    "ubuntuLinux": [
+      {
+        "version": "22.04 'Jammy Jellyfish' (LTS)",
+        "numEnrolled": 999
+      },
+      ...
+    ],
+    "centosLinux": [
+      {
+        "version": "12.3.1",
+        "numEnrolled": 999
+      },
+      ...
+    ],
+    "debianLinux": [
+      {
+        "version": "11 (Bullseye)",
+        "numEnrolled": 999
+      },
+      ...
+    ],
+    "redhatLinux": [
+      {
+        "version": "9",
+        "numEnrolled": 999
+      },
+      ...
+    ],
+    "amazonLinux": [
+      {
+        "version": "AMI",
+        "numEnrolled": 999
+      },
+      ...
+    ]
+  },
+  "storedErrors": [
+    {
+      "count": 3,
+      "loc": [
+        "github.com/fleetdm/fleet/v4/server/example.example:12",
+        "github.com/fleetdm/fleet/v4/server/example.example:130",
+      ]
+    },
+    ...
+  ]
 }
 ```
 

--- a/handbook/product.md
+++ b/handbook/product.md
@@ -501,11 +501,13 @@ Google drive.
 
 Each week Reed Haynes follows the [directions in this document](https://docs.google.com/document/d/1MkM57cLNzkN51Hqq5CyBG4HaauAaf446ZhwWJlVho0M/edit?usp=sharing) (internal doc) and a backup copy of the Product office hours document is created and dropped in the [Product office hours backup folder](https://drive.google.com/drive/folders/1WTSSLxA-P3OlspkMKjlRXKjzZsDRoe-4?usp=sharing) in the shared drive.
 
-## Usage analytics
+## Usage statistics
 
-In order to understand the usage of the Fleet product, we [collect analytics](https://fleetdm.com/docs/using-fleet/usage-statistics) from installations where this functionality is enabled.
+In order to understand the usage of the Fleet product, we [collect statistics](https://fleetdm.com/docs/using-fleet/usage-statistics) from installations where this functionality is enabled.
 
-Fleet team members can view these statistics in the Google spreadsheet[Fleet usage](https://docs.google.com/spreadsheets/d/1Mh7Vf4kJL8b5TWlHxcX7mYwaakZMg_ZGNLY3kl1VI-c/edit#gid=0) available in Drive.
+Fleet team members can view these statistics in the Google spreadsheet [Fleet
+usage](https://docs.google.com/spreadsheets/d/1Mh7Vf4kJL8b5TWlHxcX7mYwaakZMg_ZGNLY3kl1VI-c/edit#gid=0)
+available in Google Drive.
 
 ## Rituals
 

--- a/website/views/pages/pricing.ejs
+++ b/website/views/pages/pricing.ejs
@@ -129,7 +129,7 @@
                         style="width: 16px; height: 16px; left: 0; top: 4px"
                         class="position-absolute"
                       />
-                      Self-hosted agent autoupdates
+                      Self-managed agent autoupdates
                     </p>
                   </div>
                 </div>
@@ -1000,7 +1000,7 @@
                         src="/images/ellipse-6x6@2x.png"
                         style="width: 6px; height: 6px; margin-top: 09.6px"
                       />
-                      <p class="ml-2 my-0">Self-hosted</p>
+                      <p class="ml-2 my-0">Self-managed</p>
                     </div>
                     <div class="col-2">
                       <img
@@ -1106,7 +1106,7 @@
                         src="/images/ellipse-6x6@2x.png"
                         style="width: 6px; height: 6px; margin-top: 09.6px"
                       />
-                      <p class="ml-2 my-0">Self-hosted autoupdate registry†</p>
+                      <p class="ml-2 my-0">Self-managed autoupdate registry†</p>
                     </div>
                     <div class="col-2"></div>
                     <div class="col-3">


### PR DESCRIPTION
- Add new properties to "Usage statistics" docs
  - These properties will be included in Fleet versions 4.17.0 and higher
  - The current `fleet-v-4.17.0-usage-stats` branch won't be merged when 4.17.0 is released includes an additional property (`organization`) that won't be included in Fleet 4.17.0. This branch will likely be merged prior to 4.18.0. cc @DominusKelvin 
- Update "self-hosted" to "self-managed" on fleetdm.com/pricing. 
  - This is because we'd like to communicate that the user is able to manage a Fleet deploying or manage agent updates
- Fix spacing in Product handbook
