### PR TITLE
Prepare for 4.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Fleet 4.22.1 (Oct 27, 2022)
+
+* Fixed the error response of the `/device/:token/desktop` endpoint causing problems on free Fleet Desktop instances on versions `1.3.x`.
+
 ## Fleet 4.22.0 (Oct 20, 2022)
 
 * Added usage statistics for the weekly count of aggregate policy violation days. One policy violation day is counted for each policy that a host is failing, measured as of the time the count increments. The count increments once per 24-hour interval and resets each week.

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,9 +4,9 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v4.22.0
+version: v4.22.1
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git
-appVersion: v4.22.0
+appVersion: v4.22.1
 

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -2,7 +2,7 @@
 # All settings related to how Fleet is deployed in Kubernetes
 hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
-imageTag: v4.22.0 # Version of Fleet to deploy
+imageTag: v4.22.1 # Version of Fleet to deploy
 createIngress: true # Whether or not to automatically create an Ingress
 ingressAnnotations: {} # Additional annotation to add to the Ingress
 podAnnotations: {} # Additional annotations to add to the Fleet pod

--- a/docs/Deploying/Server-Installation.md
+++ b/docs/Deploying/Server-Installation.md
@@ -264,7 +264,7 @@ spec:
     spec:
       containers:
       - name: fleet
-        image: fleetdm/fleet:4.22.0
+        image: fleetdm/fleet:4.22.1
         env:
           # if running Fleet behind external ingress controller that terminates TLS
           - name: FLEET_SERVER_TLS

--- a/infrastructure/dogfood/terraform/aws/variables.tf
+++ b/infrastructure/dogfood/terraform/aws/variables.tf
@@ -56,7 +56,7 @@ variable "database_name" {
 
 variable "fleet_image" {
   description = "the name of the container image to run"
-  default     = "fleetdm/fleet:v4.22.0"
+  default     = "fleetdm/fleet:v4.22.1"
 }
 
 variable "software_inventory" {

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -68,5 +68,5 @@ variable "redis_mem" {
 }
 
 variable "image" {
-  default = "fleet:v4.22.0"
+  default = "fleet:v4.22.1"
 }

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetctl",
-  "version": "v4.22.0",
+  "version": "v4.22.1",
   "description": "Installer for the fleetctl CLI tool",
   "bin": {
     "fleetctl": "./run.js"


### PR DESCRIPTION
This updates the changelog and updates versioning for 4.22.1 patch release.

Note: the base branch of this PR is `patch-fleet-v4.22.1`, the changes should be cherry-picked into `main` afterwards.
