### PR TITLE
Fleet UI: Fix padding between multiple enroll secrets

### DIFF
--- a/changes/issue-8146-padding-between-enroll-secrets
+++ b/changes/issue-8146-padding-between-enroll-secrets
@@ -1,0 +1,1 @@
+* Padding between multiple enroll secrets

--- a/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/_styles.scss
+++ b/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/_styles.scss
@@ -2,6 +2,7 @@
   &__secret {
     display: flex;
     align-items: center;
+    margin-bottom: $pad-medium;
   }
 
   .form-field {
@@ -85,10 +86,6 @@
     .enroll-secrets__secret-download-icon {
       margin-bottom: $pad-medium;
     }
-  }
-
-  &--multiple-secrets > * + * {
-    margin-top: $pad-medium;
   }
 
   &__edit-secret-btn,

--- a/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/_styles.scss
+++ b/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/_styles.scss
@@ -87,6 +87,10 @@
     }
   }
 
+  &--multiple-secrets > * + * {
+    margin-top: $pad-medium;
+  }
+
   &__edit-secret-btn,
   &__delete-secret-btn {
     margin: 0 $pad-small;

--- a/frontend/components/EnrollSecrets/SecretField/_styles.scss
+++ b/frontend/components/EnrollSecrets/SecretField/_styles.scss
@@ -1,5 +1,7 @@
 .secret-field {
   &__secret-input {
+    margin-bottom: 8px;
+
     .form-field__label {
       position: relative;
       font-size: $x-small;
@@ -75,16 +77,6 @@
       width: 12px;
       height: 12px;
       margin-left: 7px;
-    }
-  }
-
-  &--multiple-secrets {
-    .form-field__label {
-      margin-top: 0;
-    }
-
-    .enroll-secrets__secret-download-icon {
-      margin-bottom: $pad-medium;
     }
   }
 }

--- a/frontend/pages/UserSettingsPage/_styles.scss
+++ b/frontend/pages/UserSettingsPage/_styles.scss
@@ -21,10 +21,6 @@
     width: 400px;
   }
 
-  .secret-field__secret-input {
-    margin-bottom: 8px;
-  }
-
   .info-banner {
     margin-bottom: 24px;
     p {


### PR DESCRIPTION
Cerra #8146 

**Fix**
- Padding between multiple enroll secrets using CSS

**Other**
- Remove unused multiple secrets code for API token fields
- Put drilled down css into proper component (component only used in one place...)

**Screenshot**
<img width="738" alt="Screen Shot 2022-10-12 at 3 12 00 PM" src="https://user-images.githubusercontent.com/71795832/195428591-9b6e445b-744b-40c5-bd18-35e6d3e9888a.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality