### PR TITLE
Edwardsb vuln processing sandcastle

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -81,7 +82,7 @@ func cronVulnerabilities(
 	config *config.VulnerabilitiesConfig,
 ) error {
 	if config == nil {
-		return fmt.Errorf("nil configuration")
+		return errors.New("nil configuration")
 	}
 	if config.CurrentInstanceChecks == "no" || config.CurrentInstanceChecks == "0" {
 		level.Info(logger).Log("msg", "host not configured to check for vulnerabilities")

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -80,6 +80,9 @@ func cronVulnerabilities(
 	logger kitlog.Logger,
 	config *config.VulnerabilitiesConfig,
 ) error {
+	if config == nil {
+		return fmt.Errorf("nil configuration")
+	}
 	if config.CurrentInstanceChecks == "no" || config.CurrentInstanceChecks == "0" {
 		level.Info(logger).Log("msg", "host not configured to check for vulnerabilities")
 		return nil
@@ -97,21 +100,7 @@ func cronVulnerabilities(
 		return nil
 	}
 
-	var vulnPath string
-	switch {
-	case config.DatabasesPath != "" && appConfig.VulnerabilitySettings.DatabasesPath != "":
-		vulnPath = config.DatabasesPath
-		level.Info(logger).Log(
-			"msg", "fleet config takes precedence over app config when both are configured",
-			"databases_path", vulnPath,
-		)
-	case config.DatabasesPath != "":
-		vulnPath = config.DatabasesPath
-	case appConfig.VulnerabilitySettings.DatabasesPath != "":
-		vulnPath = appConfig.VulnerabilitySettings.DatabasesPath
-	default:
-		level.Info(logger).Log("msg", "vulnerability scanning not configured, vulnerabilities databases path is empty")
-	}
+	vulnPath := configureVulnPath(*config, appConfig, logger)
 	if vulnPath != "" {
 		level.Info(logger).Log("msg", "scanning vulnerabilities")
 		if err := scanVulnerabilities(ctx, ds, logger, config, appConfig, vulnPath); err != nil {

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -21,6 +21,7 @@ func main() {
 
 	configManager := config.NewManager(rootCmd)
 
+	rootCmd.AddCommand(createVulnProcessingCmd(configManager))
 	rootCmd.AddCommand(createPrepareCmd(configManager))
 	rootCmd.AddCommand(createServeCmd(configManager))
 	rootCmd.AddCommand(createConfigDumpCmd(configManager))

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"math/rand"
 	"os"
 	"time"
@@ -91,4 +93,23 @@ func applyDevFlags(cfg *config.FleetConfig) {
 		DisableSSL:       true,
 		ForceS3PathStyle: true,
 	}
+}
+
+func initLogger(cfg config.FleetConfig) kitlog.Logger {
+	var logger kitlog.Logger
+	{
+		output := os.Stderr
+		if cfg.Logging.JSON {
+			logger = kitlog.NewJSONLogger(output)
+		} else {
+			logger = kitlog.NewLogfmtLogger(output)
+		}
+		if cfg.Logging.Debug {
+			logger = level.NewFilter(logger, level.AllowDebug())
+		} else {
+			logger = level.NewFilter(logger, level.AllowInfo())
+		}
+		logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC)
+	}
+	return logger
 }

--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"fmt"
-	kitlog "github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	"math/rand"
 	"os"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/config"
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 )

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -124,21 +124,7 @@ the way that the Fleet server works.
 				fleet.WriteExpiredLicenseBanner(os.Stderr)
 			}
 
-			var logger kitlog.Logger
-			{
-				output := os.Stderr
-				if config.Logging.JSON {
-					logger = kitlog.NewJSONLogger(output)
-				} else {
-					logger = kitlog.NewLogfmtLogger(output)
-				}
-				if config.Logging.Debug {
-					logger = level.NewFilter(logger, level.AllowDebug())
-				} else {
-					logger = level.NewFilter(logger, level.AllowInfo())
-				}
-				logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC)
-			}
+			logger := initLogger(config)
 
 			// Init tracing
 			if config.Logging.TracingEnabled {
@@ -619,10 +605,13 @@ the way that the Fleet server works.
 				initFatal(err, "failed to register stats schedule")
 			}
 
-			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
-				return newVulnerabilitiesSchedule(ctx, instanceID, ds, logger, &config.Vulnerabilities)
-			}); err != nil {
-				initFatal(err, "failed to register vulnerabilities schedule")
+			if !config.Vulnerabilities.ExternalScheduled {
+				// vuln processing by default is run by internal cron mechanism
+				if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
+					return newVulnerabilitiesSchedule(ctx, instanceID, ds, logger, &config.Vulnerabilities)
+				}); err != nil {
+					initFatal(err, "failed to register vulnerabilities schedule")
+				}
 			}
 
 			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {

--- a/cmd/fleet/vuln_process.go
+++ b/cmd/fleet/vuln_process.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/WatchBeam/clock"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
@@ -10,7 +12,6 @@ import (
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/spf13/cobra"
-	"time"
 )
 
 var dev bool

--- a/cmd/fleet/vuln_process.go
+++ b/cmd/fleet/vuln_process.go
@@ -10,7 +10,6 @@ import (
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/spf13/cobra"
-	"os"
 	"time"
 )
 
@@ -43,42 +42,37 @@ vulnerability processing. By default the Fleet server command internally manages
 			switch status.StatusCode {
 			case fleet.AllMigrationsCompleted:
 				// only continue if db is considered up-to-date
-				fmt.Println("database check complete, continuing vuln processing")
+				break
 			case fleet.NoMigrationsCompleted, fleet.SomeMigrationsCompleted, fleet.UnknownMigrations:
 				initFatal(fmt.Errorf("database migrations incompatible with current version"), "refusing to continue processing vulnerabilities")
 			}
 
+			logger := initLogger(cfg)
+			logger = kitlog.With(logger, fleet.CronVulnerabilities)
+
 			ctx := context.Background()
-
-			logger := setupLogger(cfg)
-
 			appConfig, err := ds.AppConfig(ctx)
-			vulnConfig := cfg.Vulnerabilities
-			var vulnPath string
-			switch {
-			case vulnConfig.DatabasesPath != "" && appConfig.VulnerabilitySettings.DatabasesPath != "":
-				vulnPath = vulnConfig.DatabasesPath
-				level.Info(logger).Log(
-					"msg", "fleet config takes precedence over app config when both are configured",
-					"databases_path", vulnPath,
-				)
-			case vulnConfig.DatabasesPath != "":
-				vulnPath = vulnConfig.DatabasesPath
-			case appConfig.VulnerabilitySettings.DatabasesPath != "":
-				vulnPath = appConfig.VulnerabilitySettings.DatabasesPath
-			default:
-				level.Info(logger).Log("msg", "vulnerability scanning not configured, vulnerabilities databases path is empty")
+			if err != nil {
+				initFatal(err, "error fetching app config during vulnerability processing")
 			}
-			if vulnPath != "" {
-				level.Info(logger).Log("msg", "scanning vulnerabilities")
-				if err := scanVulnerabilities(ctx, ds, logger, &vulnConfig, appConfig, vulnPath); err != nil {
-					initFatal(fmt.Errorf("scanning vulnerabilities: %w", err), "error during vulnerability processing")
-				}
+			vulnConfig := cfg.Vulnerabilities
+			vulnPath := configureVulnPath(vulnConfig, appConfig, logger)
+			// this really shouldn't ever be empty string since it's defaulted, but could be due to some misconfiguration
+			// we'll throw an error here since the entire point of this command is to process vulnerabilities
+			if vulnPath == "" {
+				initFatal(fmt.Errorf("vuln path empty, check environment variables or app config yml"), "error during vulnerability processing")
+			}
+			level.Info(logger).Log("msg", "scanning vulnerabilities")
+			err = scanVulnerabilities(ctx, ds, logger, &vulnConfig, appConfig, vulnPath)
+			if err != nil {
+				// errors during vuln processing should bubble up, so you know the job is failing without having to scour logs, e.g. non-zero exit code
+				initFatal(fmt.Errorf("scanning vulnerabilities: %w", err), "error during vulnerability processing")
 			}
 
 			err = ds.SyncHostsSoftware(ctx, time.Now())
 			if err != nil {
-				level.Error(logger).Log("msg", "failed to sync host software", "err", err)
+				// though vulnerability processing succeeded, we'll still fatally error here to indicate there was a problem
+				initFatal(err, "failed to sync host software")
 			}
 
 			return
@@ -89,21 +83,20 @@ vulnerability processing. By default the Fleet server command internally manages
 	return vulnProcessingCmd
 }
 
-func setupLogger(cfg config.FleetConfig) kitlog.Logger {
-	var logger kitlog.Logger
-	{
-		output := os.Stderr
-		if cfg.Logging.JSON {
-			logger = kitlog.NewJSONLogger(output)
-		} else {
-			logger = kitlog.NewLogfmtLogger(output)
-		}
-		if cfg.Logging.Debug {
-			logger = level.NewFilter(logger, level.AllowDebug())
-		} else {
-			logger = level.NewFilter(logger, level.AllowInfo())
-		}
-		logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC)
+func configureVulnPath(vulnConfig config.VulnerabilitiesConfig, appConfig *fleet.AppConfig, logger kitlog.Logger) (vulnPath string) {
+	switch {
+	case vulnConfig.DatabasesPath != "" && appConfig != nil && appConfig.VulnerabilitySettings.DatabasesPath != "":
+		vulnPath = vulnConfig.DatabasesPath
+		level.Info(logger).Log(
+			"msg", "fleet config takes precedence over app config when both are configured",
+			"databases_path", vulnPath,
+		)
+	case vulnConfig.DatabasesPath != "":
+		vulnPath = vulnConfig.DatabasesPath
+	case appConfig != nil && appConfig.VulnerabilitySettings.DatabasesPath != "":
+		vulnPath = appConfig.VulnerabilitySettings.DatabasesPath
+	default:
+		level.Info(logger).Log("msg", "vulnerability scanning not configured, vulnerabilities databases path is empty")
 	}
-	return logger
+	return vulnPath
 }

--- a/cmd/fleet/vuln_process.go
+++ b/cmd/fleet/vuln_process.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/WatchBeam/clock"
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/spf13/cobra"
+	"os"
+	"time"
+)
+
+var dev bool
+
+func createVulnProcessingCmd(configManager config.Manager) *cobra.Command {
+	vulnProcessingCmd := &cobra.Command{
+		Use:   "vuln_processing",
+		Short: "Run the vulnerability processing features of Fleet",
+		Long: `The vuln_processing command is intended for advanced configurations that want to externally manage 
+vulnerability processing. By default the Fleet server command internally manages vulnerability processing via scheduled
+'cron' style jobs.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			cfg := configManager.LoadConfig()
+			if dev {
+				applyDevFlags(&cfg)
+			}
+
+			ds, err := mysql.New(cfg.Mysql, clock.C)
+			if err != nil {
+				initFatal(err, "creating db connection")
+			}
+
+			// we need to ensure this command isn't running with an out-of-date database
+			status, err := ds.MigrationStatus(cmd.Context())
+			if err != nil {
+				initFatal(err, "retrieving migration status")
+			}
+
+			switch status.StatusCode {
+			case fleet.AllMigrationsCompleted:
+				// only continue if db is considered up-to-date
+				fmt.Println("database check complete, continuing vuln processing")
+			case fleet.NoMigrationsCompleted, fleet.SomeMigrationsCompleted, fleet.UnknownMigrations:
+				initFatal(fmt.Errorf("database migrations incompatible with current version"), "refusing to continue processing vulnerabilities")
+			}
+
+			ctx := context.Background()
+
+			logger := setupLogger(cfg)
+
+			appConfig, err := ds.AppConfig(ctx)
+			vulnConfig := cfg.Vulnerabilities
+			var vulnPath string
+			switch {
+			case vulnConfig.DatabasesPath != "" && appConfig.VulnerabilitySettings.DatabasesPath != "":
+				vulnPath = vulnConfig.DatabasesPath
+				level.Info(logger).Log(
+					"msg", "fleet config takes precedence over app config when both are configured",
+					"databases_path", vulnPath,
+				)
+			case vulnConfig.DatabasesPath != "":
+				vulnPath = vulnConfig.DatabasesPath
+			case appConfig.VulnerabilitySettings.DatabasesPath != "":
+				vulnPath = appConfig.VulnerabilitySettings.DatabasesPath
+			default:
+				level.Info(logger).Log("msg", "vulnerability scanning not configured, vulnerabilities databases path is empty")
+			}
+			if vulnPath != "" {
+				level.Info(logger).Log("msg", "scanning vulnerabilities")
+				if err := scanVulnerabilities(ctx, ds, logger, &vulnConfig, appConfig, vulnPath); err != nil {
+					initFatal(fmt.Errorf("scanning vulnerabilities: %w", err), "error during vulnerability processing")
+				}
+			}
+
+			err = ds.SyncHostsSoftware(ctx, time.Now())
+			if err != nil {
+				level.Error(logger).Log("msg", "failed to sync host software", "err", err)
+			}
+
+			return
+		},
+	}
+	vulnProcessingCmd.PersistentFlags().BoolVar(&dev, "dev", false, "Enable developer options")
+
+	return vulnProcessingCmd
+}
+
+func setupLogger(cfg config.FleetConfig) kitlog.Logger {
+	var logger kitlog.Logger
+	{
+		output := os.Stderr
+		if cfg.Logging.JSON {
+			logger = kitlog.NewJSONLogger(output)
+		} else {
+			logger = kitlog.NewLogfmtLogger(output)
+		}
+		if cfg.Logging.Debug {
+			logger = level.NewFilter(logger, level.AllowDebug())
+		} else {
+			logger = level.NewFilter(logger, level.AllowInfo())
+		}
+		logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC)
+	}
+	return logger
+}

--- a/cmd/fleet/vuln_process.go
+++ b/cmd/fleet/vuln_process.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -45,7 +46,7 @@ vulnerability processing. By default the Fleet server command internally manages
 				// only continue if db is considered up-to-date
 				break
 			case fleet.NoMigrationsCompleted, fleet.SomeMigrationsCompleted, fleet.UnknownMigrations:
-				initFatal(fmt.Errorf("database migrations incompatible with current version"), "refusing to continue processing vulnerabilities")
+				initFatal(errors.New("database migrations incompatible with current version"), "refusing to continue processing vulnerabilities")
 			}
 
 			logger := initLogger(cfg)
@@ -61,7 +62,7 @@ vulnerability processing. By default the Fleet server command internally manages
 			// this really shouldn't ever be empty string since it's defaulted, but could be due to some misconfiguration
 			// we'll throw an error here since the entire point of this command is to process vulnerabilities
 			if vulnPath == "" {
-				initFatal(fmt.Errorf("vuln path empty, check environment variables or app config yml"), "error during vulnerability processing")
+				initFatal(errors.New("vuln path empty, check environment variables or app config yml"), "error during vulnerability processing")
 			}
 			level.Info(logger).Log("msg", "scanning vulnerabilities")
 			err = scanVulnerabilities(ctx, ds, logger, &vulnConfig, appConfig, vulnPath)

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -2231,6 +2231,19 @@ When running multiple instances of the Fleet server, by default, one of them dyn
   	current_instance_checks: yes
   ```
 
+##### external_scheduled
+
+To externally manage running vulnerability processing set the value to `true` and then run `fleet vuln_processing` using external
+tools like crontab.
+
+- Default value: `false`
+- Environment variable: `FLEET_VULNERABILITIES_EXTERNAL_SCHEDULED`
+- Config file format:
+  ```
+  vulnerabilities:
+  	external_scheduled: false
+  ```
+
 ##### disable_data_sync
 
 Fleet by default automatically downloads and keeps the different data streams needed to properly do vulnerability processing. In some setups, this behavior is not wanted, as access to outside resources might be blocked, or the data stream files might need review/audit before use.

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -2153,7 +2153,7 @@ The path specified needs to exist and Fleet needs to be able to read and write t
 
 When `current_instance_checks` is set to `auto` (the default), Fleet instances will try to create the `databases_path` if it doesn't exist.
 
-- Default value: none
+- Default value: `/tmp/vulndbs`
 - Environment variable: `FLEET_VULNERABILITIES_DATABASES_PATH`
 - Config file format:
   ```

--- a/docs/Using-Fleet/Vulnerability-Processing.md
+++ b/docs/Using-Fleet/Vulnerability-Processing.md
@@ -127,6 +127,36 @@ found in the [configuration documentation](https://fleetdm.com/docs/deploying/co
 
 You'll need to restart the Fleet instances after changing these settings.
 
+### Advanced Configuration
+
+Fleet runs vulnerability downloading and processing via internal scheduled cron job. This internal mechanism is very useful
+for frictionless deployments and is well suited for most use cases. However, in larger deployments, 
+where there can be dozens of Fleet server replicas sitting behind a load balancer, it is desirable to manage vulnerability processing externally.
+
+The reasons for this are as follows:
+
+- lower resource requirements across the entire Fleet server deployment (as vulnerability processing requires considerably more resources than just running Fleet server alone)
+- more control over scheduling constraints (only process during windows of low utilization, etc.)
+
+It is possible today to limit vulnerability processing to a single [dedicated host](https://fleetdm.com/docs/deploying/configuration#current-instance-checks), by setting
+`current_instance_checks` to `no` but still run one Fleet server as `yes`, but the drawback here is still having to dedicate resources
+for this single host 24/7. The Fleet binary has a command which handles the same vulnerability processing, but will exit (successfully with 0) on completion. Using this sub-command we can delegate vulnerability processing
+to external systems such as:
+
+- [ECS](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/scheduling_tasks.html)
+- [K8S](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/)
+- [GCP](https://cloud.google.com/run/docs/triggering/using-scheduler#create_job)
+- [Plain old cron](https://en.wikipedia.org/wiki/Cron)
+
+To opt into this functionality, be sure to configure your Fleet server deployment with
+```
+FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS=no
+```
+And then externally run with the same environment variables/configuration files passed to the server command.
+```
+fleet vuln_processing
+```
+
 ## Performance
 
 ### Windows/Mac OS

--- a/docs/Using-Fleet/Vulnerability-Processing.md
+++ b/docs/Using-Fleet/Vulnerability-Processing.md
@@ -138,7 +138,7 @@ The reasons for this are as follows:
 - lower resource requirements across the entire Fleet server deployment (as vulnerability processing requires considerably more resources than just running Fleet server alone)
 - more control over scheduling constraints (only process during windows of low utilization, etc.)
 
-It is possible today to limit vulnerability processing to a single [dedicated host](https://fleetdm.com/docs/deploying/configuration#current-instance-checks), by setting
+It is possible to limit vulnerability processing to a single [dedicated host](https://fleetdm.com/docs/deploying/configuration#current-instance-checks), by setting
 `current_instance_checks` to `no` but still run one Fleet server as `yes`, but the drawback here is still having to dedicate resources
 for this single host 24/7. The Fleet binary has a command which handles the same vulnerability processing, but will exit (successfully with 0) on completion. Using this sub-command we can delegate vulnerability processing
 to external systems such as:
@@ -150,8 +150,10 @@ to external systems such as:
 
 To opt into this functionality, be sure to configure your Fleet server deployment with
 ```
-FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS=no
+FLEET_VULNERABILITIES_EXTERNAL_SCHEDULED=true
 ```
+which will **disable** the internal scheduling mechanism for vulnerability processing.
+
 And then externally run with the same environment variables/configuration files passed to the server command.
 ```
 fleet vuln_processing

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -323,6 +323,7 @@ type VulnerabilitiesConfig struct {
 	CPETranslationsURL          string        `json:"cpe_translations_url" yaml:"cpe_translations_url"`
 	CVEFeedPrefixURL            string        `json:"cve_feed_prefix_url" yaml:"cve_feed_prefix_url"`
 	CurrentInstanceChecks       string        `json:"current_instance_checks" yaml:"current_instance_checks"`
+	ExternalScheduled           bool          `json:"external_scheduled" yaml:"external_scheduled"`
 	DisableDataSync             bool          `json:"disable_data_sync" yaml:"disable_data_sync"`
 	RecentVulnerabilityMaxAge   time.Duration `json:"recent_vulnerability_max_age" yaml:"recent_vulnerability_max_age"`
 	DisableWinOSVulnerabilities bool          `json:"disable_win_os_vulnerabilities" yaml:"disable_win_os_vulnerabilities"`
@@ -968,6 +969,8 @@ func (man Manager) addConfigs() {
 		"Prefix URL for the CVE data feed. If empty, default to https://nvd.nist.gov/")
 	man.addConfigString("vulnerabilities.current_instance_checks", "auto",
 		"Allows to manually select an instance to do the vulnerability processing.")
+	man.addConfigBool("vulnerabilities.external_scheduled", false,
+		"Vulnerability processing is managed by an external 'cron' mechanism.")
 	man.addConfigBool("vulnerabilities.disable_data_sync", false,
 		"Skips synchronizing data streams and expects them to be available in the databases_path.")
 	man.addConfigDuration("vulnerabilities.recent_vulnerability_max_age", 30*24*time.Hour,

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1242,6 +1242,7 @@ func (man Manager) LoadConfig() FleetConfig {
 			CPETranslationsURL:          man.getConfigString("vulnerabilities.cpe_translations_url"),
 			CVEFeedPrefixURL:            man.getConfigString("vulnerabilities.cve_feed_prefix_url"),
 			CurrentInstanceChecks:       man.getConfigString("vulnerabilities.current_instance_checks"),
+			ExternalScheduled:           man.getConfigBool("vulnerabilities.external_scheduled"),
 			DisableDataSync:             man.getConfigBool("vulnerabilities.disable_data_sync"),
 			RecentVulnerabilityMaxAge:   man.getConfigDuration("vulnerabilities.recent_vulnerability_max_age"),
 			DisableWinOSVulnerabilities: man.getConfigBool("vulnerabilities.disable_win_os_vulnerabilities"),


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
