### PR TITLE
docs: Remove deprecated vulnerability_settings options

### DIFF
--- a/docs/Using-Fleet/Vulnerability-Processing.md
+++ b/docs/Using-Fleet/Vulnerability-Processing.md
@@ -111,7 +111,7 @@ data feeds. This can be done by setting the following app config:
 apiVersion: v1
 kind: config
 spec:
-  vulnerability_settings:
+  vulnerabilities:
     databases_path: /some/path
 ```
 

--- a/docs/Using-Fleet/configuration-files/README.md
+++ b/docs/Using-Fleet/configuration-files/README.md
@@ -236,8 +236,16 @@ spec:
     issuer_uri: ""
     metadata: ""
     metadata_url: ""
-  vulnerability_settings:
-    databases_path: ""
+  vulnerabilities:
+    databases_path: "/tmp/vulndbs"
+    periodicity: 1h
+    cpe_database_url: ""
+    cpe_translations_url: ""
+    cve_feed_prefix_url: ""
+    current_instance_checks: "auto"
+    disable_data_sync: false
+    recent_vulnerability_max_age: 30d
+    disable_win_os_vulnerabilities: false
   webhook_settings:
     failing_policies_webhook:
       destination_url: ""
@@ -623,15 +631,15 @@ A URL that references the identity provider metadata.
 
 #### Vulnerability settings
 
-##### vulnerability_settings.databases_path
+##### vulnerabilities.databases_path
 
 Path to a directory on the local filesystem (accessible to the Fleet server) where the various vulnerability databases will be stored.
 
 - Optional setting, must be set to enable vulnerability detection (string).
-- Default value: "".
+- Default value: "/tmp/vulndb".
 - Config file format:
   ```yaml
-  vulnerability_settings:
+  vulnerabilities:
     databases_path: "/path/to/dir"
   ```
 


### PR DESCRIPTION
This fixes #8697, though I'm not sure if that is sufficient to clean up the docs. There appear to be two sets of documentation of fleet options, an [older page](https://fleetdm.com/docs/using-fleet/configuration-files and a [newer page](https://fleetdm.com/docs/deploying/configuration). The document similar things but are slightly different and the older page also includes deprecated options