### PR TITLE
Fleet UI: Fix dropdown by fixing icon styling

### DIFF
--- a/frontend/components/BackLink/BackLink.tsx
+++ b/frontend/components/BackLink/BackLink.tsx
@@ -29,7 +29,7 @@ const BackLink = ({ text, path, className }: IBackLinkProps): JSX.Element => {
           direction="left"
           color="coreVibrantBlue"
         />
-        {text}
+        <span>{text}</span>
       </>
     </Link>
   );

--- a/frontend/components/BackLink/_styles.scss
+++ b/frontend/components/BackLink/_styles.scss
@@ -1,4 +1,7 @@
 .back-link {
+  display: flex;
+  align-items: center;
+
   &__back-icon {
     padding-right: $pad-small;
     display: inline;

--- a/frontend/components/Icon/_styles.scss
+++ b/frontend/components/Icon/_styles.scss
@@ -1,5 +1,5 @@
 .icon {
-  // only style that aligns properly whether in text
-  display: inline;
-  vertical-align: middle;
+  // keeps this element the same size as the svg
+  // aligns properly in text, buttons, dropdowns, summary tile custom component
+  display: inline-flex;
 }

--- a/frontend/components/icons/CalendarCheck.tsx
+++ b/frontend/components/icons/CalendarCheck.tsx
@@ -3,9 +3,9 @@ import React from "react";
 const CalendarCheck = () => {
   return (
     <svg
-      width="14"
-      height="14"
-      viewBox="0 0 14 14"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >


### PR DESCRIPTION
- Fixes icon styling to work for all buttons, dropdowns, inline text, custom components like summary tile
- The svg was somehow creating the parent of it to have extra padding inside, needed inline-flex to remove padding

Co-authored by: Gabe Hernandez 


- [x] Manual QA for all new/changed functionality