### PR TITLE
API Bugs: Team view (fleet/teams/{id}) #6970

### DIFF
--- a/changes/bug-6970-missing-host-count-user-count
+++ b/changes/bug-6970-missing-host-count-user-count
@@ -1,0 +1,1 @@
+* Fix host_count and user_count being always returned as `0` in `teams/{id}` endpoint.

--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -1,6 +1,5 @@
 # REST API
 
-- [Overview](#overview)
 - [Authentication](#authentication)
 - [Activities](#activities)
 - [Fleet configuration](#fleet-configuration)
@@ -4966,8 +4965,6 @@ _Available in Fleet Premium_
   "team": {
     "name": "Workstations",
     "id": 1,
-    "user_ids": [1, 17, 22, 32],
-    "host_ids": [],
     "user_count": 4,
     "host_count": 0,
     "agent_options": {
@@ -5039,8 +5036,6 @@ _Available in Fleet Premium_
     {
       "name": "workstations",
       "id": 1,
-      "user_ids": [],
-      "host_ids": [],
       "user_count": 0,
       "host_count": 0,
       "agent_options": {
@@ -5130,8 +5125,6 @@ _Available in Fleet Premium_
   "team": {
     "name": "Workstations",
     "id": 1,
-    "user_ids": [1, 17, 22, 32],
-    "host_ids": [],
     "user_count": 4,
     "host_count": 0,
     "agent_options": {
@@ -5190,8 +5183,6 @@ _Available in Fleet Premium_
   "team": {
     "name": "Workstations",
     "id": 1,
-    "user_ids": [1, 17, 22, 32],
-    "host_ids": [3, 6, 7, 8, 9, 20, 32, 44],
     "user_count": 4,
     "host_count": 8,
     "agent_options": {
@@ -5283,8 +5274,6 @@ _Available in Fleet Premium_
   "team": {
     "name": "Workstations",
     "id": 1,
-    "user_ids": [1, 17, 22, 32],
-    "host_ids": [3, 6, 7, 8, 9, 20, 32, 44],
     "user_count": 4,
     "host_count": 8,
     "agent_options": {

--- a/server/datastore/mysql/teams_test.go
+++ b/server/datastore/mysql/teams_test.go
@@ -226,6 +226,16 @@ func testTeamsList(t *testing.T, ds *Datastore) {
 	assert.Equal(t, "team2", teams[1].Name)
 	assert.Equal(t, 2, teams[1].HostCount)
 	assert.Equal(t, 1, teams[1].UserCount)
+
+	// Test that ds.Teams returns the same data as ds.ListTeams
+	// (except list of users).
+	for _, t1 := range teams {
+		t2, err := ds.Team(context.Background(), t1.ID)
+		require.NoError(t, err)
+		t2.Users = nil
+		require.Equal(t, t1, t2)
+	}
+
 }
 
 func testTeamsSummary(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
For #6970

make user_count and host_count in endpoint teams/id functional.

- [X] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [X] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
