### PR TITLE
Fleet Sandbox: Logout redirects to marketing site

### DIFF
--- a/changes/issue-5902-sandbox-logout
+++ b/changes/issue-5902-sandbox-logout
@@ -1,0 +1,1 @@
+* Redirect to fleetdm.com when logging out of sandbox

--- a/frontend/pages/LogoutPage/LogoutPage.tsx
+++ b/frontend/pages/LogoutPage/LogoutPage.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect } from "react";
 import { InjectedRouter } from "react-router";
 
+import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import sessionsAPI from "services/entities/sessions";
 import { clearToken } from "utilities/local";
@@ -10,6 +11,7 @@ interface ILogoutPageProps {
 }
 
 const LogoutPage = ({ router }: ILogoutPageProps) => {
+  const { isSandboxMode } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 
   useEffect(() => {
@@ -18,7 +20,9 @@ const LogoutPage = ({ router }: ILogoutPageProps) => {
         await sessionsAPI.destroy();
         clearToken();
         setTimeout(() => {
-          window.location.href = "/";
+          window.location.href = isSandboxMode
+            ? "https://www.fleetdm.com"
+            : "/";
         }, 500);
       } catch (response) {
         console.error(response);


### PR DESCRIPTION
Cerra #5902 

- Redirect to fleetdm.com after logging out of Fleet Sandbox

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
