### PR TITLE
UI: org logo bug fix

### DIFF
--- a/changes/10981-org-logo-clickable-outside-nav
+++ b/changes/10981-org-logo-clickable-outside-nav
@@ -1,0 +1,1 @@
+- Fixed a bug where for certain org logos, the user could still click on it even outside the navbar

--- a/frontend/components/icons/OrgLogoIcon/OrgLogoIcon.jsx
+++ b/frontend/components/icons/OrgLogoIcon/OrgLogoIcon.jsx
@@ -72,7 +72,10 @@ class OrgLogoIcon extends Component {
     const { imageSrc } = this.state;
     const { onError } = this;
 
-    const classNames = classnames(baseClass, className);
+    const classNames =
+      imageSrc === fleetAvatar
+        ? classnames(baseClass, className, "default-fleet-logo")
+        : classnames(baseClass, className);
 
     return (
       <img

--- a/frontend/components/icons/OrgLogoIcon/_styles.scss
+++ b/frontend/components/icons/OrgLogoIcon/_styles.scss
@@ -1,4 +1,8 @@
 .org-logo-icon {
   // ensures consistant nav bar height regardless of the logo image used
-  max-height: 92px;
+  max-height: 46px;
+}
+
+.default-fleet-logo {
+  transform: scale(0.5);
 }

--- a/frontend/components/top_nav/SiteTopNav/_styles.scss
+++ b/frontend/components/top_nav/SiteTopNav/_styles.scss
@@ -84,7 +84,6 @@
     align-items: center;
     min-width: 64px;
     max-width: 140px;
-    transform: scale(0.5);
   }
 
   &--active {


### PR DESCRIPTION
## Addresses #10981 

Halve org logo max-height and restrict .5x transform to the default fleet logo

Manually QAed using:
- Default Fleet logo (no link)
- https://www.ellucian.com/sites/default/files/uploads/images/2018/12/flywire-logo-rgb.svg
- https://cdn.comparably.com/27306312/p/120882_profile_flywire.png
- https://cdn2.unrealengine.com/Unreal+Engine%2Feg-logo-filled-1255x1272-0eb9d144a0f981d1cbaaa1eb957de7a3207b31bb.png

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality