### PR TITLE
WIP: Add interpolateParams

### DIFF
--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -21,7 +21,7 @@ func (ds *Datastore) NewActivity(ctx context.Context, user *fleet.User, activity
 		user.ID,
 		user.Name,
 		activityType,
-		detailsBytes,
+		string(detailsBytes),
 	)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "new activity")

--- a/server/datastore/mysql/aggregated_stats.go
+++ b/server/datastore/mysql/aggregated_stats.go
@@ -143,7 +143,7 @@ func calculatePercentiles(ctx context.Context, tx sqlx.ExtContext, aggregate str
 
 	_, err = tx.ExecContext(ctx,
 		`INSERT INTO aggregated_stats(id, type, json_value) VALUES(?, ?, ?) ON DUPLICATE KEY UPDATE json_value=VALUES(json_value)`,
-		id, aggregate, statsJson,
+		id, aggregate, string(statsJson),
 	)
 	if err != nil {
 		return ctxerr.Wrapf(ctx, err, "inserting stats for %s id %d", aggregate, id)

--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -57,7 +57,7 @@ func (ds *Datastore) SaveAppConfig(ctx context.Context, info *fleet.AppConfig) e
 	return ds.withTx(ctx, func(tx sqlx.ExtContext) error {
 		_, err := tx.ExecContext(ctx,
 			`INSERT INTO app_config_json(json_value) VALUES(?) ON DUPLICATE KEY UPDATE json_value = VALUES(json_value)`,
-			configBytes,
+			string(configBytes),
 		)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "insert app_config_json")

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2593,7 +2593,7 @@ ON DUPLICATE KEY UPDATE
     json_value = VALUES(json_value),
     updated_at = CURRENT_TIMESTAMP
 `,
-		id, platformKey("mdm_status", platform), statusJson,
+		id, platformKey("mdm_status", platform), string(statusJson),
 	)
 	if err != nil {
 		return ctxerr.Wrapf(ctx, err, "inserting stats for mdm_status id %d", id)
@@ -2650,7 +2650,7 @@ ON DUPLICATE KEY UPDATE
     json_value = VALUES(json_value),
     updated_at = CURRENT_TIMESTAMP
 `,
-		id, platformKey("mdm_solutions", platform), resultsJSON,
+		id, platformKey("mdm_solutions", platform), string(resultsJSON),
 	)
 	if err != nil {
 		return ctxerr.Wrapf(ctx, err, "inserting stats for mdm_solutions id %d", id)

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2492,7 +2492,7 @@ ON DUPLICATE KEY UPDATE
     json_value = VALUES(json_value),
     updated_at = CURRENT_TIMESTAMP
 `,
-		id, "munki_versions", versionsJson,
+		id, "munki_versions", string(versionsJson),
 	)
 	if err != nil {
 		return ctxerr.Wrapf(ctx, err, "inserting stats for munki_versions id %d", id)
@@ -2541,7 +2541,7 @@ VALUES (?, ?, ?)
 ON DUPLICATE KEY UPDATE
     json_value = VALUES(json_value),
     updated_at = CURRENT_TIMESTAMP
-`, id, "munki_issues", issuesJSON)
+`, id, "munki_issues", string(issuesJSON))
 	if err != nil {
 		return ctxerr.Wrapf(ctx, err, "inserting stats for munki_issues id %d", id)
 	}
@@ -3003,7 +3003,7 @@ func (ds *Datastore) UpdateOSVersions(ctx context.Context) error {
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "marshal os version stats")
 		}
-		args = append(args, id, "os_versions", jsonValue)
+		args = append(args, id, "os_versions", string(jsonValue))
 	}
 
 	insertStmt := "INSERT INTO aggregated_stats (id, type, json_value) VALUES "

--- a/server/datastore/mysql/migrations/tables/20210818151828_AddJSONKeyValueTable.go
+++ b/server/datastore/mysql/migrations/tables/20210818151828_AddJSONKeyValueTable.go
@@ -163,7 +163,7 @@ func Up_20210818151828(tx *sql.Tx) error {
 	//nolint
 	_, err = tx.Exec(
 		`INSERT INTO app_config_json(json_value) VALUES(?) ON DUPLICATE KEY UPDATE json_value = VALUES(json_value)`,
-		configBytes,
+		string(configBytes),
 	)
 	return nil
 }

--- a/server/datastore/mysql/migrations/tables/20220404091216_UpdateAppConfigLogEndpoint.go
+++ b/server/datastore/mysql/migrations/tables/20220404091216_UpdateAppConfigLogEndpoint.go
@@ -50,7 +50,7 @@ func Up_20220404091216(tx *sql.Tx) error {
 	}
 
 	const updateStmt = `UPDATE app_config_json SET json_value = ? WHERE id = 1`
-	if _, err := tx.Exec(updateStmt, b); err != nil {
+	if _, err := tx.Exec(updateStmt, string(b)); err != nil {
 		return errors.Wrap(err, "update app_config_json")
 	}
 

--- a/server/datastore/mysql/migrations/tables/migration.go
+++ b/server/datastore/mysql/migrations/tables/migration.go
@@ -76,7 +76,7 @@ func updateAppConfigJSON(tx *sql.Tx, fn func(config *fleet.AppConfig) error) err
 	}
 
 	const updateStmt = `UPDATE app_config_json SET json_value = ? WHERE id = 1`
-	if _, err := tx.Exec(updateStmt, b); err != nil {
+	if _, err := tx.Exec(updateStmt, string(b)); err != nil {
 		return errors.Wrap(err, "update app_config_json")
 	}
 

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -983,6 +983,7 @@ func generateMysqlConnectionString(conf config.MysqlConfig) string {
 		"allowNativePasswords": []string{"true"},
 		"group_concat_max_len": []string{"4194304"},
 		"multiStatements":      []string{"true"},
+		"interpolateParams":    []string{"true"},
 	}
 	if conf.TLSConfig != "" {
 		params.Set("tls", conf.TLSConfig)

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -782,7 +782,7 @@ func incrementViolationDaysDB(ctx context.Context, tx sqlx.ExtContext) error {
 		VALUES (?, ?, ?)
 		ON DUPLICATE KEY UPDATE 
 			json_value = VALUES(json_value)`
-	if _, err := tx.ExecContext(ctx, upsertStmt, statsID, statsType, statsJSON); err != nil {
+	if _, err := tx.ExecContext(ctx, upsertStmt, statsID, statsType, string(statsJSON)); err != nil {
 		return ctxerr.Wrap(ctx, err, "update policy violation days aggregated stats")
 	}
 
@@ -813,7 +813,7 @@ func initializePolicyViolationDaysDB(ctx context.Context, tx sqlx.ExtContext) er
 		ON DUPLICATE KEY UPDATE 
 			json_value = VALUES(json_value),
 			created_at = CURRENT_TIMESTAMP`
-	if _, err := tx.ExecContext(ctx, stmt, statsID, statsType, statsJSON); err != nil {
+	if _, err := tx.ExecContext(ctx, stmt, statsID, statsType, string(statsJSON)); err != nil {
 		return ctxerr.Wrap(ctx, err, "initialize policy violation days aggregated stats")
 	}
 


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
