### PR TITLE
vuln processing distinct command

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -352,7 +352,7 @@ func checkNVDVulnerabilities(
 		}
 	}
 
-	if err := nvd.LoadCVEMeta(logger, vulnPath, ds); err != nil {
+	if err := nvd.LoadCVEMeta(ctx, logger, vulnPath, ds); err != nil {
 		errHandler(ctx, logger, "load cve meta", err)
 		// don't return, continue on ...
 	}

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -79,7 +80,7 @@ func cronVulnerabilities(
 	config *config.VulnerabilitiesConfig,
 ) error {
 	if config == nil {
-		return fmt.Errorf("nil configuration")
+		return errors.New("nil configuration")
 	}
 	if config.CurrentInstanceChecks == "no" || config.CurrentInstanceChecks == "0" {
 		level.Info(logger).Log("msg", "host not configured to check for vulnerabilities")

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -291,10 +291,6 @@ func checkOvalVulnerabilities(
 	config *config.VulnerabilitiesConfig,
 	collectVulns bool,
 ) []fleet.SoftwareVulnerability {
-	if config.DisableDataSync {
-		return nil
-	}
-
 	var results []fleet.SoftwareVulnerability
 
 	// Get Platforms
@@ -304,13 +300,15 @@ func checkOvalVulnerabilities(
 		return nil
 	}
 
-	// Sync on disk OVAL definitions with current OS Versions.
-	downloaded, err := oval.Refresh(ctx, versions, vulnPath)
-	if err != nil {
-		errHandler(ctx, logger, "updating oval definitions", err)
-	}
-	for _, d := range downloaded {
-		level.Debug(logger).Log("oval-sync-downloaded", d)
+	if !config.DisableDataSync {
+		// Sync on disk OVAL definitions with current OS Versions.
+		downloaded, err := oval.Refresh(ctx, versions, vulnPath)
+		if err != nil {
+			errHandler(ctx, logger, "updating oval definitions", err)
+		}
+		for _, d := range downloaded {
+			level.Debug(logger).Log("oval-sync-downloaded", d)
+		}
 	}
 
 	// Analyze all supported os versions using the synched OVAL definitions.

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -21,6 +21,7 @@ func main() {
 
 	configManager := config.NewManager(rootCmd)
 
+	rootCmd.AddCommand(createVulnProcessingCmd(configManager))
 	rootCmd.AddCommand(createPrepareCmd(configManager))
 	rootCmd.AddCommand(createServeCmd(configManager))
 	rootCmd.AddCommand(createConfigDumpCmd(configManager))

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"math/rand"
 	"os"
 	"time"
@@ -91,4 +93,23 @@ func applyDevFlags(cfg *config.FleetConfig) {
 		DisableSSL:       true,
 		ForceS3PathStyle: true,
 	}
+}
+
+func initLogger(cfg config.FleetConfig) kitlog.Logger {
+	var logger kitlog.Logger
+	{
+		output := os.Stderr
+		if cfg.Logging.JSON {
+			logger = kitlog.NewJSONLogger(output)
+		} else {
+			logger = kitlog.NewLogfmtLogger(output)
+		}
+		if cfg.Logging.Debug {
+			logger = level.NewFilter(logger, level.AllowDebug())
+		} else {
+			logger = level.NewFilter(logger, level.AllowInfo())
+		}
+		logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC)
+	}
+	return logger
 }

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"fmt"
-	kitlog "github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	"math/rand"
 	"os"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/config"
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 )

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -105,15 +105,7 @@ the way that the Fleet server works.
 				applyDevFlags(&config)
 			}
 
-			if devLicense {
-				// This license key is valid for development only
-				config.License.Key = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbGVldCBEZXZpY2UgTWFuYWdlbWVudCBJbmMuIiwiZXhwIjoxNzUxMjQxNjAwLCJzdWIiOiJkZXZlbG9wbWVudC1vbmx5IiwiZGV2aWNlcyI6MTAwLCJub3RlIjoiZm9yIGRldmVsb3BtZW50IG9ubHkiLCJ0aWVyIjoicHJlbWl1bSIsImlhdCI6MTY1NjY5NDA4N30.dvfterOvfTGdrsyeWYH9_lPnyovxggM5B7tkSl1q1qgFYk_GgOIxbaqIZ6gJlL0cQuBF9nt5NgV0AUT9RmZUaA"
-			} else if devExpiredLicense {
-				// An expired license key
-				config.License.Key = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbGVldCBEZXZpY2UgTWFuYWdlbWVudCBJbmMuIiwiZXhwIjoxNjI5NzYzMjAwLCJzdWIiOiJEZXYgbGljZW5zZSAoZXhwaXJlZCkiLCJkZXZpY2VzIjo1MDAwMDAsIm5vdGUiOiJUaGlzIGxpY2Vuc2UgaXMgdXNlZCB0byBmb3IgZGV2ZWxvcG1lbnQgcHVycG9zZXMuIiwidGllciI6ImJhc2ljIiwiaWF0IjoxNjI5OTA0NzMyfQ.AOppRkl1Mlc_dYKH9zwRqaTcL0_bQzs7RM3WSmxd3PeCH9CxJREfXma8gm0Iand6uIWw8gHq5Dn0Ivtv80xKvQ"
-			}
-
-			license, err := licensing.LoadLicense(config.License.Key)
+			license, err := initLicense(config, devLicense, devExpiredLicense)
 			if err != nil {
 				initFatal(
 					err,
@@ -622,13 +614,15 @@ the way that the Fleet server works.
 				initFatal(err, "failed to register stats schedule")
 			}
 
-			if !config.Vulnerabilities.ExternalScheduled {
+			if !config.Vulnerabilities.DisableSchedule {
 				// vuln processing by default is run by internal cron mechanism
 				if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
 					return newVulnerabilitiesSchedule(ctx, instanceID, ds, logger, &config.Vulnerabilities)
 				}); err != nil {
 					initFatal(err, "failed to register vulnerabilities schedule")
 				}
+			} else {
+				level.Info(logger).Log("msg", "vulnerabilities schedule disabled")
 			}
 
 			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
@@ -889,6 +883,17 @@ the way that the Fleet server works.
 	serveCmd.PersistentFlags().BoolVar(&devExpiredLicense, "dev_expired_license", false, "Enable expired development license")
 
 	return serveCmd
+}
+
+func initLicense(config configpkg.FleetConfig, devLicense, devExpiredLicense bool) (*fleet.LicenseInfo, error) {
+	if devLicense {
+		// This license key is valid for development only
+		config.License.Key = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbGVldCBEZXZpY2UgTWFuYWdlbWVudCBJbmMuIiwiZXhwIjoxNzUxMjQxNjAwLCJzdWIiOiJkZXZlbG9wbWVudC1vbmx5IiwiZGV2aWNlcyI6MTAwLCJub3RlIjoiZm9yIGRldmVsb3BtZW50IG9ubHkiLCJ0aWVyIjoicHJlbWl1bSIsImlhdCI6MTY1NjY5NDA4N30.dvfterOvfTGdrsyeWYH9_lPnyovxggM5B7tkSl1q1qgFYk_GgOIxbaqIZ6gJlL0cQuBF9nt5NgV0AUT9RmZUaA"
+	} else if devExpiredLicense {
+		// An expired license key
+		config.License.Key = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJGbGVldCBEZXZpY2UgTWFuYWdlbWVudCBJbmMuIiwiZXhwIjoxNjI5NzYzMjAwLCJzdWIiOiJEZXYgbGljZW5zZSAoZXhwaXJlZCkiLCJkZXZpY2VzIjo1MDAwMDAsIm5vdGUiOiJUaGlzIGxpY2Vuc2UgaXMgdXNlZCB0byBmb3IgZGV2ZWxvcG1lbnQgcHVycG9zZXMuIiwidGllciI6ImJhc2ljIiwiaWF0IjoxNjI5OTA0NzMyfQ.AOppRkl1Mlc_dYKH9zwRqaTcL0_bQzs7RM3WSmxd3PeCH9CxJREfXma8gm0Iand6uIWw8gHq5Dn0Ivtv80xKvQ"
+	}
+	return licensing.LoadLicense(config.License.Key)
 }
 
 // basicAuthHandler wraps the given handler behind HTTP Basic Auth.

--- a/cmd/fleet/vuln_process.go
+++ b/cmd/fleet/vuln_process.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/WatchBeam/clock"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
@@ -10,7 +12,6 @@ import (
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/spf13/cobra"
-	"time"
 )
 
 var dev bool

--- a/cmd/fleet/vuln_process.go
+++ b/cmd/fleet/vuln_process.go
@@ -10,7 +10,6 @@ import (
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/spf13/cobra"
-	"os"
 	"time"
 )
 
@@ -43,42 +42,37 @@ vulnerability processing. By default the Fleet server command internally manages
 			switch status.StatusCode {
 			case fleet.AllMigrationsCompleted:
 				// only continue if db is considered up-to-date
-				fmt.Println("database check complete, continuing vuln processing")
+				break
 			case fleet.NoMigrationsCompleted, fleet.SomeMigrationsCompleted, fleet.UnknownMigrations:
 				initFatal(fmt.Errorf("database migrations incompatible with current version"), "refusing to continue processing vulnerabilities")
 			}
 
+			logger := initLogger(cfg)
+			logger = kitlog.With(logger, fleet.CronVulnerabilities)
+
 			ctx := context.Background()
-
-			logger := setupLogger(cfg)
-
 			appConfig, err := ds.AppConfig(ctx)
-			vulnConfig := cfg.Vulnerabilities
-			var vulnPath string
-			switch {
-			case vulnConfig.DatabasesPath != "" && appConfig.VulnerabilitySettings.DatabasesPath != "":
-				vulnPath = vulnConfig.DatabasesPath
-				level.Info(logger).Log(
-					"msg", "fleet config takes precedence over app config when both are configured",
-					"databases_path", vulnPath,
-				)
-			case vulnConfig.DatabasesPath != "":
-				vulnPath = vulnConfig.DatabasesPath
-			case appConfig.VulnerabilitySettings.DatabasesPath != "":
-				vulnPath = appConfig.VulnerabilitySettings.DatabasesPath
-			default:
-				level.Info(logger).Log("msg", "vulnerability scanning not configured, vulnerabilities databases path is empty")
+			if err != nil {
+				initFatal(err, "error fetching app config during vulnerability processing")
 			}
-			if vulnPath != "" {
-				level.Info(logger).Log("msg", "scanning vulnerabilities")
-				if err := scanVulnerabilities(ctx, ds, logger, &vulnConfig, appConfig, vulnPath); err != nil {
-					initFatal(fmt.Errorf("scanning vulnerabilities: %w", err), "error during vulnerability processing")
-				}
+			vulnConfig := cfg.Vulnerabilities
+			vulnPath := configureVulnPath(vulnConfig, appConfig, logger)
+			// this really shouldn't ever be empty string since it's defaulted, but could be due to some misconfiguration
+			// we'll throw an error here since the entire point of this command is to process vulnerabilities
+			if vulnPath == "" {
+				initFatal(fmt.Errorf("vuln path empty, check environment variables or app config yml"), "error during vulnerability processing")
+			}
+			level.Info(logger).Log("msg", "scanning vulnerabilities")
+			err = scanVulnerabilities(ctx, ds, logger, &vulnConfig, appConfig, vulnPath)
+			if err != nil {
+				// errors during vuln processing should bubble up, so you know the job is failing without having to scour logs, e.g. non-zero exit code
+				initFatal(fmt.Errorf("scanning vulnerabilities: %w", err), "error during vulnerability processing")
 			}
 
 			err = ds.SyncHostsSoftware(ctx, time.Now())
 			if err != nil {
-				level.Error(logger).Log("msg", "failed to sync host software", "err", err)
+				// though vulnerability processing succeeded, we'll still fatally error here to indicate there was a problem
+				initFatal(err, "failed to sync host software")
 			}
 
 			return
@@ -89,21 +83,20 @@ vulnerability processing. By default the Fleet server command internally manages
 	return vulnProcessingCmd
 }
 
-func setupLogger(cfg config.FleetConfig) kitlog.Logger {
-	var logger kitlog.Logger
-	{
-		output := os.Stderr
-		if cfg.Logging.JSON {
-			logger = kitlog.NewJSONLogger(output)
-		} else {
-			logger = kitlog.NewLogfmtLogger(output)
-		}
-		if cfg.Logging.Debug {
-			logger = level.NewFilter(logger, level.AllowDebug())
-		} else {
-			logger = level.NewFilter(logger, level.AllowInfo())
-		}
-		logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC)
+func configureVulnPath(vulnConfig config.VulnerabilitiesConfig, appConfig *fleet.AppConfig, logger kitlog.Logger) (vulnPath string) {
+	switch {
+	case vulnConfig.DatabasesPath != "" && appConfig != nil && appConfig.VulnerabilitySettings.DatabasesPath != "":
+		vulnPath = vulnConfig.DatabasesPath
+		level.Info(logger).Log(
+			"msg", "fleet config takes precedence over app config when both are configured",
+			"databases_path", vulnPath,
+		)
+	case vulnConfig.DatabasesPath != "":
+		vulnPath = vulnConfig.DatabasesPath
+	case appConfig != nil && appConfig.VulnerabilitySettings.DatabasesPath != "":
+		vulnPath = appConfig.VulnerabilitySettings.DatabasesPath
+	default:
+		level.Info(logger).Log("msg", "vulnerability scanning not configured, vulnerabilities databases path is empty")
 	}
-	return logger
+	return vulnPath
 }

--- a/cmd/fleet/vuln_process.go
+++ b/cmd/fleet/vuln_process.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/WatchBeam/clock"
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/spf13/cobra"
+	"os"
+	"time"
+)
+
+var dev bool
+
+func createVulnProcessingCmd(configManager config.Manager) *cobra.Command {
+	vulnProcessingCmd := &cobra.Command{
+		Use:   "vuln_processing",
+		Short: "Run the vulnerability processing features of Fleet",
+		Long: `The vuln_processing command is intended for advanced configurations that want to externally manage 
+vulnerability processing. By default the Fleet server command internally manages vulnerability processing via scheduled
+'cron' style jobs.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			cfg := configManager.LoadConfig()
+			if dev {
+				applyDevFlags(&cfg)
+			}
+
+			ds, err := mysql.New(cfg.Mysql, clock.C)
+			if err != nil {
+				initFatal(err, "creating db connection")
+			}
+
+			// we need to ensure this command isn't running with an out-of-date database
+			status, err := ds.MigrationStatus(cmd.Context())
+			if err != nil {
+				initFatal(err, "retrieving migration status")
+			}
+
+			switch status.StatusCode {
+			case fleet.AllMigrationsCompleted:
+				// only continue if db is considered up-to-date
+				fmt.Println("database check complete, continuing vuln processing")
+			case fleet.NoMigrationsCompleted, fleet.SomeMigrationsCompleted, fleet.UnknownMigrations:
+				initFatal(fmt.Errorf("database migrations incompatible with current version"), "refusing to continue processing vulnerabilities")
+			}
+
+			ctx := context.Background()
+
+			logger := setupLogger(cfg)
+
+			appConfig, err := ds.AppConfig(ctx)
+			vulnConfig := cfg.Vulnerabilities
+			var vulnPath string
+			switch {
+			case vulnConfig.DatabasesPath != "" && appConfig.VulnerabilitySettings.DatabasesPath != "":
+				vulnPath = vulnConfig.DatabasesPath
+				level.Info(logger).Log(
+					"msg", "fleet config takes precedence over app config when both are configured",
+					"databases_path", vulnPath,
+				)
+			case vulnConfig.DatabasesPath != "":
+				vulnPath = vulnConfig.DatabasesPath
+			case appConfig.VulnerabilitySettings.DatabasesPath != "":
+				vulnPath = appConfig.VulnerabilitySettings.DatabasesPath
+			default:
+				level.Info(logger).Log("msg", "vulnerability scanning not configured, vulnerabilities databases path is empty")
+			}
+			if vulnPath != "" {
+				level.Info(logger).Log("msg", "scanning vulnerabilities")
+				if err := scanVulnerabilities(ctx, ds, logger, &vulnConfig, appConfig, vulnPath); err != nil {
+					initFatal(fmt.Errorf("scanning vulnerabilities: %w", err), "error during vulnerability processing")
+				}
+			}
+
+			err = ds.SyncHostsSoftware(ctx, time.Now())
+			if err != nil {
+				level.Error(logger).Log("msg", "failed to sync host software", "err", err)
+			}
+
+			return
+		},
+	}
+	vulnProcessingCmd.PersistentFlags().BoolVar(&dev, "dev", false, "Enable developer options")
+
+	return vulnProcessingCmd
+}
+
+func setupLogger(cfg config.FleetConfig) kitlog.Logger {
+	var logger kitlog.Logger
+	{
+		output := os.Stderr
+		if cfg.Logging.JSON {
+			logger = kitlog.NewJSONLogger(output)
+		} else {
+			logger = kitlog.NewLogfmtLogger(output)
+		}
+		if cfg.Logging.Debug {
+			logger = level.NewFilter(logger, level.AllowDebug())
+		} else {
+			logger = level.NewFilter(logger, level.AllowInfo())
+		}
+		logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC)
+	}
+	return logger
+}

--- a/cmd/fleet/vuln_process.go
+++ b/cmd/fleet/vuln_process.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -45,7 +46,7 @@ vulnerability processing. By default the Fleet server command internally manages
 				// only continue if db is considered up-to-date
 				break
 			case fleet.NoMigrationsCompleted, fleet.SomeMigrationsCompleted, fleet.UnknownMigrations:
-				initFatal(fmt.Errorf("database migrations incompatible with current version"), "refusing to continue processing vulnerabilities")
+				initFatal(errors.New("database migrations incompatible with current version"), "refusing to continue processing vulnerabilities")
 			}
 
 			logger := initLogger(cfg)
@@ -61,7 +62,7 @@ vulnerability processing. By default the Fleet server command internally manages
 			// this really shouldn't ever be empty string since it's defaulted, but could be due to some misconfiguration
 			// we'll throw an error here since the entire point of this command is to process vulnerabilities
 			if vulnPath == "" {
-				initFatal(fmt.Errorf("vuln path empty, check environment variables or app config yml"), "error during vulnerability processing")
+				initFatal(errors.New("vuln path empty, check environment variables or app config yml"), "error during vulnerability processing")
 			}
 			level.Info(logger).Log("msg", "scanning vulnerabilities")
 			err = scanVulnerabilities(ctx, ds, logger, &vulnConfig, appConfig, vulnPath)

--- a/cmd/fleet/vuln_process.go
+++ b/cmd/fleet/vuln_process.go
@@ -77,7 +77,7 @@ will disable it on the server allowing the user configure their own 'cron' mecha
 				initFatal(migrationError, "refusing to continue processing vulnerabilities, database out of sync")
 			}
 
-			ctx := context.Background()
+			ctx, cancel := context.WithTimeout(context.Background(), lockDuration)
 			ctx = license.NewContext(ctx, licenseInfo)
 			instanceID, err := server.GenerateRandomText(64)
 			if err != nil {
@@ -98,6 +98,7 @@ will disable it on the server allowing the user configure their own 'cron' mecha
 				if err != nil {
 					initFatal(err, "failed to release vuln processing lock")
 				}
+				cancel()
 			}()
 
 			logger := initLogger(cfg)

--- a/cmd/fleet/vuln_process.go
+++ b/cmd/fleet/vuln_process.go
@@ -85,7 +85,7 @@ will disable it on the server allowing the user configure their own 'cron' mecha
 			}
 			// using the same lock name as the cron scheduled version of vuln processing, that way if we fail to obtain the lock
 			// it's most likely due to vulnerabilities.disable_schedule=false but still trying to run external vuln processing command
-			lock, err := ds.Lock(ctx, "cron_vulnerabilities", instanceID, lockDuration)
+			lock, err := ds.Lock(ctx, string(fleet.CronVulnerabilities), instanceID, lockDuration)
 			if err != nil {
 				initFatal(err, "failed to obtain vuln processing lock")
 			}
@@ -136,8 +136,8 @@ will disable it on the server allowing the user configure their own 'cron' mecha
 	vulnProcessingCmd.PersistentFlags().DurationVar(
 		&lockDuration,
 		"lock_duration",
-		time.Second*60,
-		"the duration (https://pkg.go.dev/time#ParseDuration) the lock should be obtained, ideally this duration is less than the interval in which the job runs (defaults to 60s)")
+		time.Second*60*60,
+		"the duration (https://pkg.go.dev/time#ParseDuration) the lock should be obtained, ideally this duration is less than the interval in which the job runs (defaults to 60m)")
 
 	return vulnProcessingCmd
 }

--- a/cmd/fleet/vuln_process.go
+++ b/cmd/fleet/vuln_process.go
@@ -32,7 +32,8 @@ func createVulnProcessingCmd(configManager config.Manager) *cobra.Command {
 		Long: `The vuln_processing command is intended for advanced configurations that want to externally manage 
 vulnerability processing. By default the Fleet server command internally manages vulnerability processing via scheduled
 'cron' style jobs, but setting 'vulnerabilities.disable_schedule=true' or 'FLEET_VULNERABILITIES_DISABLE_SCHEDULE=true' 
-will disable it on the server allowing the user configure their own 'cron' mechanism`,
+will disable it on the server allowing the user configure their own 'cron' mechanism. Successful processing will be indicated
+by an exit code of zero.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg := configManager.LoadConfig()
 			if dev {
@@ -138,7 +139,7 @@ will disable it on the server allowing the user configure their own 'cron' mecha
 		&lockDuration,
 		"lock_duration",
 		time.Second*60*60,
-		"the duration (https://pkg.go.dev/time#ParseDuration) the lock should be obtained, ideally this duration is less than the interval in which the job runs (defaults to 60m)")
+		"the duration (https://pkg.go.dev/time#ParseDuration) the lock should be obtained, ideally this duration is less than the interval in which the job runs (defaults to 60m). If vuln processing isn't finished before this duration the command will exit with a non-zero status code.")
 
 	return vulnProcessingCmd
 }

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -2237,17 +2237,17 @@ When running multiple instances of the Fleet server, by default, one of them dyn
   	current_instance_checks: yes
   ```
 
-##### external_scheduled
+##### disable_schedule
 
 To externally manage running vulnerability processing set the value to `true` and then run `fleet vuln_processing` using external
 tools like crontab.
 
 - Default value: `false`
-- Environment variable: `FLEET_VULNERABILITIES_EXTERNAL_SCHEDULED`
+- Environment variable: `FLEET_VULNERABILITIES_DISABLE_SCHEDULE`
 - Config file format:
   ```
   vulnerabilities:
-  	external_scheduled: false
+  	disable_schedule: false
   ```
 
 ##### disable_data_sync

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -2237,6 +2237,19 @@ When running multiple instances of the Fleet server, by default, one of them dyn
   	current_instance_checks: yes
   ```
 
+##### external_scheduled
+
+To externally manage running vulnerability processing set the value to `true` and then run `fleet vuln_processing` using external
+tools like crontab.
+
+- Default value: `false`
+- Environment variable: `FLEET_VULNERABILITIES_EXTERNAL_SCHEDULED`
+- Config file format:
+  ```
+  vulnerabilities:
+  	external_scheduled: false
+  ```
+
 ##### disable_data_sync
 
 Fleet by default automatically downloads and keeps the different data streams needed to properly do vulnerability processing. In some setups, this behavior is not wanted, as access to outside resources might be blocked, or the data stream files might need review/audit before use.

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -2159,7 +2159,7 @@ The path specified needs to exist and Fleet needs to be able to read and write t
 
 When `current_instance_checks` is set to `auto` (the default), Fleet instances will try to create the `databases_path` if it doesn't exist.
 
-- Default value: none
+- Default value: `/tmp/vulndbs`
 - Environment variable: `FLEET_VULNERABILITIES_DATABASES_PATH`
 - Config file format:
   ```

--- a/docs/Using-Fleet/Vulnerability-Processing.md
+++ b/docs/Using-Fleet/Vulnerability-Processing.md
@@ -150,7 +150,7 @@ to external systems such as:
 
 To opt into this functionality, be sure to configure your Fleet server deployment with
 ```
-FLEET_VULNERABILITIES_EXTERNAL_SCHEDULED=true
+FLEET_VULNERABILITIES_DISABLE_SCHEDULE=true
 ```
 which will **disable** the internal scheduling mechanism for vulnerability processing.
 

--- a/docs/Using-Fleet/Vulnerability-Processing.md
+++ b/docs/Using-Fleet/Vulnerability-Processing.md
@@ -127,6 +127,36 @@ found in the [configuration documentation](https://fleetdm.com/docs/deploying/co
 
 You'll need to restart the Fleet instances after changing these settings.
 
+### Advanced Configuration
+
+Fleet runs vulnerability downloading and processing via internal scheduled cron job. This internal mechanism is very useful
+for frictionless deployments and is well suited for most use cases. However, in larger deployments, 
+where there can be dozens of Fleet server replicas sitting behind a load balancer, it is desirable to manage vulnerability processing externally.
+
+The reasons for this are as follows:
+
+- lower resource requirements across the entire Fleet server deployment (as vulnerability processing requires considerably more resources than just running Fleet server alone)
+- more control over scheduling constraints (only process during windows of low utilization, etc.)
+
+It is possible today to limit vulnerability processing to a single [dedicated host](https://fleetdm.com/docs/deploying/configuration#current-instance-checks), by setting
+`current_instance_checks` to `no` but still run one Fleet server as `yes`, but the drawback here is still having to dedicate resources
+for this single host 24/7. The Fleet binary has a command which handles the same vulnerability processing, but will exit (successfully with 0) on completion. Using this sub-command we can delegate vulnerability processing
+to external systems such as:
+
+- [ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/scheduling_tasks.html)
+- [K8S](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/)
+- [GCP](https://cloud.google.com/run/docs/triggering/using-scheduler#create_job)
+- [Plain old cron](https://en.wikipedia.org/wiki/Cron)
+
+To opt into this functionality, be sure to configure your Fleet server deployment with
+```
+FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS=no
+```
+And then externally run with the same environment variables/configuration files passed to the server command.
+```
+fleet vuln_processing
+```
+
 ## Performance
 
 ### Windows/Mac OS

--- a/docs/Using-Fleet/Vulnerability-Processing.md
+++ b/docs/Using-Fleet/Vulnerability-Processing.md
@@ -138,7 +138,7 @@ The reasons for this are as follows:
 - lower resource requirements across the entire Fleet server deployment (as vulnerability processing requires considerably more resources than just running Fleet server alone)
 - more control over scheduling constraints (only process during windows of low utilization, etc.)
 
-It is possible today to limit vulnerability processing to a single [dedicated host](https://fleetdm.com/docs/deploying/configuration#current-instance-checks), by setting
+It is possible to limit vulnerability processing to a single [dedicated host](https://fleetdm.com/docs/deploying/configuration#current-instance-checks), by setting
 `current_instance_checks` to `no` but still run one Fleet server as `yes`, but the drawback here is still having to dedicate resources
 for this single host 24/7. The Fleet binary has a command which handles the same vulnerability processing, but will exit (successfully with 0) on completion. Using this sub-command we can delegate vulnerability processing
 to external systems such as:
@@ -150,8 +150,10 @@ to external systems such as:
 
 To opt into this functionality, be sure to configure your Fleet server deployment with
 ```
-FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS=no
+FLEET_VULNERABILITIES_EXTERNAL_SCHEDULED=true
 ```
+which will **disable** the internal scheduling mechanism for vulnerability processing.
+
 And then externally run with the same environment variables/configuration files passed to the server command.
 ```
 fleet vuln_processing

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -324,6 +324,7 @@ type VulnerabilitiesConfig struct {
 	CPETranslationsURL          string        `json:"cpe_translations_url" yaml:"cpe_translations_url"`
 	CVEFeedPrefixURL            string        `json:"cve_feed_prefix_url" yaml:"cve_feed_prefix_url"`
 	CurrentInstanceChecks       string        `json:"current_instance_checks" yaml:"current_instance_checks"`
+	ExternalScheduled           bool          `json:"external_scheduled" yaml:"external_scheduled"`
 	DisableDataSync             bool          `json:"disable_data_sync" yaml:"disable_data_sync"`
 	RecentVulnerabilityMaxAge   time.Duration `json:"recent_vulnerability_max_age" yaml:"recent_vulnerability_max_age"`
 	DisableWinOSVulnerabilities bool          `json:"disable_win_os_vulnerabilities" yaml:"disable_win_os_vulnerabilities"`
@@ -969,6 +970,8 @@ func (man Manager) addConfigs() {
 		"Prefix URL for the CVE data feed. If empty, default to https://nvd.nist.gov/")
 	man.addConfigString("vulnerabilities.current_instance_checks", "auto",
 		"Allows to manually select an instance to do the vulnerability processing.")
+	man.addConfigBool("vulnerabilities.external_scheduled", false,
+		"Vulnerability processing is managed by an external 'cron' mechanism.")
 	man.addConfigBool("vulnerabilities.disable_data_sync", false,
 		"Skips synchronizing data streams and expects them to be available in the databases_path.")
 	man.addConfigDuration("vulnerabilities.recent_vulnerability_max_age", 30*24*time.Hour,

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -324,7 +324,7 @@ type VulnerabilitiesConfig struct {
 	CPETranslationsURL          string        `json:"cpe_translations_url" yaml:"cpe_translations_url"`
 	CVEFeedPrefixURL            string        `json:"cve_feed_prefix_url" yaml:"cve_feed_prefix_url"`
 	CurrentInstanceChecks       string        `json:"current_instance_checks" yaml:"current_instance_checks"`
-	ExternalScheduled           bool          `json:"external_scheduled" yaml:"external_scheduled"`
+	DisableSchedule             bool          `json:"disable_schedule" yaml:"disable_schedule"`
 	DisableDataSync             bool          `json:"disable_data_sync" yaml:"disable_data_sync"`
 	RecentVulnerabilityMaxAge   time.Duration `json:"recent_vulnerability_max_age" yaml:"recent_vulnerability_max_age"`
 	DisableWinOSVulnerabilities bool          `json:"disable_win_os_vulnerabilities" yaml:"disable_win_os_vulnerabilities"`
@@ -970,8 +970,8 @@ func (man Manager) addConfigs() {
 		"Prefix URL for the CVE data feed. If empty, default to https://nvd.nist.gov/")
 	man.addConfigString("vulnerabilities.current_instance_checks", "auto",
 		"Allows to manually select an instance to do the vulnerability processing.")
-	man.addConfigBool("vulnerabilities.external_scheduled", false,
-		"Vulnerability processing is managed by an external 'cron' mechanism.")
+	man.addConfigBool("vulnerabilities.disable_schedule", false,
+		"Set this to true when the vulnerability processing job is scheduled by an external mechanism")
 	man.addConfigBool("vulnerabilities.disable_data_sync", false,
 		"Skips synchronizing data streams and expects them to be available in the databases_path.")
 	man.addConfigDuration("vulnerabilities.recent_vulnerability_max_age", 30*24*time.Hour,
@@ -1243,7 +1243,7 @@ func (man Manager) LoadConfig() FleetConfig {
 			CPETranslationsURL:          man.getConfigString("vulnerabilities.cpe_translations_url"),
 			CVEFeedPrefixURL:            man.getConfigString("vulnerabilities.cve_feed_prefix_url"),
 			CurrentInstanceChecks:       man.getConfigString("vulnerabilities.current_instance_checks"),
-			ExternalScheduled:           man.getConfigBool("vulnerabilities.external_scheduled"),
+			DisableSchedule:             man.getConfigBool("vulnerabilities.disable_schedule"),
 			DisableDataSync:             man.getConfigBool("vulnerabilities.disable_data_sync"),
 			RecentVulnerabilityMaxAge:   man.getConfigDuration("vulnerabilities.recent_vulnerability_max_age"),
 			DisableWinOSVulnerabilities: man.getConfigBool("vulnerabilities.disable_win_os_vulnerabilities"),

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1243,6 +1243,7 @@ func (man Manager) LoadConfig() FleetConfig {
 			CPETranslationsURL:          man.getConfigString("vulnerabilities.cpe_translations_url"),
 			CVEFeedPrefixURL:            man.getConfigString("vulnerabilities.cve_feed_prefix_url"),
 			CurrentInstanceChecks:       man.getConfigString("vulnerabilities.current_instance_checks"),
+			ExternalScheduled:           man.getConfigBool("vulnerabilities.external_scheduled"),
 			DisableDataSync:             man.getConfigBool("vulnerabilities.disable_data_sync"),
 			RecentVulnerabilityMaxAge:   man.getConfigDuration("vulnerabilities.recent_vulnerability_max_age"),
 			DisableWinOSVulnerabilities: man.getConfigBool("vulnerabilities.disable_win_os_vulnerabilities"),

--- a/server/vulnerabilities/nvd/sync.go
+++ b/server/vulnerabilities/nvd/sync.go
@@ -181,6 +181,7 @@ func DownloadCISAKnownExploitsFeed(vulnPath string) error {
 func LoadCVEMeta(ctx context.Context, logger log.Logger, vulnPath string, ds fleet.Datastore) error {
 	if !license.IsPremium(ctx) {
 		level.Info(logger).Log("msg", "skipping cve_meta parsing due to license check")
+		return nil
 	}
 	// load cvss scores
 	files, err := getNVDCVEFeedFiles(vulnPath)

--- a/server/vulnerabilities/nvd/sync.go
+++ b/server/vulnerabilities/nvd/sync.go
@@ -5,6 +5,7 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"io"
 	"net/url"
 	"os"
@@ -280,6 +281,7 @@ func LoadCVEMeta(logger log.Logger, vulnPath string, ds fleet.Datastore) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
 
+	license.IsPremium(ctx)
 	if err := ds.InsertCVEMeta(ctx, meta); err != nil {
 		return fmt.Errorf("insert cve meta: %w", err)
 	}

--- a/server/vulnerabilities/nvd/sync_test.go
+++ b/server/vulnerabilities/nvd/sync_test.go
@@ -2,6 +2,7 @@ package nvd
 
 import (
 	"context"
+	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -46,7 +47,9 @@ func TestLoadCVEMeta(t *testing.T) {
 	}
 
 	logger := log.NewNopLogger()
-	err := LoadCVEMeta(logger, "../testdata", ds)
+	err := LoadCVEMeta(license.NewContext(context.Background(), &fleet.LicenseInfo{
+		Tier: "premium",
+	}), logger, "../testdata", ds)
 	require.NoError(t, err)
 	require.True(t, ds.InsertCVEMetaFuncInvoked)
 


### PR DESCRIPTION
closes https://github.com/fleetdm/fleet/issues/3723

Add new vuln processing command, configs, and documentation on how to utilize.

this feature is completely opt-in so all existing fleet deployments will continue to operate as-is without intervention.