### PR TITLE
send enroll secret in query for installers

### DIFF
--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -1717,14 +1717,14 @@ Redirects to the transparency URL.
 
 Downloads a pre-built fleet-osquery installer with the given parameters.
 
-`GET /api/_version_/fleet/download_installer/{enroll_secret}/{kind}`
+`GET /api/_version_/fleet/download_installer/{kind}`
 
 #### Parameters
 
 | Name          | Type    | In    | Description                                                        |
 | ------------- | ------- | ----- | ------------------------------------------------------------------ |
-| enroll_secret | string  | path  | The global enroll secret.                                          |
 | kind          | string  | path  | The installer kind: pkg, msi, deb or rpm.                          |
+| enroll_secret | string  | query | The global enroll secret.                                          |
 | desktop       | boolean | query | Set to `true` to ask for an installer that includes Fleet Desktop. |
 
 ##### Default response

--- a/frontend/services/entities/installers.ts
+++ b/frontend/services/entities/installers.ts
@@ -15,9 +15,11 @@ export default {
     includeDesktop,
     installerType,
   }: IDownloadInstallerRequestParams): Promise<BlobPart> => {
-    const path = `${ENDPOINTS.DOWNLOAD_INSTALLER}/${encodeURIComponent(
+    const path = `${
+      ENDPOINTS.DOWNLOAD_INSTALLER
+    }/${installerType}?desktop=${includeDesktop}&enroll_secret=${encodeURIComponent(
       enrollSecret
-    )}/${installerType}?desktop=${includeDesktop}`;
+    )}`;
     console.log("path: ", path);
 
     return sendRequest("GET", path, undefined, "blob");

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -360,7 +360,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 
 	ue.GET("/api/_version_/fleet/activities", listActivitiesEndpoint, listActivitiesRequest{})
 
-	ue.GET("/api/_version_/fleet/download_installer/{enroll_secret}/{kind}", getInstallerEndpoint, installerRequest{})
+	ue.GET("/api/_version_/fleet/download_installer/{kind}", getInstallerEndpoint, installerRequest{})
 
 	ue.GET("/api/_version_/fleet/packs/{id:[0-9]+}/scheduled", getScheduledQueriesInPackEndpoint, getScheduledQueriesInPackRequest{})
 	ue.EndingAtVersion("v1").POST("/api/_version_/fleet/schedule", scheduleQueryEndpoint, scheduleQueryRequest{})

--- a/server/service/installer.go
+++ b/server/service/installer.go
@@ -13,8 +13,8 @@ import (
 )
 
 type installerRequest struct {
-	EnrollSecret string `url:"enroll_secret"`
 	Kind         string `url:"kind"`
+	EnrollSecret string `query:"enroll_secret"`
 	Desktop      bool   `query:"desktop,optional"`
 }
 

--- a/server/service/integration_sandbox_test.go
+++ b/server/service/integration_sandbox_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const enrollSecret = "xyz"
+const enrollSecret = "xyz/abc$@"
 
 type integrationSandboxTestSuite struct {
 	suite.Suite
@@ -99,7 +99,7 @@ func (s *integrationSandboxTestSuite) TestInstallerGet() {
 }
 
 func installerURL(secret, kind string, desktop bool) string {
-	url := fmt.Sprintf("/api/latest/fleet/download_installer/%s?enroll_secret=%s", secret, kind)
+	url := fmt.Sprintf("/api/latest/fleet/download_installer/%s?enroll_secret=%s", kind, secret)
 	if desktop {
 		url = url + "&desktop=1"
 	}

--- a/server/service/integration_sandbox_test.go
+++ b/server/service/integration_sandbox_test.go
@@ -99,9 +99,9 @@ func (s *integrationSandboxTestSuite) TestInstallerGet() {
 }
 
 func installerURL(secret, kind string, desktop bool) string {
-	url := fmt.Sprintf("/api/latest/fleet/download_installer/%s/%s", secret, kind)
+	url := fmt.Sprintf("/api/latest/fleet/download_installer/%s?enroll_secret=%s", secret, kind)
 	if desktop {
-		url = url + "?desktop=1"
+		url = url + "&desktop=1"
 	}
 	return url
 }


### PR DESCRIPTION
This changes how the enroll secret is sent to the server, as they might contain `/`, which was causing problems with our router.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
