### PR TITLE
fix osquery query used to determine MDM disk encryption status

### DIFF
--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -572,8 +572,7 @@ var mdmQueries = map[string]DetailQuery{
 		// > location at any time.
 		//
 		// [1]: https://developer.apple.com/documentation/devicemanagement/fderecoverykeyescrow
-		Query: fmt.Sprintf(`SELECT to_base64(group_concat(line, x'0a')) as filevault_key,
-						(%s) as encrypted FROM file_lines WHERE path='/var/db/FileVaultPRK.dat'`, usesMacOSDiskEncryptionQuery),
+		Query:            fmt.Sprintf(`SELECT to_base64(group_concat(line, x'0a')) as filevault_key, COALESCE((%s), 0) as encrypted FROM file_lines WHERE path='/var/db/FileVaultPRK.dat'`, usesMacOSDiskEncryptionQuery),
 		Platforms:        []string{"darwin"},
 		DirectIngestFunc: directIngestDiskEncryptionKeyDarwin,
 		Discovery:        discoveryTable("file_lines"),


### PR DESCRIPTION
Related to https://github.com/fleetdm/fleet/issues/10786.

The query we use to determine if disk encryption is off doesn't return any rows if disk encryption is off. This accounts for that in the MDM query.

# Checklist for submitter

- [x] Manual QA for all new/changed functionality
