### PR TITLE
add retry logic for native notarization and codesigning

### DIFF
--- a/changes/issue-7130-native-notarization-retry
+++ b/changes/issue-7130-native-notarization-retry
@@ -1,0 +1,1 @@
+* Added logic to retry notarization and codesigning when using `FLEETCTL_NATIVE_TOOLING`

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -33,8 +33,8 @@ func WithMaxAttempts(a int) Option {
 // non-nil error it performs a retry according to the options
 // provided.
 //
-// By default operations are retried between 30 seconds and an
-// unlimited number of times.
+// By default operations are retried an unlimited number of times for 30
+// seconds
 func Do(fn func() error, opts ...Option) error {
 	cfg := &config{
 		interval: 30 * time.Second,

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -1,0 +1,63 @@
+// package retry has utilities to retry operations
+package retry
+
+import (
+	"time"
+)
+
+type config struct {
+	interval    time.Duration
+	maxAttempts int
+}
+
+// Option allows to configure the behavior of retry.Do
+type Option func(*config)
+
+// WithRetryInterval allows to specify a custom duration to wait
+// between retries.
+func WithInterval(i time.Duration) Option {
+	return func(c *config) {
+		c.interval = i
+	}
+}
+
+// WithMaxAttempts allows to specify a maximum number of attempts
+// before the doer gives up
+func WithMaxAttempts(a int) Option {
+	return func(c *config) {
+		c.maxAttempts = a
+	}
+}
+
+// Do executes the provided function, if the function returns a
+// non-nil error it performs a retry according to the options
+// provided.
+//
+// By default operations are retried between 30 seconds and an
+// unlimited number of times.
+func Do(fn func() error, opts ...Option) error {
+	cfg := &config{
+		interval: 30 * time.Second,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	attempts := 0
+	ticker := time.NewTicker(cfg.interval)
+	defer ticker.Stop()
+
+	for {
+		attempts++
+		err := fn()
+		if err == nil {
+			return nil
+		}
+
+		if cfg.maxAttempts != 0 && attempts >= cfg.maxAttempts {
+			return err
+		}
+
+		<-ticker.C
+	}
+}

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -1,0 +1,41 @@
+package retry
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var errTest = errors.New("test error")
+
+func TestRetryDo(t *testing.T) {
+	t.Run("WithMaxAttempts only performs the operation the configured number of times", func(t *testing.T) {
+		count := 0
+		max := 3
+
+		err := Do(func() error {
+			count++
+			return errTest
+		}, WithMaxAttempts(max), WithInterval(1*time.Millisecond))
+
+		require.ErrorIs(t, errTest, err)
+		require.Equal(t, max, count)
+	})
+
+	t.Run("operations are run an unlimited number of times by default", func(t *testing.T) {
+		count := 0
+		max := 10
+
+		err := Do(func() error {
+			if count++; count != max {
+				return errTest
+			}
+			return nil
+		}, WithInterval(1*time.Millisecond))
+
+		require.NoError(t, err)
+		require.Equal(t, max, count)
+	})
+}


### PR DESCRIPTION
Related to [#7130](https://github.com/fleetdm/fleet/issues/7130), this adds logic to retry native notarization up to three times if it fails for some reason.

Since we're adding retries in various places, I added a new package under `pkg` for this purpose.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
