### PR TITLE
Fleet UI: Use currentTeam.id from app context to set teamId for API calls on Manage host page

### DIFF
--- a/changes/9986-bug-host
+++ b/changes/9986-bug-host
@@ -1,0 +1,1 @@
+* Create activity feed types for the creation, update, and deletion of macOS profiles (settings) via MDM

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -62,8 +62,6 @@ import TeamsDropdown from "components/TeamsDropdown";
 import Spinner from "components/Spinner";
 import MainContent from "components/MainContent";
 import EmptyTable from "components/EmptyTable";
-
-import { getValidatedTeamId } from "utilities/helpers";
 import {
   defaultHiddenColumns,
   generateVisibleTableColumns,
@@ -423,12 +421,7 @@ const ManageHostsPage = ({
     setIsHostsLoading(true);
     options = {
       ...options,
-      teamId: getValidatedTeamId(
-        availableTeams || [],
-        options.teamId as number,
-        currentUser,
-        isOnGlobalTeam as boolean
-      ),
+      teamId: currentTeam?.id,
     };
 
     if (queryParams.team_id) {
@@ -460,12 +453,7 @@ const ManageHostsPage = ({
 
     options = {
       ...options,
-      teamId: getValidatedTeamId(
-        availableTeams || [],
-        options.teamId as number,
-        currentUser,
-        isOnGlobalTeam as boolean
-      ),
+      teamId: currentTeam?.id,
     };
 
     if (queryParams.team_id) {
@@ -667,18 +655,11 @@ const ManageHostsPage = ({
   const handleTeamSelect = (teamId: number) => {
     const { MANAGE_HOSTS } = PATHS;
 
-    const teamIdParam = getValidatedTeamId(
-      availableTeams || [],
-      teamId,
-      currentUser,
-      isOnGlobalTeam ?? false
-    );
-
     const slimmerParams = omit(queryParams, ["team_id"]);
 
-    const newQueryParams = !teamIdParam
+    const newQueryParams = !teamId
       ? slimmerParams
-      : Object.assign(slimmerParams, { team_id: teamIdParam });
+      : Object.assign(slimmerParams, { team_id: teamId });
 
     const nextLocation = getNextLocationPath({
       pathPrefix: MANAGE_HOSTS,
@@ -1497,12 +1478,7 @@ const ManageHostsPage = ({
 
     options = {
       ...options,
-      teamId: getValidatedTeamId(
-        availableTeams || [],
-        options.teamId as number,
-        currentUser,
-        isOnGlobalTeam as boolean
-      ),
+      teamId: currentTeam?.id,
     };
 
     if (queryParams.team_id) {

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -791,28 +791,6 @@ export const getSortedTeamOptions = memoize((teams: ITeam[]) =>
     .sort((a, b) => sortUtils.caseInsensitiveAsc(a.label, b.label))
 );
 
-export const getValidatedTeamId = (
-  teams: ITeam[] | ITeamSummary[],
-  teamId: number,
-  currentUser: IUser | null,
-  isOnGlobalTeam: boolean
-) => {
-  let currentUserTeams: ITeamSummary[] = [];
-  if (isOnGlobalTeam) {
-    currentUserTeams = teams;
-  } else if (currentUser && currentUser.teams) {
-    currentUserTeams = currentUser.teams;
-  }
-
-  const currentUserTeamIds = currentUserTeams.map((t) => t.id);
-  const validatedTeamId =
-    !isNaN(teamId) && teamId > 0 && currentUserTeamIds.includes(teamId)
-      ? teamId
-      : undefined;
-
-  return validatedTeamId;
-};
-
 // returns a mixture of props from host
 export const normalizeEmptyValues = (
   hostData: Partial<IHost>
@@ -872,7 +850,6 @@ export default {
   labelSlug,
   setupData,
   syntaxHighlight,
-  getValidatedTeamId,
   normalizeEmptyValues,
   wrapFleetHelper,
 };


### PR DESCRIPTION
## Issue
Cerra #9986 

## Fix
- Use AppContext currentTeam.id to set team for API calls on manage host page
- Fixes API being called without a team Id which was causing the bug

## Screenrecording
https://user-images.githubusercontent.com/71795832/220944192-b9909282-a299-4671-ad2b-32505916b6f2.mov


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
