### PR TITLE
use _self instead of iframe to download installers

### DIFF
--- a/frontend/components/AddHostsModal/DownloadInstallers/DownloadInstallers.tsx
+++ b/frontend/components/AddHostsModal/DownloadInstallers/DownloadInstallers.tsx
@@ -100,7 +100,7 @@ const DownloadForm: FunctionComponent<IDownloadFormProps> = ({
           disabled={!selectedInstaller}
           type="submit"
         >
-          {isCheckingForInstaller ? <Spinner /> : "Download insssstaller"}
+          {isCheckingForInstaller ? <Spinner /> : "Download installer"}
         </Button>
       )}
     </form>

--- a/frontend/components/AddHostsModal/DownloadInstallers/DownloadInstallers.tsx
+++ b/frontend/components/AddHostsModal/DownloadInstallers/DownloadInstallers.tsx
@@ -37,7 +37,7 @@ interface IDownloadFormProps {
   enrollSecret: string;
   includeDesktop: boolean;
   selectedInstaller: string | undefined;
-  isDownloading: boolean;
+  isCheckingForInstaller: boolean;
   isDownloadSuccess: boolean;
 }
 
@@ -80,7 +80,7 @@ const DownloadForm: FunctionComponent<IDownloadFormProps> = ({
   enrollSecret,
   includeDesktop,
   selectedInstaller,
-  isDownloading,
+  isCheckingForInstaller,
   isDownloadSuccess,
 }) => {
   return (
@@ -100,7 +100,7 @@ const DownloadForm: FunctionComponent<IDownloadFormProps> = ({
           disabled={!selectedInstaller}
           type="submit"
         >
-          {isDownloading ? <Spinner /> : "Download installer"}
+          {isCheckingForInstaller ? <Spinner /> : "Download insssstaller"}
         </Button>
       )}
     </form>
@@ -174,7 +174,7 @@ const DownloadInstallers = ({
       enrollSecret={enrollSecret}
       includeDesktop={includeDesktop}
       selectedInstaller={selectedInstaller}
-      isDownloading={isDownloading}
+      isCheckingForInstaller={isDownloading}
       isDownloadSuccess={isDownloadSuccess}
     />
   );

--- a/frontend/components/AddHostsModal/DownloadInstallers/DownloadInstallers.tsx
+++ b/frontend/components/AddHostsModal/DownloadInstallers/DownloadInstallers.tsx
@@ -88,13 +88,12 @@ const DownloadForm: FunctionComponent<IDownloadFormProps> = ({
       key="form"
       method="POST"
       action={url}
-      target="auxFrame"
+      target="_self"
       onSubmit={onSubmit}
     >
       <input type="hidden" name="token" value={token || ""} />
       <input type="hidden" name="enroll_secret" value={enrollSecret} />
       <input type="hidden" name="desktop" value={String(includeDesktop)} />
-      <iframe title="auxFrame" name="auxFrame" />
       {!isDownloadSuccess && (
         <Button
           className={`${baseClass}__button--download`}

--- a/frontend/components/AddHostsModal/DownloadInstallers/_styles.scss
+++ b/frontend/components/AddHostsModal/DownloadInstallers/_styles.scss
@@ -4,10 +4,6 @@
   padding: 0;
   padding-bottom: 20px;
 
-  iframe {
-    display: none;
-  }
-
   p {
     padding-top: $pad-small;
     padding-bottom: $pad-medium;
@@ -100,10 +96,6 @@
     p {
       margin: 0;
       padding-bottom: 24px;
-    }
-
-    iframe {
-      display: none;
     }
   }
 


### PR DESCRIPTION
This updates the modal to download installers with an idea from @gillespi314 to simplify the process and ensure the interaction doesn't get blocked as a pop-up