### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/cmd/fleetctl/config_test.go
+++ b/cmd/fleetctl/config_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -155,7 +154,7 @@ func TestCustomHeadersConfig(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
-	os.Setenv("FLEET_SERVER_ADDRESS", srv.URL)
+	t.Setenv("FLEET_SERVER_ADDRESS", srv.URL)
 
 	runAppForTest(t, []string{
 		"config", "set",

--- a/cmd/fleetctl/debug_test.go
+++ b/cmd/fleetctl/debug_test.go
@@ -11,7 +11,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -78,7 +77,7 @@ func TestDebugConnectionCommand(t *testing.T) {
 			fmt.Fprint(w, `{"error": "error", "node_invalid": true}`)
 		}))
 		defer srv.Close()
-		os.Setenv("FLEET_SERVER_ADDRESS", srv.URL)
+		t.Setenv("FLEET_SERVER_ADDRESS", srv.URL)
 
 		// get the certificate of the TLS server
 		certPath := rawCertToPemFile(t, srv.Certificate().Raw)
@@ -95,7 +94,7 @@ func TestDebugConnectionCommand(t *testing.T) {
 			fmt.Fprint(w, `{"error": "error", "node_invalid": true}`)
 		}))
 		defer srv.Close()
-		os.Setenv("FLEET_SERVER_ADDRESS", srv.URL)
+		t.Setenv("FLEET_SERVER_ADDRESS", srv.URL)
 
 		// get the invalid certificate (for example.com)
 		dir := t.TempDir()
@@ -160,7 +159,7 @@ func TestDebugCheckAPIEndpoint(t *testing.T) {
 		srv.Close()
 	})
 
-	os.Setenv("FLEET_SERVER_ADDRESS", srv.URL)
+	t.Setenv("FLEET_SERVER_ADDRESS", srv.URL)
 	cli, base, err := rawHTTPClientFromConfig(Context{Address: srv.URL, TLSSkipVerify: true})
 	require.NoError(t, err)
 	for i, c := range cases {

--- a/cmd/fleetctl/preview_test.go
+++ b/cmd/fleetctl/preview_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -15,7 +14,7 @@ import (
 func TestPreview(t *testing.T) {
 	nettest.Run(t)
 
-	os.Setenv("FLEET_SERVER_ADDRESS", "https://localhost:8412")
+	t.Setenv("FLEET_SERVER_ADDRESS", "https://localhost:8412")
 	testOverridePreviewDirectory = t.TempDir()
 	configPath := filepath.Join(t.TempDir(), "config")
 	t.Log("config path: ", configPath)

--- a/ee/fleetctl/updates_test.go
+++ b/ee/fleetctl/updates_test.go
@@ -43,11 +43,10 @@ func TestPassphraseHandlerEnvironment(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.role, func(t *testing.T) {
 			tt := tt
-			t.Parallel()
 
 			handler := newPassphraseHandler()
 			envKey := fmt.Sprintf("FLEET_%s_PASSPHRASE", strings.ToUpper(tt.role))
-			require.NoError(t, os.Setenv(envKey, tt.passphrase))
+			t.Setenv(envKey, tt.passphrase)
 
 			passphrase, err := handler.getPassphrase(tt.role, false, false)
 			require.NoError(t, err)
@@ -64,17 +63,17 @@ func TestPassphraseHandlerEnvironment(t *testing.T) {
 func TestPassphraseHandlerEmpty(t *testing.T) {
 	// Not t.Parallel() due to modifications to environment.
 	handler := newPassphraseHandler()
-	require.NoError(t, os.Setenv("FLEET_ROOT_PASSPHRASE", ""))
+	t.Setenv("FLEET_ROOT_PASSPHRASE", "")
 	_, err := handler.getPassphrase("root", false, false)
 	require.Error(t, err)
 }
 
 func setPassphrases(t *testing.T) {
 	t.Helper()
-	require.NoError(t, os.Setenv("FLEET_ROOT_PASSPHRASE", "root"))
-	require.NoError(t, os.Setenv("FLEET_TIMESTAMP_PASSPHRASE", "timestamp"))
-	require.NoError(t, os.Setenv("FLEET_TARGETS_PASSPHRASE", "targets"))
-	require.NoError(t, os.Setenv("FLEET_SNAPSHOT_PASSPHRASE", "snapshot"))
+	t.Setenv("FLEET_ROOT_PASSPHRASE", "root")
+	t.Setenv("FLEET_TIMESTAMP_PASSPHRASE", "timestamp")
+	t.Setenv("FLEET_TARGETS_PASSPHRASE", "targets")
+	t.Setenv("FLEET_SNAPSHOT_PASSPHRASE", "snapshot")
 }
 
 func runUpdatesCommand(args ...string) error {
@@ -104,7 +103,7 @@ func TestUpdatesErrorInvalidPassphrase(t *testing.T) {
 	require.NoError(t, runUpdatesCommand("init", "--path", tmpDir))
 
 	// Should not be able to add with invalid passphrase
-	require.NoError(t, os.Setenv("FLEET_SNAPSHOT_PASSPHRASE", "invalid"))
+	t.Setenv("FLEET_SNAPSHOT_PASSPHRASE", "invalid")
 	// Reset the cache that already has correct passwords stored
 	passHandler = newPassphraseHandler()
 	require.Error(t, runUpdatesCommand("add", "--path", tmpDir, "--target", "anything", "--platform", "windows", "--name", "test", "--version", "1.3.4.7"))

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -316,7 +316,7 @@ osquery:
 			os.Clearenv()
 			for _, env := range c.envVars {
 				kv := strings.SplitN(env, "=", 2)
-				os.Setenv(kv[0], kv[1])
+				t.Setenv(kv[0], kv[1])
 			}
 
 			var loadedCfg FleetConfig

--- a/server/datastore/mysql/testing_utils.go
+++ b/server/datastore/mysql/testing_utils.go
@@ -269,7 +269,6 @@ func CreateNamedMySQLDS(t *testing.T, name string) *Datastore {
 		t.Skip("MySQL tests are disabled")
 	}
 
-	t.Parallel()
 	ds := initializeDatabase(t, name, new(DatastoreTestOptions))
 	t.Cleanup(func() { ds.Close() })
 	return ds

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -3199,7 +3199,7 @@ func (s *integrationTestSuite) TestExternalIntegrationsConfig() {
 	}`), http.StatusOK)
 
 	// set environmental varible to use Zendesk test client
-	os.Setenv("TEST_ZENDESK_CLIENT", "true")
+	t.Setenv("TEST_ZENDESK_CLIENT", "true")
 	// create zendesk integration
 	s.DoRaw("PATCH", "/api/v1/fleet/config", []byte(fmt.Sprintf(`{
 		"integrations": {
@@ -5149,8 +5149,7 @@ func (s *integrationTestSuite) TestFleetSandboxDemoLogin() {
 
 	// with the FLEET_DEMO env var set, the login works as expected, validating
 	// the credentials
-	os.Setenv("FLEET_DEMO", "1")
-	defer os.Unsetenv("FLEET_DEMO")
+	t.Setenv("FLEET_DEMO", "1")
 
 	formBody.Set("email", validEmail)
 	formBody.Set("password", wrongPwd)

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -649,7 +648,7 @@ func (s *integrationEnterpriseTestSuite) TestExternalIntegrationsTeamConfig() {
 	}}, http.StatusOK, &tmResp)
 
 	// set environmental varible to use Zendesk test client
-	os.Setenv("TEST_ZENDESK_CLIENT", "true")
+	t.Setenv("TEST_ZENDESK_CLIENT", "true")
 
 	// add an unknown automation - does not exist at the global level
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), fleet.TeamPayload{Integrations: &fleet.TeamIntegrations{

--- a/server/service/integration_live_queries_test.go
+++ b/server/service/integration_live_queries_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"sort"
 	"sync"
 	"testing"
@@ -42,7 +41,7 @@ func (s *liveQueriesTestSuite) SetupTest() {
 
 // SetupSuite partially implements suite.SetupAllSuite.
 func (s *liveQueriesTestSuite) SetupSuite() {
-	require.NoError(s.T(), os.Setenv("FLEET_LIVE_QUERY_REST_PERIOD", "5s"))
+	s.T().Setenv("FLEET_LIVE_QUERY_REST_PERIOD", "5s")
 
 	s.withDS.SetupSuite("liveQueriesTestSuite")
 

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -493,7 +493,7 @@ func TestDangerousReplaceQuery(t *testing.T) {
 	queries := GetDetailQueries(&fleet.AppConfig{HostSettings: fleet.HostSettings{EnableHostUsers: true}}, config.FleetConfig{})
 	originalQuery := queries["users"].Query
 
-	require.NoError(t, os.Setenv("FLEET_DANGEROUS_REPLACE_USERS", "select * from blah"))
+	t.Setenv("FLEET_DANGEROUS_REPLACE_USERS", "select * from blah")
 	queries = GetDetailQueries(&fleet.AppConfig{HostSettings: fleet.HostSettings{EnableHostUsers: true}}, config.FleetConfig{})
 	assert.NotEqual(t, originalQuery, queries["users"].Query)
 


### PR DESCRIPTION
This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

This saves us at least 2 lines (error check, and unsetting the env var) on every instance.

Reference: https://pkg.go.dev/testing#T.Setenv

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
