### PR TITLE
Fleet UI: Sentence casing, typo

### DIFF
--- a/changes/issue-6940-sentence-case
+++ b/changes/issue-6940-sentence-case
@@ -1,0 +1,1 @@
+* Fix sentence casing in Fleet UI

--- a/frontend/components/forms/fields/Dropdown/Dropdown.jsx
+++ b/frontend/components/forms/fields/Dropdown/Dropdown.jsx
@@ -44,7 +44,7 @@ class Dropdown extends Component {
     disabled: false,
     multi: false,
     name: "targets",
-    placeholder: "Select One...",
+    placeholder: "Select one...",
     parseTarget: false,
     tooltip: "",
   };

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -199,7 +199,7 @@ export const LOGGING_TYPE_OPTIONS = [
   { label: "Snapshot", value: "snapshot" },
   { label: "Differential", value: "differential" },
   {
-    label: "Differential (Ignore Removals)",
+    label: "Differential (ignore removals)",
     value: "differential_ignore_removals",
   },
 ];
@@ -382,7 +382,7 @@ export const VULNERABLE_DROPDOWN_OPTIONS = [
     disabled: false,
     label: "All software",
     value: false,
-    helpText: "All sofware installed on your hosts.",
+    helpText: "All software installed on your hosts.",
   },
   {
     disabled: false,


### PR DESCRIPTION
Cerra #6940 

**Fix**
- 2 sentence casing
- 1 typo

<img width="434" alt="Screen Shot 2022-07-28 at 11 46 58 AM" src="https://user-images.githubusercontent.com/71795832/181581445-5b715bae-2446-47ba-bf3c-857118d2e706.png">
<img width="790" alt="Screen Shot 2022-07-28 at 11 46 27 AM" src="https://user-images.githubusercontent.com/71795832/181581448-9ade316e-f496-42d6-b30f-04adc85e70a6.png">
<img width="1185" alt="Screen Shot 2022-07-28 at 11 45 59 AM" src="https://user-images.githubusercontent.com/71795832/181581452-96cc810a-9e3c-4ff7-bfd3-98f7a264440b.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
