### PR TITLE
initialize empty slice for host counts usage statistics

### DIFF
--- a/changes/bug-8509-invalid-usage-stats
+++ b/changes/bug-8509-invalid-usage-stats
@@ -1,0 +1,1 @@
+# Fixed an issue where fleet would send invalid usage stats if no hosts were enrolled

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -3088,7 +3088,7 @@ WHERE
 }
 
 func amountHostsByOrbitVersionDB(ctx context.Context, db sqlx.QueryerContext) ([]fleet.HostsCountByOrbitVersion, error) {
-	var counts []fleet.HostsCountByOrbitVersion
+	counts := make([]fleet.HostsCountByOrbitVersion, 0)
 
 	const stmt = `
 		SELECT version as orbit_version, count(*) as num_hosts
@@ -3096,14 +3096,14 @@ func amountHostsByOrbitVersionDB(ctx context.Context, db sqlx.QueryerContext) ([
 		GROUP BY version
   	`
 	if err := sqlx.SelectContext(ctx, db, &counts, stmt); err != nil {
-		return []fleet.HostsCountByOrbitVersion{}, err
+		return nil, err
 	}
 
 	return counts, nil
 }
 
 func amountHostsByOsqueryVersionDB(ctx context.Context, db sqlx.QueryerContext) ([]fleet.HostsCountByOsqueryVersion, error) {
-	var counts []fleet.HostsCountByOsqueryVersion
+	counts := make([]fleet.HostsCountByOsqueryVersion, 0)
 
 	const stmt = `
 		SELECT osquery_version, count(*) as num_hosts
@@ -3111,7 +3111,7 @@ func amountHostsByOsqueryVersionDB(ctx context.Context, db sqlx.QueryerContext) 
 		GROUP BY osquery_version
   	`
 	if err := sqlx.SelectContext(ctx, db, &counts, stmt); err != nil {
-		return []fleet.HostsCountByOsqueryVersion{}, err
+		return nil, err
 	}
 
 	return counts, nil

--- a/server/datastore/mysql/statistics_test.go
+++ b/server/datastore/mysql/statistics_test.go
@@ -49,11 +49,7 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	freeLicense := &fleet.LicenseInfo{Tier: "free"}
 
 	// First time running with no hosts
-	var stats fleet.StatisticsPayload
-	var shouldSend bool
-	var err error
-
-	stats, shouldSend, err = ds.ShouldSendStatistics(ctx, time.Millisecond, fleetConfig, premiumLicense)
+	stats, shouldSend, err := ds.ShouldSendStatistics(ctx, time.Millisecond, fleetConfig, premiumLicense)
 	require.NoError(t, err)
 	assert.True(t, shouldSend)
 	assert.Equal(t, "premium", stats.LicenseTier)
@@ -200,8 +196,6 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	assert.Equal(t, `[{"count":10,"loc":["a","b","c"]}]`, string(stats.StoredErrors))
 	assert.Equal(t, []fleet.HostsCountByOsqueryVersion{{OsqueryVersion: "4.9.0", NumHosts: 1}}, stats.HostsEnrolledByOsqueryVersion)
 	assert.Equal(t, []fleet.HostsCountByOrbitVersion{{OrbitVersion: "1.1.0", NumHosts: 1}}, stats.HostsEnrolledByOrbitVersion)
-
-	firstIdentifier = stats.AnonymousIdentifier
 
 	err = ds.RecordStatisticsSent(ctx)
 	require.NoError(t, err)

--- a/server/datastore/mysql/statistics_test.go
+++ b/server/datastore/mysql/statistics_test.go
@@ -53,33 +53,31 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	var shouldSend bool
 	var err error
 
-	/*
-		stats, shouldSend, err = ds.ShouldSendStatistics(ctx, time.Millisecond, fleetConfig, premiumLicense)
-		require.NoError(t, err)
-		assert.True(t, shouldSend)
-		assert.Equal(t, "premium", stats.LicenseTier)
-		assert.Equal(t, "Fleet", stats.Organization)
-		assert.Equal(t, 0, stats.NumHostsEnrolled)
-		assert.Equal(t, 0, stats.NumUsers)
-		assert.Equal(t, 0, stats.NumTeams)
-		assert.Equal(t, 0, stats.NumPolicies)
-		assert.Equal(t, 0, stats.NumLabels)
-		assert.Equal(t, false, stats.SoftwareInventoryEnabled)
-		assert.Equal(t, true, stats.SystemUsersEnabled)
-		assert.Equal(t, false, stats.VulnDetectionEnabled)
-		assert.Equal(t, false, stats.HostsStatusWebHookEnabled)
-		assert.Equal(t, 0, stats.NumWeeklyActiveUsers)
-		assert.Equal(t, 0, stats.NumWeeklyPolicyViolationDaysActual)
-		assert.Equal(t, 0, stats.NumWeeklyPolicyViolationDaysPossible)
-		assert.Equal(t, `[{"count":10,"loc":["a","b","c"]}]`, string(stats.StoredErrors))
-		assert.Equal(t, []fleet.HostsCountByOsqueryVersion{}, stats.HostsEnrolledByOsqueryVersion) // should be empty slice instead of nil
-		assert.Equal(t, []fleet.HostsCountByOrbitVersion{}, stats.HostsEnrolledByOrbitVersion) // should be empty slice instead of nil
+	stats, shouldSend, err = ds.ShouldSendStatistics(ctx, time.Millisecond, fleetConfig, premiumLicense)
+	require.NoError(t, err)
+	assert.True(t, shouldSend)
+	assert.Equal(t, "premium", stats.LicenseTier)
+	assert.Equal(t, "Fleet", stats.Organization)
+	assert.Equal(t, 0, stats.NumHostsEnrolled)
+	assert.Equal(t, 0, stats.NumUsers)
+	assert.Equal(t, 0, stats.NumTeams)
+	assert.Equal(t, 0, stats.NumPolicies)
+	assert.Equal(t, 0, stats.NumLabels)
+	assert.Equal(t, false, stats.SoftwareInventoryEnabled)
+	assert.Equal(t, true, stats.SystemUsersEnabled)
+	assert.Equal(t, false, stats.VulnDetectionEnabled)
+	assert.Equal(t, false, stats.HostsStatusWebHookEnabled)
+	assert.Equal(t, 0, stats.NumWeeklyActiveUsers)
+	assert.Equal(t, 0, stats.NumWeeklyPolicyViolationDaysActual)
+	assert.Equal(t, 0, stats.NumWeeklyPolicyViolationDaysPossible)
+	assert.Equal(t, `[{"count":10,"loc":["a","b","c"]}]`, string(stats.StoredErrors))
+	assert.Equal(t, []fleet.HostsCountByOsqueryVersion{}, stats.HostsEnrolledByOsqueryVersion) // should be empty slice instead of nil
+	assert.Equal(t, []fleet.HostsCountByOrbitVersion{}, stats.HostsEnrolledByOrbitVersion)     // should be empty slice instead of nil
 
-		firstIdentifier := stats.AnonymousIdentifier
+	firstIdentifier := stats.AnonymousIdentifier
 
-		err = ds.RecordStatisticsSent(ctx)
-		require.NoError(t, err)
-	*/
+	err = ds.RecordStatisticsSent(ctx)
+	require.NoError(t, err)
 
 	// Create new host for test
 	h1, err := ds.NewHost(ctx, &fleet.Host{
@@ -180,7 +178,7 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	time.Sleep(1100 * time.Millisecond) // ensure the DB timestamp is not in the same second
 
 	// Running with 1 host
-	stats, shouldSend, err = ds.ShouldSendStatistics(ctx, fleet.StatisticsFrequency, fleetConfig, premiumLicense)
+	stats, shouldSend, err = ds.ShouldSendStatistics(ctx, time.Millisecond, fleetConfig, premiumLicense)
 	require.NoError(t, err)
 	assert.True(t, shouldSend)
 	assert.NotEmpty(t, stats.AnonymousIdentifier)
@@ -203,7 +201,7 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	assert.Equal(t, []fleet.HostsCountByOsqueryVersion{{OsqueryVersion: "4.9.0", NumHosts: 1}}, stats.HostsEnrolledByOsqueryVersion)
 	assert.Equal(t, []fleet.HostsCountByOrbitVersion{{OrbitVersion: "1.1.0", NumHosts: 1}}, stats.HostsEnrolledByOrbitVersion)
 
-	firstIdentifier := stats.AnonymousIdentifier
+	firstIdentifier = stats.AnonymousIdentifier
 
 	err = ds.RecordStatisticsSent(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
#8509

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added/updated tests
