### PR TITLE
omit actor information from activities if not present

### DIFF
--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -432,10 +432,10 @@ func (a ActivityTypeUserAddedBySSO) Documentation() (activity string, details st
 type Activity struct {
 	CreateTimestamp
 	ID            uint             `json:"id" db:"id"`
-	ActorFullName *string          `json:"actor_full_name" db:"name"`
-	ActorID       *uint            `json:"actor_id" db:"user_id"`
-	ActorGravatar *string          `json:"actor_gravatar" db:"gravatar_url"`
-	ActorEmail    *string          `json:"actor_email" db:"email"`
+	ActorFullName *string          `json:"actor_full_name,omitempty" db:"name"`
+	ActorID       *uint            `json:"actor_id,omitempty" db:"user_id"`
+	ActorGravatar *string          `json:"actor_gravatar,omitempty" db:"gravatar_url"`
+	ActorEmail    *string          `json:"actor_email,omitempty" db:"email"`
 	Type          string           `json:"type" db:"activity_type"`
 	Details       *json.RawMessage `json:"details" db:"details"`
 	Streamed      *bool            `json:"-" db:"streamed"`


### PR DESCRIPTION
This is a follow up from #9127 in order to completely omit those fields from the response instead of returning `null` in order to be consistent with how the API generally works.