### PR TITLE
UI: Address tooltip in headers spacing bug

### DIFF
--- a/changes/9988-extra-space-at-end-of-table
+++ b/changes/9988-extra-space-at-end-of-table
@@ -1,0 +1,1 @@
+- Fixed a UI bug where in certain states, there would be extra space at the right edge of the Manage Hosts table.

--- a/frontend/components/TableContainer/DataTable/HeaderCell/HeaderCell.tsx
+++ b/frontend/components/TableContainer/DataTable/HeaderCell/HeaderCell.tsx
@@ -25,9 +25,11 @@ const HeaderCell = ({
   }
 
   let lastColumnHeaderWithTooltipClass = "";
-  // Since value will only be a string or a TooltipWrapper, this checks for a TooltipWrapper
-  // TODO - add better checking for this
-  if (typeof value !== "string" && isLastColumn) {
+  if (
+    typeof value !== "string" &&
+    value.type.name === "TooltipWrapper" &&
+    isLastColumn
+  ) {
     lastColumnHeaderWithTooltipClass = "last-col-header-with-tip";
   }
 

--- a/frontend/components/TableContainer/DataTable/HeaderCell/HeaderCell.tsx
+++ b/frontend/components/TableContainer/DataTable/HeaderCell/HeaderCell.tsx
@@ -1,15 +1,19 @@
 import React from "react";
 
+import classnames from "classnames";
+
 interface IHeaderCellProps {
-  value: string | JSX.Element;
+  value: string | JSX.Element; // either a string or a TooltipWrapper
   isSortedDesc?: boolean;
   disableSortBy?: boolean;
+  isLastColumn?: boolean;
 }
 
 const HeaderCell = ({
   value,
   isSortedDesc,
   disableSortBy,
+  isLastColumn = false,
 }: IHeaderCellProps): JSX.Element => {
   let sortArrowClass = "";
   if (isSortedDesc === undefined) {
@@ -20,8 +24,21 @@ const HeaderCell = ({
     sortArrowClass = "ascending";
   }
 
+  let lastColumnHeaderWithTooltipClass = "";
+  // Since value will only be a string or a TooltipWrapper, this checks for a TooltipWrapper
+  // TODO - add better checking for this
+  if (typeof value !== "string" && isLastColumn) {
+    lastColumnHeaderWithTooltipClass = "last-col-header-with-tip";
+  }
+
   return (
-    <div className={`header-cell ${sortArrowClass}`}>
+    <div
+      className={classnames(
+        "header-cell",
+        sortArrowClass,
+        lastColumnHeaderWithTooltipClass
+      )}
+    >
       <span>{value}</span>
       {!disableSortBy && (
         <div className="sort-arrows">

--- a/frontend/interfaces/datatable_config.ts
+++ b/frontend/interfaces/datatable_config.ts
@@ -4,6 +4,7 @@ export type IDataColumn = Column & {
   title?: string;
   disableHidden?: boolean;
   disableSortBy?: boolean;
+  isLastColumn?: boolean;
   filterValue?: any;
   preFilteredRows?: any;
   setFilter?: any;

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -49,6 +49,7 @@ interface IHeaderProps {
   column: {
     title: string;
     isSortedDesc: boolean;
+    isLastColumn?: boolean;
   };
   getToggleAllRowsSelectedProps: () => IGetToggleAllRowsSelectedProps;
   toggleAllRowsSelected: () => void;
@@ -150,6 +151,7 @@ const allHostTableHeaders: IDataColumn[] = [
       <HeaderCell
         value={cellProps.column.title}
         isSortedDesc={cellProps.column.isSortedDesc}
+        isLastColumn={cellProps.column.isLastColumn}
       />
     ),
     accessor: "display_name",
@@ -200,6 +202,7 @@ const allHostTableHeaders: IDataColumn[] = [
       <HeaderCell
         value={cellProps.column.title}
         isSortedDesc={cellProps.column.isSortedDesc}
+        isLastColumn={cellProps.column.isLastColumn}
       />
     ),
     accessor: "hostname",
@@ -211,6 +214,7 @@ const allHostTableHeaders: IDataColumn[] = [
       <HeaderCell
         value={cellProps.column.title}
         isSortedDesc={cellProps.column.isSortedDesc}
+        isLastColumn={cellProps.column.isLastColumn}
       />
     ),
     accessor: "computer_name",
@@ -222,6 +226,7 @@ const allHostTableHeaders: IDataColumn[] = [
       <HeaderCell
         value={cellProps.column.title}
         isSortedDesc={cellProps.column.isSortedDesc}
+        isLastColumn={cellProps.column.isLastColumn}
       />
     ),
     accessor: "team_name",
@@ -231,7 +236,7 @@ const allHostTableHeaders: IDataColumn[] = [
   },
   {
     title: "Status",
-    Header: (headerProps: IHeaderProps): JSX.Element => {
+    Header: (cellProps: IHeaderProps): JSX.Element => {
       const titleWithToolTip = (
         <TooltipWrapper
           tipContent={`
@@ -245,8 +250,9 @@ const allHostTableHeaders: IDataColumn[] = [
       );
       return (
         <HeaderCell
-          value={headerProps.rows.length === 1 ? "Status" : titleWithToolTip}
+          value={cellProps.rows.length === 1 ? "Status" : titleWithToolTip}
           disableSortBy
+          isLastColumn={cellProps.column.isLastColumn}
         />
       );
     },
@@ -279,6 +285,7 @@ const allHostTableHeaders: IDataColumn[] = [
       <HeaderCell
         value={cellProps.column.title}
         isSortedDesc={cellProps.column.isSortedDesc}
+        isLastColumn={cellProps.column.isLastColumn}
       />
     ),
     accessor: "gigs_disk_space_available",
@@ -305,6 +312,7 @@ const allHostTableHeaders: IDataColumn[] = [
       <HeaderCell
         value={cellProps.column.title}
         isSortedDesc={cellProps.column.isSortedDesc}
+        isLastColumn={cellProps.column.isLastColumn}
       />
     ),
     accessor: "os_version",
@@ -354,7 +362,7 @@ const allHostTableHeaders: IDataColumn[] = [
           </>
         );
       }
-      return <span className="text-muted">---</span>;
+      return <span className="text-muted">{DEFAULT_EMPTY_CELL_VALUE}</span>;
     },
   },
   {
@@ -363,6 +371,7 @@ const allHostTableHeaders: IDataColumn[] = [
       <HeaderCell
         value={cellProps.column.title}
         isSortedDesc={cellProps.column.isSortedDesc}
+        isLastColumn={cellProps.column.isLastColumn}
       />
     ),
     accessor: "primary_ip",
@@ -370,18 +379,25 @@ const allHostTableHeaders: IDataColumn[] = [
   },
   {
     title: "MDM status",
-    Header: (): JSX.Element => {
+    Header: (cellProps: IHeaderProps): JSX.Element => {
       const titleWithToolTip = (
         <TooltipWrapper
           tipContent={`
-            Settings can be updated remotely on hosts with MDM turned on.<br/>
-            To filter by MDM status, head to the Dashboard page.
+            Settings can be updated remotely on <br/>
+            hosts with MDM turned on. To filter by<br/>
+            MDM status, head to the Dashboard page.
           `}
         >
           MDM status
         </TooltipWrapper>
       );
-      return <HeaderCell value={titleWithToolTip} disableSortBy />;
+      return (
+        <HeaderCell
+          value={titleWithToolTip}
+          isLastColumn={cellProps.column.isLastColumn}
+          disableSortBy
+        />
+      );
     },
     disableSortBy: true,
     accessor: "mdm.enrollment_status",
@@ -389,23 +405,30 @@ const allHostTableHeaders: IDataColumn[] = [
     Cell: (cellProps: ICellProps) => {
       if (cellProps.cell.value)
         return <TextCell value={cellProps.cell.value} />;
-      return <span className="text-muted">---</span>;
+      return <span className="text-muted">{DEFAULT_EMPTY_CELL_VALUE}</span>;
     },
   },
   {
     title: "MDM server URL",
-    Header: (): JSX.Element => {
+    Header: (cellProps: IHeaderProps): JSX.Element => {
       const titleWithToolTip = (
         <TooltipWrapper
           tipContent={`
-            The MDM server that updates settings on the host.<br/>
-            To filter by MDM server URL, head to the Dashboard page.
+            The MDM server that updates settings<br/>
+            on the host. To filter by MDM server URL,<br/>
+            head to the Dashboard page.
           `}
         >
           MDM server URL
         </TooltipWrapper>
       );
-      return <HeaderCell value={titleWithToolTip} disableSortBy />;
+      return (
+        <HeaderCell
+          value={titleWithToolTip}
+          isLastColumn={cellProps.column.isLastColumn}
+          disableSortBy
+        />
+      );
     },
     disableSortBy: true,
     accessor: "mdm.server_url",
@@ -423,6 +446,7 @@ const allHostTableHeaders: IDataColumn[] = [
       <HeaderCell
         value={cellProps.column.title}
         isSortedDesc={cellProps.column.isSortedDesc}
+        isLastColumn={cellProps.column.isLastColumn}
       />
     ),
     accessor: "public_ip",
@@ -463,7 +487,7 @@ const allHostTableHeaders: IDataColumn[] = [
   },
   {
     title: "Last fetched",
-    Header: (headerProps: IHeaderProps): JSX.Element => {
+    Header: (cellProps: IHeaderProps): JSX.Element => {
       const titleWithToolTip = (
         <TooltipWrapper
           tipContent={`
@@ -476,7 +500,8 @@ const allHostTableHeaders: IDataColumn[] = [
       return (
         <HeaderCell
           value={titleWithToolTip}
-          isSortedDesc={headerProps.column.isSortedDesc}
+          isSortedDesc={cellProps.column.isSortedDesc}
+          isLastColumn={cellProps.column.isLastColumn}
         />
       );
     },
@@ -490,7 +515,7 @@ const allHostTableHeaders: IDataColumn[] = [
   },
   {
     title: "Last seen",
-    Header: (headerProps: IHeaderProps): JSX.Element => {
+    Header: (cellProps: IHeaderProps): JSX.Element => {
       const titleWithToolTip = (
         <TooltipWrapper
           tipContent={`
@@ -503,7 +528,8 @@ const allHostTableHeaders: IDataColumn[] = [
       return (
         <HeaderCell
           value={titleWithToolTip}
-          isSortedDesc={headerProps.column.isSortedDesc}
+          isSortedDesc={cellProps.column.isSortedDesc}
+          isLastColumn={cellProps.column.isLastColumn}
         />
       );
     },
@@ -521,6 +547,7 @@ const allHostTableHeaders: IDataColumn[] = [
       <HeaderCell
         value={cellProps.column.title}
         isSortedDesc={cellProps.column.isSortedDesc}
+        isLastColumn={cellProps.column.isLastColumn}
       />
     ),
     accessor: "uuid",
@@ -534,6 +561,7 @@ const allHostTableHeaders: IDataColumn[] = [
       <HeaderCell
         value={cellProps.column.title}
         isSortedDesc={cellProps.column.isSortedDesc}
+        isLastColumn={cellProps.column.isLastColumn}
       />
     ),
     accessor: "uptime",
@@ -563,6 +591,7 @@ const allHostTableHeaders: IDataColumn[] = [
       <HeaderCell
         value={cellProps.column.title}
         isSortedDesc={cellProps.column.isSortedDesc}
+        isLastColumn={cellProps.column.isLastColumn}
       />
     ),
     accessor: "memory",
@@ -576,6 +605,7 @@ const allHostTableHeaders: IDataColumn[] = [
       <HeaderCell
         value={cellProps.column.title}
         isSortedDesc={cellProps.column.isSortedDesc}
+        isLastColumn={cellProps.column.isLastColumn}
       />
     ),
     accessor: "primary_mac",
@@ -587,6 +617,7 @@ const allHostTableHeaders: IDataColumn[] = [
       <HeaderCell
         value={cellProps.column.title}
         isSortedDesc={cellProps.column.isSortedDesc}
+        isLastColumn={cellProps.column.isLastColumn}
       />
     ),
     accessor: "hardware_serial",
@@ -598,6 +629,7 @@ const allHostTableHeaders: IDataColumn[] = [
       <HeaderCell
         value={cellProps.column.title}
         isSortedDesc={cellProps.column.isSortedDesc}
+        isLastColumn={cellProps.column.isLastColumn}
       />
     ),
     accessor: "hardware_model",

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1760,6 +1760,7 @@ const ManageHostsPage = ({
       currentUser,
       currentTeam
     );
+    tableColumns[tableColumns.length - 1].isLastColumn = true;
 
     const emptyState = () => {
       const emptyHosts: IEmptyTableProps = {

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1760,6 +1760,11 @@ const ManageHostsPage = ({
       currentUser,
       currentTeam
     );
+
+    // Update last column
+    tableColumns.forEach((dataColumn) => {
+      dataColumn.isLastColumn = false;
+    });
     tableColumns[tableColumns.length - 1].isLastColumn = true;
 
     const emptyState = () => {

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -174,9 +174,12 @@
           &__table {
             thead {
               tr {
-                th:last-child {
-                  .component__tooltip-wrapper__tip-text {
-                    left: -8px;
+                th {
+                  .last-col-header-with-tip {
+                    min-width: 90px;
+                    .component__tooltip-wrapper__tip-text {
+                      left: -96px;
+                    }
                   }
                 }
               }


### PR DESCRIPTION
## Addresses #9988

* Adjust copy in tooltips to take up less width
* Refactor table headers to take an optional "isLastColumn" property that is set to true when that header is in the last column.
* Use above property in conjunction with presence of TooltipWrapper as a value for the header cell to add a class specific to that state.
* Use that class to adjust the location of the tooltip text and the min-width of the column to avoid the bug.

The 3 states which exhibited this bug, now fixed:
<img width="1496" alt="Screenshot 2023-03-27 at 4 36 01 PM" src="https://user-images.githubusercontent.com/61553566/228091971-4d5d034d-55c5-4921-955a-4946119f7785.png">
<img width="1496" alt="Screenshot 2023-03-27 at 4 36 12 PM" src="https://user-images.githubusercontent.com/61553566/228091968-adf90b32-8fd2-45d9-b56d-a64c654151ef.png">
<img width="1496" alt="Screenshot 2023-03-27 at 4 36 24 PM" src="https://user-images.githubusercontent.com/61553566/228091962-ff626daa-b13d-4093-b34f-de704b820161.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality