### PR TITLE
DeviceUserPage MDM banner adjustments

### DIFF
--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -32,9 +32,8 @@
 
 .device-user {
   display: flex;
-  flex-wrap: wrap;
-  flex-grow: 1;
-  align-content: flex-start;
+  flex-direction: column;
+  justify-content: flex-start;
   padding-bottom: 50px;
   min-width: 0;
   background-color: $ui-off-white;

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -40,6 +40,12 @@
   background-color: $ui-off-white;
   gap: $pad-medium;
 
+  .info-banner {
+    &__cta {
+      white-space: nowrap;
+    }
+  }
+
   .header {
     flex: 100%;
     display: flex;


### PR DESCRIPTION
# Addresses #9668 
- Turn on MDM now doesn't wrap
- Also kept banner width matching the rest of the page content:
    - before: <img width="1196" alt="before" src="https://user-images.githubusercontent.com/61553566/217093932-2ac6cdfb-6078-4895-bad3-6c777287f8cb.png">
    - after: <img width="1300" alt="after" src="https://user-images.githubusercontent.com/61553566/217093943-9f171b9c-a342-44e0-825a-63f397e2966c.png">


# Checklist for submitter
- [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.