### PR TITLE
Only use gravatar fallback if explicitly set to false

### DIFF
--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -53,7 +53,7 @@ const ADMIN_ATTRS = ["email", "name", "password", "password_confirmation"];
 export const addGravatarUrlToResource = (resource: any): any => {
   const { email } = resource;
   const gravatarAvailable =
-    localStorage.getItem("gravatar_available") === "true";
+    localStorage.getItem("gravatar_available") !== "false"; // Only fallback if explicitly set to "false"
 
   const emailHash = md5(email.toLowerCase());
 


### PR DESCRIPTION
I realized the current logic is such that anyone logged in when the upgrade is made would use gravatar fallbacks. Instead, only fallback if the localStorage is explicitly set to "false". 