### PR TITLE
Fleet UI: Show SQL of scheduled queries

### DIFF
--- a/changes/issue-5725-show-sql-of-scheduled-queries
+++ b/changes/issue-5725-show-sql-of-scheduled-queries
@@ -1,0 +1,1 @@
+* UI shows sql of scheduled queries

--- a/cypress/integration/all/app/queryflow.spec.ts
+++ b/cypress/integration/all/app/queryflow.spec.ts
@@ -167,7 +167,10 @@ describe("Query flow (seeded)", () => {
           cy.findByText(/show query/i).click();
         });
       cy.getAttached(".show-query-modal").within(() => {
-        cy.findByText(/''/i).should("exist"); // TODO: query string heres
+        cy.getAttached(".ace_content").within(() => {
+          cy.findByText(/select/i).should("exist");
+          cy.findByText(/datetime/i).should("exist");
+        });
       });
     });
 

--- a/cypress/integration/all/app/queryflow.spec.ts
+++ b/cypress/integration/all/app/queryflow.spec.ts
@@ -159,6 +159,18 @@ describe("Query flow (seeded)", () => {
       cy.findByText(/successfully added/i).should("be.visible");
     });
 
+    it("shows sql of a scheduled query successfully", () => {
+      cy.getAttached("tbody>tr")
+        .should("have.length", 1)
+        .within(() => {
+          cy.findByText(/action/i).click();
+          cy.findByText(/show query/i).click();
+        });
+      cy.getAttached(".show-query-modal").within(() => {
+        cy.findByText(/''/i).should("exist"); // TODO: query string heres
+      });
+    });
+
     it("edit a scheduled query successfully", () => {
       cy.getAttached("tbody>tr")
         .should("have.length", 1)

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelForm/LabelForm.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelForm/LabelForm.tsx
@@ -197,6 +197,7 @@ const LabelForm = ({
           wrapperClassName={`${baseClass}__text-editor-wrapper`}
           hint={aceHintText}
           handleSubmit={noop}
+          wrapEnabled
         />
       )}
 

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -439,6 +439,7 @@ const PolicyForm = ({
           value={lastEditedQueryBody}
           name="query editor"
           wrapperClassName={`${baseClass}__text-editor-wrapper`}
+          wrapEnabled
           readOnly
         />
       )}
@@ -467,6 +468,7 @@ const PolicyForm = ({
           wrapperClassName={`${baseClass}__text-editor-wrapper`}
           onChange={onChangePolicy}
           handleSubmit={promptSavePolicy}
+          wrapEnabled
         />
         <span className={`${baseClass}__platform-compatibility`}>
           {renderPlatformCompatibility()}

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -417,6 +417,7 @@ const QueryForm = ({
           name="query editor"
           wrapperClassName={`${baseClass}__text-editor-wrapper`}
           readOnly
+          wrapEnabled
         />
       )}
       <span className={`${baseClass}__platform-compatibility`}>
@@ -459,6 +460,7 @@ const QueryForm = ({
           wrapperClassName={`${baseClass}__text-editor-wrapper`}
           onChange={onChangeQuery}
           handleSubmit={promptSaveQuery}
+          wrapEnabled
         />
         <span className={`${baseClass}__platform-compatibility`}>
           {renderPlatformCompatibility()}

--- a/frontend/pages/queries/QueryPage/components/QueryResults/ShowQueryModal/ShowQueryModal.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/ShowQueryModal/ShowQueryModal.tsx
@@ -22,6 +22,7 @@ const ShowQueryModal = ({ onCancel }: IShowQueryModalProps): JSX.Element => {
           name="query editor"
           wrapperClassName={`${baseClass}__text-editor-wrapper`}
           readOnly
+          wrapEnabled
         />
         <div className="modal-cta-wrap">
           <Button onClick={onCancel} variant="brand">

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -12,6 +12,7 @@ import { ITeam } from "interfaces/team";
 import { IQuery } from "interfaces/query";
 import {
   IScheduledQuery,
+  IScheduleFormData,
   IEditScheduledQuery,
   ILoadAllGlobalScheduledQueriesResponse,
   ILoadAllTeamScheduledQueriesResponse,
@@ -32,6 +33,7 @@ import MainContent from "components/MainContent";
 import ScheduleTable from "./components/ScheduleTable";
 import ScheduleEditorModal from "./components/ScheduleEditorModal";
 import RemoveScheduledQueryModal from "./components/RemoveScheduledQueryModal";
+import ShowQueryModal from "./components/ShowQueryModal";
 
 const baseClass = "manage-schedule-page";
 
@@ -43,6 +45,7 @@ const renderTable = (
   router: InjectedRouter,
   onRemoveScheduledQueryClick: (selectIds: number[]) => void,
   onEditScheduledQueryClick: (selectedQuery: IEditScheduledQuery) => void,
+  onShowQueryClick: (selectedQuery: IEditScheduledQuery) => void,
   allScheduledQueriesList: IScheduledQuery[],
   allScheduledQueriesError: Error | null,
   toggleScheduleEditorModal: () => void,
@@ -59,6 +62,7 @@ const renderTable = (
       router={router}
       onRemoveScheduledQueryClick={onRemoveScheduledQueryClick}
       onEditScheduledQueryClick={onEditScheduledQueryClick}
+      onShowQueryClick={onShowQueryClick}
       allScheduledQueriesList={allScheduledQueriesList}
       toggleScheduleEditorModal={toggleScheduleEditorModal}
       isOnGlobalTeam={isOnGlobalTeam}
@@ -100,17 +104,6 @@ interface ITeamSchedulesPageProps {
     team_id: string;
   };
   router: InjectedRouter; // v3
-}
-interface IFormData {
-  interval: number;
-  name?: string;
-  shard: number;
-  query?: string;
-  query_id?: number;
-  logging_type: string;
-  platform: string;
-  version: string;
-  team_id?: number;
 }
 
 const ManageSchedulePage = ({
@@ -299,6 +292,7 @@ const ManageSchedulePage = ({
     false
   );
   const [showScheduleEditorModal, setShowScheduleEditorModal] = useState(false);
+  const [showShowQueryModal, setShowShowQueryModal] = useState(false);
   const [showPreviewDataModal, setShowPreviewDataModal] = useState(false);
   const [
     showRemoveScheduledQueryModal,
@@ -325,6 +319,11 @@ const ManageSchedulePage = ({
     setShowScheduleEditorModal(!showScheduleEditorModal);
   }, [showScheduleEditorModal, setShowScheduleEditorModal]);
 
+  const toggleShowQueryModal = useCallback(() => {
+    setSelectedScheduledQuery(undefined);
+    setShowShowQueryModal(!showShowQueryModal);
+  }, [showShowQueryModal, setShowShowQueryModal]);
+
   const toggleRemoveScheduledQueryModal = useCallback(() => {
     setShowRemoveScheduledQueryModal(!showRemoveScheduledQueryModal);
   }, [showRemoveScheduledQueryModal, setShowRemoveScheduledQueryModal]);
@@ -334,6 +333,11 @@ const ManageSchedulePage = ({
   ): void => {
     toggleRemoveScheduledQueryModal();
     setSelectedQueryIds(selectedTableQueryIds);
+  };
+
+  const onShowQueryClick = (selectedQuery: IEditScheduledQuery): void => {
+    toggleShowQueryModal();
+    setSelectedScheduledQuery(selectedQuery);
   };
 
   const onEditScheduledQueryClick = (
@@ -379,7 +383,10 @@ const ManageSchedulePage = ({
   ]);
 
   const onAddScheduledQuerySubmit = useCallback(
-    (formData: IFormData, editQuery: IEditScheduledQuery | undefined) => {
+    (
+      formData: IScheduleFormData,
+      editQuery: IEditScheduledQuery | undefined
+    ) => {
       setIsUpdatingScheduledQuery(true);
       if (editQuery) {
         const updatedAttributes = deepDifference(formData, editQuery);
@@ -509,6 +516,7 @@ const ManageSchedulePage = ({
               router,
               onRemoveScheduledQueryClick,
               onEditScheduledQueryClick,
+              onShowQueryClick,
               allScheduledQueriesList,
               allScheduledQueriesError,
               toggleScheduleEditorModal,
@@ -565,6 +573,9 @@ const ManageSchedulePage = ({
             onSubmit={onRemoveScheduledQuerySubmit}
             isUpdatingScheduledQuery={isUpdatingScheduledQuery}
           />
+        )}
+        {showShowQueryModal && (
+          <ShowQueryModal onCancel={toggleRemoveScheduledQueryModal} />
         )}
       </div>
     </MainContent>

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -12,7 +12,6 @@ import { ITeam } from "interfaces/team";
 import { IQuery } from "interfaces/query";
 import {
   IScheduledQuery,
-  IScheduleFormData,
   IEditScheduledQuery,
   ILoadAllGlobalScheduledQueriesResponse,
   ILoadAllTeamScheduledQueriesResponse,
@@ -98,6 +97,18 @@ const renderAllTeamsTable = (
     </div>
   );
 };
+
+interface IFormData {
+  interval: number;
+  name?: string;
+  shard: number;
+  query?: string;
+  query_id?: number;
+  logging_type: string;
+  platform: string;
+  version: string;
+  team_id?: number;
+}
 
 interface ITeamSchedulesPageProps {
   params: {
@@ -383,10 +394,7 @@ const ManageSchedulePage = ({
   ]);
 
   const onAddScheduledQuerySubmit = useCallback(
-    (
-      formData: IScheduleFormData,
-      editQuery: IEditScheduledQuery | undefined
-    ) => {
+    (formData: IFormData, editQuery: IEditScheduledQuery | undefined) => {
       setIsUpdatingScheduledQuery(true);
       if (editQuery) {
         const updatedAttributes = deepDifference(formData, editQuery);

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -336,6 +336,7 @@ const ManageSchedulePage = ({
   }, [showShowQueryModal, setShowShowQueryModal]);
 
   const toggleRemoveScheduledQueryModal = useCallback(() => {
+    console.log("toggleRemoveScheduledQueryModal");
     setShowRemoveScheduledQueryModal(!showRemoveScheduledQueryModal);
   }, [showRemoveScheduledQueryModal, setShowRemoveScheduledQueryModal]);
 
@@ -583,7 +584,10 @@ const ManageSchedulePage = ({
           />
         )}
         {showShowQueryModal && (
-          <ShowQueryModal onCancel={toggleRemoveScheduledQueryModal} />
+          <ShowQueryModal
+            query={selectedScheduledQuery?.query}
+            onCancel={toggleShowQueryModal}
+          />
         )}
       </div>
     </MainContent>

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -336,7 +336,7 @@ const ManageSchedulePage = ({
   }, [showShowQueryModal, setShowShowQueryModal]);
 
   const toggleRemoveScheduledQueryModal = useCallback(() => {
-    console.log("toggleRemoveScheduledQueryModal");
+    console.log("toggleRemoveScheduledqueryModal");
     setShowRemoveScheduledQueryModal(!showRemoveScheduledQueryModal);
   }, [showRemoveScheduledQueryModal, setShowRemoveScheduledQueryModal]);
 

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTable.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTable.tsx
@@ -33,6 +33,7 @@ interface IScheduleTableProps {
   router: InjectedRouter; // v3
   onRemoveScheduledQueryClick?: (selectIds: number[]) => void;
   onEditScheduledQueryClick?: (selectedQuery: IEditScheduledQuery) => void;
+  onShowQueryClick?: (selectedQuery: IEditScheduledQuery) => void;
   allScheduledQueriesList: IScheduledQuery[];
   toggleScheduleEditorModal?: () => void;
   inheritedQueries?: boolean;
@@ -45,9 +46,10 @@ interface IScheduleTableProps {
 const ScheduleTable = ({
   router,
   onRemoveScheduledQueryClick,
+  onEditScheduledQueryClick,
+  onShowQueryClick,
   allScheduledQueriesList,
   toggleScheduleEditorModal,
-  onEditScheduledQueryClick,
   inheritedQueries,
   isOnGlobalTeam,
   selectedTeamData,
@@ -134,6 +136,10 @@ const ScheduleTable = ({
           onEditScheduledQueryClick(scheduledQuery);
         }
         break;
+      case "showQuery":
+        if (onShowQueryClick) {
+          onShowQueryClick(scheduledQuery);
+        }
       default:
         if (onRemoveScheduledQueryClick) {
           onRemoveScheduledQueryClick([scheduledQuery.id]);

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTable.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTable.tsx
@@ -140,6 +140,7 @@ const ScheduleTable = ({
         if (onShowQueryClick) {
           onShowQueryClick(scheduledQuery);
         }
+        break;
       default:
         if (onRemoveScheduledQueryClick) {
           onRemoveScheduledQueryClick([scheduledQuery.id]);

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTableConfig.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTableConfig.tsx
@@ -242,6 +242,7 @@ const enhanceAllScheduledQueryData = (
       interval: scheduledQuery.interval,
       actions: generateActionDropdownOptions(),
       id: scheduledQuery.id,
+      query: scheduledQuery.query,
       query_id: scheduledQuery.query_id,
       snapshot: scheduledQuery.snapshot,
       removed: scheduledQuery.removed,

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTableConfig.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTableConfig.tsx
@@ -116,8 +116,8 @@ const generateTableHeaders = (
       disableHidden: true,
     },
     {
-      title: "Query",
-      Header: "Query",
+      title: "Name",
+      Header: "Name",
       disableSortBy: true,
       accessor: "query_name",
       Cell: (cellProps: ICellProps): JSX.Element => (
@@ -211,6 +211,11 @@ const generateActionDropdownOptions = (): IDropdownOption[] => {
       label: "Edit",
       disabled: false,
       value: "edit",
+    },
+    {
+      label: "Show query",
+      disabled: false,
+      value: "showQuery",
     },
     {
       label: "Remove",

--- a/frontend/pages/schedule/ManageSchedulePage/components/ShowQueryModal/ShowQueryModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ShowQueryModal/ShowQueryModal.tsx
@@ -1,35 +1,40 @@
 import React from "react";
 
+import FleetAce from "components/FleetAce";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
-import Spinner from "components/Spinner";
 
-const baseClass = "remove-scheduled-query-modal";
+const baseClass = "show-query-modal";
 
 interface IShowQueryModalProps {
-  isLoading: boolean;
   onCancel: () => void;
-  onSubmit: () => void;
+  query?: string;
 }
 
 const ShowQueryModal = ({
-  isLoading,
+  query,
   onCancel,
 }: IShowQueryModalProps): JSX.Element => {
   return (
-    <Modal title={"Query"} onExit={onCancel} className={baseClass}>
-      {isLoading ? (
-        <Spinner />
-      ) : (
-        <div className={baseClass}>
-          TODO: Put the SQL editor here.
-          <div className="modal-cta-wrap">
-            <Button onClick={onCancel} variant="inverse-alert">
-              Done
-            </Button>
-          </div>
+    <Modal
+      title={"Query"}
+      onExit={onCancel}
+      onEnter={onCancel}
+      className={baseClass}
+    >
+      <div className={baseClass}>
+        <FleetAce
+          value={query}
+          name="Scheduled query"
+          wrapperClassName={`${baseClass}__text-editor-wrapper`}
+          readOnly
+        />
+        <div className="modal-cta-wrap">
+          <Button onClick={onCancel} variant="brand">
+            Done
+          </Button>
         </div>
-      )}
+      </div>
     </Modal>
   );
 };

--- a/frontend/pages/schedule/ManageSchedulePage/components/ShowQueryModal/ShowQueryModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ShowQueryModal/ShowQueryModal.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+import Modal from "components/Modal";
+import Button from "components/buttons/Button";
+import Spinner from "components/Spinner";
+
+const baseClass = "remove-scheduled-query-modal";
+
+interface IShowQueryModalProps {
+  isLoading: boolean;
+  onCancel: () => void;
+  onSubmit: () => void;
+}
+
+const ShowQueryModal = ({
+  isLoading,
+  onCancel,
+}: IShowQueryModalProps): JSX.Element => {
+  return (
+    <Modal title={"Query"} onExit={onCancel} className={baseClass}>
+      {isLoading ? (
+        <Spinner />
+      ) : (
+        <div className={baseClass}>
+          TODO: Put the SQL editor here.
+          <div className="modal-cta-wrap">
+            <Button onClick={onCancel} variant="inverse-alert">
+              Done
+            </Button>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+};
+
+export default ShowQueryModal;

--- a/frontend/pages/schedule/ManageSchedulePage/components/ShowQueryModal/ShowQueryModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ShowQueryModal/ShowQueryModal.tsx
@@ -15,11 +15,6 @@ const ShowQueryModal = ({
   query,
   onCancel,
 }: IShowQueryModalProps): JSX.Element => {
-  console.log("query", query);
-
-  const splitQuery = query && query.replace("FROM", "\nFROM");
-  console.log("splitQuery", splitQuery);
-
   return (
     <Modal
       title={"Query"}

--- a/frontend/pages/schedule/ManageSchedulePage/components/ShowQueryModal/ShowQueryModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ShowQueryModal/ShowQueryModal.tsx
@@ -15,6 +15,11 @@ const ShowQueryModal = ({
   query,
   onCancel,
 }: IShowQueryModalProps): JSX.Element => {
+  console.log("query", query);
+
+  const splitQuery = query && query.replace("FROM", "\nFROM");
+  console.log("splitQuery", splitQuery);
+
   return (
     <Modal
       title={"Query"}
@@ -27,6 +32,7 @@ const ShowQueryModal = ({
           value={query}
           name="Scheduled query"
           wrapperClassName={`${baseClass}__text-editor-wrapper`}
+          wrapEnabled
           readOnly
         />
         <div className="modal-cta-wrap">

--- a/frontend/pages/schedule/ManageSchedulePage/components/ShowQueryModal/index.ts
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ShowQueryModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ShowQueryModal";


### PR DESCRIPTION
Cerra #5725 

**Feature**
- Show query option in Actions dropdown for manage schedule table
- Opens a modal showing the sql in a fleet ace readonly

**Other tech debt**
- Wrap sql app wide so you don't have to scroll right to see long queries

<img width="1196" alt="Screen Shot 2022-08-23 at 11 55 19 AM" src="https://user-images.githubusercontent.com/71795832/186240785-1bd098d2-8db7-4e45-b881-4dec8a015251.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
