### PR TITLE
allow to download installers without checking for authorization

### DIFF
--- a/frontend/components/AddHostsModal/DownloadInstallers/DownloadInstallers.tsx
+++ b/frontend/components/AddHostsModal/DownloadInstallers/DownloadInstallers.tsx
@@ -65,7 +65,6 @@ const DownloadInstallers = ({
   onCancel,
 }: IDownloadInstallersProps): JSX.Element => {
   const [includeDesktop, setIncludeDesktop] = useState(true);
-  const [isDownloadError, setIsDownloadError] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
   const [isDownloadSuccess, setIsDownloadSuccess] = useState(false);
   const [selectedInstaller, setSelectedInstaller] = useState<
@@ -78,23 +77,13 @@ const DownloadInstallers = ({
       return;
     }
     setIsDownloading(true);
-    try {
-      const blob: BlobPart = await installerAPI.downloadInstaller({
-        enrollSecret,
-        installerType,
-        includeDesktop,
-      });
-      const filename = `fleet-osquery.${installerType}`;
-      const file = new global.window.File([blob], filename, {
-        type: "application/octet-stream",
-      });
-      FileSaver.saveAs(file);
-      setIsDownloadSuccess(true);
-    } catch {
-      setIsDownloadError(true);
-    } finally {
-      setIsDownloading(false);
-    }
+    installerAPI.downloadInstaller({
+      enrollSecret,
+      installerType,
+      includeDesktop,
+    });
+    setIsDownloading(false);
+    setIsDownloadSuccess(true);
   };
 
   const onClickSelector = (type: IInstallerType) => {
@@ -108,14 +97,6 @@ const DownloadInstallers = ({
     }
     setSelectedInstaller(type);
   };
-
-  if (isDownloadError) {
-    return (
-      <div className={`${baseClass}__error`}>
-        <DataError />
-      </div>
-    );
-  }
 
   if (isDownloadSuccess) {
     const installerPlatform =

--- a/frontend/services/entities/installers.ts
+++ b/frontend/services/entities/installers.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { IInstallerType } from "interfaces/installer";
-import sendRequest from "services";
 import ENDPOINTS from "utilities/endpoints";
+import URL_PREFIX from "router/url_prefix";
 
 export interface IDownloadInstallerRequestParams {
   enrollSecret: string;
@@ -14,14 +14,14 @@ export default {
     enrollSecret,
     includeDesktop,
     installerType,
-  }: IDownloadInstallerRequestParams): Promise<BlobPart> => {
-    const path = `${
+  }: IDownloadInstallerRequestParams) => {
+    const { origin } = global.window.location;
+    const url = `${origin}${URL_PREFIX}/api/${
       ENDPOINTS.DOWNLOAD_INSTALLER
     }/${installerType}?desktop=${includeDesktop}&enroll_secret=${encodeURIComponent(
       enrollSecret
     )}`;
-    console.log("path: ", path);
 
-    return sendRequest("GET", path, undefined, "blob");
+    window.open(url);
   },
 };

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -360,8 +360,6 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 
 	ue.GET("/api/_version_/fleet/activities", listActivitiesEndpoint, listActivitiesRequest{})
 
-	ue.GET("/api/_version_/fleet/download_installer/{kind}", getInstallerEndpoint, installerRequest{})
-
 	ue.GET("/api/_version_/fleet/packs/{id:[0-9]+}/scheduled", getScheduledQueriesInPackEndpoint, getScheduledQueriesInPackRequest{})
 	ue.EndingAtVersion("v1").POST("/api/_version_/fleet/schedule", scheduleQueryEndpoint, scheduleQueryRequest{})
 	ue.StartingAtVersion("2022-04").POST("/api/_version_/fleet/packs/schedule", scheduleQueryEndpoint, scheduleQueryRequest{})
@@ -471,6 +469,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ne.POST("/api/v1/fleet/sso", initiateSSOEndpoint, initiateSSORequest{})
 	ne.POST("/api/v1/fleet/sso/callback", makeCallbackSSOEndpoint(config.Server.URLPrefix), callbackSSORequest{})
 	ne.GET("/api/v1/fleet/sso", settingsSSOEndpoint, nil)
+	ne.GET("/api/_version_/fleet/download_installer/{kind}", getInstallerEndpoint, installerRequest{})
 
 	// the websocket distributed query results endpoint is a bit different - the
 	// provided path is a prefix, not an exact match, and it is not a go-kit

--- a/server/service/integration_sandbox_test.go
+++ b/server/service/integration_sandbox_test.go
@@ -86,10 +86,13 @@ func (s *integrationSandboxTestSuite) TestInstallerGet() {
 	require.Equal(t, "attachment", r.Header.Get("Content-Disposition"))
 
 	// unauthorized requests
-	s.DoRawNoAuth("GET", validURL, nil, http.StatusUnauthorized)
-	s.token = "invalid"
-	s.Do("GET", validURL, nil, http.StatusUnauthorized)
-	s.token = s.cachedAdminToken
+	r = s.DoRawNoAuth("GET", validURL, nil, http.StatusOK)
+	body, err = io.ReadAll(r.Body)
+	require.NoError(t, err)
+	require.Equal(t, "mock", string(body))
+	require.Equal(t, "application/octet-stream", r.Header.Get("Content-Type"))
+	require.Equal(t, "4", r.Header.Get("Content-Length"))
+	require.Equal(t, "attachment", r.Header.Get("Content-Disposition"))
 
 	// wrong enroll secret
 	s.Do("GET", installerURL("wrong-enroll", "pkg", false), nil, http.StatusInternalServerError)


### PR DESCRIPTION
Related to https://github.com/fleetdm/fleet/issues/7206, this delegates the handling of the download to the browser:

![2022-08-15 16 23 57](https://user-images.githubusercontent.com/4419992/184705371-5155b401-4176-4484-8eab-e1e57f140a09.gif)

# Checklist for submitter

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
