### PR TITLE
Fleet UI: Bug fix user page pagination

### DIFF
--- a/changes/issue-7582-user-pagination-bug
+++ b/changes/issue-7582-user-pagination-bug
@@ -1,0 +1,1 @@
+* Fleet UI to use Client side pagination which fixes bug hiding users over 20 users

--- a/frontend/services/entities/invites.ts
+++ b/frontend/services/entities/invites.ts
@@ -40,17 +40,8 @@ export default {
 
     return sendRequest("DELETE", path);
   },
-  loadAll: ({
-    page = 0,
-    perPage = 20,
-    globalFilter = "",
-    sortBy = [],
-  }: IInviteSearchOptions) => {
+  loadAll: ({ globalFilter = "", sortBy = [] }: IInviteSearchOptions) => {
     const { INVITES } = endpoints;
-
-    // NOTE: this code is duplicated from /entities/users.js
-    // we should pull this out into shared utility at some point.
-    const pagination = `page=${page}&per_page=${perPage}`;
 
     let orderKeyParam = "";
     let orderDirection = "";
@@ -64,10 +55,10 @@ export default {
 
     let searchQuery = "";
     if (globalFilter !== "") {
-      searchQuery = `&query=${globalFilter}`;
+      searchQuery = `query=${globalFilter}`;
     }
 
-    const path = `${INVITES}?${pagination}${searchQuery}${orderKeyParam}${orderDirection}`;
+    const path = `${INVITES}?${searchQuery}${orderKeyParam}${orderDirection}`;
 
     return sendRequest("GET", path).then((response) => {
       const { invites } = response;

--- a/frontend/services/entities/invites.ts
+++ b/frontend/services/entities/invites.ts
@@ -2,6 +2,8 @@
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
 import helpers from "utilities/helpers";
+import { buildQueryStringFromParams } from "utilities/url";
+
 import {
   IInvite,
   ICreateInviteFormData,
@@ -40,25 +42,14 @@ export default {
 
     return sendRequest("DELETE", path);
   },
-  loadAll: ({ globalFilter = "", sortBy = [] }: IInviteSearchOptions) => {
-    const { INVITES } = endpoints;
+  loadAll: ({ globalFilter = "" }: IInviteSearchOptions) => {
+    const queryParams = {
+      query: globalFilter,
+    };
 
-    let orderKeyParam = "";
-    let orderDirection = "";
-    if (sortBy.length !== 0) {
-      const sortItem = sortBy[0];
-      orderKeyParam += `&order_key=${sortItem.id}`;
-      orderDirection = sortItem.desc
-        ? "&order_direction=desc"
-        : "&order_direction=asc";
-    }
-
-    let searchQuery = "";
-    if (globalFilter !== "") {
-      searchQuery = `query=${globalFilter}`;
-    }
-
-    const path = `${INVITES}?${searchQuery}${orderKeyParam}${orderDirection}`;
+    const queryString = buildQueryStringFromParams(queryParams);
+    const endpoint = endpoints.INVITES;
+    const path = `${endpoint}?${queryString}`;
 
     return sendRequest("GET", path).then((response) => {
       const { invites } = response;

--- a/frontend/services/entities/users.ts
+++ b/frontend/services/entities/users.ts
@@ -2,6 +2,8 @@
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
 import helpers from "utilities/helpers";
+import { buildQueryStringFromParams } from "utilities/url";
+
 import {
   ICreateUserFormData,
   IUpdateUserFormData,
@@ -92,34 +94,15 @@ export default {
 
     return sendRequest("POST", FORGOT_PASSWORD, { email });
   },
-  loadAll: ({
-    globalFilter = "",
-    sortBy = [],
-    teamId,
-  }: IUserSearchOptions = {}) => {
-    const { USERS } = endpoints;
+  loadAll: ({ globalFilter = "", teamId }: IUserSearchOptions = {}) => {
+    const queryParams = {
+      query: globalFilter,
+      team_id: teamId,
+    };
 
-    let orderKeyParam = "";
-    let orderDirection = "";
-    if (sortBy.length !== 0) {
-      const sortItem = sortBy[0];
-      orderKeyParam += `&order_key=${sortItem.id}`;
-      orderDirection = sortItem.desc
-        ? "&order_direction=desc"
-        : "&order_direction=asc";
-    }
-
-    let searchQuery = "";
-    if (globalFilter !== "") {
-      searchQuery = `&query=${globalFilter}`;
-    }
-
-    let teamQuery = "";
-    if (teamId !== undefined) {
-      teamQuery = `&team_id=${teamId}`;
-    }
-
-    const path = `${USERS}?${searchQuery}${orderKeyParam}${orderDirection}${teamQuery}`;
+    const queryString = buildQueryStringFromParams(queryParams);
+    const endpoint = endpoints.USERS;
+    const path = `${endpoint}?${queryString}`;
 
     return sendRequest("GET", path).then((response) => {
       const { users } = response;

--- a/frontend/services/entities/users.ts
+++ b/frontend/services/entities/users.ts
@@ -93,16 +93,11 @@ export default {
     return sendRequest("POST", FORGOT_PASSWORD, { email });
   },
   loadAll: ({
-    page = 0,
-    perPage = 20,
     globalFilter = "",
     sortBy = [],
     teamId,
   }: IUserSearchOptions = {}) => {
     const { USERS } = endpoints;
-
-    // TODO: add this query param logic to client class
-    const pagination = `page=${page}&per_page=${perPage}`;
 
     let orderKeyParam = "";
     let orderDirection = "";
@@ -124,7 +119,7 @@ export default {
       teamQuery = `&team_id=${teamId}`;
     }
 
-    const path = `${USERS}?${pagination}${searchQuery}${orderKeyParam}${orderDirection}${teamQuery}`;
+    const path = `${USERS}?${searchQuery}${orderKeyParam}${orderDirection}${teamQuery}`;
 
     return sendRequest("GET", path).then((response) => {
       const { users } = response;


### PR DESCRIPTION
Cerra #7582 

Users and invites get merged into one table, then is paginated client side

- (Bug fix) Remove server side pagination for both tables as it is hiding any users or invites past the pagination
- Remove server side sort for both tables as the table is client side sorting
- Refactor using buildQueryStringFromParams 

QA
I QAed search, pagination, creation

<img width="1345" alt="Screen Shot 2022-09-06 at 10 54 18 AM" src="https://user-images.githubusercontent.com/71795832/188667642-0b59f1d5-5d1f-43e7-93ff-4894f610a176.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
