### PR TITLE
query for discovering TLS certs

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -926,7 +926,7 @@ kind: query
 spec:
   name: Discover TLS certificates
   platforms: Linux, Windows, macOS
-  description: Finds where certs are being served. Enables mTLS adoption analysis and cert expiration notifications
+  description: Retrieves metadata about TLS certificates for servers listening on the local machine. Enables mTLS adoption analysis and cert expiration notifications.
   query: SELECT * FROM curl_certificate WHERE hostname IN (SELECT DISTINCT 'localhost:'||port FROM listening_ports WHERE protocol=6 AND address!='127.0.0.1' AND address!='::1');
   purpose: Informational
   tags: network, tls

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -926,7 +926,7 @@ kind: query
 spec:
   name: Discover TLS certificates
   platforms: Linux, Windows, macOS
-  description: Finds where certs are being served
+  description: Finds where certs are being served. Enables mTLS adoption analysis and cert expiration notifications
   query: SELECT * FROM curl_certificate WHERE hostname IN (SELECT DISTINCT 'localhost:'||port FROM listening_ports WHERE protocol=6 AND address!='127.0.0.1' AND address!='::1');
   purpose: Informational
   tags: network, tls

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -930,4 +930,4 @@ spec:
   query: SELECT * FROM curl_certificate WHERE hostname IN (SELECT DISTINCT 'localhost:'||port FROM listening_ports WHERE protocol=6 AND address!='127.0.0.1' AND address!='::1');
   purpose: Informational
   tags: network, tls
-  contributors: zhumo
+  contributors: nabilschear

--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -920,3 +920,14 @@ spec:
   tags: compliance, built-in
   platform: darwin
   contributors: GuillaumeRoss
+---
+apiVersion: v1
+kind: query
+spec:
+  name: Discover TLS certificates
+  platforms: Linux, Windows, macOS
+  description: Finds where certs are being served
+  query: SELECT * FROM curl_certificate WHERE hostname IN (SELECT DISTINCT 'localhost:'||port FROM listening_ports WHERE protocol=6 AND address!='127.0.0.1' AND address!='::1');
+  purpose: Informational
+  tags: network, tls
+  contributors: zhumo


### PR DESCRIPTION
This was one of the queries shown at the osquery @ scale conference. We thought it was very clever and useful! 