### PR TITLE
Fleet UI: Icon classname now global styled (non-released bug)

### DIFF
--- a/frontend/pages/admin/AppSettingsPage/cards/Agents/Agents.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/Agents/Agents.tsx
@@ -82,11 +82,7 @@ const Agents = ({
               rel="noopener noreferrer"
             >
               Learn more about agent options
-              <img
-                className="icon"
-                src={ExternalLinkIcon}
-                alt="Open external link"
-              />
+              <img src={ExternalLinkIcon} alt="Open external link" />
             </a>
           </p>
           {isPremiumTier ? (

--- a/frontend/pages/admin/AppSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
@@ -91,11 +91,7 @@ const FleetDesktop = ({
               rel="noopener noreferrer"
             >
               https://fleetdm.com/transparency
-              <img
-                className="icon"
-                src={ExternalLinkIcon}
-                alt="Open external link"
-              />
+              <img src={ExternalLinkIcon} alt="Open external link" />
             </a>{" "}
             . You can override the URL to take them to a resource of your
             choice.

--- a/frontend/pages/admin/AppSettingsPage/cards/Statistics/Statistics.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/Statistics/Statistics.tsx
@@ -101,11 +101,7 @@ const Statistics = ({
               rel="noopener noreferrer"
             >
               Learn more about usage statistics
-              <img
-                className="icon"
-                src={ExternalLinkIcon}
-                alt="Open external link"
-              />
+              <img src={ExternalLinkIcon} alt="Open external link" />
             </a>
           </p>
           <div className={`${baseClass}__inputs ${baseClass}__inputs--usage`}>

--- a/frontend/pages/hosts/details/DeviceUserPage/InfoModal/InfoModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/InfoModal/InfoModal.tsx
@@ -34,7 +34,11 @@ const InfoModal = ({ onCancel }: IInfoModalProps): JSX.Element => {
             Read about{" "}
             <span className="no-wrap">
               transparency
-              <img src={ExternalLinkIcon} alt="Open external link" />
+              <img
+                className="external-link-icon"
+                src={ExternalLinkIcon}
+                alt="Open external link"
+              />
             </span>
           </a>
         </p>

--- a/frontend/pages/hosts/details/DeviceUserPage/InfoModal/InfoModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/InfoModal/InfoModal.tsx
@@ -34,11 +34,7 @@ const InfoModal = ({ onCancel }: IInfoModalProps): JSX.Element => {
             Read about{" "}
             <span className="no-wrap">
               transparency
-              <img
-                className="icon"
-                src={ExternalLinkIcon}
-                alt="Open external link"
-              />
+              <img src={ExternalLinkIcon} alt="Open external link" />
             </span>
           </a>
         </p>

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -18,7 +18,7 @@
     flex-direction: column;
   }
 
-  a img.icon {
+  a img.external-link-icon {
     width: 12px;
     height: 12px;
     margin-left: 0.25rem;


### PR DESCRIPTION
Cerra #8361 

- Remove classname .icon from links as these are now globally styled with icon component
- Rename classname on Device User Page to .external-link-icon instead of .icon
- Fixes bug where link icons were being displayed as a flex (new line) instead of inline

<img width="1213" alt="Screen Shot 2022-10-20 at 1 03 53 PM" src="https://user-images.githubusercontent.com/71795832/197013201-3b73f5ac-4d0c-456a-85a2-b6e7520e7c8b.png">
<img width="1208" alt="Screen Shot 2022-10-20 at 1 03 47 PM" src="https://user-images.githubusercontent.com/71795832/197013206-869acddd-d2c2-49df-b7e7-ecfbb8c9ae5c.png">
<img width="1220" alt="Screen Shot 2022-10-20 at 1 03 41 PM" src="https://user-images.githubusercontent.com/71795832/197013210-1802fe7a-d239-4b2e-9478-51b3d545c873.png">
<img width="1214" alt="Screen Shot 2022-10-20 at 1 03 23 PM" src="https://user-images.githubusercontent.com/71795832/197013211-b1e698b1-049c-4866-95dc-40fb32fd67b4.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

No change file as this is non-released bug
- [x] Manual QA for all new/changed functionality

