### PR TITLE
avoid panic when storing a nil pointer in cached_mysql

### DIFF
--- a/changes/issue-7420-config-panics
+++ b/changes/issue-7420-config-panics
@@ -1,0 +1,1 @@
+* Fixed a server panic happening when a team was edited via yaml without an `agent_options` key.

--- a/server/datastore/cached_mysql/cached_mysql.go
+++ b/server/datastore/cached_mysql/cached_mysql.go
@@ -35,6 +35,10 @@ func clone(v interface{}) (interface{}, error) {
 		return cloner.Clone()
 	}
 
+	if v == nil {
+		return nil, nil
+	}
+
 	// Use reflection to initialize a clone of v of the same type.
 	vv := reflect.ValueOf(v)
 
@@ -43,6 +47,9 @@ func clone(v interface{}) (interface{}, error) {
 	isPtr := false
 	if vv.Kind() == reflect.Ptr {
 		isPtr = true
+		if vv.IsNil() {
+			return nil, nil
+		}
 		vv = vv.Elem()
 	}
 

--- a/server/datastore/cached_mysql/cached_mysql_test.go
+++ b/server/datastore/cached_mysql/cached_mysql_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestClone(t *testing.T) {
+	var nilRawMessage *json.RawMessage
+
 	tests := []struct {
 		name string
 		src  interface{}
@@ -60,6 +62,16 @@ func TestClone(t *testing.T) {
 			name: "pointer to slice",
 			src:  &[]string{"foo", "bar"},
 			want: &[]string{"foo", "bar"},
+		},
+		{
+			name: "nil",
+			src:  nil,
+			want: nil,
+		},
+		{
+			name: "nil pointer",
+			src:  nilRawMessage,
+			want: nil,
 		},
 	}
 


### PR DESCRIPTION
related to https://github.com/fleetdm/fleet/issues/7420, this improves the logic of the `clone` function in `cached_mysql` to properly handle `nil` and `nil` pointers.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
