### PR TITLE
Adding password policy query to the default library

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -737,3 +737,15 @@ spec:
   tags: compliance, inventory, hardware
   platform: darwin
   contributors: erikng
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Password requires 10 or more characters (macOS)
+  query: SELECT 1 FROM (SELECT cast(lengthtxt as integer(2)) minlength FROM (SELECT SUBSTRING(length, 1, 2) AS lengthtxt FROM (SELECT policy_description, policy_identifier, split(policy_content, '{', 1) AS length FROM password_policy WHERE policy_identifier LIKE '%minLength')) WHERE minlength >= 10);
+  description: "Checks that the password policy requires at least 10 characters."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving configuration profiles for password length."
+  platforms: macOS
+  tags: compliance, hardening, built-in
+  platform: darwin
+  contributors: GuillaumeRoss

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -743,7 +743,7 @@ kind: policy
 spec:
   name: Password requires 10 or more characters (macOS)
   query: SELECT 1 FROM (SELECT cast(lengthtxt as integer(2)) minlength FROM (SELECT SUBSTRING(length, 1, 2) AS lengthtxt FROM (SELECT policy_description, policy_identifier, split(policy_content, '{', 1) AS length FROM password_policy WHERE policy_identifier LIKE '%minLength')) WHERE minlength >= 10);
-  description: "Checks that the password policy requires at least 10 characters."
+  description: "Checks that the password policy requires at least 10 characters. Requires osquery 5.4.0 or newer."
   resolution: "Contact your IT administrator to ensure your Mac is receiving configuration profiles for password length."
   platforms: macOS
   tags: compliance, hardening, built-in

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -170,6 +170,17 @@ export const DEFAULT_POLICIES = [
       "Ask your IT administrator to enable the Interactive Logon: Machine inactivity limit setting with a value of 1800 seconds or lower.",
     platform: "windows",
   },
+  {
+    key: 16,
+    query:
+      "SELECT 1 FROM (SELECT cast(lengthtxt as integer(2)) minlength FROM (SELECT SUBSTRING(length, 1, 2) AS lengthtxt FROM (SELECT policy_description, policy_identifier, split(policy_content, '{', 1) AS length FROM password_policy WHERE policy_identifier LIKE '%minLength')) WHERE minlength >= 10);",
+    name: "Password requires 10 or more characters (macOS)",
+    description:
+      "Checks that the password policy requires at least 10 characters. Requires osquery 5.4.0 or newer.",
+    resolution:
+      "Contact your IT administrator to ensure your Mac is receiving configuration profiles for password length.",
+    platform: "darwin",
+  },
 ] as IPolicyNew[];
 
 export const FREQUENCY_DROPDOWN_OPTIONS = [


### PR DESCRIPTION
Adding a built-in policy to check the minimum password length on macOS using the recently released password_policy table.

Once merged, this will close https://github.com/fleetdm/confidential/issues/1407