### PR TITLE
Update Vulnerability processing docs

### DIFF
--- a/docs/Using-Fleet/Vulnerability-Processing.md
+++ b/docs/Using-Fleet/Vulnerability-Processing.md
@@ -7,15 +7,19 @@
 
 ## What to expect
 
-Vulnerability processing is enabled by default for new installations.
+Vulnerability processing in Fleet detects vulnerable software installed on your hosts. To see what software vulnerability processing covers, check out the [Coverage section on this page}(#coverage).
 
 <div purpose="embedded-content">
    <iframe src="https://www.youtube.com/embed/amJFecMWyvI" allowfullscreen></iframe>
 </div>
 
-Fleet strategy for vulnerability detection varies according to the host's platform. For Windows/macOS, 
-vulnerabilities are checked using the National Vulnerability Database (NVD), for Linux
-we use the official OVAL definitions maintained by the different publishers (Canonical, Red Hat etc.).
+Vulnerable software can have one or more vulnerabilities (CVEs).
+
+For Fleet Premium users, each CVE includes its CVSS base score (reported by the [National Vulnerability Database](https://nvd.nist.gov/)), probability of exploit (reported by [FIRST](https://www.first.org/epss/)), and whether or not their is a known exploit in the wild (reported by the [Cybersecurity & Infrastructure Security Agency](https://www.cisa.gov/known-exploited-vulnerabilities-catalog)).
+
+Fleet's strategy for detecting vulnerabilities (CVEs) varies according to the host's platform. For macOS and Windows hosts, 
+CVEs are detected using the National Vulnerability Database (NVD). For Linux hosts,
+CVEs are detected using the official OVAL definitions maintained by the different publishers (Canonical, Red Hat etc.).
 
 ### Windows/MacOS hosts
 


### PR DESCRIPTION
Doc updates for the "Add ability to prioritize vulnerable software" issue: #4512 

- Remove note about vulnerability processing being enabled by default. This message is outdated
- Update first sentence to be explicit that "Vulnerability processing" in Fleet detects vulnerable software
- Add sentence about vulnerability date for Fleet Premium (CVSS, EPSS, CISA).
