### PR TITLE
Notify orbit via the GET config endpoint that the DEP profile needs to be renewed

### DIFF
--- a/changes/issue-9277-notify-orbit-to-renew-enroll-profile
+++ b/changes/issue-9277-notify-orbit-to-renew-enroll-profile
@@ -1,0 +1,1 @@
+* Added a `notifications` object to the response payload of `GET /api/fleet/orbit/config` that includes a `renew_enrollment_profile` field to indicate to fleetd that it needs to run a command on the device to renew the DEP enrollment profile.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1265,11 +1265,11 @@ func (ds *Datastore) LoadHostByOrbitNodeKey(ctx context.Context, nodeKey string)
       host_mdm hm
     ON
       hm.host_id = h.id
-		LEFT OUTER JOIN
-			mobile_device_management_solutions mdms
-		ON
+    LEFT OUTER JOIN
+    	mobile_device_management_solutions mdms
+    ON
       hm.mdm_id = mdms.id
-		WHERE
+    WHERE
       h.orbit_node_key = ?`
 
 	var hostWithMDM struct {

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -419,7 +419,7 @@ SELECT
       host_id = h.id
   ) AS additional,
   COALESCE(failing_policies.count, 0) AS failing_policies_count,
-  COALESCE(failing_policies.count, 0) AS total_issues_count 
+  COALESCE(failing_policies.count, 0) AS total_issues_count
   ` + hostMDMSelect + `
 FROM
   hosts h
@@ -483,9 +483,9 @@ const hostMDMSelect = `,
 		WHEN hmdm.enrolled = 0 AND hmdm.installed_from_dep = 0 THEN 'Off'
 		ELSE NULL
 	END AS mdm_enrollment_status,
-	CASE 
+	CASE
 		WHEN hmdm.is_server = 1 THEN NULL
-		ELSE hmdm.server_url 
+		ELSE hmdm.server_url
 	END as mdm_server_url
 	`
 
@@ -1211,11 +1211,78 @@ func (ds *Datastore) LoadHostByNodeKey(ctx context.Context, nodeKey string) (*fl
 // LoadHostByOrbitNodeKey loads the whole host identified by the node key.
 // If the node key is invalid it returns a NotFoundError.
 func (ds *Datastore) LoadHostByOrbitNodeKey(ctx context.Context, nodeKey string) (*fleet.Host, error) {
-	query := `SELECT * FROM hosts WHERE orbit_node_key = ?`
+	var hostWithMDM struct {
+		fleet.Host
+		fleet.HostMDM
+	}
+	query := `
+    SELECT
+      h.id,
+      h.osquery_host_id,
+      h.created_at,
+      h.updated_at,
+      h.detail_updated_at,
+      h.node_key,
+      h.hostname,
+      h.uuid,
+      h.platform,
+      h.osquery_version,
+      h.os_version,
+      h.build,
+      h.platform_like,
+      h.code_name,
+      h.uptime,
+      h.memory,
+      h.cpu_type,
+      h.cpu_subtype,
+      h.cpu_brand,
+      h.cpu_physical_cores,
+      h.cpu_logical_cores,
+      h.hardware_vendor,
+      h.hardware_model,
+      h.hardware_version,
+      h.hardware_serial,
+      h.computer_name,
+      h.primary_ip_id,
+      h.distributed_interval,
+      h.logger_tls_period,
+      h.config_tls_refresh,
+      h.primary_ip,
+      h.primary_mac,
+      h.label_updated_at,
+      h.last_enrolled_at,
+      h.refetch_requested,
+      h.team_id,
+      h.policy_updated_at,
+      h.public_ip,
+      h.orbit_node_key,
+      hm.host_id,
+      hm.enrolled,
+      hm.server_url,
+      hm.installed_from_dep,
+      hm.mdm_id,
+      hm.is_server,
+      COALESCE(mdms.name, ?) AS name
+    FROM
+      hosts h
+    LEFT OUTER JOIN
+      host_mdm hm
+    ON
+      hm.host_id = h.id
+		LEFT OUTER JOIN
+			mobile_device_management_solutions mdms
+		ON
+      hm.mdm_id = mdms.id
+		WHERE
+      h.orbit_node_key = ?`
 
-	var host fleet.Host
-	switch err := ds.getContextTryStmt(ctx, &host, query, nodeKey); {
+	switch err := ds.getContextTryStmt(ctx, &hostWithMDM, query, fleet.UnknownMDMName, nodeKey); {
 	case err == nil:
+		host := hostWithMDM.Host
+		// leave MDMInfo nil unless it has mdm information
+		if hostWithMDM.HostMDM.HostID == host.ID {
+			host.MDMInfo = &hostWithMDM.HostMDM
+		}
 		return &host, nil
 	case errors.Is(err, sql.ErrNoRows):
 		return nil, ctxerr.Wrap(ctx, notFound("Host"))
@@ -1498,7 +1565,7 @@ func (ds *Datastore) HostByIdentifier(ctx context.Context, identifier string) (*
       COALESCE(hd.gigs_disk_space_available, 0) as gigs_disk_space_available,
       COALESCE(hd.percent_disk_space_available, 0) as percent_disk_space_available,
       COALESCE(hst.seen_time, h.created_at) AS seen_time,
-	  COALESCE(hu.software_updated_at, h.created_at) AS software_updated_at 
+	  COALESCE(hu.software_updated_at, h.created_at) AS software_updated_at
 	  ` + hostMDMSelect + `
     FROM hosts h
     LEFT JOIN host_seen_times hst ON (h.id = hst.host_id)
@@ -2306,7 +2373,7 @@ func (ds *Datastore) GetHostMDMCheckinInfo(ctx context.Context, hostUUID string)
 	var hmdm fleet.HostMDMCheckinInfo
 	err := sqlx.GetContext(ctx, ds.reader, &hmdm, `
 		SELECT
-			h.hardware_serial, hm.installed_from_dep 
+			h.hardware_serial, hm.installed_from_dep
 		FROM
 			hosts h
 		JOIN

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1266,7 +1266,7 @@ func (ds *Datastore) LoadHostByOrbitNodeKey(ctx context.Context, nodeKey string)
     ON
       hm.host_id = h.id
     LEFT OUTER JOIN
-    	mobile_device_management_solutions mdms
+      mobile_device_management_solutions mdms
     ON
       hm.mdm_id = mdms.id
     WHERE

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -5960,7 +5960,7 @@ func testHostsLoadHostByOrbitNodeKey(t *testing.T, ds *Datastore) {
 	require.NotNil(t, loadSimple.MDMInfo)
 	require.Equal(t, hSimple.ID, loadSimple.MDMInfo.HostID)
 	require.True(t, loadSimple.IsOsqueryEnrolled())
-	require.False(t, loadSimple.MDMInfo.IsPendingFleetEnrollment())
+	require.False(t, loadSimple.MDMInfo.IsPendingDEPFleetEnrollment())
 
 	// create a host that will be pending enrollment in Fleet MDM
 	hFleet := createOrbitHost("fleet")
@@ -5973,5 +5973,5 @@ func testHostsLoadHostByOrbitNodeKey(t *testing.T, ds *Datastore) {
 	require.NotNil(t, loadFleet.MDMInfo)
 	require.Equal(t, hFleet.ID, loadFleet.MDMInfo.HostID)
 	require.True(t, loadFleet.IsOsqueryEnrolled())
-	require.True(t, loadFleet.MDMInfo.IsPendingFleetEnrollment())
+	require.True(t, loadFleet.MDMInfo.IsPendingDEPFleetEnrollment())
 }

--- a/server/fleet/agent_options.go
+++ b/server/fleet/agent_options.go
@@ -7,6 +7,13 @@ import (
 	"strings"
 )
 
+// OrbitConfigNotifications are notifications that the fleet server sends to
+// fleetd (orbit) so that it can run commands or more generally react to this
+// information.
+type OrbitConfigNotifications struct {
+	RenewEnrollmentProfile bool `json:"renew_enrollment_profile,omitempty"`
+}
+
 type AgentOptions struct {
 	// Config is the base config options.
 	Config json.RawMessage `json:"config"`

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -411,9 +411,10 @@ type HostMDM struct {
 	Name             string `db:"name" json:"-" csv:"-"`
 }
 
-// IsPendingFleetEnrollment returns true if the host's MDM information
-// indicates that it is in pending state for Fleet MDM enrollment.
-func (h *HostMDM) IsPendingFleetEnrollment() bool {
+// IsPendingDEPFleetEnrollment returns true if the host's MDM information
+// indicates that it is in pending state for Fleet MDM DEP (automatic)
+// enrollment.
+func (h *HostMDM) IsPendingDEPFleetEnrollment() bool {
 	if h == nil {
 		return false
 	}

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -207,10 +207,12 @@ type Host struct {
 	MDMEnrollmentStatus *string `json:"mdm_enrollment_status" db:"mdm_enrollment_status" csv:"mdm_enrollment_status"`
 	// MDMServerURL is the server_url stored in the host_mdm table, loaded by JOIN in datastore
 	MDMServerURL *string `json:"mdm_server_url" db:"mdm_server_url" csv:"mdm_server_url"`
-}
 
-// TODO(mna): rebase off of main once #9320 lands, as Sarah added the MDM
-// enrolment status in the host struct.
+	// MDMInfo stores the MDM information about the host. Note that as for many
+	// other host fields, it is not filled in by all host-returning datastore
+	// methods.
+	MDMInfo *HostMDM `json:"-" csv:"-"`
+}
 
 // IsOsqueryEnrolled returns true if the host is enrolled via osquery.
 func (h *Host) IsOsqueryEnrolled() bool {
@@ -400,13 +402,23 @@ type HostMunkiInfo struct {
 // used by a host. Note that it uses a different JSON representation than its
 // struct - it implements a custom JSON marshaler.
 type HostMDM struct {
-	HostID           uint   `db:"host_id" json:"-"`
-	Enrolled         bool   `db:"enrolled" json:"-"`
-	ServerURL        string `db:"server_url" json:"-"`
-	InstalledFromDep bool   `db:"installed_from_dep" json:"-"`
-	IsServer         bool   `db:"is_server" json:"-"`
-	MDMID            *uint  `db:"mdm_id" json:"-"`
-	Name             string `db:"name" json:"-"`
+	HostID           uint   `db:"host_id" json:"-" csv:"-"`
+	Enrolled         bool   `db:"enrolled" json:"-" csv:"-"`
+	ServerURL        string `db:"server_url" json:"-" csv:"-"`
+	InstalledFromDep bool   `db:"installed_from_dep" json:"-" csv:"-"`
+	IsServer         bool   `db:"is_server" json:"-" csv:"-"`
+	MDMID            *uint  `db:"mdm_id" json:"-" csv:"-"`
+	Name             string `db:"name" json:"-" csv:"-"`
+}
+
+// IsPendingFleetEnrollment returns true if the host's MDM information
+// indicates that it is in pending state for Fleet MDM enrollment.
+func (h *HostMDM) IsPendingFleetEnrollment() bool {
+	if h == nil {
+		return false
+	}
+	return (!h.IsServer) && (!h.Enrolled) && h.InstalledFromDep &&
+		h.Name == WellKnownMDMFleet
 }
 
 // HostMunkiIssue represents a single munki issue for a host.

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -209,6 +209,14 @@ type Host struct {
 	MDMServerURL *string `json:"mdm_server_url" db:"mdm_server_url" csv:"mdm_server_url"`
 }
 
+// TODO(mna): rebase off of main once #9320 lands, as Sarah added the MDM
+// enrolment status in the host struct.
+
+// IsOsqueryEnrolled returns true if the host is enrolled via osquery.
+func (h *Host) IsOsqueryEnrolled() bool {
+	return h.OsqueryHostID != nil && *h.OsqueryHostID != ""
+}
+
 // DisplayName returns ComputerName if it isn't empty. Otherwise, it returns Hostname if it isn't
 // empty. If Hostname is empty and both HardwareSerial and HardwareModel are not empty, it returns a
 // composite string with HardwareModel and HardwareSerial. If all else fails, it returns an empty

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -54,8 +54,11 @@ type Service interface {
 	AuthenticateOrbitHost(ctx context.Context, nodeKey string) (host *Host, debug bool, err error)
 	// EnrollOrbit enrolls orbit to Fleet by using the enrollSecret and returns the orbitNodeKey if successful
 	EnrollOrbit(ctx context.Context, hardwareUUID string, enrollSecret string) (orbitNodeKey string, err error)
-	// GetOrbitConfig returns team specific flags and extensions in agent options if the team id is not nil for host, otherwise it returns flags from global agent options
-	GetOrbitConfig(ctx context.Context) (flags json.RawMessage, extensions json.RawMessage, err error)
+	// GetOrbitConfig returns team specific flags and extensions in agent options
+	// if the team id is not nil for host, otherwise it returns flags from global
+	// agent options. It also returns any notifications that fleet wants to surface
+	// to fleetd (formerly orbit).
+	GetOrbitConfig(ctx context.Context) (flags json.RawMessage, extensions json.RawMessage, notifications OrbitConfigNotifications, err error)
 
 	// SetOrUpdateDeviceAuthToken creates or updates a device auth token for the given host.
 	SetOrUpdateDeviceAuthToken(ctx context.Context, authToken string) error

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -6278,6 +6278,7 @@ func createOrbitEnrolledHost(t *testing.T, os, suffix string, ds fleet.Datastore
 	require.NoError(t, err)
 	orbitKey := uuid.New().String()
 	_, err = ds.EnrollOrbit(context.Background(), *h.OsqueryHostID, orbitKey, nil)
+	require.NoError(t, err)
 	h.OrbitNodeKey = &orbitKey
 	return h
 }

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -6190,6 +6190,40 @@ func (s *integrationTestSuite) TestAppleMDMNotConfigured() {
 	s.DoJSON("GET", "/api/latest/fleet/mdm/apple", nil, http.StatusNotFound, &resp)
 }
 
+func (s *integrationTestSuite) TestOrbitConfigNotifications() {
+	t := s.T()
+
+	var resp orbitGetConfigResponse
+	// missing orbit key
+	s.DoJSON("POST", "/api/fleet/orbit/config", nil, http.StatusUnauthorized, &resp)
+
+	hNoMDM := createOrbitEnrolledHost(t, "darwin", "nomdm", s.ds)
+	resp = orbitGetConfigResponse{}
+	s.DoJSON("POST", "/api/fleet/orbit/config", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *hNoMDM.OrbitNodeKey)), http.StatusOK, &resp)
+	require.False(t, resp.Notifications.RenewEnrollmentProfile)
+
+	hSimpleMDM := createOrbitEnrolledHost(t, "darwin", "simplemdm", s.ds)
+	err := s.ds.SetOrUpdateMDMData(context.Background(), hSimpleMDM.ID, false, true, "https://simplemdm.com", false, fleet.WellKnownMDMSimpleMDM)
+	require.NoError(t, err)
+	resp = orbitGetConfigResponse{}
+	s.DoJSON("POST", "/api/fleet/orbit/config", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *hSimpleMDM.OrbitNodeKey)), http.StatusOK, &resp)
+	require.False(t, resp.Notifications.RenewEnrollmentProfile)
+
+	hFleetMDM := createOrbitEnrolledHost(t, "darwin", "fleetmdm", s.ds)
+	err = s.ds.SetOrUpdateMDMData(context.Background(), hFleetMDM.ID, false, false, "https://fleetdm.com", true, fleet.WellKnownMDMFleet)
+	require.NoError(t, err)
+	resp = orbitGetConfigResponse{}
+	s.DoJSON("POST", "/api/fleet/orbit/config", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *hFleetMDM.OrbitNodeKey)), http.StatusOK, &resp)
+	require.True(t, resp.Notifications.RenewEnrollmentProfile)
+
+	// if the fleet mdm host is fully enrolled (not pending anymore), then the notification is false
+	err = s.ds.SetOrUpdateMDMData(context.Background(), hFleetMDM.ID, false, true, "https://fleetdm.com", true, fleet.WellKnownMDMFleet)
+	require.NoError(t, err)
+	resp = orbitGetConfigResponse{}
+	s.DoJSON("POST", "/api/fleet/orbit/config", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *hFleetMDM.OrbitNodeKey)), http.StatusOK, &resp)
+	require.False(t, resp.Notifications.RenewEnrollmentProfile)
+}
+
 // this test can be deleted once the "v1" version is removed.
 func (s *integrationTestSuite) TestAPIVersion_v1_2022_04() {
 	t := s.T()
@@ -6226,6 +6260,26 @@ func (s *integrationTestSuite) TestAPIVersion_v1_2022_04() {
 	// properly delete with old endpoint and old version
 	var delResp deleteGlobalScheduleResponse
 	s.DoJSON("DELETE", fmt.Sprintf("/api/v1/fleet/global/schedule/%d", createResp.Scheduled.ID), nil, http.StatusOK, &delResp)
+}
+
+func createOrbitEnrolledHost(t *testing.T, os, suffix string, ds fleet.Datastore) *fleet.Host {
+	name := t.Name() + suffix
+	h, err := ds.NewHost(context.Background(), &fleet.Host{
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now().Add(-time.Minute),
+		OsqueryHostID:   ptr.String(name),
+		NodeKey:         ptr.String(name),
+		UUID:            uuid.New().String(),
+		Hostname:        fmt.Sprintf("%s.local", name),
+		Platform:        os,
+	})
+	require.NoError(t, err)
+	orbitKey := uuid.New().String()
+	_, err = ds.EnrollOrbit(context.Background(), *h.OsqueryHostID, orbitKey, nil)
+	h.OrbitNodeKey = &orbitKey
+	return h
 }
 
 // creates a session and returns it, its key is to be passed as authorization header.

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -143,6 +143,11 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (flags json.RawMessage, 
 		return nil, nil, notifs, orbitError{message: "internal error: missing host from request context"}
 	}
 
+	// set the host's orbit notifications
+	if host.IsOsqueryEnrolled() && host.IsPendingFleetMDMEnrolment() {
+		notifs.RenewEnrollmentProfile = true
+	}
+
 	// team ID is not nil, get team specific flags and options
 	if host.TeamID != nil {
 		teamAgentOptions, err := svc.ds.TeamAgentOptions(ctx, *host.TeamID)

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -144,7 +144,7 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (flags json.RawMessage, 
 	}
 
 	// set the host's orbit notifications
-	if host.IsOsqueryEnrolled() && host.MDMInfo.IsPendingFleetEnrollment() {
+	if host.IsOsqueryEnrolled() && host.MDMInfo.IsPendingDEPFleetEnrollment() {
 		notifs.RenewEnrollmentProfile = true
 	}
 

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -44,9 +44,10 @@ func (r *orbitGetConfigRequest) orbitHostNodeKey() string {
 }
 
 type orbitGetConfigResponse struct {
-	Flags      json.RawMessage `json:"command_line_startup_flags,omitempty"`
-	Extensions json.RawMessage `json:"extensions,omitempty"`
-	Err        error           `json:"error,omitempty"`
+	Flags         json.RawMessage                `json:"command_line_startup_flags,omitempty"`
+	Extensions    json.RawMessage                `json:"extensions,omitempty"`
+	Notifications fleet.OrbitConfigNotifications `json:"notifications,omitempty"`
+	Err           error                          `json:"error,omitempty"`
 }
 
 func (r orbitGetConfigResponse) error() error { return r.Err }
@@ -124,50 +125,52 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hardwareUUID string, enroll
 }
 
 func getOrbitConfigEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
-	opts, extensions, err := svc.GetOrbitConfig(ctx)
+	flags, extensions, notifs, err := svc.GetOrbitConfig(ctx)
 	if err != nil {
 		return orbitGetConfigResponse{Err: err}, nil
 	}
-	return orbitGetConfigResponse{Flags: opts, Extensions: extensions}, nil
+	return orbitGetConfigResponse{Flags: flags, Extensions: extensions, Notifications: notifs}, nil
 }
 
-func (svc *Service) GetOrbitConfig(ctx context.Context) (json.RawMessage, json.RawMessage, error) {
+func (svc *Service) GetOrbitConfig(ctx context.Context) (flags json.RawMessage, extensions json.RawMessage, notifications fleet.OrbitConfigNotifications, err error) {
 	// this is not a user-authenticated endpoint
 	svc.authz.SkipAuthorization(ctx)
 
+	var notifs fleet.OrbitConfigNotifications
+
 	host, ok := hostctx.FromContext(ctx)
 	if !ok {
-		return nil, nil, orbitError{message: "internal error: missing host from request context"}
+		return nil, nil, notifs, orbitError{message: "internal error: missing host from request context"}
 	}
 
 	// team ID is not nil, get team specific flags and options
 	if host.TeamID != nil {
 		teamAgentOptions, err := svc.ds.TeamAgentOptions(ctx, *host.TeamID)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, notifs, err
 		}
 
 		if teamAgentOptions != nil && len(*teamAgentOptions) > 0 {
 			var opts fleet.AgentOptions
 			if err := json.Unmarshal(*teamAgentOptions, &opts); err != nil {
-				return nil, nil, err
+				return nil, nil, notifs, err
 			}
-			return opts.CommandLineStartUpFlags, opts.Extensions, nil
+			return opts.CommandLineStartUpFlags, opts.Extensions, notifs, nil
 		}
 	}
 
 	// team ID is nil, get global flags and options
 	config, err := svc.ds.AppConfig(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, notifs, err
 	}
 	var opts fleet.AgentOptions
 	if config.AgentOptions != nil {
 		if err := json.Unmarshal(*config.AgentOptions, &opts); err != nil {
-			return nil, nil, err
+			return nil, nil, notifs, err
 		}
 	}
-	return opts.CommandLineStartUpFlags, opts.Extensions, nil
+	return opts.CommandLineStartUpFlags, opts.Extensions, notifs, nil
 }
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -144,7 +144,7 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (flags json.RawMessage, 
 	}
 
 	// set the host's orbit notifications
-	if host.IsOsqueryEnrolled() && host.IsPendingFleetMDMEnrolment() {
+	if host.IsOsqueryEnrolled() && host.MDMInfo.IsPendingFleetEnrollment() {
 		notifs.RenewEnrollmentProfile = true
 	}
 

--- a/server/service/orbit_client.go
+++ b/server/service/orbit_client.go
@@ -97,6 +97,9 @@ type OrbitConfig struct {
 	Flags json.RawMessage
 	// Extensions holds the orbit managed extensions
 	Extensions json.RawMessage
+	// Notifications holds the notifications that the fleet server sends to
+	// the orbit instance (fleetd).
+	Notifications fleet.OrbitConfigNotifications
 }
 
 // GetConfig returns the Orbit config fetched from Fleet server for this instance of OrbitClient.
@@ -107,8 +110,9 @@ func (oc *OrbitClient) GetConfig() (*OrbitConfig, error) {
 		return nil, err
 	}
 	return &OrbitConfig{
-		Flags:      resp.Flags,
-		Extensions: resp.Extensions,
+		Flags:         resp.Flags,
+		Extensions:    resp.Extensions,
+		Notifications: resp.Notifications,
 	}, nil
 }
 


### PR DESCRIPTION
#9277 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
