### PR TITLE
Website: License dispenser patch

### DIFF
--- a/website/api/controllers/customers/save-billing-info-and-subscribe.js
+++ b/website/api/controllers/customers/save-billing-info-and-subscribe.js
@@ -98,7 +98,7 @@ module.exports = {
     // Generate the license key for this subscription
     let licenseKey = await sails.helpers.createLicenseKey.with({
       numberOfHosts: quoteRecord.numberOfHosts,
-      organization: this.req.me.organization,
+      organization: this.req.me.organization ? this.req.me.organization : this.req.me.emailAddress,
       validTo: subscription.current_period_end
     });
 


### PR DESCRIPTION
fixes outage: https://github.com/fleetdm/confidential/issues/1713

Changes:
- Updated `save-billing-info-and-subscribe.js` to use the `create-license-key` helper with a user's email address if their organization is set to a blank string.
