### PR TITLE
Fleet UI: Bug fix, Can view more than 20 teams in UI

### DIFF
--- a/changes/issue-7622-more-than-20-teams-in-ui
+++ b/changes/issue-7622-more-than-20-teams-in-ui
@@ -1,0 +1,1 @@
+* UI supports more than 20 teams

--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -253,7 +253,7 @@ const TeamManagementPage = (): JSX.Element => {
           showMarkAllPages={false}
           isAllPagesSelected={false}
           searchable={teams && teams.length > 0 && searchString !== ""}
-          disablePagination
+          isClientSidePagination
         />
       )}
       {showCreateTeamModal && (

--- a/frontend/services/entities/teams.ts
+++ b/frontend/services/entities/teams.ts
@@ -3,6 +3,7 @@ import sendRequest from "services";
 import endpoints from "utilities/endpoints";
 import { pick } from "lodash";
 
+import { buildQueryStringFromParams } from "utilities/url";
 import { IEnrollSecret } from "interfaces/enroll_secret";
 import {
   INewMembersBody,
@@ -51,21 +52,15 @@ export default {
     return sendRequest("GET", path);
   },
   loadAll: ({
-    page = 0,
-    perPage = 20,
     globalFilter = "",
   }: ILoadTeamsParams = {}): Promise<ILoadTeamsResponse> => {
-    const { TEAMS } = endpoints;
+    const queryParams = {
+      query: globalFilter,
+    };
 
-    // TODO: add this query param logic to client class
-    const pagination = `page=${page}&per_page=${perPage}`;
-
-    let searchQuery = "";
-    if (globalFilter !== "") {
-      searchQuery = `&query=${globalFilter}`;
-    }
-
-    const path = `${TEAMS}?${pagination}${searchQuery}`;
+    const queryString = buildQueryStringFromParams(queryParams);
+    const endpoint = endpoints.TEAMS;
+    const path = `${endpoint}?${queryString}`;
 
     return sendRequest("GET", path);
   },


### PR DESCRIPTION
Cerra #7622 

**FIX**
- API calls without pagination to return the number of teams even if it's more than 20 teams
- Pagination on page for users that have more than 20 teams

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
