### PR TITLE
Change technical sub-task default label

### DIFF
--- a/.github/ISSUE_TEMPLATE/technical-sub-task.md
+++ b/.github/ISSUE_TEMPLATE/technical-sub-task.md
@@ -2,7 +2,7 @@
 name: 🎟  Technical sub-task
 about: Specify an optional technical sub-task for a Scrum user story. 
 title: ''
-labels: 'technical sub-task'
+labels: 'sub-task'
 assignees: ''
 
 ---


### PR DESCRIPTION
Thoughts on changing the default label to simply `sub-task`? 