### PR TITLE
Update YAML schema table validation

### DIFF
--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -26640,7 +26640,11 @@
     "name": "file_lines",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
     "description": "Allows reading an arbitrary file.",
-    "platforms": "darwin, windows, linux",
+    "platforms": [
+      "darwin",
+      "windows",
+      "linux"
+    ],
     "evented": false,
     "examples": "Output the content of `/etc/hosts` line by line. \n```\nSELECT * FROM file_lines WHERE path='/etc/hosts';\n```",
     "columns": [
@@ -26664,7 +26668,9 @@
     "name": "filevault_users",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
     "description": "Information on the users able to unlock the current boot volume if protected with FileVault.",
-    "platforms": "darwin",
+    "platforms": [
+      "darwin"
+    ],
     "evented": false,
     "examples": "List the usernames able to unlock and boot a computer protected by FileVault, joined to [users.username](http://fleetdm.com/tables/users) to obtain the description of the operating system account that owns it.\n```\nSELECT fu.username, u.description FROM filevault_users fu JOIN users u ON fu.uuid=u.uuid;\n```",
     "columns": [
@@ -26688,7 +26694,11 @@
     "name": "google_chrome_profiles",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
     "description": "Profiles configured in Google Chrome.",
-    "platforms": "darwin, windows, linux",
+    "platforms": [
+      "darwin",
+      "windows",
+      "linux"
+    ],
     "evented": false,
     "examples": "List the Google Chrome accounts logged in to with `fleetdm.com` email addresses, joined to the [users](https://fleetdm.com/tables/users) table, to see the description of the operating system account that owns it.\n```\nSELECT gp.email, gp.username, u.description FROM google_chrome_profiles gp JOIN users u ON gp.username=u.username WHERE gp.email LIKE '%fleetdm.com';\n```",
     "columns": [
@@ -26743,7 +26753,9 @@
     "name": "macadmins_unified_log",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
     "description": "Allows querying macOS [unified logs](https://developer.apple.com/documentation/os/logging).",
-    "platforms": "darwin",
+    "platforms": [
+      "darwin"
+    ],
     "evented": false,
     "examples": "Select the log entries that happened during the last minute and are related to `LaunchServices`. Convert the UNIX time to a human readable format,  and the signature table to verify its cryptographic signature.\n```\nSELECT u.category, u.event_message, u.process_id, datetime(u.timestamp, 'unixepoch') AS human_time, p.path, s.signed, s.identifier, s.authority FROM macadmins_unified_log u JOIN processes p ON u.process_id = p.pid JOIN signature s ON p.path = s.path WHERE u.sender_image_path LIKE '%LaunchServices%' AND last = \"1m\";\n```",
     "columns": [
@@ -26857,7 +26869,9 @@
     "name": "macos_profiles",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
     "description": "High level information on installed profiles enrollment.",
-    "platforms": "darwin",
+    "platforms": [
+      "darwin"
+    ],
     "evented": false,
     "examples": "Identify all profiles that are not *verified*.\n```\nSELECT display_name, install_date FROM macos_profiles WHERE verification_state!='verified';  \n```",
     "columns": [
@@ -26914,10 +26928,80 @@
     "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/macos_profiles.yml"
   },
   {
+    "name": "munki_info",
+    "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).<p> Code based on work by [Kolide](https://github.com/kolide/launcher).",
+    "description": "Information from the last [Munki](https://github.com/munki/munki) run.",
+    "platforms": [
+      "darwin"
+    ],
+    "evented": false,
+    "examples": "Output errors, warnings and problematic installations from Munki.\n```\nSELECT errors, warnings, problem_installs FROM munki_info ;\n```",
+    "columns": [
+      {
+        "name": "console_user",
+        "description": "The username of the user currently logged into the console of the Mac.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "end_time",
+        "description": "The date and time at which the latest Munki run ended.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "errors",
+        "description": "If Munki encountered any error during the last run, they will be returned in this column.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "manifest_name",
+        "description": "The internal manifest name",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "problem_installs",
+        "description": "A list of installs that did not succeed, if any.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "start_time",
+        "description": "The date and time at which the latest Munki run started.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "success",
+        "description": "Shows if the Munki run was a success (true), or not (false).",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "version",
+        "description": "The version of Munki used during the last run.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "warnings",
+        "description": "If Munki encountered any error during the last run, they will be returned in this column.",
+        "required": false,
+        "type": "text"
+      }
+    ],
+    "url": "https://fleetdm.com/tables/munki_info",
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/munki_info.yml"
+  },
+  {
     "name": "mdm",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).<p> Code based on work by [Kolide](https://github.com/kolide/launcher). <p> Due to changes in macOS 12.3, the output of `profiles show -type enrollment` can only be generated once a day. If you are running this command with another tool, you should set the `PROFILES_SHOW_ENROLLMENT_CACHE_PATH` environment variable to the path you are caching this. The cache file should be `json` with the keys `dep_capable` and `rate_limited present`, both booleans representing whether the device is capable of DEP enrollment and whether the response from `profiles show -type enrollment` is being rate limited or not.",
     "description": "Information on the device's MDM enrollment.",
-    "platforms": "darwin",
+    "platforms": [
+      "darwin"
+    ],
     "evented": false,
     "examples": "Identify Macs that are DEP capable but have not been enrolled to MDM.\n```\nSELECT * FROM mdm WHERE dep_capable='true' AND enrolled='false';\n```",
     "columns": [
@@ -27004,76 +27088,12 @@
     "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/mdm.yml"
   },
   {
-    "name": "munki_info",
-    "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).<p> Code based on work by [Kolide](https://github.com/kolide/launcher).",
-    "description": "Information from the last [Munki](https://github.com/munki/munki) run.",
-    "platforms": "darwin",
-    "evented": false,
-    "examples": "Output errors, warnings and problematic installations from Munki.\n```\nSELECT errors, warnings, problem_installs FROM munki_info ;\n```",
-    "columns": [
-      {
-        "name": "console_user",
-        "description": "The username of the user currently logged into the console of the Mac.",
-        "required": false,
-        "type": "text"
-      },
-      {
-        "name": "end_time",
-        "description": "The date and time at which the latest Munki run ended.",
-        "required": false,
-        "type": "text"
-      },
-      {
-        "name": "errors",
-        "description": "If Munki encountered any error during the last run, they will be returned in this column.",
-        "required": false,
-        "type": "text"
-      },
-      {
-        "name": "manifest_name",
-        "description": "The internal manifest name",
-        "required": false,
-        "type": "text"
-      },
-      {
-        "name": "problem_installs",
-        "description": "A list of installs that did not succeed, if any.",
-        "required": false,
-        "type": "text"
-      },
-      {
-        "name": "start_time",
-        "description": "The date and time at which the latest Munki run started.",
-        "required": false,
-        "type": "text"
-      },
-      {
-        "name": "success",
-        "description": "Shows if the Munki run was a success (true), or not (false).",
-        "required": false,
-        "type": "text"
-      },
-      {
-        "name": "version",
-        "description": "The version of Munki used during the last run.",
-        "required": false,
-        "type": "text"
-      },
-      {
-        "name": "warnings",
-        "description": "If Munki encountered any error during the last run, they will be returned in this column.",
-        "required": false,
-        "type": "text"
-      }
-    ],
-    "url": "https://fleetdm.com/tables/munki_info",
-    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/munki_info.yml"
-  },
-  {
     "name": "munki_installs",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).<p> Code based on work by [Kolide](https://github.com/kolide/launcher).",
     "description": "Software packages and other items [Munki](https://github.com/munki/munki) is managing.",
-    "platforms": "darwin",
+    "platforms": [
+      "darwin"
+    ],
     "evented": false,
     "examples": "See the version of software that has been deployed by Munki.\n```\nSELECT name, installed_version FROM munki_installs WHERE installed='true';\n```",
     "columns": [
@@ -27109,7 +27129,11 @@
     "name": "puppet_facts",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
     "description": "Facts about [Puppet](https://puppet.com/). Puppet facts are *key:value* pairs.",
-    "platforms": "darwin, windows, linux",
+    "platforms": [
+      "darwin",
+      "windows",
+      "linux"
+    ],
     "evented": false,
     "examples": "List all Puppet facts.\n```\nSELECT * FROM puppet_facts;\n```",
     "columns": [
@@ -27139,7 +27163,11 @@
     "name": "puppet_info",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
     "description": "Information on the last [Puppet](https://puppet.com/) run. This table uses data from the `last_run_report` that Puppet creates.",
-    "platforms": "darwin, windows, linux",
+    "platforms": [
+      "darwin",
+      "windows",
+      "linux"
+    ],
     "evented": false,
     "examples": "List all the information available about the last Puppet run.\n```\nSELECT * FROM puppet_info;\n```",
     "columns": [
@@ -27250,58 +27278,14 @@
     "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/puppet_info.yml"
   },
   {
-    "name": "puppet_logs",
-    "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
-    "description": "Outputs [Puppet](https://puppet.com/) logs from the last run.",
-    "platforms": "darwin, windows, linux",
-    "evented": false,
-    "examples": "List Puppet logs that are of a level of anything but informational.\n```\nSELECT * FROM puppet_logs WHERE level!='info';\n```",
-    "columns": [
-      {
-        "name": "level",
-        "description": "The level of the log item (info, error, etc).",
-        "required": false,
-        "type": "text"
-      },
-      {
-        "name": "message",
-        "description": "The log message content.",
-        "required": false,
-        "type": "text"
-      },
-      {
-        "name": "source",
-        "description": "The source of the log item.",
-        "required": false,
-        "type": "text"
-      },
-      {
-        "name": "time",
-        "description": "The time at which this item was logged.",
-        "required": false,
-        "type": "text"
-      },
-      {
-        "name": "file",
-        "description": "The file from which osquery read this log.",
-        "required": false,
-        "type": "text"
-      },
-      {
-        "name": "line",
-        "description": "The line from which this log item was read.",
-        "required": false,
-        "type": "text"
-      }
-    ],
-    "url": "https://fleetdm.com/tables/puppet_logs",
-    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/puppet_logs.yml"
-  },
-  {
     "name": "puppet_state",
     "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
     "description": "State of every resource [Puppet](https://puppet.com/) is managing. This table uses data from the `last_run_report` that Puppet creates.",
-    "platforms": "darwin, windows, linux",
+    "platforms": [
+      "darwin",
+      "windows",
+      "linux"
+    ],
     "evented": false,
     "examples": "List resources that failed or took over a minute to evaluate.\n```\nSELECT * FROM puppet_state WHERE failed='true' OR evaluation_time>'60';\n```",
     "columns": [
@@ -27386,5 +27370,57 @@
     ],
     "url": "https://fleetdm.com/tables/puppet_state",
     "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/puppet_state.yml"
+  },
+  {
+    "name": "puppet_logs",
+    "notes": "Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).",
+    "description": "Outputs [Puppet](https://puppet.com/) logs from the last run.",
+    "platforms": [
+      "darwin",
+      "windows",
+      "linux"
+    ],
+    "evented": false,
+    "examples": "List Puppet logs that are of a level of anything but informational.\n```\nSELECT * FROM puppet_logs WHERE level!='info';\n```",
+    "columns": [
+      {
+        "name": "level",
+        "description": "The level of the log item (info, error, etc).",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "message",
+        "description": "The log message content.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "source",
+        "description": "The source of the log item.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "time",
+        "description": "The time at which this item was logged.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "file",
+        "description": "The file from which osquery read this log.",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "line",
+        "description": "The line from which this log item was read.",
+        "required": false,
+        "type": "text"
+      }
+    ],
+    "url": "https://fleetdm.com/tables/puppet_logs",
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/puppet_logs.yml"
   }
 ]

--- a/schema/tables/file_lines.yml
+++ b/schema/tables/file_lines.yml
@@ -1,7 +1,10 @@
 name: file_lines
 notes: Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).
 description: Allows reading an arbitrary file.
-platforms: darwin, windows, linux
+platforms: 
+  - darwin
+  - windows
+  - linux
 evented: false
 examples: >-
   Output the content of `/etc/hosts` line by line. 

--- a/schema/tables/filevault_users.yml
+++ b/schema/tables/filevault_users.yml
@@ -1,7 +1,8 @@
 name: filevault_users
 notes: Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).
 description: Information on the users able to unlock the current boot volume if protected with FileVault.
-platforms: darwin
+platforms: 
+  - darwin
 evented: false
 examples: >-
   List the usernames able to unlock and boot a computer protected by FileVault, joined to

--- a/schema/tables/google_chrome_profiles.yml
+++ b/schema/tables/google_chrome_profiles.yml
@@ -1,7 +1,10 @@
 name: google_chrome_profiles
 notes: Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).
 description: Profiles configured in Google Chrome.
-platforms: darwin, windows, linux
+platforms: 
+  - darwin
+  - windows
+  - linux
 evented: false
 examples: >-
   List the Google Chrome accounts logged in to with `fleetdm.com` email addresses, joined to the

--- a/schema/tables/macadmins_unified_log.yml
+++ b/schema/tables/macadmins_unified_log.yml
@@ -1,7 +1,8 @@
 name: macadmins_unified_log
 notes: Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).
 description: Allows querying macOS [unified logs](https://developer.apple.com/documentation/os/logging).
-platforms: darwin
+platforms: 
+  - darwin
 evented: false
 examples: >-
   Select the log entries that happened during the last minute and are related to `LaunchServices`. Convert the UNIX time to a human readable format,  and the signature table to verify its cryptographic signature.

--- a/schema/tables/macos_profiles.yml
+++ b/schema/tables/macos_profiles.yml
@@ -1,7 +1,8 @@
 name: macos_profiles
 notes: Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).
 description: High level information on installed profiles enrollment.
-platforms: darwin
+platforms: 
+  - darwin
 evented: false
 examples: >-
   Identify all profiles that are not *verified*.

--- a/schema/tables/mdm.yml
+++ b/schema/tables/mdm.yml
@@ -1,7 +1,8 @@
 name: mdm
 notes: Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).<p> Code based on work by [Kolide](https://github.com/kolide/launcher). <p> Due to changes in macOS 12.3, the output of `profiles show -type enrollment` can only be generated once a day. If you are running this command with another tool, you should set the `PROFILES_SHOW_ENROLLMENT_CACHE_PATH` environment variable to the path you are caching this. The cache file should be `json` with the keys `dep_capable` and `rate_limited present`, both booleans representing whether the device is capable of DEP enrollment and whether the response from `profiles show -type enrollment` is being rate limited or not.
 description: Information on the device's MDM enrollment.
-platforms: darwin
+platforms: 
+  - darwin
 evented: false
 examples: >-
   Identify Macs that are DEP capable but have not been enrolled to MDM.

--- a/schema/tables/munki_info.yml
+++ b/schema/tables/munki_info.yml
@@ -1,7 +1,8 @@
 name: munki_info
 notes: Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).<p> Code based on work by [Kolide](https://github.com/kolide/launcher).
 description: Information from the last [Munki](https://github.com/munki/munki) run.
-platforms: darwin
+platforms: 
+  - darwin
 evented: false
 examples: >-
   Output errors, warnings and problematic installations from Munki.

--- a/schema/tables/munki_installs.yml
+++ b/schema/tables/munki_installs.yml
@@ -1,7 +1,8 @@
 name: munki_installs
 notes: Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).<p> Code based on work by [Kolide](https://github.com/kolide/launcher).
 description: Software packages and other items [Munki](https://github.com/munki/munki) is managing.
-platforms: darwin
+platforms: 
+  - darwin
 evented: false
 examples: >-
   See the version of software that has been deployed by Munki.

--- a/schema/tables/puppet_facts.yml
+++ b/schema/tables/puppet_facts.yml
@@ -1,7 +1,10 @@
 name: puppet_facts
 notes: Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).
 description: Facts about [Puppet](https://puppet.com/). Puppet facts are *key:value* pairs.
-platforms: darwin, windows, linux
+platforms: 
+  - darwin
+  - windows
+  - linux
 evented: false
 examples: >-
   List all Puppet facts.

--- a/schema/tables/puppet_info.yml
+++ b/schema/tables/puppet_info.yml
@@ -1,7 +1,10 @@
 name: puppet_info
 notes: Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).
 description: Information on the last [Puppet](https://puppet.com/) run. This table uses data from the `last_run_report` that Puppet creates.
-platforms: darwin, windows, linux
+platforms: 
+  - darwin
+  - windows
+  - linux
 evented: false
 examples: >-
   List all the information available about the last Puppet run.

--- a/schema/tables/puppet_logs.yml
+++ b/schema/tables/puppet_logs.yml
@@ -1,7 +1,10 @@
 name: puppet_logs
 notes: Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).
 description: Outputs [Puppet](https://puppet.com/) logs from the last run. 
-platforms: darwin, windows, linux
+platforms: 
+  - darwin
+  - windows
+  - linux
 evented: false
 examples: >-
   List Puppet logs that are of a level of anything but informational.

--- a/schema/tables/puppet_state.yml
+++ b/schema/tables/puppet_state.yml
@@ -1,7 +1,10 @@
 name: puppet_state
 notes: Requires [macadmins-extension](https://github.com/macadmins/osquery-extension/), which is included by default on osquery packages built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).
 description: State of every resource [Puppet](https://puppet.com/) is managing. This table uses data from the `last_run_report` that Puppet creates.
-platforms: darwin, windows, linux
+platforms: 
+  - darwin
+  - windows
+  - linux
 evented: false
 examples: >-
   List resources that failed or took over a minute to evaluate.

--- a/website/api/helpers/get-extended-osquery-schema.js
+++ b/website/api/helpers/get-extended-osquery-schema.js
@@ -241,9 +241,13 @@ module.exports = {
 
         if(!fleetOverrideToPush.description) {
           throw new Error(`Could not add a new table from the Fleet overrides to final merged schema, the "${fleetOverrideToPush.name}" table is missing a 'description' value. To resolve, add a description to this table to the Fleet overrides schema at ${path.resolve(topLvlRepoPath+'/schema/tables', fleetOverrideToPush.name+'.yml')}. Tip: If this table is meant to override a table in the osquery schema, you may want to check that the "name" value of the added table is the same as the table in the osquery schema located at https://github.com/osquery/osquery-site/source/src/data/osquery_schema_versions/${VERSION_OF_OSQUERY_SCHEMA_TO_USE}.json`);
+        } else if(typeof fleetOverrideToPush.description !== 'string'){
+          throw new Error(`Could not add a new table from the Fleet overrides to final merged schema, The "description" of the "${fleetOverridesForTable.name}" table is an invalid type (Eexpected a string, but instead got a ${typeof fleetOverrideToPush.description}). to resolve, change the tables's "description" to be a string.`);
         }
         if(!fleetOverrideToPush.platforms) {
           throw new Error(`Could not add a new table from the Fleet overrides to final merged schema, the "${fleetOverrideToPush.name}" table is missing a 'platforms' value. To resolve, add an array of platforms to this table to the Fleet overrides schema at ${path.resolve(topLvlRepoPath+'/schema/tables', fleetOverrideToPush.name+'.yml')}. Tip: If this table is meant to override a table in the osquery schema, you may want to check that the "name" value of the added table is the same as the table in the osquery schema located at https://github.com/osquery/osquery-site/source/src/data/osquery_schema_versions/${VERSION_OF_OSQUERY_SCHEMA_TO_USE}.json`);
+        } else if(!_.isArray(fleetOverrideToPush.platforms)) {
+          throw new Error(`Could not add a new table from the Fleet overrides to final merged schema, the "${fleetOverrideToPush.name}" table has an invalid 'platforms' value. (expected an array, but instead got a ${typeof fleetOverrideToPush.platforms}) To resolve, change the "platforms" value to be an array of values, then try runing this script again.`);
         }
         if(fleetOverrideToPush.evented === undefined) {
           throw new Error(`Could not add a new table from the Fleet overrides to final merged schema, the "${fleetOverrideToPush.name}" table is missing a 'evented' value. To resolve, add an evented value to this table to the Fleet overrides schema at ${path.resolve(topLvlRepoPath+'/schema/tables', fleetOverrideToPush.name+'.yml')} .\n Tip: If this table is meant to override a table in the osquery schema, you may want to check that the "name" value of the added table is the same as the table in the osquery schema https://github.com/osquery/osquery-site/source/src/data/osquery_schema_versions/${VERSION_OF_OSQUERY_SCHEMA_TO_USE}.json`);
@@ -252,6 +256,8 @@ module.exports = {
         }
         if(!fleetOverrideToPush.columns) {
           throw new Error(`Could not add a new table from the Fleet overrides to final merged schema. The "${fleetOverrideToPush.name}" table is missing a "columns" value. To resolve, add an array of columns to this table to the Fleet overrides schema at ${path.resolve(topLvlRepoPath+'/schema/tables', fleetOverrideToPush.name+'.yml')}. Tip: If this table is meant to override a table in the osquery schema, you may want to check that the "name" value of the added table is the same as the table in the osquery schema located at https://github.com/osquery/osquery-site/source/src/data/osquery_schema_versions/${VERSION_OF_OSQUERY_SCHEMA_TO_USE}.json`);
+        } else if(!_.isArray(fleetOverrideToPush.columns)){
+          throw new Error(`Could not add a new table from the Fleet overrides to final merged schema, the "${fleetOverrideToPush.name}" table has an invalid "columns" value. (Expected an array, but instead got a ${typeof fleetOverrideToPush.columns}) To resolve, change the "columns" value to be an array of values, then try runing this script again.`);
         } else {
 
           for(let columnToValidate of fleetOverrideToPush.columns) { // Check each column in the table to make sure it has the required values, and that all values are the correct type.


### PR DESCRIPTION
Changes:
- Added three errors to `website/api/helpers/get-extended-osquery-schema.js` that are thrown if a YAML schema table has:
   - A `platforms` value that is not an array
   - A `description` value that is not a string
   - A `columns` value that is not an array
- Updated the `platforms` of YAML schema tables in `schema/tables/` that had string `platforms` values
- Regenerated `/schema/osquery_fleet_schema.json`
 
.