### PR TITLE
Spiffer Fleet UI: Readable copy message, fix modal cta button alignment

### DIFF
--- a/changes/issue-6876-copy-button-alignment
+++ b/changes/issue-6876-copy-button-alignment
@@ -1,0 +1,1 @@
+* Readable copy message, fix modal CTA button alignment

--- a/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
+++ b/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
@@ -164,4 +164,11 @@
       display: inline;
     }
   }
+
+  &__copy-message {
+    background-color: $ui-light-grey;
+    border: solid 1px #e2e4ea;
+    border-radius: 10px;
+    padding: 2px 6px;
+  }
 }

--- a/frontend/components/EnrollSecretTable/EnrollSecretRow/EnrollSecretRow.tsx
+++ b/frontend/components/EnrollSecretTable/EnrollSecretRow/EnrollSecretRow.tsx
@@ -71,7 +71,11 @@ const EnrollSecretRow = ({
     return (
       <span className={`${baseClass}__name`}>
         <span className="buttons">
-          {copyMessage && <span>{`${copyMessage} `}</span>}
+          {copyMessage && (
+            <span
+              className={`${baseClass}__copy-message`}
+            >{`${copyMessage} `}</span>
+          )}
           <Button
             variant="unstyled"
             className={`${baseClass}__secret-copy-icon`}

--- a/frontend/components/SecretField/_styles.scss
+++ b/frontend/components/SecretField/_styles.scss
@@ -30,8 +30,11 @@
 
   .copy-message {
     position: absolute;
-    top: -32px;
-    right: 10px;
+    right: 44px;
+    background-color: $ui-light-grey;
+    border: solid 1px #e2e4ea;
+    border-radius: 10px;
+    padding: 2px 6px;
   }
 
   .buttons {

--- a/frontend/pages/UserSettingsPage/_styles.scss
+++ b/frontend/pages/UserSettingsPage/_styles.scss
@@ -1,5 +1,4 @@
 .user-settings {
-
   &__sandboxMode {
     margin-top: 70px;
   }
@@ -51,7 +50,11 @@
   }
 
   .token-message {
-    font-size: $xx-small;
     margin-bottom: 2rem;
+  }
+
+  &__button-wrap {
+    display: flex;
+    justify-content: flex-end;
   }
 }

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/OSPolicyModal/OSPolicyModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/OSPolicyModal/OSPolicyModal.tsx
@@ -51,7 +51,11 @@ const RenderOSPolicyModal = ({
         <span className={`${baseClass}__cta`}>{osPolicyLabel}</span>{" "}
         <span className={`${baseClass}__name`}>
           <span className="buttons">
-            {copyMessage && <span>{`${copyMessage} `}</span>}
+            {copyMessage && (
+              <span
+                className={`${baseClass}__copy-message`}
+              >{`${copyMessage} `}</span>
+            )}
             <Button
               variant="unstyled"
               className={`${baseClass}__os-policy-copy-icon`}

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/OSPolicyModal/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/OSPolicyModal/_styles.scss
@@ -40,4 +40,11 @@
     margin-left: $pad-small;
     margin-right: $pad-medium;
   }
+
+  &__copy-message {
+    background-color: $ui-light-grey;
+    border: solid 1px #e2e4ea;
+    border-radius: 10px;
+    padding: 2px 6px;
+  }
 }


### PR DESCRIPTION
Cerra #6876 

**Fixes**
- API User modal, OS Policy modal: Some copy message overlap the SQL/secret/etc text it's copying, make it easier to read with a consistent background color and outline
- API User modal: Fix Done button to be aligned right (per figma)
- API User modal: Fix 12px font to correct 14px (per figma)

**Screenshots of fixes**
<img width="1203" alt="Screen Shot 2022-07-26 at 10 12 34 AM" src="https://user-images.githubusercontent.com/71795832/181028315-29623bd2-6aa2-4d4a-a915-69ace1520ce0.png">
<img width="1233" alt="Screen Shot 2022-07-26 at 10 17 36 AM" src="https://user-images.githubusercontent.com/71795832/181028655-dbd67e10-32ce-401c-97e9-c8ee4efb7371.png">
<img width="682" alt="Screen Shot 2022-07-26 at 10 20 58 AM" src="https://user-images.githubusercontent.com/71795832/181029390-5c67da0d-437c-46dd-84c2-159b9717dabb.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
