### PR TITLE
add disk encryption table aggregate UI

### DIFF
--- a/frontend/pages/ManageControlsPage/MacOSSettings/cards/DiskEncryption/DiskEncryption.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/cards/DiskEncryption/DiskEncryption.tsx
@@ -106,7 +106,9 @@ const DiskEncryption = ({ currentTeamId }: IDiskEncryptionProps) => {
             <Spinner />
           ) : (
             <div className="disk-encryption-content">
-              {/* <DiskEncryptionTable currentTeamId={currentTeamId} /> */}
+              {showAggregate && (
+                <DiskEncryptionTable currentTeamId={currentTeamId} />
+              )}
               <Checkbox
                 onChange={onToggleCheckbox}
                 value={diskEncryptionEnabled}

--- a/frontend/pages/ManageControlsPage/MacOSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTableConfig.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTableConfig.tsx
@@ -71,7 +71,9 @@ const defaultTableHeaders: IDataColumn[] = [
       />
     ),
     accessor: "hosts",
-    Cell: ({ cell: { value } }: ICellProps) => <TextCell value={value} />,
+    Cell: ({ cell: { value } }: ICellProps) => (
+      <TextCell value={value} formatter={(val) => <>{val}</>} />
+    ),
   },
 ];
 


### PR DESCRIPTION
relates to #9404

Adds back in the disk encryption aggregate table into the UI. This was removed and waiting for the completion of #9434. We can now add the UI back in now that the API implementation has been merged in.

![image](https://user-images.githubusercontent.com/1153709/228340250-7a14ca31-d626-420e-a5de-be695c8fcbe1.png)

- [x] Manual QA for all new/changed functionality
  