### PR TITLE
Bot: Fix GitHub API integration for adding "#handbook" label

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -254,8 +254,8 @@ module.exports = {
         // Add the #handbook label to PRs that only make changes to the handbook.
         if(isHandbookPR) {
           // [?] https://docs.github.com/en/rest/issues/labels#add-labels-to-an-issue
-          await sails.helpers.http.post(`https://api.github.com/repos/${owner}/${repo}/issue/${prNumber}/labels`, {
-            labels: '#handbook'
+          await sails.helpers.http.post(`https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/labels`, {
+            labels: ['#handbook']
           }, baseHeaders);
         }
 


### PR DESCRIPTION
Closes https://github.com/fleetdm/confidential/issues/1574

This is a follow-up to fix a couple of issues introduced in https://github.com/fleetdm/fleet/pull/6967
