### PR TITLE
Configuration docs: Update MDM section

### DIFF
--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -2605,6 +2605,10 @@ packaging:
 
 > MDM features require some endpoints to be publicly accessible outside your VPN or intranet, for more details see [What API endpoints should I expose to the public internet?](./FAQ.md#what-api-endpoints-should-i-expose-to-the-public-internet)
 
+This section is a reference for the configuration required to turn on MDM features in production.
+
+If you're a Fleet contributor and you'd like to turn on MDM features in a local environment, see the guided instructions [here](../Contributing/Testing-and-local-development.md#mdm-setup-and-testing).
+
 ##### mdm.apple_enable
 
 This is the second feature flag required to turn on MDM features. This environment variable flag must be set to `1` (or `true` in the `yaml`) at the same time as when you set the certificate and keys for Apple Push Certificate server (APNs) and Apple Business Manager (ABM). Otherwise, the Fleet server won't start.
@@ -2617,21 +2621,9 @@ This is the second feature flag required to turn on MDM features. This environme
     apple_enable: true
   ```
 
-##### mdm.apple_apns_cert
-
-This is the path to the Apple Push Notification service (APNs) certificate downloaded from [Apple Push Certificates Portal](https://identity.apple.com). See how to download the certificate [here](../Using-Fleet/MDM-setup.md#apple-push-notification-service-apns). Only one of `apple_apns_cert` and `apple_apns_cert_bytes` can be set.
-
-- Default value: ""
-- Environment variable: `FLEET_MDM_APPLE_APNS_CERT`
-- Config file format:
-  ```
-  mdm:
-    apple_apns_cert: /path/to/apns_cert.pem
-  ```
-
 ##### mdm.apple_apns_cert_bytes
 
-The content of the Apple Push Notification service (APNs) certificate. An X.509 certificate, PEM-encoded. Typically generated via `fleetctl generate mdm-apple`. Only one of `apple_apns_cert` and `apple_apns_cert_bytes` can be set.
+The content of the Apple Push Notification service (APNs) certificate. An X.509 certificate, PEM-encoded. Typically generated via `fleetctl generate mdm-apple`.
 
 - Default value: ""
 - Environment variable: `FLEET_MDM_APPLE_APNS_CERT_BYTES`
@@ -2644,21 +2636,9 @@ The content of the Apple Push Notification service (APNs) certificate. An X.509 
       -----END CERTIFICATE-----
   ```
 
-##### mdm.apple_apns_key
-
-This is the path to a PEM-encoded private key for the Apple Push Notification service (APNs). It's typically generated via `fleetctl generate mdm-apple`. Only one of `apple_apns_key` and `apple_apns_key_bytes` can be set.
-
-- Default value: ""
-- Environment variable: `FLEET_MDM_APPLE_APNS_KEY`
-- Config file format:
-  ```
-  mdm:
-    apple_apns_key: /path/to/fleet-mdm-apple-apns.key
-  ```
-
 ##### mdm.apple_apns_key_bytes
 
-The content of the PEM-encoded private key for the Apple Push Notification service (APNs). Typically generated via `fleetctl generate mdm-apple`. Only one of `apple_apns_key` and `apple_apns_key_bytes` can be set.
+The content of the PEM-encoded private key for the Apple Push Notification service (APNs). Typically generated via `fleetctl generate mdm-apple`.
 
 - Default value: ""
 - Environment variable: `FLEET_MDM_APPLE_APNS_KEY_BYTES`
@@ -2671,21 +2651,9 @@ The content of the PEM-encoded private key for the Apple Push Notification servi
       -----END RSA PRIVATE KEY-----
   ```
 
-##### mdm.apple_scep_cert
-
-This is the path to the Simple Certificate Enrollment Protocol (SCEP) certificate.  The SCEP certificate is a PEM-encoded X.509 certificate that's typically generated via `fleetctl generate mdm-apple`. Only one of `apple_scep_cert` and `apple_scep_cert_bytes` can be set.
-
-- Default value: ""
-- Environment variable: `FLEET_MDM_APPLE_SCEP_CERT`
-- Config file format:
-  ```
-  mdm:
-    apple_scep_cert: /path/to/fleet-mdm-apple-scep.crt
-  ```
-
 ##### mdm.apple_scep_cert_bytes
 
-The content of the Simple Certificate Enrollment Protocol (SCEP) certificate. An X.509 certificate, PEM-encoded. Typically generated via `fleetctl generate mdm-apple`. Only one of `apple_scep_cert` and `apple_scep_cert_bytes` can be set.
+The content of the Simple Certificate Enrollment Protocol (SCEP) certificate. An X.509 certificate, PEM-encoded. Typically generated via `fleetctl generate mdm-apple`.
 
 - Default value: ""
 - Environment variable: `FLEET_MDM_APPLE_SCEP_CERT_BYTES`
@@ -2698,21 +2666,9 @@ The content of the Simple Certificate Enrollment Protocol (SCEP) certificate. An
       -----END CERTIFICATE-----
   ```
 
-##### mdm.apple_scep_key
-
-This is the path to a PEM-encoded private key for the Simple Certificate Enrollment Protocol (SCEP). It's typically generated via `fleetctl generate mdm-apple`. Only one of `apple_scep_key` and `apple_scep_key_bytes` can be set.
-
-- Default value: ""
-- Environment variable: `FLEET_MDM_APPLE_SCEP_KEY`
-- Config file format:
-  ```
-  mdm:
-    apple_scep_key: /path/to/fleet-mdm-apple-scep.key
-  ```
-
 ##### mdm.apple_scep_key_bytes
 
-The content of the PEM-encoded private key for the Simple Certificate Enrollment Protocol (SCEP). Typically generated via `fleetctl generate mdm-apple`. Only one of `apple_scep_key` and `apple_scep_key_bytes` can be set.
+The content of the PEM-encoded private key for the Simple Certificate Enrollment Protocol (SCEP). Typically generated via `fleetctl generate mdm-apple`.
 
 - Default value: ""
 - Environment variable: `FLEET_MDM_APPLE_SCEP_KEY_BYTES`


### PR DESCRIPTION
- Remove MDM configuration options that accept non-bytes (filepaths) for certs/keys
  - Why? The configuration docs are a reference for production Fleet deployments. We observed that these options aren't normally used in production. We observed, during beta, that presenting users with bytes v. non-bytes options was confusing.
- Point Fleet contributors that want to turn on MDM locally to contributing docs. These docs include instructions for using config options that accept non-bytes.
