### PR TITLE
"Why open source?"

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -269,7 +269,7 @@ Fleet Managed Cloud. <a href="https://kqphpqst851.typeform.com/to/yoo5smT9">Join
                 <a href="/try-fleet/register?tryitnow" class="d-block pr-md-5 pr-sm-3 pb-2">Try it out</a>
                 <a href="/docs" class="d-block pr-md-5 pr-sm-3 pb-2">Docs</a>
                 <a href="/queries" class="d-block pr-md-5 pr-sm-3 pb-2">Query library</a>
-                <a href="/transparency" class="d-block pr-md-5 pr-sm-3 pb-2 pb-xl-0">Transparency</a>
+                <a href="/handbook/company/why-this-way#why-open-source" class="d-block pr-md-5 pr-sm-3 pb-2 pb-xl-0">Why open source?</a>
               </div>
               <div class="flex-column">
                 <a href="/pricing" class="d-block px-md-5 px-sm-3 pb-2">Pricing</a>


### PR DESCRIPTION
In the footer, instead of https://fleetdm.com/transparency, include a link to ["Why open source?"](https://fleetdm.com/handbook/company/why-this-way#why-open-source) (in "Why this way?", in the handbook)

Why?  "Transparency" is a page designed especially for end users, and linked to already from within Fleet Desktop.  Let's use this footer link to help communicate some of the same ideas, but with additional context for IT and security folks within customer and contributor organizations.