### PR TITLE
Frontend: Add hostdetails BackLink fallback path

### DIFF
--- a/changes/9141-host-details-backlink-bug
+++ b/changes/9141-host-details-backlink-bug
@@ -1,0 +1,3 @@
+- Made the 'Back to all hosts' link on the host details page fall back to the default path to the
+  manage hosts page. This addresses a bug in this functionality when the user navigates directly
+  with the URL

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -627,7 +627,10 @@ const HostDetailsPage = ({
     <MainContent className={baseClass}>
       <div className={`${baseClass}__wrapper`}>
         <div className={`${baseClass}__header-links`}>
-          <BackLink text="Back to all hosts" path={filteredHostsPath} />
+          <BackLink
+            text="Back to all hosts"
+            path={filteredHostsPath || PATHS.MANAGE_HOSTS}
+          />
         </div>
         <HostSummaryCard
           statusClassName={statusClassName}


### PR DESCRIPTION
# Addresses #9141 

# Fixes
- 'Back to all hosts' link on Host Details page was navigating incorrectly when the user had previously navigated directly with the browser URL. This prevents this bug by adding a fallback path for that BackLink to the default Manage Hosts path.

https://www.loom.com/share/579501365f514ac488f86eacadb2fd07

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality