### PR TITLE
fix squashed slack button image on welcome card

### DIFF
--- a/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
@@ -17,7 +17,6 @@ import LinkArrow from "../../../../../assets/images/icon-arrow-right-vibrant-blu
 import IconDisabled from "../../../../../assets/images/icon-action-disable-red-16x16@2x.png";
 import IconPassed from "../../../../../assets/images/icon-check-circle-green-16x16@2x.png";
 import IconError from "../../../../../assets/images/icon-exclamation-circle-red-16x16@2x.png";
-import IconChevron from "../../../../../assets/images/icon-chevron-purple-9x6@2x.png";
 import SlackButton from "../../../../../assets/images/slack-button-get-help.png";
 
 interface IHostResponse {

--- a/frontend/pages/Homepage/cards/WelcomeHost/_styles.scss
+++ b/frontend/pages/Homepage/cards/WelcomeHost/_styles.scss
@@ -5,6 +5,7 @@
 
   .button-slack {
     width: 173px;
+    height: auto;
     margin-top: 4px;
   }
 


### PR DESCRIPTION
relates to #7637

fixes smashed slack button on welcome card.