### PR TITLE
Frontend: Fix Clicking "Back to all hosts" doesn't clear filter after filtering by software

### DIFF
--- a/frontend/components/ViewAllHostsLink/ViewAllHostsLink.tsx
+++ b/frontend/components/ViewAllHostsLink/ViewAllHostsLink.tsx
@@ -34,7 +34,7 @@ const ViewAllHostsLink = ({
     : endpoint;
 
   return (
-    <Link className={viewAllHostsLinkClass} to={path} title="host-link">
+    <Link className={viewAllHostsLinkClass} to={path}>
       {!condensed && <span>View all hosts</span>}
       <Icon
         name="chevron"

--- a/frontend/components/ViewAllHostsLink/ViewAllHostsLink.tsx
+++ b/frontend/components/ViewAllHostsLink/ViewAllHostsLink.tsx
@@ -34,7 +34,7 @@ const ViewAllHostsLink = ({
     : endpoint;
 
   return (
-    <Link className={viewAllHostsLinkClass} to={path}>
+    <Link className={viewAllHostsLinkClass} to={path} title="host-link">
       {!condensed && <span>View all hosts</span>}
       <Icon
         name="chevron"

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -550,8 +550,9 @@ const ManageHostsPage = ({
       retrieveHostCount(omit(options, "device_mapping"));
       setCurrentQueryOptions(options);
     }
-
-    setFilteredHostsPath(location.pathname + location.search);
+    if (!location.search.includes("software_id")) {
+      setFilteredHostsPath(location.pathname + location.search);
+    }
   }, [availableTeams, currentTeam, location, labels]);
 
   const isLastPage =


### PR DESCRIPTION
# Addresses #8923 

# Fixes

When a user followed the flow ManageHosts > HostDetails > Software tab > View all hosts (aka, filter all hosts by the software this row represents), and then hit browser back, then 'Back to all hosts', the software filter remained on the ManageHosts Page. (see #8923)

Now the filter clears correctly, while still maintaining the desired filters if they exist (OS, team, label)
https://www.loom.com/share/a3c1d182ba5145df93d13d893833db95

# Checklist for submitter
- [x] Manual QA for all new/changed functionality
