### PR TITLE
Manage policies page: Add search functionality

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -96,6 +96,13 @@ const PoliciesTable = ({
         </Button>
       );
     }
+    if (searchString) {
+      delete emptyPolicies.iconName;
+      delete emptyPolicies.primaryButton;
+      emptyPolicies.header = "No policies match the current search criteria.";
+      emptyPolicies.info =
+        "Expecting to see policies? Try again in a few seconds as the system catches up.";
+    }
 
     return emptyPolicies;
   };

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { AppContext } from "context/app";
 import { noop } from "lodash";
 import paths from "router/paths";
@@ -9,7 +9,7 @@ import { IEmptyTableProps } from "interfaces/empty_table";
 
 import Button from "components/buttons/Button";
 import Spinner from "components/Spinner";
-import TableContainer from "components/TableContainer";
+import TableContainer, { ITableQueryData } from "components/TableContainer";
 import EmptyTable from "components/EmptyTable";
 import { generateTableHeaders, generateDataSet } from "./PoliciesTableConfig";
 
@@ -45,6 +45,12 @@ const PoliciesTable = ({
   const { MANAGE_HOSTS } = paths;
 
   const { config } = useContext(AppContext);
+
+  const [searchString, setSearchString] = useState("");
+
+  const handleSearchChange = ({ searchQuery }: ITableQueryData) => {
+    setSearchString(searchQuery);
+  };
 
   const emptyState = () => {
     const emptyPolicies: IEmptyTableProps = {
@@ -94,6 +100,8 @@ const PoliciesTable = ({
     return emptyPolicies;
   };
 
+  const searchable = !(policiesList?.length === 0 && searchString === "");
+
   return (
     <div
       className={`${baseClass} ${
@@ -134,9 +142,13 @@ const PoliciesTable = ({
               primaryButton: emptyState().primaryButton,
             })
           }
-          onQueryChange={noop}
           disableCount={tableType === "inheritedPolicies"}
           isClientSidePagination
+          isClientSideFilter
+          searchQueryColumn="name"
+          onQueryChange={handleSearchChange}
+          inputPlaceHolder="Search by name"
+          searchable={searchable}
         />
       )}
     </div>


### PR DESCRIPTION
## Issue
Cerra #10491 
Part of a larger story to make cis benchmarks easier to import and use #10589 

## Description
Implement client side search to search policies by name on the manage policies page

## Screen recording
https://user-images.githubusercontent.com/71795832/230098423-a9c79011-301c-47ed-8bdb-c34b23d6b3dc.mov


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality