### PR TITLE
Fleet Sandbox: Login for sandbox redirects to sandbox's login url

### DIFF
--- a/changes/issue-7211-redirect-to-sandbox-login
+++ b/changes/issue-7211-redirect-to-sandbox-login
@@ -1,0 +1,1 @@
+* Sandbox redirects to sandbox login

--- a/frontend/router/components/AuthenticatedRoutes/AuthenticatedRoutes.tsx
+++ b/frontend/router/components/AuthenticatedRoutes/AuthenticatedRoutes.tsx
@@ -28,6 +28,10 @@ export const AuthenticatedRoutes = ({
     return router.push(LOGIN);
   };
 
+  const redirectToSandboxLogin = () => {
+    return router.push("https://www.fleetdm.com/try-fleet/login");
+  };
+
   const redirectToPasswordReset = () => {
     const { RESET_PASSWORD } = paths;
 
@@ -43,7 +47,12 @@ export const AuthenticatedRoutes = ({
   useDeepEffect(() => {
     // this works with App.tsx. if authToken does
     // exist, user state is checked and fetched if null
+
     if (!authToken()) {
+      if (window.location.pathname.includes("sandbox")) {
+        return redirectToSandboxLogin();
+      }
+
       return redirectToLogin();
     }
 


### PR DESCRIPTION
Cerra #7211 

- When redirected to login page, fleet sandbox is directed to www.fleetdm.com/try-fleet/login
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] Manual QA for all new/changed functionality
