### PR TITLE
Website: add utm_source to Calendly link

### DIFF
--- a/website/assets/js/pages/customers/new-license.page.js
+++ b/website/assets/js/pages/customers/new-license.page.js
@@ -77,7 +77,7 @@ parasails.registerPage('new-license', {
     clickScheduleDemo: async function() {
       this.syncing = true;
       // Note: we keep loading spinner present indefinitely so that it is apparent that a new page is loading
-      window.location = 'https://calendly.com/fleetdm/demo';
+      window.location = 'https://calendly.com/fleetdm/demo?utm_source=self+service+100';
     },
 
     clickResetForm: async function() {


### PR DESCRIPTION
Changes: 
- Added a utm_source to the Calednly link on /customers/new-license