### PR TITLE
Website: update /device-management page id

### DIFF
--- a/website/assets/js/pages/fleet-mdm.page.js
+++ b/website/assets/js/pages/fleet-mdm.page.js
@@ -1,4 +1,4 @@
-parasails.registerPage('fleet-mdm', {
+parasails.registerPage('device-management', {
   //  ╦╔╗╔╦╔╦╗╦╔═╗╦    ╔═╗╔╦╗╔═╗╔╦╗╔═╗
   //  ║║║║║ ║ ║╠═╣║    ╚═╗ ║ ╠═╣ ║ ║╣
   //  ╩╝╚╝╩ ╩ ╩╩ ╩╩═╝  ╚═╝ ╩ ╩ ╩ ╩ ╚═╝

--- a/website/assets/styles/pages/fleet-mdm.less
+++ b/website/assets/styles/pages/fleet-mdm.less
@@ -1,4 +1,4 @@
-#fleet-mdm {
+#device-management {
 
   h1 {
     font-weight: 800;

--- a/website/views/pages/fleet-mdm.ejs
+++ b/website/views/pages/fleet-mdm.ejs
@@ -1,4 +1,4 @@
-<div id="fleet-mdm" v-cloak>
+<div id="device-management" v-cloak>
   <div purpose="hero-background" class="container-lg d-flex justify-content-center">
     <div purpose="hero-container" class="d-flex flex-column align-items-center">
       <div purpose="hero-text">


### PR DESCRIPTION
Changes:
- Changed the id of the `/device-management` page to `device-management` (previously `fleet-mdm`)