### PR TITLE
allow to start Fleet MDM without configuring Apple BM

### DIFF
--- a/changes/10299-mdm-no-abm
+++ b/changes/10299-mdm-no-abm
@@ -1,0 +1,1 @@
+* Fixed a bug that prevented starting the Fleet server with MDM features if Apple Business Manager (ABM) was not configured.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -528,13 +528,6 @@ the way that the Fleet server works.
 					initFatal(errors.New("Apple APNs and SCEP configuration must be provided to enable MDM"), "validate Apple MDM")
 				}
 
-				// TODO: for now (dogfood), Apple BM must be set when MDM is enabled,
-				// but when the MDM will be production-ready, Apple BM will be
-				// optional.
-				if !config.MDM.IsAppleBMSet() {
-					initFatal(errors.New("Apple BM configuration must be provided to enable MDM"), "validate Apple MDM")
-				}
-
 				scepStorage, err = mds.NewSCEPDepot(appleSCEPCertPEM, appleSCEPKeyPEM)
 				if err != nil {
 					initFatal(err, "initialize mdm apple scep storage")
@@ -652,10 +645,13 @@ the way that the Fleet server works.
 			}
 
 			if config.MDMApple.Enable {
-				if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
-					return newAppleMDMDEPProfileAssigner(ctx, instanceID, config.MDMApple.DEP.SyncPeriodicity, ds, depStorage, logger, config.Logging.Debug)
-				}); err != nil {
-					initFatal(err, "failed to register apple_mdm_dep_profile_assigner schedule")
+
+				if license.IsPremium() && config.MDM.IsAppleBMSet() {
+					if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
+						return newAppleMDMDEPProfileAssigner(ctx, instanceID, config.MDMApple.DEP.SyncPeriodicity, ds, depStorage, logger, config.Logging.Debug)
+					}); err != nil {
+						initFatal(err, "failed to register apple_mdm_dep_profile_assigner schedule")
+					}
 				}
 				if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
 					return newMDMAppleProfileManager(


### PR DESCRIPTION
Related to https://github.com/fleetdm/fleet/issues/10299, this allows to start the Fleet server with MDM enabled without having to provide ABM configs.

I have tested this with:

1. Premium account, no ABM config: the server starts normally, but without ABM features
2. Premium account, invalid ABM config: error starting the server
3. Premium account, valid ABM config: ABM features enabled
4. Free account, no ABM config: the server starts normally
5. Free account, any ABM config: error due to invalid license

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
