### PR TITLE
fix issue in fleet desktop causing it to spam free installations

### DIFF
--- a/orbit/changes/8373-fix-desktop-free-spam
+++ b/orbit/changes/8373-fix-desktop-free-spam
@@ -1,0 +1,1 @@
+- Fixed a bug in Fleet Desktop causing it to spam servers without licenses for policies.

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -206,6 +206,7 @@ func main() {
 			defer tic.Stop()
 
 			for {
+				<-tic.C
 				failingPolicies, err := client.NumberOfFailingPolicies(tokenReader.GetCached())
 				switch {
 				case err == nil:
@@ -242,8 +243,6 @@ func main() {
 					}
 				}
 				myDeviceItem.Enable()
-
-				<-tic.C
 			}
 		}()
 


### PR DESCRIPTION
the `switch` statement that checks for errors (including license errors) issues a `continue` before we even have the chance to wait for the ticker.

this has the drawback that premium users will have to wait 5 minutes before they see policy info, but the alternative would be to use labels and go-to, at least with the current code structure.

related to https://github.com/fleetdm/fleet/issues/8373

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes (in `changes/` and/or `orbit/changes/`).
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
