### PR TITLE
Fleet UI: Fix styling on query modal buttons

### DIFF
--- a/changes/bug-7757-select-query-styling
+++ b/changes/bug-7757-select-query-styling
@@ -1,0 +1,1 @@
+- Fix styling of select a query modal on the host details page

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -52,6 +52,16 @@ $base-class: "button";
     outline: none;
   }
 
+  .transparent-text {
+    opacity: 0;
+  }
+
+  .children-wrapper {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
   &--brand {
     @include button-variant(
       $core-vibrant-blue,
@@ -324,21 +334,32 @@ $base-class: "button";
       background-color: $ui-vibrant-blue-10;
       box-shadow: none;
     }
+
+    .children-wrapper {
+      display: flex;
+      width: 100%;
+      flex-direction: column;
+
+      .info {
+        &__header {
+          display: block;
+          width: 100%;
+          text-align: left;
+        }
+        &__data {
+          display: block;
+          width: 100%;
+          font-weight: normal;
+          text-align: left;
+          margin-top: 10px;
+        }
+      }
+    }
   }
 
   &--contextual-nav-item {
     @include button-variant(transparent, $ui-vibrant-blue-10);
     display: flex;
     justify-content: space-between;
-  }
-
-  .transparent-text {
-    opacity: 0;
-  }
-
-  .children-wrapper {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
   }
 }

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/SelectQueryModal/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/SelectQueryModal/_styles.scss
@@ -5,27 +5,6 @@
     width: 658px;
     padding: $pad-xxlarge;
     border-radius: $pad-small;
-
-    .info {
-      display: flex;
-      flex-direction: column;
-
-      &__header {
-        display: block;
-        color: $core-fleet-black;
-        font-weight: $bold;
-        font-size: $x-small;
-        text-align: left;
-      }
-      &__data {
-        display: block;
-        color: $core-fleet-black;
-        font-weight: normal;
-        font-size: $x-small;
-        text-align: left;
-        margin-top: 10px;
-      }
-    }
   }
 
   &__no-queries {
@@ -72,6 +51,8 @@
   }
 
   &__create-query {
+    display: flex;
+
     span {
       margin: 15px;
       font-weight: bold;

--- a/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/_styles.scss
@@ -7,24 +7,5 @@
 
   &__policy-selection {
     padding: $pad-large 0;
-
-    .children-wrapper {
-      display: block;
-    }
-
-    .info {
-      display: flex;
-
-      &__header {
-        display: block;
-        text-align: left;
-      }
-      &__data {
-        display: block;
-        font-weight: normal;
-        text-align: left;
-        margin-top: 10px;
-      }
-    }
   }
 }


### PR DESCRIPTION
Cerra #7757 

Add policy modal was fixed before release, Select query modal was not

**FIX**
- Fix styling of query picker buttons in Select query modal
- Styles applied to `<Button variant="unstyled-query-modal" />`

<img width="879" alt="Screen Shot 2022-09-14 at 10 40 24 AM" src="https://user-images.githubusercontent.com/71795832/190186109-4f4cd41f-3123-4b77-9e73-b4e54f0cc7d6.png">
<img width="847" alt="Screen Shot 2022-09-14 at 10 40 08 AM" src="https://user-images.githubusercontent.com/71795832/190186113-0fdecdde-7b63-420c-a2a6-759c23b73c55.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
