### PR TITLE
Remove debug on failure from integration test action

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -287,10 +287,6 @@ jobs:
         name: orbit-${{ matrix.orbit-channel }}-osqueryd-${{ matrix.osqueryd-channel }}.msi
         path: orbit-${{ matrix.orbit-channel }}-osqueryd-${{ matrix.osqueryd-channel }}.msi
 
-    - name: Debug on failure
-      if: failure()
-      uses: mxschmitt/action-tmate@8b4e4ac71822ed7e0ad5fb3d1c33483e9e8fb270 # v3
-
   orbit-windows:
     timeout-minutes: 15
     strategy:


### PR DESCRIPTION
This would cause the job to take much longer to report a failure. Instead, just add this line if debugging is necessary.
