### PR TITLE
launch Nudge using /usr/bin/open

### DIFF
--- a/orbit/changes/10044-orbit-hang
+++ b/orbit/changes/10044-orbit-hang
@@ -1,0 +1,1 @@
+* Fixed an issue affecting macOS devices with MDM enabled that prevented Orbit for restarting if Nudge was still open.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -526,11 +526,13 @@ func main() {
 		const renewEnrollmentProfileCommandFrequency = time.Hour
 		configFetcher := update.ApplyRenewEnrollmentProfileConfigFetcherMiddleware(orbitClient, renewEnrollmentProfileCommandFrequency)
 
-		// add middleware to handle nudge installation and updates
-		const nudgeLaunchInterval = 30 * time.Minute
-		configFetcher = update.ApplyNudgeConfigFetcherMiddleware(configFetcher, update.NudgeConfigFetcherOptions{
-			UpdateRunner: updateRunner, RootDir: c.String("root-dir"), Interval: nudgeLaunchInterval,
-		})
+		if runtime.GOOS == "darwin" {
+			// add middleware to handle nudge installation and updates
+			const nudgeLaunchInterval = 30 * time.Minute
+			configFetcher = update.ApplyNudgeConfigFetcherMiddleware(configFetcher, update.NudgeConfigFetcherOptions{
+				UpdateRunner: updateRunner, RootDir: c.String("root-dir"), Interval: nudgeLaunchInterval,
+			})
+		}
 
 		const orbitFlagsUpdateInterval = 30 * time.Second
 		flagRunner := update.NewFlagRunner(configFetcher, update.FlagUpdateOptions{

--- a/orbit/pkg/execuser/execuser.go
+++ b/orbit/pkg/execuser/execuser.go
@@ -4,6 +4,7 @@ package execuser
 
 type eopts struct {
 	env        [][2]string
+	args       [][2]string
 	stderrPath string //nolint:structcheck,unused
 }
 
@@ -14,6 +15,17 @@ type Option func(*eopts)
 func WithEnv(name, value string) Option {
 	return func(a *eopts) {
 		a.env = append(a.env, [2]string{name, value})
+	}
+}
+
+// WithArg sets command line arguments for the application.
+//
+// TODO: for now CLI arguments are only used by the darwin
+// implementation, just because it's the only platform that needs
+// them.
+func WithArg(name, value string) Option {
+	return func(a *eopts) {
+		a.args = append(a.args, [2]string{name, value})
 	}
 }
 

--- a/orbit/pkg/execuser/execuser_darwin.go
+++ b/orbit/pkg/execuser/execuser_darwin.go
@@ -20,11 +20,24 @@ func run(path string, opts eopts) error {
 	if opts.stderrPath != "" {
 		arg = append(arg, "--stderr", opts.stderrPath)
 	}
+
+	// set environment variables
 	for _, nv := range opts.env {
 		arg = append(arg, "--env", fmt.Sprintf("%s=%s", nv[0], nv[1]))
 	}
+
+	// set the path to be executed
 	arg = append(arg, path)
-	cmd := exec.Command("open", arg...)
+
+	// set the program arguments
+	if len(opts.args) > 0 {
+		arg = append(arg, "--args")
+		for _, nv := range opts.args {
+			arg = append(arg, nv[0], nv[1])
+		}
+	}
+
+	cmd := exec.Command("/usr/bin/open", arg...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	if err := cmd.Run(); err != nil {

--- a/orbit/pkg/update/nudge.go
+++ b/orbit/pkg/update/nudge.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sync"
 	"time"
 
@@ -44,10 +43,6 @@ type NudgeConfigFetcherOptions struct {
 	// runNudgeFn can be set in tests to mock the command executed to
 	// run Nudge.
 	runNudgeFn func(execPath, configPath string) error
-
-	// skipOSCheck can be set in tests to skip OS checks and run the
-	// nudge checker in non-darwin platforms.
-	skipOSCheck bool
 }
 
 func ApplyNudgeConfigFetcherMiddleware(f OrbitConfigFetcher, opt NudgeConfigFetcherOptions) OrbitConfigFetcher {
@@ -65,11 +60,7 @@ func ApplyNudgeConfigFetcherMiddleware(f OrbitConfigFetcher, opt NudgeConfigFetc
 func (n *NudgeConfigFetcher) GetConfig() (*fleet.OrbitConfig, error) {
 	log.Debug().Msg("running nudge config fetcher middleware")
 	cfg, err := n.Fetcher.GetConfig()
-	switch {
-	case runtime.GOOS != "darwin" && !n.opt.skipOSCheck:
-		log.Debug().Msg("skipping Nudge loop as platform is not darwin")
-		return cfg, err
-	case err != nil:
+	if err != nil {
 		log.Info().Err(err).Msg("calling GetConfig from NudgeConfigFetcher")
 		return nil, err
 	}

--- a/orbit/pkg/update/nudge.go
+++ b/orbit/pkg/update/nudge.go
@@ -44,6 +44,10 @@ type NudgeConfigFetcherOptions struct {
 	// runNudgeFn can be set in tests to mock the command executed to
 	// run Nudge.
 	runNudgeFn func(execPath, configPath string) error
+
+	// skipOSCheck can be set in tests to skip OS checks and run the
+	// nudge checker in non-darwin platforms.
+	skipOSCheck bool
 }
 
 func ApplyNudgeConfigFetcherMiddleware(f OrbitConfigFetcher, opt NudgeConfigFetcherOptions) OrbitConfigFetcher {
@@ -62,7 +66,7 @@ func (n *NudgeConfigFetcher) GetConfig() (*fleet.OrbitConfig, error) {
 	log.Debug().Msg("running nudge config fetcher middleware")
 	cfg, err := n.Fetcher.GetConfig()
 	switch {
-	case runtime.GOOS != "darwin":
+	case runtime.GOOS != "darwin" && !n.opt.skipOSCheck:
 		log.Debug().Msg("skipping Nudge loop as platform is not darwin")
 		return cfg, err
 	case err != nil:

--- a/orbit/pkg/update/nudge_test.go
+++ b/orbit/pkg/update/nudge_test.go
@@ -44,7 +44,6 @@ func (s *nudgeTestSuite) TestNudgeConfigFetcherAddNudge() {
 		RootDir:      tmpDir,
 		Interval:     interval,
 		runNudgeFn:   runNudgeFn,
-		skipOSCheck:  true,
 	})
 
 	// nudge is not added to targets if nudge config is not present

--- a/orbit/pkg/update/nudge_test.go
+++ b/orbit/pkg/update/nudge_test.go
@@ -44,6 +44,7 @@ func (s *nudgeTestSuite) TestNudgeConfigFetcherAddNudge() {
 		RootDir:      tmpDir,
 		Interval:     interval,
 		runNudgeFn:   runNudgeFn,
+		skipOSCheck:  true,
 	})
 
 	// nudge is not added to targets if nudge config is not present


### PR DESCRIPTION
this accomplishes two things:

1. We're not waiting on Nudge to exit anymore, preventing issues like https://github.com/fleetdm/fleet/issues/10044
2. Nudge is launched as a local user instead of root, which is the recommended way to do it.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
