### PR TITLE
Update placeholder text for select targets search box

### DIFF
--- a/changes/issue-6711-hosts-search-hint
+++ b/changes/issue-6711-hosts-search-hint
@@ -1,0 +1,2 @@
+- Removed MAC address from placeholder text for the select targets search box and updated text to
+reflect currently supported search values: hostname, UUID, serial number, or IPv4.

--- a/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
+++ b/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { Row } from "react-table";
+import { isEmpty, pullAllBy } from "lodash";
 
 import { IHost } from "interfaces/host";
-import { isEmpty, pullAllBy } from "lodash";
+import { HOSTS_SEARCH_BOX_PLACEHOLDER } from "utilities/constants";
 
 import DataError from "components/DataError";
 // @ts-ignore
@@ -56,7 +57,7 @@ const TargetsInput = ({
           tabIndex={tabIndex}
           iconPosition="start"
           label="Target specific hosts"
-          placeholder="Search hosts by hostname, UUID, MAC address"
+          placeholder={HOSTS_SEARCH_BOX_PLACEHOLDER}
           onChange={setSearchText}
         />
         {isActiveSearch && (

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -40,6 +40,7 @@ import sortUtils from "utilities/sort";
 import {
   DEFAULT_CREATE_LABEL_ERRORS,
   HOSTS_SEARCH_BOX_PLACEHOLDER,
+  HOSTS_SEARCH_BOX_TOOLTIP,
   PLATFORM_LABEL_DISPLAY_NAMES,
   PolicyResponse,
 } from "utilities/constants";
@@ -1548,9 +1549,7 @@ const ManageHostsPage = ({
         isAllPagesSelected={isAllMatchingHostsSelected}
         searchable
         renderCount={renderHostCount}
-        searchToolTipText={
-          "Search hosts by hostname, UUID, machine serial or private IP address"
-        }
+        searchToolTipText={HOSTS_SEARCH_BOX_TOOLTIP}
         emptyComponent={EmptyHosts}
         customControl={renderStatusDropdown}
         onActionButtonClick={toggleEditColumnsModal}

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -39,6 +39,7 @@ import deepDifference from "utilities/deep_difference";
 import sortUtils from "utilities/sort";
 import {
   DEFAULT_CREATE_LABEL_ERRORS,
+  HOSTS_SEARCH_BOX_PLACEHOLDER,
   PLATFORM_LABEL_DISPLAY_NAMES,
   PolicyResponse,
 } from "utilities/constants";
@@ -1537,7 +1538,7 @@ const ManageHostsPage = ({
         actionButtonIcon={EditColumnsIcon}
         actionButtonVariant={"text-icon"}
         additionalQueries={JSON.stringify(selectedFilters)}
-        inputPlaceHolder={"Search hostname, UUID, serial number, or IPv4"}
+        inputPlaceHolder={HOSTS_SEARCH_BOX_PLACEHOLDER}
         primarySelectActionButtonText={"Delete"}
         primarySelectActionButtonIcon={"delete"}
         primarySelectActionButtonVariant={"text-icon"}

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -360,6 +360,9 @@ export const PLATFORM_NAME_TO_LABEL_NAME = {
   linux: "All Linux",
 };
 
+export const HOSTS_SEARCH_BOX_PLACEHOLDER =
+  "Search hostname, UUID, serial number, or IPv4";
+
 export const VULNERABLE_DROPDOWN_OPTIONS = [
   {
     disabled: false,

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -363,6 +363,9 @@ export const PLATFORM_NAME_TO_LABEL_NAME = {
 export const HOSTS_SEARCH_BOX_PLACEHOLDER =
   "Search hostname, UUID, serial number, or IPv4";
 
+export const HOSTS_SEARCH_BOX_TOOLTIP =
+  "Search hosts by hostname, UUID, machine serial or private IP address";
+
 export const VULNERABLE_DROPDOWN_OPTIONS = [
   {
     disabled: false,


### PR DESCRIPTION
Issue #6711 

Removed MAC address from placeholder text for the select targets search box and updated text to reflect currently supported search values: hostname, UUID, serial number, or IPv4.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
