### PR TITLE
Update Community nav on layout.ejs

### DIFF
--- a/website/assets/styles/bootstrap-overrides.less
+++ b/website/assets/styles/bootstrap-overrides.less
@@ -201,7 +201,7 @@ a.text-danger:hover, a.text-danger:focus {
     opacity: 1;
     pointer-events: auto;
     z-index: 3;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
   .collapse {
     opacity: 0;

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -166,13 +166,14 @@
               <a purpose="mobile-dropdown-toggle" class="d-flex align-items-center mr-4 collapsed" data-toggle="collapse" data-target="#mobileNavbarToggleCommunity">Community</a>
               <div class="d-block">
                 <div id="mobileNavbarToggleCommunity" purpose="mobile-dropdown" class="collapse" data-parent="#mobileDropdowns">
-                  <a href="/slack" target="_blank">Chat</a>
-                  <a href="/podcasts">Podcasts</a>
-                  <a href="/reports/state-of-device-management">State of device management</a>
-                  <span>ARTICLES</span>
+                  <a href="/announcements">Announcements</a>
                   <a href="/securing">Security</a>
                   <a href="/engineering">Engineering</a>
-                  <a href="/announcements">Announcements</a>
+                  <a href="/podcasts">Podcasts</a>
+                  <a href="/reports/state-of-device-management">Reports</a>
+                  <span>RESOURCES</span>
+                  <a href="/slack" target="_blank">Join the conversation</a>
+                  <a href="/contribute">Contribute to Fleet</a>
                   <span>RESOURCES</span>
                   <a href="/handbook">Handbook</a>
                   <a href="/logos">Logos & artwork</a>
@@ -215,14 +216,15 @@
             <div purpose="dropdown-button" class="btn-group">
               <a class="dropdown-toggle d-flex align-items-center py-2 px-3" data-toggle="dropdown">Community</a>
               <div purpose="header-dropdown" class="dropdown-menu">
-                <a class="dropdown-item mb-1" href="/slack" target="_blank">Chat</a>
-                <a class="dropdown-item mb-1" href="/podcasts">Podcasts</a>
-                <a class="dropdown-item mb-1" href="/reports/state-of-device-management">State of device management</a>
-                <div class="dropdown-divider"></div>
-                <span class="muted dropdown-header">ARTICLES</span>
+                <a class="dropdown-item mb-1" href="/announcements">Announcements</a>
                 <a class="dropdown-item mb-1" href="/securing">Security</a>
                 <a class="dropdown-item mb-1" href="/engineering">Engineering</a>
-                <a class="dropdown-item mb-1" href="/announcements">Announcements</a>
+                <a class="dropdown-item mb-1" href="/podcasts">Podcasts</a>
+                <a class="dropdown-item mb-1" href="/reports/state-of-device-management">Reports</a>
+                <div class="dropdown-divider"></div>
+                <span class="muted dropdown-header">CONTRIBUTE</span>
+                <a class="dropdown-item mb-1" href="/slack" target="_blank">Join the conversation</a>
+                <a class="dropdown-item mb-1" href="/contribute">Contribute to Fleet</a>
                 <div class="dropdown-divider"></div>
                 <span class="muted dropdown-header">RESOURCES</span>
                 <a class="dropdown-item mb-1" href="/handbook">Handbook</a>


### PR DESCRIPTION
- Re-ordered articles based on a request from Mike M
- Added Contribute to Fleet based on a request from Mike M
- Renamed "Chat" to "Join the conversation" and moved it down the list order since it directs users away from the site.
    - We have little data about how effective Chat is or whether it is even helpful to visitors. We previously discussed removing entirely from the top nav, but I'd like to rename it before taking that action because I believe users may misunderstand "Chat" as an online chat with the team rather than the community Slack.
