### PR TITLE
add workflow to test for uncommited schema changes

### DIFF
--- a/.github/workflows/test-schema-changes.yml
+++ b/.github/workflows/test-schema-changes.yml
@@ -5,11 +5,11 @@ on:
     branches:
       - main
       - patch-*
-    pull_request:
-      paths:
-        - 'server/datastore/mysql/schema.sql'
-        - 'server/datastore/mysql/migrations/**.go'
-        - '.github/workflows/test-schema-changes.yml'
+  pull_request:
+    paths:
+      - 'server/datastore/mysql/schema.sql'
+      - 'server/datastore/mysql/migrations/**.go'
+      - '.github/workflows/test-schema-changes.yml'
   workflow_dispatch: # Manual
 
 permissions:

--- a/.github/workflows/test-schema-changes.yml
+++ b/.github/workflows/test-schema-changes.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Verify changes
       run: |
-        if [[ $(git diff .github/workflows/test-schema-changes.yml) ]]; then
+        if [[ $(git diff server/datastore/mysql/schema.sql) ]]; then
           echo "❌ fail: uncommited changes in schema.sql"
           echo "please run make dump-test-schema and commit the changes"
           exit 1

--- a/.github/workflows/test-schema-changes.yml
+++ b/.github/workflows/test-schema-changes.yml
@@ -26,6 +26,10 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
+    - name: Start Infra Dependencies
+      # Use & to background this
+      run: docker-compose up -d mysql_test &
+
     - name: Dump test schema
       run: make dump-test-schema
 

--- a/.github/workflows/test-schema-changes.yml
+++ b/.github/workflows/test-schema-changes.yml
@@ -1,0 +1,38 @@
+name: Schema Change Tests
+
+on:
+  push:
+    branches:
+      - main
+      - patch-*
+    pull_request:
+      paths:
+        - 'server/datastore/mysql/migrations/**.go'
+        - '.github/workflows/test-schema-changes.yml'
+  workflow_dispatch: # Manual
+
+permissions:
+  contents: read
+
+jobs:
+  test-schema-changes:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # v2
+      with:
+        go-version: '^1.17.8'
+    - name: Checkout Code
+      uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+
+    - name: Dump test schema
+      run: make dump-test-schema
+
+    - name: Verify changes
+      run: |
+        if [[ $(git diff .github/workflows/test-schema-changes.yml) ]]; then
+          echo "❌ fail: uncommited changes in schema.sql"
+          echo "please run make dump-test-schema and commit the changes"
+          exit 1
+        fi
+

--- a/.github/workflows/test-schema-changes.yml
+++ b/.github/workflows/test-schema-changes.yml
@@ -7,6 +7,7 @@ on:
       - patch-*
     pull_request:
       paths:
+        - 'server/datastore/mysql/schema.sql'
         - 'server/datastore/mysql/migrations/**.go'
         - '.github/workflows/test-schema-changes.yml'
   workflow_dispatch: # Manual

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE `activities` (
 CREATE TABLE `aggregated_stats` (
   `id` bigint(20) unsigned NOT NULL,
   `type` varchar(255) NOT NULL,
-  `json_value` json NULL,
+  `json_value` json NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`,`type`),

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE `activities` (
 CREATE TABLE `aggregated_stats` (
   `id` bigint(20) unsigned NOT NULL,
   `type` varchar(255) NOT NULL,
-  `json_value` json NOT NULL,
+  `json_value` json NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`,`type`),


### PR DESCRIPTION
This adds a new workflow to CI in order to test that the PR doesn't contain uncommited schema changes, which are the source of many merge conflicts and developer frustration.

- This is how a failed run looks like: https://github.com/fleetdm/fleet/runs/8102450312?check_suite_focus=true
- This is how a successful run looks like: https://github.com/fleetdm/fleet/runs/8102469150?check_suite_focus=true
