### PR TITLE
Fleet UI: Fix banner width to not go pass margin

### DIFF
--- a/frontend/components/InfoBanner/_styles.scss
+++ b/frontend/components/InfoBanner/_styles.scss
@@ -2,7 +2,6 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: 100%;
   padding: $pad-medium;
   border-radius: $border-radius;
   border: 1px solid $ui-vibrant-blue-50;


### PR DESCRIPTION
Thanks for catching this Gabe. I triple checked every instance of `<InfoBanner/>` that the fix removing `width: 100%` didn't cause more bugs

<img width="1194" alt="Screenshot 2023-01-23 at 12 51 19 PM" src="https://user-images.githubusercontent.com/71795832/214114795-18280933-2fa1-4328-829d-5f931d6df675.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

~~- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.~~ bug not released 
  
- [x] Manual QA for all new/changed functionality
