### PR TITLE
Fix select dropdown highlighting on Firefox

### DIFF
--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -43,23 +43,22 @@
 }
 
 .Select {
-  .Select-control {
+  &.dropdown__select {
     border: 1px solid $ui-fleet-blue-15;
-    background-color: $ui-light-grey;
     border-radius: $border-radius;
-    height: 40px;
     transition: border-color 100ms;
-
+    height: 40px;
     &:hover {
       box-shadow: none;
       border: 1px solid $core-vibrant-blue;
     }
-
+  }
+  .Select-control {
+    background-color: $ui-light-grey;
+    border: 0;
     .Select-value {
       font-size: $small;
-      border-radius: 4px;
       background-color: $ui-off-white;
-      border: solid 1px $core-dark-blue-grey;
     }
   }
 
@@ -67,7 +66,6 @@
     font-size: $small;
     border-radius: $border-radius;
     background-color: $ui-off-white;
-    border: solid 1px $core-dark-blue-grey;
 
     .Select-value-icon {
       border: 0;
@@ -119,7 +117,7 @@
   }
 
   &.is-focused {
-    .Select-control {
+    &.dropdown__select {
       border: 1px solid $core-vibrant-blue;
     }
 

--- a/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
+++ b/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
@@ -33,9 +33,14 @@
     box-sizing: border-box;
     color: $core-fleet-black;
     font-weight: $regular;
+    transition: border-color 100ms;
 
     ::placeholder {
       color: $core-fleet-blue;
+    }
+
+    &:hover, &:focus {
+      border: 1px solid $core-vibrant-blue;
     }
 
     &:focus {

--- a/frontend/layouts/GatedLayout/_styles.scss
+++ b/frontend/layouts/GatedLayout/_styles.scss
@@ -2,4 +2,11 @@
     .flash-message {
         border: 0;
     }
+    a {
+        img {
+            height: 12px;
+            width: 12px;
+            margin-left: $pad-xsmall;
+        }
+    }
 }

--- a/frontend/layouts/GatedLayout/_styles.scss
+++ b/frontend/layouts/GatedLayout/_styles.scss
@@ -2,7 +2,7 @@
     .flash-message {
         border: 0;
     }
-    a {
+    a.external-link {
         img {
             height: 12px;
             width: 12px;

--- a/frontend/pages/ForgotPasswordPage/ForgotPasswordPage.tsx
+++ b/frontend/pages/ForgotPasswordPage/ForgotPasswordPage.tsx
@@ -58,6 +58,7 @@ const ForgotPasswordPage = () => {
               href="https://fleetdm.com/docs/using-fleet/fleetctl-cli#using-fleetctl-with-an-api-only-user?utm_medium=fleetui&utm_campaign=get-api-token"
               target="_blank"
               rel="noopener noreferrer"
+              className="external-link"
             >
               Password reset FAQ
               <img src={ExternalLinkIcon} alt="Open external link" />


### PR DESCRIPTION
For #7649 

Fixes hover border highlight of react select dropdown in Firefox. 

I also applied the hover border color change to the login page input elements. 

I also corrected the size of the external link icon on the forgot password confirmation screen (it was too large): 

![Image](https://user-images.githubusercontent.com/2495927/196261576-c63c2144-b9da-4859-997e-9170cf1f5093.png)

