### PR TITLE
fix host details UI to only show munki card on  for mac hosts

### DIFF
--- a/changes/issue-8648-muki-only-shows-for-macs
+++ b/changes/issue-8648-muki-only-shows-for-macs
@@ -1,0 +1,1 @@
+- fix host details page so munki card only shows for mac hosts

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -618,7 +618,7 @@ const HostDetailsPage = ({
                 }
                 deviceType={host?.platform === "darwin" ? "macos" : ""}
               />
-              {macadmins && (
+              {host?.platform === "darwin" && macadmins && (
                 <MunkiIssuesCard
                   isLoading={isLoadingHost}
                   munkiIssues={macadmins.munki_issues}


### PR DESCRIPTION
relates to #8648

fix host details UI to only show munki card on for mac hosts

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
