### PR TITLE
Fleet UI: Munki title on homepage, hide entire card when no munki_versions installed on team/global

### DIFF
--- a/cypress/integration/free/admin.spec.ts
+++ b/cypress/integration/free/admin.spec.ts
@@ -100,7 +100,6 @@ describe(
           cy.findByText(/fleet test/i).should("exist");
           cy.getAttached(".hosts-summary").should("exist");
           cy.getAttached(".hosts-status").should("exist");
-          cy.getAttached(".home-munki").should("exist");
           cy.getAttached(".home-mdm").should("exist");
           // "get" because we expect it not to exist
           cy.get(".home-software").should("not.exist");

--- a/cypress/integration/free/maintainer.spec.ts
+++ b/cypress/integration/free/maintainer.spec.ts
@@ -92,7 +92,6 @@ describe(
           cy.findByText(/fleet test/i).should("exist");
           cy.getAttached(".hosts-summary").should("exist");
           cy.getAttached(".hosts-status").should("exist");
-          cy.getAttached(".home-munki").should("exist");
           cy.getAttached(".home-mdm").should("exist");
           // "get" because we expect it not to exist
           cy.get(".home-software").should("not.exist");

--- a/cypress/integration/free/observer.spec.ts
+++ b/cypress/integration/free/observer.spec.ts
@@ -87,7 +87,6 @@ describe("Free tier - Observer user", () => {
         cy.findByText(/fleet test/i).should("exist");
         cy.getAttached(".hosts-summary").should("exist");
         cy.getAttached(".hosts-status").should("exist");
-        cy.getAttached(".home-munki").should("exist");
         cy.getAttached(".home-mdm").should("exist");
         // "get" because we expect it not to exist
         cy.get(".home-software").should("not.exist");

--- a/cypress/integration/premium/maintainer.spec.ts
+++ b/cypress/integration/premium/maintainer.spec.ts
@@ -84,7 +84,6 @@ describe("Premium tier - Maintainer user", () => {
           cy.findByText(/all teams/i).should("exist");
           cy.getAttached(".hosts-summary").should("exist");
           cy.getAttached(".hosts-status").should("exist");
-          cy.getAttached(".home-munki").should("exist");
           cy.getAttached(".home-mdm").should("exist");
           // "get" because we expect it not to exist
           cy.get(".home-software").should("not.exist");

--- a/cypress/integration/premium/observer.spec.ts
+++ b/cypress/integration/premium/observer.spec.ts
@@ -85,7 +85,6 @@ describe("Premium tier - Observer user", () => {
           cy.findByText(/all teams/i).should("exist");
           cy.getAttached(".hosts-summary").should("exist");
           cy.getAttached(".hosts-status").should("exist");
-          cy.getAttached(".home-munki").should("exist");
           cy.getAttached(".home-mdm").should("exist");
           // "get" because we expect it not to exist
           cy.get(".home-software").should("not.exist");

--- a/cypress/integration/premium/team_admin.spec.ts
+++ b/cypress/integration/premium/team_admin.spec.ts
@@ -90,7 +90,6 @@ describe("Premium tier - Team Admin user", () => {
         cy.findByText(/apples/i).should("exist");
         cy.getAttached(".hosts-summary").should("exist");
         cy.getAttached(".hosts-status").should("exist");
-        cy.getAttached(".home-munki").should("exist");
         cy.getAttached(".home-mdm").should("exist");
         // "get" because we expect it not to exist
         cy.get(".home-software").should("not.exist");

--- a/cypress/integration/premium/team_maintainer_observer.spec.ts
+++ b/cypress/integration/premium/team_maintainer_observer.spec.ts
@@ -85,7 +85,6 @@ describe("Premium tier - Team observer/maintainer user", () => {
           cy.findByText(/apples/i).should("exist");
           cy.getAttached(".hosts-summary").should("exist");
           cy.getAttached(".hosts-status").should("exist");
-          cy.getAttached(".home-munki").should("exist");
           cy.getAttached(".home-mdm").should("exist");
           // "get" because we expect it not to exist
           cy.get(".home-software").should("not.exist");

--- a/frontend/interfaces/macadmins.ts
+++ b/frontend/interfaces/macadmins.ts
@@ -1,4 +1,4 @@
-export interface IDataTableMDMFormat {
+export interface IDataTableMdmFormat {
   status: string;
   hosts: number;
 }
@@ -14,13 +14,13 @@ export interface IMunkiIssuesAggregate {
   type: "error" | "warning";
   hosts_count: number;
 }
-export interface IMDMAggregateStatus {
+export interface IMdmAggregateStatus {
   enrolled_manual_hosts_count: number;
   enrolled_automated_hosts_count: number;
   unenrolled_hosts_count: number;
 }
 
-export interface IMDMSolution {
+export interface IMdmSolution {
   id: number;
   name: string | null;
   server_url: string;
@@ -32,7 +32,7 @@ export interface IMacadminAggregate {
     counts_updated_at: string;
     munki_versions: IMunkiVersionsAggregate[];
     munki_issues: IMunkiIssuesAggregate[];
-    mobile_device_management_enrollment_status: IMDMAggregateStatus;
-    mobile_device_management_solution: IMDMSolution[] | null;
+    mobile_device_management_enrollment_status: IMdmAggregateStatus;
+    mobile_device_management_solution: IMdmSolution[] | null;
   };
 }

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -30,6 +30,7 @@ import Spinner from "components/Spinner";
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
 import MainContent from "components/MainContent";
+import LastUpdatedText from "components/LastUpdatedText";
 import useInfoCard from "./components/InfoCard";
 import HostsStatus from "./cards/HostsStatus";
 import HostsSummary from "./cards/HostsSummary";
@@ -86,6 +87,12 @@ const Homepage = (): JSX.Element => {
   const [munkiVersionsData, setMunkiVersionsData] = useState<
     IMunkiVersionsAggregate[]
   >([]);
+  const [mdmTitleDetail, setMdmTitleDetail] = useState<
+    JSX.Element | string | null
+  >();
+  const [munkiTitleDetail, setMunkiTitleDetail] = useState<
+    JSX.Element | string | null
+  >();
 
   const canEnrollHosts =
     isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer;
@@ -194,13 +201,12 @@ const Homepage = (): JSX.Element => {
           munki_issues,
         } = data.macadmins;
 
-        // setTitleDetail &&
-        //   setTitleDetail(
-        //     <LastUpdatedText
-        //       lastUpdatedAt={macadmins_counts_updated_at}
-        //       whatToRetrieve={"MDM enrollment"}
-        //     />
-        //   );
+        setMdmTitleDetail(
+          <LastUpdatedText
+            lastUpdatedAt={macadmins_counts_updated_at}
+            whatToRetrieve={"MDM enrollment"}
+          />
+        );
         setFormattedMdmData([
           {
             status: "Enrolled (manual)",
@@ -216,13 +222,12 @@ const Homepage = (): JSX.Element => {
         setMunkiVersionsData(munki_versions);
         setMunkiIssuesData(munki_issues);
         setShowMunkiCard(!!munki_versions);
-        // setTitleDetail &&
-        //   setTitleDetail(
-        //     <LastUpdatedText
-        //       lastUpdatedAt={munki_counts_updated_at}
-        //       whatToRetrieve={"Munki"}
-        //     />
-        //   );
+        setMunkiTitleDetail(
+          <LastUpdatedText
+            lastUpdatedAt={munki_counts_updated_at}
+            whatToRetrieve={"Munki"}
+          />
+        );
       },
       onError: () => {
         setShowMDMUI(true);
@@ -327,6 +332,7 @@ const Homepage = (): JSX.Element => {
 
   const MunkiCard = useInfoCard({
     title: "Munki",
+    titleDetail: munkiTitleDetail,
     showTitle: !isMacAdminsFetching,
     description: (
       <p>
@@ -353,6 +359,7 @@ const Homepage = (): JSX.Element => {
 
   const MDMCard = useInfoCard({
     title: "Mobile device management (MDM)",
+    titleDetail: mdmTitleDetail,
     showTitle: !isMacAdminsFetching,
     description: (
       <p>

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -194,13 +194,13 @@ const Homepage = (): JSX.Element => {
           munki_issues,
         } = data.macadmins;
 
-        setTitleDetail &&
-          setTitleDetail(
-            <LastUpdatedText
-              lastUpdatedAt={macadmins_counts_updated_at}
-              whatToRetrieve={"MDM enrollment"}
-            />
-          );
+        // setTitleDetail &&
+        //   setTitleDetail(
+        //     <LastUpdatedText
+        //       lastUpdatedAt={macadmins_counts_updated_at}
+        //       whatToRetrieve={"MDM enrollment"}
+        //     />
+        //   );
         setFormattedMdmData([
           {
             status: "Enrolled (manual)",
@@ -216,13 +216,13 @@ const Homepage = (): JSX.Element => {
         setMunkiVersionsData(munki_versions);
         setMunkiIssuesData(munki_issues);
         setShowMunkiCard(!!munki_versions);
-        setTitleDetail &&
-          setTitleDetail(
-            <LastUpdatedText
-              lastUpdatedAt={munki_counts_updated_at}
-              whatToRetrieve={"Munki"}
-            />
-          );
+        // setTitleDetail &&
+        //   setTitleDetail(
+        //     <LastUpdatedText
+        //       lastUpdatedAt={munki_counts_updated_at}
+        //       whatToRetrieve={"Munki"}
+        //     />
+        //   );
       },
       onError: () => {
         setShowMDMUI(true);
@@ -326,8 +326,8 @@ const Homepage = (): JSX.Element => {
   });
 
   const MunkiCard = useInfoCard({
-    title: "Munki versions",
-    showTitle: showMunkiUI,
+    title: "Munki",
+    showTitle: !isMacAdminsFetching,
     description: (
       <p>
         Munki is a tool for managing software on macOS devices.{" "}
@@ -353,7 +353,7 @@ const Homepage = (): JSX.Element => {
 
   const MDMCard = useInfoCard({
     title: "Mobile device management (MDM)",
-    showTitle: showMDMUI,
+    showTitle: !isMacAdminsFetching,
     description: (
       <p>
         MDM is used to manage configuration on macOS devices.{" "}

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -62,6 +62,7 @@ const Homepage = (): JSX.Element => {
   const [showActivityFeedTitle, setShowActivityFeedTitle] = useState(false);
   const [showSoftwareUI, setShowSoftwareUI] = useState(false);
   const [showMunkiUI, setShowMunkiUI] = useState(false);
+  const [showMunkiCard, setShowMunkiCard] = useState(true);
   const [showMDMUI, setShowMDMUI] = useState(false);
   const [showAddHostsModal, setShowAddHostsModal] = useState(false);
   const [showOperatingSystemsUI, setShowOperatingSystemsUI] = useState(false);
@@ -260,6 +261,7 @@ const Homepage = (): JSX.Element => {
     children: (
       <Munki
         setShowMunkiUI={setShowMunkiUI}
+        setShowMunkiCard={setShowMunkiCard}
         showMunkiUI={showMunkiUI}
         currentTeamId={currentTeam?.id}
       />
@@ -326,7 +328,9 @@ const Homepage = (): JSX.Element => {
     <>
       <div className={`${baseClass}__section`}>{OperatingSystemsCard}</div>
       <div className={`${baseClass}__section`}>{MDMCard}</div>
-      <div className={`${baseClass}__section`}>{MunkiCard}</div>
+      {showMunkiCard && (
+        <div className={`${baseClass}__section`}>{MunkiCard}</div>
+      )}
     </>
   );
 

--- a/frontend/pages/Homepage/cards/MDM/MDM.tsx
+++ b/frontend/pages/Homepage/cards/MDM/MDM.tsx
@@ -72,7 +72,7 @@ const Mdm = ({
   const solutionsDataSet = generateSolutionsDataSet(mdmSolutions);
 
   // Renders opaque information as host information is loading
-  const opacity = isMacAdminsFetching ? { opacity: 1 } : { opacity: 0 };
+  const opacity = isMacAdminsFetching ? { opacity: 0 } : { opacity: 1 };
 
   return (
     <div className={baseClass}>

--- a/frontend/pages/Homepage/cards/MDM/MDM.tsx
+++ b/frontend/pages/Homepage/cards/MDM/MDM.tsx
@@ -7,7 +7,6 @@ import TabsWrapper from "components/TabsWrapper";
 import TableContainer from "components/TableContainer";
 import Spinner from "components/Spinner";
 import TableDataError from "components/DataError";
-import LastUpdatedText from "components/LastUpdatedText";
 import {
   generateSolutionsTableHeaders,
   generateSolutionsDataSet,

--- a/frontend/pages/Homepage/cards/MDM/MDM.tsx
+++ b/frontend/pages/Homepage/cards/MDM/MDM.tsx
@@ -1,13 +1,7 @@
 import React, { useState } from "react";
-import { useQuery } from "react-query";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 
-import macadminsAPI from "services/entities/macadmins";
-import {
-  IMacadminAggregate,
-  IDataTableMDMFormat,
-  IMDMSolution,
-} from "interfaces/macadmins";
+import { IDataTableMdmFormat, IMdmSolution } from "interfaces/macadmins";
 
 import TabsWrapper from "components/TabsWrapper";
 import TableContainer from "components/TableContainer";
@@ -20,11 +14,11 @@ import {
 } from "./MDMSolutionsTableConfig";
 import generateEnrollmentTableHeaders from "./MDMEnrollmentTableConfig";
 
-interface IMDMCardProps {
-  showMDMUI: boolean;
-  currentTeamId: number | undefined;
-  setShowMDMUI: (showMDMTitle: boolean) => void;
-  setTitleDetail?: (content: JSX.Element | string | null) => void;
+interface IMdmCardProps {
+  errorMacAdmins: Error | null;
+  isMacAdminsFetching: boolean;
+  formattedMdmData: IDataTableMdmFormat[];
+  mdmSolutions: IMdmSolution[] | null;
 }
 
 const DEFAULT_SORT_DIRECTION = "desc";
@@ -34,7 +28,7 @@ const ENROLLMENT_DEFAULT_SORT_HEADER = "status";
 const PAGE_SIZE = 8;
 const baseClass = "home-mdm";
 
-const EmptyMDMEnrollment = (): JSX.Element => (
+const EmptyMdmEnrollment = (): JSX.Element => (
   <div className={`${baseClass}__empty-mdm`}>
     <h1>Unable to detect MDM enrollment</h1>
     <p>
@@ -51,7 +45,7 @@ const EmptyMDMEnrollment = (): JSX.Element => (
   </div>
 );
 
-const EmptyMDMSolutions = (): JSX.Element => (
+const EmptyMdmSolutions = (): JSX.Element => (
   <div className={`${baseClass}__empty-mdm`}>
     <h1>No MDM solutions detected</h1>
     <p>
@@ -61,60 +55,13 @@ const EmptyMDMSolutions = (): JSX.Element => (
   </div>
 );
 
-const MDM = ({
-  showMDMUI,
-  currentTeamId,
-  setShowMDMUI,
-  setTitleDetail,
-}: IMDMCardProps): JSX.Element => {
+const Mdm = ({
+  isMacAdminsFetching,
+  errorMacAdmins,
+  formattedMdmData,
+  mdmSolutions,
+}: IMdmCardProps): JSX.Element => {
   const [navTabIndex, setNavTabIndex] = useState(0);
-  const [formattedMDMData, setFormattedMDMData] = useState<
-    IDataTableMDMFormat[]
-  >([]);
-  const [solutions, setSolutions] = useState<IMDMSolution[] | null>([]);
-
-  const { isFetching: isMDMFetching, error: errorMDM } = useQuery<
-    IMacadminAggregate,
-    Error
-  >(["MDM", currentTeamId], () => macadminsAPI.loadAll(currentTeamId), {
-    keepPreviousData: true,
-    onSuccess: (data) => {
-      const {
-        counts_updated_at,
-        mobile_device_management_enrollment_status,
-        mobile_device_management_solution,
-      } = data.macadmins;
-      const {
-        enrolled_manual_hosts_count,
-        enrolled_automated_hosts_count,
-        unenrolled_hosts_count,
-      } = mobile_device_management_enrollment_status;
-
-      setShowMDMUI(true);
-      setTitleDetail &&
-        setTitleDetail(
-          <LastUpdatedText
-            lastUpdatedAt={counts_updated_at}
-            whatToRetrieve={"MDM enrollment"}
-          />
-        );
-      setFormattedMDMData([
-        {
-          status: "Enrolled (manual)",
-          hosts: enrolled_manual_hosts_count,
-        },
-        {
-          status: "Enrolled (automatic)",
-          hosts: enrolled_automated_hosts_count,
-        },
-        { status: "Unenrolled", hosts: unenrolled_hosts_count },
-      ]);
-      setSolutions(mobile_device_management_solution);
-    },
-    onError: () => {
-      setShowMDMUI(true);
-    },
-  });
 
   const onTabChange = (index: number) => {
     setNavTabIndex(index);
@@ -122,14 +69,14 @@ const MDM = ({
 
   const solutionsTableHeaders = generateSolutionsTableHeaders();
   const enrollmentTableHeaders = generateEnrollmentTableHeaders();
-  const solutionsDataSet = generateSolutionsDataSet(solutions);
+  const solutionsDataSet = generateSolutionsDataSet(mdmSolutions);
 
   // Renders opaque information as host information is loading
-  const opacity = showMDMUI ? { opacity: 1 } : { opacity: 0 };
+  const opacity = isMacAdminsFetching ? { opacity: 1 } : { opacity: 0 };
 
   return (
     <div className={baseClass}>
-      {!showMDMUI && (
+      {isMacAdminsFetching && (
         <div className="spinner">
           <Spinner />
         </div>
@@ -142,18 +89,18 @@ const MDM = ({
               <Tab>Enrollment</Tab>
             </TabList>
             <TabPanel>
-              {errorMDM ? (
+              {errorMacAdmins ? (
                 <TableDataError card />
               ) : (
                 <TableContainer
                   columns={solutionsTableHeaders}
                   data={solutionsDataSet}
-                  isLoading={isMDMFetching}
+                  isLoading={isMacAdminsFetching}
                   defaultSortHeader={SOLUTIONS_DEFAULT_SORT_HEADER}
                   defaultSortDirection={DEFAULT_SORT_DIRECTION}
                   hideActionButton
                   resultsTitle={"MDM"}
-                  emptyComponent={EmptyMDMSolutions}
+                  emptyComponent={EmptyMdmSolutions}
                   showMarkAllPages={false}
                   isAllPagesSelected={false}
                   isClientSidePagination
@@ -164,18 +111,18 @@ const MDM = ({
               )}
             </TabPanel>
             <TabPanel>
-              {errorMDM ? (
+              {errorMacAdmins ? (
                 <TableDataError card />
               ) : (
                 <TableContainer
                   columns={enrollmentTableHeaders}
-                  data={formattedMDMData}
-                  isLoading={isMDMFetching}
+                  data={formattedMdmData}
+                  isLoading={isMacAdminsFetching}
                   defaultSortHeader={ENROLLMENT_DEFAULT_SORT_HEADER}
                   defaultSortDirection={ENROLLMENT_DEFAULT_SORT_DIRECTION}
                   hideActionButton
                   resultsTitle={"MDM"}
-                  emptyComponent={EmptyMDMEnrollment}
+                  emptyComponent={EmptyMdmEnrollment}
                   showMarkAllPages={false}
                   isAllPagesSelected={false}
                   disableCount
@@ -192,4 +139,4 @@ const MDM = ({
   );
 };
 
-export default MDM;
+export default Mdm;

--- a/frontend/pages/Homepage/cards/MDM/MDMEnrollmentTableConfig.tsx
+++ b/frontend/pages/Homepage/cards/MDM/MDMEnrollmentTableConfig.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router";
 
-import { IDataTableMDMFormat } from "interfaces/macadmins";
+import { IDataTableMdmFormat } from "interfaces/macadmins";
 
 import PATHS from "router/paths";
 import TextCell from "components/TableContainer/DataTable/TextCell";
@@ -15,7 +15,7 @@ interface ICellProps {
     value: string;
   };
   row: {
-    original: IDataTableMDMFormat;
+    original: IDataTableMdmFormat;
   };
 }
 

--- a/frontend/pages/Homepage/cards/MDM/MDMSolutionsTableConfig.tsx
+++ b/frontend/pages/Homepage/cards/MDM/MDMSolutionsTableConfig.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router";
 
-import { IMDMSolution } from "interfaces/macadmins";
+import { IMdmSolution } from "interfaces/macadmins";
 
 import PATHS from "router/paths";
 import { greyCell } from "utilities/helpers";
@@ -16,7 +16,7 @@ interface ICellProps {
     value: string;
   };
   row: {
-    original: IMDMSolution;
+    original: IMdmSolution;
   };
 }
 
@@ -98,7 +98,7 @@ export const generateSolutionsTableHeaders = (): IDataColumn[] => {
   return solutionsTableHeaders;
 };
 
-const enhanceSolutionsData = (solutions: IMDMSolution[]): IMDMSolution[] => {
+const enhanceSolutionsData = (solutions: IMdmSolution[]): IMdmSolution[] => {
   return Object.values(solutions).map((solution) => {
     return {
       id: solution.id,
@@ -110,8 +110,8 @@ const enhanceSolutionsData = (solutions: IMDMSolution[]): IMDMSolution[] => {
 };
 
 export const generateSolutionsDataSet = (
-  solutions: IMDMSolution[] | null
-): IMDMSolution[] => {
+  solutions: IMdmSolution[] | null
+): IMdmSolution[] => {
   if (!solutions) {
     return [];
   }

--- a/frontend/pages/Homepage/cards/Munki/Munki.tsx
+++ b/frontend/pages/Homepage/cards/Munki/Munki.tsx
@@ -21,6 +21,7 @@ interface IMunkiCardProps {
   showMunkiUI: boolean;
   currentTeamId: number | undefined;
   setShowMunkiUI: (showMunkiTitle: boolean) => void;
+  setShowMunkiCard: (showMunkiCard: boolean) => void;
   setTitleDetail?: (content: JSX.Element | string | null) => void;
 }
 
@@ -60,6 +61,7 @@ const Munki = ({
   showMunkiUI,
   currentTeamId,
   setShowMunkiUI,
+  setShowMunkiCard,
   setTitleDetail,
 }: IMunkiCardProps): JSX.Element => {
   const [navTabIndex, setNavTabIndex] = useState<number>(0);
@@ -75,7 +77,6 @@ const Munki = ({
     IMacadminAggregate,
     Error
   >(["munki", currentTeamId], () => macadminsAPI.loadAll(currentTeamId), {
-    keepPreviousData: true,
     onSuccess: (data) => {
       const {
         counts_updated_at,
@@ -86,11 +87,12 @@ const Munki = ({
       setMunkiVersionsData(munki_versions);
       setMunkiIssuesData(munki_issues);
       setShowMunkiUI(true);
+      setShowMunkiCard(!!munki_versions);
       setTitleDetail &&
         setTitleDetail(
           <LastUpdatedText
             lastUpdatedAt={counts_updated_at}
-            whatToRetrieve={"Munki versions"}
+            whatToRetrieve={"Munki"}
           />
         );
     },

--- a/frontend/pages/Homepage/cards/Munki/Munki.tsx
+++ b/frontend/pages/Homepage/cards/Munki/Munki.tsx
@@ -1,10 +1,7 @@
 import React, { useState } from "react";
-import { useQuery } from "react-query";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 
-import macadminsAPI from "services/entities/macadmins";
 import {
-  IMacadminAggregate,
   IMunkiIssuesAggregate,
   IMunkiVersionsAggregate,
 } from "interfaces/macadmins";
@@ -18,11 +15,10 @@ import munkiVersionsTableHeaders from "./MunkiVersionsTableConfig";
 import munkiIssuesTableHeaders from "./MunkiIssuesTableConfig";
 
 interface IMunkiCardProps {
-  showMunkiUI: boolean;
-  currentTeamId: number | undefined;
-  setShowMunkiUI: (showMunkiTitle: boolean) => void;
-  setShowMunkiCard: (showMunkiCard: boolean) => void;
-  setTitleDetail?: (content: JSX.Element | string | null) => void;
+  errorMacAdmins: Error | null;
+  isMacAdminsFetching: boolean;
+  munkiIssuesData: IMunkiIssuesAggregate[];
+  munkiVersionsData: IMunkiVersionsAggregate[];
 }
 
 const DEFAULT_SORT_DIRECTION = "desc";
@@ -58,59 +54,23 @@ const EmptyMunkiVersions = (): JSX.Element => (
 );
 
 const Munki = ({
-  showMunkiUI,
-  currentTeamId,
-  setShowMunkiUI,
-  setShowMunkiCard,
-  setTitleDetail,
+  errorMacAdmins,
+  isMacAdminsFetching,
+  munkiIssuesData,
+  munkiVersionsData,
 }: IMunkiCardProps): JSX.Element => {
   const [navTabIndex, setNavTabIndex] = useState<number>(0);
-  const [pageIndex, setPageIndex] = useState<number>(0);
-  const [munkiIssuesData, setMunkiIssuesData] = useState<
-    IMunkiIssuesAggregate[]
-  >([]);
-  const [munkiVersionsData, setMunkiVersionsData] = useState<
-    IMunkiVersionsAggregate[]
-  >([]);
-
-  const { isFetching: isMunkiFetching, error: errorMunki } = useQuery<
-    IMacadminAggregate,
-    Error
-  >(["munki", currentTeamId], () => macadminsAPI.loadAll(currentTeamId), {
-    onSuccess: (data) => {
-      const {
-        counts_updated_at,
-        munki_versions,
-        munki_issues,
-      } = data.macadmins;
-
-      setMunkiVersionsData(munki_versions);
-      setMunkiIssuesData(munki_issues);
-      setShowMunkiUI(true);
-      setShowMunkiCard(!!munki_versions);
-      setTitleDetail &&
-        setTitleDetail(
-          <LastUpdatedText
-            lastUpdatedAt={counts_updated_at}
-            whatToRetrieve={"Munki"}
-          />
-        );
-    },
-    onError: () => {
-      setShowMunkiUI(true);
-    },
-  });
 
   const onTabChange = (index: number) => {
     setNavTabIndex(index);
   };
 
   // Renders opaque information as host information is loading
-  const opacity = showMunkiUI ? { opacity: 1 } : { opacity: 0 };
+  const opacity = isMacAdminsFetching ? { opacity: 1 } : { opacity: 0 };
 
   return (
     <div className={baseClass}>
-      {!showMunkiUI && (
+      {isMacAdminsFetching && (
         <div className="spinner">
           <Spinner />
         </div>
@@ -123,13 +83,13 @@ const Munki = ({
               <Tab>Versions</Tab>
             </TabList>
             <TabPanel>
-              {errorMunki ? (
+              {errorMacAdmins ? (
                 <TableDataError card />
               ) : (
                 <TableContainer
                   columns={munkiIssuesTableHeaders}
                   data={munkiIssuesData || []}
-                  isLoading={isMunkiFetching}
+                  isLoading={isMacAdminsFetching}
                   defaultSortHeader={DEFAULT_SORT_HEADER}
                   defaultSortDirection={DEFAULT_SORT_DIRECTION}
                   hideActionButton
@@ -146,13 +106,13 @@ const Munki = ({
               )}
             </TabPanel>
             <TabPanel>
-              {errorMunki ? (
+              {errorMacAdmins ? (
                 <TableDataError card />
               ) : (
                 <TableContainer
                   columns={munkiVersionsTableHeaders}
                   data={munkiVersionsData || []}
-                  isLoading={isMunkiFetching}
+                  isLoading={isMacAdminsFetching}
                   defaultSortHeader={DEFAULT_SORT_HEADER}
                   defaultSortDirection={DEFAULT_SORT_DIRECTION}
                   hideActionButton

--- a/frontend/pages/Homepage/cards/Munki/Munki.tsx
+++ b/frontend/pages/Homepage/cards/Munki/Munki.tsx
@@ -10,7 +10,6 @@ import TabsWrapper from "components/TabsWrapper";
 import TableContainer from "components/TableContainer";
 import Spinner from "components/Spinner";
 import TableDataError from "components/DataError";
-import LastUpdatedText from "components/LastUpdatedText";
 import munkiVersionsTableHeaders from "./MunkiVersionsTableConfig";
 import munkiIssuesTableHeaders from "./MunkiIssuesTableConfig";
 

--- a/frontend/pages/Homepage/cards/Munki/Munki.tsx
+++ b/frontend/pages/Homepage/cards/Munki/Munki.tsx
@@ -66,7 +66,7 @@ const Munki = ({
   };
 
   // Renders opaque information as host information is loading
-  const opacity = isMacAdminsFetching ? { opacity: 1 } : { opacity: 0 };
+  const opacity = isMacAdminsFetching ? { opacity: 0 } : { opacity: 1 };
 
   return (
     <div className={baseClass}>

--- a/frontend/pages/Homepage/components/InfoCard/InfoCard.tsx
+++ b/frontend/pages/Homepage/components/InfoCard/InfoCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Link } from "react-router";
 
 import Button from "components/buttons/Button";
@@ -6,6 +6,7 @@ import LinkArrow from "../../../../../assets/images/icon-arrow-right-vibrant-blu
 
 interface IInfoCardProps {
   title: string;
+  titleDetail?: JSX.Element | string | null;
   description?: JSX.Element | string;
   children: React.ReactChild | React.ReactChild[];
   action?:
@@ -27,6 +28,7 @@ const baseClass = "homepage-info-card";
 
 const useInfoCard = ({
   title,
+  titleDetail: defaultTitleDetail,
   description: defaultDescription,
   children,
   action,
@@ -35,11 +37,17 @@ const useInfoCard = ({
 }: IInfoCardProps): JSX.Element => {
   const [actionLink, setActionURL] = useState<string | null>(null);
   const [titleDetail, setTitleDetail] = useState<JSX.Element | string | null>(
-    null
+    defaultTitleDetail || null
   );
   const [description, setDescription] = useState<JSX.Element | string | null>(
     defaultDescription || null
   );
+
+  useEffect(() => {
+    if (defaultTitleDetail) {
+      setTitleDetail(defaultTitleDetail);
+    }
+  }, [defaultTitleDetail]);
 
   const renderAction = () => {
     if (action) {

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -34,7 +34,7 @@ import {
 } from "interfaces/enroll_secret";
 import { IHost } from "interfaces/host";
 import { ILabel } from "interfaces/label";
-import { IMDMSolution, IMunkiIssuesAggregate } from "interfaces/macadmins";
+import { IMdmSolution, IMunkiIssuesAggregate } from "interfaces/macadmins";
 import {
   formatOperatingSystemDisplayName,
   IOperatingSystemVersion,
@@ -225,7 +225,7 @@ const ManageHostsPage = ({
   const [
     mdmSolutionDetails,
     setMDMSolutionDetails,
-  ] = useState<IMDMSolution | null>(null);
+  ] = useState<IMdmSolution | null>(null);
   const [
     munkiIssueDetails,
     setMunkiIssueDetails,


### PR DESCRIPTION
Cerra #7642 

**FIXES**
- Homepage Munki card titled "Munki" not "Munki versions"
- Hides entire Munki card if no `munki_versions` are installed

**TECH DEBT**
Requires refactor because:
- The API call is on the card, so hiding the card makes it so the API call is not called again when switching teams
- Realized we're calling the macadminsAPI twice (one for MDM card one for Munki card) which will need to refactor into homepage as one call since we might as well because we need to move the macadmins call off that card
- Update title details can come from parent component and not just cloned from children


https://user-images.githubusercontent.com/71795832/189193581-305deacb-862b-4994-ba69-054b8c6e0378.mov



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

~~- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).~~
Part of larger EPIC/issue with change file already added
- [x] Manual QA for all new/changed functionality
