### PR TITLE
Fleet UI: Remove team policy stale time, remove team policy automation statetime

### DIFF
--- a/changes/9218-fix-team-policies-stale-time
+++ b/changes/9218-fix-team-policies-stale-time
@@ -1,0 +1,1 @@
+- Remove stale time from loading team policies/policy automation so users are provided accurate team data when toggling between teams

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -131,7 +131,6 @@ const ManagePolicyPage = ({
         setTeamPolicies(data.policies);
         setInheritedPolicies(data.inherited_policies);
       },
-      staleTime: 5000,
     }
   );
 
@@ -167,7 +166,6 @@ const ManagePolicyPage = ({
     {
       enabled: !!teamId && canAddOrDeletePolicy,
       select: (data) => data.team,
-      staleTime: 5000,
     }
   );
 


### PR DESCRIPTION
### Issue
- Cerra #9218 

### Fix
- Remove 5 sec stale time for call to team policies and team policy automations
- This stale time was causing a bug where the correct team's data would not load if you toggled between teams under 5 seconds

### Steps to QA
- Toggle between several team policies and policy automations (modal) and see that they are now correct no matter how fast you toggle.
<img width="1482" alt="Screenshot 2023-01-09 at 3 28 14 PM" src="https://user-images.githubusercontent.com/71795832/211401916-7650896b-5e69-4e3d-a649-431485c8f1e8.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
