### PR TITLE
Change terraform sandbox deploy tag to main

### DIFF
--- a/infrastructure/sandbox/PreProvisioner/lambda/deploy_terraform/fleet/templates/deployment.yaml
+++ b/infrastructure/sandbox/PreProvisioner/lambda/deploy_terraform/fleet/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
     spec:
       containers:
       - name: {{ .Values.fleetName }}
+        imagePullPolicy: always
         command: [/usr/bin/fleet]
         args: ["serve"]
         image: fleetdm/fleet:{{ .Values.imageTag }}

--- a/infrastructure/sandbox/PreProvisioner/lambda/deploy_terraform/fleet/templates/job-migration.yaml
+++ b/infrastructure/sandbox/PreProvisioner/lambda/deploy_terraform/fleet/templates/job-migration.yaml
@@ -28,6 +28,7 @@ spec:
         command: [/usr/bin/fleet]
         args: ["prepare","db","--no-prompt"]
         image: fleetdm/fleet:{{ .Values.imageTag }}
+        imagePullPolicy: always
         resources:
           limits:
             cpu: {{ .Values.resources.limits.cpu }}

--- a/infrastructure/sandbox/PreProvisioner/lambda/deploy_terraform/main.tf
+++ b/infrastructure/sandbox/PreProvisioner/lambda/deploy_terraform/main.tf
@@ -150,7 +150,7 @@ resource "helm_release" "main" {
 
   set {
     name  = "imageTag"
-    value = "v4.17.0"
+    value = "main"
   }
 }
 


### PR DESCRIPTION
Deploy `main` as sandbox tag for QA purposes during freeze week. Will change to `4.18.0` when it is published.