### PR TITLE
Fleet UI: Fix localized tooltip alignment

### DIFF
--- a/changes/issue-7071-fix-text-alignment
+++ b/changes/issue-7071-fix-text-alignment
@@ -1,0 +1,1 @@
+* Fix Fleet Desktop text alignment

--- a/frontend/components/AddHostsModal/DownloadInstallers/_styles.scss
+++ b/frontend/components/AddHostsModal/DownloadInstallers/_styles.scss
@@ -10,6 +10,10 @@
     margin: 0;
   }
 
+  .fleet-checkbox {
+    display: flex;
+    align-items: center;
+  }
   .component__tooltip-wrapper__tip-text {
     p {
       padding: 0;


### PR DESCRIPTION
Cerra #7071 


**Fix**
- Align Fleet desktop text in sandbox view (safari)

<img width="935" alt="Screen Shot 2022-08-05 at 10 06 41 AM" src="https://user-images.githubusercontent.com/71795832/183094217-af99779e-1181-43a8-a35a-259f900434c3.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
