### PR TITLE
Store details (query_name and query_sql) about live query in activity feed

### DIFF
--- a/changes/issue-7754-live-query-name-and-sql
+++ b/changes/issue-7754-live-query-name-and-sql
@@ -1,0 +1,1 @@
+* store details (query_name and query_sql) about live query in activity feed.

--- a/orbit/pkg/table/privaterelay/privaterelay.go
+++ b/orbit/pkg/table/privaterelay/privaterelay.go
@@ -74,7 +74,7 @@ func getConsoleUidGid() (uid uint32, gid uint32, err error) {
 	}
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
-	    return 0, 0, fmt.Errorf("unexpected type %T", info.Sys()) 
+		return 0, 0, fmt.Errorf("unexpected type %T", info.Sys())
 	}
 	return stat.Uid, stat.Gid, nil
 }

--- a/server/service/campaigns.go
+++ b/server/service/campaigns.go
@@ -162,11 +162,18 @@ func (svc *Service) NewDistributedQueryCampaign(ctx context.Context, queryString
 		return nil, ctxerr.Wrap(ctx, err, "counting hosts")
 	}
 
+	activityData := map[string]interface{}{
+		"targets_count": campaign.Metrics.TotalHosts,
+		"query_sql":     query.Query,
+	}
+	if queryID != nil {
+		activityData["query_name"] = query.Name
+	}
 	if err := svc.ds.NewActivity(
 		ctx,
 		authz.UserFromContext(ctx),
 		fleet.ActivityTypeLiveQuery,
-		&map[string]interface{}{"targets_count": campaign.Metrics.TotalHosts},
+		&activityData,
 	); err != nil {
 		return nil, err
 	}

--- a/server/service/campaigns_test.go
+++ b/server/service/campaigns_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
@@ -83,7 +84,15 @@ func TestLiveQueryAuth(t *testing.T) {
 	ds.CountHostsInTargetsFunc = func(ctx context.Context, filters fleet.TeamFilter, targets fleet.HostTargets, now time.Time) (fleet.TargetMetrics, error) {
 		return fleet.TargetMetrics{}, nil
 	}
+	var queryName, querySQL string
 	ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activityType string, details *map[string]interface{}) error {
+		name := (*details)["query_name"]
+		if name == nil {
+			queryName = ""
+		} else {
+			queryName = name.(string)
+		}
+		querySQL = (*details)["query_sql"].(string)
 		return nil
 	}
 	ds.QueryFunc = func(ctx context.Context, id uint) (*fleet.Query, error) {
@@ -207,15 +216,25 @@ func TestLiveQueryAuth(t *testing.T) {
 			}
 			_, err := svc.NewDistributedQueryCampaign(ctx, query1ObsCanRun.Query, nil, fleet.HostTargets{TeamIDs: tms})
 			checkAuthErr(t, tt.shouldFailRunNew, err)
+			checkActivity := func(t testing.TB, err error, expectName, exceptSQL string) {
+				if err != nil {
+					return
+				}
+				require.Equal(t, expectName, queryName)
+				require.Equal(t, exceptSQL, querySQL)
+			}
+			checkActivity(t, err, "", query1ObsCanRun.Query)
 
 			if tt.teamID != nil {
 				tms = []uint{*tt.teamID}
 			}
 			_, err = svc.NewDistributedQueryCampaign(ctx, query1ObsCanRun.Query, ptr.Uint(query1ObsCanRun.ID), fleet.HostTargets{TeamIDs: tms})
 			checkAuthErr(t, tt.shouldFailRunObsCan, err)
+			checkActivity(t, err, query1ObsCanRun.Name, query1ObsCanRun.Query)
 
 			_, err = svc.NewDistributedQueryCampaign(ctx, query2ObsCannotRun.Query, ptr.Uint(query2ObsCannotRun.ID), fleet.HostTargets{TeamIDs: tms})
 			checkAuthErr(t, tt.shouldFailRunObsCannot, err)
+			checkActivity(t, err, query2ObsCannotRun.Name, query2ObsCannotRun.Query)
 
 			// tests with a team target cannot run the "ByNames" calls, as there's no way
 			// to pass a team target with this call.


### PR DESCRIPTION
For #7754

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
