### PR TITLE
Fleet UI: Fix left align wrapping on software table

### DIFF
--- a/changes/bug-8795-wrap-long-software-name
+++ b/changes/bug-8795-wrap-long-software-name
@@ -1,0 +1,1 @@
+* Fix query table json platforms to be type array

--- a/changes/bug-8795-wrap-long-software-name
+++ b/changes/bug-8795-wrap-long-software-name
@@ -1,1 +1,1 @@
-* Fix query table json platforms to be type array
+* Fix long software name from aligning center

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -20,6 +20,14 @@
       border-collapse: collapse;
       color: $core-fleet-black;
       font-size: $x-small;
+
+      .component__tooltip-wrapper {
+        margin: 10px 0; // vertical padding multiline text with tooltip
+      }
+
+      .component__tooltip-wrapper__element {
+        white-space: initial; // wraps long text with tooltip
+      }
     }
 
     tr {

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -148,6 +148,7 @@ $base-class: "button";
     padding: 0;
     height: auto;
     line-height: normal;
+    text-align: left;
 
     &:active {
       color: $core-vibrant-blue-down;

--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -174,14 +174,6 @@
             tbody {
               .name__cell {
                 width: $col-md;
-
-                .component__tooltip-wrapper {
-                  margin: 10px 0; // vertical padding long software name in row
-                }
-
-                .component__tooltip-wrapper__element {
-                  white-space: initial; // wraps long software names
-                }
               }
               .version__cell {
                 width: 0;

--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -174,11 +174,13 @@
             tbody {
               .name__cell {
                 width: $col-md;
-                a {
-                  text-decoration: none;
-                  &:hover {
-                    text-decoration: underline;
-                  }
+
+                .component__tooltip-wrapper {
+                  margin: 10px 0; // vertical padding long software name in row
+                }
+
+                .component__tooltip-wrapper__element {
+                  white-space: initial; // wraps long software names
                 }
               }
               .version__cell {
@@ -204,6 +206,7 @@
                   justify-content: space-between;
                   .hosts-cell__link {
                     display: flex;
+                    white-space: nowrap;
                   }
                 }
               }


### PR DESCRIPTION
## Issue
Cerra #8795 

## Fixes
- View all host link will always be on one line
- Software page > software table > name including with tooltip will wrap and align left
- Fix applied to all table cell > buttons
- Adds vertical padding to multiline tooltips so the underline doesn't run into the row border

## Screenshots
<img width="974" alt="Screenshot 2022-11-23 at 1 11 29 PM" src="https://user-images.githubusercontent.com/71795832/203620775-2305b8af-ac21-4f15-8b43-803a1dc99fef.png">
<img width="974" alt="Screenshot 2022-11-23 at 1 11 04 PM" src="https://user-images.githubusercontent.com/71795832/203620777-26a7548a-5940-40f3-ae08-6635cda3dd7c.png">

### Room for iteration
- Row margin should be the same whether it's one line or two line
- Should standardize if we are overflow text ellipsis or not in all table text and table links

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
