### PR TITLE
Fix redirect of user resetting password

### DIFF
--- a/frontend/pages/LoginPage/LoginPage.tsx
+++ b/frontend/pages/LoginPage/LoginPage.tsx
@@ -74,10 +74,12 @@ const LoginPage = ({ router, location }: ILoginPageProps) => {
       }
     };
 
-    if (currentUser) {
-      router?.push(HOME);
-    } else {
+    if (!currentUser) {
       getSSO();
+    }
+
+    if (currentUser && !currentUser.force_password_reset) {
+      router?.push(HOME);
     }
 
     if (pageStatus && pageStatus in statusMessages) {


### PR DESCRIPTION
For #8245. This bug was introduced when another related bug was fixed at https://github.com/fleetdm/fleet/pull/8102/files. That fix correctly redirected logged-in users to the dashboard, but it did not consider what would happen to users that were on the reset password page.  
