### PR TITLE
WIP: Remove duplicated indexes

### DIFF
--- a/server/datastore/mysql/migrations/tables/20221128141346_RemoveDuplicateIndexes.go
+++ b/server/datastore/mysql/migrations/tables/20221128141346_RemoveDuplicateIndexes.go
@@ -1,0 +1,33 @@
+package tables
+
+import (
+	"database/sql"
+
+	"github.com/pkg/errors"
+)
+
+func init() {
+	MigrationClient.AddMigration(Up_20221128141346, Down_20221128141346)
+}
+
+func Up_20221128141346(tx *sql.Tx) error {
+	dropIndexes := []string{
+		"ALTER TABLE app_config_json DROP INDEX id;",
+		"ALTER TABLE host_users DROP INDEX idx_uid_username;",
+		"ALTER TABLE policy_membership DROP INDEX idx_policy_membership_policy_id;",
+		"ALTER TABLE queries DROP INDEX constraint_query_name_unique;",
+		"ALTER TABLE software DROP INDEX software_listing_idx, ADD INDEX software_listing_idx (`name`);",
+		"ALTER TABLE software_cve DROP INDEX software_cve_software_id;",
+	}
+	for _, alter := range dropIndexes {
+		_, err := tx.Exec(alter)
+		if err != nil {
+			return errors.Wrapf(err, "create table")
+		}
+	}
+	return nil
+}
+
+func Down_20221128141346(tx *sql.Tx) error {
+	return nil
+}

--- a/server/datastore/mysql/migrations/tables/20221128141346_RemoveDuplicateIndexes_test.go
+++ b/server/datastore/mysql/migrations/tables/20221128141346_RemoveDuplicateIndexes_test.go
@@ -1,0 +1,20 @@
+package tables
+
+import "testing"
+
+func TestUp_20221128141346(t *testing.T) {
+	db := applyUpToPrev(t)
+
+	//
+	// Insert data to test the migration
+	//
+	// ...
+
+	// Apply current migration.
+	applyNext(t, db)
+
+	//
+	// Check data, insert new entries, e.g. to verify migration is safe.
+	//
+	// ...
+}


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
