### PR TITLE
Fleet UI: Hitting enter global modal parameter, rename modals to match UI

### DIFF
--- a/changes/issue-6910-enter-closes-api-modal
+++ b/changes/issue-6910-enter-closes-api-modal
@@ -1,0 +1,1 @@
+* Hit enter closes API token modal

--- a/cypress/integration/all/app/policiesflow.spec.ts
+++ b/cypress/integration/all/app/policiesflow.spec.ts
@@ -375,11 +375,11 @@ describe("Policies flow (seeded)", () => {
           });
       });
       cy.findByRole("button", { name: /delete/i }).click();
-      cy.getAttached(".remove-policies-modal").within(() => {
+      cy.getAttached(".delete-policies-modal").within(() => {
         cy.findByRole("button", { name: /cancel/i }).should("exist");
         cy.findByRole("button", { name: /delete/i }).click();
       });
-      cy.findByText(/removed policy/i).should("exist");
+      cy.findByText(/deleted policy/i).should("exist");
       cy.findByText(/backup/i).should("not.exist");
     });
     it("creates a failing policies webhook", () => {

--- a/cypress/integration/all/app/queryflow.spec.ts
+++ b/cypress/integration/all/app/queryflow.spec.ts
@@ -110,10 +110,10 @@ describe("Query flow (seeded)", () => {
           });
         });
       cy.findByRole("button", { name: /delete/i }).click();
-      cy.getAttached(".remove-query-modal .modal-cta-wrap").within(() => {
+      cy.getAttached(".delete-query-modal .modal-cta-wrap").within(() => {
         cy.findByRole("button", { name: /delete/i }).click();
       });
-      cy.findByText(/successfully removed query/i).should("be.visible");
+      cy.findByText(/successfully deleted query/i).should("be.visible");
       cy.findByText(/detect presence of authorized ssh keys/i).should(
         "not.exist"
       );

--- a/cypress/integration/free/admin.spec.ts
+++ b/cypress/integration/free/admin.spec.ts
@@ -670,7 +670,7 @@ describe(
             });
         });
         cy.findByRole("button", { name: /delete/i }).click();
-        cy.getAttached(".remove-policies-modal").within(() => {
+        cy.getAttached(".delete-policies-modal").within(() => {
           cy.findByRole("button", { name: /delete/i }).should("exist");
           cy.findByRole("button", { name: /cancel/i }).click();
         });

--- a/cypress/integration/free/maintainer.spec.ts
+++ b/cypress/integration/free/maintainer.spec.ts
@@ -278,7 +278,7 @@ describe(
             });
         });
         cy.findByRole("button", { name: /delete/i }).click();
-        cy.getAttached(".remove-policies-modal").within(() => {
+        cy.getAttached(".delete-policies-modal").within(() => {
           cy.findByRole("button", { name: /delete/i }).should("exist");
           cy.findByRole("button", { name: /cancel/i }).click();
         });

--- a/cypress/integration/premium/admin.spec.ts
+++ b/cypress/integration/premium/admin.spec.ts
@@ -613,7 +613,7 @@ describe("Premium tier - Global Admin user", () => {
           });
       });
       cy.findByRole("button", { name: /delete/i }).click();
-      cy.getAttached(".remove-policies-modal").within(() => {
+      cy.getAttached(".delete-policies-modal").within(() => {
         cy.findByRole("button", { name: /delete/i }).should("exist");
         cy.findByRole("button", { name: /cancel/i }).click();
       });

--- a/cypress/integration/premium/maintainer.spec.ts
+++ b/cypress/integration/premium/maintainer.spec.ts
@@ -264,7 +264,7 @@ describe("Premium tier - Maintainer user", () => {
             });
         });
         cy.findByRole("button", { name: /delete/i }).click();
-        cy.getAttached(".remove-policies-modal").within(() => {
+        cy.getAttached(".delete-policies-modal").within(() => {
           cy.findByRole("button", { name: /delete/i }).should("exist");
           cy.findByRole("button", { name: /cancel/i }).click();
         });

--- a/cypress/integration/premium/team_admin.spec.ts
+++ b/cypress/integration/premium/team_admin.spec.ts
@@ -349,7 +349,7 @@ describe("Premium tier - Team Admin user", () => {
           });
       });
       cy.findByRole("button", { name: /delete/i }).click();
-      cy.getAttached(".remove-policies-modal").within(() => {
+      cy.getAttached(".delete-policies-modal").within(() => {
         cy.findByRole("button", { name: /delete/i }).should("exist");
         cy.findByRole("button", { name: /cancel/i }).click();
       });

--- a/frontend/components/DeleteSecretModal/DeleteSecretModal.tsx
+++ b/frontend/components/DeleteSecretModal/DeleteSecretModal.tsx
@@ -29,23 +29,10 @@ const DeleteSecretModal = ({
     return teams.find((team) => team.id === selectedTeam);
   };
 
-  useEffect(() => {
-    const listener = (event: KeyboardEvent) => {
-      if (event.code === "Enter" || event.code === "NumpadEnter") {
-        event.preventDefault();
-        onDeleteSecret();
-      }
-    };
-
-    document.addEventListener("keydown", listener);
-    return () => {
-      document.removeEventListener("keydown", listener);
-    };
-  }, []);
-
   return (
     <Modal
       onExit={toggleDeleteSecretModal}
+      onEnter={onDeleteSecret}
       title={"Delete secret"}
       className={baseClass}
     >

--- a/frontend/components/EnrollSecretModal/EnrollSecretModal.tsx
+++ b/frontend/components/EnrollSecretModal/EnrollSecretModal.tsx
@@ -32,20 +32,6 @@ const EnrollSecretModal = ({
   setSelectedSecret,
   globalSecrets,
 }: IEnrollSecretModal): JSX.Element => {
-  useEffect(() => {
-    const listener = (event: KeyboardEvent) => {
-      if (event.code === "Enter" || event.code === "NumpadEnter") {
-        event.preventDefault();
-        onReturnToApp();
-      }
-    };
-
-    document.addEventListener("keydown", listener);
-    return () => {
-      document.removeEventListener("keydown", listener);
-    };
-  }, []);
-
   const renderTeam = () => {
     if (typeof selectedTeam === "string") {
       selectedTeam = parseInt(selectedTeam, 10);
@@ -65,6 +51,7 @@ const EnrollSecretModal = ({
   return (
     <Modal
       onExit={onReturnToApp}
+      onEnter={onReturnToApp}
       title={"Manage enroll secrets"}
       className={baseClass}
     >

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -7,6 +7,7 @@ const baseClass = "modal";
 export interface IModalProps {
   children: JSX.Element;
   onExit: () => void;
+  onEnter?: () => void;
   title: string | JSX.Element;
   className?: string;
 }
@@ -14,6 +15,7 @@ export interface IModalProps {
 const Modal = ({
   children,
   onExit,
+  onEnter,
   title,
   className,
 }: IModalProps): JSX.Element => {
@@ -33,6 +35,22 @@ const Modal = ({
       document.removeEventListener("keydown", closeWithEscapeKey);
     };
   }, []);
+
+  useEffect(() => {
+    if (onEnter) {
+      const closeOrSaveWithEnterKey = (event: KeyboardEvent) => {
+        if (event.code === "Enter" || event.code === "NumpadEnter") {
+          event.preventDefault();
+          onEnter();
+        }
+      };
+
+      document.addEventListener("keydown", closeOrSaveWithEnterKey);
+      return () => {
+        document.removeEventListener("keydown", closeOrSaveWithEnterKey);
+      };
+    }
+  }, [onEnter]);
 
   const modalContainerClassName = classnames(
     `${baseClass}__modal_container`,

--- a/frontend/components/SecretEditorModal/SecretEditorModal.tsx
+++ b/frontend/components/SecretEditorModal/SecretEditorModal.tsx
@@ -77,6 +77,7 @@ const SecretEditorModal = ({
   return (
     <Modal
       onExit={toggleSecretEditorModal}
+      onEnter={onSaveSecretClick}
       title={selectedSecret ? "Edit secret" : "Add secret"}
       className={baseClass}
     >

--- a/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
@@ -30,7 +30,7 @@ interface IWelcomeHostCardProps {
 }
 
 const baseClass = "welcome-host";
-const HOST_ID = 20;
+const HOST_ID = 1;
 const policyPass = "pass";
 const policyFail = "fail";
 

--- a/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
@@ -30,7 +30,7 @@ interface IWelcomeHostCardProps {
 }
 
 const baseClass = "welcome-host";
-const HOST_ID = 1;
+const HOST_ID = 20;
 const policyPass = "pass";
 const policyFail = "fail";
 
@@ -296,6 +296,7 @@ const WelcomeHost = ({
           <Modal
             title={currentPolicyShown?.name || ""}
             onExit={() => setShowPolicyModal(false)}
+            onEnter={() => setShowPolicyModal(false)}
             className={`${baseClass}__policy-modal`}
           >
             <>

--- a/frontend/pages/UserSettingsPage/UserSettingsPage.tsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.tsx
@@ -49,22 +49,6 @@ const UserSettingsPage = ({
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const [userErrors, setUserErrors] = useState<{ [key: string]: string }>({});
 
-  useEffect(() => {
-    if (showApiTokenModal) {
-      const listener = (event: KeyboardEvent) => {
-        if (event.code === "Enter" || event.code === "NumpadEnter") {
-          event.preventDefault();
-          onToggleApiTokenModal();
-        }
-      };
-
-      document.addEventListener("keydown", listener);
-      return () => {
-        document.removeEventListener("keydown", listener);
-      };
-    }
-  }, [showApiTokenModal]);
-
   const onCancel = (evt: React.MouseEvent<HTMLButtonElement>) => {
     evt.preventDefault();
     return router.goBack();
@@ -194,7 +178,11 @@ const UserSettingsPage = ({
     }
 
     return (
-      <Modal title="Get API token" onExit={onToggleApiTokenModal}>
+      <Modal
+        title="Get API token"
+        onExit={onToggleApiTokenModal}
+        onEnter={onToggleApiTokenModal}
+      >
         <>
           <InfoBanner>
             <p>

--- a/frontend/pages/UserSettingsPage/UserSettingsPage.tsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.tsx
@@ -1,6 +1,5 @@
-import React, { useState, useContext } from "react";
+import React, { useState, useContext, useEffect } from "react";
 import { InjectedRouter } from "react-router";
-import classnames from "classnames";
 
 import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
@@ -49,6 +48,22 @@ const UserSettingsPage = ({
   const [showApiTokenModal, setShowApiTokenModal] = useState<boolean>(false);
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const [userErrors, setUserErrors] = useState<{ [key: string]: string }>({});
+
+  useEffect(() => {
+    if (showApiTokenModal) {
+      const listener = (event: KeyboardEvent) => {
+        if (event.code === "Enter" || event.code === "NumpadEnter") {
+          event.preventDefault();
+          onToggleApiTokenModal();
+        }
+      };
+
+      document.addEventListener("keydown", listener);
+      return () => {
+        document.removeEventListener("keydown", listener);
+      };
+    }
+  }, [showApiTokenModal]);
 
   const onCancel = (evt: React.MouseEvent<HTMLButtonElement>) => {
     evt.preventDefault();

--- a/frontend/pages/admin/IntegrationsPage/components/DeleteIntegrationModal/DeleteIntegrationModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/components/DeleteIntegrationModal/DeleteIntegrationModal.tsx
@@ -18,21 +18,13 @@ const DeleteIntegrationModal = ({
   onSubmit,
   onCancel,
 }: IDeleteIntegrationModalProps): JSX.Element => {
-  useEffect(() => {
-    const listener = (event: KeyboardEvent) => {
-      if (event.code === "Enter" || event.code === "NumpadEnter") {
-        event.preventDefault();
-        onSubmit();
-      }
-    };
-    document.addEventListener("keydown", listener);
-    return () => {
-      document.removeEventListener("keydown", listener);
-    };
-  }, []);
-
   return (
-    <Modal title={"Delete integration"} onExit={onCancel} className={baseClass}>
+    <Modal
+      title={"Delete integration"}
+      onExit={onCancel}
+      onEnter={onSubmit}
+      className={baseClass}
+    >
       <form className={`${baseClass}__form`}>
         <p>
           This action will delete the{" "}

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/components/RemoveMemberModal/RemoveMemberModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/components/RemoveMemberModal/RemoveMemberModal.tsx
@@ -21,21 +21,13 @@ const RemoveMemberModal = ({
   onSubmit,
   onCancel,
 }: IDeleteTeamModalProps): JSX.Element => {
-  useEffect(() => {
-    const listener = (event: KeyboardEvent) => {
-      if (event.code === "Enter" || event.code === "NumpadEnter") {
-        event.preventDefault();
-        onSubmit();
-      }
-    };
-    document.addEventListener("keydown", listener);
-    return () => {
-      document.removeEventListener("keydown", listener);
-    };
-  }, []);
-
   return (
-    <Modal title={"Remove team member"} onExit={onCancel} className={baseClass}>
+    <Modal
+      title={"Remove team member"}
+      onExit={onCancel}
+      onEnter={onSubmit}
+      className={baseClass}
+    >
       {isLoading ? (
         <Spinner />
       ) : (

--- a/frontend/pages/admin/TeamManagementPage/components/DeleteTeamModal/DeleteTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/DeleteTeamModal/DeleteTeamModal.tsx
@@ -19,21 +19,13 @@ const DeleteTeamModal = ({
   onSubmit,
   onCancel,
 }: IDeleteTeamModalProps): JSX.Element => {
-  useEffect(() => {
-    const listener = (event: KeyboardEvent) => {
-      if (event.code === "Enter" || event.code === "NumpadEnter") {
-        event.preventDefault();
-        onSubmit();
-      }
-    };
-    document.addEventListener("keydown", listener);
-    return () => {
-      document.removeEventListener("keydown", listener);
-    };
-  }, []);
-
   return (
-    <Modal title={"Delete team"} onExit={onCancel} className={baseClass}>
+    <Modal
+      title={"Delete team"}
+      onExit={onCancel}
+      onEnter={onSubmit}
+      className={baseClass}
+    >
       {isLoading ? (
         <Spinner />
       ) : (

--- a/frontend/pages/admin/UserManagementPage/components/ResetPasswordModal/ResetPasswordModal.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/ResetPasswordModal/ResetPasswordModal.tsx
@@ -17,7 +17,11 @@ const ResetPasswordModal = ({
   onResetCancel,
 }: IResetPasswordModal): JSX.Element => {
   return (
-    <Modal title="Require password reset" onExit={onResetCancel}>
+    <Modal
+      title="Require password reset"
+      onExit={onResetCancel}
+      onEnter={() => onResetConfirm(user)}
+    >
       <div className={baseClass}>
         <p>
           This user will be asked to reset their password after their next

--- a/frontend/pages/admin/UserManagementPage/components/ResetSessionsModal/ResetSessionsModal.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/ResetSessionsModal/ResetSessionsModal.tsx
@@ -17,7 +17,11 @@ const ResetSessionsModal = ({
   onResetCancel,
 }: IResetSessionsModal): JSX.Element => {
   return (
-    <Modal title="Reset sessions" onExit={onResetCancel}>
+    <Modal
+      title="Reset sessions"
+      onExit={onResetCancel}
+      onEnter={() => onResetConfirm(user)}
+    >
       <div className={baseClass}>
         <p>
           This user will be logged out of Fleet.

--- a/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/DeleteHostModal.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/DeleteHostModal/DeleteHostModal.tsx
@@ -18,21 +18,13 @@ const DeleteHostModal = ({
   onCancel,
   isAllMatchingHostsSelected,
 }: IDeleteHostModalProps): JSX.Element => {
-  useEffect(() => {
-    const listener = (event: KeyboardEvent) => {
-      if (event.code === "Enter" || event.code === "NumpadEnter") {
-        event.preventDefault();
-        onSubmit();
-      }
-    };
-    document.addEventListener("keydown", listener);
-    return () => {
-      document.removeEventListener("keydown", listener);
-    };
-  }, []);
-
   return (
-    <Modal title={"Delete host"} onExit={onCancel} className={baseClass}>
+    <Modal
+      title={"Delete host"}
+      onExit={onCancel}
+      onEnter={onSubmit}
+      className={baseClass}
+    >
       <form className={`${baseClass}__form`}>
         <p>
           This action will delete{" "}

--- a/frontend/pages/hosts/ManageHostsPage/components/DeleteLabelModal/DeleteLabelModal.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/DeleteLabelModal/DeleteLabelModal.tsx
@@ -14,21 +14,13 @@ const DeleteLabelModal = ({
   onSubmit,
   onCancel,
 }: IDeleteLabelModalProps): JSX.Element => {
-  useEffect(() => {
-    const listener = (event: KeyboardEvent) => {
-      if (event.code === "Enter" || event.code === "NumpadEnter") {
-        event.preventDefault();
-        onSubmit();
-      }
-    };
-    document.addEventListener("keydown", listener);
-    return () => {
-      document.removeEventListener("keydown", listener);
-    };
-  }, []);
-
   return (
-    <Modal title="Delete label" onExit={onCancel} className={baseClass}>
+    <Modal
+      title="Delete label"
+      onExit={onCancel}
+      onEnter={onSubmit}
+      className={baseClass}
+    >
       <>
         <p>Are you sure you wish to delete this label?</p>
         <div className="modal-cta-wrap">

--- a/frontend/pages/packs/EditPackPage/components/RemovePackQueryModal/RemovePackQueryModal.tsx
+++ b/frontend/pages/packs/EditPackPage/components/RemovePackQueryModal/RemovePackQueryModal.tsx
@@ -19,23 +19,15 @@ const RemovePackQueryModal = ({
   selectedQuery,
   selectedQueryIds,
 }: IRemovePackQueryModalProps): JSX.Element => {
-  useEffect(() => {
-    const listener = (event: KeyboardEvent) => {
-      if (event.code === "Enter" || event.code === "NumpadEnter") {
-        event.preventDefault();
-        onSubmit();
-      }
-    };
-    document.addEventListener("keydown", listener);
-    return () => {
-      document.removeEventListener("keydown", listener);
-    };
-  }, []);
-
   const queryOrQueries =
     selectedQuery || selectedQueryIds?.length === 1 ? "query" : "queries";
   return (
-    <Modal title={"Remove queries"} onExit={onCancel} className={baseClass}>
+    <Modal
+      title={"Remove queries"}
+      onExit={onCancel}
+      onEnter={onSubmit}
+      className={baseClass}
+    >
       <div className={baseClass}>
         Are you sure you want to remove the selected {queryOrQueries} from your
         pack?

--- a/frontend/pages/packs/ManagePacksPage/ManagePacksPage.tsx
+++ b/frontend/pages/packs/ManagePacksPage/ManagePacksPage.tsx
@@ -104,7 +104,7 @@ const ManagePacksPage = ({ router }: IManagePacksPageProps): JSX.Element => {
       .catch(() => {
         renderFlash(
           "error",
-          `Unable to remove ${packOrPacks}. Please try again.`
+          `Unable to delete ${packOrPacks}. Please try again.`
         );
       })
       .finally(() => {

--- a/frontend/pages/packs/ManagePacksPage/ManagePacksPage.tsx
+++ b/frontend/pages/packs/ManagePacksPage/ManagePacksPage.tsx
@@ -15,7 +15,7 @@ import TableDataError from "components/DataError";
 import Spinner from "components/Spinner";
 import MainContent from "components/MainContent";
 import PacksListWrapper from "./components/PacksListWrapper";
-import RemovePackModal from "./components/RemovePackModal";
+import DeletePackModal from "./components/DeletePackModal";
 
 const baseClass = "manage-packs-page";
 
@@ -28,7 +28,7 @@ interface IPacksResponse {
 }
 
 const renderTable = (
-  onRemovePackClick: (selectedTablePackIds: number[]) => void,
+  onDeletePackClick: (selectedTablePackIds: number[]) => void,
   onEnablePackClick: (selectedTablePackIds: number[]) => void,
   onDisablePackClick: (selectedTablePackIds: number[]) => void,
   onCreatePackClick: React.MouseEventHandler<HTMLButtonElement>,
@@ -44,7 +44,7 @@ const renderTable = (
 
   return (
     <PacksListWrapper
-      onRemovePackClick={onRemovePackClick}
+      onDeletePackClick={onDeletePackClick}
       onEnablePackClick={onEnablePackClick}
       onDisablePackClick={onDisablePackClick}
       onCreatePackClick={onCreatePackClick}
@@ -61,7 +61,7 @@ const ManagePacksPage = ({ router }: IManagePacksPageProps): JSX.Element => {
   const onCreatePackClick = () => router.push(PATHS.NEW_PACK);
 
   const [selectedPackIds, setSelectedPackIds] = useState<number[]>([]);
-  const [showRemovePackModal, setShowRemovePackModal] = useState<boolean>(
+  const [showDeletePackModal, setShowDeletePackModal] = useState<boolean>(
     false
   );
 
@@ -81,16 +81,16 @@ const ManagePacksPage = ({ router }: IManagePacksPageProps): JSX.Element => {
     }
   );
 
-  const toggleRemovePackModal = useCallback(() => {
-    setShowRemovePackModal(!showRemovePackModal);
-  }, [showRemovePackModal, setShowRemovePackModal]);
+  const toggleDeletePackModal = useCallback(() => {
+    setShowDeletePackModal(!showDeletePackModal);
+  }, [showDeletePackModal, setShowDeletePackModal]);
 
-  const onRemovePackClick = (selectedTablePackIds: number[]) => {
-    toggleRemovePackModal();
+  const onDeletePackClick = (selectedTablePackIds: number[]) => {
+    toggleDeletePackModal();
     setSelectedPackIds(selectedTablePackIds);
   };
 
-  const onRemovePackSubmit = useCallback(() => {
+  const onDeletePackSubmit = useCallback(() => {
     const packOrPacks = selectedPackIds.length === 1 ? "pack" : "packs";
 
     const promises = selectedPackIds.map((id: number) => {
@@ -109,9 +109,9 @@ const ManagePacksPage = ({ router }: IManagePacksPageProps): JSX.Element => {
       })
       .finally(() => {
         refetchPacks();
-        toggleRemovePackModal();
+        toggleDeletePackModal();
       });
-  }, [refetchPacks, selectedPackIds, toggleRemovePackModal]);
+  }, [refetchPacks, selectedPackIds, toggleDeletePackModal]);
 
   const onEnableDisablePackSubmit = useCallback(
     (selectedTablePackIds: number[], disablePack: boolean) => {
@@ -186,7 +186,7 @@ const ManagePacksPage = ({ router }: IManagePacksPageProps): JSX.Element => {
             <Spinner />
           ) : (
             renderTable(
-              onRemovePackClick,
+              onDeletePackClick,
               onEnablePackClick,
               onDisablePackClick,
               onCreatePackClick,
@@ -196,10 +196,10 @@ const ManagePacksPage = ({ router }: IManagePacksPageProps): JSX.Element => {
             )
           )}
         </div>
-        {showRemovePackModal && (
-          <RemovePackModal
-            onCancel={toggleRemovePackModal}
-            onSubmit={onRemovePackSubmit}
+        {showDeletePackModal && (
+          <DeletePackModal
+            onCancel={toggleDeletePackModal}
+            onSubmit={onDeletePackSubmit}
           />
         )}
       </div>

--- a/frontend/pages/packs/ManagePacksPage/components/DeletePackModal/DeletePackModal.tsx
+++ b/frontend/pages/packs/ManagePacksPage/components/DeletePackModal/DeletePackModal.tsx
@@ -5,15 +5,15 @@ import Button from "components/buttons/Button";
 
 const baseClass = "remove-pack-modal";
 
-interface IRemovePackModalProps {
+interface IDeletePackModalProps {
   onCancel: () => void;
   onSubmit: () => void;
 }
 
-const RemovePackModal = ({
+const DeletePackModal = ({
   onCancel,
   onSubmit,
-}: IRemovePackModalProps): JSX.Element => {
+}: IDeletePackModalProps): JSX.Element => {
   return (
     <Modal
       title={"Delete pack"}
@@ -45,4 +45,4 @@ const RemovePackModal = ({
   );
 };
 
-export default RemovePackModal;
+export default DeletePackModal;

--- a/frontend/pages/packs/ManagePacksPage/components/DeletePackModal/index.ts
+++ b/frontend/pages/packs/ManagePacksPage/components/DeletePackModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeletePackModal";

--- a/frontend/pages/packs/ManagePacksPage/components/PacksListWrapper/PacksListWrapper.tsx
+++ b/frontend/pages/packs/ManagePacksPage/components/PacksListWrapper/PacksListWrapper.tsx
@@ -11,7 +11,7 @@ const baseClass = "packs-list-wrapper";
 const noPacksClass = "no-packs";
 
 interface IPacksListWrapperProps {
-  onRemovePackClick: (selectedTablePackIds: number[]) => void;
+  onDeletePackClick: (selectedTablePackIds: number[]) => void;
   onEnablePackClick: (selectedTablePackIds: number[]) => void;
   onDisablePackClick: (selectedTablePackIds: number[]) => void;
   onCreatePackClick: (
@@ -22,7 +22,7 @@ interface IPacksListWrapperProps {
 }
 
 const PacksListWrapper = ({
-  onRemovePackClick,
+  onDeletePackClick,
   onEnablePackClick,
   onDisablePackClick,
   onCreatePackClick,
@@ -122,7 +122,7 @@ const PacksListWrapper = ({
         inputPlaceHolder="Search by name"
         searchable={packs && packs.length > 0}
         disablePagination
-        onPrimarySelectActionClick={onRemovePackClick}
+        onPrimarySelectActionClick={onDeletePackClick}
         primarySelectActionButtonVariant="text-icon"
         primarySelectActionButtonIcon="delete"
         primarySelectActionButtonText={"Delete"}

--- a/frontend/pages/packs/ManagePacksPage/components/RemovePackModal/RemovePackModal.tsx
+++ b/frontend/pages/packs/ManagePacksPage/components/RemovePackModal/RemovePackModal.tsx
@@ -14,21 +14,13 @@ const RemovePackModal = ({
   onCancel,
   onSubmit,
 }: IRemovePackModalProps): JSX.Element => {
-  useEffect(() => {
-    const listener = (event: KeyboardEvent) => {
-      if (event.code === "Enter" || event.code === "NumpadEnter") {
-        event.preventDefault();
-        onSubmit();
-      }
-    };
-    document.addEventListener("keydown", listener);
-    return () => {
-      document.removeEventListener("keydown", listener);
-    };
-  }, []);
-
   return (
-    <Modal title={"Delete pack"} onExit={onCancel} className={baseClass}>
+    <Modal
+      title={"Delete pack"}
+      onExit={onCancel}
+      onEnter={onSubmit}
+      className={baseClass}
+    >
       <div className={baseClass}>
         Are you sure you want to delete the selected packs?
         <div className="modal-cta-wrap">

--- a/frontend/pages/packs/ManagePacksPage/components/RemovePackModal/index.ts
+++ b/frontend/pages/packs/ManagePacksPage/components/RemovePackModal/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./RemovePackModal";

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -28,7 +28,7 @@ import MainContent from "components/MainContent";
 import PoliciesListWrapper from "./components/PoliciesListWrapper";
 import ManageAutomationsModal from "./components/ManageAutomationsModal";
 import AddPolicyModal from "./components/AddPolicyModal";
-import RemovePoliciesModal from "./components/RemovePoliciesModal";
+import DeletePoliciesModal from "./components/DeletePoliciesModal";
 
 interface IManagePoliciesPageProps {
   router: InjectedRouter;
@@ -86,7 +86,7 @@ const ManagePolicyPage = ({
   );
   const [showPreviewPayloadModal, setShowPreviewPayloadModal] = useState(false);
   const [showAddPolicyModal, setShowAddPolicyModal] = useState(false);
-  const [showRemovePoliciesModal, setShowRemovePoliciesModal] = useState(false);
+  const [showDeletePoliciesModal, setShowDeletePoliciesModal] = useState(false);
   const [showInheritedPolicies, setShowInheritedPolicies] = useState(false);
 
   useEffect(() => {
@@ -197,8 +197,8 @@ const ManagePolicyPage = ({
 
   const toggleAddPolicyModal = () => setShowAddPolicyModal(!showAddPolicyModal);
 
-  const toggleRemovePoliciesModal = () =>
-    setShowRemovePoliciesModal(!showRemovePoliciesModal);
+  const toggleDeletePoliciesModal = () =>
+    setShowDeletePoliciesModal(!showDeletePoliciesModal);
 
   const toggleShowInheritedPolicies = () =>
     setShowInheritedPolicies(!showInheritedPolicies);
@@ -232,12 +232,12 @@ const ManagePolicyPage = ({
     toggleAddPolicyModal();
   };
 
-  const onRemovePoliciesClick = (selectedTableIds: number[]): void => {
-    toggleRemovePoliciesModal();
+  const onDeletePoliciesClick = (selectedTableIds: number[]): void => {
+    toggleDeletePoliciesModal();
     setSelectedPolicyIds(selectedTableIds);
   };
 
-  const onRemovePoliciesSubmit = async () => {
+  const onDeletePoliciesSubmit = async () => {
     const id = currentTeam?.id;
     setIsRemovingPolicy(true);
     try {
@@ -263,7 +263,7 @@ const ManagePolicyPage = ({
         }. Please try again.`
       );
     } finally {
-      toggleRemovePoliciesModal();
+      toggleDeletePoliciesModal();
       setIsRemovingPolicy(false);
     }
   };
@@ -426,7 +426,7 @@ const ManagePolicyPage = ({
                   isFetchingConfig
                 }
                 onAddPolicyClick={onAddPolicyClick}
-                onRemovePoliciesClick={onRemovePoliciesClick}
+                onDeletePoliciesClick={onDeletePoliciesClick}
                 canAddOrRemovePolicy={canAddOrRemovePolicy}
                 currentTeam={currentTeam}
                 currentAutomatedPolicies={currentAutomatedPolicies}
@@ -442,7 +442,7 @@ const ManagePolicyPage = ({
                 policiesList={globalPolicies || []}
                 isLoading={isFetchingGlobalPolicies || isFetchingConfig}
                 onAddPolicyClick={onAddPolicyClick}
-                onRemovePoliciesClick={onRemovePoliciesClick}
+                onDeletePoliciesClick={onDeletePoliciesClick}
                 canAddOrRemovePolicy={canAddOrRemovePolicy}
                 currentTeam={currentTeam}
                 currentAutomatedPolicies={currentAutomatedPolicies}
@@ -478,7 +478,7 @@ const ManagePolicyPage = ({
                 <PoliciesListWrapper
                   isLoading={isFetchingGlobalPolicies}
                   policiesList={globalPolicies || []}
-                  onRemovePoliciesClick={noop}
+                  onDeletePoliciesClick={noop}
                   resultsTitle="policies"
                   canAddOrRemovePolicy={canAddOrRemovePolicy}
                   tableType="inheritedPolicies"
@@ -507,11 +507,11 @@ const ManagePolicyPage = ({
             teamName={currentTeam?.name}
           />
         )}
-        {showRemovePoliciesModal && (
-          <RemovePoliciesModal
+        {showDeletePoliciesModal && (
+          <DeletePoliciesModal
             isLoading={isRemovingPolicy}
-            onCancel={toggleRemovePoliciesModal}
-            onSubmit={onRemovePoliciesSubmit}
+            onCancel={toggleDeletePoliciesModal}
+            onSubmit={onDeletePoliciesSubmit}
           />
         )}
       </div>

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -79,7 +79,7 @@ const ManagePolicyPage = ({
   const [isAutomationsLoading, setIsAutomationsLoading] = useState<boolean>(
     false
   );
-  const [isRemovingPolicy, setIsRemovingPolicy] = useState<boolean>(false);
+  const [isDeletingPolicy, setIsDeletingPolicy] = useState<boolean>(false);
   const [selectedPolicyIds, setSelectedPolicyIds] = useState<number[]>([]);
   const [showManageAutomationsModal, setShowManageAutomationsModal] = useState(
     false
@@ -126,7 +126,7 @@ const ManagePolicyPage = ({
     }
   );
 
-  const canAddOrRemovePolicy =
+  const canAddOrDeletePolicy =
     isGlobalAdmin || isGlobalMaintainer || isTeamMaintainer || isTeamAdmin;
   const canManageAutomations = isGlobalAdmin || isTeamAdmin;
 
@@ -140,7 +140,7 @@ const ManagePolicyPage = ({
       return configAPI.loadAll();
     },
     {
-      enabled: canAddOrRemovePolicy,
+      enabled: canAddOrDeletePolicy,
       onSuccess: (data) => {
         setConfig(data);
       },
@@ -156,7 +156,7 @@ const ManagePolicyPage = ({
     ["teams", teamId],
     () => teamsAPI.load(teamId),
     {
-      enabled: !!teamId && canAddOrRemovePolicy,
+      enabled: !!teamId && canAddOrDeletePolicy,
       select: (data) => data.team,
       staleTime: 5000,
     }
@@ -239,7 +239,7 @@ const ManagePolicyPage = ({
 
   const onDeletePoliciesSubmit = async () => {
     const id = currentTeam?.id;
-    setIsRemovingPolicy(true);
+    setIsDeletingPolicy(true);
     try {
       const request = id
         ? teamPoliciesAPI.destroy(id, selectedPolicyIds)
@@ -248,7 +248,7 @@ const ManagePolicyPage = ({
       await request.then(() => {
         renderFlash(
           "success",
-          `Successfully removed ${
+          `Successfully deleted ${
             selectedPolicyIds?.length === 1 ? "policy" : "policies"
           }.`
         );
@@ -258,13 +258,13 @@ const ManagePolicyPage = ({
     } catch {
       renderFlash(
         "error",
-        `Unable to remove ${
+        `Unable to delete ${
           selectedPolicyIds?.length === 1 ? "policy" : "policies"
         }. Please try again.`
       );
     } finally {
       toggleDeletePoliciesModal();
-      setIsRemovingPolicy(false);
+      setIsDeletingPolicy(false);
     }
   };
 
@@ -384,7 +384,7 @@ const ManagePolicyPage = ({
                     <span>Manage automations</span>
                   </Button>
                 )}
-              {canAddOrRemovePolicy && (
+              {canAddOrDeletePolicy && (
                 <div className={`${baseClass}__action-button-container`}>
                   <Button
                     variant="brand"
@@ -427,7 +427,7 @@ const ManagePolicyPage = ({
                 }
                 onAddPolicyClick={onAddPolicyClick}
                 onDeletePoliciesClick={onDeletePoliciesClick}
-                canAddOrRemovePolicy={canAddOrRemovePolicy}
+                canAddOrDeletePolicy={canAddOrDeletePolicy}
                 currentTeam={currentTeam}
                 currentAutomatedPolicies={currentAutomatedPolicies}
               />
@@ -443,7 +443,7 @@ const ManagePolicyPage = ({
                 isLoading={isFetchingGlobalPolicies || isFetchingConfig}
                 onAddPolicyClick={onAddPolicyClick}
                 onDeletePoliciesClick={onDeletePoliciesClick}
-                canAddOrRemovePolicy={canAddOrRemovePolicy}
+                canAddOrDeletePolicy={canAddOrDeletePolicy}
                 currentTeam={currentTeam}
                 currentAutomatedPolicies={currentAutomatedPolicies}
               />
@@ -480,7 +480,7 @@ const ManagePolicyPage = ({
                   policiesList={globalPolicies || []}
                   onDeletePoliciesClick={noop}
                   resultsTitle="policies"
-                  canAddOrRemovePolicy={canAddOrRemovePolicy}
+                  canAddOrDeletePolicy={canAddOrDeletePolicy}
                   tableType="inheritedPolicies"
                   currentTeam={currentTeam}
                 />
@@ -509,7 +509,7 @@ const ManagePolicyPage = ({
         )}
         {showDeletePoliciesModal && (
           <DeletePoliciesModal
-            isLoading={isRemovingPolicy}
+            isLoading={isDeletingPolicy}
             onCancel={toggleDeletePoliciesModal}
             onSubmit={onDeletePoliciesSubmit}
           />

--- a/frontend/pages/policies/ManagePoliciesPage/components/DeletePoliciesModal/DeletePoliciesModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/DeletePoliciesModal/DeletePoliciesModal.tsx
@@ -4,7 +4,7 @@ import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 import Spinner from "components/Spinner";
 
-const baseClass = "remove-policies-modal";
+const baseClass = "delete-policies-modal";
 
 interface IDeletePoliciesModalProps {
   isLoading: boolean;

--- a/frontend/pages/policies/ManagePoliciesPage/components/DeletePoliciesModal/DeletePoliciesModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/DeletePoliciesModal/DeletePoliciesModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
@@ -6,17 +6,17 @@ import Spinner from "components/Spinner";
 
 const baseClass = "remove-policies-modal";
 
-interface IRemovePoliciesModalProps {
+interface IDeletePoliciesModalProps {
   isLoading: boolean;
   onCancel: () => void;
   onSubmit: () => void;
 }
 
-const RemovePoliciesModal = ({
+const DeletePoliciesModal = ({
   isLoading,
   onCancel,
   onSubmit,
-}: IRemovePoliciesModalProps): JSX.Element => {
+}: IDeletePoliciesModalProps): JSX.Element => {
   return (
     <Modal
       title={"Delete policies"}
@@ -54,4 +54,4 @@ const RemovePoliciesModal = ({
   );
 };
 
-export default RemovePoliciesModal;
+export default DeletePoliciesModal;

--- a/frontend/pages/policies/ManagePoliciesPage/components/DeletePoliciesModal/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/DeletePoliciesModal/_styles.scss
@@ -1,4 +1,4 @@
-.remove-policies-modal {
+.delete-policies-modal {
   font-size: $x-small;
 
   &__btn-wrap {

--- a/frontend/pages/policies/ManagePoliciesPage/components/DeletePoliciesModal/index.ts
+++ b/frontend/pages/policies/ManagePoliciesPage/components/DeletePoliciesModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeletePoliciesModal";

--- a/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -166,11 +166,7 @@ const ManageAutomationsModal = ({
     );
   };
 
-  const onClickSave = (
-    evt: React.MouseEvent<HTMLFormElement> | KeyboardEvent
-  ) => {
-    evt.preventDefault();
-
+  const onSubmit = () => {
     const newPolicyIds: number[] = [];
     policyItems?.forEach((p) => p.isChecked && newPolicyIds.push(p.id));
 
@@ -249,19 +245,6 @@ const ManageAutomationsModal = ({
 
     setErrors(newErrors);
   };
-
-  useEffect(() => {
-    const listener = (event: KeyboardEvent) => {
-      if (event.code === "Enter" || event.code === "NumpadEnter") {
-        event.preventDefault();
-        onClickSave(event);
-      }
-    };
-    document.addEventListener("keydown", listener);
-    return () => {
-      document.removeEventListener("keydown", listener);
-    };
-  }, [onClickSave]);
 
   const renderWebhook = () => {
     return (
@@ -342,7 +325,12 @@ const ManageAutomationsModal = ({
   return showPreviewModal ? (
     renderPreview()
   ) : (
-    <Modal onExit={onExit} title={"Manage automations"} className={baseClass}>
+    <Modal
+      onExit={onExit}
+      onEnter={onSubmit}
+      title={"Manage automations"}
+      className={baseClass}
+    >
       <>
         {isAutomationsLoading ? (
           <Spinner />
@@ -446,7 +434,7 @@ const ManageAutomationsModal = ({
                 className={`${baseClass}__btn`}
                 type="submit"
                 variant="brand"
-                onClick={onClickSave}
+                onClick={onSubmit}
               >
                 Save
               </Button>

--- a/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -166,7 +166,9 @@ const ManageAutomationsModal = ({
     );
   };
 
-  const onSubmit = () => {
+  const onSubmit = (evt: React.MouseEvent<HTMLFormElement> | KeyboardEvent) => {
+    evt.preventDefault();
+
     const newPolicyIds: number[] = [];
     policyItems?.forEach((p) => p.isChecked && newPolicyIds.push(p.id));
 
@@ -245,6 +247,19 @@ const ManageAutomationsModal = ({
 
     setErrors(newErrors);
   };
+
+  useEffect(() => {
+    const listener = (event: KeyboardEvent) => {
+      if (event.code === "Enter" || event.code === "NumpadEnter") {
+        event.preventDefault();
+        onSubmit(event);
+      }
+    };
+    document.addEventListener("keydown", listener);
+    return () => {
+      document.removeEventListener("keydown", listener);
+    };
+  }, [onSubmit]);
 
   const renderWebhook = () => {
     return (
@@ -325,12 +340,7 @@ const ManageAutomationsModal = ({
   return showPreviewModal ? (
     renderPreview()
   ) : (
-    <Modal
-      onExit={onExit}
-      onEnter={onSubmit}
-      title={"Manage automations"}
-      className={baseClass}
-    >
+    <Modal onExit={onExit} title={"Manage automations"} className={baseClass}>
       <>
         {isAutomationsLoading ? (
           <Spinner />

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesListWrapper/PoliciesListWrapper.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesListWrapper/PoliciesListWrapper.tsx
@@ -25,7 +25,7 @@ interface IPoliciesListWrapperProps {
   policiesList: IPolicyStats[];
   isLoading: boolean;
   onAddPolicyClick?: () => void;
-  onRemovePoliciesClick: (selectedTableIds: number[]) => void;
+  onDeletePoliciesClick: (selectedTableIds: number[]) => void;
   resultsTitle?: string;
   canAddOrRemovePolicy?: boolean;
   tableType?: string;
@@ -37,7 +37,7 @@ const PoliciesListWrapper = ({
   policiesList,
   isLoading,
   onAddPolicyClick,
-  onRemovePoliciesClick,
+  onDeletePoliciesClick,
   resultsTitle,
   canAddOrRemovePolicy,
   tableType,
@@ -134,7 +134,7 @@ const PoliciesListWrapper = ({
           showMarkAllPages={false}
           isAllPagesSelected={false}
           disablePagination
-          onPrimarySelectActionClick={onRemovePoliciesClick}
+          onPrimarySelectActionClick={onDeletePoliciesClick}
           primarySelectActionButtonVariant="text-icon"
           primarySelectActionButtonIcon="delete"
           primarySelectActionButtonText={"Delete"}

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesListWrapper/PoliciesListWrapper.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesListWrapper/PoliciesListWrapper.tsx
@@ -27,7 +27,7 @@ interface IPoliciesListWrapperProps {
   onAddPolicyClick?: () => void;
   onDeletePoliciesClick: (selectedTableIds: number[]) => void;
   resultsTitle?: string;
-  canAddOrRemovePolicy?: boolean;
+  canAddOrDeletePolicy?: boolean;
   tableType?: string;
   currentTeam: ITeamSummary | undefined;
   currentAutomatedPolicies?: number[];
@@ -39,7 +39,7 @@ const PoliciesListWrapper = ({
   onAddPolicyClick,
   onDeletePoliciesClick,
   resultsTitle,
-  canAddOrRemovePolicy,
+  canAddOrDeletePolicy,
   tableType,
   currentTeam,
   currentAutomatedPolicies,
@@ -89,7 +89,7 @@ const PoliciesListWrapper = ({
                 changes.
               </p>
             </div>
-            {canAddOrRemovePolicy && (
+            {canAddOrDeletePolicy && (
               <div className={`${baseClass}__action-button-container`}>
                 <Button
                   variant="brand"
@@ -109,7 +109,7 @@ const PoliciesListWrapper = ({
   return (
     <div
       className={`${baseClass} ${
-        canAddOrRemovePolicy ? "" : "hide-selection-column"
+        canAddOrDeletePolicy ? "" : "hide-selection-column"
       }`}
     >
       {isLoading ? (
@@ -119,7 +119,7 @@ const PoliciesListWrapper = ({
           resultsTitle={resultsTitle || "policies"}
           columns={generateTableHeaders({
             selectedTeamId: currentTeam?.id,
-            canAddOrRemovePolicy,
+            canAddOrDeletePolicy,
             tableType,
           })}
           data={generateDataSet(

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesListWrapper/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesListWrapper/PoliciesTableConfig.tsx
@@ -94,10 +94,10 @@ const getTooltip = (osqueryPolicyMs: number): JSX.Element => {
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
 const generateTableHeaders = (options: {
   selectedTeamId: number | undefined | null;
-  canAddOrRemovePolicy: boolean | undefined;
+  canAddOrDeletePolicy: boolean | undefined;
   tableType: string | undefined;
 }): IDataColumn[] => {
-  const { selectedTeamId, tableType, canAddOrRemovePolicy } = options;
+  const { selectedTeamId, tableType, canAddOrDeletePolicy } = options;
 
   switch (tableType) {
     case "inheritedPolicies":
@@ -242,7 +242,7 @@ const generateTableHeaders = (options: {
         },
       ];
 
-      if (!canAddOrRemovePolicy) {
+      if (!canAddOrDeletePolicy) {
         return tableHeaders;
       }
 

--- a/frontend/pages/policies/ManagePoliciesPage/components/RemovePoliciesModal/RemovePoliciesModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/RemovePoliciesModal/RemovePoliciesModal.tsx
@@ -17,21 +17,13 @@ const RemovePoliciesModal = ({
   onCancel,
   onSubmit,
 }: IRemovePoliciesModalProps): JSX.Element => {
-  useEffect(() => {
-    const listener = (event: KeyboardEvent) => {
-      if (event.code === "Enter" || event.code === "NumpadEnter") {
-        event.preventDefault();
-        onSubmit();
-      }
-    };
-    document.addEventListener("keydown", listener);
-    return () => {
-      document.removeEventListener("keydown", listener);
-    };
-  }, []);
-
   return (
-    <Modal title={"Delete policies"} onExit={onCancel} className={baseClass}>
+    <Modal
+      title={"Delete policies"}
+      onExit={onCancel}
+      onEnter={onSubmit}
+      className={baseClass}
+    >
       <>
         {isLoading ? (
           <Spinner />

--- a/frontend/pages/policies/ManagePoliciesPage/components/RemovePoliciesModal/index.ts
+++ b/frontend/pages/policies/ManagePoliciesPage/components/RemovePoliciesModal/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./RemovePoliciesModal";

--- a/frontend/pages/policies/PolicyPage/components/PolicyQueriesErrorsListWrapper/PolicyQueriesErrorsListWrapper.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyQueriesErrorsListWrapper/PolicyQueriesErrorsListWrapper.tsx
@@ -15,14 +15,14 @@ interface IPoliciesListWrapperProps {
   errorsList: ICampaignError[];
   isLoading: boolean;
   resultsTitle?: string;
-  canAddOrRemovePolicy?: boolean;
+  canAddOrDeletePolicy?: boolean;
 }
 
 const PoliciesListWrapper = ({
   errorsList,
   isLoading,
   resultsTitle,
-  canAddOrRemovePolicy,
+  canAddOrDeletePolicy,
 }: IPoliciesListWrapperProps): JSX.Element => {
   const NoPolicyQueries = () => {
     return (
@@ -35,7 +35,7 @@ const PoliciesListWrapper = ({
   return (
     <div
       className={`${baseClass} ${
-        canAddOrRemovePolicy ? "" : "hide-selection-column"
+        canAddOrDeletePolicy ? "" : "hide-selection-column"
       }`}
     >
       <TableContainer

--- a/frontend/pages/policies/PolicyPage/components/PolicyQueriesListWrapper/PolicyQueriesListWrapper.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyQueriesListWrapper/PolicyQueriesListWrapper.tsx
@@ -15,14 +15,14 @@ interface IPoliciesListWrapperProps {
   policyHostsList: IHostPolicyQuery[];
   isLoading: boolean;
   resultsTitle?: string;
-  canAddOrRemovePolicy?: boolean;
+  canAddOrDeletePolicy?: boolean;
 }
 
 const PoliciesListWrapper = ({
   policyHostsList,
   isLoading,
   resultsTitle,
-  canAddOrRemovePolicy,
+  canAddOrDeletePolicy,
 }: IPoliciesListWrapperProps): JSX.Element => {
   const NoPolicyQueries = () => {
     return (
@@ -35,7 +35,7 @@ const PoliciesListWrapper = ({
   return (
     <div
       className={`${baseClass} ${
-        canAddOrRemovePolicy ? "" : "hide-selection-column"
+        canAddOrDeletePolicy ? "" : "hide-selection-column"
       }`}
     >
       <TableContainer

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -25,7 +25,7 @@ import Spinner from "components/Spinner";
 import TableDataError from "components/DataError";
 import MainContent from "components/MainContent";
 import QueriesListWrapper from "./components/QueriesListWrapper";
-import RemoveQueryModal from "./components/RemoveQueryModal";
+import DeleteQueryModal from "./components/DeleteQueryModal";
 
 const baseClass = "manage-queries-page";
 interface IManageQueriesPageProps {
@@ -97,7 +97,7 @@ const ManageQueriesPage = ({
     "all"
   );
   const [selectedQueryIds, setSelectedQueryIds] = useState<number[]>([]);
-  const [showRemoveQueryModal, setShowRemoveQueryModal] = useState<boolean>(
+  const [showDeleteQueryModal, setShowDeleteQueryModal] = useState<boolean>(
     false
   );
   const [queryIsRemoving, setQueryIsRemoving] = useState<boolean>(false);
@@ -133,26 +133,26 @@ const ManageQueriesPage = ({
 
   const onCreateQueryClick = () => router.push(PATHS.NEW_QUERY);
 
-  const toggleRemoveQueryModal = useCallback(() => {
-    setShowRemoveQueryModal(!showRemoveQueryModal);
-  }, [showRemoveQueryModal, setShowRemoveQueryModal]);
+  const toggleDeleteQueryModal = useCallback(() => {
+    setShowDeleteQueryModal(!showDeleteQueryModal);
+  }, [showDeleteQueryModal, setShowDeleteQueryModal]);
 
-  const onRemoveQueryClick = (selectedTableQueryIds: number[]) => {
-    toggleRemoveQueryModal();
+  const onDeleteQueryClick = (selectedTableQueryIds: number[]) => {
+    toggleDeleteQueryModal();
     setSelectedQueryIds(selectedTableQueryIds);
   };
 
-  const onRemoveQuerySubmit = useCallback(async () => {
+  const onDeleteQuerySubmit = useCallback(async () => {
     const queryOrQueries = selectedQueryIds.length === 1 ? "query" : "queries";
 
     setQueryIsRemoving(true);
 
-    const removeQueries = selectedQueryIds.map((id) =>
+    const deleteQueries = selectedQueryIds.map((id) =>
       fleetQueriesAPI.destroy(id)
     );
 
     try {
-      await Promise.all(removeQueries).then(() => {
+      await Promise.all(deleteQueries).then(() => {
         renderFlash("success", `Successfully removed ${queryOrQueries}.`);
         setResetSelectedRows(true);
         refetchFleetQueries();
@@ -164,10 +164,10 @@ const ManageQueriesPage = ({
         `There was an error removing your ${queryOrQueries}. Please try again later.`
       );
     } finally {
-      toggleRemoveQueryModal();
+      toggleDeleteQueryModal();
       setQueryIsRemoving(false);
     }
-  }, [refetchFleetQueries, selectedQueryIds, toggleRemoveQueryModal]);
+  }, [refetchFleetQueries, selectedQueryIds, toggleDeleteQueryModal]);
 
   const renderPlatformDropdown = () => {
     return (
@@ -218,7 +218,7 @@ const ManageQueriesPage = ({
               queriesList={queriesList}
               isLoading={isTableDataLoading}
               onCreateQueryClick={onCreateQueryClick}
-              onRemoveQueryClick={onRemoveQueryClick}
+              onDeleteQueryClick={onDeleteQueryClick}
               searchable={!!queriesList}
               customControl={renderPlatformDropdown}
               selectedDropdownFilter={selectedDropdownFilter}
@@ -226,11 +226,11 @@ const ManageQueriesPage = ({
             />
           )}
         </div>
-        {showRemoveQueryModal && (
-          <RemoveQueryModal
+        {showDeleteQueryModal && (
+          <DeleteQueryModal
             isLoading={queryIsRemoving}
-            onCancel={toggleRemoveQueryModal}
-            onSubmit={onRemoveQuerySubmit}
+            onCancel={toggleDeleteQueryModal}
+            onSubmit={onDeleteQuerySubmit}
           />
         )}
       </div>

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -100,7 +100,7 @@ const ManageQueriesPage = ({
   const [showDeleteQueryModal, setShowDeleteQueryModal] = useState<boolean>(
     false
   );
-  const [queryIsRemoving, setQueryIsRemoving] = useState<boolean>(false);
+  const [queryIsDeleting, setQueryIsDeleting] = useState<boolean>(false);
 
   const {
     data: fleetQueries,
@@ -145,7 +145,7 @@ const ManageQueriesPage = ({
   const onDeleteQuerySubmit = useCallback(async () => {
     const queryOrQueries = selectedQueryIds.length === 1 ? "query" : "queries";
 
-    setQueryIsRemoving(true);
+    setQueryIsDeleting(true);
 
     const deleteQueries = selectedQueryIds.map((id) =>
       fleetQueriesAPI.destroy(id)
@@ -153,19 +153,19 @@ const ManageQueriesPage = ({
 
     try {
       await Promise.all(deleteQueries).then(() => {
-        renderFlash("success", `Successfully removed ${queryOrQueries}.`);
+        renderFlash("success", `Successfully deleted ${queryOrQueries}.`);
         setResetSelectedRows(true);
         refetchFleetQueries();
       });
-      renderFlash("success", `Successfully removed ${queryOrQueries}.`);
+      renderFlash("success", `Successfully deleted ${queryOrQueries}.`);
     } catch (errorResponse) {
       renderFlash(
         "error",
-        `There was an error removing your ${queryOrQueries}. Please try again later.`
+        `There was an error deleting your ${queryOrQueries}. Please try again later.`
       );
     } finally {
       toggleDeleteQueryModal();
-      setQueryIsRemoving(false);
+      setQueryIsDeleting(false);
     }
   }, [refetchFleetQueries, selectedQueryIds, toggleDeleteQueryModal]);
 
@@ -228,7 +228,7 @@ const ManageQueriesPage = ({
         </div>
         {showDeleteQueryModal && (
           <DeleteQueryModal
-            isLoading={queryIsRemoving}
+            isLoading={queryIsDeleting}
             onCancel={toggleDeleteQueryModal}
             onSubmit={onDeleteQuerySubmit}
           />

--- a/frontend/pages/queries/ManageQueriesPage/components/DeleteQueryModal/DeleteQueryModal.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/DeleteQueryModal/DeleteQueryModal.tsx
@@ -1,22 +1,22 @@
-import React, { useEffect } from "react";
+import React from "react";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 import Spinner from "components/Spinner";
 
-const baseClass = "remove-query-modal";
+const baseClass = "delete-query-modal";
 
-interface IRemoveQueryModalProps {
+interface IDeleteQueryModalProps {
   isLoading: boolean;
   onCancel: () => void;
   onSubmit: () => void;
 }
 
-const RemoveQueryModal = ({
+const DeleteQueryModal = ({
   isLoading,
   onCancel,
   onSubmit,
-}: IRemoveQueryModalProps): JSX.Element => {
+}: IDeleteQueryModalProps): JSX.Element => {
   return (
     <Modal
       title={"Delete query"}
@@ -45,4 +45,4 @@ const RemoveQueryModal = ({
   );
 };
 
-export default RemoveQueryModal;
+export default DeleteQueryModal;

--- a/frontend/pages/queries/ManageQueriesPage/components/DeleteQueryModal/index.ts
+++ b/frontend/pages/queries/ManageQueriesPage/components/DeleteQueryModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeleteQueryModal";

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesListWrapper.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesListWrapper/QueriesListWrapper.tsx
@@ -20,7 +20,7 @@ interface IQueryTableData extends IQuery {
 interface IQueriesListWrapperProps {
   queriesList: IQueryTableData[] | null;
   isLoading: boolean;
-  onRemoveQueryClick: (selectedTableQueryIds: number[]) => void;
+  onDeleteQueryClick: (selectedTableQueryIds: number[]) => void;
   onCreateQueryClick: () => void;
   searchable: boolean;
   customControl?: () => JSX.Element;
@@ -31,7 +31,7 @@ interface IQueriesListWrapperProps {
 const QueriesListWrapper = ({
   queriesList,
   isLoading,
-  onRemoveQueryClick,
+  onDeleteQueryClick,
   onCreateQueryClick,
   searchable,
   customControl,
@@ -124,7 +124,7 @@ const QueriesListWrapper = ({
         inputPlaceHolder="Search by name"
         searchable={searchable}
         disablePagination
-        onPrimarySelectActionClick={onRemoveQueryClick}
+        onPrimarySelectActionClick={onDeleteQueryClick}
         primarySelectActionButtonVariant="text-icon"
         primarySelectActionButtonIcon="delete"
         primarySelectActionButtonText={"Delete"}

--- a/frontend/pages/queries/ManageQueriesPage/components/RemoveQueryModal/RemoveQueryModal.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/RemoveQueryModal/RemoveQueryModal.tsx
@@ -17,21 +17,13 @@ const RemoveQueryModal = ({
   onCancel,
   onSubmit,
 }: IRemoveQueryModalProps): JSX.Element => {
-  useEffect(() => {
-    const listener = (event: KeyboardEvent) => {
-      if (event.code === "Enter" || event.code === "NumpadEnter") {
-        event.preventDefault();
-        onSubmit();
-      }
-    };
-    document.addEventListener("keydown", listener);
-    return () => {
-      document.removeEventListener("keydown", listener);
-    };
-  }, []);
-
   return (
-    <Modal title={"Delete query"} onExit={onCancel} className={baseClass}>
+    <Modal
+      title={"Delete query"}
+      onExit={onCancel}
+      onEnter={onSubmit}
+      className={baseClass}
+    >
       <>
         {isLoading ? (
           <Spinner />

--- a/frontend/pages/queries/ManageQueriesPage/components/RemoveQueryModal/index.ts
+++ b/frontend/pages/queries/ManageQueriesPage/components/RemoveQueryModal/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./RemoveQueryModal";

--- a/frontend/pages/schedule/ManageSchedulePage/components/RemoveScheduledQueryModal/RemoveScheduledQueryModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/RemoveScheduledQueryModal/RemoveScheduledQueryModal.tsx
@@ -17,23 +17,11 @@ const RemoveScheduledQueryModal = ({
   onCancel,
   onSubmit,
 }: IRemoveScheduledQueryModalProps): JSX.Element => {
-  useEffect(() => {
-    const listener = (event: KeyboardEvent) => {
-      if (event.code === "Enter" || event.code === "NumpadEnter") {
-        event.preventDefault();
-        onSubmit();
-      }
-    };
-    document.addEventListener("keydown", listener);
-    return () => {
-      document.removeEventListener("keydown", listener);
-    };
-  }, []);
-
   return (
     <Modal
       title={"Remove scheduled query"}
       onExit={onCancel}
+      onEnter={onSubmit}
       className={baseClass}
     >
       {isLoading ? (

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
@@ -223,19 +223,6 @@ const ScheduleEditorModal = ({
     );
   };
 
-  useEffect(() => {
-    const listener = (event: KeyboardEvent) => {
-      if (event.code === "Enter" || event.code === "NumpadEnter") {
-        event.preventDefault();
-        onFormSubmit();
-      }
-    };
-    document.addEventListener("keydown", listener);
-    return () => {
-      document.removeEventListener("keydown", listener);
-    };
-  }, [onFormSubmit]);
-
   if (showPreviewDataModal) {
     return <PreviewDataModal onCancel={togglePreviewDataModal} />;
   }
@@ -244,6 +231,7 @@ const ScheduleEditorModal = ({
     <Modal
       title={editQuery?.query_name || "Schedule editor"}
       onExit={onClose}
+      onEnter={onFormSubmit}
       className={baseClass}
     >
       {isLoading ? (


### PR DESCRIPTION
Cerra #6910 

**Fix**
- Add `onEnter` prop to `Modal` component so we don't have to repeat a bunch of event listener code 

**Modals refactored clearing repetitive code**
- Delete secret > deletes
- Enroll secrets overview modal > closes modal
- Delete integration > deletes
- Remove team member > removes
- Delete team > deletes
- Delete host > deletes
- Delete label > deletes
- Remove pack query > deletes
- Delete pack > deletes
- Delete policy > removes
- Delete query > removes
- Remove scheduled query > removes 
- Schedule editor > saves

**Modals fixed where enter key did nothing and now it works**
- Edit secret > saves
- Get API Token > closes modal
- Reset password > resets
- Reset sessions > resets
- Welcome host policy modal > closes

**Other**
- Fix manage automation naming convention (onClickSave to onSubmit) to match rest of app
- Cannot use for manage automations modals because they conditionally disable save button
- Fix RemoveQueryModal to DeleteQueryModal (Pattern: Frontend naming convention matches UI naming convention for remove vs. delete)
- Fix RemovePackModal to DeletePackModal (Pattern: Frontend naming convention matches UI naming convention for remove vs. delete)
- Fix RemovePoliciesModal to DeletePoliciesModal (Pattern: Frontend naming convention matches UI naming convention for remove vs. delete)

Final screenshots of component names matching UI wording (Delete vs. Remove)
<img width="406" alt="Screen Shot 2022-07-29 at 4 43 01 PM" src="https://user-images.githubusercontent.com/71795832/181840963-3cf36883-dfb5-418c-9e9d-97d420220a58.png">
<img width="386" alt="Screen Shot 2022-07-29 at 4 42 38 PM" src="https://user-images.githubusercontent.com/71795832/181840964-104ffb2f-c6ca-4218-8355-5e8045dc6f65.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
