### PR TITLE
adjust installers endpoint to avoid AJAX downloads

### DIFF
--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -1725,7 +1725,7 @@ Downloads a pre-built fleet-osquery installer with the given parameters.
 | ------------- | ------- | ---------------------- | ------------------------------------------------------------------ |
 | kind          | string  | path                   | The installer kind: pkg, msi, deb or rpm.                          |
 | enroll_secret | string  | x-www-form-urlencoded  | The global enroll secret.                                          |
-| token         | string  | x-www-form-urlencoded  | The Authentication token.                                          |
+| token         | string  | x-www-form-urlencoded  | The authentication token.                                          |
 | desktop       | boolean | x-www-form-urlencoded  | Set to `true` to ask for an installer that includes Fleet Desktop. |
 
 ##### Default response

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -1717,15 +1717,16 @@ Redirects to the transparency URL.
 
 Downloads a pre-built fleet-osquery installer with the given parameters.
 
-`GET /api/_version_/fleet/download_installer/{kind}`
+`POST /api/_version_/fleet/download_installer/{kind}`
 
 #### Parameters
 
-| Name          | Type    | In    | Description                                                        |
-| ------------- | ------- | ----- | ------------------------------------------------------------------ |
-| kind          | string  | path  | The installer kind: pkg, msi, deb or rpm.                          |
-| enroll_secret | string  | query | The global enroll secret.                                          |
-| desktop       | boolean | query | Set to `true` to ask for an installer that includes Fleet Desktop. |
+| Name          | Type    | In                     | Description                                                        |
+| ------------- | ------- | ---------------------- | ------------------------------------------------------------------ |
+| kind          | string  | path                   | The installer kind: pkg, msi, deb or rpm.                          |
+| enroll_secret | string  | x-www-form-urlencoded  | The global enroll secret.                                          |
+| token         | string  | x-www-form-urlencoded  | The Authentication token.                                          |
+| desktop       | boolean | x-www-form-urlencoded  | Set to `true` to ask for an installer that includes Fleet Desktop. |
 
 ##### Default response
 

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -1752,7 +1752,7 @@ This error occurs if an installer with the provided parameters doesn't exist.
 
 Checks if a pre-built fleet-osquery installer with the given parameters exists.
 
-`HEAD /api/_version_/fleet/download_installer/{enroll_secret}/{kind}`
+`HEAD /api/_version_/fleet/download_installer/{kind}`
 
 #### Parameters
 

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -1758,8 +1758,8 @@ Checks if a pre-built fleet-osquery installer with the given parameters exists.
 
 | Name          | Type    | In    | Description                                                        |
 | ------------- | ------- | ----- | ------------------------------------------------------------------ |
-| enroll_secret | string  | path  | The global enroll secret.                                          |
 | kind          | string  | path  | The installer kind: pkg, msi, deb or rpm.                          |
+| enroll_secret | string  | query | The global enroll secret.                                          |
 | desktop       | boolean | query | Set to `true` to ask for an installer that includes Fleet Desktop. |
 
 ##### Default response

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -32,6 +32,7 @@ Unlike the [Fleet REST API documentation](../Using-Fleet/REST-API.md), only the 
     - [Get device's policies](#get-devices-policies)
     - [Get device's API features](#get-devices-api-features)
     - [Get device's transparency URL](#get-devices-transparency-url)
+- [Check if an installer exists](#check-if-an-installer-exists)
 - [Download an installer](#download-an-installer)
 
 ### Get queries spec
@@ -1745,6 +1746,33 @@ If an installer with the provided parameters is found, the installer is returned
 `Status: 400`
 
 This error occurs if an installer with the provided parameters doesn't exist.
+
+
+### Check if an installer exists 
+
+Checks if a pre-built fleet-osquery installer with the given parameters exists.
+
+`HEAD /api/_version_/fleet/download_installer/{enroll_secret}/{kind}`
+
+#### Parameters
+
+| Name          | Type    | In    | Description                                                        |
+| ------------- | ------- | ----- | ------------------------------------------------------------------ |
+| enroll_secret | string  | path  | The global enroll secret.                                          |
+| kind          | string  | path  | The installer kind: pkg, msi, deb or rpm.                          |
+| desktop       | boolean | query | Set to `true` to ask for an installer that includes Fleet Desktop. |
+
+##### Default response
+
+`Status: 200`
+
+If an installer with the provided parameters is found.
+
+##### Installer doesn't exist
+
+`Status: 400`
+
+If an installer with the provided parameters doesn't exist.
 
 
 <meta name="pageOrderInSection" value="800">

--- a/frontend/components/AddHostsModal/DownloadInstallers/DownloadInstallers.tsx
+++ b/frontend/components/AddHostsModal/DownloadInstallers/DownloadInstallers.tsx
@@ -83,7 +83,6 @@ const DownloadInstallers = ({
       // do nothing
       return;
     }
-    console.log(event);
     event.preventDefault();
     event.persist();
 
@@ -102,7 +101,6 @@ const DownloadInstallers = ({
         setIsDownloadSuccess(true);
       });
     } catch (error) {
-      console.log(error);
       setIsDownloadError(true);
     } finally {
       setIsDownloading(false);

--- a/frontend/components/AddHostsModal/DownloadInstallers/DownloadInstallers.tsx
+++ b/frontend/components/AddHostsModal/DownloadInstallers/DownloadInstallers.tsx
@@ -83,11 +83,16 @@ const DownloadInstallers = ({
       // do nothing
       return;
     }
+
+    // Prevent the submit behavior, as we want to control when the POST is
+    // actually performed.
     event.preventDefault();
     event.persist();
 
     setIsDownloading(true);
     try {
+      // First check if the installer exists, no need to save the result of
+      // this operation as any status other than 200 will throw an error
       await installerAPI.checkInstallerExistence({
         enrollSecret,
         includeDesktop,
@@ -97,6 +102,7 @@ const DownloadInstallers = ({
       // For some reason only Firefox fails with NS_ERROR_FAILURE unless we
       // push back this operation to the bottom of the event queue
       setTimeout(() => {
+        // Submit the form now that we know that is safe to do so.
         (event.target as HTMLFormElement).submit();
         setIsDownloadSuccess(true);
       });

--- a/frontend/components/AddHostsModal/DownloadInstallers/_styles.scss
+++ b/frontend/components/AddHostsModal/DownloadInstallers/_styles.scss
@@ -4,6 +4,10 @@
   padding: 0;
   padding-bottom: 20px;
 
+  iframe {
+    display: none;
+  }
+
   p {
     padding-top: $pad-small;
     padding-bottom: $pad-medium;
@@ -96,6 +100,10 @@
     p {
       margin: 0;
       padding-bottom: 24px;
+    }
+
+    iframe {
+      display: none;
     }
   }
 

--- a/frontend/services/entities/installers.ts
+++ b/frontend/services/entities/installers.ts
@@ -3,25 +3,24 @@ import { IInstallerType } from "interfaces/installer";
 import sendRequest from "services";
 import ENDPOINTS from "utilities/endpoints";
 
-export interface IDownloadInstallerRequestParams {
+export interface ICheckInstallerExistenceRequestParams {
   enrollSecret: string;
   includeDesktop: boolean;
   installerType: IInstallerType;
 }
 
 export default {
-  downloadInstaller: ({
+  checkInstallerExistence: ({
     enrollSecret,
     includeDesktop,
     installerType,
-  }: IDownloadInstallerRequestParams): Promise<BlobPart> => {
+  }: ICheckInstallerExistenceRequestParams): Promise<BlobPart> => {
     const path = `${
       ENDPOINTS.DOWNLOAD_INSTALLER
     }/${installerType}?desktop=${includeDesktop}&enroll_secret=${encodeURIComponent(
       enrollSecret
     )}`;
-    console.log("path: ", path);
 
-    return sendRequest("GET", path, undefined, "blob");
+    return sendRequest("HEAD", path, undefined);
   },
 };

--- a/frontend/services/index.ts
+++ b/frontend/services/index.ts
@@ -7,7 +7,7 @@ import local from "utilities/local";
 import URL_PREFIX from "router/url_prefix";
 
 const sendRequest = async (
-  method: "GET" | "POST" | "PATCH" | "DELETE",
+  method: "GET" | "POST" | "PATCH" | "DELETE" | "HEAD",
   path: string,
   data?: unknown,
   responseType: AxiosResponseType = "json"

--- a/server/contexts/token/token.go
+++ b/server/contexts/token/token.go
@@ -16,12 +16,16 @@ const tokenKey key = 0
 type Token string
 
 // FromHTTPRequest extracts an Authorization
-// from an HTTP header if present.
+// from an HTTP request if present.
 func FromHTTPRequest(r *http.Request) Token {
 	headers := r.Header.Get("Authorization")
 	headerParts := strings.Split(headers, " ")
 	if len(headerParts) != 2 || strings.ToUpper(headerParts[0]) != "BEARER" {
-		return ""
+		if err := r.ParseForm(); err != nil {
+			return ""
+		}
+
+		return Token(r.FormValue("token"))
 	}
 	return Token(headerParts[1])
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -30,6 +30,7 @@ type CarveStore interface {
 type InstallerStore interface {
 	Get(ctx context.Context, installer Installer) (io.ReadCloser, int64, error)
 	Put(ctx context.Context, installer Installer) (string, error)
+	Exists(ctx context.Context, installer Installer) (bool, error)
 }
 
 // Datastore combines all the interfaces in the Fleet DAL

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -485,4 +485,5 @@ type Service interface {
 	// Installers
 
 	GetInstaller(ctx context.Context, installer Installer) (io.ReadCloser, int64, error)
+	CheckInstallerExistence(ctx context.Context, installer Installer) error
 }

--- a/server/mock/datastore_installers.go
+++ b/server/mock/datastore_installers.go
@@ -15,12 +15,17 @@ type GetFunc func(ctx context.Context, installer fleet.Installer) (io.ReadCloser
 
 type PutFunc func(ctx context.Context, installer fleet.Installer) (string, error)
 
+type ExistsFunc func(ctx context.Context, installer fleet.Installer) (bool, error)
+
 type InstallerStore struct {
 	GetFunc        GetFunc
 	GetFuncInvoked bool
 
 	PutFunc        PutFunc
 	PutFuncInvoked bool
+
+	ExistsFunc        ExistsFunc
+	ExistsFuncInvoked bool
 }
 
 func (s *InstallerStore) Get(ctx context.Context, installer fleet.Installer) (io.ReadCloser, int64, error) {
@@ -31,4 +36,9 @@ func (s *InstallerStore) Get(ctx context.Context, installer fleet.Installer) (io
 func (s *InstallerStore) Put(ctx context.Context, installer fleet.Installer) (string, error) {
 	s.PutFuncInvoked = true
 	return s.PutFunc(ctx, installer)
+}
+
+func (s *InstallerStore) Exists(ctx context.Context, installer fleet.Installer) (bool, error) {
+	s.ExistsFuncInvoked = true
+	return s.ExistsFunc(ctx, installer)
 }

--- a/server/service/endpoint_utils.go
+++ b/server/service/endpoint_utils.go
@@ -363,6 +363,10 @@ func (e *authEndpointer) DELETE(path string, f handlerFunc, v interface{}) {
 	e.handleEndpoint(path, f, v, "DELETE")
 }
 
+func (e *authEndpointer) HEAD(path string, f handlerFunc, v interface{}) {
+	e.handleEndpoint(path, f, v, "HEAD")
+}
+
 // PathHandler registers a handler for the verb and path. The pathHandler is
 // a function that receives the actual path to which it will be mounted, and
 // returns the actual http.Handler that will handle this endpoint. This is for

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -360,7 +360,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 
 	ue.GET("/api/_version_/fleet/activities", listActivitiesEndpoint, listActivitiesRequest{})
 
-	ue.GET("/api/_version_/fleet/download_installer/{kind}", getInstallerEndpoint, installerRequest{})
+	ue.POST("/api/_version_/fleet/download_installer/{kind}", getInstallerEndpoint, getInstallerRequest{})
 
 	ue.GET("/api/_version_/fleet/packs/{id:[0-9]+}/scheduled", getScheduledQueriesInPackEndpoint, getScheduledQueriesInPackRequest{})
 	ue.EndingAtVersion("v1").POST("/api/_version_/fleet/schedule", scheduleQueryEndpoint, scheduleQueryRequest{})

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -361,6 +361,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.GET("/api/_version_/fleet/activities", listActivitiesEndpoint, listActivitiesRequest{})
 
 	ue.POST("/api/_version_/fleet/download_installer/{kind}", getInstallerEndpoint, getInstallerRequest{})
+	ue.HEAD("/api/_version_/fleet/download_installer/{kind}", checkInstallerEndpoint, checkInstallerRequest{})
 
 	ue.GET("/api/_version_/fleet/packs/{id:[0-9]+}/scheduled", getScheduledQueriesInPackEndpoint, getScheduledQueriesInPackRequest{})
 	ue.EndingAtVersion("v1").POST("/api/_version_/fleet/schedule", scheduleQueryEndpoint, scheduleQueryRequest{})

--- a/server/service/installer_test.go
+++ b/server/service/installer_test.go
@@ -99,3 +99,76 @@ func TestGetInstaller(t *testing.T) {
 		require.True(t, is.GetFuncInvoked)
 	})
 }
+func TestCheckInstallerExistence(t *testing.T) {
+	t.Run("unauthorized access is not allowed", func(t *testing.T) {
+		_, _, _, svc := setup(t)
+		err := svc.CheckInstallerExistence(context.Background(), fleet.Installer{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), authz.ForbiddenErrorMessage)
+	})
+
+	t.Run("errors if store is not configured", func(t *testing.T) {
+		ctx, ds, _, _ := setup(t)
+		svc := newTestService(t, ds, nil, nil, &TestServerOpts{Is: nil})
+		err := svc.CheckInstallerExistence(ctx, fleet.Installer{})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "installer storage has not been configured")
+	})
+
+	t.Run("errors if the provided enroll secret cannot be found", func(t *testing.T) {
+		ctx, ds, _, svc := setup(t)
+		ds.VerifyEnrollSecretFunc = func(ctx context.Context, enrollSecret string) (*fleet.EnrollSecret, error) {
+			return nil, notFoundError{}
+		}
+		err := svc.CheckInstallerExistence(ctx, fleet.Installer{})
+		require.Error(t, err)
+		require.ErrorAs(t, err, &notFoundError{})
+		require.True(t, ds.VerifyEnrollSecretFuncInvoked)
+	})
+
+	t.Run("errors if there's a problem verifying the enroll secret", func(t *testing.T) {
+		ctx, ds, _, svc := setup(t)
+		ds.VerifyEnrollSecretFunc = func(ctx context.Context, enrollSecret string) (*fleet.EnrollSecret, error) {
+			return nil, ctxerr.New(ctx, "test error")
+		}
+		err := svc.CheckInstallerExistence(ctx, fleet.Installer{})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "test error")
+		require.True(t, ds.VerifyEnrollSecretFuncInvoked)
+	})
+
+	t.Run("errors if there's a problem checking the blob storage", func(t *testing.T) {
+		ctx, ds, is, svc := setup(t)
+		is.ExistsFunc = func(ctx context.Context, installer fleet.Installer) (bool, error) {
+			return false, ctxerr.New(ctx, "test error")
+		}
+		err := svc.CheckInstallerExistence(ctx, fleet.Installer{})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "test error")
+		require.True(t, ds.VerifyEnrollSecretFuncInvoked)
+		require.True(t, is.ExistsFuncInvoked)
+	})
+
+	t.Run("errors with not found if the installer is not in the storage", func(t *testing.T) {
+		ctx, ds, is, svc := setup(t)
+		is.ExistsFunc = func(ctx context.Context, installer fleet.Installer) (bool, error) {
+			return false, nil
+		}
+		err := svc.CheckInstallerExistence(ctx, fleet.Installer{})
+		require.Error(t, err)
+		require.ErrorAs(t, err, &notFoundError{})
+		require.True(t, ds.VerifyEnrollSecretFuncInvoked)
+		require.True(t, is.ExistsFuncInvoked)
+	})
+
+	t.Run("returns no errors if the installer exists", func(t *testing.T) {
+		ctx, ds, is, svc := setup(t)
+		is.ExistsFunc = func(ctx context.Context, installer fleet.Installer) (bool, error) {
+			return true, nil
+		}
+		err := svc.CheckInstallerExistence(ctx, fleet.Installer{})
+		require.NoError(t, err)
+		require.True(t, ds.VerifyEnrollSecretFuncInvoked)
+		require.True(t, is.ExistsFuncInvoked)
+	})
+}

--- a/server/service/installer_test.go
+++ b/server/service/installer_test.go
@@ -109,7 +109,9 @@ func TestCheckInstallerExistence(t *testing.T) {
 
 	t.Run("errors if store is not configured", func(t *testing.T) {
 		ctx, ds, _, _ := setup(t)
-		svc := newTestService(t, ds, nil, nil, &TestServerOpts{Is: nil})
+		cfg := config.TestConfig()
+		cfg.Server.SandboxEnabled = true
+		svc := newTestServiceWithConfig(t, ds, cfg, nil, nil, &TestServerOpts{Is: nil, FleetConfig: &cfg})
 		err := svc.CheckInstallerExistence(ctx, fleet.Installer{})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "installer storage has not been configured")

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5112,8 +5112,8 @@ func (s *integrationTestSuite) TestSandboxEndpoints() {
 	require.NotEqual(t, http.StatusOK, res.StatusCode)
 
 	// installers endpoint is not enabled
-	url, installersBody := installerReq(enrollSecret, "pkg", s.token, "false")
-	s.DoRaw("GET", url, installersBody, http.StatusInternalServerError)
+	url, installersBody := installerGETReq(enrollSecret, "pkg", s.token, false)
+	s.DoRaw("POST", url, installersBody, http.StatusInternalServerError)
 }
 
 func (s *integrationTestSuite) TestGetHostBatteries() {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5112,8 +5112,8 @@ func (s *integrationTestSuite) TestSandboxEndpoints() {
 	require.NotEqual(t, http.StatusOK, res.StatusCode)
 
 	// installers endpoint is not enabled
-	validURL := installerURL(enrollSecret, "pkg", false)
-	s.Do("GET", validURL, nil, http.StatusInternalServerError)
+	url, installersBody := installerReq(enrollSecret, "pkg", s.token, "false")
+	s.DoRaw("GET", url, installersBody, http.StatusInternalServerError)
 }
 
 func (s *integrationTestSuite) TestGetHostBatteries() {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5112,7 +5112,7 @@ func (s *integrationTestSuite) TestSandboxEndpoints() {
 	require.NotEqual(t, http.StatusOK, res.StatusCode)
 
 	// installers endpoint is not enabled
-	url, installersBody := installerGETReq(enrollSecret, "pkg", s.token, false)
+	url, installersBody := installerPOSTReq(enrollSecret, "pkg", s.token, false)
 	s.DoRaw("POST", url, installersBody, http.StatusInternalServerError)
 }
 

--- a/server/service/integration_sandbox_test.go
+++ b/server/service/integration_sandbox_test.go
@@ -84,7 +84,7 @@ func (s *integrationSandboxTestSuite) TestInstallerGet() {
 	require.Equal(t, "mock", string(body))
 	require.Equal(t, "application/octet-stream", r.Header.Get("Content-Type"))
 	require.Equal(t, "4", r.Header.Get("Content-Length"))
-	require.Equal(t, "attachment", r.Header.Get("Content-Disposition"))
+	require.Equal(t, `attachment;filename="fleet-osquery.pkg"`, r.Header.Get("Content-Disposition"))
 
 	// unauthorized requests
 	s.DoRawNoAuth("GET", validURL, nil, http.StatusUnauthorized)
@@ -105,7 +105,7 @@ func (s *integrationSandboxTestSuite) TestInstallerGet() {
 func (s *integrationSandboxTestSuite) TestInstallerHeadCheck() {
 	// make sure FLEET_DEMO is not set
 	os.Unsetenv("FLEET_DEMO")
-	validURL := fmt.Sprintf("/api/latest/fleet/download_installer/%s/%s", enrollSecret, "pkg")
+	validURL := fmt.Sprintf("/api/latest/fleet/download_installer/%s?enroll_secret=%s", enrollSecret, "pkg")
 	s.Do("HEAD", validURL, nil, http.StatusInternalServerError)
 
 	os.Setenv("FLEET_DEMO", "1")
@@ -121,11 +121,11 @@ func (s *integrationSandboxTestSuite) TestInstallerHeadCheck() {
 	s.token = s.cachedAdminToken
 
 	// wrong enroll secret
-	invalidURL := fmt.Sprintf("/api/latest/fleet/download_installer/%s/%s", "wrong-enroll", "pkg")
+	invalidURL := fmt.Sprintf("/api/latest/fleet/download_installer/%s?enroll_secret=%s", "wrong-enroll", "pkg")
 	s.Do("HEAD", invalidURL, nil, http.StatusInternalServerError)
 
 	// non-existent package
-	invalidURL = fmt.Sprintf("/api/latest/fleet/download_installer/%s/%s", enrollSecret, "exe")
+	invalidURL = fmt.Sprintf("/api/latest/fleet/download_installer/%s?enroll_secret=%s", enrollSecret, "exe")
 	s.Do("HEAD", invalidURL, nil, http.StatusNotFound)
 }
 

--- a/server/service/integration_sandbox_test.go
+++ b/server/service/integration_sandbox_test.go
@@ -75,7 +75,7 @@ func (s *integrationSandboxTestSuite) TestDemoLogin() {
 func (s *integrationSandboxTestSuite) TestInstallerGet() {
 	t := s.T()
 
-	validURL, formBody := installerGETReq(enrollSecret, "pkg", s.token, false)
+	validURL, formBody := installerPOSTReq(enrollSecret, "pkg", s.token, false)
 
 	r := s.DoRaw("POST", validURL, formBody, http.StatusOK)
 	body, err := io.ReadAll(r.Body)
@@ -92,11 +92,11 @@ func (s *integrationSandboxTestSuite) TestInstallerGet() {
 	s.token = s.cachedAdminToken
 
 	// wrong enroll secret
-	wrongURL, wrongFormBody := installerGETReq("wrong-enroll", "pkg", s.token, false)
+	wrongURL, wrongFormBody := installerPOSTReq("wrong-enroll", "pkg", s.token, false)
 	s.Do("POST", wrongURL, wrongFormBody, http.StatusInternalServerError)
 
 	// non-existent package
-	wrongURL, wrongFormBody = installerGETReq(enrollSecret, "exe", s.token, false)
+	wrongURL, wrongFormBody = installerPOSTReq(enrollSecret, "exe", s.token, false)
 	s.Do("POST", wrongURL, wrongFormBody, http.StatusNotFound)
 }
 
@@ -127,7 +127,7 @@ func installerURL(secret, kind string, desktop bool) string {
 	return path
 }
 
-func installerGETReq(secret, kind, token string, desktop bool) (string, []byte) {
+func installerPOSTReq(secret, kind, token string, desktop bool) (string, []byte) {
 	path := installerURL(secret, kind, desktop)
 	d := "0"
 	if desktop {

--- a/server/service/integration_sandbox_test.go
+++ b/server/service/integration_sandbox_test.go
@@ -106,6 +106,6 @@ func installerReq(secret, kind, token, desktop string) (string, []byte) {
 	formBody := make(url.Values)
 	formBody.Set("token", token)
 	formBody.Set("enroll_secret", secret)
-	formBody.Set("desktop", string(desktop))
+	formBody.Set("desktop", desktop)
 	return path, []byte(formBody.Encode())
 }

--- a/server/service/integration_sandbox_test.go
+++ b/server/service/integration_sandbox_test.go
@@ -87,19 +87,18 @@ func (s *integrationSandboxTestSuite) TestInstallerGet() {
 	require.Equal(t, `attachment;filename="fleet-osquery.pkg"`, r.Header.Get("Content-Disposition"))
 
 	// unauthorized requests
-	s.DoRawNoAuth("GET", validURL, nil, http.StatusUnauthorized)
+	s.DoRawNoAuth("POST", validURL, nil, http.StatusUnauthorized)
 	s.token = "invalid"
-	s.Do("GET", validURL, nil, http.StatusUnauthorized)
+	s.Do("POST", validURL, nil, http.StatusUnauthorized)
 	s.token = s.cachedAdminToken
 
 	// wrong enroll secret
 	wrongURL, wrongFormBody := installerReq("wrong-enroll", "pkg", s.token, "false")
-	s.Do("GET", wrongURL, wrongFormBody, http.StatusInternalServerError)
+	s.Do("POST", wrongURL, wrongFormBody, http.StatusInternalServerError)
 
 	// non-existent package
 	wrongURL, wrongFormBody = installerReq("wrong-enroll", "exe", s.token, "false")
-	s.Do("GET", wrongURL, wrongFormBody, http.StatusInternalServerError)
-	s.Do("GET", wrongURL, wrongFormBody, http.StatusNotFound)
+	s.Do("POST", wrongURL, wrongFormBody, http.StatusNotFound)
 }
 
 func (s *integrationSandboxTestSuite) TestInstallerHeadCheck() {
@@ -115,9 +114,9 @@ func (s *integrationSandboxTestSuite) TestInstallerHeadCheck() {
 	s.Do("HEAD", validURL, nil, http.StatusOK)
 
 	// unauthorized requests
-	s.DoRawNoAuth("GET", validURL, nil, http.StatusUnauthorized)
+	s.DoRawNoAuth("HEAD", validURL, nil, http.StatusUnauthorized)
 	s.token = "invalid"
-	s.Do("GET", validURL, nil, http.StatusUnauthorized)
+	s.Do("HEAD", validURL, nil, http.StatusUnauthorized)
 	s.token = s.cachedAdminToken
 
 	// wrong enroll secret


### PR DESCRIPTION
Related to https://github.com/fleetdm/fleet/issues/7206, this delegates the handling of the download to the browser:

![2022-08-16 08 27 58](https://user-images.githubusercontent.com/4419992/184869008-90c193d8-f99e-463c-9c9b-4c178d2753ae.gif)


# Checklist for submitter

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
