### PR TITLE
firehose.tf lifecycle_rule on "osquery-results" is deprecated

### DIFF
--- a/infrastructure/loadtesting/terraform/firehose.tf
+++ b/infrastructure/loadtesting/terraform/firehose.tf
@@ -2,12 +2,6 @@ resource "aws_s3_bucket" "osquery-results" { #tfsec:ignore:aws-s3-encryption-cus
   bucket = "${local.prefix}-loadtest-osquery-logs-archive"
   acl    = "private"
 
-  lifecycle_rule {
-    enabled = true
-    expiration {
-      days = 1
-    }
-  }
   #checkov:skip=CKV_AWS_18:dev env
   #checkov:skip=CKV_AWS_144:dev env
   #checkov:skip=CKV_AWS_21:dev env
@@ -18,7 +12,19 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "osquery-results" 
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm     = "aws:kms"
+      sse_algorithm = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "osquery-results" {
+  bucket = aws_s3_bucket.osquery-results.id
+
+  rule {
+    id     = "rule-1"
+    status = "Enabled"
+    expiration {
+      days = 1
     }
   }
 }
@@ -53,7 +59,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "osquery-status" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm     = "aws:kms"
+      sse_algorithm = "aws:kms"
     }
   }
 }


### PR DESCRIPTION
`lifecycle_rule` on s3 buckets is deprecated, as noted by the warning on this job: https://github.com/fleetdm/fleet/actions/runs/4568578149/jobs/8063810135#step:4:54