### PR TITLE
Add file carving to permissions documentation

### DIFF
--- a/changes/issue-7906-add-file-carving-to-permissions
+++ b/changes/issue-7906-add-file-carving-to-permissions
@@ -1,0 +1,1 @@
+* Permissions documentation includes initiating and retreiving file carving 

--- a/docs/Using-Fleet/Permissions.md
+++ b/docs/Using-Fleet/Permissions.md
@@ -8,37 +8,40 @@ Users with the Admin role receive all permissions.
 
 | **Action**                                                                         | Observer | Maintainer | Admin |
 | ----------------------------------------------------                               | -------- | ---------- | ----- |
-| View all activity                                                                  | ✅       | ✅         | ✅    |
-| View all hosts                                                                     | ✅       | ✅         | ✅    |
-| Filter hosts using labels                                                          | ✅       | ✅         | ✅    |
+| View all [activity](https://fleetdm.com/docs/using-fleet/rest-api#activities)                                                                  | ✅       | ✅         | ✅    |
+| View all hosts                                                                    | ✅       | ✅         | ✅    |
+| Filter hosts using [labels](https://fleetdm.com/docs/using-fleet/rest-api#labels)                                                          | ✅       | ✅         | ✅    |
 | Target hosts using labels                                                          | ✅       | ✅         | ✅    |
 | Add and delete hosts                                                               |          | ✅         | ✅    |
 | Transfer hosts between teams\*                                                     |          | ✅         | ✅    |
 | Create, edit, and delete labels                                                    |          | ✅         | ✅    |
 | View all software                                                                  | ✅       | ✅         | ✅    |
-| Filter software by vulnerabilities                                                 | ✅       | ✅         | ✅    |
+| Filter software by [vulnerabilities](https://fleetdm.com/docs/using-fleet/vulnerability-processing#vulnerability-processing)                                                 | ✅       | ✅         | ✅    |
 | Filter hosts by software                                                           | ✅       | ✅         | ✅    |
 | Filter software by team\*                                                          | ✅       | ✅         | ✅    |
-| Manage vulnerability automations                                                   |          |            | ✅    |
+| Manage [vulnerability automations](https://fleetdm.com/docs/using-fleet/automations#vulnerability-automations)                                                  |          |            | ✅    |
 | Run only designated, **observer can run** ,queries as live queries against all hosts | ✅       | ✅         | ✅    |
-| Run any query as live query against all hosts                                      |          | ✅         | ✅    |
+| Run any query as [live query](https://fleetdm.com/docs/using-fleet/fleet-ui#run-a-query) against all hosts                                      |          | ✅         | ✅    |
 | Create, edit, and delete queries                                                   |          | ✅         | ✅    |
 | View all queries                                                                   | ✅       | ✅         | ✅    |
-| Add, edit, and remove queries from all schedules                                   |          | ✅         | ✅    |
+| Add, edit, and remove queries from all schedules                                  |          | ✅         | ✅    |
 | Create, edit, view, and delete packs                                               |          | ✅         | ✅    |
 | View all policies                                                                  | ✅       | ✅         | ✅    |
 | Filter hosts using policies                                                        | ✅       | ✅         | ✅    |
 | Create, edit, and delete policies for all hosts                                    |          | ✅         | ✅    |
 | Create, edit, and delete policies for all hosts assigned to team\*                 |          | ✅         | ✅    |
-| Manage policy automations                                                          |          |            | ✅    |
+| Manage [policy automations](https://fleetdm.com/docs/using-fleet/automations#policy-automations)                                                         |          |            | ✅    |
 | Create, edit, view, and delete users                                               |          |            | ✅    |
 | Add and remove team members\*                                                      |          |            | ✅    |
 | Create, edit, and delete teams\*                                                   |          |            | ✅    |
-| Create, edit, and delete enroll secrets                                            |          | ✅         | ✅    |
-| Create, edit, and delete enroll secrets for teams\*                                |          | ✅         | ✅    |
-| Edit organization settings                                                         |          |            | ✅    |
-| Edit agent options                                                                 |          |            | ✅    |
-| Edit agent options for hosts assigned to teams\*                                   |          |            | ✅    |
+| Create, edit, and delete [enroll secrets](https://fleetdm.com/docs/deploying/faq#when-do-i-need-to-deploy-a-new-enroll-secret-to-my-hosts)                                           |          | ✅         | ✅    |
+| Create, edit, and delete [enroll secrets for teams](https://fleetdm.com/docs/using-fleet/rest-api#get-enroll-secrets-for-a-team)\*                                |          | ✅         | ✅    |
+| Edit [organization settings](https://fleetdm.com/docs/using-fleet/configuration-files#organization-settings)                                                         |          |            | ✅    |
+| Edit [agent options](https://fleetdm.com/docs/using-fleet/configuration-files#agent-options)                                                                 |          |            | ✅    |
+| Edit [agent options for hosts assigned to teams](https://fleetdm.com/docs/using-fleet/configuration-files#team-agent-options)\*                                   |          |            | ✅    |
+| Initiate [file carving](https://fleetdm.com/docs/using-fleet/rest-api#file-carving)                                                              |          | ✅         | ✅    |
+| Retrieve contents from file carving                                                |          |            | ✅    |
+
 
 
 
@@ -51,11 +54,11 @@ Users with the Admin role receive all permissions.
 
 Users in Fleet either have team access or global access. 
 
-Users with team access only have access to the hosts, software, schedules, and policies assigned to
+Users with team access only have access to the [hosts](https://fleetdm.com/docs/using-fleet/rest-api#hosts), [software](https://fleetdm.com/docs/using-fleet/rest-api#software), [schedules](https://fleetdm.com/docs/using-fleet/fleet-ui#schedule-a-query) , and [policies](https://fleetdm.com/docs/using-fleet/rest-api#policies) assigned to
 their team.
 
 Users with global access have access to all
-hosts, software, queries, schedules, and policies. Check out [the user permissions
+[hosts](https://fleetdm.com/docs/using-fleet/rest-api#hosts), [software](https://fleetdm.com/docs/using-fleet/rest-api#software), [queries](https://fleetdm.com/docs/using-fleet/rest-api#queries), [schedules](https://fleetdm.com/docs/using-fleet/fleet-ui#schedule-a-query) , and [policies](https://fleetdm.com/docs/using-fleet/rest-api#policies). Check out [the user permissions
 table](#user-permissions) above for global user permissions.
 
 Users can be a member of multiple teams in Fleet.
@@ -64,26 +67,27 @@ Users that are members of multiple teams can be assigned different roles for eac
 
 | **Action**                                                                         | Team observer | Team maintainer | Team admin |
 | ------------------------------------------------------------                       | --------      | ----------      | -------    |
-| View hosts                                                                         | ✅            | ✅              | ✅         |
-| Filter hosts using labels                                                          | ✅            | ✅              | ✅         |
+| View hosts                                                                        | ✅            | ✅              | ✅         |
+| Filter hosts using [labels](https://fleetdm.com/docs/using-fleet/rest-api#labels)                                                          | ✅            | ✅              | ✅         |
 | Target hosts using labels                                                          | ✅            | ✅              | ✅         |
 | Add and delete hosts                                                               |               | ✅              | ✅         |
-| Filter software by vulnerabilities                                                 | ✅            | ✅              | ✅         |
+| Filter software by [vulnerabilities]((https://fleetdm.com/docs/using-fleet/vulnerability-processing#vulnerability-processing))                                                 | ✅            | ✅              | ✅         |
 | Filter hosts by software                                                           | ✅            | ✅              | ✅         |
 | Filter software                                                                    | ✅            | ✅              | ✅         |
 | Run only designated, **observer can run** ,queries as live queries against all hosts | ✅            | ✅              | ✅         |
-| Run any query as live query                                                        |               | ✅              | ✅         |
+| Run any query as [live query](https://fleetdm.com/docs/using-fleet/fleet-ui#run-a-query)                                                        |               | ✅              | ✅         |
 | Create, edit, and delete only **self authored** queries                              |               | ✅              | ✅         |
 | Add, edit, and remove queries from the schedule                                    |               | ✅              | ✅         |
 | View policies                                                                      | ✅            | ✅              | ✅         |
 | View global (inherited) policies                                                   | ✅            | ✅              | ✅         |
 | Filter hosts using policies                                                        | ✅            | ✅              | ✅         |
 | Create, edit, and delete policies                                                  |               | ✅              | ✅         |
-| Manage policy automations                                                          |               |                 | ✅         |
+| Manage [policy automations](https://fleetdm.com/docs/using-fleet/automations#policy-automations)                                                          |               |                 | ✅         |
 | Add and remove team members                                                        |               |                 | ✅         |
 | Edit team name                                                                     |               |                 | ✅         |
-| Create, edit, and delete team enroll secrets                                       |               | ✅              | ✅         |
-| Edit agent options                                                                 |               |                 | ✅         |
+| Create, edit, and delete [team enroll secrets](https://fleetdm.com/docs/using-fleet/rest-api#get-enroll-secrets-for-a-team)                                      |               | ✅              | ✅         |
+| Edit [agent options](https://fleetdm.com/docs/using-fleet/configuration-files#agent-options)                                                                 |               |                 | ✅         |
+| Initiate [file carving](https://fleetdm.com/docs/using-fleet/rest-api#file-carving)                                                              |               | ✅               | ✅         |
 
 
 <meta name="pageOrderInSection" value="900">


### PR DESCRIPTION
Cerra #7906 

- Document permissions for initiating and retrieving file carving
- Additional: Add links to various permissions

Screenshots:
<img width="650" alt="Screen Shot 2022-10-03 at 12 14 15 PM" src="https://user-images.githubusercontent.com/71795832/193627303-d22fce78-0213-411c-ba03-d5d293915046.png">
<img width="1154" alt="Screen Shot 2022-10-03 at 12 14 28 PM" src="https://user-images.githubusercontent.com/71795832/193627298-1087a593-066f-418f-8a32-82baf296cbf9.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Documented any permissions changes
- [x] Manual QA for all new/changed functionality
