### PR TITLE
add configuration to retrieve installers from S3

### DIFF
--- a/changes/6365-s3-config
+++ b/changes/6365-s3-config
@@ -1,0 +1,1 @@
+* Added options to configure S3 for retrieval of pre-built Orbit packages.

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -2553,3 +2553,144 @@ stored in your database.
   packaging:
     global_enroll_secret: "xyz"
   ```
+
+##### packaging.s3_bucket
+
+Name of the S3 bucket to use to store pre-built Orbit installers.
+
+- Default value: ""
+- Environment variable: `FLEET_PACKAGING_S3_BUCKET`
+- Config file format:
+
+  ```
+  packaging:
+    s3:
+      bucket: some-bucket
+  ```
+
+##### s3_access_key_id
+
+AWS access key ID to use for S3 authentication.
+
+If `s3_access_key_id` and `s3_secret_access_key` are omitted, Fleet will try to use
+[the default credential provider chain](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials).
+
+The IAM identity used in this context must be allowed to perform the following actions on the bucket: `s3:GetObject`, `s3:ListBucket`.
+
+- Default value: ""
+- Environment variable: `FLEET_PACKAGING_S3_ACCESS_KEY_ID`
+- Config file format:
+
+  ```
+  packaging:
+    s3:
+      access_key_id: AKIAIOSFODNN7EXAMPLE
+  ```
+
+##### s3_secret_access_key
+
+AWS secret access key to use for S3 authentication.
+
+- Default value: ""
+- Environment variable: `FLEET_PACKAGING_S3_SECRET_ACCESS_KEY`
+- Config file format:
+
+  ```
+  packaging:
+    s3:
+      secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+  ```
+
+##### s3_sts_assume_role_arn
+
+AWS STS role ARN to use for S3 authentication.
+
+- Default value: ""
+- Environment variable: `FLEET_PACKAGING_S3_STS_ASSUME_ROLE_ARN`
+- Config file format:
+
+  ```
+  packaging:
+    s3:
+      sts_assume_role_arn: arn:aws:iam::1234567890:role/some-s3-role
+  ```
+
+##### s3_endpoint_url
+
+AWS S3 Endpoint URL. Override when using a different S3 compatible object storage backend (such as Minio),
+or running s3 locally with localstack. Leave this blank to use the default S3 service endpoint.
+
+- Default value: ""
+- Environment variable: `FLEET_PACKAGING_S3_ENDPOINT_URL`
+- Config file format:
+
+  ```
+  packaging:
+    s3:
+      endpoint_url: http://localhost:9000
+  ```
+
+##### s3_disable_ssl
+
+AWS S3 Disable SSL. Useful for local testing.
+
+- Default value: false
+- Environment variable: `FLEET_PACKAGING_S3_DISABLE_SSL`
+- Config file format:
+
+  ```
+  packaging:
+    s3:
+      disable_ssl: false
+  ```
+
+##### s3_force_s3_path_style
+
+AWS S3 Force S3 Path Style. Set this to `true` to force the request to use path-style addressing,
+i.e., `http://s3.amazonaws.com/BUCKET/KEY`. By default, the S3 client
+will use virtual hosted bucket addressing when possible
+(`http://BUCKET.s3.amazonaws.com/KEY`).
+
+See [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html) for details.
+
+- Default value: false
+- Environment variable: `FLEET_PACKAGING_S3_FORCE_S3_PATH_STYLE`
+- Config file format:
+
+  ```
+  packaging:
+    s3:
+      force_s3_path_style: false
+  ```
+
+##### s3_region
+
+AWS S3 Region. Leave blank to enable region discovery.
+
+Minio users must set this to any nonempty value (eg. `minio`), as Minio does not support region discovery.
+
+- Default value: ""
+- Environment variable: `FLEET_PACKAGING_S3_REGION`
+- Config file format:
+
+  ```
+  packaging:
+    s3:
+      region: us-east-1
+  ```
+
+##### Example YAML
+
+```yaml
+apiVersion: v1
+kind: config
+spec:
+  packaging:
+    s3:
+      bucket: some-bucket
+      prefix: installers/
+      access_key_id: AKIAIOSFODNN7EXAMPLE
+      secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+      sts_assume_role_arn: arn:aws:iam::1234567890:role/some-s3-role
+      region: us-east-1
+```

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -2529,7 +2529,7 @@ Configurations used to control how Fleet interacts with the (coming soon)
 packaging server.  These features are currently only intended to be used within
 Fleet Sandbox, but this is subject to change.
 
-##### packaging.global_enroll_secret
+##### packaging_global_enroll_secret
 
 Enroll secret to use for adding hosts to the global scope. If this value is
 set, the server won't allow changes to the enroll secret via the config
@@ -2554,7 +2554,7 @@ stored in your database.
     global_enroll_secret: "xyz"
   ```
 
-##### packaging.s3_bucket
+##### packaging_s3_bucket
 
 Name of the S3 bucket to use to store pre-built Orbit installers.
 
@@ -2568,7 +2568,7 @@ Name of the S3 bucket to use to store pre-built Orbit installers.
       bucket: some-bucket
   ```
 
-##### packaging.s3_prefix
+##### packaging_s3_prefix
 
 Prefix to prepend when searching for installers.
 
@@ -2582,7 +2582,7 @@ Prefix to prepend when searching for installers.
       prefix: carves-go-here/
   ```
 
-##### packaging.s3_access_key_id
+##### packaging_s3_access_key_id
 
 AWS access key ID to use for S3 authentication.
 
@@ -2601,7 +2601,7 @@ The IAM identity used in this context must be allowed to perform the following a
       access_key_id: AKIAIOSFODNN7EXAMPLE
   ```
 
-##### packaging.s3_secret_access_key
+##### packaging_s3_secret_access_key
 
 AWS secret access key to use for S3 authentication.
 
@@ -2615,7 +2615,7 @@ AWS secret access key to use for S3 authentication.
       secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   ```
 
-##### packaging.s3_sts_assume_role_arn
+##### packaging_s3_sts_assume_role_arn
 
 AWS STS role ARN to use for S3 authentication.
 
@@ -2629,7 +2629,7 @@ AWS STS role ARN to use for S3 authentication.
       sts_assume_role_arn: arn:aws:iam::1234567890:role/some-s3-role
   ```
 
-##### packaging.s3_endpoint_url
+##### packaging_s3_endpoint_url
 
 AWS S3 Endpoint URL. Override when using a different S3 compatible object storage backend (such as Minio),
 or running s3 locally with localstack. Leave this blank to use the default S3 service endpoint.
@@ -2644,7 +2644,7 @@ or running s3 locally with localstack. Leave this blank to use the default S3 se
       endpoint_url: http://localhost:9000
   ```
 
-##### packaging.s3_disable_ssl
+##### packaging_s3_disable_ssl
 
 AWS S3 Disable SSL. Useful for local testing.
 
@@ -2658,7 +2658,7 @@ AWS S3 Disable SSL. Useful for local testing.
       disable_ssl: false
   ```
 
-##### packaging.s3_force_s3_path_style
+##### packaging_s3_force_s3_path_style
 
 AWS S3 Force S3 Path Style. Set this to `true` to force the request to use path-style addressing,
 i.e., `http://s3.amazonaws.com/BUCKET/KEY`. By default, the S3 client
@@ -2677,7 +2677,7 @@ See [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html) f
       force_s3_path_style: false
   ```
 
-##### packaging.s3_region
+##### packaging_s3_region
 
 AWS S3 Region. Leave blank to enable region discovery.
 

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -2579,7 +2579,8 @@ Prefix to prepend when searching for installers.
   ```
   packaging:
     s3:
-      prefix: carves-go-here/
+      prefix:
+        installers-go-here/
   ```
 
 ##### packaging_s3_access_key_id
@@ -2632,7 +2633,7 @@ AWS STS role ARN to use for S3 authentication.
 ##### packaging_s3_endpoint_url
 
 AWS S3 Endpoint URL. Override when using a different S3 compatible object storage backend (such as Minio),
-or running s3 locally with localstack. Leave this blank to use the default S3 service endpoint.
+or running s3 locally with localstack. Leave this blank to use the default AWS S3 service endpoint.
 
 - Default value: ""
 - Environment variable: `FLEET_PACKAGING_S3_ENDPOINT_URL`
@@ -2702,7 +2703,7 @@ spec:
   packaging:
     s3:
       bucket: some-bucket
-      prefix: installers/
+      prefix: installers-go-here/
       access_key_id: AKIAIOSFODNN7EXAMPLE
       secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
       sts_assume_role_arn: arn:aws:iam::1234567890:role/some-s3-role

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -2568,7 +2568,21 @@ Name of the S3 bucket to use to store pre-built Orbit installers.
       bucket: some-bucket
   ```
 
-##### s3_access_key_id
+##### packaging.s3_prefix
+
+Prefix to prepend when searching for installers.
+
+- Default value: ""
+- Environment variable: `FLEET_PACKAGING_S3_PREFIX`
+- Config file format:
+
+  ```
+  packaging:
+    s3:
+      prefix: carves-go-here/
+  ```
+
+##### packaging.s3_access_key_id
 
 AWS access key ID to use for S3 authentication.
 
@@ -2587,7 +2601,7 @@ The IAM identity used in this context must be allowed to perform the following a
       access_key_id: AKIAIOSFODNN7EXAMPLE
   ```
 
-##### s3_secret_access_key
+##### packaging.s3_secret_access_key
 
 AWS secret access key to use for S3 authentication.
 
@@ -2601,7 +2615,7 @@ AWS secret access key to use for S3 authentication.
       secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   ```
 
-##### s3_sts_assume_role_arn
+##### packaging.s3_sts_assume_role_arn
 
 AWS STS role ARN to use for S3 authentication.
 
@@ -2615,7 +2629,7 @@ AWS STS role ARN to use for S3 authentication.
       sts_assume_role_arn: arn:aws:iam::1234567890:role/some-s3-role
   ```
 
-##### s3_endpoint_url
+##### packaging.s3_endpoint_url
 
 AWS S3 Endpoint URL. Override when using a different S3 compatible object storage backend (such as Minio),
 or running s3 locally with localstack. Leave this blank to use the default S3 service endpoint.
@@ -2630,7 +2644,7 @@ or running s3 locally with localstack. Leave this blank to use the default S3 se
       endpoint_url: http://localhost:9000
   ```
 
-##### s3_disable_ssl
+##### packaging.s3_disable_ssl
 
 AWS S3 Disable SSL. Useful for local testing.
 
@@ -2644,7 +2658,7 @@ AWS S3 Disable SSL. Useful for local testing.
       disable_ssl: false
   ```
 
-##### s3_force_s3_path_style
+##### packaging.s3_force_s3_path_style
 
 AWS S3 Force S3 Path Style. Set this to `true` to force the request to use path-style addressing,
 i.e., `http://s3.amazonaws.com/BUCKET/KEY`. By default, the S3 client
@@ -2663,7 +2677,7 @@ See [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html) f
       force_s3_path_style: false
   ```
 
-##### s3_region
+##### packaging.s3_region
 
 AWS S3 Region. Leave blank to enable region discovery.
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -311,6 +311,8 @@ type PackagingConfig struct {
 	// GlobalEnrollSecret is the enroll secret that will be used to enroll
 	// hosts in the global scope
 	GlobalEnrollSecret string `yaml:"global_enroll_secret"`
+	// S3 configuration used to retrieve pre-built installers
+	S3 S3Config `yaml:"s3"`
 }
 
 // FleetConfig stores the application configuration. Each subcategory is
@@ -654,6 +656,15 @@ func (man Manager) addConfigs() {
 
 	// Packaging config
 	man.addConfigString("packaging.global_enroll_secret", "", "Enroll secret to be used for the global domain (instead of randomly generating one)")
+	man.addConfigString("packaging.s3.bucket", "", "Bucket where to retrieve installers")
+	man.addConfigString("packaging.s3.prefix", "", "Prefix under which installers are stored")
+	man.addConfigString("packaging.s3.region", "", "AWS Region (if blank region is derived)")
+	man.addConfigString("packaging.s3.endpoint_url", "", "AWS Service Endpoint to use (leave blank for default service endpoints)")
+	man.addConfigString("packaging.s3.access_key_id", "", "Access Key ID for AWS authentication")
+	man.addConfigString("packaging.s3.secret_access_key", "", "Secret Access Key for AWS authentication")
+	man.addConfigString("packaging.s3.sts_assume_role_arn", "", "ARN of role to assume for AWS")
+	man.addConfigBool("packaging.s3.disable_ssl", false, "Disable SSL (typically for local testing)")
+	man.addConfigBool("packaging.s3.force_s3_path_style", false, "Set this to true to force path-style addressing, i.e., `http://s3.amazonaws.com/BUCKET/KEY`")
 }
 
 // LoadConfig will load the config variables into a fully initialized


### PR DESCRIPTION
Related to #6365, this adds relevant configuration to the `packaging` key to retrieve installers from S3.

# Checklist for submitter

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Manual QA for all new/changed functionality
