### PR TITLE
Add .5x transform only to .svg org logos

### DIFF
--- a/frontend/components/icons/OrgLogoIcon/_styles.scss
+++ b/frontend/components/icons/OrgLogoIcon/_styles.scss
@@ -3,6 +3,7 @@
   max-height: 46px;
 }
 
-.default-fleet-logo {
+.default-fleet-logo,
+.org-logo-icon[src*="svg"] {
   transform: scale(0.5);
 }


### PR DESCRIPTION
## Addresses an issue where .svg org logos are formatted incorrectly
Discussion: https://fleetdm.slack.com/archives/C02MP2CTQUE/p1680881152608239


**Before (svg):**
<img width="301" alt="Screenshot 2023-04-07 at 12 33 30 PM" src="https://user-images.githubusercontent.com/61553566/230666887-8c2d4dcc-5a09-4be8-ae3f-65654b00f6d6.png">
---
**After (svg):**
<img width="301" alt="Screenshot 2023-04-07 at 12 33 43 PM" src="https://user-images.githubusercontent.com/61553566/230666910-ffa8295c-23af-440d-826e-8a67dea3fadc.png">
---
**Before and after, non-svgs (no change):**
<img width="301" alt="Screenshot 2023-04-07 at 12 34 07 PM" src="https://user-images.githubusercontent.com/61553566/230666973-ee9f20d1-7a12-41bd-8b74-0b3b9f75e6b9.png">
---
<img width="301" alt="Screenshot 2023-04-07 at 12 34 30 PM" src="https://user-images.githubusercontent.com/61553566/230666975-d1ace7a0-7055-4a81-add8-4e42c9e493ec.png">

- [x] Manual QA for all new/changed functionality, using links:
    - None (default Fleet logo)
    - http://cdn.vmpower.com/images/VMPower-logo.svg
    - https://www.ellucian.com/sites/default/files/uploads/images/2018/12/flywire-logo-rgb.svg
    - https://cdn.comparably.com/27306312/p/120882_profile_flywire.png
    - https://cdn2.unrealengine.com/Unreal+Engine%2Feg-logo-filled-1255x1272-0eb9d144a0f981d1cbaaa1eb957de7a3207b31bb.png