### PR TITLE
fix a couple of flaky tests

### DIFF
--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -783,7 +783,7 @@ func testHostsListStatus(t *testing.T, ds *Datastore) {
 			DetailUpdatedAt: time.Now(),
 			LabelUpdatedAt:  time.Now(),
 			PolicyUpdatedAt: time.Now(),
-			SeenTime:        time.Now().Add(-time.Duration(i) * time.Minute * 2),
+			SeenTime:        time.Now().Add(-time.Duration(i) * time.Minute * 5),
 			OsqueryHostID:   ptr.String(strconv.Itoa(i)),
 			NodeKey:         ptr.String(fmt.Sprintf("%d", i)),
 			UUID:            fmt.Sprintf("%d", i),
@@ -6205,6 +6205,10 @@ func testHostsLoadHostByOrbitNodeKey(t *testing.T, ds *Datastore) {
 		h.DiskEncryptionResetRequested = ptr.Bool(false)
 		returned, err := ds.LoadHostByOrbitNodeKey(ctx, orbitKey)
 		require.NoError(t, err)
+
+		// compare only the fields we care about
+		h.CreatedAt = returned.CreatedAt
+		h.UpdatedAt = returned.UpdatedAt
 		assert.Equal(t, h, returned)
 	}
 

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -2491,14 +2491,17 @@ func (s *integrationEnterpriseTestSuite) TestListSoftware() {
 	s.DoJSON("GET", "/api/latest/fleet/software", nil, http.StatusOK, &resp)
 	require.NotNil(t, resp)
 
-	barPayload := resp.Software[0]
-	if barPayload.Name != "bar" {
-		barPayload = resp.Software[1]
-	}
+	var fooPayload, barPayload fleet.Software
+	for _, s := range resp.Software {
+		switch s.Name {
+		case "foo":
+			fooPayload = s
+		case "bar":
+			barPayload = s
+		default:
+			require.Failf(t, "unrecognized software %s", s.Name)
 
-	fooPayload := resp.Software[1]
-	if barPayload.Name != "bar" {
-		barPayload = resp.Software[0]
+		}
 	}
 
 	require.Empty(t, fooPayload.Vulnerabilities)


### PR DESCRIPTION
This fixes the following flaky tests:

- `TestHosts/LoadHostByOrbitNodeKey`
- `TestIntegrationsEnterprise/TestListSoftware`
- `TestHosts/ListStatus`

I couldn't figure out what's wrong with `TestScanVulnerabilities` which is also randomly failing, and it's super slow to run (since it has  to download assets from GitHub) maybe @juan-fdz-hawa can spot it?

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
