### PR TITLE
Add check for macOS CIS 5.9

### DIFF
--- a/ee/cis/macos-13/cis-policy-queries.yml
+++ b/ee/cis/macos-13/cis-policy-queries.yml
@@ -778,7 +778,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure the OS is not Activate When Resuming from Sleep
+  name: CIS - Ensure the OS is not Activate When Resuming from Sleep (Fleetd, FDA Required)
   platforms: macOS
   platform: darwin
   description: |
@@ -1728,6 +1728,36 @@ spec:
     AND uid = 0 AND gid = 0;
   purpose: Informational
   tags: compliance, CIS, CIS_Level2, CIS5.8
+  contributors: lucasmrod
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Legacy EFI Is Valid and Updating
+  platforms: macOS
+  platform: darwin
+  description: |
+    In order to mitigate firmware attacks, Apple has created an automated Firmware check to ensure that the EFI version
+    running is a known good version from Apple. There is also an automated process to check it every seven days.
+    This check is only valid on T1 chips and prior. Neither T2 chips nor Apple silicon require this control check
+    If the Firmware of a computer has been compromised, the Operating System that the Firmware loads cannot be trusted, either.
+  resolution: |
+    If EFI does not pass the integrity check, you may send a report to Apple. Backing up files and clean installing a
+    known good Operating System and Firmware is recommended.
+  query: |
+    SELECT 1 FROM firmware_eficheck_integity_check
+    WHERE chip != 'intel-t1' OR (
+      chip = 'intel-t1' AND
+      output LIKE '%Primary allowlist version match found. No changes detected in primary hashes%' AND
+      NOT EXISTS (
+          SELECT * FROM plist WHERE
+          path = '/var/db/com.apple.xpc.launchd/disabled.plist' AND
+          key = 'com.apple.driver.eficheck' AND
+          value = '0'
+      )
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS5.9
   contributors: lucasmrod
 ---
 apiVersion: v1

--- a/ee/cis/macos-13/cis-policy-queries.yml
+++ b/ee/cis/macos-13/cis-policy-queries.yml
@@ -1733,7 +1733,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure Legacy EFI Is Valid and Updating
+  name: CIS - Ensure Legacy EFI Is Valid and Updating (Fleetd Required)
   platforms: macOS
   platform: darwin
   description: |

--- a/orbit/changes/9260-add-firmware_eficheck_integity_check-table
+++ b/orbit/changes/9260-add-firmware_eficheck_integity_check-table
@@ -1,0 +1,1 @@
+* Add `firmware_eficheck_integity_check` table for macOS CIS 5.9.

--- a/orbit/pkg/table/extension_darwin.go
+++ b/orbit/pkg/table/extension_darwin.go
@@ -5,6 +5,7 @@ package table
 import (
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/authdb"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/csrutil_info"
+	firmware_eficheck_integity_check "github.com/fleetdm/fleet/v4/orbit/pkg/table/firmware_eficheck_integrity_check"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/nvram_info"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/pmset"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/privaterelay"
@@ -29,6 +30,7 @@ func platformTables() []osquery.OsqueryPlugin {
 		table.NewPlugin("nvram_info", nvram_info.Columns(), nvram_info.Generate),
 		table.NewPlugin("authdb", authdb.Columns(), authdb.Generate),
 		table.NewPlugin("pmset", pmset.Columns(), pmset.Generate),
+		table.NewPlugin("firmware_eficheck_integity_check", firmware_eficheck_integity_check.Columns(), firmware_eficheck_integity_check.Generate),
 
 		// Macadmins extension tables
 		table.NewPlugin("filevault_users", filevaultusers.FileVaultUsersColumns(), filevaultusers.FileVaultUsersGenerate),

--- a/orbit/pkg/table/firmware_eficheck_integrity_check/firmware_eficheck_integrity_check_darwin.go
+++ b/orbit/pkg/table/firmware_eficheck_integrity_check/firmware_eficheck_integrity_check_darwin.go
@@ -1,0 +1,77 @@
+//go:build darwin
+// +build darwin
+
+// Package firmware_integrity_check implements a table
+// to perform an integrity check for Legacy EFI.
+package firmware_eficheck_integity_check
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/osquery/osquery-go/plugin/table"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sys/unix"
+)
+
+// Columns is the schema of the table.
+func Columns() []table.ColumnDefinition {
+	return []table.ColumnDefinition{
+		table.TextColumn("chip"),
+		table.TextColumn("output"),
+	}
+}
+
+// Generate is called to return the results for the table at query time.
+//
+// Constraints for generating can be retrieved from the queryContext.
+//
+// This table implements the check for macOS 13 5.9 "Ensure Legacy EFI Is Valid and Updating".
+func Generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	modelName, err := unix.Sysctl("machdep.cpu.brand_string")
+	if err != nil {
+		return nil, fmt.Errorf("get CPU brand: %w", err)
+	}
+	log.Debug().Str("modelName", modelName).Msg("machdep.cpu.brand_string")
+
+	if strings.Contains(modelName, "Apple") {
+		// Apple chip, nothing to check.
+		return []map[string]string{{
+			"chip":   "apple",
+			"output": "",
+		}}, nil
+	}
+
+	// Intel chip
+	output, err := exec.Command(
+		"/usr/sbin/system_profiler", "SPiBridgeDataType",
+	).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("run system_profiler: %w", err)
+	}
+	log.Debug().Str("output", string(output)).Msg("system_profiler SPiBridgeDataType")
+
+	if strings.Contains(string(output), "Model Name: Apple T2 Security Chip") {
+		// Intel T2, nothing to check.
+		return []map[string]string{{
+			"chip":   "intel-t2",
+			"output": "",
+		}}, nil
+	}
+
+	// Intel T1.
+	output, err = exec.Command(
+		"/usr/libexec/firmwarecheckers/eficheck/eficheck", "--integrity-check",
+	).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("run eficheck: %w", err)
+	}
+	log.Debug().Str("output", string(output)).Msg("eficheck")
+
+	return []map[string]string{{
+		"chip":   "intel-t1",
+		"output": string(output),
+	}}, nil
+}

--- a/schema/tables/firmware_eficheck_integity_check.yml
+++ b/schema/tables/firmware_eficheck_integity_check.yml
@@ -1,0 +1,21 @@
+name: firmware_eficheck_integity_check
+platforms:
+  - darwin
+description: Performs eficheck's integrity check on macOS Intel T1 chips (CIS 5.9).
+columns:
+  - name: chip
+    type: text
+    required: false
+    description: |
+      Contains the chip type, values are "apple", "intel-t1" and "intel-t2".
+      If chip type is "apple" or "intel-t2" then no eficheck integrity check is executed.
+columns:
+  - name: output
+    type: text
+    required: false
+    description: |
+      Output of the `/usr/libexec/firmwarecheckers/eficheck/eficheck --integrity-check` command.
+      This value is only valid when chip is "intel-t1".
+notes: >-
+  - This table is not a core osquery table. It is included as part of Fleetd, the osquery manager from Fleet.
+evented: false


### PR DESCRIPTION
#9260

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- ~[ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~[ ] Documented any permissions changes~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- ~[ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [X] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
