### PR TITLE
lock Docker version to 4.10.0 on macOS runners

### DIFF
--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -198,7 +198,8 @@ jobs:
     # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
     - name: Install Docker
       run: |
-        brew install --cask docker
+        # fixme: lock Docker version to 4.10.0 as newer versions fail to initialize
+        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb && brew install docker.rb
         sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
         open -a /Applications/Docker.app --args --unattended --accept-license
         echo "Waiting for Docker to start up..."

--- a/.github/workflows/fleetctl-preview-latest.yml
+++ b/.github/workflows/fleetctl-preview-latest.yml
@@ -38,7 +38,8 @@ jobs:
       if: contains(matrix.os, 'macos')
       # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
       run: |
-        brew install --cask docker
+        # fixme: lock Docker version to 4.10.0 as newer versions fail to initialize
+        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb && brew install docker.rb
         sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
         open -a /Applications/Docker.app --args --unattended --accept-license
         echo "Waiting for Docker to start up..."

--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -24,7 +24,8 @@ jobs:
       if: contains(matrix.os, 'macos')
       # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
       run: |
-        brew install --cask docker
+        # fixme: lock Docker version to 4.10.0 as newer versions fail to initialize
+        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb && brew install docker.rb
         sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
         open -a /Applications/Docker.app --args --unattended --accept-license
         echo "Waiting for Docker to start up..."

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -34,7 +34,8 @@ jobs:
       if: matrix.os == 'macos-latest'
       # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
       run: |
-        brew install --cask docker
+        # fixme: lock Docker version to 4.10.0 as newer versions fail to initialize
+        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb && brew install docker.rb
         sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
         open -a /Applications/Docker.app --args --unattended --accept-license
         echo "Waiting for Docker to start up..."


### PR DESCRIPTION
The macOS runners installing Docker are having problems initializing the new Docker version (4.11.0) which effectively blocks PRs with Go code.

This locks the Docker version we install to 4.10.0, which works until we figure out a solution or a new Docker version goes out.