### PR TITLE
Update CODEOWNERS to include handbook, etc

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,8 +16,8 @@ go.mod @fleetdm/go
 # Changelog
 CHANGELOG.md @noahtalerman
 
-# Markdown docs
-/docs/*.md @Desmi-Dizney  # todo: we might need to do double stars here for it to work
+# Fleet documentation
+/docs/**/* @Desmi-Dizney
 
-# API documentation
+# REST API reference documentation
 /docs/Using-Fleet/REST-API.md @ksatter

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,6 +13,9 @@ go.mod @fleetdm/go
 # GitHub settings + actions
 /.github/ @fleetdm/g-platform
 
+# Codeowners file
+/CODEOWNERS @zwass @mikermcneil
+
 # Changelog
 CHANGELOG.md @noahtalerman
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,7 +17,7 @@ go.mod @fleetdm/go
 CHANGELOG.md @noahtalerman
 
 # Markdown docs
-*.md @Desmi-Dizney
+/docs/*.md @Desmi-Dizney  # todo: we might need to do double stars here for it to work
 
 # API documentation
 /docs/Using-Fleet/REST-API.md @ksatter

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,7 +17,7 @@ go.mod @fleetdm/go
 CHANGELOG.md @noahtalerman
 
 # Fleet documentation
-/docs/ @Desmi-Dizney
+/docs/ @Desmi-Dizney @chris-mcgillicuddy
 
 # REST API reference documentation
 /docs/Using-Fleet/REST-API.md @ksatter
@@ -44,11 +44,11 @@ CHANGELOG.md @noahtalerman
 /README.md @chris-mcgillicuddy
 
 # NPM brandfront (npmjs.com/package/fleetctl)
-/tools/fleetctl-npm/README.md @mike-j-thomas
+/tools/fleetctl-npm/README.md @chris-mcgillicuddy
 
 # Handbook
-/handbook/README.md @mikermcneil
 /handbook/company @mikermcneil
+/handbook/people @charlottechance @hollidayn
 /handbook/security @guillaumeross
 /handbook/engineering @zwass
 /handbook/product @noahtalerman
@@ -56,10 +56,9 @@ CHANGELOG.md @noahtalerman
 /handbook/customers @tgauda
 /handbook/growth @timmy-k
 /handbook/community @timmy-k
-/handbook/digital-experience @mike-j-thomas
-/handbook/handbook @mike-j-thomas
-/handbook/people @charlottechance
-
+/handbook/digital-experience @mike-j-thomas @chris-mcgillicuddy
+/handbook/README.md @chris-mcgillicuddy
+/handbook/handbook @chris-mcgillicuddy
 
 #
 # For configuration that determines auto-approval + auto-unfreezing, so that contributors

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,7 +17,7 @@ go.mod @fleetdm/go
 /CODEOWNERS @zwass @mikermcneil
 
 # Changelog
-CHANGELOG.md @noahtalerman
+/CHANGELOG.md @noahtalerman
 
 # Fleet documentation
 /docs/ @Desmi-Dizney @chris-mcgillicuddy
@@ -28,6 +28,9 @@ CHANGELOG.md @noahtalerman
 
 # Standard query library YAML
 /docs/01-Using-Fleet/standard-query-library/standard-query-library.yml @guillaumeross
+
+# Articles
+/articles @chris-mcgillicuddy
 
 # Website
 /website/ @eashaw

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,7 +17,52 @@ go.mod @fleetdm/go
 CHANGELOG.md @noahtalerman
 
 # Fleet documentation
-/docs/**/* @Desmi-Dizney
+/docs/ @Desmi-Dizney
 
 # REST API reference documentation
 /docs/Using-Fleet/REST-API.md @ksatter
+/docs/Contributing/API-for-contributors.md @ksatter
+
+# Standard query library YAML
+/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml @guillaumeross
+
+# Website
+/website/ @eashaw
+/website/views/ @eashaw
+/website/assets/ @eashaw
+
+# Website redirects and URLs
+/website/config/routes.js @eashaw @mike-j-thomas
+
+# Website backend, scripts, deps
+/website/api/ @mikermcneil
+/website/config/ @mikermcneil
+/website/scripts/ @mikermcneil
+/website/package.json @mikermcneil
+
+# GitHub brandfront
+/README.md @chris-mcgillicuddy
+
+# NPM brandfront (npmjs.com/package/fleetctl)
+/tools/fleetctl-npm/README.md @mike-j-thomas
+
+# Handbook
+/handbook/README.md @mikermcneil
+/handbook/company @mikermcneil
+/handbook/security @guillaumeross
+/handbook/engineering @zwass
+/handbook/product @noahtalerman
+/handbook/sales @alexmitchelliii
+/handbook/customers @tgauda
+/handbook/growth @timmy-k
+/handbook/community @timmy-k
+/handbook/digital-experience @mike-j-thomas
+/handbook/handbook @mike-j-thomas
+/handbook/people @charlottechance
+
+
+#
+# For configuration that determines auto-approval + auto-unfreezing, so that contributors
+# can merge their own PRs without additional approval, please see the latest version of:
+# https://github.com/fleetdm/fleet/blob/74f65447b718663bd04df31ea1da28915d98792c/website/config/custom.js#L88-L128
+#

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -99,7 +99,7 @@ module.exports.custom = {
     'tools/fleetctl-npm/README.md': ['chris-mcgillicuddy', 'mike-j-thomas'],//« brandfront for fleetctl package on npm
 
     'articles': ['chris-mcgillicuddy', 'mike-j-thomas', 'eashaw'],
-    
+
     'handbook': ['chris-mcgillicuddy', 'mike-j-thomas', 'eashaw', 'mikermcneil'],// (default for handbook)
     'handbook/company': 'mikermcneil',
     'handbook/people': 'charlottechance',

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -95,12 +95,12 @@ module.exports.custom = {
   *                                                                          *
   ***************************************************************************/
   githubRepoDRIByPath: {
-    'README.md': 'chris-mcgillicuddy',// (github brandfront)
+    'README.md': ['chris-mcgillicuddy'],// (github brandfront)
     'tools/fleetctl-npm/README.md': ['chris-mcgillicuddy', 'mike-j-thomas'],//« brandfront for fleetctl package on npm
 
-    'articles': ['chris-mcgillicuddy', 'mike-j-thomas', 'eashaw'],
+    'articles': ['chris-mcgillicuddy', 'mike-j-thomas', 'eashaw', 'zwass', 'mikermcneil'],
 
-    'handbook': ['chris-mcgillicuddy', 'mike-j-thomas', 'eashaw', 'mikermcneil'],// (default for handbook)
+    'handbook': ['chris-mcgillicuddy', 'mike-j-thomas', 'eashaw', 'mikermcneil', 'zwass'],// (default for handbook)
     'handbook/company': 'mikermcneil',
     'handbook/people': 'charlottechance',
     'handbook/engineering': 'zwass',
@@ -117,7 +117,7 @@ module.exports.custom = {
     'website/assets': 'eashaw',
     'website/config/routes.js': ['eashaw', 'mike-j-thomas'],// (for managing website URLs)
 
-    'docs': ['desmi-dizney', 'chris-mcgillicuddy'],// (default for docs)
+    'docs': ['desmi-dizney', 'chris-mcgillicuddy', 'zwass', 'mikermcneil'],// (default for docs)
     'docs/images': ['chris-mcgillicuddy', 'noahtalerman', 'eashaw', 'mike-j-thomas'],
     'docs/Using-Fleet/REST-API.md': 'ksatter',
     'docs/Contributing/API-for-contributors.md': 'ksatter',
@@ -125,7 +125,7 @@ module.exports.custom = {
     'docs/Contributing/FAQ.md': ['ksatter', 'tgauda'],
     'docs/Using-Fleet/FAQ.md': ['ksatter', 'tgauda'],
 
-    'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml': 'guillaumeross',// (standard query library)
+    'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml': ['guillaumeross','zwass'],// (standard query library)
   },
 
 

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -96,33 +96,34 @@ module.exports.custom = {
   ***************************************************************************/
   githubRepoDRIByPath: {
     'README.md': 'chris-mcgillicuddy',// (github brandfront)
+    'tools/fleetctl-npm/README.md': ['chris-mcgillicuddy', 'mike-j-thomas'],//« brandfront for fleetctl package on npm
 
-    'handbook': ['desmi-dizney', 'mike-j-thomas', 'mikermcneil'],// (default for handbook)
+    'articles': ['chris-mcgillicuddy', 'mike-j-thomas', 'eashaw'],
+    
+    'handbook': ['chris-mcgillicuddy', 'mike-j-thomas', 'eashaw', 'mikermcneil'],// (default for handbook)
     'handbook/company': 'mikermcneil',
     'handbook/people': 'charlottechance',
     'handbook/engineering': 'zwass',
     'handbook/product': 'noahtalerman',
     'handbook/security': 'guillaumeross',
+    'handbook/sales': 'alexmitchelliii',
     'handbook/digital-experience': 'mike-j-thomas',
     'handbook/growth': 'timmy-k',
     'handbook/customers': 'tgauda',
-    'handbook/community': ['dominuskelvin', 'ksatter'],
-    'handbook/README.md': '*',// (any fleetie can update this page and merge their change without waiting for their change to be approved)
-
-    'tools/fleetctl-npm/README.md': ['mike-j-thomas'],//« brandfront for fleetctl package on npm
+    'handbook/community': ['timmy-k'],
 
     'website': 'mikermcneil',// (default for website)
     'website/views': 'eashaw',
     'website/assets': 'eashaw',
     'website/config/routes.js': ['eashaw', 'mike-j-thomas'],// (for managing website URLs)
 
-    'docs': 'zwass',// (default for docs)
-    'docs/images': ['noahtalerman', 'eashaw', 'mike-j-thomas'],
-    'docs/Using-Fleet/REST-API.md': 'lukeheath',
-    'docs/Contributing/API-for-contributors.md': 'lukeheath',
-    'docs/Deploying/FAQ.md': ['ksatter', 'dominuskelvin'],
-    'docs/Contributing/FAQ.md': ['ksatter', 'dominuskelvin'],
-    'docs/Using-Fleet/FAQ.md': ['ksatter', 'dominuskelvin'],
+    'docs': ['desmi-dizney', 'chris-mcgillicuddy'],// (default for docs)
+    'docs/images': ['chris-mcgillicuddy', 'noahtalerman', 'eashaw', 'mike-j-thomas'],
+    'docs/Using-Fleet/REST-API.md': 'ksatter',
+    'docs/Contributing/API-for-contributors.md': 'ksatter',
+    'docs/Deploying/FAQ.md': ['ksatter', 'tgauda'],
+    'docs/Contributing/FAQ.md': ['ksatter', 'tgauda'],
+    'docs/Using-Fleet/FAQ.md': ['ksatter', 'tgauda'],
 
     'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml': 'guillaumeross',// (standard query library)
   },


### PR DESCRIPTION
## tldr
This PR updates CODEOWNERS to work for the handbook, articles, etc.
 
## Context

I just noticed that codeowners is automatically adding @Desmi-Dizney as a reviewer on markdown PRs.  Desmi is the default reviewer for PRs to the docs, but not for other areas like the handbook (instead, he does his editing pass post facto, to avoid delaying merges, and so that he doesn't get unnecessary notifications.)

He's likely getting pinged a looooooot right now and is probably making it hard for him to tell what is a real review request that he needs to route to the oncall engineer, versus what is just an unrelated PR to the handbook, etc where he was added as a reviewer automatically.

![image](https://user-images.githubusercontent.com/618009/184064957-a4dbd5e8-eda2-4f14-8221-b60c184f0559.png)


> FYI For future code archaelogists finding this in a `git blame`, here is the manifest of DRIs per repo path that is used to auto-approve (and auto-unfreeze) PRs from the DRI that exclusively change files within that path: https://github.com/fleetdm/fleet/blob/74f65447b718663bd04df31ea1da28915d98792c/website/config/custom.js#L88-L128