### PR TITLE
fix missing host when ordering by display name

### DIFF
--- a/changes/issue-8371-missing-host
+++ b/changes/issue-8371-missing-host
@@ -1,0 +1,2 @@
+* Fixed an issue where a host was enrolled with orbit, but was being omitted when listing hosts and ordering by display name
+* Fixed an issue where popos hosts were not being includes in the linux hosts count on the hosts dashboard page.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -902,9 +902,18 @@ func (ds *Datastore) EnrollOrbit(ctx context.Context, hardwareUUID string, orbit
 					orbit_node_key
 				) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)
 			`
-			_, err := tx.ExecContext(ctx, sqlInsert, zeroTime, zeroTime, zeroTime, zeroTime, hardwareUUID, orbitNodeKey, teamID, orbitNodeKey)
+			result, err := tx.ExecContext(ctx, sqlInsert, zeroTime, zeroTime, zeroTime, zeroTime, hardwareUUID, orbitNodeKey, teamID, orbitNodeKey)
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "orbit enroll error inserting host details")
+			}
+			hostID, _ := result.LastInsertId()
+			level.Info(ds.logger).Log("hostID", hostID)
+			const sqlHostDisplayName = `
+				INSERT INTO host_display_names (host_id, display_name) VALUES (?, '')
+			`
+			_, err = tx.ExecContext(ctx, sqlHostDisplayName, hostID)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "insert host_display_names")
 			}
 		default:
 			return ctxerr.Wrap(ctx, err, "orbit enroll error selecting host details")

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -285,7 +285,7 @@ func (h *Host) FleetPlatform() string {
 
 // HostLinuxOSs are the possible linux values for Host.Platform.
 var HostLinuxOSs = []string{
-	"linux", "ubuntu", "debian", "rhel", "centos", "sles", "kali", "gentoo", "amzn",
+	"linux", "ubuntu", "debian", "rhel", "centos", "sles", "kali", "gentoo", "amzn", "pop",
 }
 
 func IsLinux(hostPlatform string) bool {


### PR DESCRIPTION
#8371 #6760

When enrolling with orbit, there should be a dummy row inserted into the `host_display_names` table. Otherwise, it will be filtered out when listing hosts and ordering by the display name as there is a `JOIN host_display_names` involved.

While this does fix the above issues, we should probably revisit if inserting a dummy row is a good idea in the first place. Listing hosts should probably be able to handle a missing display name. 

Also fixed #6760 where popos hosts weren't being included in the linux hosts count.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
