### PR TITLE
Fleet UI: Munki card order, fix alignment of arrow

### DIFF
--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -325,8 +325,8 @@ const Homepage = (): JSX.Element => {
   const macOSLayout = () => (
     <>
       <div className={`${baseClass}__section`}>{OperatingSystemsCard}</div>
-      <div className={`${baseClass}__section`}>{MunkiCard}</div>
       <div className={`${baseClass}__section`}>{MDMCard}</div>
+      <div className={`${baseClass}__section`}>{MunkiCard}</div>
     </>
   );
 

--- a/frontend/pages/Homepage/cards/MDM/_styles.scss
+++ b/frontend/pages/Homepage/cards/MDM/_styles.scss
@@ -56,6 +56,7 @@
           text-overflow: none;
           img {
             vertical-align: text-top;
+            height: 16px;
             width: 16px;
           }
         }

--- a/frontend/pages/Homepage/cards/Munki/_styles.scss
+++ b/frontend/pages/Homepage/cards/Munki/_styles.scss
@@ -75,6 +75,7 @@
             text-overflow: none;
             img {
               vertical-align: text-top;
+              height: 16px;
               width: 16px;
             }
           }


### PR DESCRIPTION
QA Fixes to #6931 

- Munki card after MDM card
- Fix arrow on link to host page

<img width="1325" alt="Screen Shot 2022-09-07 at 1 42 23 PM" src="https://user-images.githubusercontent.com/71795832/188944059-04f786bd-d1ce-4909-9adb-4acc7c0acc4b.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

~~- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).~~
No change file as a part of #6931 changefile
- [x] Manual QA for all new/changed functionality
