### PR TITLE
Setting restricted ACL for windows secret-orbit-node-file

### DIFF
--- a/orbit/changes/bug-9157-secret-orbit-node-file-is-world-accessible
+++ b/orbit/changes/bug-9157-secret-orbit-node-file-is-world-accessible
@@ -1,0 +1,1 @@
+* Orbit service on windows is not creating the secret-orbit-node-key.txt with a restricted ACL to allow only privileged users to access its content

--- a/orbit/pkg/constant/constant.go
+++ b/orbit/pkg/constant/constant.go
@@ -10,9 +10,6 @@ const (
 	// DefaultWorldReadableFileMode is the default file mode to apply to files
 	// that can be read by other processes.
 	DefaultWorldReadableFileMode = 0o644
-	// DefaultRestrictedReadFileMode is the default file mode to apply to files
-	// that can be read by other privileged processes.
-	DefaultRestrictedReadFileMode = 0o640
 	// DefaultSystemdUnitMode is the required file mode to systemd unit files.
 	DefaultSystemdUnitMode = DefaultWorldReadableFileMode
 	// DesktopAppExecName is the name of Fleet's Desktop executable.

--- a/orbit/pkg/constant/constant.go
+++ b/orbit/pkg/constant/constant.go
@@ -10,6 +10,9 @@ const (
 	// DefaultWorldReadableFileMode is the default file mode to apply to files
 	// that can be read by other processes.
 	DefaultWorldReadableFileMode = 0o644
+	// DefaultRestrictedReadFileMode is the default file mode to apply to files
+	// that can be read by other privileged processes.
+	DefaultRestrictedReadFileMode = 0o640
 	// DefaultSystemdUnitMode is the required file mode to systemd unit files.
 	DefaultSystemdUnitMode = DefaultWorldReadableFileMode
 	// DesktopAppExecName is the name of Fleet's Desktop executable.

--- a/orbit/pkg/platform/platform_notwindows.go
+++ b/orbit/pkg/platform/platform_notwindows.go
@@ -16,7 +16,7 @@ import (
 // ChmodRestrictFile sets the appropriate permissions on a file so it can not be read by everyone
 // On POSIX this is a normal chmod call.
 func ChmodRestrictFile(path string) error {
-	if err := os.Chmod(path, constant.DefaultRestrictedReadFileMode); err != nil {
+	if err := os.Chmod(path, constant.DefaultFileMode); err != nil {
 		return fmt.Errorf("chmod restrict file: %w", err)
 	}
 	return nil

--- a/orbit/pkg/platform/platform_notwindows.go
+++ b/orbit/pkg/platform/platform_notwindows.go
@@ -13,6 +13,15 @@ import (
 	gopsutil_process "github.com/shirou/gopsutil/v3/process"
 )
 
+// ChmodRestrictFile sets the appropriate permissions on a file so it can not be read by everyone
+// On POSIX this is a normal chmod call.
+func ChmodRestrictFile(path string) error {
+	if err := os.Chmod(path, constant.DefaultRestrictedReadFileMode); err != nil {
+		return fmt.Errorf("chmod restrict file: %w", err)
+	}
+	return nil
+}
+
 // ChmodExecutableDirectory sets the appropriate permissions on an executable
 // file. On POSIX this is a normal chmod call.
 func ChmodExecutableDirectory(path string) error {

--- a/orbit/pkg/platform/platform_windows.go
+++ b/orbit/pkg/platform/platform_windows.go
@@ -25,6 +25,23 @@ const (
 	readAndExecute = uint32(131241)
 )
 
+// ChmodRestrictFile sets the appropriate permissions on a file so it can not be read by everyone
+// On POSIX this is a normal chmod call.
+func ChmodRestrictFile(path string) error {
+	if err := acl.Apply(
+		path,
+		true,
+		false,
+		acl.GrantSid(windows.GENERIC_ALL, constant.SystemSID),
+		acl.GrantSid(windows.GENERIC_ALL, constant.AdminSID),
+		acl.GrantSid(0, constant.UserSID), // no access permissions for regular users
+	); err != nil {
+		return fmt.Errorf("restricting file access: %w", err)
+	}
+
+	return nil
+}
+
 // ChmodExecutableDirectory sets the appropriate permissions on the parent
 // directory of an executable file. On Windows this involves setting the
 // appropriate ACLs.

--- a/server/service/orbit_client.go
+++ b/server/service/orbit_client.go
@@ -225,15 +225,11 @@ func (oc *OrbitClient) enrollAndWriteNodeKeyFile() (string, error) {
 		if err := platform.ChmodRestrictFile(oc.nodeKeyFilePath); err != nil {
 			return "", fmt.Errorf("apply ACLs: %w", err)
 		}
+	}
 
-		// writing raw key material to the acl-ready secret file
-		if err := os.WriteFile(oc.nodeKeyFilePath, []byte(orbitNodeKey), constant.DefaultFileMode); err != nil {
-			return "", fmt.Errorf("write orbit node key file: %w", err)
-		}
-	} else {
-		if err := os.WriteFile(oc.nodeKeyFilePath, []byte(orbitNodeKey), constant.DefaultFileMode); err != nil {
-			return "", fmt.Errorf("write orbit node key file: %w", err)
-		}
+	// writing raw key material to the acl-ready secret file
+	if err := os.WriteFile(oc.nodeKeyFilePath, []byte(orbitNodeKey), constant.DefaultFileMode); err != nil {
+		return "", fmt.Errorf("write orbit node key file: %w", err)
 	}
 
 	return orbitNodeKey, nil


### PR DESCRIPTION
This relates to #9157 

# Checklist for submitter

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Manual QA for all new/changed functionality

