### PR TITLE
Fleet UI: Fix multi select styling on schedule, packs, members

### DIFF
--- a/changes/bug-9100-multi-select-styling
+++ b/changes/bug-9100-multi-select-styling
@@ -1,0 +1,1 @@
+- Fixes to multiselect styling

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -251,14 +251,12 @@
       flex-grow: 1;
 
       .Select-value {
-        margin-top: 1px;
-        border: 1px solid #6a67fe;
-        background-color: #f1f0ff;
+        border: 1px solid $ui-fleet-black-75;
         vertical-align: middle;
+        margin-top: 0;
 
         .Select-value-label {
           font-size: $x-small;
-          height: 16px;
         }
       }
     }

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -254,9 +254,12 @@
         border: 1px solid $ui-fleet-black-75;
         vertical-align: middle;
         margin-top: 0;
+        display: inline-flex;
+        flex-direction: row-reverse;
 
         .Select-value-label {
           font-size: $x-small;
+          align-self: center;
         }
       }
     }

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -252,9 +252,13 @@
 
       .Select-value {
         margin-top: 1px;
+        border: 1px solid #6a67fe;
+        background-color: #f1f0ff;
+        vertical-align: middle;
 
         .Select-value-label {
           font-size: $x-small;
+          height: 16px;
         }
       }
     }

--- a/frontend/components/forms/fields/SelectTargetsDropdown/_styles.scss
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/_styles.scss
@@ -98,13 +98,6 @@
           border-bottom-left-radius: 0;
         }
       }
-
-      .Select-value {
-        line-height: 34px;
-        border: 1px solid $ui-fleet-black-75;
-        margin-top: 5px;
-        margin-bottom: 0;
-      }
     }
   }
 

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/components/AutocompleteDropdown/_styles.scss
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/components/AutocompleteDropdown/_styles.scss
@@ -1,5 +1,13 @@
 .autocomplete-dropdown {
   .Select {
+    border: solid 1px $ui-fleet-blue-15;
+    border-radius: 4px;
+
+    &:hover,
+    &.is-focused {
+      border-color: $core-vibrant-blue;
+    }
+
     &.Select--multi {
       .Select-option {
         color: $core-fleet-black;
@@ -32,10 +40,6 @@
       .Select-value {
         border: 1px solid $core-vibrant-blue;
         background-color: $ui-vibrant-blue-10;
-
-        .Select-value-label {
-          font-weight: $bold;
-        }
 
         .Select-value-icon {
           &:after {


### PR DESCRIPTION
### Issue
Cerra #9100 

### Fixes

#### Multi select (applies to schedule and packs platform picker)
- Fix pill outline color
- Use display: flex and vertical alignments to vertically align correctly no matter the size (e.g. select targets height is larger) replacing styling by moving pixels

#### Members
- Add grey border to match other input fields
- Add blue hover border for focus state and hover state to match other input fields
- Align pills vertically
- Remove bold text on pills

### Screenshots
<img width="1473" alt="Screenshot 2022-12-22 at 12 56 25 PM" src="https://user-images.githubusercontent.com/71795832/209196886-9195ad21-f1e0-4889-ae30-e7f0e3d2b7ec.png">
<img width="1477" alt="Screenshot 2022-12-22 at 12 55 27 PM" src="https://user-images.githubusercontent.com/71795832/209196888-307f74e0-d5a6-4bb3-bd04-dbb7870183d6.png">
<img width="1470" alt="Screenshot 2022-12-22 at 12 55 11 PM" src="https://user-images.githubusercontent.com/71795832/209196889-10b827b4-0f8b-4d6a-8258-0470b1c5884b.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
