### PR TITLE
add links for evented tables and to columns in query side panel

### DIFF
--- a/changes/issue-8409-add-links-to-query-sidebar
+++ b/changes/issue-8409-add-links-to-query-sidebar
@@ -1,0 +1,1 @@
+- add links to evented tables and columns that requires_user_context in the query sidepanel

--- a/frontend/components/side_panels/QuerySidePanel/EventedTableTag/EventedTableTag.tsx
+++ b/frontend/components/side_panels/QuerySidePanel/EventedTableTag/EventedTableTag.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+import { buildQueryStringFromParams } from "utilities/url";
+import Icon from "components/Icon";
+
+interface IEventedTableTagProps {
+  selectedTableName: string;
+}
+
+const baseClass = "evented-table-tag";
+
+const EventedTableTag = ({ selectedTableName }: IEventedTableTagProps) => {
+  const queryString = buildQueryStringFromParams({
+    utm_source: "fleet-ui",
+    utm_table: `table-${selectedTableName}`,
+  });
+
+  return (
+    <a
+      href={`https://fleetdm.com/guides/osquery-evented-tables-overview?${queryString}`}
+      className={baseClass}
+      target="__blank"
+    >
+      <Icon name="calendar-check" />
+      <span>EVENTED TABLE</span>
+    </a>
+  );
+};
+
+export default EventedTableTag;

--- a/frontend/components/side_panels/QuerySidePanel/EventedTableTag/_styles.scss
+++ b/frontend/components/side_panels/QuerySidePanel/EventedTableTag/_styles.scss
@@ -1,0 +1,11 @@
+.evented-table-tag {
+  display: inline-flex;
+  align-items: center;
+  color: $core-fleet-black;
+  background-color: $ui-fleet-blue-15;
+  padding: $pad-xsmall $pad-small;
+  border-radius: 6px;
+  font-size: $xxx-small;
+  font-weight: $bold;
+  gap: $pad-small
+}

--- a/frontend/components/side_panels/QuerySidePanel/EventedTableTag/index.ts
+++ b/frontend/components/side_panels/QuerySidePanel/EventedTableTag/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EventedTableTag";

--- a/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tsx
+++ b/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tsx
@@ -6,7 +6,6 @@ import { osqueryTableNames } from "utilities/osquery_tables";
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
 import FleetMarkdown from "components/FleetMarkdown";
-import Icon from "components/Icon";
 
 import QueryTableColumns from "./QueryTableColumns";
 import QueryTablePlatforms from "./QueryTablePlatforms";
@@ -15,6 +14,7 @@ import QueryTablePlatforms from "./QueryTablePlatforms";
 import CloseIcon from "../../../../assets/images/icon-close-black-50-8x8@2x.png";
 import QueryTableExample from "./QueryTableExample";
 import QueryTableNotes from "./QueryTableNotes";
+import EventedTableTag from "./EventedTableTag";
 
 interface IQuerySidePanel {
   selectedOsqueryTable: IOsQueryTable;
@@ -78,12 +78,7 @@ const QuerySidePanel = ({
         </h2>
         {renderTableSelect()}
       </div>
-      {evented && (
-        <div className={`${baseClass}__evented-table-tag`}>
-          <Icon name="calendar-check" className={`${baseClass}__event-icon`} />
-          <span>EVENTED TABLE</span>
-        </div>
-      )}
+      {evented && <EventedTableTag selectedTableName={name} />}
       <div className={`${baseClass}__description`}>
         <FleetMarkdown markdown={description} />
       </div>

--- a/frontend/components/side_panels/QuerySidePanel/QueryTableColumns/ColumnListItem/ColumnListItem.tsx
+++ b/frontend/components/side_panels/QuerySidePanel/QueryTableColumns/ColumnListItem/ColumnListItem.tsx
@@ -4,9 +4,11 @@ import classnames from "classnames";
 import { ColumnType, IQueryTableColumn } from "interfaces/osquery_table";
 import { PLATFORM_DISPLAY_NAMES } from "utilities/constants";
 import TooltipWrapper from "components/TooltipWrapper";
+import { buildQueryStringFromParams } from "utilities/url";
 
 interface IColumnListItemProps {
   column: IQueryTableColumn;
+  selectedTableName: string;
 }
 
 const baseClass = "column-list-item";
@@ -22,7 +24,10 @@ const FOOTNOTES = {
  * current tooltip only supports strings. we can change this when it support ReactNodes
  * in the future.
  */
-const createTooltipHtml = (column: IQueryTableColumn) => {
+const createTooltipHtml = (
+  column: IQueryTableColumn,
+  selectedTableName: string
+) => {
   const toolTipHtml = [];
 
   const descriptionHtml = `<span class="${baseClass}__column-description">${column.description}</span>`;
@@ -35,8 +40,19 @@ const createTooltipHtml = (column: IQueryTableColumn) => {
   }
 
   if (column.requires_user_context) {
+    const queryString = buildQueryStringFromParams({
+      utm_source: "fleet-ui",
+      utm_table: `table-${selectedTableName}`,
+    });
+
+    const href = `https://fleetdm.com/guides/osquery-consider-joining-against-the-users-table?${queryString}`;
+    const classNames = classnames(
+      `${baseClass}__footnote`,
+      `${baseClass}__footnote-link`
+    );
+
     toolTipHtml.push(
-      `<span class="${baseClass}__footnote">${FOOTNOTES.requires_user_context}</span>`
+      `<a href="${href}" target="__blank" class="${classNames}">${FOOTNOTES.requires_user_context}</a>`
     );
   }
 
@@ -77,7 +93,10 @@ const createListItemClassnames = (column: IQueryTableColumn) => {
   });
 };
 
-const ColumnListItem = ({ column }: IColumnListItemProps) => {
+const ColumnListItem = ({
+  column,
+  selectedTableName,
+}: IColumnListItemProps) => {
   const columnNameClasses = createListItemClassnames(column);
 
   return (
@@ -85,7 +104,7 @@ const ColumnListItem = ({ column }: IColumnListItemProps) => {
       <div className={`${baseClass}__name-wrapper`}>
         <span className={columnNameClasses}>
           <TooltipWrapper
-            tipContent={createTooltipHtml(column)}
+            tipContent={createTooltipHtml(column, selectedTableName)}
             className={`${baseClass}__tooltip`}
           >
             {column.name}

--- a/frontend/components/side_panels/QuerySidePanel/QueryTableColumns/ColumnListItem/_styles.scss
+++ b/frontend/components/side_panels/QuerySidePanel/QueryTableColumns/ColumnListItem/_styles.scss
@@ -56,4 +56,10 @@
       margin-bottom: 0;
     }
   }
+
+  &__footnote-link {
+    font-size: $xx-small;
+    color: $core-white;
+    text-decoration: underline;
+  }
 }

--- a/frontend/components/side_panels/QuerySidePanel/QueryTableColumns/QueryTableColumns.tsx
+++ b/frontend/components/side_panels/QuerySidePanel/QueryTableColumns/QueryTableColumns.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useContext } from "react";
 
 import { IQueryTableColumn } from "interfaces/osquery_table";
+import { QueryContext } from "context/query";
 
 import ColumnListItem from "./ColumnListItem";
 
@@ -32,8 +33,16 @@ interface IQueryTableColumnsProps {
 const baseClass = "query-table-columns";
 
 const QueryTableColumns = ({ columns }: IQueryTableColumnsProps) => {
+  const { selectedOsqueryTable } = useContext(QueryContext);
+
   const columnListItems = orderColumns(columns).map((column) => {
-    return <ColumnListItem key={column.name} column={column} />;
+    return (
+      <ColumnListItem
+        key={column.name}
+        column={column}
+        selectedTableName={selectedOsqueryTable.name}
+      />
+    );
   });
 
   return (

--- a/frontend/components/side_panels/QuerySidePanel/_styles.scss
+++ b/frontend/components/side_panels/QuerySidePanel/_styles.scss
@@ -80,20 +80,6 @@
     }
   }
 
-  &__evented-table-tag {
-    display: inline-flex;
-    align-items: center;
-    background-color: $ui-fleet-blue-15;
-    padding: $pad-xsmall $pad-small;
-    border-radius: 6px;
-    font-size: $xxx-small;
-    font-weight: $bold;
-  }
-
-  &__event-icon {
-    margin-right: $pad-small;
-  }
-
   &__description {
     font-size: $x-small;
     overflow-wrap: break-word;


### PR DESCRIPTION
relates to [#8409](https://github.com/fleetdm/fleet/issues/8409)

this adds links for evented tables and for the `requires_user_context` columns.

**Evented table tag is now a link**

![image](https://user-images.githubusercontent.com/1153709/202508242-bbb0cdbb-3ce2-458d-875d-d8a060696775.png)

**required_user_context is now a link**

![image](https://user-images.githubusercontent.com/1153709/202508511-7b271754-7750-4aae-9415-d6a841c8341e.png)

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
