### PR TITLE
Fleet UI: Select all fix on table checkboxes

### DIFF
--- a/changes/issue-8114-select-all-checkbox-fix
+++ b/changes/issue-8114-select-all-checkbox-fix
@@ -1,0 +1,1 @@
+* Clicking the select all checkbox will select all, unless all are selected it will deselect all

--- a/frontend/components/forms/fields/Checkbox/Checkbox.tsx
+++ b/frontend/components/forms/fields/Checkbox/Checkbox.tsx
@@ -70,9 +70,6 @@ const Checkbox = (props: ICheckboxProps) => {
           onChange={handleChange}
           onBlur={onBlur}
           type="checkbox"
-          ref={(element) => {
-            element && indeterminate && (element.indeterminate = indeterminate);
-          }}
         />
         <span className={checkBoxTickClass} />
 


### PR DESCRIPTION
Cerra #8114 

**Fix**
- Indeterminate state (minus sign) turns to a checkbox to show that all are selected when clicking on it, clicking once more will deselect all

**Recording of the fix**

https://user-images.githubusercontent.com/71795832/195436023-a1bc73d3-0028-4686-ac1a-b61b506e7878.mov

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality