### PR TITLE
fix label filter showing under table header and adding no custom filter state

### DIFF
--- a/changes/issue-7917-fix-z-index-and-add-no-custom-labels-state
+++ b/changes/issue-7917-fix-z-index-and-add-no-custom-labels-state
@@ -1,0 +1,1 @@
+- This fixes the UI bug where the label filter dropdown goes under the table header and add a "no custom labels" state that shows when the user has not created any custom labels yet.

--- a/frontend/pages/hosts/ManageHostsPage/components/CustomLabelGroupHeading/CustomLabelGroupHeading.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/CustomLabelGroupHeading/CustomLabelGroupHeading.tsx
@@ -1,3 +1,8 @@
+/**
+ * This component is a custom UI for a React Select group header.
+ * More can be learnt about React Select custom components here:
+ * https://react-select.com/components
+ */
 import Button from "components/buttons/Button";
 import { ILabel } from "interfaces/label";
 import React, { useRef } from "react";

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -58,6 +58,7 @@
   .label-filter-select__menu {
     width: 300px;
     margin-top: 0;
+    z-index: 2;
   }
 
   .label-filter-select__menu-list {

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/constants.ts
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/constants.ts
@@ -2,8 +2,13 @@ import linuxIcon from "../../../../../../assets/images/icon-linux-fleet-black-16
 import darwinIcon from "../../../../../../assets/images/icon-darwin-fleet-black-16x16@2x.png";
 import windowsIcon from "../../../../../../assets/images/icon-windows-fleet-black-16x16@2x.png";
 
+export const NO_LABELS_OPTION = {
+  label: "No custom labels",
+  isDisabled: true,
+};
+
 export const EMPTY_OPTION = {
-  label: "No Matching Labels",
+  label: "No matching labels",
   isDisabled: true,
 };
 

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/helpers.ts
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/helpers.ts
@@ -1,5 +1,5 @@
 import { ILabel } from "interfaces/label";
-import { EMPTY_OPTION, FILTERED_LINUX } from "./constants";
+import { EMPTY_OPTION, FILTERED_LINUX, NO_LABELS_OPTION } from "./constants";
 
 export interface IEmptyOption {
   label: string;
@@ -24,7 +24,26 @@ const createOptionGroup = (
   };
 };
 
-export const createDropdownOptions = (labels: ILabel[], labelQuery: string) => {
+/** Will create the custom label group options and handles when no labels have been created yet or
+ * will filter by the desired search query */
+const createCustomLabelOptions = (labels: ILabel[], query: string) => {
+  const customLabels = labels.filter((label) => label.label_type === "regular");
+
+  let customLabelGroupOptions: ILabel[] | IEmptyOption[];
+  if (customLabels.length === 0) {
+    customLabelGroupOptions = [NO_LABELS_OPTION];
+  } else {
+    const matchingLabels = customLabels.filter((label) =>
+      label.display_text.toLowerCase().includes(query)
+    );
+    customLabelGroupOptions =
+      matchingLabels.length !== 0 ? matchingLabels : [EMPTY_OPTION];
+  }
+
+  return customLabelGroupOptions;
+};
+
+export const createDropdownOptions = (labels: ILabel[], query: string) => {
   const builtInLabels = labels.filter(
     // we filter out All Hosts as that is included in hosts status dropdown filter
     (label) =>
@@ -32,16 +51,12 @@ export const createDropdownOptions = (labels: ILabel[], labelQuery: string) => {
       label.name !== "All Hosts" &&
       !FILTERED_LINUX.includes(label.name)
   );
-  const customLabels = labels.filter(
-    (label) =>
-      label.label_type === "regular" &&
-      label.display_text.toLowerCase().includes(labelQuery)
-  );
-  const customGroupOptions =
-    customLabels.length !== 0 ? customLabels : [EMPTY_OPTION];
+
+  const customLabels = createCustomLabelOptions(labels, query);
+
   const options: IGroupOption[] = [
     createOptionGroup("platform", "Platforms", builtInLabels),
-    createOptionGroup("custom", "Labels", customGroupOptions),
+    createOptionGroup("custom", "Labels", customLabels),
   ];
   return options;
 };


### PR DESCRIPTION
relates to [#7917](https://github.com/fleetdm/fleet/issues/7917)

This fixes the UI bug where the label filter dropdown goes under the table header.

![image](https://user-images.githubusercontent.com/1153709/192793338-6cc18a1b-ba93-4169-bacf-7dff611d50aa.png)


It also adds a "no custom labels" state that shows when the user has not created any custom labels yet.

**User has not created custom labels yet**

![image](https://user-images.githubusercontent.com/1153709/192789335-1f8a0583-dd29-42df-968c-8aafae6a85a0.png)

**User has custom labels but no search matches**

![image](https://user-images.githubusercontent.com/1153709/192789512-41500b8e-0f79-4b82-a48c-2ed4f1d606d7.png)


- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
