### PR TITLE
E2e tests: Fix flakey button on teamflow

### DIFF
--- a/cypress/integration/premium/teamflow.spec.ts
+++ b/cypress/integration/premium/teamflow.spec.ts
@@ -14,7 +14,9 @@ describe("Teams flow (empty)", () => {
       cy.visit("/settings/teams");
     });
     it("creates a new team", () => {
-      cy.getAttached(".no-teams__create-button").click();
+      cy.getAttached(".no-teams").within(() => {
+        cy.contains("button", /create team/i).click();
+      });
       cy.findByLabelText(/team name/i)
         .click()
         .type("Valor");


### PR DESCRIPTION
- Follow pattern on selecting button on hosts.spec.ts that takes a few seconds to load

_hosts.spec.ts_
`      cy.getAttached(".manage-hosts").within(() => {
        cy.contains("button", /add hosts/i).click();
      });`

update to _teamflow.spec.ts_
`      cy.getAttached(".no-teams").within(() => {
        cy.contains("button", /create team/i).click();
      });`

Screenshots of flakey failing test on multiple PRs:
https://github.com/fleetdm/fleet/runs/8096678677?check_suite_focus=true
<img width="1237" alt="Screen Shot 2022-08-30 at 11 08 43 AM" src="https://user-images.githubusercontent.com/71795832/187512720-5684df29-fee6-40fb-99f3-27ceb0e7594f.png">
https://github.com/fleetdm/fleet/runs/8121766499?check_suite_focus=true
<img width="1414" alt="Screen Shot 2022-08-31 at 1 31 19 PM" src="https://user-images.githubusercontent.com/71795832/187776353-72df2f55-d89b-46ef-b730-64f274f8dc73.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
