### PR TITLE
Remove CORS headers from expires request

### DIFF
--- a/frontend/services/entities/config.ts
+++ b/frontend/services/entities/config.ts
@@ -54,11 +54,6 @@ export default {
         url,
         params: { id: instanceId },
         responseType: "json",
-        headers: {
-          "Access-Control-Request-Method": "GET",
-          "Access-Control-Request-Headers": "content-type",
-          Origin: `https://${instanceId}.sandbox.fleetdm.com`,
-        },
       });
       return data.timestamp;
     } catch (error) {


### PR DESCRIPTION
For #7104 

QA reported browser console warnings saying the CORS headers could not be set. I removed them, and the request is now completing successfully. The browser is including the `origin` header on its own, which may be all it needs. Testing locally and this is working fine without the CORS headers.