### PR TITLE
fix the vertical alignment of the host count in software table at smaller screen sizes

### DIFF
--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -218,6 +218,7 @@
                 width: auto;
                 .hosts-cell__wrapper {
                   display: flex;
+                  align-items: center;
                   justify-content: space-between;
                   .hosts-cell__link {
                     display: flex;


### PR DESCRIPTION
relates to #7659

Quick fix to fix vertical alignment of host count on software page table