### PR TITLE
Bug 10767: Don't return 500s if secret not found

### DIFF
--- a/changes/bug_10767-return_proper_status_code
+++ b/changes/bug_10767-return_proper_status_code
@@ -1,0 +1,1 @@
+Return proper status code (401) on '/api/fleet/orbit/enroll' if secret is invalid.

--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -79,7 +79,7 @@ func (ds *Datastore) VerifyEnrollSecret(ctx context.Context, secret string) (*fl
 	err := sqlx.GetContext(ctx, ds.reader, &s, "SELECT team_id FROM enroll_secrets WHERE secret = ?", secret)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ctxerr.Wrap(ctx, sql.ErrNoRows, "no matching secret found")
+			return nil, ctxerr.Wrap(ctx, notFound("EnrollSecret"), "no matching secret found")
 		}
 		return nil, ctxerr.Wrap(ctx, err, "verify enroll secret")
 	}

--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -79,7 +79,7 @@ func (ds *Datastore) VerifyEnrollSecret(ctx context.Context, secret string) (*fl
 	err := sqlx.GetContext(ctx, ds.reader, &s, "SELECT team_id FROM enroll_secrets WHERE secret = ?", secret)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ctxerr.New(ctx, "no matching secret found")
+			return nil, ctxerr.Wrap(ctx, sql.ErrNoRows, "no matching secret found")
 		}
 		return nil, ctxerr.Wrap(ctx, err, "verify enroll secret")
 	}

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -6373,12 +6373,14 @@ func (s *integrationTestSuite) TestTryingToEnrollWithTheWrongSecret() {
 	})
 	require.NoError(t, err)
 
-	var resp EnrollOrbitResponse
+	var resp jsonError
 	s.DoJSON("POST", "/api/fleet/orbit/enroll", EnrollOrbitRequest{
 		EnrollSecret:   uuid.New().String(),
 		HardwareUUID:   h.UUID,
 		HardwareSerial: h.HardwareSerial,
 	}, http.StatusUnauthorized, &resp)
+
+	require.Equal(t, resp.Message, "Authentication failed")
 }
 
 func (s *integrationTestSuite) TestEnrollOrbitExistingHostNoSerialMatch() {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -6360,6 +6360,27 @@ func (s *integrationTestSuite) TestOrbitConfigNotifications() {
 	require.False(t, resp.Notifications.RenewEnrollmentProfile)
 }
 
+func (s *integrationTestSuite) TestTryingToEnrollWithTheWrongSecret() {
+	t := s.T()
+	ctx := context.Background()
+
+	h, err := s.ds.NewHost(ctx, &fleet.Host{
+		HardwareSerial:   uuid.New().String(),
+		Platform:         "darwin",
+		LastEnrolledAt:   time.Now(),
+		DetailUpdatedAt:  time.Now(),
+		RefetchRequested: true,
+	})
+	require.NoError(t, err)
+
+	var resp EnrollOrbitResponse
+	s.DoJSON("POST", "/api/fleet/orbit/enroll", EnrollOrbitRequest{
+		EnrollSecret:   uuid.New().String(),
+		HardwareUUID:   h.UUID,
+		HardwareSerial: h.HardwareSerial,
+	}, http.StatusUnauthorized, &resp)
+}
+
 func (s *integrationTestSuite) TestEnrollOrbitExistingHostNoSerialMatch() {
 	t := s.T()
 	ctx := context.Background()

--- a/server/service/integration_sandbox_test.go
+++ b/server/service/integration_sandbox_test.go
@@ -94,7 +94,7 @@ func (s *integrationSandboxTestSuite) TestInstallerGet() {
 
 	// wrong enroll secret
 	wrongURL, wrongFormBody := installerPOSTReq("wrong-enroll", "pkg", s.token, false)
-	s.Do("POST", wrongURL, wrongFormBody, http.StatusInternalServerError)
+	s.Do("POST", wrongURL, wrongFormBody, http.StatusNotFound)
 
 	// non-existent package
 	wrongURL, wrongFormBody = installerPOSTReq(enrollSecret, "exe", s.token, false)
@@ -113,7 +113,7 @@ func (s *integrationSandboxTestSuite) TestInstallerHeadCheck() {
 
 	// wrong enroll secret
 	invalidURL := installerURL("wrong-enroll", "pkg", false)
-	s.DoRaw("HEAD", invalidURL, nil, http.StatusInternalServerError)
+	s.DoRaw("HEAD", invalidURL, nil, http.StatusNotFound)
 
 	// non-existent package
 	invalidURL = installerURL(enrollSecret, "exe", false)

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -132,8 +132,8 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 	if err != nil {
 		if fleet.IsNotFound(err) {
 			// OK - This can happen if the following sequence of events take place:
-			// 	1. user deletes global/team enroll secret
-			// 	2. user deletes the host in Fleet and then
+			// 	1. User deletes global/team enroll secret.
+			// 	2. User deletes the host in Fleet.
 			// 	3. Orbit tries to re-enroll using old secret.
 			return "", fleet.NewAuthFailedError("invalid secret")
 		}

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -130,6 +132,10 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 
 	secret, err := svc.ds.VerifyEnrollSecret(ctx, enrollSecret)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// OK: We are either in the middle of a secret rotation or the secret is invalid ...
+			return "", fleet.NewAuthFailedError("invalid secret")
+		}
 		return "", orbitError{message: err.Error()}
 	}
 


### PR DESCRIPTION
Addresses https://github.com/fleetdm/fleet/issues/10767

Return proper status code (401) on '/api/fleet/orbit/enroll' if secret is invalid.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Added/updated tests