### PR TITLE
More robust version handling for macOS software

### DIFF
--- a/changes/macos-app-version
+++ b/changes/macos-app-version
@@ -1,0 +1,1 @@
+* Improve version detection for macOS apps. This fixes some false positives in macOS vulnerability detection.

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -607,7 +607,7 @@ var softwareMacOS = DetailQuery{
 	Query: withCachedUsers(`WITH cached_users AS (%s)
 SELECT
   name AS name,
-  bundle_short_version AS version,
+  COALESCE(NULLIF(bundle_short_version, ''), bundle_version) AS version,
   'Application (macOS)' AS type,
   bundle_identifier AS bundle_identifier,
   'apps' AS source,


### PR DESCRIPTION
This should get version numbers for more apps on macOS. Notably, 1Password includes helper apps that were getting vulnerability false positives because we were not picking up the versions.

Addresses #10702.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
