### PR TITLE
UI: Set form field height to $form-field-label-min-height for consistency between states, including on error

### DIFF
--- a/changes/issue-8393-fix-height-discrepancy-of-input-labels-on-error-state
+++ b/changes/issue-8393-fix-height-discrepancy-of-input-labels-on-error-state
@@ -1,0 +1,1 @@
+* Fix a discrepancy in the height of input labels when there is a validation error

--- a/cypress/integration/all/app/settingsflow.spec.ts
+++ b/cypress/integration/all/app/settingsflow.spec.ts
@@ -239,7 +239,7 @@ describe("App settings flow", () => {
       // specifically targeting this one to avoid conflict
       // with cypress seeing multiple "metadata" - one
       // in a tooltip, the other as the actual label
-      cy.getAttached("[for='smtpServer']")
+      cy.findByLabelText(/SMTP server/)
         .click({ force: true })
         .type("localhost");
 

--- a/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/_styles.scss
+++ b/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/_styles.scss
@@ -16,6 +16,7 @@
       font-weight: $bold;
       margin-bottom: 0;
       width: 500px;
+      height: 0;
     }
 
     .input-field {

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -14,7 +14,7 @@ const baseClass = "component__tooltip-wrapper";
 const TooltipWrapper = ({
   children,
   tipContent,
-  position = "bottom",
+  position = "top",
   isDelayed,
   className,
 }: ITooltipWrapperProps): JSX.Element => {

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -14,7 +14,7 @@ const baseClass = "component__tooltip-wrapper";
 const TooltipWrapper = ({
   children,
   tipContent,
-  position = "top",
+  position = "bottom",
   isDelayed,
   className,
 }: ITooltipWrapperProps): JSX.Element => {

--- a/frontend/components/TooltipWrapper/_styles.scss
+++ b/frontend/components/TooltipWrapper/_styles.scss
@@ -43,7 +43,7 @@
   &__tip-text {
     width: max-content;
     max-width: 341px;
-    padding: 12px;
+    padding: 6px;
     color: $core-white;
     background-color: $core-fleet-blue;
     font-weight: $regular;

--- a/frontend/components/forms/FormField/_styles.scss
+++ b/frontend/components/forms/FormField/_styles.scss
@@ -2,7 +2,7 @@
   margin-bottom: $pad-large;
 
   &__label {
-    font-size: $x-small;
+    font-size: $small;
     font-weight: $bold;
     color: $core-fleet-black;
     display: block;

--- a/frontend/components/forms/FormField/_styles.scss
+++ b/frontend/components/forms/FormField/_styles.scss
@@ -7,7 +7,7 @@
     color: $core-fleet-black;
     display: block;
     margin-bottom: $pad-xsmall;
-    height: $form-field-label-height;
+    min-height: $form-field-label-min-height;
 
     &--error {
       font-weight: $bold;

--- a/frontend/components/forms/FormField/_styles.scss
+++ b/frontend/components/forms/FormField/_styles.scss
@@ -6,8 +6,8 @@
     font-weight: $bold;
     color: $core-fleet-black;
     display: block;
-    margin-bottom: $pad-xsmall;
-    min-height: $form-field-label-min-height;
+    margin-bottom: $pad-small;
+    height: $form-field-label-height;
 
     &--error {
       font-weight: $bold;

--- a/frontend/components/forms/FormField/_styles.scss
+++ b/frontend/components/forms/FormField/_styles.scss
@@ -7,6 +7,7 @@
     color: $core-fleet-black;
     display: block;
     margin-bottom: $pad-xsmall;
+    height: $form-field-label-height;
 
     &--error {
       font-weight: $bold;

--- a/frontend/pages/admin/AppSettingsPage/components/OrgSettingsForm/_styles.scss
+++ b/frontend/pages/admin/AppSettingsPage/components/OrgSettingsForm/_styles.scss
@@ -60,8 +60,6 @@
     width: 100%;
 
     &__label {
-      font-weight: $bold;
-      margin-bottom: $pad-xsmall;
       width: 100%;
     }
 
@@ -102,7 +100,7 @@
       color: $core-fleet-black;
       border-bottom: solid 1px $ui-fleet-blue-15;
       margin: 0 0 $pad-xxlarge;
-      @media(min-width: $break-990) {
+      @media (min-width: $break-990) {
         max-width: 65%;
       }
     }
@@ -135,19 +133,17 @@
     font-size: $x-small;
     color: $core-fleet-black;
     width: 100%;
-    @media(min-width: $break-990) {
+    @media (min-width: $break-990) {
       width: 60%;
     }
   }
-
-
 
   &__inputs {
     width: 100%;
     float: left;
     padding-right: $pad-small;
     box-sizing: border-box;
-    @media(min-width: $break-990) {
+    @media (min-width: $break-990) {
       width: 60%;
     }
 

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
@@ -77,7 +77,6 @@
 
   &__password {
     width: 98%;
-    float: left;
     padding: 0 $pad-medium 0 0;
     box-sizing: border-box;
 

--- a/frontend/styles/var/forms.scss
+++ b/frontend/styles/var/forms.scss
@@ -1,1 +1,1 @@
-$form-field-label-min-height: 24px;
+$form-field-label-height: 24px;

--- a/frontend/styles/var/forms.scss
+++ b/frontend/styles/var/forms.scss
@@ -1,0 +1,1 @@
+$form-field-label-height: 23.6333px;

--- a/frontend/styles/var/forms.scss
+++ b/frontend/styles/var/forms.scss
@@ -1,1 +1,1 @@
-$form-field-label-min-height: 23.6333px;
+$form-field-label-min-height: 24px;

--- a/frontend/styles/var/forms.scss
+++ b/frontend/styles/var/forms.scss
@@ -1,1 +1,1 @@
-$form-field-label-height: 23.6333px;
+$form-field-label-min-height: 23.6333px;


### PR DESCRIPTION
## Addresses #8393

## Fixes:
- A slight discrepancy in height of input labels when inputs that use TooltipWrapper labels show an error value

## Screencast:

https://www.loom.com/share/78601f4242e14a4991868e2cd4dfa273

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
