### PR TITLE
Use ubuntu-20.04 runner for Fleet build

### DIFF
--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: Docker Hub
     permissions:
       contents: write

--- a/changes/build-ubuntu-20
+++ b/changes/build-ubuntu-20
@@ -1,0 +1,1 @@
+* Build on Ubuntu 20 to resolve glibc changes that were causing issues for older Docker runtimes.


### PR DESCRIPTION
A customer had a seccomp profile that seemed to be incompatible with the changes in glibc in ubuntu-22.04. Setting the builder back to 20.04 explicitly to resolve this issue.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
