### PR TITLE
Fleet UI: Select targets picker greys out filters if all host selected

### DIFF
--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -136,6 +136,7 @@ const SelectTargets = ({
   const [searchText, setSearchText] = useState("");
   const [debouncedSearchText, setDebouncedSearchText] = useState("");
   const [isDebouncing, setIsDebouncing] = useState(false);
+  const [allHostsSelected, setAllHostsSelected] = useState(false);
 
   const debounceSearch = useDebouncedCallback(
     (search: string) => {
@@ -266,8 +267,20 @@ const SelectTargets = ({
 
     // if the target was previously selected, we want to remove it now
     const newTargets = prevTargets.filter((t) => t.id !== selectedEntity.id);
+
     // if the length remains the same, the target was not previously selected so we want to add it now
     prevTargets.length === newTargets.length && newTargets.push(selectedEntity);
+
+    // if allHostsSelected, UI greys out other target filters
+    if (isLabel(selectedEntity)) {
+      const selectedLabelEntity = selectedEntity as ILabel;
+      if (
+        selectedLabelEntity.name === "All Hosts" &&
+        selectedLabelEntity.label_type === "builtin"
+      ) {
+        setAllHostsSelected(!allHostsSelected);
+      }
+    }
 
     isLabel(selectedEntity)
       ? setTargetedLabels(newTargets as ILabel[])
@@ -385,13 +398,28 @@ const SelectTargets = ({
     <div className={`${baseClass}__wrapper`}>
       <h1>Select targets</h1>
       <div className={`${baseClass}__target-selectors`}>
-        {!!labels?.allHosts.length &&
-          renderTargetEntityList("", labels.allHosts)}
-        {!!labels?.platforms?.length &&
-          renderTargetEntityList("Platforms", labels.platforms)}
-        {!!teams?.length && renderTargetEntityList("Teams", teams)}
-        {!!labels?.other?.length &&
-          renderTargetEntityList("Labels", labels.other)}
+        <div
+          className={
+            !allHostsSelected &&
+            (selectedTargets.length || targetedHosts.length)
+              ? `${baseClass}__target-selectors--greyed`
+              : ""
+          }
+        >
+          {!!labels?.allHosts.length &&
+            renderTargetEntityList("", labels.allHosts)}
+        </div>
+        <div
+          className={
+            allHostsSelected ? `${baseClass}__target-selectors--greyed` : ""
+          }
+        >
+          {!!labels?.platforms?.length &&
+            renderTargetEntityList("Platforms", labels.platforms)}
+          {!!teams?.length && renderTargetEntityList("Teams", teams)}
+          {!!labels?.other?.length &&
+            renderTargetEntityList("Labels", labels.other)}
+        </div>
       </div>
       <TargetsInput
         tabIndex={inputTabIndex || 0}
@@ -403,6 +431,7 @@ const SelectTargets = ({
         setSearchText={setSearchText}
         handleRowSelect={handleRowSelect}
         handleRowRemove={handleRowRemove}
+        greyedOut={allHostsSelected}
       />
       <div className={`${baseClass}__targets-button-wrap`}>
         <Button

--- a/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
+++ b/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
@@ -21,6 +21,7 @@ interface ITargetsInputProps {
   setSearchText: (value: string) => void;
   handleRowSelect: (value: Row) => void;
   handleRowRemove: (value: Row) => void;
+  greyedOut?: boolean;
 }
 
 const baseClass = "targets-input";
@@ -35,6 +36,7 @@ const TargetsInput = ({
   handleRowSelect,
   handleRowRemove,
   setSearchText,
+  greyedOut,
 }: ITargetsInputProps): JSX.Element => {
   const resultsDropdownTableHeaders = generateTableHeaders();
   const selectedTableHeaders = generateTableHeaders(handleRowRemove);
@@ -49,17 +51,21 @@ const TargetsInput = ({
   return (
     <div>
       <div className={baseClass}>
-        <Input
-          autofocus
-          type="search"
-          iconName="search"
-          value={searchText}
-          tabIndex={tabIndex}
-          iconPosition="start"
-          label="Target specific hosts"
-          placeholder={HOSTS_SEARCH_BOX_PLACEHOLDER}
-          onChange={setSearchText}
-        />
+        <div
+          className={greyedOut ? `${baseClass}__target-selectors--greyed` : ""}
+        >
+          <Input
+            autofocus
+            type="search"
+            iconName="search"
+            value={searchText}
+            tabIndex={tabIndex}
+            iconPosition="start"
+            label="Target specific hosts"
+            placeholder={HOSTS_SEARCH_BOX_PLACEHOLDER}
+            onChange={setSearchText}
+          />
+        </div>
         {isActiveSearch && (
           <div className={`${baseClass}__hosts-search-dropdown`}>
             <TableContainer
@@ -93,17 +99,23 @@ const TargetsInput = ({
           </div>
         )}
         <div className={`${baseClass}__hosts-selected-table`}>
-          <TableContainer
-            columns={selectedTableHeaders}
-            data={targetedHosts}
-            isLoading={false}
-            resultsTitle=""
-            showMarkAllPages={false}
-            isAllPagesSelected={false}
-            disableCount
-            disablePagination
-            emptyComponent={() => <></>}
-          />
+          <div
+            className={
+              greyedOut ? `${baseClass}__target-selectors--greyed` : ""
+            }
+          >
+            <TableContainer
+              columns={selectedTableHeaders}
+              data={targetedHosts}
+              isLoading={false}
+              resultsTitle=""
+              showMarkAllPages={false}
+              isAllPagesSelected={false}
+              disableCount
+              disablePagination
+              emptyComponent={() => <></>}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/components/LiveQuery/TargetsInput/_styles.scss
+++ b/frontend/components/LiveQuery/TargetsInput/_styles.scss
@@ -1,6 +1,10 @@
 .targets-input {
   position: relative;
 
+  &__target-selectors--greyed {
+    opacity: 50%;
+  }
+
   &__hosts-search-dropdown {
     width: 100%;
     position: absolute;

--- a/frontend/pages/policies/PolicyPage/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/_styles.scss
@@ -116,6 +116,10 @@
         }
       }
     }
+
+    &--greyed {
+      opacity: 60%;
+    }
   }
   &__targets-button-wrap {
     margin-top: 30px;

--- a/frontend/pages/queries/QueryPage/_styles.scss
+++ b/frontend/pages/queries/QueryPage/_styles.scss
@@ -119,6 +119,10 @@
         }
       }
     }
+
+    &--greyed {
+      opacity: 60%;
+    }
   }
   &__targets-button-wrap {
     margin-top: 30px;


### PR DESCRIPTION
## Issue
Cerra #9603

## Fix
- Grey out filtering targets that cannot be applied with all hosts

## Note
- If we want to have selecting a filter deselect the all hosts filter, it will require a frontend revamp of how the pills are selected/deselected

## Screenrecording
https://user-images.githubusercontent.com/71795832/220198715-8a85170e-8518-47c1-842c-a6b073bc38fe.mov



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
