### PR TITLE
Fleet UI: Fix table button icons misalignment

### DIFF
--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -167,11 +167,13 @@
     top: 1px;
   }
 
-  // Truncates clickable button cells
-  .children-wrapper {
-    overflow: hidden;
-    white-space: nowrap;
-    display: block;
-    text-overflow: ellipsis;
+  // Truncates clickable button cells (not compatible with buttons with icons)
+  tbody {
+    .children-wrapper {
+      overflow: hidden;
+      white-space: nowrap;
+      display: block;
+      text-overflow: ellipsis;
+    }
   }
 }


### PR DESCRIPTION
### Unreleased bug fix (broken in main only)
- Truncating long names in table require display block instead of display flex, however that misaligned the icons which require display flex to be correctly centered (bug in main now)
- Fix: Only apply truncated text (display block) for the body of a table where there are no icons

### Screenshot
<img width="861" alt="Screenshot 2023-01-26 at 11 16 12 AM" src="https://user-images.githubusercontent.com/71795832/214889335-940c5fec-fd40-46e6-8805-b7d6f43b08e5.png">
<img width="1311" alt="Screenshot 2023-01-26 at 11 15 56 AM" src="https://user-images.githubusercontent.com/71795832/214889338-ed288723-48c4-4ab0-aaaf-23d5278a9f74.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality