### PR TITLE
fix flaky TestIntegrationsSandbox/TestInstallerHeadCheck

### DIFF
--- a/server/service/integration_sandbox_test.go
+++ b/server/service/integration_sandbox_test.go
@@ -102,21 +102,21 @@ func (s *integrationSandboxTestSuite) TestInstallerGet() {
 
 func (s *integrationSandboxTestSuite) TestInstallerHeadCheck() {
 	validURL := installerURL(enrollSecret, "pkg", false)
-	s.Do("HEAD", validURL, nil, http.StatusOK)
+	s.DoRaw("HEAD", validURL, nil, http.StatusOK)
 
 	// unauthorized requests
 	s.DoRawNoAuth("HEAD", validURL, nil, http.StatusUnauthorized)
 	s.token = "invalid"
-	s.Do("HEAD", validURL, nil, http.StatusUnauthorized)
+	s.DoRaw("HEAD", validURL, nil, http.StatusUnauthorized)
 	s.token = s.cachedAdminToken
 
 	// wrong enroll secret
 	invalidURL := installerURL("wrong-enroll", "pkg", false)
-	s.Do("HEAD", invalidURL, nil, http.StatusInternalServerError)
+	s.DoRaw("HEAD", invalidURL, nil, http.StatusInternalServerError)
 
 	// non-existent package
 	invalidURL = installerURL(enrollSecret, "exe", false)
-	s.Do("HEAD", invalidURL, nil, http.StatusNotFound)
+	s.DoRaw("HEAD", invalidURL, nil, http.StatusNotFound)
 }
 
 func installerURL(secret, kind string, desktop bool) string {

--- a/server/service/testing_client.go
+++ b/server/service/testing_client.go
@@ -65,8 +65,12 @@ func (ts *withServer) TearDownSuite() {
 func (ts *withServer) Do(verb, path string, params interface{}, expectedStatusCode int, queryParams ...string) *http.Response {
 	t := ts.s.T()
 
-	j, err := json.Marshal(params)
-	require.NoError(t, err)
+	var j []byte
+	var err error
+	if params != nil {
+		j, err = json.Marshal(params)
+		require.NoError(t, err)
+	}
 
 	resp := ts.DoRaw(verb, path, j, expectedStatusCode, queryParams...)
 

--- a/server/service/testing_client.go
+++ b/server/service/testing_client.go
@@ -65,12 +65,8 @@ func (ts *withServer) TearDownSuite() {
 func (ts *withServer) Do(verb, path string, params interface{}, expectedStatusCode int, queryParams ...string) *http.Response {
 	t := ts.s.T()
 
-	var j []byte
-	var err error
-	if params != nil {
-		j, err = json.Marshal(params)
-		require.NoError(t, err)
-	}
+	j, err := json.Marshal(params)
+	require.NoError(t, err)
 
 	resp := ts.DoRaw(verb, path, j, expectedStatusCode, queryParams...)
 


### PR DESCRIPTION
This adjusts the `TestInstallerHeadCheck` check to use `DoRaw` instead of `Do`, which sends a body with `null` when `nil` is passed for the `params` parameter.

Originally, I tried to "solve" this the wrong way in https://github.com/fleetdm/fleet/pull/7313, h/t to @mna for calling out the mistake.

# Checklist for submitter

- [x] Added/updated tests
