### PR TITLE
CIS - WIN10 - 2.3.10.X policies

### DIFF
--- a/changes/9921-cis-win-10-2.3.10.x
+++ b/changes/9921-cis-win-10-2.3.10.x
@@ -1,0 +1,1 @@
+- Add Win 10 policies for CIS Benchmark 2.3.10.x

--- a/ee/cis/win-10/cis-policy-queries.yml
+++ b/ee/cis/win-10/cis-policy-queries.yml
@@ -723,9 +723,7 @@ spec:
     environment.
   resolution: |
     To establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
-    Policies\Security Options\Network access: Do not allow anonymous enumeration
-    of SAM accounts and shares'
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow anonymous enumeration of SAM accounts and shares'
   query: |
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\restrictanonymous' AND data != 0);
   purpose: Informational
@@ -745,9 +743,7 @@ spec:
     authentication.
   resolution: |
     To establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
-    Policies\Security Options\Network access: Do not allow storage of passwords
-    and credentials for network authentication'
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow storage of passwords and credentials for network authentication'
   query: |
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\disabledomaincreds' AND data != 0);
   purpose: Informational
@@ -766,9 +762,7 @@ spec:
     connections to the computer.
   resolution: |
     To establish the recommended configuration via GP, set the following UI path to Disabled:
-    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
-    Policies\Security Options\Network access: Let Everyone permissions apply to
-    anonymous users'
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Let Everyone permissions apply to anonymous users'
   query: |
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\everyoneincludesanonymous' AND data == 0);
   purpose: Informational
@@ -788,9 +782,7 @@ spec:
   resolution: |
     To establish the recommended configuration via GP, set the following UI path to <blank>
     (i.e. None):
-    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
-    Policies\Security Options\Network access: Named Pipes that can be accessed
-    anonymously'
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Named Pipes that can be accessed anonymously'
   query: |
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanManServer\\Parameters\NullSessionPipes' and data == '');
   purpose: Informational
@@ -813,8 +805,7 @@ spec:
     System\CurrentControlSet\Control\ProductOptions
     System\CurrentControlSet\Control\Server Applications
     SOFTWARE\Microsoft\Windows NT\CurrentVersion
-    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
-    Policies\Security Options\Network access: Remotely accessible registry paths'
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Remotely accessible registry paths'
   query: |
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SecurePipeServers\\Winreg\\AllowedExactPaths\Machine' and data == 'System\CurrentControlSet\Control\ProductOptions,System\CurrentControlSet\Control\Server Applications,Software\Microsoft\Windows NT\CurrentVersion');
   purpose: Informational
@@ -845,9 +836,7 @@ spec:
     System\CurrentControlSet\Control\Terminal Server\DefaultUserConfiguration
     SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib
     System\CurrentControlSet\Services\SysmonLog
-    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
-    Policies\Security Options\Network access: Remotely accessible registry paths
-    and sub-paths'
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Remotely accessible registry paths and sub-paths'
   query: |
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SecurePipeServers\\Winreg\\AllowedPaths\Machine' and data == 'System\CurrentControlSet\Control\Print\Printers,System\CurrentControlSet\Services\Eventlog,Software\Microsoft\OLAP Server,Software\Microsoft\Windows NT\CurrentVersion\Print,Software\Microsoft\Windows NT\CurrentVersion\Windows,System\CurrentControlSet\Control\ContentIndex,System\CurrentControlSet\Control\Terminal Server,System\CurrentControlSet\Control\Terminal Server\UserConfig,System\CurrentControlSet\Control\Terminal Server\DefaultUserConfiguration,Software\Microsoft\Windows NT\CurrentVersion\Perflib,System\CurrentControlSet\Services\SysmonLog');
   purpose: Informational
@@ -872,9 +861,7 @@ spec:
     server service restricts unauthenticated clients' access to named resources.
   resolution: |
     To establish the recommended configuration via GP, set the following UI path to Enabled:
-    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
-    Policies\Security Options\Network access: Restrict anonymous access to Named
-    Pipes and Shares'
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Restrict anonymous access to Named Pipes and Shares'
   query: |
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanManServer\\Parameters\restrictnullsessaccess' and data == '1');
   purpose: Informational
@@ -893,9 +880,7 @@ spec:
   resolution: |
     To establish the recommended configuration via GP, set the following UI path to
     Administrators: Remote Access: Allow:
-    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
-    Policies\Security Options\Network access: Restrict clients allowed to make
-    remote calls to SAM'
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Restrict clients allowed to make remote calls to SAM'
   query: |
 SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\RestrictRemoteSAM' and (data == '' or data == 'O:BAG:BAD:'));
   purpose: Informational
@@ -916,9 +901,7 @@ spec:
   resolution: |
     To establish the recommended configuration via GP, set the following UI path to <blank>
     (i.e. None):
-    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
-    Policies\Security Options\Network access: Shares that can be accessed
-    anonymously'
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Shares that can be accessed anonymously'
   query: |
     SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanManServer\\Parameters\NullSessionShares' and data == '');
   purpose: Informational
@@ -941,9 +924,7 @@ spec:
   resolution: |
     To establish the recommended configuration via GP, set the following UI path to Classic -
     local users authenticate as themselves:
-    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
-    Policies\Security Options\Network access: Sharing and security model for
-    local accounts'
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Sharing and security model for local accounts'
   query: |
         SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\forceguest' AND data == 0);
   purpose: Informational

--- a/ee/cis/win-10/cis-policy-queries.yml
+++ b/ee/cis/win-10/cis-policy-queries.yml
@@ -667,26 +667,26 @@ spec:
   tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.7.8
   contributors: marcosd4h
 ---
-apiVersion: v1
-kind: policy
-spec:
-  name: >
-    CIS - Ensure 'Network access : Allow anonymous SID/Name translation' is set to 'Disabled' (Automated)
-  platforms: win10
-  platform: windows
-  description: |
-    This policy setting determines whether an anonymous user can request security identifier
-    (SID) attributes for another user, or use a SID to obtain its corresponding user name.
-    The recommended state for this setting is: Disabled.
-  resolution: |
-    To establish the recommended configuration via GP, set the following UI path to Disabled:
-    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Allow anonymous SID/Name translation'
-  query: |
-    TODO
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.1
-  contributors: rachelelysia
----
+# apiVersion: v1
+# kind: policy
+# spec:
+#   name: >
+#     CIS - Ensure 'Network access : Allow anonymous SID/Name translation' is set to 'Disabled' (Automated)
+#   platforms: win10
+#   platform: windows
+#   description: |
+#     This policy setting determines whether an anonymous user can request security identifier
+#     (SID) attributes for another user, or use a SID to obtain its corresponding user name.
+#     The recommended state for this setting is: Disabled.
+#   resolution: |
+#     To establish the recommended configuration via GP, set the following UI path to Disabled:
+#     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Allow anonymous SID/Name translation'
+#   query: |
+#     TODO: See ./test/debug/CIS_2.3.10.1.txt for more information
+#   purpose: Informational
+#   tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.1
+#   contributors: rachelelysia
+# ---
 apiVersion: v1
 kind: policy
 spec:
@@ -920,7 +920,7 @@ spec:
     Policies\Security Options\Network access: Shares that can be accessed
     anonymously'
   query: |
-    TODO
+    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanManServer\\Parameters\NullSessionShares' and data == '');
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.11
   contributors: rachelelysia
@@ -945,7 +945,7 @@ spec:
     Policies\Security Options\Network access: Sharing and security model for
     local accounts'
   query: |
-    TODO
+        SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\forceguest' AND data == 0);
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.12
   contributors: rachelelysia

--- a/ee/cis/win-10/cis-policy-queries.yml
+++ b/ee/cis/win-10/cis-policy-queries.yml
@@ -704,8 +704,7 @@ spec:
     To establish the recommended configuration via GP, set the following UI path to Enabled:
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow anonymous enumeration of SAM accounts'
   query: |
-    TODO
-    SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/LocalPoliciesSecurityOptions/NetworkAccess_DoNotAllowAnonymousEnumerationOfSAMAccountsAndShares</LocURI></Target></Item></Get></SyncBody>";
+        SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\restrictanonymoussam' AND data != 0);
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.2
   contributors: rachelelysia

--- a/ee/cis/win-10/cis-policy-queries.yml
+++ b/ee/cis/win-10/cis-policy-queries.yml
@@ -792,7 +792,7 @@ spec:
     Policies\Security Options\Network access: Named Pipes that can be accessed
     anonymously'
   query: |
-    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanManServer\Parameters\NullSessionPipes' and data == '');
+    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanManServer\\Parameters\NullSessionPipes' and data == '');
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.6
   contributors: rachelelysia
@@ -849,7 +849,7 @@ spec:
     Policies\Security Options\Network access: Remotely accessible registry paths
     and sub-paths'
   query: |
-    TODO
+    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SecurePipeServers\\Winreg\\AllowedPaths\Machine' and data == 'System\CurrentControlSet\Control\Print\Printers,System\CurrentControlSet\Services\Eventlog,Software\Microsoft\OLAP Server,Software\Microsoft\Windows NT\CurrentVersion\Print,Software\Microsoft\Windows NT\CurrentVersion\Windows,System\CurrentControlSet\Control\ContentIndex,System\CurrentControlSet\Control\Terminal Server,System\CurrentControlSet\Control\Terminal Server\UserConfig,System\CurrentControlSet\Control\Terminal Server\DefaultUserConfiguration,Software\Microsoft\Windows NT\CurrentVersion\Perflib,System\CurrentControlSet\Services\SysmonLog');
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.8
   contributors: rachelelysia
@@ -876,7 +876,7 @@ spec:
     Policies\Security Options\Network access: Restrict anonymous access to Named
     Pipes and Shares'
   query: |
-    TODO
+    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanManServer\\Parameters\restrictnullsessaccess' and data == '1');
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.9
   contributors: rachelelysia
@@ -897,7 +897,7 @@ spec:
     Policies\Security Options\Network access: Restrict clients allowed to make
     remote calls to SAM'
   query: |
-    TODO
+SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\RestrictRemoteSAM' and (data == '' or data == 'O:BAG:BAD:'));
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.10
   contributors: rachelelysia

--- a/ee/cis/win-10/cis-policy-queries.yml
+++ b/ee/cis/win-10/cis-policy-queries.yml
@@ -58,7 +58,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Minimum password length' is set to '14 or more characters' 
+  name: CIS - Ensure 'Minimum password length' is set to '14 or more characters'
   platforms: win10
   platform: windows
   description: |
@@ -76,7 +76,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Password must meet complexity requirements' is set to 'Enabled' 
+  name: CIS - Ensure 'Password must meet complexity requirements' is set to 'Enabled'
   platforms: win10
   platform: windows
   description: |
@@ -243,7 +243,7 @@ spec:
   description: |
     This policy setting allows a process to assume the identity of any user and thus gain access to the resources that the user is authorized to access.
     The recommended state for this setting is: No One.
-    Note: This user right is considered a "sensitive privilege" for the purposes of auditing. 
+    Note: This user right is considered a "sensitive privilege" for the purposes of auditing.
   resolution: |
     Automatic method:
     Ask your system administrator to establish the recommended configuration via GP, set the following UI path to an empty list of users:
@@ -330,7 +330,7 @@ spec:
   description: |
     This policy setting allows users to circumvent file and directory permissions to back up the system. This user right is enabled only when an application (such as NTBACKUP) attempts to access a file or directory through the NTFS file system backup application programming interface (API). Otherwise, the assigned file and directory permissions apply.
     The recommended state for this setting is: Administrators.
-    Note: This user right is considered a "sensitive privilege" for the purposes of auditing. 
+    Note: This user right is considered a "sensitive privilege" for the purposes of auditing.
   resolution: |
     Automatic method:
     Ask your system administrator to establish the recommended configuration via GP, set the following UI path to a list containing only 'Administrators':
@@ -344,11 +344,11 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure 'Accounts Administrator account status' is set to 'Disabled' 
+  name: CIS - Ensure 'Accounts Administrator account status' is set to 'Disabled'
   platforms: win10
   platform: windows
   description: |
-    This policy setting enables or disables the Administrator account during normal operation. 
+    This policy setting enables or disables the Administrator account during normal operation.
   resolution: |
     Automatic method:
     Ask your system administrator to establish the recommended configuration via GP, set the following UI path to 'Disabled':
@@ -422,7 +422,7 @@ spec:
   description: |
     The built-in local administrator account is a well-known account name that attackers will
     target. It is recommended to choose another name for this account, and to avoid names that
-    denote administrative or elevated access accounts. 
+    denote administrative or elevated access accounts.
   resolution: |
     Automatic method:
     Ask your system administrator to establish the recommended configuration via GP, set the following UI path to value different than 'Administrator':
@@ -481,7 +481,7 @@ spec:
     This policy setting determines whether the system shuts down if it is unable to log Security
     events. It is a requirement for Trusted Computer System Evaluation Criteria (TCSEC)-C2 and
     Common Criteria certification to prevent auditable events from occurring if the audit system is
-    unable to log them. 
+    unable to log them.
   resolution: |
     Automatic method:
     Ask your system administrator to establish the recommended configuration via GP, set the following UI path to 'Disabled':
@@ -501,7 +501,7 @@ spec:
   description: |
     For a computer to print to a shared printer, the driver for that shared printer must be
     installed on the local computer. This security setting determines who is allowed to install a
-    printer driver as part of connecting to a shared printer. 
+    printer driver as part of connecting to a shared printer.
   resolution: |
     Automatic method:
     Ask your system administrator to establish the recommended configuration via GP, set the following UI path to 'Enabled':
@@ -519,7 +519,7 @@ spec:
   platforms: win10
   platform: windows
   description: |
-    This policy setting determines whether users must press CTRL+ALT+DEL before they log on. 
+    This policy setting determines whether users must press CTRL+ALT+DEL before they log on.
   resolution: |
     Automatic method:
     Ask your system administrator to establish the recommended configuration via GP, set the following UI path to 'Disabled':
@@ -589,7 +589,7 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Configure 'Interactive logon Message text for users attempting to log on' 
+  name: CIS - Configure 'Interactive logon Message text for users attempting to log on'
   platforms: win10
   platform: windows
   description: |
@@ -666,3 +666,220 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.7.8
   contributors: marcosd4h
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: >
+    CIS - Ensure 'Network access : Allow anonymous SID/Name translation' is set to 'Disabled' (Automated)
+  platforms: win10
+  platform: windows
+  description: |
+    This policy setting determines whether an anonymous user can request security identifier
+    (SID) attributes for another user, or use a SID to obtain its corresponding user name.
+    The recommended state for this setting is: Disabled.
+  resolution: |
+    To establish the recommended configuration via GP, set the following UI path to Disabled:
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Allow anonymous SID/Name translation'
+  query: |
+    TODO
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.1
+  contributors: rachelelysia
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: >
+    CIS - Ensure 'Network access: Do not allow anonymous enumeration of SAM accounts' is set to 'Enabled' (Automated)
+  platforms: win10
+  platform: windows
+  description: |
+    This policy setting controls the ability of anonymous users to enumerate the accounts in
+    the Security Accounts Manager (SAM). If you enable this policy setting, users with
+    anonymous connections will not be able to enumerate domain account user names on the
+    systems in your environment. This policy setting also allows additional restrictions on
+    anonymous connections. 
+    The recommended state for this setting is: Enabled.
+    Note: This policy has no effect on Domain Controllers.
+  resolution: |
+    To establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow anonymous enumeration of SAM accounts'
+  query: |
+    TODO
+    SELECT 1 FROM mdm_bridge where mdm_command_input = "<SyncBody><Get><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Result/LocalPoliciesSecurityOptions/NetworkAccess_DoNotAllowAnonymousEnumerationOfSAMAccountsAndShares</LocURI></Target></Item></Get></SyncBody>";
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.2
+  contributors: rachelelysia
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: >
+    CIS - Ensure 'Network access: Do not allow anonymous enumeration of SAM accounts and shares' is set to 'Enabled' (Automated)
+  platforms: win10
+  platform: windows
+  description: |
+    TODO
+  resolution: |
+    TODO
+  query: |
+    TODO
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.3
+  contributors: rachelelysia
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: >
+    CIS - Ensure 'Network access: Do not allow storage of passwords and credentials for network authentication' is set to 'Enabled' (Automated)
+  platforms: win10
+  platform: windows
+  description: |
+    TODO
+  resolution: |
+    TODO
+  query: |
+    TODO
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.4
+  contributors: rachelelysia
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: >
+    CIS - Ensure 'Network access: Let Everyone permissions apply to anonymous users' is set to 'Disabled' (Automated)
+  platforms: win10
+  platform: windows
+  description: |
+    TODO
+  resolution: |
+    TODO
+  query: |
+    TODO
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.5
+  contributors: rachelelysia
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: >
+    CIS - Ensure 'Network access: Named Pipes that can be accessed anonymously' is set to 'None' (Automated)
+  platforms: win10
+  platform: windows
+  description: |
+    TODO
+  resolution: |
+    TODO
+  query: |
+    TODO
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.6
+  contributors: rachelelysia
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: >
+    CIS - Ensure 'Network access: Remotely accessible registry paths' is configured (Automated)
+  platforms: win10
+  platform: windows
+  description: |
+    TODO
+  resolution: |
+    TODO
+  query: |
+    TODO
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.7
+  contributors: rachelelysia
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: >
+    CIS - Ensure 'Network access: Remotely accessible registry paths and sub-paths' is configured (Automated)
+  platforms: win10
+  platform: windows
+  description: |
+    TODO
+  resolution: |
+    TODO
+  query: |
+    TODO
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.8
+  contributors: rachelelysia
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: >
+    CIS - Ensure 'Network access: Restrict anonymous access to Named Pipes and Shares' is set to 'Enabled' (Automated)
+  platforms: win10
+  platform: windows
+  description: |
+    TODO
+  resolution: |
+    TODO
+  query: |
+    TODO
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.9
+  contributors: rachelelysia
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: >
+    CIS - Ensure 'Network access: Restrict clients allowed to make remote calls to SAM' is set to 'Administrators: Remote Access: Allow' (Automated)
+  platforms: win10
+  platform: windows
+  description: |
+    TODO
+  resolution: |
+    TODO
+  query: |
+    TODO
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.10
+  contributors: rachelelysia
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: >
+    CIS - Ensure 'Network access: Shares that can be accessed anonymously' is set to 'None' (Automated)
+  platforms: win10
+  platform: windows
+  description: |
+    TODO
+  resolution: |
+    TODO
+  query: |
+    TODO
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.11
+  contributors: rachelelysia
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: >
+    CIS - Ensure 'Network access: Sharing and security model for local accounts' is set to 'Classic - local users authenticate as themselves' (Automated)
+  platforms: win10
+  platform: windows
+  description: |
+    TODO
+  resolution: |
+    TODO
+  query: |
+    TODO
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.12
+  contributors: rachelelysia
+---
+

--- a/ee/cis/win-10/cis-policy-queries.yml
+++ b/ee/cis/win-10/cis-policy-queries.yml
@@ -770,7 +770,7 @@ spec:
     Policies\Security Options\Network access: Let Everyone permissions apply to
     anonymous users'
   query: |
-    TODO
+    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\everyoneincludesanonymous' AND data == 0);
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.5
   contributors: rachelelysia
@@ -792,7 +792,7 @@ spec:
     Policies\Security Options\Network access: Named Pipes that can be accessed
     anonymously'
   query: |
-    TODO
+    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanManServer\Parameters\NullSessionPipes' and data == '');
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.6
   contributors: rachelelysia
@@ -816,7 +816,7 @@ spec:
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local
     Policies\Security Options\Network access: Remotely accessible registry paths'
   query: |
-    TODO
+    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SecurePipeServers\\Winreg\\AllowedExactPaths\Machine' and data == 'System\CurrentControlSet\Control\ProductOptions,System\CurrentControlSet\Control\Server Applications,Software\Microsoft\Windows NT\CurrentVersion');
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.7
   contributors: rachelelysia

--- a/ee/cis/win-10/cis-policy-queries.yml
+++ b/ee/cis/win-10/cis-policy-queries.yml
@@ -704,7 +704,7 @@ spec:
     To establish the recommended configuration via GP, set the following UI path to Enabled:
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow anonymous enumeration of SAM accounts'
   query: |
-        SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\restrictanonymoussam' AND data != 0);
+    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\restrictanonymoussam' AND data != 0);
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.2
   contributors: rachelelysia
@@ -727,7 +727,7 @@ spec:
     Policies\Security Options\Network access: Do not allow anonymous enumeration
     of SAM accounts and shares'
   query: |
-    TODO
+    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\restrictanonymous' AND data != 0);
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.3
   contributors: rachelelysia
@@ -749,7 +749,7 @@ spec:
     Policies\Security Options\Network access: Do not allow storage of passwords
     and credentials for network authentication'
   query: |
-    TODO
+    SELECT 1 FROM registry WHERE (path = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\disabledomaincreds' AND data != 0);
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS_win10_enterprise_1.12.0, CIS_bullet_2.3.10.4
   contributors: rachelelysia

--- a/ee/cis/win-10/cis-policy-queries.yml
+++ b/ee/cis/win-10/cis-policy-queries.yml
@@ -699,9 +699,7 @@ spec:
     the Security Accounts Manager (SAM). If you enable this policy setting, users with
     anonymous connections will not be able to enumerate domain account user names on the
     systems in your environment. This policy setting also allows additional restrictions on
-    anonymous connections. 
-    The recommended state for this setting is: Enabled.
-    Note: This policy has no effect on Domain Controllers.
+    anonymous connections.
   resolution: |
     To establish the recommended configuration via GP, set the following UI path to Enabled:
     'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow anonymous enumeration of SAM accounts'
@@ -720,9 +718,15 @@ spec:
   platforms: win10
   platform: windows
   description: |
-    TODO
+    This policy setting controls the ability of anonymous users to enumerate SAM accounts as
+    well as shares. If you enable this policy setting, anonymous users will not be able to
+    enumerate domain account user names and network share names on the systems in your
+    environment.
   resolution: |
-    TODO
+    To establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
+    Policies\Security Options\Network access: Do not allow anonymous enumeration
+    of SAM accounts and shares'
   query: |
     TODO
   purpose: Informational
@@ -737,9 +741,14 @@ spec:
   platforms: win10
   platform: windows
   description: |
-    TODO
+    This policy setting determines whether Credential Manager (formerly called Stored User
+    Names and Passwords) saves passwords or credentials for later use when it gains domain
+    authentication.
   resolution: |
-    TODO
+    To establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
+    Policies\Security Options\Network access: Do not allow storage of passwords
+    and credentials for network authentication'
   query: |
     TODO
   purpose: Informational
@@ -754,9 +763,13 @@ spec:
   platforms: win10
   platform: windows
   description: |
-    TODO
+    This policy setting determines what additional permissions are assigned for anonymous
+    connections to the computer.
   resolution: |
-    TODO
+    To establish the recommended configuration via GP, set the following UI path to Disabled:
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
+    Policies\Security Options\Network access: Let Everyone permissions apply to
+    anonymous users'
   query: |
     TODO
   purpose: Informational
@@ -771,9 +784,14 @@ spec:
   platforms: win10
   platform: windows
   description: |
-    TODO
+    This policy setting determines which communication sessions, or pipes, will have attributes
+    and permissions that allow anonymous access.
   resolution: |
-    TODO
+    To establish the recommended configuration via GP, set the following UI path to <blank>
+    (i.e. None):
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
+    Policies\Security Options\Network access: Named Pipes that can be accessed
+    anonymously'
   query: |
     TODO
   purpose: Informational
@@ -788,9 +806,16 @@ spec:
   platforms: win10
   platform: windows
   description: |
-    TODO
+    This policy setting determines which registry paths will be accessible over the network,
+    regardless of the users or groups listed in the access control list (ACL) of the winreg
+    registry key.
   resolution: |
-    TODO
+    To establish the recommended configuration via GP, set the following UI path to:
+    System\CurrentControlSet\Control\ProductOptions
+    System\CurrentControlSet\Control\Server Applications
+    SOFTWARE\Microsoft\Windows NT\CurrentVersion
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
+    Policies\Security Options\Network access: Remotely accessible registry paths'
   query: |
     TODO
   purpose: Informational
@@ -805,9 +830,25 @@ spec:
   platforms: win10
   platform: windows
   description: |
-    TODO
+    This policy setting determines which registry paths and sub-paths will be accessible over
+    the network, regardless of the users or groups listed in the access control list (ACL) of the
+    winreg registry key.
   resolution: |
-    TODO
+    To establish the recommended configuration via GP, set the following UI path to:
+    System\CurrentControlSet\Control\Print\Printers
+    System\CurrentControlSet\Services\Eventlog
+    SOFTWARE\Microsoft\OLAP Server
+    SOFTWARE\Microsoft\Windows NT\CurrentVersion\Print
+    SOFTWARE\Microsoft\Windows NT\CurrentVersion\Windows
+    System\CurrentControlSet\Control\ContentIndex
+    System\CurrentControlSet\Control\Terminal Server
+    System\CurrentControlSet\Control\Terminal Server\UserConfig
+    System\CurrentControlSet\Control\Terminal Server\DefaultUserConfiguration
+    SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib
+    System\CurrentControlSet\Services\SysmonLog
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
+    Policies\Security Options\Network access: Remotely accessible registry paths
+    and sub-paths'
   query: |
     TODO
   purpose: Informational
@@ -822,9 +863,19 @@ spec:
   platforms: win10
   platform: windows
   description: |
-    TODO
+    When enabled, this policy setting restricts anonymous access to only those shares and
+    pipes that are named in the Network access: Named pipes that can be accessed
+    anonymously and Network access: Shares that can be accessed anonymously settings.
+    This policy setting controls null session access to shares on your computers by adding
+    RestrictNullSessAccess with the value 1 in the
+    HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters
+    registry key. This registry value toggles null session shares on or off to control whether the
+    server service restricts unauthenticated clients' access to named resources.
   resolution: |
-    TODO
+    To establish the recommended configuration via GP, set the following UI path to Enabled:
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
+    Policies\Security Options\Network access: Restrict anonymous access to Named
+    Pipes and Shares'
   query: |
     TODO
   purpose: Informational
@@ -839,9 +890,13 @@ spec:
   platforms: win10
   platform: windows
   description: |
-    TODO
+    This policy setting allows you to restrict remote RPC connections to SAM.
   resolution: |
-    TODO
+    To establish the recommended configuration via GP, set the following UI path to
+    Administrators: Remote Access: Allow:
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
+    Policies\Security Options\Network access: Restrict clients allowed to make
+    remote calls to SAM'
   query: |
     TODO
   purpose: Informational
@@ -856,9 +911,15 @@ spec:
   platforms: win10
   platform: windows
   description: |
-    TODO
+    This policy setting determines which network shares can be accessed by anonymous users.
+    The default configuration for this policy setting has little effect because all users have to be
+    authenticated before they can access shared resources on the server.
   resolution: |
-    TODO
+    To establish the recommended configuration via GP, set the following UI path to <blank>
+    (i.e. None):
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
+    Policies\Security Options\Network access: Shares that can be accessed
+    anonymously'
   query: |
     TODO
   purpose: Informational
@@ -873,9 +934,17 @@ spec:
   platforms: win10
   platform: windows
   description: |
-    TODO
+    This policy setting determines how network logons that use local accounts are
+    authenticated. The Classic option allows precise control over access to resources, including
+    the ability to assign different types of access to different users for the same resource. The
+    Guest only option allows you to treat all users equally. In this context, all users authenticate
+    as Guest only to receive the same access level to a given resource.
   resolution: |
-    TODO
+    To establish the recommended configuration via GP, set the following UI path to Classic -
+    local users authenticate as themselves:
+    'Computer Configuration\Policies\Windows Settings\Security Settings\Local
+    Policies\Security Options\Network access: Sharing and security model for
+    local accounts'
   query: |
     TODO
   purpose: Informational

--- a/ee/cis/win-10/test/debug/CIS_2.3.10.1.txt
+++ b/ee/cis/win-10/test/debug/CIS_2.3.10.1.txt
@@ -1,0 +1,29 @@
+Expected scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to 'Disabled':
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Allow anonymous SID/Name
+translation'
+
+2) After running the policy check, it should return 1 indicating that setting was properly set
+
+
+
+Failure scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to a value different than 'Disabled':
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Allow anonymous SID/Name
+translation'
+
+2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value
+
+TODO
+==================
+Everything is done but writing the Query
+
+Notes
+==================
+- No HKEY
+- No OMAURI
+- CIS Benchmarks Page 228: https://drive.google.com/file/d/16M2AuKHu_x-WJZWObhl_7MpZkPkKSQaq/view
+- Tenable website entry: https://www.tenable.com/audits/items/CIS_Microsoft_Windows_Server_2022_Benchmark_v1.0.0_L1_DC.audit:2160eacb1749dc3d77171ae1d7a2db96
+- Tried searching all related registry items (SELECT * FROM registry WHERE (key = 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa');) for a path being modified, but that path has nothing related to this policy

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.10.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.10.txt
@@ -1,8 +1,7 @@
 Expected scenario
 ==================
 1) Open "Edit Group Policy" tool and set the following UI path to an empty value (to allow):
-'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Restrict clients allowed to make
-remote calls to SAM'
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Restrict clients allowed to make remote calls to SAM'
 
 2) After running the policy check, it should return 1 indicating that setting was properly set
 
@@ -11,8 +10,7 @@ remote calls to SAM'
 Failure scenario
 ==================
 1) Open "Edit Group Policy" tool and set the following UI path to a non-empty value:
-'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Restrict clients allowed to make
-remote calls to SAM'
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Restrict clients allowed to make remote calls to SAM'
 
 2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value
 

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.10.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.10.txt
@@ -4,7 +4,7 @@ Expected scenario
 'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Restrict clients allowed to make
 remote calls to SAM'
 
-2) After running the policy check, it should return '' (or 'O:BAG:BAD:' if the setting was previously modified) indicating that setting was properly set
+2) After running the policy check, it should return 1 indicating that setting was properly set
 
 
 

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.10.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.10.txt
@@ -1,0 +1,23 @@
+Expected scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to an empty value (to allow):
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Restrict clients allowed to make
+remote calls to SAM'
+
+2) After running the policy check, it should return '' (or 'O:BAG:BAD:' if the setting was previously modified) indicating that setting was properly set
+
+
+
+Failure scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to a non-empty value:
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Restrict clients allowed to make
+remote calls to SAM'
+
+2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value
+
+
+
+Note
+==================
+Once set to a value other than '', the UI does not allow setting the value back to '' and sets the value to 'O:BAG:BAD:'

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.11.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.11.txt
@@ -1,9 +1,7 @@
 Expected scenario
 ==================
 1) Open "Edit Group Policy" tool and set the following UI path to an empty value:
-'Computer Configuration\Policies\Windows Settings\Security Settings\Local
-Policies\Security Options\Network access: Shares that can be accessed
-anonymously'
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Shares that can be accessed anonymously'
 
 2) After running the policy check, it should return 1 indicating that setting was properly set
 
@@ -12,8 +10,6 @@ anonymously'
 Failure scenario
 ==================
 1) Open "Edit Group Policy" tool and set the following UI path to a non-empty value:
-'Computer Configuration\Policies\Windows Settings\Security Settings\Local
-Policies\Security Options\Network access: Shares that can be accessed
-anonymously'
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Shares that can be accessed anonymously'
 
 2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.11.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.11.txt
@@ -1,0 +1,19 @@
+Expected scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to an empty value:
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local
+Policies\Security Options\Network access: Shares that can be accessed
+anonymously'
+
+2) After running the policy check, it should return 1 indicating that setting was properly set
+
+
+
+Failure scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to a non-empty value:
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local
+Policies\Security Options\Network access: Shares that can be accessed
+anonymously'
+
+2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.12.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.12.txt
@@ -1,0 +1,19 @@
+Expected scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to 'Classic - local users authenticate as
+themselves':
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Sharing and security model for
+local accounts'
+
+2) After running the policy check, it should return 1 indicating that setting was properly set
+
+
+
+Failure scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to a value other than 'Classic - local users authenticate as
+themselves':
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Sharing and security model for
+local accounts'
+
+2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.12.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.12.txt
@@ -2,8 +2,7 @@ Expected scenario
 ==================
 1) Open "Edit Group Policy" tool and set the following UI path to 'Classic - local users authenticate as
 themselves':
-'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Sharing and security model for
-local accounts'
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Sharing and security model for local accounts'
 
 2) After running the policy check, it should return 1 indicating that setting was properly set
 
@@ -13,7 +12,6 @@ Failure scenario
 ==================
 1) Open "Edit Group Policy" tool and set the following UI path to a value other than 'Classic - local users authenticate as
 themselves':
-'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Sharing and security model for
-local accounts'
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Sharing and security model for local accounts'
 
 2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.2.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.2.txt
@@ -13,4 +13,3 @@ Failure scenario
 'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow anonymous enumeration of SAM'
 
 2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value
-

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.2.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.2.txt
@@ -1,0 +1,16 @@
+Expected scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to 'Enabled':
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow anonymous enumeration of SAM'
+
+2) After running the policy check, it should return 1 indicating that setting was properly set
+
+
+
+Failure scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to value different than 'Enabled':
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow anonymous enumeration of SAM'
+
+2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value
+

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.3.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.3.txt
@@ -13,5 +13,3 @@ Failure scenario
 'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow anonymous enumeration of SAM accounts and shares'
 
 2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value
-
-ee/

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.3.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.3.txt
@@ -1,0 +1,17 @@
+Expected scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to 'Enabled':
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow anonymous enumeration of SAM accounts and shares'
+
+2) After running the policy check, it should return 1 indicating that setting was properly set
+
+
+
+Failure scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to value different than 'Enabled':
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow anonymous enumeration of SAM accounts and shares'
+
+2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value
+
+ee/

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.4.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.4.txt
@@ -1,8 +1,7 @@
 Expected scenario
 ==================
 1) Open "Edit Group Policy" tool and set the following UI path to 'Enabled':
-'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow storage of passwords
-and credentials for network authentication'
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow storage of passwords and credentials for network authentication'
 
 2) After running the policy check, it should return 1 indicating that setting was properly set
 
@@ -11,8 +10,7 @@ and credentials for network authentication'
 Failure scenario
 ==================
 1) Open "Edit Group Policy" tool and set the following UI path to value different than 'Enabled':
-'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow storage of passwords
-and credentials for network authentication'
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow storage of passwords and credentials for network authentication'
 
 2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value
 

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.4.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.4.txt
@@ -1,0 +1,19 @@
+Expected scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to 'Enabled':
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow storage of passwords
+and credentials for network authentication'
+
+2) After running the policy check, it should return 1 indicating that setting was properly set
+
+
+
+Failure scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to value different than 'Enabled':
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Do not allow storage of passwords
+and credentials for network authentication'
+
+2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value
+
+ee/

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.5.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.5.txt
@@ -1,8 +1,7 @@
 Expected scenario
 ==================
 1) Open "Edit Group Policy" tool and set the following UI path to 'Disabled':
-'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Let Everyone permissions apply to
-anonymous users'
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Let Everyone permissions apply to anonymous users'
 
 2) After running the policy check, it should return 1 indicating that setting was properly set
 
@@ -11,8 +10,7 @@ anonymous users'
 Failure scenario
 ==================
 1) Open "Edit Group Policy" tool and set the following UI path to value different than 'Disabled':
-'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Let Everyone permissions apply to
-anonymous users'
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Let Everyone permissions apply to anonymous users'
 
 2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value
 

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.5.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.5.txt
@@ -1,0 +1,19 @@
+Expected scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to 'Disabled':
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Let Everyone permissions apply to
+anonymous users'
+
+2) After running the policy check, it should return 1 indicating that setting was properly set
+
+
+
+Failure scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to value different than 'Disabled':
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Let Everyone permissions apply to
+anonymous users'
+
+2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value
+
+ee/

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.6.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.6.txt
@@ -1,8 +1,7 @@
 Expected scenario
 ==================
 1) Open "Edit Group Policy" tool and set the following UI path to an empty value:
-'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Named Pipes that can be accessed
-anonymously'
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Named Pipes that can be accessed anonymously'
 
 2) After running the policy check, it should return 1 indicating that setting was properly set
 
@@ -11,7 +10,6 @@ anonymously'
 Failure scenario
 ==================
 1) Open "Edit Group Policy" tool and set the following UI path to a non-empty value:
-'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Named Pipes that can be accessed
-anonymously'
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Named Pipes that can be accessed anonymously'
 
 2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.6.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.6.txt
@@ -1,0 +1,17 @@
+Expected scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to an empty value:
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Named Pipes that can be accessed
+anonymously'
+
+2) After running the policy check, it should return 1 indicating that setting was properly set
+
+
+
+Failure scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to a non-empty value:
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Named Pipes that can be accessed
+anonymously'
+
+2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.7.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.7.txt
@@ -1,0 +1,21 @@
+Expected scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to
+'System\CurrentControlSet\Control\ProductOptions
+System\CurrentControlSet\Control\Server Applications
+Software\Microsoft\Windows NT\CurrentVersion':
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Remotely accessible registry paths'
+
+2) After running the policy check, it should return 1 indicating that setting was properly set
+
+
+
+Failure scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to a value different than
+'System\CurrentControlSet\Control\ProductOptions
+System\CurrentControlSet\Control\Server Applications
+Software\Microsoft\Windows NT\CurrentVersion':
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Remotely accessible registry paths'
+
+2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.8.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.8.txt
@@ -32,7 +32,6 @@ System\CurrentControlSet\Control\Terminal Server\UserConfig
 System\CurrentControlSet\Control\Terminal Server\DefaultUserConfiguration
 Software\Microsoft\Windows NT\CurrentVersion\Perflib
 System\CurrentControlSet\Services\SysmonLog':
-'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Remotely accessible registry paths
-and sub-paths'
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Remotely accessible registry paths and sub-paths'
 
 2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.8.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.8.txt
@@ -1,0 +1,38 @@
+Expected scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to
+'System\CurrentControlSet\Control\Print\Printers
+System\CurrentControlSet\Services\Eventlog
+Software\Microsoft\OLAP Server
+Software\Microsoft\Windows NT\CurrentVersion\Print
+Software\Microsoft\Windows NT\CurrentVersion\Windows
+System\CurrentControlSet\Control\ContentIndex
+System\CurrentControlSet\Control\Terminal Server
+System\CurrentControlSet\Control\Terminal Server\UserConfig
+System\CurrentControlSet\Control\Terminal Server\DefaultUserConfiguration
+Software\Microsoft\Windows NT\CurrentVersion\Perflib
+System\CurrentControlSet\Services\SysmonLog':
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Remotely accessible registry paths and sub-paths'
+
+2) After running the policy check, it should return 1 indicating that setting was properly set
+
+
+
+Failure scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to a value different than
+'System\CurrentControlSet\Control\Print\Printers
+System\CurrentControlSet\Services\Eventlog
+Software\Microsoft\OLAP Server
+Software\Microsoft\Windows NT\CurrentVersion\Print
+Software\Microsoft\Windows NT\CurrentVersion\Windows
+System\CurrentControlSet\Control\ContentIndex
+System\CurrentControlSet\Control\Terminal Server
+System\CurrentControlSet\Control\Terminal Server\UserConfig
+System\CurrentControlSet\Control\Terminal Server\DefaultUserConfiguration
+Software\Microsoft\Windows NT\CurrentVersion\Perflib
+System\CurrentControlSet\Services\SysmonLog':
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Remotely accessible registry paths
+and sub-paths'
+
+2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.9.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.9.txt
@@ -1,8 +1,7 @@
 Expected scenario
 ==================
 1) Open "Edit Group Policy" tool and set the following UI path to an empty value:
-'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Restrict anonymous access to Named
-Pipes and Shares'
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Restrict anonymous access to Named Pipes and Shares'
 
 2) After running the policy check, it should return 1 indicating that setting was properly set
 
@@ -11,7 +10,6 @@ Pipes and Shares'
 Failure scenario
 ==================
 1) Open "Edit Group Policy" tool and set the following UI path to a non-empty value:
-'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Restrict anonymous access to Named
-Pipes and Shares'
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Restrict anonymous access to Named Pipes and Shares'
 
 2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value

--- a/ee/cis/win-10/test/instructions/CIS_2.3.10.9.txt
+++ b/ee/cis/win-10/test/instructions/CIS_2.3.10.9.txt
@@ -1,0 +1,17 @@
+Expected scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to an empty value:
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Restrict anonymous access to Named
+Pipes and Shares'
+
+2) After running the policy check, it should return 1 indicating that setting was properly set
+
+
+
+Failure scenario
+==================
+1) Open "Edit Group Policy" tool and set the following UI path to a non-empty value:
+'Computer Configuration\Policies\Windows Settings\Security Settings\Local Policies\Security Options\Network access: Restrict anonymous access to Named
+Pipes and Shares'
+
+2) After running the policy check, it should return nothing, indicating that setting was set to a non-compliant value


### PR DESCRIPTION
## Issue
Cerra #9921 

## Description
- 2.3.10.2 - 2.3.10-12 completely finished
- 2.3.10.1 query is missing
- Created `ee/cis/win-10/test/debug/` directory and added `CIS_2.3.10.1.txt` as test instructions with documentation on TODO & NOTES since 2.3.10.1 is incomplete without its query
- In `cis-policy-queries.yml`, commented out the entire 2.3.10.1 policy with the `query` set as `TODO: See ./test/debug/CIS_2.3.10.1.txt for more information`

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

