### PR TITLE
Helm chart to allow mysql TLS w/o client certs

### DIFF
--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,7 +4,7 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v5.0.0
+version: v5.0.1
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -128,14 +128,10 @@ spec:
           - name: FLEET_MYSQL_TLS_KEY
             value: "/secrets/mysql/{{ .Values.mysql.tls.keyKey }}"
           {{- end }}
-          {{- if .Values.mysql.tls.config }}
           - name: FLEET_MYSQL_TLS_CONFIG
             value: "{{ .Values.mysql.tls.config }}"
-          {{- end }}
-          {{- if .Values.mysql.tls.serverName }}
           - name: FLEET_MYSQL_TLS_SERVER_NAME
             value: "{{ .Values.mysql.tls.serverName }}"
-          {{- end }}
           {{- end }}
           ## END MYSQL SECTION
           ## BEGIN REDIS SECTION

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -116,16 +116,26 @@ spec:
           - name: FLEET_MYSQL_CONN_MAX_LIFETIME
             value: "{{ .Values.mysql.connMaxLifetime }}"
           {{- if .Values.mysql.tls.enabled }}
+          {{- if .Values.mysql.tls.caCertKey }}
           - name: FLEET_MYSQL_TLS_CA
             value: "/secrets/mysql/{{ .Values.mysql.tls.caCertKey }}"
+          {{- end }}
+          {{- if .Values.mysql.tls.certKey }}
           - name: FLEET_MYSQL_TLS_CERT
             value: "/secrets/mysql/{{ .Values.mysql.tls.certKey }}"
+          {{- end }}
+          {{- if .Values.mysql.tls.keyKey }}
           - name: FLEET_MYSQL_TLS_KEY
             value: "/secrets/mysql/{{ .Values.mysql.tls.keyKey }}"
+          {{- end }}
+          {{- if .Values.mysql.tls.config }}
           - name: FLEET_MYSQL_TLS_CONFIG
             value: "{{ .Values.mysql.tls.config }}"
+          {{- end }}
+          {{- if .Values.mysql.tls.serverName }}
           - name: FLEET_MYSQL_TLS_SERVER_NAME
             value: "{{ .Values.mysql.tls.serverName }}"
+          {{- end }}
           {{- end }}
           ## END MYSQL SECTION
           ## BEGIN REDIS SECTION

--- a/charts/fleet/templates/job-migration.yaml
+++ b/charts/fleet/templates/job-migration.yaml
@@ -90,16 +90,26 @@ spec:
           - name: FLEET_MYSQL_CONN_MAX_LIFETIME
             value: "{{ .Values.mysql.connMaxLifetime }}"
           {{- if .Values.mysql.tls.enabled }}
+          {{- if .Values.mysql.tls.caCertKey }}
           - name: FLEET_MYSQL_TLS_CA
             value: "/secrets/mysql/{{ .Values.mysql.tls.caCertKey }}"
+          {{- end }}
+          {{- if .Values.mysql.tls.certKey }}
           - name: FLEET_MYSQL_TLS_CERT
             value: "/secrets/mysql/{{ .Values.mysql.tls.certKey }}"
+          {{- end }}
+          {{- if .Values.mysql.tls.keyKey }}
           - name: FLEET_MYSQL_TLS_KEY
             value: "/secrets/mysql/{{ .Values.mysql.tls.keyKey }}"
+          {{- end }}
+          {{- if .Values.mysql.tls.config }}
           - name: FLEET_MYSQL_TLS_CONFIG
             value: "{{ .Values.mysql.tls.config }}"
+          {{- end }}
+          {{- if .Values.mysql.tls.serverName }}
           - name: FLEET_MYSQL_TLS_SERVER_NAME
             value: "{{ .Values.mysql.tls.serverName }}"
+          {{- end }}
           {{- end }}
           ## END MYSQL SECTION
         securityContext:

--- a/charts/fleet/templates/job-migration.yaml
+++ b/charts/fleet/templates/job-migration.yaml
@@ -102,14 +102,10 @@ spec:
           - name: FLEET_MYSQL_TLS_KEY
             value: "/secrets/mysql/{{ .Values.mysql.tls.keyKey }}"
           {{- end }}
-          {{- if .Values.mysql.tls.config }}
           - name: FLEET_MYSQL_TLS_CONFIG
             value: "{{ .Values.mysql.tls.config }}"
-          {{- end }}
-          {{- if .Values.mysql.tls.serverName }}
           - name: FLEET_MYSQL_TLS_SERVER_NAME
             value: "{{ .Values.mysql.tls.serverName }}"
-          {{- end }}
           {{- end }}
           ## END MYSQL SECTION
         securityContext:

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -160,11 +160,13 @@ mysql:
   connMaxLifetime: 0
   tls:
     enabled: false
-    caCertKey: ca.cert
-    certKey: client.cert
-    keyKey: client.key
-    config: ""
-    serverName: ""
+    ## All options below are option.  Uncomment to use.
+    # caCertKey: ca.cert
+    ## Client certificates require both the certKey and keyKey
+    # certKey: client.cert
+    # keyKey: client.key
+    # config: ""
+    # serverName: ""
 
 ## Section: Redis
 # All of the connection settings for Redis

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -160,13 +160,13 @@ mysql:
   connMaxLifetime: 0
   tls:
     enabled: false
-    ## All options below are option.  Uncomment to use.
+    ## Commented options below are optional.  Uncomment to use.
     # caCertKey: ca.cert
     ## Client certificates require both the certKey and keyKey
     # certKey: client.cert
     # keyKey: client.key
-    # config: ""
-    # serverName: ""
+    config: ""
+    serverName: ""
 
 ## Section: Redis
 # All of the connection settings for Redis


### PR DESCRIPTION
This will allow MySQL TLS to be enabled for fleet in the helm chart with a self-signed CA but without requiring client certs to be utilized.  It should be backwards compatible with previous values.yaml files that had these TLS values specified, but might require someone to uncomment them if they did not explicitly define them in their own values.

I am not certain if this should be considered a breaking change here, since a complete values.yaml will continue to work as before.  We can just adjust the version number as-desired if so.

There could be edge cases I missed with this in testing, but I _think_ we are in good shape.

Note: this resolves #8207 
