### PR TITLE
Fleet Documentation: Update agent options and enrollment secret documentation

### DIFF
--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -1032,7 +1032,7 @@ to the amount of time it takes for Fleet to give the host the label queries.
 
 ##### osquery_enable_async_host_processing
 
-**Experimental feature**. Enable asynchronous processing of hosts' query results. Currently, asyncronous processing is only supported for label query execution, policy membership results, hosts' last seen timestamp and hosts' scheduled query statistics. This may improve the performance and CPU usage of the Fleet instances and MySQL database servers for setups with a large number of hosts while requiring more resources from Redis server(s).
+**Experimental feature**. Enable asynchronous processing of hosts' query results. Currently, asyncronous processing is only supported for label query execution, policy membership results, hosts' last seen timestamp, and hosts' scheduled query statistics. This may improve the performance and CPU usage of the Fleet instances and MySQL database servers for setups with a large number of hosts while requiring more resources from Redis server(s).
 
 Note that currently, if both the failing policies webhook *and* this `osquery.enable_async_host_processing` option are set, some failing policies webhooks could be missing (some transitions from succeeding to failing or vice-versa could happen without triggering a webhook request).
 

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -225,7 +225,7 @@ The path to a PEM encoded certificate is used for TLS authentication.
 
 ##### mysql_tls_key
 
-The path to a PEM encoded private key uses for TLS authentication.
+The path to a PEM encoded private key used for TLS authentication.
 
 - Default value: none
 - Environment variable: `FLEET_MYSQL_TLS_KEY`
@@ -395,7 +395,7 @@ Use a TLS connection to the Redis server.
 
 ##### redis_duplicate_results
 
-Whether or not to duplicate Live Query results to another Redis channel named `LQDuplicate`. This is useful in a scenario involving shipping the Live Query results outside of Fleet, near-realtime.
+Whether or not to duplicate Live Query results to another Redis channel named `LQDuplicate`. This is useful in a scenario involving shipping the Live Query results outside of Fleet, near real-time.
 
 - Default value: `false`
 - Environment variable: `FLEET_REDIS_DUPLICATE_RESULTS`
@@ -904,7 +904,7 @@ The identifier to use when determining uniqueness of hosts.
 
 Options are `provided` (default), `uuid`, `hostname`, or `instance`.
 
-This setting works in combination with the `--host_identifier` flag in osquery. In most deployments, using `uuid` will be the best option. The flag defaults to `provided` -- preserving the existing behavior of Fleet's handling of host identifiers -- using the identifier provided by osquery. `instance`, `uuid`, and `hostname` correspond to the same meanings as for osquery's `--host_identifier` flag.
+This setting works in combination with the `--host_identifier` flag in osquery. In most deployments, using `uuid` will be the best option. The flag defaults to `provided` -- preserving the existing behavior of Fleet's handling of host identifiers -- using the identifier provided by osquery. `instance`, `uuid`, and `hostname` correspond to the same meanings as osquery's `--host_identifier` flag.
 
 Users that have duplicate UUIDs in their environment can benefit from setting this flag to `instance`.
 
@@ -1032,7 +1032,7 @@ to the amount of time it takes for Fleet to give the host the label queries.
 
 ##### osquery_enable_async_host_processing
 
-**Experimental feature**. Enable asynchronous processing of hosts' query results. Currently, only supported for label query execution, policy membership results, hosts' last seen timestamp and hosts' scheduled query statistics. This may improve the performance and CPU usage of the Fleet instances and MySQL database servers for setups with a large number of hosts while requiring more resources from Redis server(s).
+**Experimental feature**. Enable asynchronous processing of hosts' query results. Currently, asyncronous processing is only supported for label query execution, policy membership results, hosts' last seen timestamp and hosts' scheduled query statistics. This may improve the performance and CPU usage of the Fleet instances and MySQL database servers for setups with a large number of hosts while requiring more resources from Redis server(s).
 
 Note that currently, if both the failing policies webhook *and* this `osquery.enable_async_host_processing` option are set, some failing policies webhooks could be missing (some transitions from succeeding to failing or vice-versa could happen without triggering a webhook request).
 
@@ -2809,7 +2809,7 @@ After modifying the configuration you will need to reload and restart the Fleet 
 
 Fleet supports SAML single sign-on capability.
 
-Fleet supports both SP-initiated SAML login and IDP-initiated login however, IDP-initiated login must be enabled in the web interface's SAML single sign-on options.
+Fleet supports both SP-initiated SAML login and IDP-initiated login. However, IDP-initiated login must be enabled in the web interface's SAML single sign-on options.
 
 Fleet supports the SAML Web Browser SSO Profile using the HTTP Redirect Binding.
 
@@ -2844,7 +2844,7 @@ Otherwise, the following values are required:
 - _Identity provider name_ - A human-readable name of the IDP. This is rendered on the login page.
 
 - _Entity ID_ - A URI that identifies your Fleet instance as the issuer of authorization
-  requests (e.g., `fleet.example.com`). This much match the _Entity ID_ configured with the IDP.
+  requests (e.g., `fleet.example.com`). This must match the _Entity ID_ configured with the IDP.
 
 - _Issuer URI_ - Obtain this value from the IDP.
 

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -55,41 +55,13 @@ The `fleet` binary contains several "commands." Similarly to how `git` has many 
 
 You can specify options in the order of precedence via
 
-- a configuration file (in YAML format).
-- environment variables.
-- command-line flags.
+1. a configuration file (in YAML format)
+2. environment variables
+3. command-line flags
 
 For example, all of the following ways of launching Fleet are equivalent:
 
-##### Using only CLI flags
-
-```
-/usr/bin/fleet serve \
---mysql_address=127.0.0.1:3306 \
---mysql_database=fleet \
---mysql_username=root \
---mysql_password=toor \
---redis_address=127.0.0.1:6379 \
---server_cert=/tmp/server.cert \
---server_key=/tmp/server.key \
---logging_json
-```
-
-##### Using only environment variables
-
-```
-FLEET_MYSQL_ADDRESS=127.0.0.1:3306 \
-FLEET_MYSQL_DATABASE=fleet \
-FLEET_MYSQL_USERNAME=root \
-FLEET_MYSQL_PASSWORD=toor \
-FLEET_REDIS_ADDRESS=127.0.0.1:6379 \
-FLEET_SERVER_CERT=/tmp/server.cert \
-FLEET_SERVER_KEY=/tmp/server.key \
-FLEET_LOGGING_JSON=true \
-/usr/bin/fleet serve
-```
-
-##### Using a YAML config file
+##### 1. Using a YAML config file
 
 ```
 echo '
@@ -111,6 +83,35 @@ fleet serve --config /tmp/fleet.yml
 ```
 
 For more information on using YAML configuration files with fleet, please see the [configuration files](https://fleetdm.com/docs/using-fleet/configuration-files) documentation.
+
+##### 2. Using only environment variables
+
+```
+FLEET_MYSQL_ADDRESS=127.0.0.1:3306 \
+FLEET_MYSQL_DATABASE=fleet \
+FLEET_MYSQL_USERNAME=root \
+FLEET_MYSQL_PASSWORD=toor \
+FLEET_REDIS_ADDRESS=127.0.0.1:6379 \
+FLEET_SERVER_CERT=/tmp/server.cert \
+FLEET_SERVER_KEY=/tmp/server.key \
+FLEET_LOGGING_JSON=true \
+/usr/bin/fleet serve
+```
+
+##### 3. Using only CLI flags
+
+```
+/usr/bin/fleet serve \
+--mysql_address=127.0.0.1:3306 \
+--mysql_database=fleet \
+--mysql_username=root \
+--mysql_password=toor \
+--redis_address=127.0.0.1:6379 \
+--server_cert=/tmp/server.cert \
+--server_key=/tmp/server.key \
+--logging_json
+```
+
 
 ### What are the options?
 

--- a/docs/Deploying/FAQ.md
+++ b/docs/Deploying/FAQ.md
@@ -5,7 +5,6 @@
 - [Why aren't my osquery agents connecting to Fleet?](#why-arent-my-osquery-agents-connecting-to-fleet)
 - [How do I fix "certificate verify failed" errors from osqueryd?](#how-do-i-fix-certificate-verify-failed-errors-from-osqueryd)
 - [What do I need to do to change the Fleet server TLS certificate?](#what-do-i-need-to-do-to-change-the-fleet-server-tls-certificate)
-- [When do I need to deploy a new enroll secret to my hosts?](#when-do-i-need-to-deploy-a-new-enroll-secret-to-my-hosts)
 - [How do I migrate hosts from one Fleet server to another (eg. testing to production)?](#how-do-i-migrate-hosts-from-one-fleet-server-to-another-eg-testing-to-production)
 - [What do I do about "too many open files" errors?](#what-do-i-do-about-too-many-open-files-errors)
 - [Can I skip versions when updating Fleet to the latest version?](#can-i-skip-versions-when-updating-to-the-latest-version)
@@ -16,9 +15,6 @@
 - [What are the MySQL user access requirements?](#what-are-the-mysql-user-requirements)
 - [Does Fleet support MySQL replication?](#does-fleet-support-mysql-replication)
 - [What is duplicate enrollment and how do I fix it?](#what-is-duplicate-enrollment-and-how-do-i-fix-it)
-- [How long are osquery enroll secrets valid?](#how-long-are-osquery-enroll-secrets-valid)
-- [Should I use multiple enroll secrets?](#should-i-use-multiple-enroll-secrets)
-- [How can enroll secrets be rotated?](#how-can-enroll-secrets-be-rotated)
 - [What API endpoints should I expose to the public internet?](#what-api-endpoints-should-i-expose-to-the-public-internet)
 - [What Redis versions are supported?](#what-redis-versions-are-supported)
 - [Will my older version of Fleet work with Redis 6?](#will-my-older-version-of-fleet-work-with-redis-6)
@@ -85,14 +81,6 @@ We recommend a config like the following:
 ```
 client-output-buffer-limit pubsub 0 0 60
 ```
-
-## When do I need to deploy a new enroll secret to my hosts?
-
-Osquery provides the enroll secret only during the enrollment process. Once a host is enrolled, the node key it receives remains valid for authentication independent from the enroll secret.
-
-Currently enrolled hosts do not necessarily need enroll secrets updated, as the existing enrollment will continue to be valid as long as the host is not deleted from Fleet and the osquery store on the host remains valid. Any newly enrolling hosts must have the new secret.
-
-Deploying a new enroll secret cannot be done centrally from Fleet.
 
 ## How do I migrate hosts from one Fleet server to another (eg. testing to production)?
 
@@ -180,77 +168,6 @@ the problem can be resolved by setting `--osquery_host_identifier=instance` (whi
 osquery generated UUID), and then delete the associated host in the Fleet UI.
 
 Find more information about [host identifiers here](https://fleetdm.com/docs/deploying/configuration#osquery-host-identifier).
-
-## How long are osquery enroll secrets valid?
-
-Enroll secrets are valid until you delete them.
-
-## Should I use multiple enroll secrets?
-
-That is up to you! Some organizations have internal goals around rotating secrets. Having multiple secrets allows some of them to work at the same time the rotation is happening.
-Another reason you might want to use multiple enroll secrets is to use a certain enroll secret to
-auto-enroll hosts into a specific team (Fleet Premium).
-
-## How can enroll secrets be rotated?
-
-Rotating enroll secrets follows this process:
-
-1. Add a new secret.
-2. Transition existing clients to the new secret. Note that existing clients may not need to be
-   updated, as the enroll secret is not used by already enrolled clients.
-3. Remove the old secret.
-
-To do this with `fleetctl` (assuming the existing secret is `oldsecret` and the new secret is `newsecret`):
-
-Begin by retrieving the existing secret configuration:
-
-```
-$ fleetctl get enroll_secret
----
-apiVersion: v1
-kind: enroll_secret
-spec:
-  secrets:
-  - created_at: "2021-11-17T00:39:50Z"
-    secret: oldsecret
-```
-
-Apply the new configuration with both secrets:
-
-```
-$ echo '
----
-apiVersion: v1
-kind: enroll_secret
-spec:
-  secrets:
-  - created_at: "2021-11-17T00:39:50Z"
-    secret: oldsecret
-  - secret: newsecret
-' > secrets.yml
-$ fleetctl apply -f secrets.yml
-```
-
-Now transition clients to using only the new secret. When the transition is completed, remove the
-old secret:
-
-```
-$ echo '
----
-apiVersion: v1
-kind: enroll_secret
-spec:
-  secrets:
-  - secret: newsecret
-' > secrets.yml
-$ fleetctl apply -f secrets.yml
-```
-
-At this point, the old secret will no longer be accepted for new enrollments and the rotation is
-complete.
-
-A similar process may be followed for rotating team-specific enroll secrets. For teams, the secrets
-are managed in the team yaml.
 
 ## How do I resolve an "unknown column" error when upgrading Fleet?
 

--- a/docs/Using-Fleet/FAQ.md
+++ b/docs/Using-Fleet/FAQ.md
@@ -53,7 +53,6 @@
   - [Why aren't "additional queries" being applied to hosts enrolled in a team?](why-arent-additional-queries-being-applied-to-hosts-enrolled-in-a-team)
   - [Why am I seeing an error when using the `after` key in `api/v1/fleet/hosts`?](#why-am-i-seeing-an-error-when-using-the-after-key-in-apiv1fleethosts)
   - [What can I do if Fleet is slow or unresponsive after enabling a feature?](#what-can-i-do-if-fleet-is-slow-or-unresponseive-after-enabling-a-feature)
-  - [Why am I seeing an "unsupported key" error when updating agent options?](#why-am-i-seeing-an-unsupported-key-error-when-updating-agent-options)
   - [How can I renew my Apple Business Manager server token?](#how-can-i-renew-my-apple-business-manager-server-token)
   - [Why am I getting errors when generating a .msi package on MacOS?](#why-am-i-getting-errors-when-generating-a-msi-package-on-macos)
 
@@ -69,7 +68,7 @@ It’s standard deployment practice to have multiple Fleet servers behind a load
 
 ## Can I target my hosts using their enroll secrets?
 
-No, currently, there’s no way to retrieve the name of the enroll secret with a query. This means that there's no way to create a label using your hosts' enroll secrets and then use this label as atarget for live queries or scheduled queries.
+No, currently, there’s no way to retrieve the name of the enroll secret with a query. This means that there's no way to create a label using your hosts' enroll secrets and then use this label as a target for live queries or scheduled queries.
 
 Typically folks will use some other unique identifier to create labels that distinguish each type of device. As a workaround, [Fleet's manual labels](https://fleetdm.com/docs/using-fleet/fleetctl-cli#host-labels) provide a way to create groups of hosts without a query. These manual labels can then be used as targets for queries.
 
@@ -175,9 +174,6 @@ The ability to view each host’s installed software was released behind a featu
 Once the Software inventory feature is turned on, a list of a specific host’s installed software is available using the `api/v1/fleet/hosts/{id}` endpoint. [Check out the documentation for this endpoint](https://fleetdm.com/docs/using-fleet/rest-api#get-host).
 
 It’s possible in Fleet to retrieve each host’s kernel version, using the Fleet API, through `additional_queries`. The Fleet configuration options YAML file includes an `additional_queries` property that allows you to append custom query results to the host details returned by the `api/v1/fleet/hosts` endpoint. [Check out an example configuration file with the additional_queries field](https://fleetdm.com/docs/using-fleet/fleetctl-cli#fleet-configuration-options).
-## How do I automatically assign a host to a team when it enrolls with Fleet?
-
-[Team enroll secrets](https://fleetdm.com/docs/using-fleet/teams#enroll-hosts-to-a-team) allow you to automatically assign a host to a team.
 
 ## Why is my host not updating a policy's response?
 
@@ -392,22 +388,7 @@ There is a [bug](https://github.com/fleetdm/fleet/issues/8443) in MySQL validati
 Depending on your infrastructure capabilities, and the number of hosts enrolled into your Fleet instance, Fleet might be slow or unresponsive after globally enabling a feature like [software inventory](https://fleetdm.com/docs/deploying/configuration#software-inventory).
 
 In those cases, we recommend a slow rollout by partially enabling the feature by teams using the `features` key of the [teams configuration](https://fleetdm.com/docs/using-fleet/configuration-files#teams).
-
-## Why am I seeing an "unsupported key" error when updating agent options?
-
-When updating agent options, you may see an error similar to this:
-
-```
-[...] unsupported key provided: "logger_plugin"
-If you’re not using the latest osquery, use the fleetctl apply --force command to override validation.
-```
-
-This error indicates that you're providing a config option that isn't valid in the current version of osquery, typically because you're setting a command line flag through the configuration key. This has always been unsupported through the config plugin, but osquery has recently become more opinionated and Fleet now validates the configuration to make sure there aren't errors in the osquery agent.
-
-If you are not using the latest version of osquery, you can create a config YAML file and apply it with `fleetctl` using the `--force` flag to override the validation:
-
-```fleetctl apply --force -f config.yaml```
-
+   
 ## How can I renew my Apple Business Manager server token?
 
 > This feature is currently in development and is not ready for production use.

--- a/docs/Using-Fleet/Fleet-UI.md
+++ b/docs/Using-Fleet/Fleet-UI.md
@@ -87,7 +87,9 @@ How to update agent options:
 
 2. On the Organization settings page, select **Agent options** on the left side of the page.
 
-3. To see all agent options, head to the [agent options documentation](https://fleetdm.com/docs/deploying/configuration#agent-options).
+3. Use Fleet's YAML editor to configure your osquery options, decorators, or set command line flags.
+
+To see all agent options, head to the [agent options documentation](https://fleetdm.com/docs/using-fleet/configuration-files#agent-options).
 
 4. Place your new setting one level below the `options` key. The new setting's key should be below and one tab to the right of `options`.
 

--- a/docs/Using-Fleet/Fleet-UI.md
+++ b/docs/Using-Fleet/Fleet-UI.md
@@ -95,7 +95,21 @@ To see all agent options, head to the [agent options documentation](https://flee
 
 5. Select **Save**.
 
-The agents may take several seconds to update because Fleet has to wait for the hosts to check in.
+The agents may take several seconds to update because Fleet has to wait for the hosts to check in. Additionally, hosts enrolled with removed enroll secrets must properly rotate their secret to have the new changes take effect.
+
+When updating agent options, you may see an error similar to this:
+
+```
+[...] unsupported key provided: "logger_plugin"
+If you’re not using the latest osquery, use the fleetctl apply --force command to override validation.
+```
+
+This error indicates that you're providing a config option that isn't valid in the current version of osquery, typically because you're setting a command line flag through the configuration key. This has always been unsupported through the config plugin, but osquery has recently become more opinionated and Fleet now validates the configuration to make sure there aren't errors in the osquery agent.
+
+If you are not using the latest version of osquery, you can create a config YAML file and apply it with `fleetctl` using the `--force` flag to override the validation:
+
+```fleetctl apply --force -f config.yaml```
+
 
 <meta name="title" value="Fleet UI">
 

--- a/docs/Using-Fleet/Fleet-UI.md
+++ b/docs/Using-Fleet/Fleet-UI.md
@@ -97,20 +97,6 @@ To see all agent options, head to the [agent options documentation](https://flee
 
 The agents may take several seconds to update because Fleet has to wait for the hosts to check in. Additionally, hosts enrolled with removed enroll secrets must properly rotate their secret to have the new changes take effect.
 
-When updating agent options, you may see an error similar to this:
-
-```
-[...] unsupported key provided: "logger_plugin"
-If you’re not using the latest osquery, use the fleetctl apply --force command to override validation.
-```
-
-This error indicates that you're providing a config option that isn't valid in the current version of osquery, typically because you're setting a command line flag through the configuration key. This has always been unsupported through the config plugin, but osquery has recently become more opinionated and Fleet now validates the configuration to make sure there aren't errors in the osquery agent.
-
-If you are not using the latest version of osquery, you can create a config YAML file and apply it with `fleetctl` using the `--force` flag to override the validation:
-
-```fleetctl apply --force -f config.yaml```
-
-
 <meta name="title" value="Fleet UI">
 
 <meta name="pageOrderInSection" value="200">

--- a/docs/Using-Fleet/Learn-how-to-use-Fleet.md
+++ b/docs/Using-Fleet/Learn-how-to-use-Fleet.md
@@ -39,15 +39,15 @@ This question can easily be answered by running this simple query: "Get operatin
 To run this query on your device:
 
 1. Select **Queries** in the top navigation.
-2. Enter "Get operating system information" in the search bar.
-3. Select **Get operating system information** to enter the **query console**.
+2. Select **Create new query** (or browse your organization's queries for "operating system information" in the search bar).
+3. Type the query you would like to run, `SELECT * FROM os_version;`.
 4. Select **Run query**, then select **All hosts** (your device may be the only host added to Fleet), and finally select **Run** to execute the query.
 
-The query may take several seconds to complete, because Fleet has to wait for the osquery agents to respond with results.
+The query may take several seconds to complete, because Fleet has to wait for the osquery agents to respond with results. Only online hosts will respond with results to a live query.
 
 > Fleet's query response time is inherently variable because of osquery's heartbeat response time. This helps prevent performance issues on hosts.
 
-When the query has finished, you should see several columns in the "Results" table:
+When the query has finished, see several columns in the "Results" table:
 
 - The "name" column answers: "What operating system is installed on my device?" 
 

--- a/docs/Using-Fleet/Learn-how-to-use-Fleet.md
+++ b/docs/Using-Fleet/Learn-how-to-use-Fleet.md
@@ -47,7 +47,7 @@ The query may take several seconds to complete, because Fleet has to wait for th
 
 > Fleet's query response time is inherently variable because of osquery's heartbeat response time. This helps prevent performance issues on hosts.
 
-When the query has finished, see several columns in the "Results" table:
+When the query has finished, you should see several columns in the "Results" table:
 
 - The "name" column answers: "What operating system is installed on my device?" 
 

--- a/docs/Using-Fleet/configuration-files/README.md
+++ b/docs/Using-Fleet/configuration-files/README.md
@@ -1033,7 +1033,7 @@ You can verify that these flags have taken effect on the hosts by running a quer
 
 > If you revoked an old enroll secret, this feature won't update for hosts that were added to Fleet using this old enroll secret. This is because Orbit uses the enroll secret to receive new flags from Fleet. For these hosts, all existing features will work as expected.
 
-For further documentation on how to rotate enroll secrets, please see [this guide](https://fleetdm.com/docs/deploying/faq#how-can-enroll-secrets-be-rotated).
+For further documentation on how to rotate enroll secrets, please see [this guide](#rotating-enroll-secrets).
 
 If you prefer to deploy a new package with the updated enroll secret:
 

--- a/docs/Using-Fleet/configuration-files/README.md
+++ b/docs/Using-Fleet/configuration-files/README.md
@@ -3,7 +3,12 @@
 - [Queries](#queries)
 - [Labels](#labels)
 - [Enroll secrets](#enroll-secrets)
-- [Teams](#teams)
+  - [Multiple enroll secrets](#multiple-enroll-secrets)
+  - [Rotating enroll secrets](#rotating-enroll-secrets)
+- [Team settings](#team-settings)
+  - [Team agent options](#team-agent-options)
+  - [Team enroll secrets](#team-enroll-secrets)
+- [Mobile device management settings](#mobile-device-management-mdm-settings)
 - [Organization settings](#organization-settings)
 
 Fleet can be managed with configuration files (YAML syntax) and the fleetctl command line tool. This page tells you how to write these configuration files.
@@ -46,7 +51,7 @@ Continued edits and applications to this file will update the queries.
 
 If you want to change the name of a query, you must first create a new query with the new name and then delete the query with the old name.
 
-### Labels
+## Labels
 
 The following file describes the labels which hosts should be automatically grouped into. The label resource should include the actual SQL query so that the label is self-contained:
 
@@ -107,11 +112,7 @@ Deploying a new enroll secret cannot be done centrally from Fleet.
 ### Multiple enroll secrets 
 
 Fleet allows the abiility to maintain multiple enroll secrets. Some organizations have internal goals  around rotating secrets. Having multiple secrets allows some of them to work at the same time the rotation is happening.
-Another reason you might want to use multiple enroll secrets is to use a certain enroll secret to auto-enroll hosts into a specific team (Fleet Premium).
-
-### Team enroll secrets
-
-On Fleet Premium, [team enroll secrets](https://fleetdm.com/docs/using-fleet/teams#enroll-hosts-to-a-team) allow you to automatically assign a host to a team.
+Another reason you might want to use multiple enroll secrets is to use a certain [team enroll secret](#team-enroll-secrets) to auto-enroll hosts into a specific [team](https://fleetdm.com/docs/using-fleet/teams) (Fleet Premium).
 
 ### Rotating enroll secrets
 
@@ -174,7 +175,7 @@ complete.
 A similar process may be followed for rotating team-specific enroll secrets. For teams, the secrets
 are managed in the team yaml.
 
-## Teams
+## Team settings
 
 **Applies only to Fleet Premium**.
 
@@ -221,9 +222,7 @@ spec:
         deadline: 2022-01-04
 ```
 
-### Team settings
-
-#### Team agent options
+### Team agent options
 
 The team agent options specify options that only apply to this team. When team-specific agent options have been specified, the agent options specified at the organization level are ignored for this team.
 
@@ -239,7 +238,7 @@ spec:
       # the team-specific options go here
 ```
 
-#### Secrets
+### Team secrets
 
 The `secrets` section provides the list of enroll secrets that will be valid for this team. If the section is missing, the existing secrets are left unmodified. Otherwise, they are replaced with this list of secrets for this team.
 
@@ -287,7 +286,7 @@ webhook_settings
 
 You can bypass these errors by removing the key from your YAML or adding the `--force` flag. This flag will force application of the changes without validation. Proceed with caution.
 
-#### Mobile device management (MDM) settings
+## Mobile device management (MDM) settings
 
 > MDM features are not ready for production and are currently in development. These features are disabled by default.
 

--- a/docs/Using-Fleet/configuration-files/README.md
+++ b/docs/Using-Fleet/configuration-files/README.md
@@ -916,6 +916,8 @@ The `command_line_flags` key inside of `agent_options` allows you to remotely ma
 
 To see the full list of these osquery command line flags, please run `osquery` with the `--help` switch.
 
+> Note: Setting `command_line_flags` using YAML are not additive and will replace any command line flags in the CLI.
+
 Just like the other `agent_options` above, remove the dashed lines (`--`) for Fleet to successfully update them.
 
 Here is an example of using the `command_line_flags` key:

--- a/docs/Using-Fleet/configuration-files/README.md
+++ b/docs/Using-Fleet/configuration-files/README.md
@@ -14,7 +14,7 @@ Changes are applied to Fleet when the configuration file is applied using fleetc
 
 The `query` YAML file controls queries in Fleet.
 
-You can define one or more queries in the same file with with `---`.
+You can define one or more queries in the same file with `---`.
 
 The following example file includes several queries:
 
@@ -98,7 +98,7 @@ spec:
 
 The `team` YAML file controls a team in Fleet.
 
-You can define one or more teams in the same file with with `---`.
+You can define one or more teams in the same file with `---`.
 
 The following example file includes one team:
 
@@ -328,7 +328,7 @@ spec:
 
 All possible settings are organized below by section.
 
-Each section's key must be one level below the `spec` key, indented with spaces (not `<tab>` charaters) as required by the YAML format.
+Each section's key must be one level below the `spec` key, indented with spaces (not `<tab>` characters) as required by the YAML format.
 
 For example, when adding the `host_expiry_settings.host_expiry_enabled` setting, you'd specify the `host_expiry_settings` section one level below the `spec` key:
 
@@ -801,7 +801,7 @@ The following options allow the configuration of a webhook that will be triggere
 
 ###### webhook_settings.host_status_webhook.days_count
 
-Number of days that hosts need to be offline for to count as part of the percentage.
+Number of days that hosts need to be offline to count as part of the percentage.
 
 - Optional setting, required if webhook is enabled (integer).
 - Default value: `0`.
@@ -916,7 +916,7 @@ The `command_line_flags` key inside of `agent_options` allows you to remotely ma
 
 To see the full list of these osquery command line flags, please run `osquery` with the `--help` switch.
 
-> Note: Setting `command_line_flags` using YAML are not additive and will replace any command line flags in the CLI.
+> YAML `command_line_flags` are not additive and will replace any osquery command line flags in the CLI.
 
 Just like the other `agent_options` above, remove the dashed lines (`--`) for Fleet to successfully update them.
 
@@ -935,9 +935,9 @@ spec:
 
 Note that the `command_line_flags` key does not support the `overrides` key, which is documented below.
 
-You can verfiy that these flags have taken effect on the hosts by running a query against the `osquery_flags` table.
+You can verify that these flags have taken effect on the hosts by running a query against the `osquery_flags` table.
 
-If you revoked an old enroll secret, this feature won't work for hosts that were added to Fleet using this old enroll secret. This is because Orbit uses the enroll secret to receive new flags from Fleet. For these hosts, all existing features will work as expected.
+> If you revoked an old enroll secret, this feature won't update for hosts that were added to Fleet using this old enroll secret. This is because Orbit uses the enroll secret to receive new flags from Fleet. For these hosts, all existing features will work as expected.
 
 For further documentation on how to rotate enroll secrets, please see [this guide](https://fleetdm.com/docs/deploying/faq#how-can-enroll-secrets-be-rotated).
 
@@ -989,11 +989,11 @@ spec:
         platform: 'macos'
 ```
  
-In the above example, we are configuring our `hello_world` extension. We do this by creating a `hello_world` sub-key under `extensions`, and then specifying the `channel` and `platform` keys for that extension. 
+In the above example, we are configuring our `hello_world` extension. We do this by creating a `hello_world` subkey under `extensions`, and then specifying the `channel` and `platform` keys for that extension. 
 
 Next, you will need to make sure to push the binary file of our `hello_world` extension as a target on your TUF server. This step needs to follow these conventions:
 
-* The binary file of the extension, must have the same name as the extension, followed by the `.ext`. In the above case, the filename should be `hello_world.ext`
+* The binary file of the extension must have the same name as the extension, followed by the `.ext`. In the above case, the filename should be `hello_world.ext`
 * The target name for the TUF server must be named as `extensions/<extension_name>`. For the above example, this would be `extensions/hello_world`
 * `platform` is one of `macos`, `linux`, or `windows`
 
@@ -1007,7 +1007,7 @@ After successfully configuring the agent options, and pushing the extension as a
 
 If you are using a self-hosted TUF server, you must also manage all of Orbit's versions, including osquery, Fleet Desktop and osquery extensions.
 
-Fleet recommends deploying extensions created with osquery-go or natively with C++, instead of Python. Extensions written in Python requires the user to compile it into a single packaged binary along with all the dependencies.
+Fleet recommends deploying extensions created with osquery-go or natively with C++, instead of Python. Extensions written in Python require the user to compile it into a single packaged binary along with all the dependencies.
 
 
 ##### Example Agent options YAML
@@ -1037,7 +1037,7 @@ spec:
       # with the top-level configuration!! This means that settings values defined 
       # on the top-level config.options section will not be propagated to the platform
       # override sections. So for example, the config.options.distributed_interval value 
-      # will be discared on a platform override section, and only the section value 
+      # will be discarded on a platform override section, and only the section value 
       # for distributed_interval will be used. If the given setting is not specified 
       # in the override section, its default value will be enforced. 
       # Going back to the example, if the override section is windows, 
@@ -1279,7 +1279,7 @@ Set name of default team to use with Apple Business Manager.
 
 **Applies only to Fleet Premium**.
 
-The following options allow to configure the behavior of Nudge for macOS hosts that belong to no team and are enrolled into Fleet's MDM.
+The following options allow configuring the behavior of Nudge for macOS hosts that belong to no team and are enrolled into Fleet's MDM.
 
 ##### mdm.macos_updates.minimum_version
 
@@ -1297,7 +1297,7 @@ Requires `mdm.macos_updates.deadline` to be set.
 
 ##### mdm.macos_updates.deadline
 
-A deadline in the form `YYYY-MM-DD`. The exact deadline time is at 04:00:00 (UTC-8).
+A deadline in the form of `YYYY-MM-DD`. The exact deadline time is at 04:00:00 (UTC-8).
 
 Hosts that belong to no team and are enrolled into Fleet's MDM won't be able to dismiss the Nudge window once this deadline is past.
 

--- a/frontend/components/EnrollSecrets/DeleteSecretModal/DeleteSecretModal.tsx
+++ b/frontend/components/EnrollSecrets/DeleteSecretModal/DeleteSecretModal.tsx
@@ -57,7 +57,7 @@ const DeleteSecretModal = ({
           <p>
             Follow this guide to{" "}
             <CustomLink
-              url="https://fleetdm.com/docs/deploying/faq#how-can-enroll-secrets-be-rotated"
+              url="https://fleetdm.com/docs/using-fleet/configuration-files#rotate-enroll-secrets"
               text="rotate enroll secrets"
               newTab
             />

--- a/frontend/components/EnrollSecrets/DeleteSecretModal/DeleteSecretModal.tsx
+++ b/frontend/components/EnrollSecrets/DeleteSecretModal/DeleteSecretModal.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 import { ITeam } from "interfaces/team";
+import CustomLink from "components/CustomLink";
 
 interface IDeleteSecretModal {
   selectedTeam: number;
@@ -47,6 +48,18 @@ const DeleteSecretModal = ({
           <p>
             Any hosts that attempt to enroll to Fleet using this secret will be
             unable to enroll.
+          </p>
+          <p>
+            Any hosts that enrolled using this secret cannot update their
+            configuration through Orbit.
+          </p>
+          <p>
+            For further documentation on how to rotate enroll secrets, please
+            see{" "}
+            <CustomLink
+              url="https://fleetdm.com/docs/deploying/faq#how-can-enroll-secrets-be-rotated"
+              text="this guide"
+            />
           </p>
           <p>You cannot undo this action.</p>
         </div>

--- a/frontend/components/EnrollSecrets/DeleteSecretModal/DeleteSecretModal.tsx
+++ b/frontend/components/EnrollSecrets/DeleteSecretModal/DeleteSecretModal.tsx
@@ -50,16 +50,18 @@ const DeleteSecretModal = ({
             unable to enroll.
           </p>
           <p>
-            Any hosts that enrolled using this secret cannot update their
-            configuration through Orbit.
+            Any enrolled hosts using this secret will not receive updates
+            through Orbit including updates to agent options and command line
+            flags.
           </p>
           <p>
-            For further documentation on how to rotate enroll secrets, please
-            see{" "}
+            Follow this guide to{" "}
             <CustomLink
               url="https://fleetdm.com/docs/deploying/faq#how-can-enroll-secrets-be-rotated"
-              text="this guide"
+              text="rotate enroll secrets"
+              newTab
             />
+            .
           </p>
           <p>You cannot undo this action.</p>
         </div>

--- a/frontend/utilities/yaml/index.ts
+++ b/frontend/utilities/yaml/index.ts
@@ -32,7 +32,7 @@ export const agentOptionsToYaml = (agentOpts: any) => {
   let yamlString = yaml.dump(agentOpts);
   if (addFlagsComment) {
     yamlString +=
-      "command_line_flags: {} # requires Fleet's osquery installer\n";
+      "# requires Fleet's osquery installer\n# command_line_flags: {}\n";
   }
 
   return yamlString;

--- a/frontend/utilities/yaml/index.ts
+++ b/frontend/utilities/yaml/index.ts
@@ -32,7 +32,7 @@ export const agentOptionsToYaml = (agentOpts: any) => {
   let yamlString = yaml.dump(agentOpts);
   if (addFlagsComment) {
     yamlString +=
-      "# requires Fleet's osquery installer\n# command_line_flags: {}\n";
+      "# Requires Fleet's osquery installer\n# command_line_flags: {}\n";
   }
 
   return yamlString;


### PR DESCRIPTION
## PR Timeline
- Looking to merge beginning of next sprint, would like eyes from the DRI of docs as well as product (since I'm adding some verbiage to the UI), thank you!

## On call update documentation and #9300 
- Updates agent options documentation
- Updates enroll secrets documentation
- Small update to Fleet configuration documentation

### Fixes
- Cerra #9300 and document appropriately
- More explicit about repercussions of deleting enroll secrets and how to properly rotate them
- UI points to more helpful agent options doc (there's 2, see questions left unanswered)
- Move agent options and enroll secret questions out of FAQ and into their appropriate sections
- Reorder Fleet configuration doc to match order of precedent outlined
- Spelling and grammar fixes on all documents updated

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Documented any permissions changes

