### PR TITLE
Fixed missing "t" in "the"

### DIFF
--- a/articles/fleet-4.17.0.md
+++ b/articles/fleet-4.17.0.md
@@ -19,7 +19,7 @@ Fleet's osquery installer (Orbit) is out of beta! Orbit is a lightweight wrapper
 
 Future plans for the installer include adding the ability to manage `osquery` extensions and enrollment flags across your organization without needing to reinstall anything or ssh in to individual machines. A simple, one-stop shop for remotely managing `osquery`.
 
-You can generate your installer using the [`fleetctl` CLI tool](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer). If you're enrolling your host to a Fleet server, he best place to find the full command with flags specific to your Fleet instance is **Hosts > Add hosts** in the Fleet UI. Once the installer has been generated, just extract the file and run it on the host!
+You can generate your installer using the [`fleetctl` CLI tool](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer). If you're enrolling your host to a Fleet server, the best place to find the full command with flags specific to your Fleet instance is **Hosts > Add hosts** in the Fleet UI. Once the installer has been generated, just extract the file and run it on the host!
 
 [Read more about bringing Orbit out of beta.](https://github.com/fleetdm/fleet/issues/5454)
 


### PR DESCRIPTION
If you're enrolling your host to a Fleet server, he best place to find the full command"...

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
