### PR TITLE
Fleet UI: Wrap activity feed

### DIFF
--- a/changes/10071-wrap-long-activity-words
+++ b/changes/10071-wrap-long-activity-words
@@ -1,0 +1,1 @@
+- Fleet UI bug: Long words in activity feed wrap within the div

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/_styles.scss
@@ -38,6 +38,7 @@
 
   &__details-topline {
     font-size: $x-small;
+    overflow-wrap: anywhere;
   }
 
   &__details-bottomline {


### PR DESCRIPTION
## Issue
Cerra #10071 

## Fix
- Wrap activity feed overflow words to fit inside div

## Screen
<img width="1161" alt="Screenshot 2023-02-23 at 3 11 42 PM" src="https://user-images.githubusercontent.com/71795832/221020295-11a288e1-f163-4ccb-b2de-f9bd26be87f9.png">
shot


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Added/updated tests

