### PR TITLE
fix showing turn off mdm host action depending on mdm solution

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
@@ -109,6 +109,7 @@ describe("Host Actions Dropdown", () => {
           onSelect={noop}
           hostStatus="online"
           hostMdmEnrollemntStatus="On (automatic)"
+          mdmName="Fleet"
         />
       );
 
@@ -132,6 +133,7 @@ describe("Host Actions Dropdown", () => {
           onSelect={noop}
           hostStatus="online"
           hostMdmEnrollemntStatus="On (automatic)"
+          mdmName="Fleet"
         />
       );
 
@@ -155,6 +157,7 @@ describe("Host Actions Dropdown", () => {
           onSelect={noop}
           hostStatus="online"
           hostMdmEnrollemntStatus="On (automatic)"
+          mdmName="Fleet"
         />
       );
 
@@ -178,12 +181,37 @@ describe("Host Actions Dropdown", () => {
           onSelect={noop}
           hostStatus="online"
           hostMdmEnrollemntStatus="On (automatic)"
+          mdmName="Fleet"
         />
       );
 
       await user.click(screen.getByText("Actions"));
 
       expect(screen.getByText("Turn off MDM")).toBeInTheDocument();
+    });
+
+    it("does not render the action when the host is enrolled in a non Fleet MDM solution", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isMdmFeatureFlagEnabled: true, // TODO: remove when we release MDM
+            isTeamMaintainer: true,
+          },
+        },
+      });
+
+      const { user } = render(
+        <HostActionsDropdown
+          onSelect={noop}
+          hostStatus="online"
+          hostMdmEnrollemntStatus="On (automatic)"
+          mdmName="Non Fleet MDM"
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+
+      expect(screen.queryByText("Turn off MDM")).not.toBeInTheDocument();
     });
 
     it("renders as disabled when the host is offline", async () => {
@@ -201,6 +229,7 @@ describe("Host Actions Dropdown", () => {
           onSelect={noop}
           hostStatus="offline"
           hostMdmEnrollemntStatus="On (automatic)"
+          mdmName="Fleet"
         />
       );
 

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tsx
@@ -13,6 +13,7 @@ interface IHostActionsDropdownProps {
   hostStatus: string;
   hostMdmEnrollemntStatus: MdmEnrollmentStatus | null;
   doesStoreEncryptionKey?: boolean;
+  mdmName?: string;
   onSelect: (value: string) => void;
 }
 
@@ -21,6 +22,7 @@ const HostActionsDropdown = ({
   hostStatus,
   hostMdmEnrollemntStatus,
   doesStoreEncryptionKey,
+  mdmName,
 }: IHostActionsDropdownProps) => {
   const {
     isPremiumTier = false,
@@ -41,6 +43,7 @@ const HostActionsDropdown = ({
     isEnrolledInMdm: ["On (automatic)", "On (manual)"].includes(
       hostMdmEnrollemntStatus ?? ""
     ),
+    isFleetMdm: mdmName === "Fleet",
     isMdmFeatureFlagEnabled,
     doesStoreEncryptionKey: doesStoreEncryptionKey ?? false,
   });

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.ts
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.ts
@@ -38,6 +38,7 @@ interface IHostActionConfigOptions {
   isTeamMaintainer: boolean;
   isHostOnline: boolean;
   isEnrolledInMdm: boolean;
+  isFleetMdm: boolean;
   isMdmFeatureFlagEnabled: boolean; // TODO: remove when we release MDM
   doesStoreEncryptionKey: boolean;
 }
@@ -54,11 +55,13 @@ const canEditMdm = (config: IHostActionConfigOptions) => {
     isTeamAdmin,
     isTeamMaintainer,
     isEnrolledInMdm,
+    isFleetMdm,
     isMdmFeatureFlagEnabled,
   } = config;
   return (
     isMdmFeatureFlagEnabled &&
     isEnrolledInMdm &&
+    isFleetMdm &&
     (isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer)
   );
 };

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -543,6 +543,7 @@ const HostDetailsPage = ({
         hostStatus={host.status}
         hostMdmEnrollemntStatus={host.mdm.enrollment_status}
         doesStoreEncryptionKey={host.mdm.encryption_key_available}
+        mdmName={host.mdm.name}
       />
     );
   };


### PR DESCRIPTION
relates to #9866

fix showing turn off mdm host action depending on mdm solution. Only shows for hosts that are managed by the Fleet mdm solution

- [x] Manual QA for all new/changed functionality
