### PR TITLE
fix a bug causing features to be false

### DIFF
--- a/changes/team-features-bug
+++ b/changes/team-features-bug
@@ -1,0 +1,1 @@
+* Fixed a bug where if a team didn't have a `config.features` settings and was edited via the UI, the both `features.enable_host_users` and `features.enable_software_inventory` would be `false` instad of the global default.

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -47,18 +47,7 @@ func (ds *Datastore) NewTeam(ctx context.Context, team *fleet.Team) (*fleet.Team
 }
 
 func (ds *Datastore) Team(ctx context.Context, tid uint) (*fleet.Team, error) {
-	t, err := teamDB(ctx, ds.reader, tid)
-	if err != nil {
-		return nil, err
-	}
-
-	features, err := ds.TeamFeatures(ctx, tid)
-	if err != nil {
-		return nil, err
-	}
-	t.Config.Features = *features
-
-	return t, nil
+	return teamDB(ctx, ds.reader, tid)
 }
 
 func teamDB(ctx context.Context, q sqlx.QueryerContext, tid uint) (*fleet.Team, error) {

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -47,7 +47,18 @@ func (ds *Datastore) NewTeam(ctx context.Context, team *fleet.Team) (*fleet.Team
 }
 
 func (ds *Datastore) Team(ctx context.Context, tid uint) (*fleet.Team, error) {
-	return teamDB(ctx, ds.reader, tid)
+	t, err := teamDB(ctx, ds.reader, tid)
+	if err != nil {
+		return nil, err
+	}
+
+	features, err := ds.TeamFeatures(ctx, tid)
+	if err != nil {
+		return nil, err
+	}
+	t.Config.Features = *features
+
+	return t, nil
 }
 
 func teamDB(ctx context.Context, q sqlx.QueryerContext, tid uint) (*fleet.Team, error) {
@@ -72,6 +83,9 @@ func teamDB(ctx context.Context, q sqlx.QueryerContext, tid uint) (*fleet.Team, 
 		return nil, err
 	}
 	if err := loadHostCountForTeamDB(ctx, q, team); err != nil {
+		return nil, err
+	}
+	if err := loadFeaturesForTeamDB(ctx, q, team); err != nil {
 		return nil, err
 	}
 
@@ -128,6 +142,9 @@ func (ds *Datastore) TeamByName(ctx context.Context, name string) (*fleet.Team, 
 	if err := loadHostCountForTeamDB(ctx, ds.reader, team); err != nil {
 		return nil, err
 	}
+	if err := loadFeaturesForTeamDB(ctx, ds.reader, team); err != nil {
+		return nil, err
+	}
 
 	return team, nil
 }
@@ -158,6 +175,15 @@ func loadHostCountForTeamDB(ctx context.Context, q sqlx.QueryerContext, team *fl
 		return ctxerr.Wrap(ctx, err, "load HostsCount for team")
 	}
 
+	return nil
+}
+
+func loadFeaturesForTeamDB(ctx context.Context, q sqlx.QueryerContext, team *fleet.Team) error {
+	features, err := teamFeaturesDB(ctx, q, team.ID)
+	if err != nil {
+		return err
+	}
+	team.Config.Features = *features
 	return nil
 }
 
@@ -323,9 +349,13 @@ func (ds *Datastore) TeamAgentOptions(ctx context.Context, tid uint) (*json.RawM
 
 // TeamFeatures loads the features enabled for a team.
 func (ds *Datastore) TeamFeatures(ctx context.Context, tid uint) (*fleet.Features, error) {
+	return teamFeaturesDB(ctx, ds.reader, tid)
+}
+
+func teamFeaturesDB(ctx context.Context, q sqlx.QueryerContext, tid uint) (*fleet.Features, error) {
 	sql := `SELECT config->'$.features' as features FROM teams WHERE id = ?`
 	var raw *json.RawMessage
-	if err := sqlx.GetContext(ctx, ds.reader, &raw, sql, tid); err != nil {
+	if err := sqlx.GetContext(ctx, q, &raw, sql, tid); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get team config features")
 	}
 

--- a/server/datastore/mysql/teams_test.go
+++ b/server/datastore/mysql/teams_test.go
@@ -81,7 +81,7 @@ func testTeamsGetSetDelete(t *testing.T, ds *Datastore) {
 			require.NoError(t, err)
 			require.Empty(t, newP.Teams)
 
-			team, err = ds.TeamByName(context.Background(), tt.name)
+			_, err = ds.TeamByName(context.Background(), tt.name)
 			require.Error(t, err)
 
 			require.NoError(t, ds.DeletePack(context.Background(), newP.Name))
@@ -453,10 +453,20 @@ func testTeamsFeatures(t *testing.T, ds *Datastore) {
 			)
 			return err
 		})
+
 		features, err := ds.TeamFeatures(ctx, team.ID)
 		require.NoError(t, err)
-
 		assert.Equal(t, &defaultFeatures, features)
+
+		// retrieving a team also returns a team with the default
+		// features
+		team, err = ds.Team(ctx, team.ID)
+		require.NoError(t, err)
+		assert.Equal(t, defaultFeatures, team.Config.Features)
+
+		team, err = ds.TeamByName(ctx, team.Name)
+		require.NoError(t, err)
+		assert.Equal(t, defaultFeatures, team.Config.Features)
 	})
 
 	t.Run("NULL config.features in the database", func(t *testing.T) {
@@ -470,10 +480,20 @@ func testTeamsFeatures(t *testing.T, ds *Datastore) {
 			)
 			return err
 		})
+
 		features, err := ds.TeamFeatures(ctx, team.ID)
 		require.NoError(t, err)
-
 		assert.Equal(t, &defaultFeatures, features)
+
+		// retrieving a team also returns a team with the default
+		// features
+		team, err = ds.Team(ctx, team.ID)
+		require.NoError(t, err)
+		assert.Equal(t, defaultFeatures, team.Config.Features)
+
+		team, err = ds.TeamByName(ctx, team.Name)
+		require.NoError(t, err)
+		assert.Equal(t, defaultFeatures, team.Config.Features)
 	})
 
 	t.Run("saves and retrieves configs", func(t *testing.T) {


### PR DESCRIPTION
Related to https://github.com/fleetdm/fleet/issues/8010 and https://github.com/fleetdm/fleet/issues/8013 this prevents a bug that happens when:

1. A team doesn't have a `config.features` key in the JSON stored in the table or `config` is `NULL`
2. The team is edited from the UI

All `config.features` will default to `false`, which can be a problem if your global settings are `true` for both (which is the default)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
