### PR TITLE
update documentation of orbit/pkg/packaging

### DIFF
--- a/orbit/pkg/packaging/deb.go
+++ b/orbit/pkg/packaging/deb.go
@@ -2,6 +2,8 @@ package packaging
 
 import "github.com/goreleaser/nfpm/v2/deb"
 
+// BuildDeb builds a .deb package
+// Note: this function is not safe for concurrent use
 func BuildDeb(opt Options) (string, error) {
 	return buildNFPM(opt, deb.Default)
 }

--- a/orbit/pkg/packaging/macos.go
+++ b/orbit/pkg/packaging/macos.go
@@ -19,8 +19,13 @@ import (
 
 // See helful docs in http://bomutils.dyndns.org/tutorial.html
 
-// BuildPkg builds a macOS .pkg. So far this is tested only on macOS but in theory it works with bomutils on
-// Linux.
+// BuildPkg builds a macOS .pkg.
+//
+// Building packages works out of the box in macOS, but it's also supported on
+// Linux given that the necessary dependencies are installed and
+// Options.NativeTooling is `true`
+//
+// Note: this function is not safe for concurrent use
 func BuildPkg(opt Options) (string, error) {
 	// Initialize directories
 	tmpDir, err := initializeTempDir()

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -1,4 +1,7 @@
 // Package packaging provides tools for building Orbit installation packages.
+//
+// The functions exported by this package are not safe for concurrent use at
+// the moment.
 package packaging
 
 import (

--- a/orbit/pkg/packaging/rpm.go
+++ b/orbit/pkg/packaging/rpm.go
@@ -2,6 +2,8 @@ package packaging
 
 import "github.com/goreleaser/nfpm/v2/rpm"
 
+// BuildRPM builds a .rpm package
+// Note: this function is not safe for concurrent use
 func BuildRPM(opt Options) (string, error) {
 	return buildNFPM(opt, rpm.Default)
 }

--- a/orbit/pkg/packaging/windows.go
+++ b/orbit/pkg/packaging/windows.go
@@ -18,6 +18,7 @@ import (
 )
 
 // BuildMSI builds a Windows .msi.
+// Note: this function is not safe for concurrent use
 func BuildMSI(opt Options) (string, error) {
 	tmpDir, err := initializeTempDir()
 	if err != nil {


### PR DESCRIPTION
This updates the documentation of `orbit/pkg/packaging` mainly to note that the exported functions are not safe for concurrent usage (subject to change.)

I'm not sure if `orbit/README.md` should be updated too as it seems to be more user-facing, but `fleetctl package` is not safe for concurrent use either as it uses this package internally.