### PR TITLE
Bug 6717: Duplicate calls on vulnerability third party integrations.

### DIFF
--- a/changes/bug-6717-duplicate-calls-third-party-integrations
+++ b/changes/bug-6717-duplicate-calls-third-party-integrations
@@ -1,0 +1,2 @@
+* If the same vulnerability was detected in more than one Software, duplicate calls were being
+issued to third party integrations.

--- a/cmd/fleet/cron_test.go
+++ b/cmd/fleet/cron_test.go
@@ -40,6 +40,7 @@ func TestFilterRecentVulns(t *testing.T) {
 		ovalVulns := []fleet.SoftwareVulnerability{
 			{CVE: "cve-recent-1"},
 			{CVE: "cve-recent-2"},
+			{CVE: "cve-recent-2"},
 			{CVE: "cve-outdated-1"},
 		}
 
@@ -70,6 +71,7 @@ func TestFilterRecentVulns(t *testing.T) {
 			"cve-recent-3": {CVE: "cve-recent-3"},
 		}
 
+		require.Equal(t, len(expected), len(actual))
 		require.ElementsMatch(t, expected, actual)
 		require.Equal(t, expectedMeta, meta)
 	})

--- a/ee/server/webhooks/mapper.go
+++ b/ee/server/webhooks/mapper.go
@@ -18,12 +18,12 @@ func NewMapper() fleetwebhooks.VulnMapper {
 func (m *Mapper) GetPayload(
 	hostBaseURL *url.URL,
 	hosts []*fleet.HostShort,
-	vuln fleet.SoftwareVulnerability,
+	cve string,
 	meta fleet.CVEMeta,
 ) fleetwebhooks.WebhookPayload {
 	r := m.Mapper.GetPayload(hostBaseURL,
 		hosts,
-		vuln,
+		cve,
 		meta,
 	)
 	r.EPSSProbability = meta.EPSSProbability

--- a/ee/server/webhooks/mapper_test.go
+++ b/ee/server/webhooks/mapper_test.go
@@ -26,7 +26,7 @@ func TestGetPayload(t *testing.T) {
 
 	sut := Mapper{}
 
-	result := sut.GetPayload(serverURL, nil, vuln, meta)
+	result := sut.GetPayload(serverURL, nil, vuln.CVE, meta)
 	require.Equal(t, *meta.CISAKnownExploit, *result.CISAKnownExploit)
 	require.Equal(t, *meta.EPSSProbability, *result.EPSSProbability)
 	require.Equal(t, *meta.CVSSScore, *result.CVSSScore)

--- a/server/webhooks/mapper.go
+++ b/server/webhooks/mapper.go
@@ -12,7 +12,7 @@ import (
 // VulnMapper used for mapping vulnerabilities and their associated data into the payload that
 // will be sent via thrid party webhooks.
 type VulnMapper interface {
-	GetPayload(*url.URL, []*fleet.HostShort, fleet.SoftwareVulnerability, fleet.CVEMeta) WebhookPayload
+	GetPayload(*url.URL, []*fleet.HostShort, string, fleet.CVEMeta) WebhookPayload
 }
 
 type hostPayloadPart struct {
@@ -56,12 +56,12 @@ func (m *Mapper) getHostPayloadPart(
 func (m *Mapper) GetPayload(
 	hostBaseURL *url.URL,
 	hosts []*fleet.HostShort,
-	vuln fleet.SoftwareVulnerability,
+	cve string,
 	meta fleet.CVEMeta,
 ) WebhookPayload {
 	return WebhookPayload{
-		CVE:   vuln.CVE,
-		Link:  fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", vuln.CVE),
+		CVE:   cve,
+		Link:  fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", cve),
 		Hosts: m.getHostPayloadPart(hostBaseURL, hosts),
 	}
 }

--- a/server/webhooks/mapper_test.go
+++ b/server/webhooks/mapper_test.go
@@ -26,7 +26,7 @@ func TestGetPaylaod(t *testing.T) {
 
 	sut := Mapper{}
 
-	result := sut.GetPayload(serverURL, nil, vuln, meta)
+	result := sut.GetPayload(serverURL, nil, vuln.CVE, meta)
 	require.Empty(t, result.CISAKnownExploit)
 	require.Empty(t, result.EPSSProbability)
 	require.Empty(t, result.CVSSScore)

--- a/server/webhooks/vulnerabilities.go
+++ b/server/webhooks/vulnerabilities.go
@@ -44,7 +44,7 @@ func TriggerVulnerabilitiesWebhook(
 	for cve, sIDs := range groups {
 		hosts, err := ds.HostsBySoftwareIDs(ctx, sIDs)
 		if err != nil {
-			return ctxerr.Wrap(ctx, err, "get hosts by software id")
+			return ctxerr.Wrap(ctx, err, "get hosts by software ids")
 		}
 
 		for len(hosts) > 0 {

--- a/server/webhooks/vulnerabilities_test.go
+++ b/server/webhooks/vulnerabilities_test.go
@@ -117,7 +117,7 @@ func TestTriggerVulnerabilitiesWebhook(t *testing.T) {
 			},
 			{
 				"1 vuln in multiple software, 1 host",
-				[]fleet.SoftwareVulnerability{{CVE: cves[0], SoftwareID: 1}, {CVE: cves[0], SoftwareID: 2}},
+				[]fleet.SoftwareVulnerability{{CVE: cves[0], SoftwareID: 1}, {CVE: cves[0], SoftwareID: 1}, {CVE: cves[0], SoftwareID: 2}},
 				nil,
 				hosts[:1],
 				fmt.Sprintf("%s[%s]}}", jsonCVE1, jsonH1),

--- a/server/webhooks/vulnerabilities_test.go
+++ b/server/webhooks/vulnerabilities_test.go
@@ -116,6 +116,13 @@ func TestTriggerVulnerabilitiesWebhook(t *testing.T) {
 				fmt.Sprintf("%s[%s]}}", jsonCVE1, jsonH1),
 			},
 			{
+				"1 vuln in multiple software, 1 host",
+				[]fleet.SoftwareVulnerability{{CVE: cves[0], SoftwareID: 1}, {CVE: cves[0], SoftwareID: 2}},
+				nil,
+				hosts[:1],
+				fmt.Sprintf("%s[%s]}}", jsonCVE1, jsonH1),
+			},
+			{
 				"1 vuln, 2 hosts",
 				[]fleet.SoftwareVulnerability{{CVE: cves[0], SoftwareID: 1}},
 				nil,

--- a/server/worker/zendesk_test.go
+++ b/server/worker/zendesk_test.go
@@ -122,6 +122,32 @@ func TestZendeskQueueVulnJobs(t *testing.T) {
 	ctx := context.Background()
 	logger := kitlog.NewNopLogger()
 
+	t.Run("same vulnerability on multiple software only queue one job", func(t *testing.T) {
+		var count int
+		ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
+			count++
+			return job, nil
+		}
+		vulns := []fleet.SoftwareVulnerability{{
+			CVE:        "CVE-1234-5678",
+			SoftwareID: 1,
+		}, {
+			CVE:        "CVE-1234-5678",
+			SoftwareID: 2,
+		}, {
+			CVE:        "CVE-1234-5678",
+			SoftwareID: 2,
+		}, {
+			CVE:        "CVE-1234-5678",
+			SoftwareID: 3,
+		}}
+
+		err := QueueZendeskVulnJobs(ctx, ds, logger, vulns)
+		require.NoError(t, err)
+		require.True(t, ds.NewJobFuncInvoked)
+		require.Equal(t, 1, count)
+	})
+
 	t.Run("success", func(t *testing.T) {
 		ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
 			return job, nil


### PR DESCRIPTION
#6717 

If the same vulnerability was present in more than one software, then duplicated third party integration calls were being issued.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
