### PR TITLE
Fleet UI: Surface how to override invalid agent options

### DIFF
--- a/changes/issue-8002-inform-user-override-agent-options-validation
+++ b/changes/issue-8002-inform-user-override-agent-options-validation
@@ -1,0 +1,1 @@
+- When submitting invalid agent options, inform user how to override agent options using fleetctl force flag

--- a/frontend/pages/admin/AppSettingsPage/components/OrgSettingsForm/OrgSettingsForm.tsx
+++ b/frontend/pages/admin/AppSettingsPage/components/OrgSettingsForm/OrgSettingsForm.tsx
@@ -82,9 +82,24 @@ const OrgSettingsForm = ({
               "Could not connect to SMTP server. Please try again."
             );
           } else if (response?.data.errors) {
+            const agentOptionsInvalid =
+              response.data.errors[0].reason.includes(
+                "unsupported key provided"
+              ) ||
+              response.data.errors[0].reason.includes("invalid value type");
+
             renderFlash(
               "error",
-              `Could not update settings. ${response.data.errors[0].reason}`
+              <>
+                Could not update settings. {response.data.errors[0].reason}
+                {agentOptionsInvalid && (
+                  <>
+                    <br />
+                    If you’re not using the latest osquery, use the fleetctl
+                    apply --force command to override validation.
+                  </>
+                )}
+              </>
             );
           }
         })

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
@@ -109,9 +109,24 @@ const AgentOptionsPage = ({
       })
       .catch((response: { data: IApiError }) => {
         console.error(response);
+
+        const agentOptionsInvalid =
+          response.data.errors[0].reason.includes("unsupported key provided") ||
+          response.data.errors[0].reason.includes("invalid value type");
+
         return renderFlash(
           "error",
-          `Could not update ${teamName} team agent options. ${response.data.errors[0].reason}`
+          <>
+            Could not update {teamName} team agent options.{" "}
+            {response.data.errors[0].reason}
+            {agentOptionsInvalid && (
+              <>
+                <br />
+                If you’re not using the latest osquery, use the fleetctl apply
+                --force command to override validation.
+              </>
+            )}
+          </>
         );
       })
       .finally(() => {


### PR DESCRIPTION
Cerra #8002 

**Fixes**
- When a key or type is invalid in agent options, a message will appear in the error how to override the error for older osquery versions
- Updated on org settings agent options and team agent options

**Screenshots**
App agent options
<img width="1435" alt="Screen Shot 2022-11-03 at 1 19 07 PM" src="https://user-images.githubusercontent.com/71795832/199791997-c970f0f9-6789-48fd-ad9b-dec9c8ef3192.png">
Team agent options
<img width="1436" alt="Screen Shot 2022-11-03 at 1 27 33 PM" src="https://user-images.githubusercontent.com/71795832/199792495-ebb70ddd-990a-4f20-8032-86150c6ec525.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality