### PR TITLE
Update deploy to dogfood instructions

### DIFF
--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -151,9 +151,11 @@ How to deploy a new release to dogfood:
 3. Locate the tag for the new release and copy the image name. An example image name is "fleetdm/fleet:v4.19.0".
 4. Head to the "Deploy Dogfood Environment" action on GitHub: https://github.com/fleetdm/fleet/actions/workflows/dogfood-deploy.yml
 5. Select **Run workflow** and paste the image name in the **The image tag wished to be deployed.** field.
-6. Select **Run workflow**. **main** should be selected under the **Use workflow from** field.
+6. Select **Run workflow**. **dogfood_mdm** should be selected under the **Use workflow from** field.
 
 > Note that this action will not handle down migrations. Always deploy a newer version than is currently deployed.
+> 
+> Note that "fleetdm/fleet:main" is not a image name, instead use the commit hash in place of "main".
 
 ## Oncall rotation
 


### PR DESCRIPTION
- Changed the "Use workflow from" instructions per advice from @zwinnerman-fleetdm 
- Added note that "main" is not a valid image name and the commit hash must be used instead.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

