### PR TITLE
Manage Host Page: Spiffier users tooltip

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -81,11 +81,16 @@ const condenseDeviceUsers = (users: IDeviceUser[]): string[] => {
     return [];
   }
   const condensed =
-    users
-      .slice(-3)
-      .map((u) => u.email)
-      .reverse() || [];
-  return users.length > 3
+    users.length === 4
+      ? users
+          .slice(-4)
+          .map((u) => u.email)
+          .reverse()
+      : users
+          .slice(-3)
+          .map((u) => u.email)
+          .reverse() || [];
+  return users.length > 4
     ? condensed.concat(`+${users.length - 3} more`) // TODO: confirm limit
     : condensed;
 };


### PR DESCRIPTION
**Spiffier**

The tooltip renders up to 4 lines, so spiffied the tooltip for exactly 4 users. Instead of rendering a list of 3 users and a line stating +1 more, it renders a list of all 4 users

Before:
<img width="262" alt="Screen Shot 2022-07-18 at 5 50 48 PM" src="https://user-images.githubusercontent.com/71795832/179623660-42b024c8-080b-4d93-8c48-a53d8d45e521.png">

After:
<img width="376" alt="Screen Shot 2022-07-18 at 5 49 22 PM" src="https://user-images.githubusercontent.com/71795832/179623663-6a5ab718-fb61-4702-a4ad-6ad9adf58e6a.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
