### PR TITLE
fix vertical align of manage enroll icons

### DIFF
--- a/frontend/components/EnrollSecretModal/_styles.scss
+++ b/frontend/components/EnrollSecretModal/_styles.scss
@@ -6,7 +6,7 @@
 
   &__secret-wrapper {
     position: relative;
-    margin: $pad-medium 0 0 0;
+    margin: $pad-medium 0;
   }
 
   pre,

--- a/frontend/components/EnrollSecretTable/EnrollSecretRow/_styles.scss
+++ b/frontend/components/EnrollSecretTable/EnrollSecretRow/_styles.scss
@@ -1,13 +1,19 @@
 .enroll-secrets {
   &__secret {
     display: flex;
+    align-items: center;
   }
+
+  .form-field {
+    margin-bottom: 0;
+  }
+
   &__secret-input {
     .form-field__label {
       position: relative;
       font-size: $x-small;
       font-weight: $bold;
-      margin-top: $pad-small;
+      margin-bottom: 0;
       width: 560px;
     }
 
@@ -35,7 +41,7 @@
     align-items: center;
     position: absolute;
     right: 16px;
-    top: 16px;
+    top: 12px;
     height: 16px;
 
     span {
@@ -83,6 +89,6 @@
 
   &__edit-secret-btn,
   &__delete-secret-btn {
-    margin: $pad-xsmall $pad-small $pad-large;
+    margin: 0 $pad-small;
   }
 }


### PR DESCRIPTION
relates to #7631 

fix alignment of icons on manage enroll secret modal

![image](https://user-images.githubusercontent.com/1153709/189133201-3bdf4feb-4656-48a4-acde-c80e80e3755f.png)
