### PR TITLE
Fleet UI: Fix host count for hosts filtered by operating system version

### DIFF
--- a/changes/10069-os-host-count-bug
+++ b/changes/10069-os-host-count-bug
@@ -1,0 +1,1 @@
+- Fix bug with host count on hosts filtered by operating system version

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTableConfig.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleTable/ScheduleTableConfig.tsx
@@ -236,10 +236,6 @@ const enhanceAllScheduledQueryData = (
       system_time_p50: scheduledQuery.stats?.system_time_p50,
       total_executions: scheduledQuery.stats?.total_executions,
     };
-    console.log(
-      "performanceIndicator(scheduledQueryPerformance)",
-      performanceIndicator(scheduledQueryPerformance)
-    );
     return {
       name: scheduledQuery.name,
       query_name: scheduledQuery.query_name,

--- a/frontend/services/entities/host_count.ts
+++ b/frontend/services/entities/host_count.ts
@@ -27,9 +27,9 @@ export interface IHostCountLoadOptions {
   mdmId?: number;
   mdmEnrollmentStatus?: string;
   munkiIssueId?: number;
-  os_id?: number;
-  os_name?: string;
-  os_version?: string;
+  osId?: number;
+  osName?: string;
+  osVersion?: string;
 }
 
 export default {
@@ -46,6 +46,9 @@ export default {
     const munkiIssueId = options?.munkiIssueId;
     const lowDiskSpaceHosts = options?.lowDiskSpaceHosts;
     const label = getLabelParam(selectedLabels);
+    const osId = options?.osId;
+    const osName = options?.osName;
+    const osVersion = options?.osVersion;
 
     const queryParams = {
       query: globalFilter,
@@ -59,6 +62,9 @@ export default {
         munkiIssueId,
         softwareId,
         lowDiskSpaceHosts,
+        osName,
+        osId,
+        osVersion,
       }),
       label_id: label,
       status,


### PR DESCRIPTION
## Issue
Cerra #10069 

## Fix
- Bug on operating system version count not registering the operating system version and just returning all count (snake case should have been camel case...)

## Screenshot
<img width="1342" alt="Screenshot 2023-02-23 at 1 10 00 PM" src="https://user-images.githubusercontent.com/71795832/220993282-084d2cfe-7a6c-46a0-ade3-7a12a9ac0639.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
