### PR TITLE
Website: Move docsearch public api key to config variable

### DIFF
--- a/website/api/controllers/docs/view-basic-documentation.js
+++ b/website/api/controllers/docs/view-basic-documentation.js
@@ -76,7 +76,7 @@ module.exports = {
         : 'Documentation for Fleet for osquery.'// « otherwise use the generic description
       ),
       showSwagForm,
-      docSearchPublicKey: sails.config.custom.docSearchPublicKey,
+      algoliaPublicKey: sails.config.custom.algoliaPublicKey,
     };
 
   }

--- a/website/api/controllers/docs/view-basic-documentation.js
+++ b/website/api/controllers/docs/view-basic-documentation.js
@@ -75,7 +75,8 @@ module.exports = {
         thisPage.meta.description ? thisPage.meta.description // « custom meta description for this page, if provided in markdown
         : 'Documentation for Fleet for osquery.'// « otherwise use the generic description
       ),
-      showSwagForm
+      showSwagForm,
+      docSearchPublicKey: sails.config.custom.docSearchPublicKey,
     };
 
   }

--- a/website/api/controllers/handbook/view-basic-handbook.js
+++ b/website/api/controllers/handbook/view-basic-handbook.js
@@ -69,6 +69,7 @@ module.exports = {
         thisPage.meta.description ? thisPage.meta.description // « custom meta description for this page, if provided in markdown
         : 'View the Fleet handbook.'// « otherwise use a generic description
       ),
+      docSearchPublicKey: sails.config.custom.docSearchPublicKey,
     };
 
   }

--- a/website/api/controllers/handbook/view-basic-handbook.js
+++ b/website/api/controllers/handbook/view-basic-handbook.js
@@ -69,7 +69,7 @@ module.exports = {
         thisPage.meta.description ? thisPage.meta.description // « custom meta description for this page, if provided in markdown
         : 'View the Fleet handbook.'// « otherwise use a generic description
       ),
-      docSearchPublicKey: sails.config.custom.docSearchPublicKey,
+      algoliaPublicKey: sails.config.custom.algoliaPublicKey,
     };
 
   }

--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -82,10 +82,10 @@ parasails.registerPage('basic-documentation', {
 
   mounted: async function() {
     // Algolia DocSearch
-    if(this.docSearchPublicKey) { // Note: Docsearch will only be enabled if sails.config.custom.docSearchPublicKey is set.
+    if(this.algoliaPublicKey) { // Note: Docsearch will only be enabled if sails.config.custom.algoliaPublicKey is set. If the value is undefined, the documentation search will be disabled.
       docsearch({
         appId: 'NZXAYZXDGH',
-        apiKey: this.docSearchPublicKey,
+        apiKey: this.algoliaPublicKey,
         indexName: 'fleetdm',
         inputSelector: (this.isDocsLandingPage ? '#docsearch-query-landing' : '#docsearch-query'),
         debug: false,

--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -82,16 +82,18 @@ parasails.registerPage('basic-documentation', {
 
   mounted: async function() {
     // Algolia DocSearch
-    docsearch({
-      appId: 'NZXAYZXDGH',
-      apiKey: 'f3c02b646222734376a5e94408d6fead',
-      indexName: 'fleetdm',
-      inputSelector: (this.isDocsLandingPage ? '#docsearch-query-landing' : '#docsearch-query'),
-      debug: false,
-      algoliaOptions: {
-        'facetFilters': ['section:docs']
-      },
-    });
+    if(this.docSearchPublicKey) { // Note: Docsearch will only be enabled if sails.config.custom.docSearchPublicKey is set.
+      docsearch({
+        appId: 'NZXAYZXDGH',
+        apiKey: this.docSearchPublicKey,
+        indexName: 'fleetdm',
+        inputSelector: (this.isDocsLandingPage ? '#docsearch-query-landing' : '#docsearch-query'),
+        debug: false,
+        algoliaOptions: {
+          'facetFilters': ['section:docs']
+        },
+      });
+    }
 
     // Handle hashes in urls when coming from an external page.
     if(window.location.hash){

--- a/website/assets/js/pages/handbook/basic-handbook.page.js
+++ b/website/assets/js/pages/handbook/basic-handbook.page.js
@@ -25,17 +25,19 @@ parasails.registerPage('basic-handbook', {
   mounted: async function() {
 
     // Algolia DocSearch
-    docsearch({
-      appId: 'NZXAYZXDGH',
-      apiKey: 'f3c02b646222734376a5e94408d6fead',
-      indexName: 'fleetdm',
-      inputSelector: '#docsearch-query',
-      debug: false,
-      clickAnalytics: true,
-      algoliaOptions: {
-        facetFilters: ['section:handbook']
-      },
-    });
+    if(this.docSearchPublicKey) {// Note: Docsearch will only be enabled if sails.config.custom.docSearchPublicKey is set.
+      docsearch({
+        appId: 'NZXAYZXDGH',
+        apiKey: this.docSearchPublicKey,
+        indexName: 'fleetdm',
+        inputSelector: '#docsearch-query',
+        debug: false,
+        clickAnalytics: true,
+        algoliaOptions: {
+          facetFilters: ['section:handbook']
+        },
+      });
+    }
 
     // Handle hashes in urls when coming from an external page.
     if(window.location.hash){

--- a/website/assets/js/pages/handbook/basic-handbook.page.js
+++ b/website/assets/js/pages/handbook/basic-handbook.page.js
@@ -25,10 +25,10 @@ parasails.registerPage('basic-handbook', {
   mounted: async function() {
 
     // Algolia DocSearch
-    if(this.docSearchPublicKey) {// Note: Docsearch will only be enabled if sails.config.custom.docSearchPublicKey is set.
+    if(this.algoliaPublicKey) {// Note: Docsearch will only be enabled if sails.config.custom.algoliaPublicKey is set. If the value is undefined, the handbook search will be disabled.
       docsearch({
         appId: 'NZXAYZXDGH',
-        apiKey: this.docSearchPublicKey,
+        apiKey: this.algoliaPublicKey,
         indexName: 'fleetdm',
         inputSelector: '#docsearch-query',
         debug: false,

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -97,6 +97,9 @@
       height: 100%;
       width: 98%;
     }
+    .docsearch-input:focus-visible {
+      outline: none;
+    }
 
     .ds-input:focus {
       outline: rgba(0, 0, 0, 0);

--- a/website/assets/styles/pages/handbook/basic-handbook.less
+++ b/website/assets/styles/pages/handbook/basic-handbook.less
@@ -38,7 +38,7 @@
     .docsearch-input:focus-visible {
       outline: none;
     }
-    .ds-input:focus,  {
+    .ds-input:focus {
       outline: rgba(0, 0, 0, 0);
     }
     .input-group-text {

--- a/website/assets/styles/pages/handbook/basic-handbook.less
+++ b/website/assets/styles/pages/handbook/basic-handbook.less
@@ -35,7 +35,10 @@
       height: 100%;
       width: 98%;
     }
-    .ds-input:focus {
+    .docsearch-input:focus-visible{
+      outline: none;
+    }
+    .ds-input:focus,  {
       outline: rgba(0, 0, 0, 0);
     }
     .input-group-text {

--- a/website/assets/styles/pages/handbook/basic-handbook.less
+++ b/website/assets/styles/pages/handbook/basic-handbook.less
@@ -35,7 +35,7 @@
       height: 100%;
       width: 98%;
     }
-    .docsearch-input:focus-visible{
+    .docsearch-input:focus-visible {
       outline: none;
     }
     .ds-input:focus,  {


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/1642
Changes:
- Added a new config variable `sails.config.custom.docSearchPublicKey`
- Updated the view actions for handbook and documentation pages to pass in the value of `sails.config.custom.docSearchPublicKey` to the page script.
- Updated the page scripts of the handbook and documentation pages to enable docsearch if the API key is provided.
- Updated styles to disable the search bar's outline if docSearch is disabled.
