### PR TITLE
exclude critical attribute on a policy update payload if on free tier

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -227,14 +227,17 @@ const PolicyForm = ({
     if (!isEditMode) {
       setIsNewPolicyModalOpen(true);
     } else {
-      onUpdate({
+      const payload: IPolicyFormData = {
         name: lastEditedQueryName,
         description: lastEditedQueryDescription,
         query: lastEditedQueryBody,
         resolution: lastEditedQueryResolution,
-        critical: lastEditedQueryCritical,
         platform: newPlatformString,
-      });
+      };
+      if (isPremiumTier) {
+        payload.critical = lastEditedQueryCritical;
+      }
+      onUpdate(payload);
     }
 
     setIsEditingName(false);


### PR DESCRIPTION
quick fix to only include critical attribute on a policy update if user is on premium tier