### PR TITLE
Fleet UI: Print mode fixed

### DIFF
--- a/changes/bug-7941-can-print-app
+++ b/changes/bug-7941-can-print-app
@@ -1,0 +1,1 @@
+* Fixes bug which small screen overlay is shown when trying to print

--- a/frontend/layouts/CoreLayout/_styles.scss
+++ b/frontend/layouts/CoreLayout/_styles.scss
@@ -12,8 +12,14 @@
   background-color: $core-white;
   display: flex;
 
+  // App hidden below 768px
   @media (max-width: $break-768 - 1px) {
     display: none;
+  }
+
+  // App not hidden when printing
+  @media print {
+    display: initial;
   }
 
   a {
@@ -32,8 +38,15 @@
   top: 0;
   left: 0;
   z-index: 100;
+
+  // Nav hidden below 768px;
   @media (max-width: $break-768 - 1px) {
     display: none;
+  }
+
+  // Nav not hidden when printing
+  @media print {
+    display: initial;
   }
 }
 
@@ -49,7 +62,13 @@
   justify-content: center;
   gap: $pad-medium;
 
+  // Overlay below 768px
   @media (min-width: 768px) {
+    display: none;
+  }
+
+  // No overlay when printing
+  @media print {
     display: none;
   }
 


### PR DESCRIPTION
Cerra #7941 

**FIX**
- Can see app and nav bar in print mode

**QA Screenshots**
- I QAed on Chrome, Firefox, Safari
<img width="990" alt="Screen Shot 2022-09-27 at 3 01 40 PM" src="https://user-images.githubusercontent.com/71795832/192613383-a6de14d7-a233-447b-8bd5-cf13fa7b2fdb.png">
<img width="1159" alt="Screen Shot 2022-09-27 at 3 01 17 PM" src="https://user-images.githubusercontent.com/71795832/192613386-d636e9ed-628c-4f99-8065-629580bc762a.png">
<img width="694" alt="Screen Shot 2022-09-27 at 3 00 34 PM" src="https://user-images.githubusercontent.com/71795832/192613389-0f95b899-e7a6-41a4-bb02-7676dea2a61f.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Add changelog for user visible changes
- [x] Manual QA for all new/changed functionality
