### PR TITLE
Packs UI: Do not abbreviate packs frequency units

### DIFF
--- a/changes/issue-4094-frequency-units
+++ b/changes/issue-4094-frequency-units
@@ -1,0 +1,1 @@
+* * Packs frequency units match Schedules frequency units

--- a/frontend/components/queries/PackQueriesListWrapper/PackQueriesTable/PackQueriesTableConfig.tsx
+++ b/frontend/components/queries/PackQueriesListWrapper/PackQueriesTable/PackQueriesTableConfig.tsx
@@ -4,11 +4,7 @@
 import React from "react";
 import { find } from "lodash";
 
-import {
-  performanceIndicator,
-  secondsToDhms,
-  abbreviateTimeUnits,
-} from "utilities/helpers";
+import { performanceIndicator, secondsToDhms } from "utilities/helpers";
 import { IScheduledQuery } from "interfaces/scheduled_query";
 import { IDropdownOption } from "interfaces/dropdownOption";
 
@@ -125,7 +121,7 @@ const generateTableHeaders = (
       accessor: "interval",
       Cell: (cellProps: ICellProps) => (
         <TextCell
-          formatter={(val) => abbreviateTimeUnits(secondsToDhms(val))}
+          formatter={(val) => secondsToDhms(val)}
           value={cellProps.cell.value}
         />
       ),


### PR DESCRIPTION
Cerra #4094 

- Suggested fix looks 😳 with the ... but approved by QA and Product
- Note that packs allows _n_ seconds hence the granulated units

**Fix following tickets spec**
<img width="814" alt="Screen Shot 2022-07-14 at 3 28 06 PM" src="https://user-images.githubusercontent.com/71795832/179067699-e1756ad4-11b9-48b5-80b5-5b2083892531.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
