### PR TITLE
Fleet UI: Move last word to next line with icon

### DIFF
--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
@@ -267,6 +267,7 @@ const ScheduleEditorModal = ({
               url="https://fleetdm.com/docs/deploying/configuration#osquery-result-log-plugin"
               text="how to configure a different log destination"
               newTab
+              multiline
             />
             .
           </p>


### PR DESCRIPTION
Cerra #8639 

**Fix**
- External link icon no longer on a line by itself (the word destination is wrapped to new line)

<img width="1257" alt="Screen Shot 2022-11-09 at 10 30 19 AM" src="https://user-images.githubusercontent.com/71795832/200872265-da26273f-cac5-412e-86b3-8031f27d4a90.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- not user visible bug
- [x] Manual QA for all new/changed functionality