### PR TITLE
Fleet UI: Placeholder text vertical padding

### DIFF
--- a/changes/issue-7819-placeholder-text
+++ b/changes/issue-7819-placeholder-text
@@ -1,0 +1,1 @@
+* Placeholder text size small not extra small

--- a/frontend/components/Modal/_styles.scss
+++ b/frontend/components/Modal/_styles.scss
@@ -17,7 +17,6 @@
 
       &::placeholder {
         font-style: italic;
-        font-size: $x-small;
       }
     }
 

--- a/frontend/components/Modal/_styles.scss
+++ b/frontend/components/Modal/_styles.scss
@@ -16,7 +16,9 @@
       width: 100%;
 
       &::placeholder {
+        font-size: $x-small;
         font-style: italic;
+        line-height: 24px;
       }
     }
 

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -4,7 +4,7 @@
   border: solid 1px $ui-fleet-blue-15;
   border-radius: 4px;
   font-size: $small;
-  padding: $pad-xsmall 12px;
+  padding: 7px 12px;
   color: $core-fleet-blue;
   font-family: "Nunito Sans", sans-serif;
   box-sizing: border-box;


### PR DESCRIPTION
Cerra #7819 

- Change padding of input-field to match padding shown in input that will be applied to textbox as well

<img width="627" alt="Screen Shot 2022-09-20 at 12 28 43 PM" src="https://user-images.githubusercontent.com/71795832/191313574-f867c962-903b-4080-8f1a-7244ca450c68.png">
<img width="597" alt="Screen Shot 2022-09-20 at 12 28 17 PM" src="https://user-images.githubusercontent.com/71795832/191313577-8a295524-9c65-465a-8f98-734874cbd5d0.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
