### PR TITLE
Fixing osquery shell issue caused by osquery extension namedpipe name reuse

### DIFF
--- a/orbit/changes/bug-6935-cannot-run-orbit-shell-on-windows
+++ b/orbit/changes/bug-6935-cannot-run-orbit-shell-on-windows
@@ -1,1 +1,1 @@
-* Orbit does not exit now when running osquery shell
+* Fixed an issue that prevented orbit shell to run when the osqueryd instance ran through orbit shell attempted to register the same named pipe name used by the osqueryd instance launched by orbit service

--- a/orbit/changes/bug-6935-cannot-run-orbit-shell-on-windows
+++ b/orbit/changes/bug-6935-cannot-run-orbit-shell-on-windows
@@ -1,0 +1,1 @@
+* Orbit does not exit now when running osquery shell

--- a/orbit/pkg/osquery/osquery.go
+++ b/orbit/pkg/osquery/osquery.go
@@ -119,6 +119,23 @@ func WithDataPath(path string) Option {
 	}
 }
 
+func WithDataPathAndExtensionPathPostfix(path string, extensionPathPostfix string) Option {
+	return func(r *Runner) error {
+		r.dataPath = path
+
+		if err := secure.MkdirAll(path, constant.DefaultDirMode); err != nil {
+			return fmt.Errorf("initialize osquery data path: %w", err)
+		}
+
+		r.cmd.Args = append(r.cmd.Args,
+			"--pidfile="+filepath.Join(path, "osquery.pid"),
+			"--database_path="+filepath.Join(path, "osquery.db"),
+			"--extensions_socket="+r.ExtensionSocketPath()+extensionPathPostfix,
+		)
+		return nil
+	}
+}
+
 // WithStderr sets the runner's cmd's stderr to the given writer.
 func WithStderr(w io.Writer) Option {
 	return func(r *Runner) error {


### PR DESCRIPTION
This relates to #6935 

There was an issue when the osqueryd instance ran through `orbit shell` attempted to register the same named pipe name used by the osqueryd instance launched by orbit service

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [X] Manual QA for all new/changed functionality