### PR TITLE
Generate targets for osqueryd 5.7.0

### DIFF
--- a/.github/workflows/generate-osqueryd-targets.yml
+++ b/.github/workflows/generate-osqueryd-targets.yml
@@ -24,7 +24,7 @@ defaults:
     shell: bash
 
 env:
-  OSQUERY_VERSION: 5.6.0
+  OSQUERY_VERSION: 5.7.0
 
 permissions:
   contents: read


### PR DESCRIPTION
5.7.0 is now in pre-release.