### PR TITLE
terraform/gcp: make prefix use consistent, use new database sizing, and refer to DNS zone

### DIFF
--- a/infrastructure/dogfood/terraform/gcp/loadbalancer.tf
+++ b/infrastructure/dogfood/terraform/gcp/loadbalancer.tf
@@ -1,5 +1,5 @@
 resource "google_dns_managed_zone" "default" {
-  dns_name = var.dns_name
+  dns_name = var.dns_zone
   name     = "${var.prefix}-zone"
   dnssec_config {
     state = "on"
@@ -56,3 +56,4 @@ module "lb-http" {
     }
   }
 }
+

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -59,7 +59,7 @@ variable "project_id" {
 }
 
 variable "prefix" {
-  default     = "fleet-"
+  default     = "fleet"
   description = "prefix resources with this string"
 }
 

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -20,7 +20,7 @@ variable "db_tier" {
 }
 
 variable "db_version" {
-  default = "MYSQL_5_7"
+  default = "MYSQL_8_0"
 }
 
 variable "fleet_cpu" {

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -16,7 +16,7 @@ variable "db_name" {
 }
 
 variable "db_tier" {
-  default = "db-n1-standard-1"
+  default = "db-custom-1-3840"
 }
 
 variable "db_version" {

--- a/infrastructure/dogfood/terraform/gcp/vpc.tf
+++ b/infrastructure/dogfood/terraform/gcp/vpc.tf
@@ -7,7 +7,7 @@ module "vpc" {
   source       = "terraform-google-modules/network/google"
   version      = "~> 4.1.0"
   project_id   = var.project_id
-  network_name = "${var.prefix}network"
+  network_name = "${var.prefix}-network"
   mtu          = 1460
 
   subnets = [


### PR DESCRIPTION
This pull request contains a number of small commits changing things I found while configuring Fleet on GCP. Most of these changes are modernization, but 288c437 fixes a bug around the DNS zone. Changes are broken out by commit so let me know if any one of these don't make sense to land.

# Checklist for submitter

N/A. None of the items in the list are relevant to this change.
