### PR TITLE
MDM profile: Re-enable software automatic downloads

### DIFF
--- a/mdm_profiles/automatic_updates.mobileconfig
+++ b/mdm_profiles/automatic_updates.mobileconfig
@@ -8,9 +8,9 @@
 			<key>AllowPreReleaseInstallation</key>
 			<true/>
 			<key>AutomaticCheckEnabled</key>
-			<false/>
+			<true/>
 			<key>AutomaticDownload</key>
-			<false/>
+			<true/>
 			<key>AutomaticallyInstallAppUpdates</key>
 			<true/>
 			<key>AutomaticallyInstallMacOSUpdates</key>


### PR DESCRIPTION
This was disabled for testing. Re-enabling. 