### PR TITLE
MDM docs: Reset Mac password with recovery key

### DIFF
--- a/docs/Using-Fleet/Mobile-device-management.md
+++ b/docs/Using-Fleet/Mobile-device-management.md
@@ -24,7 +24,9 @@ If there is less than 1 day, the window is shown every 2 hours. The end user can
 
 If the end user is past the deadline, Fleet shows the window and end user can't close the window until they upgrade.
 
-## Disk encryption
+## macOS settings
+
+### Disk encryption
 
 In Fleet, you can enforce disk encryption on your macOS hosts. Apple calls this [FileVault](https://support.apple.com/en-us/HT204837). If turned on, hosts’ disk encryption keys will be stored in Fleet.
 
@@ -46,7 +48,7 @@ Fleet UI:
 
 3. Run the `fleetctl apply -f <your-YAML-file-here>` command.
 
-### Viewing a disk encryption key
+#### Viewing a disk encryption key
 
 The disk encryption key allows you to unlock a Mac if you forgot login credentials. This key can be accessed by Fleet admin, maintainers, and observers. An event is tracked in the activity feed when a user views the key in Fleet.
 
@@ -56,46 +58,17 @@ How to view the disk encryption key:
 
 2. On the **Host details** page, select **Actions > Show disk encryption key**.
 
-### Unlock a macOS host using the disk encryption key
+#### Unlock a macOS host using the disk encryption key
 
 How to unlock a macOS host using the disk encryption key:
 
-1. Restart the device while holding Command + R
+1. Restart the host. If you just unlocked a host that was locked remotely, the host will automatically restart.
 
-2. Open Terminal
+2. On the Mac's login screen, enter the incorrect password three times. After the third failed login attempt, the Mac will display a prompt below the password field with the following message: "If you forgot your password, you can reset it using your Recovery Key." Select the right facing arrow at the end of this prompt. 
 
-3. Unlock the disk encryption key by executing a command similar to:
-```
-security unlock-keychain <path to the secure copy of the 
-FileVaultMaster.keychain file>
-```
+3. Enter the disk encryption key. Note that Apple calls this "Recovery key." Learn how to find a host's disk encryption key [here in the docs](#viewing-a-disk-encryption-key).
 
-4. Locate the Logical Volume UUID of the encrypted disk by executing:
-```
-diskutil cs list
-```
-
-5. Unlock the encrypted drive with the Logical Volume UUID and disk encryption key by executing a command similar to:
-```
-diskutil cs unlockVolume <UUID> -recoveryKeychain <path to the secure copy of the FileVaultMaster.keychain file>
-```
-6. Turn off disk encryption by executing a command similar to: 
-```
-diskutil cs revert <UUID> -recoveryKeychain <path to the secure copy of the FileVaultMaster.keychain file>
-```
-
-Once successful, you can reset the account password using the Reset Password utility and recover data by either logging in to the user’s account or using the command line.
-
-1. Restart the device while pressing Command + R.
-
-2. Open Terminal and launch the Reset Password utility by executing:
-```
-resetpassword
-```
-
-3. Use the Reset Password utility to reset the account’s password.
-
-4. Restart the computer and log in using the new password.
+4. The Mac will display a prompt to reset the password. Reset the password and save this password somewhere safe. If you plan to prepare this Mac for a new employee, you'll need this password to erase all content and settings on the Mac.
 
 ## Set up
 

--- a/docs/Using-Fleet/Mobile-device-management.md
+++ b/docs/Using-Fleet/Mobile-device-management.md
@@ -50,7 +50,9 @@ Fleet UI:
 
 #### Viewing a disk encryption key
 
-The disk encryption key allows you to unlock a Mac if you forgot login credentials. This key can be accessed by Fleet admin, maintainers, and observers. An event is tracked in the activity feed when a user views the key in Fleet.
+The disk encryption key allows you to reset a macOS host's password if you don't know it. This way, if you plan to prepare a host for a new employee, you can login to it and erase all its content and settings.
+
+The key can be accessed by Fleet admin, maintainers, and observers. An event is tracked in the activity feed when a user views the key in Fleet.
 
 How to view the disk encryption key:
 
@@ -58,9 +60,9 @@ How to view the disk encryption key:
 
 2. On the **Host details** page, select **Actions > Show disk encryption key**.
 
-#### Unlock a macOS host using the disk encryption key
+#### Reset a macOS host's password using the disk encryption key
 
-How to unlock a macOS host using the disk encryption key:
+How to reset a macOS host's password using the disk encryption key:
 
 1. Restart the host. If you just unlocked a host that was locked remotely, the host will automatically restart.
 

--- a/docs/Using-Fleet/Mobile-device-management.md
+++ b/docs/Using-Fleet/Mobile-device-management.md
@@ -24,9 +24,7 @@ If there is less than 1 day, the window is shown every 2 hours. The end user can
 
 If the end user is past the deadline, Fleet shows the window and end user can't close the window until they upgrade.
 
-## macOS settings
-
-### Disk encryption
+## Disk encryption
 
 In Fleet, you can enforce disk encryption on your macOS hosts. Apple calls this [FileVault](https://support.apple.com/en-us/HT204837). If turned on, hosts’ disk encryption keys will be stored in Fleet.
 
@@ -48,7 +46,7 @@ Fleet UI:
 
 3. Run the `fleetctl apply -f <your-YAML-file-here>` command.
 
-#### Viewing a disk encryption key
+### Viewing a disk encryption key
 
 The disk encryption key allows you to reset a macOS host's password if you don't know it. This way, if you plan to prepare a host for a new employee, you can login to it and erase all its content and settings.
 
@@ -60,7 +58,7 @@ How to view the disk encryption key:
 
 2. On the **Host details** page, select **Actions > Show disk encryption key**.
 
-#### Reset a macOS host's password using the disk encryption key
+### Reset a macOS host's password using the disk encryption key
 
 How to reset a macOS host's password using the disk encryption key:
 


### PR DESCRIPTION
- Update the instructions. Frame the instructions around resetting the Mac's password so that the IT admin can prepare the device for a new employee (erase the Mac manually)
