### PR TITLE
Website: Update `<call-to-action>` component and article formatting guide

### DIFF
--- a/articles/fleet-4.26.0.md
+++ b/articles/fleet-4.26.0.md
@@ -48,7 +48,7 @@ You already have a lot of raw data to sift through in your data lake, especially
 
 Fleet 4.26.0 reduces the number of calls you have to make to pull software data with the REST API. Each time a host has software added, updated, or deleted, a `host_software_updated_at` timestamp gets updated for that host. The `host_software_updated_at` timestamp is exposed through the API. This lets you send the latest software data to your data lake, so you can avoid drowning in outdated information.
 
-<call-to-action type="mdm-beta"></call-to-action>
+<call-to-action preset="mdm-beta"></call-to-action>
 
 ## Fleet MDM
 **MDM features are not ready for production and are currently in development. These features are disabled by default.**

--- a/articles/fleet-4.27.0.md
+++ b/articles/fleet-4.27.0.md
@@ -21,7 +21,7 @@ In the UI an account administrator will see the following information:
 
 If you pair this new login activity with the audit improvements from [release 4.26](https://fleetdm.com/releases/fleet-4.26.0) you can now set up an alert if multiple failed login attempts occur. 
 
-<call-to-action type="premium-upgrade"></call-to-action>
+<call-to-action preset="premium-upgrade"></call-to-action>
 
 ## Better search filters on the ‘Select Targets’ screen in Fleet
 

--- a/handbook/marketing/article-formatting-guide.md
+++ b/handbook/marketing/article-formatting-guide.md
@@ -90,7 +90,7 @@ Use the following code snippet to include an inline CTA (call to action) in your
 
 ![Customizable CTA example](../../images/cta-example-1-900x320@2x.jpg)
 
-> __Tip__: paste the code-snippet at the end of your article, or, when creating long articles, consider adding a CTA mid-way through.
+__Tip__: paste the code-snippet at the end of your article, or, when creating long articles, consider adding a CTA mid-way through.
 
 ### How to modify the customizable CTA
 You can customize the CTA to promote what's relevant to your article.
@@ -113,6 +113,9 @@ The secondary call to action interaction. E.g., “Schedule a demo.”
 #### `secondary-button-href` 
 The URL link for your secondary CTA.
 
+#### `preset` (optional)
+If provided, a `preset` will override all other values passed into the call to action component and the component will be rendered as a preset call to action. Check out our [preset examples](#preset-examples) to see our current presets.
+
 ### Example
 In the following example we will modify `title`, `text`, `primary-button-text`, and also remove `secondary-button-text` and `secondary-button-href` to create a call to action that promotes a job opening at Fleet.
 
@@ -126,6 +129,18 @@ In the following example we will modify `title`, `text`, `primary-button-text`, 
 ```
 
 ![Customizable CTA example](../../images/cta-example-2-900x280@2x.jpg)
+
+### Preset examples
+
+`<call-to-action preset="mdm-beta"></call-to-action>`
+
+<call-to-action preset="mdm-beta">
+</call-to-action>
+
+`<call-to-action preset="premium-upgrade"></call-to-action>`
+
+<call-to-action preset="premium-upgrade">
+</call-to-action>
 
 ## Related pages
 - [How to submit and publish an article](./how-to-submit-and-publish-an-article.md)

--- a/website/assets/js/components/call-to-action.component.js
+++ b/website/assets/js/components/call-to-action.component.js
@@ -19,7 +19,7 @@ parasails.registerComponent('callToAction', {
     'primaryButtonHref', // Required: the url that the call to action button leads
     'secondaryButtonText', // Optional: if provided with a `secondaryButtonHref`, a second button will be added to the call to action with this value as the button text
     'secondaryButtonHref', // Optional: if provided with a `secondaryButtonText`, a second button will be added to the call to action with this value as the href
-    'type',// Optional: if provided, all other values will be ignored, and this component will display a specified varient, can be set to 'premium-upgrade' or 'mdm-beta'.
+    'preset',// Optional: if provided, all other values will be ignored, and this component will display a specified varient, can be set to 'premium-upgrade' or 'mdm-beta'.
   ],
 
   //  ╦╔╗╔╦╔╦╗╦╔═╗╦    ╔═╗╔╦╗╔═╗╔╦╗╔═╗
@@ -32,7 +32,7 @@ parasails.registerComponent('callToAction', {
     let calltoActionPrimaryBtnHref = '';
     let calltoActionSecondaryBtnText = '';
     let calltoActionSecondaryBtnHref = '';
-    let callToActionType = '';
+    let callToActionPreset = '';
 
     return {
       callToActionTitle,
@@ -41,7 +41,7 @@ parasails.registerComponent('callToAction', {
       calltoActionPrimaryBtnHref,
       calltoActionSecondaryBtnText,
       calltoActionSecondaryBtnHref,
-      callToActionType
+      callToActionPreset
     };
   },
 
@@ -50,7 +50,7 @@ parasails.registerComponent('callToAction', {
   //  ╩ ╩ ╩ ╩ ╩╩═╝
   template: `
   <div id="cta-component">
-    <div v-if="!callToActionType" purpose="custom-cta">
+    <div v-if="!callToActionPreset" purpose="custom-cta">
       <div purpose="custom-cta-content" class="text-white text-center">
         <div purpose="custom-cta-title">{{callToActionTitle}}</div>
         <div purpose="custom-cta-text">{{callToActionText}}</div>
@@ -63,7 +63,7 @@ parasails.registerComponent('callToAction', {
       </div>
     </div>
     <div v-else>
-      <div v-if="callToActionType === 'premium-upgrade'" purpose="fleet-premium-cta" class="d-flex flex-column flex-sm-row align-items-center justify-content-center">
+      <div v-if="callToActionPreset === 'premium-upgrade'" purpose="fleet-premium-cta" class="d-flex flex-column flex-sm-row align-items-center justify-content-center">
         <div class="order-2 order-sm-1 justify-content-center" purpose="premium-cta-text">
           <h2>Get even more control <br>with <span>Fleet Premium</span></h2>
           <a style="color: #fff; text-decoration: none;" purpose="premium-cta-btn" href="/upgrade">Learn more</a>
@@ -72,7 +72,7 @@ parasails.registerComponent('callToAction', {
           <img alt="A computer reporting it's disk encryption status" src="/images/premium-landing-feature-4.svg">
         </div>
       </div>
-      <div v-else-if="callToActionType === 'mdm-beta'" purpose="mdm-beta-cta-container">
+      <div v-else-if="callToActionPreset === 'mdm-beta'" purpose="mdm-beta-cta-container">
         <div purpose="mdm-beta-cta-background">
           <div purpose="mdm-beta-cta" class="d-flex flex-column flex-sm-row">
             <div purpose="mdm-small-banner" class="d-flex d-sm-none">
@@ -98,9 +98,9 @@ parasails.registerComponent('callToAction', {
 
   },
   mounted: async function() {
-    if(this.type){
-      if(_.contains(['premium-upgrade', 'mdm-beta'], this.type)){
-        this.callToActionType = this.type;
+    if(this.preset){
+      if(_.contains(['premium-upgrade', 'mdm-beta'], this.preset)){
+        this.callToActionPreset = this.preset;
       } else {
         throw new Error('Incomplete usage of <call-to-action>: If providing a type, it must be either \'premium-upgrade\' or \'mdm-beta\'');
       }

--- a/website/assets/styles/components/call-to-action.component.less
+++ b/website/assets/styles/components/call-to-action.component.less
@@ -69,6 +69,7 @@
     [purpose='premium-cta-image'] {
       img {
         height: 220px;
+        width: auto;
         padding: 0;
       }
     }


### PR DESCRIPTION
Changes:
- Changed the name of the `type` prop of the `<call-to-action>` component to `preset`
- Updated `<call-to-action>` components in articles to use the new prop name
- Updated the article formatting guide in the Handbook to document how to use a `<call-to-action>` preset and added examples of our two presets.