### PR TITLE
Website: Update logo links on homepage

### DIFF
--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -18,18 +18,16 @@
         </div>
     </div>
     <div class="px-2" style="background-color: #192147;">
-      <a href="#community">
         <div purpose="hero-logos" style="max-width: 780px;" class="mx-auto d-flex flex-row align-items-center justify-content-center">
           <div purpose="logo-column" class="flex-md-row flex-column d-flex justify-content-between align-items-center">
-            <img purpose="snowflake-logo" class="ml-md-auto mb-4 mb-md-0" alt="snowflake logo" src="/images/logo-snowflake-white-151x30@2x.png">
-            <img purpose="wayfair-logo" alt="wayfair logo" src="/images/logo-wayfair-150x33@2x.png">
+            <a href="/guides/delivering-data-to-snowflake-from-fleet-and-osquery"><img purpose="snowflake-logo" class="ml-md-auto mb-4 mb-md-0" alt="snowflake logo" src="/images/logo-snowflake-white-151x30@2x.png"></a>
+            <a href="#community"><img purpose="wayfair-logo" alt="wayfair logo" src="/images/logo-wayfair-150x33@2x.png"></a>
           </div>
           <div purpose="logo-column" class="d-flex flex-md-row flex-column justify-content-between align-items-start align-items-md-center">
-            <img purpose="uber-logo" alt="Uber logo" class="mb-4 mb-md-0" src="/images/logo-uber-84x29@2x.png">
-            <img purpose="atlassian-logo" alt="Atlassian logo" class="mr-md-auto" src="/images/logo-atlassian-white-172x22@2x.png">
+            <a href="#community"><img purpose="uber-logo" alt="Uber logo" class="mb-4 mb-md-0" src="/images/logo-uber-84x29@2x.png"></a>
+            <a href="#community"><img purpose="atlassian-logo" alt="Atlassian logo" class="mr-md-auto" src="/images/logo-atlassian-white-172x22@2x.png"></a>
           </div>
         </div>
-      </a>
     </div>
   </div>
 


### PR DESCRIPTION
Changes:
- Changed the Snowflake logo to link to https://fleetdm.com/guides/delivering-data-to-snowflake-from-fleet-and-osquery