### PR TITLE
Orbit: Add retries to `launchctl bootstrap` to fix issue with MDM push

### DIFF
--- a/orbit/changes/add-retries-bootstrap-mdm-push
+++ b/orbit/changes/add-retries-bootstrap-mdm-push
@@ -1,0 +1,1 @@
+- Added `launchctl bootstrap` retries in Orbit `pkg` installer to fix MDM deployments of Orbit (when pushed with `InstallEnterpriseApplication`).

--- a/orbit/pkg/packaging/macos_templates.go
+++ b/orbit/pkg/packaging/macos_templates.go
@@ -60,8 +60,26 @@ DAEMON_PLIST="/Library/LaunchDaemons/${DAEMON_LABEL}.plist"
 pkill fleet-desktop || true
 # Remove any pre-existing version of the config
 launchctl bootout "system/${DAEMON_LABEL}"
-# Add the daemon to the launchd system
-launchctl bootstrap system "${DAEMON_PLIST}"
+
+# Add the daemon to the launchd system.
+#
+# We add retries because we've seen "launchctl bootstrap" fail
+# if the service is still running after bootout (in case the
+# service takes a bit longer to terminate gracefully).
+# We've seen this when deploying the package via an MDM server.
+#
+count=0
+while ! launchctl bootstrap system "${DAEMON_PLIST}"; do
+	sleep 1
+	((count++))
+	if [[ $count -eq 5 ]]; then
+		echo "Failed to bootstrap system ${DAEMON_PLIST}"
+		exit 1
+	fi
+	echo "Retrying launchctl bootstrap..."
+done
+echo "Successfully bootstrap system ${DAEMON_PLIST}"
+
 # Enable the daemon
 launchctl enable "system/${DAEMON_LABEL}"
 # Force the daemon to start

--- a/orbit/pkg/packaging/macos_templates.go
+++ b/orbit/pkg/packaging/macos_templates.go
@@ -72,7 +72,7 @@ count=0
 while ! launchctl bootstrap system "${DAEMON_PLIST}"; do
 	sleep 1
 	((count++))
-	if [[ $count -eq 5 ]]; then
+	if [[ $count -eq 30 ]]; then
 		echo "Failed to bootstrap system ${DAEMON_PLIST}"
 		exit 1
 	fi


### PR DESCRIPTION
- [X] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
~- [ ] Documented any permissions changes~
~- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
~- [ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality
  - ~For Orbit and Fleet Desktop changes:~
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
