### PR TITLE
Fleet UI: Manage host page performance issues > 50 hosts pp

### DIFF
--- a/changes/9562-hosts-pp
+++ b/changes/9562-hosts-pp
@@ -1,0 +1,1 @@
+* Change default hosts per page from 100 to 50

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -536,7 +536,7 @@ const ManageHostsPage = ({
       osName,
       osVersion,
       page: tableQueryData ? tableQueryData.pageIndex : 0,
-      perPage: tableQueryData ? tableQueryData.pageSize : 100,
+      perPage: tableQueryData ? tableQueryData.pageSize : 50,
       device_mapping: true,
     };
 
@@ -1766,7 +1766,7 @@ const ManageHostsPage = ({
           (sortBy[0] && sortBy[0].direction) || DEFAULT_SORT_DIRECTION
         }
         defaultSearchQuery={searchQuery}
-        pageSize={100}
+        pageSize={50}
         actionButtonText={"Edit columns"}
         actionButtonIcon={EditColumnsIcon}
         actionButtonVariant={"text-icon"}


### PR DESCRIPTION
## Issue
#9562 

## Short term fix
- Change the default hosts per page from 100 to 50 to decrease performance issues while we dig into root cause

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

