### PR TITLE
lifecycle_rule on aws_s3_bucket is deprecated on loadtesting/firehose.tf 

### DIFF
--- a/infrastructure/loadtesting/terraform/firehose.tf
+++ b/infrastructure/loadtesting/terraform/firehose.tf
@@ -46,16 +46,21 @@ resource "aws_s3_bucket" "osquery-status" { #tfsec:ignore:aws-s3-encryption-cust
   bucket = "${local.prefix}-loadtest-osquery-status-archive"
   acl    = "private"
 
-  lifecycle_rule {
-    enabled = true
+  #checkov:skip=CKV_AWS_18:dev env
+  #checkov:skip=CKV_AWS_144:dev env
+  #checkov:skip=CKV_AWS_21:dev env
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "osquery-status" {
+  bucket = aws_s3_bucket.osquery-status.id
+
+  rule {
+    id     = "rule-1"
+    status = "Enabled"
     expiration {
       days = 1
     }
   }
-
-  #checkov:skip=CKV_AWS_18:dev env
-  #checkov:skip=CKV_AWS_144:dev env
-  #checkov:skip=CKV_AWS_21:dev env
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "osquery-status" {


### PR DESCRIPTION
`lifecycle_rule` on `aws_s3_bucket` is a deprecated argument.

Highlighted in this job: https://github.com/fleetdm/fleet/actions/runs/4583725754/jobs/8094753489#step:4:57