### PR TITLE
add min macos version edited activitiy

### DIFF
--- a/changes/issue-9352-add-min-macos-version-edit-activity
+++ b/changes/issue-9352-add-min-macos-version-edit-activity
@@ -1,0 +1,1 @@
+- add edited min macos version activity

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -31,6 +31,7 @@ export enum ActivityType {
   UserDeletedTeamRole = "deleted_user_team_role",
   MdmEnrolled = "mdm_enrolled",
   MdmUnenrolled = "mdm_unenrolled",
+  EditedMacosMinVersion = "edited_macos_min_version",
 }
 export interface IActivity {
   created_at: string;
@@ -50,8 +51,8 @@ export interface IActivityDetails {
   query_id?: number;
   query_name?: string;
   query_sql?: string;
-  team_id?: number;
-  team_name?: string;
+  team_id?: number | null;
+  team_name?: string | null;
   teams?: ITeamSummary[];
   targets_count?: number;
   specs?: IQuery[] | IPolicy[];
@@ -63,4 +64,6 @@ export interface IActivityDetails {
   host_serial?: string;
   host_display_name?: string;
   installed_from_dep?: boolean;
+  minimum_version?: string;
+  deadline?: string;
 }

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -170,6 +170,35 @@ const TAGGED_TEMPLATES = {
       </>
     );
   },
+  editedMacosMinVersion: (activity: IActivity) => {
+    const editedActivity =
+      activity.details?.minimum_version === "" ? "removed" : "updated";
+
+    const versionSection = activity.details?.minimum_version ? (
+      <>
+        to <b>{activity.details.minimum_version}</b>
+      </>
+    ) : null;
+
+    const deadlineSection = activity.details?.deadline ? (
+      <>(deadline: {activity.details.deadline})</>
+    ) : null;
+
+    const teamSection = activity.details?.team_id ? (
+      <>
+        the <b>{activity.details.team_name}</b> team
+      </>
+    ) : (
+      <>no team</>
+    );
+
+    return (
+      <>
+        {editedActivity} the minimum macOS version {versionSection}{" "}
+        {deadlineSection} on hosts assigned to {teamSection}.
+      </>
+    );
+  },
 
   defaultActivityTemplate: (activity: IActivity) => {
     const entityName = find(activity.details, (_, key) =>
@@ -247,6 +276,9 @@ const getDetail = (
     }
     case ActivityType.MdmUnenrolled: {
       return TAGGED_TEMPLATES.mdmUnenrolled(activity);
+    }
+    case ActivityType.EditedMacosMinVersion: {
+      return TAGGED_TEMPLATES.editedMacosMinVersion(activity);
     }
     default: {
       return TAGGED_TEMPLATES.defaultActivityTemplate(activity);


### PR DESCRIPTION
relates to https://github.com/fleetdm/fleet/issues/9352

adds an edited minimum mac os version activity to the UI

**with team:**

![image](https://user-images.githubusercontent.com/1153709/216044501-3dc34a24-5a49-4fb5-8a83-6808eb79d9ce.png)

**without team:**

![image](https://user-images.githubusercontent.com/1153709/216044543-aa0891c1-6bd4-4453-b646-dcd254fa418b.png)


- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality
