### PR TITLE
Add prometheus to loadtesting

### DIFF
--- a/infrastructure/loadtesting/terraform/ecs.tf
+++ b/infrastructure/loadtesting/terraform/ecs.tf
@@ -125,6 +125,14 @@ resource "aws_ecs_task_definition" "backend" {
           {
             name      = "FLEET_LICENSE_KEY"
             valueFrom = data.aws_secretsmanager_secret.license.arn
+          },
+          {
+            name      = "FLEET_PROMETHEUS_BASIC_AUTH_USERNAME"
+            valueFrom = data.aws_secretsmanager_secret.prometheus.basic_auth_username
+          },
+          {
+            name      = "FLEET_PROMETHEUS_BASIC_AUTH_PASSWORD"
+            valueFrom = data.aws_secretsmanager_secret.prometheus.basic_auth_password
           }
         ]
         environment = concat([


### PR DESCRIPTION
I've only set Fleet's configuration to enable the Prometheus metrics endpoint (path `GET /metrics`).
What else needs to be modified?

Also, guessing the username/password should be stored in 1Password.