### PR TITLE
add API endpoint to retrieve host disk encryption keys

### DIFF
--- a/changes/issue-8708-disk-encryption-key
+++ b/changes/issue-8708-disk-encryption-key
@@ -1,0 +1,1 @@
+- Added an API endpoint to retrieve a host disk encryption key (macOS hosts only)

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -230,6 +230,14 @@ allow {
 	action == write
 }
 
+# Global users can get the encryption key for any host
+# TODO: define cross-team rules, see https://github.com/fleetdm/fleet/issues/8708#issuecomment-1333829676
+allow {
+  object.type == "host_disk_encryption_key"
+  subject.global_role == [admin, maintainer, observer][_]
+  action == read
+}
+
 ##
 # Labels
 ##

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2240,6 +2240,25 @@ func (ds *Datastore) GetHostMDM(ctx context.Context, hostID uint) (*fleet.HostMD
 	return &hmdm, nil
 }
 
+func (ds *Datastore) GetHostDiskEncryptionKey(ctx context.Context, hostID uint) (*fleet.HostDiskEncryptionKey, error) {
+	var key fleet.HostDiskEncryptionKey
+	err := sqlx.GetContext(ctx, ds.reader, &key, `
+      SELECT
+        host_id, disk_encryption_key, created_at, updated_at
+      FROM
+        host_disk_encryption_keys
+      WHERE host_id = ?`, hostID)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			msg := fmt.Sprintf("for host %d", hostID)
+			return nil, ctxerr.Wrap(ctx, notFound("HostDiskEncryptionKey").WithMessage(msg))
+		}
+		return nil, ctxerr.Wrapf(ctx, err, "getting data from host_mdm for host_id %d", hostID)
+	}
+	return &key, nil
+}
+
 func (ds *Datastore) GetMDMSolution(ctx context.Context, mdmID uint) (*fleet.MDMSolution, error) {
 	var solution fleet.MDMSolution
 	err := sqlx.GetContext(ctx, ds.reader, &solution, `

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -45,6 +45,8 @@ const (
 	ActivityTypeEditedAgentOptions = "edited_agent_options"
 	// ActivityTypeAppliedSpecTeam is the activity type for a team spec applied
 	ActivityTypeAppliedSpecTeam = "applied_spec_team"
+	// ActivityTypeReadHostDiskEncryptionKey is the activity type for when a host disk encryption key is viewed
+	ActivityTypeReadHostDiskEncryptionKey = "read_host_disk_encryption_key"
 )
 
 type Activity struct {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -251,6 +251,7 @@ type Datastore interface {
 	GetHostMunkiVersion(ctx context.Context, hostID uint) (string, error)
 	GetHostMunkiIssues(ctx context.Context, hostID uint) ([]*HostMunkiIssue, error)
 	GetHostMDM(ctx context.Context, hostID uint) (*HostMDM, error)
+	GetHostDiskEncryptionKey(ctx context.Context, hostID uint) (*HostDiskEncryptionKey, error)
 
 	AggregatedMunkiVersion(ctx context.Context, teamID *uint) ([]AggregatedMunkiVersion, time.Time, error)
 	AggregatedMunkiIssues(ctx context.Context, teamID *uint) ([]AggregatedMunkiIssue, time.Time, error)

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -560,3 +560,14 @@ type EnrollHostLimiter interface {
 	CanEnrollNewHost(ctx context.Context) (ok bool, err error)
 	SyncEnrolledHostIDs(ctx context.Context) error
 }
+
+type HostDiskEncryptionKey struct {
+	HostID    string `json:"-" db:"host_id"`
+	Key       string `json:"key" db:"disk_encryption_key"`
+	CreatedAt string `json:"-" db:"created_at"`
+	UpdatedAt string `json:"updated_at" db:"updated_at"`
+}
+
+func (d HostDiskEncryptionKey) AuthzType() string {
+	return "host_disk_encryption_key"
+}

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -320,6 +320,7 @@ type Service interface {
 	AggregatedMDMData(ctx context.Context, id *uint, platform string) (AggregatedMDMData, error)
 	GetMDMSolution(ctx context.Context, mdmID uint) (*MDMSolution, error)
 	GetMunkiIssue(ctx context.Context, munkiIssueID uint) (*MunkiIssue, error)
+	HostEncryptionKey(ctx context.Context, id uint) (*HostDiskEncryptionKey, error)
 
 	// OSVersions returns a list of operating systems and associated host counts, which may be
 	// filtered using the following optional criteria: team id, platform, or name and version.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -199,6 +199,8 @@ type GetHostMunkiIssuesFunc func(ctx context.Context, hostID uint) ([]*fleet.Hos
 
 type GetHostMDMFunc func(ctx context.Context, hostID uint) (*fleet.HostMDM, error)
 
+type GetHostDiskEncryptionKeyFunc func(ctx context.Context, hostID uint) (*fleet.HostDiskEncryptionKey, error)
+
 type AggregatedMunkiVersionFunc func(ctx context.Context, teamID *uint) ([]fleet.AggregatedMunkiVersion, time.Time, error)
 
 type AggregatedMunkiIssuesFunc func(ctx context.Context, teamID *uint) ([]fleet.AggregatedMunkiIssue, time.Time, error)
@@ -788,6 +790,9 @@ type DataStore struct {
 
 	GetHostMDMFunc        GetHostMDMFunc
 	GetHostMDMFuncInvoked bool
+
+	GetHostDiskEncryptionKeyFunc        GetHostDiskEncryptionKeyFunc
+	GetHostDiskEncryptionKeyFuncInvoked bool
 
 	AggregatedMunkiVersionFunc        AggregatedMunkiVersionFunc
 	AggregatedMunkiVersionFuncInvoked bool
@@ -1718,6 +1723,11 @@ func (s *DataStore) GetHostMunkiIssues(ctx context.Context, hostID uint) ([]*fle
 func (s *DataStore) GetHostMDM(ctx context.Context, hostID uint) (*fleet.HostMDM, error) {
 	s.GetHostMDMFuncInvoked = true
 	return s.GetHostMDMFunc(ctx, hostID)
+}
+
+func (s *DataStore) GetHostDiskEncryptionKey(ctx context.Context, hostID uint) (*fleet.HostDiskEncryptionKey, error) {
+	s.GetHostDiskEncryptionKeyFuncInvoked = true
+	return s.GetHostDiskEncryptionKeyFunc(ctx, hostID)
 }
 
 func (s *DataStore) AggregatedMunkiVersion(ctx context.Context, teamID *uint) ([]fleet.AggregatedMunkiVersion, time.Time, error) {

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -345,6 +345,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 
 	ue.GET("/api/_version_/fleet/hosts/summary/mdm", getHostMDMSummary, getHostMDMSummaryRequest{})
 	ue.GET("/api/_version_/fleet/hosts/{id:[0-9]+}/mdm", getHostMDM, getHostMDMRequest{})
+	ue.GET("/api/_version_/fleet/hosts/{id:[0-9]+}/encryption_key", getHostEncryptionKey, getHostEncryptionKeyRequest{})
 
 	ue.POST("/api/_version_/fleet/labels", createLabelEndpoint, createLabelRequest{})
 	ue.PATCH("/api/_version_/fleet/labels/{id:[0-9]+}", modifyLabelEndpoint, modifyLabelRequest{})

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -11,7 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fleetdm/fleet/v4/server/contexts/authz"
+	"github.com/fleetdm/fleet/v4/server/authz"
+	authzctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/contexts/logging"
@@ -388,7 +389,7 @@ func getHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service
 }
 
 func (svc *Service) GetHost(ctx context.Context, id uint, opts fleet.HostDetailOptions) (*fleet.HostDetail, error) {
-	alreadyAuthd := svc.authz.IsAuthenticatedWith(ctx, authz.AuthnDeviceToken)
+	alreadyAuthd := svc.authz.IsAuthenticatedWith(ctx, authzctx.AuthnDeviceToken)
 	if !alreadyAuthd {
 		// First ensure the user has access to list hosts, then check the specific
 		// host once team_id is loaded.
@@ -723,7 +724,7 @@ func refetchHostEndpoint(ctx context.Context, request interface{}, svc fleet.Ser
 }
 
 func (svc *Service) RefetchHost(ctx context.Context, id uint) error {
-	if !svc.authz.IsAuthenticatedWith(ctx, authz.AuthnDeviceToken) {
+	if !svc.authz.IsAuthenticatedWith(ctx, authzctx.AuthnDeviceToken) {
 		if err := svc.authz.Authorize(ctx, &fleet.Host{}, fleet.ActionList); err != nil {
 			return err
 		}
@@ -871,7 +872,7 @@ func listHostDeviceMappingEndpoint(ctx context.Context, request interface{}, svc
 }
 
 func (svc *Service) ListHostDeviceMapping(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
-	if !svc.authz.IsAuthenticatedWith(ctx, authz.AuthnDeviceToken) {
+	if !svc.authz.IsAuthenticatedWith(ctx, authzctx.AuthnDeviceToken) {
 		if err := svc.authz.Authorize(ctx, &fleet.Host{}, fleet.ActionList); err != nil {
 			return nil, err
 		}
@@ -959,7 +960,7 @@ func getMacadminsDataEndpoint(ctx context.Context, request interface{}, svc flee
 }
 
 func (svc *Service) MacadminsData(ctx context.Context, id uint) (*fleet.MacadminsData, error) {
-	if !svc.authz.IsAuthenticatedWith(ctx, authz.AuthnDeviceToken) {
+	if !svc.authz.IsAuthenticatedWith(ctx, authzctx.AuthnDeviceToken) {
 		if err := svc.authz.Authorize(ctx, &fleet.Host{}, fleet.ActionList); err != nil {
 			return nil, err
 		}
@@ -1237,7 +1238,7 @@ func hostsReportEndpoint(ctx context.Context, request interface{}, svc fleet.Ser
 	// for now, only csv format is allowed
 	if req.Format != "csv" {
 		// prevent returning an "unauthorized" error, we want that specific error
-		if az, ok := authz.FromContext(ctx); ok {
+		if az, ok := authzctx.FromContext(ctx); ok {
 			az.SetChecked()
 		}
 		err := ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("format", "unsupported or unspecified report format").
@@ -1351,4 +1352,60 @@ func (svc *Service) OSVersions(ctx context.Context, teamID *uint, platform *stri
 	}
 
 	return osVersions, nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Encryption Key
+////////////////////////////////////////////////////////////////////////////////
+
+type getHostEncryptionKeyRequest struct {
+	ID uint `url:"id"`
+}
+
+type getHostEncryptionKeyResponse struct {
+	Err           error                        `json:"error,omitempty"`
+	EncryptionKey *fleet.HostDiskEncryptionKey `json:"encryption_key,omitempty"`
+	HostID        uint                         `json:"host_id,omitempty"`
+}
+
+func (r getHostEncryptionKeyResponse) error() error { return r.Err }
+
+func getHostEncryptionKey(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+	req := request.(*getHostEncryptionKeyRequest)
+	key, err := svc.HostEncryptionKey(ctx, req.ID)
+	if err != nil {
+		return getHostEncryptionKeyResponse{Err: err}, nil
+	}
+	return getHostEncryptionKeyResponse{EncryptionKey: key, HostID: req.ID}, nil
+}
+
+func (svc *Service) HostEncryptionKey(ctx context.Context, id uint) (*fleet.HostDiskEncryptionKey, error) {
+	if err := svc.authz.Authorize(ctx, fleet.HostDiskEncryptionKey{}, fleet.ActionRead); err != nil {
+		return nil, err
+	}
+
+	host, err := svc.ds.Host(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := svc.ds.GetHostDiskEncryptionKey(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	err = svc.ds.NewActivity(
+		ctx,
+		authz.UserFromContext(ctx),
+		fleet.ActivityTypeReadHostDiskEncryptionKey,
+		&map[string]interface{}{
+			"host_id":           id,
+			"host_display_name": host.DisplayName(),
+		},
+	)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "create read host disk encryption key activity")
+	}
+
+	return key, nil
 }


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
