### PR TITLE
Add note about Orbit host identifier

### DIFF
--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -908,6 +908,8 @@ This setting works in combination with the `--host_identifier` flag in osquery. 
 
 Users that have duplicate UUIDs in their environment can benefit from setting this flag to `instance`.
 
+> If you are enrolling your hosts using Fleet generated packages, it is reccommended to use `uuid` as your indentifier. This prevents potential issues with duplicate host enrollments. 
+
 - Default value: `provided`
 - Environment variable: `FLEET_OSQUERY_HOST_IDENTIFIER`
 - Config file format:


### PR DESCRIPTION
Added a note reccomending `uuid` as host identifier when using Fleet generated packages. Resolves #9033

