### PR TITLE
Fleet UI: Fix jumpy action dropdown

### DIFF
--- a/changes/issue-6874-jumpy-action-button
+++ b/changes/issue-6874-jumpy-action-button
@@ -1,0 +1,1 @@
+* Fix "jumpy" action dropdown

--- a/frontend/components/TableContainer/DataTable/DropdownCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/DropdownCell/_styles.scss
@@ -66,13 +66,13 @@
     &.is-open {
       .Select-control .Select-placeholder {
         color: $core-vibrant-blue;
+        top: 0;
       }
-      .Select-arrow {
-        margin-top: 4px;
-        margin-bottom: -2px;
-      }
-      .Select-placeholder {
-        margin-top: 1px;
+
+      .Select-control {
+        .Select-arrow {
+          top: 0;
+        }
       }
     }
   }


### PR DESCRIPTION
Cerra #6874 

**Fix**
- Action dropdown and arrow no longer jumps when selected/deselected

**Screenshot**
<img width="384" alt="Screen Shot 2022-07-26 at 3 26 00 PM" src="https://user-images.githubusercontent.com/71795832/181094996-de0d824e-76e6-4afe-820c-75973b45d186.png">

Manually QAd various dropdowns before/after fix

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
