### PR TITLE
Use the same HTTP server config as the production server in tests

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -646,8 +645,6 @@ the way that the Fleet server works.
 				}
 			}
 
-			defaultWritetimeout := 40 * time.Second
-			writeTimeout := defaultWritetimeout
 			// The "GET /api/latest/fleet/queries/run" API requires
 			// WriteTimeout to be higher than the live query rest period
 			// (otherwise the response is not sent back to the client).
@@ -655,9 +652,6 @@ the way that the Fleet server works.
 			// We add 10s to the live query rest period to allow the writing
 			// of the response.
 			liveQueryRestPeriod += 10 * time.Second
-			if liveQueryRestPeriod > writeTimeout {
-				writeTimeout = liveQueryRestPeriod
-			}
 
 			// Create the handler based on whether tracing should be there
 			var handler http.Handler
@@ -667,17 +661,9 @@ the way that the Fleet server works.
 				handler = launcher.Handler(rootMux)
 			}
 
-			srv := &http.Server{
-				Addr:              config.Server.Address,
-				Handler:           handler,
-				ReadTimeout:       25 * time.Second,
-				WriteTimeout:      writeTimeout,
-				ReadHeaderTimeout: 5 * time.Second,
-				IdleTimeout:       5 * time.Minute,
-				MaxHeaderBytes:    1 << 18, // 0.25 MB (262144 bytes)
-				BaseContext: func(l net.Listener) context.Context {
-					return ctx
-				},
+			srv := config.Server.DefaultHTTPServer(ctx, handler)
+			if liveQueryRestPeriod > srv.WriteTimeout {
+				srv.WriteTimeout = liveQueryRestPeriod
 			}
 			srv.SetKeepAlivesEnabled(config.Server.Keepalive)
 			errs := make(chan error, 2)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1,11 +1,14 @@
 package config
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -85,6 +88,21 @@ type ServerConfig struct {
 	URLPrefix      string `yaml:"url_prefix"`
 	Keepalive      bool   `yaml:"keepalive"`
 	SandboxEnabled bool   `yaml:"sandbox_enabled"`
+}
+
+func (s *ServerConfig) DefaultHTTPServer(ctx context.Context, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              s.Address,
+		Handler:           handler,
+		ReadTimeout:       25 * time.Second,
+		WriteTimeout:      40 * time.Second,
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       5 * time.Minute,
+		MaxHeaderBytes:    1 << 18, // 0.25 MB (262144 bytes)
+		BaseContext: func(l net.Listener) context.Context {
+			return ctx
+		},
+	}
 }
 
 // AuthConfig defines configs related to user authorization

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -76,7 +76,7 @@ func (s *integrationTestSuite) TestSlowOsqueryHost() {
 		server.Close()
 	}()
 
-	req, err := http.NewRequest("POST", s.server.URL+"/api/v1/osquery/distributed/write", &slowReader{})
+	req, err := http.NewRequest("POST", server.URL+"/api/v1/osquery/distributed/write", &slowReader{})
 	require.NoError(t, err)
 
 	client := fleethttp.NewClient()

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -64,9 +64,16 @@ func (s *slowReader) Read(p []byte) (n int, err error) {
 
 func (s *integrationTestSuite) TestSlowOsqueryHost() {
 	t := s.T()
-	s.server.Config.ReadTimeout = 2 * time.Second
+	_, server := RunServerForTestsWithDS(
+		t,
+		s.ds,
+		&TestServerOpts{
+			SkipCreateTestUsers: true,
+			ServerConfig:        &http.Server{ReadTimeout: 2 * time.Second},
+		},
+	)
 	defer func() {
-		s.server.Config.ReadTimeout = 25 * time.Second
+		server.Close()
 	}()
 
 	req, err := http.NewRequest("POST", s.server.URL+"/api/v1/osquery/distributed/write", &slowReader{})

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -69,7 +69,7 @@ func (s *integrationTestSuite) TestSlowOsqueryHost() {
 		s.ds,
 		&TestServerOpts{
 			SkipCreateTestUsers: true,
-			ServerConfig:        &http.Server{ReadTimeout: 2 * time.Second},
+			HTTPServerConfig:    &http.Server{ReadTimeout: 2 * time.Second},
 		},
 	)
 	defer func() {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -69,7 +69,8 @@ func (s *integrationTestSuite) TestSlowOsqueryHost() {
 		s.ds,
 		&TestServerOpts{
 			SkipCreateTestUsers: true,
-			HTTPServerConfig:    &http.Server{ReadTimeout: 2 * time.Second},
+			//nolint:gosec // G112: server is just run for testing this explicit config.
+			HTTPServerConfig: &http.Server{ReadTimeout: 2 * time.Second},
 		},
 	)
 	defer func() {

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -226,7 +226,7 @@ type TestServerOpts struct {
 	MDMStorage          nanomdm_storage.AllStorage
 	DEPStorage          nanodep_storage.AllStorage
 	MDMPusher           nanomdm_push.Pusher
-	ServerConfig        *http.Server
+	HTTPServerConfig    *http.Server
 }
 
 func RunServerForTestsWithDS(t *testing.T, ds fleet.Datastore, opts ...*TestServerOpts) (map[string]fleet.User, *httptest.Server) {
@@ -255,8 +255,8 @@ func RunServerForTestsWithDS(t *testing.T, ds fleet.Datastore, opts ...*TestServ
 	r := MakeHandler(svc, cfg, logger, limitStore, WithLoginRateLimit(throttled.PerMin(100)))
 	server := httptest.NewUnstartedServer(r)
 	server.Config = cfg.Server.DefaultHTTPServer(context.Background(), r)
-	if len(opts) > 0 && opts[0].ServerConfig != nil {
-		server.Config = opts[0].ServerConfig
+	if len(opts) > 0 && opts[0].HTTPServerConfig != nil {
+		server.Config = opts[0].HTTPServerConfig
 		// make sure we use the application handler we just created
 		server.Config.Handler = r
 	}

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/WatchBeam/clock"
 	eeservice "github.com/fleetdm/fleet/v4/ee/server/service"
@@ -227,6 +226,7 @@ type TestServerOpts struct {
 	MDMStorage          nanomdm_storage.AllStorage
 	DEPStorage          nanodep_storage.AllStorage
 	MDMPusher           nanomdm_push.Pusher
+	ServerConfig        *http.Server
 }
 
 func RunServerForTestsWithDS(t *testing.T, ds fleet.Datastore, opts ...*TestServerOpts) (map[string]fleet.User, *httptest.Server) {
@@ -254,8 +254,12 @@ func RunServerForTestsWithDS(t *testing.T, ds fleet.Datastore, opts ...*TestServ
 	limitStore, _ := memstore.New(0)
 	r := MakeHandler(svc, cfg, logger, limitStore, WithLoginRateLimit(throttled.PerMin(100)))
 	server := httptest.NewUnstartedServer(r)
-	// Set the same ReadTimeout as the actual server
-	server.Config.ReadTimeout = 25 * time.Second
+	server.Config = cfg.Server.DefaultHTTPServer(context.Background(), r)
+	if len(opts) > 0 && opts[0].ServerConfig != nil {
+		server.Config = opts[0].ServerConfig
+		// make sure we use the application handler we just created
+		server.Config.Handler = r
+	}
 	server.Start()
 	t.Cleanup(func() {
 		server.Close()


### PR DESCRIPTION
This abstracts the default config we use to run the server into a function so it can be used in tests to run an HTTP server using the same configuration.

Additionally, this fixes a [data race in tests][1], as an HTTP server configuration [can't be changed once you call `server.Start()`][2]

[1]: https://github.com/fleetdm/fleet/actions/runs/3262426635/jobs/5359547773#step:9:10243
[2]:
https://cs.opensource.google/go/go/+/refs/tags/go1.19.2:src/net/http/httptest/server.go;l=40;drc=19309779ac5e2f5a2fd3cbb34421dafb2855ac21

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
