### PR TITLE
Fleet UI: Various dropdown fixes

### DIFF
--- a/frontend/components/TableContainer/DataTable/DropdownCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/DropdownCell/_styles.scss
@@ -15,9 +15,15 @@
       border: 0;
     }
 
+    &.is-focused:not(.is-open) {
+      .Select-control {
+        background-color: initial;
+      }
+    }
+
     .Select-control {
       display: flex;
-      background-color: $core-white;
+      background-color: initial;
       height: auto;
       justify-content: space-between;
       border: 0;

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -57,12 +57,14 @@
     border-radius: $border-radius;
     .Select-value {
       font-size: $small;
+      background-color: $ui-light-grey;
     }
   }
 
   .Select-value {
     font-size: $small;
     border-radius: $border-radius;
+    background-color: $ui-light-grey;
 
     .Select-value-icon {
       border: 0;

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -57,14 +57,12 @@
     border-radius: $border-radius;
     .Select-value {
       font-size: $small;
-      background-color: $ui-off-white;
     }
   }
 
   .Select-value {
     font-size: $small;
     border-radius: $border-radius;
-    background-color: $ui-off-white;
 
     .Select-value-icon {
       border: 0;

--- a/frontend/components/forms/fields/SelectTargetsDropdown/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/_styles.scss
@@ -82,10 +82,6 @@
       color: $ui-fleet-black-50;
     }
 
-    // .Select-arrow-zone {
-    //   padding-right: 30px;
-    // }
-
     &.Select--multi {
       .Select-option {
         padding: 0;
@@ -146,7 +142,6 @@
   .Select-value {
     border-radius: $border-radius;
     background-color: $core-white;
-    // border: solid 1px $ui-fleet-blue-15;
 
     .Select-value-icon {
       height: 100%;

--- a/frontend/components/forms/fields/SelectTargetsDropdown/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/_styles.scss
@@ -27,8 +27,17 @@
   }
 
   &.Select {
+    border-radius: $border-radius;
+    border: 1px solid $ui-fleet-blue-15;
+
+    &.is-focused,
+    &:hover {
+      border: 1px solid $core-vibrant-blue;
+    }
+
     .Select-control {
       min-height: 48px;
+      background-color: $ui-light-grey;
     }
 
     .Select-arrow {
@@ -38,30 +47,20 @@
       margin-left: 6px;
       border: none;
 
-      &:hover {
-        content: url("../assets/images/icon-chevron-blue-16x16@2x.png");
-      }
-    }
-
-    &.is-open {
-      .Select-arrow {
-        content: url("../assets/images/icon-collapse-black-16x16@2x.png");
-        height: 16px;
-        width: 16px;
-        margin-left: 6px;
-        border: none;
-
-        &:hover {
-          content: url("../assets/images/icon-collapse-blue-16x16@2x.png");
-        }
-      }
-
       .Select-arrow-zone {
         &:hover {
           .Select-arrow {
             border-top-color: transparent;
           }
         }
+      }
+    }
+
+    &:hover,
+    &.is-open {
+      .Select-arrow {
+        content: url("../assets/images/icon-chevron-blue-16x16@2x.png");
+        margin-left: 6px;
       }
     }
 
@@ -80,11 +79,12 @@
     .Select-placeholder {
       line-height: 53px;
       font-size: $small;
+      color: $ui-fleet-black-50;
     }
 
-    .Select-arrow-zone {
-      padding-right: 30px;
-    }
+    // .Select-arrow-zone {
+    //   padding-right: 30px;
+    // }
 
     &.Select--multi {
       .Select-option {
@@ -108,12 +108,6 @@
         border: 1px solid $ui-fleet-black-75;
         margin-top: 5px;
         margin-bottom: 0;
-      }
-    }
-
-    &.is-focused {
-      .Select-control {
-        border: 1px solid $core-vibrant-blue;
       }
     }
   }
@@ -152,7 +146,7 @@
   .Select-value {
     border-radius: $border-radius;
     background-color: $core-white;
-    border: solid 1px $ui-fleet-blue-15;
+    // border: solid 1px $ui-fleet-blue-15;
 
     .Select-value-icon {
       height: 100%;


### PR DESCRIPTION
Cerra #8635 

**Fixes**

**Dropdown.jsx stylesheet**
- [x] The default `background-color` should be `$ui-light-grey` not `$ui-off-white` (Dropdowns for host table to be the same color--color confirmed on Figma: https://www.figma.com/file/b21afB3Lr6fbHPdnaoOBkr/2-Fleet-EE-components?node-id=303%3A476)

**DropdownCell.tsx stylesheet**
- [x] The `background-color` of this dropdown should be `initial`, meaning whether the row hovered or not, the background color shouldn't be any different than the row its in

**SelectTargetsDropdown.tsx (Used on New Pack and Edit Pack) stylesheet**
- [x] The border should match the borders of the page 
  - [x] Grey default border added
  - [x] On hover border fixed
  - [x] This fixed the weird jump happening
- [x] The background color should stay $ui-light-grey and not switch to white
- [x] The dropdown chevron should match other parts of the UI
  - [x] Remove old chevron
  - [x] Have same functionality where on focus and on hover is the blue, otherwise it's the original one
- [x] Fix select targets dropdown placeholder text color to match name and description placeholder text color (was original darkness, fixed to $ui-fleet-black-50, not exactly the same on Firefox but better than dark placeholder text) 

- [x] Personally QAed on Chrome, Safari, Firefox

**Screenshots/Video**
https://user-images.githubusercontent.com/71795832/200923966-db73cd0d-8157-413c-8bb0-482de3e1e5f9.mov
<img width="812" alt="Screen Shot 2022-11-10 at 11 34 41 AM" src="https://user-images.githubusercontent.com/71795832/201154257-dfff0953-2ec2-427d-90c4-8276af33f06e.png">
<img width="282" alt="Screen Shot 2022-11-10 at 11 34 23 AM" src="https://user-images.githubusercontent.com/71795832/201154259-efc2ccad-191f-45c6-bcc8-7197c5242277.png">
<img width="539" alt="Screen Shot 2022-11-10 at 11 34 13 AM" src="https://user-images.githubusercontent.com/71795832/201154261-eb699c40-6529-470a-8843-81e140cbc94a.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality