### PR TITLE
Handbook: Update `<call-to-action>` component example

### DIFF
--- a/handbook/marketing/article-formatting-guide.md
+++ b/handbook/marketing/article-formatting-guide.md
@@ -79,12 +79,12 @@ Use the following code snippet to include an inline CTA (call to action) in your
 
 ```
 <call-to-action 
-  title=”All the data you need, without the performance hit.”
-  text=”Fleet is the lightweight telemetry platform for servers and workstations.”
-  primary-button-text=”Try Fleet Free” 
-  primary-button-href=”/get-started?try-it-now” 
-  secondary-button-text=”Schedule a demo”
-  secondary-button-href=”calendly.com/fleetdm/demo”>
+  title="All the data you need, without the performance hit."
+  text="Fleet is the lightweight telemetry platform for servers and workstations."
+  primary-button-text="Try Fleet Free" 
+  primary-button-href="/get-started?try-it-now" 
+  secondary-button-text="Schedule a demo"
+  secondary-button-href="https://calendly.com/fleetdm/demo">
 </call-to-action>
 ```
 


### PR DESCRIPTION
Changes:
- Updated the `<call-to-action>` component example in the article formatting guide handbook page to use the correct quotation marks (`”` » `"`)