### PR TITLE
Fix terraform logging addon-module and apply to dogfood

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -53,7 +53,7 @@ module "main" {
   rds_config = {
     name                = local.customer
     snapshot_identifier = "arn:aws:rds:us-east-2:611884880216:cluster-snapshot:a2023-03-06-pre-migration"
-    db_parameters       = {
+    db_parameters = {
       # 8mb up from 262144 (256k) default
       sort_buffer_size = 8388608
     }
@@ -89,12 +89,11 @@ module "main" {
   }
   alb_config = {
     name = local.customer
-    # TODO: This is broken, idk why
-    #access_logs = {
-    #  bucket  = module.logging_alb.log_s3_bucket_id
-    #  prefix  = local.customer
-    #  enabled = true
-    #}
+    access_logs = {
+      bucket  = module.logging_alb.log_s3_bucket_id
+      prefix  = local.customer
+      enabled = true
+    }
     allowed_cidrs = [
       "128.0.0.0/1",
       "64.0.0.0/2",

--- a/terraform/addons/logging-alb/main.tf
+++ b/terraform/addons/logging-alb/main.tf
@@ -8,13 +8,13 @@ data "aws_iam_policy_document" "kms" {
     principals {
       type        = "AWS"
       identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
-    } 
+    }
     resources = ["*"]
-  } 
+  }
   statement {
-    actions = [ 
+    actions = [
       "kms:Encrypt*",
-      "kms:Decrypt*",     
+      "kms:Decrypt*",
       "kms:ReEncrypt*",
       "kms:GenerateDataKey*",
       "kms:Describe*",
@@ -25,8 +25,8 @@ data "aws_iam_policy_document" "kms" {
       identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
     }
   }
-}   
-      
+}
+
 resource "aws_kms_key" "logs" {
   policy              = data.aws_iam_policy_document.kms.json
   enable_key_rotation = true
@@ -40,13 +40,13 @@ resource "aws_kms_alias" "logs_alias" {
 module "s3_bucket_for_logs" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "3.6.0"
-    
+
   bucket = "${var.prefix}-alb-logs"
   acl    = "log-delivery-write"
 
   # Allow deletion of non-empty bucket
-  force_destroy = true 
-    
+  force_destroy = true
+
   attach_elb_log_delivery_policy        = true # Required for ALB logs
   attach_lb_log_delivery_policy         = true # Required for ALB/NLB logs
   attach_deny_insecure_transport_policy = true
@@ -56,18 +56,15 @@ module "s3_bucket_for_logs" {
   ignore_public_acls                    = true
   restrict_public_buckets               = true
   server_side_encryption_configuration = {
-    rule = {        
-      apply_server_side_encryption_by_default = {
-        kms_master_key_id = aws_kms_key.logs.arn
-        sse_algorithm     = "aws:kms"
-      }
+    rule = {
+       bucket_key_enabled = true
     }
-  } 
+  }
   lifecycle_rule = [
     {
       id      = "log"
       enabled = true
-  
+
       transition = [
         {
           days          = var.s3_transition_days


### PR DESCRIPTION
This is the minimum change to the logging module to get things to work.  The athena bucket still uses KMS keys, but that might be a bit dubious since we have to use SSE for the logs bucket itself in order for it to function.  We would technically purge KMS from the logging module completely and use SSE for both buckets.

I will leave the decision for that up to the discussion/review below.