### PR TITLE
Packs UI: Update osquery releases on add/edit query pack dropdown

### DIFF
--- a/changes/issue-6371-osquery-releases-updated
+++ b/changes/issue-6371-osquery-releases-updated
@@ -1,0 +1,1 @@
+* Convert uptime column to last restarted on the Manage hosts page

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -208,6 +208,17 @@ export const MAX_OSQUERY_SCHEDULED_QUERY_INTERVAL = 604800;
 
 export const MIN_OSQUERY_VERSION_OPTIONS = [
   { label: "All", value: "" },
+  { label: "5.4.0 +", value: "5.4.0" },
+  { label: "5.3.0 +", value: "5.3.0" },
+  { label: "5.2.3 +", value: "5.2.4" },
+  { label: "5.2.2 +", value: "5.2.2" },
+  { label: "5.2.1 +", value: "5.2.1" },
+  { label: "5.2.0 +", value: "5.2.0" },
+  { label: "5.1.0 +", value: "5.1.0" },
+  { label: "5.0.1 +", value: "5.0.1" },
+  { label: "5.0.0 +", value: "5.0.0" },
+  { label: "4.9.0 +", value: "4.9.0" },
+  { label: "4.8.0 +", value: "4.8.0" },
   { label: "4.7.0 +", value: "4.7.0" },
   { label: "4.6.0 +", value: "4.6.0" },
   { label: "4.5.1 +", value: "4.5.1" },


### PR DESCRIPTION
Cerra #6371 

# Checklist for submitter

**Fix**
- Update osquery releases in dropdown

**Screenshot**
<img width="759" alt="Screen Shot 2022-07-26 at 2 44 00 PM" src="https://user-images.githubusercontent.com/71795832/181086874-691aff22-524a-4923-badc-2defadd924ed.png">

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
