### PR TITLE
Orbit: Handle `SIGTERM` on unix and kill pre-existing fleet-desktop processes at startup

### DIFF
--- a/orbit/changes/6441-duplicated-fleet-desktop-bis
+++ b/orbit/changes/6441-duplicated-fleet-desktop-bis
@@ -1,0 +1,2 @@
+* Orbit now kills any pre-existing fleet desktop processes at startup.
+* Orbit now handles SIGTERM on unix.

--- a/orbit/cmd/orbit/signal_unix.go
+++ b/orbit/cmd/orbit/signal_unix.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package main
 
 import (

--- a/orbit/cmd/orbit/signal_unix.go
+++ b/orbit/cmd/orbit/signal_unix.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"context"
+	"os"
+	"syscall"
+
+	"github.com/oklog/run"
+)
+
+func signalHandler(ctx context.Context) (execute func() error, interrupt func(error)) {
+	return run.SignalHandler(ctx, os.Interrupt, os.Kill, syscall.SIGTERM)
+}

--- a/orbit/cmd/orbit/signal_windows.go
+++ b/orbit/cmd/orbit/signal_windows.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"os"
-	"syscall"
 
 	"github.com/oklog/run"
 )

--- a/orbit/cmd/orbit/signal_windows.go
+++ b/orbit/cmd/orbit/signal_windows.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"context"
+	"os"
+	"syscall"
+
+	"github.com/oklog/run"
+)
+
+func signalHandler(ctx context.Context) (execute func() error, interrupt func(error)) {
+	return run.SignalHandler(ctx, os.Interrupt, os.Kill)
+}

--- a/tools/tuf/test/README.md
+++ b/tools/tuf/test/README.md
@@ -45,15 +45,24 @@ E.g. to add a new version of `orbit` for Windows:
 # Compile a new version of Orbit:
 GOOS=windows GOARCH=amd64 go build -o orbit-windows.exe ./orbit/cmd/orbit
 
-# Push the compiled Orbit as a new version:
+# Push the compiled Orbit as a new version
 ./tools/tuf/test/push_target.sh windows orbit orbit-windows.exe 43
 ```
 
 E.g. to add a new version of `osqueryd` for macOS:
 ```sh
-# Download some version from our TUF server:
-curl --output osqueryd https://tuf.fleetctl.com/targets/osqueryd/macos/5.0.1/osqueryd
+# Generate osqueryd app bundle.
+make osqueryd-app-tar-gz version=5.5.1 out-path=.
 
-# Push the osqueryd target as a new version:
-./tools/tuf/test/push_target.sh macos osqueryd osqueryd 43
+# Push the osqueryd target as a new version
+./tools/tuf/test/push_target.sh macos-app osqueryd osqueryd.app.tar.gz 5.5.1
+```
+
+E.g. to add a new version of `desktop` for macOS:
+```sh
+# Compile a new version of fleet-desktop
+make desktop-app-tar-gz
+
+# Push the desktop target as a new version
+./tools/tuf/test/push_target.sh macos desktop desktop.app.tar.gz 43
 ```


### PR DESCRIPTION
- [X] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [X] Manual QA for all new/changed functionality
