### PR TITLE
Update endpoints for osquery

### DIFF
--- a/docs/Deploying/FAQ.md
+++ b/docs/Deploying/FAQ.md
@@ -177,9 +177,12 @@ Check out the [documentation on running database migrations](https://fleetdm.com
 
 ## What API endpoints should I expose to the public internet?
 
-If you would like to manage hosts that can travel outside your VPN or intranet we recommend only exposing the `/api/v1/osquery` endpoint to the public internet.
+If you would like to manage hosts that can travel outside your VPN or intranet we recommend only exposing the osquery endpoints to the public internet:
 
-If you are using Fleet Desktop and want it to work on remote devices, the bare minimum API to expose is `/api/latest/fleet/device/*/desktop`. This minimal endpoint will only provide the number of failing policies. 
+- `/api/osquery`
+- `/api/v1/osquery`
+
+If you are using Fleet Desk, top and want it to work on remote devices, the bare minimum API to expose is `/api/latest/fleet/device/*/desktop`. This minimal endpoint will only provide the number of failing policies. 
 
 For full Fleet Desktop functionality, `/api/fleet/orbit/*` and`/api/fleet/device/ping` must also be exposed.
 
@@ -187,7 +190,6 @@ If you would like to use the fleetctl CLI from outside of your network, the foll
 
 - /api/setup
 - /api/v1/setup
-- /api/osquery/*
 - /api/latest/fleet/*
 - /api/v1/fleet/*
 


### PR DESCRIPTION
Added `/api/osquery` to the list of endpoints to expose to public internet.
