### PR TITLE
Read enroll-secret and fleet-url from config profile on macOS

### DIFF
--- a/orbit/changes/9459-read-config
+++ b/orbit/changes/9459-read-config
@@ -1,0 +1,1 @@
+* Allow `fleetd` to get an enroll secret and Fleet URL configuration from a configuration profile on macOS.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -236,7 +236,6 @@ func main() {
 			case errors.Is(err, profiles.ErrNotImplemented), errors.Is(err, profiles.ErrNotFound):
 				log.Debug().Msgf("reading configuration profile: %v", err)
 			case err != nil:
-				// TODO: should we retun here? that will make orbit exit
 				log.Error().Err(err).Msg("reading configuration profile")
 			case config.EnrollSecret == "" || config.FleetURL == "":
 				log.Debug().Msg("enroll secret or fleet url are empty in configuration profile, not setting either")

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -234,7 +234,7 @@ func main() {
 			// not have a configuration profile, or to get into this situation in
 			// operating systems that don't have profile support.
 			case errors.Is(err, profiles.ErrNotImplemented), errors.Is(err, profiles.ErrNotFound):
-				log.Debug().Msgf("reading configuration profile: %e", err)
+				log.Debug().Msgf("reading configuration profile: %v", err)
 			case err != nil:
 				// TODO: should we retun here? that will make orbit exit
 				log.Error().Err(err).Msg("reading configuration profile")

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -24,6 +24,7 @@ import (
 	"github.com/fleetdm/fleet/v4/orbit/pkg/osquery"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/osservice"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/platform"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/profiles"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/orbit_info"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/token"
@@ -220,6 +221,34 @@ func main() {
 
 			if err := c.Set("enroll-secret", strings.TrimSpace(string(b))); err != nil {
 				return fmt.Errorf("set enroll secret from file: %w", err)
+			}
+		}
+
+		// if neither are set, this might be an agent deployed via MDM, try to read
+		// both configs from a configuration profile
+		if c.String("fleet-url") == "" && c.String("enroll-secret") == "" {
+			config, err := profiles.GetFleetdConfig()
+			switch {
+			// handle these errors separately as debug messages to not raise false
+			// alarms when users look into the orbit logs, it's perfectly normal to
+			// not have a configuration profile, or to get into this situation in
+			// operating systems that don't have profile support.
+			case errors.Is(err, profiles.ErrNotImplemented):
+			case errors.Is(err, profiles.ErrNotFound):
+				log.Debug().Msgf("reading configuration profile: %e", err)
+			case err != nil:
+				// TODO: should we retun here? that will make orbit exit
+				log.Error().Err(err).Msg("reading configuration profile")
+			case config.EnrollSecret == "" || config.FleetURL == "":
+				log.Debug().Msg("enroll secret or fleet url are empty in configuration profile, not setting either")
+			default:
+				log.Info().Msg("setting enroll-secret and fleet-url configs from configuration profile")
+				if err := c.Set("enroll-secret", config.EnrollSecret); err != nil {
+					return fmt.Errorf("set enroll secret from configuration profile: %w", err)
+				}
+				if err := c.Set("fleet-url", config.FleetURL); err != nil {
+					return fmt.Errorf("set fleet URL from configuration profile: %w", err)
+				}
 			}
 		}
 

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -233,8 +233,7 @@ func main() {
 			// alarms when users look into the orbit logs, it's perfectly normal to
 			// not have a configuration profile, or to get into this situation in
 			// operating systems that don't have profile support.
-			case errors.Is(err, profiles.ErrNotImplemented):
-			case errors.Is(err, profiles.ErrNotFound):
+			case errors.Is(err, profiles.ErrNotImplemented), errors.Is(err, profiles.ErrNotFound):
 				log.Debug().Msgf("reading configuration profile: %e", err)
 			case err != nil:
 				// TODO: should we retun here? that will make orbit exit

--- a/orbit/pkg/profiles/profiles.go
+++ b/orbit/pkg/profiles/profiles.go
@@ -1,0 +1,8 @@
+package profiles
+
+import "errors"
+
+var (
+	ErrNotFound       = errors.New("profile not found")
+	ErrNotImplemented = errors.New("not implemented on this platform")
+)

--- a/orbit/pkg/profiles/profiles_darwin.go
+++ b/orbit/pkg/profiles/profiles_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package profiles
 
@@ -13,24 +12,24 @@ import (
 	"github.com/groob/plist"
 )
 
-type profileItem[T any] struct {
-	PayloadContent T
+type profileItem struct {
+	PayloadContent fleet.MDMAppleFleetdConfig
 	PayloadType    string
 }
 
-type profilePayload[T any] struct {
+type profilePayload struct {
 	ProfileIdentifier string
-	ProfileItems      []profileItem[T]
+	ProfileItems      []profileItem
 }
 
-type profilesOutput[T any] struct {
-	ComputerLevel []profilePayload[T] `plist:"_computerlevel"`
+type profilesOutput struct {
+	ComputerLevel []profilePayload `plist:"_computerlevel"`
 }
 
 // GetFleetdConfig searches and parses a device level configuration profile
 // with Fleet's payload identifier.
 func GetFleetdConfig() (*fleet.MDMAppleFleetdConfig, error) {
-	p, err := getProfile[fleet.MDMAppleFleetdConfig](apple_mdm.FleetdConfigPayloadIdentifier)
+	p, err := getProfile(apple_mdm.FleetdConfigPayloadIdentifier)
 	if err != nil {
 		return nil, err
 	}
@@ -38,13 +37,13 @@ func GetFleetdConfig() (*fleet.MDMAppleFleetdConfig, error) {
 	return &p.ProfileItems[0].PayloadContent, nil
 }
 
-func getProfile[T any](identifier string) (*profilePayload[T], error) {
+func getProfile(identifier string) (*profilePayload, error) {
 	outBuf, err := execProfileCmd()
 	if err != nil {
 		return nil, fmt.Errorf("get profile: %w", err)
 	}
 
-	var profiles profilesOutput[T]
+	var profiles profilesOutput
 	if err := plist.Unmarshal(outBuf.Bytes(), &profiles); err != nil {
 		return nil, fmt.Errorf("get profile: %w", err)
 	}

--- a/orbit/pkg/profiles/profiles_darwin.go
+++ b/orbit/pkg/profiles/profiles_darwin.go
@@ -1,0 +1,72 @@
+//go:build darwin
+// +build darwin
+
+package profiles
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/groob/plist"
+)
+
+type profileItem[T any] struct {
+	PayloadContent T
+	PayloadType    string
+}
+
+type profilePayload[T any] struct {
+	ProfileIdentifier string
+	ProfileItems      []profileItem[T]
+}
+
+type profilesOutput[T any] struct {
+	ComputerLevel []profilePayload[T] `plist:"_computerlevel"`
+}
+
+// GetFleetdConfig searches and parses a device level configuration profile
+// with Fleet's payload identifier.
+func GetFleetdConfig() (*fleet.MDMAppleFleetdConfig, error) {
+	p, err := getProfile[fleet.MDMAppleFleetdConfig](apple_mdm.FleetdConfigPayloadIdentifier)
+	if err != nil {
+		return nil, err
+	}
+
+	return &p.ProfileItems[0].PayloadContent, nil
+}
+
+func getProfile[T any](identifier string) (*profilePayload[T], error) {
+	outBuf, err := execProfileCmd()
+	if err != nil {
+		return nil, fmt.Errorf("get profile: %w", err)
+	}
+
+	var profiles profilesOutput[T]
+	if err := plist.Unmarshal(outBuf.Bytes(), &profiles); err != nil {
+		return nil, fmt.Errorf("get profile: %w", err)
+	}
+
+	for _, profile := range profiles.ComputerLevel {
+		if profile.ProfileIdentifier == identifier {
+			return &profile, nil
+		}
+	}
+
+	return nil, ErrNotFound
+}
+
+// execProfileCmd is declared as a variable so it can be overwritten by tests.
+var execProfileCmd = func() (*bytes.Buffer, error) {
+	var outBuf bytes.Buffer
+	cmd := exec.Command("/usr/bin/profiles", "list", "-o", "stdout-xml")
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &outBuf
+
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	return &outBuf, nil
+}

--- a/orbit/pkg/profiles/profiles_darwin_test.go
+++ b/orbit/pkg/profiles/profiles_darwin_test.go
@@ -1,0 +1,110 @@
+//go:build darwin
+// +build darwin
+
+package profiles
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFleetdConfig(t *testing.T) {
+	testErr := errors.New("test error")
+	cases := []struct {
+		cmdOut  *string
+		cmdErr  error
+		wantOut *fleet.MDMAppleFleetdConfig
+		wantErr error
+	}{
+		{nil, testErr, nil, testErr},
+		{ptr.String("invalid-xml"), nil, nil, io.EOF},
+		{&emptyOutput, nil, nil, ErrNotFound},
+		{&withFleetdConfig, nil, &fleet.MDMAppleFleetdConfig{EnrollSecret: "ENROLL_SECRET", FleetURL: "https://test.example.com"}, nil},
+	}
+
+	origExecProfileCmd := execProfileCmd
+	t.Cleanup(func() { execProfileCmd = origExecProfileCmd })
+	for _, c := range cases {
+		execProfileCmd = func() (*bytes.Buffer, error) {
+			if c.cmdOut == nil {
+				return nil, c.cmdErr
+			}
+
+			var buf bytes.Buffer
+			buf.WriteString(*c.cmdOut)
+			return &buf, nil
+		}
+
+		out, err := GetFleetdConfig()
+		require.ErrorIs(t, err, c.wantErr)
+		require.Equal(t, c.wantOut, out)
+	}
+
+}
+
+var (
+	emptyOutput = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>`
+
+	withFleetdConfig = `
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_computerlevel</key>
+	<array>
+		<dict>
+			<key>ProfileDescription</key>
+			<string>test descripiton</string>
+			<key>ProfileDisplayName</key>
+			<string>test name</string>
+			<key>ProfileIdentifier</key>
+			<string>com.fleetdm.fleetd.config</string>
+			<key>ProfileInstallDate</key>
+			<string>2023-02-27 18:55:07 +0000</string>
+			<key>ProfileItems</key>
+			<array>
+				<dict>
+					<key>PayloadContent</key>
+					<dict>
+						<key>EnrollSecret</key>
+						<string>ENROLL_SECRET</string>
+						<key>FleetURL</key>
+						<string>https://test.example.com</string>
+					</dict>
+					<key>PayloadDescription</key>
+					<string>test description</string>
+					<key>PayloadDisplayName</key>
+					<string>test name</string>
+					<key>PayloadIdentifier</key>
+					<string>com.fleetdm.fleetd.config</string>
+					<key>PayloadType</key>
+					<string>com.fleetdm.fleetd</string>
+					<key>PayloadUUID</key>
+					<string>0C6AFB45-01B6-4E19-944A-123CD16381C7</string>
+					<key>PayloadVersion</key>
+					<integer>1</integer>
+				</dict>
+			</array>
+			<key>ProfileRemovalDisallowed</key>
+			<string>true</string>
+			<key>ProfileType</key>
+			<string>Configuration</string>
+			<key>ProfileUUID</key>
+			<string>8D0F62E6-E24F-4B2F-AFA8-CAC1F07F4FDC</string>
+			<key>ProfileVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+</dict>
+</plist>`
+)

--- a/orbit/pkg/profiles/profiles_darwin_test.go
+++ b/orbit/pkg/profiles/profiles_darwin_test.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package profiles
 

--- a/orbit/pkg/profiles/profiles_notdarwin.go
+++ b/orbit/pkg/profiles/profiles_notdarwin.go
@@ -1,0 +1,10 @@
+//go:build !darwin
+// +build !darwin
+
+package profiles
+
+import "github.com/fleetdm/fleet/v4/server/fleet"
+
+func GetFleetdConfig() (*fleet.MDMAppleFleetdConfiguration, error) {
+	return nil, ErrNotImplemented
+}

--- a/orbit/pkg/profiles/profiles_notdarwin.go
+++ b/orbit/pkg/profiles/profiles_notdarwin.go
@@ -1,5 +1,4 @@
 //go:build !darwin
-// +build !darwin
 
 package profiles
 

--- a/orbit/pkg/profiles/profiles_notdarwin.go
+++ b/orbit/pkg/profiles/profiles_notdarwin.go
@@ -5,6 +5,6 @@ package profiles
 
 import "github.com/fleetdm/fleet/v4/server/fleet"
 
-func GetFleetdConfig() (*fleet.MDMAppleFleetdConfiguration, error) {
+func GetFleetdConfig() (*fleet.MDMAppleFleetdConfig, error) {
 	return nil, ErrNotImplemented
 }

--- a/orbit/pkg/profiles/profiles_notdarwin_test.go
+++ b/orbit/pkg/profiles/profiles_notdarwin_test.go
@@ -1,0 +1,16 @@
+//go:build !darwin
+// +build !darwin
+
+package profiles
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFleetdConfig(t *testing.T) {
+	config, err := GetFleetdConfig()
+	require.ErrorIs(t, ErrNotImplemented, err)
+	require.Nil(t, config)
+}

--- a/orbit/pkg/profiles/profiles_notdarwin_test.go
+++ b/orbit/pkg/profiles/profiles_notdarwin_test.go
@@ -1,5 +1,4 @@
 //go:build !darwin
-// +build !darwin
 
 package profiles
 

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -445,3 +445,10 @@ type MDMAppleBulkUpsertHostProfilePayload struct {
 	OperationType     MDMAppleOperationType
 	Status            *MDMAppleDeliveryStatus
 }
+
+// MDMAppleFleetdConfig contains the fields used to configure
+// `fleetd` in macOS devices via a configuration profile.
+type MDMAppleFleetdConfig struct {
+	FleetURL     string
+	EnrollSecret string
+}

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -38,6 +38,10 @@ const (
 	// FleetPayloadIdentifier is the value for the "<key>PayloadIdentifier</key>"
 	// used by Fleet MDM on the enrollment profile.
 	FleetPayloadIdentifier = "com.fleetdm.fleet.mdm.apple"
+
+	// FleetdConfigPayloadIdentifier is the value for the PayloadIdentifier used
+	// by fleetd to read configuration values from the system.
+	FleetdConfigPayloadIdentifier = "com.fleetdm.fleetd.config"
 )
 
 func ResolveAppleMDMURL(serverURL string) (string, error) {


### PR DESCRIPTION
This allows orbit to read enroll-secret and fleet-url from a configuration profile if both values are not set when the package is built.

Part of https://github.com/fleetdm/fleet/issues/9459

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
