### PR TITLE
Record activity when the macos minimum version requirement is edited

### DIFF
--- a/changes/issue-9355-macos-min-version-activity
+++ b/changes/issue-9355-macos-min-version-activity
@@ -1,0 +1,1 @@
+* Added an activity `edited_macos_min_version` when the required minimum macOS version is updated.

--- a/docs/Using-Fleet/Audit-Activities.md
+++ b/docs/Using-Fleet/Audit-Activities.md
@@ -43,7 +43,7 @@ This activity contains the following fields:
 
 ```json
 {
-	"pack_id": 123, 
+	"pack_id": 123,
 	"pack_name": "foo"
 }
 ```
@@ -60,7 +60,7 @@ This activity contains the following fields:
 
 ```json
 {
-	"pack_id": 123, 
+	"pack_id": 123,
 	"pack_name": "foo"
 }
 ```
@@ -98,7 +98,7 @@ This activity contains the following fields:
 
 ```json
 {
-	"policy_id": 123, 
+	"policy_id": 123,
 	"policy_name": "foo"
 }
 ```
@@ -115,7 +115,7 @@ This activity contains the following fields:
 
 ```json
 {
-	"policy_id": 123, 
+	"policy_id": 123,
 	"policy_name": "foo"
 }
 ```
@@ -132,7 +132,7 @@ This activity contains the following fields:
 
 ```json
 {
-	"policy_id": 123, 
+	"policy_id": 123,
 	"policy_name": "foo"
 }
 ```
@@ -188,7 +188,7 @@ This activity contains the following fields:
 
 ```json
 {
-	"query_id": 123, 
+	"query_id": 123,
 	"query_name": "foo"
 }
 ```
@@ -205,7 +205,7 @@ This activity contains the following fields:
 
 ```json
 {
-	"query_id": 123, 
+	"query_id": 123,
 	"query_name": "foo"
 }
 ```
@@ -275,7 +275,7 @@ This activity contains the following fields:
 
 ```json
 {
-	"team_id": 123, 
+	"team_id": 123,
 	"team_name": "foo"
 }
 ```
@@ -292,7 +292,7 @@ This activity contains the following fields:
 
 ```json
 {
-	"team_id": 123, 
+	"team_id": 123,
 	"team_name": "foo"
 }
 ```
@@ -311,7 +311,7 @@ This activity contains a field "teams" where each item contains the team details
 {
 	"teams": [
 		{
-			"id": 123, 
+			"id": 123,
 			"name": "foo"
 		}
 	]
@@ -331,7 +331,7 @@ This activity contains the following fields:
 
 ```json
 {
-	"team_id": 123, 
+	"team_id": 123,
 	"team_name": "foo",
 	"global": false
 }
@@ -350,7 +350,7 @@ This activity contains the following fields:
 
 ```json
 {
-	"targets_count": 5000, 
+	"targets_count": 5000,
 	"query_sql": "SELECT * from osquery_info;",
 	"query_name": "foo"
 }
@@ -530,6 +530,7 @@ Generated when a host is enrolled in Fleet's MDM.
 
 This activity contains the following fields:
 - "host_serial": Serial number of the host.
+- "host_display_name": Display name of the host.
 - "installed_from_dep": Whether the host was enrolled via DEP.
 
 #### Example
@@ -537,6 +538,7 @@ This activity contains the following fields:
 ```json
 {
   "host_serial": "C08VQ2AXHT96",
+  "host_display_name": "MacBookPro16,1 (C08VQ2AXHT96)",
   "installed_from_dep": true
 }
 ```
@@ -547,6 +549,7 @@ Generated when a host is unenrolled from Fleet's MDM.
 
 This activity contains the following fields:
 - "host_serial": Serial number of the host.
+- "host_display_name": Display name of the host.
 - "installed_from_dep": Whether the host was enrolled via DEP.
 
 #### Example
@@ -554,7 +557,29 @@ This activity contains the following fields:
 ```json
 {
   "host_serial": "C08VQ2AXHT96",
+  "host_display_name": "MacBookPro16,1 (C08VQ2AXHT96)",
   "installed_from_dep": true
+}
+```
+
+### Type `edited_macos_min_version`
+
+Generated when the minimum required macOS version is modified.
+
+This activity contains the following fields:
+- "team_id": The ID of the team that the minimum macOS version applies to, null if it applies to devices that are not in a team.
+- "team_name": The name of the team that the minimum macOS version applies to, null if it applies to devices that are not in a team.
+- "minimum_version": The minimum macOS version required, empty if the requirement was removed.
+- "deadline": The deadline by which the minimum version requirement must be applied, empty if the requirement was removed.
+
+#### Example
+
+```json
+{
+  "team_id": 3,
+  "team_name": "Workstations",
+  "minimum_version": "13.0.1",
+  "deadline": "2023-06-01"
 }
 ```
 

--- a/docs/Using-Fleet/Detail-Queries-Summary.md
+++ b/docs/Using-Fleet/Detail-Queries-Summary.md
@@ -25,7 +25,7 @@ SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT "" AND filevault_status = '
 
 ## disk_encryption_linux
 
-- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos
 
 - Query:
 
@@ -45,7 +45,7 @@ SELECT 1 FROM bitlocker_info WHERE drive_letter = 'C:' AND protection_status = 1
 
 ## disk_space_unix
 
-- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, darwin
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, darwin
 
 - Query:
 
@@ -166,7 +166,7 @@ select version, errors, warnings from munki_info;
 
 ## network_interface_unix
 
-- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, darwin
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, darwin
 
 - Query:
 
@@ -230,7 +230,7 @@ SELECT version FROM orbit_info
 
 ## os_unix_like
 
-- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, darwin
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, darwin
 
 - Query:
 
@@ -328,7 +328,7 @@ SELECT *,
 
 ## software_linux
 
-- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos
 
 - Query:
 

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -45,6 +45,8 @@ var ActivityDetailsList = []ActivityDetails{
 
 	ActivityTypeMDMEnrolled{},
 	ActivityTypeMDMUnenrolled{},
+
+	ActivityTypeEditedMacOSMinVersion{},
 }
 
 type ActivityDetails interface {
@@ -68,7 +70,7 @@ func (a ActivityTypeCreatedPack) Documentation() (activity string, details strin
 		`This activity contains the following fields:
 - "pack_id": the id of the created pack.
 - "pack_name": the name of the created pack.`, `{
-	"pack_id": 123, 
+	"pack_id": 123,
 	"pack_name": "foo"
 }`
 }
@@ -87,7 +89,7 @@ func (a ActivityTypeEditedPack) Documentation() (activity string, details string
 		`This activity contains the following fields:
 - "pack_id": the id of the edited pack.
 - "pack_name": the name of the edited pack.`, `{
-	"pack_id": 123, 
+	"pack_id": 123,
 	"pack_name": "foo"
 }`
 }
@@ -133,7 +135,7 @@ func (a ActivityTypeCreatedPolicy) Documentation() (activity string, details str
 		`This activity contains the following fields:
 - "policy_id": the ID of the created policy.
 - "policy_name": the name of the created policy.`, `{
-	"policy_id": 123, 
+	"policy_id": 123,
 	"policy_name": "foo"
 }`
 }
@@ -152,7 +154,7 @@ func (a ActivityTypeEditedPolicy) Documentation() (activity string, details stri
 		`This activity contains the following fields:
 - "policy_id": the ID of the edited policy.
 - "policy_name": the name of the edited policy.`, `{
-	"policy_id": 123, 
+	"policy_id": 123,
 	"policy_name": "foo"
 }`
 }
@@ -171,7 +173,7 @@ func (a ActivityTypeDeletedPolicy) Documentation() (activity string, details str
 		`This activity contains the following fields:
 - "policy_id": the ID of the deleted policy.
 - "policy_name": the name of the deleted policy.`, `{
-	"policy_id": 123, 
+	"policy_id": 123,
 	"policy_name": "foo"
 }`
 }
@@ -230,7 +232,7 @@ func (a ActivityTypeCreatedSavedQuery) Documentation() (activity string, details
 		`This activity contains the following fields:
 - "query_id": the ID of the created query.
 - "query_name": the name of the created query.`, `{
-	"query_id": 123, 
+	"query_id": 123,
 	"query_name": "foo"
 }`
 }
@@ -249,7 +251,7 @@ func (a ActivityTypeEditedSavedQuery) Documentation() (activity string, details 
 		`This activity contains the following fields:
 - "query_id": the ID of the query being edited.
 - "query_name": the name of the query being edited.`, `{
-	"query_id": 123, 
+	"query_id": 123,
 	"query_name": "foo"
 }`
 }
@@ -324,7 +326,7 @@ func (a ActivityTypeCreatedTeam) Documentation() (activity string, details strin
 		`This activity contains the following fields:
 - "team_id": unique ID of the created team.
 - "team_name": the name of the created team.`, `{
-	"team_id": 123, 
+	"team_id": 123,
 	"team_name": "foo"
 }`
 }
@@ -343,7 +345,7 @@ func (a ActivityTypeDeletedTeam) Documentation() (activity string, details strin
 		`This activity contains the following fields:
 - "team_id": unique ID of the deleted team.
 - "team_name": the name of the deleted team.`, `{
-	"team_id": 123, 
+	"team_id": 123,
 	"team_name": "foo"
 }`
 }
@@ -368,7 +370,7 @@ func (a ActivityTypeAppliedSpecTeam) Documentation() (activity string, details s
 - "name": Name of the team.`, `{
 	"teams": [
 		{
-			"id": 123, 
+			"id": 123,
 			"name": "foo"
 		}
 	]
@@ -391,7 +393,7 @@ func (a ActivityTypeEditedAgentOptions) Documentation() (activity string, detail
 - "global": "true" if the user updated the global agent options, "false" if the agent options of a team were updated.
 - "team_id": unique ID of the team for which the agent options were updated (null if global is true).
 - "team_name": the name of the team for which the agent options were updated (null if global is true).`, `{
-	"team_id": 123, 
+	"team_id": 123,
 	"team_name": "foo",
 	"global": false
 }`
@@ -413,7 +415,7 @@ func (a ActivityTypeLiveQuery) Documentation() (activity string, details string,
 - "targets_count": Number of hosts where the live query was targeted to run.
 - "query_sql": The SQL query to run on hosts.
 - "query_name": Name of the query (this field is not set if this was not a saved query).`, `{
-	"targets_count": 5000, 
+	"targets_count": 5000,
 	"query_sql": "SELECT * from osquery_info;",
 	"query_name": "foo"
 }`
@@ -440,6 +442,11 @@ type Activity struct {
 	Type          string           `json:"type" db:"activity_type"`
 	Details       *json.RawMessage `json:"details" db:"details"`
 	Streamed      *bool            `json:"-" db:"streamed"`
+}
+
+// AuthzType implement AuthzTyper to be able to verify access to activities
+func (*Activity) AuthzType() string {
+	return "activity"
 }
 
 type ActivityTypeUserLoggedIn struct {
@@ -677,7 +684,27 @@ func (a ActivityTypeMDMUnenrolled) Documentation() (activity string, details str
 }`
 }
 
-// AuthzType implement AuthzTyper to be able to verify access to activities
-func (*Activity) AuthzType() string {
-	return "activity"
+type ActivityTypeEditedMacOSMinVersion struct {
+	TeamID         *uint   `json:"team_id"`
+	TeamName       *string `json:"team_name"`
+	MinimumVersion string  `json:"minimum_version"`
+	Deadline       string  `json:"deadline"`
+}
+
+func (a ActivityTypeEditedMacOSMinVersion) ActivityName() string {
+	return "edited_macos_min_version"
+}
+
+func (a ActivityTypeEditedMacOSMinVersion) Documentation() (activity string, details string, detailsExample string) {
+	return `Generated when the minimum required macOS version is modified.`,
+		`This activity contains the following fields:
+- "team_id": The ID of the team that the minimum macOS version applies to, null if it applies to devices that are not in a team.
+- "team_name": The name of the team that the minimum macOS version applies to, null if it applies to devices that are not in a team.
+- "minimum_version": The minimum macOS version required, empty if the requirement was removed.
+- "deadline": The deadline by which the minimum version requirement must be applied, empty if the requirement was removed.`, `{
+  "team_id": 3,
+  "team_name": "Workstations",
+  "minimum_version": "13.0.1",
+  "deadline": "2023-06-01"
+}`
 }

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -429,7 +429,22 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 				Global: true,
 			},
 		); err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "create activity for app config modification")
+			return nil, ctxerr.Wrap(ctx, err, "create activity for app config agent options modification")
+		}
+	}
+
+	// if the macOS minimum version requirement changed, create the corresponding
+	// activity
+	if oldAppConfig.MDM.MacOSUpdates != appConfig.MDM.MacOSUpdates {
+		if err := svc.ds.NewActivity(
+			ctx,
+			authz.UserFromContext(ctx),
+			fleet.ActivityTypeEditedMacOSMinVersion{
+				MinimumVersion: appConfig.MDM.MacOSUpdates.MinimumVersion,
+				Deadline:       appConfig.MDM.MacOSUpdates.Deadline,
+			},
+		); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "create activity for app config macos min version modification")
 		}
 	}
 


### PR DESCRIPTION
#9355 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
