### PR TITLE
Add update channels to `orbit_info`

### DIFF
--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -648,8 +648,11 @@ func main() {
 			&g,
 			r.ExtensionSocketPath(),
 			table.WithExtension(orbitInfoExtension{
-				orbitClient: orbitClient,
-				trw:         trw,
+				orbitClient:     orbitClient,
+				orbitChannel:    c.String("orbit-channel"),
+				osquerydChannel: c.String("osqueryd-channel"),
+				desktopChannel:  c.String("desktop-channel"),
+				trw:             trw,
 			}),
 		)
 

--- a/orbit/cmd/orbit/orbit_info.go
+++ b/orbit/cmd/orbit/orbit_info.go
@@ -13,8 +13,11 @@ import (
 
 // orbitInfoExtension implements an extension table that provides info about Orbit.
 type orbitInfoExtension struct {
-	orbitClient *service.OrbitClient
-	trw         *token.ReadWriter
+	orbitClient     *service.OrbitClient
+	orbitChannel    string
+	osquerydChannel string
+	desktopChannel  string
+	trw             *token.ReadWriter
 }
 
 var _ orbit_table.Extension = orbitInfoExtension{}
@@ -31,6 +34,9 @@ func (o orbitInfoExtension) Columns() []table.ColumnDefinition {
 		table.TextColumn("device_auth_token"),
 		table.TextColumn("enrolled"),
 		table.TextColumn("last_recorded_error"),
+		table.TextColumn("orbit_channel"),
+		table.TextColumn("osqueryd_channel"),
+		table.TextColumn("desktop_channel"),
 	}
 }
 
@@ -53,12 +59,13 @@ func (o orbitInfoExtension) GenerateFunc(_ context.Context, _ table.QueryContext
 		}
 	}
 
-	return []map[string]string{
-		{
-			"version":             v,
-			"device_auth_token":   token,
-			"enrolled":            strconv.FormatBool(o.orbitClient.Enrolled()),
-			"last_recorded_error": lastRecordedError,
-		},
-	}, nil
+	return []map[string]string{{
+		"version":             v,
+		"device_auth_token":   token,
+		"enrolled":            strconv.FormatBool(o.orbitClient.Enrolled()),
+		"last_recorded_error": lastRecordedError,
+		"orbit_channel":       o.orbitChannel,
+		"osqueryd_channel":    o.osquerydChannel,
+		"desktop_channel":     o.desktopChannel,
+	}}, nil
 }


### PR DESCRIPTION
This is useful when developing/testing a new version of Orbit (to know which channels each host is configured with).