### PR TITLE
fix integration.yml CI workflow by setting a Go version

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -213,7 +213,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version: '^1.19.1'
 
     - name: Checkout Code
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2

--- a/.github/workflows/test-native-tooling-packaging.yml
+++ b/.github/workflows/test-native-tooling-packaging.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        go-version: ['^1.17.8']
+        go-version: ['^1.19.1']
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
We don't have a `matrix.go-version` defined, so the task was using `go1.17.13` as the default.

This explicitly sets the version to `go1.19.1`, I didn't use a `matrix` definition because at least for now, we only want to run this test using a single Go version.

Since I was there, I also updated test-native-tooling-packaging.yml to use `go1.19.1` too.

