### PR TITLE
switch orbit enroll logic to use osquery_host_id

### DIFF
--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -849,10 +849,10 @@ func (ds *Datastore) EnrollOrbit(ctx context.Context, hardwareUUID string, orbit
 
 	var host fleet.Host
 	err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		err := sqlx.GetContext(ctx, tx, &host, `SELECT id FROM hosts WHERE uuid = ?`, hardwareUUID)
+		err := sqlx.GetContext(ctx, tx, &host, `SELECT id FROM hosts WHERE osquery_host_id = ?`, hardwareUUID)
 		switch {
 		case err == nil:
-			sqlUpdate := `UPDATE hosts SET orbit_node_key = ? WHERE uuid = ? `
+			sqlUpdate := `UPDATE hosts SET orbit_node_key = ? WHERE osquery_host_id = ? `
 			_, err := tx.ExecContext(ctx, sqlUpdate, orbitNodeKey, hardwareUUID)
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "orbit enroll error updating host details")


### PR DESCRIPTION
This switches the enroll logic for Orbit to use `osquery_host_id` column instead of `uuid`, because `osquery_host_id` is unique, while `uuid` may not be

- [x] Manual QA for all new/changed functionality
