### PR TITLE
Tentative dependabot config with assignees

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,16 +22,16 @@ updates:
     schedule:
       interval: "daily"
     reviewers:
-      - "@fleetdm/go"
-      - "@fleetdm/infra"
+      - "fleetdm/go"
+      - "fleetdm/infra"
     pull-request-branch-name:
       # Default is "/" which makes "docker tag" fail with
       # "not a valid repository/tag: invalid reference format".
       separator: "-"
     # Add assignees
     assignees:
-      - "@fleetdm/go"
-      - "@fleetdm/infra"
+      - "fleetdm/go"
+      - "fleetdm/infra"
 
 # Maintain dependencies for website NPM
   - package-ecosystem: "npm"
@@ -41,11 +41,13 @@ updates:
     schedule:
       interval: "daily"
     reviewers:
-      - "@eashaw"
+      - "eashaw"
     pull-request-branch-name:
       # Default is "/" which makes "docker tag" fail with
       # "not a valid repository/tag: invalid reference format".
       separator: "-"
+    assignees:
+      - "eashaw"
 
 # Maintain dependencies for Go
   - package-ecosystem: "gomod"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
       # Default is "/" which makes "docker tag" fail with
       # "not a valid repository/tag: invalid reference format".
       separator: "-"
+    # Add assignees
+    assignees:
+      - "zwass"
+
 # Maintain dependencies for Dockerfiles
   - package-ecosystem: "docker"
     directory: "/"
@@ -24,3 +28,53 @@ updates:
       # Default is "/" which makes "docker tag" fail with
       # "not a valid repository/tag: invalid reference format".
       separator: "-"
+    # Add assignees
+    assignees:
+      - "@fleetdm/go"
+      - "@fleetdm/infra"
+
+# Maintain dependencies for website NPM
+  - package-ecosystem: "npm"
+    directory: "/website"
+    labels:
+      - "website"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "@eashaw"
+    pull-request-branch-name:
+      # Default is "/" which makes "docker tag" fail with
+      # "not a valid repository/tag: invalid reference format".
+      separator: "-"
+
+# Maintain dependencies for Go
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "fleetdm/go"
+    pull-request-branch-name:
+      # Default is "/" which makes "docker tag" fail with
+      # "not a valid repository/tag: invalid reference format".
+      separator: "-"
+    # Add assignees
+    assignees:
+      - "fleetdm/go"
+      - lucasmrod
+
+# Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "fleetdm/frontend"
+    pull-request-branch-name:
+      # Default is "/" which makes "docker tag" fail with
+      # "not a valid repository/tag: invalid reference format".
+      separator: "-"
+    # Add assignees
+    assignees:
+      - "fleetdm/frontend"
+      - lukeheath


### PR DESCRIPTION
I am not 100% sure the npm thing for / and /website separately will work as intended but this should already make things more precise. Unfortunately the dependabot validator has disappeared from GitHub.