### PR TITLE
improve installerstore tool w/ better errors and bucket creation

### DIFF
--- a/server/datastore/s3/testing_utils.go
+++ b/server/datastore/s3/testing_utils.go
@@ -35,10 +35,8 @@ func setupInstallerStore(tb testing.TB, bucket, prefix string) *InstallerStore {
 	})
 	require.Nil(tb, err)
 
-	store.s3client.CreateBucket(&s3.CreateBucketInput{
-		Bucket:                    &bucket,
-		CreateBucketConfiguration: &s3.CreateBucketConfiguration{},
-	})
+	err = store.CreateTestBucket(bucket)
+	require.NoError(tb, err)
 
 	tb.Cleanup(func() { cleanupStore(tb, store) })
 

--- a/tools/installerstore/README.md
+++ b/tools/installerstore/README.md
@@ -25,6 +25,7 @@ GLOBAL OPTIONS:
    --sts-assume-role-arn value                               ARN of role to assume for AWS [$INSTALLER_STS_ASSUME_ROLE_ARN]
    --disable-ssl                                             Disable SSL (typically for local testing) (default: false) [$INSTALLER_DISABLE_SSL]
    --force-s3-path-style http://s3.amazonaws.com/BUCKET/KEY  Set this to true to force path-style addressing, i.e., http://s3.amazonaws.com/BUCKET/KEY (default: false) [$INSTALLER_FORCE_S3_PATH_STYLE]
+   --create-bucket                                           Set this to true to create the bucket if it doesn't exist. Only recommended for local testing. (default: false) [$INSTALLER_CREATE_BUCKET]
    --help, -h                                                show help (default: false)
 ```
 
@@ -43,5 +44,10 @@ go run tools/installerstore/main.go \
   --secret-access-key=minio123! \
   --disable-ssl=true \
   --force-s3-path-style=true \
+  --create-bucket=true \
   fleet-osquery.pkg
 ```
+
+Tip: MinIO provides an UI you can use to explore your local buckets. If you're
+running the Fleet server in development, it shoud be available at
+http://localhost:9001.

--- a/tools/installerstore/main.go
+++ b/tools/installerstore/main.go
@@ -17,11 +17,12 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "installerstore"
 	app.Usage = "Utility to upload pre-built installers to a file storage (AWS S3, MinIO, etc.)"
-	app.UsageText = "installerstore --enroll-secret xyz --bucket installers ~/path/to/file.pkg"
+	app.UsageText = "installerstore --enroll-secret=xyz --bucket=installers ~/path/to/file.pkg"
+	app.ExitErrHandler = exitErrHandler
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
 			Name:    "fleet-desktop",
-			Usage:   "Wether or not the installer includes Fleet Desktop",
+			Usage:   "Whether or not the installer includes Fleet Desktop",
 			EnvVars: []string{"INSTALLER_FLEET_DESKTOP"},
 		},
 		&cli.StringFlag{
@@ -76,11 +77,17 @@ func main() {
 			Usage:   "Set this to true to force path-style addressing, i.e., `http://s3.amazonaws.com/BUCKET/KEY`",
 			EnvVars: []string{"INSTALLER_FORCE_S3_PATH_STYLE"},
 		},
+		&cli.BoolFlag{
+			Name:    "create-bucket",
+			Usage:   "Set this to true to create the bucket if it doesn't exist. Only recommended for local testing.",
+			EnvVars: []string{"INSTALLER_CREATE_BUCKET"},
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {
+		bucket := c.String("bucket")
 		store, err := s3.NewInstallerStore(config.S3Config{
-			Bucket:           c.String("bucket"),
+			Bucket:           bucket,
 			Prefix:           c.String("prefix"),
 			Region:           c.String("region"),
 			EndpointURL:      c.String("endpoint-url"),
@@ -91,7 +98,13 @@ func main() {
 			ForceS3PathStyle: c.Bool("force-s3-path-style"),
 		})
 		if err != nil {
-			return fmt.Errorf("unable to setup store: %v", err)
+			return fmt.Errorf("unable to setup store: %w", err)
+		}
+
+		if c.Bool("create-bucket") {
+			if err := store.CreateTestBucket(bucket); err != nil {
+				return fmt.Errorf("unable to create bucket: %w", err)
+			}
 		}
 
 		fp := c.Args().Get(0)
@@ -101,7 +114,7 @@ func main() {
 
 		r, err := os.Open(fp)
 		if err != nil {
-			return fmt.Errorf("there was an error opening %s", fp)
+			return fmt.Errorf("there was an error opening %s: %w", fp, err)
 		}
 
 		key, err := store.Put(context.Background(), fleet.Installer{
@@ -111,12 +124,20 @@ func main() {
 			Content:      r,
 		})
 		if err != nil {
-			return fmt.Errorf("there was a problem uploading the installer with key %s", key)
+			return fmt.Errorf("there was a problem uploading the installer with key %s: %w", key, err)
 		}
 
-		fmt.Printf("installer uploaded with key %s\n", key)
+		fmt.Printf(`installer uploaded to bucket "%s" with key "%s"\n`, bucket, key)
 		return nil
 	}
 
 	app.Run(os.Args)
+}
+
+func exitErrHandler(c *cli.Context, err error) {
+	if err == nil {
+		return
+	}
+	fmt.Fprintf(c.App.ErrWriter, "Error: %+v\n", err)
+	cli.OsExiter(1)
 }


### PR DESCRIPTION
This improves the `installerstore` CLI tool with:

- The ability to create tests buckets for local development (otherwise you have to interact with another CLI or the MinIO UI)
- Improved error handling and messaging.

# Checklist for submitter

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
