### PR TITLE
Website - /pricing update CTA text for Fleet Community Edition

### DIFF
--- a/website/views/pages/pricing.ejs
+++ b/website/views/pages/pricing.ejs
@@ -158,7 +158,7 @@
                 </div>
               </div>
               <div>
-                <a purpose="card-button" class="btn btn-block btn-lg btn-primary mx-auto" href="/try-fleet/register">Get started</a>
+                <a purpose="card-button" class="btn btn-block btn-lg btn-primary mx-auto" href="/try-fleet/register">Try it out</a>
               </div>
             </div>
           </div>
@@ -177,7 +177,7 @@
                 <td v-if="index === 0">
                   <strong>Community</strong>
                   <a purpose="table-button" class="btn btn-info d-none d-sm-inline-block" href="/try-fleet/register">
-                    Get started
+                    Try it out
                   </a>
                 </td>
                 <td v-else></td>


### PR DESCRIPTION
Updated the CTA text for Fleet Community Edition that links to sandbox from "Get started" to "Try it out."

See [this Slack thread](https://fleetdm.slack.com/archives/C01ALP02RB5/p1675811264928269) for context.