### PR TITLE
change showing turn off mdm from data from host/:id/mdm

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -543,7 +543,7 @@ const HostDetailsPage = ({
         hostStatus={host.status}
         hostMdmEnrollemntStatus={host.mdm.enrollment_status}
         doesStoreEncryptionKey={host.mdm.encryption_key_available}
-        mdmName={host.mdm.name}
+        mdmName={mdm?.name}
       />
     );
   };


### PR DESCRIPTION
relates to https://github.com/fleetdm/fleet/issues/9866

fix displaying turn off mdm host action by using the data from `hosts/:id/mdm` to check the mdm name

- [x] Manual QA for all new/changed functionality
