### PR TITLE
Add macOS CIS 6.3.1 (Safari Automatic Opening)

### DIFF
--- a/ee/cis/macos-13/cis-policy-queries.yml
+++ b/ee/cis/macos-13/cis-policy-queries.yml
@@ -1846,6 +1846,35 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
+  name: CIS - Ensure Automatic Opening of Safe Files in Safari Is Disabled (MDM Required)
+  platforms: macOS
+  platform: darwin
+  description: |
+    Safari will automatically run or execute what it considers safe files. This can include
+    installers and other files that execute on the operating system. Safari evaluates file safety by
+    using a list of filetypes maintained by Apple. The list of files include text, image, video and
+    archive formats that would be run in the context of the OS rather than the browser.
+    Hackers have taken advantage of this setting via drive-by attacks. These attacks occur when a
+    user visits a legitimate website that has been corrupted. The user unknowingly downloads a
+    malicious file either by closing an infected pop-up or hovering over a malicious banner. An
+    attacker can create a malicious file that will fall within Safari's safe file list that will
+    download and execute without user input.
+  resolution: |
+    Payload Method:
+    Ask your administrator to deploy a profile which disables AutoOpenSafeDownloads in Safari
+  query: |
+    SELECT 1 FROM managed_policies WHERE
+      domain = 'com.apple.Safari' AND
+      name = 'AutoOpenSafeDownloads' AND
+      value = '0'
+      LIMIT 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS6.3.1
+  contributors: artemist-work
+---
+apiVersion: v1
+kind: policy
+spec:
   name: CIS - Ensure Advertising Privacy Protection in Safari Is Enabled (FDA Required)
   platforms: macOS
   platform: darwin

--- a/ee/cis/macos-13/test/profiles/6.3.1.mobileconfig
+++ b/ee/cis/macos-13/test/profiles/6.3.1.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>PayloadContent</key>
+		<array>
+			<dict>
+				<key>PayloadDisplayName</key>
+				<string>test</string>
+				<key>PayloadType</key>
+				<string>com.apple.Safari</string>
+				<key>PayloadIdentifier</key>
+				<string>com.fleetdm.cis-6.3.1.check</string>
+				<key>PayloadUUID</key>
+				<string>3CAAC721-D492-45AC-95E4-8ECBF81EA21E</string>
+				<key>AutoOpenSafeDownloads</key>
+				<false/>
+			</dict>
+		</array>
+		<key>PayloadDescription</key>
+		<string>test</string>
+		<key>PayloadDisplayName</key>
+		<string>Ensure Automatic Opening of Safe Files in Safari Is Disabled</string>
+		<key>PayloadIdentifier</key>
+		<string>com.fleetdm.cis-6.3.1</string>
+		<key>PayloadRemovalDisallowed</key>
+		<false/>
+		<key>PayloadScope</key>
+		<string>System</string>
+		<key>PayloadType</key>
+		<string>Configuration</string>
+		<key>PayloadUUID</key>
+		<string>2556F162-9AE5-4163-92C1-F89A2847C80E</string>
+		<key>PayloadVersion</key>
+		<integer>1</integer>
+	</dict>
+</plist>


### PR DESCRIPTION
This adds a query for CIS 3.6.1, which tests both via a profile and via the per-user settings. It's a bit more work than it needs to be but it's more flexible, especially since this setting is off by default