### PR TITLE
try supporting compose v1 and v2 for tests

### DIFF
--- a/cmd/fleetctl/preview_test.go
+++ b/cmd/fleetctl/preview_test.go
@@ -63,23 +63,3 @@ func TestPreview(t *testing.T) {
 	ok = strings.Contains(appConf, `databases_path: /vulndb`)
 	require.True(t, ok, appConf)
 }
-
-func TestDockerCompose(t *testing.T) {
-	t.Run("returns the right command according to the version", func(t *testing.T) {
-		v1 := dockerCompose{dockerComposeV1}
-		cmd1 := v1.Command("up")
-		require.Equal(t, []string{"docker-compose", "up"}, cmd1.Args)
-
-		v2 := dockerCompose{dockerComposeV2}
-		cmd2 := v2.Command("up")
-		require.Equal(t, []string{"docker", "compose", "up"}, cmd2.Args)
-	})
-
-	t.Run("strings according to the version", func(t *testing.T) {
-		v1 := dockerCompose{dockerComposeV1}
-		require.Equal(t, v1.String(), "`docker-compose`")
-
-		v2 := dockerCompose{dockerComposeV2}
-		require.Equal(t, v2.String(), "`docker compose`")
-	})
-}

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -1,0 +1,45 @@
+package docker
+
+import (
+	"errors"
+	"os/exec"
+)
+
+const (
+	dockerComposeV1 int = iota
+	dockerComposeV2
+)
+
+type Compose struct {
+	version int
+}
+
+func (d *Compose) String() string {
+	if d.version == dockerComposeV1 {
+		return "`docker-compose`"
+	}
+
+	return "`docker compose`"
+}
+
+func (d *Compose) Command(arg ...string) *exec.Cmd {
+	if d.version == dockerComposeV1 {
+		return exec.Command("docker-compose", arg...)
+	}
+
+	return exec.Command("docker", append([]string{"compose"}, arg...)...)
+}
+
+func NewCompose() (*Compose, error) {
+	// first, check if `docker compose` is available
+	if err := exec.Command("docker", "compose").Run(); err == nil {
+		return &Compose{dockerComposeV2}, nil
+	}
+
+	// if not, try to use `docker-compose`
+	if _, err := exec.LookPath("docker-compose"); err == nil {
+		return &Compose{dockerComposeV1}, nil
+	}
+
+	return nil, errors.New("docker compose not found")
+}

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -1,0 +1,27 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDockerCompose(t *testing.T) {
+	t.Run("returns the right command according to the version", func(t *testing.T) {
+		v1 := Compose{dockerComposeV1}
+		cmd1 := v1.Command("up")
+		require.Equal(t, []string{"docker-compose", "up"}, cmd1.Args)
+
+		v2 := Compose{dockerComposeV2}
+		cmd2 := v2.Command("up")
+		require.Equal(t, []string{"docker", "compose", "up"}, cmd2.Args)
+	})
+
+	t.Run("strings according to the version", func(t *testing.T) {
+		v1 := Compose{dockerComposeV1}
+		require.Equal(t, v1.String(), "`docker-compose`")
+
+		v2 := Compose{dockerComposeV2}
+		require.Equal(t, v2.String(), "`docker compose`")
+	})
+}

--- a/server/datastore/mysql/migrations_test.go
+++ b/server/datastore/mysql/migrations_test.go
@@ -2,9 +2,9 @@ package mysql
 
 import (
 	"context"
-	"os/exec"
 	"testing"
 
+	"github.com/fleetdm/fleet/v4/pkg/docker"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/migrations/tables"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -62,9 +62,12 @@ func TestMigrations(t *testing.T) {
 
 	require.NoError(t, ds.MigrateTables(context.Background()))
 
+	compose, err := docker.NewCompose()
+	require.NoError(t, err)
+
 	// Dump schema to dumpfile
-	cmd := exec.Command(
-		"docker-compose", "exec", "-T", "mysql_test",
+	cmd := compose.Command(
+		"exec", "-T", "mysql_test",
 		// Command run inside container
 		"mysqldump", "-u"+testUsername, "-p"+testPassword, "TestMigrations", "--compact", "--skip-comments",
 	)

--- a/server/datastore/mysql/testing_utils.go
+++ b/server/datastore/mysql/testing_utils.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"runtime"
 	"strings"
@@ -16,6 +15,7 @@ import (
 	"time"
 
 	"github.com/WatchBeam/clock"
+	"github.com/fleetdm/fleet/v4/pkg/docker"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/go-kit/kit/log"
 	"github.com/jmoiron/sqlx"
@@ -188,10 +188,12 @@ func initializeDatabase(t testing.TB, testName string, opts *DatastoreTestOption
 	if opts.Replica {
 		dbs = append(dbs, testName+testReplicaDatabaseSuffix)
 	}
+	compose, err := docker.NewCompose()
+	require.NoError(t, err)
 	for _, dbName := range dbs {
 		// Load schema from dumpfile
-		if out, err := exec.Command(
-			"docker-compose", "exec", "-T", "mysql_test",
+		if out, err := compose.Command(
+			"exec", "-T", "mysql_test",
 			// Command run inside container
 			"mysql",
 			"-u"+testUsername, "-p"+testPassword,


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
