### PR TITLE
ingest empty disk encryption keys

### DIFF
--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1316,16 +1316,8 @@ func directIngestDiskEncryptionKeyDarwin(
 		)
 	}
 
-	if strings.TrimSpace(rows[0]["filevault_key"]) == "" {
-		level.Debug(logger).Log(
-			"component", "service",
-			"method", "directIngestDiskEncryptionKeyDarwin",
-			"msg", "host reported empty /var/db/FileVaultPRK.dat contents",
-			"host", host.Hostname,
-		)
-		return nil
-	}
-
+	// it's okay if the key comes empty, this can happen and if the disk is
+	// encrypted it means we need to reset the encryption key
 	return ds.SetOrUpdateHostDiskEncryptionKey(ctx, host.ID, rows[0]["filevault_key"])
 }
 

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -875,8 +875,9 @@ func TestDirectIngestDiskEncryptionKeyDarwin(t *testing.T) {
 	logger := log.NewNopLogger()
 	wantKey := "OTM5ODRDQTYtOUY1Mi00NERELTkxOUEtMDlBN0ZBOUUzNUY5Cg=="
 	host := &fleet.Host{ID: 1}
+
 	ds.SetOrUpdateHostDiskEncryptionKeyFunc = func(ctx context.Context, hostID uint, encryptedBase64Key string) error {
-		require.Equal(t, wantKey, encryptedBase64Key)
+		require.Empty(t, encryptedBase64Key)
 		require.Equal(t, host.ID, hostID)
 		return nil
 	}
@@ -888,6 +889,13 @@ func TestDirectIngestDiskEncryptionKeyDarwin(t *testing.T) {
 	err = directIngestDiskEncryptionKeyDarwin(ctx, logger, host, ds, []map[string]string{{"filevault_key": ""}})
 	require.NoError(t, err)
 	require.True(t, ds.SetOrUpdateHostDiskEncryptionKeyFuncInvoked)
+	ds.SetOrUpdateHostDiskEncryptionKeyFuncInvoked = false
+
+	ds.SetOrUpdateHostDiskEncryptionKeyFunc = func(ctx context.Context, hostID uint, encryptedBase64Key string) error {
+		require.Equal(t, wantKey, encryptedBase64Key)
+		require.Equal(t, host.ID, hostID)
+		return nil
+	}
 
 	err = directIngestDiskEncryptionKeyDarwin(ctx, logger, host, ds, []map[string]string{{"filevault_key": wantKey}})
 	require.NoError(t, err)

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -887,7 +887,7 @@ func TestDirectIngestDiskEncryptionKeyDarwin(t *testing.T) {
 
 	err = directIngestDiskEncryptionKeyDarwin(ctx, logger, host, ds, []map[string]string{{"filevault_key": ""}})
 	require.NoError(t, err)
-	require.False(t, ds.SetOrUpdateHostDiskEncryptionKeyFuncInvoked)
+	require.True(t, ds.SetOrUpdateHostDiskEncryptionKeyFuncInvoked)
 
 	err = directIngestDiskEncryptionKeyDarwin(ctx, logger, host, ds, []map[string]string{{"filevault_key": wantKey}})
 	require.NoError(t, err)


### PR DESCRIPTION
this cover edge cases when the `/var/db/FileVaultPRK.dat` is not present, but the disk is still encrypted and thus we're not able to get the encryption key.


https://github.com/fleetdm/fleet/issues/10672

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
