### PR TITLE
Use tx instead of writer within withTx style code to prevent deadlocks

### DIFF
--- a/changes/fix-some-tx-not-used
+++ b/changes/fix-some-tx-not-used
@@ -1,0 +1,1 @@
+* Improve database usage to prevent some deadlocks

--- a/server/datastore/mysql/operating_systems.go
+++ b/server/datastore/mysql/operating_systems.go
@@ -24,11 +24,11 @@ func listOperatingSystemsDB(ctx context.Context, tx sqlx.QueryerContext) ([]flee
 
 func (ds *Datastore) UpdateHostOperatingSystem(ctx context.Context, hostID uint, hostOS fleet.OperatingSystem) error {
 	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		os, err := getOrGenerateOperatingSystemDB(ctx, ds.writer, hostOS)
+		os, err := getOrGenerateOperatingSystemDB(ctx, tx, hostOS)
 		if err != nil {
 			return err
 		}
-		return upsertHostOperatingSystemDB(ctx, ds.writer, hostID, os.ID)
+		return upsertHostOperatingSystemDB(ctx, tx, hostID, os.ID)
 	})
 }
 


### PR DESCRIPTION
https://github.com/fleetdm/fleet/issues/8555

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- ~Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~Documented any permissions changes~
- ~Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- ~Added/updated tests~
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - ~Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
