### PR TITLE
Website: Update invalid custom title error

### DIFF
--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -350,7 +350,7 @@ module.exports = {
               let pageTitle;
               if (embeddedMetadata.title) {// Attempt to use custom title, if one was provided.
                 if (embeddedMetadata.title.length > 40) {
-                  throw new Error(`Failed compiling markdown content: Invalid custom title (<meta name="title" value="${embeddedMetadata.title}">) embedded in "${path.join(topLvlRepoPath, sectionRepoPath)}".  To resolve, try changing the title to a different, valid value, then rebuild.`);
+                  throw new Error(`Failed compiling markdown content: Invalid custom title (<meta name="title" value="${embeddedMetadata.title}">) embedded in "${path.join(topLvlRepoPath, sectionRepoPath)}".  To resolve, try changing the title to a shorter (less than 40 characters), valid value, then rebuild.`);
                 }//•
                 pageTitle = embeddedMetadata.title;
               } else {// Otherwise use the automatically-determined fallback title.


### PR DESCRIPTION
@mike-j-thomas ran into this error with https://github.com/fleetdm/fleet/pull/6936, and it was unclear why the error was being thrown.

Changes: 
- Updated the error for invalid title meta tags to be clear about why the error is being thrown