### PR TITLE
Fleet UI: Packs chevron

### DIFF
--- a/frontend/components/forms/packs/PackForm/_styles.scss
+++ b/frontend/components/forms/packs/PackForm/_styles.scss
@@ -38,6 +38,7 @@
 
     #back-chevron {
       width: 16px;
+      height: 16px;
       margin-right: $pad-small;
       vertical-align: text-top;
     }

--- a/frontend/pages/packs/EditPackPage/_styles.scss
+++ b/frontend/pages/packs/EditPackPage/_styles.scss
@@ -10,6 +10,7 @@
       height: 16px;
       margin-right: $pad-small;
       vertical-align: text-top;
+      margin-top: -1px;
     }
   }
 

--- a/frontend/pages/packs/EditPackPage/_styles.scss
+++ b/frontend/pages/packs/EditPackPage/_styles.scss
@@ -7,6 +7,7 @@
 
     #back-chevron {
       width: 16px;
+      height: 16px;
       margin-right: $pad-small;
       vertical-align: text-top;
     }


### PR DESCRIPTION
Cerra #8018 

- Fix chevron on back to packs

<img width="867" alt="Screen Shot 2022-09-30 at 9 36 10 AM" src="https://user-images.githubusercontent.com/71795832/193281834-5479bef9-f5b2-4d99-869a-8a31bf4fdf05.png">

# Checklist for submitter
- [x] Manual QA for all new/changed functionality
