### PR TITLE
number_cache_clusters is a deprecated argument in loadtesting/redis.tf

### DIFF
--- a/infrastructure/loadtesting/terraform/redis.tf
+++ b/infrastructure/loadtesting/terraform/redis.tf
@@ -5,7 +5,7 @@ resource "aws_elasticache_replication_group" "default" {
   subnet_group_name             = data.terraform_remote_state.shared.outputs.vpc.elasticache_subnet_group_name
   security_group_ids            = [aws_security_group.redis.id, aws_security_group.backend.id]
   replication_group_id          = "${local.prefix}-redis"
-  number_cache_clusters         = 3
+  num_cache_clusters            = 3
   node_type                     = var.redis_instance_type
   engine_version                = "5.0.6"
   port                          = "6379"


### PR DESCRIPTION
`number_cache_clusters` is a deprecated argument for `aws_elasticache_replication_group`.
The replacement is `num_cache_clusters`.

Highlighted on this job: https://github.com/fleetdm/fleet/actions/runs/4600246486/jobs/8126589394#step:4:54

---
From https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group#argument-reference:

> `number_cache_clusters` - (Optional, Deprecated use `num_cache_clusters` instead) 