### PR TITLE
fix for View all host results on the Operating Systems table.

### DIFF
--- a/frontend/pages/DashboardPage/cards/OperatingSystems/OperatingSystemsTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/OperatingSystems/OperatingSystemsTableConfig.tsx
@@ -74,8 +74,8 @@ const defaultTableHeaders = [
           <span className="hosts-cell__link">
             <ViewAllHostsLink
               queryParams={{
-                os_name: encodeURIComponent(name_only),
-                os_version: encodeURIComponent(version),
+                os_name: name_only,
+                os_version: version,
               }}
               className="os-hosts-link"
             />


### PR DESCRIPTION
The `View all host` button on Operating systems table would navigate to the host page but not show the related hosts. This fixes that issue.

If some of the following don't apply, delete the relevant line.

**Before:**

https://www.loom.com/share/a29fc7064e694fac8dbdde571b409264

**After:**

https://www.loom.com/share/3adfa9b9ab7f4f498d7112b6d1052ea1

- [x] Manual QA for all new/changed functionality
