### PR TITLE
Fleet UI: Indicate hoverable text with grey font

### DIFF
--- a/changes/issue-7065-indicate-hoverable-text
+++ b/changes/issue-7065-indicate-hoverable-text
@@ -1,0 +1,1 @@
+* Indicate hoverable text on host details/ device user details

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -216,6 +216,10 @@
     }
   }
 
+  .tooltip {
+    color: $ui-fleet-black-50;
+  }
+
   .button img {
     transform: scale(0.5);
   }

--- a/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
@@ -214,6 +214,10 @@
     }
   }
 
+  .tooltip {
+    color: $ui-fleet-black-50;
+  }
+
   .component__tabs-wrapper {
     background-color: $ui-off-white;
     width: 100%;


### PR DESCRIPTION
Cerra #7065

**FIX**
- Indicates multiple users is hoverable with grey font on host details page and device user details page

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
