### PR TITLE
Fix undetected missing migrations

### DIFF
--- a/changes/fix-undetected-missing-migrations
+++ b/changes/fix-undetected-missing-migrations
@@ -1,0 +1,1 @@
+- Fixed undetected missing migrations in the cases where the are also unknown migrations.

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -570,21 +570,26 @@ func compareMigrations(knownTable goose.Migrations, knownData goose.Migrations, 
 		}
 	}
 
+	//
 	// The following code assumes there cannot be migrations missing on
 	// "table" and database being ahead on "data" (and vice-versa).
-	if len(unknownTable) > 0 || len(unknownData) > 0 {
+	//
+
+	// Check for missing migrations first, as these are more important
+	// to detect than the unknown migrations.
+	if len(missingTable) > 0 || len(missingData) > 0 {
 		return &fleet.MigrationStatus{
-			StatusCode:   fleet.UnknownMigrations,
-			UnknownTable: unknownTable,
-			UnknownData:  unknownData,
+			StatusCode:   fleet.SomeMigrationsCompleted,
+			MissingTable: missingTable,
+			MissingData:  missingData,
 		}
 	}
 
-	// len(missingTable) > 0 || len(missingData) > 0
+	// len(unknownTable) > 0 || len(unknownData) > 0
 	return &fleet.MigrationStatus{
-		StatusCode:   fleet.SomeMigrationsCompleted,
-		MissingTable: missingTable,
-		MissingData:  missingData,
+		StatusCode:   fleet.UnknownMigrations,
+		UnknownTable: unknownTable,
+		UnknownData:  unknownData,
 	}
 }
 


### PR DESCRIPTION
This issue was reproduced in dogfood, where we had (due to internal tests) an unknown (unreleased) migration.