### PR TITLE
Deep-clone the appconfig when getting from cache

### DIFF
--- a/changes/bug-fix-dry-run-apply-app-config
+++ b/changes/bug-fix-dry-run-apply-app-config
@@ -1,0 +1,1 @@
+* Fixed a bug when running `fleetctl apply` with the `--dry-run` flag, it could fail with an obscure "invalid JSON" error due to the way the internal caching was done.

--- a/cmd/fleetctl/apply_test.go
+++ b/cmd/fleetctl/apply_test.go
@@ -272,6 +272,107 @@ spec:
 	assert.True(t, savedAppConfig.Features.EnableSoftwareInventory)
 }
 
+func TestApplyAppConfigDryRunIssue(t *testing.T) {
+	// reproduces the bug fixed by https://github.com/fleetdm/fleet/pull/8194
+	_, ds := runServerWithMockedDS(t)
+
+	ds.ListUsersFunc = func(ctx context.Context, opt fleet.UserListOptions) ([]*fleet.User, error) {
+		return userRoleSpecList, nil
+	}
+
+	ds.UserByEmailFunc = func(ctx context.Context, email string) (*fleet.User, error) {
+		if email == "admin1@example.com" {
+			return userRoleSpecList[0], nil
+		}
+		return userRoleSpecList[1], nil
+	}
+
+	ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activityType string, details *map[string]interface{}) error {
+		return nil
+	}
+
+	var currentAppConfig = &fleet.AppConfig{
+		OrgInfo: fleet.OrgInfo{OrgName: "Fleet"}, ServerSettings: fleet.ServerSettings{ServerURL: "https://example.org"},
+	}
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return currentAppConfig, nil
+	}
+
+	ds.SaveAppConfigFunc = func(ctx context.Context, config *fleet.AppConfig) error {
+		currentAppConfig = config
+		return nil
+	}
+
+	// first, set the default app config's agent options as set after fleetctl setup
+	name := writeTmpYml(t, `---
+apiVersion: v1
+kind: config
+spec:
+  agent_options:
+    config:
+      decorators:
+        load:
+        - SELECT uuid AS host_uuid FROM system_info;
+        - SELECT hostname AS hostname FROM system_info;
+      options:
+        disable_distributed: false
+        distributed_interval: 10
+        distributed_plugin: tls
+        distributed_tls_max_attempts: 3
+        logger_tls_endpoint: /api/osquery/log
+        logger_tls_period: 10
+        pack_delimiter: /
+    overrides: {}
+`)
+
+	assert.Equal(t, "[+] applied fleet config\n", runAppForTest(t, []string{"apply", "-f", name}))
+
+	// then, dry-run a valid app config's agent options, which made the original
+	// app config's agent options invalid JSON (when it shouldn't have modified
+	// it at all - the issue was in the cached_mysql datastore, it did not clone
+	// the app config properly).
+	name = writeTmpYml(t, `---
+apiVersion: v1
+kind: config
+spec:
+  agent_options:
+    overrides:
+      platforms:
+        darwin:
+          auto_table_construction:
+            tcc_system_entries:
+              query: "SELECT service, client, allowed, prompt_count, last_modified FROM access"
+              path: "/Library/Application Support/com.apple.TCC/TCC.db"
+              columns:
+                - "service"
+                - "client"
+                - "allowed"
+                - "prompt_count"
+                - "last_modified"
+`)
+
+	assert.Equal(t, "[+] would've applied fleet config\n", runAppForTest(t, []string{"apply", "--dry-run", "-f", name}))
+
+	// the saved app config was left unchanged, still equal to the original agent
+	// options
+	got := runAppForTest(t, []string{"get", "config"})
+	assert.Contains(t, got, `agent_options:
+    config:
+      decorators:
+        load:
+        - SELECT uuid AS host_uuid FROM system_info;
+        - SELECT hostname AS hostname FROM system_info;
+      options:
+        disable_distributed: false
+        distributed_interval: 10
+        distributed_plugin: tls
+        distributed_tls_max_attempts: 3
+        logger_tls_endpoint: /api/osquery/log
+        logger_tls_period: 10
+        pack_delimiter: /
+    overrides: {}`)
+}
+
 func TestApplyAppConfigUnknownFields(t *testing.T) {
 	_, ds := runServerWithMockedDS(t)
 

--- a/cmd/fleetctl/testing_utils.go
+++ b/cmd/fleetctl/testing_utils.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/server/datastore/cached_mysql"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/service"
@@ -47,7 +48,9 @@ func runServerWithMockedDS(t *testing.T, opts ...*service.TestServerOpts) (*http
 	ds.ListUsersFunc = func(ctx context.Context, opt fleet.UserListOptions) ([]*fleet.User, error) {
 		return users, nil
 	}
-	_, server := service.RunServerForTestsWithDS(t, ds, opts...)
+
+	cachedDS := cached_mysql.New(ds)
+	_, server := service.RunServerForTestsWithDS(t, cachedDS, opts...)
 	os.Setenv("FLEET_SERVER_ADDRESS", server.URL)
 
 	return server, ds

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95
 	github.com/igm/sockjs-go/v3 v3.0.0
-	github.com/jinzhu/copier v0.3.2
+	github.com/jinzhu/copier v0.3.5
 	github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5
 	github.com/kevinburke/go-bindata v3.22.0+incompatible
 	github.com/kolide/kit v0.0.0-20191023141830-6312ecc11c23

--- a/go.sum
+++ b/go.sum
@@ -819,6 +819,8 @@ github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJS
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jinzhu/copier v0.3.2 h1:QdBOCbaouLDYaIPFfi1bKv5F5tPpeTwXe4sD0jqtz5w=
 github.com/jinzhu/copier v0.3.2/go.mod h1:24xnZezI2Yqac9J61UC6/dG/k76ttpq0DdJI3QmUvro=
+github.com/jinzhu/copier v0.3.5 h1:GlvfUwHk62RokgqVNvYsku0TATCF7bAHVwEXoBh3iJg=
+github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jinzhu/gorm v1.9.1/go.mod h1:Vla75njaFJ8clLU1W44h34PjIkijhjHIYnZxMqCdxqo=
 github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/server/datastore/cached_mysql/cached_mysql.go
+++ b/server/datastore/cached_mysql/cached_mysql.go
@@ -55,7 +55,7 @@ func clone(v interface{}) (interface{}, error) {
 
 	clone := reflect.New(vv.Type())
 
-	err := copier.Copy(clone.Interface(), v)
+	err := copier.CopyWithOption(clone.Interface(), v, copier.Option{DeepCopy: true, IgnoreEmpty: true})
 	if err != nil {
 		return nil, err
 	}

--- a/server/datastore/cached_mysql/cached_mysql_test.go
+++ b/server/datastore/cached_mysql/cached_mysql_test.go
@@ -74,6 +74,19 @@ func TestClone(t *testing.T) {
 			src:  nilRawMessage,
 			want: nil,
 		},
+		{
+			name: "pointer to struct with nested slice",
+			src: &fleet.AppConfig{
+				ServerSettings: fleet.ServerSettings{
+					DebugHostIDs: []uint{1, 2, 3},
+				},
+			},
+			want: &fleet.AppConfig{
+				ServerSettings: fleet.ServerSettings{
+					DebugHostIDs: []uint{1, 2, 3},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -92,8 +105,8 @@ func TestClone(t *testing.T) {
 				assert.NotEqual(t, v1.Pointer(), v2.Pointer())
 			}
 
-			// if it is a slice, a map, or a pointer to a slice, ensure that writing
-			// to src does not alter the cloned value.
+			// ensure that writing to src does not alter the cloned value (i.e. that
+			// the nested fields are deeply cloned too).
 			switch src := tc.src.(type) {
 			case []string:
 				if len(src) > 0 {
@@ -104,6 +117,11 @@ func TestClone(t *testing.T) {
 				if len(*src) > 0 {
 					(*src)[0] = "modified"
 					assert.NotEqual(t, src, clone)
+				}
+			case *fleet.AppConfig:
+				if len(src.ServerSettings.DebugHostIDs) > 0 {
+					src.ServerSettings.DebugHostIDs[0] = 999
+					assert.NotEqual(t, src.ServerSettings.DebugHostIDs, clone.(*fleet.AppConfig).ServerSettings.DebugHostIDs)
 				}
 			}
 		})

--- a/server/datastore/cached_mysql/cached_mysql_test.go
+++ b/server/datastore/cached_mysql/cached_mysql_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -80,6 +81,31 @@ func TestClone(t *testing.T) {
 			clone, err := clone(tc.src)
 			require.NoError(t, err)
 			assert.Equal(t, tc.want, clone)
+
+			v1, v2 := reflect.ValueOf(tc.src), reflect.ValueOf(clone)
+			if k := v1.Kind(); k == reflect.Pointer || k == reflect.Slice || k == reflect.Map || k == reflect.Chan || k == reflect.Func || k == reflect.UnsafePointer {
+				if clone == nil {
+					assert.True(t, v1.IsNil())
+					return
+				}
+				require.Equal(t, v1.Kind(), v2.Kind())
+				assert.NotEqual(t, v1.Pointer(), v2.Pointer())
+			}
+
+			// if it is a slice, a map, or a pointer to a slice, ensure that writing
+			// to src does not alter the cloned value.
+			switch src := tc.src.(type) {
+			case []string:
+				if len(src) > 0 {
+					src[0] = "modified"
+					assert.NotEqual(t, src, clone)
+				}
+			case *[]string:
+				if len(*src) > 0 {
+					(*src)[0] = "modified"
+					assert.NotEqual(t, src, clone)
+				}
+			}
 		})
 	}
 }

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -132,6 +132,54 @@ type AppConfig struct {
 	didUnmarshalLegacySettings bool
 }
 
+func (c *AppConfig) Clone() (interface{}, error) {
+	if c == nil {
+		return nil, nil
+	}
+
+	var clone AppConfig
+	clone = *c
+	// OrgInfo: nothing needs cloning
+	if c.ServerSettings.DebugHostIDs != nil {
+		clone.ServerSettings.DebugHostIDs = make([]uint, len(c.ServerSettings.DebugHostIDs))
+		copy(clone.ServerSettings.DebugHostIDs, c.ServerSettings.DebugHostIDs)
+	}
+	// SMTPSettings: nothing needs cloning
+	// HostExpirySettings: nothing needs cloning
+	if c.Features.AdditionalQueries != nil {
+		aq := make(json.RawMessage, len(*c.Features.AdditionalQueries))
+		copy(aq, *c.Features.AdditionalQueries)
+		c.Features.AdditionalQueries = &aq
+	}
+	if c.AgentOptions != nil {
+		ao := make(json.RawMessage, len(*c.AgentOptions))
+		copy(ao, *c.AgentOptions)
+		clone.AgentOptions = &ao
+	}
+	// SSOSettings: nothing needs cloning
+	// FleetDesktop: nothing needs cloning
+	// VulnerabilitySettings: nothing needs cloning
+	if c.WebhookSettings.FailingPoliciesWebhook.PolicyIDs != nil {
+		clone.WebhookSettings.FailingPoliciesWebhook.PolicyIDs = make([]uint, len(c.WebhookSettings.FailingPoliciesWebhook.PolicyIDs))
+		copy(clone.WebhookSettings.FailingPoliciesWebhook.PolicyIDs, c.WebhookSettings.FailingPoliciesWebhook.PolicyIDs)
+	}
+	if c.Integrations.Jira != nil {
+		clone.Integrations.Jira = make([]*JiraIntegration, len(c.Integrations.Jira))
+		for i, j := range c.Integrations.Jira {
+			jira := *j
+			clone.Integrations.Jira[i] = &jira
+		}
+	}
+	if c.Integrations.Zendesk != nil {
+		clone.Integrations.Zendesk = make([]*ZendeskIntegration, len(c.Integrations.Zendesk))
+		for i, z := range c.Integrations.Zendesk {
+			zd := *z
+			clone.Integrations.Zendesk[i] = &zd
+		}
+	}
+	return &clone, nil
+}
+
 // legacyConfig holds settings that have been replaced, superceded or
 // deprecated by other AppConfig settings.
 type legacyConfig struct {

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -132,54 +132,6 @@ type AppConfig struct {
 	didUnmarshalLegacySettings bool
 }
 
-func (c *AppConfig) Clone() (interface{}, error) {
-	if c == nil {
-		return nil, nil
-	}
-
-	var clone AppConfig
-	clone = *c
-	// OrgInfo: nothing needs cloning
-	if c.ServerSettings.DebugHostIDs != nil {
-		clone.ServerSettings.DebugHostIDs = make([]uint, len(c.ServerSettings.DebugHostIDs))
-		copy(clone.ServerSettings.DebugHostIDs, c.ServerSettings.DebugHostIDs)
-	}
-	// SMTPSettings: nothing needs cloning
-	// HostExpirySettings: nothing needs cloning
-	if c.Features.AdditionalQueries != nil {
-		aq := make(json.RawMessage, len(*c.Features.AdditionalQueries))
-		copy(aq, *c.Features.AdditionalQueries)
-		c.Features.AdditionalQueries = &aq
-	}
-	if c.AgentOptions != nil {
-		ao := make(json.RawMessage, len(*c.AgentOptions))
-		copy(ao, *c.AgentOptions)
-		clone.AgentOptions = &ao
-	}
-	// SSOSettings: nothing needs cloning
-	// FleetDesktop: nothing needs cloning
-	// VulnerabilitySettings: nothing needs cloning
-	if c.WebhookSettings.FailingPoliciesWebhook.PolicyIDs != nil {
-		clone.WebhookSettings.FailingPoliciesWebhook.PolicyIDs = make([]uint, len(c.WebhookSettings.FailingPoliciesWebhook.PolicyIDs))
-		copy(clone.WebhookSettings.FailingPoliciesWebhook.PolicyIDs, c.WebhookSettings.FailingPoliciesWebhook.PolicyIDs)
-	}
-	if c.Integrations.Jira != nil {
-		clone.Integrations.Jira = make([]*JiraIntegration, len(c.Integrations.Jira))
-		for i, j := range c.Integrations.Jira {
-			jira := *j
-			clone.Integrations.Jira[i] = &jira
-		}
-	}
-	if c.Integrations.Zendesk != nil {
-		clone.Integrations.Zendesk = make([]*ZendeskIntegration, len(c.Integrations.Zendesk))
-		for i, z := range c.Integrations.Zendesk {
-			zd := *z
-			clone.Integrations.Zendesk[i] = &zd
-		}
-	}
-	return &clone, nil
-}
-
 // legacyConfig holds settings that have been replaced, superceded or
 // deprecated by other AppConfig settings.
 type legacyConfig struct {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -188,6 +188,7 @@ func modifyAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet
 	if err != nil {
 		return appConfigResponse{appConfigResponseFields: appConfigResponseFields{Err: err}}, nil
 	}
+
 	license, err := svc.License(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The cloning in `cached_mysql` was shallow and that causes issues for the `AppConfig` struct, when `--dry-run` validations were requested for a YAML payload, it would trash the raw JSON of the `agent_options` field and make it invalid JSON. Detailed discussion in the internal slack: https://fleetdm.slack.com/archives/C019WG4GH0A/p1665595772101659

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests
