### PR TITLE
Fleet UI: Team and global observers can view team software

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -6,18 +6,21 @@ on:
       - main
       - patch-*
     paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - "server/authz/policy.rego"
+      - ".github/workflows/test-go.yaml"
   pull_request:
     paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/test-go.yaml'
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/test-go.yaml"
+      - "server/authz/policy.rego"
   workflow_dispatch: # Manual
   schedule:
-    - cron: '0 4 * * *'
+    - cron: "0 4 * * *"
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
@@ -37,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go-version: ['^1.19.4']
+        go-version: ["^1.19.4"]
         mysql: ["mysql:5.7.21", "mysql:8.0.28"]
     runs-on: ${{ matrix.os }}
 
@@ -46,85 +49,85 @@ jobs:
       GO_TEST_TIMEOUT: 10m
 
     steps:
-    - name: Install Go
-      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
-      with:
-        go-version: ${{ matrix.go-version }}
+      - name: Install Go
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+        with:
+          go-version: ${{ matrix.go-version }}
 
-    - name: Checkout Code
-      uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2
+      - name: Checkout Code
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2
 
-    # Pre-starting dependencies here means they are ready to go when we need them.
-    - name: Start Infra Dependencies
-      # Use & to background this
-      run: FLEET_MYSQL_IMAGE=${{ matrix.mysql }} docker-compose up -d mysql_test redis redis-cluster-1 redis-cluster-2 redis-cluster-3 redis-cluster-4 redis-cluster-5 redis-cluster-6 redis-cluster-setup minio saml_idp &
+      # Pre-starting dependencies here means they are ready to go when we need them.
+      - name: Start Infra Dependencies
+        # Use & to background this
+        run: FLEET_MYSQL_IMAGE=${{ matrix.mysql }} docker-compose up -d mysql_test redis redis-cluster-1 redis-cluster-2 redis-cluster-3 redis-cluster-4 redis-cluster-5 redis-cluster-6 redis-cluster-setup minio saml_idp &
 
-    # It seems faster not to cache Go dependencies
-    - name: Install Go Dependencies
-      run: make deps-go
+      # It seems faster not to cache Go dependencies
+      - name: Install Go Dependencies
+        run: make deps-go
 
-    - name: Generate static files
-      run: |
-        export PATH=$PATH:~/go/bin
-        make generate-go
+      - name: Generate static files
+        run: |
+          export PATH=$PATH:~/go/bin
+          make generate-go
 
-    - name: Set Go race setting on schedule
-      if: github.event.schedule == '0 4 * * *'
-      run: |
-        echo "RACE_ENABLED=true" >> $GITHUB_ENV
-        echo "GO_TEST_TIMEOUT=1h" >> $GITHUB_ENV
+      - name: Set Go race setting on schedule
+        if: github.event.schedule == '0 4 * * *'
+        run: |
+          echo "RACE_ENABLED=true" >> $GITHUB_ENV
+          echo "GO_TEST_TIMEOUT=1h" >> $GITHUB_ENV
 
-    - name: Wait for mysql
-      run: |
-        echo "waiting for mysql..."
-        until docker-compose exec -T mysql_test sh -c "mysql -uroot -p\"\${MYSQL_ROOT_PASSWORD}\" -e \"SELECT 1=1\" fleet" &> /dev/null; do
-            echo "."
-            sleep 1
-        done
-        echo "mysql is ready"
+      - name: Wait for mysql
+        run: |
+          echo "waiting for mysql..."
+          until docker-compose exec -T mysql_test sh -c "mysql -uroot -p\"\${MYSQL_ROOT_PASSWORD}\" -e \"SELECT 1=1\" fleet" &> /dev/null; do
+              echo "."
+              sleep 1
+          done
+          echo "mysql is ready"
 
-    - name: Run Go Tests
-      run: |
-        GO_TEST_EXTRA_FLAGS="-v -race=$RACE_ENABLED -timeout=$GO_TEST_TIMEOUT" \
-          TEST_LOCK_FILE_PATH=$(pwd)/lock \
-          NETWORK_TEST=1 \
-          REDIS_TEST=1 \
-          MYSQL_TEST=1 \
-          MINIO_STORAGE_TEST=1 \
-          SAML_IDP_TEST=1 \
-          NETWORK_TEST_GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
-          make test-go 2>&1 | tee /tmp/gotest.log
+      - name: Run Go Tests
+        run: |
+          GO_TEST_EXTRA_FLAGS="-v -race=$RACE_ENABLED -timeout=$GO_TEST_TIMEOUT" \
+            TEST_LOCK_FILE_PATH=$(pwd)/lock \
+            NETWORK_TEST=1 \
+            REDIS_TEST=1 \
+            MYSQL_TEST=1 \
+            MINIO_STORAGE_TEST=1 \
+            SAML_IDP_TEST=1 \
+            NETWORK_TEST_GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            make test-go 2>&1 | tee /tmp/gotest.log
 
-    - name: Upload to Codecov
-      uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
-      with:
-        files: coverage.txt
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
+        with:
+          files: coverage.txt
 
-    - name: Slack Notification
-      if: github.event.schedule == '0 4 * * *' && failure()
-      uses: slackapi/slack-github-action@16b6c78ee73689a627b65332b34e5d409c7299da # v1.18.0
-      with:
-        payload: |
-          {
-            "text": "${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}",
-            "blocks": [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "Go tests result: ${{ job.status }}\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}"
+      - name: Slack Notification
+        if: github.event.schedule == '0 4 * * *' && failure()
+        uses: slackapi/slack-github-action@16b6c78ee73689a627b65332b34e5d409c7299da # v1.18.0
+        with:
+          payload: |
+            {
+              "text": "${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Go tests result: ${{ job.status }}\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}"
+                  }
                 }
-              }
-            ]
-          }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_G_HELP_ENGINEERING_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_G_HELP_ENGINEERING_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
-    - name: Upload test log
-      if: always()
-      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v2
-      with:
-        name: test-log
-        path: /tmp/gotest.log
-        if-no-files-found: error
+      - name: Upload test log
+        if: always()
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v2
+        with:
+          name: test-log
+          path: /tmp/gotest.log
+          if-no-files-found: error

--- a/changes/9984-observer-software-bug.x
+++ b/changes/9984-observer-software-bug.x
@@ -1,0 +1,1 @@
+- Observers can now view the manage software page

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -32,7 +32,7 @@ import {
   GITHUB_NEW_ISSUE_LINK,
   VULNERABLE_DROPDOWN_OPTIONS,
 } from "utilities/constants";
-import { buildQueryStringFromParams, QueryParams } from "utilities/url";
+import { buildQueryStringFromParams } from "utilities/url";
 
 import Button from "components/buttons/Button";
 // @ts-ignore

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -78,7 +78,7 @@ allow {
   team_role(subject, object.id) == [admin,maintainer,observer][_]
   action == read
 }
-# or global admins or global maintainers
+# or global users can read
 allow {
   object.type == "team"
   object.id != 0

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -75,14 +75,14 @@ allow {
 allow {
   object.type == "team"
   object.id != 0
-  team_role(subject, object.id) == [admin,maintainer][_]
+  team_role(subject, object.id) == [admin,maintainer,observer][_]
   action == read
 }
 # or global admins or global maintainers
 allow {
   object.type == "team"
   object.id != 0
-  subject.global_role == [admin, maintainer][_]
+  subject.global_role == [admin, maintainer,observer][_]
   action == read
 }
 


### PR DESCRIPTION
## Issue 
Cerra #9984 

## Description
- Global and team observers no longer receive a 403 error when trying to view a team's software in the software tab
- The fix is that global and team observers should have _read_ access to the teams API


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Documented any permissions changes
- [x] Manual QA for all new/changed functionality
