### PR TITLE
Fix one pixel offset on dropdown menu

### DIFF
--- a/frontend/components/TeamsDropdown/_styles.scss
+++ b/frontend/components/TeamsDropdown/_styles.scss
@@ -34,6 +34,7 @@
     top: 36px;
     border-radius: 6px;
     padding-right: 0;
+    margin: 0;
   }
 
   .Select-control {

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -46,7 +46,6 @@
   &.dropdown__select {
     border: 1px solid $ui-fleet-blue-15;
     border-radius: $border-radius;
-    height: 40px;
     &:hover {
       box-shadow: none;
       border: 1px solid $core-vibrant-blue;
@@ -55,6 +54,7 @@
   .Select-control {
     background-color: $ui-light-grey;
     border: 0;
+    border-radius: $border-radius;
     .Select-value {
       font-size: $small;
       background-color: $ui-off-white;
@@ -137,6 +137,9 @@
       margin-left: -4px;
       border: none;
     }
+    .Select-control {
+      border-radius: $border-radius;
+    }
   }
   :hover {
     .Select-arrow {
@@ -172,11 +175,10 @@
 
   .Select-menu-outer {
     box-shadow: 0 4px 10px rgba(52, 59, 96, 0.15);
-    border-radius: 0 0 $border-radius $border-radius;
     z-index: 6;
     overflow: hidden;
     border: 0;
-    margin: 0;
+    margin: 1px 0 0;
     padding: $pad-small;
   }
 
@@ -277,7 +279,3 @@
     }
   }
 }
-
-// .is-focused {
-//   border: 1px solid $core-vibrant-blue;
-// }


### PR DESCRIPTION
For #8370 

Bug retro: There was a bug fix for Firefox that required moving the border of the dropdown element to a higher level in the DOM. When that happened, the border height was no longer being calculated into the height of the element, so when the popup menu positions itself with `top: 100%` it is one pixel short and covers the bottom border.