### PR TITLE
add a new tool to upload installers to blob storage

### DIFF
--- a/server/datastore/s3/installer.go
+++ b/server/datastore/s3/installer.go
@@ -51,6 +51,17 @@ func (i *InstallerStore) Get(ctx context.Context, installer fleet.Installer) (io
 	return req.Body, nil
 }
 
+// Put uploads an installer to S3
+func (i *InstallerStore) Put(ctx context.Context, installer fleet.Installer) (string, error) {
+	key := i.keyForInstaller(installer)
+	_, err := i.s3client.PutObject(&s3.PutObjectInput{
+		Bucket: &i.bucket,
+		Body:   installer.Content,
+		Key:    &key,
+	})
+	return key, err
+}
+
 // keyForInstaller builds an S3 key to search for the installer
 func (i *InstallerStore) keyForInstaller(installer fleet.Installer) string {
 	file := fmt.Sprintf("%s.%s", executable, installer.Kind)

--- a/server/datastore/s3/installer_test.go
+++ b/server/datastore/s3/installer_test.go
@@ -3,15 +3,17 @@ package s3
 import (
 	"context"
 	"io"
+	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/stretchr/testify/require"
 )
 
 func TestInstallerExists(t *testing.T) {
 	ctx := context.Background()
-	store := setupInstallerStore(t, "installers", "random-prefix")
+	store := setupInstallerStore(t, "installers", "exists-prefix")
 
 	t.Run("returns true for existing installers", func(t *testing.T) {
 		installers := seedInstallerStore(t, store, "enroll-secret")
@@ -46,7 +48,7 @@ func TestInstallerExists(t *testing.T) {
 
 func TestGetInstaller(t *testing.T) {
 	ctx := context.Background()
-	store := setupInstallerStore(t, "installers", "random-prefix")
+	store := setupInstallerStore(t, "installers", "get-prefix")
 
 	t.Run("gets a blob with the file contents for each installer", func(t *testing.T) {
 		installers := seedInstallerStore(t, store, "enroll-secret")
@@ -79,4 +81,25 @@ func TestGetInstaller(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, blob)
 	})
+}
+
+func TestInstallerPut(t *testing.T) {
+	store := setupInstallerStore(t, "installers", "put-prefix")
+	i := fleet.Installer{
+		EnrollSecret: "xyz",
+		Kind:         "pkg",
+		Desktop:      false,
+		Content:      aws.ReadSeekCloser(strings.NewReader(mockInstallerContents)),
+	}
+	key, err := store.Put(context.Background(), i)
+	require.NoError(t, err)
+	require.Equal(t, store.keyForInstaller(i), key)
+
+	ri, err := store.Get(context.Background(), i)
+	require.NoError(t, err)
+
+	rc, err := io.ReadAll(ri)
+	require.NoError(t, err)
+
+	require.Equal(t, mockInstallerContents, string(rc))
 }

--- a/server/datastore/s3/installer_test.go
+++ b/server/datastore/s3/installer_test.go
@@ -17,7 +17,7 @@ func TestInstallerExists(t *testing.T) {
 		installers := seedInstallerStore(t, store, "enroll-secret")
 
 		for _, i := range installers {
-			exists, err := store.Exists(ctx, *i)
+			exists, err := store.Exists(ctx, i)
 			require.NoError(t, err)
 			require.Equal(t, exists, true)
 		}
@@ -52,7 +52,7 @@ func TestGetInstaller(t *testing.T) {
 		installers := seedInstallerStore(t, store, "enroll-secret")
 
 		for _, i := range installers {
-			blob, err := store.Get(ctx, *i)
+			blob, err := store.Get(ctx, i)
 			require.NoError(t, err)
 			contents, err := io.ReadAll(blob)
 			require.NoError(t, err)

--- a/server/datastore/s3/testing_utils.go
+++ b/server/datastore/s3/testing_utils.go
@@ -47,16 +47,15 @@ func setupInstallerStore(tb testing.TB, bucket, prefix string) *InstallerStore {
 
 func seedInstallerStore(tb testing.TB, store *InstallerStore, enrollSecret string) []fleet.Installer {
 	checkEnv(tb)
-	content := aws.ReadSeekCloser(strings.NewReader(mockInstallerContents))
 	installers := []fleet.Installer{
-		{EnrollSecret: enrollSecret, Kind: "pkg", Desktop: false, Content: content},
-		{EnrollSecret: enrollSecret, Kind: "msi", Desktop: false, Content: content},
-		{EnrollSecret: enrollSecret, Kind: "deb", Desktop: false, Content: content},
-		{EnrollSecret: enrollSecret, Kind: "rpm", Desktop: false, Content: content},
-		{EnrollSecret: enrollSecret, Kind: "pkg", Desktop: true, Content: content},
-		{EnrollSecret: enrollSecret, Kind: "msi", Desktop: true, Content: content},
-		{EnrollSecret: enrollSecret, Kind: "deb", Desktop: true, Content: content},
-		{EnrollSecret: enrollSecret, Kind: "rpm", Desktop: true, Content: content},
+		mockInstaller(enrollSecret, "pkg", true),
+		mockInstaller(enrollSecret, "msi", true),
+		mockInstaller(enrollSecret, "deb", true),
+		mockInstaller(enrollSecret, "rpm", true),
+		mockInstaller(enrollSecret, "pkg", false),
+		mockInstaller(enrollSecret, "msi", false),
+		mockInstaller(enrollSecret, "deb", false),
+		mockInstaller(enrollSecret, "rpm", false),
 	}
 
 	for _, i := range installers {
@@ -65,6 +64,15 @@ func seedInstallerStore(tb testing.TB, store *InstallerStore, enrollSecret strin
 	}
 
 	return installers
+}
+
+func mockInstaller(secret, kind string, desktop bool) fleet.Installer {
+	return fleet.Installer{
+		EnrollSecret: secret,
+		Kind:         kind,
+		Desktop:      desktop,
+		Content:      aws.ReadSeekCloser(strings.NewReader(mockInstallerContents)),
+	}
 }
 
 func cleanupStore(tb testing.TB, store *InstallerStore) {

--- a/server/datastore/s3/testing_utils.go
+++ b/server/datastore/s3/testing_utils.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -44,34 +45,26 @@ func setupInstallerStore(tb testing.TB, bucket, prefix string) *InstallerStore {
 	return store
 }
 
-func seedInstallerStore(tb testing.TB, store *InstallerStore, enrollSecret string) []*fleet.Installer {
+func seedInstallerStore(tb testing.TB, store *InstallerStore, enrollSecret string) []fleet.Installer {
 	checkEnv(tb)
-	installers := []*fleet.Installer{
-		{EnrollSecret: enrollSecret, Kind: "pkg", Desktop: false},
-		{EnrollSecret: enrollSecret, Kind: "msi", Desktop: false},
-		{EnrollSecret: enrollSecret, Kind: "deb", Desktop: false},
-		{EnrollSecret: enrollSecret, Kind: "rpm", Desktop: false},
-		{EnrollSecret: enrollSecret, Kind: "pkg", Desktop: true},
-		{EnrollSecret: enrollSecret, Kind: "msi", Desktop: true},
-		{EnrollSecret: enrollSecret, Kind: "deb", Desktop: true},
-		{EnrollSecret: enrollSecret, Kind: "rpm", Desktop: true},
+	content := aws.ReadSeekCloser(strings.NewReader(mockInstallerContents))
+	installers := []fleet.Installer{
+		{EnrollSecret: enrollSecret, Kind: "pkg", Desktop: false, Content: content},
+		{EnrollSecret: enrollSecret, Kind: "msi", Desktop: false, Content: content},
+		{EnrollSecret: enrollSecret, Kind: "deb", Desktop: false, Content: content},
+		{EnrollSecret: enrollSecret, Kind: "rpm", Desktop: false, Content: content},
+		{EnrollSecret: enrollSecret, Kind: "pkg", Desktop: true, Content: content},
+		{EnrollSecret: enrollSecret, Kind: "msi", Desktop: true, Content: content},
+		{EnrollSecret: enrollSecret, Kind: "deb", Desktop: true, Content: content},
+		{EnrollSecret: enrollSecret, Kind: "rpm", Desktop: true, Content: content},
 	}
 
 	for _, i := range installers {
-		uploadMockInstaller(tb, store, i)
+		_, err := store.Put(context.Background(), i)
+		require.NoError(tb, err)
 	}
 
 	return installers
-}
-
-func uploadMockInstaller(tb testing.TB, store *InstallerStore, installer *fleet.Installer) {
-	checkEnv(tb)
-	_, err := store.s3client.PutObject(&s3.PutObjectInput{
-		Bucket: &store.bucket,
-		Body:   aws.ReadSeekCloser(strings.NewReader(mockInstallerContents)),
-		Key:    aws.String(store.keyForInstaller(*installer)),
-	})
-	require.NoError(tb, err)
 }
 
 func cleanupStore(tb testing.TB, store *InstallerStore) {
@@ -102,6 +95,5 @@ func cleanupStore(tb testing.TB, store *InstallerStore) {
 func checkEnv(tb testing.TB) {
 	if _, ok := os.LookupEnv("MINIO_STORAGE_TEST"); !ok {
 		tb.Skip("set MINIO_STORAGE_TEST environment variable to run S3-based tests")
-
 	}
 }

--- a/server/fleet/installer.go
+++ b/server/fleet/installer.go
@@ -1,8 +1,11 @@
 package fleet
 
+import "io"
+
 // Installer describes an installer in an S3 bucket
 type Installer struct {
 	EnrollSecret string
 	Kind         string
 	Desktop      bool
+	Content      io.ReadSeeker
 }

--- a/tools/installerstore/README.md
+++ b/tools/installerstore/README.md
@@ -1,0 +1,47 @@
+## installerstore 
+
+Small utility to upload installers to a file storage (AWS S3, MinIO, etc.)
+using the keys where the Fleet server expects to find them.
+
+```
+NAME:
+   installerstore - Utility to upload pre-built installers to a file storage (AWS S3, MinIO, etc.)
+
+USAGE:
+   installerstore --enroll-secret xyz --bucket installers ~/path/to/file.pkg
+
+COMMANDS:
+   help, h  Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --fleet-desktop value                                     Wether or not the installer includes Fleet Desktop [$INSTALLER_FLEET_DESKTOP]
+   --enroll-secret value                                     Enroll secret associated with the installer [$INSTALLER_ENROLL_SECRET]
+   --bucket value                                            Bucket where to store installers [$INSTALLER_BUCKET]
+   --prefix value                                            Prefix under which installers are stored [$INSTALLER_PREFIX]
+   --region value                                            AWS Region (if blank region is derived) [$INSTALLER_REGION]
+   --endpoint-url value                                      AWS Service Endpoint to use (leave blank for default service endpoints) [$INSTALLER_ENDPOINT_URL]
+   --access-key-id value                                     Access Key ID for AWS authentication [$INSTALLER_ACCESS_KEY_ID]
+   --secret-access-key value                                 Secret Access Key for AWS authentication [$INSTALLER_SECRET_ACCESS_KEY]
+   --sts-assume-role-arn value                               ARN of role to assume for AWS [$INSTALLER_STS_ASSUME_ROLE_ARN]
+   --disable-ssl                                             Disable SSL (typically for local testing) (default: false) [$INSTALLER_DISABLE_SSL]
+   --force-s3-path-style http://s3.amazonaws.com/BUCKET/KEY  Set this to true to force path-style addressing, i.e., http://s3.amazonaws.com/BUCKET/KEY (default: false) [$INSTALLER_FORCE_S3_PATH_STYLE]
+   --help, -h                                                show help (default: false)
+```
+
+### Example
+
+To upload a file for testing to your local MinIO server, you can run this
+command from the root of the repo:
+
+```
+go run tools/installerstore/main.go \
+  --enroll-secret=xyz \
+  --bucket=installers \
+  --region=minio \
+  --endpoint-url=localhost:9000 \
+  --access-key-id=minio \
+  --secret-access-key=minio123! \
+  --disable-ssl=true \
+  --force-s3-path-style=true \
+  fleet-osquery.pkg
+```

--- a/tools/installerstore/README.md
+++ b/tools/installerstore/README.md
@@ -8,13 +8,13 @@ NAME:
    installerstore - Utility to upload pre-built installers to a file storage (AWS S3, MinIO, etc.)
 
 USAGE:
-   installerstore --enroll-secret xyz --bucket installers ~/path/to/file.pkg
+   installerstore --enroll-secret=xyz --bucket=installers ~/path/to/file.pkg
 
 COMMANDS:
    help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --fleet-desktop value                                     Wether or not the installer includes Fleet Desktop [$INSTALLER_FLEET_DESKTOP]
+   --fleet-desktop value                                     Whether or not the installer includes Fleet Desktop [$INSTALLER_FLEET_DESKTOP]
    --enroll-secret value                                     Enroll secret associated with the installer [$INSTALLER_ENROLL_SECRET]
    --bucket value                                            Bucket where to store installers [$INSTALLER_BUCKET]
    --prefix value                                            Prefix under which installers are stored [$INSTALLER_PREFIX]

--- a/tools/installerstore/main.go
+++ b/tools/installerstore/main.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/datastore/s3"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/urfave/cli/v2"
+)
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "installerstore"
+	app.Usage = "Utility to upload pre-built installers to a file storage (AWS S3, MinIO, etc.)"
+	app.UsageText = "installerstore --enroll-secret xyz --bucket installers ~/path/to/file.pkg"
+	app.Flags = []cli.Flag{
+		&cli.StringFlag{
+			Name:    "fleet-desktop",
+			Usage:   "Wether or not the installer includes Fleet Desktop",
+			EnvVars: []string{"INSTALLER_FLEET_DESKTOP"},
+		},
+		&cli.StringFlag{
+			Name:     "enroll-secret",
+			Usage:    "Enroll secret associated with the installer",
+			EnvVars:  []string{"INSTALLER_ENROLL_SECRET"},
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:     "bucket",
+			Usage:    "Bucket where to store installers",
+			EnvVars:  []string{"INSTALLER_BUCKET"},
+			Required: true,
+		},
+		&cli.StringFlag{
+			Name:    "prefix",
+			Usage:   "Prefix under which installers are stored",
+			EnvVars: []string{"INSTALLER_PREFIX"},
+		},
+		&cli.StringFlag{
+			Name:    "region",
+			Usage:   "AWS Region (if blank region is derived)",
+			EnvVars: []string{"INSTALLER_REGION"},
+		},
+		&cli.StringFlag{
+			Name:    "endpoint-url",
+			Usage:   "AWS Service Endpoint to use (leave blank for default service endpoints)",
+			EnvVars: []string{"INSTALLER_ENDPOINT_URL"},
+		},
+		&cli.StringFlag{
+			Name:    "access-key-id",
+			Usage:   "Access Key ID for AWS authentication",
+			EnvVars: []string{"INSTALLER_ACCESS_KEY_ID"},
+		},
+		&cli.StringFlag{
+			Name:    "secret-access-key",
+			Usage:   "Secret Access Key for AWS authentication",
+			EnvVars: []string{"INSTALLER_SECRET_ACCESS_KEY"},
+		},
+		&cli.StringFlag{
+			Name:    "sts-assume-role-arn",
+			Usage:   "ARN of role to assume for AWS",
+			EnvVars: []string{"INSTALLER_STS_ASSUME_ROLE_ARN"},
+		},
+		&cli.BoolFlag{
+			Name:    "disable-ssl",
+			Usage:   "Disable SSL (typically for local testing)",
+			EnvVars: []string{"INSTALLER_DISABLE_SSL"},
+		},
+		&cli.BoolFlag{
+			Name:    "force-s3-path-style",
+			Usage:   "Set this to true to force path-style addressing, i.e., `http://s3.amazonaws.com/BUCKET/KEY`",
+			EnvVars: []string{"INSTALLER_FORCE_S3_PATH_STYLE"},
+		},
+	}
+
+	app.Action = func(c *cli.Context) error {
+		store, err := s3.NewInstallerStore(config.S3Config{
+			Bucket:           c.String("bucket"),
+			Prefix:           c.String("prefix"),
+			Region:           c.String("region"),
+			EndpointURL:      c.String("endpoint-url"),
+			AccessKeyID:      c.String("access-key-id"),
+			SecretAccessKey:  c.String("secret-access-key"),
+			StsAssumeRoleArn: c.String("sts-assume-role-arn"),
+			DisableSSL:       c.Bool("disable-ssl"),
+			ForceS3PathStyle: c.Bool("force-s3-path-style"),
+		})
+		if err != nil {
+			return fmt.Errorf("unable to setup store: %v", err)
+		}
+
+		fp := c.Args().Get(0)
+		if fp == "" {
+			return errors.New("please provide an input file")
+		}
+
+		r, err := os.Open(fp)
+		if err != nil {
+			return fmt.Errorf("there was an error opening %s", fp)
+		}
+
+		key, err := store.Put(context.Background(), fleet.Installer{
+			EnrollSecret: c.String("enroll-secret"),
+			Kind:         filepath.Ext(fp)[1:],
+			Desktop:      c.Bool("fleet-desktop"),
+			Content:      r,
+		})
+		if err != nil {
+			return fmt.Errorf("there was a problem uploading the installer with key %s", key)
+		}
+
+		fmt.Printf("installer uploaded with key %s\n", key)
+		return nil
+	}
+
+	app.Run(os.Args)
+}


### PR DESCRIPTION
Related to #6365 this adds a new tool to upload pre-built Orbit installers to a storage blob. It uses the same file conventions that the Fleet server expects, making it useful for local testing and infra envs alike.\

Usage and details in the README

# Checklist for submitter

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
