### PR TITLE
update golangci-lint version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -32,5 +32,8 @@ jobs:
         run: |
           # The following packages are needed to build Fleet Desktop on Ubuntu.
           sudo apt install -y gcc libgtk-3-dev libayatana-appindicator3-dev
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
+          # Don't forget to update
+          # docs/Contributing/Testing-and-local-development.md when this
+          # version changes
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
           make lint-go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,8 +18,8 @@ linters:
 
 linters-settings:
   depguard:
-    list-type: blacklist
-    include-go-root: false
+    list-type: denylist
+    include-go-stdlib: false
     packages-with-error-message:
       - github.com/pkg/errors: "use ctxerr if a context.Context is available or stdlib errors.New / fmt.Errorf with the %w verb"
 

--- a/docs/Contributing/Testing-and-local-development.md
+++ b/docs/Contributing/Testing-and-local-development.md
@@ -37,7 +37,7 @@ Check out [`/tools/osquery` directory instructions](https://github.com/fleetdm/f
 You must install the [`golangci-lint`](https://golangci-lint.run/) command to run `make test[-go]` or `make lint[-go]`, using:
 
 ```
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.0
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
 ```
 
 Make sure it is available in your `PATH`. To execute the basic unit and integration tests, run the following from the root of the repository:


### PR DESCRIPTION
I was getting a ton of false positives when running `make lint-go` locally because I had the wrong version installed, this:

1. Updates the `golangci-lint` version to the latest compatible with go 1.17
2. Updates the contributing documentation to match the version
3. Updates the config parameters names, the underlying functionality didn't change but they changed the names