### PR TITLE
tag fleetdm/fleetctl docker image before pushing to Hub

### DIFF
--- a/.github/workflows/build-and-push-fleetctl-docker.yml
+++ b/.github/workflows/build-and-push-fleetctl-docker.yml
@@ -40,5 +40,7 @@ jobs:
         run: make fleetctl-docker
 
       - name: Push to Docker
-        run: docker push fleetdm/fleetctl:${{ inputs.image_tag }}
+        run: |
+          docker tag fleetdm/fleetctl fleetdm/fleetctl:${{ inputs.image_tag }}
+          docker push fleetdm/fleetctl:${{ inputs.image_tag }}
 


### PR DESCRIPTION
A minor tweak to #6533 to tag the image before pushing to Docker Hub, based on this [failed run](https://github.com/fleetdm/fleet/runs/7283311794?check_suite_focus=true).

# Checklist for submitter

- [x] Manual QA for all new/changed functionality
