### PR TITLE
Fleet UI: Welcome to Fleet and Learn Fleet render conditionally for roles (excluded on teams)

### DIFF
--- a/changes/issue-6956-welcome-to-fleet-card
+++ b/changes/issue-6956-welcome-to-fleet-card
@@ -1,0 +1,1 @@
+* Welcome to Fleet and Learn Fleet card only shows on All teams for users that have permission to enroll hosts

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -294,12 +294,15 @@ const Homepage = (): JSX.Element => {
 
   const allLayout = () => (
     <div className={`${baseClass}__section`}>
-      {hostSummaryData && hostSummaryData?.totals_hosts_count < 2 && (
-        <>
-          {WelcomeHostCard}
-          {LearnFleetCard}
-        </>
-      )}
+      {!currentTeam &&
+        canEnrollGlobalHosts &&
+        hostSummaryData &&
+        hostSummaryData?.totals_hosts_count < 2 && (
+          <>
+            {WelcomeHostCard}
+            {LearnFleetCard}
+          </>
+        )}
       {SoftwareCard}
       {!currentTeam && isOnGlobalTeam && <>{ActivityFeedCard}</>}
     </div>


### PR DESCRIPTION
Cerra #6956 

**Fix**
- Welcome to Fleet and Learn Fleet card only render for global dashboard
- Welcome to Fleet and Learn Fleet card only render if user has permission to enroll hosts globally

Note: Future consideration for Product to spec different card copy for Team view and/or users with roles who cannot enroll host

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
