### PR TITLE
Fleet UI: Filter by low disk space hosts on various platforms

### DIFF
--- a/changes/bug-8546-low-disk-space-by-platform-filter
+++ b/changes/bug-8546-low-disk-space-by-platform-filter
@@ -1,0 +1,1 @@
+* UI allows for filtering low disk space hosts by platform!

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -413,6 +413,7 @@ const DashboardPage = (): JSX.Element => {
         lowDiskSpaceCount={lowDiskSpaceCount}
         isLoadingHosts={isHostSummaryFetching}
         showHostsUI={showHostsUI}
+        selectedPlatformLabelId={selectedPlatformLabelId}
       />
     ),
   });

--- a/frontend/pages/DashboardPage/cards/LowDiskSpaceHosts/LowDiskSpaceHosts.tsx
+++ b/frontend/pages/DashboardPage/cards/LowDiskSpaceHosts/LowDiskSpaceHosts.tsx
@@ -12,6 +12,7 @@ interface IHostSummaryProps {
   lowDiskSpaceCount: number;
   isLoadingHosts: boolean;
   showHostsUI: boolean;
+  selectedPlatformLabelId?: number;
 }
 
 const LowDiskSpaceHosts = ({
@@ -19,6 +20,7 @@ const LowDiskSpaceHosts = ({
   lowDiskSpaceCount,
   isLoadingHosts,
   showHostsUI,
+  selectedPlatformLabelId,
 }: IHostSummaryProps): JSX.Element => {
   // build the manage hosts URL filtered by low disk space only
   // currently backend cannot filter by both low disk space and label
@@ -26,7 +28,9 @@ const LowDiskSpaceHosts = ({
     low_disk_space: lowDiskSpaceGb,
   };
   const queryString = buildQueryStringFromParams(queryParams);
-  const endpoint = PATHS.MANAGE_HOSTS;
+  const endpoint = selectedPlatformLabelId
+    ? PATHS.MANAGE_HOSTS_LABEL(selectedPlatformLabelId)
+    : PATHS.MANAGE_HOSTS;
   const path = `${endpoint}?${queryString}`;
 
   return (

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1560,6 +1560,13 @@ const ManageHostsPage = ({
     ) {
       const renderFilterPill = () => {
         switch (true) {
+          // backend allows for pill combos label x low disk space
+          case showSelectedLabel && !!lowDiskSpaceHosts:
+            return (
+              <>
+                {renderLabelFilterPill()} {renderLowDiskSpaceFilterBlock()}
+              </>
+            );
           case showSelectedLabel:
             return renderLabelFilterPill();
           case !!policyId:

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -242,7 +242,7 @@
     display: flex;
     align-items: center;
     margin-bottom: $pad-medium;
-    gap: $pad-small; // between multiple filters pills
+    gap: $pad-small; // between multiple filter pills
   }
 
   &__policies-filter-pill {

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -242,6 +242,7 @@
     display: flex;
     align-items: center;
     margin-bottom: $pad-medium;
+    gap: $pad-small; // between multiple filters pills
   }
 
   &__policies-filter-pill {

--- a/frontend/pages/hosts/ManageHostsPage/components/FilterPill/FilterPill.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/FilterPill/FilterPill.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from "react";
 import ReactTooltip from "react-tooltip";
 import classnames from "classnames";
+import { uniqueId } from "lodash";
 
 import Button from "components/buttons/Button";
 
@@ -35,7 +36,10 @@ const FilterPill = ({
       aria-label={`hosts filtered by ${label}`}
     >
       <>
-        <span data-tip={tooltipDescription} data-for="filter-pill-tooltip">
+        <span
+          data-tip={tooltipDescription}
+          data-for={`filter-pill-tooltip-${label}`}
+        >
           <div className={labelClasses}>
             {icon && <img src={icon} alt="" />}
             {label}
@@ -55,7 +59,7 @@ const FilterPill = ({
             place="bottom"
             effect="solid"
             backgroundColor="#3e4771"
-            id="filter-pill-tooltip"
+            id={`filter-pill-tooltip-${label}`}
             data-html
           >
             <span>{tooltipDescription}</span>

--- a/frontend/pages/hosts/ManageHostsPage/components/FilterPill/FilterPill.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/FilterPill/FilterPill.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode } from "react";
 import ReactTooltip from "react-tooltip";
 import classnames from "classnames";
-import { uniqueId } from "lodash";
 
 import Button from "components/buttons/Button";
 

--- a/frontend/utilities/url/index.ts
+++ b/frontend/utilities/url/index.ts
@@ -68,6 +68,11 @@ export const reconcileMutuallyExclusiveHostParams = ({
   osVersion,
 }: IMutuallyExclusiveHostParams): Record<string, unknown> => {
   if (label) {
+    // backend api now allows label x low disk space
+    // all other params are still mutually exclusive
+    if (lowDiskSpaceHosts) {
+      return { low_disk_space: lowDiskSpaceHosts };
+    }
     return {};
   }
 


### PR DESCRIPTION
Cerra #8546 

**Fix**
- UI allows for filtering low disk space hosts by platform!
- Used my best judgement for what the UI should look like, added a 8px gap between filter pills

**Screenshot**
<img width="1257" alt="Screen Shot 2022-11-09 at 4 07 10 PM" src="https://user-images.githubusercontent.com/71795832/200941976-0322a747-ffce-4642-b6ee-d4d0ce1114b9.png">

**QA**
1. Go to Dashboard
2. Choose a platform from the dropdown
3. Click on low disk space hosts
Should see new UI
In console, should see network calls for `/hosts` and `/count` to include parameters for `labels`/`label_id` AND `low_disk_space`
4. Click around for teams (not mutually exclusive host filter) shouldn't clear anything
5. Clicking around for other mutually exclusive filters like status dropdown will reset the low disk space filter

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
