### PR TITLE
Website: Conditionally show swag CTA

### DIFF
--- a/website/api/controllers/docs/view-basic-documentation.js
+++ b/website/api/controllers/docs/view-basic-documentation.js
@@ -56,8 +56,8 @@ module.exports = {
     }
 
     let showSwagForm = false;
-    // Check the requesting user's cf-ipcountry to see if they're in the US, and their cf-iplongitude header to see if they're in the contiguous US.
-    if(this.req.headers['cf-ipcountry'] === 'US' && this.req.headers['cf-iplongitude'] > -125) {
+    // Due to shipping costs, we'll check the requesting user's cf-ipcountry to see if they're in the US, and their cf-iplongitude header to see if they're in the contiguous US.
+    if(this.req.get('cf-ipcountry') === 'US' && this.req.get('cf-iplongitude') > -125) {
       showSwagForm = true;
     }
 

--- a/website/api/controllers/docs/view-basic-documentation.js
+++ b/website/api/controllers/docs/view-basic-documentation.js
@@ -57,7 +57,7 @@ module.exports = {
 
     let showSwagForm = false;
     // Check the cf-ipcountry header
-    if(this.req.headers['cf-ipcountry'] === 'US') {
+    if(this.req.headers['cf-ipcountry'] === 'US' && this.req.headers['cf-iplongitude'] > -125) {
       showSwagForm = true;
     }
 

--- a/website/api/controllers/docs/view-basic-documentation.js
+++ b/website/api/controllers/docs/view-basic-documentation.js
@@ -55,6 +55,12 @@ module.exports = {
       }
     }
 
+    let showSwagForm = false;
+    // Check the cf-ipcountry header
+    if(this.req.headers['cf-ipcountry'] === 'US') {
+      showSwagForm = true;
+    }
+
     // Respond with view.
     return {
       path: require('path'),
@@ -69,6 +75,7 @@ module.exports = {
         thisPage.meta.description ? thisPage.meta.description // « custom meta description for this page, if provided in markdown
         : 'Documentation for Fleet for osquery.'// « otherwise use the generic description
       ),
+      showSwagForm
     };
 
   }

--- a/website/api/controllers/docs/view-basic-documentation.js
+++ b/website/api/controllers/docs/view-basic-documentation.js
@@ -56,7 +56,7 @@ module.exports = {
     }
 
     let showSwagForm = false;
-    // Check the cf-ipcountry header
+    // Check the requesting user's cf-ipcountry to see if they're in the US, and their cf-iplongitude header to see if they're in the contiguous US.
     if(this.req.headers['cf-ipcountry'] === 'US' && this.req.headers['cf-iplongitude'] > -125) {
       showSwagForm = true;
     }

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -183,7 +183,7 @@
               </li>
             </ul>
           </div>
-          <div class="d-none d-lg-block" purpose="swag-cta">
+          <div class="d-none d-lg-block" purpose="swag-cta" v-if="showSwagForm">
             <a class="d-flex flex-column align-items-center justify-content-center" href="https://kqphpqst851.typeform.com/to/ZfA3sOu0" target="_blank">
               <img style="height: auto; width: 54px; margin-right: 5px;" alt="A very nice Fleet branded shirt" src="/images/fleet-shirt-60x55@2x.png">
               <p class="mb-0"><strong>Request Fleet swag</strong></p>


### PR DESCRIPTION
closes: https://github.com/fleetdm/confidential/issues/1514
Changes:
- Added a check to see if users are in the contiguous united states before showing the Fleet swag request form on docs pages using headers that Cloudflare adds to incoming requests.


This check uses the `cf-ipcountry` header to check if users are in the US, and the `cf-longitude` header to check if users are in the contiguous US

https://developers.cloudflare.com/rules/transform/managed-transforms/reference/ 