### PR TITLE
Disable dependabot for go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # Disable version updates
+    open-pull-requests-limit: 0
     reviewers:
       - lucasmrod
     pull-request-branch-name:


### PR DESCRIPTION
Same reason as stated here: https://github.com/fleetdm/fleet/pull/7697