### PR TITLE
Updated Slack channel for Operations

### DIFF
--- a/handbook/digital-experience/README.md
+++ b/handbook/digital-experience/README.md
@@ -611,7 +611,7 @@ These groups maintain the following [Slack channels](https://fleetdm.com/handboo
 | `#help-finance`             | Nathan Holliday
 | `#help-brex-memos`          | Nathan Holliday
 | `#help-p1`		      | Mike McNeil
-| `#help-operations`          | Nathan Holliday
+| `#help-operations-and-contract-reviews`          | Nathan Holliday
 
 
 <meta name="maintainedBy" value="mike-j-thomas">


### PR DESCRIPTION
Done as per @mikermcneil's request in Slack 

-------------

mikermcneil
@Desmi Dizney
  can you update this slack channel in the relevant handbook to reflect this? https://fleetdm.slack.com/archives/C03MMC90MNU/p1658798689913439
mikermcneil
has renamed the channel from "help-operations" to "help-operations-and-contract-reviews"