### PR TITLE
Set CORS headers for sandbox expiry request

### DIFF
--- a/frontend/services/entities/config.ts
+++ b/frontend/services/entities/config.ts
@@ -56,7 +56,9 @@ export default {
         params: { id: instanceId },
         responseType: "json",
         headers: {
-          Authorization: `Bearer ${token}`,
+          "Access-Control-Request-Method": "GET",
+          "Access-Control-Request-Headers": "content-type",
+          Origin: `https://'${instanceId}.sandbox.fleetdm.com`,
         },
       });
       return data.timestamp;

--- a/frontend/services/entities/config.ts
+++ b/frontend/services/entities/config.ts
@@ -58,7 +58,7 @@ export default {
         headers: {
           "Access-Control-Request-Method": "GET",
           "Access-Control-Request-Headers": "content-type",
-          Origin: `https://'${instanceId}.sandbox.fleetdm.com`,
+          Origin: `https://${instanceId}.sandbox.fleetdm.com`,
         },
       });
       return data.timestamp;


### PR DESCRIPTION
For #5723 

Worked with infra to define the headers the API is expecting to receive. Tested locally with a live sandbox instance id.
