### PR TITLE
Update docs for `device_mapping`, works on all OSs (with fleetd)

### DIFF
--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -2593,15 +2593,9 @@ Request (`filters` is specified):
 
 ### Get host's Google Chrome profiles
 
-Requires the [macadmins osquery
-extension](https://github.com/macadmins/osquery-extension) which comes bundled
-in [Fleet's osquery
-installers](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).
-Currently supported only on macOS.
+Retrieves a host's Google Chrome profile information which can be used to link a host to a specific user by email.
 
-
-Retrieves a host's Google Chrome profile information which can be used to link a host to a specific
-user by email.
+Requires [Fleetd](https://fleetdm.com/docs/using-fleet/orbit), the osquery manager from Fleet. Fleetd can be built with [fleetctl](https://fleetdm.com/docs/using-fleet/adding-hosts#osquery-installer).
 
 `GET /api/v1/fleet/hosts/{id}/device_mapping`
 


### PR DESCRIPTION
The `google_chrome_profiles` table is present in the three OSs. The one requirement is that the user must use fleetd.