### PR TITLE
Add isSoftwareEnabled dependency to rerender count

### DIFF
--- a/changes/issue-7585-fix-flakey-software-count
+++ b/changes/issue-7585-fix-flakey-software-count
@@ -1,0 +1,1 @@
+* Fix flakey software count

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -399,7 +399,13 @@ const ManageSoftwarePage = ({
     }
 
     return null;
-  }, [isFetchingCount, software, softwareCountError, softwareCount]);
+  }, [
+    isFetchingCount,
+    software,
+    softwareCountError,
+    softwareCount,
+    isSoftwareEnabled,
+  ]);
 
   // TODO: retool this with react-router location descriptor objects
   const buildUrlQueryString = (queryString: string, vulnerable: boolean) => {


### PR DESCRIPTION
Cerra #7585 

- Fix flakey software count by fixing race between config API (to retrieve if software is enabled) and software API 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
