### PR TITLE
Fleet UI: Remove dead space on queries table platform column

### DIFF
--- a/changes/issue-7156-query-table-column-widths
+++ b/changes/issue-7156-query-table-column-widths
@@ -1,0 +1,1 @@
+* Less dead space on queries table

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -116,10 +116,10 @@
       .data-table__table {
         thead {
           .name__header {
-            width: $col-lg;
+            width: auto;
           }
           .platforms__header {
-            width: auto;
+            width: $col-sm;
           }
           .author_name__header {
             display: none;
@@ -130,9 +130,6 @@
             width: 0;
           }
           @media (min-width: $break-990) {
-            .platforms__header {
-              width: $col-md;
-            }
             .author_name__header {
               display: table-cell;
               width: auto;


### PR DESCRIPTION
Cerra #7156 

**Fix**
- Platform column with platform icons a fixed width removing dead space in this column
- Allows for larger width for query name column so there's less truncated text

https://user-images.githubusercontent.com/71795832/184991808-f43a4523-e095-435b-8164-98b0cb0c255e.mov

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
