### PR TITLE
update file carver block size and various MySQL references

### DIFF
--- a/docs/Deploying/Load-testing.md
+++ b/docs/Deploying/Load-testing.md
@@ -18,27 +18,27 @@ A test is deemed successful when the Fleet server is able to receive and make re
 
 With the following infrastructure, 2,500 hosts successfully communicate with Fleet. The Fleet server is able to run live queries against all hosts.
 
-|Fleet instances| CPU Units       |RAM             |
-|-------|-------------------------|----------------|
-| 1 Fargate task | 512 CPU Units  | 4GB of memory |
+| Fleet instances | CPU Units     | RAM           |
+|-----------------|---------------|---------------|
+| 1 Fargate task  | 512 CPU Units | 4GB of memory |
 
-|&#8203;| Version                 |Instance type |
-|-------|-------------------------|--------------|
-| Redis | 5.0.6                   | cache.t4g.medium |
-| MySQL | 5.7.mysql_aurora.2.10.0 | db.t4g.small |
+| &#8203; | Version                 | Instance type    |
+|---------|-------------------------|------------------|
+| Redis   | 6.x                     | cache.t4g.medium |
+| MySQL   | 8.0.mysql_aurora.3.02.0 | db.t4g.small     |
 
 ### 150,000 hosts
 
 With the infrastructure listed below, 150,000 hosts successfully communicate with Fleet. The Fleet server is able to run live queries against all hosts.
 
-|Fleet instance | CPU Units       |RAM             |
-|-------|-------------------------|----------------|
-| 20 Fargate tasks | 1024 CPU units  | 4GB of memory |
+| Fleet instance   | CPU Units      | RAM           |
+|------------------|----------------|---------------|
+| 20 Fargate tasks | 1024 CPU units | 4GB of memory |
 
-|&#8203;| Version                 |Instance type   |
-|-------|-------------------------|----------------|
-| Redis | 5.0.6                   | cache.m6g.large |
-| MySQL | 5.7.mysql_aurora.2.10.0 | db.r6g.4xlarge |
+| &#8203; | Version                 | Instance type   |
+|---------|-------------------------|-----------------|
+| Redis   | 6.x                     | cache.m6g.large |
+| MySQL   | 8.0.mysql_aurora.3.02.0 | db.r6g.4xlarge  |
 
 In the above setup, the read replica was the same size as the writer node.
 

--- a/docs/Deploying/Reference-Architectures.md
+++ b/docs/Deploying/Reference-Architectures.md
@@ -45,7 +45,7 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 | Dependencies | Version                 | Instance type |
 |--------------|-------------------------|---------------|
 | Redis        | 6                       | t4g.small     |
-| MySQL        | 5.7.mysql_aurora.2.10.0 | db.t3.small   |        
+| MySQL        | 8.0.mysql_aurora.3.02.0 | db.t3.small   |        
 
 #### [Up to 25000 hosts](https://calculator.aws/#/estimate?id=4a3e3168275967d1e79a3d1fcfedc5b17d67a271)
 
@@ -56,7 +56,7 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 | Dependencies | Version                 | Instance type |
 |--------------|-------------------------|---------------|
 | Redis        | 6                       | m6g.large     |
-| MySQL        | 5.7.mysql_aurora.2.10.0 | db.r6g.large  |
+| MySQL        | 8.0.mysql_aurora.3.02.0 | db.r6g.large  |
 
 
 #### [Up to 150000 hosts](https://calculator.aws/#/estimate?id=1d8fdd63f01e71027e9d898ed05f4a07299a7000)
@@ -68,7 +68,7 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 | Dependencies | Version                 | Instance type  | Nodes |
 |--------------|-------------------------|----------------|-------|
 | Redis        | 6                       | m6g.large      | 3     |
-| MySQL        | 5.7.mysql_aurora.2.10.0 | db.r6g.4xlarge | 1     |
+| MySQL        | 8.0.mysql_aurora.3.02.0 | db.r6g.4xlarge | 1     |
 
 #### [Up to 300000 hosts](https://calculator.aws/#/estimate?id=f3da0597a172c6a0a3683023e2700a6df6d42c0b)
 
@@ -79,7 +79,7 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 | Dependencies | Version                 | Instance type   | Nodes |
 |--------------|-------------------------|-----------------|-------|
 | Redis        | 6                       | m6g.large       | 3     |
-| MySQL        | 5.7.mysql_aurora.2.10.0 | db.r6g.16xlarge | 2     |
+| MySQL        | 8.0.mysql_aurora.3.02.0 | db.r6g.16xlarge | 2     |
 
 AWS reference architecture can be found [here](https://github.com/fleetdm/fleet/tree/main/infrastructure/dogfood/terraform/aws). This configuration includes:
 
@@ -91,7 +91,7 @@ AWS reference architecture can be found [here](https://github.com/fleetdm/fleet/
 - ECS as the container orchestrator
   - Fargate for underlying compute
   - Task roles via IAM
-- RDS Aurora MySQL 5.7
+- RDS Aurora MySQL 8
 - Elasticache Redis Engine
 - Firehose osquery log destination
   - S3 bucket sync to allow further ingestion/processing
@@ -159,10 +159,10 @@ GCP reference architecture can be found in [the Fleet repository](https://github
 |-----------------|-----|-----|
 | 2 Cloud Run     | 1   | 2GB |
 
-| Dependencies | Version                 | Instance type |
-|--------------|-------------------------|---------------|
-| Redis        | MemoryStore Redis 6     | M1 Basic      |
-| MySQL        | Cloud SQL for MySQL 5.7 | db-standard-1 |        
+| Dependencies | Version               | Instance type |
+|--------------|-----------------------|---------------|
+| Redis        | MemoryStore Redis 6   | M1 Basic      |
+| MySQL        | Cloud SQL for MySQL 8 | db-standard-1 |        
 
 #### [Up to 25000 hosts](https://cloud.google.com/products/calculator/#id=fadbb96c-967c-4397-9921-743d75b98d42)
 
@@ -170,10 +170,10 @@ GCP reference architecture can be found in [the Fleet repository](https://github
 |-----------------|-----|-----|
 | 10 Cloud Run    | 1   | 2GB |
 
-| Dependencies | Version                 | Instance type |
-|--------------|-------------------------|---------------|
-| Redis        | MemoryStore Redis 6     | M1 2GB        |
-| MySQL        | Cloud SQL for MySQL 5.7 | db-standard-4 |
+| Dependencies | Version               | Instance type |
+|--------------|-----------------------|---------------|
+| Redis        | MemoryStore Redis 6   | M1 2GB        |
+| MySQL        | Cloud SQL for MySQL 8 | db-standard-4 |
 
 
 #### [Up to 150000 hosts](https://cloud.google.com/products/calculator/#id=baff774c-d294-491f-a9da-dd97bbfa8ef2)
@@ -182,10 +182,10 @@ GCP reference architecture can be found in [the Fleet repository](https://github
 |-----------------|-------|-----|
 | 30 Cloud Run    | 1 CPU | 2GB |
 
-| Dependencies | Version                 | Instance type | Nodes |
-|--------------|-------------------------|---------------|-------|
-| Redis        | MemoryStore Redis 6     | M1 4GB        | 1     |
-| MySQL        | Cloud SQL for MySQL 5.7 | db-highmem-16 | 1     |
+| Dependencies | Version               | Instance type | Nodes |
+|--------------|-----------------------|---------------|-------|
+| Redis        | MemoryStore Redis 6   | M1 4GB        | 1     |
+| MySQL        | Cloud SQL for MySQL 8 | db-highmem-16 | 1     |
 
 ### Azure
 

--- a/docs/Using-Fleet/fleetctl-CLI.md
+++ b/docs/Using-Fleet/fleetctl-CLI.md
@@ -322,7 +322,7 @@ Given a working flagfile for connecting osquery agents to Fleet, add the followi
 --carver_disable_function=false
 --carver_start_endpoint=/api/v1/osquery/carve/begin
 --carver_continue_endpoint=/api/v1/osquery/carve/block
---carver_block_size=2097152
+--carver_block_size=8000000
 ```
 
 The default flagfile provided in the "Add New Host" dialog also includes this configuration.
@@ -332,16 +332,12 @@ The default flagfile provided in the "Add New Host" dialog also includes this co
 The `carver_block_size` flag should be configured in osquery.
 
 For the (default) MySQL Backend, the configured value must be less than the value of
-`max_allowed_packet` in the MySQL connection, allowing for some overhead. The default for MySQL 5.7
-is 4MB and for MySQL 8 it is 64MB. 2MiB (`2097152`) is a good starting value.
+`max_allowed_packet` in the MySQL connection, allowing for some overhead. The default for [MySQL 5.7](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_max_allowed_packet)
+is 4MB and for [MySQL 8](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_allowed_packet) it is 64MB. 2MiB (`2097152`) is a good starting value.
 
 For the S3/Minio backend, this value must be set to at least 5MiB (`5242880`) due to the
 [constraints of S3's multipart
 uploads](https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html).
-
-Using a smaller value for `carver_block_size` will lead to more HTTP requests during the carving
-process, resulting in longer carve times and higher load on the Fleet server. If the value is too
-high, HTTP requests may run long enough to cause server timeouts.
 
 #### Compression
 
@@ -424,7 +420,7 @@ When using the MySQL backend (default), this value must be less than the `max_al
 setting in MySQL. If it is too large, MySQL will reject the writes.
 
 When using S3, the value must be at least 5MiB (5242880 bytes), as smaller multipart upload
-sizes are rejected. Additionally [S3
+sizes are rejected. Additionally, [S3
 limits](https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html) the maximum number of
 parts to 10,000.
 

--- a/docs/Using-Fleet/fleetctl-CLI.md
+++ b/docs/Using-Fleet/fleetctl-CLI.md
@@ -333,7 +333,7 @@ The `carver_block_size` flag should be configured in osquery.
 
 For the (default) MySQL Backend, the configured value must be less than the value of
 `max_allowed_packet` in the MySQL connection, allowing for some overhead. The default for [MySQL 5.7](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_max_allowed_packet)
-is 4MB and for [MySQL 8](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_allowed_packet) it is 64MB. 2MiB (`2097152`) is a good starting value.
+is 4MB and for [MySQL 8](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_allowed_packet) it is 64MB.
 
 For the S3/Minio backend, this value must be set to at least 5MiB (`5242880`) due to the
 [constraints of S3's multipart

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -121,7 +121,7 @@ const PlatformWrapper = ({
 --disable_carver=false
 --carver_start_endpoint=/api/v1/osquery/carve/begin
 --carver_continue_endpoint=/api/v1/osquery/carve/block
---carver_block_size=2000000`;
+--carver_block_size=8000000`;
 
   const onDownloadEnrollSecret = (evt: React.MouseEvent) => {
     evt.preventDefault();

--- a/orbit/changes/issue-9550-default-carver-block-size
+++ b/orbit/changes/issue-9550-default-carver-block-size
@@ -1,0 +1,1 @@
+- update fleetctl to generate installer flags that use a larger default file carving block size compatible with MySQL 8 & S3

--- a/orbit/pkg/osquery/flags.go
+++ b/orbit/pkg/osquery/flags.go
@@ -32,6 +32,6 @@ func FleetFlags(fleetURL *url.URL) []string {
 		"--carver_disable_function=false",
 		"--carver_start_endpoint=" + path.Join(prefix, "/api/v1/osquery/carve/begin"),
 		"--carver_continue_endpoint=" + path.Join(prefix, "/api/v1/osquery/carve/block"),
-		"--carver_block_size=2000000",
+		"--carver_block_size=8000000",
 	}
 }

--- a/tools/kubequery/kubequery-fleet.yml
+++ b/tools/kubequery/kubequery-fleet.yml
@@ -99,7 +99,7 @@ data:
     --disable_carver=false
     --carver_start_endpoint=/api/v1/osquery/carve/begin
     --carver_continue_endpoint=/api/v1/osquery/carve/block
-    --carver_block_size=2000000
+    --carver_block_size=8000000
   kubequery.conf: |
   fleet.pem: |
     -----BEGIN CERTIFICATE-----

--- a/tools/osquery/example_osquery.flags
+++ b/tools/osquery/example_osquery.flags
@@ -27,4 +27,4 @@
 --disable_carver=false
 --carver_start_endpoint=/api/osquery/carve/begin
 --carver_continue_endpoint=/api/osquery/carve/block
---carver_block_size=2000000
+--carver_block_size=8000000


### PR DESCRIPTION
Update the default file carver block size to be compatible with MySQL 8 & S3.
Update surrounding docs.
Various other updates to references of MySQL versions (all terraform deploys are now defaulted MySQL 8 in AWS)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
