### PR TITLE
Fleet UI: Add es_process_file_events, password_policy, windows_update_history to osquery tables

### DIFF
--- a/changes/issue-7816-add-es_process_file_events-to-tables
+++ b/changes/issue-7816-add-es_process_file_events-to-tables
@@ -1,0 +1,1 @@
+Use MSRC parser to generate security bulletin artifacts to be used for detecting Windows OS vulnerabilities.

--- a/changes/issue-7816-add-es_process_file_events-to-tables
+++ b/changes/issue-7816-add-es_process_file_events-to-tables
@@ -1,1 +1,1 @@
-Use MSRC parser to generate security bulletin artifacts to be used for detecting Windows OS vulnerabilities.
+* Add es_process_file_events to osquery tables

--- a/changes/issue-7816-add-es_process_file_events-to-tables
+++ b/changes/issue-7816-add-es_process_file_events-to-tables
@@ -1,1 +1,0 @@
-* Add es_process_file_events to osquery tables

--- a/changes/issue-7816-update-fleet-copy-of-osquery-tables
+++ b/changes/issue-7816-update-fleet-copy-of-osquery-tables
@@ -1,0 +1,1 @@
+* Add es_process_file_events, password_policy and windows_update_history to osquery tables

--- a/frontend/osquery_tables.json
+++ b/frontend/osquery_tables.json
@@ -7556,6 +7556,104 @@
     ]
   },
   {
+    "name": "es_process_file_events",
+    "description": "Process execution events from EndpointSecurity.",
+    "url": "https://github.com/osquery/osquery/blob/master/specs/darwin/es_process_file_events.table",
+    "platforms": ["darwin"],
+    "evented": true,
+    "cacheable": false,
+    "columns": [
+      {
+        "name": "version",
+        "description": "Version of EndpointSecurity event",
+        "type": "integer",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "seq_num",
+        "description": "Per event sequence number",
+        "type": "bigint",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "global_seq_num",
+        "description": "Global sequence number",
+        "type": "bigint",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "pid",
+        "description": "Process (or thread) ID",
+        "type": "bigint",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "path",
+        "description": "Path of executed file",
+        "type": "text",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "parent",
+        "description": "Parent process ID",
+        "type": "bigint",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "dest_filename",
+        "description": "Destination filename for the event",
+        "type": "text",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "event_type",
+        "description": "Type of EndpointSecurity event",
+        "type": "text",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "time",
+        "description": "Time of execution in UNIX time",
+        "type": "bigint",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "event_type",
+        "description": "Type of EndpointSecurity event",
+        "type": "text",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "eid",
+        "description": "Event ID",
+        "type": "text",
+        "hidden": true,
+        "required": false,
+        "index": false
+      }
+    ]
+  },
+  {
     "name": "etc_hosts",
     "description": "Line-parsed /etc/hosts.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/etc_hosts.table",

--- a/frontend/osquery_tables.json
+++ b/frontend/osquery_tables.json
@@ -14540,6 +14540,48 @@
     ]
   },
   {
+    "name": "password_policy",
+    "description": "Password Policies for macOS.",
+    "url": "https://github.com/osquery/osquery/blob/master/specs/darwin/password_policy.table",
+    "platforms": ["darwin"],
+    "evented": false,
+    "cacheable": false,
+    "columns": [
+      {
+        "name": "uid",
+        "description": "User ID for the policy if available",
+        "type": "bigint",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "policy_identifier",
+        "description": "Policy Identifier",
+        "type": "text",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "policy_content",
+        "description": "Policy content",
+        "type": "text",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "policy_description",
+        "description": "Policy description",
+        "type": "text",
+        "hidden": false,
+        "required": false,
+        "index": false
+      }
+    ]
+  },
+  {
     "name": "patches",
     "description": "Lists all the patches applied. Note: This does not include patches applied via MSI or downloaded from Windows Update (e.g. Service Packs).",
     "url": "https://github.com/osquery/osquery/blob/master/specs/windows/patches.table",
@@ -21897,6 +21939,112 @@
         "name": "signatures_up_to_date",
         "description": "1 if product signatures are up to date, else 0",
         "type": "integer",
+        "hidden": false,
+        "required": false,
+        "index": false
+      }
+    ]
+  },
+  {
+    "name": "windows_update_history",
+    "description": "Provides the history of the windows update events.",
+    "url": "https://github.com/osquery/osquery/blob/master/specs/windows/windows_update_history.table",
+    "platforms": ["windows"],
+    "evented": false,
+    "cacheable": false,
+    "columns": [
+      {
+        "name": "client_app_id",
+        "description": "Identifier of the client application that processed an update",
+        "type": "text",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "date",
+        "description": "Date and the time an update was applied",
+        "type": "bigint",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "description",
+        "description": "Description of an update",
+        "type": "text",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "hresult",
+        "description": "HRESULT value that is returned from the operation on an update",
+        "type": "bigint",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "operation",
+        "description": "Operation on an update",
+        "type": "text",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "result_code",
+        "description": "Result of an operation on an update",
+        "type": "text",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "server_selection",
+        "description": "Value that indicates which server provided an update",
+        "type": "text",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "service_id",
+        "description": "Service identifier of an update service that is not a Windows update",
+        "type": "text",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "support_url",
+        "description": "Hyperlink to the language-specific support information for an update",
+        "type": "text",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "title",
+        "description": "Title of an update",
+        "type": "text",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "update_id",
+        "description": "Revision-independent identifier of an update",
+        "type": "text",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "update_revision",
+        "description": "Revision number of an update",
+        "type": "bigint",
         "hidden": false,
         "required": false,
         "index": false


### PR DESCRIPTION
Cerra #7816 

**Fix**
- Add new `es_process_file_events`, `password_policy`, and `windows_update_history` to osquery_tables.json for Fleet frontend
- Shows up in UI

**Screenshots**
<img width="1079" alt="Screen Shot 2022-09-19 at 11 45 32 AM" src="https://user-images.githubusercontent.com/71795832/191058382-544087bb-6363-4d9b-9609-dcab6a2678f3.png">
<img width="1489" alt="Screen Shot 2022-09-19 at 3 32 32 PM" src="https://user-images.githubusercontent.com/71795832/191100357-9e0c587f-cf88-4a75-ba05-b0612f6a88ea.png">
<img width="1492" alt="Screen Shot 2022-09-19 at 3 31 52 PM" src="https://user-images.githubusercontent.com/71795832/191100359-2e8f025f-db9c-440e-a4bc-1e02775f16bd.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
