### PR TITLE
Article: Category for Orbit post

### DIFF
--- a/articles/introducing-orbit-your-fleet-agent-manager.md
+++ b/articles/introducing-orbit-your-fleet-agent-manager.md
@@ -30,7 +30,7 @@ Orbit will be the one-stop shop for all your agent needs in Fleet. Stay tuned as
 If you have suggestions for Orbit, please share them with us in the osquery Slack [#fleet channel](https://osquery.slack.com/join/shared_invite/zt-h29zm0gk-s2DBtGUTW4CFel0f0IjTEw#/) or open an issue in Github.
 
 
-<meta name="category" value="releases">
+<meta name="category" value="announcements">
 <meta name="authorFullName" value="Mo Zhu">
 <meta name="authorGitHubUsername" value="zhumo">
 <meta name="publishedOn" value="2022-08-18">


### PR DESCRIPTION
This is a low priority, quick adjustment.

Should this "Orbit" post be categorized under announcements rather than releases? https://fleetdm.com/releases/introducing-orbit-your-fleet-agent-manager

It would make it match the Fleet Desktop announcement:
![image](https://user-images.githubusercontent.com/618009/186225094-5b8c7190-a9f1-427f-acc5-371d70d8016b.png)

This PR changes the category.


@chris-mcgillicuddy If you agree, no need to wait for Mo to merge this.

fyi @zhumo If you prefer to keep it the way it is, feel free to jump in and revert in a separate PR (though in that case, we might consider doing the same for the Fleet Desktop post?)