### PR TITLE
Support redis username

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -314,6 +314,7 @@ the way that the Fleet server works.
 
 			redisPool, err := redis.NewPool(redis.PoolConfig{
 				Server:                    config.Redis.Address,
+				Username:                  config.Redis.Username,
 				Password:                  config.Redis.Password,
 				Database:                  config.Redis.Database,
 				UseTLS:                    config.Redis.UseTLS,

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -344,6 +344,18 @@ For the address of the Redis server that Fleet should connect to, include the ho
   	address: 127.0.0.1:7369
   ```
 
+##### redis_username
+
+The username to use when connecting to the Redis instance.
+
+- Default value: `<empty>`
+- Environment variable: `FLEET_REDIS_USERNAME`
+- Config file format:
+  ```
+  redis:
+  	username: foobar
+  ```
+
 ##### redis_password
 
 The password to use when connecting to the Redis instance.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -51,6 +51,7 @@ type MysqlConfig struct {
 // RedisConfig defines configs related to Redis
 type RedisConfig struct {
 	Address                   string
+	Username                  string
 	Password                  string
 	Database                  int
 	UseTLS                    bool          `yaml:"use_tls"`
@@ -704,6 +705,8 @@ func (man Manager) addConfigs() {
 	// Redis
 	man.addConfigString("redis.address", "localhost:6379",
 		"Redis server address (host:port)")
+	man.addConfigString("redis.username", "",
+		"Redis server username")
 	man.addConfigString("redis.password", "",
 		"Redis server password (prefer env variable for security)")
 	man.addConfigInt("redis.database", 0,
@@ -1039,6 +1042,7 @@ func (man Manager) LoadConfig() FleetConfig {
 		MysqlReadReplica: loadMysqlConfig("mysql_read_replica"),
 		Redis: RedisConfig{
 			Address:                   man.getConfigString("redis.address"),
+			Username:                  man.getConfigString("redis.username"),
 			Password:                  man.getConfigString("redis.password"),
 			Database:                  man.getConfigInt("redis.database"),
 			UseTLS:                    man.getConfigBool("redis.use_tls"),

--- a/server/datastore/redis/redis.go
+++ b/server/datastore/redis/redis.go
@@ -44,6 +44,7 @@ func (p *clusterPool) Mode() fleet.RedisMode {
 // PoolConfig holds the redis pool configuration options.
 type PoolConfig struct {
 	Server                    string
+	Username                  string
 	Password                  string
 	Database                  int
 	UseTLS                    bool
@@ -71,7 +72,7 @@ type PoolConfig struct {
 }
 
 // NewPool creates a Redis connection pool using the provided server
-// address, password and database.
+// address, username, password and database.
 func NewPool(config PoolConfig) (fleet.RedisPool, error) {
 	cluster, err := newCluster(config)
 	if err != nil {
@@ -249,6 +250,7 @@ func newCluster(conf PoolConfig) (*redisc.Cluster, error) {
 		redis.DialUseTLS(conf.UseTLS),
 		redis.DialConnectTimeout(conf.ConnTimeout),
 		redis.DialKeepAlive(conf.KeepAlive),
+		redis.DialUsername(conf.Username),
 		redis.DialPassword(conf.Password),
 		redis.DialWriteTimeout(conf.WriteTimeout),
 		redis.DialReadTimeout(conf.ReadTimeout),

--- a/server/datastore/redis/redistest/redistest.go
+++ b/server/datastore/redis/redistest/redistest.go
@@ -48,6 +48,7 @@ func SetupRedis(tb testing.TB, cleanupKeyPrefix string, cluster, redir, readRepl
 
 	var (
 		addr     = "127.0.0.1:"
+		username = ""
 		password = ""
 		database = 0
 		useTLS   = false
@@ -60,6 +61,7 @@ func SetupRedis(tb testing.TB, cleanupKeyPrefix string, cluster, redir, readRepl
 
 	pool, err := redis.NewPool(redis.PoolConfig{
 		Server:                    addr,
+		Username:                  username,
 		Password:                  password,
 		Database:                  database,
 		UseTLS:                    useTLS,


### PR DESCRIPTION
This PR adds support for setting a redis username for users who use redis ACLs

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
