### PR TITLE
Handbook - removed <br> from Rituals table on Growth.md

### DIFF
--- a/handbook/growth.md
+++ b/handbook/growth.md
@@ -94,7 +94,7 @@ The following table lists the Growth group's rituals, frequency, and Directly Re
 |:-----------------------------|:-----------------------------|:----------------------------------------------------|-------------------|
 | Daily tweet         | Daily | Post Fleet content on Twitter.     | Drew Baker        |
 | Daily LinkedIn post        | Daily | Post Fleet content to LinkedIn.   | Drew Baker        |
-| Check Twitter messages | Daily | Check and reply to messages on the Fleet Twitter account.<br> Disregard requests unrelated to Fleet. | Drew Baker | 
+| Check Twitter messages | Daily | Check and reply to messages on the Fleet Twitter account. Disregard requests unrelated to Fleet. | Drew Baker | 
 | Social engagement     | Weekly | Participate in 50 social media engagements per week.| Drew Baker        |  
 | Osquery jobs          | Weekly | Post to @osqueryjobs twice a week.            | Drew Baker        |
 | Enrich Salesforce leads       | Weekly | Follow the Salesforce lead enrichment process every Friday.    | Drew Baker        |


### PR DESCRIPTION
I removed the `<br>` tag from the Rituals table.

FYI @Desmi-Dizney, nice idea to break up these sentences, but `<br>` tags should be avoided, partly because they often become unruly at different browser sizes and cause ugly gaps in paragraphs. In this case, it forced a [widow](https://www.fonts.com/content/learning/fontology/level-2/text-typography/rags-widows-orphans).
