### PR TITLE
Fix double scroll bar from tooltip rendering off page

### DIFF
--- a/changes/issue-7527-fix-scroll-bug
+++ b/changes/issue-7527-fix-scroll-bug
@@ -1,0 +1,1 @@
+* Add padding to accomodate tooltip at bottom of page causing double scroll bar 

--- a/frontend/components/buttons/RevealButton/_styles.scss
+++ b/frontend/components/buttons/RevealButton/_styles.scss
@@ -1,5 +1,5 @@
 .reveal {
-  margin: $pad-medium 0 0 0;
+  margin: $pad-medium 0 $pad-large;
   color: $core-vibrant-blue;
   font-weight: $bold;
   font-size: $x-small;


### PR DESCRIPTION
Cerra #7527 

**FIX**
- Fix double scrollbar by accommodating tooltip space at bottom of the page

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
