### PR TITLE
Correct copy on the Manual Enrollment Modal

### DIFF
--- a/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
@@ -104,7 +104,7 @@ const ManualEnrollMdmModal = ({
           </li>
           <li>
             In the search bar, type “Profiles”. Select <b>Profiles</b>, double
-            click <b>Enrollment Profile</b>, and select <b>Install</b>.
+            click <b>Fleet Enrollment</b>, and select <b>Install</b>.
           </li>
           <li>
             Enter your password, and select <b>Enroll</b>.

--- a/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
@@ -104,7 +104,7 @@ const ManualEnrollMdmModal = ({
           </li>
           <li>
             In the search bar, type “Profiles”. Select <b>Profiles</b>, double
-            click <b>Fleet Enrollment</b>, and select <b>Install</b>.
+            click <b>Fleet Enrollment</b>, and select <b>Enroll</b>.
           </li>
           <li>
             Enter your password, and select <b>Enroll</b>.


### PR DESCRIPTION
## Implements

Previously read "Enrollment Profile," when the actual displayed name of the profile is "Fleet Enrollment"

Previously read "Install", actually "Enroll"
