### PR TITLE
Fleet UI: Save manage host table filters in state so we can return back to same filters

### DIFF
--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -14,6 +14,7 @@ enum ACTIONS {
   SET_CONFIG = "SET_CONFIG",
   SET_ENROLL_SECRET = "SET_ENROLL_SECRET",
   SET_SANDBOX_EXPIRY = "SET_SANDBOX_EXPIRY",
+  SET_FILTERED_HOSTS_PATH = "SET_FILTERED_HOSTS_PATH",
 }
 
 interface ISetAvailableTeamsAction {
@@ -44,13 +45,19 @@ interface ISetSandboxExpiryAction {
   sandboxExpiry: string;
 }
 
+interface ISetFilteredHostsPathAction {
+  type: ACTIONS.SET_FILTERED_HOSTS_PATH;
+  filteredHostsPath: string;
+}
+
 type IAction =
   | ISetAvailableTeamsAction
   | ISetConfigAction
   | ISetCurrentTeamAction
   | ISetCurrentUserAction
   | ISetEnrollSecretAction
-  | ISetSandboxExpiryAction;
+  | ISetSandboxExpiryAction
+  | ISetFilteredHostsPathAction;
 
 type Props = {
   children: ReactNode;
@@ -80,12 +87,14 @@ type InitialStateType = {
   isOnlyObserver?: boolean;
   isNoAccess?: boolean;
   sandboxExpiry?: string;
+  fileredHostsPath?: string;
   setAvailableTeams: (availableTeams: ITeamSummary[]) => void;
   setCurrentUser: (user: IUser) => void;
   setCurrentTeam: (team?: ITeamSummary) => void;
   setConfig: (config: IConfig) => void;
   setEnrollSecret: (enrollSecret: IEnrollSecret[]) => void;
   setSandboxExpiry: (sandboxExpiry: string) => void;
+  setFilteredHostsPathAction: (filteredHostsPath: string) => void;
 };
 
 export type IAppContext = InitialStateType;
@@ -113,12 +122,14 @@ export const initialState = {
   isTeamAdmin: undefined,
   isOnlyObserver: undefined,
   isNoAccess: undefined,
+  filteredHostsPath: undefined,
   setAvailableTeams: () => null,
   setCurrentUser: () => null,
   setCurrentTeam: () => null,
   setConfig: () => null,
   setEnrollSecret: () => null,
   setSandboxExpiry: () => null,
+  setFilteredHostsPath: () => null,
 };
 
 const detectPreview = () => {
@@ -215,6 +226,13 @@ const reducer = (state: InitialStateType, action: IAction) => {
         sandboxExpiry,
       };
     }
+    case ACTIONS.SET_FILTERED_HOSTS_PATH: {
+      const { filteredHostsPath } = action;
+      return {
+        ...state,
+        filteredHostsPath,
+      };
+    }
     default:
       return state;
   }
@@ -232,6 +250,7 @@ const AppProvider = ({ children }: Props): JSX.Element => {
     currentTeam: state.currentTeam,
     enrollSecret: state.enrollSecret,
     sandboxExpiry: state.sandboxExpiry,
+    filteredHostsPath: state.filteredHostsPath,
     isPreviewMode: detectPreview(),
     isSandboxMode: state.isSandboxMode,
     isFreeTier: state.isFreeTier,
@@ -266,6 +285,9 @@ const AppProvider = ({ children }: Props): JSX.Element => {
     },
     setSandboxExpiry: (sandboxExpiry: string) => {
       dispatch({ type: ACTIONS.SET_SANDBOX_EXPIRY, sandboxExpiry });
+    },
+    setFilteredHostsPath: (filteredHostsPath: string) => {
+      dispatch({ type: ACTIONS.SET_FILTERED_HOSTS_PATH, filteredHostsPath });
     },
   };
 

--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -87,14 +87,14 @@ type InitialStateType = {
   isOnlyObserver?: boolean;
   isNoAccess?: boolean;
   sandboxExpiry?: string;
-  fileredHostsPath?: string;
+  filteredHostsPath?: string;
   setAvailableTeams: (availableTeams: ITeamSummary[]) => void;
   setCurrentUser: (user: IUser) => void;
   setCurrentTeam: (team?: ITeamSummary) => void;
   setConfig: (config: IConfig) => void;
   setEnrollSecret: (enrollSecret: IEnrollSecret[]) => void;
   setSandboxExpiry: (sandboxExpiry: string) => void;
-  setFilteredHostsPathAction: (filteredHostsPath: string) => void;
+  setFilteredHostsPath: (filteredHostsPath: string) => void;
 };
 
 export type IAppContext = InitialStateType;

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -137,6 +137,7 @@ const ManageHostsPage = ({
     isSandboxMode,
     setAvailableTeams,
     setCurrentTeam,
+    setFilteredHostsPath,
   } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 
@@ -543,6 +544,9 @@ const ManageHostsPage = ({
       retrieveHostCount(omit(options, "device_mapping"));
       setCurrentQueryOptions(options);
     }
+
+    setFilteredHostsPath(location.pathname + location.search);
+    console.log("location", location);
   }, [availableTeams, currentTeam, location, labels]);
 
   const isLastPage =

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -546,7 +546,6 @@ const ManageHostsPage = ({
     }
 
     setFilteredHostsPath(location.pathname + location.search);
-    console.log("location", location);
   }, [availableTeams, currentTeam, location, labels]);
 
   const isLastPage =

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -112,6 +112,7 @@ const HostDetailsPage = ({
     isPremiumTier,
     isOnlyObserver,
     isGlobalMaintainer,
+    filteredHostsPath,
   } = useContext(AppContext);
   const {
     setLastEditedQueryName,
@@ -606,7 +607,7 @@ const HostDetailsPage = ({
     <MainContent className={baseClass}>
       <div className={`${baseClass}__wrapper`}>
         <div className={`${baseClass}__header-links`}>
-          <BackLink text="Back to all hosts" />
+          <BackLink text="Back to all hosts" path={filteredHostsPath} />
         </div>
         <HostSummaryCard
           statusClassName={statusClassName}


### PR DESCRIPTION
## Issue
Bug merged in main related to #8504 

## Fix
- Host filters are saved in global state to be referred back to
- Back to all hosts link uses host filters saved in global state, so no matter what tabs/links you traverse through in the UI, if you end up back at the host details page, the back to all hosts link will send the user to the last used host filters

## Reasoning
- Originally it was just using the browser history, back button, however, once you clicked a tab or a link from the details page, a different URL is added to the history stack, so clicking the back to all hosts button went to the new URL added to the stack instead of the manage host page filtered
- Since we need that filter no matter where we navigate in our app, it's saved in state so we can refer back to it any possible way of getting back to the back to all host button

## Screen recording
Showing the filtered being saved as we navigate around from the host details page and go back using the Back to all host button.

https://user-images.githubusercontent.com/71795832/203641431-5e63ecba-4a34-4800-a44a-fa6663a21824.mov



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality