### PR TITLE
fix failed enrollments due to duplicate slashes on paths

### DIFF
--- a/changes/9088-mdm-enroll-urls
+++ b/changes/9088-mdm-enroll-urls
@@ -1,0 +1,1 @@
+- Fixed an issue causing enrollment profiles to fail if the server URL had a trailing slash.

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -188,3 +188,35 @@ func TestAppleMDMAuthorization(t *testing.T) {
 	_, err = svc.NewMDMAppleDEPKeyPair(ctx)
 	require.NoError(t, err)
 }
+
+func TestMDMAppleEnrollURL(t *testing.T) {
+	svc := Service{}
+
+	cases := []struct {
+		appConfig   *fleet.AppConfig
+		expectedURL string
+	}{
+		{
+			appConfig: &fleet.AppConfig{
+				ServerSettings: fleet.ServerSettings{
+					ServerURL: "https://foo.example.com",
+				},
+			},
+			expectedURL: "https://foo.example.com/api/mdm/apple/enroll?token=tok",
+		},
+		{
+			appConfig: &fleet.AppConfig{
+				ServerSettings: fleet.ServerSettings{
+					ServerURL: "https://foo.example.com/",
+				},
+			},
+			expectedURL: "https://foo.example.com/api/mdm/apple/enroll?token=tok",
+		},
+	}
+
+	for _, tt := range cases {
+		enrollURL, err := svc.mdmAppleEnrollURL("tok", tt.appConfig)
+		require.NoError(t, err)
+		require.Equal(t, tt.expectedURL, enrollURL)
+	}
+}


### PR DESCRIPTION
This ensures URLs in enrollment profiles are properly formatted, preventing errors as described in #9088.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
