### PR TITLE
set defaults for team spec configs related to features

### DIFF
--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -265,13 +265,13 @@ func (c *AppConfig) ApplyDefaultsForNewInstalls() {
 	agentOptions := json.RawMessage(`{"config": {"options": {"logger_plugin": "tls", "pack_delimiter": "/", "logger_tls_period": 10, "distributed_plugin": "tls", "disable_distributed": false, "logger_tls_endpoint": "/api/osquery/log", "distributed_interval": 10, "distributed_tls_max_attempts": 3}, "decorators": {"load": ["SELECT uuid AS host_uuid FROM system_info;", "SELECT hostname AS hostname FROM system_info;"]}}, "overrides": {}}`)
 	c.AgentOptions = &agentOptions
 
-	c.Features.EnableSoftwareInventory = true
+	c.Features.ApplyDefaultsForNewInstalls()
 
 	c.ApplyDefaults()
 }
 
 func (c *AppConfig) ApplyDefaults() {
-	c.Features.EnableHostUsers = true
+	c.Features.ApplyDefaults()
 	c.WebhookSettings.Interval.Duration = 24 * time.Hour
 }
 
@@ -337,6 +337,19 @@ type Features struct {
 	EnableHostUsers         bool             `json:"enable_host_users"`
 	EnableSoftwareInventory bool             `json:"enable_software_inventory"`
 	AdditionalQueries       *json.RawMessage `json:"additional_queries,omitempty"`
+}
+
+func (f *Features) ApplyDefaultsForNewInstalls() {
+	// Software inventory is enabled only for new inst
+	// we didn't want to enable software inventory from one version to the
+	// next in already running fleets, but we enable it by default for
+	// new installs.
+	f.EnableSoftwareInventory = true
+	f.ApplyDefaults()
+}
+
+func (f *Features) ApplyDefaults() {
+	f.EnableHostUsers = true
 }
 
 // FleetDesktopSettings contains settings used to configure Fleet Desktop.

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -340,10 +340,9 @@ type Features struct {
 }
 
 func (f *Features) ApplyDefaultsForNewInstalls() {
-	// Software inventory is enabled only for new inst
+	// Software inventory is enabled only for new installs as
 	// we didn't want to enable software inventory from one version to the
-	// next in already running fleets, but we enable it by default for
-	// new installs.
+	// next in already running fleets
 	f.EnableSoftwareInventory = true
 	f.ApplyDefaults()
 }

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -253,5 +253,5 @@ type TeamSpec struct {
 	Name         string           `json:"name"`
 	AgentOptions *json.RawMessage `json:"agent_options"`
 	Secrets      []EnrollSecret   `json:"secrets"`
-	Features     *Features        `json:"features"`
+	Features     *json.RawMessage `json:"features"`
 }

--- a/server/service/teams_test.go
+++ b/server/service/teams_test.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -9,6 +11,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTeamAuth(t *testing.T) {
@@ -177,4 +180,178 @@ func TestTeamAuth(t *testing.T) {
 			checkAuthErr(t, tt.shouldFailTeamWrite, err)
 		})
 	}
+}
+
+func TestApplyTeamSpecs(t *testing.T) {
+	ds := new(mock.Store)
+	license := &fleet.LicenseInfo{Tier: fleet.TierPremium, Expiration: time.Now().Add(24 * time.Hour)}
+	svc := newTestService(t, ds, nil, nil, &TestServerOpts{License: license, SkipCreateTestUsers: true})
+	user := &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}
+	ctx := viewer.NewContext(context.Background(), viewer.Viewer{User: user})
+	baseFeatures := fleet.Features{
+		EnableHostUsers:         true,
+		EnableSoftwareInventory: true,
+		AdditionalQueries:       ptr.RawMessage(json.RawMessage(`{"foo": "bar"}`)),
+	}
+
+	mkspec := func(s string) *json.RawMessage {
+		return ptr.RawMessage(json.RawMessage(s))
+	}
+
+	t.Run("Features for new teams", func(t *testing.T) {
+		cases := []struct {
+			name   string
+			spec   *json.RawMessage
+			global fleet.Features
+			result fleet.Features
+		}{
+			{
+				name:   "no spec features uses global config as defaults",
+				spec:   nil,
+				global: baseFeatures,
+				result: baseFeatures,
+			},
+			{
+				name:   "missing spec features uses new config default values",
+				spec:   mkspec(`{"enable_software_inventory": false}`),
+				global: baseFeatures,
+				result: fleet.Features{
+					EnableHostUsers:         true,
+					EnableSoftwareInventory: false,
+					AdditionalQueries:       nil,
+				},
+			},
+			{
+				name:   "defaults can be overwritten",
+				spec:   mkspec(`{"enable_host_users": false}`),
+				global: baseFeatures,
+				result: fleet.Features{
+					EnableHostUsers:         false,
+					EnableSoftwareInventory: true,
+					AdditionalQueries:       nil,
+				},
+			},
+			{
+				name: "all config can be changed",
+				spec: mkspec(`{
+          "enable_host_users": false,
+          "enable_software_inventory": false,
+          "additional_queries": {"example": "query"}
+        }`),
+				global: baseFeatures,
+				result: fleet.Features{
+					EnableHostUsers:         false,
+					EnableSoftwareInventory: false,
+					AdditionalQueries:       ptr.RawMessage([]byte(`{"example": "query"}`)),
+				},
+			},
+		}
+
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+					return nil, sql.ErrNoRows
+				}
+
+				ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+					return &fleet.AppConfig{Features: tt.global}, nil
+				}
+
+				ds.NewTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+					require.Equal(t, "team1", team.Name)
+					require.Equal(t, tt.result, team.Config.Features)
+					team.ID = 1
+					return team, nil
+				}
+
+				ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activityType string, details *map[string]interface{}) error {
+					require.Len(t, (*details)["teams"], 1)
+					return nil
+				}
+
+				err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{{Name: "team1", Features: tt.spec}})
+				require.NoError(t, err)
+			})
+		}
+	})
+
+	t.Run("Features for existing teams", func(t *testing.T) {
+		cases := []struct {
+			name   string
+			spec   *json.RawMessage
+			old    fleet.Features
+			result fleet.Features
+		}{
+			{
+				name:   "no spec features uses old config",
+				spec:   nil,
+				old:    baseFeatures,
+				result: baseFeatures,
+			},
+			{
+				name: "missing spec features uses new config default values",
+				spec: mkspec(`{"enable_software_inventory": false}`),
+				old:  baseFeatures,
+				result: fleet.Features{
+					EnableHostUsers:         true,
+					EnableSoftwareInventory: false,
+					AdditionalQueries:       nil,
+				},
+			},
+			{
+				name: "config has defaults based on what are the global defaults",
+				spec: mkspec(`{"additional_queries": {}}`),
+				old:  baseFeatures,
+				result: fleet.Features{
+					EnableHostUsers:         true,
+					EnableSoftwareInventory: true,
+					AdditionalQueries:       nil,
+				},
+			},
+			{
+				name: "defaults can be overwritten",
+				spec: mkspec(`{"enable_host_users": false}`),
+				old:  baseFeatures,
+				result: fleet.Features{
+					EnableHostUsers:         false,
+					EnableSoftwareInventory: false,
+					AdditionalQueries:       nil,
+				},
+			},
+			{
+				name: "all config can be changed",
+				spec: mkspec(`{
+          "enable_host_users": false,
+          "enable_software_inventory": true,
+          "additional_queries": {"example": "query"}
+        }`),
+				old: baseFeatures,
+				result: fleet.Features{
+					EnableHostUsers:         false,
+					EnableSoftwareInventory: true,
+					AdditionalQueries:       ptr.RawMessage([]byte(`{"example": "query"}`)),
+				},
+			},
+		}
+
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+					return &fleet.Team{Config: fleet.TeamConfig{Features: tt.old}}, nil
+				}
+
+				ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+					return &fleet.Team{}, nil
+				}
+
+				ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activityType string, details *map[string]interface{}) error {
+					require.Len(t, (*details)["teams"], 1)
+					return nil
+				}
+
+				err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{{Name: "team1", Features: tt.spec}})
+				require.NoError(t, err)
+			})
+		}
+	})
 }


### PR DESCRIPTION
This adjusts functions related to applying team specs to make sure the `features` key works as expected, this is:

1. **Create Team flow**
    1. if no features are provided, we copy whatever features are set in the global config
    2. otherwise, we generate a new config merging whatever is provided with the defaults for new installs.
2. **Edit Team flow**: we always generate a new config merging whatever is provided with the defaults for new installs.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
