### PR TITLE
Run cleanup of `cron_stats` outside of the `schedule` package to prevent outages from breaking cron jobs

### DIFF
--- a/changes/9486-pending-jobs-not-clearing-after-outage
+++ b/changes/9486-pending-jobs-not-clearing-after-outage
@@ -1,0 +1,1 @@
+* Run periodic cleanup of pending `cron_stats` outside the `schedule` package to prevent Fleet outages from breaking cron jobs.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -740,11 +740,6 @@ func newCleanupsAndAggregationSchedule(
 				return ds.CleanupExpiredPasswordResetRequests(ctx)
 			},
 		),
-		schedule.WithJob(
-			"cleanup_cron_stats", func(ctx context.Context) error {
-				return ds.CleanupCronStats(ctx)
-			},
-		),
 		// Run aggregation jobs after cleanups.
 		schedule.WithJob(
 			"query_aggregated_stats",

--- a/server/service/schedule/schedule.go
+++ b/server/service/schedule/schedule.go
@@ -182,7 +182,7 @@ func (s *Schedule) Start() {
 		}()
 
 		for {
-			level.Debug(s.logger).Log("waiting", fmt.Sprintf("%v remaining until next tick", s.getRemainingInterval(s.intervalStartedAt)))
+			level.Debug(s.logger).Log("msg", fmt.Sprintf("%v remaining until next tick", s.getRemainingInterval(s.intervalStartedAt)))
 
 			select {
 			case <-s.ctx.Done():
@@ -191,7 +191,7 @@ func (s *Schedule) Start() {
 				return
 
 			case <-s.trigger:
-				level.Debug(s.logger).Log("waiting", "done, trigger received")
+				level.Debug(s.logger).Log("msg", "done, trigger received")
 
 				ok, cancelHold := s.holdLock()
 				if !ok {
@@ -224,13 +224,13 @@ func (s *Schedule) Start() {
 					newStart := intervalStartedAt.Add(time.Since(intervalStartedAt).Truncate(schedInterval)) // advances start time by the number of full interval elasped
 					s.setIntervalStartedAt(newStart)
 					schedTicker.Reset(s.getRemainingInterval(newStart))
-					level.Debug(s.logger).Log("waiting", fmt.Sprintf("triggered run spanned schedule interval, new wait %v", s.getRemainingInterval(newStart)))
+					level.Debug(s.logger).Log("msg", fmt.Sprintf("triggered run spanned schedule interval, new wait %v", s.getRemainingInterval(newStart)))
 				}
 
 				cancelHold()
 
 			case <-schedTicker.C:
-				level.Debug(s.logger).Log("waiting", "done, tick received")
+				level.Debug(s.logger).Log("msg", "done, tick received")
 
 				schedInterval := s.getSchedInterval()
 
@@ -246,6 +246,7 @@ func (s *Schedule) Start() {
 
 				if prevScheduledRun.Status == fleet.CronStatsStatusPending || prevTriggeredRun.Status == fleet.CronStatsStatusPending {
 					// skip ahead to the next interval
+					level.Info(s.logger).Log("msg", fmt.Sprintf("pending job might still be running, wait %v", schedInterval))
 					schedTicker.Reset(schedInterval)
 					continue
 				}
@@ -260,7 +261,9 @@ func (s *Schedule) Start() {
 
 				if time.Since(intervalStartedAt) < schedInterval {
 					// wait for the remaining interval plus a small buffer
-					schedTicker.Reset(s.getRemainingInterval(intervalStartedAt) + 100*time.Millisecond)
+					newWait := s.getRemainingInterval(intervalStartedAt) + 100*time.Millisecond
+					level.Info(s.logger).Log("msg", fmt.Sprintf("wait remaining interval %v", newWait))
+					schedTicker.Reset(newWait)
 					continue
 				}
 
@@ -269,7 +272,7 @@ func (s *Schedule) Start() {
 					newStart := intervalStartedAt.Add(time.Since(intervalStartedAt).Truncate(schedInterval)) // advances start time by the number of full interval elasped
 					s.setIntervalStartedAt(newStart)
 					schedTicker.Reset(s.getRemainingInterval(newStart))
-					level.Debug(s.logger).Log("waiting", fmt.Sprintf("prior run spanned schedule interval, new wait %v", s.getRemainingInterval(newStart)))
+					level.Debug(s.logger).Log("msg", fmt.Sprintf("prior run spanned schedule interval, new wait %v", s.getRemainingInterval(newStart)))
 					continue
 				}
 


### PR DESCRIPTION
#9486

Now cron jobs should recover from a Fleet outage after ~ two hours.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- ~[ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~[ ] Documented any permissions changes~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- ~[ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality
  - ~For Orbit and Fleet Desktop changes:~
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
