### PR TITLE
Run authorization check before processing policy spec

### DIFF
--- a/changes/fix-useless-error-on-policy-spec
+++ b/changes/fix-useless-error-on-policy-spec
@@ -1,0 +1,1 @@
+* Run authorization checks before processing policy specs.

--- a/server/service/global_policies.go
+++ b/server/service/global_policies.go
@@ -451,7 +451,7 @@ func (svc *Service) checkPolicySpecAuthorization(ctx context.Context, policies [
 					TeamID: &team.ID,
 				},
 			}, fleet.ActionWrite); err != nil {
-				return ctxerr.Wrap(ctx, err)
+				return err
 			}
 		} else {
 			checkGlobalPolicyAuth = true
@@ -459,7 +459,7 @@ func (svc *Service) checkPolicySpecAuthorization(ctx context.Context, policies [
 	}
 	if checkGlobalPolicyAuth {
 		if err := svc.authz.Authorize(ctx, &fleet.Policy{}, fleet.ActionWrite); err != nil {
-			return ctxerr.Wrap(ctx, err)
+			return err
 		}
 	}
 	return nil
@@ -468,7 +468,7 @@ func (svc *Service) checkPolicySpecAuthorization(ctx context.Context, policies [
 func (svc *Service) ApplyPolicySpecs(ctx context.Context, policies []*fleet.PolicySpec) error {
 	// Check authorization first.
 	if err := svc.checkPolicySpecAuthorization(ctx, policies); err != nil {
-		return ctxerr.Wrap(ctx, err)
+		return err
 	}
 
 	// After the authorization check, check the policy fields.


### PR DESCRIPTION
I was getting a cryptic error and no logs in fleet when trying to apply an invalid spec file:
```sh
fleetctl apply -f ./some-queries.yml
Error: applying policies: POST /api/latest/fleet/spec/policies received status 500 forbidden: forbidden
```

With the changes in this PR now I get a more descriptive error (bad request):

```sh
fleetctl apply -f ./some-queries.yml
Error: applying policies: POST /api/latest/fleet/spec/policies received status 400 Bad request: policy spec payload verification: policy query cannot be empty
```

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- ~[ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
~- [ ] Documented any permissions changes~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [x] Added/updated tests
- [X] Manual QA for all new/changed functionality
  - ~For Orbit and Fleet Desktop changes:~
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
