### PR TITLE
Bug 7332: Include software without CPE entries

### DIFF
--- a/changes/bug-7332-software-list-includes-without-cpe
+++ b/changes/bug-7332-software-list-includes-without-cpe
@@ -1,0 +1,2 @@
+When listing software for vulnerability detection, software without CPE entries should not be
+excluded.

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -1134,7 +1134,7 @@ func (ds *Datastore) ListSoftwareForVulnDetection(
 
 	stmt := dialect.
 		From(goqu.T("software").As("s")).
-		Join(
+		LeftJoin(
 			goqu.T("software_cpe").As("cpe"),
 			goqu.On(goqu.Ex{
 				"s.id": goqu.I("cpe.software_id"),
@@ -1152,7 +1152,7 @@ func (ds *Datastore) ListSoftwareForVulnDetection(
 			goqu.I("s.version"),
 			goqu.I("s.release"),
 			goqu.I("s.arch"),
-			goqu.I("cpe.cpe").As("generated_cpe"),
+			goqu.COALESCE(goqu.I("cpe.cpe"), "").As("generated_cpe"),
 		).
 		Where(goqu.C("host_id").Eq(hostID))
 


### PR DESCRIPTION
#7332 

When listing software for performing vuln. detection include software without CPE entries.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
