### PR TITLE
fix test race in schedule mock

### DIFF
--- a/server/service/schedule/schedule_test.go
+++ b/server/service/schedule/schedule_test.go
@@ -506,7 +506,7 @@ func TestTriggerReleaseLock(t *testing.T) {
 		require.Equal(t, seedStats, statsByType[fleet.CronStatsTypeScheduled])
 	}
 
-	require.True(t, locker.expiresAt.Before(time.Now()))
+	require.True(t, locker.GetExpiration().Before(time.Now()))
 }
 
 func TestMultipleScheduleInstancesConfigChangesDS(t *testing.T) {

--- a/server/service/schedule/testing_utils.go
+++ b/server/service/schedule/testing_utils.go
@@ -99,6 +99,13 @@ func (ml *MockLock) GetLockCount() int {
 	return ml.LockCount
 }
 
+func (ml *MockLock) GetExpiration() time.Time {
+	ml.mu.Lock()
+	defer ml.mu.Unlock()
+
+	return ml.expiresAt
+}
+
 func (ml *MockLock) AddChannels(t *testing.T, chanNames ...string) error {
 	ml.mu.Lock()
 	defer ml.mu.Unlock()


### PR DESCRIPTION
This fixes the races that are occurring on tests ([example](https://github.com/fleetdm/fleet/actions/runs/4339799935))

# Checklist for submitter

- [x] Added/updated tests
