### PR TITLE
cleanup all policy memberships for a host on re-enrollment

### DIFF
--- a/changes/issue-7664-re-enrollment-cleanup
+++ b/changes/issue-7664-re-enrollment-cleanup
@@ -1,0 +1,1 @@
+* Added logic to clean up irrelevant policies for a host on re-enrollment, for example: if a host changes its OS from linux to macOS or it changes teams.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -823,21 +823,6 @@ func (ds *Datastore) GenerateHostStatusStatistics(ctx context.Context, filter fl
 	return &summary, nil
 }
 
-func shouldCleanTeamPolicies(currentTeamID, newTeamID *uint) bool {
-	// if the host is global, then there should be nothing to clean up
-	if currentTeamID == nil {
-		return false
-	}
-
-	// if the host is switching from a team to global, we should clean up
-	if newTeamID == nil {
-		return true
-	}
-
-	// clean up if the host is switching to a different team
-	return *currentTeamID != *newTeamID
-}
-
 func (ds *Datastore) EnrollOrbit(ctx context.Context, hardwareUUID string, orbitNodeKey string, teamID *uint) (*fleet.Host, error) {
 	if orbitNodeKey == "" {
 		return nil, ctxerr.New(ctx, "orbit node key is empty")
@@ -938,10 +923,8 @@ func (ds *Datastore) EnrollHost(ctx context.Context, osqueryHostID, nodeKey stri
 			}
 			hostID = int64(host.ID)
 
-			if shouldCleanTeamPolicies(host.TeamID, teamID) {
-				if err := cleanupPolicyMembershipOnTeamChange(ctx, tx, []uint{host.ID}); err != nil {
-					return ctxerr.Wrap(ctx, err, "EnrollHost delete policy membership")
-				}
+			if err := deleteAllPolicyMemberships(ctx, tx, []uint{host.ID}); err != nil {
+				return ctxerr.Wrap(ctx, err, "cleanup policy membership on re-enroll")
 			}
 
 			// Update existing host record

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -124,7 +124,6 @@ func TestHosts(t *testing.T) {
 		{"OSVersions", testOSVersions},
 		{"DeleteHosts", testHostsDeleteHosts},
 		{"HostIDsByOSVersion", testHostIDsByOSVersion},
-		{"ShouldCleanTeamPolicies", testShouldCleanTeamPolicies},
 		{"ReplaceHostBatteries", testHostsReplaceHostBatteries},
 		{"CountHostsNotResponding", testCountHostsNotResponding},
 		{"FailingPoliciesCount", testFailingPoliciesCount},
@@ -4875,27 +4874,6 @@ func testHostsDeleteHosts(t *testing.T, ds *Datastore) {
 		err = ds.writer.Get(&ok, fmt.Sprintf("SELECT 1 FROM %s WHERE host_id = ?", hostRef), host.ID)
 		require.True(t, err == nil || errors.Is(err, sql.ErrNoRows), "table: %s", hostRef)
 		require.False(t, ok, "table: %s", hostRef)
-	}
-}
-
-func testShouldCleanTeamPolicies(t *testing.T, ds *Datastore) {
-	var idOne uint = 1
-	var idTwo uint = 2
-
-	cases := []struct {
-		currentTeamID *uint
-		newTeamID     *uint
-		out           bool
-	}{
-		{nil, nil, false},
-		{nil, &idOne, false},
-		{&idOne, nil, true},
-		{&idOne, &idOne, false},
-		{&idOne, &idTwo, true},
-	}
-
-	for _, c := range cases {
-		require.Equal(t, shouldCleanTeamPolicies(c.currentTeamID, c.newTeamID), c.out)
 	}
 }
 

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -536,6 +536,17 @@ func (ds *Datastore) AsyncBatchUpdatePolicyTimestamp(ctx context.Context, ids []
 	})
 }
 
+func deleteAllPolicyMemberships(ctx context.Context, tx sqlx.ExtContext, hostIDs []uint) error {
+	query, args, err := sqlx.In(`DELETE FROM policy_membership WHERE host_id IN (?)`, hostIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "building query to delete policies")
+	}
+	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+		return ctxerr.Wrap(ctx, err, "exec delete policies")
+	}
+	return nil
+}
+
 func cleanupPolicyMembershipOnTeamChange(ctx context.Context, tx sqlx.ExtContext, hostIDs []uint) error {
 	// hosts can only be in one team, so if there's a policy that has a team id and a result from one of our hosts
 	// it can only be from the previous team they are being transferred from

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -1858,5 +1858,5 @@ func testDeleteAllPolicyMemberships(t *testing.T, ds *Datastore) {
 
 	err = ds.writer.Get(&count, "select COUNT(*) from policy_membership")
 	require.NoError(t, err)
-	require.Equal(t, 1, count)
+	require.Equal(t, 0, count)
 }

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -43,6 +43,7 @@ func TestPolicies(t *testing.T) {
 		{"FlippingPoliciesForHost", testFlippingPoliciesForHost},
 		{"PlatformUpdate", testPolicyPlatformUpdate},
 		{"CleanupPolicyMembership", testPolicyCleanupPolicyMembership},
+		{"DeleteAllPolicyMemberships", testDeleteAllPolicyMemberships},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -976,7 +977,7 @@ func testTeamPolicyTransfer(t *testing.T, ds *Datastore) {
 	require.NoError(t, ds.RecordPolicyQueryExecutions(context.Background(), host2, map[uint]*bool{teamPolicy.ID: ptr.Bool(false), globalPolicy.ID: ptr.Bool(true)}, time.Now(), false))
 	require.NoError(t, ds.RecordPolicyQueryExecutions(context.Background(), host2, map[uint]*bool{teamPolicy.ID: ptr.Bool(true), globalPolicy.ID: ptr.Bool(true)}, time.Now(), false))
 
-	checkPassingCount := func(expectedCount uint) {
+	checkPassingCount := func(expectedCount, expectedGlobalCount uint) {
 		policies, err := ds.ListTeamPolicies(context.Background(), team1.ID)
 		require.NoError(t, err)
 		require.Len(t, policies, 1)
@@ -986,35 +987,37 @@ func testTeamPolicyTransfer(t *testing.T, ds *Datastore) {
 		policies, err = ds.ListGlobalPolicies(context.Background())
 		require.NoError(t, err)
 		require.Len(t, policies, 1)
-		assert.Equal(t, uint(2), policies[0].PassingHostCount)
+		assert.Equal(t, expectedGlobalCount, policies[0].PassingHostCount)
 
 		policies, err = ds.ListTeamPolicies(context.Background(), team2.ID)
 		require.NoError(t, err)
 		require.Len(t, policies, 0)
 	}
 
-	checkPassingCount(2)
+	checkPassingCount(2, 2)
 
 	// team policies are removed when AddHostsToTeam is called
 	require.NoError(t, ds.AddHostsToTeam(context.Background(), ptr.Uint(team2.ID), []uint{host1.ID}))
-	checkPassingCount(1)
+	checkPassingCount(1, 2)
 
-	// team policies are not removed when a host is enrolled in the same team
+	// all host policies are removed when a host is enrolled in the same team
 	_, err = ds.EnrollHost(context.Background(), "2", "2", &team1.ID, 0)
 	require.NoError(t, err)
-	checkPassingCount(1)
+	checkPassingCount(0, 1)
 
 	// team policies are removed if the host is enrolled in a different team
 	_, err = ds.EnrollHost(context.Background(), "2", "2", &team2.ID, 0)
 	require.NoError(t, err)
-	checkPassingCount(0)
+	checkPassingCount(0, 1)
 
 	// team policies are removed if the host is re-enrolled without a team
 	require.NoError(t, ds.RecordPolicyQueryExecutions(context.Background(), host2, map[uint]*bool{teamPolicy.ID: ptr.Bool(true), globalPolicy.ID: ptr.Bool(true)}, time.Now(), false))
-	checkPassingCount(1)
+	checkPassingCount(1, 2)
+
+	// all host policies are removed when a host is re-enrolled
 	_, err = ds.EnrollHost(context.Background(), "2", "2", nil, 0)
 	require.NoError(t, err)
-	checkPassingCount(0)
+	checkPassingCount(0, 1)
 }
 
 func testApplyPolicySpec(t *testing.T, ds *Datastore) {
@@ -1807,4 +1810,53 @@ func updatePolicyWithTimestamp(t *testing.T, ds *Datastore, p *fleet.Policy, ts 
 			WHERE id = ?`
 	_, err := ds.writer.ExecContext(context.Background(), sql, p.Name, p.Query, p.Description, p.Resolution, p.Platform, ts, p.ID)
 	require.NoError(t, err)
+}
+
+func testDeleteAllPolicyMemberships(t *testing.T, ds *Datastore) {
+	user1 := test.NewUser(t, ds, "Alan", "alan@example.com", true)
+	ctx := context.Background()
+	globalPolicy, err := ds.NewGlobalPolicy(ctx, &user1.ID, fleet.PolicyPayload{
+		Name:        "query1",
+		Query:       "select 1;",
+		Description: "query1 desc",
+		Resolution:  "query1 resolution",
+	})
+	require.NoError(t, err)
+
+	host, err := ds.NewHost(ctx, &fleet.Host{
+		OsqueryHostID:   "567898",
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now(),
+		NodeKey:         "4",
+		UUID:            "4",
+		Hostname:        "bar.local",
+	})
+	require.NoError(t, err)
+
+	err = ds.RecordPolicyQueryExecutions(
+		ctx,
+		host,
+		map[uint]*bool{globalPolicy.ID: ptr.Bool(false)},
+		time.Now(),
+		false,
+	)
+	require.NoError(t, err)
+
+	hostPolicies, err := ds.ListPoliciesForHost(ctx, host)
+	require.NoError(t, err)
+	require.Len(t, hostPolicies, 1)
+
+	var count int
+	err = ds.writer.Get(&count, "select COUNT(*) from policy_membership")
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	err = deleteAllPolicyMemberships(ctx, ds.writer, []uint{host.ID})
+	require.NoError(t, err)
+
+	err = ds.writer.Get(&count, "select COUNT(*) from policy_membership")
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
 }

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -4983,6 +4983,63 @@ func (s *integrationTestSuite) TestEnrollHost() {
 	require.NotEmpty(t, resp.NodeKey)
 }
 
+func (s *integrationTestSuite) TestReenrollHostCleansPolicies() {
+	t := s.T()
+	ctx := context.Background()
+	host := s.createHosts(t)[0]
+
+	// set the enroll secret
+	var applyResp applyEnrollSecretSpecResponse
+	s.DoJSON("POST", "/api/latest/fleet/spec/enroll_secret", applyEnrollSecretSpecRequest{
+		Spec: &fleet.EnrollSecretSpec{
+			Secrets: []*fleet.EnrollSecret{{Secret: t.Name()}},
+		},
+	}, http.StatusOK, &applyResp)
+
+	var getHostResp getHostResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+	require.Empty(t, getHostResp.Host.Policies)
+
+	// create a policy and make the host fail it
+	pol, err := s.ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{Name: t.Name(), Query: "SELECT 1", Platform: host.FleetPlatform()})
+	require.NoError(t, err)
+	err = s.ds.RecordPolicyQueryExecutions(ctx, &fleet.Host{ID: host.ID}, map[uint]*bool{pol.ID: ptr.Bool(false)}, time.Now(), false)
+	require.NoError(t, err)
+
+	// refetch the host details
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+	require.Len(t, *getHostResp.Host.Policies, 1)
+
+	// re-enroll the host, but using a different platform
+	j, err := json.Marshal(&enrollAgentRequest{
+		EnrollSecret:   t.Name(),
+		HostIdentifier: host.OsqueryHostID,
+		HostDetails:    map[string](map[string]string){"os_version": map[string]string{"platform": "windows"}},
+	})
+	require.NoError(t, err)
+
+	// prevent the enroll cooldown from being applied
+	mysql.ExecAdhocSQL(t, s.ds, func(db sqlx.ExtContext) error {
+		_, err := db.ExecContext(
+			context.Background(),
+			"UPDATE hosts SET last_enrolled_at = DATE_SUB(NOW(), INTERVAL '1' HOUR) WHERE id = ?",
+			host.ID,
+		)
+		return err
+	})
+	var resp enrollAgentResponse
+	hres := s.DoRawNoAuth("POST", "/api/osquery/enroll", j, http.StatusOK)
+	defer hres.Body.Close()
+	require.NoError(t, json.NewDecoder(hres.Body).Decode(&resp))
+	require.NotEmpty(t, resp.NodeKey)
+
+	// refetch the host details
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+
+	// policies should be gone
+	require.Empty(t, getHostResp.Host.Policies)
+}
+
 func (s *integrationTestSuite) TestCarve() {
 	t := s.T()
 	hosts := s.createHosts(t)


### PR DESCRIPTION
Related to https://github.com/fleetdm/fleet/issues/7664, this cleans up all policy memberships for a host when its re-enrolled, afterwards only the relevant policy memberships for the host will be created.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality