### PR TITLE
fix conditional clauses to run workflows

### DIFF
--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -199,7 +199,6 @@ jobs:
     # FIXME: lock Docker version to 4.10.0 as newer versions fail to initialize
     - name: Install Docker
       timeout-minutes: 20
-      if: matrix.os == 'macos-latest'
       run: |
         curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb
         brew install --cask docker.rb

--- a/.github/workflows/fleetctl-preview-latest.yml
+++ b/.github/workflows/fleetctl-preview-latest.yml
@@ -46,7 +46,7 @@ jobs:
     # FIXME: lock Docker version to 4.10.0 as newer versions fail to initialize
     - name: Install Docker
       timeout-minutes: 20
-      if: matrix.os == 'macos-latest'
+      if: contains(matrix.os, 'macos')
       run: |
         curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb
         brew install --cask docker.rb


### PR DESCRIPTION
In https://github.com/fleetdm/fleet/pull/7399 we accidentally:

1. added a condition to `.github/workflows/fleet-and-orbit.yml`  that always evaluates to `false` making this workflow always fail
2. modified the condition of `.github/workflows/fleetctl-preview-latest.yml` 

This reverts those changes.