### PR TITLE
Fleet UI: Fix back to packs chevron

### DIFF
--- a/frontend/components/forms/packs/PackForm/_styles.scss
+++ b/frontend/components/forms/packs/PackForm/_styles.scss
@@ -38,6 +38,7 @@
 
     #back-chevron {
       width: 16px;
+      height: 16px;
       margin-right: $pad-small;
       vertical-align: text-top;
     }


### PR DESCRIPTION
Cerra #8018 

**Fix**
Packs chevron height is 16px not 12px

<img width="742" alt="Screen Shot 2022-09-28 at 5 04 52 PM" src="https://user-images.githubusercontent.com/71795832/192888523-d938554c-5af6-4297-9ea8-3ad2d5cd040c.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
