### PR TITLE
Updated translation rules so that Docker Desktop can be mapped to the proper CPE

### DIFF
--- a/changes/8186-fix-bug-with-docker-false-positive
+++ b/changes/8186-fix-bug-with-docker-false-positive
@@ -1,0 +1,1 @@
+Updated translation rules so that Docker Desktop can be mapped to the correct CPE.

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -1141,6 +1141,38 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 				BundleIdentifier: "com.microsoft.Excel",
 			}, cpe: "",
 		},
+		{
+			software: fleet.Software{
+				Name:             "Docker.app",
+				Source:           "apps",
+				Version:          "4.7.1",
+				BundleIdentifier: "com.docker.docker",
+			}, cpe: "cpe:2.3:a:docker:docker_desktop:4.7.1:*:*:*:*:macos:*:*",
+		},
+		{
+			software: fleet.Software{
+				Name:             "Docker Desktop.app",
+				Source:           "apps",
+				Version:          "4.16.2",
+				BundleIdentifier: "com.electron.dockerdesktop",
+			}, cpe: "cpe:2.3:a:docker:docker_desktop:4.16.2:*:*:*:*:macos:*:*",
+		},
+		{
+			software: fleet.Software{
+				Name:             "Docker Desktop.app",
+				Source:           "apps",
+				Version:          "3.5.0",
+				BundleIdentifier: "com.electron.docker-frontend",
+			}, cpe: "cpe:2.3:a:docker:docker_desktop:3.5.0:*:*:*:*:macos:*:*",
+		},
+		// 2023-03-06: there are no entries for the docker python package at the NVD dataset.
+		{
+			software: fleet.Software{
+				Name:    "docker",
+				Source:  "python_packages",
+				Version: "6.0.1",
+			}, cpe: "",
+		},
 	}
 
 	tempDir := t.TempDir()

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -79,5 +79,26 @@
     "filter": {
       "skip": true
     }
+  },
+  {
+    "software": {
+      "bundle_identifier": [
+        "/(?i)(com\\.docker\\.docker|com\\.electron\\.dockerdesktop|com\\.electron\\.docker-frontend)/"
+      ],
+      "source": ["apps"]
+    },
+    "filter": {
+      "product": ["docker_desktop"],
+      "vendor": ["docker"]
+    }
+  },
+  {
+    "software": {
+      "name": ["docker"],
+      "source": ["python_packages"]
+    },
+    "filter": {
+      "skip": true
+    }
   }
 ]


### PR DESCRIPTION
Addresses https://github.com/fleetdm/fleet/issues/8186

Updated translation rules so that Docker Desktop can be mapped to the proper CPE.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests