### PR TITLE
enable a reader replica in load testing RDS

### DIFF
--- a/infrastructure/loadtesting/terraform/rds.tf
+++ b/infrastructure/loadtesting/terraform/rds.tf
@@ -45,10 +45,7 @@ module "aurora_mysql" { #tfsec:ignore:aws-rds-enable-performance-insights-encryp
   # Old Jump box?
   # allowed_security_groups = ["sg-0063a978193fdf7ee"]
 
-  replica_count         = 1
-  replica_scale_enabled = true
-  replica_scale_min     = 1
-  replica_scale_max     = 1
+  replica_count         = 2
   snapshot_identifier   = "arn:aws:rds:us-east-2:917007347864:cluster-snapshot:cleaned"
 
   monitoring_interval           = 60


### PR DESCRIPTION
We discussed in the @fleetdm/g-platform weekly meeting that it would be good to have a read replica enabled by default in load testing, as it matches what we would recommend to customers for deployments of the size we use to load test with.

This is just what I did to get it working in the past, but I'm happy to adjust as you consider appropriate.