### PR TITLE
Make osquery-perf aware of kubequery so that hosts are not reported as such erroneously

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -865,7 +865,7 @@ func (a *agent) processQuery(name, query string) (handled bool, results []map[st
 			results = a.diskSpace()
 		}
 		return true, results, &ss
-	case name == hostDetailQueryPrefix+"kubequery_info":
+	case name == hostDetailQueryPrefix+"kubequery_info" && a.os != "kubequery":
 		// Real osquery running on hosts would return no results if it was not
 		// running kubequery (due to discovery query). Returning true here so that
 		// the caller knows it is handled, will not try to return lorem-ipsum-style

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -786,6 +786,7 @@ func (a *agent) processQuery(name, query string) (handled bool, results []map[st
 		hostDetailQueryPrefix = "fleet_detail_query_"
 	)
 	statusOK := fleet.StatusOK
+	statusNotOK := fleet.OsqueryStatus(1)
 
 	switch {
 	case strings.HasPrefix(name, hostPolicyQueryPrefix):
@@ -864,6 +865,12 @@ func (a *agent) processQuery(name, query string) (handled bool, results []map[st
 			results = a.diskSpace()
 		}
 		return true, results, &ss
+	case name == hostDetailQueryPrefix+"kubequery_info":
+		// Real osquery running on hosts would return no results if it was not
+		// running kubequery (due to discovery query). Returning true here so that
+		// the caller knows it is handled, will not try to return lorem-ipsum-style
+		// results.
+		return true, nil, &statusNotOK
 	default:
 		// Look for results in the template file.
 		if t := a.templates.Lookup(name); t == nil {


### PR DESCRIPTION
For context, hosts were being reported as running on the `kubequery` platform in load testing: https://github.com/fleetdm/fleet/issues/7591#issuecomment-1258249195

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [x] Manual QA for all new/changed functionality
