### PR TITLE
Fleet UI: Remove packs, comment out frontend packs tests

### DIFF
--- a/cypress/integration/all/app/packflow.spec.ts
+++ b/cypress/integration/all/app/packflow.spec.ts
@@ -1,91 +1,92 @@
-// NOTE: Product decision to remove packs from UI
+/* NOTE: Product decision to remove packs from UI
 
-// import managePacksPage from "../../pages/managePacksPage";
+import managePacksPage from "../../pages/managePacksPage";
 
-// describe("Pack flow (empty)", () => {
-//   before(() => {
-//     Cypress.session.clearAllSavedSessions();
-//     cy.setup();
-//     cy.loginWithCySession();
-//     cy.viewport(1200, 660);
-//   });
-//   after(() => {
-//     cy.logout();
-//   });
+describe("Pack flow (empty)", () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions();
+    cy.setup();
+    cy.loginWithCySession();
+    cy.viewport(1200, 660);
+  });
+  after(() => {
+    cy.logout();
+  });
 
-//   describe("Manage packs page", () => {
-//     beforeEach(() => {
-//       cy.loginWithCySession();
-//       managePacksPage.visitsManagePacksPage();
-//     });
-//     it("creates a new pack", () => {
-//       managePacksPage.allowsCreatePack();
-//       managePacksPage.verifiesCreatedPack();
-//     });
-//   });
-// });
-// describe("Pack flow (seeded)", () => {
-//   before(() => {
-//     Cypress.session.clearAllSavedSessions();
-//     cy.setup();
-//     cy.loginWithCySession();
-//     cy.seedQueries();
-//     cy.seedPacks();
-//     cy.viewport(1200, 660);
-//   });
-//   after(() => {
-//     cy.logout();
-//   });
+  describe("Manage packs page", () => {
+    beforeEach(() => {
+      cy.loginWithCySession();
+      managePacksPage.visitsManagePacksPage();
+    });
+    it("creates a new pack", () => {
+      managePacksPage.allowsCreatePack();
+      managePacksPage.verifiesCreatedPack();
+    });
+  });
+});
+describe("Pack flow (seeded)", () => {
+  before(() => {
+    Cypress.session.clearAllSavedSessions();
+    cy.setup();
+    cy.loginWithCySession();
+    cy.seedQueries();
+    cy.seedPacks();
+    cy.viewport(1200, 660);
+  });
+  after(() => {
+    cy.logout();
+  });
 
-//   describe("Pack details page", () => {
-//     beforeEach(() => {
-//       cy.loginWithCySession();
-//       managePacksPage.visitsManagePacksPage();
-//       cy.getAttached(".name__cell > .button--text-link").first().click();
-//     });
-//     it("adds a query to an existing pack", () => {
-//       cy.findByRole("button", { name: /add query/i }).click();
-//       cy.findByText(/select query/i).click();
-//       cy.findByText(/get authorized/i).click();
-//       cy.getAttached(
-//         ".pack-query-editor-modal__form-field--frequency > .input-field"
-//       )
-//         .click()
-//         .type("3600");
-//       cy.getAttached(
-//         ".pack-query-editor-modal__form-field--osquer-vers > .Select"
-//       ).click();
-//       cy.findByText(/4.7/i).click();
-//       cy.getAttached(
-//         ".pack-query-editor-modal__form-field--shard > .input-field"
-//       )
-//         .click()
-//         .type("50");
-//       cy.getAttached(".pack-query-editor-modal .modal-cta-wrap")
-//         .contains("button", /add query/i)
-//         .click();
-//       cy.findByText(/get authorized/i).should("exist");
-//     });
-//     it("removes a query from an existing pack", () => {
-//       cy.getAttached(".fleet-checkbox__input").check({ force: true });
-//       cy.findByRole("button", { name: /remove/i }).click();
-//       cy.getAttached(".remove-pack-query-modal .modal-cta-wrap")
-//         .contains("button", /remove/i)
-//         .click();
-//     });
-//     it("edits an existing pack", () => {
-//       managePacksPage.allowsEditPack();
-//       managePacksPage.verifiesEditedPack();
-//     });
-//   });
-//   describe("Manage packs page", () => {
-//     beforeEach(() => {
-//       cy.loginWithCySession();
-//       managePacksPage.visitsManagePacksPage();
-//     });
-//     it("deletes an existing pack", () => {
-//       managePacksPage.allowsDeletePack();
-//       managePacksPage.verifiesDeletedPack();
-//     });
-//   });
-// });
+  describe("Pack details page", () => {
+    beforeEach(() => {
+      cy.loginWithCySession();
+      managePacksPage.visitsManagePacksPage();
+      cy.getAttached(".name__cell > .button--text-link").first().click();
+    });
+    it("adds a query to an existing pack", () => {
+      cy.findByRole("button", { name: /add query/i }).click();
+      cy.findByText(/select query/i).click();
+      cy.findByText(/get authorized/i).click();
+      cy.getAttached(
+        ".pack-query-editor-modal__form-field--frequency > .input-field"
+      )
+        .click()
+        .type("3600");
+      cy.getAttached(
+        ".pack-query-editor-modal__form-field--osquer-vers > .Select"
+      ).click();
+      cy.findByText(/4.7/i).click();
+      cy.getAttached(
+        ".pack-query-editor-modal__form-field--shard > .input-field"
+      )
+        .click()
+        .type("50");
+      cy.getAttached(".pack-query-editor-modal .modal-cta-wrap")
+        .contains("button", /add query/i)
+        .click();
+      cy.findByText(/get authorized/i).should("exist");
+    });
+    it("removes a query from an existing pack", () => {
+      cy.getAttached(".fleet-checkbox__input").check({ force: true });
+      cy.findByRole("button", { name: /remove/i }).click();
+      cy.getAttached(".remove-pack-query-modal .modal-cta-wrap")
+        .contains("button", /remove/i)
+        .click();
+    });
+    it("edits an existing pack", () => {
+      managePacksPage.allowsEditPack();
+      managePacksPage.verifiesEditedPack();
+    });
+  });
+  describe("Manage packs page", () => {
+    beforeEach(() => {
+      cy.loginWithCySession();
+      managePacksPage.visitsManagePacksPage();
+    });
+    it("deletes an existing pack", () => {
+      managePacksPage.allowsDeletePack();
+      managePacksPage.verifiesDeletedPack();
+    });
+  });
+});
+*/

--- a/cypress/integration/all/app/packflow.spec.ts
+++ b/cypress/integration/all/app/packflow.spec.ts
@@ -1,89 +1,91 @@
-import managePacksPage from "../../pages/managePacksPage";
+// NOTE: Product decision to remove packs from UI
 
-describe("Pack flow (empty)", () => {
-  before(() => {
-    Cypress.session.clearAllSavedSessions();
-    cy.setup();
-    cy.loginWithCySession();
-    cy.viewport(1200, 660);
-  });
-  after(() => {
-    cy.logout();
-  });
+// import managePacksPage from "../../pages/managePacksPage";
 
-  describe("Manage packs page", () => {
-    beforeEach(() => {
-      cy.loginWithCySession();
-      managePacksPage.visitsManagePacksPage();
-    });
-    it("creates a new pack", () => {
-      managePacksPage.allowsCreatePack();
-      managePacksPage.verifiesCreatedPack();
-    });
-  });
-});
-describe("Pack flow (seeded)", () => {
-  before(() => {
-    Cypress.session.clearAllSavedSessions();
-    cy.setup();
-    cy.loginWithCySession();
-    cy.seedQueries();
-    cy.seedPacks();
-    cy.viewport(1200, 660);
-  });
-  after(() => {
-    cy.logout();
-  });
+// describe("Pack flow (empty)", () => {
+//   before(() => {
+//     Cypress.session.clearAllSavedSessions();
+//     cy.setup();
+//     cy.loginWithCySession();
+//     cy.viewport(1200, 660);
+//   });
+//   after(() => {
+//     cy.logout();
+//   });
 
-  describe("Pack details page", () => {
-    beforeEach(() => {
-      cy.loginWithCySession();
-      managePacksPage.visitsManagePacksPage();
-      cy.getAttached(".name__cell > .button--text-link").first().click();
-    });
-    it("adds a query to an existing pack", () => {
-      cy.findByRole("button", { name: /add query/i }).click();
-      cy.findByText(/select query/i).click();
-      cy.findByText(/get authorized/i).click();
-      cy.getAttached(
-        ".pack-query-editor-modal__form-field--frequency > .input-field"
-      )
-        .click()
-        .type("3600");
-      cy.getAttached(
-        ".pack-query-editor-modal__form-field--osquer-vers > .Select"
-      ).click();
-      cy.findByText(/4.7/i).click();
-      cy.getAttached(
-        ".pack-query-editor-modal__form-field--shard > .input-field"
-      )
-        .click()
-        .type("50");
-      cy.getAttached(".pack-query-editor-modal .modal-cta-wrap")
-        .contains("button", /add query/i)
-        .click();
-      cy.findByText(/get authorized/i).should("exist");
-    });
-    it("removes a query from an existing pack", () => {
-      cy.getAttached(".fleet-checkbox__input").check({ force: true });
-      cy.findByRole("button", { name: /remove/i }).click();
-      cy.getAttached(".remove-pack-query-modal .modal-cta-wrap")
-        .contains("button", /remove/i)
-        .click();
-    });
-    it("edits an existing pack", () => {
-      managePacksPage.allowsEditPack();
-      managePacksPage.verifiesEditedPack();
-    });
-  });
-  describe("Manage packs page", () => {
-    beforeEach(() => {
-      cy.loginWithCySession();
-      managePacksPage.visitsManagePacksPage();
-    });
-    it("deletes an existing pack", () => {
-      managePacksPage.allowsDeletePack();
-      managePacksPage.verifiesDeletedPack();
-    });
-  });
-});
+//   describe("Manage packs page", () => {
+//     beforeEach(() => {
+//       cy.loginWithCySession();
+//       managePacksPage.visitsManagePacksPage();
+//     });
+//     it("creates a new pack", () => {
+//       managePacksPage.allowsCreatePack();
+//       managePacksPage.verifiesCreatedPack();
+//     });
+//   });
+// });
+// describe("Pack flow (seeded)", () => {
+//   before(() => {
+//     Cypress.session.clearAllSavedSessions();
+//     cy.setup();
+//     cy.loginWithCySession();
+//     cy.seedQueries();
+//     cy.seedPacks();
+//     cy.viewport(1200, 660);
+//   });
+//   after(() => {
+//     cy.logout();
+//   });
+
+//   describe("Pack details page", () => {
+//     beforeEach(() => {
+//       cy.loginWithCySession();
+//       managePacksPage.visitsManagePacksPage();
+//       cy.getAttached(".name__cell > .button--text-link").first().click();
+//     });
+//     it("adds a query to an existing pack", () => {
+//       cy.findByRole("button", { name: /add query/i }).click();
+//       cy.findByText(/select query/i).click();
+//       cy.findByText(/get authorized/i).click();
+//       cy.getAttached(
+//         ".pack-query-editor-modal__form-field--frequency > .input-field"
+//       )
+//         .click()
+//         .type("3600");
+//       cy.getAttached(
+//         ".pack-query-editor-modal__form-field--osquer-vers > .Select"
+//       ).click();
+//       cy.findByText(/4.7/i).click();
+//       cy.getAttached(
+//         ".pack-query-editor-modal__form-field--shard > .input-field"
+//       )
+//         .click()
+//         .type("50");
+//       cy.getAttached(".pack-query-editor-modal .modal-cta-wrap")
+//         .contains("button", /add query/i)
+//         .click();
+//       cy.findByText(/get authorized/i).should("exist");
+//     });
+//     it("removes a query from an existing pack", () => {
+//       cy.getAttached(".fleet-checkbox__input").check({ force: true });
+//       cy.findByRole("button", { name: /remove/i }).click();
+//       cy.getAttached(".remove-pack-query-modal .modal-cta-wrap")
+//         .contains("button", /remove/i)
+//         .click();
+//     });
+//     it("edits an existing pack", () => {
+//       managePacksPage.allowsEditPack();
+//       managePacksPage.verifiesEditedPack();
+//     });
+//   });
+//   describe("Manage packs page", () => {
+//     beforeEach(() => {
+//       cy.loginWithCySession();
+//       managePacksPage.visitsManagePacksPage();
+//     });
+//     it("deletes an existing pack", () => {
+//       managePacksPage.allowsDeletePack();
+//       managePacksPage.verifiesDeletedPack();
+//     });
+//   });
+// });

--- a/cypress/integration/free/maintainer.spec.ts
+++ b/cypress/integration/free/maintainer.spec.ts
@@ -149,20 +149,22 @@ describe(
         managePoliciesPage.allowsRunSavePolicy();
       });
     });
-    // describe("Manage packs page", () => {
-    //   beforeEach(() => {
-    //     cy.loginWithCySession("mary@organization.com", GOOD_PASSWORD);
-    //     managePacksPage.visitsManagePacksPage();
-    //   });
-    //   it("allows maintainer to create a pack", () => {
-    //     managePacksPage.allowsCreatePack();
-    //     managePacksPage.verifiesCreatedPack();
-    //   });
-    //   it("allows maintainer to delete a pack", () => {
-    //     managePacksPage.allowsDeletePack();
-    //     managePacksPage.verifiesDeletedPack();
-    //   });
-    // });
+    /* NOTE: Product decision to remove packs from UI
+    describe("Manage packs page", () => {
+      beforeEach(() => {
+        cy.loginWithCySession("mary@organization.com", GOOD_PASSWORD);
+        managePacksPage.visitsManagePacksPage();
+      });
+      it("allows maintainer to create a pack", () => {
+        managePacksPage.allowsCreatePack();
+        managePacksPage.verifiesCreatedPack();
+      });
+      it("allows maintainer to delete a pack", () => {
+        managePacksPage.allowsDeletePack();
+        managePacksPage.verifiesDeletedPack();
+      });
+    });
+    */
     describe("User profile page", () => {
       beforeEach(() => {
         cy.loginWithCySession("mary@organization.com", GOOD_PASSWORD);

--- a/cypress/integration/free/maintainer.spec.ts
+++ b/cypress/integration/free/maintainer.spec.ts
@@ -149,46 +149,46 @@ describe(
         managePoliciesPage.allowsRunSavePolicy();
       });
     });
-    describe("Manage packs page", () => {
+    // describe("Manage packs page", () => {
+    //   beforeEach(() => {
+    //     cy.loginWithCySession("mary@organization.com", GOOD_PASSWORD);
+    //     managePacksPage.visitsManagePacksPage();
+    //   });
+    //   it("allows maintainer to create a pack", () => {
+    //     managePacksPage.allowsCreatePack();
+    //     managePacksPage.verifiesCreatedPack();
+    //   });
+    //   it("allows maintainer to delete a pack", () => {
+    //     managePacksPage.allowsDeletePack();
+    //     managePacksPage.verifiesDeletedPack();
+    //   });
+    // });
+    describe("User profile page", () => {
       beforeEach(() => {
         cy.loginWithCySession("mary@organization.com", GOOD_PASSWORD);
-        managePacksPage.visitsManagePacksPage();
+        userProfilePage.visitUserProfilePage();
       });
-      it("allows maintainer to create a pack", () => {
-        managePacksPage.allowsCreatePack();
-        managePacksPage.verifiesCreatedPack();
+      it("verifies maintainer role and teams is disabled", () => {
+        userProfilePage.showRole("Maintainer");
       });
-      it("allows maintainer to delete a pack", () => {
-        managePacksPage.allowsDeletePack();
-        managePacksPage.verifiesDeletedPack();
-      });
-      describe("User profile page", () => {
-        beforeEach(() => {
-          cy.loginWithCySession("mary@organization.com", GOOD_PASSWORD);
-          userProfilePage.visitUserProfilePage();
-        });
-        it("verifies maintainer role and teams is disabled", () => {
-          userProfilePage.showRole("Maintainer");
-        });
-      });
+    });
 
-      // nav restrictions are at the end because we expect to see a
-      // 403 error overlay which will hide the nav and make the test fail
-      describe("Nav restrictions", () => {
-        // cypress tends to fail on uncaught exceptions. since we have
-        // our own error handling, it's suggested to use this block to
-        // suppress so the tests will keep running
-        Cypress.on("uncaught:exception", () => {
-          return false;
-        });
-        beforeEach(() => {
-          cy.loginWithCySession("mary@organization.com", GOOD_PASSWORD);
-        });
-        it("verifies maintainer does not have access to settings", () => {
-          cy.findByText(/settings/i).should("not.exist");
-          cy.visit("/settings/organization");
-          cy.findByText(/you do not have permissions/i).should("exist");
-        });
+    // nav restrictions are at the end because we expect to see a
+    // 403 error overlay which will hide the nav and make the test fail
+    describe("Nav restrictions", () => {
+      // cypress tends to fail on uncaught exceptions. since we have
+      // our own error handling, it's suggested to use this block to
+      // suppress so the tests will keep running
+      Cypress.on("uncaught:exception", () => {
+        return false;
+      });
+      beforeEach(() => {
+        cy.loginWithCySession("mary@organization.com", GOOD_PASSWORD);
+      });
+      it("verifies maintainer does not have access to settings", () => {
+        cy.findByText(/settings/i).should("not.exist");
+        cy.visit("/settings/organization");
+        cy.findByText(/you do not have permissions/i).should("exist");
       });
     });
   }

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -471,7 +471,8 @@ const ManageSchedulePage = ({
           </div>
           {allScheduledQueriesList?.length !== 0 && !allScheduledQueriesError && (
             <div className={`${baseClass}__action-button-container`}>
-              {isOnGlobalTeam && (
+              {/* NOTE:  Product decision to remove packs from UI */}
+              {/* {isOnGlobalTeam && (
                 <Button
                   variant="inverse"
                   onClick={handleAdvanced}
@@ -479,7 +480,7 @@ const ManageSchedulePage = ({
                 >
                   Advanced
                 </Button>
-              )}
+              )} */}
               <Button
                 variant="brand"
                 className={`${baseClass}__schedule-button`}

--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -471,8 +471,8 @@ const ManageSchedulePage = ({
           </div>
           {allScheduledQueriesList?.length !== 0 && !allScheduledQueriesError && (
             <div className={`${baseClass}__action-button-container`}>
-              {/* NOTE:  Product decision to remove packs from UI */}
-              {/* {isOnGlobalTeam && (
+              {/* NOTE:  Product decision to remove packs from UI
+              {isOnGlobalTeam && (
                 <Button
                   variant="inverse"
                   onClick={handleAdvanced}

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTable.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTable.tsx
@@ -106,21 +106,22 @@ const ScheduleTable = ({
       );
     }
 
-    // NOTE: Product decision to remove packs from UI
-    // if (isOnGlobalTeam) {
-    //   emptySchedule.info = (
-    //     <>Or go to your osquery packs via the ‘Advanced’ button. </>
-    //   );
-    //   emptySchedule.secondaryButton = (
-    //     <Button
-    //       variant="inverse"
-    //       onClick={handleAdvanced}
-    //       className={`${baseClass}__advanced-button`}
-    //     >
-    //       Advanced
-    //     </Button>
-    //   );
-    // }
+    /* NOTE: Product decision to remove packs from UI
+    if (isOnGlobalTeam) {
+      emptySchedule.info = (
+        <>Or go to your osquery packs via the ‘Advanced’ button. </>
+      );
+      emptySchedule.secondaryButton = (
+        <Button
+          variant="inverse"
+          onClick={handleAdvanced}
+          className={`${baseClass}__advanced-button`}
+        >
+          Advanced
+        </Button>
+      );
+    }
+    */
     return emptySchedule;
   };
 

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTable.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTable.tsx
@@ -106,20 +106,21 @@ const ScheduleTable = ({
       );
     }
 
-    if (isOnGlobalTeam) {
-      emptySchedule.info = (
-        <>Or go to your osquery packs via the ‘Advanced’ button. </>
-      );
-      emptySchedule.secondaryButton = (
-        <Button
-          variant="inverse"
-          onClick={handleAdvanced}
-          className={`${baseClass}__advanced-button`}
-        >
-          Advanced
-        </Button>
-      );
-    }
+    // NOTE: Product decision to remove packs from UI
+    // if (isOnGlobalTeam) {
+    //   emptySchedule.info = (
+    //     <>Or go to your osquery packs via the ‘Advanced’ button. </>
+    //   );
+    //   emptySchedule.secondaryButton = (
+    //     <Button
+    //       variant="inverse"
+    //       onClick={handleAdvanced}
+    //       className={`${baseClass}__advanced-button`}
+    //     >
+    //       Advanced
+    //     </Button>
+    //   );
+    // }
     return emptySchedule;
   };
 


### PR DESCRIPTION
### Issue
Frontend portion of #8887 

### Feature removed
- Removes Advanced Buttons from Schedule page UI (No way to navigate to Packs in UI)
- Comment out Packs tests
- Leaves URLs in per product decision

### Screenshots (No advanced button)
<img width="1483" alt="Screenshot 2023-01-20 at 12 35 52 PM" src="https://user-images.githubusercontent.com/71795832/213766274-4fac5a14-c886-45fd-ba75-76a96ea74f5f.png">
<img width="1477" alt="Screenshot 2023-01-20 at 12 35 32 PM" src="https://user-images.githubusercontent.com/71795832/213766277-c24925c3-952c-44a2-814d-e3c8f55ddc48.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
