### PR TITLE
Use openssl legacy provider to run webpack until we upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,11 +151,11 @@ test: lint test-go test-js
 generate: clean-assets generate-js generate-go
 
 generate-ci:
-	NODE_ENV=development yarn run webpack
+	NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=development yarn run webpack
 	make generate-go
 
 generate-js: clean-assets .prefix
-	NODE_ENV=production yarn run webpack --progress --colors
+	NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=production yarn run webpack --progress --colors
 
 generate-go: .prefix
 	go run github.com/kevinburke/go-bindata/go-bindata -pkg=bindata -tags full \
@@ -166,11 +166,11 @@ generate-go: .prefix
 # output bundle file. then, generate debug bindata source file. finally, we
 # run webpack in watch mode to continuously re-generate the bundle
 generate-dev: .prefix
-	NODE_ENV=development webpack --progress --colors
+	NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=development yarn run webpack --progress --colors
 	go run github.com/kevinburke/go-bindata/go-bindata -debug -pkg=bindata -tags full \
 		-o=server/bindata/generated.go \
 		frontend/templates/ assets/... server/mail/templates
-	NODE_ENV=development webpack --progress --colors --watch
+	NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=development yarn run webpack --progress --colors --watch
 
 generate-mock: .prefix
 	go install github.com/fleetdm/mockimpl@8d7943aa39d8f5f464d3d3618d9571d385f7bcc5

--- a/Makefile
+++ b/Makefile
@@ -151,11 +151,11 @@ test: lint test-go test-js
 generate: clean-assets generate-js generate-go
 
 generate-ci:
-	NODE_ENV=development webpack
+	NODE_ENV=development yarn run webpack
 	make generate-go
 
 generate-js: clean-assets .prefix
-	NODE_ENV=production webpack --progress --colors
+	NODE_ENV=production yarn run webpack --progress --colors
 
 generate-go: .prefix
 	go run github.com/kevinburke/go-bindata/go-bindata -pkg=bindata -tags full \


### PR DESCRIPTION
Related to https://github.com/fleetdm/fleet/issues/9945, this changes our Makefile to use the project-local `webpack` binary and to use `NODE_OPTIONS=--openssl-legacy-provider` as described here: https://github.com/webpack/webpack/issues/14532

The real fix is to upgrade webpack to v5 or newer, but that can be a can of worms.