### PR TITLE
UI: Prevent bg color change of disabled pagination buttons in Activity card

### DIFF
--- a/changes/issue-8392-improve-pagination
+++ b/changes/issue-8392-improve-pagination
@@ -1,0 +1,1 @@
+- Prevent background color change for disabled pagination buttons on Activity card

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/_styles.scss
@@ -48,7 +48,7 @@
       margin-right: $pad-large;
     }
 
-    &:hover,
+    &:hover:not(.button--disabled),
     &:focus {
       background-color: $ui-vibrant-blue-10;
     }


### PR DESCRIPTION
# Addresses #8392 

# Fixes
- On Dashboard > Activity card, pagination prev/next buttons were being highlighted on hover even when disabled.

# Ideas for improvement
- The Activity card is not using the Pagination component like every other similar UI component, which led to the divergent styling logic that caused this. Perhaps Activity card should be refactored to use the Pagination component for consistency with the rest of the UI.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
