### PR TITLE
Creating job posting sub pages for current roles open

### DIFF
--- a/handbook/business-operations/README.md
+++ b/handbook/business-operations/README.md
@@ -308,10 +308,11 @@ Every new position being created goes through this process before interviewing, 
   - Reply in the `#hiring-xxxxx-2022` Slack channel, at-mentioning the original proposer, to let them know the new position is approved.
 After getting CEO approval, create a position in Breezy.
 
-#### Creating a new position in Breezy
-Review [Breezy positions video](https://www.loom.com/home) on how to post a job on fleetdm.com/apply using Breezy. Collect candidate feedback from the team and manage the hiring process.
-
-> Breezy is being replaced at the end of Feb 2023.  TODO: Update this section with new instructions for posting the job.
+#### Creating a new position 
+1. A new handbook subpage is created on the "Company" page and a link to the subpage is added to the "Open positions" section on the "Company" page.
+2. The job description is copy/pasted in the new subpage.
+3. When an applicant has completed an application, there is a Zapier automation that will post to `g-business-operations`. 
+4. The applicant information is then forwarded to the applicable `#hiring-xxxxx-202x` Slack channel` and the hiring manager is @mentioned.
 
 ### Recruiting
 #### Checking legal restrictions on hiring

--- a/handbook/company/⚗️ Product Designer.md
+++ b/handbook/company/⚗️ Product Designer.md
@@ -1,0 +1,43 @@
+⚗️ Product Designer
+
+
+### Your primary responsibilities 🔭
+
+As Product Designer at Fleet, you will get the chance to…
+
+In your first 90 days:
+
+- ⏫ Engage with product management, engineering, business stakeholders, and customers to understand initiatives
+- 📣 Design consistent interactions across the Fleet user experience, including API and CLI
+- 🌡️ Drive the refinement process from concept to high fidelity prototypes
+
+
+### Are you our new team member? 🧑‍🚀
+
+If most of these qualities sound like you, we would love to chat and see if we're a good fit.
+
+### You "get it":
+
+- 🦉 Articulate the problem to be solved and create a compelling narrative around proposed solutions
+- 📖 Maintain a design system that enables speed for designers, PMs, and engineers
+- 🧑‍🔬 Develop an understanding of developer-first automation workflows, including API and CLI experiences
+- 🧪 Translate user insights into digital experiences that are well crafted and easy-to-use
+
+### You can "walk the walk":
+
+- 🤝 Collaboration: You work best in a participatory, team-based environment.
+- 📈 Prototype-first: You embrace speed and failure as we iterate towards the right solution. You have hands-on experience in creating low and high fidelity prototypes. You’re comfortable accepting suboptimal designs in favor of iteration.
+- 🧬 Simplicity: You love complex questions and use your work to simplify that complexity for users.
+- 🟣 Openness: You are flexible and open to new ideas and ways of working
+- ➕ Bonus: cybersecurity or IT background
+
+### You can "talk the talk":
+
+- 💭 3-5 years' of experience as a UX designer
+- 💖 Proficient in visual design and wireframing tools (we use Figma)
+- ✍️ Experience designing CLI experiences for developers or willingness to learn
+- ➕ Bonus: YB2B SaaS background
+
+
+You can apply for this position here, or ask us anything at https://fleetdm.com/contact.
+

--- a/handbook/company/🚀 Engineering Manager, MDM.md
+++ b/handbook/company/🚀 Engineering Manager, MDM.md
@@ -1,0 +1,37 @@
+# 🚀 Engineering Manager, MDM
+
+
+## Your primary responsibilities 🔭
+
+Your top priority is to ensure the technical success of MDM features within Fleet’s product offering. You'll work collaboratively with business, product, and engineering stakeholders to implement new features efficiently and to specification. Manage daily Scrum process to maintain business alignment and ensure consistent delivery of product features.
+
+- Lead a team of full-stack software engineers writing open-source code in Go and React.
+- Support customers and users using software your team built at organizations you’ve heard of.
+- Work with Fleet’s product team, customers, and the broader open-source community to envision and deliver improved IT and security workflows.
+- Collaborate with product and engineering to refine wireframes, user stories, and development tasks.
+- Identify gaps in requirements and opportunities to reduce scope while delivering business value.
+- Optimize velocity and throughput by maintaining accurate requirements and efficient development and code review processes.
+- Prioritize development tasks, bugs, and technical debt to consistently deliver valuable features while maintaining product stability.
+- Support the career growth of team members through mentorship and continuous feedback.
+- Hire and retain software engineers by building a positive culture of engineering excellence.
+
+
+## Are you our new teammate? 🧑‍🚀
+
+The ideal candidate could act as a tech lead manager, spending some of their time managing the team, and some of their time developing and evangelizing osquery and Fleet's other agent software.
+
+- 🔩You have experience managing high-output remote engineering teams.
+- 🗣️ You have excellent written and oral communication skills.
+- 🦉 You have 4+ years of experience as an engineer and 1+ years as an engineering manager (or equivalent).
+- 👁 You can help craft and implement a vision for how Fleet and osquery can improve the experience of IT admins, security teams, and the end-users of computing devices.
+- ➕ Bonus: Experience working in and leading open-source communities.
+- ➕ Bonus: Interest in contributing directly to the community via code, written content, and conference presentations.
+- ➕ Bonus: Experience with system APIs and packaging in one or more of macOS, Linux, and Windows.
+- ➕ Bonus: Knowledge of MDM products/APIs on macOS and Windows.
+- ➕ Bonus: Familiarity with IT operations, system administration, or cybersecurity.
+
+
+Want to join the team?
+
+You can apply for this position here, or ask us anything at https://fleetdm.com/contact.
+

--- a/handbook/company/🫧 Field Marketer.md
+++ b/handbook/company/🫧 Field Marketer.md
@@ -1,0 +1,44 @@
+# 🫧 Field Marketer
+
+
+## Your primary responsibilities 🔭
+
+As Field Marketing Manager - Enterprise, at Fleet, you will get the chance to…
+
+- ⏫ Design, drive and execute account-based marketing campaigns
+- 📣 Manage numerous projects simultaneously, in a dynamic environment
+- 🌡️ Plan and execute events and trade show sponsorships with end to end planning & follow-up, measurement and results
+- 🪴 Work with the marketing team on US regional press announcements
+- 🕴️ Utilize systems and tools such as salesforce to analyze pipeline and opportunity data
+- 🚀 Work collaboratively with the community marketing, sales and product teams to drive results in the US
+- 🧑‍💻 Plan, execute and track impactful marketing campaigns, in order to meet and/or exceed quarterly pipeline and revenue targets
+- 📈 Manage to a quarterly and annual budget
+
+## Are you our new team member? 🧑‍🚀
+
+If most of these qualities sound like you, we would love to chat and see if we're a good fit.
+
+### You "get it":
+
+- 🦉 3+ years in managing and executing trade shows and events
+- 🧪 Experience with salesforce
+- 🧑‍💻 Motivated self-starter who thrives in complex fast-paced, results driven environments
+
+### You can "walk the walk":
+
+- 🤝 Decisive with the ability to shift gears between thinking and doing
+- 📈 Ability to partner with various teams and stakeholders to drive results
+- 👀 Experience with developing, executing and tracking results tied to Demand Generation campaigns
+- ➕ Bonus: 5+ years of leading/executing marketing programs
+
+### You can "talk the talk":
+
+- 💭 You know how to market to developers, IT engineers, or security engineers.
+- 💖 You know how to grow a community, not just harvest it.
+- ✍ Ability to effectively influence key stakeholders and team
+- 🧬 You care about using a consistent voice, messaging, and design.
+- ➕ Bonus: You are comfortable with concepts like security, APIs, and DevOps.
+
+
+You can apply for this position here, or ask us anything at https://fleetdm.com/contact.
+

--- a/handbook/company/🫧 Revenue Operations Manager.md
+++ b/handbook/company/🫧 Revenue Operations Manager.md
@@ -1,0 +1,52 @@
+# 🫧 Revenue Operations Manager
+
+
+## Your primary responsibilities 🔭
+
+As RevOps at Fleet, you will get the chance to…
+
+In your first 90 days:
+
+- 📣 Own data and reporting analysis in Salesforce.
+- 🌡️ Represent Fleet’s culture and values in all client conversations
+- ⏫ Collaborate with our GTM (Go To Market) team to refine and build our sales and marketing data stack, and execute on roadmap items related to commercial needs.
+
+
+Soon afterward:
+
+- 🚀 Own an end-to-end inside sales cycle from lead to opportunity to close
+  - Or rephrased: Lead our post-sale, “Quote-To-Cash” process: accounts receivable, invoicing, Stripe tracking and forecasting.
+- 🪴 Work closely with Fleet’s Sales and Marketing leadership team to design and execute our revenue planning process.
+- 🕴️ Manage revenue operations for Fleet, including, but not limited to: managing our CRM (currently Salesforce), pipeline and renewals tracking, enablement and training, outreach sequences, and commissions.
+
+
+## Are you our new team member? 🧑‍🚀
+
+If most of these qualities sound like you, we would love to chat and see if we're a good fit.
+
+### You "get it":
+
+- 🦉 2-3 years of Revenue Operations experience, preferably in a Series A —> Series B organization
+- 🧪 Pipeline strategy/GTM planning experience
+- 🧑‍💻 Highly organized with excellent verbal and written communication skills
+
+
+### You can "walk the walk":
+
+- 🤝 Experience using Salesforce and the ability to take ownership of the sales tech stack, provisioning of licenses for sales tools and performing sales enablement functions. Or rephrased: You can build dashboard reports and pull insights from them.
+- 📈 You know your way around spreadsheets and are comfortable with quantitative benefits analysis. Or rephrased: You are good with numbers and you have analytical experience.
+- ➕ Bonus: experience working in support automation systems and working with third-party vendors.
+
+
+### You can "talk the talk":
+
+- 💭 You can provide insights on selling efficiently, target customers, and the best sellers for our strategy.
+- 💖 You have a friendly demeanor and a positive work attitude.
+- ✍️ You can make complicated ideas easy to digest. You write simply.
+- 🧬 You care about positivity and desire to uplift and share knowledge with those around you.
+- ➕ Bonus: You are familiar with SCRUM and AGILE methods.
+
+
+
+You can apply for this position here, or ask us anything at https://fleetdm.com/contact.
+


### PR DESCRIPTION
Breezy migration: https://github.com/fleetdm/fleet/issues/9930

Typeform needs to be added to the bottom of the pages, did that out of order slightly. 
<!-- actually, I think it's a redirect that needs to be created --> to add the Typeform link: https://3x3q33auqgj.typeform.com/to/upGkhYsN

Zapier works. 

Handbook is updated. 

Final step is to cancel Breezy. 