### PR TITLE
Fleet UI CX: Remove bulky tooltip overflowing if host table is only 1 row

### DIFF
--- a/changes/9364-bulky-tooltip-overflow
+++ b/changes/9364-bulky-tooltip-overflow
@@ -1,0 +1,1 @@
+- When table only has 1 host, remove bulky tooltip overflow

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -200,7 +200,6 @@ const allHostTableHeaders: IDataColumn[] = [
   {
     title: "Status",
     Header: (headerProps: IHeaderProps): JSX.Element => {
-      console.log("headerProps", headerProps);
       const titleWithToolTip = (
         <TooltipWrapper
           tipContent={`

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -36,6 +36,12 @@ interface IGetToggleAllRowsSelectedProps {
   onChange: () => void;
   style: { cursor: string };
 }
+
+interface IRow {
+  original: IHost;
+  getToggleRowSelectedProps: () => IGetToggleAllRowsSelectedProps;
+  toggleRowSelected: () => void;
+}
 interface IHeaderProps {
   column: {
     title: string;
@@ -43,17 +49,14 @@ interface IHeaderProps {
   };
   getToggleAllRowsSelectedProps: () => IGetToggleAllRowsSelectedProps;
   toggleAllRowsSelected: () => void;
+  rows: IRow[];
 }
 
 interface ICellProps {
   cell: {
     value: string;
   };
-  row: {
-    original: IHost;
-    getToggleRowSelectedProps: () => IGetToggleAllRowsSelectedProps;
-    toggleRowSelected: () => void;
-  };
+  row: IRow;
 }
 
 interface INumberCellProps {
@@ -197,6 +200,7 @@ const allHostTableHeaders: IDataColumn[] = [
   {
     title: "Status",
     Header: (headerProps: IHeaderProps): JSX.Element => {
+      console.log("headerProps", headerProps);
       const titleWithToolTip = (
         <TooltipWrapper
           tipContent={`
@@ -208,7 +212,12 @@ const allHostTableHeaders: IDataColumn[] = [
           Status
         </TooltipWrapper>
       );
-      return <HeaderCell value={titleWithToolTip} disableSortBy />;
+      return (
+        <HeaderCell
+          value={headerProps.rows.length === 1 ? "Status" : titleWithToolTip}
+          disableSortBy
+        />
+      );
     },
     disableSortBy: true,
     accessor: "status",
@@ -503,7 +512,7 @@ const defaultHiddenColumns = [
 const generateAvailableTableHeaders = (
   config: IConfig,
   currentUser: IUser,
-  currentTeam: ITeamSummary | undefined
+  currentTeam?: ITeamSummary
 ): IDataColumn[] => {
   return allHostTableHeaders.reduce(
     (columns: Column[], currentColumn: Column) => {
@@ -553,7 +562,7 @@ const generateVisibleTableColumns = (
   hiddenColumns: string[],
   config: IConfig,
   currentUser: IUser,
-  currentTeam: ITeamSummary | undefined
+  currentTeam?: ITeamSummary
 ): IDataColumn[] => {
   // remove columns set as hidden by the user.
   return generateAvailableTableHeaders(config, currentUser, currentTeam).filter(

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -91,9 +91,9 @@ const getTooltip = (osqueryPolicyMs: number): JSX.Element => {
 // NOTE: cellProps come from react-table
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
 const generateTableHeaders = (options: {
-  selectedTeamId: number | undefined | null;
-  canAddOrDeletePolicy: boolean | undefined;
-  tableType: string | undefined;
+  selectedTeamId?: number | null;
+  canAddOrDeletePolicy?: boolean;
+  tableType?: string;
 }): IDataColumn[] => {
   const { selectedTeamId, tableType, canAddOrDeletePolicy } = options;
 


### PR DESCRIPTION
### Issue
Cerra #9364 

### Fix
- Status header tooltip goes pass 1 row in height so it needs to overflow or be removed so it won't be cut off when there's only 1 row in the table
- Cannot overflow-y: visible and overflow-x: scroll because setting overflow-x to scroll will always overrides overflow y to auto which causes the cut (top answer of https://stackoverflow.com/questions/6421966/css-overflow-x-visible-and-overflow-y-hidden-causing-scrollbar-issue)
- Remove tooltip with only 1 row in table

### Screenshots
Still has tooltip on hovering on the row online/offline status
<img width="1341" alt="Screenshot 2023-01-18 at 10 40 15 AM" src="https://user-images.githubusercontent.com/71795832/213219700-51c46646-bd02-4d4a-8719-89bad7111fbc.png">
No tooltip on the header status when only 1 row
<img width="1329" alt="Screenshot 2023-01-18 at 10 40 04 AM" src="https://user-images.githubusercontent.com/71795832/213219703-ef83a65b-66d4-4469-8314-f9cbe2eae69c.png">
Underline/tooltip shows when table has more than 1 row
<img width="1031" alt="Screenshot 2023-01-18 at 10 39 48 AM" src="https://user-images.githubusercontent.com/71795832/213219706-1b0bf236-db4f-4ae4-b703-88e009b85e02.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality