### PR TITLE
UI: Edit team modal

### DIFF
--- a/changes/8872-add-MDM-settings-modals
+++ b/changes/8872-add-MDM-settings-modals
@@ -1,0 +1,1 @@
+* Added Request CSR and Change default MDM BM team modals to Integrations > MDM

--- a/frontend/pages/admin/IntegrationsPage/cards/Mdm/Mdm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Mdm/Mdm.tsx
@@ -285,7 +285,7 @@ const Mdm = (): JSX.Element => {
       {showEditTeamModal && (
         <EditTeamModal
           onCancel={toggleEditTeamModal}
-          onEdit={toggleEditTeamModal}
+          currentDefaultTeamName={mdmAppleBm?.default_team ?? "No default team"}
         />
       )}
     </div>

--- a/frontend/pages/admin/IntegrationsPage/cards/Mdm/Mdm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Mdm/Mdm.tsx
@@ -285,7 +285,7 @@ const Mdm = (): JSX.Element => {
       {showEditTeamModal && (
         <EditTeamModal
           onCancel={toggleEditTeamModal}
-          currentDefaultTeamName={mdmAppleBm?.default_team ?? "No default team"}
+          currentDefaultTeamName={mdmAppleBm?.default_team}
         />
       )}
     </div>

--- a/frontend/pages/admin/IntegrationsPage/cards/Mdm/components/EditTeamModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Mdm/components/EditTeamModal.tsx
@@ -20,31 +20,27 @@ const EditTeamModal = ({
   onCancel,
   currentDefaultTeamName,
 }: IEditTeamModal): JSX.Element => {
-  // availableTeams: Array<ITeamSummary>
   const { availableTeams } = useContext(AppContext);
 
   const teamNameOptions = availableTeams?.map((teamSummary) => {
     return { value: teamSummary.name, label: teamSummary.name };
   });
 
-  const [defaultTeamName, setDefaultTeamName] = useState<string | undefined>(
+  const [defaultTeamName, setDefaultTeamName] = useState(
     currentDefaultTeamName
   );
 
-  const [requestState, setRequestState] = useState<"loading" | undefined>(
-    undefined
-  );
+  const [isLoading, setIsLoading] = useState(false);
 
-  const onFormSubmit = async (event: FormEvent): Promise<void> => {
+  const onFormSubmit = async (event: FormEvent) => {
     event.preventDefault();
     try {
-      setRequestState("loading");
-      const response = await configAPI.update({
+      setIsLoading(true);
+      await configAPI.update({
         mdm: { apple_bm_default_team: defaultTeamName },
       });
-      setRequestState(undefined);
-      onCancel();
-    } catch {
+      setIsLoading(false);
+    } finally {
       onCancel();
     }
   };
@@ -66,11 +62,7 @@ const EditTeamModal = ({
           </p>
         </div>
         <div className="modal-cta-wrap">
-          <Button
-            type="submit"
-            variant="brand"
-            isLoading={requestState === "loading"}
-          >
+          <Button type="submit" variant="brand" isLoading={isLoading}>
             Save
           </Button>
           <Button onClick={onCancel} variant="inverse">

--- a/frontend/pages/admin/IntegrationsPage/cards/Mdm/components/EditTeamModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Mdm/components/EditTeamModal.tsx
@@ -1,29 +1,83 @@
-import React from "react";
+import React, { useState, useContext, FormEvent } from "react";
+
+import { AppContext } from "context/app";
+import configAPI from "services/entities/config";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 
+// @ts-ignore
+import Dropdown from "components/forms/fields/Dropdown";
+
 interface IEditTeamModal {
   onCancel: () => void;
-  onEdit: () => void;
+  currentDefaultTeamName: string | undefined;
 }
 
 const baseClass = "edit-team-modal";
 
-const EditTeamModal = ({ onCancel, onEdit }: IEditTeamModal): JSX.Element => {
+const EditTeamModal = ({
+  onCancel,
+  currentDefaultTeamName,
+}: IEditTeamModal): JSX.Element => {
+  // availableTeams: Array<ITeamSummary>
+  const { availableTeams } = useContext(AppContext);
+
+  const teamNameOptions = availableTeams?.map((teamSummary) => {
+    return { value: teamSummary.name, label: teamSummary.name };
+  });
+
+  const [defaultTeamName, setDefaultTeamName] = useState<string | undefined>(
+    currentDefaultTeamName
+  );
+
+  const [requestState, setRequestState] = useState<"loading" | undefined>(
+    undefined
+  );
+
+  const onFormSubmit = async (event: FormEvent): Promise<void> => {
+    event.preventDefault();
+    try {
+      setRequestState("loading");
+      const response = await configAPI.update({
+        mdm: { apple_bm_default_team: defaultTeamName },
+      });
+      setRequestState(undefined);
+      onCancel();
+    } catch {
+      onCancel();
+    }
+  };
+
   return (
     <Modal title="Edit team" onExit={onCancel} className={baseClass}>
-      <>
-        Cool beans
+      <form className={`${baseClass}__form`} onSubmit={onFormSubmit}>
+        <div className="bottom-label">
+          <Dropdown
+            placeholder={defaultTeamName ?? "No team"}
+            options={teamNameOptions}
+            onChange={setDefaultTeamName}
+            value={defaultTeamName ?? ""}
+            label="Team"
+          />
+          <p>
+            macOS hosts will be added to this team when they&apos;re first
+            unboxed.
+          </p>
+        </div>
         <div className="modal-cta-wrap">
-          <Button onClick={onEdit} variant="brand">
+          <Button
+            type="submit"
+            variant="brand"
+            isLoading={requestState === "loading"}
+          >
             Save
           </Button>
           <Button onClick={onCancel} variant="inverse">
             Cancel
           </Button>
         </div>
-      </>
+      </form>
     </Modal>
   );
 };

--- a/frontend/services/entities/mdm_apple_bm.ts
+++ b/frontend/services/entities/mdm_apple_bm.ts
@@ -4,6 +4,8 @@ import { sendRequest } from "services/mock_service/service/service"; // MDM TODO
 import endpoints from "utilities/endpoints";
 
 export default {
+  // TODO: set up full MDM testing environment, including all keys/credentials/tokens, to be able to
+  // get proper data from this API as opposed to the mock backend above
   getAppleBMInfo: () => {
     const { MDM_APPLE_BM } = endpoints;
     const path = MDM_APPLE_BM;


### PR DESCRIPTION
# Addresses #8872

# Implements

- A modal on the MDM settings tab to change the default Apple Business Manager team
https://www.loom.com/share/0eb45931d9db4a60843b5d427bdc9e61

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality