### PR TITLE
Sandcastle UI: Update software inventory messages

### DIFF
--- a/frontend/pages/DashboardPage/cards/Software/Software.tsx
+++ b/frontend/pages/DashboardPage/cards/Software/Software.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import { Row } from "react-table";
 import { InjectedRouter } from "react-router";
 import PATHS from "router/paths";
 
+import { AppContext } from "context/app";
 import { buildQueryStringFromParams } from "utilities/url";
 
 import TabsWrapper from "components/TabsWrapper";
@@ -50,6 +51,8 @@ const Software = ({
   software,
   router,
 }: ISoftwareCardProps): JSX.Element => {
+  const { noSandboxHosts } = useContext(AppContext);
+
   const tableHeaders = generateTableHeaders();
 
   const handleRowSelect = (row: IRowProps) => {
@@ -92,11 +95,13 @@ const Software = ({
                   hideActionButton
                   resultsTitle={"software"}
                   emptyComponent={() =>
-                    EmptySoftware(
-                      (!isSoftwareEnabled && "disabled") ||
+                    EmptySoftware({
+                      message:
+                        (!isSoftwareEnabled && "disabled") ||
                         (isCollectingInventory && "collecting") ||
-                        "default"
-                    )
+                        "default",
+                      noSandboxHosts,
+                    })
                   }
                   showMarkAllPages={false}
                   isAllPagesSelected={false}
@@ -122,11 +127,13 @@ const Software = ({
                   hideActionButton
                   resultsTitle={"software"}
                   emptyComponent={() =>
-                    EmptySoftware(
-                      (!isSoftwareEnabled && "disabled") ||
+                    EmptySoftware({
+                      message:
+                        (!isSoftwareEnabled && "disabled") ||
                         (isCollectingInventory && "collecting") ||
-                        "default"
-                    )
+                        "default",
+                      noSandboxHosts,
+                    })
                   }
                   showMarkAllPages={false}
                   isAllPagesSelected={false}

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -111,6 +111,7 @@ const ManageSoftwarePage = ({
     currentTeam,
     isOnGlobalTeam,
     isPremiumTier,
+    noSandboxHosts,
   } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 
@@ -549,11 +550,13 @@ const ManageSoftwarePage = ({
               isLoading={isFetchingSoftware || isFetchingCount}
               resultsTitle={"software items"}
               emptyComponent={() =>
-                EmptySoftware(
-                  (!isSoftwareEnabled && "disabled") ||
+                EmptySoftware({
+                  message:
+                    (!isSoftwareEnabled && "disabled") ||
                     (isCollectingInventory && "collecting") ||
-                    "default"
-                )
+                    "default",
+                  noSandboxHosts,
+                })
               }
               defaultSortHeader={DEFAULT_SORT_HEADER}
               defaultSortDirection={DEFAULT_SORT_DIRECTION}

--- a/frontend/pages/software/components/EmptySoftware.tsx
+++ b/frontend/pages/software/components/EmptySoftware.tsx
@@ -6,9 +6,15 @@ import CustomLink from "components/CustomLink";
 
 const baseClass = "manage-software-page";
 
-type IEmptySoftware = "disabled" | "collecting" | "default" | "";
+type IEmptySoftwareProps = {
+  message: "disabled" | "collecting" | "default" | "";
+  noSandboxHosts?: boolean;
+};
 
-const EmptySoftware = (message: IEmptySoftware): JSX.Element => {
+const EmptySoftware = ({
+  message,
+  noSandboxHosts,
+}: IEmptySoftwareProps): JSX.Element => {
   switch (message) {
     case "disabled": {
       return (
@@ -31,8 +37,17 @@ const EmptySoftware = (message: IEmptySoftware): JSX.Element => {
       return (
         <div className={`${baseClass}__empty-software`}>
           <div className="empty-software__inner">
-            <h1>Fleet is collecting software inventory.</h1>
-            <p>Try again in about 1 hour as the system catches up.</p>
+            <h1>
+              {noSandboxHosts
+                ? "Fleet begins collecting software inventory after a host is enrolled"
+                : "Fleet is collecting software inventory"}
+            </h1>
+            <p>
+              Try again in about{" "}
+              {noSandboxHosts
+                ? "5 minutes after host enrollment."
+                : "1 hour as the system catches up."}
+            </p>
           </div>
         </div>
       );


### PR DESCRIPTION
### Issue
#9271 

### Fix
- Updates the empty software section messaging for Sandbox
- "Fleet is collecting software inventory" -> "Fleet begins collecting software inventory after a host is enrolled"
"Try again in about 1 hour as the system catches up" -> "Try again about 5 minutes after host enrollment" 

### Screenshots
Screen recording:
https://user-images.githubusercontent.com/71795832/211828244-ea7b893f-b29b-4bd3-a010-63947d1b42e5.mov
Screenshot (note this sandbox view is from hardcoding sandbox mode in dev production):
<img width="1302" alt="Screenshot 2023-01-11 at 9 16 05 AM" src="https://user-images.githubusercontent.com/71795832/211828807-fb65199b-99a1-4c23-b64d-970bb28776a4.png">


### Steps to QA
Start new instance of sandbox > Go to software details section

### Related
#6799 I'm finishing a big refactor of software messages throughout the app on the `main` branch, I'll be sure to include these copy changes. <3

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality