### PR TITLE
update documentation for viewing code coverage locally

### DIFF
--- a/docs/Contributing/Testing.md
+++ b/docs/Contributing/Testing.md
@@ -116,20 +116,18 @@ NETWORK_TEST=1 make test-go
 
 ### Viewing test coverage
 
-When you run `make test` or `make test-go` from the root of the repository, test coverage reports are generated in every subpackage. For example, the `server` subpackage will have a coverage report generated in `./server/server.cover`
+When you run `make test` or `make test-go` from the root of the repository, a test coverage report is generated at the root of the repo in a filed named `coverage.txt`
 
 To explore a test coverage report on a line-by-line basis in the browser, run the following:
 
 ```bash
-# substitute ./datastore/datastore.cover, etc
-go tool cover -html=./server/server.cover
+go tool cover -html=coverage.txt
 ```
 
 To view test a test coverage report in a terminal, run the following:
 
 ```bash
-# substitute ./datastore/datastore.cover, etc
-go tool cover -func=./server/server.cover
+go tool cover -func=coverage.txt
 ```
 
 ## End-to-end tests


### PR DESCRIPTION
This updates the contributor documentation with the right instructions to view code coverage in a local env.