### PR TITLE
Remove border around actions button

### DIFF
--- a/frontend/components/TableContainer/DataTable/DropdownCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/DropdownCell/_styles.scss
@@ -7,6 +7,12 @@
 
   .Select {
     position: relative;
+    border: 0;
+    height: auto;
+
+    &.is-focused, &:hover {
+      border: 0;
+    }
 
     .Select-control {
       display: flex;

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -42,11 +42,18 @@
   }
 }
 
+.actions__cell .Select.dropdown__select {
+  border: 0;
+  height: auto;
+  &:hover, &:active, &:focus, &.is-focused {
+    border: 0;
+  }
+}
+
 .Select {
   &.dropdown__select {
     border: 1px solid $ui-fleet-blue-15;
     border-radius: $border-radius;
-    transition: border-color 100ms;
     height: 40px;
     &:hover {
       box-shadow: none;

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -42,14 +42,6 @@
   }
 }
 
-.actions__cell .Select.dropdown__select {
-  border: 0;
-  height: auto;
-  &:hover, &:active, &:focus, &.is-focused {
-    border: 0;
-  }
-}
-
 .Select {
   &.dropdown__select {
     border: 1px solid $ui-fleet-blue-15;


### PR DESCRIPTION
For #8359 

Bug retro: It was recently reported that borders were not appearing around all dropdown select items in Firefox. Implementing that fix, a border was manually set on dropdown selects. That border was inherited by the dropdown select element inside the `actions__cell` of our data table, which is styled differently. The fix for this bug is manually setting the border for dropdowns inside of `actions__cell` to 0. 