### PR TITLE
Issue 10300 self healing

### DIFF
--- a/orbit/changes/10300-symlink-not-present-quirk
+++ b/orbit/changes/10300-symlink-not-present-quirk
@@ -1,0 +1,1 @@
+* An update bug where orbit symlink was not present is now fixed

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -163,7 +163,6 @@ func main() {
 				return fmt.Errorf("failed to set root-dir: %w", err)
 			}
 		}
-
 		return nil
 	}
 	app.Action = func(c *cli.Context) error {
@@ -790,6 +789,9 @@ func main() {
 		return nil
 	}
 
+	if len(os.Args) == 2 && os.Args[1] == "--help" {
+		selfHealing()
+	}
 	if err := app.Run(os.Args); err != nil {
 		log.Error().Err(err).Msg("run orbit failed")
 	}
@@ -986,6 +988,18 @@ var versionCommand = &cli.Command{
 		fmt.Println("date - " + build.Date)
 		return nil
 	},
+}
+
+// selfHealing attempts to fix an issue with the auto-update mechanism in
+// an Orbit version released for Windows. See https://github.com/fleetdm/fleet/issues/10300.
+func selfHealing() {
+	if runtime.GOOS != "windows" {
+		return
+	}
+
+	//
+	// SELF HEALING ROUTINE FOR WINDOWS HERE.
+	//
 }
 
 // serviceChecker is a helper to gracefully shutdown the runners group when a

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -790,7 +790,7 @@ func main() {
 	}
 
 	if len(os.Args) == 2 && os.Args[1] == "--help" {
-		platform.RunUpdateQuirks()
+		platform.PreUpdateQuirks()
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -790,8 +790,9 @@ func main() {
 	}
 
 	if len(os.Args) == 2 && os.Args[1] == "--help" {
-		selfHealing()
+		platform.RunUpdateQuirks()
 	}
+
 	if err := app.Run(os.Args); err != nil {
 		log.Error().Err(err).Msg("run orbit failed")
 	}
@@ -988,18 +989,6 @@ var versionCommand = &cli.Command{
 		fmt.Println("date - " + build.Date)
 		return nil
 	},
-}
-
-// selfHealing attempts to fix an issue with the auto-update mechanism in
-// an Orbit version released for Windows. See https://github.com/fleetdm/fleet/issues/10300.
-func selfHealing() {
-	if runtime.GOOS != "windows" {
-		return
-	}
-
-	//
-	// SELF HEALING ROUTINE FOR WINDOWS HERE.
-	//
 }
 
 // serviceChecker is a helper to gracefully shutdown the runners group when a

--- a/orbit/pkg/platform/platform_notwindows.go
+++ b/orbit/pkg/platform/platform_notwindows.go
@@ -89,3 +89,7 @@ func GetProcessByName(name string) (*gopsutil_process.Process, error) {
 func GetSMBiosUUID() (string, UUIDSource, error) {
 	return "", UUIDSourceInvalid, errors.New("not implemented.")
 }
+
+// RunUpdateQuirks is a no-op on non-windows platforms
+func RunUpdateQuirks() {
+}

--- a/orbit/pkg/platform/platform_notwindows.go
+++ b/orbit/pkg/platform/platform_notwindows.go
@@ -93,3 +93,8 @@ func GetSMBiosUUID() (string, UUIDSource, error) {
 // RunUpdateQuirks is a no-op on non-windows platforms
 func PreUpdateQuirks() {
 }
+
+// IsInvalidReparsePoint is a no-op on non-windows platforms
+func IsInvalidReparsePoint(err error) bool {
+	return false
+}

--- a/orbit/pkg/platform/platform_notwindows.go
+++ b/orbit/pkg/platform/platform_notwindows.go
@@ -91,5 +91,5 @@ func GetSMBiosUUID() (string, UUIDSource, error) {
 }
 
 // RunUpdateQuirks is a no-op on non-windows platforms
-func RunUpdateQuirks() {
+func PreUpdateQuirks() {
 }

--- a/orbit/pkg/platform/platform_windows.go
+++ b/orbit/pkg/platform/platform_windows.go
@@ -400,6 +400,22 @@ func getOrbitVersion(path string) (string, error) {
 	return versionStr, nil
 }
 
+// fixSymlinkNotPresentCheckForBuggyOrbitVersion checks if the target orbit version has the problematic logic
+func fixSymlinkNotPresentCheckForBuggyOrbitVersion(orbitPath string) (bool, error) {
+	// gathering target orbit version
+	versionOrbit, err := getOrbitVersion(orbitPath)
+	if err != nil {
+		return false, fmt.Errorf("getting orbit version: %w", err)
+	}
+
+	// checking if target orbit has the problematic logic
+	if versionOrbit != "1.6.0" && versionOrbit != "1.7.0" {
+		return true, nil
+	}
+
+	return false, errors.New("Orbit version does not have the problematic logic")
+}
+
 // fixSymlinkNotPresent fixes the issue where the symlink to the orbit service binary is not present
 // this is a workaround for the issue described here https://github.com/fleetdm/fleet/issues/10300
 func fixSymlinkNotPresent() error {
@@ -413,14 +429,9 @@ func fixSymlinkNotPresent() error {
 	orbitPath := execPath + "\\..\\bin\\orbit\\orbit.exe"
 
 	// gathering target orbit version
-	versionOrbit, err := getOrbitVersion(orbitPath)
-	if err != nil {
-		return fmt.Errorf("getting orbit version: %w", err)
-	}
-
-	// checking if target orbit has the problematic logic
-	if versionOrbit != "1.6.0" && versionOrbit != "1.7.0" {
-		return nil
+	versionOrbit, err := fixSymlinkNotPresentCheckForBuggyOrbitVersion(orbitPath)
+	if err != nil || !versionOrbit {
+		return err
 	}
 
 	// checking if the orbit service binary symlink needs to be regenerated

--- a/orbit/pkg/update/runner.go
+++ b/orbit/pkg/update/runner.go
@@ -200,9 +200,12 @@ func (r *Runner) UpdateAction() (bool, error) {
 			}
 		}
 
-		// Check whether the hash of the repository is different than
-		// that of the target local file.
-		if !bytes.Equal(r.localHashes[target], metaHash) || needsSymlinkUpdate {
+		// Check whether the hash of the repository is different than that of the target local file
+		binaryNotUpdated := !bytes.Equal(r.localHashes[target], metaHash)
+
+		// Performing update if either the binary is not updated
+		// or the symlink needs to be updated and binary is not updated.
+		if binaryNotUpdated || (needsSymlinkUpdate && binaryNotUpdated) {
 			// Update detected
 			log.Info().Str("target", target).Msg("update detected")
 			if err := r.updateTarget(target); err != nil {

--- a/orbit/pkg/update/runner.go
+++ b/orbit/pkg/update/runner.go
@@ -201,11 +201,11 @@ func (r *Runner) UpdateAction() (bool, error) {
 		}
 
 		// Check whether the hash of the repository is different than that of the target local file
-		binaryNotUpdated := !bytes.Equal(r.localHashes[target], metaHash)
+		localBinaryNotUpdated := !bytes.Equal(r.localHashes[target], metaHash)
 
 		// Performing update if either the binary is not updated
 		// or the symlink needs to be updated and binary is not updated.
-		if binaryNotUpdated || (needsSymlinkUpdate && binaryNotUpdated) {
+		if localBinaryNotUpdated || (needsSymlinkUpdate && localBinaryNotUpdated) {
 			// Update detected
 			log.Info().Str("target", target).Msg("update detected")
 			if err := r.updateTarget(target); err != nil {

--- a/orbit/pkg/update/runner.go
+++ b/orbit/pkg/update/runner.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/orbit/pkg/platform"
 	"github.com/rs/zerolog/log"
 )
 
@@ -232,6 +233,13 @@ func (r *Runner) needsOrbitSymlinkUpdate() (bool, error) {
 		if errors.Is(err, os.ErrNotExist) {
 			return true, nil
 		}
+
+		if platform.IsInvalidReparsePoint(err) {
+			// On Windows, the symlink may be a file instead of a symlink.
+			// let's handle this case by forcing the update to happen
+			return true, nil
+		}
+
 		return false, fmt.Errorf("read existing symlink: %w", err)
 	}
 


### PR DESCRIPTION
This relates to #10300 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows, and Linux. (Tested on Windows and Linux - need @lucasmrod and @sharon-fdm to test in MacOS)
    - [ ] Auto-update manual QA from the released version of the component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md)) (test is WIP - I'm pushing the PR to receive feedback ASAP due to the criticality of the issue)
