### PR TITLE
UI: Ensure TextCell is always greyed when no value passed in

### DIFF
--- a/changes/10038-consistent-empty-cell-coloring
+++ b/changes/10038-consistent-empty-cell-coloring
@@ -1,0 +1,1 @@
+- Fixed a bug where some empty table cells were slightly different colors

--- a/frontend/components/TableContainer/DataTable/TextCell/TextCell.tsx
+++ b/frontend/components/TableContainer/DataTable/TextCell/TextCell.tsx
@@ -19,6 +19,9 @@ const TextCell = ({
   if (typeof value === "boolean") {
     val = value.toString();
   }
+  if (!val) {
+    greyed = true;
+  }
   return (
     <span className={`text-cell ${classes} ${greyed && "grey-cell"}`}>
       {formatter(val) || DEFAULT_EMPTY_CELL_VALUE}


### PR DESCRIPTION
# Addresses #10038 

- Add logic to ensure consistent light-grey coloring of text cells using DEFAULT_EMPTY_VALUE
<img width="622" alt="Screenshot 2023-03-22 at 4 06 30 PM" src="https://user-images.githubusercontent.com/61553566/227058308-2c35e0b3-7017-4a0d-9e60-d03d46194f55.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
