### PR TITLE
Fleet queries bug: Fix osquery fleet tables json types

### DIFF
--- a/changes/bug-8798-fix-query-table-platform-type
+++ b/changes/bug-8798-fix-query-table-platform-type
@@ -1,0 +1,1 @@
+* Fix query table json platforms to be type array

--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -3,9 +3,7 @@
     "name": "account_policy_data",
     "description": "Additional macOS user account data from the AccountPolicy section of OpenDirectory.",
     "url": "https://fleetdm.com/tables/account_policy_data",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -57,10 +55,7 @@
     "name": "acpi_tables",
     "description": "Firmware ACPI functional table common metadata and content.",
     "url": "https://fleetdm.com/tables/acpi_tables",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -96,9 +91,7 @@
     "name": "ad_config",
     "description": "macOS Active Directory configuration.",
     "url": "https://fleetdm.com/tables/ad_config",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -142,9 +135,7 @@
     "name": "alf",
     "description": "macOS application layer firewall (ALF) service details.",
     "url": "https://fleetdm.com/tables/alf",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -212,9 +203,7 @@
     "name": "alf_exceptions",
     "description": "The exceptions configured for the [built-in firewall protection](https://fleetdm.com/tables/alf) on this Mac.",
     "url": "https://fleetdm.com/tables/alf_exceptions",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -242,9 +231,7 @@
     "name": "alf_explicit_auths",
     "description": "ALF services explicitly allowed to perform networking.",
     "url": "https://fleetdm.com/tables/alf_explicit_auths",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -265,9 +252,7 @@
     "name": "app_schemes",
     "description": "macOS application schemes and handlers (e.g., http, file, mailto).",
     "url": "https://fleetdm.com/tables/app_schemes",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -319,9 +304,7 @@
     "name": "apparmor_events",
     "description": "Track AppArmor events.",
     "url": "https://fleetdm.com/tables/apparmor_events",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -509,9 +492,7 @@
     "name": "apparmor_profiles",
     "description": "Track active AppArmor profiles.",
     "url": "https://fleetdm.com/tables/apparmor_profiles",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -563,9 +544,7 @@
     "name": "appcompat_shims",
     "description": "Application Compatibility shims are a way to persist malware. This table presents the AppCompat Shim information from the registry in a nice format. See http://files.brucon.org/2015/Tomczak_and_Ballenthin_Shims_for_the_Win.pdf for more details.",
     "url": "https://fleetdm.com/tables/appcompat_shims",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -625,9 +604,7 @@
     "name": "apps",
     "description": "macOS applications installed in known search paths (e.g., /Applications).",
     "url": "https://fleetdm.com/tables/apps",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -791,9 +768,7 @@
     "name": "apt_sources",
     "description": "Current list of APT repositories or software channels.",
     "url": "https://fleetdm.com/tables/apt_sources",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -868,9 +843,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "On Ubuntu or other Debian based systems, identify APT repositories that are not maintained by Ubuntu.\n```\nSELECT * FROM apt_sources WHERE maintainer!='Ubuntu';\n```",
@@ -880,12 +853,7 @@
     "name": "arp_cache",
     "description": "Address resolution cache, both static and dynamic (from ARP, NDP).",
     "url": "https://fleetdm.com/tables/arp_cache",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -930,9 +898,7 @@
     "name": "asl",
     "description": "Queries the Apple System Log data structure for system events.",
     "url": "https://fleetdm.com/tables/asl",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -1048,12 +1014,7 @@
     "name": "atom_packages",
     "description": "Lists all atom packages in a directory or globally installed in a system.",
     "url": "https://fleetdm.com/tables/atom_packages",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -1122,10 +1083,7 @@
     "name": "augeas",
     "description": "Configuration files parsed by augeas.",
     "url": "https://fleetdm.com/tables/augeas",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -1169,9 +1127,7 @@
     "name": "authenticode",
     "description": "File (executable, bundle, installer, disk) code signing status.",
     "url": "https://fleetdm.com/tables/authenticode",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -1231,9 +1187,7 @@
     "name": "authorization_mechanisms",
     "description": "macOS Authorization mechanisms database.",
     "url": "https://fleetdm.com/tables/authorization_mechanisms",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -1285,9 +1239,7 @@
     "name": "authorizations",
     "description": "macOS Authorization rights database.",
     "url": "https://fleetdm.com/tables/authorizations",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -1395,10 +1347,7 @@
     "name": "authorized_keys",
     "description": "A line-delimited authorized_keys table.",
     "url": "https://fleetdm.com/tables/authorized_keys",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -1442,9 +1391,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "List the SSH keys allowed to connect to this host.\n```\nSELECT key FROM authorized_keys;\n```",
@@ -1454,9 +1401,7 @@
     "name": "autoexec",
     "description": "Aggregate of executables that will automatically execute on the target machine. This is an amalgamation of other tables like services, scheduled_tasks, startup_items and more.",
     "url": "https://fleetdm.com/tables/autoexec",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -1492,12 +1437,7 @@
     "name": "azure_instance_metadata",
     "description": "Azure instance metadata.",
     "url": "https://fleetdm.com/tables/azure_instance_metadata",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -1637,12 +1577,7 @@
     "name": "azure_instance_tags",
     "description": "Azure instance tags.",
     "url": "https://fleetdm.com/tables/azure_instance_tags",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -1678,9 +1613,7 @@
     "name": "background_activities_moderator",
     "description": "Background Activities Moderator (BAM) tracks application execution.",
     "url": "https://fleetdm.com/tables/background_activities_moderator",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -1716,9 +1649,7 @@
     "name": "battery",
     "description": "Provides information about the internal battery of a Macbook.",
     "url": "https://fleetdm.com/tables/battery",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -1874,9 +1805,7 @@
     "name": "bitlocker_info",
     "description": "Retrieve bitlocker status of the machine.",
     "url": "https://fleetdm.com/tables/bitlocker_info",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -1961,10 +1890,7 @@
     "name": "block_devices",
     "description": "Block (buffered access) device file nodes: disks, ramdisks, and DMG containers.",
     "url": "https://fleetdm.com/tables/block_devices",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -2048,9 +1974,7 @@
     "name": "bpf_process_events",
     "description": "Track time/action process executions.",
     "url": "https://fleetdm.com/tables/bpf_process_events",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -2198,9 +2122,7 @@
     "name": "bpf_socket_events",
     "description": "Track network socket opens and closes.",
     "url": "https://fleetdm.com/tables/bpf_socket_events",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -2388,9 +2310,7 @@
     "name": "browser_plugins",
     "description": "All C/NPAPI browser plugin details for all users. C/NPAPI has been deprecated on all major browsers. To query for plugins on modern browsers, try: `chrome_extensions` `firefox_addons` `safari_extensions`.",
     "url": "https://fleetdm.com/tables/browser_plugins",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -2482,12 +2402,7 @@
     "name": "carbon_black_info",
     "description": "Returns info about a Carbon Black sensor install.",
     "url": "https://fleetdm.com/tables/carbon_black_info",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -2667,12 +2582,7 @@
     "name": "carves",
     "description": "List the set of completed and in-progress carves. If carve=1 then the query is treated as a new carve request.",
     "url": "https://fleetdm.com/tables/carves",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -2748,12 +2658,7 @@
     "name": "certificates",
     "description": "[Certificate authorities](https://en.wikipedia.org/wiki/Certificate_authority) installed in Keychains/ca-bundles.",
     "url": "https://fleetdm.com/tables/certificates",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -2892,9 +2797,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "store_location",
@@ -2903,9 +2806,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "store",
@@ -2914,9 +2815,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "username",
@@ -2925,9 +2824,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "store_id",
@@ -2936,9 +2833,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "issuer2",
@@ -2947,10 +2842,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux",
-          "macOS"
-        ]
+        "platforms": ["Linux", "macOS"]
       },
       {
         "name": "subject2",
@@ -2959,10 +2851,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux",
-          "macOS"
-        ]
+        "platforms": ["Linux", "macOS"]
       }
     ],
     "examples": "Replace 1QAZ2WSX with your Apple Developer ID, if you have one. This query will then let you identify Macs that have a copy of your code signing and notarization certificates.\n```\nSELECT * FROM certificates WHERE common_\"name\" LIKE '%%1QAZ2SWX%%';\n```",
@@ -2972,9 +2861,7 @@
     "name": "chassis_info",
     "description": "Display information pertaining to the chassis and its security status.",
     "url": "https://fleetdm.com/tables/chassis_info",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -3090,9 +2977,7 @@
     "name": "chocolatey_packages",
     "description": "Chocolatey packages installed in a system.",
     "url": "https://fleetdm.com/tables/chocolatey_packages",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -3152,12 +3037,7 @@
     "name": "chrome_extension_content_scripts",
     "description": "Chrome browser extension content scripts.",
     "url": "https://fleetdm.com/tables/chrome_extension_content_scripts",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -3241,12 +3121,7 @@
     "name": "chrome_extensions",
     "description": "Chrome-based browser extensions.",
     "url": "https://fleetdm.com/tables/chrome_extensions",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -3475,9 +3350,7 @@
     "name": "connectivity",
     "description": "Provides the overall system's network state.",
     "url": "https://fleetdm.com/tables/connectivity",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -3561,10 +3434,7 @@
     "name": "cpu_info",
     "description": "Retrieve cpu hardware info of the machine.",
     "url": "https://fleetdm.com/tables/cpu_info",
-    "platforms": [
-      "linux",
-      "windows"
-    ],
+    "platforms": ["linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -3672,10 +3542,7 @@
     "name": "cpu_time",
     "description": "Displays information from /proc/stat file about the time the cpu cores spent in different parts of the system.",
     "url": "https://fleetdm.com/tables/cpu_time",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -3775,12 +3642,7 @@
     "name": "cpuid",
     "description": "Useful CPU features from the cpuid ASM call.",
     "url": "https://fleetdm.com/tables/cpuid",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -3832,9 +3694,7 @@
     "name": "crashes",
     "description": "Application, System, and Mobile App crash logs.",
     "url": "https://fleetdm.com/tables/crashes",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -3975,10 +3835,7 @@
     "name": "crontab",
     "description": "Line parsed values from system and user cron/tab.",
     "url": "https://fleetdm.com/tables/crontab",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -4053,9 +3910,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       }
     ],
     "examples": "List commands scheduled for execution as cron jobs\n```\nSELECT * FROM crontab;\n```",
@@ -4065,9 +3920,7 @@
     "name": "cups_destinations",
     "description": "Returns all configured printers.",
     "url": "https://fleetdm.com/tables/cups_destinations",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -4103,9 +3956,7 @@
     "name": "cups_jobs",
     "description": "Returns all completed print jobs from cups.",
     "url": "https://fleetdm.com/tables/cups_jobs",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -4181,12 +4032,7 @@
     "name": "curl",
     "description": "Perform an http request and return stats about it.",
     "url": "https://fleetdm.com/tables/curl",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -4254,12 +4100,7 @@
     "name": "curl_certificate",
     "description": "Inspect TLS certificates by connecting to input hostnames.",
     "url": "https://fleetdm.com/tables/curl_certificate",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -4527,9 +4368,7 @@
     "name": "deb_packages",
     "description": "The installed DEB package database.",
     "url": "https://fleetdm.com/tables/deb_packages",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -4628,9 +4467,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "mount_namespace_id",
@@ -4639,9 +4476,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/deb_packages.yml"
@@ -4650,9 +4485,7 @@
     "name": "default_environment",
     "description": "Default environment variables and values.",
     "url": "https://fleetdm.com/tables/default_environment",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -4688,10 +4521,7 @@
     "name": "device_file",
     "description": "Similar to the file table, but use TSK and allow block address access.",
     "url": "https://fleetdm.com/tables/device_file",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -4823,9 +4653,7 @@
     "name": "device_firmware",
     "description": "A best-effort list of discovered firmware versions.",
     "url": "https://fleetdm.com/tables/device_firmware",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -4861,10 +4689,7 @@
     "name": "device_hash",
     "description": "Similar to the hash table, but use TSK and allow block address access.",
     "url": "https://fleetdm.com/tables/device_hash",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -4924,10 +4749,7 @@
     "name": "device_partitions",
     "description": "Use TSK to enumerate details about partitions on a disk device.",
     "url": "https://fleetdm.com/tables/device_partitions",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -5011,10 +4833,7 @@
     "name": "disk_encryption",
     "description": "Disk encryption status and information.",
     "url": "https://fleetdm.com/tables/disk_encryption",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -5065,9 +4884,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "macOS"
-        ]
+        "platforms": ["macOS"]
       },
       {
         "name": "user_uuid",
@@ -5076,9 +4893,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "macOS"
-        ]
+        "platforms": ["macOS"]
       },
       {
         "name": "filevault_status",
@@ -5087,9 +4902,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "macOS"
-        ]
+        "platforms": ["macOS"]
       }
     ],
     "examples": "A policy query to check if Filevault disk encryption is enabled on a Mac.\n```\nSELECT 1 FROM disk_encryption WHERE user_uuid IS NOT '' AND filevault_status = 'on' LIMIT 1;\n```",
@@ -5099,9 +4912,7 @@
     "name": "disk_events",
     "description": "Track DMG disk image events (appearance/disappearance) when opened.",
     "url": "https://fleetdm.com/tables/disk_events",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -5241,9 +5052,7 @@
     "name": "disk_info",
     "description": "Retrieve basic information about the physical disks of a system.",
     "url": "https://fleetdm.com/tables/disk_info",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -5343,9 +5152,7 @@
     "name": "dns_cache",
     "description": "Enumerate the DNS cache using the undocumented DnsGetCacheDataTable function in dnsapi.dll.",
     "url": "https://fleetdm.com/tables/dns_cache",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -5381,10 +5188,7 @@
     "name": "dns_resolvers",
     "description": "Resolvers used by this host.",
     "url": "https://fleetdm.com/tables/dns_resolvers",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -5435,9 +5239,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "Identify computers that are using an external DNS server instead of an internal one. This query also removes null and empty strings that can be returned by this table.\n```\nSELECT address FROM dns_resolvers WHERE type='nameserver' AND address NOT LIKE '192.168%%' AND address NOT LIKE '172.16%%' AND address NOT LIKE '172.17%%' AND address NOT LIKE '172.18%%' AND address NOT LIKE '172.19%%' AND address NOT LIKE '172.20%%' AND address NOT LIKE '172.21%%' AND address NOT LIKE '172.22%%' AND address NOT LIKE '172.23%%' AND address NOT LIKE '10.%%'  AND address NOT LIKE '127.%%' AND address IS NOT NULL AND address IS NOT ' ' AND address IS NOT ''; \n```",
@@ -5447,10 +5249,7 @@
     "name": "docker_container_envs",
     "description": "Docker container environment variables.",
     "url": "https://fleetdm.com/tables/docker_container_envs",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -5486,10 +5285,7 @@
     "name": "docker_container_fs_changes",
     "description": "Changes to files or directories on container's filesystem.",
     "url": "https://fleetdm.com/tables/docker_container_fs_changes",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -5525,10 +5321,7 @@
     "name": "docker_container_labels",
     "description": "Docker container labels.",
     "url": "https://fleetdm.com/tables/docker_container_labels",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -5564,10 +5357,7 @@
     "name": "docker_container_mounts",
     "description": "Docker container mounts.",
     "url": "https://fleetdm.com/tables/docker_container_mounts",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -5651,10 +5441,7 @@
     "name": "docker_container_networks",
     "description": "Docker container networks.",
     "url": "https://fleetdm.com/tables/docker_container_networks",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -5754,10 +5541,7 @@
     "name": "docker_container_ports",
     "description": "Docker container ports.",
     "url": "https://fleetdm.com/tables/docker_container_ports",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -5809,10 +5593,7 @@
     "name": "docker_container_processes",
     "description": "Docker container processes.",
     "url": "https://fleetdm.com/tables/docker_container_processes",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -6008,10 +5789,7 @@
     "name": "docker_container_stats",
     "description": "Docker container statistics. Queries on this table take at least one second.",
     "url": "https://fleetdm.com/tables/docker_container_stats",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -6215,10 +5993,7 @@
     "name": "docker_containers",
     "description": "Docker containers information.",
     "url": "https://fleetdm.com/tables/docker_containers",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -6365,9 +6140,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "ipc_namespace",
@@ -6376,9 +6149,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "mnt_namespace",
@@ -6387,9 +6158,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "net_namespace",
@@ -6398,9 +6167,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "pid_namespace",
@@ -6409,9 +6176,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "user_namespace",
@@ -6420,9 +6185,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "uts_namespace",
@@ -6431,9 +6194,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "Identify containers that are running with high privileges.\n```\nSELECT state, status, image, image_id FROM docker_containers WHERE privileged='1';\n```",
@@ -6443,10 +6204,7 @@
     "name": "docker_image_history",
     "description": "Docker image history information.",
     "url": "https://fleetdm.com/tables/docker_image_history",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -6506,10 +6264,7 @@
     "name": "docker_image_labels",
     "description": "Docker image labels.",
     "url": "https://fleetdm.com/tables/docker_image_labels",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -6545,10 +6300,7 @@
     "name": "docker_image_layers",
     "description": "Docker image layers information.",
     "url": "https://fleetdm.com/tables/docker_image_layers",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -6584,10 +6336,7 @@
     "name": "docker_images",
     "description": "Docker images information.",
     "url": "https://fleetdm.com/tables/docker_images",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -6631,10 +6380,7 @@
     "name": "docker_info",
     "description": "Docker system information.",
     "url": "https://fleetdm.com/tables/docker_info",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -6902,10 +6648,7 @@
     "name": "docker_network_labels",
     "description": "Docker network labels.",
     "url": "https://fleetdm.com/tables/docker_network_labels",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -6941,10 +6684,7 @@
     "name": "docker_networks",
     "description": "Docker networks information.",
     "url": "https://fleetdm.com/tables/docker_networks",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -7012,10 +6752,7 @@
     "name": "docker_version",
     "description": "Docker version information.",
     "url": "https://fleetdm.com/tables/docker_version",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -7099,10 +6836,7 @@
     "name": "docker_volume_labels",
     "description": "Docker volume labels.",
     "url": "https://fleetdm.com/tables/docker_volume_labels",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -7138,10 +6872,7 @@
     "name": "docker_volumes",
     "description": "Docker volumes information.",
     "url": "https://fleetdm.com/tables/docker_volumes",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -7184,9 +6915,7 @@
     "name": "drivers",
     "description": "Details for in-use Windows device drivers. This does not display installed but unused drivers.",
     "url": "https://fleetdm.com/tables/drivers",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -7310,12 +7039,7 @@
     "name": "ec2_instance_metadata",
     "description": "EC2 instance metadata.",
     "url": "https://fleetdm.com/tables/ec2_instance_metadata",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -7439,12 +7163,7 @@
     "name": "ec2_instance_tags",
     "description": "EC2 instance tag key value pairs.",
     "url": "https://fleetdm.com/tables/ec2_instance_tags",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -7480,9 +7199,7 @@
     "name": "es_process_events",
     "description": "Process execution events from EndpointSecurity.",
     "url": "https://fleetdm.com/tables/es_process_events",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -7702,9 +7419,7 @@
     "name": "es_process_file_events",
     "description": "Process execution events from EndpointSecurity.",
     "url": "https://fleetdm.com/tables/es_process_file_events",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -7804,12 +7519,7 @@
     "name": "etc_hosts",
     "description": "Line-parsed /etc/hosts.",
     "url": "https://fleetdm.com/tables/etc_hosts",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -7836,9 +7546,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "Identify host\"name\"s pointed to IP addresses using the hosts file. This technique is often abused by malware, but can also indicate services that do not have proper DNS configuration to be reached from workstations.\n```\nSELECT * FROM etc_hosts WHERE address!='127.0.0.1' AND address!='::1' AND address!='255.255.255.255';\n```",
@@ -7848,12 +7556,7 @@
     "name": "etc_protocols",
     "description": "Line-parsed /etc/protocols.",
     "url": "https://fleetdm.com/tables/etc_protocols",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -7897,12 +7600,7 @@
     "name": "etc_services",
     "description": "Line-parsed /etc/services.",
     "url": "https://fleetdm.com/tables/etc_services",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -7954,9 +7652,7 @@
     "name": "event_taps",
     "description": "Returns information about installed event taps.",
     "url": "https://fleetdm.com/tables/event_taps",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -8008,10 +7704,7 @@
     "name": "extended_attributes",
     "description": "Returns the extended attributes for files (similar to Windows ADS).",
     "url": "https://fleetdm.com/tables/extended_attributes",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -8063,9 +7756,7 @@
     "name": "fan_speed_sensors",
     "description": "Fan speeds.",
     "url": "https://fleetdm.com/tables/fan_speed_sensors",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -8125,9 +7816,7 @@
     "name": "fbsd_kmods",
     "description": "Loaded FreeBSD kernel modules.",
     "url": "https://fleetdm.com/tables/fbsd_kmods",
-    "platforms": [
-      "freebsd"
-    ],
+    "platforms": ["freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -8171,12 +7860,7 @@
     "name": "file",
     "description": "Interactive filesystem attributes and metadata.",
     "url": "https://fleetdm.com/tables/file",
-    "platforms": [
-      "darwin",
-      "linux",
-      "freebsd",
-      "windows"
-    ],
+    "platforms": ["darwin", "linux", "freebsd", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -8323,9 +8007,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "volume_serial",
@@ -8334,9 +8016,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "file_id",
@@ -8345,9 +8025,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "file_version",
@@ -8356,9 +8034,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "product_version",
@@ -8367,9 +8043,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "original_filename",
@@ -8378,9 +8052,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "bsd_flags",
@@ -8389,9 +8061,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "macOS"
-        ]
+        "platforms": ["macOS"]
       },
       {
         "name": "pid_with_namespace",
@@ -8400,9 +8070,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "mount_namespace_id",
@@ -8411,9 +8079,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "List zip files in the downloads folder as well as their associated sha256 hash.\n```\nSELECT f.path, h.sha256 FROM file f JOIN hash h ON f.path = h.path WHERE f.path LIKE '/Users/%/Downloads/%%.zip';\n```",
@@ -8423,10 +8089,7 @@
     "name": "file_events",
     "description": "Track time/action changes to files specified in configuration data.",
     "url": "https://fleetdm.com/tables/file_events",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -8582,12 +8245,7 @@
     "name": "firefox_addons",
     "description": "Firefox browser extensions, webapps, and addons.",
     "url": "https://fleetdm.com/tables/firefox_addons",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -8720,9 +8378,7 @@
     "name": "gatekeeper",
     "description": "macOS Gatekeeper Details.",
     "url": "https://fleetdm.com/tables/gatekeeper",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -8766,9 +8422,7 @@
     "name": "gatekeeper_approved_apps",
     "description": "Gatekeeper apps a user has allowed to run.",
     "url": "https://fleetdm.com/tables/gatekeeper_approved_apps",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -8812,12 +8466,7 @@
     "name": "groups",
     "description": "Local system groups.",
     "url": "https://fleetdm.com/tables/groups",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -8852,9 +8501,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "comment",
@@ -8863,9 +8510,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "is_hidden",
@@ -8874,9 +8519,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "macOS"
-        ]
+        "platforms": ["macOS"]
       },
       {
         "name": "pid_with_namespace",
@@ -8885,9 +8528,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "See all groups with the IsHidden OpenDirectory attribute\n```\nSELECT * FROM groups WHERE is_hidden='1';\n```",
@@ -8898,10 +8539,7 @@
     "name": "hardware_events",
     "description": "Hardware (PCI/USB/HID) events from UDEV or IOKit.",
     "url": "https://fleetdm.com/tables/hardware_events",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -9009,12 +8647,7 @@
     "name": "hash",
     "description": "Filesystem hash data.",
     "url": "https://fleetdm.com/tables/hash",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -9065,9 +8698,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "mount_namespace_id",
@@ -9076,9 +8707,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "List zip files in the downloads folder as well as their associated sha256 hash.\n```\nSELECT f.path, h.sha256 FROM file f JOIN hash h ON f.path = h.path WHERE f.path LIKE '/Users/%/Downloads/%%.zip';\n```",
@@ -9088,9 +8717,7 @@
     "name": "homebrew_packages",
     "description": "The installed homebrew package database.",
     "url": "https://fleetdm.com/tables/homebrew_packages",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -9134,9 +8761,7 @@
     "name": "hvci_status",
     "description": "Retrieve HVCI info of the machine.",
     "url": "https://fleetdm.com/tables/hvci_status",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -9188,9 +8813,7 @@
     "name": "ibridge_info",
     "description": "Information about the Apple iBridge hardware controller.",
     "url": "https://fleetdm.com/tables/ibridge_info",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -9234,9 +8857,7 @@
     "name": "ie_extensions",
     "description": "Internet Explorer browser extensions.",
     "url": "https://fleetdm.com/tables/ie_extensions",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -9280,10 +8901,7 @@
     "name": "intel_me_info",
     "description": "Intel ME/CSE Info.",
     "url": "https://fleetdm.com/tables/intel_me_info",
-    "platforms": [
-      "linux",
-      "windows"
-    ],
+    "platforms": ["linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -9303,12 +8921,7 @@
     "name": "interface_addresses",
     "description": "Network interfaces and relevant metadata.",
     "url": "https://fleetdm.com/tables/interface_addresses",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -9367,9 +8980,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       }
     ],
     "examples": "Find all interfaces that have a public Internet IP. This query filters out all RFC1918 IPv4 addresses as well as IPv6 localhost.\n```\nSELECT * FROM interface_addresses WHERE address NOT LIKE '192.168%%' AND address NOT LIKE '172.16%%' AND address NOT LIKE '172.17%%' AND address NOT LIKE '172.18%%' AND address NOT LIKE '172.19%%' AND address NOT LIKE '172.20%%' AND address NOT LIKE '172.21%%' AND address NOT LIKE '172.22%%' AND address NOT LIKE '172.23%%' AND address NOT LIKE '10.%%'  AND address NOT LIKE '127.%%' AND address IS NOT NULL AND address IS NOT ' ' AND address IS NOT '' AND address IS NOT '::1' AND mask IS NOT 'ffff:ffff:ffff:ffff::';\n```",
@@ -9379,12 +8990,7 @@
     "name": "interface_details",
     "description": "Detailed information and stats of network interfaces.",
     "url": "https://fleetdm.com/tables/interface_details",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -9523,10 +9129,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux",
-          "macOS"
-        ]
+        "platforms": ["Linux", "macOS"]
       },
       {
         "name": "pci_slot",
@@ -9535,9 +9138,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "friendly_name",
@@ -9546,9 +9147,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "description",
@@ -9557,9 +9156,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "manufacturer",
@@ -9568,9 +9165,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "connection_id",
@@ -9579,9 +9174,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "connection_status",
@@ -9590,9 +9183,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "enabled",
@@ -9601,9 +9192,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "physical_adapter",
@@ -9612,9 +9201,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "speed",
@@ -9623,9 +9210,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "service",
@@ -9634,9 +9219,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "dhcp_enabled",
@@ -9645,9 +9228,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "dhcp_lease_expires",
@@ -9656,9 +9237,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "dhcp_lease_obtained",
@@ -9667,9 +9246,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "dhcp_server",
@@ -9678,9 +9255,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "dns_domain",
@@ -9689,9 +9264,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "dns_domain_suffix_search_order",
@@ -9700,9 +9273,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "dns_host_name",
@@ -9711,9 +9282,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "dns_server_search_order",
@@ -9722,9 +9291,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       }
     ],
     "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/interface_details.yml"
@@ -9733,10 +9300,7 @@
     "name": "interface_ipv6",
     "description": "IPv6 configuration and stats of network interfaces.",
     "url": "https://fleetdm.com/tables/interface_ipv6",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -9788,9 +9352,7 @@
     "name": "iokit_devicetree",
     "description": "The IOKit registry matching the DeviceTree plane.",
     "url": "https://fleetdm.com/tables/iokit_devicetree",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -9874,9 +9436,7 @@
     "name": "iokit_registry",
     "description": "The full IOKit registry without selecting a plane.",
     "url": "https://fleetdm.com/tables/iokit_registry",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -9944,9 +9504,7 @@
     "name": "iptables",
     "description": "Linux IP packet filtering and NAT tool.",
     "url": "https://fleetdm.com/tables/iptables",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -10102,9 +9660,7 @@
     "name": "kernel_extensions",
     "description": "macOS's kernel extensions, both loaded and within the load search path.",
     "url": "https://fleetdm.com/tables/kernel_extensions",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -10172,12 +9728,7 @@
     "name": "kernel_info",
     "description": "Basic active kernel information.",
     "url": "https://fleetdm.com/tables/kernel_info",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -10221,9 +9772,7 @@
     "name": "kernel_modules",
     "description": "Linux kernel modules both loaded and within the load search path.",
     "url": "https://fleetdm.com/tables/kernel_modules",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -10275,9 +9824,7 @@
     "name": "kernel_panics",
     "description": "System kernel panic logs.",
     "url": "https://fleetdm.com/tables/kernel_panics",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -10393,9 +9940,7 @@
     "name": "keychain_acls",
     "description": "Applications that have ACL entries in the keychain.",
     "url": "https://fleetdm.com/tables/keychain_acls",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -10447,9 +9992,7 @@
     "name": "keychain_items",
     "description": "Generic details about keychain items.",
     "url": "https://fleetdm.com/tables/keychain_items",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -10525,10 +10068,7 @@
     "name": "known_hosts",
     "description": "A line-delimited known_hosts table.",
     "url": "https://fleetdm.com/tables/known_hosts",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -10564,9 +10104,7 @@
     "name": "kva_speculative_info",
     "description": "Display kernel virtual address and speculative execution information for the system.",
     "url": "https://fleetdm.com/tables/kva_speculative_info",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -10666,10 +10204,7 @@
     "name": "last",
     "description": "System logins and logouts.",
     "url": "https://fleetdm.com/tables/last",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -10737,9 +10272,7 @@
     "name": "launchd",
     "description": "LaunchAgents and LaunchDaemons from default search paths.",
     "url": "https://fleetdm.com/tables/launchd",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -10919,9 +10452,7 @@
     "name": "launchd_overrides",
     "description": "Override keys, per user, for LaunchDaemons and Agents.",
     "url": "https://fleetdm.com/tables/launchd_overrides",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -10973,12 +10504,7 @@
     "name": "listening_ports",
     "description": "Processes with listening (bound) network sockets/ports.",
     "url": "https://fleetdm.com/tables/listening_ports",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -11053,9 +10579,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "List executables listening on network ports.\n```\nSELECT l.port, l.pid, p.name, p.path FROM listening_ports l JOIN processes p USING (pid); \n```",
@@ -11065,10 +10589,7 @@
     "name": "load_average",
     "description": "Displays information about the system wide load averages.",
     "url": "https://fleetdm.com/tables/load_average",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11096,9 +10617,7 @@
     "name": "location_services",
     "description": "Reports the status of the Location Services feature of the OS.",
     "url": "https://fleetdm.com/tables/location_services",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11118,12 +10637,7 @@
     "name": "logged_in_users",
     "description": "Users with an active shell on the system.",
     "url": "https://fleetdm.com/tables/logged_in_users",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -11182,9 +10696,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "registry_hive",
@@ -11193,9 +10705,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       }
     ],
     "examples": "See the user currently logged in on the console of the computer.\n```\nSELECT user, type, tty from logged_in_users WHERE tty='console';\n```",
@@ -11205,9 +10715,7 @@
     "name": "logical_drives",
     "description": "Details for logical drives on the system. A logical drive generally represents a single partition.",
     "url": "https://fleetdm.com/tables/logical_drives",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11275,9 +10783,7 @@
     "name": "logon_sessions",
     "description": "Windows Logon Session.",
     "url": "https://fleetdm.com/tables/logon_sessions",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11409,9 +10915,7 @@
     "name": "lxd_certificates",
     "description": "LXD certificates information.",
     "url": "https://fleetdm.com/tables/lxd_certificates",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11455,9 +10959,7 @@
     "name": "lxd_cluster",
     "description": "LXD cluster information.",
     "url": "https://fleetdm.com/tables/lxd_cluster",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11525,9 +11027,7 @@
     "name": "lxd_cluster_members",
     "description": "LXD cluster members information.",
     "url": "https://fleetdm.com/tables/lxd_cluster_members",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11579,9 +11079,7 @@
     "name": "lxd_images",
     "description": "LXD images information.",
     "url": "https://fleetdm.com/tables/lxd_images",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11745,9 +11243,7 @@
     "name": "lxd_instance_config",
     "description": "LXD instance configuration information.",
     "url": "https://fleetdm.com/tables/lxd_instance_config",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11783,9 +11279,7 @@
     "name": "lxd_instance_devices",
     "description": "LXD instance devices information.",
     "url": "https://fleetdm.com/tables/lxd_instance_devices",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11837,9 +11331,7 @@
     "name": "lxd_instances",
     "description": "LXD instances information.",
     "url": "https://fleetdm.com/tables/lxd_instances",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -11939,9 +11431,7 @@
     "name": "lxd_networks",
     "description": "LXD network information.",
     "url": "https://fleetdm.com/tables/lxd_networks",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -12057,9 +11547,7 @@
     "name": "lxd_storage_pools",
     "description": "LXD storage pool information.",
     "url": "https://fleetdm.com/tables/lxd_storage_pools",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -12135,10 +11623,7 @@
     "name": "magic",
     "description": "Magic number recognition library table.",
     "url": "https://fleetdm.com/tables/magic",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -12190,9 +11675,7 @@
     "name": "managed_policies",
     "description": "The managed configuration policies from AD, MDM, MCX, etc.",
     "url": "https://fleetdm.com/tables/managed_policies",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -12252,9 +11735,7 @@
     "name": "md_devices",
     "description": "Software RAID array settings.",
     "url": "https://fleetdm.com/tables/md_devices",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -12514,9 +11995,7 @@
     "name": "md_drives",
     "description": "Drive devices used for Software RAID.",
     "url": "https://fleetdm.com/tables/md_drives",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -12560,9 +12039,7 @@
     "name": "md_personalities",
     "description": "Software RAID setting supported by the kernel.",
     "url": "https://fleetdm.com/tables/md_personalities",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -12582,9 +12059,7 @@
     "name": "mdfind",
     "description": "Run searches against the spotlight database.",
     "url": "https://fleetdm.com/tables/mdfind",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -12612,9 +12087,7 @@
     "name": "mdls",
     "description": "Query file metadata in the Spotlight database.",
     "url": "https://fleetdm.com/tables/mdls",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -12658,10 +12131,7 @@
     "name": "memory_array_mapped_addresses",
     "description": "Data associated for address mapping of physical memory arrays.",
     "url": "https://fleetdm.com/tables/memory_array_mapped_addresses",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -12713,10 +12183,7 @@
     "name": "memory_arrays",
     "description": "Data associated with collection of memory devices that operate to form a memory address.",
     "url": "https://fleetdm.com/tables/memory_arrays",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -12784,10 +12251,7 @@
     "name": "memory_device_mapped_addresses",
     "description": "Data associated for address mapping of physical memory devices.",
     "url": "https://fleetdm.com/tables/memory_device_mapped_addresses",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -12863,10 +12327,7 @@
     "name": "memory_devices",
     "description": "Physical memory device (type 17) information retrieved from SMBIOS.",
     "url": "https://fleetdm.com/tables/memory_devices",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -13038,10 +12499,7 @@
     "name": "memory_error_info",
     "description": "Data associated with errors of a physical memory array.",
     "url": "https://fleetdm.com/tables/memory_error_info",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -13117,9 +12575,7 @@
     "name": "memory_info",
     "description": "Main memory information in bytes.",
     "url": "https://fleetdm.com/tables/memory_info",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -13211,9 +12667,7 @@
     "name": "memory_map",
     "description": "OS memory region map.",
     "url": "https://fleetdm.com/tables/memory_map",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -13249,10 +12703,7 @@
     "name": "mounts",
     "description": "System mounted devices and filesystems (not process specific).",
     "url": "https://fleetdm.com/tables/mounts",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -13352,9 +12803,7 @@
     "name": "msr",
     "description": "Various pieces of data stored in the model specific register per processor. NOTE: the msr kernel module must be enabled, and osquery must be run as root.",
     "url": "https://fleetdm.com/tables/msr",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -13446,9 +12895,7 @@
     "name": "nfs_shares",
     "description": "NFS shares exported by the host.",
     "url": "https://fleetdm.com/tables/nfs_shares",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -13484,12 +12931,7 @@
     "name": "npm_packages",
     "description": "Node packages installed in a system.",
     "url": "https://fleetdm.com/tables/npm_packages",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -13564,9 +13006,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "mount_namespace_id",
@@ -13575,9 +13015,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "List the author, description and more information about packages made by Fleet. Replace the homepage with any other distributor desired.\n```\nSELECT author, description, directory, version FROM npm_packages WHERE homepage='https://fleetdm.com';\n```",
@@ -13587,9 +13025,7 @@
     "name": "ntdomains",
     "description": "Display basic NT domain information of a Windows machine.",
     "url": "https://fleetdm.com/tables/ntdomains",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -13665,9 +13101,7 @@
     "name": "ntfs_acl_permissions",
     "description": "Retrieve NTFS ACL permission information for files and directories.",
     "url": "https://fleetdm.com/tables/ntfs_acl_permissions",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -13719,9 +13153,7 @@
     "name": "ntfs_journal_events",
     "description": "Track time/action changes to files specified in configuration data.",
     "url": "https://fleetdm.com/tables/ntfs_journal_events",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -13837,9 +13269,7 @@
     "name": "nvram",
     "description": "Apple NVRAM variable listing.",
     "url": "https://fleetdm.com/tables/nvram",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -13875,10 +13305,7 @@
     "name": "oem_strings",
     "description": "OEM defined strings retrieved from SMBIOS.",
     "url": "https://fleetdm.com/tables/oem_strings",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -13914,9 +13341,7 @@
     "name": "office_mru",
     "description": "View recently opened Office documents.",
     "url": "https://fleetdm.com/tables/office_mru",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -13968,12 +13393,7 @@
     "name": "os_version",
     "description": "A single row containing the operating system name and version.",
     "url": "https://fleetdm.com/tables/os_version",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -14064,9 +13484,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "pid_with_namespace",
@@ -14075,9 +13493,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "mount_namespace_id",
@@ -14086,9 +13502,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "See the OS version as well as the CPU architecture in use (X86 vs ARM for example)\n```\nSELECT arch, version FROM os_version;\n```",
@@ -14098,12 +13512,7 @@
     "name": "osquery_events",
     "description": "Information about the event publishers and subscribers.",
     "url": "https://fleetdm.com/tables/osquery_events",
-    "platforms": [
-      "darwin",
-      "linux",
-      "freebsd",
-      "windows"
-    ],
+    "platforms": ["darwin", "linux", "freebsd", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -14171,12 +13580,7 @@
     "name": "osquery_extensions",
     "description": "List of active osquery extensions.",
     "url": "https://fleetdm.com/tables/osquery_extensions",
-    "platforms": [
-      "darwin",
-      "linux",
-      "freebsd",
-      "windows"
-    ],
+    "platforms": ["darwin", "linux", "freebsd", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -14236,12 +13640,7 @@
     "name": "osquery_flags",
     "description": "Configurable flags that modify osquery's behavior.",
     "url": "https://fleetdm.com/tables/osquery_flags",
-    "platforms": [
-      "darwin",
-      "linux",
-      "freebsd",
-      "windows"
-    ],
+    "platforms": ["darwin", "linux", "freebsd", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -14301,12 +13700,7 @@
     "name": "osquery_info",
     "description": "Top level information about the running version of osquery.",
     "url": "https://fleetdm.com/tables/osquery_info",
-    "platforms": [
-      "darwin",
-      "linux",
-      "freebsd",
-      "windows"
-    ],
+    "platforms": ["darwin", "linux", "freebsd", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -14414,12 +13808,7 @@
     "name": "osquery_packs",
     "description": "Information about the current query packs that are loaded in osquery.",
     "url": "https://fleetdm.com/tables/osquery_packs",
-    "platforms": [
-      "darwin",
-      "linux",
-      "freebsd",
-      "windows"
-    ],
+    "platforms": ["darwin", "linux", "freebsd", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -14487,12 +13876,7 @@
     "name": "osquery_registry",
     "description": "List the osquery registry plugins.",
     "url": "https://fleetdm.com/tables/osquery_registry",
-    "platforms": [
-      "darwin",
-      "linux",
-      "freebsd",
-      "windows"
-    ],
+    "platforms": ["darwin", "linux", "freebsd", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -14544,12 +13928,7 @@
     "name": "osquery_schedule",
     "description": "Information about the current queries that are scheduled in osquery.",
     "url": "https://fleetdm.com/tables/osquery_schedule",
-    "platforms": [
-      "darwin",
-      "linux",
-      "freebsd",
-      "windows"
-    ],
+    "platforms": ["darwin", "linux", "freebsd", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -14689,9 +14068,7 @@
     "name": "package_bom",
     "description": "macOS package bill of materials (BOM) file list.",
     "url": "https://fleetdm.com/tables/package_bom",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -14759,9 +14136,7 @@
     "name": "package_install_history",
     "description": "macOS package install history.",
     "url": "https://fleetdm.com/tables/package_install_history",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -14821,9 +14196,7 @@
     "name": "package_receipts",
     "description": "macOS package receipt details.",
     "url": "https://fleetdm.com/tables/package_receipts",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -14891,9 +14264,7 @@
     "name": "password_policy",
     "description": "Password Policies for macOS.",
     "url": "https://fleetdm.com/tables/password_policy",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -14937,9 +14308,7 @@
     "name": "patches",
     "description": "Lists all the patches applied. Note: This does not include patches applied via MSI or downloaded from Windows Update (e.g. Service Packs).",
     "url": "https://fleetdm.com/tables/patches",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -15015,10 +14384,7 @@
     "name": "pci_devices",
     "description": "PCI devices active on the host system.",
     "url": "https://fleetdm.com/tables/pci_devices",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -15085,9 +14451,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "pci_subclass_id",
@@ -15096,9 +14460,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "pci_subclass",
@@ -15107,9 +14469,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "subsystem_vendor_id",
@@ -15118,9 +14478,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "subsystem_vendor",
@@ -15129,9 +14487,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "subsystem_model_id",
@@ -15140,9 +14496,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "subsystem_model",
@@ -15151,9 +14505,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "This table allows you to list PCI devices. With this query, identify devices with a specific model ID. This can be useful when trying to identify systems that use common hardware, for example, when trying to target firmware updates or understand similarities between problematic systems.\n```\nSELECT driver, model, vendor, vendor_id FROM pci_devices WHERE model_id='0x1001';\n```",
@@ -15163,9 +14515,7 @@
     "name": "physical_disk_performance",
     "description": "Provides provides raw data from performance counters that monitor hard or fixed disk drives on the system.",
     "url": "https://fleetdm.com/tables/physical_disk_performance",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -15273,9 +14623,7 @@
     "name": "pipes",
     "description": "Named and Anonymous pipes.",
     "url": "https://fleetdm.com/tables/pipes",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -15327,9 +14675,7 @@
     "name": "pkg_packages",
     "description": "pkgng packages that are currently installed on the host system.",
     "url": "https://fleetdm.com/tables/pkg_packages",
-    "platforms": [
-      "freebsd"
-    ],
+    "platforms": ["freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -15373,12 +14719,7 @@
     "name": "platform_info",
     "description": "Information about EFI/UEFI/ROM and platform/boot.",
     "url": "https://fleetdm.com/tables/platform_info",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -15454,9 +14795,7 @@
     "name": "plist",
     "description": "Read and parse a plist file.",
     "url": "https://fleetdm.com/tables/plist",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -15500,9 +14839,7 @@
     "name": "portage_keywords",
     "description": "A summary about portage configurations like keywords, mask and unmask.",
     "url": "https://fleetdm.com/tables/portage_keywords",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -15554,9 +14891,7 @@
     "name": "portage_packages",
     "description": "List of currently installed packages.",
     "url": "https://fleetdm.com/tables/portage_packages",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -15632,9 +14967,7 @@
     "name": "portage_use",
     "description": "List of enabled portage USE values for specific package.",
     "url": "https://fleetdm.com/tables/portage_use",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -15670,9 +15003,7 @@
     "name": "power_sensors",
     "description": "Machine power (currents, voltages, wattages, etc) sensors.",
     "url": "https://fleetdm.com/tables/power_sensors",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -15716,9 +15047,7 @@
     "name": "powershell_events",
     "description": "Powershell script blocks reconstructed to their full script content, this table requires script block logging to be enabled.",
     "url": "https://fleetdm.com/tables/powershell_events",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -15794,9 +15123,7 @@
     "name": "preferences",
     "description": "macOS defaults and managed preferences.",
     "url": "https://fleetdm.com/tables/preferences",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -15865,9 +15192,7 @@
     "name": "prefetch",
     "description": "Prefetch files show metadata related to file execution.",
     "url": "https://fleetdm.com/tables/prefetch",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -15983,10 +15308,7 @@
     "name": "process_envs",
     "description": "A key/value table of environment variables for each process.",
     "url": "https://fleetdm.com/tables/process_envs",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -16022,10 +15344,7 @@
     "name": "process_events",
     "description": "Track time/action process executions.",
     "url": "https://fleetdm.com/tables/process_events",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -16236,9 +15555,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "macOS"
-        ]
+        "platforms": ["macOS"]
       },
       {
         "name": "fsuid",
@@ -16247,9 +15564,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "suid",
@@ -16258,9 +15573,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "fsgid",
@@ -16269,9 +15582,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "sgid",
@@ -16280,9 +15591,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "syscall",
@@ -16291,9 +15600,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/process_events.yml"
@@ -16302,9 +15609,7 @@
     "name": "process_file_events",
     "description": "A File Integrity Monitor implementation using the audit service.",
     "url": "https://fleetdm.com/tables/process_file_events",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -16476,12 +15781,7 @@
     "name": "process_memory_map",
     "description": "Process memory mapped files and pseudo device/regions.",
     "url": "https://fleetdm.com/tables/process_memory_map",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -16565,9 +15865,7 @@
     "name": "process_namespaces",
     "description": "Linux namespaces for processes running on the host system.",
     "url": "https://fleetdm.com/tables/process_namespaces",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -16643,10 +15941,7 @@
     "name": "process_open_files",
     "description": "File descriptors for each process.",
     "url": "https://fleetdm.com/tables/process_open_files",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -16682,9 +15977,7 @@
     "name": "process_open_pipes",
     "description": "Pipes and partner processes for each process.",
     "url": "https://fleetdm.com/tables/process_open_pipes",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -16760,12 +16053,7 @@
     "name": "process_open_sockets",
     "description": "Processes which have open network sockets on the system.",
     "url": "https://fleetdm.com/tables/process_open_sockets",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -16856,11 +16144,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows",
-          "Linux",
-          "macOS"
-        ]
+        "platforms": ["Windows", "Linux", "macOS"]
       },
       {
         "name": "net_namespace",
@@ -16869,9 +16153,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "This table allows you to see network activity by process. With this query, list all connections made to or from a process, excluding connections to localhost and [RFC1918](https://en.wikipedia.org/wiki/Private_network) IP addresses.\n```\nSELECT pos.local_port, pos.remote_port, pos.remote_address, p.pid, p.path FROM process_open_sockets pos JOIN processes p ON pos.pid = p.pid WHERE remote_address NOT LIKE '192.168%' AND remote_address NOT LIKE '10.%' AND remote_address NOT LIKE '172.16.%' AND remote_address NOT LIKE '127.%' AND remote_address!='0.0.0.0' AND remote_address NOT LIKE 'fe80%' AND remote_port!='0'; \n```",
@@ -16881,12 +16163,7 @@
     "name": "processes",
     "description": "All running processes on the host system.",
     "url": "https://fleetdm.com/tables/processes",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -17105,9 +16382,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "secure_process",
@@ -17116,9 +16391,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "protection_type",
@@ -17127,9 +16400,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "virtual_process",
@@ -17138,9 +16409,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "elapsed_time",
@@ -17149,9 +16418,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "handle_count",
@@ -17160,9 +16427,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "percent_processor_time",
@@ -17171,9 +16436,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "upid",
@@ -17182,9 +16445,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "macOS"
-        ]
+        "platforms": ["macOS"]
       },
       {
         "name": "uppid",
@@ -17193,9 +16454,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "macOS"
-        ]
+        "platforms": ["macOS"]
       },
       {
         "name": "cpu_type",
@@ -17204,9 +16463,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "macOS"
-        ]
+        "platforms": ["macOS"]
       },
       {
         "name": "cpu_subtype",
@@ -17215,9 +16472,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "macOS"
-        ]
+        "platforms": ["macOS"]
       },
       {
         "name": "translated",
@@ -17226,9 +16481,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "macOS"
-        ]
+        "platforms": ["macOS"]
       }
     ],
     "examples": "List executables listening on network ports.\n```\nSELECT l.port, l.pid, p.name, p.path FROM listening_ports l JOIN processes p USING (pid); \n```",
@@ -17238,9 +16491,7 @@
     "name": "programs",
     "description": "Represents products as they are installed by Windows Installer. A product generally correlates to one installation package on Windows. Some fields may be blank as Windows installation details are left to the discretion of the product author.",
     "url": "https://fleetdm.com/tables/programs",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -17324,10 +16575,7 @@
     "name": "prometheus_metrics",
     "description": "Retrieve metrics from a Prometheus server.",
     "url": "https://fleetdm.com/tables/prometheus_metrics",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -17371,12 +16619,7 @@
     "name": "python_packages",
     "description": "Python packages installed in a system.",
     "url": "https://fleetdm.com/tables/python_packages",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -17443,9 +16686,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "List the versions of pip installed.\n```\nSELECT author, name, summary, version FROM python_packages WHERE name='pip';\n```",
@@ -17455,9 +16696,7 @@
     "name": "quicklook_cache",
     "description": "Files and thumbnails within macOS's Quicklook Cache.",
     "url": "https://fleetdm.com/tables/quicklook_cache",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -17565,9 +16804,7 @@
     "name": "registry",
     "description": "All of the Windows registry hives.",
     "url": "https://fleetdm.com/tables/registry",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -17627,12 +16864,7 @@
     "name": "routes",
     "description": "The active route table for the host system.",
     "url": "https://fleetdm.com/tables/routes",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -17715,10 +16947,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux",
-          "macOS"
-        ]
+        "platforms": ["Linux", "macOS"]
       }
     ],
     "examples": "Identify static routes\n```\nSELECT destination, interface, type FROM routes WHERE type='static';\n```",
@@ -17728,9 +16957,7 @@
     "name": "rpm_package_files",
     "description": "RPM packages that are currently installed on the host system.",
     "url": "https://fleetdm.com/tables/rpm_package_files",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -17798,9 +17025,7 @@
     "name": "rpm_packages",
     "description": "RPM packages that are currently installed on the host system.",
     "url": "https://fleetdm.com/tables/rpm_packages",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -17899,9 +17124,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       },
       {
         "name": "mount_namespace_id",
@@ -17910,9 +17133,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/rpm_packages.yml"
@@ -17921,9 +17142,7 @@
     "name": "running_apps",
     "description": "macOS applications currently running on the host system.",
     "url": "https://fleetdm.com/tables/running_apps",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -17959,9 +17178,7 @@
     "name": "safari_extensions",
     "description": "Safari browser extension details for all users.",
     "url": "https://fleetdm.com/tables/safari_extensions",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -18053,9 +17270,7 @@
     "name": "sandboxes",
     "description": "macOS application sandboxes container details.",
     "url": "https://fleetdm.com/tables/sandboxes",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -18115,9 +17330,7 @@
     "name": "scheduled_tasks",
     "description": "Lists all of the tasks in the Windows task scheduler.",
     "url": "https://fleetdm.com/tables/scheduled_tasks",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -18209,9 +17422,7 @@
     "name": "screenlock",
     "description": "macOS screenlock status for the current logged in user context.",
     "url": "https://fleetdm.com/tables/screenlock",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -18239,9 +17450,7 @@
     "name": "seccomp_events",
     "description": "A virtual table that tracks seccomp events.",
     "url": "https://fleetdm.com/tables/seccomp_events",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -18373,10 +17582,7 @@
     "name": "secureboot",
     "description": "Secure Boot UEFI Settings.",
     "url": "https://fleetdm.com/tables/secureboot",
-    "platforms": [
-      "linux",
-      "windows"
-    ],
+    "platforms": ["linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -18404,9 +17610,7 @@
     "name": "selinux_events",
     "description": "Track SELinux events.",
     "url": "https://fleetdm.com/tables/selinux_events",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -18458,9 +17662,7 @@
     "name": "selinux_settings",
     "description": "Track active SELinux settings.",
     "url": "https://fleetdm.com/tables/selinux_settings",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -18496,9 +17698,7 @@
     "name": "services",
     "description": "Lists all installed Windows services and their relevant data.",
     "url": "https://fleetdm.com/tables/services",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -18606,9 +17806,7 @@
     "name": "shadow",
     "description": "Local system users encrypted passwords and related information. Please note, that you usually need superuser rights to access `/etc/shadow`.",
     "url": "https://fleetdm.com/tables/shadow",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -18700,9 +17898,7 @@
     "name": "shared_folders",
     "description": "Folders available to others via SMB or AFP.",
     "url": "https://fleetdm.com/tables/shared_folders",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -18730,9 +17926,7 @@
     "name": "shared_memory",
     "description": "OS shared memory regions.",
     "url": "https://fleetdm.com/tables/shared_memory",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -18848,9 +18042,7 @@
     "name": "shared_resources",
     "description": "Displays shared resources on a computer system running Windows. This may be a disk drive, printer, interprocess communication, or other sharable device.",
     "url": "https://fleetdm.com/tables/shared_resources",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -18935,9 +18127,7 @@
     "name": "sharing_preferences",
     "description": "macOS Sharing preferences.",
     "url": "https://fleetdm.com/tables/sharing_preferences",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -19029,10 +18219,7 @@
     "name": "shell_history",
     "description": "A line-delimited (command) table of per-user .*_history data.",
     "url": "https://fleetdm.com/tables/shell_history",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -19077,9 +18264,7 @@
     "name": "shellbags",
     "description": "Shows directories accessed via Windows Explorer.",
     "url": "https://fleetdm.com/tables/shellbags",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -19155,9 +18340,7 @@
     "name": "shimcache",
     "description": "Application Compatibility Cache, contains artifacts of execution.",
     "url": "https://fleetdm.com/tables/shimcache",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -19201,9 +18384,7 @@
     "name": "signature",
     "description": "File (executable, bundle, installer, disk) code signing status.",
     "url": "https://fleetdm.com/tables/signature",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -19279,9 +18460,7 @@
     "name": "sip_config",
     "description": "Apple's System Integrity Protection (rootless) status.",
     "url": "https://fleetdm.com/tables/sip_config",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -19317,10 +18496,7 @@
     "name": "smbios_tables",
     "description": "BIOS (DMI) structure common details and content.",
     "url": "https://fleetdm.com/tables/smbios_tables",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -19389,9 +18565,7 @@
     "name": "smc_keys",
     "description": "Apple's system management controller keys.",
     "url": "https://fleetdm.com/tables/smc_keys",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -19443,10 +18617,7 @@
     "name": "socket_events",
     "description": "Track network socket opens and closes.",
     "url": "https://fleetdm.com/tables/socket_events",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -19594,12 +18765,7 @@
     "name": "ssh_configs",
     "description": "A table of parsed ssh_configs.",
     "url": "https://fleetdm.com/tables/ssh_configs",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -19644,12 +18810,7 @@
     "name": "startup_items",
     "description": "Applications and binaries set as user/login startup items.",
     "url": "https://fleetdm.com/tables/startup_items",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -19717,10 +18878,7 @@
     "name": "sudoers",
     "description": "Rules for running commands as other users via sudo.",
     "url": "https://fleetdm.com/tables/sudoers",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -19756,10 +18914,7 @@
     "name": "suid_bin",
     "description": "suid binaries in common locations.",
     "url": "https://fleetdm.com/tables/suid_bin",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -19802,9 +18957,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "Identify unsigned executables with suid privileges.\n```\nSELECT s.path, s.username, s.permissions, sig.signed, sig.team_identifier, sig.authority FROM suid_bin s JOIN signature sig on s.path = sig.path WHERE sig.signed='0';\n```",
@@ -19814,9 +18967,7 @@
     "name": "syslog_events",
     "description": "",
     "url": "https://fleetdm.com/tables/syslog_events",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -19892,10 +19043,7 @@
     "name": "system_controls",
     "description": "sysctl names, values, and settings information.",
     "url": "https://fleetdm.com/tables/system_controls",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -19954,9 +19102,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "macOS"
-        ]
+        "platforms": ["macOS"]
       }
     ],
     "examples": "See if IP forwarding is enabled (value=1) or not (current_value=0). This table provides access to a large quantity of low-level settings and is ideal to build policies.\n```\nSELECT current_value, name FROM system_controls WHERE name='net.inet.ip.forwarding';\n```",
@@ -19966,9 +19112,7 @@
     "name": "system_extensions",
     "description": "macOS (>= 10.15) system extension table.",
     "url": "https://fleetdm.com/tables/system_extensions",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -20052,12 +19196,7 @@
     "name": "system_info",
     "description": "System information for identification.",
     "url": "https://fleetdm.com/tables/system_info",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -20221,9 +19360,7 @@
     "name": "systemd_units",
     "description": "Track systemd units.",
     "url": "https://fleetdm.com/tables/systemd_units",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -20339,9 +19476,7 @@
     "name": "temperature_sensors",
     "description": "Machine's temperature sensors.",
     "url": "https://fleetdm.com/tables/temperature_sensors",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -20385,12 +19520,7 @@
     "name": "time",
     "description": "Track current date and time in UTC.",
     "url": "https://fleetdm.com/tables/time",
-    "platforms": [
-      "darwin",
-      "linux",
-      "freebsd",
-      "windows"
-    ],
+    "platforms": ["darwin", "linux", "freebsd", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -20505,9 +19635,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       }
     ],
     "examples": "View the timezone a system is configured in. \n```\nSELECT local_timezone FROM time;\n```",
@@ -20517,9 +19645,7 @@
     "name": "time_machine_backups",
     "description": "Backups to drives using TimeMachine.",
     "url": "https://fleetdm.com/tables/time_machine_backups",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -20547,9 +19673,7 @@
     "name": "time_machine_destinations",
     "description": "Locations backed up to using Time Machine.",
     "url": "https://fleetdm.com/tables/time_machine_destinations",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -20617,9 +19741,7 @@
     "name": "tpm_info",
     "description": "A table that lists the TPM related information.",
     "url": "https://fleetdm.com/tables/tpm_info",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -20703,10 +19825,7 @@
     "name": "ulimit_info",
     "description": "System resource usage limits.",
     "url": "https://fleetdm.com/tables/ulimit_info",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -20742,12 +19861,7 @@
     "name": "uptime",
     "description": "Track time passed since last boot. Some systems track this as calendar time, some as runtime.",
     "url": "https://fleetdm.com/tables/uptime",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -20799,10 +19913,7 @@
     "name": "usb_devices",
     "description": "USB devices that are actively plugged into the host system.",
     "url": "https://fleetdm.com/tables/usb_devices",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -20910,10 +20021,7 @@
     "name": "user_events",
     "description": "Track user events from the audit framework.",
     "url": "https://fleetdm.com/tables/user_events",
-    "platforms": [
-      "darwin",
-      "linux"
-    ],
+    "platforms": ["darwin", "linux"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -21013,12 +20121,7 @@
     "name": "user_groups",
     "description": "Local system user group relationships.",
     "url": "https://fleetdm.com/tables/user_groups",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -21046,9 +20149,7 @@
     "name": "user_interaction_events",
     "description": "Track user interaction events from macOS' event tapping framework.",
     "url": "https://fleetdm.com/tables/user_interaction_events",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -21068,12 +20169,7 @@
     "name": "user_ssh_keys",
     "description": "Returns the private keys in the users ~/.ssh directory and whether or not they are encrypted.",
     "url": "https://fleetdm.com/tables/user_ssh_keys",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -21117,9 +20213,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "Identify SSH keys stored in clear text in user directories\n```\nSELECT * FROM users JOIN user_ssh_keys USING (uid) WHERE encrypted = 0;,\n```",
@@ -21129,9 +20223,7 @@
     "name": "userassist",
     "description": "UserAssist Registry Key tracks when a user executes an application from Windows Explorer.",
     "url": "https://fleetdm.com/tables/userassist",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -21175,12 +20267,7 @@
     "name": "users",
     "description": "Local user accounts (including domain accounts that have logged on locally (Windows)).",
     "url": "https://fleetdm.com/tables/users",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -21263,9 +20350,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Windows"
-        ]
+        "platforms": ["Windows"]
       },
       {
         "name": "is_hidden",
@@ -21274,9 +20359,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "macOS"
-        ]
+        "platforms": ["macOS"]
       },
       {
         "name": "pid_with_namespace",
@@ -21285,9 +20368,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "List users that have interactive access via a shell that isn't false.\n```\nSELECT * FROM users WHERE shell!='/usr/bin/false';\n```",
@@ -21297,9 +20378,7 @@
     "name": "video_info",
     "description": "Retrieve video card information of the machine.",
     "url": "https://fleetdm.com/tables/video_info",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -21375,9 +20454,7 @@
     "name": "virtual_memory_info",
     "description": "Darwin Virtual Memory statistics.",
     "url": "https://fleetdm.com/tables/virtual_memory_info",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -21565,9 +20642,7 @@
     "name": "wifi_networks",
     "description": "macOS known/remembered Wi-Fi networks list.",
     "url": "https://fleetdm.com/tables/wifi_networks",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -21723,9 +20798,7 @@
     "name": "wifi_status",
     "description": "macOS current WiFi status.",
     "url": "https://fleetdm.com/tables/wifi_status",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -21841,9 +20914,7 @@
     "name": "wifi_survey",
     "description": "Scan for nearby WiFi networks.",
     "url": "https://fleetdm.com/tables/wifi_survey",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -21935,9 +21006,7 @@
     "name": "winbaseobj",
     "description": "Lists named Windows objects in the default object directories, across all terminal services sessions.  Example Windows ojbect types include Mutexes, Events, Jobs and Semaphors.",
     "url": "https://fleetdm.com/tables/winbaseobj",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -21973,9 +21042,7 @@
     "name": "windows_crashes",
     "description": "Extracted information from Windows crash logs (Minidumps).",
     "url": "https://fleetdm.com/tables/windows_crashes",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -22155,9 +21222,7 @@
     "name": "windows_eventlog",
     "description": "Table for querying all recorded Windows event logs.",
     "url": "https://fleetdm.com/tables/windows_eventlog",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -22290,9 +21355,7 @@
     "name": "windows_events",
     "description": "Windows Event logs.",
     "url": "https://fleetdm.com/tables/windows_events",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -22400,9 +21463,7 @@
     "name": "windows_firewall_rules",
     "description": "Provides the list of Windows firewall rules.",
     "url": "https://fleetdm.com/tables/windows_firewall_rules",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -22543,9 +21604,7 @@
     "name": "windows_optional_features",
     "description": "Lists names and installation states of windows features. Maps to Win32_OptionalFeature WMI class.",
     "url": "https://fleetdm.com/tables/windows_optional_features",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -22589,9 +21648,7 @@
     "name": "windows_security_center",
     "description": "The health status of Window Security features. Health values can be \"Good\", \"Poor\". \"Snoozed\", \"Not Monitored\", and \"Error\".",
     "url": "https://fleetdm.com/tables/windows_security_center",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -22659,9 +21716,7 @@
     "name": "windows_security_products",
     "description": "Enumeration of registered Windows security products.",
     "url": "https://fleetdm.com/tables/windows_security_products",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -22721,9 +21776,7 @@
     "name": "windows_update_history",
     "description": "Provides the history of the windows update events.",
     "url": "https://fleetdm.com/tables/windows_update_history",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -22831,9 +21884,7 @@
     "name": "wmi_bios_info",
     "description": "Lists important information from the system bios.",
     "url": "https://fleetdm.com/tables/wmi_bios_info",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -22861,9 +21912,7 @@
     "name": "wmi_cli_event_consumers",
     "description": "WMI CommandLineEventConsumer, which can be used for persistence on Windows. See https://www.blackhat.com/docs/us-15/materials/us-15-Graeber-Abusing-Windows-Management-Instrumentation-WMI-To-Build-A-Persistent%20Asynchronous-And-Fileless-Backdoor-wp.pdf for more details.",
     "url": "https://fleetdm.com/tables/wmi_cli_event_consumers",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -22915,9 +21964,7 @@
     "name": "wmi_event_filters",
     "description": "Lists WMI event filters.",
     "url": "https://fleetdm.com/tables/wmi_event_filters",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -22969,9 +22016,7 @@
     "name": "wmi_filter_consumer_binding",
     "description": "Lists the relationship between event consumers and filters.",
     "url": "https://fleetdm.com/tables/wmi_filter_consumer_binding",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -23015,9 +22060,7 @@
     "name": "wmi_script_event_consumers",
     "description": "WMI ActiveScriptEventConsumer, which can be used for persistence on Windows. See https://www.blackhat.com/docs/us-15/materials/us-15-Graeber-Abusing-Windows-Management-Instrumentation-WMI-To-Build-A-Persistent%20Asynchronous-And-Fileless-Backdoor-wp.pdf for more details.",
     "url": "https://fleetdm.com/tables/wmi_script_event_consumers",
-    "platforms": [
-      "windows"
-    ],
+    "platforms": ["windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -23077,9 +22120,7 @@
     "name": "xprotect_entries",
     "description": "Database of the machine's XProtect signatures.",
     "url": "https://fleetdm.com/tables/xprotect_entries",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -23147,9 +22188,7 @@
     "name": "xprotect_meta",
     "description": "Database of the machine's XProtect browser-related signatures.",
     "url": "https://fleetdm.com/tables/xprotect_meta",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -23193,9 +22232,7 @@
     "name": "xprotect_reports",
     "description": "Database of XProtect matches (if user generated/sent an XProtect report).",
     "url": "https://fleetdm.com/tables/xprotect_reports",
-    "platforms": [
-      "darwin"
-    ],
+    "platforms": ["darwin"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -23231,11 +22268,7 @@
     "name": "yara",
     "description": "Track YARA matches for files or PIDs.",
     "url": "https://fleetdm.com/tables/yara",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows"
-    ],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -23319,11 +22352,7 @@
     "name": "yara_events",
     "description": "Track YARA matches for files specified in configuration data.",
     "url": "https://fleetdm.com/tables/yara_events",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows"
-    ],
+    "platforms": ["darwin", "linux", "windows"],
     "evented": true,
     "cacheable": false,
     "columns": [
@@ -23415,12 +22444,7 @@
     "name": "ycloud_instance_metadata",
     "description": "Yandex.Cloud instance metadata.",
     "url": "https://fleetdm.com/tables/ycloud_instance_metadata",
-    "platforms": [
-      "darwin",
-      "linux",
-      "windows",
-      "freebsd"
-    ],
+    "platforms": ["darwin", "linux", "windows", "freebsd"],
     "evented": false,
     "cacheable": true,
     "columns": [
@@ -23504,9 +22528,7 @@
     "name": "yum_sources",
     "description": "Current list of Yum repositories or software channels.",
     "url": "https://fleetdm.com/tables/yum_sources",
-    "platforms": [
-      "linux"
-    ],
+    "platforms": ["linux"],
     "evented": false,
     "cacheable": false,
     "columns": [
@@ -23565,9 +22587,7 @@
         "hidden": false,
         "required": false,
         "index": false,
-        "platforms": [
-          "Linux"
-        ]
+        "platforms": ["Linux"]
       }
     ],
     "examples": "Find yum repositories on Linux servers for which cryptographic verification via GPG is disabled. This could allow untrusted packages to be injected into a repository that could then be installed.\n```\nSELECT * FROM yum_sources WHERE gpgcheck='0'; \n```",
@@ -23577,7 +22597,7 @@
     "name": "file_lines",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
     "description": "Allows reading an arbitrary file.",
-    "platforms": "darwin, windows, linux",
+    "platforms": ["darwin", "windows", "linux"],
     "evented": false,
     "examples": "Output the content of `/etc/hosts` line by line. \n```\nSELECT * FROM file_lines WHERE path='/etc/hosts';\n```",
     "columns": [
@@ -23595,13 +22615,13 @@
       }
     ],
     "url": "https://fleetdm.com/tables/file_lines",
-    "fleetRepoUrl": "https://github.com/edit/fleetdm/fleet/schema/tables/file_lines.yml"
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/file_lines.yml"
   },
   {
     "name": "filevault_users",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
     "description": "Information on the users able to unlock the current boot volume if protected with FileVault.",
-    "platforms": "darwin",
+    "platforms": ["darwin"],
     "evented": false,
     "examples": "List the usernames able to unlock and boot a computer protected by FileVault, joined to [users.username](http://fleetdm.com/tables/users) to obtain the description of the operating system account that owns it.\n```\nSELECT fu.username, u.description FROM filevault_users fu JOIN users u ON fu.uuid=u.uuid;\n```",
     "columns": [
@@ -23625,7 +22645,7 @@
     "name": "google_chrome_profiles",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
     "description": "Profiles configured in Google Chrome.",
-    "platforms": "darwin, windows, linux",
+    "platforms": ["darwin", "windows", "linux"],
     "evented": false,
     "examples": "List the Google Chrome accounts logged in to with `fleetdm.com` email addresses, joined to the [users](https://fleetdm.com/tables/users) table, to see the description of the operating system account that owns it.\n```\nSELECT gp.email, gp.username, u.description FROM google_chrome_profiles gp JOIN users u ON gp.username=u.username WHERE gp.email LIKE '%fleetdm.com';\n```",
     "columns": [
@@ -23661,7 +22681,7 @@
     "name": "macos_profiles",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
     "description": "High level information on installed profiles enrollment.",
-    "platforms": "darwin",
+    "platforms": ["darwin"],
     "evented": false,
     "examples": "Identify all profiles that are not *verified*.\n```\nSELECT display_name, install_date FROM macos_profiles WHERE verification_state!='verified';  \n```",
     "columns": [
@@ -23721,7 +22741,7 @@
     "name": "mdm",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).<p> Code based on work by [Kolide](https://github.com/kolide/launcher). <p> Due to changes in macOS 12.3, the output of `profiles show -type enrollment` can only be generated once a day. If you are running this command with another tool, you should set the `PROFILES_SHOW_ENROLLMENT_CACHE_PATH` environment variable to the path you are caching this. The cache file should be `json` with the keys `dep_capable` and `rate_limited present`, both booleans representing whether the device is capable of DEP enrollment and whether the response from `profiles show -type enrollment` is being rate limited or not.",
     "description": "Information on the device's MDM enrollment.",
-    "platforms": "darwin",
+    "platforms": ["darwin"],
     "evented": false,
     "examples": "Identify Macs that are DEP capable but have not been enrolled to MDM.\n```\nSELECT * FROM mdm WHERE dep_capable='true' AND enrolled='false';\n```",
     "columns": [
@@ -23811,7 +22831,7 @@
     "name": "munki_info",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).<p> Code based on work by [Kolide](https://github.com/kolide/launcher).",
     "description": "Information from the last [Munki](https://github.com/munki/munki) run.",
-    "platforms": "darwin",
+    "platforms": ["darwin"],
     "evented": false,
     "examples": "Output errors, warnings and problematic installations from Munki.\n```\nSELECT errors, warnings, problem_installs FROM munki_info ;\n```",
     "columns": [
@@ -23877,7 +22897,7 @@
     "name": "munki_installs",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).<p> Code based on work by [Kolide](https://github.com/kolide/launcher).",
     "description": "Software packages and other items [Munki](https://github.com/munki/munki) is managing.",
-    "platforms": "darwin",
+    "platforms": ["darwin"],
     "evented": false,
     "examples": "See the version of software that has been deployed by Munki.\n```\nSELECT name, installed_version FROM munki_installs WHERE installed='true';\n```",
     "columns": [
@@ -23913,7 +22933,7 @@
     "name": "puppet_facts",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
     "description": "Facts about [Puppet](https://puppet.com/). Puppet facts are *key:value* pairs.",
-    "platforms": "darwin, windows, linux",
+    "platforms": ["darwin", "windows", "linux"],
     "evented": false,
     "examples": "List all Puppet facts.\n```\nSELECT * FROM puppet_facts;\n```",
     "columns": [
@@ -23943,7 +22963,7 @@
     "name": "puppet_info",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
     "description": "Information on the last [Puppet](https://puppet.com/) run. This table uses data from the `last_run_report` that Puppet creates.",
-    "platforms": "darwin, windows, linux",
+    "platforms": ["darwin", "windows", "linux"],
     "evented": false,
     "examples": "List all the information available about the last Puppet run.\n```\nSELECT * FROM puppet_info;\n```",
     "columns": [
@@ -24057,7 +23077,7 @@
     "name": "puppet_logs",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
     "description": "Outputs [Puppet](https://puppet.com/) logs from the last run.",
-    "platforms": "darwin, windows, linux",
+    "platforms": ["darwin", "windows", "linux"],
     "evented": false,
     "examples": "List Puppet logs that are of a level of anything but informational.\n```\nSELECT * FROM puppet_logs WHERE level!='info';\n```",
     "columns": [
@@ -24105,7 +23125,7 @@
     "name": "puppet_state",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
     "description": "State of every resource [Puppet](https://puppet.com/) is managing. This table uses data from the `last_run_report` that Puppet creates.",
-    "platforms": "darwin, windows, linux",
+    "platforms": ["darwin", "windows", "linux"],
     "evented": false,
     "examples": "List resources that failed or took over a minute to evaluate.\n```\nSELECT * FROM puppet_state WHERE failed='true' OR evaluation_time>'60';\n```",
     "columns": [
@@ -24195,7 +23215,7 @@
     "name": "unified_log",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
     "description": "Allows querying macOS [unified logs](https://developer.apple.com/documentation/os/logging).",
-    "platforms": "darwin",
+    "platforms": ["darwin"],
     "evented": false,
     "examples": "Select the latest 100 log items related to `LaunchServices` and convert the UNIX time to a human readable format,  and the signature table to verify its cryptographic signature.\n```\nSELECT u.category, u.level, u.message, u.pid, datetime(u.timestamp, 'unixepoch') AS human_time, p.path, s.signed, s.identifier, s.authority FROM unified_log u JOIN processes p ON u.pid = p.pid JOIN signature s ON p.path=s.path WHERE sender='LaunchServices' LIMIT 100;  \n```",
     "columns": [


### PR DESCRIPTION
Cerra #8798 

- Platform type should be `string[]` not `string`
- Fix on 12 broken tables:
  - `file_lines`
  - `filevault_users`
  - `google_chrome_profiles`
  - `macos_profiles`
  - `mdm`
  - `munki_info`
  - `munki_installs`
  - `puppet_facts`
  - `puppet_info`
  - `puppet_logs`
  - `puppet_state`
  - `unified_log`

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

