### PR TITLE
don't delete nano_* tables when a host is deleted

### DIFF
--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -2572,18 +2572,26 @@ func testGetMDMAppleCommandResults(t *testing.T, ds *Datastore) {
 		},
 	})
 
-	// delete host [0] and verify that it did delete its command results
+	// delete host [0] and verify that it didn't delete its command results
 	err = ds.DeleteHost(ctx, enrolledHosts[0].ID)
 	require.NoError(t, err)
 
-	// command now has only the hosts[1] result
 	res, err = ds.GetMDMAppleCommandResults(ctx, uuid2)
 	require.NoError(t, err)
-	require.Len(t, res, 1)
+	require.Len(t, res, 2)
 
 	require.NotZero(t, res[0].UpdatedAt)
 	res[0].UpdatedAt = time.Time{}
+	require.NotZero(t, res[1].UpdatedAt)
+	res[1].UpdatedAt = time.Time{}
 	require.ElementsMatch(t, res, []*fleet.MDMAppleCommandResult{
+		{
+			DeviceID:    enrolledHosts[0].UUID,
+			CommandUUID: uuid2,
+			Status:      "Acknowledged",
+			RequestType: "ProfileList",
+			Result:      []byte(rawCmd2),
+		},
 		{
 			DeviceID:    enrolledHosts[1].UUID,
 			CommandUUID: uuid2,

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -339,9 +339,6 @@ var hostRefs = []string{
 // and the map value is the column name to match to the host.uuid.
 var additionalHostRefsByUUID = map[string]string{
 	"host_mdm_apple_profiles": "host_uuid",
-	// deleting from nano_devices causes cascading deletes to nano_enrollments and
-	// any other tables that reference nano_devices.
-	"nano_devices": "id",
 }
 
 func (ds *Datastore) DeleteHost(ctx context.Context, hid uint) error {


### PR DESCRIPTION
In https://github.com/fleetdm/fleet/pull/11017 we thought it was a good idea to cleanup the `nano_*` tables when a host is deleted via the UI/API.

But since we don't want to unenroll the host from MDM when is removed from the UI (if the host still has a valid enroll secret it will just re-enroll) we want to keep the nano references too to preserve the server-side enrollment.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
