### PR TITLE
Fleet UI: 2 new premium roles (Observer+, GitOps)

### DIFF
--- a/docs/Using-Fleet/fleetctl-CLI.md
+++ b/docs/Using-Fleet/fleetctl-CLI.md
@@ -242,14 +242,28 @@ To create your new API-only user, run `fleetctl user create` and pass values for
 fleetctl user create --name "API User" --email api@example.com --password temp!pass --api-only
 ```
 
-### Permissions for an API-only user
+### Creating an API-only user
 An API-only user can be given the same permissions as a regular user. The default access level is `Observer`. For more information on permissions, see the [user permissions documentation](https://fleetdm.com/docs/using-fleet/permissions#user-permissions).
 
 If you'd like your API-only user to have a different access level than the default `Observer` role, you can specify what level of access the new user should have using the `--global-role` flag:
 
 ```
-fleetctl user create --name "API User" --email api@example.com --password temp!pass --api-only --global-role admin
+fleetctl user create --name "API User" --email api@example.com --password temp#pass --api-only --global-role admin
 ```
+
+On Fleet Premium, use the `--team` flag setting `team_id:role` to create an API-only user on a team:
+
+```
+fleetctl user create --name "API Team GitOps User" --email apigitops@example.com --password temp#pass --team 4:gitops
+```
+
+> Fleet Premium: Check out our new `gitops` role, available only through fleetctl as an API-only user. 
+
+### Changing permissions of an API-only user
+
+To change roles of a current user, log into the Fleet UI as an admin and navigate to **Settings > Users**.
+
+> Suggestion: To disable/enable a user's access to the UI (converting a regular user to an API-only user or vice versa), create a new user.
 
 ### Use fleetctl as an API-only user
 

--- a/docs/Using-Fleet/fleetctl-CLI.md
+++ b/docs/Using-Fleet/fleetctl-CLI.md
@@ -254,10 +254,8 @@ fleetctl user create --name "API User" --email api@example.com --password temp#p
 On Fleet Premium, use the `--team` flag setting `team_id:role` to create an API-only user on a team:
 
 ```
-fleetctl user create --name "API Team GitOps User" --email apigitops@example.com --password temp#pass --team 4:gitops
+fleetctl user create --name "API Team Maintainer User" --email apimaintainer@example.com --password temp#pass --team 4:maintainer
 ```
-
-> Fleet Premium: Check out our new `gitops` role, available only through fleetctl as an API-only user. 
 
 ### Changing permissions of an API-only user
 

--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -90,18 +90,16 @@ type InitialStateType = {
   isGlobalAdmin?: boolean;
   isGlobalMaintainer?: boolean;
   isGlobalObserver?: boolean;
-  isGlobalObserverPlus?: boolean;
   isOnGlobalTeam?: boolean;
   isAnyTeamMaintainer?: boolean;
   isAnyTeamMaintainerOrTeamAdmin?: boolean;
   isTeamObserver?: boolean;
-  isTeamObserverPlus?: boolean;
   isTeamMaintainer?: boolean;
   isTeamMaintainerOrTeamAdmin?: boolean;
   isAnyTeamAdmin?: boolean;
   isTeamAdmin?: boolean;
   isOnlyObserver?: boolean;
-  isOnlyObserverPlus?: boolean;
+  isObserverPlus?: boolean;
   isNoAccess?: boolean;
   sandboxExpiry?: string;
   noSandboxHosts?: boolean;
@@ -135,18 +133,16 @@ export const initialState = {
   isGlobalAdmin: undefined,
   isGlobalMaintainer: undefined,
   isGlobalObserver: undefined,
-  isGlobalObserverPlus: undefined,
   isOnGlobalTeam: undefined,
   isAnyTeamMaintainer: undefined,
   isAnyTeamMaintainerOrTeamAdmin: undefined,
   isTeamObserver: undefined,
-  isTeamObserverPlus: undefined,
   isTeamMaintainer: undefined,
   isTeamMaintainerOrTeamAdmin: undefined,
   isAnyTeamAdmin: undefined,
   isTeamAdmin: undefined,
   isOnlyObserver: undefined,
-  isOnlyObserverPlus: undefined,
+  isObserverPlus: undefined,
   isNoAccess: undefined,
   filteredHostsPath: undefined,
   setAvailableTeams: () => null,
@@ -200,7 +196,7 @@ const setPermissions = (
       teamId
     ),
     isOnlyObserver: permissions.isOnlyObserver(user),
-    isOnlyObserverPlus: permissions.isOnlyObserverPlus(user),
+    isObserverPlus: permissions.isObserverPlus(user, teamId),
     isNoAccess: permissions.isNoAccess(user),
   };
 };
@@ -313,18 +309,16 @@ const AppProvider = ({ children }: Props): JSX.Element => {
     isGlobalAdmin: state.isGlobalAdmin,
     isGlobalMaintainer: state.isGlobalMaintainer,
     isGlobalObserver: state.isGlobalObserver,
-    isGlobalObserverPlus: state.isGlobalObserver,
     isOnGlobalTeam: state.isOnGlobalTeam,
     isAnyTeamMaintainer: state.isAnyTeamMaintainer,
     isAnyTeamMaintainerOrTeamAdmin: state.isAnyTeamMaintainerOrTeamAdmin,
     isTeamObserver: state.isTeamObserver,
-    isTeamObserverPlus: state.isTeamObserverPlus,
     isTeamMaintainer: state.isTeamMaintainer,
     isTeamAdmin: state.isTeamAdmin,
     isTeamMaintainerOrTeamAdmin: state.isTeamMaintainer,
     isAnyTeamAdmin: state.isAnyTeamAdmin,
     isOnlyObserver: state.isOnlyObserver,
-    isOnlyObserverPlus: state.isOnlyObserverPlus,
+    isObserverPlus: state.isObserverPlus,
     isNoAccess: state.isNoAccess,
     setAvailableTeams: (user: IUser | null, availableTeams: ITeamSummary[]) => {
       dispatch({

--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -90,15 +90,18 @@ type InitialStateType = {
   isGlobalAdmin?: boolean;
   isGlobalMaintainer?: boolean;
   isGlobalObserver?: boolean;
+  isGlobalObserverPlus?: boolean;
   isOnGlobalTeam?: boolean;
   isAnyTeamMaintainer?: boolean;
   isAnyTeamMaintainerOrTeamAdmin?: boolean;
   isTeamObserver?: boolean;
+  isTeamObserverPlus?: boolean;
   isTeamMaintainer?: boolean;
   isTeamMaintainerOrTeamAdmin?: boolean;
   isAnyTeamAdmin?: boolean;
   isTeamAdmin?: boolean;
   isOnlyObserver?: boolean;
+  isOnlyObserverPlus?: boolean;
   isNoAccess?: boolean;
   sandboxExpiry?: string;
   noSandboxHosts?: boolean;
@@ -132,15 +135,18 @@ export const initialState = {
   isGlobalAdmin: undefined,
   isGlobalMaintainer: undefined,
   isGlobalObserver: undefined,
+  isGlobalObserverPlus: undefined,
   isOnGlobalTeam: undefined,
   isAnyTeamMaintainer: undefined,
   isAnyTeamMaintainerOrTeamAdmin: undefined,
   isTeamObserver: undefined,
+  isTeamObserverPlus: undefined,
   isTeamMaintainer: undefined,
   isTeamMaintainerOrTeamAdmin: undefined,
   isAnyTeamAdmin: undefined,
   isTeamAdmin: undefined,
   isOnlyObserver: undefined,
+  isOnlyObserverPlus: undefined,
   isNoAccess: undefined,
   filteredHostsPath: undefined,
   setAvailableTeams: () => null,
@@ -194,6 +200,7 @@ const setPermissions = (
       teamId
     ),
     isOnlyObserver: permissions.isOnlyObserver(user),
+    isOnlyObserverPlus: permissions.isOnlyObserverPlus(user),
     isNoAccess: permissions.isNoAccess(user),
   };
 };
@@ -306,15 +313,18 @@ const AppProvider = ({ children }: Props): JSX.Element => {
     isGlobalAdmin: state.isGlobalAdmin,
     isGlobalMaintainer: state.isGlobalMaintainer,
     isGlobalObserver: state.isGlobalObserver,
+    isGlobalObserverPlus: state.isGlobalObserver,
     isOnGlobalTeam: state.isOnGlobalTeam,
     isAnyTeamMaintainer: state.isAnyTeamMaintainer,
     isAnyTeamMaintainerOrTeamAdmin: state.isAnyTeamMaintainerOrTeamAdmin,
     isTeamObserver: state.isTeamObserver,
+    isTeamObserverPlus: state.isTeamObserverPlus,
     isTeamMaintainer: state.isTeamMaintainer,
     isTeamAdmin: state.isTeamAdmin,
     isTeamMaintainerOrTeamAdmin: state.isTeamMaintainer,
     isAnyTeamAdmin: state.isAnyTeamAdmin,
     isOnlyObserver: state.isOnlyObserver,
+    isOnlyObserverPlus: state.isOnlyObserverPlus,
     isNoAccess: state.isNoAccess,
     setAvailableTeams: (user: IUser | null, availableTeams: ITeamSummary[]) => {
       dispatch({

--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -91,6 +91,7 @@ type InitialStateType = {
   isGlobalMaintainer?: boolean;
   isGlobalObserver?: boolean;
   isOnGlobalTeam?: boolean;
+  isAnyTeamObserverPlus?: boolean;
   isAnyTeamMaintainer?: boolean;
   isAnyTeamMaintainerOrTeamAdmin?: boolean;
   isTeamObserver?: boolean;
@@ -134,6 +135,7 @@ export const initialState = {
   isGlobalMaintainer: undefined,
   isGlobalObserver: undefined,
   isOnGlobalTeam: undefined,
+  isAnyTeamObserverPlus: undefined,
   isAnyTeamMaintainer: undefined,
   isAnyTeamMaintainerOrTeamAdmin: undefined,
   isTeamObserver: undefined,
@@ -183,6 +185,7 @@ const setPermissions = (
     isGlobalMaintainer: permissions.isGlobalMaintainer(user),
     isGlobalObserver: permissions.isGlobalObserver(user),
     isOnGlobalTeam: permissions.isOnGlobalTeam(user),
+    isAnyTeamObserverPlus: permissions.isAnyTeamObserverPlus(user),
     isAnyTeamMaintainer: permissions.isAnyTeamMaintainer(user),
     isAnyTeamMaintainerOrTeamAdmin: permissions.isAnyTeamMaintainerOrTeamAdmin(
       user
@@ -310,6 +313,7 @@ const AppProvider = ({ children }: Props): JSX.Element => {
     isGlobalMaintainer: state.isGlobalMaintainer,
     isGlobalObserver: state.isGlobalObserver,
     isOnGlobalTeam: state.isOnGlobalTeam,
+    isAnyTeamObserverPlus: state.isAnyTeamObserverPlus,
     isAnyTeamMaintainer: state.isAnyTeamMaintainer,
     isAnyTeamMaintainerOrTeamAdmin: state.isAnyTeamMaintainerOrTeamAdmin,
     isTeamObserver: state.isTeamObserver,

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -1,6 +1,7 @@
 import { IPolicy } from "./policy";
 import { IQuery } from "./query";
 import { ITeamSummary } from "./team";
+import { UserRole } from "./user";
 
 export enum ActivityType {
   CreatedPack = "created_pack",
@@ -66,7 +67,7 @@ export interface IActivityDetails {
   public_ip?: string;
   user_email?: string;
   email?: string;
-  role?: string;
+  role?: UserRole;
   host_serial?: string;
   host_display_name?: string;
   installed_from_dep?: boolean;

--- a/frontend/interfaces/invite.ts
+++ b/frontend/interfaces/invite.ts
@@ -1,18 +1,5 @@
-import PropTypes from "prop-types";
-import teamInterface, { ITeam } from "./team";
+import { ITeam } from "./team";
 import { UserRole } from "./user";
-
-export default PropTypes.shape({
-  created_at: PropTypes.string,
-  updated_at: PropTypes.string,
-  id: PropTypes.number,
-  invited_by: PropTypes.number,
-  email: PropTypes.string,
-  name: PropTypes.string,
-  sso_enabled: PropTypes.bool,
-  global_role: PropTypes.any, // eslint-disable-line react/forbid-prop-types
-  teams: PropTypes.arrayOf(teamInterface),
-});
 
 export interface IInvite {
   created_at: string;

--- a/frontend/interfaces/invite.ts
+++ b/frontend/interfaces/invite.ts
@@ -24,6 +24,7 @@ export interface IInvite {
   sso_enabled: boolean;
   global_role: UserRole | null;
   teams: ITeam[];
+  api_only?: boolean;
 }
 
 export interface ICreateInviteFormData {

--- a/frontend/interfaces/invite.ts
+++ b/frontend/interfaces/invite.ts
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import teamInterface, { ITeam } from "./team";
+import { UserRole } from "./user";
 
 export default PropTypes.shape({
   created_at: PropTypes.string,
@@ -9,7 +10,7 @@ export default PropTypes.shape({
   email: PropTypes.string,
   name: PropTypes.string,
   sso_enabled: PropTypes.bool,
-  global_role: PropTypes.string,
+  global_role: PropTypes.any, // eslint-disable-line react/forbid-prop-types
   teams: PropTypes.arrayOf(teamInterface),
 });
 
@@ -21,13 +22,13 @@ export interface IInvite {
   email: string;
   name: string;
   sso_enabled: boolean;
-  global_role: string | null;
+  global_role: UserRole | null;
   teams: ITeam[];
 }
 
 export interface ICreateInviteFormData {
   email: string;
-  global_role: string | null;
+  global_role: UserRole | null;
   invited_by?: number;
   name: string;
   sso_enabled?: boolean;
@@ -37,7 +38,7 @@ export interface ICreateInviteFormData {
 export interface IEditInviteFormData {
   currentUserId?: number;
   email?: string;
-  global_role: string | null;
+  global_role: UserRole | null;
   name?: string;
   password: null;
   sso_enabled: boolean;

--- a/frontend/interfaces/role.ts
+++ b/frontend/interfaces/role.ts
@@ -5,10 +5,12 @@ export default PropTypes.shape({
   disabled: PropTypes.bool,
   label: PropTypes.string,
   value: PropTypes.any, // eslint-disable-line react/forbid-prop-types
+  helpText: PropTypes.string,
 });
 
 export interface IRole {
   disabled: boolean;
   label: string;
   value: UserRole;
+  helpText?: string;
 }

--- a/frontend/interfaces/role.ts
+++ b/frontend/interfaces/role.ts
@@ -1,13 +1,14 @@
 import PropTypes from "prop-types";
+import { UserRole } from "./user";
 
 export default PropTypes.shape({
   disabled: PropTypes.bool,
   label: PropTypes.string,
-  value: PropTypes.string,
+  value: PropTypes.any, // eslint-disable-line react/forbid-prop-types
 });
 
 export interface IRole {
   disabled: boolean;
   label: string;
-  value: string;
+  value: UserRole;
 }

--- a/frontend/interfaces/team.ts
+++ b/frontend/interfaces/team.ts
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import { IConfigFeatures, IWebhookSettings } from "./config";
 import enrollSecretInterface, { IEnrollSecret } from "./enroll_secret";
 import { IIntegrations } from "./integration";
+import { UserRole } from "./user";
 
 export default PropTypes.shape({
   id: PropTypes.number.isRequired,
@@ -9,7 +10,8 @@ export default PropTypes.shape({
   name: PropTypes.string.isRequired,
   description: PropTypes.string,
   agent_options: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-  role: PropTypes.string, // role value is included when the team is in the context of a user
+  role: PropTypes.any, // eslint-disable-line react/forbid-prop-types
+  // role value is included when the team is in the context of a user
   user_count: PropTypes.number,
   host_count: PropTypes.number,
   secrets: PropTypes.arrayOf(enrollSecretInterface),
@@ -40,7 +42,7 @@ export interface ITeam extends ITeamSummary {
   user_count?: number;
   host_count?: number;
   secrets?: IEnrollSecret[];
-  role?: string; // role value is included when the team is in the context of a user
+  role?: UserRole; // role value is included when the team is in the context of a user
   mdm?: {
     macos_updates: {
       minimum_version: string;
@@ -77,9 +79,9 @@ export type ITeamConfig = ITeam & ITeamAutomationsConfig;
 /**
  * The shape of a new member to add to a team
  */
-interface INewMember {
+export interface INewMember {
   id: number;
-  role: string;
+  role: UserRole;
 }
 
 /**

--- a/frontend/interfaces/user.ts
+++ b/frontend/interfaces/user.ts
@@ -18,6 +18,18 @@ export default PropTypes.shape({
 
 export const USERS_ROLES = ["admin", "maintainer", "observer"] as const;
 export type IUserRole = typeof USERS_ROLES[number];
+export type UserRole =
+  | "admin"
+  | "maintainer"
+  | "observer"
+  | "observer_plus"
+  | "Admin"
+  | "Maintainer"
+  | "Observer"
+  | "Observer+"
+  | "Unassigned"
+  | ""
+  | "Various";
 
 export interface IUser {
   created_at?: string;
@@ -25,12 +37,12 @@ export interface IUser {
   id: number;
   name: string;
   email: string;
-  role: string;
+  role: UserRole;
   force_password_reset: boolean;
   gravatar_url?: string;
   gravatar_url_dark?: string;
   sso_enabled: boolean;
-  global_role: string | null;
+  global_role: UserRole | null;
   api_only: boolean;
   teams: ITeam[];
 }
@@ -39,11 +51,13 @@ export interface IUser {
  * The shape of the request body when updating a user.
  */
 export interface IUserUpdateBody {
-  global_role?: string | null;
+  global_role?: UserRole | null;
   teams?: ITeam[];
-  name?: string;
+  name: string;
   email?: string;
   sso_enabled?: boolean;
+  role?: UserRole;
+  id: number;
 }
 
 export interface IUserFormErrors {
@@ -55,7 +69,7 @@ export interface IUserFormErrors {
 
 export interface ICreateUserFormData {
   email: string;
-  global_role: string | null;
+  global_role: UserRole | null;
   name: string;
   password?: string | null;
   sso_enabled?: boolean | undefined;
@@ -65,7 +79,7 @@ export interface ICreateUserFormData {
 export interface IUpdateUserFormData {
   currentUserId?: number;
   email?: string;
-  global_role?: string | null;
+  global_role?: UserRole | null;
   name?: string;
   password?: string | null;
   sso_enabled?: boolean;

--- a/frontend/interfaces/user.ts
+++ b/frontend/interfaces/user.ts
@@ -23,10 +23,12 @@ export type UserRole =
   | "maintainer"
   | "observer"
   | "observer_plus"
+  | "gitops"
   | "Admin"
   | "Maintainer"
   | "Observer"
   | "Observer+"
+  | "GitOps"
   | "Unassigned"
   | ""
   | "Various";

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/MembersPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/MembersPage.tsx
@@ -482,6 +482,7 @@ const MembersPage = ({ location, router }: IMembersPageProps): JSX.Element => {
           isModifiedByGlobalAdmin={isGlobalAdmin}
           currentTeam={currentTeamDetails}
           isUpdatingUsers={isUpdatingMembers}
+          isApiOnly={userEditing?.api_only || false}
         />
       )}
       {showCreateUserModal && currentTeamDetails && (

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/MembersPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/MembersPage.tsx
@@ -8,7 +8,7 @@ import useTeamIdParam from "hooks/useTeamIdParam";
 import { IEmptyTableProps } from "interfaces/empty_table";
 import { IApiError } from "interfaces/errors";
 import { INewMembersBody, ITeam } from "interfaces/team";
-import { IUser, IUserFormErrors } from "interfaces/user";
+import { IUpdateUserFormData, IUser, IUserFormErrors } from "interfaces/user";
 import PATHS from "router/paths";
 import usersAPI from "services/entities/users";
 import inviteAPI from "services/entities/invites";
@@ -296,7 +296,7 @@ const MembersPage = ({ location, router }: IMembersPageProps): JSX.Element => {
 
   const onEditMemberSubmit = useCallback(
     (formData: IFormData) => {
-      const updatedAttrs = userManagementHelpers.generateUpdateData(
+      const updatedAttrs: IUpdateUserFormData = userManagementHelpers.generateUpdateData(
         userEditing as IUser,
         formData
       );

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/MembersPageTableConfig.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/MembersPageTableConfig.tsx
@@ -3,7 +3,7 @@ import ReactTooltip from "react-tooltip";
 import TextCell from "components/TableContainer/DataTable/TextCell/TextCell";
 import DropdownCell from "components/TableContainer/DataTable/DropdownCell";
 import CustomLink from "components/CustomLink";
-import { IUser } from "interfaces/user";
+import { IUser, UserRole } from "interfaces/user";
 import { ITeam } from "interfaces/team";
 import { IDropdownOption } from "interfaces/dropdownOption";
 import stringUtils from "utilities/strings";
@@ -48,7 +48,7 @@ interface IDataColumn {
 export interface IMembersTableData {
   name: string;
   email: string;
-  role: string;
+  role: UserRole;
   teams: ITeam[];
   actions: IDropdownOption[];
   id: number;
@@ -165,9 +165,9 @@ const generateActionDropdownOptions = (): IDropdownOption[] => {
     },
   ];
 };
-const generateRole = (teamId: number, teams: ITeam[]): string => {
-  const role = teams.find((team) => teamId === team.id)?.role ?? "";
-  return stringUtils.capitalize(role);
+const generateRole = (teamId: number, teams: ITeam[]): UserRole => {
+  const role = teams.find((team) => teamId === team.id)?.role ?? "Unassigned";
+  return stringUtils.capitalizeRole(role);
 };
 
 const enhanceMembersData = (

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/MembersPageTableConfig.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/MembersPageTableConfig.tsx
@@ -7,6 +7,7 @@ import { IUser, UserRole } from "interfaces/user";
 import { ITeam } from "interfaces/team";
 import { IDropdownOption } from "interfaces/dropdownOption";
 import stringUtils from "utilities/strings";
+import TooltipWrapper from "components/TooltipWrapper";
 
 interface IHeaderProps {
   column: {
@@ -120,9 +121,37 @@ const generateTableHeaders = (
       Header: "Role",
       disableSortBy: true,
       accessor: "role",
-      Cell: (cellProps: ICellProps) => (
-        <TextCell value={cellProps.cell.value} />
-      ),
+      Cell: (cellProps: ICellProps) => {
+        if (cellProps.cell.value === "GitOps") {
+          return (
+            <TooltipWrapper
+              position="top"
+              tipContent={`
+            The GitOps role is only available on the command-line<br/>
+            when creating an API-only user. This user has no<br/>
+            access to the UI.
+          `}
+            >
+              GitOps
+            </TooltipWrapper>
+          );
+        }
+        if (cellProps.cell.value === "Observer+") {
+          return (
+            <TooltipWrapper
+              position="top"
+              tipContent={`
+            Users with the Observer+ role have access to all of<br/>
+            the same functions as an Observer, with the added<br/>
+            ability to run any live query against all hosts. 
+          `}
+            >
+              {cellProps.cell.value}
+            </TooltipWrapper>
+          );
+        }
+        return <TextCell value={cellProps.cell.value} />;
+      },
     },
     {
       title: "Email",

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/components/AddMemberModal/AddMemberModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/components/AddMemberModal/AddMemberModal.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
 
-import { INewMembersBody, ITeam } from "interfaces/team";
+import { INewMember, INewMembersBody, ITeam } from "interfaces/team";
 import endpoints from "utilities/endpoints";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
@@ -34,9 +34,11 @@ const AddMemberModal = ({
   );
 
   const onFormSubmit = useCallback(() => {
-    const newMembers = selectedMembers.map((member: IDropdownOption) => {
-      return { id: member.value as number, role: "observer" };
-    });
+    const newMembers: INewMember[] = selectedMembers.map(
+      (member: IDropdownOption) => {
+        return { id: member.value as number, role: "observer" };
+      }
+    );
     onSubmit({ users: newMembers });
   }, [selectedMembers, onSubmit]);
 

--- a/frontend/pages/admin/UserManagementPage/components/CreateUserModal/CreateUserModal.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/CreateUserModal/CreateUserModal.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { ITeam } from "interfaces/team";
-import { IUserFormErrors } from "interfaces/user";
+import { IUserFormErrors, UserRole } from "interfaces/user";
 import Modal from "components/Modal";
 import UserForm from "../UserForm";
 import { IFormData } from "../UserForm/UserForm";
@@ -9,8 +9,8 @@ import { IFormData } from "../UserForm/UserForm";
 interface ICreateUserModalProps {
   onCancel: () => void;
   onSubmit: (formData: IFormData) => void;
-  defaultGlobalRole?: string | null;
-  defaultTeamRole?: string;
+  defaultGlobalRole?: UserRole | null;
+  defaultTeamRole?: UserRole;
   defaultTeams?: ITeam[];
   availableTeams?: ITeam[];
   isPremiumTier: boolean;

--- a/frontend/pages/admin/UserManagementPage/components/EditUserModal/EditUserModal.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/EditUserModal/EditUserModal.tsx
@@ -20,6 +20,7 @@ interface IEditUserModalProps {
   smtpConfigured: boolean;
   canUseSso: boolean; // corresponds to whether SSO is enabled for the organization
   isSsoEnabled?: boolean; // corresponds to whether SSO is enabled for the individual user
+  isApiOnly?: boolean;
   editUserErrors?: IUserFormErrors;
   isModifiedByGlobalAdmin?: boolean | false;
   isInvitePending?: boolean;
@@ -41,6 +42,7 @@ const EditUserModal = ({
   smtpConfigured,
   canUseSso,
   isSsoEnabled,
+  isApiOnly,
   currentTeam,
   editUserErrors,
   isModifiedByGlobalAdmin,
@@ -68,6 +70,7 @@ const EditUserModal = ({
         smtpConfigured={smtpConfigured}
         canUseSso={canUseSso}
         isSsoEnabled={isSsoEnabled}
+        isApiOnly={isApiOnly}
         isModifiedByGlobalAdmin={isModifiedByGlobalAdmin}
         isInvitePending={isInvitePending}
         currentTeam={currentTeam}

--- a/frontend/pages/admin/UserManagementPage/components/EditUserModal/EditUserModal.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/EditUserModal/EditUserModal.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { ITeam } from "interfaces/team";
-import { IUserFormErrors } from "interfaces/user";
+import { IUserFormErrors, UserRole } from "interfaces/user";
 import Modal from "components/Modal";
 import UserForm from "../UserForm";
 import { IFormData } from "../UserForm/UserForm";
@@ -11,8 +11,8 @@ interface IEditUserModalProps {
   onSubmit: (formData: IFormData) => void;
   defaultName?: string;
   defaultEmail?: string;
-  defaultGlobalRole?: string | null;
-  defaultTeamRole?: string;
+  defaultGlobalRole?: UserRole | null;
+  defaultTeamRole?: UserRole;
   defaultTeams?: ITeam[];
   availableTeams: ITeam[];
   currentTeam?: ITeam;

--- a/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
@@ -14,17 +14,27 @@ interface ISelectRoleFormProps {
   teams: ITeam[];
   onFormChange: (teams: ITeam[]) => void;
   label: string | string[];
-  isNewUser?: boolean;
+  isApiOnly?: boolean;
 }
 
 const baseClass = "select-role-form";
 
 interface RoleParams {
   isPremiumTier?: boolean;
-  isNewUser?: boolean;
+  isApiOnly?: boolean;
 }
 
-const roleOptions = ({ isPremiumTier, isNewUser }: RoleParams): IRole[] => {
+const roleOptions = ({ isPremiumTier, isApiOnly }: RoleParams): IRole[] => {
+  if (isApiOnly) {
+    return [
+      {
+        disabled: false,
+        label: "GitOps",
+        value: "gitops",
+      },
+    ];
+  }
+
   const roles: IRole[] = [
     {
       disabled: false,
@@ -49,14 +59,6 @@ const roleOptions = ({ isPremiumTier, isNewUser }: RoleParams): IRole[] => {
       label: "Observer+",
       value: "observer_plus",
     });
-    // Only existing users can be converted to gitops user
-    if (!isNewUser) {
-      roles.splice(3, 0, {
-        disabled: false,
-        label: "GitOps",
-        value: "gitops",
-      });
-    }
   }
 
   return roles;
@@ -89,7 +91,7 @@ const SelectRoleForm = ({
   teams,
   onFormChange,
   label,
-  isNewUser,
+  isApiOnly,
 }: ISelectRoleFormProps): JSX.Element => {
   const { isPremiumTier } = useContext(AppContext);
 
@@ -114,7 +116,7 @@ const SelectRoleForm = ({
           label={label}
           value={selectedRole}
           className={`${baseClass}__role-dropdown`}
-          options={roleOptions({ isPremiumTier, isNewUser })}
+          options={roleOptions({ isPremiumTier, isApiOnly })}
           searchable={false}
           onChange={(newRoleValue: UserRole) =>
             updateSelectedRole(newRoleValue)

--- a/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
@@ -43,6 +43,11 @@ const roleOptions = (isPremiumTier: boolean): IRole[] => {
       label: "Observer+",
       value: "observer_plus",
     });
+    roles.splice(3, 0, {
+      disabled: false,
+      label: "GitOps",
+      value: "gitops",
+    });
   }
 
   return roles;

--- a/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
@@ -14,11 +14,17 @@ interface ISelectRoleFormProps {
   teams: ITeam[];
   onFormChange: (teams: ITeam[]) => void;
   label: string | string[];
+  isNewUser?: boolean;
 }
 
 const baseClass = "select-role-form";
 
-const roleOptions = (isPremiumTier: boolean): IRole[] => {
+interface RoleParams {
+  isPremiumTier?: boolean;
+  isNewUser?: boolean;
+}
+
+const roleOptions = ({ isPremiumTier, isNewUser }: RoleParams): IRole[] => {
   const roles: IRole[] = [
     {
       disabled: false,
@@ -43,11 +49,14 @@ const roleOptions = (isPremiumTier: boolean): IRole[] => {
       label: "Observer+",
       value: "observer_plus",
     });
-    roles.splice(3, 0, {
-      disabled: false,
-      label: "GitOps",
-      value: "gitops",
-    });
+    // Only existing users can be converted to gitops user
+    if (!isNewUser) {
+      roles.splice(3, 0, {
+        disabled: false,
+        label: "GitOps",
+        value: "gitops",
+      });
+    }
   }
 
   return roles;
@@ -80,6 +89,7 @@ const SelectRoleForm = ({
   teams,
   onFormChange,
   label,
+  isNewUser,
 }: ISelectRoleFormProps): JSX.Element => {
   const { isPremiumTier } = useContext(AppContext);
 
@@ -104,7 +114,7 @@ const SelectRoleForm = ({
           label={label}
           value={selectedRole}
           className={`${baseClass}__role-dropdown`}
-          options={roleOptions(isPremiumTier || false)}
+          options={roleOptions({ isPremiumTier, isNewUser })}
           searchable={false}
           onChange={(newRoleValue: UserRole) =>
             updateSelectedRole(newRoleValue)

--- a/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
@@ -49,11 +49,13 @@ const roleOptions = ({ isPremiumTier, isApiOnly }: RoleParams): IRole[] => {
       label: "Observer+",
       value: "observer_plus",
     });
-    roles.splice(3, 0, {
-      disabled: !isApiOnly,
-      label: "GitOps",
-      value: "gitops",
-    });
+    if (isApiOnly) {
+      roles.splice(3, 0, {
+        disabled: false,
+        label: "GitOps",
+        value: "gitops",
+      });
+    }
   }
 
   return roles;

--- a/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 
 import { ITeam } from "interfaces/team";
 import { IRole } from "interfaces/role";
@@ -6,6 +6,7 @@ import { UserRole } from "interfaces/user";
 // ignore TS error for now until these are rewritten in ts.
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
+import { AppContext } from "context/app";
 
 interface ISelectRoleFormProps {
   defaultTeamRole: UserRole;
@@ -17,28 +18,35 @@ interface ISelectRoleFormProps {
 
 const baseClass = "select-role-form";
 
-const roles: IRole[] = [
-  {
-    disabled: false,
-    label: "Observer+",
-    value: "observer_plus",
-  },
-  {
-    disabled: false,
-    label: "Observer",
-    value: "observer",
-  },
-  {
-    disabled: false,
-    label: "Maintainer",
-    value: "maintainer",
-  },
-  {
-    disabled: false,
-    label: "Admin",
-    value: "admin",
-  },
-];
+const roleOptions = (isPremiumTier: boolean): IRole[] => {
+  const roles: IRole[] = [
+    {
+      disabled: false,
+      label: "Observer",
+      value: "observer",
+    },
+    {
+      disabled: false,
+      label: "Maintainer",
+      value: "maintainer",
+    },
+    {
+      disabled: false,
+      label: "Admin",
+      value: "admin",
+    },
+  ];
+
+  if (isPremiumTier) {
+    roles.unshift({
+      disabled: false,
+      label: "Observer+",
+      value: "observer_plus",
+    });
+  }
+
+  return roles;
+};
 
 const generateSelectedTeamData = (
   allTeams: ITeam[],
@@ -68,6 +76,8 @@ const SelectRoleForm = ({
   onFormChange,
   label,
 }: ISelectRoleFormProps): JSX.Element => {
+  const { isPremiumTier } = useContext(AppContext);
+
   const [selectedRole, setSelectedRole] = useState(
     defaultTeamRole.toLowerCase()
   );
@@ -89,7 +99,7 @@ const SelectRoleForm = ({
           label={label}
           value={selectedRole}
           className={`${baseClass}__role-dropdown`}
-          options={roles}
+          options={roleOptions(isPremiumTier || false)}
           searchable={false}
           onChange={(newRoleValue: UserRole) =>
             updateSelectedRole(newRoleValue)

--- a/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
@@ -25,16 +25,6 @@ interface RoleParams {
 }
 
 const roleOptions = ({ isPremiumTier, isApiOnly }: RoleParams): IRole[] => {
-  if (isApiOnly) {
-    return [
-      {
-        disabled: false,
-        label: "GitOps",
-        value: "gitops",
-      },
-    ];
-  }
-
   const roles: IRole[] = [
     {
       disabled: false,
@@ -58,6 +48,11 @@ const roleOptions = ({ isPremiumTier, isApiOnly }: RoleParams): IRole[] => {
       disabled: false,
       label: "Observer+",
       value: "observer_plus",
+    });
+    roles.splice(3, 0, {
+      disabled: !isApiOnly,
+      label: "GitOps",
+      value: "gitops",
     });
   }
 

--- a/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
@@ -49,13 +49,14 @@ const roleOptions = ({ isPremiumTier, isApiOnly }: RoleParams): IRole[] => {
       label: "Observer+",
       value: "observer_plus",
     });
-    if (isApiOnly) {
-      roles.splice(3, 0, {
-        disabled: false,
-        label: "GitOps",
-        value: "gitops",
-      });
-    }
+    // Next release:
+    // if (isApiOnly) {
+    //   roles.splice(3, 0, {
+    //     disabled: false,
+    //     label: "GitOps",
+    //     value: "gitops",
+    //   });
+    // }
   }
 
   return roles;

--- a/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
@@ -2,12 +2,13 @@ import React, { useState } from "react";
 
 import { ITeam } from "interfaces/team";
 import { IRole } from "interfaces/role";
+import { UserRole } from "interfaces/user";
 // ignore TS error for now until these are rewritten in ts.
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
 
 interface ISelectRoleFormProps {
-  defaultTeamRole: string;
+  defaultTeamRole: UserRole;
   currentTeam?: ITeam;
   teams: ITeam[];
   onFormChange: (teams: ITeam[]) => void;
@@ -17,6 +18,11 @@ interface ISelectRoleFormProps {
 const baseClass = "select-role-form";
 
 const roles: IRole[] = [
+  {
+    disabled: false,
+    label: "Observer+",
+    value: "observer_plus",
+  },
   {
     disabled: false,
     label: "Observer",
@@ -66,7 +72,7 @@ const SelectRoleForm = ({
     defaultTeamRole.toLowerCase()
   );
 
-  const updateSelectedRole = (newRoleValue: string) => {
+  const updateSelectedRole = (newRoleValue: UserRole) => {
     const updatedTeam = { ...currentTeam };
 
     updatedTeam.role = newRoleValue;
@@ -85,7 +91,9 @@ const SelectRoleForm = ({
           className={`${baseClass}__role-dropdown`}
           options={roles}
           searchable={false}
-          onChange={(newRoleValue: string) => updateSelectedRole(newRoleValue)}
+          onChange={(newRoleValue: UserRole) =>
+            updateSelectedRole(newRoleValue)
+          }
           testId={`${name}-checkbox`}
         />
       </div>

--- a/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectRoleForm/SelectRoleForm.tsx
@@ -7,6 +7,7 @@ import { UserRole } from "interfaces/user";
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
 import { AppContext } from "context/app";
+import { roleOptions } from "../../helpers/userManagementHelpers";
 
 interface ISelectRoleFormProps {
   defaultTeamRole: UserRole;
@@ -18,49 +19,6 @@ interface ISelectRoleFormProps {
 }
 
 const baseClass = "select-role-form";
-
-interface RoleParams {
-  isPremiumTier?: boolean;
-  isApiOnly?: boolean;
-}
-
-const roleOptions = ({ isPremiumTier, isApiOnly }: RoleParams): IRole[] => {
-  const roles: IRole[] = [
-    {
-      disabled: false,
-      label: "Observer",
-      value: "observer",
-    },
-    {
-      disabled: false,
-      label: "Maintainer",
-      value: "maintainer",
-    },
-    {
-      disabled: false,
-      label: "Admin",
-      value: "admin",
-    },
-  ];
-
-  if (isPremiumTier) {
-    roles.unshift({
-      disabled: false,
-      label: "Observer+",
-      value: "observer_plus",
-    });
-    // Next release:
-    // if (isApiOnly) {
-    //   roles.splice(3, 0, {
-    //     disabled: false,
-    //     label: "GitOps",
-    //     value: "gitops",
-    //   });
-    // }
-  }
-
-  return roles;
-};
 
 const generateSelectedTeamData = (
   allTeams: ITeam[],

--- a/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 
 import { ITeam } from "interfaces/team";
 import { UserRole } from "interfaces/user";
+import { IRole } from "interfaces/role";
 import Checkbox from "components/forms/fields/Checkbox";
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
@@ -14,40 +15,43 @@ interface ISelectedTeamsFormProps {
   availableTeams: ITeam[];
   usersCurrentTeams: ITeam[];
   onFormChange: (teams: ITeam[]) => void;
+  isApiOnly?: boolean;
 }
 
 const baseClass = "selected-teams-form";
 
-const roles = [
-  {
-    disabled: false,
-    label: "Observer+",
-    value: "observer_plus",
-  },
-  {
-    disabled: false,
-    label: "Observer",
-    value: "observer",
-  },
-  {
-    disabled: false,
-    label: "Maintainer",
-    value: "maintainer",
-  },
-  {
-    disabled: false,
-    label: "Admin",
-    value: "admin",
-  },
-];
+const roleOptions = (isApiOnly = false): IRole[] => {
+  console.log("isApiOnly", isApiOnly);
+  const roles: IRole[] = [
+    {
+      disabled: false,
+      label: "Observer+",
+      value: "observer_plus",
+    },
+    {
+      disabled: false,
+      label: "Observer",
+      value: "observer",
+    },
+    {
+      disabled: !isApiOnly,
+      label: `GitOps`,
+      value: "gitops",
+    },
+    {
+      disabled: false,
+      label: "Maintainer",
+      value: "maintainer",
+    },
+    {
+      disabled: false,
+      label: "Admin",
+      value: "admin",
+    },
+  ];
 
-const gitOpsRole = [
-  {
-    disabled: false,
-    label: "GitOps",
-    value: "gitops",
-  },
-];
+  return roles;
+};
 
 const generateFormListItems = (
   allTeams: ITeam[],
@@ -133,6 +137,7 @@ const SelectedTeamsForm = ({
   availableTeams,
   usersCurrentTeams,
   onFormChange,
+  isApiOnly,
 }: ISelectedTeamsFormProps): JSX.Element => {
   const [teamsFormList, updateSelectedTeams] = useSelectedTeamState(
     availableTeams,
@@ -159,7 +164,7 @@ const SelectedTeamsForm = ({
               <Dropdown
                 value={role}
                 className={`${baseClass}__role-dropdown`}
-                options={role === "gitops" ? gitOpsRole : roles}
+                options={roleOptions(isApiOnly)}
                 searchable={false}
                 onChange={(newValue: UserRole) =>
                   updateSelectedTeams(teamItem.id, newValue)

--- a/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
@@ -21,6 +21,11 @@ const baseClass = "selected-teams-form";
 const roles = [
   {
     disabled: false,
+    label: "Observer+",
+    value: "observer_plus",
+  },
+  {
+    disabled: false,
     label: "Observer",
     value: "observer",
   },

--- a/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 
 import { ITeam } from "interfaces/team";
+import { UserRole } from "interfaces/user";
 import Checkbox from "components/forms/fields/Checkbox";
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
@@ -77,7 +78,7 @@ const generateSelectedTeamData = (
 const updateFormState = (
   prevTeamItems: ITeamCheckboxListItem[],
   teamId: number,
-  newValue: string | boolean | undefined
+  newValue: UserRole | boolean | undefined
 ): ITeamCheckboxListItem[] => {
   const prevItemIndex = prevTeamItems.findIndex((item) => item.id === teamId);
   const prevItem = prevTeamItems[prevItemIndex];
@@ -100,7 +101,10 @@ const useSelectedTeamState = (
     return generateFormListItems(allTeams, currentTeams);
   });
 
-  const updateSelectedTeams = (teamId: number, newValue: string | boolean) => {
+  const updateSelectedTeams = (
+    teamId: number,
+    newValue: UserRole | boolean
+  ) => {
     setTeamsFormList((prevState) => {
       const updatedTeamFormList = updateFormState(prevState, teamId, newValue);
       const selectedTeamsData = generateSelectedTeamData(updatedTeamFormList);
@@ -144,7 +148,7 @@ const SelectedTeamsForm = ({
                 className={`${baseClass}__role-dropdown`}
                 options={roles}
                 searchable={false}
-                onChange={(newValue: string) =>
+                onChange={(newValue: UserRole) =>
                   updateSelectedTeams(teamItem.id, newValue)
                 }
                 testId={`${name}-checkbox`}

--- a/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
@@ -36,13 +36,16 @@ const roles = [
   },
   {
     disabled: false,
-    label: "GitOps",
-    value: "gitops",
-  },
-  {
-    disabled: false,
     label: "Admin",
     value: "admin",
+  },
+];
+
+const gitOpsRole = [
+  {
+    disabled: false,
+    label: "GitOps",
+    value: "gitops",
   },
 ];
 
@@ -156,7 +159,7 @@ const SelectedTeamsForm = ({
               <Dropdown
                 value={role}
                 className={`${baseClass}__role-dropdown`}
-                options={roles}
+                options={role === "gitops" ? gitOpsRole : roles}
                 searchable={false}
                 onChange={(newValue: UserRole) =>
                   updateSelectedTeams(teamItem.id, newValue)

--- a/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
@@ -2,10 +2,10 @@ import React, { useState } from "react";
 
 import { ITeam } from "interfaces/team";
 import { UserRole } from "interfaces/user";
-import { IRole } from "interfaces/role";
 import Checkbox from "components/forms/fields/Checkbox";
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
+import { roleOptions } from "../../helpers/userManagementHelpers";
 
 interface ITeamCheckboxListItem extends ITeam {
   isChecked: boolean | undefined;
@@ -19,42 +19,6 @@ interface ISelectedTeamsFormProps {
 }
 
 const baseClass = "selected-teams-form";
-
-const roleOptions = (isApiOnly = false): IRole[] => {
-  const roles: IRole[] = [
-    {
-      disabled: false,
-      label: "Observer+",
-      value: "observer_plus",
-    },
-    {
-      disabled: false,
-      label: "Observer",
-      value: "observer",
-    },
-    {
-      disabled: false,
-      label: "Maintainer",
-      value: "maintainer",
-    },
-    {
-      disabled: false,
-      label: "Admin",
-      value: "admin",
-    },
-  ];
-
-  // Next release:
-  // if (isApiOnly) {
-  //   roles.splice(3, 0, {
-  //     disabled: false,
-  //     label: "GitOps",
-  //     value: "gitops",
-  //   });
-  // }
-
-  return roles;
-};
 
 const generateFormListItems = (
   allTeams: ITeam[],
@@ -167,7 +131,7 @@ const SelectedTeamsForm = ({
               <Dropdown
                 value={role}
                 className={`${baseClass}__role-dropdown`}
-                options={roleOptions(isApiOnly)}
+                options={roleOptions({ isPremiumTier: true, isApiOnly })}
                 searchable={false}
                 onChange={(newValue: UserRole) =>
                   updateSelectedTeams(teamItem.id, newValue)

--- a/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
@@ -44,13 +44,14 @@ const roleOptions = (isApiOnly = false): IRole[] => {
     },
   ];
 
-  if (isApiOnly) {
-    roles.splice(3, 0, {
-      disabled: false,
-      label: "GitOps",
-      value: "gitops",
-    });
-  }
+  // Next release:
+  // if (isApiOnly) {
+  //   roles.splice(3, 0, {
+  //     disabled: false,
+  //     label: "GitOps",
+  //     value: "gitops",
+  //   });
+  // }
 
   return roles;
 };

--- a/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
@@ -21,7 +21,6 @@ interface ISelectedTeamsFormProps {
 const baseClass = "selected-teams-form";
 
 const roleOptions = (isApiOnly = false): IRole[] => {
-  console.log("isApiOnly", isApiOnly);
   const roles: IRole[] = [
     {
       disabled: false,
@@ -34,11 +33,6 @@ const roleOptions = (isApiOnly = false): IRole[] => {
       value: "observer",
     },
     {
-      disabled: !isApiOnly,
-      label: `GitOps`,
-      value: "gitops",
-    },
-    {
       disabled: false,
       label: "Maintainer",
       value: "maintainer",
@@ -49,6 +43,14 @@ const roleOptions = (isApiOnly = false): IRole[] => {
       value: "admin",
     },
   ];
+
+  if (isApiOnly) {
+    roles.splice(3, 0, {
+      disabled: false,
+      label: "GitOps",
+      value: "gitops",
+    });
+  }
 
   return roles;
 };

--- a/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/SelectedTeamsForm/SelectedTeamsForm.tsx
@@ -36,6 +36,11 @@ const roles = [
   },
   {
     disabled: false,
+    label: "GitOps",
+    value: "gitops",
+  },
+  {
+    disabled: false,
     label: "Admin",
     value: "admin",
   },

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -5,6 +5,7 @@ import PATHS from "router/paths";
 import { NotificationContext } from "context/notification";
 import { ITeam } from "interfaces/team";
 import { IUserFormErrors, UserRole } from "interfaces/user";
+import { IRole } from "interfaces/role";
 
 import Button from "components/buttons/Button";
 import validatePresence from "components/forms/validators/validate_presence";
@@ -34,28 +35,35 @@ enum UserTeamType {
   AssignTeams = "ASSIGN_TEAMS",
 }
 
-const globalUserRoles = [
-  {
-    disabled: false,
-    label: "Observer+",
-    value: "observer_plus",
-  },
-  {
-    disabled: false,
-    label: "Observer",
-    value: "observer",
-  },
-  {
-    disabled: false,
-    label: "Maintainer",
-    value: "maintainer",
-  },
-  {
-    disabled: false,
-    label: "Admin",
-    value: "admin",
-  },
-];
+const globalUserRoles = (isPremiumTier: boolean): IRole[] => {
+  const roles: IRole[] = [
+    {
+      disabled: false,
+      label: "Observer",
+      value: "observer",
+    },
+    {
+      disabled: false,
+      label: "Maintainer",
+      value: "maintainer",
+    },
+    {
+      disabled: false,
+      label: "Admin",
+      value: "admin",
+    },
+  ];
+
+  if (isPremiumTier) {
+    roles.unshift({
+      disabled: false,
+      label: "Observer+",
+      value: "observer_plus",
+    });
+  }
+
+  return roles;
+};
 
 export interface IFormData {
   email: string;
@@ -312,7 +320,7 @@ const UserForm = ({
           label="Role"
           value={formData.global_role || "Observer"}
           className={`${baseClass}__global-role-dropdown`}
-          options={globalUserRoles}
+          options={globalUserRoles(isPremiumTier || false)}
           searchable={false}
           onChange={onGlobalUserRoleChange}
           wrapperClassName={`${baseClass}__form-field ${baseClass}__form-field--global-role`}

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -60,6 +60,11 @@ const globalUserRoles = (isPremiumTier: boolean): IRole[] => {
       label: "Observer+",
       value: "observer_plus",
     });
+    roles.splice(3, 0, {
+      disabled: false,
+      label: "GitOps",
+      value: "gitops",
+    });
   }
 
   return roles;

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -4,7 +4,7 @@ import PATHS from "router/paths";
 
 import { NotificationContext } from "context/notification";
 import { ITeam } from "interfaces/team";
-import { IUserFormErrors } from "interfaces/user";
+import { IUserFormErrors, UserRole } from "interfaces/user";
 
 import Button from "components/buttons/Button";
 import validatePresence from "components/forms/validators/validate_presence";
@@ -37,6 +37,11 @@ enum UserTeamType {
 const globalUserRoles = [
   {
     disabled: false,
+    label: "Observer+",
+    value: "observer_plus",
+  },
+  {
+    disabled: false,
     label: "Observer",
     value: "observer",
   },
@@ -58,10 +63,11 @@ export interface IFormData {
   newUserType?: NewUserType | null;
   password?: string | null;
   sso_enabled?: boolean;
-  global_role: string | null;
+  global_role: UserRole | null;
   teams: ITeam[];
   currentUserId?: number;
   invited_by?: number;
+  role?: UserRole;
 }
 
 interface ICreateUserFormProps {
@@ -74,8 +80,8 @@ interface ICreateUserFormProps {
   currentUserId?: number;
   currentTeam?: ITeam;
   isModifiedByGlobalAdmin?: boolean | false;
-  defaultGlobalRole?: string | null;
-  defaultTeamRole?: string;
+  defaultGlobalRole?: UserRole | null;
+  defaultTeamRole?: UserRole;
   defaultTeams?: ITeam[];
   isPremiumTier: boolean;
   smtpConfigured?: boolean;

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -35,7 +35,15 @@ enum UserTeamType {
   AssignTeams = "ASSIGN_TEAMS",
 }
 
-const globalUserRoles = (isPremiumTier: boolean): IRole[] => {
+interface GlobalRoleParams {
+  isPremiumTier: boolean;
+  isNewUser?: boolean;
+}
+
+const globalUserRoles = ({
+  isPremiumTier,
+  isNewUser,
+}: GlobalRoleParams): IRole[] => {
   const roles: IRole[] = [
     {
       disabled: false,
@@ -60,11 +68,14 @@ const globalUserRoles = (isPremiumTier: boolean): IRole[] => {
       label: "Observer+",
       value: "observer_plus",
     });
-    roles.splice(3, 0, {
-      disabled: false,
-      label: "GitOps",
-      value: "gitops",
-    });
+    // Only existing users can be converted to gitops user
+    if (!isNewUser) {
+      roles.splice(3, 0, {
+        disabled: false,
+        label: "GitOps",
+        value: "gitops",
+      });
+    }
   }
 
   return roles;
@@ -325,7 +336,10 @@ const UserForm = ({
           label="Role"
           value={formData.global_role || "Observer"}
           className={`${baseClass}__global-role-dropdown`}
-          options={globalUserRoles(isPremiumTier || false)}
+          options={globalUserRoles({
+            isPremiumTier,
+            isNewUser,
+          })}
           searchable={false}
           onChange={onGlobalUserRoleChange}
           wrapperClassName={`${baseClass}__form-field ${baseClass}__form-field--global-role`}
@@ -385,6 +399,7 @@ const UserForm = ({
               teams={formData.teams}
               defaultTeamRole={defaultTeamRole || "observer"}
               onFormChange={onTeamRoleChange}
+              isNewUser={isNewUser}
             />
           ))}
         {!availableTeams.length && renderNoTeamsMessage()}

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -40,20 +40,11 @@ interface GlobalRoleParams {
   isApiOnly?: boolean;
 }
 
+// Create and edit global user role
 const globalUserRoles = ({
   isPremiumTier,
   isApiOnly,
 }: GlobalRoleParams): IRole[] => {
-  if (isApiOnly) {
-    return [
-      {
-        disabled: false,
-        label: "GitOps",
-        value: "gitops",
-      },
-    ];
-  }
-
   const roles: IRole[] = [
     {
       disabled: false,
@@ -77,6 +68,11 @@ const globalUserRoles = ({
       disabled: false,
       label: "Observer+",
       value: "observer_plus",
+    });
+    roles.splice(3, 0, {
+      disabled: !isApiOnly,
+      label: "GitOps",
+      value: "gitops",
     });
   }
 
@@ -394,6 +390,7 @@ const UserForm = ({
                 availableTeams={availableTeams}
                 usersCurrentTeams={formData.teams}
                 onFormChange={onSelectedTeamChange}
+                isApiOnly={isApiOnly}
               />
             </>
           ) : (

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -22,6 +22,7 @@ import InfoBanner from "components/InfoBanner/InfoBanner";
 import CustomLink from "components/CustomLink";
 import SelectedTeamsForm from "../SelectedTeamsForm/SelectedTeamsForm";
 import SelectRoleForm from "../SelectRoleForm/SelectRoleForm";
+import { roleOptions } from "../../helpers/userManagementHelpers";
 
 const baseClass = "create-user-form";
 
@@ -34,53 +35,6 @@ enum UserTeamType {
   GlobalUser = "GLOBAL_USER",
   AssignTeams = "ASSIGN_TEAMS",
 }
-
-interface GlobalRoleParams {
-  isPremiumTier: boolean;
-  isApiOnly?: boolean;
-}
-
-// Create and edit global user role
-const globalUserRoles = ({
-  isPremiumTier,
-  isApiOnly,
-}: GlobalRoleParams): IRole[] => {
-  const roles: IRole[] = [
-    {
-      disabled: false,
-      label: "Observer",
-      value: "observer",
-    },
-    {
-      disabled: false,
-      label: "Maintainer",
-      value: "maintainer",
-    },
-    {
-      disabled: false,
-      label: "Admin",
-      value: "admin",
-    },
-  ];
-
-  if (isPremiumTier) {
-    roles.unshift({
-      disabled: false,
-      label: "Observer+",
-      value: "observer_plus",
-    });
-    // Next release
-    // if (isApiOnly) {
-    //   roles.splice(3, 0, {
-    //     disabled: false,
-    //     label: "GitOps",
-    //     value: "gitops",
-    //   });
-    // }
-  }
-
-  return roles;
-};
 
 export interface IFormData {
   email: string;
@@ -339,7 +293,7 @@ const UserForm = ({
           label="Role"
           value={formData.global_role || "Observer"}
           className={`${baseClass}__global-role-dropdown`}
-          options={globalUserRoles({
+          options={roleOptions({
             isPremiumTier,
             isApiOnly,
           })}

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -37,13 +37,23 @@ enum UserTeamType {
 
 interface GlobalRoleParams {
   isPremiumTier: boolean;
-  isNewUser?: boolean;
+  isApiOnly?: boolean;
 }
 
 const globalUserRoles = ({
   isPremiumTier,
-  isNewUser,
+  isApiOnly,
 }: GlobalRoleParams): IRole[] => {
+  if (isApiOnly) {
+    return [
+      {
+        disabled: false,
+        label: "GitOps",
+        value: "gitops",
+      },
+    ];
+  }
+
   const roles: IRole[] = [
     {
       disabled: false,
@@ -68,14 +78,6 @@ const globalUserRoles = ({
       label: "Observer+",
       value: "observer_plus",
     });
-    // Only existing users can be converted to gitops user
-    if (!isNewUser) {
-      roles.splice(3, 0, {
-        disabled: false,
-        label: "GitOps",
-        value: "gitops",
-      });
-    }
   }
 
   return roles;
@@ -111,6 +113,7 @@ interface ICreateUserFormProps {
   smtpConfigured?: boolean;
   canUseSso: boolean; // corresponds to whether SSO is enabled for the organization
   isSsoEnabled?: boolean; // corresponds to whether SSO is enabled for the individual user
+  isApiOnly?: boolean;
   isNewUser?: boolean;
   isInvitePending?: boolean;
   serverErrors?: { base: string; email: string }; // "server" because this form does its own client validation
@@ -135,6 +138,7 @@ const UserForm = ({
   smtpConfigured,
   canUseSso,
   isSsoEnabled,
+  isApiOnly,
   isNewUser,
   isInvitePending,
   serverErrors,
@@ -338,7 +342,7 @@ const UserForm = ({
           className={`${baseClass}__global-role-dropdown`}
           options={globalUserRoles({
             isPremiumTier,
-            isNewUser,
+            isApiOnly,
           })}
           searchable={false}
           onChange={onGlobalUserRoleChange}
@@ -399,7 +403,7 @@ const UserForm = ({
               teams={formData.teams}
               defaultTeamRole={defaultTeamRole || "observer"}
               onFormChange={onTeamRoleChange}
-              isNewUser={isNewUser}
+              isApiOnly={isApiOnly}
             />
           ))}
         {!availableTeams.length && renderNoTeamsMessage()}

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -69,13 +69,14 @@ const globalUserRoles = ({
       label: "Observer+",
       value: "observer_plus",
     });
-    if (isApiOnly) {
-      roles.splice(3, 0, {
-        disabled: false,
-        label: "GitOps",
-        value: "gitops",
-      });
-    }
+    // Next release
+    // if (isApiOnly) {
+    //   roles.splice(3, 0, {
+    //     disabled: false,
+    //     label: "GitOps",
+    //     value: "gitops",
+    //   });
+    // }
   }
 
   return roles;

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -69,11 +69,13 @@ const globalUserRoles = ({
       label: "Observer+",
       value: "observer_plus",
     });
-    roles.splice(3, 0, {
-      disabled: !isApiOnly,
-      label: "GitOps",
-      value: "gitops",
-    });
+    if (isApiOnly) {
+      roles.splice(3, 0, {
+        disabled: false,
+        label: "GitOps",
+        value: "gitops",
+      });
+    }
   }
 
   return roles;

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
@@ -431,7 +431,6 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
   const renderEditUserModal = () => {
     const userData = getUser(userEditing.type, userEditing.id);
 
-    console.log("userData", userData);
     return (
       <Modal title="Edit user" onExit={toggleEditUserModal}>
         <>

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
@@ -431,6 +431,7 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
   const renderEditUserModal = () => {
     const userData = getUser(userEditing.type, userEditing.id);
 
+    console.log("userData", userData);
     return (
       <Modal title="Edit user" onExit={toggleEditUserModal}>
         <>
@@ -446,6 +447,7 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
             smtpConfigured={config?.smtp_settings.configured || false}
             canUseSso={config?.sso_settings.enable_sso || false}
             isSsoEnabled={userData?.sso_enabled}
+            isApiOnly={userData?.api_only || false}
             isModifiedByGlobalAdmin
             isInvitePending={userEditing.type === "invite"}
             editUserErrors={editUserErrors}

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
@@ -131,7 +131,7 @@ const generateTableHeaders = (
       accessor: "role",
       disableSortBy: true,
       Cell: (cellProps: ICellProps) => {
-        if (cellProps.cell.value === "GitOps") {
+        if (cellProps.cell.value === "Gitops") {
           return (
             <TooltipWrapper
               position="top"
@@ -141,7 +141,7 @@ const generateTableHeaders = (
             access to the UI.
           `}
             >
-              {cellProps.cell.value}
+              GitOps
             </TooltipWrapper>
           );
         }

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
@@ -131,7 +131,7 @@ const generateTableHeaders = (
       accessor: "role",
       disableSortBy: true,
       Cell: (cellProps: ICellProps) => {
-        if (cellProps.cell.value === "Gitops") {
+        if (cellProps.cell.value === "GitOps") {
           return (
             <TooltipWrapper
               position="top"

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
@@ -131,6 +131,20 @@ const generateTableHeaders = (
       accessor: "role",
       disableSortBy: true,
       Cell: (cellProps: ICellProps) => {
+        if (cellProps.cell.value === "GitOps") {
+          return (
+            <TooltipWrapper
+              position="top"
+              tipContent={`
+            The GitOps role is only available on the command-line<br/>
+            when creating an API-only user. This user has no<br/>
+            access to the UI.
+          `}
+            >
+              {cellProps.cell.value}
+            </TooltipWrapper>
+          );
+        }
         if (cellProps.cell.value === "Observer+") {
           return (
             <TooltipWrapper

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
@@ -4,7 +4,11 @@ import ReactTooltip from "react-tooltip";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";
 import StatusIndicator from "components/StatusIndicator";
 import TextCell from "components/TableContainer/DataTable/TextCell/TextCell";
+<<<<<<< HEAD
 import CustomLink from "components/CustomLink";
+=======
+import TooltipWrapper from "components/TooltipWrapper";
+>>>>>>> a3df83b31 (Create observer plus to be part of observer role, and modify ui to allow observer plus access)
 import { IInvite } from "interfaces/invite";
 import { IUser, UserRole } from "interfaces/user";
 import { IDropdownOption } from "interfaces/dropdownOption";
@@ -126,12 +130,28 @@ const generateTableHeaders = (
       Header: "Role",
       accessor: "role",
       disableSortBy: true,
-      Cell: (cellProps: ICellProps) => (
-        <TextCell
-          value={cellProps.cell.value}
-          greyed={greyCell(cellProps.cell.value)}
-        />
-      ),
+      Cell: (cellProps: ICellProps) => {
+        if (cellProps.cell.value === "Observer+") {
+          return (
+            <TooltipWrapper
+              position="top"
+              tipContent={`
+            Users with the Observer+ role have access to all of<br/>
+            the same functions as an Observer, with the added<br/>
+            ability to run any live query against all hosts. 
+          `}
+            >
+              {cellProps.cell.value}
+            </TooltipWrapper>
+          );
+        }
+        return (
+          <TextCell
+            value={cellProps.cell.value}
+            greyed={greyCell(cellProps.cell.value)}
+          />
+        );
+      },
     },
     {
       title: "Status",

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
@@ -6,7 +6,7 @@ import StatusIndicator from "components/StatusIndicator";
 import TextCell from "components/TableContainer/DataTable/TextCell/TextCell";
 import CustomLink from "components/CustomLink";
 import { IInvite } from "interfaces/invite";
-import { IUser } from "interfaces/user";
+import { IUser, UserRole } from "interfaces/user";
 import { IDropdownOption } from "interfaces/dropdownOption";
 import { generateRole, generateTeam, greyCell } from "utilities/helpers";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
@@ -53,7 +53,7 @@ export interface IUserTableData {
   status: string;
   email: string;
   teams: string;
-  role: string;
+  role: UserRole;
   actions: IDropdownOption[];
   id: number;
   type: string;

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
@@ -4,11 +4,8 @@ import ReactTooltip from "react-tooltip";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";
 import StatusIndicator from "components/StatusIndicator";
 import TextCell from "components/TableContainer/DataTable/TextCell/TextCell";
-<<<<<<< HEAD
 import CustomLink from "components/CustomLink";
-=======
 import TooltipWrapper from "components/TooltipWrapper";
->>>>>>> a3df83b31 (Create observer plus to be part of observer role, and modify ui to allow observer plus access)
 import { IInvite } from "interfaces/invite";
 import { IUser, UserRole } from "interfaces/user";
 import { IDropdownOption } from "interfaces/dropdownOption";

--- a/frontend/pages/admin/UserManagementPage/helpers/userManagementHelpers.tests.ts
+++ b/frontend/pages/admin/UserManagementPage/helpers/userManagementHelpers.tests.ts
@@ -1,15 +1,17 @@
 import { userStub, userTeamStub } from "test/stubs";
+import { IUserUpdateBody } from "interfaces/user";
+
 import { IFormData, NewUserType } from "../components/UserForm/UserForm";
 import userManagementHelpers from "./userManagementHelpers";
 
 describe("userManagementHelpers module", () => {
   describe("generateUpdatedData function", () => {
     it("returns an object with only the difference between the two", () => {
-      const updatedTeam = {
+      const updatedTeam: IUserUpdateBody = {
         ...userTeamStub,
         role: "maintainer",
       };
-      const newTeam = {
+      const newTeam: IUserUpdateBody = {
         ...userTeamStub,
         id: 2,
         role: "observer",

--- a/frontend/pages/admin/UserManagementPage/helpers/userManagementHelpers.ts
+++ b/frontend/pages/admin/UserManagementPage/helpers/userManagementHelpers.ts
@@ -10,6 +10,7 @@ import {
 
 import { IInvite } from "interfaces/invite";
 import { IUser, IUserUpdateBody, IUpdateUserFormData } from "interfaces/user";
+import { IRole } from "interfaces/role";
 import { IFormData } from "../components/UserForm/UserForm";
 
 type ICurrentUserData = Pick<
@@ -21,6 +22,11 @@ interface ILocationParams {
   pathPrefix?: string;
   routeTemplate?: string;
   routeParams?: { [key: string]: number };
+}
+
+interface IRoleOptionsParams {
+  isPremiumTier?: boolean;
+  isApiOnly?: boolean;
 }
 
 /**
@@ -92,7 +98,49 @@ export const getNextLocationPath = ({
   return `/${nextLocation}`;
 };
 
+export const roleOptions = ({
+  isPremiumTier,
+  isApiOnly,
+}: IRoleOptionsParams): IRole[] => {
+  const roles: IRole[] = [
+    {
+      disabled: false,
+      label: "Observer",
+      value: "observer",
+    },
+    {
+      disabled: false,
+      label: "Maintainer",
+      value: "maintainer",
+    },
+    {
+      disabled: false,
+      label: "Admin",
+      value: "admin",
+    },
+  ];
+
+  if (isPremiumTier) {
+    roles.unshift({
+      disabled: false,
+      label: "Observer+",
+      value: "observer_plus",
+    });
+    // Next release:
+    // if (isApiOnly) {
+    //   roles.splice(3, 0, {
+    //     disabled: false,
+    //     label: "GitOps",
+    //     value: "gitops",
+    //   });
+    // }
+  }
+
+  return roles;
+};
+
 export default {
   generateUpdateData,
   getNextLocationPath,
+  roleOptions,
 };

--- a/frontend/pages/admin/UserManagementPage/helpers/userManagementHelpers.ts
+++ b/frontend/pages/admin/UserManagementPage/helpers/userManagementHelpers.ts
@@ -9,7 +9,7 @@ import {
 } from "lodash";
 
 import { IInvite } from "interfaces/invite";
-import { IUser, IUserUpdateBody } from "interfaces/user";
+import { IUser, IUserUpdateBody, IUpdateUserFormData } from "interfaces/user";
 import { IFormData } from "../components/UserForm/UserForm";
 
 type ICurrentUserData = Pick<
@@ -33,7 +33,7 @@ interface ILocationParams {
 const generateUpdateData = (
   currentUserData: IUser | IInvite,
   formData: IFormData
-): IUserUpdateBody => {
+): IUpdateUserFormData => {
   const updatableFields = [
     "global_role",
     "teams",
@@ -41,7 +41,7 @@ const generateUpdateData = (
     "email",
     "sso_enabled",
   ];
-  return Object.keys(formData).reduce<IUserUpdateBody>(
+  return Object.keys(formData).reduce<IUserUpdateBody | any>(
     (updatedAttributes, attr) => {
       // attribute can be updated and is different from the current value.
       if (

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -110,6 +110,7 @@ const HostDetailsPage = ({
     isGlobalAdmin = false,
     isPremiumTier = false,
     isOnlyObserver,
+    isObserverPlus,
     filteredHostsPath,
   } = useContext(AppContext);
   const {
@@ -636,6 +637,7 @@ const HostDetailsPage = ({
           diskEncryption={hostDiskEncryption}
           isPremiumTier={isPremiumTier}
           isOnlyObserver={isOnlyObserver}
+          isObserverPlus={isObserverPlus}
           toggleOSPolicyModal={toggleOSPolicyModal}
           toggleMacSettingsModal={toggleMacSettingsModal}
           hostMacSettings={host?.mdm.profiles}
@@ -728,6 +730,7 @@ const HostDetailsPage = ({
             queries={fleetQueries || []}
             queryErrors={fleetQueriesError}
             isOnlyObserver={isOnlyObserver}
+            isObserverPlus={isObserverPlus}
             onQueryHostCustom={onQueryHostCustom}
             onQueryHostSaved={onQueryHostSaved}
           />

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -637,7 +637,6 @@ const HostDetailsPage = ({
           diskEncryption={hostDiskEncryption}
           isPremiumTier={isPremiumTier}
           isOnlyObserver={isOnlyObserver}
-          isObserverPlus={isObserverPlus}
           toggleOSPolicyModal={toggleOSPolicyModal}
           toggleMacSettingsModal={toggleMacSettingsModal}
           hostMacSettings={host?.mdm.profiles}

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -729,9 +729,9 @@ const HostDetailsPage = ({
             queries={fleetQueries || []}
             queryErrors={fleetQueriesError}
             isOnlyObserver={isOnlyObserver}
-            isObserverPlus={isObserverPlus}
             onQueryHostCustom={onQueryHostCustom}
             onQueryHostSaved={onQueryHostSaved}
+            hostsTeamId={host?.team_id}
           />
         )}
         {!!host && showTransferHostModal && (

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/SelectQueryModal/SelectQueryModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/SelectQueryModal/SelectQueryModal.tsx
@@ -16,7 +16,8 @@ export interface ISelectQueryModalProps {
   onQueryHostSaved: (selectedQuery: IQuery) => void;
   queries: IQuery[] | [];
   queryErrors: Error | null;
-  isOnlyObserver: boolean | undefined;
+  isOnlyObserver?: boolean;
+  isObserverPlus?: boolean;
 }
 
 const baseClass = "select-query-modal";
@@ -28,12 +29,13 @@ const SelectQueryModal = ({
   queries,
   queryErrors,
   isOnlyObserver,
+  isObserverPlus,
 }: ISelectQueryModalProps): JSX.Element => {
   let queriesAvailableToRun = queries;
 
   const [queriesFilter, setQueriesFilter] = useState("");
 
-  if (isOnlyObserver) {
+  if (isOnlyObserver && !isObserverPlus) {
     queriesAvailableToRun = queries.filter(
       (query) => query.observer_can_run === true
     );
@@ -94,7 +96,7 @@ const SelectQueryModal = ({
             catches up.
           </span>
           <div className="modal-cta-wrap">
-            {!isOnlyObserver && customQueryButton()}
+            {(!isOnlyObserver || isObserverPlus) && customQueryButton()}
           </div>
         </div>
       );
@@ -128,7 +130,7 @@ const SelectQueryModal = ({
                 autofocus
               />
             </div>
-            {!isOnlyObserver && (
+            {(!isOnlyObserver || isObserverPlus) && (
               <div className={`${baseClass}__create-query`}>
                 <span>OR</span>
                 {customQueryButton()}
@@ -153,7 +155,7 @@ const SelectQueryModal = ({
                 autofocus
               />
             </div>
-            {!isOnlyObserver && (
+            {(!isOnlyObserver || isObserverPlus) && (
               <div className={`${baseClass}__create-query`}>
                 <span>OR</span>
                 {customQueryButton()}

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -213,7 +213,7 @@ const HostSummary = ({
         <div className="info-flex__item info-flex__item--title">
           <span className="info-flex__header">Operating system</span>
           <span className="info-flex__data">
-            {(isOnlyObserver && !isObserverPlus) || deviceUser ? (
+            {isOnlyObserver || deviceUser ? (
               `${titleData.os_version}`
             ) : (
               <Button

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -28,7 +28,6 @@ interface IHostSummaryProps {
   diskEncryption?: IHostDiskEncryptionProps;
   isPremiumTier?: boolean;
   isOnlyObserver?: boolean;
-  isObserverPlus?: boolean;
   toggleOSPolicyModal?: () => void;
   toggleMacSettingsModal?: () => void;
   hostMacSettings?: IMacSettings;
@@ -47,7 +46,6 @@ const HostSummary = ({
   diskEncryption,
   isPremiumTier,
   isOnlyObserver,
-  isObserverPlus,
   toggleOSPolicyModal,
   toggleMacSettingsModal,
   hostMacSettings,

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -28,6 +28,7 @@ interface IHostSummaryProps {
   diskEncryption?: IHostDiskEncryptionProps;
   isPremiumTier?: boolean;
   isOnlyObserver?: boolean;
+  isObserverPlus?: boolean;
   toggleOSPolicyModal?: () => void;
   toggleMacSettingsModal?: () => void;
   hostMacSettings?: IMacSettings;
@@ -46,6 +47,7 @@ const HostSummary = ({
   diskEncryption,
   isPremiumTier,
   isOnlyObserver,
+  isObserverPlus,
   toggleOSPolicyModal,
   toggleMacSettingsModal,
   hostMacSettings,
@@ -211,7 +213,7 @@ const HostSummary = ({
         <div className="info-flex__item info-flex__item--title">
           <span className="info-flex__header">Operating system</span>
           <span className="info-flex__data">
-            {isOnlyObserver || deviceUser ? (
+            {(isOnlyObserver && !isObserverPlus) || deviceUser ? (
               `${titleData.os_version}`
             ) : (
               <Button

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -84,7 +84,9 @@ const enhanceQuery = (q: IQuery) => {
 const ManageQueriesPage = ({
   router,
 }: IManageQueriesPageProps): JSX.Element => {
-  const { isOnlyObserver, isObserverPlus } = useContext(AppContext);
+  const { isOnlyObserver, isObserverPlus, isAnyTeamObserverPlus } = useContext(
+    AppContext
+  );
   const { setResetSelectedRows } = useContext(TableContext);
   const { renderFlash } = useContext(NotificationContext);
 
@@ -188,17 +190,18 @@ const ManageQueriesPage = ({
               </h1>
             </div>
           </div>
-          {(!isOnlyObserver || isObserverPlus) && !!fleetQueries?.length && (
-            <div className={`${baseClass}__action-button-container`}>
-              <Button
-                variant="brand"
-                className={`${baseClass}__create-button`}
-                onClick={onCreateQueryClick}
-              >
-                Create new query
-              </Button>
-            </div>
-          )}
+          {(!isOnlyObserver || isObserverPlus || isAnyTeamObserverPlus) &&
+            !!fleetQueries?.length && (
+              <div className={`${baseClass}__action-button-container`}>
+                <Button
+                  variant="brand"
+                  className={`${baseClass}__create-button`}
+                  onClick={onCreateQueryClick}
+                >
+                  Create new query
+                </Button>
+              </div>
+            )}
         </div>
         <div className={`${baseClass}__description`}>
           <p>Manage queries to ask specific questions about your devices.</p>

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -84,7 +84,7 @@ const enhanceQuery = (q: IQuery) => {
 const ManageQueriesPage = ({
   router,
 }: IManageQueriesPageProps): JSX.Element => {
-  const { isOnlyObserver } = useContext(AppContext);
+  const { isOnlyObserver, isObserverPlus } = useContext(AppContext);
   const { setResetSelectedRows } = useContext(TableContext);
   const { renderFlash } = useContext(NotificationContext);
 
@@ -188,7 +188,7 @@ const ManageQueriesPage = ({
               </h1>
             </div>
           </div>
-          {!isOnlyObserver && !!fleetQueries?.length && (
+          {(!isOnlyObserver || isObserverPlus) && !!fleetQueries?.length && (
             <div className={`${baseClass}__action-button-container`}>
               <Button
                 variant="brand"
@@ -216,6 +216,7 @@ const ManageQueriesPage = ({
               customControl={renderPlatformDropdown}
               selectedDropdownFilter={selectedDropdownFilter}
               isOnlyObserver={isOnlyObserver}
+              isObserverPlus={isObserverPlus}
             />
           )}
         </div>

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -220,6 +220,7 @@ const ManageQueriesPage = ({
               selectedDropdownFilter={selectedDropdownFilter}
               isOnlyObserver={isOnlyObserver}
               isObserverPlus={isObserverPlus}
+              isAnyTeamObserverPlus={isAnyTeamObserverPlus || false}
             />
           )}
         </div>

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -27,6 +27,7 @@ interface IQueriesTableProps {
   customControl?: () => JSX.Element;
   selectedDropdownFilter: string;
   isOnlyObserver?: boolean;
+  isObserverPlus?: boolean;
 }
 
 const QueriesTable = ({
@@ -37,6 +38,7 @@ const QueriesTable = ({
   customControl,
   selectedDropdownFilter,
   isOnlyObserver,
+  isObserverPlus,
 }: IQueriesTableProps): JSX.Element | null => {
   const { currentUser } = useContext(AppContext);
   const [searchString, setSearchString] = useState("");
@@ -56,7 +58,7 @@ const QueriesTable = ({
       emptyQueries.header = "No queries match the current search criteria.";
       emptyQueries.info =
         "Expecting to see queries? Try again in a few seconds as the system catches up.";
-    } else if (!isOnlyObserver) {
+    } else if (!isOnlyObserver || isObserverPlus) {
       emptyQueries.additionalInfo = (
         <>
           Create a new query, or{" "}

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -28,6 +28,7 @@ interface IQueriesTableProps {
   selectedDropdownFilter: string;
   isOnlyObserver?: boolean;
   isObserverPlus?: boolean;
+  isAnyTeamObserverPlus: boolean;
 }
 
 const QueriesTable = ({
@@ -39,6 +40,7 @@ const QueriesTable = ({
   selectedDropdownFilter,
   isOnlyObserver,
   isObserverPlus,
+  isAnyTeamObserverPlus,
 }: IQueriesTableProps): JSX.Element | null => {
   const { currentUser } = useContext(AppContext);
   const [searchString, setSearchString] = useState("");
@@ -58,7 +60,7 @@ const QueriesTable = ({
       emptyQueries.header = "No queries match the current search criteria.";
       emptyQueries.info =
         "Expecting to see queries? Try again in a few seconds as the system catches up.";
-    } else if (!isOnlyObserver || isObserverPlus) {
+    } else if (!isOnlyObserver || isObserverPlus || isAnyTeamObserverPlus) {
       emptyQueries.additionalInfo = (
         <>
           Create a new query, or{" "}

--- a/frontend/pages/queries/QueryPage/QueryPage.tsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.tsx
@@ -47,6 +47,7 @@ const QueryPage = ({
     isGlobalMaintainer,
     isAnyTeamMaintainerOrTeamAdmin,
     isObserverPlus,
+    isAnyTeamObserverPlus,
   } = useContext(AppContext);
   const {
     selectedOsqueryTable,
@@ -234,7 +235,8 @@ const QueryPage = ({
     (isGlobalAdmin ||
       isGlobalMaintainer ||
       isAnyTeamMaintainerOrTeamAdmin ||
-      isObserverPlus);
+      isObserverPlus ||
+      isAnyTeamObserverPlus);
 
   return (
     <>

--- a/frontend/pages/queries/QueryPage/QueryPage.tsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.tsx
@@ -46,6 +46,7 @@ const QueryPage = ({
     isGlobalAdmin,
     isGlobalMaintainer,
     isAnyTeamMaintainerOrTeamAdmin,
+    isObserverPlus,
   } = useContext(AppContext);
   const {
     selectedOsqueryTable,
@@ -230,7 +231,10 @@ const QueryPage = ({
   const showSidebar =
     isFirstStep &&
     isSidebarOpen &&
-    (isGlobalAdmin || isGlobalMaintainer || isAnyTeamMaintainerOrTeamAdmin);
+    (isGlobalAdmin ||
+      isGlobalMaintainer ||
+      isAnyTeamMaintainerOrTeamAdmin ||
+      isObserverPlus);
 
   return (
     <>

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -98,6 +98,7 @@ const QueryForm = ({
     isGlobalAdmin,
     isGlobalMaintainer,
     isObserverPlus,
+    isAnyTeamObserverPlus,
   } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 
@@ -105,7 +106,7 @@ const QueryForm = ({
   const [errors, setErrors] = useState<{ [key: string]: any }>({}); // string | null | undefined or boolean | undefined
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
   const [showQueryEditor, setShowQueryEditor] = useState(
-    isObserverPlus || false
+    isObserverPlus || isAnyTeamObserverPlus || false
   );
   const [isEditingName, setIsEditingName] = useState(false);
   const [isEditingDescription, setIsEditingDescription] = useState(false);
@@ -405,7 +406,7 @@ const QueryForm = ({
         </div>
         <div className="author">{renderAuthor()}</div>
       </div>
-      {!isObserverPlus && (
+      {(!isObserverPlus || !isAnyTeamObserverPlus) && (
         <RevealButton
           isShowing={showQueryEditor}
           className={baseClass}
@@ -420,7 +421,7 @@ const QueryForm = ({
           name="query editor"
           label="Query"
           wrapperClassName={`${baseClass}__text-editor-wrapper`}
-          readOnly={!isObserverPlus}
+          readOnly={!isObserverPlus || !isAnyTeamObserverPlus}
           labelActionComponent={isObserverPlus && renderLabelComponent()}
           wrapEnabled
         />
@@ -429,7 +430,9 @@ const QueryForm = ({
         {renderPlatformCompatibility()}
       </span>
       {renderLiveQueryWarning()}
-      {(lastEditedQueryObserverCanRun || isObserverPlus) && (
+      {(lastEditedQueryObserverCanRun ||
+        isObserverPlus ||
+        isAnyTeamObserverPlus) && (
         <div
           className={`${baseClass}__button-wrap ${baseClass}__button-wrap--new-query`}
         >
@@ -572,7 +575,12 @@ const QueryForm = ({
     return <Spinner />;
   }
 
-  if (isOnlyObserver || isGlobalObserver || isObserverPlus) {
+  if (
+    isOnlyObserver ||
+    isGlobalObserver ||
+    isObserverPlus ||
+    isAnyTeamObserverPlus
+  ) {
     return renderRunForObserver;
   }
 

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -418,8 +418,10 @@ const QueryForm = ({
         <FleetAce
           value={lastEditedQueryBody}
           name="query editor"
+          label="Query"
           wrapperClassName={`${baseClass}__text-editor-wrapper`}
-          readOnly
+          readOnly={!isObserverPlus}
+          labelActionComponent={isObserverPlus && renderLabelComponent()}
           wrapEnabled
         />
       )}
@@ -570,7 +572,7 @@ const QueryForm = ({
     return <Spinner />;
   }
 
-  if (isOnlyObserver || isGlobalObserver) {
+  if (isOnlyObserver || isGlobalObserver || isObserverPlus) {
     return renderRunForObserver;
   }
 

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -76,14 +76,6 @@ const QueryForm = ({
   renderLiveQueryWarning,
   backendValidators,
 }: IQueryFormProps): JSX.Element => {
-  const isEditMode = !!queryIdForEdit;
-  const [errors, setErrors] = useState<{ [key: string]: any }>({}); // string | null | undefined or boolean | undefined
-  const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
-  const [showQueryEditor, setShowQueryEditor] = useState(false);
-  const [isEditingName, setIsEditingName] = useState(false);
-  const [isEditingDescription, setIsEditingDescription] = useState(false);
-  const [isSaveAsNewLoading, setIsSaveAsNewLoading] = useState(false);
-
   // Note: The QueryContext values should always be used for any mutable query data such as query name
   // The storedQuery prop should only be used to access immutable metadata such as author id
   const {
@@ -105,8 +97,19 @@ const QueryForm = ({
     isAnyTeamMaintainerOrTeamAdmin,
     isGlobalAdmin,
     isGlobalMaintainer,
+    isObserverPlus,
   } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
+
+  const isEditMode = !!queryIdForEdit;
+  const [errors, setErrors] = useState<{ [key: string]: any }>({}); // string | null | undefined or boolean | undefined
+  const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
+  const [showQueryEditor, setShowQueryEditor] = useState(
+    isObserverPlus || false
+  );
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [isEditingDescription, setIsEditingDescription] = useState(false);
+  const [isSaveAsNewLoading, setIsSaveAsNewLoading] = useState(false);
 
   const platformCompatibility = usePlatformCompatibility();
   const { setCompatiblePlatforms } = platformCompatibility;
@@ -402,13 +405,15 @@ const QueryForm = ({
         </div>
         <div className="author">{renderAuthor()}</div>
       </div>
-      <RevealButton
-        isShowing={showQueryEditor}
-        className={baseClass}
-        hideText="Hide SQL"
-        showText="Show SQL"
-        onClick={() => setShowQueryEditor(!showQueryEditor)}
-      />
+      {!isObserverPlus && (
+        <RevealButton
+          isShowing={showQueryEditor}
+          className={baseClass}
+          hideText="Hide SQL"
+          showText="Show SQL"
+          onClick={() => setShowQueryEditor(!showQueryEditor)}
+        />
+      )}
       {showQueryEditor && (
         <FleetAce
           value={lastEditedQueryBody}
@@ -422,7 +427,7 @@ const QueryForm = ({
         {renderPlatformCompatibility()}
       </span>
       {renderLiveQueryWarning()}
-      {lastEditedQueryObserverCanRun && (
+      {(lastEditedQueryObserverCanRun || isObserverPlus) && (
         <div
           className={`${baseClass}__button-wrap ${baseClass}__button-wrap--new-query`}
         >

--- a/frontend/router/components/AuthAnyMaintainerAdminObserverPlusRoutes/AuthAnyMaintainerAdminObserverPlusRoutes.tsx
+++ b/frontend/router/components/AuthAnyMaintainerAdminObserverPlusRoutes/AuthAnyMaintainerAdminObserverPlusRoutes.tsx
@@ -1,0 +1,43 @@
+import React, { useContext } from "react";
+import { useErrorHandler } from "react-error-boundary";
+import { AppContext } from "context/app";
+
+interface IAuthAnyMaintainerAdminObserverPlusRoutesProps {
+  children: JSX.Element;
+}
+
+/**
+ * Checks if a user is any maintainer or any admin when routing
+ */
+const AuthAnyMaintainerAdminObserverPlusRoutes = ({
+  children,
+}: IAuthAnyMaintainerAdminObserverPlusRoutesProps) => {
+  const handlePageError = useErrorHandler();
+  const {
+    currentUser,
+    isGlobalAdmin,
+    isGlobalMaintainer,
+    isAnyTeamAdmin,
+    isAnyTeamMaintainer,
+    isObserverPlus,
+  } = useContext(AppContext);
+
+  if (!currentUser) {
+    return null;
+  }
+
+  if (
+    !isGlobalAdmin &&
+    !isGlobalMaintainer &&
+    !isAnyTeamAdmin &&
+    !isAnyTeamMaintainer &&
+    !isObserverPlus
+  ) {
+    handlePageError({ status: 403 });
+    return null;
+  }
+
+  return <>{children}</>;
+};
+
+export default AuthAnyMaintainerAdminObserverPlusRoutes;

--- a/frontend/router/components/AuthAnyMaintainerAdminObserverPlusRoutes/AuthAnyMaintainerAdminObserverPlusRoutes.tsx
+++ b/frontend/router/components/AuthAnyMaintainerAdminObserverPlusRoutes/AuthAnyMaintainerAdminObserverPlusRoutes.tsx
@@ -19,6 +19,7 @@ const AuthAnyMaintainerAdminObserverPlusRoutes = ({
     isGlobalMaintainer,
     isAnyTeamAdmin,
     isAnyTeamMaintainer,
+    isAnyTeamObserverPlus,
     isObserverPlus,
   } = useContext(AppContext);
 
@@ -31,7 +32,8 @@ const AuthAnyMaintainerAdminObserverPlusRoutes = ({
     !isGlobalMaintainer &&
     !isAnyTeamAdmin &&
     !isAnyTeamMaintainer &&
-    !isObserverPlus
+    !isObserverPlus &&
+    !isAnyTeamObserverPlus
   ) {
     handlePageError({ status: 403 });
     return null;

--- a/frontend/router/components/AuthAnyMaintainerAdminObserverPlusRoutes/AuthAnyMaintainerAdminObserverPlusRoutes.tsx
+++ b/frontend/router/components/AuthAnyMaintainerAdminObserverPlusRoutes/AuthAnyMaintainerAdminObserverPlusRoutes.tsx
@@ -7,7 +7,7 @@ interface IAuthAnyMaintainerAdminObserverPlusRoutesProps {
 }
 
 /**
- * Checks if a user is any maintainer or any admin when routing
+ * Checks if a user is any maintainer, admin, or observer plus when routing
  */
 const AuthAnyMaintainerAdminObserverPlusRoutes = ({
   children,

--- a/frontend/router/components/AuthAnyMaintainerAdminObserverPlusRoutes/index.ts
+++ b/frontend/router/components/AuthAnyMaintainerAdminObserverPlusRoutes/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AuthAnyMaintainerAdminObserverPlusRoutes";

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -62,6 +62,7 @@ import AuthenticatedRoutes from "./components/AuthenticatedRoutes";
 import UnauthenticatedRoutes from "./components/UnauthenticatedRoutes";
 import AuthGlobalAdminMaintainerRoutes from "./components/AuthGlobalAdminMaintainerRoutes";
 import AuthAnyMaintainerAnyAdminRoutes from "./components/AuthAnyMaintainerAnyAdminRoutes";
+import AuthAnyMaintainerAdminObserverPlusRoutes from "./components/AuthAnyMaintainerAdminObserverPlusRoutes";
 import PremiumRoutes from "./components/PremiumRoutes";
 
 interface IAppWrapperProps {
@@ -200,7 +201,7 @@ const routes = (
           <Route path="queries">
             <IndexRedirect to={"manage"} />
             <Route path="manage" component={ManageQueriesPage} />
-            <Route component={AuthAnyMaintainerAnyAdminRoutes}>
+            <Route component={AuthAnyMaintainerAdminObserverPlusRoutes}>
               <Route path="new" component={QueryPage} />
             </Route>
             <Route path=":id" component={QueryPage} />

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -491,9 +491,7 @@ export const generateRole = (
   globalRole: UserRole | null
 ): UserRole => {
   if (globalRole === null) {
-    const listOfRoles: (UserRole | undefined)[] = teams.map(
-      (team) => team.role
-    );
+    const listOfRoles = teams.map<UserRole | undefined>((team) => team.role);
 
     if (teams.length === 0) {
       // no global role and no teams
@@ -501,18 +499,10 @@ export const generateRole = (
     } else if (teams.length === 1) {
       // no global role and only one team
       return stringUtils.capitalizeRole(teams[0].role || "Unassigned");
-    } else if (
-      listOfRoles.every(
-        (role: UserRole | undefined): boolean => role === "maintainer"
-      )
-    ) {
+    } else if (listOfRoles.every((role): boolean => role === "maintainer")) {
       // only team maintainers
       return "Maintainer";
-    } else if (
-      listOfRoles.every(
-        (role: UserRole | undefined): boolean => role === "observer"
-      )
-    ) {
+    } else if (listOfRoles.every((role): boolean => role === "observer")) {
       // only team observers
       return "Observer";
     }

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -33,7 +33,7 @@ import {
   IPackTargets,
 } from "interfaces/target";
 import { ITeam, ITeamSummary } from "interfaces/team";
-import { IUser } from "interfaces/user";
+import { IUser, UserRole } from "interfaces/user";
 
 import stringUtils from "utilities/strings";
 import sortUtils from "utilities/sort";
@@ -488,27 +488,29 @@ export const formatPackForClient = (pack: IPack): IPack => {
 
 export const generateRole = (
   teams: ITeam[],
-  globalRole: string | null
-): string => {
+  globalRole: UserRole | null
+): UserRole => {
   if (globalRole === null) {
-    const listOfRoles: (string | undefined)[] = teams.map((team) => team.role);
+    const listOfRoles: (UserRole | undefined)[] = teams.map(
+      (team) => team.role
+    );
 
     if (teams.length === 0) {
       // no global role and no teams
       return "Unassigned";
     } else if (teams.length === 1) {
       // no global role and only one team
-      return stringUtils.capitalize(teams[0].role ?? "");
+      return stringUtils.capitalizeRole(teams[0].role || "Unassigned");
     } else if (
       listOfRoles.every(
-        (role: string | undefined): boolean => role === "maintainer"
+        (role: UserRole | undefined): boolean => role === "maintainer"
       )
     ) {
       // only team maintainers
       return "Maintainer";
     } else if (
       listOfRoles.every(
-        (role: string | undefined): boolean => role === "observer"
+        (role: UserRole | undefined): boolean => role === "observer"
       )
     ) {
       // only team observers
@@ -520,14 +522,14 @@ export const generateRole = (
 
   if (teams.length === 0) {
     // global role and no teams
-    return stringUtils.capitalize(globalRole);
+    return stringUtils.capitalizeRole(globalRole);
   }
   return "Various"; // global role and one or more teams
 };
 
 export const generateTeam = (
   teams: ITeam[],
-  globalRole: string | null
+  globalRole: UserRole | null
 ): string => {
   if (globalRole === null) {
     if (teams.length === 0) {

--- a/frontend/utilities/permissions/permissions.ts
+++ b/frontend/utilities/permissions/permissions.ts
@@ -26,11 +26,9 @@ export const isGlobalMaintainer = (user: IUser): boolean => {
 };
 
 export const isGlobalObserver = (user: IUser): boolean => {
-  return user.global_role === "observer";
-};
-
-export const isGlobalObserverPlus = (user: IUser): boolean => {
-  return user.global_role === "observer_plus";
+  return (
+    user.global_role === "observer" || user.global_role === "observer_plus"
+  );
 };
 
 export const isOnGlobalTeam = (user: IUser): boolean => {
@@ -38,14 +36,12 @@ export const isOnGlobalTeam = (user: IUser): boolean => {
 };
 
 // This checks against a specific team
-const isTeamObserver = (user: IUser | null, teamId: number): boolean => {
-  const userTeamRole = user?.teams.find((team) => team.id === teamId)?.role;
-  return userTeamRole === "observer";
-};
-
 const isTeamObserverPlus = (user: IUser, teamId: number): boolean => {
   const userTeamRole = user.teams.find((team) => team.id === teamId)?.role;
   return userTeamRole === "observer_plus";
+const isTeamObserver = (user: IUser, teamId: number): boolean => {
+  const userTeamRole = user.teams.find((team) => team.id === teamId)?.role;
+  return userTeamRole === "observer" || userTeamRole === "observer_plus";
 };
 
 const isTeamMaintainer = (
@@ -101,35 +97,23 @@ const isOnlyObserver = (user: IUser): boolean => {
     return true;
   }
 
-  // Return false if any role is team maintainer
+  // Return false if any role is team maintainer or team admin
   if (!isOnGlobalTeam(user)) {
     return !user.teams.some(
-      (team) =>
-        team?.role === "maintainer" ||
-        team?.role === "admin" ||
-        team?.role === "observer"
+      (team) => team?.role === "maintainer" || team?.role === "admin"
     );
   }
 
   return false;
 };
 
-const isOnlyObserverPlus = (user: IUser): boolean => {
-  if (isGlobalObserverPlus(user)) {
+const isObserverPlus = (user: IUser, teamId: number | null): boolean => {
+  if (user.global_role === "observer_plus") {
     return true;
   }
 
-  // Return false if any role is team maintainer
-  if (!isOnGlobalTeam(user)) {
-    return !user.teams.some(
-      (team) =>
-        team?.role === "maintainer" ||
-        team?.role === "admin" ||
-        team?.role === "observer"
-    );
-  }
-
-  return false;
+  const userTeamRole = user?.teams.find((team) => team.id === teamId)?.role;
+  return userTeamRole === "observer_plus";
 };
 
 const isNoAccess = (user: IUser): boolean => {
@@ -144,10 +128,8 @@ export default {
   isGlobalAdmin,
   isGlobalMaintainer,
   isGlobalObserver,
-  isGlobalObserverPlus,
   isOnGlobalTeam,
   isTeamObserver,
-  isTeamObserverPlus,
   isTeamMaintainer,
   isTeamMaintainerOrTeamAdmin,
   isAnyTeamMaintainer,
@@ -155,6 +137,6 @@ export default {
   isTeamAdmin,
   isAnyTeamAdmin,
   isOnlyObserver,
-  isOnlyObserverPlus,
+  isObserverPlus,
   isNoAccess,
 };

--- a/frontend/utilities/permissions/permissions.ts
+++ b/frontend/utilities/permissions/permissions.ts
@@ -39,6 +39,8 @@ export const isOnGlobalTeam = (user: IUser): boolean => {
 const isTeamObserverPlus = (user: IUser, teamId: number): boolean => {
   const userTeamRole = user.teams.find((team) => team.id === teamId)?.role;
   return userTeamRole === "observer_plus";
+};
+
 const isTeamObserver = (user: IUser, teamId: number): boolean => {
   const userTeamRole = user.teams.find((team) => team.id === teamId)?.role;
   return userTeamRole === "observer" || userTeamRole === "observer_plus";

--- a/frontend/utilities/permissions/permissions.ts
+++ b/frontend/utilities/permissions/permissions.ts
@@ -36,11 +36,6 @@ export const isOnGlobalTeam = (user: IUser): boolean => {
 };
 
 // This checks against a specific team
-const isTeamObserverPlus = (user: IUser, teamId: number): boolean => {
-  const userTeamRole = user.teams.find((team) => team.id === teamId)?.role;
-  return userTeamRole === "observer_plus";
-};
-
 const isTeamObserver = (user: IUser | null, teamId: number): boolean => {
   const userTeamRole = user?.teams.find((team) => team.id === teamId)?.role;
   return userTeamRole === "observer" || userTeamRole === "observer_plus";

--- a/frontend/utilities/permissions/permissions.ts
+++ b/frontend/utilities/permissions/permissions.ts
@@ -29,6 +29,10 @@ export const isGlobalObserver = (user: IUser): boolean => {
   return user.global_role === "observer";
 };
 
+export const isGlobalObserverPlus = (user: IUser): boolean => {
+  return user.global_role === "observer_plus";
+};
+
 export const isOnGlobalTeam = (user: IUser): boolean => {
   return user.global_role !== null;
 };
@@ -37,6 +41,11 @@ export const isOnGlobalTeam = (user: IUser): boolean => {
 const isTeamObserver = (user: IUser | null, teamId: number): boolean => {
   const userTeamRole = user?.teams.find((team) => team.id === teamId)?.role;
   return userTeamRole === "observer";
+};
+
+const isTeamObserverPlus = (user: IUser, teamId: number): boolean => {
+  const userTeamRole = user.teams.find((team) => team.id === teamId)?.role;
+  return userTeamRole === "observer_plus";
 };
 
 const isTeamMaintainer = (
@@ -95,7 +104,28 @@ const isOnlyObserver = (user: IUser): boolean => {
   // Return false if any role is team maintainer
   if (!isOnGlobalTeam(user)) {
     return !user.teams.some(
-      (team) => team?.role === "maintainer" || team?.role === "admin"
+      (team) =>
+        team?.role === "maintainer" ||
+        team?.role === "admin" ||
+        team?.role === "observer"
+    );
+  }
+
+  return false;
+};
+
+const isOnlyObserverPlus = (user: IUser): boolean => {
+  if (isGlobalObserverPlus(user)) {
+    return true;
+  }
+
+  // Return false if any role is team maintainer
+  if (!isOnGlobalTeam(user)) {
+    return !user.teams.some(
+      (team) =>
+        team?.role === "maintainer" ||
+        team?.role === "admin" ||
+        team?.role === "observer"
     );
   }
 
@@ -114,8 +144,10 @@ export default {
   isGlobalAdmin,
   isGlobalMaintainer,
   isGlobalObserver,
+  isGlobalObserverPlus,
   isOnGlobalTeam,
   isTeamObserver,
+  isTeamObserverPlus,
   isTeamMaintainer,
   isTeamMaintainerOrTeamAdmin,
   isAnyTeamMaintainer,
@@ -123,5 +155,6 @@ export default {
   isTeamAdmin,
   isAnyTeamAdmin,
   isOnlyObserver,
+  isOnlyObserverPlus,
   isNoAccess,
 };

--- a/frontend/utilities/permissions/permissions.ts
+++ b/frontend/utilities/permissions/permissions.ts
@@ -41,8 +41,8 @@ const isTeamObserverPlus = (user: IUser, teamId: number): boolean => {
   return userTeamRole === "observer_plus";
 };
 
-const isTeamObserver = (user: IUser, teamId: number): boolean => {
-  const userTeamRole = user.teams.find((team) => team.id === teamId)?.role;
+const isTeamObserver = (user: IUser | null, teamId: number): boolean => {
+  const userTeamRole = user?.teams.find((team) => team.id === teamId)?.role;
   return userTeamRole === "observer" || userTeamRole === "observer_plus";
 };
 

--- a/frontend/utilities/permissions/permissions.ts
+++ b/frontend/utilities/permissions/permissions.ts
@@ -63,6 +63,14 @@ const isTeamMaintainerOrTeamAdmin = (
 };
 
 // This checks against all teams
+const isAnyTeamObserverPlus = (user: IUser): boolean => {
+  if (!isOnGlobalTeam(user)) {
+    return user.teams.some((team) => team?.role === "observer_plus");
+  }
+
+  return false;
+};
+
 const isAnyTeamMaintainer = (user: IUser): boolean => {
   if (!isOnGlobalTeam(user)) {
     return user.teams.some((team) => team?.role === "maintainer");
@@ -129,6 +137,7 @@ export default {
   isTeamObserver,
   isTeamMaintainer,
   isTeamMaintainerOrTeamAdmin,
+  isAnyTeamObserverPlus,
   isAnyTeamMaintainer,
   isAnyTeamMaintainerOrTeamAdmin,
   isTeamAdmin,

--- a/frontend/utilities/strings/stringUtils.ts
+++ b/frontend/utilities/strings/stringUtils.ts
@@ -1,3 +1,5 @@
+import { UserRole } from "interfaces/user";
+
 /**
  * Capitalizes the words of the string passed in.
  * @param str un-capitalized string
@@ -6,6 +8,14 @@ const capitalize = (str: string): string => {
   return str.replace(/\b\w/g, (letter) => letter.toUpperCase());
 };
 
+const capitalizeRole = (str: UserRole): UserRole => {
+  if (str === "observer_plus") {
+    return "Observer+";
+  }
+  return str.replace(/\b\w/g, (letter) => letter.toUpperCase()) as UserRole;
+};
+
 export default {
   capitalize,
+  capitalizeRole,
 };

--- a/frontend/utilities/strings/stringUtils.ts
+++ b/frontend/utilities/strings/stringUtils.ts
@@ -12,6 +12,9 @@ const capitalizeRole = (str: UserRole): UserRole => {
   if (str === "observer_plus") {
     return "Observer+";
   }
+  if (str === "gitops") {
+    return "GitOps";
+  }
   return str.replace(/\b\w/g, (letter) => letter.toUpperCase()) as UserRole;
 };
 


### PR DESCRIPTION
## Issue
#8593 

## Description
- Add 2 new premium roles to the UI
  - **Comment out code for GitOps role in UI** since it is being pushed to next release
- Observer plus: Exactly like observer but can run queries
  - Query details page: New UI where run (not save) button is available and query is always showing
  - Manage queries page: Permission to reach create new query page, see schema table on right side column (regular observers never had access to), and ability to run (not save)
  - Host details page: Query dropdown > Create new query button available for observer + role

- Commented out in frontend code ~~GitOps role~~
  - ~~Only appears in dropdowns for API only users (both global and team level)~~
- Manage users page and manage members page:
  - Adds GitOps and Observer+ to role column with tooltip for each  
  - GitOps tooltip and option available on frontend so when backend merges allowing users to choose GitOps role, it should automatically appear for those users

## Frontend cleanup
- Fix a bunch of user roles from type string to type IUserRole

## Edge cases to QA
- Observer+ for 1 team and observer for another team (ability to run live query for only hosts team is observer plus on from both the host details page and the manage queries page)

## Screenshots
Premium view of User Management Page with some users as Observer+/GitOps
<img width="1546" alt="Screenshot 2023-04-06 at 8 57 03 AM" src="https://user-images.githubusercontent.com/71795832/230385901-43ee7dfc-d405-4c51-bc83-b503f173dc03.png">
Premium admin view of Dropdown of editing an API user's role 
<img width="1539" alt="Screenshot 2023-04-06 at 8 57 43 AM" src="https://user-images.githubusercontent.com/71795832/230386008-11f62e76-1138-4dc0-a7c1-46d6bec509c1.png">
Premium admin view of Dropwn of editing a non-API user's role (hides GitOps)
<img width="1544" alt="Screenshot 2023-04-06 at 8 57 57 AM" src="https://user-images.githubusercontent.com/71795832/230386347-2c7f4c78-7056-47b9-bf87-9d9ec340242d.png">




# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`. (Lucas made on backend PRs)
- [ ] Added/updated tests (QA Wolf needs to make)
- [x] Manual QA for all new/changed functionality
 