### PR TITLE
Remove attach check on queries and return proper bad request error

### DIFF
--- a/changes/10378-remove-attach-check
+++ b/changes/10378-remove-attach-check
@@ -1,0 +1,1 @@
+* Remove the `ATTACH` check on SQL osquery queries (osquery bug fixed a while ago in 4.6.0)

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -35,7 +35,6 @@ var (
 	errPolicyEmptyName       = errors.New("policy name cannot be empty")
 	errPolicyEmptyQuery      = errors.New("policy query cannot be empty")
 	errPolicyIDAndQuerySet   = errors.New("both fields \"queryID\" and \"query\" cannot be set")
-	errPolicyInvalidQuery    = errors.New("invalid policy query")
 	errPolicyInvalidPlatform = errors.New("invalid policy platform")
 )
 

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -74,9 +74,6 @@ func verifyPolicyQuery(query string) error {
 	if emptyString(query) {
 		return errPolicyEmptyQuery
 	}
-	if validateSQLRegexp.MatchString(query) {
-		return errPolicyInvalidQuery
-	}
 	return nil
 }
 

--- a/server/fleet/queries.go
+++ b/server/fleet/queries.go
@@ -3,7 +3,6 @@ package fleet
 import (
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -80,7 +79,6 @@ func (tq *TargetedQuery) AuthzType() string {
 }
 
 var (
-	validateSQLRegexp  = regexp.MustCompile(`(?i)attach[^\w]+.*[^\w]+as[^\w]+`)
 	errQueryEmptyName  = errors.New("query name cannot be empty")
 	errQueryEmptyQuery = errors.New("query's SQL query cannot be empty")
 )

--- a/server/fleet/queries.go
+++ b/server/fleet/queries.go
@@ -83,7 +83,6 @@ var (
 	validateSQLRegexp  = regexp.MustCompile(`(?i)attach[^\w]+.*[^\w]+as[^\w]+`)
 	errQueryEmptyName  = errors.New("query name cannot be empty")
 	errQueryEmptyQuery = errors.New("query's SQL query cannot be empty")
-	errQueryInvalidSQL = errors.New("invalid query's SQL")
 )
 
 func verifyQueryName(name string) error {
@@ -96,16 +95,6 @@ func verifyQueryName(name string) error {
 func verifyQuerySQL(query string) error {
 	if emptyString(query) {
 		return errQueryEmptyQuery
-	}
-	if err := verifySQL(query); err != nil {
-		return err
-	}
-	return nil
-}
-
-func verifySQL(query string) error {
-	if validateSQLRegexp.MatchString(query) {
-		return errQueryInvalidSQL
 	}
 	return nil
 }

--- a/server/fleet/queries_test.go
+++ b/server/fleet/queries_test.go
@@ -101,38 +101,3 @@ func TestRoundtripQueriesYaml(t *testing.T) {
 		})
 	}
 }
-
-func TestValidateSQL(t *testing.T) {
-	testCases := []struct {
-		sql       string
-		shouldErr bool
-	}{
-		{"", false},
-		{"foo", false},
-		{"select 1", false},
-		{"select * from time", false},
-		{"select 1 from ATTACH", false},
-		{"select * from attach where fast = 3", false},
-
-		{"attach 'foo' as bar;", true},
-		{"attach   (foo )as bar", true},
-		{"attach('foo')AS bar", true},
-		{"ATTACH 'foo' AS bar", true},
-		{"ATTACH select name from where path = '/foobar' as bar", true},
-		{`attach
-   foo
-    as
-  bar`, true},
-	}
-
-	for _, tt := range testCases {
-		t.Run(tt.sql, func(t *testing.T) {
-			err := verifySQL(tt.sql)
-			if tt.shouldErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -2054,7 +2054,7 @@ func (s *integrationTestSuite) TestTeamPoliciesProprietaryInvalid() {
 			tname:      "Invalid query",
 			testUpdate: true,
 			name:       "Invalid query",
-			query:      "ATTACH 'foo' AS bar;",
+			query:      "",
 		},
 	} {
 		t.Run(tc.tname, func(t *testing.T) {
@@ -4394,7 +4394,7 @@ func (s *integrationTestSuite) TestQueriesBadRequests() {
 		{
 			tname: "Invalid query",
 			name:  "Invalid query",
-			query: "ATTACH 'foo' AS bar;",
+			query: "",
 		},
 	} {
 		t.Run(tc.tname, func(t *testing.T) {
@@ -6305,7 +6305,7 @@ func (s *integrationTestSuite) TestPingEndpoints() {
 func (s *integrationTestSuite) TestAppleMDMNotConfigured() {
 	var rawResp json.RawMessage
 	s.DoJSON("GET", "/api/latest/fleet/mdm/apple", nil, http.StatusNotFound, &rawResp)
-	s.DoJSON("GET", "/api/latest/fleet/mdm/apple_bm", nil, http.StatusPaymentRequired, &rawResp) //premium only
+	s.DoJSON("GET", "/api/latest/fleet/mdm/apple_bm", nil, http.StatusPaymentRequired, &rawResp) // premium only
 }
 
 func (s *integrationTestSuite) TestOrbitConfigNotifications() {
@@ -6394,7 +6394,7 @@ func (s *integrationTestSuite) TestEnrollOrbitExistingHostNoSerialMatch() {
 	// host identifier.
 	// See https://github.com/fleetdm/fleet/issues/9033#issuecomment-1411150758
 
-	//osqueryID := uuid.New().String()
+	// osqueryID := uuid.New().String()
 	osqueryID := hostUUID
 
 	s.DoJSON("POST", "/api/osquery/enroll", enrollAgentRequest{

--- a/server/service/queries_test.go
+++ b/server/service/queries_test.go
@@ -12,19 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewQueryAttach(t *testing.T) {
-	ds := new(mock.Store)
-	svc, ctx := newTestService(t, ds, nil, nil)
-
-	name := "bad"
-	query := "attach '/nope' as bad"
-	_, err := svc.NewQuery(
-		ctx,
-		fleet.QueryPayload{Name: &name, Query: &query},
-	)
-	require.Error(t, err)
-}
-
 func TestFilterQueriesForObserver(t *testing.T) {
 	require.True(t, onlyShowObserverCanRunQueries(&fleet.User{GlobalRole: ptr.String(fleet.RoleObserver)}))
 	require.False(t, onlyShowObserverCanRunQueries(&fleet.User{GlobalRole: ptr.String(fleet.RoleMaintainer)}))


### PR DESCRIPTION
Fixes both #10378 and https://github.com/fleetdm/confidential/issues/2133

On `main`:
```sh
curl -v -k -X POST -H "Authorization: Bearer $TEST_TOKEN" \
https://localhost:8080/api/latest/fleet/queries/run \
-d '{ "query": "select \"With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in system even if they lacked permissions to mount it themselves.\" as Rationale;" }'

< HTTP/2 500
< content-type: application/json; charset=utf-8
< content-length: 130
< date: Fri, 10 Mar 2023 17:50:40 GMT
<
{
  "message": "invalid query's SQL",
  "errors": [
    {
      "name": "base",
      "reason": "invalid query's SQL"
    }
  ]
}
```
With changes in this PR:
```sh
curl -v -k -X POST -H "Authorization: Bearer $TEST_TOKEN" \
https://localhost:8080/api/latest/fleet/queries/run \
-d '{ "query": "select \"With automounting enabled anyone with physical access could attach a USB drive or disc and have its contents available in system even if they lacked permissions to mount it themselves.\" as Rationale;", "selected": { "hosts": [57] } }'

< HTTP/2 200
< content-type: application/json; charset=utf-8
< content-length: 325
< date: Fri, 10 Mar 2023 17:49:40 GMT
<
{
  "campaign": {
    "created_at": "0001-01-01T00:00:00Z",
    "updated_at": "0001-01-01T00:00:00Z",
    "Metrics": {
      "TotalHosts": 1,
      "OnlineHosts": 1,
      "OfflineHosts": 0,
      "MissingInActionHosts": 0,
      "NewHosts": 0
    },
    "id": 87,
    "query_id": 85,
    "status": 0,
    "user_id": 1
  }
}
```

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- ~[ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~[ ] Documented any permissions changes~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
  - ~For Orbit and Fleet Desktop changes:~
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
