### PR TITLE
Add fix for destroying loadtesting ECR

### DIFF
--- a/infrastructure/loadtesting/terraform/ecr.tf
+++ b/infrastructure/loadtesting/terraform/ecr.tf
@@ -1,5 +1,5 @@
 locals {
-  loadtest_tag = "${var.git_branch != null ? var.git_branch : var.tag}"
+  loadtest_tag = var.git_branch != null ? var.git_branch : var.tag
 }
 
 resource "aws_kms_key" "main" {
@@ -20,6 +20,8 @@ resource "aws_ecr_repository" "fleet" {
     encryption_type = "KMS"
     kms_key         = aws_kms_key.main.arn
   }
+
+  force_delete = true
 }
 
 data "aws_ecr_authorization_token" "token" {}


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
