### PR TITLE
Add sandbox_enabled property to config interface

### DIFF
--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -180,6 +180,7 @@ const reducer = (state: InitialStateType, action: IAction) => {
     }
     case ACTIONS.SET_CONFIG: {
       const { config } = action;
+      // config.sandbox_enabled = true;
 
       return {
         ...state,

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -117,6 +117,7 @@ export interface IConfig {
     org_name: string;
     org_logo_url: string;
   };
+  sandbox_enabled: boolean;
   server_settings: {
     server_url: string;
     live_query_disabled: boolean;


### PR DESCRIPTION
Related to #6544 and #6597 

--

New Fleet Sandbox instances will have a `config.sandbox_enabled` property set so the frontend can modify the UI accordingly. This config will be set during the provisioning process, and there is not currently an easy way for us to enable/disable the property for local frontend development. 

I'm adding this interface prop and commented out line so that we have an easy way of making our local environments `sandbox_enabled` so we can build supporting features in the UI. 