### PR TITLE
increase the CI timeout to install Docker on macOS

### DIFF
--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -198,7 +198,7 @@ jobs:
     # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
     # FIXME: lock Docker version to 4.10.0 as newer versions fail to initialize
     - name: Install Docker
-      timeout-minutes: 10
+      timeout-minutes: 20
       if: matrix.os == 'macos-latest'
       run: |
         curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb

--- a/.github/workflows/fleetctl-preview-latest.yml
+++ b/.github/workflows/fleetctl-preview-latest.yml
@@ -37,7 +37,7 @@ jobs:
     # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
     # FIXME: lock Docker version to 4.10.0 as newer versions fail to initialize
     - name: Install Docker
-      timeout-minutes: 10
+      timeout-minutes: 20
       if: matrix.os == 'macos-latest'
       run: |
         curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb

--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -24,7 +24,7 @@ jobs:
     # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
     # FIXME: lock Docker version to 4.10.0 as newer versions fail to initialize
     - name: Install Docker
-      timeout-minutes: 10
+      timeout-minutes: 20
       if: contains(matrix.os, 'macos')
       run: |
         curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -34,7 +34,7 @@ jobs:
     # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
     # FIXME: lock Docker version to 4.10.0 as newer versions fail to initialize
     - name: Install Docker
-      timeout-minutes: 10
+      timeout-minutes: 20
       if: matrix.os == 'macos-latest'
       run: |
         curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb


### PR DESCRIPTION
in https://github.com/fleetdm/fleet/pull/7399 we reduced the timeout to 10 minutes, however there are multiple timing out and failing on `main` on the install docker step.
