### PR TITLE
UI: Fix line height issue on error in registration flow via replacing InputFieldWithIcon with InputField 

### DIFF
--- a/changes/fix-label-height-change-on-error-in-registration-page
+++ b/changes/fix-label-height-change-on-error-in-registration-page
@@ -1,0 +1,1 @@
+- Fix an issue where the height of the label for some input fields changed when an error message is displayed

--- a/cypress/integration/all/setup/setup.spec.ts
+++ b/cypress/integration/all/setup/setup.spec.ts
@@ -4,22 +4,22 @@ const { GOOD_PASSWORD } = CONSTANTS;
 
 const fillOutForm = () => {
   // Page 1
-  cy.findByPlaceholderText(/full name/i).type("Test name");
+  cy.findByLabelText(/full name/i).type("Test name");
 
-  cy.findByPlaceholderText(/email/i).type("test@example.com");
+  cy.findByLabelText(/email/i).type("test@example.com");
 
-  cy.findByPlaceholderText(/^password/i)
+  cy.findByLabelText(/^password/i)
     .first()
     .type(GOOD_PASSWORD);
 
-  cy.findByPlaceholderText(/confirm password/i)
+  cy.findByLabelText(/confirm password/i)
     .last()
     .type(GOOD_PASSWORD);
 
   cy.contains("button:enabled", /next/i).click();
 
   // Page 2
-  cy.findByPlaceholderText(/organization name/i).type("Fleet Test");
+  cy.findByLabelText(/organization name/i).type("Fleet Test");
 
   cy.contains("button:enabled", /next/i).click();
 

--- a/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
@@ -5,6 +5,7 @@ import Form from "components/forms/Form";
 import formFieldInterface from "interfaces/form_field";
 import Button from "components/buttons/Button";
 import InputFieldWithIcon from "components/forms/fields/InputFieldWithIcon";
+import InputField from "components/forms/fields/InputField";
 import helpers from "./helpers";
 
 const formFields = ["name", "password", "password_confirmation", "email"];
@@ -44,9 +45,10 @@ class AdminDetails extends Component {
     return (
       <form onSubmit={handleSubmit} className={className} autoComplete="off">
         <div className="registration-fields">
-          <InputFieldWithIcon
+          <InputField
             {...fields.name}
             placeholder="Full name"
+            label="Full name"
             tabIndex={tabIndex}
             autofocus={currentPage}
             ref={(input) => {
@@ -56,25 +58,28 @@ class AdminDetails extends Component {
               maxLength: "80",
             }}
           />
-          <InputFieldWithIcon
+          <InputField
             {...fields.email}
             placeholder="Email"
+            label="Email"
             tabIndex={tabIndex}
           />
-          <InputFieldWithIcon
+          <InputField
             {...fields.password}
             placeholder="Password"
+            label="Password"
             type="password"
             tabIndex={tabIndex}
             hint={[
               "Must include 12 characters, at least 1 number (e.g. 0 - 9), and at least 1 symbol (e.g. &*#)",
             ]}
           />
-          <InputFieldWithIcon
+          <InputField
             {...fields.password_confirmation}
             placeholder="Confirm password"
             type="password"
             tabIndex={tabIndex}
+            label="Confirm password"
           />
         </div>
         <Button

--- a/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
@@ -4,7 +4,6 @@ import PropTypes from "prop-types";
 import Form from "components/forms/Form";
 import formFieldInterface from "interfaces/form_field";
 import Button from "components/buttons/Button";
-import InputFieldWithIcon from "components/forms/fields/InputFieldWithIcon";
 import InputField from "components/forms/fields/InputField";
 import helpers from "./helpers";
 
@@ -47,7 +46,6 @@ class AdminDetails extends Component {
         <div className="registration-fields">
           <InputField
             {...fields.name}
-            placeholder="Full name"
             label="Full name"
             tabIndex={tabIndex}
             autofocus={currentPage}
@@ -58,15 +56,9 @@ class AdminDetails extends Component {
               maxLength: "80",
             }}
           />
-          <InputField
-            {...fields.email}
-            placeholder="Email"
-            label="Email"
-            tabIndex={tabIndex}
-          />
+          <InputField {...fields.email} label="Email" tabIndex={tabIndex} />
           <InputField
             {...fields.password}
-            placeholder="Password"
             label="Password"
             type="password"
             tabIndex={tabIndex}
@@ -76,7 +68,6 @@ class AdminDetails extends Component {
           />
           <InputField
             {...fields.password_confirmation}
-            placeholder="Confirm password"
             type="password"
             tabIndex={tabIndex}
             label="Confirm password"

--- a/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.tests.jsx
+++ b/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.tests.jsx
@@ -10,8 +10,8 @@ describe("AdminDetails - form", () => {
   it("renders", () => {
     render(<AdminDetails handleSubmit={onSubmitSpy} />);
 
-    expect(screen.getByPlaceholderText("Password")).toBeInTheDocument();
-    expect(screen.getByPlaceholderText("Confirm password")).toBeInTheDocument();
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(screen.getByLabelText("Confirm password")).toBeInTheDocument();
     expect(
       screen.getByRole("textbox", { name: "Full name" })
     ).toBeInTheDocument();
@@ -55,11 +55,8 @@ describe("AdminDetails - form", () => {
       <AdminDetails handleSubmit={onSubmitSpy} currentPage />
     );
 
-    await user.type(screen.getByPlaceholderText("Password"), "p@ssw0rd");
-    await user.type(
-      screen.getByPlaceholderText("Confirm password"),
-      "password123"
-    );
+    await user.type(screen.getByLabelText("Password"), "p@ssw0rd");
+    await user.type(screen.getByLabelText("Confirm password"), "password123");
     await user.click(screen.getByRole("button", { name: "Next" }));
     // then
     expect(onSubmitSpy).not.toHaveBeenCalled();
@@ -73,11 +70,8 @@ describe("AdminDetails - form", () => {
       <AdminDetails handleSubmit={onSubmitSpy} currentPage />
     );
 
-    await user.type(screen.getByPlaceholderText("Password"), "passw0rd");
-    await user.type(
-      screen.getByPlaceholderText("Confirm password"),
-      "passw0rd"
-    );
+    await user.type(screen.getByLabelText("Password"), "passw0rd");
+    await user.type(screen.getByLabelText("Confirm password"), "passw0rd");
     await user.click(screen.getByRole("button", { name: "Next" }));
     // then
     expect(onSubmitSpy).not.toHaveBeenCalled();
@@ -95,11 +89,8 @@ describe("AdminDetails - form", () => {
       screen.getByRole("textbox", { name: "Email" }),
       "hi@gnar.dog"
     );
-    await user.type(screen.getByPlaceholderText("Password"), "password123#");
-    await user.type(
-      screen.getByPlaceholderText("Confirm password"),
-      "password123#"
-    );
+    await user.type(screen.getByLabelText("Password"), "password123#");
+    await user.type(screen.getByLabelText("Confirm password"), "password123#");
     await user.type(
       screen.getByRole("textbox", { name: "Full name" }),
       "Gnar Dog"

--- a/frontend/components/forms/RegistrationForm/FleetDetails/FleetDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/FleetDetails/FleetDetails.jsx
@@ -5,7 +5,7 @@ import Form from "components/forms/Form";
 import formFieldInterface from "interfaces/form_field";
 import Button from "components/buttons/Button";
 import helpers from "components/forms/RegistrationForm/FleetDetails/helpers";
-import InputFieldWithIcon from "components/forms/fields/InputFieldWithIcon";
+import InputField from "components/forms/fields/InputField";
 
 const formFields = ["server_url"];
 const { validate } = helpers;
@@ -41,9 +41,10 @@ class FleetDetails extends Component {
     return (
       <form onSubmit={handleSubmit} className={className} autoComplete="off">
         <div className="registration-fields">
-          <InputFieldWithIcon
+          <InputField
             {...fields.server_url}
             placeholder="Fleet web address"
+            label="Fleet web address"
             tabIndex={tabIndex}
             hint={[
               "Don’t include ",

--- a/frontend/components/forms/RegistrationForm/FleetDetails/FleetDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/FleetDetails/FleetDetails.jsx
@@ -43,7 +43,6 @@ class FleetDetails extends Component {
         <div className="registration-fields">
           <InputField
             {...fields.server_url}
-            placeholder="Fleet web address"
             label="Fleet web address"
             tabIndex={tabIndex}
             hint={[

--- a/frontend/components/forms/RegistrationForm/OrgDetails/OrgDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/OrgDetails/OrgDetails.jsx
@@ -44,7 +44,6 @@ class OrgDetails extends Component {
         <div className="registration-fields">
           <InputField
             {...fields.org_name}
-            placeholder="Organization name"
             label="Organization name"
             tabIndex={tabIndex}
             ref={(input) => {
@@ -53,7 +52,6 @@ class OrgDetails extends Component {
           />
           <InputField
             {...fields.org_logo_url}
-            placeholder="Organization logo URL (optional)"
             label="Organization logo URL (optional)"
             tabIndex={tabIndex}
             hint="Personalize Fleet with your brand.  For best results, use a square image at least 150px wide, like https://fleetdm.com/logo.png."

--- a/frontend/components/forms/RegistrationForm/OrgDetails/OrgDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/OrgDetails/OrgDetails.jsx
@@ -5,7 +5,7 @@ import Form from "components/forms/Form";
 import formFieldInterface from "interfaces/form_field";
 import Button from "components/buttons/Button";
 import helpers from "components/forms/RegistrationForm/OrgDetails/helpers";
-import InputFieldWithIcon from "components/forms/fields/InputFieldWithIcon";
+import InputField from "components/forms/fields/InputField";
 
 const formFields = ["org_name", "org_logo_url"];
 const { validate } = helpers;
@@ -42,17 +42,19 @@ class OrgDetails extends Component {
     return (
       <form onSubmit={handleSubmit} className={className} autoComplete="off">
         <div className="registration-fields">
-          <InputFieldWithIcon
+          <InputField
             {...fields.org_name}
             placeholder="Organization name"
+            label="Organization name"
             tabIndex={tabIndex}
             ref={(input) => {
               this.firstInput = input;
             }}
           />
-          <InputFieldWithIcon
+          <InputField
             {...fields.org_logo_url}
             placeholder="Organization logo URL (optional)"
+            label="Organization logo URL (optional)"
             tabIndex={tabIndex}
             hint="Personalize Fleet with your brand.  For best results, use a square image at least 150px wide, like https://fleetdm.com/logo.png."
           />

--- a/frontend/components/forms/RegistrationForm/_styles.scss
+++ b/frontend/components/forms/RegistrationForm/_styles.scss
@@ -33,7 +33,7 @@
 
     &--admin {
       left: 0;
-      top: unquote("max(56%, 480px)");
+      top: unquote("max(56%, 560px)");
       margin: auto;
     }
 

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -10,6 +10,7 @@
   box-sizing: border-box;
   height: 40px;
   transition: border-color 100ms;
+  width: 100%;
 
   &::placeholder {
     color: $ui-fleet-black-50;


### PR DESCRIPTION
# Fixes

The same problem in issue #8393 was happening on the registration pages, which mostly used the InputFieldWithIcon component.

In this solution I replace the InputFieldWithIcon component with the InputField component (which the former extends). In the alternate solution in PR #8818 I updated styling and some logic of the current components used in the registration workflow. I think the solution in this PR is better for a number of reasons, including that these fields do not use icons, and that InputField's use of the FormField component makes its logic a bit more modular than that of InputFieldIcon, and that this brings the styling of the fields in line with the style guide and the rest of the inputs, most of which use InputField.

# Ideas for further improvement

Swap other places using InputFieldWithIcon for InputField as appropriate. It seems like this same component may be causing [a problem in the login page.](https://github.com/fleetdm/fleet/issues/8695#issuecomment-1331132288)

# Screencasts
## before:
https://user-images.githubusercontent.com/61553566/204066884-479145e7-3b5d-4ec4-8e73-45bd83f1326e.mov

## after:
https://user-images.githubusercontent.com/61553566/204066889-8d34a637-576a-4722-8180-ee8c19c910b2.mov

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionalityThis is an alternate, and what I think more long-viewed solution to the same issue dealt with by PR #8818.



