### PR TITLE
Filter removed mdm profiles from host details

### DIFF
--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -141,7 +141,7 @@ func (ds *Datastore) DeleteMDMAppleConfigProfile(ctx context.Context, profileID 
 }
 
 func (ds *Datastore) GetHostMDMProfiles(ctx context.Context, hostUUID string) ([]fleet.HostMDMAppleProfile, error) {
-	stmt := `
+	stmt := fmt.Sprintf(`
 SELECT 
 	hmap.profile_id,
 	name, 
@@ -154,7 +154,11 @@ FROM
 JOIN
 	mdm_apple_configuration_profiles hmacp ON hmap.profile_id = hmacp.profile_id
 WHERE 
-	host_uuid = ?`
+	host_uuid = ? AND (operation_type != '%s' OR (operation_type = '%s' AND status != '%s'))`,
+		fleet.MDMAppleOperationTypeRemove,
+		fleet.MDMAppleOperationTypeRemove,
+		fleet.MDMAppleDeliveryApplied,
+	)
 
 	var profiles []fleet.HostMDMAppleProfile
 	if err := sqlx.SelectContext(ctx, ds.reader, &profiles, stmt, hostUUID); err != nil {

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -154,8 +154,7 @@ FROM
 JOIN
 	mdm_apple_configuration_profiles hmacp ON hmap.profile_id = hmacp.profile_id
 WHERE 
-	host_uuid = ? AND (operation_type != '%s' OR (operation_type = '%s' AND status != '%s'))`,
-		fleet.MDMAppleOperationTypeRemove,
+	host_uuid = ? AND NOT (operation_type = '%s' AND status = '%s')`,
 		fleet.MDMAppleOperationTypeRemove,
 		fleet.MDMAppleDeliveryApplied,
 	)

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -422,6 +422,8 @@ func (s *integrationMDMTestSuite) TestProfileManagement() {
 	var res getHostResponse
 	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d", host.ID), getHostRequest{}, http.StatusOK, &res)
 	require.NotEmpty(t, res.Host.MDM.Profiles)
+	resProfiles := *res.Host.MDM.Profiles
+	require.Len(t, resProfiles, len(teamProfiles))
 }
 
 func (s *integrationMDMTestSuite) TestDEPProfileAssignment() {


### PR DESCRIPTION
Follow up to #10034 

- Filter out mdm profiles where `operation_type = 'remove' AND status = 'applied'` (frontend expects these to be pre-filtered).

# Checklist for submitter
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

