### PR TITLE
Change display type for label checkboxes

### DIFF
--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -84,7 +84,7 @@
   &__label {
     font-size: $x-small;
     padding-left: $pad-small;
-    display: inline;
+    display: inline-block;
     vertical-align: top;
   }
 


### PR DESCRIPTION
Fixes alignment issue on Settings > SSO for "Learn More" link. Fixed screenshot: 

![image](https://user-images.githubusercontent.com/2495927/193343372-dd2b9fc4-0249-4901-a4d3-70a8cbc9ced7.png)
