### PR TITLE
Update documentation and Sails app for additional usage statistics

### DIFF
--- a/docs/Using-Fleet/Usage-statistics.md
+++ b/docs/Using-Fleet/Usage-statistics.md
@@ -84,7 +84,8 @@ Fleet Device Management Inc. periodically collects anonymous information about y
       ]
     },
     ...
-  ]
+  ],
+  "numHostsNotResponding": 9
 }
 ```
 

--- a/frontend/pages/admin/AppSettingsPage/cards/constants.ts
+++ b/frontend/pages/admin/AppSettingsPage/cards/constants.ts
@@ -133,6 +133,7 @@ export const usageStatsPreview = {
       ],
     },
   ],
+  numHostsNotResponding: 9,
 };
 
 export default {

--- a/website/api/controllers/webhooks/receive-usage-analytics.js
+++ b/website/api/controllers/webhooks/receive-usage-analytics.js
@@ -23,6 +23,7 @@ module.exports = {
     numWeeklyActiveUsers: { type: 'number', defaultsTo: 0 },
     hostsEnrolledByOperatingSystem: { type: 'json', defaultsTo: {} },
     storedErrors: { type: 'json', defaultsTo: '[]' },
+    numHostsNotResponding: { type: 'number', defaultsTo: 0, description: 'The number of hosts per deployment that have not submitted results for distibuted queries. A host is counted as not responding if Fleet hasn\'t received a distributed write to requested distibuted queries for the host during the 2-hour interval since the host was last seen. Hosts that have not been seen for 7 days or more are not counted.', },
   },
 
 

--- a/website/api/models/HistoricalUsageSnapshot.js
+++ b/website/api/models/HistoricalUsageSnapshot.js
@@ -27,7 +27,7 @@ module.exports = {
     numWeeklyActiveUsers: { required: true, type: 'number' },
     hostsEnrolledByOperatingSystem: { required: true, type: 'json' },
     storedErrors: { required: true, type: 'json' },
-    numHostsNotResponding: { required: true, type: 'number ', description: 'The number of hosts per deployment that have not submitted results for distibuted queries. A host is counted as not responding if Fleet hasn\'t received a distributed write to requested distibuted queries for the host during the 2-hour interval since the host was last seen. Hosts that have not been seen for 7 days or more are not counted.'},
+    numHostsNotResponding: { required: true, type: 'number', description: 'The number of hosts per deployment that have not submitted results for distibuted queries. A host is counted as not responding if Fleet hasn\'t received a distributed write to requested distibuted queries for the host during the 2-hour interval since the host was last seen. Hosts that have not been seen for 7 days or more are not counted.'},
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗

--- a/website/api/models/HistoricalUsageSnapshot.js
+++ b/website/api/models/HistoricalUsageSnapshot.js
@@ -27,7 +27,7 @@ module.exports = {
     numWeeklyActiveUsers: { required: true, type: 'number' },
     hostsEnrolledByOperatingSystem: { required: true, type: 'json' },
     storedErrors: { required: true, type: 'json' },
-    numHostsNotResponding: { required: true, type: 'number', description: 'The number of hosts per deployment that have not submitted results for distibuted queries. A host is counted as not responding if Fleet hasn\'t received a distributed write to requested distibuted queries for the host during the 2-hour interval since the host was last seen. Hosts that have not been seen for 7 days or more are not counted.'},
+    numHostsNotResponding: { required: true, type: 'number', description: 'The number of hosts per deployment that have not submitted results for distibuted queries. A host is counted as not responding if Fleet hasn\'t received a distributed write to requested distibuted queries for the host during the 2-hour interval since the host was last seen. Hosts that have not been seen for 7 days or more are not counted.', },
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗

--- a/website/api/models/HistoricalUsageSnapshot.js
+++ b/website/api/models/HistoricalUsageSnapshot.js
@@ -27,6 +27,7 @@ module.exports = {
     numWeeklyActiveUsers: { required: true, type: 'number' },
     hostsEnrolledByOperatingSystem: { required: true, type: 'json' },
     storedErrors: { required: true, type: 'json' },
+    numHostsNotResponding: { required: true, type: 'number ', description: 'The number of hosts per deployment that have not submitted results for distibuted queries. A host is counted as not responding if Fleet hasn\'t received a distributed write to requested distibuted queries for the host during the 2-hour interval since the host was last seen. Hosts that have not been seen for 7 days or more are not counted.'},
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗


### PR DESCRIPTION
Issue #6448 

Add usage statistics to include number of hosts not responding to distributed queries:
- Update docs
- Update UI example stats payload
- Update Sails app for fleetdm.com

Note: #6495 implements related changes to Fleet server 
