### PR TITLE
Add method to fleetDesktopResponse to satisfy the errorer interface

### DIFF
--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -46,6 +46,8 @@ type fleetDesktopResponse struct {
 	FailingPolicies *uint `json:"failing_policies_count,omitempty"`
 }
 
+func (r fleetDesktopResponse) error() error { return r.Err }
+
 type getFleetDesktopRequest struct {
 	Token string `url:"token"`
 }

--- a/server/service/integration_desktop_test.go
+++ b/server/service/integration_desktop_test.go
@@ -135,6 +135,13 @@ func (s *integrationTestSuite) TestDeviceAuthenticatedEndpoints() {
 	json.NewDecoder(res.Body).Decode(&getHostResp)
 	res.Body.Close()
 	require.Nil(t, listPoliciesResp.Policies)
+
+	// /device/desktop is not accessible for free endpoints
+	getDesktopResp := fleetDesktopResponse{}
+	res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/desktop", nil, http.StatusPaymentRequired)
+	json.NewDecoder(res.Body).Decode(&getDesktopResp)
+	res.Body.Close()
+	require.Nil(t, getDesktopResp.FailingPolicies)
 }
 
 // TestDefaultTransparencyURL tests that Fleet Free licensees are restricted to the default transparency url.


### PR DESCRIPTION
https://github.com/fleetdm/fleet/issues/8439

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
