### PR TITLE
Website: Update usage statistics webhook inputs

### DIFF
--- a/website/api/controllers/webhooks/receive-usage-analytics.js
+++ b/website/api/controllers/webhooks/receive-usage-analytics.js
@@ -24,8 +24,8 @@ module.exports = {
     numWeeklyPolicyViolationDaysActual: { type: 'number', defaultsTo: 0 },
     numWeeklyPolicyViolationDaysPossible: { type: 'number', defaultsTo: 0 },
     hostsEnrolledByOperatingSystem: { type: {}, defaultsTo: {} },
-    hostsEnrolledByOrbitVersion: { type: [{version: 'string', numEnrolled: 'number'}], defaultsTo: [] }, // TODO: The name of this parameter does not match naming conventions.
-    hostsEnrolledByOsqueryVersion: { type: [{version: 'string', numEnrolled: 'number'}], defaultsTo: [] }, // TODO: The name of this parameter does not match naming conventions.
+    hostsEnrolledByOrbitVersion: { type: [{orbitVersion: 'string', numHosts: 'number'}], defaultsTo: [] }, // TODO: The name of this parameter does not match naming conventions.
+    hostsEnrolledByOsqueryVersion: { type: [{osqueryVersion: 'string', numHosts: 'number'}], defaultsTo: [] }, // TODO: The name of this parameter does not match naming conventions.
     storedErrors: { type: [{}], defaultsTo: [] }, // TODO migrate all rows that have "[]" to {}
     numHostsNotResponding: { type: 'number', defaultsTo: 0, description: 'The number of hosts per deployment that have not submitted results for distibuted queries. A host is counted as not responding if Fleet hasn\'t received a distributed write to requested distibuted queries for the host during the 2-hour interval since the host was last seen. Hosts that have not been seen for 7 days or more are not counted.', },
     organization: { type: 'string', defaultsTo: 'unknown', description: 'For Fleet Premium deployments, the organization registered with the license.', },


### PR DESCRIPTION
Changes:
- Updated the types for `hostsEnrolledByOsqueryVersion` and `hostsEnrolledByOrbitVersion` to match the [JSON sent from Fleet instances ](https://github.com/fleetdm/fleet/blob/adb2ab53f066a04ebf098f5e45c11ac6aafb6702/server/fleet/statistics.go#L42-L49)

