### PR TITLE
Website: Update handbook redirects

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -257,13 +257,14 @@ module.exports.routes = {
   'GET /handbook/sales': '/handbook/customers#sales',
   'GET /handbook/people': '/handbook/business-operations',
   'GET /handbook/people/ceo-handbook': '/handbook/business-operations/ceo-handbook',
-  'GET /handbook/growth': '/handbook/marketing/growth',
-  'GET /handbook/community': '/handbook/marketing/community',
-  'GET /handbook/digital-experience': '/handbook/marketing/digital-experience',
-  'GET /handbook/digital-experience/article-formatting-guide': '/handbook/marketing',// FUTURE: Figure out the real place this went
-  'GET /handbook/digital-experience/commonly-used-terms': '/handbook/marketing',// FUTURE: Figure out the real place this went
-  'GET /handbook/digital-experience/how-to-submit-and-publish-an-article': '/handbook/marketing',// FUTURE: Figure out the real place this went
-  'GET /handbook/digital-experience/markdown-guide': '/handbook/marketing',// FUTURE: Figure out the real place this went
+  'GET /handbook/growth': '/handbook/marketing#growth',
+  'GET /handbook/community': '/handbook/marketing#community',
+  'GET /handbook/digital-experience': '/handbook/marketing#digital-experience',
+  'GET /handbook/digital-experience/article-formatting-guide': '/handbook/marketing/article-formatting-guide',
+  'GET /handbook/digital-experience/commonly-used-terms': '/handbook/marketing/commonly-used-terms',
+  'GET /handbook/digital-experience/how-to-submit-and-publish-an-article': '/handbook/marketing/how-to-submit-and-publish-an-article',
+  'GET /handbook/digital-experience/markdown-guide': '/handbook/marketing/markdown-guide',
+  'GET /handbook/quality': '/handbook/engineering#quality',
 
 
   //  ╔╦╗╦╔═╗╔═╗  ╦═╗╔═╗╔╦╗╦╦═╗╔═╗╔═╗╔╦╗╔═╗   ┬   ╔╦╗╔═╗╦ ╦╔╗╔╦  ╔═╗╔═╗╔╦╗╔═╗


### PR DESCRIPTION
Changes:
- Added a redirect for `/handbook/quality` to go to the quality section of the engineering page.
- Updated the redirects for pages in the `/marketing/` folder
- Updated the redirects for `handbook/growth`, `handbook/digital-experience`, and `handbook/community` to go to the marketing handbook page.