### PR TITLE
doubly encode the CSR in base64

### DIFF
--- a/website/api/controllers/deliver-apple-csr.js
+++ b/website/api/controllers/deliver-apple-csr.js
@@ -139,6 +139,10 @@ module.exports = {
       template: 'email-signed-csr-for-apns',
       templateData: {},
       attachments: [{
+        // When the file is provided as an attachment to the Sails helper, it
+        // gets decoded, since we need for the signed CSR to be delivered in
+        // base64 format, we doubly encode the contents before sending the
+        // email.
         contentBytes: Buffer.from(generateCertificateResult.request).toString('base64'),
         name: 'apple-apns-request.txt',
         type: 'text/plain',

--- a/website/api/controllers/deliver-apple-csr.js
+++ b/website/api/controllers/deliver-apple-csr.js
@@ -139,7 +139,7 @@ module.exports = {
       template: 'email-signed-csr-for-apns',
       templateData: {},
       attachments: [{
-        contentBytes: generateCertificateResult.request,
+        contentBytes: Buffer.from(generateCertificateResult.request).toString('base64'),
         name: 'apple-apns-request.txt',
         type: 'text/plain',
       }],


### PR DESCRIPTION
When the file is provided as an attachment to the Sails helper, it gets decoded, since we need for the signed CSR to be delivered in base64 format, we doubly encode the contents before sending the email.
