### PR TITLE
fix panic when reading team features from the database

### DIFF
--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -308,9 +308,13 @@ func (ds *Datastore) TeamFeatures(ctx context.Context, tid uint) (*fleet.Feature
 	if err := sqlx.GetContext(ctx, ds.reader, &raw, sql, tid); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get team config features")
 	}
+
 	var features fleet.Features
-	if err := json.Unmarshal(*raw, &features); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "unmarshal team config features")
+	features.ApplyDefaultsForNewInstalls()
+	if raw != nil {
+		if err := json.Unmarshal(*raw, &features); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "unmarshal team config features")
+		}
 	}
 	return &features, nil
 }

--- a/server/datastore/mysql/teams_test.go
+++ b/server/datastore/mysql/teams_test.go
@@ -449,6 +449,23 @@ func testTeamsFeatures(t *testing.T, ds *Datastore) {
 		assert.Equal(t, &defaultFeatures, features)
 	})
 
+	t.Run("NULL config.features in the database", func(t *testing.T) {
+		team, err := ds.NewTeam(ctx, &fleet.Team{Name: "team_null_config_features"})
+		require.NoError(t, err)
+		ExecAdhocSQL(t, ds, func(tx sqlx.ExtContext) error {
+			_, err = tx.ExecContext(
+				ctx,
+				"UPDATE teams SET config = '{}' WHERE id = ?",
+				team.ID,
+			)
+			return err
+		})
+		features, err := ds.TeamFeatures(ctx, team.ID)
+		require.NoError(t, err)
+
+		assert.Equal(t, &defaultFeatures, features)
+	})
+
 	t.Run("saves and retrieves configs", func(t *testing.T) {
 		team, err := ds.NewTeam(ctx, &fleet.Team{
 			Name: "team1",


### PR DESCRIPTION
This fixes an unreleased bug I introduced in eeefe2, as the `config` colum in the `teams` table is nulleable, it unmarshalls into `nil` and we can't dereference the variable.

# Checklist for submitter

- [x] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
