### PR TITLE
Website: Retry failed PUT requests to Vanta

### DIFF
--- a/website/scripts/send-data-to-vanta.js
+++ b/website/scripts/send-data-to-vanta.js
@@ -334,7 +334,9 @@ module.exports = {
           'authorization': 'Bearer '+updatedRecord.vantaAuthToken,
           'content-type': 'application/json',
         },
-      }).tolerate((err)=>{// If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
+      })
+      .retry()
+      .tolerate((err)=>{// If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
         errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/user_account/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${err}`);
       });
 
@@ -358,7 +360,9 @@ module.exports = {
           'authorization': 'Bearer '+updatedRecord.vantaAuthToken,
           'content-type': 'application/json',
         },
-      }).tolerate((err)=>{// If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
+      })
+      .retry()
+      .tolerate((err)=>{// If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
         errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/macos_user_computer/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${err}`);
       });
 
@@ -382,7 +386,9 @@ module.exports = {
           'authorization': 'Bearer '+updatedRecord.vantaAuthToken,
           'content-type': 'application/json',
         },
-      }).tolerate((err)=>{// If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
+      })
+      .retry()
+      .tolerate((err)=>{// If an error occurs while sending a request to Vanta, we'll add the error to the errorReportById object, with this connections ID set as the key.
         errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/macos_user_computer/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${err}`);
       });
 


### PR DESCRIPTION
Changes:
- Chained a `.retry()` onto the PUT requests to Vanta in the `send-data-to-vanta` script
.