### PR TITLE
Fleet UI: Disk Encryption settings update across control tabs

### DIFF
--- a/frontend/pages/ManageControlsPage/MacOSSettings/MacOSSettings.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/MacOSSettings.tsx
@@ -1,10 +1,14 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Params } from "react-router/lib/Router";
 
+import { AppContext } from "context/app";
 import SideNav from "pages/admin/components/SideNav";
 import { useQuery } from "react-query";
 import { IMdmProfile, IMdmProfilesResponse } from "interfaces/mdm";
+import { IConfig } from "interfaces/config";
+
 import mdmAPI from "services/entities/mdm";
+import configAPI from "services/entities/config";
 
 import MAC_OS_SETTINGS_NAV_ITEMS from "./MacOSSettingsNavItems";
 import AggregateMacSettingsIndicators from "./AggregateMacSettingsIndicators/AggregateMacSettingsIndicators";
@@ -26,7 +30,9 @@ const MacOSSettings = ({ params, location }: IMacOSSettingsProps) => {
   // Avoids possible case where Number(undefined) returns NaN
   const teamId = team_id === undefined ? 0 : Number(team_id); // team_id===0 for 'No teams'
 
-  const { data: profiles, refetch: refectchProfiles } = useQuery<
+  const { setConfig } = useContext(AppContext);
+
+  const { data: profiles, refetch: refetchProfiles } = useQuery<
     IMdmProfilesResponse,
     unknown,
     IMdmProfile[] | null
@@ -34,6 +40,18 @@ const MacOSSettings = ({ params, location }: IMacOSSettingsProps) => {
     select: (data) => data.profiles,
     refetchOnWindowFocus: false,
   });
+
+  const { data: config, refetch: refetchConfig } = useQuery<IConfig, Error>(
+    ["config"],
+    () => {
+      return configAPI.loadAll();
+    },
+    {
+      onSuccess: (data) => {
+        setConfig(data);
+      },
+    }
+  );
 
   const DEFAULT_SETTINGS_SECTION = MAC_OS_SETTINGS_NAV_ITEMS[0];
 
@@ -58,8 +76,9 @@ const MacOSSettings = ({ params, location }: IMacOSSettingsProps) => {
             key={team_id}
             currentTeamId={teamId}
             profiles={profiles}
-            onProfileUpload={refectchProfiles}
-            onProfileDelete={refectchProfiles}
+            refetchProfiles={refetchProfiles}
+            config={config}
+            refetchConfig={refetchConfig}
           />
         }
       />

--- a/frontend/pages/ManageControlsPage/MacOSSettings/MacOSSettings.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/MacOSSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { Params } from "react-router/lib/Router";
 
 import { AppContext } from "context/app";
@@ -32,12 +32,17 @@ const MacOSSettings = ({ params, location }: IMacOSSettingsProps) => {
 
   const { setConfig } = useContext(AppContext);
 
-  const { data: profiles, refetch: refetchProfiles } = useQuery<
+  const [profiles, setProfiles] = useState<IMdmProfile[] | null>();
+
+  const { data: mdmProfiles, refetch: refetchProfiles } = useQuery<
     IMdmProfilesResponse,
     unknown,
     IMdmProfile[] | null
   >(["profiles", teamId], () => mdmAPI.getProfiles(teamId), {
     select: (data) => data.profiles,
+    onSuccess: (data) => {
+      setProfiles(data);
+    },
     refetchOnWindowFocus: false,
   });
 

--- a/frontend/pages/ManageControlsPage/MacOSSettings/MacOSSettingsNavItems.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/MacOSSettingsNavItems.tsx
@@ -1,6 +1,7 @@
 import PATHS from "router/paths";
 import { ISideNavItem } from "pages/admin/components/SideNav/SideNav";
 import { IMdmProfile } from "interfaces/mdm";
+import { IConfig } from "interfaces/config";
 
 import DiskEncryption from "./cards/DiskEncryption";
 import CustomSettings from "./cards/CustomSettings";
@@ -8,8 +9,9 @@ import CustomSettings from "./cards/CustomSettings";
 interface IMacOSSettingsCardProps {
   currentTeamId?: number;
   profiles?: IMdmProfile[];
-  onProfileUpload?: () => void;
-  onProfileDelete?: () => void;
+  refetchProfiles?: () => void;
+  config: IConfig;
+  refetchConfig?: () => void;
 }
 
 // TODO: types

--- a/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/CustomSettings.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/CustomSettings.tsx
@@ -25,6 +25,11 @@ interface ICustomSettingsProps {
   refetchConfig: () => void;
 }
 
+interface IDeleteProfileProps {
+  profileId: number;
+  profileName: string;
+}
+
 const CustomSettings = ({
   profiles,
   refetchProfiles,
@@ -78,12 +83,19 @@ const CustomSettings = ({
     setShowDeleteProfileModal(false);
   };
 
-  const onDeleteProfile = async (profileId: number) => {
+  const onDeleteProfile = async ({
+    profileId,
+    profileName,
+  }: IDeleteProfileProps) => {
     try {
-      await mdmAPI.deleteProfile(profileId);
-      refetchProfiles();
-      refetchConfig();
-      renderFlash("success", "Successfully deleted!");
+      profileName === "Disk encryption"
+        ? mdmAPI.updateAppleMdmSettings(false, currentTeam?.id || 0)
+        : mdmAPI.deleteProfile(profileId);
+      const timer = setTimeout(() => {
+        renderFlash("success", "Successfully deleted!");
+        refetchProfiles();
+        refetchConfig();
+      }, 1000);
     } catch (e) {
       renderFlash("error", "Couldn’t delete. Please try again.");
     } finally {
@@ -91,6 +103,7 @@ const CustomSettings = ({
       setShowDeleteProfileModal(false);
     }
   };
+  console.log("profiles", profiles);
 
   return (
     <div className={baseClass}>

--- a/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/CustomSettings.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/CustomSettings.tsx
@@ -103,7 +103,6 @@ const CustomSettings = ({
       setShowDeleteProfileModal(false);
     }
   };
-  console.log("profiles", profiles);
 
   return (
     <div className={baseClass}>

--- a/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/CustomSettings.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/CustomSettings.tsx
@@ -21,14 +21,14 @@ const baseClass = "custom-settings";
 
 interface ICustomSettingsProps {
   profiles: IMdmProfile[];
-  onProfileUpload: () => void;
-  onProfileDelete: () => void;
+  refetchProfiles: () => void;
+  refetchConfig: () => void;
 }
 
 const CustomSettings = ({
   profiles,
-  onProfileUpload,
-  onProfileDelete,
+  refetchProfiles,
+  refetchConfig,
 }: ICustomSettingsProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const { currentTeam } = useContext(AppContext);
@@ -61,7 +61,8 @@ const CustomSettings = ({
 
     try {
       await mdmAPI.uploadProfile(file, currentTeam?.id);
-      onProfileUpload();
+      refetchProfiles();
+      refetchConfig();
       renderFlash("success", "Successfully uploaded!");
     } catch (e) {
       const error = e as AxiosResponse<IApiError>;
@@ -80,7 +81,8 @@ const CustomSettings = ({
   const onDeleteProfile = async (profileId: number) => {
     try {
       await mdmAPI.deleteProfile(profileId);
-      onProfileDelete();
+      refetchProfiles();
+      refetchConfig();
       renderFlash("success", "Successfully deleted!");
     } catch (e) {
       renderFlash("error", "Couldn’t delete. Please try again.");

--- a/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/components/DeleteProfileModal/DeleteProfileModal.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/components/DeleteProfileModal/DeleteProfileModal.tsx
@@ -5,11 +5,16 @@ import { AppContext } from "context/app";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 
+interface IDeleteProfileProps {
+  profileId: number;
+  profileName: string;
+}
+
 interface DeleteProfileModalProps {
   profileName: string;
   profileId: number;
   onCancel: () => void;
-  onDelete: (profileId: number) => void;
+  onDelete: ({ profileId, profileName }: IDeleteProfileProps) => void;
 }
 
 const baseClass = "delete-profile-modal";
@@ -36,7 +41,7 @@ const DeleteProfileModal = ({
       className={baseClass}
       title={"Delete configuration profile"}
       onExit={onCancel}
-      onEnter={() => onDelete(profileId)}
+      onEnter={() => onDelete({ profileId, profileName })}
     >
       <>
         <p>
@@ -47,7 +52,7 @@ const DeleteProfileModal = ({
         <div className="modal-cta-wrap">
           <Button
             type="button"
-            onClick={() => onDelete(profileId)}
+            onClick={() => onDelete({ profileId, profileName })}
             variant="alert"
             className="delete-loading"
           >

--- a/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/components/DeleteProfileModal/DeleteProfileModal.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/components/DeleteProfileModal/DeleteProfileModal.tsx
@@ -18,7 +18,7 @@ const generateMessageSuffix = (isPremiumTier?: boolean, teamId?: number) => {
   if (!isPremiumTier) {
     return "";
   }
-  return teamId ? " assigned to this team" : " with no team";
+  return teamId ? "assigned to this team" : "with no team";
 };
 
 const DeleteProfileModal = ({
@@ -42,7 +42,7 @@ const DeleteProfileModal = ({
         <p>
           This action will delete configuration profile{" "}
           <span className={`${baseClass}__profile-name`}>{profileName}</span>{" "}
-          from all macOS hosts{messageSuffix}.
+          from all macOS hosts {messageSuffix}.
         </p>
         <div className="modal-cta-wrap">
           <Button

--- a/frontend/pages/ManageControlsPage/MacOSSettings/cards/DiskEncryption/DiskEncryption.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/cards/DiskEncryption/DiskEncryption.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "react-query";
 import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import { ITeamConfig } from "interfaces/team";
+import { IConfig } from "interfaces/config";
 import mdmAPI from "services/entities/mdm";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
 
@@ -17,10 +18,18 @@ import DiskEncryptionTable from "./components/DiskEncryptionTable";
 const baseClass = "disk-encryption";
 interface IDiskEncryptionProps {
   currentTeamId?: number;
+  config: IConfig;
+  refetchProfiles: () => void;
+  refetchConfig: () => void;
 }
 
-const DiskEncryption = ({ currentTeamId }: IDiskEncryptionProps) => {
-  const { isPremiumTier, config } = useContext(AppContext);
+const DiskEncryption = ({
+  currentTeamId,
+  refetchProfiles,
+  refetchConfig,
+  config,
+}: IDiskEncryptionProps) => {
+  const { isPremiumTier } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 
   const defaultShowDiskEncryption = currentTeamId
@@ -29,7 +38,7 @@ const DiskEncryption = ({ currentTeamId }: IDiskEncryptionProps) => {
 
   const [showAggregate, setShowAggregate] = useState(defaultShowDiskEncryption);
   const [diskEncryptionEnabled, setDiskEncryptionEnabled] = useState(
-    defaultShowDiskEncryption
+    config?.mdm.macos_settings.enable_disk_encryption
   );
 
   const onToggleCheckbox = (value: boolean) => {
@@ -61,6 +70,8 @@ const DiskEncryption = ({ currentTeamId }: IDiskEncryptionProps) => {
         "Successfully updated disk encryption key storage setting."
       );
       setShowAggregate(diskEncryptionEnabled);
+      refetchProfiles();
+      refetchConfig();
     } catch {
       console.error("error updating");
       renderFlash(

--- a/frontend/pages/ManageControlsPage/MacOSSettings/cards/DiskEncryption/DiskEncryption.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/cards/DiskEncryption/DiskEncryption.tsx
@@ -46,22 +46,22 @@ const DiskEncryption = ({
     setDiskEncryptionEnabled(value);
   };
 
-  const { isLoading: isLoadingTeam } = useQuery<
-    ILoadTeamResponse,
-    Error,
-    ITeamConfig
-  >(["team", currentTeamId], () => teamsAPI.load(currentTeamId ?? 0), {
-    refetchOnWindowFocus: false,
-    retry: false,
-    enabled: Boolean(currentTeamId),
-    select: (res) => res.team,
-    onSuccess: (res) => {
-      const enableDiskEncryption =
-        res.mdm?.macos_settings.enable_disk_encryption ?? false;
-      setDiskEncryptionEnabled(enableDiskEncryption);
-      setShowAggregate(enableDiskEncryption);
-    },
-  });
+  useQuery<ILoadTeamResponse, Error, ITeamConfig>(
+    ["team", currentTeamId],
+    () => teamsAPI.load(currentTeamId ?? 0),
+    {
+      refetchOnWindowFocus: false,
+      retry: false,
+      enabled: Boolean(currentTeamId),
+      select: (res) => res.team,
+      onSuccess: (res) => {
+        const enableDiskEncryption =
+          res.mdm?.macos_settings.enable_disk_encryption ?? false;
+        setDiskEncryptionEnabled(enableDiskEncryption);
+        setShowAggregate(enableDiskEncryption);
+      },
+    }
+  );
 
   const onUpdateDiskEncryption = async () => {
     try {
@@ -81,10 +81,6 @@ const DiskEncryption = ({
       );
     }
   };
-
-  if (isLoadingTeam) {
-    return <Spinner />;
-  }
 
   return (
     <div className={baseClass}>

--- a/frontend/pages/ManageControlsPage/MacOSSettings/cards/DiskEncryption/DiskEncryption.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/cards/DiskEncryption/DiskEncryption.tsx
@@ -8,6 +8,7 @@ import { IConfig } from "interfaces/config";
 import mdmAPI from "services/entities/mdm";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
 
+import Spinner from "components/Spinner";
 import Button from "components/buttons/Button";
 import CustomLink from "components/CustomLink";
 import Checkbox from "components/forms/fields/Checkbox";
@@ -38,29 +39,29 @@ const DiskEncryption = ({
 
   const [showAggregate, setShowAggregate] = useState(defaultShowDiskEncryption);
   const [diskEncryptionEnabled, setDiskEncryptionEnabled] = useState(
-    config?.mdm.macos_settings.enable_disk_encryption
+    defaultShowDiskEncryption
   );
 
   const onToggleCheckbox = (value: boolean) => {
     setDiskEncryptionEnabled(value);
   };
 
-  useQuery<ILoadTeamResponse, Error, ITeamConfig>(
-    ["team", currentTeamId],
-    () => teamsAPI.load(currentTeamId ?? 0),
-    {
-      refetchOnWindowFocus: false,
-      retry: false,
-      enabled: Boolean(currentTeamId),
-      select: (res) => res.team,
-      onSuccess: (res) => {
-        const enableDiskEncryption =
-          res.mdm?.macos_settings.enable_disk_encryption ?? false;
-        setDiskEncryptionEnabled(enableDiskEncryption);
-        setShowAggregate(enableDiskEncryption);
-      },
-    }
-  );
+  const { isLoading: isLoadingTeam } = useQuery<
+    ILoadTeamResponse,
+    Error,
+    ITeamConfig
+  >(["team", currentTeamId], () => teamsAPI.load(currentTeamId ?? 0), {
+    refetchOnWindowFocus: false,
+    retry: false,
+    enabled: Boolean(currentTeamId),
+    select: (res) => res.team,
+    onSuccess: (res) => {
+      const enableDiskEncryption =
+        res.mdm?.macos_settings.enable_disk_encryption ?? false;
+      setDiskEncryptionEnabled(enableDiskEncryption);
+      setShowAggregate(enableDiskEncryption);
+    },
+  });
 
   const onUpdateDiskEncryption = async () => {
     try {
@@ -80,6 +81,10 @@ const DiskEncryption = ({
       );
     }
   };
+
+  if (isLoadingTeam) {
+    return <Spinner />;
+  }
 
   return (
     <div className={baseClass}>


### PR DESCRIPTION
## Issue
Cerra #10550 
Cerra #10549 

## Description
- Disk encryption updated between two tabs of MacOS settings
- Note: For some reason it's not updating automatically, I think it's from the backend bug that it's failing the first try, I added a workaround 1 second wait that did the trick in the meantime

## Screen recording

https://user-images.githubusercontent.com/71795832/225981494-e953a2de-a7bc-4381-8535-5a4252d4f50f.mov

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

