### PR TITLE
Article: Update casing

### DIFF
--- a/articles/ebpf-the-future-of-osquery-on-linux.md
+++ b/articles/ebpf-the-future-of-osquery-on-linux.md
@@ -10,7 +10,7 @@ This talk discusses the Audit approach to Linux events with osquery, including c
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/p3rIRJM2vwo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-### Slide Deck
+### Slide deck
 
 <iframe class="speakerdeck-iframe" frameborder="0" src="https://speakerdeck.com/player/a0444dd4b2b24bad8db7908590506699" title="eBPF &amp; the future of osquery on Linux" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true" style="border: 0px; background: padding-box padding-box rgba(0, 0, 0, 0.1); padding: 0px; border-radius: 6px; box-shadow: rgba(0, 0, 0, 0.2) 0px 5px 40px; width: 560px; height: 314px;" data-ratio="1.78343949044586"></iframe>
 


### PR DESCRIPTION
Looks like on https://fleetdm.com/securing/ebpf-the-future-of-osquery-on-linux, the  "D" in "Slide Deck" could use a lowercase "D" to match Fleet's brand standards of [using sentence case in headings](https://fleetdm.com/handbook/digital-experience#how-to-write-headings-subheadings).