### PR TITLE
Consolidate duplicate DUP/HostDetails styles in shared parent stylesheet

### DIFF
--- a/frontend/layouts/CoreLayout/_styles.scss
+++ b/frontend/layouts/CoreLayout/_styles.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  background-color: $ui-off-white;
 }
 
 .core-wrapper {

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -1,5 +1,4 @@
 .app-wrap {
-  background-color: $ui-off-white;
   .site-nav {
     height: 50px;
   }
@@ -33,7 +32,6 @@
     list-style-position: inside;
   }
 }
-
 .device-user {
   display: flex;
   flex-direction: column;
@@ -48,292 +46,14 @@
       white-space: nowrap;
     }
   }
-
-  .header {
-    flex: 100%;
-    display: flex;
-    flex-direction: column;
-  }
-
   a img.external-link-icon {
     width: 12px;
     height: 12px;
     margin-left: 0.25rem;
   }
 
-  .section {
-    flex: 100%;
-    display: flex;
-    flex-direction: column;
-    background-color: $core-white;
-    border-radius: 16px;
-    border: 1px solid $ui-fleet-black-10;
-    padding: $pad-xxlarge;
-    box-shadow: 0px 3px 0px rgba(226, 228, 234, 0.4);
-
-    &__header {
-      font-size: $medium;
-      font-weight: $bold;
-      margin: 0 0 $pad-large 0;
-    }
-
-    .info-flex {
-      display: flex;
-      flex-wrap: wrap;
-
-      .info-flex__item--title {
-        margin-bottom: 2.5rem;
-      }
-
-      &__item {
-        font-size: $x-small;
-        display: flex;
-        flex-direction: column;
-        white-space: nowrap;
-
-        &--title {
-          margin-right: $pad-xxlarge;
-
-          .info-flex__data {
-            display: flex;
-            gap: 4px;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-
-            img {
-              width: 16px;
-              height: 16px;
-              vertical-align: sub;
-            }
-
-            .icon {
-              width: 16px;
-              height: 16px;
-              align-self: center;
-            }
-
-            &__text {
-              padding-left: $pad-xsmall;
-            }
-          }
-        }
-
-        // Position tooltip over parent div
-        .component__tooltip-wrapper {
-          position: absolute;
-          margin-top: 20px;
-        }
-      }
-
-      &__header {
-        color: $core-fleet-black;
-        font-weight: $bold;
-      }
-    }
-
-    .info-grid {
-      display: grid;
-      grid-auto-flow: column;
-      grid-template-columns: repeat(4, max-content);
-      grid-template-rows: repeat(3, 1fr);
-      column-gap: $pad-xxlarge;
-      row-gap: $pad-medium;
-
-      &__block {
-        font-size: $x-small;
-        display: flex;
-        flex-direction: column;
-        white-space: nowrap;
-
-        &--title {
-          margin-right: $pad-xxlarge;
-
-          .info__data {
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-          }
-        }
-      }
-      &__header {
-        color: $core-fleet-black;
-        font-weight: $bold;
-      }
-    }
-
-    .list {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-
-      &__item {
-        margin-bottom: 12px;
-        display: flex;
-
-        &:last-child {
-          margin-bottom: 0;
-        }
-      }
-    }
-
-    .results {
-      margin: 0;
-      width: 350px;
-
-      &__header {
-        margin: 0 0 $pad-medium 0;
-        font-size: $small;
-        color: $core-fleet-black;
-        font-weight: $bold;
-      }
-
-      &__data {
-        margin: 0;
-        font-size: $x-small;
-      }
-    }
-  }
-
-  .title {
-    flex-direction: row;
-    justify-content: space-between;
-    margin: 0;
-    padding-bottom: 0;
-
-    .display-name-container {
-      display: flex;
-      align-items: center;
-    }
-
-    .display-name {
-      font-size: $large;
-      font-weight: $bold;
-    }
-
-    .last-fetched {
-      font-size: $xx-small;
-      color: $core-fleet-black;
-      margin: 0;
-      padding-left: $pad-small;
-    }
-
-    .refetch {
-      display: flex;
-      margin-right: $pad-small;
-
-      .refetch-btn {
-        font-size: $x-small;
-        height: 38px;
-        margin-right: $pad-small;
-
-        &::before {
-          display: inline-block;
-          position: relative;
-          padding: 5px 0 0 0; // centers spin
-          content: url(../assets/images/icon-refetch-12x12@2x.png);
-          transform: scale(0.5);
-          height: 28px;
-        }
-      }
-
-      .refetch-offline {
-        opacity: 25%;
-      }
-
-      .refetch-spinner {
-        color: $core-vibrant-blue;
-        cursor: default;
-        font-size: $x-small;
-        height: 38px;
-        opacity: 50%;
-        filter: saturate(100%);
-
-        &::before {
-          display: inline-block;
-          position: relative;
-          padding: 5px 0 0 0; // centers spin
-          display: inline-block;
-          content: url(../assets/images/icon-refetch-12x12@2x.png);
-          transform: scale(0.5);
-          animation: spin 2s linear infinite;
-        }
-
-        @keyframes spin {
-          0% {
-            transform: scale(0.5) rotate(0deg);
-            transform-origin: center center;
-          }
-          100% {
-            transform: scale(0.5) rotate(360deg);
-            transform-origin: center center;
-          }
-        }
-      }
-    }
-  }
-
   .button img {
     transform: scale(0.5);
-  }
-
-  .component__tabs-wrapper {
-    background-color: $ui-off-white;
-    width: 100%;
-
-    .react-tabs__tab {
-      padding: 6px 0px 16px 0px;
-      margin-right: $pad-xxlarge;
-    }
-
-    .react-tabs__tab--selected {
-      background-color: $ui-off-white;
-    }
-
-    .focus-visible {
-      background-color: $ui-vibrant-blue-10;
-    }
-
-    .section {
-      margin-top: $pad-medium;
-    }
-  }
-
-  .col-50 {
-    flex: 2;
-  }
-
-  .col-25 {
-    flex: 1;
-  }
-
-  .status {
-    color: $core-fleet-black;
-    text-transform: capitalize;
-
-    &--online {
-      &:before {
-        background-color: $ui-success;
-        border-radius: 100%;
-        content: " ";
-        display: inline-block;
-        height: 8px;
-        margin-right: $pad-small;
-        width: 8px;
-      }
-    }
-
-    &--offline {
-      &:before {
-        background-color: $ui-fleet-black-25;
-        border-radius: 100%;
-        content: " ";
-        display: inline-block;
-        height: 8px;
-        margin-right: $pad-small;
-        width: 8px;
-      }
-    }
   }
 
   &__error {
@@ -355,6 +75,7 @@
         font-size: $x-small;
         text-align: left;
       }
+
       &__data {
         display: block;
         color: $core-fleet-black;
@@ -393,26 +114,6 @@
       height: 16px;
       width: auto;
     }
-  }
-
-  .buttons {
-    display: flex;
-    align-items: center;
-    position: absolute;
-    right: 25px;
-
-    span {
-      font-weight: $regular;
-    }
-
-    a {
-      display: flex;
-      align-items: center;
-    }
-  }
-
-  .form-field--dropdown {
-    margin: 0;
   }
 
   .section--policies

--- a/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/_styles.scss
@@ -6,241 +6,10 @@
     gap: 1rem;
   }
 
-  .header {
-    flex: 100%;
-    display: flex;
-    flex-direction: column;
-  }
-
-  .section {
-    flex: 100%;
-    display: flex;
-    flex-direction: column;
-    background-color: $core-white;
-    border-radius: 16px;
-    border: 1px solid $ui-fleet-black-10;
-    padding: $pad-xxlarge;
-    box-shadow: 0px 3px 0px rgba(226, 228, 234, 0.4);
-
-    &__header {
-      font-size: $medium;
-      font-weight: $bold;
-      margin: 0 0 $pad-large 0;
-    }
-
-    .info-flex {
-      display: flex;
-      flex-wrap: wrap;
-
-      .info-flex__item--title {
-        margin-bottom: 2.5rem;
-      }
-
-      &__item {
-        font-size: $x-small;
-        display: flex;
-        flex-direction: column;
-        white-space: nowrap;
-
-        &--title {
-          margin-right: $pad-xxlarge;
-
-          .info-flex__data {
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-
-            img {
-              width: 16px;
-              height: 16px;
-              vertical-align: sub;
-            }
-
-            &__text {
-              padding-left: $pad-xsmall;
-            }
-          }
-        }
-
-        // Position tooltip over parent div
-        .component__tooltip-wrapper {
-          position: absolute;
-          margin-top: 20px;
-        }
-      }
-
-      &__header {
-        color: $core-fleet-black;
-        font-weight: $bold;
-      }
-
-      &__no-team {
-        color: $ui-fleet-black-50;
-      }
-    }
-
-    .info-grid {
-      display: grid;
-      grid-auto-flow: column;
-      grid-template-columns: repeat(4, max-content);
-      grid-template-rows: repeat(3, 1fr);
-      column-gap: $pad-xxlarge;
-      row-gap: $pad-medium;
-
-      &__block {
-        font-size: $x-small;
-        display: flex;
-        flex-direction: column;
-        white-space: nowrap;
-
-        &--title {
-          margin-right: $pad-xxlarge;
-
-          .info__data {
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-          }
-        }
-      }
-      &__header {
-        color: $core-fleet-black;
-        font-weight: $bold;
-      }
-    }
-
-    .list {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-
-      &__item {
-        margin-bottom: 12px;
-        display: flex;
-
-        &:last-child {
-          margin-bottom: 0;
-        }
-      }
-    }
-
-    .results {
-      margin: 0;
-      width: 350px;
-
-      &__header {
-        margin: 0 0 $pad-medium 0;
-        font-size: $small;
-        color: $core-fleet-black;
-        font-weight: $bold;
-      }
-
-      &__data {
-        margin: 0;
-        font-size: $x-small;
-      }
-    }
-  }
-
-  .title {
-    flex-direction: row;
-    justify-content: space-between;
-    margin: 0;
-    padding-bottom: 0;
-
-    .display-name-container {
-      display: flex;
-      align-items: center;
-    }
-
-    .display-name {
-      font-size: $large;
-      font-weight: $bold;
-    }
-
-    .last-fetched {
-      font-size: $xx-small;
-      color: $core-fleet-black;
-      margin: 0;
-      padding-left: $pad-small;
-    }
-
-    .refetch {
-      display: flex;
-      margin-right: $pad-small;
-
-      .refetch-btn {
-        font-size: $x-small;
-        height: 38px;
-        margin-right: $pad-small;
-
-        &::before {
-          display: inline-block;
-          position: relative;
-          padding: 5px 0 0 0; // centers spin
-          content: url(../assets/images/icon-refetch-12x12@2x.png);
-          transform: scale(0.5);
-          height: 28px;
-        }
-      }
-
-      .refetch-offline {
-        opacity: 25%;
-      }
-
-      .refetch-spinner {
-        color: $core-vibrant-blue;
-        cursor: default;
-        font-size: $x-small;
-        height: 38px;
-        opacity: 50%;
-        filter: saturate(100%);
-
-        &::before {
-          display: inline-block;
-          position: relative;
-          padding: 5px 0 0 0; // centers spin
-          display: inline-block;
-          content: url(../assets/images/icon-refetch-12x12@2x.png);
-          transform: scale(0.5);
-          animation: spin 2s linear infinite;
-        }
-
-        @keyframes spin {
-          0% {
-            transform: scale(0.5) rotate(0deg);
-            transform-origin: center center;
-          }
-          100% {
-            transform: scale(0.5) rotate(360deg);
-            transform-origin: center center;
-          }
-        }
-      }
-    }
-  }
-
   .component__tabs-wrapper {
-    background-color: $ui-off-white;
-    width: 100%;
-
     .react-tabs__tab {
-      padding: 6px 0px 16px 0px;
-      margin-right: $pad-xxlarge;
       display: inline-flex;
       flex-direction: row;
-    }
-
-    .react-tabs__tab--selected {
-      background-color: $ui-off-white;
-    }
-
-    .focus-visible {
-      background-color: $ui-vibrant-blue-10;
-    }
-
-    .section {
-      margin-top: $pad-medium;
     }
   }
 
@@ -252,6 +21,7 @@
   .section.osquery {
     margin-right: $pad-small;
   }
+
   .section.labels {
     margin-left: $pad-small;
   }
@@ -265,7 +35,6 @@
           flex-direction: row;
         }
       }
-
       &__block {
         display: flex;
         flex-direction: column;
@@ -280,64 +49,6 @@
       }
     }
   }
-
-  .col-50 {
-    flex: 2;
-  }
-
-  .col-25 {
-    flex: 1;
-  }
-
-  .status {
-    color: $core-fleet-black;
-    text-transform: capitalize;
-
-    &--online {
-      &:before {
-        background-color: $ui-success;
-        border-radius: 100%;
-        content: " ";
-        display: inline-block;
-        height: 8px;
-        margin-right: $pad-small;
-        width: 8px;
-      }
-    }
-
-    &--offline {
-      &:before {
-        background-color: $ui-fleet-black-25;
-        border-radius: 100%;
-        content: " ";
-        display: inline-block;
-        height: 8px;
-        margin-right: $pad-small;
-        width: 8px;
-      }
-    }
-  }
-
-  .form-field--dropdown {
-    margin: 0;
-  }
-
-  .buttons {
-    display: flex;
-    align-items: center;
-    position: absolute;
-    right: 25px;
-
-    span {
-      font-weight: $regular;
-    }
-
-    a {
-      display: flex;
-      align-items: center;
-    }
-  }
-
   .button img {
     transform: scale(0.5);
   }

--- a/frontend/pages/hosts/details/_styles.scss
+++ b/frontend/pages/hosts/details/_styles.scss
@@ -1,0 +1,299 @@
+.host-details,
+.device-user {
+  .header {
+    flex: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+  .section {
+    flex: 100%;
+    display: flex;
+    flex-direction: column;
+    background-color: $core-white;
+    border-radius: 16px;
+    border: 1px solid $ui-fleet-black-10;
+    padding: $pad-xxlarge;
+    box-shadow: 0px 3px 0px rgba(226, 228, 234, 0.4);
+
+    &__header {
+      font-size: $medium;
+      font-weight: $bold;
+      margin: 0 0 $pad-large 0;
+    }
+
+    .info-flex {
+      display: flex;
+      flex-wrap: wrap;
+
+      .info-flex__item--title {
+        margin-bottom: 2.5rem;
+      }
+
+      &__item {
+        font-size: $x-small;
+        display: flex;
+        flex-direction: column;
+        white-space: nowrap;
+
+        &--title {
+          margin-right: $pad-xxlarge;
+
+          .info-flex__data {
+            display: flex;
+            gap: 4px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+
+            img {
+              width: 16px;
+              height: 16px;
+              vertical-align: sub;
+            }
+
+            .icon {
+              width: 16px;
+              height: 16px;
+              align-self: center;
+            }
+
+            &__text {
+              padding-left: $pad-xsmall;
+            }
+          }
+        }
+
+        // Position tooltip over parent div
+        .component__tooltip-wrapper {
+          position: absolute;
+          margin-top: 20px;
+        }
+      }
+
+      &__header {
+        color: $core-fleet-black;
+        font-weight: $bold;
+      }
+
+      &__no-team {
+        color: $ui-fleet-black-50;
+      }
+    }
+
+    .info-grid {
+      display: grid;
+      grid-auto-flow: column;
+      grid-template-columns: repeat(4, max-content);
+      grid-template-rows: repeat(3, 1fr);
+      column-gap: $pad-xxlarge;
+      row-gap: $pad-medium;
+
+      &__block {
+        font-size: $x-small;
+        display: flex;
+        flex-direction: column;
+        white-space: nowrap;
+
+        &--title {
+          margin-right: $pad-xxlarge;
+
+          .info__data {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+          }
+        }
+      }
+      &__header {
+        color: $core-fleet-black;
+        font-weight: $bold;
+      }
+    }
+
+    .list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+
+      &__item {
+        margin-bottom: 12px;
+        display: flex;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
+
+    .results {
+      margin: 0;
+      width: 350px;
+
+      &__header {
+        margin: 0 0 $pad-medium 0;
+        font-size: $small;
+        color: $core-fleet-black;
+        font-weight: $bold;
+      }
+
+      &__data {
+        margin: 0;
+        font-size: $x-small;
+      }
+    }
+  }
+
+  .title {
+    flex-direction: row;
+    justify-content: space-between;
+    margin: 0;
+    padding-bottom: 0;
+
+    .display-name-container {
+      display: flex;
+      align-items: center;
+    }
+
+    .display-name {
+      font-size: $large;
+      font-weight: $bold;
+    }
+
+    .last-fetched {
+      font-size: $xx-small;
+      color: $core-fleet-black;
+      margin: 0;
+      padding-left: $pad-small;
+    }
+
+    .refetch {
+      display: flex;
+      margin-right: $pad-small;
+
+      .refetch-btn {
+        font-size: $x-small;
+        height: 38px;
+        margin-right: $pad-small;
+
+        &::before {
+          display: inline-block;
+          position: relative;
+          padding: 5px 0 0 0; // centers spin
+          content: url(../assets/images/icon-refetch-12x12@2x.png);
+          transform: scale(0.5);
+          height: 28px;
+        }
+      }
+
+      .refetch-offline {
+        opacity: 25%;
+      }
+
+      .refetch-spinner {
+        color: $core-vibrant-blue;
+        cursor: default;
+        font-size: $x-small;
+        height: 38px;
+        opacity: 50%;
+        filter: saturate(100%);
+
+        &::before {
+          display: inline-block;
+          position: relative;
+          padding: 5px 0 0 0; // centers spin
+          display: inline-block;
+          content: url(../assets/images/icon-refetch-12x12@2x.png);
+          transform: scale(0.5);
+          animation: spin 2s linear infinite;
+        }
+
+        @keyframes spin {
+          0% {
+            transform: scale(0.5) rotate(0deg);
+            transform-origin: center center;
+          }
+          100% {
+            transform: scale(0.5) rotate(360deg);
+            transform-origin: center center;
+          }
+        }
+      }
+    }
+  }
+  .component__tabs-wrapper {
+    background-color: $ui-off-white;
+    width: 100%;
+
+    .react-tabs__tab {
+      padding: 6px 0px 16px 0px;
+      margin-right: $pad-xxlarge;
+    }
+    .react-tabs__tab--selected {
+      background-color: $ui-off-white;
+    }
+
+    .focus-visible {
+      background-color: $ui-vibrant-blue-10;
+    }
+
+    .section {
+      margin-top: $pad-medium;
+    }
+  }
+  .col-50 {
+    flex: 2;
+  }
+
+  .col-25 {
+    flex: 1;
+  }
+
+  .status {
+    color: $core-fleet-black;
+    text-transform: capitalize;
+
+    &--online {
+      &:before {
+        background-color: $ui-success;
+        border-radius: 100%;
+        content: " ";
+        display: inline-block;
+        height: 8px;
+        margin-right: $pad-small;
+        width: 8px;
+      }
+    }
+
+    &--offline {
+      &:before {
+        background-color: $ui-fleet-black-25;
+        border-radius: 100%;
+        content: " ";
+        display: inline-block;
+        height: 8px;
+        margin-right: $pad-small;
+        width: 8px;
+      }
+    }
+  }
+
+  .form-field--dropdown {
+    margin: 0;
+  }
+
+  .buttons {
+    display: flex;
+    align-items: center;
+    position: absolute;
+    right: 25px;
+
+    span {
+      font-weight: $regular;
+    }
+
+    a {
+      display: flex;
+      align-items: center;
+    }
+  }
+}


### PR DESCRIPTION
## Addresses duplicate styles between the Device User Page and Host Details Page

Manual check that resulting page styling remains constant – windows on the left are on `main` (containing duplicate styles), windows on the right are on this branch:

**Host details:**
![Screenshot 2023-04-04 at 3 42 27 PM](https://user-images.githubusercontent.com/61553566/229941459-061e3798-be47-467d-984a-10631028e1d3.png)
**DUP:**
![Screenshot 2023-04-04 at 3 41 38 PM](https://user-images.githubusercontent.com/61553566/229941468-2f9d993f-1961-49dc-a76d-4da4709e8a81.png)

## Checklist for submitter
- [x] Manual QA for all new/changed functionality