### PR TITLE
Fix error writing coverage when running tests

### DIFF
--- a/cmd/fleetctl/convert_test.go
+++ b/cmd/fleetctl/convert_test.go
@@ -41,6 +41,7 @@ func TestConvertFileOutput(t *testing.T) {
 
 func TestConvertFileStdout(t *testing.T) {
 	r, w, _ := os.Pipe()
+	oldStdout := os.Stdout
 	os.Stdout = w
 
 	// setup the cli and the convert command
@@ -60,6 +61,7 @@ func TestConvertFileStdout(t *testing.T) {
 	err = app.Run(args)
 	require.NoError(t, err)
 
+	os.Stdout = oldStdout
 	w.Close()
 	out, _ := ioutil.ReadAll(r)
 	require.Equal(t, expected, out)

--- a/cmd/fleetctl/trigger_test.go
+++ b/cmd/fleetctl/trigger_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/service"
 	"github.com/fleetdm/fleet/v4/server/service/schedule"
+	kitlog "github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/cmd/fleetctl/trigger_test.go
+++ b/cmd/fleetctl/trigger_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/service"
 	"github.com/fleetdm/fleet/v4/server/service/schedule"
-	kitlog "github.com/go-kit/kit/log"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,6 +48,7 @@ func TestTrigger(t *testing.T) {
 	}
 
 	r, w, _ := os.Pipe()
+	oldStdout := os.Stdout
 	os.Stdout = w
 
 	_, _ = runServerWithMockedDS(t, &service.TestServerOpts{
@@ -78,6 +77,7 @@ func TestTrigger(t *testing.T) {
 		assert.Equal(t, "", runAppForTest(t, c.args))
 	}
 
+	os.Stdout = oldStdout
 	w.Close()
 	out, _ := ioutil.ReadAll(r)
 	outlines := strings.Split(string(out), "\n")


### PR DESCRIPTION
Intended to fix this error we are seeing in CI:

```
error generating coverage report: write |1: file already closed
```

It seems like perhaps a change in the way the test coverage is reported in a recent Go version has interacted with the closing of stdout in these tests.

# Checklist for submitter

- [x] Added/updated tests
