### PR TITLE
add index to `orbit_node_key`

### DIFF
--- a/server/datastore/mysql/migrations/tables/20220908181826_AddOrbitNodeKeyToHosts.go
+++ b/server/datastore/mysql/migrations/tables/20220908181826_AddOrbitNodeKeyToHosts.go
@@ -10,6 +10,9 @@ func init() {
 
 func Up_20220908181826(tx *sql.Tx) error {
 	_, err := tx.Exec(`ALTER TABLE hosts ADD COLUMN orbit_node_key VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL;`)
+	if err != nil {
+		return err
+	}
 	_, err = tx.Exec(`ALTER TABLE hosts ADD UNIQUE KEY idx_host_unique_orbitnodekey (orbit_node_key);`)
 	return err
 }

--- a/server/datastore/mysql/migrations/tables/20220908181826_AddOrbitNodeKeyToHosts.go
+++ b/server/datastore/mysql/migrations/tables/20220908181826_AddOrbitNodeKeyToHosts.go
@@ -10,6 +10,7 @@ func init() {
 
 func Up_20220908181826(tx *sql.Tx) error {
 	_, err := tx.Exec(`ALTER TABLE hosts ADD COLUMN orbit_node_key VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL;`)
+	_, err = tx.Exec(`ALTER TABLE hosts ADD UNIQUE KEY idx_host_unique_orbitnodekey (orbit_node_key);`)
 	return err
 }
 

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -305,6 +305,7 @@ CREATE TABLE `hosts` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_osquery_host_id` (`osquery_host_id`),
   UNIQUE KEY `idx_host_unique_nodekey` (`node_key`),
+  UNIQUE KEY `idx_host_unique_orbitnodekey` (`orbit_node_key`),
   KEY `fk_hosts_team_id` (`team_id`),
   KEY `hosts_platform_idx` (`platform`),
   FULLTEXT KEY `hosts_search` (`hostname`,`uuid`),


### PR DESCRIPTION
Adds an index on `orbit_node_key`  in the `hosts` table

- [x] Manual QA for all new/changed functionality
