### PR TITLE
Fleet UI CX: Add license expiration to user settings page

### DIFF
--- a/changes/9370-license-expiry
+++ b/changes/9370-license-expiry
@@ -1,0 +1,1 @@
+- Add license expiry to account information page for premium users

--- a/frontend/pages/UserSettingsPage/UserSidePanel/UserSidePanel.tsx
+++ b/frontend/pages/UserSettingsPage/UserSidePanel/UserSidePanel.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useEffect, useState } from "react";
-import { intlFormat } from "date-fns";
 
 import { IUser } from "interfaces/user";
 import { IVersionData } from "interfaces/version";

--- a/frontend/pages/UserSettingsPage/UserSidePanel/UserSidePanel.tsx
+++ b/frontend/pages/UserSettingsPage/UserSidePanel/UserSidePanel.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
+import { intlFormat } from "date-fns";
 
 import { IUser } from "interfaces/user";
 import { IVersionData } from "interfaces/version";
@@ -11,7 +12,12 @@ import Avatar from "components/Avatar";
 import Button from "components/buttons/Button";
 import HumanTimeDiffWithDateTip from "components/HumanTimeDiffWithDateTip";
 
-import { generateRole, generateTeam, greyCell } from "utilities/helpers";
+import {
+  generateRole,
+  generateTeam,
+  greyCell,
+  readableDate,
+} from "utilities/helpers";
 
 interface IUserSidePanelProps {
   currentUser: IUser;
@@ -26,7 +32,7 @@ const UserSidePanel = ({
   onChangePassword,
   onGetApiToken,
 }: IUserSidePanelProps): JSX.Element => {
-  const { isPremiumTier } = useContext(AppContext);
+  const { isPremiumTier, config } = useContext(AppContext);
   const [versionData, setVersionData] = useState<IVersionData>();
 
   useEffect(() => {
@@ -91,6 +97,16 @@ const UserSidePanel = ({
           {roleText}
         </p>
       </div>
+      {isPremiumTier && config && (
+        <div className={`${baseClass}__more-info-detail`}>
+          <p className={`${baseClass}__header`}>License expiration date</p>
+          <p
+            className={`${baseClass}__description ${baseClass}__license-expiration`}
+          >
+            {readableDate(config.license.expiration)}
+          </p>
+        </div>
+      )}
       <div className={`${baseClass}__more-info-detail`}>
         <p className={`${baseClass}__header`}>Password</p>
       </div>

--- a/frontend/pages/admin/IntegrationsPage/cards/Mdm/Mdm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Mdm/Mdm.tsx
@@ -15,6 +15,7 @@ import Spinner from "components/Spinner";
 import DataError from "components/DataError";
 import Icon from "components/Icon";
 import TooltipWrapper from "components/TooltipWrapper";
+import { readableDate } from "utilities/helpers";
 
 import RequestCSRModal from "./components/RequestCSRModal";
 import EditTeamModal from "./components/EditTeamModal";
@@ -23,16 +24,6 @@ import EditTeamModal from "./components/EditTeamModal";
 // import { isValidKeys } from "../../..";
 
 const baseClass = "mdm-integrations";
-
-const readableDate = (date: string) => {
-  const dateString = new Date(date);
-
-  return new Intl.DateTimeFormat(navigator.language, {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  }).format(dateString);
-};
 
 const Mdm = (): JSX.Element => {
   const { isPremiumTier } = useContext(AppContext);

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -683,6 +683,16 @@ export const licenseExpirationWarning = (expiration: string): boolean => {
   return isAfter(new Date(), new Date(expiration));
 };
 
+export const readableDate = (date: string) => {
+  const dateString = new Date(date);
+
+  return new Intl.DateTimeFormat(navigator.language, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(dateString);
+};
+
 export const performanceIndicator = (
   scheduledQueryStats: IScheduledQueryStats
 ): string => {
@@ -850,6 +860,7 @@ export default {
   humanQueryLastRun,
   inMilliseconds,
   licenseExpirationWarning,
+  readableDate,
   secondsToHms,
   secondsToDhms,
   labelSlug,


### PR DESCRIPTION
## Issue
Cerra #9370 

## Feature
- Add license expiry to side panel of user setting page

## Screenshot
<img width="1477" alt="Screenshot 2023-01-18 at 9 58 34 AM" src="https://user-images.githubusercontent.com/71795832/213205674-51055367-a895-422c-99c0-91f1c0d63801.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
