### PR TITLE
Website: add Zapier webhook to signup.js

### DIFF
--- a/website/api/controllers/entrance/signup.js
+++ b/website/api/controllers/entrance/signup.js
@@ -129,7 +129,7 @@ the account verification message.)`,
         'firstName': signupReason === 'Buy a license' ? firstName : '?',
         'lastName': signupReason === 'Buy a license' ? lastName : '?',
         'signupReason': signupReason,
-        'webhook-secret': sails.config.custom.zapierSandboxWebhookSecret
+        'webhookSecret': sails.config.custom.zapierSandboxWebhookSecret
       }
     )
     .timeout(5000)

--- a/website/api/controllers/entrance/signup.js
+++ b/website/api/controllers/entrance/signup.js
@@ -55,6 +55,12 @@ the account verification message.)`,
       type: 'string',
       example: 'Rivera',
       description: 'The user\'s last name.',
+    },
+
+    signupReason: {
+      type: 'string',
+      isIn: ['Buy a license', 'Try Fleet Sandbox'],
+      defaultsTo: 'Buy a license',
     }
 
   },
@@ -81,7 +87,7 @@ the account verification message.)`,
   },
 
 
-  fn: async function ({emailAddress, password, firstName, lastName, organization}) {
+  fn: async function ({emailAddress, password, firstName, lastName, organization, signupReason}) {
 
     var newEmailAddress = emailAddress.toLowerCase();
 
@@ -114,7 +120,24 @@ the account verification message.)`,
         stripeCustomerId
       });
     }
-
+    // Send a POST request to Zapier
+    await sails.helpers.http.post(
+      'https://hooks.zapier.com/hooks/catch/3627242/bqsf4rj/',
+      {
+        'emailAddress': newEmailAddress,
+        'organization': signupReason === 'Buy a license' ? organization : '?',
+        'firstName': signupReason === 'Buy a license' ? firstName : '?',
+        'lastName': signupReason === 'Buy a license' ? lastName : '?',
+        'signupReason': signupReason,
+        'webhook-secret': sails.config.custom.zapierSandboxWebhookSecret
+      }
+    )
+    .timeout(5000)
+    .tolerate(['non200Response', 'requestFailed'], (err)=>{
+      // Note that Zapier responds with a 2xx status code even if something goes wrong, so just because this message is not logged doesn't mean everything is hunky dory.  More info: https://github.com/fleetdm/fleet/pull/6380#issuecomment-1204395762
+      sails.log.warn(`When a new user signed up, a lead/contact could not be verified in the CRM for this email address: ${newEmailAddress}. Raw error: ${err}`);
+      return;
+    });
     // Store the user's new id in their session.
     this.req.session.userId = newUserRecord.id;
 


### PR DESCRIPTION
Changes:
- Added a signupReason input
- Added a POST request to a Zapier webhook

These changes are similar to a request that is a part of #6380  (https://github.com/fleetdm/fleet/pull/6380/files#diff-9c6a73c96fdd057f48cfb92925ac8cbf02462ac4889c1ee6dd5bc88cec546465), with a couple of changes:
- The webhook secret is now being sent in the request body instead of a header. This was done because of how Zapier's webhook trigger works (you can choose between receiving a formatted request body, or headers and a raw request body)
- This request runs at every signup, (the request added to #6380 only runs when there is a Fleet sandbox signup)
- This request sends the users name and organization or uses '?' for the values if the user is signing up to try Fleet Sandbox



TODO after this PR is merged:
- [x] Update #6380 to resolve merge conflicts
- [x] Remove the Zapier webhook from #6380
