### PR TITLE
lifecycle_rule on aws_s3_bucket is deprecated on dogfood/firehose.tf

### DIFF
--- a/infrastructure/dogfood/terraform/aws/firehose.tf
+++ b/infrastructure/dogfood/terraform/aws/firehose.tf
@@ -42,18 +42,23 @@ resource "aws_s3_bucket" "osquery-status" { #tfsec:ignore:aws-s3-encryption-cust
   bucket = var.osquery_status_s3_bucket
   acl    = "private"
 
-  lifecycle_rule {
-    enabled = true
-    expiration {
-      days = 1
-    }
-  }
-
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
         sse_algorithm = "aws:kms"
       }
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "osquery-status" {
+  bucket = aws_s3_bucket.osquery-status.id
+
+  rule {
+    id     = "rule-1"
+    status = "Enabled"
+    expiration {
+      days = 1
     }
   }
 }


### PR DESCRIPTION
`lifecycle_rule` on `aws_s3_bucket` is a deprecated argument.

Highlighted on this job: https://github.com/fleetdm/fleet/actions/runs/4570054990/jobs/8066956394#step:4:56