### PR TITLE
Add authz and datastore methods for mdm config profiles

### DIFF
--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -518,6 +518,22 @@ allow {
 # Apple MDM
 ##
 
+# Global admins and maintainers can read and write Apple MDM config profiles.
+allow {
+  object.type == "mdm_apple_config_profile"
+  subject.global_role == [admin, maintainer][_]
+  action == [read, write][_]
+}
+
+# Team admins and maintainers can read and write Apple MDM config profiles on their teams.
+allow {
+  not is_null(object.team_id)
+  object.team_id != 0
+  object.type == "mdm_apple_config_profile"
+  team_role(subject, object.team_id) == [admin, maintainer][_]
+  action == [read, write][_]
+}
+
 # Global admins and maintainers can issue MDM commands to all hosts.
 allow {
   object.type == "host"

--- a/server/authz/policy_test.go
+++ b/server/authz/policy_test.go
@@ -816,7 +816,7 @@ func TestAuthorizeMDMAppleConfigProfile(t *testing.T) {
 
 	globalProfile := &fleet.MDMAppleConfigProfile{}
 	teamProfile := &fleet.MDMAppleConfigProfile{
-		TeamID: uint(1),
+		TeamID: ptr.Uint(1),
 	}
 	runTestCases(t, []authTestCase{
 		{user: test.UserNoRoles, object: globalProfile, action: write, allow: false},

--- a/server/authz/policy_test.go
+++ b/server/authz/policy_test.go
@@ -811,6 +811,66 @@ func TestAuthorizePolicies(t *testing.T) {
 	})
 }
 
+func TestAuthorizeMDMAppleConfigProfile(t *testing.T) {
+	t.Parallel()
+
+	globalProfile := &fleet.MDMAppleConfigProfile{}
+	teamProfile := &fleet.MDMAppleConfigProfile{
+		TeamID: uint(1),
+	}
+	runTestCases(t, []authTestCase{
+		{user: test.UserNoRoles, object: globalProfile, action: write, allow: false},
+		{user: test.UserNoRoles, object: globalProfile, action: read, allow: false},
+		{user: test.UserNoRoles, object: teamProfile, action: write, allow: false},
+		{user: test.UserNoRoles, object: teamProfile, action: read, allow: false},
+
+		{user: test.UserAdmin, object: globalProfile, action: write, allow: true},
+		{user: test.UserAdmin, object: globalProfile, action: read, allow: true},
+		{user: test.UserAdmin, object: teamProfile, action: write, allow: true},
+		{user: test.UserAdmin, object: teamProfile, action: read, allow: true},
+
+		{user: test.UserMaintainer, object: globalProfile, action: write, allow: true},
+		{user: test.UserMaintainer, object: globalProfile, action: read, allow: true},
+		{user: test.UserMaintainer, object: teamProfile, action: write, allow: true},
+		{user: test.UserMaintainer, object: teamProfile, action: read, allow: true},
+
+		{user: test.UserObserver, object: globalProfile, action: write, allow: false},
+		{user: test.UserObserver, object: globalProfile, action: read, allow: false},
+		{user: test.UserObserver, object: teamProfile, action: write, allow: false},
+		{user: test.UserObserver, object: teamProfile, action: read, allow: false},
+
+		{user: test.UserTeamAdminTeam1, object: globalProfile, action: write, allow: false},
+		{user: test.UserTeamAdminTeam1, object: globalProfile, action: read, allow: false},
+		{user: test.UserTeamAdminTeam1, object: teamProfile, action: write, allow: true},
+		{user: test.UserTeamAdminTeam1, object: teamProfile, action: read, allow: true},
+
+		{user: test.UserTeamAdminTeam2, object: globalProfile, action: write, allow: false},
+		{user: test.UserTeamAdminTeam2, object: globalProfile, action: read, allow: false},
+		{user: test.UserTeamAdminTeam2, object: teamProfile, action: write, allow: false},
+		{user: test.UserTeamAdminTeam2, object: teamProfile, action: read, allow: false},
+
+		{user: test.UserTeamMaintainerTeam1, object: globalProfile, action: write, allow: false},
+		{user: test.UserTeamMaintainerTeam1, object: globalProfile, action: read, allow: false},
+		{user: test.UserTeamMaintainerTeam1, object: teamProfile, action: write, allow: true},
+		{user: test.UserTeamMaintainerTeam1, object: teamProfile, action: read, allow: true},
+
+		{user: test.UserTeamMaintainerTeam2, object: globalProfile, action: write, allow: false},
+		{user: test.UserTeamMaintainerTeam2, object: globalProfile, action: read, allow: false},
+		{user: test.UserTeamMaintainerTeam2, object: teamProfile, action: write, allow: false},
+		{user: test.UserTeamMaintainerTeam2, object: teamProfile, action: read, allow: false},
+
+		{user: test.UserTeamObserverTeam1, object: globalProfile, action: write, allow: false},
+		{user: test.UserTeamObserverTeam1, object: globalProfile, action: read, allow: false},
+		{user: test.UserTeamObserverTeam1, object: teamProfile, action: write, allow: false},
+		{user: test.UserTeamObserverTeam1, object: teamProfile, action: read, allow: false},
+
+		{user: test.UserTeamObserverTeam2, object: globalProfile, action: write, allow: false},
+		{user: test.UserTeamObserverTeam2, object: globalProfile, action: read, allow: false},
+		{user: test.UserTeamObserverTeam2, object: teamProfile, action: write, allow: false},
+		{user: test.UserTeamObserverTeam2, object: teamProfile, action: read, allow: false},
+	})
+}
+
 func assertAuthorized(t *testing.T, user *fleet.User, object, action interface{}) {
 	t.Helper()
 

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -49,7 +49,8 @@ func testNewMDMAppleConfigProfileDuplicateName(t *testing.T, ds *Datastore) {
 		Mobileconfig: initialCP.Mobileconfig,
 	}
 	_, err := ds.NewMDMAppleConfigProfile(ctx, duplicateCP)
-	require.ErrorContains(t, err, alreadyExists("PayloadDisplayName", initialCP.Name).Error())
+	expectedErr := &existsError{ResourceType: "MDMAppleConfigProfile.PayloadDisplayName", Identifier: initialCP.Name, TeamID: &initialCP.TeamID}
+	require.ErrorContains(t, err, expectedErr.Error())
 
 	// can create another profile with the same name if it is on a different team
 	duplicateCP.TeamID += 1
@@ -73,7 +74,8 @@ func testNewMDMAppleConfigProfileDuplicateIdentifier(t *testing.T, ds *Datastore
 		Mobileconfig: initialCP.Mobileconfig,
 	}
 	_, err := ds.NewMDMAppleConfigProfile(ctx, duplicateCP)
-	require.ErrorContains(t, err, alreadyExists("PayloadIdentifier", initialCP.Identifier).Error())
+	expectedErr := &existsError{ResourceType: "MDMAppleConfigProfile.PayloadIdentifier", Identifier: initialCP.Identifier, TeamID: &initialCP.TeamID}
+	require.ErrorContains(t, err, expectedErr.Error())
 
 	// can create another profile with the same name if it is on a different team
 	duplicateCP.TeamID += 1

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"testing"
 	"time"
@@ -13,6 +14,177 @@ import (
 	"github.com/micromdm/nanodep/godep"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNewMDMAppleConfigProfile(t *testing.T) {
+	ds := CreateMySQLDS(t)
+
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, ds *Datastore)
+	}{
+		{"TestNewMDMAppleConfigProfileDuplicateName", testNewMDMAppleConfigProfileDuplicateName},
+		{"TestNewMDMAppleConfigProfileDuplicateIdentifier", testNewMDMAppleConfigProfileDuplicateIdentifier},
+		{"TestDeleteMDMAppleConfigProfile", testDeleteMDMAppleConfigProfile},
+		{"TestListMDMAppleConfigProfiles", testListMDMAppleConfigProfiles},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer TruncateTables(t, ds)
+
+			c.fn(t, ds)
+		})
+	}
+}
+
+func testNewMDMAppleConfigProfileDuplicateName(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	initialCP := storeDummyConfigProfileForTest(t, ds)
+
+	// cannot create another profile with the same name if it is on the same team
+	duplicateCP := fleet.MDMAppleConfigProfile{
+		Name:         initialCP.Name,
+		Identifier:   "DifferentIdentifierDoesNotMatter",
+		TeamID:       initialCP.TeamID,
+		Mobileconfig: initialCP.Mobileconfig,
+	}
+	_, err := ds.NewMDMAppleConfigProfile(ctx, duplicateCP)
+	require.ErrorContains(t, err, alreadyExists("PayloadDisplayName", initialCP.Name).Error())
+
+	// can create another profile with the same name if it is on a different team
+	duplicateCP.TeamID += 1
+	newCP, err := ds.NewMDMAppleConfigProfile(ctx, duplicateCP)
+	require.NoError(t, err)
+	checkConfigProfile(t, &duplicateCP, newCP)
+	storedCP, err := ds.GetMDMAppleConfigProfile(ctx, newCP.ProfileID)
+	require.NoError(t, err)
+	checkConfigProfile(t, newCP, storedCP)
+}
+
+func testNewMDMAppleConfigProfileDuplicateIdentifier(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	initialCP := storeDummyConfigProfileForTest(t, ds)
+
+	// cannot create another profile with the same identifier if it is on the same team
+	duplicateCP := fleet.MDMAppleConfigProfile{
+		Name:         "DifferentNameDoesNotMatter",
+		Identifier:   initialCP.Identifier,
+		TeamID:       initialCP.TeamID,
+		Mobileconfig: initialCP.Mobileconfig,
+	}
+	_, err := ds.NewMDMAppleConfigProfile(ctx, duplicateCP)
+	require.ErrorContains(t, err, alreadyExists("PayloadIdentifier", initialCP.Identifier).Error())
+
+	// can create another profile with the same name if it is on a different team
+	duplicateCP.TeamID += 1
+	newCP, err := ds.NewMDMAppleConfigProfile(ctx, duplicateCP)
+	require.NoError(t, err)
+	checkConfigProfile(t, &duplicateCP, newCP)
+	storedCP, err := ds.GetMDMAppleConfigProfile(ctx, newCP.ProfileID)
+	require.NoError(t, err)
+	checkConfigProfile(t, newCP, storedCP)
+}
+
+func testListMDMAppleConfigProfiles(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	generateCP := func(name string, identifier string, teamID uint) *fleet.MDMAppleConfigProfile {
+		mc := fleet.Mobileconfig([]byte(name + identifier))
+		return &fleet.MDMAppleConfigProfile{
+			Name:         name,
+			Identifier:   identifier,
+			TeamID:       teamID,
+			Mobileconfig: &mc,
+		}
+	}
+
+	expectedTeam0 := []*fleet.MDMAppleConfigProfile{}
+	expectedTeam1 := []*fleet.MDMAppleConfigProfile{}
+
+	// add profile with team id zero (i.e. profile is not associated with any team)
+	cp, err := ds.NewMDMAppleConfigProfile(ctx, *generateCP("name0", "identifier0", 0))
+	require.NoError(t, err)
+	expectedTeam0 = append(expectedTeam0, cp)
+	cps, err := ds.ListMDMAppleConfigProfiles(ctx, uint(0))
+	require.NoError(t, err)
+	require.Len(t, cps, 1)
+	checkConfigProfile(t, expectedTeam0[0], cps[0])
+
+	// add profile with team id 1
+	cp, err = ds.NewMDMAppleConfigProfile(ctx, *generateCP("name1", "identifier1", 1))
+	require.NoError(t, err)
+	expectedTeam1 = append(expectedTeam1, cp)
+	// list profiles for team id 1
+	cps, err = ds.ListMDMAppleConfigProfiles(ctx, uint(1))
+	require.NoError(t, err)
+	require.Len(t, cps, 1)
+	checkConfigProfile(t, expectedTeam1[0], cps[0])
+
+	// add another profile with team id 1
+	cp, err = ds.NewMDMAppleConfigProfile(ctx, *generateCP("another_name1", "another_identifier1", 1))
+	require.NoError(t, err)
+	expectedTeam1 = append(expectedTeam1, cp)
+	// list profiles for team id 1
+	cps, err = ds.ListMDMAppleConfigProfiles(ctx, uint(1))
+	require.NoError(t, err)
+	require.Len(t, cps, 2)
+	for _, cp := range cps {
+		switch cp.Name {
+		case "name1":
+			checkConfigProfile(t, expectedTeam1[0], cp)
+		case "another_name1":
+			checkConfigProfile(t, expectedTeam1[1], cp)
+		default:
+			t.FailNow()
+		}
+	}
+
+	// try to list profiles for non-existent team id
+	cps, err = ds.ListMDMAppleConfigProfiles(ctx, uint(42))
+	require.NoError(t, err)
+	require.Len(t, cps, 0)
+}
+
+func testDeleteMDMAppleConfigProfile(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	initialCP := storeDummyConfigProfileForTest(t, ds)
+
+	err := ds.DeleteMDMAppleConfigProfile(ctx, initialCP.ProfileID)
+	require.NoError(t, err)
+
+	_, err = ds.GetMDMAppleConfigProfile(ctx, initialCP.ProfileID)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+
+	err = ds.DeleteMDMAppleConfigProfile(ctx, initialCP.ProfileID)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+}
+
+func storeDummyConfigProfileForTest(t *testing.T, ds *Datastore) *fleet.MDMAppleConfigProfile {
+	dummyMC := fleet.Mobileconfig([]byte("DummyTestMobileconfigBytes"))
+	dummyCP := fleet.MDMAppleConfigProfile{
+		Name:         "DummyTestName",
+		Identifier:   "DummyTestIdentifier",
+		Mobileconfig: &dummyMC,
+		TeamID:       uint(0),
+	}
+
+	ctx := context.Background()
+
+	newCP, err := ds.NewMDMAppleConfigProfile(ctx, dummyCP)
+	require.NoError(t, err)
+	checkConfigProfile(t, &dummyCP, newCP)
+	storedCP, err := ds.GetMDMAppleConfigProfile(ctx, newCP.ProfileID)
+	require.NoError(t, err)
+	checkConfigProfile(t, newCP, storedCP)
+
+	return storedCP
+}
+
+func checkConfigProfile(t *testing.T, expected *fleet.MDMAppleConfigProfile, actual *fleet.MDMAppleConfigProfile) {
+	require.Equal(t, expected.Name, actual.Name)
+	require.Equal(t, expected.Identifier, actual.Identifier)
+	require.Equal(t, *expected.Mobileconfig, *actual.Mobileconfig)
+}
 
 func TestIngestMDMAppleDevicesFromDEPSync(t *testing.T) {
 	ds := CreateMySQLDS(t)

--- a/server/datastore/mysql/errors.go
+++ b/server/datastore/mysql/errors.go
@@ -68,6 +68,7 @@ func (e *notFoundError) Is(other error) bool {
 type existsError struct {
 	Identifier   interface{}
 	ResourceType string
+	TeamID       *uint
 }
 
 func alreadyExists(kind string, identifier interface{}) error {
@@ -80,8 +81,17 @@ func alreadyExists(kind string, identifier interface{}) error {
 	}
 }
 
+func (e *existsError) WithTeamID(teamID uint) error {
+	e.TeamID = &teamID
+	return e
+}
+
 func (e *existsError) Error() string {
-	return fmt.Sprintf("%s %v already exists", e.ResourceType, e.Identifier)
+	msg := fmt.Sprintf("%s %v already exists", e.ResourceType, e.Identifier)
+	if e.TeamID != nil {
+		msg += fmt.Sprintf(" with TeamID %d", *e.TeamID)
+	}
+	return msg
 }
 
 func (e *existsError) IsExists() bool {

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -212,8 +212,8 @@ type Mobileconfig []byte
 // a PayloadIdentifier and a PayloadDisplayName and that it has PayloadType set to "Configuration".
 //
 // Adapted from https://github.com/micromdm/micromdm/blob/main/platform/profile/profile.go
-func (mc *Mobileconfig) ParseConfigProfile() (*MDMAppleConfigProfile, error) {
-	mcBytes := *mc
+func (mc Mobileconfig) ParseConfigProfile() (*MDMAppleConfigProfile, error) {
+	mcBytes := mc
 	if !bytes.HasPrefix(mcBytes, []byte("<?xml")) {
 		p7, err := pkcs7.Parse(mcBytes)
 		if err != nil {
@@ -259,7 +259,7 @@ type MDMAppleConfigProfile struct {
 	ProfileID uint `db:"profile_id" json:"profile_id"`
 	// TeamID is the id of the team with which the configuration is associated. A team id of zero
 	// represents a configuration profile that is not associated with any team.
-	TeamID uint `db:"team_id" json:"team_id"`
+	TeamID *uint `db:"team_id" json:"team_id"`
 	// Identifier corresponds to the payload identifier of the associated mobileconfig payload.
 	// Fleet requires that Identifier must be unique in combination with the Name and TeamID.
 	Identifier string `db:"identifier" json:"identifier"`
@@ -268,9 +268,9 @@ type MDMAppleConfigProfile struct {
 	Name string `db:"name" json:"name"`
 	// Mobileconfig is the byte slice corresponding to the XML property list (i.e. plist)
 	// representation of the configuration profile. It must be XML or PKCS7 parseable.
-	Mobileconfig *Mobileconfig `db:"mobileconfig" json:"-"`
-	CreatedAt    time.Time     `db:"created_at" json:"created_at"`
-	UpdatedAt    time.Time     `db:"updated_at" json:"updated_at"`
+	Mobileconfig Mobileconfig `db:"mobileconfig" json:"-"`
+	CreatedAt    time.Time    `db:"created_at" json:"created_at"`
+	UpdatedAt    time.Time    `db:"updated_at" json:"updated_at"`
 }
 
 // AuthzType implements authz.AuthzTyper.

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -256,21 +256,26 @@ func (mc *Mobileconfig) ParseConfigProfile() (*MDMAppleConfigProfile, error) {
 // See also https://developer.apple.com/documentation/devicemanagement/configuring_multiple_devices_using_profiles.
 type MDMAppleConfigProfile struct {
 	// ProfileID is the unique id of the configuration profile in Fleet
-	ProfileID uint `db:"profile_id"`
+	ProfileID uint `db:"profile_id" json:"profile_id"`
 	// TeamID is the id of the team with which the configuration is associated. A team id of zero
 	// represents a configuration profile that is not associated with any team.
-	TeamID uint `db:"team_id"`
+	TeamID uint `db:"team_id" json:"team_id"`
 	// Identifier corresponds to the payload identifier of the associated mobileconfig payload.
 	// Fleet requires that Identifier must be unique in combination with the Name and TeamID.
-	Identifier string `db:"identifier"`
+	Identifier string `db:"identifier" json:"identifier"`
 	// Name corresponds to the payload display name of the associated mobileconfig payload.
 	// Fleet requires that Name must be unique in combination with the Identifier and TeamID.
-	Name string `db:"name"`
+	Name string `db:"name" json:"name"`
 	// Mobileconfig is the byte slice corresponding to the XML property list (i.e. plist)
 	// representation of the configuration profile. It must be XML or PKCS7 parseable.
-	Mobileconfig *Mobileconfig `db:"mobileconfig"`
-	CreatedAt    time.Time     `db:"created_at"`
-	UpdatedAt    time.Time     `db:"updated_at"`
+	Mobileconfig *Mobileconfig `db:"mobileconfig" json:"-"`
+	CreatedAt    time.Time     `db:"created_at" json:"created_at"`
+	UpdatedAt    time.Time     `db:"updated_at" json:"updated_at"`
+}
+
+// AuthzType implements authz.AuthzTyper.
+func (m MDMAppleConfigProfile) AuthzType() string {
+	return "mdm_apple_config_profile"
 }
 
 func (cp *MDMAppleConfigProfile) Validate() error {

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -274,11 +274,11 @@ type MDMAppleConfigProfile struct {
 }
 
 // AuthzType implements authz.AuthzTyper.
-func (m MDMAppleConfigProfile) AuthzType() string {
+func (cp MDMAppleConfigProfile) AuthzType() string {
 	return "mdm_apple_config_profile"
 }
 
-func (cp *MDMAppleConfigProfile) Validate() error {
+func (cp MDMAppleConfigProfile) Validate() error {
 	// TODO(sarah): Additional validations for PayloadContent (e.g., screening out FileVault payloads)
 	// should be handled here
 

--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -82,7 +82,7 @@ func TestMDMAppleConfigProfile(t *testing.T) {
 		t.Run(c.testName, func(t *testing.T) {
 			mc := c.mobileconfig
 			cp := new(MDMAppleConfigProfile)
-			cp.Mobileconfig = &mc
+			cp.Mobileconfig = mc
 
 			parsed, err := cp.Mobileconfig.ParseConfigProfile()
 			if c.shouldFail {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -701,6 +701,21 @@ type Datastore interface {
 	///////////////////////////////////////////////////////////////////////////////
 	// Apple MDM
 
+	// NewMDMAppleConfigProfile creates and returns a new configuration profile.
+	NewMDMAppleConfigProfile(ctx context.Context, p MDMAppleConfigProfile) (*MDMAppleConfigProfile, error)
+
+	// GetMDMAppleConfigProfile returns the mdm config profile corresponding to the specified
+	// profile id.
+	GetMDMAppleConfigProfile(ctx context.Context, profileID uint) (*MDMAppleConfigProfile, error)
+
+	// ListMDMAppleConfigProfiles lists mdm config profiles associated with the specified team id.
+	// For global config profiles, specify zero as the team id.
+	ListMDMAppleConfigProfiles(ctx context.Context, teamID uint) ([]*MDMAppleConfigProfile, error)
+
+	// DeleteMDMAppleConfigProfile deleted the mdm config profile corresponding to the specified
+	// profile id.
+	DeleteMDMAppleConfigProfile(ctx context.Context, profileID uint) error
+
 	// NewMDMAppleEnrollmentProfile creates and returns new enrollment profile.
 	// Such enrollment profiles allow devices to enroll to Fleet MDM.
 	NewMDMAppleEnrollmentProfile(ctx context.Context, enrollmentPayload MDMAppleEnrollmentProfilePayload) (*MDMAppleEnrollmentProfile, error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -710,7 +710,7 @@ type Datastore interface {
 
 	// ListMDMAppleConfigProfiles lists mdm config profiles associated with the specified team id.
 	// For global config profiles, specify zero as the team id.
-	ListMDMAppleConfigProfiles(ctx context.Context, teamID uint) ([]*MDMAppleConfigProfile, error)
+	ListMDMAppleConfigProfiles(ctx context.Context, teamID *uint) ([]*MDMAppleConfigProfile, error)
 
 	// DeleteMDMAppleConfigProfile deleted the mdm config profile corresponding to the specified
 	// profile id.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -504,6 +504,14 @@ type InsertOSVulnerabilitiesFunc func(ctx context.Context, vulnerabilities []fle
 
 type DeleteOSVulnerabilitiesFunc func(ctx context.Context, vulnerabilities []fleet.OSVulnerability) error
 
+type NewMDMAppleConfigProfileFunc func(ctx context.Context, p fleet.MDMAppleConfigProfile) (*fleet.MDMAppleConfigProfile, error)
+
+type GetMDMAppleConfigProfileFunc func(ctx context.Context, profileID uint) (*fleet.MDMAppleConfigProfile, error)
+
+type ListMDMAppleConfigProfilesFunc func(ctx context.Context, teamID uint) ([]*fleet.MDMAppleConfigProfile, error)
+
+type DeleteMDMAppleConfigProfileFunc func(ctx context.Context, profileID uint) error
+
 type NewMDMAppleEnrollmentProfileFunc func(ctx context.Context, enrollmentPayload fleet.MDMAppleEnrollmentProfilePayload) (*fleet.MDMAppleEnrollmentProfile, error)
 
 type GetMDMAppleEnrollmentProfileByTokenFunc func(ctx context.Context, token string) (*fleet.MDMAppleEnrollmentProfile, error)
@@ -1271,6 +1279,18 @@ type DataStore struct {
 
 	DeleteOSVulnerabilitiesFunc        DeleteOSVulnerabilitiesFunc
 	DeleteOSVulnerabilitiesFuncInvoked bool
+
+	NewMDMAppleConfigProfileFunc        NewMDMAppleConfigProfileFunc
+	NewMDMAppleConfigProfileFuncInvoked bool
+
+	GetMDMAppleConfigProfileFunc        GetMDMAppleConfigProfileFunc
+	GetMDMAppleConfigProfileFuncInvoked bool
+
+	ListMDMAppleConfigProfilesFunc        ListMDMAppleConfigProfilesFunc
+	ListMDMAppleConfigProfilesFuncInvoked bool
+
+	DeleteMDMAppleConfigProfileFunc        DeleteMDMAppleConfigProfileFunc
+	DeleteMDMAppleConfigProfileFuncInvoked bool
 
 	NewMDMAppleEnrollmentProfileFunc        NewMDMAppleEnrollmentProfileFunc
 	NewMDMAppleEnrollmentProfileFuncInvoked bool
@@ -2544,6 +2564,26 @@ func (s *DataStore) InsertOSVulnerabilities(ctx context.Context, vulnerabilities
 func (s *DataStore) DeleteOSVulnerabilities(ctx context.Context, vulnerabilities []fleet.OSVulnerability) error {
 	s.DeleteOSVulnerabilitiesFuncInvoked = true
 	return s.DeleteOSVulnerabilitiesFunc(ctx, vulnerabilities)
+}
+
+func (s *DataStore) NewMDMAppleConfigProfile(ctx context.Context, p fleet.MDMAppleConfigProfile) (*fleet.MDMAppleConfigProfile, error) {
+	s.NewMDMAppleConfigProfileFuncInvoked = true
+	return s.NewMDMAppleConfigProfileFunc(ctx, p)
+}
+
+func (s *DataStore) GetMDMAppleConfigProfile(ctx context.Context, profileID uint) (*fleet.MDMAppleConfigProfile, error) {
+	s.GetMDMAppleConfigProfileFuncInvoked = true
+	return s.GetMDMAppleConfigProfileFunc(ctx, profileID)
+}
+
+func (s *DataStore) ListMDMAppleConfigProfiles(ctx context.Context, teamID uint) ([]*fleet.MDMAppleConfigProfile, error) {
+	s.ListMDMAppleConfigProfilesFuncInvoked = true
+	return s.ListMDMAppleConfigProfilesFunc(ctx, teamID)
+}
+
+func (s *DataStore) DeleteMDMAppleConfigProfile(ctx context.Context, profileID uint) error {
+	s.DeleteMDMAppleConfigProfileFuncInvoked = true
+	return s.DeleteMDMAppleConfigProfileFunc(ctx, profileID)
 }
 
 func (s *DataStore) NewMDMAppleEnrollmentProfile(ctx context.Context, enrollmentPayload fleet.MDMAppleEnrollmentProfilePayload) (*fleet.MDMAppleEnrollmentProfile, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -508,7 +508,7 @@ type NewMDMAppleConfigProfileFunc func(ctx context.Context, p fleet.MDMAppleConf
 
 type GetMDMAppleConfigProfileFunc func(ctx context.Context, profileID uint) (*fleet.MDMAppleConfigProfile, error)
 
-type ListMDMAppleConfigProfilesFunc func(ctx context.Context, teamID uint) ([]*fleet.MDMAppleConfigProfile, error)
+type ListMDMAppleConfigProfilesFunc func(ctx context.Context, teamID *uint) ([]*fleet.MDMAppleConfigProfile, error)
 
 type DeleteMDMAppleConfigProfileFunc func(ctx context.Context, profileID uint) error
 
@@ -2576,7 +2576,7 @@ func (s *DataStore) GetMDMAppleConfigProfile(ctx context.Context, profileID uint
 	return s.GetMDMAppleConfigProfileFunc(ctx, profileID)
 }
 
-func (s *DataStore) ListMDMAppleConfigProfiles(ctx context.Context, teamID uint) ([]*fleet.MDMAppleConfigProfile, error) {
+func (s *DataStore) ListMDMAppleConfigProfiles(ctx context.Context, teamID *uint) ([]*fleet.MDMAppleConfigProfile, error) {
 	s.ListMDMAppleConfigProfilesFuncInvoked = true
 	return s.ListMDMAppleConfigProfilesFunc(ctx, teamID)
 }


### PR DESCRIPTION
Issue #9586

- Add authz and datastore methods for mdm config profiles

Note: API service layer for Issue #9586 will follow in another PR 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
