### PR TITLE
Terraform MDM make DEP/ABM optional

### DIFF
--- a/terraform/addons/mdm/.header.md
+++ b/terraform/addons/mdm/.header.md
@@ -5,6 +5,8 @@ The following secrets are created:
 - scep
 - apn
 
+Note: dep is optional.  If Apple Business Manager (ABM) is not used, set the dep variable to `null` and it will be omitted.
+
 Since this module cannot determine the value for the secrets at apply time, this module must be applied in 2 phases:
 
 1. In the first phase, just add the module without passing additional config to the main Fleet module

--- a/terraform/addons/mdm/README.md
+++ b/terraform/addons/mdm/README.md
@@ -5,6 +5,8 @@ The following secrets are created:
 - scep
 - apn
 
+Note: dep is optional.  If Apple Business Manager (ABM) is not used, set the dep variable to `null` and it will be omitted.
+
 Since this module cannot determine the value for the secrets at apply time, this module must be applied in 2 phases:
 
 1. In the first phase, just add the module without passing additional config to the main Fleet module
@@ -56,9 +58,11 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_secretsmanager_secret.apn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.dep](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.scep](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_iam_policy_document.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
@@ -67,11 +71,16 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_apn_secret_name"></a> [apn\_secret\_name](#input\_apn\_secret\_name) | n/a | `string` | `"fleet-apn"` | no |
 | <a name="input_dep_secret_name"></a> [dep\_secret\_name](#input\_dep\_secret\_name) | n/a | `string` | `"fleet-dep"` | no |
+| <a name="input_public_domain_name"></a> [public\_domain\_name](#input\_public\_domain\_name) | n/a | `string` | n/a | yes |
 | <a name="input_scep_secret_name"></a> [scep\_secret\_name](#input\_scep\_secret\_name) | n/a | `string` | `"fleet-scep"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| <a name="output_apn"></a> [apn](#output\_apn) | n/a |
+| <a name="output_dep"></a> [dep](#output\_dep) | n/a |
 | <a name="output_extra_environment_variables"></a> [extra\_environment\_variables](#output\_extra\_environment\_variables) | n/a |
+| <a name="output_extra_execution_iam_policies"></a> [extra\_execution\_iam\_policies](#output\_extra\_execution\_iam\_policies) | n/a |
 | <a name="output_extra_secrets"></a> [extra\_secrets](#output\_extra\_secrets) | n/a |
+| <a name="output_scep"></a> [scep](#output\_scep) | n/a |

--- a/terraform/addons/mdm/main.tf
+++ b/terraform/addons/mdm/main.tf
@@ -9,17 +9,17 @@ resource "aws_secretsmanager_secret" "scep" {
 }
 
 resource "aws_secretsmanager_secret" "dep" {
+  count = var.dep_secret_name == null ? 0 : 1
   name = var.dep_secret_name
 }
 
 data "aws_iam_policy_document" "main" {
   statement {
     actions = ["secretsmanager:GetSecretValue"]
-    resources = [
+    resources = concat([
       aws_secretsmanager_secret.apn.arn,
       aws_secretsmanager_secret.scep.arn,
-      aws_secretsmanager_secret.dep.arn,
-    ]
+    ], var.dep_secret_name == null ? [] : [aws_secretsmanager_secret.dep[0].arn])
   }
 }
 

--- a/terraform/addons/mdm/outputs.tf
+++ b/terraform/addons/mdm/outputs.tf
@@ -7,7 +7,7 @@ output "extra_environment_variables" {
 }
 
 output "extra_secrets" {
-  value = {
+  value = merge({
     FLEET_MDM_APPLE_SCEP_CERT_BYTES       = "${aws_secretsmanager_secret.scep.arn}:crt::"
     FLEET_MDM_APPLE_SCEP_CA_CERT_PEM      = "${aws_secretsmanager_secret.scep.arn}:crt::"
     FLEET_MDM_APPLE_SCEP_KEY_BYTES        = "${aws_secretsmanager_secret.scep.arn}:key::"
@@ -17,11 +17,12 @@ output "extra_secrets" {
     FLEET_MDM_APPLE_MDM_PUSH_CERT_PEM     = "${aws_secretsmanager_secret.apn.arn}:FLEET_MDM_APPLE_MDM_PUSH_CERT_PEM::"
     FLEET_MDM_APPLE_APNS_KEY_BYTES        = "${aws_secretsmanager_secret.apn.arn}:FLEET_MDM_APPLE_MDM_PUSH_KEY_PEM::"
     FLEET_MDM_APPLE_MDM_PUSH_KEY_PEM      = "${aws_secretsmanager_secret.apn.arn}:FLEET_MDM_APPLE_MDM_PUSH_KEY_PEM::"
-    FLEET_MDM_APPLE_DEP_TOKEN             = "${aws_secretsmanager_secret.dep.arn}:token::"
-    FLEET_MDM_APPLE_BM_SERVER_TOKEN_BYTES = "${aws_secretsmanager_secret.dep.arn}:token-encrypted::"
-    FLEET_MDM_APPLE_BM_CERT_BYTES         = "${aws_secretsmanager_secret.dep.arn}:cert::"
-    FLEET_MDM_APPLE_BM_KEY_BYTES          = "${aws_secretsmanager_secret.dep.arn}:key::"
-  }
+  }, var.dep_secret_name == null ? {} : {
+    FLEET_MDM_APPLE_DEP_TOKEN             = "${aws_secretsmanager_secret.dep[0].arn}:token::"
+    FLEET_MDM_APPLE_BM_SERVER_TOKEN_BYTES = "${aws_secretsmanager_secret.dep[0].arn}:token-encrypted::"
+    FLEET_MDM_APPLE_BM_CERT_BYTES         = "${aws_secretsmanager_secret.dep[0].arn}:cert::"
+    FLEET_MDM_APPLE_BM_KEY_BYTES          = "${aws_secretsmanager_secret.dep[0].arn}:key::"
+  })
 }
 
 output "extra_execution_iam_policies" {
@@ -35,7 +36,7 @@ output "scep" {
 }
 
 output "dep" {
-  value = aws_secretsmanager_secret.dep
+  value = var.dep_secret_name == null ? null : aws_secretsmanager_secret.dep[0]
 }
 
 output "apn" {

--- a/terraform/addons/mdm/variables.tf
+++ b/terraform/addons/mdm/variables.tf
@@ -12,7 +12,7 @@ variable "scep_secret_name" {
 
 variable "dep_secret_name" {
   default  = "fleet-dep"
-  nullable = false
+  nullable = true
   type     = string
 }
 


### PR DESCRIPTION
This looks right at least from the standpoint of a `terraform plan`.  This is to support MDM without ABM enabled.