### PR TITLE
Adding custom action to WIX template to ensure files are not locked during uninstallation

### DIFF
--- a/changes/bug-3563-uninstall-does-not-remove-files
+++ b/changes/bug-3563-uninstall-does-not-remove-files
@@ -1,0 +1,1 @@
+* Windows installer now ensures that no files are left on the filesystem when orbit uninstallation process is kicked off

--- a/orbit/pkg/packaging/windows_templates.go
+++ b/orbit/pkg/packaging/windows_templates.go
@@ -95,6 +95,14 @@ var windowsWixTemplate = template.Must(template.New("").Option("missingkey=error
       </Directory>
     </Directory>
 
+    <CustomAction Id="StopOrbit_cmd" Property="WixQuietExecCmdLine" Value='"[WindowsFolder]System32\taskkill.exe" /F /IM osqueryd.exe /IM fleet-desktop.exe /IM orbit.exe' />
+    <CustomAction Id="StopOrbit" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="immediate" Return="check"/>
+
+    <InstallExecuteSequence>
+      <Custom Action='StopOrbit_cmd' Before='RemoveFiles'>(NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")</Custom>
+      <Custom Action='StopOrbit' After='StopOrbit_cmd'>(NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")</Custom>
+    </InstallExecuteSequence>
+
     <Feature Id="Orbit" Title="Fleet osquery" Level="1" Display="hidden">
       <ComponentGroupRef Id="OrbitFiles" />
       <ComponentRef Id="C_ORBITROOT_REMOVAL" />


### PR DESCRIPTION
This relates to #3563 

Adding custom action to ensure that no fleetdm-related processes are running on a product uninstall scenario. This will ensure that no file locks are present during file removal. This custom action will only run during uninstallation.

This was tested using a recommended approach through msiexec: 

**Install**: `msiexec /i fleet-osquery.msi /quiet /passive /lv fleet_install_log.txt`
**Uninstall**: `msiexec /x fleet-osquery.msi /quiet /passive /lv fleet_uninstall_log.txt`

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Manual QA for all new/changed functionality

