### PR TITLE
fix 500 when no software on device/:token page

### DIFF
--- a/changes/issue-8085-error-500-when-no-software-on-device
+++ b/changes/issue-8085-error-500-when-no-software-on-device
@@ -1,0 +1,1 @@
+- fixes 500 error issue on details/:token page when host has software.

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -98,7 +98,7 @@ const DeviceUserPage = ({
       onSuccess: (returnedHost: IHostResponse) => {
         setShowRefetchSpinner(returnedHost.host.refetch_requested);
         setIsPremiumTier(returnedHost.license.tier === "premium");
-        setHostSoftware(returnedHost.host.software);
+        setHostSoftware(returnedHost.host.software ?? []);
         setHost(returnedHost.host);
         setOrgLogoURL(returnedHost.org_logo_url);
         if (returnedHost?.host.refetch_requested) {


### PR DESCRIPTION
relates to #8085 

fixes 500 error issue on details/:token page when host has software.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).

- [x] Manual QA for all new/changed functionality

