### PR TITLE
add passed policies column to inherited policies table. Add new colors and add to icons.

### DIFF
--- a/changes/issue-7671-add-policies-columns
+++ b/changes/issue-7671-add-policies-columns
@@ -1,0 +1,1 @@
+- add passed policies column on the inherited policies table for teams

--- a/frontend/components/BackLink/BackLink.tsx
+++ b/frontend/components/BackLink/BackLink.tsx
@@ -27,7 +27,7 @@ const BackLink = ({ text, path, className }: IBackLinkProps): JSX.Element => {
           name="chevron"
           className={`${baseClass}__back-icon`}
           direction="left"
-          color="coreVibrantBlue"
+          color="core-fleet-blue"
         />
         <span>{text}</span>
       </>

--- a/frontend/components/Icon/Icon.tsx
+++ b/frontend/components/Icon/Icon.tsx
@@ -1,10 +1,12 @@
 import React, { useMemo } from "react";
-import { IconNames, ICON_MAP } from "components/icons";
 import classnames from "classnames";
+
+import { IconNames, ICON_MAP } from "components/icons";
+import { Colors } from "styles/var/colors";
 
 interface IIconProps {
   name: IconNames;
-  color?: "coreVibrantBlue" | "coreFleetBlack";
+  color?: Colors;
   direction?: "up" | "down" | "left" | "right";
   className?: string;
   size?: "small" | "medium";

--- a/frontend/components/ViewAllHostsLink/ViewAllHostsLink.tsx
+++ b/frontend/components/ViewAllHostsLink/ViewAllHostsLink.tsx
@@ -33,7 +33,7 @@ const ViewAllHostsLink = ({
         name="chevron"
         className={`${baseClass}__icon`}
         direction="right"
-        color="coreVibrantBlue"
+        color="core-fleet-blue"
       />
     </Link>
   );

--- a/frontend/components/icons/Chevron.tsx
+++ b/frontend/components/icons/Chevron.tsx
@@ -1,7 +1,8 @@
 import React from "react";
+import { COLORS, Colors } from "styles/var/colors";
 
 interface IChevronProps {
-  color?: "coreVibrantBlue" | "coreFleetBlack";
+  color?: Colors;
   /** Default direction "down" */
   direction?: "up" | "down" | "left" | "right";
 }
@@ -17,13 +18,8 @@ const SVG_PATH = {
     "M10.891 7.749 6.594 3.605a.385.385 0 0 0-.528 0l-.957.927a.345.345 0 0 0 0 .502L8.189 8l-3.08 2.966a.345.345 0 0 0 0 .502l.957.927c.145.14.383.14.528 0l4.297-4.144a.345.345 0 0 0 0-.502Z",
 };
 
-const FLEET_COLORS = {
-  coreFleetBlack: "#192147",
-  coreVibrantBlue: "#6a67fe",
-};
-
 const Chevron = ({
-  color = "coreFleetBlack",
+  color = "core-fleet-black",
   direction = "down",
 }: IChevronProps) => {
   return (
@@ -32,7 +28,7 @@ const Chevron = ({
         fillRule="evenodd"
         clipRule="evenodd"
         d={SVG_PATH[direction]}
-        fill={FLEET_COLORS[color]}
+        fill={COLORS[color]}
       />
     </svg>
   );

--- a/frontend/components/icons/Error.tsx
+++ b/frontend/components/icons/Error.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+interface IErrorProps {
+  color?: "coreVibrantBlue" | "coreFleetBlack";
+}
+
+const FLEET_COLORS = {
+  coreFleetBlack: "#192147",
+  coreVibrantBlue: "#6a67fe",
+};
+
+const Error = ({ color = "coreFleetBlack" }: IErrorProps) => {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm1 13H7v-2h2v2zm-2-3h2V3H7v7z"
+        fill="#515774"
+      />
+    </svg>
+  );
+};
+
+export default Error;

--- a/frontend/components/icons/Error.tsx
+++ b/frontend/components/icons/Error.tsx
@@ -1,15 +1,12 @@
 import React from "react";
 
+import { COLORS, Colors } from "styles/var/colors";
+
 interface IErrorProps {
-  color?: "coreVibrantBlue" | "coreFleetBlack";
+  color?: Colors;
 }
 
-const FLEET_COLORS = {
-  coreFleetBlack: "#192147",
-  coreVibrantBlue: "#6a67fe",
-};
-
-const Error = ({ color = "coreFleetBlack" }: IErrorProps) => {
+const Error = ({ color = "status-error" }: IErrorProps) => {
   return (
     <svg
       width="16"
@@ -22,7 +19,7 @@ const Error = ({ color = "coreFleetBlack" }: IErrorProps) => {
         fillRule="evenodd"
         clipRule="evenodd"
         d="M8 0C3.58 0 0 3.58 0 8s3.58 8 8 8 8-3.58 8-8-3.58-8-8-8zm1 13H7v-2h2v2zm-2-3h2V3H7v7z"
-        fill="#515774"
+        fill={COLORS[color]}
       />
     </svg>
   );

--- a/frontend/components/icons/Success.tsx
+++ b/frontend/components/icons/Success.tsx
@@ -1,15 +1,11 @@
 import React from "react";
+import { COLORS, Colors } from "styles/var/colors";
 
 interface ISuccessProps {
-  color?: "coreVibrantBlue" | "coreFleetBlack";
+  color?: Colors;
 }
 
-const FLEET_COLORS = {
-  coreFleetBlack: "#192147",
-  coreVibrantBlue: "#6a67fe",
-};
-
-const Success = ({ color = "coreFleetBlack" }: ISuccessProps) => {
+const Success = ({ color = "status-success" }: ISuccessProps) => {
   return (
     <svg
       width="16"
@@ -22,7 +18,7 @@ const Success = ({ color = "coreFleetBlack" }: ISuccessProps) => {
         fillRule="evenodd"
         clipRule="evenodd"
         d="M0 8c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8-8 3.58-8 8Zm11.29-2.71a1.003 1.003 0 0 1 1.42 1.42l-5 5c-.18.18-.43.29-.71.29-.28 0-.53-.11-.71-.29l-3-3a1.003 1.003 0 0 1 1.42-1.42L7 9.59l4.29-4.3Z"
-        fill="#515774"
+        fill={COLORS[color]}
       />
     </svg>
   );

--- a/frontend/components/icons/Success.tsx
+++ b/frontend/components/icons/Success.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+interface ISuccessProps {
+  color?: "coreVibrantBlue" | "coreFleetBlack";
+}
+
+const FLEET_COLORS = {
+  coreFleetBlack: "#192147",
+  coreVibrantBlue: "#6a67fe",
+};
+
+const Success = ({ color = "coreFleetBlack" }: ISuccessProps) => {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M0 8c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8-8 3.58-8 8Zm11.29-2.71a1.003 1.003 0 0 1 1.42 1.42l-5 5c-.18.18-.43.29-.71.29-.28 0-.53-.11-.71-.29l-3-3a1.003 1.003 0 0 1 1.42-1.42L7 9.59l4.29-4.3Z"
+        fill="#515774"
+      />
+    </svg>
+  );
+};
+
+export default Success;

--- a/frontend/components/icons/index.ts
+++ b/frontend/components/icons/index.ts
@@ -9,6 +9,8 @@ import ApplePurple from "./ApplePurple";
 import LinuxGreen from "./LinuxGreen";
 import WindowsBlue from "./WindowsBlue";
 import ExternalLink from "./ExternalLink";
+import Error from "./Error";
+import Success from "./Success";
 import Check from "./Check";
 import Plus from "./Plus";
 
@@ -18,6 +20,8 @@ export const ICON_MAP = {
   chevron: Chevron,
   check: Check,
   plus: Plus,
+  success: Success,
+  error: Error,
   darwin: Apple,
   macOS: Apple,
   windows: Windows,

--- a/frontend/pages/hosts/ManageHostsPage/components/CustomDropdownIndicator/CustomDropdownIndicator.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/CustomDropdownIndicator/CustomDropdownIndicator.tsx
@@ -15,7 +15,9 @@ const CustomDropdownIndicator = (
   // no access to hover state here from react-select so that is done in the scss
   // file of LabelFilterSelect.
   const color =
-    isFocused || selectProps.menuIsOpen ? "coreVibrantBlue" : "coreFleetBlack";
+    isFocused || selectProps.menuIsOpen
+      ? "core-fleet-blue"
+      : "core-fleet-black";
 
   return (
     <components.DropdownIndicator {...props} className={baseClass}>

--- a/frontend/pages/policies/ManagePoliciesPage/components/PassingColumnHeader/PassingColumnHeader.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PassingColumnHeader/PassingColumnHeader.tsx
@@ -1,0 +1,22 @@
+import Icon from "components/Icon";
+import React from "react";
+
+interface IPassingColumnHeaderProps {
+  isPassing: boolean;
+}
+
+const baseClass = "passing-column-header";
+
+const PassingColumnHeader = ({ isPassing }: IPassingColumnHeaderProps) => {
+  const iconName = isPassing ? "success" : "error";
+  const columnText = isPassing ? "Yes" : "No";
+
+  return (
+    <div className={baseClass}>
+      <Icon name={iconName} />
+      <span className="status-header-text">{columnText}</span>
+    </div>
+  );
+};
+
+export default PassingColumnHeader;

--- a/frontend/pages/policies/ManagePoliciesPage/components/PassingColumnHeader/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PassingColumnHeader/_styles.scss
@@ -1,0 +1,4 @@
+.passing-column-header {
+  display: flex;
+  align-items: center;
+}

--- a/frontend/pages/policies/ManagePoliciesPage/components/PassingColumnHeader/index.ts
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PassingColumnHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PassingColumnHeader";

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -14,6 +14,8 @@ import sortUtils from "utilities/sort";
 import { PolicyResponse } from "utilities/constants";
 import PassIcon from "../../../../../../assets/images/icon-check-circle-green-16x16@2x.png";
 import FailIcon from "../../../../../../assets/images/icon-action-fail-16x16@2x.png";
+import PassingColumnHeader from "../PassingColumnHeader";
+import resultsTableHeaders from "pages/queries/QueryPage/components/QueryResults/QueryResultsTableConfig";
 
 // TODO functions for paths math e.g., path={PATHS.MANAGE_HOSTS + getParams(cellProps.row.original)}
 
@@ -99,178 +101,147 @@ const generateTableHeaders = (options: {
 }): IDataColumn[] => {
   const { selectedTeamId, tableType, canAddOrDeletePolicy } = options;
 
-  switch (tableType) {
-    case "inheritedPolicies":
-      return [
-        {
-          title: "Name",
-          Header: "Name",
-          disableSortBy: true,
-          accessor: "name",
-          Cell: (cellProps: ICellProps): JSX.Element => (
+  const tableColumns: IDataColumn[] = [
+    {
+      title: "Name",
+      Header: "Name",
+      disableSortBy: true,
+      accessor: "name",
+      Cell: (cellProps: ICellProps): JSX.Element => (
+        <LinkCell
+          classes="w250-sm"
+          value={cellProps.cell.value}
+          path={PATHS.EDIT_POLICY(cellProps.row.original)}
+        />
+      ),
+    },
+    {
+      title: "Yes",
+      Header: () => <PassingColumnHeader isPassing />,
+      disableSortBy: true,
+      accessor: "passing_host_count",
+      Cell: (cellProps: ICellProps): JSX.Element => {
+        if (cellProps.row.original.has_run) {
+          return (
             <LinkCell
-              value={cellProps.cell.value}
-              path={PATHS.EDIT_POLICY(cellProps.row.original)}
-              classes="" // Override default
+              value={`${cellProps.cell.value} host${
+                cellProps.cell.value.toString() === "1" ? "" : "s"
+              }`}
+              path={
+                PATHS.MANAGE_HOSTS +
+                TAGGED_TEMPLATES.hostsByPolicyRoute(
+                  cellProps.row.original.id,
+                  PolicyResponse.PASSING,
+                  selectedTeamId
+                )
+              }
             />
-          ),
-        },
-      ];
-    default: {
-      const tableHeaders: IDataColumn[] = [
-        {
-          title: "Name",
-          Header: "Name",
-          disableSortBy: true,
-          accessor: "name",
-          Cell: (cellProps: ICellProps): JSX.Element => (
+          );
+        }
+        return (
+          <>
+            <span
+              className="text-cell text-muted has-not-run tooltip"
+              data-tip
+              data-for={`passing_${cellProps.row.original.id.toString()}`}
+            >
+              ---
+            </span>
+            <ReactTooltip
+              place="bottom"
+              effect="solid"
+              backgroundColor="#3e4771"
+              id={`passing_${cellProps.row.original.id.toString()}`}
+              data-html
+            >
+              {getTooltip(cellProps.row.original.osquery_policy_ms)}
+            </ReactTooltip>
+          </>
+        );
+      },
+    },
+    {
+      title: "No",
+      Header: () => <PassingColumnHeader isPassing={false} />,
+      disableSortBy: true,
+      accessor: "failing_host_count",
+      Cell: (cellProps: ICellProps): JSX.Element => {
+        if (cellProps.row.original.has_run) {
+          return (
             <LinkCell
-              classes="w250-sm"
-              value={cellProps.cell.value}
-              path={PATHS.EDIT_POLICY(cellProps.row.original)}
+              value={`${cellProps.cell.value} host${
+                cellProps.cell.value.toString() === "1" ? "" : "s"
+              }`}
+              path={
+                PATHS.MANAGE_HOSTS +
+                TAGGED_TEMPLATES.hostsByPolicyRoute(
+                  cellProps.row.original.id,
+                  PolicyResponse.FAILING,
+                  selectedTeamId
+                )
+              }
             />
-          ),
-        },
-        {
-          title: "Yes",
-          Header: () => (
-            <>
-              <img alt="host passing" src={PassIcon} />
-              <span className="status-header-text">Yes</span>
-            </>
-          ),
-          disableSortBy: true,
-          accessor: "passing_host_count",
-          Cell: (cellProps: ICellProps): JSX.Element => {
-            if (cellProps.row.original.has_run) {
-              return (
-                <LinkCell
-                  value={`${cellProps.cell.value} host${
-                    cellProps.cell.value.toString() === "1" ? "" : "s"
-                  }`}
-                  path={
-                    PATHS.MANAGE_HOSTS +
-                    TAGGED_TEMPLATES.hostsByPolicyRoute(
-                      cellProps.row.original.id,
-                      PolicyResponse.PASSING,
-                      selectedTeamId
-                    )
-                  }
-                />
-              );
-            }
-            return (
-              <>
-                <span
-                  className="text-cell text-muted has-not-run tooltip"
-                  data-tip
-                  data-for={`passing_${cellProps.row.original.id.toString()}`}
-                >
-                  ---
-                </span>
-                <ReactTooltip
-                  place="bottom"
-                  effect="solid"
-                  backgroundColor="#3e4771"
-                  id={`passing_${cellProps.row.original.id.toString()}`}
-                  data-html
-                >
-                  {getTooltip(cellProps.row.original.osquery_policy_ms)}
-                </ReactTooltip>
-              </>
-            );
-          },
-        },
-        {
-          title: "No",
-          Header: () => (
-            <>
-              <img alt="host passing" src={FailIcon} />
-              <span className="status-header-text">No</span>
-            </>
-          ),
-          disableSortBy: true,
-          accessor: "failing_host_count",
-          Cell: (cellProps: ICellProps): JSX.Element => {
-            if (cellProps.row.original.has_run) {
-              return (
-                <LinkCell
-                  value={`${cellProps.cell.value} host${
-                    cellProps.cell.value.toString() === "1" ? "" : "s"
-                  }`}
-                  path={
-                    PATHS.MANAGE_HOSTS +
-                    TAGGED_TEMPLATES.hostsByPolicyRoute(
-                      cellProps.row.original.id,
-                      PolicyResponse.FAILING,
-                      selectedTeamId
-                    )
-                  }
-                />
-              );
-            }
-            return (
-              <>
-                <span
-                  className="text-cell text-muted has-not-run tooltip"
-                  data-tip
-                  data-for={`failing_${cellProps.row.original.id.toString()}`}
-                >
-                  ---
-                </span>
-                <ReactTooltip
-                  place="bottom"
-                  effect="solid"
-                  backgroundColor="#3e4771"
-                  id={`failing_${cellProps.row.original.id.toString()}`}
-                  data-html
-                >
-                  {getTooltip(cellProps.row.original.osquery_policy_ms)}
-                </ReactTooltip>
-              </>
-            );
-          },
-        },
-        {
-          title: "Automations",
-          Header: "Automations",
-          disableSortBy: true,
-          accessor: "webhook",
-          Cell: (cellProps: ICellProps): JSX.Element => (
-            <StatusCell value={cellProps.cell.value} />
-          ),
-        },
-      ];
+          );
+        }
+        return (
+          <>
+            <span
+              className="text-cell text-muted has-not-run tooltip"
+              data-tip
+              data-for={`failing_${cellProps.row.original.id.toString()}`}
+            >
+              ---
+            </span>
+            <ReactTooltip
+              place="bottom"
+              effect="solid"
+              backgroundColor="#3e4771"
+              id={`failing_${cellProps.row.original.id.toString()}`}
+              data-html
+            >
+              {getTooltip(cellProps.row.original.osquery_policy_ms)}
+            </ReactTooltip>
+          </>
+        );
+      },
+    },
+  ];
 
-      if (!canAddOrDeletePolicy) {
-        return tableHeaders;
-      }
+  if (tableType !== "inheritedPolicies") {
+    tableColumns.unshift({
+      id: "selection",
+      Header: (cellProps: IHeaderProps) => {
+        const props = cellProps.getToggleAllRowsSelectedProps();
+        const checkboxProps = {
+          value: props.checked,
+          indeterminate: props.indeterminate,
+          onChange: () => cellProps.toggleAllRowsSelected(),
+        };
+        return <Checkbox {...checkboxProps} />;
+      },
+      Cell: (cellProps: ICellProps): JSX.Element => {
+        const props = cellProps.row.getToggleRowSelectedProps();
+        const checkboxProps = {
+          value: props.checked,
+          onChange: () => cellProps.row.toggleRowSelected(),
+        };
+        return <Checkbox {...checkboxProps} />;
+      },
+      disableHidden: true,
+    });
 
-      tableHeaders.unshift({
-        id: "selection",
-        Header: (cellProps: IHeaderProps): JSX.Element => {
-          const props = cellProps.getToggleAllRowsSelectedProps();
-          const checkboxProps = {
-            value: props.checked,
-            indeterminate: props.indeterminate,
-            onChange: () => cellProps.toggleAllRowsSelected(),
-          };
-          return <Checkbox {...checkboxProps} />;
-        },
-        Cell: (cellProps: ICellProps): JSX.Element => {
-          const props = cellProps.row.getToggleRowSelectedProps();
-          const checkboxProps = {
-            value: props.checked,
-            onChange: () => cellProps.row.toggleRowSelected(),
-          };
-          return <Checkbox {...checkboxProps} />;
-        },
-        disableHidden: true,
-      });
-
-      return tableHeaders;
-    }
+    tableColumns.push({
+      title: "Automations",
+      Header: "Automations",
+      disableSortBy: true,
+      accessor: "webhook",
+      Cell: (cellProps: ICellProps): JSX.Element => (
+        <StatusCell value={cellProps.cell.value} />
+      ),
+    });
   }
+
+  return tableColumns;
 };
 
 const generateDataSet = (

--- a/frontend/styles/var/colors.ts
+++ b/frontend/styles/var/colors.ts
@@ -1,0 +1,28 @@
+export type Colors = keyof typeof COLORS;
+
+export const COLORS = {
+  // core colors
+  "core-fleet-black": "#192147",
+  "core-fleet-blue": "#6A67FE",
+  "core-fleet-red": "#FF5C83",
+  "core-fleet-purple": "#AE6DDF",
+  "core-fleet-white": "#FFFFFF",
+
+  // ui colors
+  "ui-fleet-black-75": "#515774",
+  "ui-fleet-black-50": "#8B8FA2",
+  "ui-fleet-black-33": "#B3B6C1",
+  "ui-fleet-black-25": "#C5C7D1",
+  "ui-fleet-black-15": "#E2E4EA",
+  "ui-off-white": "#F9FAFC",
+  "ui-blue-hover": "#5D5AE7",
+  "ui-blue-pressed": "#4B4AB4",
+  "ui-blue-50": "#B4B2FE",
+  "ui-blue-25": "#D9D9FE",
+  "ui-blue-10": "#F1F0FF",
+
+  // Notifications & status
+  "status-success": "#3DB67B",
+  "status-warning": "#F8CD6B",
+  "status-error": "#ED6E85",
+};


### PR DESCRIPTION
relates to [#7671](https://github.com/fleetdm/fleet/issues/7671)

This adds two new columns to the inherited policies table.
![image](https://user-images.githubusercontent.com/1153709/199308779-3c3cb07c-080f-45fc-a473-354728be6eb4.png)


It also adds the colors from the design system and applies them to the icons. These new colors are from [this figma page](https://www.figma.com/file/qbjRu8jf01BzEfdcge1dgu/Fleet-style-guide-2022-(WIP)?node-id=46%3A7598)

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more info
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
