### PR TITLE
Manage Host UI: Convert uptime column to last restarted

### DIFF
--- a/changes/issue-6521-convert-uptime-to-last-restarted
+++ b/changes/issue-6521-convert-uptime-to-last-restarted
@@ -1,0 +1,1 @@
+* Convert uptime column to last restarted on the Manage hosts page

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -15,7 +15,7 @@ import StatusCell from "components/TableContainer/DataTable/StatusCell/StatusCel
 import TextCell from "components/TableContainer/DataTable/TextCell/TextCell";
 import {
   humanHostMemory,
-  humanHostUptime,
+  humanHostLastRestart,
   humanHostLastSeen,
   humanHostDetailUpdated,
   hostTeamName,
@@ -324,7 +324,7 @@ const allHostTableHeaders: IDataColumn[] = [
     Cell: (cellProps: ICellProps) => <TextCell value={cellProps.cell.value} />,
   },
   {
-    title: "Uptime",
+    title: "Last restarted",
     Header: (cellProps: IHeaderProps) => (
       <HeaderCell
         value={cellProps.column.title}
@@ -332,9 +332,13 @@ const allHostTableHeaders: IDataColumn[] = [
       />
     ),
     accessor: "uptime",
-    Cell: (cellProps: ICellProps) => (
-      <TextCell value={cellProps.cell.value} formatter={humanHostUptime} />
-    ),
+    Cell: (cellProps: ICellProps) => {
+      const { uptime, detail_updated_at } = cellProps.row.original;
+
+      return (
+        <TextCell value={humanHostLastRestart(detail_updated_at, uptime)} />
+      );
+    },
   },
   {
     title: "CPU",

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -580,16 +580,6 @@ export const inMilliseconds = (nanoseconds: number): number => {
   return nanoseconds / NANOSECONDS_PER_MILLISECOND;
 };
 
-export const humanHostUptime = (uptimeInNanoseconds: number): string => {
-  const uptimeMilliseconds = inMilliseconds(uptimeInNanoseconds);
-  const restartDate = new Date();
-  restartDate.setMilliseconds(
-    restartDate.getMilliseconds() - uptimeMilliseconds
-  );
-
-  return formatDistanceToNow(new Date(restartDate), { addSuffix: true });
-};
-
 export const humanHostLastRestart = (
   detailUpdatedAt: string,
   uptime: number

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -807,7 +807,6 @@ export default {
   generateRole,
   generateTeam,
   greyCell,
-  humanHostUptime,
   humanHostLastSeen,
   humanHostEnrolled,
   humanHostMemory,


### PR DESCRIPTION
Cerra #6521 

**Fix**
- Convert uptime column to last restarted column in the UI
- Use humanHostLastRestart to calculate sum of milliseconds since last updated + uptime

**Screenshot**
<img width="1177" alt="Screen Shot 2022-07-21 at 4 27 48 PM" src="https://user-images.githubusercontent.com/71795832/180309201-4dfebb93-1cd3-44ca-9312-03d3a72218c9.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
