### PR TITLE
MDM profiles: Update display names

### DIFF
--- a/mdm_profiles/automatic_updates.mobileconfig
+++ b/mdm_profiles/automatic_updates.mobileconfig
@@ -38,7 +38,7 @@
 	<key>PayloadDescription</key>
 	<string>Enables automatic updates</string>
 	<key>PayloadDisplayName</key>
-	<string>Automatic updates</string>
+	<string>Turn on automatic updates</string>
 	<key>PayloadIdentifier</key>
 	<string>com.github.erikberglund.ProfileCreator.BEBA0740-4DDB-4AC4-85DC-BA48B96C0DC8</string>
 	<key>PayloadOrganization</key>

--- a/mdm_profiles/chrome_enrollment.mobileconfig
+++ b/mdm_profiles/chrome_enrollment.mobileconfig
@@ -24,7 +24,7 @@
 		</dict>
 	</array>
 	<key>PayloadDisplayName</key>
-	<string>Chrome Enrollment</string>
+	<string>Enroll in managed Google Chrome</string>
 	<key>PayloadIdentifier</key>
 	<string>com.github.erikberglund.ProfileCreator.B6965621-36DF-46F6-839D-0F6591C9CA57</string>
 	<key>PayloadOrganization</key>

--- a/mdm_profiles/disable_bluetooth_file_sharing.mobileconfig
+++ b/mdm_profiles/disable_bluetooth_file_sharing.mobileconfig
@@ -6,7 +6,7 @@
 	<key>PayloadDescription</key>
 	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
 	<key>PayloadDisplayName</key>
-	<string>CIS - Bluetooth Sharing</string>
+	<string>Disable Bluetooth sharing</string>
 	<key>PayloadEnabled</key>
 	<true/>
 	<key>PayloadIdentifier</key>

--- a/mdm_profiles/disable_content_caching.mobileconfig
+++ b/mdm_profiles/disable_content_caching.mobileconfig
@@ -13,7 +13,7 @@
 	<key>PayloadUUID</key>
 	<string>D1DCE625-F264-4F01-81A0-B091EABC89AF</string>
 	<key>PayloadDisplayName</key>
-	<string>CIS - Content Caching</string>
+	<string>Disable content caching</string>
 	<key>PayloadEnabled</key>
 	<true/>
 	<key>PayloadVersion</key>

--- a/mdm_profiles/disable_guest_account.mobileconfig
+++ b/mdm_profiles/disable_guest_account.mobileconfig
@@ -5,7 +5,7 @@
 	<key>PayloadDescription</key>
 	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
 	<key>PayloadDisplayName</key>
-	<string>CIS - Guest Account Disabled</string>
+	<string>Disable guest account</string>
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section5.GuestAccess</string>
 	<key>PayloadOrganization</key>

--- a/mdm_profiles/disable_guest_shares.mobileconfig
+++ b/mdm_profiles/disable_guest_shares.mobileconfig
@@ -5,7 +5,7 @@
 	<key>PayloadDescription</key>
 	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
 	<key>PayloadDisplayName</key>
-	<string>CIS - Guest Shared Folders Access</string>
+	<string>Disable guest access to shared folders</string>
 	<key>PayloadEnabled</key>
 	<true/>
 	<key>PayloadIdentifier</key>

--- a/mdm_profiles/disable_internet_sharing.mobileconfig
+++ b/mdm_profiles/disable_internet_sharing.mobileconfig
@@ -5,7 +5,7 @@
 	<key>PayloadDescription</key>
 	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
 	<key>PayloadDisplayName</key>
-	<string>CIS - Internet Sharing Disabled</string>
+	<string>Disable internet sharing</string>
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section2.InternetSharing</string>
 	<key>PayloadOrganization</key>

--- a/mdm_profiles/disable_media_sharing.mobileconfig
+++ b/mdm_profiles/disable_media_sharing.mobileconfig
@@ -5,7 +5,7 @@
 	<key>PayloadDescription</key>
 	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
 	<key>PayloadDisplayName</key>
-	<string>CIS - Media Sharing</string>
+	<string>Disable media sharing</string>
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section2.MediaSharing</string>
 	<key>PayloadOrganization</key>

--- a/mdm_profiles/disable_safari_safefiles.mobileconfig
+++ b/mdm_profiles/disable_safari_safefiles.mobileconfig
@@ -5,7 +5,7 @@
 	<key>PayloadDescription</key>
 	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
 	<key>PayloadDisplayName</key>
-	<string>CIS - Safari Safe Files</string>
+	<string>Disable Safari Safe Files</string>
 	<key>PayloadEnabled</key>
 	<true/>
 	<key>PayloadIdentifier</key>

--- a/mdm_profiles/enable_doh.mobileconfig
+++ b/mdm_profiles/enable_doh.mobileconfig
@@ -20,7 +20,7 @@
 				<string>https://cloudflare-dns.com/dns-query</string>
 			</dict>
 			<key>PayloadDescription</key>
-			<string>Configure to use Cloudflare Encrypted DNS over HTTPS</string>
+			<string>Configures device to use Cloudflare Encrypted DNS over HTTPS</string>
 			<key>PayloadDisplayName</key>
 			<string>Configure Cloudflare encrypted DNS over HTTPS</string>
 			<key>PayloadIdentifier</key>
@@ -38,7 +38,7 @@
 	<key>PayloadDescription</key>
 	<string>Adds the Cloudflare DNS to Big Sur and iOS 14 based systems</string>
 	<key>PayloadDisplayName</key>
-	<string>Cloudflare DNS over HTTPS</string>
+	<string>Configure Cloudflare encrypted DNS over HTTPS</string>
 	<key>PayloadIdentifier</key>
 	<string>com.paulmillr.apple-dns</string>
 	<key>PayloadRemovalDisallowed</key>

--- a/mdm_profiles/enable_doh.mobileconfig
+++ b/mdm_profiles/enable_doh.mobileconfig
@@ -22,7 +22,7 @@
 			<key>PayloadDescription</key>
 			<string>Configures device to use Cloudflare Encrypted DNS over HTTPS</string>
 			<key>PayloadDisplayName</key>
-			<string>Configure Cloudflare encrypted DNS over HTTPS</string>
+			<string>Cloudflare DNS over HTTPS</string>
 			<key>PayloadIdentifier</key>
 			<string>com.apple.dnsSettings.managed.9d6e5fdf-e404-4f34-ae94-27ed2f636ac4</string>
 			<key>PayloadType</key>

--- a/mdm_profiles/enable_doh.mobileconfig
+++ b/mdm_profiles/enable_doh.mobileconfig
@@ -20,9 +20,9 @@
 				<string>https://cloudflare-dns.com/dns-query</string>
 			</dict>
 			<key>PayloadDescription</key>
-			<string>Configures device to use Cloudflare Encrypted DNS over HTTPS</string>
+			<string>Configure to use Cloudflare Encrypted DNS over HTTPS</string>
 			<key>PayloadDisplayName</key>
-			<string>Cloudflare DNS over HTTPS</string>
+			<string>Configure Cloudflare encrypted DNS over HTTPS</string>
 			<key>PayloadIdentifier</key>
 			<string>com.apple.dnsSettings.managed.9d6e5fdf-e404-4f34-ae94-27ed2f636ac4</string>
 			<key>PayloadType</key>

--- a/mdm_profiles/enable_firewall_logging.mobileconfig
+++ b/mdm_profiles/enable_firewall_logging.mobileconfig
@@ -5,7 +5,7 @@
 	<key>PayloadDescription</key>
 	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 12.0 (v1.0.0)</string>
 	<key>PayloadDisplayName</key>
-	<string>CIS - Firewall Logging</string>
+	<string>Turn on Firewall logging</string>
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section3.Logging</string>
 	<key>PayloadOrganization</key>

--- a/mdm_profiles/enable_gatekeeper.mobileconfig
+++ b/mdm_profiles/enable_gatekeeper.mobileconfig
@@ -5,7 +5,7 @@
 	<key>PayloadDescription</key>
 	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
 	<key>PayloadDisplayName</key>
-	<string>CIS - Gatekeeper Settings</string>
+	<string>Turn on Gatekeeper</string>
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section2.GateKeeper</string>
 	<key>PayloadOrganization</key>

--- a/mdm_profiles/enforce_library_validation.mobileconfig
+++ b/mdm_profiles/enforce_library_validation.mobileconfig
@@ -6,7 +6,7 @@
 	<key>PayloadDescription</key>
 	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
 	<key>PayloadDisplayName</key>
-	<string>CIS - Library Validation</string>
+	<string>Turn on Library Validation</string>
 	<key>PayloadEnabled</key>
 	<true/>
 	<key>PayloadIdentifier</key>

--- a/mdm_profiles/firewall.mobileconfig
+++ b/mdm_profiles/firewall.mobileconfig
@@ -32,7 +32,7 @@
 	<key>PayloadDescription</key>
 	<string>Configures the firewall to ne enabled in stealth mode</string>
 	<key>PayloadDisplayName</key>
-	<string>Firewall</string>
+	<string>Turn on Firewall stealth mode</string>
 	<key>PayloadIdentifier</key>
 	<string>com.github.erikberglund.ProfileCreator.F302AA03-F873-4249-A1C3-7BD94B9B855F</string>
 	<key>PayloadOrganization</key>

--- a/mdm_profiles/full_disk_access_for_orbit.mobileconfig
+++ b/mdm_profiles/full_disk_access_for_orbit.mobileconfig
@@ -58,7 +58,7 @@
 	<key>PayloadDescription</key>
 	<string>Grants full disk access to orbit and orbit edge</string>
 	<key>PayloadDisplayName</key>
-	<string>Full disk access for orbit</string>
+	<string>Turn on full disk access for fleetd</string>
 	<key>PayloadIdentifier</key>
 	<string>com.github.erikberglund.ProfileCreator.2C1ED825-A0C3-4274-B0AD-40B80FCA4F71</string>
 	<key>PayloadOrganization</key>

--- a/mdm_profiles/kernel_extensions.mobileconfig
+++ b/mdm_profiles/kernel_extensions.mobileconfig
@@ -32,7 +32,7 @@
 	<key>PayloadDescription</key>
 	<string>Prevents the use of kernel extensions unless explicitly allowed</string>
 	<key>PayloadDisplayName</key>
-	<string>Kernel extensions</string>
+	<string>Turn off kernel extensions</string>
 	<key>PayloadIdentifier</key>
 	<string>com.github.erikberglund.ProfileCreator.75031211-FF2D-46A8-9AB8-2EADAECC1D75</string>
 	<key>PayloadOrganization</key>

--- a/mdm_profiles/limit_ad_tracking.mobileconfig
+++ b/mdm_profiles/limit_ad_tracking.mobileconfig
@@ -5,7 +5,7 @@
 	<key>PayloadDescription</key>
 	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
 	<key>PayloadDisplayName</key>
-	<string>CIS - Limit Ad Tracking and Personalized Ads</string>
+	<string>Turn off ad tracking and personalized ads</string>
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section2.LimitAdTracking</string>
 	<key>PayloadOrganization</key>

--- a/mdm_profiles/misc.mobileconfig
+++ b/mdm_profiles/misc.mobileconfig
@@ -58,7 +58,7 @@
 		</dict>
 	</array>
 	<key>PayloadDisplayName</key>
-	<string>Misc Settings</string>
+	<string>Varous restriction settings</string>
 	<key>PayloadIdentifier</key>
 	<string>com.github.erikberglund.ProfileCreator.7E6F9053-A8AF-4BD2-B254-8C4E2B8748F0</string>
 	<key>PayloadOrganization</key>

--- a/mdm_profiles/password_policy.mobileconfig
+++ b/mdm_profiles/password_policy.mobileconfig
@@ -38,7 +38,7 @@
 	<key>PayloadDescription</key>
 	<string>Configures our Macs to require passwords that are 10 character long</string>
 	<key>PayloadDisplayName</key>
-	<string>Password policy</string>
+	<string>Password policy - require 10 characters</string>
 	<key>PayloadIdentifier</key>
 	<string>com.github.erikberglund.ProfileCreator.F7CF282E-D91B-44E9-922F-A719634F9C8E</string>
 	<key>PayloadOrganization</key>

--- a/mdm_profiles/prevent_autologon.mobileconfig
+++ b/mdm_profiles/prevent_autologon.mobileconfig
@@ -5,7 +5,7 @@
 	<key>PayloadDescription</key>
 	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
 	<key>PayloadDisplayName</key>
-	<string>CIS - Automatic Login</string>
+	<string>Turn off automatic login</string>
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section5.AutoLogin</string>
 	<key>PayloadOrganization</key>

--- a/mdm_profiles/secure_terminal_keyboard.mobileconfig
+++ b/mdm_profiles/secure_terminal_keyboard.mobileconfig
@@ -5,7 +5,7 @@
 	<key>PayloadDescription</key>
 	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
 	<key>PayloadDisplayName</key>
-	<string>CIS - Terminal Secure Keyboard</string>
+	<string>Turn on secure keyboard entry in Terminal</string>
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section2.SecureKeyboard</string>
 	<key>PayloadOrganization</key>

--- a/mdm_profiles/time_and_date.mobileconfig
+++ b/mdm_profiles/time_and_date.mobileconfig
@@ -5,7 +5,7 @@
 	<key>PayloadDescription</key>
 	<string>This profile configuration is designed to apply the CIS Benchmark for macOS 10.14 (v2.0.0), 10.15 (v2.0.0), 11.0 (v2.0.0), and 12.0 (v1.0.0)</string>
 	<key>PayloadDisplayName</key>
-	<string>CIS - Set Time and Date</string>
+	<string>Turn on set time and date automatically</string>
 	<key>PayloadIdentifier</key>
 	<string>cis.macOSBenchmark.section2.TimeDate</string>
 	<key>PayloadOrganization</key>


### PR DESCRIPTION
- Update display names so that anyone at Fleet who views the **Controls > macOS settings** page can understand what settings Fleet controls/enforces
