### PR TITLE
Remove info banner from Team details > Agent options

### DIFF
--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
@@ -97,18 +97,6 @@ const AgentOptionsPage = ({
           </span>
         </a>
       </p>
-      <InfoBanner className={`${baseClass}__config-docs`}>
-        See Fleet documentation for an example file that includes the overrides
-        option.{" "}
-        <a
-          href="https://fleetdm.com/docs/using-fleet/configuration-files#overrides-option"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Go to Fleet docs
-          <img alt="Open external link" src={ExternalLinkIcon} />
-        </a>
-      </InfoBanner>
       <div className={`${baseClass}__form-wrapper`}>
         <OsqueryOptionsForm
           formData={formData}


### PR DESCRIPTION
UPDATE: I added this PR to the release board because there is no issue for this change (noahtalerman 2022-10-11).

The `overrides` section was removed from the default agent options in "Add fleetctl and Fleet UI support for remote flags" #7377:
> When there is no overrides being specified by the user, do not show a blank overrides section

- This PR removes the info banner that links to help with `overrides`. The banner is removed because a new Fleet user won't understand what the `overrides` section is.
