### PR TITLE
Website: Remove /osquery-management from download-sitemap.js

### DIFF
--- a/website/api/controllers/download-sitemap.js
+++ b/website/api/controllers/download-sitemap.js
@@ -65,7 +65,6 @@ module.exports = {
       '/deploy',
       '/podcasts',
       '/device-management',
-      '/osquery-management',
       // FUTURE: Do something smarter to get hand-coded HTML pages from routes.js, like how rebuild-cloud-sdk works, to avoid this manual duplication.
       // See also https://github.com/sailshq/sailsjs.com/blob/b53c6e6a90c9afdf89e5cae00b9c9dd3f391b0e7/api/helpers/get-pages-for-sitemap.js#L27
     ];


### PR DESCRIPTION
https://github.com/fleetdm/fleet/pull/10207#issuecomment-1451073086
Changes:
- Removed the `/osquery-management` landing page from `download-sitemap.js`