### PR TITLE
Live Query UI: Fix query results count

### DIFF
--- a/changes/bug-6700-live-query-results
+++ b/changes/bug-6700-live-query-results
@@ -1,0 +1,1 @@
+* Live query correctly counts results not hosts

--- a/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
@@ -187,7 +187,7 @@ const QueryResults = ({
           isMultiColumnFilter
           showMarkAllPages={false}
           isAllPagesSelected={false}
-          resultsTitle={tableType === "results" ? "hosts" : tableType}
+          resultsTitle={tableType}
           customControl={() => renderTableButtons(tableType)}
           setExportRows={
             tableType === "errors" ? setFilteredErrors : setFilteredResults


### PR DESCRIPTION
Cerra #6700 

- Live query correctly counts results not hosts
- Dev fix: _tableType_ is only type string "results" or "errors"

<img width="833" alt="Screen Shot 2022-07-18 at 9 45 12 AM" src="https://user-images.githubusercontent.com/71795832/179525210-5207afe8-eacd-4566-8988-475a04064274.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
