### PR TITLE
Fleet UI CX Customer Request: UUID tooltip

### DIFF
--- a/changes/9199-uuid-hoverable
+++ b/changes/9199-uuid-hoverable
@@ -1,0 +1,1 @@
+- User can hover over host UUID to see and copy full ID string

--- a/frontend/components/TableContainer/DataTable/TruncatedTextCell/TruncatedTextCell.tsx
+++ b/frontend/components/TableContainer/DataTable/TruncatedTextCell/TruncatedTextCell.tsx
@@ -46,7 +46,7 @@ const TruncatedTextCell = ({
         </span>
       </div>
       <ReactTooltip
-        place="bottom"
+        place="top"
         effect="solid"
         backgroundColor="#3e4771"
         id={tooltipId}

--- a/frontend/components/TableContainer/DataTable/TruncatedTextCell/TruncatedTextCell.tsx
+++ b/frontend/components/TableContainer/DataTable/TruncatedTextCell/TruncatedTextCell.tsx
@@ -52,6 +52,8 @@ const TruncatedTextCell = ({
         id={tooltipId}
         data-html
         className={"truncated-tooltip"} // responsive widths
+        clickable
+        delayHide={200} // need delay set to hover using clickable
       >
         {value}
       </ReactTooltip>

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -13,6 +13,7 @@ import IssueCell from "components/TableContainer/DataTable/IssueCell/IssueCell";
 import LinkCell from "components/TableContainer/DataTable/LinkCell/LinkCell";
 import StatusIndicator from "components/StatusIndicator";
 import TextCell from "components/TableContainer/DataTable/TextCell/TextCell";
+import TruncatedTextCell from "components/TableContainer/DataTable/TruncatedTextCell";
 import TooltipWrapper from "components/TooltipWrapper";
 import HumanTimeDiffWithDateTip from "components/HumanTimeDiffWithDateTip";
 import {
@@ -402,7 +403,9 @@ const allHostTableHeaders: IDataColumn[] = [
       />
     ),
     accessor: "uuid",
-    Cell: (cellProps: ICellProps) => <TextCell value={cellProps.cell.value} />,
+    Cell: (cellProps: ICellProps) => (
+      <TruncatedTextCell value={cellProps.cell.value} />
+    ),
   },
   {
     title: "Last restarted",


### PR DESCRIPTION
### Issue
Cerra #9199 

### Fix
- Make UUID cell have tooltip to see full UUID
- Make Truncated text cells have tooltips that are hoverable so you can copy the text within the tooltip

### Screenshot (outdated, now tooltip is above)
<img width="1624" alt="Screenshot 2023-01-17 at 4 42 54 PM" src="https://user-images.githubusercontent.com/71795832/213019333-f6b36de4-6c23-4e1a-a6aa-b27599dd4ad5.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
