### PR TITLE
Small bug fix: hide show/hide sql toggle for observer plus view

### DIFF
--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -406,7 +406,7 @@ const QueryForm = ({
         </div>
         <div className="author">{renderAuthor()}</div>
       </div>
-      {(!isObserverPlus || !isAnyTeamObserverPlus) && (
+      {((!isObserverPlus && isGlobalObserver) || !isAnyTeamObserverPlus) && (
         <RevealButton
           isShowing={showQueryEditor}
           className={baseClass}


### PR DESCRIPTION
## Description
- Trivial bug fix

## Reproduce bug on main
- Have a user that is observer for Team A and observer + for Team B
- Select the observer team, Team A in a UI team drop down
- Navigate to Queries > Create new query
- Bug: User is observer plus for another team so they shouldn't have the unnecessary show/hide sql that "observer can run" view has

## Fix
-  The show/hide query toggle that is on observer view of a query is never shown if a user is an observer+ for at least one team 

## Screenshot of before fix
<img width="1636" alt="Screenshot 2023-04-07 at 2 17 20 PM" src="https://user-images.githubusercontent.com/71795832/230657916-d07e4fc8-9163-4fca-b7bc-e227923daf72.png">


## Screenshot of fix
<img width="1633" alt="Screenshot 2023-04-07 at 2 10 54 PM" src="https://user-images.githubusercontent.com/71795832/230657824-545722e1-550c-441e-81bd-60f82fc8a344.png">
