### PR TITLE
Feat/add mdm modal

### DIFF
--- a/changes/issue-8987-add-mdm-enrollment-profile-modal
+++ b/changes/issue-8987-add-mdm-enrollment-profile-modal
@@ -1,0 +1,1 @@
+- add modal to allow user to download an enrollment profile required for fleet mdm enrollment.

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -94,7 +94,6 @@ import PolicyIcon from "../../../../assets/images/icon-policy-fleet-black-12x12@
 import DownloadIcon from "../../../../assets/images/icon-download-12x12@2x.png";
 import LabelFilterSelect from "./components/LabelFilterSelect";
 import FilterPill from "./components/FilterPill";
-import ManualEnrollMdmModal from "../details/DeviceUserPage/ManualEnrollMdmModal";
 
 interface IManageHostsProps {
   route: RouteProps;
@@ -1390,15 +1389,14 @@ const ManageHostsPage = ({
         ? teamSecrets?.[0].secret
         : globalSecrets?.[0].secret;
     return (
-      <ManualEnrollMdmModal onCancel={() => undefined} />
-      // <AddHostsModal
-      //   currentTeam={currentTeam}
-      //   enrollSecret={enrollSecret}
-      //   isLoading={isLoadingTeams || isGlobalSecretsLoading}
-      //   isSandboxMode={!!isSandboxMode}
-      //   onCancel={toggleAddHostsModal}
-      //   openEnrollSecretModal={() => setShowEnrollSecretModal(true)}
-      // />
+      <AddHostsModal
+        currentTeam={currentTeam}
+        enrollSecret={enrollSecret}
+        isLoading={isLoadingTeams || isGlobalSecretsLoading}
+        isSandboxMode={!!isSandboxMode}
+        onCancel={toggleAddHostsModal}
+        openEnrollSecretModal={() => setShowEnrollSecretModal(true)}
+      />
     );
   };
 

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -94,6 +94,7 @@ import PolicyIcon from "../../../../assets/images/icon-policy-fleet-black-12x12@
 import DownloadIcon from "../../../../assets/images/icon-download-12x12@2x.png";
 import LabelFilterSelect from "./components/LabelFilterSelect";
 import FilterPill from "./components/FilterPill";
+import ManualEnrollMdmModal from "../details/DeviceUserPage/ManualEnrollMdmModal";
 
 interface IManageHostsProps {
   route: RouteProps;
@@ -1389,14 +1390,15 @@ const ManageHostsPage = ({
         ? teamSecrets?.[0].secret
         : globalSecrets?.[0].secret;
     return (
-      <AddHostsModal
-        currentTeam={currentTeam}
-        enrollSecret={enrollSecret}
-        isLoading={isLoadingTeams || isGlobalSecretsLoading}
-        isSandboxMode={!!isSandboxMode}
-        onCancel={toggleAddHostsModal}
-        openEnrollSecretModal={() => setShowEnrollSecretModal(true)}
-      />
+      <ManualEnrollMdmModal onCancel={() => undefined} />
+      // <AddHostsModal
+      //   currentTeam={currentTeam}
+      //   enrollSecret={enrollSecret}
+      //   isLoading={isLoadingTeams || isGlobalSecretsLoading}
+      //   isSandboxMode={!!isSandboxMode}
+      //   onCancel={toggleAddHostsModal}
+      //   openEnrollSecretModal={() => setShowEnrollSecretModal(true)}
+      // />
     );
   };
 

--- a/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+import Button from "components/buttons/Button";
+import Modal from "components/Modal";
+
+export interface IInfoModalProps {
+  onCancel: () => void;
+}
+
+const baseClass = "manual-enroll-mdm-modal";
+
+const ManualEnrollMdmModal = ({ onCancel }: IInfoModalProps): JSX.Element => {
+  // const handleDownload = () => {};
+
+  return (
+    <Modal title="Turn on MDM" onExit={onCancel} className={baseClass}>
+      <div>
+        <p>
+          To turn on MDM, Apple Inc. requires that you download and install a
+          profile
+        </p>
+        <ol>
+          <li>
+            <span>Download your profile.</span>
+            <Button type="button" onClick={() => undefined} variant="brand">
+              Download
+            </Button>
+          </li>
+          <li>
+            From the Apple menu in the top left corner of your screen, select{" "}
+            <b>System Settings</b> or <b>System Preferences</b>.
+          </li>
+          <li>
+            In the search bar, type “Profiles.” Select <b>Profiles</b>, find and
+            select <b>Enrollment Profile</b>, and select <b>Install</b>.
+          </li>
+          <li>
+            Enter your password, and select <b>Enroll</b>.
+          </li>
+          <li>
+            Close this window and select <b>Refetch</b> on your My device page
+            to tell your organization that MDM is on.
+          </li>
+        </ol>
+        <div className="modal-cta-wrap">
+          <Button type="button" onClick={onCancel} variant="brand">
+            Done
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ManualEnrollMdmModal;

--- a/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
 
 import Button from "components/buttons/Button";
 import Modal from "components/Modal";
+
+import mdmAPI from "services/entities/mdm";
 
 export interface IInfoModalProps {
   onCancel: () => void;
@@ -10,19 +12,38 @@ export interface IInfoModalProps {
 const baseClass = "manual-enroll-mdm-modal";
 
 const ManualEnrollMdmModal = ({ onCancel }: IInfoModalProps): JSX.Element => {
-  // const handleDownload = () => {};
+  const [showDownloading, setshowDownloading] = useState(false);
+
+  const handleDownload = async () => {
+    setshowDownloading(true);
+    setTimeout(() => {
+      setshowDownloading(false);
+    }, 1000);
+
+    try {
+      await mdmAPI.downloadEnrollmentProfile();
+    } catch (e) {
+      console.error("error downloading profile:", e);
+    }
+  };
 
   return (
     <Modal title="Turn on MDM" onExit={onCancel} className={baseClass}>
       <div>
-        <p>
+        <p className={`${baseClass}__description`}>
           To turn on MDM, Apple Inc. requires that you download and install a
           profile
         </p>
         <ol>
           <li>
             <span>Download your profile.</span>
-            <Button type="button" onClick={() => undefined} variant="brand">
+            <Button
+              type="button"
+              onClick={handleDownload}
+              variant="brand"
+              isLoading={showDownloading}
+              className={`${baseClass}__download-button`}
+            >
               Download
             </Button>
           </li>

--- a/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/_styles.scss
@@ -1,12 +1,20 @@
 .manual-enroll-mdm-modal {
   width: 800px;
 
+  &__description {
+    margin: $pad-large 0;
+  }
+
   ol {
-    padding-left: 0
+    padding-left: 0;
   }
 
   li {
     margin-bottom: $pad-large;
     list-style: number inside;
+  }
+
+  &__download-button {
+    margin-top: 12px;
   }
 }

--- a/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/_styles.scss
@@ -1,0 +1,12 @@
+.manual-enroll-mdm-modal {
+  width: 800px;
+
+  ol {
+    padding-left: 0
+  }
+
+  li {
+    margin-bottom: $pad-large;
+    list-style: number inside;
+  }
+}

--- a/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/index.ts
+++ b/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ManualEnrollMdmModal";

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -1,0 +1,11 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import { sendRequest } from "services/mock_service/service/service"; // MDM TODO: Replace when backend is merged
+// import sendRequest from "services";
+import endpoints from "utilities/endpoints";
+
+export default {
+  downloadEnrollmentProfile: () => {
+    const { MDM_DOWNLOAD_ENROLLMENT_PROFILE } = endpoints;
+    return sendRequest("GET", MDM_DOWNLOAD_ENROLLMENT_PROFILE);
+  },
+};

--- a/frontend/services/mock_service/mocks/config.ts
+++ b/frontend/services/mock_service/mocks/config.ts
@@ -24,6 +24,7 @@ const REQUEST_RESPONSE_MAPPINGS: IResponses = {
     "targets?query={*}": RESPONSES.hosts,
     "mdm/apple": RESPONSES.mdmApple,
     "mdm/apple_bm": RESPONSES.mdmAppleBm,
+    "mdm/profile": RESPONSES.mdmEnrollmentProfile,
   },
   POST: {
     // request body is ISelectedTargets

--- a/frontend/services/mock_service/mocks/responses.ts
+++ b/frontend/services/mock_service/mocks/responses.ts
@@ -29,6 +29,9 @@ const mdmAppleBm = {
   renew_date: "2023-09-30T00:00:00Z",
 };
 
+// MDM TODO: Remove mock when backend is merged
+const mdmEnrollmentProfile = {};
+
 const hosts = {
   hosts: [
     {
@@ -388,4 +391,5 @@ export default {
   labels,
   mdmApple,
   mdmAppleBm,
+  mdmEnrollmentProfile,
 };

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -31,6 +31,7 @@ export default {
   LOGIN: `/${API_VERSION}/fleet/login`,
   LOGOUT: `/${API_VERSION}/fleet/logout`,
   MACADMINS: `/${API_VERSION}/fleet/macadmins`,
+  MDM_DOWNLOAD_ENROLLMENT_PROFILE: `/${API_VERSION}/fleet/mdm/profile`, // TODO: change if needed when API READY
   MDM_APPLE: `/${API_VERSION}/fleet/mdm/apple`,
   MDM_APPLE_BM: `/${API_VERSION}/fleet/mdm/apple_bm`,
   MDM_APPLE_BM_KEYS: `/${API_VERSION}/fleet/mdm/apple_bm/keys`,


### PR DESCRIPTION
relates to https://github.com/fleetdm/fleet/issues/8987

adds an MDM modal users can use to download an enrollment profile. It purposely is not displayed anywhere currently.

![image](https://user-images.githubusercontent.com/1153709/211021307-a3c41209-08d9-458f-98fd-3c668ef265e3.png)

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
