### PR TITLE
Redirect all unauthenticated pages on sandbox

### DIFF
--- a/frontend/router/components/UnauthenticatedRoutes/UnauthenticatedRoutes.tsx
+++ b/frontend/router/components/UnauthenticatedRoutes/UnauthenticatedRoutes.tsx
@@ -5,6 +5,9 @@ interface IAppProps {
 }
 
 export const UnauthenticatedRoutes = ({ children }: IAppProps): JSX.Element => {
+  if (window.location.hostname.includes(".sandbox.fleetdm.com")) {
+    window.location.href = "https://www.fleetdm.com/try-fleet/login";
+  }
   return <div>{children}</div>;
 };
 


### PR DESCRIPTION
For #8607 

--

Failed to redirect sandbox instances if user attempted to load unauthenticated routes manually.