### PR TITLE
max height for org logo images, ensured consistant nav height

### DIFF
--- a/changes/issue-9672-max-height-on-org-logo
+++ b/changes/issue-9672-max-height-on-org-logo
@@ -1,0 +1,1 @@
+- add max height on org logo image to ensure consistent height of the nav bar

--- a/frontend/components/icons/OrgLogoIcon/OrgLogoIcon.jsx
+++ b/frontend/components/icons/OrgLogoIcon/OrgLogoIcon.jsx
@@ -1,7 +1,10 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import classnames from "classnames";
 
 import fleetAvatar from "../../../../assets/images/fleet-avatar-24x24@2x.png";
+
+const baseClass = "org-logo-icon";
 
 class OrgLogoIcon extends Component {
   static propTypes = {
@@ -69,10 +72,12 @@ class OrgLogoIcon extends Component {
     const { imageSrc } = this.state;
     const { onError } = this;
 
+    const classNames = classnames(baseClass, className);
+
     return (
       <img
         alt="Organization Logo"
-        className={className}
+        className={classNames}
         onError={onError}
         src={imageSrc}
       />

--- a/frontend/components/icons/OrgLogoIcon/_styles.scss
+++ b/frontend/components/icons/OrgLogoIcon/_styles.scss
@@ -1,0 +1,4 @@
+.org-logo-icon {
+  // ensures consistant nav bar height regardless of the logo image used
+  max-height: 92px;
+}


### PR DESCRIPTION
relates to #9672

adds max height on org logo image to ensure consistent height of the nav bar

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
