### PR TITLE
Add CIS check for 5.7

### DIFF
--- a/ee/cis/macos-13/cis-policy-queries.yml
+++ b/ee/cis/macos-13/cis-policy-queries.yml
@@ -1401,3 +1401,27 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS5.2.8
   contributors: sharon-fdm
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure an Administrator Account Cannot Login to Another User's Active and Locked Session (Fleetd Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Disabling the administrator's and/or user's ability to log into another user's active and locked session prevents
+    unauthorized persons from viewing potentially sensitive and/or personal information.
+  resolution: |
+    Automated method:
+    Ask your system administrator to deploy a script that runs the following:
+      /usr/bin/sudo /usr/bin/security authorizationdb write system.login.screensaver use-login-window-ui
+  query: |
+    SELECT 1 WHERE EXISTS (
+      SELECT JSON_EXTRACT(json_result, '$.rule') AS rule
+      FROM authdb
+      WHERE right_name = 'system.login.screensaver' AND 
+      rule LIKE '%use-login-window-ui%'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS5.7
+  contributors: lucasmrod

--- a/ee/cis/macos-13/test/scripts/CIS_5.7.sh
+++ b/ee/cis/macos-13/test/scripts/CIS_5.7.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/sudo /usr/bin/security authorizationdb write system.login.screensaver use-login-window-ui

--- a/orbit/changes/9260-add-authdb-table
+++ b/orbit/changes/9260-add-authdb-table
@@ -1,0 +1,1 @@
+* Add `authdb` table for macOS CIS check 5.7.

--- a/orbit/pkg/table/authdb/authdb_darwin.go
+++ b/orbit/pkg/table/authdb/authdb_darwin.go
@@ -1,0 +1,68 @@
+//go:build darwin
+// +build darwin
+
+package authdb
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/osquery/osquery-go/plugin/table"
+	"howett.net/plist"
+)
+
+// Columns is the schema of the table.
+func Columns() []table.ColumnDefinition {
+	return []table.ColumnDefinition{
+		table.TextColumn("right_name"), // required
+		table.TextColumn("json_result"),
+	}
+}
+
+// Generate is called to return the results for the table at query time.
+// Constraints for generating can be retrieved from the queryContext.
+func Generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	rightName := ""
+	if constraints, ok := queryContext.Constraints["right_name"]; ok {
+		for _, constraint := range constraints.Constraints {
+			if constraint.Operator == table.OperatorEquals {
+				rightName = constraint.Expression
+			}
+		}
+	}
+	if rightName == "" {
+		return nil, errors.New("missing right_name")
+	}
+
+	cmd := exec.Command("/usr/bin/security", "authorizationdb", "read", rightName)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("generate failed: %w", err)
+	}
+
+	result, err := parseAuthDBReadOutput(out)
+	if err != nil {
+		return nil, fmt.Errorf("parse authorizationdb read output: %w", err)
+	}
+
+	jsonResult, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("marshal json result: %w", err)
+	}
+
+	return []map[string]string{{
+		"right_name":  rightName,
+		"json_result": string(jsonResult),
+	}}, nil
+}
+
+func parseAuthDBReadOutput(out []byte) (map[string]interface{}, error) {
+	var m map[string]interface{}
+	if _, err := plist.Unmarshal(out, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}

--- a/orbit/pkg/table/authdb/authdb_darwin_test.go
+++ b/orbit/pkg/table/authdb/authdb_darwin_test.go
@@ -1,0 +1,39 @@
+//go:build darwin
+// +build darwin
+
+package authdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAuthDBReadOutput(t *testing.T) {
+	const systemLoginScreensaver = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>class</key>
+        <string>rule</string>
+        <key>created</key>
+        <real>656503622.12447298</real>
+        <key>modified</key>
+        <real>697495406.285501</real>
+        <key>rule</key>
+        <array>
+                <string>authenticate-session-owner-or-admin</string>
+        </array>
+        <key>version</key>
+        <integer>0</integer>
+</dict>
+</plist>`
+	m, err := parseAuthDBReadOutput([]byte(systemLoginScreensaver))
+	require.NoError(t, err)
+	require.NotNil(t, m["rule"])
+	rule, ok := m["rule"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, rule, 1)
+	require.Equal(t, "authenticate-session-owner-or-admin", rule[0])
+	require.Equal(t, "rule", m["class"])
+}

--- a/orbit/pkg/table/extension_darwin.go
+++ b/orbit/pkg/table/extension_darwin.go
@@ -3,19 +3,19 @@
 package table
 
 import (
+	"github.com/fleetdm/fleet/v4/orbit/pkg/table/authdb"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/csrutil_info"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/nvram_info"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/privaterelay"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/pwd_policy"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/user_login_settings"
-	"github.com/osquery/osquery-go"
-	"github.com/osquery/osquery-go/plugin/table"
-
 	"github.com/macadmins/osquery-extension/tables/filevaultusers"
 	"github.com/macadmins/osquery-extension/tables/macos_profiles"
 	"github.com/macadmins/osquery-extension/tables/mdm"
 	"github.com/macadmins/osquery-extension/tables/munki"
 	"github.com/macadmins/osquery-extension/tables/unifiedlog"
+	"github.com/osquery/osquery-go"
+	"github.com/osquery/osquery-go/plugin/table"
 )
 
 func platformTables() []osquery.OsqueryPlugin {
@@ -26,6 +26,7 @@ func platformTables() []osquery.OsqueryPlugin {
 		table.NewPlugin("pwd_policy", pwd_policy.Columns(), pwd_policy.Generate),
 		table.NewPlugin("csrutil_info", csrutil_info.Columns(), csrutil_info.Generate),
 		table.NewPlugin("nvram_info", nvram_info.Columns(), nvram_info.Generate),
+		table.NewPlugin("authdb", authdb.Columns(), authdb.Generate),
 
 		// Macadmins extension tables
 		table.NewPlugin("filevault_users", filevaultusers.FileVaultUsersColumns(), filevaultusers.FileVaultUsersGenerate),

--- a/schema/tables/authdb.yml
+++ b/schema/tables/authdb.yml
@@ -1,0 +1,18 @@
+name: authdb
+platforms:
+  - darwin
+description: Returns JSON output for the `authorizationdb read <right_name>` command.
+columns:
+  - name: right_name
+    type: text
+    required: true
+    description: |
+      The right_name to query in the `authorizationdb read <right_name>` command.
+  - name: json_result
+    type: text
+    required: false
+    description: |
+      The JSON output parsed from the plist output of the `authorizationdb read <right_name>` command. 
+notes: >-
+  - This table is not a core osquery table. It is included as part of Fleetd, the osquery manager from Fleet.
+evented: false


### PR DESCRIPTION
#9260

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- ~[ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~[ ] Documented any permissions changes~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [X] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
