### PR TITLE
Remove duplicate `columns` property in `firmware_eficheck_integrity_check.yml`

### DIFF
--- a/schema/tables/firmware_eficheck_integrity_check.yml
+++ b/schema/tables/firmware_eficheck_integrity_check.yml
@@ -9,7 +9,6 @@ columns:
     description: |
       Contains the chip type, values are "apple", "intel-t1" and "intel-t2".
       If chip type is "apple" or "intel-t2" then no eficheck integrity check is executed.
-columns:
   - name: output
     type: text
     required: false


### PR DESCRIPTION
Changes:
- Removed the duplicate `columns` property from the `firmware_eficheck_integrity_check` table's YAML file that is currently causing the website build script to fail. (https://github.com/fleetdm/fleet/actions/runs/4136825407/jobs/7151210650#step:13:19)