### PR TITLE
E2E fixes: Updating seeded users DOM

### DIFF
--- a/cypress/integration/free/admin.spec.ts
+++ b/cypress/integration/free/admin.spec.ts
@@ -197,7 +197,9 @@ describe(
         });
       });
       it("displays the 'Create user' button", () => {
-        cy.findByRole("button", { name: /create user/i }).click();
+        cy.findByRole("button", { name: /create user/i }).click({
+          force: true,
+        });
       });
       it("hides assigning a user to a team", () => {
         cy.findByText(/team/i).should("not.exist");

--- a/cypress/integration/premium/admin.spec.ts
+++ b/cypress/integration/premium/admin.spec.ts
@@ -540,13 +540,13 @@ describe("Premium tier - Global Admin user", () => {
       cy.getAttached(".react-tabs").within(() => {
         cy.findByText(/users/i).click();
       });
-      cy.findByRole("button", { name: /create user/i }).click();
+      cy.findByRole("button", { name: /create user/i }).click({ force: true });
       cy.findByText(/assign teams/i).should("exist");
     });
     it("allows global admin to edit existing user password", () => {
       cy.visit("/settings/users");
       cy.getAttached("tbody").within(() => {
-        cy.findByText("Oliver") // case-sensitive
+        cy.contains("Oliver") // case-sensitive
           .parent()
           .next()
           .next()

--- a/cypress/integration/premium/team_admin.spec.ts
+++ b/cypress/integration/premium/team_admin.spec.ts
@@ -163,7 +163,7 @@ describe("Premium tier - Team Admin user", () => {
       cy.findByText(/apples/i).should("exist");
     });
     it("displays the team admin controls", () => {
-      cy.findByRole("button", { name: /create user/i }).click();
+      cy.findByRole("button", { name: /create user/i }).click({ force: true });
       cy.findByRole("button", { name: /cancel/i }).click();
       cy.findByRole("button", { name: /add hosts/i }).click();
       cy.findByRole("button", { name: /done/i }).click();
@@ -173,7 +173,7 @@ describe("Premium tier - Team Admin user", () => {
     it("allows team admin to edit a team member", () => {
       cy.getAttached("tbody").within(() => {
         cy.getAttached("tr")
-          .eq(1)
+          .eq(2)
           .within(() => {
             cy.findByText(/action/i).click();
             cy.findByText(/edit/i).click();
@@ -186,7 +186,7 @@ describe("Premium tier - Team Admin user", () => {
       cy.findByRole("button", { name: /save/i }).click();
       cy.getAttached("tbody").within(() => {
         cy.getAttached("tr")
-          .eq(1)
+          .eq(2)
           .within(() => {
             cy.findByText(/maintainer/i).should("exist");
           });

--- a/cypress/integration/premium/team_admin.spec.ts
+++ b/cypress/integration/premium/team_admin.spec.ts
@@ -172,8 +172,15 @@ describe("Premium tier - Team Admin user", () => {
     });
     it("allows team admin to edit a team member", () => {
       cy.getAttached("tbody").within(() => {
-        cy.getAttached("tr")
-          .eq(2)
+        cy.getAttached("tr");
+        cy.contains("Toni") // case-sensitive
+          .parent()
+          .next()
+          .within(() => {
+            cy.findByText(/observer/i).should("exist");
+          })
+          .next()
+          .next()
           .within(() => {
             cy.findByText(/action/i).click();
             cy.findByText(/edit/i).click();
@@ -185,8 +192,10 @@ describe("Premium tier - Team Admin user", () => {
       });
       cy.findByRole("button", { name: /save/i }).click();
       cy.getAttached("tbody").within(() => {
-        cy.getAttached("tr")
-          .eq(2)
+        cy.getAttached("tr");
+        cy.contains("Toni") // case-sensitive
+          .parent()
+          .next()
           .within(() => {
             cy.findByText(/maintainer/i).should("exist");
           });

--- a/tools/api/fleet/teams/create_free
+++ b/tools/api/fleet/teams/create_free
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # This script creates 3 users with various roles.
+# These users are seeded to Fleet Free E2E tests
 
 source $FLEET_ENV_PATH
 

--- a/tools/api/fleet/teams/create_premium
+++ b/tools/api/fleet/teams/create_premium
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-# This script creates 2 teams and 4 users with various roles.
+# This script creates 2 teams and 7 users with various roles.
+# These users are seeded to Fleet Premium E2E tests
 
 source $FLEET_ENV_PATH
 


### PR DESCRIPTION
Adding a mixed role user to seed data hit e2e flakiness


**Fixes**
- Create user button scrolled off screen because of table length in Users tab
- User selected by table row was no longer an observer. Fix ensures user was observer during switching roles from observer to maintainer test
- Left comments on seed data that they are also used for e2e tests

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

