### PR TITLE
Adding sanity check for input MDM commands

### DIFF
--- a/orbit/pkg/table/mdm/mdm_windows.go
+++ b/orbit/pkg/table/mdm/mdm_windows.go
@@ -181,7 +181,7 @@ func isValidMDMcommand(inputCMD string) (bool, error) {
 	isSyncBodyPrefixPresent := strings.HasPrefix(strings.ToLower(inputCMD), "<syncbody>")
 	isSyncBodySuffixPresent := strings.HasSuffix(strings.ToLower(inputCMD), "</syncbody>")
 	if !isSyncBodyPrefixPresent || !isSyncBodySuffixPresent {
-		return false, errors.New("input MDM command is not a valid")
+		return false, errors.New("input MDM command is not a valid command")
 	}
 
 	// checking if input MDM command is a valid XML

--- a/orbit/pkg/table/mdm/mdm_windows.go
+++ b/orbit/pkg/table/mdm/mdm_windows.go
@@ -69,7 +69,7 @@ func Generate(ctx context.Context, queryContext table.QueryContext) ([]map[strin
 	if constraintList, present := queryContext.Constraints["mdm_command_input"]; present {
 		for _, constraint := range constraintList.Constraints {
 			if constraint.Operator == table.OperatorEquals {
-				inputCmd = constraint.Expression
+				inputCmd = constraint.Expression // this input as to be kept as-is and returned on the same input column due to a sqlite requirement
 				log.Debug().Msgf("mdm_bridge input command request:\n%s", inputCmd)
 			}
 		}
@@ -91,7 +91,7 @@ func Generate(ctx context.Context, queryContext table.QueryContext) ([]map[strin
 	if len(inputCmd) > 0 {
 
 		// performs the actual MDM cmd execution against the OS MDM stack
-		outputCmd, err := executeMDMcommand(inputCmd)
+		outputCmd, err := executeMDMcommand(strings.TrimSpace(inputCmd))
 		if err != nil {
 			return nil, fmt.Errorf("mdm command execution: %s ", err)
 		}


### PR DESCRIPTION
This relates to #9310 

The PR just adds a sanity check to ensure that the input command is a valid SyncML command
