### PR TITLE
Fleet UI: Fix software table button tooltip to overflow

### DIFF
--- a/changes/9753-fix-bug-software-link-tooltip
+++ b/changes/9753-fix-bug-software-link-tooltip
@@ -1,0 +1,1 @@
+* Fix software table links that were cutting off tooltip

--- a/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
@@ -67,6 +67,7 @@ const condenseVulnerabilities = (
 const renderBundleTooltip = (name: string, bundle: string) => (
   <span className="name-container">
     <TooltipWrapper
+      position="top"
       tipContent={`
         <span>
           <b>Bundle identifier: </b>

--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -149,6 +149,11 @@
             tbody {
               .name__cell {
                 width: $col-md;
+
+                // Tooltip does not get cut off
+                .children-wrapper {
+                  overflow: initial;
+                }
               }
               .version__cell {
                 width: 0;


### PR DESCRIPTION
## Issue
Cerra #9753 

## Description
- Fix bug that tooltip is being cut off
- Other: Positioned tooltip to top to match other tables' tooltips

## Discussion
I'm sure we have overflow hidden on buttons for a reason, but this was a 1 off fix because I didn't want to potentially introduce more bugs by removing the `overflow: hidden` on a widely used global component like  `<Button/>`

## Screenshot
<img width="945" alt="Screenshot 2023-03-16 at 11 27 36 AM" src="https://user-images.githubusercontent.com/71795832/225667223-869c7216-191b-4dc4-80dc-14e5e862610a.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
