### PR TITLE
Fleet UI: Clarify last fetched and last seen time on Manage Host Page

### DIFF
--- a/changes/issue-7310-clarify-last-seen-last-fetched
+++ b/changes/issue-7310-clarify-last-seen-last-fetched
@@ -1,0 +1,1 @@
+* Clarify last seen time and last fetched time in Fleet UI

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -13,6 +13,7 @@ import IssueCell from "components/TableContainer/DataTable/IssueCell/IssueCell";
 import LinkCell from "components/TableContainer/DataTable/LinkCell/LinkCell";
 import StatusCell from "components/TableContainer/DataTable/StatusCell/StatusCell";
 import TextCell from "components/TableContainer/DataTable/TextCell/TextCell";
+import TooltipWrapper from "components/TooltipWrapper";
 import {
   humanHostMemory,
   humanHostLastRestart,
@@ -285,12 +286,23 @@ const allHostTableHeaders: IDataColumn[] = [
   },
   {
     title: "Last fetched",
-    Header: (cellProps: IHeaderProps) => (
-      <HeaderCell
-        value={cellProps.column.title}
-        isSortedDesc={cellProps.column.isSortedDesc}
-      />
-    ),
+    Header: (headerProps: IHeaderProps): JSX.Element => {
+      const titleWithToolTip = (
+        <TooltipWrapper
+          tipContent={`
+            The last time the host reported vitals.
+          `}
+        >
+          Last fetched
+        </TooltipWrapper>
+      );
+      return (
+        <HeaderCell
+          value={titleWithToolTip}
+          isSortedDesc={headerProps.column.isSortedDesc}
+        />
+      );
+    },
     accessor: "detail_updated_at",
     Cell: (cellProps: ICellProps) => (
       <TextCell
@@ -301,12 +313,23 @@ const allHostTableHeaders: IDataColumn[] = [
   },
   {
     title: "Last seen",
-    Header: (cellProps: IHeaderProps) => (
-      <HeaderCell
-        value={cellProps.column.title}
-        isSortedDesc={cellProps.column.isSortedDesc}
-      />
-    ),
+    Header: (headerProps: IHeaderProps): JSX.Element => {
+      const titleWithToolTip = (
+        <TooltipWrapper
+          tipContent={`
+            The last time the host was online.
+          `}
+        >
+          Last seen
+        </TooltipWrapper>
+      );
+      return (
+        <HeaderCell
+          value={titleWithToolTip}
+          isSortedDesc={headerProps.column.isSortedDesc}
+        />
+      );
+    },
     accessor: "seen_time",
     Cell: (cellProps: ICellProps) => (
       <TextCell value={cellProps.cell.value} formatter={humanHostLastSeen} />

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -550,6 +550,7 @@ export const inMilliseconds = (nanoseconds: number): number => {
   return nanoseconds / NANOSECONDS_PER_MILLISECOND;
 };
 
+// update
 export const humanHostLastRestart = (
   detailUpdatedAt: string,
   uptime: number | string
@@ -588,7 +589,7 @@ export const humanHostLastSeen = (lastSeen: string): string => {
   if (!lastSeen || lastSeen < "2016-07-28T00:00:00Z") {
     return "Never";
   }
-  return format(new Date(lastSeen), "MMM d yyyy, HH:mm:ss");
+  return formatDistanceToNow(new Date(lastSeen), { addSuffix: true });
 };
 
 export const humanHostEnrolled = (enrolled: string): string => {

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -550,7 +550,6 @@ export const inMilliseconds = (nanoseconds: number): number => {
   return nanoseconds / NANOSECONDS_PER_MILLISECOND;
 };
 
-// update
 export const humanHostLastRestart = (
   detailUpdatedAt: string,
   uptime: number | string


### PR DESCRIPTION
Cerra  #7310 

**New features**
- Two new tooltips on Manage host table for last seen and last fetched
- Convert last seen to time ago

**Screenshots**
<img width="662" alt="Screen Shot 2022-10-04 at 4 54 34 PM" src="https://user-images.githubusercontent.com/71795832/194108771-17ac0ce3-fe7d-4630-9e7c-b1caba7a4f29.png">
<img width="679" alt="Screen Shot 2022-10-04 at 4 54 29 PM" src="https://user-images.githubusercontent.com/71795832/194108772-b6b9e721-399d-494d-902c-7ec3e7ac4446.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
