### PR TITLE
Make code match what we are running in prod for sandbox timeout

### DIFF
--- a/infrastructure/sandbox/JITProvisioner/jitprovisioner.tf
+++ b/infrastructure/sandbox/JITProvisioner/jitprovisioner.tf
@@ -131,7 +131,7 @@ resource "aws_lambda_function" "jitprovisioner" {
   role                           = aws_iam_role.jitprovisioner.arn
   reserved_concurrent_executions = -1
   kms_key_arn                    = var.kms_key.arn
-  timeout                        = 10
+  timeout                        = 5
   memory_size                    = 512
   vpc_config {
     security_group_ids = [aws_security_group.jitprovisioner.id]


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
