### PR TITLE
fix brew install warning

### DIFF
--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -196,14 +196,19 @@ jobs:
 
     # Docker needs to be installed manually on macOS.
     # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
+    # FIXME: lock Docker version to 4.10.0 as newer versions fail to initialize
     - name: Install Docker
+      timeout-minutes: 10
+      if: matrix.os == 'macos-latest'
       run: |
-        # fixme: lock Docker version to 4.10.0 as newer versions fail to initialize
-        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb && brew install docker.rb
+        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb
+        brew install --cask docker.rb
         sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
         open -a /Applications/Docker.app --args --unattended --accept-license
         echo "Waiting for Docker to start up..."
-        while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do sleep 1; done
+        while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do
+          sleep 1;
+        done
         echo "Docker is ready."
 
     - name: Build Repository and run TUF server

--- a/.github/workflows/fleetctl-preview-latest.yml
+++ b/.github/workflows/fleetctl-preview-latest.yml
@@ -33,17 +33,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
+    # Docker needs to be installed manually on macOS.
+    # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
+    # FIXME: lock Docker version to 4.10.0 as newer versions fail to initialize
     - name: Install Docker
-      # Docker needs to be installed manually on macOS.
-      if: contains(matrix.os, 'macos')
-      # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
+      timeout-minutes: 10
+      if: matrix.os == 'macos-latest'
       run: |
-        # fixme: lock Docker version to 4.10.0 as newer versions fail to initialize
-        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb && brew install docker.rb
+        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb
+        brew install --cask docker.rb
         sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
         open -a /Applications/Docker.app --args --unattended --accept-license
         echo "Waiting for Docker to start up..."
-        while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do sleep 1; done
+        while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do
+          sleep 1;
+        done
         echo "Docker is ready."
 
     - name: Install Go

--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -19,17 +19,22 @@ jobs:
         os: [ubuntu-20.04, ubuntu-18.04, macos-11, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
+
+    # Docker needs to be installed manually on macOS.
+    # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
+    # FIXME: lock Docker version to 4.10.0 as newer versions fail to initialize
     - name: Install Docker
-      # Docker needs to be installed manually on macOS.
+      timeout-minutes: 10
       if: contains(matrix.os, 'macos')
-      # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
       run: |
-        # fixme: lock Docker version to 4.10.0 as newer versions fail to initialize
-        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb && brew install docker.rb
+        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb
+        brew install --cask docker.rb
         sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
         open -a /Applications/Docker.app --args --unattended --accept-license
         echo "Waiting for Docker to start up..."
-        while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do sleep 1; done
+        while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do
+          sleep 1;
+        done
         echo "Docker is ready."
 
     - name: Start tunnel

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -35,11 +35,14 @@ jobs:
       # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
       run: |
         # fixme: lock Docker version to 4.10.0 as newer versions fail to initialize
-        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb && brew install docker.rb
+        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb
+        brew install --cask docker.rb
         sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
         open -a /Applications/Docker.app --args --unattended --accept-license
         echo "Waiting for Docker to start up..."
-        while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do sleep 1; done
+        while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do
+          sleep 1;
+        done
         echo "Docker is ready."
 
     - name: Pull fleetdm/wix

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -29,12 +29,14 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+
+    # Docker needs to be installed manually on macOS.
+    # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
+    # FIXME: lock Docker version to 4.10.0 as newer versions fail to initialize
     - name: Install Docker
-      timeout-minutes: 60
+      timeout-minutes: 10
       if: matrix.os == 'macos-latest'
-      # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
       run: |
-        # fixme: lock Docker version to 4.10.0 as newer versions fail to initialize
         curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb
         brew install --cask docker.rb
         sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components


### PR DESCRIPTION
Fixes the following warning

```
Error: Failed to load formula: docker.rb
[16](https://github.com/fleetdm/fleet/runs/8021154527?check_suite_focus=true#step:2:17)
docker: undefined method `cask' for Formulary::FormulaNamespace8362a552d420bbfaa5328cbe17305b04:Module
[17](https://github.com/fleetdm/fleet/runs/8021154527?check_suite_focus=true#step:2:18)
Did you mean?  case
[18](https://github.com/fleetdm/fleet/runs/8021154527?check_suite_focus=true#step:2:19)
Warning: Treating docker.rb as a cask.
```

See https://github.com/fleetdm/fleet/runs/8021154527?check_suite_focus=true for an example workflow run.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] ~Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).~
- [ ] ~Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- [ ] ~Documented any permissions changes~
- [ ] ~Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
- [ ] ~Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [ ] ~Added/updated tests~
- [ ] ~Manual QA for all new/changed functionality~
