### PR TITLE
Bug 6777: Make the regexp used for detecting the oval platform major, min versions more permissive

### DIFF
--- a/changes/bug-6777-update-version-regexp
+++ b/changes/bug-6777-update-version-regexp
@@ -1,0 +1,2 @@
+- Updated the regexp we use for detecting the major/minor version on OS platforms to account for any
+  string after the version part.

--- a/server/vulnerabilities/oval/oval_platform.go
+++ b/server/vulnerabilities/oval/oval_platform.go
@@ -19,7 +19,7 @@ var SupportedHostPlatforms = []string{"ubuntu", "rhel", "amzn"}
 // getMajorMinorVer returns the major and minor version of an 'os_version'.
 // ex: 'Ubuntu 20.4.0' => '(20, 04)'
 func getMajorMinorVer(osVersion string) (string, string) {
-	re := regexp.MustCompile(` (?P<major>\d+)\.?(?P<minor>\d+)?\.?(\*|\d+)?`)
+	re := regexp.MustCompile(` (?P<major>\d+)\.?(?P<minor>\d+)?`)
 	m := re.FindStringSubmatch(osVersion)
 
 	if len(m) < 2 {

--- a/server/vulnerabilities/oval/oval_platform.go
+++ b/server/vulnerabilities/oval/oval_platform.go
@@ -19,7 +19,7 @@ var SupportedHostPlatforms = []string{"ubuntu", "rhel", "amzn"}
 // getMajorMinorVer returns the major and minor version of an 'os_version'.
 // ex: 'Ubuntu 20.4.0' => '(20, 04)'
 func getMajorMinorVer(osVersion string) (string, string) {
-	re := regexp.MustCompile(` (?P<major>\d+)\.?(?P<minor>\d+)?\.?(\*|\d+)?$`)
+	re := regexp.MustCompile(` (?P<major>\d+)\.?(?P<minor>\d+)?\.?(\*|\d+)?`)
 	m := re.FindStringSubmatch(osVersion)
 
 	if len(m) < 2 {

--- a/server/vulnerabilities/oval/oval_platform_test.go
+++ b/server/vulnerabilities/oval/oval_platform_test.go
@@ -24,6 +24,7 @@ func TestOvalPlatform(t *testing.T) {
 			{"ubuntu", "Ubuntu 18.4.0", "ubuntu_1804"},
 			{"ubuntu", "Ubuntu 18.4", "ubuntu_1804"},
 			{"ubuntu", "Ubuntu 18.4.0 ", "ubuntu_1804"},
+			{"ubuntu", "Ubuntu 18.4.0 LTS asdfasd", "ubuntu_1804"},
 			{"rhel", "CentOS Linux 7.9.2009", "rhel_07"},
 			{"amzn", "Amazon Linux 2.0.0", "amzn_02"},
 			{"rhel", "Fedora Linux 12.0.0", "rhel_06"},
@@ -51,6 +52,7 @@ func TestOvalPlatform(t *testing.T) {
 			{"rhel", "Fedora Linux 34.0.0", "rhel_09"},
 			{"rhel", "Fedora Linux 35.0.0", "rhel_09"},
 			{"rhel", "Fedora Linux 36.0.0", "rhel_09"},
+			{"ubuntu", "Ubuntu 20.04.2 LTS", "ubuntu_2004"},
 		}
 
 		for _, c := range cases {


### PR DESCRIPTION
#6777

See related issue for more info - basically the problem here was that on the `os_versions` aggregated stats `ubuntu` platforms now include the LTS post-fix on their names.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
