### PR TITLE
Handbook: Update bug process

### DIFF
--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -755,7 +755,7 @@ To start a preview without starting the simulated hosts, use the `--no-hosts` fl
 
 For each bug found, please use the [bug report template](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=bug%2C%3Areproduce&template=bug-report.md&title=) to create a new bug report issue.
 
-For unreleased bugs in an active sprint, no bug report issue is created. Instead, QA moves the associated story (ignoring any technical sub-task issues) back to the "In progress" column in the appropriate project board. Fixing the bug becomes part of the story.
+For unreleased bugs in an active sprint, no bug report issue is created. Instead, QA moves the associated story (ignoring any technical sub-task issues) back to the "In progress" column in the appropriate project board and assigns the [engineering manager (EM)](../company/development-groups#current-product-groups). QA adds comments about the back or lack of expected functionality that was found. Fixing the bug becomes part of the story.
 
 ### Bug process
 
@@ -790,7 +790,7 @@ If the inbox item is a bug, QA should apply the acknowledged state to the bug. Q
 Once reproduced, QA should document the reproduction steps and move it to the reproduced state.
 
 #### Reproduced
-When reproduced, the bug is assigned to the appropriate [engineering manager (EM)](../company/development-groups#current-product-groups) and added to the product backlog. The EM is responsible for investigating the root cause of the bug and proposing solutions to their product counterpart if it requires discussion. Otherwise, the EM includes it in this release (if there's space) or the next release.
+When reproduced, the bug is assigned to the appropriate EM and added to the product backlog. The EM is responsible for investigating the root cause of the bug and proposing solutions to their product counterpart if it requires discussion. Otherwise, the EM includes it in this release (if there's space) or the next release.
 
 #### After reproduced
 After it's in a release formally, the bug should be treated like any other piece of work per the standard engineering process.


### PR DESCRIPTION
- For unreleased bugs, clarify that QA adds comments about the bug
- For unreleased bugs, clarify that QA assigns the story to the EM

Addresses these comments: 
- https://github.com/fleetdm/fleet/pull/9363#discussion_r1073776173
- https://github.com/fleetdm/fleet/pull/9363#discussion_r1074043031
