### PR TITLE
Fleet UI: Fix header margin being added to tooltip margin (unreleased)

### DIFF
--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -20,7 +20,9 @@
       border-collapse: collapse;
       color: $core-fleet-black;
       font-size: $x-small;
+    }
 
+    tbody {
       .component__tooltip-wrapper {
         margin: 10px 0; // vertical padding multiline text with tooltip
       }


### PR DESCRIPTION
Cerra #8882 

Problem:
- Multiline tooltip margin was being added to the header margin causing the header to be too tall

Fix:
- Should only ensure margin around multiline tooltips in the table body

Screenshot of fix:
<img width="740" alt="Screenshot 2022-11-29 at 9 15 26 PM" src="https://user-images.githubusercontent.com/71795832/204691205-5f72f854-b1aa-4353-b560-7526859aaf29.png">
<img width="1013" alt="Screenshot 2022-11-29 at 9 15 22 PM" src="https://user-images.githubusercontent.com/71795832/204691208-650dd214-e01e-4d7a-bc2e-aaafad9f4ed2.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality