### PR TITLE
orbit: rename `unified_log` table from extension to `macadmins_unified_log`

### DIFF
--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -33,5 +33,5 @@ export const MACADMINS_EXTENSION_TABLES: Record<string, IOsqueryPlatform[]> = {
   puppet_info: ["darwin", "linux", "windows"],
   puppet_logs: ["darwin", "linux", "windows"],
   puppet_state: ["darwin", "linux", "windows"],
-  unified_log: ["darwin"],
+  macadmins_unified_log: ["darwin"],
 };

--- a/orbit/changes/rename-unified-log
+++ b/orbit/changes/rename-unified-log
@@ -1,0 +1,1 @@
+* Rename `unified_log` table to `macadmins_unified_log` to avoid collision with core

--- a/orbit/pkg/table/extension_darwin.go
+++ b/orbit/pkg/table/extension_darwin.go
@@ -20,6 +20,8 @@ func platformTables() []osquery.OsqueryPlugin {
 		table.NewPlugin("mdm", mdm.MDMInfoColumns(), mdm.MDMInfoGenerate),
 		table.NewPlugin("munki_info", munki.MunkiInfoColumns(), munki.MunkiInfoGenerate),
 		table.NewPlugin("munki_installs", munki.MunkiInstallsColumns(), munki.MunkiInstallsGenerate),
+		// osquery version 5.5.0 and up ships a unified_log table in core
+		// we are renaming the one from the macadmins extension to avoid collision
 		table.NewPlugin("macadmins_unified_log", unifiedlog.UnifiedLogColumns(), unifiedlog.UnifiedLogGenerate),
 	}
 }

--- a/orbit/pkg/table/extension_darwin.go
+++ b/orbit/pkg/table/extension_darwin.go
@@ -20,6 +20,6 @@ func platformTables() []osquery.OsqueryPlugin {
 		table.NewPlugin("mdm", mdm.MDMInfoColumns(), mdm.MDMInfoGenerate),
 		table.NewPlugin("munki_info", munki.MunkiInfoColumns(), munki.MunkiInfoGenerate),
 		table.NewPlugin("munki_installs", munki.MunkiInstallsColumns(), munki.MunkiInstallsGenerate),
-		table.NewPlugin("unified_log", unifiedlog.UnifiedLogColumns(), unifiedlog.UnifiedLogGenerate),
+		table.NewPlugin("macadmins_unified_log", unifiedlog.UnifiedLogColumns(), unifiedlog.UnifiedLogGenerate),
 	}
 }


### PR DESCRIPTION
Haven't had a chance to test this, but I think this is the only change required..?