### PR TITLE
Allow loadtests to separate git branch from dockerhub tag

### DIFF
--- a/infrastructure/loadtesting/terraform/ecr.tf
+++ b/infrastructure/loadtesting/terraform/ecr.tf
@@ -1,3 +1,7 @@
+locals {
+  loadtest_tag = "${var.git_branch != null ? var.git_branch : var.tag}"
+}
+
 resource "aws_kms_key" "main" {
   description             = "${local.prefix}-${random_pet.db_secret_postfix.id}"
   deletion_window_in_days = 10
@@ -38,7 +42,7 @@ data "docker_registry_image" "dockerhub" {
 }
 
 resource "docker_registry_image" "loadtest" {
-  name          = "${aws_ecr_repository.fleet.repository_url}:loadtest-${var.tag}-${split(":", data.docker_registry_image.dockerhub.sha256_digest)[1]}"
+  name          = "${aws_ecr_repository.fleet.repository_url}:loadtest-${local.loadtest_tag}-${split(":", data.docker_registry_image.dockerhub.sha256_digest)[1]}"
   keep_remotely = true
 
   build {
@@ -46,7 +50,7 @@ resource "docker_registry_image" "loadtest" {
     dockerfile = "loadtest.Dockerfile"
     platform   = "linux/amd64"
     build_args = {
-      TAG = var.tag
+      TAG = local.loadtest_tag
     }
     pull_parent = true
   }

--- a/infrastructure/loadtesting/terraform/readme.md
+++ b/infrastructure/loadtesting/terraform/readme.md
@@ -40,6 +40,12 @@ There are a few main places of interest to monitor the load and resource usage:
 
 ### Troubleshooting
 
+#### Using a release tag instead of a branch
+
+Since the tag name on Dockerhub doesn't match the tag name on GitHub, this presents a special use case when wanting to deploy a release tag.  In this case, you can use the optional `-var github_branch` in order to specify the separate tag.  For example, you would use the following to deploy a loadtest of version 4.25.0:
+
+`terraform apply -var tag=v4.25.0 -var github_branch=fleet-v4.25.0 -var loadtest_containers=8`
+
 #### General Troubleshooting
 
 If terraform fails for some reason, you can make it output extra information to `stderr` by setting the `TF_LOG` environment variable to "DEBUG" or "TRACE", e.g.:

--- a/infrastructure/loadtesting/terraform/variables.tf
+++ b/infrastructure/loadtesting/terraform/variables.tf
@@ -2,6 +2,12 @@ variable "tag" {
   description = "The tag to deploy. This would be the same as the branch name"
 }
 
+variable "git_branch" {
+  description = "The git branch to use to build loadtest containers.  Only needed if docker tag doesn't match the git branch"
+  type = string
+  default = null
+}
+
 variable "fleet_config" {
   description = "The configuration to use for fleet itself, gets translated as environment variables"
   type        = map(string)


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
