### PR TITLE
Add new configuration option to set default team for Apple Business Manager

### DIFF
--- a/changes/8733-apple-business-manager-set-default-team
+++ b/changes/8733-apple-business-manager-set-default-team
@@ -1,0 +1,1 @@
+- Add new configuration option to set default team for Apple Business Manager

--- a/changes/8733-mdm-default-team
+++ b/changes/8733-mdm-default-team
@@ -1,0 +1,1 @@
+- Add application configuration: mdm.apple_bm_default_team.

--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -1125,12 +1125,8 @@ func getMDMAppleBMCommand() *cli.Command {
 				}
 				return fmt.Errorf("could not get Apple BM information: %w", err)
 			}
-			config, err := client.GetAppConfig()
-			if err != nil {
-				return fmt.Errorf("could not get app config: %w", err)
-			}
 
-			defaultTeam := config.MDM.AppleBMDefaultTeam
+			defaultTeam := bm.DefaultTeam
 			if defaultTeam == "" {
 				defaultTeam = "No team"
 			}

--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -1125,8 +1125,12 @@ func getMDMAppleBMCommand() *cli.Command {
 				}
 				return fmt.Errorf("could not get Apple BM information: %w", err)
 			}
+			config, err := client.GetAppConfig()
+			if err != nil {
+				return fmt.Errorf("could not get app config: %w", err)
+			}
 
-			defaultTeam := bm.DefaultTeam
+			defaultTeam := config.MDM.AppleBMDefaultTeam
 			if defaultTeam == "" {
 				defaultTeam = "No team"
 			}

--- a/cmd/fleetctl/get_test.go
+++ b/cmd/fleetctl/get_test.go
@@ -473,6 +473,8 @@ spec:
   integrations:
     jira: null
     zendesk: null
+  mdm:
+    apple_bm_default_team: ""
   org_info:
     org_logo_url: ""
     org_name: ""
@@ -592,7 +594,8 @@ spec:
       },
       "interval": "0s"
     },
-    "integrations": { "jira": null, "zendesk": null }
+    "integrations": { "jira": null, "zendesk": null },
+	"mdm": { "apple_bm_default_team": "" }
   }
 }
 `
@@ -618,6 +621,8 @@ spec:
   integrations:
     jira: null
     zendesk: null
+  mdm:
+    apple_bm_default_team: ""
   license:
     expiration: "0001-01-01T00:00:00Z"
     tier: free
@@ -780,6 +785,9 @@ spec:
     "integrations": {
       "jira": null,
       "zendesk": null
+    },
+    "mdm": {
+      "apple_bm_default_team": ""
     },
     "update_interval": {
       "osquery_detail": "1h0m0s",

--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -1004,7 +1004,7 @@ Modifies the Fleet's configuration with the supplied information.
 | email                             | string  | body  | _integrations.zendesk[] settings_. The Zendesk user email to use for this Zendesk integration. |
 | api_token                         | string  | body  | _integrations.zendesk[] settings_. The Zendesk API token to use for this Zendesk integration. |
 | group_id                          | integer | body  | _integrations.zendesk[] settings_. The Zendesk group id to use for this integration. Zendesk tickets will be created in this group. |
-| apple_bm_default_team             | string  | body  | _mdm setting_. The default team to use with Apple Business Manager. |
+| apple_bm_default_team             | string  | body  | _mdm settings_. The default team to use with Apple Business Manager. |
 | additional_queries                | boolean | body  | Whether or not additional queries are enabled on hosts.                                                                                                                                |
 | force                             | bool    | query | Force apply the agent options even if there are validation errors.                                                                                                 |
 | dry_run                           | bool    | query | Validate the configuration and return any validation errors, but do not apply the changes.                                                                         |

--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -904,6 +904,9 @@ None.
   "integrations": {
     "jira": null
   },
+  "mdm": {
+    "apple_bm_default_team": ""
+  },
   "logging": {
     "debug": false,
     "json": false,
@@ -1001,6 +1004,7 @@ Modifies the Fleet's configuration with the supplied information.
 | email                             | string  | body  | _integrations.zendesk[] settings_. The Zendesk user email to use for this Zendesk integration. |
 | api_token                         | string  | body  | _integrations.zendesk[] settings_. The Zendesk API token to use for this Zendesk integration. |
 | group_id                          | integer | body  | _integrations.zendesk[] settings_. The Zendesk group id to use for this integration. Zendesk tickets will be created in this group. |
+| apple_bm_default_team             | string  | body  | _mdm setting_. The default team to use with Apple Business Manager. |
 | additional_queries                | boolean | body  | Whether or not additional queries are enabled on hosts.                                                                                                                                |
 | force                             | bool    | query | Force apply the agent options even if there are validation errors.                                                                                                 |
 | dry_run                           | bool    | query | Validate the configuration and return any validation errors, but do not apply the changes.                                                                         |
@@ -1127,6 +1131,9 @@ Modifies the Fleet's configuration with the supplied information.
         "enable_software_vulnerabilities": false
       }
     ]
+  },
+  "mdm": {
+    "apple_bm_default_team": ""
   },
   "logging": {
       "debug": false,
@@ -1705,7 +1712,7 @@ None.
 | os_id                   | integer | query | The ID of the operating system to filter hosts by.                                                                                                                                                                                                                                                                                          |
 | os_name                 | string  | query | The name of the operating system to filter hosts by. `os_version` must also be specified with `os_name`                                                                                                                                                                                                                                     |
 | os_version              | string  | query | The version of the operating system to filter hosts by. `os_name` must also be specified with `os_version`                                                                                                                                                                                                                                  |
-| device_mapping          | boolean | query | Indicates whether `device_mapping` should be included for each host. See ["Get host's Google Chrome profiles](#get-host's-google-chrome-profiles) for more information about this feature.                                                                                                                                                  |
+| device_mapping          | boolean | query | Indicates whether `device_mapping` should be included for each host. See ["Get host's Google Chrome profiles](#get-hosts-google-chrome-profiles) for more information about this feature.                                                                                                                                                  |
 | mdm_id                  | integer | query | The ID of the _mobile device management_ (MDM) solution to filter hosts by (that is, filter hosts that use a specific MDM provider and URL).                                                                                                                                                                                                |
 | mdm_enrollment_status   | string  | query | The _mobile device management_ (MDM) enrollment status to filter hosts by. Can be one of 'manual', 'automatic' or 'unenrolled'.                                                                                                                                                                                                             |
 | munki_issue_id          | integer | query | The ID of the _munki issue_ (a Munki-reported error or warning message) to filter hosts by (that is, filter hosts that are affected by that corresponding error or warning message).                                                                                                                                                        |

--- a/docs/Using-Fleet/configuration-files/README.md
+++ b/docs/Using-Fleet/configuration-files/README.md
@@ -254,6 +254,8 @@ spec:
       destination_url: ""
       enable_vulnerabilities_webhook: false
       host_batch_size: 0
+  mdm:
+    apple_bm_default_team: ""
 ```
 
 ### Settings
@@ -1116,6 +1118,23 @@ agent_options:
   command_line_flags:
     enable_file_events: true
 ```
+
+#### MDM Setting
+
+MDM Options, currently supports Apple Business Manager.
+
+**Applies only to Fleet Premium**.
+
+##### mdm.apple_bm_default_team
+
+Set name of default team to use with Apple Business Manager.
+
+- Default value: ""
+- Config file format:
+  ```yaml
+  mdm:
+    team: "Workstations"
+  ```
 
 #### Advanced configuration
 

--- a/docs/Using-Fleet/configuration-files/README.md
+++ b/docs/Using-Fleet/configuration-files/README.md
@@ -1119,7 +1119,7 @@ agent_options:
     enable_file_events: true
 ```
 
-#### MDM Setting
+#### MDM settings
 
 MDM Options, currently supports Apple Business Manager.
 

--- a/docs/Using-Fleet/configuration-files/README.md
+++ b/docs/Using-Fleet/configuration-files/README.md
@@ -1121,7 +1121,7 @@ agent_options:
 
 #### MDM settings
 
-MDM Options, currently supports Apple Business Manager.
+Fleet currently supports Apple Business Manager for mobile device management (MDM).
 
 **Applies only to Fleet Premium**.
 

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -42,7 +42,7 @@ func (svc *Service) GetAppleBM(ctx context.Context) (*fleet.AppleBM, error) {
 	appleBM.RenewDate = tok.AccessTokenExpiry
 	// TODO: default team will have to be set when https://github.com/fleetdm/fleet/issues/8733
 	// is implemented.
-	appleBM.DefaultTeam = ""
+	appleBM.DefaultTeam = appCfg.MDM.AppleBMDefaultTeam
 	appleBM.MDMServerURL = appCfg.ServerSettings.ServerURL + apple_mdm.MDMPath
 
 	return appleBM, nil

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -100,6 +100,11 @@ type VulnerabilitySettings struct {
 	DatabasesPath string `json:"databases_path"`
 }
 
+// MDM is part of AppConfig and defines the mdm settings.
+type MDM struct {
+	AppleBMDefaultTeam string `json:"apple_bm_default_team"`
+}
+
 // AppConfig holds server configuration that can be changed via the API.
 //
 // Note: management of deprecated fields is done on JSON-marshalling and uses
@@ -124,6 +129,8 @@ type AppConfig struct {
 
 	WebhookSettings WebhookSettings `json:"webhook_settings"`
 	Integrations    Integrations    `json:"integrations"`
+
+	MDM MDM `json:"mdm"`
 
 	// when true, strictDecoding causes the UnmarshalJSON method to return an
 	// error if there are unknown fields in the raw JSON.

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -103,6 +103,11 @@ type VulnerabilitySettings struct {
 // MDM is part of AppConfig and defines the mdm settings.
 type MDM struct {
 	AppleBMDefaultTeam string `json:"apple_bm_default_team"`
+
+	/////////////////////////////////////////////////////////////////
+	// WARNING: If you add to this struct make sure it's taken into
+	// account in the AppConfig Clone implementation!
+	/////////////////////////////////////////////////////////////////
 }
 
 // AppConfig holds server configuration that can be changed via the API.
@@ -151,9 +156,15 @@ type legacyConfig struct {
 	HostSettings *Features `json:"host_settings"`
 }
 
+// Clone implements cloner.
 func (c *AppConfig) Clone() (interface{}, error) {
+	return c.Copy(), nil
+}
+
+// Copy returns a copy of the AppConfig.
+func (c *AppConfig) Copy() *AppConfig {
 	if c == nil {
-		return nil, nil
+		return nil
 	}
 
 	var clone AppConfig
@@ -204,7 +215,7 @@ func (c *AppConfig) Clone() (interface{}, error) {
 		}
 	}
 
-	return &clone, nil
+	return &clone
 }
 
 // EnrichedAppConfig contains the AppConfig along with additional fleet

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -244,6 +244,7 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	if err != nil {
 		return nil, err
 	}
+	oldAppConfig := appConfig.Copy()
 
 	license, err := svc.License(ctx)
 	if err != nil {
@@ -332,8 +333,7 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	fleet.ValidateEnabledVulnerabilitiesIntegrations(appConfig.WebhookSettings.VulnerabilitiesWebhook, appConfig.Integrations, invalid)
 	fleet.ValidateEnabledFailingPoliciesIntegrations(appConfig.WebhookSettings.FailingPoliciesWebhook, appConfig.Integrations, invalid)
 	fleet.ValidateEnabledHostStatusIntegrations(appConfig.WebhookSettings.HostStatusWebhook, invalid)
-
-	svc.validateMDM(ctx, appConfig.MDM, invalid)
+	svc.validateMDM(ctx, license, &oldAppConfig.MDM, &appConfig.MDM, invalid)
 
 	if invalid.HasErrors() {
 		return nil, ctxerr.Wrap(ctx, invalid)
@@ -394,7 +394,6 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	if license.Tier != "premium" {
 		// reset transparency url to empty for downgraded licenses
 		appConfig.FleetDesktop.TransparencyURL = ""
-		appConfig.MDM = fleet.MDM{}
 	}
 
 	if err := svc.ds.SaveAppConfig(ctx, appConfig); err != nil {
@@ -426,8 +425,18 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	return obfuscatedConfig, nil
 }
 
-func (svc *Service) validateMDM(ctx context.Context, mdm fleet.MDM, invalid *fleet.InvalidArgumentError) {
-	if name := mdm.AppleBMDefaultTeam; name != "" {
+func (svc *Service) validateMDM(
+	ctx context.Context,
+	license *fleet.LicenseInfo,
+	oldMdm *fleet.MDM,
+	mdm *fleet.MDM,
+	invalid *fleet.InvalidArgumentError,
+) {
+	if name := mdm.AppleBMDefaultTeam; name != "" && name != oldMdm.AppleBMDefaultTeam {
+		if !license.IsPremium() {
+			invalid.Append("mdm.apple_bm_default_team", ErrMissingLicense.Error())
+			return
+		}
 		if _, err := svc.ds.TeamByName(ctx, name); err != nil {
 			invalid.Append("apple_bm_default_team", "team name not found")
 		}

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -332,6 +332,9 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	fleet.ValidateEnabledVulnerabilitiesIntegrations(appConfig.WebhookSettings.VulnerabilitiesWebhook, appConfig.Integrations, invalid)
 	fleet.ValidateEnabledFailingPoliciesIntegrations(appConfig.WebhookSettings.FailingPoliciesWebhook, appConfig.Integrations, invalid)
 	fleet.ValidateEnabledHostStatusIntegrations(appConfig.WebhookSettings.HostStatusWebhook, invalid)
+
+	svc.validateMDM(ctx, appConfig.MDM, invalid)
+
 	if invalid.HasErrors() {
 		return nil, ctxerr.Wrap(ctx, invalid)
 	}
@@ -388,9 +391,10 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		}
 	}
 
-	// reset transparency url to empty for downgraded licenses
-	if license.Tier != "premium" && appConfig.FleetDesktop.TransparencyURL != "" {
+	if license.Tier != "premium" {
+		// reset transparency url to empty for downgraded licenses
 		appConfig.FleetDesktop.TransparencyURL = ""
+		appConfig.MDM = fleet.MDM{}
 	}
 
 	if err := svc.ds.SaveAppConfig(ctx, appConfig); err != nil {
@@ -420,6 +424,14 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	}
 
 	return obfuscatedConfig, nil
+}
+
+func (svc *Service) validateMDM(ctx context.Context, mdm fleet.MDM, invalid *fleet.InvalidArgumentError) {
+	if name := mdm.AppleBMDefaultTeam; name != "" {
+		if _, err := svc.ds.TeamByName(ctx, name); err != nil {
+			invalid.Append("apple_bm_default_team", "team name not found")
+		}
+	}
 }
 
 func validateSSOSettings(p fleet.AppConfig, existing *fleet.AppConfig, invalid *fleet.InvalidArgumentError, license *fleet.LicenseInfo) {

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -621,4 +622,103 @@ func TestTransparencyURLDowngradeLicense(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "f1337", ac.OrgInfo.OrgName)
 	require.Equal(t, "", ac.FleetDesktop.TransparencyURL)
+}
+
+func TestService_ModifyAppConfig_MDM(t *testing.T) {
+	ds := new(mock.Store)
+
+	admin := &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}
+
+	const licenseErr = "missing or invalid license"
+	const notFoundErr = "not found"
+	testCases := []struct {
+		name          string
+		licenseTier   string
+		oldMDM        fleet.MDM
+		newMDM        fleet.MDM
+		expectedMDM   fleet.MDM
+		expectedError string
+		findTeam      bool
+	}{
+		{
+			name:        "nochange",
+			licenseTier: "free",
+		}, {
+			name:          "newDefaultTeamNoLicense",
+			licenseTier:   "free",
+			newMDM:        fleet.MDM{AppleBMDefaultTeam: "foobar"},
+			expectedError: licenseErr,
+		}, {
+			name:          "notFoundNew",
+			licenseTier:   "premium",
+			newMDM:        fleet.MDM{AppleBMDefaultTeam: "foobar"},
+			expectedError: notFoundErr,
+		}, {
+			name:          "notFoundEdit",
+			licenseTier:   "premium",
+			oldMDM:        fleet.MDM{AppleBMDefaultTeam: "foobar"},
+			newMDM:        fleet.MDM{AppleBMDefaultTeam: "bar"},
+			expectedError: notFoundErr,
+		}, {
+			name:        "foundNew",
+			licenseTier: "premium",
+			findTeam:    true,
+			newMDM:      fleet.MDM{AppleBMDefaultTeam: "foobar"},
+			expectedMDM: fleet.MDM{AppleBMDefaultTeam: "foobar"},
+		}, {
+			name:        "foundEdit",
+			licenseTier: "premium",
+			findTeam:    true,
+			oldMDM:      fleet.MDM{AppleBMDefaultTeam: "bar"},
+			newMDM:      fleet.MDM{AppleBMDefaultTeam: "foobar"},
+			expectedMDM: fleet.MDM{AppleBMDefaultTeam: "foobar"},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: &fleet.LicenseInfo{Tier: tt.licenseTier}})
+			ctx = viewer.NewContext(ctx, viewer.Viewer{User: admin})
+
+			dsAppConfig := &fleet.AppConfig{
+				OrgInfo:        fleet.OrgInfo{OrgName: "Test"},
+				ServerSettings: fleet.ServerSettings{ServerURL: "https://example.org"},
+				MDM:            tt.oldMDM,
+			}
+
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return dsAppConfig, nil
+			}
+
+			ds.SaveAppConfigFunc = func(ctx context.Context, conf *fleet.AppConfig) error {
+				*dsAppConfig = *conf
+				return nil
+			}
+			ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+				if tt.findTeam {
+					return &fleet.Team{}, nil
+				}
+				return nil, errors.New(notFoundErr)
+			}
+
+			ac, err := svc.AppConfig(ctx)
+			require.NoError(t, err)
+			require.Equal(t, tt.oldMDM, ac.MDM)
+
+			raw, err := json.Marshal(tt.newMDM)
+			require.NoError(t, err)
+			raw = []byte(`{"mdm":` + string(raw) + `}`)
+			modified, err := svc.ModifyAppConfig(ctx, raw, fleet.ApplySpecOptions{})
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.expectedError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedMDM, modified.MDM)
+			ac, err = svc.AppConfig(ctx)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedMDM, ac.MDM)
+		})
+	}
 }

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -61,12 +61,12 @@ type Service struct {
 	cronSchedulesService fleet.CronSchedulesService
 }
 
-func (s *Service) LookupGeoIP(ctx context.Context, ip string) *fleet.GeoLocation {
-	return s.geoIP.Lookup(ctx, ip)
+func (svc *Service) LookupGeoIP(ctx context.Context, ip string) *fleet.GeoLocation {
+	return svc.geoIP.Lookup(ctx, ip)
 }
 
-func (s *Service) SetEnterpriseOverrides(overrides fleet.EnterpriseOverrides) {
-	s.EnterpriseOverrides = &overrides
+func (svc *Service) SetEnterpriseOverrides(overrides fleet.EnterpriseOverrides) {
+	svc.EnterpriseOverrides = &overrides
 }
 
 // NewService creates a new service from the config struct
@@ -126,8 +126,8 @@ func NewService(
 	return validationMiddleware{svc, ds, sso}, nil
 }
 
-func (s *Service) SendEmail(mail fleet.Email) error {
-	return s.mailService.SendEmail(mail)
+func (svc *Service) SendEmail(mail fleet.Email) error {
+	return svc.mailService.SendEmail(mail)
 }
 
 type validationMiddleware struct {


### PR DESCRIPTION
For  #8733

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)

- [X] Manual QA for all new/changed functionality
