### PR TITLE
Add EndeavourOS, Manjaro, openSUSE Leap and Tumbleweed to HostLinuxOSs

### DIFF
--- a/changes/10456-add-more-distros-to-hostlinuxoss
+++ b/changes/10456-add-more-distros-to-hostlinuxoss
@@ -1,0 +1,1 @@
+* Added EndeavourOS, Manjaro, openSUSE Leap and Tumbleweed to HostLinuxOSs.

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -513,7 +513,7 @@ func (h *Host) FleetPlatform() string {
 
 // HostLinuxOSs are the possible linux values for Host.Platform.
 var HostLinuxOSs = []string{
-	"linux", "ubuntu", "debian", "rhel", "centos", "sles", "kali", "gentoo", "amzn", "pop", "arch", "linuxmint", "void", "nixos",
+	"linux", "ubuntu", "debian", "rhel", "centos", "sles", "kali", "gentoo", "amzn", "pop", "arch", "linuxmint", "void", "nixos", "endeavouros", "manjaro", "opensuse-leap", "opensuse-tumbleweed",
 }
 
 func IsLinux(hostPlatform string) bool {


### PR DESCRIPTION
Fixes broken data collection (e.g. disk space, IP addresses, installed Python and RPM packages) and "unrecognized platform" error for those distros.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
