### PR TITLE
try using colima as the container runtime in CI

### DIFF
--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -15,6 +15,7 @@ on:
   pull_request:
     paths:
       - 'orbit/**.go'
+      - '.github/workflows/fleet-and-orbit.yml'
   workflow_dispatch: # Manual
 
 permissions:
@@ -194,21 +195,11 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2
 
-    # Docker needs to be installed manually on macOS.
-    # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
-    # FIXME: lock Docker version to 4.10.0 as newer versions fail to initialize
     - name: Install Docker
       timeout-minutes: 20
       run: |
-        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb
-        brew install --cask docker.rb
-        sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
-        open -a /Applications/Docker.app --args --unattended --accept-license
-        echo "Waiting for Docker to start up..."
-        while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do
-          sleep 1;
-        done
-        echo "Docker is ready."
+        brew install docker colima
+        colima start
 
     - name: Build Repository and run TUF server
       env:

--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -198,7 +198,7 @@ jobs:
     - name: Install Docker
       timeout-minutes: 20
       run: |
-        brew install docker colima
+        brew install docker docker-compose colima
         colima start
 
     - name: Build Repository and run TUF server

--- a/.github/workflows/fleetctl-preview-latest.yml
+++ b/.github/workflows/fleetctl-preview-latest.yml
@@ -46,7 +46,7 @@ jobs:
       timeout-minutes: 20
       if: contains(matrix.os, 'macos')
       run: |
-        brew install docker colima
+        brew install docker docker-compose colima
         colima start
 
     - name: Install Go

--- a/.github/workflows/fleetctl-preview-latest.yml
+++ b/.github/workflows/fleetctl-preview-latest.yml
@@ -25,6 +25,7 @@ on:
       - 'orbit/**.go'
       - 'ee/fleetctl/**.go'
       - 'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml'
+      - '.github/workflows/fleetctl-preview-latest.yml'
   workflow_dispatch: # Manual
 
 permissions:
@@ -41,22 +42,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
-    # Docker needs to be installed manually on macOS.
-    # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
-    # FIXME: lock Docker version to 4.10.0 as newer versions fail to initialize
     - name: Install Docker
       timeout-minutes: 20
       if: contains(matrix.os, 'macos')
       run: |
-        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb
-        brew install --cask docker.rb
-        sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
-        open -a /Applications/Docker.app --args --unattended --accept-license
-        echo "Waiting for Docker to start up..."
-        while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do
-          sleep 1;
-        done
-        echo "Docker is ready."
+        brew install docker colima
+        colima start
 
     - name: Install Go
       uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # v2

--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -24,7 +24,7 @@ jobs:
       timeout-minutes: 20
       if: contains(matrix.os, 'macos')
       run: |
-        brew install docker colima
+        brew install docker docker-compose colima
         colima start
 
     - name: Start tunnel

--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -20,22 +20,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
-    # Docker needs to be installed manually on macOS.
-    # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
-    # FIXME: lock Docker version to 4.10.0 as newer versions fail to initialize
     - name: Install Docker
       timeout-minutes: 20
       if: contains(matrix.os, 'macos')
       run: |
-        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb
-        brew install --cask docker.rb
-        sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
-        open -a /Applications/Docker.app --args --unattended --accept-license
-        echo "Waiting for Docker to start up..."
-        while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do
-          sleep 1;
-        done
-        echo "Docker is ready."
+        brew install docker colima
+        colima start
 
     - name: Start tunnel
       run: |

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -38,22 +38,12 @@ jobs:
 
     steps:
 
-    # Docker needs to be installed manually on macOS.
-    # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
-    # FIXME: lock Docker version to 4.10.0 as newer versions fail to initialize
     - name: Install Docker
       timeout-minutes: 20
       if: matrix.os == 'macos-latest'
       run: |
-        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb
-        brew install --cask docker.rb
-        sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
-        open -a /Applications/Docker.app --args --unattended --accept-license
-        echo "Waiting for Docker to start up..."
-        while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do
-          sleep 1;
-        done
-        echo "Docker is ready."
+        brew install docker colima
+        colima start
 
     - name: Pull fleetdm/wix
       # Run in background while other steps complete to speed up the workflow

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -42,7 +42,7 @@ jobs:
       timeout-minutes: 20
       if: matrix.os == 'macos-latest'
       run: |
-        brew install docker colima
+        brew install docker docker-compose colima
         colima start
 
     - name: Pull fleetdm/wix


### PR DESCRIPTION
**Motivation:**

- _All_ of the macOS tests that involve installing Docker are flaky because the installation step is fragile
- Due to a known Docker issue we have to lock the version to 4.10.0 to be able to use it in CI
- We have spent several man-hours debugging and patching the two points above

**How:**

[Colima](https://github.com/abiosoft/colima) is a container runtime for macOS, it's an alternative to installing the Docker.app in macOS, with great CLI support.

According to this issue https://github.com/actions/runner-images/issues/6216, it will be included by default in the GitHub macOS runners soon, so we won't even have to install it.

**Questions:**

- Maybe we still want to use Docker.app for `fleetctl preview`? this way we simulate the way that people will actually use it