### PR TITLE
Tool: Workaround for mergefreeze API

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -242,7 +242,12 @@ module.exports = {
         // [?] https://docs.mergefreeze.com/web-api#get-freeze-status
         let isMainBranchFrozen = (
           await sails.helpers.http.get('https://www.mergefreeze.com/api/branches/fleetdm/fleet/main', { access_token: sails.config.custom.mergeFreezeAccessToken }) //eslint-disable-line camelcase
-        ).frozen;
+        ).frozen || (
+          // TODO: Remove this timeboxed hack to consider the repo frozen
+          // for a while as a workaround for an issue where the MergeFreeze API
+          // reports that the repo is not frozen, when it actually is frozen.
+          Date.now() < (new Date('Jul 28, 2022 14:00 UTC')).getTime()
+        );
 
         // Now, if appropriate, auto-approve the change.
         if (isAutoApproved) {


### PR DESCRIPTION
A timeboxed workaround for an intermittent issue where the mergefreeze API reports that a repo is frozen: false, when the mergefreeze UI says that it is actually truly frozen.

<img width="743" alt="image" src="https://user-images.githubusercontent.com/618009/181179027-5bee8d94-cc26-42a0-9bcf-aa04398a5904.png">
