### PR TITLE
Onboarding: Add 'zayhanlon' to Humans

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -82,6 +82,7 @@ module.exports = {
       'wclithero',
       'fx5',
       'marcosd4h',
+      'zayhanlon',
     ];
 
     let GREEN_LABEL_COLOR = 'C2E0C6';// « Used in multiple places below.  (FUTURE: Use the "+" prefix for this instead of color.  2022-05-05)


### PR DESCRIPTION
As part of onboarding issue, add 'zayhanlon' to Humans within receive-from-github.js

# Checklist for submitter

