### PR TITLE
Fleet UI: Remove underline from 2 cancel buttons

### DIFF
--- a/changes/issue-6915-remove-underline-on-cancel
+++ b/changes/issue-6915-remove-underline-on-cancel
@@ -1,0 +1,1 @@
+* Consistent styling for cancel buttons

--- a/frontend/pages/policies/PolicyPage/components/NewPolicyModal/NewPolicyModal.tsx
+++ b/frontend/pages/policies/PolicyPage/components/NewPolicyModal/NewPolicyModal.tsx
@@ -140,7 +140,7 @@ const NewPolicyModal = ({
             <Button
               className={`${baseClass}__button--modal-cancel`}
               onClick={() => setIsNewPolicyModalOpen(false)}
-              variant="text-link"
+              variant="inverse"
             >
               Cancel
             </Button>

--- a/frontend/pages/queries/QueryPage/components/NewQueryModal/NewQueryModal.tsx
+++ b/frontend/pages/queries/QueryPage/components/NewQueryModal/NewQueryModal.tsx
@@ -120,7 +120,7 @@ const NewQueryModal = ({
             <Button
               className={`${baseClass}__btn`}
               onClick={() => setIsSaveModalOpen(false)}
-              variant="text-link"
+              variant="inverse"
             >
               Cancel
             </Button>


### PR DESCRIPTION
Cerra #6915 

**Fix**
- Remove on hover underline on 2 cancel buttons

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
