### PR TITLE
Handle db migrations when loading fixtures for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,11 +267,9 @@ e2e-setup:
 #
 # Use in lieu of `e2e-setup` for tests that depend on these fixtures
 e2e-setup-with-software:
-	curl 'https://localhost:8642/api/v1/setup' \
-		--data-raw '{"server_url":"https://localhost:8642","org_info":{"org_name":"Fleet Test"},"admin":{"admin":true,"email":"admin@example.com","name":"Admin","password":"password123#","password_confirmation":"password123#"}}' \
-		--compressed \
-		--insecure
+	docker-compose exec -T mysql_test bash -c 'echo "drop database if exists e2e; create database e2e;" | MYSQL_PWD=toor mysql -uroot'
 	./tools/backup_db/restore_e2e_software_test.sh
+	echo -ne '\n' | ./build/fleet prepare db --mysql_address=localhost:3307  --mysql_username=root --mysql_password=toor --mysql_database=e2e
 
 e2e-serve-free: e2e-reset-db
 	./build/fleet serve --mysql_address=localhost:3307 --mysql_username=root --mysql_password=toor --mysql_database=e2e --server_address=0.0.0.0:8642

--- a/cypress/integration/all/app/software.spec.ts
+++ b/cypress/integration/all/app/software.spec.ts
@@ -197,45 +197,45 @@ describe("Software", () => {
   });
 
   // TODO: Software list and details test coverage (Issue #3954)
-  // describe("Manage software page", () => {
-  //   beforeEach(() => {
-  //     cy.loginWithCySession();
-  //     cy.viewport(1600, 900);
-  //     cy.visit("/software/manage");
-  //   });
-  //   it("renders and searches the host's software,  links to filter hosts by software", () => {
-  //     // cy.getAttached(".manage-software-page__count").within(() => {
-  //     //   cy.findByText(/902 software items/i).should("exist");
-  //     // });
-  //     cy.findByPlaceholderText(/search software/i).type("lib");
-  //     // Ensures search completes
-  //     cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
-  //     cy.getAttached(".table-container__results-count")
-  //       .invoke("text")
-  //       .then((text) => {
-  //         const fullText = text;
-  //         const pattern = /[0-9]+/g;
-  //         const newCount = fullText.match(pattern);
-  //         const searchCount = parseInt(newCount[0], 10);
-  //         expect(searchCount).to.be.equal(444);
-  //       });
-  //     cy.getAttached(".software-link").first().click({ force: true });
-  //     cy.getAttached(".manage-hosts__software-filter-block").within(() => {
-  //       cy.getAttached(".manage-hosts__software-filter-name-card").should(
-  //         "exist"
-  //       );
-  //     });
-  //     cy.getAttached(".table-container__results-count")
-  //       .invoke("text")
-  //       .then((text) => {
-  //         const fullText = text;
-  //         const pattern = /[0-9]+/g;
-  //         const newCount = fullText.match(pattern);
-  //         const searchCount = parseInt(newCount[0], 10);
-  //         expect(searchCount).to.be.equal(2);
-  //       });
-  //   });
-  // });
+  describe("Manage software page", () => {
+    beforeEach(() => {
+      cy.loginWithCySession();
+      cy.viewport(1600, 900);
+      cy.visit("/software/manage");
+    });
+    it("renders and searches the host's software,  links to filter hosts by software", () => {
+      // cy.getAttached(".manage-software-page__count").within(() => {
+      //   cy.findByText(/902 software items/i).should("exist");
+      // });
+      cy.findByPlaceholderText(/search software/i).type("lib");
+      // Ensures search completes
+      cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.getAttached(".table-container__results-count")
+        .invoke("text")
+        .then((text) => {
+          const fullText = text;
+          const pattern = /[0-9]+/g;
+          const newCount = fullText.match(pattern);
+          const searchCount = parseInt(newCount[0], 10);
+          expect(searchCount).to.be.equal(444);
+        });
+      cy.getAttached(".software-link").first().click({ force: true });
+      cy.getAttached(".manage-hosts__software-filter-block").within(() => {
+        cy.getAttached(".manage-hosts__software-filter-name-card").should(
+          "exist"
+        );
+      });
+      cy.getAttached(".table-container__results-count")
+        .invoke("text")
+        .then((text) => {
+          const fullText = text;
+          const pattern = /[0-9]+/g;
+          const newCount = fullText.match(pattern);
+          const searchCount = parseInt(newCount[0], 10);
+          expect(searchCount).to.be.equal(1);
+        });
+    });
+  });
   describe("Manage software page (mock integrations)", () => {
     beforeEach(() => {
       cy.loginWithCySession();

--- a/cypress/integration/all/app/software.spec.ts
+++ b/cypress/integration/all/app/software.spec.ts
@@ -190,7 +190,7 @@ describe("Software", () => {
     Cypress.session.clearAllSavedSessions();
     cy.setupWithSoftware();
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(10000);
+    cy.wait(30000);
     cy.loginWithCySession();
     cy.viewport(1600, 900);
   });
@@ -205,7 +205,7 @@ describe("Software", () => {
       cy.viewport(1600, 900);
       cy.visit("/software/manage");
     });
-    it("renders and searches the host's software,  links to filter hosts by software", () => {
+    it("renders and searches the host's software, links to filter hosts by software", () => {
       cy.getAttached(".manage-software-page__count").within(() => {
         cy.findByText(/902 software items/i).should("exist");
       });

--- a/cypress/integration/all/app/software.spec.ts
+++ b/cypress/integration/all/app/software.spec.ts
@@ -191,7 +191,6 @@ describe("Software", () => {
     cy.setupWithSoftware();
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(30000);
-    cy.loginWithCySession();
     cy.viewport(1600, 900);
   });
   after(() => {
@@ -201,7 +200,8 @@ describe("Software", () => {
   // TODO: Software list and details test coverage (Issue #3954)
   describe("Manage software page", () => {
     beforeEach(() => {
-      cy.loginWithCySession();
+      Cypress.session.clearAllSavedSessions();
+      cy.login("admin@example.com", "password123#");
       cy.viewport(1600, 900);
       cy.visit("/software/manage");
     });

--- a/cypress/integration/all/app/software.spec.ts
+++ b/cypress/integration/all/app/software.spec.ts
@@ -189,6 +189,8 @@ describe("Software", () => {
   before(() => {
     Cypress.session.clearAllSavedSessions();
     cy.setupWithSoftware();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(10000);
     cy.loginWithCySession();
     cy.viewport(1600, 900);
   });
@@ -204,9 +206,9 @@ describe("Software", () => {
       cy.visit("/software/manage");
     });
     it("renders and searches the host's software,  links to filter hosts by software", () => {
-      // cy.getAttached(".manage-software-page__count").within(() => {
-      //   cy.findByText(/902 software items/i).should("exist");
-      // });
+      cy.getAttached(".manage-software-page__count").within(() => {
+        cy.findByText(/902 software items/i).should("exist");
+      });
       cy.findByPlaceholderText(/search software/i).type("lib");
       // Ensures search completes
       cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting


### PR DESCRIPTION
Issue #3954 

The `prepare db` command was altered recently to require "Press ENTER to continue" that was blocking migrations for when loading the software e2e test fixtures. Shell scripts are now updated to accommodate this.
