### PR TITLE
Add meta tag for proper page title name.

### DIFF
--- a/docs/Using-Fleet/CIS-Benchmarks.md
+++ b/docs/Using-Fleet/CIS-Benchmarks.md
@@ -118,3 +118,4 @@ The following CIS benchmark checks cannot be automated and must be addressed man
 Please refer to the "CIS Apple macOS 13.0 Ventura Benchmark v1.0.0 - 11-14-2022" PDF for descriptions and instructions on how to remediate.
 
 <meta name="pageOrderInSection" value="1700">
+<meta name="title" value="CIS benchmarks">

--- a/docs/Using-Fleet/CIS-Benchmarks.md
+++ b/docs/Using-Fleet/CIS-Benchmarks.md
@@ -118,4 +118,4 @@ The following CIS benchmark checks cannot be automated and must be addressed man
 Please refer to the "CIS Apple macOS 13.0 Ventura Benchmark v1.0.0 - 11-14-2022" PDF for descriptions and instructions on how to remediate.
 
 <meta name="pageOrderInSection" value="1700">
-<meta name="title" value="CIS benchmarks">
+<meta name="title" value="CIS Benchmarks">


### PR DESCRIPTION
meta tag update to properly set the page title to `CIS Benchmarks`.