### PR TITLE
Remove unnecessary JSON.stringify from axios requests

### DIFF
--- a/frontend/services/entities/queries.ts
+++ b/frontend/services/entities/queries.ts
@@ -66,6 +66,6 @@ export default {
     const { QUERIES } = endpoints;
     const path = `${QUERIES}/${id}`;
 
-    return sendRequest("PATCH", path, JSON.stringify(updateParams));
+    return sendRequest("PATCH", path, updateParams);
   },
 };

--- a/frontend/services/entities/sessions.ts
+++ b/frontend/services/entities/sessions.ts
@@ -28,7 +28,7 @@ export default {
   },
   initializeSSO: (relay_url: string) => {
     const { SSO } = endpoints;
-    return sendRequest("POST", SSO, JSON.stringify({ relay_url }));
+    return sendRequest("POST", SSO, { relay_url });
   },
   ssoSettings: () => {
     const { SSO } = endpoints;


### PR DESCRIPTION
Community PR https://github.com/fleetdm/fleet/pull/7658 highlighted that `JSON.stringify()` is being applied unnecessarily to some request payloads. This PR removes the two instances not covered by #7658.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
