### PR TITLE
Host Details Page UI: Back to host from host details page keeps host table filters applied

### DIFF
--- a/changes/issue-3191-back-to-host-filtered
+++ b/changes/issue-3191-back-to-host-filtered
@@ -1,0 +1,1 @@
+* Back to host from host details keeps filters

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState, useCallback, useEffect } from "react";
-import { Link } from "react-router";
+import { browserHistory } from "react-router";
 import { Params, InjectedRouter } from "react-router/lib/Router";
 import { useQuery } from "react-query";
 import { useErrorHandler } from "react-error-boundary";
@@ -541,10 +541,18 @@ const HostDetailsPage = ({
     <MainContent className={baseClass}>
       <div className={`${baseClass}__wrapper`}>
         <div>
-          <Link to={PATHS.MANAGE_HOSTS} className={`${baseClass}__back-link`}>
-            <img src={BackChevron} alt="back chevron" id="back-chevron" />
-            <span>Back to all hosts</span>
-          </Link>
+          <Button
+            variant={"text-icon"}
+            onClick={() => {
+              browserHistory.goBack();
+            }}
+            className={`${baseClass}__back-link`}
+          >
+            <>
+              <img src={BackChevron} alt="back chevron" id="back-chevron" />
+              <span>Back to all hosts</span>
+            </>
+          </Button>
         </div>
         <HostSummaryCard
           statusClassName={statusClassName}

--- a/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
@@ -369,11 +369,6 @@
     text-decoration: none;
   }
 
-  #back-chevron {
-    width: 16px;
-    margin-right: $pad-small;
-  }
-
   &__device_mapping {
     .device_mapping--tooltip {
       flex-direction: column;


### PR DESCRIPTION
Cerra #3191 

**FIX**
Going back to the host table has the filters still applied

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
