### PR TITLE
Fleet UI Safari: Remove weird focus state on side panel close button

### DIFF
--- a/changes/issue-6833-remove-weird-focus-side-panel-button
+++ b/changes/issue-6833-remove-weird-focus-side-panel-button
@@ -1,0 +1,1 @@
+* Clean up Safari focus on side panel button

--- a/frontend/components/side_panels/QuerySidePanel/_styles.scss
+++ b/frontend/components/side_panels/QuerySidePanel/_styles.scss
@@ -20,6 +20,10 @@
     img {
       transform: scale(0.5);
     }
+
+    &:focus {
+      outline: none;
+    }
   }
 
   &__header {


### PR DESCRIPTION
Cerra #6833 

**Fix**
- Removes focus state on side panel close button

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
