### PR TITLE
fix XML formatting of RemoveProfile command

### DIFF
--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -924,7 +924,7 @@ func (svc *Service) enqueueMDMAppleCommandRemoveEnrollmentProfile(ctx context.Co
 func generateMDMAppleCommandRemoveEnrollmentProfile(cmdUUID string, profileUUID string) string {
 	return fmt.Sprintf(`
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"&gt;
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CommandUUID</key>


### PR DESCRIPTION
potential fix for https://github.com/fleetdm/fleet/issues/9802, I still can't reproduce locally but it might be that ngrok is doing some magic encoding/decoding the bytes transferred.

# Checklist for submitter

- [x] Manual QA for all new/changed functionality
