### PR TITLE
Fleet UI: Empty yaml syntax fix

### DIFF
--- a/frontend/utilities/yaml/index.ts
+++ b/frontend/utilities/yaml/index.ts
@@ -11,7 +11,7 @@ export const constructErrorString = (yamlError: IYAMLError) => {
 };
 
 export const agentOptionsToYaml = (agentOpts: any) => {
-  agentOpts ||= {};
+  agentOpts ||= { config: {} };
 
   // hide the "overrides" key if it is empty
   if (!agentOpts.overrides || Object.keys(agentOpts.overrides).length === 0) {


### PR DESCRIPTION
Closes [QA Bug found](https://github.com/fleetdm/fleet/issues/8095#issuecomment-1286245134)

- Fix: For empty agent_options, defaults the yaml editor for proper yaml editor syntax to:
```
config: {}
command_line_flags: {} # requires Fleet's osquery installer
```
What was broken syntax in yaml editor:
```
{}
command_line_flags: {} # requires Fleet's osquery installer
```

Engineer QAed empty agent options on fleetctl and in UI

**Screenshot**
<img width="1590" alt="Screen Shot 2022-10-21 at 10 12 18 AM" src="https://user-images.githubusercontent.com/71795832/197217099-3bb31ca7-68c3-4261-a27f-21fd5b9c3bfd.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.


- [x] Manual QA for all new/changed functionality
