### PR TITLE
Website: Update generated subtopics in Markdown content

### DIFF
--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -120,7 +120,7 @@ parasails.registerPage('basic-documentation', {
       let subtopics = $('#body-content').find('h2.markdown-heading').map((_, el) => el.innerText);
       subtopics = $.makeArray(subtopics).map((title) => {
         // Removing all apostrophes from the title to keep  _.kebabCase() from turning words like 'user’s' into 'user-s'
-        let kebabCaseFriendlyTitle = title.replace(/[\’]/g, '');
+        let kebabCaseFriendlyTitle = title.replace(/[\’\']/g, '');
         return {
           title,
           url: '#' + _.kebabCase(kebabCaseFriendlyTitle.toLowerCase()),

--- a/website/assets/js/pages/handbook/basic-handbook.page.js
+++ b/website/assets/js/pages/handbook/basic-handbook.page.js
@@ -83,7 +83,7 @@ parasails.registerPage('basic-handbook', {
       }
       subtopics = $.makeArray(subtopics).map((title) => {
         // Removing all apostrophes from the title to keep  _.kebabCase() from turning words like 'user’s' into 'user-s'
-        let kebabCaseFriendlyTitle = title.replace(/[\’]/g, '');
+        let kebabCaseFriendlyTitle = title.replace(/[\’\']/g, '');
         return {
           title: title.replace(/([\uE000-\uF8FF]|\uD83C[\uDF00-\uDFFF]|\uD83D[\uDC00-\uDDFF])/g, ''), // take out any emojis (they look weird in the menu)
           url: '#' + _.kebabCase(kebabCaseFriendlyTitle.toLowerCase()),


### PR DESCRIPTION
https://fleetdm.slack.com/archives/C01EZVBHFHU/p1679598174642469

Changes:
- Updated the handbook and documentation pages page script to strip `'` characters from subtopic IDs before they're converted to kebab case.
