### PR TITLE
explicitly enable orbit to read config from the system

### DIFF
--- a/cmd/fleetctl/package.go
+++ b/cmd/fleetctl/package.go
@@ -175,6 +175,12 @@ func packageCommand() *cli.Command {
 				EnvVars:     []string{"FLEETCTL_APP_STORE_CONNECT_API_KEY_CONTENT"},
 				Destination: &opt.AppStoreConnectAPIKeyContent,
 			},
+			&cli.BoolFlag{
+				Name:        "use-system-configuration",
+				Usage:       "Try to read --fleet-url and --enroll-secret using configuration in the host (curently only macOS profiles are supported)",
+				EnvVars:     []string{"FLEETCTL_USE_SYSTEM_CONFIGURATION"},
+				Destination: &opt.UseSystemConfiguration,
+			},
 		},
 		Action: func(c *cli.Context) error {
 			if opt.FleetURL != "" || opt.EnrollSecret != "" {
@@ -200,6 +206,10 @@ func packageCommand() *cli.Command {
 				if err != nil {
 					return fmt.Errorf("failed to read certificate %q: %w", opt.FleetCertificate, err)
 				}
+			}
+
+			if opt.UseSystemConfiguration && c.String("type") != "pkg" {
+				return errors.New("--use-system-configuration is only available for pkg installers")
 			}
 
 			var buildFunc func(packaging.Options) (string, error)

--- a/cmd/fleetctl/package_test.go
+++ b/cmd/fleetctl/package_test.go
@@ -49,11 +49,14 @@ func TestPackage(t *testing.T) {
 		require.Greater(t, info.Size(), int64(0)) // TODO verify contents
 	})
 
-	t.Run("rpm", func(t *testing.T) {
-		runAppForTest(t, []string{"package", "--type=rpm", "--insecure", "--disable-open-folder"})
-		info, err := os.Stat(fmt.Sprintf("fleet-osquery-%s.x86_64.rpm", updatesData.OrbitVersion))
-		require.NoError(t, err)
-		require.Greater(t, info.Size(), int64(0)) // TODO verify contents
+	t.Run("--use-sytem-configuration can't be used on installers that aren't pkg", func(t *testing.T) {
+		for _, p := range []string{"deb", "msi", "rpm", ""} {
+			runAppCheckErr(
+				t,
+				[]string{"package", fmt.Sprintf("--type=%s", p), "--use-system-configuration"},
+				"--use-system-configuration is only available for pkg installers",
+			)
+		}
 	})
 
 	// fleet-osquery.msi

--- a/docs/Using-Fleet/Adding-hosts.md
+++ b/docs/Using-Fleet/Adding-hosts.md
@@ -113,28 +113,29 @@ To generate an osquery installer for a team:
 
 The following command-line flags allow you to configure an osquery installer further to communicate with a specific Fleet instance.
 
-| Flag                | Options                                                                                                                                 |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| --type              | **Required** - Type of package to build.<br> Options: `pkg`(macOS),`msi`(Windows), `deb`(Debian based Linux), `rpm`(RHEL, CentOS, etc.) |
-| --fleet-desktop     | Include Fleet Desktop.                                                                                                                  |
-| --enroll-secret     | Enroll secret for authenticating to Fleet server                                                                                        |
-| --fleet-url         | URL (`host:port`) of Fleet server                                                                                                       |
-| --fleet-certificate | Path to server certificate bundle                                                                                                       |
-| --identifier        | Identifier for package product (default: `com.fleetdm.orbit`)                                                                           |
-| --version           | Version for package product (default: `0.0.3`)                                                                                          |
-| --insecure          | Disable TLS certificate verification (default: `false`)                                                                                 |
-| --service           | Install osquery with a persistence service (launchd, systemd, etc.) (default: `true`)                                                   |
-| --sign-identity     | Identity to use for macOS codesigning                                                                                                   |
-| --notarize          | Whether to notarize macOS packages (default: `false`)                                                                                   |
-| --disable-updates   | Disable auto updates on the generated package (default: false)                                                                          |
-| --osqueryd-channel  | Update channel of osqueryd to use (default: `stable`)                                                                                   |
-| --orbit-channel     | Update channel of Orbit to use (default: `stable`)                                                                                      |
-| --desktop-channel   | Update channel of desktop to use (default: `stable`)                                                                                    |
-| --update-url        | URL for update server (default: `https://tuf.fleetctl.com`)                                                                             |
-| --update-roots      | Root key JSON metadata for update server (from fleetctl updates roots)                                                                  |
-| --debug             | Enable debug logging (default: `false`)                                                                                                 |
-| --verbose           | Log detailed information when building the package (default: false)                                                                     |
-| --help, -h          | show help (default: `false`)                                                                                                            |
+| Flag                       | Options                                                                                                                                 |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| --type                     | **Required** - Type of package to build.<br> Options: `pkg`(macOS),`msi`(Windows), `deb`(Debian based Linux), `rpm`(RHEL, CentOS, etc.) |
+| --fleet-desktop            | Include Fleet Desktop.                                                                                                                  |
+| --enroll-secret            | Enroll secret for authenticating to Fleet server                                                                                        |
+| --fleet-url                | URL (`host:port`) of Fleet server                                                                                                       |
+| --fleet-certificate        | Path to server certificate bundle                                                                                                       |
+| --identifier               | Identifier for package product (default: `com.fleetdm.orbit`)                                                                           |
+| --version                  | Version for package product (default: `0.0.3`)                                                                                          |
+| --insecure                 | Disable TLS certificate verification (default: `false`)                                                                                 |
+| --service                  | Install osquery with a persistence service (launchd, systemd, etc.) (default: `true`)                                                   |
+| --sign-identity            | Identity to use for macOS codesigning                                                                                                   |
+| --notarize                 | Whether to notarize macOS packages (default: `false`)                                                                                   |
+| --disable-updates          | Disable auto updates on the generated package (default: false)                                                                          |
+| --osqueryd-channel         | Update channel of osqueryd to use (default: `stable`)                                                                                   |
+| --orbit-channel            | Update channel of Orbit to use (default: `stable`)                                                                                      |
+| --desktop-channel          | Update channel of desktop to use (default: `stable`)                                                                                    |
+| --update-url               | URL for update server (default: `https://tuf.fleetctl.com`)                                                                             |
+| --update-roots             | Root key JSON metadata for update server (from fleetctl updates roots)                                                                  |
+| --use-system-configuration | Try to read --fleet-url and --enroll-secret using configuration in the host (curently only macOS profiles are supported)                |
+| --debug                    | Enable debug logging (default: `false`)                                                                                                 |
+| --verbose                  | Log detailed information when building the package (default: false)                                                                     |
+| --help, -h                 | show help (default: `false`)                                                                                                            |
 
 
 Fleet supports other methods for adding your hosts to Fleet, such as the [plain osquery binaries](#add-hosts-with-plain-osquery) or [Kolide Osquery Launcher](https://github.com/kolide/launcher/blob/master/docs/launcher.md#connecting-to-fleet).

--- a/docs/Using-Fleet/Orbit.md
+++ b/docs/Using-Fleet/Orbit.md
@@ -174,28 +174,29 @@ When the Fleet server uses a self-signed (or otherwise invalid) TLS certificate,
 
 The following command-line flags allow you to configure an osquery installer further to communicate with a specific Fleet instance.
 
-| Flag                | Options                                                                                                                                 |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| --type              | **Required** - Type of package to build.<br> Options: `pkg`(macOS),`msi`(Windows), `deb`(Debian based Linux), `rpm`(RHEL, CentOS, etc.) |
-| --fleet-desktop     | Include Fleet Desktop.                                                                                                                  |
-| --enroll-secret     | Enroll secret for authenticating to Fleet server                                                                                        |
-| --fleet-url         | URL (`host:port`) of Fleet server                                                                                                       |
-| --fleet-certificate | Path to server certificate bundle                                                                                                       |
-| --identifier        | Identifier for package product (default: `com.fleetdm.orbit`)                                                                           |
-| --version           | Version for package product (default: `0.0.3`)                                                                                          |
-| --insecure          | Disable TLS certificate verification (default: `false`)                                                                                 |
-| --service           | Install osquery with a persistence service (launchd, systemd, etc.) (default: `true`)                                                   |
-| --sign-identity     | Identity to use for macOS codesigning                                                                                                   |
-| --notarize          | Whether to notarize macOS packages (default: `false`)                                                                                   |
-| --disable-updates   | Disable auto updates on the generated package (default: false)                                                                          |
-| --osqueryd-channel  | Update channel of osqueryd to use (default: `stable`)                                                                                   |
-| --orbit-channel     | Update channel of Orbit to use (default: `stable`)                                                                                      |
-| --desktop-channel   | Update channel of desktop to use (default: `stable`)                                                                                    |
-| --update-url        | URL for update server (default: `https://tuf.fleetctl.com`)                                                                             |
-| --update-roots      | Root key JSON metadata for update server (from fleetctl updates roots)                                                                  |
-| --debug             | Enable debug logging (default: `false`)                                                                                                 |
-| --verbose           | Log detailed information when building the package (default: false)                                                                     |
-| --help, -h          | show help (default: `false`)                                                                                                            |
+| Flag                       | Options                                                                                                                                 |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| --type                     | **Required** - Type of package to build.<br> Options: `pkg`(macOS),`msi`(Windows), `deb`(Debian based Linux), `rpm`(RHEL, CentOS, etc.) |
+| --fleet-desktop            | Include Fleet Desktop.                                                                                                                  |
+| --enroll-secret            | Enroll secret for authenticating to Fleet server                                                                                        |
+| --fleet-url                | URL (`host:port`) of Fleet server                                                                                                       |
+| --fleet-certificate        | Path to server certificate bundle                                                                                                       |
+| --identifier               | Identifier for package product (default: `com.fleetdm.orbit`)                                                                           |
+| --version                  | Version for package product (default: `0.0.3`)                                                                                          |
+| --insecure                 | Disable TLS certificate verification (default: `false`)                                                                                 |
+| --service                  | Install osquery with a persistence service (launchd, systemd, etc.) (default: `true`)                                                   |
+| --sign-identity            | Identity to use for macOS codesigning                                                                                                   |
+| --notarize                 | Whether to notarize macOS packages (default: `false`)                                                                                   |
+| --disable-updates          | Disable auto updates on the generated package (default: false)                                                                          |
+| --osqueryd-channel         | Update channel of osqueryd to use (default: `stable`)                                                                                   |
+| --orbit-channel            | Update channel of Orbit to use (default: `stable`)                                                                                      |
+| --desktop-channel          | Update channel of desktop to use (default: `stable`)                                                                                    |
+| --update-url               | URL for update server (default: `https://tuf.fleetctl.com`)                                                                             |
+| --update-roots             | Root key JSON metadata for update server (from fleetctl updates roots)                                                                  |
+| --use-system-configuration | Try to read --fleet-url and --enroll-secret using configuration in the host (curently only macOS profiles are supported)                |
+| --debug                    | Enable debug logging (default: `false`)                                                                                                 |
+| --verbose                  | Log detailed information when building the package (default: false)                                                                     |
+| --help, -h                 | show help (default: `false`)                                                                                                            |
 
 #### Fleet Desktop
 

--- a/orbit/changes/9459-use-system-config
+++ b/orbit/changes/9459-use-system-config
@@ -1,0 +1,1 @@
+* Added a new flag, `--use-system-config` to make orbit read configuration values from the system. Currently this is only supported in macOS via configuration profiles.

--- a/orbit/changes/9459-use-system-config
+++ b/orbit/changes/9459-use-system-config
@@ -1,1 +1,1 @@
-* Added a new flag, `--use-system-config` to make orbit read configuration values from the system. Currently this is only supported in macOS via configuration profiles.
+* Added a new flag, `--use-system-configuration` to make orbit read configuration values from the system. Currently this is only supported in macOS via configuration profiles.

--- a/orbit/pkg/packaging/macos_templates.go
+++ b/orbit/pkg/packaging/macos_templates.go
@@ -121,6 +121,10 @@ var macosLaunchdTemplate = template.Must(template.New("").Option("missingkey=err
 		<key>ORBIT_FLEET_URL</key>
 		<string>{{ .FleetURL }}</string>
 		{{- end }}
+		{{- if .UseSystemConfiguration }}
+		<key>ORBIT_USE_SYSTEM_CONFIGURATION</key>
+		<string>{{ .UseSystemConfiguration }}</string>
+		{{- end }}
 		{{- if .DisableUpdates }}
 		<key>ORBIT_DISABLE_UPDATES</key>
 		<string>true</string>

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -78,6 +78,10 @@ type Options struct {
 	AppStoreConnectAPIKeyIssuer string
 	// AppStoreConnectAPIKeyContent is the content of the App Store API Key
 	AppStoreConnectAPIKeyContent string
+	// UseSystemConfiguration tells fleetd to try to read FleetURL and
+	// EnrollSecret from a system configuration that's present on the host.
+	// Currently only macOS profiles are supported.
+	UseSystemConfiguration bool
 }
 
 func initializeTempDir() (string, error) {


### PR DESCRIPTION
in #10134 we added a silent mechanism to try to read configuration values from macOS configuration profiles if --fleet-url and --enroll-secret weren't present.

while using this logic to test #9459 I have found that there's a race condition where sometimes `fleetd` is installed before the configuration profile with the values delivered by Fleet, causing orbit to get stuck forever.

I added logic to loop every 30 seconds and try to fetch the values again if none are found, but I didn't felt comfortable adding this logic without also adding an extra flag to explicitly enable this behavior.

I'm okay removing the extra flag if anyone feels like I'm being overly cautious.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
