### PR TITLE
Website: Osquery schema tables updates

### DIFF
--- a/website/assets/js/pages/osquery-table-details.page.js
+++ b/website/assets/js/pages/osquery-table-details.page.js
@@ -58,9 +58,10 @@ parasails.registerPage('osquery-table-details', {
           $(el).html(replacementHMTL);
         }
       });
+      // Adding [purpose="line-break"] to SQL keywords if they are one of: SELECT, WHERE, FROM, JOIN. (case-insensitive)
       $('.hljs-keyword').each((i, el)=>{
         for(i in el.innerText.match(/select|where|from|join/gi)) {
-          $(el).addClass('line-break');
+          $(el).attr({'purpose':'line-break'});
         }
       });
     })();

--- a/website/assets/js/pages/osquery-table-details.page.js
+++ b/website/assets/js/pages/osquery-table-details.page.js
@@ -58,6 +58,11 @@ parasails.registerPage('osquery-table-details', {
           $(el).html(replacementHMTL);
         }
       });
+      $('.hljs-keyword').each((i, el)=>{
+        for(i in el.innerText.match(/select|where|from|join/gi)) {
+          $(el).addClass('line-break');
+        }
+      });
     })();
     // Adjust the height of the sidebar navigation to match the height of the html partial
     (()=>{

--- a/website/assets/styles/pages/osquery-table-details.less
+++ b/website/assets/styles/pages/osquery-table-details.less
@@ -205,7 +205,7 @@
           color: #AE6DDF;
           white-space: pre;
         }
-        .line-break:not(:first-of-type)::before {
+        [purpose='line-break']:not(:first-of-type)::before {
           content: '\a';
         }
         .hljs-attr { // For table and column names

--- a/website/assets/styles/pages/osquery-table-details.less
+++ b/website/assets/styles/pages/osquery-table-details.less
@@ -46,6 +46,7 @@
       border: 1px solid @core-vibrant-blue;
     }
     [purpose='mobile-nav'] {
+      scrollbar-width: none;
       padding-top: 16px;
       overflow-y: scroll;
       height: 100%;
@@ -72,10 +73,11 @@
     font-size: 14px;
     line-height: 14px;
   }
-  [purpose='left-sidebar']::-webkit-scrollbar, [purpose='table-of-contents']::-webkit-scrollbar {
+  [purpose='left-sidebar']::-webkit-scrollbar, [purpose='table-of-contents']::-webkit-scrollbar, [purpose='mobile-nav']::-webkit-scrollbar {
     display: none;
   }
   [purpose='left-sidebar'] {
+    scrollbar-width: none;
     background: #FFF;
     min-width: 245px;
     max-width: 250px;
@@ -89,6 +91,7 @@
     }
   }
   [purpose='table-of-contents'] {
+    scrollbar-width: none;
     padding-top: 16px;
     padding-bottom: 120px;
     margin-top: 16px;
@@ -201,9 +204,8 @@
         .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
           color: #AE6DDF;
           white-space: pre;
-          break-before: always;
         }
-        .hljs-keyword:not(:first-of-type)::before {
+        .line-break:not(:first-of-type)::before {
           content: '\a';
         }
         .hljs-attr { // For table and column names

--- a/website/assets/styles/pages/osquery-table-details.less
+++ b/website/assets/styles/pages/osquery-table-details.less
@@ -264,6 +264,9 @@
           }
         }
       }
+      td:nth-child(2) {
+        text-transform: uppercase;
+      }
     }
     li, p, h4 {
       word-break: break-word;

--- a/website/views/pages/osquery-table-details.ejs
+++ b/website/views/pages/osquery-table-details.ejs
@@ -22,7 +22,7 @@
         <div class="d-flex">
           <div purpose="search">
             <img style="height: 16px; width: 16px;" class="d-inline mr-2" alt="search" src="/images/icon-search-16x16@2x.png">
-            <input placeholder="Search tables" v-model="search">
+            <input placeholder="Search tables" v-model="search" @input="showTableNav = true">
           </div>
         </div>
       </div>

--- a/website/views/pages/osquery-table-details.ejs
+++ b/website/views/pages/osquery-table-details.ejs
@@ -21,7 +21,7 @@
       <div class="d-flex">
         <div purpose="search">
           <img style="height: 16px; width: 16px;" class="d-inline mr-2" alt="search" src="/images/icon-search-16x16@2x.png">
-          <input placeholder="Search tables" v-model="search">
+          <input placeholder="Search tables" v-model="search" @input="showTableNav = true">
         </div>
       </div>
     </div>


### PR DESCRIPTION
Changes:
- Updated linebreaks in code examples
- Hid scrollbars on elements on Safari and Firefox
- Updated the mobile navigation to display if a user types in the search bar 
- Updated the text in the type column of schema tables to be uppercase