### PR TITLE
Fix incorrect integer conversion

### DIFF
--- a/server/fleet/packs.go
+++ b/server/fleet/packs.go
@@ -61,7 +61,7 @@ func (p *Pack) teamPack() (*uint, error) {
 		return nil, nil
 	}
 	t := strings.TrimPrefix(*p.Type, "team-")
-	teamID, err := strconv.ParseUint(t, 10, 64)
+	teamID, err := strconv.ParseUint(t, 10, 32)
 	if err != nil {
 		return nil, err
 	}

--- a/server/fleet/packs_test.go
+++ b/server/fleet/packs_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -106,4 +107,29 @@ func TestPack_Marshal(t *testing.T) {
 	err = json.Unmarshal(b, &m)
 	require.NoError(t, err)
 	require.NotNil(t, m["disabled"], "marshalled pack does not contain disabled field: %s", string(b))
+}
+
+func TestPack_TeamPack(t *testing.T) {
+	p := Pack{
+		ID:   13,
+		Name: "team-foobar",
+		Type: ptr.String("team-27"),
+	}
+	id, err := p.teamPack()
+	require.NoError(t, err)
+	assert.Equal(t, uint(27), *id)
+
+	p.Type = ptr.String("other")
+	id, err = p.teamPack()
+	assert.NoError(t, err)
+	assert.Nil(t, id)
+
+	p.Type = nil
+	id, err = p.teamPack()
+	assert.NoError(t, err)
+	assert.Nil(t, id)
+
+	p.Type = ptr.String("team-foobar")
+	id, err = p.teamPack()
+	assert.Error(t, err)
 }

--- a/server/fleet/packs_test.go
+++ b/server/fleet/packs_test.go
@@ -130,6 +130,6 @@ func TestPack_TeamPack(t *testing.T) {
 	assert.Nil(t, id)
 
 	p.Type = ptr.String("team-foobar")
-	id, err = p.teamPack()
+	_, err = p.teamPack()
 	assert.Error(t, err)
 }


### PR DESCRIPTION
This was caught by CodeQL. We parsed as a 64 bit but then convert to a (possibly 32 bit) `uint`. It would be 64 bit on most platforms, but we actually use a 32 bit `int` type in MySQL as well.
