### PR TITLE
fix order of query string and hashes in SSO link

### DIFF
--- a/frontend/pages/admin/AppSettingsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/Sso/Sso.tsx
@@ -222,7 +222,7 @@ const Sso = ({
               <>
                 Automatically create Observer user on Login{" "}
                 <a
-                  href="https://fleetdm.com/docs/deploying/configuration#just-in-time-jit-user-provisioning?utm_medium=fleetui&utm_source=sso-settings"
+                  href="https://fleetdm.com/docs/deploying/configuration?utm_medium=fleetui&utm_source=sso-settings#just-in-time-jit-user-provisioning"
                   target="_blank"
                   rel="noopener noreferrer"
                 >


### PR DESCRIPTION
as reported by @noahtalerman in https://github.com/fleetdm/fleet/issues/7054#issuecomment-1223118912 this fixes the link to actually navigate to the given hash.

# Checklist for submitter

- [x] Manual QA for all new/changed functionality
