### PR TITLE
add browser-related security headers to HTML responses

### DIFF
--- a/changes/8031-security-headers
+++ b/changes/8031-security-headers
@@ -1,0 +1,1 @@
+- Added security headers to HTML, CSV and installer responses.

--- a/server/service/endpoint_utils.go
+++ b/server/service/endpoint_utils.go
@@ -394,6 +394,24 @@ func writeCapabilitiesHeader(w http.ResponseWriter, capabilities fleet.Capabilit
 	w.Header().Set(fleet.CapabilitiesHeader, capabilities.String())
 }
 
+func writeBrowserSecurityHeaders(w http.ResponseWriter) {
+	// Strict-Transport-Security informs browsers that the site should only be
+	// accessed using HTTPS, and that any future attempts to access it using
+	// HTTP should automatically be converted to HTTPS.
+	w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains;")
+	// X-Frames-Options disallows embedding the UI in other sites via <frame>,
+	// <iframe>, <embed> or <object>, which can prevent attacks like
+	// clickjacking.
+	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+	// X-Content-Type-Options prevents browsers from trying to guess the MIME
+	// type which can cause browsers to transform non-executable content into
+	// executable content.
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	// Referrer-Policy prevents leaking the origin of the referrer in the
+	// Referer.
+	w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+}
+
 func (e *authEndpointer) POST(path string, f handlerFunc, v interface{}) {
 	e.handleEndpoint(path, f, v, "POST")
 }

--- a/server/service/endpoint_utils_test.go
+++ b/server/service/endpoint_utils_test.go
@@ -460,3 +460,19 @@ func TestEndpointerCustomMiddleware(t *testing.T) {
 	m2.Handler.ServeHTTP(rec, req)
 	require.Equal(t, "ABCH2", buf.String())
 }
+
+func TestWriteBrowserSecurityHeaders(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeBrowserSecurityHeaders(w)
+	headers := w.Header()
+	require.Equal(
+		t,
+		http.Header{
+			"X-Content-Type-Options":    {"nosniff"},
+			"X-Frame-Options":           {"SAMEORIGIN"},
+			"Strict-Transport-Security": {"max-age=31536000; includeSubDomains;"},
+			"Referrer-Policy":           {"strict-origin-when-cross-origin"},
+		},
+		headers,
+	)
+}

--- a/server/service/frontend.go
+++ b/server/service/frontend.go
@@ -2,7 +2,7 @@ package service
 
 import (
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	assetfs "github.com/elazarl/go-bindata-assetfs"
@@ -25,13 +25,15 @@ func ServeFrontend(urlPrefix string, sandbox bool, logger log.Logger) http.Handl
 		http.Error(w, err, http.StatusInternalServerError)
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeBrowserSecurityHeaders(w)
+
 		fs := newBinaryFileSystem("/frontend")
 		file, err := fs.Open("templates/react.tmpl")
 		if err != nil {
 			herr(w, "load react template: "+err.Error())
 			return
 		}
-		data, err := ioutil.ReadAll(file)
+		data, err := io.ReadAll(file)
 		if err != nil {
 			herr(w, "read bindata file: "+err.Error())
 			return

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1164,6 +1164,7 @@ func (r hostsReportResponse) hijackRender(ctx context.Context, w http.ResponseWr
 
 	w.Header().Add("Content-Disposition", fmt.Sprintf(`attachment; filename="Hosts %s.csv"`, time.Now().Format("2006-01-02")))
 	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(http.StatusOK)
 
 	var err error

--- a/server/service/installer.go
+++ b/server/service/installer.go
@@ -51,6 +51,7 @@ func (r getInstallerResponse) error() error { return r.Err }
 func (r getInstallerResponse) hijackRender(ctx context.Context, w http.ResponseWriter) {
 	w.Header().Set("Content-Length", strconv.FormatInt(r.fileLength, 10))
 	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment;filename="fleet-osquery.%s"`, r.fileExt))
 
 	// OK to just log the error here as writing anything on

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5517,8 +5517,10 @@ func (s *integrationTestSuite) TestHostsReportDownload() {
 	require.Contains(t, rows[0], "hostname") // first row contains headers
 	require.Contains(t, res.Header, "Content-Disposition")
 	require.Contains(t, res.Header, "Content-Type")
+	require.Contains(t, res.Header, "X-Content-Type-Options")
 	require.Contains(t, res.Header.Get("Content-Disposition"), "attachment;")
 	require.Contains(t, res.Header.Get("Content-Type"), "text/csv")
+	require.Contains(t, res.Header.Get("X-Content-Type-Options"), "nosniff")
 
 	// pagination does not apply to this endpoint, it returns the complete list of hosts
 	res = s.DoRaw("GET", "/api/latest/fleet/hosts/report", nil, http.StatusOK, "format", "csv", "page", "1", "per_page", "2", "columns", "hostname")

--- a/server/service/integration_sandbox_test.go
+++ b/server/service/integration_sandbox_test.go
@@ -84,6 +84,7 @@ func (s *integrationSandboxTestSuite) TestInstallerGet() {
 	require.Equal(t, "application/octet-stream", r.Header.Get("Content-Type"))
 	require.Equal(t, "4", r.Header.Get("Content-Length"))
 	require.Equal(t, `attachment;filename="fleet-osquery.pkg"`, r.Header.Get("Content-Disposition"))
+	require.Equal(t, `nosniff`, r.Header.Get("X-Content-Type-Options"))
 
 	// unauthorized requests
 	s.DoRawNoAuth("POST", validURL, nil, http.StatusUnauthorized)

--- a/server/service/transport.go
+++ b/server/service/transport.go
@@ -25,6 +25,7 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response interfa
 	// page and the error will be logged
 	if page, ok := response.(htmlPage); ok {
 		w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+		writeBrowserSecurityHeaders(w)
 		if coder, ok := page.error().(kithttp.StatusCoder); ok {
 			w.WriteHeader(coder.StatusCode())
 		}


### PR DESCRIPTION
related to #8031, this adds the following headers to HTML responses:

- Strict-Transport-Security: informs browsers that the site should only be accessed using HTTPS, and that any future attempts to access it using HTTP should automatically be converted to HTTPS.
- X-Frames-Options: disallows embedding the UI in other sites via <frame>, <iframe>, <embed> or <object>, which can prevent attacks like clickjacking.
- X-Content-Type-Options: prevents browsers from trying to guess the MIME type which can cause browsers to transform non-executable content into executable content.
- Referrer-Policy: prevents leaking the origin of the referrer in the Referer.

additionally, this ensures we set `X-Content-Type-Options` for CSV and installer responses.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
