### PR TITLE
Host Details Page: Correct software vulnerabilities count

### DIFF
--- a/changes/bug-6708-soft-vuln-count
+++ b/changes/bug-6708-soft-vuln-count
@@ -1,0 +1,1 @@
+* Render correct software vulnerabilities count on host details page

--- a/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
@@ -5,7 +5,6 @@ import ReactTooltip from "react-tooltip";
 import { formatDistanceToNow } from "date-fns";
 
 import { ISoftware } from "interfaces/software";
-import { IVulnerability } from "interfaces/vulnerability";
 
 import PATHS from "router/paths";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";
@@ -191,7 +190,6 @@ export const generateSoftwareTableHeaders = (
       Cell: (cellProps: IVulnCellProps): JSX.Element => {
         const vulnerabilities = cellProps.cell.value || [];
 
-        console.log("vulnerabilities", vulnerabilities);
         const tooltipText = condenseVulnerabilities(vulnerabilities).map(
           (value) => {
             return (

--- a/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
@@ -90,15 +90,12 @@ const formatSoftwareType = (source: string) => {
   return DICT[source] || "Unknown";
 };
 
-const condenseVulnerabilities = (vulns: IVulnerability[]): string[] => {
+const condenseVulnerabilities = (vulns: string[]): string[] => {
   const condensed =
-    (vulns?.length &&
-      vulns
-        .slice(-3)
-        .map((v) => v.cve)
-        .reverse()) ||
-    [];
-  return vulns?.length > 3
+    (vulns?.length && vulns.length === 4
+      ? vulns.slice(-4).reverse()
+      : vulns.slice(-3).reverse()) || [];
+  return vulns?.length > 4
     ? condensed.concat(`+${vulns?.length - 3} more`)
     : condensed;
 };
@@ -113,7 +110,7 @@ export const generateSoftwareTableData = (
   return software.map((s) => {
     return {
       ...s,
-      vulnerabilities: condenseVulnerabilities(s.vulnerabilities || []),
+      vulnerabilities: s.vulnerabilities?.map((v) => v.cve) || [],
     };
   });
 };
@@ -193,14 +190,18 @@ export const generateSoftwareTableHeaders = (
       filter: "hasLength", // filters out rows where vulnerabilities has no length if filter value is `true`
       Cell: (cellProps: IVulnCellProps): JSX.Element => {
         const vulnerabilities = cellProps.cell.value || [];
-        const tooltipText = vulnerabilities?.map((value) => {
-          return (
-            <span key={`vuln_${value}`}>
-              {value}
-              <br />
-            </span>
-          );
-        });
+
+        console.log("vulnerabilities", vulnerabilities);
+        const tooltipText = condenseVulnerabilities(vulnerabilities).map(
+          (value) => {
+            return (
+              <span key={`vuln_${value}`}>
+                {value}
+                <br />
+              </span>
+            );
+          }
+        );
 
         if (!vulnerabilities?.length) {
           return <span className="vulnerabilities text-muted">---</span>;


### PR DESCRIPTION
Cerra #6708 

*Fix*
- Fix vulnerabilities count

*Spiffier*
- The tooltip renders up to 4 lines, so spiffied the tooltip for exactly 4 vulnerabilities. Instead of rendering a list of 3 vulnerabilities and a line stating +1 more, it renders a list of all 4 vulnerabilities

<img width="164" alt="Screen Shot 2022-07-18 at 5 36 17 PM" src="https://user-images.githubusercontent.com/71795832/179622558-db753408-c39c-4d83-b41f-8f73be01d2a0.png">
<img width="187" alt="Screen Shot 2022-07-18 at 5 36 12 PM" src="https://user-images.githubusercontent.com/71795832/179622561-32c1bb7c-5020-4e85-b919-1742729cc372.png">
<img width="175" alt="Screen Shot 2022-07-18 at 5 36 07 PM" src="https://user-images.githubusercontent.com/71795832/179622562-a4f35ce4-4b29-482f-a47b-3490505d9d08.png">
<img width="200" alt="Screen Shot 2022-07-18 at 5 33 54 PM" src="https://user-images.githubusercontent.com/71795832/179622564-1ae92379-e12c-4fcc-b2e9-fd27965384e2.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
