### PR TITLE
Remove errors tooltips from Fleet Desktop menu

### DIFF
--- a/orbit/changes/remove-desktop-errors-tooltip
+++ b/orbit/changes/remove-desktop-errors-tooltip
@@ -1,0 +1,1 @@
+* Stop rendering errors as tooltips in Fleet Desktop. Errors can now be found in the Fleet Desktop logs.

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -49,7 +49,7 @@ func main() {
 		log.Info().Msg("ready")
 
 		systray.SetTemplateIcon(icoBytes, icoBytes)
-		systray.SetTooltip("Fleet Device Management Menu.")
+		systray.SetTooltip("Fleet Desktop")
 
 		// Add a disabled menu item with the current version
 		versionItem := systray.AddMenuItem(fmt.Sprintf("Fleet Desktop v%s", version), "")
@@ -88,13 +88,10 @@ func main() {
 					if err == nil || errors.Is(err, service.ErrMissingLicense) {
 						myDeviceItem.SetTitle("My device")
 						myDeviceItem.Enable()
-						myDeviceItem.SetTooltip("")
 						transparencyItem.Enable()
 						return
 					}
 
-					// To ease troubleshooting we set the tooltip as the error.
-					myDeviceItem.SetTooltip(err.Error())
 					log.Error().Err(err).Msg("get device URL")
 
 					<-ticker.C
@@ -120,8 +117,6 @@ func main() {
 					myDeviceItem.SetTitle("My device")
 					continue
 				default:
-					// To ease troubleshooting we set the tooltip as the error.
-					myDeviceItem.SetTooltip(err.Error())
 					log.Error().Err(err).Msg("get device URL")
 					continue
 				}


### PR DESCRIPTION
Now that these errors are available in log files, we think this adds more confusion for end users.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
~- [ ] Added/updated tests~
~- [ ] Manual QA for all new/changed functionality~ (I think we can get away without manual QA due to small size)
