### PR TITLE
Fix deprecated virtual runner and golangci-lint deprecated checkers

### DIFF
--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # Doesn't work on Windows because Linux Docker containers are not supported.
-        os: [ubuntu-20.04, ubuntu-18.04, macos-11, macos-12]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 linters:
   disable-all: true
   enable:
-    - deadcode
     - depguard
     - gosec
     - gocritic
@@ -11,7 +10,6 @@ linters:
     - revive
     - rowserrcheck
     - sqlclosecheck
-    - structcheck
     - typecheck
     - unconvert
     - unused

--- a/tools/file-server/main.go
+++ b/tools/file-server/main.go
@@ -8,6 +8,7 @@ import (
 func main() {
 	fs := http.FileServer(http.FS(os.DirFS(os.Args[2])))
 	http.Handle("/", fs)
+	//nolint:gosec // G114: file server used for testing purposes only.
 	err := http.ListenAndServe(":"+os.Args[1], nil)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Fixing the following two issues:
```
golangci-lint run --skip-dirs ./node_modules --timeout 10m

WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.

WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.

WARN [linters context] rowserrcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.

WARN [linters context] sqlclosecheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.

WARN [linters context] structcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.

tools/file-server/main.go:11:9: G114: Use of net/http serve function that has no support for setting timeouts (gosec)
        err := http.ListenAndServe(":"+os.Args[1], nil)
               ^
make: *** [lint-go] Error 1
```


```
The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002
```