### PR TITLE
Host Details Page UI: Disk space levels

### DIFF
--- a/changes/issue-6551-disk-space-host-details
+++ b/changes/issue-6551-disk-space-host-details
@@ -1,0 +1,1 @@
+* Host details page shows new disk space tooltip and 3 status levels

--- a/cypress/integration/all/app/fleetdesktop.spec.ts
+++ b/cypress/integration/all/app/fleetdesktop.spec.ts
@@ -21,9 +21,9 @@ describe("Fleet Desktop", () => {
       cy.findByText(/my device/i).should("exist");
       cy.getAttached(".status--online").should("exist");
       cy.getAttached(".info-flex").within(() => {
-        cy.findByText(/operating system/i)
-          .next()
-          .contains(/ubuntu 20/i);
+        cy.findByText(/ubuntu 20/i)
+          .prev()
+          .contains(/operating system/i);
       });
       cy.getAttached(".info-grid").within(() => {
         cy.findByText(/private ip address/i)

--- a/frontend/components/forms/fields/SelectTargetsDropdown/TargetDetails/TargetDetails.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/TargetDetails/TargetDetails.jsx
@@ -114,11 +114,11 @@ class TargetDetails extends Component {
               </td>
             </tr>
             <tr>
-              <th>Operating System</th>
+              <th>Operating system</th>
               <td>{osVersion}</td>
             </tr>
             <tr>
-              <th>Osquery Version</th>
+              <th>Osquery version</th>
               <td>{osqueryVersion}</td>
             </tr>
             <tr>

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -75,6 +75,10 @@
         }
       }
 
+      &__disk-space-wrapper {
+        display: inline-block;
+      }
+
       &__disk-space {
         display: inline-block;
         height: 4px;
@@ -83,6 +87,7 @@
         border-radius: 2px;
         margin-right: $pad-small;
         overflow: hidden;
+        margin-bottom: 2px;
       }
 
       &__disk-space-green {

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -85,13 +85,18 @@
         overflow: hidden;
       }
 
-      &__disk-space-used {
+      &__disk-space-green {
         background-color: $ui-success;
         height: 100%;
       }
 
-      &__disk-space-warning {
+      &__disk-space-yellow {
         background-color: $ui-warning;
+        height: 100%;
+      }
+
+      &__disk-space-red {
+        background-color: $ui-error;
         height: 100%;
       }
 
@@ -419,7 +424,11 @@
     margin: 0;
   }
 
-  .section--policies .data-table-block .data-table__table thead .response__header {
+  .section--policies
+    .data-table-block
+    .data-table__table
+    thead
+    .response__header {
     width: $col-md;
   }
 }

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -77,6 +77,10 @@
 
       &__disk-space-wrapper {
         display: inline-block;
+
+        &:hover {
+          cursor: help;
+        }
       }
 
       &__disk-space {

--- a/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
@@ -82,13 +82,18 @@
         overflow: hidden;
       }
 
-      &__disk-space-used {
+      &__disk-space-green {
         background-color: $ui-success;
         height: 100%;
       }
 
-      &__disk-space-warning {
+      &__disk-space-yellow {
         background-color: $ui-warning;
+        height: 100%;
+      }
+
+      &__disk-space-red {
+        background-color: $ui-error;
         height: 100%;
       }
 

--- a/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
@@ -74,6 +74,10 @@
 
       &__disk-space-wrapper {
         display: inline-block;
+
+        &:hover {
+          cursor: help;
+        }
       }
 
       &__disk-space {

--- a/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
@@ -72,6 +72,10 @@
         }
       }
 
+      &__disk-space-wrapper {
+        display: inline-block;
+      }
+
       &__disk-space {
         display: inline-block;
         height: 4px;
@@ -80,6 +84,7 @@
         border-radius: 2px;
         margin-right: $pad-small;
         overflow: hidden;
+        margin-bottom: 2px;
       }
 
       &__disk-space-green {

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -173,15 +173,19 @@ const HostSummary = ({
     ) {
       return (
         <span className="info-flex__data">
-          <div className="info-flex__disk-space">
-            <div
-              className={`info-flex__disk-space-${diskSpaceIndicator()}`}
-              style={{
-                width: `${100 - titleData.percent_disk_space_available}%`,
-              }}
-              data-tip
-              data-for="disk-space-tooltip"
-            />
+          <div
+            className="info-flex__disk-space-wrapper"
+            data-tip
+            data-for="disk-space-tooltip"
+          >
+            <div className="info-flex__disk-space">
+              <div
+                className={`info-flex__disk-space-${diskSpaceIndicator()}`}
+                style={{
+                  width: `${100 - titleData.percent_disk_space_available}%`,
+                }}
+              />
+            </div>
           </div>
           <ReactTooltip
             place="bottom"

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -123,6 +123,49 @@ const HostSummary = ({
   );
 
   const renderDiskSpace = () => {
+    const diskSpaceTooltip = () => {
+      const diskSpaceAvailable = titleData.gigs_disk_space_available;
+      switch (true) {
+        case diskSpaceAvailable < 16:
+          return (
+            <span className={`${baseClass}__tooltip-text`}>
+              Not enough disk space <br />
+              available to install most <br />
+              small operating systems <br />
+              updates.
+            </span>
+          );
+        case diskSpaceAvailable < 32:
+          return (
+            <span className={`${baseClass}__tooltip-text`}>
+              Not enough disk space <br />
+              available to install most <br />
+              large operating systems <br />
+              updates.
+            </span>
+          );
+        default:
+          return (
+            <span className={`${baseClass}__tooltip-text`}>
+              Enough disk space available <br />
+              to install most operating <br />
+              systems updates.
+            </span>
+          );
+      }
+    };
+
+    const diskSpaceIndicator = () => {
+      const diskSpaceAvailable = titleData.gigs_disk_space_available;
+      switch (true) {
+        case diskSpaceAvailable < 16:
+          return "red";
+        case diskSpaceAvailable < 32:
+          return "yellow";
+        default:
+          return "green";
+      }
+    };
     if (
       titleData &&
       (titleData.gigs_disk_space_available > 0 ||
@@ -132,16 +175,23 @@ const HostSummary = ({
         <span className="info-flex__data">
           <div className="info-flex__disk-space">
             <div
-              className={
-                titleData.percent_disk_space_available > 20
-                  ? "info-flex__disk-space-used"
-                  : "info-flex__disk-space-warning"
-              }
+              className={`info-flex__disk-space-${diskSpaceIndicator()}`}
               style={{
                 width: `${100 - titleData.percent_disk_space_available}%`,
               }}
+              data-tip
+              data-for="disk-space-tooltip"
             />
           </div>
+          <ReactTooltip
+            place="bottom"
+            type="dark"
+            effect="solid"
+            id="disk-space-tooltip"
+            backgroundColor="#3e4771"
+          >
+            {diskSpaceTooltip()}
+          </ReactTooltip>
           {titleData.gigs_disk_space_available} GB available
         </span>
       );

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -18,6 +18,11 @@ body {
 html,
 body {
   height: 100%;
+
+  .__react_component_tooltip.show {
+    opacity: 1; // Overrides 0.9 default opacity
+    text-align: center;
+  }
 }
 
 .wrapper,


### PR DESCRIPTION
Cerra #6551 
 
**Host Details/Device User Page Changes**
- Allows user to see 3 levels of disk space usage (Red <16 GB, Yellow <32GB, Green)
- Tooltip on hover over the bar graph explaining the different levels
- Tooltip padded hover area includes above and below graph for more on hover area

**Other tech debt**
- Fix sentence casing

**Screenshot**
<img width="550" alt="Screen Shot 2022-07-13 at 3 53 43 PM" src="https://user-images.githubusercontent.com/71795832/178821271-d13107ed-b8c8-4ecc-b78c-7b3837e98631.png">




# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
