### PR TITLE
Change the default memory value to a sane value

### DIFF
--- a/terraform/byo-vpc/byo-db/byo-ecs/variables.tf
+++ b/terraform/byo-vpc/byo-db/byo-ecs/variables.tf
@@ -12,7 +12,7 @@ variable "vpc_id" {
 variable "fleet_config" {
   type = object({
     mem                          = optional(number, 4096)
-    cpu                          = optional(number, 256)
+    cpu                          = optional(number, 512)
     image                        = optional(string, "fleetdm/fleet:v4.22.1")
     family                       = optional(string, "fleet")
     extra_environment_variables  = optional(map(string), {})

--- a/terraform/byo-vpc/byo-db/byo-ecs/variables.tf
+++ b/terraform/byo-vpc/byo-db/byo-ecs/variables.tf
@@ -11,7 +11,7 @@ variable "vpc_id" {
 
 variable "fleet_config" {
   type = object({
-    mem                          = optional(number, 512)
+    mem                          = optional(number, 4096)
     cpu                          = optional(number, 256)
     image                        = optional(string, "fleetdm/fleet:v4.22.1")
     family                       = optional(string, "fleet")

--- a/terraform/byo-vpc/byo-db/variables.tf
+++ b/terraform/byo-vpc/byo-db/variables.tf
@@ -51,7 +51,7 @@ variable "ecs_cluster" {
 variable "fleet_config" {
   type = object({
     mem                          = optional(number, 4096)
-    cpu                          = optional(number, 256)
+    cpu                          = optional(number, 512)
     image                        = optional(string, "fleetdm/fleet:v4.22.1")
     family                       = optional(string, "fleet")
     extra_environment_variables  = optional(map(string), {})

--- a/terraform/byo-vpc/byo-db/variables.tf
+++ b/terraform/byo-vpc/byo-db/variables.tf
@@ -50,7 +50,7 @@ variable "ecs_cluster" {
 
 variable "fleet_config" {
   type = object({
-    mem                          = optional(number, 512)
+    mem                          = optional(number, 4096)
     cpu                          = optional(number, 256)
     image                        = optional(string, "fleetdm/fleet:v4.22.1")
     family                       = optional(string, "fleet")

--- a/terraform/byo-vpc/variables.tf
+++ b/terraform/byo-vpc/variables.tf
@@ -130,7 +130,7 @@ variable "ecs_cluster" {
 
 variable "fleet_config" {
   type = object({
-    mem                          = optional(number, 512)
+    mem                          = optional(number, 4096)
     cpu                          = optional(number, 256)
     image                        = optional(string, "fleetdm/fleet:v4.22.1")
     family                       = optional(string, "fleet")

--- a/terraform/byo-vpc/variables.tf
+++ b/terraform/byo-vpc/variables.tf
@@ -131,7 +131,7 @@ variable "ecs_cluster" {
 variable "fleet_config" {
   type = object({
     mem                          = optional(number, 4096)
-    cpu                          = optional(number, 256)
+    cpu                          = optional(number, 512)
     image                        = optional(string, "fleetdm/fleet:v4.22.1")
     family                       = optional(string, "fleet")
     extra_environment_variables  = optional(map(string), {})

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -186,7 +186,7 @@ variable "ecs_cluster" {
 variable "fleet_config" {
   type = object({
     mem                          = optional(number, 4096)
-    cpu                          = optional(number, 256)
+    cpu                          = optional(number, 512)
     image                        = optional(string, "fleetdm/fleet:v4.22.1")
     family                       = optional(string, "fleet")
     extra_environment_variables  = optional(map(string), {})

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -185,7 +185,7 @@ variable "ecs_cluster" {
 
 variable "fleet_config" {
   type = object({
-    mem                          = optional(number, 512)
+    mem                          = optional(number, 4096)
     cpu                          = optional(number, 256)
     image                        = optional(string, "fleetdm/fleet:v4.22.1")
     family                       = optional(string, "fleet")


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
