### PR TITLE
Fleet UI: Fix side panel scroll issue

### DIFF
--- a/changes/bug-7818-fix-side-panel-tooltip-horizontal-scroll
+++ b/changes/bug-7818-fix-side-panel-tooltip-horizontal-scroll
@@ -1,0 +1,1 @@
+* Fix side panel tooltips to not be wider than side panel causing scroll bug

--- a/frontend/components/SidePanelContent/_styles.scss
+++ b/frontend/components/SidePanelContent/_styles.scss
@@ -7,4 +7,8 @@
   padding: $pad-xxlarge;
   // need relative positioning for a close icon that is on some sidebars have
   position: relative;
+
+  .component__tooltip-wrapper__tip-text {
+    max-width: 280px;
+  }
 }


### PR DESCRIPTION
Cerra #7818

**Fix**
- Side panel tooltip max-width is not wider than side panel
- Fixes bug of scrolling off the page

**Screenshot**
Tooltip max width 300 px, so this long tooltip does not scroll off page but instead creates a second line
<img width="585" alt="Screen Shot 2022-09-19 at 11 20 30 AM" src="https://user-images.githubusercontent.com/71795832/191053764-f8c62483-3a6f-4202-900f-029dcff4e225.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
