### PR TITLE
server_side_encryption_configuration argument is deprecated

### DIFF
--- a/infrastructure/loadtesting/terraform/firehose.tf
+++ b/infrastructure/loadtesting/terraform/firehose.tf
@@ -8,17 +8,19 @@ resource "aws_s3_bucket" "osquery-results" { #tfsec:ignore:aws-s3-encryption-cus
       days = 1
     }
   }
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "aws:kms"
-      }
-    }
-  }
   #checkov:skip=CKV_AWS_18:dev env
   #checkov:skip=CKV_AWS_144:dev env
   #checkov:skip=CKV_AWS_21:dev env
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "osquery-results" {
+  bucket = aws_s3_bucket.osquery-results.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+    }
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "osquery-results" {


### PR DESCRIPTION
For an s3 bucket, the argument `server_side_encryption_configuration` is deprecated. See more at https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#enable-default-server-side-encryption

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
