### PR TITLE
Fix rds deprecations in loadtesting

### DIFF
--- a/infrastructure/loadtesting/terraform/rds.tf
+++ b/infrastructure/loadtesting/terraform/rds.tf
@@ -8,8 +8,8 @@ resource "random_pet" "db_secret_postfix" {
 }
 
 resource "aws_secretsmanager_secret" "database_password_secret" {
-  name                    = "/fleet/database/password/master-2-${random_pet.db_secret_postfix.id}"
-  kms_key_id              = aws_kms_key.main.id
+  name       = "/fleet/database/password/master-2-${random_pet.db_secret_postfix.id}"
+  kms_key_id = aws_kms_key.main.id
   # No need to keep these around to potentially break re-using the same
   # workspace.
   recovery_window_in_days = 0
@@ -26,7 +26,7 @@ module "aurora_mysql" { #tfsec:ignore:aws-rds-enable-performance-insights-encryp
 
   name                  = "${local.name}-mysql"
   engine                = "aurora-mysql"
-  engine_version        = "5.7.mysql_aurora.2.10.3"
+  engine_version        = "8.0.mysql_aurora.3.02.2"
   instance_type         = var.db_instance_type
   instance_type_replica = var.db_instance_type
 
@@ -40,16 +40,16 @@ module "aurora_mysql" { #tfsec:ignore:aws-rds-enable-performance-insights-encryp
   performance_insights_enabled        = true
   enabled_cloudwatch_logs_exports     = ["slowquery"]
 
-  vpc_id                  = data.terraform_remote_state.shared.outputs.vpc.vpc_id
-  vpc_security_group_ids  = [aws_security_group.backend.id]
-  subnets                 = data.terraform_remote_state.shared.outputs.vpc.database_subnets
-  create_security_group   = true
-  allowed_cidr_blocks     = concat(data.terraform_remote_state.shared.outputs.vpc.private_subnets_cidr_blocks, local.vpn_cidr_blocks)
+  vpc_id                 = data.terraform_remote_state.shared.outputs.vpc.vpc_id
+  vpc_security_group_ids = [aws_security_group.backend.id]
+  subnets                = data.terraform_remote_state.shared.outputs.vpc.database_subnets
+  create_security_group  = true
+  allowed_cidr_blocks    = concat(data.terraform_remote_state.shared.outputs.vpc.private_subnets_cidr_blocks, local.vpn_cidr_blocks)
   # Old Jump box?
   # allowed_security_groups = ["sg-0063a978193fdf7ee"]
 
-  replica_count         = 2
-  snapshot_identifier   = "arn:aws:rds:us-east-2:917007347864:cluster-snapshot:cleaned"
+  replica_count       = 2
+  snapshot_identifier = "arn:aws:rds:us-east-2:917007347864:cluster-snapshot:cleaned"
 
   monitoring_interval           = 60
   iam_role_name                 = "${local.name}-rds"
@@ -60,20 +60,4 @@ module "aurora_mysql" { #tfsec:ignore:aws-rds-enable-performance-insights-encryp
 
   apply_immediately   = true
   skip_final_snapshot = true
-
-  db_parameter_group_name         = aws_db_parameter_group.example_mysql.id
-  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.example_mysql.id
-
-}
-
-resource "aws_db_parameter_group" "example_mysql" {
-  name        = "${local.name}-aurora-db-mysql-parameter-group"
-  family      = "aurora-mysql5.7"
-  description = "${local.name}-aurora-db-mysql-parameter-group"
-}
-
-resource "aws_rds_cluster_parameter_group" "example_mysql" {
-  name        = "${local.name}-aurora-mysql-cluster-parameter-group"
-  family      = "aurora-mysql5.7"
-  description = "${local.name}-aurora-mysql-cluster-parameter-group"
 }


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).

Closes #10869