### PR TITLE
UI: Fix line height issue on error in InputFieldWithIcon

### DIFF
--- a/changes/fix-label-height-change-on-error-in-registration-page
+++ b/changes/fix-label-height-change-on-error-in-registration-page
@@ -1,0 +1,1 @@
+- Fix an issue where the height of the label for some input fields changed when an error message is displayed

--- a/frontend/components/forms/FormField/_styles.scss
+++ b/frontend/components/forms/FormField/_styles.scss
@@ -10,7 +10,6 @@
     height: $form-field-label-height;
 
     &--error {
-      font-weight: $bold;
       color: $core-vibrant-red;
     }
 

--- a/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
+++ b/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
@@ -29,11 +29,14 @@ class InputFieldWithIcon extends InputField {
 
   renderHeading = () => {
     const { error, placeholder, name, label, tooltip } = this.props;
-    const labelClasses = classnames(`${baseClass}__label`);
-
+    const labelClassArr = [`${baseClass}__label`];
+    let labelText = label;
     if (error) {
-      return <div className={`${baseClass}__errors`}>{error}</div>;
+      // return <div className={`${labelClasses}--error`}>{error}</div>;
+      labelClassArr.push(`${baseClass}__label--error`);
+      labelText = error;
     }
+    const labelClasses = classnames(labelClassArr);
 
     return (
       <label
@@ -42,9 +45,9 @@ class InputFieldWithIcon extends InputField {
         data-has-tooltip={!!tooltip}
       >
         {tooltip ? (
-          <TooltipWrapper tipContent={tooltip}>{label}</TooltipWrapper>
+          <TooltipWrapper tipContent={tooltip}>{labelText}</TooltipWrapper>
         ) : (
-          <>{label || placeholder}</>
+          <>{labelText || placeholder}</>
         )}
       </label>
     );

--- a/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
+++ b/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
@@ -62,20 +62,16 @@
   }
 
   &__label {
+    font-size: $small;
+    font-weight: $bold;
+    color: $core-fleet-black;
     display: block;
-    font-size: $x-small;
-    font-weight: $bold;
-    margin-bottom: $pad-xsmall;
+    margin-bottom: $pad-small;
+    height: $form-field-label-height;
 
-    &[data-has-tooltip="true"] {
-      margin-bottom: $pad-small;
+    &--error {
+      color: $core-vibrant-red;
     }
-  }
-
-  &__errors {
-    font-size: $x-small;
-    font-weight: $bold;
-    color: $core-vibrant-red;
   }
 
   &__hint {


### PR DESCRIPTION
# Fixes

The same problem in issue #8393 was happening on the registration pages, which mostly use the InputFieldWithIcon component.

I fixed the problem by changing the styling and some logic of InputFieldWithIcon but **do folks agree that the better and more long-term solution is to swap out InputFieldWIthIcon for FormField here?**

# Screencasts

## before:
https://user-images.githubusercontent.com/61553566/204066884-479145e7-3b5d-4ec4-8e73-45bd83f1326e.mov

## after:
https://user-images.githubusercontent.com/61553566/204066889-8d34a637-576a-4722-8180-ee8c19c910b2.mov


