### PR TITLE
Sandbox UI: Homepage, CTA to add personal device

### DIFF
--- a/changes/issue-5911-sandbox-homepage
+++ b/changes/issue-5911-sandbox-homepage
@@ -1,0 +1,1 @@
+* Dashboard updates for app, Fleet Sandbox, and Fleet Preview

--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -183,7 +183,7 @@ const reducer = (state: InitialStateType, action: IAction) => {
     }
     case ACTIONS.SET_CONFIG: {
       const { config } = action;
-      // config.sandbox_enabled = true; // TODO: uncomment for sandbox dev
+      config.sandbox_enabled = true; // TODO: uncomment for sandbox dev
 
       return {
         ...state,

--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -183,7 +183,7 @@ const reducer = (state: InitialStateType, action: IAction) => {
     }
     case ACTIONS.SET_CONFIG: {
       const { config } = action;
-      config.sandbox_enabled = true; // TODO: uncomment for sandbox dev
+      // config.sandbox_enabled = true; // TODO: uncomment for sandbox dev
 
       return {
         ...state,

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -31,7 +31,6 @@ import WelcomeHost from "./cards/WelcomeHost";
 import MDM from "./cards/MDM";
 import Munki from "./cards/Munki";
 import OperatingSystems from "./cards/OperatingSystems";
-// import Modal from "components/Modal";
 import AddHostsModal from "../../components/AddHostsModal";
 import ExternalURLIcon from "../../../assets/images/icon-external-url-12x12@2x.png";
 

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -37,6 +37,7 @@ const Homepage = (): JSX.Element => {
     isPremiumTier,
     isFreeTier,
     isPreviewMode,
+    isSandboxMode,
     isOnGlobalTeam,
     setCurrentTeam,
   } = useContext(AppContext);
@@ -88,6 +89,7 @@ const Homepage = (): JSX.Element => {
     {
       select: (data: IHostSummary) => data,
       onSuccess: (data: IHostSummary) => {
+        console.log("data", data);
         setLabels(data.builtin_labels);
         setOnlineCount(data.online_count);
         setOfflineCount(data.offline_count);
@@ -156,11 +158,19 @@ const Homepage = (): JSX.Element => {
 
   const WelcomeHostCard = useInfoCard({
     title: "Welcome to Fleet",
-    children: <WelcomeHost />,
+    showTitle: true,
+    children: (
+      <WelcomeHost
+        totalsHostsCount={
+          (hostSummaryData && hostSummaryData.totals_hosts_count) || 0
+        }
+      />
+    ),
   });
 
   const LearnFleetCard = useInfoCard({
     title: "Learn how to use Fleet",
+    showTitle: true,
     children: <LearnFleet />,
   });
 
@@ -252,7 +262,7 @@ const Homepage = (): JSX.Element => {
 
   const allLayout = () => (
     <div className={`${baseClass}__section`}>
-      {isPreviewMode && (
+      {hostSummaryData && hostSummaryData?.totals_hosts_count > 2 && (
         <>
           {WelcomeHostCard}
           {LearnFleetCard}

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -3,10 +3,15 @@ import { useQuery } from "react-query";
 import { AppContext } from "context/app";
 import { find } from "lodash";
 
+import {
+  IEnrollSecret,
+  IEnrollSecretsResponse,
+} from "interfaces/enroll_secret";
 import { IHostSummary, IHostSummaryPlatforms } from "interfaces/host_summary";
 import { ILabelSummary } from "interfaces/label";
 import { IOsqueryPlatform } from "interfaces/platform";
 import { ITeam } from "interfaces/team";
+import enrollSecretsAPI from "services/entities/enroll_secret";
 import hostSummaryAPI from "services/entities/host_summary";
 import teamsAPI, { ILoadTeamsResponse } from "services/entities/teams";
 import sortUtils from "utilities/sort";
@@ -26,6 +31,8 @@ import WelcomeHost from "./cards/WelcomeHost";
 import MDM from "./cards/MDM";
 import Munki from "./cards/Munki";
 import OperatingSystems from "./cards/OperatingSystems";
+// import Modal from "components/Modal";
+import AddHostsModal from "../../components/AddHostsModal";
 import ExternalURLIcon from "../../../assets/images/icon-external-url-12x12@2x.png";
 
 const baseClass = "homepage";
@@ -34,9 +41,12 @@ const Homepage = (): JSX.Element => {
   const {
     config,
     currentTeam,
+    isGlobalAdmin,
+    isGlobalMaintainer,
+    isTeamAdmin,
+    isTeamMaintainer,
     isPremiumTier,
     isFreeTier,
-    isPreviewMode,
     isSandboxMode,
     isOnGlobalTeam,
     setCurrentTeam,
@@ -55,25 +65,30 @@ const Homepage = (): JSX.Element => {
   const [showSoftwareUI, setShowSoftwareUI] = useState<boolean>(false);
   const [showMunkiUI, setShowMunkiUI] = useState<boolean>(false);
   const [showMDMUI, setShowMDMUI] = useState<boolean>(false);
+  const [showAddHostModal, setShowAddHostModal] = useState<boolean>(false);
   const [showOperatingSystemsUI, setShowOperatingSystemsUI] = useState<boolean>(
     false
   );
   const [showHostsUI, setShowHostsUI] = useState<boolean>(false); // Hides UI on first load only
 
-  const { data: teams } = useQuery<ILoadTeamsResponse, Error, ITeam[]>(
-    ["teams"],
-    () => teamsAPI.loadAll(),
-    {
-      enabled: !!isPremiumTier,
-      select: (data: ILoadTeamsResponse) =>
-        data.teams.sort((a, b) => sortUtils.caseInsensitiveAsc(a.name, b.name)),
-      onSuccess: (responseTeams) => {
-        if (!currentTeam && !isOnGlobalTeam && responseTeams.length) {
-          setCurrentTeam(responseTeams[0]);
-        }
-      },
-    }
-  );
+  const canEnrollHosts =
+    isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer;
+  const canEnrollGlobalHosts = isGlobalAdmin || isGlobalMaintainer;
+
+  const { data: teams, isLoading: isLoadingTeams } = useQuery<
+    ILoadTeamsResponse,
+    Error,
+    ITeam[]
+  >(["teams"], () => teamsAPI.loadAll(), {
+    enabled: !!isPremiumTier,
+    select: (data: ILoadTeamsResponse) =>
+      data.teams.sort((a, b) => sortUtils.caseInsensitiveAsc(a.name, b.name)),
+    onSuccess: (responseTeams) => {
+      if (!currentTeam && !isOnGlobalTeam && responseTeams.length) {
+        setCurrentTeam(responseTeams[0]);
+      }
+    },
+  });
 
   const {
     data: hostSummaryData,
@@ -89,7 +104,6 @@ const Homepage = (): JSX.Element => {
     {
       select: (data: IHostSummary) => data,
       onSuccess: (data: IHostSummary) => {
-        console.log("data", data);
         setLabels(data.builtin_labels);
         setOnlineCount(data.online_count);
         setOfflineCount(data.offline_count);
@@ -110,9 +124,26 @@ const Homepage = (): JSX.Element => {
     }
   );
 
+  const {
+    isLoading: isGlobalSecretsLoading,
+    data: globalSecrets,
+    refetch: refetchGlobalSecrets,
+  } = useQuery<IEnrollSecretsResponse, Error, IEnrollSecret[]>(
+    ["global secrets"],
+    () => enrollSecretsAPI.getGlobalEnrollSecrets(),
+    {
+      enabled: !!canEnrollGlobalHosts,
+      select: (data: IEnrollSecretsResponse) => data.secrets,
+    }
+  );
+
   const handleTeamSelect = (teamId: number) => {
     const selectedTeam = find(teams, ["id", teamId]);
     setCurrentTeam(selectedTeam);
+  };
+
+  const toggleAddHostModal = () => {
+    setShowAddHostModal(!showAddHostModal);
   };
 
   const HostsSummaryCard = useInfoCard({
@@ -164,6 +195,7 @@ const Homepage = (): JSX.Element => {
         totalsHostsCount={
           (hostSummaryData && hostSummaryData.totals_hosts_count) || 0
         }
+        toggleAddHostModal={toggleAddHostModal}
       />
     ),
   });
@@ -262,16 +294,14 @@ const Homepage = (): JSX.Element => {
 
   const allLayout = () => (
     <div className={`${baseClass}__section`}>
-      {hostSummaryData && hostSummaryData?.totals_hosts_count > 2 && (
+      {hostSummaryData && hostSummaryData?.totals_hosts_count < 2 && (
         <>
           {WelcomeHostCard}
           {LearnFleetCard}
         </>
       )}
       {SoftwareCard}
-      {!isPreviewMode && !currentTeam && isOnGlobalTeam && (
-        <>{ActivityFeedCard}</>
-      )}
+      {!currentTeam && isOnGlobalTeam && <>{ActivityFeedCard}</>}
     </div>
   );
 
@@ -297,6 +327,19 @@ const Homepage = (): JSX.Element => {
       default:
         return allLayout();
     }
+  };
+
+  const renderAddHostModal = () => {
+    const enrollSecret = globalSecrets?.[0].secret;
+    return (
+      <AddHostsModal
+        currentTeam={currentTeam}
+        enrollSecret={enrollSecret}
+        isLoading={isLoadingTeams || isGlobalSecretsLoading}
+        isSandboxMode={!!isSandboxMode}
+        onCancel={toggleAddHostModal}
+      />
+    );
   };
 
   return (
@@ -346,6 +389,7 @@ const Homepage = (): JSX.Element => {
           </>
         </div>
         {renderCards()}
+        {showAddHostModal && renderAddHostModal()}
       </div>
     </div>
   );

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -65,7 +65,7 @@ const Homepage = (): JSX.Element => {
   const [showSoftwareUI, setShowSoftwareUI] = useState<boolean>(false);
   const [showMunkiUI, setShowMunkiUI] = useState<boolean>(false);
   const [showMDMUI, setShowMDMUI] = useState<boolean>(false);
-  const [showAddHostModal, setShowAddHostModal] = useState<boolean>(false);
+  const [showAddHostsModal, setShowAddHostsModal] = useState<boolean>(false);
   const [showOperatingSystemsUI, setShowOperatingSystemsUI] = useState<boolean>(
     false
   );
@@ -142,8 +142,8 @@ const Homepage = (): JSX.Element => {
     setCurrentTeam(selectedTeam);
   };
 
-  const toggleAddHostModal = () => {
-    setShowAddHostModal(!showAddHostModal);
+  const toggleAddHostsModal = () => {
+    setShowAddHostsModal(!showAddHostsModal);
   };
 
   const HostsSummaryCard = useInfoCard({
@@ -195,7 +195,7 @@ const Homepage = (): JSX.Element => {
         totalsHostsCount={
           (hostSummaryData && hostSummaryData.totals_hosts_count) || 0
         }
-        toggleAddHostModal={toggleAddHostModal}
+        toggleAddHostsModal={toggleAddHostsModal}
       />
     ),
   });
@@ -329,7 +329,7 @@ const Homepage = (): JSX.Element => {
     }
   };
 
-  const renderAddHostModal = () => {
+  const renderAddHostsModal = () => {
     const enrollSecret = globalSecrets?.[0].secret;
     return (
       <AddHostsModal
@@ -337,7 +337,7 @@ const Homepage = (): JSX.Element => {
         enrollSecret={enrollSecret}
         isLoading={isLoadingTeams || isGlobalSecretsLoading}
         isSandboxMode={!!isSandboxMode}
-        onCancel={toggleAddHostModal}
+        onCancel={toggleAddHostsModal}
       />
     );
   };
@@ -389,7 +389,7 @@ const Homepage = (): JSX.Element => {
           </>
         </div>
         {renderCards()}
-        {showAddHostModal && renderAddHostModal()}
+        {showAddHostsModal && renderAddHostsModal()}
       </div>
     </div>
   );

--- a/frontend/pages/Homepage/cards/ActivityFeed/ActivityFeed.tsx
+++ b/frontend/pages/Homepage/cards/ActivityFeed/ActivityFeed.tsx
@@ -145,11 +145,10 @@ const ActivityFeed = ({
     return (
       <div className={`${baseClass}__no-activities`}>
         <p>
-          <b>This is the start of your Fleet activities.</b>
+          <b>Fleet has not recorded any activity.</b>
         </p>
         <p>
-          Did you recently edit your queries, update your packs, or run a live
-          query? Try again in a few seconds as the system catches up.
+          Try editing a query, updating your policies, or running a live query.
         </p>
       </div>
     );

--- a/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
@@ -244,21 +244,21 @@ const WelcomeHost = ({
           {host.policies?.slice(0, 3).map((p) => {
             if (p.response) {
               return (
-                <div className="policy-block">
-                  <div className="info">
-                    <img
-                      alt={p.response}
-                      src={p.response === policyPass ? IconPassed : IconError}
-                    />
-                    {p.name}
-                  </div>
-                  <Button
-                    variant="text-icon"
-                    onClick={() => handlePolicyModal(p.id)}
-                  >
+                <Button
+                  variant="text-icon"
+                  onClick={() => handlePolicyModal(p.id)}
+                >
+                  <div className="policy-block">
+                    <div className="info">
+                      <img
+                        alt={p.response}
+                        src={p.response === policyPass ? IconPassed : IconError}
+                      />
+                      {p.name}
+                    </div>
                     <img alt="" src={IconChevron} />
-                  </Button>
-                </div>
+                  </div>
+                </Button>
               );
             }
 

--- a/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
@@ -26,7 +26,7 @@ interface IHostResponse {
 
 interface IWelcomeHostCardProps {
   totalsHostsCount: number;
-  toggleAddHostModal: (showAddHostModal: boolean) => void;
+  toggleAddHostsModal: (showAddHostsModal: boolean) => void;
 }
 
 const baseClass = "welcome-host";
@@ -36,7 +36,7 @@ const policyFail = "fail";
 
 const WelcomeHost = ({
   totalsHostsCount,
-  toggleAddHostModal,
+  toggleAddHostsModal,
 }: IWelcomeHostCardProps): JSX.Element => {
   const { renderFlash } = useContext(NotificationContext);
   const [refetchStartTime, setRefetchStartTime] = useState<number | null>(null);
@@ -153,10 +153,10 @@ const WelcomeHost = ({
             "hosts."
           </p>
           <Button
-            onClick={toggleAddHostModal}
+            onClick={toggleAddHostsModal}
             className={`${baseClass}__add-host button button--brand`}
           >
-            <span>Add host</span>
+            <span>Add hosts</span>
           </Button>
         </div>
       </div>

--- a/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
@@ -150,7 +150,7 @@ const WelcomeHost = ({
           <p>Add your personal device to assess the security of your device.</p>
           <p>
             In Fleet, laptops, workstations, and servers are referred to as
-            "hosts."
+            &quot;hosts.&quot;
           </p>
           <Button
             onClick={toggleAddHostsModal}

--- a/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
@@ -143,7 +143,7 @@ const WelcomeHost = ({
     );
   }
 
-  if (loadingHostError || totalsHostsCount === 0) {
+  if (loadingHostError) {
     return (
       <div className={baseClass}>
         <div className={`${baseClass}__empty-hosts`}>

--- a/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
@@ -26,6 +26,7 @@ interface IHostResponse {
 
 interface IWelcomeHostCardProps {
   totalsHostsCount: number;
+  toggleAddHostModal: (showAddHostModal: boolean) => void;
 }
 
 const baseClass = "welcome-host";
@@ -35,6 +36,7 @@ const policyFail = "fail";
 
 const WelcomeHost = ({
   totalsHostsCount,
+  toggleAddHostModal,
 }: IWelcomeHostCardProps): JSX.Element => {
   const { renderFlash } = useContext(NotificationContext);
   const [refetchStartTime, setRefetchStartTime] = useState<number | null>(null);
@@ -136,17 +138,34 @@ const WelcomeHost = ({
     return (
       <div className={baseClass}>
         <div className={`${baseClass}__loading`}>
-          <p>Adding your device to Fleet</p>
           <Spinner />
         </div>
       </div>
     );
   }
 
-  if (
-    loadingHostError ||
-    (totalsHostsCount === 1 && host && host.status === "offline")
-  ) {
+  console.log("loadingHostError", loadingHostError);
+  if (loadingHostError || totalsHostsCount === 0) {
+    return (
+      <div className={baseClass}>
+        <div className={`${baseClass}__empty-hosts`}>
+          <p>Add your personal device to assess the security of your device.</p>
+          <p>
+            In Fleet, laptops, workstations, and servers are referred to as
+            "hosts."
+          </p>
+          <Button
+            onClick={toggleAddHostModal}
+            className={`${baseClass}__add-host button button--brand`}
+          >
+            <span>Add host</span>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (totalsHostsCount === 1 && host && host.status === "offline") {
     return (
       <div className={baseClass}>
         <div className={`${baseClass}__error`}>

--- a/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
@@ -24,12 +24,18 @@ interface IHostResponse {
   host: IHost;
 }
 
+interface IWelcomeHostCardProps {
+  totalsHostsCount: number;
+}
+
 const baseClass = "welcome-host";
 const HOST_ID = 1;
 const policyPass = "pass";
 const policyFail = "fail";
 
-const WelcomeHost = (): JSX.Element => {
+const WelcomeHost = ({
+  totalsHostsCount,
+}: IWelcomeHostCardProps): JSX.Element => {
   const { renderFlash } = useContext(NotificationContext);
   const [refetchStartTime, setRefetchStartTime] = useState<number | null>(null);
   const [currentPolicyShown, setCurrentPolicyShown] = useState<IHostPolicy>();
@@ -51,6 +57,7 @@ const WelcomeHost = (): JSX.Element => {
     {
       select: (data: IHostResponse) => data.host,
       onSuccess: (returnedHost) => {
+        console.log("returnedHost", returnedHost);
         setShowRefetchLoadingSpinner(returnedHost.refetch_requested);
 
         const anyPassingOrFailingPolicy = returnedHost?.policies?.find(
@@ -136,7 +143,10 @@ const WelcomeHost = (): JSX.Element => {
     );
   }
 
-  if (loadingHostError) {
+  if (
+    loadingHostError ||
+    (totalsHostsCount === 1 && host && host.status === "offline")
+  ) {
     return (
       <div className={baseClass}>
         <div className={`${baseClass}__error`}>
@@ -194,7 +204,7 @@ const WelcomeHost = (): JSX.Element => {
     );
   }
 
-  if (host) {
+  if (totalsHostsCount === 1 && host && host.status === "online") {
     return (
       <div className={baseClass}>
         <div className={`${baseClass}__intro`}>
@@ -204,20 +214,17 @@ const WelcomeHost = (): JSX.Element => {
               {host.hostname}
               <img alt="" src={LinkArrow} />
             </Link>
-            <p>
-              Your device is successully connected to this local preview of
-              Fleet.
-            </p>
+            <p>Your host is successully connected to Fleet.</p>
           </div>
         </div>
         <div className={`${baseClass}__blurb`}>
           <p>
-            Fleet already ran the following checks to assess the security of
+            Fleet already ran the following policies to assess the security of
             your device:{" "}
           </p>
         </div>
         <div className={`${baseClass}__policies`}>
-          {host.policies?.slice(0, 10).map((p) => {
+          {host.policies?.slice(0, 3).map((p) => {
             if (p.response) {
               return (
                 <div className="policy-block">
@@ -240,17 +247,15 @@ const WelcomeHost = (): JSX.Element => {
 
             return null;
           })}
-          {host.policies?.length > 10 && (
+          {host.policies?.length > 3 && (
             <Link to={PATHS.HOST_DETAILS(host)} className="external-link">
-              Go to Host details to see all checks
+              Go to Host details to see all policies
               <img alt="" src={LinkArrow} />
             </Link>
           )}
         </div>
         <div className={`${baseClass}__blurb`}>
-          <p>
-            Resolved a failing check? Refetch your device information to verify.
-          </p>
+          <p>Resolved a failing policy? Refetch your host vitals to verify.</p>
         </div>
         <div className={`${baseClass}__refetch`}>
           <Button

--- a/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
@@ -59,7 +59,6 @@ const WelcomeHost = ({
     {
       select: (data: IHostResponse) => data.host,
       onSuccess: (returnedHost) => {
-        console.log("returnedHost", returnedHost);
         setShowRefetchLoadingSpinner(returnedHost.refetch_requested);
 
         const anyPassingOrFailingPolicy = returnedHost?.policies?.find(
@@ -144,7 +143,6 @@ const WelcomeHost = ({
     );
   }
 
-  console.log("loadingHostError", loadingHostError);
   if (loadingHostError || totalsHostsCount === 0) {
     return (
       <div className={baseClass}>

--- a/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
@@ -231,7 +231,7 @@ const WelcomeHost = ({
               {host.hostname}
               <img alt="" src={LinkArrow} />
             </Link>
-            <p>Your host is successully connected to Fleet.</p>
+            <p>Your host is successfully connected to Fleet.</p>
           </div>
         </div>
         <div className={`${baseClass}__blurb`}>

--- a/frontend/pages/Homepage/cards/WelcomeHost/_styles.scss
+++ b/frontend/pages/Homepage/cards/WelcomeHost/_styles.scss
@@ -58,7 +58,7 @@
     margin-bottom: $pad-large;
 
     > * {
-      margin: 4px;
+      margin: 4px 0;
     }
 
     button {

--- a/frontend/pages/Homepage/cards/WelcomeHost/_styles.scss
+++ b/frontend/pages/Homepage/cards/WelcomeHost/_styles.scss
@@ -57,14 +57,28 @@
     margin-top: $pad-large;
     margin-bottom: $pad-large;
 
+    > * {
+      margin: 4px;
+    }
+
+    button {
+      height: auto;
+      width: 100%;
+      img {
+        transform: scale(0.58) rotate(-90deg);
+        position: relative;
+        top: 1px;
+      }
+    }
+
     .policy-block {
+      width: 100%;
       padding: $pad-small 12px;
       border: 1px solid $ui-fleet-black-25;
       border-radius: 6px;
       display: flex;
       justify-content: space-between;
       align-items: center;
-      margin: 10px 0;
 
       .info {
         font-size: $small;
@@ -77,15 +91,6 @@
           transform: scale(0.5);
           position: relative;
           top: -1px;
-        }
-      }
-      button {
-        height: auto;
-
-        img {
-          transform: scale(0.58) rotate(-90deg);
-          position: relative;
-          top: 1px;
         }
       }
     }

--- a/frontend/pages/Homepage/cards/WelcomeHost/_styles.scss
+++ b/frontend/pages/Homepage/cards/WelcomeHost/_styles.scss
@@ -90,6 +90,11 @@
       }
     }
   }
+  &__loading {
+    .loading-spinner {
+      margin: $pad-medium auto;
+    }
+  }
   &__refetch {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Cerra #5911 

**What's changed**
Welcome to Fleet card
- Conditionally renders for app, preview, and sandbox for host count of 0 or 1
- Conditional rendering based on totalsHostsCount being 0 or 1 online or 1 offline
- Add host button/modal also accessible on Homepage's Welcome to Fleet card (same functionality as Add hosts button/modal on Manage Host page)
- Update: Loading state includes spinner only, no "Adding your device to Fleet"
- Update: 1 online host state copy

Learn Fleet card
- Conditionally renders for app, preview, and sandbox for host count of 0 or 1
- Fix: Learn how to use Fleet title now shows up

Activity Feed card
- Renders up for app, preview, and sandbox 
- Update: Empty state copy

**QA Strategy**
Fleet App view
- [x] 0 hosts
- [x] 1 host
- [x] 2+ hosts

Fleet Preview view
- [x] 0 hosts
- [x] 1 host
- [x] 2+ hosts

Fleet Sandbox view
- [x] 0 hosts
- [x] 1 host
- [x] 2+ hosts


**Screenshot 1 host**
<img width="1210" alt="Screen Shot 2022-07-21 at 12 47 20 PM" src="https://user-images.githubusercontent.com/71795832/180270266-202c3613-8989-4b7f-a2fa-75276ca8716b.png">

**Screenshot 2+ hosts**
<img width="1215" alt="Screen Shot 2022-07-21 at 1 08 07 PM" src="https://user-images.githubusercontent.com/71795832/180272981-624f1f7a-6ed5-437f-9a5b-363993a8a51b.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
