### PR TITLE
Fleet UI: Safari hack to be able to triple click tooltip

### DIFF
--- a/frontend/components/TableContainer/DataTable/TruncatedTextCell/TruncatedTextCell.tsx
+++ b/frontend/components/TableContainer/DataTable/TruncatedTextCell/TruncatedTextCell.tsx
@@ -58,7 +58,7 @@ const TruncatedTextCell = ({
         <>
           {value}
           <div className="safari-hack">&nbsp;</div>
-          {/* Safari hack work around */}
+          {/* Fixes triple click selecting next element in Safari */}
         </>
       </ReactTooltip>
     </div>

--- a/frontend/components/TableContainer/DataTable/TruncatedTextCell/TruncatedTextCell.tsx
+++ b/frontend/components/TableContainer/DataTable/TruncatedTextCell/TruncatedTextCell.tsx
@@ -55,7 +55,11 @@ const TruncatedTextCell = ({
         clickable
         delayHide={200} // need delay set to hover using clickable
       >
-        {value}
+        <>
+          {value}
+          <div className="safari-hack">&nbsp;</div>
+          {/* Safari hack work around */}
+        </>
       </ReactTooltip>
     </div>
   );

--- a/frontend/components/TableContainer/DataTable/TruncatedTextCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/TruncatedTextCell/_styles.scss
@@ -27,6 +27,10 @@
     overflow-wrap: break-word;
     display: block;
     white-space: pre-wrap;
+
+    .safari-hack {
+      height: 0px;
+    }
   }
 
   @media (min-width: $break-990) {


### PR DESCRIPTION
### Issue
#9199 

@xpkoala found safari bug: https://github.com/fleetdm/fleet/issues/9199#issuecomment-1400775556

### Bug fix

- Safari has this weird bug where triple clicking selects more than just the select. After googling a bit, I came across: https://github.com/ckeditor/ckeditor4/issues/1827 which suggested it might be grabbing the next element or node.
- The only way I got around this bug is by 1. creating an empty element that renders something after it and then 2. hiding it using a height: 0 (visibility hidden wouldn't work)

### Screenshot
https://user-images.githubusercontent.com/71795832/214138136-f2afdb94-3754-4a09-a94e-fabe17e21866.mov

This all seems super hacky just to get safari to allow a triple click on a tooltip. Thoughts @fleetdm/frontend ?

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

