### PR TITLE
Fix Content-Type used for login request

### DIFF
--- a/frontend/services/entities/sessions.ts
+++ b/frontend/services/entities/sessions.ts
@@ -11,18 +11,16 @@ export default {
   create: ({ email, password }: ICreateSessionProps) => {
     const { LOGIN } = endpoints;
 
-    return sendRequest("POST", LOGIN, { email, password }).then(
-      (response) => {
-        const { user, available_teams } = response;
-        const userWithGravatarUrl = helpers.addGravatarUrlToResource(user);
+    return sendRequest("POST", LOGIN, { email, password }).then((response) => {
+      const { user, available_teams } = response;
+      const userWithGravatarUrl = helpers.addGravatarUrlToResource(user);
 
-        return {
-          ...response,
-          user: userWithGravatarUrl,
-          available_teams,
-        };
-      }
-    );
+      return {
+        ...response,
+        user: userWithGravatarUrl,
+        available_teams,
+      };
+    });
   },
   destroy: () => {
     const { LOGOUT } = endpoints;

--- a/frontend/services/entities/sessions.ts
+++ b/frontend/services/entities/sessions.ts
@@ -11,7 +11,7 @@ export default {
   create: ({ email, password }: ICreateSessionProps) => {
     const { LOGIN } = endpoints;
 
-    return sendRequest("POST", LOGIN, JSON.stringify({ email, password })).then(
+    return sendRequest("POST", LOGIN, { email, password }).then(
       (response) => {
         const { user, available_teams } = response;
         const userWithGravatarUrl = helpers.addGravatarUrlToResource(user);


### PR DESCRIPTION
`Content-Type` ends up being `application/x-www-form-urlencoded` as axios is receiving a string and not an object.

This change follows what is found in tests and other code locations.

# Checklist for submitter

- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
