### PR TITLE
Add fleetctl endpoints to FAQ

### DIFF
--- a/docs/Getting-started/FAQ.md
+++ b/docs/Getting-started/FAQ.md
@@ -593,6 +593,14 @@ Check out the [documentation on running database migrations](../Deploying/Upgrad
 
 If you would like to manage hosts that can travel outside your VPN or intranet we recommend only exposing the "/api/v1/osquery" endpoint to the public internet.
 
+If you would like to use the Fleet CLI from outside of your network, the following endpoints will also need to be exposed for `fleetctl`:
+
+- /api/setup
+- /api/v1/setup
+- /api/osquery/*
+- /api/latest/fleet/*
+- /api/v1/fleet/*
+
 ### What is the minimum version of MySQL required by Fleet?
 
 Fleet requires at least MySQL version 5.7.


### PR DESCRIPTION
Added the endpoints that are used by `fleetctl` to the FAQ entry for "What API endpoints should I expose to the public internet?"