### PR TITLE
MDM docs: Add MDM server in Apple Business Manager

### DIFF
--- a/docs/Using-Fleet/Mobile-device-management.md
+++ b/docs/Using-Fleet/Mobile-device-management.md
@@ -228,9 +228,15 @@ Connect Fleet to your ABM account to automatically enroll macOS hosts to Fleet w
 
 If a new macOS host that appears in ABM hasn't been unboxed, it will appear in Fleet with **MDM status** set to "Pending." These hosts will automatically enroll to the default team in Fleet. Learn how to update the default team [here](#default-team).
 
-To connect Fleet to ABM, get these four files using the Fleet UI or the `fleetctl` command-line interface: An ABM certificate, private key and server token.
+To connect Fleet to ABM, first create a new MDM server in ABM and then get these two files using the Fleet UI or the `fleetctl` command-line interface: An ABM certificate and private key.
 
-To do this, choose the "Fleet UI" or "fleetctl" method and follow the steps below.
+How to create a new MDM server in ABM:
+
+1. Login to [ABM](https://business.apple.com) and click your name at the bottom of the sidebar, click **Preferences**, then click **MDM Server Assignment**.
+
+2. Click the **Add** button, then enter a unique name for the server. A good name to start is "Fleet MDM."
+
+To get the two files, choose the "Fleet UI" or "fleetctl" method and follow the steps below.
 
 Fleet UI:
 


### PR DESCRIPTION
- Add instructions for creating an MDM server in ABM

Addresses [this issue](https://github.com/fleetdm/fleet/issues/9732) and the following TODO in the "Docs for MDM migration" issue: #9009

_TODO Docs for IT admins on how to switch MDM servers to automatically enroll new macOS hosts to Fleet (set up ABM with Fleet MDM server)._

