### PR TITLE
orbit: Always update orbit symlink when changing channels

### DIFF
--- a/orbit/changes/bug-9053-update-symlink-on-change
+++ b/orbit/changes/bug-9053-update-symlink-on-change
@@ -1,0 +1,2 @@
+* Orbit now restarts and switches channels when needed,
+even if the new channel is already installed

--- a/orbit/pkg/update/runner_test.go
+++ b/orbit/pkg/update/runner_test.go
@@ -44,11 +44,10 @@ func TestNewRunner(t *testing.T) {
 	require.FileExists(t, execPath)
 
 	// Create another Runner but with the target already existing.
-	// This should be true since orbit needs to restart
 	r2, err := NewRunner(u, runnerOpts)
 	require.NoError(t, err)
 
 	didUpdate, err = r2.UpdateAction()
 	require.NoError(t, err)
-	require.True(t, didUpdate)
+	require.False(t, didUpdate)
 }

--- a/orbit/pkg/update/runner_test.go
+++ b/orbit/pkg/update/runner_test.go
@@ -44,10 +44,11 @@ func TestNewRunner(t *testing.T) {
 	require.FileExists(t, execPath)
 
 	// Create another Runner but with the target already existing.
+	// This should be true since orbit needs to restart
 	r2, err := NewRunner(u, runnerOpts)
 	require.NoError(t, err)
 
 	didUpdate, err = r2.UpdateAction()
 	require.NoError(t, err)
-	require.False(t, didUpdate)
+	require.True(t, didUpdate)
 }


### PR DESCRIPTION
Currently, switching between different channels does not always work because orbit will only update the symlink when a new version of the target channel is detected (see #9053). This PR will check if the symlink is out of date when updating so that we always update into the correct channel.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
