### PR TITLE
Website: Update Fleet Sandbox redirects

### DIFF
--- a/website/api/controllers/try-fleet/view-sandbox-teleporter-or-redirect-because-expired.js
+++ b/website/api/controllers/try-fleet/view-sandbox-teleporter-or-redirect-because-expired.js
@@ -45,10 +45,7 @@ module.exports = {
       throw new Error(`Consistency violation: The logged-in user's (${this.req.me.emailAddress}) fleetSandboxDemoKey has somehow gone missing!`);
     }
 
-    // If this user's Fleet Sandbox instance is expired, we'll redirect them to the sandbox-expired page
-    if(this.req.me.fleetSandboxExpiresAt < Date.now()){
-      throw {redirect: '/try-fleet/sandbox-expired' };
-    }
+    // If this user's Fleet Sandbox instance is expired, they will be redirected /try-fleet/sandbox-expired by EKS.
 
     // Respond with view.
     return {

--- a/website/api/controllers/try-fleet/view-sandbox-teleporter-or-redirect-because-expired.js
+++ b/website/api/controllers/try-fleet/view-sandbox-teleporter-or-redirect-because-expired.js
@@ -45,7 +45,7 @@ module.exports = {
       throw new Error(`Consistency violation: The logged-in user's (${this.req.me.emailAddress}) fleetSandboxDemoKey has somehow gone missing!`);
     }
 
-    // If this user's Fleet Sandbox instance is expired, they will be redirected /try-fleet/sandbox-expired by EKS.
+    // If this user's Fleet Sandbox instance is expired, they will be redirected /try-fleet/sandbox-expired by EKS. https://github.com/fleetdm/fleet/blob/3f3c0b34c4939d85cd700364370a14ae773cb07b/infrastructure/sandbox/SharedInfrastructure/eks.tf#L336-L367
 
     // Respond with view.
     return {

--- a/website/config/policies.js
+++ b/website/config/policies.js
@@ -43,5 +43,6 @@ module.exports.policies = {
   'create-or-update-one-newsletter-subscription': true,
   'unsubscribe-from-all-newsletters': true,
   'view-osquery-table-details': true,
+  'try-fleet/view-sandbox-expired': true,
 
 };


### PR DESCRIPTION
https://fleetdm.slack.com/archives/C019WG4GH0A/p1666627155459609

Changes:
- Removed the `/try-fleet/sandbox-expired` redirect in `view-sandbox-teleporter-or-redirect-because-expired.js` (Should the name be changed to `view-sandbox-teleporter-or-redirect`?)
- Updated `website/config/policies.js` to bypass the `is-logged-in` policy for `try-fleet/sandbox-expired`