### PR TITLE
Non released bug: Fix online, offline, new dropdown

### DIFF
--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -59,6 +59,37 @@ const labelSlug = (label: ILabel): string => {
   return `labels/${id}`;
 };
 
+const labelStubs = [
+  {
+    id: "new",
+    count: 0,
+    description: "Hosts that have been enrolled to Fleet in the last 24 hours.",
+    display_text: "New",
+    slug: "new",
+    statusLabelKey: "new_count",
+    title_description: "(added in last 24hrs)",
+    type: "status",
+  },
+  {
+    id: "online",
+    count: 0,
+    description: "Hosts that have recently checked-in to Fleet.",
+    display_text: "Online",
+    slug: "online",
+    statusLabelKey: "online_count",
+    type: "status",
+  },
+  {
+    id: "offline",
+    count: 0,
+    description: "Hosts that have not checked-in to Fleet recently.",
+    display_text: "Offline",
+    slug: "offline",
+    statusLabelKey: "offline_count",
+    type: "status",
+  },
+];
+
 const isLabel = (target: ISelectTargetsEntity) => {
   return "label_type" in target;
 };
@@ -219,7 +250,7 @@ const formatLabelResponse = (response: any): ILabel[] => {
     };
   });
 
-  return labels;
+  return labels.concat(labelStubs);
 };
 
 export const formatSelectedTargetsForApi = (


### PR DESCRIPTION
Cerra #7552 

- Revert online, offline, new dropdown label stubs


**Screenshots**
<img width="1292" alt="Screen Shot 2022-09-02 at 3 45 25 PM" src="https://user-images.githubusercontent.com/71795832/188226050-466a7c99-3603-420b-920d-7f739b0dcaad.png">
<img width="1299" alt="Screen Shot 2022-09-02 at 3 45 19 PM" src="https://user-images.githubusercontent.com/71795832/188226051-a15e8ef3-7c03-4245-a08b-c5b81e06c872.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

~~- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).~~
- Not released so no changefile
- [x] Manual QA for all new/changed functionality
