### PR TITLE
Dump pprof when orbit is given a SIGUSR1. Fixes #8456

### DIFF
--- a/orbit/changes/8485-dump-pprof
+++ b/orbit/changes/8485-dump-pprof
@@ -1,0 +1,2 @@
+- On Unix systems, dump pprof data into a `profiles` directory in the orbit root dir
+  when receiving a SIGUSR1. This is to assist debugging for memory leaks

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -666,6 +666,8 @@ func main() {
 		defer cancel()
 		g.Add(signalHandler(ctx))
 
+		go sigusrListener(c.String("root-dir"))
+
 		if err := g.Run(); err != nil {
 			log.Error().Err(err).Msg("unexpected exit")
 		}

--- a/orbit/cmd/orbit/signal_unix.go
+++ b/orbit/cmd/orbit/signal_unix.go
@@ -32,7 +32,7 @@ func sigusrListener(rootDir string) {
 		<-c
 
 		if err := dumpProf(rootDir); err != nil {
-			log.Warn().Err(err).Msg("Unable to create pprof")
+			log.Warn().Err(err).Msg("unable to create pprof")
 		}
 	}
 }
@@ -43,7 +43,7 @@ func dumpProf(rootDir string) error {
 	}
 	now := time.Now()
 
-	// We can't use ISO 8601/RFC 3339 because Windows does not allow colons in filenames
+	// We can't use ISO 8601/RFC 3339 because NTFS and FAT do not allow colons in filenames
 	timestamp := now.UTC().Format("2006-01-02T15-04-05")
 
 	out, err := os.Create(path.Join(rootDir, "profiles", fmt.Sprintf("profiles-%s.tar.gz", timestamp)))
@@ -68,23 +68,12 @@ func dumpProf(rootDir string) error {
 		header := tar.Header{
 			Typeflag:   tar.TypeReg,
 			Name:       fmt.Sprintf("%s.pprof", profile.Name()),
-			Linkname:   "",
 			Size:       int64(buf.Len()),
 			Mode:       0o664,
-			Uid:        0,
-			Gid:        0,
-			Uname:      "",
-			Gname:      "",
 			ModTime:    now,
 			AccessTime: now,
 			ChangeTime: now,
-			Devmajor:   0,
-			Devminor:   0,
-			Xattrs:     map[string]string{},
-			PAXRecords: map[string]string{},
-			Format:     0,
 		}
-		log.Info().Msgf("tar header: %+v", header)
 		err = tw.WriteHeader(&header)
 		if err != nil {
 			return err

--- a/orbit/cmd/orbit/signal_unix.go
+++ b/orbit/cmd/orbit/signal_unix.go
@@ -3,13 +3,97 @@
 package main
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
+	"fmt"
 	"os"
+	"os/signal"
+	"path"
+	"runtime/pprof"
 	"syscall"
+	"time"
 
+	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
+	"github.com/fleetdm/fleet/v4/pkg/secure"
 	"github.com/oklog/run"
+	"github.com/rs/zerolog/log"
 )
 
 func signalHandler(ctx context.Context) (execute func() error, interrupt func(error)) {
 	return run.SignalHandler(ctx, os.Interrupt, os.Kill, syscall.SIGTERM)
+}
+
+func sigusrListener(rootDir string) {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGUSR1)
+	for {
+		<-c
+
+		if err := dumpProf(rootDir); err != nil {
+			log.Warn().Err(err).Msg("Unable to create pprof")
+		}
+	}
+}
+
+func dumpProf(rootDir string) error {
+	if err := secure.MkdirAll(path.Join(rootDir, "profiles"), constant.DefaultDirMode); err != nil {
+		return err
+	}
+	now := time.Now()
+
+	// We can't use ISO 8601/RFC 3339 because Windows does not allow colons in filenames
+	timestamp := now.UTC().Format("2006-01-02T15-04-05")
+
+	out, err := os.Create(path.Join(rootDir, "profiles", fmt.Sprintf("profiles-%s.tar.gz", timestamp)))
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	gw := gzip.NewWriter(out)
+	defer gw.Close()
+	tw := tar.NewWriter(gw)
+	defer tw.Close()
+
+	buf := new(bytes.Buffer)
+
+	for _, profile := range pprof.Profiles() {
+		err = profile.WriteTo(buf, 0)
+		if err != nil {
+			return err
+		}
+
+		header := tar.Header{
+			Typeflag:   tar.TypeReg,
+			Name:       fmt.Sprintf("%s.pprof", profile.Name()),
+			Linkname:   "",
+			Size:       int64(buf.Len()),
+			Mode:       0o664,
+			Uid:        0,
+			Gid:        0,
+			Uname:      "",
+			Gname:      "",
+			ModTime:    now,
+			AccessTime: now,
+			ChangeTime: now,
+			Devmajor:   0,
+			Devminor:   0,
+			Xattrs:     map[string]string{},
+			PAXRecords: map[string]string{},
+			Format:     0,
+		}
+		log.Info().Msgf("tar header: %+v", header)
+		err = tw.WriteHeader(&header)
+		if err != nil {
+			return err
+		}
+		_, err = buf.WriteTo(tw)
+		if err != nil {
+			return err
+		}
+		buf.Reset()
+	}
+	return nil
 }

--- a/orbit/cmd/orbit/signal_windows.go
+++ b/orbit/cmd/orbit/signal_windows.go
@@ -10,3 +10,7 @@ import (
 func signalHandler(ctx context.Context) (execute func() error, interrupt func(error)) {
 	return run.SignalHandler(ctx, os.Interrupt, os.Kill)
 }
+
+func dumpProf(rootDir string) error {
+	return nil
+}

--- a/orbit/cmd/orbit/signal_windows.go
+++ b/orbit/cmd/orbit/signal_windows.go
@@ -11,6 +11,6 @@ func signalHandler(ctx context.Context) (execute func() error, interrupt func(er
 	return run.SignalHandler(ctx, os.Interrupt, os.Kill)
 }
 
-func dumpProf(rootDir string) error {
+func sigusrListener(rootDir string) error {
 	return nil
 }


### PR DESCRIPTION
Partially done prototype for dumping pprof to a .tar.gz when the orbit cli receives a `SIGUSR1`. I still need to add some documentation. Note that I'm using a .tar.gz but that may not be the best format because I need to know the length of the pprof before writing, which means I need to copy it into a buffer

# Checklist for submitter
- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.