### PR TITLE
Temporarily remove docs DRI

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,7 +21,11 @@ go.mod @fleetdm/go
 /CHANGELOG.md @noahtalerman
 
 # Fleet documentation
-/docs/ @chris-mcgillicuddy @ksatter @jarodreyes
+# TODO: will anyone be auto-requested as reviewer for docs?
+# previously this was:
+# /docs/ @chris-mcgillicuddy
+# then mikermcneil added more folks, but it was a bad idea that resulted in a lot of extra notifications to ≥3 people.
+# So instead, who will be DRI for reviewing docs?
 
 # REST API reference documentation
 /docs/Using-Fleet/REST-API.md @ksatter @lukeheath


### PR DESCRIPTION
.  Reverse a previous change I made that was a mistake, and temporarily remove automated requests for review for documentation in general.  As it was, it wasn't working, and was just creating noise for more folks e.g. extra reviewers in https://github.com/fleetdm/fleet/pull/9001 didn't mean doc changes were getting reviewed quickly-- just meant more notifications for folks.

@chris-mcgillicuddy could you let @jarodreyes know how it's been going as far as routing documentation PRs for review?  I think it's worth reevaluating this approach.  (e.g. maybe a daily editor check of new doc changes like Desmi was running is more sustainable and adds less friction / distraction)