### PR TITLE
Frontend: Fix flaky cypress

### DIFF
--- a/cypress/integration/free/maintainer.spec.ts
+++ b/cypress/integration/free/maintainer.spec.ts
@@ -85,7 +85,6 @@ describe(
       it("allows maintainer to see and click 'Add label', 'Add hosts', and 'Manage enroll secrets' buttons", () => {
         manageHostsPage.allowsAddHosts();
         manageHostsPage.allowsManageAndAddSecrets();
-        manageHostsPage.allowsAddHosts();
       });
     });
     describe("Host details page", () => {

--- a/cypress/integration/pages/manageHostsPage.ts
+++ b/cypress/integration/pages/manageHostsPage.ts
@@ -7,10 +7,11 @@ const manageHostsPage = {
     cy.getAttached(".button-wrap")
       .contains("button", /manage enroll secret/i)
       .click();
+    cy.wait(500); // eslint-disable-line cypress/no-unnecessary-waiting
     cy.contains("button", /add secret/i).click();
+    cy.wait(500); // eslint-disable-line cypress/no-unnecessary-waiting
     cy.contains("button", /save/i).click();
     cy.findByText(/successfully added/i);
-    cy.getAttached(".modal__ex").click();
   },
 
   allowsAddHosts: () => {

--- a/cypress/integration/pages/managePacksPage.ts
+++ b/cypress/integration/pages/managePacksPage.ts
@@ -8,6 +8,7 @@ const managePacksPage = {
   },
 
   allowsCreatePack: () => {
+    cy.getAttached(".empty-table__container");
     cy.findByRole("button", { name: /create new pack/i }).click();
     cy.findByLabelText(/name/i).click().type("Errors and crashes");
     cy.findByLabelText(/description/i)

--- a/cypress/integration/premium/admin.spec.ts
+++ b/cypress/integration/premium/admin.spec.ts
@@ -380,8 +380,8 @@ describe("Premium tier - Global Admin user", () => {
     });
     it("allows global admin to see and click all CTA buttons", () => {
       manageHostsPage.allowsAddHosts();
-      manageHostsPage.allowsManageAndAddSecrets();
       manageHostsPage.allowsAddLabelForm();
+      manageHostsPage.allowsManageAndAddSecrets();
     });
   });
   describe("Host details page", () => {


### PR DESCRIPTION
### Fixes

#### `team_admin.spec.ts`
- Add waits for flaky modal transitions
- Remove clicking on x which is so tiny that transitions can easily mess it up (move around code so closing modal is not necessary to complete test)
- Ensure parent element loads before trying to create a new pack

#### Screenshots
<img width="1365" alt="Screenshot 2023-01-13 at 3 22 32 PM" src="https://user-images.githubusercontent.com/71795832/212412368-9620eb86-ca9a-4c13-b3b0-584847bdd729.png">


- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

