### PR TITLE
WIP: Store osquery query execution and fleet ingestion errors in redis

### DIFF
--- a/changes/8983-store-errors-in-redis
+++ b/changes/8983-store-errors-in-redis
@@ -1,0 +1,1 @@
+* Store osquery query execution errors and Fleet result ingestion errors in redis

--- a/server/contexts/ctxerr/ctxerr.go
+++ b/server/contexts/ctxerr/ctxerr.go
@@ -76,6 +76,7 @@ func setMetadata(ctx context.Context, data map[string]interface{}) map[string]in
 		data["host"] = map[string]interface{}{
 			"platform":        h.Platform,
 			"osquery_version": h.OsqueryVersion,
+			"os_version":      h.OSVersion,
 		}
 	}
 

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -991,8 +990,6 @@ func (svc *Service) ingestQueryResults(
 
 	return detailUpdated, additionalUpdated, err
 }
-
-var noSuchTableRegexp = regexp.MustCompile(`^no such table: \S+$`)
 
 func (svc *Service) directIngestDetailQuery(ctx context.Context, host *fleet.Host, name string, rows []map[string]string) (ingested bool, err error) {
 	features, err := svc.HostFeatures(ctx, host)


### PR DESCRIPTION
#8983.

[Here](https://github.com/fleetdm/fleet/files/10326108/sample.txt)'s a sample generated by:
```sh
fleetctl debug errors
################################################################################
# WARNING:
#   The generated file may contain sensitive data.
#   Please review the file before sharing.
#
#   Output written to: fleet-errors-20221230164559Z.json
################################################################################

cat fleet-errors-20221230164559Z.json | jq > sample.json
```

## To discuss

Redis load/storage if we generate a lot of errors (this is different than user errors, because these are errors generated by devices, so several orders of magnitude larger).

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- ~[ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~[ ] Documented any permissions changes~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - ~For Orbit and Fleet Desktop changes:~
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~