### PR TITLE
Fleet UI: Back link compatible with Firefox

### DIFF
--- a/frontend/components/BackLink/BackLink.tsx
+++ b/frontend/components/BackLink/BackLink.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { browserHistory, Link } from "react-router";
+import Button from "components/buttons/Button";
 import Icon from "components/Icon";
 import classnames from "classnames";
 
@@ -21,7 +22,8 @@ const BackLink = ({ text, path, className }: IBackLinkProps): JSX.Element => {
   };
 
   return (
-    <Link to={path || ".."} onClick={onClick} className={backLinkClass}>
+    /* Need to update react-router to use Link component to go back on FF */
+    <Button onClick={onClick} className={backLinkClass} variant="text-link">
       <>
         <Icon
           name="chevron"
@@ -31,7 +33,7 @@ const BackLink = ({ text, path, className }: IBackLinkProps): JSX.Element => {
         />
         <span>{text}</span>
       </>
-    </Link>
+    </Button>
   );
 };
 export default BackLink;

--- a/frontend/components/BackLink/BackLink.tsx
+++ b/frontend/components/BackLink/BackLink.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { browserHistory, Link } from "react-router";
+import { browserHistory } from "react-router";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon";
 import classnames from "classnames";

--- a/frontend/components/BackLink/_styles.scss
+++ b/frontend/components/BackLink/_styles.scss
@@ -1,4 +1,4 @@
-.back-link {
+.back-link .children-wrapper {
   display: inline-flex;
   align-items: center;
   padding: $pad-small $pad-xxsmall; // larger clickable area


### PR DESCRIPTION
Cerra #8622 

**Unreleased bug fix's fix**
- BackLink works on firefox to go back on manage host page and keep filters
- Issue is Link requires a to path and ".." default path doesn't play nice with FF. Other browsers seem to default to the onClick attribute, but FF defaults to the required path attribute.


**Consideration**
Update react-router from 3.6.2 to it's current 6.4 which will allow us to use new functionality and their API to deal with react-router thingz
- New react-router uses a useHistory hook to solve this issue

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

