### PR TITLE
restore restrictive permissions for GET /mdm/apple and adjust UI

### DIFF
--- a/docs/Using-Fleet/Permissions.md
+++ b/docs/Using-Fleet/Permissions.md
@@ -41,9 +41,9 @@ Users with the Admin role receive all permissions.
 | Edit [agent options for hosts assigned to teams](https://fleetdm.com/docs/using-fleet/configuration-files#team-agent-options)\*            |          |            | ✅    |
 | Initiate [file carving](https://fleetdm.com/docs/using-fleet/rest-api#file-carving)                                                        |          | ✅         | ✅    |
 | Retrieve contents from file carving                                                                                                        |          |            | ✅    |
-| View Apple mobile device management (MDM) certificate information                                                                          |          | ✅         | ✅    |
-| View Apple business manager (BM) information                                                                                               |          | ✅         | ✅    |
-| Generate Apple mobile device management (MDM) certificate signing request (CSR)                                                            |          | ✅         | ✅    |
+| View Apple mobile device management (MDM) certificate information                                                                          |          |            | ✅    |
+| View Apple business manager (BM) information                                                                                               |          |            | ✅    |
+| Generate Apple mobile device management (MDM) certificate signing request (CSR)                                                            |          |            | ✅    |
 | View disk encryption key for macOS hosts enrolled in Fleet's MDM                                                                           | ✅       | ✅         | ✅    |
 | Create edit and delete configuration profiles for macOS hosts enrolled in Fleet's MDM                                                      |         | ✅         | ✅    |
 
@@ -89,9 +89,6 @@ Users that are members of multiple teams can be assigned different roles for eac
 | Create, edit, and delete [team enroll secrets](https://fleetdm.com/docs/using-fleet/rest-api#get-enroll-secrets-for-a-team)      |               | ✅              | ✅         |
 | Edit [agent options](https://fleetdm.com/docs/using-fleet/configuration-files#agent-options)                                     |               |                 | ✅         |
 | Initiate [file carving](https://fleetdm.com/docs/using-fleet/rest-api#file-carving)                                              |               | ✅              | ✅         |
-| View Apple mobile device management (MDM) certificate information                                                                |               | ✅              | ✅         |
-| View Apple business manager (BM) information                                                                                     |               | ✅              | ✅         |
-| Generate Apple mobile device management (MDM) certificate signing request (CSR)                                                  |               | ✅              | ✅         |
 | View disk encryption key for macOS hosts enrolled in Fleet's MDM                                                                 | ✅            | ✅              | ✅         |
 | Create edit and delete configuration profiles for macOS hosts enrolled in Fleet's MDM                                            |               | ✅              | ✅         |
 

--- a/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
+++ b/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
@@ -51,13 +51,9 @@ const ManageControlsPage = ({
   location,
   router,
 }: IManageControlsPageProps): JSX.Element => {
-  const {
-    availableTeams,
-    isPremiumTier,
-    currentTeam,
-    setCurrentTeam,
-    config,
-  } = useContext(AppContext);
+  const { availableTeams, currentTeam, setCurrentTeam, config } = useContext(
+    AppContext
+  );
 
   const navigateToNav = (i: number): void => {
     const navPath = controlsSubNav[i].pathname;
@@ -98,7 +94,7 @@ const ManageControlsPage = ({
   const onConnectClick = () => router.push(PATHS.ADMIN_INTEGRATIONS_MDM);
 
   const renderBody = () => {
-    return isPremiumTier && config?.mdm.enabled_and_configured ? (
+    return config?.mdm.enabled_and_configured ? (
       <div>
         <TabsWrapper>
           <Tabs

--- a/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
+++ b/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
@@ -1,13 +1,11 @@
 import React, { useContext } from "react";
 import { find } from "lodash";
-import { useQuery } from "react-query";
 import { Tab, Tabs, TabList } from "react-tabs";
 import { InjectedRouter } from "react-router";
+import { Location } from "history";
 
 import PATHS from "router/paths";
 import { AppContext } from "context/app";
-import mdmAppleAPI from "services/entities/mdm_apple";
-import { IMdmApple } from "interfaces/mdm";
 
 import TabsWrapper from "components/TabsWrapper";
 import MainContent from "components/MainContent";
@@ -16,7 +14,6 @@ import TeamsDropdownHeader, {
 } from "components/PageHeader/TeamsDropdownHeader";
 import EmptyTable from "components/EmptyTable";
 import Button from "components/buttons/Button";
-import Spinner from "components/Spinner";
 
 interface IControlsSubNavItem {
   name: string;
@@ -36,7 +33,7 @@ const controlsSubNav: IControlsSubNavItem[] = [
 
 interface IManageControlsPageProps {
   children: JSX.Element;
-  location: any; // no type in react-router v3
+  location: Location;
   router: InjectedRouter; // v3
 }
 
@@ -59,16 +56,8 @@ const ManageControlsPage = ({
     isPremiumTier,
     currentTeam,
     setCurrentTeam,
+    config,
   } = useContext(AppContext);
-
-  const { data: mdmApple, isLoading: isLoadingMdmApple } = useQuery<
-    IMdmApple,
-    Error
-  >(["mdmAppleAPI"], () => mdmAppleAPI.getAppleAPNInfo(), {
-    enabled: isPremiumTier,
-    staleTime: 5000,
-    retry: false,
-  });
 
   const navigateToNav = (i: number): void => {
     const navPath = controlsSubNav[i].pathname;
@@ -109,10 +98,7 @@ const ManageControlsPage = ({
   const onConnectClick = () => router.push(PATHS.ADMIN_INTEGRATIONS_MDM);
 
   const renderBody = () => {
-    if (isLoadingMdmApple) {
-      return <Spinner />;
-    }
-    return mdmApple ? (
+    return isPremiumTier && config?.mdm.enabled_and_configured ? (
       <div>
         <TabsWrapper>
           <Tabs

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -549,17 +549,10 @@ allow {
   action == mdm_command
 }
 
-# Global admins and maintainers can read and write MDM apple information.
+# Global admins can read and write MDM apple information.
 allow {
   object.type == "mdm_apple"
-  subject.global_role == [admin, maintainer][_]
-  action == [read, write][_]
-}
-
-# Team admins and maintainers can read and write MDM apple information.
-allow {
-  object.type == "mdm_apple"
-  team_role(subject, subject.teams[_].id) == [admin,maintainer][_]
+  subject.global_role == admin
   action == [read, write][_]
 }
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -2436,7 +2436,9 @@ func (s *DataStore) LoadHostSoftware(ctx context.Context, host *fleet.Host, incl
 }
 
 func (s *DataStore) ListSoftwareBySourceIter(ctx context.Context, sources []string) (fleet.SoftwareIterator, error) {
+	s.mu.Lock()
 	s.ListSoftwareBySourceIterFuncInvoked = true
+	s.mu.Unlock()
 	return s.ListSoftwareBySourceIterFunc(ctx, sources)
 }
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -2436,9 +2436,7 @@ func (s *DataStore) LoadHostSoftware(ctx context.Context, host *fleet.Host, incl
 }
 
 func (s *DataStore) ListSoftwareBySourceIter(ctx context.Context, sources []string) (fleet.SoftwareIterator, error) {
-	s.mu.Lock()
 	s.ListSoftwareBySourceIterFuncInvoked = true
-	s.mu.Unlock()
 	return s.ListSoftwareBySourceIterFunc(ctx, sources)
 }
 


### PR DESCRIPTION
Related to #10121 this reverts #10107, and modifies the UI to use `mdm.enabled_and_configured` instead of the `GET /mdm/apple` endpoint so we don't face permissions issues and Maintainers are able to see the Controls page.

More details and rationale in https://github.com/fleetdm/fleet/issues/10121#issuecomment-1450335235

Tested with Admins, Maintainers and Observers

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Documented any permissions changes
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
