### PR TITLE
Fleet UI: Allow software table rows to be clickable

### DIFF
--- a/changes/issue-8389-add-clickable-rows-software-tables
+++ b/changes/issue-8389-add-clickable-rows-software-tables
@@ -1,0 +1,1 @@
+- Software tables now have clickable rows to direct to view all hosts filtered by software

--- a/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
+++ b/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
@@ -82,7 +82,7 @@ const TargetsInput = ({
               isAllPagesSelected={false}
               disableCount
               disablePagination
-              // disableMultiRowSelect
+              disableMultiRowSelect
               onSelectSingleRow={handleRowSelect}
             />
           </div>

--- a/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
+++ b/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
@@ -82,7 +82,7 @@ const TargetsInput = ({
               isAllPagesSelected={false}
               disableCount
               disablePagination
-              disableMultiRowSelect
+              // disableMultiRowSelect
               onSelectSingleRow={handleRowSelect}
             />
           </div>

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -21,10 +21,9 @@ export interface ITableQueryData {
   sortHeader: string;
   sortDirection: string;
 }
-
-interface IRowProps {
-  row: {
-    original: any;
+interface IRowProps extends Row {
+  original: {
+    id?: number;
   };
 }
 

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -13,7 +13,6 @@ import { ButtonVariant } from "components/buttons/Button/Button";
 import DataTable from "./DataTable/DataTable";
 import TableContainerUtils from "./TableContainerUtils";
 import { IActionButtonProps } from "./DataTable/ActionButton";
-// import {IRowProps } from "components/"
 
 export interface ITableQueryData {
   pageIndex: number;
@@ -21,6 +20,12 @@ export interface ITableQueryData {
   searchQuery: string;
   sortHeader: string;
   sortDirection: string;
+}
+
+interface IRowProps {
+  row: {
+    original: any;
+  };
 }
 
 interface ITableContainerProps {

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -13,6 +13,7 @@ import { ButtonVariant } from "components/buttons/Button/Button";
 import DataTable from "./DataTable/DataTable";
 import TableContainerUtils from "./TableContainerUtils";
 import { IActionButtonProps } from "./DataTable/ActionButton";
+// import {IRowProps } from "components/"
 
 export interface ITableQueryData {
   pageIndex: number;
@@ -73,7 +74,7 @@ interface ITableContainerProps {
   onPrimarySelectActionClick?: (selectedItemIds: number[]) => void;
   customControl?: () => JSX.Element;
   stackControls?: boolean;
-  onSelectSingleRow?: (value: Row) => void;
+  onSelectSingleRow?: (value: Row | IRowProps) => void;
   filters?: Record<string, string | number | boolean>;
   renderCount?: () => JSX.Element | null;
   renderFooter?: () => JSX.Element | null;

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -488,6 +488,7 @@ const DashboardPage = ({
         navTabIndex={softwareNavTabIndex}
         onTabChange={onSoftwareTabChange}
         onQueryChange={onSoftwareQueryChange}
+        router={router}
       />
     ),
   });

--- a/frontend/pages/DashboardPage/cards/Software/Software.tsx
+++ b/frontend/pages/DashboardPage/cards/Software/Software.tsx
@@ -1,10 +1,16 @@
 import React from "react";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
+import { Row } from "react-table";
+import { InjectedRouter } from "react-router";
+import PATHS from "router/paths";
+
+import { buildQueryStringFromParams } from "utilities/url";
 
 import TabsWrapper from "components/TabsWrapper";
 import TableContainer from "components/TableContainer";
 import TableDataError from "components/DataError";
 import Spinner from "components/Spinner";
+
 import generateTableHeaders from "./SoftwareTableConfig";
 import EmptySoftware from "../../../software/components/EmptySoftware";
 
@@ -18,6 +24,13 @@ interface ISoftwareCardProps {
   navTabIndex: any;
   onTabChange: any;
   onQueryChange: any;
+  router: InjectedRouter;
+}
+
+interface IRowProps extends Row {
+  original: {
+    id: number;
+  };
 }
 
 const SOFTWARE_DEFAULT_SORT_DIRECTION = "desc";
@@ -35,8 +48,19 @@ const Software = ({
   onTabChange,
   onQueryChange,
   software,
+  router,
 }: ISoftwareCardProps): JSX.Element => {
   const tableHeaders = generateTableHeaders();
+
+  const handleRowSelect = (row: IRowProps) => {
+    const queryParams = { software_id: row.original.id };
+
+    const path = queryParams
+      ? `${PATHS.MANAGE_HOSTS}?${buildQueryStringFromParams(queryParams)}`
+      : PATHS.MANAGE_HOSTS;
+
+    router.push(path);
+  };
 
   // Renders opaque information as host information is loading
   const opacity = isSoftwareFetching ? { opacity: 0 } : { opacity: 1 };
@@ -80,6 +104,8 @@ const Software = ({
                   disableActionButton
                   pageSize={SOFTWARE_DEFAULT_PAGE_SIZE}
                   onQueryChange={onQueryChange}
+                  disableMultiRowSelect
+                  onSelectSingleRow={handleRowSelect}
                 />
               )}
             </TabPanel>

--- a/frontend/pages/DashboardPage/cards/Software/Software.tsx
+++ b/frontend/pages/DashboardPage/cards/Software/Software.tsx
@@ -29,7 +29,7 @@ interface ISoftwareCardProps {
 
 interface IRowProps extends Row {
   original: {
-    id: number;
+    id?: number;
   };
 }
 
@@ -134,6 +134,8 @@ const Software = ({
                   disableActionButton
                   pageSize={SOFTWARE_DEFAULT_PAGE_SIZE}
                   onQueryChange={onQueryChange}
+                  disableMultiRowSelect
+                  onSelectSingleRow={handleRowSelect}
                 />
               )}
             </TabPanel>

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -662,6 +662,7 @@ const HostDetailsPage = ({
                   featuresConfig?.enable_software_inventory
                 }
                 deviceType={host?.platform === "darwin" ? "macos" : ""}
+                router={router}
               />
               {host?.platform === "darwin" && macadmins && (
                 <MunkiIssuesCard

--- a/frontend/pages/hosts/details/cards/Software/Software.tsx
+++ b/frontend/pages/hosts/details/cards/Software/Software.tsx
@@ -1,8 +1,12 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
+import { InjectedRouter } from "react-router";
+import { Row } from "react-table";
+import PATHS from "router/paths";
 
 import { ISoftware } from "interfaces/software";
 import { VULNERABLE_DROPDOWN_OPTIONS } from "utilities/constants";
+import { buildQueryStringFromParams } from "utilities/url";
 
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
@@ -28,6 +32,13 @@ interface ISoftwareTableProps {
   deviceUser?: boolean;
   deviceType?: string;
   softwareInventoryEnabled?: boolean;
+  router?: InjectedRouter;
+}
+
+interface IRowProps extends Row {
+  original: {
+    id?: number;
+  };
 }
 
 const SoftwareTable = ({
@@ -36,6 +47,7 @@ const SoftwareTable = ({
   deviceUser,
   deviceType,
   softwareInventoryEnabled,
+  router,
 }: ISoftwareTableProps): JSX.Element => {
   const [searchString, setSearchString] = useState("");
   const [filterVuln, setFilterVuln] = useState(false);
@@ -58,12 +70,27 @@ const SoftwareTable = ({
   const tableSoftware = useMemo(() => generateSoftwareTableData(software), [
     software,
   ]);
-  const tableHeaders = useMemo(() => generateSoftwareTableHeaders(deviceUser), [
-    deviceUser,
-  ]);
+  const tableHeaders = useMemo(
+    () => generateSoftwareTableHeaders(deviceUser, router),
+    [deviceUser, router]
+  );
 
   const onVulnFilterChange = (value: boolean) => {
     setFilterVuln(value);
+  };
+
+  const handleRowSelect = (row: IRowProps) => {
+    if (deviceUser || !router) {
+      return;
+    }
+
+    const queryParams = { software_id: row.original.id };
+
+    const path = queryParams
+      ? `${PATHS.MANAGE_HOSTS}?${buildQueryStringFromParams(queryParams)}`
+      : PATHS.MANAGE_HOSTS;
+
+    router.push(path);
   };
 
   const renderVulnFilterDropdown = () => {
@@ -125,6 +152,8 @@ const SoftwareTable = ({
                 isClientSidePagination
                 pageSize={20}
                 isClientSideFilter
+                disableMultiRowSelect={!deviceUser && !!router} // device user cannot view hosts by software
+                onSelectSingleRow={handleRowSelect}
               />
             </div>
           )}

--- a/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { Link } from "react-router";
+import { InjectedRouter } from "react-router";
 import ReactTooltip from "react-tooltip";
 
 import { formatDistanceToNow } from "date-fns";
 
 import { ISoftware } from "interfaces/software";
-
 import PATHS from "router/paths";
+
+import Button from "components/buttons/Button";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import TooltipWrapper from "components/TooltipWrapper";
@@ -133,7 +134,8 @@ export const generateSoftwareTableData = (
 // NOTE: cellProps come from react-table
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
 export const generateSoftwareTableHeaders = (
-  deviceUser = false
+  deviceUser = false,
+  router?: InjectedRouter
 ): IDataColumn[] => {
   const tableHeaders: IDataColumn[] = [
     {
@@ -156,10 +158,18 @@ export const generateSoftwareTableHeaders = (
             <span>{name}</span>
           );
         }
+
+        const onClickSoftware = (e: React.MouseEvent) => {
+          // Allows for button to be clickable in a clickable row
+          e.stopPropagation();
+
+          router?.push(PATHS.SOFTWARE_DETAILS(id.toString()));
+        };
+
         return (
-          <Link to={`${PATHS.SOFTWARE_DETAILS(id.toString())}`}>
+          <Button onClick={onClickSoftware} variant="text-link">
             {bundle ? renderBundleTooltip(name, bundle) : name}
-          </Link>
+          </Button>
         );
       },
       sortType: "caseInsensitive",

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -92,7 +92,7 @@ interface IHeaderButtonsState extends ITeamsDropdownState {
 
 interface IRowProps extends Row {
   original: {
-    id: number;
+    id?: number;
   };
 }
 

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -5,6 +5,8 @@ import React, {
   useMemo,
   useState,
 } from "react";
+import { Row } from "react-table";
+import PATHS from "router/paths";
 import { useQuery } from "react-query";
 import { InjectedRouter } from "react-router/lib/Router";
 import { useDebouncedCallback } from "use-debounce";
@@ -30,6 +32,7 @@ import {
   GITHUB_NEW_ISSUE_LINK,
   VULNERABLE_DROPDOWN_OPTIONS,
 } from "utilities/constants";
+import { buildQueryStringFromParams, QueryParams } from "utilities/url";
 
 import Button from "components/buttons/Button";
 // @ts-ignore
@@ -86,6 +89,13 @@ interface ISoftwareAutomations {
 interface IHeaderButtonsState extends ITeamsDropdownState {
   isLoading: boolean;
 }
+
+interface IRowProps extends Row {
+  original: {
+    id: number;
+  };
+}
+
 const DEFAULT_SORT_DIRECTION = "desc";
 const DEFAULT_PAGE_SIZE = 20;
 
@@ -510,6 +520,15 @@ const ManageSoftwarePage = ({
     () => generateSoftwareTableHeaders(isPremiumTier),
     [isPremiumTier]
   );
+  const handleRowSelect = (row: IRowProps) => {
+    const queryParams = { software_id: row.original.id };
+
+    const path = queryParams
+      ? `${PATHS.MANAGE_HOSTS}?${buildQueryStringFromParams(queryParams)}`
+      : PATHS.MANAGE_HOSTS;
+
+    router.push(path);
+  };
 
   return !availableTeams ||
     !globalConfig ||
@@ -555,6 +574,8 @@ const ManageSoftwarePage = ({
               renderFooter={renderTableFooter}
               disableActionButton
               hideActionButton
+              disableMultiRowSelect
+              onSelectSingleRow={handleRowSelect}
             />
           )}
         </div>

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -517,8 +517,8 @@ const ManageSoftwarePage = ({
       softwareCount;
 
   const softwareTableHeaders = useMemo(
-    () => generateSoftwareTableHeaders(isPremiumTier),
-    [isPremiumTier]
+    () => generateSoftwareTableHeaders(isPremiumTier, router),
+    [isPremiumTier, router]
   );
   const handleRowSelect = (row: IRowProps) => {
     const queryParams = { software_id: row.original.id };

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -517,7 +517,7 @@ const ManageSoftwarePage = ({
       softwareCount;
 
   const softwareTableHeaders = useMemo(
-    () => generateSoftwareTableHeaders(isPremiumTier, router),
+    () => generateSoftwareTableHeaders(router, isPremiumTier),
     [isPremiumTier, router]
   );
   const handleRowSelect = (row: IRowProps) => {

--- a/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import { Column } from "react-table";
+import { InjectedRouter } from "react-router";
 import ReactTooltip from "react-tooltip";
-import { Link } from "react-router";
 
 import { formatSoftwareType, ISoftware } from "interfaces/software";
 import { IVulnerability } from "interfaces/vulnerability";
 import PATHS from "router/paths";
 import { formatFloatAsPercentage } from "utilities/helpers";
 
+import Button from "components/buttons/Button";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import TooltipWrapper from "components/TooltipWrapper";
@@ -178,7 +179,10 @@ const generateVulnColumnHeader = () => {
   };
 };
 
-const generateTableHeaders = (isPremiumTier?: boolean): Column[] => {
+const generateTableHeaders = (
+  isPremiumTier?: boolean,
+  router: InjectedRouter
+): Column[] => {
   const softwareTableHeaders = [
     {
       title: "Name",
@@ -187,10 +191,18 @@ const generateTableHeaders = (isPremiumTier?: boolean): Column[] => {
       accessor: "name",
       Cell: (cellProps: IStringCellProps): JSX.Element => {
         const { id, name, bundle_identifier: bundle } = cellProps.row.original;
+
+        const onClickSoftware = (e: React.MouseEvent) => {
+          // Allows for button to be clickable in a clickable row
+          e.stopPropagation();
+
+          router?.push(PATHS.SOFTWARE_DETAILS(id.toString()));
+        };
+
         return (
-          <Link to={`${PATHS.SOFTWARE_DETAILS(id.toString())}`}>
+          <Button onClick={onClickSoftware} variant="text-link">
             {bundle ? renderBundleTooltip(name, bundle) : name}
-          </Link>
+          </Button>
         );
       },
       sortType: "caseInsensitive",

--- a/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
@@ -180,8 +180,8 @@ const generateVulnColumnHeader = () => {
 };
 
 const generateTableHeaders = (
-  isPremiumTier?: boolean,
-  router: InjectedRouter
+  router: InjectedRouter,
+  isPremiumTier?: boolean
 ): Column[] => {
   const softwareTableHeaders = [
     {


### PR DESCRIPTION
Cerra #8389 

**New feature**
- Software table rows now clickable and lead users to the hosts page filtered by software
  - Pages with new feature: Software Page, Dashboard Page, Host Details Page
  - Vulnerable software table rows also clickable
  - Software name links to software details (different from clicking the row)
- Clickable rows are light fleet purple on hover, vs. the grey on other tables

**Screenshots**
<img width="870" alt="Screenshot 2022-11-21 at 11 19 20 AM" src="https://user-images.githubusercontent.com/71795832/203105396-7de4eefb-8695-4c29-853b-f0672a0c68b2.png">
<img width="1498" alt="Screenshot 2022-11-21 at 11 19 01 AM" src="https://user-images.githubusercontent.com/71795832/203105400-6ae72619-fdcd-4f42-9dec-552ca63bd93d.png">
<img width="1498" alt="Screenshot 2022-11-21 at 3 26 08 PM" src="https://user-images.githubusercontent.com/71795832/203153204-469f9e67-fe5c-4316-a5b5-d06bef9d8f37.png">

**Dev QA**
- [x] Functionality on 3 software tables + 3 vulnerability tables, software details links still work, on Chrome, FF, and Safari

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality

