### PR TITLE
update to article submission guide

### DIFF
--- a/handbook/digital-experience/article-formatting-guide.md
+++ b/handbook/digital-experience/article-formatting-guide.md
@@ -1,21 +1,12 @@
 # Article formatting guide
 
-To publish an article, you will need to create a Pull Request for a new file, formatted in Markdown, in [https://github.com/fleetdm/fleet/tree/main/articles](https://github.com/fleetdm/fleet/tree/main/articles).
-
-> Learn how to write Fleet-flavored Markdown in our [Markdown guide](./markdown-guide).
-
-### On this page
-- [Layout](#layout)
-- [Images and screenshots](#images-and-screenshots)
-- [Meta tags](#meta-tags)
-- [Customizable CTA](#customizable-cta)
-- [Related pages](#related-pages)
+> Before creating a pull request for an article, please submit a Google Doc draft (see [How to submit an article](./how-to-submit-and-publish-an-article.md#how-to-submit-an-article)). If you need help with Fleet-flavored Markdown, please read our handy [Markdown guide](./markdown-guide).
 
 ## Layout
 The following layout guide aims to help you create consistently formatted articles. For an existing article example, check out the [Markdown](https://raw.githubusercontent.com/fleetdm/fleet/main/articles/tales-from-fleet-security-speeding-up-macos-updates-with-nudge.md) and the [finished result](https://fleetdm.com/securing/tales-from-fleet-security-speeding-up-macos-updates-with-nudge).
 
 ### Hero image
-Consider adding a hero image for a more significant impact. Get in touch with Digital Experience via #content on Slack to make a request. 
+Consider adding a hero image for a more significant impact. Get in touch with Digital Experience in [#help-content-calendar](https://fleetdm.slack.com/archives/C03PH3BBVSM) on Slack to make a request. 
 
 ### Table of contents
 For long articles or guides, consider adding a table of contents.
@@ -28,9 +19,6 @@ The main body of your article.
 
 ### Conclusion
 It’s a good idea to finish your article with a clear closing statement.
-
-### Add a customizable CTA
-Add a CTA at the end of your article. See [Customizable CTA](#customizable-cta) below for instructions on creating a CTA tailored to your article topic.
 
 ## Images and screenshots
 Images are a great way to help engage your readers. But consider the following before including images or screenshots in your article:

--- a/handbook/digital-experience/how-to-submit-and-publish-an-article.md
+++ b/handbook/digital-experience/how-to-submit-and-publish-an-article.md
@@ -4,17 +4,6 @@ This guide includes everything you need to know about Fleet’s editorial proces
 
 > For help with formatting your article, check out our [article formatting guide](./article-formatting-guide).
 
-### On this page
-
-- [Article DRIs](#article-dr-is)
-- [Who can publish articles?](#who-can-publish-articles)
-- [Communication](#communication)
-- [Schedule](#schedule)
-- [How to submit an article](#how-to-submit-an-article)
-- [Review process](#review-process)
-- [Pre-publication checklist](#pre-publication-checklist)
-- [After publication](#after-publication)
-
 ## Article DRIs
 
 | Activity | DRI |
@@ -38,11 +27,8 @@ Publishing occurs according to our [content calendar](https://docs.google.com/sp
 
 ## How to submit an article
 
-1. Familiarize yourself with our [article formatting guide](./article-formatting-guide) and writing style guide (todo).
-2. Create a pull request for fleetdm.com with a file of your article, formatted in [Markdown](./markdown-guide).
-3. Include any relevant images, image suggestions, or other design requests you may have.
-
-> **IMPORTANT**: Your PR is not confidential. If the information in your article is confidential, please prepare your article in a Google Doc, or create a draft PR ~1 hour before publication time to keep your article private.
+1. Submit your draft to Chris McGillcuddy as a Google Doc. 
+2. Include any relevant images, image suggestions, or other design requests you may have.
 
 ## Review process
 
@@ -61,6 +47,18 @@ Articles are official Fleet communication. We carefully review published content
 | Posts requiring a technical review | Three business days |
 
 > Review times for posts requiring a technical review may vary depending on the Engineering and Security teams' schedules. E.g., if a review coincides with a product release.
+
+## Create a PR for your article
+
+After your article has been editied and approved, create a pull request on fleetdm.com and request review from Chris McGillicuddy.
+
+### How to PR your article   
+
+1. Familiarize yourself with our [article formatting guide](./article-formatting-guide).
+2. Add a file, formatted in [Markdown](./markdown-guide), to the Fleet repo in Github [fleetdm/fleet/articles](https://github.com/fleetdm/fleet/tree/main/articles), using the name of your article as the filename. E.g., `deploy-fleet-on-render.md`.
+3. Request a review from Chris McGillicuddy. 
+
+> **IMPORTANT**: Your PR is not confidential. If the information in your article is confidential, please prepare your article in a Google Doc, or create a draft PR ~1 hour before publication time to keep your article private.
 
 ## Pre-publication checklist
 

--- a/handbook/digital-experience/how-to-submit-and-publish-an-article.md
+++ b/handbook/digital-experience/how-to-submit-and-publish-an-article.md
@@ -27,7 +27,7 @@ Publishing occurs according to our [content calendar](https://docs.google.com/sp
 
 ## How to submit an article
 
-1. Submit your draft to Chris McGillcuddy as a Google Doc. 
+1. Submit your draft to Chris McGillicuddy as a Google Doc. 
 2. Include any relevant images, image suggestions, or other design requests you may have.
 
 ## Review process


### PR DESCRIPTION
I made the following changes:

- I updated the guide to clarify that submitting drafts as a Google Doc is the official article submission process.
- I did some housekeeping for improved clarity. 
