### PR TITLE
Revert "Add MDM-enforced OS autoupdate query"

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -1034,19 +1034,3 @@ spec:
   purpose: inventory
   tags: inventory
   contributors: zwass
----
-apiVersion: v1
-kind: query
-spec:
-  name: macOS Auto-updates enforced by MDM
-  platform: darwin
-  description: Finds all hosts where a mobile device management (MDM) solution enforces macOS auto-updates.
-  query: >-
-    SELECT * 
-    FROM managed_policies AS mp
-    WHERE mp.domain = "com.apple.SoftwareUpdate"
-    AND mp.name = "AutomaticallyInstallMacOSUpdates"
-    AND mp.value = "0";
-  purpose: compliance
-  tags: compliance
-  contributors: zhumo


### PR DESCRIPTION
Reverts fleetdm/fleet#8927

This query already existed here: https://fleetdm.com/queries/automatic-installation-of-operating-system-updates-is-enabled-mac-os. I didn't see it because of the "built-in" default filter. 