### PR TITLE
Add artemist-work as maintainer in receive-from-github.js webhook

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -81,6 +81,7 @@ module.exports = {
       'ghernandez345',
       'chris-mcgillicuddy',
       'rfairburn',
+      'artemist-work',
     ];
 
     let GREEN_LABEL_COLOR = 'C2E0C6';// « Used in multiple places below.  (FUTURE: Use the "+" prefix for this instead of color.  2022-05-05)


### PR DESCRIPTION
# Checklist for submitter

Nothing seems to apply 

I need to add myself to the list of maintainers and bots so that automations correctly reflect my status