### PR TITLE
Fleet UI: 3 release fixes

### DIFF
--- a/frontend/pages/MacOSUpdates/components/OsMinVersionForm/OsMinVersionForm.tsx
+++ b/frontend/pages/MacOSUpdates/components/OsMinVersionForm/OsMinVersionForm.tsx
@@ -138,7 +138,7 @@ const OsMinVersionForm = ({ currentTeamId }: IOsMinVersionForm) => {
       <InputField
         label="Minimum version"
         tooltip="The end user sees the window until their macOS is at or above this version."
-        hint="Version number only (e.g. “13.0.1” not “Ventura 13” or “13.0.1 (22A400)”)"
+        hint="Version number only (e.g., “13.0.1” not “Ventura 13” or “13.0.1 (22A400)”)"
         placeholder="13.0.1"
         value={minOsVersion}
         error={minOsVersionError}

--- a/frontend/pages/MacOSUpdates/components/OsMinVersionForm/OsMinVersionForm.tsx
+++ b/frontend/pages/MacOSUpdates/components/OsMinVersionForm/OsMinVersionForm.tsx
@@ -138,7 +138,7 @@ const OsMinVersionForm = ({ currentTeamId }: IOsMinVersionForm) => {
       <InputField
         label="Minimum version"
         tooltip="The end user sees the window until their macOS is at or above this version."
-        hint="Version number only (e.g., “13.0.1.”) NOT “Ventura 13” or “13.0.1 (22A400)."
+        hint="Version number only (e.g. “13.0.1” not “Ventura 13” or “13.0.1 (22A400)”)"
         placeholder="13.0.1"
         value={minOsVersion}
         error={minOsVersionError}

--- a/frontend/pages/admin/IntegrationsPage/cards/Mdm/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/Mdm/_styles.scss
@@ -40,9 +40,6 @@
     font-size: $x-small;
     color: $core-fleet-black;
     width: 100%;
-    @media (min-width: $break-990) {
-      width: 60%;
-    }
   }
 
   &__section-information {

--- a/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/_styles.scss
@@ -1,4 +1,4 @@
-.manual-enroll-mdm-modal {
+.enroll-mdm-modal {
   &__download-button {
     margin-top: 12px;
   }


### PR DESCRIPTION
### Release issues
- Cerra #9670 
- Cerra #9669 
- Cerra #9667 

### FIXES
- CSS baseclass name on component changed but not updated on css file which caused download button to not be styled with top margin
- Fix grammar error with parentheses, use of e.g., and quotes
- Allow content to take as much space as headers, leave headers at 65% width to match other setting pages


### Screenshots
<img width="1257" alt="Screenshot 2023-02-03 at 4 02 28 PM" src="https://user-images.githubusercontent.com/71795832/216710141-1c4c05f3-df3e-491f-8081-60a9fa07db6a.png">
<img width="583" alt="Screenshot 2023-02-03 at 4 07 15 PM" src="https://user-images.githubusercontent.com/71795832/216710931-2460c2f2-6414-4713-801b-a5c8f8c45e34.png">
<img width="793" alt="Screenshot 2023-02-03 at 3 58 19 PM" src="https://user-images.githubusercontent.com/71795832/216710144-252bdf7c-d008-4f8e-b56b-1625c4e9b5d5.png">


// Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
