### PR TITLE
Use stricter file permissions in `fleetctl updates add`

### DIFF
--- a/changes/fleetctl-update-permissions
+++ b/changes/fleetctl-update-permissions
@@ -1,0 +1,1 @@
+* Use stricter file permissions in `fleetctl updates add` command.

--- a/ee/fleetctl/updates.go
+++ b/ee/fleetctl/updates.go
@@ -595,11 +595,11 @@ func copyTarget(srcPath, dstPath string) error {
 	}
 	defer src.Close()
 
-	if err := secure.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+	if err := secure.MkdirAll(filepath.Dir(dstPath), 0o700); err != nil {
 		return fmt.Errorf("create dst dir for copy: %w", err)
 	}
 
-	dst, err := secure.OpenFile(dstPath, os.O_RDWR|os.O_CREATE, 0o644)
+	dst, err := secure.OpenFile(dstPath, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		return fmt.Errorf("open dst for copy: %w", err)
 	}


### PR DESCRIPTION
This resolves an issue with adding updates on a macOS 13 machine. It seems like macOS may have changed the default directory permissions and these new stricter permissions are compatible with that default.

This is the error that was encountered before these changes:

```
Error: create dst dir for copy: Path staged/targets already exists with
mode 20000000700 instead of the expected 20000000755
```

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
