### PR TITLE
Adjust cron schedule tests

### DIFF
--- a/server/datastore/mysql/cron_stats.go
+++ b/server/datastore/mysql/cron_stats.go
@@ -50,13 +50,13 @@ func (ds *Datastore) UpdateCronStats(ctx context.Context, id int, status fleet.C
 }
 
 func (ds *Datastore) CleanupCronStats(ctx context.Context) error {
-	deleteStmt := `DELETE FROM cron_stats WHERE created_at < DATE_SUB(NOW(), INTERVAL ? DAY)`
+	deleteStmt := `DELETE FROM cron_stats WHERE created_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL ? DAY)`
 	const MAX_DAYS_RETAINED = 14
 	if _, err := ds.writer.ExecContext(ctx, deleteStmt, MAX_DAYS_RETAINED); err != nil {
 		return ctxerr.Wrap(ctx, err, "deleting old cron stats")
 	}
 	const MAX_HOURS_PENDING = 2
-	updateStmt := `UPDATE cron_stats SET status = ? WHERE created_at < DATE_SUB(NOW(), INTERVAL ? HOUR) AND status = ?`
+	updateStmt := `UPDATE cron_stats SET status = ? WHERE created_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL ? HOUR) AND status = ?`
 	if _, err := ds.writer.ExecContext(ctx, updateStmt, fleet.CronStatsStatusExpired, MAX_HOURS_PENDING, fleet.CronStatsStatusPending); err != nil {
 		return ctxerr.Wrap(ctx, err, "updating expired cron stats")
 	}

--- a/server/datastore/mysql/cron_stats.go
+++ b/server/datastore/mysql/cron_stats.go
@@ -50,13 +50,13 @@ func (ds *Datastore) UpdateCronStats(ctx context.Context, id int, status fleet.C
 }
 
 func (ds *Datastore) CleanupCronStats(ctx context.Context) error {
-	deleteStmt := `DELETE FROM cron_stats WHERE created_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL ? DAY)`
+	deleteStmt := `DELETE FROM cron_stats WHERE created_at < DATE_SUB(NOW(), INTERVAL ? DAY)`
 	const MAX_DAYS_RETAINED = 14
 	if _, err := ds.writer.ExecContext(ctx, deleteStmt, MAX_DAYS_RETAINED); err != nil {
 		return ctxerr.Wrap(ctx, err, "deleting old cron stats")
 	}
 	const MAX_HOURS_PENDING = 2
-	updateStmt := `UPDATE cron_stats SET status = ? WHERE created_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL ? HOUR) AND status = ?`
+	updateStmt := `UPDATE cron_stats SET status = ? WHERE created_at < DATE_SUB(NOW(), INTERVAL ? HOUR) AND status = ?`
 	if _, err := ds.writer.ExecContext(ctx, updateStmt, fleet.CronStatsStatusExpired, MAX_HOURS_PENDING, fleet.CronStatsStatusPending); err != nil {
 		return ctxerr.Wrap(ctx, err, "updating expired cron stats")
 	}

--- a/server/datastore/mysql/cron_stats_test.go
+++ b/server/datastore/mysql/cron_stats_test.go
@@ -197,7 +197,7 @@ func TestCleanupCronStats(t *testing.T) {
 	}
 
 	var stats []fleet.CronStats
-	err := sqlx.SelectContext(ctx, ds.reader, &stats, `SELECT * FROM cron_stats`)
+	err := sqlx.SelectContext(ctx, ds.reader, &stats, `SELECT * FROM cron_stats ORDER BY id`)
 	require.NoError(t, err)
 	require.Len(t, stats, len(cases))
 	for i, s := range stats {
@@ -207,7 +207,7 @@ func TestCleanupCronStats(t *testing.T) {
 
 	ds.CleanupCronStats(ctx)
 	stats = []fleet.CronStats{}
-	err = sqlx.SelectContext(ctx, ds.reader, &stats, `SELECT * FROM cron_stats`)
+	err = sqlx.SelectContext(ctx, ds.reader, &stats, `SELECT * FROM cron_stats ORDER BY id`)
 	require.NoError(t, err)
 	require.Len(t, stats, len(cases)-1) // case[7] was deleted because it exceeded max age
 	for i, c := range cases {

--- a/server/datastore/mysql/cron_stats_test.go
+++ b/server/datastore/mysql/cron_stats_test.go
@@ -67,8 +67,8 @@ func TestGetInsertUpdateCronStats(t *testing.T) {
 		require.Equal(t, c.Name, res.Name)
 		require.Equal(t, c.Instance, res.Instance)
 		require.Equal(t, c.Status, res.Status)
-		require.Equal(t, now, res.CreatedAt)
-		require.Equal(t, now, res.UpdatedAt)
+		require.WithinRange(t, res.CreatedAt, now, now.Add(1*time.Second))
+		require.WithinRange(t, res.UpdatedAt, now, now.Add(1*time.Second))
 		results = append(results, res)
 	}
 
@@ -90,9 +90,9 @@ func TestGetInsertUpdateCronStats(t *testing.T) {
 		require.Equal(t, fleet.CronStatsStatusCompleted, r.Status)
 		require.Equal(t, results[i].CreatedAt, r.CreatedAt)
 		if cases[i].Status != fleet.CronStatsStatusCompleted {
-			require.Equal(t, start.Add(2*time.Second), r.UpdatedAt)
+			require.WithinRange(t, r.UpdatedAt, start.Add(2*time.Second), time.Now())
 		} else {
-			require.Equal(t, start, r.UpdatedAt)
+			require.Equal(t, results[i].UpdatedAt, r.UpdatedAt)
 		}
 	}
 
@@ -106,11 +106,8 @@ func TestGetInsertUpdateCronStats(t *testing.T) {
 	require.Equal(t, cases[1].Instance, res.Instance)
 	require.Equal(t, fleet.CronStatsStatusCompleted, res.Status)
 	require.Equal(t, results[1].CreatedAt, res.CreatedAt)
-	if cases[2].Status != fleet.CronStatsStatusCompleted {
-		require.Equal(t, start.Add(2*time.Second), res.UpdatedAt)
-	} else {
-		require.Equal(t, start, res.UpdatedAt)
-	}
+	require.WithinRange(t, res.UpdatedAt, start.Add(2*time.Second), time.Now()) // second case was updated from pending to completed
+
 	res, err = ds.GetLatestCronStats(ctx, "sched2")
 	require.NoError(t, err)
 	// sixth case was the last inserted for sched2
@@ -119,11 +116,8 @@ func TestGetInsertUpdateCronStats(t *testing.T) {
 	require.Equal(t, cases[5].Instance, res.Instance)
 	require.Equal(t, fleet.CronStatsStatusCompleted, res.Status)
 	require.Equal(t, results[5].CreatedAt, res.CreatedAt)
-	if cases[5].Status != fleet.CronStatsStatusCompleted {
-		require.Equal(t, start.Add(2*time.Second), res.UpdatedAt)
-	} else {
-		require.Equal(t, start, res.UpdatedAt)
-	}
+	require.Equal(t, results[5].CreatedAt, res.CreatedAt)
+	require.Equal(t, results[5].UpdatedAt, res.UpdatedAt) // sixth case wasn't updated
 }
 
 func TestCleanupCronStats(t *testing.T) {

--- a/server/service/schedule/schedule_test.go
+++ b/server/service/schedule/schedule_test.go
@@ -361,7 +361,7 @@ func TestScheduleReleaseLock(t *testing.T) {
 		require.Equal(t, 4, ml.GetLockCount())
 		require.WithinRange(t, time.Now(),
 			start.Add(2*schedInterval).Add(jobDuration),
-			start.Add(2*schedInterval).Add(jobDuration).Add(20*time.Millisecond),
+			start.Add(2*schedInterval).Add(jobDuration).Add(500*time.Millisecond),
 		)
 	}
 }
@@ -420,7 +420,7 @@ func TestScheduleHoldLock(t *testing.T) {
 		require.Equal(t, 4, ml.GetLockCount())
 		require.WithinRange(t, time.Now(),
 			start.Add(3*schedInterval).Add(jobDuration),
-			start.Add(3*schedInterval).Add(jobDuration).Add(20*time.Millisecond),
+			start.Add(3*schedInterval).Add(jobDuration).Add(500*time.Millisecond),
 		)
 	}
 }

--- a/server/service/schedule/schedule_test.go
+++ b/server/service/schedule/schedule_test.go
@@ -359,10 +359,7 @@ func TestScheduleReleaseLock(t *testing.T) {
 	case <-ml.Unlocked:
 		require.Equal(t, 2, jobCount)
 		require.Equal(t, 4, ml.GetLockCount())
-		require.WithinRange(t, time.Now(),
-			start.Add(2*schedInterval).Add(jobDuration),
-			start.Add(2*schedInterval).Add(jobDuration).Add(1*time.Second),
-		)
+		require.True(t, time.Now().After(start.Add(2*schedInterval).Add(jobDuration)))
 	}
 }
 

--- a/server/service/schedule/schedule_test.go
+++ b/server/service/schedule/schedule_test.go
@@ -361,7 +361,7 @@ func TestScheduleReleaseLock(t *testing.T) {
 		require.Equal(t, 4, ml.GetLockCount())
 		require.WithinRange(t, time.Now(),
 			start.Add(2*schedInterval).Add(jobDuration),
-			start.Add(2*schedInterval).Add(jobDuration).Add(500*time.Millisecond),
+			start.Add(2*schedInterval).Add(jobDuration).Add(1*time.Second),
 		)
 	}
 }
@@ -420,7 +420,7 @@ func TestScheduleHoldLock(t *testing.T) {
 		require.Equal(t, 4, ml.GetLockCount())
 		require.WithinRange(t, time.Now(),
 			start.Add(3*schedInterval).Add(jobDuration),
-			start.Add(3*schedInterval).Add(jobDuration).Add(500*time.Millisecond),
+			start.Add(3*schedInterval).Add(jobDuration).Add(1*time.Second),
 		)
 	}
 }


### PR DESCRIPTION
- Increase time range for tests to account for lags in CI that have resulted in test flake
- Tweak cleanup cron schedules test to account for variance in sql select order