### PR TITLE
Bug 7682: Fixed issue with migration not running on MariaDB

### DIFF
--- a/changes/bug-7682-bug-migration-maria-db
+++ b/changes/bug-7682-bug-migration-maria-db
@@ -1,0 +1,1 @@
+* Under MariaDB the FK from software_cve to software_cpe has a different name which was causing the migration to fail.

--- a/server/datastore/mysql/migrations/tables/migration.go
+++ b/server/datastore/mysql/migrations/tables/migration.go
@@ -11,6 +11,22 @@ import (
 
 var MigrationClient = goose.New("migration_status_tables", goose.MySqlDialect{})
 
+func fkExists(tx *sql.Tx, table, name string) bool {
+	var count int
+	err := tx.QueryRow(`
+SELECT COUNT(1)
+FROM information_schema.REFERENTIAL_CONSTRAINTS
+WHERE CONSTRAINT_SCHEMA = DATABASE() 
+AND TABLE_NAME = ?
+AND CONSTRAINT_NAME = ? 
+	`, table, name).Scan(&count)
+	if err != nil {
+		return false
+	}
+
+	return count > 0
+}
+
 func columnExists(tx *sql.Tx, table, column string) bool {
 	var count int
 	err := tx.QueryRow(


### PR DESCRIPTION
#7682 

Under MariaDB the FK from software_cve to software_cpe has a different name which was causing the migration to fail.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
~- [ ] Documented any permissions changes~
- [x] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
~- [ ] Added/updated tests~
- [x] Manual QA for all new/changed functionality
