### PR TITLE
Website: Update signup error handling when there is a Stripe related error.

### DIFF
--- a/website/api/controllers/entrance/signup.js
+++ b/website/api/controllers/entrance/signup.js
@@ -105,7 +105,7 @@ the account verification message.)`,
       throw 'emailAlreadyInUse';
     }
 
-    // Create a new customer entry in the Stripe API for this user before we provision a Sandbox Instance.
+    // Create a new customer entry in the Stripe API for this user before we send a request to the cloud provisioner.
     let stripeCustomerId = await sails.helpers.stripe.saveBillingInfo.with({
       emailAddress: newEmailAddress
     })

--- a/website/api/controllers/entrance/signup.js
+++ b/website/api/controllers/entrance/signup.js
@@ -105,20 +105,20 @@ the account verification message.)`,
       throw 'emailAlreadyInUse';
     }
 
-    let stripeCustomerId;
+
     if (!sails.config.custom.enableBillingFeatures) {
       throw new Error('The Stripe configuration variables (sails.config.custom.stripePublishableKey and sails.config.custom.stripeSecret) are missing!');
-    } else {
-      // Create a new customer entry in the Stripe API for this user before we send a request to the cloud provisioner.
-      stripeCustomerId = await sails.helpers.stripe.saveBillingInfo.with({
-        emailAddress: newEmailAddress
-      })
-      .timeout(5000)
-      .retry()
-      .intercept((error)=>{
-        return new Error(`An error occurred when trying to create a Stripe Customer for a new user with the using the email address ${newEmailAddress}. The incomplete user record has not been saved in the database, and the user will be asked to try signing up again. Full error: ${error.raw}`);
-      });
     }
+
+    // Create a new customer entry in the Stripe API for this user before we send a request to the cloud provisioner.
+    let stripeCustomerId = await sails.helpers.stripe.saveBillingInfo.with({
+      emailAddress: newEmailAddress
+    })
+    .timeout(5000)
+    .retry()
+    .intercept((error)=>{
+      return new Error(`An error occurred when trying to create a Stripe Customer for a new user with the using the email address ${newEmailAddress}. The incomplete user record has not been saved in the database, and the user will be asked to try signing up again. Full error: ${error.raw}`);
+    });
 
     // Provisioning a Fleet sandbox instance for the new user. Note: Because this is the only place where we provision Sandbox instances, We'll provision a Sandbox instance BEFORE
     // creating the new User record. This way, if this fails, we won't save the new record to the database, and the user will see an error on the signup form asking them to try again.


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/1748

Changes:
- Added an error that is thrown if a Stripe customer cannot be created for a new user.
- Updated `signup.js` to create Stripe customers for new users before the new record is saved in the database. This helps prevent situations where users are shown an error message when they submit the signup form, but their account was actually created (without a `stripeCustomerId`).