### PR TITLE
Changes in Fleet server to support Fleetd for Chrome

### DIFF
--- a/changes/chrome
+++ b/changes/chrome
@@ -1,0 +1,1 @@
+* Minor server changes to support Fleetd for ChromeOS (to be released soon).

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -392,7 +392,10 @@ func PlatformFromHost(hostPlatform string) string {
 		return "linux"
 	case hostPlatform == "darwin", hostPlatform == "windows",
 		// Some customers have custom agents that support ChromeOS
-		hostPlatform == "CrOS":
+		// TODO remove this once that customer migrates to Fleetd for Chrome
+		hostPlatform == "CrOS",
+		// Fleet now supports Chrome via fleetd
+		hostPlatform == "chrome":
 		return hostPlatform
 	default:
 		return ""


### PR DESCRIPTION
These are minor changes needed to support the new ChromeOS extension. This should have no effect on non-Chrome platforms.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
