### PR TITLE
unset loading state on invalid profile upload

### DIFF
--- a/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/CustomSettings.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/CustomSettings.tsx
@@ -55,6 +55,7 @@ const CustomSettings = ({
       !file.name.includes(".mobileconfig")
     ) {
       renderFlash("error", UPLOAD_ERROR_MESSAGES.wrongType.message);
+      setShowLoading(false);
       return;
     }
 


### PR DESCRIPTION
## Addresses #10242 

Profile upload button now correctly exits loading state when the user tries to upload an invalid profile.

<img width="643" alt="Screenshot 2023-03-15 at 1 14 37 PM" src="https://user-images.githubusercontent.com/61553566/225432159-70757da6-91e1-4abd-ad4f-72725321a63d.png">

## Checklist for submitter
- [x] Manual QA for all new/changed functionality