### PR TITLE
Update code links and tip blockquote styles

### DIFF
--- a/website/assets/styles/pages/articles/basic-article.less
+++ b/website/assets/styles/pages/articles/basic-article.less
@@ -120,7 +120,11 @@
     [purpose='checklist-item']::marker {
       display: none;
     }
-    code:not(.nohighlight):not(.mermaid) {
+    a > code:not(.hljs):not(.nohighlight):not(.mermaid) {
+      color: inherit;
+      text-decoration: inherit;
+    }
+    code:not(.bash):not(.nohighlight):not(.mermaid) {
       background: #F1F0FF;
       padding: 4px 8px;
       font-family: @code-font;
@@ -188,7 +192,7 @@
       border: 1px solid @core-vibrant-blue-50;
       padding: 16px;
       border-radius: 8px;
-      display: inline-flex;
+      display: flex;
       img {
         display: flex;
         margin: 4px 12px 0 0;
@@ -198,9 +202,18 @@
       }
       p {
         display: block;
-        margin-bottom: 0px;
+        margin-bottom: 16px;
         line-height: 24px;
         font-size: 16px;
+      }
+      p:only-child, p:last-child {
+        margin-bottom: 0px;
+      }
+      ul:last-child {
+        margin-bottom: 0px;
+      }
+      li:last-child {
+        padding-bottom: 0px;
       }
     }
     [purpose='embedded-content'] {

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -513,7 +513,7 @@
         border: 1px solid @core-vibrant-blue-50;
         padding: 16px;
         border-radius: 8px;
-        display: inline-flex;
+        display: flex;
         img {
           display: flex;
           margin: 4px 12px 0 0;
@@ -523,9 +523,18 @@
         }
         p {
           display: block;
-          margin-bottom: 0px;
+          margin-bottom: 16px;
           line-height: 24px;
           font-size: 16px;
+        }
+        p:last-child {
+          margin-bottom: 0px;
+        }
+        ul:last-child {
+          margin-bottom: 0px;
+        }
+        li:last-child {
+          padding-bottom: 0px;
         }
       }
 

--- a/website/assets/styles/pages/docs/code-blocks.less
+++ b/website/assets/styles/pages/docs/code-blocks.less
@@ -1,5 +1,9 @@
 // lesshint-disable spaceAroundComma, trailingWhitespace
 
+  a > code:not(.hljs):not(.nohighlight):not(.mermaid) {
+    color: inherit;
+    text-decoration: inherit;
+  }
   code:not(.hljs):not(.nohighlight):not(.mermaid) {
     background-color: @ui-off-white;
     border: 1px solid @border-lt-gray;

--- a/website/assets/styles/pages/handbook/basic-handbook.less
+++ b/website/assets/styles/pages/handbook/basic-handbook.less
@@ -203,6 +203,10 @@
       padding: 24px 16px;
       margin: auto;
     }
+    a > code:not(.hljs):not(.nohighlight):not(.mermaid) {
+      color: inherit;
+      text-decoration: inherit;
+    }
     code:not(.nohighlight):not(.mermaid) {
       background-color: @ui-off-white;
       border: 1px solid @border-lt-gray;
@@ -286,7 +290,7 @@
       border: 1px solid @core-vibrant-blue-50;
       padding: 16px;
       border-radius: 8px;
-      display: inline-flex;
+      display: flex;
       img {
         display: flex;
         margin: 4px 12px 0 0;
@@ -296,9 +300,18 @@
       }
       p {
         display: block;
-        margin-bottom: 0px;
+        margin-bottom: 16px;
         line-height: 24px;
         font-size: 16px;
+      }
+      p:last-child {
+        margin-bottom: 0px;
+      }
+      ul:last-child {
+        margin-bottom: 0px;
+      }
+      li:last-child {
+        padding-bottom: 0px;
       }
     }
     [purpose='checklist-item'] {


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/7432
Changes:
- Updated the styles for tip blockquotes on handbook, article, and docs pages
- Updated the styles for `<code>` elements wrapped in `<a>` tags on handbook, article, and docs pages