### PR TITLE
Website: Fix failing step in website deploy script

### DIFF
--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -51,8 +51,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    # Build storybook in the website's assets/ folder
-    - run: npm run build-storybook -- -o ./website/assets/storybook --loglevel verbose
+    # Download top-level dependencies and build Storybook in the website's assets/ folder
+    - run: npm install && npm run build-storybook -- -o ./website/assets/storybook --loglevel verbose
 
     # Now start building!
     # > …but first, get a little crazy for a sec and delete the top-level package.json file


### PR DESCRIPTION
Changes:
- Added `npm install` to the build storybook step of the website's deploy workflow to resolve an error with current builds.
