### PR TITLE
Frontend: Refactor building query params for export hosts and host count

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -278,7 +278,7 @@ const ManageHostsPage = ({
       ? parseInt(queryParams?.mdm_id, 10)
       : undefined;
   const mdmEnrollmentStatus = queryParams?.mdm_enrollment_status;
-  const { os_id, os_name, os_version } = queryParams;
+  const { os_id: osId, os_name: osName, os_version: osVersion } = queryParams;
   const { active_label: activeLabel, label_id: labelID } = routeParams;
 
   // ===== filter matching
@@ -540,9 +540,9 @@ const ManageHostsPage = ({
       softwareId,
       mdmId,
       mdmEnrollmentStatus,
-      os_id,
-      os_name,
-      os_version,
+      osId,
+      osName,
+      osVersion,
       page: tableQueryData ? tableQueryData.pageIndex : 0,
       perPage: tableQueryData ? tableQueryData.pageSize : 100,
       device_mapping: true,
@@ -802,15 +802,15 @@ const ManageHostsPage = ({
       }
 
       if (
-        (os_id || (os_name && os_version)) &&
+        (osId || (osName && osVersion)) &&
         !softwareId &&
         !policyId &&
         !mdmEnrollmentStatus &&
         !mdmId
       ) {
-        newQueryParams.os_id = os_id;
-        newQueryParams.os_name = os_name;
-        newQueryParams.os_version = os_version;
+        newQueryParams.os_id = osId;
+        newQueryParams.os_name = osName;
+        newQueryParams.os_version = osVersion;
       }
       router.replace(
         getNextLocationPath({
@@ -830,9 +830,9 @@ const ManageHostsPage = ({
       softwareId,
       mdmId,
       mdmEnrollmentStatus,
-      os_id,
-      os_name,
-      os_version,
+      osId,
+      osName,
+      osVersion,
       sortBy,
     ]
   );
@@ -1072,9 +1072,9 @@ const ManageHostsPage = ({
         softwareId,
         mdmId,
         mdmEnrollmentStatus,
-        os_id,
-        os_name,
-        os_version,
+        osId,
+        osName,
+        osVersion,
       });
 
       toggleTransferHostModal();
@@ -1122,9 +1122,9 @@ const ManageHostsPage = ({
         softwareId,
         mdmId,
         mdmEnrollmentStatus,
-        os_id,
-        os_name,
-        os_version,
+        osId,
+        osName,
+        osVersion,
       });
 
       refetchLabels();
@@ -1188,11 +1188,11 @@ const ManageHostsPage = ({
     if (!os_id && !(os_name && os_version)) return null;
 
     let os: IOperatingSystemVersion | undefined;
-    if (os_id) {
-      os = osVersions?.find((v) => v.os_id === os_id);
-    } else if (os_name && os_version) {
-      const name: string = os_name;
-      const vers: string = os_version;
+    if (osId) {
+      os = osVersions?.find((v) => v.os_id === osId);
+    } else if (osName && osVersion) {
+      const name: string = osName;
+      const vers: string = osVersion;
 
       os = osVersions?.find(
         ({ name_only, version }) =>
@@ -1493,9 +1493,9 @@ const ManageHostsPage = ({
       softwareId,
       mdmId,
       mdmEnrollmentStatus,
-      os_id,
-      os_name,
-      os_version,
+      os_id: osId,
+      os_name: osName,
+      os_version: osVersion,
       visibleColumns,
     };
 
@@ -1569,8 +1569,8 @@ const ManageHostsPage = ({
       showSelectedLabel ||
       mdmId ||
       mdmEnrollmentStatus ||
-      os_id ||
-      (os_name && os_version)
+      osId ||
+      (osName && osVersion)
     ) {
       return (
         <div className={`${baseClass}__labels-active-filter-wrap`}>
@@ -1599,7 +1599,7 @@ const ManageHostsPage = ({
             !mdmId &&
             !showSelectedLabel &&
             renderMDMEnrollmentFilterBlock()}
-          {(!!os_id || (!!os_name && !!os_version)) &&
+          {(!!osId || (!!osName && !!osVersion)) &&
             !policyId &&
             !softwareId &&
             !showSelectedLabel &&
@@ -1704,9 +1704,9 @@ const ManageHostsPage = ({
         policy_id ||
         mdm_id ||
         mdm_enrollment_status ||
-        os_id ||
-        os_name ||
-        os_version
+        osId ||
+        osName ||
+        osVersion
       );
 
       return (

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1185,7 +1185,7 @@ const ManageHostsPage = ({
   };
 
   const renderOSFilterBlock = () => {
-    if (!os_id && !(os_name && os_version)) return null;
+    if (!osId && !(osName && osVersion)) return null;
 
     let os: IOperatingSystemVersion | undefined;
     if (osId) {

--- a/frontend/services/entities/host_count.ts
+++ b/frontend/services/entities/host_count.ts
@@ -1,6 +1,7 @@
 /* eslint-disable  @typescript-eslint/explicit-module-boundary-types */
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
+import { buildQueryStringFromParams } from "utilities/url";
 
 export interface ISortOption {
   key: string;
@@ -24,78 +25,121 @@ export interface IHostCountLoadOptions {
   os_version?: string;
 }
 
+const getPolicyParams = (
+  label?: string,
+  policyId?: number,
+  policyResponse?: string
+) => {
+  if (label !== undefined || policyId === undefined) return {};
+
+  return {
+    policy_id: policyId,
+    policy_response: policyResponse,
+  };
+};
+
+const getSoftwareParam = (
+  label?: string,
+  policyId?: number,
+  softwareId?: number,
+  mdmId?: number,
+  mdmEnrollmentStatus?: string
+) => {
+  return !label && !policyId && !mdmId && !mdmEnrollmentStatus
+    ? softwareId
+    : undefined;
+};
+
+const getMDMParams = (
+  label?: string,
+  policyId?: number,
+  softwareId?: number,
+  mdmId?: number,
+  mdmEnrollmentStatus?: string
+) => {
+  if (!label && !policyId && !softwareId && !mdmEnrollmentStatus && !mdmId)
+    return undefined;
+
+  return { mdmId: mdmId, mdmEnrollmentStatus: mdmEnrollmentStatus };
+};
+
+const getOperatingSystemParam = (
+  label?: string,
+  policyId?: number,
+  softwareId?: number,
+  operatingSystemId?: number
+) => {
+  return label === undefined &&
+    policyId === undefined &&
+    softwareId === undefined
+    ? operatingSystemId
+    : undefined;
+};
+
+const LABEL_PREFIX = "labels/";
+
+const getStatusParam = (selectedLabels?: string[]) => {
+  if (selectedLabels === undefined) return undefined;
+
+  const status = selectedLabels.find((f) => !f.includes(LABEL_PREFIX));
+  if (status === undefined) return undefined;
+
+  const statusFilterList = ["new", "online", "offline"];
+  return statusFilterList.includes(status) ? status : undefined;
+};
+
+const getLabelParam = (selectedLabels?: string[]) => {
+  if (selectedLabels === undefined) return undefined;
+
+  const label = selectedLabels.find((f) => f.includes(LABEL_PREFIX));
+  if (label === undefined) return undefined;
+
+  return label.slice(7);
+};
+
 export default {
   // hostCount.load share similar variables and parameters with hosts.loadAll
   load: (options: IHostCountLoadOptions | undefined) => {
-    const { HOSTS_COUNT } = endpoints;
+    const selectedLabels = options?.selectedLabels || [];
+    const policyId = options?.policyId;
+    const policyResponse = options?.policyResponse;
     const globalFilter = options?.globalFilter || "";
     const teamId = options?.teamId || null;
-    const policyId = options?.policyId || null;
-    const policyResponse = options?.policyResponse || null;
-    const selectedLabels = options?.selectedLabels || [];
-    const softwareId = options?.softwareId || null;
-    const mdmId = options?.mdmId || null;
-    const mdmEnrollmentStatus = options?.mdmEnrollmentStatus || null;
-    const { os_id, os_name, os_version } = options || {};
+    const softwareId = options?.softwareId;
+    const mdmId = options?.mdmId;
+    const mdmEnrollmentStatus = options?.mdmEnrollmentStatus;
+    const operatingSystemId = options?.operatingSystemId;
+    const label = getLabelParam(selectedLabels);
+    const policyParams = getPolicyParams(label, policyId, policyResponse);
+    const mdmParams = getMDMParams(
+      label,
+      policyId,
+      softwareId,
+      mdmId,
+      mdmEnrollmentStatus
+    );
 
-    const labelPrefix = "labels/";
+    const queryParams = {
+      query: globalFilter,
+      team_id: teamId,
+      policy_id: policyParams.policy_id,
+      policy_response: policyParams.policy_response,
+      software_id: getSoftwareParam(label, policyId, softwareId),
+      mdm_id: mdmParams?.mdmId,
+      mdm_enrollment_status: mdmParams?.mdmEnrollmentStatus,
+      operating_system_id: getOperatingSystemParam(
+        label,
+        policyId,
+        softwareId,
+        operatingSystemId
+      ),
+      status: getStatusParam(selectedLabels),
+      label_id: label,
+    };
 
-    // Handle multiple filters
-    const label = selectedLabels.find((f) => f.includes(labelPrefix));
-    const status = selectedLabels.find((f) => !f.includes(labelPrefix));
-    const isValidStatus =
-      status === "new" || status === "online" || status === "offline";
-    let queryString = "";
-
-    if (globalFilter !== "") {
-      queryString += `&query=${globalFilter}`;
-    }
-
-    if (status && isValidStatus) {
-      queryString += `&status=${status}`;
-    }
-
-    if (label) {
-      queryString += `&label_id=${parseInt(
-        label.substr(labelPrefix.length),
-        10
-      )}`;
-    }
-
-    if (teamId) {
-      queryString += `&team_id=${teamId}`;
-    }
-
-    if (!label && policyId) {
-      queryString += `&policy_id=${policyId}`;
-      queryString += `&policy_response=${policyResponse || "passing"}`; // TODO confirm whether there should be a default if there is an id but no response specified
-    }
-
-    // TODO: consider how to check for mutually exclusive scenarios with label, policy and software
-    if (!label && !policyId && softwareId) {
-      queryString += `&software_id=${softwareId}`;
-    }
-
-    if (!label && !policyId && mdmId) {
-      queryString += `&mdm_id=${mdmId}`;
-    }
-
-    if (!label && !policyId && mdmEnrollmentStatus) {
-      queryString += `&mdm_enrollment_status=${mdmEnrollmentStatus}`;
-    }
-
-    if (!label && !policyId && !softwareId && !mdmId && !mdmEnrollmentStatus) {
-      if (os_id) {
-        queryString += `&os_id=${os_id}`;
-      } else if (os_name && os_version) {
-        queryString += `&os_name=${encodeURIComponent(
-          os_name
-        )}&os_version=${encodeURIComponent(os_version)}`;
-      }
-    }
-
-    // Append query string to endpoint route after slicing off the leading ampersand
-    const path = `${HOSTS_COUNT}${queryString && `?${queryString.slice(1)}`}`;
+    const queryString = buildQueryStringFromParams(queryParams);
+    const endpoint = endpoints.HOSTS_COUNT;
+    const path = `${endpoint}?${queryString}`;
 
     return sendRequest("GET", path);
   },

--- a/frontend/services/entities/host_count.ts
+++ b/frontend/services/entities/host_count.ts
@@ -34,7 +34,6 @@ export interface IHostCountLoadOptions {
 }
 
 export default {
-  // hostCount.load share similar variables and parameters with hosts.loadAll
   load: (options: IHostCountLoadOptions | undefined) => {
     const selectedLabels = options?.selectedLabels || [];
     const policyId = options?.policyId;

--- a/frontend/services/entities/host_count.ts
+++ b/frontend/services/entities/host_count.ts
@@ -40,7 +40,6 @@ export default {
     const softwareId = options?.softwareId;
     const mdmId = options?.mdmId;
     const mdmEnrollmentStatus = options?.mdmEnrollmentStatus;
-    const operatingSystemId = options?.operatingSystemId;
     const label = getLabelParam(selectedLabels);
 
     const queryParams = {
@@ -52,8 +51,7 @@ export default {
         policyResponse,
         mdmId,
         mdmEnrollmentStatus,
-        softwareId,
-        operatingSystemId
+        softwareId
       ),
       status: getStatusParam(selectedLabels),
       label_id: label,

--- a/frontend/services/entities/host_count.ts
+++ b/frontend/services/entities/host_count.ts
@@ -4,10 +4,7 @@ import endpoints from "utilities/endpoints";
 import {
   buildQueryStringFromParams,
   getLabelParam,
-  getMDMParams,
-  getOperatingSystemParam,
-  getPolicyParams,
-  getSoftwareParam,
+  reconcileMutuallyExclusiveHostParams,
   getStatusParam,
 } from "utilities/url";
 
@@ -45,26 +42,16 @@ export default {
     const mdmEnrollmentStatus = options?.mdmEnrollmentStatus;
     const operatingSystemId = options?.operatingSystemId;
     const label = getLabelParam(selectedLabels);
-    const policyParams = getPolicyParams(label, policyId, policyResponse);
-    const mdmParams = getMDMParams(
-      label,
-      policyId,
-      softwareId,
-      mdmId,
-      mdmEnrollmentStatus
-    );
 
     const queryParams = {
       query: globalFilter,
       team_id: teamId,
-      policy_id: policyParams.policy_id,
-      policy_response: policyParams.policy_response,
-      software_id: getSoftwareParam(label, policyId, softwareId),
-      mdm_id: mdmParams?.mdmId,
-      mdm_enrollment_status: mdmParams?.mdmEnrollmentStatus,
-      operating_system_id: getOperatingSystemParam(
+      ...reconcileMutuallyExclusiveHostParams(
         label,
         policyId,
+        policyResponse,
+        mdmId,
+        mdmEnrollmentStatus,
         softwareId,
         operatingSystemId
       ),

--- a/frontend/services/entities/host_count.ts
+++ b/frontend/services/entities/host_count.ts
@@ -1,7 +1,15 @@
 /* eslint-disable  @typescript-eslint/explicit-module-boundary-types */
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
-import { buildQueryStringFromParams } from "utilities/url";
+import {
+  buildQueryStringFromParams,
+  getLabelParam,
+  getMDMParams,
+  getOperatingSystemParam,
+  getPolicyParams,
+  getSoftwareParam,
+  getStatusParam,
+} from "utilities/url";
 
 export interface ISortOption {
   key: string;
@@ -25,78 +33,6 @@ export interface IHostCountLoadOptions {
   os_version?: string;
 }
 
-const getPolicyParams = (
-  label?: string,
-  policyId?: number,
-  policyResponse?: string
-) => {
-  if (label !== undefined || policyId === undefined) return {};
-
-  return {
-    policy_id: policyId,
-    policy_response: policyResponse,
-  };
-};
-
-const getSoftwareParam = (
-  label?: string,
-  policyId?: number,
-  softwareId?: number,
-  mdmId?: number,
-  mdmEnrollmentStatus?: string
-) => {
-  return !label && !policyId && !mdmId && !mdmEnrollmentStatus
-    ? softwareId
-    : undefined;
-};
-
-const getMDMParams = (
-  label?: string,
-  policyId?: number,
-  softwareId?: number,
-  mdmId?: number,
-  mdmEnrollmentStatus?: string
-) => {
-  if (!label && !policyId && !softwareId && !mdmEnrollmentStatus && !mdmId)
-    return undefined;
-
-  return { mdmId: mdmId, mdmEnrollmentStatus: mdmEnrollmentStatus };
-};
-
-const getOperatingSystemParam = (
-  label?: string,
-  policyId?: number,
-  softwareId?: number,
-  operatingSystemId?: number
-) => {
-  return label === undefined &&
-    policyId === undefined &&
-    softwareId === undefined
-    ? operatingSystemId
-    : undefined;
-};
-
-const LABEL_PREFIX = "labels/";
-
-const getStatusParam = (selectedLabels?: string[]) => {
-  if (selectedLabels === undefined) return undefined;
-
-  const status = selectedLabels.find((f) => !f.includes(LABEL_PREFIX));
-  if (status === undefined) return undefined;
-
-  const statusFilterList = ["new", "online", "offline"];
-  return statusFilterList.includes(status) ? status : undefined;
-};
-
-const getLabelParam = (selectedLabels?: string[]) => {
-  if (selectedLabels === undefined) return undefined;
-
-  const label = selectedLabels.find((f) => f.includes(LABEL_PREFIX));
-  if (label === undefined) return undefined;
-
-  return label.slice(7);
-};
-
 export default {
   // hostCount.load share similar variables and parameters with hosts.loadAll
   load: (options: IHostCountLoadOptions | undefined) => {
@@ -104,7 +40,7 @@ export default {
     const policyId = options?.policyId;
     const policyResponse = options?.policyResponse;
     const globalFilter = options?.globalFilter || "";
-    const teamId = options?.teamId || null;
+    const teamId = options?.teamId;
     const softwareId = options?.softwareId;
     const mdmId = options?.mdmId;
     const mdmEnrollmentStatus = options?.mdmEnrollmentStatus;

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -2,7 +2,15 @@
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
 import { IHost } from "interfaces/host";
-import { buildQueryStringFromParams } from "utilities/url";
+import {
+  buildQueryStringFromParams,
+  getLabelParam,
+  getMDMParams,
+  getOperatingSystemParam,
+  getPolicyParams,
+  getSoftwareParam,
+  getStatusParam,
+} from "utilities/url";
 
 export interface ISortOption {
   key: string;
@@ -60,7 +68,7 @@ const getLabel = (selectedLabels?: string[]) => {
 
 const getHostEndpoint = (selectedLabels?: string[]) => {
   const { HOSTS, LABEL_HOSTS } = endpoints;
-  if (selectedLabels === undefined) return endpoints.HOSTS;
+  if (selectedLabels === undefined) return HOSTS;
 
   const label = getLabel(selectedLabels);
   if (label) {
@@ -81,82 +89,6 @@ const getSortParams = (sortOptions?: ISortOption[]) => {
     order_key: sortItem.key,
     order_direction: sortItem.direction,
   };
-};
-
-const getStatusParam = (selectedLabels?: string[]) => {
-  if (selectedLabels === undefined) return undefined;
-
-  const status = selectedLabels.find((f) => !f.includes(LABEL_PREFIX));
-  if (status === undefined) return undefined;
-
-  const statusFilterList = ["new", "online", "offline"];
-  return statusFilterList.includes(status) ? status : undefined;
-};
-
-const getPolicyParams = (
-  label?: string,
-  policyId?: number,
-  policyResponse?: string
-) => {
-  if (label !== undefined || policyId === undefined) return {};
-
-  return {
-    policy_id: policyId,
-    policy_response: policyResponse,
-  };
-};
-
-const getSoftwareParam = (
-  label?: string,
-  policyId?: number,
-  softwareId?: number,
-  mdmId?: number,
-  mdmEnrollmentStatus?: string
-) => {
-  return !label && !policyId && !mdmId && !mdmEnrollmentStatus
-    ? softwareId
-    : undefined;
-};
-
-const getMDMParams = (
-  label?: string,
-  policyId?: number,
-  softwareId?: number,
-  mdmId?: number,
-  mdmEnrollmentStatus?: string
-) => {
-  if (!label && !policyId && !softwareId && !mdmEnrollmentStatus && !mdmId)
-    return undefined;
-
-  return { mdmId: mdmId, mdmEnrollmentStatus: mdmEnrollmentStatus };
-};
-
-const getOperatingSystemParams = (
-  label?: string,
-  policyId?: number,
-  softwareId?: number,
-  mdmId?: number,
-  mdmEnrollmentStatus?: string,
-  os_id?: number,
-  os_name?: string,
-  os_version?: string
-) => {
-  if (label || policyId || softwareId || mdmId || mdmEnrollmentStatus) {
-    return {};
-  }
-  if (os_id) {
-    return { os_id };
-  }
-  return os_name && os_version ? { os_name, os_version } : {};
-};
-
-const getLabelParam = (selectedLabels?: string[]) => {
-  if (selectedLabels === undefined) return undefined;
-
-  const label = selectedLabels.find((f) => f.includes(LABEL_PREFIX));
-  if (label === undefined) return undefined;
-
-  return label.slice(7);
 };
 
 export default {
@@ -194,13 +126,6 @@ export default {
     const teamId = options?.teamId;
     const policyId = options?.policyId;
     const policyResponse = options?.policyResponse || "passing";
-<<<<<<< HEAD
-    const softwareId = options?.softwareId || null;
-    const mdmId = options?.mdmId || null;
-    const mdmEnrollmentStatus = options?.mdmEnrollmentStatus || null;
-    const visibleColumns = options?.visibleColumns || null;
-    const { os_id, os_name, os_version } = options;
-=======
     const softwareId = options?.softwareId;
     const mdmId = options?.mdmId;
     const mdmEnrollmentStatus = options?.mdmEnrollmentStatus;
@@ -214,74 +139,11 @@ export default {
       mdmId,
       mdmEnrollmentStatus
     );
->>>>>>> 49ab3c190 (Refactor export host api call)
 
     if (!sortBy.length) {
       throw Error("sortBy is a required field.");
     }
 
-<<<<<<< HEAD
-    const orderKeyParam = `?order_key=${sortBy[0].key}`;
-    const orderDirection = `&order_direction=${sortBy[0].direction}`;
-
-    let path = `${HOSTS_REPORT}${orderKeyParam}${orderDirection}`;
-
-    if (globalFilter !== "") {
-      path += `&query=${globalFilter}`;
-    }
-    const labelPrefix = "labels/";
-
-    // Handle multiple filters
-    const label = selectedLabels.find((f) => f.includes(labelPrefix)) || "";
-    const status = selectedLabels.find((f) => !f.includes(labelPrefix)) || "";
-    const statusFilterList = ["new", "online", "offline"];
-    const isStatusFilter = statusFilterList.includes(status);
-
-    if (isStatusFilter) {
-      path += `&status=${status}`;
-    }
-
-    if (teamId) {
-      path += `&team_id=${teamId}`;
-    }
-
-    // label OR policy_id OR software_id OR mdm_id OR mdm_enrollment_status are valid filters.
-    if (label) {
-      const lid = label.substr(labelPrefix.length);
-      path += `&label_id=${parseInt(lid, 10)}`;
-    }
-
-    if (!label && policyId) {
-      path += `&policy_id=${policyId}`;
-      path += `&policy_response=${policyResponse}`;
-    }
-
-    if (!label && !policyId && !mdmId && !mdmEnrollmentStatus && softwareId) {
-      path += `&software_id=${softwareId}`;
-    }
-
-    if (!label && !policyId && !softwareId && !mdmEnrollmentStatus && mdmId) {
-      path += `&mdm_id=${mdmId}`;
-    }
-
-    if (!label && !policyId && !softwareId && !mdmId && mdmEnrollmentStatus) {
-      path += `&mdm_enrollment_status=${mdmEnrollmentStatus}`;
-    }
-
-    if (!label && !policyId && !softwareId && !mdmId && !mdmEnrollmentStatus) {
-      if (os_id) {
-        path += `&os_id=${os_id}`;
-      } else if (os_name && os_version) {
-        path += `&os_name=${encodeURIComponent(
-          os_name
-        )}&os_version=${encodeURIComponent(os_version)}`;
-      }
-    }
-
-    if (visibleColumns) {
-      path += `&columns=${visibleColumns}`;
-    }
-=======
     const queryParams = {
       order_key: sortBy[0].key,
       order_direction: sortBy[0].direction,
@@ -297,7 +159,6 @@ export default {
       columns: visibleColumns,
       format: "csv",
     };
->>>>>>> 49ab3c190 (Refactor export host api call)
 
     const queryString = buildQueryStringFromParams(queryParams);
     const endpoint = endpoints.HOSTS_REPORT;

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -26,9 +26,9 @@ export interface ILoadHostsOptions {
   softwareId?: number;
   mdmId?: number;
   mdmEnrollmentStatus?: string;
-  os_id?: number;
-  os_name?: string;
-  os_version?: string;
+  osId?: number;
+  osName?: string;
+  osVersion?: string;
   device_mapping?: boolean;
   columns?: string;
   visibleColumns?: string;
@@ -46,9 +46,9 @@ export interface IExportHostsOptions {
   softwareId?: number;
   mdmId?: number;
   mdmEnrollmentStatus?: string;
-  os_id?: number;
-  os_name?: string;
-  os_version?: string;
+  osId?: number;
+  osName?: string;
+  osVersion?: string;
   device_mapping?: boolean;
   columns?: string;
   visibleColumns?: string;
@@ -168,9 +168,9 @@ export default {
     softwareId,
     mdmId,
     mdmEnrollmentStatus,
-    os_id,
-    os_name,
-    os_version,
+    osId,
+    osName,
+    osVersion,
     device_mapping,
     selectedLabels,
     sortBy,
@@ -193,11 +193,9 @@ export default {
         mdmId,
         mdmEnrollmentStatus,
         softwareId,
-        mdmId,
-        mdmEnrollmentStatus,
-        os_id,
-        os_name,
-        os_version
+        osId,
+        osName,
+        osVersion
       ),
       status: getStatusParam(selectedLabels),
     };

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -118,28 +118,17 @@ const getSoftwareParam = (
     : undefined;
 };
 
-const getMDMSolutionParam = (
+const getMDMParams = (
   label?: string,
   policyId?: number,
   softwareId?: number,
   mdmId?: number,
   mdmEnrollmentStatus?: string
 ) => {
-  return !label && !policyId && !softwareId && !mdmEnrollmentStatus
-    ? mdmId
-    : undefined;
-};
+  if (!label && !policyId && !softwareId && !mdmEnrollmentStatus && !mdmId)
+    return undefined;
 
-const getMDMEnrollmentStatusParam = (
-  label?: string,
-  policyId?: number,
-  softwareId?: number,
-  mdmId?: number,
-  mdmEnrollmentStatus?: string
-) => {
-  return !label && !policyId && !softwareId && !mdmId
-    ? mdmEnrollmentStatus
-    : undefined;
+  return { mdmId: mdmId, mdmEnrollmentStatus: mdmEnrollmentStatus };
 };
 
 const getOperatingSystemParams = (
@@ -292,6 +281,13 @@ export default {
     const label = getLabel(selectedLabels);
     const sortParams = getSortParams(sortBy);
     const policyParams = getPolicyParams(label, policyId, policyResponse);
+    const mdmParams = getMDMParams(
+      label,
+      policyId,
+      softwareId,
+      mdmId,
+      mdmEnrollmentStatus
+    );
 
     const queryParams = {
       page,
@@ -304,21 +300,9 @@ export default {
       policy_id: policyParams.policy_id,
       policy_response: policyParams.policy_response,
       software_id: getSoftwareParam(label, policyId, softwareId),
-      mdm_id: getMDMSolutionParam(
-        label,
-        policyId,
-        softwareId,
-        mdmId,
-        mdmEnrollmentStatus
-      ),
-      mdm_enrollment_status: getMDMEnrollmentStatusParam(
-        label,
-        policyId,
-        softwareId,
-        mdmId,
-        mdmEnrollmentStatus
-      ),
-      ...getOperatingSystemParams(
+      mdm_id: mdmParams?.mdmId,
+      mdm_enrollment_status: mdmParams?.mdmEnrollmentStatus,
+      operating_system_id: getOperatingSystemParam(
         label,
         policyId,
         softwareId,

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -150,6 +150,15 @@ const getOperatingSystemParams = (
   return os_name && os_version ? { os_name, os_version } : {};
 };
 
+const getLabelParam = (selectedLabels?: string[]) => {
+  if (selectedLabels === undefined) return undefined;
+
+  const label = selectedLabels.find((f) => f.includes(LABEL_PREFIX));
+  if (label === undefined) return undefined;
+
+  return label.slice(7);
+};
+
 export default {
   destroy: (host: IHost) => {
     const { HOSTS } = endpoints;
@@ -179,23 +188,39 @@ export default {
     });
   },
   exportHosts: (options: IExportHostsOptions) => {
-    const { HOSTS_REPORT } = endpoints;
     const sortBy = options.sortBy;
     const selectedLabels = options?.selectedLabels || [];
     const globalFilter = options?.globalFilter || "";
-    const teamId = options?.teamId || null;
-    const policyId = options?.policyId || null;
+    const teamId = options?.teamId;
+    const policyId = options?.policyId;
     const policyResponse = options?.policyResponse || "passing";
+<<<<<<< HEAD
     const softwareId = options?.softwareId || null;
     const mdmId = options?.mdmId || null;
     const mdmEnrollmentStatus = options?.mdmEnrollmentStatus || null;
     const visibleColumns = options?.visibleColumns || null;
     const { os_id, os_name, os_version } = options;
+=======
+    const softwareId = options?.softwareId;
+    const mdmId = options?.mdmId;
+    const mdmEnrollmentStatus = options?.mdmEnrollmentStatus;
+    const visibleColumns = options?.visibleColumns;
+    const label = getLabelParam(selectedLabels);
+    const policyParams = getPolicyParams(label, policyId, policyResponse);
+    const mdmParams = getMDMParams(
+      label,
+      policyId,
+      softwareId,
+      mdmId,
+      mdmEnrollmentStatus
+    );
+>>>>>>> 49ab3c190 (Refactor export host api call)
 
     if (!sortBy.length) {
       throw Error("sortBy is a required field.");
     }
 
+<<<<<<< HEAD
     const orderKeyParam = `?order_key=${sortBy[0].key}`;
     const orderDirection = `&order_direction=${sortBy[0].direction}`;
 
@@ -256,8 +281,27 @@ export default {
     if (visibleColumns) {
       path += `&columns=${visibleColumns}`;
     }
+=======
+    const queryParams = {
+      order_key: sortBy[0].key,
+      order_direction: sortBy[0].direction,
+      query: globalFilter,
+      team_id: teamId,
+      policy_id: policyParams.policy_id,
+      policy_response: policyParams.policy_response,
+      software_id: getSoftwareParam(label, policyId, softwareId),
+      mdm_id: mdmParams?.mdmId,
+      mdm_enrollment_status: mdmParams?.mdmEnrollmentStatus,
+      status: getStatusParam(selectedLabels),
+      label_id: label,
+      columns: visibleColumns,
+      format: "csv",
+    };
+>>>>>>> 49ab3c190 (Refactor export host api call)
 
-    path += "&format=csv";
+    const queryString = buildQueryStringFromParams(queryParams);
+    const endpoint = endpoints.HOSTS_REPORT;
+    const path = `${endpoint}?${queryString}`;
 
     return sendRequest("GET", path);
   },

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -5,10 +5,7 @@ import { IHost } from "interfaces/host";
 import {
   buildQueryStringFromParams,
   getLabelParam,
-  getMDMParams,
-  getOperatingSystemParam,
-  getPolicyParams,
-  getSoftwareParam,
+  reconcileMutuallyExclusiveHostParams,
   getStatusParam,
 } from "utilities/url";
 
@@ -131,14 +128,6 @@ export default {
     const mdmEnrollmentStatus = options?.mdmEnrollmentStatus;
     const visibleColumns = options?.visibleColumns;
     const label = getLabelParam(selectedLabels);
-    const policyParams = getPolicyParams(label, policyId, policyResponse);
-    const mdmParams = getMDMParams(
-      label,
-      policyId,
-      softwareId,
-      mdmId,
-      mdmEnrollmentStatus
-    );
 
     if (!sortBy.length) {
       throw Error("sortBy is a required field.");
@@ -149,11 +138,14 @@ export default {
       order_direction: sortBy[0].direction,
       query: globalFilter,
       team_id: teamId,
-      policy_id: policyParams.policy_id,
-      policy_response: policyParams.policy_response,
-      software_id: getSoftwareParam(label, policyId, softwareId),
-      mdm_id: mdmParams?.mdmId,
-      mdm_enrollment_status: mdmParams?.mdmEnrollmentStatus,
+      ...reconcileMutuallyExclusiveHostParams(
+        label,
+        policyId,
+        policyResponse,
+        mdmId,
+        mdmEnrollmentStatus,
+        softwareId
+      ),
       status: getStatusParam(selectedLabels),
       label_id: label,
       columns: visibleColumns,
@@ -185,14 +177,6 @@ export default {
   }: ILoadHostsOptions) => {
     const label = getLabel(selectedLabels);
     const sortParams = getSortParams(sortBy);
-    const policyParams = getPolicyParams(label, policyId, policyResponse);
-    const mdmParams = getMDMParams(
-      label,
-      policyId,
-      softwareId,
-      mdmId,
-      mdmEnrollmentStatus
-    );
 
     const queryParams = {
       page,
@@ -202,14 +186,12 @@ export default {
       device_mapping,
       order_key: sortParams.order_key,
       order_direction: sortParams.order_direction,
-      policy_id: policyParams.policy_id,
-      policy_response: policyParams.policy_response,
-      software_id: getSoftwareParam(label, policyId, softwareId),
-      mdm_id: mdmParams?.mdmId,
-      mdm_enrollment_status: mdmParams?.mdmEnrollmentStatus,
-      operating_system_id: getOperatingSystemParam(
+      ...reconcileMutuallyExclusiveHostParams(
         label,
         policyId,
+        policyResponse,
+        mdmId,
+        mdmEnrollmentStatus,
         softwareId,
         mdmId,
         mdmEnrollmentStatus,
@@ -217,7 +199,6 @@ export default {
         os_name,
         os_version
       ),
-
       status: getStatusParam(selectedLabels),
     };
 

--- a/frontend/utilities/url/index.ts
+++ b/frontend/utilities/url/index.ts
@@ -75,7 +75,7 @@ export const getMDMParams = (
   if (!label && !policyId && !softwareId && !mdmEnrollmentStatus && !mdmId)
     return undefined;
 
-  return { mdmId: mdmId, mdmEnrollmentStatus: mdmEnrollmentStatus };
+  return { mdmId, mdmEnrollmentStatus };
 };
 
 export const getOperatingSystemParam = (

--- a/frontend/utilities/url/index.ts
+++ b/frontend/utilities/url/index.ts
@@ -40,55 +40,30 @@ export const buildQueryStringFromParams = (queryParams: QueryParams) => {
   return queryString;
 };
 
-export const getPolicyParams = (
+export const reconcileMutuallyExclusiveHostParams = (
   label?: string,
   policyId?: number,
-  policyResponse?: string
-) => {
-  if (label !== undefined || policyId === undefined) return {};
-
-  return {
-    policy_id: policyId,
-    policy_response: policyResponse,
-  };
-};
-
-export const getSoftwareParam = (
-  label?: string,
-  policyId?: number,
-  softwareId?: number,
+  policyResponse?: string,
   mdmId?: number,
-  mdmEnrollmentStatus?: string
-) => {
-  return !label && !policyId && !mdmId && !mdmEnrollmentStatus
-    ? softwareId
-    : undefined;
-};
-
-export const getMDMParams = (
-  label?: string,
-  policyId?: number,
-  softwareId?: number,
-  mdmId?: number,
-  mdmEnrollmentStatus?: string
-) => {
-  if (!label && !policyId && !softwareId && !mdmEnrollmentStatus && !mdmId)
-    return undefined;
-
-  return { mdmId, mdmEnrollmentStatus };
-};
-
-export const getOperatingSystemParam = (
-  label?: string,
-  policyId?: number,
+  mdmEnrollmentStatus?: string,
   softwareId?: number,
   operatingSystemId?: number
-) => {
-  return label === undefined &&
-    policyId === undefined &&
-    softwareId === undefined
-    ? operatingSystemId
-    : undefined;
+): Record<string, unknown> => {
+  if (label) {
+    return {};
+  }
+  switch (true) {
+    case !!policyId:
+      return { policy_id: policyId, policy_response: policyResponse };
+    case !!mdmId:
+      return { mdm_id: mdmId, mdm_status: mdmEnrollmentStatus };
+    case !!softwareId:
+      return { software_id: softwareId };
+    case !!operatingSystemId:
+      return { operating_system_id: operatingSystemId };
+    default:
+      return {};
+  }
 };
 
 const LABEL_PREFIX = "labels/";

--- a/frontend/utilities/url/index.ts
+++ b/frontend/utilities/url/index.ts
@@ -39,3 +39,75 @@ export const buildQueryStringFromParams = (queryParams: QueryParams) => {
   }
   return queryString;
 };
+
+export const getPolicyParams = (
+  label?: string,
+  policyId?: number,
+  policyResponse?: string
+) => {
+  if (label !== undefined || policyId === undefined) return {};
+
+  return {
+    policy_id: policyId,
+    policy_response: policyResponse,
+  };
+};
+
+export const getSoftwareParam = (
+  label?: string,
+  policyId?: number,
+  softwareId?: number,
+  mdmId?: number,
+  mdmEnrollmentStatus?: string
+) => {
+  return !label && !policyId && !mdmId && !mdmEnrollmentStatus
+    ? softwareId
+    : undefined;
+};
+
+export const getMDMParams = (
+  label?: string,
+  policyId?: number,
+  softwareId?: number,
+  mdmId?: number,
+  mdmEnrollmentStatus?: string
+) => {
+  if (!label && !policyId && !softwareId && !mdmEnrollmentStatus && !mdmId)
+    return undefined;
+
+  return { mdmId: mdmId, mdmEnrollmentStatus: mdmEnrollmentStatus };
+};
+
+export const getOperatingSystemParam = (
+  label?: string,
+  policyId?: number,
+  softwareId?: number,
+  operatingSystemId?: number
+) => {
+  return label === undefined &&
+    policyId === undefined &&
+    softwareId === undefined
+    ? operatingSystemId
+    : undefined;
+};
+
+const LABEL_PREFIX = "labels/";
+
+export const getStatusParam = (selectedLabels?: string[]) => {
+  if (selectedLabels === undefined) return undefined;
+
+  const status = selectedLabels.find((f) => !f.includes(LABEL_PREFIX));
+  if (status === undefined) return undefined;
+
+  const statusFilterList = ["new", "online", "offline"];
+  return statusFilterList.includes(status) ? status : undefined;
+};
+
+export const getLabelParam = (selectedLabels?: string[]) => {
+  if (selectedLabels === undefined) return undefined;
+
+  const label = selectedLabels.find((f) => f.includes(LABEL_PREFIX));
+  if (label === undefined) return undefined;
+
+  return label.slice(7);
+};

--- a/frontend/utilities/url/index.ts
+++ b/frontend/utilities/url/index.ts
@@ -47,7 +47,9 @@ export const reconcileMutuallyExclusiveHostParams = (
   mdmId?: number,
   mdmEnrollmentStatus?: string,
   softwareId?: number,
-  operatingSystemId?: number
+  osId?: number,
+  osName?: string,
+  osVersion?: string
 ): Record<string, unknown> => {
   if (label) {
     return {};
@@ -59,8 +61,10 @@ export const reconcileMutuallyExclusiveHostParams = (
       return { mdm_id: mdmId, mdm_status: mdmEnrollmentStatus };
     case !!softwareId:
       return { software_id: softwareId };
-    case !!operatingSystemId:
-      return { operating_system_id: operatingSystemId };
+    case !!osId:
+      return { os_id: osId };
+    case !!osName && !!osVersion:
+      return { os_name: osName, os_version: osVersion };
     default:
       return {};
   }


### PR DESCRIPTION
**Techdebt addressed**
- Use @gillespi314 's `buildQueryStringFromParams` function on `hostsAPI.exportHosts` and `hostCountAPI.load `entities for cleaner and consistent code
- Move reused helper functions to utilities/url/index.ts

# Checklist for submitter

If some of the following don't apply, delete the relevant line.
- No changelog because changes are not user visible
- Test built already
- [x] Manual QA for all new/changed functionality
