### PR TITLE
Fleet UI: Spiffier firefox/safari dropdown input alignment

### DIFF
--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -97,12 +97,8 @@
   &--single {
     > .Select-control {
       .Select-value {
-        line-height: 36px;
+        line-height: 38px;
         border: none;
-        top: 1px;
-        right: 1px;
-        left: 1px;
-        bottom: 1px;
       }
     }
   }
@@ -223,14 +219,19 @@
   .Select-placeholder {
     color: $core-fleet-blue;
     font-size: $small;
-    line-height: 34px;
+    line-height: 38px;
     box-sizing: border-box;
   }
   .Select-input {
     color: $core-fleet-blue;
     font-size: $small;
     box-sizing: border-box;
-    line-height: 34px;
+    height: 38px;
+
+    > input {
+      line-height: 38px;
+      padding: 0;
+    }
   }
 
   &.Select--multi {

--- a/frontend/components/forms/fields/SelectTargetsDropdown/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/_styles.scss
@@ -73,7 +73,7 @@
       padding: 0 0 0 10px;
 
       > input {
-        line-height: 36px;
+        line-height: 53px;
         color: $core-fleet-black;
         font-size: $small;
       }

--- a/frontend/components/side_panels/QuerySidePanel/_styles.scss
+++ b/frontend/components/side_panels/QuerySidePanel/_styles.scss
@@ -35,10 +35,6 @@
     .form-field {
       margin-bottom: $pad-medium;
     }
-
-    .Select {
-      margin: 0 0 $pad-small;
-    }
   }
 
   &__description {

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -52,7 +52,7 @@ export const DEFAULT_POLICIES = [
       "SELECT 1 FROM managed_policies WHERE domain = 'com.apple.loginwindow' AND name = 'com.apple.login.mcx.DisableAutoLoginClient' AND value = 1 LIMIT 1;",
     name: "Automatic login disabled (macOS)",
     description:
-      "Required: You’re already enforcing a policy via Moble Device Management (MDM). Checks to make sure that the device user cannot log in to the device without a password.",
+      "Required: You’re already enforcing a policy via Mobile Device Management (MDM). Checks to make sure that the device user cannot log in to the device without a password.",
     resolution:
       "The following example profile includes a setting to disable automatic login: https://github.com/gregneagle/profiles/blob/fecc73d66fa17b6fa78b782904cb47cdc1913aeb/loginwindow.mobileconfig#L64-L65.",
     platform: "darwin",
@@ -105,7 +105,7 @@ export const DEFAULT_POLICIES = [
       "SELECT 1 FROM managed_policies WHERE domain = 'com.apple.loginwindow' AND name = 'DisableGuestAccount' AND value = 1 LIMIT 1;",
     name: "Guest users disabled (macOS)",
     description:
-      "Required: You’re already enforcing a policy via Moble Device Management (MDM). Checks to make sure that guest accounts cannot be used to log in to the device without a password.",
+      "Required: You’re already enforcing a policy via Mobile Device Management (MDM). Checks to make sure that guest accounts cannot be used to log in to the device without a password.",
     resolution:
       "The following example profile includes a setting to disable guest users: https://github.com/gregneagle/profiles/blob/fecc73d66fa17b6fa78b782904cb47cdc1913aeb/loginwindow.mobileconfig#L68-L71.",
     platform: "darwin",
@@ -125,7 +125,7 @@ export const DEFAULT_POLICIES = [
       "SELECT 1 FROM managed_policies WHERE domain = 'com.apple.Terminal' AND name = 'SecureKeyboardEntry' AND value = 1 LIMIT 1;",
     name: "Secure keyboard entry for Terminal.app enabled (macOS)",
     description:
-      "Required: You’re already enforcing a policy via Moble Device Management (MDM). Checks to make sure that the Secure Keyboard Entry setting is enabled.",
+      "Required: You’re already enforcing a policy via Mobile Device Management (MDM). Checks to make sure that the Secure Keyboard Entry setting is enabled.",
     resolution: "",
     platform: "darwin",
   },


### PR DESCRIPTION
Cerra #6827 

**Fix after QA**
- firefox and safari alignment (which incorrectly shows input default of 17px line height, top padding 8 px bottom padding 12 px)

**Other fix**
- Typo in default policy


**Fixed screenshots of Safari and Firefox**
<img width="1447" alt="Screen Shot 2022-07-27 at 2 58 33 PM" src="https://user-images.githubusercontent.com/71795832/181351139-041ef7b8-857c-4a9f-8d37-63df67819f09.png">
<img width="1269" alt="Screen Shot 2022-07-27 at 2 58 12 PM" src="https://user-images.githubusercontent.com/71795832/181351143-ce4bf820-58f7-475e-b70b-680bde1decf5.png">
<img width="1268" alt="Screen Shot 2022-07-27 at 2 57 42 PM" src="https://user-images.githubusercontent.com/71795832/181351146-b3863542-c01a-4c8e-beb8-a2e58936f6b3.png">
<img width="1444" alt="Screen Shot 2022-07-27 at 2 57 19 PM" src="https://user-images.githubusercontent.com/71795832/181351151-113632b3-61d6-42d3-b4e1-bcd22c377879.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`). (previous PR)
- [x] Manual QA for all new/changed functionality
