### PR TITLE
Website: remove zero-width spaces from schema table page headings

### DIFF
--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -587,7 +587,7 @@ module.exports = {
             ).replace(/[^a-z0-9\-]/ig,'');
 
             // Convert the markdown string to HTML.
-            let htmlString = await sails.helpers.strings.toHtml(tableMdString);
+            let htmlString = await sails.helpers.strings.toHtml.with({mdString: tableMdString, addIdsToHeadings: false});
 
             // Add the language-sql class to codeblocks in generated HTML partial for syntax highlighting.
             htmlString = htmlString.replace(/(<pre><code)([^>]*)(>)/gm, '$1 class="language-sql"$2$3');


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/7987
Changes:
- Updated the Markdown compilation for table pages to use an alternate heading renderer by passing in `addIdsToHeadings: false`. This makes three changes to the headings on tables pages
   1. Removes the leading zero-width spaces before underscores
   2. Removes the hover anchor links (currently not used or visible on table pages)
   3. Removes the id on the rendered element