### PR TITLE
Change all instances of hostname to display_name

### DIFF
--- a/frontend/interfaces/campaign.ts
+++ b/frontend/interfaces/campaign.ts
@@ -12,7 +12,7 @@ export default PropTypes.shape({
 });
 
 export interface ICampaignError {
-  host_hostname: string;
+  host_display_name: string;
   osquery_version: string;
   error: string;
 }

--- a/frontend/pages/policies/PolicyPage/components/PolicyQueriesErrorsTable/PolicyQueriesErrorsTableConfig.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyQueriesErrorsTable/PolicyQueriesErrorsTableConfig.tsx
@@ -73,7 +73,7 @@ const generateTableHeaders = (): IDataColumn[] => {
 const generateDataSet = memoize(
   (policyHostsErrorsList: ICampaignError[] = []): ICampaignError[] => {
     policyHostsErrorsList = policyHostsErrorsList.sort((a, b) =>
-      sortUtils.caseInsensitiveAsc(a.host_hostname, b.host_hostname)
+      sortUtils.caseInsensitiveAsc(a.host_display_name, b.host_display_name)
     );
     return policyHostsErrorsList;
   }

--- a/frontend/pages/policies/PolicyPage/components/PolicyQueriesErrorsTable/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyQueriesErrorsTable/_styles.scss
@@ -23,7 +23,7 @@
       padding: $pad-medium $pad-large;
     }
 
-    .host_hostname__header {
+    .host_display_name__header {
       width: 50%;
     }
   }

--- a/frontend/test/stubs.ts
+++ b/frontend/test/stubs.ts
@@ -104,6 +104,7 @@ export const hostStub = {
   primary_ip: "172.19.0.8",
   primary_mac: "02:42:ac:13:00:08",
   status: "online",
+  display_name: "52883a0ba916",
   display_text: "52883a0ba916",
   target_type: "hosts",
 };
@@ -229,7 +230,7 @@ const queryResultStub = {
   gid: "0",
   gid_signed: "0",
   groupname: "root",
-  host_hostname: hostStub.hostname,
+  host_display_name: hostStub.display_name,
 };
 
 export const campaignStub = {

--- a/frontend/utilities/campaign_helpers/index.ts
+++ b/frontend/utilities/campaign_helpers/index.ts
@@ -62,7 +62,7 @@ const updateCampaignStateFromResults = (
 
     newErrors = errors.concat([
       {
-        host_hostname: host?.hostname,
+        host_display_name: host?.display_name,
         osquery_version: host?.osquery_version,
         error:
           error ||


### PR DESCRIPTION
I think this is the final uses of hostname removed

# Checklist for submitter

If some of the following don't apply, delete the relevant line.


- [ ] Manual QA for all new/changed functionality
