### PR TITLE
Apply password requirements to admin-created users

### DIFF
--- a/changes/admin-user
+++ b/changes/admin-user
@@ -1,0 +1,1 @@
+* Enforce the same password requirements when admins create users directly as are already applied for users created through invites.

--- a/server/fleet/users_test.go
+++ b/server/fleet/users_test.go
@@ -127,7 +127,7 @@ func TestAdminCreateValidate(t *testing.T) {
 			errContains: []string{"password"},
 		},
 		{
-			payload:     UserPayload{Name: ptr.String("Foo"), Email: ptr.String("foo@example.com"), Password: ptr.String("foo"), InviteToken: ptr.String("foo")},
+			payload:     UserPayload{Name: ptr.String("Foo"), Email: ptr.String("foo@example.com"), Password: ptr.String("Foofoofoo1337#"), InviteToken: ptr.String("foo")},
 			errContains: []string{"invite_token"},
 		},
 		{
@@ -143,6 +143,7 @@ func TestAdminCreateValidate(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				ierr := err.(*InvalidArgumentError)
+				require.Equal(t, len(tc.errContains), len(*ierr))
 				for _, expected := range tc.errContains {
 					assertContainsErrorName(t, *ierr, expected)
 				}
@@ -191,6 +192,7 @@ func TestInviteCreateValidate(t *testing.T) {
 			} else {
 				ierr := err.(*InvalidArgumentError)
 				for _, expected := range tc.errContains {
+					require.Equal(t, len(tc.errContains), len(*ierr))
 					assertContainsErrorName(t, *ierr, expected)
 				}
 			}

--- a/server/fleet/users_test.go
+++ b/server/fleet/users_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
@@ -97,4 +98,111 @@ func TestSaltAndHashPassword(t *testing.T) {
 		err = bcrypt.CompareHashAndPassword(hashed, []byte(fmt.Sprint("invalidpassword", salt)))
 		require.Error(t, err)
 	}
+}
+
+func TestAdminCreateValidate(t *testing.T) {
+	testCases := []struct {
+		payload UserPayload
+		// if errContains is empty then no error is expected
+		errContains []string
+	}{
+		{
+			payload:     UserPayload{},
+			errContains: []string{"name", "email", "password"},
+		},
+		{
+			payload:     UserPayload{Name: ptr.String(""), Email: ptr.String(""), Password: ptr.String("")},
+			errContains: []string{"name", "email", "password"},
+		},
+		{
+			payload:     UserPayload{Name: ptr.String("Foo"), Email: ptr.String(""), Password: ptr.String("")},
+			errContains: []string{"email", "password"},
+		},
+		{
+			payload:     UserPayload{Name: ptr.String("Foo"), Email: ptr.String("foo@example.com"), Password: ptr.String("")},
+			errContains: []string{"password"},
+		},
+		{
+			payload:     UserPayload{Name: ptr.String("Foo"), Email: ptr.String("foo@example.com"), Password: ptr.String("foo")},
+			errContains: []string{"password"},
+		},
+		{
+			payload:     UserPayload{Name: ptr.String("Foo"), Email: ptr.String("foo@example.com"), Password: ptr.String("foo"), InviteToken: ptr.String("foo")},
+			errContains: []string{"invite_token"},
+		},
+		{
+			payload:     UserPayload{Name: ptr.String("Foo"), Email: ptr.String("foo@example.com"), Password: ptr.String("Foofoofoo1337#")},
+			errContains: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			err := tc.payload.VerifyAdminCreate()
+			if len(tc.errContains) == 0 {
+				require.NoError(t, err)
+			} else {
+				ierr := err.(*InvalidArgumentError)
+				for _, expected := range tc.errContains {
+					assertContainsErrorName(t, *ierr, expected)
+				}
+			}
+		})
+	}
+}
+
+func TestInviteCreateValidate(t *testing.T) {
+	testCases := []struct {
+		payload UserPayload
+		// if errContains is empty then no error is expected
+		errContains []string
+	}{
+		{
+			payload:     UserPayload{},
+			errContains: []string{"name", "email", "password", "invite_token"},
+		},
+		{
+			payload:     UserPayload{Name: ptr.String(""), Email: ptr.String(""), Password: ptr.String("")},
+			errContains: []string{"name", "email", "password", "invite_token"},
+		},
+		{
+			payload:     UserPayload{Name: ptr.String("Foo"), Email: ptr.String(""), Password: ptr.String("")},
+			errContains: []string{"email", "password", "invite_token"},
+		},
+		{
+			payload:     UserPayload{Name: ptr.String("Foo"), Email: ptr.String("foo@example.com"), Password: ptr.String("")},
+			errContains: []string{"password", "invite_token"},
+		},
+		{
+			payload:     UserPayload{Name: ptr.String("Foo"), Email: ptr.String("foo@example.com"), Password: ptr.String("foo")},
+			errContains: []string{"password", "invite_token"},
+		},
+		{
+			payload:     UserPayload{Name: ptr.String("Foo"), Email: ptr.String("foo@example.com"), Password: ptr.String("Foofoofoo1337#"), InviteToken: ptr.String("foo")},
+			errContains: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			err := tc.payload.VerifyInviteCreate()
+			if len(tc.errContains) == 0 {
+				require.NoError(t, err)
+			} else {
+				ierr := err.(*InvalidArgumentError)
+				for _, expected := range tc.errContains {
+					assertContainsErrorName(t, *ierr, expected)
+				}
+			}
+		})
+	}
+}
+
+func assertContainsErrorName(t *testing.T, invalid InvalidArgumentError, name string) {
+	for _, argErr := range invalid {
+		if argErr.name == name {
+			return
+		}
+	}
+	t.Errorf("%v does not contain error %s", invalid, name)
 }


### PR DESCRIPTION
This was requested by a customer.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [x] Added/updated tests
- [ ] Manual QA for all new/changed functionality
