### PR TITLE
Fleet UI: Fix manage host page for invalid query strings spinner

### DIFF
--- a/changes/9129-fix-neverending-spinner
+++ b/changes/9129-fix-neverending-spinner
@@ -1,0 +1,1 @@
+- Invalid query string will not result in neverending spinner

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -349,7 +349,7 @@ const ManageHostsPage = ({
     }
   );
 
-  useQuery<IStoredPolicyResponse, Error>(
+  const { isLoading: isLoadingPolicy } = useQuery<IStoredPolicyResponse, Error>(
     ["policy"],
     () => globalPoliciesAPI.load(policyId),
     {
@@ -357,8 +357,13 @@ const ManageHostsPage = ({
       onSuccess: ({ policy: policyAPIResponse }) => {
         setPolicy(policyAPIResponse);
       },
+      onError: () => {
+        setHasHostErrors(true);
+      },
     }
   );
+
+  console.log("hasPolicyErrors", hasHostErrors);
 
   const { data: osVersions } = useQuery<
     IOSVersionsResponse,
@@ -1645,7 +1650,14 @@ const ManageHostsPage = ({
   };
 
   const renderTable = () => {
-    if (!config || !currentUser || !hosts || !teamSync) {
+    if (
+      !config ||
+      !currentUser ||
+      isHostCountLoading ||
+      isHostsLoading ||
+      isLoadingPolicy ||
+      !teamSync
+    ) {
       return <Spinner />;
     }
 
@@ -1709,7 +1721,7 @@ const ManageHostsPage = ({
     return (
       <TableContainer
         columns={tableColumns}
-        data={hosts}
+        data={hosts || []}
         isLoading={isHostsLoading || isHostCountLoading}
         manualSortBy
         defaultSortHeader={(sortBy[0] && sortBy[0].key) || DEFAULT_SORT_HEADER}

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -363,8 +363,6 @@ const ManageHostsPage = ({
     }
   );
 
-  console.log("hasPolicyErrors", hasHostErrors);
-
   const { data: osVersions } = useQuery<
     IOSVersionsResponse,
     Error,


### PR DESCRIPTION
### Issue
Cerra #9129 

### Fix
- Fix never ending spinners
  - Fixes initial finding of never ending spinner for invalid `mdm_enrollment_status` to now show error state
  - Other neverending spinners fixed by fix to show error state: invalid `order_direction`, invalid `order_key`, invalid `software_id`
- Fix empty states that are not correct
  - Also fix invalid `policy_id`, invalid `policy_response` to show error state instead of empty state

### Screenshot
<img width="1291" alt="Screenshot 2023-01-05 at 2 40 19 PM" src="https://user-images.githubusercontent.com/71795832/210866101-63570bbf-c8f3-460a-8288-1d84aec23a64.png">
<img width="1290" alt="Screenshot 2023-01-05 at 2 41 32 PM" src="https://user-images.githubusercontent.com/71795832/210866512-c07721b2-25a5-4afe-8201-950921914bda.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
