### PR TITLE
Allow updating `enable_disk_encryption` via the Modify Team endpoint

### DIFF
--- a/changes/issue-9433-support-modify-team-disk-encryption
+++ b/changes/issue-9433-support-modify-team-disk-encryption
@@ -1,0 +1,1 @@
+* Added support to update a team's disk encryption via the Modify Team (`PATCH /api/latest/fleet/teams/{id}`) endpoint.

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -531,13 +531,13 @@ The MDM endpoints exist to support the related command-line interface sub-comman
 - [Unenroll host from Fleet MDM](#unenroll-host-from-fleet-mdm)
 - [Generate Apple DEP Key Pair](#generate-apple-dep-key-pair)
 - [Request Certificate Signing Request (CSR)](#request-certificate-signing-request-csr)
-- [Batch-apply Apple MDM custom settings](#batch-apply-apple-mdm-custom-settings)
-
 - [New configuration profile](#new-mdm-apple-configuration-profile)
 - [List configuration profiles](#list-mdm-apple-configuration-profiles)
 - [Download configuration profile](#download-mdm-apple-configuration-profile)
 - [Delete configuration profile](#delete-mdm-apple-confugruation-profile)
 - [Get Apple MDM profiles summary](#get-mdm-apple-profiles-summary)
+- [Batch-apply Apple MDM custom settings](#batch-apply-apple-mdm-custom-settings)
+- [Update Apple MDM settings](#update-apple-mdm-settings)
 
 ### Get Apple MDM
 
@@ -895,6 +895,27 @@ If no team (id or name) is provided, the profiles are applied for all hosts (for
 #### Example
 
 `POST /api/v1/fleet/mdm/apple/profiles/batch`
+
+##### Default response
+
+`204`
+
+### Update Apple MDM settings
+
+_Available in Fleet Premium_
+
+`PATCH /api/v1/fleet/mdm/apple/settings`
+
+#### Parameters
+
+| Name                   | Type    | In    | Description                                                                                 |
+| -------------          | ------  | ----  | --------------------------------------------------------------------------------------      |
+| team_id                | integer | body  | The team ID to apply the settings to. Settings applied to hosts in no team if absent.       |
+| enable_disk_encryption | boolean | body  | Whether disk encryption should be enforced on devices that belong to the team (or no team). |
+
+#### Example
+
+`PATCH /api/v1/fleet/mdm/apple/settings`
 
 ##### Default response
 

--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -5524,6 +5524,8 @@ _Available in Fleet Premium_
 | &nbsp;&nbsp;macos_updates                               | object  | body | MacOS updates settings.                                                                                                                                                                                   |
 | &nbsp;&nbsp;&nbsp;&nbsp;minimum_version                 | string  | body | Hosts that belong to this team and are enrolled into Fleet's MDM will be nudged until their macOS is at or above this version.                                                                            |
 | &nbsp;&nbsp;&nbsp;&nbsp;deadline                        | string  | body | Hosts that belong to this team and are enrolled into Fleet's MDM won't be able to dismiss the Nudge window once this deadline is past.                                                                    |
+| &nbsp;&nbsp;macos_settings                              | object  | body | MacOS-specific settings.                                                                                                                                                                                  |
+| &nbsp;&nbsp;&nbsp;&nbsp;enable_disk_encryption          | boolean | body | Hosts that belong to this team and are enrolled into Fleet's MDM will have disk encryption enabled if set to true.                                                                                        |
 
 
 #### Example (add users to a team)
@@ -5582,8 +5584,12 @@ _Available in Fleet Premium_
       "macos_updates": {
         "minimum_version": "12.3.1",
         "deadline": "2022-01-01"
+      },
+      "macos_settings": {
+        "custom_settings": [],
+        "enable_disk_encryption": false
       }
-    },
+    }
   }
 }
 ```

--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -5410,6 +5410,12 @@ _Available in Fleet Premium_
         "policy_ids": null,
         "host_batch_size": 0
       }
+    },
+    "mdm": {
+      "macos_settings": {
+        "custom_settings": [],
+        "enable_disk_encryption": false
+      }
     }
   }
 }

--- a/ee/server/service/service.go
+++ b/ee/server/service/service.go
@@ -53,8 +53,9 @@ func NewService(
 	// Override methods that can't be easily overriden via
 	// embedding.
 	svc.SetEnterpriseOverrides(fleet.EnterpriseOverrides{
-		HostFeatures:   eeservice.HostFeatures,
-		TeamByIDOrName: eeservice.teamByIDOrName,
+		HostFeatures:               eeservice.HostFeatures,
+		TeamByIDOrName:             eeservice.teamByIDOrName,
+		UpdateTeamMDMAppleSettings: eeservice.updateTeamMDMAppleSettings,
 	})
 
 	return eeservice, nil

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -113,6 +113,15 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 			macOSMinVersionUpdated = team.Config.MDM.MacOSUpdates != *payload.MDM.MacOSUpdates
 			team.Config.MDM.MacOSUpdates = *payload.MDM.MacOSUpdates
 		}
+
+		if payload.MDM.MacOSSettings != nil {
+			if !svc.config.MDMApple.Enable && payload.MDM.MacOSSettings.EnableDiskEncryption {
+				return nil, fleet.NewInvalidArgumentError("macos_settings.enable_disk_encryption",
+					`Couldn't update macos_settings because MDM features aren't turned on in Fleet. Use fleetctl generate mdm-apple and then fleet serve with mdm configuration to turn on MDM features.`)
+			}
+
+			team.Config.MDM.MacOSSettings.EnableDiskEncryption = payload.MDM.MacOSSettings.EnableDiskEncryption
+		}
 	}
 
 	if payload.Integrations != nil {

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -711,6 +711,19 @@ func unmarshalWithGlobalDefaults(b *json.RawMessage) (fleet.Features, error) {
 	return *defaults, nil
 }
 
-func (svc *Service) UpdateTeamMDMAppleSettings(ctx context.Context, tm *fleet.Team, payload fleet.MDMAppleSettingsPayload) error {
-	panic("unimplemented")
+func (svc *Service) updateTeamMDMAppleSettings(ctx context.Context, tm *fleet.Team, payload fleet.MDMAppleSettingsPayload) error {
+	var didUpdate bool
+	if payload.EnableDiskEncryption != nil {
+		if tm.Config.MDM.MacOSSettings.EnableDiskEncryption != *payload.EnableDiskEncryption {
+			tm.Config.MDM.MacOSSettings.EnableDiskEncryption = *payload.EnableDiskEncryption
+			didUpdate = true
+		}
+	}
+
+	if didUpdate {
+		if _, err := svc.ds.SaveTeam(ctx, tm); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -106,11 +106,13 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 
 	var macOSMinVersionUpdated bool
 	if payload.MDM != nil {
-		if err := payload.MDM.MacOSUpdates.Validate(); err != nil {
-			return nil, fleet.NewInvalidArgumentError("macos_updates", err.Error())
+		if payload.MDM.MacOSUpdates != nil {
+			if err := payload.MDM.MacOSUpdates.Validate(); err != nil {
+				return nil, fleet.NewInvalidArgumentError("macos_updates", err.Error())
+			}
+			macOSMinVersionUpdated = team.Config.MDM.MacOSUpdates != *payload.MDM.MacOSUpdates
+			team.Config.MDM.MacOSUpdates = *payload.MDM.MacOSUpdates
 		}
-		macOSMinVersionUpdated = team.Config.MDM.MacOSUpdates != payload.MDM.MacOSUpdates
-		team.Config.MDM = *payload.MDM
 	}
 
 	if payload.Integrations != nil {

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -710,3 +710,7 @@ func unmarshalWithGlobalDefaults(b *json.RawMessage) (fleet.Features, error) {
 
 	return *defaults, nil
 }
+
+func (svc *Service) UpdateTeamMDMAppleSettings(ctx context.Context, tm *fleet.Team, payload fleet.MDMAppleSettingsPayload) error {
+	panic("unimplemented")
+}

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -611,3 +611,18 @@ allow {
   subject.global_role == admin
   action == [read, write][_]
 }
+
+# Global admins and maintainers can read and write MDM Apple settings.
+allow {
+  object.type == "mdm_apple_settings"
+  subject.global_role == [admin, maintainer][_]
+  action == [read, write][_]
+}
+
+# Team admins and maintainers can read and write MDM Apple Settings of their teams.
+allow {
+  not is_null(object.team_id)
+  object.type == "mdm_apple_settings"
+  team_role(subject, object.team_id) == [admin, maintainer][_]
+  action == [read, write][_]
+}

--- a/server/authz/policy_test.go
+++ b/server/authz/policy_test.go
@@ -871,6 +871,66 @@ func TestAuthorizeMDMAppleConfigProfile(t *testing.T) {
 	})
 }
 
+func TestAuthorizeMDMAppleSettings(t *testing.T) {
+	t.Parallel()
+
+	globalSettings := &fleet.MDMAppleSettingsPayload{}
+	teamSettings := &fleet.MDMAppleSettingsPayload{
+		TeamID: ptr.Uint(1),
+	}
+	runTestCases(t, []authTestCase{
+		{user: test.UserNoRoles, object: globalSettings, action: write, allow: false},
+		{user: test.UserNoRoles, object: globalSettings, action: read, allow: false},
+		{user: test.UserNoRoles, object: teamSettings, action: write, allow: false},
+		{user: test.UserNoRoles, object: teamSettings, action: read, allow: false},
+
+		{user: test.UserAdmin, object: globalSettings, action: write, allow: true},
+		{user: test.UserAdmin, object: globalSettings, action: read, allow: true},
+		{user: test.UserAdmin, object: teamSettings, action: write, allow: true},
+		{user: test.UserAdmin, object: teamSettings, action: read, allow: true},
+
+		{user: test.UserMaintainer, object: globalSettings, action: write, allow: true},
+		{user: test.UserMaintainer, object: globalSettings, action: read, allow: true},
+		{user: test.UserMaintainer, object: teamSettings, action: write, allow: true},
+		{user: test.UserMaintainer, object: teamSettings, action: read, allow: true},
+
+		{user: test.UserObserver, object: globalSettings, action: write, allow: false},
+		{user: test.UserObserver, object: globalSettings, action: read, allow: false},
+		{user: test.UserObserver, object: teamSettings, action: write, allow: false},
+		{user: test.UserObserver, object: teamSettings, action: read, allow: false},
+
+		{user: test.UserTeamAdminTeam1, object: globalSettings, action: write, allow: false},
+		{user: test.UserTeamAdminTeam1, object: globalSettings, action: read, allow: false},
+		{user: test.UserTeamAdminTeam1, object: teamSettings, action: write, allow: true},
+		{user: test.UserTeamAdminTeam1, object: teamSettings, action: read, allow: true},
+
+		{user: test.UserTeamAdminTeam2, object: globalSettings, action: write, allow: false},
+		{user: test.UserTeamAdminTeam2, object: globalSettings, action: read, allow: false},
+		{user: test.UserTeamAdminTeam2, object: teamSettings, action: write, allow: false},
+		{user: test.UserTeamAdminTeam2, object: teamSettings, action: read, allow: false},
+
+		{user: test.UserTeamMaintainerTeam1, object: globalSettings, action: write, allow: false},
+		{user: test.UserTeamMaintainerTeam1, object: globalSettings, action: read, allow: false},
+		{user: test.UserTeamMaintainerTeam1, object: teamSettings, action: write, allow: true},
+		{user: test.UserTeamMaintainerTeam1, object: teamSettings, action: read, allow: true},
+
+		{user: test.UserTeamMaintainerTeam2, object: globalSettings, action: write, allow: false},
+		{user: test.UserTeamMaintainerTeam2, object: globalSettings, action: read, allow: false},
+		{user: test.UserTeamMaintainerTeam2, object: teamSettings, action: write, allow: false},
+		{user: test.UserTeamMaintainerTeam2, object: teamSettings, action: read, allow: false},
+
+		{user: test.UserTeamObserverTeam1, object: globalSettings, action: write, allow: false},
+		{user: test.UserTeamObserverTeam1, object: globalSettings, action: read, allow: false},
+		{user: test.UserTeamObserverTeam1, object: teamSettings, action: write, allow: false},
+		{user: test.UserTeamObserverTeam1, object: teamSettings, action: read, allow: false},
+
+		{user: test.UserTeamObserverTeam2, object: globalSettings, action: write, allow: false},
+		{user: test.UserTeamObserverTeam2, object: globalSettings, action: read, allow: false},
+		{user: test.UserTeamObserverTeam2, object: teamSettings, action: write, allow: false},
+		{user: test.UserTeamObserverTeam2, object: teamSettings, action: read, allow: false},
+	})
+}
+
 func assertAuthorized(t *testing.T, user *fleet.User, object, action interface{}) {
 	t.Helper()
 

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -468,3 +468,15 @@ type MDMAppleFleetdConfig struct {
 	FleetURL     string
 	EnrollSecret string
 }
+
+// MDMAppleSettingsPayload describes the payload accepted by the endpoint to
+// update specific MDM macos settings for a team (or no team).
+type MDMAppleSettingsPayload struct {
+	TeamID               *uint `json:"team_id"`
+	EnableDiskEncryption *bool `json:"enable_disk_encryption"`
+}
+
+// AuthzType implements authz.AuthzTyper.
+func (p MDMAppleSettingsPayload) AuthzType() string {
+	return "mdm_apple_settings"
+}

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -17,6 +17,9 @@ import (
 type EnterpriseOverrides struct {
 	HostFeatures   func(context context.Context, host *Host) (*Features, error)
 	TeamByIDOrName func(ctx context.Context, id *uint, name *string) (*Team, error)
+	// UpdateTeamMDMAppleSettings is the team-specific service method for when
+	// a team ID is provided to the UpdateMDMAppleSettings method.
+	UpdateTeamMDMAppleSettings func(ctx context.Context, tm *Team, payload MDMAppleSettingsPayload) error
 }
 
 type OsqueryService interface {
@@ -641,11 +644,6 @@ type Service interface {
 	// UpdateMDMAppleSettings updates the specified MDM Apple settings for a
 	// specified team or for hosts with no team.
 	UpdateMDMAppleSettings(ctx context.Context, payload MDMAppleSettingsPayload) error
-
-	// UpdateTeamMDMAppleSettings is the team-specific service method for when
-	// a team ID is provided to the UpdateMDMAppleSettings method. This is a
-	// distinct method so that it can be implemented under the ee/ package.
-	UpdateTeamMDMAppleSettings(ctx context.Context, tm *Team, payload MDMAppleSettingsPayload) error
 
 	///////////////////////////////////////////////////////////////////////////////
 	// CronSchedulesService

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -638,6 +638,15 @@ type Service interface {
 	// profile for the given team.
 	MDMAppleDisableFileVaultAndEscrow(ctx context.Context, teamID uint) error
 
+	// UpdateMDMAppleSettings updates the specified MDM Apple settings for a
+	// specified team or for hosts with no team.
+	UpdateMDMAppleSettings(ctx context.Context, payload MDMAppleSettingsPayload) error
+
+	// UpdateTeamMDMAppleSettings is the team-specific service method for when
+	// a team ID is provided to the UpdateMDMAppleSettings method. This is a
+	// distinct method so that it can be implemented under the ee/ package.
+	UpdateTeamMDMAppleSettings(ctx context.Context, tm *Team, payload MDMAppleSettingsPayload) error
+
 	///////////////////////////////////////////////////////////////////////////////
 	// CronSchedulesService
 

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -19,8 +19,16 @@ type TeamPayload struct {
 	Secrets         []*EnrollSecret      `json:"secrets"`
 	WebhookSettings *TeamWebhookSettings `json:"webhook_settings"`
 	Integrations    *TeamIntegrations    `json:"integrations"`
-	MDM             *TeamMDM             `json:"mdm"`
+	MDM             *TeamPayloadMDM      `json:"mdm"`
 	// Note AgentOptions must be set by a separate endpoint.
+}
+
+// TeamPayloadMDM is a distinct struct than TeamMDM because in ModifyTeam we
+// need to be able which part of the MDM config was provided in the request,
+// so the fields are pointers to structs.
+type TeamPayloadMDM struct {
+	MacOSUpdates  *MacOSUpdates  `json:"macos_updates"`
+	MacOSSettings *MacOSSettings `json:"macos_settings"`
 }
 
 // Team is the data representation for the "Team" concept (group of hosts and

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1565,6 +1565,69 @@ func (svc *Service) BatchSetMDMAppleProfiles(ctx context.Context, tmID *uint, tm
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Update MDM Apple Settings
+////////////////////////////////////////////////////////////////////////////////
+
+type updateMDMAppleSettingsRequest struct {
+	fleet.MDMAppleSettingsPayload
+}
+
+type updateMDMAppleSettingsResponse struct {
+	Err error `json:"error,omitempty"`
+}
+
+func (r updateMDMAppleSettingsResponse) error() error { return r.Err }
+
+func (r updateMDMAppleSettingsResponse) Status() int { return http.StatusNoContent }
+
+// This endpoint is required because the UI must allow maintainers (in addition
+// to admins) to update some MDM Apple settings, while the update config/update
+// team endpoints only allow write access to admins.
+func updateMDMAppleSettingsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
+	req := request.(*updateMDMAppleSettingsRequest)
+	if err := svc.UpdateMDMAppleSettings(ctx, req.MDMAppleSettingsPayload); err != nil {
+		return updateMDMAppleSettingsResponse{Err: err}, nil
+	}
+	return updateMDMAppleSettingsResponse{}, nil
+}
+
+func (svc *Service) UpdateMDMAppleSettings(ctx context.Context, payload fleet.MDMAppleSettingsPayload) error {
+	// for now, assume all settings require premium (this is true for the first
+	// supported setting, enable_disk_encryption. Adjust as needed in the future
+	// if this is not always the case).
+	license, err := svc.License(ctx)
+	if err != nil {
+		svc.authz.SkipAuthorization(ctx) // so that the error message is not replaced by "forbidden"
+		return err
+	}
+	if !license.IsPremium() {
+		svc.authz.SkipAuthorization(ctx) // so that the error message is not replaced by "forbidden"
+		return ErrMissingLicense
+	}
+
+	if err := svc.authz.Authorize(ctx, payload, fleet.ActionWrite); err != nil {
+		return ctxerr.Wrap(ctx, err)
+	}
+
+	if payload.TeamID != nil {
+		tm, err := svc.EnterpriseOverrides.TeamByIDOrName(ctx, payload.TeamID, nil)
+		if err != nil {
+			return err
+		}
+		return svc.UpdateTeamMDMAppleSettings(ctx, tm, payload)
+	}
+	return svc.updateAppConfigMDMAppleSettings(ctx, payload)
+}
+
+func (svc *Service) UpdateTeamMDMAppleSettings(ctx context.Context, tm *fleet.Team, payload fleet.MDMAppleSettingsPayload) error {
+	return fleet.ErrMissingLicense
+}
+
+func (svc *Service) updateAppConfigMDMAppleSettings(ctx context.Context, payload fleet.MDMAppleSettingsPayload) error {
+	panic("unimplemented")
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // FileVault-related free version implementation
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -1238,6 +1238,160 @@ func TestMDMBatchSetAppleProfiles(t *testing.T) {
 	}
 }
 
+func TestUpdateMDMAppleSettings(t *testing.T) {
+	svc, ctx, ds := setupAppleMDMService(t)
+
+	ds.TeamFunc = func(ctx context.Context, id uint) (*fleet.Team, error) {
+		return &fleet.Team{ID: id, Name: "team"}, nil
+	}
+	ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+		return team, nil
+	}
+	ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+		return nil
+	}
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{}, nil
+	}
+	ds.SaveAppConfigFunc = func(ctx context.Context, appConfig *fleet.AppConfig) error {
+		return nil
+	}
+
+	testCases := []struct {
+		name    string
+		user    *fleet.User
+		premium bool
+		teamID  *uint
+		wantErr string
+	}{
+		{
+			"global admin",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
+			false,
+			nil,
+			ErrMissingLicense.Error(),
+		},
+		{
+			"global admin premium",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
+			true,
+			nil,
+			"",
+		},
+		{
+			"global admin, team",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
+			true,
+			ptr.Uint(1),
+			"",
+		},
+		{
+			"global maintainer",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleMaintainer)},
+			false,
+			nil,
+			ErrMissingLicense.Error(),
+		},
+		{
+			"global maintainer premium",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleMaintainer)},
+			true,
+			nil,
+			"",
+		},
+		{
+			"global maintainer, team",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleMaintainer)},
+			true,
+			ptr.Uint(1),
+			"",
+		},
+		{
+			"global observer",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleObserver)},
+			true,
+			nil,
+			authz.ForbiddenErrorMessage,
+		},
+		{
+			"team admin, DOES belong to team",
+			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleAdmin}}},
+			true,
+			ptr.Uint(1),
+			"",
+		},
+		{
+			"team admin, DOES NOT belong to team",
+			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 2}, Role: fleet.RoleAdmin}}},
+			true,
+			ptr.Uint(1),
+			authz.ForbiddenErrorMessage,
+		},
+		{
+			"team maintainer, DOES belong to team",
+			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleMaintainer}}},
+			true,
+			ptr.Uint(1),
+			"",
+		},
+		{
+			"team maintainer, DOES NOT belong to team",
+			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 2}, Role: fleet.RoleMaintainer}}},
+			true,
+			ptr.Uint(1),
+			authz.ForbiddenErrorMessage,
+		},
+		{
+			"team observer, DOES belong to team",
+			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserver}}},
+			true,
+			ptr.Uint(1),
+			authz.ForbiddenErrorMessage,
+		},
+		{
+			"team observer, DOES NOT belong to team",
+			&fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 2}, Role: fleet.RoleObserver}}},
+			true,
+			ptr.Uint(1),
+			authz.ForbiddenErrorMessage,
+		},
+		{
+			"user no roles",
+			&fleet.User{ID: 1337},
+			true,
+			nil,
+			authz.ForbiddenErrorMessage,
+		},
+		{
+			"team id with free license",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
+			false,
+			ptr.Uint(1),
+			ErrMissingLicense.Error(),
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			// prepare the context with the user and license
+			ctx := viewer.NewContext(ctx, viewer.Viewer{User: tt.user})
+			tier := fleet.TierFree
+			if tt.premium {
+				tier = fleet.TierPremium
+			}
+			ctx = license.NewContext(ctx, &fleet.LicenseInfo{Tier: tier})
+
+			err := svc.UpdateMDMAppleSettings(ctx, fleet.MDMAppleSettingsPayload{TeamID: tt.teamID})
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
 func TestMDMAppleCommander(t *testing.T) {
 	ctx := context.Background()
 	mdmStorage := &nanomdm_mock.Storage{}

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -451,6 +451,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 		ue.POST("/api/_version_/fleet/mdm/hosts/{id:[0-9]+}/lock", deviceLockEndpoint, deviceLockRequest{})
 		ue.POST("/api/_version_/fleet/mdm/hosts/{id:[0-9]+}/wipe", deviceWipeEndpoint, deviceWipeRequest{})
 
+		ue.PATCH("/api/_version_/fleet/mdm/apple/settings", updateMDMAppleSettingsEndpoint, updateMDMAppleSettingsRequest{})
 	}
 	ue.POST("/api/_version_/fleet/mdm/apple/dep/key_pair", newMDMAppleDEPKeyPairEndpoint, nil)
 	ue.GET("/api/_version_/fleet/mdm/apple", getAppleMDMEndpoint, nil)

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -4515,6 +4515,9 @@ func (s *integrationTestSuite) TestPremiumEndpointsWithoutLicense() {
 	res := s.Do("POST", "/api/latest/fleet/mdm/apple/profiles/batch", nil, http.StatusUnprocessableEntity)
 	errMsg := extractServerErrorText(res.Body)
 	require.Contains(t, errMsg, "Fleet MDM is not enabled")
+
+	// update MDM settings, the endpoint is not even mounted if MDM is not enabled
+	s.Do("PATCH", "/api/latest/fleet/mdm/apple/settings", fleet.MDMAppleSettingsPayload{}, http.StatusNotFound)
 }
 
 // TestGlobalPoliciesBrowsing tests that team users can browse (read) global policies (see #3722).

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -1978,6 +1978,8 @@ func (s *integrationEnterpriseTestSuite) TestAppleMDMNotConfigured() {
 	var rawResp json.RawMessage
 	s.DoJSON("GET", "/api/latest/fleet/mdm/apple", nil, http.StatusNotFound, &rawResp)
 	s.DoJSON("GET", "/api/latest/fleet/mdm/apple_bm", nil, http.StatusNotFound, &rawResp)
+	// update MDM settings, the endpoint is not even mounted if MDM is not enabled
+	s.Do("PATCH", "/api/latest/fleet/mdm/apple/settings", fleet.MDMAppleSettingsPayload{}, http.StatusNotFound)
 }
 
 func (s *integrationEnterpriseTestSuite) TestGlobalPolicyCreateReadPatch() {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -1263,8 +1263,8 @@ func (s *integrationEnterpriseTestSuite) TestMacOSUpdatesConfig() {
 
 	// modify the team's config
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), fleet.TeamPayload{
-		MDM: &fleet.TeamMDM{
-			MacOSUpdates: fleet.MacOSUpdates{
+		MDM: &fleet.TeamPayloadMDM{
+			MacOSUpdates: &fleet.MacOSUpdates{
 				MinimumVersion: "10.15.0",
 				Deadline:       "2021-01-01",
 			},
@@ -1276,8 +1276,8 @@ func (s *integrationEnterpriseTestSuite) TestMacOSUpdatesConfig() {
 
 	// only update the deadline
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), fleet.TeamPayload{
-		MDM: &fleet.TeamMDM{
-			MacOSUpdates: fleet.MacOSUpdates{
+		MDM: &fleet.TeamPayloadMDM{
+			MacOSUpdates: &fleet.MacOSUpdates{
 				MinimumVersion: "10.15.0",
 				Deadline:       "2025-10-01",
 			},
@@ -1295,7 +1295,7 @@ func (s *integrationEnterpriseTestSuite) TestMacOSUpdatesConfig() {
 	s.lastActivityMatches("", "", lastActivity)
 
 	// sending an empty MacOSUpdate empties both fields
-	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), fleet.TeamPayload{MDM: &fleet.TeamMDM{MacOSUpdates: fleet.MacOSUpdates{}}}, http.StatusOK, &tmResp)
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), fleet.TeamPayload{MDM: &fleet.TeamPayloadMDM{MacOSUpdates: &fleet.MacOSUpdates{}}}, http.StatusOK, &tmResp)
 	require.Empty(t, tmResp.Team.Config.MDM.MacOSUpdates.MinimumVersion)
 	require.Empty(t, tmResp.Team.Config.MDM.MacOSUpdates.Deadline)
 	s.lastActivityMatches(fleet.ActivityTypeEditedMacOSMinVersion{}.ActivityName(), fmt.Sprintf(`{"team_id": %d, "team_name": %q, "minimum_version": "", "deadline": ""}`, team.ID, team.Name), 0)
@@ -1304,8 +1304,8 @@ func (s *integrationEnterpriseTestSuite) TestMacOSUpdatesConfig() {
 
 	// try to set an invalid deadline
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), fleet.TeamPayload{
-		MDM: &fleet.TeamMDM{
-			MacOSUpdates: fleet.MacOSUpdates{
+		MDM: &fleet.TeamPayloadMDM{
+			MacOSUpdates: &fleet.MacOSUpdates{
 				MinimumVersion: "10.15.0",
 				Deadline:       "2021-01-01T00:00:00Z",
 			},
@@ -1314,8 +1314,8 @@ func (s *integrationEnterpriseTestSuite) TestMacOSUpdatesConfig() {
 
 	// try to set an invalid minimum version
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), fleet.TeamPayload{
-		MDM: &fleet.TeamMDM{
-			MacOSUpdates: fleet.MacOSUpdates{
+		MDM: &fleet.TeamPayloadMDM{
+			MacOSUpdates: &fleet.MacOSUpdates{
 				MinimumVersion: "10.15.0 (19A583)",
 				Deadline:       "2021-01-01T00:00:00Z",
 			},
@@ -1324,8 +1324,8 @@ func (s *integrationEnterpriseTestSuite) TestMacOSUpdatesConfig() {
 
 	// try to set a deadline but not a minimum version
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), fleet.TeamPayload{
-		MDM: &fleet.TeamMDM{
-			MacOSUpdates: fleet.MacOSUpdates{
+		MDM: &fleet.TeamPayloadMDM{
+			MacOSUpdates: &fleet.MacOSUpdates{
 				Deadline: "2021-01-01T00:00:00Z",
 			},
 		},
@@ -1333,8 +1333,8 @@ func (s *integrationEnterpriseTestSuite) TestMacOSUpdatesConfig() {
 
 	// try to set a minimum version but not a deadline
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), fleet.TeamPayload{
-		MDM: &fleet.TeamMDM{
-			MacOSUpdates: fleet.MacOSUpdates{
+		MDM: &fleet.TeamPayloadMDM{
+			MacOSUpdates: &fleet.MacOSUpdates{
 				MinimumVersion: "10.15.0 (19A583)",
 			},
 		},
@@ -2298,8 +2298,8 @@ func (s *integrationEnterpriseTestSuite) TestOrbitConfigNudgeSettings() {
 	// modify the team config, add macos_updates config
 	var tmResp teamResponse
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), fleet.TeamPayload{
-		MDM: &fleet.TeamMDM{
-			MacOSUpdates: fleet.MacOSUpdates{
+		MDM: &fleet.TeamPayloadMDM{
+			MacOSUpdates: &fleet.MacOSUpdates{
 				Deadline:       "1992-01-01",
 				MinimumVersion: "13.1.1",
 			},

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -562,6 +562,15 @@ func (s *integrationEnterpriseTestSuite) TestTeamEndpoints() {
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", tm1ID), team, http.StatusOK, &tmResp)
 	assert.Contains(t, tmResp.Team.Description, "Alt ")
 
+	// modify team's disk encryption, impossible without mdm enabled
+	res := s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", tm1ID), fleet.TeamPayload{
+		MDM: &fleet.TeamPayloadMDM{
+			MacOSSettings: &fleet.MacOSSettings{EnableDiskEncryption: true},
+		},
+	}, http.StatusUnprocessableEntity)
+	errMsg := extractServerErrorText(res.Body)
+	assert.Contains(t, errMsg, `Couldn't update macos_settings because MDM features aren't turned on in Fleet.`)
+
 	// modify a team with a NULL config
 	defaultFeatures := fleet.Features{}
 	defaultFeatures.ApplyDefaultsForNewInstalls()


### PR DESCRIPTION
#9433 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
