### PR TITLE
Prevent user action in profiles managed by Fleet

### DIFF
--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/fleetdm/fleet/v4/server/service/externalsvc"
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/google/uuid"
@@ -125,26 +126,24 @@ func (svc *Service) MDMAppleEnableFileVaultAndEscrow(ctx context.Context, teamID
 
 	var contents bytes.Buffer
 	params := fileVaultProfileOptions{
-		PayloadIdentifier:    apple_mdm.FleetFileVaultPayloadIdentifier,
+		PayloadIdentifier:    mobileconfig.FleetFileVaultPayloadIdentifier,
 		Base64DerCertificate: base64.StdEncoding.EncodeToString(cert.Leaf.Raw),
 	}
 	if err := fileVaultProfileTemplate.Execute(&contents, params); err != nil {
 		return ctxerr.Wrap(ctx, err, "enabling FileVault")
 	}
 
-	mc := fleet.Mobileconfig(contents.Bytes())
-	cp, err := mc.ParseConfigProfile()
+	cp, err := fleet.NewMDMAppleConfigProfile(contents.Bytes(), teamID)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "enabling FileVault")
 	}
-	cp.TeamID = teamID
 
 	_, err = svc.ds.NewMDMAppleConfigProfile(ctx, *cp)
 	return ctxerr.Wrap(ctx, err, "enabling FileVault")
 }
 
 func (svc *Service) MDMAppleDisableFileVaultAndEscrow(ctx context.Context, teamID *uint) error {
-	err := svc.ds.DeleteMDMAppleConfigProfileByTeamAndIdentifier(ctx, teamID, apple_mdm.FleetFileVaultPayloadIdentifier)
+	err := svc.ds.DeleteMDMAppleConfigProfileByTeamAndIdentifier(ctx, teamID, mobileconfig.FleetFileVaultPayloadIdentifier)
 	return ctxerr.Wrap(ctx, err, "disabling FileVault")
 }
 

--- a/ee/server/service/mdm_test.go
+++ b/ee/server/service/mdm_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/service/externalsvc"
@@ -113,7 +113,7 @@ func TestMDMAppleEnableFileVaultAndEscrow(t *testing.T) {
 		ds, svc, _ := setup(t)
 		ds.NewMDMAppleConfigProfileFunc = func(ctx context.Context, p fleet.MDMAppleConfigProfile) (*fleet.MDMAppleConfigProfile, error) {
 			require.Equal(t, &teamID, p.TeamID)
-			require.Equal(t, p.Identifier, apple_mdm.FleetFileVaultPayloadIdentifier)
+			require.Equal(t, p.Identifier, mobileconfig.FleetFileVaultPayloadIdentifier)
 			require.Equal(t, p.Name, "Disk encryption")
 			require.Contains(t, string(p.Mobileconfig), `MIID6DCCAdACFGX99Sw4aF2qKGLucoIWQRAXHrs1MA0GCSqGSIb3DQEBCwUAMDUxEzARBgNVBAoMClJlZGlzIFRlc3QxHjAcBgNVBAMMFUNlcnRpZmljYXRlIEF1dGhvcml0eTAeFw0yMTEwMTkxNzM0MzlaFw0yMjEwMTkxNzM0MzlaMCwxEzARBgNVBAoMClJlZGlzIFRlc3QxFTATBgNVBAMMDEdlbmVyaWMtY2VydDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKSHcH8EjSvp3Nm4IHAFxG9DZm8+0h1BwU0OX0VHcJ+Cf+f6h0XYMcMo9LFEpnUJRRMjKrM4mkI75NIIufNBN+GrtqqTPTid8wfOGu/Ufa5EEU1hb2j7AiMlpM6i0+ZysXSNo+Vc/cNZT0PXfyOtJnYm6p9WZM84ID1t2ea0bLwC12cTKv5oybVGtJHh76TRxAR3FeQ9+SY30vUAxYm6oWyYho8rRdKtUSe11pXj6OhxxfTZnsSWn4lo0uBpXai63XtieTVpz74htSNC1bunIGv7//m5F60sH5MrF5JSkPxfCfgqski84ICDSRNlvpT+eMPiygAAJ8zY8wYUXRYFYTUCAwEAATANBgkqhkiG9w0BAQsFAAOCAgEAAAw+6Uz2bAcXgQ7fQfdOm+T6FLRBcr8PD4ajOvSu/T+HhVVjE26Qt2IBwFEYve2FvDxrBCF8aQYZcyQqnP8bdKebnWAaqL8BbTwLWW+fDuZLO2b4QHjAEdEKKdZC5/FRpQrkerf5CCPTHE+5M17OZg41wdVYnCEwJOkP5pUAVsmwtrSwVeIquy20TZO0qbscDQETf7NIJgW0IXg82wBe53Rv4/wL3Ybq13XVRGYiJrwpaNTfUNgsDWqgwlQ5L2GOLDgg8S2NoF9mWVgCGSp3a2eHW+EmBRQ1OP6EYQtIhKdGLrSndAOMJ2ER1pgHWUFKkWQaZ9i37Dx2j7P5c4/XNeVozcRQcLwKwN+n8k+bwIYcTX0HMOVFYm+WiFi/gjI860Tx853Sc0nkpOXmBCeHSXigGUscgjBYbmJz4iExXuwgawLXKLDKs0yyhLDnKEjmx/Vhz03JpsVFJ84kSWkTZkYsXiG306TxuJCX9zAt1z+6ClieTTGiFY+D8DfkC4H82rlPEtImpZ6rInsMUlAykImpd58e4PMSa+w/wSHXDvwFP7py1Gvz3XvcbGLmpBXblxTUpToqC7zSQJhHOMBBt6XnhcRwd6G9Vj/mQM3FvJIrxtKk8O7FwMJloGivS85OEzCIur5A+bObXbM2pcI8y4ueHE4NtElRBwn859AdB2k=`)
 			return nil, nil
@@ -131,7 +131,7 @@ func TestMDMAppleDisableFileVaultAndEscrow(t *testing.T) {
 	ds.DeleteMDMAppleConfigProfileByTeamAndIdentifierFunc = func(ctx context.Context, teamID *uint, profileIdentifier string) error {
 		require.NotNil(t, teamID)
 		require.Equal(t, wantTeamID, *teamID)
-		require.Equal(t, apple_mdm.FleetFileVaultPayloadIdentifier, profileIdentifier)
+		require.Equal(t, mobileconfig.FleetFileVaultPayloadIdentifier, profileIdentifier)
 		return nil
 	}
 

--- a/orbit/pkg/profiles/profiles_darwin.go
+++ b/orbit/pkg/profiles/profiles_darwin.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/groob/plist"
 )
 
@@ -29,7 +29,7 @@ type profilesOutput struct {
 // GetFleetdConfig searches and parses a device level configuration profile
 // with Fleet's payload identifier.
 func GetFleetdConfig() (*fleet.MDMAppleFleetdConfig, error) {
-	p, err := getProfile(apple_mdm.FleetdConfigPayloadIdentifier)
+	p, err := getProfile(mobileconfig.FleetdConfigPayloadIdentifier)
 	if err != nil {
 		return nil, err
 	}

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -95,7 +95,7 @@ WHERE
 	}
 	stmt, args, err := sqlx.In(stmt, teamID, fleetIdentifiers)
 	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "sqlx.In loadTeamsForUsers")
+		return nil, ctxerr.Wrap(ctx, err, "sqlx.In ListMDMAppleConfigProfiles")
 	}
 
 	var res []*fleet.MDMAppleConfigProfile

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
@@ -892,7 +893,10 @@ VALUES
 		}
 
 		// profiles that are managed and delivered by Fleet
-		fleetIdents := apple_mdm.ProfilesManagedByFleet()
+		fleetIdents := []string{}
+		for ident := range mobileconfig.FleetPayloadIdentifiers() {
+			fleetIdents = append(fleetIdents, ident)
+		}
 
 		var (
 			stmt string
@@ -983,7 +987,7 @@ func (ds *Datastore) ListMDMAppleProfilesToRemove(ctx context.Context) ([]*fleet
 	return profiles, err
 }
 
-func (ds *Datastore) GetMDMAppleProfilesContents(ctx context.Context, ids []uint) (map[uint]fleet.Mobileconfig, error) {
+func (ds *Datastore) GetMDMAppleProfilesContents(ctx context.Context, ids []uint) (map[uint]mobileconfig.Mobileconfig, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
@@ -1001,10 +1005,10 @@ func (ds *Datastore) GetMDMAppleProfilesContents(ctx context.Context, ids []uint
 		return nil, err
 	}
 	defer rows.Close()
-	results := make(map[uint]fleet.Mobileconfig)
+	results := make(map[uint]mobileconfig.Mobileconfig)
 	for rows.Next() {
 		var id uint
-		var mobileconfig fleet.Mobileconfig
+		var mobileconfig mobileconfig.Mobileconfig
 		if err := rows.Scan(&id, &mobileconfig); err != nil {
 			return nil, err
 		}

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -269,7 +269,6 @@ func NewMDMAppleConfigProfile(raw []byte, teamID *uint) (*MDMAppleConfigProfile,
 	if err != nil {
 		return nil, fmt.Errorf("new MDMAppleConfigProfile: %w", err)
 	}
-
 	return &MDMAppleConfigProfile{
 		TeamID:       teamID,
 		Identifier:   cp.PayloadIdentifier,
@@ -283,9 +282,11 @@ func (cp MDMAppleConfigProfile) AuthzType() string {
 	return "mdm_apple_config_profile"
 }
 
-// ScreenPayloads screens the profile's Mobileconfig and returns an error if it
-// detects certain PayloadTypes or PayloadIdentifiers managed by Fleet.
-func (cp MDMAppleConfigProfile) ScreenPayloads() error {
+func (cp MDMAppleConfigProfile) ValidateUserProvided() error {
+	if _, ok := mobileconfig.FleetPayloadIdentifiers()[cp.Identifier]; ok {
+		return fmt.Errorf("payload identifier %s is not allowed", cp.Identifier)
+	}
+
 	return cp.Mobileconfig.ScreenPayloads()
 }
 

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1,23 +1,19 @@
 package fleet
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/micromdm/nanodep/godep"
 	"github.com/micromdm/nanomdm/mdm"
-	"go.mozilla.org/pkcs7"
-	"howett.net/plist"
 )
 
 type MDMAppleCommandIssuer interface {
-	InstallProfile(ctx context.Context, hostUUIDs []string, profile Mobileconfig, uuid string) error
+	InstallProfile(ctx context.Context, hostUUIDs []string, profile mobileconfig.Mobileconfig, uuid string) error
 	RemoveProfile(ctx context.Context, hostUUIDs []string, identifier string, uuid string) error
 	DeviceLock(ctx context.Context, hostUUIDs []string, uuid string) error
 	EraseDevice(ctx context.Context, hostUUIDs []string, uuid string) error
@@ -245,127 +241,6 @@ func (e MDMAppleCommandTimeoutError) StatusCode() int {
 	return http.StatusGatewayTimeout
 }
 
-// Mobileconfig is the byte slice corresponding to an XML property list (i.e. plist) representation
-// of an Apple MDM configuration profile in Fleet.
-//
-// Configuration profiles are used to configure Apple devices. See also
-// https://developer.apple.com/documentation/devicemanagement/configuring_multiple_devices_using_profiles.
-type Mobileconfig []byte
-
-// ParseConfigProfile attempts to parse the Mobileconfig byte slice as a Fleet MDMAppleConfigProfile.
-//
-// The byte slice must be XML or PKCS7 parseable. Fleet also requires that it contains both
-// a PayloadIdentifier and a PayloadDisplayName and that it has PayloadType set to "Configuration".
-//
-// Adapted from https://github.com/micromdm/micromdm/blob/main/platform/profile/profile.go
-func (mc Mobileconfig) ParseConfigProfile() (*MDMAppleConfigProfile, error) {
-	mcBytes := mc
-	if !bytes.HasPrefix(mcBytes, []byte("<?xml")) {
-		p7, err := pkcs7.Parse(mcBytes)
-		if err != nil {
-			return nil, fmt.Errorf("mobileconfig is not XML nor PKCS7 parseable: %w", err)
-		}
-		err = p7.Verify()
-		if err != nil {
-			return nil, err
-		}
-		mcBytes = Mobileconfig(p7.Content)
-	}
-	var parsed struct {
-		PayloadIdentifier  string
-		PayloadDisplayName string
-		PayloadType        string
-	}
-	_, err := plist.Unmarshal(mcBytes, &parsed)
-	if err != nil {
-		return nil, err
-	}
-	if parsed.PayloadType != "Configuration" {
-		return nil, fmt.Errorf("invalid PayloadType: %s", parsed.PayloadType)
-	}
-	if parsed.PayloadIdentifier == "" {
-		return nil, errors.New("empty PayloadIdentifier in profile")
-	}
-	if parsed.PayloadDisplayName == "" {
-		return nil, errors.New("empty PayloadDisplayName in profile")
-	}
-
-	return &MDMAppleConfigProfile{
-		Identifier:   parsed.PayloadIdentifier,
-		Name:         parsed.PayloadDisplayName,
-		Mobileconfig: mc,
-	}, nil
-}
-
-// GetPayloadTypes attempts to parse the PayloadContent list of the Mobileconfig's TopLevel object.
-// It returns the PayloadType for each PayloadContentItem.
-//
-// See also https://developer.apple.com/documentation/devicemanagement/toplevel
-func (mc Mobileconfig) GetPayloadTypes() ([]string, error) {
-	mcBytes := mc
-	if !bytes.HasPrefix(mcBytes, []byte("<?xml")) {
-		p7, err := pkcs7.Parse(mcBytes)
-		if err != nil {
-			return nil, fmt.Errorf("mobileconfig is not XML nor PKCS7 parseable: %w", err)
-		}
-		err = p7.Verify()
-		if err != nil {
-			return nil, err
-		}
-		mcBytes = Mobileconfig(p7.Content)
-	}
-
-	// unmarshal the values we need from the top-level object
-	var tlo struct {
-		IsEncrypted    bool
-		PayloadContent []map[string]interface{}
-		PayloadType    string
-	}
-	_, err := plist.Unmarshal(mcBytes, &tlo)
-	if err != nil {
-		return nil, err
-	}
-	// confirm that the top-level payload type matches the expected value
-	if tlo.PayloadType != "Configuration" {
-		return nil, &ErrInvalidPayloadType{tlo.PayloadType}
-	}
-
-	if len(tlo.PayloadContent) < 1 {
-		if tlo.IsEncrypted {
-			return nil, ErrEncryptedPayloadContent
-		}
-		return nil, ErrEmptyPayloadContent
-	}
-
-	// extract the payload types of each payload content item from the array of
-	// payload dictionaries
-	var result []string
-	for _, payloadDict := range tlo.PayloadContent {
-		pt, ok := payloadDict["PayloadType"]
-		if !ok {
-			continue
-		}
-		if s, ok := pt.(string); ok {
-			result = append(result, s)
-		}
-	}
-
-	return result, nil
-}
-
-type ErrInvalidPayloadType struct {
-	payloadType string
-}
-
-func (e ErrInvalidPayloadType) Error() string {
-	return fmt.Sprintf("invalid PayloadType: %s", e.payloadType)
-}
-
-var (
-	ErrEmptyPayloadContent     = errors.New("empty PayloadContent")
-	ErrEncryptedPayloadContent = errors.New("encrypted PayloadContent")
-)
-
 // MDMAppleConfigProfile represents an Apple MDM configuration profile in Fleet.
 // Configuration profiles are used to configure Apple devices .
 // See also https://developer.apple.com/documentation/devicemanagement/configuring_multiple_devices_using_profiles.
@@ -383,9 +258,24 @@ type MDMAppleConfigProfile struct {
 	Name string `db:"name" json:"name"`
 	// Mobileconfig is the byte slice corresponding to the XML property list (i.e. plist)
 	// representation of the configuration profile. It must be XML or PKCS7 parseable.
-	Mobileconfig Mobileconfig `db:"mobileconfig" json:"-"`
-	CreatedAt    time.Time    `db:"created_at" json:"created_at"`
-	UpdatedAt    time.Time    `db:"updated_at" json:"updated_at"`
+	Mobileconfig mobileconfig.Mobileconfig `db:"mobileconfig" json:"-"`
+	CreatedAt    time.Time                 `db:"created_at" json:"created_at"`
+	UpdatedAt    time.Time                 `db:"updated_at" json:"updated_at"`
+}
+
+func NewMDMAppleConfigProfile(raw []byte, teamID *uint) (*MDMAppleConfigProfile, error) {
+	mc := mobileconfig.Mobileconfig(raw)
+	cp, err := mc.ParseConfigProfile()
+	if err != nil {
+		return nil, fmt.Errorf("new MDMAppleConfigProfile: %w", err)
+	}
+
+	return &MDMAppleConfigProfile{
+		TeamID:       teamID,
+		Identifier:   cp.PayloadIdentifier,
+		Name:         cp.PayloadDisplayName,
+		Mobileconfig: mc,
+	}, nil
 }
 
 // AuthzType implements authz.AuthzTyper.
@@ -393,31 +283,10 @@ func (cp MDMAppleConfigProfile) AuthzType() string {
 	return "mdm_apple_config_profile"
 }
 
-// ScreenPayloadTypes screens the profile's Mobileconfig and returns an error if it
-// detects certain PayloadTypes related to FileVault settings.
-func (cp MDMAppleConfigProfile) ScreenPayloadTypes() error {
-	pct, err := cp.Mobileconfig.GetPayloadTypes()
-	if err != nil {
-		switch {
-		case errors.Is(err, ErrEmptyPayloadContent), errors.Is(err, ErrEncryptedPayloadContent):
-			// ok, there's nothing for us to screen
-		default:
-			return err
-		}
-	}
-
-	var screened []string
-	for _, t := range pct {
-		switch t {
-		case "com.apple.security.FDERecoveryKeyEscrow", "com.apple.MCX.FileVault2", "com.apple.security.FDERecoveryRedirect":
-			screened = append(screened, t)
-		}
-	}
-	if len(screened) > 0 {
-		return fmt.Errorf("unsupported PayloadType(s): %s", strings.Join(screened, ", "))
-	}
-
-	return nil
+// ScreenPayloads screens the profile's Mobileconfig and returns an error if it
+// detects certain PayloadTypes or PayloadIdentifiers managed by Fleet.
+func (cp MDMAppleConfigProfile) ScreenPayloads() error {
+	return cp.Mobileconfig.ScreenPayloads()
 }
 
 // HostMDMAppleProfile represents the status of an Apple MDM profile in a host.

--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -145,7 +145,7 @@ func TestMDMAppleConfigProfileScreenPayloadContent(t *testing.T) {
 			require.Equal(t, "ValidName", parsed.Name)
 			require.Equal(t, "ValidIdentifier", parsed.Identifier)
 
-			err = parsed.ScreenPayloads()
+			err = parsed.ValidateUserProvided()
 			for _, pt := range c.shouldFail {
 				require.Error(t, err)
 				require.ErrorContains(t, err, pt)
@@ -200,7 +200,7 @@ func TestMDMAppleConfigProfileScreenPayloadIdentifiers(t *testing.T) {
 			require.Equal(t, "ValidName", parsed.Name)
 			require.Equal(t, "ValidIdentifier", parsed.Identifier)
 
-			err = parsed.ScreenPayloads()
+			err = parsed.ValidateUserProvided()
 			for _, pt := range c.shouldFail {
 				require.Error(t, err)
 				require.ErrorContains(t, err, pt)

--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -154,6 +154,61 @@ func TestMDMAppleConfigProfileScreenPayloadContent(t *testing.T) {
 	}
 }
 
+func TestMDMAppleConfigProfileScreenPayloadIdentifiers(t *testing.T) {
+	cases := []struct {
+		testName           string
+		payloadIdentifiers []string
+		shouldFail         []string
+	}{
+		{
+			testName:           "AllFleetProfilesScreened",
+			payloadIdentifiers: []string{"com.fleetdm.fleet.mdm.filevault", "com.fleetdm.fleetd.config"},
+			shouldFail:         []string{"com.fleetdm.fleet.mdm.filevault", "com.fleetdm.fleetd.config"},
+		},
+		{
+			testName:           "FileVault",
+			payloadIdentifiers: []string{"com.fleetdm.fleet.mdm.filevault"},
+			shouldFail:         []string{"com.fleetdm.fleet.mdm.filevault"},
+		},
+		{
+			testName:           "Fleetd config",
+			payloadIdentifiers: []string{"com.fleetdm.fleetd.config"},
+			shouldFail:         []string{"com.fleetdm.fleetd.config"},
+		},
+		{
+			testName:           "OtherPayloadTypesOK",
+			payloadIdentifiers: []string{"com.my.custom.profile", "com.test.example"},
+			shouldFail:         nil,
+		},
+		{
+			testName:           "Mixed",
+			payloadIdentifiers: []string{"com.fleetdm.fleet.mdm.filevault", "com.my.custom.profile", "com.test.example"},
+			shouldFail:         []string{"com.fleetdm.fleet.mdm.filevault"},
+		},
+		{
+			testName:           "NoPayloadContent",
+			payloadIdentifiers: nil,
+			shouldFail:         nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.testName, func(t *testing.T) {
+			mc := mobileconfigForTest("ValidName", "ValidIdentifier", uuid.NewString(), mcPayloadContentForTest(c.payloadIdentifiers))
+			parsed, err := NewMDMAppleConfigProfile(mc, nil)
+			require.NoError(t, err)
+			require.Equal(t, "ValidName", parsed.Name)
+			require.Equal(t, "ValidIdentifier", parsed.Identifier)
+
+			err = parsed.ScreenPayloads()
+			for _, pt := range c.shouldFail {
+				require.Error(t, err)
+				require.ErrorContains(t, err, pt)
+			}
+		})
+	}
+}
+
 func mobileconfigForTest(name string, identifier string, uuid string, payloadContent string) mobileconfig.Mobileconfig {
 	pc := "<array/>"
 	if payloadContent != "" {
@@ -181,27 +236,27 @@ func mobileconfigForTest(name string, identifier string, uuid string, payloadCon
 `, pc, name, identifier, uuid))
 }
 
-func mcPayloadContentForTest(payloadTypes []string) string {
+func mcPayloadContentForTest(refs []string) string {
 	formatted := ""
-	for _, pt := range payloadTypes {
-		if pt == "" {
+	for _, ref := range refs {
+		if ref == "" {
 			continue
 		}
-		ss := strings.Split(pt, ".")
+		ss := strings.Split(ref, ".")
 		uuid := uuid.New()
 		formatted += fmt.Sprintf(`
 		<dict>
 			<key>PayloadDisplayName</key>
 			<string>%s</string>
 			<key>PayloadIdentifier</key>
-			<string>%s.%s</string>
+			<string>%s</string>
 			<key>PayloadType</key>
 			<string>%s</string>
 			<key>PayloadUUID</key>
 			<string>%s</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
-		</dict>`, ss[len(ss)-1], pt, uuid, pt, uuid)
+		</dict>`, ss[len(ss)-1], ref, ref, uuid)
 	}
 
 	return formatted

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/health"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/micromdm/nanodep/godep"
 )
 
@@ -807,7 +808,7 @@ type Datastore interface {
 
 	// GetMDMAppleProfilesContents retrieves the XML contents of the
 	// profiles requested.
-	GetMDMAppleProfilesContents(ctx context.Context, profileIDs []uint) (map[uint]Mobileconfig, error)
+	GetMDMAppleProfilesContents(ctx context.Context, profileIDs []uint) (map[uint]mobileconfig.Mobileconfig, error)
 
 	// UpdateOrDeleteHostMDMAppleProfile updates information about a single
 	// profile status. It deletes the row if the profile operation is "remove"

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -45,22 +45,7 @@ const (
 
 	// FleetFileVaultPayloadIdentifier is the value for the PayloadIdentifier
 	// used by Fleet to configure FileVault and FileVault Escrow.
-	FleetFileVaultPayloadIdentifier = "com.fleetdm.fleet.mdm.filevault"
-
-	// FleetdConfigPayloadIdentifier is the value for the PayloadIdentifier used
-	// by fleetd to read configuration values from the system.
-	FleetdConfigPayloadIdentifier = "com.fleetdm.fleetd.config"
 )
-
-// ProfilesManagedByFleet returns a list of profile identifiers
-// that are handled and delivered by Fleet.
-func ProfilesManagedByFleet() []string {
-	return []string{
-		FleetPayloadIdentifier,
-		FleetFileVaultPayloadIdentifier,
-		FleetdConfigPayloadIdentifier,
-	}
-}
 
 func ResolveAppleMDMURL(serverURL string) (string, error) {
 	return resolveURL(serverURL, MDMPath)

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -42,9 +42,6 @@ const (
 	// FleetPayloadIdentifier is the value for the "<key>PayloadIdentifier</key>"
 	// used by Fleet MDM on the enrollment profile.
 	FleetPayloadIdentifier = "com.fleetdm.fleet.mdm.apple"
-
-	// FleetFileVaultPayloadIdentifier is the value for the PayloadIdentifier
-	// used by Fleet to configure FileVault and FileVault Escrow.
 )
 
 func ResolveAppleMDMURL(serverURL string) (string, error) {

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -52,6 +52,16 @@ const (
 	FleetdConfigPayloadIdentifier = "com.fleetdm.fleetd.config"
 )
 
+// ProfilesManagedByFleet returns a list of profile identifiers
+// that are handled and delivered by Fleet.
+func ProfilesManagedByFleet() []string {
+	return []string{
+		FleetPayloadIdentifier,
+		FleetFileVaultPayloadIdentifier,
+		FleetdConfigPayloadIdentifier,
+	}
+}
+
 func ResolveAppleMDMURL(serverURL string) (string, error) {
 	return resolveURL(serverURL, MDMPath)
 }

--- a/server/mdm/apple/mobileconfig/mobileconfig.go
+++ b/server/mdm/apple/mobileconfig/mobileconfig.go
@@ -89,9 +89,6 @@ func (mc Mobileconfig) ParseConfigProfile() (*Parsed, error) {
 	if p.PayloadIdentifier == "" {
 		return nil, errors.New("empty PayloadIdentifier in profile")
 	}
-	if _, ok := FleetPayloadIdentifiers()[p.PayloadIdentifier]; ok {
-		return nil, fmt.Errorf("payload identifier %s is not allowed", p.PayloadIdentifier)
-	}
 	if p.PayloadDisplayName == "" {
 		return nil, errors.New("empty PayloadDisplayName in profile")
 	}

--- a/server/mdm/apple/mobileconfig/mobileconfig.go
+++ b/server/mdm/apple/mobileconfig/mobileconfig.go
@@ -1,0 +1,207 @@
+package mobileconfig
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.mozilla.org/pkcs7"
+	"howett.net/plist"
+)
+
+const (
+	FleetFileVaultPayloadIdentifier = "com.fleetdm.fleet.mdm.filevault"
+
+	// FleetdConfigPayloadIdentifier is the value for the PayloadIdentifier used
+	// by fleetd to read configuration values from the system.
+	FleetdConfigPayloadIdentifier = "com.fleetdm.fleetd.config"
+)
+
+// FleetPayloadIdentifiers returns a map of profile identifiers
+// that are handled and delivered by Fleet.
+func FleetPayloadIdentifiers() map[string]struct{} {
+	return map[string]struct{}{
+		//FleetPayloadIdentifier:          {},
+		FleetFileVaultPayloadIdentifier: {},
+		FleetdConfigPayloadIdentifier:   {},
+	}
+}
+
+func FleetPayloadTypes() map[string]struct{} {
+	return map[string]struct{}{
+		"com.apple.security.FDERecoveryKeyEscrow": {},
+		"com.apple.MCX.FileVault2":                {},
+		"com.apple.security.FDERecoveryRedirect":  {},
+	}
+}
+
+// Mobileconfig is the byte slice corresponding to an XML property list (i.e. plist) representation
+// of an Apple MDM configuration profile in Fleet.
+//
+// Configuration profiles are used to configure Apple devices. See also
+// https://developer.apple.com/documentation/devicemanagement/configuring_multiple_devices_using_profiles.
+type Mobileconfig []byte
+
+type Parsed struct {
+	PayloadIdentifier  string
+	PayloadDisplayName string
+	PayloadType        string
+}
+
+// ParseConfigProfile attempts to parse the Mobileconfig byte slice as a Fleet MDMAppleConfigProfile.
+//
+// The byte slice must be XML or PKCS7 parseable. Fleet also requires that it contains both
+// a PayloadIdentifier and a PayloadDisplayName and that it has PayloadType set to "Configuration".
+//
+// Adapted from https://github.com/micromdm/micromdm/blob/main/platform/profile/profile.go
+func (mc Mobileconfig) ParseConfigProfile() (*Parsed, error) {
+	mcBytes := mc
+	if !bytes.HasPrefix(mcBytes, []byte("<?xml")) {
+		p7, err := pkcs7.Parse(mcBytes)
+		if err != nil {
+			return nil, fmt.Errorf("mobileconfig is not XML nor PKCS7 parseable: %w", err)
+		}
+		err = p7.Verify()
+		if err != nil {
+			return nil, err
+		}
+		mcBytes = Mobileconfig(p7.Content)
+	}
+	p := &Parsed{}
+	_, err := plist.Unmarshal(mcBytes, &p)
+	if err != nil {
+		return nil, err
+	}
+	if p.PayloadType != "Configuration" {
+		return nil, fmt.Errorf("invalid PayloadType: %s", p.PayloadType)
+	}
+	if p.PayloadIdentifier == "" {
+		return nil, errors.New("empty PayloadIdentifier in profile")
+	}
+	if p.PayloadDisplayName == "" {
+		return nil, errors.New("empty PayloadDisplayName in profile")
+	}
+
+	return p, nil
+}
+
+type PayloadSummary struct {
+	Type       string
+	Identifier string
+}
+
+// GetPayloadSummary attempts to parse the PayloadContent list of the Mobileconfig's TopLevel object.
+// It returns the PayloadType for each PayloadContentItem.
+//
+// See also https://developer.apple.com/documentation/devicemanagement/toplevel
+func (mc Mobileconfig) GetPayloadSummary() ([]PayloadSummary, error) {
+	mcBytes := mc
+	if !bytes.HasPrefix(mcBytes, []byte("<?xml")) {
+		p7, err := pkcs7.Parse(mcBytes)
+		if err != nil {
+			return nil, fmt.Errorf("mobileconfig is not XML nor PKCS7 parseable: %w", err)
+		}
+		err = p7.Verify()
+		if err != nil {
+			return nil, err
+		}
+		mcBytes = Mobileconfig(p7.Content)
+	}
+
+	// unmarshal the values we need from the top-level object
+	var tlo struct {
+		IsEncrypted    bool
+		PayloadContent []map[string]interface{}
+		PayloadType    string
+	}
+	_, err := plist.Unmarshal(mcBytes, &tlo)
+	if err != nil {
+		return nil, err
+	}
+	// confirm that the top-level payload type matches the expected value
+	if tlo.PayloadType != "Configuration" {
+		return nil, &ErrInvalidPayloadType{tlo.PayloadType}
+	}
+
+	if len(tlo.PayloadContent) < 1 {
+		if tlo.IsEncrypted {
+			return nil, ErrEncryptedPayloadContent
+		}
+		return nil, ErrEmptyPayloadContent
+	}
+
+	// extract the payload types of each payload content item from the array of
+	// payload dictionaries
+	var result []PayloadSummary
+	for _, payloadDict := range tlo.PayloadContent {
+		summary := PayloadSummary{}
+
+		pt, ok := payloadDict["PayloadType"]
+		if ok {
+			if s, ok := pt.(string); ok {
+				summary.Type = s
+			}
+		}
+
+		pi, ok := payloadDict["PayloadIdentifier"]
+		if ok {
+			if s, ok := pi.(string); ok {
+				summary.Identifier = s
+			}
+		}
+
+		if summary.Type != "" || summary.Identifier != "" {
+			result = append(result, summary)
+		}
+
+	}
+
+	return result, nil
+}
+
+func (mc *Mobileconfig) ScreenPayloads() error {
+	pct, err := mc.GetPayloadSummary()
+	if err != nil {
+		// don't error if there's nothing for us to screen.
+		if !errors.Is(err, ErrEmptyPayloadContent) || !errors.Is(err, ErrEncryptedPayloadContent) {
+			return err
+		}
+	}
+
+	fleetIdentifiers := FleetPayloadIdentifiers()
+	fleetTypes := FleetPayloadTypes()
+	screenedTypes := []string{}
+	screenedIdentifiers := []string{}
+	for _, t := range pct {
+		if _, ok := fleetTypes[t.Type]; ok {
+			screenedTypes = append(screenedTypes, t.Type)
+		}
+		if _, ok := fleetIdentifiers[t.Identifier]; ok {
+			screenedIdentifiers = append(screenedIdentifiers, t.Identifier)
+		}
+	}
+
+	if len(screenedTypes) > 0 {
+		return fmt.Errorf("unsupported PayloadType(s): %s", strings.Join(screenedTypes, ", "))
+	}
+
+	if len(screenedIdentifiers) > 0 {
+		return fmt.Errorf("unsupported PayloadIdentifier(s): %s", strings.Join(screenedIdentifiers, ", "))
+	}
+
+	return nil
+}
+
+type ErrInvalidPayloadType struct {
+	payloadType string
+}
+
+func (e ErrInvalidPayloadType) Error() string {
+	return fmt.Sprintf("invalid PayloadType: %s", e.payloadType)
+}
+
+var (
+	ErrEmptyPayloadContent     = errors.New("empty PayloadContent")
+	ErrEncryptedPayloadContent = errors.New("encrypted PayloadContent")
+)

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/micromdm/nanodep/godep"
 )
 
@@ -559,7 +560,7 @@ type ListMDMAppleProfilesToRemoveFunc func(ctx context.Context) ([]*fleet.MDMApp
 
 type BulkUpsertMDMAppleHostProfilesFunc func(ctx context.Context, payload []*fleet.MDMAppleBulkUpsertHostProfilePayload) error
 
-type GetMDMAppleProfilesContentsFunc func(ctx context.Context, profileIDs []uint) (map[uint]fleet.Mobileconfig, error)
+type GetMDMAppleProfilesContentsFunc func(ctx context.Context, profileIDs []uint) (map[uint]mobileconfig.Mobileconfig, error)
 
 type UpdateOrDeleteHostMDMAppleProfileFunc func(ctx context.Context, profile *fleet.HostMDMAppleProfile) error
 
@@ -3308,7 +3309,7 @@ func (s *DataStore) BulkUpsertMDMAppleHostProfiles(ctx context.Context, payload 
 	return s.BulkUpsertMDMAppleHostProfilesFunc(ctx, payload)
 }
 
-func (s *DataStore) GetMDMAppleProfilesContents(ctx context.Context, profileIDs []uint) (map[uint]fleet.Mobileconfig, error) {
+func (s *DataStore) GetMDMAppleProfilesContents(ctx context.Context, profileIDs []uint) (map[uint]mobileconfig.Mobileconfig, error) {
 	s.mu.Lock()
 	s.GetMDMAppleProfilesContentsFuncInvoked = true
 	s.mu.Unlock()

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -22,6 +22,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/google/uuid"
@@ -303,16 +304,14 @@ func (svc *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, r
 		})
 	}
 
-	mc := fleet.Mobileconfig(b)
-	cp, err := mc.ParseConfigProfile()
+	cp, err := fleet.NewMDMAppleConfigProfile(b, &teamID)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
 			Message: fmt.Sprintf("failed to parse config profile: %s", err.Error()),
 		})
 	}
-	cp.TeamID = &teamID
 
-	if err := cp.ScreenPayloadTypes(); err != nil {
+	if err := cp.ScreenPayloads(); err != nil {
 		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{Message: err.Error()})
 	}
 
@@ -484,6 +483,14 @@ func (svc *Service) DeleteMDMAppleConfigProfile(ctx context.Context, profileID u
 	// now we can do a specific authz check based on team id of profile before we delete the profile
 	if err := svc.authz.Authorize(ctx, cp, fleet.ActionWrite); err != nil {
 		return ctxerr.Wrap(ctx, err)
+	}
+
+	// prevent deleting profiles that are managed by Fleet
+	if _, ok := mobileconfig.FleetPayloadIdentifiers()[cp.Identifier]; ok {
+		return &fleet.BadRequestError{
+			Message:     "profiles managed by Fleet can't be deleted using this endpoint.",
+			InternalErr: fmt.Errorf("deleting profile %s for team %s not allowed because it's managed by Fleet", cp.Identifier, teamName),
+		}
 	}
 
 	if err := svc.ds.DeleteMDMAppleConfigProfile(ctx, profileID); err != nil {
@@ -1417,15 +1424,14 @@ func (svc *Service) BatchSetMDMAppleProfiles(ctx context.Context, tmID *uint, tm
 	profs := make([]*fleet.MDMAppleConfigProfile, 0, len(profiles))
 	byName, byIdent := make(map[string]bool, len(profiles)), make(map[string]bool, len(profiles))
 	for i, prof := range profiles {
-		mobConf := fleet.Mobileconfig(prof)
-		mdmProf, err := mobConf.ParseConfigProfile()
+		mdmProf, err := fleet.NewMDMAppleConfigProfile(prof, tmID)
 		if err != nil {
 			return ctxerr.Wrap(ctx,
 				fleet.NewInvalidArgumentError(fmt.Sprintf("profiles[%d]", i), err.Error()),
 				"invalid mobileconfig profile")
 		}
 
-		if err := mdmProf.ScreenPayloadTypes(); err != nil {
+		if err := mdmProf.ScreenPayloads(); err != nil {
 			return ctxerr.Wrap(ctx,
 				fleet.NewInvalidArgumentError(fmt.Sprintf("profiles[%d]", i), err.Error()))
 		}
@@ -1752,7 +1758,7 @@ func NewMDMAppleCommander(mdmStorage nanomdm_storage.AllStorage, mdmPushService 
 
 // InstallProfile sends the homonymous MDM command to the given hosts, it also
 // takes care of the base64 encoding of the provided profile bytes.
-func (svc *MDMAppleCommander) InstallProfile(ctx context.Context, hostUUIDs []string, profile fleet.Mobileconfig, uuid string) error {
+func (svc *MDMAppleCommander) InstallProfile(ctx context.Context, hostUUIDs []string, profile mobileconfig.Mobileconfig, uuid string) error {
 	base64Profile := base64.StdEncoding.EncodeToString(profile)
 	raw := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -311,7 +311,7 @@ func (svc *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, r
 		})
 	}
 
-	if err := cp.ScreenPayloads(); err != nil {
+	if err := cp.ValidateUserProvided(); err != nil {
 		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{Message: err.Error()})
 	}
 
@@ -1431,7 +1431,7 @@ func (svc *Service) BatchSetMDMAppleProfiles(ctx context.Context, tmID *uint, tm
 				"invalid mobileconfig profile")
 		}
 
-		if err := mdmProf.ScreenPayloads(); err != nil {
+		if err := mdmProf.ValidateUserProvided(); err != nil {
 			return ctxerr.Wrap(ctx,
 				fleet.NewInvalidArgumentError(fmt.Sprintf("profiles[%d]", i), err.Error()))
 		}

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -1626,3 +1626,40 @@ func mobileconfigForTest(name, identifier string) []byte {
 </plist>
 `, name, identifier, uuid.New().String()))
 }
+
+func mobileconfigForTestWithContent(name, identifier, inneridentifier, innertype string) []byte {
+	return []byte(fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+          <dict>
+            <key>PayloadDisplayName</key>
+            <string>%s</string>
+            <key>PayloadIdentifier</key>
+            <string>%s</string>
+            <key>PayloadType</key>
+            <string>%s</string>
+            <key>PayloadUUID</key>
+            <string>3548D750-6357-4910-8DEA-D80ADCE2C787</string>
+            <key>PayloadVersion</key>
+            <integer>1</integer>
+            <key>ShowRecoveryKey</key>
+            <false/>
+          </dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>%s</string>
+	<key>PayloadIdentifier</key>
+	<string>%s</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>%s</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>
+`, name+".inner", inneridentifier, innertype, name, identifier, uuid.New().String()))
+}

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	nanodep_mock "github.com/fleetdm/fleet/v4/server/mock/nanodep"
 	nanomdm_mock "github.com/fleetdm/fleet/v4/server/mock/nanomdm"
@@ -1498,9 +1499,9 @@ func TestMDMAppleReconcileProfiles(t *testing.T) {
 		}, nil
 	}
 
-	ds.GetMDMAppleProfilesContentsFunc = func(ctx context.Context, profileIDs []uint) (map[uint]fleet.Mobileconfig, error) {
+	ds.GetMDMAppleProfilesContentsFunc = func(ctx context.Context, profileIDs []uint) (map[uint]mobileconfig.Mobileconfig, error) {
 		require.ElementsMatch(t, []uint{1, 2}, profileIDs)
-		return map[uint]fleet.Mobileconfig{
+		return map[uint]mobileconfig.Mobileconfig{
 			1: contents1,
 			2: contents2,
 		}, nil

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -19,6 +19,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/gocarina/gocsv"
 )
 
@@ -811,7 +812,7 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 
 		// determine disk encryption and action required here based on profiles and
 		// raw decryptable key status.
-		host.MDM.DetermineDiskEncryptionStatus(profiles, apple_mdm.FleetFileVaultPayloadIdentifier)
+		host.MDM.DetermineDiskEncryptionStatus(profiles, mobileconfig.FleetFileVaultPayloadIdentifier)
 	}
 	host.MDM.Profiles = &profiles
 

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/test"
@@ -118,7 +119,7 @@ func TestHostDetailsMDMDiskEncryption(t *testing.T) {
 			ptr.Int(-1),
 			&fleet.HostMDMAppleProfile{
 				HostUUID:      "abc",
-				Identifier:    apple_mdm.FleetFileVaultPayloadIdentifier,
+				Identifier:    mobileconfig.FleetFileVaultPayloadIdentifier,
 				Status:        &fleet.MDMAppleDeliveryApplied,
 				OperationType: fleet.MDMAppleOperationTypeInstall,
 			},
@@ -130,7 +131,7 @@ func TestHostDetailsMDMDiskEncryption(t *testing.T) {
 			nil,
 			&fleet.HostMDMAppleProfile{
 				HostUUID:      "abc",
-				Identifier:    apple_mdm.FleetFileVaultPayloadIdentifier,
+				Identifier:    mobileconfig.FleetFileVaultPayloadIdentifier,
 				Status:        &fleet.MDMAppleDeliveryApplied,
 				OperationType: fleet.MDMAppleOperationTypeInstall,
 			},
@@ -142,7 +143,7 @@ func TestHostDetailsMDMDiskEncryption(t *testing.T) {
 			ptr.Int(0),
 			&fleet.HostMDMAppleProfile{
 				HostUUID:      "abc",
-				Identifier:    apple_mdm.FleetFileVaultPayloadIdentifier,
+				Identifier:    mobileconfig.FleetFileVaultPayloadIdentifier,
 				Status:        &fleet.MDMAppleDeliveryApplied,
 				OperationType: fleet.MDMAppleOperationTypeInstall,
 			},
@@ -154,7 +155,7 @@ func TestHostDetailsMDMDiskEncryption(t *testing.T) {
 			ptr.Int(1),
 			&fleet.HostMDMAppleProfile{
 				HostUUID:      "abc",
-				Identifier:    apple_mdm.FleetFileVaultPayloadIdentifier,
+				Identifier:    mobileconfig.FleetFileVaultPayloadIdentifier,
 				Status:        &fleet.MDMAppleDeliveryApplied,
 				OperationType: fleet.MDMAppleOperationTypeInstall,
 			},
@@ -166,7 +167,7 @@ func TestHostDetailsMDMDiskEncryption(t *testing.T) {
 			ptr.Int(1),
 			&fleet.HostMDMAppleProfile{
 				HostUUID:      "abc",
-				Identifier:    apple_mdm.FleetFileVaultPayloadIdentifier,
+				Identifier:    mobileconfig.FleetFileVaultPayloadIdentifier,
 				Status:        &fleet.MDMAppleDeliveryPending,
 				OperationType: fleet.MDMAppleOperationTypeInstall,
 			},
@@ -178,7 +179,7 @@ func TestHostDetailsMDMDiskEncryption(t *testing.T) {
 			nil,
 			&fleet.HostMDMAppleProfile{
 				HostUUID:      "abc",
-				Identifier:    apple_mdm.FleetFileVaultPayloadIdentifier,
+				Identifier:    mobileconfig.FleetFileVaultPayloadIdentifier,
 				Status:        &fleet.MDMAppleDeliveryPending,
 				OperationType: fleet.MDMAppleOperationTypeInstall,
 			},
@@ -190,7 +191,7 @@ func TestHostDetailsMDMDiskEncryption(t *testing.T) {
 			ptr.Int(-1),
 			&fleet.HostMDMAppleProfile{
 				HostUUID:      "abc",
-				Identifier:    apple_mdm.FleetFileVaultPayloadIdentifier,
+				Identifier:    mobileconfig.FleetFileVaultPayloadIdentifier,
 				Status:        &fleet.MDMAppleDeliveryPending,
 				OperationType: fleet.MDMAppleOperationTypeInstall,
 			},
@@ -202,7 +203,7 @@ func TestHostDetailsMDMDiskEncryption(t *testing.T) {
 			ptr.Int(-1),
 			&fleet.HostMDMAppleProfile{
 				HostUUID:      "abc",
-				Identifier:    apple_mdm.FleetFileVaultPayloadIdentifier,
+				Identifier:    mobileconfig.FleetFileVaultPayloadIdentifier,
 				Status:        &fleet.MDMAppleDeliveryFailed,
 				OperationType: fleet.MDMAppleOperationTypeInstall,
 			},
@@ -214,7 +215,7 @@ func TestHostDetailsMDMDiskEncryption(t *testing.T) {
 			ptr.Int(0),
 			&fleet.HostMDMAppleProfile{
 				HostUUID:      "abc",
-				Identifier:    apple_mdm.FleetFileVaultPayloadIdentifier,
+				Identifier:    mobileconfig.FleetFileVaultPayloadIdentifier,
 				Status:        &fleet.MDMAppleDeliveryFailed,
 				OperationType: fleet.MDMAppleOperationTypeInstall,
 			},
@@ -226,7 +227,7 @@ func TestHostDetailsMDMDiskEncryption(t *testing.T) {
 			ptr.Int(1),
 			&fleet.HostMDMAppleProfile{
 				HostUUID:      "abc",
-				Identifier:    apple_mdm.FleetFileVaultPayloadIdentifier,
+				Identifier:    mobileconfig.FleetFileVaultPayloadIdentifier,
 				Status:        &fleet.MDMAppleDeliveryPending,
 				OperationType: fleet.MDMAppleOperationTypeRemove,
 			},
@@ -238,7 +239,7 @@ func TestHostDetailsMDMDiskEncryption(t *testing.T) {
 			ptr.Int(-1),
 			&fleet.HostMDMAppleProfile{
 				HostUUID:      "abc",
-				Identifier:    apple_mdm.FleetFileVaultPayloadIdentifier,
+				Identifier:    mobileconfig.FleetFileVaultPayloadIdentifier,
 				Status:        &fleet.MDMAppleDeliveryPending,
 				OperationType: fleet.MDMAppleOperationTypeRemove,
 			},
@@ -250,7 +251,7 @@ func TestHostDetailsMDMDiskEncryption(t *testing.T) {
 			nil,
 			&fleet.HostMDMAppleProfile{
 				HostUUID:      "abc",
-				Identifier:    apple_mdm.FleetFileVaultPayloadIdentifier,
+				Identifier:    mobileconfig.FleetFileVaultPayloadIdentifier,
 				Status:        &fleet.MDMAppleDeliveryFailed,
 				OperationType: fleet.MDMAppleOperationTypeRemove,
 			},
@@ -262,7 +263,7 @@ func TestHostDetailsMDMDiskEncryption(t *testing.T) {
 			ptr.Int(0),
 			&fleet.HostMDMAppleProfile{
 				HostUUID:      "abc",
-				Identifier:    apple_mdm.FleetFileVaultPayloadIdentifier,
+				Identifier:    mobileconfig.FleetFileVaultPayloadIdentifier,
 				Status:        &fleet.MDMAppleDeliveryApplied,
 				OperationType: fleet.MDMAppleOperationTypeRemove,
 			},

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -1444,6 +1444,13 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 	errMsg := extractServerErrorText(res.Body)
 	assert.Contains(t, errMsg, `invalid value type at 'macos_settings.enable_disk_encryption': expected bool but got float64`)
 
+	// apply an empty set of batch profiles to the team
+	s.Do("POST", "/api/v1/fleet/mdm/apple/profiles/batch", batchSetMDMAppleProfilesRequest{Profiles: nil},
+		http.StatusUnprocessableEntity, "team_id", strconv.Itoa(int(team.ID)), "team_name", team.Name)
+
+	// the configuration profile is still there
+	s.assertConfigProfilesByIdentifier(ptr.Uint(team.ID), apple_mdm.FleetFileVaultPayloadIdentifier, true)
+
 	// apply without disk encryption settings specified and unrelated field,
 	// should not replace existing disk encryption
 	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{


### PR DESCRIPTION
related to https://github.com/fleetdm/fleet/issues/10547, https://github.com/fleetdm/fleet/issues/10549, https://github.com/fleetdm/fleet/issues/10550 and https://github.com/fleetdm/fleet/issues/10552 this prevents user interaction with fleet-managed profiles, including:

- batch actions
- individual POST/UPDATE/DELETE actions
- listing

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
