### PR TITLE
Update Github URL for tables that have Fleet overrides

### DIFF
--- a/website/api/helpers/get-extended-osquery-schema.js
+++ b/website/api/helpers/get-extended-osquery-schema.js
@@ -275,7 +275,7 @@ module.exports = {
         }
         // After we've made sure that this table has all the required values, we'll add the url of the table's YAML file in the Fleet GitHub repo as the `fleetRepoUrl`  and the location of this table on fleetdm.com as the `url` before adding it to our merged schema.
         fleetOverrideToPush.url = 'https://fleetdm.com/tables/'+encodeURIComponent(fleetOverrideToPush.name);
-        fleetOverrideToPush.fleetRepoUrl = 'https://github.com/edit/fleetdm/fleet/schema/tables/'+encodeURIComponent(fleetOverrideToPush.name)+'.yml';
+        fleetOverrideToPush.fleetRepoUrl = 'https://github.com/fleetdm/fleet/blob/main/schema/tables/'+encodeURIComponent(fleetOverrideToPush.name)+'.yml';
         expandedTables.push(fleetOverrideToPush);
       }//∞ After each Fleet overrides table
     }


### PR DESCRIPTION
Changes:
- Updated the fleetRepoUrl value for osquery schema tables that have Fleet overrides to use the correct URL.