### PR TITLE
Move Okta and EULA config options to contributors docs

### DIFF
--- a/docs/Deploying/Configuration.md
+++ b/docs/Deploying/Configuration.md
@@ -2907,54 +2907,6 @@ This is the content of the PEM-encoded private key for the Apple Business Manage
       -----END RSA PRIVATE KEY-----
   ```
 
-##### mdm.okta_server_url
-
-This is the URL of your Okta [authorization server](https://developer.okta.com/docs/concepts/auth-servers/)
-
-- Default value: ""
-- Environment variable: `FLEET_MDM_OKTA_SERVER_URL`
-- Config file format:
-  ```
-  mdm:
-    okta_server_url: https://example.okta.com
-```
-
-##### mdm.okta_client_id
-
-This is the client ID of the Okta application that will be used to authenticate users. This value can be found in the Okta admin page under "Applications > Client Credentials."
-
-- Default value: ""
-- Environment variable: `FLEET_MDM_OKTA_CLIENT_ID`
-- Config file format:
-  ```
-  mdm:
-    okta_client_id: 9oa4eoxample2rpdi1087
-```
-
-##### mdm.okta_client_secret
-
-This is the client secret of the Okta application that will be used to authenticate users. This value can be found in the Okta admin page under "Applications > Client Credentials."
-
-- Default value: ""
-- Environment variable: `FLEET_MDM_OKTA_CLIENT_SECRET`
-- Config file format:
-  ```
-  mdm:
-    okta_client_secret: COp8o5zskEQ0OylgjqTrd0xu7rQLx-VteaQW4YGf
-```
-
-##### mdm.eula_url
-
-An URL containing a PDF file that will be used as an EULA during DEP onboarding.
-
-- Default value: ""
-- Environment variable: `FLEET_MDM_OKTA_EULA_URL`
-- Config file format:
-  ```
-  mdm:
-    eula_url: https://example.com/eula.pdf
-```
-
 ##### mdm.apple_dep_sync_periodicity
 
 The duration between DEP device syncing (fetching and setting of DEP profiles). Only relevant if Apple Business Manager (ABM) is configured.
@@ -2966,25 +2918,6 @@ The duration between DEP device syncing (fetching and setting of DEP profiles). 
   mdm:
     apple_dep_sync_periodicity: 10m
   ```
-
-##### Example YAML
-
-```yaml
-mdm:
-  apple_enable: true
-  apple_apns_cert: /path/to/apns_cert
-  apple_apns_key: /path/to/apns_key
-  apple_scep_cert: /path/to/scep_cert
-  apple_scep_key: /path/to/scep_key
-  apple_scep_challenge: scepchallenge
-  apple_bm_server_token: /path/to/server_token.p7m
-  apple_bm_cert: /path/to/bm_cert
-  apple_bm_key: /path/to/private_key
-  okta_server_url: https://example.okta.com
-  okta_client_id: 9oa4eoxample2rpdi1087
-  okta_client_secret: COp8o5zskEQ0OylgjqTrd0xu7rQLx-VteaQW4YGf
-  eula_url: https://example.com/eula.pdf
-```
 
 ## Managing osquery configurations
 


### PR DESCRIPTION
The Okta and EULA config options are not meant for production use (once MDM launches).

Context:
- These configuration options were built for a proof of concept for a prospective Fleet customer. 
  - They wanted enrollment to be gated behind end user auth and an end user license agreement (EULA).
- At some point we thought this POC would be made into fully supported features in Fleet. 
  - The plan changed. Instead, we will add UI/CLI support for using any identity provider (IdP) that supports SAML, to gate enrollment behind end user authentication.

More discussion on decision to remove the docs is in the original PR here: https://github.com/fleetdm/fleet/pull/10897#discussion_r1160048616