### PR TITLE
Support low_disk_space filter for endpoint /labels/{id}/hosts

### DIFF
--- a/changes/8401-support-low-disk-space-filter-for-labels
+++ b/changes/8401-support-low-disk-space-filter-for-labels
@@ -1,0 +1,1 @@
+* Support low_disk_space filter for endpoint /labels/{id}/hosts.

--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -602,7 +602,7 @@ Returns a list of the activities that have been performed in Fleet. The followin
 
 Fleet supports osquery's file carving functionality as of Fleet 3.3.0. This allows the Fleet server to request files (and sets of files) from osquery agents, returning the full contents to Fleet.
 
-To initiate a file carve using the Fleet API, you can use the [live query](#run-live-query) or [scheduled query](#add-scheduled-query-to-a-pack) endpoints to run a query against the `carves` table.
+To initiate a file carve using the Fleet API, you can use the [live query](#run-live-query) endpoint to run a query against the `carves` table.
 
 For more information on executing a file carve in Fleet, go to the [File carving with Fleet docs](https://fleetdm.com/docs/using-fleet/fleetctl-cli#file-carving-with-fleet).
 
@@ -3222,6 +3222,7 @@ Returns a list of the hosts that belong to the specified label.
 | query                    | string  | query | Search query keywords. Searchable fields include `hostname`, `machine_serial`, `uuid`, and `ipv4`.                                                                                                                         |
 | team_id                  | integer | query | _Available in Fleet Premium_ Filters the hosts to only include hosts in the specified team.                                                                                                                                |
 | disable_failing_policies | boolean | query | If "true", hosts will return failing policies as 0 regardless of whether there are any that failed for the host. This is meant to be used when increased performance is needed in exchange for the extra information.      |
+| low_disk_space           | integer | query | _Available in Fleet Premium_ Filters the hosts to only include hosts with less GB of disk space available than this value. Must be a number between 1-100.                                                                 |
 
 #### Example
 
@@ -4851,7 +4852,6 @@ Deletes the session specified by ID. When the user associated with the session n
         "hosts_count": 1
       }
     ]
-  }
 }
 ```
 

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -510,7 +510,6 @@ func (ds *Datastore) ListHostsInLabel(ctx context.Context, filter fleet.TeamFilt
     LEFT JOIN host_seen_times hst ON (h.id=hst.host_id)
     LEFT JOIN host_disks hd ON (h.id=hd.host_id)
     %s
-    %s
 	`
 	failingPoliciesSelect := `,
 		coalesce(failing_policies.count, 0) as failing_policies_count,
@@ -526,12 +525,7 @@ func (ds *Datastore) ListHostsInLabel(ctx context.Context, filter fleet.TeamFilt
 		failingPoliciesJoin = ""
 	}
 
-	displayNameJoin := ""
-	if opt.ListOptions.OrderKey == "display_name" {
-		displayNameJoin = ` JOIN host_display_names hdn ON h.id = hdn.host_id `
-	}
-
-	query := fmt.Sprintf(queryFmt, failingPoliciesSelect, failingPoliciesJoin, displayNameJoin)
+	query := fmt.Sprintf(queryFmt, failingPoliciesSelect, failingPoliciesJoin)
 
 	query, params := ds.applyHostLabelFilters(filter, lid, query, opt)
 
@@ -547,7 +541,14 @@ func (ds *Datastore) ListHostsInLabel(ctx context.Context, filter fleet.TeamFilt
 func (ds *Datastore) applyHostLabelFilters(filter fleet.TeamFilter, lid uint, query string, opt fleet.HostListOptions) (string, []interface{}) {
 	params := []interface{}{lid}
 
+	if opt.ListOptions.OrderKey == "display_name" {
+		query += ` JOIN host_display_names hdn ON h.id = hdn.host_id `
+	}
 	query += fmt.Sprintf(` WHERE lm.label_id = ? AND %s `, ds.whereFilterHostsByTeams(filter, "h"))
+	if opt.LowDiskSpaceFilter != nil {
+		query += ` AND hd.gigs_disk_space_available < ? `
+		params = append(params, *opt.LowDiskSpaceFilter)
+	}
 	query, params = filterHostsByStatus(ds.clock.Now(), query, opt, params)
 	query, params = filterHostsByTeam(query, opt, params)
 	query, params = searchLike(query, params, opt.MatchQuery, hostSearchColumns...)
@@ -560,14 +561,12 @@ func (ds *Datastore) CountHostsInLabel(ctx context.Context, filter fleet.TeamFil
 	query := `SELECT count(*) FROM label_membership lm
     JOIN hosts h ON (lm.host_id = h.id)
 	LEFT JOIN host_seen_times hst ON (h.id=hst.host_id)
-	%s`
+ 	`
 
-	displayNameJoin := ""
-	if opt.ListOptions.OrderKey == "display_name" {
-		displayNameJoin = ` JOIN host_display_names hdn ON h.id = hdn.host_id `
+	if opt.LowDiskSpaceFilter != nil {
+		query += ` LEFT JOIN host_disks hd ON (h.id=hd.host_id) `
 	}
 
-	query = fmt.Sprintf(query, displayNameJoin)
 	query, params := ds.applyHostLabelFilters(filter, lid, query, opt)
 
 	var count int


### PR DESCRIPTION
For #8401

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md
- [x] Added/updated tests
- [X] Manual QA for all new/changed functionality