### PR TITLE
ensure we provide a future date in MSRC test

### DIFF
--- a/server/vulnerabilities/msrc/io/msrc_test.go
+++ b/server/vulnerabilities/msrc/io/msrc_test.go
@@ -31,10 +31,17 @@ func TestMSRCClient(t *testing.T) {
 				require.Error(t, err)
 			})
 
-			t.Run("provided month and year is in the future", func(t *testing.T) {
-				future := now.AddDate(1, 1, 0)
-				_, err := sut.GetFeed(future.Month(), future.Year())
-				require.Error(t, err)
+			t.Run("provided arguments are in the future", func(t *testing.T) {
+				cases := []time.Time{
+					now.AddDate(0, 1, 0),
+					now.AddDate(1, 0, 0),
+					now.AddDate(1, 1, 0),
+				}
+
+				for _, c := range cases {
+					_, err := sut.GetFeed(c.Month(), c.Year())
+					require.Error(t, err)
+				}
 			})
 		})
 

--- a/server/vulnerabilities/msrc/io/msrc_test.go
+++ b/server/vulnerabilities/msrc/io/msrc_test.go
@@ -32,7 +32,8 @@ func TestMSRCClient(t *testing.T) {
 			})
 
 			t.Run("provided month and year is in the future", func(t *testing.T) {
-				_, err := sut.GetFeed((now.AddDate(0, 1, 0)).Month(), now.Year())
+				future := now.AddDate(1, 1, 0)
+				_, err := sut.GetFeed(future.Month(), future.Year())
 				require.Error(t, err)
 			})
 		})


### PR DESCRIPTION
As of today, `TestMSRCClient/#GetFeed/with_invalid_args/provided_month_and_year_is_in_the_future` was failing because we were incrementing the month but not the year provided to the `GetFeed` function.

# Checklist for submitter

- [x] Added/updated tests
