### PR TITLE
Orbit to support environments with revoked enroll secrets

### DIFF
--- a/changes/feature-6581-remote-flags-manaement-with-orbit
+++ b/changes/feature-6581-remote-flags-manaement-with-orbit
@@ -6,7 +6,16 @@ On environments where an enroll secret has been revoked, Orbit hosts that were d
 This is not a regression, all existing features should work as expected, but we recommend to fix this issue given that we will be adding
 more features to Orbit that will use the new communication channel.
 
+## Solution 1 (generate new packages)
+
 1. To determine which hosts need to be fixed, run the following query: `SELECT * FROM orbit_info WHERE enrolled = false`.
 Hosts not running Orbit will fail to execute such query because the table doesn't exist, those can be ignored.
 2. Generate Orbit packages with the new enroll secret.
 3. Deploy Orbit packages to the hosts returned in (1).
+
+## Deploy new secret
+
+Alternatively, instead of generating new packages, the administrator can push the new enroll secret to hosts with revoked enroll secrets:
+- macOS: Push new secret to `/opt/orbit/secret.txt`.
+- Windows: Push new secret to `C:\Program Files\Orbit\secret.txt`.
+- Linux: Update the new secret set in the configuration file `/etc/default/orbit`.

--- a/changes/feature-6581-remote-flags-manaement-with-orbit
+++ b/changes/feature-6581-remote-flags-manaement-with-orbit
@@ -1,1 +1,12 @@
-* Added new endpoints for orbit to enroll and get startup flags
+* Orbit allows configuring osquery startup flags from Fleet, see [#7377](https://github.com/fleetdm/fleet/issues/7377).
+
+Important note for existing deployments that use Orbit: 
+This feature requires Orbit to communicate with Fleet. Orbit uses osquery's enroll secret to authenticate and enroll to Fleet.
+On environments where an enroll secret has been revoked, Orbit hosts that were deployed with such secret will fail to enroll to Fleet.
+This is not a regression, all existing features should work as expected, but we recommend to fix this issue given that we will be adding
+more features to Orbit that will use the new communication channel.
+
+1. To determine which hosts need to be fixed, run the following query: `SELECT * FROM orbit_info WHERE enrolled = false`.
+Hosts not running Orbit will fail to execute such query because the table doesn't exist, those can be ignored.
+2. Generate Orbit packages with the new enroll secret.
+3. Deploy Orbit packages to the hosts returned in (1).

--- a/orbit/changes/6581-remote-flags-management
+++ b/orbit/changes/6581-remote-flags-management
@@ -1,2 +1,13 @@
-* Orbit now enrolls itself to Fleet using osquery's enroll secret, and periodically checks for new osquery startup flags.
-Important note for existing deployments that use Orbit: If an enroll secret has been revoked, Orbit hosts that were deployed with such secret will fail to enroll to Fleet, thus this feature won't be available until this is fixed. See the following instructions on how to fix this issue [here](TODO...).
+* Orbit allows configuring osquery startup flags from Fleet, see [#7377](https://github.com/fleetdm/fleet/issues/7377).
+
+Important note for existing deployments that use Orbit: 
+This feature requires Orbit to communicate with Fleet. Orbit uses osquery's enroll secret to authenticate and enroll to Fleet.
+On environments where an enroll secret has been revoked, Orbit hosts that were deployed with such secret will fail to enroll to Fleet.
+This is not a regression, all existing features should work as expected, but we recommend to fix this issue given that we will be adding
+more features to Orbit that will use the new communication channel.
+
+1. To determine which hosts need to be fixed, run the following query: `SELECT * FROM orbit_info WHERE enrolled = false`.
+Hosts not running Orbit will fail to execute such query because the table doesn't exist, those can be ignored.
+2. Generate Orbit packages with the new enroll secret.
+3. Deploy Orbit packages to the hosts returned in (1).
+

--- a/orbit/changes/6581-remote-flags-management
+++ b/orbit/changes/6581-remote-flags-management
@@ -1,1 +1,2 @@
-* Orbit now enrolls with fleet using it's own orbit_node_key, and periodically checks for new flags (using the new API), and applies them to osquery
+* Orbit now enrolls itself to Fleet using osquery's enroll secret, and periodically checks for new osquery startup flags.
+Important note for existing deployments that use Orbit: If an enroll secret has been revoked, Orbit hosts that were deployed with such secret will fail to enroll to Fleet, thus this feature won't be available until this is fixed. See the following instructions on how to fix this issue [here](TODO...).

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/service"
 	"github.com/google/uuid"
 
@@ -492,42 +491,29 @@ func main() {
 
 		}
 
-		capabilities := fleet.CapabilityMap{}
-
-		orbitClient, err := service.NewOrbitClient(fleetURL, c.String("fleet-certificate"), c.Bool("insecure"), enrollSecret, uuidStr, capabilities)
+		orbitClient, err := service.NewOrbitClient(
+			c.String("root-dir"),
+			fleetURL,
+			c.String("fleet-certificate"),
+			c.Bool("insecure"),
+			enrollSecret,
+			uuidStr,
+		)
 		if err != nil {
 			return fmt.Errorf("error new orbit client: %w", err)
 		}
-
-		// ping the server to get the latest capabilities
-		if err := orbitClient.Ping(); err != nil {
-			return fmt.Errorf("error pinging the server: %w", err)
+		const orbitFlagsUpdateInterval = 30 * time.Second
+		flagRunner := update.NewFlagRunner(orbitClient, update.FlagUpdateOptions{
+			CheckInterval: orbitFlagsUpdateInterval,
+			RootDir:       c.String("root-dir"),
+		})
+		// Try performing a flags update to use latest configured osquery flags from get-go.
+		if _, err := flagRunner.DoFlagsUpdate(); err != nil {
+			// Just log, OK to continue, since flagRunner will retry
+			// in flagRunner.Execute.
+			log.Info().Err(err).Msg("initial flags update failed")
 		}
-
-		if orbitClient.GetServerCapabilities().Has(fleet.CapabilityOrbitEndpoints) {
-			log.Info().Msg("Orbit endpoints are enabled")
-			orbitNodeKey, err := getOrbitNodeKeyOrEnroll(orbitClient, c.String("root-dir"))
-			if err != nil {
-				return fmt.Errorf("error enroll: %w", err)
-			}
-
-			const orbitFlagsUpdateInterval = 30 * time.Second
-			flagRunner, err := update.NewFlagRunner(orbitClient, update.FlagUpdateOptions{
-				CheckInterval: orbitFlagsUpdateInterval,
-				RootDir:       c.String("root-dir"),
-				OrbitNodeKey:  orbitNodeKey,
-			})
-			if err != nil {
-				return err
-			}
-			// do the initial flags update
-			_, err = flagRunner.DoFlagsUpdate()
-			if err != nil {
-				// just log, OK to continue, since we will retry
-				log.Info().Err(err).Msg("Initial flags update failed")
-			}
-			g.Add(flagRunner.Execute, flagRunner.Interrupt)
-		}
+		g.Add(flagRunner.Execute, flagRunner.Interrupt)
 
 		// --force is sometimes needed when an older osquery process has not
 		// exited properly
@@ -563,14 +549,14 @@ func main() {
 		// This ends up forcing the rest of the interrupt functions in the runner group to get called
 		interruptFunctions = append(interruptFunctions, r.Interrupt)
 
-		registerExtensionRunner(&g, r.ExtensionSocketPath(), deviceAuthToken)
-
-		checkerClient, err := service.NewOrbitClient(fleetURL, c.String("fleet-certificate"), c.Bool("insecure"), enrollSecret, uuidStr, capabilities)
-		if err != nil {
-			return fmt.Errorf("new client for capabilities checker: %w", err)
-		}
-		capabilitiesChecker := newCapabilitiesChecker(checkerClient)
-		g.Add(capabilitiesChecker.actor())
+		registerExtensionRunner(
+			&g,
+			r.ExtensionSocketPath(),
+			table.WithExtension(orbitInfoExtension{
+				orbitClient:     orbitClient,
+				deviceAuthToken: deviceAuthToken,
+			}),
+		)
 
 		if c.Bool("fleet-desktop") {
 			desktopRunner := newDesktopRunner(desktopPath, fleetURL, deviceAuthToken, c.String("fleet-certificate"), c.Bool("insecure"))
@@ -594,10 +580,8 @@ func main() {
 	}
 }
 
-func registerExtensionRunner(g *run.Group, extSockPath, deviceAuthToken string) {
-	ext := table.NewRunner(extSockPath, table.WithExtension(orbitInfoExtension{
-		deviceAuthToken: deviceAuthToken,
-	}))
+func registerExtensionRunner(g *run.Group, extSockPath string, opts ...table.Opt) {
+	ext := table.NewRunner(extSockPath, opts...)
 	g.Add(ext.Execute, ext.Interrupt)
 }
 
@@ -765,42 +749,6 @@ func getUUID(osqueryPath string) (string, error) {
 	return uuids[0].UuidString, nil
 }
 
-// getOrbitNodeKeyOrEnroll attempts to read the orbit node key if the file exists on disk
-// otherwise it enrolls the host with Fleet and saves the node key to disk
-func getOrbitNodeKeyOrEnroll(orbitClient *service.OrbitClient, rootDir string) (string, error) {
-	nodeKeyFilePath := filepath.Join(rootDir, constant.OrbitNodeKeyFileName)
-	orbitNodeKey, err := ioutil.ReadFile(nodeKeyFilePath)
-	switch {
-	case err == nil:
-		return string(orbitNodeKey), nil
-	case errors.Is(err, fs.ErrNotExist):
-		// OK
-	default:
-		return "", fmt.Errorf("read orbit node key file: %w", err)
-	}
-	for retries := 0; retries < constant.OrbitEnrollMaxRetries; retries++ {
-		orbitNodeKey, err := enrollAndWriteNodeKeyFile(orbitClient, nodeKeyFilePath)
-		if err != nil {
-			log.Info().Err(err).Msg("enroll failed, retrying")
-			time.Sleep(constant.OrbitEnrollRetrySleep)
-			continue
-		}
-		return orbitNodeKey, nil
-	}
-	return "", fmt.Errorf("orbit node key enroll failed, attempts=%d", constant.OrbitEnrollMaxRetries)
-}
-
-func enrollAndWriteNodeKeyFile(orbitClient *service.OrbitClient, nodeKeyFilePath string) (string, error) {
-	orbitNodeKey, err := orbitClient.DoEnroll()
-	if err != nil {
-		return "", fmt.Errorf("enroll request: %w", err)
-	}
-	if err := os.WriteFile(nodeKeyFilePath, []byte(orbitNodeKey), constant.DefaultFileMode); err != nil {
-		return "", fmt.Errorf("write orbit node key file: %w", err)
-	}
-	return orbitNodeKey, nil
-}
-
 func loadOrGenerateToken(rootDir string) (string, error) {
 	filePath := filepath.Join(rootDir, "identifier")
 	id, err := ioutil.ReadFile(filePath)
@@ -831,65 +779,4 @@ var versionCommand = &cli.Command{
 		fmt.Println("date - " + build.Date)
 		return nil
 	},
-}
-
-// capabilitiesChecker is a helper to restart Orbit as soon as certain capabilities
-// are changed in the server.
-//
-// This struct and its methods are designed to play nicely with `oklog.Group`.
-type capabilitiesChecker struct {
-	client        *service.OrbitClient
-	interruptCh   chan struct{} // closed when interrupt is triggered
-	executeDoneCh chan struct{} // closed when execute returns
-}
-
-func newCapabilitiesChecker(client *service.OrbitClient) *capabilitiesChecker {
-	return &capabilitiesChecker{
-		client:        client,
-		interruptCh:   make(chan struct{}),
-		executeDoneCh: make(chan struct{}),
-	}
-}
-
-func (f *capabilitiesChecker) actor() (func() error, func(error)) {
-	return f.execute, f.interrupt
-}
-
-// execute will poll the server for capabilities and emit a stop signal to restart
-// Orbit if certain capabilities are enabled.
-//
-// You need to add an explicit check for each capability you want to watch for
-func (f *capabilitiesChecker) execute() error {
-	defer close(f.executeDoneCh)
-	capabilitiesCheckTicker := time.NewTicker(5 * time.Minute)
-
-	if err := f.client.Ping(); err != nil {
-		log.Error().Err(err).Msg("pinging the server")
-	}
-
-	for {
-		select {
-		case <-capabilitiesCheckTicker.C:
-			oldCapabilities := f.client.GetServerCapabilities()
-			// ping the server to get the latest capabilities
-			if err := f.client.Ping(); err != nil {
-				log.Error().Err(err).Msg("pinging the server")
-				continue
-			}
-			newCapabilities := f.client.GetServerCapabilities()
-
-			if oldCapabilities.Has(fleet.CapabilityOrbitEndpoints) != newCapabilities.Has(fleet.CapabilityOrbitEndpoints) {
-				log.Info().Msg("orbit endpoints capability changed, restarting")
-				return nil
-			}
-		case <-f.interruptCh:
-			return nil
-		}
-	}
-}
-
-func (f *capabilitiesChecker) interrupt(err error) {
-	log.Debug().Err(err).Msg("interrupt capabilitiesChecker")
-	close(f.interruptCh) // Signal execute to return.
-	<-f.executeDoneCh    // Wait for execute to return.
 }

--- a/orbit/cmd/orbit/orbit_info.go
+++ b/orbit/cmd/orbit/orbit_info.go
@@ -29,7 +29,7 @@ func (o orbitInfoExtension) Columns() []table.ColumnDefinition {
 		table.TextColumn("version"),
 		table.TextColumn("device_auth_token"),
 		table.TextColumn("enrolled"),
-		table.TextColumn("last_request_error"),
+		table.TextColumn("last_recorded_error"),
 	}
 }
 
@@ -39,17 +39,17 @@ func (o orbitInfoExtension) GenerateFunc(_ context.Context, _ table.QueryContext
 	if v == "" {
 		v = "unknown"
 	}
-	lastRequestError := ""
-	if err := o.orbitClient.LastRequestError(); err != nil {
-		lastRequestError = err.Error()
+	lastRecordedError := ""
+	if err := o.orbitClient.LastRecordedError(); err != nil {
+		lastRecordedError = err.Error()
 	}
 
 	return []map[string]string{
 		{
-			"version":            v,
-			"device_auth_token":  o.deviceAuthToken,
-			"enrolled":           strconv.FormatBool(o.orbitClient.Enrolled()),
-			"last_request_error": lastRequestError,
+			"version":             v,
+			"device_auth_token":   o.deviceAuthToken,
+			"enrolled":            strconv.FormatBool(o.orbitClient.Enrolled()),
+			"last_recorded_error": lastRecordedError,
 		},
 	}, nil
 }

--- a/orbit/cmd/orbit/orbit_info.go
+++ b/orbit/cmd/orbit/orbit_info.go
@@ -2,14 +2,17 @@ package main
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/build"
 	orbit_table "github.com/fleetdm/fleet/v4/orbit/pkg/table"
+	"github.com/fleetdm/fleet/v4/server/service"
 	"github.com/osquery/osquery-go/plugin/table"
 )
 
 // orbitInfoExtension implements an extension table that provides info about Orbit.
 type orbitInfoExtension struct {
+	orbitClient     *service.OrbitClient
 	deviceAuthToken string
 }
 
@@ -25,6 +28,8 @@ func (o orbitInfoExtension) Columns() []table.ColumnDefinition {
 	return []table.ColumnDefinition{
 		table.TextColumn("version"),
 		table.TextColumn("device_auth_token"),
+		table.TextColumn("enrolled"),
+		table.TextColumn("last_request_error"),
 	}
 }
 
@@ -34,10 +39,17 @@ func (o orbitInfoExtension) GenerateFunc(_ context.Context, _ table.QueryContext
 	if v == "" {
 		v = "unknown"
 	}
+	lastRequestError := ""
+	if err := o.orbitClient.LastRequestError(); err != nil {
+		lastRequestError = err.Error()
+	}
+
 	return []map[string]string{
 		{
-			"version":           v,
-			"device_auth_token": o.deviceAuthToken,
+			"version":            v,
+			"device_auth_token":  o.deviceAuthToken,
+			"enrolled":           strconv.FormatBool(o.orbitClient.Enrolled()),
+			"last_request_error": lastRequestError,
 		},
 	}, nil
 }

--- a/orbit/cmd/orbit/shell.go
+++ b/orbit/cmd/orbit/shell.go
@@ -109,7 +109,7 @@ var shellCommand = &cli.Command{
 			// leaving the extension runner waiting for the socket.
 			// NOTE(lucas): `--extensions_require` doesn't seem to work with
 			// thrift extensions?
-			registerExtensionRunner(&g, r.ExtensionSocketPath(), "")
+			registerExtensionRunner(&g, r.ExtensionSocketPath())
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/orbit/pkg/constant/constant.go
+++ b/orbit/pkg/constant/constant.go
@@ -17,7 +17,7 @@ const (
 	// OrbitNodeKeyFileName is the filename on disk where we write the orbit node key to
 	OrbitNodeKeyFileName = "secret-orbit-node-key.txt"
 	// OrbitEnrollMaxRetries is the max retries when doing an enroll request
-	OrbitEnrollMaxRetries = 10
+	OrbitEnrollMaxRetries = 3
 	// OrbitEnrollRetrySleep is the time duration to sleep between retries
 	OrbitEnrollRetrySleep = 5 * time.Second
 	// OsquerydName is the name of osqueryd binary

--- a/orbit/pkg/update/flag_runner.go
+++ b/orbit/pkg/update/flag_runner.go
@@ -32,19 +32,16 @@ type FlagUpdateOptions struct {
 	CheckInterval time.Duration
 	// RootDir is the root directory for orbit state
 	RootDir string
-	// OrbitNodeKey is the orbit node key for the enrolled host
-	OrbitNodeKey string
 }
 
 // NewFlagRunner creates a new runner with provided options
 // The runner must be started with Execute
-func NewFlagRunner(orbitClient *service.OrbitClient, opt FlagUpdateOptions) (*FlagRunner, error) {
-	r := &FlagRunner{
+func NewFlagRunner(orbitClient *service.OrbitClient, opt FlagUpdateOptions) *FlagRunner {
+	return &FlagRunner{
 		orbitClient: orbitClient,
 		opt:         opt,
-		cancel:      make(chan struct{}, 1),
+		cancel:      make(chan struct{}),
 	}
-	return r, nil
 }
 
 // Execute starts the loop checking for updates
@@ -54,7 +51,6 @@ func (r *FlagRunner) Execute() error {
 	ticker := time.NewTicker(r.opt.CheckInterval)
 	defer ticker.Stop()
 
-	// Run until cancel or returning an error
 	for {
 		select {
 		case <-r.cancel:
@@ -69,6 +65,7 @@ func (r *FlagRunner) Execute() error {
 				log.Info().Msg("flags updated, exiting")
 				return nil
 			}
+			ticker.Reset(r.opt.CheckInterval)
 		}
 	}
 }
@@ -96,26 +93,18 @@ func (r *FlagRunner) DoFlagsUpdate() (bool, error) {
 	}
 
 	// next GetConfig from Fleet API
-	flagsJSON, err := r.orbitClient.GetConfig(r.opt.OrbitNodeKey)
-	// on 401 unauthenticated error, re-enroll and update orbit node key
-	if errors.Is(err, service.ErrUnauthenticated) {
-		r.opt.OrbitNodeKey, err = r.updateOrbitNodeKey()
-		if err != nil {
-			return false, err
-		}
-		return false, nil
-	}
+	config, err := r.orbitClient.GetConfig()
 	if err != nil {
-		return false, fmt.Errorf("error getting flags from fleet %w", err)
+		return false, fmt.Errorf("error getting flags from fleet: %w", err)
 	}
-	if len(flagsJSON) == 0 {
+	if len(config.Flags) == 0 {
 		// command_line_flags not set in YAML, nothing to do
 		return false, nil
 	}
 
-	osqueryFlagMapFromFleet, err := getFlagsFromJSON(flagsJSON)
+	osqueryFlagMapFromFleet, err := getFlagsFromJSON(config.Flags)
 	if err != nil {
-		return false, fmt.Errorf("error parsing flags %w", err)
+		return false, fmt.Errorf("error parsing flags: %w", err)
 	}
 
 	// compare both flags, if they are equal, nothing to do
@@ -126,7 +115,7 @@ func (r *FlagRunner) DoFlagsUpdate() (bool, error) {
 	// flags are not equal, write the fleet flags to disk
 	err = writeFlagFile(r.opt.RootDir, osqueryFlagMapFromFleet)
 	if err != nil {
-		return false, fmt.Errorf("error writing flags to disk %w", err)
+		return false, fmt.Errorf("error writing flags to disk: %w", err)
 	}
 	return true, nil
 }
@@ -207,24 +196,4 @@ func readFlagFile(rootDir string) (map[string]string, error) {
 		}
 	}
 	return result, nil
-}
-
-// updateOrbitNodeKey does re-enrolls by calling the /enroll API and writes the response to disk
-func (r *FlagRunner) updateOrbitNodeKey() (string, error) {
-	for retries := 0; retries < constant.OrbitEnrollMaxRetries; retries++ {
-		newOrbitNodeKey, err := r.orbitClient.DoEnroll()
-		if err != nil {
-			log.Info().Err(err).Msg("re-enroll failed, retrying")
-			time.Sleep(constant.OrbitEnrollRetrySleep)
-			continue
-		}
-		nodeKeyFilePath := filepath.Join(r.opt.RootDir, constant.OrbitNodeKeyFileName)
-		if err := os.WriteFile(nodeKeyFilePath, []byte(newOrbitNodeKey), constant.DefaultFileMode); err != nil {
-			log.Info().Err(err).Msg("failed to write orbit node key to disk")
-			time.Sleep(constant.OrbitEnrollRetrySleep)
-			continue
-		}
-		return newOrbitNodeKey, nil
-	}
-	return "", fmt.Errorf("orbit re-enroll failed, attempts=%d", constant.OrbitEnrollMaxRetries)
 }

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -1,4 +1,4 @@
-// package retry has utilities to retry operations
+// Package retry has utilities to retry operations.
 package retry
 
 import (
@@ -22,7 +22,7 @@ func WithInterval(i time.Duration) Option {
 }
 
 // WithMaxAttempts allows to specify a maximum number of attempts
-// before the doer gives up
+// before the doer gives up.
 func WithMaxAttempts(a int) Option {
 	return func(c *config) {
 		c.maxAttempts = a
@@ -54,7 +54,7 @@ func Do(fn func() error, opts ...Option) error {
 			return nil
 		}
 
-		if cfg.maxAttempts != 0 && attempts >= cfg.maxAttempts {
+		if cfg.maxAttempts != 0 && attempts > cfg.maxAttempts {
 			return err
 		}
 

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -13,6 +13,10 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 )
 
+type setOrbitNodeKeyer interface {
+	setOrbitNodeKey(nodeKey string)
+}
+
 type orbitError struct {
 	message string
 }
@@ -29,6 +33,10 @@ type enrollOrbitResponse struct {
 
 type orbitGetConfigRequest struct {
 	OrbitNodeKey string `json:"orbit_node_key"`
+}
+
+func (r *orbitGetConfigRequest) setOrbitNodeKey(nodeKey string) {
+	r.OrbitNodeKey = nodeKey
 }
 
 func (r *orbitGetConfigRequest) orbitHostNodeKey() string {
@@ -55,7 +63,7 @@ func (r enrollOrbitResponse) hijackRender(ctx context.Context, w http.ResponseWr
 	enc.SetIndent("", "  ")
 
 	if err := enc.Encode(r); err != nil {
-		encodeError(ctx, osqueryError{message: fmt.Sprintf("orbit enroll failed: %e", err)}, w)
+		encodeError(ctx, osqueryError{message: fmt.Sprintf("orbit enroll failed: %s", err)}, w)
 	}
 }
 
@@ -96,7 +104,7 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hardwareUUID string, enroll
 
 	secret, err := svc.ds.VerifyEnrollSecret(ctx, enrollSecret)
 	if err != nil {
-		return "", orbitError{message: "orbit enroll failed: " + err.Error()}
+		return "", orbitError{message: err.Error()}
 	}
 
 	orbitNodeKey, err := server.GenerateRandomText(svc.config.Osquery.NodeKeySize)

--- a/server/service/orbit_client.go
+++ b/server/service/orbit_client.go
@@ -29,8 +29,8 @@ type OrbitClient struct {
 	enrolledMu sync.Mutex
 	enrolled   bool
 
-	lastReqErrMu sync.Mutex
-	lastReqErr   error
+	lastRecordedErrMu sync.Mutex
+	lastRecordedErr   error
 }
 
 func (oc *OrbitClient) request(verb string, path string, params interface{}, resp interface{}) error {
@@ -54,13 +54,13 @@ func (oc *OrbitClient) request(verb string, path string, params interface{}, res
 	oc.setClientCapabilitiesHeader(request)
 	response, err := oc.http.Do(request)
 	if err != nil {
-		oc.setLastRequestError(err)
+		oc.setLastRecordedError(err)
 		return fmt.Errorf("%s %s: %w", verb, path, err)
 	}
 	defer response.Body.Close()
 
 	if err := oc.parseResponse(verb, path, response, resp); err != nil {
-		oc.setLastRequestError(err)
+		oc.setLastRecordedError(err)
 		return err
 	}
 	return nil
@@ -226,16 +226,16 @@ func (oc *OrbitClient) setEnrolled(v bool) {
 	oc.enrolled = v
 }
 
-func (oc *OrbitClient) LastRequestError() error {
-	oc.lastReqErrMu.Lock()
-	defer oc.lastReqErrMu.Unlock()
+func (oc *OrbitClient) LastRecordedError() error {
+	oc.lastRecordedErrMu.Lock()
+	defer oc.lastRecordedErrMu.Unlock()
 
-	return oc.lastReqErr
+	return oc.lastRecordedErr
 }
 
-func (oc *OrbitClient) setLastRequestError(err error) {
-	oc.lastReqErrMu.Lock()
-	defer oc.lastReqErrMu.Unlock()
+func (oc *OrbitClient) setLastRecordedError(err error) {
+	oc.lastRecordedErrMu.Lock()
+	defer oc.lastRecordedErrMu.Unlock()
 
-	oc.lastReqErr = fmt.Errorf("%s: %w", time.Now().UTC().Format("2006-01-02T15:04:05Z"), err)
+	oc.lastRecordedErr = fmt.Errorf("%s: %w", time.Now().UTC().Format("2006-01-02T15:04:05Z"), err)
 }

--- a/server/service/orbit_client.go
+++ b/server/service/orbit_client.go
@@ -5,15 +5,32 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
+	"io/ioutil"
 	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
 
+	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
+	"github.com/fleetdm/fleet/v4/pkg/retry"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/rs/zerolog/log"
 )
 
+// OrbitClient exposes the Orbit API to communicate with the Fleet server.
 type OrbitClient struct {
 	*baseClient
-	enrollSecret string
-	hardwareUUID string
+	nodeKeyFilePath string
+	enrollSecret    string
+	uuid            string
+
+	enrolledMu sync.Mutex
+	enrolled   bool
+
+	lastReqErrMu sync.Mutex
+	lastReqErr   error
 }
 
 func (oc *OrbitClient) request(verb string, path string, params interface{}, resp interface{}) error {
@@ -22,7 +39,7 @@ func (oc *OrbitClient) request(verb string, path string, params interface{}, res
 	if params != nil {
 		bodyBytes, err = json.Marshal(params)
 		if err != nil {
-			return fmt.Errorf("making requst json marshalling : %w", err)
+			return fmt.Errorf("making request json marshalling : %w", err)
 		}
 	}
 
@@ -37,29 +54,71 @@ func (oc *OrbitClient) request(verb string, path string, params interface{}, res
 	oc.setClientCapabilitiesHeader(request)
 	response, err := oc.http.Do(request)
 	if err != nil {
+		oc.setLastRequestError(err)
 		return fmt.Errorf("%s %s: %w", verb, path, err)
 	}
 	defer response.Body.Close()
 
-	return oc.parseResponse(verb, path, response, resp)
+	if err := oc.parseResponse(verb, path, response, resp); err != nil {
+		oc.setLastRequestError(err)
+		return err
+	}
+	return nil
 }
 
-func NewOrbitClient(addr string, rootCA string, insecureSkipVerify bool, enrollSecret, hardwareUUID string, capabilities fleet.CapabilityMap) (*OrbitClient, error) {
-	bc, err := newBaseClient(addr, insecureSkipVerify, rootCA, "", capabilities)
+// NewOrbitClient creates a new OrbitClient.
+//
+// rootDir is the Orbit's root directory, where the Orbit node key is loaded-from/stored.
+// addr is the address of the Fleet server.
+// uuid is the UUID of the OrbitClient instance.
+func NewOrbitClient(rootDir string, addr string, rootCA string, insecureSkipVerify bool, enrollSecret, uuid string) (*OrbitClient, error) {
+	orbitCapabilities := fleet.CapabilityMap{}
+	bc, err := newBaseClient(addr, insecureSkipVerify, rootCA, "", orbitCapabilities)
 	if err != nil {
 		return nil, err
 	}
 
+	nodeKeyFilePath := filepath.Join(rootDir, constant.OrbitNodeKeyFileName)
 	return &OrbitClient{
-		baseClient:   bc,
-		enrollSecret: enrollSecret,
-		hardwareUUID: hardwareUUID,
+		nodeKeyFilePath: nodeKeyFilePath,
+		baseClient:      bc,
+		enrollSecret:    enrollSecret,
+		uuid:            uuid,
+		enrolled:        false,
 	}, nil
 }
 
-func (oc *OrbitClient) DoEnroll() (string, error) {
+// OrbitConfig holds the config returned by the Fleet server for a Orbit instance.
+type OrbitConfig struct {
+	// Flags holds the osquery startup flags to use when running osquery.
+	Flags json.RawMessage
+}
+
+// GetConfig returns the Orbit config fetched from Fleet server for this instance of OrbitClient.
+func (oc *OrbitClient) GetConfig() (*OrbitConfig, error) {
+	verb, path := "POST", "/api/fleet/orbit/config"
+	var resp orbitGetConfigResponse
+	if err := oc.authenticatedRequest(verb, path, &orbitGetConfigRequest{}, &resp); err != nil {
+		return nil, err
+	}
+	return &OrbitConfig{
+		Flags: resp.Flags,
+	}, nil
+}
+
+func (oc *OrbitClient) Ping() error {
+	verb, path := "HEAD", "/api/fleet/orbit/ping"
+	err := oc.request(verb, path, nil, nil)
+	if err == nil || errors.Is(err, notFoundErr{}) {
+		// notFound is ok, it means an old server without the capabilities header
+		return nil
+	}
+	return err
+}
+
+func (oc *OrbitClient) enroll() (string, error) {
 	verb, path := "POST", "/api/fleet/orbit/enroll"
-	params := enrollOrbitRequest{EnrollSecret: oc.enrollSecret, HardwareUUID: oc.hardwareUUID}
+	params := enrollOrbitRequest{EnrollSecret: oc.enrollSecret, HardwareUUID: oc.uuid}
 	var resp enrollOrbitResponse
 	err := oc.request(verb, path, params, &resp)
 	if err != nil {
@@ -68,26 +127,115 @@ func (oc *OrbitClient) DoEnroll() (string, error) {
 	return resp.OrbitNodeKey, nil
 }
 
-func (oc *OrbitClient) GetConfig(orbitNodeKey string) (json.RawMessage, error) {
-	verb, path := "POST", "/api/fleet/orbit/config"
-	params := orbitGetConfigRequest{OrbitNodeKey: orbitNodeKey}
-	var resp orbitGetConfigResponse
-	err := oc.request(verb, path, params, &resp)
-	if err != nil {
-		return nil, err
-	}
+// enrollLock helps protect the enrolling process in case mutliple OrbitClients
+// want to re-enroll at the same time.
+var enrollLock sync.Mutex
 
-	return resp.Flags, nil
+// getNodeKeyOrEnroll attempts to read the orbit node key if the file exists on disk
+// otherwise it enrolls the host with Fleet and saves the node key to disk
+func (oc *OrbitClient) getNodeKeyOrEnroll() (string, error) {
+	enrollLock.Lock()
+	defer enrollLock.Unlock()
+
+	orbitNodeKey, err := ioutil.ReadFile(oc.nodeKeyFilePath)
+	switch {
+	case err == nil:
+		return string(orbitNodeKey), nil
+	case errors.Is(err, fs.ErrNotExist):
+		// OK, if there's no orbit node key, proceed to enroll.
+	default:
+		return "", fmt.Errorf("read orbit node key file: %w", err)
+	}
+	var (
+		orbitNodeKey_        string
+		endpointDoesNotExist bool
+	)
+	if err := retry.Do(
+		func() error {
+			var err error
+			orbitNodeKey_, err = oc.enrollAndWriteNodeKeyFile()
+			switch {
+			case err == nil:
+				return nil
+			case errors.Is(err, notFoundErr{}):
+				// Do not retry if the endpoint does not exist.
+				endpointDoesNotExist = true
+				return nil
+			default:
+				log.Info().Err(err).Msg("enroll failed, retrying")
+				return err
+			}
+		},
+		retry.WithInterval(constant.OrbitEnrollRetrySleep),
+		retry.WithMaxAttempts(constant.OrbitEnrollMaxRetries),
+	); err != nil {
+		return "", fmt.Errorf("orbit node key enroll failed, attempts=%d", constant.OrbitEnrollMaxRetries)
+	}
+	if endpointDoesNotExist {
+		return "", errors.New("enroll endpoint does not exist")
+	}
+	return orbitNodeKey_, nil
 }
 
-func (oc *OrbitClient) Ping() error {
-	verb, path := "HEAD", "/api/fleet/orbit/ping"
-	err := oc.request(verb, path, nil, nil)
+func (oc *OrbitClient) enrollAndWriteNodeKeyFile() (string, error) {
+	orbitNodeKey, err := oc.enroll()
+	if err != nil {
+		return "", fmt.Errorf("enroll request: %w", err)
+	}
+	if err := os.WriteFile(oc.nodeKeyFilePath, []byte(orbitNodeKey), constant.DefaultFileMode); err != nil {
+		return "", fmt.Errorf("write orbit node key file: %w", err)
+	}
+	return orbitNodeKey, nil
+}
 
-	if err == nil || errors.Is(err, notFoundErr{}) {
-		// notFound is ok, it means an old server without the capabilities header
-		return nil
+func (oc *OrbitClient) authenticatedRequest(verb string, path string, params interface{}, resp interface{}) error {
+	nodeKey, err := oc.getNodeKeyOrEnroll()
+	if err != nil {
+		return err
 	}
 
-	return err
+	s := params.(setOrbitNodeKeyer)
+	s.setOrbitNodeKey(nodeKey)
+
+	switch oc.request(verb, path, params, resp); {
+	case err == nil:
+		oc.setEnrolled(true)
+		return nil
+	case errors.Is(err, ErrUnauthenticated):
+		if err := os.Remove(oc.nodeKeyFilePath); err != nil {
+			log.Info().Err(err).Msg("remove orbit node key")
+		}
+		oc.setEnrolled(false)
+		return err
+	default:
+		return err
+	}
+}
+
+func (oc *OrbitClient) Enrolled() bool {
+	oc.enrolledMu.Lock()
+	defer oc.enrolledMu.Unlock()
+
+	return oc.enrolled
+}
+
+func (oc *OrbitClient) setEnrolled(v bool) {
+	oc.enrolledMu.Lock()
+	defer oc.enrolledMu.Unlock()
+
+	oc.enrolled = v
+}
+
+func (oc *OrbitClient) LastRequestError() error {
+	oc.lastReqErrMu.Lock()
+	defer oc.lastReqErrMu.Unlock()
+
+	return oc.lastReqErr
+}
+
+func (oc *OrbitClient) setLastRequestError(err error) {
+	oc.lastReqErrMu.Lock()
+	defer oc.lastReqErrMu.Unlock()
+
+	oc.lastReqErr = fmt.Errorf("%s: %w", time.Now().UTC().Format("2006-01-02T15:04:05Z"), err)
 }


### PR DESCRIPTION
Fixes #8042.

@roperzh: Orbit now always runs the FlagRunner, which in turn tries to enroll to Fleet if it isn't already enrolled.
Thus, I've removed the capabilities checker because we are now trying the Orbit enroll every 30 seconds (as part of the `FlagRunner` interval check). Let me know if we need such capabilities checker on this release and I can restore it back (I just didn't see need for it now).

I've decreased `OrbitEnrollMaxRetries` from `10` to `3` to decrease startup "downtime" on cases where the enroll secret is invalid.

- [X] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
