### PR TITLE
UI: set local min-height to 0 to restore proper enroll secret icon alignment

### DIFF
--- a/changes/issue-9025-restore-correct-icon-alignment-on-input
+++ b/changes/issue-9025-restore-correct-icon-alignment-on-input
@@ -1,0 +1,2 @@
+- Fixed the alignment of the "copy" and "show" button icons in the manage enroll secrets and get API
+  token modals

--- a/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/_styles.scss
+++ b/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/_styles.scss
@@ -17,6 +17,7 @@
       margin-bottom: 0;
       width: 500px;
       height: 0;
+      min-height: 0;
     }
 
     .input-field {

--- a/frontend/components/EnrollSecrets/SecretField/_styles.scss
+++ b/frontend/components/EnrollSecrets/SecretField/_styles.scss
@@ -8,6 +8,8 @@
       font-weight: $bold;
       margin-top: $pad-small;
       width: 100%;
+      height: 0;
+      min-height: 0;
     }
 
     .input-field {


### PR DESCRIPTION
## Addresses #9025 

## Fixes

- Global min-height for labels caused the label being used here to have a height, even though it is just being used to hold the icon buttons. This overrides that global label min-height locally in two places to fix the issue quickly.

Bug:
![bug](https://user-images.githubusercontent.com/61553566/207944559-a7a024ee-137e-4d62-9f39-9ce26af38d98.png)

Fixed:
![fixed](https://user-images.githubusercontent.com/61553566/207944569-4a9c8559-3b9b-48ed-9bd0-c3ed2e147bfa.png)

Bug:
![Screenshot 2022-12-15 at 5 41 37 PM](https://user-images.githubusercontent.com/61553566/208002471-d7f36f09-8cff-4952-a529-58e29c077729.png)

Fixed:
![Screenshot 2022-12-15 at 5 42 15 PM](https://user-images.githubusercontent.com/61553566/208002561-d4a0ecdc-1dd6-439b-badb-954d7489c5d3.png)

## Notes
- Since these uses of `label` element are not actually being used as labels, maybe it should be a more general element, a `div` perhaps. This would be more semantically sound, and would prevent it from being targeted by the global `label` min-height, which is intended for labels that are using text.
- It seems like EnrollSecretRow is duplicating the functionality of SecretField, the latter of which is used in the Get API Token modal. Per Mike's "rule of 3" refactor guidance, I'm patching these locally, but if there emerges a 3rd place where we want hidden inputs like this it seems to me they should all use the SecretField component.

## Checklist for submitter

- [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.