### PR TITLE
Fleet UI: MDM > ABM fix org_name key

### DIFF
--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -8,7 +8,7 @@ export interface IMdmApple {
 export interface IMdmAppleBm {
   default_team?: string;
   apple_id: string;
-  organization_name: string;
+  org_name: string;
   mdm_server_url: string;
   renew_date: string;
 }

--- a/frontend/pages/admin/IntegrationsPage/cards/Mdm/Mdm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Mdm/Mdm.tsx
@@ -249,7 +249,7 @@ const Mdm = (): JSX.Element => {
           <h4>Apple ID</h4>
           <p>{mdmAppleBm.apple_id}</p>
           <h4>Organization name</h4>
-          <p>{mdmAppleBm.organization_name}</p>
+          <p>{mdmAppleBm.org_name}</p>
           <h4>MDM Server URL</h4>
           <p>{mdmAppleBm.mdm_server_url}</p>
           <h4>Renew date</h4>

--- a/frontend/services/mock_service/mocks/config.ts
+++ b/frontend/services/mock_service/mocks/config.ts
@@ -22,9 +22,6 @@ const REQUEST_RESPONSE_MAPPINGS: IResponses = {
     // request query string is hostname, uuid, or mac address; response is host detail excluding any
     // expensive data operations
     "targets?query={*}": RESPONSES.hosts,
-    "mdm/apple": RESPONSES.mdmApple,
-    "mdm/apple_bm": RESPONSES.mdmAppleBm,
-    "mdm/profile": RESPONSES.mdmEnrollmentProfile,
   },
   POST: {
     // request body is ISelectedTargets

--- a/frontend/services/mock_service/mocks/responses.ts
+++ b/frontend/services/mock_service/mocks/responses.ts
@@ -11,27 +11,6 @@ const count = {
   targets_missing_in_action: 0,
 };
 
-// MDM TODO: Remove mock when backend is merged
-const mdmApple = {
-  common_name: "Mock backend response APSP:04b46ce0-xxxx-xxxx-xxxx-xxxxxxxx",
-  serial_number: "Mock backend response 123938388712",
-  issuer:
-    "Mock backend response Apple Application Integration 2 Certification Authority",
-  renew_date: "2023-09-30T00:00:00Z",
-};
-
-// MDM TODO: Remove mock when backend is merged
-const mdmAppleBm = {
-  default_team: "Mock backend response Apples",
-  apple_id: "Mock backend response test@example.com",
-  organization_name: "Mock backend response Fleet Device Management",
-  mdm_server_url: "Mock backend response https://fleet.organization.com/mdm",
-  renew_date: "2023-09-30T00:00:00Z",
-};
-
-// MDM TODO: Remove mock when backend is merged
-const mdmEnrollmentProfile = {};
-
 const hosts = {
   hosts: [
     {
@@ -389,7 +368,4 @@ export default {
   count,
   hosts,
   labels,
-  mdmApple,
-  mdmAppleBm,
-  mdmEnrollmentProfile,
 };


### PR DESCRIPTION
### FIX
- API returns `org_name` not `organization_name`

### OTHER
- Remove MDM mock data no longer needed for development

<img width="929" alt="Screenshot 2023-02-03 at 10 51 19 AM" src="https://user-images.githubusercontent.com/71795832/216647378-3dc118c9-736b-4b7e-8a3b-8a728488bf5c.png">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
