### PR TITLE
Add enabled/disabled disk encryption activities and trigger profiles generation

### DIFF
--- a/changes/issue-9435-disk-encryption-activities
+++ b/changes/issue-9435-disk-encryption-activities
@@ -1,0 +1,2 @@
+* Added activities for when macOS disk encryption setting is enabled or disabled.
+* Fixed an issue when applying the configuration YAML returned by `fleetctl get config` with `fleetctl apply` when MDM is not enabled.

--- a/docs/Using-Fleet/Audit-Activities.md
+++ b/docs/Using-Fleet/Audit-Activities.md
@@ -659,6 +659,40 @@ This activity contains the following fields:
 }
 ```
 
+### Type `enabled_macos_disk_encryption`
+
+Generated when a user turns on macOS disk encryption for a team (or no team).
+
+This activity contains the following fields:
+- "team_id": The ID of the team that disk encryption applies to, null if it applies to devices that are not in a team.
+- "team_name": The name of the team that disk encryption applies to, null if it applies to devices that are not in a team.
+
+#### Example
+
+```json
+{
+  "team_id": 123,
+  "team_name": "Workstations"
+}
+```
+
+### Type `disabled_macos_disk_encryption`
+
+Generated when a user turns off macOS disk encryption for a team (or no team).
+
+This activity contains the following fields:
+- "team_id": The ID of the team that disk encryption applies to, null if it applies to devices that are not in a team.
+- "team_name": The name of the team that disk encryption applies to, null if it applies to devices that are not in a team.
+
+#### Example
+
+```json
+{
+  "team_id": 123,
+  "team_name": "Workstations"
+}
+```
+
 
 
 <meta name="pageOrderInSection" value="1400">

--- a/docs/Using-Fleet/Detail-Queries-Summary.md
+++ b/docs/Using-Fleet/Detail-Queries-Summary.md
@@ -164,6 +164,16 @@ SELECT 1 FROM osquery_registry WHERE active = true AND registry = 'table' AND na
 select version, errors, warnings from munki_info;
 ```
 
+## network_interface_chrome
+
+- Platforms: chrome
+
+- Query:
+
+```sql
+SELECT address, mac FROM network_interfaces LIMIT 1
+```
+
 ## network_interface_unix
 
 - Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, darwin

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -114,7 +114,7 @@ func (svc *Service) MDMAppleEraseDevice(ctx context.Context, hostID uint) error 
 	return nil
 }
 
-func (svc *Service) MDMAppleEnableFileVaultAndEscrow(ctx context.Context, teamID uint) error {
+func (svc *Service) MDMAppleEnableFileVaultAndEscrow(ctx context.Context, teamID *uint) error {
 	cert, _, _, err := svc.config.MDM.AppleSCEP()
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "enabling FileVault")
@@ -134,13 +134,13 @@ func (svc *Service) MDMAppleEnableFileVaultAndEscrow(ctx context.Context, teamID
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "enabling FileVault")
 	}
-	cp.TeamID = &teamID
+	cp.TeamID = teamID
 
 	_, err = svc.ds.NewMDMAppleConfigProfile(ctx, *cp)
 	return ctxerr.Wrap(ctx, err, "enabling FileVault")
 }
 
-func (svc *Service) MDMAppleDisableFileVaultAndEscrow(ctx context.Context, teamID uint) error {
+func (svc *Service) MDMAppleDisableFileVaultAndEscrow(ctx context.Context, teamID *uint) error {
 	err := svc.ds.DeleteMDMAppleConfigProfileByTeamAndIdentifier(ctx, teamID, apple_mdm.FleetFileVaultPayloadIdentifier)
 	return ctxerr.Wrap(ctx, err, "disabling FileVault")
 }

--- a/ee/server/service/mdm_test.go
+++ b/ee/server/service/mdm_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,7 +34,7 @@ func TestMDMAppleEnableFileVaultAndEscrow(t *testing.T) {
 	t.Run("fails if SCEP is not configured", func(t *testing.T) {
 		ds := new(mock.Store)
 		svc := &Service{ds: ds, config: config.FleetConfig{}}
-		err := svc.MDMAppleEnableFileVaultAndEscrow(ctx, 0)
+		err := svc.MDMAppleEnableFileVaultAndEscrow(ctx, nil)
 		require.Error(t, err)
 	})
 
@@ -43,7 +44,7 @@ func TestMDMAppleEnableFileVaultAndEscrow(t *testing.T) {
 		ds.NewMDMAppleConfigProfileFunc = func(ctx context.Context, p fleet.MDMAppleConfigProfile) (*fleet.MDMAppleConfigProfile, error) {
 			return nil, testErr
 		}
-		err := svc.MDMAppleEnableFileVaultAndEscrow(ctx, 0)
+		err := svc.MDMAppleEnableFileVaultAndEscrow(ctx, nil)
 		require.ErrorIs(t, err, testErr)
 		require.True(t, ds.NewMDMAppleConfigProfileFuncInvoked)
 	})
@@ -59,7 +60,7 @@ func TestMDMAppleEnableFileVaultAndEscrow(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.MDMAppleEnableFileVaultAndEscrow(ctx, teamID)
+		err := svc.MDMAppleEnableFileVaultAndEscrow(ctx, ptr.Uint(teamID))
 		require.NoError(t, err)
 		require.True(t, ds.NewMDMAppleConfigProfileFuncInvoked)
 	})
@@ -68,13 +69,14 @@ func TestMDMAppleEnableFileVaultAndEscrow(t *testing.T) {
 func TestMDMAppleDisableFileVaultAndEscrow(t *testing.T) {
 	var wantTeamID uint
 	ds, svc := setup()
-	ds.DeleteMDMAppleConfigProfileByTeamAndIdentifierFunc = func(ctx context.Context, teamID uint, profileIdentifier string) error {
-		require.Equal(t, wantTeamID, teamID)
+	ds.DeleteMDMAppleConfigProfileByTeamAndIdentifierFunc = func(ctx context.Context, teamID *uint, profileIdentifier string) error {
+		require.NotNil(t, teamID)
+		require.Equal(t, wantTeamID, *teamID)
 		require.Equal(t, apple_mdm.FleetFileVaultPayloadIdentifier, profileIdentifier)
 		return nil
 	}
 
-	err := svc.MDMAppleDisableFileVaultAndEscrow(context.Background(), wantTeamID)
+	err := svc.MDMAppleDisableFileVaultAndEscrow(context.Background(), ptr.Uint(wantTeamID))
 	require.NoError(t, err)
 	require.True(t, ds.DeleteMDMAppleConfigProfileByTeamAndIdentifierFuncInvoked)
 

--- a/ee/server/service/service.go
+++ b/ee/server/service/service.go
@@ -53,9 +53,11 @@ func NewService(
 	// Override methods that can't be easily overriden via
 	// embedding.
 	svc.SetEnterpriseOverrides(fleet.EnterpriseOverrides{
-		HostFeatures:               eeservice.HostFeatures,
-		TeamByIDOrName:             eeservice.teamByIDOrName,
-		UpdateTeamMDMAppleSettings: eeservice.updateTeamMDMAppleSettings,
+		HostFeatures:                      eeservice.HostFeatures,
+		TeamByIDOrName:                    eeservice.teamByIDOrName,
+		UpdateTeamMDMAppleSettings:        eeservice.updateTeamMDMAppleSettings,
+		MDMAppleEnableFileVaultAndEscrow:  eeservice.MDMAppleEnableFileVaultAndEscrow,
+		MDMAppleDisableFileVaultAndEscrow: eeservice.MDMAppleDisableFileVaultAndEscrow,
 	})
 
 	return eeservice, nil

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -180,8 +180,14 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		var act fleet.ActivityDetails
 		if team.Config.MDM.MacOSSettings.EnableDiskEncryption {
 			act = fleet.ActivityTypeEnabledMacosDiskEncryption{TeamID: &team.ID, TeamName: &team.Name}
+			if err := svc.MDMAppleEnableFileVaultAndEscrow(ctx, &team.ID); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "enable team filevault and escrow")
+			}
 		} else {
 			act = fleet.ActivityTypeDisabledMacosDiskEncryption{TeamID: &team.ID, TeamName: &team.Name}
+			if err := svc.MDMAppleDisableFileVaultAndEscrow(ctx, &team.ID); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "disable team filevault and escrow")
+			}
 		}
 		if err := svc.ds.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "create activity for team macos disk encryption")
@@ -632,6 +638,10 @@ func (svc *Service) createTeamFromSpec(
 	}
 
 	if macOSSettings.EnableDiskEncryption {
+		if err := svc.MDMAppleEnableFileVaultAndEscrow(ctx, &tm.ID); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "enable team filevault and escrow")
+		}
+
 		if err := svc.ds.NewActivity(
 			ctx,
 			authz.UserFromContext(ctx),
@@ -699,8 +709,14 @@ func (svc *Service) editTeamFromSpec(
 		var act fleet.ActivityDetails
 		if team.Config.MDM.MacOSSettings.EnableDiskEncryption {
 			act = fleet.ActivityTypeEnabledMacosDiskEncryption{TeamID: &team.ID, TeamName: &team.Name}
+			if err := svc.MDMAppleEnableFileVaultAndEscrow(ctx, &team.ID); err != nil {
+				return ctxerr.Wrap(ctx, err, "enable team filevault and escrow")
+			}
 		} else {
 			act = fleet.ActivityTypeDisabledMacosDiskEncryption{TeamID: &team.ID, TeamName: &team.Name}
+			if err := svc.MDMAppleDisableFileVaultAndEscrow(ctx, &team.ID); err != nil {
+				return ctxerr.Wrap(ctx, err, "disable team filevault and escrow")
+			}
 		}
 		if err := svc.ds.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
 			return ctxerr.Wrap(ctx, err, "create activity for team macos disk encryption")
@@ -767,8 +783,14 @@ func (svc *Service) updateTeamMDMAppleSettings(ctx context.Context, tm *fleet.Te
 			var act fleet.ActivityDetails
 			if tm.Config.MDM.MacOSSettings.EnableDiskEncryption {
 				act = fleet.ActivityTypeEnabledMacosDiskEncryption{TeamID: &tm.ID, TeamName: &tm.Name}
+				if err := svc.MDMAppleEnableFileVaultAndEscrow(ctx, &tm.ID); err != nil {
+					return ctxerr.Wrap(ctx, err, "enable team filevault and escrow")
+				}
 			} else {
 				act = fleet.ActivityTypeDisabledMacosDiskEncryption{TeamID: &tm.ID, TeamName: &tm.Name}
+				if err := svc.MDMAppleDisableFileVaultAndEscrow(ctx, &tm.ID); err != nil {
+					return ctxerr.Wrap(ctx, err, "disable team filevault and escrow")
+				}
 			}
 			if err := svc.ds.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
 				return ctxerr.Wrap(ctx, err, "create activity for team macos disk encryption")

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -140,7 +140,11 @@ func (ds *Datastore) DeleteMDMAppleConfigProfile(ctx context.Context, profileID 
 	return nil
 }
 
-func (ds *Datastore) DeleteMDMAppleConfigProfileByTeamAndIdentifier(ctx context.Context, teamID uint, profileIdentifier string) error {
+func (ds *Datastore) DeleteMDMAppleConfigProfileByTeamAndIdentifier(ctx context.Context, teamID *uint, profileIdentifier string) error {
+	if teamID == nil {
+		teamID = ptr.Uint(0)
+	}
+
 	res, err := ds.writer.ExecContext(ctx, `DELETE FROM mdm_apple_configuration_profiles WHERE team_id = ? AND identifier = ?`, teamID, profileIdentifier)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err)
@@ -156,18 +160,18 @@ func (ds *Datastore) DeleteMDMAppleConfigProfileByTeamAndIdentifier(ctx context.
 
 func (ds *Datastore) GetHostMDMProfiles(ctx context.Context, hostUUID string) ([]fleet.HostMDMAppleProfile, error) {
 	stmt := fmt.Sprintf(`
-SELECT 
+SELECT
 	hmap.profile_id,
-	name, 
-	status, 
-	operation_type, 
+	name,
+	status,
+	operation_type,
 	detail
-	
-FROM 
+
+FROM
 	host_mdm_apple_profiles hmap
 JOIN
 	mdm_apple_configuration_profiles hmacp ON hmap.profile_id = hmacp.profile_id
-WHERE 
+WHERE
 	host_uuid = ? AND NOT (operation_type = '%s' AND status = '%s')`,
 		fleet.MDMAppleOperationTypeRemove,
 		fleet.MDMAppleDeliveryApplied,
@@ -951,7 +955,7 @@ func (ds *Datastore) ListMDMAppleProfilesToInstall(ctx context.Context) ([]*flee
           AND hmap.host_uuid IS NULL
           AND hmap.status != 'pending' OR hmap.status IS NULL
           AND hmap.operation_type != 'install' OR hmap.operation_type IS NULL
-          -- accounts for the edge case of having profiles but not having hosts 
+          -- accounts for the edge case of having profiles but not having hosts
           AND ds.host_uuid IS NOT NULL
 	`
 
@@ -972,7 +976,7 @@ func (ds *Datastore) ListMDMAppleProfilesToRemove(ctx context.Context) ([]*fleet
           SELECT hmap.profile_id, hmap.profile_identifier, hmap.host_uuid
           FROM (
             SELECT h.uuid, macp.profile_id
-            FROM mdm_apple_configuration_profiles macp 
+            FROM mdm_apple_configuration_profiles macp
             JOIN hosts h ON h.team_id = macp.team_id OR (h.team_id IS NULL AND macp.team_id = 0)
             JOIN nano_enrollments ne ON ne.device_id = h.uuid
             WHERE h.platform = 'darwin' AND ne.enabled = 1

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -173,13 +173,13 @@ func testDeleteMDMAppleConfigProfileByTeamAndIdentifier(t *testing.T, ds *Datast
 	ctx := context.Background()
 	initialCP := storeDummyConfigProfileForTest(t, ds)
 
-	err := ds.DeleteMDMAppleConfigProfileByTeamAndIdentifier(ctx, *initialCP.TeamID, initialCP.Identifier)
+	err := ds.DeleteMDMAppleConfigProfileByTeamAndIdentifier(ctx, initialCP.TeamID, initialCP.Identifier)
 	require.NoError(t, err)
 
 	_, err = ds.GetMDMAppleConfigProfile(ctx, initialCP.ProfileID)
 	require.ErrorIs(t, err, sql.ErrNoRows)
 
-	err = ds.DeleteMDMAppleConfigProfileByTeamAndIdentifier(ctx, *initialCP.TeamID, initialCP.Identifier)
+	err = ds.DeleteMDMAppleConfigProfileByTeamAndIdentifier(ctx, initialCP.TeamID, initialCP.Identifier)
 	require.ErrorIs(t, err, sql.ErrNoRows)
 }
 

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -54,6 +54,9 @@ var ActivityDetailsList = []ActivityDetails{
 	ActivityTypeCreatedMacosProfile{},
 	ActivityTypeDeletedMacosProfile{},
 	ActivityTypeEditedMacosProfile{},
+
+	ActivityTypeEnabledMacosDiskEncryption{},
+	ActivityTypeDisabledMacosDiskEncryption{},
 }
 
 type ActivityDetails interface {
@@ -799,6 +802,44 @@ func (a ActivityTypeEditedMacosProfile) Documentation() (activity, details, deta
 		`This activity contains the following fields:
 - "team_id": The ID of the team that the profiles apply to, null if they apply to devices that are not in a team.
 - "team_name": The name of the team that the profiles apply to, null if they apply to devices that are not in a team.`, `{
+  "team_id": 123,
+  "team_name": "Workstations"
+}`
+}
+
+type ActivityTypeEnabledMacosDiskEncryption struct {
+	TeamID   *uint   `json:"team_id"`
+	TeamName *string `json:"team_name"`
+}
+
+func (a ActivityTypeEnabledMacosDiskEncryption) ActivityName() string {
+	return "enabled_macos_disk_encryption"
+}
+
+func (a ActivityTypeEnabledMacosDiskEncryption) Documentation() (activity, details, detailsExample string) {
+	return `Generated when a user turns on macOS disk encryption for a team (or no team).`,
+		`This activity contains the following fields:
+- "team_id": The ID of the team that disk encryption applies to, null if it applies to devices that are not in a team.
+- "team_name": The name of the team that disk encryption applies to, null if it applies to devices that are not in a team.`, `{
+  "team_id": 123,
+  "team_name": "Workstations"
+}`
+}
+
+type ActivityTypeDisabledMacosDiskEncryption struct {
+	TeamID   *uint   `json:"team_id"`
+	TeamName *string `json:"team_name"`
+}
+
+func (a ActivityTypeDisabledMacosDiskEncryption) ActivityName() string {
+	return "disabled_macos_disk_encryption"
+}
+
+func (a ActivityTypeDisabledMacosDiskEncryption) Documentation() (activity, details, detailsExample string) {
+	return `Generated when a user turns off macOS disk encryption for a team (or no team).`,
+		`This activity contains the following fields:
+- "team_id": The ID of the team that disk encryption applies to, null if it applies to devices that are not in a team.
+- "team_name": The name of the team that disk encryption applies to, null if it applies to devices that are not in a team.`, `{
   "team_id": 123,
   "team_name": "Workstations"
 }`

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -372,7 +372,7 @@ var (
 type MDMAppleConfigProfile struct {
 	// ProfileID is the unique id of the configuration profile in Fleet
 	ProfileID uint `db:"profile_id" json:"profile_id"`
-	// TeamID is the id of the team with which the configuration is associated. A team id of zero
+	// TeamID is the id of the team with which the configuration is associated. A nil team id
 	// represents a configuration profile that is not associated with any team.
 	TeamID *uint `db:"team_id" json:"team_id"`
 	// Identifier corresponds to the payload identifier of the associated mobileconfig payload.

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -714,7 +714,7 @@ type Datastore interface {
 	GetMDMAppleConfigProfile(ctx context.Context, profileID uint) (*MDMAppleConfigProfile, error)
 
 	// ListMDMAppleConfigProfiles lists mdm config profiles associated with the specified team id.
-	// For global config profiles, specify zero as the team id.
+	// For global config profiles, specify nil as the team id.
 	ListMDMAppleConfigProfiles(ctx context.Context, teamID *uint) ([]*MDMAppleConfigProfile, error)
 
 	// DeleteMDMAppleConfigProfile deletes the mdm config profile corresponding
@@ -723,7 +723,7 @@ type Datastore interface {
 
 	// DeleteMDMAppleConfigProfileByTeamAndIdentifier deletes a configuration
 	// profile using the unique key defined by `team_id` and `identifier`
-	DeleteMDMAppleConfigProfileByTeamAndIdentifier(ctx context.Context, teamID uint, profileIdentifier string) error
+	DeleteMDMAppleConfigProfileByTeamAndIdentifier(ctx context.Context, teamID *uint, profileIdentifier string) error
 
 	// GetHostMDMProfiles returns the MDM profile information for the specified host UUID.
 	GetHostMDMProfiles(ctx context.Context, hostUUID string) ([]HostMDMAppleProfile, error)

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -20,6 +20,14 @@ type EnterpriseOverrides struct {
 	// UpdateTeamMDMAppleSettings is the team-specific service method for when
 	// a team ID is provided to the UpdateMDMAppleSettings method.
 	UpdateTeamMDMAppleSettings func(ctx context.Context, tm *Team, payload MDMAppleSettingsPayload) error
+
+	// The next two functions are implemented by the ee/service, and called
+	// properly when called from an ee/service method (e.g. Modify Team), but
+	// they also need to be called from the standard server/service method (e.g.
+	// Modify AppConfig), so in this case we need to use the enterprise
+	// overrides.
+	MDMAppleEnableFileVaultAndEscrow  func(ctx context.Context, teamID *uint) error
+	MDMAppleDisableFileVaultAndEscrow func(ctx context.Context, teamID *uint) error
 }
 
 type OsqueryService interface {
@@ -635,11 +643,11 @@ type Service interface {
 	// MDMAppleEnableFileVaultAndEscrow adds a configuration profile for the
 	// given team that enables FileVault with a config that allows Fleet to
 	// escrow the recovery key.
-	MDMAppleEnableFileVaultAndEscrow(ctx context.Context, teamID uint) error
+	MDMAppleEnableFileVaultAndEscrow(ctx context.Context, teamID *uint) error
 
 	// MDMAppleDisableFileVaultAndEscrow removes the FileVault configuration
 	// profile for the given team.
-	MDMAppleDisableFileVaultAndEscrow(ctx context.Context, teamID uint) error
+	MDMAppleDisableFileVaultAndEscrow(ctx context.Context, teamID *uint) error
 
 	// UpdateMDMAppleSettings updates the specified MDM Apple settings for a
 	// specified team or for hosts with no team.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -515,7 +515,7 @@ type ListMDMAppleConfigProfilesFunc func(ctx context.Context, teamID *uint) ([]*
 
 type DeleteMDMAppleConfigProfileFunc func(ctx context.Context, profileID uint) error
 
-type DeleteMDMAppleConfigProfileByTeamAndIdentifierFunc func(ctx context.Context, teamID uint, profileIdentifier string) error
+type DeleteMDMAppleConfigProfileByTeamAndIdentifierFunc func(ctx context.Context, teamID *uint, profileIdentifier string) error
 
 type GetHostMDMProfilesFunc func(ctx context.Context, hostUUID string) ([]fleet.HostMDMAppleProfile, error)
 
@@ -3149,7 +3149,7 @@ func (s *DataStore) DeleteMDMAppleConfigProfile(ctx context.Context, profileID u
 	return s.DeleteMDMAppleConfigProfileFunc(ctx, profileID)
 }
 
-func (s *DataStore) DeleteMDMAppleConfigProfileByTeamAndIdentifier(ctx context.Context, teamID uint, profileIdentifier string) error {
+func (s *DataStore) DeleteMDMAppleConfigProfileByTeamAndIdentifier(ctx context.Context, teamID *uint, profileIdentifier string) error {
 	s.mu.Lock()
 	s.DeleteMDMAppleConfigProfileByTeamAndIdentifierFuncInvoked = true
 	s.mu.Unlock()

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -444,7 +444,15 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	}
 
 	if oldAppConfig.MDM.MacOSSettings.EnableDiskEncryption != appConfig.MDM.MacOSSettings.EnableDiskEncryption {
-		// TODO(mna): save enabled/disabled activity
+		var act fleet.ActivityDetails
+		if appConfig.MDM.MacOSSettings.EnableDiskEncryption {
+			act = fleet.ActivityTypeEnabledMacosDiskEncryption{}
+		} else {
+			act = fleet.ActivityTypeDisabledMacosDiskEncryption{}
+		}
+		if err := svc.ds.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "create activity for app config macos disk encryption")
+		}
 	}
 
 	return obfuscatedConfig, nil

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -447,8 +447,14 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		var act fleet.ActivityDetails
 		if appConfig.MDM.MacOSSettings.EnableDiskEncryption {
 			act = fleet.ActivityTypeEnabledMacosDiskEncryption{}
+			if err := svc.EnterpriseOverrides.MDMAppleEnableFileVaultAndEscrow(ctx, nil); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "enable no-team filevault and escrow")
+			}
 		} else {
 			act = fleet.ActivityTypeDisabledMacosDiskEncryption{}
+			if err := svc.EnterpriseOverrides.MDMAppleDisableFileVaultAndEscrow(ctx, nil); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "disable no-team filevault and escrow")
+			}
 		}
 		if err := svc.ds.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "create activity for app config macos disk encryption")

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -443,6 +443,10 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		}
 	}
 
+	if oldAppConfig.MDM.MacOSSettings.EnableDiskEncryption != appConfig.MDM.MacOSSettings.EnableDiskEncryption {
+		// TODO(mna): save enabled/disabled activity
+	}
+
 	return obfuscatedConfig, nil
 }
 

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1648,7 +1648,15 @@ func (svc *Service) updateAppConfigMDMAppleSettings(ctx context.Context, payload
 			return err
 		}
 		if didUpdateMacOSDiskEncryption {
-			// TODO(mna): save enabled/disabled activity
+			var act fleet.ActivityDetails
+			if ac.MDM.MacOSSettings.EnableDiskEncryption {
+				act = fleet.ActivityTypeEnabledMacosDiskEncryption{}
+			} else {
+				act = fleet.ActivityTypeDisabledMacosDiskEncryption{}
+			}
+			if err := svc.ds.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
+				return ctxerr.Wrap(ctx, err, "create activity for app config macos disk encryption")
+			}
 		}
 	}
 	return nil

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1625,17 +1625,21 @@ func (svc *Service) updateAppConfigMDMAppleSettings(ctx context.Context, payload
 		return err
 	}
 
-	var didUpdate bool
+	var didUpdate, didUpdateMacOSDiskEncryption bool
 	if payload.EnableDiskEncryption != nil {
 		if ac.MDM.MacOSSettings.EnableDiskEncryption != *payload.EnableDiskEncryption {
 			ac.MDM.MacOSSettings.EnableDiskEncryption = *payload.EnableDiskEncryption
 			didUpdate = true
+			didUpdateMacOSDiskEncryption = true
 		}
 	}
 
 	if didUpdate {
 		if err := svc.ds.SaveAppConfig(ctx, ac); err != nil {
 			return err
+		}
+		if didUpdateMacOSDiskEncryption {
+			// TODO(mna): save enabled/disabled activity
 		}
 	}
 	return nil

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1651,8 +1651,14 @@ func (svc *Service) updateAppConfigMDMAppleSettings(ctx context.Context, payload
 			var act fleet.ActivityDetails
 			if ac.MDM.MacOSSettings.EnableDiskEncryption {
 				act = fleet.ActivityTypeEnabledMacosDiskEncryption{}
+				if err := svc.EnterpriseOverrides.MDMAppleEnableFileVaultAndEscrow(ctx, nil); err != nil {
+					return ctxerr.Wrap(ctx, err, "enable no-team filevault and escrow")
+				}
 			} else {
 				act = fleet.ActivityTypeDisabledMacosDiskEncryption{}
+				if err := svc.EnterpriseOverrides.MDMAppleDisableFileVaultAndEscrow(ctx, nil); err != nil {
+					return ctxerr.Wrap(ctx, err, "disable no-team filevault and escrow")
+				}
 			}
 			if err := svc.ds.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
 				return ctxerr.Wrap(ctx, err, "create activity for app config macos disk encryption")
@@ -1666,11 +1672,11 @@ func (svc *Service) updateAppConfigMDMAppleSettings(ctx context.Context, payload
 // FileVault-related free version implementation
 ////////////////////////////////////////////////////////////////////////////////
 
-func (svc *Service) MDMAppleEnableFileVaultAndEscrow(ctx context.Context, teamID uint) error {
+func (svc *Service) MDMAppleEnableFileVaultAndEscrow(ctx context.Context, teamID *uint) error {
 	return fleet.ErrMissingLicense
 }
 
-func (svc *Service) MDMAppleDisableFileVaultAndEscrow(ctx context.Context, teamID uint) error {
+func (svc *Service) MDMAppleDisableFileVaultAndEscrow(ctx context.Context, teamID *uint) error {
 	return fleet.ErrMissingLicense
 }
 

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -1589,10 +1589,10 @@ func TestMDMAppleReconcileProfiles(t *testing.T) {
 func TestAppleMDMFileVaultEscrowFunctions(t *testing.T) {
 	svc := Service{}
 
-	err := svc.MDMAppleEnableFileVaultAndEscrow(context.Background(), uint(1))
+	err := svc.MDMAppleEnableFileVaultAndEscrow(context.Background(), ptr.Uint(1))
 	require.ErrorIs(t, fleet.ErrMissingLicense, err)
 
-	err = svc.MDMAppleDisableFileVaultAndEscrow(context.Background(), uint(1))
+	err = svc.MDMAppleDisableFileVaultAndEscrow(context.Background(), ptr.Uint(1))
 	require.ErrorIs(t, fleet.ErrMissingLicense, err)
 }
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -4511,8 +4511,15 @@ func (s *integrationTestSuite) TestPremiumEndpointsWithoutLicense() {
 	s.DoJSON("GET", "/api/latest/fleet/mdm/apple_bm", nil, http.StatusPaymentRequired, &appleBMResp)
 	assert.Nil(t, appleBMResp.AppleBM)
 
-	// batch-apply a set of MDM profiles
-	res := s.Do("POST", "/api/latest/fleet/mdm/apple/profiles/batch", nil, http.StatusUnprocessableEntity)
+	// batch-apply an empty set of MDM profiles succeeds even though MDM is not
+	// enabled, because it wouldn't change anything (and it needs to support the
+	// case where `fleetctl get config`'s output is used as input to `fleetctl
+	// apply`).
+	s.Do("POST", "/api/latest/fleet/mdm/apple/profiles/batch", nil, http.StatusNoContent)
+
+	// batch-apply a non-empty set of MDM profiles fails
+	res := s.Do("POST", "/api/latest/fleet/mdm/apple/profiles/batch",
+		map[string]interface{}{"profiles": [][]byte{[]byte(`xyz`)}}, http.StatusUnprocessableEntity)
 	errMsg := extractServerErrorText(res.Body)
 	require.Contains(t, errMsg, "Fleet MDM is not enabled")
 

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -167,12 +167,6 @@ func (s *integrationMDMTestSuite) SetupSuite() {
 	}))
 	s.T().Setenv("TEST_FLEETDM_API_URL", fleetdmSrv.URL)
 
-	appCfg, err := s.ds.AppConfig(context.Background())
-	require.NoError(s.T(), err)
-	appCfg.MDM.EnabledAndConfigured = true
-	err = s.ds.SaveAppConfig(context.Background(), appCfg)
-	require.NoError(s.T(), err)
-
 	s.T().Cleanup(fleetdmSrv.Close)
 }
 

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -1401,7 +1401,7 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 	teamResp = getTeamResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), nil, http.StatusOK, &teamResp)
 	require.False(t, teamResp.Team.Config.MDM.MacOSSettings.EnableDiskEncryption)
-	lastDiskActID = s.lastActivityOfTypeMatches(fleet.ActivityTypeDisabledMacosDiskEncryption{}.ActivityName(),
+	s.lastActivityOfTypeMatches(fleet.ActivityTypeDisabledMacosDiskEncryption{}.ActivityName(),
 		fmt.Sprintf(`{"team_id": %d, "team_name": %q}`, team.ID, teamName), 0)
 
 	// modify team's disk encryption via ModifyTeam endpoint
@@ -1412,7 +1412,7 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 		},
 	}, http.StatusOK, &modResp)
 	require.True(t, modResp.Team.Config.MDM.MacOSSettings.EnableDiskEncryption)
-	lastDiskActID = s.lastActivityOfTypeMatches(fleet.ActivityTypeEnabledMacosDiskEncryption{}.ActivityName(),
+	s.lastActivityOfTypeMatches(fleet.ActivityTypeEnabledMacosDiskEncryption{}.ActivityName(),
 		fmt.Sprintf(`{"team_id": %d, "team_name": %q}`, team.ID, teamName), 0)
 
 	// modify team's disk encryption and description via ModifyTeam endpoint
@@ -1425,7 +1425,7 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 	}, http.StatusOK, &modResp)
 	require.False(t, modResp.Team.Config.MDM.MacOSSettings.EnableDiskEncryption)
 	require.Equal(t, "foobar", modResp.Team.Description)
-	lastDiskActID = s.lastActivityOfTypeMatches(fleet.ActivityTypeDisabledMacosDiskEncryption{}.ActivityName(),
+	s.lastActivityOfTypeMatches(fleet.ActivityTypeDisabledMacosDiskEncryption{}.ActivityName(),
 		fmt.Sprintf(`{"team_id": %d, "team_name": %q}`, team.ID, teamName), 0)
 
 	// use the MDM settings endpoint to set it to true

--- a/server/service/testing_client.go
+++ b/server/service/testing_client.go
@@ -331,3 +331,36 @@ func (ts *withServer) lastActivityMatches(name, details string, id uint) uint {
 	}
 	return act.ID
 }
+
+// gets the latest activity with the specified type name and checks that it
+// matches any provided properties. empty string or 0 id means do not check
+// that property. It returns the ID of that latest activity.
+//
+// The difference with lastActivityMatches is that the asserted activity does
+// not need to be the very last one, it will look for the last one of this
+// specified type, which must be in one of the last 10 activities otherwise the
+// test is failed.
+func (ts *withServer) lastActivityOfTypeMatches(name, details string, id uint) uint {
+	t := ts.s.T()
+
+	var listActivities listActivitiesResponse
+	ts.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK,
+		&listActivities, "order_key", "a.id", "order_direction", "desc", "per_page", "10")
+	require.True(t, len(listActivities.Activities) > 0)
+
+	for _, act := range listActivities.Activities {
+		if act.Type == name {
+			if details != "" {
+				require.NotNil(t, act.Details)
+				assert.JSONEq(t, details, string(*act.Details))
+			}
+			if id > 0 {
+				assert.Equal(t, id, act.ID)
+			}
+			return act.ID
+		}
+	}
+
+	t.Fatalf("no activity of type %s found in the last %d activities", name, len(listActivities.Activities))
+	return 0
+}


### PR DESCRIPTION
#9435 

Note that the PR also includes a fix (for a bug discussed on Slack in DMs) for when running `fleetctl get config` and using that yaml as input for `fleetctl apply` when MDM is not enabled. This results in an error (MDM not enabled, cannot set `macos_settings.custom_profiles`) because the `mdm.macos_settings.custom_profiles` key _is set_ (but empty), which is a scenario we want to support to clear existing settings, but breaks this workflow. The fix simply ignores the "MDM not enabled" validation if no profiles are provided, and returns a success response.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality (manually tested `fleetctl get (config|team)` and then `fleetctl apply -f ...` without MDM enabled
