### PR TITLE
mechanism to allow premium implementations in deeply nested svc methods

### DIFF
--- a/ee/server/service/service.go
+++ b/ee/server/service/service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/WatchBeam/clock"
@@ -21,6 +22,11 @@ type Service struct {
 	license *fleet.LicenseInfo
 }
 
+func (s *Service) ExampleMethod(ctx context.Context) error {
+	fmt.Println("premium example method!")
+	return nil
+}
+
 func NewService(
 	svc fleet.Service,
 	ds fleet.Datastore,
@@ -36,7 +42,7 @@ func NewService(
 		return nil, fmt.Errorf("new authorizer: %w", err)
 	}
 
-	return &Service{
+	eesvc := &Service{
 		Service: svc,
 		ds:      ds,
 		logger:  logger,
@@ -44,5 +50,7 @@ func NewService(
 		clock:   c,
 		authz:   authorizer,
 		license: license,
-	}, nil
+	}
+	svc.HijackWith(eesvc)
+	return eesvc, nil
 }

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -10,6 +10,14 @@ import (
 	"github.com/kolide/kit/version"
 )
 
+type Hijacker interface {
+	// HijackWith lets the caller implement custom behavior for the
+	// set of methods in this interface.
+	HijackWith(Hijacker)
+
+	ExampleMethod(ctx context.Context) error
+}
+
 type OsqueryService interface {
 	EnrollAgent(
 		ctx context.Context, enrollSecret, hostIdentifier string, hostDetails map[string](map[string]string),
@@ -41,6 +49,7 @@ type OsqueryService interface {
 
 type Service interface {
 	OsqueryService
+	Hijacker
 
 	///////////////////////////////////////////////////////////////////////////////
 	// UserService contains methods for managing a Fleet User.

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -47,11 +47,25 @@ type Service struct {
 	jitterMu *sync.Mutex
 	jitterH  map[time.Duration]*jitterHashTable
 
-	geoIP fleet.GeoIP
+	geoIP  fleet.GeoIP
+	hijack fleet.Hijacker
 }
 
 func (s *Service) LookupGeoIP(ctx context.Context, ip string) *fleet.GeoLocation {
 	return s.geoIP.Lookup(ctx, ip)
+}
+
+func (s *Service) HijackWith(h fleet.Hijacker) { s.hijack = h }
+
+func (s *Service) ExampleMethod(ctx context.Context) error {
+	if s.hijack != nil {
+		return s.hijack.ExampleMethod(ctx)
+	}
+
+	fmt.Println("free example method!")
+
+	// free implementation...
+	return nil
 }
 
 // NewService creates a new service from the config struct


### PR DESCRIPTION
Currently, if you need to define premium behavior for `service.C` below, you can't just define `eeservice.C`, you're forced to heavily refactor `service.A` and `service.B` due to how embedding works.

```
func(s *Service) A() {
 // ...
  s.B()
 // ...
}

func(s *Service) B() {
 // ...
  s.C()
 // ...
}
```

The example above only illustrates three-levels deep, but we have service methods buried under many more layers, _and_ you can have more than one set of layers (if the method is used in different parts of the code).

This is a proposal to add a _temporary_ workaround that allows us to hijack methods in `ee`, in a way that ensures the right method will be called.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
