### PR TITLE
Fixed bug with CPE matching, UTM.app was matching to the incorrect CPE

### DIFF
--- a/changes/bug-8145-utm.app-bad-cpe-matching
+++ b/changes/bug-8145-utm.app-bad-cpe-matching
@@ -1,0 +1,1 @@
+* Fixed bug with our CPE matching process. UTM.app was matching to the wrong CPE.

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -218,7 +218,7 @@ func CPEFromSoftware(db *sqlx.DB, software *fleet.Software, translations CPETran
 		}
 
 		var match *IndexedCPEItem
-		for _, item := range results {
+		for i, item := range results {
 			hasAllTerms := true
 
 			sName := strings.ToLower(software.Name)
@@ -245,7 +245,7 @@ func CPEFromSoftware(db *sqlx.DB, software *fleet.Software, translations CPETran
 			}
 
 			if hasAllTerms {
-				match = &item
+				match = &results[i]
 				break
 			}
 		}

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -208,6 +208,8 @@ func CPEFromSoftware(db *sqlx.DB, software *fleet.Software, translations CPETran
 		}
 
 		var results []IndexedCPEItem
+		var match *IndexedCPEItem
+
 		err = db.Select(&results, stm, args...)
 		if err == sql.ErrNoRows {
 			return "", nil
@@ -217,7 +219,6 @@ func CPEFromSoftware(db *sqlx.DB, software *fleet.Software, translations CPETran
 			return "", fmt.Errorf("getting cpes for: %s: %w", software.Name, err)
 		}
 
-		var match *IndexedCPEItem
 		for i, item := range results {
 			hasAllTerms := true
 
@@ -229,12 +230,6 @@ func CPEFromSoftware(db *sqlx.DB, software *fleet.Software, translations CPETran
 			sVendor := strings.ToLower(software.Vendor)
 			sBundle := strings.ToLower(software.BundleIdentifier)
 			for _, sV := range strings.Split(item.Vendor, "_") {
-				// If we can't check the vendor, then assume is a bad match, this is to avoid any
-				// false positives.
-				if sVendor == "" && sBundle == "" {
-					hasAllTerms = false
-				}
-
 				if sVendor != "" {
 					hasAllTerms = hasAllTerms && strings.Index(sVendor, sV) != -1
 				}

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -712,7 +712,7 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 				Version:          "2.37.1",
 				Vendor:           "The Git Development Community",
 				BundleIdentifier: "",
-			}, cpe: "cpe:2.3:a:git:git:2.37.1:*:*:*:*:windows:*:*",
+			}, cpe: "cpe:2.3:a:git-scm:git:2.37.1:*:*:*:*:windows:*:*",
 		},
 		{
 			software: fleet.Software{

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -1128,6 +1128,14 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 				BundleIdentifier: "",
 			}, cpe: "cpe:2.3:a:python:urllib3:1.26.5:*:*:*:*:python:*:*",
 		},
+		{
+			software: fleet.Software{
+				Name:             "UTM.app",
+				Source:           "apps",
+				Version:          "3.2.4",
+				BundleIdentifier: "com.utmapp.UTM",
+			}, cpe: "",
+		},
 	}
 	nettest.Run(t)
 


### PR DESCRIPTION
#8145 

Fixed bug with our CPE matching process, we were always performing the 'deprecated' logic branch, which was causing some false positives if there was no match in the first place.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests