### PR TITLE
Disable dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,8 +58,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    # Disable version updates
-    open-pull-requests-limit: 0
     reviewers:
       - lucasmrod
     pull-request-branch-name:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,8 @@ updates:
       - "website"
     schedule:
       interval: "daily"
+    # Disable version updates
+    open-pull-requests-limit: 0
     allow:
       - dependency-type: "production"
     reviewers:
@@ -56,6 +58,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Disable version updates
+    open-pull-requests-limit: 0
     reviewers:
       - lucasmrod
     pull-request-branch-name:
@@ -71,6 +75,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Disable version updates
+    open-pull-requests-limit: 0
     reviewers:
       - lukeheath
     allow:


### PR DESCRIPTION
This PR disables dependabot version PRs for `npm` dependencies. Because we use no many `npm` dependencies and patch releases are very frequent, we're getting more PRs than we can handle. This will limit the PRs to security vulnerabilities only.