### PR TITLE
Don't go get go-ruleguard in make deps-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,6 @@ deps-js:
 
 deps-go:
 	go mod download
-	go get github.com/quasilyte/go-ruleguard/dsl
 
 migration:
 	go run github.com/fleetdm/goose/cmd/goose -dir server/datastore/mysql/migrations/tables create $(name)


### PR DESCRIPTION
Doing this could cause the package to update and therefore generate a dirty worktree after a run of `make deps-go`. Goreleaser will refuse to make a build on a dirty work tree (which is probably the behavior we want, as we only want to build with committed changes).