### PR TITLE
Bizops handbook

### DIFF
--- a/handbook/business-operations/README.md
+++ b/handbook/business-operations/README.md
@@ -1,10 +1,5 @@
 # Business Operations
 
-#### In this section
-
-- [Finance](#finance)
-- [BizOps](#bizops)
-
 
 ## Finance
 
@@ -56,16 +51,13 @@ For non-travel purchases that would require an increase in the Brex cardholder's
 - In general, recurring purchases such as subscription services that will continually stretch the spend limit on a cardholder's Brex card should be paid through other means. 
 - For one time purchases where payment via credit card is the most convenient then the card limit will be temporarily increased to accomodate the purchase.  
 
-
-## BizOps
-
-#### Zoom
+## Zoom
 We use [Zoom](https://zoom.us) for virtual meetings at Fleet, and it is important that every team member feels comfortable hosting, joining, and scheduling Zoom meetings.
 By default, Zoom settings are the same for all Fleet team members, but you can change your personal settings on your [profile settings](https://zoom.us/profile/setting) page. 
 Settings that have a lock icon next to them have been locked by an administrator and cannot be changed. Zoom administrators can change settings for all team members on the [account settings page](https://zoom.us/account/setting) or for individual accounts on the [user management page](https://zoom.us/account/user#/).
 
 
-#### Gong
+## Gong
 Capturing video from meetings with customers, prospects, and community members outside the company is an important part of building world-class sales and customer success teams and is a widespread practice across the industry. At Fleet, we use Gong to capture Zoom meetings and share them company-wide. If a team member with a Gong license attends certain meetings, generally those with at least one person from outside of Fleet in attendance.  
   - While some Fleeties may have a Gong seat that is necessary in their work, the typical use case at Fleet is for employees on the company's sales, customer success, or customer support teams. 
   - You should be notified anytime you join a recorded call with an audio message announcing "this meeting is being recorded" or "recording in progress."  To stop a recording, the host of the call can press "Stop." 
@@ -92,13 +84,13 @@ Troubleshooting Gong:
 >If you need help using Gong, please check out Gong Academy at [https://academy.gong.io/](https://academy.gong.io/).
 
 
-#### Slack
+## Slack
 At Fleet, we do not send internal emails to each other. Instead, we prefer to use Slack to communicate with other folks who work at Fleet.
 We use threads in Slack as much as possible. Threads help limit noise for other people following the channel and reduce notification overload.
 We configure our [working hours in Slack](https://slack.com/help/articles/360025054173-Set-up-Slack-for-work-hours-) to make sure everyone knows when they can get in touch with others.
 
 
-#### Zapier and DocuSign
+## Zapier and DocuSign
 We use Zapier to automate how completed DocuSign envelopes are formatted and stored. This process ensures we store signed documents in the correct folder and that filenames are formatted consistently. 
 When the final signature is added to an envelope in DocuSign, it is marked as completed and sent to Zapier, where it goes through these steps:
 1. Zapier sends the following information about the DocuSign envelope to our Hydroplane webhook:
@@ -116,7 +108,7 @@ When the final signature is added to an envelope in DocuSign, it is marked as co
       link: drive.google.com/[destinationFolderID]
    ```
 
-#### Salesforce 
+## Salesforce 
 We consider Salesforce to be our Rolodex for customer information. During the onboarding process, you may need to add a license for the new hire. Here are the steps we take: 
 1. Go to “Your account.”
 2. View contracts -> pick current contract.
@@ -127,57 +119,37 @@ We consider Salesforce to be our Rolodex for customer information. During the on
 
 ## Security
 
-#### In this section
-
-- [Security](#security) 
-- [Security policies](#security-policies)
-
-
-### Security
-Details about Security processes are located on [the Security page](./security.md).
-
-### Security policies
-Review the [security policies](./security-policies.md) page for more information about Fleet's security policies. 
- 
- 
-## PeopleOps
-
-#### In this section
-
-- [CEO handbook](#ceo-handbook)
-- [Directly responsible individuals](#directly-responsible-individuals)
-- [Benefits](#benefits)
-- [Payroll](#payroll)
-- [Security](#security)
-- [All the things](#all-the-things)
-- [Hiring](#hiring)
-- [Onboarding](#onboarding)
-- [Taxes and compliance](#taxes-and-compliance)
-- [Celebrations](#celebrations)
-- [Departures](#departures)
+At Fleet, we care about security. Here are a few resources about Fleet's security policies and best practices.
+1. [Security policies](https://fleetdm.com/handbook/security/security-policies#security-policies)
+2. [Human resources security policy](https://fleetdm.com/handbook/security/security-policies#human-resources-security-policy)
+3. [Account recovery process](https://fleetdm.com/handbook/security#account-recovery-process)
+4. [Personal mobile devices](https://fleetdm.com/handbook/security#personal-mobile-devices)
+5. [Hardware security keys](https://fleetdm.com/handbook/security#hardware-security-keys)
+6. More details about internal security processes at Fleet are located on [the Security page](./security.md).
 
 
-### CEO handbook
+
+## CEO handbook
 [The CEO handbook](./ceo-handbook.md) details processes specific to Mike McNeil, CEO of Fleet. 
 
 
-### Directly responsible individuals
+## Directly responsible individuals
 At Fleet, we use the concept of Directly Responsible Individuals (**DRI**s). This person is singularly responsible for a given aspect of the open source project, the product, or the company.
 This person is accountable for accomplishing goals and making decisions about a particular element of Fleet.
 DRIs help us collaborate efficiently by knowing exactly who is responsible and can make decisions about the work they're doing and are available to view in the [codeowners file](https://github.com/fleetdm/fleet/blob/main/CODEOWNERS).
 >You can read more about directly responsible individuals in [GitLab's handbook](https://about.gitlab.com/handbook/people-group/directly-responsible-individuals/)
 
 
-### Benefits
+## Benefits
 
-#### Coworking
+### Coworking
 Your Brex card may be used for up to $500 USD per month in coworking costs. Please get prior approval from your manager. Once approved, get started by reaching out to Charlie Chance via direct message in Slack.
 
-#### Paid time off
+### Paid time off
 What matters most is your results, which are driven by your focus, your availability to collaborate, and the time and consideration you put into your work. Fleet offers all team members unlimited time off. Whether you're sick, you want to take a trip, you are eager for some time to relax, or you need to get some chores done around the house, any reason is a good reason.
 For team members working in jurisdictions that require certain mandatory sick leave or PTO policies, Fleet complies to the extent required by law.
 
-#### Taking time off
+### Taking time off
 When you take any time off, you should follow this process:
 - Let your manager and team know as soon as possible (i.e., post a message in your team's Slack channel with when and how long).
 - Find someone to cover anything that needs covering while you're out and communicate what they need to take over the responsibilities as well as who to refer to for help (e.g., meetings, planned tasks, unfinished business, important Slack/email threads, anything where someone might be depending on you).
@@ -186,7 +158,7 @@ If you can’t complete the above because you need to take the day off quickly d
 If you ever want to take a day off, and the only thing stopping you is internal (Fleetie-only) meetings, don’t stress. Consider, “Is this a meeting that I can reschedule to another day, or is this a meeting that can go on without me and not interfere with the company’s plans?” Talk to your manager if you’re unsure, but it is perfectly OK to reschedule internal meetings that can wait so that you can take a day off.
 This process is the same for any days you take off, whether it's a holiday or you just need a break.
    
-#### Holidays
+### Holidays
 At Fleet, we have team members with various employment classifications in many different countries worldwide. Fleet is a US company, but we think you should choose the days you want to work and what days you are on holiday, rather than being locked into any particular nation or culture's expectation about when to take time off.
 When a team member joins Fleet, they pick one of the following holiday schedules:
  - **Traditional**: This is based on the country where you work. Non-US team members should let their managers know the dates of national holidays.
@@ -194,15 +166,15 @@ When a team member joins Fleet, they pick one of the following holiday schedules
  - **Freestyle**: You have no set schedule and start with no holidays. Then you add the days that are holidays to you.
 Either way, it's up to you to make sure that your responsibilities are covered, and that your team knows you're out of the office.
 
-#### New parent leave
+### New parent leave
 Fleet gives new parents six weeks of paid leave. After six weeks, if you don't feel ready to return yet, we'll set up a quick call to discuss and work together to come up with a plan to help you return to work gradually or when you're ready.
 
-#### Compensation changes
+### Compensation changes
 Fleet evaluates compensation during annual workiversaries. Supervisors and managers will document compensation changes and effective date in employee 1:1 docs and email confirmation to Charlie. Charlie will make sure that a copy of the compensation change is added to the [¶¶People Operations folder](https://drive.google.com/drive/folders/1NKZ0UTmLbOPOeAA-iaEote3_diqu8Cbw?usp=share_link) for record keeping. (For the forseeable (pre series B) future, comp changes will originate during zach/mike 1:1s in our agenda doc.)
 Additional steps: Charlie will update the respective payroll platform (Gusto or Pilot) and update the [Equity spreadsheet](https://docs.google.com/spreadsheets/d/1_GJlqnWWIQBiZFOoyl9YbTr72bg5qdSSp4O3kuKm1Jc/edit?usp=sharing) (internal doc).
 
 
-### Payroll
+## Payroll
 Many of these processes are automated, but it's vital to check Gusto and Pilot manually for accuracy.
  - Salary employees are automated in Gusto and Pilot
  - Contractors are a manual process in Gusto and Pilot
@@ -225,39 +197,31 @@ The steps for doing this are highlighted in this loom, TODO.
 5. Sync hours
 6. Run contractor payroll
 
-#### Reimbursements
+## Reimbursements
 We provide all of our team members with Brex cards for making purchases for the company. Fleet will reimburse team members who pay for work-related expenses with their personal funds.
 Team members can request reimbursement through [Gusto]([https://app.gusto.com/expenses](https://support.gusto.com/article/209831449100000/Get-reimbursed-for-expenses-as-an-employee)) if they're in the US or [Pilot]([https://pilot.co/](https://help.pilot.co/en/articles/4658204-how-to-request-a-reimbursement#:~:text=If%20you%20made%20a%20purchase,and%20click%20'Add%20new%20expense.)) if they are an international team member. When submitting an expense report, team members need to provide the receipt and a description of the expense.
 Operations will review the expense and reach out to the team member if they have any questions. The reimbursement will be added to the team member's next payroll when an expense is approved.
 >Pilot handles reimbursements differently depending on if the international team member is classified as an employee or a contractor. If the reimbursement is for a contractor, Operations will need to add the expense reimbursement to an upcoming recurring payment or schedule the reimbursement as an off-cycle payment. If the reimbursement is for an employee, no other action is needed; Pilot will add the reimbursement to the team member's next payroll. 
 
 
-#### Performance feedback
+## Performance feedback
 At Fleet, performance feedback is a continuous process. We give feedback (particularly negative) as soon as possible. Most feedback will happen during 1:1 meetings, if not sooner.
 Founders evaluate and update compensation decisions yearly, shortly after the anniversary of a team member's start date.
 
 
-### Security
-At Fleet, we care about security. Here are a few resources about Fleet's security policies and best practices.
-1. [Security Policies](https://fleetdm.com/handbook/security/security-policies#security-policies)
-2. [Human Resources Security Policy](https://fleetdm.com/handbook/security/security-policies#human-resources-security-policy)
-3. [Account recovery process](https://fleetdm.com/handbook/security#account-recovery-process)
-4. [Personal mobile devices](https://fleetdm.com/handbook/security#personal-mobile-devices)
-5. [Hardware security keys](https://fleetdm.com/handbook/security#hardware-security-keys)
 
 
-### All the things
 
-#### Key reviews
+## Key reviews
 Every release cycle, each department leader prepares a [key review deck](https://about.gitlab.com/handbook/key-review/#purpose) and presents it to the CEO. In this deck, the department will highlight KPI metrics and progress of OKRs. The information for creating this deck is located in the ["🌈 Fleet" Google drive](https://drive.google.com/drive/folders/1lizTSi7YotG_zA7zJeHuOXTg_KF1Ji8k) using ["How to create key review"](https://docs.google.com/document/d/1PDwJL0HiCz-KbEGZMfldAYX_aLk5OVAU1MMSgMYYF2A/edit?usp=sharing)(internal doc).
 
-#### Meetings
+## Meetings
 * At Fleet, meetings start whether you're there or not. Nevertheless, being even a few minutes late can make a big difference and slow your meeting counterparts down. When in doubt, show up a couple of minutes early.
 * It's okay to spend the first minute or two of a meeting being present and making small talk. Since we are all remote, it's easy to miss out on hallway chatter and human connections that happen in [meatspace](https://www.dictionary.com/browse/meatspace).  Use this time together during the first minute to say "Hi!"  Then you can jump into the topics to be discussed.
 * Turning on your camera allows for more complete and intuitive verbal and non-verbal communication. Feel free to leave your camera on or turn it off when joining meetings with new participants you might not be familiar with yet. Turn your camera on when you lead or cohost a meeting.
 * In an all-remote company, “face time” matters. Remember: even if someone’s calendar is open, they have other work to do. Limiting (or batching up) internal meetings can enable longer, uninterrupted stretches of deep work.
 
-#### Internal meeting scheduling
+### Internal meeting scheduling
 Use the Google Calendar "[Find a meeting
 time](https://support.google.com/calendar/answer/37161?hl=en&co=GENIE.Platform%3DDesktop#zippy=%2Cfind-a-meeting-time)"
 feature to coordinate meetings with Fleet team members. Enter the `@fleetdm.com` emails for each
@@ -273,20 +237,20 @@ schedule a time when you are not available. Many team members use the free tier 
 [reclaim.ai](https://reclaim.ai/) to synchronize personal event times (without event details) into
 their work calendars. It is also common practice to block out time for focused work.
 
-#### Modifying an event organized by someone else
+### Modifying an event organized by someone else
 To edit an event where someone else at Fleet is the organizer, you can first subscribe to their calendar in Google Calendar and then edit the event on their calendar.  Your edits will automatically apply to all attendees.
 > This works because every Fleetie grants edit access to everyone else at Fleet as part of onboarding.
 
-#### External meeting scheduling
+### External meeting scheduling
 When scheduling external meetings, provide external participants with a
 [Calendly](https://calendly.com) link to schedule with the relevant internal participants. If you
 need a Calendly account, reach out to `@charlottechance` via Slack.
 
-#### Scheduling a Zoom meeting
+### Scheduling a Zoom meeting
 We use the Zoom add-on for Google Calendar to schedule Zoom meetings when we create calendar events. To add a Zoom meeting to a calendar event, click the "Add video conferencing" dropdown and select "Zoom Meeting." Google Calendar will automatically add the Zoom meeting details and instructions to join the event.
 We configure our Zoom meetings to let participants join before the host starts the meeting. We do this to make sure meetings start on time, even if the host isn't there.
 
-#### Slack channel prefixes
+### Slack channel prefixes
 We have specific channels for various topics, but we also have more general channels for the teams at Fleet.
 We use these prefixes to organize the Fleet Slack:
  * ***g-***: for team/group channels *(Note: "g-" is short for "grupo")*.
@@ -294,23 +258,23 @@ We use these prefixes to organize the Fleet Slack:
  * ***help-***: for asking for help on specific topics.
  * ***at*** or ***fleet-at***: for customer channels.
 
-#### Slack communications and best practices
+### Slack communications and best practices
 In consideration of our team, Fleet avoids using global tags in channels (i.e. @here, @channel, etc). 
       1. What about polls? Good question, Fleeties are asked to post their poll in the channel and @mention the teammates they would like to hear from. 
       2. Why does this matter? Great question! The Fleet [culture](https://fleetdm.com/handbook/company#culture) is pretty simple: think of others, and remember the company [Values](https://fleetdm.com/handbook/company#values).
 
 
-### Hiring
 
-#### Open positions
+## Open positions
 
 - 🚀 [Engineering Manager, MDM](https://fleet-device-management.breezy.hr/p/41ad774fe34a-engineering-manager-mdm)
 - ⚗️ [Product Designer](https://fleet-device-management.breezy.hr/p/68ef1b6ace54-product-designer)
 - 🫧 [Revenue Operations Manager](https://fleet-device-management.breezy.hr/p/c28cce9abf5e-revenue-ops)
 - 🫧 [Field Marketer](https://fleet-device-management.breezy.hr/p/3bd97ce5f54a-field-marketing-manager-enterprise)
 
+## Hiring
 
-#### Creating a new position
+### Creating a new position
 Every new position being created goes through this process before interviewing, accepting applicants, or extending offers.
 1. Add the proposed position to ["Fleeties"](https://docs.google.com/spreadsheets/d/1OSLn-ZCbGSjPusHPiR5dwQhheH1K8-xqyZdsOe9y7qc/edit#gid=0) as a new row, with a blank start date.  Be sure to include job title, manager, and department.
 2. Add a job description to the ["Roles."](https://docs.google.com/document/d/1wS5jFfrZtO4xMH-3U_S8pE59gNXOTR3rS1WWD8pkq9E/edit#heading=h.5z24knw25190)  Include only "Responsibilities" and "Experience." (You will insert these into the existing job description template.)
@@ -333,10 +297,10 @@ Every new position being created goes through this process before interviewing, 
   - Reply in the `#hiring-xxxxx-2022` Slack channel, at-mentioning the original proposer, to let them know the new position is approved.
 After getting CEO approval, create a position in Breezy.
 
-#### Creating a new position in Breezy
+### Creating a new position in Breezy
 Review [Breezy positions video](https://www.loom.com/home) on how to post a job on fleetdm.com/apply using Breezy. Collect candidate feedback from the team and manage the hiring process.
 
-#### Interviewing at Fleet
+### Interviewing at Fleet
 We're glad you're interested in joining the team! 
 Here are some of the things you can anticipate throughout this process:
   - We try to reply by email within one business day from the time when the application arrives.
@@ -344,7 +308,7 @@ Here are some of the things you can anticipate throughout this process:
   - You may receive an invitation to "book with us."
 If you've been invited to "book with us," you'll have a Zoom meeting with the hiring team to discuss the next steps. 
 
-#### Hiring a new team member
+### Hiring a new team member
 > Fleet is unable to hire team members in some countries. See [this internal document](https://docs.google.com/document/d/1jHHJqShIyvlVwzx1C-FB9GC74Di_Rfdgmhpai1SPC0g/edit) for the list.
 1. **Manager:** At-mention People Operations in the `#hiring-xxxxx-2022` channel and indicate that you would like for Fleet to make an offer to the candidate.  Include the candidate's name, personal email address, the timeframe for their start date, and the country where they will be working. 
 2. **People Ops:** People Operations will research compensation using [Pave](https://www.pave.com), making sure to adjust for the cost of living where the candidate will do the work.  _If People Ops is unsure of their findings, ask for help from the CEO._  People Ops will then document this decision in the [compensation decisions document](https://docs.google.com/document/d/1NQ-IjcOTbyFluCWqsFLMfP4SvnopoXDcX0civ-STS5c/edit) for future reference.
@@ -374,7 +338,7 @@ The CEO will then reply in `#g-people` to indicate that the offer is approved.
   - When sending the offer, the CEO or CTO will edit the permissions of the exit scenarios sheet so it is accessible to the candidate.
   - People Ops is cc'd on the offer email but will not participate in the email thread until after the offer is accepted.
 
-#### Hiring a new consultant
+### Hiring a new consultant
 Consultant agreements are sent through [DocuSign](https://www.docusign.com/), using the "Consulting Agreement" template. To send a new consulting agreement, you'll need the new consultant's name, the term of the service, a summary of the services provided, and the consultant's fee. 
 There are some defaults that we use for these agreements:
    - Term: one month
@@ -384,7 +348,7 @@ There are some defaults that we use for these agreements:
    - Hours: Default to 10 hr/week - 40 hr/week
 Then hit send!  After all of the signatures are there, the completed document will automatically be uploaded to the appropriate Google Drive folder, and a Slack message will appear in the `#g-people` channel.
 
-#### Updating a consultant's fee
+### Updating a consultant's fee
  - Direct message Charlie with rate change information.
  - Charlie will post the information to `#g-people` and tag the CEO for approval.
  - After CEO approval, Charlie will issue a new contractor agreement with the updated fee via DocuSign.
@@ -442,7 +406,7 @@ Once you send the agreement, add a new row to the [advisory board spreadsheet](h
    >**_Note:_** *Be sure to mark any columns that haven't been completed yet as "TODO"*
 When you complete the agreement, make sure it is in the correct Google Drive folder, update the [advisory board spreadsheet](https://docs.google.com/spreadsheets/d/15knBE2-PrQ1Ad-QcIk0mxCN-xFsATKK9hcifqrm0qFQ/edit#gid=1803674483) to show that the agreement has been signed, and ask the new advisor to add us on [Linkedin](https://www.linkedin.com/company/71111416), [Crunchbase](https://www.crunchbase.com/organization/fleet-device-management), and [Angellist](https://angel.co/company/fleetdm).
 
-#### Purchasing a company-issued device
+### Purchasing a company-issued device
 Fleet provides laptops for team members to use while working at Fleet. As soon as an offer is accepted, `@charlottechance` will reach out to the new team member to start this process. `@charlottechance` will work with the new team member to get their laptop purchased and shipped to them.
 Most of the team at Fleet uses 16" MacBook Pros, but team members are free to choose any laptop or operating system that works for them, as long as the price [is within reason](#spending-company-money).
 When selecting your new laptop, we ask that you optimize your configuration to have a large hard drive and be available for delivery or pickup quickly, without waiting for customization.
@@ -482,9 +446,9 @@ Weekly, Charlie looks in the [Fleeties spreadsheet](https://docs.google.com/spre
  - Total # interviews? 
 
 
-### Celebrations
+## Celebrations
 
-#### Weekly updates
+### Weekly updates
 We like to celebrate our achievements weekly in `#general`.
   - Every Thursday night, Charlie creates a thread in #help-manage requesting weekly updates, and managers will reply to the thread with their weekly updates.
   - Friday afternoons, Charlie updates the KPIs in the [weekly updates spreadsheet](https://docs.google.com/spreadsheets/d/1Hso0LxqwrRVINCyW_n436bNHmoqhoLhC8bcbvLPOs9A/edit#gid=0), and Friday nights, Charlie will post the updates in #general.
@@ -492,14 +456,14 @@ Weekly update principles
    - Each department's update is 20-40 words or less.
    - Erring on the side of referring to items that are completely done and/or mentioning news that is potentially very exciting to folks throughout the company.
  
-#### Workiversaries
+### Workiversaries
 We're happy you've ventured a trip around the sun with Fleet. Let's celebrate!
 - Each Friday, if there are any upcoming workiversaries in the next seven days, People Operations posts about them in #g-people and tags @mikermcneil to let them know.
 
 
-### Departures
+## Departures
 
-#### Communicating departures
+### Communicating departures
 Although it's sad to see you go, Fleet understands that not everything is meant to be forever like open-source is. There are a few steps that we'll need to take to communicate to the team of your departure. 
 1. Direct team: The CEO will reach out to the departing teammember's direct reports in 1:1 calls.
 2. Key stakeholders: The CEO will reach out to his direct reports about the departing teammember's departure.


### PR DESCRIPTION
- Think we should merge these PeopleOps and BizOps sections (and instead surface their contents as top-level nav items)?  Would make the page easier to explore.
- Seeing navigation like "Business operations > BizOps" is confusing to me, and we don't normally use PascalCase headings.  One solution could be to "deindent" BizOps (so its underlying sections are top level) and to change PeopleOps to "People"



## Design considerations
<img width="637" alt="image" src="https://user-images.githubusercontent.com/618009/217692023-286acade-f237-4db5-b9f7-52ad4efe060a.png">
