### PR TITLE
Fleet UI: Unreleased styling bugs (Enroll secret width, Label dropdown icon)

### DIFF
--- a/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/_styles.scss
+++ b/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/_styles.scss
@@ -15,7 +15,7 @@
       font-size: $x-small;
       font-weight: $bold;
       margin-bottom: 0;
-      width: 560px;
+      width: 485px;
     }
 
     .input-field {

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -34,6 +34,7 @@
       content: url(../assets/images/icon-filter-v2-black-16x16@2x.png);
       transform: scale(0.5);
       left: -6px;
+      top: -1px;
     }
   }
 


### PR DESCRIPTION
Cerra #8552, #8560

**Fixes**
- Fix input field width 100% that was flowing the edit and delete icons off the modal
- Fix icon in manage host page label dropdown to be vertically centered

**Screenshots**
<img width="750" alt="Screen Shot 2022-11-03 at 3 02 10 PM" src="https://user-images.githubusercontent.com/71795832/199812927-925458c7-31ac-48ed-90bb-8d26480dbad7.png">
<img width="755" alt="Screen Shot 2022-11-03 at 3 01 54 PM" src="https://user-images.githubusercontent.com/71795832/199812929-0231dbbb-ee92-4b64-864c-03c16b7658c3.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality