### PR TITLE
Fleet UI: Add optional tooltip delay used on compatibility tooltip

### DIFF
--- a/changes/issue-7989-delay-tooltip
+++ b/changes/issue-7989-delay-tooltip
@@ -1,0 +1,1 @@
+* Add delay to compatibility tooltip that is covering UI action checkbox

--- a/frontend/components/PlatformCompatibility/PlatformCompatibility.tsx
+++ b/frontend/components/PlatformCompatibility/PlatformCompatibility.tsx
@@ -67,7 +67,7 @@ const PlatformCompatibility = ({
       <b>
         <TooltipWrapper
           tipContent="Estimated compatiblity based on <br /> the tables used in the query."
-          tipDelay
+          isDelayed
         >
           Compatible with:
         </TooltipWrapper>

--- a/frontend/components/PlatformCompatibility/PlatformCompatibility.tsx
+++ b/frontend/components/PlatformCompatibility/PlatformCompatibility.tsx
@@ -65,7 +65,10 @@ const PlatformCompatibility = ({
   return (
     <span className={baseClass}>
       <b>
-        <TooltipWrapper tipContent="Estimated compatiblity based on <br /> the tables used in the query.">
+        <TooltipWrapper
+          tipContent="Estimated compatiblity based on <br /> the tables used in the query."
+          tipDelay
+        >
           Compatible with:
         </TooltipWrapper>
       </b>

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -4,7 +4,7 @@ interface ITooltipWrapperProps {
   children: string;
   tipContent: string;
   position?: "top" | "bottom";
-  tipDelay?: boolean;
+  isDelayed?: boolean;
 }
 
 const baseClass = "component__tooltip-wrapper";
@@ -13,9 +13,9 @@ const TooltipWrapper = ({
   children,
   tipContent,
   position = "bottom",
-  tipDelay,
+  isDelayed,
 }: ITooltipWrapperProps): JSX.Element => {
-  const tipClass = tipDelay
+  const tipClass = isDelayed
     ? `${baseClass}__tip-text delayed-tip`
     : `${baseClass}__tip-text`;
 

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -4,6 +4,7 @@ interface ITooltipWrapperProps {
   children: string;
   tipContent: string;
   position?: "top" | "bottom";
+  tipDelay?: boolean;
 }
 
 const baseClass = "component__tooltip-wrapper";
@@ -12,7 +13,12 @@ const TooltipWrapper = ({
   children,
   tipContent,
   position = "bottom",
+  tipDelay,
 }: ITooltipWrapperProps): JSX.Element => {
+  const tipClass = tipDelay
+    ? `${baseClass}__tip-text delayed-tip`
+    : `${baseClass}__tip-text`;
+
   return (
     <div className={baseClass} data-position={position}>
       <div className={`${baseClass}__element`}>
@@ -20,7 +26,7 @@ const TooltipWrapper = ({
         <div className={`${baseClass}__underline`} data-text={children} />
       </div>
       <div
-        className={`${baseClass}__tip-text`}
+        className={tipClass}
         dangerouslySetInnerHTML={{ __html: tipContent }}
       />
     </div>

--- a/frontend/components/TooltipWrapper/_styles.scss
+++ b/frontend/components/TooltipWrapper/_styles.scss
@@ -8,7 +8,13 @@
       visibility: visible;
       opacity: 1;
     }
+
+    .delayed-tip {
+      transition: 300ms all;
+      transition-delay: 300ms;
+    }
   }
+
   &__element {
     position: static;
     display: inline; // treat like a span but allow other tags as children


### PR DESCRIPTION
Cerra #7989 

- Fixes tooltip obstructing checkbox action by creating and adding an optional tooltip delay

Further action items suggested: 
- Find other UI this happens at and add a delay

*Screen recording of fix*

https://user-images.githubusercontent.com/71795832/193633998-b8ecee8b-cfeb-4b9d-a609-93e53167228c.mov



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
