### PR TITLE
Fleet UI: Fix input field alignments

### DIFF
--- a/changes/issue-8753-input-field-alignment
+++ b/changes/issue-8753-input-field-alignment
@@ -1,0 +1,1 @@
+* Fix buggy input field alignments

--- a/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
+++ b/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
@@ -63,7 +63,7 @@
     }
   }
 
-  &__advanced {
+  &__advanced--installer {
     .input-field {
       height: 115px;
     }
@@ -127,9 +127,6 @@
 
   &__advanced {
     padding-top: 6px;
-    .input-field__textarea {
-      min-height: 92px;
-    }
     .reveal-button {
       margin: 8px 0;
     }

--- a/frontend/components/forms/FormField/_styles.scss
+++ b/frontend/components/forms/FormField/_styles.scss
@@ -7,7 +7,7 @@
     color: $core-fleet-black;
     display: block;
     margin-bottom: $pad-small;
-    height: $form-field-label-height;
+    min-height: $form-field-label-height;
 
     &--error {
       font-weight: $bold;

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/OSPolicyModal/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/OSPolicyModal/_styles.scss
@@ -27,6 +27,11 @@
     }
   }
 
+  &__name {
+    .buttons {
+      margin-top: 10px;
+    }
+  }
   &__os-policy-copy-icon {
     color: $core-vibrant-blue;
     margin-left: $pad-small;


### PR DESCRIPTION
### Issue
Cerra #8953 

### Fixes
- Add hosts > Advanced field height and label height
- Host details page > OS policy modal > Copy button location

### Screenshots
<img width="680" alt="Screenshot 2022-12-08 at 9 53 49 AM" src="https://user-images.githubusercontent.com/71795832/206528154-9b844a59-9ff9-4896-a9a0-36e8a89ef804.png">
<img width="1025" alt="Screenshot 2022-12-08 at 9 50 09 AM" src="https://user-images.githubusercontent.com/71795832/206528157-f73c1612-f70a-4167-be03-b3a1dc11cda1.png">

### QA
- [x] Self tested on chrome, firefox, safari

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
