### PR TITLE
Docs: fleetctl CLI typo

### DIFF
--- a/docs/Getting-started/FAQ.md
+++ b/docs/Getting-started/FAQ.md
@@ -593,7 +593,7 @@ Check out the [documentation on running database migrations](../Deploying/Upgrad
 
 If you would like to manage hosts that can travel outside your VPN or intranet we recommend only exposing the "/api/v1/osquery" endpoint to the public internet.
 
-If you would like to use the Fleet CLI from outside of your network, the following endpoints will also need to be exposed for `fleetctl`:
+If you would like to use the fleetctl CLI from outside of your network, the following endpoints will also need to be exposed for `fleetctl`:
 
 - /api/setup
 - /api/v1/setup


### PR DESCRIPTION
Changed "Fleet CLI" to "fleetctl CLI" for consistency.
