### PR TITLE
account for currently unsupported user enrollments

### DIFF
--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -949,7 +949,7 @@ func (ds *Datastore) ListMDMAppleProfilesToInstall(ctx context.Context) ([]*flee
             FROM mdm_apple_configuration_profiles macp
             JOIN hosts h ON h.team_id = macp.team_id OR (h.team_id IS NULL AND macp.team_id = 0)
             JOIN nano_enrollments ne ON ne.device_id = h.uuid
-            WHERE h.platform = 'darwin' AND ne.enabled = 1
+            WHERE h.platform = 'darwin' AND ne.enabled = 1 AND ne.type = 'Device'
           ) as ds
           LEFT JOIN host_mdm_apple_profiles hmap
             ON hmap.profile_id = ds.profile_id AND hmap.host_uuid = ds.host_uuid
@@ -982,7 +982,7 @@ func (ds *Datastore) ListMDMAppleProfilesToRemove(ctx context.Context) ([]*fleet
             FROM mdm_apple_configuration_profiles macp
             JOIN hosts h ON h.team_id = macp.team_id OR (h.team_id IS NULL AND macp.team_id = 0)
             JOIN nano_enrollments ne ON ne.device_id = h.uuid
-            WHERE h.platform = 'darwin' AND ne.enabled = 1
+            WHERE h.platform = 'darwin' AND ne.enabled = 1 AND ne.type = 'Device'
           ) as ds
           RIGHT JOIN host_mdm_apple_profiles hmap
             ON hmap.profile_id = ds.profile_id AND hmap.host_uuid = ds.uuid

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -924,7 +924,8 @@ func testMDMAppleProfileManagement(t *testing.T, ds *Datastore) {
 		Platform:      "darwin",
 	})
 	require.NoError(t, err)
-	nanoEnroll(t, ds, host1)
+	// add a user enrollment for this device, nothing else should be modified
+	nanoEnroll(t, ds, host1, true)
 
 	// non-macOS hosts shouldn't modify any of the results below
 	_, err = ds.NewHost(ctx, &fleet.Host{
@@ -970,7 +971,7 @@ func testMDMAppleProfileManagement(t *testing.T, ds *Datastore) {
 		Platform:      "darwin",
 	})
 	require.NoError(t, err)
-	nanoEnroll(t, ds, host2)
+	nanoEnroll(t, ds, host2, false)
 
 	// still the same profiles to assign as there are no profiles for team 1
 	profiles, err = ds.ListMDMAppleProfilesToInstall(ctx)
@@ -1016,7 +1017,7 @@ func testMDMAppleProfileManagement(t *testing.T, ds *Datastore) {
 		Platform:      "darwin",
 	})
 	require.NoError(t, err)
-	nanoEnroll(t, ds, host3)
+	nanoEnroll(t, ds, host3, false)
 
 	// more profiles, this time for both global hosts and the team
 	profiles, err = ds.ListMDMAppleProfilesToInstall(ctx)
@@ -1241,7 +1242,7 @@ func createBuiltinLabels(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 }
 
-func nanoEnroll(t *testing.T, ds *Datastore, host *fleet.Host) {
+func nanoEnroll(t *testing.T, ds *Datastore, host *fleet.Host, withUser bool) {
 	_, err := ds.writer.Exec(`INSERT INTO nano_devices (id, authenticate) VALUES (?, 'test')`, host.UUID)
 	require.NoError(t, err)
 
@@ -1259,6 +1260,23 @@ VALUES
 		host.UUID,
 	)
 	require.NoError(t, err)
+
+	if withUser {
+		_, err = ds.writer.Exec(`
+INSERT INTO nano_enrollments
+	(id, device_id, user_id, type, topic, push_magic, token_hex)
+VALUES
+	(?, ?, ?, ?, ?, ?, ?)`,
+			host.UUID+":Device",
+			host.UUID,
+			nil,
+			"User",
+			host.UUID+".topic",
+			host.UUID+".magic",
+			host.UUID,
+		)
+		require.NoError(t, err)
+	}
 }
 
 func testMDMAppleHostsProfilesStatus(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
This modifies the query we use to list profiles to add/remove to account for (currently) unsupported User enrollments.

#10659

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality