### PR TITLE
Add --skipGithubRequests option to build-static-content

### DIFF
--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -95,9 +95,10 @@ module.exports = {
         }, []);
 
         let githubDataByUsername = {};
+
         if(local) {// If the local flag was provided, we'll skip querying GitHubs API
           sails.log('Local run: Skipping GitHub API requests for contributer profiles.\nNOTE: The names of contributors in the standard query library will be set to the contributors GitHub username instead of the name on their profile. To see how the standard query library will look on fleetdm.com, run this script without the `--local` flag.');
-          // Because we're not querying github to get the real names for contributer profiles, we'll use their gitHub handle as
+          // Because we're not querying GitHub to get the real names for contributer profiles, we'll use their GitHub username as their name and their handle
           for (let query of queries) {
             let usernames = query.contributors.split(',');
             let contributorProfiles = [];
@@ -111,7 +112,7 @@ module.exports = {
             }
             query.contributors = contributorProfiles;
           }
-        } else { // If the local flag was not provided, we'll query GitHub's API to get additional information about each contributor.
+        } else {// If the local flag was not provided, we'll query GitHub's API to get additional information about each contributor.
           await sails.helpers.flow.simultaneouslyForEach(githubUsernames, async(username)=>{
             githubDataByUsername[username] = await sails.helpers.http.get.with({
               url: 'https://api.github.com/users/' + encodeURIComponent(username),

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -9,7 +9,7 @@ module.exports = {
 
   inputs: {
     dry: { type: 'boolean', description: 'Whether to make this a dry run.  (.sailsrc file will not be overwritten.  HTML files will not be generated.)' },
-    local: { type: 'boolean', description: 'Whether to send requests to the GitHub API when running this script. If this option is set to `true`, query contributer profiles will not be populated', defaultsTo: false },
+    local: { type: 'boolean', description: 'Whether to send requests to the GitHub API when running this script. If this option is set to `true`, query contributer profiles will not be populated'},
   },
 
 

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -107,7 +107,7 @@ module.exports = {
                 name: username,
                 handle: username,
                 avatarUrl: 'https://placekitten.com/200/200',
-                htmlUrl: 'https://github.com/'+username,
+                htmlUrl: 'https://github.com/'+encodeURIComponent(username),
               });
             }
             query.contributors = contributorProfiles;


### PR DESCRIPTION
This PR adds a local option to the website's `build-static-content` script that can be used by chaining `--skipGithubRequests` to `sails run build-static-content`. 

This improves local testing of Markdown content by allowing contributors to run the `build-static-content` script without hitting their GitHub API rate limit.

Changes:
- Added new boolean input to `build-static-content`: `local`
- Updated the build script to skip querying GitHub's API if the local flag was provided.
   - If the local flag was provided, the names of contributors on the standard query library page will be the contributor's GitHub username instead of the name on their GitHub profile.
- Added a new error that is thrown when a contributor hits their GitHub API rate limit while running the script, with a suggestion to run the script with the --local flag. 