### PR TITLE
Fix broken links in Adding-hosts.md and Orbit.md

### DIFF
--- a/docs/Using-Fleet/Adding-hosts.md
+++ b/docs/Using-Fleet/Adding-hosts.md
@@ -1,32 +1,34 @@
 # Adding hosts
 
-- [Introduction](#introduction)
-- [Add hosts with Orbit](#add-hosts-with-orbit)
-  - [Signing installers](#signing-installers)
-  - [Including Fleet Desktop](#including-fleet-desktop)
-  - [Adding multiple hosts](#adding-multiple-hosts)
-  - [Automatically adding hosts to a team](#automatically-adding-hosts-to-a-team)
-  - [Configuration options](#configuration-options)
-- [Add hosts with plain osquery](#add-hosts-with-plain-osquery)
-  - [Set an environment variable with an enroll secret](#set-an-environment-variable-with-an-enroll-secret)
-  - [Deploy the TLS certificate that osquery will use to communicate with Fleet](#deploy-the-tls-certificate-that-osquery-will-use-to-communicate-with-fleet)
-  - [Launching osqueryd](#launching-osqueryd)
-  - [Using a flag file to manage flags](#using-a-flag-file-to-manage-flags)
-    - [Flag file on Windows](#flag-file-on-windows)
-  - [Migrating from plain osquery to osquery installer](#migrating-from-plain-osquery-to-osquery-installer)
-    - [Generate installer](#generate-installer)
-    - [Migrate](#migrate)
-- [Grant full disk access to osquery on macOS](#grant-full-disk-access-to-osquery-on-macos)
-  - [Creating the configuration profile](#creating-the-configuration-profile)
-    - [Obtaining identifiers](#obtaining-identifiers)
-    - [Creating the profile](#creating-the-profile)
-    - [Test the profile](#test-the-profile)
+- [Adding hosts](#adding-hosts)
+  - [Introduction](#introduction)
+  - [Add hosts with Orbit](#add-hosts-with-orbit)
+    - [Signing installers](#signing-installers)
+    - [Including Fleet Desktop](#including-fleet-desktop)
+    - [Adding multiple hosts](#adding-multiple-hosts)
+    - [Automatically adding hosts to a team](#automatically-adding-hosts-to-a-team)
+    - [Configuration options](#configuration-options)
+  - [Add hosts with plain osquery](#add-hosts-with-plain-osquery)
+    - [Set up your Fleet enroll secret](#set-up-your-fleet-enroll-secret)
+    - [Provide the TLS certificate that osquery will use to communicate with Fleet](#provide-the-tls-certificate-that-osquery-will-use-to-communicate-with-fleet)
+    - [Configure and launch osquery](#configure-and-launch-osquery)
+      - [Launching osqueryd using command-line flags](#launching-osqueryd-using-command-line-flags)
+      - [Launching osqueryd using a flag file](#launching-osqueryd-using-a-flag-file)
+    - [Migrating from plain osquery to osquery installer](#migrating-from-plain-osquery-to-osquery-installer)
+      - [Generate installer](#generate-installer)
+      - [Migrate](#migrate)
+  - [Grant full disk access to osquery on macOS](#grant-full-disk-access-to-osquery-on-macos)
+    - [Creating the configuration profile](#creating-the-configuration-profile)
+      - [Obtaining identifiers](#obtaining-identifiers)
+      - [Creating the profile](#creating-the-profile)
+      - [Test the profile](#test-the-profile)
 
 ## Introduction
 
 Fleet gathers information from an [osquery](https://github.com/osquery/osquery) agent installed on each of your hosts. The recomended way to install osquery is using [Orbit](https://fleetdm.com/docs/using-fleet/orbit), Fleet's lightweight osquery runtime and autoupdater. 
 
 You can also install plain osquery on your hosts and connect to Fleet using osquery's `TLS API` plugins.
+
 ## Add hosts with Orbit
 
 To create an Orbit installer, you can use the `fleetctl package` command. To use the `fleetctl package` command, you must first install the `fleetctl` command-line tool. [Learn how to install `fleetctl`](https://fleetdm.com/fleetctl-preview).
@@ -111,31 +113,31 @@ To generate an osquery installer for a team:
 
 The following command-line flags allow you to configure an osquery installer further to communicate with a specific Fleet instance.
 
-|Flag | Options|
-|------|--------|
-|  --type |  **Required** - Type of package to build.<br> Options: `pkg`(macOS),`msi`(Windows), `deb`(Debian based Linux), `rpm`(RHEL, CentOS, etc.)|
-|--fleet-desktop |      Include Fleet Desktop. |
-|--enroll-secret |      Enroll secret for authenticating to Fleet server |
-|--fleet-url |          URL (`host:port`) of Fleet server |
-|--fleet-certificate |  Path to server certificate bundle |
-|--identifier |         Identifier for package product (default: `com.fleetdm.orbit`) |
-|--version |            Version for package product (default: `0.0.3`) |
-| --insecure  |             Disable TLS certificate verification (default: `false`) |
-| --service   |             Install osquery with a persistence service (launchd, systemd, etc.) (default: `true`) |
-|--sign-identity |      Identity to use for macOS codesigning |
-| --notarize |             Whether to notarize macOS packages (default: `false`) |
-| --disable-updates |   Disable auto updates on the generated package (default: false) |
-|--osqueryd-channel |   Update channel of osqueryd to use (default: `stable`) |
-|--orbit-channel |      Update channel of Orbit to use (default: `stable`) |
-|--desktop-channel |    Update channel of desktop to use (default: `stable`) |
-|--update-url |         URL for update server (default: `https://tuf.fleetctl.com`) |
-|--update-roots |       Root key JSON metadata for update server (from fleetctl updates roots) |
-| --debug     |             Enable debug logging (default: `false`) |
-| --verbose   |             Log detailed information when building the package (default: false) |
-| --help, -h    |             show help (default: `false`) |
+| Flag                | Options                                                                                                                                 |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| --type              | **Required** - Type of package to build.<br> Options: `pkg`(macOS),`msi`(Windows), `deb`(Debian based Linux), `rpm`(RHEL, CentOS, etc.) |
+| --fleet-desktop     | Include Fleet Desktop.                                                                                                                  |
+| --enroll-secret     | Enroll secret for authenticating to Fleet server                                                                                        |
+| --fleet-url         | URL (`host:port`) of Fleet server                                                                                                       |
+| --fleet-certificate | Path to server certificate bundle                                                                                                       |
+| --identifier        | Identifier for package product (default: `com.fleetdm.orbit`)                                                                           |
+| --version           | Version for package product (default: `0.0.3`)                                                                                          |
+| --insecure          | Disable TLS certificate verification (default: `false`)                                                                                 |
+| --service           | Install osquery with a persistence service (launchd, systemd, etc.) (default: `true`)                                                   |
+| --sign-identity     | Identity to use for macOS codesigning                                                                                                   |
+| --notarize          | Whether to notarize macOS packages (default: `false`)                                                                                   |
+| --disable-updates   | Disable auto updates on the generated package (default: false)                                                                          |
+| --osqueryd-channel  | Update channel of osqueryd to use (default: `stable`)                                                                                   |
+| --orbit-channel     | Update channel of Orbit to use (default: `stable`)                                                                                      |
+| --desktop-channel   | Update channel of desktop to use (default: `stable`)                                                                                    |
+| --update-url        | URL for update server (default: `https://tuf.fleetctl.com`)                                                                             |
+| --update-roots      | Root key JSON metadata for update server (from fleetctl updates roots)                                                                  |
+| --debug             | Enable debug logging (default: `false`)                                                                                                 |
+| --verbose           | Log detailed information when building the package (default: false)                                                                     |
+| --help, -h          | show help (default: `false`)                                                                                                            |
 
 
-Fleet supports other methods for adding your hosts to Fleet, such as the [plain osquery binaries](#plain-osquery) or [Kolide Osquery Launcher](https://github.com/kolide/launcher/blob/master/docs/launcher.md#connecting-to-fleet).
+Fleet supports other methods for adding your hosts to Fleet, such as the [plain osquery binaries](#add-hosts-with-plain-osquery) or [Kolide Osquery Launcher](https://github.com/kolide/launcher/blob/master/docs/launcher.md#connecting-to-fleet).
 
 ## Add hosts with plain osquery
 
@@ -256,7 +258,7 @@ If you currently ship a certificate (`fleet.pem`), also include this in the gene
 `--fleet-certificate [/path/to/fleet.pem]`.
 
 Fleet automatically manages most of the osquery flags to connect to the Fleet server. There's no
-need to set any of the flags mentioned above in [Launching osqueryd](#launching-osqueryd). To
+need to set any of the flags mentioned above in [Configure and launch osquery](#configure-and-launch-osquery). To
 include other osquery flags, provide a flagfile when packaging with `--osquery-flagfile
 [/path/to/osquery.flags]`.
 

--- a/docs/Using-Fleet/Orbit.md
+++ b/docs/Using-Fleet/Orbit.md
@@ -1,35 +1,38 @@
 # Orbit
 
-- [Introduction](#introduction)
-- [Try Orbit](#try-orbit)
-    - [With [`fleetctl preview` already running](https://github.com/fleetdm/fleet#try-fleet):](#with---fleetctl-preview--already-running--https---githubcom-fleetdm-fleet-try-fleet--)
-- [Capabilities](#capabilities)
-- [Usage](#usage)
-  - [Permissions](#permissions)
-    - [macOS/Linux](#macos-linux)
-    - [Windows](#windows)
-  - [Osquery shell](#osquery-shell)
-  - [Connect to a Fleet server](#connect-to-a-fleet-server)
-  - [Osquery flags](#osquery-flags)
-- [Packaging](#packaging)
-  - [Dependencies](#dependencies)
-  - [Packaging support](#packaging-support)
-  - [Building packages](#building-packages)
-    - [Configuration options](#configuration-options)
-    - [Update channels](#update-channels)
-    - [macOS signing & notarization](#macos-signing---notarization)
-    - [Orbit osquery result and status logs](#orbit-osquery-result-and-status-logs)
-    - [Orbit development](#orbit-development)
-      - [Run Orbit from source](#run-orbit-from-source)
-      - [Generate installer packages from Orbit source](#generate-installer-packages-from-orbit-source)
-  - [Troubleshooting](#troubleshooting)
-    - [Logs](#logs)
-    - [Debug](#debug)
-  - [Uninstall](#uninstall)
-    - [Windows](#windows-1)
-    - [Linux](#linux)
-    - [macOS](#macos)
-- [Bugs](#bugs)
+- [Orbit](#orbit)
+  - [Introduction](#introduction)
+  - [Try Orbit](#try-orbit)
+      - [With `fleetctl preview` already running:](#with-fleetctl-preview-already-running)
+  - [Capabilities](#capabilities)
+  - [Usage](#usage)
+    - [Permissions](#permissions)
+      - [macOS/Linux](#macoslinux)
+      - [Windows](#windows)
+    - [Osquery shell](#osquery-shell)
+    - [Connect to a Fleet server](#connect-to-a-fleet-server)
+    - [Osquery flags](#osquery-flags)
+    - [Osquery extensions](#osquery-extensions)
+  - [Packaging](#packaging)
+    - [Dependencies](#dependencies)
+    - [Packaging support](#packaging-support)
+    - [Building packages](#building-packages)
+      - [Configuration options](#configuration-options)
+      - [Fleet Desktop](#fleet-desktop)
+      - [Update channels](#update-channels)
+      - [macOS signing \& notarization](#macos-signing--notarization)
+      - [Orbit osquery result and status logs](#orbit-osquery-result-and-status-logs)
+      - [Orbit development](#orbit-development)
+        - [Run Orbit from source](#run-orbit-from-source)
+        - [Generate installer packages from Orbit source](#generate-installer-packages-from-orbit-source)
+    - [Troubleshooting](#troubleshooting)
+      - [Logs](#logs)
+      - [Debug](#debug)
+    - [Uninstall](#uninstall)
+      - [Windows](#windows-1)
+      - [Linux](#linux)
+      - [macOS](#macos)
+  - [Bugs](#bugs)
 
 
 ## Introduction
@@ -59,16 +62,16 @@ Now run that installer (double click, on a Mac) to enroll your own computer as a
 
 | Capability                           | Status |
 | ------------------------------------ | ------ |
-| Secure autoupdate for osquery        | ✅     |
-| Secure autoupdate for Orbit          | ✅     |
-| Configurable update channels         | ✅     |
-| Full osquery flag customization      | ✅     |
-| Package tooling for macOS `.pkg`     | ✅     |
-| Package tooling for Linux `.deb`     | ✅     |
-| Package tooling for Linux `.rpm`     | ✅     |
-| Package tooling for Windows `.msi`   | ✅     |
-| Manage/update osquery extensions     | ✅     |
-| Manage cgroups for Linux performance | 🔜     |
+| Secure autoupdate for osquery        | ✅      |
+| Secure autoupdate for Orbit          | ✅      |
+| Configurable update channels         | ✅      |
+| Full osquery flag customization      | ✅      |
+| Package tooling for macOS `.pkg`     | ✅      |
+| Package tooling for Linux `.deb`     | ✅      |
+| Package tooling for Linux `.rpm`     | ✅      |
+| Package tooling for Windows `.msi`   | ✅      |
+| Manage/update osquery extensions     | ✅      |
+| Manage cgroups for Linux performance | 🔜      |
 
 ## Usage
 
@@ -171,28 +174,28 @@ When the Fleet server uses a self-signed (or otherwise invalid) TLS certificate,
 
 The following command-line flags allow you to configure an osquery installer further to communicate with a specific Fleet instance.
 
-|Flag | Options|
-|------|--------|
-|  --type |  **Required** - Type of package to build.<br> Options: `pkg`(macOS),`msi`(Windows), `deb`(Debian based Linux), `rpm`(RHEL, CentOS, etc.)|
-|--fleet-desktop |      Include Fleet Desktop. |
-|--enroll-secret |      Enroll secret for authenticating to Fleet server |
-|--fleet-url |          URL (`host:port`) of Fleet server |
-|--fleet-certificate |  Path to server certificate bundle |
-|--identifier |         Identifier for package product (default: `com.fleetdm.orbit`) |
-|--version |            Version for package product (default: `0.0.3`) |
-| --insecure  |             Disable TLS certificate verification (default: `false`) |
-| --service   |             Install osquery with a persistence service (launchd, systemd, etc.) (default: `true`) |
-|--sign-identity |      Identity to use for macOS codesigning |
-| --notarize |             Whether to notarize macOS packages (default: `false`) |
-| --disable-updates |   Disable auto updates on the generated package (default: false) |
-|--osqueryd-channel |   Update channel of osqueryd to use (default: `stable`) |
-|--orbit-channel |      Update channel of Orbit to use (default: `stable`) |
-|--desktop-channel |    Update channel of desktop to use (default: `stable`) |
-|--update-url |         URL for update server (default: `https://tuf.fleetctl.com`) |
-|--update-roots |       Root key JSON metadata for update server (from fleetctl updates roots) |
-| --debug     |             Enable debug logging (default: `false`) |
-| --verbose   |             Log detailed information when building the package (default: false) |
-| --help, -h    |             show help (default: `false`) |
+| Flag                | Options                                                                                                                                 |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| --type              | **Required** - Type of package to build.<br> Options: `pkg`(macOS),`msi`(Windows), `deb`(Debian based Linux), `rpm`(RHEL, CentOS, etc.) |
+| --fleet-desktop     | Include Fleet Desktop.                                                                                                                  |
+| --enroll-secret     | Enroll secret for authenticating to Fleet server                                                                                        |
+| --fleet-url         | URL (`host:port`) of Fleet server                                                                                                       |
+| --fleet-certificate | Path to server certificate bundle                                                                                                       |
+| --identifier        | Identifier for package product (default: `com.fleetdm.orbit`)                                                                           |
+| --version           | Version for package product (default: `0.0.3`)                                                                                          |
+| --insecure          | Disable TLS certificate verification (default: `false`)                                                                                 |
+| --service           | Install osquery with a persistence service (launchd, systemd, etc.) (default: `true`)                                                   |
+| --sign-identity     | Identity to use for macOS codesigning                                                                                                   |
+| --notarize          | Whether to notarize macOS packages (default: `false`)                                                                                   |
+| --disable-updates   | Disable auto updates on the generated package (default: false)                                                                          |
+| --osqueryd-channel  | Update channel of osqueryd to use (default: `stable`)                                                                                   |
+| --orbit-channel     | Update channel of Orbit to use (default: `stable`)                                                                                      |
+| --desktop-channel   | Update channel of desktop to use (default: `stable`)                                                                                    |
+| --update-url        | URL for update server (default: `https://tuf.fleetctl.com`)                                                                             |
+| --update-roots      | Root key JSON metadata for update server (from fleetctl updates roots)                                                                  |
+| --debug             | Enable debug logging (default: `false`)                                                                                                 |
+| --verbose           | Log detailed information when building the package (default: false)                                                                     |
+| --help, -h          | show help (default: `false`)                                                                                                            |
 
 #### Fleet Desktop
 
@@ -270,7 +273,7 @@ go run github.com/fleetdm/fleet/v4/orbit/cmd/orbit \
 
 The `fleetctl package` command generates installers by fetching the targets/executables from a [TUF](https://theupdateframework.io/) repository.
 To generate an installer that contains an Orbit built from source, you need to setup a local TUF repository.
-The following document explains how you can generate a TUF repository and installers that use it: [tools/tuf/test](../tools/tuf/test/README.md).
+The following document explains how you can generate a TUF repository and installers that use it: [tools/tuf/test](../../tools/tuf/test/README.md).
 
 ### Troubleshooting
 
@@ -306,7 +309,7 @@ sudo rpm -e fleet-osquery-X.Y.Z.x86_64
 
 #### macOS
 
-Run the [cleanup script](./tools/cleanup/cleanup_macos.sh).
+Run the [cleanup script](../../orbit/tools/cleanup/cleanup_macos.sh).
 
 ## Bugs
 


### PR DESCRIPTION
Hi folks!

I wanted to share some docs to a user and I got a 404:
The "cleanup script" link on https://fleetdm.com/docs/using-fleet/orbit#mac-os click returns a 404.

- I used the "Markdown All in One" VS code extension to re-generate (and fix) the indexes in those files.
- I used https://github.com/tcort/markdown-link-check to check for broken links:
```
markdown-link-check Orbit.md
markdown-link-check Adding-hosts.md
```