### PR TITLE
Fleet UI: Fix add host button disappearing

### DIFF
--- a/changes/issue-7268-add-host-button-bug
+++ b/changes/issue-7268-add-host-button-bug
@@ -1,0 +1,1 @@
+- Add host button still shown when search returns 0 hosts, noly hides when 0 hosts and empty state with add host button is shown

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1871,7 +1871,8 @@ const ManageHostsPage = ({
                 ) &&
                 !(
                   getStatusSelected() === ALL_HOSTS_LABEL &&
-                  filteredHostCount === 0
+                  filteredHostCount === 0 &&
+                  searchQuery === ""
                 ) && (
                   <Button
                     onClick={toggleAddHostsModal}


### PR DESCRIPTION
Cerra #7268 

**FIX**
- Add host button only disappears if there are 0 hosts as an initial empty state, not if it's filtered by search query and has 0 hosts

<img width="1347" alt="Screen Shot 2022-09-06 at 3 48 25 PM" src="https://user-images.githubusercontent.com/71795832/188725853-82e29074-5416-4dc0-8da1-3f5fc6148573.png">
<img width="1347" alt="Screen Shot 2022-09-06 at 3 48 14 PM" src="https://user-images.githubusercontent.com/71795832/188725858-8ce572c2-8c4a-495e-a919-888a5b07df01.png">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
