### PR TITLE
Bug 9386: Docs chrome extension has the wrong CPE.

### DIFF
--- a/docs/Using-Fleet/Vulnerability-Processing.md
+++ b/docs/Using-Fleet/Vulnerability-Processing.md
@@ -311,6 +311,24 @@ When searching for CPEs, the specifed `product` and `vendor` will be added to th
   }
 ]
 ```
+##### Excluding software
+
+If software is mapped to the wrong CPE and it is known that there are no entries for it in the
+NVD dataset, you can specify an exclusion rule by using the `skip` field. If the rule matches, the
+software will be excluded from the NVD vulnerability scanning process and, **no NVD vulnerabilities**
+will be reported.
+
+```
+{
+    "software": {
+      "name": ["Docs"],
+      "source": ["chrome_extensions"]
+    },
+    "filter": {
+      "skip": true
+    }
+  }
+```
 
 ##### CPE Translations (array[CPE Translation Entry])
 
@@ -342,6 +360,7 @@ The CPE translation. Used to match CPEs in the CPE database. Fields are are AND'
 | `product`   | array[string] | The CPE product.         |
 | `vendor`    | array[string] | The CPE vendor.          |
 | `target_sw` | array[string] | The CPE target software. |
+| `skip`      | bool          | If true, matched software will be skipped from the NVD vulnerability scanning process |
 
 ### Matching a CPE to a CVE
 

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -157,7 +157,12 @@ func CPEFromSoftware(db *sqlx.DB, software *fleet.Software, translations CPETran
 	if err != nil {
 		return "", fmt.Errorf("translate software: %w", err)
 	}
+
 	if match {
+		if translation.IsEmpty() {
+			return "", nil
+		}
+
 		ds := goqu.Dialect("sqlite").From(goqu.I("cpe_2").As("c")).
 			Select(
 				"c.rowid",

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -159,7 +159,7 @@ func CPEFromSoftware(db *sqlx.DB, software *fleet.Software, translations CPETran
 	}
 
 	if match {
-		if translation.IsEmpty() {
+		if translation.Skip {
 			return "", nil
 		}
 

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -346,6 +346,8 @@ func TestLegacyCPEDB(t *testing.T) {
 }
 
 func TestCPEFromSoftwareIntegration(t *testing.T) {
+	nettest.Run(t)
+
 	testCases := []struct {
 		software fleet.Software
 		cpe      string
@@ -1132,8 +1134,15 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 				BundleIdentifier: "com.utmapp.UTM",
 			}, cpe: "",
 		},
+		{
+			software: fleet.Software{
+				Name:             "Docs",
+				Source:           "chrome_extensions",
+				Version:          "0.10",
+				BundleIdentifier: "",
+			}, cpe: "",
+		},
 	}
-	nettest.Run(t)
 
 	tempDir := t.TempDir()
 
@@ -1156,6 +1165,6 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 	for _, tt := range testCases {
 		cpe, err := CPEFromSoftware(db, &tt.software, cpeTranslations, reCache)
 		require.NoError(t, err)
-		assert.Equal(t, tt.cpe, cpe)
+		assert.Equal(t, tt.cpe, cpe, tt.software.Name)
 	}
 }

--- a/server/vulnerabilities/nvd/cpe_translations.go
+++ b/server/vulnerabilities/nvd/cpe_translations.go
@@ -136,6 +136,13 @@ type CPETranslationItem struct {
 	Filter   CPETranslation         `json:"filter"`
 }
 
+// IsEmpty returns true if the translation rule is empty - an empty rule is used when we know
+// there's not a valid CPE in the NVD dataset for the software in question, thus we want to skip the
+// 'Software to CPE' translation step to avoid any false positives.
+func (c CPETranslation) IsEmpty() bool {
+	return len(c.Product) == 0 && len(c.Vendor) == 0 && len(c.TargetSW) == 0
+}
+
 // CPETranslationSoftware represents software match criteria for cpe translations.
 type CPETranslationSoftware struct {
 	Name             []string `json:"name"`

--- a/server/vulnerabilities/nvd/cpe_translations.go
+++ b/server/vulnerabilities/nvd/cpe_translations.go
@@ -136,13 +136,6 @@ type CPETranslationItem struct {
 	Filter   CPETranslation         `json:"filter"`
 }
 
-// IsEmpty returns true if the translation rule is empty - an empty rule is used when we know
-// there's not a valid CPE in the NVD dataset for the software in question, thus we want to skip the
-// 'Software to CPE' translation step to avoid any false positives.
-func (c CPETranslation) IsEmpty() bool {
-	return len(c.Product) == 0 && len(c.Vendor) == 0 && len(c.TargetSW) == 0
-}
-
 // CPETranslationSoftware represents software match criteria for cpe translations.
 type CPETranslationSoftware struct {
 	Name             []string `json:"name"`
@@ -220,4 +213,6 @@ type CPETranslation struct {
 	Product  []string `json:"product"`
 	Vendor   []string `json:"vendor"`
 	TargetSW []string `json:"target_sw"`
+	// If Skip is set, no NVD vulnerabilities will be reported for the matching software.
+	Skip bool `json:"skip"`
 }

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -59,5 +59,15 @@
       "product": ["7-zip"],
       "vendor": ["7-zip"]
     }
+  },
+  {
+    "software": {
+      "name": ["Docs"],
+      "source": ["chrome_extensions"]
+    },
+    "filter": {
+      "product": [],
+      "vendor": []
+    }
   }
 ]

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -66,8 +66,7 @@
       "source": ["chrome_extensions"]
     },
     "filter": {
-      "product": [],
-      "vendor": []
+      "skip": true
     }
   }
 ]


### PR DESCRIPTION
Related to #9386 - this should fix one of the three reported problems.

* Add the ability to add exclusion rules to cpe_translations.
* Added exclusion rule for Docs chrome extension.

# Checklist for submitter
- [x] Added/updated tests