### PR TITLE
Remove Rosetta requirement for macOS installers

### DIFF
--- a/changes/rosetta
+++ b/changes/rosetta
@@ -1,0 +1,1 @@
+* Remove requirement for Rosetta in installation of macOS packages on Apple Silicon. The binaries have been "universal" for a while now, but the installer still required Rosetta until now.

--- a/orbit/pkg/packaging/macos_templates.go
+++ b/orbit/pkg/packaging/macos_templates.go
@@ -39,6 +39,7 @@ var macosDistributionTemplate = template.Must(template.New("").Option("missingke
         <bundle id="{{.Identifier}}" path="" />
       </bundle-version>
     </pkg-ref>
+	<options customize="never" hostArchitectures="arm64,x86_64" require-scripts="false" allow-external-scripts="false" />
 </installer-gui-script>
 `))
 


### PR DESCRIPTION
Even though the binaries are "universal" (compatible with both arm64 and x86_64), this configuration must be provided in the Distribution XML in order to prevent macOS from installing Rosetta when the user goes to install the package. Verified with Suspicious Package.

For #9932

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
