### PR TITLE
Fleet UI: Host table defaults to 100 hosts per page

### DIFF
--- a/changes/bug-8209-host-default-100-per-page
+++ b/changes/bug-8209-host-default-100-per-page
@@ -1,0 +1,1 @@
+* Fix host table to default to 100 hosts per page

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1676,7 +1676,7 @@ const ManageHostsPage = ({
         defaultSortDirection={
           (sortBy[0] && sortBy[0].direction) || DEFAULT_SORT_DIRECTION
         }
-        pageSize={100} // Default is 20
+        pageSize={100}
         actionButtonText={"Edit columns"}
         actionButtonIcon={EditColumnsIcon}
         actionButtonVariant={"text-icon"}

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1676,6 +1676,7 @@ const ManageHostsPage = ({
         defaultSortDirection={
           (sortBy[0] && sortBy[0].direction) || DEFAULT_SORT_DIRECTION
         }
+        pageSize={100} // Default is 20
         actionButtonText={"Edit columns"}
         actionButtonIcon={EditColumnsIcon}
         actionButtonVariant={"text-icon"}

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -172,7 +172,7 @@ export default {
   },
   loadHosts: ({
     page = 0,
-    perPage = 20,
+    perPage = 100,
     globalFilter,
     teamId,
     policyId,


### PR DESCRIPTION
Cerra #8209 

**Bug fix**
- Host table defaults to 100 hosts per page

**Screen recording**

https://user-images.githubusercontent.com/71795832/196440660-375a27c4-f99d-494e-84ec-c047fa3aeb91.mov


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality

