### PR TITLE
fix No teams typo and cleanup controls page

### DIFF
--- a/frontend/components/TeamsDropdown/TeamsDropdown.tsx
+++ b/frontend/components/TeamsDropdown/TeamsDropdown.tsx
@@ -31,7 +31,7 @@ const generateDropdownOptions = (
   if (includeNoTeams) {
     options.unshift({
       disabled: false,
-      label: "No teams",
+      label: "No team",
       value: 0,
     });
   }

--- a/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
+++ b/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
@@ -1,11 +1,13 @@
 import React, { useContext } from "react";
-
+import { find } from "lodash";
+import { useQuery } from "react-query";
 import { Tab, Tabs, TabList } from "react-tabs";
 import { InjectedRouter } from "react-router";
+
 import PATHS from "router/paths";
 import { AppContext } from "context/app";
-
 import mdmAppleAPI from "services/entities/mdm_apple";
+import { IMdmApple } from "interfaces/mdm";
 
 import TabsWrapper from "components/TabsWrapper";
 import MainContent from "components/MainContent";
@@ -14,11 +16,6 @@ import TeamsDropdownHeader, {
 } from "components/PageHeader/TeamsDropdownHeader";
 import EmptyTable from "components/EmptyTable";
 import Button from "components/buttons/Button";
-
-import { IMdmApple } from "interfaces/mdm";
-
-import { find } from "lodash";
-import { useQuery } from "react-query";
 import Spinner from "components/Spinner";
 
 interface IControlsSubNavItem {


### PR DESCRIPTION
quick fix to change `No teams` to `No team`. also did some organising of import statements on controls page