### PR TITLE
Fleet UI: Gravatar external link opens in new tab

### DIFF
--- a/changes/issue-6893-gravatar-opens-new-tab
+++ b/changes/issue-6893-gravatar-opens-new-tab
@@ -1,0 +1,1 @@
+* Gravatar link opens in new tab

--- a/frontend/pages/UserSettingsPage/UserSidePanel/UserSidePanel.tsx
+++ b/frontend/pages/UserSettingsPage/UserSidePanel/UserSidePanel.tsx
@@ -63,7 +63,13 @@ const UserSidePanel = ({
     <div className={baseClass}>
       <div className={`${baseClass}__change-avatar`}>
         <Avatar user={currentUser} className={`${baseClass}__avatar`} />
-        <a href="http://en.gravatar.com/emails/">Change photo at Gravatar</a>
+        <a
+          href="https://en.gravatar.com/emails/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Change photo at Gravatar
+        </a>
       </div>
       {isPremiumTier && (
         <div className={`${baseClass}__more-info-detail`}>


### PR DESCRIPTION
Cerra #6893 

**Fix**
- Gravatar external link opens to a new tab

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
