### PR TITLE
UI: Remove minwidth to fix account info being cut off

### DIFF
--- a/changes/10800-account-info-cutoff
+++ b/changes/10800-account-info-cutoff
@@ -1,0 +1,1 @@
+- Fixed a UI bug where fields on the "My account" page were cut off at smaller viewport widths

--- a/frontend/pages/UserSettingsPage/_styles.scss
+++ b/frontend/pages/UserSettingsPage/_styles.scss
@@ -14,7 +14,6 @@
 
   &__manage {
     flex-grow: 1;
-    min-width: 542px;
   }
 
   .info-banner {


### PR DESCRIPTION
## Addresses #10800 

**Before**
<img width="779" alt="Screenshot 2023-04-10 at 5 00 38 PM" src="https://user-images.githubusercontent.com/61553566/231021958-8df1dd3b-6008-4b73-92bf-dd8facafccb4.png">

**After**
<img width="779" alt="Screenshot 2023-04-10 at 5 01 12 PM" src="https://user-images.githubusercontent.com/61553566/231021968-51654111-5173-4387-9163-e11bc75560aa.png">


- [x] Changes file added for user-visible changes in `changes/` 
- [x] Manual QA for all new/changed functionality