### PR TITLE
Simplify disk encryption query in linux and filter at ingestion

### DIFF
--- a/changes/issue-8982-ingest-encrypted-linux
+++ b/changes/issue-8982-ingest-encrypted-linux
@@ -1,0 +1,1 @@
+* Fix how we are querying and ingesting disk encryption in linux to workaround an osquery bug.

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -991,6 +991,22 @@ func (a *agent) diskEncryption() []map[string]string {
 	return []map[string]string{}
 }
 
+func (a *agent) diskEncryptionLinux() []map[string]string {
+	// 50% of results have encryption enabled
+	enabled := rand.Intn(2) == 1
+	if enabled {
+		return []map[string]string{
+			{"path": "/etc", "encrypted": "0"},
+			{"path": "/tmp", "encrypted": "0"},
+			{"path": "/", "encrypted": "1"},
+		}
+	}
+	return []map[string]string{
+		{"path": "/etc", "encrypted": "0"},
+		{"path": "/tmp", "encrypted": "0"},
+	}
+}
+
 func (a *agent) processQuery(name, query string) (handled bool, results []map[string]string, status *fleet.OsqueryStatus) {
 	const (
 		hostPolicyQueryPrefix = "fleet_policy_query_"
@@ -1065,6 +1081,13 @@ func (a *agent) processQuery(name, query string) (handled bool, results []map[st
 		ss := fleet.OsqueryStatus(rand.Intn(2))
 		if ss == fleet.StatusOK {
 			results = a.diskSpace()
+		}
+		return true, results, &ss
+
+	case strings.HasPrefix(name, hostDetailQueryPrefix+"disk_encryption_linux"):
+		ss := fleet.OsqueryStatus(rand.Intn(2))
+		if ss == fleet.StatusOK {
+			results = a.diskEncryptionLinux()
 		}
 		return true, results, &ss
 	case strings.HasPrefix(name, hostDetailQueryPrefix+"disk_encryption_"):

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -587,7 +587,7 @@ FROM
 	"disk_encryption_linux": {
 		// This query doesn't do any filtering as we've seen what's possibly an osquery bug because it's returning bad
 		// results if we filter further, so we'll do the filtering in Go.
-		Query:            `SELECT * FROM disk_encryption`,
+		Query:            `SELECT de.encrypted, m.path FROM disk_encryption de JOIN mounts m ON m.device_alias = de.name;`,
 		Platforms:        fleet.HostLinuxOSs,
 		DirectIngestFunc: directIngestDiskEncryptionLinux,
 		// the "disk_encryption" table doesn't need a Discovery query as it is an official
@@ -1299,7 +1299,7 @@ func directIngestDiskEncryptionLinux(ctx context.Context, logger log.Logger, hos
 
 	encrypted := false
 	for _, row := range rows {
-		if row["name"] == "/dev/dm-1" && row["encrypted"] == "1" {
+		if row["path"] == "/" && row["encrypted"] == "1" {
 			encrypted = true
 			break
 		}

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -585,9 +585,11 @@ FROM
 		// osquery table on darwin and linux, it is always present.
 	},
 	"disk_encryption_linux": {
-		Query:            `SELECT 1 FROM (SELECT encrypted, path FROM disk_encryption FULL OUTER JOIN mounts ON mounts.device_alias = disk_encryption.name) WHERE encrypted = 1 AND path = '/';`,
+		// This query doesn't do any filtering as we've seen what's possibly an osquery bug because it's returning bad
+		// results if we filter further, so we'll do the filtering in Go.
+		Query:            `SELECT * FROM disk_encryption`,
 		Platforms:        fleet.HostLinuxOSs,
-		DirectIngestFunc: directIngestDiskEncryption,
+		DirectIngestFunc: directIngestDiskEncryptionLinux,
 		// the "disk_encryption" table doesn't need a Discovery query as it is an official
 		// osquery table on darwin and linux, it is always present.
 	},
@@ -1287,6 +1289,23 @@ func directIngestMunkiInfo(ctx context.Context, logger log.Logger, host *fleet.H
 	errors, warnings := rows[0]["errors"], rows[0]["warnings"]
 	errList, warnList := splitCleanSemicolonSeparated(errors), splitCleanSemicolonSeparated(warnings)
 	return ds.SetOrUpdateMunkiInfo(ctx, host.ID, rows[0]["version"], errList, warnList)
+}
+
+func directIngestDiskEncryptionLinux(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string, failed bool) error {
+	if failed {
+		level.Error(logger).Log("op", "directIngestDiskEncryptionLinux", "err", "failed")
+		return nil
+	}
+
+	encrypted := false
+	for _, row := range rows {
+		if row["name"] == "/dev/dm-1" && row["encrypted"] == "1" {
+			encrypted = true
+			break
+		}
+	}
+
+	return ds.SetOrUpdateHostDisksEncryption(ctx, host.ID, encrypted)
 }
 
 func directIngestDiskEncryption(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string, failed bool) error {

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -851,11 +851,9 @@ func TestDirectIngestDiskEncryptionLinux(t *testing.T) {
 
 	expectEncrypted = true
 	err = directIngestDiskEncryptionLinux(context.Background(), log.NewNopLogger(), &host, ds, []map[string]string{
-		{"name": "/dev/vda", "encrypted": "0"},
-		{"name": "/dev/vda1", "encrypted": "0"},
-		{"name": "/dev/vda2", "encrypted": "0"},
-		{"name": "/dev/dm-0", "encrypted": "1"},
-		{"name": "/dev/dm-1", "encrypted": "1"},
+		{"path": "/etc/hosts", "encrypted": "0"},
+		{"path": "/tmp", "encrypted": "0"},
+		{"path": "/", "encrypted": "1"},
 	}, false)
 	require.NoError(t, err)
 	require.True(t, ds.SetOrUpdateHostDisksEncryptionFuncInvoked)


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- ~Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~Documented any permissions changes~
- ~Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
