### PR TITLE
fix minor issues in activity items

### DIFF
--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -4,15 +4,13 @@ import { intlFormat, formatDistanceToNowStrict } from "date-fns";
 
 import { ActivityType, IActivity, IActivityDetails } from "interfaces/activity";
 import { addGravatarUrlToResource } from "utilities/helpers";
+import { DEFAULT_GRAVATAR_LINK } from "utilities/constants";
 import Avatar from "components/Avatar";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon";
 import ReactTooltip from "react-tooltip";
 
 const baseClass = "activity-item";
-
-const DEFAULT_GRAVATAR_URL =
-  "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=blank&size=200";
 
 const TAGGED_TEMPLATES = {
   liveQueryActivityTemplate: (
@@ -153,7 +151,7 @@ const TAGGED_TEMPLATES = {
   mdmEnrolled: (activity: IActivity) => {
     return (
       <>
-        An end user turned on MDM features for a host with serial number
+        An end user turned on MDM features for a host with serial number{" "}
         <b>
           {activity.details?.host_serial} (
           {activity.details?.installed_from_dep ? "automatic" : "manual"})
@@ -275,7 +273,7 @@ const ActivityItem = ({
   const { actor_email } = activity;
   const { gravatarURL } = actor_email
     ? addGravatarUrlToResource({ email: actor_email })
-    : { gravatarURL: DEFAULT_GRAVATAR_URL };
+    : { gravatarURL: DEFAULT_GRAVATAR_LINK };
 
   const activityCreatedAt = new Date(activity.created_at);
 


### PR DESCRIPTION
This fixes two minor issues for activity items:

1. The value for DEFAULT_GRAVATAR_URL was a transparent square, this uses the same image we use as the fallback for all other avatars.
2. Added a whitespace for MDM activities.

# Checklist for submitter

- [x] Manual QA for all new/changed functionality
