### PR TITLE
skip TestHosts/TestHostOrder until we figure why it's flaky in CI

### DIFF
--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -5381,6 +5381,8 @@ func testHostsSetOrUpdateHostDisksSpace(t *testing.T, ds *Datastore) {
 
 // testHostOrder tests listing a host sorted by different keys.
 func testHostOrder(t *testing.T, ds *Datastore) {
+	t.Skip("flaky: https://github.com/fleetdm/fleet/issues/8768")
+
 	ctx := context.Background()
 	_, err := ds.NewHost(ctx, &fleet.Host{ID: 1, OsqueryHostID: "1", Hostname: "0001", NodeKey: "1"})
 	require.NoError(t, err)


### PR DESCRIPTION
This has been failing for a while, see all the [go tests workflow runs](https://github.com/fleetdm/fleet/actions/workflows/test-go.yaml), a bunch of them fail in CI because of this test.

I spent a bit trying to reproduce locally, but I couldn't (tried running the tests in parallel like in CI), so based on discussions in Slack I'm proposing we skip it until someone can allocate time to investigate why it fails.