### PR TITLE
Support matching a host in orbit enrollment using the serial number

### DIFF
--- a/changes/issue-9124-orbit-enroll-match-by-serial
+++ b/changes/issue-9124-orbit-enroll-match-by-serial
@@ -1,0 +1,1 @@
+* Added support for fleetd to enroll a device using its serial number (in addition to its system UUID) to help avoid host-matching issues when a host is first created in Fleet via the MDM automatic enrollment (Apple Business Manager).

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -457,7 +457,8 @@ func (a *agent) waitingDo(req *fasthttp.Request, res *fasthttp.Response) {
 // now, we assume that the agent is not already enrolled, if you kill the agent
 // process then those Orbit node keys are gone.
 func (a *agent) orbitEnroll() error {
-	params := service.EnrollOrbitRequest{EnrollSecret: a.EnrollSecret, HardwareUUID: a.UUID}
+	// TODO(mna): would it be important for osquery-perf to provide a serial? Probably not for now...
+	params := service.EnrollOrbitRequest{EnrollSecret: a.EnrollSecret, HardwareUUID: a.UUID, HardwareSerial: ""}
 
 	req := fasthttp.AcquireRequest()
 

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -329,6 +329,7 @@ func (a *agent) runOrbitLoop() {
 		true,
 		a.EnrollSecret,
 		a.UUID,
+		"",
 	)
 	if err != nil {
 		log.Println("creating orbit client: ", err)

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -908,20 +908,20 @@ func (d *desktopRunner) interrupt(err error) {
 // shell out to osquery (on Linux and macOS) or to wmic (on Windows), and get
 // the system uuid and serial number
 func getUUIDAndSerial(osqueryPath string) (uuid, serial string, err error) {
-	if runtime.GOOS == "windows" {
-		uuidData, uuidSource, err := platform.GetSMBiosUUID()
-		if err != nil {
-			return "", "", err
-		}
+	//if runtime.GOOS == "windows" {
+	//	uuidData, uuidSource, err := platform.GetSMBiosUUID()
+	//	if err != nil {
+	//		return "", "", err
+	//	}
 
-		log.Debug().Msgf("UUID source was %s.", uuidSource)
+	//	log.Debug().Msgf("UUID source was %s.", uuidSource)
 
-		// TODO(mna): is there an alternative way to get the serial number on
-		// Windows? Would osquery not work there? SMBios seems very complex/error
-		// prone. Should we get the UUID via SMBios and then continue with the
-		// osquery query to get the serial on Windows?
-		return uuidData, "", nil
-	}
+	//	// TODO(mna): is there an alternative way to get the serial number on
+	//	// Windows? Would osquery not work there? SMBios seems very complex/error
+	//	// prone. Should we get the UUID via SMBios and then continue with the
+	//	// osquery query to get the serial on Windows?
+	//	return uuidData, "", nil
+	//}
 	type Output struct {
 		UuidString     string `json:"uuid"`
 		HardwareSerial string `json:"hardware_serial"`

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -380,12 +380,12 @@ func main() {
 			return fmt.Errorf("cleanup old files: %w", err)
 		}
 
-		log.Debug().Msg("running single query (SELECT uuid FROM system_info)")
-		uuidStr, err := getUUID(osquerydPath)
+		log.Debug().Msg("running single query (SELECT uuid, hardware_serial FROM system_info)")
+		uuidStr, serial, err := getUUIDAndSerial(osquerydPath)
 		if err != nil {
 			return fmt.Errorf("get UUID: %w", err)
 		}
-		log.Debug().Msg("UUID is " + uuidStr)
+		log.Debug().Msgf("UUID is %s, serial is %s", uuidStr, serial)
 
 		var options []osquery.Option
 		options = append(options, osquery.WithDataPath(c.String("root-dir")))
@@ -516,6 +516,7 @@ func main() {
 			c.Bool("insecure"),
 			enrollSecret,
 			uuidStr,
+			serial,
 		)
 		if err != nil {
 			return fmt.Errorf("error new orbit client: %w", err)
@@ -717,6 +718,7 @@ func main() {
 			c.Bool("insecure"),
 			enrollSecret,
 			uuidStr,
+			serial,
 		)
 		if err != nil {
 			return fmt.Errorf("new client for capabilities checker: %w", err)
@@ -903,37 +905,42 @@ func (d *desktopRunner) interrupt(err error) {
 	}
 }
 
-// shell out to osquery (on Linux and macOS) or to wmic (on Windows), and get the system uuid
-func getUUID(osqueryPath string) (string, error) {
+// shell out to osquery (on Linux and macOS) or to wmic (on Windows), and get
+// the system uuid and serial number
+func getUUIDAndSerial(osqueryPath string) (uuid, serial string, err error) {
 	if runtime.GOOS == "windows" {
 		uuidData, uuidSource, err := platform.GetSMBiosUUID()
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 
 		log.Debug().Msgf("UUID source was %s.", uuidSource)
 
-		return uuidData, nil
+		// TODO(mna): is there an alternative way to get the serial number on
+		// Windows? Would osquery not work there? SMBios seems very complex/error
+		// prone.
+		return uuidData, "", nil
 	}
-	type UuidOutput struct {
-		UuidString string `json:"uuid"`
+	type Output struct {
+		UuidString     string `json:"uuid"`
+		HardwareSerial string `json:"hardware_serial"`
 	}
 
 	args := []string{"-S", "--json", "select uuid from system_info"}
 	out, err := exec.Command(osqueryPath, args...).Output()
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	var uuids []UuidOutput
-	err = json.Unmarshal(out, &uuids)
+	var sysinfo []Output
+	err = json.Unmarshal(out, &sysinfo)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	if len(uuids) != 1 {
-		return "", fmt.Errorf("invalid number of rows from system_info query: %d", len(uuids))
+	if len(sysinfo) != 1 {
+		return "", "", fmt.Errorf("invalid number of rows from system_info query: %d", len(sysinfo))
 	}
-	return uuids[0].UuidString, nil
+	return sysinfo[0].UuidString, sysinfo[0].HardwareSerial, nil
 }
 
 var versionCommand = &cli.Command{

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -918,7 +918,8 @@ func getUUIDAndSerial(osqueryPath string) (uuid, serial string, err error) {
 
 		// TODO(mna): is there an alternative way to get the serial number on
 		// Windows? Would osquery not work there? SMBios seems very complex/error
-		// prone.
+		// prone. Should we get the UUID via SMBios and then continue with the
+		// osquery query to get the serial on Windows?
 		return uuidData, "", nil
 	}
 	type Output struct {

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -931,7 +931,7 @@ func (ds *Datastore) GenerateHostStatusStatistics(ctx context.Context, filter fl
 	return &summary, nil
 }
 
-func (ds *Datastore) EnrollOrbit(ctx context.Context, hardwareUUID string, orbitNodeKey string, teamID *uint) (*fleet.Host, error) {
+func (ds *Datastore) EnrollOrbit(ctx context.Context, hardwareUUID, hardwareSerial, orbitNodeKey string, teamID *uint) (*fleet.Host, error) {
 	if orbitNodeKey == "" {
 		return nil, ctxerr.New(ctx, "orbit node key is empty")
 	}
@@ -939,6 +939,7 @@ func (ds *Datastore) EnrollOrbit(ctx context.Context, hardwareUUID string, orbit
 	if hardwareUUID == "" {
 		return nil, ctxerr.New(ctx, "hardware uuid is empty")
 	}
+	// TODO(mna): allow empty serial? For now, it would be empty for Windows.
 
 	var host fleet.Host
 	err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -5913,7 +5913,7 @@ func testHostsLoadHostByOrbitNodeKey(t *testing.T, ds *Datastore) {
 		orbitKey := uuid.New().String()
 		// on orbit enrollment, the "hardware UUID" is matched with the osquery
 		// host ID to identify the host being enrolled
-		_, err = ds.EnrollOrbit(ctx, *h.OsqueryHostID, orbitKey, nil)
+		_, err = ds.EnrollOrbit(ctx, *h.OsqueryHostID, h.HardwareSerial, orbitKey, nil)
 		require.NoError(t, err)
 
 		// the returned host by LoadHostByOrbitNodeKey will have the orbit key stored
@@ -5943,7 +5943,7 @@ func testHostsLoadHostByOrbitNodeKey(t *testing.T, ds *Datastore) {
 		require.NoError(t, err)
 
 		orbitKey := uuid.New().String()
-		_, err = ds.EnrollOrbit(ctx, *h.OsqueryHostID, orbitKey, nil)
+		_, err = ds.EnrollOrbit(ctx, *h.OsqueryHostID, h.HardwareSerial, orbitKey, nil)
 		require.NoError(t, err)
 		h.OrbitNodeKey = &orbitKey
 		return h

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -138,6 +138,7 @@ func TestHosts(t *testing.T) {
 		{"GetHostMDMCheckinInfo", testHostsGetHostMDMCheckinInfo},
 		{"UnenrollFromMDM", testHostsUnenrollFromMDM},
 		{"LoadHostByOrbitNodeKey", testHostsLoadHostByOrbitNodeKey},
+		{"EnrollOrbit", testHostsEnrollOrbit},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -5974,4 +5975,76 @@ func testHostsLoadHostByOrbitNodeKey(t *testing.T, ds *Datastore) {
 	require.Equal(t, hFleet.ID, loadFleet.MDMInfo.HostID)
 	require.True(t, loadFleet.IsOsqueryEnrolled())
 	require.True(t, loadFleet.MDMInfo.IsPendingDEPFleetEnrollment())
+}
+
+func testHostsEnrollOrbit(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	createHost := func(osqueryID, serial string) *fleet.Host {
+		dbZeroTime := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+		var osqueryIDPtr *string
+		if osqueryID != "" {
+			osqueryIDPtr = &osqueryID
+		}
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			HardwareSerial:   serial,
+			Platform:         "darwin",
+			LastEnrolledAt:   dbZeroTime,
+			DetailUpdatedAt:  dbZeroTime,
+			OsqueryHostID:    osqueryIDPtr,
+			RefetchRequested: true,
+		})
+		require.NoError(t, err)
+		return h
+	}
+
+	// create and enroll a host with just an osquery ID, no serial
+	hOsqueryNoSerial := createHost(uuid.New().String(), "")
+	h, err := ds.EnrollOrbit(ctx, *hOsqueryNoSerial.OsqueryHostID, hOsqueryNoSerial.HardwareSerial, uuid.New().String(), nil)
+	require.NoError(t, err)
+	require.Equal(t, hOsqueryNoSerial.ID, h.ID)
+	require.Empty(t, h.HardwareSerial)
+
+	// create and enroll a host with just a serial, no osquery ID (that is, it
+	// got created this way, but when enrolling in orbit it does have an osquery
+	// ID)
+	hSerialNoOsquery := createHost("", uuid.New().String())
+	h, err = ds.EnrollOrbit(ctx, uuid.New().String(), hSerialNoOsquery.HardwareSerial, uuid.New().String(), nil)
+	require.NoError(t, err)
+	require.Equal(t, hSerialNoOsquery.ID, h.ID)
+	require.Empty(t, h.OsqueryHostID)
+
+	// create and enroll a host with both
+	hBoth := createHost(uuid.New().String(), uuid.New().String())
+	h, err = ds.EnrollOrbit(ctx, *hBoth.OsqueryHostID, hBoth.HardwareSerial, uuid.New().String(), nil)
+	require.NoError(t, err)
+	require.Equal(t, hBoth.ID, h.ID)
+	require.Empty(t, h.HardwareSerial) // this is just to prove that it was loaded based on osquery_node_id, the serial was not set in the lookup
+
+	// enroll with osquery id from hBoth and serial from hSerialNoOsquery (should
+	// use the osquery match)
+	h, err = ds.EnrollOrbit(ctx, *hBoth.OsqueryHostID, hSerialNoOsquery.HardwareSerial, uuid.New().String(), nil)
+	require.NoError(t, err)
+	require.Equal(t, hBoth.ID, h.ID)
+	require.Empty(t, h.HardwareSerial)
+
+	// enroll with no match, will create a new one
+	h, err = ds.EnrollOrbit(ctx, uuid.New().String(), uuid.New().String(), uuid.New().String(), nil)
+	require.NoError(t, err)
+	require.Nil(t, h) // it was not found in the lookup, proves that it created a new one
+
+	// simulate a "corrupt database" where two hosts have the same serial and
+	// enroll by serial should always use the same (the smaller ID)
+	hDupSerial1 := createHost("", uuid.New().String())
+	hDupSerial2 := createHost("", hDupSerial1.HardwareSerial)
+	require.Greater(t, hDupSerial2.ID, hDupSerial1.ID)
+	h, err = ds.EnrollOrbit(ctx, uuid.New().String(), hDupSerial1.HardwareSerial, uuid.New().String(), nil)
+	require.NoError(t, err)
+	require.Equal(t, hDupSerial1.ID, h.ID)
+
+	// enroll with osquery ID from hOsqueryNoSerial and the duplicate serial,
+	// will always match osquery ID
+	h, err = ds.EnrollOrbit(ctx, *hOsqueryNoSerial.OsqueryHostID, hDupSerial1.HardwareSerial, uuid.New().String(), nil)
+	require.NoError(t, err)
+	require.Equal(t, hOsqueryNoSerial.ID, h.ID)
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -654,7 +654,7 @@ type Datastore interface {
 	EnrollHost(ctx context.Context, osqueryHostId, nodeKey string, teamID *uint, cooldown time.Duration) (*Host, error)
 
 	// EnrollOrbit will enroll a new orbit host with the given uuid, setting the orbit node key
-	EnrollOrbit(ctx context.Context, hardwareUUID string, orbitNodeKey string, teamID *uint) (*Host, error)
+	EnrollOrbit(ctx context.Context, hardwareUUID, hardwareSerial, orbitNodeKey string, teamID *uint) (*Host, error)
 
 	SerialUpdateHost(ctx context.Context, host *Host) error
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -53,7 +53,7 @@ type Service interface {
 	// AuthenticateOrbitHost loads host identified by orbit's nodeKey. Returns an error if that nodeKey doesn't exist
 	AuthenticateOrbitHost(ctx context.Context, nodeKey string) (host *Host, debug bool, err error)
 	// EnrollOrbit enrolls orbit to Fleet by using the enrollSecret and returns the orbitNodeKey if successful
-	EnrollOrbit(ctx context.Context, hardwareUUID string, enrollSecret string) (orbitNodeKey string, err error)
+	EnrollOrbit(ctx context.Context, hardwareUUID, hardwareSerial, enrollSecret string) (orbitNodeKey string, err error)
 	// GetOrbitConfig returns team specific flags and extensions in agent options
 	// if the team id is not nil for host, otherwise it returns flags from global
 	// agent options. It also returns any notifications that fleet wants to surface

--- a/server/mock/datastore.go
+++ b/server/mock/datastore.go
@@ -18,7 +18,7 @@ type Store struct {
 	DataStore
 }
 
-func (m *Store) EnrollOrbit(ctx context.Context, hardwareUUID string, orbitNodeKey string, teamID *uint) (*fleet.Host, error) {
+func (m *Store) EnrollOrbit(ctx context.Context, hardwareUUID, hardwareSerial, orbitNodeKey string, teamID *uint) (*fleet.Host, error) {
 	return nil, nil
 }
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -472,7 +472,7 @@ type VerifyEnrollSecretFunc func(ctx context.Context, secret string) (*fleet.Enr
 
 type EnrollHostFunc func(ctx context.Context, osqueryHostId string, nodeKey string, teamID *uint, cooldown time.Duration) (*fleet.Host, error)
 
-type EnrollOrbitFunc func(ctx context.Context, hardwareUUID string, orbitNodeKey string, teamID *uint) (*fleet.Host, error)
+type EnrollOrbitFunc func(ctx context.Context, hardwareUUID string, hardwareSerial string, orbitNodeKey string, teamID *uint) (*fleet.Host, error)
 
 type SerialUpdateHostFunc func(ctx context.Context, host *fleet.Host) error
 
@@ -2446,9 +2446,9 @@ func (s *DataStore) EnrollHost(ctx context.Context, osqueryHostId string, nodeKe
 	return s.EnrollHostFunc(ctx, osqueryHostId, nodeKey, teamID, cooldown)
 }
 
-func (s *DataStore) EnrollOrbit(ctx context.Context, hardwareUUID string, orbitNodeKey string, teamID *uint) (*fleet.Host, error) {
+func (s *DataStore) EnrollOrbit(ctx context.Context, hardwareUUID string, hardwareSerial string, orbitNodeKey string, teamID *uint) (*fleet.Host, error) {
 	s.EnrollOrbitFuncInvoked = true
-	return s.EnrollOrbitFunc(ctx, hardwareUUID, orbitNodeKey, teamID)
+	return s.EnrollOrbitFunc(ctx, hardwareUUID, hardwareSerial, orbitNodeKey, teamID)
 }
 
 func (s *DataStore) SerialUpdateHost(ctx context.Context, host *fleet.Host) error {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -6361,7 +6361,7 @@ func createOrbitEnrolledHost(t *testing.T, os, suffix string, ds fleet.Datastore
 	})
 	require.NoError(t, err)
 	orbitKey := uuid.New().String()
-	_, err = ds.EnrollOrbit(context.Background(), *h.OsqueryHostID, orbitKey, nil)
+	_, err = ds.EnrollOrbit(context.Background(), *h.OsqueryHostID, h.HardwareSerial, orbitKey, nil)
 	require.NoError(t, err)
 	h.OrbitNodeKey = &orbitKey
 	return h

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -22,8 +22,9 @@ type orbitError struct {
 }
 
 type EnrollOrbitRequest struct {
-	EnrollSecret string `json:"enroll_secret"`
-	HardwareUUID string `json:"hardware_uuid"`
+	EnrollSecret   string `json:"enroll_secret"`
+	HardwareUUID   string `json:"hardware_uuid"`
+	HardwareSerial string `json:"hardware_serial"`
 }
 
 type EnrollOrbitResponse struct {
@@ -71,7 +72,7 @@ func (r EnrollOrbitResponse) hijackRender(ctx context.Context, w http.ResponseWr
 
 func enrollOrbitEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*EnrollOrbitRequest)
-	nodeKey, err := svc.EnrollOrbit(ctx, req.HardwareUUID, req.EnrollSecret)
+	nodeKey, err := svc.EnrollOrbit(ctx, req.HardwareUUID, req.HardwareSerial, req.EnrollSecret)
 	if err != nil {
 		return EnrollOrbitResponse{Err: err}, nil
 	}
@@ -99,10 +100,10 @@ func (svc *Service) AuthenticateOrbitHost(ctx context.Context, orbitNodeKey stri
 }
 
 // EnrollOrbit returns an orbit nodeKey on successful enroll
-func (svc *Service) EnrollOrbit(ctx context.Context, hardwareUUID string, enrollSecret string) (string, error) {
+func (svc *Service) EnrollOrbit(ctx context.Context, hardwareUUID, hardwareSerial, enrollSecret string) (string, error) {
 	// this is not a user-authenticated endpoint
 	svc.authz.SkipAuthorization(ctx)
-	logging.WithExtras(ctx, "hardware_uuid", hardwareUUID)
+	logging.WithExtras(ctx, "hardware_uuid", hardwareUUID, "hardware_serial", hardwareSerial)
 
 	secret, err := svc.ds.VerifyEnrollSecret(ctx, enrollSecret)
 	if err != nil {
@@ -114,7 +115,7 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hardwareUUID string, enroll
 		return "", orbitError{message: "failed to generate orbit node key: " + err.Error()}
 	}
 
-	_, err = svc.ds.EnrollOrbit(ctx, hardwareUUID, orbitNodeKey, secret.TeamID)
+	_, err = svc.ds.EnrollOrbit(ctx, hardwareUUID, hardwareSerial, orbitNodeKey, secret.TeamID)
 	if err != nil {
 		return "", orbitError{message: "failed to enroll " + err.Error()}
 	}

--- a/server/service/orbit_client.go
+++ b/server/service/orbit_client.go
@@ -27,6 +27,7 @@ type OrbitClient struct {
 	nodeKeyFilePath string
 	enrollSecret    string
 	uuid            string
+	serial          string
 
 	enrolledMu sync.Mutex
 	enrolled   bool
@@ -89,6 +90,7 @@ func NewOrbitClient(rootDir string, addr string, rootCA string, insecureSkipVeri
 		baseClient:      bc,
 		enrollSecret:    enrollSecret,
 		uuid:            uuid,
+		serial:          serialNum,
 		enrolled:        false,
 	}, nil
 }
@@ -134,7 +136,7 @@ func (oc *OrbitClient) Ping() error {
 
 func (oc *OrbitClient) enroll() (string, error) {
 	verb, path := "POST", "/api/fleet/orbit/enroll"
-	params := EnrollOrbitRequest{EnrollSecret: oc.enrollSecret, HardwareUUID: oc.uuid}
+	params := EnrollOrbitRequest{EnrollSecret: oc.enrollSecret, HardwareUUID: oc.uuid, HardwareSerial: oc.serial}
 	var resp EnrollOrbitResponse
 	err := oc.request(verb, path, params, &resp)
 	if err != nil {

--- a/server/service/orbit_client.go
+++ b/server/service/orbit_client.go
@@ -76,7 +76,7 @@ func (oc *OrbitClient) request(verb string, path string, params interface{}, res
 // rootDir is the Orbit's root directory, where the Orbit node key is loaded-from/stored.
 // addr is the address of the Fleet server.
 // uuid is the UUID of the OrbitClient instance.
-func NewOrbitClient(rootDir string, addr string, rootCA string, insecureSkipVerify bool, enrollSecret, uuid string) (*OrbitClient, error) {
+func NewOrbitClient(rootDir string, addr string, rootCA string, insecureSkipVerify bool, enrollSecret, uuid, serialNum string) (*OrbitClient, error) {
 	orbitCapabilities := fleet.CapabilityMap{}
 	bc, err := newBaseClient(addr, insecureSkipVerify, rootCA, "", orbitCapabilities)
 	if err != nil {


### PR DESCRIPTION
#9124 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
