### PR TITLE
Remove lifecycle part for rds, terraform doesn't support it

### DIFF
--- a/infrastructure/dogfood/terraform/aws/rds.tf
+++ b/infrastructure/dogfood/terraform/aws/rds.tf
@@ -104,10 +104,6 @@ module "aurora_mysql" {
 
   db_parameter_group_name         = aws_db_parameter_group.example_mysql.id
   db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.example_mysql.id
-
-  lifecycle {
-    ignore_changes = [snapshot_identifier]
-  }
 }
 
 resource "aws_db_parameter_group" "example_mysql" {


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
