### PR TITLE
Website: Update Fleet Sandbox redirect

### DIFF
--- a/website/api/controllers/try-fleet/view-sandbox-teleporter-or-redirect-because-expired.js
+++ b/website/api/controllers/try-fleet/view-sandbox-teleporter-or-redirect-because-expired.js
@@ -44,11 +44,8 @@ module.exports = {
     if(!this.req.me.fleetSandboxDemoKey) {
       throw new Error(`Consistency violation: The logged-in user's (${this.req.me.emailAddress}) fleetSandboxDemoKey has somehow gone missing!`);
     }
+    // Note: If this user's Fleet Sandbox instance is expired, they will be redirected to the sandbox-expired page by the Fleet Sandbox server.
 
-    // If this user's Fleet Sandbox instance is expired, we'll redirect them to the sandbox-expired page
-    if(this.req.me.fleetSandboxExpiresAt < Date.now()){
-      throw {redirect: '/try-fleet/sandbox-expired' };
-    }
 
     // Respond with view.
     return {

--- a/website/api/controllers/try-fleet/view-sandbox-teleporter.js
+++ b/website/api/controllers/try-fleet/view-sandbox-teleporter.js
@@ -1,13 +1,12 @@
 module.exports = {
 
 
-  friendlyName: 'View sandbox teleporter or redirect because sandbox expired',
+  friendlyName: 'View sandbox teleporter',
 
   description:
     `Display "Sandbox teleporter" page (an auto-submitting interstitial HTML form used as a hack to grab a bit of HTML
     from the Fleet Sandbox instance, which sets browser localstorage to consider this user logged in and "teleports" them,
-    magically authenticated, into their Fleet Sandbox instance running on a different domain), or redirect the user to
-    a page about their sandbox instance being expired.`,
+    magically authenticated, into their Fleet Sandbox instance running on a different domain)`,
 
   moreInfoUrl: 'https://github.com/fleetdm/fleet/pull/6380',
 

--- a/website/config/policies.js
+++ b/website/config/policies.js
@@ -40,7 +40,7 @@ module.exports.policies = {
   'view-sales-one-pager': true,
   'try-fleet/view-register': true,
   'try-fleet/view-sandbox-login': true,
-  'try-fleet/view-sandbox-teleporter-or-redirect-because-expired': true,
+  'try-fleet/view-sandbox-teleporter': true,
   'create-or-update-one-newsletter-subscription': true,
   'unsubscribe-from-all-newsletters': true,
   'view-osquery-table-details': true,

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -195,7 +195,7 @@ module.exports.routes = {
   },
 
   'GET /try-fleet/sandbox': {
-    action: 'try-fleet/view-sandbox-teleporter-or-redirect-because-expired',
+    action: 'try-fleet/view-sandbox-teleporter',
     locals: {
       layout: 'layouts/layout-sandbox',
     },


### PR DESCRIPTION
Closes: #9367

Changes:
- Renamed `view-sandbox-teleporter-or-redirect-because-expired` to `view-sandbox-teleporter`
- Updated routes, and policies
- Removed the `/try-fleet/sandbox-expired` redirect from `view-sandbox-teleporter`. The Fleet sandbox server already redirects users with expired sandbox instances to the `sandbox-expired` page