### PR TITLE
Add note about `fleet` vs `fleetctl` packages

### DIFF
--- a/docs/Deploying/Server-Installation.md
+++ b/docs/Deploying/Server-Installation.md
@@ -58,6 +58,8 @@ For example, after downloading:
 unzip fleet.zip 'linux/*' -d fleet
 sudo cp fleet/linux/fleet* /usr/bin/
 ```
+> There are several downloads available in the releases page, including the `fleetctl` CLI. Make sure you grab the one that starts with `fleet_` when setting up your Fleet server. 
+
 
 ### Installing and configuring dependencies
 
@@ -271,6 +273,8 @@ For example, after downloading:
 unzip fleet.zip 'linux/*' -d fleet
 sudo cp fleet/linux/fleet* /usr/bin/
 ```
+
+> There are several downloads available in the releases page, including the `fleetctl` CLI. Make sure you grab the one that starts with `fleet_` when setting up your Fleet server. 
 
 ### Installing and configuring dependencies
 


### PR DESCRIPTION
There have been a couple of instances of people mistakenly downloading the `fleetctl` package rather than Fleet. Adding a note to installation instructions for CentOS and Ubuntu. 
