### PR TITLE
Use dynamic serial numbers in osquery-perf

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -212,6 +212,7 @@ type agent struct {
 
 	EnrollSecret          string
 	UUID                  string
+	SerialNumber          string
 	ConfigInterval        time.Duration
 	QueryInterval         time.Duration
 	DiskEncryptionEnabled bool
@@ -264,7 +265,8 @@ func newAgent(
 		EnrollSecret:   enrollSecret,
 		ConfigInterval: configInterval,
 		QueryInterval:  queryInterval,
-		UUID:           uuid.New().String(),
+		UUID:           strings.ToUpper(uuid.New().String()),
+		SerialNumber:   randSerial(),
 	}
 }
 
@@ -1268,4 +1270,16 @@ func main() {
 
 	fmt.Println("Agents running. Kill with C-c.")
 	<-make(chan struct{})
+}
+
+// numbers plus capital letters without I, L, O for readability
+const serialLetters = "0123456789ABCDEFGHJKMNPQRSTUVWXYZ"
+
+func randSerial() string {
+	b := make([]byte, 12)
+	for i := range b {
+		//nolint:gosec // not used for crypto, only to generate random serial for testing
+		b[i] = serialLetters[rand.Intn(len(serialLetters))]
+	}
+	return string(b)
 }

--- a/cmd/osquery-perf/mac10.14.6.tmpl
+++ b/cmd/osquery-perf/mac10.14.6.tmpl
@@ -44,7 +44,7 @@
             "cpu_subtype": "Intel x86-64h Haswell",
             "cpu_type": "x86_64h",
             "hardware_model": "MacBookPro11,4",
-            "hardware_serial": "D02R835DG8WK",
+            "hardware_serial": "{{ .SerialNumber }}",
             "hardware_vendor": "Apple Inc.",
             "hardware_version": "1.0",
             "hostname": "{{ .CachedString "hostname" }}",
@@ -135,7 +135,7 @@
 [
   {
     "hostname":"{{ .CachedString "hostname" }}",
-    "uuid":"4740D59F-699E-5B29-960B-979AAF9BBEEB",
+    "uuid": "{{ .UUID }}",
     "cpu_type":"x86_64h",
     "cpu_subtype":"Intel x86-64h Haswell",
     "cpu_brand":"Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz",
@@ -146,7 +146,7 @@
     "hardware_vendor":"Apple Inc.",
     "hardware_model":"MacBookPro11,4",
     "hardware_version":"1.0",
-    "hardware_serial":"C02R262BM8LN",
+    "hardware_serial":"{{ .SerialNumber }}",
     "computer_name":"{{ .CachedString "hostname" }}",
     "local_hostname":"{{ .CachedString "hostname" }}"
   }


### PR DESCRIPTION
This helps with MDM local testing as serial numbers play a big role.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [x] Manual QA for all new/changed functionality
