### PR TITLE
Frontend: Refactor reused code

### DIFF
--- a/cypress/integration/premium/teamflow.spec.ts
+++ b/cypress/integration/premium/teamflow.spec.ts
@@ -15,7 +15,9 @@ describe("Teams flow (empty)", () => {
     });
     it("creates a new team", () => {
       cy.getAttached(".no-teams").within(() => {
-        cy.contains("button", /create team/i).click();
+        cy.getAttached(".no-teams__inner-text").within(() => {
+          cy.contains("button", /create team/i).click();
+        });
       });
       cy.findByLabelText(/team name/i)
         .click()

--- a/frontend/pages/Homepage/Homepage.tsx
+++ b/frontend/pages/Homepage/Homepage.tsx
@@ -70,9 +70,7 @@ const Homepage = (): JSX.Element => {
   const [offlineCount, setOfflineCount] = useState(0);
   const [showActivityFeedTitle, setShowActivityFeedTitle] = useState(false);
   const [showSoftwareUI, setShowSoftwareUI] = useState(false);
-  const [showMunkiUI, setShowMunkiUI] = useState(false);
   const [showMunkiCard, setShowMunkiCard] = useState(true);
-  const [showMDMUI, setShowMDMUI] = useState(false);
   const [showAddHostsModal, setShowAddHostsModal] = useState(false);
   const [showOperatingSystemsUI, setShowOperatingSystemsUI] = useState(false);
   const [showHostsUI, setShowHostsUI] = useState(false); // Hides UI on first load only
@@ -228,10 +226,6 @@ const Homepage = (): JSX.Element => {
             whatToRetrieve={"Munki"}
           />
         );
-      },
-      onError: () => {
-        setShowMDMUI(true);
-        setShowMunkiUI(true);
       },
     }
   );

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -4,7 +4,6 @@ import { useErrorHandler } from "react-error-boundary";
 import { InjectedRouter, Link, RouteProps } from "react-router";
 import { Tab, TabList, Tabs } from "react-tabs";
 import { find, toNumber } from "lodash";
-import classnames from "classnames";
 
 import { NotificationContext } from "context/notification";
 import { AppContext } from "context/app";

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1571,8 +1571,6 @@ const ManageHostsPage = ({
             return renderLabelFilterPill();
           case !!policyId:
             return renderPoliciesFilterBlock();
-          case showSelectedLabel:
-            return renderLabelFilterPill();
           case !!softwareId:
             return renderSoftwareFilterBlock();
           case !!mdmId:

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -73,6 +73,7 @@ import {
   DEFAULT_SORT_DIRECTION,
   DEFAULT_PAGE_SIZE,
   HOST_SELECT_STATUSES,
+  omitParams,
 } from "./constants";
 import { isAcceptableStatus, getNextLocationPath } from "./helpers";
 import DeleteSecretModal from "../../../components/EnrollSecrets/DeleteSecretModal";
@@ -621,7 +622,7 @@ const ManageHostsPage = ({
     );
   };
 
-  const handleClearPoliciesFilter = () => {
+  const handleClearFilter = (omitParams: string[]) => {
     handleResetPageIndex();
 
     router.replace(
@@ -629,77 +630,33 @@ const ManageHostsPage = ({
         pathPrefix: PATHS.MANAGE_HOSTS,
         routeTemplate,
         routeParams,
-        queryParams: omit(queryParams, ["policy_id", "policy_response"]),
+        queryParams: omit(queryParams, omitParams),
       })
     );
+  };
+
+  const handleClearPoliciesFilter = () => {
+    handleClearFilter(["policy_id", "policy_response"]);
   };
 
   const handleClearOSFilter = () => {
-    handleResetPageIndex();
-
-    router.replace(
-      getNextLocationPath({
-        pathPrefix: PATHS.MANAGE_HOSTS,
-        routeTemplate,
-        routeParams,
-        queryParams: omit(queryParams, ["os_id", "os_name", "os_version"]),
-      })
-    );
+    handleClearFilter(["os_id", "os_name", "os_version"]);
   };
 
   const handleClearSoftwareFilter = () => {
-    handleResetPageIndex();
-
-    router.replace(
-      getNextLocationPath({
-        pathPrefix: PATHS.MANAGE_HOSTS,
-        routeTemplate,
-        routeParams,
-        queryParams: omit(queryParams, ["software_id"]),
-      })
-    );
-    setSoftwareDetails(null);
+    handleClearFilter(["software_id"]);
   };
 
   const handleClearMDMSolutionFilter = () => {
-    handleResetPageIndex();
-
-    router.replace(
-      getNextLocationPath({
-        pathPrefix: PATHS.MANAGE_HOSTS,
-        routeTemplate,
-        routeParams,
-        queryParams: omit(queryParams, ["mdm_id"]),
-      })
-    );
-    setMDMSolutionDetails(null);
+    handleClearFilter(["mdm_id"]);
   };
 
   const handleClearMDMEnrollmentFilter = () => {
-    handleResetPageIndex();
-
-    router.replace(
-      getNextLocationPath({
-        pathPrefix: PATHS.MANAGE_HOSTS,
-        routeTemplate,
-        routeParams,
-        queryParams: omit(queryParams, ["mdm_enrollment_status"]),
-      })
-    );
+    handleClearFilter(["mdm_enrollment_status"]);
   };
 
   const handleClearMunkiIssueFilter = () => {
-    handleResetPageIndex();
-
-    router.replace(
-      getNextLocationPath({
-        pathPrefix: PATHS.MANAGE_HOSTS,
-        routeTemplate,
-        routeParams,
-        queryParams: omit(queryParams, ["munki_issue_id"]),
-      })
-    );
-    setMunkiIssueDetails(null);
+    handleClearFilter(["munki_issue_id"]);
   };
 
   const handleTeamSelect = (teamId: number) => {

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -73,7 +73,6 @@ import {
   DEFAULT_SORT_DIRECTION,
   DEFAULT_PAGE_SIZE,
   HOST_SELECT_STATUSES,
-  omitParams,
 } from "./constants";
 import { isAcceptableStatus, getNextLocationPath } from "./helpers";
 import DeleteSecretModal from "../../../components/EnrollSecrets/DeleteSecretModal";

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1597,7 +1597,9 @@ const ManageHostsPage = ({
       selectedLabel &&
       selectedLabel.type !== "all" &&
       selectedLabel.type !== "status";
+
     if (
+      showSelectedLabel ||
       policyId ||
       softwareId ||
       showSelectedLabel ||
@@ -1607,56 +1609,35 @@ const ManageHostsPage = ({
       (osName && osVersion) ||
       munkiIssueId
     ) {
+      const renderFilterPill = () => {
+        switch (true) {
+          case showSelectedLabel:
+            return renderLabelFilterPill();
+          case !!policyId:
+            return renderPoliciesFilterBlock();
+          case showSelectedLabel:
+            return renderLabelFilterPill();
+          case !!softwareId:
+            return renderSoftwareFilterBlock();
+          case !!mdmId:
+            return renderMDMSolutionFilterBlock();
+          case !!mdmEnrollmentStatus:
+            return renderMDMEnrollmentFilterBlock();
+          case !!osId || (!!osName && !!osVersion):
+            return renderOSFilterBlock();
+          case !!munkiIssueId:
+            return renderMunkiIssueFilterBlock();
+          default:
+            return null;
+        }
+      };
+
       return (
         <div className={`${baseClass}__labels-active-filter-wrap`}>
-          {showSelectedLabel && renderLabelFilterPill()}
-          {!!policyId &&
-            !softwareId &&
-            !mdmId &&
-            !mdmEnrollmentStatus &&
-            !munkiIssueId &&
-            !showSelectedLabel &&
-            renderPoliciesFilterBlock()}
-          {!!softwareId &&
-            !policyId &&
-            !mdmId &&
-            !mdmEnrollmentStatus &&
-            !munkiIssueId &&
-            !showSelectedLabel &&
-            renderSoftwareFilterBlock()}
-          {!!mdmId &&
-            !policyId &&
-            !softwareId &&
-            !mdmEnrollmentStatus &&
-            !munkiIssueId &&
-            !showSelectedLabel &&
-            renderMDMSolutionFilterBlock()}
-          {!!mdmEnrollmentStatus &&
-            !policyId &&
-            !softwareId &&
-            !mdmId &&
-            !munkiIssueId &&
-            !showSelectedLabel &&
-            renderMDMEnrollmentFilterBlock()}
-          {(!!osId || (!!osName && !!osVersion)) &&
-            !policyId &&
-            !softwareId &&
-            !showSelectedLabel &&
-            !mdmId &&
-            !mdmEnrollmentStatus &&
-            !munkiIssueId &&
-            renderOSFilterBlock()}
-          {!!munkiIssueId &&
-            !policyId &&
-            !softwareId &&
-            !showSelectedLabel &&
-            !mdmId &&
-            !mdmEnrollmentStatus &&
-            renderMunkiIssueFilterBlock()}
+          {renderFilterPill()}
         </div>
       );
     }
-    return null;
   };
 
   const renderCustomControls = () => {

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -426,11 +426,9 @@ const HostDetailsPage = ({
   };
 
   const onLabelClick = (label: ILabel) => {
-    if (label.name === "All Hosts") {
-      return router.push(PATHS.MANAGE_HOSTS);
-    }
-
-    return router.push(`${PATHS.MANAGE_HOSTS}/labels/${label.id}`);
+    return label.name === "All Hosts"
+      ? router.push(PATHS.MANAGE_HOSTS)
+      : router.push(PATHS.MANAGE_HOSTS_LABEL(label.id));
   };
 
   const onQueryHostCustom = () => {


### PR DESCRIPTION

#7794 

**Tech debt cleaning up ManageHostsPage.tsx**
- Remove 2 unused states
- Create and reuse a handleClearFilter function to clear 5 filters
- Use switch case to render mutually exclusive filter pills
- Clean up route path code

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
