### PR TITLE
add activities for mdm turned off and min mac os version

### DIFF
--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -31,6 +31,8 @@ export enum ActivityType {
   UserDeletedTeamRole = "deleted_user_team_role",
   MdmEnrolled = "mdm_enrolled",
   MdmUnenrolled = "mdm_unenrolled",
+  MdmTurnedOff = "mdm_turned_off", // TODO: change when we get actual activity type
+  UpdateMinMacVersion = "update_min_mac_version", // TODO: change when we get actual activity type
 }
 export interface IActivity {
   created_at: string;
@@ -63,4 +65,7 @@ export interface IActivityDetails {
   host_serial?: string;
   host_display_name?: string;
   installed_from_dep?: boolean;
+  host_display_name?: string;
+  minimum_version?: string;
+  deadline?: string;
 }

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tests.tsx
@@ -8,20 +8,6 @@ import { ActivityType } from "interfaces/activity";
 
 import ActivityItem from ".";
 
-const getByTextContent = (text: string) => {
-  return screen.getByText((content, element) => {
-    if (!element) {
-      return false;
-    }
-    const hasText = (thisElement: Element) => thisElement.textContent === text;
-    const elementHasText = hasText(element);
-    const childrenDontHaveText = Array.from(element?.children || []).every(
-      (child) => !hasText(child)
-    );
-    return elementHasText && childrenDontHaveText;
-  });
-};
-
 describe("Activity Feed", () => {
   it("renders avatar, actor name, timestamp", async () => {
     const currentDate = new Date();

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -171,6 +171,29 @@ const TAGGED_TEMPLATES = {
     );
   },
 
+  mdmTurnedOff: (activity: IActivity) => {
+    return (
+      <>
+        turned off mobile device management (MDM) for{" "}
+        <b>{activity.details?.host_display_name}</b>.
+      </>
+    );
+  },
+
+  udpateMinMacVersion: (activity: IActivity) => {
+    return (
+      <>
+        updated the minimum macOS version to{" "}
+        <b>{activity.details?.minimum_version}</b>
+        deadline: {activity.details?.deadline} on hosts assigned to{" "}
+        {activity.details?.team_name
+          ? `the ${(<b>{activity.details?.team_name}</b>)} team`
+          : "no team"}
+        .
+      </>
+    );
+  },
+
   defaultActivityTemplate: (activity: IActivity) => {
     const entityName = find(activity.details, (_, key) =>
       key.includes("_name")
@@ -247,6 +270,12 @@ const getDetail = (
     }
     case ActivityType.MdmUnenrolled: {
       return TAGGED_TEMPLATES.mdmUnenrolled(activity);
+    }
+    case ActivityType.MdmTurnedOff: {
+      return TAGGED_TEMPLATES.mdmUnenrolled(activity);
+    }
+    case ActivityType.UpdateMinMacVersion: {
+      return TAGGED_TEMPLATES.udpateMinMacVersion(activity);
     }
     default: {
       return TAGGED_TEMPLATES.defaultActivityTemplate(activity);


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
