### PR TITLE
Fleet UI: Helpful team agent errors

### DIFF
--- a/changes/issue-7997-better-agent-options-error
+++ b/changes/issue-7997-better-agent-options-error
@@ -1,0 +1,1 @@
+* Global agent options renders backend errors in UI

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
@@ -72,7 +72,7 @@ const AgentOptionsPage = ({
         console.error(response);
         return renderFlash(
           "error",
-          `Could not update agent options. ${response.data.errors[0].reason}`
+          `Could not update team agent options. ${response.data.errors[0].reason}`
         );
       });
   };

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
@@ -4,6 +4,7 @@ import { useErrorHandler } from "react-error-boundary";
 import yaml from "js-yaml";
 
 import { NotificationContext } from "context/notification";
+import { IApiError } from "interfaces/errors";
 import { ITeam } from "interfaces/team";
 import endpoints from "utilities/endpoints";
 import teamsAPI, { ILoadTeamsResponse } from "services/entities/teams";
@@ -62,16 +63,18 @@ const AgentOptionsPage = ({
       return renderFlash("error", error.reason);
     }
 
-    try {
-      await osqueryOptionsAPI.update(
-        updatedForm,
-        TEAMS_AGENT_OPTIONS(teamIdFromURL)
-      );
-      return renderFlash("success", "Successfully saved agent options");
-    } catch (response) {
-      console.error(response);
-      return renderFlash("error", "Could not save agent options");
-    }
+    osqueryOptionsAPI
+      .update(updatedForm, TEAMS_AGENT_OPTIONS(teamIdFromURL))
+      .then(() => {
+        renderFlash("success", "Successfully saved agent options");
+      })
+      .catch((response: { data: IApiError }) => {
+        console.error(response);
+        return renderFlash(
+          "error",
+          `Could not update agent options. ${response.data.errors[0].reason}`
+        );
+      });
   };
 
   return (

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
@@ -31,6 +31,7 @@ const AgentOptionsPage = ({
   const teamIdFromURL = parseInt(team_id, 10);
   const { renderFlash } = useContext(NotificationContext);
 
+  const [teamName, setTeamName] = useState("");
   const [formData, setFormData] = useState<{ osquery_options?: string }>({});
   const handlePageError = useErrorHandler();
 
@@ -46,6 +47,7 @@ const AgentOptionsPage = ({
           setFormData({
             osquery_options: yaml.dump(selected.agent_options),
           });
+          setTeamName(selected.name);
         } else {
           handlePageError({ status: 404 });
         }
@@ -72,7 +74,7 @@ const AgentOptionsPage = ({
         console.error(response);
         return renderFlash(
           "error",
-          `Could not update team agent options. ${response.data.errors[0].reason}`
+          `Could not update ${teamName} team agent options. ${response.data.errors[0].reason}`
         );
       });
   };


### PR DESCRIPTION
Cerra #7997 

**Fix**
- Render team name and error in flash message for updating team agent options error

Error on global agent options:
<img width="1238" alt="Screen Shot 2022-09-28 at 10 38 37 AM" src="https://user-images.githubusercontent.com/71795832/192810756-d8b87034-c39b-40f2-ae2b-403ba15ee004.png">
New error on team agent options to match:
<img width="1233" alt="Screen Shot 2022-09-28 at 10 47 12 AM" src="https://user-images.githubusercontent.com/71795832/192810915-85d611f6-3988-4b6c-8571-1ccd5d5f67d6.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
