### PR TITLE
Remove infrastructure from website/config/custom.js

### DIFF
--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -144,7 +144,6 @@ module.exports.custom = {
     // Folders of configuration files
     'mdm_profiles': ['lukeheath', 'zwass'],
     'vpn': ['rfairburn', 'zwass'],
-    'infrastructure': ['rfairburn', 'zwinnerman-fleetdm', 'edwardsb', 'zwass'],
 
     // Folder that any fleetie (team member contracted with company) can push to, willy-nilly
     'free-for-all': '*',


### PR DESCRIPTION
If this allows `fleet-release` to auto-approve PRs then I cannot have this set here.