### PR TITLE
reduce the build time of loadtest.Dockerfile

### DIFF
--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -1,7 +1,6 @@
 FROM golang:1.19.1
 ARG TAG
-RUN apt update && apt upgrade -y && apt install npm yarnpkg -y && ln -s /usr/bin/yarnpkg /usr/bin/yarn
-RUN git clone -b $TAG https://github.com/fleetdm/fleet.git && cd /go/fleet/cmd/osquery-perf/ && go build .
+RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/cmd/osquery-perf/ && go build .
 
 FROM golang:1.19.1
 COPY --from=0 /go/fleet/cmd/osquery-perf/osquery-perf /go/osquery-perf


### PR DESCRIPTION
two minor things:

1. `yarn` is not needed to build `osquery-perf`
2. we can change the clone step to not fetch unnecessary data