### PR TITLE
Only set public IPs on `host.public_ip` and add docs

### DIFF
--- a/changes/9857-fix-public-ip-and-add-docs
+++ b/changes/9857-fix-public-ip-and-add-docs
@@ -1,0 +1,1 @@
+* Only set public IPs on the `host.public_ip` field and add documentation on how to properly configure the deployment to ingest correct public IPs from enrolled devices.

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -2952,7 +2952,7 @@ Follow these steps to configure Fleet SSO with Google Workspace. This will requi
 ## Public IPs of devices
 
 > IMPORTANT: In order for this feature to work properly, devices must connect to Fleet via the public internet.
-> If Fleet and the agents are deployed on a private network then the "Public IP address" for such device will not be set. 
+> If the agent connects to Fleet via a private network then the "Public IP address" for such device will not be set.
 
 Fleet attempts to deduce the public IP of devices from well-known HTTP headers received on requests made by the osquery agent.
 

--- a/docs/Deploying/Reference-Architectures.md
+++ b/docs/Deploying/Reference-Architectures.md
@@ -39,22 +39,22 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 #### [Up to 1000 hosts](https://calculator.aws/#/estimate?id=ae7d7ddec64bb979f3f6611d23616b1dff0e8dbd)
 
 | Fleet instances | CPU Units     | RAM |
-|-----------------|---------------|-----|
+| --------------- | ------------- | --- |
 | 1 Fargate task  | 512 CPU Units | 4GB |
 
 | Dependencies | Version                 | Instance type |
-|--------------|-------------------------|---------------|
+| ------------ | ----------------------- | ------------- |
 | Redis        | 6                       | t4g.small     |
-| MySQL        | 8.0.mysql_aurora.3.02.0 | db.t3.small   |        
+| MySQL        | 8.0.mysql_aurora.3.02.0 | db.t3.small   |
 
 #### [Up to 25000 hosts](https://calculator.aws/#/estimate?id=4a3e3168275967d1e79a3d1fcfedc5b17d67a271)
 
 | Fleet instances | CPU Units      | RAM |
-|-----------------|----------------|-----|
+| --------------- | -------------- | --- |
 | 10 Fargate task | 1024 CPU Units | 4GB |
 
 | Dependencies | Version                 | Instance type |
-|--------------|-------------------------|---------------|
+| ------------ | ----------------------- | ------------- |
 | Redis        | 6                       | m6g.large     |
 | MySQL        | 8.0.mysql_aurora.3.02.0 | db.r6g.large  |
 
@@ -62,22 +62,22 @@ assume On-Demand pricing (savings are available through Reserved Instances). Cal
 #### [Up to 150000 hosts](https://calculator.aws/#/estimate?id=1d8fdd63f01e71027e9d898ed05f4a07299a7000)
 
 | Fleet instances | CPU Units      | RAM |
-|-----------------|----------------|-----|
+| --------------- | -------------- | --- |
 | 20 Fargate task | 1024 CPU Units | 4GB |
 
 | Dependencies | Version                 | Instance type  | Nodes |
-|--------------|-------------------------|----------------|-------|
+| ------------ | ----------------------- | -------------- | ----- |
 | Redis        | 6                       | m6g.large      | 3     |
 | MySQL        | 8.0.mysql_aurora.3.02.0 | db.r6g.4xlarge | 1     |
 
 #### [Up to 300000 hosts](https://calculator.aws/#/estimate?id=f3da0597a172c6a0a3683023e2700a6df6d42c0b)
 
 | Fleet instances | CPU Units      | RAM |
-|-----------------|----------------|-----|
+| --------------- | -------------- | --- |
 | 20 Fargate task | 1024 CPU Units | 4GB |
 
 | Dependencies | Version                 | Instance type   | Nodes |
-|--------------|-------------------------|-----------------|-------|
+| ------------ | ----------------------- | --------------- | ----- |
 | Redis        | 6                       | m6g.large       | 3     |
 | MySQL        | 8.0.mysql_aurora.3.02.0 | db.r6g.16xlarge | 2     |
 
@@ -156,22 +156,22 @@ GCP reference architecture can be found in [the Fleet repository](https://github
 #### [Up to 1000 hosts](https://cloud.google.com/products/calculator/#id=59670518-9af4-4044-af4a-cc100a9bed2f)
 
 | Fleet instances | CPU | RAM |
-|-----------------|-----|-----|
+| --------------- | --- | --- |
 | 2 Cloud Run     | 1   | 2GB |
 
 | Dependencies | Version               | Instance type |
-|--------------|-----------------------|---------------|
+| ------------ | --------------------- | ------------- |
 | Redis        | MemoryStore Redis 6   | M1 Basic      |
-| MySQL        | Cloud SQL for MySQL 8 | db-standard-1 |        
+| MySQL        | Cloud SQL for MySQL 8 | db-standard-1 |
 
 #### [Up to 25000 hosts](https://cloud.google.com/products/calculator/#id=fadbb96c-967c-4397-9921-743d75b98d42)
 
 | Fleet instances | CPU | RAM |
-|-----------------|-----|-----|
+| --------------- | --- | --- |
 | 10 Cloud Run    | 1   | 2GB |
 
 | Dependencies | Version               | Instance type |
-|--------------|-----------------------|---------------|
+| ------------ | --------------------- | ------------- |
 | Redis        | MemoryStore Redis 6   | M1 2GB        |
 | MySQL        | Cloud SQL for MySQL 8 | db-standard-4 |
 
@@ -179,11 +179,11 @@ GCP reference architecture can be found in [the Fleet repository](https://github
 #### [Up to 150000 hosts](https://cloud.google.com/products/calculator/#id=baff774c-d294-491f-a9da-dd97bbfa8ef2)
 
 | Fleet instances | CPU   | RAM |
-|-----------------|-------|-----|
+| --------------- | ----- | --- |
 | 30 Cloud Run    | 1 CPU | 2GB |
 
 | Dependencies | Version               | Instance type | Nodes |
-|--------------|-----------------------|---------------|-------|
+| ------------ | --------------------- | ------------- | ----- |
 | Redis        | MemoryStore Redis 6   | M1 4GB        | 1     |
 | MySQL        | Cloud SQL for MySQL 8 | db-highmem-16 | 1     |
 
@@ -332,9 +332,6 @@ services:
   - key: FLEET_VULNERABILITIES_DATABASES_PATH
     scope: RUN_TIME
     value: /home/fleet
-  - key: FLEET_BETA_SOFTWARE_INVENTORY
-    scope: RUN_TIME
-    value: "1"
   health_check:
     http_path: /healthz
   http_port: 8080

--- a/test/upgrade/docker-compose.yaml
+++ b/test/upgrade/docker-compose.yaml
@@ -25,7 +25,8 @@ services:
     ports:
       - "443"
 
-  fleet-a: &default-fleet
+  fleet-a:
+    &default-fleet
     image: fleetdm/fleet:${FLEET_VERSION_A:-latest}
     environment:
       FLEET_MYSQL_ADDRESS: mysql:3306
@@ -36,7 +37,6 @@ services:
       FLEET_SERVER_ADDRESS: 0.0.0.0:8080
       FLEET_SERVER_TLS: 'false'
       FLEET_LOGGING_JSON: 'true'
-      FLEET_BETA_SOFTWARE_INVENTORY: 1
       FLEET_LICENSE_KEY: ${FLEET_LICENSE_KEY}
       FLEET_OSQUERY_LABEL_UPDATE_INTERVAL: 1m
       FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS: "yes"


### PR DESCRIPTION
#9857

The "Public IP address" field is sometimes set to a "Private IP" on the following types of Fleet deployments:
- Local deployments.
- Deployments where Fleet is on a private network.
- Deployments where an agent connects to Fleet not via the public internet.

This PR will prevent a private IP to be set on the `host.public_ip` field.
And this PR also adds documentation on how Fleet deduces the public IPs of the devices so that a user can make the changes to fix this.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- ~[ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~[ ] Documented any permissions changes~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- ~[ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality
  - ~For Orbit and Fleet Desktop changes:~
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
