### PR TITLE
Fleet UI: Policy does not exist banner

### DIFF
--- a/changes/issue-7209-policy-dne-banner
+++ b/changes/issue-7209-policy-dne-banner
@@ -1,0 +1,1 @@
+* Users will be informed if they navigate to hosts filtered by a policy that does not exist

--- a/frontend/components/InfoBanner/InfoBanner.tsx
+++ b/frontend/components/InfoBanner/InfoBanner.tsx
@@ -10,7 +10,7 @@ export interface IInfoBannerProps {
   children?: React.ReactNode;
   className?: string;
   /** default light purple */
-  color?: "yellow";
+  color?: "yellow" | "grey";
   pageLevel?: boolean;
   /** cta and link are mutually exclusive */
   cta?: JSX.Element;

--- a/frontend/components/InfoBanner/_styles.scss
+++ b/frontend/components/InfoBanner/_styles.scss
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: 100%;
+  width: auto;
   padding: $pad-medium;
   border-radius: $border-radius;
   border: 1px solid $ui-vibrant-blue-50;
@@ -14,6 +14,11 @@
   &__yellow {
     background-color: $ui-yellow-banner;
     border-color: $ui-yellow-banner-outline;
+  }
+
+  &__grey {
+    background-color: $ui-off-white;
+    border-color: $ui-fleet-black-50;
   }
 
   &__page-banner {
@@ -36,7 +41,7 @@
 
   &__close {
     margin-left: $pad-small;
-    padding: $xx-small;
+    padding: 3px;
     padding-right: 0;
 
     &:hover {

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -536,7 +536,7 @@ const ManageHostsPage = ({
       sortBy,
       teamId: selectedTeam?.id,
       policyId: validPolicyId ? policyId : undefined,
-      policyResponse,
+      policyResponse: validPolicyId ? policyResponse : undefined,
       softwareId,
       status,
       mdmId,
@@ -796,6 +796,8 @@ const ManageHostsPage = ({
       }
       if (policyId && policyResponse) {
         newQueryParams.policy_id = policyId;
+      }
+      if (policyResponse && validPolicyId) {
         newQueryParams.policy_response = policyResponse;
       } else if (softwareId) {
         newQueryParams.software_id = softwareId;
@@ -1022,7 +1024,7 @@ const ManageHostsPage = ({
         sortBy,
         teamId: currentTeam?.id,
         policyId: validPolicyId ? policyId : undefined,
-        policyResponse,
+        policyResponse: validPolicyId ? policyResponse : undefined,
         softwareId,
         status,
         mdmId,

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -63,6 +63,7 @@ import TeamsDropdown from "components/TeamsDropdown";
 import Spinner from "components/Spinner";
 import MainContent from "components/MainContent";
 import EmptyTable from "components/EmptyTable";
+import InfoBanner from "components/InfoBanner";
 
 import { getValidatedTeamId } from "utilities/helpers";
 import {
@@ -77,11 +78,7 @@ import {
   DEFAULT_PAGE_SIZE,
   HOST_SELECT_STATUSES,
 } from "./constants";
-import {
-  isAcceptableStatus,
-  getNextLocationPath,
-  isValidPolicyResponse,
-} from "./helpers";
+import { isAcceptableStatus, getNextLocationPath } from "./helpers";
 import DeleteSecretModal from "../../../components/EnrollSecrets/DeleteSecretModal";
 import SecretEditorModal from "../../../components/EnrollSecrets/SecretEditorModal";
 import AddHostsModal from "../../../components/AddHostsModal";
@@ -404,8 +401,6 @@ const ManageHostsPage = ({
     }
   );
 
-  console.log("isInvalidPolicyId", isInvalidPolicyId);
-
   const { data: osVersions } = useQuery<
     IOSVersionsResponse,
     Error,
@@ -567,7 +562,7 @@ const ManageHostsPage = ({
       sortBy,
       teamId: selectedTeam?.id,
       policyId,
-      policyResponse: policyId ? policyResponse : undefined,
+      policyResponse,
       softwareId,
       status,
       mdmId,
@@ -835,9 +830,9 @@ const ManageHostsPage = ({
       availableTeams,
       currentTeam,
       currentUser,
+      policy,
       policyId,
       policyResponse,
-      isValidPolicyResponse,
       queryParams,
       softwareId,
       status,
@@ -1843,24 +1838,10 @@ const ManageHostsPage = ({
       ((canEnrollHosts && noTeamEnrollSecrets) ||
         (canEnrollGlobalHosts && noGlobalEnrollSecrets)) &&
       showNoEnrollSecretBanner && (
-        <div className={`${baseClass}__no-enroll-secret-banner`}>
-          <div>
-            <span>
-              You have no enroll secrets. Manage enroll secrets to enroll hosts
-              to <b>{currentTeam?.id ? currentTeam.name : "Fleet"}</b>.
-            </span>
-          </div>
-          <div className={`dismiss-banner-button`}>
-            <Button
-              variant="unstyled"
-              onClick={() =>
-                setShowNoEnrollSecretBanner(!showNoEnrollSecretBanner)
-              }
-            >
-              <img alt="Dismiss no enroll secret banner" src={CloseIconBlack} />
-            </Button>
-          </div>
-        </div>
+        <InfoBanner color="grey" pageLevel closable>
+          You have no enroll secrets. Manage enroll secrets to enroll hosts to{" "}
+          <b>{currentTeam?.id ? currentTeam.name : "Fleet"}</b>.
+        </InfoBanner>
       )
     );
   };
@@ -1868,22 +1849,10 @@ const ManageHostsPage = ({
   const renderInvalidPolicyIdBanner = () => {
     return (
       isInvalidPolicyId && (
-        <div className={`${baseClass}__no-valid-policy-banner`}>
-          <div>
-            <span>
-              The policy does not exist. Head to the <b>Policies</b> page to see
-              a list of policies.
-            </span>
-          </div>
-          <div className={`dismiss-banner-button`}>
-            <Button
-              variant="unstyled"
-              onClick={() => setIsInvalidPolicyId(!isInvalidPolicyId)}
-            >
-              <img alt="Dismiss no enroll secret banner" src={CloseIconBlack} />
-            </Button>
-          </div>
-        </div>
+        <InfoBanner color="grey" pageLevel closable>
+          The policy does not exist. Head to the <b>Policies</b> page to see a
+          list of policies.
+        </InfoBanner>
       )
     );
   };

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -196,9 +196,7 @@ const ManageHostsPage = ({
   const [showNoEnrollSecretBanner, setShowNoEnrollSecretBanner] = useState(
     true
   );
-  const [showInvalidPolicyIdBanner, setShowInvalidPolicyIdBanner] = useState(
-    false
-  );
+  const [isInvalidPolicyId, setIsInvalidPolicyId] = useState(false);
   const [showDeleteSecretModal, setShowDeleteSecretModal] = useState(false);
   const [showSecretEditorModal, setShowSecretEditorModal] = useState(false);
   const [showEnrollSecretModal, setShowEnrollSecretModal] = useState(false);
@@ -366,7 +364,7 @@ const ManageHostsPage = ({
       },
       onError: (error: any) => {
         if (error.data.message === "Resource Not Found") {
-          setShowInvalidPolicyIdBanner(true);
+          setIsInvalidPolicyId(true);
         }
         setHasHostErrors(true);
         console.log("print error", error.data);
@@ -792,7 +790,12 @@ const ManageHostsPage = ({
       }
       // iff valid policy ID
       if (policyResponse && policy?.id) {
+        newQueryParams.policy_id = policy.id;
         newQueryParams.policy_response = policyResponse;
+        if (isInvalidPolicyId) {
+          delete newQueryParams.policy_id;
+          delete newQueryParams.policy_response;
+        }
       } else if (softwareId) {
         newQueryParams.software_id = softwareId;
       } else if (mdmId) {
@@ -1565,27 +1568,6 @@ const ManageHostsPage = ({
   const renderActiveFilterBlock = () => {
     const showSelectedLabel = selectedLabel && selectedLabel.type !== "all";
 
-    const renderFilterPill = () => {
-      switch (true) {
-        case showSelectedLabel:
-          return renderLabelFilterPill();
-        case !!policy?.id && !isLoadingPolicies:
-          return renderPoliciesFilterBlock();
-        case !!softwareId:
-          return renderSoftwareFilterBlock();
-        case !!mdmId:
-          return renderMDMSolutionFilterBlock();
-        case !!mdmEnrollmentStatus:
-          return renderMDMEnrollmentFilterBlock();
-        case !!osId || (!!osName && !!osVersion):
-          return renderOSFilterBlock();
-        case !!munkiIssueId:
-          return renderMunkiIssueFilterBlock();
-        default:
-          return null;
-      }
-    };
-
     if (
       selectedLabel ||
       policyId ||
@@ -1597,7 +1579,6 @@ const ManageHostsPage = ({
       (osName && osVersion) ||
       munkiIssueId
     ) {
-<<<<<<< HEAD
       const renderFilterPill = () => {
         switch (true) {
           // backend allows for pill combos (label + low disk space) OR
@@ -1623,7 +1604,7 @@ const ManageHostsPage = ({
             );
           case showSelectedLabel:
             return renderLabelFilterPill();
-          case !!policyId && validPolicyId && !isLoadingPolicy:
+          case !!policyId && !isLoadingPolicy && !isInvalidPolicyId:
             return renderPoliciesFilterBlock();
           case !!softwareId:
             return renderSoftwareFilterBlock();
@@ -1642,8 +1623,6 @@ const ManageHostsPage = ({
         }
       };
 
-=======
->>>>>>> 1ce41afcd (Work towards scalability)
       return (
         <div className={`${baseClass}__labels-active-filter-wrap`}>
           {renderFilterPill()}
@@ -1881,8 +1860,7 @@ const ManageHostsPage = ({
 
   const renderInvalidPolicyIdBanner = () => {
     return (
-      !policy?.id &&
-      showInvalidPolicyIdBanner && (
+      isInvalidPolicyId && (
         <div className={`${baseClass}__no-valid-policy-banner`}>
           <div>
             <span>
@@ -1893,9 +1871,7 @@ const ManageHostsPage = ({
           <div className={`dismiss-banner-button`}>
             <Button
               variant="unstyled"
-              onClick={() =>
-                setShowInvalidPolicyIdBanner(!showInvalidPolicyIdBanner)
-              }
+              onClick={() => setIsInvalidPolicyId(!isInvalidPolicyId)}
             >
               <img alt="Dismiss no enroll secret banner" src={CloseIconBlack} />
             </Button>

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -271,7 +271,6 @@ const ManageHostsPage = ({
   const missingHosts = queryParams?.status === "missing";
   const { active_label: activeLabel, label_id: labelID } = routeParams;
 
-  console.log("policy", policy);
   // ===== filter matching
   const selectedFilters: string[] = [];
   labelID && selectedFilters.push(`${LABEL_SLUG_PREFIX}${labelID}`);
@@ -367,6 +366,7 @@ const ManageHostsPage = ({
   const handleClearFilter = (omitParams: string[]) => {
     handleResetPageIndex();
 
+    // TODO: Fix race condition for loading all hosts redirected
     router.replace(
       getNextLocationPath({
         pathPrefix: PATHS.MANAGE_HOSTS,
@@ -1021,7 +1021,7 @@ const ManageHostsPage = ({
         sortBy,
         teamId: currentTeam?.id,
         policyId,
-        policyResponse: policy?.id ? policyResponse : undefined,
+        policyResponse,
         softwareId,
         status,
         mdmId,
@@ -1707,6 +1707,8 @@ const ManageHostsPage = ({
         osVersion
       );
 
+      console.log("policy_id", policy_id, "policyResponse", policyResponse);
+      console.log("includesNameCardFilter", includesNameCardFilter);
       const emptyState = () => {
         const emptyHosts: IEmptyTableProps = {
           iconName: "empty-hosts",
@@ -1719,8 +1721,7 @@ const ManageHostsPage = ({
           emptyHosts.header = "No hosts match the current criteria";
           emptyHosts.info =
             "Expecting to see new hosts? Try again in a few seconds as the system catches up.";
-        }
-        if (canEnrollHosts) {
+        } else if (canEnrollHosts) {
           emptyHosts.header = "Add your devices to Fleet";
           emptyHosts.info = "Generate an installer to add your own devices.";
           emptyHosts.primaryButton = (

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -266,7 +266,8 @@
     padding-bottom: $pad-large;
   }
 
-  &__no-enroll-secret-banner {
+  &__no-enroll-secret-banner,
+  &__no-valid-policy-banner {
     display: flex;
     justify-content: space-between;
     align-items: center;

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -261,35 +261,6 @@
     margin-right: $pad-small;
   }
 
-  &__info-banners {
-    padding-top: $pad-xxlarge;
-    padding-bottom: $pad-large;
-  }
-
-  &__no-enroll-secret-banner,
-  &__no-valid-policy-banner {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    font-size: $x-small;
-    background-color: $ui-off-white;
-    padding: $pad-large;
-    border-radius: 10px;
-    border: 1px solid $ui-fleet-black-50;
-
-    .dismiss-banner-button {
-      display: flex;
-      align-items: center;
-      img {
-        height: 16px;
-        width: auto;
-      }
-    }
-    &:not(:only-child) {
-      margin-bottom: $pad-medium;
-    }
-  }
-
   .total-issues-count {
     margin-left: $pad-small;
   }


### PR DESCRIPTION
Cerra #7209 

**Fix**
- If user filters by a policy ID that does not exist, it will clear the policy filter and explain that the policy does not exist in a banner

**Screenshot**
<img width="1402" alt="Screen Shot 2022-10-10 at 10 43 08 AM" src="https://user-images.githubusercontent.com/71795832/194892527-45f35edd-7fee-4662-b629-862ca01b24a8.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality

