### PR TITLE
Update broken links to MDM docs

### DIFF
--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -1108,10 +1108,10 @@ func getMDMAppleCommand() *cli.Command {
 			warnDate := time.Now().Add(expirationWarning)
 			if mdm.RenewDate.Before(time.Now()) {
 				// certificate is expired, print an error
-				color.New(color.FgRed).Fprintln(c.App.Writer, "\nERROR: Your Apple Push Notification service (APNs) certificate is expired. MDM features are turned off. To renew your APNs certificate, follow these instructions: https://fleetdm.com/docs/using-fleet/mdm-setup#apple-push-notification-service-ap-ns")
+				color.New(color.FgRed).Fprintln(c.App.Writer, "\nERROR: Your Apple Push Notification service (APNs) certificate is expired. MDM features are turned off. To renew your APNs certificate, follow these instructions: https://fleetdm.com/docs/using-fleet/mdm-setup#apple-push-notification-service-apns")
 			} else if mdm.RenewDate.Before(warnDate) {
 				// certificate will soon expire, print a warning
-				color.New(color.FgYellow).Fprintln(c.App.Writer, "\nWARNING: Your Apple Push Notification service (APNs) certificate is less than 30 days from expiration. If it expires, MDM features will be turned off. To renew your APNs certificate, follow these instructions: https://fleetdm.com/docs/using-fleet/mdm-setup#apple-push-notification-service-ap-ns")
+				color.New(color.FgYellow).Fprintln(c.App.Writer, "\nWARNING: Your Apple Push Notification service (APNs) certificate is less than 30 days from expiration. If it expires, MDM features will be turned off. To renew your APNs certificate, follow these instructions: https://fleetdm.com/docs/using-fleet/mdm-setup#renewing-apns")
 			}
 
 			return nil

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/DiskEncryptionKeyModal/DiskEncryptionKeyModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/DiskEncryptionKeyModal/DiskEncryptionKeyModal.tsx
@@ -48,7 +48,7 @@ const DiskEncryptionKeyModal = ({
             Use this key to log in to the host if you forgot the password.{" "}
             <CustomLink
               text="View recovery instructions"
-              url="https://fleetdm.com/docs/using-fleet/mdm-macos-settings#reset-a-mac-os-hosts-password-using-the-disk-encryption-key"
+              url="https://fleetdm.com/docs/using-fleet/mdm-macos-settings#reset-a-macos-hosts-password-using-the-disk-encryption-key"
               newTab
             />
           </p>


### PR DESCRIPTION
- At some point we updated how we generate anchor links on fleetdm.com/docs. PR is here: #10657
  - For example:
    - `https://fleetdm.com/docs/using-fleet/mdm-setup#apple-push-notification-service-ap-ns` is now `https://fleetdm.com/docs/using-fleet/mdm-setup#apple-push-notification-service-apns` (apns doesn't have a hyphen)
