### PR TITLE
Website: pricing update

### DIFF
--- a/website/api/controllers/customers/create-quote.js
+++ b/website/api/controllers/customers/create-quote.js
@@ -25,7 +25,7 @@ module.exports = {
   fn: async function ({ numberOfHosts }) {
 
     // Determine the price, 1 dollar * host * month (Billed anually)
-    let price = 1.00 * numberOfHosts * 12;
+    let price = 2.00 * numberOfHosts * 12;
 
     let quote = await Quote.create({
       numberOfHosts: numberOfHosts,

--- a/website/api/controllers/customers/save-billing-info-and-subscribe.js
+++ b/website/api/controllers/customers/save-billing-info-and-subscribe.js
@@ -89,7 +89,7 @@ module.exports = {
       customer: this.req.me.stripeCustomerId,
       items: [
         {
-          price: sails.config.custom.stripeSubscriptionProduct,
+          price: sails.config.custom.stripeSubscriptionPriceId,
           quantity: quoteRecord.numberOfHosts,
         },
       ],

--- a/website/views/pages/customers/new-license.ejs
+++ b/website/views/pages/customers/new-license.ejs
@@ -18,7 +18,7 @@
 
               <div style="color: #515774;" class="order-last text-left text-sm-right col-12 col-sm-6 pr-0 pl-sm-4 pl-0 pt-sm-4">
                 <p class="small">
-                  <strong class="pr-1" style="font-size: 18px; color: #192147">$1.00</strong>/month/device<br>(Billed annually at $12/device)
+                  <strong class="pr-1" style="font-size: 18px; color: #192147">$2.00</strong>/month/device<br>(Billed annually at $24/device)
                 </p>
               </div>
 
@@ -29,7 +29,7 @@
                 <strong>Order total</strong>
               </div>
               <div class="ml-auto">
-                <strong>${{(!showQuotedPrice || _.isNaN(formData.numberOfHosts * 12)) ? quotedPrice : formData.numberOfHosts * 12}}.00 /year</strong>
+                <strong>${{(!showQuotedPrice || _.isNaN(formData.numberOfHosts * 24)) ? quotedPrice : formData.numberOfHosts * 24}}.00 /year</strong>
               </div>
             </div>
             <div  :class="[showBillingForm ? 'pt-2' : '' ]" v-if="!showBillingForm">

--- a/website/views/pages/pricing.ejs
+++ b/website/views/pages/pricing.ejs
@@ -78,10 +78,10 @@
                     <p class="font-weight-bold mb-0">
                       Premium
                     </p>
-                    <h2 style="color: #6b6cfa">$1</h2>
+                    <h2 style="color: #6b6cfa">$2</h2>
                     <p class="mb-0">/host/month</p>
                     <p style="color: #8f8ea1; font-size: 13px" class="mb-0">
-                      (USD, billed annually at $12)
+                      (USD, billed annually at $24)
                     </p>
                   </div>
                   <a


### PR DESCRIPTION
Changes:
- Updated the price of Fleet Premium on the pricing page and license dispenser
- Renamed the `stripeSubscriptionProduct` variable to be `stripeSubscriptionPriceId` to be clear that the value is the ID of a price of a subscription in stripe. The updated variable has been added to Heroku.

cc: @alexmitchelliii 