### PR TITLE
Website: Remove category links from article cards

### DIFF
--- a/website/assets/styles/pages/articles/articles.less
+++ b/website/assets/styles/pages/articles/articles.less
@@ -52,7 +52,7 @@
         padding: 24px 24px 32px 24px;
         [purpose='category-name'] {
           text-transform: uppercase;
-          color: @core-vibrant-blue;
+          color: @core-fleet-black-50;
           font-size: 12px;
           font-weight: 700;
           line-height: 20px;

--- a/website/assets/styles/pages/articles/articles.less
+++ b/website/assets/styles/pages/articles/articles.less
@@ -52,9 +52,10 @@
         padding: 24px 24px 32px 24px;
         [purpose='category-name'] {
           text-transform: uppercase;
-          color: @core-fleet-black-50;
+          color: @core-vibrant-blue;
           font-size: 12px;
           font-weight: 700;
+          line-height: 20px;
           text-decoration: none;
         }
         [purpose='article-title'] {

--- a/website/assets/styles/pages/articles/articles.less
+++ b/website/assets/styles/pages/articles/articles.less
@@ -50,7 +50,7 @@
       }
       [purpose='article-card-body'] {
         padding: 24px 24px 32px 24px;
-        [purpose='category-link'] {
+        [purpose='category-name'] {
           text-transform: uppercase;
           color: @core-fleet-black-50;
           font-size: 12px;

--- a/website/views/pages/articles/articles.ejs
+++ b/website/views/pages/articles/articles.ejs
@@ -27,7 +27,7 @@
             <img style="width: 100%; height: auto;" :src="[article.meta.articleImageUrl ? article.meta.articleImageUrl : '/images/press-kit/press-kit-fleet-logo-white-preview-600x336@2x.png']" alt="Article hero image">
           </a>
           <div purpose="article-card-body" class="card-body d-flex flex-column">
-            <a purpose="category-link" :href="article.url.split('/')[1]" class="pb-2">{{article.meta.category}}</a>
+            <p purpose="category-name" class="pb-2 mb-0">{{article.meta.category}}</p>
             <a purpose="article-title" :href="article.url"><h5>{{article.meta.articleTitle}}</h5></a>
             <div purpose="article-details" class="d-flex mt-auto flex-row align-items-center">
               <img alt="The author's GitHub profile picture" style="height: 32px; width: 32px; border-radius: 100%;" :src="'https://github.com/'+article.meta.authorGitHubUsername+'.png?size=200'">


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/7282
Changes:
- Updated the layout of article cards on category pages to make the category title non-clickable
- Updated the color of the text to match wireframes
