### PR TITLE
Set interface for response types

### DIFF
--- a/docs/Contributing/Adding-new-endpoints.md
+++ b/docs/Contributing/Adding-new-endpoints.md
@@ -111,7 +111,7 @@ type countAllHostsResponse struct {
 
 func (r countAllHostsResponse) error() error { return r.Err }
 
-func countAllHostsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func countAllHostsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
     req := request.(*countAllHostsRequest)
     count, err := svc.CountAllHosts(ctx)
     if err != nil {

--- a/server/service/activities.go
+++ b/server/service/activities.go
@@ -21,7 +21,7 @@ type listActivitiesResponse struct {
 
 func (r listActivitiesResponse) error() error { return r.Err }
 
-func listActivitiesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listActivitiesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*listActivitiesRequest)
 	activities, err := svc.ListActivities(ctx, fleet.ListActivitiesOptions{
 		ListOptions: req.ListOptions,

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -75,7 +75,7 @@ func (r *appConfigResponse) UnmarshalJSON(data []byte) error {
 
 func (r appConfigResponse) error() error { return r.Err }
 
-func getAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	vc, ok := viewer.FromContext(ctx)
 	if !ok {
 		return nil, errors.New("could not fetch user")
@@ -196,7 +196,7 @@ type modifyAppConfigRequest struct {
 	json.RawMessage
 }
 
-func modifyAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func modifyAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*modifyAppConfigRequest)
 	config, err := svc.ModifyAppConfig(ctx, req.RawMessage, fleet.ApplySpecOptions{
 		Force:  req.Force,
@@ -467,7 +467,7 @@ type applyEnrollSecretSpecResponse struct {
 
 func (r applyEnrollSecretSpecResponse) error() error { return r.Err }
 
-func applyEnrollSecretSpecEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func applyEnrollSecretSpecEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*applyEnrollSecretSpecRequest)
 	err := svc.ApplyEnrollSecretSpec(ctx, req.Spec)
 	if err != nil {
@@ -508,7 +508,7 @@ type getEnrollSecretSpecResponse struct {
 
 func (r getEnrollSecretSpecResponse) error() error { return r.Err }
 
-func getEnrollSecretSpecEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getEnrollSecretSpecEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	specs, err := svc.GetEnrollSecretSpec(ctx)
 	if err != nil {
 		return getEnrollSecretSpecResponse{Err: err}, nil
@@ -539,7 +539,7 @@ type versionResponse struct {
 
 func (r versionResponse) error() error { return r.Err }
 
-func versionEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func versionEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	info, err := svc.Version(ctx)
 	if err != nil {
 		return versionResponse{Err: err}, nil
@@ -567,7 +567,7 @@ type getCertificateResponse struct {
 
 func (r getCertificateResponse) error() error { return r.Err }
 
-func getCertificateEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getCertificateEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	chain, err := svc.CertificateChain(ctx)
 	if err != nil {
 		return getCertificateResponse{Err: err}, nil

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -44,7 +44,7 @@ type createMDMAppleEnrollmentProfileResponse struct {
 
 func (r createMDMAppleEnrollmentProfileResponse) error() error { return r.Err }
 
-func createMDMAppleEnrollmentProfilesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func createMDMAppleEnrollmentProfilesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*createMDMAppleEnrollmentProfileRequest)
 
 	enrollmentProfile, err := svc.NewMDMAppleEnrollmentProfile(ctx, fleet.MDMAppleEnrollmentProfilePayload{
@@ -171,7 +171,7 @@ type listMDMAppleEnrollmentProfilesResponse struct {
 
 func (r listMDMAppleEnrollmentProfilesResponse) error() error { return r.Err }
 
-func listMDMAppleEnrollmentsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listMDMAppleEnrollmentsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	enrollmentProfiles, err := svc.ListMDMAppleEnrollmentProfiles(ctx)
 	if err != nil {
 		return listMDMAppleEnrollmentProfilesResponse{
@@ -218,7 +218,7 @@ type getMDMAppleCommandResultsResponse struct {
 
 func (r getMDMAppleCommandResultsResponse) error() error { return r.Err }
 
-func getMDMAppleCommandResultsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getMDMAppleCommandResultsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getMDMAppleCommandResultsRequest)
 	results, err := svc.GetMDMAppleCommandResults(ctx, req.CommandUUID)
 	if err != nil {
@@ -269,7 +269,7 @@ func (uploadAppleInstallerRequest) DecodeRequest(ctx context.Context, r *http.Re
 
 func (r uploadAppleInstallerResponse) error() error { return r.Err }
 
-func uploadAppleInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func uploadAppleInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*uploadAppleInstallerRequest)
 	ff, err := req.Installer.Open()
 	if err != nil {
@@ -357,7 +357,7 @@ type getAppleInstallerDetailsResponse struct {
 
 func (r getAppleInstallerDetailsResponse) error() error { return r.Err }
 
-func getAppleInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getAppleInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getAppleInstallerDetailsRequest)
 	installer, err := svc.GetMDMAppleInstallerByID(ctx, req.ID)
 	if err != nil {
@@ -390,7 +390,7 @@ type deleteAppleInstallerDetailsResponse struct {
 
 func (r deleteAppleInstallerDetailsResponse) error() error { return r.Err }
 
-func deleteAppleInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteAppleInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteAppleInstallerDetailsRequest)
 	if err := svc.DeleteMDMAppleInstaller(ctx, req.ID); err != nil {
 		return deleteAppleInstallerDetailsResponse{Err: err}, nil
@@ -418,7 +418,7 @@ type listMDMAppleDevicesResponse struct {
 
 func (r listMDMAppleDevicesResponse) error() error { return r.Err }
 
-func listMDMAppleDevicesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listMDMAppleDevicesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	devices, err := svc.ListMDMAppleDevices(ctx)
 	if err != nil {
 		return listMDMAppleDevicesResponse{Err: err}, nil
@@ -445,7 +445,7 @@ type listMDMAppleDEPDevicesResponse struct {
 
 func (r listMDMAppleDEPDevicesResponse) error() error { return r.Err }
 
-func listMDMAppleDEPDevicesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listMDMAppleDEPDevicesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	devices, err := svc.ListMDMAppleDEPDevices(ctx)
 	if err != nil {
 		return listMDMAppleDEPDevicesResponse{Err: err}, nil
@@ -483,7 +483,7 @@ type newMDMAppleDEPKeyPairResponse struct {
 
 func (r newMDMAppleDEPKeyPairResponse) error() error { return r.Err }
 
-func newMDMAppleDEPKeyPairEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func newMDMAppleDEPKeyPairEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	keyPair, err := svc.NewMDMAppleDEPKeyPair(ctx)
 	if err != nil {
 		return newMDMAppleDEPKeyPairResponse{
@@ -528,7 +528,7 @@ type enqueueMDMAppleCommandResponse struct {
 func (r enqueueMDMAppleCommandResponse) error() error { return r.Err }
 func (r enqueueMDMAppleCommandResponse) Status() int  { return r.status }
 
-func enqueueMDMAppleCommandEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func enqueueMDMAppleCommandEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*enqueueMDMAppleCommandRequest)
 	rawCommand, err := base64.RawStdEncoding.DecodeString(req.Command)
 	if err != nil {
@@ -698,7 +698,7 @@ func (r mdmAppleEnrollResponse) hijackRender(ctx context.Context, w http.Respons
 	}
 }
 
-func mdmAppleEnrollEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func mdmAppleEnrollEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*mdmAppleEnrollRequest)
 
 	profile, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, req.Token)
@@ -885,7 +885,7 @@ func (r mdmAppleGetInstallerResponse) hijackRender(ctx context.Context, w http.R
 	}
 }
 
-func mdmAppleGetInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func mdmAppleGetInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*mdmAppleGetInstallerRequest)
 	installer, err := svc.GetMDMAppleInstallerByToken(ctx, req.Token)
 	if err != nil {
@@ -914,7 +914,7 @@ type mdmAppleHeadInstallerRequest struct {
 	Token string `query:"token"`
 }
 
-func mdmAppleHeadInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func mdmAppleHeadInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*mdmAppleHeadInstallerRequest)
 	installer, err := svc.GetMDMAppleInstallerDetailsByToken(ctx, req.Token)
 	if err != nil {
@@ -947,7 +947,7 @@ type listMDMAppleInstallersResponse struct {
 
 func (r listMDMAppleInstallersResponse) error() error { return r.Err }
 
-func listMDMAppleInstallersEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listMDMAppleInstallersEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	installers, err := svc.ListMDMAppleInstallers(ctx)
 	if err != nil {
 		return listMDMAppleInstallersResponse{

--- a/server/service/campaigns.go
+++ b/server/service/campaigns.go
@@ -31,7 +31,7 @@ type createDistributedQueryCampaignResponse struct {
 
 func (r createDistributedQueryCampaignResponse) error() error { return r.Err }
 
-func createDistributedQueryCampaignEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func createDistributedQueryCampaignEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*createDistributedQueryCampaignRequest)
 	campaign, err := svc.NewDistributedQueryCampaign(ctx, req.QuerySQL, req.QueryID, req.Selected)
 	if err != nil {
@@ -194,7 +194,7 @@ type distributedQueryCampaignTargetsByNames struct {
 	Hosts  []string `json:"hosts"`
 }
 
-func createDistributedQueryCampaignByNamesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func createDistributedQueryCampaignByNamesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*createDistributedQueryCampaignByNamesRequest)
 	campaign, err := svc.NewDistributedQueryCampaignByNames(ctx, req.QuerySQL, req.QueryID, req.Selected.Hosts, req.Selected.Labels)
 	if err != nil {

--- a/server/service/carves.go
+++ b/server/service/carves.go
@@ -29,7 +29,7 @@ type listCarvesResponse struct {
 
 func (r listCarvesResponse) error() error { return r.Err }
 
-func listCarvesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listCarvesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*listCarvesRequest)
 	carves, err := svc.ListCarves(ctx, req.ListOptions)
 	if err != nil {
@@ -66,7 +66,7 @@ type getCarveResponse struct {
 
 func (r getCarveResponse) error() error { return r.Err }
 
-func getCarveEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getCarveEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getCarveRequest)
 	carve, err := svc.GetCarve(ctx, req.ID)
 	if err != nil {
@@ -74,7 +74,6 @@ func getCarveEndpoint(ctx context.Context, request interface{}, svc fleet.Servic
 	}
 
 	return getCarveResponse{Carve: *carve}, nil
-
 }
 
 func (svc *Service) GetCarve(ctx context.Context, id int64) (*fleet.CarveMetadata, error) {
@@ -101,7 +100,7 @@ type getCarveBlockResponse struct {
 
 func (r getCarveBlockResponse) error() error { return r.Err }
 
-func getCarveBlockEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getCarveBlockEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getCarveBlockRequest)
 	data, err := svc.GetBlock(ctx, req.ID, req.BlockId)
 	if err != nil {
@@ -162,7 +161,7 @@ type carveBeginResponse struct {
 
 func (r carveBeginResponse) error() error { return r.Err }
 
-func carveBeginEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func carveBeginEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*carveBeginRequest)
 
 	payload := fleet.CarveBeginPayload{
@@ -257,7 +256,7 @@ type carveBlockResponse struct {
 
 func (r carveBlockResponse) error() error { return r.Err }
 
-func carveBlockEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func carveBlockEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*carveBlockRequest)
 
 	payload := fleet.CarveBlockPayload{

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -18,6 +18,8 @@ type devicePingRequest struct{}
 
 type devicePingResponse struct{}
 
+func (r devicePingResponse) error() error { return nil }
+
 func (r devicePingResponse) hijackRender(ctx context.Context, w http.ResponseWriter) {
 	writeCapabilitiesHeader(w, fleet.ServerDeviceCapabilities)
 }
@@ -25,7 +27,7 @@ func (r devicePingResponse) hijackRender(ctx context.Context, w http.ResponseWri
 // NOTE: we're intentionally not reading the capabilities header in this
 // endpoint as is unauthenticated and we don't want to trust whatever comes in
 // there.
-func devicePingEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func devicePingEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	svc.DisableAuthForPing(ctx)
 	return devicePingResponse{}, nil
 }
@@ -58,7 +60,7 @@ func (r *getFleetDesktopRequest) deviceAuthToken() string {
 
 // getFleetDesktopEndpoint is meant to be the only API endpoint used by Fleet Desktop. This
 // endpoint should not include any kind of identifying information about the host.
-func getFleetDesktopEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getFleetDesktopEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	host, ok := hostctx.FromContext(ctx)
 
 	if !ok {
@@ -95,7 +97,7 @@ type getDeviceHostResponse struct {
 
 func (r getDeviceHostResponse) error() error { return r.Err }
 
-func getDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	host, ok := hostctx.FromContext(ctx)
 	if !ok {
 		err := ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))
@@ -174,7 +176,7 @@ func (r *refetchDeviceHostRequest) deviceAuthToken() string {
 	return r.Token
 }
 
-func refetchDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func refetchDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	host, ok := hostctx.FromContext(ctx)
 	if !ok {
 		err := ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))
@@ -200,7 +202,7 @@ func (r *listDeviceHostDeviceMappingRequest) deviceAuthToken() string {
 	return r.Token
 }
 
-func listDeviceHostDeviceMappingEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listDeviceHostDeviceMappingEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	host, ok := hostctx.FromContext(ctx)
 	if !ok {
 		err := ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))
@@ -226,7 +228,7 @@ func (r *getDeviceMacadminsDataRequest) deviceAuthToken() string {
 	return r.Token
 }
 
-func getDeviceMacadminsDataEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getDeviceMacadminsDataEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	host, ok := hostctx.FromContext(ctx)
 	if !ok {
 		err := ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))
@@ -259,7 +261,7 @@ type listDevicePoliciesResponse struct {
 
 func (r listDevicePoliciesResponse) error() error { return r.Err }
 
-func listDevicePoliciesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listDevicePoliciesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	host, ok := hostctx.FromContext(ctx)
 	if !ok {
 		err := ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))
@@ -314,7 +316,7 @@ func (r transparencyURLResponse) hijackRender(ctx context.Context, w http.Respon
 
 func (r transparencyURLResponse) error() error { return r.Err }
 
-func transparencyURL(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func transparencyURL(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	config, err := svc.AppConfig(ctx)
 	if err != nil {
 		return transparencyURLResponse{Err: err}, nil

--- a/server/service/endpoint_utils.go
+++ b/server/service/endpoint_utils.go
@@ -23,7 +23,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-type handlerFunc func(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error)
+type handlerFunc func(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error)
 
 // parseTag parses a `url` tag and whether it's optional or not, which is an optional part of the tag
 func parseTag(tag string) (string, bool, error) {

--- a/server/service/endpoint_utils_test.go
+++ b/server/service/endpoint_utils_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -251,6 +252,10 @@ func TestUniversalDecoderQueryAndListPlayNice(t *testing.T) {
 	assert.Equal(t, uint(444), *casted.ID1)
 }
 
+type stringErrorer string
+
+func (s stringErrorer) error() error { return errors.New(string(s)) }
+
 func TestEndpointer(t *testing.T) {
 	r := mux.NewRouter()
 	ds := new(mock.Store)
@@ -292,13 +297,13 @@ func TestEndpointer(t *testing.T) {
 	}
 
 	e := newUserAuthenticatedEndpointer(svc, fleetAPIOptions, r, "v1", "2021-11")
-	nopHandler := func(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+	nopHandler := func(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 		setAuthCheckedOnPreAuthErr(ctx)
-		return "nop", nil
+		return stringErrorer("nop"), nil
 	}
-	overrideHandler := func(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+	overrideHandler := func(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 		setAuthCheckedOnPreAuthErr(ctx)
-		return "override", nil
+		return stringErrorer("override"), nil
 	}
 
 	// Regular path, no plan to deprecate
@@ -413,7 +418,7 @@ func TestEndpointerCustomMiddleware(t *testing.T) {
 
 	var buf bytes.Buffer
 	e := newNoAuthEndpointer(svc, fleetAPIOptions, r, "v1")
-	e.GET("/none/", func(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+	e.GET("/none/", func(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 		buf.WriteString("H1")
 		return nil, nil
 	}, nil)
@@ -438,7 +443,7 @@ func TestEndpointerCustomMiddleware(t *testing.T) {
 			}
 		},
 	).
-		GET("/mw/", func(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+		GET("/mw/", func(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 			buf.WriteString("H2")
 			return nil, nil
 		}, nil)

--- a/server/service/endpoint_utils_test.go
+++ b/server/service/endpoint_utils_test.go
@@ -3,7 +3,6 @@ package service
 import (
 	"bytes"
 	"context"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -254,7 +253,7 @@ func TestUniversalDecoderQueryAndListPlayNice(t *testing.T) {
 
 type stringErrorer string
 
-func (s stringErrorer) error() error { return errors.New(string(s)) }
+func (s stringErrorer) error() error { return nil }
 
 func TestEndpointer(t *testing.T) {
 	r := mux.NewRouter()

--- a/server/service/global_policies.go
+++ b/server/service/global_policies.go
@@ -34,7 +34,7 @@ type globalPolicyResponse struct {
 
 func (r globalPolicyResponse) error() error { return r.Err }
 
-func globalPolicyEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func globalPolicyEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*globalPolicyRequest)
 	resp, err := svc.NewGlobalPolicy(ctx, fleet.PolicyPayload{
 		QueryID:     req.QueryID,
@@ -94,7 +94,7 @@ type listGlobalPoliciesResponse struct {
 
 func (r listGlobalPoliciesResponse) error() error { return r.Err }
 
-func listGlobalPoliciesEndpoint(ctx context.Context, _ interface{}, svc fleet.Service) (interface{}, error) {
+func listGlobalPoliciesEndpoint(ctx context.Context, _ interface{}, svc fleet.Service) (errorer, error) {
 	resp, err := svc.ListGlobalPolicies(ctx)
 	if err != nil {
 		return listGlobalPoliciesResponse{Err: err}, nil
@@ -125,7 +125,7 @@ type getPolicyByIDResponse struct {
 
 func (r getPolicyByIDResponse) error() error { return r.Err }
 
-func getPolicyByIDEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getPolicyByIDEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getPolicyByIDRequest)
 	policy, err := svc.GetPolicyByIDQueries(ctx, req.PolicyID)
 	if err != nil {
@@ -162,7 +162,7 @@ type deleteGlobalPoliciesResponse struct {
 
 func (r deleteGlobalPoliciesResponse) error() error { return r.Err }
 
-func deleteGlobalPoliciesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteGlobalPoliciesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteGlobalPoliciesRequest)
 	resp, err := svc.DeleteGlobalPolicies(ctx, req.IDs)
 	if err != nil {
@@ -268,7 +268,7 @@ type modifyGlobalPolicyResponse struct {
 
 func (r modifyGlobalPolicyResponse) error() error { return r.Err }
 
-func modifyGlobalPolicyEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func modifyGlobalPolicyEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*modifyGlobalPolicyRequest)
 	resp, err := svc.ModifyGlobalPolicy(ctx, req.PolicyID, req.ModifyPolicyPayload)
 	if err != nil {
@@ -296,7 +296,7 @@ type resetAutomationResponse struct {
 
 func (r resetAutomationResponse) error() error { return r.Err }
 
-func resetAutomationEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func resetAutomationEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*resetAutomationRequest)
 	err := svc.ResetAutomation(ctx, req.TeamIDs, req.PolicyIDs)
 	return resetAutomationResponse{Err: err}, nil
@@ -427,7 +427,7 @@ type applyPolicySpecsResponse struct {
 
 func (r applyPolicySpecsResponse) error() error { return r.Err }
 
-func applyPolicySpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func applyPolicySpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*applyPolicySpecsRequest)
 	err := svc.ApplyPolicySpecs(ctx, req.Specs)
 	if err != nil {

--- a/server/service/global_schedule.go
+++ b/server/service/global_schedule.go
@@ -23,7 +23,7 @@ type getGlobalScheduleResponse struct {
 
 func (r getGlobalScheduleResponse) error() error { return r.Err }
 
-func getGlobalScheduleEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getGlobalScheduleEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getGlobalScheduleRequest)
 
 	gp, err := svc.GetGlobalScheduledQueries(ctx, req.ListOptions)
@@ -72,7 +72,7 @@ type globalScheduleQueryResponse struct {
 
 func (r globalScheduleQueryResponse) error() error { return r.Err }
 
-func globalScheduleQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func globalScheduleQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*globalScheduleQueryRequest)
 
 	scheduled, err := svc.GlobalScheduleQuery(ctx, &fleet.ScheduledQuery{
@@ -122,7 +122,7 @@ type modifyGlobalScheduleResponse struct {
 
 func (r modifyGlobalScheduleResponse) error() error { return r.Err }
 
-func modifyGlobalScheduleEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func modifyGlobalScheduleEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*modifyGlobalScheduleRequest)
 
 	sq, err := svc.ModifyGlobalScheduledQueries(ctx, req.ID, req.ScheduledQueryPayload)
@@ -166,7 +166,7 @@ type deleteGlobalScheduleResponse struct {
 
 func (r deleteGlobalScheduleResponse) error() error { return r.Err }
 
-func deleteGlobalScheduleEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteGlobalScheduleEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteGlobalScheduleRequest)
 	err := svc.DeleteGlobalScheduledQueries(ctx, req.ID)
 	if err != nil {

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -66,7 +66,7 @@ type listHostsResponse struct {
 
 func (r listHostsResponse) error() error { return r.Err }
 
-func listHostsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listHostsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*listHostsRequest)
 
 	var software *fleet.Software
@@ -173,7 +173,7 @@ type deleteHostsResponse struct {
 
 func (r deleteHostsResponse) error() error { return r.Err }
 
-func deleteHostsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteHostsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteHostsRequest)
 	listOpt := fleet.HostListOptions{
 		ListOptions: fleet.ListOptions{
@@ -238,7 +238,7 @@ type countHostsResponse struct {
 
 func (r countHostsResponse) error() error { return r.Err }
 
-func countHostsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func countHostsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*countHostsRequest)
 	count, err := svc.CountHosts(ctx, req.LabelID, req.Opts)
 	if err != nil {
@@ -301,7 +301,7 @@ type searchHostsResponse struct {
 
 func (r searchHostsResponse) error() error { return r.Err }
 
-func searchHostsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func searchHostsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*searchHostsRequest)
 
 	hosts, err := svc.SearchHosts(ctx, req.MatchQuery, req.QueryID, req.ExcludedHostIDs)
@@ -368,7 +368,7 @@ type getHostResponse struct {
 
 func (r getHostResponse) error() error { return r.Err }
 
-func getHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getHostRequest)
 	opts := fleet.HostDetailOptions{
 		IncludeCVEScores: false,
@@ -449,7 +449,7 @@ type getHostSummaryResponse struct {
 
 func (r getHostSummaryResponse) error() error { return r.Err }
 
-func getHostSummaryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getHostSummaryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getHostSummaryRequest)
 	if req.LowDiskSpace != nil {
 		if *req.LowDiskSpace < 1 || *req.LowDiskSpace > 100 {
@@ -522,7 +522,7 @@ type hostByIdentifierRequest struct {
 	Identifier string `url:"identifier"`
 }
 
-func hostByIdentifierEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func hostByIdentifierEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*hostByIdentifierRequest)
 	opts := fleet.HostDetailOptions{
 		IncludeCVEScores: false,
@@ -580,7 +580,7 @@ type deleteHostResponse struct {
 
 func (r deleteHostResponse) error() error { return r.Err }
 
-func deleteHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteHostRequest)
 	err := svc.DeleteHost(ctx, req.ID)
 	if err != nil {
@@ -622,7 +622,7 @@ type addHostsToTeamResponse struct {
 
 func (r addHostsToTeamResponse) error() error { return r.Err }
 
-func addHostsToTeamEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func addHostsToTeamEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*addHostsToTeamRequest)
 	err := svc.AddHostsToTeam(ctx, req.TeamID, req.HostIDs)
 	if err != nil {
@@ -663,7 +663,7 @@ type addHostsToTeamByFilterResponse struct {
 
 func (r addHostsToTeamByFilterResponse) error() error { return r.Err }
 
-func addHostsToTeamByFilterEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func addHostsToTeamByFilterEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*addHostsToTeamByFilterRequest)
 	listOpt := fleet.HostListOptions{
 		ListOptions: fleet.ListOptions{
@@ -713,7 +713,7 @@ type refetchHostResponse struct {
 
 func (r refetchHostResponse) error() error { return r.Err }
 
-func refetchHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func refetchHostEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*refetchHostRequest)
 	err := svc.RefetchHost(ctx, req.ID)
 	if err != nil {
@@ -861,7 +861,7 @@ type listHostDeviceMappingResponse struct {
 
 func (r listHostDeviceMappingResponse) error() error { return r.Err }
 
-func listHostDeviceMappingEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listHostDeviceMappingEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*listHostDeviceMappingRequest)
 	dms, err := svc.ListHostDeviceMapping(ctx, req.ID)
 	if err != nil {
@@ -903,7 +903,9 @@ type getHostMDMResponse struct {
 	*fleet.HostMDM
 }
 
-func getHostMDM(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func (r getHostMDMResponse) error() error { return r.Err }
+
+func getHostMDM(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getHostMDMRequest)
 	mdm, err := svc.MDMData(ctx, req.ID)
 	if err != nil {
@@ -922,7 +924,9 @@ type getHostMDMSummaryRequest struct {
 	Platform string `query:"platform,optional"`
 }
 
-func getHostMDMSummary(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func (r getHostMDMSummaryResponse) error() error { return r.Err }
+
+func getHostMDMSummary(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getHostMDMSummaryRequest)
 	resp := getHostMDMSummaryResponse{}
 	var err error
@@ -949,7 +953,7 @@ type getMacadminsDataResponse struct {
 
 func (r getMacadminsDataResponse) error() error { return r.Err }
 
-func getMacadminsDataEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getMacadminsDataEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getMacadminsDataRequest)
 	data, err := svc.MacadminsData(ctx, req.ID)
 	if err != nil {
@@ -1026,7 +1030,7 @@ type getAggregatedMacadminsDataResponse struct {
 
 func (r getAggregatedMacadminsDataResponse) error() error { return r.Err }
 
-func getAggregatedMacadminsDataEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getAggregatedMacadminsDataEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getAggregatedMacadminsDataRequest)
 	data, err := svc.AggregatedMacadminsData(ctx, req.TeamID)
 	if err != nil {
@@ -1239,7 +1243,7 @@ func (r hostsReportResponse) hijackRender(ctx context.Context, w http.ResponseWr
 	}
 }
 
-func hostsReportEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func hostsReportEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*hostsReportRequest)
 
 	// for now, only csv format is allowed
@@ -1315,7 +1319,7 @@ type osVersionsResponse struct {
 
 func (r osVersionsResponse) error() error { return r.Err }
 
-func osVersionsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func osVersionsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*osVersionsRequest)
 
 	osVersions, err := svc.OSVersions(ctx, req.TeamID, req.Platform, req.Name, req.Version)

--- a/server/service/installer.go
+++ b/server/service/installer.go
@@ -65,7 +65,7 @@ func (r getInstallerResponse) hijackRender(ctx context.Context, w http.ResponseW
 	r.fileReader.Close()
 }
 
-func getInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(getInstallerRequest)
 
 	fileReader, fileLength, err := svc.GetInstaller(ctx, fleet.Installer{
@@ -73,7 +73,6 @@ func getInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.Se
 		Kind:         req.Kind,
 		Desktop:      req.Desktop,
 	})
-
 	if err != nil {
 		return getInstallerResponse{Err: err}, nil
 	}
@@ -124,7 +123,7 @@ type checkInstallerResponse struct {
 
 func (r checkInstallerResponse) error() error { return r.Err }
 
-func checkInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func checkInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*checkInstallerRequest)
 
 	err := svc.CheckInstallerExistence(ctx, fleet.Installer{
@@ -132,7 +131,6 @@ func checkInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.
 		Kind:         req.Kind,
 		Desktop:      req.Desktop,
 	})
-
 	if err != nil {
 		return checkInstallerResponse{Err: err}, nil
 	}

--- a/server/service/invites.go
+++ b/server/service/invites.go
@@ -31,7 +31,7 @@ type createInviteResponse struct {
 
 func (r createInviteResponse) error() error { return r.Err }
 
-func createInviteEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func createInviteEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*createInviteRequest)
 	invite, err := svc.InviteNewUser(ctx, req.InvitePayload)
 	if err != nil {
@@ -139,7 +139,7 @@ type listInvitesResponse struct {
 
 func (r listInvitesResponse) error() error { return r.Err }
 
-func listInvitesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listInvitesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*listInvitesRequest)
 	invites, err := svc.ListInvites(ctx, req.ListOptions)
 	if err != nil {
@@ -176,7 +176,7 @@ type updateInviteResponse struct {
 
 func (r updateInviteResponse) error() error { return r.Err }
 
-func updateInviteEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func updateInviteEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*updateInviteRequest)
 	invite, err := svc.UpdateInvite(ctx, req.ID, req.InvitePayload)
 	if err != nil {
@@ -252,7 +252,7 @@ type deleteInviteResponse struct {
 
 func (r deleteInviteResponse) error() error { return r.Err }
 
-func deleteInviteEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteInviteEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteInviteRequest)
 	err := svc.DeleteInvite(ctx, req.ID)
 	if err != nil {
@@ -283,7 +283,7 @@ type verifyInviteResponse struct {
 
 func (r verifyInviteResponse) error() error { return r.Err }
 
-func verifyInviteEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func verifyInviteEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*verifyInviteRequest)
 	invite, err := svc.VerifyInvite(ctx, req.Token)
 	if err != nil {

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -23,7 +23,7 @@ type createLabelResponse struct {
 
 func (r createLabelResponse) error() error { return r.Err }
 
-func createLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func createLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*createLabelRequest)
 
 	label, err := svc.NewLabel(ctx, req.LabelPayload)
@@ -87,7 +87,7 @@ type modifyLabelResponse struct {
 
 func (r modifyLabelResponse) error() error { return r.Err }
 
-func modifyLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func modifyLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*modifyLabelRequest)
 	label, err := svc.ModifyLabel(ctx, req.ID, req.ModifyLabelPayload)
 	if err != nil {
@@ -142,7 +142,7 @@ type getLabelResponse struct {
 
 func (r getLabelResponse) error() error { return r.Err }
 
-func getLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getLabelRequest)
 	label, err := svc.GetLabel(ctx, req.ID)
 	if err != nil {
@@ -178,7 +178,7 @@ type listLabelsResponse struct {
 
 func (r listLabelsResponse) error() error { return r.Err }
 
-func listLabelsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listLabelsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*listLabelsRequest)
 
 	labels, err := svc.ListLabels(ctx, req.ListOptions)
@@ -227,7 +227,9 @@ type getLabelsSummaryResponse struct {
 	Err    error                 `json:"error,omitempty"`
 }
 
-func getLabelsSummaryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func (r getLabelsSummaryResponse) error() error { return r.Err }
+
+func getLabelsSummaryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	labels, err := svc.LabelsSummary(ctx)
 	if err != nil {
 		return getLabelsSummaryResponse{Err: err}, nil
@@ -252,7 +254,7 @@ type listHostsInLabelRequest struct {
 	ListOptions fleet.HostListOptions `url:"host_options"`
 }
 
-func listHostsInLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listHostsInLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*listHostsInLabelRequest)
 	hosts, err := svc.ListHostsInLabel(ctx, req.ID, req.ListOptions)
 	if err != nil {
@@ -307,7 +309,7 @@ type deleteLabelResponse struct {
 
 func (r deleteLabelResponse) error() error { return r.Err }
 
-func deleteLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteLabelEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteLabelRequest)
 	err := svc.DeleteLabel(ctx, req.Name)
 	if err != nil {
@@ -338,7 +340,7 @@ type deleteLabelByIDResponse struct {
 
 func (r deleteLabelByIDResponse) error() error { return r.Err }
 
-func deleteLabelByIDEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteLabelByIDEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteLabelByIDRequest)
 	err := svc.DeleteLabelByID(ctx, req.ID)
 	if err != nil {
@@ -373,7 +375,7 @@ type applyLabelSpecsResponse struct {
 
 func (r applyLabelSpecsResponse) error() error { return r.Err }
 
-func applyLabelSpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func applyLabelSpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*applyLabelSpecsRequest)
 	err := svc.ApplyLabelSpecs(ctx, req.Specs)
 	if err != nil {
@@ -410,7 +412,7 @@ type getLabelSpecsResponse struct {
 
 func (r getLabelSpecsResponse) error() error { return r.Err }
 
-func getLabelSpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getLabelSpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	specs, err := svc.GetLabelSpecs(ctx)
 	if err != nil {
 		return getLabelSpecsResponse{Err: err}, nil
@@ -437,7 +439,7 @@ type getLabelSpecResponse struct {
 
 func (r getLabelSpecResponse) error() error { return r.Err }
 
-func getLabelSpecEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getLabelSpecEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getGenericSpecRequest)
 	spec, err := svc.GetLabelSpec(ctx, req.Name)
 	if err != nil {

--- a/server/service/live_queries.go
+++ b/server/service/live_queries.go
@@ -33,7 +33,7 @@ type runLiveQueryResponse struct {
 
 func (r runLiveQueryResponse) error() error { return r.Err }
 
-func runLiveQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func runLiveQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*runLiveQueryRequest)
 
 	// The period used here should always be less than the request timeout for any load

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -13,7 +13,7 @@ type getAppleMDMResponse struct {
 
 func (r getAppleMDMResponse) error() error { return r.Err }
 
-func getAppleMDMEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getAppleMDMEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	appleMDM, err := svc.GetAppleMDM(ctx)
 	if err != nil {
 		return getAppleMDMResponse{Err: err}, nil
@@ -56,7 +56,7 @@ type getAppleBMResponse struct {
 
 func (r getAppleBMResponse) error() error { return r.Err }
 
-func getAppleBMEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getAppleBMEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	appleBM, err := svc.GetAppleBM(ctx)
 	if err != nil {
 		return getAppleBMResponse{Err: err}, nil

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -95,7 +95,7 @@ type enrollAgentResponse struct {
 
 func (r enrollAgentResponse) error() error { return r.Err }
 
-func enrollAgentEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func enrollAgentEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*enrollAgentRequest)
 	nodeKey, err := svc.EnrollAgent(ctx, req.EnrollSecret, req.HostIdentifier, req.HostDetails)
 	if err != nil {
@@ -311,15 +311,23 @@ type getClientConfigResponse struct {
 
 func (r getClientConfigResponse) error() error { return r.Err }
 
-func getClientConfigEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+// MarshalJSON implements json.Marshaler.
+//
+// Osquery expects the response for configs to be at the
+// top-level of the JSON response.
+func (r getClientConfigResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.Config)
+}
+
+func getClientConfigEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	config, err := svc.GetClientConfig(ctx)
 	if err != nil {
 		return getClientConfigResponse{Err: err}, nil
 	}
 
-	// We return the config here explicitly because osquery exepects the
-	// response for configs to be at the top-level of the JSON response
-	return config, nil
+	return getClientConfigResponse{
+		Config: config,
+	}, nil
 }
 
 func (svc *Service) GetClientConfig(ctx context.Context) (map[string]interface{}, error) {
@@ -495,7 +503,7 @@ type getDistributedQueriesResponse struct {
 
 func (r getDistributedQueriesResponse) error() error { return r.Err }
 
-func getDistributedQueriesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getDistributedQueriesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	queries, discovery, accelerate, err := svc.GetDistributedQueries(ctx)
 	if err != nil {
 		return getDistributedQueriesResponse{Err: err}, nil
@@ -747,7 +755,7 @@ type submitDistributedQueryResultsResponse struct {
 
 func (r submitDistributedQueryResultsResponse) error() error { return r.Err }
 
-func submitDistributedQueryResultsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func submitDistributedQueryResultsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	shim := request.(*submitDistributedQueryResultsRequestShim)
 	req, err := shim.toRequest(ctx)
 	if err != nil {
@@ -1202,7 +1210,7 @@ type submitLogsResponse struct {
 
 func (r submitLogsResponse) error() error { return r.Err }
 
-func submitLogsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func submitLogsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*submitLogsRequest)
 
 	var err error

--- a/server/service/packs.go
+++ b/server/service/packs.go
@@ -64,7 +64,7 @@ type getPackResponse struct {
 
 func (r getPackResponse) error() error { return r.Err }
 
-func getPackEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getPackEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getPackRequest)
 	pack, err := svc.GetPack(ctx, req.ID)
 	if err != nil {
@@ -104,7 +104,7 @@ type createPackResponse struct {
 
 func (r createPackResponse) error() error { return r.Err }
 
-func createPackEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func createPackEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*createPackRequest)
 	pack, err := svc.NewPack(ctx, req.PackPayload)
 	if err != nil {
@@ -197,7 +197,7 @@ type modifyPackResponse struct {
 
 func (r modifyPackResponse) error() error { return r.Err }
 
-func modifyPackEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func modifyPackEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*modifyPackRequest)
 	pack, err := svc.ModifyPack(ctx, req.ID, req.PackPayload)
 	if err != nil {
@@ -292,7 +292,7 @@ type listPacksResponse struct {
 
 func (r listPacksResponse) error() error { return r.Err }
 
-func listPacksEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listPacksEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*listPacksRequest)
 	packs, err := svc.ListPacks(ctx, fleet.PackListOptions{ListOptions: req.ListOptions, IncludeSystemPacks: false})
 	if err != nil {
@@ -332,7 +332,7 @@ type deletePackResponse struct {
 
 func (r deletePackResponse) error() error { return r.Err }
 
-func deletePackEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deletePackEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deletePackRequest)
 	err := svc.DeletePack(ctx, req.Name)
 	if err != nil {
@@ -385,7 +385,7 @@ type deletePackByIDResponse struct {
 
 func (r deletePackByIDResponse) error() error { return r.Err }
 
-func deletePackByIDEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deletePackByIDEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deletePackByIDRequest)
 	err := svc.DeletePackByID(ctx, req.ID)
 	if err != nil {
@@ -436,7 +436,7 @@ type applyPackSpecsResponse struct {
 
 func (r applyPackSpecsResponse) error() error { return r.Err }
 
-func applyPackSpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func applyPackSpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*applyPackSpecsRequest)
 	_, err := svc.ApplyPackSpecs(ctx, req.Specs)
 	if err != nil {
@@ -510,7 +510,7 @@ type getPackSpecsResponse struct {
 
 func (r getPackSpecsResponse) error() error { return r.Err }
 
-func getPackSpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getPackSpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	specs, err := svc.GetPackSpecs(ctx)
 	if err != nil {
 		return getPackSpecsResponse{Err: err}, nil
@@ -537,7 +537,7 @@ type getPackSpecResponse struct {
 
 func (r getPackSpecResponse) error() error { return r.Err }
 
-func getPackSpecEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getPackSpecEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getGenericSpecRequest)
 	spec, err := svc.GetPackSpec(ctx, req.Name)
 	if err != nil {

--- a/server/service/queries.go
+++ b/server/service/queries.go
@@ -29,7 +29,7 @@ type getQueryResponse struct {
 
 func (r getQueryResponse) error() error { return r.Err }
 
-func getQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getQueryRequest)
 	query, err := svc.GetQuery(ctx, req.ID)
 	if err != nil {
@@ -61,7 +61,7 @@ type listQueriesResponse struct {
 
 func (r listQueriesResponse) error() error { return r.Err }
 
-func listQueriesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listQueriesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*listQueriesRequest)
 	queries, err := svc.ListQueries(ctx, req.ListOptions)
 	if err != nil {
@@ -125,7 +125,7 @@ type createQueryResponse struct {
 
 func (r createQueryResponse) error() error { return r.Err }
 
-func createQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func createQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*createQueryRequest)
 	query, err := svc.NewQuery(ctx, req.QueryPayload)
 	if err != nil {
@@ -212,7 +212,7 @@ type modifyQueryResponse struct {
 
 func (r modifyQueryResponse) error() error { return r.Err }
 
-func modifyQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func modifyQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*modifyQueryRequest)
 	query, err := svc.ModifyQuery(ctx, req.ID, req.QueryPayload)
 	if err != nil {
@@ -293,7 +293,7 @@ type deleteQueryResponse struct {
 
 func (r deleteQueryResponse) error() error { return r.Err }
 
-func deleteQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteQueryRequest)
 	err := svc.DeleteQuery(ctx, req.Name)
 	if err != nil {
@@ -348,7 +348,7 @@ type deleteQueryByIDResponse struct {
 
 func (r deleteQueryByIDResponse) error() error { return r.Err }
 
-func deleteQueryByIDEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteQueryByIDEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteQueryByIDRequest)
 	err := svc.DeleteQueryByID(ctx, req.ID)
 	if err != nil {
@@ -404,7 +404,7 @@ type deleteQueriesResponse struct {
 
 func (r deleteQueriesResponse) error() error { return r.Err }
 
-func deleteQueriesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteQueriesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteQueriesRequest)
 	deleted, err := svc.DeleteQueries(ctx, req.IDs)
 	if err != nil {
@@ -462,7 +462,7 @@ type applyQuerySpecsResponse struct {
 
 func (r applyQuerySpecsResponse) error() error { return r.Err }
 
-func applyQuerySpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func applyQuerySpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*applyQuerySpecsRequest)
 	err := svc.ApplyQuerySpecs(ctx, req.Specs)
 	if err != nil {
@@ -541,7 +541,7 @@ type getQuerySpecsResponse struct {
 
 func (r getQuerySpecsResponse) error() error { return r.Err }
 
-func getQuerySpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getQuerySpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	specs, err := svc.GetQuerySpecs(ctx)
 	if err != nil {
 		return getQuerySpecsResponse{Err: err}, nil
@@ -585,7 +585,7 @@ type getQuerySpecResponse struct {
 
 func (r getQuerySpecResponse) error() error { return r.Err }
 
-func getQuerySpecEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getQuerySpecEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getGenericSpecRequest)
 	spec, err := svc.GetQuerySpec(ctx, req.Name)
 	if err != nil {

--- a/server/service/scheduled_queries.go
+++ b/server/service/scheduled_queries.go
@@ -27,7 +27,7 @@ type getScheduledQueriesInPackResponse struct {
 
 func (r getScheduledQueriesInPackResponse) error() error { return r.Err }
 
-func getScheduledQueriesInPackEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getScheduledQueriesInPackEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getScheduledQueriesInPackRequest)
 	resp := getScheduledQueriesInPackResponse{Scheduled: []scheduledQueryResponse{}}
 
@@ -76,7 +76,7 @@ type scheduleQueryResponse struct {
 
 func (r scheduleQueryResponse) error() error { return r.Err }
 
-func scheduleQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func scheduleQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*scheduleQueryRequest)
 
 	scheduled, err := svc.ScheduleQuery(ctx, &fleet.ScheduledQuery{
@@ -164,7 +164,7 @@ type getScheduledQueryResponse struct {
 
 func (r getScheduledQueryResponse) error() error { return r.Err }
 
-func getScheduledQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getScheduledQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getScheduledQueryRequest)
 
 	sq, err := svc.GetScheduledQuery(ctx, req.ID)
@@ -204,7 +204,7 @@ type modifyScheduledQueryResponse struct {
 
 func (r modifyScheduledQueryResponse) error() error { return r.Err }
 
-func modifyScheduledQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func modifyScheduledQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*modifyScheduledQueryRequest)
 
 	sq, err := svc.ModifyScheduledQuery(ctx, req.ID, req.ScheduledQueryPayload)
@@ -294,7 +294,7 @@ type deleteScheduledQueryResponse struct {
 
 func (r deleteScheduledQueryResponse) error() error { return r.Err }
 
-func deleteScheduledQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteScheduledQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteScheduledQueryRequest)
 
 	err := svc.DeleteScheduledQuery(ctx, req.ID)

--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -40,7 +40,7 @@ type getInfoAboutSessionResponse struct {
 
 func (r getInfoAboutSessionResponse) error() error { return r.Err }
 
-func getInfoAboutSessionEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getInfoAboutSessionEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getInfoAboutSessionRequest)
 	session, err := svc.GetInfoAboutSession(ctx, req.ID)
 	if err != nil {
@@ -86,7 +86,7 @@ type deleteSessionResponse struct {
 
 func (r deleteSessionResponse) error() error { return r.Err }
 
-func deleteSessionEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteSessionEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteSessionRequest)
 	err := svc.DeleteSession(ctx, req.ID)
 	if err != nil {
@@ -126,7 +126,7 @@ type loginResponse struct {
 
 func (r loginResponse) error() error { return r.Err }
 
-func loginEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func loginEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*loginRequest)
 	req.Email = strings.ToLower(req.Email)
 
@@ -210,7 +210,7 @@ type logoutResponse struct {
 
 func (r logoutResponse) error() error { return r.Err }
 
-func logoutEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func logoutEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	err := svc.Logout(ctx)
 	if err != nil {
 		return logoutResponse{Err: err}, nil
@@ -261,7 +261,7 @@ type initiateSSOResponse struct {
 
 func (r initiateSSOResponse) error() error { return r.Err }
 
-func initiateSSOEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func initiateSSOEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*initiateSSORequest)
 	idProviderURL, err := svc.InitiateSSO(ctx, req.RelayURL)
 	if err != nil {
@@ -356,7 +356,7 @@ func (r callbackSSOResponse) error() error { return r.Err }
 func (r callbackSSOResponse) html() string { return r.content }
 
 func makeCallbackSSOEndpoint(urlPrefix string) handlerFunc {
-	return func(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+	return func(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 		authResponse := request.(fleet.Auth)
 		session, err := getSSOSession(ctx, svc, authResponse)
 		var resp callbackSSOResponse
@@ -536,7 +536,7 @@ type ssoSettingsResponse struct {
 
 func (r ssoSettingsResponse) error() error { return r.Err }
 
-func settingsSSOEndpoint(ctx context.Context, _ interface{}, svc fleet.Service) (interface{}, error) {
+func settingsSSOEndpoint(ctx context.Context, _ interface{}, svc fleet.Service) (errorer, error) {
 	settings, err := svc.SSOSettings(ctx)
 	if err != nil {
 		return ssoSettingsResponse{Err: err}, nil
@@ -674,7 +674,7 @@ func (r demologinResponse) error() error { return r.Err }
 func (r demologinResponse) html() string { return r.content }
 
 func makeDemologinEndpoint(urlPrefix string) handlerFunc {
-	return func(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+	return func(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 		req := request.(demologinRequest)
 
 		if !svc.SandboxEnabled() {

--- a/server/service/software.go
+++ b/server/service/software.go
@@ -23,7 +23,7 @@ type listSoftwareResponse struct {
 
 func (r listSoftwareResponse) error() error { return r.Err }
 
-func listSoftwareEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listSoftwareEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*listSoftwareRequest)
 	resp, err := svc.ListSoftware(ctx, req.SoftwareListOptions)
 	if err != nil {
@@ -82,7 +82,7 @@ type getSoftwareResponse struct {
 
 func (r getSoftwareResponse) error() error { return r.Err }
 
-func getSoftwareEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getSoftwareEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getSoftwareRequest)
 
 	software, err := svc.SoftwareByID(ctx, req.ID, false)
@@ -121,7 +121,7 @@ type countSoftwareResponse struct {
 
 func (r countSoftwareResponse) error() error { return r.Err }
 
-func countSoftwareEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func countSoftwareEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*countSoftwareRequest)
 	count, err := svc.CountSoftware(ctx, req.SoftwareListOptions)
 	if err != nil {

--- a/server/service/status.go
+++ b/server/service/status.go
@@ -17,7 +17,7 @@ type statusResponse struct {
 
 func (m statusResponse) error() error { return m.Err }
 
-func statusResultStoreEndpoint(ctx context.Context, req interface{}, svc fleet.Service) (interface{}, error) {
+func statusResultStoreEndpoint(ctx context.Context, req interface{}, svc fleet.Service) (errorer, error) {
 	var resp statusResponse
 	if err := svc.StatusResultStore(ctx); err != nil {
 		resp.Err = err
@@ -37,7 +37,7 @@ func (svc *Service) StatusResultStore(ctx context.Context) error {
 // Status Live Query
 ////////////////////////////////////////////////////////////////////////////////
 
-func statusLiveQueryEndpoint(ctx context.Context, req interface{}, svc fleet.Service) (interface{}, error) {
+func statusLiveQueryEndpoint(ctx context.Context, req interface{}, svc fleet.Service) (errorer, error) {
 	var resp statusResponse
 	if err := svc.StatusLiveQuery(ctx); err != nil {
 		resp.Err = err

--- a/server/service/targets.go
+++ b/server/service/targets.go
@@ -126,7 +126,7 @@ type searchTargetsResponse struct {
 
 func (r searchTargetsResponse) error() error { return r.Err }
 
-func searchTargetsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func searchTargetsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*searchTargetsRequest)
 
 	results, err := svc.SearchTargets(ctx, req.MatchQuery, req.QueryID, req.Selected)
@@ -266,7 +266,7 @@ type countTargetsResponse struct {
 
 func (r countTargetsResponse) error() error { return r.Err }
 
-func countTargetsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func countTargetsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*countTargetsRequest)
 
 	counts, err := svc.CountHostsInTargets(ctx, req.QueryID, req.Selected)

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -36,7 +36,7 @@ type teamPolicyResponse struct {
 
 func (r teamPolicyResponse) error() error { return r.Err }
 
-func teamPolicyEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func teamPolicyEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*teamPolicyRequest)
 	resp, err := svc.NewTeamPolicy(ctx, req.TeamID, fleet.PolicyPayload{
 		QueryID:     req.QueryID,
@@ -108,7 +108,7 @@ type listTeamPoliciesResponse struct {
 
 func (r listTeamPoliciesResponse) error() error { return r.Err }
 
-func listTeamPoliciesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listTeamPoliciesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*listTeamPoliciesRequest)
 	tmPols, inheritedPols, err := svc.ListTeamPolicies(ctx, req.TeamID)
 	if err != nil {
@@ -149,7 +149,7 @@ type getTeamPolicyByIDResponse struct {
 
 func (r getTeamPolicyByIDResponse) error() error { return r.Err }
 
-func getTeamPolicyByIDEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getTeamPolicyByIDEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getTeamPolicyByIDRequest)
 	teamPolicy, err := svc.GetTeamPolicyByIDQueries(ctx, req.TeamID, req.PolicyID)
 	if err != nil {
@@ -191,7 +191,7 @@ type deleteTeamPoliciesResponse struct {
 
 func (r deleteTeamPoliciesResponse) error() error { return r.Err }
 
-func deleteTeamPoliciesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteTeamPoliciesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteTeamPoliciesRequest)
 	resp, err := svc.DeleteTeamPolicies(ctx, req.TeamID, req.IDs)
 	if err != nil {
@@ -276,7 +276,7 @@ type modifyTeamPolicyResponse struct {
 
 func (r modifyTeamPolicyResponse) error() error { return r.Err }
 
-func modifyTeamPolicyEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func modifyTeamPolicyEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*modifyTeamPolicyRequest)
 	resp, err := svc.ModifyTeamPolicy(ctx, req.TeamID, req.PolicyID, req.ModifyPolicyPayload)
 	if err != nil {

--- a/server/service/team_schedule.go
+++ b/server/service/team_schedule.go
@@ -21,7 +21,7 @@ type getTeamScheduleResponse struct {
 
 func (r getTeamScheduleResponse) error() error { return r.Err }
 
-func getTeamScheduleEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getTeamScheduleEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getTeamScheduleRequest)
 	resp := getTeamScheduleResponse{Scheduled: []scheduledQueryResponse{}}
 	queries, err := svc.GetTeamScheduledQueries(ctx, req.TeamID, req.ListOptions)
@@ -81,7 +81,7 @@ func nullIntToPtrUint(v *null.Int) *uint {
 	return ptr.Uint(uint(v.ValueOrZero()))
 }
 
-func teamScheduleQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func teamScheduleQueryEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*teamScheduleQueryRequest)
 	resp, err := svc.TeamScheduleQuery(ctx, req.TeamID, &fleet.ScheduledQuery{
 		QueryID:  uintValueOrZero(req.QueryID),
@@ -133,7 +133,7 @@ type modifyTeamScheduleResponse struct {
 
 func (r modifyTeamScheduleResponse) error() error { return r.Err }
 
-func modifyTeamScheduleEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func modifyTeamScheduleEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*modifyTeamScheduleRequest)
 	resp, err := svc.ModifyTeamScheduledQueries(ctx, req.TeamID, req.ScheduledQueryID, req.ScheduledQueryPayload)
 	if err != nil {
@@ -176,7 +176,7 @@ type deleteTeamScheduleResponse struct {
 
 func (r deleteTeamScheduleResponse) error() error { return r.Err }
 
-func deleteTeamScheduleEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteTeamScheduleEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteTeamScheduleRequest)
 	err := svc.DeleteTeamScheduledQueries(ctx, req.TeamID, req.ScheduledQueryID)
 	if err != nil {

--- a/server/service/teams.go
+++ b/server/service/teams.go
@@ -25,7 +25,7 @@ type listTeamsResponse struct {
 
 func (r listTeamsResponse) error() error { return r.Err }
 
-func listTeamsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listTeamsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*listTeamsRequest)
 	teams, err := svc.ListTeams(ctx, req.ListOptions)
 	if err != nil {
@@ -62,7 +62,7 @@ type getTeamResponse struct {
 
 func (r getTeamResponse) error() error { return r.Err }
 
-func getTeamEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getTeamEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getTeamRequest)
 	team, err := svc.GetTeam(ctx, req.ID)
 	if err != nil {
@@ -94,7 +94,7 @@ type teamResponse struct {
 
 func (r teamResponse) error() error { return r.Err }
 
-func createTeamEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func createTeamEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*createTeamRequest)
 
 	team, err := svc.NewTeam(ctx, req.TeamPayload)
@@ -121,7 +121,7 @@ type modifyTeamRequest struct {
 	fleet.TeamPayload
 }
 
-func modifyTeamEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func modifyTeamEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*modifyTeamRequest)
 	team, err := svc.ModifyTeam(ctx, req.ID, req.TeamPayload)
 	if err != nil {
@@ -152,7 +152,7 @@ type deleteTeamResponse struct {
 
 func (r deleteTeamResponse) error() error { return r.Err }
 
-func deleteTeamEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteTeamEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteTeamRequest)
 	err := svc.DeleteTeam(ctx, req.ID)
 	if err != nil {
@@ -197,7 +197,7 @@ type applyTeamSpecsResponse struct {
 
 func (r applyTeamSpecsResponse) error() error { return r.Err }
 
-func applyTeamSpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func applyTeamSpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*applyTeamSpecsRequest)
 
 	// remove any nil spec (may happen in conversion from YAML to JSON with fleetctl, but also
@@ -238,7 +238,7 @@ type modifyTeamAgentOptionsRequest struct {
 	json.RawMessage
 }
 
-func modifyTeamAgentOptionsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func modifyTeamAgentOptionsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*modifyTeamAgentOptionsRequest)
 	team, err := svc.ModifyTeamAgentOptions(ctx, req.ID, req.RawMessage, fleet.ApplySpecOptions{
 		Force:  req.Force,
@@ -267,7 +267,7 @@ type listTeamUsersRequest struct {
 	ListOptions fleet.ListOptions `url:"list_options"`
 }
 
-func listTeamUsersEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listTeamUsersEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*listTeamUsersRequest)
 	users, err := svc.ListTeamUsers(ctx, req.TeamID, req.ListOptions)
 	if err != nil {
@@ -301,7 +301,7 @@ type modifyTeamUsersRequest struct {
 	Users []fleet.TeamUser `json:"users"`
 }
 
-func addTeamUsersEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func addTeamUsersEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*modifyTeamUsersRequest)
 	team, err := svc.AddTeamUsers(ctx, req.TeamID, req.Users)
 	if err != nil {
@@ -318,7 +318,7 @@ func (svc *Service) AddTeamUsers(ctx context.Context, teamID uint, users []fleet
 	return nil, fleet.ErrMissingLicense
 }
 
-func deleteTeamUsersEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteTeamUsersEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*modifyTeamUsersRequest)
 	team, err := svc.DeleteTeamUsers(ctx, req.TeamID, req.Users)
 	if err != nil {
@@ -350,7 +350,7 @@ type teamEnrollSecretsResponse struct {
 
 func (r teamEnrollSecretsResponse) error() error { return r.Err }
 
-func teamEnrollSecretsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func teamEnrollSecretsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*teamEnrollSecretsRequest)
 	secrets, err := svc.TeamEnrollSecrets(ctx, req.TeamID)
 	if err != nil {
@@ -377,7 +377,7 @@ type modifyTeamEnrollSecretsRequest struct {
 	Secrets []fleet.EnrollSecret `json:"secrets"`
 }
 
-func modifyTeamEnrollSecretsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func modifyTeamEnrollSecretsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*modifyTeamEnrollSecretsRequest)
 	secrets, err := svc.ModifyTeamEnrollSecrets(ctx, req.TeamID, req.Secrets)
 	if err != nil {

--- a/server/service/translator.go
+++ b/server/service/translator.go
@@ -17,7 +17,7 @@ type translatorResponse struct {
 
 func (r translatorResponse) error() error { return r.Err }
 
-func translatorEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func translatorEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*translatorRequest)
 	resp, err := svc.Translate(ctx, req.List)
 	if err != nil {

--- a/server/service/transport_error.go
+++ b/server/service/transport_error.go
@@ -18,7 +18,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 )
 
-// erroer interface is implemented by response structs to encode business logic errors
+// errorer interface is implemented by response structs to encode business logic errors
 type errorer interface {
 	error() error
 }

--- a/server/service/trigger.go
+++ b/server/service/trigger.go
@@ -16,7 +16,7 @@ type triggerResponse struct {
 
 func (r triggerResponse) error() error { return r.Err }
 
-func triggerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func triggerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	_, err := svc.AuthenticatedUser(ctx)
 	if err != nil {
 		return triggerResponse{Err: err}, nil

--- a/server/service/user_roles.go
+++ b/server/service/user_roles.go
@@ -17,7 +17,7 @@ type applyUserRoleSpecsResponse struct {
 
 func (r applyUserRoleSpecsResponse) error() error { return r.Err }
 
-func applyUserRoleSpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func applyUserRoleSpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*applyUserRoleSpecsRequest)
 	err := svc.ApplyUserRolesSpecs(ctx, *req.Spec)
 	if err != nil {

--- a/server/service/users.go
+++ b/server/service/users.go
@@ -34,7 +34,7 @@ type createUserResponse struct {
 
 func (r createUserResponse) error() error { return r.Err }
 
-func createUserEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func createUserEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*createUserRequest)
 	user, err := svc.CreateUser(ctx, req.UserPayload)
 	if err != nil {
@@ -72,7 +72,7 @@ func (svc *Service) CreateUser(ctx context.Context, p fleet.UserPayload) (*fleet
 // Create User From Invite
 ////////////////////////////////////////////////////////////////////////////////
 
-func createUserFromInviteEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func createUserFromInviteEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*createUserRequest)
 	user, err := svc.CreateUserFromInvite(ctx, req.UserPayload)
 	if err != nil {
@@ -126,7 +126,7 @@ type listUsersResponse struct {
 
 func (r listUsersResponse) error() error { return r.Err }
 
-func listUsersEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func listUsersEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*listUsersRequest)
 	users, err := svc.ListUsers(ctx, req.ListOptions)
 	if err != nil {
@@ -156,7 +156,7 @@ func (svc *Service) ListUsers(ctx context.Context, opt fleet.UserListOptions) ([
 // Me (get own current user)
 ////////////////////////////////////////////////////////////////////////////////
 
-func meEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func meEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	user, err := svc.AuthenticatedUser(ctx)
 	if err != nil {
 		return getUserResponse{Err: err}, nil
@@ -204,7 +204,7 @@ type getUserResponse struct {
 
 func (r getUserResponse) error() error { return r.Err }
 
-func getUserEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getUserEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getUserRequest)
 	user, err := svc.User(ctx, req.ID)
 	if err != nil {
@@ -260,7 +260,7 @@ type modifyUserResponse struct {
 
 func (r modifyUserResponse) error() error { return r.Err }
 
-func modifyUserEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func modifyUserEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*modifyUserRequest)
 	user, err := svc.ModifyUser(ctx, req.ID, req.UserPayload)
 	if err != nil {
@@ -405,7 +405,7 @@ type deleteUserResponse struct {
 
 func (r deleteUserResponse) error() error { return r.Err }
 
-func deleteUserEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteUserEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteUserRequest)
 	err := svc.DeleteUser(ctx, req.ID)
 	if err != nil {
@@ -459,7 +459,7 @@ type requirePasswordResetResponse struct {
 
 func (r requirePasswordResetResponse) error() error { return r.Err }
 
-func requirePasswordResetEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func requirePasswordResetEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*requirePasswordResetRequest)
 	user, err := svc.RequirePasswordReset(ctx, req.ID, req.Require)
 	if err != nil {
@@ -511,7 +511,7 @@ type changePasswordResponse struct {
 
 func (r changePasswordResponse) error() error { return r.Err }
 
-func changePasswordEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func changePasswordEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*changePasswordRequest)
 	err := svc.ChangePassword(ctx, req.OldPassword, req.NewPassword)
 	return changePasswordResponse{Err: err}, nil
@@ -567,7 +567,7 @@ type getInfoAboutSessionsForUserResponse struct {
 
 func (r getInfoAboutSessionsForUserResponse) error() error { return r.Err }
 
-func getInfoAboutSessionsForUserEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func getInfoAboutSessionsForUserEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*getInfoAboutSessionsForUserRequest)
 	sessions, err := svc.GetInfoAboutSessionsForUser(ctx, req.ID)
 	if err != nil {
@@ -619,7 +619,7 @@ type deleteSessionsForUserResponse struct {
 
 func (r deleteSessionsForUserResponse) error() error { return r.Err }
 
-func deleteSessionsForUserEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func deleteSessionsForUserEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*deleteSessionsForUserRequest)
 	err := svc.DeleteSessionsForUser(ctx, req.ID)
 	if err != nil {
@@ -651,7 +651,7 @@ type changeEmailResponse struct {
 
 func (r changeEmailResponse) error() error { return r.Err }
 
-func changeEmailEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func changeEmailEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*changeEmailRequest)
 	newEmailAddress, err := svc.ChangeUserEmail(ctx, req.Token)
 	if err != nil {
@@ -804,7 +804,7 @@ type performRequiredPasswordResetResponse struct {
 
 func (r performRequiredPasswordResetResponse) error() error { return r.Err }
 
-func performRequiredPasswordResetEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func performRequiredPasswordResetEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*performRequiredPasswordResetRequest)
 	user, err := svc.PerformRequiredPasswordReset(ctx, req.Password)
 	if err != nil {
@@ -889,7 +889,7 @@ type resetPasswordResponse struct {
 
 func (r resetPasswordResponse) error() error { return r.Err }
 
-func resetPasswordEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func resetPasswordEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*resetPasswordRequest)
 	err := svc.ResetPassword(ctx, req.PasswordResetToken, req.NewPassword)
 	return resetPasswordResponse{Err: err}, nil
@@ -964,7 +964,7 @@ type forgotPasswordResponse struct {
 func (r forgotPasswordResponse) error() error { return r.Err }
 func (r forgotPasswordResponse) Status() int  { return http.StatusAccepted }
 
-func forgotPasswordEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (interface{}, error) {
+func forgotPasswordEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*forgotPasswordRequest)
 	// Any error returned by the service should not be returned to the
 	// client to prevent information disclosure (it will be logged in the


### PR DESCRIPTION
We missed implementing `error() error` on some response types. Let's use the interface so that we don't forget. 

NOTE: Maybe there's a reason not all types implement it. Am all ears. (The types that were missing the implementation look like we just forgot.)