### PR TITLE
update mockimpl version to allow concurrent mock calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ generate-dev: .prefix
 	NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=development yarn run webpack --progress --colors --watch
 
 generate-mock: .prefix
-	go install github.com/fleetdm/mockimpl@8d7943aa39d8f5f464d3d3618d9571d385f7bcc5
+	go install github.com/fleetdm/mockimpl@ecbb3041eabfc9e046a3f2e414e32c28254b75b2
 	go generate github.com/fleetdm/fleet/v4/server/mock github.com/fleetdm/fleet/v4/server/mock/mockresult github.com/fleetdm/fleet/v4/server/service/mock
 
 generate-doc: .prefix

--- a/server/mock/datastore_installers.go
+++ b/server/mock/datastore_installers.go
@@ -5,6 +5,7 @@ package mock
 import (
 	"context"
 	"io"
+	"sync"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 )
@@ -26,19 +27,27 @@ type InstallerStore struct {
 
 	ExistsFunc        ExistsFunc
 	ExistsFuncInvoked bool
+
+	mu sync.Mutex
 }
 
 func (s *InstallerStore) Get(ctx context.Context, installer fleet.Installer) (io.ReadCloser, int64, error) {
+	s.mu.Lock()
 	s.GetFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetFunc(ctx, installer)
 }
 
 func (s *InstallerStore) Put(ctx context.Context, installer fleet.Installer) (string, error) {
+	s.mu.Lock()
 	s.PutFuncInvoked = true
+	s.mu.Unlock()
 	return s.PutFunc(ctx, installer)
 }
 
 func (s *InstallerStore) Exists(ctx context.Context, installer fleet.Installer) (bool, error) {
+	s.mu.Lock()
 	s.ExistsFuncInvoked = true
+	s.mu.Unlock()
 	return s.ExistsFunc(ctx, installer)
 }

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -5,6 +5,7 @@ package mock
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/config"
@@ -1344,1334 +1345,1868 @@ type DataStore struct {
 
 	OutdatedAutomationBatchFunc        OutdatedAutomationBatchFunc
 	OutdatedAutomationBatchFuncInvoked bool
+
+	mu sync.Mutex
 }
 
 func (s *DataStore) HealthCheck() error {
+	s.mu.Lock()
 	s.HealthCheckFuncInvoked = true
+	s.mu.Unlock()
 	return s.HealthCheckFunc()
 }
 
 func (s *DataStore) NewCarve(ctx context.Context, metadata *fleet.CarveMetadata) (*fleet.CarveMetadata, error) {
+	s.mu.Lock()
 	s.NewCarveFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewCarveFunc(ctx, metadata)
 }
 
 func (s *DataStore) UpdateCarve(ctx context.Context, metadata *fleet.CarveMetadata) error {
+	s.mu.Lock()
 	s.UpdateCarveFuncInvoked = true
+	s.mu.Unlock()
 	return s.UpdateCarveFunc(ctx, metadata)
 }
 
 func (s *DataStore) Carve(ctx context.Context, carveId int64) (*fleet.CarveMetadata, error) {
+	s.mu.Lock()
 	s.CarveFuncInvoked = true
+	s.mu.Unlock()
 	return s.CarveFunc(ctx, carveId)
 }
 
 func (s *DataStore) CarveBySessionId(ctx context.Context, sessionId string) (*fleet.CarveMetadata, error) {
+	s.mu.Lock()
 	s.CarveBySessionIdFuncInvoked = true
+	s.mu.Unlock()
 	return s.CarveBySessionIdFunc(ctx, sessionId)
 }
 
 func (s *DataStore) CarveByName(ctx context.Context, name string) (*fleet.CarveMetadata, error) {
+	s.mu.Lock()
 	s.CarveByNameFuncInvoked = true
+	s.mu.Unlock()
 	return s.CarveByNameFunc(ctx, name)
 }
 
 func (s *DataStore) ListCarves(ctx context.Context, opt fleet.CarveListOptions) ([]*fleet.CarveMetadata, error) {
+	s.mu.Lock()
 	s.ListCarvesFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListCarvesFunc(ctx, opt)
 }
 
 func (s *DataStore) NewBlock(ctx context.Context, metadata *fleet.CarveMetadata, blockId int64, data []byte) error {
+	s.mu.Lock()
 	s.NewBlockFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewBlockFunc(ctx, metadata, blockId, data)
 }
 
 func (s *DataStore) GetBlock(ctx context.Context, metadata *fleet.CarveMetadata, blockId int64) ([]byte, error) {
+	s.mu.Lock()
 	s.GetBlockFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetBlockFunc(ctx, metadata, blockId)
 }
 
 func (s *DataStore) CleanupCarves(ctx context.Context, now time.Time) (expired int, err error) {
+	s.mu.Lock()
 	s.CleanupCarvesFuncInvoked = true
+	s.mu.Unlock()
 	return s.CleanupCarvesFunc(ctx, now)
 }
 
 func (s *DataStore) NewUser(ctx context.Context, user *fleet.User) (*fleet.User, error) {
+	s.mu.Lock()
 	s.NewUserFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewUserFunc(ctx, user)
 }
 
 func (s *DataStore) ListUsers(ctx context.Context, opt fleet.UserListOptions) ([]*fleet.User, error) {
+	s.mu.Lock()
 	s.ListUsersFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListUsersFunc(ctx, opt)
 }
 
 func (s *DataStore) UserByEmail(ctx context.Context, email string) (*fleet.User, error) {
+	s.mu.Lock()
 	s.UserByEmailFuncInvoked = true
+	s.mu.Unlock()
 	return s.UserByEmailFunc(ctx, email)
 }
 
 func (s *DataStore) UserByID(ctx context.Context, id uint) (*fleet.User, error) {
+	s.mu.Lock()
 	s.UserByIDFuncInvoked = true
+	s.mu.Unlock()
 	return s.UserByIDFunc(ctx, id)
 }
 
 func (s *DataStore) SaveUser(ctx context.Context, user *fleet.User) error {
+	s.mu.Lock()
 	s.SaveUserFuncInvoked = true
+	s.mu.Unlock()
 	return s.SaveUserFunc(ctx, user)
 }
 
 func (s *DataStore) SaveUsers(ctx context.Context, users []*fleet.User) error {
+	s.mu.Lock()
 	s.SaveUsersFuncInvoked = true
+	s.mu.Unlock()
 	return s.SaveUsersFunc(ctx, users)
 }
 
 func (s *DataStore) DeleteUser(ctx context.Context, id uint) error {
+	s.mu.Lock()
 	s.DeleteUserFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeleteUserFunc(ctx, id)
 }
 
 func (s *DataStore) PendingEmailChange(ctx context.Context, userID uint, newEmail string, token string) error {
+	s.mu.Lock()
 	s.PendingEmailChangeFuncInvoked = true
+	s.mu.Unlock()
 	return s.PendingEmailChangeFunc(ctx, userID, newEmail, token)
 }
 
 func (s *DataStore) ConfirmPendingEmailChange(ctx context.Context, userID uint, token string) (string, error) {
+	s.mu.Lock()
 	s.ConfirmPendingEmailChangeFuncInvoked = true
+	s.mu.Unlock()
 	return s.ConfirmPendingEmailChangeFunc(ctx, userID, token)
 }
 
 func (s *DataStore) ApplyQueries(ctx context.Context, authorID uint, queries []*fleet.Query) error {
+	s.mu.Lock()
 	s.ApplyQueriesFuncInvoked = true
+	s.mu.Unlock()
 	return s.ApplyQueriesFunc(ctx, authorID, queries)
 }
 
 func (s *DataStore) NewQuery(ctx context.Context, query *fleet.Query, opts ...fleet.OptionalArg) (*fleet.Query, error) {
+	s.mu.Lock()
 	s.NewQueryFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewQueryFunc(ctx, query, opts...)
 }
 
 func (s *DataStore) SaveQuery(ctx context.Context, query *fleet.Query) error {
+	s.mu.Lock()
 	s.SaveQueryFuncInvoked = true
+	s.mu.Unlock()
 	return s.SaveQueryFunc(ctx, query)
 }
 
 func (s *DataStore) DeleteQuery(ctx context.Context, name string) error {
+	s.mu.Lock()
 	s.DeleteQueryFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeleteQueryFunc(ctx, name)
 }
 
 func (s *DataStore) DeleteQueries(ctx context.Context, ids []uint) (uint, error) {
+	s.mu.Lock()
 	s.DeleteQueriesFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeleteQueriesFunc(ctx, ids)
 }
 
 func (s *DataStore) Query(ctx context.Context, id uint) (*fleet.Query, error) {
+	s.mu.Lock()
 	s.QueryFuncInvoked = true
+	s.mu.Unlock()
 	return s.QueryFunc(ctx, id)
 }
 
 func (s *DataStore) ListQueries(ctx context.Context, opt fleet.ListQueryOptions) ([]*fleet.Query, error) {
+	s.mu.Lock()
 	s.ListQueriesFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListQueriesFunc(ctx, opt)
 }
 
 func (s *DataStore) QueryByName(ctx context.Context, name string, opts ...fleet.OptionalArg) (*fleet.Query, error) {
+	s.mu.Lock()
 	s.QueryByNameFuncInvoked = true
+	s.mu.Unlock()
 	return s.QueryByNameFunc(ctx, name, opts...)
 }
 
 func (s *DataStore) ObserverCanRunQuery(ctx context.Context, queryID uint) (bool, error) {
+	s.mu.Lock()
 	s.ObserverCanRunQueryFuncInvoked = true
+	s.mu.Unlock()
 	return s.ObserverCanRunQueryFunc(ctx, queryID)
 }
 
 func (s *DataStore) NewDistributedQueryCampaign(ctx context.Context, camp *fleet.DistributedQueryCampaign) (*fleet.DistributedQueryCampaign, error) {
+	s.mu.Lock()
 	s.NewDistributedQueryCampaignFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewDistributedQueryCampaignFunc(ctx, camp)
 }
 
 func (s *DataStore) DistributedQueryCampaign(ctx context.Context, id uint) (*fleet.DistributedQueryCampaign, error) {
+	s.mu.Lock()
 	s.DistributedQueryCampaignFuncInvoked = true
+	s.mu.Unlock()
 	return s.DistributedQueryCampaignFunc(ctx, id)
 }
 
 func (s *DataStore) SaveDistributedQueryCampaign(ctx context.Context, camp *fleet.DistributedQueryCampaign) error {
+	s.mu.Lock()
 	s.SaveDistributedQueryCampaignFuncInvoked = true
+	s.mu.Unlock()
 	return s.SaveDistributedQueryCampaignFunc(ctx, camp)
 }
 
 func (s *DataStore) DistributedQueryCampaignTargetIDs(ctx context.Context, id uint) (targets *fleet.HostTargets, err error) {
+	s.mu.Lock()
 	s.DistributedQueryCampaignTargetIDsFuncInvoked = true
+	s.mu.Unlock()
 	return s.DistributedQueryCampaignTargetIDsFunc(ctx, id)
 }
 
 func (s *DataStore) NewDistributedQueryCampaignTarget(ctx context.Context, target *fleet.DistributedQueryCampaignTarget) (*fleet.DistributedQueryCampaignTarget, error) {
+	s.mu.Lock()
 	s.NewDistributedQueryCampaignTargetFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewDistributedQueryCampaignTargetFunc(ctx, target)
 }
 
 func (s *DataStore) CleanupDistributedQueryCampaigns(ctx context.Context, now time.Time) (expired uint, err error) {
+	s.mu.Lock()
 	s.CleanupDistributedQueryCampaignsFuncInvoked = true
+	s.mu.Unlock()
 	return s.CleanupDistributedQueryCampaignsFunc(ctx, now)
 }
 
 func (s *DataStore) DistributedQueryCampaignsForQuery(ctx context.Context, queryID uint) ([]*fleet.DistributedQueryCampaign, error) {
+	s.mu.Lock()
 	s.DistributedQueryCampaignsForQueryFuncInvoked = true
+	s.mu.Unlock()
 	return s.DistributedQueryCampaignsForQueryFunc(ctx, queryID)
 }
 
 func (s *DataStore) ApplyPackSpecs(ctx context.Context, specs []*fleet.PackSpec) error {
+	s.mu.Lock()
 	s.ApplyPackSpecsFuncInvoked = true
+	s.mu.Unlock()
 	return s.ApplyPackSpecsFunc(ctx, specs)
 }
 
 func (s *DataStore) GetPackSpecs(ctx context.Context) ([]*fleet.PackSpec, error) {
+	s.mu.Lock()
 	s.GetPackSpecsFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetPackSpecsFunc(ctx)
 }
 
 func (s *DataStore) GetPackSpec(ctx context.Context, name string) (*fleet.PackSpec, error) {
+	s.mu.Lock()
 	s.GetPackSpecFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetPackSpecFunc(ctx, name)
 }
 
 func (s *DataStore) NewPack(ctx context.Context, pack *fleet.Pack, opts ...fleet.OptionalArg) (*fleet.Pack, error) {
+	s.mu.Lock()
 	s.NewPackFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewPackFunc(ctx, pack, opts...)
 }
 
 func (s *DataStore) SavePack(ctx context.Context, pack *fleet.Pack) error {
+	s.mu.Lock()
 	s.SavePackFuncInvoked = true
+	s.mu.Unlock()
 	return s.SavePackFunc(ctx, pack)
 }
 
 func (s *DataStore) DeletePack(ctx context.Context, name string) error {
+	s.mu.Lock()
 	s.DeletePackFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeletePackFunc(ctx, name)
 }
 
 func (s *DataStore) Pack(ctx context.Context, pid uint) (*fleet.Pack, error) {
+	s.mu.Lock()
 	s.PackFuncInvoked = true
+	s.mu.Unlock()
 	return s.PackFunc(ctx, pid)
 }
 
 func (s *DataStore) ListPacks(ctx context.Context, opt fleet.PackListOptions) ([]*fleet.Pack, error) {
+	s.mu.Lock()
 	s.ListPacksFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListPacksFunc(ctx, opt)
 }
 
 func (s *DataStore) PackByName(ctx context.Context, name string, opts ...fleet.OptionalArg) (*fleet.Pack, bool, error) {
+	s.mu.Lock()
 	s.PackByNameFuncInvoked = true
+	s.mu.Unlock()
 	return s.PackByNameFunc(ctx, name, opts...)
 }
 
 func (s *DataStore) ListPacksForHost(ctx context.Context, hid uint) (packs []*fleet.Pack, err error) {
+	s.mu.Lock()
 	s.ListPacksForHostFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListPacksForHostFunc(ctx, hid)
 }
 
 func (s *DataStore) EnsureGlobalPack(ctx context.Context) (*fleet.Pack, error) {
+	s.mu.Lock()
 	s.EnsureGlobalPackFuncInvoked = true
+	s.mu.Unlock()
 	return s.EnsureGlobalPackFunc(ctx)
 }
 
 func (s *DataStore) EnsureTeamPack(ctx context.Context, teamID uint) (*fleet.Pack, error) {
+	s.mu.Lock()
 	s.EnsureTeamPackFuncInvoked = true
+	s.mu.Unlock()
 	return s.EnsureTeamPackFunc(ctx, teamID)
 }
 
 func (s *DataStore) ApplyLabelSpecs(ctx context.Context, specs []*fleet.LabelSpec) error {
+	s.mu.Lock()
 	s.ApplyLabelSpecsFuncInvoked = true
+	s.mu.Unlock()
 	return s.ApplyLabelSpecsFunc(ctx, specs)
 }
 
 func (s *DataStore) GetLabelSpecs(ctx context.Context) ([]*fleet.LabelSpec, error) {
+	s.mu.Lock()
 	s.GetLabelSpecsFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetLabelSpecsFunc(ctx)
 }
 
 func (s *DataStore) GetLabelSpec(ctx context.Context, name string) (*fleet.LabelSpec, error) {
+	s.mu.Lock()
 	s.GetLabelSpecFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetLabelSpecFunc(ctx, name)
 }
 
 func (s *DataStore) NewLabel(ctx context.Context, Label *fleet.Label, opts ...fleet.OptionalArg) (*fleet.Label, error) {
+	s.mu.Lock()
 	s.NewLabelFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewLabelFunc(ctx, Label, opts...)
 }
 
 func (s *DataStore) SaveLabel(ctx context.Context, label *fleet.Label) (*fleet.Label, error) {
+	s.mu.Lock()
 	s.SaveLabelFuncInvoked = true
+	s.mu.Unlock()
 	return s.SaveLabelFunc(ctx, label)
 }
 
 func (s *DataStore) DeleteLabel(ctx context.Context, name string) error {
+	s.mu.Lock()
 	s.DeleteLabelFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeleteLabelFunc(ctx, name)
 }
 
 func (s *DataStore) Label(ctx context.Context, lid uint) (*fleet.Label, error) {
+	s.mu.Lock()
 	s.LabelFuncInvoked = true
+	s.mu.Unlock()
 	return s.LabelFunc(ctx, lid)
 }
 
 func (s *DataStore) ListLabels(ctx context.Context, filter fleet.TeamFilter, opt fleet.ListOptions) ([]*fleet.Label, error) {
+	s.mu.Lock()
 	s.ListLabelsFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListLabelsFunc(ctx, filter, opt)
 }
 
 func (s *DataStore) LabelsSummary(ctx context.Context) ([]*fleet.LabelSummary, error) {
+	s.mu.Lock()
 	s.LabelsSummaryFuncInvoked = true
+	s.mu.Unlock()
 	return s.LabelsSummaryFunc(ctx)
 }
 
 func (s *DataStore) LabelQueriesForHost(ctx context.Context, host *fleet.Host) (map[string]string, error) {
+	s.mu.Lock()
 	s.LabelQueriesForHostFuncInvoked = true
+	s.mu.Unlock()
 	return s.LabelQueriesForHostFunc(ctx, host)
 }
 
 func (s *DataStore) ListLabelsForHost(ctx context.Context, hid uint) ([]*fleet.Label, error) {
+	s.mu.Lock()
 	s.ListLabelsForHostFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListLabelsForHostFunc(ctx, hid)
 }
 
 func (s *DataStore) ListHostsInLabel(ctx context.Context, filter fleet.TeamFilter, lid uint, opt fleet.HostListOptions) ([]*fleet.Host, error) {
+	s.mu.Lock()
 	s.ListHostsInLabelFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListHostsInLabelFunc(ctx, filter, lid, opt)
 }
 
 func (s *DataStore) ListUniqueHostsInLabels(ctx context.Context, filter fleet.TeamFilter, labels []uint) ([]*fleet.Host, error) {
+	s.mu.Lock()
 	s.ListUniqueHostsInLabelsFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListUniqueHostsInLabelsFunc(ctx, filter, labels)
 }
 
 func (s *DataStore) SearchLabels(ctx context.Context, filter fleet.TeamFilter, query string, omit ...uint) ([]*fleet.Label, error) {
+	s.mu.Lock()
 	s.SearchLabelsFuncInvoked = true
+	s.mu.Unlock()
 	return s.SearchLabelsFunc(ctx, filter, query, omit...)
 }
 
 func (s *DataStore) LabelIDsByName(ctx context.Context, labels []string) ([]uint, error) {
+	s.mu.Lock()
 	s.LabelIDsByNameFuncInvoked = true
+	s.mu.Unlock()
 	return s.LabelIDsByNameFunc(ctx, labels)
 }
 
 func (s *DataStore) AsyncBatchInsertLabelMembership(ctx context.Context, batch [][2]uint) error {
+	s.mu.Lock()
 	s.AsyncBatchInsertLabelMembershipFuncInvoked = true
+	s.mu.Unlock()
 	return s.AsyncBatchInsertLabelMembershipFunc(ctx, batch)
 }
 
 func (s *DataStore) AsyncBatchDeleteLabelMembership(ctx context.Context, batch [][2]uint) error {
+	s.mu.Lock()
 	s.AsyncBatchDeleteLabelMembershipFuncInvoked = true
+	s.mu.Unlock()
 	return s.AsyncBatchDeleteLabelMembershipFunc(ctx, batch)
 }
 
 func (s *DataStore) AsyncBatchUpdateLabelTimestamp(ctx context.Context, ids []uint, ts time.Time) error {
+	s.mu.Lock()
 	s.AsyncBatchUpdateLabelTimestampFuncInvoked = true
+	s.mu.Unlock()
 	return s.AsyncBatchUpdateLabelTimestampFunc(ctx, ids, ts)
 }
 
 func (s *DataStore) NewHost(ctx context.Context, host *fleet.Host) (*fleet.Host, error) {
+	s.mu.Lock()
 	s.NewHostFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewHostFunc(ctx, host)
 }
 
 func (s *DataStore) DeleteHost(ctx context.Context, hid uint) error {
+	s.mu.Lock()
 	s.DeleteHostFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeleteHostFunc(ctx, hid)
 }
 
 func (s *DataStore) Host(ctx context.Context, id uint) (*fleet.Host, error) {
+	s.mu.Lock()
 	s.HostFuncInvoked = true
+	s.mu.Unlock()
 	return s.HostFunc(ctx, id)
 }
 
 func (s *DataStore) ListHosts(ctx context.Context, filter fleet.TeamFilter, opt fleet.HostListOptions) ([]*fleet.Host, error) {
+	s.mu.Lock()
 	s.ListHostsFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListHostsFunc(ctx, filter, opt)
 }
 
 func (s *DataStore) MarkHostsSeen(ctx context.Context, hostIDs []uint, t time.Time) error {
+	s.mu.Lock()
 	s.MarkHostsSeenFuncInvoked = true
+	s.mu.Unlock()
 	return s.MarkHostsSeenFunc(ctx, hostIDs, t)
 }
 
 func (s *DataStore) SearchHosts(ctx context.Context, filter fleet.TeamFilter, query string, omit ...uint) ([]*fleet.Host, error) {
+	s.mu.Lock()
 	s.SearchHostsFuncInvoked = true
+	s.mu.Unlock()
 	return s.SearchHostsFunc(ctx, filter, query, omit...)
 }
 
 func (s *DataStore) EnrolledHostIDs(ctx context.Context) ([]uint, error) {
+	s.mu.Lock()
 	s.EnrolledHostIDsFuncInvoked = true
+	s.mu.Unlock()
 	return s.EnrolledHostIDsFunc(ctx)
 }
 
 func (s *DataStore) CountEnrolledHosts(ctx context.Context) (int, error) {
+	s.mu.Lock()
 	s.CountEnrolledHostsFuncInvoked = true
+	s.mu.Unlock()
 	return s.CountEnrolledHostsFunc(ctx)
 }
 
 func (s *DataStore) CleanupIncomingHosts(ctx context.Context, now time.Time) ([]uint, error) {
+	s.mu.Lock()
 	s.CleanupIncomingHostsFuncInvoked = true
+	s.mu.Unlock()
 	return s.CleanupIncomingHostsFunc(ctx, now)
 }
 
 func (s *DataStore) GenerateHostStatusStatistics(ctx context.Context, filter fleet.TeamFilter, now time.Time, platform *string, lowDiskSpace *int) (*fleet.HostSummary, error) {
+	s.mu.Lock()
 	s.GenerateHostStatusStatisticsFuncInvoked = true
+	s.mu.Unlock()
 	return s.GenerateHostStatusStatisticsFunc(ctx, filter, now, platform, lowDiskSpace)
 }
 
 func (s *DataStore) HostIDsByName(ctx context.Context, filter fleet.TeamFilter, hostnames []string) ([]uint, error) {
+	s.mu.Lock()
 	s.HostIDsByNameFuncInvoked = true
+	s.mu.Unlock()
 	return s.HostIDsByNameFunc(ctx, filter, hostnames)
 }
 
 func (s *DataStore) HostIDsByOSID(ctx context.Context, osID uint, offset int, limit int) ([]uint, error) {
+	s.mu.Lock()
 	s.HostIDsByOSIDFuncInvoked = true
+	s.mu.Unlock()
 	return s.HostIDsByOSIDFunc(ctx, osID, offset, limit)
 }
 
 func (s *DataStore) HostIDsByOSVersion(ctx context.Context, osVersion fleet.OSVersion, offset int, limit int) ([]uint, error) {
+	s.mu.Lock()
 	s.HostIDsByOSVersionFuncInvoked = true
+	s.mu.Unlock()
 	return s.HostIDsByOSVersionFunc(ctx, osVersion, offset, limit)
 }
 
 func (s *DataStore) HostByIdentifier(ctx context.Context, identifier string) (*fleet.Host, error) {
+	s.mu.Lock()
 	s.HostByIdentifierFuncInvoked = true
+	s.mu.Unlock()
 	return s.HostByIdentifierFunc(ctx, identifier)
 }
 
 func (s *DataStore) AddHostsToTeam(ctx context.Context, teamID *uint, hostIDs []uint) error {
+	s.mu.Lock()
 	s.AddHostsToTeamFuncInvoked = true
+	s.mu.Unlock()
 	return s.AddHostsToTeamFunc(ctx, teamID, hostIDs)
 }
 
 func (s *DataStore) TotalAndUnseenHostsSince(ctx context.Context, daysCount int) (total int, unseen int, err error) {
+	s.mu.Lock()
 	s.TotalAndUnseenHostsSinceFuncInvoked = true
+	s.mu.Unlock()
 	return s.TotalAndUnseenHostsSinceFunc(ctx, daysCount)
 }
 
 func (s *DataStore) DeleteHosts(ctx context.Context, ids []uint) error {
+	s.mu.Lock()
 	s.DeleteHostsFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeleteHostsFunc(ctx, ids)
 }
 
 func (s *DataStore) CountHosts(ctx context.Context, filter fleet.TeamFilter, opt fleet.HostListOptions) (int, error) {
+	s.mu.Lock()
 	s.CountHostsFuncInvoked = true
+	s.mu.Unlock()
 	return s.CountHostsFunc(ctx, filter, opt)
 }
 
 func (s *DataStore) CountHostsInLabel(ctx context.Context, filter fleet.TeamFilter, lid uint, opt fleet.HostListOptions) (int, error) {
+	s.mu.Lock()
 	s.CountHostsInLabelFuncInvoked = true
+	s.mu.Unlock()
 	return s.CountHostsInLabelFunc(ctx, filter, lid, opt)
 }
 
 func (s *DataStore) ListHostDeviceMapping(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) {
+	s.mu.Lock()
 	s.ListHostDeviceMappingFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListHostDeviceMappingFunc(ctx, id)
 }
 
 func (s *DataStore) ListHostBatteries(ctx context.Context, id uint) ([]*fleet.HostBattery, error) {
+	s.mu.Lock()
 	s.ListHostBatteriesFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListHostBatteriesFunc(ctx, id)
 }
 
 func (s *DataStore) LoadHostByDeviceAuthToken(ctx context.Context, authToken string, tokenTTL time.Duration) (*fleet.Host, error) {
+	s.mu.Lock()
 	s.LoadHostByDeviceAuthTokenFuncInvoked = true
+	s.mu.Unlock()
 	return s.LoadHostByDeviceAuthTokenFunc(ctx, authToken, tokenTTL)
 }
 
 func (s *DataStore) SetOrUpdateDeviceAuthToken(ctx context.Context, hostID uint, authToken string) error {
+	s.mu.Lock()
 	s.SetOrUpdateDeviceAuthTokenFuncInvoked = true
+	s.mu.Unlock()
 	return s.SetOrUpdateDeviceAuthTokenFunc(ctx, hostID, authToken)
 }
 
 func (s *DataStore) FailingPoliciesCount(ctx context.Context, host *fleet.Host) (uint, error) {
+	s.mu.Lock()
 	s.FailingPoliciesCountFuncInvoked = true
+	s.mu.Unlock()
 	return s.FailingPoliciesCountFunc(ctx, host)
 }
 
 func (s *DataStore) ListPoliciesForHost(ctx context.Context, host *fleet.Host) ([]*fleet.HostPolicy, error) {
+	s.mu.Lock()
 	s.ListPoliciesForHostFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListPoliciesForHostFunc(ctx, host)
 }
 
 func (s *DataStore) GetHostMunkiVersion(ctx context.Context, hostID uint) (string, error) {
+	s.mu.Lock()
 	s.GetHostMunkiVersionFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetHostMunkiVersionFunc(ctx, hostID)
 }
 
 func (s *DataStore) GetHostMunkiIssues(ctx context.Context, hostID uint) ([]*fleet.HostMunkiIssue, error) {
+	s.mu.Lock()
 	s.GetHostMunkiIssuesFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetHostMunkiIssuesFunc(ctx, hostID)
 }
 
 func (s *DataStore) GetHostMDM(ctx context.Context, hostID uint) (*fleet.HostMDM, error) {
+	s.mu.Lock()
 	s.GetHostMDMFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetHostMDMFunc(ctx, hostID)
 }
 
 func (s *DataStore) GetHostMDMCheckinInfo(ctx context.Context, hostUUID string) (*fleet.HostMDMCheckinInfo, error) {
+	s.mu.Lock()
 	s.GetHostMDMCheckinInfoFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetHostMDMCheckinInfoFunc(ctx, hostUUID)
 }
 
 func (s *DataStore) AggregatedMunkiVersion(ctx context.Context, teamID *uint) ([]fleet.AggregatedMunkiVersion, time.Time, error) {
+	s.mu.Lock()
 	s.AggregatedMunkiVersionFuncInvoked = true
+	s.mu.Unlock()
 	return s.AggregatedMunkiVersionFunc(ctx, teamID)
 }
 
 func (s *DataStore) AggregatedMunkiIssues(ctx context.Context, teamID *uint) ([]fleet.AggregatedMunkiIssue, time.Time, error) {
+	s.mu.Lock()
 	s.AggregatedMunkiIssuesFuncInvoked = true
+	s.mu.Unlock()
 	return s.AggregatedMunkiIssuesFunc(ctx, teamID)
 }
 
 func (s *DataStore) AggregatedMDMStatus(ctx context.Context, teamID *uint, platform string) (fleet.AggregatedMDMStatus, time.Time, error) {
+	s.mu.Lock()
 	s.AggregatedMDMStatusFuncInvoked = true
+	s.mu.Unlock()
 	return s.AggregatedMDMStatusFunc(ctx, teamID, platform)
 }
 
 func (s *DataStore) AggregatedMDMSolutions(ctx context.Context, teamID *uint, platform string) ([]fleet.AggregatedMDMSolutions, time.Time, error) {
+	s.mu.Lock()
 	s.AggregatedMDMSolutionsFuncInvoked = true
+	s.mu.Unlock()
 	return s.AggregatedMDMSolutionsFunc(ctx, teamID, platform)
 }
 
 func (s *DataStore) GenerateAggregatedMunkiAndMDM(ctx context.Context) error {
+	s.mu.Lock()
 	s.GenerateAggregatedMunkiAndMDMFuncInvoked = true
+	s.mu.Unlock()
 	return s.GenerateAggregatedMunkiAndMDMFunc(ctx)
 }
 
 func (s *DataStore) GetMunkiIssue(ctx context.Context, munkiIssueID uint) (*fleet.MunkiIssue, error) {
+	s.mu.Lock()
 	s.GetMunkiIssueFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetMunkiIssueFunc(ctx, munkiIssueID)
 }
 
 func (s *DataStore) GetMDMSolution(ctx context.Context, mdmID uint) (*fleet.MDMSolution, error) {
+	s.mu.Lock()
 	s.GetMDMSolutionFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetMDMSolutionFunc(ctx, mdmID)
 }
 
 func (s *DataStore) OSVersions(ctx context.Context, teamID *uint, platform *string, name *string, version *string) (*fleet.OSVersions, error) {
+	s.mu.Lock()
 	s.OSVersionsFuncInvoked = true
+	s.mu.Unlock()
 	return s.OSVersionsFunc(ctx, teamID, platform, name, version)
 }
 
 func (s *DataStore) UpdateOSVersions(ctx context.Context) error {
+	s.mu.Lock()
 	s.UpdateOSVersionsFuncInvoked = true
+	s.mu.Unlock()
 	return s.UpdateOSVersionsFunc(ctx)
 }
 
 func (s *DataStore) CountHostsInTargets(ctx context.Context, filter fleet.TeamFilter, targets fleet.HostTargets, now time.Time) (fleet.TargetMetrics, error) {
+	s.mu.Lock()
 	s.CountHostsInTargetsFuncInvoked = true
+	s.mu.Unlock()
 	return s.CountHostsInTargetsFunc(ctx, filter, targets, now)
 }
 
 func (s *DataStore) HostIDsInTargets(ctx context.Context, filter fleet.TeamFilter, targets fleet.HostTargets) ([]uint, error) {
+	s.mu.Lock()
 	s.HostIDsInTargetsFuncInvoked = true
+	s.mu.Unlock()
 	return s.HostIDsInTargetsFunc(ctx, filter, targets)
 }
 
 func (s *DataStore) NewPasswordResetRequest(ctx context.Context, req *fleet.PasswordResetRequest) (*fleet.PasswordResetRequest, error) {
+	s.mu.Lock()
 	s.NewPasswordResetRequestFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewPasswordResetRequestFunc(ctx, req)
 }
 
 func (s *DataStore) DeletePasswordResetRequestsForUser(ctx context.Context, userID uint) error {
+	s.mu.Lock()
 	s.DeletePasswordResetRequestsForUserFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeletePasswordResetRequestsForUserFunc(ctx, userID)
 }
 
 func (s *DataStore) FindPasswordResetByToken(ctx context.Context, token string) (*fleet.PasswordResetRequest, error) {
+	s.mu.Lock()
 	s.FindPasswordResetByTokenFuncInvoked = true
+	s.mu.Unlock()
 	return s.FindPasswordResetByTokenFunc(ctx, token)
 }
 
 func (s *DataStore) CleanupExpiredPasswordResetRequests(ctx context.Context) error {
+	s.mu.Lock()
 	s.CleanupExpiredPasswordResetRequestsFuncInvoked = true
+	s.mu.Unlock()
 	return s.CleanupExpiredPasswordResetRequestsFunc(ctx)
 }
 
 func (s *DataStore) SessionByKey(ctx context.Context, key string) (*fleet.Session, error) {
+	s.mu.Lock()
 	s.SessionByKeyFuncInvoked = true
+	s.mu.Unlock()
 	return s.SessionByKeyFunc(ctx, key)
 }
 
 func (s *DataStore) SessionByID(ctx context.Context, id uint) (*fleet.Session, error) {
+	s.mu.Lock()
 	s.SessionByIDFuncInvoked = true
+	s.mu.Unlock()
 	return s.SessionByIDFunc(ctx, id)
 }
 
 func (s *DataStore) ListSessionsForUser(ctx context.Context, id uint) ([]*fleet.Session, error) {
+	s.mu.Lock()
 	s.ListSessionsForUserFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListSessionsForUserFunc(ctx, id)
 }
 
 func (s *DataStore) NewSession(ctx context.Context, userID uint, sessionKey string) (*fleet.Session, error) {
+	s.mu.Lock()
 	s.NewSessionFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewSessionFunc(ctx, userID, sessionKey)
 }
 
 func (s *DataStore) DestroySession(ctx context.Context, session *fleet.Session) error {
+	s.mu.Lock()
 	s.DestroySessionFuncInvoked = true
+	s.mu.Unlock()
 	return s.DestroySessionFunc(ctx, session)
 }
 
 func (s *DataStore) DestroyAllSessionsForUser(ctx context.Context, id uint) error {
+	s.mu.Lock()
 	s.DestroyAllSessionsForUserFuncInvoked = true
+	s.mu.Unlock()
 	return s.DestroyAllSessionsForUserFunc(ctx, id)
 }
 
 func (s *DataStore) MarkSessionAccessed(ctx context.Context, session *fleet.Session) error {
+	s.mu.Lock()
 	s.MarkSessionAccessedFuncInvoked = true
+	s.mu.Unlock()
 	return s.MarkSessionAccessedFunc(ctx, session)
 }
 
 func (s *DataStore) NewAppConfig(ctx context.Context, info *fleet.AppConfig) (*fleet.AppConfig, error) {
+	s.mu.Lock()
 	s.NewAppConfigFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewAppConfigFunc(ctx, info)
 }
 
 func (s *DataStore) AppConfig(ctx context.Context) (*fleet.AppConfig, error) {
+	s.mu.Lock()
 	s.AppConfigFuncInvoked = true
+	s.mu.Unlock()
 	return s.AppConfigFunc(ctx)
 }
 
 func (s *DataStore) SaveAppConfig(ctx context.Context, info *fleet.AppConfig) error {
+	s.mu.Lock()
 	s.SaveAppConfigFuncInvoked = true
+	s.mu.Unlock()
 	return s.SaveAppConfigFunc(ctx, info)
 }
 
 func (s *DataStore) GetEnrollSecrets(ctx context.Context, teamID *uint) ([]*fleet.EnrollSecret, error) {
+	s.mu.Lock()
 	s.GetEnrollSecretsFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetEnrollSecretsFunc(ctx, teamID)
 }
 
 func (s *DataStore) ApplyEnrollSecrets(ctx context.Context, teamID *uint, secrets []*fleet.EnrollSecret) error {
+	s.mu.Lock()
 	s.ApplyEnrollSecretsFuncInvoked = true
+	s.mu.Unlock()
 	return s.ApplyEnrollSecretsFunc(ctx, teamID, secrets)
 }
 
 func (s *DataStore) NewInvite(ctx context.Context, i *fleet.Invite) (*fleet.Invite, error) {
+	s.mu.Lock()
 	s.NewInviteFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewInviteFunc(ctx, i)
 }
 
 func (s *DataStore) ListInvites(ctx context.Context, opt fleet.ListOptions) ([]*fleet.Invite, error) {
+	s.mu.Lock()
 	s.ListInvitesFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListInvitesFunc(ctx, opt)
 }
 
 func (s *DataStore) Invite(ctx context.Context, id uint) (*fleet.Invite, error) {
+	s.mu.Lock()
 	s.InviteFuncInvoked = true
+	s.mu.Unlock()
 	return s.InviteFunc(ctx, id)
 }
 
 func (s *DataStore) InviteByEmail(ctx context.Context, email string) (*fleet.Invite, error) {
+	s.mu.Lock()
 	s.InviteByEmailFuncInvoked = true
+	s.mu.Unlock()
 	return s.InviteByEmailFunc(ctx, email)
 }
 
 func (s *DataStore) InviteByToken(ctx context.Context, token string) (*fleet.Invite, error) {
+	s.mu.Lock()
 	s.InviteByTokenFuncInvoked = true
+	s.mu.Unlock()
 	return s.InviteByTokenFunc(ctx, token)
 }
 
 func (s *DataStore) DeleteInvite(ctx context.Context, id uint) error {
+	s.mu.Lock()
 	s.DeleteInviteFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeleteInviteFunc(ctx, id)
 }
 
 func (s *DataStore) UpdateInvite(ctx context.Context, id uint, i *fleet.Invite) (*fleet.Invite, error) {
+	s.mu.Lock()
 	s.UpdateInviteFuncInvoked = true
+	s.mu.Unlock()
 	return s.UpdateInviteFunc(ctx, id, i)
 }
 
 func (s *DataStore) ListScheduledQueriesInPackWithStats(ctx context.Context, id uint, opts fleet.ListOptions) ([]*fleet.ScheduledQuery, error) {
+	s.mu.Lock()
 	s.ListScheduledQueriesInPackWithStatsFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListScheduledQueriesInPackWithStatsFunc(ctx, id, opts)
 }
 
 func (s *DataStore) NewScheduledQuery(ctx context.Context, sq *fleet.ScheduledQuery, opts ...fleet.OptionalArg) (*fleet.ScheduledQuery, error) {
+	s.mu.Lock()
 	s.NewScheduledQueryFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewScheduledQueryFunc(ctx, sq, opts...)
 }
 
 func (s *DataStore) SaveScheduledQuery(ctx context.Context, sq *fleet.ScheduledQuery) (*fleet.ScheduledQuery, error) {
+	s.mu.Lock()
 	s.SaveScheduledQueryFuncInvoked = true
+	s.mu.Unlock()
 	return s.SaveScheduledQueryFunc(ctx, sq)
 }
 
 func (s *DataStore) DeleteScheduledQuery(ctx context.Context, id uint) error {
+	s.mu.Lock()
 	s.DeleteScheduledQueryFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeleteScheduledQueryFunc(ctx, id)
 }
 
 func (s *DataStore) ScheduledQuery(ctx context.Context, id uint) (*fleet.ScheduledQuery, error) {
+	s.mu.Lock()
 	s.ScheduledQueryFuncInvoked = true
+	s.mu.Unlock()
 	return s.ScheduledQueryFunc(ctx, id)
 }
 
 func (s *DataStore) CleanupExpiredHosts(ctx context.Context) ([]uint, error) {
+	s.mu.Lock()
 	s.CleanupExpiredHostsFuncInvoked = true
+	s.mu.Unlock()
 	return s.CleanupExpiredHostsFunc(ctx)
 }
 
 func (s *DataStore) ScheduledQueryIDsByName(ctx context.Context, batchSize int, packAndSchedQueryNames ...[2]string) ([]uint, error) {
+	s.mu.Lock()
 	s.ScheduledQueryIDsByNameFuncInvoked = true
+	s.mu.Unlock()
 	return s.ScheduledQueryIDsByNameFunc(ctx, batchSize, packAndSchedQueryNames...)
 }
 
 func (s *DataStore) NewTeam(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+	s.mu.Lock()
 	s.NewTeamFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewTeamFunc(ctx, team)
 }
 
 func (s *DataStore) SaveTeam(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+	s.mu.Lock()
 	s.SaveTeamFuncInvoked = true
+	s.mu.Unlock()
 	return s.SaveTeamFunc(ctx, team)
 }
 
 func (s *DataStore) Team(ctx context.Context, tid uint) (*fleet.Team, error) {
+	s.mu.Lock()
 	s.TeamFuncInvoked = true
+	s.mu.Unlock()
 	return s.TeamFunc(ctx, tid)
 }
 
 func (s *DataStore) DeleteTeam(ctx context.Context, tid uint) error {
+	s.mu.Lock()
 	s.DeleteTeamFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeleteTeamFunc(ctx, tid)
 }
 
 func (s *DataStore) TeamByName(ctx context.Context, name string) (*fleet.Team, error) {
+	s.mu.Lock()
 	s.TeamByNameFuncInvoked = true
+	s.mu.Unlock()
 	return s.TeamByNameFunc(ctx, name)
 }
 
 func (s *DataStore) ListTeams(ctx context.Context, filter fleet.TeamFilter, opt fleet.ListOptions) ([]*fleet.Team, error) {
+	s.mu.Lock()
 	s.ListTeamsFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListTeamsFunc(ctx, filter, opt)
 }
 
 func (s *DataStore) TeamsSummary(ctx context.Context) ([]*fleet.TeamSummary, error) {
+	s.mu.Lock()
 	s.TeamsSummaryFuncInvoked = true
+	s.mu.Unlock()
 	return s.TeamsSummaryFunc(ctx)
 }
 
 func (s *DataStore) SearchTeams(ctx context.Context, filter fleet.TeamFilter, matchQuery string, omit ...uint) ([]*fleet.Team, error) {
+	s.mu.Lock()
 	s.SearchTeamsFuncInvoked = true
+	s.mu.Unlock()
 	return s.SearchTeamsFunc(ctx, filter, matchQuery, omit...)
 }
 
 func (s *DataStore) TeamEnrollSecrets(ctx context.Context, teamID uint) ([]*fleet.EnrollSecret, error) {
+	s.mu.Lock()
 	s.TeamEnrollSecretsFuncInvoked = true
+	s.mu.Unlock()
 	return s.TeamEnrollSecretsFunc(ctx, teamID)
 }
 
 func (s *DataStore) DeleteIntegrationsFromTeams(ctx context.Context, deletedIntgs fleet.Integrations) error {
+	s.mu.Lock()
 	s.DeleteIntegrationsFromTeamsFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeleteIntegrationsFromTeamsFunc(ctx, deletedIntgs)
 }
 
 func (s *DataStore) ListSoftwareForVulnDetection(ctx context.Context, hostID uint) ([]fleet.Software, error) {
+	s.mu.Lock()
 	s.ListSoftwareForVulnDetectionFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListSoftwareForVulnDetectionFunc(ctx, hostID)
 }
 
 func (s *DataStore) ListSoftwareVulnerabilitiesByHostIDsSource(ctx context.Context, hostIDs []uint, source fleet.VulnerabilitySource) (map[uint][]fleet.SoftwareVulnerability, error) {
+	s.mu.Lock()
 	s.ListSoftwareVulnerabilitiesByHostIDsSourceFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListSoftwareVulnerabilitiesByHostIDsSourceFunc(ctx, hostIDs, source)
 }
 
 func (s *DataStore) LoadHostSoftware(ctx context.Context, host *fleet.Host, includeCVEScores bool) error {
+	s.mu.Lock()
 	s.LoadHostSoftwareFuncInvoked = true
+	s.mu.Unlock()
 	return s.LoadHostSoftwareFunc(ctx, host, includeCVEScores)
 }
 
 func (s *DataStore) AllSoftwareWithoutCPEIterator(ctx context.Context, excludedPlatforms []string) (fleet.SoftwareIterator, error) {
+	s.mu.Lock()
 	s.AllSoftwareWithoutCPEIteratorFuncInvoked = true
+	s.mu.Unlock()
 	return s.AllSoftwareWithoutCPEIteratorFunc(ctx, excludedPlatforms)
 }
 
 func (s *DataStore) AddCPEForSoftware(ctx context.Context, software fleet.Software, cpe string) error {
+	s.mu.Lock()
 	s.AddCPEForSoftwareFuncInvoked = true
+	s.mu.Unlock()
 	return s.AddCPEForSoftwareFunc(ctx, software, cpe)
 }
 
 func (s *DataStore) ListSoftwareCPEs(ctx context.Context) ([]fleet.SoftwareCPE, error) {
+	s.mu.Lock()
 	s.ListSoftwareCPEsFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListSoftwareCPEsFunc(ctx)
 }
 
 func (s *DataStore) InsertSoftwareVulnerabilities(ctx context.Context, vulns []fleet.SoftwareVulnerability, source fleet.VulnerabilitySource) (int64, error) {
+	s.mu.Lock()
 	s.InsertSoftwareVulnerabilitiesFuncInvoked = true
+	s.mu.Unlock()
 	return s.InsertSoftwareVulnerabilitiesFunc(ctx, vulns, source)
 }
 
 func (s *DataStore) SoftwareByID(ctx context.Context, id uint, includeCVEScores bool) (*fleet.Software, error) {
+	s.mu.Lock()
 	s.SoftwareByIDFuncInvoked = true
+	s.mu.Unlock()
 	return s.SoftwareByIDFunc(ctx, id, includeCVEScores)
 }
 
 func (s *DataStore) ListSoftwareByHostIDShort(ctx context.Context, hostID uint) ([]fleet.Software, error) {
+	s.mu.Lock()
 	s.ListSoftwareByHostIDShortFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListSoftwareByHostIDShortFunc(ctx, hostID)
 }
 
 func (s *DataStore) SyncHostsSoftware(ctx context.Context, updatedAt time.Time) error {
+	s.mu.Lock()
 	s.SyncHostsSoftwareFuncInvoked = true
+	s.mu.Unlock()
 	return s.SyncHostsSoftwareFunc(ctx, updatedAt)
 }
 
 func (s *DataStore) HostsBySoftwareIDs(ctx context.Context, softwareIDs []uint) ([]*fleet.HostShort, error) {
+	s.mu.Lock()
 	s.HostsBySoftwareIDsFuncInvoked = true
+	s.mu.Unlock()
 	return s.HostsBySoftwareIDsFunc(ctx, softwareIDs)
 }
 
 func (s *DataStore) HostsByCVE(ctx context.Context, cve string) ([]*fleet.HostShort, error) {
+	s.mu.Lock()
 	s.HostsByCVEFuncInvoked = true
+	s.mu.Unlock()
 	return s.HostsByCVEFunc(ctx, cve)
 }
 
 func (s *DataStore) InsertCVEMeta(ctx context.Context, cveMeta []fleet.CVEMeta) error {
+	s.mu.Lock()
 	s.InsertCVEMetaFuncInvoked = true
+	s.mu.Unlock()
 	return s.InsertCVEMetaFunc(ctx, cveMeta)
 }
 
 func (s *DataStore) ListCVEs(ctx context.Context, maxAge time.Duration) ([]fleet.CVEMeta, error) {
+	s.mu.Lock()
 	s.ListCVEsFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListCVEsFunc(ctx, maxAge)
 }
 
 func (s *DataStore) ListOperatingSystems(ctx context.Context) ([]fleet.OperatingSystem, error) {
+	s.mu.Lock()
 	s.ListOperatingSystemsFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListOperatingSystemsFunc(ctx)
 }
 
 func (s *DataStore) UpdateHostOperatingSystem(ctx context.Context, hostID uint, hostOS fleet.OperatingSystem) error {
+	s.mu.Lock()
 	s.UpdateHostOperatingSystemFuncInvoked = true
+	s.mu.Unlock()
 	return s.UpdateHostOperatingSystemFunc(ctx, hostID, hostOS)
 }
 
 func (s *DataStore) CleanupHostOperatingSystems(ctx context.Context) error {
+	s.mu.Lock()
 	s.CleanupHostOperatingSystemsFuncInvoked = true
+	s.mu.Unlock()
 	return s.CleanupHostOperatingSystemsFunc(ctx)
 }
 
 func (s *DataStore) UpdateHostTablesOnMDMUnenroll(ctx context.Context, uuid string) error {
+	s.mu.Lock()
 	s.UpdateHostTablesOnMDMUnenrollFuncInvoked = true
+	s.mu.Unlock()
 	return s.UpdateHostTablesOnMDMUnenrollFunc(ctx, uuid)
 }
 
 func (s *DataStore) NewActivity(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+	s.mu.Lock()
 	s.NewActivityFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewActivityFunc(ctx, user, activity)
 }
 
 func (s *DataStore) ListActivities(ctx context.Context, opt fleet.ListActivitiesOptions) ([]*fleet.Activity, *fleet.PaginationMetadata, error) {
+	s.mu.Lock()
 	s.ListActivitiesFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListActivitiesFunc(ctx, opt)
 }
 
 func (s *DataStore) MarkActivitiesAsStreamed(ctx context.Context, activityIDs []uint) error {
+	s.mu.Lock()
 	s.MarkActivitiesAsStreamedFuncInvoked = true
+	s.mu.Unlock()
 	return s.MarkActivitiesAsStreamedFunc(ctx, activityIDs)
 }
 
 func (s *DataStore) ShouldSendStatistics(ctx context.Context, frequency time.Duration, config config.FleetConfig) (fleet.StatisticsPayload, bool, error) {
+	s.mu.Lock()
 	s.ShouldSendStatisticsFuncInvoked = true
+	s.mu.Unlock()
 	return s.ShouldSendStatisticsFunc(ctx, frequency, config)
 }
 
 func (s *DataStore) RecordStatisticsSent(ctx context.Context) error {
+	s.mu.Lock()
 	s.RecordStatisticsSentFuncInvoked = true
+	s.mu.Unlock()
 	return s.RecordStatisticsSentFunc(ctx)
 }
 
 func (s *DataStore) CleanupStatistics(ctx context.Context) error {
+	s.mu.Lock()
 	s.CleanupStatisticsFuncInvoked = true
+	s.mu.Unlock()
 	return s.CleanupStatisticsFunc(ctx)
 }
 
 func (s *DataStore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs []*fleet.PolicySpec) error {
+	s.mu.Lock()
 	s.ApplyPolicySpecsFuncInvoked = true
+	s.mu.Unlock()
 	return s.ApplyPolicySpecsFunc(ctx, authorID, specs)
 }
 
 func (s *DataStore) NewGlobalPolicy(ctx context.Context, authorID *uint, args fleet.PolicyPayload) (*fleet.Policy, error) {
+	s.mu.Lock()
 	s.NewGlobalPolicyFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewGlobalPolicyFunc(ctx, authorID, args)
 }
 
 func (s *DataStore) Policy(ctx context.Context, id uint) (*fleet.Policy, error) {
+	s.mu.Lock()
 	s.PolicyFuncInvoked = true
+	s.mu.Unlock()
 	return s.PolicyFunc(ctx, id)
 }
 
 func (s *DataStore) SavePolicy(ctx context.Context, p *fleet.Policy) error {
+	s.mu.Lock()
 	s.SavePolicyFuncInvoked = true
+	s.mu.Unlock()
 	return s.SavePolicyFunc(ctx, p)
 }
 
 func (s *DataStore) ListGlobalPolicies(ctx context.Context) ([]*fleet.Policy, error) {
+	s.mu.Lock()
 	s.ListGlobalPoliciesFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListGlobalPoliciesFunc(ctx)
 }
 
 func (s *DataStore) PoliciesByID(ctx context.Context, ids []uint) (map[uint]*fleet.Policy, error) {
+	s.mu.Lock()
 	s.PoliciesByIDFuncInvoked = true
+	s.mu.Unlock()
 	return s.PoliciesByIDFunc(ctx, ids)
 }
 
 func (s *DataStore) DeleteGlobalPolicies(ctx context.Context, ids []uint) ([]uint, error) {
+	s.mu.Lock()
 	s.DeleteGlobalPoliciesFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeleteGlobalPoliciesFunc(ctx, ids)
 }
 
 func (s *DataStore) PolicyQueriesForHost(ctx context.Context, host *fleet.Host) (map[string]string, error) {
+	s.mu.Lock()
 	s.PolicyQueriesForHostFuncInvoked = true
+	s.mu.Unlock()
 	return s.PolicyQueriesForHostFunc(ctx, host)
 }
 
 func (s *DataStore) AsyncBatchInsertPolicyMembership(ctx context.Context, batch []fleet.PolicyMembershipResult) error {
+	s.mu.Lock()
 	s.AsyncBatchInsertPolicyMembershipFuncInvoked = true
+	s.mu.Unlock()
 	return s.AsyncBatchInsertPolicyMembershipFunc(ctx, batch)
 }
 
 func (s *DataStore) AsyncBatchUpdatePolicyTimestamp(ctx context.Context, ids []uint, ts time.Time) error {
+	s.mu.Lock()
 	s.AsyncBatchUpdatePolicyTimestampFuncInvoked = true
+	s.mu.Unlock()
 	return s.AsyncBatchUpdatePolicyTimestampFunc(ctx, ids, ts)
 }
 
 func (s *DataStore) MigrateTables(ctx context.Context) error {
+	s.mu.Lock()
 	s.MigrateTablesFuncInvoked = true
+	s.mu.Unlock()
 	return s.MigrateTablesFunc(ctx)
 }
 
 func (s *DataStore) MigrateData(ctx context.Context) error {
+	s.mu.Lock()
 	s.MigrateDataFuncInvoked = true
+	s.mu.Unlock()
 	return s.MigrateDataFunc(ctx)
 }
 
 func (s *DataStore) MigrationStatus(ctx context.Context) (*fleet.MigrationStatus, error) {
+	s.mu.Lock()
 	s.MigrationStatusFuncInvoked = true
+	s.mu.Unlock()
 	return s.MigrationStatusFunc(ctx)
 }
 
 func (s *DataStore) ListSoftware(ctx context.Context, opt fleet.SoftwareListOptions) ([]fleet.Software, error) {
+	s.mu.Lock()
 	s.ListSoftwareFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListSoftwareFunc(ctx, opt)
 }
 
 func (s *DataStore) CountSoftware(ctx context.Context, opt fleet.SoftwareListOptions) (int, error) {
+	s.mu.Lock()
 	s.CountSoftwareFuncInvoked = true
+	s.mu.Unlock()
 	return s.CountSoftwareFunc(ctx, opt)
 }
 
 func (s *DataStore) DeleteSoftwareVulnerabilities(ctx context.Context, vulnerabilities []fleet.SoftwareVulnerability) error {
+	s.mu.Lock()
 	s.DeleteSoftwareVulnerabilitiesFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeleteSoftwareVulnerabilitiesFunc(ctx, vulnerabilities)
 }
 
 func (s *DataStore) NewTeamPolicy(ctx context.Context, teamID uint, authorID *uint, args fleet.PolicyPayload) (*fleet.Policy, error) {
+	s.mu.Lock()
 	s.NewTeamPolicyFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewTeamPolicyFunc(ctx, teamID, authorID, args)
 }
 
 func (s *DataStore) ListTeamPolicies(ctx context.Context, teamID uint) (teamPolicies []*fleet.Policy, inheritedPolicies []*fleet.Policy, err error) {
+	s.mu.Lock()
 	s.ListTeamPoliciesFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListTeamPoliciesFunc(ctx, teamID)
 }
 
 func (s *DataStore) DeleteTeamPolicies(ctx context.Context, teamID uint, ids []uint) ([]uint, error) {
+	s.mu.Lock()
 	s.DeleteTeamPoliciesFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeleteTeamPoliciesFunc(ctx, teamID, ids)
 }
 
 func (s *DataStore) TeamPolicy(ctx context.Context, teamID uint, policyID uint) (*fleet.Policy, error) {
+	s.mu.Lock()
 	s.TeamPolicyFuncInvoked = true
+	s.mu.Unlock()
 	return s.TeamPolicyFunc(ctx, teamID, policyID)
 }
 
 func (s *DataStore) CleanupPolicyMembership(ctx context.Context, now time.Time) error {
+	s.mu.Lock()
 	s.CleanupPolicyMembershipFuncInvoked = true
+	s.mu.Unlock()
 	return s.CleanupPolicyMembershipFunc(ctx, now)
 }
 
 func (s *DataStore) IncrementPolicyViolationDays(ctx context.Context) error {
+	s.mu.Lock()
 	s.IncrementPolicyViolationDaysFuncInvoked = true
+	s.mu.Unlock()
 	return s.IncrementPolicyViolationDaysFunc(ctx)
 }
 
 func (s *DataStore) InitializePolicyViolationDays(ctx context.Context) error {
+	s.mu.Lock()
 	s.InitializePolicyViolationDaysFuncInvoked = true
+	s.mu.Unlock()
 	return s.InitializePolicyViolationDaysFunc(ctx)
 }
 
 func (s *DataStore) Lock(ctx context.Context, name string, owner string, expiration time.Duration) (bool, error) {
+	s.mu.Lock()
 	s.LockFuncInvoked = true
+	s.mu.Unlock()
 	return s.LockFunc(ctx, name, owner, expiration)
 }
 
 func (s *DataStore) Unlock(ctx context.Context, name string, owner string) error {
+	s.mu.Lock()
 	s.UnlockFuncInvoked = true
+	s.mu.Unlock()
 	return s.UnlockFunc(ctx, name, owner)
 }
 
 func (s *DataStore) DBLocks(ctx context.Context) ([]*fleet.DBLock, error) {
+	s.mu.Lock()
 	s.DBLocksFuncInvoked = true
+	s.mu.Unlock()
 	return s.DBLocksFunc(ctx)
 }
 
 func (s *DataStore) GetLatestCronStats(ctx context.Context, name string) ([]fleet.CronStats, error) {
+	s.mu.Lock()
 	s.GetLatestCronStatsFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetLatestCronStatsFunc(ctx, name)
 }
 
 func (s *DataStore) InsertCronStats(ctx context.Context, statsType fleet.CronStatsType, name string, instance string, status fleet.CronStatsStatus) (int, error) {
+	s.mu.Lock()
 	s.InsertCronStatsFuncInvoked = true
+	s.mu.Unlock()
 	return s.InsertCronStatsFunc(ctx, statsType, name, instance, status)
 }
 
 func (s *DataStore) UpdateCronStats(ctx context.Context, id int, status fleet.CronStatsStatus) error {
+	s.mu.Lock()
 	s.UpdateCronStatsFuncInvoked = true
+	s.mu.Unlock()
 	return s.UpdateCronStatsFunc(ctx, id, status)
 }
 
 func (s *DataStore) UpdateAllCronStatsForInstance(ctx context.Context, instance string, fromStatus fleet.CronStatsStatus, toStatus fleet.CronStatsStatus) error {
+	s.mu.Lock()
 	s.UpdateAllCronStatsForInstanceFuncInvoked = true
+	s.mu.Unlock()
 	return s.UpdateAllCronStatsForInstanceFunc(ctx, instance, fromStatus, toStatus)
 }
 
 func (s *DataStore) CleanupCronStats(ctx context.Context) error {
+	s.mu.Lock()
 	s.CleanupCronStatsFuncInvoked = true
+	s.mu.Unlock()
 	return s.CleanupCronStatsFunc(ctx)
 }
 
 func (s *DataStore) UpdateScheduledQueryAggregatedStats(ctx context.Context) error {
+	s.mu.Lock()
 	s.UpdateScheduledQueryAggregatedStatsFuncInvoked = true
+	s.mu.Unlock()
 	return s.UpdateScheduledQueryAggregatedStatsFunc(ctx)
 }
 
 func (s *DataStore) UpdateQueryAggregatedStats(ctx context.Context) error {
+	s.mu.Lock()
 	s.UpdateQueryAggregatedStatsFuncInvoked = true
+	s.mu.Unlock()
 	return s.UpdateQueryAggregatedStatsFunc(ctx)
 }
 
 func (s *DataStore) LoadHostByNodeKey(ctx context.Context, nodeKey string) (*fleet.Host, error) {
+	s.mu.Lock()
 	s.LoadHostByNodeKeyFuncInvoked = true
+	s.mu.Unlock()
 	return s.LoadHostByNodeKeyFunc(ctx, nodeKey)
 }
 
 func (s *DataStore) LoadHostByOrbitNodeKey(ctx context.Context, nodeKey string) (*fleet.Host, error) {
+	s.mu.Lock()
 	s.LoadHostByOrbitNodeKeyFuncInvoked = true
+	s.mu.Unlock()
 	return s.LoadHostByOrbitNodeKeyFunc(ctx, nodeKey)
 }
 
 func (s *DataStore) HostLite(ctx context.Context, hostID uint) (*fleet.Host, error) {
+	s.mu.Lock()
 	s.HostLiteFuncInvoked = true
+	s.mu.Unlock()
 	return s.HostLiteFunc(ctx, hostID)
 }
 
 func (s *DataStore) UpdateHostOsqueryIntervals(ctx context.Context, hostID uint, intervals fleet.HostOsqueryIntervals) error {
+	s.mu.Lock()
 	s.UpdateHostOsqueryIntervalsFuncInvoked = true
+	s.mu.Unlock()
 	return s.UpdateHostOsqueryIntervalsFunc(ctx, hostID, intervals)
 }
 
 func (s *DataStore) TeamAgentOptions(ctx context.Context, teamID uint) (*json.RawMessage, error) {
+	s.mu.Lock()
 	s.TeamAgentOptionsFuncInvoked = true
+	s.mu.Unlock()
 	return s.TeamAgentOptionsFunc(ctx, teamID)
 }
 
 func (s *DataStore) TeamFeatures(ctx context.Context, teamID uint) (*fleet.Features, error) {
+	s.mu.Lock()
 	s.TeamFeaturesFuncInvoked = true
+	s.mu.Unlock()
 	return s.TeamFeaturesFunc(ctx, teamID)
 }
 
 func (s *DataStore) TeamMDMConfig(ctx context.Context, teamID uint) (*fleet.TeamMDM, error) {
+	s.mu.Lock()
 	s.TeamMDMConfigFuncInvoked = true
+	s.mu.Unlock()
 	return s.TeamMDMConfigFunc(ctx, teamID)
 }
 
 func (s *DataStore) SaveHostPackStats(ctx context.Context, hostID uint, stats []fleet.PackStats) error {
+	s.mu.Lock()
 	s.SaveHostPackStatsFuncInvoked = true
+	s.mu.Unlock()
 	return s.SaveHostPackStatsFunc(ctx, hostID, stats)
 }
 
 func (s *DataStore) AsyncBatchSaveHostsScheduledQueryStats(ctx context.Context, stats map[uint][]fleet.ScheduledQueryStats, batchSize int) (int, error) {
+	s.mu.Lock()
 	s.AsyncBatchSaveHostsScheduledQueryStatsFuncInvoked = true
+	s.mu.Unlock()
 	return s.AsyncBatchSaveHostsScheduledQueryStatsFunc(ctx, stats, batchSize)
 }
 
 func (s *DataStore) UpdateHostSoftware(ctx context.Context, hostID uint, software []fleet.Software) error {
+	s.mu.Lock()
 	s.UpdateHostSoftwareFuncInvoked = true
+	s.mu.Unlock()
 	return s.UpdateHostSoftwareFunc(ctx, hostID, software)
 }
 
 func (s *DataStore) UpdateHost(ctx context.Context, host *fleet.Host) error {
+	s.mu.Lock()
 	s.UpdateHostFuncInvoked = true
+	s.mu.Unlock()
 	return s.UpdateHostFunc(ctx, host)
 }
 
 func (s *DataStore) ListScheduledQueriesInPack(ctx context.Context, packID uint) (fleet.ScheduledQueryList, error) {
+	s.mu.Lock()
 	s.ListScheduledQueriesInPackFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListScheduledQueriesInPackFunc(ctx, packID)
 }
 
 func (s *DataStore) UpdateHostRefetchRequested(ctx context.Context, hostID uint, value bool) error {
+	s.mu.Lock()
 	s.UpdateHostRefetchRequestedFuncInvoked = true
+	s.mu.Unlock()
 	return s.UpdateHostRefetchRequestedFunc(ctx, hostID, value)
 }
 
 func (s *DataStore) FlippingPoliciesForHost(ctx context.Context, hostID uint, incomingResults map[uint]*bool) (newFailing []uint, newPassing []uint, err error) {
+	s.mu.Lock()
 	s.FlippingPoliciesForHostFuncInvoked = true
+	s.mu.Unlock()
 	return s.FlippingPoliciesForHostFunc(ctx, hostID, incomingResults)
 }
 
 func (s *DataStore) RecordPolicyQueryExecutions(ctx context.Context, host *fleet.Host, results map[uint]*bool, updated time.Time, deferredSaveHost bool) error {
+	s.mu.Lock()
 	s.RecordPolicyQueryExecutionsFuncInvoked = true
+	s.mu.Unlock()
 	return s.RecordPolicyQueryExecutionsFunc(ctx, host, results, updated, deferredSaveHost)
 }
 
 func (s *DataStore) RecordLabelQueryExecutions(ctx context.Context, host *fleet.Host, results map[uint]*bool, t time.Time, deferredSaveHost bool) error {
+	s.mu.Lock()
 	s.RecordLabelQueryExecutionsFuncInvoked = true
+	s.mu.Unlock()
 	return s.RecordLabelQueryExecutionsFunc(ctx, host, results, t, deferredSaveHost)
 }
 
 func (s *DataStore) SaveHostUsers(ctx context.Context, hostID uint, users []fleet.HostUser) error {
+	s.mu.Lock()
 	s.SaveHostUsersFuncInvoked = true
+	s.mu.Unlock()
 	return s.SaveHostUsersFunc(ctx, hostID, users)
 }
 
 func (s *DataStore) SaveHostAdditional(ctx context.Context, hostID uint, additional *json.RawMessage) error {
+	s.mu.Lock()
 	s.SaveHostAdditionalFuncInvoked = true
+	s.mu.Unlock()
 	return s.SaveHostAdditionalFunc(ctx, hostID, additional)
 }
 
 func (s *DataStore) SetOrUpdateMunkiInfo(ctx context.Context, hostID uint, version string, errors []string, warnings []string) error {
+	s.mu.Lock()
 	s.SetOrUpdateMunkiInfoFuncInvoked = true
+	s.mu.Unlock()
 	return s.SetOrUpdateMunkiInfoFunc(ctx, hostID, version, errors, warnings)
 }
 
 func (s *DataStore) SetOrUpdateMDMData(ctx context.Context, hostID uint, isServer bool, enrolled bool, serverURL string, installedFromDep bool, name string) error {
+	s.mu.Lock()
 	s.SetOrUpdateMDMDataFuncInvoked = true
+	s.mu.Unlock()
 	return s.SetOrUpdateMDMDataFunc(ctx, hostID, isServer, enrolled, serverURL, installedFromDep, name)
 }
 
 func (s *DataStore) SetOrUpdateHostDisksSpace(ctx context.Context, hostID uint, gigsAvailable float64, percentAvailable float64) error {
+	s.mu.Lock()
 	s.SetOrUpdateHostDisksSpaceFuncInvoked = true
+	s.mu.Unlock()
 	return s.SetOrUpdateHostDisksSpaceFunc(ctx, hostID, gigsAvailable, percentAvailable)
 }
 
 func (s *DataStore) SetOrUpdateHostDisksEncryption(ctx context.Context, hostID uint, encrypted bool) error {
+	s.mu.Lock()
 	s.SetOrUpdateHostDisksEncryptionFuncInvoked = true
+	s.mu.Unlock()
 	return s.SetOrUpdateHostDisksEncryptionFunc(ctx, hostID, encrypted)
 }
 
 func (s *DataStore) SetOrUpdateHostDiskEncryptionKey(ctx context.Context, hostID uint, encryptedBase64Key string) error {
+	s.mu.Lock()
 	s.SetOrUpdateHostDiskEncryptionKeyFuncInvoked = true
+	s.mu.Unlock()
 	return s.SetOrUpdateHostDiskEncryptionKeyFunc(ctx, hostID, encryptedBase64Key)
 }
 
 func (s *DataStore) GetUnverifiedDiskEncryptionKeys(ctx context.Context) ([]fleet.HostDiskEncryptionKey, error) {
+	s.mu.Lock()
 	s.GetUnverifiedDiskEncryptionKeysFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetUnverifiedDiskEncryptionKeysFunc(ctx)
 }
 
 func (s *DataStore) SetHostsDiskEncryptionKeyStatus(ctx context.Context, hostIDs []uint, encryptable bool, threshold time.Time) error {
+	s.mu.Lock()
 	s.SetHostsDiskEncryptionKeyStatusFuncInvoked = true
+	s.mu.Unlock()
 	return s.SetHostsDiskEncryptionKeyStatusFunc(ctx, hostIDs, encryptable, threshold)
 }
 
 func (s *DataStore) GetHostDiskEncryptionKey(ctx context.Context, hostID uint) (*fleet.HostDiskEncryptionKey, error) {
+	s.mu.Lock()
 	s.GetHostDiskEncryptionKeyFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetHostDiskEncryptionKeyFunc(ctx, hostID)
 }
 
 func (s *DataStore) SetOrUpdateHostOrbitInfo(ctx context.Context, hostID uint, version string) error {
+	s.mu.Lock()
 	s.SetOrUpdateHostOrbitInfoFuncInvoked = true
+	s.mu.Unlock()
 	return s.SetOrUpdateHostOrbitInfoFunc(ctx, hostID, version)
 }
 
 func (s *DataStore) ReplaceHostDeviceMapping(ctx context.Context, id uint, mappings []*fleet.HostDeviceMapping) error {
+	s.mu.Lock()
 	s.ReplaceHostDeviceMappingFuncInvoked = true
+	s.mu.Unlock()
 	return s.ReplaceHostDeviceMappingFunc(ctx, id, mappings)
 }
 
 func (s *DataStore) ReplaceHostBatteries(ctx context.Context, id uint, mappings []*fleet.HostBattery) error {
+	s.mu.Lock()
 	s.ReplaceHostBatteriesFuncInvoked = true
+	s.mu.Unlock()
 	return s.ReplaceHostBatteriesFunc(ctx, id, mappings)
 }
 
 func (s *DataStore) VerifyEnrollSecret(ctx context.Context, secret string) (*fleet.EnrollSecret, error) {
+	s.mu.Lock()
 	s.VerifyEnrollSecretFuncInvoked = true
+	s.mu.Unlock()
 	return s.VerifyEnrollSecretFunc(ctx, secret)
 }
 
 func (s *DataStore) EnrollHost(ctx context.Context, osqueryHostId string, nodeKey string, teamID *uint, cooldown time.Duration) (*fleet.Host, error) {
+	s.mu.Lock()
 	s.EnrollHostFuncInvoked = true
+	s.mu.Unlock()
 	return s.EnrollHostFunc(ctx, osqueryHostId, nodeKey, teamID, cooldown)
 }
 
 func (s *DataStore) EnrollOrbit(ctx context.Context, hardwareUUID string, orbitNodeKey string, teamID *uint) (*fleet.Host, error) {
+	s.mu.Lock()
 	s.EnrollOrbitFuncInvoked = true
+	s.mu.Unlock()
 	return s.EnrollOrbitFunc(ctx, hardwareUUID, orbitNodeKey, teamID)
 }
 
 func (s *DataStore) SerialUpdateHost(ctx context.Context, host *fleet.Host) error {
+	s.mu.Lock()
 	s.SerialUpdateHostFuncInvoked = true
+	s.mu.Unlock()
 	return s.SerialUpdateHostFunc(ctx, host)
 }
 
 func (s *DataStore) NewJob(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
+	s.mu.Lock()
 	s.NewJobFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewJobFunc(ctx, job)
 }
 
 func (s *DataStore) GetQueuedJobs(ctx context.Context, maxNumJobs int) ([]*fleet.Job, error) {
+	s.mu.Lock()
 	s.GetQueuedJobsFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetQueuedJobsFunc(ctx, maxNumJobs)
 }
 
 func (s *DataStore) UpdateJob(ctx context.Context, id uint, job *fleet.Job) (*fleet.Job, error) {
+	s.mu.Lock()
 	s.UpdateJobFuncInvoked = true
+	s.mu.Unlock()
 	return s.UpdateJobFunc(ctx, id, job)
 }
 
 func (s *DataStore) InnoDBStatus(ctx context.Context) (string, error) {
+	s.mu.Lock()
 	s.InnoDBStatusFuncInvoked = true
+	s.mu.Unlock()
 	return s.InnoDBStatusFunc(ctx)
 }
 
 func (s *DataStore) ProcessList(ctx context.Context) ([]fleet.MySQLProcess, error) {
+	s.mu.Lock()
 	s.ProcessListFuncInvoked = true
+	s.mu.Unlock()
 	return s.ProcessListFunc(ctx)
 }
 
 func (s *DataStore) ListWindowsUpdatesByHostID(ctx context.Context, hostID uint) ([]fleet.WindowsUpdate, error) {
+	s.mu.Lock()
 	s.ListWindowsUpdatesByHostIDFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListWindowsUpdatesByHostIDFunc(ctx, hostID)
 }
 
 func (s *DataStore) InsertWindowsUpdates(ctx context.Context, hostID uint, updates []fleet.WindowsUpdate) error {
+	s.mu.Lock()
 	s.InsertWindowsUpdatesFuncInvoked = true
+	s.mu.Unlock()
 	return s.InsertWindowsUpdatesFunc(ctx, hostID, updates)
 }
 
 func (s *DataStore) ListOSVulnerabilities(ctx context.Context, hostID []uint) ([]fleet.OSVulnerability, error) {
+	s.mu.Lock()
 	s.ListOSVulnerabilitiesFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListOSVulnerabilitiesFunc(ctx, hostID)
 }
 
 func (s *DataStore) InsertOSVulnerabilities(ctx context.Context, vulnerabilities []fleet.OSVulnerability, source fleet.VulnerabilitySource) (int64, error) {
+	s.mu.Lock()
 	s.InsertOSVulnerabilitiesFuncInvoked = true
+	s.mu.Unlock()
 	return s.InsertOSVulnerabilitiesFunc(ctx, vulnerabilities, source)
 }
 
 func (s *DataStore) DeleteOSVulnerabilities(ctx context.Context, vulnerabilities []fleet.OSVulnerability) error {
+	s.mu.Lock()
 	s.DeleteOSVulnerabilitiesFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeleteOSVulnerabilitiesFunc(ctx, vulnerabilities)
 }
 
 func (s *DataStore) NewMDMAppleConfigProfile(ctx context.Context, p fleet.MDMAppleConfigProfile) (*fleet.MDMAppleConfigProfile, error) {
+	s.mu.Lock()
 	s.NewMDMAppleConfigProfileFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewMDMAppleConfigProfileFunc(ctx, p)
 }
 
 func (s *DataStore) GetMDMAppleConfigProfile(ctx context.Context, profileID uint) (*fleet.MDMAppleConfigProfile, error) {
+	s.mu.Lock()
 	s.GetMDMAppleConfigProfileFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetMDMAppleConfigProfileFunc(ctx, profileID)
 }
 
 func (s *DataStore) ListMDMAppleConfigProfiles(ctx context.Context, teamID *uint) ([]*fleet.MDMAppleConfigProfile, error) {
+	s.mu.Lock()
 	s.ListMDMAppleConfigProfilesFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListMDMAppleConfigProfilesFunc(ctx, teamID)
 }
 
 func (s *DataStore) DeleteMDMAppleConfigProfile(ctx context.Context, profileID uint) error {
+	s.mu.Lock()
 	s.DeleteMDMAppleConfigProfileFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeleteMDMAppleConfigProfileFunc(ctx, profileID)
 }
 
 func (s *DataStore) NewMDMAppleEnrollmentProfile(ctx context.Context, enrollmentPayload fleet.MDMAppleEnrollmentProfilePayload) (*fleet.MDMAppleEnrollmentProfile, error) {
+	s.mu.Lock()
 	s.NewMDMAppleEnrollmentProfileFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewMDMAppleEnrollmentProfileFunc(ctx, enrollmentPayload)
 }
 
 func (s *DataStore) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, token string) (*fleet.MDMAppleEnrollmentProfile, error) {
+	s.mu.Lock()
 	s.GetMDMAppleEnrollmentProfileByTokenFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetMDMAppleEnrollmentProfileByTokenFunc(ctx, token)
 }
 
 func (s *DataStore) ListMDMAppleEnrollmentProfiles(ctx context.Context) ([]*fleet.MDMAppleEnrollmentProfile, error) {
+	s.mu.Lock()
 	s.ListMDMAppleEnrollmentProfilesFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListMDMAppleEnrollmentProfilesFunc(ctx)
 }
 
 func (s *DataStore) GetMDMAppleCommandResults(ctx context.Context, commandUUID string) (map[string]*fleet.MDMAppleCommandResult, error) {
+	s.mu.Lock()
 	s.GetMDMAppleCommandResultsFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetMDMAppleCommandResultsFunc(ctx, commandUUID)
 }
 
 func (s *DataStore) NewMDMAppleInstaller(ctx context.Context, name string, size int64, manifest string, installer []byte, urlToken string) (*fleet.MDMAppleInstaller, error) {
+	s.mu.Lock()
 	s.NewMDMAppleInstallerFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewMDMAppleInstallerFunc(ctx, name, size, manifest, installer, urlToken)
 }
 
 func (s *DataStore) MDMAppleInstaller(ctx context.Context, token string) (*fleet.MDMAppleInstaller, error) {
+	s.mu.Lock()
 	s.MDMAppleInstallerFuncInvoked = true
+	s.mu.Unlock()
 	return s.MDMAppleInstallerFunc(ctx, token)
 }
 
 func (s *DataStore) MDMAppleInstallerDetailsByID(ctx context.Context, id uint) (*fleet.MDMAppleInstaller, error) {
+	s.mu.Lock()
 	s.MDMAppleInstallerDetailsByIDFuncInvoked = true
+	s.mu.Unlock()
 	return s.MDMAppleInstallerDetailsByIDFunc(ctx, id)
 }
 
 func (s *DataStore) DeleteMDMAppleInstaller(ctx context.Context, id uint) error {
+	s.mu.Lock()
 	s.DeleteMDMAppleInstallerFuncInvoked = true
+	s.mu.Unlock()
 	return s.DeleteMDMAppleInstallerFunc(ctx, id)
 }
 
 func (s *DataStore) MDMAppleInstallerDetailsByToken(ctx context.Context, token string) (*fleet.MDMAppleInstaller, error) {
+	s.mu.Lock()
 	s.MDMAppleInstallerDetailsByTokenFuncInvoked = true
+	s.mu.Unlock()
 	return s.MDMAppleInstallerDetailsByTokenFunc(ctx, token)
 }
 
 func (s *DataStore) ListMDMAppleInstallers(ctx context.Context) ([]fleet.MDMAppleInstaller, error) {
+	s.mu.Lock()
 	s.ListMDMAppleInstallersFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListMDMAppleInstallersFunc(ctx)
 }
 
 func (s *DataStore) BatchSetMDMAppleProfiles(ctx context.Context, tmID *uint, profiles []*fleet.MDMAppleConfigProfile) error {
+	s.mu.Lock()
 	s.BatchSetMDMAppleProfilesFuncInvoked = true
+	s.mu.Unlock()
 	return s.BatchSetMDMAppleProfilesFunc(ctx, tmID, profiles)
 }
 
 func (s *DataStore) MDMAppleListDevices(ctx context.Context) ([]fleet.MDMAppleDevice, error) {
+	s.mu.Lock()
 	s.MDMAppleListDevicesFuncInvoked = true
+	s.mu.Unlock()
 	return s.MDMAppleListDevicesFunc(ctx)
 }
 
 func (s *DataStore) IngestMDMAppleDevicesFromDEPSync(ctx context.Context, devices []godep.Device) (int64, error) {
+	s.mu.Lock()
 	s.IngestMDMAppleDevicesFromDEPSyncFuncInvoked = true
+	s.mu.Unlock()
 	return s.IngestMDMAppleDevicesFromDEPSyncFunc(ctx, devices)
 }
 
 func (s *DataStore) IngestMDMAppleDeviceFromCheckin(ctx context.Context, mdmHost fleet.MDMAppleHostDetails) error {
+	s.mu.Lock()
 	s.IngestMDMAppleDeviceFromCheckinFuncInvoked = true
+	s.mu.Unlock()
 	return s.IngestMDMAppleDeviceFromCheckinFunc(ctx, mdmHost)
 }
 
 func (s *DataStore) GetNanoMDMEnrollmentStatus(ctx context.Context, id string) (bool, error) {
+	s.mu.Lock()
 	s.GetNanoMDMEnrollmentStatusFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetNanoMDMEnrollmentStatusFunc(ctx, id)
 }
 
 func (s *DataStore) IncreasePolicyAutomationIteration(ctx context.Context, policyID uint) error {
+	s.mu.Lock()
 	s.IncreasePolicyAutomationIterationFuncInvoked = true
+	s.mu.Unlock()
 	return s.IncreasePolicyAutomationIterationFunc(ctx, policyID)
 }
 
 func (s *DataStore) OutdatedAutomationBatch(ctx context.Context) ([]fleet.PolicyFailure, error) {
+	s.mu.Lock()
 	s.OutdatedAutomationBatchFuncInvoked = true
+	s.mu.Unlock()
 	return s.OutdatedAutomationBatchFunc(ctx)
 }

--- a/server/mock/mockresult/datastore_query_results.go
+++ b/server/mock/mockresult/datastore_query_results.go
@@ -4,6 +4,7 @@ package mock
 
 import (
 	"context"
+	"sync"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 )
@@ -25,19 +26,27 @@ type QueryResultStore struct {
 
 	HealthCheckFunc        HealthCheckFunc
 	HealthCheckFuncInvoked bool
+
+	mu sync.Mutex
 }
 
 func (s *QueryResultStore) WriteResult(result fleet.DistributedQueryResult) error {
+	s.mu.Lock()
 	s.WriteResultFuncInvoked = true
+	s.mu.Unlock()
 	return s.WriteResultFunc(result)
 }
 
 func (s *QueryResultStore) ReadChannel(ctx context.Context, query fleet.DistributedQueryCampaign) (<-chan interface{}, error) {
+	s.mu.Lock()
 	s.ReadChannelFuncInvoked = true
+	s.mu.Unlock()
 	return s.ReadChannelFunc(ctx, query)
 }
 
 func (s *QueryResultStore) HealthCheck() error {
+	s.mu.Lock()
 	s.HealthCheckFuncInvoked = true
+	s.mu.Unlock()
 	return s.HealthCheckFunc()
 }

--- a/server/mock/nanodep/storage.go
+++ b/server/mock/nanodep/storage.go
@@ -4,6 +4,7 @@ package mock
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/micromdm/nanodep/client"
@@ -62,54 +63,76 @@ type Storage struct {
 
 	StoreAssignerProfileFunc        StoreAssignerProfileFunc
 	StoreAssignerProfileFuncInvoked bool
+
+	mu sync.Mutex
 }
 
 func (s *Storage) RetrieveAuthTokens(ctx context.Context, name string) (*client.OAuth1Tokens, error) {
+	s.mu.Lock()
 	s.RetrieveAuthTokensFuncInvoked = true
+	s.mu.Unlock()
 	return s.RetrieveAuthTokensFunc(ctx, name)
 }
 
 func (s *Storage) RetrieveConfig(p0 context.Context, p1 string) (*client.Config, error) {
+	s.mu.Lock()
 	s.RetrieveConfigFuncInvoked = true
+	s.mu.Unlock()
 	return s.RetrieveConfigFunc(p0, p1)
 }
 
 func (s *Storage) RetrieveAssignerProfile(ctx context.Context, name string) (profileUUID string, modTime time.Time, err error) {
+	s.mu.Lock()
 	s.RetrieveAssignerProfileFuncInvoked = true
+	s.mu.Unlock()
 	return s.RetrieveAssignerProfileFunc(ctx, name)
 }
 
 func (s *Storage) RetrieveCursor(ctx context.Context, name string) (cursor string, modTime time.Time, err error) {
+	s.mu.Lock()
 	s.RetrieveCursorFuncInvoked = true
+	s.mu.Unlock()
 	return s.RetrieveCursorFunc(ctx, name)
 }
 
 func (s *Storage) StoreCursor(ctx context.Context, name string, cursor string) error {
+	s.mu.Lock()
 	s.StoreCursorFuncInvoked = true
+	s.mu.Unlock()
 	return s.StoreCursorFunc(ctx, name, cursor)
 }
 
 func (s *Storage) StoreAuthTokens(ctx context.Context, name string, tokens *client.OAuth1Tokens) error {
+	s.mu.Lock()
 	s.StoreAuthTokensFuncInvoked = true
+	s.mu.Unlock()
 	return s.StoreAuthTokensFunc(ctx, name, tokens)
 }
 
 func (s *Storage) StoreConfig(ctx context.Context, name string, config *client.Config) error {
+	s.mu.Lock()
 	s.StoreConfigFuncInvoked = true
+	s.mu.Unlock()
 	return s.StoreConfigFunc(ctx, name, config)
 }
 
 func (s *Storage) StoreTokenPKI(ctx context.Context, name string, pemCert []byte, pemKey []byte) error {
+	s.mu.Lock()
 	s.StoreTokenPKIFuncInvoked = true
+	s.mu.Unlock()
 	return s.StoreTokenPKIFunc(ctx, name, pemCert, pemKey)
 }
 
 func (s *Storage) RetrieveTokenPKI(ctx context.Context, name string) (pemCert []byte, pemKey []byte, err error) {
+	s.mu.Lock()
 	s.RetrieveTokenPKIFuncInvoked = true
+	s.mu.Unlock()
 	return s.RetrieveTokenPKIFunc(ctx, name)
 }
 
 func (s *Storage) StoreAssignerProfile(ctx context.Context, name string, profileUUID string) error {
+	s.mu.Lock()
 	s.StoreAssignerProfileFuncInvoked = true
+	s.mu.Unlock()
 	return s.StoreAssignerProfileFunc(ctx, name, profileUUID)
 }

--- a/server/mock/nanomdm/storage.go
+++ b/server/mock/nanomdm/storage.go
@@ -5,6 +5,7 @@ package mock
 import (
 	"context"
 	"crypto/tls"
+	"sync"
 
 	"github.com/micromdm/nanomdm/mdm"
 	"github.com/micromdm/nanomdm/storage"
@@ -112,104 +113,146 @@ type Storage struct {
 
 	RetrieveTokenUpdateTallyFunc        RetrieveTokenUpdateTallyFunc
 	RetrieveTokenUpdateTallyFuncInvoked bool
+
+	mu sync.Mutex
 }
 
 func (s *Storage) StoreAuthenticate(r *mdm.Request, msg *mdm.Authenticate) error {
+	s.mu.Lock()
 	s.StoreAuthenticateFuncInvoked = true
+	s.mu.Unlock()
 	return s.StoreAuthenticateFunc(r, msg)
 }
 
 func (s *Storage) StoreTokenUpdate(r *mdm.Request, msg *mdm.TokenUpdate) error {
+	s.mu.Lock()
 	s.StoreTokenUpdateFuncInvoked = true
+	s.mu.Unlock()
 	return s.StoreTokenUpdateFunc(r, msg)
 }
 
 func (s *Storage) StoreUserAuthenticate(r *mdm.Request, msg *mdm.UserAuthenticate) error {
+	s.mu.Lock()
 	s.StoreUserAuthenticateFuncInvoked = true
+	s.mu.Unlock()
 	return s.StoreUserAuthenticateFunc(r, msg)
 }
 
 func (s *Storage) Disable(r *mdm.Request) error {
+	s.mu.Lock()
 	s.DisableFuncInvoked = true
+	s.mu.Unlock()
 	return s.DisableFunc(r)
 }
 
 func (s *Storage) StoreCommandReport(r *mdm.Request, report *mdm.CommandResults) error {
+	s.mu.Lock()
 	s.StoreCommandReportFuncInvoked = true
+	s.mu.Unlock()
 	return s.StoreCommandReportFunc(r, report)
 }
 
 func (s *Storage) RetrieveNextCommand(r *mdm.Request, skipNotNow bool) (*mdm.Command, error) {
+	s.mu.Lock()
 	s.RetrieveNextCommandFuncInvoked = true
+	s.mu.Unlock()
 	return s.RetrieveNextCommandFunc(r, skipNotNow)
 }
 
 func (s *Storage) ClearQueue(r *mdm.Request) error {
+	s.mu.Lock()
 	s.ClearQueueFuncInvoked = true
+	s.mu.Unlock()
 	return s.ClearQueueFunc(r)
 }
 
 func (s *Storage) StoreBootstrapToken(r *mdm.Request, msg *mdm.SetBootstrapToken) error {
+	s.mu.Lock()
 	s.StoreBootstrapTokenFuncInvoked = true
+	s.mu.Unlock()
 	return s.StoreBootstrapTokenFunc(r, msg)
 }
 
 func (s *Storage) RetrieveBootstrapToken(r *mdm.Request, msg *mdm.GetBootstrapToken) (*mdm.BootstrapToken, error) {
+	s.mu.Lock()
 	s.RetrieveBootstrapTokenFuncInvoked = true
+	s.mu.Unlock()
 	return s.RetrieveBootstrapTokenFunc(r, msg)
 }
 
 func (s *Storage) RetrievePushInfo(p0 context.Context, p1 []string) (map[string]*mdm.Push, error) {
+	s.mu.Lock()
 	s.RetrievePushInfoFuncInvoked = true
+	s.mu.Unlock()
 	return s.RetrievePushInfoFunc(p0, p1)
 }
 
 func (s *Storage) IsPushCertStale(ctx context.Context, topic string, staleToken string) (bool, error) {
+	s.mu.Lock()
 	s.IsPushCertStaleFuncInvoked = true
+	s.mu.Unlock()
 	return s.IsPushCertStaleFunc(ctx, topic, staleToken)
 }
 
 func (s *Storage) RetrievePushCert(ctx context.Context, topic string) (cert *tls.Certificate, staleToken string, err error) {
+	s.mu.Lock()
 	s.RetrievePushCertFuncInvoked = true
+	s.mu.Unlock()
 	return s.RetrievePushCertFunc(ctx, topic)
 }
 
 func (s *Storage) StorePushCert(ctx context.Context, pemCert []byte, pemKey []byte) error {
+	s.mu.Lock()
 	s.StorePushCertFuncInvoked = true
+	s.mu.Unlock()
 	return s.StorePushCertFunc(ctx, pemCert, pemKey)
 }
 
 func (s *Storage) EnqueueCommand(ctx context.Context, id []string, cmd *mdm.Command) (map[string]error, error) {
+	s.mu.Lock()
 	s.EnqueueCommandFuncInvoked = true
+	s.mu.Unlock()
 	return s.EnqueueCommandFunc(ctx, id, cmd)
 }
 
 func (s *Storage) HasCertHash(r *mdm.Request, hash string) (bool, error) {
+	s.mu.Lock()
 	s.HasCertHashFuncInvoked = true
+	s.mu.Unlock()
 	return s.HasCertHashFunc(r, hash)
 }
 
 func (s *Storage) EnrollmentHasCertHash(r *mdm.Request, hash string) (bool, error) {
+	s.mu.Lock()
 	s.EnrollmentHasCertHashFuncInvoked = true
+	s.mu.Unlock()
 	return s.EnrollmentHasCertHashFunc(r, hash)
 }
 
 func (s *Storage) IsCertHashAssociated(r *mdm.Request, hash string) (bool, error) {
+	s.mu.Lock()
 	s.IsCertHashAssociatedFuncInvoked = true
+	s.mu.Unlock()
 	return s.IsCertHashAssociatedFunc(r, hash)
 }
 
 func (s *Storage) AssociateCertHash(r *mdm.Request, hash string) error {
+	s.mu.Lock()
 	s.AssociateCertHashFuncInvoked = true
+	s.mu.Unlock()
 	return s.AssociateCertHashFunc(r, hash)
 }
 
 func (s *Storage) RetrieveMigrationCheckins(p0 context.Context, p1 chan<- interface{}) error {
+	s.mu.Lock()
 	s.RetrieveMigrationCheckinsFuncInvoked = true
+	s.mu.Unlock()
 	return s.RetrieveMigrationCheckinsFunc(p0, p1)
 }
 
 func (s *Storage) RetrieveTokenUpdateTally(ctx context.Context, id string) (int, error) {
+	s.mu.Lock()
 	s.RetrieveTokenUpdateTallyFuncInvoked = true
+	s.mu.Unlock()
 	return s.RetrieveTokenUpdateTallyFunc(ctx, id)
 }

--- a/server/mock/scep/depot.go
+++ b/server/mock/scep/depot.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"math/big"
+	"sync"
 
 	"github.com/micromdm/scep/v2/depot"
 )
@@ -32,24 +33,34 @@ type Depot struct {
 
 	HasCNFunc        HasCNFunc
 	HasCNFuncInvoked bool
+
+	mu sync.Mutex
 }
 
 func (d *Depot) CA(pass []byte) ([]*x509.Certificate, *rsa.PrivateKey, error) {
+	d.mu.Lock()
 	d.CAFuncInvoked = true
+	d.mu.Unlock()
 	return d.CAFunc(pass)
 }
 
 func (d *Depot) Put(name string, crt *x509.Certificate) error {
+	d.mu.Lock()
 	d.PutFuncInvoked = true
+	d.mu.Unlock()
 	return d.PutFunc(name, crt)
 }
 
 func (d *Depot) Serial() (*big.Int, error) {
+	d.mu.Lock()
 	d.SerialFuncInvoked = true
+	d.mu.Unlock()
 	return d.SerialFunc()
 }
 
 func (d *Depot) HasCN(cn string, allowTime int, cert *x509.Certificate, revokeOldCertificate bool) (bool, error) {
+	d.mu.Lock()
 	d.HasCNFuncInvoked = true
+	d.mu.Unlock()
 	return d.HasCNFunc(cn, allowTime, cert, revokeOldCertificate)
 }

--- a/server/service/mock/service_osquery.go
+++ b/server/service/mock/service_osquery.go
@@ -5,6 +5,7 @@ package mock
 import (
 	"context"
 	"encoding/json"
+	"sync"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 )
@@ -46,39 +47,55 @@ type TLSService struct {
 
 	SubmitResultLogsFunc        SubmitResultLogsFunc
 	SubmitResultLogsFuncInvoked bool
+
+	mu sync.Mutex
 }
 
 func (s *TLSService) EnrollAgent(ctx context.Context, enrollSecret string, hostIdentifier string, hostDetails map[string](map[string]string)) (nodeKey string, err error) {
+	s.mu.Lock()
 	s.EnrollAgentFuncInvoked = true
+	s.mu.Unlock()
 	return s.EnrollAgentFunc(ctx, enrollSecret, hostIdentifier, hostDetails)
 }
 
 func (s *TLSService) AuthenticateHost(ctx context.Context, nodeKey string) (host *fleet.Host, debug bool, err error) {
+	s.mu.Lock()
 	s.AuthenticateHostFuncInvoked = true
+	s.mu.Unlock()
 	return s.AuthenticateHostFunc(ctx, nodeKey)
 }
 
 func (s *TLSService) GetClientConfig(ctx context.Context) (config map[string]interface{}, err error) {
+	s.mu.Lock()
 	s.GetClientConfigFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetClientConfigFunc(ctx)
 }
 
 func (s *TLSService) GetDistributedQueries(ctx context.Context) (queries map[string]string, discovery map[string]string, accelerate uint, err error) {
+	s.mu.Lock()
 	s.GetDistributedQueriesFuncInvoked = true
+	s.mu.Unlock()
 	return s.GetDistributedQueriesFunc(ctx)
 }
 
 func (s *TLSService) SubmitDistributedQueryResults(ctx context.Context, results fleet.OsqueryDistributedQueryResults, statuses map[string]fleet.OsqueryStatus, messages map[string]string) (err error) {
+	s.mu.Lock()
 	s.SubmitDistributedQueryResultsFuncInvoked = true
+	s.mu.Unlock()
 	return s.SubmitDistributedQueryResultsFunc(ctx, results, statuses, messages)
 }
 
 func (s *TLSService) SubmitStatusLogs(ctx context.Context, logs []json.RawMessage) (err error) {
+	s.mu.Lock()
 	s.SubmitStatusLogsFuncInvoked = true
+	s.mu.Unlock()
 	return s.SubmitStatusLogsFunc(ctx, logs)
 }
 
 func (s *TLSService) SubmitResultLogs(ctx context.Context, logs []json.RawMessage) (err error) {
+	s.mu.Lock()
 	s.SubmitResultLogsFuncInvoked = true
+	s.mu.Unlock()
 	return s.SubmitResultLogsFunc(ctx, logs)
 }

--- a/server/service/mock/service_push_provider.go
+++ b/server/service/mock/service_push_provider.go
@@ -3,6 +3,8 @@
 package mock
 
 import (
+	"sync"
+
 	"github.com/micromdm/nanomdm/mdm"
 	"github.com/micromdm/nanomdm/push"
 )
@@ -14,9 +16,13 @@ type PushFunc func(p0 []*mdm.Push) (map[string]*push.Response, error)
 type APNSPushProvider struct {
 	PushFunc        PushFunc
 	PushFuncInvoked bool
+
+	mu sync.Mutex
 }
 
 func (s *APNSPushProvider) Push(p0 []*mdm.Push) (map[string]*push.Response, error) {
+	s.mu.Lock()
 	s.PushFuncInvoked = true
+	s.mu.Unlock()
 	return s.PushFunc(p0)
 }

--- a/server/service/mock/service_pusher_factory.go
+++ b/server/service/mock/service_pusher_factory.go
@@ -4,6 +4,7 @@ package mock
 
 import (
 	"crypto/tls"
+	"sync"
 
 	"github.com/micromdm/nanomdm/push"
 )
@@ -15,9 +16,13 @@ type NewPushProviderFunc func(p0 *tls.Certificate) (push.PushProvider, error)
 type APNSPushProviderFactory struct {
 	NewPushProviderFunc        NewPushProviderFunc
 	NewPushProviderFuncInvoked bool
+
+	mu sync.Mutex
 }
 
 func (s *APNSPushProviderFactory) NewPushProvider(p0 *tls.Certificate) (push.PushProvider, error) {
+	s.mu.Lock()
 	s.NewPushProviderFuncInvoked = true
+	s.mu.Unlock()
 	return s.NewPushProviderFunc(p0)
 }


### PR DESCRIPTION
this uses the associated new version in our fork
https://github.com/fleetdm/mockimpl/commit/ecbb3041eabfc9e046a3f2e414e32c28254b75b2

to allow for concurrent access to mocks
