### PR TITLE
Fleet UI: Use app context currentTeam as source of truth for teamId

### DIFF
--- a/changes/10104-policy-tab-click-bug
+++ b/changes/10104-policy-tab-click-bug
@@ -1,0 +1,1 @@
+* Fix bug to keep team when clicking on policy tab twice

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -68,9 +68,7 @@ const ManagePolicyPage = ({
   } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 
-  const teamId = location?.query?.team_id
-    ? parseInt(location?.query?.team_id, 10)
-    : 0;
+  const teamId = currentTeam?.id;
 
   const {
     setLastEditedQueryName,

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -68,7 +68,7 @@ const ManagePolicyPage = ({
   } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 
-  const teamId = currentTeam?.id;
+  const teamId = currentTeam?.id || 0;
 
   const {
     setLastEditedQueryName,


### PR DESCRIPTION
## Issue 
Cerra #10104 

## Fix
- Clicking on the policy tab again does not clear the team selected
- Use `AppContext` as source of truth which team is currently selected

## Screenshot
<img width="1549" alt="Screenshot 2023-02-27 at 11 34 25 AM" src="https://user-images.githubusercontent.com/71795832/221623383-2f3b0a8d-b42f-48d5-be95-74f9749b5da6.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

