### PR TITLE
Website: use EJS tags for article and documentation page titles

### DIFF
--- a/website/views/pages/articles/basic-article.ejs
+++ b/website/views/pages/articles/basic-article.ejs
@@ -1,14 +1,14 @@
 <div id="basic-article" v-cloak>
   <div style="max-width: 800px;" class="container-fluid px-0">
     <div purpose="article-title">
-      <h1>{{thisPage.meta.articleTitle}}</h1>
+      <h1><%=thisPage.meta.articleTitle %></h1>
       <h2 v-if="articleHasSubtitle && articleSubtitle !== undefined">{{articleSubtitle}}</h2>
     </div>
     <div purpose="article-details" class="d-flex flex-row align-items-center">
     <span><js-timestamp format="billing" :at="thisPage.meta.publishedOn"></js-timestamp></span>
     <span class="px-2">|</span>
     <img style="height: 28px; width: 28px; border-radius: 100%;" alt="The author's GitHub profile picture" :src="'https://github.com/'+thisPage.meta.authorGitHubUsername+'.png?size=200'">
-    <p class="pl-2 font-weight-bold">{{thisPage.meta.authorFullName}}</p>
+    <p class="pl-2 font-weight-bold"><%=thisPage.meta.authorFullName %></p>
     </div>
     <div purpose="article-content" class="d-flex flex-column">
       <%- partial(path.relative(path.dirname(__filename), path.resolve( sails.config.appPath, path.join(sails.config.builtStaticContent.compiledPagePartialsAppPath, thisPage.htmlId)))) %>

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -139,7 +139,7 @@
 
       </div>
 
-      <h1 purpose="page-title" class="d-flex d-lg-none py-4 m-0">{{thisPage.title}}</h1>
+      <h1 purpose="page-title" class="d-flex d-lg-none py-4 m-0"><%= thisPage.title %></h1>
 
       <div purpose="edit-button-container">
         <div purpose="edit-button">


### PR DESCRIPTION
Changes:
- Switched from using vue templates `{{ foo }}` to EJS tags `<%= foo %>` for page titles on documentation and article pages.
- switched to EJS tags for authors on article pages.