### PR TITLE
Add handling for Apple Team ID in Notarization

### DIFF
--- a/.github/workflows/generate-desktop-targets.yml
+++ b/.github/workflows/generate-desktop-targets.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           AC_USERNAME: ${{ secrets.APPLE_USERNAME }}
           AC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          AC_TEAM_ID: ${{ secrets.AC_TEAM_ID }}
+          AC_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           CODESIGN_IDENTITY: 51049B247B25B3119FAE7E9C0CC4375A43E47237
         run: |
           AC_USERNAME=$AC_USERNAME \

--- a/.github/workflows/generate-desktop-targets.yml
+++ b/.github/workflows/generate-desktop-targets.yml
@@ -51,6 +51,7 @@ jobs:
         env:
           AC_USERNAME: ${{ secrets.APPLE_USERNAME }}
           AC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          AC_TEAM_ID: ${{ secrets.AC_TEAM_ID }}
           CODESIGN_IDENTITY: 51049B247B25B3119FAE7E9C0CC4375A43E47237
         run: |
           AC_USERNAME=$AC_USERNAME \

--- a/.github/workflows/generate-desktop-targets.yml
+++ b/.github/workflows/generate-desktop-targets.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 env:
-  FLEET_DESKTOP_VERSION: 1.1.0
+  FLEET_DESKTOP_VERSION: 1.2.0
 
 permissions:
   contents: read
@@ -55,6 +55,7 @@ jobs:
         run: |
           AC_USERNAME=$AC_USERNAME \
           AC_PASSWORD=$AC_PASSWORD \
+          AC_TEAM_ID=$AC_TEAM_ID \
           FLEET_DESKTOP_APPLE_AUTHORITY=$CODESIGN_IDENTITY \
           FLEET_DESKTOP_NOTARIZE=true \
           FLEET_DESKTOP_VERSION=$FLEET_DESKTOP_VERSION \

--- a/changes/notarization-team-id
+++ b/changes/notarization-team-id
@@ -1,0 +1,1 @@
+* Add support for Apple Team ID in Notarization workflows via `AC_TEAM_ID` environment variable.

--- a/docs/Using-Fleet/Adding-hosts.md
+++ b/docs/Using-Fleet/Adding-hosts.md
@@ -36,7 +36,7 @@ Check out the example below:
 
 The above command should be run on a macOS device as notarizing and signing of macOS osquery installers can only be done on macOS devices.
 
-Also, remember to replace both `AC_USERNAME` and `AC_PASSWORD` environment variables with your Apple ID and a valid [app-specific](https://support.apple.com/en-ca/HT204397) password, respectively. Some organizations (notably those with Apple Enterprise Developer Accounts) may also need to specify `AC_TEAM_ID`. This value can be found on the [Apple Developer "Membership" page](https://developer.apple.com/account/#!/membership) under "Team ID". 
+Also, remember to replace both `AC_USERNAME` and `AC_PASSWORD` environment variables with your Apple ID and a valid [app-specific](https://support.apple.com/en-ca/HT204397) password, respectively. Some organizations (notably those with Apple Enterprise Developer Accounts) may also need to specify `AC_TEAM_ID`. This value can be found on the [Apple Developer "Membership" page](https://developer.apple.com/account/#!/membership) under "Team ID."
 
 ### Including Fleet Desktop
 

--- a/docs/Using-Fleet/Adding-hosts.md
+++ b/docs/Using-Fleet/Adding-hosts.md
@@ -36,7 +36,7 @@ Check out the example below:
 
 The above command should be run on a macOS device as notarizing and signing of macOS osquery installers can only be done on macOS devices.
 
-Also, remember to replace both `AC_USERNAME` and `AC_PASSWORD` environment variables with your Apple ID and a valid [app-specific](https://support.apple.com/en-ca/HT204397) password, respectively.
+Also, remember to replace both `AC_USERNAME` and `AC_PASSWORD` environment variables with your Apple ID and a valid [app-specific](https://support.apple.com/en-ca/HT204397) password, respectively. Some organizations (notably those with Apple Enterprise Developer Accounts) may also need to specify `AC_TEAM_ID`. This value can be found on the [Apple Developer "Membership" page](https://developer.apple.com/account/#!/membership) under "Team ID". 
 
 ### Including Fleet Desktop
 

--- a/orbit/README.md
+++ b/orbit/README.md
@@ -160,7 +160,7 @@ Orbit's packager can automate the codesigning and Notarization steps to allow th
 
 For signing, a "Developer ID Installer" certificate must be available on the build machine ([generation instructions](https://help.apple.com/xcode/mac/current/#/dev154b28f09)). Use `security find-identity -v` to verify the existence of this certificate and make note of the identifier provided in the left column.
 
-For Notarization, valid App Store Connect credentials must be available on the build machine. Set these in the environment variables `AC_USERNAME` and `AC_PASSWORD`. It is common to configure this via [app-specific passwords](https://support.apple.com/en-ca/HT204397).
+For Notarization, valid App Store Connect credentials must be available on the build machine. Set these in the environment variables `AC_USERNAME` and `AC_PASSWORD`. It is common to configure this via [app-specific passwords](https://support.apple.com/en-ca/HT204397). Some organizations (notably those with Apple Enterprise Developer Accounts) may also need to specify `AC_TEAM_ID`. This value can be found on the [Apple Developer "Membership" page](https://developer.apple.com/account/#!/membership) under "Team ID".
 
 Build a signed and notarized macOS package with an invocation like the following:
 

--- a/orbit/pkg/packaging/macos_notarize.go
+++ b/orbit/pkg/packaging/macos_notarize.go
@@ -25,6 +25,10 @@ func Notarize(path, bundleIdentifier string) error {
 		return errors.New("AC_PASSWORD must be set in environment")
 	}
 
+	// This is typically optional, though seems to be required if the organization has an Apple
+	// Enterprise Dev account.
+	teamID, _ := os.LookupEnv("AC_TEAM_ID")
+
 	info, err := notarize.Notarize(
 		context.Background(),
 		&notarize.Options{
@@ -32,6 +36,7 @@ func Notarize(path, bundleIdentifier string) error {
 			BundleId: bundleIdentifier,
 			Username: username,
 			Password: password,
+			Provider: teamID,
 			Status: &statusHuman{
 				Lock: &sync.Mutex{},
 			},

--- a/tools/desktop/desktop.go
+++ b/tools/desktop/desktop.go
@@ -81,7 +81,7 @@ func macos() *cli.Command {
 				EnvVars: []string{"FLEET_DESKTOP_APPLE_AUTHORITY"},
 			},
 			&cli.BoolFlag{
-				Name:    "`notarize`",
+				Name:    "notarize",
 				Usage:   "If true, the generated application will be notarized and stapled. Requires the `AC_USERNAME` and `AC_PASSWORD` to be set in the environment",
 				EnvVars: []string{"FLEET_DESKTOP_NOTARIZE"},
 			},


### PR DESCRIPTION
Fleet's Notarization workflows no longer work without this argument, so this is added as an optional argument for Notarization.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
~- [ ] Documented any permissions changes~
~- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
~- [ ] Added/updated tests~
- [x] Manual QA for all new/changed functionality
