### PR TITLE
Fleet frontend: Integration layer needs new handler (mock mac admins handler)

### DIFF
--- a/frontend/__mocks__/macAdminsMock.ts
+++ b/frontend/__mocks__/macAdminsMock.ts
@@ -1,0 +1,24 @@
+import { IMacadminsResponse } from "interfaces/host";
+
+const DEFAULT_MAC_ADMINS_MOCK: IMacadminsResponse = {
+  macadmins: {
+    mobile_device_management: {
+      enrollment_status: "Enrolled (manual)",
+      server_url: "https://kandji.com/2",
+      name: "Kandji",
+      id: 11,
+    },
+    munki: {
+      version: "1.2.3",
+    },
+    munki_issues: [],
+  },
+};
+
+const createMockMacAdmins = (
+  overrides?: Partial<IMacadminsResponse>
+): IMacadminsResponse => {
+  return { ...DEFAULT_MAC_ADMINS_MOCK, ...overrides };
+};
+
+export default createMockMacAdmins;

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -87,6 +87,8 @@ export interface IMunkiData {
 export interface IMDMData {
   enrollment_status: string;
   server_url: string;
+  id: number;
+  name: string;
 }
 
 export interface IMunkiIssue {

--- a/frontend/test/default-handlers.ts
+++ b/frontend/test/default-handlers.ts
@@ -2,6 +2,7 @@ import { defaultActivityHandler } from "./handlers/activity-handlers";
 import {
   defaultDeviceHandler,
   defaultDeviceMappingHandler,
+  defaultMacAdminsHandler,
 } from "./handlers/device-handler";
 
 export const baseUrl = (path: string) => {
@@ -11,6 +12,7 @@ export const baseUrl = (path: string) => {
 const handlers = [
   defaultDeviceHandler,
   defaultDeviceMappingHandler,
+  defaultMacAdminsHandler,
   defaultActivityHandler,
 ];
 

--- a/frontend/test/handlers/device-handler.ts
+++ b/frontend/test/handlers/device-handler.ts
@@ -3,6 +3,7 @@ import { rest } from "msw";
 import createMockDeviceUser from "__mocks__/deviceUserMock";
 import createMockHost from "__mocks__/hostMock";
 import createMockLicense from "__mocks__/licenseMock";
+import createMockMacAdmins from "__mocks__/macAdminsMock";
 import { baseUrl } from "test/test-utils";
 
 export const defaultDeviceHandler = rest.get(
@@ -25,6 +26,17 @@ export const defaultDeviceMappingHandler = rest.get(
       context.json({
         device_mapping: [createMockDeviceUser()],
         host_id: 1,
+      })
+    );
+  }
+);
+
+export const defaultMacAdminsHandler = rest.get(
+  baseUrl("/device/:token/macadmins"),
+  (req, res, context) => {
+    return res(
+      context.json({
+        macadmins: createMockMacAdmins(),
       })
     );
   }


### PR DESCRIPTION
Blocking #7309 

Device user page was not actually flowing in mock data and test was false-positive passing on main. Erroring out on /macadmins call which was 400 on the integration layer

**FIX**
- Added a mockMacAdmins handler to the integration layer

# Checklist for submitter

If some of the following don't apply, delete the relevant line.


- [x] Added/updated tests