### PR TITLE
consolidate sandbox env flags

### DIFF
--- a/docs/Contributing/Testing.md
+++ b/docs/Contributing/Testing.md
@@ -411,10 +411,10 @@ Pre-built installers are kept in a blob storage like AWS S3. As part of your you
    for local testing.
 2. Use the [installerstore](../../tools/installerstore/README.md) tool to upload them to your MinIO instance.
 3. Configure your fleet server setting `FLEET_PACKAGING_GLOBAL_ENROLL_SECRET` to match your global enroll secret.
-4. Set `FLEET_DEMO=1`, as the endpoint to retrieve the installer is only available in the sandbox.
+4. Set `FLEET_SERVER_SANDBOX_ENABLED=1`, as the endpoint to retrieve the installer is only available in the sandbox.
 
 ```
-FLEET_DEMO=1 FLEET_PACKAGING_GLOBAL_ENROLL_SECRET=xyz  ./build/fleet serve --dev 
+FLEET_SERVER_SANDBOX_ENABLED=1 FLEET_PACKAGING_GLOBAL_ENROLL_SECRET=xyz  ./build/fleet serve --dev 
 ```
 
 Be sure to replace the `FLEET_PACKAGING_GLOBAL_ENROLL_SECRET` value above with the global enroll

--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -824,7 +824,6 @@ None.
     "org_name": "fleet",
     "org_logo_url": ""
   },
-  "sandbox_enabled": true,
   "server_settings": {
     "server_url": "https://localhost:8080",
     "live_query_disabled": false,

--- a/infrastructure/sandbox/PreProvisioner/lambda/deploy_terraform/fleet/templates/deployment.yaml
+++ b/infrastructure/sandbox/PreProvisioner/lambda/deploy_terraform/fleet/templates/deployment.yaml
@@ -50,8 +50,6 @@ spec:
             memory: {{ .Values.resources.requests.memory }}
         env:
           ## BEGIN FLEET SECTION
-          - name: FLEET_DEMO
-            value: "1"
           - name: FLEET_SERVER_SANDBOX_ENABLED
             value: "1"
           - name: FLEET_SERVER_ADDRESS

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -466,6 +466,12 @@ func (man Manager) addConfigs() {
 	man.addConfigBool("server.sandbox_enabled", false,
 		"When enabled, Fleet limits some features for the Sandbox")
 
+	// Hide the sandbox flag as we don't want it to be discoverable for users for now
+	sandboxFlag := man.command.PersistentFlags().Lookup(flagNameFromConfigKey("server.sandbox_enabled"))
+	if sandboxFlag != nil {
+		sandboxFlag.Hidden = true
+	}
+
 	// Auth
 	man.addConfigInt("auth.bcrypt_cost", 12,
 		"Bcrypt iterations")

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -493,7 +493,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ne.WithCustomMiddleware(limiter.Limit("login", throttled.RateQuota{MaxRate: loginRateLimit, MaxBurst: 9})).
 		POST("/api/_version_/fleet/login", loginEndpoint, loginRequest{})
 
-	// Fleet Sandbox demo login (always errors unless FLEET_DEMO environment variable is set)
+	// Fleet Sandbox demo login (always errors unless config.server.sandbox_enabled is set)
 	ne.WithCustomMiddleware(limiter.Limit("login", throttled.RateQuota{MaxRate: loginRateLimit, MaxBurst: 9})).
 		POST("/api/_version_/fleet/demologin", makeDemologinEndpoint(config.Server.URLPrefix), demologinRequest{})
 }

--- a/server/service/installer.go
+++ b/server/service/installer.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"os"
 	"strconv"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -71,9 +70,7 @@ func (svc *Service) GetInstaller(ctx context.Context, installer fleet.Installer)
 		return nil, int64(0), err
 	}
 
-	// Undocumented FLEET_DEMO environment variable, as this endpoint is intended only to be
-	// used in the Fleet Sandbox demo environment.
-	if os.Getenv("FLEET_DEMO") != "1" {
+	if !svc.SandboxEnabled() {
 		return nil, int64(0), errors.New("this endpoint only enabled in demo mode")
 	}
 

--- a/server/service/installer_test.go
+++ b/server/service/installer_test.go
@@ -21,7 +21,7 @@ func setup(t *testing.T) (context.Context, *mock.Store, *mock.InstallerStore, fl
 	is := new(mock.InstallerStore)
 	cfg := config.TestConfig()
 	cfg.Server.SandboxEnabled = true
-	svc := newTestServiceWithConfig(t, ds, cfg, nil, nil, &TestServerOpts{Is: is})
+	svc := newTestServiceWithConfig(t, ds, cfg, nil, nil, &TestServerOpts{Is: is, FleetConfig: &cfg})
 	ds.VerifyEnrollSecretFunc = func(ctx context.Context, enrollSecret string) (*fleet.EnrollSecret, error) {
 		return &fleet.EnrollSecret{Secret: "xyz"}, nil
 
@@ -39,7 +39,9 @@ func TestGetInstaller(t *testing.T) {
 
 	t.Run("errors if store is not configured", func(t *testing.T) {
 		ctx, ds, _, _ := setup(t)
-		svc := newTestService(t, ds, nil, nil, &TestServerOpts{Is: nil})
+		cfg := config.TestConfig()
+		cfg.Server.SandboxEnabled = true
+		svc := newTestServiceWithConfig(t, ds, cfg, nil, nil, &TestServerOpts{Is: nil, FleetConfig: &cfg})
 		_, _, err := svc.GetInstaller(ctx, fleet.Installer{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "installer storage has not been configured")

--- a/server/service/installer_test.go
+++ b/server/service/installer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/authz"
+	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
@@ -15,11 +16,12 @@ import (
 )
 
 func setup(t *testing.T) (context.Context, *mock.Store, *mock.InstallerStore, fleet.Service) {
-	t.Setenv("FLEET_DEMO", "1")
 	ctx := test.UserContext(test.UserAdmin)
 	ds := new(mock.Store)
 	is := new(mock.InstallerStore)
-	svc := newTestService(t, ds, nil, nil, &TestServerOpts{Is: is})
+	cfg := config.TestConfig()
+	cfg.Server.SandboxEnabled = true
+	svc := newTestServiceWithConfig(t, ds, cfg, nil, nil, &TestServerOpts{Is: is})
 	ds.VerifyEnrollSecretFunc = func(ctx context.Context, enrollSecret string) (*fleet.EnrollSecret, error) {
 		return &fleet.EnrollSecret{Secret: "xyz"}, nil
 

--- a/server/service/integration_sandbox_test.go
+++ b/server/service/integration_sandbox_test.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
+	"net/url"
 	"testing"
 
+	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/s3"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/stretchr/testify/require"
@@ -16,18 +17,22 @@ import (
 
 const enrollSecret = "xyz"
 
-type integrationInstallersTestSuite struct {
+type integrationSandboxTestSuite struct {
 	suite.Suite
 	withServer
 	installers []fleet.Installer
 }
 
-func (s *integrationInstallersTestSuite) SetupSuite() {
-	s.withDS.SetupSuite("integrationInstallersTestSuite")
+func (s *integrationSandboxTestSuite) SetupSuite() {
+	s.withDS.SetupSuite("integrationSandboxTestSuite")
 	t := s.T()
 
+	// make sure sandbox is enabled
+	cfg := config.TestConfig()
+	cfg.Server.SandboxEnabled = true
+
 	is := s3.SetupTestInstallerStore(t, "integration-tests", "")
-	users, server := RunServerForTestsWithDS(t, s.ds, &TestServerOpts{Is: is})
+	users, server := RunServerForTestsWithDS(t, s.ds, &TestServerOpts{FleetConfig: &cfg})
 	s.server = server
 	s.users = users
 	s.token = s.getTestAdminToken()
@@ -37,24 +42,41 @@ func (s *integrationInstallersTestSuite) SetupSuite() {
 	require.NoError(t, err)
 }
 
-func TestIntegrationsInstallers(t *testing.T) {
-	testingSuite := new(integrationInstallersTestSuite)
+func TestIntegrationsSandbox(t *testing.T) {
+	testingSuite := new(integrationSandboxTestSuite)
 	testingSuite.s = &testingSuite.Suite
 	suite.Run(t, testingSuite)
 }
 
-func (s *integrationInstallersTestSuite) TestInstallerGet() {
+func (s *integrationSandboxTestSuite) TestDemoLogin() {
 	t := s.T()
 
-	// make sure FLEET_DEMO is not set
-	os.Unsetenv("FLEET_DEMO")
+	validEmail := testUsers["user1"].Email
+	validPwd := testUsers["user1"].PlaintextPassword
+	wrongPwd := "nope"
+	hdrs := map[string]string{"Content-Type": "application/x-www-form-urlencoded"}
+
+	formBody := make(url.Values)
+	formBody.Set("email", validEmail)
+	formBody.Set("password", wrongPwd)
+	res := s.DoRawWithHeaders("POST", "/api/v1/fleet/demologin", []byte(formBody.Encode()), http.StatusUnauthorized, hdrs)
+	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+
+	formBody.Set("email", validEmail)
+	formBody.Set("password", validPwd)
+	res = s.DoRawWithHeaders("POST", "/api/v1/fleet/demologin", []byte(formBody.Encode()), http.StatusOK, hdrs)
+	resBody, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Contains(t, string(resBody), `window.location = "/"`)
+	require.Regexp(t, `window.localStorage.setItem\('FLEET::auth_token', '[^']+'\)`, string(resBody))
+}
+
+func (s *integrationSandboxTestSuite) TestInstallerGet() {
+	t := s.T()
+
 	validURL := installerURL(enrollSecret, "pkg", false)
-	s.Do("GET", validURL, nil, http.StatusInternalServerError)
 
-	os.Setenv("FLEET_DEMO", "1")
-	defer os.Unsetenv("FLEET_DEMO")
-
-	// works when FLEET_DEMO is set
 	r := s.Do("GET", validURL, nil, http.StatusOK)
 	body, err := io.ReadAll(r.Body)
 	require.NoError(t, err)

--- a/server/service/integration_sandbox_test.go
+++ b/server/service/integration_sandbox_test.go
@@ -32,7 +32,7 @@ func (s *integrationSandboxTestSuite) SetupSuite() {
 	cfg.Server.SandboxEnabled = true
 
 	is := s3.SetupTestInstallerStore(t, "integration-tests", "")
-	users, server := RunServerForTestsWithDS(t, s.ds, &TestServerOpts{FleetConfig: &cfg})
+	users, server := RunServerForTestsWithDS(t, s.ds, &TestServerOpts{FleetConfig: &cfg, Is: is})
 	s.server = server
 	s.users = users
 	s.token = s.getTestAdminToken()

--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -11,7 +11,6 @@ import (
 	"html/template"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -635,9 +634,7 @@ func makeDemologinEndpoint(urlPrefix string) handlerFunc {
 	return func(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
 		req := request.(demologinRequest)
 
-		// Undocumented FLEET_DEMO environment variable, as this endpoint is intended only to be
-		// used in the Fleet Sandbox demo environment.
-		if os.Getenv("FLEET_DEMO") != "1" {
+		if !svc.SandboxEnabled() {
 			return nil, errors.New("this endpoint only enabled in demo mode")
 		}
 


### PR DESCRIPTION
Related to https://github.com/fleetdm/fleet/issues/6894, this entirely replaces `FLEET_DEMO` with the server config added in https://github.com/fleetdm/fleet/issues/6597 

As part of this, I also implemented a small refactor to the integration test suite to allow setting a custom config when the server is initialized.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
