### PR TITLE
fix data race in TestAutomationsSchedule

### DIFF
--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -23,6 +23,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// safeStore is a wrapper around mock.Store to allow for concurrent calling to
+// AppConfig, in the past we have seen this test fail with a data race warning.
+//
+// TODO: if we see other tests failing for similar reasons, we should build a
+// more robust pattern instead of doing this everywhere
+type safeStore struct {
+	mock.Store
+	mu sync.Mutex
+}
+
+func (s *safeStore) AppConfig(ctx context.Context) (*fleet.AppConfig, error) {
+	s.mu.Lock()
+	s.AppConfigFuncInvoked = true
+	s.mu.Unlock()
+	return s.AppConfigFunc(ctx)
+}
+
 func TestMaybeSendStatistics(t *testing.T) {
 	ds := new(mock.Store)
 
@@ -130,7 +147,7 @@ func TestMaybeSendStatisticsSkipsIfNotConfigured(t *testing.T) {
 }
 
 func TestAutomationsSchedule(t *testing.T) {
-	ds := new(mock.Store)
+	ds := new(safeStore)
 
 	endpointCalled := int32(0)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -313,7 +330,7 @@ func TestCronVulnerabilitiesSkipMkdirIfDisabled(t *testing.T) {
 // for the current automation crons and that their duration is equal to the current
 // schedule interval.
 func TestAutomationsScheduleLockDuration(t *testing.T) {
-	ds := new(mock.Store)
+	ds := new(safeStore)
 	expectedInterval := 1 * time.Second
 
 	intitalConfigLoaded := make(chan struct{}, 1)
@@ -379,7 +396,7 @@ func TestAutomationsScheduleLockDuration(t *testing.T) {
 }
 
 func TestAutomationsScheduleIntervalChange(t *testing.T) {
-	ds := new(mock.Store)
+	ds := new(safeStore)
 
 	interval := struct {
 		sync.Mutex


### PR DESCRIPTION
This fixes a data race we have seen in tests when they are run with `-race=true`, for an example see here: https://github.com/fleetdm/fleet/actions/runs/3125104507/jobs/5069136977

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
