### PR TITLE
Add usage statistics to measure policy violations

### DIFF
--- a/changes/issue-6072-policy-violation-days
+++ b/changes/issue-6072-policy-violation-days
@@ -1,0 +1,3 @@
+- Added usage statistics for the weekly count of aggregate policy violation days. One policy
+  violation day is counted for each policy that a host is failing, measured as of the time the
+  count increments. The count increments once per 24-hour interval and resets each week.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -719,22 +719,11 @@ func trySendStatistics(ctx context.Context, ds fleet.Datastore, frequency time.D
 		return err
 	}
 
-	if err := cleanupStatistics(ctx, ds); err != nil {
+	if err := ds.CleanupStatistics(ctx); err != nil {
 		return err
 	}
 
 	return ds.RecordStatisticsSent(ctx)
-}
-
-// cleanupStatistics executes cleanup tasks to be performed upon successful transmission of
-// statistics.
-func cleanupStatistics(ctx context.Context, ds fleet.Datastore) error {
-	// reset weekly count of policy violation days
-	if err := ds.InitializePolicyViolationDays(ctx, time.Now()); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // NanoDEPLogger is a logger adapter for nanodep.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -671,7 +671,7 @@ func startCleanupsAndAggregationSchedule(
 		schedule.WithJob(
 			"increment_policy_violation_days",
 			func(ctx context.Context) error {
-				return ds.IncrementPolicyViolationDays(ctx, time.Now())
+				return ds.IncrementPolicyViolationDays(ctx)
 			},
 		),
 		schedule.WithJob(

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -60,20 +60,21 @@ func TestMaybeSendStatistics(t *testing.T) {
 
 	ds.ShouldSendStatisticsFunc = func(ctx context.Context, frequency time.Duration, config config.FleetConfig, license *fleet.LicenseInfo) (fleet.StatisticsPayload, bool, error) {
 		return fleet.StatisticsPayload{
-			AnonymousIdentifier:          "ident",
-			FleetVersion:                 "1.2.3",
-			LicenseTier:                  "premium",
-			NumHostsEnrolled:             999,
-			NumUsers:                     99,
-			NumTeams:                     9,
-			NumPolicies:                  0,
-			NumLabels:                    3,
-			SoftwareInventoryEnabled:     true,
-			VulnDetectionEnabled:         true,
-			SystemUsersEnabled:           true,
-			HostsStatusWebHookEnabled:    true,
-			NumWeeklyActiveUsers:         111,
-			NumWeeklyPolicyViolationDays: 0,
+			AnonymousIdentifier:                  "ident",
+			FleetVersion:                         "1.2.3",
+			LicenseTier:                          "premium",
+			NumHostsEnrolled:                     999,
+			NumUsers:                             99,
+			NumTeams:                             9,
+			NumPolicies:                          0,
+			NumLabels:                            3,
+			SoftwareInventoryEnabled:             true,
+			VulnDetectionEnabled:                 true,
+			SystemUsersEnabled:                   true,
+			HostsStatusWebHookEnabled:            true,
+			NumWeeklyActiveUsers:                 111,
+			NumWeeklyPolicyViolationDaysActual:   0,
+			NumWeeklyPolicyViolationDaysPossible: 0,
 			HostsEnrolledByOperatingSystem: map[string][]fleet.HostsCountByOSVersion{
 				"linux": {
 					fleet.HostsCountByOSVersion{Version: "1.2.3", NumEnrolled: 22},
@@ -98,7 +99,7 @@ func TestMaybeSendStatistics(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, recorded)
 	require.True(t, cleanedup)
-	assert.Equal(t, `{"anonymousIdentifier":"ident","fleetVersion":"1.2.3","licenseTier":"premium","organization":"Fleet","numHostsEnrolled":999,"numUsers":99,"numTeams":9,"numPolicies":0,"numLabels":3,"softwareInventoryEnabled":true,"vulnDetectionEnabled":true,"systemUsersEnabled":true,"hostsStatusWebHookEnabled":true,"numWeeklyActiveUsers":111,"numWeeklyPolicyViolationDays":0,"hostsEnrolledByOperatingSystem":{"linux":[{"version":"1.2.3","numEnrolled":22}]},"storedErrors":[],"numHostsNotResponding":0}`, requestBody)
+	assert.Equal(t, `{"anonymousIdentifier":"ident","fleetVersion":"1.2.3","licenseTier":"premium","organization":"Fleet","numHostsEnrolled":999,"numUsers":99,"numTeams":9,"numPolicies":0,"numLabels":3,"softwareInventoryEnabled":true,"vulnDetectionEnabled":true,"systemUsersEnabled":true,"hostsStatusWebHookEnabled":true,"numWeeklyActiveUsers":111,"numWeeklyPolicyViolationDaysActual":0,"numWeeklyPolicyViolationDaysPossible":0,"hostsEnrolledByOperatingSystem":{"linux":[{"version":"1.2.3","numEnrolled":22}]},"storedErrors":[],"numHostsNotResponding":0}`, requestBody)
 }
 
 func TestMaybeSendStatisticsSkipsSendingIfNotNeeded(t *testing.T) {

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -60,19 +60,20 @@ func TestMaybeSendStatistics(t *testing.T) {
 
 	ds.ShouldSendStatisticsFunc = func(ctx context.Context, frequency time.Duration, config config.FleetConfig, license *fleet.LicenseInfo) (fleet.StatisticsPayload, bool, error) {
 		return fleet.StatisticsPayload{
-			AnonymousIdentifier:       "ident",
-			FleetVersion:              "1.2.3",
-			LicenseTier:               "premium",
-			NumHostsEnrolled:          999,
-			NumUsers:                  99,
-			NumTeams:                  9,
-			NumPolicies:               0,
-			NumLabels:                 3,
-			SoftwareInventoryEnabled:  true,
-			VulnDetectionEnabled:      true,
-			SystemUsersEnabled:        true,
-			HostsStatusWebHookEnabled: true,
-			NumWeeklyActiveUsers:      111,
+			AnonymousIdentifier:          "ident",
+			FleetVersion:                 "1.2.3",
+			LicenseTier:                  "premium",
+			NumHostsEnrolled:             999,
+			NumUsers:                     99,
+			NumTeams:                     9,
+			NumPolicies:                  0,
+			NumLabels:                    3,
+			SoftwareInventoryEnabled:     true,
+			VulnDetectionEnabled:         true,
+			SystemUsersEnabled:           true,
+			HostsStatusWebHookEnabled:    true,
+			NumWeeklyActiveUsers:         111,
+			NumWeeklyPolicyViolationDays: 0,
 			HostsEnrolledByOperatingSystem: map[string][]fleet.HostsCountByOSVersion{
 				"linux": {
 					fleet.HostsCountByOSVersion{Version: "1.2.3", NumEnrolled: 22},
@@ -87,11 +88,17 @@ func TestMaybeSendStatistics(t *testing.T) {
 		recorded = true
 		return nil
 	}
+	cleanedup := false
+	ds.CleanupStatisticsFunc = func(ctx context.Context) error {
+		cleanedup = true
+		return nil
+	}
 
 	err := trySendStatistics(context.Background(), ds, fleet.StatisticsFrequency, ts.URL, fleetConfig, &fleet.LicenseInfo{Tier: "premium"})
 	require.NoError(t, err)
 	assert.True(t, recorded)
-	assert.Equal(t, `{"anonymousIdentifier":"ident","fleetVersion":"1.2.3","licenseTier":"premium","organization":"Fleet","numHostsEnrolled":999,"numUsers":99,"numTeams":9,"numPolicies":0,"numLabels":3,"softwareInventoryEnabled":true,"vulnDetectionEnabled":true,"systemUsersEnabled":true,"hostsStatusWebHookEnabled":true,"numWeeklyActiveUsers":111,"hostsEnrolledByOperatingSystem":{"linux":[{"version":"1.2.3","numEnrolled":22}]},"storedErrors":[],"numHostsNotResponding":0}`, requestBody)
+	require.True(t, cleanedup)
+	assert.Equal(t, `{"anonymousIdentifier":"ident","fleetVersion":"1.2.3","licenseTier":"premium","organization":"Fleet","numHostsEnrolled":999,"numUsers":99,"numTeams":9,"numPolicies":0,"numLabels":3,"softwareInventoryEnabled":true,"vulnDetectionEnabled":true,"systemUsersEnabled":true,"hostsStatusWebHookEnabled":true,"numWeeklyActiveUsers":111,"numWeeklyPolicyViolationDays":0,"hostsEnrolledByOperatingSystem":{"linux":[{"version":"1.2.3","numEnrolled":22}]},"storedErrors":[],"numHostsNotResponding":0}`, requestBody)
 }
 
 func TestMaybeSendStatisticsSkipsSendingIfNotNeeded(t *testing.T) {
@@ -118,10 +125,16 @@ func TestMaybeSendStatisticsSkipsSendingIfNotNeeded(t *testing.T) {
 		recorded = true
 		return nil
 	}
+	cleanedup := false
+	ds.CleanupStatisticsFunc = func(ctx context.Context) error {
+		cleanedup = true
+		return nil
+	}
 
 	err := trySendStatistics(context.Background(), ds, fleet.StatisticsFrequency, ts.URL, fleetConfig, &fleet.LicenseInfo{Tier: "premium"})
 	require.NoError(t, err)
 	assert.False(t, recorded)
+	assert.False(t, cleanedup)
 	assert.False(t, called)
 }
 

--- a/docs/Using-Fleet/Usage-statistics.md
+++ b/docs/Using-Fleet/Usage-statistics.md
@@ -26,7 +26,8 @@ Below is the JSON payload that is sent to Fleet Device Management Inc:
   "systemUsersEnabled": true,
   "hostStatusWebhookEnabled": true,
   "numWeeklyActiveUsers": 999,
-  "numWeeklyPolicyViolationDays": 999,
+  "numWeeklyPolicyViolationDaysActual": 999,
+  "numWeeklyPolicyViolationDaysPossible": 999,
   "hostsEnrolledByOperatingSystem": {
     "darwin": [
       {

--- a/docs/Using-Fleet/Usage-statistics.md
+++ b/docs/Using-Fleet/Usage-statistics.md
@@ -25,6 +25,8 @@ Below is the JSON payload that is sent to Fleet Device Management Inc:
   "vulnDetectionEnabled": true,
   "systemUsersEnabled": true,
   "hostStatusWebhookEnabled": true,
+  "numWeeklyActiveUsers": 999,
+  "numWeeklyPolicyViolationDays": 999,
   "hostsEnrolledByOperatingSystem": {
     "darwin": [
       {

--- a/frontend/pages/admin/AppSettingsPage/cards/constants.ts
+++ b/frontend/pages/admin/AppSettingsPage/cards/constants.ts
@@ -84,7 +84,8 @@ export const usageStatsPreview = {
   systemUsersEnabled: true,
   hostStatusWebhookEnabled: true,
   numWeeklyActiveUsers: 999,
-  numWeeklyPolicyViolationDays: 999,
+  numWeeklyPolicyViolationDaysActual: 999,
+  numWeeklyPolicyViolationDaysPossible: 999,
   hostsEnrolledByOperatingSystem: {
     darwin: [
       {

--- a/frontend/pages/admin/AppSettingsPage/cards/constants.ts
+++ b/frontend/pages/admin/AppSettingsPage/cards/constants.ts
@@ -84,6 +84,7 @@ export const usageStatsPreview = {
   systemUsersEnabled: true,
   hostStatusWebhookEnabled: true,
   numWeeklyActiveUsers: 999,
+  numWeeklyPolicyViolationDays: 999,
   hostsEnrolledByOperatingSystem: {
     darwin: [
       {

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -810,7 +810,7 @@ func amountPolicyViolationDaysDB(ctx context.Context, tx sqlx.QueryerContext) (i
 		WHERE 
 			id = ? AND type = ?
 	`, statsID, statsType); err != nil {
-		return res, ctxerr.Wrap(ctx, err, "getting policy violation days aggregated stats")
+		return 0, err
 	}
 
 	return res, nil

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -1810,12 +1810,12 @@ func testPolicyViolationDays(t *testing.T, ds *Datastore) {
 	// add one violation
 	now = now.Add(1 * time.Minute)
 	require.NoError(t, ds.RecordPolicyQueryExecutions(context.Background(), hosts[0], map[uint]*bool{pol.ID: ptr.Bool(false)}, now, false))
-	count, err = amountPolicyViolationDaysDB(ctx, ds.reader)
-	require.NoError(t, err)
 
 	// update interval hasn't pased so count does not increment
 	now = now.Add(1 * time.Minute)
 	require.NoError(t, ds.IncrementPolicyViolationDays(ctx, now))
+	count, err = amountPolicyViolationDaysDB(ctx, ds.reader)
+	require.NoError(t, err)
 	require.Equal(t, 0, count)
 
 	// next update interval passed so count increments by one
@@ -1828,8 +1828,6 @@ func testPolicyViolationDays(t *testing.T, ds *Datastore) {
 	// add one violation by a different host
 	now = now.Add(1 * time.Minute)
 	require.NoError(t, ds.RecordPolicyQueryExecutions(context.Background(), hosts[1], map[uint]*bool{pol.ID: ptr.Bool(false)}, now, false))
-	count, err = amountPolicyViolationDaysDB(ctx, ds.reader)
-	require.NoError(t, err)
 
 	// update interval hasn't pased so count does not increment
 	now = now.Add(1 * time.Minute)
@@ -1855,8 +1853,8 @@ func testPolicyViolationDays(t *testing.T, ds *Datastore) {
 	// resolve one violation
 	require.NoError(t, ds.RecordPolicyQueryExecutions(context.Background(), hosts[0], map[uint]*bool{pol.ID: ptr.Bool(true)}, now, false))
 
-	// update interval resets with initialization so count is not incremented even though there are
-	// still two outstanding violations
+	// update interval resets when initialized so count is not incremented even though there is
+	// still one outstanding violation
 	now = now.Add(1 * time.Minute)
 	require.NoError(t, ds.IncrementPolicyViolationDays(ctx, now))
 	count, err = amountPolicyViolationDaysDB(ctx, ds.reader)

--- a/server/datastore/mysql/statistics.go
+++ b/server/datastore/mysql/statistics.go
@@ -48,6 +48,10 @@ func (ds *Datastore) ShouldSendStatistics(ctx context.Context, frequency time.Du
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "amount active users")
 		}
+		amountPolicyViolationDays, err := amountPolicyViolationDaysDB(ctx, ds.writer)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "amount policy violation days")
+		}
 		storedErrs, err := ctxerr.Aggregate(ctx)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "statistics error store")
@@ -67,6 +71,7 @@ func (ds *Datastore) ShouldSendStatistics(ctx context.Context, frequency time.Du
 		stats.SystemUsersEnabled = appConfig.Features.EnableHostUsers
 		stats.HostsStatusWebHookEnabled = appConfig.WebhookSettings.HostStatusWebhook.Enable
 		stats.NumWeeklyActiveUsers = amountWeeklyUsers
+		stats.NumWeeklyPolicyViolationDays = amountPolicyViolationDays
 		stats.HostsEnrolledByOperatingSystem = enrolledHostsByOS
 		stats.StoredErrors = storedErrs
 		stats.NumHostsNotResponding = amountHostsNotResponding

--- a/server/datastore/mysql/statistics_test.go
+++ b/server/datastore/mysql/statistics_test.go
@@ -116,6 +116,8 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// Initialize policy violation days for test
+	pvdJSON, err := json.Marshal(PolicyViolationDays{FailingHostCount: 5, TotalHostCount: 10})
+	require.NoError(t, err)
 	_, err = ds.writer.ExecContext(ctx, `
 		INSERT INTO
 			aggregated_stats (id, type, json_value, created_at, updated_at)
@@ -123,7 +125,7 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 		ON DUPLICATE KEY UPDATE
 			json_value = VALUES(json_value),
 			updated_at = VALUES(updated_at)
-	`, 0, "policy_violation_days", 5, time.Now().Add(-48*time.Hour), time.Now().Add(-7*24*time.Hour))
+	`, 0, "policy_violation_days", pvdJSON, time.Now().Add(-48*time.Hour), time.Now().Add(-7*24*time.Hour))
 	require.NoError(t, err)
 
 	require.NoError(t, err)
@@ -158,7 +160,8 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	assert.Equal(t, stats.VulnDetectionEnabled, false)
 	assert.Equal(t, stats.HostsStatusWebHookEnabled, true)
 	assert.Equal(t, stats.NumWeeklyActiveUsers, 1)
-	assert.Equal(t, stats.NumWeeklyPolicyViolationDays, 5)
+	assert.Equal(t, stats.NumWeeklyPolicyViolationDaysActual, 5)
+	assert.Equal(t, stats.NumWeeklyPolicyViolationDaysPossible, 10)
 	assert.Equal(t, string(stats.StoredErrors), `[{"count":10,"loc":["a","b","c"]}]`)
 
 	firstIdentifier := stats.AnonymousIdentifier
@@ -249,7 +252,7 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	assert.Equal(t, stats.NumUsers, 2)
 	assert.Equal(t, stats.NumWeeklyActiveUsers, 0)          // no active user since last stats were sent
 	require.Len(t, stats.HostsEnrolledByOperatingSystem, 3) // empty platform, rhel and macos
-	assert.Equal(t, stats.NumWeeklyPolicyViolationDays, 5)
+	assert.Equal(t, stats.NumWeeklyPolicyViolationDaysActual, 5)
 	require.ElementsMatch(t, []fleet.HostsCountByOSVersion{
 		{Version: "Fedora 35", NumEnrolled: 2},
 		{Version: "Fedora 36", NumEnrolled: 1},
@@ -286,7 +289,8 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	assert.Equal(t, stats.NumHostsEnrolled, 5)
 	assert.Equal(t, stats.NumUsers, 2)
 	assert.Equal(t, stats.NumWeeklyActiveUsers, 1)
-	assert.Equal(t, stats.NumWeeklyPolicyViolationDays, 0)
+	assert.Equal(t, stats.NumWeeklyPolicyViolationDaysActual, 0)
+	assert.Equal(t, stats.NumWeeklyPolicyViolationDaysPossible, 0)
 	assert.Equal(t, string(stats.StoredErrors), `[{"count":10,"loc":["a","b","c"]}]`)
 
 	// Add host to test hosts not responding stats

--- a/server/datastore/mysql/statistics_test.go
+++ b/server/datastore/mysql/statistics_test.go
@@ -113,6 +113,18 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 			OrgLogoURL: "localhost:8080/logo.png",
 		},
 	})
+	require.NoError(t, err)
+
+	// Initialize policy violation days for test
+	_, err = ds.writer.ExecContext(ctx, `
+		INSERT INTO
+			aggregated_stats (id, type, json_value, created_at, updated_at)
+		VALUES (?, ?, CAST(? AS JSON), ?, ?)
+		ON DUPLICATE KEY UPDATE
+			json_value = VALUES(json_value),
+			updated_at = VALUES(updated_at)
+	`, 0, "policy_violation_days", 5, time.Now().Add(-48*time.Hour), time.Now().Add(-7*24*time.Hour))
+	require.NoError(t, err)
 
 	require.NoError(t, err)
 	config.Features.EnableSoftwareInventory = false
@@ -146,6 +158,7 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	assert.Equal(t, stats.VulnDetectionEnabled, false)
 	assert.Equal(t, stats.HostsStatusWebHookEnabled, true)
 	assert.Equal(t, stats.NumWeeklyActiveUsers, 1)
+	assert.Equal(t, stats.NumWeeklyPolicyViolationDays, 5)
 	assert.Equal(t, string(stats.StoredErrors), `[{"count":10,"loc":["a","b","c"]}]`)
 
 	firstIdentifier := stats.AnonymousIdentifier
@@ -236,6 +249,7 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	assert.Equal(t, stats.NumUsers, 2)
 	assert.Equal(t, stats.NumWeeklyActiveUsers, 0)          // no active user since last stats were sent
 	require.Len(t, stats.HostsEnrolledByOperatingSystem, 3) // empty platform, rhel and macos
+	assert.Equal(t, stats.NumWeeklyPolicyViolationDays, 5)
 	require.ElementsMatch(t, []fleet.HostsCountByOSVersion{
 		{Version: "Fedora 35", NumEnrolled: 2},
 		{Version: "Fedora 36", NumEnrolled: 1},
@@ -256,6 +270,10 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	_, err = ds.NewSession(ctx, u1.ID, "session_key4")
 	require.NoError(t, err)
 
+	// CleanupStatistics resets policy violation days
+	err = ds.CleanupStatistics(ctx)
+	require.NoError(t, err)
+
 	// wait a bit and resend statistics
 	time.Sleep(1100 * time.Millisecond) // ensure the DB timestamp is not in the same second
 
@@ -268,6 +286,7 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	assert.Equal(t, stats.NumHostsEnrolled, 5)
 	assert.Equal(t, stats.NumUsers, 2)
 	assert.Equal(t, stats.NumWeeklyActiveUsers, 1)
+	assert.Equal(t, stats.NumWeeklyPolicyViolationDays, 0)
 	assert.Equal(t, string(stats.StoredErrors), `[{"count":10,"loc":["a","b","c"]}]`)
 
 	// Add host to test hosts not responding stats

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -490,10 +490,10 @@ type Datastore interface {
 	// policy violation day is added for each policy that a host is failing as of the time the count
 	// is incremented. The count only increments once per 24-hour interval. If the interval has not
 	// elapsed, IncrementPolicyViolationDays returns nil without incrementing the count.
-	IncrementPolicyViolationDays(ctx context.Context, now time.Time) error
+	IncrementPolicyViolationDays(ctx context.Context) error
 	// InitializePolicyViolationDays sets the aggregated count of policy violation days to zero. If
 	// a record of the count already exists, its `created_at` timestamp is updated to the current timestamp.
-	InitializePolicyViolationDays(ctx context.Context, now time.Time) error
+	InitializePolicyViolationDays(ctx context.Context) error
 
 	///////////////////////////////////////////////////////////////////////////////
 	// Locking

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -483,6 +483,14 @@ type Datastore interface {
 	TeamPolicy(ctx context.Context, teamID uint, policyID uint) (*Policy, error)
 
 	CleanupPolicyMembership(ctx context.Context, now time.Time) error
+	// IncrementPolicyViolationDays increments the aggregate count of policy violation days. One
+	// policy violation day is added for each policy that a host is failing as of the time the count
+	// is incremented. The count only increments once per 24-hour interval. If the interval has not
+	// elapsed, IncrementPolicyViolationDays returns nil without incrementing the count.
+	IncrementPolicyViolationDays(ctx context.Context, now time.Time) error
+	// InitializePolicyViolationDays sets the aggregated count of policy violation days to zero. If
+	// a record of the count already exists, its `created_at` timestamp is updated to the current timestamp.
+	InitializePolicyViolationDays(ctx context.Context, now time.Time) error
 
 	///////////////////////////////////////////////////////////////////////////////
 	// Locking

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -437,6 +437,9 @@ type Datastore interface {
 
 	ShouldSendStatistics(ctx context.Context, frequency time.Duration, config config.FleetConfig, license *LicenseInfo) (StatisticsPayload, bool, error)
 	RecordStatisticsSent(ctx context.Context) error
+	// CleanupStatistics executes cleanup tasks to be performed upon successful transmission of
+	// statistics.
+	CleanupStatistics(ctx context.Context) error
 
 	///////////////////////////////////////////////////////////////////////////////
 	// GlobalPoliciesStore

--- a/server/fleet/statistics.go
+++ b/server/fleet/statistics.go
@@ -6,20 +6,24 @@ import (
 )
 
 type StatisticsPayload struct {
-	AnonymousIdentifier            string                             `json:"anonymousIdentifier"`
-	FleetVersion                   string                             `json:"fleetVersion"`
-	LicenseTier                    string                             `json:"licenseTier"`
-	Organization                   string                             `json:"organization"`
-	NumHostsEnrolled               int                                `json:"numHostsEnrolled"`
-	NumUsers                       int                                `json:"numUsers"`
-	NumTeams                       int                                `json:"numTeams"`
-	NumPolicies                    int                                `json:"numPolicies"`
-	NumLabels                      int                                `json:"numLabels"`
-	SoftwareInventoryEnabled       bool                               `json:"softwareInventoryEnabled"`
-	VulnDetectionEnabled           bool                               `json:"vulnDetectionEnabled"`
-	SystemUsersEnabled             bool                               `json:"systemUsersEnabled"`
-	HostsStatusWebHookEnabled      bool                               `json:"hostsStatusWebHookEnabled"`
-	NumWeeklyActiveUsers           int                                `json:"numWeeklyActiveUsers"`
+	AnonymousIdentifier       string `json:"anonymousIdentifier"`
+	FleetVersion              string `json:"fleetVersion"`
+	LicenseTier               string `json:"licenseTier"`
+	Organization              string `json:"organization"`
+	NumHostsEnrolled          int    `json:"numHostsEnrolled"`
+	NumUsers                  int    `json:"numUsers"`
+	NumTeams                  int    `json:"numTeams"`
+	NumPolicies               int    `json:"numPolicies"`
+	NumLabels                 int    `json:"numLabels"`
+	SoftwareInventoryEnabled  bool   `json:"softwareInventoryEnabled"`
+	VulnDetectionEnabled      bool   `json:"vulnDetectionEnabled"`
+	SystemUsersEnabled        bool   `json:"systemUsersEnabled"`
+	HostsStatusWebHookEnabled bool   `json:"hostsStatusWebHookEnabled"`
+	NumWeeklyActiveUsers      int    `json:"numWeeklyActiveUsers"`
+	// NumWeeklyPolicyViolationDays is an aggregate count of policy violation days. One
+	// policy violation day is added for each policy that a host is failing as of the time the count
+	// is incremented. The count increments once per 24-hour interval and resets each week.
+	NumWeeklyPolicyViolationDays   int                                `json:"numWeeklyPolicyViolationDays"`
 	HostsEnrolledByOperatingSystem map[string][]HostsCountByOSVersion `json:"hostsEnrolledByOperatingSystem"`
 	StoredErrors                   json.RawMessage                    `json:"storedErrors"`
 	// NumHostsNotResponding is a count of hosts that connect to Fleet successfully but fail to submit results for distributed queries.

--- a/server/fleet/statistics.go
+++ b/server/fleet/statistics.go
@@ -20,12 +20,17 @@ type StatisticsPayload struct {
 	SystemUsersEnabled        bool   `json:"systemUsersEnabled"`
 	HostsStatusWebHookEnabled bool   `json:"hostsStatusWebHookEnabled"`
 	NumWeeklyActiveUsers      int    `json:"numWeeklyActiveUsers"`
-	// NumWeeklyPolicyViolationDays is an aggregate count of policy violation days. One
+	// NumWeeklyPolicyViolationDaysActual is an aggregate count of actual policy violation days. One
 	// policy violation day is added for each policy that a host is failing as of the time the count
 	// is incremented. The count increments once per 24-hour interval and resets each week.
-	NumWeeklyPolicyViolationDays   int                                `json:"numWeeklyPolicyViolationDays"`
-	HostsEnrolledByOperatingSystem map[string][]HostsCountByOSVersion `json:"hostsEnrolledByOperatingSystem"`
-	StoredErrors                   json.RawMessage                    `json:"storedErrors"`
+	NumWeeklyPolicyViolationDaysActual int `json:"numWeeklyPolicyViolationDaysActual"`
+	// NumWeeklyPolicyViolationDaysActual is an aggregate count of possible policy violation
+	// days. The count is incremented by the organization's total number of policies
+	// mulitplied by the total number of hosts as of the time the count is incremented. The count
+	// increments once per 24-hour interval and resets each week.
+	NumWeeklyPolicyViolationDaysPossible int                                `json:"numWeeklyPolicyViolationDaysPossible"`
+	HostsEnrolledByOperatingSystem       map[string][]HostsCountByOSVersion `json:"hostsEnrolledByOperatingSystem"`
+	StoredErrors                         json.RawMessage                    `json:"storedErrors"`
 	// NumHostsNotResponding is a count of hosts that connect to Fleet successfully but fail to submit results for distributed queries.
 	NumHostsNotResponding int `json:"numHostsNotResponding"`
 }

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -381,6 +381,10 @@ type TeamPolicyFunc func(ctx context.Context, teamID uint, policyID uint) (*flee
 
 type CleanupPolicyMembershipFunc func(ctx context.Context, now time.Time) error
 
+type IncrementPolicyViolationDaysFunc func(ctx context.Context, now time.Time) error
+
+type InitializePolicyViolationDaysFunc func(ctx context.Context, now time.Time) error
+
 type LockFunc func(ctx context.Context, name string, owner string, expiration time.Duration) (bool, error)
 
 type UnlockFunc func(ctx context.Context, name string, owner string) error
@@ -1029,6 +1033,12 @@ type DataStore struct {
 
 	CleanupPolicyMembershipFunc        CleanupPolicyMembershipFunc
 	CleanupPolicyMembershipFuncInvoked bool
+
+	IncrementPolicyViolationDaysFunc        IncrementPolicyViolationDaysFunc
+	IncrementPolicyViolationDaysFuncInvoked bool
+
+	InitializePolicyViolationDaysFunc        InitializePolicyViolationDaysFunc
+	InitializePolicyViolationDaysFuncInvoked bool
 
 	LockFunc        LockFunc
 	LockFuncInvoked bool
@@ -2093,6 +2103,16 @@ func (s *DataStore) TeamPolicy(ctx context.Context, teamID uint, policyID uint) 
 func (s *DataStore) CleanupPolicyMembership(ctx context.Context, now time.Time) error {
 	s.CleanupPolicyMembershipFuncInvoked = true
 	return s.CleanupPolicyMembershipFunc(ctx, now)
+}
+
+func (s *DataStore) IncrementPolicyViolationDays(ctx context.Context, now time.Time) error {
+	s.IncrementPolicyViolationDaysFuncInvoked = true
+	return s.IncrementPolicyViolationDaysFunc(ctx, now)
+}
+
+func (s *DataStore) InitializePolicyViolationDays(ctx context.Context, now time.Time) error {
+	s.InitializePolicyViolationDaysFuncInvoked = true
+	return s.InitializePolicyViolationDaysFunc(ctx, now)
 }
 
 func (s *DataStore) Lock(ctx context.Context, name string, owner string, expiration time.Duration) (bool, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -383,9 +383,9 @@ type TeamPolicyFunc func(ctx context.Context, teamID uint, policyID uint) (*flee
 
 type CleanupPolicyMembershipFunc func(ctx context.Context, now time.Time) error
 
-type IncrementPolicyViolationDaysFunc func(ctx context.Context, now time.Time) error
+type IncrementPolicyViolationDaysFunc func(ctx context.Context) error
 
-type InitializePolicyViolationDaysFunc func(ctx context.Context, now time.Time) error
+type InitializePolicyViolationDaysFunc func(ctx context.Context) error
 
 type LockFunc func(ctx context.Context, name string, owner string, expiration time.Duration) (bool, error)
 
@@ -2115,14 +2115,14 @@ func (s *DataStore) CleanupPolicyMembership(ctx context.Context, now time.Time) 
 	return s.CleanupPolicyMembershipFunc(ctx, now)
 }
 
-func (s *DataStore) IncrementPolicyViolationDays(ctx context.Context, now time.Time) error {
+func (s *DataStore) IncrementPolicyViolationDays(ctx context.Context) error {
 	s.IncrementPolicyViolationDaysFuncInvoked = true
-	return s.IncrementPolicyViolationDaysFunc(ctx, now)
+	return s.IncrementPolicyViolationDaysFunc(ctx)
 }
 
-func (s *DataStore) InitializePolicyViolationDays(ctx context.Context, now time.Time) error {
+func (s *DataStore) InitializePolicyViolationDays(ctx context.Context) error {
 	s.InitializePolicyViolationDaysFuncInvoked = true
-	return s.InitializePolicyViolationDaysFunc(ctx, now)
+	return s.InitializePolicyViolationDaysFunc(ctx)
 }
 
 func (s *DataStore) Lock(ctx context.Context, name string, owner string, expiration time.Duration) (bool, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -339,6 +339,8 @@ type ShouldSendStatisticsFunc func(ctx context.Context, frequency time.Duration,
 
 type RecordStatisticsSentFunc func(ctx context.Context) error
 
+type CleanupStatisticsFunc func(ctx context.Context) error
+
 type ApplyPolicySpecsFunc func(ctx context.Context, authorID uint, specs []*fleet.PolicySpec) error
 
 type NewGlobalPolicyFunc func(ctx context.Context, authorID *uint, args fleet.PolicyPayload) (*fleet.Policy, error)
@@ -970,6 +972,9 @@ type DataStore struct {
 
 	RecordStatisticsSentFunc        RecordStatisticsSentFunc
 	RecordStatisticsSentFuncInvoked bool
+
+	CleanupStatisticsFunc        CleanupStatisticsFunc
+	CleanupStatisticsFuncInvoked bool
 
 	ApplyPolicySpecsFunc        ApplyPolicySpecsFunc
 	ApplyPolicySpecsFuncInvoked bool
@@ -1998,6 +2003,11 @@ func (s *DataStore) ShouldSendStatistics(ctx context.Context, frequency time.Dur
 func (s *DataStore) RecordStatisticsSent(ctx context.Context) error {
 	s.RecordStatisticsSentFuncInvoked = true
 	return s.RecordStatisticsSentFunc(ctx)
+}
+
+func (s *DataStore) CleanupStatistics(ctx context.Context) error {
+	s.CleanupStatisticsFuncInvoked = true
+	return s.CleanupStatisticsFunc(ctx)
 }
 
 func (s *DataStore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs []*fleet.PolicySpec) error {


### PR DESCRIPTION
Issue #6027

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- ~~Documented any permissions changes~~
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- ~~Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~~
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

