### PR TITLE
Adjust max age for cron stats entries

### DIFF
--- a/server/datastore/mysql/cron_stats.go
+++ b/server/datastore/mysql/cron_stats.go
@@ -85,7 +85,7 @@ func (ds *Datastore) UpdateAllCronStatsForInstance(ctx context.Context, instance
 
 func (ds *Datastore) CleanupCronStats(ctx context.Context) error {
 	deleteStmt := `DELETE FROM cron_stats WHERE created_at < DATE_SUB(NOW(), INTERVAL ? DAY)`
-	const MAX_DAYS_RETAINED = 14
+	const MAX_DAYS_RETAINED = 2
 	if _, err := ds.writer.ExecContext(ctx, deleteStmt, MAX_DAYS_RETAINED); err != nil {
 		return ctxerr.Wrap(ctx, err, "deleting old cron stats")
 	}

--- a/server/datastore/mysql/cron_stats_test.go
+++ b/server/datastore/mysql/cron_stats_test.go
@@ -105,7 +105,7 @@ func TestCleanupCronStats(t *testing.T) {
 	ctx := context.Background()
 	ds := CreateMySQLDS(t)
 	now := time.Now().UTC().Truncate(time.Second)
-	twoWeeksAgo := now.Add(-2 * 24 * time.Hour)
+	twoDaysAgo := now.Add(-2 * 24 * time.Hour)
 	name := "test_sched"
 	instance := "test_instance"
 
@@ -152,13 +152,13 @@ func TestCleanupCronStats(t *testing.T) {
 			shouldCleanupMaxAge:     false,
 		},
 		{
-			createdAt:               twoWeeksAgo.Add(1 * time.Hour),
+			createdAt:               twoDaysAgo.Add(1 * time.Hour),
 			status:                  fleet.CronStatsStatusCompleted,
 			shouldCleanupMaxPending: false,
 			shouldCleanupMaxAge:     false,
 		},
 		{
-			createdAt:               twoWeeksAgo.Add(-1 * time.Hour),
+			createdAt:               twoDaysAgo.Add(-1 * time.Hour),
 			status:                  fleet.CronStatsStatusCompleted,
 			shouldCleanupMaxPending: false,
 			shouldCleanupMaxAge:     true,

--- a/server/datastore/mysql/cron_stats_test.go
+++ b/server/datastore/mysql/cron_stats_test.go
@@ -105,7 +105,7 @@ func TestCleanupCronStats(t *testing.T) {
 	ctx := context.Background()
 	ds := CreateMySQLDS(t)
 	now := time.Now().UTC().Truncate(time.Second)
-	twoWeeksAgo := now.Add(-14 * 24 * time.Hour)
+	twoWeeksAgo := now.Add(-2 * 24 * time.Hour)
 	name := "test_sched"
 	instance := "test_instance"
 


### PR DESCRIPTION
For the initial implementation of `cron_stats`, we arbitrarily set a max age of 14 days for retention of table entries. In practice, there's not a demonstrated need for that length of time. Additionally, we've been expanding the number and frequency of cron jobs that generate entries so having a shorter window to clean up older entries will reduce database usage.
