### PR TITLE
In Product handbook, add "epic" DRI

### DIFF
--- a/handbook/company.md
+++ b/handbook/company.md
@@ -281,13 +281,14 @@ At Fleet, groups define the relevant sections of the engineering org chart.  A p
 interim product manager):
 
 - Interface PM: Noah Talerman
-- Platform PM: Zach Wasserman
+- Platform PM: Mo Zhu
 - Agent PM: Mo Zhu
 
 Each group is associated with an engineering manager (EM), who, with their group of engineers, form the engineering members of the group.
 
-Each group's PM works very closely with engineers within their group:
+Each group's PM works closely with engineers within their group:
 - The PM **prioritizes** work and defines **what** to iteratively build and release next within their group's domain to best serve the group's goals and the company's goals as a whole. The PM communicates **why** this work is prioritized and works with engineering to come up with the best possible **how**.
+- The PM is responsible for epics. Sometimes initiatives require multiple issues that may, or may not, include multiple development groups. These initiatives are tracked as GitHub issues with the "epic" label. To make sure that all issues associated with the epic (child issues) make it into a release, one PM is assigned to the epic. It's the PM's responsibility to track progress and close the epic when the initiative is complete.
 - The EM (along with engineers) defines **how** to implement that definition within the surface area of code, processes, and rituals owned by their group while serving their group’s goals and the company's goals as a whole.
 
 ### Interface group


### PR DESCRIPTION
- Why? Make sure that epics have an owner (DRI) like the child issues do.
- Document Mo as Platform PM