### PR TITLE
A fix for dogfood having too many mysql connections

### DIFF
--- a/.github/workflows/dogfood-deploy.yml
+++ b/.github/workflows/dogfood-deploy.yml
@@ -22,6 +22,7 @@ env:
   TF_VAR_fleet_license: ${{ secrets.DOGFOOD_LICENSE_KEY }}
   TF_VAR_cloudwatch_log_retention: 30
   TF_VAR_rds_backup_retention_period: 30
+  TF_VAR_fleet_max_open_conns: 30
   TF_VAR_extra_security_group_cidrs: '["10.255.1.0/24", "10.255.2.0/24", "10.255.3.0/24"]'
 
 permissions:

--- a/infrastructure/dogfood/terraform/aws/ecs.tf
+++ b/infrastructure/dogfood/terraform/aws/ecs.tf
@@ -300,6 +300,10 @@ resource "aws_ecs_task_definition" "backend" {
             name  = "FLEET_MDM_APPLE_SERVER_ADDRESS"
             value = "dogfood.fleetdm.com"
           },
+          {
+            name  = "FLEET_MYSQL_MAX_OPEN_CONNS"
+            value = var.fleet_max_open_conns
+          }
         ]
       }
   ])

--- a/infrastructure/dogfood/terraform/aws/variables.tf
+++ b/infrastructure/dogfood/terraform/aws/variables.tf
@@ -129,3 +129,7 @@ variable "extra_security_group_cidrs" {
 variable "rds_initial_snapshot" {
   default = null
 }
+
+variable "fleet_max_open_cons" {
+  default = "50"
+}

--- a/infrastructure/dogfood/terraform/aws/variables.tf
+++ b/infrastructure/dogfood/terraform/aws/variables.tf
@@ -130,6 +130,6 @@ variable "rds_initial_snapshot" {
   default = null
 }
 
-variable "fleet_max_open_cons" {
+variable "fleet_max_open_conns" {
   default = "50"
 }


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
