### PR TITLE
Fix CI tests for Go

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -65,8 +65,9 @@ jobs:
         echo "GO_TEST_TIMEOUT=1h" >> $GITHUB_ENV
 
     - name: Run Go Tests
+			# bash shell sets -eo pipefail so that the pipe to tee will exit with an error if test-go fails
+      shell: bash
       run: |
-        set -o pipefail
         GO_TEST_EXTRA_FLAGS="-v -race=$RACE_ENABLED -timeout=$GO_TEST_TIMEOUT" \
           TEST_LOCK_FILE_PATH=$(pwd)/lock \
           NETWORK_TEST=1 \

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -65,7 +65,7 @@ jobs:
         echo "GO_TEST_TIMEOUT=1h" >> $GITHUB_ENV
 
     - name: Run Go Tests
-			# bash shell sets -eo pipefail so that the pipe to tee will exit with an error if test-go fails
+      # bash shell sets -eo pipefail so that the pipe to tee will exit with an error if test-go fails
       shell: bash
       run: |
         GO_TEST_EXTRA_FLAGS="-v -race=$RACE_ENABLED -timeout=$GO_TEST_TIMEOUT" \

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -66,6 +66,7 @@ jobs:
 
     - name: Run Go Tests
       run: |
+        set -o pipefail
         GO_TEST_EXTRA_FLAGS="-v -race=$RACE_ENABLED -timeout=$GO_TEST_TIMEOUT" \
           TEST_LOCK_FILE_PATH=$(pwd)/lock \
           NETWORK_TEST=1 \

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -54,7 +54,7 @@ func Do(fn func() error, opts ...Option) error {
 			return nil
 		}
 
-		if cfg.maxAttempts != 0 && attempts > cfg.maxAttempts {
+		if cfg.maxAttempts != 0 && attempts >= cfg.maxAttempts {
 			return err
 		}
 

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -21,7 +21,7 @@ func TestRetryDo(t *testing.T) {
 		}, WithMaxAttempts(max), WithInterval(1*time.Millisecond))
 
 		require.ErrorIs(t, errTest, err)
-		require.Equal(t, max+1000, count)
+		require.Equal(t, max, count)
 	})
 
 	t.Run("operations are run an unlimited number of times by default", func(t *testing.T) {

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -21,7 +21,7 @@ func TestRetryDo(t *testing.T) {
 		}, WithMaxAttempts(max), WithInterval(1*time.Millisecond))
 
 		require.ErrorIs(t, errTest, err)
-		require.Equal(t, max, count)
+		require.Equal(t, max+1000, count)
 	})
 
 	t.Run("operations are run an unlimited number of times by default", func(t *testing.T) {

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -187,8 +187,8 @@ func TestAgentOptionsForHost(t *testing.T) {
 	assert.JSONEq(t, `{"foo":"override2"}`, string(opt))
 }
 
-// One of these queries is the disk space, only one of the two works in a platform. Similarly, one
-// is for operating system.
+// One of these queries is the disk space, only one of the two works in a platform. Similarly, os_version_windows
+// is only for Windows, while os_version is for all platforms.
 var expectedDetailQueries = osquery_utils.GetDetailQueries(config.FleetConfig{Vulnerabilities: config.VulnerabilitiesConfig{DisableWinOSVulnerabilities: true}}, &fleet.Features{EnableHostUsers: true})
 
 func TestEnrollAgent(t *testing.T) {
@@ -560,9 +560,10 @@ func TestHostDetailQueries(t *testing.T) {
 
 	queries, discovery, err = svc.detailQueriesForHost(context.Background(), &host)
 	require.NoError(t, err)
-	// 2 additional queries, but -3 expected queries due to removed disk space query (only 1 of 2
-	// active for a given platform) and removed two Windows-specific operating system queries
-	require.Equal(t, len(expectedDetailQueries)-1, len(queries), distQueriesMapKeys(queries))
+	// 2 additional queries, but -2 expected queries due to removed disk space query (only 1 of 2
+	// active for a given platform) and removed the Windows-specific operating system queries,
+	// so the result is +0.
+	require.Equal(t, len(expectedDetailQueries)+0, len(queries), distQueriesMapKeys(queries))
 	verifyDiscovery(t, queries, discovery)
 	for name := range queries {
 		assert.True(t,
@@ -742,9 +743,9 @@ func TestLabelQueries(t *testing.T) {
 	// should be turned on so that we can quickly fill labels)
 	queries, discovery, acc, err := svc.GetDistributedQueries(ctx)
 	require.NoError(t, err)
-	// -3 expected queries due to removed disk space query (only 1 of 2 active for a given platform)
-	// and removed two Windows-specific operating system queries
-	require.Equal(t, len(expectedDetailQueries)-3, len(queries), distQueriesMapKeys(queries))
+	// -2 expected queries due to removed disk space query (only 1 of 2 active for a given platform)
+	// and removed the Windows-specific operating system queries
+	require.Equal(t, len(expectedDetailQueries)-2, len(queries), distQueriesMapKeys(queries))
 	verifyDiscovery(t, queries, discovery)
 	assert.NotZero(t, acc)
 
@@ -834,9 +835,9 @@ func TestLabelQueries(t *testing.T) {
 	ctx = hostctx.NewContext(ctx, host)
 	queries, discovery, acc, err = svc.GetDistributedQueries(ctx)
 	require.NoError(t, err)
-	// +3 for label queries, but -3 expected queries due to removed disk space query (only 1 of 2
-	// active for a given platform) and removed two Windows-specific operating system query
-	require.Equal(t, len(expectedDetailQueries), len(queries), distQueriesMapKeys(queries))
+	// +3 for label queries, but -2 expected queries due to removed disk space query (only 1 of 2
+	// active for a given platform) and removed the Windows-specific operating system query
+	require.Equal(t, len(expectedDetailQueries)+1, len(queries), distQueriesMapKeys(queries))
 	verifyDiscovery(t, queries, discovery)
 	assert.Zero(t, acc)
 
@@ -1066,8 +1067,8 @@ func TestDetailQueriesWithEmptyStrings(t *testing.T) {
 	require.NoError(t, err)
 	// somehow confusingly, the query response above changed the host's platform
 	// from windows to darwin, so now it has all expected queries except the
-	// extra disk space one and the two windows-specific operating system query
-	require.Equal(t, len(expectedDetailQueries)-3, len(queries), distQueriesMapKeys(queries))
+	// extra disk space one and the windows-specific operating system query
+	require.Equal(t, len(expectedDetailQueries)-2, len(queries), distQueriesMapKeys(queries))
 	verifyDiscovery(t, queries, discovery)
 	assert.Zero(t, acc)
 }
@@ -1126,9 +1127,9 @@ func TestDetailQueries(t *testing.T) {
 	// queries)
 	queries, discovery, acc, err := svc.GetDistributedQueries(ctx)
 	require.NoError(t, err)
-	// -6 due to linux platform, so battery, mdm, and munki are missing, and the extra disk space
-	// query, and the two windows-specific operating system queries, then +1 due to software inventory being enabled.
-	if !assert.Equal(t, len(expectedDetailQueries)-5, len(queries)) {
+	// -5 due to linux platform, so battery, mdm, and munki are missing, and the extra disk space
+	// query, and the windows-specific operating system queries, then +1 due to software inventory being enabled.
+	if !assert.Equal(t, len(expectedDetailQueries)-4, len(queries)) {
 		// this is just to print the diff between the expected and actual query
 		// keys when the count assertion fails, to help debugging - they are not
 		// expected to match.
@@ -1387,10 +1388,10 @@ func TestDetailQueries(t *testing.T) {
 
 	queries, discovery, acc, err = svc.GetDistributedQueries(ctx)
 	require.NoError(t, err)
-	// host platform changed to darwin, so -3 for the
-	// extra disk space query and the two windows-specific operating system query,
+	// host platform changed to darwin, so -2 for the
+	// extra disk space query and the windows-specific operating system query,
 	// +1 for the software inventory enabled.
-	require.Equal(t, len(expectedDetailQueries)-2, len(queries), distQueriesMapKeys(queries))
+	require.Equal(t, len(expectedDetailQueries)-1, len(queries), distQueriesMapKeys(queries))
 	verifyDiscovery(t, queries, discovery)
 	assert.Zero(t, acc)
 }
@@ -2354,9 +2355,9 @@ func TestPolicyQueries(t *testing.T) {
 
 	queries, discovery, _, err := svc.GetDistributedQueries(ctx)
 	require.NoError(t, err)
-	// all queries -3 for the extra disk space one and two windows-specific operating system queries,
+	// all queries -2 for the extra disk space one and the windows-specific operating system query,
 	// and +2 for the policy queries
-	require.Equal(t, len(expectedDetailQueries)-1, len(queries), distQueriesMapKeys(queries))
+	require.Equal(t, len(expectedDetailQueries)-0, len(queries), distQueriesMapKeys(queries))
 	verifyDiscovery(t, queries, discovery)
 
 	checkPolicyResults := func(queries map[string]string) {
@@ -2412,8 +2413,8 @@ func TestPolicyQueries(t *testing.T) {
 	ctx = hostctx.NewContext(context.Background(), host)
 	queries, discovery, _, err = svc.GetDistributedQueries(ctx)
 	require.NoError(t, err)
-	// all standard queries minus the extra disk space and two windows-specific operating system queries
-	require.Equal(t, len(expectedDetailQueries)-3, len(queries), distQueriesMapKeys(queries))
+	// all standard queries minus the extra disk space and the windows-specific operating system query
+	require.Equal(t, len(expectedDetailQueries)-2, len(queries), distQueriesMapKeys(queries))
 	verifyDiscovery(t, queries, discovery)
 	noPolicyResults(queries)
 
@@ -2422,9 +2423,9 @@ func TestPolicyQueries(t *testing.T) {
 
 	queries, discovery, _, err = svc.GetDistributedQueries(ctx)
 	require.NoError(t, err)
-	// all standard queries -3 (the extra disk space and two windows-specific operating system
-	// queries) and +2 policy queries
-	require.Equal(t, len(expectedDetailQueries)-1, len(queries), distQueriesMapKeys(queries))
+	// all standard queries -2 (the extra disk space and a windows-specific operating system
+	// query) and +2 policy queries
+	require.Equal(t, len(expectedDetailQueries)+0, len(queries), distQueriesMapKeys(queries))
 	verifyDiscovery(t, queries, discovery)
 	checkPolicyResults(queries)
 
@@ -2452,8 +2453,8 @@ func TestPolicyQueries(t *testing.T) {
 	ctx = hostctx.NewContext(context.Background(), host)
 	queries, discovery, _, err = svc.GetDistributedQueries(ctx)
 	require.NoError(t, err)
-	// all standard queries minus the extra disk space and two windows-specific operating system queries
-	require.Equal(t, len(expectedDetailQueries)-3, len(queries), distQueriesMapKeys(queries))
+	// all standard queries minus the extra disk space and windows-specific operating system query
+	require.Equal(t, len(expectedDetailQueries)-2, len(queries), distQueriesMapKeys(queries))
 	verifyDiscovery(t, queries, discovery)
 	noPolicyResults(queries)
 
@@ -2462,9 +2463,9 @@ func TestPolicyQueries(t *testing.T) {
 	ctx = hostctx.NewContext(context.Background(), host)
 	queries, discovery, _, err = svc.GetDistributedQueries(ctx)
 	require.NoError(t, err)
-	// all standard queries -3 (the extra disk space and two windows-specific operating system
-	// queries) and +2 policy queries
-	require.Equal(t, len(expectedDetailQueries)-1, len(queries), distQueriesMapKeys(queries))
+	// all standard queries -2 (the extra disk space and the windows-specific operating system
+	// query) and +2 policy queries
+	require.Equal(t, len(expectedDetailQueries)+0, len(queries), distQueriesMapKeys(queries))
 	verifyDiscovery(t, queries, discovery)
 	checkPolicyResults(queries)
 
@@ -2494,8 +2495,8 @@ func TestPolicyQueries(t *testing.T) {
 	ctx = hostctx.NewContext(context.Background(), host)
 	queries, discovery, _, err = svc.GetDistributedQueries(ctx)
 	require.NoError(t, err)
-	// all standard queries minus the extra disk space and two windows-specific operating system queries
-	require.Equal(t, len(expectedDetailQueries)-3, len(queries), distQueriesMapKeys(queries))
+	// all standard queries minus the extra disk space and the windows-specific operating system query
+	require.Equal(t, len(expectedDetailQueries)-2, len(queries), distQueriesMapKeys(queries))
 	verifyDiscovery(t, queries, discovery)
 	noPolicyResults(queries)
 }
@@ -2560,8 +2561,8 @@ func TestPolicyWebhooks(t *testing.T) {
 
 	queries, discovery, _, err := svc.GetDistributedQueries(ctx)
 	require.NoError(t, err)
-	// all queries -3 for extra disk space and two windows-specific operating system queries, +3 for policies
-	require.Equal(t, len(expectedDetailQueries), len(queries), distQueriesMapKeys(queries))
+	// all queries -2 for extra disk space and the windows-specific operating system query, +3 for policies
+	require.Equal(t, len(expectedDetailQueries)+1, len(queries), distQueriesMapKeys(queries))
 	verifyDiscovery(t, queries, discovery)
 
 	checkPolicyResults := func(queries map[string]string) {
@@ -2674,8 +2675,8 @@ func TestPolicyWebhooks(t *testing.T) {
 	ctx = hostctx.NewContext(context.Background(), host)
 	queries, discovery, _, err = svc.GetDistributedQueries(ctx)
 	require.NoError(t, err)
-	// all standard queries minus the extra disk space and two windows-specific operating system queries
-	require.Equal(t, len(expectedDetailQueries)-3, len(queries), distQueriesMapKeys(queries))
+	// all standard queries minus the extra disk space and the windows-specific operating system query
+	require.Equal(t, len(expectedDetailQueries)-2, len(queries), distQueriesMapKeys(queries))
 	verifyDiscovery(t, queries, discovery)
 	noPolicyResults(queries)
 
@@ -2684,8 +2685,8 @@ func TestPolicyWebhooks(t *testing.T) {
 
 	queries, discovery, _, err = svc.GetDistributedQueries(ctx)
 	require.NoError(t, err)
-	// all queries -3 for extra disk space and windows-specific operating system queries, +3 for policies
-	require.Equal(t, len(expectedDetailQueries), len(queries), distQueriesMapKeys(queries))
+	// all queries -2 for extra disk space and windows-specific operating system query, +3 for policies
+	require.Equal(t, len(expectedDetailQueries)+1, len(queries), distQueriesMapKeys(queries))
 	verifyDiscovery(t, queries, discovery)
 	checkPolicyResults(queries)
 
@@ -2808,8 +2809,8 @@ func TestLiveQueriesFailing(t *testing.T) {
 
 	queries, discovery, _, err := svc.GetDistributedQueries(ctx)
 	require.NoError(t, err)
-	// all standard queries minus the extra disk space and two windows-specific operating system queries
-	require.Equal(t, len(expectedDetailQueries)-3, len(queries), distQueriesMapKeys(queries))
+	// all standard queries minus the extra disk space and the windows-specific operating system query
+	require.Equal(t, len(expectedDetailQueries)-2, len(queries), distQueriesMapKeys(queries))
 	verifyDiscovery(t, queries, discovery)
 
 	logs, err := io.ReadAll(buf)

--- a/server/vulnerabilities/nvd/sync_test.go
+++ b/server/vulnerabilities/nvd/sync_test.go
@@ -51,7 +51,7 @@ func TestLoadCVEMeta(t *testing.T) {
 	}
 
 	logger := log.NewNopLogger()
-	err := LoadCVEMeta(logger, "testdata", ds)
+	err := LoadCVEMeta(logger, "../testdata", ds)
 	require.NoError(t, err)
 	require.True(t, ds.InsertCVEMetaFuncInvoked)
 


### PR DESCRIPTION
Failing tests had made it to `main` because of a change in the go test yaml / Github action. This should fix the failing tests AND fix the exit code of the Github action.