### PR TITLE
CIS 5.1.2

### DIFF
--- a/ee/cis/macos-13/cis-policy-queries.yml
+++ b/ee/cis/macos-13/cis-policy-queries.yml
@@ -893,6 +893,27 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
+  name: CIS - Ensure System Integrity Protection Status (SIP) Is Enabled
+  platforms: macOS
+  platform: darwin
+  description: |
+    System Integrity Protection is a security feature introduced in OS X 10.11 El Capitan. System Integrity Protection restricts access to System domain locations and restricts runtime attachment to system processes. Any attempt to inspect or attach to a system process will fail. Kernel Extensions are now restricted to /Library/Extensions and are required to be signed with a Developer ID.
+  resolution: |
+    Terminal Method:
+    Perform the following steps to enable System Integrity Protection:
+      1. Reboot into the Recovery Partition (reboot and hold down Command (⌘) + R)
+      2. Select Utilities
+      3. Select Terminal
+      4. Run the following command:
+          /usr/bin/sudo /usr/bin/csrutil enable
+  query: SELECT 1 FROM sip_config WHERE config_flag="sip" and enabled=1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS5.1.2
+  contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
   name: CIS - Ensure Password Account Lockout Threshold Is Configured (Fleetd required)
   platforms: macOS
   platform: darwin


### PR DESCRIPTION
This one is going to be hard to test because in order to change the mode one need to go into Recovery Partition (Hopefully it's possible in VMs)

These are the steps to change SIP:
Terminal Method:
    Perform the following steps to enable System Integrity Protection:
      1. Reboot into the Recovery Partition (reboot and hold down Command (⌘) + R)
      2. Select Utilities
      3. Select Terminal
      4. Run the following command:
          /usr/bin/sudo /usr/bin/csrutil enable


Found on Google but did not try:
You can do that using the following command:

```
sudo nvram "recovery-boot-mode=unused"
sudo reboot
```
This sets a firmware variable in nvram indicating that you want to start in Recovery mode on the next boot, and then reboots the machine.

When done in Recovery mode, run the following from the Terminal in Recovery mode:

`nvram -d recovery-boot-mode`