### PR TITLE
Frontend: Organize response interfaces into appropriate interface directories

### DIFF
--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -73,6 +73,14 @@ export default PropTypes.shape({
   }),
 });
 
+export interface ILicense {
+  tier: string;
+  device_count: number;
+  expiration: string;
+  note: string;
+  organization: string;
+}
+
 export interface IFleetDesktopSettings {
   transparency_url: string;
 }
@@ -165,13 +173,7 @@ export interface IConfig {
     osquery_detail: number;
     osquery_policy: number;
   };
-  license: {
-    organization: string;
-    device_count: number;
-    tier: string;
-    expiration: string;
-    note: string;
-  };
+  license: ILicense;
   fleet_desktop: IFleetDesktopSettings;
   vulnerabilities: {
     databases_path: string;

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -132,6 +132,10 @@ interface IBattery {
   health: string;
 }
 
+export interface IHostResponse {
+  host: IHost;
+}
+
 export interface IHost {
   created_at: string;
   updated_at: string;

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -6,6 +6,7 @@ import packInterface, { IPack } from "./pack";
 import softwareInterface, { ISoftware } from "./software";
 import hostQueryResult from "./campaign";
 import queryStatsInterface, { IQueryStats } from "./query_stats";
+import { ILicense } from "./config";
 
 export default PropTypes.shape({
   created_at: PropTypes.string,
@@ -134,6 +135,11 @@ interface IBattery {
 
 export interface IHostResponse {
   host: IHost;
+}
+export interface IDeviceUserResponse {
+  host: IHost;
+  license: ILicense;
+  org_logo_url: string;
 }
 
 export interface IHost {

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -140,6 +140,8 @@ export interface IDeviceUserResponse {
   host: IHost;
   license: ILicense;
   org_logo_url: string;
+  disk_encryption_enabled?: boolean;
+  platform?: string;
 }
 
 export interface IHost {

--- a/frontend/interfaces/pack.ts
+++ b/frontend/interfaces/pack.ts
@@ -19,6 +19,14 @@ export default PropTypes.shape({
   team_ids: PropTypes.arrayOf(PropTypes.number),
 });
 
+export interface IStoredPacksResponse {
+  packs: IPack[];
+}
+
+export interface IStoredPackResponse {
+  pack: IPack;
+}
+
 export interface IPack {
   created_at: string;
   updated_at: string;

--- a/frontend/interfaces/policy.ts
+++ b/frontend/interfaces/policy.ts
@@ -17,6 +17,10 @@ export default PropTypes.shape({
   updated_at: PropTypes.string.isRequired,
 });
 
+export interface IStoredPolicyResponse {
+  policy: IPolicy;
+}
+
 export interface IPolicy {
   id: number;
   name: string;

--- a/frontend/interfaces/query.ts
+++ b/frontend/interfaces/query.ts
@@ -26,6 +26,14 @@ export interface IQueryFormData {
   observer_can_run?: string | number | boolean | undefined;
 }
 
+export interface IStoredQueryResponse {
+  query: IQuery;
+}
+
+export interface IFleetQueriesResponse {
+  queries: IQuery[];
+}
+
 export interface IQuery {
   created_at: string;
   updated_at: string;

--- a/frontend/interfaces/scheduled_query.ts
+++ b/frontend/interfaces/scheduled_query.ts
@@ -62,7 +62,7 @@ export interface ILoadAllGlobalScheduledQueriesResponse {
   global_schedule: IScheduledQuery[];
 }
 
-export interface ILoadAllTeamScheduledQueriesResponse {
+export interface IStoredScheduledQueriesResponse {
   scheduled: IScheduledQuery[];
 }
 

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -10,6 +10,19 @@ export default PropTypes.shape({
   vulnerabilities: PropTypes.arrayOf(vulnerabilityInterface),
 });
 
+export interface ISoftwareResponse {
+  counts_updated_at: string;
+  software: ISoftware[];
+}
+
+export interface ISoftwareCountResponse {
+  count: number;
+}
+
+export interface IGetSoftwareByIdResponse {
+  software: ISoftware;
+}
+
 export interface ISoftware {
   hosts_count?: number;
   id: number;

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -18,11 +18,12 @@ import {
   IMunkiVersionsAggregate,
 } from "interfaces/macadmins";
 import { ISelectedPlatform } from "interfaces/platform";
+import { ISoftwareResponse } from "interfaces/software";
 import { ITeam } from "interfaces/team";
 import enrollSecretsAPI from "services/entities/enroll_secret";
 import hostSummaryAPI from "services/entities/host_summary";
 import macadminsAPI from "services/entities/macadmins";
-import softwareAPI, { ISoftwareResponse } from "services/entities/software";
+import softwareAPI from "services/entities/software";
 import teamsAPI, { ILoadTeamsResponse } from "services/entities/teams";
 import sortUtils from "utilities/sort";
 import {

--- a/frontend/pages/DashboardPage/cards/WelcomeHost/WelcomeHost.tsx
+++ b/frontend/pages/DashboardPage/cards/WelcomeHost/WelcomeHost.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "react-query";
 import { formatDistanceToNow } from "date-fns";
 
 import { NotificationContext } from "context/notification";
-import { IHost } from "interfaces/host";
+import { IHost, IHostResponse } from "interfaces/host";
 import { IHostPolicy } from "interfaces/policy";
 import hostAPI from "services/entities/hosts";
 
@@ -18,10 +18,6 @@ import IconDisabled from "../../../../../assets/images/icon-action-disable-red-1
 import IconPassed from "../../../../../assets/images/icon-check-circle-green-16x16@2x.png";
 import IconError from "../../../../../assets/images/icon-exclamation-circle-red-16x16@2x.png";
 import SlackButton from "../../../../../assets/images/slack-button-get-help.png";
-
-interface IHostResponse {
-  host: IHost;
-}
 
 interface IWelcomeHostCardProps {
   totalsHostsCount: number;

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -38,9 +38,9 @@ import {
   formatOperatingSystemDisplayName,
   IOperatingSystemVersion,
 } from "interfaces/operating_system";
-import { IPolicy } from "interfaces/policy";
+import { IPolicy, IStoredPolicyResponse } from "interfaces/policy";
 import { ISoftware } from "interfaces/software";
-import team, { ITeam } from "interfaces/team";
+import { ITeam } from "interfaces/team";
 import sortUtils from "utilities/sort";
 import {
   HOSTS_SEARCH_BOX_PLACEHOLDER,
@@ -100,10 +100,6 @@ interface IManageHostsProps {
   params: Params;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   location: any; // no type in react-router v3
-}
-
-interface IPolicyAPIResponse {
-  policy: IPolicy;
 }
 
 interface ITableQueryProps {
@@ -351,7 +347,7 @@ const ManageHostsPage = ({
     }
   );
 
-  useQuery<IPolicyAPIResponse, Error>(
+  useQuery<IStoredPolicyResponse, Error>(
     ["policy"],
     () => globalPoliciesAPI.load(policyId),
     {

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -13,6 +13,7 @@ import {
   IHostResponse,
   IDeviceMappingResponse,
   IMacadminsResponse,
+  IDeviceUserResponse,
 } from "interfaces/host";
 import { ISoftware } from "interfaces/software";
 import { IHostPolicy } from "interfaces/policy";
@@ -105,7 +106,7 @@ const DeviceUserPage = ({
     isLoading: isLoadingHost,
     error: loadingDeviceUserError,
     refetch: refetchHostDetails,
-  } = useQuery<IHostResponse, Error, IHostResponse>(
+  } = useQuery<IDeviceUserResponse, Error, IDeviceUserResponse>(
     ["host", deviceAuthToken],
     () => deviceUserAPI.loadHostDetails(deviceAuthToken),
     {
@@ -114,8 +115,8 @@ const DeviceUserPage = ({
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
       retry: false,
-      select: (data: IHostResponse) => data,
-      onSuccess: (returnedHost: IHostResponse) => {
+      select: (data: IDeviceUserResponse) => data,
+      onSuccess: (returnedHost: IDeviceUserResponse) => {
         setShowRefetchSpinner(returnedHost.host.refetch_requested);
         setIsPremiumTier(returnedHost.license.tier === "premium");
         setHostSoftware(returnedHost.host.software ?? []);

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -8,9 +8,9 @@ import { pick } from "lodash";
 
 import { NotificationContext } from "context/notification";
 import deviceUserAPI from "services/entities/device_user";
-import hostAPI from "services/entities/hosts";
 import {
   IHost,
+  IHostResponse,
   IDeviceMappingResponse,
   IMacadminsResponse,
 } from "interfaces/host";
@@ -42,22 +42,6 @@ const baseClass = "device-user";
 
 interface IDeviceUserPageProps {
   params: Params;
-}
-
-interface ILicense {
-  tier: string;
-  device_count: number;
-  expiration: string;
-  note: string;
-  organization: string;
-}
-
-interface IHostResponse {
-  host: IHost;
-  org_logo_url: string;
-  license: ILicense;
-  disk_encryption_enabled?: boolean;
-  platform?: string;
 }
 
 interface IHostDiskEncryptionProps {

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -19,13 +19,14 @@ import {
   IDeviceMappingResponse,
   IMacadminsResponse,
   IPackStats,
+  IHostResponse,
 } from "interfaces/host";
+import { ILabel } from "interfaces/label";
+import { IHostPolicy } from "interfaces/policy";
+import { IQuery, IFleetQueriesResponse } from "interfaces/query";
 import { IQueryStats } from "interfaces/query_stats";
 import { ISoftware } from "interfaces/software";
-import { IHostPolicy } from "interfaces/policy";
-import { ILabel } from "interfaces/label";
 import { ITeam } from "interfaces/team";
-import { IQuery } from "interfaces/query";
 import { IUser } from "interfaces/user";
 import permissionUtils from "utilities/permissions";
 
@@ -70,13 +71,6 @@ interface IHostDetailsProps {
   params: Params;
 }
 
-interface IFleetQueriesResponse {
-  queries: IQuery[];
-}
-
-interface IHostResponse {
-  host: IHost;
-}
 interface ISearchQueryData {
   searchQuery: string;
   sortHeader: string;

--- a/frontend/pages/packs/EditPackPage/EditPackPage.tsx
+++ b/frontend/pages/packs/EditPackPage/EditPackPage.tsx
@@ -2,11 +2,12 @@ import React, { useState, useCallback, useContext } from "react";
 import { useQuery } from "react-query";
 import { InjectedRouter, Params } from "react-router/lib/Router";
 
-import { IPack } from "interfaces/pack";
-import { IQuery } from "interfaces/query";
+import { IPack, IStoredPackResponse } from "interfaces/pack";
+import { IQuery, IFleetQueriesResponse } from "interfaces/query";
 import {
   IPackQueryFormData,
   IScheduledQuery,
+  IStoredScheduledQueriesResponse,
 } from "interfaces/scheduled_query";
 import { ITarget, ITargetsAPIResponse } from "interfaces/target";
 import { AppContext } from "context/app";
@@ -31,18 +32,6 @@ interface IEditPacksPageProps {
   params: Params;
 }
 
-interface IStoredFleetQueriesResponse {
-  queries: IQuery[];
-}
-
-interface IStoredPackResponse {
-  pack: IPack;
-}
-
-interface IStoredPackQueriesResponse {
-  scheduled: IScheduledQuery[];
-}
-
 interface IFormData {
   name?: string;
   description?: string;
@@ -61,11 +50,11 @@ const EditPacksPage = ({
   const packId: number = parseInt(paramsPackId, 10);
 
   const { data: fleetQueries } = useQuery<
-    IStoredFleetQueriesResponse,
+    IFleetQueriesResponse,
     Error,
     IQuery[]
   >(["fleet queries"], () => queriesAPI.loadAll(), {
-    select: (data: IStoredFleetQueriesResponse) => data.queries,
+    select: (data: IFleetQueriesResponse) => data.queries,
   });
 
   const { data: storedPack } = useQuery<IStoredPackResponse, Error, IPack>(
@@ -80,11 +69,11 @@ const EditPacksPage = ({
     data: storedPackQueries,
     isLoading: isStoredPackQueriesLoading,
     refetch: refetchStoredPackQueries,
-  } = useQuery<IStoredPackQueriesResponse, Error, IScheduledQuery[]>(
+  } = useQuery<IStoredScheduledQueriesResponse, Error, IScheduledQuery[]>(
     ["stored pack queries"],
     () => scheduledQueriesAPI.loadAll(packId),
     {
-      select: (data: IStoredPackQueriesResponse) => data.scheduled,
+      select: (data: IStoredScheduledQueriesResponse) => data.scheduled,
     }
   );
 

--- a/frontend/pages/packs/ManagePacksPage/ManagePacksPage.tsx
+++ b/frontend/pages/packs/ManagePacksPage/ManagePacksPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useContext } from "react";
 import { useQuery } from "react-query";
 import { InjectedRouter } from "react-router/lib/Router";
 
-import { IPack } from "interfaces/pack";
+import { IPack, IStoredPacksResponse } from "interfaces/pack";
 import { IError } from "interfaces/errors";
 import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
@@ -21,10 +21,6 @@ const baseClass = "manage-packs-page";
 
 interface IManagePacksPageProps {
   router: InjectedRouter; // v3
-}
-
-interface IPacksResponse {
-  packs: IPack[];
 }
 
 const renderTable = (
@@ -69,14 +65,14 @@ const ManagePacksPage = ({ router }: IManagePacksPageProps): JSX.Element => {
     error: packsError,
     isFetching: isLoadingPacks,
     refetch: refetchPacks,
-  } = useQuery<IPacksResponse, IError, IPack[]>(
+  } = useQuery<IStoredPacksResponse, IError, IPack[]>(
     "packs",
     () => packsAPI.loadAll(),
     {
       // refetchOnMount: false,
       // refetchOnReconnect: false,
       refetchOnWindowFocus: false,
-      select: (data: IPacksResponse) => data.packs,
+      select: (data: IStoredPacksResponse) => data.packs,
     }
   );
 

--- a/frontend/pages/policies/PolicyPage/PolicyPage.tsx
+++ b/frontend/pages/policies/PolicyPage/PolicyPage.tsx
@@ -11,9 +11,13 @@ import globalPoliciesAPI from "services/entities/global_policies";
 import teamPoliciesAPI from "services/entities/team_policies";
 import hostAPI from "services/entities/hosts";
 import statusAPI from "services/entities/status";
-import { IHost } from "interfaces/host";
+import { IHost, IHostResponse } from "interfaces/host";
 import { ILabel } from "interfaces/label";
-import { IPolicyFormData, IPolicy } from "interfaces/policy";
+import {
+  IPolicyFormData,
+  IPolicy,
+  IStoredPolicyResponse,
+} from "interfaces/policy";
 import { ITarget } from "interfaces/target";
 import { ITeam } from "interfaces/team";
 
@@ -29,14 +33,6 @@ interface IPolicyPageProps {
   router: InjectedRouter;
   params: Params;
   location: { query: { host_ids: string; team_id: string } };
-}
-
-interface IStoredPolicyResponse {
-  policy: IPolicy;
-}
-
-interface IHostResponse {
-  host: IHost;
 }
 
 const baseClass = "policy-page";

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -14,7 +14,7 @@ import { TableContext } from "context/table";
 import { NotificationContext } from "context/notification";
 import { performanceIndicator } from "utilities/helpers";
 import { IOsqueryPlatform } from "interfaces/platform";
-import { IQuery } from "interfaces/query";
+import { IQuery, IFleetQueriesResponse } from "interfaces/query";
 import fleetQueriesAPI from "services/entities/queries";
 import PATHS from "router/paths";
 import checkPlatformCompatibility from "utilities/sql_tools";
@@ -32,9 +32,6 @@ interface IManageQueriesPageProps {
   router: InjectedRouter; // v3
 }
 
-interface IFleetQueriesResponse {
-  queries: IQuery[];
-}
 interface IQueryTableData extends IQuery {
   performance: string;
   platforms: string[];

--- a/frontend/pages/queries/QueryPage/QueryPage.tsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.tsx
@@ -9,10 +9,10 @@ import { QUERIES_PAGE_STEPS, DEFAULT_QUERY } from "utilities/constants";
 import queryAPI from "services/entities/queries";
 import hostAPI from "services/entities/hosts";
 import statusAPI from "services/entities/status";
-import { IHost } from "interfaces/host";
+import { IHost, IHostResponse } from "interfaces/host";
 import { ILabel } from "interfaces/label";
 import { ITeam } from "interfaces/team";
-import { IQueryFormData, IQuery } from "interfaces/query";
+import { IQueryFormData, IQuery, IStoredQueryResponse } from "interfaces/query";
 import { ITarget } from "interfaces/target";
 
 import QuerySidePanel from "components/side_panels/QuerySidePanel";
@@ -30,14 +30,6 @@ interface IQueryPageProps {
   location: {
     query: { host_ids: string };
   };
-}
-
-interface IStoredQueryResponse {
-  query: IQuery;
-}
-
-interface IHostResponse {
-  host: IHost;
 }
 
 const baseClass = "query-page";

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -9,12 +9,12 @@ import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import deepDifference from "utilities/deep_difference";
 import { ITeam } from "interfaces/team";
-import { IQuery } from "interfaces/query";
+import { IQuery, IFleetQueriesResponse } from "interfaces/query";
 import {
   IScheduledQuery,
   IEditScheduledQuery,
   ILoadAllGlobalScheduledQueriesResponse,
-  ILoadAllTeamScheduledQueriesResponse,
+  IStoredScheduledQueriesResponse,
 } from "interfaces/scheduled_query";
 import fleetQueriesAPI from "services/entities/queries";
 import globalScheduledQueriesAPI from "services/entities/global_scheduled_queries";
@@ -35,10 +35,6 @@ import RemoveScheduledQueryModal from "./components/RemoveScheduledQueryModal";
 import ShowQueryModal from "./components/ShowQueryModal";
 
 const baseClass = "manage-schedule-page";
-
-interface IFleetQueriesResponse {
-  queries: IQuery[];
-}
 
 const renderTable = (
   router: InjectedRouter,
@@ -217,7 +213,7 @@ const ManageSchedulePage = ({
     error: teamScheduledQueriesError,
     isLoading: isLoadingTeamScheduledQueries,
     refetch: refetchTeamScheduledQueries,
-  } = useQuery<ILoadAllTeamScheduledQueriesResponse, Error, IScheduledQuery[]>(
+  } = useQuery<IStoredScheduledQueriesResponse, Error, IScheduledQuery[]>(
     ["teamScheduledQueries", selectedTeamId],
     () => teamScheduledQueriesAPI.loadAll(selectedTeamId),
     {

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -20,13 +20,11 @@ import {
   IZendeskIntegration,
   IIntegrations,
 } from "interfaces/integration";
+import { ISoftwareResponse, ISoftwareCountResponse } from "interfaces/software";
 import { ITeamConfig } from "interfaces/team";
 import { IWebhookSoftwareVulnerabilities } from "interfaces/webhook"; // @ts-ignore
 import configAPI from "services/entities/config";
-import softwareAPI, {
-  ISoftwareResponse,
-  ISoftwareCountResponse,
-} from "services/entities/software";
+import softwareAPI from "services/entities/software";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
 import {
   GITHUB_NEW_ISSUE_LINK,

--- a/frontend/pages/software/SoftwareDetailsPage/SoftwareDetailsPage.tsx
+++ b/frontend/pages/software/SoftwareDetailsPage/SoftwareDetailsPage.tsx
@@ -4,10 +4,12 @@ import { useQuery } from "react-query";
 import PATHS from "router/paths";
 
 import { AppContext } from "context/app";
-import { formatSoftwareType, ISoftware } from "interfaces/software";
-import softwareAPI, {
+import {
+  formatSoftwareType,
+  ISoftware,
   IGetSoftwareByIdResponse,
-} from "services/entities/software";
+} from "interfaces/software";
+import softwareAPI from "services/entities/software";
 import hostCountAPI from "services/entities/host_count";
 
 import Spinner from "components/Spinner";

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -2,7 +2,11 @@ import { snakeCase, reduce } from "lodash";
 
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
-import { ISoftware } from "interfaces/software";
+import {
+  ISoftwareResponse,
+  ISoftwareCountResponse,
+  IGetSoftwareByIdResponse,
+} from "interfaces/software";
 import { buildQueryStringFromParams, QueryParams } from "utilities/url";
 
 interface IGetSoftwareProps {
@@ -13,19 +17,6 @@ interface IGetSoftwareProps {
   query?: string;
   vulnerable?: boolean;
   teamId?: number;
-}
-
-export interface ISoftwareResponse {
-  counts_updated_at: string;
-  software: ISoftware[];
-}
-
-export interface ISoftwareCountResponse {
-  count: number;
-}
-
-export interface IGetSoftwareByIdResponse {
-  software: ISoftware;
 }
 
 type ISoftwareParams = Partial<IGetSoftwareProps>;


### PR DESCRIPTION

Response interfaces were being repeated in multiple places and/or defined in multiple places

**Fix**
- Move response interfaces into appropriate `/interface` directory files

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality