### PR TITLE
enable notarization on Sandbox pre-provisioner

### DIFF
--- a/infrastructure/sandbox/PreProvisioner/lambda/main.go
+++ b/infrastructure/sandbox/PreProvisioner/lambda/main.go
@@ -85,6 +85,7 @@ func buildPackages(instanceID, enrollSecret string) (err error) {
 		OsquerydChannel:              "stable",
 		DesktopChannel:               "stable",
 		OrbitUpdateInterval:          15 * time.Minute,
+		Notarize:                     true,
 		MacOSDevIDCertificateContent: options.MacOSDevIDCertificateContent,
 		AppStoreConnectAPIKeyID:      options.AppStoreConnectAPIKeyID,
 		AppStoreConnectAPIKeyIssuer:  options.AppStoreConnectAPIKeyIssuer,


### PR DESCRIPTION
As found out by @xpkoala [here](https://github.com/fleetdm/fleet/issues/6674#issuecomment-1208432071), packages in Sandbox are signed but not notarized/stapled.

I confirmed this by creating a new instance and downloading a package, which upon inspection:

![image](https://user-images.githubusercontent.com/4419992/183486628-18dbb27d-0eea-4637-a56e-c1a2d1deb8c1.png)


This is because for historic reasons, we need `opt.Notarize` to be set to `true` in the packaging options.
