### PR TITLE
Fleet UI: Remove all retries for Welcome to Fleet host

### DIFF
--- a/changes/issue-6965-no-retry-host-homepage
+++ b/changes/issue-6965-no-retry-host-homepage
@@ -1,0 +1,1 @@
+* Removes retries for API request for host on Welcome to Fleet card

--- a/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
@@ -57,6 +57,7 @@ const WelcomeHost = ({
     ["host"],
     () => hostAPI.loadHostDetails(HOST_ID),
     {
+      retry: false,
       select: (data: IHostResponse) => data.host,
       onSuccess: (returnedHost) => {
         setShowRefetchLoadingSpinner(returnedHost.refetch_requested);


### PR DESCRIPTION
Cerra #6965 

- Shows the user the host error message sooner by overriding useQuery's default 3 retries

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
