### PR TITLE
Expand description of min_version

### DIFF
--- a/schema/tables/xprotect_meta.yml
+++ b/schema/tables/xprotect_meta.yml
@@ -3,7 +3,10 @@ description: "This Mac's browser-related [XProtect](https://support.apple.com/en
 columns:
   - name: identifier
     description: "Browser extension or plugin [identifier](https://fleetdm.com/tables/safari_extensions)"
-examples: >-
+  - name: min_version
+    description: "The minimum allowed plugin version, or 'any' if no version is allowed."
+
+  examples: >-
   See the minimum version of specific components allowed by Xprotect. This
   usually means the previous versions have vulnerabilities that are being
   exploited at scale, or were exploited at scale at some point in time.


### PR DESCRIPTION
Documentation only change - expanded description of `min_version`column in the `xprotect_meta` table to include an explanation of `any`.

Resolves #9545 
