### PR TITLE
Ensuring that null or empty settings return as empty strings

### DIFF
--- a/orbit/pkg/table/mdm/mdm_windows.go
+++ b/orbit/pkg/table/mdm/mdm_windows.go
@@ -213,7 +213,7 @@ func getCmdResponseData(outputCmd string) (string, error) {
 				// extracting the data from the result
 				workStr := element.Item[0].Data
 				if len(workStr) == 0 {
-					workStr = "data_not_set" // default value for empty data
+					workStr = "" // default value for empty data
 				}
 				responseData += workStr
 			}


### PR DESCRIPTION
This relates to #9310 