### PR TITLE
Fleet UI: Update create team name suggestions

### DIFF
--- a/changes/issue-7533-change-create-teams-suggestion
+++ b/changes/issue-7533-change-create-teams-suggestion
@@ -1,0 +1,1 @@
+* Create teams modal has better team name suggestions

--- a/frontend/components/InfoBanner/InfoBanner.tests.tsx
+++ b/frontend/components/InfoBanner/InfoBanner.tests.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+import { render, screen } from "@testing-library/react";
+
+import InfoBanner from "./InfoBanner";
+
+describe("InfoBanner - component", () => {
+  it("info banner renders text", () => {
+    render(<InfoBanner>Info banner testing text</InfoBanner>);
+
+    const title = screen.getByText("Info banner testing text");
+
+    expect(title).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/admin/TeamManagementPage/components/CreateTeamModal/CreateTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/CreateTeamModal/CreateTeamModal.tsx
@@ -67,8 +67,9 @@ const CreateTeamModal = ({
           error={errors.name}
         />
         <InfoBanner className={`${baseClass}__sandbox-info`}>
-          To organize your hosts, create a team, like "Workstations," "Servers,"
-          or "Servers (canary)".
+          To organize your hosts, create a team, like
+          &ldquo;Workstations,&rdquo; &ldquo;Servers,&rdquo; or &ldquo;Servers
+          (canary)&rdquo;.
         </InfoBanner>
         <div className="modal-cta-wrap">
           <Button

--- a/frontend/pages/admin/TeamManagementPage/components/CreateTeamModal/CreateTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/CreateTeamModal/CreateTeamModal.tsx
@@ -62,19 +62,13 @@ const CreateTeamModal = ({
           name="name"
           onChange={onInputChange}
           label="Team name"
-          placeholder="Team name"
+          placeholder="Workstations"
           value={name}
           error={errors.name}
         />
         <InfoBanner className={`${baseClass}__sandbox-info`}>
-          <p className={`${baseClass}__info-header`}>
-            Need to test queries and configurations before deploying?
-          </p>
-          <p>
-            A popular pattern is to end a team’s name with “- Sandbox”, then you
-            can use this to test new queries and configuration with staging
-            hosts or volunteers acting as canaries.
-          </p>
+          To organize your hosts, create a team, like "Workstations," "Servers,"
+          or "Servers (canary)".
         </InfoBanner>
         <div className="modal-cta-wrap">
           <Button

--- a/frontend/pages/admin/TeamManagementPage/components/CreateTeamModal/_styles.scss
+++ b/frontend/pages/admin/TeamManagementPage/components/CreateTeamModal/_styles.scss
@@ -3,7 +3,11 @@
     margin-top: $pad-medium;
   }
 
-  &__info-header {
-    font-weight: $bold;
+  .form-field {
+    margin: 38px 0 $pad-medium;
+  }
+
+  .modal-cta-wrap {
+    margin-top: $pad-xxlarge;
   }
 }


### PR DESCRIPTION
Cerra #7533 

- Updates texts for create team modal
- Updates padding to match figma (more padding on this modal than other modals on figma)

<img width="653" alt="Screen Shot 2022-10-04 at 12 10 08 PM" src="https://user-images.githubusercontent.com/71795832/193870640-0b8a0e66-89e6-4b00-9567-9b779da6e776.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
