### PR TITLE
add server side validation for emails

### DIFF
--- a/changes/7199-email-validation
+++ b/changes/7199-email-validation
@@ -1,0 +1,1 @@
+* Added server-side validation of user emails

--- a/ee/server/service/users.go
+++ b/ee/server/service/users.go
@@ -18,6 +18,9 @@ func (svc *Service) GetSSOUser(ctx context.Context, auth fleet.Auth) (*fleet.Use
 		return nil, ctxerr.Wrap(ctx, err, "getting app config")
 	}
 
+	// despite the fact that svc.NewUser will also validate the
+	// email, we do it here to avoid hitting the database early if
+	// the email happens to be invalid.
 	if err := fleet.ValidateEmail(auth.UserID()); err != nil {
 		return nil, ctxerr.New(ctx, "validating SSO response")
 	}

--- a/server/fleet/users.go
+++ b/server/fleet/users.go
@@ -199,6 +199,8 @@ func (p *UserPayload) verifyCreateShared(invalid *InvalidArgumentError) {
 		invalid.Append("email", "Email missing required argument")
 	} else if *p.Email == "" {
 		invalid.Append("email", "Email cannot be empty")
+	} else if err := ValidateEmail(*p.Email); err != nil {
+		invalid.Append("email", err.Error())
 	}
 }
 
@@ -342,16 +344,14 @@ func ValidatePasswordRequirements(password string) error {
 //
 // 1. We're able to parse the address
 // 2. The parsed address is equal to the provided address
-//
-// TODO: see issue #7199, we should use this logic for all user-creation flows
 func ValidateEmail(email string) error {
 	addr, err := mail.ParseAddress(email)
 	if err != nil {
-		return fmt.Errorf("Invalid email address: %e", err)
+		return err
 	}
 
 	if addr.Address != email {
-		return errors.New("Invalid email address")
+		return errors.New("Email is invalid")
 	}
 
 	return nil

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -83,6 +83,20 @@ func (s *integrationTestSuite) TestUserWithoutRoleErrors() {
 	assertErrorCodeAndMessage(t, resp, fleet.ErrNoRoleNeeded, "either global role or team role needs to be defined")
 }
 
+func (s *integrationTestSuite) TestUserEmailValidation() {
+	params := fleet.UserPayload{
+		Name:       ptr.String("user_invalid_email"),
+		Email:      ptr.String("invalid"),
+		Password:   &test.GoodPassword,
+		GlobalRole: ptr.String(fleet.RoleObserver),
+	}
+
+	s.Do("POST", "/api/latest/fleet/users/admin", &params, http.StatusUnprocessableEntity)
+
+	params.Email = ptr.String("user_valid_mail@example.com")
+	s.Do("POST", "/api/latest/fleet/users/admin", &params, http.StatusOK)
+}
+
 func (s *integrationTestSuite) TestUserWithWrongRoleErrors() {
 	t := s.T()
 


### PR DESCRIPTION
related to https://github.com/fleetdm/fleet/issues/7199, this adds email validation to the `verifyCreateShared` which is used for user creation in the server.

validation messages come directly from Go's `net/mail` package.

```
~/fleet $ curl 'https://localhost:8080/api/latest/fleet/users/admin' -X POST -H 'Authorization: Bearer $TOKEN' --data-raw '{"email":"asdf","name":"asdf@asd.com","password":"as;lkdfjasdlk;fja3234@","global_role":"observer","teams":[]}'
{
  "message": "Validation Failed",
  "errors": [
    {
      "name": "email",
      "reason": "mail: missing '@' or angle-addr"
    }
  ]
}
```

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
