### PR TITLE
Add MDM Card to Windows and All Dashboards and change mdm data source on host details page

### DIFF
--- a/changes/issue-7861-add-mdm-info-to-windows_all-and-host-details
+++ b/changes/issue-7861-add-mdm-info-to-windows_all-and-host-details
@@ -1,2 +1,4 @@
-- add counts_update_at attribute to GET /hosts/summary/mdm response. add mdm information to UI for
+- add counts_update_at attribute to GET /hosts/summary/mdm response. update GET /labels/:id/hosts to
+  filter by mdm_id and mdm_enrollment_status query params. add mobile_device_management_solution to
+  response from GET /labels/:id/hosts when including mdm_id query param. add mdm information to UI for
   windows/all dashboard and host details.

--- a/changes/issue-7861-add-mdm-info-to-windows_all-and-host-details
+++ b/changes/issue-7861-add-mdm-info-to-windows_all-and-host-details
@@ -1,0 +1,2 @@
+- add counts_update_at attribute to GET /hosts/summary/mdm response. add mdm information to UI for
+  windows/all dashboard and host details.

--- a/cypress/integration/pages/dashboardPage.ts
+++ b/cypress/integration/pages/dashboardPage.ts
@@ -16,7 +16,6 @@ const dashboardPage = {
         cy.getAttached(".dashboard-page__wrapper").within(() => {
           cy.findByText(/platform/i).should("exist");
           cy.getAttached(".hosts-summary").should("exist");
-          cy.getAttached(".home-mdm").should("exist");
           cy.getAttached(".operating-systems").should("exist");
           // "get" because we expect it not to exist
           cy.get(".home-software").should("not.exist");

--- a/cypress/integration/pages/hostDetailsPage.ts
+++ b/cypress/integration/pages/hostDetailsPage.ts
@@ -38,7 +38,7 @@ const hostDetailsPage = {
       });
   },
 
-  allowsTransferHost: (create: boolean) => {
+  allowsTransferHost: (create?: boolean) => {
     cy.findByRole("button", { name: /transfer/i }).click();
     if (create) {
       cy.findByText(/create a team/i).should("exist");

--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -3233,8 +3233,8 @@ Returns a list of the hosts that belong to the specified label.
 | query                    | string  | query | Search query keywords. Searchable fields include `hostname`, `machine_serial`, `uuid`, and `ipv4`.                                                                                                                         |
 | team_id                  | integer | query | _Available in Fleet Premium_ Filters the hosts to only include hosts in the specified team.                                                                                                                                |
 | disable_failing_policies | boolean | query | If "true", hosts will return failing policies as 0 regardless of whether there are any that failed for the host. This is meant to be used when increased performance is needed in exchange for the extra information.      |
+| mdm_id                  | integer | query | The ID of the _mobile device management_ (MDM) solution to filter hosts by (that is, filter hosts that use a specific MDM provider and URL).      |
 | low_disk_space           | integer | query | _Available in Fleet Premium_ Filters the hosts to only include hosts with less GB of disk space available than this value. Must be a number between 1-100.                                                                 |
-
 #### Example
 
 `GET /api/v1/fleet/labels/6/hosts&query=floobar`

--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -2611,6 +2611,7 @@ Retrieves MDM enrollment summary. Windows servers are excluded from the aggregat
 
 ```json
 {
+  "counts_updated_at": "2021-03-21T12:32:44Z",
   "mobile_device_management_enrollment_status": {
     "enrolled_manual_hosts_count": 0,
     "enrolled_automated_hosts_count": 2,
@@ -2724,7 +2725,7 @@ Retrieves aggregated host's MDM enrollment status and Munki versions.
 ```json
 {
   "macadmins": {
-    "counts_updated_at": "2021-03-21 12:32:44",
+    "counts_updated_at": "2021-03-21T12:32:44Z",
     "munki_versions": [
       {
         "version": "5.5",

--- a/frontend/__mocks__/mdmMock.ts
+++ b/frontend/__mocks__/mdmMock.ts
@@ -1,0 +1,28 @@
+import { IHostMdmData } from "interfaces/host";
+import { IMdmSolution } from "interfaces/mdm";
+
+const DEFAULT_MDM_SOLUTION_MOCK: IMdmSolution = {
+  id: 1,
+  name: "MDM Solution",
+  server_url: "http://mdmsolution.com",
+  hosts_count: 5,
+};
+
+export const createMockMdmSolution = (
+  overrides?: Partial<IMdmSolution>
+): IMdmSolution => {
+  return { ...DEFAULT_MDM_SOLUTION_MOCK, ...overrides };
+};
+
+const DEFAULT_HOST_MDM_DATA: IHostMdmData = {
+  enrollment_status: "Enrolled (automatic)",
+  server_url: "http://mdmsolution.com",
+  name: "MDM Solution",
+  id: 1,
+};
+
+export const createMockHostMdmData = (
+  overrides?: Partial<IHostMdmData>
+): IHostMdmData => {
+  return { ...DEFAULT_HOST_MDM_DATA, ...overrides };
+};

--- a/frontend/components/ViewAllHostsLink/ViewAllHostsLink.tsx
+++ b/frontend/components/ViewAllHostsLink/ViewAllHostsLink.tsx
@@ -9,6 +9,8 @@ import { buildQueryStringFromParams, QueryParams } from "utilities/url";
 interface IHostLinkProps {
   queryParams?: QueryParams;
   className?: string;
+  /** Including the platformId will view all hosts for the platform provided */
+  platformLabelId?: number;
   /** Shows right chevron without text */
   condensed?: boolean;
 }
@@ -18,13 +20,18 @@ const baseClass = "view-all-hosts-link";
 const ViewAllHostsLink = ({
   queryParams,
   className,
+  platformLabelId,
   condensed = false,
 }: IHostLinkProps): JSX.Element => {
   const viewAllHostsLinkClass = classnames(baseClass, className);
 
-  const path = queryParams
-    ? `${PATHS.MANAGE_HOSTS}?${buildQueryStringFromParams(queryParams)}`
+  const endpoint = platformLabelId
+    ? PATHS.MANAGE_HOSTS_LABEL(platformLabelId)
     : PATHS.MANAGE_HOSTS;
+
+  const path = queryParams
+    ? `${endpoint}?${buildQueryStringFromParams(queryParams)}`
+    : endpoint;
 
   return (
     <Link className={viewAllHostsLinkClass} to={path} title="host-link">

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -85,7 +85,7 @@ export interface IMunkiData {
   version: string;
 }
 
-export interface IMDMData {
+export interface IHostMdmData {
   enrollment_status: string;
   server_url: string;
   id: number;
@@ -102,7 +102,7 @@ export interface IMunkiIssue {
 export interface IMacadminsResponse {
   macadmins: null | {
     munki: null | IMunkiData;
-    mobile_device_management: null | IMDMData;
+    mobile_device_management: null | IHostMdmData;
     munki_issues: IMunkiIssue[];
   };
 }
@@ -202,7 +202,7 @@ export interface IHost {
   users: IHostUser[];
   device_users?: IDeviceUser[];
   munki?: IMunkiData;
-  mdm?: IMDMData;
+  mdm?: IHostMdmData;
   policies: IHostPolicy[];
   query_results?: unknown[];
   geolocation?: IGeoLocation;

--- a/frontend/interfaces/macadmins.ts
+++ b/frontend/interfaces/macadmins.ts
@@ -1,7 +1,4 @@
-export interface IMdmEnrollmentCardData {
-  status: "Enrolled (manual)" | "Enrolled (automatic)" | "Unenrolled";
-  hosts: number;
-}
+import { IMdmAggregateStatus, IMdmSolution } from "./mdm";
 
 export interface IMunkiVersionsAggregate {
   version: string;
@@ -14,18 +11,6 @@ export interface IMunkiIssuesAggregate {
   type: "error" | "warning";
   hosts_count: number;
 }
-export interface IMdmAggregateStatus {
-  enrolled_manual_hosts_count: number;
-  enrolled_automated_hosts_count: number;
-  unenrolled_hosts_count: number;
-}
-
-export interface IMdmSolution {
-  id: number;
-  name: string | null;
-  server_url: string;
-  hosts_count: number;
-}
 
 export interface IMacadminAggregate {
   macadmins: {
@@ -35,17 +20,4 @@ export interface IMacadminAggregate {
     mobile_device_management_enrollment_status: IMdmAggregateStatus;
     mobile_device_management_solution: IMdmSolution[] | null;
   };
-}
-
-interface IMdmEnrollementStatus {
-  enrolled_manual_hosts_count: number;
-  enrolled_automated_hosts_count: number;
-  unenrolled_hosts_count: number;
-  hosts_count: number;
-}
-
-export interface IMdmSummaryResponse {
-  counts_updated_at: string;
-  mobile_device_management_enrollment_status: IMdmEnrollementStatus;
-  mobile_device_management_solution: IMdmSolution[] | null;
 }

--- a/frontend/interfaces/macadmins.ts
+++ b/frontend/interfaces/macadmins.ts
@@ -1,4 +1,4 @@
-export interface IDataTableMdmFormat {
+export interface IMdmEnrollmentCardData {
   status: "Enrolled (manual)" | "Enrolled (automatic)" | "Unenrolled";
   hosts: number;
 }
@@ -35,4 +35,16 @@ export interface IMacadminAggregate {
     mobile_device_management_enrollment_status: IMdmAggregateStatus;
     mobile_device_management_solution: IMdmSolution[] | null;
   };
+}
+
+interface IMdmEnrollementStatus {
+  enrolled_manual_hosts_count: number;
+  enrolled_automated_hosts_count: number;
+  unenrolled_hosts_count: number;
+  hosts_count: number;
+}
+
+export interface IMdmSummaryResponse {
+  mobile_device_management_enrollment_status: IMdmEnrollementStatus;
+  mobile_device_management_solution: IMdmSolution[] | null;
 }

--- a/frontend/interfaces/macadmins.ts
+++ b/frontend/interfaces/macadmins.ts
@@ -45,6 +45,7 @@ interface IMdmEnrollementStatus {
 }
 
 export interface IMdmSummaryResponse {
+  counts_updated_at: string;
   mobile_device_management_enrollment_status: IMdmEnrollementStatus;
   mobile_device_management_solution: IMdmSolution[] | null;
 }

--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -28,10 +28,3 @@ export interface IMdmSummaryResponse {
   mobile_device_management_enrollment_status: IMdmEnrollementStatus;
   mobile_device_management_solution: IMdmSolution[] | null;
 }
-
-export interface IHostMdmResponse {
-  enrollment_status: string | null;
-  server_url: string | null;
-  name: string | null;
-  id: number;
-}

--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -1,0 +1,37 @@
+export interface IMdmEnrollmentCardData {
+  status: "Enrolled (manual)" | "Enrolled (automatic)" | "Unenrolled";
+  hosts: number;
+}
+
+export interface IMdmAggregateStatus {
+  enrolled_manual_hosts_count: number;
+  enrolled_automated_hosts_count: number;
+  unenrolled_hosts_count: number;
+}
+
+export interface IMdmSolution {
+  id: number;
+  name: string | null;
+  server_url: string;
+  hosts_count: number;
+}
+
+interface IMdmEnrollementStatus {
+  enrolled_manual_hosts_count: number;
+  enrolled_automated_hosts_count: number;
+  unenrolled_hosts_count: number;
+  hosts_count: number;
+}
+
+export interface IMdmSummaryResponse {
+  counts_updated_at: string;
+  mobile_device_management_enrollment_status: IMdmEnrollementStatus;
+  mobile_device_management_solution: IMdmSolution[] | null;
+}
+
+export interface IHostMdmResponse {
+  enrollment_status: string | null;
+  server_url: string | null;
+  name: string | null;
+  id: number;
+}

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -555,6 +555,7 @@ const DashboardPage = ({
         error={errorMdm}
         mdmEnrollmentData={mdmEnrollmentData}
         mdmSolutions={mdmSolutions}
+        selectedPlatformLabelId={selectedPlatformLabelId}
       />
     ),
   });

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -368,6 +368,8 @@ const DashboardPage = ({
       if (selectedPlatform !== "all") {
         const labelValue = PLATFORM_NAME_TO_LABEL_NAME[selectedPlatform];
         setSelectedPlatformLabelId(getLabel(labelValue, labels)?.id);
+      } else {
+        setSelectedPlatformLabelId(undefined);
       }
     }
   }, [labels, selectedPlatform]);

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -12,13 +12,15 @@ import {
 import { IHostSummary, IHostSummaryPlatforms } from "interfaces/host_summary";
 import { ILabelSummary } from "interfaces/label";
 import {
-  IMdmEnrollmentCardData,
-  IMdmSolution,
   IMacadminAggregate,
   IMunkiIssuesAggregate,
   IMunkiVersionsAggregate,
-  IMdmSummaryResponse,
 } from "interfaces/macadmins";
+import {
+  IMdmEnrollmentCardData,
+  IMdmSolution,
+  IMdmSummaryResponse,
+} from "interfaces/mdm";
 import { ISelectedPlatform } from "interfaces/platform";
 import { ISoftwareResponse } from "interfaces/software";
 import { ITeam } from "interfaces/team";
@@ -294,11 +296,7 @@ const DashboardPage = ({
           hosts_count,
         } = mobile_device_management_enrollment_status;
 
-        if (
-          hosts_count === 0 &&
-          (mobile_device_management_solution === null ||
-            mobile_device_management_solution.length === 0)
-        ) {
+        if (hosts_count === 0 && mobile_device_management_solution === null) {
           setShowMdmCard(false);
           return;
         }
@@ -322,9 +320,6 @@ const DashboardPage = ({
         ]);
         setMdmSolutions(mobile_device_management_solution);
         setShowMdmCard(true);
-      },
-      onError: (err) => {
-        console.error("err", err);
       },
     }
   );
@@ -552,7 +547,7 @@ const DashboardPage = ({
     titleDetail: mdmTitleDetail,
     showTitle: !isMacAdminsFetching,
     description: (
-      <p>MDM is used to manage configuration on your workstations.</p>
+      <p>MDM can be used to manage configuration on your workstations.</p>
     ),
     children: (
       <Mdm

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -107,6 +107,7 @@ const DashboardPage = ({
   const [softwarePageIndex, setSoftwarePageIndex] = useState(0);
   const [softwareActionUrl, setSoftwareActionUrl] = useState<string>();
   const [showMunkiCard, setShowMunkiCard] = useState(true);
+  const [showMdmCard, setShowMdmCard] = useState(true);
   const [showAddHostsModal, setShowAddHostsModal] = useState(false);
   const [showOperatingSystemsUI, setShowOperatingSystemsUI] = useState(false);
   const [showHostsUI, setShowHostsUI] = useState(false); // Hides UI on first load only
@@ -282,12 +283,32 @@ const DashboardPage = ({
       enabled: selectedPlatform !== "linux",
       onSuccess: (data) => {
         const {
+          mobile_device_management_enrollment_status,
+          mobile_device_management_solution,
+          counts_updated_at,
+        } = data;
+        const {
           enrolled_manual_hosts_count,
           enrolled_automated_hosts_count,
           unenrolled_hosts_count,
-        } = data.mobile_device_management_enrollment_status;
+          hosts_count,
+        } = mobile_device_management_enrollment_status;
 
-        setMdmTitleDetail(<p>TODO LAST UPDATED</p>);
+        if (
+          hosts_count === 0 &&
+          (mobile_device_management_solution === null ||
+            mobile_device_management_solution.length === 0)
+        ) {
+          setShowMdmCard(false);
+          return;
+        }
+
+        setMdmTitleDetail(
+          <LastUpdatedText
+            lastUpdatedAt={counts_updated_at}
+            whatToRetrieve={"MDM information"}
+          />
+        );
         setMdmEnrollmentData([
           {
             status: "Enrolled (manual)",
@@ -299,7 +320,8 @@ const DashboardPage = ({
           },
           { status: "Unenrolled", hosts: unenrolled_hosts_count },
         ]);
-        setMdmSolutions(data.mobile_device_management_solution);
+        setMdmSolutions(mobile_device_management_solution);
+        setShowMdmCard(true);
       },
       onError: (err) => {
         console.error("err", err);
@@ -569,6 +591,7 @@ const DashboardPage = ({
           )}
         {SoftwareCard}
         {!currentTeam && isOnGlobalTeam && <>{ActivityFeedCard}</>}
+        {showMdmCard && <>{MDMCard}</>}
       </div>
     );
   };
@@ -576,7 +599,7 @@ const DashboardPage = ({
   const macOSLayout = () => (
     <>
       <div className={`${baseClass}__section`}>{OperatingSystemsCard}</div>
-      <div className={`${baseClass}__section`}>{MDMCard}</div>
+      {showMdmCard && <div className={`${baseClass}__section`}>{MDMCard}</div>}
       {showMunkiCard && (
         <div className={`${baseClass}__section`}>{MunkiCard}</div>
       )}
@@ -584,7 +607,10 @@ const DashboardPage = ({
   );
 
   const windowsLayout = () => (
-    <div className={`${baseClass}__section`}>{OperatingSystemsCard}</div>
+    <>
+      <div className={`${baseClass}__section`}>{OperatingSystemsCard}</div>
+      {showMdmCard && <div className={`${baseClass}__section`}>{MDMCard}</div>}
+    </>
   );
   const linuxLayout = () => null;
 

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tests.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { renderWithSetup } from "test/testingUtils";
+
+import { createMockMdmSolution } from "__mocks__/mdmMock";
+
+import MDM from "./MDM";
+
+describe("MDM Card", () => {
+  it("render the correct number of MDM solutions", () => {
+    render(
+      <MDM
+        error={null}
+        isFetching={false}
+        mdmEnrollmentData={[]}
+        mdmSolutions={[
+          createMockMdmSolution(),
+          createMockMdmSolution({ id: 2 }),
+        ]}
+      />
+    );
+
+    expect(screen.getAllByText("MDM Solution").length).toBe(2);
+  });
+
+  it("render the correct number of Enrollment status", async () => {
+    const { user } = renderWithSetup(
+      <MDM
+        error={null}
+        isFetching={false}
+        mdmEnrollmentData={[
+          { status: "Enrolled (automatic)", hosts: 10 },
+          { status: "Enrolled (manual)", hosts: 5 },
+          { status: "Unenrolled", hosts: 1 },
+        ]}
+        mdmSolutions={[]}
+      />
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Enrollment" }));
+
+    expect(
+      screen.getByRole("row", {
+        name: /Enrolled \(automatic\)(.*?)10 host/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("row", {
+        name: /Enrolled \(manual\)(.*?)5 host/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("row", {
+        name: /Unenrolled(.*?)1 host/i,
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tests.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { renderWithSetup } from "test/testingUtils";
+import { renderWithSetup } from "test/test-utils";
 
 import { createMockMdmSolution } from "__mocks__/mdmMock";
 

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
@@ -11,7 +11,10 @@ import {
   generateSolutionsTableHeaders,
   generateSolutionsDataSet,
 } from "./MDMSolutionsTableConfig";
-import generateEnrollmentTableHeaders from "./MDMEnrollmentTableConfig";
+import {
+  generateEnrollmentTableHeaders,
+  generateEnrollmentDataSet,
+} from "./MDMEnrollmentTableConfig";
 
 interface IMdmCardProps {
   error: Error | null;
@@ -74,6 +77,10 @@ const Mdm = ({
     mdmSolutions,
     selectedPlatformLabelId
   );
+  const enrollmentDataSet = generateEnrollmentDataSet(
+    mdmEnrollmentData,
+    selectedPlatformLabelId
+  );
 
   // Renders opaque information as host information is loading
   const opacity = isFetching ? { opacity: 0 } : { opacity: 1 };
@@ -120,7 +127,7 @@ const Mdm = ({
               ) : (
                 <TableContainer
                   columns={enrollmentTableHeaders}
-                  data={mdmEnrollmentData}
+                  data={enrollmentDataSet}
                   isLoading={isFetching}
                   defaultSortHeader={ENROLLMENT_DEFAULT_SORT_HEADER}
                   defaultSortDirection={ENROLLMENT_DEFAULT_SORT_DIRECTION}

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 
-import { IMdmEnrollmentCardData, IMdmSolution } from "interfaces/macadmins";
+import { IMdmEnrollmentCardData, IMdmSolution } from "interfaces/mdm";
 
 import TabsWrapper from "components/TabsWrapper";
 import TableContainer from "components/TableContainer";

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 
-import { IDataTableMdmFormat, IMdmSolution } from "interfaces/macadmins";
+import { IMdmEnrollmentCardData, IMdmSolution } from "interfaces/macadmins";
 
 import TabsWrapper from "components/TabsWrapper";
 import TableContainer from "components/TableContainer";
@@ -14,9 +14,9 @@ import {
 import generateEnrollmentTableHeaders from "./MDMEnrollmentTableConfig";
 
 interface IMdmCardProps {
-  errorMacAdmins: Error | null;
-  isMacAdminsFetching: boolean;
-  formattedMdmData: IDataTableMdmFormat[];
+  error: Error | null;
+  isFetching: boolean;
+  mdmEnrollmentData: IMdmEnrollmentCardData[];
   mdmSolutions: IMdmSolution[] | null;
 }
 
@@ -55,9 +55,9 @@ const EmptyMdmSolutions = (): JSX.Element => (
 );
 
 const Mdm = ({
-  isMacAdminsFetching,
-  errorMacAdmins,
-  formattedMdmData,
+  isFetching,
+  error,
+  mdmEnrollmentData,
   mdmSolutions,
 }: IMdmCardProps): JSX.Element => {
   const [navTabIndex, setNavTabIndex] = useState(0);
@@ -71,11 +71,11 @@ const Mdm = ({
   const solutionsDataSet = generateSolutionsDataSet(mdmSolutions);
 
   // Renders opaque information as host information is loading
-  const opacity = isMacAdminsFetching ? { opacity: 0 } : { opacity: 1 };
+  const opacity = isFetching ? { opacity: 0 } : { opacity: 1 };
 
   return (
     <div className={baseClass}>
-      {isMacAdminsFetching && (
+      {isFetching && (
         <div className="spinner">
           <Spinner />
         </div>
@@ -88,13 +88,13 @@ const Mdm = ({
               <Tab>Enrollment</Tab>
             </TabList>
             <TabPanel>
-              {errorMacAdmins ? (
+              {error ? (
                 <TableDataError card />
               ) : (
                 <TableContainer
                   columns={solutionsTableHeaders}
                   data={solutionsDataSet}
-                  isLoading={isMacAdminsFetching}
+                  isLoading={isFetching}
                   defaultSortHeader={SOLUTIONS_DEFAULT_SORT_HEADER}
                   defaultSortDirection={DEFAULT_SORT_DIRECTION}
                   hideActionButton
@@ -110,13 +110,13 @@ const Mdm = ({
               )}
             </TabPanel>
             <TabPanel>
-              {errorMacAdmins ? (
+              {error ? (
                 <TableDataError card />
               ) : (
                 <TableContainer
                   columns={enrollmentTableHeaders}
-                  data={formattedMdmData}
-                  isLoading={isMacAdminsFetching}
+                  data={mdmEnrollmentData}
+                  isLoading={isFetching}
                   defaultSortHeader={ENROLLMENT_DEFAULT_SORT_HEADER}
                   defaultSortDirection={ENROLLMENT_DEFAULT_SORT_DIRECTION}
                   hideActionButton

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
@@ -18,6 +18,7 @@ interface IMdmCardProps {
   isFetching: boolean;
   mdmEnrollmentData: IMdmEnrollmentCardData[];
   mdmSolutions: IMdmSolution[] | null;
+  selectedPlatformLabelId?: number;
 }
 
 const DEFAULT_SORT_DIRECTION = "desc";
@@ -59,6 +60,7 @@ const Mdm = ({
   error,
   mdmEnrollmentData,
   mdmSolutions,
+  selectedPlatformLabelId,
 }: IMdmCardProps): JSX.Element => {
   const [navTabIndex, setNavTabIndex] = useState(0);
 
@@ -68,7 +70,10 @@ const Mdm = ({
 
   const solutionsTableHeaders = generateSolutionsTableHeaders();
   const enrollmentTableHeaders = generateEnrollmentTableHeaders();
-  const solutionsDataSet = generateSolutionsDataSet(mdmSolutions);
+  const solutionsDataSet = generateSolutionsDataSet(
+    mdmSolutions,
+    selectedPlatformLabelId
+  );
 
   // Renders opaque information as host information is loading
   const opacity = isFetching ? { opacity: 0 } : { opacity: 1 };

--- a/frontend/pages/DashboardPage/cards/MDM/MDMEnrollmentTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDMEnrollmentTableConfig.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { IMdmEnrollmentCardData } from "interfaces/macadmins";
+import { IMdmEnrollmentCardData } from "interfaces/mdm";
 
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import TooltipWrapper from "components/TooltipWrapper";

--- a/frontend/pages/DashboardPage/cards/MDM/MDMEnrollmentTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDMEnrollmentTableConfig.tsx
@@ -50,17 +50,17 @@ const enrollmentTableHeaders = [
         if (status === "Enrolled (automatic)") {
           return `
                 <span>
-                  Hosts automatically enrolled to an MDM solution <br/>
-                  the first time the host is used. Administrators <br />
-                  might have a higher level of control over these <br />
-                  hosts.
+                  Hosts automatically enrolled to an MDM solution <br />
+                  using Apple Automated Device Enrollment (DEP) <br />
+                  or Windows Autopilot. Administrators can block <br />
+                  users from unenrolling these hosts from MDM.
                 </span>
               `;
         }
         return `
                 <span>
-                  Hosts manually enrolled to an MDM solution by a<br />
-                  user or administrator.
+                  Hosts manually enrolled to an MDM solution. Users <br />
+                  can unenroll these hosts from MDM.
                 </span>
               `;
       };

--- a/frontend/pages/DashboardPage/cards/MDM/MDMEnrollmentTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDMEnrollmentTableConfig.tsx
@@ -6,6 +6,10 @@ import TextCell from "components/TableContainer/DataTable/TextCell";
 import TooltipWrapper from "components/TooltipWrapper";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 
+interface IIMdmEnrollmentData extends IMdmEnrollmentCardData {
+  selectedPlatformLabelId?: number;
+}
+
 // NOTE: cellProps come from react-table
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
 interface ICellProps {
@@ -13,7 +17,7 @@ interface ICellProps {
     value: string;
   };
   row: {
-    original: IMdmEnrollmentCardData;
+    original: IIMdmEnrollmentData;
   };
 }
 
@@ -106,6 +110,7 @@ const enrollmentTableHeaders = [
         <ViewAllHostsLink
           queryParams={{ mdm_enrollment_status: statusParam() }}
           className="mdm-solution-link"
+          platformLabelId={cellProps.row.original.selectedPlatformLabelId}
         />
       );
     },
@@ -113,8 +118,28 @@ const enrollmentTableHeaders = [
   },
 ];
 
-const generateEnrollmentTableHeaders = (): IDataColumn[] => {
+export const generateEnrollmentTableHeaders = (): IDataColumn[] => {
   return enrollmentTableHeaders;
 };
 
-export default generateEnrollmentTableHeaders;
+const enhanceEnrollmentData = (
+  enrollmentData: IMdmEnrollmentCardData[],
+  selectedPlatformLabelId?: number
+): IIMdmEnrollmentData[] => {
+  return Object.values(enrollmentData).map((data) => {
+    return {
+      ...data,
+      selectedPlatformLabelId,
+    };
+  });
+};
+
+export const generateEnrollmentDataSet = (
+  enrollmentData: IMdmEnrollmentCardData[] | null,
+  selectedPlatformLabelId?: number
+): IIMdmEnrollmentData[] => {
+  if (!enrollmentData) {
+    return [];
+  }
+  return [...enhanceEnrollmentData(enrollmentData, selectedPlatformLabelId)];
+};

--- a/frontend/pages/DashboardPage/cards/MDM/MDMEnrollmentTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDMEnrollmentTableConfig.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { IDataTableMdmFormat } from "interfaces/macadmins";
+import { IMdmEnrollmentCardData } from "interfaces/macadmins";
 
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import TooltipWrapper from "components/TooltipWrapper";
@@ -13,7 +13,7 @@ interface ICellProps {
     value: string;
   };
   row: {
-    original: IDataTableMdmFormat;
+    original: IMdmEnrollmentCardData;
   };
 }
 

--- a/frontend/pages/DashboardPage/cards/MDM/MDMEnrollmentTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDMEnrollmentTableConfig.tsx
@@ -6,7 +6,7 @@ import TextCell from "components/TableContainer/DataTable/TextCell";
 import TooltipWrapper from "components/TooltipWrapper";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 
-interface IIMdmEnrollmentData extends IMdmEnrollmentCardData {
+interface IMdmEnrollmentData extends IMdmEnrollmentCardData {
   selectedPlatformLabelId?: number;
 }
 
@@ -17,7 +17,7 @@ interface ICellProps {
     value: string;
   };
   row: {
-    original: IIMdmEnrollmentData;
+    original: IMdmEnrollmentData;
   };
 }
 
@@ -125,7 +125,7 @@ export const generateEnrollmentTableHeaders = (): IDataColumn[] => {
 const enhanceEnrollmentData = (
   enrollmentData: IMdmEnrollmentCardData[],
   selectedPlatformLabelId?: number
-): IIMdmEnrollmentData[] => {
+): IMdmEnrollmentData[] => {
   return Object.values(enrollmentData).map((data) => {
     return {
       ...data,
@@ -137,7 +137,7 @@ const enhanceEnrollmentData = (
 export const generateEnrollmentDataSet = (
   enrollmentData: IMdmEnrollmentCardData[] | null,
   selectedPlatformLabelId?: number
-): IIMdmEnrollmentData[] => {
+): IMdmEnrollmentData[] => {
   if (!enrollmentData) {
     return [];
   }

--- a/frontend/pages/DashboardPage/cards/MDM/MDMSolutionsTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDMSolutionsTableConfig.tsx
@@ -123,5 +123,3 @@ export const generateSolutionsDataSet = (
   }
   return [...enhanceSolutionsData(solutions, selectedPlatformLabelId)];
 };
-
-export default { generateSolutionsTableHeaders, generateSolutionsDataSet };

--- a/frontend/pages/DashboardPage/cards/MDM/MDMSolutionsTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDMSolutionsTableConfig.tsx
@@ -9,12 +9,17 @@ import ViewAllHostsLink from "components/ViewAllHostsLink";
 
 // NOTE: cellProps come from react-table
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
+
+interface IMDMSolutionWithPlatformId extends IMdmSolution {
+  selectedPlatformLabelId?: number;
+}
+
 interface ICellProps {
   cell: {
     value: string;
   };
   row: {
-    original: IMdmSolution;
+    original: IMDMSolutionWithPlatformId;
   };
 }
 
@@ -82,6 +87,7 @@ const solutionsTableHeaders = [
         <ViewAllHostsLink
           queryParams={{ mdm_id: cellProps.row.original.id }}
           className="mdm-solution-link"
+          platformLabelId={cellProps.row.original.selectedPlatformLabelId}
         />
       );
     },
@@ -93,24 +99,29 @@ export const generateSolutionsTableHeaders = (): IDataColumn[] => {
   return solutionsTableHeaders;
 };
 
-const enhanceSolutionsData = (solutions: IMdmSolution[]): IMdmSolution[] => {
+const enhanceSolutionsData = (
+  solutions: IMdmSolution[],
+  selectedPlatformLabelId?: number
+): IMdmSolution[] => {
   return Object.values(solutions).map((solution) => {
     return {
       id: solution.id,
       name: solution.name || "Unknown",
       server_url: solution.server_url,
       hosts_count: solution.hosts_count,
+      selectedPlatformLabelId,
     };
   });
 };
 
 export const generateSolutionsDataSet = (
-  solutions: IMdmSolution[] | null
+  solutions: IMdmSolution[] | null,
+  selectedPlatformLabelId?: number
 ): IMdmSolution[] => {
   if (!solutions) {
     return [];
   }
-  return [...enhanceSolutionsData(solutions)];
+  return [...enhanceSolutionsData(solutions, selectedPlatformLabelId)];
 };
 
 export default { generateSolutionsTableHeaders, generateSolutionsDataSet };

--- a/frontend/pages/DashboardPage/cards/MDM/MDMSolutionsTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDMSolutionsTableConfig.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { IMdmSolution } from "interfaces/macadmins";
+import { IMdmSolution } from "interfaces/mdm";
 
 import { greyCell } from "utilities/helpers";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell";

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -33,7 +33,8 @@ import {
 } from "interfaces/enroll_secret";
 import { IHost } from "interfaces/host";
 import { ILabel } from "interfaces/label";
-import { IMdmSolution, IMunkiIssuesAggregate } from "interfaces/macadmins";
+import { IMunkiIssuesAggregate } from "interfaces/macadmins";
+import { IMdmSolution } from "interfaces/mdm";
 import {
   formatOperatingSystemDisplayName,
   IOperatingSystemVersion,

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1570,6 +1570,13 @@ const ManageHostsPage = ({
                 {renderLabelFilterPill()} {renderLowDiskSpaceFilterBlock()}
               </>
             );
+
+          case showSelectedLabel && !!mdmId:
+            return (
+              <>
+                {renderLabelFilterPill()} {renderMDMSolutionFilterBlock()}
+              </>
+            );
           case showSelectedLabel:
             return renderLabelFilterPill();
           case !!policyId:

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1563,18 +1563,25 @@ const ManageHostsPage = ({
     ) {
       const renderFilterPill = () => {
         switch (true) {
-          // backend allows for pill combos label x low disk space
+          // backend allows for pill combos (label + low disk space) OR
+          // (label + mdm solution) OR (label + mdm enrollment status)
           case showSelectedLabel && !!lowDiskSpaceHosts:
             return (
               <>
                 {renderLabelFilterPill()} {renderLowDiskSpaceFilterBlock()}
               </>
             );
-
           case showSelectedLabel && !!mdmId:
             return (
               <>
                 {renderLabelFilterPill()} {renderMDMSolutionFilterBlock()}
+              </>
+            );
+
+          case showSelectedLabel && !!mdmEnrollmentStatus:
+            return (
+              <>
+                {renderLabelFilterPill()} {renderMDMEnrollmentFilterBlock()}
               </>
             );
           case showSelectedLabel:

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1247,11 +1247,13 @@ const ManageHostsPage = ({
       case "automatic":
         TooltipDescription = (
           <span className={`tooltip__tooltip-text`}>
-            Hosts automatically enrolled <br />
-            to an MDM solution the first time <br />
-            the host is used. Administrators <br />
-            might have a higher level of control <br />
-            over these hosts.
+            Hosts automatically enrolled in <br />
+            an MDM solution using Apple <br />
+            Automated Device Enrollment <br />
+            (DEP) or Windows Autopilot. <br />
+            Administrators can block users <br />
+            from unenrolling these hosts <br />
+            from MDM.
           </span>
         );
         break;
@@ -1259,8 +1261,8 @@ const ManageHostsPage = ({
         TooltipDescription = (
           <span className={`tooltip__tooltip-text`}>
             Hosts manually enrolled to an <br />
-            MDM solution by a user or <br />
-            administrator.
+            MDM solution. Users can unenroll <br />
+            these hosts from MDM.
           </span>
         );
         break;

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -10,7 +10,6 @@ import { NotificationContext } from "context/notification";
 import deviceUserAPI from "services/entities/device_user";
 import {
   IHost,
-  IHostResponse,
   IDeviceMappingResponse,
   IMacadminsResponse,
   IDeviceUserResponse,
@@ -295,9 +294,8 @@ const DeviceUserPage = ({
                   <AboutCard
                     aboutData={aboutData}
                     deviceMapping={deviceMapping}
-                    macadmins={macadmins}
+                    munki={macadmins?.munki}
                     wrapFleetHelper={wrapFleetHelper}
-                    deviceUser
                   />
                 </TabPanel>
                 <TabPanel>

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -20,6 +20,7 @@ import {
   IMacadminsResponse,
   IPackStats,
   IHostResponse,
+  IHostMdmData,
 } from "interfaces/host";
 import { ILabel } from "interfaces/label";
 import { IHostPolicy } from "interfaces/policy";
@@ -200,6 +201,22 @@ const HostDetailsPage = ({
     }
   );
 
+  const { data: mdm, refetch: refetchMdm } = useQuery<IHostMdmData>(
+    ["mdm", hostIdFromURL],
+    () => hostAPI.getMdm(hostIdFromURL),
+    {
+      enabled: !!hostIdFromURL,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+      retry: false,
+      onError: (err) => {
+        // no handling needed atm. data is simply not shown.
+        console.error(err);
+      },
+    }
+  );
+
   const { data: macadmins, refetch: refetchMacadmins } = useQuery(
     ["macadmins", hostIdFromURL],
     () => hostAPI.loadHostDetailsExtension(hostIdFromURL, "macadmins"),
@@ -216,6 +233,7 @@ const HostDetailsPage = ({
   const refetchExtensions = () => {
     deviceMapping !== null && refetchDeviceMapping();
     macadmins !== null && refetchMacadmins();
+    mdm !== null && refetchMdm();
   };
 
   const {
@@ -638,7 +656,8 @@ const HostDetailsPage = ({
               <AboutCard
                 aboutData={aboutData}
                 deviceMapping={deviceMapping}
-                macadmins={macadmins}
+                munki={macadmins?.munki}
+                mdm={mdm}
                 wrapFleetHelper={wrapFleetHelper}
               />
               <div className="col-2">

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -2,26 +2,23 @@ import React from "react";
 
 import ReactTooltip from "react-tooltip";
 
-import { IMDMData, IMunkiData, IDeviceUser } from "interfaces/host";
+import { IHostMdmData, IMunkiData, IDeviceUser } from "interfaces/host";
 import { humanHostLastRestart, humanHostEnrolled } from "utilities/helpers";
 
 interface IAboutProps {
   aboutData: { [key: string]: any };
   deviceMapping?: IDeviceUser[];
-  macadmins?: {
-    munki: IMunkiData | null;
-    mobile_device_management: IMDMData | null;
-  } | null;
+  munki?: IMunkiData | null;
+  mdm?: IHostMdmData | null;
   wrapFleetHelper: (helperFn: (value: any) => string, value: string) => string;
-  deviceUser?: boolean;
 }
 
 const About = ({
   aboutData,
   deviceMapping,
-  macadmins,
+  munki,
+  mdm,
   wrapFleetHelper,
-  deviceUser,
 }: IAboutProps): JSX.Element => {
   const renderSerialAndIPs = () => {
     return (
@@ -43,10 +40,6 @@ const About = ({
   };
 
   const renderMunkiData = () => {
-    if (!macadmins) {
-      return null;
-    }
-    const { munki } = macadmins;
     return munki ? (
       <>
         <div className="info-grid__block">
@@ -58,11 +51,10 @@ const About = ({
   };
 
   const renderMdmData = () => {
-    if (!macadmins?.mobile_device_management) {
+    if (!mdm || mdm.enrollment_status === "Unenrolled") {
       return null;
     }
-    const mdm = macadmins.mobile_device_management;
-    return mdm.enrollment_status !== "Unenrolled" ? (
+    return (
       <>
         <div className="info-grid__block">
           <span className="info-grid__header">MDM enrollment</span>
@@ -75,7 +67,7 @@ const About = ({
           <span className="info-grid__data">{mdm.server_url || "---"}</span>
         </div>
       </>
-    ) : null;
+    );
   };
 
   const renderDeviceUser = () => {

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -101,13 +101,7 @@ const getSortParams = (sortOptions?: ISortOption[]) => {
   };
 };
 
-const createMdmParams = (
-  hostId?: number,
-  platform?: ISelectedPlatform,
-  teamId?: number
-) => {
-  if (hostId) return "";
-
+const createMdmParams = (platform?: ISelectedPlatform, teamId?: number) => {
   if (platform === "all") {
     return buildQueryStringFromParams({ team_id: teamId });
   }
@@ -292,26 +286,20 @@ export default {
     });
   },
 
-  getMdmSummary: (
-    platform?: ISelectedPlatform,
-    teamId?: number,
-    id?: number
-  ) => {
-    const { MDM_SUMMARY, HOST_MDM } = endpoints;
+  getMdm: (id: number) => {
+    const { HOST_MDM } = endpoints;
+    return sendRequest("GET", HOST_MDM(id));
+  },
+
+  getMdmSummary: (platform?: ISelectedPlatform, teamId?: number) => {
+    const { MDM_SUMMARY } = endpoints;
 
     if (!platform || platform === "linux") {
-      throw new Error("mdm not supported for platform");
+      throw new Error("mdm not supported for this platform");
     }
 
-    let path = "";
-    if (id) {
-      path = HOST_MDM(id);
-    } else {
-      path = MDM_SUMMARY;
-    }
-
-    const params = createMdmParams(id, platform, teamId);
-    const fullPath = params !== "" ? `${path}?${params}` : path;
+    const params = createMdmParams(platform, teamId);
+    const fullPath = params !== "" ? `${MDM_SUMMARY}?${params}` : MDM_SUMMARY;
     return sendRequest("GET", fullPath);
   },
 };

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -7,6 +7,7 @@ import {
   getLabelParam,
   reconcileMutuallyExclusiveHostParams,
 } from "utilities/url";
+import { ISelectedPlatform } from "interfaces/platform";
 
 export interface ISortOption {
   key: string;
@@ -98,6 +99,20 @@ const getSortParams = (sortOptions?: ISortOption[]) => {
     order_key: sortItem.key,
     order_direction: sortItem.direction,
   };
+};
+
+const createMdmParams = (
+  hostId?: number,
+  platform?: ISelectedPlatform,
+  teamId?: number
+) => {
+  if (hostId) return "";
+
+  if (platform === "all") {
+    return buildQueryStringFromParams({ team_id: teamId });
+  }
+
+  return buildQueryStringFromParams({ platform, team_id: teamId });
 };
 
 export default {
@@ -275,5 +290,28 @@ export default {
         label_id: labelId,
       },
     });
+  },
+
+  getMdmSummary: (
+    platform?: ISelectedPlatform,
+    teamId?: number,
+    id?: number
+  ) => {
+    const { MDM_SUMMARY, HOST_MDM } = endpoints;
+
+    if (!platform || platform === "linux") {
+      throw new Error("mdm not supported for platform");
+    }
+
+    let path = "";
+    if (id) {
+      path = HOST_MDM(id);
+    } else {
+      path = MDM_SUMMARY;
+    }
+
+    const params = createMdmParams(id, platform, teamId);
+    const fullPath = params !== "" ? `${path}?${params}` : path;
+    return sendRequest("GET", fullPath);
   },
 };

--- a/frontend/test/test-utils.tsx
+++ b/frontend/test/test-utils.tsx
@@ -116,14 +116,14 @@ const addContextWrappers = (
  * This will also set up the @testing-library/user-events and expose a user object
  * you can use to perform user interactions.
  */
-export const createCustomRenderer = (renderOptions: ICustomRenderOptions) => {
+export const createCustomRenderer = (renderOptions?: ICustomRenderOptions) => {
   let CustomWrapperComponent = ({ children }: IChildrenProp) => <>{children}</>;
 
-  if (renderOptions.withBackendMock) {
+  if (renderOptions?.withBackendMock) {
     CustomWrapperComponent = addQueryProviderWrapper(CustomWrapperComponent);
   }
 
-  if (renderOptions.context !== undefined) {
+  if (renderOptions?.context !== undefined) {
     CustomWrapperComponent = addContextWrappers(
       renderOptions.context,
       CustomWrapperComponent

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -31,6 +31,8 @@ export default {
   LOGIN: `/${API_VERSION}/fleet/login`,
   LOGOUT: `/${API_VERSION}/fleet/logout`,
   MACADMINS: `/${API_VERSION}/fleet/macadmins`,
+  MDM_SUMMARY: `/${API_VERSION}/fleet/hosts/summary/mdm`,
+  HOST_MDM: (id: number) => `/${API_VERSION}/fleet/hosts/${id}/mdm`,
   ME: `/${API_VERSION}/fleet/me`,
   OS_VERSIONS: `/${API_VERSION}/fleet/os_versions`,
   OSQUERY_OPTIONS: `/${API_VERSION}/fleet/spec/osquery_options`,

--- a/frontend/utilities/url/index.ts
+++ b/frontend/utilities/url/index.ts
@@ -68,10 +68,13 @@ export const reconcileMutuallyExclusiveHostParams = ({
   osVersion,
 }: IMutuallyExclusiveHostParams): Record<string, unknown> => {
   if (label) {
-    // backend api now allows label + low disk space and label + mdm id.
-    // all other params are still mutually exclusive.
+    // backend api now allows (label + low disk space) OR (label + mdm id) OR
+    // (label + mdm enrollment status). all other params are still mutually exclusive.
     if (mdmId) {
       return { mdm_id: mdmId };
+    }
+    if (mdmEnrollmentStatus) {
+      return { mdm_enrollment_status: mdmEnrollmentStatus };
     }
     if (lowDiskSpaceHosts) {
       return { low_disk_space: lowDiskSpaceHosts };

--- a/frontend/utilities/url/index.ts
+++ b/frontend/utilities/url/index.ts
@@ -68,8 +68,11 @@ export const reconcileMutuallyExclusiveHostParams = ({
   osVersion,
 }: IMutuallyExclusiveHostParams): Record<string, unknown> => {
   if (label) {
-    // backend api now allows label x low disk space
-    // all other params are still mutually exclusive
+    // backend api now allows label + low disk space and label + mdm id.
+    // all other params are still mutually exclusive.
+    if (mdmId) {
+      return { mdm_id: mdmId };
+    }
     if (lowDiskSpaceHosts) {
       return { low_disk_space: lowDiskSpaceHosts };
     }

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -322,6 +322,10 @@ func testLabelsListHostsInLabel(t *testing.T, db *Datastore) {
 	listHostsInLabelCheckCount(t, db, filter, l1.ID, fleet.HostListOptions{LowDiskSpaceFilter: ptr.Int(25)}, 2)
 	listHostsInLabelCheckCount(t, db, filter, l1.ID, fleet.HostListOptions{LowDiskSpaceFilter: ptr.Int(15)}, 1)
 	listHostsInLabelCheckCount(t, db, filter, l1.ID, fleet.HostListOptions{LowDiskSpaceFilter: ptr.Int(5)}, 0)
+
+	listHostsInLabelCheckCount(t, db, filter, l1.ID, fleet.HostListOptions{MDMIDFilter: ptr.Uint(99)}, 0)
+	listHostsInLabelCheckCount(t, db, filter, l1.ID, fleet.HostListOptions{MDMIDFilter: ptr.Uint(simpleMDMID)}, 2)
+	listHostsInLabelCheckCount(t, db, filter, l1.ID, fleet.HostListOptions{MDMIDFilter: ptr.Uint(kandjiID)}, 1)
 }
 
 func listHostsInLabelCheckCount(

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -282,7 +282,7 @@ func testLabelsListHostsInLabel(t *testing.T, db *Datastore) {
 	require.NoError(t, db.SetOrUpdateHostDisksSpace(context.Background(), h3.ID, 30, 15))
 
 	ctx := context.Background()
-	const simpleMDM, kandji, unknown = "https://simplemdm.com", "https://kandji.io", "https://url.com"
+	const simpleMDM, kandji = "https://simplemdm.com", "https://kandji.io"
 	err = db.SetOrUpdateMDMData(ctx, h1.ID, false, true, simpleMDM, true, "") // enrollment: automatic
 	require.NoError(t, err)
 	err = db.SetOrUpdateMDMData(ctx, h2.ID, false, true, kandji, true, "") // enrollment: automatic

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -495,8 +495,9 @@ type AggregatedMDMStatus struct {
 
 // AggregatedMDMData contains aggregated data from mdm installations.
 type AggregatedMDMData struct {
-	MDMStatus    AggregatedMDMStatus      `json:"mobile_device_management_enrollment_status"`
-	MDMSolutions []AggregatedMDMSolutions `json:"mobile_device_management_solution"`
+	CountsUpdatedAt time.Time                `json:"counts_updated_at"`
+	MDMStatus       AggregatedMDMStatus      `json:"mobile_device_management_enrollment_status"`
+	MDMSolutions    []AggregatedMDMSolutions `json:"mobile_device_management_solution"`
 }
 
 // MDMSolution represents a single MDM solution, as returned by the list hosts

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1113,17 +1113,25 @@ func (svc *Service) AggregatedMDMData(ctx context.Context, teamID *uint, platfor
 		return fleet.AggregatedMDMData{}, err
 	}
 
-	var err error
-	data := fleet.AggregatedMDMData{}
-	data.MDMStatus, _, err = svc.ds.AggregatedMDMStatus(ctx, teamID, platform)
+	mdmStatus, mdmStatusUpdatedAt, err := svc.ds.AggregatedMDMStatus(ctx, teamID, platform)
 	if err != nil {
 		return fleet.AggregatedMDMData{}, err
 	}
-	data.MDMSolutions, _, err = svc.ds.AggregatedMDMSolutions(ctx, teamID, platform)
+	mdmSolutions, mdmSolutionsUpdatedAt, err := svc.ds.AggregatedMDMSolutions(ctx, teamID, platform)
 	if err != nil {
 		return fleet.AggregatedMDMData{}, err
 	}
-	return data, nil
+
+	countsUpdatedAt := mdmStatusUpdatedAt
+	if mdmStatusUpdatedAt.Before(mdmSolutionsUpdatedAt) {
+		countsUpdatedAt = mdmSolutionsUpdatedAt
+	}
+
+	return fleet.AggregatedMDMData{
+		MDMStatus:       mdmStatus,
+		MDMSolutions:    mdmSolutions,
+		CountsUpdatedAt: countsUpdatedAt,
+	}, nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -2535,7 +2535,7 @@ type macadminsDataResponse struct {
 	} `json:"macadmins"`
 }
 
-func (s *integrationTestSuite) TestGetMacadminsData() {
+func (s *integrationTestSuite) TestGetMacadminsAData() {
 	t := s.T()
 
 	ctx := context.Background()
@@ -2778,6 +2778,13 @@ func (s *integrationTestSuite) TestGetMacadminsData() {
 			require.Fail(t, "unknown MDM server URL: %s", sol.ServerURL)
 		}
 	}
+
+	// TODO: ideally we'd pull this out into its own function that specifically tests
+	// the mdm summary endpoint. We can add additional tests for testing the platform
+	// and team_id query params for this endpoint.
+	mdmAgg := getHostMDMSummaryResponse{}
+	s.DoJSON("GET", "/api/latest/fleet/hosts/summary/mdm", nil, http.StatusOK, &mdmAgg)
+	assert.NotZero(t, mdmAgg.AggregatedMDMData.CountsUpdatedAt)
 
 	team, err := s.ds.NewTeam(context.Background(), &fleet.Team{
 		Name:        "team1" + t.Name(),

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -2535,7 +2535,7 @@ type macadminsDataResponse struct {
 	} `json:"macadmins"`
 }
 
-func (s *integrationTestSuite) TestGetMacadminsAData() {
+func (s *integrationTestSuite) TestGetMacadminsData() {
 	t := s.T()
 
 	ctx := context.Background()

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -259,6 +259,15 @@ func listHostsInLabelEndpoint(ctx context.Context, request interface{}, svc flee
 		return listLabelsResponse{Err: err}, nil
 	}
 
+	var mdmSolution *fleet.MDMSolution
+	if req.ListOptions.MDMIDFilter != nil {
+		var err error
+		mdmSolution, err = svc.GetMDMSolution(ctx, *req.ListOptions.MDMIDFilter)
+		if err != nil && !fleet.IsNotFound(err) { // ignore not found, just return nil for the MDM solution in that case
+			return listHostsResponse{Err: err}, nil
+		}
+	}
+
 	hostResponses := make([]fleet.HostResponse, len(hosts))
 	for i, host := range hosts {
 		h, err := fleet.HostResponseForHost(ctx, svc, host)
@@ -268,7 +277,7 @@ func listHostsInLabelEndpoint(ctx context.Context, request interface{}, svc flee
 
 		hostResponses[i] = *h
 	}
-	return listHostsResponse{Hosts: hostResponses}, nil
+	return listHostsResponse{Hosts: hostResponses, MDMSolution: mdmSolution}, nil
 }
 
 func (svc *Service) ListHostsInLabel(ctx context.Context, lid uint, opt fleet.HostListOptions) ([]*fleet.Host, error) {


### PR DESCRIPTION
relates to #7861

This adds the mdm card to windows and all dashboards as well as gets the mdm data from new endpoints. The work included to do this is:

**frontend**

- get MDM data from the new `GET hosts/summary/mdm` and `GET /hosts/:id/mdm` endpoints
- build UI to show mdm card on windows and all dashboards
- add conditional rendering to the mdm card based on the data that comes back from the API.
- extend ViewAllHostsLink component to take a platform to enable showing viewing all hosts for a specific platform.
- update copy for MDM cards on dashboard and manage dashboard page.
- update manage host page to show filter pills for (platform + mdm solution) OR (platform + mdm enrollment status)

**Backend**
- extending APIs for `GET /labels/:id/hosts` to take `mdm_id` and `mdm_enrollment_status` query params.
- extend `GET /hosts/summary/mdm` endpoint to include `counts_updated_at` in response.
- extend `GET /labels/:id/hosts` to include `mobile_device_management_solution` attribute in response when passing a `mdm_id` query param filter

---

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Manual QA for all new/changed functionality
