### PR TITLE
Fleet UI: Show software on dashboard only if software

### DIFF
--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -590,7 +590,7 @@ const DashboardPage = ({
               {LearnFleetCard}
             </>
           )}
-        {!software && SoftwareCard}
+        {software && SoftwareCard}
         {!currentTeam && isOnGlobalTeam && <>{ActivityFeedCard}</>}
         {showMdmCard && <>{MDMCard}</>}
       </div>

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -590,7 +590,7 @@ const DashboardPage = ({
               {LearnFleetCard}
             </>
           )}
-        {software && SoftwareCard}
+        {software?.software && SoftwareCard}
         {!currentTeam && isOnGlobalTeam && <>{ActivityFeedCard}</>}
         {showMdmCard && <>{MDMCard}</>}
       </div>


### PR DESCRIPTION
Whoops, I think `!software` instead of `software?.software` that I was using for testing slipped into a PR 


Steps to QA
- No software (usually no hosts or only new hosts that haven't updated yet) hides the software card on Dashboard 
- Software on hosts shows the software card on Dashboard

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality