### PR TITLE
Fleet UI: /login route redirects to dashboard if already logged in

### DIFF
--- a/changes/issue-7992-login-dependency
+++ b/changes/issue-7992-login-dependency
@@ -1,0 +1,1 @@
+* Login route reroutes to dashboard if already logged in

--- a/frontend/pages/LoginPage/LoginPage.tsx
+++ b/frontend/pages/LoginPage/LoginPage.tsx
@@ -83,7 +83,7 @@ const LoginPage = ({ router, location }: ILoginPageProps) => {
     if (pageStatus && pageStatus in statusMessages) {
       renderFlash("error", statusMessages[pageStatus as keyof IStatusMessages]);
     }
-  }, [router]);
+  }, [router, currentUser]);
 
   const onChange = () => {
     if (size(errors)) {


### PR DESCRIPTION
Cerra #7992 

**Fix**
- UX fix: Login page redirects to dashboard if already logged in (Fixes missing dependency because user isn't in AppContext on first load)

**Screen recording**

https://user-images.githubusercontent.com/71795832/194344434-6e29f208-7e95-47ef-a0c7-c93b7b9c70b4.mov


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality

