### PR TITLE
Fix query editor deleting wrong word

### DIFF
--- a/frontend/components/FleetAce/FleetAce.tsx
+++ b/frontend/components/FleetAce/FleetAce.tsx
@@ -70,21 +70,10 @@ const FleetAce = ({
   };
 
   const handleDelete = (deleteCommand: string) => {
-    const currentText = editorRef.current?.editor.getValue();
     const selectedText = editorRef.current?.editor.getSelectedText();
-    const range = editorRef.current?.editor.getSelectionRange();
-
-    console.log("currentText: ", currentText);
-    console.log("selectedText: ", selectedText);
-    console.log("range: ", range);
 
     if (selectedText) {
-      const remainingText = currentText?.replace(selectedText, "");
-      if (typeof remainingText !== "undefined") {
-        onChange && onChange(remainingText);
-        editorRef.current?.editor.navigateLeft();
-        editorRef.current?.editor.clearSelection();
-      }
+      editorRef.current?.editor.removeWordLeft();
     } else {
       editorRef.current?.editor.execCommand(deleteCommand);
     }

--- a/frontend/components/FleetAce/FleetAce.tsx
+++ b/frontend/components/FleetAce/FleetAce.tsx
@@ -72,6 +72,11 @@ const FleetAce = ({
   const handleDelete = (deleteCommand: string) => {
     const currentText = editorRef.current?.editor.getValue();
     const selectedText = editorRef.current?.editor.getSelectedText();
+    const range = editorRef.current?.editor.getSelectionRange();
+
+    console.log("currentText: ", currentText);
+    console.log("selectedText: ", selectedText);
+    console.log("range: ", range);
 
     if (selectedText) {
       const remainingText = currentText?.replace(selectedText, "");


### PR DESCRIPTION
For #8608

--

Notes: 

We have our own function implemented to handle `delete` and `backspace` keypresses. For `delete`, if a word was selected, we would search for the first instance of that word and remove it. Of course, this causes problems if you delete anything other than the first instance of a word. 

Instead of search and replace, I am instead using the `removeWordLeft()`, which will remove the selected word if one is highlighted. I've tested this to work as expected in Chrome, Safari, and Firefox.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Manual QA for all new/changed functionality
