### PR TITLE
Update osquery schema version and regenerate merged schema JSON

### DIFF
--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -8625,6 +8625,15 @@
         "hidden": true,
         "required": false,
         "index": false
+      },
+      {
+        "name": "codesigning_flags",
+        "description": "Codesigning flags matching one of these options, in a comma separated list: NOT_VALID, ADHOC, NOT_RUNTIME, INSTALLER. See kern/cs_blobs.h in XNU for descriptions.",
+        "type": "text",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
       }
     ],
     "osqueryRepoUrl": "https://github.com/osquery/osquery/blob/master/specs/darwin/es_process_events.table",
@@ -20505,6 +20514,229 @@
     "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/secureboot.yml"
   },
   {
+    "name": "security_profile_info",
+    "description": "Information on the security profile of a given system by listing the system Account and Audit Policies. This table mimics the exported securitypolicy output from the secedit tool.",
+    "url": "https://fleetdm.com/tables/security_profile_info",
+    "platforms": [
+      "windows"
+    ],
+    "evented": false,
+    "cacheable": false,
+    "notes": "",
+    "examples": [],
+    "columns": [
+      {
+        "name": "minimum_password_age",
+        "description": "Determines the minimum number of days that a password must be used before the user can change it",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "maximum_password_age",
+        "description": "Determines the maximum number of days that a password can be used before the client requires the user to change it",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "minimum_password_length",
+        "description": "Determines the least number of characters that can make up a password for a user account",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "password_complexity",
+        "description": "Determines whether passwords must meet a series of strong-password guidelines",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "password_history_size",
+        "description": "Number of unique new passwords that must be associated with a user account before an old password can be reused",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "lockout_bad_count",
+        "description": "Number of failed logon attempts after which a user account MUST be locked out",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "logon_to_change_password",
+        "description": "Determines if logon session is required to change the password",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "force_logoff_when_expire",
+        "description": "Determines whether SMB client sessions with the SMB server will be forcibly disconnected when the client's logon hours expire",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "new_administrator_name",
+        "description": "Determines the name of the Administrator account on the local computer",
+        "type": "text",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "new_guest_name",
+        "description": "Determines the name of the Guest account on the local computer",
+        "type": "text",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "clear_text_password",
+        "description": "Determines whether passwords MUST be stored by using reversible encryption",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "lsa_anonymous_name_lookup",
+        "description": "Determines if an anonymous user is allowed to query the local LSA policy",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "enable_admin_account",
+        "description": "Determines whether the Administrator account on the local computer is enabled",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "enable_guest_account",
+        "description": "Determines whether the Guest account on the local computer is enabled",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "audit_system_events",
+        "description": "Determines whether the operating system MUST audit System Change, System Startup, System Shutdown, Authentication Component Load, and Loss or Excess of Security events",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "audit_logon_events",
+        "description": "Determines whether the operating system MUST audit each instance of a user attempt to log on or log off this computer",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "audit_object_access",
+        "description": "Determines whether the operating system MUST audit each instance of user attempts to access a non-Active Directory object that has its own SACL specified",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "audit_privilege_use",
+        "description": "Determines whether the operating system MUST audit each instance of user attempts to exercise a user right",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "audit_policy_change",
+        "description": "Determines whether the operating system MUST audit each instance of user attempts to change user rights assignment policy, audit policy, account policy, or trust policy",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "audit_account_manage",
+        "description": "Determines whether the operating system MUST audit each event of account management on a computer",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "audit_process_tracking",
+        "description": "Determines whether the operating system MUST audit process-related events",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "audit_ds_access",
+        "description": "Determines whether the operating system MUST audit each instance of user attempts to access an Active Directory object that has its own system access control list (SACL) specified",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      },
+      {
+        "name": "audit_account_logon",
+        "description": "Determines whether the operating system MUST audit each time this computer validates the credentials of an account",
+        "type": "integer",
+        "notes": "",
+        "hidden": false,
+        "required": false,
+        "index": false
+      }
+    ],
+    "osqueryRepoUrl": "https://github.com/osquery/osquery/blob/master/specs/windows/security_profile_info.table",
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/new/main/schema/tables/?filename=%2Ftables%2Fsecurity_profile_info.yml&value=name%3A%20security_profile_info%0Adescription%3A%20%3E-%20%23%20(required)%20string%20-%20The%20description%20for%20this%20table.%20Note%3A%20this%20field%20supports%20markdown%0A%09%23%20Add%20description%20here%0Aexamples%3A%20%3E-%20%23%20(optional)%20string%20-%20An%20example%20query%20for%20this%20table.%20Note%3A%20This%20field%20supports%20markdown%0A%09%23%20Add%20examples%20here%0Anotes%3A%20%3E-%20%23%20(optional)%20string%20-%20Notes%20about%20this%20table.%20Note%3A%20This%20field%20supports%20markdown.%0A%09%23%20Add%20notes%20here%0Acolumns%3A%20%23%20(required)%0A%09-%20name%3A%20%23%20(required)%20string%20-%20The%20name%20of%20the%20column%0A%09%20%20description%3A%20%23%20(required)%20string%20-%20The%20column's%20description%0A%09%20%20type%3A%20%23%20(required)%20string%20-%20the%20column's%20data%20type%0A%09%20%20required%3A%20%23%20(required)%20boolean%20-%20whether%20or%20not%20this%20column%20is%20required%20to%20query%20this%20table."
+  },
+  {
     "name": "selinux_events",
     "description": "Track SELinux events.",
     "url": "https://fleetdm.com/tables/selinux_events",
@@ -26426,7 +26658,7 @@
       }
     ],
     "url": "https://fleetdm.com/tables/file_lines",
-    "fleetRepoUrl": "https://github.com/edit/fleetdm/fleet/schema/tables/file_lines.yml"
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/file_lines.yml"
   },
   {
     "name": "filevault_users",
@@ -26450,7 +26682,7 @@
       }
     ],
     "url": "https://fleetdm.com/tables/filevault_users",
-    "fleetRepoUrl": "https://github.com/edit/fleetdm/fleet/schema/tables/filevault_users.yml"
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/filevault_users.yml"
   },
   {
     "name": "google_chrome_profiles",
@@ -26486,7 +26718,7 @@
       }
     ],
     "url": "https://fleetdm.com/tables/google_chrome_profiles",
-    "fleetRepoUrl": "https://github.com/edit/fleetdm/fleet/schema/tables/google_chrome_profiles.yml"
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/google_chrome_profiles.yml"
   },
   {
     "name": "icloud_private_relay",
@@ -26505,7 +26737,7 @@
     "notes": "- This table is not a core osquery table. It is included as part of Fleetd, the osquery manager from Fleet. ",
     "evented": false,
     "url": "https://fleetdm.com/tables/icloud_private_relay",
-    "fleetRepoUrl": "https://github.com/edit/fleetdm/fleet/schema/tables/icloud_private_relay.yml"
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/icloud_private_relay.yml"
   },
   {
     "name": "macadmins_unified_log",
@@ -26619,7 +26851,7 @@
       }
     ],
     "url": "https://fleetdm.com/tables/macadmins_unified_log",
-    "fleetRepoUrl": "https://github.com/edit/fleetdm/fleet/schema/tables/macadmins_unified_log.yml"
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/macadmins_unified_log.yml"
   },
   {
     "name": "macos_profiles",
@@ -26679,7 +26911,7 @@
       }
     ],
     "url": "https://fleetdm.com/tables/macos_profiles",
-    "fleetRepoUrl": "https://github.com/edit/fleetdm/fleet/schema/tables/macos_profiles.yml"
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/macos_profiles.yml"
   },
   {
     "name": "mdm",
@@ -26769,7 +27001,7 @@
       }
     ],
     "url": "https://fleetdm.com/tables/mdm",
-    "fleetRepoUrl": "https://github.com/edit/fleetdm/fleet/schema/tables/mdm.yml"
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/mdm.yml"
   },
   {
     "name": "munki_info",
@@ -26835,7 +27067,7 @@
       }
     ],
     "url": "https://fleetdm.com/tables/munki_info",
-    "fleetRepoUrl": "https://github.com/edit/fleetdm/fleet/schema/tables/munki_info.yml"
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/munki_info.yml"
   },
   {
     "name": "munki_installs",
@@ -26871,7 +27103,7 @@
       }
     ],
     "url": "https://fleetdm.com/tables/munki_installs",
-    "fleetRepoUrl": "https://github.com/edit/fleetdm/fleet/schema/tables/munki_installs.yml"
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/munki_installs.yml"
   },
   {
     "name": "puppet_facts",
@@ -26901,7 +27133,7 @@
       }
     ],
     "url": "https://fleetdm.com/tables/puppet_facts",
-    "fleetRepoUrl": "https://github.com/edit/fleetdm/fleet/schema/tables/puppet_facts.yml"
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/puppet_facts.yml"
   },
   {
     "name": "puppet_info",
@@ -27015,7 +27247,7 @@
       }
     ],
     "url": "https://fleetdm.com/tables/puppet_info",
-    "fleetRepoUrl": "https://github.com/edit/fleetdm/fleet/schema/tables/puppet_info.yml"
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/puppet_info.yml"
   },
   {
     "name": "puppet_logs",
@@ -27063,7 +27295,7 @@
       }
     ],
     "url": "https://fleetdm.com/tables/puppet_logs",
-    "fleetRepoUrl": "https://github.com/edit/fleetdm/fleet/schema/tables/puppet_logs.yml"
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/puppet_logs.yml"
   },
   {
     "name": "puppet_state",
@@ -27153,6 +27385,6 @@
       }
     ],
     "url": "https://fleetdm.com/tables/puppet_state",
-    "fleetRepoUrl": "https://github.com/edit/fleetdm/fleet/schema/tables/puppet_state.yml"
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/puppet_state.yml"
   }
 ]

--- a/website/api/helpers/get-extended-osquery-schema.js
+++ b/website/api/helpers/get-extended-osquery-schema.js
@@ -23,7 +23,7 @@ module.exports = {
     let YAML = require('yaml');
     let topLvlRepoPath = path.resolve(sails.config.appPath, '../');
 
-    let VERSION_OF_OSQUERY_SCHEMA_TO_USE = '5.6.0';
+    let VERSION_OF_OSQUERY_SCHEMA_TO_USE = '5.7.0';
     // Getting the specified osquery schema from the osquery/osquery-site GitHub repo.
     let rawOsqueryTables = await sails.helpers.http.get('https://raw.githubusercontent.com/osquery/osquery-site/source/src/data/osquery_schema_versions/'+VERSION_OF_OSQUERY_SCHEMA_TO_USE+'.json');
 


### PR DESCRIPTION
Changes:
- Updated the version of the osquery schema we merge with Fleet's overrides (`5.6.0` » `5.7.0`)
- Ran the `generate-merged-schema` script to regenerate `schema/osquery_fleet_schema.json`
 . .