### PR TITLE
#7624 accept empty bearer authorization token.

### DIFF
--- a/changes/bug-7624-sso-login-button-not-working
+++ b/changes/bug-7624-sso-login-button-not-working
@@ -1,0 +1,1 @@
+- Fix Single Sign On button not working after a failed authorization attempt.

--- a/server/contexts/token/token.go
+++ b/server/contexts/token/token.go
@@ -20,14 +20,17 @@ type Token string
 func FromHTTPRequest(r *http.Request) Token {
 	headers := r.Header.Get("Authorization")
 	headerParts := strings.Split(headers, " ")
-	if len(headerParts) != 2 || strings.ToUpper(headerParts[0]) != "BEARER" {
-		if err := r.ParseForm(); err != nil {
-			return ""
+	if len(headerParts) > 0 && strings.ToUpper(headerParts[0]) == "BEARER" {
+		if len(headerParts) == 2 {
+			return Token(headerParts[1])
 		}
-
-		return Token(r.FormValue("token"))
+		// This indicates "no token". We don't want to read the request-body here.
+		return ""
 	}
-	return Token(headerParts[1])
+	if err := r.ParseForm(); err != nil {
+		return ""
+	}
+	return Token(r.FormValue("token"))
 }
 
 // NewContext returns a new context carrying the Authorization Bearer token.

--- a/server/contexts/token/token_test.go
+++ b/server/contexts/token/token_test.go
@@ -1,0 +1,70 @@
+package token
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestFromHTTPRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		r    *http.Request
+		want Token
+	}{
+		{
+			name: "no auth",
+			want: "",
+			r:    &http.Request{},
+		}, {
+			name: "empty auth",
+			r: &http.Request{
+				Header: map[string][]string{
+					"Authorization": {""},
+				},
+			},
+			want: "",
+		}, {
+			name: "BEARER no data",
+			r: &http.Request{
+				Header: map[string][]string{
+					"Authorization": {"BEARER"},
+					"Content-Type":  {"application/x-www-form-urlencoded"},
+				},
+				Method: http.MethodPost,
+				Body:   io.NopCloser(strings.NewReader("token=bar")),
+			},
+			want: "",
+		}, {
+			name: "BEARER foobar",
+			r: &http.Request{
+				Header: map[string][]string{
+					"Authorization": {"BEARER foobar"},
+					"Content-Type":  {"application/x-www-form-urlencoded"},
+				},
+				Method: http.MethodPost,
+				Body:   io.NopCloser(strings.NewReader("token=bar")),
+			},
+			want: "foobar",
+		}, {
+			name: "from body",
+			r: &http.Request{
+				Header: map[string][]string{
+					"Authorization": {"FOOBAR foobar"},
+					"Content-Type":  {"application/x-www-form-urlencoded"},
+				},
+				Method: http.MethodPost,
+				Body:   io.NopCloser(strings.NewReader("token=bar")),
+			},
+			want: "bar",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FromHTTPRequest(tt.r); got != tt.want {
+				t.Errorf("FromHTTPRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix the SSO button being defunct after a failed login attempt. This happened, because the frontend sends an empty Authorisation token to the backend ("BEARER" instead of "BEARER foobar"). In this case the request body was consumed by the ParseForm() function and the real endpoint received an empty body.

The PR accepts this string as an empty/missing token.

- [X] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
