### PR TITLE
Update docs for enabling SSO for an existing user to match the actual UI

### DIFF
--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -3059,7 +3059,11 @@ configuration problems.
 > Individual users must also be set up on the IDP before signing in to Fleet.
 
 ### Enabling SSO for existing users in Fleet
-As an admin, you can enable SSO for existing users in Fleet. To do this, go to the Settings page, then click on the Users tab. Locate the user you want to enable SSO for and on the Actions dropdown menu for that user, click on "Enable single sign-on."
+As an admin, you can enable SSO for existing users in Fleet. To do this, go to the Settings page,
+then click on the Users tab. Locate the user you want to enable SSO for, and in the Actions dropdown
+menu for that user, click on "Edit." In the dialogue that opens, check the box labeled "Enable
+single sign-on," then click "Save." If you are unable to check that box, you must first [configure
+and enable SSO for the organization](https://fleetdm.com/docs/deploying/configuration#configuring-single-sign-on-sso).
 
 ### Just-in-time (JIT) user provisioning
 


### PR DESCRIPTION
The docs do not currently match the UI – this change brings the docs and UI into agreement.

Relevant UI:
<img width="945" alt="Screenshot 2023-03-23 at 3 43 07 PM" src="https://user-images.githubusercontent.com/61553566/227383100-aeaea0bb-e740-4b04-aedb-1b2f81d0fa41.png">

