### PR TITLE
Activity feed UI: Update turn off MDM

### DIFF
--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -182,7 +182,7 @@ const TAGGED_TEMPLATES = {
     return (
       <>
         {activity.actor_full_name
-          ? " turned off mobile device management (MDM) for"
+          ? " told Fleet to turn off mobile device management (MDM) for"
           : "Mobile device management (MDM) was turned off for"}{" "}
         <b>{activity.details?.host_display_name}</b>.
       </>


### PR DESCRIPTION
- Clarify the "Turn off MDM" activity feed item. One item tracks when an IT admin clicked the Turn off MDM button in the UI (command was queued) and the other item tracks when the host reported that MDM was turned off (command ran)

More context is here in Slack (internal): https://fleetdm.slack.com/archives/C03C41L5YEL/p1677090855479879?thread_ts=1677089154.560089&cid=C03C41L5YEL