### PR TITLE
Fleet UI: API only badge

### DIFF
--- a/changes/10879-api-only-user-badge
+++ b/changes/10879-api-only-user-badge
@@ -1,0 +1,1 @@
+- User management table informs which users only have API accesss

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/MembersPageTableConfig.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/MembersPageTableConfig.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+import ReactTooltip from "react-tooltip";
 import TextCell from "components/TableContainer/DataTable/TextCell/TextCell";
 import DropdownCell from "components/TableContainer/DataTable/DropdownCell";
+import CustomLink from "components/CustomLink";
 import { IUser } from "interfaces/user";
 import { ITeam } from "interfaces/team";
 import { IDropdownOption } from "interfaces/dropdownOption";
@@ -64,9 +66,54 @@ const generateTableHeaders = (
       disableSortBy: true,
       sortType: "caseInsensitive",
       accessor: "name",
-      Cell: (cellProps: ICellProps) => (
-        <TextCell value={cellProps.cell.value} />
-      ),
+      Cell: (cellProps: ICellProps) => {
+        const formatter = (val: string) => {
+          const apiOnlyUser =
+            "api_only" in cellProps.row.original
+              ? cellProps.row.original.api_only
+              : false;
+
+          return (
+            <>
+              {val}
+              {apiOnlyUser && (
+                <>
+                  <span
+                    className="members__api-only-user"
+                    data-tip
+                    data-for={`api-only-tooltip-${cellProps.row.original.id}`}
+                  >
+                    API
+                  </span>
+                  <ReactTooltip
+                    className="api-only-tooltip"
+                    place="top"
+                    type="dark"
+                    effect="solid"
+                    id={`api-only-tooltip-${cellProps.row.original.id}`}
+                    backgroundColor="#3e4771"
+                    clickable
+                    delayHide={200} // need delay set to hover using clickable
+                  >
+                    <>
+                      This user was created using fleetctl and
+                      <br /> only has API access.{" "}
+                      <CustomLink
+                        text="Learn more"
+                        newTab
+                        url="https://fleetdm.com/docs/using-fleet/fleetctl-cli#using-fleetctl-with-an-api-only-user"
+                        iconColor="core-fleet-white"
+                      />
+                    </>
+                  </ReactTooltip>
+                </>
+              )}
+            </>
+          );
+        };
+
+        return <TextCell value={cellProps.cell.value} formatter={formatter} />;
+      },
     },
     {
       title: "Role",
@@ -137,6 +184,7 @@ const enhanceMembersData = (
       global_role: user.global_role,
       actions: generateActionDropdownOptions(),
       id: user.id,
+      api_only: user.api_only,
     };
   });
 };

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/_styles.scss
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/_styles.scss
@@ -6,6 +6,10 @@
     margin: 0;
   }
 
+  &__api-only-user {
+    @include grey-badge;
+  }
+
   .data-table-block {
     .data-table__table {
       thead {

--- a/frontend/pages/admin/UserManagementPage/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/_styles.scss
@@ -9,4 +9,18 @@
   &__sandbox-demo-message {
     margin-top: 3.5rem;
   }
+
+  &__api-only-user {
+    background-color: $ui-fleet-black-25;
+    color: $core-white;
+    font-size: $xx-small;
+    font-weight: 700;
+    padding: 0 4px;
+    border-radius: 4px;
+    position: relative;
+    top: -2px;
+    min-width: 95px;
+    max-height: 19px;
+    margin-left: 4px;
+  }
 }

--- a/frontend/pages/admin/UserManagementPage/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/_styles.scss
@@ -11,16 +11,6 @@
   }
 
   &__api-only-user {
-    background-color: $ui-fleet-black-25;
-    color: $core-white;
-    font-size: $xx-small;
-    font-weight: 700;
-    padding: 0 4px;
-    border-radius: 4px;
-    position: relative;
-    top: -2px;
-    min-width: 95px;
-    max-height: 19px;
-    margin-left: 4px;
+    @include grey-badge;
   }
 }

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 
+import ReactTooltip from "react-tooltip";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";
 import StatusIndicator from "components/StatusIndicator";
 import TextCell from "components/TableContainer/DataTable/TextCell/TextCell";
+import CustomLink from "components/CustomLink";
 import { IInvite } from "interfaces/invite";
 import { IUser } from "interfaces/user";
 import { IDropdownOption } from "interfaces/dropdownOption";
@@ -55,6 +57,7 @@ export interface IUserTableData {
   actions: IDropdownOption[];
   id: number;
   type: string;
+  api_only: boolean;
 }
 
 // NOTE: cellProps come from react-table
@@ -69,9 +72,54 @@ const generateTableHeaders = (
       Header: "Name",
       disableSortBy: true,
       accessor: "name",
-      Cell: (cellProps: ICellProps) => (
-        <TextCell value={cellProps.cell.value} />
-      ),
+      Cell: (cellProps: ICellProps) => {
+        const formatter = (val: string) => {
+          const apiOnlyUser =
+            "api_only" in cellProps.row.original
+              ? cellProps.row.original.api_only
+              : false;
+
+          return (
+            <>
+              {val}
+              {apiOnlyUser && (
+                <>
+                  <span
+                    className="user-management__api-only-user"
+                    data-tip
+                    data-for={`api-only-tooltip-${cellProps.row.original.id}`}
+                  >
+                    API
+                  </span>
+                  <ReactTooltip
+                    className="api-only-tooltip"
+                    place="top"
+                    type="dark"
+                    effect="solid"
+                    id={`api-only-tooltip-${cellProps.row.original.id}`}
+                    backgroundColor="#3e4771"
+                    clickable
+                    delayHide={200} // need delay set to hover using clickable
+                  >
+                    <>
+                      This user was created using fleetctl and
+                      <br /> only has API access.{" "}
+                      <CustomLink
+                        text="Learn more"
+                        newTab
+                        url="https://fleetdm.com/docs/using-fleet/fleetctl-cli#using-fleetctl-with-an-api-only-user"
+                        iconColor="core-fleet-white"
+                      />
+                    </>
+                  </ReactTooltip>
+                </>
+              )}
+            </>
+          );
+        };
+
+        return <TextCell value={cellProps.cell.value} formatter={formatter} />;
+      },
     },
     {
       title: "Role",
@@ -206,6 +254,7 @@ const enhanceUserData = (
       ),
       id: user.id,
       type: "user",
+      api_only: user.api_only,
     };
   });
 };
@@ -221,6 +270,7 @@ const enhanceInviteData = (invites: IInvite[]): IUserTableData[] => {
       actions: generateActionDropdownOptions(false, true, invite.sso_enabled),
       id: invite.id,
       type: "invite",
+      api_only: false, // api only users are created through fleetctl and not invites
     };
   });
 };

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -42,11 +42,8 @@ $max-width: 2560px;
   color: $core-white;
   font-size: $xx-small;
   font-weight: 700;
-  padding: 0 4px;
-  border-radius: 4px;
+  padding: 0 $pad-xsmall;
+  border-radius: $border-radius;
   position: relative;
-  top: -2px;
-  min-width: 95px;
-  max-height: 19px;
-  margin-left: 4px;
+  margin-left: $pad-xsmall;
 }

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -36,3 +36,17 @@ $max-width: 2560px;
   margin: 0;
   padding: $pad-xxlarge 0 54px 0;
 }
+
+@mixin grey-badge {
+  background-color: $ui-fleet-black-25;
+  color: $core-white;
+  font-size: $xx-small;
+  font-weight: 700;
+  padding: 0 4px;
+  border-radius: 4px;
+  position: relative;
+  top: -2px;
+  min-width: 95px;
+  max-height: 19px;
+  margin-left: 4px;
+}


### PR DESCRIPTION
## Issue
Cerra #10879 

## Description
- Users management page: Add an API only user badge to help see which users only have API access
- Team members page: Add an API only user badge to help see which users only have API access

## Screenshot
<img width="1392" alt="Screenshot 2023-03-30 at 11 30 38 AM" src="https://user-images.githubusercontent.com/71795832/228887512-2ad88857-0454-4b4d-b11f-104914027177.png">

<img width="379" alt="Screenshot 2023-03-30 at 3 57 05 PM" src="https://user-images.githubusercontent.com/71795832/228950348-637fe17c-edc3-496f-acfd-7edc485f0a64.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

