### PR TITLE
include subfolders for markdown docs codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,7 +17,7 @@ go.mod @fleetdm/go
 CHANGELOG.md @noahtalerman
 
 # Markdown docs
-/docs/*.md @Desmi-Dizney
+/docs/**/*.md @Desmi-Dizney
 
 # API documentation
 /docs/Using-Fleet/REST-API.md @ksatter


### PR DESCRIPTION
As the title suggests, alternatively we could just do `/docs/` with everything inside.

