### PR TITLE
style fixes for code editor and query sidepanel table dropdown

### DIFF
--- a/changes/issue-8702-style-changes-code-editor-table-dropdown
+++ b/changes/issue-8702-style-changes-code-editor-table-dropdown
@@ -1,0 +1,1 @@
+- change/fix styles for code editor gutter and query side panel table dropdown

--- a/frontend/components/FleetAce/theme.css
+++ b/frontend/components/FleetAce/theme.css
@@ -38,10 +38,6 @@
 .ace-fleet .ace_gutter-active-line {
   background-color: rgba(174, 109, 223, 0.15);
   border-radius: 2px;
-  left: 4px;
-  right: 4px;
-  height: 24px !important;
-  margin-top: 3px;
 }
 
 .ace-fleet .ace_print-margin {

--- a/frontend/components/side_panels/QuerySidePanel/_styles.scss
+++ b/frontend/components/side_panels/QuerySidePanel/_styles.scss
@@ -51,14 +51,32 @@
     font-size: $x-small;
   }
 
-  // use to truncate selected long table names in the dropdown
   &__table-select {
-    &.Select.has-value.Select--single > .Select-control .Select-value .Select-value-label {
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      width: 220px;
-      display: inline-block;
+
+    // TODO: Remove these overrides when we do a style update for the core
+    // dropdown component.
+    &.Select {
+
+      // fixes up some padding issues with the scroll bar for the dropdown.
+      .Select-menu-outer {
+        padding: 0;
+
+        .Select-menu {
+          padding: $pad-xsmall
+        }
+      }
+
+      // use to truncate selected long table names in the dropdown
+      &.has-value.Select--single>.Select-control {
+
+        .Select-value .Select-value-label {
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          width: 220px;
+          display: inline-block;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
relates to [#8656](https://github.com/fleetdm/fleet/issues/8656)

style fixes for code editor and query side panel table dropdown.

**code editor gutter styles**

![image](https://user-images.githubusercontent.com/1153709/201700300-89760874-0698-44b1-99c6-770c6c775905.png)

**Spacing fixes table dropdown**

![image](https://user-images.githubusercontent.com/1153709/201700178-15276fa0-1866-4ff3-824e-53c07448b6f0.png)

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
