### PR TITLE
ensure HEAD responses for installers contain an empty body

### DIFF
--- a/server/service/integration_sandbox_test.go
+++ b/server/service/integration_sandbox_test.go
@@ -101,6 +101,7 @@ func (s *integrationSandboxTestSuite) TestInstallerGet() {
 }
 
 func (s *integrationSandboxTestSuite) TestInstallerHeadCheck() {
+	t := s.T()
 	validURL := installerURL(enrollSecret, "pkg", false)
 	s.Do("HEAD", validURL, nil, http.StatusOK)
 
@@ -112,11 +113,17 @@ func (s *integrationSandboxTestSuite) TestInstallerHeadCheck() {
 
 	// wrong enroll secret
 	invalidURL := installerURL("wrong-enroll", "pkg", false)
-	s.Do("HEAD", invalidURL, nil, http.StatusInternalServerError)
+	resp := s.Do("HEAD", invalidURL, nil, http.StatusInternalServerError)
+	bodyContent, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Empty(t, bodyContent)
 
 	// non-existent package
 	invalidURL = installerURL(enrollSecret, "exe", false)
-	s.Do("HEAD", invalidURL, nil, http.StatusNotFound)
+	resp = s.Do("HEAD", invalidURL, nil, http.StatusNotFound)
+	bodyContent, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Empty(t, bodyContent)
 }
 
 func installerURL(secret, kind string, desktop bool) string {


### PR DESCRIPTION
We were getting intermittent errors in integration tests, because the Go client reused the same connection and found unexpected bytes in between requests:

```
2022-08-19T04:51:18.0756634Z 2022/08/19 04:34:22 Unsolicited response received on idle HTTP channel starting with "HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain; charset=utf-8\r\nConnection: close\r\n\r\n400 Bad Request"; err=<nil>
```

Which can be verified via `curl` (note the `content-length`:

```
curl -I --header "Authorization: Bearer $TOKEN" "https://localhost:8080/api/latest/fleet/download_installer/pkg?desktop=1&enroll_secret=$ENROLL_SECRET"
HTTP/2 200
content-type: application/json; charset=utf-8
content-length: 3
date: Fri, 19 Aug 2022 14:45:29 GMT
```

This is happening because our server automatically adds a response body to responses with errors:

https://github.com/fleetdm/fleet/blob/1e62613450059e70ff409924997b1d0d7b10ff42/server/service/transport.go#L35-L38

This hijacks the render of `HEAD /api/_version_/fleet/download_installers/{type}` to ensure we send and empty response body.

```
curl -I --header "Authorization: Bearer $TOKEN" "https://localhost:8080/api/latest/fleet/download_installer/pkg?desktop=1&enroll_secret=$ENROLL_SECRET"
HTTP/2 200
content-type: application/json; charset=utf-8
date: Fri, 19 Aug 2022 14:45:08 GMT
```

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
