### PR TITLE
Add `enable_jit_role_sync` config

### DIFF
--- a/cmd/fleetctl/get_test.go
+++ b/cmd/fleetctl/get_test.go
@@ -1005,7 +1005,8 @@ func TestEnrichedAppConfig(t *testing.T) {
           "idp_name": "",
           "enable_sso": false,
           "enable_sso_idp_login": false,
-          "enable_jit_provisioning": false
+          "enable_jit_provisioning": false,
+          "enable_jit_role_sync": false
         },
         "fleet_desktop": {
           "transparency_url": "https://fleetdm.com/transparency"

--- a/cmd/fleetctl/testdata/expectedGetConfigAppConfigJson.json
+++ b/cmd/fleetctl/testdata/expectedGetConfigAppConfigJson.json
@@ -43,6 +43,7 @@
 			"metadata_url": "",
 			"idp_name": "",
 			"enable_jit_provisioning": false,
+			"enable_jit_role_sync": false,
 			"enable_sso": false,
 			"enable_sso_idp_login": false
 		},

--- a/cmd/fleetctl/testdata/expectedGetConfigAppConfigYaml.yml
+++ b/cmd/fleetctl/testdata/expectedGetConfigAppConfigYaml.yml
@@ -47,6 +47,7 @@ spec:
     verify_ssl_certs: false
   sso_settings:
     enable_jit_provisioning: false
+    enable_jit_role_sync: false
     enable_sso: false
     enable_sso_idp_login: false
     entity_id: ""

--- a/cmd/fleetctl/testdata/expectedGetConfigIncludeServerConfigJson.json
+++ b/cmd/fleetctl/testdata/expectedGetConfigIncludeServerConfigJson.json
@@ -50,6 +50,7 @@
 		},
 		"sso_settings": {
 			"enable_jit_provisioning": false,
+			"enable_jit_role_sync": false,
 			"entity_id": "",
 			"issuer_uri": "",
 			"idp_image_url": "",

--- a/cmd/fleetctl/testdata/expectedGetConfigIncludeServerConfigYaml.yml
+++ b/cmd/fleetctl/testdata/expectedGetConfigIncludeServerConfigYaml.yml
@@ -86,6 +86,7 @@ spec:
     verify_ssl_certs: false
   sso_settings:
     enable_jit_provisioning: false
+    enable_jit_role_sync: false
     enable_sso: false
     enable_sso_idp_login: false
     entity_id: ""

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -3038,7 +3038,8 @@ SAML supports multi-valued attributes, Fleet will always use the last value.
 
 NOTE: Setting both `FLEET_JIT_USER_ROLE_GLOBAL` and `FLEET_JIT_USER_ROLE_TEAM_<TEAM_ID>` will cause an error during login as Fleet users cannot be Global users and belong to teams.
 
-During SSO login, if the account already exists, the roles of the Fleet account will be updated to match those set in the SAML custom attributes.
+During every SSO login, if `sso_settings.enable_jit_role_sync` is set to `true` (default is `false`) and if the account already exists, the roles of the Fleet account will be updated to match those set in the SAML custom attributes.
+> IMPORTANT: Beware that if `sso_settings.enable_jit_role_sync` is set to `true` but no SAML role attributes are configured for accounts then all Fleet users are changed to Global observers on every SSO login (overriding any previous role change).
 
 If none of the attributes above are set, then Fleet will default to use the `Global Observer` role.
 

--- a/docs/Using-Fleet/configuration-files/README.md
+++ b/docs/Using-Fleet/configuration-files/README.md
@@ -701,6 +701,21 @@ For additional information on SSO configuration, including just-in-time (JIT) us
     enable_jit_provisioning: true
   ```
 
+##### sso_settings.enable_jit_role_sync
+
+**Available in Fleet Premium**.
+
+If set to `true` Fleet account roles will be updated to match those set in the SAML custom attributes at every login. See [customization of user roles](../../Deploying/Configuration.md#customization-of-user-roles).
+This flag only has effect if `sso_settings.enable_jit_provisioning` is set to `true`.
+
+- Optional setting (boolean)
+- Default value: `false`
+- Config file format:
+  ```yaml
+  sso_settings:
+    enable_jit_role_sync: true
+  ```
+
 ##### sso_settings.enable_sso
 
 Configures if single sign-on is enabled.

--- a/ee/server/service/users.go
+++ b/ee/server/service/users.go
@@ -32,8 +32,9 @@ func (svc *Service) GetSSOUser(ctx context.Context, auth fleet.Auth) (*fleet.Use
 		// If the user exists, we want to update the user roles from the attributes received
 		// in the SAMLResponse.
 
-		// If JIT provisioning is disabled, then we don't attempt to change the role of the user.
-		if !config.SSOSettings.EnableJITProvisioning {
+		// If JIT provisioning or role sync are disabled, then we don't attempt to change the
+		// role of the existing user.
+		if !config.SSOSettings.EnableJITProvisioning || !config.SSOSettings.EnableJITRoleSync {
 			return user, nil
 		}
 

--- a/orbit/pkg/update/nudge.go
+++ b/orbit/pkg/update/nudge.go
@@ -71,7 +71,7 @@ func (n *NudgeConfigFetcher) GetConfig() (*fleet.OrbitConfig, error) {
 	}
 
 	if cfg.NudgeConfig == nil {
-		log.Info().Msg("empty nudge config, removing nudge as target")
+		log.Debug().Msg("empty nudge config, removing nudge as target")
 		// TODO(roberto): by early returning and removing the target from the
 		// runner/updater we ensure Nudge won't be opened/updated again
 		// but we don't actually remove the file from disk. We

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -57,6 +57,9 @@ type SSOSettings struct {
 	// EnableJITProvisioning allows user accounts to be created the first time
 	// users try to log in
 	EnableJITProvisioning bool `json:"enable_jit_provisioning"`
+	// EnableJITRoleSync sets whether the roles of existing accounts will be updated
+	// every time SSO users log in (does not have effect if EnableJITProvisioning is false).
+	EnableJITRoleSync bool `json:"enable_jit_role_sync"`
 }
 
 // SMTPSettings is part of the AppConfig which defines the wire representation

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -549,8 +549,13 @@ func validateSSOSettings(p fleet.AppConfig, existing *fleet.AppConfig, invalid *
 				invalid.Append("idp_name", "required")
 			}
 		}
-		if !license.IsPremium() && p.SSOSettings.EnableJITProvisioning {
-			invalid.Append("enable_jit_provisioning", ErrMissingLicense.Error())
+		if !license.IsPremium() {
+			if p.SSOSettings.EnableJITProvisioning {
+				invalid.Append("enable_jit_provisioning", ErrMissingLicense.Error())
+			}
+			if p.SSOSettings.EnableJITRoleSync {
+				invalid.Append("enable_jit_role_sync", ErrMissingLicense.Error())
+			}
 		}
 	}
 }

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -326,6 +326,25 @@ func TestJITProvisioning(t *testing.T) {
 		assert.Contains(t, invalid.Error(), "missing or invalid license")
 	})
 
+	config = fleet.AppConfig{
+		SSOSettings: fleet.SSOSettings{
+			EnableSSO:         true,
+			EntityID:          "fleet",
+			IssuerURI:         "http://issuer.idp.com",
+			IDPName:           "onelogin",
+			MetadataURL:       "http://isser.metadata.com",
+			EnableJITRoleSync: true,
+		},
+	}
+
+	t.Run("doesn't allow to enable JIT role sync without a premium license", func(t *testing.T) {
+		invalid := &fleet.InvalidArgumentError{}
+		validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{})
+		require.True(t, invalid.HasErrors())
+		assert.Contains(t, invalid.Error(), "enable_jit_role_sync")
+		assert.Contains(t, invalid.Error(), "missing or invalid license")
+	})
+
 	t.Run("allows JIT provisioning to be enabled with a premium license", func(t *testing.T) {
 		invalid := &fleet.InvalidArgumentError{}
 		validateSSOSettings(config, &fleet.AppConfig{}, invalid, &fleet.LicenseInfo{Tier: fleet.TierPremium})
@@ -338,11 +357,7 @@ func TestJITProvisioning(t *testing.T) {
 
 		oldConfig.SSOSettings.EnableJITProvisioning = true
 		config.SSOSettings.EnableJITProvisioning = false
-		validateSSOSettings(config, oldConfig, invalid, &fleet.LicenseInfo{})
-		require.False(t, invalid.HasErrors())
-
-		oldConfig.SSOSettings.EnableJITProvisioning = false
-		config.SSOSettings.EnableJITProvisioning = false
+		config.SSOSettings.EnableJITRoleSync = false
 		validateSSOSettings(config, oldConfig, invalid, &fleet.LicenseInfo{})
 		require.False(t, invalid.HasErrors())
 	})

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -1701,6 +1701,7 @@ func (s *integrationEnterpriseTestSuite) TestSSOJITProvisioning() {
 	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
 	require.NotNil(t, acResp)
 	require.False(t, acResp.SSOSettings.EnableJITProvisioning)
+	require.False(t, acResp.SSOSettings.EnableJITRoleSync)
 
 	acResp = appConfigResponse{}
 	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
@@ -1715,6 +1716,7 @@ func (s *integrationEnterpriseTestSuite) TestSSOJITProvisioning() {
 	}`), http.StatusOK, &acResp)
 	require.NotNil(t, acResp)
 	require.False(t, acResp.SSOSettings.EnableJITProvisioning)
+	require.False(t, acResp.SSOSettings.EnableJITRoleSync)
 
 	// users can't be created if SSO is disabled
 	auth, body := s.LoginSSOUser("sso_user", "user123#")
@@ -1733,11 +1735,13 @@ func (s *integrationEnterpriseTestSuite) TestSSOJITProvisioning() {
 			"issuer_uri": "http://localhost:8080/simplesaml/saml2/idp/SSOService.php",
 			"idp_name": "SimpleSAML",
 			"metadata_url": "http://localhost:9080/simplesaml/saml2/idp/metadata.php",
-			"enable_jit_provisioning": true
+			"enable_jit_provisioning": true,
+			"enable_jit_role_sync": false
 		}
 	}`), http.StatusOK, &acResp)
 	require.NotNil(t, acResp)
 	require.True(t, acResp.SSOSettings.EnableJITProvisioning)
+	require.False(t, acResp.SSOSettings.EnableJITRoleSync)
 
 	// a new user is created and redirected accordingly
 	auth, body = s.LoginSSOUser("sso_user", "user123#")
@@ -1760,6 +1764,48 @@ func (s *integrationEnterpriseTestSuite) TestSSOJITProvisioning() {
 		}
 		return false
 	})
+
+	// Test that roles are not updated for an existing user because enable_jit_role_sync is false.
+
+	// Change role to global admin first.
+	user.GlobalRole = ptr.String("admin")
+	err = s.ds.SaveUser(context.Background(), user)
+	require.NoError(t, err)
+	// Login should NOT change the role to the default (global observer).
+	auth, body = s.LoginSSOUser("sso_user", "user123#")
+	assert.Equal(t, "sso_user@example.com", auth.UserID())
+	assert.Equal(t, "SSO User 1", auth.UserDisplayName())
+	require.Contains(t, body, "Redirecting to Fleet at  ...")
+	user, err = s.ds.UserByEmail(context.Background(), "sso_user@example.com")
+	require.NoError(t, err)
+	require.NotNil(t, user.GlobalRole)
+	require.Equal(t, *user.GlobalRole, "admin")
+
+	// Test that roles are updated for an existing user because enable_jit_role_sync is true.
+	acResp = appConfigResponse{}
+	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+		"sso_settings": {
+			"enable_sso": true,
+			"entity_id": "https://localhost:8080",
+			"issuer_uri": "http://localhost:8080/simplesaml/saml2/idp/SSOService.php",
+			"idp_name": "SimpleSAML",
+			"metadata_url": "http://localhost:9080/simplesaml/saml2/idp/metadata.php",
+			"enable_jit_provisioning": true,
+			"enable_jit_role_sync": true
+		}
+	}`), http.StatusOK, &acResp)
+	require.NotNil(t, acResp)
+	require.True(t, acResp.SSOSettings.EnableJITProvisioning)
+	require.True(t, acResp.SSOSettings.EnableJITRoleSync)
+	// Login should change the role to the default role (global observer).
+	auth, body = s.LoginSSOUser("sso_user", "user123#")
+	assert.Equal(t, "sso_user@example.com", auth.UserID())
+	assert.Equal(t, "SSO User 1", auth.UserDisplayName())
+	require.Contains(t, body, "Redirecting to Fleet at  ...")
+	user, err = s.ds.UserByEmail(context.Background(), "sso_user@example.com")
+	require.NoError(t, err)
+	require.NotNil(t, user.GlobalRole)
+	require.Equal(t, *user.GlobalRole, "observer")
 
 	// A user with pre-configured roles can be created
 	// see `tools/saml/users.php` for details.

--- a/server/service/integration_sso_test.go
+++ b/server/service/integration_sso_test.go
@@ -155,7 +155,7 @@ func (s *integrationSSOTestSuite) TestSSOLogin() {
 	// A new activity item for the failed SSO login is created.
 	checkNewFailedLoginActivity()
 
-	// an user created by an admin with SSOEnabled is able to log-in
+	// A user created by an admin with SSOEnabled is able to log-in
 	params = fleet.UserPayload{
 		Name:       ptr.String("SSO User 2"),
 		Email:      ptr.String("sso_user2@example.com"),

--- a/server/service/sessions_test.go
+++ b/server/service/sessions_test.go
@@ -229,6 +229,7 @@ func TestGetSSOUser(t *testing.T) {
 				EnableSSO:             true,
 				EnableSSOIdPLogin:     true,
 				EnableJITProvisioning: true,
+				EnableJITRoleSync:     true,
 			},
 		}, nil
 	}
@@ -315,7 +316,48 @@ func TestGetSSOUser(t *testing.T) {
 
 	require.True(t, ds.SaveUserFuncInvoked)
 
-	// (3) Test with invalid team ID in the attributes
+	// (3) Test existing user's role is not changed after a new login if EnableJITRoleSync is false.
+
+	ds.SaveUserFuncInvoked = false
+
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{
+			SSOSettings: fleet.SSOSettings{
+				EnableSSO:             true,
+				EnableSSOIdPLogin:     true,
+				EnableJITProvisioning: true,
+				EnableJITRoleSync:     false,
+			},
+		}, nil
+	}
+
+	// No configuration set for this user.
+	auth.assertionAttributes = []fleet.SAMLAttribute{
+		{
+			Name: "FLEET_JIT_USER_ROLE_TEAM_2",
+			Values: []fleet.SAMLAttributeValue{
+				{Value: "admin"},
+			},
+		},
+	}
+
+	_, err = svc.GetSSOUser(ctx, auth)
+	require.NoError(t, err)
+
+	require.False(t, ds.SaveUserFuncInvoked)
+
+	// (4) Test with invalid team ID in the attributes
+
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{
+			SSOSettings: fleet.SSOSettings{
+				EnableSSO:             true,
+				EnableSSOIdPLogin:     true,
+				EnableJITProvisioning: true,
+				EnableJITRoleSync:     true,
+			},
+		}, nil
+	}
 
 	ds.TeamFunc = func(ctx context.Context, tid uint) (*fleet.Team, error) {
 		return nil, newNotFoundError()


### PR DESCRIPTION
#8411

We decided to only update roles for existing accounts if enabled by a new setting (disabled by default) `sso_settings.enable_jit_role_sync`.

- ~[ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.~
- ~[ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~[ ] Documented any permissions changes~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
  - ~For Orbit and Fleet Desktop changes:~
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
