### PR TITLE
Update preview payload modal

### DIFF
--- a/changes/issue-7602-software-automations-payload-example
+++ b/changes/issue-7602-software-automations-payload-example
@@ -1,0 +1,1 @@
+* Fleet Free and Fleet Premium UI show different software automation payload example 

--- a/frontend/interfaces/vulnerability.ts
+++ b/frontend/interfaces/vulnerability.ts
@@ -5,10 +5,16 @@ export default PropTypes.shape({
   details_link: PropTypes.string,
 });
 
+export interface IHostsAffected {
+  id: number;
+  hostname: string;
+  url: string;
+}
 export interface IVulnerability {
-  cisa_known_exploit: string | null;
+  cisa_known_exploit?: boolean;
   cve: string;
-  cvss_score: string | null;
+  cvss_score?: number;
   details_link: string;
-  epss_probability: number | null;
+  epss_probability?: number;
+  hosts_affected?: IHostsAffected[];
 }

--- a/frontend/pages/software/ManageSoftwarePage/components/PreviewPayloadModal/PreviewPayloadModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/PreviewPayloadModal/PreviewPayloadModal.tsx
@@ -22,7 +22,7 @@ const PreviewPayloadModal = ({
 }: IPreviewPayloadModalProps): JSX.Element => {
   const { isFreeTier } = useContext(AppContext);
 
-  let json: IJsonPayload = {
+  const json: IJsonPayload = {
     timestamp: "0000-00-00T00:00:00Z",
     vulnerability: {
       cve: "CVE-2014-9471",

--- a/frontend/pages/software/ManageSoftwarePage/components/PreviewPayloadModal/PreviewPayloadModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/PreviewPayloadModal/PreviewPayloadModal.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useContext } from "react";
 import { syntaxHighlight } from "utilities/helpers";
 
+import { AppContext } from "context/app";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 import ExternalLinkIcon from "../../../../../../assets/images/icon-external-link-12x12@2x.png";
@@ -11,17 +12,36 @@ interface IPreviewPayloadModalProps {
   onCancel: () => void;
 }
 
+interface IHostsAffectedProps {
+  id: number;
+  hostname: string;
+  url: string;
+}
+interface IJsonPayload {
+  timestamp: string;
+  vulnerability: {
+    cve: string;
+    details_link: string;
+    epss_probability?: number;
+    cvss_score?: number;
+    cisa_known_exploit?: boolean;
+    hosts_affected: IHostsAffectedProps[];
+  };
+}
+
 const PreviewPayloadModal = ({
   onCancel,
 }: IPreviewPayloadModalProps): JSX.Element => {
-  const json = {
+  const { isFreeTier } = useContext(AppContext);
+
+  let json: IJsonPayload = {
     timestamp: "0000-00-00T00:00:00Z",
     vulnerability: {
       cve: "CVE-2014-9471",
       details_link: "https://nvd.nist.gov/vuln/detail/CVE-2014-9471",
-      epss_probability: 0.7, // Premium feature only
-      cvss_score: 5.7, // Premium feature only
-      cisa_known_exploit: true, // Premium feature only
+      epss_probability: 0.7,
+      cvss_score: 5.7,
+      cisa_known_exploit: true,
       hosts_affected: [
         {
           id: 1,
@@ -36,6 +56,13 @@ const PreviewPayloadModal = ({
       ],
     },
   };
+
+  if (isFreeTier) {
+    // Premium only features
+    delete json.vulnerability.epss_probability;
+    delete json.vulnerability.cvss_score;
+    delete json.vulnerability.cisa_known_exploit;
+  }
 
   return (
     <Modal title={"Example payload"} onExit={onCancel} className={baseClass}>

--- a/frontend/pages/software/ManageSoftwarePage/components/PreviewPayloadModal/PreviewPayloadModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/PreviewPayloadModal/PreviewPayloadModal.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import { syntaxHighlight } from "utilities/helpers";
 
 import { AppContext } from "context/app";
+import { IVulnerability } from "interfaces/vulnerability";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 import ExternalLinkIcon from "../../../../../../assets/images/icon-external-link-12x12@2x.png";
@@ -11,22 +12,9 @@ const baseClass = "preview-data-modal";
 interface IPreviewPayloadModalProps {
   onCancel: () => void;
 }
-
-interface IHostsAffectedProps {
-  id: number;
-  hostname: string;
-  url: string;
-}
 interface IJsonPayload {
   timestamp: string;
-  vulnerability: {
-    cve: string;
-    details_link: string;
-    epss_probability?: number;
-    cvss_score?: number;
-    cisa_known_exploit?: boolean;
-    hosts_affected: IHostsAffectedProps[];
-  };
+  vulnerability: IVulnerability;
 }
 
 const PreviewPayloadModal = ({


### PR DESCRIPTION
Cerra #7602 

**FIX**
- Preview Payload modal shows different payload for Premium vs. Free (Free does not include: `epss_probability`, `cvss_score`, and `cisa_known_exploit`)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
