### PR TITLE
Testing MDM: Disable OS downloads

### DIFF
--- a/mdm_profiles/automatic_updates.mobileconfig
+++ b/mdm_profiles/automatic_updates.mobileconfig
@@ -8,9 +8,9 @@
 			<key>AllowPreReleaseInstallation</key>
 			<true/>
 			<key>AutomaticCheckEnabled</key>
-			<true/>
+			<false/>
 			<key>AutomaticDownload</key>
-			<true/>
+			<false/>
 			<key>AutomaticallyInstallAppUpdates</key>
 			<true/>
 			<key>AutomaticallyInstallMacOSUpdates</key>


### PR DESCRIPTION
Testing re-applying profiles to determine if the bug during the sprint demo is fixed. 