### PR TITLE
Website: update osquery schema pages - add evented table icons to sidenav, update code highlighting

### DIFF
--- a/website/assets/js/pages/osquery-table-details.page.js
+++ b/website/assets/js/pages/osquery-table-details.page.js
@@ -54,7 +54,7 @@ parasails.registerPage('osquery-table-details', {
       $('pre code').each((i, block) => {
         let keywordsToHighlight = [];// Empty array to track the keywords that we will need to highlight
         for(let keyword of keywordsForThisTable){// Going through the array of keywords for this table, if the entire word matches, we'll add it to the
-          for(let match of block.innerText.match(keyword)||[]){
+          for(let match of block.innerHTML.match(keyword)||[]){
             keywordsToHighlight.push(match);
           }
         }

--- a/website/assets/js/pages/osquery-table-details.page.js
+++ b/website/assets/js/pages/osquery-table-details.page.js
@@ -45,18 +45,26 @@ parasails.registerPage('osquery-table-details', {
     if(this.tableToDisplay.keywordsForSyntaxHighlighting){
       keywordsForThisTable = this.tableToDisplay.keywordsForSyntaxHighlighting;
     }
+    keywordsForThisTable = keywordsForThisTable.sort((a,b)=>{// Sorting the array of keywords by length to match larger keywords first.
+      if(a.length > b.length){
+        return -1;
+      }
+    });
     (()=>{
       $('pre code').each((i, block) => {
-        let keywordsInExample = [];
-        for(let keyword of keywordsForThisTable){
+        let keywordsToHighlight = [];// Empty array to track the keywords that we will need to highlight
+        for(let keyword of keywordsForThisTable){// Going through the array of keywords for this table, if the entire word matches, we'll add it to the
           for(let match of block.innerText.match(keyword)||[]){
-            keywordsInExample.push(match);
+            keywordsToHighlight.push(match);
           }
         }
-        for(let keyword of keywordsInExample) {
-          let replacementHMTL = block.innerHTML.replaceAll(keyword, '<span class="hljs-attr">'+keyword+'</span>');
-          $(block).html(replacementHMTL);
+        // Now iterate through the keywordsToHighlight, replacing all matches in the elements innerHTML.
+        let replacementHMTL = block.innerHTML;
+        for(let keywordInExample of keywordsToHighlight) {
+          replacementHMTL = replacementHMTL.replaceAll(keywordInExample, '<span class="hljs-attr">'+keywordInExample+'</span>');
         }
+        $(block).html(replacementHMTL);
+        // After we've highlighted our keywords, we'll highlight the rest of the codeblock
         window.hljs.highlightBlock(block);
       });
       // Adding [purpose="line-break"] to SQL keywords if they are one of: SELECT, WHERE, FROM, JOIN. (case-insensitive)

--- a/website/assets/js/pages/osquery-table-details.page.js
+++ b/website/assets/js/pages/osquery-table-details.page.js
@@ -47,16 +47,17 @@ parasails.registerPage('osquery-table-details', {
     }
     (()=>{
       $('pre code').each((i, block) => {
-        window.hljs.highlightBlock(block);
-      });
-      $('.hljs').each((i, el)=>{
-        let keywordsInExample = _.filter(keywordsForThisTable, (word)=>{
-          return _.includes(_.words(el.innerText, /[^, ]+/g), word);
-        });
-        for(let keyword of keywordsInExample) {
-          let replacementHMTL = el.innerHTML.replaceAll(keyword, '<span class="hljs-attr">'+keyword+'</span>');
-          $(el).html(replacementHMTL);
+        let keywordsInExample = [];
+        for(let keyword of keywordsForThisTable){
+          for(let match of block.innerText.match(keyword)||[]){
+            keywordsInExample.push(match);
+          }
         }
+        for(let keyword of keywordsInExample) {
+          let replacementHMTL = block.innerHTML.replaceAll(keyword, '<span class="hljs-attr">'+keyword+'</span>');
+          $(block).html(replacementHMTL);
+        }
+        window.hljs.highlightBlock(block);
       });
       // Adding [purpose="line-break"] to SQL keywords if they are one of: SELECT, WHERE, FROM, JOIN. (case-insensitive)
       $('.hljs-keyword').each((i, el)=>{

--- a/website/assets/styles/pages/osquery-table-details.less
+++ b/website/assets/styles/pages/osquery-table-details.less
@@ -226,9 +226,6 @@
           .hljs-keyword {
             color: #FFF;
           }
-          .hljs-string {
-            color: #FFF;
-          }
           color: #FFF;
           background-color: #AE6DDF;
           border-radius: 4px;

--- a/website/assets/styles/pages/osquery-table-details.less
+++ b/website/assets/styles/pages/osquery-table-details.less
@@ -113,6 +113,20 @@
     overflow-y: scroll;
     overflow-x: show;
   }
+  [purpose='evented-table-icon'] {
+    margin-left: 4px;
+    padding: 4px 8px;
+    background-color: @core-vibrant-blue-15;
+    border-radius: 4px;
+    display: inline-block;
+    line-height: 14px;
+    vertical-align: middle;
+    img {
+      height: 14px;
+      width: 14px;
+      display: inline-block;
+    }
+  }
   [purpose='table-container'] {
     height: min-content;
   }
@@ -209,6 +223,12 @@
           content: '\a';
         }
         .hljs-attr { // For table and column names
+          .hljs-keyword {
+            color: #FFF;
+          }
+          .hljs-string {
+            color: #FFF;
+          }
           color: #FFF;
           background-color: #AE6DDF;
           border-radius: 4px;

--- a/website/views/pages/osquery-table-details.ejs
+++ b/website/views/pages/osquery-table-details.ejs
@@ -41,7 +41,7 @@
         </div>
         <div class="d-flex d-lg-none pt-3" v-if="showTableNav">
           <div purpose="mobile-table-of-contents">
-            <a class="d-block" :class="[tableToDisplay.title === table.title ? 'active' : '']" :href="table.url" v-for="table in filteredTables">{{table.title}}</a>
+            <a class="d-block" :class="[tableToDisplay.title === table.title ? 'active' : '']" :href="table.url" v-for="table in filteredTables">{{table.title}} <span purpose="evented-table-icon" v-if="table.evented"><img src="/images/icon-evented-14x14@2x.png" ></span></a>
           </div>
         </div>
       </div>
@@ -59,7 +59,7 @@
           </div>
           <div style="position: relative;">
             <div purpose="table-of-contents">
-              <a class="d-block" :class="[tableToDisplay.title === table.title ? 'active' : '']" :href="table.url" v-for="table in filteredTables">{{table.title}}</a>
+              <a class="d-block" :class="[tableToDisplay.title === table.title ? 'active' : '']" :href="table.url" v-for="table in filteredTables">{{table.title}} <span purpose="evented-table-icon" v-if="table.evented"><img src="/images/icon-evented-14x14@2x.png" ></span></a>
             </div>
             <div purpose="overflow-shadow" class="d-none d-lg-block"></div>
           </div>

--- a/website/views/pages/osquery-table-details.ejs
+++ b/website/views/pages/osquery-table-details.ejs
@@ -41,7 +41,7 @@
         </div>
         <div class="d-flex d-lg-none pt-3" v-if="showTableNav">
           <div purpose="mobile-table-of-contents">
-            <a class="d-block" :class="[tableToDisplay.title === table.title ? 'active' : '']" :href="table.url" v-for="table in filteredTables">{{table.title}} <span purpose="evented-table-icon" v-if="table.evented"><img src="/images/icon-evented-14x14@2x.png" ></span></a>
+            <a class="d-block" :class="[tableToDisplay.title === table.title ? 'active' : '']" :href="table.url" v-for="table in filteredTables">{{table.title}} <span purpose="evented-table-icon" v-if="table.evented"><img alt="evented table" src="/images/icon-evented-14x14@2x.png" ></span></a>
           </div>
         </div>
       </div>
@@ -59,7 +59,7 @@
           </div>
           <div style="position: relative;">
             <div purpose="table-of-contents">
-              <a class="d-block" :class="[tableToDisplay.title === table.title ? 'active' : '']" :href="table.url" v-for="table in filteredTables">{{table.title}} <span purpose="evented-table-icon" v-if="table.evented"><img src="/images/icon-evented-14x14@2x.png" ></span></a>
+              <a class="d-block" :class="[tableToDisplay.title === table.title ? 'active' : '']" :href="table.url" v-for="table in filteredTables">{{table.title}} <span purpose="evented-table-icon" v-if="table.evented"><img alt="evented table" src="/images/icon-evented-14x14@2x.png" ></span></a>
             </div>
             <div purpose="overflow-shadow" class="d-none d-lg-block"></div>
           </div>


### PR DESCRIPTION
Changes:
- Updated how keywords are highlighted in table examples. table keywords (Table name, and column names) are now highlighted before other syntax.
- Added evented table icons to the tables in the table of contents that have `"evented": true`