### PR TITLE
Website: hide documentation sidebars scrollbars

### DIFF
--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -311,6 +311,7 @@
     }
 
     [purpose='left-sidebar'] {
+      scrollbar-width: none;
       font-size: 14px;
       border-right: 1px solid @core-fleet-black-25;
 
@@ -353,9 +354,12 @@
       }
 
     }
+    [purpose='left-sidebar']::-webkit-scrollbar,[purpose='right-sidebar']::-webkit-scrollbar,[purpose='subtopics']::-webkit-scrollbar {
+      display: none;
+    }
 
     [purpose='right-sidebar'] {
-
+      scrollbar-width: none;
       p, a {
         font-size: 14px;
       }
@@ -688,6 +692,7 @@
         transition-duration: 500ms;
 
         [purpose='subtopics'] {
+          scrollbar-width: none;
           max-height: 100vh;
           overflow-y: auto;
           color: @core-fleet-black;

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -354,7 +354,7 @@
       }
 
     }
-    [purpose='left-sidebar']::-webkit-scrollbar,[purpose='right-sidebar']::-webkit-scrollbar,[purpose='subtopics']::-webkit-scrollbar {
+    [purpose='left-sidebar']::-webkit-scrollbar, [purpose='right-sidebar']::-webkit-scrollbar, [purpose='subtopics']::-webkit-scrollbar {
       display: none;
     }
 


### PR DESCRIPTION
Changes:
- Updated `basic-documentation.less` to hide scrollbars on the sidebar menus of documentation pages on fleetdm.com