### PR TITLE
Set dependabot to check npm production dependencies only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,8 @@ updates:
       - "website"
     schedule:
       interval: "daily"
+    allow:
+      - dependency-type: "production"
     reviewers:
       - "eashaw"
     pull-request-branch-name:
@@ -71,6 +73,8 @@ updates:
       interval: "daily"
     reviewers:
       - lukeheath
+    allow:
+      - dependency-type: "production"
     pull-request-branch-name:
       # Default is "/" which makes "docker tag" fail with
       # "not a valid repository/tag: invalid reference format".


### PR DESCRIPTION
Currently configured to check all dependencies, which is spamming us with PRs for development dependencies that are not used in production, which leads to ignoring the PRs. This change uses the [allow option](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow) to allow PRs for npm production dependencies only. 