### PR TITLE
Bug 6479: Storing proxy certificate in a secure location 

### DIFF
--- a/orbit/changes/bug-6479-store-proxy-cert-at-secure-location
+++ b/orbit/changes/bug-6479-store-proxy-cert-at-secure-location
@@ -1,0 +1,2 @@
+* Orbit lost communication with Fleet server 
+when the certificate used for insecure mode gets deleted.  

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -395,7 +395,13 @@ func main() {
 				},
 			)
 
-			certPath := filepath.Join(os.TempDir(), "fleet.crt")
+			// Directory to store proxy related assets
+			proxyDirectory := filepath.Join(c.String("root-dir"), "proxy")
+			if err := secure.MkdirAll(proxyDirectory, constant.DefaultDirMode); err != nil {
+				return fmt.Errorf("there was a problem creating the proxy directory: %w", err)
+			}
+
+			certPath := filepath.Join(proxyDirectory, "fleet.crt")
 
 			// Write cert that proxy uses
 			err = ioutil.WriteFile(certPath, []byte(insecure.ServerCert), os.ModePerm)


### PR DESCRIPTION
This relates to [#6479](https://github.com/fleetdm/fleet/issues/6479)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] Added/updated tests
- [X] Manual QA for all new/changed functionality
