### PR TITLE
Fleet UI: Select targets logic for "All hosts" to be mutually exclusive from other filters

### DIFF
--- a/changes/9603-selecting-all-hosts-mutually-exclusive-from-filters
+++ b/changes/9603-selecting-all-hosts-mutually-exclusive-from-filters
@@ -1,0 +1,1 @@
+- Live query/policy selecting "All hosts" is mutually exclusive from other filters

--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -72,6 +72,10 @@ const DEBOUNCE_DELAY = 500;
 const STALE_TIME = 60000;
 
 const isLabel = (entity: ISelectTargetsEntity) => "label_type" in entity;
+const isAllHosts = (entity: ISelectTargetsEntity) =>
+  "label_type" in entity &&
+  entity.name === "All Hosts" &&
+  entity.label_type === "builtin";
 
 const parseLabels = (list?: ILabelSummary[]) => {
   const allHosts = list?.filter((l) => l.name === "All Hosts") || [];
@@ -265,9 +269,30 @@ const SelectTargets = ({
       : targetedTeams;
 
     // if the target was previously selected, we want to remove it now
-    const newTargets = prevTargets.filter((t) => t.id !== selectedEntity.id);
+    let newTargets = prevTargets.filter((t) => t.id !== selectedEntity.id);
     // if the length remains the same, the target was not previously selected so we want to add it now
     prevTargets.length === newTargets.length && newTargets.push(selectedEntity);
+
+    // Logic when to deselect/select "all hosts" when using more granuated filters
+    // if all hosts is selected
+    if (isAllHosts(selectedEntity)) {
+      // and all hosts is already selected, deselect it
+      if (targetedLabels.some((t) => isAllHosts(t))) {
+        newTargets = [];
+      } // else deselect everything but all hosts
+      else {
+        newTargets = [selectedEntity];
+      }
+      setTargetedTeams([]);
+      setTargetedHosts([]);
+    }
+    // else deselect all hosts
+    else {
+      if (targetedLabels.some((t) => isAllHosts(t))) {
+        setTargetedLabels([]);
+      }
+      newTargets = newTargets.filter((t) => !isAllHosts(t));
+    }
 
     isLabel(selectedEntity)
       ? setTargetedLabels(newTargets as ILabel[])
@@ -278,6 +303,11 @@ const SelectTargets = ({
     const selectedHost = row.original as IHost;
     setTargetedHosts((prevHosts) => prevHosts.concat(selectedHost));
     setSearchText("");
+
+    // If "all hosts "already selected when using host target picker, deselect "all hosts"
+    if (targetedLabels.some((t) => isAllHosts(t))) {
+      setTargetedLabels([]);
+    }
   };
 
   const handleRowRemove = (row: Row) => {


### PR DESCRIPTION
## Issue
Cerra #9603 

## Fix
- Selecting targets by label, team, or individual hosts will unselect "All hosts" option
- Selecting "All hosts" option will unselect targets by label, team, or individual hosts
- NOTE: The code behind this is messy due to the nature of the 3 different ways to select targets (by label which is also used by "All hosts", by team, and by individual targets), left thorough notes in the code how it works

## Screenrecording
https://www.loom.com/share/c8bc52b513e14ed98b6524a3f0372562

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

