### PR TITLE
Fleet UI: Add source link to query table side panel

### DIFF
--- a/changes/9546-query-table-source-link
+++ b/changes/9546-query-table-source-link
@@ -1,0 +1,1 @@
+- UI includes link to query table source (fleetdm.com/tables/table_name)

--- a/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tsx
+++ b/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tsx
@@ -15,6 +15,7 @@ import CloseIcon from "../../../../assets/images/icon-close-black-50-8x8@2x.png"
 import QueryTableExample from "./QueryTableExample";
 import QueryTableNotes from "./QueryTableNotes";
 import EventedTableTag from "./EventedTableTag";
+import CustomLink from "components/CustomLink";
 
 interface IQuerySidePanel {
   selectedOsqueryTable: IOsQueryTable;
@@ -86,6 +87,11 @@ const QuerySidePanel = ({
       <QueryTableColumns columns={columns} />
       {examples && <QueryTableExample example={examples} />}
       {notes && <QueryTableNotes notes={notes} />}
+      <CustomLink
+        url={`https://www.fleetdm.com/tables/${name}`}
+        text="Source"
+        newTab
+      />
     </>
   );
 };


### PR DESCRIPTION
## Issue
Cerra #9546 

## Fix
- In the query table side panel, Add "Source" external link that opens in a new tab
- This allows the user to be able to Edit table information if incorrect

## Screenrecording

https://user-images.githubusercontent.com/71795832/220149914-7ae804ac-543f-4637-8649-8165fa869874.mov

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
