### PR TITLE
add attribute to GET /activities endpoint with pagination metadata

### DIFF
--- a/changes/issue-8928-add-meta-attribute-to-get-activities
+++ b/changes/issue-8928-add-meta-attribute-to-get-activities
@@ -1,0 +1,2 @@
+- add `meta` attribute to `GET /activities` endpointthat includes pagination metadata. fix edge case
+  on UI for pagination buttons on activities card.

--- a/changes/issue-8928-add-meta-attribute-to-get-activities
+++ b/changes/issue-8928-add-meta-attribute-to-get-activities
@@ -1,2 +1,2 @@
-- add `meta` attribute to `GET /activities` endpointthat includes pagination metadata. fix edge case
+- add `meta` attribute to `GET /activities` endpoint that includes pagination metadata. fix edge case
   on UI for pagination buttons on activities card.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -947,7 +947,7 @@ func cronActivitiesStreaming(
 	page := uint(0)
 	for {
 		// (1) Get batch of activities that haven't been streamed.
-		activitiesToStream, err := ds.ListActivities(ctx, fleet.ListActivitiesOptions{
+		activitiesToStream, _, err := ds.ListActivities(ctx, fleet.ListActivitiesOptions{
 			ListOptions: fleet.ListOptions{
 				OrderKey:       "id",
 				OrderDirection: fleet.OrderAscending,

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -856,8 +856,8 @@ func TestCronActivitiesStreaming(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
 		as := []*fleet.Activity{a1, a2, a3}
 
-		ds.ListActivitiesFunc = func(ctx context.Context, opt fleet.ListActivitiesOptions) ([]*fleet.Activity, error) {
-			return as, nil
+		ds.ListActivitiesFunc = func(ctx context.Context, opt fleet.ListActivitiesOptions) ([]*fleet.Activity, *fleet.PaginationMetadata, error) {
+			return as, nil, nil
 		}
 
 		ds.MarkActivitiesAsStreamedFunc = func(ctx context.Context, activityIDs []uint) error {
@@ -880,8 +880,8 @@ func TestCronActivitiesStreaming(t *testing.T) {
 	t.Run("fail_to_stream_an_activity", func(t *testing.T) {
 		as := []*fleet.Activity{a1, a2, a3}
 
-		ds.ListActivitiesFunc = func(ctx context.Context, opt fleet.ListActivitiesOptions) ([]*fleet.Activity, error) {
-			return as, nil
+		ds.ListActivitiesFunc = func(ctx context.Context, opt fleet.ListActivitiesOptions) ([]*fleet.Activity, *fleet.PaginationMetadata, error) {
+			return as, nil, nil
 		}
 
 		ds.MarkActivitiesAsStreamedFunc = func(ctx context.Context, activityIDs []uint) error {
@@ -908,18 +908,18 @@ func TestCronActivitiesStreaming(t *testing.T) {
 			as[i] = newActivity(uint(i), "foo", uint(i), "foog", "fooe", "bar", `{"bar": "foo"}`)
 		}
 
-		ds.ListActivitiesFunc = func(ctx context.Context, opt fleet.ListActivitiesOptions) ([]*fleet.Activity, error) {
+		ds.ListActivitiesFunc = func(ctx context.Context, opt fleet.ListActivitiesOptions) ([]*fleet.Activity, *fleet.PaginationMetadata, error) {
 			require.Equal(t, opt.PerPage, ActivitiesToStreamBatchCount)
 			switch opt.Page {
 			case 0:
-				return as[:ActivitiesToStreamBatchCount], nil
+				return as[:ActivitiesToStreamBatchCount], nil, nil
 			case 1:
-				return as[ActivitiesToStreamBatchCount : ActivitiesToStreamBatchCount*2], nil
+				return as[ActivitiesToStreamBatchCount : ActivitiesToStreamBatchCount*2], nil, nil
 			case 2:
-				return as[ActivitiesToStreamBatchCount*2:], nil
+				return as[ActivitiesToStreamBatchCount*2:], nil, nil
 			default:
 				t.Fatalf("invalid page requested: %d", opt.Page)
-				return nil, nil
+				return nil, nil, nil
 			}
 		}
 

--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -422,7 +422,8 @@ This is the callback endpoint that the identity provider will use to send securi
 
 ### List activities
 
-Returns a list of the activities that have been performed in Fleet. The following types of activity are included:
+Returns a list of the activities that have been performed in Fleet as well as additional meta data
+for pagination. The following types of activity are included:
 
 - Created pack
 - Edited pack
@@ -587,7 +588,11 @@ Returns a list of the activities that have been performed in Fleet. The followin
         "target_counts": 14
       }
     }
-  ]
+  ],
+  "meta": {
+    "has_next_results": true,
+    "has_previous_results": false
+  }
 }
 
 ```

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tests.tsx
@@ -4,7 +4,10 @@ import { noop } from "lodash";
 
 import { createCustomRenderer } from "test/test-utils";
 import mockServer from "test/mock-server";
-import { activityHandler9Activities } from "test/handlers/activity-handlers";
+import {
+  activityHandlerHasMoreActivities,
+  activityHandlerHasPreviousActivities,
+} from "test/handlers/activity-handlers";
 
 import ActivityFeed from "./ActivityFeed";
 
@@ -38,7 +41,7 @@ describe("Activity Feed", () => {
   });
 
   it("enables next pagination when there are more activities", async () => {
-    mockServer.use(activityHandler9Activities);
+    mockServer.use(activityHandlerHasMoreActivities);
 
     const render = createCustomRenderer({
       withBackendMock: true,
@@ -52,7 +55,7 @@ describe("Activity Feed", () => {
     expect(screen.getByRole("button", { name: "Next" })).toBeEnabled();
   });
 
-  it("disables previous pagination on initial page", async () => {
+  it("disables previous pagination when there are not previous activities", async () => {
     const render = createCustomRenderer({
       withBackendMock: true,
     });
@@ -65,8 +68,8 @@ describe("Activity Feed", () => {
     expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
   });
 
-  it("enables previous pagination when on subsequent pages", async () => {
-    mockServer.use(activityHandler9Activities);
+  it("enables previous pagination when there are more previous activities", async () => {
+    mockServer.use(activityHandlerHasPreviousActivities);
 
     const render = createCustomRenderer({
       withBackendMock: true,

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tsx
@@ -6,7 +6,7 @@ import activitiesAPI, {
   IActivitiesResponse,
 } from "services/entities/activities";
 
-import { IActivity, IActivityDetails } from "interfaces/activity";
+import { IActivityDetails } from "interfaces/activity";
 
 import ShowQueryModal from "components/modals/ShowQueryModal";
 import DataError from "components/DataError";
@@ -29,18 +29,17 @@ const ActivityFeed = ({
   isPremiumTier,
 }: IActvityCardProps): JSX.Element => {
   const [pageIndex, setPageIndex] = useState(0);
-  const [showMore, setShowMore] = useState(true);
   const [showShowQueryModal, setShowShowQueryModal] = useState(false);
   const queryShown = useRef("");
 
   const {
-    data: activities,
+    data: activitiesData,
     error: errorActivities,
     isFetching: isFetchingActivities,
   } = useQuery<
     IActivitiesResponse,
     Error,
-    IActivity[],
+    IActivitiesResponse,
     Array<{
       scope: string;
       pageIndex: number;
@@ -54,14 +53,8 @@ const ActivityFeed = ({
     {
       keepPreviousData: true,
       staleTime: 5000,
-      select: (data) => {
-        return data.activities;
-      },
-      onSuccess: (results) => {
+      onSuccess: (data) => {
         setShowActivityFeedTitle(true);
-        if (results.length < DEFAULT_PAGE_SIZE) {
-          setShowMore(false);
-        }
       },
       onError: () => {
         setShowActivityFeedTitle(true);
@@ -70,7 +63,6 @@ const ActivityFeed = ({
   );
 
   const onLoadPrevious = () => {
-    setShowMore(true);
     setPageIndex(pageIndex - 1);
   };
 
@@ -103,6 +95,9 @@ const ActivityFeed = ({
   // Renders opaque information as activity feed is loading
   const opacity = isFetchingActivities ? { opacity: 0.4 } : { opacity: 1 };
 
+  const activities = activitiesData?.activities;
+  const meta = activitiesData?.meta;
+
   return (
     <div className={baseClass}>
       {errorActivities && renderError()}
@@ -131,7 +126,7 @@ const ActivityFeed = ({
         (!isEmpty(activities) || (isEmpty(activities) && pageIndex > 0)) && (
           <div className={`${baseClass}__pagination`}>
             <Button
-              disabled={isFetchingActivities || pageIndex === 0}
+              disabled={isFetchingActivities || !meta?.has_previous_results}
               onClick={onLoadPrevious}
               variant="unstyled"
               className={`${baseClass}__load-activities-button`}
@@ -141,7 +136,7 @@ const ActivityFeed = ({
               </>
             </Button>
             <Button
-              disabled={isFetchingActivities || !showMore}
+              disabled={isFetchingActivities || !meta?.has_next_results}
               onClick={onLoadNext}
               variant="unstyled"
               className={`${baseClass}__load-activities-button`}

--- a/frontend/services/entities/activities.ts
+++ b/frontend/services/entities/activities.ts
@@ -10,6 +10,10 @@ const ORDER_DIRECTION = "desc";
 
 export interface IActivitiesResponse {
   activities: IActivity[];
+  meta: {
+    has_next_results: boolean;
+    has_previous_results: boolean;
+  };
 }
 
 export default {

--- a/frontend/test/handlers/activity-handlers.ts
+++ b/frontend/test/handlers/activity-handlers.ts
@@ -15,12 +15,16 @@ export const defaultActivityHandler = rest.get(
           createMockActivity({ id: 2, actor_full_name: "Test User 2" }),
           createMockActivity({ id: 3, actor_full_name: "Test User 3" }),
         ],
+        meta: {
+          has_next_results: false,
+          has_previous_results: false,
+        },
       })
     );
   }
 );
 
-export const activityHandler9Activities = rest.get(
+export const activityHandlerHasMoreActivities = rest.get(
   baseUrl("/activities"),
   (req, res, context) => {
     return res(
@@ -29,13 +33,30 @@ export const activityHandler9Activities = rest.get(
           createMockActivity(),
           createMockActivity({ id: 2 }),
           createMockActivity({ id: 3 }),
-          createMockActivity({ id: 4 }),
-          createMockActivity({ id: 5 }),
-          createMockActivity({ id: 6 }),
-          createMockActivity({ id: 7 }),
-          createMockActivity({ id: 8 }),
-          createMockActivity({ id: 9 }),
         ],
+        meta: {
+          has_next_results: true,
+          has_previous_results: false,
+        },
+      })
+    );
+  }
+);
+
+export const activityHandlerHasPreviousActivities = rest.get(
+  baseUrl("/activities"),
+  (req, res, context) => {
+    return res(
+      context.json({
+        activities: [
+          createMockActivity(),
+          createMockActivity({ id: 2 }),
+          createMockActivity({ id: 3 }),
+        ],
+        meta: {
+          has_next_results: false,
+          has_previous_results: true,
+        },
       })
     );
   }

--- a/server/datastore/mysql/carves.go
+++ b/server/datastore/mysql/carves.go
@@ -234,7 +234,7 @@ func (ds *Datastore) ListCarves(ctx context.Context, opt fleet.CarveListOptions)
 	if !opt.Expired {
 		stmt += ` WHERE NOT expired `
 	}
-	stmt = appendListOptionsToSQL(stmt, opt.ListOptions)
+	stmt = appendListOptionsToSQL(stmt, &opt.ListOptions)
 	carves := []*fleet.CarveMetadata{}
 	if err := sqlx.SelectContext(ctx, ds.reader, &carves, stmt); err != nil && err != sql.ErrNoRows {
 		return nil, ctxerr.Wrap(ctx, err, "list carves")

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -712,7 +712,7 @@ func (ds *Datastore) applyHostFilters(opt fleet.HostListOptions, sql string, fil
 	sql, params = filterHostsByMDM(sql, opt, params)
 	sql, params = filterHostsByOS(sql, opt, params)
 	sql, params = hostSearchLike(sql, params, opt.MatchQuery, hostSearchColumns...)
-	sql, params = appendListOptionsWithCursorToSQL(sql, params, opt.ListOptions)
+	sql, params = appendListOptionsWithCursorToSQL(sql, params, &opt.ListOptions)
 
 	return sql, params
 }
@@ -2306,7 +2306,7 @@ func (ds *Datastore) GetHostMDMCheckinInfo(ctx context.Context, hostUUID string)
 	var hmdm fleet.HostMDMCheckinInfo
 	err := sqlx.GetContext(ctx, ds.reader, &hmdm, `
 		SELECT
-			h.hardware_serial, hm.installed_from_dep 
+			h.hardware_serial, hm.installed_from_dep
 		FROM
 			hosts h
 		JOIN

--- a/server/datastore/mysql/invites.go
+++ b/server/datastore/mysql/invites.go
@@ -55,7 +55,6 @@ func (ds *Datastore) NewInvite(ctx context.Context, i *fleet.Invite) (*fleet.Inv
 		}
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +67,7 @@ func (ds *Datastore) ListInvites(ctx context.Context, opt fleet.ListOptions) ([]
 	invites := []*fleet.Invite{}
 	query := "SELECT * FROM invites WHERE true"
 	query, params := searchLike(query, nil, opt.MatchQuery, inviteSearchColumns...)
-	query = appendListOptionsToSQL(query, opt)
+	query = appendListOptionsToSQL(query, &opt)
 
 	err := sqlx.SelectContext(ctx, ds.reader, &invites, query, params...)
 	if err == sql.ErrNoRows {

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -289,7 +289,7 @@ func (ds *Datastore) ListLabels(ctx context.Context, filter fleet.TeamFilter, op
 		`, ds.whereFilterHostsByTeams(filter, "h"),
 	)
 
-	query = appendListOptionsToSQL(query, opt)
+	query = appendListOptionsToSQL(query, &opt)
 	labels := []*fleet.Label{}
 
 	if err := sqlx.SelectContext(ctx, ds.reader, &labels, query); err != nil {
@@ -562,7 +562,7 @@ func (ds *Datastore) applyHostLabelFilters(filter fleet.TeamFilter, lid uint, qu
 	query, params = filterHostsByMDM(query, opt, params)
 	query, params = searchLike(query, params, opt.MatchQuery, hostSearchColumns...)
 
-	query = appendListOptionsToSQL(query, opt.ListOptions)
+	query = appendListOptionsToSQL(query, &opt.ListOptions)
 	return query, params
 }
 

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -773,11 +773,21 @@ func appendLimitOffsetToSelect(ds *goqu.SelectDataset, opts fleet.ListOptions) *
 	return ds
 }
 
+// Appends the list options SQL to the passed in SQL string. This appended
+// SQL is determined by the passed in options.
+//
+// NOTE: this method will mutate the options argument if no explicit PerPage
+// option is set (a default value will be provided) or if the cursor approach is used.
 func appendListOptionsToSQL(sql string, opts *fleet.ListOptions) string {
 	sql, _ = appendListOptionsWithCursorToSQL(sql, nil, opts)
 	return sql
 }
 
+// Appends the list options SQL to the passed in SQL string. This appended
+// SQL is determined by the passed in options. This supports cursor options
+//
+// NOTE: this method will mutate the options argument if no explicit PerPage option
+// is set (a default value will be provided) or if the cursor approach is used.
 func appendListOptionsWithCursorToSQL(sql string, params []interface{}, opts *fleet.ListOptions) (string, []interface{}) {
 	orderKey := sanitizeColumn(opts.OrderKey)
 

--- a/server/datastore/mysql/mysql_test.go
+++ b/server/datastore/mysql/mysql_test.go
@@ -347,7 +347,7 @@ func TestAppendListOptionsToSQL(t *testing.T) {
 		OrderKey: "***name***",
 	}
 
-	actual := appendListOptionsToSQL(sql, opts)
+	actual := appendListOptionsToSQL(sql, &opts)
 	expected := "SELECT * FROM my_table ORDER BY `name` ASC LIMIT 1000000"
 	if actual != expected {
 		t.Error("Expected", expected, "Actual", actual)
@@ -355,7 +355,7 @@ func TestAppendListOptionsToSQL(t *testing.T) {
 
 	sql = "SELECT * FROM my_table"
 	opts.OrderDirection = fleet.OrderDescending
-	actual = appendListOptionsToSQL(sql, opts)
+	actual = appendListOptionsToSQL(sql, &opts)
 	expected = "SELECT * FROM my_table ORDER BY `name` DESC LIMIT 1000000"
 	if actual != expected {
 		t.Error("Expected", expected, "Actual", actual)
@@ -366,7 +366,7 @@ func TestAppendListOptionsToSQL(t *testing.T) {
 	}
 
 	sql = "SELECT * FROM my_table"
-	actual = appendListOptionsToSQL(sql, opts)
+	actual = appendListOptionsToSQL(sql, &opts)
 	expected = "SELECT * FROM my_table LIMIT 10"
 	if actual != expected {
 		t.Error("Expected", expected, "Actual", actual)
@@ -374,7 +374,7 @@ func TestAppendListOptionsToSQL(t *testing.T) {
 
 	sql = "SELECT * FROM my_table"
 	opts.Page = 2
-	actual = appendListOptionsToSQL(sql, opts)
+	actual = appendListOptionsToSQL(sql, &opts)
 	expected = "SELECT * FROM my_table LIMIT 10 OFFSET 20"
 	if actual != expected {
 		t.Error("Expected", expected, "Actual", actual)
@@ -382,7 +382,7 @@ func TestAppendListOptionsToSQL(t *testing.T) {
 
 	opts = fleet.ListOptions{}
 	sql = "SELECT * FROM my_table"
-	actual = appendListOptionsToSQL(sql, opts)
+	actual = appendListOptionsToSQL(sql, &opts)
 	expected = "SELECT * FROM my_table LIMIT 1000000"
 
 	if actual != expected {

--- a/server/datastore/mysql/packs.go
+++ b/server/datastore/mysql/packs.go
@@ -550,7 +550,7 @@ func (ds *Datastore) ListPacks(ctx context.Context, opt fleet.PackListOptions) (
 		query = `SELECT * FROM packs`
 	}
 	var packs []*fleet.Pack
-	err := sqlx.SelectContext(ctx, ds.reader, &packs, appendListOptionsToSQL(query, opt.ListOptions))
+	err := sqlx.SelectContext(ctx, ds.reader, &packs, appendListOptionsToSQL(query, &opt.ListOptions))
 	if err != nil && err != sql.ErrNoRows {
 		return nil, ctxerr.Wrap(ctx, err, "listing packs")
 	}

--- a/server/datastore/mysql/queries.go
+++ b/server/datastore/mysql/queries.go
@@ -192,7 +192,7 @@ func (ds *Datastore) ListQueries(ctx context.Context, opt fleet.ListQueryOptions
 	if opt.OnlyObserverCanRun {
 		sql += " AND q.observer_can_run=true"
 	}
-	sql = appendListOptionsToSQL(sql, opt.ListOptions)
+	sql = appendListOptionsToSQL(sql, &opt.ListOptions)
 
 	results := []*fleet.Query{}
 

--- a/server/datastore/mysql/scheduled_queries.go
+++ b/server/datastore/mysql/scheduled_queries.go
@@ -41,7 +41,7 @@ func (ds *Datastore) ListScheduledQueriesInPackWithStats(ctx context.Context, id
 		LEFT JOIN aggregated_stats ag ON (ag.id=sq.id AND ag.type='scheduled_query')
 		WHERE sq.pack_id = ?
 	`
-	query = appendListOptionsToSQL(query, opts)
+	query = appendListOptionsToSQL(query, &opts)
 	results := []*fleet.ScheduledQuery{}
 
 	if err := sqlx.SelectContext(ctx, ds.reader, &results, query, id); err != nil {

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -253,7 +253,7 @@ func (ds *Datastore) ListTeams(ctx context.Context, filter fleet.TeamFilter, opt
 		ds.whereFilterTeams(filter, "t"),
 	)
 	query, params := searchLike(query, nil, opt.MatchQuery, teamSearchColumns...)
-	query = appendListOptionsToSQL(query, opt)
+	query = appendListOptionsToSQL(query, &opt)
 	teams := []*fleet.Team{}
 	if err := sqlx.SelectContext(ctx, ds.reader, &teams, query, params...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list teams")

--- a/server/datastore/mysql/users.go
+++ b/server/datastore/mysql/users.go
@@ -109,7 +109,7 @@ func (ds *Datastore) ListUsers(ctx context.Context, opt fleet.UserListOptions) (
 	}
 
 	sqlStatement, params = searchLike(sqlStatement, params, opt.MatchQuery, userSearchColumns...)
-	sqlStatement = appendListOptionsToSQL(sqlStatement, opt.ListOptions)
+	sqlStatement = appendListOptionsToSQL(sqlStatement, &opt.ListOptions)
 	users := []*fleet.User{}
 
 	if err := sqlx.SelectContext(ctx, ds.reader, &users, sqlStatement, params...); err != nil {

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -480,14 +480,19 @@ type ListOptions struct {
 	// (varies depending on entity, eg. hostname, IP address for hosts).
 	// Handling for this parameter must be implemented separately for each type.
 	MatchQuery string `query:"query,optional"`
-
 	// After denotes the row to start from. This is meant to be used in conjunction with OrderKey
 	// If OrderKey is "id", it'll assume After is a number and will try to convert it.
 	After string `query:"after,optional"`
+	// Used to request the metadata of a query
+	IncludeMetadata bool
 }
 
 func (l ListOptions) Empty() bool {
 	return l == ListOptions{}
+}
+
+func (l ListOptions) UsesCursorPagination() bool {
+	return l.After != "" && l.OrderKey != ""
 }
 
 type ListQueryOptions struct {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -444,7 +444,7 @@ type Datastore interface {
 	// ActivitiesStore
 
 	NewActivity(ctx context.Context, user *User, activity ActivityDetails) error
-	ListActivities(ctx context.Context, opt ListActivitiesOptions) ([]*Activity, error)
+	ListActivities(ctx context.Context, opt ListActivitiesOptions) ([]*Activity, *PaginationMetadata, error)
 	MarkActivitiesAsStreamed(ctx context.Context, activityIDs []uint) error
 
 	///////////////////////////////////////////////////////////////////////////////

--- a/server/fleet/meta.go
+++ b/server/fleet/meta.go
@@ -4,3 +4,8 @@ type ObjectMetadata struct {
 	ApiVersion string `json:"apiVersion"`
 	Kind       string `json:"kind"`
 }
+
+type PaginationMetadata struct {
+	HasNextResults     bool `json:"has_next_results"`
+	HasPreviousResults bool `json:"has_previous_results"`
+}

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -457,7 +457,7 @@ type Service interface {
 	///////////////////////////////////////////////////////////////////////////////
 	// ActivitiesService
 
-	ListActivities(ctx context.Context, opt ListActivitiesOptions) ([]*Activity, error)
+	ListActivities(ctx context.Context, opt ListActivitiesOptions) ([]*Activity, *PaginationMetadata, error)
 
 	///////////////////////////////////////////////////////////////////////////////
 	// UserRolesService

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -342,7 +342,7 @@ type UpdateHostTablesOnMDMUnenrollFunc func(ctx context.Context, uuid string) er
 
 type NewActivityFunc func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error
 
-type ListActivitiesFunc func(ctx context.Context, opt fleet.ListActivitiesOptions) ([]*fleet.Activity, error)
+type ListActivitiesFunc func(ctx context.Context, opt fleet.ListActivitiesOptions) ([]*fleet.Activity, *fleet.PaginationMetadata, error)
 
 type MarkActivitiesAsStreamedFunc func(ctx context.Context, activityIDs []uint) error
 
@@ -2111,7 +2111,7 @@ func (s *DataStore) NewActivity(ctx context.Context, user *fleet.User, activity 
 	return s.NewActivityFunc(ctx, user, activity)
 }
 
-func (s *DataStore) ListActivities(ctx context.Context, opt fleet.ListActivitiesOptions) ([]*fleet.Activity, error) {
+func (s *DataStore) ListActivities(ctx context.Context, opt fleet.ListActivitiesOptions) ([]*fleet.Activity, *fleet.PaginationMetadata, error) {
 	s.ListActivitiesFuncInvoked = true
 	return s.ListActivitiesFunc(ctx, opt)
 }

--- a/server/service/activities.go
+++ b/server/service/activities.go
@@ -15,28 +15,29 @@ type listActivitiesRequest struct {
 }
 
 type listActivitiesResponse struct {
-	Activities []*fleet.Activity `json:"activities"`
-	Err        error             `json:"error,omitempty"`
+	Meta       *fleet.PaginationMetadata `json:"meta"`
+	Activities []*fleet.Activity         `json:"activities"`
+	Err        error                     `json:"error,omitempty"`
 }
 
 func (r listActivitiesResponse) error() error { return r.Err }
 
 func listActivitiesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*listActivitiesRequest)
-	activities, err := svc.ListActivities(ctx, fleet.ListActivitiesOptions{
+	activities, metadata, err := svc.ListActivities(ctx, fleet.ListActivitiesOptions{
 		ListOptions: req.ListOptions,
 	})
 	if err != nil {
 		return listActivitiesResponse{Err: err}, nil
 	}
 
-	return listActivitiesResponse{Activities: activities}, nil
+	return listActivitiesResponse{Meta: metadata, Activities: activities}, nil
 }
 
 // ListActivities returns a slice of activities for the whole organization
-func (svc *Service) ListActivities(ctx context.Context, opt fleet.ListActivitiesOptions) ([]*fleet.Activity, error) {
+func (svc *Service) ListActivities(ctx context.Context, opt fleet.ListActivitiesOptions) ([]*fleet.Activity, *fleet.PaginationMetadata, error) {
 	if err := svc.authz.Authorize(ctx, &fleet.Activity{}, fleet.ActionRead); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	return svc.ds.ListActivities(ctx, opt)
 }

--- a/server/service/activities_test.go
+++ b/server/service/activities_test.go
@@ -19,34 +19,34 @@ func TestListActivities(t *testing.T) {
 	globalUsers := []*fleet.User{test.UserAdmin, test.UserMaintainer, test.UserObserver}
 	teamUsers := []*fleet.User{test.UserTeamAdminTeam1, test.UserTeamMaintainerTeam1, test.UserTeamObserverTeam1}
 
-	ds.ListActivitiesFunc = func(ctx context.Context, opts fleet.ListActivitiesOptions) ([]*fleet.Activity, error) {
+	ds.ListActivitiesFunc = func(ctx context.Context, opts fleet.ListActivitiesOptions) ([]*fleet.Activity, *fleet.PaginationMetadata, error) {
 		return []*fleet.Activity{
 			{ID: 1},
 			{ID: 2},
-		}, nil
+		}, nil, nil
 	}
 
 	// any global user can read activities
 	for _, u := range globalUsers {
-		activities, err := svc.ListActivities(test.UserContext(ctx, u), fleet.ListActivitiesOptions{})
+		activities, _, err := svc.ListActivities(test.UserContext(ctx, u), fleet.ListActivitiesOptions{})
 		require.NoError(t, err)
 		require.Len(t, activities, 2)
 	}
 
 	// team users cannot read activities
 	for _, u := range teamUsers {
-		_, err := svc.ListActivities(test.UserContext(ctx, u), fleet.ListActivitiesOptions{})
+		_, _, err := svc.ListActivities(test.UserContext(ctx, u), fleet.ListActivitiesOptions{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), authz.ForbiddenErrorMessage)
 	}
 
 	// user with no roles cannot read activities
-	_, err := svc.ListActivities(test.UserContext(ctx, test.UserNoRoles), fleet.ListActivitiesOptions{})
+	_, _, err := svc.ListActivities(test.UserContext(ctx, test.UserNoRoles), fleet.ListActivitiesOptions{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), authz.ForbiddenErrorMessage)
 
 	// no user in context
-	_, err = svc.ListActivities(ctx, fleet.ListActivitiesOptions{})
+	_, _, err = svc.ListActivities(ctx, fleet.ListActivitiesOptions{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), authz.ForbiddenErrorMessage)
 }

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -2173,7 +2173,7 @@ func (s *integrationTestSuite) TestListActivities() {
 	ctx := context.Background()
 	u := s.users["admin1@example.com"]
 
-	prevActivities, err := s.ds.ListActivities(ctx, fleet.ListActivitiesOptions{})
+	prevActivities, _, err := s.ds.ListActivities(ctx, fleet.ListActivitiesOptions{})
 	require.NoError(t, err)
 
 	err = s.ds.NewActivity(ctx, &u, fleet.ActivityTypeAppliedSpecPack{})
@@ -2190,6 +2190,7 @@ func (s *integrationTestSuite) TestListActivities() {
 	var listResp listActivitiesResponse
 	s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &listResp, "per_page", strconv.Itoa(lenPage), "order_key", "id")
 	require.Len(t, listResp.Activities, lenPage)
+	require.NotNil(t, listResp.Meta)
 	assert.Equal(t, fleet.ActivityTypeAppliedSpecPack{}.ActivityName(), listResp.Activities[lenPage-2].Type)
 	assert.Equal(t, fleet.ActivityTypeDeletedPack{}.ActivityName(), listResp.Activities[lenPage-1].Type)
 
@@ -2200,6 +2201,11 @@ func (s *integrationTestSuite) TestListActivities() {
 	s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &listResp, "per_page", "1", "order_key", "id", "order_direction", "desc")
 	require.Len(t, listResp.Activities, 1)
 	assert.Equal(t, fleet.ActivityTypeEditedPack{}.ActivityName(), listResp.Activities[0].Type)
+
+	listResp = listActivitiesResponse{}
+	s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &listResp, "per_page", "1", "order_key", "a.id", "after", "0")
+	require.Len(t, listResp.Activities, 1)
+	require.Nil(t, listResp.Meta)
 }
 
 func (s *integrationTestSuite) TestListGetCarves() {


### PR DESCRIPTION
relates to https://github.com/fleetdm/fleet/issues/8928

This adds a new `meta` attribute to the "GET /activities" endpoint that includes pagination metadata. This can allow clients to know if there are additional items to request.


- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
