### PR TITLE
Add required values to `icloud_private_relay` table YAML file

### DIFF
--- a/schema/tables/icloud_private_relay.yml
+++ b/schema/tables/icloud_private_relay.yml
@@ -1,7 +1,12 @@
 name: icloud_private_relay
-description: Whether (iCloud Private Relay)[https://support.apple.com/en-us/HT212614] is enabled.
+platforms:
+  - macOS
+description: Whether [iCloud Private Relay](https://support.apple.com/en-us/HT212614) is enabled.
 columns: 
   - name: status
+    type: integer
+    required: false
     description: whether iCloud Private Relay is on or off. 1 is on. 0 is off.
 notes: >-
   - This table is not a core osquery table. It is included as part of Fleetd, the osquery manager from Fleet. 
+evented: false


### PR DESCRIPTION
The `icloud_private_relay` YAML file added in https://github.com/fleetdm/fleet/pull/8910 is missing some required values and is currently causing the website's build script to fail.

Changes:
- Updated the `icloud_private_relay` table YAML file to have all of the required values.
- Fixed a Markdown link in the `icloud_private_relay` table's description
