### PR TITLE
Fleet UI: Fix 100% width bug for truncated text

### DIFF
--- a/frontend/components/TableContainer/DataTable/TruncatedTextCell/TruncatedTextCell.tsx
+++ b/frontend/components/TableContainer/DataTable/TruncatedTextCell/TruncatedTextCell.tsx
@@ -37,7 +37,7 @@ const TruncatedTextCell = ({
       >
         <span
           className={`data-table__truncated-text--cell ${
-            !tooltipDisabled && "truncated"
+            tooltipDisabled ? "" : "truncated"
           }`}
         >
           {value}

--- a/frontend/components/TableContainer/DataTable/TruncatedTextCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/TruncatedTextCell/_styles.scss
@@ -4,6 +4,7 @@
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+    max-width: 101%;
   }
 
   .truncated {


### PR DESCRIPTION
Cerra #7609 

**Fix**
- Truncated text cell will ellipse at smaller width
**- I changed the cells that aren't ellipses to truncate when it's at a width of 101%**

Just some dev notes:
- TruncatedTextCell.tsx is built using useRef() information that is grabbed on first load
- This took a lot of googling and finagling to get the tooltip to show up if it's truncated, but not to show up if it's not truncated
- Because if we set every cell to truncate at 100%, the tooltip will not show up because the cell will show the same width as it's container (offsetWidth will equal scrollWidth) and therefore the tooltip will not show up. This is the issue with having it rerender when dimensions changes as well.
- Because the offsetWidth and scrollWidth is grabbed with useRef on initial render, it will not rerender with a tooltip when the user manually changes the width of the screen until it's refreshed. TL;DR, the page doesn't know the user made the page width smaller so it won't show new tooltip for smaller widths until it's refreshed.




# Checklist for submitter

If some of the following don't apply, delete the relevant line.

~~- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).~~
A part of an issue already with a change file
- [x] Manual QA for all new/changed functionality
