### PR TITLE
Mention that the min macos version activity is created when deadline is modified too

### DIFF
--- a/docs/Using-Fleet/Audit-Activities.md
+++ b/docs/Using-Fleet/Audit-Activities.md
@@ -564,7 +564,7 @@ This activity contains the following fields:
 
 ### Type `edited_macos_min_version`
 
-Generated when the minimum required macOS version is modified.
+Generated when the minimum required macOS version or deadline is modified.
 
 This activity contains the following fields:
 - "team_id": The ID of the team that the minimum macOS version applies to, null if it applies to devices that are not in a team.

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -696,7 +696,7 @@ func (a ActivityTypeEditedMacOSMinVersion) ActivityName() string {
 }
 
 func (a ActivityTypeEditedMacOSMinVersion) Documentation() (activity string, details string, detailsExample string) {
-	return `Generated when the minimum required macOS version is modified.`,
+	return `Generated when the minimum required macOS version or deadline is modified.`,
 		`This activity contains the following fields:
 - "team_id": The ID of the team that the minimum macOS version applies to, null if it applies to devices that are not in a team.
 - "team_name": The name of the team that the minimum macOS version applies to, null if it applies to devices that are not in a team.


### PR DESCRIPTION
Tiny follow-up to https://github.com/fleetdm/fleet/pull/9594
