### PR TITLE
Fix "What API endpoints should I expose to the public internet" in FAQ

### DIFF
--- a/docs/Deploying/FAQ.md
+++ b/docs/Deploying/FAQ.md
@@ -238,7 +238,7 @@ Check out the [documentation on running database migrations](./Upgrading-Fleet.m
 
 ## What API endpoints should I expose to the public internet?
 
-If you would like to manage hosts that can travel outside your VPN or intranet we recommend only exposing the "/api/osquery" endpoint to the public internet.
+If you would like to manage hosts that can travel outside your VPN or intranet we recommend only exposing the "/api/v1/osquery" endpoint to the public internet.
 
 ## What is the minimum version of MySQL required by Fleet?
 


### PR DESCRIPTION
- Add `v1` to the `/api/v1/osquery` URL path. Missing `v1` was discovered in conversation a Slack conversation here: https://fleetdm.slack.com/archives/C0389SEPLR3/p1658322593002269 (internal) 
