### PR TITLE
Fix double quote usage in sql query

### DIFF
--- a/changes/issue-6706-double-quote-sql
+++ b/changes/issue-6706-double-quote-sql
@@ -1,0 +1,1 @@
+* Fixed an issue with double quotes usage in sql query. Caused by enabling `ANSI_QUOTES` in MySQL.

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -307,6 +307,20 @@ Maximum amount of time, in seconds, a connection may be reused.
   	conn_max_lifetime: 50
   ```
 
+##### mysql_sql_mode
+
+Sets the connection `sql_mode`. See [MySQL Reference](https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html) for more details.
+This setting should not usually be used.
+
+- Default value: `""`
+- Environment variable: `FLEET_MYSQL_SQL_MODE`
+- Config file format:
+
+  ```
+  mysql:
+  	sql_mode: ANSI
+  ```
+
 ##### Example YAML
 
 ```yaml

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -25,12 +25,12 @@ const (
 
 // MysqlConfig defines configs related to MySQL
 type MysqlConfig struct {
-	Protocol        string
-	Address         string
-	Username        string
-	Password        string
+	Protocol        string `yaml:"protocol"`
+	Address         string `yaml:"address"`
+	Username        string `yaml:"username"`
+	Password        string `yaml:"password"`
 	PasswordPath    string `yaml:"password_path"`
-	Database        string
+	Database        string `yaml:"database"`
 	TLSCert         string `yaml:"tls_cert"`
 	TLSKey          string `yaml:"tls_key"`
 	TLSCA           string `yaml:"tls_ca"`
@@ -39,6 +39,7 @@ type MysqlConfig struct {
 	MaxOpenConns    int    `yaml:"max_open_conns"`
 	MaxIdleConns    int    `yaml:"max_idle_conns"`
 	ConnMaxLifetime int    `yaml:"conn_max_lifetime"`
+	SQLMode         string `yaml:"sql_mode"`
 }
 
 // RedisConfig defines configs related to Redis

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -404,6 +404,7 @@ func (man Manager) addConfigs() {
 		man.addConfigInt(prefix+".max_open_conns", 50, "MySQL maximum open connection handles"+usageSuffix)
 		man.addConfigInt(prefix+".max_idle_conns", 50, "MySQL maximum idle connection handles"+usageSuffix)
 		man.addConfigInt(prefix+".conn_max_lifetime", 0, "MySQL maximum amount of time a connection may be reused"+usageSuffix)
+		man.addConfigString(prefix+".sql_mode", "", "MySQL sql_mode"+usageSuffix)
 	}
 	// MySQL
 	addMysqlConfig("mysql", "localhost:3306", ".")

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -667,6 +667,7 @@ func (man Manager) LoadConfig() FleetConfig {
 			MaxOpenConns:    man.getConfigInt(prefix + ".max_open_conns"),
 			MaxIdleConns:    man.getConfigInt(prefix + ".max_idle_conns"),
 			ConnMaxLifetime: man.getConfigInt(prefix + ".conn_max_lifetime"),
+			SQLMode:         man.getConfigString(prefix + ".sql_mode"),
 		}
 	}
 

--- a/server/datastore/mysql/config.go
+++ b/server/datastore/mysql/config.go
@@ -24,6 +24,7 @@ type dbOptions struct {
 	interceptor         sqlmw.Interceptor
 	tracingConfig       *config.LoggingConfig
 	minLastOpenedAtDiff time.Duration
+	sqlMode             string
 }
 
 // Logger adds a logger to the datastore.
@@ -72,6 +73,14 @@ func TracingEnabled(lconfig *config.LoggingConfig) DBOption {
 func WithFleetConfig(conf *config.FleetConfig) DBOption {
 	return func(o *dbOptions) error {
 		o.minLastOpenedAtDiff = conf.Osquery.MinSoftwareLastOpenedAtDiff
+		return nil
+	}
+}
+
+// SQLMode allows setting a custom sql_mode string.
+func SQLMode(mode string) DBOption {
+	return func(o *dbOptions) error {
+		o.sqlMode = mode
 		return nil
 	}
 }

--- a/server/datastore/mysql/migrations_test.go
+++ b/server/datastore/mysql/migrations_test.go
@@ -1,7 +1,6 @@
 package mysql
 
 import (
-	"bytes"
 	"context"
 	"os/exec"
 	"testing"
@@ -67,11 +66,9 @@ func TestMigrations(t *testing.T) {
 		// Command run inside container
 		"mysqldump", "-u"+testUsername, "-p"+testPassword, "TestMigrations", "--compact", "--skip-comments",
 	)
-	var stdoutBuf bytes.Buffer
-	cmd.Stdout = &stdoutBuf
-	require.NoError(t, cmd.Run())
 
-	require.NotEmpty(t, stdoutBuf.String())
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "mysqldump: %s", string(output))
 }
 
 func createMySQLDSForMigrationTests(t *testing.T, dbName string) *Datastore {

--- a/server/datastore/mysql/mysql_test.go
+++ b/server/datastore/mysql/mysql_test.go
@@ -974,3 +974,14 @@ func TestDebugs(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, len(processList), 0)
 }
+
+func TestANSIQuotesEnabled(t *testing.T) {
+
+	// Ensure sql_mode=ANSI_QUOTES is enabled for tests
+	ds := CreateMySQLDS(t)
+
+	var sqlMode string
+	err := ds.writer.GetContext(context.Background(), &sqlMode, `SELECT @@SQL_MODE`)
+	require.NoError(t, err)
+	require.Contains(t, sqlMode, "ANSI_QUOTES")
+}

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -293,7 +293,7 @@ func amountTeamsDB(ctx context.Context, db sqlx.QueryerContext) (int, error) {
 
 // TeamAgentOptions loads the agents options of a team.
 func (ds *Datastore) TeamAgentOptions(ctx context.Context, tid uint) (*json.RawMessage, error) {
-	sql := `SELECT config->"$.agent_options" FROM teams WHERE id = ?`
+	sql := `SELECT config->'$.agent_options' FROM teams WHERE id = ?`
 	var agentOptions *json.RawMessage
 	if err := sqlx.GetContext(ctx, ds.reader, &agentOptions, sql, tid); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "select team")

--- a/server/datastore/mysql/testing_utils.go
+++ b/server/datastore/mysql/testing_utils.go
@@ -44,7 +44,7 @@ func connectMySQL(t testing.TB, testName string, opts *DatastoreTestOptions) *Da
 		replicaConf.Database += testReplicaDatabaseSuffix
 		replicaOpt = Replica(&replicaConf)
 	}
-	ds, err := New(config, clock.NewMockClock(), Logger(log.NewNopLogger()), LimitAttempts(1), replicaOpt)
+	ds, err := New(config, clock.NewMockClock(), Logger(log.NewNopLogger()), LimitAttempts(1), replicaOpt, SQLMode("ANSI_QUOTES"))
 	require.Nil(t, err)
 
 	if opts.Replica {


### PR DESCRIPTION
#6706

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] ~Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- [ ] ~Documented any permissions changes~
- [ ] ~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
- [ ] ~Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [ ] ~Added/updated tests~
- [x] Manual QA for all new/changed functionality
