### PR TITLE
Software details UI: Fix horizontal scroll off viewport

### DIFF
--- a/changes/issue-6776-prevent-horizontal-scrolling
+++ b/changes/issue-6776-prevent-horizontal-scrolling
@@ -1,0 +1,1 @@
+* Use responsive design to prevent tooltip from horizontally overflowing off viewport

--- a/frontend/pages/software/SoftwareDetailsPage/components/Vulnerabilities/VulnTableConfig.tsx
+++ b/frontend/pages/software/SoftwareDetailsPage/components/Vulnerabilities/VulnTableConfig.tsx
@@ -146,7 +146,7 @@ const generateVulnTableHeaders = (isPremiumTier: boolean): IDataColumn[] => {
         const titleWithToolTip = (
           <TooltipWrapper
             tipContent={`
-            The vulnerability has been actively exploited in the wild. This data is reported by<br />
+            The vulnerability has been actively exploited in the wild. This data is reported by 
             the Cybersecurity and Infrustructure Security Agency (CISA).
           `}
           >

--- a/frontend/pages/software/SoftwareDetailsPage/components/Vulnerabilities/_styles.scss
+++ b/frontend/pages/software/SoftwareDetailsPage/components/Vulnerabilities/_styles.scss
@@ -40,10 +40,10 @@
             width: $col-sm;
           }
 
-          @media (max-width: $tooltip-sm-break-1000) {
+          @media (max-width: $tooltip-break-1000) {
             .cisa_known_exploit__header {
               .component__tooltip-wrapper__tip-text {
-                max-width: $col-sm;
+                max-width: 100px; // Prevents horizontal scrolling off viewport
                 white-space: normal;
               }
             }

--- a/frontend/pages/software/SoftwareDetailsPage/components/Vulnerabilities/_styles.scss
+++ b/frontend/pages/software/SoftwareDetailsPage/components/Vulnerabilities/_styles.scss
@@ -23,7 +23,8 @@
 
   .section--vulnerabilities {
     .component__tooltip-wrapper__tip-text {
-      max-width: none;
+      max-width: $col-md;
+      white-space: normal;
     }
 
     .data-table-block {
@@ -37,6 +38,15 @@
           }
           .cvss_score__header {
             width: $col-sm;
+          }
+
+          @media (max-width: $tooltip-sm-break-1000) {
+            .cisa_known_exploit__header {
+              .component__tooltip-wrapper__tip-text {
+                max-width: $col-sm;
+                white-space: normal;
+              }
+            }
           }
         }
 

--- a/frontend/pages/software/SoftwareDetailsPage/components/Vulnerabilities/_styles.scss
+++ b/frontend/pages/software/SoftwareDetailsPage/components/Vulnerabilities/_styles.scss
@@ -43,7 +43,7 @@
           @media (max-width: $tooltip-break-1000) {
             .cisa_known_exploit__header {
               .component__tooltip-wrapper__tip-text {
-                max-width: 100px; // Prevents horizontal scrolling off viewport
+                max-width: 200px; // Prevents horizontal scrolling off viewport
                 white-space: normal;
               }
             }

--- a/frontend/styles/var/breakpoints.scss
+++ b/frontend/styles/var/breakpoints.scss
@@ -2,4 +2,4 @@ $break-1600: 1600px;
 $break-1400: 1400px;
 $break-990: 990px;
 $break-768: 768px;
-$tooltip-sm-break-1000: 1000px; // Prevents horizontal scrolling off viewport
+$tooltip-break-1000: 1000px; // Prevents horizontal scrolling off viewport

--- a/frontend/styles/var/breakpoints.scss
+++ b/frontend/styles/var/breakpoints.scss
@@ -2,3 +2,4 @@ $break-1600: 1600px;
 $break-1400: 1400px;
 $break-990: 990px;
 $break-768: 768px;
+$tooltip-sm-break-1000: 1000px; // Prevents horizontal scrolling off viewport


### PR DESCRIPTION
Cerra #6776 

**Fix Responsive tooltip width fixes overflow off viewport**
- Tooltip max-width is consistently $col-md for entire page
- Between 768px-1000px screenwidth: Tooltip width is 200px to ensure it does not horizontally overflow


Note: No CSS property to ensure an element doesn't overflow viewport
https://stackoverflow.com/questions/50970336/prevent-css-tooltip-from-going-out-of-page-window

**Screenshots at various widths**
768px min:
<img width="614" alt="Screen Shot 2022-07-21 at 3 52 38 PM" src="https://user-images.githubusercontent.com/71795832/180303524-ff015fed-8102-46a1-83c6-86c5ff6f5e9f.png">
< 1000px:
<img width="816" alt="Screen Shot 2022-07-21 at 3 52 23 PM" src="https://user-images.githubusercontent.com/71795832/180303603-eb948ee9-7187-4992-bb44-3e0b1766594b.png">
> 1000px:
<img width="940" alt="Screen Shot 2022-07-21 at 3 52 44 PM" src="https://user-images.githubusercontent.com/71795832/180303628-8c3509c4-643d-4316-aa03-9033fcc438a0.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
