### PR TITLE
Mark just-in-time provisioning as delivered in pricing page

### DIFF
--- a/website/views/pages/pricing.ejs
+++ b/website/views/pages/pricing.ejs
@@ -683,7 +683,7 @@
                         src="/images/ellipse-6x6@2x.png"
                         style="width: 6px; height: 6px; margin-top: 09.6px"
                       />
-                      <p class="ml-2 my-0">Just-in-time provisioning*†</p>
+                      <p class="ml-2 my-0">Just-in-time provisioning†</p>
                     </div>
                     <div class="col-2"></div>
                     <div class="col-3">


### PR DESCRIPTION
Just in time user provisioning was delivered as part of 4.19.0. We can now remove the customer promise star from it in the pricing page.