### PR TITLE
Fleet UI: Rename to machine serial and private IP address

### DIFF
--- a/changes/issue-7062
+++ b/changes/issue-7062
@@ -1,0 +1,1 @@
+* Rename machine serial to serial number and IPv4 properly to private IP address

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -141,7 +141,7 @@
   }
 
   #search-tooltip {
-    width: 196px;
+    width: 204px;
     text-align: center;
   }
 

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -527,10 +527,10 @@ export const PLATFORM_NAME_TO_LABEL_NAME = {
 };
 
 export const HOSTS_SEARCH_BOX_PLACEHOLDER =
-  "Search hostname, UUID, serial number, or IPv4";
+  "Search hostname, UUID, serial number, or private IP address";
 
 export const HOSTS_SEARCH_BOX_TOOLTIP =
-  "Search hosts by hostname, UUID, machine serial or private IP address";
+  "Search hosts by hostname, UUID, serial number or private IP address";
 
 export const VULNERABLE_DROPDOWN_OPTIONS = [
   {


### PR DESCRIPTION
Cerra #7062 

In Fleet UI:
- Rename all instances (there's only 1) of machine serial to serial number
- Rename all instances (there's only 1) of IPv4 properly to private IP address
- Make width 4px wider so "address" is not an [orphan word](https://fonts.google.com/knowledge/glossary/widows_orphans) to improve readability


<img width="301" alt="Screen Shot 2022-10-04 at 12 26 50 PM" src="https://user-images.githubusercontent.com/71795832/193873855-2595b6ca-06d0-4939-862e-56a4d9b7e7d1.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
