### PR TITLE
Make the github action fail if used on the main branch

### DIFF
--- a/.github/workflows/dogfood-deploy.yml
+++ b/.github/workflows/dogfood-deploy.yml
@@ -39,6 +39,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - id: fail-on-main
+        run: "false"
+        if: ${{ github.ref == 'main' }}
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{env.AWS_IAM_ROLE}}


### PR DESCRIPTION
This is a preflight PR for setting up dogfood for MDM so that breaking changes that will live in a branch don't get stepped on nor contaminate customer terraform.