### PR TITLE
Fleet UI: URL routes for dashboard platforms

### DIFF
--- a/changes/issue-8504-routes-for-dashboard-platform
+++ b/changes/issue-8504-routes-for-dashboard-platform
@@ -1,0 +1,1 @@
+- New URL routes for dashboard platforms

--- a/frontend/components/top_nav/SiteTopNav/navItems.ts
+++ b/frontend/components/top_nav/SiteTopNav/navItems.ts
@@ -32,7 +32,7 @@ export default (
       iconName: "logo",
       location: {
         regex: new RegExp(`^${URL_PREFIX}/dashboard`),
-        pathname: PATHS.HOME,
+        pathname: PATHS.DASHBOARD,
       },
     },
   ];

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -248,7 +248,7 @@ const PageOrComponent = ({
   router,
 }: IPageProps) => {
   const doSomething = () => {
-    router.push(PATHS.HOME);
+    router.push(PATHS.DASHBOARD);
   };
 
   return (

--- a/frontend/pages/ApiOnlyUser/ApiOnlyUser.tsx
+++ b/frontend/pages/ApiOnlyUser/ApiOnlyUser.tsx
@@ -15,7 +15,7 @@ interface IApiOnlyUserProps {
 const baseClass = "api-only-user";
 
 const ApiOnlyUser = ({ router }: IApiOnlyUserProps): JSX.Element => {
-  const { LOGIN, HOME, LOGOUT } = paths;
+  const { LOGIN, DASHBOARD, LOGOUT } = paths;
   const handleClick = () => router.push(LOGOUT);
 
   useEffect(() => {
@@ -26,7 +26,7 @@ const ApiOnlyUser = ({ router }: IApiOnlyUserProps): JSX.Element => {
         if (!user) {
           router.push(LOGIN);
         } else if (!user?.api_only) {
-          router.push(HOME);
+          router.push(DASHBOARD);
         }
       } catch (response) {
         console.error(response);

--- a/frontend/pages/ConfirmInvitePage/ConfirmInvitePage.tsx
+++ b/frontend/pages/ConfirmInvitePage/ConfirmInvitePage.tsx
@@ -34,10 +34,10 @@ const ConfirmInvitePage = ({
   const [userErrors, setUserErrors] = useState<any>({});
 
   useEffect(() => {
-    const { HOME } = paths;
+    const { DASHBOARD } = paths;
 
     if (currentUser) {
-      return router.push(HOME);
+      return router.push(DASHBOARD);
     }
   }, [currentUser]);
 

--- a/frontend/pages/ConfirmSSOInvitePage/ConfirmSSOInvitePage.tsx
+++ b/frontend/pages/ConfirmSSOInvitePage/ConfirmSSOInvitePage.tsx
@@ -32,21 +32,21 @@ const ConfirmSSOInvitePage = ({
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
 
   useEffect(() => {
-    const { HOME } = paths;
+    const { DASHBOARD } = paths;
 
     if (currentUser) {
-      return router.push(HOME);
+      return router.push(DASHBOARD);
     }
   }, [currentUser]);
 
   const onSubmit = async (formData: any) => {
-    const { HOME } = paths;
+    const { DASHBOARD } = paths;
 
     formData.sso_invite = true;
 
     try {
       await usersAPI.create(formData);
-      const { url } = await sessionsAPI.initializeSSO(HOME);
+      const { url } = await sessionsAPI.initializeSSO(DASHBOARD);
       window.location.href = url;
     } catch (response) {
       const errorObject = formatErrorResponse(response);

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useState, useEffect } from "react";
+import { InjectedRouter } from "react-router";
 import { useQuery } from "react-query";
 import { AppContext } from "context/app";
 import { find } from "lodash";
@@ -56,7 +57,17 @@ const baseClass = "dashboard-page";
 // Premium feature, Gb must be set between 1-100
 const LOW_DISK_SPACE_GB = 32;
 
-const DashboardPage = (): JSX.Element => {
+interface IDashboardProps {
+  router: InjectedRouter; // v3
+  location: {
+    pathname: string;
+  };
+}
+
+const DashboardPage = ({
+  router,
+  location: { pathname },
+}: IDashboardProps): JSX.Element => {
   const {
     config,
     currentTeam,
@@ -113,6 +124,14 @@ const DashboardPage = (): JSX.Element => {
   const [munkiTitleDetail, setMunkiTitleDetail] = useState<
     JSX.Element | string | null
   >();
+
+  useEffect(() => {
+    const platformByPathname =
+      PLATFORM_DROPDOWN_OPTIONS?.find((platform) => platform.path === pathname)
+        ?.value || "all";
+
+    setSelectedPlatform(platformByPathname);
+  }, [pathname]);
 
   const canEnrollHosts =
     isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer;
@@ -631,7 +650,10 @@ const DashboardPage = (): JSX.Element => {
             options={PLATFORM_DROPDOWN_OPTIONS}
             searchable={false}
             onChange={(value: ISelectedPlatform) => {
-              setSelectedPlatform(value);
+              const selectedPlatformOption = PLATFORM_DROPDOWN_OPTIONS.find(
+                (platform) => platform.value === value
+              );
+              router.push(selectedPlatformOption?.path || paths.DASHBOARD);
             }}
           />
         </div>

--- a/frontend/pages/LoginPage/LoginPage.tsx
+++ b/frontend/pages/LoginPage/LoginPage.tsx
@@ -63,7 +63,7 @@ const LoginPage = ({ router, location }: ILoginPageProps) => {
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
 
   useEffect(() => {
-    const { HOME } = paths;
+    const { DASHBOARD } = paths;
     const getSSO = async () => {
       try {
         const { settings } = await sessionsAPI.ssoSettings();
@@ -79,7 +79,7 @@ const LoginPage = ({ router, location }: ILoginPageProps) => {
     }
 
     if (currentUser && !currentUser.force_password_reset) {
-      router?.push(HOME);
+      router?.push(DASHBOARD);
     }
 
     if (pageStatus && pageStatus in statusMessages) {
@@ -96,7 +96,7 @@ const LoginPage = ({ router, location }: ILoginPageProps) => {
   };
 
   const onSubmit = async (formData: ILoginData) => {
-    const { HOME, RESET_PASSWORD } = paths;
+    const { DASHBOARD, RESET_PASSWORD } = paths;
 
     try {
       const { user, available_teams, token } = await sessionsAPI.create(
@@ -114,7 +114,7 @@ const LoginPage = ({ router, location }: ILoginPageProps) => {
       if (user.force_password_reset) {
         return router.push(RESET_PASSWORD);
       }
-      return router.push(redirectLocation || HOME);
+      return router.push(redirectLocation || DASHBOARD);
     } catch (response) {
       const errorObject = formatErrorResponse(response);
       setErrors(errorObject);
@@ -123,8 +123,8 @@ const LoginPage = ({ router, location }: ILoginPageProps) => {
   };
 
   const ssoSignOn = async () => {
-    const { HOME } = paths;
-    let returnToAfterAuth = HOME;
+    const { DASHBOARD } = paths;
+    let returnToAfterAuth = DASHBOARD;
     if (redirectLocation != null) {
       returnToAfterAuth = redirectLocation;
     }

--- a/frontend/pages/LoginPage/LoginPreviewPage.tsx
+++ b/frontend/pages/LoginPage/LoginPreviewPage.tsx
@@ -29,7 +29,7 @@ const LoginPreviewPage = ({ router }: ILoginPreviewPageProps): JSX.Element => {
   const [loginVisible, setLoginVisible] = useState(true);
 
   const onSubmit = async (formData: ILoginData) => {
-    const { HOME } = paths;
+    const { DASHBOARD } = paths;
 
     try {
       const { user, available_teams, token } = await sessionsAPI.create(
@@ -42,7 +42,7 @@ const LoginPreviewPage = ({ router }: ILoginPreviewPageProps): JSX.Element => {
       setAvailableTeams(available_teams);
       setCurrentTeam(undefined);
 
-      return router.push(HOME);
+      return router.push(DASHBOARD);
     } catch (response) {
       console.error(response);
       return false;

--- a/frontend/pages/RegistrationPage/RegistrationPage.tsx
+++ b/frontend/pages/RegistrationPage/RegistrationPage.tsx
@@ -38,10 +38,10 @@ const RegistrationPage = ({ router }: IRegistrationPageProps) => {
   const [showSetupError, setShowSetupError] = useState(false);
 
   useEffect(() => {
-    const { HOME } = paths;
+    const { DASHBOARD } = paths;
 
     if (currentUser) {
-      return router.push(HOME);
+      return router.push(DASHBOARD);
     }
   }, [currentUser]);
 

--- a/frontend/pages/ResetPasswordPage/ResetPasswordPage.tsx
+++ b/frontend/pages/ResetPasswordPage/ResetPasswordPage.tsx
@@ -43,7 +43,7 @@ const ResetPasswordPage = ({ location, router }: IResetPasswordPageProps) => {
       await usersAPI.performRequiredPasswordReset(new_password as string);
       const config = await configAPI.loadAll();
       setConfig(config);
-      return router.push(PATHS.HOME);
+      return router.push(PATHS.DASHBOARD);
     } catch (response) {
       const errorObject = formatErrorResponse(response);
       setErrors(errorObject);

--- a/frontend/pages/errors/Fleet403/Fleet403.tsx
+++ b/frontend/pages/errors/Fleet403/Fleet403.tsx
@@ -13,7 +13,7 @@ const baseClass = "fleet-403";
 const Fleet403 = () => (
   <div className={baseClass}>
     <header className="primary-header">
-      <Link to={PATHS.HOME}>
+      <Link to={PATHS.DASHBOARD}>
         <img
           className="primary-header__logo"
           src={fleetLogoText}

--- a/frontend/pages/errors/Fleet404/Fleet404.tsx
+++ b/frontend/pages/errors/Fleet404/Fleet404.tsx
@@ -17,7 +17,7 @@ const baseClass = "fleet-404";
 const Fleet404 = () => (
   <div className={baseClass}>
     <header className="primary-header">
-      <Link to={PATHS.HOME}>
+      <Link to={PATHS.DASHBOARD}>
         <img
           className="primary-header__logo"
           src={fleetLogoText}

--- a/frontend/pages/errors/Fleet500/Fleet500.tsx
+++ b/frontend/pages/errors/Fleet500/Fleet500.tsx
@@ -16,7 +16,7 @@ const baseClass = "fleet-500";
 const Fleet500 = () => (
   <div className={baseClass}>
     <header className="primary-header">
-      <Link to={PATHS.HOME}>
+      <Link to={PATHS.DASHBOARD}>
         <img
           className="primary-header__logo"
           src={fleetLogoText}

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -98,8 +98,12 @@ const routes = (
         <Route path="email/change/:token" component={EmailTokenRedirect} />
         <Route path="logout" component={LogoutPage} />
         <Route component={CoreLayout}>
-          <IndexRedirect to={"dashboard"} />
-          <Route path="dashboard" component={DashboardPage} />
+          <IndexRedirect to={"/dashboard"} />
+          <Route path="dashboard" component={DashboardPage}>
+            <Route path="linux" component={DashboardPage} />
+            <Route path="mac" component={DashboardPage} />
+            <Route path="windows" component={DashboardPage} />
+          </Route>
           <Route path="settings" component={AuthAnyAdminRoutes}>
             <IndexRedirect to={"/dashboard"} />
             <Route component={SettingsWrapper}>

--- a/frontend/router/paths.ts
+++ b/frontend/router/paths.ts
@@ -5,7 +5,10 @@ import URL_PREFIX from "./url_prefix";
 
 export default {
   ROOT: `${URL_PREFIX}/`,
-  HOME: `${URL_PREFIX}/dashboard`,
+  DASHBOARD: `${URL_PREFIX}/dashboard`,
+  DASHBOARD_LINUX: `${URL_PREFIX}/dashboard/linux`,
+  DASHBOARD_MAC: `${URL_PREFIX}/dashboard/mac`,
+  DASHBOARD_WINDOWS: `${URL_PREFIX}/dashboard/windows`,
   ADMIN_USERS: `${URL_PREFIX}/settings/users`,
   ADMIN_INTEGRATIONS: `${URL_PREFIX}/settings/integrations`,
   ADMIN_TEAMS: `${URL_PREFIX}/settings/teams`,

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -1,5 +1,6 @@
 import URL_PREFIX from "router/url_prefix";
 import { IOsqueryPlatform } from "interfaces/platform";
+import paths from "router/paths";
 
 const { origin } = global.window.location;
 export const BASE_URL = `${origin}${URL_PREFIX}/api`;
@@ -167,11 +168,16 @@ export const PLATFORM_LABEL_DISPLAY_TYPES: Record<string, string> = {
   "Ubuntu Linux": "platform",
 };
 
-export const PLATFORM_DROPDOWN_OPTIONS = [
-  { label: "All", value: "all" },
-  { label: "Windows", value: "windows" },
-  { label: "Linux", value: "linux" },
-  { label: "macOS", value: "darwin" },
+interface IPlatformDropdownOptions {
+  label: "All" | "Windows" | "Linux" | "macOS";
+  value: "all" | "windows" | "linux" | "darwin";
+  path: string;
+}
+export const PLATFORM_DROPDOWN_OPTIONS: IPlatformDropdownOptions[] = [
+  { label: "All", value: "all", path: paths.DASHBOARD },
+  { label: "Windows", value: "windows", path: paths.DASHBOARD_WINDOWS },
+  { label: "Linux", value: "linux", path: paths.DASHBOARD_LINUX },
+  { label: "macOS", value: "darwin", path: paths.DASHBOARD_MAC },
 ];
 
 export const PLATFORM_NAME_TO_LABEL_NAME = {


### PR DESCRIPTION
Second half of #8504 

**FIXES**
- Rename any "home" routes as "dashboard" to be consistent between code and UI
- Create URL routes for platform views of dashboard


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality