### PR TITLE
Add temporary host display name for MDM devices pending enrollment to Fleet

### DIFF
--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -457,7 +457,6 @@ func upsertMDMAppleHostDisplayNamesDB(ctx context.Context, tx sqlx.ExtContext, h
 	args := []interface{}{}
 	parts := []string{}
 	for _, h := range hosts {
-		// name := fmt.Sprintf("%s (%s)", h.HardwareModel, h.HardwareSerial)
 		args = append(args, h.ID, h.DisplayName())
 		parts = append(parts, "(?, ?)")
 	}
@@ -575,13 +574,6 @@ func filterMDMAppleDevices(devices []godep.Device) []godep.Device {
 
 func unionSelectDevices(devices []godep.Device) (stmt string, args []interface{}) {
 	for i, d := range devices {
-		// if i == 0 {
-		// 	stmt = "SELECT ? hostname, ? hardware_serial, ? hardware_model"
-		// } else {
-		// 	stmt += " UNION SELECT ?, ?, ?"
-		// }
-		// name := fmt.Sprintf("%s (%s)", d.Model, d.SerialNumber)
-		// args = append(args, name, d.SerialNumber, d.Model)
 		if i == 0 {
 			stmt = "SELECT ? hardware_serial, ? hardware_model"
 		} else {

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -355,16 +355,17 @@ func insertMDMAppleHostDB(
 	if id < 1 {
 		return ctxerr.Wrap(ctx, err, "ingest mdm apple host unexpected last insert id")
 	}
+	host := fleet.Host{ID: uint(id), HardwareModel: mdmHost.Model, HardwareSerial: mdmHost.SerialNumber}
 
-	if err := upsertMDMAppleHostDisplayNamesDB(ctx, tx, uint(id)); err != nil {
+	if err := upsertMDMAppleHostDisplayNamesDB(ctx, tx, host); err != nil {
 		return ctxerr.Wrap(ctx, err, "ingest mdm apple host upsert display names")
 	}
 
-	if err := upsertMDMAppleHostLabelMembershipDB(ctx, tx, logger, uint(id)); err != nil {
+	if err := upsertMDMAppleHostLabelMembershipDB(ctx, tx, logger, host); err != nil {
 		return ctxerr.Wrap(ctx, err, "ingest mdm apple host upsert label membership")
 	}
 
-	if err := upsertMDMAppleHostMDMInfoDB(ctx, tx, appCfg.ServerSettings.ServerURL, false, uint(id)); err != nil {
+	if err := upsertMDMAppleHostMDMInfoDB(ctx, tx, appCfg.ServerSettings.ServerURL, false, host); err != nil {
 		return ctxerr.Wrap(ctx, err, "ingest mdm apple host upsert MDM info")
 	}
 	return nil
@@ -425,24 +426,24 @@ func (ds *Datastore) IngestMDMAppleDevicesFromDEPSync(ctx context.Context, devic
 			args = append(args, d.SerialNumber)
 			parts = append(parts, "?")
 		}
-		var hostIDs []uint
-		err = sqlx.SelectContext(ctx, tx, &hostIDs, fmt.Sprintf(`
-			SELECT id FROM hosts WHERE hardware_serial IN(%s)`,
+		var hosts []fleet.Host
+		err = sqlx.SelectContext(ctx, tx, &hosts, fmt.Sprintf(`
+			SELECT id, hardware_model, hardware_serial FROM hosts WHERE hardware_serial IN(%s)`,
 			strings.Join(parts, ",")),
 			args...)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "ingest mdm apple host get host ids")
 		}
 
-		if err := upsertMDMAppleHostDisplayNamesDB(ctx, tx, hostIDs...); err != nil {
+		if err := upsertMDMAppleHostDisplayNamesDB(ctx, tx, hosts...); err != nil {
 			return ctxerr.Wrap(ctx, err, "ingest mdm apple host upsert display names")
 		}
 
-		if err := upsertMDMAppleHostLabelMembershipDB(ctx, tx, ds.logger, hostIDs...); err != nil {
+		if err := upsertMDMAppleHostLabelMembershipDB(ctx, tx, ds.logger, hosts...); err != nil {
 			return ctxerr.Wrap(ctx, err, "ingest mdm apple host upsert label membership")
 		}
 
-		if err := upsertMDMAppleHostMDMInfoDB(ctx, tx, appCfg.ServerSettings.ServerURL, true, hostIDs...); err != nil {
+		if err := upsertMDMAppleHostMDMInfoDB(ctx, tx, appCfg.ServerSettings.ServerURL, true, hosts...); err != nil {
 			return ctxerr.Wrap(ctx, err, "ingest mdm apple host upsert MDM info")
 		}
 
@@ -452,12 +453,13 @@ func (ds *Datastore) IngestMDMAppleDevicesFromDEPSync(ctx context.Context, devic
 	return resCount, err
 }
 
-func upsertMDMAppleHostDisplayNamesDB(ctx context.Context, tx sqlx.ExtContext, hostIDs ...uint) error {
+func upsertMDMAppleHostDisplayNamesDB(ctx context.Context, tx sqlx.ExtContext, hosts ...fleet.Host) error {
 	args := []interface{}{}
 	parts := []string{}
-	for _, id := range hostIDs {
-		args = append(args, id)
-		parts = append(parts, "(?, '')")
+	for _, h := range hosts {
+		// name := fmt.Sprintf("%s (%s)", h.HardwareModel, h.HardwareSerial)
+		args = append(args, h.ID, h.DisplayName())
+		parts = append(parts, "(?, ?)")
 	}
 
 	_, err := tx.ExecContext(ctx, fmt.Sprintf(`
@@ -471,7 +473,7 @@ func upsertMDMAppleHostDisplayNamesDB(ctx context.Context, tx sqlx.ExtContext, h
 	return nil
 }
 
-func upsertMDMAppleHostMDMInfoDB(ctx context.Context, tx sqlx.ExtContext, serverURL string, fromSync bool, hostIDs ...uint) error {
+func upsertMDMAppleHostMDMInfoDB(ctx context.Context, tx sqlx.ExtContext, serverURL string, fromSync bool, hosts ...fleet.Host) error {
 	result, err := tx.ExecContext(ctx, `
 		INSERT INTO mobile_device_management_solutions (name, server_url) VALUES (?, ?)
 		ON DUPLICATE KEY UPDATE server_url = VALUES(server_url)`,
@@ -491,8 +493,8 @@ func upsertMDMAppleHostMDMInfoDB(ctx context.Context, tx sqlx.ExtContext, server
 
 	args := []interface{}{}
 	parts := []string{}
-	for _, id := range hostIDs {
-		args = append(args, enrolled, serverURL, fromSync, mdmID, false, id)
+	for _, h := range hosts {
+		args = append(args, enrolled, serverURL, fromSync, mdmID, false, h.ID)
 		parts = append(parts, "(?, ?, ?, ?, ?, ?)")
 	}
 
@@ -503,7 +505,7 @@ func upsertMDMAppleHostMDMInfoDB(ctx context.Context, tx sqlx.ExtContext, server
 	return ctxerr.Wrap(ctx, err, "upsert host mdm info")
 }
 
-func upsertMDMAppleHostLabelMembershipDB(ctx context.Context, tx sqlx.ExtContext, logger log.Logger, hostIDs ...uint) error {
+func upsertMDMAppleHostLabelMembershipDB(ctx context.Context, tx sqlx.ExtContext, logger log.Logger, hosts ...fleet.Host) error {
 	// Builtin label memberships are usually inserted when the first distributed
 	// query results are received; however, we want to insert pending MDM hosts
 	// now because it may still be some time before osquery is running on these
@@ -525,9 +527,9 @@ func upsertMDMAppleHostLabelMembershipDB(ctx context.Context, tx sqlx.ExtContext
 
 	parts := []string{}
 	args := []interface{}{}
-	for _, id := range hostIDs {
+	for _, h := range hosts {
 		parts = append(parts, "(?,?),(?,?)")
-		args = append(args, id, labelIDs[0], id, labelIDs[1])
+		args = append(args, h.ID, labelIDs[0], h.ID, labelIDs[1])
 	}
 	_, err = tx.ExecContext(ctx, fmt.Sprintf(`
 			INSERT INTO label_membership (host_id, label_id) VALUES %s 
@@ -573,6 +575,13 @@ func filterMDMAppleDevices(devices []godep.Device) []godep.Device {
 
 func unionSelectDevices(devices []godep.Device) (stmt string, args []interface{}) {
 	for i, d := range devices {
+		// if i == 0 {
+		// 	stmt = "SELECT ? hostname, ? hardware_serial, ? hardware_model"
+		// } else {
+		// 	stmt += " UNION SELECT ?, ?, ?"
+		// }
+		// name := fmt.Sprintf("%s (%s)", d.Model, d.SerialNumber)
+		// args = append(args, name, d.SerialNumber, d.Model)
 		if i == 0 {
 			stmt = "SELECT ? hardware_serial, ? hardware_model"
 		} else {

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -64,8 +64,8 @@ func TestIngestMDMAppleDevicesFromDEPSync(t *testing.T) {
 	gotSerials := []string{}
 	for _, h := range hosts {
 		gotSerials = append(gotSerials, h.HardwareSerial)
-		if h.HardwareSerial == "abc" || h.HardwareSerial == "xyz" {
-			checkMDMHostRelatedTables(t, ds, h.ID)
+		if hs := h.HardwareSerial; hs == "abc" || hs == "xyz" {
+			checkMDMHostRelatedTables(t, ds, h.ID, hs, "MacBook Pro")
 		}
 	}
 	require.ElementsMatch(t, wantSerials, gotSerials)
@@ -158,7 +158,7 @@ func testIngestMDMAppleCheckinAfterDEPSync(t *testing.T, ds *Datastore) {
 	// is not available from the DEP sync endpoint
 	require.Equal(t, testSerial, hosts[0].HardwareSerial)
 	require.Equal(t, "", hosts[0].UUID)
-	checkMDMHostRelatedTables(t, ds, hosts[0].ID)
+	checkMDMHostRelatedTables(t, ds, hosts[0].ID, testSerial, "MacBook Pro")
 
 	// now simulate the initial MDM checkin by that same host
 	err = fleet.HandleMDMCheckinRequest(ctx, &http.Request{
@@ -172,7 +172,7 @@ func testIngestMDMAppleCheckinAfterDEPSync(t *testing.T, ds *Datastore) {
 	hosts = listHostsCheckCount(t, ds, fleet.TeamFilter{User: test.UserAdmin}, fleet.HostListOptions{}, 1)
 	require.Equal(t, testSerial, hosts[0].HardwareSerial)
 	require.Equal(t, testUUID, hosts[0].UUID)
-	checkMDMHostRelatedTables(t, ds, hosts[0].ID)
+	checkMDMHostRelatedTables(t, ds, hosts[0].ID, testSerial, "MacBook Pro")
 
 	// an activity is created
 	activities, err := ds.ListActivities(context.Background(), fleet.ListActivitiesOptions{})
@@ -215,7 +215,7 @@ func testIngestMDMAppleCheckinBeforeDEPSync(t *testing.T, ds *Datastore) {
 	hosts := listHostsCheckCount(t, ds, fleet.TeamFilter{User: test.UserAdmin}, fleet.HostListOptions{}, 1)
 	require.Equal(t, testSerial, hosts[0].HardwareSerial)
 	require.Equal(t, testUUID, hosts[0].UUID)
-	checkMDMHostRelatedTables(t, ds, hosts[0].ID)
+	checkMDMHostRelatedTables(t, ds, hosts[0].ID, testSerial, "MacBook Pro")
 
 	// no effect if same host appears in DEP sync
 	n, err := ds.IngestMDMAppleDevicesFromDEPSync(ctx, []godep.Device{
@@ -227,7 +227,7 @@ func testIngestMDMAppleCheckinBeforeDEPSync(t *testing.T, ds *Datastore) {
 	hosts = listHostsCheckCount(t, ds, fleet.TeamFilter{User: test.UserAdmin}, fleet.HostListOptions{}, 1)
 	require.Equal(t, testSerial, hosts[0].HardwareSerial)
 	require.Equal(t, testUUID, hosts[0].UUID)
-	checkMDMHostRelatedTables(t, ds, hosts[0].ID)
+	checkMDMHostRelatedTables(t, ds, hosts[0].ID, testSerial, "MacBook Pro")
 }
 
 func testIngestMDMAppleCheckinMultipleAuthenticateRequests(t *testing.T, ds *Datastore) {
@@ -300,11 +300,11 @@ func testIngestMDMAppleCheckinCheckoutRequests(t *testing.T, ds *Datastore) {
 // host_display_names, host_seen_times, and label_membership. Note that related tables records for
 // pre-existing hosts are created outside of the MDM enrollment flows so they are not checked in
 // some tests above (e.g., testIngestMDMAppleHostAlreadyExistsInFleet)
-func checkMDMHostRelatedTables(t *testing.T, ds *Datastore, hostID uint) {
-	var ok bool
-	err := sqlx.GetContext(context.Background(), ds.reader, &ok, `SELECT 1 FROM host_display_names WHERE host_id = ?`, hostID)
+func checkMDMHostRelatedTables(t *testing.T, ds *Datastore, hostID uint, expectedSerial string, expectedModel string) {
+	var displayName string
+	err := sqlx.GetContext(context.Background(), ds.reader, &displayName, `SELECT display_name FROM host_display_names WHERE host_id = ?`, hostID)
 	require.NoError(t, err)
-	require.True(t, ok)
+	require.Equal(t, fmt.Sprintf("%s (%s)", expectedModel, expectedSerial), displayName)
 
 	var labelsOK []bool
 	err = sqlx.SelectContext(context.Background(), ds.reader, &labelsOK, `SELECT 1 FROM label_membership WHERE host_id = ?`, hostID)

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -202,12 +203,21 @@ type Host struct {
 	DeviceMapping *json.RawMessage `json:"device_mapping,omitempty" db:"device_mapping" csv:"-"`
 }
 
-// DisplayName returns ComputerName if it isn't empty or HostName otherwise.
+// DisplayName returns ComputerName if it isn't empty. Otherwise, it returns Hostname if it isn't
+// empty. If Hostname is empty and both HardwareSerial and HardwareModel are not empty, it returns a
+// composite string with HardwareModel and HardwareSerial. If all else fails, it returns an empty
+// string.
 func (h *Host) DisplayName() string {
-	if cn := h.ComputerName; cn != "" {
-		return cn
+	switch {
+	case h.ComputerName != "":
+		return h.ComputerName
+	case h.Hostname != "":
+		return h.Hostname
+	case h.HardwareModel != "" && h.HardwareSerial != "":
+		return fmt.Sprintf("%s (%s)", h.HardwareModel, h.HardwareSerial)
+	default:
+		return ""
 	}
-	return h.Hostname
 }
 
 type HostIssues struct {

--- a/server/fleet/hosts_test.go
+++ b/server/fleet/hosts_test.go
@@ -1,6 +1,7 @@
 package fleet
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -119,5 +120,45 @@ func TestPlatformFromHost(t *testing.T) {
 		fleetPlatform := PlatformFromHost(tc.host)
 		require.Equal(t, tc.expPlatform, fleetPlatform)
 
+	}
+}
+
+func TestHostDisplayName(t *testing.T) {
+	const (
+		computerName   = "K0mpu73rN4M3"
+		hostname       = "h0s7N4ME"
+		hardwareModel  = "M0D3l"
+		hardwareSerial = "53r14l"
+	)
+	for _, tc := range []struct {
+		host     Host
+		expected string
+	}{
+		{
+			host:     Host{ComputerName: computerName, Hostname: hostname, HardwareModel: hardwareModel, HardwareSerial: hardwareSerial},
+			expected: computerName, // If ComputerName is present, DisplayName is ComputerName
+		},
+		{
+			host:     Host{ComputerName: "", Hostname: "h0s7N4ME", HardwareModel: "M0D3l", HardwareSerial: "53r14l"},
+			expected: hostname, // If ComputerName is empty, DisplayName is Hostname (if present)
+		},
+		{
+			host:     Host{ComputerName: "", Hostname: "", HardwareModel: "M0D3l", HardwareSerial: "53r14l"},
+			expected: fmt.Sprintf("%s (%s)", hardwareModel, hardwareSerial), // If ComputerName and Hostname are empty, DisplayName is composite of HardwareModel and HardwareSerial (if both are present)
+		},
+		{
+			host:     Host{ComputerName: "", Hostname: "", HardwareModel: "", HardwareSerial: hardwareSerial},
+			expected: "", // If HarwareModel and/or HardwareSerial are empty, DisplayName is also empty
+		},
+		{
+			host:     Host{ComputerName: "", Hostname: "", HardwareModel: hardwareModel, HardwareSerial: ""},
+			expected: "", // If HarwareModel and/or HardwareSerial are empty, DisplayName is also empty
+		},
+		{
+			host:     Host{ComputerName: "", Hostname: "", HardwareModel: "", HardwareSerial: ""},
+			expected: "", // If HarwareModel and/or HardwareSerial are empty, DisplayName is also empty
+		},
+	} {
+		require.Equal(t, tc.expected, tc.host.DisplayName())
 	}
 }


### PR DESCRIPTION
Implements dev note from [Figma](https://www.figma.com/file/hdALBDsrti77QuDNSzLdkx/%F0%9F%9A%A7-Fleet-EE-(dev-ready%2C-scratchpad)?node-id=11911%3A331791&t=t3Gh5l2HKrqFnD9s-0)

<img width="730" alt="Screenshot 2023-01-03 at 3 18 02 PM" src="https://user-images.githubusercontent.com/73313222/210442960-7adfedf6-b883-434a-a334-7a2996b4cd0b.png">

Related to #8879