### PR TITLE
Handle tcp read timeouts

### DIFF
--- a/changes/handle-tcp-read-timeouts
+++ b/changes/handle-tcp-read-timeouts
@@ -1,0 +1,1 @@
+* Return status code 408 at tcp read timeouts instead of 500

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -58,12 +58,16 @@ func TestIntegrations(t *testing.T) {
 type slowReader struct{}
 
 func (s *slowReader) Read(p []byte) (n int, err error) {
-	time.Sleep(35 * time.Second)
+	time.Sleep(3 * time.Second)
 	return 0, nil
 }
 
 func (s *integrationTestSuite) TestSlowOsqueryHost() {
 	t := s.T()
+	s.server.Config.ReadTimeout = 2 * time.Second
+	defer func() {
+		s.server.Config.ReadTimeout = 25 * time.Second
+	}()
 
 	req, err := http.NewRequest("POST", s.server.URL+"/api/v1/osquery/distributed/write", &slowReader{})
 	require.NoError(t, err)

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/server"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -52,6 +53,27 @@ func TestIntegrations(t *testing.T) {
 	testingSuite := new(integrationTestSuite)
 	testingSuite.s = &testingSuite.Suite
 	suite.Run(t, testingSuite)
+}
+
+type slowReader struct{}
+
+func (s *slowReader) Read(p []byte) (n int, err error) {
+	time.Sleep(35 * time.Second)
+	return 0, nil
+}
+
+func (s *integrationTestSuite) TestSlowOsqueryHost() {
+	t := s.T()
+
+	req, err := http.NewRequest("POST", s.server.URL+"/api/v1/osquery/distributed/write", &slowReader{b: []byte(`{"node_key":"123457398347192739182312983"}`)})
+	require.NoError(t, err)
+
+	client := fleethttp.NewClient()
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusRequestTimeout, resp.StatusCode)
 }
 
 func (s *integrationTestSuite) TestDoubleUserCreationErrors() {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -65,7 +65,7 @@ func (s *slowReader) Read(p []byte) (n int, err error) {
 func (s *integrationTestSuite) TestSlowOsqueryHost() {
 	t := s.T()
 
-	req, err := http.NewRequest("POST", s.server.URL+"/api/v1/osquery/distributed/write", &slowReader{b: []byte(`{"node_key":"123457398347192739182312983"}`)})
+	req, err := http.NewRequest("POST", s.server.URL+"/api/v1/osquery/distributed/write", &slowReader{})
 	require.NoError(t, err)
 
 	client := fleethttp.NewClient()

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/WatchBeam/clock"
 	eeservice "github.com/fleetdm/fleet/v4/ee/server/service"
@@ -256,6 +257,8 @@ func RunServerForTestsWithDS(t *testing.T, ds fleet.Datastore, opts ...*TestServ
 	t.Cleanup(func() {
 		server.Close()
 	})
+	// Set the same ReadTimeout as the actual server
+	server.Config.ReadTimeout = 25 * time.Second
 	return users, server
 }
 

--- a/server/service/transport_error.go
+++ b/server/service/transport_error.go
@@ -174,7 +174,7 @@ func encodeError(ctx context.Context, err error, w http.ResponseWriter) {
 		enc.Encode(je)
 	default:
 		// when there's a tcp read timeout, the error is *net.OpError but the cause is an internal
-		// poll.DeadlineExceeded which we cannot match against, so we check the string here
+		// poll.DeadlineExceeded which we cannot match against, so we match against the original error
 		var opErr *net.OpError
 		if errors.As(origErr, &opErr) {
 			w.WriteHeader(http.StatusRequestTimeout)


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- ~Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~Documented any permissions changes~
- ~Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [x] Added/updated tests
- ~Manual QA for all new/changed functionality~
  - ~For Orbit and Fleet Desktop changes:~
    - ~Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
