### PR TITLE
normalise styling on setting pages for sandbox mode 

### DIFF
--- a/changes/issue-7099-normalise-styles-on-settings-page
+++ b/changes/issue-7099-normalise-styles-on-settings-page
@@ -1,0 +1,1 @@
+* make UI consistant on settings pages between sandbox messaging and integration setup message

--- a/frontend/components/Sandbox/SandboxDemoMessage/_styles.scss
+++ b/frontend/components/Sandbox/SandboxDemoMessage/_styles.scss
@@ -3,12 +3,13 @@
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
-  width: 300px;
+  width: 350px;
   margin: auto;
 
   &__message {
     font-size: $small;
     font-weight: $bold;
+    margin: 0 0 $pad-large;
   }
 
   &__link-message {

--- a/frontend/pages/admin/AppSettingsPage/AppSettingsPage.tsx
+++ b/frontend/pages/admin/AppSettingsPage/AppSettingsPage.tsx
@@ -24,6 +24,7 @@ const AppSettingsPage = ({ params }: IAppSettingsPageProps): JSX.Element => {
           <SandboxDemoMessage
             message="Organization settings are only available in self-managed Fleet"
             utmSource="fleet-ui-organization-settings-page"
+            className={`${baseClass}__sandbox-demo-message`}
           />
         )}
       >

--- a/frontend/pages/admin/AppSettingsPage/_styles.scss
+++ b/frontend/pages/admin/AppSettingsPage/_styles.scss
@@ -6,4 +6,8 @@
     color: $core-fleet-black;
     @include sticky-settings-description;
   }
+
+    &__sandbox-demo-message {
+      margin-top: 3.5rem;
+    }
 }

--- a/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
@@ -364,7 +364,7 @@ const IntegrationsPage = (): JSX.Element => {
       <div className={`${noIntegrationsClass}`}>
         <div className={`${noIntegrationsClass}__inner`}>
           <div className={`${noIntegrationsClass}__inner-text`}>
-            <h1>Set up integrations</h1>
+            <h2>Set up integrations</h2>
             <p>
               Create tickets automatically when Fleet detects new
               vulnerabilities.

--- a/frontend/pages/admin/IntegrationsPage/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/_styles.scss
@@ -26,20 +26,10 @@
     }
   }
 
-  h1 {
-    font-size: $large;
-    font-weight: $regular;
-    line-height: normal;
-    letter-spacing: normal;
-    color: $core-fleet-black;
-  }
-
   h2 {
     font-size: $small;
     font-weight: $bold;
     margin: 0 0 $pad-large;
-    line-height: 20px;
-    color: $core-fleet-black;
   }
 
   ul {

--- a/frontend/pages/admin/UserManagementPage/UserManagementPage.tsx
+++ b/frontend/pages/admin/UserManagementPage/UserManagementPage.tsx
@@ -12,7 +12,7 @@ interface IUserManagementProps {
 
 const UserManagementPage = ({ router }: IUserManagementProps): JSX.Element => {
   return (
-    <div className={`${baseClass} body-wrap`}>
+    <div className={`${baseClass}`}>
       <p className={`${baseClass}__page-description`}>
         Create new users, customize user permissions, and remove users from
         Fleet.
@@ -22,6 +22,7 @@ const UserManagementPage = ({ router }: IUserManagementProps): JSX.Element => {
           <SandboxDemoMessage
             message="User management is only available in self-managed Fleet"
             utmSource="fleet-ui-users-page"
+            className={`${baseClass}__sandbox-demo-message`}
           />
         )}
       >

--- a/frontend/pages/admin/UserManagementPage/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/_styles.scss
@@ -1,9 +1,13 @@
 .user-management {
-  padding: 0;
+
   &__page-description {
     font-size: $x-small;
     color: $core-fleet-black;
     @include sticky-settings-description;
+  }
+
+  &__sandbox-demo-message {
+    margin-top: 3.5rem;
   }
 
   .Select-menu-outer {


### PR DESCRIPTION
relates to [#7099](https://github.com/fleetdm/fleet/issues/7099)

this makes the styling consistant on settings pages between the sandbox messaging and the set up integrations messgaing.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
