### PR TITLE
Fleet UI: Fix default perpage edge cases to 20

### DIFF
--- a/changes/issue-7329-default-per-page
+++ b/changes/issue-7329-default-per-page
@@ -1,0 +1,1 @@
+* Default per page is 20 not 100

--- a/frontend/pages/Homepage/cards/ActivityFeed/ActivityFeed.tsx
+++ b/frontend/pages/Homepage/cards/ActivityFeed/ActivityFeed.tsx
@@ -30,7 +30,7 @@ interface IActivityDisplay extends IActivity {
 const DEFAULT_GRAVATAR_URL =
   "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=blank&size=200";
 
-const DEFAULT_PER_PAGE = 8;
+const DEFAULT_PAGE_SIZE = 8;
 
 const TAGGED_TEMPLATES = {
   liveQueryActivityTemplate: (activity: IActivity) => {
@@ -91,7 +91,7 @@ const ActivityFeed = ({
       perPage: number;
     }>
   >(
-    [{ scope: "activities", pageIndex, perPage: DEFAULT_PER_PAGE }],
+    [{ scope: "activities", pageIndex, perPage: DEFAULT_PAGE_SIZE }],
     ({ queryKey: [{ pageIndex: page, perPage }] }) => {
       return activitiesAPI.loadNext(page, perPage);
     },
@@ -101,7 +101,7 @@ const ActivityFeed = ({
       select: (data) => data.activities,
       onSuccess: (results) => {
         setShowActivityFeedTitle(true);
-        if (results.length < DEFAULT_PER_PAGE) {
+        if (results.length < DEFAULT_PAGE_SIZE) {
           setShowMore(false);
         }
       },

--- a/frontend/pages/Homepage/cards/Software/Software.tsx
+++ b/frontend/pages/Homepage/cards/Software/Software.tsx
@@ -25,7 +25,7 @@ interface ISoftwareCardProps {
 
 const DEFAULT_SORT_DIRECTION = "desc";
 const DEFAULT_SORT_HEADER = "hosts_count";
-const PAGE_SIZE = 8;
+const DEFAULT_PAGE_SIZE = 8;
 const baseClass = "home-software";
 
 const Software = ({
@@ -58,7 +58,7 @@ const Software = ({
       "software",
       {
         pageIndex,
-        pageSize: PAGE_SIZE,
+        pageSize: DEFAULT_PAGE_SIZE,
         sortDirection: DEFAULT_SORT_DIRECTION,
         sortHeader: DEFAULT_SORT_HEADER,
         teamId: currentTeamId,
@@ -68,7 +68,7 @@ const Software = ({
     () =>
       softwareAPI.load({
         page: pageIndex,
-        perPage: PAGE_SIZE,
+        perPage: DEFAULT_PAGE_SIZE,
         orderKey: DEFAULT_SORT_HEADER,
         orderDir: DEFAULT_SORT_DIRECTION,
         vulnerable: !!navTabIndex, // we can take the tab index as a boolean to represent the vulnerable flag :)
@@ -171,7 +171,7 @@ const Software = ({
                   isAllPagesSelected={false}
                   disableCount
                   disableActionButton
-                  pageSize={PAGE_SIZE}
+                  pageSize={DEFAULT_PAGE_SIZE}
                   onQueryChange={onQueryChange}
                 />
               )}
@@ -199,7 +199,7 @@ const Software = ({
                   isAllPagesSelected={false}
                   disableCount
                   disableActionButton
-                  pageSize={PAGE_SIZE}
+                  pageSize={DEFAULT_PAGE_SIZE}
                   onQueryChange={onQueryChange}
                 />
               )}

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -79,7 +79,7 @@ interface IHeaderButtonsState extends ITeamsDropdownState {
   isLoading: boolean;
 }
 const DEFAULT_SORT_DIRECTION = "desc";
-const PAGE_SIZE = 20;
+const DEFAULT_PAGE_SIZE = 20;
 
 const baseClass = "manage-software-page";
 
@@ -175,7 +175,7 @@ const ManageSoftwarePage = ({
       {
         scope: "software",
         page: pageIndex,
-        perPage: PAGE_SIZE,
+        perPage: DEFAULT_PAGE_SIZE,
         query: searchQuery,
         orderDir: sortDirection || DEFAULT_SORT_DIRECTION,
         // API expects "epss_probability" rather than "vulnerabilities"
@@ -480,7 +480,8 @@ const ManageSoftwarePage = ({
 
   const isLastPage =
     !!softwareCount &&
-    PAGE_SIZE * pageIndex + (software?.software?.length || 0) >= softwareCount;
+    DEFAULT_PAGE_SIZE * pageIndex + (software?.software?.length || 0) >=
+      softwareCount;
 
   const softwareTableHeaders = useMemo(
     () => generateSoftwareTableHeaders(isPremiumTier),
@@ -512,7 +513,7 @@ const ManageSoftwarePage = ({
               defaultSortHeader={DEFAULT_SORT_HEADER}
               defaultSortDirection={DEFAULT_SORT_DIRECTION}
               manualSortBy
-              pageSize={PAGE_SIZE}
+              pageSize={DEFAULT_PAGE_SIZE}
               showMarkAllPages={false}
               isAllPagesSelected={false}
               disableNextPage={isLastPage}

--- a/frontend/services/entities/activities.ts
+++ b/frontend/services/entities/activities.ts
@@ -3,7 +3,7 @@ import { IActivity } from "interfaces/activity";
 import sendRequest from "services";
 
 const DEFAULT_PAGE = 0;
-const PER_PAGE = 8;
+const DEFAULT_PAGE_SIZE = 8;
 const ORDER_KEY = "created_at";
 const ORDER_DIRECTION = "desc";
 
@@ -14,7 +14,7 @@ export interface IActivitiesResponse {
 export default {
   loadNext: (
     page = DEFAULT_PAGE,
-    perPage = PER_PAGE
+    perPage = DEFAULT_PAGE_SIZE
   ): Promise<IActivitiesResponse> => {
     const { ACTIVITIES } = endpoints;
     const pagination = `page=${page}&per_page=${perPage}`;

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -253,7 +253,7 @@ export default {
   },
   loadHosts: ({
     page = 0,
-    perPage = 100,
+    perPage = 20,
     globalFilter,
     teamId,
     policyId,

--- a/frontend/services/entities/invites.ts
+++ b/frontend/services/entities/invites.ts
@@ -42,7 +42,7 @@ export default {
   },
   loadAll: ({
     page = 0,
-    perPage = 100,
+    perPage = 20,
     globalFilter = "",
     sortBy = [],
   }: IInviteSearchOptions) => {

--- a/frontend/services/entities/teams.ts
+++ b/frontend/services/entities/teams.ts
@@ -52,7 +52,7 @@ export default {
   },
   loadAll: ({
     page = 0,
-    perPage = 100,
+    perPage = 20,
     globalFilter = "",
   }: ILoadTeamsParams = {}): Promise<ILoadTeamsResponse> => {
     const { TEAMS } = endpoints;

--- a/frontend/services/entities/users.ts
+++ b/frontend/services/entities/users.ts
@@ -94,7 +94,7 @@ export default {
   },
   loadAll: ({
     page = 0,
-    perPage = 100,
+    perPage = 20,
     globalFilter = "",
     sortBy = [],
     teamId,

--- a/frontend/services/mock_service/examples/config.ts
+++ b/frontend/services/mock_service/examples/config.ts
@@ -20,13 +20,13 @@ const WILDCARDS: string[] = [":", "*", "{", "}"];
 const REQUEST_RESPONSE_MAPPINGS: IResponses = {
   GET: {
     // this is a basic path with no wildcards
-    "/hosts?page=0&per_page=100&order_key=hostname&order_direction=asc":
+    "/hosts?page=0&per_page=20&order_key=hostname&order_direction=asc":
       RESPONSES.ALL_HOSTS,
     // this basic path only matches with '1337' as the value for the team id query param
-    "/hosts?page=0&per_page=100&order_key=hostname&order_direction=asc&team_id=1337":
+    "/hosts?page=0&per_page=20&order_key=hostname&order_direction=asc&team_id=1337":
       RESPONSES.HOSTS_TEAM_1337,
     // this wildcard path matches with any other value for the team id query param
-    "/hosts?page=0&per_page=100&order_key=hostname&order_direction=asc&team_id={team_id}":
+    "/hosts?page=0&per_page=20&order_key=hostname&order_direction=asc&team_id={team_id}":
       RESPONSES.HOSTS_TEAM_ID,
     // this basic path only matches with '1337' as the value for the host id route param
     "/hosts/1337": RESPONSES.HOST_1337,


### PR DESCRIPTION
Cerra #7329 

**Fix**
- Default per page set to 20 instead of 100
- Fixes page defaulting to 100 after transferring hosts and other edge cases

**Other techdebt addressed**
- Fix 4 files to use consistent naming `DEFAULT_PAGE_SIZE` used in 7 files


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
