### PR TITLE
Added ritual of updating the "Release" field in the #g-growth board

### DIFF
--- a/handbook/growth.md
+++ b/handbook/growth.md
@@ -103,6 +103,7 @@ The following table lists the Growth group's rituals, frequency, and Directly Re
 | Weekly ins and outs   | Weekly | Track Growth team ins and outs.        | Tim Kern          |
 | Podcast outreach      | Weekly | Conduct podcast outreach twice a week.     | Drew Baker        |
 | Weekly update      | Weekly | Update the Growth KPIs in the ["🌈 Weekly updates" spreadsheet](https://docs.google.com/spreadsheets/d/1Hso0LxqwrRVINCyW_n436bNHmoqhoLhC8bcbvLPOs9A/edit#gid=0). | Drew Baker        |
+| Update the "Release" field on the #g-growth board   | Every 3 weeks | <ul><li>Go to the [Growth board](https://github.com/orgs/fleetdm/projects/38/settings/fields/2654827)</li><li>add a 3-week iteration with the correct release number</li></ul> | Tim Kern        |
 | Monthly conference checks    | Monthly | Check for conference openings and sponsorship opportunities on the 1st of every month. | Drew Baker|
 | Freshen up pinned posts | Quarterly | Swap out or remove pinned posts on the brand Twitter account and LinkedIn company page. | Drew Baker | 
 


### PR DESCRIPTION
This was added as per:
- https://github.com/fleetdm/fleet/issues/6739

@timmy-k, will you make sure that this is what you and @mikermcneil need?