### PR TITLE
Update link previews for non-article pages

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -73,6 +73,7 @@ module.exports.routes = {
     action: 'articles/view-basic-article',
     locals: {
       currentPage: 'articles',
+      isArticlePage: true,
     }
   },// Handles /device-management/foo, /securing/foo, /releases/foo, /engineering/foo, /guides/foo, /announcements/foo, /deploy/foo, /podcasts/foo, /report/foo
 

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -73,7 +73,6 @@ module.exports.routes = {
     action: 'articles/view-basic-article',
     locals: {
       currentPage: 'articles',
-      isArticlePage: true,
     }
   },// Handles /device-management/foo, /securing/foo, /releases/foo, /engineering/foo, /guides/foo, /announcements/foo, /deploy/foo, /podcasts/foo, /report/foo
 

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -14,7 +14,7 @@
     <% /* Viewport tag for sensible mobile support */ %>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <%// Twitter meta tags%>
-    <meta name="twitter:card" content="<%= <%= typeof pageImageForMeta !== 'undefined' ? 'summary_large_image' : 'summary' %>" />
+    <meta name="twitter:card" content="<%= typeof pageImageForMeta !== 'undefined' ? 'summary_large_image' : 'summary' %>" />
     <meta name="twitter:site" content="https://fleetdm.com" />
     <meta name="twitter:description" content="<%= typeof pageDescriptionForMeta !== 'undefined' ? pageDescriptionForMeta : 'Fleet is the lightweight, programmable telemetry platform for servers and workstations. Get comprehensive, customizable data from all your devices and operating systems — without the performance hit'  %>" />
     <meta name="twitter:title" content="<%= typeof pageTitleForMeta !== 'undefined' ? pageTitleForMeta : 'Fleet for osquery | Lightweight, programmable telemetry for servers and workstations' %>" />

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -4,7 +4,6 @@
   // don't have to do `typeof` checks below.
   var me;
   var isHomepage;
-  var isArticlePage;
   var headerCTAHidden;
 %><!DOCTYPE html>
 <html>
@@ -15,7 +14,7 @@
     <% /* Viewport tag for sensible mobile support */ %>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <%// Twitter meta tags%>
-    <meta name="twitter:card" content="<%= isArticlePage ? 'summary_large_image' : 'summary' %>" />
+    <meta name="twitter:card" content="<%= <%= typeof pageImageForMeta !== 'undefined' ? 'summary_large_image' : 'summary' %>" />
     <meta name="twitter:site" content="https://fleetdm.com" />
     <meta name="twitter:description" content="<%= typeof pageDescriptionForMeta !== 'undefined' ? pageDescriptionForMeta : 'Fleet is the lightweight, programmable telemetry platform for servers and workstations. Get comprehensive, customizable data from all your devices and operating systems — without the performance hit'  %>" />
     <meta name="twitter:title" content="<%= typeof pageTitleForMeta !== 'undefined' ? pageTitleForMeta : 'Fleet for osquery | Lightweight, programmable telemetry for servers and workstations' %>" />

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -4,6 +4,7 @@
   // don't have to do `typeof` checks below.
   var me;
   var isHomepage;
+  var isArticlePage;
   var headerCTAHidden;
 %><!DOCTYPE html>
 <html>
@@ -14,7 +15,7 @@
     <% /* Viewport tag for sensible mobile support */ %>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <%// Twitter meta tags%>
-    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:card" content="<%= isArticlePage ? 'summary_large_image' : 'summary' %>" />
     <meta name="twitter:site" content="https://fleetdm.com" />
     <meta name="twitter:description" content="<%= typeof pageDescriptionForMeta !== 'undefined' ? pageDescriptionForMeta : 'Fleet is the lightweight, programmable telemetry platform for servers and workstations. Get comprehensive, customizable data from all your devices and operating systems — without the performance hit'  %>" />
     <meta name="twitter:title" content="<%= typeof pageTitleForMeta !== 'undefined' ? pageTitleForMeta : 'Fleet for osquery | Lightweight, programmable telemetry for servers and workstations' %>" />


### PR DESCRIPTION
closes https://github.com/fleetdm/fleet/issues/9544

Changes:
- Updated layout.ejs to only use `summary_large_card` for link previews if the page has a `pageImageForMeta` value