### PR TITLE
Hide browser_plugins table

### DIFF
--- a/schema/tables/browser_plugins.yml
+++ b/schema/tables/browser_plugins.yml
@@ -1,4 +1,5 @@
 name: browser_plugins
+hidden: true
 examples: >-
   See classic browser plugins (C/NPAPI) installed by users. These plugins have
   been deprecated for a long time, so this query will usually not return


### PR DESCRIPTION
It is not supported in most modern browsers and we think it is more osquerious-user-confusing than it is potentially security-helpful .

