### PR TITLE
Add UUID to Fleet errors and clean up error msgs

### DIFF
--- a/changes/8129-fleet-errors-uuid-and-internal
+++ b/changes/8129-fleet-errors-uuid-and-internal
@@ -1,0 +1,2 @@
+* Introduce UUIDs to Fleet errors and logs.
+* Don't return internal error information on Fleet API requests (internal errors are logged to stderr).

--- a/cmd/fleetctl/apply_test.go
+++ b/cmd/fleetctl/apply_test.go
@@ -1115,7 +1115,7 @@ spec:
   server_settings:
     server_url: 123
 `,
-			wantErr: `400 Bad request: json: cannot unmarshal number into Go struct field ServerSettings.server_settings.server_url of type string`,
+			wantErr: `400 Bad request: failed to decode app config`,
 		},
 		{
 			desc: "config with invalid agent options in dry-run",
@@ -1570,7 +1570,7 @@ spec:
     macos_settings:
       enable_disk_encryption: 123
 `,
-			wantErr: `400 Bad request: json: cannot unmarshal number into Go struct field MacOSSettings.mdm.macos_settings.enable_disk_encryption of type bool`,
+			wantErr: `400 Bad request: failed to decode app config`,
 		},
 		{
 			desc: "app config macos_settings.enable_disk_encryption true",

--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -15,6 +15,7 @@
 - [Teams](#teams)
 - [Translator](#translator)
 - [Users](#users)
+- [API errors](#api-responses)
 
 Use the Fleet APIs to automate Fleet.
 
@@ -6532,6 +6533,31 @@ Valid keys are: `cmdline`, `profile`, `symbol` and `trace`.
 #### Parameters
 
 None.
+
+## API errors
+
+Fleet returns API errors as a JSON document with the following fields:
+- `message`: This field contains the kind of error (bad request error, authorization error, etc.).
+- `errors`: List of errors with `name` and `reason` keys.
+- `uuid`: Unique identifier for the error. This identifier can be matched to Fleet logs which might contain more information about the cause of the error.
+
+Sample of an error when trying to send an empty body on a request that expects a JSON body:
+```sh
+$ curl -k -H "Authorization: Bearer $TOKEN" -H 'Content-Type:application/json' "https://localhost:8080/api/v1/fleet/sso" -d ''
+```
+Response:
+```json
+{
+  "message": "Bad request",
+  "errors": [
+    {
+      "name": "base",
+      "reason": "Expected JSON Body"
+    }
+  ],
+  "uuid": "c0532a64-bec2-4cf9-aa37-96fe47ead814"
+}
+```
 
 ---
 <meta name="pageOrderInSection" value="400">

--- a/ee/server/service/errors.go
+++ b/ee/server/service/errors.go
@@ -1,6 +1,10 @@
 package service
 
-type notFoundError struct{}
+import "github.com/fleetdm/fleet/v4/server/fleet"
+
+type notFoundError struct {
+	fleet.ErrorWithUUID
+}
 
 func (e notFoundError) Error() string {
 	return "not found"

--- a/server/authz/errors.go
+++ b/server/authz/errors.go
@@ -19,6 +19,8 @@ type Forbidden struct {
 	subject  *fleet.User
 	object   interface{}
 	action   interface{}
+
+	fleet.ErrorWithUUID
 }
 
 // ForbiddenWithInternal creates a new error that will return a simple
@@ -61,6 +63,8 @@ func (e *Forbidden) LogFields() []interface{} {
 // by the service.
 type CheckMissing struct {
 	response interface{}
+
+	fleet.ErrorWithUUID
 }
 
 // CheckMissingWithResponse creates a new error indicating the authorization

--- a/server/datastore/mysql/errors.go
+++ b/server/datastore/mysql/errors.go
@@ -16,6 +16,8 @@ type notFoundError struct {
 	Name         string
 	Message      string
 	ResourceType string
+
+	fleet.ErrorWithUUID
 }
 
 var _ fleet.NotFoundError = (*notFoundError)(nil)
@@ -69,6 +71,8 @@ type existsError struct {
 	Identifier   interface{}
 	ResourceType string
 	TeamID       *uint
+
+	fleet.ErrorWithUUID
 }
 
 func alreadyExists(kind string, identifier interface{}) error {
@@ -111,6 +115,8 @@ func isDuplicate(err error) bool {
 type foreignKeyError struct {
 	Name         string
 	ResourceType string
+
+	fleet.ErrorWithUUID
 }
 
 func foreignKey(kind string, name string) error {

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -101,10 +101,7 @@ type InvalidArgument struct {
 // one error.
 func NewInvalidArgumentError(name, reason string) *InvalidArgumentError {
 	var invalid InvalidArgumentError
-	invalid.Errors = append(invalid.Errors, InvalidArgument{
-		name:   name,
-		reason: reason,
-	})
+	invalid.Append(name, reason)
 	return &invalid
 }
 
@@ -116,10 +113,7 @@ func (e *InvalidArgumentError) Append(name, reason string) {
 }
 
 func (e *InvalidArgumentError) Appendf(name, reasonFmt string, args ...interface{}) {
-	e.Errors = append(e.Errors, InvalidArgument{
-		name:   name,
-		reason: fmt.Sprintf(reasonFmt, args...),
-	})
+	e.Append(name, fmt.Sprintf(reasonFmt, args...))
 }
 
 // WithStatus returns an error that combines the InvalidArgumentError

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 var (
@@ -56,9 +58,38 @@ func (e invalidArgWithStatusError) Status() int {
 	return e.code
 }
 
+// ErrorUUIDer is the interface for errors that contain a UUID.
+type ErrorUUIDer interface {
+	// UUID returns the error's UUID.
+	UUID() string
+}
+
+// ErrorWithUUID can be embedded to error types to implement ErrorUUIDer.
+type ErrorWithUUID struct {
+	uuid string
+}
+
+var _ ErrorUUIDer = (*ErrorWithUUID)(nil)
+
+// UUID implements the ErrorUUIDer interface.
+func (e *ErrorWithUUID) UUID() string {
+	if e.uuid == "" {
+		uuid, err := uuid.NewRandom()
+		if err != nil {
+			panic(err)
+		}
+		e.uuid = uuid.String()
+	}
+	return e.uuid
+}
+
 // InvalidArgumentError is the error returned when invalid data is presented to
 // a service method.
-type InvalidArgumentError []InvalidArgument
+type InvalidArgumentError struct {
+	Errors []InvalidArgument
+
+	ErrorWithUUID
+}
 
 // InvalidArgument is the details about a single invalid argument.
 type InvalidArgument struct {
@@ -70,7 +101,7 @@ type InvalidArgument struct {
 // one error.
 func NewInvalidArgumentError(name, reason string) *InvalidArgumentError {
 	var invalid InvalidArgumentError
-	invalid = append(invalid, InvalidArgument{
+	invalid.Errors = append(invalid.Errors, InvalidArgument{
 		name:   name,
 		reason: reason,
 	})
@@ -78,14 +109,14 @@ func NewInvalidArgumentError(name, reason string) *InvalidArgumentError {
 }
 
 func (e *InvalidArgumentError) Append(name, reason string) {
-	*e = append(*e, InvalidArgument{
+	e.Errors = append(e.Errors, InvalidArgument{
 		name:   name,
 		reason: reason,
 	})
 }
 
 func (e *InvalidArgumentError) Appendf(name, reasonFmt string, args ...interface{}) {
-	*e = append(*e, InvalidArgument{
+	e.Errors = append(e.Errors, InvalidArgument{
 		name:   name,
 		reason: fmt.Sprintf(reasonFmt, args...),
 	})
@@ -98,25 +129,25 @@ func (e InvalidArgumentError) WithStatus(code int) error {
 }
 
 func (e *InvalidArgumentError) HasErrors() bool {
-	return len(*e) != 0
+	return len(e.Errors) != 0
 }
 
 // Error implements the error interface.
 func (e InvalidArgumentError) Error() string {
-	switch len(e) {
+	switch len(e.Errors) {
 	case 0:
 		return "validation failed"
 	case 1:
-		return fmt.Sprintf("validation failed: %s %s", e[0].name, e[0].reason)
+		return fmt.Sprintf("validation failed: %s %s", e.Errors[0].name, e.Errors[0].reason)
 	default:
-		return fmt.Sprintf("validation failed: %s %s and %d other errors", e[0].name, e[0].reason,
-			len(e))
+		return fmt.Sprintf("validation failed: %s %s and %d other errors", e.Errors[0].name, e.Errors[0].reason,
+			len(e.Errors))
 	}
 }
 
 func (e InvalidArgumentError) Invalid() []map[string]string {
 	var invalid []map[string]string
-	for _, i := range e {
+	for _, i := range e.Errors {
 		invalid = append(invalid, map[string]string{"name": i.name, "reason": i.reason})
 	}
 	return invalid
@@ -124,7 +155,10 @@ func (e InvalidArgumentError) Invalid() []map[string]string {
 
 // BadRequestError is an error type that generates a 400 status code.
 type BadRequestError struct {
-	Message string
+	Message     string
+	InternalErr error
+
+	ErrorWithUUID
 }
 
 // Error returns the error message.
@@ -138,9 +172,18 @@ func (e *BadRequestError) BadRequestError() []map[string]string {
 	return nil
 }
 
+func (e BadRequestError) Internal() string {
+	if e.InternalErr == nil {
+		return ""
+	}
+	return e.InternalErr.Error()
+}
+
 type AuthFailedError struct {
 	// internal is the reason that should only be logged internally
 	internal string
+
+	ErrorWithUUID
 }
 
 func NewAuthFailedError(internal string) *AuthFailedError {
@@ -162,6 +205,8 @@ func (e AuthFailedError) StatusCode() int {
 type AuthRequiredError struct {
 	// internal is the reason that should only be logged internally
 	internal string
+
+	ErrorWithUUID
 }
 
 func NewAuthRequiredError(internal string) *AuthRequiredError {
@@ -183,10 +228,14 @@ func (e AuthRequiredError) StatusCode() int {
 type AuthHeaderRequiredError struct {
 	// internal is the reason that should only be logged internally
 	internal string
+
+	ErrorWithUUID
 }
 
 func NewAuthHeaderRequiredError(internal string) *AuthHeaderRequiredError {
-	return &AuthHeaderRequiredError{internal: internal}
+	return &AuthHeaderRequiredError{
+		internal: internal,
+	}
 }
 
 func (e AuthHeaderRequiredError) Error() string {
@@ -204,6 +253,8 @@ func (e AuthHeaderRequiredError) StatusCode() int {
 // PermissionError, set when user is authenticated, but not allowed to perform action
 type PermissionError struct {
 	message string
+
+	ErrorWithUUID
 }
 
 func NewPermissionError(message string) *PermissionError {
@@ -220,7 +271,9 @@ func (e PermissionError) PermissionError() []map[string]string {
 }
 
 // licenseError is returned when the application is not properly licensed.
-type licenseError struct{}
+type licenseError struct {
+	ErrorWithUUID
+}
 
 func (e licenseError) Error() string {
 	return "Requires Fleet Premium license"
@@ -230,7 +283,9 @@ func (e licenseError) StatusCode() int {
 	return http.StatusPaymentRequired
 }
 
-type passwordResetRequiredError struct{}
+type passwordResetRequiredError struct {
+	ErrorWithUUID
+}
 
 func (e passwordResetRequiredError) Error() string {
 	return "password reset required"
@@ -246,6 +301,8 @@ func (e passwordResetRequiredError) StatusCode() int {
 type Error struct {
 	Code    int    `json:"code,omitempty"`
 	Message string `json:"message,omitempty"`
+
+	ErrorWithUUID
 }
 
 const (
@@ -259,13 +316,19 @@ const (
 
 // NewError returns a fleet error with the code and message specified
 func NewError(code int, message string) error {
-	return &Error{code, message}
+	return &Error{
+		Code:    code,
+		Message: message,
+	}
 }
 
 // NewErrorf returns a fleet error with the code, and message formatted
 // based on the format string and args specified
 func NewErrorf(code int, format string, args ...interface{}) error {
-	return &Error{code, fmt.Sprintf(format, args...)}
+	return &Error{
+		Code:    code,
+		Message: fmt.Sprintf(format, args...),
+	}
 }
 
 func (ge *Error) Error() string {
@@ -277,6 +340,8 @@ func (ge *Error) Error() string {
 type UserMessageError struct {
 	error
 	statusCode int
+
+	ErrorWithUUID
 }
 
 // NewUserMessageError creates a UserMessageError that will translate the
@@ -287,7 +352,10 @@ func NewUserMessageError(err error, statusCode int) *UserMessageError {
 	if err == nil {
 		return nil
 	}
-	return &UserMessageError{err, statusCode}
+	return &UserMessageError{
+		error:      err,
+		statusCode: statusCode,
+	}
 }
 
 var rxJSONUnknownField = regexp.MustCompile(`^json: unknown field "(.+)"$`)

--- a/server/fleet/users_test.go
+++ b/server/fleet/users_test.go
@@ -143,7 +143,7 @@ func TestAdminCreateValidate(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				ierr := err.(*InvalidArgumentError)
-				require.Equal(t, len(tc.errContains), len(*ierr))
+				require.Equal(t, len(tc.errContains), len(ierr.Errors))
 				for _, expected := range tc.errContains {
 					assertContainsErrorName(t, *ierr, expected)
 				}
@@ -192,7 +192,7 @@ func TestInviteCreateValidate(t *testing.T) {
 			} else {
 				ierr := err.(*InvalidArgumentError)
 				for _, expected := range tc.errContains {
-					require.Equal(t, len(tc.errContains), len(*ierr))
+					require.Equal(t, len(tc.errContains), len(ierr.Errors))
 					assertContainsErrorName(t, *ierr, expected)
 				}
 			}
@@ -226,7 +226,7 @@ func TestValidateEmail(t *testing.T) {
 }
 
 func assertContainsErrorName(t *testing.T, invalid InvalidArgumentError, name string) {
-	for _, argErr := range invalid {
+	for _, argErr := range invalid.Errors {
 		if argErr.name == name {
 			return
 		}

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -271,7 +271,10 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	invalid := &fleet.InvalidArgumentError{}
 	var newAppConfig fleet.AppConfig
 	if err := json.Unmarshal(p, &newAppConfig); err != nil {
-		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{Message: err.Error()})
+		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+			Message:     "failed to decode app config",
+			InternalErr: err,
+		})
 	}
 
 	// default transparency URL is https://fleetdm.com/transparency so you are allowed to apply as long as it's not changing
@@ -375,7 +378,9 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	delJira, err := fleet.ValidateJiraIntegrations(ctx, storedJiraByProjectKey, newAppConfig.Integrations.Jira)
 	if err != nil {
 		if errors.As(err, &fleet.IntegrationTestError{}) {
-			return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{Message: err.Error()})
+			return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+				Message: err.Error(),
+			})
 		}
 		return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("Jira integration", err.Error()))
 	}
@@ -384,7 +389,9 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	delZendesk, err := fleet.ValidateZendeskIntegrations(ctx, storedZendeskByGroupID, newAppConfig.Integrations.Zendesk)
 	if err != nil {
 		if errors.As(err, &fleet.IntegrationTestError{}) {
-			return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{Message: err.Error()})
+			return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+				Message: err.Error(),
+			})
 		}
 		return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("Zendesk integration", err.Error()))
 	}

--- a/server/service/base_client_errors.go
+++ b/server/service/base_client_errors.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
 )
 
 var (
@@ -49,6 +51,8 @@ type NotFoundErr interface {
 
 type notFoundErr struct {
 	msg string
+
+	fleet.ErrorWithUUID
 }
 
 func (e notFoundErr) Error() string {

--- a/server/service/carves.go
+++ b/server/service/carves.go
@@ -191,30 +191,30 @@ func (svc *Service) CarveBegin(ctx context.Context, payload fleet.CarveBeginPayl
 
 	host, ok := hostctx.FromContext(ctx)
 	if !ok {
-		return nil, osqueryError{message: "internal error: missing host from request context"}
+		return nil, newOsqueryError("internal error: missing host from request context")
 	}
 
 	if payload.CarveSize == 0 {
-		return nil, osqueryError{message: "carve_size must be greater than 0"}
+		return nil, newOsqueryError("carve_size must be greater than 0")
 	}
 
 	if payload.BlockSize > maxBlockSize {
-		return nil, osqueryError{message: "block_size exceeds max"}
+		return nil, newOsqueryError("block_size exceeds max")
 	}
 	if payload.CarveSize > maxCarveSize {
-		return nil, osqueryError{message: "carve_size exceeds max"}
+		return nil, newOsqueryError("carve_size exceeds max")
 	}
 
 	// The carve should have a total size that fits appropriately into the
 	// number of blocks of the specified size.
 	if payload.CarveSize <= (payload.BlockCount-1)*payload.BlockSize ||
 		payload.CarveSize > payload.BlockCount*payload.BlockSize {
-		return nil, osqueryError{message: "carve_size does not match block_size and block_count"}
+		return nil, newOsqueryError("carve_size does not match block_size and block_count")
 	}
 
 	sessionId, err := uuid.NewRandom()
 	if err != nil {
-		return nil, osqueryError{message: "internal error: generate session ID for carve: " + err.Error()}
+		return nil, newOsqueryError("internal error: generate session ID for carve: " + err.Error())
 	}
 
 	now := time.Now().UTC()
@@ -232,7 +232,7 @@ func (svc *Service) CarveBegin(ctx context.Context, payload fleet.CarveBeginPayl
 
 	carve, err = svc.carveStore.NewCarve(ctx, carve)
 	if err != nil {
-		return nil, osqueryError{message: "internal error: new carve: " + err.Error()}
+		return nil, newOsqueryError("internal error: new carve: " + err.Error())
 	}
 
 	return carve, nil

--- a/server/service/endpoint_middleware.go
+++ b/server/service/endpoint_middleware.go
@@ -170,9 +170,7 @@ func getNodeKey(r interface{}) (string, error) {
 	if hnk, ok := r.(interface{ hostNodeKey() string }); ok {
 		return hnk.hostNodeKey(), nil
 	}
-	return "", osqueryError{
-		message: "request type does not implement hostNodeKey method. This is likely a Fleet programmer error.",
-	}
+	return "", newOsqueryError("request type does not implement hostNodeKey method. This is likely a Fleet programmer error.")
 }
 
 // authenticatedUser wraps an endpoint, requires that the Fleet user is

--- a/server/service/endpoint_middleware_test.go
+++ b/server/service/endpoint_middleware_test.go
@@ -185,7 +185,7 @@ func TestAuthenticatedHost(t *testing.T) {
 			r := &testNodeKeyRequest{NodeKey: tt.nodeKey}
 			_, err := endpoint(ctx, r)
 			if tt.shouldErr {
-				assert.IsType(t, osqueryError{}, err)
+				assert.IsType(t, &osqueryError{}, err)
 			} else {
 				assert.Nil(t, err)
 			}

--- a/server/service/endpoint_utils.go
+++ b/server/service/endpoint_utils.go
@@ -143,7 +143,7 @@ func makeDecoder(iface interface{}) kithttp.DecodeRequestFunc {
 			if r.Header.Get("content-encoding") == "gzip" {
 				gzr, err := gzip.NewReader(buf)
 				if err != nil {
-					return nil, badRequestErr("gzip decoder error: %w", err)
+					return nil, badRequestErr("gzip decoder error", err)
 				}
 				defer gzr.Close()
 				body = gzr
@@ -152,7 +152,7 @@ func makeDecoder(iface interface{}) kithttp.DecodeRequestFunc {
 			if !isBodyDecoder {
 				req := v.Interface()
 				if err := json.NewDecoder(body).Decode(req); err != nil {
-					return nil, badRequestErr("json decoder error: %w", err)
+					return nil, badRequestErr("json decoder error", err)
 				}
 				v = reflect.ValueOf(req)
 			}
@@ -209,7 +209,7 @@ func makeDecoder(iface interface{}) kithttp.DecodeRequestFunc {
 							if err == errBadRoute && optional {
 								continue
 							}
-							return nil, badRequestErr("intFromRequest: %w", err)
+							return nil, badRequestErr("intFromRequest", err)
 						}
 						field.SetInt(v)
 
@@ -219,7 +219,7 @@ func makeDecoder(iface interface{}) kithttp.DecodeRequestFunc {
 							if err == errBadRoute && optional {
 								continue
 							}
-							return nil, badRequestErr("uintFromRequest: %w", err)
+							return nil, badRequestErr("uintFromRequest", err)
 						}
 						field.SetUint(v)
 
@@ -229,7 +229,7 @@ func makeDecoder(iface interface{}) kithttp.DecodeRequestFunc {
 							if err == errBadRoute && optional {
 								continue
 							}
-							return nil, badRequestErr("stringFromRequest: %w", err)
+							return nil, badRequestErr("stringFromRequest", err)
 						}
 						field.SetString(v)
 
@@ -270,7 +270,7 @@ func makeDecoder(iface interface{}) kithttp.DecodeRequestFunc {
 				case reflect.Uint:
 					queryValUint, err := strconv.Atoi(queryVal)
 					if err != nil {
-						return nil, badRequestErr("parsing uint from query: %w", err)
+						return nil, badRequestErr("parsing uint from query", err)
 					}
 					field.SetUint(uint64(queryValUint))
 				case reflect.Bool:
@@ -292,7 +292,7 @@ func makeDecoder(iface interface{}) kithttp.DecodeRequestFunc {
 					default:
 						queryValInt, err = strconv.Atoi(queryVal)
 						if err != nil {
-							return nil, badRequestErr("parsing int from query: %w", err)
+							return nil, badRequestErr("parsing int from query", err)
 						}
 					}
 					field.SetInt(int64(queryValInt))
@@ -335,13 +335,16 @@ func badRequest(msg string) error {
 	return &fleet.BadRequestError{Message: msg}
 }
 
-func badRequestErr(msg string, err error) error {
+func badRequestErr(publicMsg string, internalErr error) error {
 	// ensure timeout errors don't become BadRequestErrors.
 	var opErr *net.OpError
-	if errors.As(err, &opErr) {
-		return fmt.Errorf(msg, err)
+	if errors.As(internalErr, &opErr) {
+		return fmt.Errorf(publicMsg+", internal: %w", internalErr)
 	}
-	return &fleet.BadRequestError{Message: fmt.Errorf(msg, err).Error()}
+	return &fleet.BadRequestError{
+		Message:     publicMsg,
+		InternalErr: internalErr,
+	}
 }
 
 type authEndpointer struct {

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -56,6 +56,11 @@ func (h *errorHandler) Handle(ctx context.Context, err error) {
 		logger = kitlog.With(logger, ewlf.LogFields()...)
 	}
 
+	var uuider fleet.ErrorUUIDer
+	if errors.As(err, &uuider) {
+		logger = kitlog.With(logger, "uuid", uuider.UUID())
+	}
+
 	var rle ratelimit.Error
 	if errors.As(err, &rle) {
 		res := rle.Result()

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1435,7 +1435,7 @@ func (svc *Service) HostEncryptionKey(ctx context.Context, id uint) (*fleet.Host
 	}
 
 	if key.Decryptable == nil || !*key.Decryptable {
-		return nil, ctxerr.Wrap(ctx, notFoundError{}, "getting host encryption key")
+		return nil, ctxerr.Wrap(ctx, newNotFoundError(), "getting host encryption key")
 	}
 
 	cert, _, _, err := svc.config.MDM.AppleSCEP()

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -719,7 +719,7 @@ func TestEmptyTeamOSVersions(t *testing.T) {
 			}, nil
 		}
 
-		return nil, notFoundError{}
+		return nil, newNotFoundError()
 	}
 
 	ds.OSVersionsFunc = func(ctx context.Context, teamID *uint, platform *string, name *string, version *string) (*fleet.OSVersions, error) {
@@ -730,7 +730,7 @@ func TestEmptyTeamOSVersions(t *testing.T) {
 			return nil, errors.New("some unknown error")
 		}
 
-		return nil, notFoundError{}
+		return nil, newNotFoundError()
 	}
 
 	// team exists with stats

--- a/server/service/http_auth_test.go
+++ b/server/service/http_auth_test.go
@@ -213,34 +213,29 @@ func TestNoHeaderErrorsDifferently(t *testing.T) {
 	require.Nil(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
-	require.Nil(t, err)
-	assert.Equal(t, `{
-  "message": "Authorization header required",
-  "errors": [
-    {
-      "name": "base",
-      "reason": "Authorization header required"
-    }
-  ]
-}
-`, string(bodyBytes))
+	jsn := struct {
+		Message string              `json:"message"`
+		Errs    []map[string]string `json:"errors,omitempty"`
+		UUID    string              `json:"uuid"`
+	}{}
+	err = json.NewDecoder(resp.Body).Decode(&jsn)
+	require.NoError(t, err)
+	assert.Equal(t, "Authorization header required", jsn.Message)
+	require.Len(t, jsn.Errs, 1)
+	assert.Equal(t, "base", jsn.Errs[0]["name"])
+	assert.Equal(t, "Authorization header required", jsn.Errs[0]["reason"])
+	assert.NotEmpty(t, jsn.UUID)
 
 	req, _ = http.NewRequest("GET", server.URL+"/api/latest/fleet/users", nil)
 	req.Header.Add("Authorization", "Bearer AAAA")
 	resp, err = client.Do(req)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
-	bodyBytes, err = ioutil.ReadAll(resp.Body)
-	require.Nil(t, err)
-	assert.Equal(t, `{
-  "message": "Authentication required",
-  "errors": [
-    {
-      "name": "base",
-      "reason": "Authentication required"
-    }
-  ]
-}
-`, string(bodyBytes))
+	err = json.NewDecoder(resp.Body).Decode(&jsn)
+	require.NoError(t, err)
+	assert.Equal(t, "Authentication required", jsn.Message)
+	require.Len(t, jsn.Errs, 1)
+	assert.Equal(t, "base", jsn.Errs[0]["name"])
+	assert.Equal(t, "Authentication required", jsn.Errs[0]["reason"])
+	assert.NotEmpty(t, jsn.UUID)
 }

--- a/server/service/installer.go
+++ b/server/service/installer.go
@@ -163,7 +163,7 @@ func (svc *Service) CheckInstallerExistence(ctx context.Context, installer fleet
 	}
 
 	if !exists {
-		return notFoundError{}
+		return newNotFoundError()
 	}
 
 	return nil

--- a/server/service/installer_test.go
+++ b/server/service/installer_test.go
@@ -50,11 +50,12 @@ func TestGetInstaller(t *testing.T) {
 	t.Run("errors if the provided enroll secret cannot be found", func(t *testing.T) {
 		ctx, ds, _, svc := setup(t)
 		ds.VerifyEnrollSecretFunc = func(ctx context.Context, enrollSecret string) (*fleet.EnrollSecret, error) {
-			return nil, notFoundError{}
+			return nil, newNotFoundError()
 		}
 		_, _, err := svc.GetInstaller(ctx, fleet.Installer{})
 		require.Error(t, err)
-		require.ErrorAs(t, err, &notFoundError{})
+		var nfe *notFoundError
+		require.ErrorAs(t, err, &nfe)
 		require.True(t, ds.VerifyEnrollSecretFuncInvoked)
 	})
 
@@ -120,11 +121,12 @@ func TestCheckInstallerExistence(t *testing.T) {
 	t.Run("errors if the provided enroll secret cannot be found", func(t *testing.T) {
 		ctx, ds, _, svc := setup(t)
 		ds.VerifyEnrollSecretFunc = func(ctx context.Context, enrollSecret string) (*fleet.EnrollSecret, error) {
-			return nil, notFoundError{}
+			return nil, newNotFoundError()
 		}
 		err := svc.CheckInstallerExistence(ctx, fleet.Installer{})
 		require.Error(t, err)
-		require.ErrorAs(t, err, &notFoundError{})
+		var nfe *notFoundError
+		require.ErrorAs(t, err, &nfe)
 		require.True(t, ds.VerifyEnrollSecretFuncInvoked)
 	})
 
@@ -158,7 +160,8 @@ func TestCheckInstallerExistence(t *testing.T) {
 		}
 		err := svc.CheckInstallerExistence(ctx, fleet.Installer{})
 		require.Error(t, err)
-		require.ErrorAs(t, err, &notFoundError{})
+		var nfe *notFoundError
+		require.ErrorAs(t, err, &nfe)
 		require.True(t, ds.VerifyEnrollSecretFuncInvoked)
 		require.True(t, is.ExistsFuncInvoked)
 	})

--- a/server/service/integration_logger_test.go
+++ b/server/service/integration_logger_test.go
@@ -174,12 +174,23 @@ func (s *integrationLoggerTestSuite) TestOsqueryEndpointsLogErrors() {
 	requestBody := io.NopCloser(bytes.NewBuffer([]byte(`{"node_key":"1234","log_type":"status","data":[}`)))
 	req, _ := http.NewRequest("POST", s.server.URL+"/api/osquery/log", requestBody)
 	client := fleethttp.NewClient()
-	_, err = client.Do(req)
-	require.Nil(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	jsn := struct {
+		Message string              `json:"message"`
+		Errs    []map[string]string `json:"errors,omitempty"`
+		UUID    string              `json:"uuid"`
+	}{}
+	err = json.NewDecoder(resp.Body).Decode(&jsn)
+	require.NoError(t, err)
+	assert.Equal(t, "Bad request", jsn.Message)
+	assert.Len(t, jsn.Errs, 1)
+	assert.Equal(t, "base", jsn.Errs[0]["name"])
+	assert.Equal(t, "json decoder error", jsn.Errs[0]["reason"])
+	require.NotEmpty(t, jsn.UUID)
 
 	logString := s.buf.String()
-	assert.Contains(t, logString, `invalid character '}' looking for beginning of value","level":"info","path":"/api/osquery/log"}
-`, logString)
+	assert.Contains(t, logString, `invalid character '}' looking for beginning of value","level":"info","path":"/api/osquery/log","uuid":"`+jsn.UUID+`"}`, logString)
 }
 
 func (s *integrationLoggerTestSuite) TestSubmitLog() {

--- a/server/service/invites.go
+++ b/server/service/invites.go
@@ -199,7 +199,7 @@ func (svc *Service) UpdateInvite(ctx context.Context, id uint, payload fleet.Inv
 	if payload.Email != nil && *payload.Email != invite.Email {
 		switch _, err := svc.ds.UserByEmail(ctx, *payload.Email); {
 		case err == nil:
-			return nil, ctxerr.Wrap(ctx, alreadyExistsError{})
+			return nil, ctxerr.Wrap(ctx, newAlreadyExistsError())
 		case errors.Is(err, sql.ErrNoRows):
 			// OK
 		default:
@@ -208,7 +208,7 @@ func (svc *Service) UpdateInvite(ctx context.Context, id uint, payload fleet.Inv
 
 		switch _, err = svc.ds.InviteByEmail(ctx, *payload.Email); {
 		case err == nil:
-			return nil, ctxerr.Wrap(ctx, alreadyExistsError{})
+			return nil, ctxerr.Wrap(ctx, newAlreadyExistsError())
 		case errors.Is(err, sql.ErrNoRows):
 			// OK
 		default:

--- a/server/service/invites_test.go
+++ b/server/service/invites_test.go
@@ -154,7 +154,7 @@ func TestInvitesAuth(t *testing.T) {
 	}
 	ds.DeleteInviteFunc = func(context.Context, uint) error { return nil }
 	ds.UserByEmailFunc = func(ctx context.Context, email string) (*fleet.User, error) {
-		return nil, notFoundError{}
+		return nil, newNotFoundError()
 	}
 	ds.NewInviteFunc = func(ctx context.Context, i *fleet.Invite) (*fleet.Invite, error) {
 		return &fleet.Invite{}, nil

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -40,7 +40,7 @@ func (svc *Service) GetAppleMDM(ctx context.Context) (*fleet.AppleMDM, error) {
 
 	// if there is no apple mdm config, fail with a 404
 	if !svc.config.MDM.IsAppleAPNsSet() {
-		return nil, notFoundError{}
+		return nil, newNotFoundError()
 	}
 
 	apns, _, _, err := svc.config.MDM.AppleAPNs()

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -66,7 +66,7 @@ func (r EnrollOrbitResponse) hijackRender(ctx context.Context, w http.ResponseWr
 	enc.SetIndent("", "  ")
 
 	if err := enc.Encode(r); err != nil {
-		encodeError(ctx, osqueryError{message: fmt.Sprintf("orbit enroll failed: %s", err)}, w)
+		encodeError(ctx, newOsqueryError(fmt.Sprintf("orbit enroll failed: %s", err)), w)
 	}
 }
 
@@ -277,13 +277,11 @@ func (svc *Service) SetOrUpdateDeviceAuthToken(ctx context.Context, deviceAuthTo
 
 	host, ok := hostctx.FromContext(ctx)
 	if !ok {
-		return osqueryError{message: "internal error: missing host from request context"}
+		return newOsqueryError("internal error: missing host from request context")
 	}
 
 	if err := svc.ds.SetOrUpdateDeviceAuthToken(ctx, host.ID, deviceAuthToken); err != nil {
-		return osqueryError{
-			message: fmt.Sprintf("internal error: failed to set or update device auth token: %e", err),
-		}
+		return newOsqueryError(fmt.Sprintf("internal error: failed to set or update device auth token: %e", err))
 	}
 
 	return nil

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -1982,7 +1982,7 @@ func TestAuthenticationErrors(t *testing.T) {
 
 	_, _, err := svc.AuthenticateHost(ctx, "")
 	require.Error(t, err)
-	require.True(t, err.(osqueryError).NodeInvalid())
+	require.True(t, err.(*osqueryError).NodeInvalid())
 
 	ms.LoadHostByNodeKeyFunc = func(ctx context.Context, nodeKey string) (*fleet.Host, error) {
 		return &fleet.Host{ID: 1}, nil
@@ -1995,12 +1995,12 @@ func TestAuthenticationErrors(t *testing.T) {
 
 	// return not found error
 	ms.LoadHostByNodeKeyFunc = func(ctx context.Context, nodeKey string) (*fleet.Host, error) {
-		return nil, notFoundError{}
+		return nil, newNotFoundError()
 	}
 
 	_, _, err = svc.AuthenticateHost(ctx, "foo")
 	require.Error(t, err)
-	require.True(t, err.(osqueryError).NodeInvalid())
+	require.True(t, err.(*osqueryError).NodeInvalid())
 
 	// return other error
 	ms.LoadHostByNodeKeyFunc = func(ctx context.Context, nodeKey string) (*fleet.Host, error) {
@@ -2009,7 +2009,7 @@ func TestAuthenticationErrors(t *testing.T) {
 
 	_, _, err = svc.AuthenticateHost(ctx, "foo")
 	require.NotNil(t, err)
-	require.False(t, err.(osqueryError).NodeInvalid())
+	require.False(t, err.(*osqueryError).NodeInvalid())
 }
 
 func TestGetHostIdentifier(t *testing.T) {

--- a/server/service/service_errors.go
+++ b/server/service/service_errors.go
@@ -1,23 +1,37 @@
 package service
 
-type alreadyExistsError struct{}
+import "github.com/fleetdm/fleet/v4/server/fleet"
 
-func (a alreadyExistsError) Error() string {
+type alreadyExistsError struct {
+	fleet.ErrorWithUUID
+}
+
+func (a *alreadyExistsError) Error() string {
 	return "Entity already exists"
 }
 
-func (a alreadyExistsError) IsExists() bool {
+func (a *alreadyExistsError) IsExists() bool {
 	return true
 }
 
-type notFoundError struct{}
+func newAlreadyExistsError() *alreadyExistsError {
+	return &alreadyExistsError{}
+}
 
-func (e notFoundError) Error() string {
+type notFoundError struct {
+	fleet.ErrorWithUUID
+}
+
+func (e *notFoundError) Error() string {
 	return "not found"
 }
 
-func (e notFoundError) IsNotFound() bool {
+func (e *notFoundError) IsNotFound() bool {
 	return true
+}
+
+func newNotFoundError() *notFoundError {
+	return &notFoundError{}
 }
 
 // ssoErrCode defines a code for the type of SSO error that occurred. This is
@@ -38,12 +52,21 @@ const (
 type ssoError struct {
 	err  error
 	code ssoErrCode
+
+	fleet.ErrorWithUUID
 }
 
-func (e ssoError) Error() string {
+func newSSOError(err error, code ssoErrCode) *ssoError {
+	return &ssoError{
+		err:  err,
+		code: code,
+	}
+}
+
+func (e *ssoError) Error() string {
 	return string(e.code) + ": " + e.err.Error()
 }
 
-func (e ssoError) Unwrap() error {
+func (e *ssoError) Unwrap() error {
 	return e.err
 }

--- a/server/service/sessions_test.go
+++ b/server/service/sessions_test.go
@@ -234,7 +234,7 @@ func TestGetSSOUser(t *testing.T) {
 	}
 
 	ds.UserByEmailFunc = func(ctx context.Context, email string) (*fleet.User, error) {
-		return nil, notFoundError{}
+		return nil, newNotFoundError()
 	}
 
 	var newUser *fleet.User
@@ -318,7 +318,7 @@ func TestGetSSOUser(t *testing.T) {
 	// (3) Test with invalid team ID in the attributes
 
 	ds.TeamFunc = func(ctx context.Context, tid uint) (*fleet.Team, error) {
-		return nil, notFoundError{}
+		return nil, newNotFoundError()
 	}
 
 	auth.assertionAttributes = []fleet.SAMLAttribute{

--- a/server/service/transport_error.go
+++ b/server/service/transport_error.go
@@ -27,6 +27,7 @@ type jsonError struct {
 	Message string              `json:"message"`
 	Code    int                 `json:"code,omitempty"`
 	Errors  []map[string]string `json:"errors,omitempty"`
+	UUID    string              `json:"uuid,omitempty"`
 }
 
 // use baseError to encode an jsonError.Errors field with an error that has
@@ -91,41 +92,43 @@ func encodeError(ctx context.Context, err error, w http.ResponseWriter) {
 
 	err = ctxerr.Cause(err)
 
+	var uuid string
+	if uuidErr, ok := err.(fleet.ErrorUUIDer); ok {
+		uuid = uuidErr.UUID()
+	}
+
+	jsonErr := jsonError{
+		UUID: uuid,
+	}
+
 	switch e := err.(type) {
 	case validationErrorInterface:
-		ve := jsonError{
-			Message: "Validation Failed",
-			Errors:  e.Invalid(),
-		}
 		if statusErr, ok := e.(statuser); ok {
 			w.WriteHeader(statusErr.Status())
 		} else {
 			w.WriteHeader(http.StatusUnprocessableEntity)
 		}
-		enc.Encode(ve) //nolint:errcheck
+		jsonErr.Message = "Validation Failed"
+		jsonErr.Errors = e.Invalid()
 	case permissionErrorInterface:
-		pe := jsonError{
-			Message: "Permission Denied",
-			Errors:  e.PermissionError(),
-		}
+		jsonErr.Message = "Permission Denied"
+		jsonErr.Errors = e.PermissionError()
 		w.WriteHeader(http.StatusForbidden)
-		enc.Encode(pe) //nolint:errcheck
-		return
 	case mailError:
-		me := jsonError{
-			Message: "Mail Error",
-			Errors:  e.MailError(),
-		}
+		jsonErr.Message = "Mail Error"
+		jsonErr.Errors = e.MailError()
 		w.WriteHeader(http.StatusInternalServerError)
-		enc.Encode(me) //nolint:errcheck
-	case osqueryError:
+	case *osqueryError:
 		// osquery expects to receive the node_invalid key when a TLS
 		// request provides an invalid node_key for authentication. It
 		// doesn't use the error message provided, but we provide this
 		// for debugging purposes (and perhaps osquery will use this
 		// error message in the future).
 
-		errMap := map[string]interface{}{"error": e.Error()}
+		errMap := map[string]interface{}{
+			"error": e.Error(),
+			"uuid":  uuid,
+		}
 		if e.NodeInvalid() {
 			w.WriteHeader(http.StatusUnauthorized)
 			errMap["node_invalid"] = true
@@ -138,72 +141,51 @@ func encodeError(ctx context.Context, err error, w http.ResponseWriter) {
 		}
 
 		enc.Encode(errMap) //nolint:errcheck
+		return
 	case notFoundErrorInterface:
-		je := jsonError{
-			Message: "Resource Not Found",
-			Errors:  baseError(e.Error()),
-		}
+		jsonErr.Message = "Resource Not Found"
+		jsonErr.Errors = baseError(e.Error())
 		w.WriteHeader(http.StatusNotFound)
-		enc.Encode(je) //nolint:errcheck
 	case existsErrorInterface:
-		je := jsonError{
-			Message: "Resource Already Exists",
-			Errors:  baseError(e.Error()),
-		}
+		jsonErr.Message = "Resource Already Exists"
+		jsonErr.Errors = baseError(e.Error())
 		w.WriteHeader(http.StatusConflict)
-		enc.Encode(je) //nolint:errcheck
 	case conflictErrorInterface:
-		je := jsonError{
-			Message: "Conflict",
-			Errors:  baseError(e.Error()),
-		}
+		jsonErr.Message = "Conflict"
+		jsonErr.Errors = baseError(e.Error())
 		w.WriteHeader(http.StatusConflict)
-		enc.Encode(je) //nolint:errcheck
 	case badRequestErrorInterface:
-		je := jsonError{
-			Message: "Bad request",
-			Errors:  baseError(e.Error()),
-		}
+		jsonErr.Message = "Bad request"
+		jsonErr.Errors = baseError(e.Error())
 		w.WriteHeader(http.StatusBadRequest)
-		enc.Encode(je) //nolint:errcheck
 	case *mysql.MySQLError:
-		je := jsonError{
-			Message: "Validation Failed",
-			Errors:  baseError(e.Error()),
-		}
+		jsonErr.Message = "Validation Failed"
+		jsonErr.Errors = baseError(e.Error())
 		statusCode := http.StatusUnprocessableEntity
 		if e.Number == 1062 {
 			statusCode = http.StatusConflict
 		}
 		w.WriteHeader(statusCode)
-		enc.Encode(je) //nolint:errcheck
 	case *fleet.Error:
-		je := jsonError{
-			Message: e.Error(),
-			Code:    e.Code,
-		}
+		jsonErr.Message = e.Error()
+		jsonErr.Code = e.Code
 		w.WriteHeader(http.StatusUnprocessableEntity)
-		enc.Encode(je) //nolint:errcheck
 	default:
 		// when there's a tcp read timeout, the error is *net.OpError but the cause is an internal
 		// poll.DeadlineExceeded which we cannot match against, so we match against the original error
 		var opErr *net.OpError
 		if errors.As(origErr, &opErr) {
+			jsonErr.Message = opErr.Error()
+			jsonErr.Errors = baseError(opErr.Error())
 			w.WriteHeader(http.StatusRequestTimeout)
-			je := jsonError{
-				Message: opErr.Error(),
-				Errors:  baseError(opErr.Error()),
-			}
-			enc.Encode(je) //nolint:errcheck
+			enc.Encode(jsonErr) //nolint:errcheck
 			return
 		}
 		if fleet.IsForeignKey(err) {
-			ve := jsonError{
-				Message: "Validation Failed",
-				Errors:  baseError(err.Error()),
-			}
+			jsonErr.Message = "Validation Failed"
+			jsonErr.Errors = baseError(err.Error())
 			w.WriteHeader(http.StatusUnprocessableEntity)
-			enc.Encode(ve) //nolint:errcheck
+			enc.Encode(jsonErr) //nolint:errcheck
 			return
 		}
 
@@ -233,12 +215,11 @@ func encodeError(ctx context.Context, err error, w http.ResponseWriter) {
 		}
 
 		w.WriteHeader(status)
-		je := jsonError{
-			Message: msg,
-			Errors:  baseError(reason),
-		}
-		enc.Encode(je) //nolint:errcheck
+		jsonErr.Message = msg
+		jsonErr.Errors = baseError(reason)
 	}
+
+	enc.Encode(jsonErr) //nolint:errcheck
 }
 
 func sendToSentry(ctx context.Context, err error) {

--- a/server/service/transport_error_test.go
+++ b/server/service/transport_error_test.go
@@ -25,7 +25,7 @@ type newAndExciting struct{}
 func (newAndExciting) Error() string { return "" }
 
 func TestHandlesErrorsCode(t *testing.T) {
-	var errorTests = []struct {
+	errorTests := []struct {
 		name string
 		err  error
 		code int
@@ -52,17 +52,17 @@ func TestHandlesErrorsCode(t *testing.T) {
 		},
 		{
 			"osquery error - invalid node",
-			osqueryError{nodeInvalid: true},
+			&osqueryError{nodeInvalid: true},
 			http.StatusUnauthorized,
 		},
 		{
 			"osquery error - valid node",
-			osqueryError{},
+			&osqueryError{},
 			http.StatusInternalServerError,
 		},
 		{
 			"data not found",
-			notFoundError{},
+			&notFoundError{},
 			http.StatusNotFound,
 		},
 		{
@@ -89,5 +89,4 @@ func TestHandlesErrorsCode(t *testing.T) {
 			assert.Equal(t, recorder.Code, tt.code)
 		})
 	}
-
 }

--- a/server/service/users.go
+++ b/server/service/users.go
@@ -743,7 +743,7 @@ func (svc *Service) modifyEmailAddress(ctx context.Context, user *fleet.User, em
 
 	switch _, err = svc.ds.UserByEmail(ctx, email); {
 	case err == nil:
-		return ctxerr.Wrap(ctx, alreadyExistsError{})
+		return ctxerr.Wrap(ctx, newAlreadyExistsError())
 	case errors.Is(err, sql.ErrNoRows):
 		// OK
 	default:
@@ -752,7 +752,7 @@ func (svc *Service) modifyEmailAddress(ctx context.Context, user *fleet.User, em
 
 	switch _, err = svc.ds.InviteByEmail(ctx, email); {
 	case err == nil:
-		return ctxerr.Wrap(ctx, alreadyExistsError{})
+		return ctxerr.Wrap(ctx, newAlreadyExistsError())
 	case errors.Is(err, sql.ErrNoRows):
 		// OK
 	default:

--- a/server/service/users_test.go
+++ b/server/service/users_test.go
@@ -516,7 +516,7 @@ func TestModifyUserEmailNoPassword(t *testing.T) {
 	var iae *fleet.InvalidArgumentError
 	ok := errors.As(err, &iae)
 	require.True(t, ok)
-	require.Len(t, *iae, 1)
+	require.Len(t, iae.Errors, 1)
 	assert.False(t, ms.PendingEmailChangeFuncInvoked)
 	assert.False(t, ms.SaveUserFuncInvoked)
 }
@@ -565,7 +565,7 @@ func TestModifyAdminUserEmailNoPassword(t *testing.T) {
 	var iae *fleet.InvalidArgumentError
 	ok := errors.As(err, &iae)
 	require.True(t, ok)
-	require.Len(t, *iae, 1)
+	require.Len(t, iae.Errors, 1)
 	assert.False(t, ms.PendingEmailChangeFuncInvoked)
 	assert.False(t, ms.SaveUserFuncInvoked)
 }
@@ -1277,7 +1277,7 @@ func TestTeamAdminAddRoleOtherTeam(t *testing.T) {
 
 	ds.UserByIDFunc = func(ctx context.Context, id uint) (*fleet.User, error) {
 		if id != 1 {
-			return nil, &notFoundError{}
+			return nil, newNotFoundError()
 		}
 		return adminTeam2, nil
 	}


### PR DESCRIPTION
#8129 

Apart from fixing the issue in #8129, this change also introduces UUIDs to Fleet errors. To be able to match a returned error from the API to a error in the Fleet logs. See https://fleetdm.slack.com/archives/C019WG4GH0A/p1677780622769939 for more context.

Samples with the changes in this PR:
```
curl -k -H "Authorization: Bearer $TEST_TOKEN" -H 'Content-Type:application/json' "https://localhost:8080/api/v1/fleet/sso" -d ''
{
  "message": "Bad request",
  "errors": [
    {
      "name": "base",
      "reason": "Expected JSON Body"
    }
  ],
  "uuid": "a01f6e10-354c-4ff0-b96e-1f64adb500b0"
}
```
```
curl -k -H "Authorization: Bearer $TEST_TOKEN" -H 'Content-Type:application/json' "https://localhost:8080/api/v1/fleet/sso" -d 'asd'
{
  "message": "Bad request",
  "errors": [
    {
      "name": "base",
      "reason": "json decoder error"
    }
  ],
  "uuid": "5f716a64-7550-464b-a1dd-e6a505a9f89d"
}
```
```
curl -k -X GET -H "Authorization: Bearer badtoken" "https://localhost:8080/api/latest/fleet/teams"
{
  "message": "Authentication required",
  "errors": [
    {
      "name": "base",
      "reason": "Authentication required"
    }
  ],
  "uuid": "efe45bc0-f956-4bf9-ba4f-aa9020a9aaaf"
}
```
```
curl -k -X PATCH -H "Authorization: Bearer $TEST_TOKEN" "https://localhost:8080/api/latest/fleet/users/14" -d '{"name": "Manuel2", "password": "what", "new_password": "p4ssw0rd.12345"}'
{
  "message": "Authorization header required",
  "errors": [
    {
      "name": "base",
      "reason": "Authorization header required"
    }
  ],
  "uuid": "57f78cd0-4559-464f-9df7-36c9ef7c89b3"
}
```
```
curl -k -X PATCH -H "Authorization: Bearer $TEST_TOKEN" "https://localhost:8080/api/latest/fleet/users/14" -d '{"name": "Manuel2", "password": "what", "new_password": "p4ssw0rd.12345"}'
{
  "message": "Permission Denied",
  "uuid": "7f0220ad-6de7-4faf-8b6c-8d7ff9d2ca06"
}
```

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- ~[ ] Documented any permissions changes~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [X] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
