### PR TITLE
Fleet frontend: Modal and modal button cleanup

### DIFF
--- a/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/Homepage/cards/WelcomeHost/WelcomeHost.tsx
@@ -303,7 +303,7 @@ const WelcomeHost = ({
                   <b>Resolve:</b> {currentPolicyShown.resolution}
                 </p>
               )}
-              <div className="done">
+              <div className="modal-cta-wrap">
                 <Button
                   variant="brand"
                   onClick={() => setShowPolicyModal(false)}

--- a/frontend/pages/Homepage/cards/WelcomeHost/_styles.scss
+++ b/frontend/pages/Homepage/cards/WelcomeHost/_styles.scss
@@ -157,11 +157,4 @@
       font-size: $x-small;
     }
   }
-  &__policy-modal {
-    .done {
-      margin-top: $pad-large;
-      display: flex;
-      justify-content: flex-end;
-    }
-  }
 }

--- a/frontend/pages/admin/AppSettingsPage/cards/HostStatusWebhook/HostStatusWebhook.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/HostStatusWebhook/HostStatusWebhook.tsx
@@ -124,7 +124,7 @@ const HostStatusWebhook = ({
               }}
             />
           </div>
-          <div className="flex-end">
+          <div className="modal-cta-wrap">
             <Button type="button" onClick={toggleHostStatusWebhookPreviewModal}>
               Done
             </Button>

--- a/frontend/pages/admin/AppSettingsPage/cards/Statistics/Statistics.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/Statistics/Statistics.tsx
@@ -71,7 +71,7 @@ const Statistics = ({
               __html: syntaxHighlight(usageStatsPreview),
             }}
           />
-          <div className="flex-end">
+          <div className="modal-cta-wrap">
             <Button type="button" onClick={toggleUsageStatsPreviewModal}>
               Done
             </Button>

--- a/frontend/pages/hosts/details/DeviceUserPage/InfoModal/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/InfoModal/_styles.scss
@@ -1,9 +1,0 @@
-.device-user-info {
-  &__modal {
-    @include position(absolute, 22px null null null);
-    background-color: $core-white;
-    width: 658px;
-    padding: $pad-xxlarge;
-    border-radius: $pad-small;
-  }
-}

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/DeleteHostModal/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/DeleteHostModal/_styles.scss
@@ -1,9 +1,0 @@
-.delete-host-modal {
-  &__modal {
-    @include position(absolute, 22px null null null);
-    background-color: $core-white;
-    width: 658px;
-    padding: $pad-xxlarge;
-    border-radius: $pad-small;
-  }
-}

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/OSPolicyModal/OSPolicyModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/OSPolicyModal/OSPolicyModal.tsx
@@ -21,7 +21,7 @@ interface IRenderOSPolicyModal {
   osPolicyLabel: string;
 }
 
-const baseClass = "render-os-policy-modal";
+const baseClass = "os-policy-modal";
 
 const RenderOSPolicyModal = ({
   onCancel,
@@ -70,11 +70,7 @@ const RenderOSPolicyModal = ({
   };
 
   return (
-    <Modal
-      title="Operating system"
-      onExit={onCancel}
-      className={`${baseClass}__modal`}
-    >
+    <Modal title="Operating system" onExit={onCancel} className={baseClass}>
       <>
         <p>
           <span className={`${baseClass}__os-modal-title`}>
@@ -98,11 +94,11 @@ const RenderOSPolicyModal = ({
           value={osPolicy}
         />
         <div className="modal-cta-wrap">
-          <Button onClick={onCancel} variant="inverse">
-            Close
-          </Button>
           <Button onClick={onCreateNewPolicy} variant="brand">
             Create new policy
+          </Button>
+          <Button onClick={onCancel} variant="inverse">
+            Close
           </Button>
         </div>
       </>

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/OSPolicyModal/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/OSPolicyModal/_styles.scss
@@ -1,12 +1,4 @@
-.render-os-policy-modal {
-  &__modal {
-    @include position(absolute, 22px null null null);
-    background-color: $core-white;
-    width: 658px;
-    padding: $pad-xxlarge;
-    border-radius: $pad-small;
-  }
-
+.os-policy-modal {
   &__os-modal-title {
     padding-right: $pad-medium;
     font-size: $medium;

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/SelectQueryModal/SelectQueryModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/SelectQueryModal/SelectQueryModal.tsx
@@ -93,7 +93,9 @@ const SelectQueryModal = ({
             Expecting to see queries? Try again in a few seconds as the system
             catches up.
           </span>
-          {!isOnlyObserver && customQueryButton()}
+          <div className="modal-cta-wrap">
+            {!isOnlyObserver && customQueryButton()}
+          </div>
         </div>
       );
     }

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/SelectQueryModal/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/SelectQueryModal/_styles.scss
@@ -1,12 +1,4 @@
 .select-query-modal {
-  &__modal {
-    @include position(absolute, 22px null null null);
-    background-color: $core-white;
-    width: 658px;
-    padding: $pad-xxlarge;
-    border-radius: $pad-small;
-  }
-
   &__no-queries {
     .info {
       &__header {

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/TransferHostModal/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/TransferHostModal/_styles.scss
@@ -1,9 +1,0 @@
-.transfer-host-modal {
-  &__modal {
-    @include position(absolute, 22px null null null);
-    background-color: $core-white;
-    width: 658px;
-    padding: $pad-xxlarge;
-    border-radius: $pad-small;
-  }
-}

--- a/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/_styles.scss
@@ -1,10 +1,4 @@
 .add-policy-modal {
-  @include position(absolute, 22px null null null);
-  background-color: $core-white;
-  width: 658px;
-  padding: $pad-xxlarge;
-  border-radius: $pad-small;
-
   &__policy-selection {
     padding: $pad-large 0;
   }


### PR DESCRIPTION
**Clean up**
- Remove old modal styling CSS off several components as styling now lives on the `<Modal />` component
- Clean up 2 modal's cta buttons to be styled by global class `modal-cta-wrap` instead

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
