### PR TITLE
fix fleetctl apply with default configuration

### DIFF
--- a/server/logging/filesystem.go
+++ b/server/logging/filesystem.go
@@ -6,16 +6,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/fleetdm/fleet/v4/pkg/secure"
-	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
-	lumberjack "gopkg.in/natefinch/lumberjack.v2"
 	"io"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
 
+	"github.com/fleetdm/fleet/v4/pkg/secure"
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/go-kit/kit/log"
+	lumberjack "gopkg.in/natefinch/lumberjack.v2"
 )
 
 type filesystemLogWriter struct {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -274,7 +274,8 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{Message: err.Error()})
 	}
 
-	if newAppConfig.FleetDesktop.TransparencyURL != "" {
+	// default transparency URL is https://fleetdm.com/transparency so you are allowed to apply as long as it's not changing
+	if newAppConfig.FleetDesktop.TransparencyURL != "" && newAppConfig.FleetDesktop.TransparencyURL != fleet.DefaultTransparencyURL {
 		if license.Tier != "premium" {
 			invalid.Append("transparency_url", ErrMissingLicense.Error())
 			return nil, ctxerr.Wrap(ctx, invalid)


### PR DESCRIPTION
closes https://github.com/fleetdm/fleet/issues/9304

This PR will fix the specific issue listed in the ticket:

```
Error: applying fleet config: PATCH /api/latest/fleet/config received status 422 Validation Failed: missing or invalid license
```

This was due to transparency URL being the default value

```
transparency_url: https://fleetdm.com/transparency
```

but validation incorrectly assuming the config needs premium license to change it.