### PR TITLE
lock rcodesign version to 0.16.0

### DIFF
--- a/infrastructure/sandbox/PreProvisioner/lambda/Dockerfile
+++ b/infrastructure/sandbox/PreProvisioner/lambda/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:latest AS builder
 
 ARG transporter_url=https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/resources/download/public/Transporter__Linux/bin
 
-RUN cargo install apple-codesign \
+RUN cargo install --version 0.16.0 apple-codesign \
   && curl -sSf $transporter_url -o transporter_install.sh \
   && sh transporter_install.sh --target transporter --accept --noexec
 

--- a/tools/fleetctl-docker/Dockerfile
+++ b/tools/fleetctl-docker/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:latest AS builder
 
 ARG transporter_url=https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/resources/download/public/Transporter__Linux/bin
 
-RUN cargo install apple-codesign \
+RUN cargo install --version 0.16.0 apple-codesign \
   && curl -sSf $transporter_url -o transporter_install.sh \
   && sh transporter_install.sh --target transporter --accept --noexec
 


### PR DESCRIPTION
As detailed [here](https://github.com/fleetdm/fleet/issues/7112) the new version of `rcodesign` added support for the Notary API (which is great) but at the same time dropped support for Transporter, which we currently use to notarize macOS packages.

This PR locks the version to 0.16.0 until we do the work to migrate to the newer version.