### PR TITLE
Fix duplicate content in steps for turning on disk encryption

### DIFF
--- a/docs/Using-Fleet/MDM-migration-guide.md
+++ b/docs/Using-Fleet/MDM-migration-guide.md
@@ -86,7 +86,7 @@ Want to know what your organization can see? Read about [transparency](https://f
 
 ![Fleet icon in menu bar](https://raw.githubusercontent.com/fleetdm/fleet/main/website/assets/images/articles/fleet-desktop-says-hello-world-cover-1600x900@2x.jpg)
 
-2. On your **My device** page, select the **Turn on MDM** button and follow the instructions. If you don’t see the **Turn on MDM** button, select the purple **Refetch** button at the top of the page. If you still don't see the **Turn on MDM** button after a couple minutes, please contact your IT administrator. If the **My device page** presents you with an error, please contact your IT administrator.
+2. On your **My device** page, select the **Turn on MDM** button and follow the instructions. If you don’t see the **Turn on MDM** button, select the purple **Refetch** button at the top of the page. If you still don't see the **Turn on MDM** button after a couple minutes, please contact your IT administrator. If the **My device** page presents you with an error, please contact your IT administrator.
 
 ![My device page - turn on MDM](https://raw.githubusercontent.com/fleetdm/fleet/main/docs/images/my-device-page-turn-on-mdm.png)
 
@@ -96,7 +96,7 @@ Want to know what your organization can see? Read about [transparency](https://f
 
 ![Fleet icon in menu bar](https://raw.githubusercontent.com/fleetdm/fleet/main/website/assets/images/articles/fleet-desktop-says-hello-world-cover-1600x900@2x.jpg)
 
-2. On your **My device** page, follow the disk encryption instructions in the yellow banner. If you don’t see the **Turn on MDM** button, select the purple **Refetch** button at the top of the page. If you still don't see the **Turn on MDM** button after a couple minutes, please contact your IT administrator. If the **My device page** presents you with an error, please contact your IT administrator.
+2. On your **My device** page, follow the disk encryption instructions in the yellow banner. If the banner persists after turning on disk encryption, select the purple **Refetch** button at the top of the page. If you still see the banner after a few minutes, or if the **My device** page presents you with an error, please contact your IT administrator.
 
 ![My device page - turn on disk encryption](https://raw.githubusercontent.com/fleetdm/fleet/main/docs/images/my-device-page-turn-on-disk-encryption.png)
 


### PR DESCRIPTION
Noticed the 2nd step of the instructions for turning on disk encryption had some content duplicated from the "How to turn on MDM" section above it. Since it didn't match up with my experience when I went to turn on disk encryption, I took a stab at updating it to be more accurate.

Also, tiny formatting thing: made the bolding for "**My device page**"/"**My device** page" consistent in those sections

# Checklist for submitter

> No checklist items apply as far as I can tell (docs-only change)
