### PR TITLE
Make 2nd file download async to fix

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/Mdm/Mdm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Mdm/Mdm.tsx
@@ -105,7 +105,7 @@ const Mdm = (): JSX.Element => {
 
       const privateFilename = "fleet-apple-mdm-bm-private.key";
       const privateFile = new global.window.File(
-        [keys.decodedPublic],
+        [keys.decodedPrivate],
         privateFilename,
         {
           type: "application/x-pem-file",
@@ -113,11 +113,13 @@ const Mdm = (): JSX.Element => {
       );
 
       FileSaver.saveAs(publicFile);
-      FileSaver.saveAs(privateFile);
+      setTimeout(() => {
+        FileSaver.saveAs(privateFile);
+      }, 100);
     } else {
       renderFlash(
         "error",
-        "Your MDM business manager keys could not be downloaded. Please TODO ACTION."
+        "Your MDM business manager keys could not be downloaded. Please try again."
       );
     }
     return false;


### PR DESCRIPTION
# Addresses #9680 
- Add 100ms timeout before 2nd key is downloaded from browser
- Fix file decoding to correctly download both keys
- Fix copy

# Checklist for submitter

- [x] Manual QA for all new/changed functionality