### PR TITLE
Match e2e testing nav link to correct header id

### DIFF
--- a/docs/Contributing/Fleet-UI-Testing.md
+++ b/docs/Contributing/Fleet-UI-Testing.md
@@ -28,7 +28,7 @@ For instructions on using our testings tools, check out our [testing docs](https
       - [Reusable hook testing](#reusable-hooks-testing)
     - [Integration testing](#integration-testing)
       - [App widgets testing](#app-widget-testing)
-    - [E2E testing](#e2e-testing)
+    - [E2E testing](#e-2-e-testing)
   - [Tooling](#tooling)
     - [ESLint and TypeScript](#es-lint-and-typescript)
     - [Jest](#jest)


### PR DESCRIPTION
# Fixes

-Nav link in testing docs pointed to incorrect header id

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
