### PR TITLE
Allow `tls_dump` in agent settings

### DIFF
--- a/server/fleet/agent_options.go
+++ b/server/fleet/agent_options.go
@@ -500,6 +500,7 @@ type OsqueryCommandLineFlagsHidden struct {
 	MinLogLevel           int32  `json:"minloglevel"`
 	StopLoggingIfFullDisk bool   `json:"stop_logging_if_full_disk"`
 	AllowUnsafe           bool   `json:"allow_unsafe"`
+	TLSDump               bool   `json:"tls_dump"`
 }
 
 // while ValidateJSONAgentOptions validates an entire Agent Options payload,


### PR DESCRIPTION
This allows for configuring `tls_dump` in the agent settings under `options` and under `command_line_flags`:
![Screenshot 2023-02-17 at 17 01 33](https://user-images.githubusercontent.com/2073526/219781091-af3f8f90-5ed3-4e53-aa3e-edc66750b3d1.png)
