### PR TITLE
Fleet UI: App settings styling

### DIFF
--- a/changes/issue-8388-app-settings-styling
+++ b/changes/issue-8388-app-settings-styling
@@ -1,0 +1,1 @@
+* Styling improvements to App Settings page

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -80,3 +80,8 @@
     }
   }
 }
+
+// Removes arrows on Firefox number fields
+input[type="number"] {
+  -moz-appearance: textfield;
+}

--- a/frontend/pages/admin/AppSettingsPage/cards/Agents/Agents.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/Agents/Agents.tsx
@@ -69,19 +69,16 @@ const Agents = ({
   return (
     <form className={baseClass} onSubmit={onFormSubmit} autoComplete="off">
       <div className={`${baseClass}__section`}>
-        <div className={`${baseClass}__yaml`}>
-          <h2>Agent options</h2>
-          <p className={`${baseClass}__section-description`}>
-            Agent options configure the osquery agent. When you update agent
-            options, they will be applied the next time a host checks in to
-            Fleet.{" "}
-            <CustomLink
-              url="https://fleetdm.com/docs/using-fleet/fleet-ui#configuring-agent-options"
-              text="Learn more about agent options"
-              newTab
-              multiline
-            />
-          </p>
+        <h2>Agent options</h2>
+        <p className={`${baseClass}__section-description`}>
+          Agent options configure the osquery agent. When you update agent
+          options, they will be applied the next time a host checks in to Fleet.{" "}
+          <CustomLink
+            url="https://fleetdm.com/docs/using-fleet/fleet-ui#configuring-agent-options"
+            text="Learn more about agent options"
+            newTab
+            multiline
+          />
           {isPremiumTier ? (
             <InfoBanner>
               These options are not applied to hosts on a team. To update agent
@@ -98,6 +95,8 @@ const Agents = ({
               />
             </InfoBanner>
           )}
+        </p>
+        <div className={`${baseClass}__inputs ${baseClass}__inputs--agents`}>
           <p className={`${baseClass}__component-label`}>
             <b>YAML</b>
           </p>

--- a/frontend/pages/admin/AppSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
@@ -80,7 +80,7 @@ const FleetDesktop = ({
             onBlur={validateForm}
             error={formErrors.transparency_url}
           />
-          <p className={`${baseClass}__component-label`}>
+          <p className={`${baseClass}__component-details`}>
             When an end user clicks “Transparency” in the Fleet Desktop menu, by
             default they are taken to{" "}
             <CustomLink

--- a/frontend/pages/admin/AppSettingsPage/cards/Info/Info.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/Info/Info.tsx
@@ -64,7 +64,7 @@ const Info = ({
 
   return (
     <form className={baseClass} onSubmit={onFormSubmit} autoComplete="off">
-      <div className={`${baseClass}__section`}>
+      <div className={`${baseClass}__section org-info`}>
         <h2>Organization info</h2>
         <div className={`${baseClass}__inputs`}>
           <InputField

--- a/frontend/pages/admin/AppSettingsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/AppSettingsPage/cards/Sso/Sso.tsx
@@ -180,7 +180,7 @@ const Sso = ({
             parseTarget
             onBlur={validateForm}
             error={formErrors.idp_image_url}
-            tooltip="An optional link to an image such as a logo for the identity provider."
+            tooltip="An optional link to an image such <br/>as a logo for the identity provider."
           />
         </div>
         <div className={`${baseClass}__inputs`}>
@@ -192,7 +192,7 @@ const Sso = ({
             value={metadata}
             parseTarget
             onBlur={validateForm}
-            tooltip="Metadata provided by the identity provider. Either metadata or a metadata url must be provided."
+            tooltip="Metadata provided by the identity provider. Either<br/> metadata or a metadata url must be provided."
           />
         </div>
         <div className={`${baseClass}__inputs`}>

--- a/frontend/pages/admin/AppSettingsPage/components/OrgSettingsForm/_styles.scss
+++ b/frontend/pages/admin/AppSettingsPage/components/OrgSettingsForm/_styles.scss
@@ -47,6 +47,12 @@
   margin-top: $pad-medium;
 }
 
+.org-info .app-config-form {
+  &__inputs {
+    width: 60%;
+  }
+}
+
 .app-config-form {
   width: 100%;
 
@@ -90,12 +96,15 @@
 
     h2 {
       padding-bottom: $pad-small;
-      max-width: 65%;
+      max-width: 100%;
       font-size: $medium;
       font-weight: $regular;
       color: $core-fleet-black;
       border-bottom: solid 1px $ui-fleet-blue-15;
       margin: 0 0 $pad-xxlarge;
+      @media(min-width: $break-990) {
+        max-width: 65%;
+      }
     }
 
     .smtp-options {
@@ -125,14 +134,22 @@
   &__section-description {
     font-size: $x-small;
     color: $core-fleet-black;
-    width: 60%;
+    width: 100%;
+    @media(min-width: $break-990) {
+      width: 60%;
+    }
   }
 
+
+
   &__inputs {
-    width: 60%;
+    width: 100%;
     float: left;
     padding-right: $pad-small;
     box-sizing: border-box;
+    @media(min-width: $break-990) {
+      width: 60%;
+    }
 
     .input-field {
       width: 100%;

--- a/frontend/pages/admin/AppSettingsPage/components/OrgSettingsForm/_styles.scss
+++ b/frontend/pages/admin/AppSettingsPage/components/OrgSettingsForm/_styles.scss
@@ -43,6 +43,10 @@
   }
 }
 
+.info-banner {
+  margin-top: $pad-medium;
+}
+
 .app-config-form {
   width: 100%;
 
@@ -124,16 +128,6 @@
     width: 60%;
   }
 
-  &__yaml {
-    .app-config-form__section-description {
-      width: initial;
-    }
-
-    h2 {
-      max-width: initial;
-    }
-  }
-
   &__inputs {
     width: 60%;
     float: left;
@@ -176,8 +170,13 @@
       margin: $pad-medium 0;
     }
 
-    &--webhook {
+    &--webhook,
+    &--agents {
       margin-bottom: $pad-large;
+
+      .yaml-ace__label {
+        min-height: 0;
+      }
     }
   }
 
@@ -225,7 +224,7 @@
   }
 
   &__component-label {
-    margin: 24px 0 0;
+    margin: $pad-medium 0 0;
     font-size: $x-small;
   }
 

--- a/frontend/pages/admin/AppSettingsPage/components/OrgSettingsForm/_styles.scss
+++ b/frontend/pages/admin/AppSettingsPage/components/OrgSettingsForm/_styles.scss
@@ -229,6 +229,11 @@
     font-size: $x-small;
   }
 
+  &__component-details {
+    margin: 0 0 $pad-medium;
+    font-size: $x-small;
+  }
+
   &__yaml {
     width: calc(90% - 50px);
     margin-bottom: $pad-medium;


### PR DESCRIPTION
Cerra #8388 

**Fixes**
- fix metadata tooltip popup styling. Too much padding at end of the lines. (xs)
- remove arrows on port input. occurs in firefox (xs)
- change the spacing between the Save button and bottom text on all sections (xs).
- All App Settings pages/forms defaults to 60% width over 990px screensize, and 100% for below 990px


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality