### PR TITLE
Stop the previous desktop agent when updating on macOS. Fixes #6441

### DIFF
--- a/changes/issue-6441-kill-old-desktop-when-installing
+++ b/changes/issue-6441-kill-old-desktop-when-installing
@@ -1,0 +1,1 @@
+* Stop the old version of Fleet desktop before starting a new version.

--- a/orbit/pkg/packaging/macos_templates.go
+++ b/orbit/pkg/packaging/macos_templates.go
@@ -55,6 +55,8 @@ ln -sf /opt/orbit /var/lib/orbit
 DAEMON_LABEL="com.fleetdm.orbit"
 DAEMON_PLIST="/Library/LaunchDaemons/${DAEMON_LABEL}.plist"
 
+# Stop the previous desktop agent
+pkill fleet-desktop || true
 # Remove any pre-existing version of the config
 launchctl bootout "system/${DAEMON_LABEL}"
 # Add the daemon to the launchd system


### PR DESCRIPTION
# Checklist for submitter

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality


Currently some users are getting two Fleet desktop icons on their macs. This will kill fleet-desktop in the postinstall script so that two instances are never running at the same time.