### PR TITLE
fix flag formatting in Orbit

### DIFF
--- a/orbit/pkg/update/flag_runner.go
+++ b/orbit/pkg/update/flag_runner.go
@@ -4,14 +4,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
-	"github.com/fleetdm/fleet/v4/server/service"
-	"github.com/rs/zerolog/log"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
+	"github.com/fleetdm/fleet/v4/server/service"
+	"github.com/rs/zerolog/log"
 )
 
 // FlagRunner is a specialized runner to periodically check and update flags from Fleet
@@ -144,8 +146,18 @@ func getFlagsFromJSON(flags json.RawMessage) (map[string]string, error) {
 	}
 
 	for k, v := range data {
-		result["--"+k] = fmt.Sprintf("%v", v)
+		switch t := v.(type) {
+		case string:
+			result["--"+k] = t
+		case bool:
+			result["--"+k] = strconv.FormatBool(t)
+		case float64:
+			result["--"+k] = fmt.Sprintf("%.f", v)
+		default:
+			result["--"+k] = fmt.Sprintf("%v", v)
+		}
 	}
+
 	return result, nil
 }
 

--- a/orbit/pkg/update/flag_runner_test.go
+++ b/orbit/pkg/update/flag_runner_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var rawJSONFlags = json.RawMessage(`{"verbose":true, "num":5, "hello":"world"}`)
+var rawJSONFlags = json.RawMessage(`{"verbose":true, "num":5, "hello":"world", "largeNum":1234567890}`)
 
 func TestGetFlagsFromJson(t *testing.T) {
 	flagsJson, err := getFlagsFromJSON(rawJSONFlags)
@@ -38,6 +38,14 @@ func TestGetFlagsFromJson(t *testing.T) {
 	}
 	if value != "world" {
 		t.Errorf(`expected "world", got %s`, value)
+	}
+
+	value, ok = flagsJson["--largeNum"]
+	if !ok {
+		t.Errorf(`key "--largeNum" expected but not found`)
+	}
+	if value != "1234567890" {
+		t.Errorf(`expected "1234567890", got %s`, value)
 	}
 }
 


### PR DESCRIPTION
This fixes the formatting of large float values, as for example the number `1234567` would get formatted as `1.234567e+06` which is invalid

# Checklist for submitter

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
