### PR TITLE
Prevent removing team enroll secrets when applying team specs without new secrets

### DIFF
--- a/changes/issue-6774-keep-existing-secrets-if-none-provided
+++ b/changes/issue-6774-keep-existing-secrets-if-none-provided
@@ -1,0 +1,1 @@
+* Updated the "apply team specs" endpoint to keep the existing enroll secrets unchanged if none are provided in the spec.

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -465,8 +465,8 @@ If the `name` is not already associated with an existing team, this API route cr
 | Name          | Type   | In   | Description                                                                                                                                                                                                                                             |
 | ------------- | ------ | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | name          | string | body | **Required.** The team's name.                                                                                                                                                                                                                          |
-| agent_options | string | body | **Required.** The agent options spec that is applied to the hosts assigned to the specified to team. These agent options completely override the global agent options specified in the [`GET /api/v1/fleet/config API route`](#get-configuration)  |
-| secrets       | list   | body | **Required.** A list of plain text strings is used as the enroll secrets.                                                                                                                                                                                  |
+| agent_options | string | body | The agent options spec that is applied to the hosts assigned to the specified to team. These agent options completely override the global agent options specified in the [`GET /api/v1/fleet/config API route`](#get-configuration)                     |
+| secrets       | list   | body | A list of plain text strings is used as the enroll secrets. Existing secrets are replaced with this list, or left unmodified if this list is empty.                                                                                                     |
 
 #### Example
 
@@ -1713,7 +1713,7 @@ Returns the URL to open when clicking the "Transparency" menu item in Fleet Desk
 
 Redirects to the transparency URL.
 
-### Download an installer 
+### Download an installer
 
 Downloads a pre-built fleet-osquery installer with the given parameters.
 

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -402,7 +402,9 @@ func (svc Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec) 
 
 		team.Name = spec.Name
 		team.Config.AgentOptions = spec.AgentOptions
-		team.Secrets = secrets
+		if len(secrets) > 0 {
+			team.Secrets = secrets
+		}
 
 		_, err = svc.ds.SaveTeam(ctx, team)
 		if err != nil {

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -409,9 +409,12 @@ func (svc Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec) 
 			return err
 		}
 
-		err = svc.ds.ApplyEnrollSecrets(ctx, ptr.Uint(team.ID), secrets)
-		if err != nil {
-			return err
+		// only replace enroll secrets if at least one is provided (#6774)
+		if len(secrets) > 0 {
+			err = svc.ds.ApplyEnrollSecrets(ctx, ptr.Uint(team.ID), secrets)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
#6774 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Added/updated tests
