### PR TITLE
Bug 6508: Don't show non-CVE entries

### DIFF
--- a/changes/bug-6508-non-cve-entries
+++ b/changes/bug-6508-non-cve-entries
@@ -1,0 +1,1 @@
+- Only include vulnerabilities (CVEs) in Fleet UI and API

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -373,8 +373,8 @@ func listSoftwareDB(
 			ids[result.ID] = idx
 		}
 
-		// handle null cve from left join
-		if result.CVE != nil {
+		// handle null cve from left join also skip any non-cve entries
+		if result.CVE != nil && strings.HasPrefix(strings.ToLower(*result.CVE), "cve") {
 			cveID := *result.CVE
 			cve := fleet.CVE{
 				CVE:         cveID,

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -373,8 +373,8 @@ func listSoftwareDB(
 			ids[result.ID] = idx
 		}
 
-		// handle null cve from left join also skip any non-cve entries
-		if result.CVE != nil && strings.HasPrefix(strings.ToLower(*result.CVE), "cve") {
+		// handle null cve from left join
+		if result.CVE != nil {
 			cveID := *result.CVE
 			cve := fleet.CVE{
 				CVE:         cveID,

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -514,10 +514,7 @@ func testSoftwareList(t *testing.T, ds *Datastore) {
 	vulns := []fleet.SoftwareVulnerability{
 		{SoftwareID: host1.Software[0].ID, CPEID: host1.Software[0].GeneratedCPEID, CVE: "CVE-2022-0001"},
 		{SoftwareID: host1.Software[0].ID, CPEID: host1.Software[0].GeneratedCPEID, CVE: "CVE-2022-0002"},
-		{SoftwareID: host1.Software[0].ID, CPEID: host1.Software[0].GeneratedCPEID, CVE: "USN-5469-1"},
-		{SoftwareID: host1.Software[0].ID, CPEID: host1.Software[0].GeneratedCPEID, CVE: "USN-5469-1"},
 		{SoftwareID: host3.Software[0].ID, CPEID: host3.Software[0].GeneratedCPEID, CVE: "CVE-2022-0003"},
-		{SoftwareID: host3.Software[0].ID, CPEID: host3.Software[0].GeneratedCPEID, CVE: "RHSA-2022:5555"},
 	}
 
 	_, err := ds.InsertVulnerabilities(context.Background(), vulns, fleet.NVDSource)

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -514,7 +514,10 @@ func testSoftwareList(t *testing.T, ds *Datastore) {
 	vulns := []fleet.SoftwareVulnerability{
 		{SoftwareID: host1.Software[0].ID, CPEID: host1.Software[0].GeneratedCPEID, CVE: "CVE-2022-0001"},
 		{SoftwareID: host1.Software[0].ID, CPEID: host1.Software[0].GeneratedCPEID, CVE: "CVE-2022-0002"},
+		{SoftwareID: host1.Software[0].ID, CPEID: host1.Software[0].GeneratedCPEID, CVE: "USN-5469-1"},
+		{SoftwareID: host1.Software[0].ID, CPEID: host1.Software[0].GeneratedCPEID, CVE: "USN-5469-1"},
 		{SoftwareID: host3.Software[0].ID, CPEID: host3.Software[0].GeneratedCPEID, CVE: "CVE-2022-0003"},
+		{SoftwareID: host3.Software[0].ID, CPEID: host3.Software[0].GeneratedCPEID, CVE: "RHSA-2022:5555"},
 	}
 
 	_, err := ds.InsertVulnerabilities(context.Background(), vulns, fleet.NVDSource)
@@ -1471,7 +1474,7 @@ func testInsertVulnerabilities(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
 
 	t.Run("no vulnerabilities to insert", func(t *testing.T) {
-		r, err := ds.InsertVulnerabilities(ctx, nil, fleet.OVALSource)
+		r, err := ds.InsertVulnerabilities(ctx, nil, fleet.UbuntuOVALSource)
 		require.Zero(t, r)
 		require.NoError(t, err)
 	})
@@ -1496,7 +1499,7 @@ func testInsertVulnerabilities(t *testing.T, ds *Datastore) {
 			})
 		}
 
-		n, err := ds.InsertVulnerabilities(ctx, vulns, fleet.OVALSource)
+		n, err := ds.InsertVulnerabilities(ctx, vulns, fleet.UbuntuOVALSource)
 		require.NoError(t, err)
 		require.Equal(t, 1, int(n))
 
@@ -1529,11 +1532,11 @@ func testInsertVulnerabilities(t *testing.T, ds *Datastore) {
 			})
 		}
 
-		n, err := ds.InsertVulnerabilities(ctx, vulns, fleet.OVALSource)
+		n, err := ds.InsertVulnerabilities(ctx, vulns, fleet.UbuntuOVALSource)
 		require.NoError(t, err)
 		require.Equal(t, 1, int(n))
 
-		n, err = ds.InsertVulnerabilities(ctx, vulns, fleet.OVALSource)
+		n, err = ds.InsertVulnerabilities(ctx, vulns, fleet.UbuntuOVALSource)
 		require.NoError(t, err)
 		require.Equal(t, 0, int(n))
 

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -147,5 +147,6 @@ type VulnerabilitySource int
 
 const (
 	NVDSource VulnerabilitySource = iota
-	OVALSource
+	UbuntuOVALSource
+	RHELOVALSource
 )

--- a/server/vulnerabilities/oval/analyzer.go
+++ b/server/vulnerabilities/oval/analyzer.go
@@ -32,6 +32,11 @@ func Analyze(
 ) ([]fleet.SoftwareVulnerability, error) {
 	platform := NewPlatform(ver.Platform, ver.Name)
 
+	source := fleet.UbuntuOVALSource
+	if platform.IsRedHat() {
+		source = fleet.RHELOVALSource
+	}
+
 	if !platform.IsSupported() {
 		return nil, nil
 	}
@@ -103,7 +108,7 @@ func Analyze(
 	}
 
 	err = batchProcess(toInsertSet, func(v []fleet.SoftwareVulnerability) error {
-		n, err := ds.InsertVulnerabilities(ctx, v, fleet.OVALSource)
+		n, err := ds.InsertVulnerabilities(ctx, v, source)
 		if err != nil {
 			return err
 		}

--- a/server/vulnerabilities/oval/analyzer_test.go
+++ b/server/vulnerabilities/oval/analyzer_test.go
@@ -172,6 +172,10 @@ func assertVulns(
 			continue
 		}
 
+		if !strings.HasPrefix(strings.ToLower(row[0]), "cve") {
+			continue
+		}
+
 		expected = append(expected, row[0])
 	}
 	require.NotEmpty(t, expected)

--- a/server/vulnerabilities/oval/parsed/definition.go
+++ b/server/vulnerabilities/oval/parsed/definition.go
@@ -90,7 +90,9 @@ func evalCriteria(c *Criteria, OSTstResults map[int]bool, pkgTstResults map[int]
 	return result, nil
 }
 
-// CveVulnerabilities Returns only CVE vulnerabilities.
+// CveVulnerabilities Returns only CVE vulnerabilities, excluding any 'advisory'
+// entries. 'Advisory' entries are excluded because we only want to report entries for which we
+// might have a NVD link.
 func (d Definition) CveVulnerabilities() []string {
 	var r []string
 	for _, v := range d.Vulnerabilities {

--- a/server/vulnerabilities/oval/parsed/definition.go
+++ b/server/vulnerabilities/oval/parsed/definition.go
@@ -2,6 +2,7 @@ package oval_parsed
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 )
@@ -26,25 +27,25 @@ type Definition struct {
 // Tests results can come from two sources:
 // - OSTstResults: Test results from making assertions against the installed OS Version
 // - pkTstResults: Tests results from making assertions against the installed software packages.
-func (r Definition) Eval(OSTstResults map[int]bool, pkgTstResults map[int][]fleet.Software) bool {
-	if r.Criteria == nil || (len(OSTstResults) == 0 && len(pkgTstResults) == 0) {
+func (d Definition) Eval(OSTstResults map[int]bool, pkgTstResults map[int][]fleet.Software) bool {
+	if d.Criteria == nil || (len(OSTstResults) == 0 && len(pkgTstResults) == 0) {
 		return false
 	}
 
-	rEval, err := evalCriteria(r.Criteria, OSTstResults, pkgTstResults)
+	rEval, err := evalCriteria(d.Criteria, OSTstResults, pkgTstResults)
 	if err != nil {
 		return false
 	}
 	return rEval
 }
 
-func (r Definition) CollectTestIds() []int {
-	if r.Criteria == nil {
+func (d Definition) CollectTestIds() []int {
+	if d.Criteria == nil {
 		return nil
 	}
 
 	var results []int
-	queue := []*Criteria{r.Criteria}
+	queue := []*Criteria{d.Criteria}
 
 	for len(queue) > 0 {
 		next := queue[0]
@@ -87,4 +88,15 @@ func evalCriteria(c *Criteria, OSTstResults map[int]bool, pkgTstResults map[int]
 	}
 
 	return result, nil
+}
+
+// CveVulnerabilities Returns only CVE vulnerabilities.
+func (d Definition) CveVulnerabilities() []string {
+	var r []string
+	for _, v := range d.Vulnerabilities {
+		if strings.HasPrefix(strings.ToLower(v), "cve") {
+			r = append(r, v)
+		}
+	}
+	return r
 }

--- a/server/vulnerabilities/oval/parsed/definition_test.go
+++ b/server/vulnerabilities/oval/parsed/definition_test.go
@@ -8,6 +8,26 @@ import (
 )
 
 func TestOvalParsedDefinition(t *testing.T) {
+	t.Run("#CveVulnerabilities", func(t *testing.T) {
+		t.Run("only returns cve vulnerabilities", func(t *testing.T) {
+			sut := Definition{
+				Vulnerabilities: []string{
+					"CVE-2022-0001",
+					"CVE-2022-0002",
+					"USN-5469-1",
+					"CVE-2022-0003",
+					"RHSA-2022:5555",
+				},
+			}
+
+			require.ElementsMatch(t, sut.CveVulnerabilities(), []string{
+				"CVE-2022-0001",
+				"CVE-2022-0002",
+				"CVE-2022-0003",
+			})
+		})
+	})
+
 	t.Run("#Eval", func(t *testing.T) {
 		t.Run("no root criteria", func(t *testing.T) {
 			sut := Definition{}

--- a/server/vulnerabilities/oval/parsed/rhel_result.go
+++ b/server/vulnerabilities/oval/parsed/rhel_result.go
@@ -47,7 +47,7 @@ func (r RhelResult) Eval(ver fleet.OSVersion, software []fleet.Software) ([]flee
 
 		for _, tId := range d.CollectTestIds() {
 			for _, software := range pkgTstResults[tId] {
-				for _, v := range d.Vulnerabilities {
+				for _, v := range d.CveVulnerabilities() {
 					vuln = append(vuln, fleet.SoftwareVulnerability{
 						SoftwareID: software.ID,
 						CPEID:      software.GeneratedCPEID,

--- a/server/vulnerabilities/oval/parsed/ubuntu_result.go
+++ b/server/vulnerabilities/oval/parsed/ubuntu_result.go
@@ -49,7 +49,7 @@ func (r UbuntuResult) Eval(ver fleet.OSVersion, software []fleet.Software) ([]fl
 
 		for _, tId := range d.CollectTestIds() {
 			for _, software := range pkgTstResults[tId] {
-				for _, v := range d.Vulnerabilities {
+				for _, v := range d.CveVulnerabilities() {
 					vuln = append(vuln, fleet.SoftwareVulnerability{
 						SoftwareID: software.ID,
 						CPEID:      software.GeneratedCPEID,


### PR DESCRIPTION
#6508

Only include vulnerabilities (CVEs) in Fleet UI and API

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
