### PR TITLE
Website: Disable bot comments on closed issues.

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -201,33 +201,34 @@ module.exports = {
         'Authorization': `token ${sails.config.custom.githubAccessToken}`
       };
 
-      if (!sails.config.custom.openAiSecret) {
-        throw new Error('sails.config.custom.openAiSecret not set.  Cannot respond with haiku.');
-      }//•
+      // Disabled on 02-06-2023 until we find out the cause of the 429 responses from OpenAI.
+      // if (!sails.config.custom.openAiSecret) {
+      //   throw new Error('sails.config.custom.openAiSecret not set.  Cannot respond with haiku.');
+      // }//•
 
-      // Grab issue title and body, then truncate the length of the body so that it fits
-      // within the maximum length tolerated by OpenAI.  Then combine those into a prompt
-      // generate a haiku based on this issue.
-      let issueSummary = '# ' + issueOrPr.title + '\n' + _.trunc(issueOrPr.body, 2000);
+      // // Grab issue title and body, then truncate the length of the body so that it fits
+      // // within the maximum length tolerated by OpenAI.  Then combine those into a prompt
+      // // generate a haiku based on this issue.
+      // let issueSummary = '# ' + issueOrPr.title + '\n' + _.trunc(issueOrPr.body, 2000);
 
-      // Generate haiku
-      // [?] https://beta.openai.com/docs/api-reference/completions/create
-      let openAiReport = await sails.helpers.http.post('https://api.openai.com/v1/completions', {
-        model: 'text-davinci-003',
-        prompt: `You are an empathetic product designer.  I will give you a Github issue with information about a particular improvement to Fleet, an open-source device management and security platform.  You will write a haiku about how this improvement could benefit users or contributors.  Be detailed and specific in the haiku.  Do not use hyperbole.  Be matter-of-fact.  Be positive.  Do not make Fleet (or anyone) sound bad.  But be honest.  If appropriate, mention imagery from nature, or from a glass city in the clouds.  Do not give orders.\n\nThe first GitHub issue is:\n${issueSummary}`,
-        temperature: 0.7,
-        max_tokens: 256//eslint-disable-line camelcase
-      }, {
-        Authorization: `Bearer ${sails.config.custom.openAiSecret}`
-      });
-      newBotComment = openAiReport.choices[0].text;
-      newBotComment = newBotComment.replace(/^\s*\n*[^\n:]*Haiku[^\n:]*:\s*/i,'');// « eliminate "*Haiku:" prefix line, if one is generated
+      // // Generate haiku
+      // // [?] https://beta.openai.com/docs/api-reference/completions/create
+      // let openAiReport = await sails.helpers.http.post('https://api.openai.com/v1/completions', {
+      //   model: 'text-davinci-003',
+      //   prompt: `You are an empathetic product designer.  I will give you a Github issue with information about a particular improvement to Fleet, an open-source device management and security platform.  You will write a haiku about how this improvement could benefit users or contributors.  Be detailed and specific in the haiku.  Do not use hyperbole.  Be matter-of-fact.  Be positive.  Do not make Fleet (or anyone) sound bad.  But be honest.  If appropriate, mention imagery from nature, or from a glass city in the clouds.  Do not give orders.\n\nThe first GitHub issue is:\n${issueSummary}`,
+      //   temperature: 0.7,
+      //   max_tokens: 256//eslint-disable-line camelcase
+      // }, {
+      //   Authorization: `Bearer ${sails.config.custom.openAiSecret}`
+      // });
+      // newBotComment = openAiReport.choices[0].text;
+      // newBotComment = newBotComment.replace(/^\s*\n*[^\n:]*Haiku[^\n:]*:\s*/i,'');// « eliminate "*Haiku:" prefix line, if one is generated
 
-      // Now that we know what to say, add our comment.
-      await sails.helpers.http.post('https://api.github.com/repos/'+encodeURIComponent(owner)+'/'+encodeURIComponent(repo)+'/issues/'+encodeURIComponent(issueNumber)+'/comments',
-        {'body': newBotComment},
-        baseHeadersForGithubApiRequests
-      );
+      // // Now that we know what to say, add our comment.
+      // await sails.helpers.http.post('https://api.github.com/repos/'+encodeURIComponent(owner)+'/'+encodeURIComponent(repo)+'/issues/'+encodeURIComponent(issueNumber)+'/comments',
+      //   {'body': newBotComment},
+      //   baseHeadersForGithubApiRequests
+      // );
 
     } else if (
       (ghNoun === 'pull_request' &&  ['opened','reopened','edited'].includes(action))

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -191,17 +191,18 @@ module.exports = {
       //  ██║███████║███████║╚██████╔╝███████╗    ╚██████╗███████╗╚██████╔╝███████║███████╗██████╔╝
       //  ╚═╝╚══════╝╚══════╝ ╚═════╝ ╚══════╝     ╚═════╝╚══════╝ ╚═════╝ ╚══════╝╚══════╝╚═════╝
       //
-      // Handle closed issue by commenting on it.
-      let owner = repository.owner.login;
-      let repo = repository.name;
-      let issueNumber = issueOrPr.number;
-      let newBotComment;
-      let baseHeadersForGithubApiRequests = {
-        'User-Agent': 'Fleetie pie',
-        'Authorization': `token ${sails.config.custom.githubAccessToken}`
-      };
-
       // Disabled on 02-06-2023 until we find out the cause of the 429 responses from OpenAI.
+      //
+      // Handle closed issue by commenting on it.
+      // let owner = repository.owner.login;
+      // let repo = repository.name;
+      // let issueNumber = issueOrPr.number;
+      // let newBotComment;
+      // let baseHeadersForGithubApiRequests = {
+      //   'User-Agent': 'Fleetie pie',
+      //   'Authorization': `token ${sails.config.custom.githubAccessToken}`
+      // };
+
       // if (!sails.config.custom.openAiSecret) {
       //   throw new Error('sails.config.custom.openAiSecret not set.  Cannot respond with haiku.');
       // }//•


### PR DESCRIPTION
Changes:
 - Disabled the Open AI API request in the `receive-from-github` webhook. It is currently returning a `429` response and causing `500` errors.
<img width="753" alt="image" src="https://user-images.githubusercontent.com/7445991/217028846-77e75d98-a595-46e7-aefa-7a76811b32d4.png">
