### PR TITLE
acl is deprecated on aws_s3_bucket

### DIFF
--- a/infrastructure/loadtesting/terraform/firehose.tf
+++ b/infrastructure/loadtesting/terraform/firehose.tf
@@ -44,11 +44,15 @@ resource "aws_s3_bucket_public_access_block" "osquery-results" {
 
 resource "aws_s3_bucket" "osquery-status" { #tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-enable-versioning
   bucket = "${local.prefix}-loadtest-osquery-status-archive"
-  acl    = "private"
 
   #checkov:skip=CKV_AWS_18:dev env
   #checkov:skip=CKV_AWS_144:dev env
   #checkov:skip=CKV_AWS_21:dev env
+}
+
+resource "aws_s3_bucket_acl" "osquery-status" {
+  bucket = aws_s3_bucket.osquery-status.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "osquery-status" {


### PR DESCRIPTION
`acl` is a deprecated argument on `aws_s3_bucket`.

Identified by this job: https://github.com/fleetdm/fleet/actions/runs/4585758981/jobs/8098079111#step:4:58