### PR TITLE
Fleet UI: Manage Host Page disable next on pagination of if on last page of results

### DIFF
--- a/changes/issue-7357-fix-next-button-server-side
+++ b/changes/issue-7357-fix-next-button-server-side
@@ -1,0 +1,1 @@
+* Disable next buton for manage host page when next page has 0 results

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -78,6 +78,7 @@ import {
   LABEL_SLUG_PREFIX,
   DEFAULT_SORT_HEADER,
   DEFAULT_SORT_DIRECTION,
+  DEFAULT_PAGE_SIZE,
   HOST_SELECT_STATUSES,
 } from "./constants";
 import { isAcceptableStatus, getNextLocationPath } from "./helpers";
@@ -562,6 +563,12 @@ const ManageHostsPage = ({
       setCurrentQueryOptions(options);
     }
   }, [availableTeams, currentTeam, location, labels]);
+
+  const isLastPage =
+    tableQueryData &&
+    !!filteredHostCount &&
+    DEFAULT_PAGE_SIZE * tableQueryData.pageIndex + (hosts?.length || 0) >=
+      filteredHostCount;
 
   const handleLabelChange = ({ slug }: ILabel): boolean => {
     if (!slug) {
@@ -1889,6 +1896,7 @@ const ManageHostsPage = ({
         onPrimarySelectActionClick={onDeleteHostsClick}
         onQueryChange={onTableQueryChange}
         toggleAllPagesSelected={toggleAllMatchingHosts}
+        disableNextPage={isLastPage}
       />
     );
   };

--- a/frontend/pages/hosts/ManageHostsPage/constants.ts
+++ b/frontend/pages/hosts/ManageHostsPage/constants.ts
@@ -5,6 +5,7 @@ export const LABEL_SLUG_PREFIX = "labels/";
 
 export const DEFAULT_SORT_HEADER = "hostname";
 export const DEFAULT_SORT_DIRECTION = "asc";
+export const DEFAULT_PAGE_SIZE = 20;
 
 export const HOST_SELECT_STATUSES = [
   {


### PR DESCRIPTION
Cerra #7357 

**Fix**
- If the host count is a multiple of the page length, disable next on the last page of results
- Server side pagination bug fixed to match fix on server side software table

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
