### PR TITLE
Fleet UI: Fix tooltip width to not be wider than column

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -290,7 +290,7 @@ const allHostTableHeaders: IDataColumn[] = [
       const titleWithToolTip = (
         <TooltipWrapper
           tipContent={`
-            The last time the host reported vitals.
+            The last time the host<br/> reported vitals.
           `}
         >
           Last fetched
@@ -317,7 +317,7 @@ const allHostTableHeaders: IDataColumn[] = [
       const titleWithToolTip = (
         <TooltipWrapper
           tipContent={`
-            The last time the host was online.
+            The last time the <br/>host was online.
           `}
         >
           Last seen


### PR DESCRIPTION
Cerra #8106 

**Fix**
- Tried to make the tooltip widen the column if it's the last column and also tried to get tooltip to go off the table and not affect the scroll on the table, neither I could get working
- Made tooltips two lines so it's not wider than the column so there's no weird scroll on the table when it's the last column

**Screenshot**
<img width="340" alt="Screen Shot 2022-10-13 at 6 04 23 PM" src="https://user-images.githubusercontent.com/71795832/195719887-bf96cd91-4a56-4cd5-90e1-799c48ced0a5.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.


- [x] Manual QA for all new/changed functionality
