### PR TITLE
Removing darwin from two tables

### DIFF
--- a/frontend/osquery_tables.json
+++ b/frontend/osquery_tables.json
@@ -8999,7 +8999,7 @@
     "name": "intel_me_info",
     "description": "Intel ME/CSE Info.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/linwin/intel_me_info.table",
-    "platforms": ["darwin", "linux", "windows"],
+    "platforms": ["linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -17705,7 +17705,7 @@
     "name": "secureboot",
     "description": "Secure Boot UEFI Settings.",
     "url": "https://github.com/osquery/osquery/blob/master/specs/linwin/secureboot.table",
-    "platforms": ["darwin", "linux", "windows"],
+    "platforms": ["linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [


### PR DESCRIPTION
According to the osquery schema these two tables (secureboot and intel_me_info) do not support macOS.

# Checklist for submitter

- [x] Manual QA for all new/changed functionality
