### PR TITLE
Fleet UI: Add MDM enrollment/unenrollment activity to activity feed

### DIFF
--- a/changes/8995-activity-feed-mdm-enrollment
+++ b/changes/8995-activity-feed-mdm-enrollment
@@ -1,0 +1,1 @@
+- Added new activities to the activities API when a host is enrolled/unenrolled from Fleet's MDM.

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -28,6 +28,8 @@ export enum ActivityType {
   UserDeletedGlobalRole = "deleted_user_global_role",
   UserChangedTeamRole = "changed_user_team_role",
   UserDeletedTeamRole = "deleted_user_team_role",
+  MdmEnrolled = "mdm_enrolled",
+  MdmUnenrolled = "mdm_unenrolled",
 }
 export interface IActivity {
   created_at: string;
@@ -56,4 +58,6 @@ export interface IActivityDetails {
   public_ip?: string;
   user_email?: string;
   role?: string;
+  host_serial?: string;
+  installed_from_dep?: boolean;
 }

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -141,6 +141,30 @@ const TAGGED_TEMPLATES = {
       </>
     );
   },
+  mdmEnrolled: (activity: IActivity) => {
+    return (
+      <>
+        An end user turned on MDM features for a host with serial number
+        <b>
+          {activity.details?.host_serial} (
+          {activity.details?.installed_from_dep ? "automatic" : "manual"})
+        </b>
+        .
+      </>
+    );
+  },
+  mdmUnenrolled: (activity: IActivity) => {
+    return (
+      <>
+        An end user turned off MDM features for a host with serial number
+        <b>
+          {activity.details?.host_serial} (
+          {activity.details?.installed_from_dep ? "automatic" : "manual"})
+        </b>
+        .
+      </>
+    );
+  },
 
   defaultActivityTemplate: (activity: IActivity) => {
     const entityName = find(activity.details, (_, key) =>
@@ -209,6 +233,12 @@ const getDetail = (
     }
     case ActivityType.UserDeletedTeamRole: {
       return TAGGED_TEMPLATES.userDeletedTeamRole(activity);
+    }
+    case ActivityType.MdmEnrolled: {
+      return TAGGED_TEMPLATES.mdmEnrolled(activity);
+    }
+    case ActivityType.MdmUnenrolled: {
+      return TAGGED_TEMPLATES.mdmUnenrolled(activity);
     }
     default: {
       return TAGGED_TEMPLATES.defaultActivityTemplate(activity);


### PR DESCRIPTION
### Issue
Cerra #8995 

### New feature
- Inform user when an end user enrolls or unenrolls to MDM

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [ ] Manual QA for all new/changed functionality