### PR TITLE
Windows installer now ensures that legacy osquery installations gets removed during clean install

### DIFF
--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -406,7 +406,7 @@ jobs:
     - name: Install msi
       shell: pwsh
       run: |
-        msiexec /i ${{ steps.download.outputs.download-path }}\fleet-osquery.msi /quiet /passive /lv log.txt
+        Start-Process msiexec -ArgumentList "/i ${{ steps.download.outputs.download-path }}\fleet-osquery.msi /quiet /passive /lv log.txt" -Wait
 
     - name: Wait enroll
       run: |

--- a/changes/bug-8891-uninstall-legacy-osquery-installations
+++ b/changes/bug-8891-uninstall-legacy-osquery-installations
@@ -1,1 +1,1 @@
-* Windows installer now ensures that installed osquery versio get removed before installing Orbit
+* Windows installer now ensures that the installed osquery version gets removed before installing Orbit

--- a/changes/bug-8891-uninstall-legacy-osquery-installations
+++ b/changes/bug-8891-uninstall-legacy-osquery-installations
@@ -1,0 +1,1 @@
+* Windows installer now ensures that installed osquery versio get removed before installing Orbit

--- a/orbit/pkg/packaging/windows.go
+++ b/orbit/pkg/packaging/windows.go
@@ -91,6 +91,10 @@ func BuildMSI(opt Options) (string, error) {
 		return "", fmt.Errorf("write eventlog file: %w", err)
 	}
 
+	if err := writePowershellInstallerUtilsFile(opt, orbitRoot); err != nil {
+		return "", fmt.Errorf("write powershell installer utils file: %w", err)
+	}
+
 	if err := writeWixFile(opt, tmpDir); err != nil {
 		return "", fmt.Errorf("write wix file: %w", err)
 	}
@@ -170,6 +174,25 @@ func writeEventLogFile(opt Options, rootPath string) error {
 
 	if err := ioutil.WriteFile(path, contents.Bytes(), constant.DefaultFileMode); err != nil {
 		return fmt.Errorf("event log manifest creation: %w", err)
+	}
+
+	return nil
+}
+
+func writePowershellInstallerUtilsFile(opt Options, rootPath string) error {
+	// Powershell installer utils file is going to be built and dumped into working directory
+	path := filepath.Join(rootPath, "installer_utils.ps1")
+	if err := secure.MkdirAll(filepath.Dir(path), constant.DefaultDirMode); err != nil {
+		return fmt.Errorf("powershell installer utils location creation: %w", err)
+	}
+
+	var contents bytes.Buffer
+	if err := windowsPSInstallerUtils.Execute(&contents, opt); err != nil {
+		return fmt.Errorf("powershell installer utils transform: %w", err)
+	}
+
+	if err := ioutil.WriteFile(path, contents.Bytes(), constant.DefaultFileMode); err != nil {
+		return fmt.Errorf("epowershell installer utils file write: %w", err)
 	}
 
 	return nil

--- a/orbit/pkg/packaging/windows.go
+++ b/orbit/pkg/packaging/windows.go
@@ -192,7 +192,7 @@ func writePowershellInstallerUtilsFile(opt Options, rootPath string) error {
 	}
 
 	if err := ioutil.WriteFile(path, contents.Bytes(), constant.DefaultFileMode); err != nil {
-		return fmt.Errorf("epowershell installer utils file write: %w", err)
+		return fmt.Errorf("powershell installer utils file write: %w", err)
 	}
 
 	return nil

--- a/orbit/pkg/packaging/windows_templates.go
+++ b/orbit/pkg/packaging/windows_templates.go
@@ -98,11 +98,6 @@ var windowsWixTemplate = template.Must(template.New("").Option("missingkey=error
                 />
               </Component>
             </Directory>
-            <Component Id="C_INSTALLER_UTILS">
-              <File KeyPath="yes" Source="installer_utils.ps1">
-                <PermissionEx Sddl="O:SYG:SYD:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;BU)" />
-              </File>
-            </Component>
           </Directory>
         </Directory>
       </Directory>
@@ -111,7 +106,7 @@ var windowsWixTemplate = template.Must(template.New("").Option("missingkey=error
     <SetProperty Id="CA_UninstallOsquery"
                  Before ="CA_UninstallOsquery"
                  Sequence="execute"
-                 Value='&quot;[POWERSHELLEXE]&quot; -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -File "[ORBITROOT]bin\installer_utils.ps1" -uninstallOsquery' />
+                 Value='&quot;[POWERSHELLEXE]&quot; -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -File "[ORBITROOT]installer_utils.ps1" -uninstallOsquery' />
 
     <CustomAction Id="CA_UninstallOsquery"
                   BinaryKey="WixCA"
@@ -123,7 +118,7 @@ var windowsWixTemplate = template.Must(template.New("").Option("missingkey=error
    <SetProperty Id="CA_StopOrbit"
                  Before ="CA_StopOrbit"
                  Sequence="execute"
-                 Value='&quot;[POWERSHELLEXE]&quot; -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -File "[ORBITROOT]bin\installer_utils.ps1" -stopOrbit' />
+                 Value='&quot;[POWERSHELLEXE]&quot; -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -File "[ORBITROOT]installer_utils.ps1" -stopOrbit' />
 
     <CustomAction Id="CA_StopOrbit"
                   BinaryKey="WixCA"
@@ -141,7 +136,6 @@ var windowsWixTemplate = template.Must(template.New("").Option("missingkey=error
       <ComponentGroupRef Id="OrbitFiles" />
       <ComponentRef Id="C_ORBITROOT_REMOVAL" />
       <ComponentRef Id="C_ORBITBIN" />
-      <ComponentRef Id="C_INSTALLER_UTILS" />
       <ComponentRef Id="C_ORBITROOT" />
     </Feature>
 

--- a/orbit/pkg/packaging/windows_templates.go
+++ b/orbit/pkg/packaging/windows_templates.go
@@ -217,7 +217,6 @@ using Microsoft.Win32;
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
-
 public class RegistryUtils
 {
 
@@ -260,6 +259,7 @@ public class RegistryUtils
 
         if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, ref htok))
         {
+            Console.WriteLine("EnablePrivilege - Failed to obtain handle to primary access token");
             return false;
         }
 
@@ -277,11 +277,13 @@ public class RegistryUtils
 
         if (!LookupPrivilegeValue(null, privilege, ref tp.Luid))
         {
+            Console.WriteLine("EnablePrivilege - Failed to lookup privilege {0}", privilege);
             return false;
         }
 
         if (!AdjustTokenPrivileges(htok, false, ref tp, 0, IntPtr.Zero, IntPtr.Zero))
         {
+            Console.WriteLine("EnablePrivilege - Failed to modify privilege {0}", privilege);
             return false;
         }
 
@@ -313,7 +315,8 @@ public class RegistryUtils
                     }
 
                     const uint HKEY_USERS = 0x80000003;
-                    int ret = RegLoadKey(HKEY_USERS, userDirName, targetFile);
+                    int retRegLoadKey = RegLoadKey(HKEY_USERS, userDirName, targetFile);
+                    Console.WriteLine("RegLoadKey result was {0}", retRegLoadKey);
                 }
             }
         }
@@ -341,7 +344,8 @@ public class RegistryUtils
                     }
 
                     const uint HKEY_USERS = 0x80000003;
-                    RegUnLoadKey(HKEY_USERS, userDirName);
+                    int retRegUnLoadKey = RegUnLoadKey(HKEY_USERS, userDirName);
+                    Console.WriteLine("RegUnLoadKey result was {0}", retRegUnLoadKey);
                 }
             }
         }
@@ -381,9 +385,9 @@ public class RegistryUtils
 
             UnloadUsersHives();
         }
-        catch
+        catch (Exception ex)
         {
-
+            Console.WriteLine("There was an exception when removing osquery installer from user hives: {0}", ex.ToString());
         }
     }
 }


### PR DESCRIPTION
This relates to #8891 

This PR introduces Wix custom actions usage

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [X] Manual QA for all new/changed functionality

