### PR TITLE
Fleet UI: Saving policy platforms always successful even if incompatible

### DIFF
--- a/changes/9994-policy-platform-saves
+++ b/changes/9994-policy-platform-saves
@@ -1,0 +1,1 @@
+- Even for default policies, you can save new (even uncompatible) policy platforms using the platform checkboxes as a user would expect the options to successfully save

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -237,10 +237,7 @@ const PolicyForm = ({
         description: lastEditedQueryDescription,
         query: lastEditedQueryBody,
         resolution: lastEditedQueryResolution,
-        platform:
-          defaultPolicy && lastEditedQueryPlatform
-            ? lastEditedQueryPlatform
-            : newPlatformString,
+        platform: newPlatformString,
       };
       if (isPremiumTier) {
         payload.critical = lastEditedQueryCritical;


### PR DESCRIPTION
## Issue
Cerra #9994 

## Fix
- Even for default policies, a user is met with a "successfully updated policy" message, meaning we would expect to save platforms even if they are incompatible
- Platforms are always saved based on the user choice, even if different from the initial policy compatibility

## Screenrecording

 
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
