### PR TITLE
Frontend Integration Tests: Create activity integration tests, reorganized mock server calls

### DIFF
--- a/frontend/__mocks__/activityFeedMock.ts
+++ b/frontend/__mocks__/activityFeedMock.ts
@@ -1,0 +1,22 @@
+import { IActivity, ActivityType } from "interfaces/activity";
+
+const DEFAULT_ACTIVITY_MOCK: IActivity = {
+  created_at: "2022-11-03T17:22:14Z",
+  id: 1,
+  actor_full_name: "Rachel",
+  actor_id: 1,
+  actor_gravatar: "",
+  actor_email: "rachel@fleetdm.com",
+  type: ActivityType.EditedAgentOptions,
+  details: {
+    global: false,
+    team_id: 1,
+    team_name: "Apples",
+  },
+};
+
+const createMockActivity = (overrides?: Partial<IActivity>): IActivity => {
+  return { ...DEFAULT_ACTIVITY_MOCK, ...overrides };
+};
+
+export default createMockActivity;

--- a/frontend/components/Avatar/Avatar.tsx
+++ b/frontend/components/Avatar/Avatar.tsx
@@ -34,7 +34,7 @@ const Avatar = ({ className, size, user }: IAvatarInterface): JSX.Element => {
   return (
     <div className="avatar-wrapper">
       <img
-        alt={!isLoading && !isError ? "User avatar" : ""}
+        alt={"User avatar"}
         className={`${avatarClasses} ${isLoading || isError ? "default" : ""}`}
         src={gravatarURL || DEFAULT_GRAVATAR_LINK}
         onError={onError}

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tests.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { noop } from "lodash";
+
+import { createCustomRenderer } from "test/test-utils";
+import mockServer from "test/mock-server";
+import {
+  activityHandler2DaysAgo,
+  activityHandler9Activities,
+} from "test/handlers/activity-handlers";
+
+import ActivityFeed from "./ActivityFeed";
+
+describe("Activity Feed", () => {
+  it("renders the correct number of activities", async () => {
+    const render = createCustomRenderer({
+      withBackendMock: true,
+    });
+
+    render(<ActivityFeed setShowActivityFeedTitle={noop} />);
+
+    // waiting for the activity data to render
+    await screen.findByText("Rachel");
+
+    expect(screen.getByText("Rachel")).toBeInTheDocument();
+    expect(screen.getByText("Gabe")).toBeInTheDocument();
+    expect(screen.getByText("Luke")).toBeInTheDocument();
+  });
+  it("disables pagination when there are no more activities", async () => {
+    const render = createCustomRenderer({
+      withBackendMock: true,
+    });
+
+    render(<ActivityFeed setShowActivityFeedTitle={noop} />);
+
+    // waiting for the activity data to render
+    await screen.findByText("Rachel");
+
+    expect(screen.getByRole("button", { name: "Next" })).toBeDisabled();
+  });
+
+  it("enables next pagination when there are more activities", async () => {
+    mockServer.use(activityHandler9Activities);
+
+    const render = createCustomRenderer({
+      withBackendMock: true,
+    });
+
+    render(<ActivityFeed setShowActivityFeedTitle={noop} />);
+
+    // waiting for the activity data to render
+    await screen.findAllByText("Rachel");
+
+    expect(screen.getByRole("button", { name: "Next" })).toBeEnabled();
+  });
+
+  it("disables previous pagination on initial page", async () => {
+    const render = createCustomRenderer({
+      withBackendMock: true,
+    });
+
+    render(<ActivityFeed setShowActivityFeedTitle={noop} />);
+
+    // waiting for the activity data to render
+    await screen.findAllByText("Rachel");
+
+    expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
+  });
+
+  it("enables previous pagination when on subsequent pages", async () => {
+    mockServer.use(activityHandler9Activities);
+
+    const render = createCustomRenderer({
+      withBackendMock: true,
+    });
+
+    const { user } = render(<ActivityFeed setShowActivityFeedTitle={noop} />);
+
+    // waiting for the activity data to render
+    await screen.findAllByText("Rachel");
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    expect(screen.getByRole("button", { name: "Previous" })).toBeEnabled();
+  });
+
+  it("renders avatar, actor name, timestamp", async () => {
+    mockServer.use(activityHandler2DaysAgo);
+
+    const render = createCustomRenderer({
+      withBackendMock: true,
+    });
+
+    render(<ActivityFeed setShowActivityFeedTitle={noop} />);
+
+    // waiting for the activity data to render
+    await screen.findByText("Rachel");
+
+    expect(screen.getByRole("img")).toHaveAttribute("alt", "User avatar");
+    expect(screen.getByText("Rachel")).toBeInTheDocument();
+    expect(screen.getByText("2 days ago")).toBeInTheDocument();
+  });
+  // TODO: Create unit size component for individual activities and
+  // test each activity type with different details at the unit level
+});

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tests.tsx
@@ -26,7 +26,8 @@ describe("Activity Feed", () => {
     expect(screen.getByText("Gabe")).toBeInTheDocument();
     expect(screen.getByText("Luke")).toBeInTheDocument();
   });
-  it("disables pagination when there are no more activities", async () => {
+
+  it("disables next pagination when there are no more activities", async () => {
     const render = createCustomRenderer({
       withBackendMock: true,
     });

--- a/frontend/test/default-handlers.ts
+++ b/frontend/test/default-handlers.ts
@@ -1,0 +1,17 @@
+import { defaultActivityHandler } from "./handlers/activity-handlers";
+import {
+  defaultDeviceHandler,
+  defaultDeviceMappingHandler,
+} from "./handlers/device-handler";
+
+export const baseUrl = (path: string) => {
+  return `/api/latest/fleet${path}`;
+};
+
+const handlers = [
+  defaultDeviceHandler,
+  defaultDeviceMappingHandler,
+  defaultActivityHandler,
+];
+
+export default handlers;

--- a/frontend/test/handlers/activity-handlers.ts
+++ b/frontend/test/handlers/activity-handlers.ts
@@ -1,0 +1,58 @@
+import { rest } from "msw";
+
+import createMockActivity from "__mocks__/activityFeedMock";
+import { baseUrl } from "test/test-utils";
+
+export const defaultActivityHandler = rest.get(
+  baseUrl("/activities"),
+  (req, res, context) => {
+    return res(
+      context.json({
+        activities: [
+          createMockActivity(),
+          createMockActivity({ id: 2, actor_full_name: "Gabe" }),
+          createMockActivity({ id: 3, actor_full_name: "Luke" }),
+        ],
+      })
+    );
+  }
+);
+
+export const activityHandler9Activities = rest.get(
+  baseUrl("/activities"),
+  (req, res, context) => {
+    return res(
+      context.json({
+        activities: [
+          createMockActivity(),
+          createMockActivity({ id: 2 }),
+          createMockActivity({ id: 3 }),
+          createMockActivity({ id: 4 }),
+          createMockActivity({ id: 5 }),
+          createMockActivity({ id: 6 }),
+          createMockActivity({ id: 7 }),
+          createMockActivity({ id: 8 }),
+          createMockActivity({ id: 9 }),
+        ],
+      })
+    );
+  }
+);
+
+export const activityHandler2DaysAgo = rest.get(
+  baseUrl("/activities"),
+  (req, res, context) => {
+    const currentDate = new Date();
+    currentDate.setDate(currentDate.getDate() - 2);
+
+    return res(
+      context.json({
+        activities: [
+          createMockActivity({
+            created_at: currentDate.toISOString(),
+          }),
+        ],
+      })
+    );
+  }
+);

--- a/frontend/test/handlers/device-handler.ts
+++ b/frontend/test/handlers/device-handler.ts
@@ -3,13 +3,11 @@ import { rest } from "msw";
 import createMockDeviceUser from "__mocks__/deviceUserMock";
 import createMockHost from "__mocks__/hostMock";
 import createMockLicense from "__mocks__/licenseMock";
+import { baseUrl } from "test/test-utils";
 
-const baseUrl = (path: string) => {
-  return `/api/latest/fleet${path}`;
-};
-
-const handlers = [
-  rest.get(baseUrl("/device/:token"), (req, res, context) => {
+export const defaultDeviceHandler = rest.get(
+  baseUrl("/device/:token"),
+  (req, res, context) => {
     return res(
       context.json({
         host: createMockHost(),
@@ -17,16 +15,17 @@ const handlers = [
         org_logo_url: "",
       })
     );
-  }),
+  }
+);
 
-  rest.get(baseUrl("/device/:token/device_mapping"), (req, res, context) => {
+export const defaultDeviceMappingHandler = rest.get(
+  baseUrl("/device/:token/device_mapping"),
+  (req, res, context) => {
     return res(
       context.json({
         device_mapping: [createMockDeviceUser()],
         host_id: 1,
       })
     );
-  }),
-];
-
-export default handlers;
+  }
+);

--- a/frontend/test/mock-server.ts
+++ b/frontend/test/mock-server.ts
@@ -1,6 +1,6 @@
 import { setupServer } from "msw/node";
 
-import handlers from "./server-handlers";
+import handlers from "./default-handlers";
 
 const mockServer = setupServer(...handlers);
 

--- a/frontend/test/test-setup.ts
+++ b/frontend/test/test-setup.ts
@@ -5,4 +5,4 @@ import mockServer from "./mock-server";
 // Mock server setup
 beforeAll(() => mockServer.listen());
 afterEach(() => mockServer.resetHandlers());
-afterEach(() => mockServer.close());
+afterAll(() => mockServer.close());

--- a/frontend/test/test-utils.tsx
+++ b/frontend/test/test-utils.tsx
@@ -10,6 +10,10 @@ import {
   NotificationContext,
 } from "context/notification";
 
+export const baseUrl = (path: string) => {
+  return `/api/latest/fleet${path}`;
+};
+
 type RenderOptionsWithProviderProps = RenderOptions & {
   contextValue: Partial<IAppContext>;
 };


### PR DESCRIPTION
Related to #7825 

**Test upgrades**
- Add activity tests
  - Renders correct number of activities
  - Disables next pagination when there's no more activities
  - Enables next pagination when there's more activities
  - Disables previous pagination on initial page
  - Enables previous pagination on subsequent pages
  - Renders avatar, actor name, time stamp

**TODO for iterations on this test is outlined in the test comments**
- Create unit size component for an activity and test each activity type at the unit level

**Other**
- Re-organized server-handlers.ts to have non-default handlers in a separate directory called handlers
- Cleans up having to call custom handlers

<img width="1164" alt="Screen Shot 2022-11-08 at 12 42 18 PM" src="https://user-images.githubusercontent.com/71795832/200637169-897704cb-2150-4ae1-8998-293859941c1b.png">

Pair programmed with @ghernandez345 

Co-authored by: Gabe <ghernandez345@gmail.com>

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
