### PR TITLE
Move status header's tooltip further to the left

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -240,7 +240,7 @@ const allHostTableHeaders: IDataColumn[] = [
              hosts won’t respond to a live query because<br/>
              they may be shut down, asleep, or not<br/>
              connected to the internet.`}
-          className="last-col-header-with-tip"
+          className="status-header"
         >
           Status
         </TooltipWrapper>

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -181,6 +181,11 @@
                       left: -126px;
                     }
                   }
+                  .status-header {
+                    .component__tooltip-wrapper__tip-text {
+                      left: -220px;
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Addresses #9988 

Discovered one final state when this occurs, which was when the 'Status' header was the last column and the viewport was small. Pushed the problematic tooltip further to the left:
<img width="746" alt="Screenshot 2023-04-06 at 4 20 14 PM" src="https://user-images.githubusercontent.com/61553566/230512143-7868c16c-32cc-4a8b-9a6c-b8fb0e88a62b.png">
<img width="746" alt="Screenshot 2023-04-06 at 4 29 14 PM" src="https://user-images.githubusercontent.com/61553566/230512147-34440393-cc6f-4824-a1df-d6f6cf0c6c0f.png">

- [x] Manual QA for all new/changed functionality