### PR TITLE
Website: Upgrade session adapter

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "description": "a Sails application",
   "keywords": [],
   "dependencies": {
-    "@sailshq/connect-redis": "^3.2.1",
+    "@sailshq/connect-redis": "^6.1.3",
     "@sailshq/lodash": "^3.10.3",
     "@sailshq/socket.io-redis": "^5.2.0",
     "jsonwebtoken": "8.5.1",


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/1375
Closes: https://github.com/fleetdm/fleet/issues/7092
Changes:
- Upgraded the session adapter for the Fleet website `@sailshq/connect-redis@3.2.1` » `6.1.3`
