### PR TITLE
Ensure invite form always returns a base error

### DIFF
--- a/frontend/components/forms/ResetPasswordForm/ResetPasswordForm.jsx
+++ b/frontend/components/forms/ResetPasswordForm/ResetPasswordForm.jsx
@@ -12,6 +12,7 @@ const formFields = ["new_password", "new_password_confirmation"];
 
 class ResetPasswordForm extends Component {
   static propTypes = {
+    baseError: PropTypes.string,
     handleSubmit: PropTypes.func,
     fields: PropTypes.shape({
       new_password: formFieldInterface.isRequired,
@@ -20,10 +21,11 @@ class ResetPasswordForm extends Component {
   };
 
   render() {
-    const { fields, handleSubmit } = this.props;
+    const { baseError, fields, handleSubmit } = this.props;
 
     return (
       <form onSubmit={handleSubmit} className={baseClass}>
+        {baseError && <div className="form__base-error">{baseError}</div>}
         <InputFieldWithIcon
           {...fields.new_password}
           autofocus

--- a/frontend/utilities/format_error_response/index.ts
+++ b/frontend/utilities/format_error_response/index.ts
@@ -22,7 +22,6 @@ const formatServerErrors = (errors: IError[]) => {
 };
 
 const formatErrorResponse = (errorResponse: any) => {
-  console.log("errorResponse: ", errorResponse);
   const errors =
     get(errorResponse, "message.errors") ||
     get(errorResponse, "data.errors") ||

--- a/frontend/utilities/format_error_response/index.ts
+++ b/frontend/utilities/format_error_response/index.ts
@@ -14,7 +14,7 @@ const formatServerErrors = (errors: IError[]) => {
     if (result[name]) {
       result[name] = join([result[name], reason], ", ");
     } else {
-      result[name] = reason;
+      result.base = reason; // Ensure a base error is always returned
     }
   });
 
@@ -22,6 +22,7 @@ const formatServerErrors = (errors: IError[]) => {
 };
 
 const formatErrorResponse = (errorResponse: any) => {
+  console.log("errorResponse: ", errorResponse);
   const errors =
     get(errorResponse, "message.errors") ||
     get(errorResponse, "data.errors") ||


### PR DESCRIPTION
For #8306 

When our API returns errors, it provides an `errors` array containing `{name: string; reason: string;`. Typically, the first item is `name: "base"`. Our login/signup pages assume there is always a `"base"` value. 

Our `POST /users` endpoint does not return a `name: "base"` error. Instead, each error has a different name. In this example, the value was `"invite_token"`. In this case, it fails to display any error message.

This is a minimal change to make sure there is always a `"base"` error message, which is what the frontend assumes. This change corrects the reported bug. 

The login/signup pages would benefit from a refactor to clean up implementation details. There's also heavy use of `any`. However, that's outside the scope of this bug, so I'm going to go with the one-line solution for now. 