### PR TITLE
add a mechanism to deprecate AppConfig settings w/ backwards-compat

### DIFF
--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -148,6 +148,7 @@ type EnrichedAppConfig struct {
 	enrichedAppConfigFields
 }
 
+// enrichedAppConfigFields are gruped separately to aid with JSON unmarshaling
 type enrichedAppConfigFields struct {
 	UpdateInterval  *UpdateIntervalConfig  `json:"update_interval,omitempty"`
 	Vulnerabilities *VulnerabilitiesConfig `json:"vulnerabilities,omitempty"`
@@ -155,6 +156,13 @@ type enrichedAppConfigFields struct {
 	Logging         *Logging               `json:"logging,omitempty"`
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface to make sure we serialize
+// both AppConfig and appConfigResponseFields properly:
+//
+// - If this function is not defined, AppConfig.UnmarshalJSON gets promoted and
+// will be called instead.
+// - If we try to unmarshal everyting in one go, AppConfig.UnmarshalJSON doesn't get
+// called.
 func (e *EnrichedAppConfig) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &e.AppConfig); err != nil {
 		return err

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -148,7 +148,7 @@ type EnrichedAppConfig struct {
 	enrichedAppConfigFields
 }
 
-// enrichedAppConfigFields are gruped separately to aid with JSON unmarshaling
+// enrichedAppConfigFields are grouped separately to aid with JSON unmarshaling
 type enrichedAppConfigFields struct {
 	UpdateInterval  *UpdateIntervalConfig  `json:"update_interval,omitempty"`
 	Vulnerabilities *VulnerabilitiesConfig `json:"vulnerabilities,omitempty"`

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -288,9 +288,6 @@ func (c *AppConfig) UnmarshalJSON(b []byte) error {
 		return errors.New("unexpected extra tokens found in config")
 	}
 
-	// Assign values to the AppConfig struct.
-	*c = AppConfig(compatConfig.appCfgNoCustomUnmarshal)
-
 	// TODO(roperzh): define and assign legacy settings to new fields. This has
 	// the drawback of legacy fields taking precedence over new fields if both
 	// are defined. Eg:

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -132,7 +132,7 @@ type AppConfig struct {
 	WebhookSettings WebhookSettings `json:"webhook_settings"`
 	Integrations    Integrations    `json:"integrations"`
 
-	strictDecoding bool `json:"-"`
+	strictDecoding bool
 }
 
 // legacyConfig holds settings that have been replaced, superceded or

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -157,7 +157,7 @@ type enrichedAppConfigFields struct {
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface to make sure we serialize
-// both AppConfig and appConfigResponseFields properly:
+// both AppConfig and enrichedAppConfigFields properly:
 //
 // - If this function is not defined, AppConfig.UnmarshalJSON gets promoted and
 // will be called instead.

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -109,7 +109,7 @@ type VulnerabilitySettings struct {
 // AppConfig holds server configuration that can be changed via the API.
 //
 // Note: management of deprecated fields is done on JSON-marshalling and uses
-// the legacyFields struct to list them.
+// the legacyConfig struct to list them.
 type AppConfig struct {
 	OrgInfo            OrgInfo            `json:"org_info"`
 	ServerSettings     ServerSettings     `json:"server_settings"`

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -145,20 +145,24 @@ type legacyConfig struct {
 // "GET /api/latest/fleet/config" API endpoint (and fleetctl get config).
 type EnrichedAppConfig struct {
 	AppConfig
+	enrichedAppConfigFields
+}
 
-	// NoopUnmarshaler is used to disallow AppConfig.UnmarshalJSON from being
-	// promoted to the top level, hijacking the JSON unmarshalling process.
-	//
-	// As a side effect of this, AppConfig.UnmarshalJSON will not be called even
-	// to serialize AppConfig itself, everything will be serialized according to
-	// default struct rules, which is fine since we only need backwards
-	// compatibility when reading AppConfig to perform changes.
-	NoopUnmarshaler
-
+type enrichedAppConfigFields struct {
 	UpdateInterval  *UpdateIntervalConfig  `json:"update_interval,omitempty"`
 	Vulnerabilities *VulnerabilitiesConfig `json:"vulnerabilities,omitempty"`
 	License         *LicenseInfo           `json:"license,omitempty"`
 	Logging         *Logging               `json:"logging,omitempty"`
+}
+
+func (e *EnrichedAppConfig) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, &e.AppConfig); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, &e.enrichedAppConfigFields); err != nil {
+		return err
+	}
+	return nil
 }
 
 type Duration struct {

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -161,7 +161,7 @@ type enrichedAppConfigFields struct {
 //
 // - If this function is not defined, AppConfig.UnmarshalJSON gets promoted and
 // will be called instead.
-// - If we try to unmarshal everyting in one go, AppConfig.UnmarshalJSON doesn't get
+// - If we try to unmarshal everything in one go, AppConfig.UnmarshalJSON doesn't get
 // called.
 func (e *EnrichedAppConfig) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &e.AppConfig); err != nil {

--- a/server/fleet/utils.go
+++ b/server/fleet/utils.go
@@ -20,14 +20,3 @@ func WriteExpiredLicenseBanner(w io.Writer) {
 	warningColor.DisableColor()
 	warningColor.Fprintln(w)
 }
-
-// NoopUnmarshaler is a type that implements the `json.Unmarshaler` interface but does
-// nothing.
-//
-// This is useful when you have an embeded field that implements
-// `json.Unmarshaler` but want to prevent the method from being promoted to the
-// top-level struct.
-type NoopUnmarshaler struct{}
-
-// UnmarshalJSON implments the `json.Unmarshaler` interface.
-func (*NoopUnmarshaler) UnmarshalJSON([]byte) error { return nil }

--- a/server/fleet/utils.go
+++ b/server/fleet/utils.go
@@ -20,3 +20,14 @@ func WriteExpiredLicenseBanner(w io.Writer) {
 	warningColor.DisableColor()
 	warningColor.Fprintln(w)
 }
+
+// NoopUnmarshaler is a type that implements the `json.Unmarshaler` interface but does
+// nothing.
+//
+// This is useful when you have an embeded field that implements
+// `json.Unmarshaler` but want to prevent the method from being promoted to the
+// top-level struct.
+type NoopUnmarshaler struct{}
+
+// UnmarshalJSON implments the `json.Unmarshaler` interface.
+func (*NoopUnmarshaler) UnmarshalJSON([]byte) error { return nil }

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -40,11 +40,11 @@ type appConfigResponse struct {
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
-// It is explicitly defined to prevent promoted methods from embedded structs
-// from taking over JSON-serialization.
+// It is explicitly defined to prevent AppConfig.UnmarshalJSON from being
+// promoted (and called) when this struct is unmarshalled.
 func (r *appConfigResponse) UnmarshalJSON(b []byte) error {
-	type Alias *appConfigResponse
-	return json.Unmarshal(b, Alias(r))
+	type responseNoLoop *appConfigResponse
+	return json.Unmarshal(b, responseNoLoop(r))
 }
 
 func (r appConfigResponse) error() error { return r.Err }

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -28,6 +28,7 @@ type appConfigResponse struct {
 	appConfigResponseFields
 }
 
+// appConfigResponseFields are gruped separately to aid with JSON unmarshaling
 type appConfigResponseFields struct {
 	UpdateInterval  *fleet.UpdateIntervalConfig  `json:"update_interval"`
 	Vulnerabilities *fleet.VulnerabilitiesConfig `json:"vulnerabilities"`
@@ -42,6 +43,13 @@ type appConfigResponseFields struct {
 	Err error `json:"error,omitempty"`
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface to make sure we serialize
+// both AppConfig and appConfigResponseFields properly:
+//
+// - If this function is not defined, AppConfig.UnmarshalJSON gets promoted and
+// will be called instead.
+// - If we try to unmarshal everyting in one go, AppConfig.UnmarshalJSON doesn't get
+// called.
 func (r *appConfigResponse) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &r.AppConfig); err != nil {
 		return err

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -26,6 +26,15 @@ import (
 type appConfigResponse struct {
 	fleet.AppConfig
 
+	// NoopUnmarshaler is used to disallow AppConfig.UnmarshalJSON from being
+	// promoted to the top level, hijacking the JSON unmarshalling process.
+	//
+	// As a side effect of this, AppConfig.UnmarshalJSON will not be called even
+	// to serialize AppConfig itself, everything will be serialized according to
+	// default struct rules, which is fine since we only need backwards
+	// compatibility when reading AppConfig to perform changes.
+	fleet.NoopUnmarshaler
+
 	UpdateInterval  *fleet.UpdateIntervalConfig  `json:"update_interval"`
 	Vulnerabilities *fleet.VulnerabilitiesConfig `json:"vulnerabilities"`
 
@@ -37,14 +46,6 @@ type appConfigResponse struct {
 	SandboxEnabled bool `json:"sandbox_enabled,omitempty"`
 
 	Err error `json:"error,omitempty"`
-}
-
-// UnmarshalJSON implements the json.Unmarshaler interface.
-// It is explicitly defined to prevent AppConfig.UnmarshalJSON from being
-// promoted (and called) when this struct is unmarshalled.
-func (r *appConfigResponse) UnmarshalJSON(b []byte) error {
-	type responseNoLoop *appConfigResponse
-	return json.Unmarshal(b, responseNoLoop(r))
 }
 
 func (r appConfigResponse) error() error { return r.Err }

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -48,7 +48,7 @@ type appConfigResponseFields struct {
 //
 // - If this function is not defined, AppConfig.UnmarshalJSON gets promoted and
 // will be called instead.
-// - If we try to unmarshal everyting in one go, AppConfig.UnmarshalJSON doesn't get
+// - If we try to unmarshal everything in one go, AppConfig.UnmarshalJSON doesn't get
 // called.
 func (r *appConfigResponse) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &r.AppConfig); err != nil {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -28,7 +28,7 @@ type appConfigResponse struct {
 	appConfigResponseFields
 }
 
-// appConfigResponseFields are gruped separately to aid with JSON unmarshaling
+// appConfigResponseFields are grouped separately to aid with JSON unmarshaling
 type appConfigResponseFields struct {
 	UpdateInterval  *fleet.UpdateIntervalConfig  `json:"update_interval"`
 	Vulnerabilities *fleet.VulnerabilitiesConfig `json:"vulnerabilities"`


### PR DESCRIPTION
Related to https://github.com/fleetdm/fleet/issues/7312, the motivation behind these changes is to introduce a way to deprecate configurations in `AppConfig`, while still preserving backwards compatibility.

From the Epic:

> NOTE: `host_settings` is now replaced by `features`. We should still support `host_settings` as an alias to `features` for backwards compatibility, but in our communications, we should use and recommend features as the canonical way forward.

I will actually use this in a follow-up PR I have ready, but that's practically all noise from doing `s/host_settings/features` and I thought this deserves a conversation.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
