### PR TITLE
Fleet UI: Welcome to Fleet and Learn Fleet render conditionally for roles (included on teams)

### DIFF
--- a/changes/issue-6956-welcome-to-fleet-card
+++ b/changes/issue-6956-welcome-to-fleet-card
@@ -1,0 +1,1 @@
+* Welcome to Fleet and Learn Fleet card only shows on All teams for users that have permission to enroll hosts

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -137,6 +137,24 @@ const Homepage = (): JSX.Element => {
     }
   );
 
+  const {
+    isLoading: isTeamSecretsLoading,
+    data: teamSecrets,
+    refetch: refetchTeamSecrets,
+  } = useQuery<IEnrollSecretsResponse, Error, IEnrollSecret[]>(
+    ["team secrets", currentTeam],
+    () => {
+      if (currentTeam) {
+        return enrollSecretsAPI.getTeamEnrollSecrets(currentTeam.id);
+      }
+      return { secrets: [] };
+    },
+    {
+      enabled: !!currentTeam?.id && !!canEnrollHosts,
+      select: (data: IEnrollSecretsResponse) => data.secrets,
+    }
+  );
+
   const handleTeamSelect = (teamId: number) => {
     const selectedTeam = find(teams, ["id", teamId]);
     setCurrentTeam(selectedTeam);
@@ -292,21 +310,22 @@ const Homepage = (): JSX.Element => {
     ),
   });
 
-  const allLayout = () => (
-    <div className={`${baseClass}__section`}>
-      {!currentTeam &&
-        canEnrollGlobalHosts &&
-        hostSummaryData &&
-        hostSummaryData?.totals_hosts_count < 2 && (
-          <>
-            {WelcomeHostCard}
-            {LearnFleetCard}
-          </>
-        )}
-      {SoftwareCard}
-      {!currentTeam && isOnGlobalTeam && <>{ActivityFeedCard}</>}
-    </div>
-  );
+  const allLayout = () => {
+    return (
+      <div className={`${baseClass}__section`}>
+        {canEnrollHosts &&
+          hostSummaryData &&
+          hostSummaryData?.totals_hosts_count < 2 && (
+            <>
+              {WelcomeHostCard}
+              {LearnFleetCard}
+            </>
+          )}
+        {SoftwareCard}
+        {!currentTeam && isOnGlobalTeam && <>{ActivityFeedCard}</>}
+      </div>
+    );
+  };
 
   const macOSLayout = () => (
     <div className={`${baseClass}__section`}>
@@ -333,7 +352,15 @@ const Homepage = (): JSX.Element => {
   };
 
   const renderAddHostsModal = () => {
-    const enrollSecret = globalSecrets?.[0].secret;
+    const enrollSecret =
+      // TODO: Currently, prepacked installers in Fleet Sandbox use the global enroll secret,
+      // and Fleet Sandbox runs Fleet Free so the isSandboxMode check here is an
+      // additional precaution/reminder to revisit this in connection with future changes.
+      // See https://github.com/fleetdm/fleet/issues/4970#issuecomment-1187679407.
+      currentTeam && !isSandboxMode
+        ? teamSecrets?.[0].secret
+        : globalSecrets?.[0].secret;
+
     return (
       <AddHostsModal
         currentTeam={currentTeam}

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -294,12 +294,15 @@ const Homepage = (): JSX.Element => {
 
   const allLayout = () => (
     <div className={`${baseClass}__section`}>
-      {hostSummaryData && hostSummaryData?.totals_hosts_count < 2 && (
-        <>
-          {WelcomeHostCard}
-          {LearnFleetCard}
-        </>
-      )}
+      {!currentTeam &&
+        canEnrollGlobalHosts &&
+        hostSummaryData &&
+        hostSummaryData?.totals_hosts_count < 2 && (
+          <>
+            {WelcomeHostCard}
+            {LearnFleetCard}
+          </>
+        )}
       {SoftwareCard}
       {!currentTeam && isOnGlobalTeam && <>{ActivityFeedCard}</>}
     </div>


### PR DESCRIPTION
Alternative fix for  Cerra #6956 

**Fix**
- Welcome to Fleet and Learn Fleet card renders team secrets for add host on team dashboard
- Welcome to Fleet and Learn Fleet card only render if user has permission to enroll hosts (globally or on a team)

Note: Future consideration for Product to spec different card copy for Team view and/or users with roles who cannot enroll host

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
