### PR TITLE
consistant UI for info banner on host details and my device page

### DIFF
--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -334,7 +334,7 @@ const DeviceUserPage = ({
               isMdmUnenrolled &&
               globalConfig?.mdm.enabled_and_configured && (
                 // Turn on MDM banner
-                <InfoBanner color="yellow" cta={turnOnMdmButton} pageLevel>
+                <InfoBanner color="yellow" cta={turnOnMdmButton}>
                   Mobile device management (MDM) is off. MDM allows your
                   organization to change settings and install software. This
                   lets your organization keep your device up to date so you

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -608,23 +608,23 @@ const HostDetailsPage = ({
   return (
     <MainContent className={baseClass}>
       <div className={`${baseClass}__wrapper`}>
-        <div className={`${baseClass}__header-links`}>
-          {host?.platform === "darwin" &&
-            isMdmUnenrolled &&
-            config?.mdm.enabled_and_configured && (
-              <InfoBanner color="yellow" pageLevel>
-                To change settings and install software, ask the end user to
-                follow the <strong>Turn on MDM</strong> instructions on their{" "}
-                <strong>My device</strong> page.
-              </InfoBanner>
-            )}
-          {showDiskEncryptionUserActionRequired && (
+        {host?.platform === "darwin" &&
+          isMdmUnenrolled &&
+          config?.mdm.enabled_and_configured && (
             <InfoBanner color="yellow">
-              Disk encryption: Requires action from the end user. Ask the end
-              user to follow <b>Disk encryption</b> instructions on their{" "}
-              <b>My device</b> page.
+              To change settings and install software, ask the end user to
+              follow the <strong>Turn on MDM</strong> instructions on their{" "}
+              <strong>My device</strong> page.
             </InfoBanner>
           )}
+        {showDiskEncryptionUserActionRequired && (
+          <InfoBanner color="yellow">
+            Disk encryption: Requires action from the end user. Ask the end user
+            to follow <b>Disk encryption</b> instructions on their{" "}
+            <b>My device</b> page.
+          </InfoBanner>
+        )}
+        <div className={`${baseClass}__header-links`}>
           <BackLink
             text="Back to all hosts"
             path={filteredHostsPath || PATHS.MANAGE_HOSTS}


### PR DESCRIPTION
relates to #10780

make the info banner at the top of host details and my device page have consistent spacing.

- [x] Manual QA for all new/changed functionality
