### PR TITLE
Website: Update subtopics on docs and handbook pages

### DIFF
--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -109,7 +109,7 @@ parasails.registerPage('basic-documentation', {
     // console.log(subtopics);
 
     this.subtopics = (() => {
-      let subtopics = $('#body-content').find('h2').map((_, el) => el.innerText);
+      let subtopics = $('#body-content').find('h2.markdown-heading').map((_, el) => el.innerText);
       subtopics = $.makeArray(subtopics).map((title) => {
         // Removing all apostrophes from the title to keep  _.kebabCase() from turning words like 'user’s' into 'user-s'
         let kebabCaseFriendlyTitle = title.replace(/[\’]/g, '');

--- a/website/assets/js/pages/handbook/basic-handbook.page.js
+++ b/website/assets/js/pages/handbook/basic-handbook.page.js
@@ -75,7 +75,7 @@ parasails.registerPage('basic-handbook', {
     this.subtopics = (() => {
       let subtopics;
       if(!this.isHandbookLandingPage){
-        subtopics = $('#body-content').find('h2').map((_, el) => el.innerText);
+        subtopics = $('#body-content').find('h2.markdown-heading').map((_, el) => el.innerText);
       } else {
         subtopics = $('#body-content').find('h3').map((_, el) => el.innerText);
       }


### PR DESCRIPTION
closes: https://github.com/fleetdm/fleet/issues/7047
Changes:
- Updated the page scripts for documentation and handbook pages to only add headings from Markdown content to the page's subtopics.