### PR TITLE
UI: Fix Tooltipwrapper causing extra whitespace if in last column of table

### DIFF
--- a/changes/issue-8390-extra-whitespace-after-last-table-header-with-tooltip
+++ b/changes/issue-8390-extra-whitespace-after-last-table-header-with-tooltip
@@ -1,0 +1,1 @@
+- remove extra whitespace in datatable after the last header containing a tooltip

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -172,6 +172,16 @@
             overflow-x: scroll;
           }
           &__table {
+            thead {
+              tr {
+                th:last-child {
+                  .component__tooltip-wrapper__tip-text {
+                    left: -8px;
+                  }
+                }
+              }
+            }
+
             tbody {
               .issues__cell {
                 display: flex;
@@ -184,6 +194,7 @@
                   }
                 }
               }
+
               .device_mapping__cell {
                 .text-cell {
                   display: inline;


### PR DESCRIPTION
# Addresses #8390 

# Fixes

- TooltipWrapper was causing extra whitespace after last table column. This solution nudges the last tooltip in the table header to the left to solve this issue without affecting the other tooltips in the header.
![lf](https://user-images.githubusercontent.com/61553566/203666181-5171806e-d3cd-4194-8375-17a24046cba8.png)
![ls](https://user-images.githubusercontent.com/61553566/203666184-d444f09a-b0e7-40d6-aafd-8fc386efa00b.png)

# Reasoning
One solution involves replacing our in-house TooltipWrapper with the third-party ReactTooltip. ReactTooltip enforces certain styling choices that are not in line with the current styling of the table headers. Pending Style Guide clarity on Tooltips/Contextual help, I chose this solution as it only modifies the last header cell of the table when applicable without changing any other tooltip styling. This change could easily be extended to the other tooltips in the table headers once the style guidance becomes more clear.

Another, potentially future solution, is to enable TooltipWrapper's tooltip text to exist outside of the boundaries of the DataTable without modifying the layout of the DataTable.

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/` 
- [x] Manual QA for all new/changed functionality