### PR TITLE
orbit: Correctly handle errors in `authenticatedRequest`. Fixes #8472

### DIFF
--- a/server/service/orbit_client.go
+++ b/server/service/orbit_client.go
@@ -219,7 +219,8 @@ func (oc *OrbitClient) authenticatedRequest(verb string, path string, params int
 	s := params.(setOrbitNodeKeyer)
 	s.setOrbitNodeKey(nodeKey)
 
-	switch oc.request(verb, path, params, resp); {
+	err = oc.request(verb, path, params, resp)
+	switch {
 	case err == nil:
 		oc.setEnrolled(true)
 		return nil


### PR DESCRIPTION
This took an absurd amount of time to find, but it seems that a minor typo cascaded into an issue that prevented orbit and fleet desktop from properly authenticating requests.
The core issue is that `err` was not properly set, so every call to `authenticatedRequest` would proceed as if there were no error, even when there was.

I'm surprised a warning or `must_use`-type-thing didn't catch this but I'm not sure what kind of things we'd add to the CI for that since they don't seem to be built-in. I expect there's something similar to `cargo clippy` we could find to add to our pipeline.

# Checklist for submitter
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
