### PR TITLE
run apt update before installing packages in golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run go lint
         run: |
           # The following packages are needed to build Fleet Desktop on Ubuntu.
-          sudo apt install -y gcc libgtk-3-dev libayatana-appindicator3-dev
+          sudo apt update && sudo apt install -y gcc libgtk-3-dev libayatana-appindicator3-dev
           # Don't forget to update
           # docs/Contributing/Testing-and-local-development.md when this
           # version changes

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run go lint
         run: |
           # The following packages are needed to build Fleet Desktop on Ubuntu.
-          sudo apt update && sudo apt install -y gcc libgtk-3-dev libayatana-appindicator3-dev
+          sudo apt update -y && sudo apt install -y gcc libgtk-3-dev libayatana-appindicator3-dev
           # Don't forget to update
           # docs/Contributing/Testing-and-local-development.md when this
           # version changes


### PR DESCRIPTION
As suggested by the title, this fixes CI that's currently failing with:

```
 Err:11 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libdbus-1-dev amd64 1.12.16-2ubuntu2.2
  404  Not Found [IP: 52.154.174.208 80]
Fetched 3622 kB in 3s (1401 kB/s)
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/d/dbus/libdbus-1-dev_1.12.16-2ubuntu2.2_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```