### PR TITLE
Run TUF CI checks on ubuntu-latest

### DIFF
--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -12,9 +12,11 @@ on:
       - patch-*
     paths:
       - 'orbit/**.go'
+      - '.github/workflows/fleet-and-orbit.yml'
   pull_request:
     paths:
       - 'orbit/**.go'
+      - '.github/workflows/fleet-and-orbit.yml'
   workflow_dispatch: # Manual
 
 env:

--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -17,6 +17,9 @@ on:
       - 'orbit/**.go'
   workflow_dispatch: # Manual
 
+env:
+  OSQUERY_VERSION: 5.5.1
+
 permissions:
   contents: read
 
@@ -124,7 +127,6 @@ jobs:
         path: |
           fleet_log
 
-
   # Sets the enroll secret of the Fleet server.
   #
   # This job also makes sure the Fleet server is up and running.
@@ -167,23 +169,13 @@ jobs:
         ./build/fleetctl apply -f secrets.yml
 
 
-  # TODO(lucas): Currently, to simplify the workflow we do all in one job:
-  # 1. Generate TUF repository (compile Orbit from source).
-  # 2. Run TUF server on localhost.
-  # 3. Generate packages using localhost TUF server.
-  #
-  # When installing the generated packages, Orbit will log "update errors"
-  # because the TUF URL is set to http://localhost:8081.
-  #
-  # TODO(lucas): Test the generated RPM package on a CentOS docker image.
-  run-tuf-and-gen-pkgs:
-    timeout-minutes: 60
+  # Here we generate the Fleet Desktop and osqueryd targets for
+  # macOS which can only be generated from a macOS host.
+  build-macos-targets:
     strategy:
       matrix:
         go-version: ['^1.19.1']
-    # We can only generate all (PKG, MSI, DEB, RPM) packages from a macOS host.
     runs-on: macos-latest
-    needs: gen
     steps:
 
     - name: Install Go
@@ -194,21 +186,54 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2
 
-    # Docker needs to be installed manually on macOS.
-    # From https://github.com/docker/for-mac/issues/2359#issuecomment-943131345
-    # FIXME: lock Docker version to 4.10.0 as newer versions fail to initialize
-    - name: Install Docker
-      timeout-minutes: 20
+    - name: Build desktop.app.tar.gz and osqueryd.app.tar.gz
       run: |
-        curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/c65030146a5cf2070c2499b6c68e2c3495c99731/Casks/docker.rb > docker.rb
-        brew install --cask docker.rb
-        sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
-        open -a /Applications/Docker.app --args --unattended --accept-license
-        echo "Waiting for Docker to start up..."
-        while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do
-          sleep 1;
-        done
-        echo "Docker is ready."
+        make desktop-app-tar-gz
+        make osqueryd-app-tar-gz version=$OSQUERY_VERSION out-path=.
+
+    - name: Upload desktop.app.tar.gz and osqueryd.app.tar.gz
+      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v2
+      with:
+        name: macos-pre-built-apps
+        path: |
+          desktop.app.tar.gz
+          osqueryd.app.tar.gz
+
+
+  # TODO(lucas): Currently, to simplify the workflow we do all in one job:
+  # 1. Generate TUF repository (compile Orbit from source).
+  # 2. Run TUF server on localhost.
+  # 3. Generate packages using localhost TUF server.
+  #
+  # When installing the generated packages, Orbit will log "update errors"
+  # because the TUF URL is set to http://localhost:8081.
+  #
+  # TODO(lucas): Test the generated RPM package on a CentOS docker image.
+  #
+  # We run this job in ubuntu because Github macOS runner doesn't have Docker
+  # installed, and installing it is time consuming and unreliable.
+  run-tuf-and-gen-pkgs:
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        go-version: ['^1.19.1']
+    runs-on: ubuntu-latest
+    needs: [gen, build-macos-targets]
+    steps:
+
+    - name: Install Go
+      uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Checkout Code
+      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2
+
+    - name: Download macos pre-built apps
+      id: download
+      uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v2
+      with:
+        name: macos-pre-built-apps
 
     - name: Build Repository and run TUF server
       env:
@@ -222,6 +247,8 @@ jobs:
         MSI_FLEET_URL: ${{ needs.gen.outputs.address }}
         MSI_TUF_URL: http://localhost:8081
         ENROLL_SECRET: ${{ needs.gen.outputs.enroll_secret }}
+        MACOS_USE_PREBUILT_DESKTOP_APP_TAR_GZ: 1
+        MACOS_USE_PREBUILT_OSQUERYD_APP_TAR_GZ: 1
         GENERATE_PKG: 1
         GENERATE_DEB: 1
         GENERATE_RPM: 1


### PR DESCRIPTION
Main change here is to not run `main.sh` (TUF repo and package generation) on ubuntu-latest instead of in (unreliable because Docker) macOS.