### PR TITLE
Fleet desktop should use lightweight endpoint for getting failing policies count

### DIFF
--- a/changes/feature-6946-fleet-desktop-uses-minimal-endpoint
+++ b/changes/feature-6946-fleet-desktop-uses-minimal-endpoint
@@ -1,0 +1,2 @@
+- Updated Fleet Desktop to use the new endpoint introduced in
+  https://github.com/fleetdm/fleet/issues/7084

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -120,7 +120,7 @@ func main() {
 
 				for {
 					refetchToken()
-					_, err := client.ListDevicePolicies(tokenReader.GetCached())
+					_, err := client.NumberOfFailingPolicies(tokenReader.GetCached())
 
 					if err == nil || errors.Is(err, service.ErrMissingLicense) {
 						log.Debug().Msg("enabling tray items")
@@ -173,7 +173,7 @@ func main() {
 			defer tic.Stop()
 
 			for {
-				policies, err := client.ListDevicePolicies(tokenReader.GetCached())
+				failingPolicies, err := client.NumberOfFailingPolicies(tokenReader.GetCached())
 				switch {
 				case err == nil:
 					// OK
@@ -185,28 +185,21 @@ func main() {
 					<-checkToken()
 					continue
 				default:
-					log.Error().Err(err).Msg("get device URL")
+					log.Error().Err(err).Msg("get failing policies")
 					continue
 				}
 
-				failedPolicyCount := 0
-				for _, policy := range policies {
-					if policy.Response != "pass" {
-						failedPolicyCount++
-					}
-				}
-
-				if failedPolicyCount > 0 {
+				if failingPolicies > 0 {
 					if runtime.GOOS == "windows" {
 						// Windows (or maybe just the systray library?) doesn't support color emoji
 						// in the system tray menu, so we use text as an alternative.
-						if failedPolicyCount == 1 {
+						if failingPolicies == 1 {
 							myDeviceItem.SetTitle("My device (1 issue)")
 						} else {
-							myDeviceItem.SetTitle(fmt.Sprintf("My device (%d issues)", failedPolicyCount))
+							myDeviceItem.SetTitle(fmt.Sprintf("My device (%d issues)", failingPolicies))
 						}
 					} else {
-						myDeviceItem.SetTitle(fmt.Sprintf("🔴 My device (%d)", failedPolicyCount))
+						myDeviceItem.SetTitle(fmt.Sprintf("🔴 My device (%d)", failingPolicies))
 					}
 				} else {
 					if runtime.GOOS == "windows" {

--- a/server/fleet/capabilities.go
+++ b/server/fleet/capabilities.go
@@ -52,8 +52,6 @@ const (
 	// CapabilityTokenRotation denotes the ability of the server to support
 	// periodic rotation of device tokens
 	CapabilityTokenRotation Capability = "token_rotation"
-	// Whether the backend supports the 'fleet/device/{token}/desktop' endpoint.
-	CapabilityDesktopEndpoint Capability = "desktop_lightweight_endpoint"
 )
 
 // ServerOrbitCapabilities is a set of capabilities that server-side,
@@ -67,9 +65,7 @@ var ServerOrbitCapabilities = CapabilityMap{
 // ServerDeviceCapabilities is a set of capabilities that server-side,
 // Device-related endpoint supports.
 // **it shouldn't be modified at runtime**
-var ServerDeviceCapabilities = CapabilityMap{
-	CapabilityDesktopEndpoint: {},
-}
+var ServerDeviceCapabilities = CapabilityMap{}
 
 // CapabilitiesHeader is the header name used to communicate the capabilities.
 const CapabilitiesHeader = "X-Fleet-Capabilities"

--- a/server/fleet/capabilities.go
+++ b/server/fleet/capabilities.go
@@ -52,6 +52,8 @@ const (
 	// CapabilityTokenRotation denotes the ability of the server to support
 	// periodic rotation of device tokens
 	CapabilityTokenRotation Capability = "token_rotation"
+	// Whether the backend supports the 'fleet/device/{token}/desktop' endpoint.
+	CapabilityDesktopEndpoint Capability = "desktop_lightweight_endpoint"
 )
 
 // ServerOrbitCapabilities is a set of capabilities that server-side,
@@ -65,7 +67,9 @@ var ServerOrbitCapabilities = CapabilityMap{
 // ServerDeviceCapabilities is a set of capabilities that server-side,
 // Device-related endpoint supports.
 // **it shouldn't be modified at runtime**
-var ServerDeviceCapabilities = CapabilityMap{}
+var ServerDeviceCapabilities = CapabilityMap{
+	CapabilityDesktopEndpoint: {},
+}
 
 // CapabilitiesHeader is the header name used to communicate the capabilities.
 const CapabilitiesHeader = "X-Fleet-Capabilities"

--- a/server/service/device_client.go
+++ b/server/service/device_client.go
@@ -63,8 +63,8 @@ func (dc *DeviceClient) DeviceURL(token string) string {
 // CheckToken checks if a token is valid by making an authenticated request to
 // the server
 func (dc *DeviceClient) CheckToken(token string) error {
-	verb, path := "GET", "/api/latest/fleet/device/"+token+"/policies"
-	return dc.request(verb, path, "", &fleetDesktopResponse{})
+	_, err := dc.NumberOfFailingPolicies(token)
+	return err
 }
 
 // Ping sends a ping to the server using the device/ping endpoint

--- a/server/service/device_client_test.go
+++ b/server/service/device_client_test.go
@@ -38,24 +38,23 @@ func TestDeviceClientGetDesktopPayload(t *testing.T) {
 
 	t.Run("with wrong license", func(t *testing.T) {
 		mockRequestDoer.statusCode = http.StatusPaymentRequired
-		_, err = client.ListDevicePolicies(token)
+		_, err = client.NumberOfFailingPolicies(token)
 		require.ErrorIs(t, err, ErrMissingLicense)
 	})
 
-	t.Run("with empty policies", func(t *testing.T) {
+	t.Run("with no failing policies", func(t *testing.T) {
 		mockRequestDoer.statusCode = http.StatusOK
-		mockRequestDoer.resBody = `{"policies": []}`
-		policies, err := client.ListDevicePolicies(token)
+		mockRequestDoer.resBody = `{}`
+		result, err := client.NumberOfFailingPolicies(token)
 		require.NoError(t, err)
-		require.Len(t, policies, 0)
+		require.Equal(t, uint(0), result)
 	})
 
-	t.Run("with policies", func(t *testing.T) {
+	t.Run("with failing policies", func(t *testing.T) {
 		mockRequestDoer.statusCode = http.StatusOK
-		mockRequestDoer.resBody = `{"policies": [{"id": 1}]}`
-		policies, err := client.ListDevicePolicies(token)
+		mockRequestDoer.resBody = `{"failing_policies_count": 1}`
+		result, err := client.NumberOfFailingPolicies(token)
 		require.NoError(t, err)
-		require.Len(t, policies, 1)
-		require.Equal(t, uint(1), policies[0].ID)
+		require.Equal(t, uint(1), result)
 	})
 }

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -41,7 +41,7 @@ func (svc *Service) DisableAuthForPing(ctx context.Context) {
 // Fleet Desktop endpoints
 /////////////////////////////////////////////////////////////////////////////////
 
-type FleetDesktopResponse struct {
+type fleetDesktopResponse struct {
 	Err             error `json:"error,omitempty"`
 	FailingPolicies *uint `json:"failing_policies_count,omitempty"`
 }
@@ -61,15 +61,15 @@ func getFleetDesktopEndpoint(ctx context.Context, request interface{}, svc fleet
 
 	if !ok {
 		err := ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))
-		return FleetDesktopResponse{Err: err}, nil
+		return fleetDesktopResponse{Err: err}, nil
 	}
 
 	r, err := svc.FailingPoliciesCount(ctx, host)
 	if err != nil {
-		return FleetDesktopResponse{Err: err}, nil
+		return fleetDesktopResponse{Err: err}, nil
 	}
 
-	return FleetDesktopResponse{FailingPolicies: &r}, nil
+	return fleetDesktopResponse{FailingPolicies: &r}, nil
 }
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -1266,7 +1266,7 @@ func (s *integrationEnterpriseTestSuite) TestListDevicePolicies() {
 	require.Len(t, *getDeviceHostResp.Host.Policies, 2)
 
 	// GET `/api/_version_/fleet/device/{token}/desktop`
-	getDesktopResp := FleetDesktopResponse{}
+	getDesktopResp := fleetDesktopResponse{}
 	res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/desktop", nil, http.StatusOK)
 	json.NewDecoder(res.Body).Decode(&getDesktopResp)
 	res.Body.Close()


### PR DESCRIPTION
#6946 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality