### PR TITLE
add concurrency to ci

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,51 @@
+# Github Actions
+
+Fleet uses Github Actions for continuous integration (CI). This document describes best practices
+and at patterns for writing and maintaining Fleet's Github Actions workflows.
+
+## Bash
+
+By default, Github Actions sets the shell to `bash -e` for linux and MacOS runners. To help write
+safer bash scripts in run jobs and avoid common issues, override the default by adding the following
+to the workflow file
+
+```
+defaults:
+  run:
+    # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+```
+
+By specifying the default shell to `bash`, some extra flags are set. The option `pipefail` changes
+the behaviour when using the pipe `|` operator such that if any command in a pipeline fails, that
+commands return code will be used a the return code for the whole pipeline. Consider the following
+example in `test-go.yaml`
+
+```
+    - name: Run Go Tests
+      run: |
+        # omitted ...
+          make test-go 2>&1 | tee /tmp/gotest.log
+```
+
+If the `pipefail` option was *not* set, this job would always succeed because `tee` would always
+return success. This is not the intended behavior.  Instead, we want the job to fail if `make
+test-go` fails.
+
+## Concurrency
+
+Github Action runners are limited. If a lot of workflows are queued, they will wait in pending until
+a runner becomes available. This has caused issue in the past where workflows take an excessively long
+time to start. To help with this issue, use the following in workflows
+
+```
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+```
+
+When a workflow is triggered via a pull request, it will cancel previous running workflows for that
+pull request. This is especially useful when changes are pushed to a pull request frequently.
+Manually triggered workflows, workflows that run on a schedule, and workflows triggered by pushes to
+`main` are unaffected.

--- a/.github/workflows/build-and-push-fleetctl-docker.yml
+++ b/.github/workflows/build-and-push-fleetctl-docker.yml
@@ -9,6 +9,11 @@ on:
         required: true
         type: string
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -7,6 +7,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,11 @@ on:
       - '**.ts'
       - '**.tsx'
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -10,6 +10,11 @@ on:
       - 'articles/**'
       - 'schema/**'
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,11 @@ on:
   schedule:
   - cron: '0 6 * * *' # Nightly 6AM UTC
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/dogfood-deploy.yml
+++ b/.github/workflows/dogfood-deploy.yml
@@ -7,6 +7,11 @@ on:
         description: 'The image tag wished to be deployed.'
         required: true
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -18,6 +18,11 @@ on:
       - '.github/workflows/fleet-and-orbit.yml'
   workflow_dispatch: # Manual
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/fleetctl-preview-latest.yml
+++ b/.github/workflows/fleetctl-preview-latest.yml
@@ -27,6 +27,16 @@ on:
       - 'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml'
   workflow_dispatch: # Manual
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
 permissions:
   contents: read
 
@@ -70,7 +80,6 @@ jobs:
       run: make fleetctl
 
     - name: Run fleetctl preview
-      shell: bash
       run: |
         ./build/fleetctl preview --std-query-lib-file-path $(pwd)/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
         sleep 10
@@ -83,7 +92,6 @@ jobs:
         # Copying logs, otherwise the upload-artifact action uploads the logs in a hidden folder (.fleet)
         cp ~/.fleet/preview/orbit.log orbit.log
         cp -r ~/.fleet/preview/logs osquery_result_status_logs
-      shell: bash
 
     - name: Upload logs
       if: always()

--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -1,11 +1,15 @@
-name: Test fleetctl preview
-
 # Tests the `fleetctl preview` command with latest npm released version of fleetctl.
+name: Test fleetctl preview
 
 on:
   workflow_dispatch: # Manual
   schedule:
   - cron: '0 2 * * *' # Nightly 2AM UTC
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/generate-desktop-targets.yml
+++ b/.github/workflows/generate-desktop-targets.yml
@@ -13,6 +13,11 @@ on:
       - '.github/workflows/generate-desktop-targets.yml'
   workflow_dispatch:
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/generate-osqueryd-targets.yml
+++ b/.github/workflows/generate-osqueryd-targets.yml
@@ -13,6 +13,11 @@ on:
       - '.github/workflows/generate-osqueryd-targets.yml'
   workflow_dispatch:
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,6 +13,11 @@ on:
       - '.github/workflows/golangci-lint.yml'
   workflow_dispatch: # Manual
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -5,6 +5,11 @@ on:
     tags:
       - 'fleet-*'
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/goreleaser-orbit.yaml
+++ b/.github/workflows/goreleaser-orbit.yaml
@@ -5,6 +5,11 @@ on:
    tags:
      - 'orbit-*'
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -2,6 +2,11 @@ name: Docker publish
 
 on: push
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,6 +11,11 @@ on:
   schedule:
   - cron: '0 2 * * *' # Nightly 2AM UTC
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/pr-helm.yaml
+++ b/.github/workflows/pr-helm.yaml
@@ -8,6 +8,11 @@ on:
     - '.github/scripts/helm-check-expected.sh'
     - 'tools/ci/helm-values/**'
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/push-osquery-perf-to-ecr.yml
+++ b/.github/workflows/push-osquery-perf-to-ecr.yml
@@ -18,6 +18,11 @@ on:
         required: true
         default: latest
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/release-helm.yaml
+++ b/.github/workflows/release-helm.yaml
@@ -5,6 +5,11 @@ on:
     types: [released] # don't trigger on pre-releases
   workflow_dispatch: # allow manual trigger
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -9,6 +9,11 @@ on:
   push:
     branches: [ main ]
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/test-db-changes.yml
+++ b/.github/workflows/test-db-changes.yml
@@ -12,13 +12,18 @@ on:
       - '.github/workflows/test-schema-changes.yml'
   workflow_dispatch: # Manual
 
-permissions:
-  contents: read
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
 
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
     shell: bash
+
+permissions:
+  contents: read
 
 jobs:
   test-db-changes:

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -19,6 +19,11 @@ on:
   schedule:
     - cron: '0 4 * * *'
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/test-native-tooling-packaging.yml
+++ b/.github/workflows/test-native-tooling-packaging.yml
@@ -21,6 +21,11 @@ on:
       - '.github/workflows/test-native-tooling-packaging.yml'
   workflow_dispatch: # Manual
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -23,6 +23,11 @@ on:
       - '.github/workflows/test-packaging.yml'
   workflow_dispatch: # Manual
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -8,6 +8,11 @@ on:
       - 'handbook/**'
       - 'schema/**'
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,11 @@ on:
       - webpack.config.js
       - tsconfig.json
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -11,6 +11,11 @@ on:
       - '**.tf'
   workflow_dispatch: # Manual dispatch
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/tfvalidate.yml
+++ b/.github/workflows/tfvalidate.yml
@@ -11,6 +11,11 @@ on:
       - '**.tf'
   workflow_dispatch: # Manual dispatch
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference

--- a/.github/workflows/update-certs.yml
+++ b/.github/workflows/update-certs.yml
@@ -5,6 +5,11 @@ on:
   schedule:
   - cron: '0 6 * * *' # Nightly 6AM UTC
 
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
 defaults:
   run:
     # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference


### PR DESCRIPTION
This changes github worflows so that pending/in progress ci runs are cancelled when a new workflow is triggered. This should help with the issue of running out of github runners and workflows spending a long time in the queue. This can be especially problematic when commits are pushed frequently to an open pr, which spawns a lot of workflow runs. 

To test, open a pr, and trigger workflows using

```
git commit --alow-empty -m "trigger ci" && git push
```

You should see that workflows are cancelled with the following annotation

<img width="1400" alt="Screen Shot 2022-10-17 at 4 46 48 PM" src="https://user-images.githubusercontent.com/39177923/196298015-161b12d9-beba-468d-b866-238498480e04.png">

This should not affect workflows triggered on `main`, as `github.head_ref` will be empty and will fallback to using the workflow run ID in the concurrency group name.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
