### PR TITLE
Fleet UI: Critical icon on policy table

### DIFF
--- a/changes/9106-critical-icon-policy-table
+++ b/changes/9106-critical-icon-policy-table
@@ -1,0 +1,1 @@
+- Add an icon on the policy table to indicate if a policy is marked critical

--- a/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tsx
+++ b/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tsx
@@ -7,7 +7,7 @@ import { browserHistory } from "react-router";
 import Button from "components/buttons/Button/Button";
 
 interface ILinkCellProps {
-  value: string;
+  value: string | JSX.Element;
   path: string;
   title?: string;
   classes?: string;

--- a/frontend/components/icons/Policy.tsx
+++ b/frontend/components/icons/Policy.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { COLORS, Colors } from "styles/var/colors";
+import {
+  ICON_SIZES,
+  IconSizes,
+  ICON_SIZES_BASE14,
+} from "styles/var/icon_sizes";
+
+interface IPolicyProps {
+  color?: Colors;
+  size?: IconSizes;
+}
+
+const Policy = ({
+  color = "core-fleet-blue",
+  size = "small",
+}: IPolicyProps) => {
+  return (
+    <svg
+      width={ICON_SIZES_BASE14[size]}
+      height={ICON_SIZES[size]}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 14 16"
+    >
+      <g
+        clipPath="url(#a)"
+        fillRule="evenodd"
+        clipRule="evenodd"
+        fill={COLORS[color]}
+      >
+        <path d="m6.951 9.838 3.112-3.015a.89.89 0 0 0 .27-.634.876.876 0 0 0-.27-.634.91.91 0 0 0-.64-.258.925.925 0 0 0-.638.258L6.313 7.95l-1.1-1.065a.919.919 0 0 0-1.477.29.877.877 0 0 0 .2.979l1.737 1.683a.91.91 0 0 0 .639.258.925.925 0 0 0 .64-.258Z" />
+        <path d="M13.041 2.357v.001L7.345.067a.925.925 0 0 0-.69 0l-6.09 2.45a.906.906 0 0 0-.409.325A.882.882 0 0 0 0 3.34v2.98c0 2.066.634 4.083 1.82 5.796a10.637 10.637 0 0 0 4.84 3.82.926.926 0 0 0 .68 0 10.637 10.637 0 0 0 4.84-3.82A10.162 10.162 0 0 0 14 6.322V3.34a.88.88 0 0 0-.156-.499.905.905 0 0 0-.408-.325l-.395-.16Zm-.86 1.583v2.382a8.4 8.4 0 0 1-1.438 4.692A8.805 8.805 0 0 1 7 14.139a8.804 8.804 0 0 1-3.743-3.125 8.4 8.4 0 0 1-1.439-4.692V3.94L7 1.854l5.182 2.086Z" />
+      </g>
+      <defs>
+        <clipPath id="a">
+          <path fill="#fff" d="M0 0h14v16H0z" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+};
+
+export default Policy;

--- a/frontend/components/icons/index.ts
+++ b/frontend/components/icons/index.ts
@@ -28,6 +28,8 @@ import M1 from "./M1";
 import Centos from "./Centos";
 import Ubuntu from "./Ubuntu";
 
+import Policy from "./Policy";
+
 // Encircled
 import ApplePurple from "./ApplePurple";
 import LinuxGreen from "./LinuxGreen";
@@ -81,6 +83,7 @@ export const ICON_MAP = {
   m1: M1,
   centos: Centos,
   ubuntu: Ubuntu,
+  policy: Policy,
   "darwin-purple": ApplePurple,
   "windows-blue": WindowsBlue,
   "linux-green": LinuxGreen,

--- a/frontend/pages/policies/ManagePoliciesPage/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/_styles.scss
@@ -150,4 +150,8 @@
   .critical-tooltip {
     font-weight: $regular;
   }
+
+  .policy-icon {
+    margin-left: $pad-xsmall;
+  }
 }

--- a/frontend/pages/policies/ManagePoliciesPage/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/_styles.scss
@@ -153,5 +153,7 @@
 
   .policy-icon {
     margin-left: $pad-xsmall;
+    position: relative;
+    bottom: -1px;
   }
 }

--- a/frontend/pages/policies/ManagePoliciesPage/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/_styles.scss
@@ -146,4 +146,8 @@
       display: none;
     }
   }
+
+  .critical-tooltip {
+    font-weight: $regular;
+  }
 }

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { IconNames } from "components/icons";
 import { AppContext } from "context/app";
 import { noop } from "lodash";
 import paths from "router/paths";

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -8,6 +8,7 @@ import ReactTooltip from "react-tooltip";
 import Checkbox from "components/forms/fields/Checkbox";
 import LinkCell from "components/TableContainer/DataTable/LinkCell/LinkCell";
 import StatusIndicator from "components/StatusIndicator";
+import Icon from "components/Icon";
 import { IPolicyStats } from "interfaces/policy";
 import PATHS from "router/paths";
 import sortUtils from "utilities/sort";
@@ -106,7 +107,31 @@ const generateTableHeaders = (options: {
       Cell: (cellProps: ICellProps): JSX.Element => (
         <LinkCell
           classes="w250"
-          value={cellProps.cell.value}
+          value={
+            <>
+              {cellProps.cell.value}{" "}
+              {cellProps.row.original.critical && (
+                <>
+                  <span
+                    data-tip
+                    data-for={`critical-tooltip-${cellProps.row.original.id}`}
+                  >
+                    <Icon name="policy" />
+                  </span>
+                  <ReactTooltip
+                    className="critical-tooltip"
+                    place="top"
+                    type="dark"
+                    effect="solid"
+                    id={`critical-tooltip-${cellProps.row.original.id}`}
+                    backgroundColor="#3e4771"
+                  >
+                    This policy has been marked as critical.
+                  </ReactTooltip>
+                </>
+              )}
+            </>
+          }
           path={PATHS.EDIT_POLICY(cellProps.row.original)}
         />
       ),

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -109,14 +109,14 @@ const generateTableHeaders = (options: {
           classes="w250"
           value={
             <>
-              {cellProps.cell.value}{" "}
+              {cellProps.cell.value}
               {cellProps.row.original.critical && (
                 <>
                   <span
                     data-tip
                     data-for={`critical-tooltip-${cellProps.row.original.id}`}
                   >
-                    <Icon name="policy" />
+                    <Icon className="policy-icon" name="policy" />
                   </span>
                   <ReactTooltip
                     className="critical-tooltip"

--- a/frontend/styles/var/icon_sizes.ts
+++ b/frontend/styles/var/icon_sizes.ts
@@ -6,3 +6,10 @@ export const ICON_SIZES = {
   large: "24",
   "extra-large": "48",
 };
+
+export const ICON_SIZES_BASE14 = {
+  small: "10.5",
+  medium: "14",
+  large: "21",
+  "extra-large": "42",
+};


### PR DESCRIPTION
## Issue
Cerra #9106 

## Description
- Manage policies page now has a critical icon to inform users which policies are marked as critical

## Screenshot
<img width="1506" alt="Screenshot 2023-03-06 at 12 39 11 PM" src="https://user-images.githubusercontent.com/71795832/223188793-9ece2ab4-7f83-4ce8-98c4-283a72c273c0.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
