### PR TITLE
Website: Update sticky header behavior

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -360,35 +360,13 @@
     <script>
         var lastScrollTop = 0;
         var header = document.querySelector('.header')
-        var ctaBanner = document.querySelector('[purpose="header-report-cta"]')
-        window.addEventListener('scroll', windowScrolled)
-
+        window.addEventListener('scroll', windowScrolled);
         function windowScrolled() {
-          var scrollTop = window.pageYOffset || document.documentElement.scrollTop
-          var fleetLogo = header.querySelector('img')
-          var hamburgerMenuIcon = header.querySelector('.btn.btn-link > img')
-          let ctaBannerHeightOrTopOfPage = ctaBanner ? ctaBanner.clientHeight : 0;
-          if(scrollTop < ctaBannerHeightOrTopOfPage && header.classList.contains('homepage-header')) {
-              if (ctaBanner) {
-                header.classList.add('homepage-header-top')
-              }
-              header.classList.remove('sticky')
-              fleetLogo.src = '/images/logo-white-162x92@2x.png'
-              hamburgerMenuIcon.src = '/images/icon-hamburger-16x14@2x.png'
-              return;
-          }
+          let scrollTop = window.pageYOffset || document.documentElement.scrollTop;
           if(scrollTop > lastScrollTop && scrollTop > window.innerHeight * 1.5) {
             header.classList.add('translate-y-0');
             lastScrollTop = scrollTop;
           } else if(scrollTop < lastScrollTop - 60) {
-            // If the header is touching the top of the viewport
-            if(header.getBoundingClientRect().y <= 0) {
-              header.classList.remove('homepage-header-top')
-              header.classList.add('sticky')
-
-              fleetLogo.src = '/images/logo-blue-162x92@2x.png'
-              hamburgerMenuIcon.src="/images/icon-hamburger-blue-16x14@2x.png"
-            }
             header.classList.remove('translate-y-0');
             lastScrollTop = scrollTop;
           }

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -379,7 +379,8 @@
           }
           if(scrollTop > lastScrollTop && scrollTop > window.innerHeight * 1.5) {
             header.classList.add('translate-y-0');
-          } else {
+            lastScrollTop = scrollTop;
+          } else if(scrollTop < lastScrollTop - 60) {
             // If the header is touching the top of the viewport
             if(header.getBoundingClientRect().y <= 0) {
               header.classList.remove('homepage-header-top')
@@ -389,8 +390,8 @@
               hamburgerMenuIcon.src="/images/icon-hamburger-blue-16x14@2x.png"
             }
             header.classList.remove('translate-y-0');
+            lastScrollTop = scrollTop;
           }
-          lastScrollTop = scrollTop;
         }
     </script>
 


### PR DESCRIPTION
Closes: #6527

Changes:
- Rewrote the sticky header event listener function to remove unused code relating to the state of device management report banner and changing the color of the homepage header
- Updated the sticky header behavior to show if a user scrolls 60 pixels up the screen (currently one pixel)