### PR TITLE
Adding support to user friendly command output 

### DIFF
--- a/orbit/pkg/table/mdm/mdm_windows.go
+++ b/orbit/pkg/table/mdm/mdm_windows.go
@@ -305,15 +305,18 @@ func isReadOnlyCommandRequest(inputCmd string) (bool, error) {
 		return false, err
 	}
 
-	// getting response data from output message
-	if len(messageObject.Item) > 0 {
-		for _, element := range messageObject.Item {
+	// sanity check on the input command structure
+	if len(messageObject.Item) == 0 {
+		return false, nil
+	}
 
-			// checking if input SyncML verb is different that Get
-			commandVerb := strings.ToLower(element.XMLName.Local)
-			if commandVerb != "get" {
-				return false, fmt.Errorf("%s is a not supported SyncML command verb", commandVerb)
-			}
+	// checking if input SyncML commands are only Get
+	for _, element := range messageObject.Item {
+
+		// checking if input SyncML verb is different that Get
+		commandVerb := strings.ToLower(element.XMLName.Local)
+		if commandVerb != "get" {
+			return false, fmt.Errorf("%s is a not supported SyncML command verb", commandVerb)
 		}
 	}
 

--- a/orbit/pkg/table/mdm/mdm_windows.go
+++ b/orbit/pkg/table/mdm/mdm_windows.go
@@ -209,11 +209,12 @@ func getCmdResponseData(outputCmd string) (string, error) {
 			// results will be appended in a comma separated list
 			if len(element.Item) > 0 {
 
-				if len(responseData) > 0 {
-					responseData += ","
+				// extracting the data from the result
+				workStr := element.Item[0].Data
+				if len(workStr) == 0 {
+					workStr = "data_not_set" // default value for empty data
 				}
-
-				responseData += element.Item[0].Data
+				responseData += workStr
 			}
 		}
 	}


### PR DESCRIPTION
This relates to #9310 

This PR adds a new column to the bridge mdm_table to provide a parsed and user-friendly output of the input command

This will help in creating compliance queries

There is also an improvement to UTF16 to go string conversion scenarios. This was required by scenarios on which output commands can vary in size

I've also added support to restrict input commands to read-only commands (only the SyncML verb Get is supported)