### PR TITLE
Fleet UI Bug Fix: Error adding integration doesn't clear fields

### DIFF
--- a/changes/bug-7843-integration-error-does-not-clear-form
+++ b/changes/bug-7843-integration-error-does-not-clear-form
@@ -1,0 +1,1 @@
+* Fix error in adding a new integration to not clear form

--- a/cypress/integration/all/app/settingsflow.spec.ts
+++ b/cypress/integration/all/app/settingsflow.spec.ts
@@ -2,7 +2,7 @@ import CONSTANTS from "../../../support/constants";
 
 const { CONFIG_INTEGRATIONS_AUTOMATIONS } = CONSTANTS;
 
-const createJiraIntegration = {
+const addJiraIntegration = {
   ...CONFIG_INTEGRATIONS_AUTOMATIONS,
   integrations: {
     jira: [
@@ -51,7 +51,7 @@ const deleteJiraIntegration = {
   },
 };
 
-const createZendeskIntegration = {
+const addZendeskIntegration = {
   ...CONFIG_INTEGRATIONS_AUTOMATIONS,
   integrations: {
     zendesk: [
@@ -397,26 +397,24 @@ describe("App settings flow", () => {
       cy.loginWithCySession();
       cy.visit("/settings/integrations");
     });
-    it("creates a new jira integration", () => {
-      cy.getAttached(".no-integrations__create-button").click();
+    it("adds a new jira integration", () => {
+      cy.getAttached(".no-integrations__add-button").click();
       cy.getAttached("#url").click().type("https://fleetdm.atlassian.com");
       cy.getAttached("#username").click().type("jira@example.com");
       cy.getAttached("#apiToken").click().type("jira123");
       cy.getAttached("#projectKey").click().type("PROJECT");
-      cy.intercept(
-        "PATCH",
-        "/api/latest/fleet/config",
-        createJiraIntegration
-      ).as("createIntegration");
-      cy.intercept("GET", "/api/latest/fleet/config", createJiraIntegration).as(
-        "createdIntegration"
+      cy.intercept("PATCH", "/api/latest/fleet/config", addJiraIntegration).as(
+        "addIntegration"
+      );
+      cy.intercept("GET", "/api/latest/fleet/config", addJiraIntegration).as(
+        "addedIntegration"
       );
       cy.findByRole("button", { name: /save/i }).click();
-      cy.wait("@createIntegration").then((configStub) => {
+      cy.wait("@addIntegration").then((configStub) => {
         cy.log(JSON.stringify(configStub));
         console.log(JSON.stringify(configStub));
       });
-      cy.wait("@createdIntegration").then((configStub) => {
+      cy.wait("@addedIntegration").then((configStub) => {
         cy.log(JSON.stringify(configStub));
         console.log(JSON.stringify(configStub));
       });
@@ -425,9 +423,9 @@ describe("App settings flow", () => {
         cy.findByText(/fleetdm.atlassian.com - PROJECT/i).should("exist");
       });
     });
-    it("creates a new zendesk integration", () => {
-      cy.getAttached(".no-integrations__create-button").click();
-      cy.getAttached(".create-integration-modal__form-field--platform").within(
+    it("adds a new zendesk integration", () => {
+      cy.getAttached(".no-integrations__add-button").click();
+      cy.getAttached(".add-integration-modal__form-field--platform").within(
         () => {
           cy.findByText(/jira/i).click();
           cy.findByText(/zendesk/i).click();
@@ -440,19 +438,17 @@ describe("App settings flow", () => {
       cy.intercept(
         "PATCH",
         "/api/latest/fleet/config",
-        createZendeskIntegration
-      ).as("createIntegration");
-      cy.intercept(
-        "GET",
-        "/api/latest/fleet/config",
-        createZendeskIntegration
-      ).as("createdIntegration");
+        addZendeskIntegration
+      ).as("addIntegration");
+      cy.intercept("GET", "/api/latest/fleet/config", addZendeskIntegration).as(
+        "addedIntegration"
+      );
       cy.findByRole("button", { name: /save/i }).click();
-      cy.wait("@createIntegration").then((configStub) => {
+      cy.wait("@addIntegration").then((configStub) => {
         cy.log(JSON.stringify(configStub));
         console.log(JSON.stringify(configStub));
       });
-      cy.wait("@createdIntegration").then((configStub) => {
+      cy.wait("@addedIntegration").then((configStub) => {
         cy.log(JSON.stringify(configStub));
         console.log(JSON.stringify(configStub));
       });

--- a/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
@@ -162,11 +162,11 @@ const IntegrationsPage = (): JSX.Element => {
           refetchIntegrations();
         })
         .catch((addError: { data: IApiError }) => {
-          if (addError.data.message.includes("Validation Failed")) {
+          if (addError.data?.message.includes("Validation Failed")) {
             renderFlash("error", VALIDATION_FAILED_ERROR);
-          } else if (addError.data.message.includes("Bad request")) {
+          } else if (addError.data?.message.includes("Bad request")) {
             if (
-              addError.data.errors[0].reason.includes(
+              addError.data?.errors[0].reason.includes(
                 "duplicate Jira integration for project key"
               )
             ) {
@@ -191,7 +191,7 @@ const IntegrationsPage = (): JSX.Element => {
             } else {
               renderFlash("error", BAD_REQUEST_ERROR);
             }
-          } else if (addError.data.message.includes("Unknown Error")) {
+          } else if (addError.data?.message.includes("Unknown Error")) {
             renderFlash("error", UNKNOWN_ERROR);
           } else {
             renderFlash(

--- a/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
@@ -163,11 +163,9 @@ const IntegrationsPage = (): JSX.Element => {
         })
         .catch((addError: { data: IApiError }) => {
           if (addError.data?.message.includes("Validation Failed")) {
-            renderFlash("error", VALIDATION_FAILED_ERROR);
-          } else if (addError.data?.message.includes("Bad request")) {
             if (
               addError.data?.errors[0].reason.includes(
-                "duplicate Jira integration for project key"
+                "duplicate Jira integration"
               )
             ) {
               renderFlash(
@@ -189,8 +187,10 @@ const IntegrationsPage = (): JSX.Element => {
                 </>
               );
             } else {
-              renderFlash("error", BAD_REQUEST_ERROR);
+              renderFlash("error", VALIDATION_FAILED_ERROR);
             }
+          } else if (addError.data?.message.includes("Bad request")) {
+            renderFlash("error", BAD_REQUEST_ERROR);
           } else if (addError.data?.message.includes("Unknown Error")) {
             renderFlash("error", UNKNOWN_ERROR);
           } else {

--- a/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
@@ -204,7 +204,6 @@ const IntegrationsPage = (): JSX.Element => {
                 . Please try again.
               </>
             );
-            toggleAddIntegrationModal();
           }
         })
         .finally(() => {

--- a/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
@@ -20,7 +20,7 @@ import configAPI from "services/entities/config";
 
 import TableContainer from "components/TableContainer";
 import TableDataError from "components/DataError";
-import AddIntegrationModal from "./components/CreateIntegrationModal";
+import AddIntegrationModal from "./components/AddIntegrationModal";
 import DeleteIntegrationModal from "./components/DeleteIntegrationModal";
 import EditIntegrationModal from "./components/EditIntegrationModal";
 import ExternalLinkIcon from "../../../../assets/images/icon-external-link-12x12@2x.png";
@@ -130,7 +130,7 @@ const IntegrationsPage = (): JSX.Element => {
     ]
   );
 
-  const onCreateSubmit = useCallback(
+  const onAddSubmit = useCallback(
     (integrationSubmitData: IIntegration[], integrationDestination: string) => {
       // Updates either integrations.jira or integrations.zendesk
       const destination = () => {
@@ -161,19 +161,19 @@ const IntegrationsPage = (): JSX.Element => {
           toggleAddIntegrationModal();
           refetchIntegrations();
         })
-        .catch((createError: { data: IApiError }) => {
-          if (createError.data.message.includes("Validation Failed")) {
+        .catch((addError: { data: IApiError }) => {
+          if (addError.data.message.includes("Validation Failed")) {
             renderFlash("error", VALIDATION_FAILED_ERROR);
-          } else if (createError.data.message.includes("Bad request")) {
+          } else if (addError.data.message.includes("Bad request")) {
             if (
-              createError.data.errors[0].reason.includes(
+              addError.data.errors[0].reason.includes(
                 "duplicate Jira integration for project key"
               )
             ) {
               renderFlash(
                 "error",
                 <>
-                  Could not add add{" "}
+                  Could not add{" "}
                   <b>
                     {
                       integrationSubmitData[integrationSubmitData.length - 1]
@@ -191,7 +191,7 @@ const IntegrationsPage = (): JSX.Element => {
             } else {
               renderFlash("error", BAD_REQUEST_ERROR);
             }
-          } else if (createError.data.message.includes("Unknown Error")) {
+          } else if (addError.data.message.includes("Unknown Error")) {
             renderFlash("error", UNKNOWN_ERROR);
           } else {
             renderFlash(
@@ -384,7 +384,7 @@ const IntegrationsPage = (): JSX.Element => {
             </p>
             <Button
               variant="brand"
-              className={`${noIntegrationsClass}__create-button`}
+              className={`${noIntegrationsClass}__add-button`}
               onClick={toggleAddIntegrationModal}
             >
               Add integration
@@ -428,7 +428,7 @@ const IntegrationsPage = (): JSX.Element => {
       {showAddIntegrationModal && (
         <AddIntegrationModal
           onCancel={toggleAddIntegrationModal}
-          onSubmit={onCreateSubmit}
+          onSubmit={onAddSubmit}
           backendValidators={backendValidators}
           integrations={integrations || { jira: [], zendesk: [] }}
           testingConnection={testingConnection}

--- a/frontend/pages/admin/IntegrationsPage/components/AddIntegrationModal/AddIntegrationModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/components/AddIntegrationModal/AddIntegrationModal.tsx
@@ -3,14 +3,13 @@ import React, { useState, useEffect } from "react";
 import Modal from "components/Modal";
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
-import Spinner from "components/Spinner";
 import { IIntegration, IIntegrations } from "interfaces/integration";
 import IntegrationForm from "../IntegrationForm";
 import ExternalLinkIcon from "../../../../../../assets/images/icon-external-link-12x12@2x.png";
 
-const baseClass = "create-integration-modal";
+const baseClass = "add-integration-modal";
 
-interface ICreateIntegrationModalProps {
+interface IAddIntegrationModalProps {
   onCancel: () => void;
   onSubmit: (
     integrationSubmitData: IIntegration[],
@@ -27,13 +26,13 @@ const destinationOptions = [
   { label: "Zendesk", value: "zendesk" },
 ];
 
-const CreateIntegrationModal = ({
+const AddIntegrationModal = ({
   onCancel,
   onSubmit,
   backendValidators,
   integrations,
   testingConnection,
-}: ICreateIntegrationModalProps): JSX.Element => {
+}: IAddIntegrationModalProps): JSX.Element => {
   const [errors, setErrors] = useState<{ [key: string]: string }>(
     backendValidators
   );
@@ -49,13 +48,8 @@ const CreateIntegrationModal = ({
 
   return (
     <Modal title={"Add integration"} onExit={onCancel} className={baseClass}>
-      {testingConnection ? (
-        <div className={`${baseClass}__testing-connection`}>
-          <b>Testing connection</b>
-          <Spinner />
-        </div>
-      ) : (
-        <>
+      <>
+        {!testingConnection && (
           <div className={`${baseClass}__info-header`}>
             <Dropdown
               label="Ticket destination"
@@ -75,16 +69,17 @@ const CreateIntegrationModal = ({
               <img src={ExternalLinkIcon} alt="Open external link" />
             </a>
           </div>
-          <IntegrationForm
-            onCancel={onCancel}
-            onSubmit={onSubmit}
-            integrations={integrations}
-            destination={destination}
-          />
-        </>
-      )}
+        )}
+        <IntegrationForm
+          onCancel={onCancel}
+          onSubmit={onSubmit}
+          integrations={integrations}
+          destination={destination}
+          testingConnection={testingConnection}
+        />
+      </>
     </Modal>
   );
 };
 
-export default CreateIntegrationModal;
+export default AddIntegrationModal;

--- a/frontend/pages/admin/IntegrationsPage/components/AddIntegrationModal/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/components/AddIntegrationModal/_styles.scss
@@ -1,4 +1,4 @@
-.create-integration-modal {
+.add-integration-modal {
   &__info-header {
     margin-bottom: $pad-xlarge;
   }

--- a/frontend/pages/admin/IntegrationsPage/components/AddIntegrationModal/index.ts
+++ b/frontend/pages/admin/IntegrationsPage/components/AddIntegrationModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddIntegrationModal";

--- a/frontend/pages/admin/IntegrationsPage/components/CreateIntegrationModal/index.ts
+++ b/frontend/pages/admin/IntegrationsPage/components/CreateIntegrationModal/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./CreateIntegrationModal";

--- a/frontend/pages/admin/IntegrationsPage/components/IntegrationForm/IntegrationForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/components/IntegrationForm/IntegrationForm.tsx
@@ -12,7 +12,6 @@ import Button from "components/buttons/Button";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
 import Spinner from "components/Spinner";
-import { debug } from "webpack";
 
 const baseClass = "integration-form";
 

--- a/frontend/pages/admin/IntegrationsPage/components/IntegrationForm/IntegrationForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/components/IntegrationForm/IntegrationForm.tsx
@@ -160,124 +160,101 @@ const IntegrationForm = ({
     return onSubmit(createSubmitData(), integrationDestination);
   };
 
-  if (testingConnection) {
-    return (
-      <div className={`${baseClass}__testing-connection`}>
-        <b>Testing connection</b>
-        <Spinner />
-      </div>
-    );
-  }
-
   return (
     <>
-      <form
-        className={
-          testingConnection ? `${baseClass}__hide-form` : `${baseClass}__form`
-        }
-        onSubmit={onFormSubmit}
-        autoComplete="off"
-      >
-        <InputField
-          autofocus
-          name="url"
-          onChange={onInputChange}
-          label="URL"
-          placeholder={
-            integrationDestination === "jira"
-              ? "https://example.atlassian.net"
-              : "https://example.zendesk.com"
-          }
-          parseTarget
-          value={url}
-          error={urlError}
-          onBlur={validateForm}
-        />
-        {integrationDestination === "jira" ? (
+      {testingConnection ? (
+        <div className={`${baseClass}__testing-connection`}>
+          <b>Testing connection</b>
+          <Spinner />
+        </div>
+      ) : (
+        <form
+          className={`${baseClass}__form`}
+          onSubmit={onFormSubmit}
+          autoComplete="off"
+        >
           <InputField
-            name="username"
+            autofocus
+            name="url"
             onChange={onInputChange}
-            label="Username"
-            placeholder="name@example.com"
+            label="URL"
+            placeholder={
+              integrationDestination === "jira"
+                ? "https://example.atlassian.net"
+                : "https://example.zendesk.com"
+            }
             parseTarget
-            value={username}
+            value={url}
+            error={urlError}
+            onBlur={validateForm}
           />
-        ) : (
+          {integrationDestination === "jira" ? (
+            <InputField
+              name="username"
+              onChange={onInputChange}
+              label="Username"
+              placeholder="name@example.com"
+              parseTarget
+              value={username}
+            />
+          ) : (
+            <InputField
+              name="email"
+              onChange={onInputChange}
+              label="Email"
+              placeholder="name@example.com"
+              parseTarget
+              value={email}
+            />
+          )}
           <InputField
-            name="email"
+            name="apiToken"
             onChange={onInputChange}
-            label="Email"
-            placeholder="name@example.com"
+            label="API token"
             parseTarget
-            value={email}
+            value={apiToken}
           />
-        )}
-        <InputField
-          name="apiToken"
-          onChange={onInputChange}
-          label="API token"
-          parseTarget
-          value={apiToken}
-        />
-        {integrationDestination === "jira" ? (
-          <InputField
-            name="projectKey"
-            onChange={onInputChange}
-            label="Project key"
-            placeholder="JRAEXAMPLE"
-            parseTarget
-            value={projectKey}
-            tooltip={
-              "\
+          {integrationDestination === "jira" ? (
+            <InputField
+              name="projectKey"
+              onChange={onInputChange}
+              label="Project key"
+              placeholder="JRAEXAMPLE"
+              parseTarget
+              value={projectKey}
+              tooltip={
+                "\
               To find the Jira project key, head to your project in <br /> \
               Jira. Your project key is in URL. For example, in <br /> \
               “jira.example.com/projects/JRAEXAMPLE,” <br /> \
               “JRAEXAMPLE” is your project key. \
             "
-            }
-          />
-        ) : (
-          <InputField
-            name="groupId"
-            onChange={onInputChange}
-            label="Group ID"
-            placeholder="28134038"
-            type="number"
-            parseTarget
-            value={groupId === 0 ? null : groupId}
-            tooltip={
-              "\
+              }
+            />
+          ) : (
+            <InputField
+              name="groupId"
+              onChange={onInputChange}
+              label="Group ID"
+              placeholder="28134038"
+              type="number"
+              parseTarget
+              value={groupId === 0 ? null : groupId}
+              tooltip={
+                "\
               To find the Zendesk group ID, select <b>Admin > <br /> \
               People > Groups</b>. Find the group and select it. <br /> \
               The group ID will appear in the search field. \
             "
-            }
-          />
-        )}
-        <div className="modal-cta-wrap">
-          <div
-            data-tip
-            data-for="create-integration-button"
-            data-tip-disable={
-              !(integrationDestination === "jira"
-                ? formData.url === "" ||
-                  formData.url.slice(0, 8) !== "https://" ||
-                  formData.username === "" ||
-                  formData.apiToken === "" ||
-                  formData.projectKey === ""
-                : formData.url === "" ||
-                  formData.url.slice(0, 8) !== "https://" ||
-                  formData.email === "" ||
-                  formData.apiToken === "" ||
-                  formData.groupId === 0)
-            }
-            className={"tooltip"}
-          >
-            <Button
-              type="submit"
-              variant="brand"
-              disabled={
-                integrationDestination === "jira"
+              }
+            />
+          )}
+          <div className="modal-cta-wrap">
+            <div
+              data-tip
+              data-for="add-integration-button"
+              data-tip-disable={
+                !(integrationDestination === "jira"
                   ? formData.url === "" ||
                     formData.url.slice(0, 8) !== "https://" ||
                     formData.username === "" ||
@@ -287,29 +264,48 @@ const IntegrationForm = ({
                     formData.url.slice(0, 8) !== "https://" ||
                     formData.email === "" ||
                     formData.apiToken === "" ||
-                    formData.groupId === 0
+                    formData.groupId === 0)
               }
+              className={"tooltip"}
             >
-              Save
+              <Button
+                type="submit"
+                variant="brand"
+                disabled={
+                  integrationDestination === "jira"
+                    ? formData.url === "" ||
+                      formData.url.slice(0, 8) !== "https://" ||
+                      formData.username === "" ||
+                      formData.apiToken === "" ||
+                      formData.projectKey === ""
+                    : formData.url === "" ||
+                      formData.url.slice(0, 8) !== "https://" ||
+                      formData.email === "" ||
+                      formData.apiToken === "" ||
+                      formData.groupId === 0
+                }
+              >
+                Save
+              </Button>
+            </div>
+            <ReactTooltip
+              className={`add-integration-tooltip`}
+              place="bottom"
+              effect="solid"
+              backgroundColor="#3e4771"
+              id="add-integration-button"
+              data-html
+            >
+              <>
+                Complete all fields to save <br /> the integration.
+              </>
+            </ReactTooltip>
+            <Button onClick={onCancel} variant="inverse">
+              Cancel
             </Button>
           </div>
-          <ReactTooltip
-            className={`create-integration-tooltip`}
-            place="bottom"
-            effect="solid"
-            backgroundColor="#3e4771"
-            id="create-integration-button"
-            data-html
-          >
-            <>
-              Complete all fields to save <br /> the integration.
-            </>
-          </ReactTooltip>
-          <Button onClick={onCancel} variant="inverse">
-            Cancel
-          </Button>
-        </div>
-      </form>
+        </form>
+      )}
     </>
   );
 };

--- a/frontend/pages/admin/IntegrationsPage/components/IntegrationForm/IntegrationForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/components/IntegrationForm/IntegrationForm.tsx
@@ -11,6 +11,8 @@ import {
 import Button from "components/buttons/Button";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
+import Spinner from "components/Spinner";
+import { debug } from "webpack";
 
 const baseClass = "integration-form";
 
@@ -31,6 +33,7 @@ interface IIntegrationFormProps {
   integrationEnableSoftwareVulnerabilities?: boolean;
   integrationEditingType?: string;
   destination?: string;
+  testingConnection?: boolean;
 }
 
 interface IFormField {
@@ -52,6 +55,7 @@ const IntegrationForm = ({
   integrationEnableSoftwareVulnerabilities,
   integrationEditingType,
   destination,
+  testingConnection,
 }: IIntegrationFormProps): JSX.Element => {
   const { jira: jiraIntegrations, zendesk: zendeskIntegrations } = integrations;
   const [formData, setFormData] = useState<IIntegrationFormData>({
@@ -157,112 +161,106 @@ const IntegrationForm = ({
     return onSubmit(createSubmitData(), integrationDestination);
   };
 
+  if (testingConnection) {
+    return (
+      <div className={`${baseClass}__testing-connection`}>
+        <b>Testing connection</b>
+        <Spinner />
+      </div>
+    );
+  }
+
   return (
-    <form
-      className={`${baseClass}__form`}
-      onSubmit={onFormSubmit}
-      autoComplete="off"
-    >
-      <InputField
-        autofocus
-        name="url"
-        onChange={onInputChange}
-        label="URL"
-        placeholder={
-          integrationDestination === "jira"
-            ? "https://example.atlassian.net"
-            : "https://example.zendesk.com"
+    <>
+      <form
+        className={
+          testingConnection ? `${baseClass}__hide-form` : `${baseClass}__form`
         }
-        parseTarget
-        value={url}
-        error={urlError}
-        onBlur={validateForm}
-      />
-      {integrationDestination === "jira" ? (
+        onSubmit={onFormSubmit}
+        autoComplete="off"
+      >
         <InputField
-          name="username"
+          autofocus
+          name="url"
           onChange={onInputChange}
-          label="Username"
-          placeholder="name@example.com"
+          label="URL"
+          placeholder={
+            integrationDestination === "jira"
+              ? "https://example.atlassian.net"
+              : "https://example.zendesk.com"
+          }
           parseTarget
-          value={username}
+          value={url}
+          error={urlError}
+          onBlur={validateForm}
         />
-      ) : (
+        {integrationDestination === "jira" ? (
+          <InputField
+            name="username"
+            onChange={onInputChange}
+            label="Username"
+            placeholder="name@example.com"
+            parseTarget
+            value={username}
+          />
+        ) : (
+          <InputField
+            name="email"
+            onChange={onInputChange}
+            label="Email"
+            placeholder="name@example.com"
+            parseTarget
+            value={email}
+          />
+        )}
         <InputField
-          name="email"
+          name="apiToken"
           onChange={onInputChange}
-          label="Email"
-          placeholder="name@example.com"
+          label="API token"
           parseTarget
-          value={email}
+          value={apiToken}
         />
-      )}
-      <InputField
-        name="apiToken"
-        onChange={onInputChange}
-        label="API token"
-        parseTarget
-        value={apiToken}
-      />
-      {integrationDestination === "jira" ? (
-        <InputField
-          name="projectKey"
-          onChange={onInputChange}
-          label="Project key"
-          placeholder="JRAEXAMPLE"
-          parseTarget
-          value={projectKey}
-          tooltip={
-            "\
+        {integrationDestination === "jira" ? (
+          <InputField
+            name="projectKey"
+            onChange={onInputChange}
+            label="Project key"
+            placeholder="JRAEXAMPLE"
+            parseTarget
+            value={projectKey}
+            tooltip={
+              "\
               To find the Jira project key, head to your project in <br /> \
               Jira. Your project key is in URL. For example, in <br /> \
               “jira.example.com/projects/JRAEXAMPLE,” <br /> \
               “JRAEXAMPLE” is your project key. \
             "
-          }
-        />
-      ) : (
-        <InputField
-          name="groupId"
-          onChange={onInputChange}
-          label="Group ID"
-          placeholder="28134038"
-          type="number"
-          parseTarget
-          value={groupId === 0 ? null : groupId}
-          tooltip={
-            "\
+            }
+          />
+        ) : (
+          <InputField
+            name="groupId"
+            onChange={onInputChange}
+            label="Group ID"
+            placeholder="28134038"
+            type="number"
+            parseTarget
+            value={groupId === 0 ? null : groupId}
+            tooltip={
+              "\
               To find the Zendesk group ID, select <b>Admin > <br /> \
               People > Groups</b>. Find the group and select it. <br /> \
               The group ID will appear in the search field. \
             "
-          }
-        />
-      )}
-      <div className="modal-cta-wrap">
-        <div
-          data-tip
-          data-for="create-integration-button"
-          data-tip-disable={
-            !(integrationDestination === "jira"
-              ? formData.url === "" ||
-                formData.url.slice(0, 8) !== "https://" ||
-                formData.username === "" ||
-                formData.apiToken === "" ||
-                formData.projectKey === ""
-              : formData.url === "" ||
-                formData.url.slice(0, 8) !== "https://" ||
-                formData.email === "" ||
-                formData.apiToken === "" ||
-                formData.groupId === 0)
-          }
-          className={"tooltip"}
-        >
-          <Button
-            type="submit"
-            variant="brand"
-            disabled={
-              integrationDestination === "jira"
+            }
+          />
+        )}
+        <div className="modal-cta-wrap">
+          <div
+            data-tip
+            data-for="create-integration-button"
+            data-tip-disable={
+              !(integrationDestination === "jira"
                 ? formData.url === "" ||
                   formData.url.slice(0, 8) !== "https://" ||
                   formData.username === "" ||
@@ -272,29 +270,48 @@ const IntegrationForm = ({
                   formData.url.slice(0, 8) !== "https://" ||
                   formData.email === "" ||
                   formData.apiToken === "" ||
-                  formData.groupId === 0
+                  formData.groupId === 0)
             }
+            className={"tooltip"}
           >
-            Save
+            <Button
+              type="submit"
+              variant="brand"
+              disabled={
+                integrationDestination === "jira"
+                  ? formData.url === "" ||
+                    formData.url.slice(0, 8) !== "https://" ||
+                    formData.username === "" ||
+                    formData.apiToken === "" ||
+                    formData.projectKey === ""
+                  : formData.url === "" ||
+                    formData.url.slice(0, 8) !== "https://" ||
+                    formData.email === "" ||
+                    formData.apiToken === "" ||
+                    formData.groupId === 0
+              }
+            >
+              Save
+            </Button>
+          </div>
+          <ReactTooltip
+            className={`create-integration-tooltip`}
+            place="bottom"
+            effect="solid"
+            backgroundColor="#3e4771"
+            id="create-integration-button"
+            data-html
+          >
+            <>
+              Complete all fields to save <br /> the integration.
+            </>
+          </ReactTooltip>
+          <Button onClick={onCancel} variant="inverse">
+            Cancel
           </Button>
         </div>
-        <ReactTooltip
-          className={`create-integration-tooltip`}
-          place="bottom"
-          effect="solid"
-          backgroundColor="#3e4771"
-          id="create-integration-button"
-          data-html
-        >
-          <>
-            Complete all fields to save <br /> the integration.
-          </>
-        </ReactTooltip>
-        <Button onClick={onCancel} variant="inverse">
-          Cancel
-        </Button>
-      </div>
-    </form>
+      </form>
+    </>
   );
 };
 

--- a/frontend/pages/admin/IntegrationsPage/components/IntegrationForm/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/components/IntegrationForm/_styles.scss
@@ -116,4 +116,8 @@
   &__tooltip-text {
     width: 300px;
   }
+
+  &__hide-form {
+    display: hidden;
+  }
 }

--- a/frontend/pages/admin/IntegrationsPage/components/IntegrationForm/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/components/IntegrationForm/_styles.scss
@@ -116,8 +116,4 @@
   &__tooltip-text {
     width: 300px;
   }
-
-  &__hide-form {
-    display: hidden;
-  }
 }


### PR DESCRIPTION
Cerra #7843 

**Fix**
- Fix bug that was clearing fields when adding integration (After `testingConnection` the form was re-rendering with the default empty fields because `formData` state lived in a child component but `testingConnection` spinner would make the component disappear and then re-render it after. Moved `testingConnection` spinner onto child component)

**Other tech debt**
- Rename `create` integration to `add` integration throughout frontend code to match UI
- Fix rendering wrong error on trying to create duplicate integration
- Fix modal from closing on default error

**Note**
- Consider removing `EditIntegrationModal.tsx` and related files since we removed Edit from the Settings > Integrations table action dropdown

**Video of fix that form does not clear on error (pardon the crop above my API token)**

https://user-images.githubusercontent.com/71795832/192628592-ac4cca60-b9e9-4efd-bbfd-f0df432f2135.mov



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
