### PR TITLE
Initial osquery-perf terraform module addon

### DIFF
--- a/infrastructure/loadtesting/terraform/loadtesting.tf
+++ b/infrastructure/loadtesting/terraform/loadtesting.tf
@@ -1,3 +1,5 @@
+data "aws_region" "current" {}
+
 resource "aws_ecs_service" "loadtest" {
   name                               = "loadtest"
   launch_type                        = "FARGATE"

--- a/terraform/addons/osquery-perf/.header.md
+++ b/terraform/addons/osquery-perf/.header.md
@@ -1,0 +1,23 @@
+# osquery-perf addon
+This addon adds osquery-perf hosts to the Fleet installation.
+These are generally used for loadtesting or other testing purposes.  See https://github.com/fleetdm/fleet/tree/main/cmd/osquery-perf to learn more about osquery-perf itself.
+
+This addon creates an AWS Secrets Manager secret that will be used to store the enroll secret that the osquery-perf hosts use to enroll into Fleet.  This secret will need to have its `SecretString` populated with the enroll secret manually once everything is setup in order for the osquery-perf hosts to connect.
+
+Below is an example implementation of the module:
+
+```
+module "osquery_perf" {
+  source                     = "github.com/fleetdm/fleet//terraform/addons/osquery-perf?ref=main"
+  customer_prefix            = "fleet"
+  ecs_cluster                = module.main.byo-vpc.byo-db.byo-ecs.service.cluster
+  subnets                    = module.main.byo-vpc.byo-db.byo-ecs.service.network_configuration[0].subnets
+  security_groups            = module.main.byo-vpc.byo-db.byo-ecs.service.network_configuration[0].security_groups
+  ecs_iam_role_arn           = module.main.byo-vpc.byo-db.byo-ecs.iam_role_arn
+  ecs_execution_iam_role_arn = module.main.byo-vpc.byo-db.byo-ecs.execution_iam_role_arn
+  server_url                 = "https://${aws_route53_record.main.fqdn}"
+  osquery_perf_image         = local.osquery_perf_image
+  extra_flags                = ["--os_templates", "mac10.14.6,ubuntu_22.04,windows_11"]
+  logging_options            = module.main.byo-vpc.byo-db.byo-ecs.logging_config
+}
+```

--- a/terraform/addons/osquery-perf/.terraform-docs.yml
+++ b/terraform/addons/osquery-perf/.terraform-docs.yml
@@ -1,0 +1,1 @@
+header-from: .header.md

--- a/terraform/addons/osquery-perf/README.md
+++ b/terraform/addons/osquery-perf/README.md
@@ -1,0 +1,68 @@
+# osquery-perf addon
+This addon adds osquery-perf hosts to the Fleet installation.
+These are generally used for loadtesting or other testing purposes.  See https://github.com/fleetdm/fleet/tree/main/cmd/osquery-perf to learn more about osquery-perf itself.
+
+This addon creates an AWS Secrets Manager secret that will be used to store the enroll secret that the osquery-perf hosts use to enroll into Fleet.  This secret will need to have its `SecretString` populated with the enroll secret manually once everything is setup in order for the osquery-perf hosts to connect.
+
+Below is an example implementation of the module:
+
+```
+module "osquery_perf" {
+  source                     = "github.com/fleetdm/fleet//terraform/addons/osquery-perf?ref=main"
+  customer_prefix            = "fleet"
+  ecs_cluster                = module.main.byo-vpc.byo-db.byo-ecs.service.cluster
+  subnets                    = module.main.byo-vpc.byo-db.byo-ecs.service.network_configuration[0].subnets
+  security_groups            = module.main.byo-vpc.byo-db.byo-ecs.service.network_configuration[0].security_groups
+  ecs_iam_role_arn           = module.main.byo-vpc.byo-db.byo-ecs.iam_role_arn
+  ecs_execution_iam_role_arn = module.main.byo-vpc.byo-db.byo-ecs.execution_iam_role_arn
+  server_url                 = "https://${aws_route53_record.main.fqdn}"
+  osquery_perf_image         = local.osquery_perf_image
+  extra_flags                = ["--os_templates", "mac10.14.6,ubuntu_22.04,windows_11"]
+  logging_options            = module.main.byo-vpc.byo-db.byo-ecs.logging_config
+}
+```
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ecs_service.osquery_perf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.osquery_perf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_kms_alias.enroll_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
+| [aws_kms_key.enroll_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_secretsmanager_secret.enroll_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.enroll_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_customer_prefix"></a> [customer\_prefix](#input\_customer\_prefix) | customer prefix to use to namespace all resources | `string` | `"fleet"` | no |
+| <a name="input_ecs_cluster"></a> [ecs\_cluster](#input\_ecs\_cluster) | n/a | `string` | n/a | yes |
+| <a name="input_ecs_execution_iam_role_arn"></a> [ecs\_execution\_iam\_role\_arn](#input\_ecs\_execution\_iam\_role\_arn) | n/a | `string` | n/a | yes |
+| <a name="input_ecs_iam_role_arn"></a> [ecs\_iam\_role\_arn](#input\_ecs\_iam\_role\_arn) | n/a | `string` | n/a | yes |
+| <a name="input_extra_flags"></a> [extra\_flags](#input\_extra\_flags) | n/a | `list(string)` | `[]` | no |
+| <a name="input_loadtest_containers"></a> [loadtest\_containers](#input\_loadtest\_containers) | n/a | `number` | `1` | no |
+| <a name="input_logging_options"></a> [logging\_options](#input\_logging\_options) | n/a | <pre>object({<br>    awslogs-group         = string<br>    awslogs-region        = string<br>    awslogs-stream-prefix = string<br>  })</pre> | n/a | yes |
+| <a name="input_osquery_perf_image"></a> [osquery\_perf\_image](#input\_osquery\_perf\_image) | n/a | `string` | n/a | yes |
+| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | n/a | `list(string)` | n/a | yes |
+| <a name="input_server_url"></a> [server\_url](#input\_server\_url) | n/a | `string` | n/a | yes |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | n/a | `list(string)` | n/a | yes |
+
+## Outputs
+
+No outputs.

--- a/terraform/addons/osquery-perf/main.tf
+++ b/terraform/addons/osquery-perf/main.tf
@@ -1,0 +1,79 @@
+resource "aws_kms_key" "enroll_secret" {
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+}
+
+resource "aws_kms_alias" "enroll_secret" {
+  name_prefix   = "alias/${var.customer_prefix}-enroll-secret-key"
+  target_key_id = aws_kms_key.enroll_secret.key_id
+}
+
+resource "aws_secretsmanager_secret" "enroll_secret" {
+  name_prefix = "${var.customer_prefix}-enroll-secret"
+  kms_key_id  = aws_kms_key.enroll_secret.arn
+}
+
+data "aws_secretsmanager_secret_version" "enroll_secret" {
+  secret_id = aws_secretsmanager_secret.enroll_secret.id
+}
+
+resource "aws_ecs_task_definition" "osquery_perf" {
+  family                   = "${var.customer_prefix}-osquery-perf"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  execution_role_arn       = var.ecs_execution_iam_role_arn
+  task_role_arn            = var.ecs_iam_role_arn
+  cpu                      = 256
+  memory                   = 1024
+  container_definitions = jsonencode(
+    [
+      {
+        name        = "osquery-perf"
+        image       = var.osquery_perf_image
+        cpu         = 256
+        memory      = 512
+        mountPoints = []
+        volumesFrom = []
+        essential   = true
+        ulimits = [
+          {
+            softLimit = 9999,
+            hardLimit = 9999,
+            name      = "nofile"
+          }
+        ]
+        networkMode = "awsvpc"
+        logConfiguration = {
+          logDriver = "awslogs"
+          options = var.logging_options
+        }
+        workingDirectory = "/go",
+        command = concat([
+          "/go/osquery-perf",
+          "-enroll_secret", data.aws_secretsmanager_secret_version.enroll_secret.secret_string,
+          "-host_count", "500",
+          "-server_url", var.server_url,
+          "--policy_pass_prob", "0.5",
+          "--start_period", "5m",
+        ], var.extra_flags)
+      }
+  ])
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_ecs_service" "osquery_perf" {
+  name                               = "osquery_perf"
+  launch_type                        = "FARGATE"
+  cluster                            = var.ecs_cluster
+  task_definition                    = aws_ecs_task_definition.osquery_perf.arn
+  desired_count                      = var.loadtest_containers
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+
+  network_configuration {
+    subnets         = var.subnets
+    security_groups = var.security_groups
+  }
+}

--- a/terraform/addons/osquery-perf/variables.tf
+++ b/terraform/addons/osquery-perf/variables.tf
@@ -1,0 +1,53 @@
+variable "customer_prefix" {
+  type        = string
+  description = "customer prefix to use to namespace all resources"
+  default     = "fleet"
+}
+
+variable "ecs_cluster" {
+  type     = string
+}
+
+variable "ecs_execution_iam_role_arn" {
+  type     = string
+}
+
+variable "ecs_iam_role_arn" {
+  type     = string
+}
+
+variable "extra_flags" {
+  type     = list(string)
+  default  = []
+}
+
+variable "loadtest_containers" {
+  type     = number
+  default  = 1
+}
+
+variable "logging_options" {
+  type = object({
+    awslogs-group         = string
+    awslogs-region        = string
+    awslogs-stream-prefix = string
+  })
+}
+
+variable "osquery_perf_image" {
+  type     = string
+}
+
+variable "security_groups" {
+  type     = list(string)
+  nullable = false
+}
+
+variable "server_url" {
+  type     = string
+}
+
+variable "subnets" {
+  type     = list(string)
+  nullable = false
+}

--- a/terraform/byo-vpc/byo-db/byo-ecs/outputs.tf
+++ b/terraform/byo-vpc/byo-db/byo-ecs/outputs.tf
@@ -6,6 +6,24 @@ output "task_definition" {
   value = aws_ecs_task_definition.backend
 }
 
+output "iam_role_arn" {
+  # Always respond sanely even if we did not generate
+  value = var.fleet_config.iam_role_arn == null ? aws_iam_role.main[0].arn : var.fleet_config.iam_role_arn
+}
+
+output "execution_iam_role_arn" {
+  value = aws_iam_role.execution.arn
+}
+
+output "logging_config" {
+  # Always respond sanely even if we did not generate
+  value = {
+    awslogs-group         = var.fleet_config.awslogs.create == true ? aws_cloudwatch_log_group.main[0].name : var.fleet_config.awslogs.name
+    awslogs-region        = var.fleet_config.awslogs.create == true ? data.aws_region.current.name : var.fleet_config.awslogs.region
+    awslogs-stream-prefix = var.fleet_config.awslogs.prefix
+  }
+}
+
 output "non_circular" {
   value = {
     "security_groups" = var.fleet_config.networking.security_groups == null ? aws_security_group.main.*.id : var.fleet_config.networking.security_groups,


### PR DESCRIPTION
I added some outputs to re-use the execution and other iam roles here.  If I should create separate roles for osquery-perf I can do so, but in other places we used it (like loadtesting), we reused the roles, so I thought it might make sense here.  I am open to discussion however.