### PR TITLE
Fleet UI: Activity feed includes editing team(s) config using fleetctl

### DIFF
--- a/changes/issue-7825-edit-team-config-file-fleetctl
+++ b/changes/issue-7825-edit-team-config-file-fleetctl
@@ -1,0 +1,1 @@
+* Activity feed includes editing team config file using fleetctl

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -1,5 +1,6 @@
 import { IPolicy } from "./policy";
 import { IQuery } from "./query";
+import { ITeamSummary } from "./team";
 
 export enum ActivityType {
   CreatedPack = "created_pack",
@@ -40,6 +41,7 @@ export interface IActivityDetails {
   query_name?: string;
   team_id?: number;
   team_name?: string;
+  teams?: ITeamSummary[];
   targets_count?: number;
   specs?: IQuery[] | IPolicy[];
   global?: boolean;

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tsx
@@ -51,6 +51,16 @@ const TAGGED_TEMPLATES = {
       ? "edited a query using fleetctl"
       : `edited ${count === 1 ? "a query" : "queries"} using fleetctl`;
   },
+  editTeamCtlActivityTemplate: (activity: IActivity) => {
+    const count = activity.details?.teams?.length;
+    return count === 1 && activity.details?.teams ? (
+      <>
+        edited <b>{activity.details?.teams[0].name}</b> team using fleetctl
+      </>
+    ) : (
+      "edited multiple teams using fleetctl"
+    );
+  },
   userAddedBySSOTempalte: () => {
     return `was added to Fleet by SSO`;
   },
@@ -109,11 +119,7 @@ const ActivityFeed = ({
       keepPreviousData: true,
       staleTime: 5000,
       select: (data) => {
-        // We purposly removed the "applied_spec_team" activity as we are currently
-        // thinking how we want to display this in the UI.
-        return data.activities.filter(
-          (activity) => activity.type !== ActivityType.AppliedSpecTeam
-        );
+        return data.activities;
       },
       onSuccess: (results) => {
         setShowActivityFeedTitle(true);
@@ -149,6 +155,9 @@ const ActivityFeed = ({
       }
       case ActivityType.AppliedSpecSavedQuery: {
         return TAGGED_TEMPLATES.editQueryCtlActivityTemplate(activity);
+      }
+      case ActivityType.AppliedSpecTeam: {
+        return TAGGED_TEMPLATES.editTeamCtlActivityTemplate(activity);
       }
       case ActivityType.UserAddedBySSO: {
         return TAGGED_TEMPLATES.userAddedBySSOTempalte();


### PR DESCRIPTION
Cerra #7825 

**Feature**
- Add editing a team using fleetctl onto activity feed

**Screenshot** (Edit 1 team vs. multiple teams)
<img width="610" alt="Screen Shot 2022-11-02 at 10 46 08 AM" src="https://user-images.githubusercontent.com/71795832/199521476-0733effa-e3ec-4518-bcd3-4eabca1b0806.png">

**How to QA (ask if you need more help)**
1. Log into fleetctl using the terminal: `fleetctl login`
2. Create a configs files below, test1team.yml and test2teams.yml
```
apiVersion: v1
kind: team
spec:
  team:
    name: Team 1
```

```
apiVersion: v1
kind: team
spec:
  team:
    name: Team 2
---
apiVersion: v1
kind: team
spec:
  team:
    name: Team 3
```
3. Apply those config files using fleetctl in terminal: `fleetctl apply -f ./tools/api/fleet/teams/test1team.yml` and `fleetctl apply -f ./tools/api/fleet/teams/test2teams.yml`  
4. Log into app and look for those two activities of applying the fleetctl yml teams edited in the feed


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
