### PR TITLE
Update osquery validations from 5.4.0 to 5.5.1

### DIFF
--- a/changes/issue-7871-update-osquery-validations-to-5.5.1
+++ b/changes/issue-7871-update-osquery-validations-to-5.5.1
@@ -1,0 +1,1 @@
+* Updated team and organization settings' "agent options" validations from osquery 5.4.0 to osquery 5.5.1.

--- a/server/fleet/agent_options.go
+++ b/server/fleet/agent_options.go
@@ -62,7 +62,7 @@ func ValidateJSONAgentOptions(rawJSON json.RawMessage) error {
 // See https://osquery.readthedocs.io/en/stable/deployment/configuration/#configuration-specification
 //
 // NOTE: Update the following line with the version used for validation.
-// Current version: 5.4.0
+// Current version: 5.5.1
 type osqueryAgentOptions struct {
 	Options osqueryOptions `json:"options"`
 
@@ -196,6 +196,7 @@ type osqueryOptions struct {
 	DisableHashCache                    bool   `json:"disable_hash_cache"`
 	DisableLogging                      bool   `json:"disable_logging"`
 	DisableMemory                       bool   `json:"disable_memory"`
+	DistributedDenylistDuration         uint64 `json:"distributed_denylist_duration"`
 	DistributedInterval                 uint64 `json:"distributed_interval"`
 	DistributedLoginfo                  bool   `json:"distributed_loginfo"`
 	DistributedPlugin                   string `json:"distributed_plugin"`
@@ -237,6 +238,7 @@ type osqueryOptions struct {
 	LoggerTlsMaxLinesize                uint64 `json:"logger_tls_max_linesize"`
 	LoggerTlsPeriod                     uint64 `json:"logger_tls_period"`
 	LxdSocket                           string `json:"lxd_socket"`
+	MallocTrimThreshold                 uint64 `json:"malloc_trim_threshold"`
 	Nullvalue                           string `json:"nullvalue"`
 	NumericMonitoringFilesystemPath     string `json:"numeric_monitoring_filesystem_path"`
 	NumericMonitoringPlugins            string `json:"numeric_monitoring_plugins"`
@@ -265,7 +267,6 @@ type osqueryOptions struct {
 	Verbose                             bool   `json:"verbose"`
 	WorkerThreads                       int32  `json:"worker_threads"`
 	YaraDelay                           uint32 `json:"yara_delay"`
-	YaraMallocTrim                      bool   `json:"yara_malloc_trim"`
 }
 
 // while ValidateJSONAgentOptions validates an entire Agent Options payload,

--- a/server/fleet/agent_options_test.go
+++ b/server/fleet/agent_options_test.go
@@ -96,6 +96,16 @@ func TestValidateAgentOptions(t *testing.T) {
 				"pack1": 1
 			}
 		}}`, `invalid number value`},
+		{"option added in osquery 5.5.1", `{"config":{
+			"options": {
+				"malloc_trim_threshold": 100
+			}
+		}}`, ``},
+		{"option removed in osquery 5.5.1", `{"config":{
+			"options": {
+				"yara_malloc_trim": true
+			}
+		}}`, `unknown field "yara_malloc_trim"`},
 	}
 
 	for _, c := range cases {

--- a/tools/osquery-agent-options/README.md
+++ b/tools/osquery-agent-options/README.md
@@ -1,7 +1,7 @@
 # osquery-agent-options
 
-This directory contains a script (a Go command) that generates the struct needed to unmarshal the Agent Options' `options` values that the current version of osquery supports. It extracts this information from `osqueryd --help` to identify which osquery command-line flags can be set via the options, and running a query in `osqueryi` to get the data type of those options.
+This directory contains a script (a Go command) that generates the struct needed to unmarshal the Agent Options' `options` values that the current version of osquery supports. It extracts this information from `osqueryd --help` to identify which osquery command-line flags can be set via the options and which are only for the command-line (i.e. require a restart), and running a query in `osqueryi` to get the data type of those options.
 
-It prints the resulting Go code to stdout, you can just copy it and insert it in the proper location in the source code.
+It prints the resulting Go code to stdout (the `osqueryOptions` and the `osqueryCommandLineFlags` structs), you can just copy it and insert it in the proper location in the source code to replace the existing struct (in `server/fleet/agent_options.go`).
 
 Note that the latest version of osquery should be installed for this tool to work properly (`osqueryd` and `osqueryi` must be in your $PATH).


### PR DESCRIPTION
Addresses the ritual of updating Fleet's agent options validation when a new osquery version is released (5.5.1 this time): #7871 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests
