### PR TITLE
UI: Disable sort arrows in manage hosts status column

### DIFF
--- a/changes/issue-8814-nonfunctioning-status-column-sort-arrows
+++ b/changes/issue-8814-nonfunctioning-status-column-sort-arrows
@@ -1,0 +1,2 @@
+- disable nonfunctional sort arrows that were erroniously displayed in header of Status column on
+manage hosts page

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -208,12 +208,7 @@ const allHostTableHeaders: IDataColumn[] = [
           Status
         </TooltipWrapper>
       );
-      return (
-        <HeaderCell
-          value={titleWithToolTip}
-          isSortedDesc={headerProps.column.isSortedDesc}
-        />
-      );
+      return <HeaderCell value={titleWithToolTip} disableSortBy />;
     },
     disableSortBy: true,
     accessor: "status",


### PR DESCRIPTION
# Addresses #8814

# Fixes
- disables nonfunctional sort arrows in the header cell of the status column on manage hosts page

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/` 
- [x] Manual QA for all new/changed functionality