### PR TITLE
Fleet UI: Host's software details links to software, improved responsiveness

### DIFF
--- a/changes/issue-7656-software-link-host-details-page
+++ b/changes/issue-7656-software-link-host-details-page
@@ -1,0 +1,1 @@
+* Host details software table links to software details, better responsive UI for software table

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -192,7 +192,7 @@ describe("Hosts flow", () => {
         });
       });
     });
-    it("renders and searches the host's software, links to filter hosts by software", () => {
+    it("renders and searches the host's software", () => {
       cy.getAttached(".react-tabs__tab-list").within(() => {
         cy.findByText(/software/i).click();
       });
@@ -219,12 +219,24 @@ describe("Hosts flow", () => {
             const searchCount = parseInt(newCount[0], 10);
             expect(searchCount).to.be.lessThan(initialCount);
           });
-        cy.getAttached(".software-link").first().click({ force: true });
       });
-      cy.findByText(/libacl1 2.2.53-6/i).should("exist");
+    });
+    it("host's software table links to filter hosts by software", () => {
+      cy.getAttached(".react-tabs__tab-list").within(() => {
+        cy.findByText(/software/i).click();
+      });
+      cy.getAttached(".software-link").first().click({ force: true });
+      cy.findByText(/adduser 3.118ubuntu2/i).should("exist"); // first seeded software item
       cy.getAttached(".data-table").within(() => {
         cy.findByText(hostname).should("exist");
       });
+    });
+    it.only("host's software table links to software details", () => {
+      cy.getAttached(".react-tabs__tab-list").within(() => {
+        cy.findByText(/software/i).click();
+      });
+      cy.contains(/adduser/i).click();
+      cy.findByText(/adduser, 3.118ubuntu2/i).should("exist");
     });
     it("renders host's schedule", () => {
       cy.getAttached(".react-tabs__tab-list").within(() => {

--- a/cypress/integration/all/app/hosts.spec.ts
+++ b/cypress/integration/all/app/hosts.spec.ts
@@ -231,7 +231,7 @@ describe("Hosts flow", () => {
         cy.findByText(hostname).should("exist");
       });
     });
-    it.only("host's software table links to software details", () => {
+    it("host's software table links to software details", () => {
       cy.getAttached(".react-tabs__tab-list").within(() => {
         cy.findByText(/software/i).click();
       });

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -95,7 +95,6 @@ import PolicyIcon from "../../../../assets/images/icon-policy-fleet-black-12x12@
 import DownloadIcon from "../../../../assets/images/icon-download-12x12@2x.png";
 import LabelFilterSelect from "./components/LabelFilterSelect";
 import FilterPill from "./components/FilterPill";
-import { IApiError } from "interfaces/errors";
 
 interface IManageHostsProps {
   route: RouteProps;

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -344,9 +344,6 @@ const ManageHostsPage = ({
       onSuccess: ({ policy: policyAPIResponse }) => {
         setPolicy(policyAPIResponse);
       },
-      onError: (error: Error) => {
-        console.log(error);
-      },
     }
   );
 

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -95,6 +95,7 @@ import PolicyIcon from "../../../../assets/images/icon-policy-fleet-black-12x12@
 import DownloadIcon from "../../../../assets/images/icon-download-12x12@2x.png";
 import LabelFilterSelect from "./components/LabelFilterSelect";
 import FilterPill from "./components/FilterPill";
+import { IApiError } from "interfaces/errors";
 
 interface IManageHostsProps {
   route: RouteProps;
@@ -343,6 +344,9 @@ const ManageHostsPage = ({
       enabled: !!policyId,
       onSuccess: ({ policy: policyAPIResponse }) => {
         setPolicy(policyAPIResponse);
+      },
+      onError: (error: Error) => {
+        console.log(error);
       },
     }
   );

--- a/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
@@ -99,6 +99,22 @@ const condenseVulnerabilities = (vulns: string[]): string[] => {
     : condensed;
 };
 
+const withBundleTooltip = (name: string, bundle: string) => (
+  <span className="name-container">
+    <TooltipWrapper
+      tipContent={`
+        <span>
+          <b>Bundle identifier: </b>
+          <br />
+          ${bundle}
+        </span>
+      `}
+    >
+      {name}
+    </TooltipWrapper>
+  </span>
+);
+
 interface ISoftwareTableData extends Omit<ISoftware, "vulnerabilities"> {
   vulnerabilities: string[];
 }
@@ -132,25 +148,12 @@ export const generateSoftwareTableHeaders = (
       disableSortBy: false,
       disableGlobalFilter: false,
       Cell: (cellProps: IStringCellProps) => {
-        const { name, bundle_identifier } = cellProps.row.original;
-        if (bundle_identifier) {
-          return (
-            <span className="name-container">
-              <TooltipWrapper
-                tipContent={`
-                <span>
-                  <b>Bundle identifier: </b>
-                  <br />
-                  ${bundle_identifier}
-                </span>
-              `}
-              >
-                {name}
-              </TooltipWrapper>
-            </span>
-          );
-        }
-        return <TextCell value={name} />;
+        const { id, name, bundle_identifier: bundle } = cellProps.row.original;
+        return (
+          <Link to={`${PATHS.SOFTWARE_DETAILS(id.toString())}`}>
+            {bundle ? withBundleTooltip(name, bundle) : name}
+          </Link>
+        );
       },
       sortType: "caseInsensitive",
     },

--- a/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
@@ -99,7 +99,7 @@ const condenseVulnerabilities = (vulns: string[]): string[] => {
     : condensed;
 };
 
-const withBundleTooltip = (name: string, bundle: string) => (
+const renderBundleTooltip = (name: string, bundle: string) => (
   <span className="name-container">
     <TooltipWrapper
       tipContent={`
@@ -151,7 +151,7 @@ export const generateSoftwareTableHeaders = (
         const { id, name, bundle_identifier: bundle } = cellProps.row.original;
         return (
           <Link to={`${PATHS.SOFTWARE_DETAILS(id.toString())}`}>
-            {bundle ? withBundleTooltip(name, bundle) : name}
+            {bundle ? renderBundleTooltip(name, bundle) : name}
           </Link>
         );
       },

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -51,7 +51,7 @@
           width: $col-sm;
         }
         .vulnerabilities__header {
-          min-width: 125px;
+          min-width: 130px;
         }
         .source__header {
           display: none;

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -50,6 +50,9 @@
         .version__header {
           width: $col-sm;
         }
+        .vulnerabilities__header {
+          min-width: 125px;
+        }
         .source__header {
           display: none;
           width: 0px;
@@ -61,14 +64,13 @@
           display: none;
         }
         .linkToFilteredHosts__header {
-          min-width: 110px;
+          min-width: 115px;
         }
-        @media (min-width: $break-990) {
+        @media (min-width: $break-1400) {
           .version__header {
             width: $col-md;
           }
-        }
-        @media (min-width: $break-1400) {
+
           .source__header {
             display: table-cell;
             width: $col-md;
@@ -143,6 +145,51 @@
           .software-link {
             visibility: visible;
           }
+        }
+      }
+    }
+  }
+
+  // table header content responsive styles
+  // NOTE: 990px is a custom breakpoint to deal with responsiveness of the
+  // table controls.
+  @media (max-width: 990px) {
+    thead .name__header {
+      width: $col-md;
+    }
+
+    .table-container__header {
+      flex-direction: column;
+    }
+
+    .table-container__search {
+      order: 1;
+      width: 100%;
+      margin-bottom: $pad-medium;
+
+      .table-container__search-input {
+        margin-left: 0;
+
+        & .search-field__input-wrapper {
+          width: auto;
+        }
+      }
+    }
+
+    .table-container__header-left {
+      order: 2;
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+
+      .results-count {
+        order: 2;
+      }
+
+      .controls {
+        .Select {
+          width: 100%;
+          margin-bottom: $pad-large;
         }
       }
     }

--- a/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
@@ -62,7 +62,7 @@ const condenseVulnerabilities = (
     : condensed;
 };
 
-const withBundleTooltip = (name: string, bundle: string) => (
+const renderBundleTooltip = (name: string, bundle: string) => (
   <span className="name-container">
     <TooltipWrapper
       tipContent={`
@@ -189,7 +189,7 @@ const generateTableHeaders = (isPremiumTier?: boolean): Column[] => {
         const { id, name, bundle_identifier: bundle } = cellProps.row.original;
         return (
           <Link to={`${PATHS.SOFTWARE_DETAILS(id.toString())}`}>
-            {bundle ? withBundleTooltip(name, bundle) : name}
+            {bundle ? renderBundleTooltip(name, bundle) : name}
           </Link>
         );
       },

--- a/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
@@ -193,6 +193,7 @@ const generateTableHeaders = (isPremiumTier?: boolean): Column[] => {
           </Link>
         );
       },
+      sortType: "caseInsensitive",
     },
     {
       title: "Version",


### PR DESCRIPTION
Cerra #7656 

**Feature**:
- Host details > software table name links to software details page
- Responsive table header from 770-990px
- Responsive columns look better from 770-990px
- E2E: Test host details > software links links to software details (This is one of those actions that are only tested once so the action does not live on an E2E page object)

**Note:** Product decided the go back link on software details does not go back to this page but all software page

**Screenshots**:
Near 990px
<img width="735" alt="Screen Shot 2022-10-04 at 2 49 11 PM" src="https://user-images.githubusercontent.com/71795832/193901949-9d82cadd-6f67-45e9-8c0d-f55b7ea4f3ca.png">
Near 770px
<img width="565" alt="Screen Shot 2022-10-04 at 2 51 02 PM" src="https://user-images.githubusercontent.com/71795832/193901970-fbedcd51-e824-468d-895f-e2f638f891d0.png">

**Video recording linking to software, and products decision to keep back button go to software inventory (not populated since I just spun up these test hosts)**

https://user-images.githubusercontent.com/71795832/194372708-f75ca682-881f-461f-bfc2-f615c6f0a117.mov



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
