### PR TITLE
Add missing return to `ingestKubequeryInfo`

### DIFF
--- a/changes/8161-fix-kubequery-rows-check
+++ b/changes/8161-fix-kubequery-rows-check
@@ -1,0 +1,1 @@
+- Fixed panic in `ingestKubequeryInfo` query ingestion.

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1201,9 +1201,7 @@ func directIngestMunkiInfo(ctx context.Context, logger log.Logger, host *fleet.H
 
 func ingestKubequeryInfo(ctx context.Context, logger log.Logger, host *fleet.Host, rows []map[string]string) error {
 	if len(rows) != 1 {
-		err := fmt.Errorf("kubernetes_info expected single result got: %d", len(rows))
-		logger.Log("component", "service", "method", "ingestKubequeryInfo", "warn", err)
-		return err
+		return fmt.Errorf("kubernetes_info expected single result got: %d", len(rows))
 	}
 
 	host.Hostname = fmt.Sprintf("kubequery %s", rows[0]["cluster_name"])

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1201,8 +1201,9 @@ func directIngestMunkiInfo(ctx context.Context, logger log.Logger, host *fleet.H
 
 func ingestKubequeryInfo(ctx context.Context, logger log.Logger, host *fleet.Host, rows []map[string]string) error {
 	if len(rows) != 1 {
-		logger.Log("component", "service", "method", "ingestKubequeryInfo", "warn",
-			fmt.Sprintf("kubernetes_info expected single result got %d", len(rows)))
+		err := fmt.Errorf("kubernetes_info expected single result got: %d", len(rows))
+		logger.Log("component", "service", "method", "ingestKubequeryInfo", "warn", err)
+		return err
 	}
 
 	host.Hostname = fmt.Sprintf("kubequery %s", rows[0]["cluster_name"])

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -813,3 +813,16 @@ func TestDirectIngestWindowsUpdateHistory(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ds.InsertWindowsUpdatesFuncInvoked)
 }
+
+func TestIngestKubequeryInfo(t *testing.T) {
+	err := ingestKubequeryInfo(context.Background(), log.NewNopLogger(), &fleet.Host{}, nil)
+	require.Error(t, err)
+	err = ingestKubequeryInfo(context.Background(), log.NewNopLogger(), &fleet.Host{}, []map[string]string{})
+	require.Error(t, err)
+	err = ingestKubequeryInfo(context.Background(), log.NewNopLogger(), &fleet.Host{}, []map[string]string{
+		{
+			"cluster_name": "foo",
+		},
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
#8161

Where is static checking when we need it...

- [X] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
~- [ ] Documented any permissions changes~
~- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [X] Added/updated tests
- [ ] ~Manual QA for all new/changed functionality~
  - ~For Orbit and Fleet Desktop changes:~  
    - [ ] ~Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~  
    - [ ] ~Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~  
