### PR TITLE
Add "edited macos profiles" activity when applying custom settings via fleetctl

### DIFF
--- a/changes/issue-9587-record-activity
+++ b/changes/issue-9587-record-activity
@@ -1,0 +1,1 @@
+* Added "edited macos profiles" activity when updating a team's (or no team's) custom macOS settings via `fleetctl apply`.

--- a/docs/Using-Fleet/Audit-Activities.md
+++ b/docs/Using-Fleet/Audit-Activities.md
@@ -600,6 +600,65 @@ This activity contains the following fields:
 }
 ```
 
+### Type `created_macos_profile`
+
+Generated when a user adds a new macOS profile to a team (or no team).
+
+This activity contains the following fields:
+- "profile_name": Name of the profile.
+- "profile_identifier": Identifier of the profile.
+- "team_id": The ID of the team that the profile applies to, null if it applies to devices that are not in a team.
+- "team_name": The name of the team that the profile applies to, null if it applies to devices that are not in a team.
+
+#### Example
+
+```json
+{
+  "profile_name": "Custom settings 1",
+  "profile_identifier": "com.my.profile",
+  "team_id": 123,
+  "team_name": "Workstations"
+}
+```
+
+### Type `deleted_macos_profile`
+
+Generated when a user deletes a macOS profile from a team (or no team).
+
+This activity contains the following fields:
+- "profile_name": Name of the deleted profile.
+- "profile_identifier": Identifier of deleted the profile.
+- "team_id": The ID of the team that the profile applied to, null if it applied to devices that are not in a team.
+- "team_name": The name of the team that the profile applied to, null if it applied to devices that are not in a team.
+
+#### Example
+
+```json
+{
+  "profile_name": "Custom settings 1",
+  "profile_identifier": "com.my.profile",
+  "team_id": 123,
+  "team_name": "Workstations"
+}
+```
+
+### Type `edited_macos_profile`
+
+Generated when a user edits the macOS profiles of a team (or no team) via the fleetctl CLI.
+
+This activity contains the following fields:
+- "team_id": The ID of the team that the profiles apply to, null if they apply to devices that are not in a team.
+- "team_name": The name of the team that the profiles apply to, null if they apply to devices that are not in a team.
+
+#### Example
+
+```json
+{
+  "team_id": 123,
+  "team_name": "Workstations"
+}
+```
+
 
 
 <meta name="pageOrderInSection" value="1400">

--- a/ee/server/service/service.go
+++ b/ee/server/service/service.go
@@ -50,8 +50,8 @@ func NewService(
 	// Override methods that can't be easily overriden via
 	// embedding.
 	svc.SetEnterpriseOverrides(fleet.EnterpriseOverrides{
-		HostFeatures: eeservice.HostFeatures,
-		TeamByName:   eeservice.teamByName,
+		HostFeatures:   eeservice.HostFeatures,
+		TeamByIDOrName: eeservice.teamByIDOrName,
 	})
 
 	return eeservice, nil

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -49,6 +49,10 @@ var ActivityDetailsList = []ActivityDetails{
 	ActivityTypeEditedMacOSMinVersion{},
 
 	ActivityTypeReadHostDiskEncryptionKey{},
+
+	ActivityTypeCreatedMacosProfile{},
+	ActivityTypeDeletedMacosProfile{},
+	ActivityTypeEditedMacosProfile{},
 }
 
 type ActivityDetails interface {
@@ -727,5 +731,74 @@ func (a ActivityTypeReadHostDiskEncryptionKey) Documentation() (activity string,
 - "host_display_name": Display name of the host.`, `{
   "host_id": 1,
   "host_display_name": "Anna's MacBook Pro",
+}`
+}
+
+type ActivityTypeCreatedMacosProfile struct {
+	ProfileName       string  `json:"profile_name"`
+	ProfileIdentifier string  `json:"profile_identifier"`
+	TeamID            *uint   `json:"team_id"`
+	TeamName          *string `json:"team_name"`
+}
+
+func (a ActivityTypeCreatedMacosProfile) ActivityName() string {
+	return "created_macos_profile"
+}
+
+func (a ActivityTypeCreatedMacosProfile) Documentation() (activity, details, detailsExample string) {
+	return `Generated when a user adds a new macOS profile to a team (or no team).`,
+		`This activity contains the following fields:
+- "profile_name": Name of the profile.
+- "profile_identifier": Identifier of the profile.
+- "team_id": The ID of the team that the profile applies to, null if it applies to devices that are not in a team.
+- "team_name": The name of the team that the profile applies to, null if it applies to devices that are not in a team.`, `{
+  "profile_name": "Custom settings 1",
+  "profile_identifier": "com.my.profile",
+  "team_id": 123,
+  "team_name": "Workstations"
+}`
+}
+
+type ActivityTypeDeletedMacosProfile struct {
+	ProfileName       string  `json:"profile_name"`
+	ProfileIdentifier string  `json:"profile_identifier"`
+	TeamID            *uint   `json:"team_id"`
+	TeamName          *string `json:"team_name"`
+}
+
+func (a ActivityTypeDeletedMacosProfile) ActivityName() string {
+	return "deleted_macos_profile"
+}
+
+func (a ActivityTypeDeletedMacosProfile) Documentation() (activity, details, detailsExample string) {
+	return `Generated when a user deletes a macOS profile from a team (or no team).`,
+		`This activity contains the following fields:
+- "profile_name": Name of the deleted profile.
+- "profile_identifier": Identifier of deleted the profile.
+- "team_id": The ID of the team that the profile applied to, null if it applied to devices that are not in a team.
+- "team_name": The name of the team that the profile applied to, null if it applied to devices that are not in a team.`, `{
+  "profile_name": "Custom settings 1",
+  "profile_identifier": "com.my.profile",
+  "team_id": 123,
+  "team_name": "Workstations"
+}`
+}
+
+type ActivityTypeEditedMacosProfile struct {
+	TeamID   *uint   `json:"team_id"`
+	TeamName *string `json:"team_name"`
+}
+
+func (a ActivityTypeEditedMacosProfile) ActivityName() string {
+	return "edited_macos_profile"
+}
+
+func (a ActivityTypeEditedMacosProfile) Documentation() (activity, details, detailsExample string) {
+	return `Generated when a user edits the macOS profiles of a team (or no team) via the fleetctl CLI.`,
+		`This activity contains the following fields:
+- "team_id": The ID of the team that the profiles apply to, null if they apply to devices that are not in a team.
+- "team_name": The name of the team that the profiles apply to, null if they apply to devices that are not in a team.`, `{
+  "team_id": 123,
+  "team_name": "Workstations"
 }`
 }

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -15,8 +15,8 @@ import (
 //
 // TODO: find if there's a better way to accomplish this and standardize.
 type EnterpriseOverrides struct {
-	HostFeatures func(context context.Context, host *Host) (*Features, error)
-	TeamByName   func(ctx context.Context, name string) (*Team, error)
+	HostFeatures   func(context context.Context, host *Host) (*Features, error)
+	TeamByIDOrName func(ctx context.Context, id *uint, name *string) (*Team, error)
 }
 
 type OsqueryService interface {

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -502,7 +502,13 @@ func TestMDMBatchSetAppleProfiles(t *testing.T) {
 	ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
 		return &fleet.Team{ID: 1, Name: name}, nil
 	}
+	ds.TeamFunc = func(ctx context.Context, id uint) (*fleet.Team, error) {
+		return &fleet.Team{ID: id, Name: "team"}, nil
+	}
 	ds.BatchSetMDMAppleProfilesFunc = func(ctx context.Context, teamID *uint, profiles []*fleet.MDMAppleConfigProfile) error {
+		return nil
+	}
+	ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
 		return nil
 	}
 

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -859,6 +859,11 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMAppleProfiles() {
 
 	// apply an empty set to no-team
 	s.Do("POST", "/api/v1/fleet/mdm/apple/profiles/batch", batchSetMDMAppleProfilesRequest{Profiles: nil}, http.StatusNoContent)
+	s.lastActivityMatches(
+		fleet.ActivityTypeEditedMacosProfile{}.ActivityName(),
+		`{"team_id": null, "team_name": null}`,
+		0,
+	)
 
 	// apply to both team id and name
 	s.Do("POST", "/api/v1/fleet/mdm/apple/profiles/batch", batchSetMDMAppleProfilesRequest{Profiles: nil},
@@ -878,6 +883,11 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMAppleProfiles() {
 	s.Do("POST", "/api/v1/fleet/mdm/apple/profiles/batch", batchSetMDMAppleProfilesRequest{Profiles: [][]byte{
 		mobileconfigForTest("N1", "I1"),
 	}}, http.StatusNoContent, "team_id", strconv.Itoa(int(tm.ID)))
+	s.lastActivityMatches(
+		fleet.ActivityTypeEditedMacosProfile{}.ActivityName(),
+		fmt.Sprintf(`{"team_id": %d, "team_name": %q}`, tm.ID, tm.Name),
+		0,
+	)
 }
 
 type device struct {


### PR DESCRIPTION
#9587 and #9639

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
