### PR TITLE
Fleet UI: Software filter renders even without software version

### DIFF
--- a/changes/bug-8660-software-filter-no-version
+++ b/changes/bug-8660-software-filter-no-version
@@ -1,0 +1,1 @@
+- Fix software filter when software does not have a version number

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1186,14 +1186,15 @@ const ManageHostsPage = ({
     if (!softwareDetails) return null;
 
     const { name, version } = softwareDetails;
-    const label = name && version ? `${name} ${version}` : "";
-    const TooltipDescription =
-      name && version ? (
-        <span className={`tooltip__tooltip-text`}>
-          {`Hosts with ${name}`},<br />
-          {`${version} installed`}
-        </span>
-      ) : undefined;
+    const label = `${name || "Unknown software"} ${version || ""}`;
+
+    const TooltipDescription = (
+      <span className={`tooltip__tooltip-text`}>
+        Hosts with {name},
+        <br />
+        {version || ""} installed
+      </span>
+    );
 
     return (
       <FilterPill

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1190,9 +1190,9 @@ const ManageHostsPage = ({
 
     const TooltipDescription = (
       <span className={`tooltip__tooltip-text`}>
-        Hosts with {name},
+        Hosts with {name || "Unknown software"},
         <br />
-        {version || ""} installed
+        {version || "version unknown"} installed
       </span>
     );
 


### PR DESCRIPTION
Bug fix: #8660 

For release

**Fix**
- Software version being empty string was causing the pill not to render
- Fix so pill and tooltip renders

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
