### PR TITLE
UI: Make label same size as button to widen click functionality; handle missed edge case

### DIFF
--- a/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/CustomSettings.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/CustomSettings.tsx
@@ -48,7 +48,10 @@ const CustomSettings = ({
 
     console.log("On upload: ", files);
 
-    if (!files || files.length === 0) return;
+    if (!files || files.length === 0) {
+      setShowLoading(false);
+      return;
+    }
 
     const file = files[0];
 

--- a/frontend/pages/ManageControlsPage/components/FileUploader/FileUploader.tsx
+++ b/frontend/pages/ManageControlsPage/components/FileUploader/FileUploader.tsx
@@ -23,7 +23,7 @@ const FileUploader = ({
     <div className={baseClass}>
       <Icon name={icon} />
       <p>{message}</p>
-      <Button isLoading={isLoading}>
+      <Button variant="brand" isLoading={isLoading}>
         <label htmlFor="upload-profile">Upload</label>
       </Button>
       <input

--- a/frontend/pages/ManageControlsPage/components/FileUploader/_styles.scss
+++ b/frontend/pages/ManageControlsPage/components/FileUploader/_styles.scss
@@ -13,7 +13,19 @@
   input {
     display: none;
   }
-  label:hover {
-    cursor: pointer;
+  .button {
+    padding: 0;
+  }
+
+  label {
+    height: 36px;
+    width: 78.2667px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover {
+      cursor: pointer;
+    }
   }
 }


### PR DESCRIPTION
## Addresses #10302 

## Implements

https://user-images.githubusercontent.com/61553566/226065248-31c10f0a-7608-47d7-941f-b7d03d5e5dc5.mov


Allows the user to click anywhere on the upload button in Controls > macOS settings > custom settings and successfully open the upload profile file browser. 

Unset loading state in one uncovered edge case

- [x] Manual QA for all new/changed functionality