### PR TITLE
Remove contents:write from build-orbit action

### DIFF
--- a/.github/workflows/build-orbit.yaml
+++ b/.github/workflows/build-orbit.yaml
@@ -21,8 +21,6 @@ permissions:
 jobs:
   build:
     runs-on: macos-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2


### PR DESCRIPTION
This is no longer needed since we use the upload action rather than draft GitHub release.