### PR TITLE
Ensure that short tags push to quay in addition to dockerhub

### DIFF
--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -76,5 +76,6 @@ jobs:
       - name: Tag and push to quay.io
         run: |
           for TAG in ${{ steps.docker.outputs.TAG }}; do
-          docker buildx imagetools create --tag quay.io/fleetdm/fleet:${TAG} fleetdm/fleet:${TAG}
+          docker tag fleetdm/fleet:${TAG} quay.io/fleetdm/fleet:${TAG}
+          docker push quay.io/fleetdm/fleet:${TAG}
           done

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -77,5 +77,6 @@ jobs:
       - name: Tag and push to quay.io
         run: |
           for TAG in ${{ steps.docker.outputs.TAG }}; do
-          docker buildx imagetools create --tag quay.io/fleetdm/fleet:${TAG} fleetdm/fleet:${TAG}
+          docker tag fleetdm/fleet:${TAG} quay.io/fleetdm/fleet:${TAG}
+          docker push quay.io/fleetdm/fleet:${TAG}
           done

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Get tag
         run: |
-          echo "TAG=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
+          echo "TAG=$(git rev-parse --abbrev-ref HEAD) $(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
         id: docker
 
       - name: List tags for push


### PR DESCRIPTION
This should include the short tags (such as `fleetdm/fleet:43e434b`) when pushing to quay.io (`quay.io/fleetdm/fleet:43e434b`)

Additionally, the previous `docker buildx imagetools create` line was only pushing a linux/amd64 image to quay.  This means that for these tags, one could not pull from quay on an arm64 Mac for example.  This update should correct that.

I will wait for the actions to run on this branch prior to pushing and ensure it behaves as expected.