### PR TITLE
Sentence case

### DIFF
--- a/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/CustomSettings.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/CustomSettings.tsx
@@ -95,7 +95,7 @@ const CustomSettings = () => {
 
   return (
     <div className={baseClass}>
-      <h2>Custom Settings</h2>
+      <h2>Custom settings</h2>
       <p className={`${baseClass}__description`}>
         Create and upload configuration profiles to apply custom settings.{" "}
         <CustomLink


### PR DESCRIPTION
Please see https://fleetdm.com/handbook/marketing/content-style-guide#sentence-case


Behold! The offending "S":
<img width="690" alt="image" src="https://user-images.githubusercontent.com/618009/223569059-b1adc776-5003-49c8-ae6e-701b79bcc389.png">
