### PR TITLE
only process mdm profiles if profiles isn't empty

### DIFF
--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1469,7 +1469,7 @@ func batchSetMDMAppleProfilesEndpoint(ctx context.Context, request interface{}, 
 }
 
 func (svc *Service) BatchSetMDMAppleProfiles(ctx context.Context, tmID *uint, tmName *string, profiles [][]byte, dryRun bool) error {
-	if !svc.config.MDMApple.Enable {
+	if len(profiles) > 0 && !svc.config.MDMApple.Enable {
 		// TODO(mna): eventually we should detect the minimum config required for
 		// this to be allowed, probably just SCEP/APNs?
 		svc.authz.SkipAuthorization(ctx) // so that the error message is not replaced by "forbidden"


### PR DESCRIPTION
on a new fleet server deployment:

`fleetctl get config > default_config.yml`

and then

`fleetctl apply -f default_config.yml` 

results in 

```
Error: applying custom settings: POST /api/latest/fleet/mdm/apple/profiles/batch received status 422 Validation Failed: cannot set custom settings: Fleet MDM is not enabled
```

with this fix now apply works:

```
[+] applied fleet config
```