### PR TITLE
Remove epic label from all new feature issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-feature-work.md
+++ b/.github/ISSUE_TEMPLATE/new-feature-work.md
@@ -2,7 +2,7 @@
 name: 🎟  New feature work
 about: Specify a planned, new feature in Fleet so that engineering can provide an estimation on the time required for implementation.
 title: ''
-labels: 'epic'
+labels: ''
 assignees: ''
 
 ---


### PR DESCRIPTION
The majority of the issues created are not epics, so I'm proposing we remove the `epic` label from being automatically assigned to all new feature issues. This will also be necessary if/when we transition to Zenhub. 