### PR TITLE
UI: Remove unused 'Issuer URI' field from UI

### DIFF
--- a/changes/10257-remove-issuer-uri
+++ b/changes/10257-remove-issuer-uri
@@ -1,0 +1,1 @@
+- Removed the unused "Issuer URI" field from the single sign-on configuration page of the UI

--- a/cypress/integration/all/app/settingsflow.spec.ts
+++ b/cypress/integration/all/app/settingsflow.spec.ts
@@ -183,10 +183,6 @@ describe("App settings flow", () => {
         .click({ force: true })
         .type("my entity id");
 
-      cy.findByLabelText(/issuer uri/i)
-        .click({ force: true })
-        .type("my issuer uri");
-
       cy.findByLabelText(/idp image url/i)
         .click()
         .type("https://http.cat/100");
@@ -215,8 +211,6 @@ describe("App settings flow", () => {
       );
 
       cy.findByLabelText(/entity id/i).should("have.value", "my entity id");
-
-      cy.findByLabelText(/issuer uri/i).should("have.value", "my issuer uri");
 
       cy.findByLabelText(/idp image url/i).should(
         "have.value",

--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -3035,8 +3035,6 @@ Otherwise, the following values are required:
 - _Entity ID_ - A URI that identifies your Fleet instance as the issuer of authorization
   requests (e.g., `fleet.example.com`). This must match the _Entity ID_ configured with the IDP.
 
-- _Issuer URI_ - Obtain this value from the IDP.
-
 - _Metadata URL_ - Obtain this value from the IDP and is used by Fleet to
   issue authorization requests to the IDP.
 
@@ -3173,16 +3171,15 @@ Follow these steps to configure Fleet SSO with Google Workspace. This will requi
 
   ![Adding a new app to Google workspace admin dashboard](https://raw.githubusercontent.com/fleetdm/fleet/main/docs/images/google-sso-configuration-step-2.png)
 
-3. Click _Download Metadata_, saving the metadata to your computer. Copy the _SSO URL_. Click _Continue_.
+3. Click _Download Metadata_, saving the metadata to your computer. Click _Continue_.
 
-  ![Download metadata and copy the SSO URL](https://raw.githubusercontent.com/fleetdm/fleet/main/docs/images/google-sso-configuration-step-3.png)
+  ![Download metadata](https://raw.githubusercontent.com/fleetdm/fleet/main/docs/images/google-sso-configuration-step-3.png)
 
 4. In Fleet, navigate to the _Organization Settings_ page. Configure the _SAML single sign-on options_ section.
 
   - Check the _Enable single sign-on_ checkbox.
   - For _Identity provider name_, use `Google`.
   - For _Entity ID_, use a unique identifier such as `fleet.example.com`. Note that Google seems to error when the provided ID includes `https://`.
-  - For _Issuer URI_, paste the _SSO URL_ copied from step three.
   - For _Metadata_, paste the contents of the downloaded metadata XML from step three.
   - All other fields can be left blank.
 

--- a/docs/Using-Fleet/configuration-files/README.md
+++ b/docs/Using-Fleet/configuration-files/README.md
@@ -776,18 +776,6 @@ A required human-friendly name for the identity provider that will provide singl
     idp_name: "SimpleSAML"
   ```
 
-##### sso_settings.issuer_uri
-
-The issuer URI supplied by the identity provider.
-
-- Optional setting (string)
-- Default value: ""
-- Config file format:
-  ```yaml
-  sso_settings:
-    issuer_uri: "https://example.com/saml2/sso-service"
-  ```
-
 ##### sso_settings.metadata
 
 Metadata (in XML format) provided by the identity provider.

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -28,7 +28,6 @@ export default PropTypes.shape({
   verify_sll_certs: PropTypes.bool,
   enable_start_tls: PropTypes.bool,
   entity_id: PropTypes.string,
-  issuer_uri: PropTypes.string,
   idp_image_url: PropTypes.string,
   metadata: PropTypes.string,
   metadata_url: PropTypes.string,
@@ -127,7 +126,6 @@ export interface IConfigFormData {
   smtpUsername: string;
   verifySslCerts: boolean;
   entityId: string;
-  issuerUri: string;
   idpImageUrl: string;
   metadata: string;
   metadataUrl: string;
@@ -180,7 +178,6 @@ export interface IConfig {
   };
   sso_settings: {
     entity_id: string;
-    issuer_uri: string;
     idp_image_url: string;
     metadata: string;
     metadata_url: string;

--- a/frontend/pages/admin/OrgSettingsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Sso/Sso.tsx
@@ -19,7 +19,6 @@ interface ISsoFormData {
   enableSso?: boolean;
   idpName?: string;
   entityId?: string;
-  issuerUri?: string;
   idpImageUrl?: string;
   metadata?: string;
   metadataUrl?: string;
@@ -37,7 +36,6 @@ const Sso = ({
     enableSso: appConfig.sso_settings.enable_sso ?? false,
     idpName: appConfig.sso_settings.idp_name ?? "",
     entityId: appConfig.sso_settings.entity_id ?? "",
-    issuerUri: appConfig.sso_settings.issuer_uri ?? "",
     idpImageUrl: appConfig.sso_settings.idp_image_url ?? "",
     metadata: appConfig.sso_settings.metadata ?? "",
     metadataUrl: appConfig.sso_settings.metadata_url ?? "",
@@ -50,7 +48,6 @@ const Sso = ({
     enableSso,
     idpName,
     entityId,
-    issuerUri,
     idpImageUrl,
     metadata,
     metadataUrl,
@@ -108,7 +105,6 @@ const Sso = ({
     const formDataToSubmit = {
       sso_settings: {
         entity_id: entityId?.trim(),
-        issuer_uri: issuerUri?.trim(),
         idp_image_url: idpImageUrl?.trim(),
         metadata: metadata?.trim(),
         metadata_url: metadataUrl?.trim(),
@@ -164,16 +160,6 @@ const Sso = ({
             onBlur={validateForm}
             error={formErrors.entity_id}
             tooltip="The required entity ID is a URI that you use to identify Fleet when configuring the identity provider."
-          />
-        </div>
-        <div className={`${baseClass}__inputs`}>
-          <InputField
-            label="Issuer URI"
-            onChange={handleInputChange}
-            name="issuerUri"
-            value={issuerUri}
-            parseTarget
-            tooltip="The issuer URI supplied by the identity provider."
           />
         </div>
         <div className={`${baseClass}__inputs`}>

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -174,7 +174,6 @@ export const formatConfigDataForServer = (config: any): any => {
   ]);
   const ssoSettingsAttrs = pick(config, [
     "entity_id",
-    "issuer_uri",
     "idp_image_url",
     "metadata",
     "metadata_url",


### PR DESCRIPTION
## Addresses #10257 

Removed the 'Issuer URI' field and its associated code. Manually confirmed that enabling single sign-on still works as expected.

<img width="525" alt="Screenshot 2023-03-24 at 4 32 56 PM" src="https://user-images.githubusercontent.com/61553566/227661519-c2684a68-8b66-48f9-a6ab-a24f02f07080.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes
- [x] Manual QA for all new/changed functionality