### PR TITLE
Use Group SID on fleetctl on Windows

### DIFF
--- a/changes/5065-fleetctl-package-language
+++ b/changes/5065-fleetctl-package-language
@@ -1,0 +1,1 @@
+* Fix an error generating Windows packages with `fleetctl package` on non-English localizations of Windows.

--- a/orbit/pkg/packaging/windows.go
+++ b/orbit/pkg/packaging/windows.go
@@ -92,9 +92,13 @@ func BuildMSI(opt Options) (string, error) {
 	}
 
 	if runtime.GOOS == "windows" {
-		// Explicitly grant read access, otherwise within the Docker container there are permissions
-		// errors.
-		out, err := exec.Command("icacls", tmpDir, "/grant", "everyone:R", "/t").CombinedOutput()
+		// Explicitly grant read access, otherwise within the Docker
+		// container there are permissions errors.
+		// "S-1-1-0" is the SID for the World/Everyone group
+		// (a group that includes all users).
+		out, err := exec.Command(
+			"icacls", tmpDir, "/grant", "S-1-1-0:R", "/t",
+		).CombinedOutput()
 		if err != nil {
 			fmt.Println(string(out))
 			return "", fmt.Errorf("icacls: %w", err)

--- a/orbit/pkg/packaging/windows.go
+++ b/orbit/pkg/packaging/windows.go
@@ -97,7 +97,7 @@ func BuildMSI(opt Options) (string, error) {
 		// "S-1-1-0" is the SID for the World/Everyone group
 		// (a group that includes all users).
 		out, err := exec.Command(
-			"icacls", tmpDir, "/grant", "S-1-1-0:R", "/t",
+			"icacls", tmpDir, "/grant", "*S-1-1-0:R", "/t",
 		).CombinedOutput()
 		if err != nil {
 			fmt.Println(string(out))


### PR DESCRIPTION
This is intended to allow packages to be built on localizations other than English.

See #5065.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
~- [ ] Documented any permissions changes~
~- [ ] Ensured that input data is properly validated, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
~- [ ] Added/updated tests~
- [x] Manual QA for all new/changed functionality
