### PR TITLE
Kickstart sofwareupdated periodically from fleetd/orbit to work around a macOS bug

### DIFF
--- a/orbit/changes/issue-9347-kickstart-softwareupdated
+++ b/orbit/changes/issue-9347-kickstart-softwareupdated
@@ -1,0 +1,1 @@
+* Added periodical restart of the `softwareupdated` service to work around a macOS bug where it sometimes hangs and prevents software updates.

--- a/orbit/pkg/update/execcmd.go
+++ b/orbit/pkg/update/execcmd.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 )
 
+var _ = runCmdCollectErr // just to avoid unused errors on non-darwin platforms
+
 func runCmdCollectErr(exe string, args ...string) error {
 	cmd := exec.Command(exe, args...)
 	out, err := cmd.CombinedOutput()

--- a/orbit/pkg/update/execcmd.go
+++ b/orbit/pkg/update/execcmd.go
@@ -1,5 +1,3 @@
-//go:build darwin
-
 package update
 
 import (
@@ -7,8 +5,8 @@ import (
 	"os/exec"
 )
 
-func runRenewEnrollmentProfile() error {
-	cmd := exec.Command("/usr/bin/profiles", "renew", "--type", "enrollment")
+func runCmdCollectErr(exe string, args ...string) error {
+	cmd := exec.Command(exe, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil && len(out) > 0 {
 		// just as a precaution, limit the length of the output

--- a/orbit/pkg/update/execcmd_darwin.go
+++ b/orbit/pkg/update/execcmd_darwin.go
@@ -1,0 +1,11 @@
+//go:build darwin
+
+package update
+
+func runRenewEnrollmentProfile() error {
+	return runCmdCollectErr("/usr/bin/profiles", "renew", "--type", "enrollment")
+}
+
+func runKickstartSoftwareUpdated() error {
+	return runCmdCollectErr("launchctl", "kickstart", "-k", "system/com.apple.softwareupdated")
+}

--- a/orbit/pkg/update/execcmd_stub.go
+++ b/orbit/pkg/update/execcmd_stub.go
@@ -5,3 +5,7 @@ package update
 func runRenewEnrollmentProfile() error {
 	return nil
 }
+
+func runKickstartSoftwareUpdated() error {
+	return nil
+}

--- a/orbit/pkg/update/softwareupdated_runner.go
+++ b/orbit/pkg/update/softwareupdated_runner.go
@@ -1,0 +1,71 @@
+package update
+
+import (
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// SoftwareUpdatedRunner is a specialized runner to periodically kickstart the
+// softwareupdated service on macOS, to work around a bug where the service
+// hangs from time to time and prevents updates from being downloaded or update
+// notifications from being shown.
+//
+// It is designed with Execute and Interrupt functions to be compatible with
+// oklog/run.
+type SoftwareUpdatedRunner struct {
+	opt    SoftwareUpdatedOptions
+	cancel chan struct{}
+}
+
+// SoftwareUpdatedOptions defines the options provided for the softwareupdated
+// runner.
+type SoftwareUpdatedOptions struct {
+	// Interval is the interval at which to run the the kickstart softwareupdated
+	// command.
+	Interval time.Duration
+}
+
+// NewSoftwareUpdatedRunner creates a new runner with the provided options. The
+// runner must be started with Execute.
+func NewSoftwareUpdatedRunner(opt SoftwareUpdatedOptions) *SoftwareUpdatedRunner {
+	return &SoftwareUpdatedRunner{
+		opt:    opt,
+		cancel: make(chan struct{}),
+	}
+}
+
+// Execute starts the loop to periodically run the kickstart command.
+func (r *SoftwareUpdatedRunner) Execute() error {
+	log.Debug().Msg("starting softwareupdated runner")
+
+	// run ~immediately the first time (e.g. on startup)
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.cancel:
+			return nil
+
+		case <-ticker.C:
+			log.Info().Msg("executing launchctl kickstart -k softwareupdated")
+			if err := r.exec(); err != nil {
+				log.Info().Err(err).Msg("executing launchctl kickstart -k softwareupdated failed")
+			}
+			// run at the defined interval the next time around
+			ticker.Reset(r.opt.Interval)
+		}
+	}
+}
+
+// Interrupt is the oklog/run interrupt method that stops the runner when
+// called.
+func (r *SoftwareUpdatedRunner) Interrupt(err error) {
+	close(r.cancel)
+	log.Debug().Err(err).Msg("interrupt for softwareupdated runner")
+}
+
+func (r *SoftwareUpdatedRunner) exec() error {
+	panic("unimplemented")
+}

--- a/orbit/pkg/update/softwareupdated_runner.go
+++ b/orbit/pkg/update/softwareupdated_runner.go
@@ -50,7 +50,7 @@ func (r *SoftwareUpdatedRunner) Execute() error {
 
 		case <-ticker.C:
 			log.Info().Msg("executing launchctl kickstart -k softwareupdated")
-			if err := r.exec(); err != nil {
+			if err := runKickstartSoftwareUpdated(); err != nil {
 				log.Info().Err(err).Msg("executing launchctl kickstart -k softwareupdated failed")
 			}
 			// run at the defined interval the next time around
@@ -64,8 +64,4 @@ func (r *SoftwareUpdatedRunner) Execute() error {
 func (r *SoftwareUpdatedRunner) Interrupt(err error) {
 	close(r.cancel)
 	log.Debug().Err(err).Msg("interrupt for softwareupdated runner")
-}
-
-func (r *SoftwareUpdatedRunner) exec() error {
-	panic("unimplemented")
 }

--- a/orbit/pkg/update/softwareupdated_runner_test.go
+++ b/orbit/pkg/update/softwareupdated_runner_test.go
@@ -1,0 +1,32 @@
+package update
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/oklog/run"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSoftwareUpdatedRunner(t *testing.T) {
+	var callCount int32
+	runFn := func() error {
+		atomic.AddInt32(&callCount, 1)
+		return nil
+	}
+
+	var g run.Group
+	// add the "lead" runner, it will return after 1s and cause all runners to stop
+	g.Add(func() error { time.Sleep(time.Second); return nil }, func(error) {})
+
+	// add the softwareupdated runner, should run at least 2 times (leave some
+	// wiggle room in case it is so slow on CI that it is not scheduled more
+	// often).
+	r := NewSoftwareUpdatedRunner(SoftwareUpdatedOptions{Interval: 300 * time.Millisecond, runCmdFn: runFn})
+	g.Add(r.Execute, r.Interrupt)
+
+	err := g.Run()
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, atomic.LoadInt32(&callCount), int32(2))
+}


### PR DESCRIPTION
#9347 

~~**NOTE**: cut from and targets https://github.com/fleetdm/fleet/pull/9409 for now (`mna-9278-agent-renew-enrollment`). Will be updated once the other PR is merged.~~

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
