### PR TITLE
Clarify native macOS update reminders vs. Nudge reminders

### DIFF
--- a/handbook/product/pricing-features-table.yml
+++ b/handbook/product/pricing-features-table.yml
@@ -20,7 +20,6 @@
     - name: End-user macOS update reminders (via Nudge)
       tier: Premium
       comingSoon: true
-      comingSoon: true
     - name: Encrypt macOS hard disks with FileVault
       tier: Premium
       comingSoon: true

--- a/handbook/product/pricing-features-table.yml
+++ b/handbook/product/pricing-features-table.yml
@@ -11,15 +11,15 @@
       comingSoon: true
     - name: Low-level macOS MDM commands (e.g. remote restart)
       tier: Free
+    - name: Native macOS update reminders
+      tier: Free
       comingSoon: true
     - name: Zero-touch setup for macOS computers
       tier: Premium
       comingSoon: true
-    - name: Remotely update macOS
+    - name: End-user macOS update reminders (via Nudge)
       tier: Premium
       comingSoon: true
-    - name: Keep macOS up to date through reminders
-      tier: Premium
       comingSoon: true
     - name: Encrypt macOS hard disks with FileVault
       tier: Premium

--- a/handbook/product/pricing-features-table.yml
+++ b/handbook/product/pricing-features-table.yml
@@ -11,6 +11,7 @@
       comingSoon: true
     - name: Low-level macOS MDM commands (e.g. remote restart)
       tier: Free
+      comingSoon: true
     - name: Native macOS update reminders
       tier: Free
       comingSoon: true


### PR DESCRIPTION
* The native macOS update reminders are free as part of the CLI
* There is no complete way to update macOS remotely. The native updates are also nudges, but only in the top right and always dismissible.

