### PR TITLE
Require TLS 1.2 in Terraform ALB listener

### DIFF
--- a/terraform/byo-vpc/byo-db/main.tf
+++ b/terraform/byo-vpc/byo-db/main.tf
@@ -53,6 +53,9 @@ module "alb" {
       }
     }
   ]
+  
+  # Require TLS 1.2 as earlier versions are insecure
+  listener_ssl_policy_default = "TLS-1-2-2017-01"
 
   https_listeners = [
     {


### PR DESCRIPTION
This should fix tfsec https://aquasecurity.github.io/tfsec/v1.0.8/checks/aws/elb/use-secure-tls-policy/ by configuring https://registry.terraform.io/modules/terraform-aws-modules/alb/aws/6.4.0#input_listener_ssl_policy_default.
