### PR TITLE
Improve how we are logging failed queries and windows detail queries

### DIFF
--- a/changes/issue-8981-os-windows-improve-query
+++ b/changes/issue-8981-os-windows-improve-query
@@ -1,0 +1,1 @@
+- Improve how we are logging failed detail queries and windows os version queries

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -822,7 +822,8 @@ func (svc *Service) SubmitDistributedQueryResults(
 
 		// live queries we do want to ingest even if the query had issues, because we want to inform the user of these
 		// issues
-		// same applies to policies, since it's a 3 state result, one of them being failure
+		// same applies to policies, since it's a 3 state result, one of them being failure, and labels take this state
+		// into account as well
 
 		var err error
 		switch {
@@ -830,6 +831,8 @@ func (svc *Service) SubmitDistributedQueryResults(
 			err = svc.ingestDistributedQuery(ctx, *host, query, rows, failed, messages[query])
 		case strings.HasPrefix(query, hostPolicyQueryPrefix):
 			err = ingestMembershipQuery(hostPolicyQueryPrefix, query, rows, policyResults, failed)
+		case strings.HasPrefix(query, hostLabelQueryPrefix):
+			err = ingestMembershipQuery(hostLabelQueryPrefix, query, rows, labelResults, failed)
 		}
 		logIngestionError(ctx, err)
 
@@ -853,8 +856,6 @@ func (svc *Service) SubmitDistributedQueryResults(
 			name := strings.TrimPrefix(query, hostAdditionalQueryPrefix)
 			additionalResults[name] = rows
 			additionalUpdated = true
-		case strings.HasPrefix(query, hostLabelQueryPrefix):
-			err = ingestMembershipQuery(hostLabelQueryPrefix, query, rows, labelResults, failed)
 		default:
 			err = osqueryError{message: "unknown query prefix: " + query}
 		}

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -824,7 +824,7 @@ func (svc *Service) SubmitDistributedQueryResults(
 			// if a query failed, don't try to ingest it
 			continue
 		}
-		
+
 		var err error
 		switch {
 		case strings.HasPrefix(query, hostDetailQueryPrefix):

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -820,14 +820,16 @@ func (svc *Service) SubmitDistributedQueryResults(
 			ll.Log("query", query, "message", messages[query], "hostID", host.ID)
 		}
 
-		var err error
-		detailUpdated, additionalUpdated, err = svc.ingestQueryResults(
+		ingestedDetailUpdated, ingestedAdditionalUpdated, err := svc.ingestQueryResults(
 			ctx, query, host, rows, failed, messages, policyResults, labelResults, additionalResults,
 		)
 		if err != nil {
 			logging.WithErr(ctx, ctxerr.New(ctx, "error in query ingestion"))
 			logging.WithExtras(ctx, "ingestion-err", err)
 		}
+
+		detailUpdated = detailUpdated || ingestedDetailUpdated
+		additionalUpdated = additionalUpdated || ingestedAdditionalUpdated
 	}
 
 	ac, err := svc.ds.AppConfig(ctx)

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -2131,7 +2131,7 @@ func TestDistributedQueriesLogsManyErrors(t *testing.T) {
 	var logData map[string]interface{}
 	err = json.Unmarshal([]byte(parts[0]), &logData)
 	require.NoError(t, err)
-	assert.Equal(t, "something went wrong || something went wrong", logData["err"])
+	assert.Equal(t, "error in query ingestion || something went wrong || something went wrong", logData["err"])
 	assert.Equal(t, "Missing authorization check", logData["internal"])
 }
 

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -2131,7 +2131,7 @@ func TestDistributedQueriesLogsManyErrors(t *testing.T) {
 	var logData map[string]interface{}
 	err = json.Unmarshal([]byte(parts[0]), &logData)
 	require.NoError(t, err)
-	assert.Equal(t, "error in query ingestion || something went wrong || something went wrong", logData["err"])
+	assert.Equal(t, "something went wrong || something went wrong", logData["err"])
 	assert.Equal(t, "Missing authorization check", logData["internal"])
 }
 

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -155,8 +155,7 @@ limit 1
 		os.codename as display_version
 	
 	FROM
-		os_version os,
-		kernel_info k`,
+		os_version os`,
 		Platforms: []string{"windows"},
 		IngestFunc: func(ctx context.Context, logger log.Logger, host *fleet.Host, rows []map[string]string) error {
 			if len(rows) != 1 {

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -35,11 +35,11 @@ type DetailQuery struct {
 	// DirectIngestFunc gathers results from a query and directly works with the datastore to
 	// persist them. This is usually used for host data that is stored in a separate table.
 	// DirectTaskIngestFunc must not be set if this is set.
-	DirectIngestFunc func(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string, failed bool) error
+	DirectIngestFunc func(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error
 	// DirectTaskIngestFunc is similar to DirectIngestFunc except that it uses a task to
 	// ingest the results. This is for ingestion that can be either sync or async.
 	// DirectIngestFunc must not be set if this is set.
-	DirectTaskIngestFunc func(ctx context.Context, logger log.Logger, host *fleet.Host, task *async.Task, rows []map[string]string, failed bool) error
+	DirectTaskIngestFunc func(ctx context.Context, logger log.Logger, host *fleet.Host, task *async.Task, rows []map[string]string) error
 }
 
 // RunsForPlatform determines whether this detail query should run on the given platform
@@ -150,54 +150,13 @@ limit 1
 	"os_version_windows": {
 		// Windows-specific registry query is required to populate `host.OSVersion` for Windows.
 		Query: `
-WITH dv AS (
 	SELECT
-		data
+		os.name,
+		os.codename as display_version
+	
 	FROM
-		registry
-	WHERE
-		path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\DisplayVersion'
-),
-rid AS (
-	SELECT
-		data
-	FROM
-		registry
-	WHERE
-		path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ReleaseId'
-)
-SELECT
-	(
-		SELECT
-			name
-		FROM
-			os_version) AS name,
-	CASE WHEN EXISTS (
-		SELECT
-			1
-		FROM
-			dv) THEN
-		(
-			SELECT
-				data
-			FROM
-				dv)
-		ELSE
-			""
-	END AS display_version,
-	CASE WHEN EXISTS (
-		SELECT
-			1
-		FROM
-			rid) THEN
-		(
-			SELECT
-				data
-			FROM
-				rid)
-		ELSE
-			""
-	END AS release_id`,
+		os_version os,
+		kernel_info k`,
 		Platforms: []string{"windows"},
 		IngestFunc: func(ctx context.Context, logger log.Logger, host *fleet.Host, rows []map[string]string) error {
 			if len(rows) != 1 {
@@ -206,17 +165,7 @@ SELECT
 				return nil
 			}
 
-			var version string
-			switch {
-			case rows[0]["display_version"] != "":
-				// prefer display version if available
-				version = rows[0]["display_version"]
-			case rows[0]["release_id"] != "":
-				// otherwise release_id if available
-				version = rows[0]["release_id"]
-			default:
-				// empty value
-			}
+			version := rows[0]["display_version"]
 			if version == "" {
 				level.Debug(logger).Log(
 					"msg", "unable to identify windows version",
@@ -396,11 +345,7 @@ func ingestNetworkInterface(ctx context.Context, logger log.Logger, host *fleet.
 	return nil
 }
 
-func directIngestDiskSpace(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string, failed bool) error {
-	if failed {
-		level.Error(logger).Log("op", "directIngestDiskSpace", "err", "failed")
-		return nil
-	}
+func directIngestDiskSpace(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	if len(rows) != 1 {
 		logger.Log("component", "service", "method", "directIngestDiskSpace", "err",
 			fmt.Sprintf("detail_query_disk_space expected single result got %d", len(rows)))
@@ -498,56 +443,16 @@ var extraDetailQueries = map[string]DetailQuery{
 		// tables. Separately, the `hosts` table is populated via the `os_version` and
 		// `os_version_windows` detail queries above.
 		Query: `
-WITH dv AS (
 	SELECT
-		data
+		os.name,
+		os.platform,
+		os.arch,
+		k.version as kernel_version,
+		os.codename as display_version
+	
 	FROM
-		registry
-	WHERE
-		path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\DisplayVersion'
-),
-rid AS (
-	SELECT
-		data
-	FROM
-		registry
-	WHERE
-		path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ReleaseId'
-)
-SELECT
-	os.name,
-	os.platform,
-	os.arch,
-	k.version as kernel_version,
-	CASE WHEN EXISTS (
-		SELECT
-			1
-		FROM
-			dv) THEN
-		(
-			SELECT
-				data
-			FROM
-				dv)
-		ELSE
-			""
-	END AS display_version,
-	CASE WHEN EXISTS (
-		SELECT
-			1
-		FROM
-			rid) THEN
-		(
-			SELECT
-				data
-			FROM
-				rid)
-		ELSE
-			""
-	END AS release_id
-FROM
-    os_version os,
-    kernel_info k`,
+		os_version os,
+		kernel_info k`,
 		Platforms:        []string{"windows"},
 		DirectIngestFunc: directIngestOSWindows,
 	},
@@ -864,11 +769,7 @@ var usersQuery = DetailQuery{
 }
 
 // directIngestOrbitInfo ingests data from the orbit_info extension table.
-func directIngestOrbitInfo(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string, failed bool) error {
-	if failed {
-		level.Error(logger).Log("op", "directIngestOrbitInfo", "err", "failed")
-		return nil
-	}
+func directIngestOrbitInfo(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	if len(rows) != 1 {
 		return ctxerr.Errorf(ctx, "directIngestOrbitInfo invalid number of rows: %d", len(rows))
 	}
@@ -881,11 +782,7 @@ func directIngestOrbitInfo(ctx context.Context, logger log.Logger, host *fleet.H
 }
 
 // directIngestOSWindows ingests selected operating system data from a host on a Windows platform
-func directIngestOSWindows(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string, failed bool) error {
-	if failed {
-		level.Error(logger).Log("op", "directIngestOSWindows", "err", "failed")
-		return nil
-	}
+func directIngestOSWindows(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	if len(rows) != 1 {
 		return ctxerr.Errorf(ctx, "directIngestOSWindows invalid number of rows: %d", len(rows))
 	}
@@ -897,17 +794,7 @@ func directIngestOSWindows(ctx context.Context, logger log.Logger, host *fleet.H
 		Platform:      rows[0]["platform"],
 	}
 
-	var version string
-	switch {
-	case rows[0]["display_version"] != "":
-		// prefer display version if available
-		version = rows[0]["display_version"]
-	case rows[0]["release_id"] != "":
-		// otherwise release_id if available
-		version = rows[0]["release_id"]
-	default:
-		// empty value
-	}
+	version := rows[0]["display_version"]
 	if version == "" {
 		level.Debug(logger).Log(
 			"msg", "unable to identify windows version",
@@ -924,11 +811,7 @@ func directIngestOSWindows(ctx context.Context, logger log.Logger, host *fleet.H
 
 // directIngestOSUnixLike ingests selected operating system data from a host on a Unix-like platform
 // (e.g., darwin or linux operating systems)
-func directIngestOSUnixLike(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string, failed bool) error {
-	if failed {
-		level.Error(logger).Log("op", "directIngestOSUnixLike", "err", "failed")
-		return nil
-	}
+func directIngestOSUnixLike(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	if len(rows) != 1 {
 		return ctxerr.Errorf(ctx, "directIngestOSUnixLike invalid number of rows: %d", len(rows))
 	}
@@ -970,12 +853,7 @@ func parseOSVersion(name string, version string, major string, minor string, pat
 	return osVersion
 }
 
-func directIngestChromeProfiles(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string, failed bool) error {
-	if failed {
-		// assume the extension is not there
-		return nil
-	}
-
+func directIngestChromeProfiles(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	mapping := make([]*fleet.HostDeviceMapping, 0, len(rows))
 	for _, row := range rows {
 		mapping = append(mapping, &fleet.HostDeviceMapping{
@@ -987,12 +865,7 @@ func directIngestChromeProfiles(ctx context.Context, logger log.Logger, host *fl
 	return ds.ReplaceHostDeviceMapping(ctx, host.ID, mapping)
 }
 
-func directIngestBattery(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string, failed bool) error {
-	if failed {
-		level.Error(logger).Log("op", "directIngestBattery", "err", "failed")
-		return nil
-	}
-
+func directIngestBattery(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	mapping := make([]*fleet.HostBattery, 0, len(rows))
 	for _, row := range rows {
 		cycleCount, err := strconv.ParseInt(EmptyToZero(row["cycle_count"]), 10, 64)
@@ -1018,13 +891,7 @@ func directIngestWindowsUpdateHistory(
 	host *fleet.Host,
 	ds fleet.Datastore,
 	rows []map[string]string,
-	failed bool,
 ) error {
-	if failed {
-		level.Error(logger).Log("op", "directIngestWindowsUpdateHistory", "err", "failed")
-		return nil
-	}
-
 	// The windows update history table will also contain entries for the Defender Antivirus. Unfortunately
 	// there's no reliable way to differentiate between those entries and Cumulative OS updates.
 	// Since each antivirus update will have the same KB ID, but different 'dates', to
@@ -1052,12 +919,7 @@ func directIngestWindowsUpdateHistory(
 	return ds.InsertWindowsUpdates(ctx, host.ID, updates)
 }
 
-func directIngestScheduledQueryStats(ctx context.Context, logger log.Logger, host *fleet.Host, task *async.Task, rows []map[string]string, failed bool) error {
-	if failed {
-		level.Error(logger).Log("op", "directIngestScheduledQueryStats", "err", "failed")
-		return nil
-	}
-
+func directIngestScheduledQueryStats(ctx context.Context, logger log.Logger, host *fleet.Host, task *async.Task, rows []map[string]string) error {
 	packs := map[string][]fleet.ScheduledQueryStats{}
 	for _, row := range rows {
 		providedName := row["name"]
@@ -1127,12 +989,7 @@ func directIngestScheduledQueryStats(ctx context.Context, logger log.Logger, hos
 	return nil
 }
 
-func directIngestSoftware(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string, failed bool) error {
-	if failed {
-		level.Error(logger).Log("op", "directIngestSoftware", "err", "failed")
-		return nil
-	}
-
+func directIngestSoftware(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	var software []fleet.Software
 	for _, row := range rows {
 		name := row["name"]
@@ -1203,7 +1060,7 @@ func directIngestSoftware(ctx context.Context, logger log.Logger, host *fleet.Ho
 	return nil
 }
 
-func directIngestUsers(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string, failed bool) error {
+func directIngestUsers(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	var users []fleet.HostUser
 	for _, row := range rows {
 		uid, err := strconv.Atoi(row["uid"])
@@ -1232,8 +1089,8 @@ func directIngestUsers(ctx context.Context, logger log.Logger, host *fleet.Host,
 	return nil
 }
 
-func directIngestMDMMac(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string, failed bool) error {
-	if len(rows) == 0 || failed {
+func directIngestMDMMac(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+	if len(rows) == 0 {
 		// assume the extension is not there
 		return nil
 	}
@@ -1261,11 +1118,7 @@ func directIngestMDMMac(ctx context.Context, logger log.Logger, host *fleet.Host
 	return ds.SetOrUpdateMDMData(ctx, host.ID, false, enrolled, rows[0]["server_url"], installedFromDep, "")
 }
 
-func directIngestMDMWindows(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string, failed bool) error {
-	if failed {
-		level.Error(logger).Log("op", "directIngestMDMWindows", "err", "failed")
-		return nil
-	}
+func directIngestMDMWindows(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	data := make(map[string]string, len(rows))
 	for _, r := range rows {
 		data[r["key"]] = r["value"]
@@ -1276,8 +1129,8 @@ func directIngestMDMWindows(ctx context.Context, logger log.Logger, host *fleet.
 	return ds.SetOrUpdateMDMData(ctx, host.ID, isServer, enrolled, data["discovery_service_url"], autoPilot, data["provider_id"])
 }
 
-func directIngestMunkiInfo(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string, failed bool) error {
-	if len(rows) == 0 || failed {
+func directIngestMunkiInfo(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+	if len(rows) == 0 {
 		// assume the extension is not there
 		return nil
 	}
@@ -1291,12 +1144,7 @@ func directIngestMunkiInfo(ctx context.Context, logger log.Logger, host *fleet.H
 	return ds.SetOrUpdateMunkiInfo(ctx, host.ID, rows[0]["version"], errList, warnList)
 }
 
-func directIngestDiskEncryptionLinux(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string, failed bool) error {
-	if failed {
-		level.Error(logger).Log("op", "directIngestDiskEncryptionLinux", "err", "failed")
-		return nil
-	}
-
+func directIngestDiskEncryptionLinux(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	encrypted := false
 	for _, row := range rows {
 		if row["path"] == "/" && row["encrypted"] == "1" {
@@ -1308,16 +1156,7 @@ func directIngestDiskEncryptionLinux(ctx context.Context, logger log.Logger, hos
 	return ds.SetOrUpdateHostDisksEncryption(ctx, host.ID, encrypted)
 }
 
-func directIngestDiskEncryption(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string, failed bool) error {
-	if failed {
-		level.Error(logger).Log("op", "directIngestDiskEncryption", "err", "failed")
-		return nil
-	}
-	if len(rows) > 1 {
-		logger.Log("component", "service", "method", "directIngestDiskEncryption", "warn",
-			fmt.Sprintf("disk_encryption expected at most a single result, got %d", len(rows)))
-	}
-
+func directIngestDiskEncryption(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	encrypted := len(rows) > 0
 	return ds.SetOrUpdateHostDisksEncryption(ctx, host.ID, encrypted)
 }

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -440,6 +440,7 @@ func TestDirectIngestMDMWindows(t *testing.T) {
 		return nil
 	}
 
+	var host fleet.Host
 	err := directIngestMDMWindows(context.Background(), log.NewNopLogger(), &host, ds, []map[string]string{
 		{"key": "discovery_service_url", "value": "some url"},
 		{"key": "autopilot", "value": "true"},
@@ -727,7 +728,6 @@ func TestDirectIngestSoftware(t *testing.T) {
 				&fleet.Host{ID: uint(i)},
 				ds,
 				tc.data,
-				false,
 			)
 
 			require.NoError(t, err)

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -405,7 +405,7 @@ func TestDetailQueriesOSVersionWindows(t *testing.T) {
 	))
 
 	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, rows))
-	assert.Equal(t, "Windows 10 Enterprise LTSC 1809", host.OSVersion)
+	assert.Equal(t, "Windows 10 Enterprise LTSC ", host.OSVersion)
 }
 
 func TestDirectIngestMDMMac(t *testing.T) {
@@ -514,17 +514,6 @@ func TestDirectIngestOSWindows(t *testing.T) {
 			},
 			data: []map[string]string{
 				{"name": "Microsoft Windows 11 Enterprise", "display_version": "21H2", "release_id": "", "arch": "64-bit", "kernel_version": "10.0.22000.795"},
-			},
-		},
-		{
-			expected: fleet.OperatingSystem{
-				Name:          "Microsoft Windows 10 Enterprise LTSC",
-				Version:       "1809",
-				Arch:          "64-bit",
-				KernelVersion: "10.0.17763",
-			},
-			data: []map[string]string{
-				{"name": "Microsoft Windows 10 Enterprise LTSC", "display_version": "", "release_id": "1809", "arch": "64-bit", "kernel_version": "10.0.17763"},
 			},
 		},
 	}


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- ~Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~Documented any permissions changes~
- ~Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [x] Added/updated tests
- ~Manual QA for all new/changed functionality~
