### PR TITLE
Disk encryption loose ends

### DIFF
--- a/frontend/pages/ManageControlsPage/MacOSSettings/cards/DiskEncryption/DiskEncryption.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/cards/DiskEncryption/DiskEncryption.tsx
@@ -77,7 +77,8 @@ const DiskEncryption = ({ currentTeamId }: IDiskEncryptionProps) => {
         <PremiumFeatureMessage />
       ) : (
         <>
-          {showAggregate ? (
+          {/* remove && false to show the table once the API is finished */}
+          {showAggregate && false ? (
             <DiskEncryptionTable currentTeamId={currentTeamId} />
           ) : null}
           <Checkbox

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -87,9 +87,18 @@ export default {
   },
 
   updateAppleMdmSettings: (enableDiskEncryption: boolean, teamId?: number) => {
-    const { MDM_UPDATE_APPLE_SETTINGS } = endpoints;
-
-    return sendRequest("PATCH", MDM_UPDATE_APPLE_SETTINGS, {
+    const {
+      MDM_UPDATE_APPLE_SETTINGS: teamsEndpoint,
+      CONFIG: noTeamsEndpoint,
+    } = endpoints;
+    if (teamId === 0) {
+      return sendRequest("PATCH", noTeamsEndpoint, {
+        mdm: {
+          macos_settings: { enable_disk_encryption: enableDiskEncryption },
+        },
+      });
+    }
+    return sendRequest("PATCH", teamsEndpoint, {
       enable_disk_encryption: enableDiskEncryption,
       team_id: teamId,
     });


### PR DESCRIPTION
## Addresses #9402, #9404

## Implements

- Hides the disk encryption aggregate table while API is WIP (#9434)
- Conditionally hits a different endpoint when setting disk encryption for team_id = 0
<img width="1282" alt="Screenshot 2023-03-16 at 3 17 18 PM" src="https://user-images.githubusercontent.com/61553566/225764940-afce847d-bac9-4d01-a17d-5a56c2ebf3b5.png">

## Checklist for submitter

If some of the following don't apply, delete the relevant line.
- [x] Manual QA for all new/changed functionality