### PR TITLE
Fleet UI: Set default pagination length to 20

### DIFF
--- a/changes/issue-7144-pagination-defaults-to-20
+++ b/changes/issue-7144-pagination-defaults-to-20
@@ -1,0 +1,1 @@
+* Fix pages so pagination dfaults to 20 items per page

--- a/frontend/components/TableContainer/DataTable/DataTable.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tests.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { noop } from "lodash";
 import DataTable from "./DataTable";
 
-const DEFAULT_PAGE_SIZE = 100;
+const DEFAULT_PAGE_SIZE = 20;
 
 describe("DataTable - component", () => {
   it("renders a data table based on the columns and data passed in", () => {

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -80,7 +80,7 @@ interface ITableContainerProps {
 
 const baseClass = "table-container";
 
-const DEFAULT_PAGE_SIZE = 100;
+const DEFAULT_PAGE_SIZE = 20;
 const DEFAULT_PAGE_INDEX = 0;
 
 const TableContainer = ({

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -479,7 +479,6 @@ const ManagePolicyPage = ({
                   isLoading={isFetchingGlobalPolicies}
                   policiesList={globalPolicies || []}
                   onDeletePoliciesClick={noop}
-                  resultsTitle="policies"
                   canAddOrDeletePolicy={canAddOrDeletePolicy}
                   tableType="inheritedPolicies"
                   currentTeam={currentTeam}

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -131,7 +131,6 @@ const PoliciesTable = ({
           manualSortBy
           showMarkAllPages={false}
           isAllPagesSelected={false}
-          disablePagination
           onPrimarySelectActionClick={onDeletePoliciesClick}
           primarySelectActionButtonVariant="text-icon"
           primarySelectActionButtonIcon="delete"
@@ -139,6 +138,7 @@ const PoliciesTable = ({
           emptyComponent={NoPolicies}
           onQueryChange={noop}
           disableCount={tableType === "inheritedPolicies"}
+          isClientSidePagination
         />
       )}
     </div>

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -26,7 +26,6 @@ interface IPoliciesTableProps {
   isLoading: boolean;
   onAddPolicyClick?: () => void;
   onDeletePoliciesClick: (selectedTableIds: number[]) => void;
-  resultsTitle?: string;
   canAddOrDeletePolicy?: boolean;
   tableType?: string;
   currentTeam: ITeamSummary | undefined;
@@ -38,7 +37,6 @@ const PoliciesTable = ({
   isLoading,
   onAddPolicyClick,
   onDeletePoliciesClick,
-  resultsTitle,
   canAddOrDeletePolicy,
   tableType,
   currentTeam,
@@ -116,7 +114,7 @@ const PoliciesTable = ({
         <Spinner />
       ) : (
         <TableContainer
-          resultsTitle={resultsTitle || "policies"}
+          resultsTitle={"policies"}
           columns={generateTableHeaders({
             selectedTeamId: currentTeam?.id,
             canAddOrDeletePolicy,

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -219,7 +219,6 @@ const ManageQueriesPage = ({
               isLoading={isTableDataLoading}
               onCreateQueryClick={onCreateQueryClick}
               onDeleteQueryClick={onDeleteQueryClick}
-              searchable={!!queriesList}
               customControl={renderPlatformDropdown}
               selectedDropdownFilter={selectedDropdownFilter}
               isOnlyObserver={isOnlyObserver}

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -22,7 +22,6 @@ interface IQueriesTableProps {
   isLoading: boolean;
   onDeleteQueryClick: (selectedTableQueryIds: number[]) => void;
   onCreateQueryClick: () => void;
-  searchable: boolean;
   customControl?: () => JSX.Element;
   selectedDropdownFilter: string;
   isOnlyObserver?: boolean;
@@ -33,7 +32,6 @@ const QueriesTable = ({
   isLoading,
   onDeleteQueryClick,
   onCreateQueryClick,
-  searchable,
   customControl,
   selectedDropdownFilter,
   isOnlyObserver,
@@ -122,7 +120,7 @@ const QueriesTable = ({
         isAllPagesSelected={false}
         onQueryChange={handleSearchChange}
         inputPlaceHolder="Search by name"
-        searchable={searchable}
+        searchable={!!queriesList}
         disablePagination
         onPrimarySelectActionClick={onDeleteQueryClick}
         primarySelectActionButtonVariant="text-icon"

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -121,7 +121,6 @@ const QueriesTable = ({
         onQueryChange={handleSearchChange}
         inputPlaceHolder="Search by name"
         searchable={!!queriesList}
-        disablePagination
         onPrimarySelectActionClick={onDeleteQueryClick}
         primarySelectActionButtonVariant="text-icon"
         primarySelectActionButtonIcon="delete"

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -48,7 +48,7 @@ const renderTable = (
   toggleScheduleEditorModal: () => void,
   isOnGlobalTeam: boolean,
   selectedTeamData: ITeam | undefined,
-  isFetchingGlobalScheduledQueries: boolean,
+  isLoadingGlobalScheduledQueries: boolean,
   isLoadingTeamScheduledQueries: boolean,
   errorQueries: Error | null
 ): JSX.Element => {
@@ -63,7 +63,7 @@ const renderTable = (
       toggleScheduleEditorModal={toggleScheduleEditorModal}
       isOnGlobalTeam={isOnGlobalTeam}
       selectedTeamData={selectedTeamData}
-      loadingInheritedQueriesTableData={isFetchingGlobalScheduledQueries}
+      loadingInheritedQueriesTableData={isLoadingGlobalScheduledQueries}
       loadingTeamQueriesTableData={isLoadingTeamScheduledQueries}
     />
   );
@@ -75,7 +75,7 @@ const renderAllTeamsTable = (
   allTeamsScheduledQueriesError: Error | null,
   isOnGlobalTeam: boolean,
   selectedTeamData: ITeam | undefined,
-  isFetchingGlobalScheduledQueries: boolean,
+  isLoadingGlobalScheduledQueries: boolean,
   isLoadingTeamScheduledQueries: boolean
 ): JSX.Element => {
   return allTeamsScheduledQueriesError ? (
@@ -88,7 +88,7 @@ const renderAllTeamsTable = (
         allScheduledQueriesList={allTeamsScheduledQueriesList}
         isOnGlobalTeam={isOnGlobalTeam}
         selectedTeamData={selectedTeamData}
-        loadingInheritedQueriesTableData={isFetchingGlobalScheduledQueries}
+        loadingInheritedQueriesTableData={isLoadingGlobalScheduledQueries}
         loadingTeamQueriesTableData={isLoadingTeamScheduledQueries}
       />
     </div>
@@ -180,7 +180,7 @@ const ManageSchedulePage = ({
   const {
     data: globalScheduledQueries,
     error: globalScheduledQueriesError,
-    isFetching: isFetchingGlobalScheduledQueries,
+    isLoading: isLoadingGlobalScheduledQueries,
     refetch: refetchGlobalScheduledQueries,
   } = useQuery<
     ILoadAllGlobalScheduledQueriesResponse,
@@ -499,7 +499,7 @@ const ManageSchedulePage = ({
         <div>
           {isLoadingTeams ||
           isLoadingFleetQueries ||
-          isFetchingGlobalScheduledQueries ||
+          isLoadingGlobalScheduledQueries ||
           isLoadingTeamScheduledQueries ? (
             <Spinner />
           ) : (
@@ -512,7 +512,7 @@ const ManageSchedulePage = ({
               toggleScheduleEditorModal,
               isOnGlobalTeam || false,
               selectedTeamData,
-              isFetchingGlobalScheduledQueries,
+              isLoadingGlobalScheduledQueries,
               isLoadingTeamScheduledQueries,
               errorQueries
             )
@@ -542,7 +542,7 @@ const ManageSchedulePage = ({
             inheritedScheduledQueriesError,
             isOnGlobalTeam || false,
             selectedTeamData,
-            isFetchingGlobalScheduledQueries,
+            isLoadingGlobalScheduledQueries,
             isLoadingTeamScheduledQueries
           )}
         {showScheduleEditorModal && fleetQueries && (

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTable.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTable.tsx
@@ -183,12 +183,12 @@ const ScheduleTable = ({
         isAllPagesSelected={false}
         inputPlaceHolder="Search"
         searchable={false}
-        disablePagination
         onPrimarySelectActionClick={onRemoveScheduledQueryClick}
         primarySelectActionButtonVariant="text-icon"
         primarySelectActionButtonIcon="remove"
         primarySelectActionButtonText={"Remove"}
         emptyComponent={NoScheduledQueries}
+        isClientSidePagination
       />
     </div>
   );


### PR DESCRIPTION
Cerra #7144 

**FIX**
- Update default pagination page size from 100 to 20 and enable pagination for Queries, Schedule, and Policies table

**Other tech debt address**
- Remove unnecessary plumbing of "policies" text for `resultsTitle` and !!queriesList for `searchable` (set on TableContainer component doesn't need it passed through parent component)
- Change isFetchingGlobalScheduledQueries to isLoadingGlobalScheduledQueries because global scheduled queries is not refetched

<img width="1529" alt="Screen Shot 2022-08-11 at 12 57 53 PM" src="https://user-images.githubusercontent.com/71795832/184191264-e6d10353-cfba-4cc7-9af0-2560c8ee08bc.png">
<img width="1529" alt="Screen Shot 2022-08-11 at 12 57 40 PM" src="https://user-images.githubusercontent.com/71795832/184191267-cc9b6c96-8dd5-46b4-a7ae-ef8d084c62db.png">
<img width="1531" alt="Screen Shot 2022-08-11 at 12 57 22 PM" src="https://user-images.githubusercontent.com/71795832/184191270-a133ad64-dbb4-4b7e-a39d-f4786dc872f1.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
