### PR TITLE
detect void as a linux platform as well

### DIFF
--- a/changes/issue-8344-add-arch-mint-linux-distros
+++ b/changes/issue-8344-add-arch-mint-linux-distros
@@ -1,1 +1,1 @@
-* Added arch and linuxmint to list of linux distros so that their data is displayed and host count includes them
+* Added arch, linuxmint and void to list of linux distros so that their data is displayed and host count includes them

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -294,7 +294,7 @@ func (h *Host) FleetPlatform() string {
 
 // HostLinuxOSs are the possible linux values for Host.Platform.
 var HostLinuxOSs = []string{
-	"linux", "ubuntu", "debian", "rhel", "centos", "sles", "kali", "gentoo", "amzn", "pop", "arch", "linuxmint",
+	"linux", "ubuntu", "debian", "rhel", "centos", "sles", "kali", "gentoo", "amzn", "pop", "arch", "linuxmint", "void",
 }
 
 func IsLinux(hostPlatform string) bool {


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.

Not *quite* true, I sneaked into the changes file of https://github.com/fleetdm/fleet/pull/8532, considering it's basically just a small follow-up on that. I hope that's okay?
