### PR TITLE
Add disclaimer about setting FLEET_DEV_MDM_ENABLED

### DIFF
--- a/docs/Using-Fleet/Mobile-device-management.md
+++ b/docs/Using-Fleet/Mobile-device-management.md
@@ -140,7 +140,7 @@ In Fleet, you can add configuration profiles using the Fleet UI or fleetctl comm
 
 The Fleet UI method is a good start if you're just getting familiar with Fleet.
 
-> During our MDM beta, you must set the environment variable `FLEET_DEV_MDM_ENABLED=1` and restart your Fleet server to reveal the MDM UI.
+> During our MDM beta, you must set the environment variable `FLEET_DEV_MDM_ENABLED=1` and restart your Fleet server to reveal the MDM features in the UI.
 
 The fleetctl CLI method enables managing configuration profiles in a git repository. This way you can enforce code review and benefit from git's change history.
 

--- a/docs/Using-Fleet/Mobile-device-management.md
+++ b/docs/Using-Fleet/Mobile-device-management.md
@@ -140,6 +140,8 @@ In Fleet, you can add configuration profiles using the Fleet UI or fleetctl comm
 
 The Fleet UI method is a good start if you're just getting familiar with Fleet.
 
+> During our MDM beta, you must set the environment variable `FLEET_DEV_MDM_ENABLED=1` and restart your Fleet server to reveal the MDM UI.
+
 The fleetctl CLI method enables managing configuration profiles in a git repository. This way you can enforce code review and benefit from git's change history.
 
 Fleet UI:


### PR DESCRIPTION
Would this be helpful?

I also noticed in this document we never describe restarting the server with all of the required MDM environment variables like we do at https://fleetdm.com/docs/contributing/testing-and-local-development#running-the-server. Should we copy that over to this doc, as well? 