### PR TITLE
try using DATE_ADD in test to ensure the timestamp is handled correctly

### DIFF
--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -5402,7 +5402,7 @@ func testHostOrder(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	chk(hosts, "0001", "0003", "0004")
 
-	_, err = ds.writer.Exec(`UPDATE hosts SET created_at = created_at + id`)
+	_, err = ds.writer.Exec(`UPDATE hosts SET created_at = DATE_ADD(created_at, INTERVAL id DAY)`)
 	require.NoError(t, err)
 
 	hosts, err = ds.ListHosts(ctx, fleet.TeamFilter{User: test.UserAdmin}, fleet.HostListOptions{


### PR DESCRIPTION
rel:  https://github.com/fleetdm/fleet/issues/8768 thanks to @gillespi314 for the idea, the test consistently fails with:

```
 === RUN   TestHosts/TestHostOrder
    hosts_test.go:5392: 
        	Error Trace:	/home/runner/work/fleet/fleet/server/datastore/mysql/hosts_test.go:5392
        	            				/home/runner/work/fleet/fleet/server/datastore/mysql/hosts_test.go:5416
        	            				/home/runner/work/fleet/fleet/server/datastore/mysql/hosts_test.go:139
        	Error:      	"[]" should have 3 item(s), but has 0
        	Test:       	TestHosts/TestHostOrder
```

and the relevant code around line `5416`:

```go
	_, err = ds.writer.Exec(`UPDATE hosts SET created_at = created_at + id`)
	require.NoError(t, err)

	hosts, err = ds.ListHosts(ctx, fleet.TeamFilter{User: test.UserAdmin}, fleet.HostListOptions{
		ListOptions: fleet.ListOptions{
			OrderKey:       "created_at",
			After:          "2010-10-22T20:22:03Z",
			OrderDirection: fleet.OrderAscending,
		},
	})
	require.NoError(t, err)
	chk(hosts, "0001", "0004", "0003")
```

This PR changes it to be `UPDATE hosts SET created_at = DATE_ADD(created_at, INTERVAL id DAY)` instead, which seems to fix the issue (so far 3 runs without issues)