### PR TITLE
Website: Remove "as seen on techcrunch" from homepage

### DIFF
--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -17,11 +17,6 @@
               <a style="max-width: 220px;" class="btn btn-lg btn-white pl-4 mx-auto mx-sm-0" purpose="animated-arrow-button-white" target="_blank" href="https://calendly.com/fleetdm/demo?utm_source=homepage+demo+top">Schedule a demo
               </a>
             </div>
-            <div class="d-flex flex-row">
-              <a style="box-sizing: content-box;" class="mx-auto mb-3 mb-sm-0"  href="https://techcrunch.com/2022/04/28/fleet-nabs-20m-to-enable-enterprises-to-manage-their-devices/" target="_blank">
-                <img style="margin-top: 32px; height: 32px;" alt="As seen on Techcrunch" src="/images/logo-techcrunch-255x32@2x.png">
-              </a>
-            </div>
             <img alt="Fleet ctl terminal and Fleet UI" src="/images/fleetctl-687x506@2x.png" style="max-width: 810px; height: auto;" class="w-100 py-3 py-sm-5 mx-auto"/>
           </div>
         </div>


### PR DESCRIPTION
It's been a few months now and, while neat to share the story, some visitors report experiencing it as an indicator that Fleet is an earlier stage company than it actually is, which is misleading.

We're not THAT hip.

fyi @mike-j-thomas I haven't tested this PR.  I know it's not the right process, but I thought this would be more useful to lay  up for you rather than creating an issue.  Could you please test this at all window widths before merging?  (I also realize I'm the one who asked for this to be added in the first place, so apologies for the wishy-washiness.)