### PR TITLE
Website: try-fleet and homepage style fixes

### DIFF
--- a/website/assets/styles/pages/try-fleet/register.less
+++ b/website/assets/styles/pages/try-fleet/register.less
@@ -1,5 +1,4 @@
 #register {
-  padding-top: 120px;
   background-color: #FFF;
   p {
     font-size: 14px;

--- a/website/assets/styles/pages/try-fleet/sandbox-expired.less
+++ b/website/assets/styles/pages/try-fleet/sandbox-expired.less
@@ -1,6 +1,4 @@
 #sandbox-expired {
-
-  padding-top: 120px;
   background-color: #FFF;
   p {
     font-size: 14px;

--- a/website/assets/styles/pages/try-fleet/sandbox-login.less
+++ b/website/assets/styles/pages/try-fleet/sandbox-login.less
@@ -1,5 +1,4 @@
 #sandbox-login {
-  padding-top: 120px;
   background-color: #FFF;
   p {
     font-size: 14px;

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -166,7 +166,7 @@
     </div>
     <%// Try Fleet and Talk to an expert calls to action%>
     <div style="padding-top: 40px;" class="flex-sm-row d-flex flex-column justify-content-center align-items-center mx-auto">
-      <a purpose="round-button" href="/try-fleet/register?tryitnow" class="btn d-flex flex-row justify-content-center">Try Fleet</a>
+      <a purpose="round-button" href="/try-fleet/register?tryitnow" class="btn d-flex flex-row mr-4 justify-content-center">Try Fleet</a>
       <a purpose="animated-arrow-button-red" style="color: #192147;" href="https://calendly.com/fleetdm/demo?utm_source=homepage-demo-mid" target="_blank" class="btn">Talk to an expert</a>
     </div>
   </div>

--- a/website/views/pages/try-fleet/register.ejs
+++ b/website/views/pages/try-fleet/register.ejs
@@ -7,7 +7,7 @@
       <h2>Play in Fleet Sandbox</h2>
       <p>
         Fleet Sandbox is designed for testing Fleet features only.<br>
-        <a href="/docs/deploying">Click here</a> for production-ready deployments.
+        <a href="/deploy">Click here</a> for production-ready deployments.
       </p>
       <div class="pt-4">
         <ajax-form :handle-submitting="handleSubmittingRegisterForm" :syncing.sync="syncing" :cloud-error.sync="cloudError" :form-errors.sync="formErrors" :form-data="formData" :form-rules="formRules" @submitted="submittedRegisterForm()">

--- a/website/views/pages/try-fleet/sandbox-login.ejs
+++ b/website/views/pages/try-fleet/sandbox-login.ejs
@@ -7,7 +7,7 @@
       <h2>Play in Fleet Sandbox</h2>
       <p>
         Fleet Sandbox is designed for testing Fleet features only.<br>
-        <a href="/docs/deploying">Click here</a> for production-ready deployments.
+        <a href="/deploy">Click here</a> for production-ready deployments.
       </p>
       <div class="pt-4">
         <ajax-form action="login" :syncing.sync="syncing" :cloud-error.sync="cloudError" :form-errors.sync="formErrors" :form-data="formData" :form-rules="formRules" @submitted="submittedLoginForm()" >


### PR DESCRIPTION
I made the following changes:

- updated the "click here" link on /register and /sandbox-login to point to /deploy (our deployment guides) for a friendlier user experience.
- removed padding-top: 120px, which was forcing an awkward scroll to get to the form on register, sandbox-login, and sandbox-expired (I think the original intent was to center the form and graphic on the page vertically)
- I added some margin-right to space out the CTAs on the homepage
