### PR TITLE
Fleet UI: Fix dropdown styles, dashboard styles

### DIFF
--- a/changes/issue-8385-dashboard-styling-fixes
+++ b/changes/issue-8385-dashboard-styling-fixes
@@ -1,0 +1,1 @@
+* Cleanup dashboard styling

--- a/frontend/components/TableContainer/DataTable/DropdownCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/DropdownCell/_styles.scss
@@ -10,7 +10,8 @@
     border: 0;
     height: auto;
 
-    &.is-focused, &:hover {
+    &.is-focused,
+    &:hover {
       border: 0;
     }
 
@@ -30,16 +31,12 @@
         color: $core-vibrant-blue;
       }
 
-      .Select-arrow {
-        margin-top: 3px;
-      }
-
       .Select-placeholder {
         color: $core-fleet-black;
         font-size: 14px;
         line-height: normal;
         padding-left: 0;
-        margin-top: 2px;
+        margin-top: 1px;
       }
 
       .Select-input {
@@ -72,13 +69,6 @@
     &.is-open {
       .Select-control .Select-placeholder {
         color: $core-vibrant-blue;
-        top: 0;
-      }
-
-      .Select-control {
-        .Select-arrow {
-          top: 0;
-        }
       }
     }
   }

--- a/frontend/components/TeamsDropdown/_styles.scss
+++ b/frontend/components/TeamsDropdown/_styles.scss
@@ -43,7 +43,7 @@
     border-radius: none;
     position: none;
     width: max-content; // move select arrow
-    height: 20px;
+    height: 32px;
 
     &:hover {
       box-shadow: none;
@@ -54,23 +54,12 @@
     }
 
     .Select-arrow-zone {
-      height: 32px;
       padding-left: 15px;
-
-      .Select-arrow {
-        top: 0 !important;
-        margin-top: 0 !important;
-      }
-    }
-
-    .is-open > .Select-arrow {
-      top: 0 !important;
     }
 
     .Select-multi-value-wrapper {
       width: max-content; // move select arrow
-      height: 20px;
-      margin-bottom: $pad-xsmall;
+      height: 32px;
 
       .Select-input {
         display: none !important;
@@ -79,14 +68,14 @@
       .Select-value {
         position: relative; // move select arrow
         display: inline-block; // move select arrow
-        line-height: 28px;
+        line-height: 32px;
         padding: 0;
         border: 0 !important;
         background-color: transparent !important;
         right: 0;
         left: 0;
         bottom: 0;
-        top: 2px;
+        top: 0;
 
         &.is-focused {
           border: 0 !important;
@@ -97,6 +86,7 @@
 
         .Select-value-label {
           font-size: $large !important;
+          line-height: 32px;
         }
       }
     }

--- a/frontend/components/buttons/DropdownButton/_styles.scss
+++ b/frontend/components/buttons/DropdownButton/_styles.scss
@@ -66,6 +66,6 @@
     border-radius: 0px;
     padding: 0px;
     padding-left: 2px;
-    margin-top: 2px;
+    margin-top: 1px;
   }
 }

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -93,7 +93,7 @@
     .Select-value-label {
       font-size: $small;
       color: $core-fleet-black;
-      line-height: 28px;
+      vertical-align: middle;
     }
   }
 
@@ -110,7 +110,8 @@
     content: url("../assets/images/icon-chevron-black-16x16@2x.png");
     height: 16px;
     width: 16px;
-    margin-top: 8px;
+    vertical-align: middle;
+    margin-top: -1px;
     margin-left: -4px;
     border: none;
   }
@@ -129,16 +130,17 @@
   }
 
   &.is-open {
-    .Select-arrow {
-      content: url("../assets/images/icon-chevron-blue-16x16@2x.png");
-      height: 16px;
-      width: 16px;
-      margin-top: 12px;
-      margin-left: -4px;
-      border: none;
-    }
     .Select-control {
       border-radius: $border-radius;
+
+      .Select-arrow {
+        content: url("../assets/images/icon-chevron-blue-16x16@2x.png");
+        height: 16px;
+        width: 16px;
+        margin-left: -4px;
+        border: none;
+        top: 0px;
+      }
     }
   }
   :hover {
@@ -154,7 +156,6 @@
         content: url("../assets/images/icon-chevron-blue-16x16@2x.png");
         height: 16px;
         width: 16px;
-        margin-top: 10px;
         margin-left: -4px;
         border: none;
       }
@@ -250,7 +251,7 @@
       flex-grow: 1;
 
       .Select-value {
-        margin-top: 2px;
+        margin-top: 1px;
 
         .Select-value-label {
           font-size: $x-small;

--- a/frontend/components/forms/fields/SelectTargetsDropdown/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/_styles.scss
@@ -35,7 +35,6 @@
       content: url("../assets/images/icon-chevron-black-16x16@2x.png");
       height: 16px;
       width: 16px;
-      margin-top: 6px;
       margin-left: 6px;
       border: none;
 
@@ -49,7 +48,6 @@
         content: url("../assets/images/icon-collapse-black-16x16@2x.png");
         height: 16px;
         width: 16px;
-        margin-top: 11px;
         margin-left: 6px;
         border: none;
 

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tsx
@@ -118,7 +118,6 @@ const ActivityFeed = ({
       onSuccess: (results) => {
         setShowActivityFeedTitle(true);
         if (results.length < DEFAULT_PAGE_SIZE) {
-          console.log("results.length", results.length);
           setShowMore(false);
         }
       },
@@ -150,9 +149,6 @@ const ActivityFeed = ({
       }
       case ActivityType.AppliedSpecSavedQuery: {
         return TAGGED_TEMPLATES.editQueryCtlActivityTemplate(activity);
-      }
-      case ActivityType.AppliedSpecTeam: {
-        return TAGGED_TEMPLATES.editTeamCtlActivityTemplate();
       }
       case ActivityType.UserAddedBySSO: {
         return TAGGED_TEMPLATES.userAddedBySSOTempalte();

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tsx
@@ -118,6 +118,7 @@ const ActivityFeed = ({
       onSuccess: (results) => {
         setShowActivityFeedTitle(true);
         if (results.length < DEFAULT_PAGE_SIZE) {
+          console.log("results.length", results.length);
           setShowMore(false);
         }
       },
@@ -149,6 +150,9 @@ const ActivityFeed = ({
       }
       case ActivityType.AppliedSpecSavedQuery: {
         return TAGGED_TEMPLATES.editQueryCtlActivityTemplate(activity);
+      }
+      case ActivityType.AppliedSpecTeam: {
+        return TAGGED_TEMPLATES.editTeamCtlActivityTemplate();
       }
       case ActivityType.UserAddedBySSO: {
         return TAGGED_TEMPLATES.userAddedBySSOTempalte();
@@ -195,14 +199,17 @@ const ActivityFeed = ({
           size="small"
         />
         <div className={`${baseClass}__details`}>
-          <p className={`${baseClass}__details-topline`}>
-            <b>{activity.actor_full_name}</b> {getDetail(activity)}.
+          <p>
+            <span className={`${baseClass}__details-topline`}>
+              <b>{activity.actor_full_name}</b> {getDetail(activity)}.
+            </span>
+            <br />
+            <span className={`${baseClass}__details-bottomline`}>
+              {formatDistanceToNowStrict(new Date(activity.created_at), {
+                addSuffix: true,
+              })}
+            </span>
           </p>
-          <span className={`${baseClass}__details-bottomline`}>
-            {formatDistanceToNowStrict(new Date(activity.created_at), {
-              addSuffix: true,
-            })}
-          </span>
         </div>
       </div>
     );

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/_styles.scss
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   position: relative;
-  min-height: 592px;
+  min-height: 500px;
 
   &__header-wrap {
     .form-field {
@@ -25,7 +25,7 @@
   &__block:before {
     content: "";
     position: relative;
-    height: 50px !important;
+    height: 36px !important;
     z-index: 0;
     top: 35px;
     left: 17px;
@@ -51,6 +51,7 @@
 
     p {
       margin: 0;
+      line-height: 16px;
     }
   }
 

--- a/frontend/pages/hosts/ManageHostsPage/components/TransferHostModal/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/TransferHostModal/_styles.scss
@@ -9,14 +9,10 @@
   .Select {
     .Select-control {
       cursor: pointer;
-      
+
       &:hover .Select-placeholder {
         color: $core-vibrant-blue;
       }
-    }
-
-    .Select-arrow {
-      margin-top: 7px;
     }
 
     &:not(.is-open) {


### PR DESCRIPTION
Cerra #8385 

**Fixes**
- Fix dashboard styling
  - Activity feed proper spacing
- Global dropdown styling cleanup
  - There was a lot of unnecessary "one-off" styling (e.g. line-height, top, margin-top...) that was fixed and replaced with `vertical-align: middle;` so it would work on various size dropdowns

**Screenshots**
Less vertical spacing in and between activity feed's activities
<img width="770" alt="Screen Shot 2022-11-01 at 1 09 07 PM" src="https://user-images.githubusercontent.com/71795832/199294247-0f5a891a-c74e-4cde-8364-395553dbfacd.png">
React select dropdown arrow alignment
<img width="466" alt="Screen Shot 2022-11-01 at 1 09 49 PM" src="https://user-images.githubusercontent.com/71795832/199294239-ba43cdbc-4a18-4500-86a1-a9c7f2dc0732.png">
React-select-5 dropdowns still aligned
<img width="717" alt="Screen Shot 2022-11-01 at 1 09 34 PM" src="https://user-images.githubusercontent.com/71795832/199294241-76696f95-8254-4148-a370-b2c6e780d94d.png">

Tested on Chrome, Firefox, and Safari

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality