### PR TITLE
Fix top nav underline positioning and size

### DIFF
--- a/frontend/components/top_nav/SiteTopNav/_styles.scss
+++ b/frontend/components/top_nav/SiteTopNav/_styles.scss
@@ -83,24 +83,24 @@
   }
 
   &--active {
-    border-bottom: 4px solid $core-vibrant-blue;
     background-color: $site-nav-on-hover;
+
+    &::after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: 3px;
+      background-color: $core-vibrant-blue;
+    }
 
     &:hover {
       background-color: $site-nav-on-hover;
     }
 
-    .site-nav-item__link {
-      padding-bottom: 12px;
-    }
-
     .site-nav-item__name {
       font-weight: $bold;
-    }
-
-    .site-nav-item__logo img {
-      position: relative;
-      top: 4px;
     }
   }
 }


### PR DESCRIPTION
This turned out to be a very quick fix using the `&::after` element. 