### PR TITLE
Fix bug with fleetctl apply for teams, clear agent options only if key is present

### DIFF
--- a/changes/issue-8336-fix-fleetctl-apply-teams
+++ b/changes/issue-8336-fix-fleetctl-apply-teams
@@ -1,0 +1,1 @@
+* Fixed a bug in `fleetctl apply` for teams, where a missing `agent_options` key in the YAML spec file would clear the existing agent options for the team (now it leaves it unchanged). If the key is present but empty, then it clears the agent options.

--- a/cmd/fleetctl/apply_test.go
+++ b/cmd/fleetctl/apply_test.go
@@ -189,6 +189,8 @@ spec:
 	require.Equal(t, "[+] applied 1 teams\n", runAppForTest(t, []string{"apply", "-f", filename}))
 	assert.Equal(t, []*fleet.EnrollSecret{{Secret: "AAA"}}, enrolledSecretsCalled[uint(42)])
 	assert.False(t, ds.ApplyEnrollSecretsFuncInvoked)
+	// agent options not provided, so left unchanged
+	assert.JSONEq(t, string(newAgentOpts), string(*teamsByName["team1"].Config.AgentOptions))
 
 	filename = writeTmpYml(t, `
 apiVersion: v1
@@ -209,6 +211,19 @@ spec:
 	assert.JSONEq(t, string(newAgentOpts), string(*teamsByName["team1"].Config.AgentOptions))
 	assert.Equal(t, []*fleet.EnrollSecret{{Secret: "BBB"}}, enrolledSecretsCalled[uint(42)])
 	assert.True(t, ds.ApplyEnrollSecretsFuncInvoked)
+
+	filename = writeTmpYml(t, `
+apiVersion: v1
+kind: team
+spec:
+  team:
+    agent_options:
+    name: team1
+`)
+
+	require.Equal(t, "[+] applied 1 teams\n", runAppForTest(t, []string{"apply", "-f", filename}))
+	// agent options provided but empty, clears the value
+	assert.Equal(t, "{}", string(*teamsByName["team1"].Config.AgentOptions))
 }
 
 func writeTmpYml(t *testing.T, contents string) string {

--- a/cmd/fleetctl/apply_test.go
+++ b/cmd/fleetctl/apply_test.go
@@ -223,7 +223,7 @@ spec:
 
 	require.Equal(t, "[+] applied 1 teams\n", runAppForTest(t, []string{"apply", "-f", filename}))
 	// agent options provided but empty, clears the value
-	assert.Equal(t, "{}", string(*teamsByName["team1"].Config.AgentOptions))
+	assert.Nil(t, teamsByName["team1"].Config.AgentOptions)
 }
 
 func writeTmpYml(t *testing.T, contents string) string {

--- a/cmd/fleetctl/apply_test.go
+++ b/cmd/fleetctl/apply_test.go
@@ -226,6 +226,10 @@ func TestApplyAppConfig(t *testing.T) {
 		return userRoleSpecList, nil
 	}
 
+	ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activityType string, details *map[string]interface{}) error {
+		return nil
+	}
+
 	ds.UserByEmailFunc = func(ctx context.Context, email string) (*fleet.User, error) {
 		if email == "admin1@example.com" {
 			return userRoleSpecList[0], nil
@@ -233,8 +237,13 @@ func TestApplyAppConfig(t *testing.T) {
 		return userRoleSpecList[1], nil
 	}
 
+	defaultAgentOpts := json.RawMessage(`{"config":{"foo":"bar"}}`)
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-		return &fleet.AppConfig{OrgInfo: fleet.OrgInfo{OrgName: "Fleet"}, ServerSettings: fleet.ServerSettings{ServerURL: "https://example.org"}}, nil
+		return &fleet.AppConfig{
+			OrgInfo:        fleet.OrgInfo{OrgName: "Fleet"},
+			ServerSettings: fleet.ServerSettings{ServerURL: "https://example.org"},
+			AgentOptions:   &defaultAgentOpts,
+		}, nil
 	}
 
 	var savedAppConfig *fleet.AppConfig
@@ -256,6 +265,8 @@ spec:
 	require.NotNil(t, savedAppConfig)
 	assert.False(t, savedAppConfig.Features.EnableHostUsers)
 	assert.False(t, savedAppConfig.Features.EnableSoftwareInventory)
+	// agent options were not modified, since they were not provided
+	assert.Equal(t, string(defaultAgentOpts), string(*savedAppConfig.AgentOptions))
 
 	name = writeTmpYml(t, `---
 apiVersion: v1
@@ -264,12 +275,15 @@ spec:
   features:
     enable_host_users: true
     enable_software_inventory: true
+  agent_options:
 `)
 
 	assert.Equal(t, "[+] applied fleet config\n", runAppForTest(t, []string{"apply", "-f", name}))
 	require.NotNil(t, savedAppConfig)
 	assert.True(t, savedAppConfig.Features.EnableHostUsers)
 	assert.True(t, savedAppConfig.Features.EnableSoftwareInventory)
+	// agent options were cleared, provided but empty
+	assert.Nil(t, savedAppConfig.AgentOptions)
 }
 
 func TestApplyAppConfigDryRunIssue(t *testing.T) {

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -518,7 +518,11 @@ func (svc Service) createTeamFromSpec(ctx context.Context, spec *fleet.TeamSpec,
 
 func (svc Service) editTeamFromSpec(ctx context.Context, team *fleet.Team, spec *fleet.TeamSpec, secrets []*fleet.EnrollSecret) error {
 	team.Name = spec.Name
-	team.Config.AgentOptions = spec.AgentOptions
+
+	// if agent options are not provided, do not change them
+	if spec.AgentOptions != nil {
+		team.Config.AgentOptions = spec.AgentOptions
+	}
 
 	// replace (don't merge) the features with the new ones, using a config
 	// that has the global defaults applied.

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -3,6 +3,7 @@
 package spec
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,7 +19,7 @@ var yamlSeparator = regexp.MustCompile(`(?m:^---[\t ]*)`)
 // Group holds a set of "specs" that can be applied to a Fleet server.
 type Group struct {
 	Queries  []*fleet.QuerySpec
-	Teams    []json.RawMessage
+	Teams    []map[string]json.RawMessage
 	Packs    []*fleet.PackSpec
 	Labels   []*fleet.LabelSpec
 	Policies []*fleet.PolicySpec
@@ -118,9 +119,19 @@ func GroupFromBytes(b []byte) (*Group, error) {
 			// unmarshal to a raw map as we don't want to strip away unknown/invalid
 			// fields at this point - that validation is done in the apply spec/teams
 			// endpoint so that it is enforced for both the API and the CLI.
-			rawTeam := make(map[string]json.RawMessage)
+			rawTeam := make(map[string]map[string]json.RawMessage)
 			if err := yaml.Unmarshal(s.Spec, &rawTeam); err != nil {
 				return nil, fmt.Errorf("unmarshaling %s spec: %w", kind, err)
+			}
+			// special-case the agent_options key: we want to leave the team's agent
+			// options untouched if the key is not provided, but we need to clear the
+			// agent options if the key is provided but empty. Unfortunately, once
+			// the JSON payload is decoded in the API, we can't distinguish between
+			// those two cases (the AgentOptions field will be nil in both cases). To
+			// allow this, we explicitly set the JSON to `{}` if the key is provided
+			// and its value is nil.
+			if v, ok := rawTeam["team"]["agent_options"]; ok && bytes.Equal(v, []byte("null")) {
+				rawTeam["team"]["agent_options"] = json.RawMessage("{}")
 			}
 			specs.Teams = append(specs.Teams, rawTeam["team"])
 

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -250,8 +250,18 @@ const (
 )
 
 type TeamSpec struct {
-	Name         string           `json:"name"`
-	AgentOptions *json.RawMessage `json:"agent_options"`
-	Secrets      []EnrollSecret   `json:"secrets"`
-	Features     *json.RawMessage `json:"features"`
+	Name string `json:"name"`
+
+	// We need to distinguish between the agent_options key being present but
+	// "empty" or being absent, as we leave the existing agent options unmodified
+	// if it is absent, and we clear it if present but empty.
+	//
+	// If the agent_options key is not provided, the field will be nil (Go nil).
+	// If the agent_options key is present but empty in the YAML, will be set to
+	// "null" (JSON null). Otherwise, if the key is present and set, it will be
+	// set to the agent options JSON object.
+	AgentOptions json.RawMessage `json:"agent_options,omitempty"` // marshals as "null" if omitempty is not set
+
+	Secrets  []EnrollSecret   `json:"secrets"`
+	Features *json.RawMessage `json:"features"`
 }

--- a/server/service/client_teams.go
+++ b/server/service/client_teams.go
@@ -19,7 +19,7 @@ func (c *Client) ListTeams(query string) ([]fleet.Team, error) {
 
 // ApplyTeams sends the list of Teams to be applied to the
 // Fleet instance.
-func (c *Client) ApplyTeams(specs []json.RawMessage, opts fleet.ApplySpecOptions) error {
+func (c *Client) ApplyTeams(specs []map[string]json.RawMessage, opts fleet.ApplySpecOptions) error {
 	verb, path := "POST", "/api/latest/fleet/spec/teams"
 	var responseBody applyTeamSpecsResponse
 	return c.authenticatedRequestWithQuery(map[string]interface{}{"specs": specs}, verb, path, &responseBody, opts.RawQuery())

--- a/server/service/client_teams.go
+++ b/server/service/client_teams.go
@@ -19,7 +19,7 @@ func (c *Client) ListTeams(query string) ([]fleet.Team, error) {
 
 // ApplyTeams sends the list of Teams to be applied to the
 // Fleet instance.
-func (c *Client) ApplyTeams(specs []map[string]json.RawMessage, opts fleet.ApplySpecOptions) error {
+func (c *Client) ApplyTeams(specs []json.RawMessage, opts fleet.ApplySpecOptions) error {
 	verb, path := "POST", "/api/latest/fleet/spec/teams"
 	var responseBody applyTeamSpecsResponse
 	return c.authenticatedRequestWithQuery(map[string]interface{}{"specs": specs}, verb, path, &responseBody, opts.RawQuery())

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -4425,6 +4425,17 @@ func (s *integrationTestSuite) TestAppConfig() {
 		require.NotEqual(t, fleet.ActivityTypeEditedAgentOptions, listActivities.Activities[0].Type)
 	}
 
+	// and it did not update the appconfig
+	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
+	require.Contains(t, string(*acResp.AgentOptions), `"logger_plugin": "tls"`) // default agent options has this setting
+
+	// test a change that does clear the agent options (the field is provided but empty).
+	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+		"agent_options": {}
+  }`), http.StatusOK, &acResp)
+	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
+	require.Equal(t, string(*acResp.AgentOptions), "{}")
+
 	// test a change that does modify the agent options.
 	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
 		"agent_options": { "config": {"views": {"foo": "bar"}} }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -83,7 +83,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamSpecs() {
     "enable_software_inventory": false,
     "additional_queries": {"foo": "bar"}
   }`)
-	teamSpecs := applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: teamName, AgentOptions: &agentOpts, Features: &features}}}
+	teamSpecs := applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: teamName, AgentOptions: agentOpts, Features: &features}}}
 	s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusOK)
 
 	team, err := s.ds.TeamByName(context.Background(), teamName)
@@ -106,7 +106,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamSpecs() {
 
 	// dry-run with invalid agent options
 	agentOpts = json.RawMessage(`{"config": {"nope": 1}}`)
-	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: teamName, AgentOptions: &agentOpts}}}
+	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: teamName, AgentOptions: agentOpts}}}
 	s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusBadRequest, "dry_run", "true")
 
 	// dry-run with empty body
@@ -128,7 +128,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamSpecs() {
 
 	// dry-run with valid agent options
 	agentOpts = json.RawMessage(`{"config": {"views": {"foo": "qux"}}}`)
-	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: teamName, AgentOptions: &agentOpts}}}
+	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: teamName, AgentOptions: agentOpts}}}
 	s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusOK, "dry_run", "true")
 
 	team, err = s.ds.TeamByName(context.Background(), teamName)
@@ -144,9 +144,18 @@ func (s *integrationEnterpriseTestSuite) TestTeamSpecs() {
 	require.NoError(t, err)
 	require.Contains(t, string(*team.Config.AgentOptions), `"foo": "bar"`) // unchanged
 
+	// apply with agent options specified but null
+	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: teamName, AgentOptions: json.RawMessage(`null`)}}}
+	s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusOK)
+
+	// agent options are cleared
+	team, err = s.ds.TeamByName(context.Background(), teamName)
+	require.NoError(t, err)
+	require.Nil(t, team.Config.AgentOptions)
+
 	// force with invalid agent options
 	agentOpts = json.RawMessage(`{"config": {"foo": "qux"}}`)
-	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: teamName, AgentOptions: &agentOpts}}}
+	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: teamName, AgentOptions: agentOpts}}}
 	s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusOK, "force", "true")
 
 	team, err = s.ds.TeamByName(context.Background(), teamName)
@@ -165,12 +174,12 @@ func (s *integrationEnterpriseTestSuite) TestTeamSpecs() {
 
 	// invalid agent options command-line flag
 	agentOpts = json.RawMessage(`{"command_line_flags": {"nope": 1}}`)
-	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: teamName, AgentOptions: &agentOpts}}}
+	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: teamName, AgentOptions: agentOpts}}}
 	s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusBadRequest)
 
 	// valid agent options command-line flag
 	agentOpts = json.RawMessage(`{"command_line_flags": {"enable_tables": "abcd"}}`)
-	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: teamName, AgentOptions: &agentOpts}}}
+	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{Name: teamName, AgentOptions: agentOpts}}}
 	s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusOK)
 
 	team, err = s.ds.TeamByName(context.Background(), teamName)


### PR DESCRIPTION
#8336 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
