### PR TITLE
Fixed flaky vulnerability CRON tests

### DIFF
--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -305,8 +305,8 @@ func TestCronVulnerabilitiesSkipMkdirIfDisabled(t *testing.T) {
 
 	go cronVulnerabilities(ctx, ds, logger, "AAA", &config)
 
-	// Every cron tick is 10 seconds ... here we just wait for a loop interation and assert is vuln
-	// dir was not created.
+	// Every cron tick is 10 seconds ... here we just wait for a loop interation and assert the vuln
+	// dir. was not created.
 	require.Eventually(t, func() bool {
 		_, err := os.Stat(vulnPath)
 		return os.IsNotExist(err)

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -244,32 +244,30 @@ func TestCronVulnerabilitiesCreatesDatabasesPath(t *testing.T) {
 }
 
 func TestScanVulnerabilitiesMkdirFailsIfVulnPathIsFile(t *testing.T) {
-	t.Run("mkdir fails if VulnPath is file", func(t *testing.T) {
-		logger := kitlog.NewNopLogger()
-		logger = level.NewFilter(logger, level.AllowDebug())
+	logger := kitlog.NewNopLogger()
+	logger = level.NewFilter(logger, level.AllowDebug())
 
-		ctx, cancelFunc := context.WithCancel(context.Background())
-		defer cancelFunc()
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
 
-		appConfig := &fleet.AppConfig{
-			HostSettings: fleet.HostSettings{EnableSoftwareInventory: true},
-		}
-		ds := new(mock.Store)
+	appConfig := &fleet.AppConfig{
+		HostSettings: fleet.HostSettings{EnableSoftwareInventory: true},
+	}
+	ds := new(mock.Store)
 
-		// creating a file with the same path should result in an error when creating the directory
-		fileVulnPath := filepath.Join(t.TempDir(), "somefile")
-		_, err := os.Create(fileVulnPath)
-		require.NoError(t, err)
+	// creating a file with the same path should result in an error when creating the directory
+	fileVulnPath := filepath.Join(t.TempDir(), "somefile")
+	_, err := os.Create(fileVulnPath)
+	require.NoError(t, err)
 
-		config := config.VulnerabilitiesConfig{
-			DatabasesPath:         fileVulnPath,
-			Periodicity:           10 * time.Second,
-			CurrentInstanceChecks: "auto",
-		}
+	config := config.VulnerabilitiesConfig{
+		DatabasesPath:         fileVulnPath,
+		Periodicity:           10 * time.Second,
+		CurrentInstanceChecks: "auto",
+	}
 
-		err = scanVulnerabilities(ctx, ds, logger, &config, appConfig, fileVulnPath)
-		require.ErrorContains(t, err, "create vulnerabilities databases directory: mkdir")
-	})
+	err = scanVulnerabilities(ctx, ds, logger, &config, appConfig, fileVulnPath)
+	require.ErrorContains(t, err, "create vulnerabilities databases directory: mkdir")
 }
 
 func TestCronVulnerabilitiesSkipMkdirIfDisabled(t *testing.T) {

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -1,15 +1,13 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path"
-	"strings"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -222,7 +220,7 @@ func TestCronVulnerabilitiesCreatesDatabasesPath(t *testing.T) {
 		return nil
 	}
 
-	vulnPath := path.Join(t.TempDir(), "something")
+	vulnPath := filepath.Join(t.TempDir(), "something")
 	require.NoDirExists(t, vulnPath)
 
 	config := config.VulnerabilitiesConfig{
@@ -245,55 +243,42 @@ func TestCronVulnerabilitiesCreatesDatabasesPath(t *testing.T) {
 	}, 5*time.Minute, 30*time.Second)
 }
 
-func TestCronVulnerabilitiesMkdirFailsIfVulnPathIsFile(t *testing.T) {
-	buf := new(bytes.Buffer)
-	logger := kitlog.NewJSONLogger(buf)
-	logger = level.NewFilter(logger, level.AllowDebug())
+func TestScanVulnerabilitiesMkdirFailsIfVulnPathIsFile(t *testing.T) {
+	t.Run("mkdir fails if VulnPath is file", func(t *testing.T) {
+		logger := kitlog.NewNopLogger()
+		logger = level.NewFilter(logger, level.AllowDebug())
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-	ds := new(mock.Store)
-	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-		return &fleet.AppConfig{
+		ctx, cancelFunc := context.WithCancel(context.Background())
+		defer cancelFunc()
+
+		appConfig := &fleet.AppConfig{
 			HostSettings: fleet.HostSettings{EnableSoftwareInventory: true},
-		}, nil
-	}
-	ds.LockFunc = func(ctx context.Context, name string, owner string, expiration time.Duration) (bool, error) {
-		return true, nil
-	}
-	ds.UnlockFunc = func(ctx context.Context, name string, owner string) error {
-		return nil
-	}
-	ds.SyncHostsSoftwareFunc = func(ctx context.Context, updatedAt time.Time) error {
-		return nil
-	}
+		}
+		ds := new(mock.Store)
 
-	// creating a file with the same path should result in an error when creating the directory
-	fileVulnPath := path.Join(t.TempDir(), "somefile")
-	_, err := os.Create(fileVulnPath)
-	require.NoError(t, err)
+		// creating a file with the same path should result in an error when creating the directory
+		fileVulnPath := filepath.Join(t.TempDir(), "somefile")
+		_, err := os.Create(fileVulnPath)
+		require.NoError(t, err)
 
-	config := config.VulnerabilitiesConfig{
-		DatabasesPath:         fileVulnPath,
-		Periodicity:           10 * time.Second,
-		CurrentInstanceChecks: "auto",
-	}
+		config := config.VulnerabilitiesConfig{
+			DatabasesPath:         fileVulnPath,
+			Periodicity:           10 * time.Second,
+			CurrentInstanceChecks: "auto",
+		}
 
-	// We cancel right away so cronsVulnerailities finishes. The logic we are testing happens before the loop starts
-	go cronVulnerabilities(ctx, ds, logger, "AAA", &config)
-
-	require.Eventually(t, func() bool {
-		return strings.Contains(buf.String(), "create vulnerabilities databases directory: mkdir")
-	}, 1*time.Minute, 5*time.Second)
+		err = scanVulnerabilities(ctx, ds, logger, &config, appConfig, fileVulnPath)
+		require.ErrorContains(t, err, "create vulnerabilities databases directory: mkdir")
+	})
 }
 
 func TestCronVulnerabilitiesSkipMkdirIfDisabled(t *testing.T) {
-	buf := new(bytes.Buffer)
-	logger := kitlog.NewJSONLogger(buf)
+	logger := kitlog.NewNopLogger()
 	logger = level.NewFilter(logger, level.AllowDebug())
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
+
 	ds := new(mock.Store)
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		// host_settings.enable_software_inventory is false
@@ -309,7 +294,7 @@ func TestCronVulnerabilitiesSkipMkdirIfDisabled(t *testing.T) {
 		return nil
 	}
 
-	vulnPath := path.Join(t.TempDir(), "something")
+	vulnPath := filepath.Join(t.TempDir(), "something")
 	require.NoDirExists(t, vulnPath)
 
 	config := config.VulnerabilitiesConfig{
@@ -320,11 +305,12 @@ func TestCronVulnerabilitiesSkipMkdirIfDisabled(t *testing.T) {
 
 	go cronVulnerabilities(ctx, ds, logger, "AAA", &config)
 
+	// Every cron tick is 10 seconds ... here we just wait for a loop interation and assert is vuln
+	// dir was not created.
 	require.Eventually(t, func() bool {
-		return strings.Contains(buf.String(), "done")
-	}, 1*time.Minute, 5*time.Second)
-
-	require.NoDirExists(t, vulnPath)
+		_, err := os.Stat(vulnPath)
+		return os.IsNotExist(err)
+	}, 24*time.Second, 12*time.Second)
 }
 
 // TestCronWebhooksLockDuration tests that the Lock method is being called


### PR DESCRIPTION
See https://github.com/fleetdm/fleet/actions/runs/2887029015 for more context, this should fix the data race issues on `TestCronVulnerabilitiesSkipMkdirIfDisabled` and `TestCronVulnerabilitiesMkdirFailsIfVulnPathIsFile`