### PR TITLE
Add Sentry secret to dogfood

### DIFF
--- a/.github/workflows/dogfood-deploy.yml
+++ b/.github/workflows/dogfood-deploy.yml
@@ -27,6 +27,7 @@ env:
   TF_VAR_fleet_image: ${{ github.event.inputs.DOCKER_IMAGE || 'fleetdm/fleet:main' }}
   TF_VAR_fleet_license: ${{ secrets.DOGFOOD_LICENSE_KEY }}
   TF_VAR_slack_webhook: ${{ secrets.SLACK_G_HELP_P1_WEBHOOK_URL }}
+  TF_VAR_sentry_dsn: ${{ secrets.DOGFOOD_SECRET_DSN }}
 
 permissions:
   id-token: write

--- a/.github/workflows/dogfood-deploy.yml
+++ b/.github/workflows/dogfood-deploy.yml
@@ -27,7 +27,7 @@ env:
   TF_VAR_fleet_image: ${{ github.event.inputs.DOCKER_IMAGE || 'fleetdm/fleet:main' }}
   TF_VAR_fleet_license: ${{ secrets.DOGFOOD_LICENSE_KEY }}
   TF_VAR_slack_webhook: ${{ secrets.SLACK_G_HELP_P1_WEBHOOK_URL }}
-  TF_VAR_sentry_dsn: ${{ secrets.DOGFOOD_SECRET_DSN }}
+  TF_VAR_sentry_dsn: ${{ secrets.DOGFOOD_SENTRY_DSN }}
 
 permissions:
   id-token: write

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -28,6 +28,8 @@ variable "fleet_license" {}
 variable "fleet_image" {
   default = "160035666661.dkr.ecr.us-east-2.amazonaws.com/fleet:1f68e7a5e39339d763da26a0c8ae3e459b2e1f016538d7962312310493381f7c"
 }
+variable "sentry_dsn" {
+}
 
 data "aws_caller_identity" "current" {}
 
@@ -146,6 +148,13 @@ resource "aws_route53_record" "main" {
 
 resource "aws_secretsmanager_secret" "sentry" {
   name = "${local.customer}-sentry"
+}
+
+resource "aws_secretsmanager_secret_version" "sentry" {
+  secret_id = aws_secretsmanager_secret.sentry.id
+  secret_string = jsonencode({
+    SENTRY_DSN = var.sentry_dsn
+  })
 }
 
 module "migrations" {


### PR DESCRIPTION
Do we prefer this like this and then populate the secretsmanager secret, or would a github secret be preferreable?

I will wait to merge and apply this regardless until the dogfood SES/email work is merged to main and apply so as not to conflict with any terrfaorm state or the like.