### PR TITLE
Remove FreeBSD references and fix standard query library

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -48,22 +48,11 @@ apiVersion: v1
 kind: query
 spec:
   name: Get installed Chrome Extensions
-  platforms: macOS, Linux, Windows, FreeBSD
+  platforms: macOS, Linux, Windows
   description: List installed Chrome Extensions for all users.
   query: SELECT * FROM users CROSS JOIN chrome_extensions USING (uid);
   purpose: Informational
   tags: browser, built-in, inventory
-  contributors: zwass
----
-apiVersion: v1
-kind: query
-spec:
-  name: Get installed FreeBSD software
-  platforms: FreeBSD
-  description: Get all software installed on a FreeBSD computer, including browser plugins and installed packages. Note that this does not include other running processes in the processes table.
-  query: SELECT name AS name, version AS version, 'Browser plugin (Chrome)' AS type, 'chrome_extensions' AS source FROM chrome_extensions UNION SELECT name AS name, version AS version, 'Browser plugin (Firefox)' AS type, 'firefox_addons' AS source FROM firefox_addons UNION SELECT name AS name, version AS version, 'Package (Atom)' AS type, 'atom_packages' AS source FROM atom_packages UNION SELECT name AS name, version AS version, 'Package (Python)' AS type, 'python_packages' AS source FROM python_packages UNION SELECT name AS name, version AS version, 'Package (pkg)' AS type, 'pkg_packages' AS source FROM pkg_packages;
-  purpose: Informational
-  tags: inventory
   contributors: zwass
 ---
 apiVersion: v1
@@ -125,7 +114,7 @@ apiVersion: v1
 kind: query
 spec:
   name: Get current users with active shell/console on the system
-  platforms: macOS, Linux, Windows, FreeBSD
+  platforms: macOS, Linux, Windows
   description: Get current users with active shell/console on the system and associated process
   query: SELECT user,host,time, p.name, p.cmdline, p.cwd, p.root FROM logged_in_users liu, processes p WHERE liu.pid = p.pid and liu.type='user' and liu.user <> '' ORDER BY time;
   purpose: Informational
@@ -136,7 +125,7 @@ apiVersion: v1
 kind: query
 spec:
   name: Get unencrypted SSH keys for local accounts
-  platforms: macOS, Linux, Windows, FreeBSD
+  platforms: macOS, Linux, Windows
   description: Identify SSH keys created without a passphrase which can be used in Lateral Movement (MITRE. TA0008)
   query: SELECT uid, username, description, path, encrypted FROM users CROSS JOIN user_ssh_keys using (uid) WHERE encrypted=0;
   purpose: Informational
@@ -148,7 +137,7 @@ apiVersion: v1
 kind: query
 spec:
   name: Get unencrypted SSH keys for domain-joined accounts
-  platforms: macOS, Linux, Windows, FreeBSD
+  platforms: macOS, Linux, Windows
   description: Identify SSH keys created without a passphrase which can be used in Lateral Movement (MITRE. TA0008)
   query: SELECT uid, username, description, path, encrypted FROM users CROSS JOIN user_ssh_keys using (uid) WHERE encrypted=0 and username in (SELECT distinct(username) FROM last);
   purpose: Informational
@@ -195,7 +184,7 @@ apiVersion: v1
 kind: query
 spec:
   name: Get network interfaces
-  platforms: macOS, Linux, Windows, FreeBSD
+  platforms: macOS, Linux, Windows
   description: Network interfaces MAC address
   query: SELECT a.interface, a.address, d.mac FROM interface_addresses a JOIN interface_details d USING (interface) WHERE address not in ('127.0.0.1', '::1');
   purpose: informational
@@ -206,7 +195,7 @@ apiVersion: v1
 kind: query
 spec:
   name: Get local user accounts
-  platforms: macOS, Linux, Windows, FreeBSD
+  platforms: macOS, Linux, Windows
   description: Local user accounts (including domain accounts that have logged on locally (Windows)).
   query: SELECT uid, gid, username, description, directory, shell FROM users;
   purpose: informational
@@ -228,7 +217,7 @@ apiVersion: v1
 kind: query
 spec:
   name: Get Nmap scanner
-  platforms: macOS, Linux, Windows, FreeBSD
+  platforms: macOS, Linux, Windows
   description: Get Nmap scanner process, as well as its user, parent, and process details.
   query: SELECT p.pid, name, p.path, cmdline, cwd, start_time, parent,
     (SELECT name FROM processes WHERE pid=p.parent) AS parent_name,
@@ -299,7 +288,7 @@ spec:
   name: Get local administrator accounts on macOS
   platforms: macOS
   description: The query allows you to check macOS systems for local administrator accounts.
-  query: SELECT uid, username, type, group name FROM users u JOIN groups g ON g.gid = u.gid;
+  query: SELECT uid, username, type FROM users u JOIN groups g ON g.gid = u.gid;
   purpose: Informational
   tags: hunting, inventory
   contributors: alphabrevity

--- a/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tsx
+++ b/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tsx
@@ -19,7 +19,6 @@ const DISPLAY_ORDER = [
   "darwin",
   "linux",
   "windows",
-  // "freebsd",
   // "None",
   // "Invalid query",
 ];

--- a/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tsx
+++ b/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tsx
@@ -114,13 +114,6 @@ const QuerySidePanel = ({
                   {PLATFORM_DISPLAY_NAMES[platform] || platform}
                 </li>
               );
-            } else if (platform === "freebsd") {
-              return (
-                <li key={platform}>
-                  <FleetIcon name="single-host" />{" "}
-                  {PLATFORM_DISPLAY_NAMES[platform]}
-                </li>
-              );
             }
             platform = platform.toLowerCase();
             let icon = (

--- a/frontend/interfaces/osquery_table.ts
+++ b/frontend/interfaces/osquery_table.ts
@@ -38,7 +38,7 @@ export const DEFAULT_OSQUERY_TABLE: IOsqueryTable = {
   description:
     "Local user accounts (including domain accounts that have logged on locally (Windows)).",
   url: "https://github.com/osquery/osquery/blob/master/specs/users.table",
-  platforms: ["darwin", "linux", "windows", "freebsd"],
+  platforms: ["darwin", "linux", "windows"],
   evented: false,
   cacheable: false,
   columns: [

--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -4,9 +4,7 @@ export type IOsqueryPlatform =
   | "windows"
   | "Windows"
   | "linux"
-  | "Linux"
-  | "freebsd"
-  | "FreeBSD";
+  | "Linux";
 
 export type IPlatformString =
   | ""

--- a/frontend/osquery_tables.json
+++ b/frontend/osquery_tables.json
@@ -827,7 +827,7 @@
     "name": "arp_cache",
     "description": "Address resolution cache, both static and dynamic (from ARP, NDP).",
     "url": "https://github.com/osquery/osquery/blob/master/specs/arp_cache.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -983,7 +983,7 @@
     "name": "atom_packages",
     "description": "Lists all atom packages in a directory or globally installed in a system.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/atom_packages.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -1389,7 +1389,7 @@
     "name": "azure_instance_metadata",
     "description": "Azure instance metadata.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/azure_instance_metadata.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -1527,7 +1527,7 @@
     "name": "azure_instance_tags",
     "description": "Azure instance tags.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/azure_instance_tags.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -2335,7 +2335,7 @@
     "name": "carbon_black_info",
     "description": "Returns info about a Carbon Black sensor install.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/carbon_black_info.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -2513,7 +2513,7 @@
     "name": "carves",
     "description": "List the set of completed and in-progress carves. If carve=1 then the query is treated as a new carve request.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/carves.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -2937,7 +2937,7 @@
     "name": "chrome_extension_content_scripts",
     "description": "Chrome browser extension content scripts.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/chrome_extension_content_scripts.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -3019,7 +3019,7 @@
     "name": "chrome_extensions",
     "description": "Chrome-based browser extensions.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/chrome_extensions.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -3531,7 +3531,7 @@
     "name": "cpuid",
     "description": "Useful CPU features from the cpuid ASM call.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/cpuid.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -3909,7 +3909,7 @@
     "name": "curl",
     "description": "Perform an http request and return stats about it.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/curl.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -3975,7 +3975,7 @@
     "name": "curl_certificate",
     "description": "Inspect TLS certificates by connecting to input hostnames.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/curl_certificate.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -6831,7 +6831,7 @@
     "name": "ec2_instance_metadata",
     "description": "EC2 instance metadata.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/ec2_instance_metadata.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -6953,7 +6953,7 @@
     "name": "ec2_instance_tags",
     "description": "EC2 instance tag key value pairs.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/ec2_instance_tags.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -7559,7 +7559,7 @@
     "name": "etc_hosts",
     "description": "Line-parsed /etc/hosts.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/etc_hosts.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -7593,7 +7593,7 @@
     "name": "etc_protocols",
     "description": "Line-parsed /etc/protocols.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/etc_protocols.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -7635,7 +7635,7 @@
     "name": "etc_services",
     "description": "Line-parsed /etc/services.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/etc_services.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -7735,7 +7735,7 @@
     "name": "example",
     "description": "This is an example table spec.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/example.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -7898,52 +7898,10 @@
     ]
   },
   {
-    "name": "fbsd_kmods",
-    "description": "Loaded FreeBSD kernel modules.",
-    "url": "https://github.com/osquery/osquery/blob/master/specs/freebsd/fbsd_kmods.table",
-    "platforms": ["freebsd"],
-    "evented": false,
-    "cacheable": false,
-    "columns": [
-      {
-        "name": "name",
-        "description": "Module name",
-        "type": "text",
-        "hidden": false,
-        "required": false,
-        "index": false
-      },
-      {
-        "name": "size",
-        "description": "Size of module content",
-        "type": "integer",
-        "hidden": false,
-        "required": false,
-        "index": false
-      },
-      {
-        "name": "refs",
-        "description": "Module reverse dependencies",
-        "type": "integer",
-        "hidden": false,
-        "required": false,
-        "index": false
-      },
-      {
-        "name": "address",
-        "description": "Kernel module address",
-        "type": "text",
-        "hidden": false,
-        "required": false,
-        "index": false
-      }
-    ]
-  },
-  {
     "name": "file",
     "description": "Interactive filesystem attributes and metadata.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/utility/file.table",
-    "platforms": ["darwin", "linux", "freebsd", "windows"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -8307,7 +8265,7 @@
     "name": "firefox_addons",
     "description": "Firefox browser extensions, webapps, and addons.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/firefox_addons.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -8521,7 +8479,7 @@
     "name": "groups",
     "description": "Local system groups.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/groups.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -8693,7 +8651,7 @@
     "name": "hash",
     "description": "Filesystem hash data.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/hash.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -8943,7 +8901,7 @@
     "name": "intel_me_info",
     "description": "Intel ME/CSE Info.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/linwin/intel_me_info.table",
-    "platforms": ["darwin", "linux", "freebsd", "windows"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -8961,7 +8919,7 @@
     "name": "interface_addresses",
     "description": "Network interfaces and relevant metadata.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/interface_addresses.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -9027,7 +8985,7 @@
     "name": "interface_details",
     "description": "Detailed information and stats of network interfaces.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/interface_details.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -9581,7 +9539,7 @@
     "name": "kernel_info",
     "description": "Basic active kernel information.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/kernel_info.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -10329,7 +10287,7 @@
     "name": "listening_ports",
     "description": "Processes with listening (bound) network sockets/ports.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/listening_ports.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -11017,7 +10975,7 @@
     "name": "logged_in_users",
     "description": "Users with an active shell on the system.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/logged_in_users.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -13681,7 +13639,7 @@
     "name": "os_version",
     "description": "A single row containing the operating system name and version.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/os_version.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -13795,7 +13753,7 @@
     "name": "osquery_events",
     "description": "Information about the event publishers and subscribers.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/utility/osquery_events.table",
-    "platforms": ["darwin", "linux", "freebsd", "windows"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -13861,7 +13819,7 @@
     "name": "osquery_extensions",
     "description": "List of active osquery extensions.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/utility/osquery_extensions.table",
-    "platforms": ["darwin", "linux", "freebsd", "windows"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -13919,7 +13877,7 @@
     "name": "osquery_flags",
     "description": "Configurable flags that modify osquery's behavior.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/utility/osquery_flags.table",
-    "platforms": ["darwin", "linux", "freebsd", "windows"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -13977,7 +13935,7 @@
     "name": "osquery_info",
     "description": "Top level information about the running version of osquery.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/utility/osquery_info.table",
-    "platforms": ["darwin", "linux", "freebsd", "windows"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -14083,7 +14041,7 @@
     "name": "osquery_packs",
     "description": "Information about the current query packs that are loaded in osquery.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/utility/osquery_packs.table",
-    "platforms": ["darwin", "linux", "freebsd", "windows"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -14149,7 +14107,7 @@
     "name": "osquery_registry",
     "description": "List the osquery registry plugins.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/utility/osquery_registry.table",
-    "platforms": ["darwin", "linux", "freebsd", "windows"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -14199,7 +14157,7 @@
     "name": "osquery_schedule",
     "description": "Information about the current queries that are scheduled in osquery.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/utility/osquery_schedule.table",
-    "platforms": ["darwin", "linux", "freebsd", "windows"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -14836,52 +14794,10 @@
     ]
   },
   {
-    "name": "pkg_packages",
-    "description": "pkgng packages that are currently installed on the host system.",
-    "url": "https://github.com/osquery/osquery/blob/master/specs/freebsd/pkg_packages.table",
-    "platforms": ["freebsd"],
-    "evented": false,
-    "cacheable": true,
-    "columns": [
-      {
-        "name": "name",
-        "description": "Package name",
-        "type": "text",
-        "hidden": false,
-        "required": false,
-        "index": false
-      },
-      {
-        "name": "version",
-        "description": "Package version",
-        "type": "text",
-        "hidden": false,
-        "required": false,
-        "index": false
-      },
-      {
-        "name": "flatsize",
-        "description": "Package size in bytes",
-        "type": "bigint",
-        "hidden": false,
-        "required": false,
-        "index": false
-      },
-      {
-        "name": "arch",
-        "description": "Architecture(s) supported",
-        "type": "text",
-        "hidden": false,
-        "required": false,
-        "index": false
-      }
-    ]
-  },
-  {
     "name": "platform_info",
     "description": "Information about EFI/UEFI/ROM and platform/boot.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/platform_info.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -15913,7 +15829,7 @@
     "name": "process_memory_map",
     "description": "Process memory mapped files and pseudo device/regions.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/process_memory_map.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -16177,7 +16093,7 @@
     "name": "process_open_sockets",
     "description": "Processes which have open network sockets on the system.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/process_open_sockets.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -16283,7 +16199,7 @@
     "name": "processes",
     "description": "All running processes on the host system.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/processes.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -16713,7 +16629,7 @@
     "name": "python_packages",
     "description": "Python packages installed in a system.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/python_packages.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -16951,7 +16867,7 @@
     "name": "routes",
     "description": "The active route table for the host system.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/routes.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -17649,7 +17565,7 @@
     "name": "secureboot",
     "description": "Secure Boot UEFI Settings.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/linwin/secureboot.table",
-    "platforms": ["darwin", "linux", "freebsd", "windows"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -19143,7 +19059,7 @@
     "name": "ssh_configs",
     "description": "A table of parsed ssh_configs.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/ssh_configs.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -19185,7 +19101,7 @@
     "name": "startup_items",
     "description": "Applications and binaries set as user/login startup items.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/startup_items.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -19557,7 +19473,7 @@
     "name": "system_info",
     "description": "System information for identification.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/system_info.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -19875,7 +19791,7 @@
     "name": "time",
     "description": "Track current date and time in the system.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/utility/time.table",
-    "platforms": ["darwin", "linux", "freebsd", "windows"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -20213,7 +20129,7 @@
     "name": "uptime",
     "description": "Track time passed since last boot. Some systems track this as calendar time, some as runtime.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/uptime.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -20467,7 +20383,7 @@
     "name": "user_groups",
     "description": "Local system user group relationships.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/user_groups.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -20511,7 +20427,7 @@
     "name": "user_ssh_keys",
     "description": "Returns the private keys in the users ~/.ssh directory and whether or not they are encrypted.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/user_ssh_keys.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -20603,7 +20519,7 @@
     "name": "users",
     "description": "Local user accounts (including domain accounts that have logged on locally (Windows)).",
     "url": "https://github.com/osquery/osquery/blob/master/specs/users.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -22433,7 +22349,7 @@
     "name": "ycloud_instance_metadata",
     "description": "Yandex.Cloud instance metadata.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/ycloud_instance_metadata.table",
-    "platforms": ["darwin", "linux", "windows", "freebsd"],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": true,
     "columns": [

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -322,7 +322,6 @@ export const DEFAULT_CAMPAIGN_STATE = {
 
 export const PLATFORM_DISPLAY_NAMES: Record<string, IOsqueryPlatform> = {
   darwin: "macOS",
-  freebsd: "FreeBSD",
   linux: "Linux",
   windows: "Windows",
 };

--- a/website/views/pages/query-detail.ejs
+++ b/website/views/pages/query-detail.ejs
@@ -8,19 +8,19 @@
       </a>
       <div purpose="title-mobile" class="d-flex d-md-none flex-column pb-4 mb-3">
         <h2 class="pt-4 pb-3 m-0">{{query.name}}</h2>
-        <h6 class="pb-3 m-0">{{query.description ? query.description : '--'}}</h6>  
+        <h6 class="pb-3 m-0">{{query.description ? query.description : '--'}}</h6>
       </div>
     </div>
     <div class="d-flex flex-column flex-md-row justify-content-md-between">
       <div class="container-fluid col-md-8 d-flex flex-column p-0 pr-md-3">
         <div purpose="title-widescreen" class="d-none d-md-flex flex-column">
           <h2 class="pt-4 pb-3 m-0">{{query.name}}</h2>
-          <h6 class="pb-3 m-0">{{query.description ? query.description : '--'}}</h6>  
-        </div>  
+          <h6 class="pb-3 m-0">{{query.description ? query.description : '--'}}</h6>
+        </div>
         <div purpose="body" class="pt-4 pt-md-3 mt-3 mt-md-0">
           <div purpose="query">
             <h3 class="pb-4 mb-3 m-0">Query</h3>
-            <code class="pb-3">{{query.query ? query.query : '--'}}</code>  
+            <code class="pb-3">{{query.query ? query.query : '--'}}</code>
           </div>
           <div purpose="resolution" v-if="query.kind === 'policy' && query.resolution">
             <h3 class="pt-5 pb-3">Resolve</h3>
@@ -37,7 +37,6 @@
               <img class="d-inline-flex ml-3 ml-md-0 mr-md-3" src="/images/os-macos-black-24x24@2x.png" alt="macOS" v-if="query.platforms.includes('macOS')"/>
               <img class="d-inline-flex ml-3 ml-md-0 mr-md-3" src="/images/os-windows-black-24x24@2x.png" alt="Windows" v-if="query.platforms.includes('Windows')"/>
               <img class="d-inline-flex ml-3 ml-md-0 mr-md-3" src="/images/os-linux-black-24x24@2x.png" alt="Linux" v-if="query.platforms.includes('Linux')"/>
-              <img class="d-inline-flex ml-3 ml-md-0 mr-md-3" src="/images/os-freebsd-black-24x24@2x.png" alt="FreeBSD" v-if="query.platforms.includes('FreeBSD')"/>
             </div>
           </div>
         </div>

--- a/website/views/pages/query-library.ejs
+++ b/website/views/pages/query-library.ejs
@@ -33,7 +33,6 @@
                 <option value="macOS">macOS</option>
                 <option value="Windows">Windows</option>
                 <option value="Linux">Linux</option>
-                <option value="FreeBSD">FreeBSD</option>
               </select>
             </div>
           </div>
@@ -71,8 +70,6 @@
                   <button class="dropdown-item" type="button"
                     @click="clickSelectPlatform('Windows')">Windows</button>
                   <button class="dropdown-item" type="button" @click="clickSelectPlatform('Linux')">Linux</button>
-                  <button class="dropdown-item" type="button"
-                    @click="clickSelectPlatform('FreeBSD')">FreeBSD</button>
                 </div>
               </div>
             </div>
@@ -132,9 +129,6 @@
                       <img class="d-inline-flex mr-1 mr-ms-0 ml-sm-1 ml-md-2 logo"
                         src="/images/os-linux-black-16x16@2x.png" alt="Linux"
                         v-if="query.platforms.includes('Linux')" />
-                      <img class="d-inline-flex mr-1 mr-sm-0 ml-sm-1 ml-md-2 logo"
-                        src="/images/os-freebsd-black-16x16@2x.png" alt="FreeBSD"
-                        v-if="query.platforms.includes('FreeBSD')" />
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
For #7000, #7001
and one query in #7259 

This removes all references to FreeBSD from the website docs, Fleet UI, and standard query library. Also fixes one broken query in the standard query library.

**Note: Do not merge before 4.19.0 is cut.**