### PR TITLE
fix CODEOWERS and add Desmi as owner of docs/*.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,10 +11,13 @@ go.mod @fleetdm/go
 /infrastructure/ @zwinnerman-fleetdm @edwardsb @rfairburn
 
 # GitHub settings + actions
-/.github/ @g-platform
+/.github/ @fleetdm/g-platform
 
 # Changelog
 CHANGELOG.md @noahtalerman
+
+# Markdown docs
+/docs/*.md @Desmi-Dizney
 
 # API documentation
 /docs/Using-Fleet/REST-API.md @ksatter


### PR DESCRIPTION
Per the new changes in the [handbook](https://fleetdm.com/handbook/community#how-to-request-a-review-for-markdown-changes-to-the-docs) this adds @Desmi-Dizney as codeowner of `docs/*.md`, this way he is automatically added as a reviewer when a file is changed.

Since I was there, I also fixed the mention to actually ping @fleetdm/g-platform
