### PR TITLE
Fleet UI: Disable save host status without required dropdowns selected

### DIFF
--- a/changes/bug-7752-save-host-status-webhook
+++ b/changes/bug-7752-save-host-status-webhook
@@ -1,0 +1,1 @@
+* Users cannot save host status webhook without choosing required  percent of hosts and days count in the app settings page

--- a/frontend/pages/admin/AppSettingsPage/cards/HostStatusWebhook/HostStatusWebhook.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/HostStatusWebhook/HostStatusWebhook.tsx
@@ -57,8 +57,18 @@ const HostStatusWebhook = ({
   const validateForm = () => {
     const errors: IAppConfigFormErrors = {};
 
-    if (enableHostStatusWebhook && !hostStatusWebhookDestinationURL) {
-      errors.destination_url = "Destination URL must be present";
+    if (enableHostStatusWebhook) {
+      if (!hostStatusWebhookDestinationURL) {
+        errors.destination_url = "Destination URL must be present";
+      }
+
+      if (!hostStatusWebhookDaysCount) {
+        errors.days_count = "Number of days must be present";
+      }
+
+      if (!hostStatusWebhookDaysCount) {
+        errors.host_percentage = "Percentage of hosts must be present";
+      }
     }
 
     setFormErrors(errors);
@@ -180,6 +190,7 @@ const HostStatusWebhook = ({
               name="hostStatusWebhookHostPercentage"
               value={hostStatusWebhookHostPercentage}
               parseTarget
+              onBlur={validateForm}
               tooltip={
                 "\
                   <p>Select the minimum percentage of hosts that<br/>must fail to check into Fleet in order to trigger<br/>the webhook request.</p>\
@@ -195,6 +206,7 @@ const HostStatusWebhook = ({
               name="hostStatusWebhookDaysCount"
               value={hostStatusWebhookDaysCount}
               parseTarget
+              onBlur={validateForm}
               tooltip={
                 "\
                   <p>Select the minimum number of days that the<br/>configured <b>Percentage of hosts</b> must fail to<br/>check into Fleet in order to trigger the<br/>webhook request.</p>\

--- a/frontend/pages/admin/AppSettingsPage/cards/constants.ts
+++ b/frontend/pages/admin/AppSettingsPage/cards/constants.ts
@@ -28,6 +28,8 @@ export interface IAppConfigFormErrors {
   user_name?: string | null;
   password?: string | null;
   destination_url?: string | null;
+  days_count?: string | null;
+  host_percentage?: string | null;
   host_expiry_window?: string | null;
   agent_options?: string | null;
   transparency_url?: string | null;


### PR DESCRIPTION
Cerra #7752 

**Fix**
- When host status webhook is checked, disable save button when required dropdowns are not selected

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
