### PR TITLE
Website: Update expiration timestamp sent to `create-license-key` helper

### DIFF
--- a/website/api/controllers/customers/save-billing-info-and-subscribe.js
+++ b/website/api/controllers/customers/save-billing-info-and-subscribe.js
@@ -117,7 +117,7 @@ module.exports = {
     let licenseKey = await sails.helpers.createLicenseKey.with({
       numberOfHosts: quoteRecord.numberOfHosts,
       organization: inputs.organization ? inputs.organization : this.req.me.organization,
-      expiresAt: subscription.current_period_end
+      expiresAt: subscription.current_period_end * 1000 // Converting the timestamp from Stripe (in seconds) to a JS timestamp before sending it to the createLicenseKey helper.
     });
 
     // Create the subscription record for this order.


### PR DESCRIPTION
Changes:
- Updated the `expiresAt` value sent to the `create-license-key` helper in `save-billing-info-and-subscribe` action to be a JS timestamp