### PR TITLE
Edit User UI: Converting a user to SSO provides new password of null

### DIFF
--- a/changes/bug-6594-convert-sso-no-password
+++ b/changes/bug-6594-convert-sso-no-password
@@ -1,0 +1,1 @@
+* Fix edit user modal converting a user to sso will provide a new password of null

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -195,6 +195,10 @@ const UserForm = ({
       submitData.new_password = formData.password;
       delete submitData.password;
       delete submitData.newUserType; // this field will not be submitted when form is used to edit an existing user
+      // if an existing user is converted to sso, the API expects `new_password` to be null
+      if (formData.sso_enabled) {
+        submitData.new_password = null;
+      }
     }
 
     if (
@@ -232,7 +236,8 @@ const UserForm = ({
       !isNewUser &&
       !isInvitePending &&
       formData.password &&
-      !validPassword(formData.password)
+      !validPassword(formData.password) &&
+      !formData.sso_enabled
     ) {
       setErrors({
         ...errors,
@@ -412,25 +417,28 @@ const UserForm = ({
             "
         }
       />
-      {!isNewUser && !isInvitePending && isModifiedByGlobalAdmin && (
-        <div className={`${baseClass}__edit-password`}>
-          <div className={`${baseClass}__password`}>
-            <InputField
-              label="Password"
-              error={errors.password}
-              name="password"
-              onChange={onInputChange("password")}
-              placeholder="••••••••"
-              value={formData.password || ""}
-              type="password"
-              hint={[
-                "Must include 12 characters, at least 1 number (e.g. 0 - 9), and at least 1 symbol (e.g. &*#)",
-              ]}
-              blockAutoComplete
-            />
+      {!isNewUser &&
+        !isInvitePending &&
+        isModifiedByGlobalAdmin &&
+        !formData.sso_enabled && (
+          <div className={`${baseClass}__edit-password`}>
+            <div className={`${baseClass}__password`}>
+              <InputField
+                label="Password"
+                error={errors.password}
+                name="password"
+                onChange={onInputChange("password")}
+                placeholder="••••••••"
+                value={formData.password || ""}
+                type="password"
+                hint={[
+                  "Must include 12 characters, at least 1 number (e.g. 0 - 9), and at least 1 symbol (e.g. &*#)",
+                ]}
+                blockAutoComplete
+              />
+            </div>
           </div>
-        </div>
-      )}
+        )}
       <div className={`${baseClass}__sso-input`}>
         <Checkbox
           name="sso_enabled"

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -689,9 +689,9 @@ export const secondsToHms = (d: number): string => {
   const m = Math.floor((d % 3600) / 60);
   const s = Math.floor((d % 3600) % 60);
 
-  const hDisplay = h > 0 ? h + (h === 1 ? " hr " : " hrs ") : "";
-  const mDisplay = m > 0 ? m + (m === 1 ? " min " : " mins ") : "";
-  const sDisplay = s > 0 ? s + (s === 1 ? " sec" : " secs") : "";
+  const hDisplay = h > 0 ? h + (h === 1 ? " hour " : " hours ") : "";
+  const mDisplay = m > 0 ? m + (m === 1 ? " minute " : " minutes ") : "";
+  const sDisplay = s > 0 ? s + (s === 1 ? " second" : " seconds") : "";
   return hDisplay + mDisplay + sDisplay;
 };
 

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -689,9 +689,9 @@ export const secondsToHms = (d: number): string => {
   const m = Math.floor((d % 3600) / 60);
   const s = Math.floor((d % 3600) % 60);
 
-  const hDisplay = h > 0 ? h + (h === 1 ? " hour " : " hours ") : "";
-  const mDisplay = m > 0 ? m + (m === 1 ? " minute " : " minutes ") : "";
-  const sDisplay = s > 0 ? s + (s === 1 ? " second" : " seconds") : "";
+  const hDisplay = h > 0 ? h + (h === 1 ? " hr " : " hrs ") : "";
+  const mDisplay = m > 0 ? m + (m === 1 ? " min " : " mins ") : "";
+  const sDisplay = s > 0 ? s + (s === 1 ? " sec" : " secs") : "";
   return hDisplay + mDisplay + sDisplay;
 };
 


### PR DESCRIPTION
Cerra #6594 

**Fixes**
- Overrides any change to password with a password of null if SSO is enabled
- Edit user flow mirrors New user flow in which it hides the password field when Enable SSO checkbox is checked to better communicate to the user that SSO does not have a password field
- Remove FE validation on password field if SSO checkbox is checked

<img width="1505" alt="Screen Shot 2022-07-15 at 11 07 55 AM" src="https://user-images.githubusercontent.com/71795832/179251758-a178ba48-15c4-4e3b-926c-2d398c682036.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
