### PR TITLE
Fleet UI: Option to show public IP address in hosts table

### DIFF
--- a/changes/issue-7905-public-ip-address-shown
+++ b/changes/issue-7905-public-ip-address-shown
@@ -1,0 +1,1 @@
+- Add option to show public IP address in Hosts table

--- a/frontend/components/LiveQuery/TargetsInput/TargetsInputHostsTableConfig.tsx
+++ b/frontend/components/LiveQuery/TargetsInput/TargetsInputHostsTableConfig.tsx
@@ -47,8 +47,8 @@ export const generateTableHeaders = (
       Cell: (cellProps) => <StatusCell value={cellProps.cell.value} />,
     },
     {
-      title: "IP address",
-      Header: "IP address",
+      title: "Private IP address",
+      Header: "Private IP address",
       accessor: "primary_ip",
       Cell: (cellProps) => <TextCell value={cellProps.cell.value} />,
     },

--- a/frontend/components/forms/fields/SelectTargetsDropdown/TargetDetails/TargetDetails.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/TargetDetails/TargetDetails.jsx
@@ -92,11 +92,11 @@ class TargetDetails extends Component {
         <table className={`${baseClass}__table`}>
           <tbody>
             <tr>
-              <th>IP Address</th>
+              <th>Private IP address</th>
               <td>{hostIpAddress}</td>
             </tr>
             <tr>
-              <th>MAC Address</th>
+              <th>MAC address</th>
               <td>
                 <span className={`${hostBaseClass}__mac-address`}>
                   {hostMac}

--- a/frontend/osquery_tables.json
+++ b/frontend/osquery_tables.json
@@ -2760,20 +2760,20 @@
         "index": false
       },
       {
-        "name":"issuer2",
-        "description":"Certificate issuer distinguished name",
-        "type":"text",
-        "hidden":true,
-        "required":false,
-        "index":false
+        "name": "issuer2",
+        "description": "Certificate issuer distinguished name",
+        "type": "text",
+        "hidden": true,
+        "required": false,
+        "index": false
       },
       {
-        "name":"subject2",
-        "description":"Certificate distinguished name",
-        "type":"text",
-        "hidden":true,
-        "required":false,
-        "index":false
+        "name": "subject2",
+        "description": "Certificate distinguished name",
+        "type": "text",
+        "hidden": true,
+        "required": false,
+        "index": false
       }
     ]
   },
@@ -8196,12 +8196,12 @@
         "index": false
       },
       {
-        "name":"original_filename",
-        "description":"(Executable files only) Original filename",
-        "type":"text",
-        "hidden":true,
-        "required":false,
-        "index":false
+        "name": "original_filename",
+        "description": "(Executable files only) Original filename",
+        "type": "text",
+        "hidden": true,
+        "required": false,
+        "index": false
       },
       {
         "name": "bsd_flags",
@@ -16664,12 +16664,12 @@
         "index": false
       },
       {
-        "name":"translated",
-        "description":"Indicates whether the process is running under the Rosetta Translation Environment, yes=1, no=0, error=-1.",
-        "type":"integer",
-        "hidden":false,
-        "required":false,
-        "index":false
+        "name": "translated",
+        "description": "Indicates whether the process is running under the Rosetta Translation Environment, yes=1, no=0, error=-1.",
+        "type": "integer",
+        "hidden": false,
+        "required": false,
+        "index": false
       }
     ]
   },

--- a/frontend/osquery_tables.json
+++ b/frontend/osquery_tables.json
@@ -2760,20 +2760,20 @@
         "index": false
       },
       {
-        "name": "issuer2",
-        "description": "Certificate issuer distinguished name",
-        "type": "text",
-        "hidden": true,
-        "required": false,
-        "index": false
+        "name":"issuer2",
+        "description":"Certificate issuer distinguished name",
+        "type":"text",
+        "hidden":true,
+        "required":false,
+        "index":false
       },
       {
-        "name": "subject2",
-        "description": "Certificate distinguished name",
-        "type": "text",
-        "hidden": true,
-        "required": false,
-        "index": false
+        "name":"subject2",
+        "description":"Certificate distinguished name",
+        "type":"text",
+        "hidden":true,
+        "required":false,
+        "index":false
       }
     ]
   },
@@ -8196,12 +8196,12 @@
         "index": false
       },
       {
-        "name": "original_filename",
-        "description": "(Executable files only) Original filename",
-        "type": "text",
-        "hidden": true,
-        "required": false,
-        "index": false
+        "name":"original_filename",
+        "description":"(Executable files only) Original filename",
+        "type":"text",
+        "hidden":true,
+        "required":false,
+        "index":false
       },
       {
         "name": "bsd_flags",
@@ -16664,12 +16664,12 @@
         "index": false
       },
       {
-        "name": "translated",
-        "description": "Indicates whether the process is running under the Rosetta Translation Environment, yes=1, no=0, error=-1.",
-        "type": "integer",
-        "hidden": false,
-        "required": false,
-        "index": false
+        "name":"translated",
+        "description":"Indicates whether the process is running under the Rosetta Translation Environment, yes=1, no=0, error=-1.",
+        "type":"integer",
+        "hidden":false,
+        "required":false,
+        "index":false
       }
     ]
   },

--- a/frontend/pages/admin/AppSettingsPage/cards/Smtp/Smtp.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/Smtp/Smtp.tsx
@@ -209,7 +209,7 @@ const Smtp = ({
             parseTarget
             onBlur={validateForm}
             error={formErrors.server}
-            tooltip="The hostname / Private IP address and corresponding port of your organization's SMTP server."
+            tooltip="The hostname / private IP address and corresponding port of your organization's SMTP server."
           />
           <InputField
             label="&nbsp;"

--- a/frontend/pages/admin/AppSettingsPage/cards/Smtp/Smtp.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/Smtp/Smtp.tsx
@@ -209,7 +209,7 @@ const Smtp = ({
             parseTarget
             onBlur={validateForm}
             error={formErrors.server}
-            tooltip="The hostname / IP address and corresponding port of your organization's SMTP server."
+            tooltip="The hostname / Private IP address and corresponding port of your organization's SMTP server."
           />
           <InputField
             label="&nbsp;"

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -456,7 +456,7 @@ const defaultHiddenColumns = [
   "computer_name",
   "device_mapping",
   "primary_mac",
-  "primary_ip",
+  "public_ip",
   "cpu_type",
   "memory",
   "uptime",

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -296,7 +296,7 @@ const allHostTableHeaders: IDataColumn[] = [
     },
   },
   {
-    title: "IP address",
+    title: "Private IP address",
     Header: (cellProps: IHeaderProps) => (
       <HeaderCell
         value={cellProps.column.title}
@@ -304,6 +304,17 @@ const allHostTableHeaders: IDataColumn[] = [
       />
     ),
     accessor: "primary_ip",
+    Cell: (cellProps: ICellProps) => <TextCell value={cellProps.cell.value} />,
+  },
+  {
+    title: "Public IP address",
+    Header: (cellProps: IHeaderProps) => (
+      <HeaderCell
+        value={cellProps.column.title}
+        isSortedDesc={cellProps.column.isSortedDesc}
+      />
+    ),
+    accessor: "public_ip",
     Cell: (cellProps: ICellProps) => <TextCell value={cellProps.cell.value} />,
   },
   {
@@ -445,6 +456,7 @@ const defaultHiddenColumns = [
   "computer_name",
   "device_mapping",
   "primary_mac",
+  "primary_ip",
   "cpu_type",
   "memory",
   "uptime",

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -185,7 +185,7 @@ export const HOSTS_SEARCH_BOX_PLACEHOLDER =
   "Search name, hostname, UUID, serial number, or private IP address";
 
 export const HOSTS_SEARCH_BOX_TOOLTIP =
-  "Search hosts by name, hostname, UUID, serial number or private IP address";
+  "Search hosts by name, hostname, UUID, serial number, or private IP address";
 
 export const VULNERABLE_DROPDOWN_OPTIONS = [
   {


### PR DESCRIPTION
Cerra #7905 

**New feature**
- Added option to show public IP address in table (default to hidden)

**Screenshots**
<img width="1498" alt="Screen Shot 2022-10-24 at 11 47 14 AM" src="https://user-images.githubusercontent.com/71795832/197569537-5b9f1404-6624-42d5-bc77-dd9c593c7574.png">
<img width="1241" alt="Screen Shot 2022-10-24 at 11 39 15 AM" src="https://user-images.githubusercontent.com/71795832/197569544-fcdf15e4-2d03-4b5a-b9a0-9bf3dc54eb70.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

