### PR TITLE
Fleet UI: Fix welcome to fleet button styling

### DIFF
--- a/changes/issue-7305-spiffier-welcome-to-fleet-card
+++ b/changes/issue-7305-spiffier-welcome-to-fleet-card
@@ -1,0 +1,1 @@
+* Clean up CSS for Welcome to Fleet card

--- a/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
@@ -31,8 +31,8 @@ interface IWelcomeHostCardProps {
 
 const baseClass = "welcome-host";
 const HOST_ID = 1;
-const policyPass = "pass";
-const policyFail = "fail";
+const POLICY_PASS = "pass";
+const POLICY_FAIL = "fail";
 
 const WelcomeHost = ({
   totalsHostsCount,
@@ -62,7 +62,7 @@ const WelcomeHost = ({
         setShowRefetchLoadingSpinner(returnedHost.refetch_requested);
 
         const anyPassingOrFailingPolicy = returnedHost?.policies?.find(
-          (p) => p.response === policyPass || p.response === policyFail
+          (p) => p.response === POLICY_PASS || p.response === POLICY_FAIL
         );
         setIsPoliciesEmpty(typeof anyPassingOrFailingPolicy === "undefined");
 
@@ -252,7 +252,7 @@ const WelcomeHost = ({
                   <div className="policy-block">
                     <img
                       alt={p.response}
-                      src={p.response === policyPass ? IconPassed : IconError}
+                      src={p.response === POLICY_PASS ? IconPassed : IconError}
                     />
                     <span className="info">{p.name}</span>
                   </div>

--- a/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
@@ -246,18 +246,15 @@ const WelcomeHost = ({
             if (p.response) {
               return (
                 <Button
-                  variant="text-icon"
+                  variant="unstyled"
                   onClick={() => handlePolicyModal(p.id)}
                 >
                   <div className="policy-block">
-                    <div className="info">
-                      <img
-                        alt={p.response}
-                        src={p.response === policyPass ? IconPassed : IconError}
-                      />
-                      {p.name}
-                    </div>
-                    <img alt="" src={IconChevron} />
+                    <img
+                      alt={p.response}
+                      src={p.response === policyPass ? IconPassed : IconError}
+                    />
+                    <span className="info">{p.name}</span>
                   </div>
                 </Button>
               );

--- a/frontend/pages/Homepage/cards/WelcomeHost/_styles.scss
+++ b/frontend/pages/Homepage/cards/WelcomeHost/_styles.scss
@@ -106,10 +106,6 @@
         border-radius: 0px;
         margin: 0 $pad-xsmall;
       }
-
-      .chevron {
-        margin-left: auto;
-      }
     }
   }
   &__loading {

--- a/frontend/pages/Homepage/cards/WelcomeHost/_styles.scss
+++ b/frontend/pages/Homepage/cards/WelcomeHost/_styles.scss
@@ -71,27 +71,44 @@
       }
     }
 
-    .policy-block {
+    .children-wrapper {
       width: 100%;
-      padding: $pad-small 12px;
+    }
+
+    .policy-block {
+      min-width: 100%;
       border: 1px solid $ui-fleet-black-25;
       border-radius: 6px;
       display: flex;
       justify-content: space-between;
       align-items: center;
+      font-weight: $regular;
+
+      img {
+        margin: 0 $pad-small;
+        transform: scale(0.5);
+        position: relative;
+        top: -1px;
+      }
 
       .info {
-        font-size: $small;
-        display: flex;
-        align-items: center;
         line-height: 1;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        flex: 1;
+        text-align: left;
+      }
 
-        img {
-          margin-right: $pad-small;
-          transform: scale(0.5);
-          position: relative;
-          top: -1px;
-        }
+      &::after {
+        content: url("../assets/images/icon-chevron-purple-9x6@2x.png");
+        transform: scale(0.5) rotate(-90deg);
+        border-radius: 0px;
+        margin: 0 $pad-xsmall;
+      }
+
+      .chevron {
+        margin-left: auto;
       }
     }
   }


### PR DESCRIPTION
Cerra #7305

**FIX**
- Font color is black
- Policy name is truncated if larger than button width
- Height 36px


**Screenshots** Chrome, Firefox, Safari
<img width="601" alt="Screen Shot 2022-09-01 at 5 41 48 PM" src="https://user-images.githubusercontent.com/71795832/188018458-af5c5bc9-d9ad-4ff9-a947-265b4e3fdb46.png">
<img width="627" alt="Screen Shot 2022-09-01 at 5 41 38 PM" src="https://user-images.githubusercontent.com/71795832/188018464-deda5a58-9957-458c-a4bb-78cd8023d24a.png">
<img width="584" alt="Screen Shot 2022-09-01 at 5 41 02 PM" src="https://user-images.githubusercontent.com/71795832/188018466-f5facacf-6a72-4f26-a69f-09a44aa026a0.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
