### PR TITLE
Finalize new default avatar images

### DIFF
--- a/frontend/components/Avatar/Avatar.stories.tsx
+++ b/frontend/components/Avatar/Avatar.stories.tsx
@@ -14,8 +14,8 @@ export default {
 } as Meta;
 
 export const Default: Story = () => (
-  <Avatar user={{ gravatarURL: DEFAULT_GRAVATAR_LINK }} />
+  <Avatar user={{ gravatar_url: DEFAULT_GRAVATAR_LINK }} />
 );
 export const Small: Story = () => (
-  <Avatar user={{ gravatarURL: DEFAULT_GRAVATAR_LINK }} size="small" />
+  <Avatar user={{ gravatar_url: DEFAULT_GRAVATAR_LINK }} size="small" />
 );

--- a/frontend/components/Avatar/Avatar.tsx
+++ b/frontend/components/Avatar/Avatar.tsx
@@ -12,11 +12,17 @@ export interface IAvatarInterface {
   className?: string;
   size?: string;
   user: IAvatarUserInterface;
+  hasWhiteBackground?: boolean;
 }
 
 const baseClass = "avatar";
 
-const Avatar = ({ className, size, user }: IAvatarInterface): JSX.Element => {
+const Avatar = ({
+  className,
+  size,
+  user,
+  hasWhiteBackground,
+}: IAvatarInterface): JSX.Element => {
   const [isLoading, setIsLoading] = useState(true);
   const [isError, setIsError] = useState(false);
 
@@ -29,6 +35,7 @@ const Avatar = ({ className, size, user }: IAvatarInterface): JSX.Element => {
 
   const avatarClasses = classnames(baseClass, className, {
     [`${baseClass}--${size?.toLowerCase()}`]: !!size,
+    "has-white-background": !!hasWhiteBackground,
   });
   const { gravatar_url } = user;
 

--- a/frontend/components/Avatar/Avatar.tsx
+++ b/frontend/components/Avatar/Avatar.tsx
@@ -4,7 +4,8 @@ import classnames from "classnames";
 import { DEFAULT_GRAVATAR_LINK } from "utilities/constants";
 
 interface IAvatarUserInterface {
-  gravatarURL?: string;
+  gravatar_url?: string;
+  gravatar_url_dark?: string;
 }
 
 export interface IAvatarInterface {
@@ -29,14 +30,14 @@ const Avatar = ({ className, size, user }: IAvatarInterface): JSX.Element => {
   const avatarClasses = classnames(baseClass, className, {
     [`${baseClass}--${size?.toLowerCase()}`]: !!size,
   });
-  const { gravatarURL } = user;
+  const { gravatar_url } = user;
 
   return (
     <div className="avatar-wrapper">
       <img
         alt={"User avatar"}
         className={`${avatarClasses} ${isLoading || isError ? "default" : ""}`}
-        src={gravatarURL || DEFAULT_GRAVATAR_LINK}
+        src={gravatar_url || DEFAULT_GRAVATAR_LINK}
         onError={onError}
         onLoad={onLoad}
       />

--- a/frontend/components/Avatar/_styles.scss
+++ b/frontend/components/Avatar/_styles.scss
@@ -12,6 +12,11 @@
     @include size(16px);
   }
 
+  &.has-white-background {
+    background: $core-white;
+    border-radius: 100%;
+  }
+
   img {
     &.default {
       display: none;

--- a/frontend/components/AvatarTopNav/AvatarTopNav.tsx
+++ b/frontend/components/AvatarTopNav/AvatarTopNav.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from "react";
 import classnames from "classnames";
 
-import { DEFAULT_GRAVATAR_LINK } from "utilities/constants";
+import { DEFAULT_GRAVATAR_LINK_DARK } from "utilities/constants";
 
 interface IAvatarUserInterface {
   gravatarURL?: string;
@@ -31,48 +31,23 @@ const Avatar = ({ className, size, user }: IAvatarInterface): JSX.Element => {
   });
   const { gravatarURL } = user;
 
-  const isDefaultAvatar = true;
+  const isDefaultAvatar = false;
   // TODO: Need to figure out how to check if the gravatarURL is the default
   // if (gravatarURL.indexOf("www.gravatar.com/avatar/") > -1) {
   //   isDefaultAvatar = false;
   // }
 
+  console.log("DEFAULT_GRAVATAR_LINK_DARK: ", DEFAULT_GRAVATAR_LINK_DARK);
+
   return (
     <div className="avatar-wrapper">
-      {isDefaultAvatar ? (
-        <svg
-          width="24"
-          height="24"
-          viewBox="0 0 24 24"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <circle
-            cx="12"
-            cy="12"
-            r="11.25"
-            fill="#515774"
-            stroke="white"
-            strokeWidth="1.5"
-          />
-          <circle cx="12" cy="10.5" r="3.75" stroke="white" strokeWidth="1.5" />
-          <path
-            d="M18.7492 20.8922C18.7486 20.8929 18.748 20.8937 18.7475 20.8944C18.6939 20.9659 18.5929 21.0736 18.4304 21.2091C18.1081 21.4777 17.6139 21.798 16.9768 22.106C15.7041 22.7214 13.9402 23.25 12 23.25C10.0598 23.25 8.29593 22.7214 7.02318 22.106C6.38614 21.798 5.89185 21.4777 5.56965 21.2091C5.40709 21.0736 5.30606 20.9659 5.25252 20.8944C5.25195 20.8937 5.25139 20.8929 5.25084 20.8922C5.30844 17.214 8.30808 14.25 12 14.25C15.6919 14.25 18.6916 17.214 18.7492 20.8922ZM18.7802 20.8444C18.7804 20.8444 18.7792 20.8472 18.7758 20.853C18.7783 20.8474 18.7799 20.8445 18.7802 20.8444ZM5.21982 20.8444C5.22005 20.8445 5.22174 20.8474 5.22421 20.853C5.22083 20.8472 5.2196 20.8444 5.21982 20.8444Z"
-            stroke="white"
-            strokeWidth="1.5"
-          />
-        </svg>
-      ) : (
-        <img
-          alt={"User avatar"}
-          className={`${avatarClasses} ${
-            isLoading || isError ? "default" : ""
-          }`}
-          src={gravatarURL}
-          onError={onError}
-          onLoad={onLoad}
-        />
-      )}
+      <img
+        alt={"User avatar"}
+        className={`${avatarClasses} ${isLoading || isError ? "default" : ""}`}
+        src={DEFAULT_GRAVATAR_LINK_DARK}
+        onError={onError}
+        onLoad={onLoad}
+      />
     </div>
   );
 };

--- a/frontend/components/AvatarTopNav/AvatarTopNav.tsx
+++ b/frontend/components/AvatarTopNav/AvatarTopNav.tsx
@@ -4,7 +4,7 @@ import classnames from "classnames";
 import { DEFAULT_GRAVATAR_LINK_DARK } from "utilities/constants";
 
 interface IAvatarUserInterface {
-  gravatarURL?: string;
+  gravatar_url_dark?: string;
 }
 
 export interface IAvatarInterface {
@@ -29,22 +29,14 @@ const Avatar = ({ className, size, user }: IAvatarInterface): JSX.Element => {
   const avatarClasses = classnames(baseClass, className, {
     [`${baseClass}--${size?.toLowerCase()}`]: !!size,
   });
-  const { gravatarURL } = user;
-
-  const isDefaultAvatar = false;
-  // TODO: Need to figure out how to check if the gravatarURL is the default
-  // if (gravatarURL.indexOf("www.gravatar.com/avatar/") > -1) {
-  //   isDefaultAvatar = false;
-  // }
-
-  console.log("DEFAULT_GRAVATAR_LINK_DARK: ", DEFAULT_GRAVATAR_LINK_DARK);
+  const { gravatar_url_dark } = user;
 
   return (
-    <div className="avatar-wrapper">
+    <div className={"avatar-wrapper-top-nav"}>
       <img
         alt={"User avatar"}
         className={`${avatarClasses} ${isLoading || isError ? "default" : ""}`}
-        src={DEFAULT_GRAVATAR_LINK_DARK}
+        src={gravatar_url_dark || DEFAULT_GRAVATAR_LINK_DARK}
         onError={onError}
         onLoad={onLoad}
       />

--- a/frontend/components/AvatarTopNav/_styles.scss
+++ b/frontend/components/AvatarTopNav/_styles.scss
@@ -1,4 +1,4 @@
-.avatar-wrapper {
+.avatar-wrapper-top-nav {
   margin-right: 8px;
   svg {
     display: block;
@@ -10,7 +10,7 @@
     border-radius: 50%;
 
     &--small {
-      @include size(32px);
+      @include size(24px);
     }
 
     &--xsmall {

--- a/frontend/components/buttons/DropdownButton/DropdownButton.stories.tsx
+++ b/frontend/components/buttons/DropdownButton/DropdownButton.stories.tsx
@@ -94,7 +94,7 @@ export default {
 
 const Template: Story<IDropdownButtonProps> = (props) => (
   <DropdownButton {...props}>
-    <Avatar user={{ gravatarURL: DEFAULT_GRAVATAR_LINK }} size="small" />
+    <Avatar user={{ gravatar_url: DEFAULT_GRAVATAR_LINK }} size="small" />
   </DropdownButton>
 );
 

--- a/frontend/components/top_nav/UserMenu/UserMenu.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tsx
@@ -74,7 +74,7 @@ const UserMenu = ({
       <DropdownButton options={dropdownItems}>
         <AvatarTopNav
           className={`${baseClass}__avatar-image`}
-          user={{ gravatarURL: currentUser.gravatarURL }}
+          user={{ gravatar_url_dark: currentUser.gravatar_url_dark }}
           size="small"
         />
       </DropdownButton>

--- a/frontend/interfaces/user.ts
+++ b/frontend/interfaces/user.ts
@@ -24,8 +24,8 @@ export interface IUser {
   email: string;
   role: string;
   force_password_reset: boolean;
-  gravatar_url: string;
-  gravatarURL?: string; // Remove when CoreLayout.jsx is refactored to Typescript (it's adding this property to User)
+  gravatar_url?: string;
+  gravatar_url_dark?: string;
   sso_enabled: boolean;
   global_role: string | null;
   api_only: boolean;

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -283,6 +283,7 @@ const ActivityItem = ({
         className={`${baseClass}__avatar-image`}
         user={{ gravatar_url }}
         size="small"
+        hasWhiteBackground
       />
       <div className={`${baseClass}__details`}>
         <p>

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -271,9 +271,9 @@ const ActivityItem = ({
   onDetailsClick = noop,
 }: IActivityItemProps) => {
   const { actor_email } = activity;
-  const { gravatarURL } = actor_email
+  const { gravatar_url } = actor_email
     ? addGravatarUrlToResource({ email: actor_email })
-    : { gravatarURL: DEFAULT_GRAVATAR_LINK };
+    : { gravatar_url: DEFAULT_GRAVATAR_LINK };
 
   const activityCreatedAt = new Date(activity.created_at);
 
@@ -281,7 +281,7 @@ const ActivityItem = ({
     <div className={baseClass}>
       <Avatar
         className={`${baseClass}__avatar-image`}
-        user={{ gravatarURL }}
+        user={{ gravatar_url }}
         size="small"
       />
       <div className={`${baseClass}__details`}>

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -11,12 +11,10 @@ export enum PolicyResponse {
 }
 
 export const DEFAULT_GRAVATAR_LINK =
-  "https://fleetdm.com/images/permanent/icon-avatar-default-128x128-2x.png";
-// "https://github.com/fleetdm/fleet/blob/main/assets/images/icon-avatar-default-transparent-64x64%402x.png";
+  "https://fleetdm.com/images/permanent/icon-avatar-default-transparent-64x64%402x.png";
 
 export const DEFAULT_GRAVATAR_LINK_DARK =
-  "https://fleetdm.com/images/permanent/icon-avatar-default-128x128-2x.png?dark=true";
-// "https://github.com/fleetdm/fleet/blob/main/assets/images/icon-avatar-default-dark-24x24%402x.png";
+  "https://fleetdm.com/images/permanent/icon-avatar-default-dark-24x24%402x.png";
 
 export const FREQUENCY_DROPDOWN_OPTIONS = [
   { value: 900, label: "Every 15 minutes" },

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -12,6 +12,11 @@ export enum PolicyResponse {
 
 export const DEFAULT_GRAVATAR_LINK =
   "https://fleetdm.com/images/permanent/icon-avatar-default-128x128-2x.png";
+// "https://github.com/fleetdm/fleet/blob/main/assets/images/icon-avatar-default-transparent-64x64%402x.png";
+
+export const DEFAULT_GRAVATAR_LINK_DARK =
+  "https://fleetdm.com/images/permanent/icon-avatar-default-128x128-2x.png?dark=true";
+// "https://github.com/fleetdm/fleet/blob/main/assets/images/icon-avatar-default-dark-24x24%402x.png";
 
 export const FREQUENCY_DROPDOWN_OPTIONS = [
   { value: 900, label: "Every 15 minutes" },

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -39,6 +39,7 @@ import stringUtils from "utilities/strings";
 import sortUtils from "utilities/sort";
 import {
   DEFAULT_GRAVATAR_LINK,
+  DEFAULT_GRAVATAR_LINK_DARK,
   PLATFORM_LABEL_DISPLAY_TYPES,
 } from "utilities/constants";
 import { IScheduledQueryStats } from "interfaces/scheduled_query_stats";
@@ -52,6 +53,9 @@ export const addGravatarUrlToResource = (resource: any): any => {
   const emailHash = md5(email.toLowerCase());
   const gravatarURL = `https://www.gravatar.com/avatar/${emailHash}?d=${encodeURIComponent(
     DEFAULT_GRAVATAR_LINK
+  )}&size=200`;
+  const gravatarURLDark = `https://www.gravatar.com/avatar/${emailHash}?d=${encodeURIComponent(
+    DEFAULT_GRAVATAR_LINK_DARK
   )}&size=200`;
   return {
     ...resource,

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -51,15 +51,16 @@ export const addGravatarUrlToResource = (resource: any): any => {
   const { email } = resource;
 
   const emailHash = md5(email.toLowerCase());
-  const gravatarURL = `https://www.gravatar.com/avatar/${emailHash}?d=${encodeURIComponent(
+  const gravatar_url = `https://www.gravatar.com/avatar/${emailHash}?d=${encodeURIComponent(
     DEFAULT_GRAVATAR_LINK
   )}&size=200`;
-  const gravatarURLDark = `https://www.gravatar.com/avatar/${emailHash}?d=${encodeURIComponent(
+  const gravatar_url_dark = `https://www.gravatar.com/avatar/${emailHash}?d=${encodeURIComponent(
     DEFAULT_GRAVATAR_LINK_DARK
   )}&size=200`;
   return {
     ...resource,
-    gravatarURL,
+    gravatar_url,
+    gravatar_url_dark,
   };
 };
 


### PR DESCRIPTION
This finishes the masthead styling work that started in #9439. It loads the new default avatars. We now have a dark version in the masthead and a transparent/light version that displays everywhere else. I tracked this follow-on work as #9561.

It also cleans up the old `gravatarURL` property in the `IUser` interface in favor of the standard snake case.