### PR TITLE
Fleet UI: Fix mdm enrollment status api call

### DIFF
--- a/changes/bug-8215-mdm-enrollment-status
+++ b/changes/bug-8215-mdm-enrollment-status
@@ -1,0 +1,1 @@
+- Fixed host filters by mdm enrollment status

--- a/frontend/utilities/url/index.ts
+++ b/frontend/utilities/url/index.ts
@@ -59,7 +59,9 @@ export const reconcileMutuallyExclusiveHostParams = (
     case !!policyId:
       return { policy_id: policyId, policy_response: policyResponse };
     case !!mdmId:
-      return { mdm_id: mdmId, mdm_status: mdmEnrollmentStatus };
+      return { mdm_id: mdmId };
+    case !!mdmEnrollmentStatus:
+      return { mdm_enrollment_status: mdmEnrollmentStatus };
     case !!munkiIssueId:
       return { munki_issue_id: munkiIssueId };
     case !!softwareId:


### PR DESCRIPTION
Cerra #8215 

**Fix**
- API call was calling mdm_status which is invalid so it removed it, not mdm_enrollment_status which is valid

**Screenshot of fix** (See `mdm_enrollment_status` in API calls to `hosts` and `count`)
<img width="1322" alt="Screen Shot 2022-10-13 at 5 12 26 PM" src="https://user-images.githubusercontent.com/71795832/195711724-8bfc9ab1-3dd1-4063-b722-6750667e3ff3.png">

Note: We need a good way to e2e test mdm

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
 