### PR TITLE
Convert seconds to units using date-fns

### DIFF
--- a/changes/issue-4120-fix-inconsistent-units
+++ b/changes/issue-4120-fix-inconsistent-units
@@ -1,0 +1,1 @@
+* Use  date-fns to convert seconds to units for schedules UI

--- a/frontend/pages/hosts/details/cards/Schedule/ScheduleTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Schedule/ScheduleTableConfig.tsx
@@ -2,10 +2,7 @@ import React from "react";
 import { uniqueId } from "lodash";
 
 import { IQueryStats } from "interfaces/query_stats";
-import {
-  performanceIndicator,
-  secondsToHumanReadable,
-} from "utilities/helpers";
+import { performanceIndicator, secondsToDhms } from "utilities/helpers";
 
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import PillCell from "components/TableContainer/DataTable/PillCell";
@@ -105,7 +102,7 @@ const enhanceScheduleData = (query_stats: IQueryStats[]): IScheduleTable[] => {
     };
     return {
       query_name: query.query_name,
-      frequency: secondsToHumanReadable(query.interval),
+      frequency: secondsToDhms(query.interval),
       performance: [
         performanceIndicator(scheduledQueryPerformance),
         query.scheduled_query_id || uniqueId(),

--- a/frontend/pages/hosts/details/cards/Schedule/ScheduleTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Schedule/ScheduleTableConfig.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { uniqueId } from "lodash";
 
 import { IQueryStats } from "interfaces/query_stats";
-import { performanceIndicator, secondsToHms } from "utilities/helpers";
+import {
+  performanceIndicator,
+  secondsToHumanReadable,
+} from "utilities/helpers";
 
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import PillCell from "components/TableContainer/DataTable/PillCell";
@@ -102,7 +105,7 @@ const enhanceScheduleData = (query_stats: IQueryStats[]): IScheduleTable[] => {
     };
     return {
       query_name: query.query_name,
-      frequency: secondsToHms(query.interval),
+      frequency: secondsToHumanReadable(query.interval),
       performance: [
         performanceIndicator(scheduledQueryPerformance),
         query.scheduled_query_id || uniqueId(),

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTableConfig.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTableConfig.tsx
@@ -2,7 +2,11 @@
 // disable this rule as it was throwing an error in Header and Cell component
 // definitions for the selection row for some reason when we dont really need it.
 import React from "react";
-import { performanceIndicator, secondsToDhms } from "utilities/helpers";
+import {
+  performanceIndicator,
+  secondsToHumanReadable,
+} from "utilities/helpers";
+import formatDuration from "date-fns/formatDuration";
 
 // @ts-ignore
 import Checkbox from "components/forms/fields/Checkbox";
@@ -130,7 +134,7 @@ const generateTableHeaders = (
       disableSortBy: true,
       accessor: "interval",
       Cell: (cellProps: INumberCellProps): JSX.Element => (
-        <TextCell value={secondsToDhms(cellProps.cell.value)} />
+        <TextCell value={secondsToHumanReadable(cellProps.cell.value)} />
       ),
     },
     {
@@ -190,9 +194,12 @@ const generateInheritedQueriesTableHeaders = (): IDataColumn[] => {
       Header: "Frequency",
       disableSortBy: true,
       accessor: "interval",
-      Cell: (cellProps: INumberCellProps): JSX.Element => (
-        <TextCell value={secondsToDhms(cellProps.cell.value)} />
-      ),
+      Cell: (cellProps: INumberCellProps): JSX.Element => {
+        console.log("cellProps.cell.value", cellProps.cell.value);
+        return (
+          <TextCell value={secondsToHumanReadable(cellProps.cell.value)} />
+        );
+      },
     },
     {
       title: "Performance impact",

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTableConfig.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTableConfig.tsx
@@ -6,7 +6,6 @@ import {
   performanceIndicator,
   secondsToHumanReadable,
 } from "utilities/helpers";
-import formatDuration from "date-fns/formatDuration";
 
 // @ts-ignore
 import Checkbox from "components/forms/fields/Checkbox";
@@ -194,12 +193,9 @@ const generateInheritedQueriesTableHeaders = (): IDataColumn[] => {
       Header: "Frequency",
       disableSortBy: true,
       accessor: "interval",
-      Cell: (cellProps: INumberCellProps): JSX.Element => {
-        console.log("cellProps.cell.value", cellProps.cell.value);
-        return (
-          <TextCell value={secondsToHumanReadable(cellProps.cell.value)} />
-        );
-      },
+      Cell: (cellProps: INumberCellProps): JSX.Element => (
+        <TextCell value={secondsToHumanReadable(cellProps.cell.value)} />
+      ),
     },
     {
       title: "Performance impact",

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTableConfig.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTableConfig.tsx
@@ -2,10 +2,7 @@
 // disable this rule as it was throwing an error in Header and Cell component
 // definitions for the selection row for some reason when we dont really need it.
 import React from "react";
-import {
-  performanceIndicator,
-  secondsToHumanReadable,
-} from "utilities/helpers";
+import { performanceIndicator, secondsToDhms } from "utilities/helpers";
 
 // @ts-ignore
 import Checkbox from "components/forms/fields/Checkbox";
@@ -133,7 +130,7 @@ const generateTableHeaders = (
       disableSortBy: true,
       accessor: "interval",
       Cell: (cellProps: INumberCellProps): JSX.Element => (
-        <TextCell value={secondsToHumanReadable(cellProps.cell.value)} />
+        <TextCell value={secondsToDhms(cellProps.cell.value)} />
       ),
     },
     {
@@ -194,7 +191,7 @@ const generateInheritedQueriesTableHeaders = (): IDataColumn[] => {
       disableSortBy: true,
       accessor: "interval",
       Cell: (cellProps: INumberCellProps): JSX.Element => (
-        <TextCell value={secondsToHumanReadable(cellProps.cell.value)} />
+        <TextCell value={secondsToDhms(cellProps.cell.value)} />
       ),
     },
     {

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -678,8 +678,12 @@ export const performanceIndicator = (
   return "Excessive";
 };
 
-export const secondsToHumanReadable = (s: number): string =>
-  formatDistanceStrict(0, s * 1000, { includeSeconds: false });
+export const secondsToHumanReadable = (s: number): string => {
+  if (s === 604800) {
+    return "1 week";
+  }
+  return formatDistanceStrict(0, s * 1000);
+};
 
 export const secondsToHms = (d: number): string => {
   const h = Math.floor(d / 3600);

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -5,6 +5,8 @@ import {
   formatDistanceToNow,
   formatDistanceStrict,
   isAfter,
+  intervalToDuration,
+  formatDuration,
 } from "date-fns";
 import yaml from "js-yaml";
 
@@ -678,11 +680,13 @@ export const performanceIndicator = (
   return "Excessive";
 };
 
-export const secondsToHumanReadable = (s: number): string => {
+export const secondsToDhms = (s: number): string => {
   if (s === 604800) {
     return "1 week";
   }
-  return formatDistanceStrict(0, s * 1000);
+
+  const duration = intervalToDuration({ start: 0, end: s * 1000 });
+  return formatDuration(duration);
 };
 
 export const secondsToHms = (d: number): string => {
@@ -694,22 +698,6 @@ export const secondsToHms = (d: number): string => {
   const mDisplay = m > 0 ? m + (m === 1 ? " min " : " mins ") : "";
   const sDisplay = s > 0 ? s + (s === 1 ? " sec" : " secs") : "";
   return hDisplay + mDisplay + sDisplay;
-};
-
-export const secondsToDhms = (d: number): string => {
-  if (d === 604800) {
-    return "1 week";
-  }
-  const day = Math.floor(d / (3600 * 24));
-  const h = Math.floor((d % (3600 * 24)) / 3600);
-  const m = Math.floor((d % 3600) / 60);
-  const s = Math.floor(d % 60);
-
-  const dDisplay = day > 0 ? day + (day === 1 ? " day " : " days ") : "";
-  const hDisplay = h > 0 ? h + (h === 1 ? " hour " : " hours ") : "";
-  const mDisplay = m > 0 ? m + (m === 1 ? " minute " : " minutes ") : "";
-  const sDisplay = s > 0 ? s + (s === 1 ? " second" : " seconds") : "";
-  return dDisplay + hDisplay + mDisplay + sDisplay;
 };
 
 export const abbreviateTimeUnits = (str: string): string =>

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -1,6 +1,11 @@
 import { isEmpty, flatMap, omit, pick, size, memoize, reduce } from "lodash";
 import md5 from "js-md5";
-import { format, formatDistanceToNow, isAfter } from "date-fns";
+import {
+  format,
+  formatDistanceToNow,
+  formatDistanceStrict,
+  isAfter,
+} from "date-fns";
 import yaml from "js-yaml";
 
 import { IConfig } from "interfaces/config";
@@ -672,6 +677,9 @@ export const performanceIndicator = (
   }
   return "Excessive";
 };
+
+export const secondsToHumanReadable = (s: number): string =>
+  formatDistanceStrict(0, s * 1000, { includeSeconds: false });
 
 export const secondsToHms = (d: number): string => {
   const h = Math.floor(d / 3600);

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -3,7 +3,6 @@ import md5 from "js-md5";
 import {
   format,
   formatDistanceToNow,
-  formatDistanceStrict,
   isAfter,
   intervalToDuration,
   formatDuration,


### PR DESCRIPTION
Cerra #4120

**Fix**
- Scheduled queries tables on host details page and schedule page both use the same frequency conversion
- Use of date-dns `intervalToDuration` and `formatDuration` functions to convert frequencies from seconds to human readable time

<img width="1297" alt="Screen Shot 2022-08-08 at 3 33 04 PM" src="https://user-images.githubusercontent.com/71795832/183499412-ca314de1-c188-49c1-b796-f651dc7e0eaf.png">
<img width="1297" alt="Screen Shot 2022-08-08 at 3 34 06 PM" src="https://user-images.githubusercontent.com/71795832/183499515-09820bbd-f8d1-4a11-86b7-32abd02a5543.png">
<img width="1584" alt="Screen Shot 2022-08-08 at 4 19 00 PM" src="https://user-images.githubusercontent.com/71795832/183507044-bfb7d9f2-e572-4045-8048-149276118489.png">

https://date-fns.org/v2.29.1/docs/intervalToDuration
https://date-fns.org/v2.29.1/docs/formatDuration

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
