### PR TITLE
Fleet UI: Scroll shadows

### DIFF
--- a/changes/issue-7308-scroll-shadows
+++ b/changes/issue-7308-scroll-shadows
@@ -1,0 +1,1 @@
+* Spiffier UI: Add scroll shadows to indicate horizontal scrolling to user

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -23,9 +23,9 @@ $shadow-transition-width: 10px;
       /* Shadows */ linear-gradient(
           to right,
           white,
-          $ui-off-white-opaque
+          $transparent
         ),
-        linear-gradient(to left, white, $ui-off-white-opaque),
+        linear-gradient(to left, white, $transparent),
         /* Shadow covers */
           linear-gradient(to right, $ui-shadow, white $shadow-transition-width),
         linear-gradient(to left, $ui-shadow, white $shadow-transition-width);
@@ -57,6 +57,10 @@ $shadow-transition-width: 10px;
       .component__tooltip-wrapper__element {
         white-space: initial; // wraps long text with tooltip
       }
+
+      tr:hover {
+        background-color: $ui-fleet-black-25-opaque; // opaque needed for horizontal scroll shadow
+      }
     }
 
     tr {
@@ -68,10 +72,6 @@ $shadow-transition-width: 10px;
 
       &.single-row {
         cursor: pointer;
-
-        &:hover {
-          background-color: rgba($core-vibrant-blue, 0.1);
-        }
       }
 
       // override styles of checkbox data cells
@@ -87,7 +87,7 @@ $shadow-transition-width: 10px;
     }
 
     thead {
-      background-color: $ui-off-white;
+      background-color: $ui-fleet-black-25-opaque; // opaque needed for horizontal scroll shadow
       color: $core-fleet-black;
       text-align: left;
       border-bottom: 1px solid $ui-fleet-blue-15;
@@ -226,10 +226,6 @@ $shadow-transition-width: 10px;
         background-color: initial;
       }
     }
-  }
-
-  tr:hover {
-    background-color: $ui-off-white;
   }
 
   .loading-overlay {

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -7,9 +7,6 @@ $shadow-transition-width: 10px;
   width: 100%;
 
   .data-table {
-    overflow: auto;
-    margin: 50px auto;
-
     &__wrapper {
       position: relative;
       border: 1px solid $ui-fleet-blue-15;

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -58,6 +58,11 @@ $shadow-transition-width: 10px;
       tr:hover {
         background-color: $ui-fleet-black-25-opaque; // opaque needed for horizontal scroll shadow
       }
+
+      .single-row:hover {
+        cursor: pointer;
+        background-color: $ui-vibrant-blue-10; // opaque needed for horizontal scroll shadow
+      }
     }
 
     tr {
@@ -65,10 +70,6 @@ $shadow-transition-width: 10px;
 
       &:last-child {
         border-bottom: 0;
-      }
-
-      &.single-row {
-        cursor: pointer;
       }
 
       // override styles of checkbox data cells

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -10,27 +10,6 @@ $shadow-transition-width: 10px;
     overflow: auto;
     margin: 50px auto;
 
-    // Shadow
-    background-image: 
-      /* Shadows */ linear-gradient(
-        to right,
-        white,
-        $ui-off-white-opaque
-      ),
-      linear-gradient(to left, white, $ui-off-white-opaque),
-      /* Shadow covers */
-        linear-gradient(to right, $ui-shadow, white $shadow-transition-width),
-      linear-gradient(to left, $ui-shadow, white $shadow-transition-width);
-
-    background-position: left center, right center, left center, right center;
-    background-repeat: no-repeat;
-    background-color: white;
-    background-size: $shadow-width 100%, $shadow-width 100%, 50% 100%, 50% 100%;
-
-    /* Opera doesn't support this in the shorthand */
-    background-attachment: local, local, scroll, scroll;
-    // End shadow
-
     &__wrapper {
       position: relative;
       border: 1px solid $ui-fleet-blue-15;
@@ -38,6 +17,28 @@ $shadow-transition-width: 10px;
       margin-top: $pad-small;
       flex-grow: 1;
       width: 100%;
+
+      // Shadow
+      background-image: 
+      /* Shadows */ linear-gradient(
+          to right,
+          white,
+          $ui-off-white-opaque
+        ),
+        linear-gradient(to left, white, $ui-off-white-opaque),
+        /* Shadow covers */
+          linear-gradient(to right, $ui-shadow, white $shadow-transition-width),
+        linear-gradient(to left, $ui-shadow, white $shadow-transition-width);
+
+      background-position: left center, right center, left center, right center;
+      background-repeat: no-repeat;
+      background-color: white;
+      background-size: $shadow-width 100%, $shadow-width 100%, 50% 100%,
+        50% 100%;
+
+      /* Opera doesn't support this in the shorthand */
+      background-attachment: local, local, scroll, scroll;
+      // End shadow
     }
 
     &__table {
@@ -86,8 +87,7 @@ $shadow-transition-width: 10px;
     }
 
     thead {
-      overflow: auto;
-      margin: 50px auto;
+      background-color: $ui-off-white;
       color: $core-fleet-black;
       text-align: left;
       border-bottom: 1px solid $ui-fleet-blue-15;
@@ -228,35 +228,9 @@ $shadow-transition-width: 10px;
     }
   }
 
-  // // Shadow
-  // thead,
-  // tr:hover {
-  //   background-image:
-  //     /* Shadows */ linear-gradient(
-  //       to right,
-  //       $ui-off-white,
-  //       $ui-off-white-opaque
-  //     ),
-  //     linear-gradient(to left, $ui-off-white, $ui-off-white-opaque),
-  //     /* Shadow covers */
-  //       linear-gradient(
-  //         to right,
-  //         $ui-shadow,
-  //         $ui-off-white $shadow-transition-width
-  //       ),
-  //     linear-gradient(
-  //       to left,
-  //       $ui-shadow,
-  //       $ui-off-white $shadow-transition-width
-  //     );
-
-  //   background-position: left center, right center, left center, right center;
-  //   background-repeat: no-repeat;
-  //   background-size: $shadow-width 100%, $shadow-width 100%, 50% 100%, 50% 100%;
-
-  //   /* Opera doesn't support this in the shorthand */
-  //   background-attachment: local, local, scroll, scroll;
-  // }
+  tr:hover {
+    background-color: $ui-off-white;
+  }
 
   .loading-overlay {
     display: flex;

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -56,12 +56,12 @@ $shadow-transition-width: 10px;
       }
 
       tr:hover {
-        background-color: $ui-fleet-black-25-opaque; // opaque needed for horizontal scroll shadow
+        background-color: $ui-off-white-opaque; // opaque needed for horizontal scroll shadow
       }
 
       .single-row:hover {
         cursor: pointer;
-        background-color: $ui-vibrant-blue-10; // opaque needed for horizontal scroll shadow
+        background-color: $ui-vibrant-blue-10-opaque; // opaque needed for horizontal scroll shadow
       }
     }
 
@@ -85,7 +85,7 @@ $shadow-transition-width: 10px;
     }
 
     thead {
-      background-color: $ui-fleet-black-25-opaque; // opaque needed for horizontal scroll shadow
+      background-color: $ui-off-white-opaque; // opaque needed for horizontal scroll shadow
       color: $core-fleet-black;
       text-align: left;
       border-bottom: 1px solid $ui-fleet-blue-15;

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -1,15 +1,41 @@
+$shadow-width: 40px;
+$shadow-transition-width: 10px;
+
 .data-table-block {
   position: relative;
   display: inline-block;
   width: 100%;
 
   .data-table {
+    overflow: auto;
+    margin: 50px auto;
+
+    // Shadow
+    background-image: 
+      /* Shadows */ linear-gradient(
+        to right,
+        white,
+        $ui-off-white-opaque
+      ),
+      linear-gradient(to left, white, $ui-off-white-opaque),
+      /* Shadow covers */
+        linear-gradient(to right, $ui-shadow, white $shadow-transition-width),
+      linear-gradient(to left, $ui-shadow, white $shadow-transition-width);
+
+    background-position: left center, right center, left center, right center;
+    background-repeat: no-repeat;
+    background-color: white;
+    background-size: $shadow-width 100%, $shadow-width 100%, 50% 100%, 50% 100%;
+
+    /* Opera doesn't support this in the shorthand */
+    background-attachment: local, local, scroll, scroll;
+    // End shadow
+
     &__wrapper {
       position: relative;
       border: 1px solid $ui-fleet-blue-15;
       border-radius: 6px;
       margin-top: $pad-small;
-      box-shadow: inset -8px 0 17px -10px #e8edf4;
       flex-grow: 1;
       width: 100%;
     }
@@ -60,7 +86,8 @@
     }
 
     thead {
-      background-color: $ui-off-white;
+      overflow: auto;
+      margin: 50px auto;
       color: $core-fleet-black;
       text-align: left;
       border-bottom: 1px solid $ui-fleet-blue-15;
@@ -194,14 +221,42 @@
           font-style: italic;
         }
       }
-      tr:hover {
-        background-color: $ui-off-white;
-      }
+
       .disable-highlight:hover {
         background-color: initial;
       }
     }
   }
+
+  // // Shadow
+  // thead,
+  // tr:hover {
+  //   background-image:
+  //     /* Shadows */ linear-gradient(
+  //       to right,
+  //       $ui-off-white,
+  //       $ui-off-white-opaque
+  //     ),
+  //     linear-gradient(to left, $ui-off-white, $ui-off-white-opaque),
+  //     /* Shadow covers */
+  //       linear-gradient(
+  //         to right,
+  //         $ui-shadow,
+  //         $ui-off-white $shadow-transition-width
+  //       ),
+  //     linear-gradient(
+  //       to left,
+  //       $ui-shadow,
+  //       $ui-off-white $shadow-transition-width
+  //     );
+
+  //   background-position: left center, right center, left center, right center;
+  //   background-repeat: no-repeat;
+  //   background-size: $shadow-width 100%, $shadow-width 100%, 50% 100%, 50% 100%;
+
+  //   /* Opera doesn't support this in the shorthand */
+  //   background-attachment: local, local, scroll, scroll;
+  // }
 
   .loading-overlay {
     display: flex;

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -10,14 +10,19 @@ $core-dark-blue-grey: #506e92;
 // UI
 $ui-fleet-black-75: #515774;
 $ui-fleet-black-50: #8b8fa2;
-$ui-fleet-black-25: #c5c7d1;
+$ui-fleet-black-25: #c5c7d1; // rgba(197, 199, 209)
+$ui-fleet-black-25-opaque: rgba(
+  (255- (0.3 * (255-197))),
+  (255- (0.3 * (255-199))),
+  (255- (0.3 * (255-209))),
+  0.3
+); // Y=255 - P*(255-X) where X is a RGB number, P=opacity (0...1)
 $ui-fleet-blue-15: #e2e4ea;
 $ui-dark-blue-gray: #afbec1;
 $ui-blue-gray: #dbe3e5;
 $ui-gray: #e3e3e3;
 $ui-light-grey: #fafafa;
 $ui-off-white: #f9fafc;
-$ui-off-white-opaque: #f9fafc00;
 $ui-shadow: #e9e9e9;
 $ui-vibrant-blue-50: rgba(106, 103, 254, 0.5);
 $ui-vibrant-blue-25: #d9d9fe;
@@ -51,3 +56,5 @@ $core-vibrant-blue-over: #5855eb;
 $core-vibrant-blue-down: #3f3cd4;
 $core-fleet-blue-over: #303860;
 $core-fleet-blue-down: $core-fleet-black;
+
+$transparent: rgba(255, 255, 255, 0);

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -17,6 +17,8 @@ $ui-blue-gray: #dbe3e5;
 $ui-gray: #e3e3e3;
 $ui-light-grey: #fafafa;
 $ui-off-white: #f9fafc;
+$ui-off-white-opaque: #f9fafc00;
+$ui-shadow: #e9e9e9;
 $ui-vibrant-blue-50: rgba(106, 103, 254, 0.5);
 $ui-vibrant-blue-25: #d9d9fe;
 $ui-vibrant-blue-10: #f1f0ff;

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -26,7 +26,13 @@ $ui-off-white: #f9fafc;
 $ui-shadow: #e9e9e9;
 $ui-vibrant-blue-50: rgba(106, 103, 254, 0.5);
 $ui-vibrant-blue-25: #d9d9fe;
-$ui-vibrant-blue-10: #f1f0ff;
+$ui-vibrant-blue-10: #f1f0ff; // rgba(241, 250, 255, 1)
+$ui-vibrant-blue-10-opaque: rgba(
+  (255- (0.3 * (255-241))),
+  (255- (0.3 * (255-250))),
+  (255- (0.3 * (255-255))),
+  0.3
+); // Y=255 - P*(255-X) where X is a RGB number, P=opacity (0...1)
 
 // Notifications & status & specific messages
 $ui-offline: #8b8fa2;

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -10,29 +10,17 @@ $core-dark-blue-grey: #506e92;
 // UI
 $ui-fleet-black-75: #515774;
 $ui-fleet-black-50: #8b8fa2;
-$ui-fleet-black-25: #c5c7d1; // rgba(197, 199, 209)
-$ui-fleet-black-25-opaque: rgba(
-  (255- (0.3 * (255-197))),
-  (255- (0.3 * (255-199))),
-  (255- (0.3 * (255-209))),
-  0.3
-); // Y=255 - P*(255-X) where X is a RGB number, P=opacity (0...1)
+$ui-fleet-black-25: #c5c7d1;
 $ui-fleet-blue-15: #e2e4ea;
 $ui-dark-blue-gray: #afbec1;
 $ui-blue-gray: #dbe3e5;
 $ui-gray: #e3e3e3;
 $ui-light-grey: #fafafa;
-$ui-off-white: #f9fafc;
+$ui-off-white: #f9fafc; // rgba(249, 250, 252, 1)
 $ui-shadow: #e9e9e9;
 $ui-vibrant-blue-50: rgba(106, 103, 254, 0.5);
 $ui-vibrant-blue-25: #d9d9fe;
-$ui-vibrant-blue-10: #f1f0ff; // rgba(241, 250, 255, 1)
-$ui-vibrant-blue-10-opaque: rgba(
-  (255- (0.3 * (255-241))),
-  (255- (0.3 * (255-250))),
-  (255- (0.3 * (255-255))),
-  0.3
-); // Y=255 - P*(255-X) where X is a RGB number, P=opacity (0...1)
+$ui-vibrant-blue-10: #f1f0ff; // rgba(241, 240, 255, 1)
 
 // Notifications & status & specific messages
 $ui-offline: #8b8fa2;
@@ -64,3 +52,20 @@ $core-fleet-blue-over: #303860;
 $core-fleet-blue-down: $core-fleet-black;
 
 $transparent: rgba(255, 255, 255, 0);
+
+// Opaque colors for row shadows
+// l = lowest color  a = (255-l)/255
+$ui-vibrant-blue-10-alpha: (255-240)/255;
+$ui-vibrant-blue-10-opaque: rgba(
+  (241-240) / $ui-vibrant-blue-10-alpha,
+  (240-240) / $ui-vibrant-blue-10-alpha,
+  (255-240) / $ui-vibrant-blue-10-alpha,
+  $ui-vibrant-blue-10-alpha
+);
+$ui-off-white-alpha: (255-249)/255; // rgba(249, 250, 252)
+$ui-off-white-opaque: rgba(
+  (249-249) / $ui-off-white-alpha,
+  (250-249) / $ui-off-white-alpha,
+  (252-249) / $ui-off-white-alpha,
+  $ui-off-white-alpha
+);

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -53,9 +53,9 @@ $core-fleet-blue-down: $core-fleet-black;
 
 $transparent: rgba(255, 255, 255, 0);
 
-// Opaque colors for row shadows
+// Opaque colors for table shadows
 // l = lowest color  a = (255-l)/255
-$ui-vibrant-blue-10-alpha: (255-240)/255;
+$ui-vibrant-blue-10-alpha: (255-240)/255; // rgba(241, 240, 255)
 $ui-vibrant-blue-10-opaque: rgba(
   (241-240) / $ui-vibrant-blue-10-alpha,
   (240-240) / $ui-vibrant-blue-10-alpha,


### PR DESCRIPTION
### Issue
Cerra #7308

### Solution
- Add left and right shadows to tables that can scroll left and right
- Ensure colors other than white have shadows as well (on hover colors, table header colors)

### Screenshots
#### Clickable row shadows (Note: Only host table is scrollable, but the row isn't clickable, this screenshot does not exist in the app, but is just an example of the shadow shown over the clickable row if it was in a scrollable table)
<img width="1294" alt="Screenshot 2022-12-05 at 8 43 16 AM" src="https://user-images.githubusercontent.com/71795832/205694501-88100758-df89-41c1-afd7-459ad0b2af7d.png">

#### Scroll left only shadow
<img width="1305" alt="Screenshot 2022-12-05 at 8 42 36 AM" src="https://user-images.githubusercontent.com/71795832/205694503-3d0b2376-5d58-436c-bd76-9cf8885d4be8.png">

#### Scroll left and right shadows
<img width="1311" alt="Screenshot 2022-12-05 at 8 42 28 AM" src="https://user-images.githubusercontent.com/71795832/205694510-fc2aebac-54b7-450c-ac78-caee2e7c6d70.png">

#### Scroll right only shadow
<img width="1312" alt="Screenshot 2022-12-05 at 8 42 21 AM" src="https://user-images.githubusercontent.com/71795832/205694517-f7e1349e-c194-4e01-92c4-c149aeb21341.png">

### Engineer self-QAed
- [x] Safari, chrome, firefox
- [x] Left scrollable shadow, right scrollable shadow, not scrollable no shadow
- [x] Clickable row, non clickable row, table header shadows

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality

