### PR TITLE
Release schedule lock when triggered run spans schedule interval

### DIFF
--- a/changes/bugfix-trigger-release-lock
+++ b/changes/bugfix-trigger-release-lock
@@ -1,0 +1,1 @@
+- Fixed a bug where `fleetctl trigger` doesn't release the schedule lock when the triggered run spans the regularly scheduled interval. This can prevent a second Fleet instance from using `fleetctl trigger` until the lock expires. This issue occurs infrequently under normal use. When it does occur, it resolves on its own in time; however, it may last up one full interval.

--- a/server/service/schedule/schedule.go
+++ b/server/service/schedule/schedule.go
@@ -225,7 +225,6 @@ func (s *Schedule) Start() {
 					s.setIntervalStartedAt(newStart)
 					schedTicker.Reset(s.getRemainingInterval(newStart))
 					level.Debug(s.logger).Log("waiting", fmt.Sprintf("triggered run spanned schedule interval, new wait %v", s.getRemainingInterval(newStart)))
-					continue
 				}
 
 				cancelHold()

--- a/server/service/schedule/testing_utils.go
+++ b/server/service/schedule/testing_utils.go
@@ -88,6 +88,7 @@ func (ml *MockLock) Unlock(ctx context.Context, name string, owner string) error
 	if ml.Unlocked != nil {
 		ml.Unlocked <- struct{}{}
 	}
+	ml.expiresAt = time.Now()
 	return nil
 }
 


### PR DESCRIPTION
Fixes a bug where `fleetctl trigger` doesn't release the schedule lock when the triggered run spans the regularly scheduled interval. This can prevent a second Fleet instance from using `fleetctl trigger` until the lock expires. This issue occurs infrequently under normal use. When it does occur, it resolves on its own in time; however, it may last up one full interval.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

