### PR TITLE
add <PayloadOrganization> to MDM enrollment payload

### DIFF
--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -752,6 +752,8 @@ var enrollmentProfileMobileconfigTemplate = template.Must(template.New("").Parse
 	<string>{{ .Organization }} Enrollment</string>
 	<key>PayloadIdentifier</key>
 	<string>com.fleetdm.fleet.mdm.apple</string>
+	<key>PayloadOrganization</key>
+	<string>{{ .Organization }}</string>
 	<key>PayloadScope</key>
 	<string>System</string>
 	<key>PayloadType</key>


### PR DESCRIPTION
The value of this attribute is used by macOS in "System Preferences > Profiles" to display a note saying "This Mac is supervised and managed by <xyz>".

When <PayloadOrganization> is not set, it uses the URL of the MDM server for the message, which looks unpolished.

Before:

![image](https://user-images.githubusercontent.com/4419992/202483661-c185e1d3-febe-4c6b-9ff4-efd68e340ea5.png)

After:

![image](https://user-images.githubusercontent.com/4419992/202483699-aa3ad7df-2e0d-42c0-86be-86978be826d2.png)

# Checklist for submitter

- [x] Manual QA for all new/changed functionality