### PR TITLE
Dashboard UI: Only show welcome cards for global view

### DIFF
--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -313,7 +313,8 @@ const Homepage = (): JSX.Element => {
   const allLayout = () => {
     return (
       <div className={`${baseClass}__section`}>
-        {canEnrollHosts &&
+        {!currentTeam &&
+          canEnrollGlobalHosts &&
           hostSummaryData &&
           hostSummaryData?.totals_hosts_count < 2 && (
             <>


### PR DESCRIPTION
- Only show welcome cards for global view

TLDR: This is the interim solution because showing welcome to fleet card for team view #6966  is blocked by #6970 
In order to show Welcome Fleet card, we would need to grab the single host ID on that team. There's no quick way to do so because the API doesn't return it and daisy chaining APIs to get it ends up with a sticky solution that causes more bugs when changing teams in the team dropdown.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
