### PR TITLE
Fleet UI: Transition fixed to edit user modal

### DIFF
--- a/changes/11087-fix-edit-user-modal-transition
+++ b/changes/11087-fix-edit-user-modal-transition
@@ -1,0 +1,1 @@
+- Fleet UI: Fix animation for opening edit user modal

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
@@ -432,29 +432,25 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
     const userData = getUser(userEditing.type, userEditing.id);
 
     return (
-      <Modal title="Edit user" onExit={toggleEditUserModal}>
-        <>
-          <EditUserModal
-            defaultEmail={userData?.email}
-            defaultName={userData?.name}
-            defaultGlobalRole={userData?.global_role}
-            defaultTeams={userData?.teams}
-            onCancel={toggleEditUserModal}
-            onSubmit={onEditUser}
-            availableTeams={teams || []}
-            isPremiumTier={isPremiumTier || false}
-            smtpConfigured={config?.smtp_settings.configured || false}
-            sesConfigured={config?.email?.backend === "ses" || false}
-            canUseSso={config?.sso_settings.enable_sso || false}
-            isSsoEnabled={userData?.sso_enabled}
-            isApiOnly={userData?.api_only || false}
-            isModifiedByGlobalAdmin
-            isInvitePending={userEditing.type === "invite"}
-            editUserErrors={editUserErrors}
-            isUpdatingUsers={isUpdatingUsers}
-          />
-        </>
-      </Modal>
+      <EditUserModal
+        defaultEmail={userData?.email}
+        defaultName={userData?.name}
+        defaultGlobalRole={userData?.global_role}
+        defaultTeams={userData?.teams}
+        onCancel={toggleEditUserModal}
+        onSubmit={onEditUser}
+        availableTeams={teams || []}
+        isPremiumTier={isPremiumTier || false}
+        smtpConfigured={config?.smtp_settings.configured || false}
+        sesConfigured={config?.email?.backend === "ses" || false}
+        canUseSso={config?.sso_settings.enable_sso || false}
+        isSsoEnabled={userData?.sso_enabled}
+        isApiOnly={userData?.api_only || false}
+        isModifiedByGlobalAdmin
+        isInvitePending={userEditing.type === "invite"}
+        editUserErrors={editUserErrors}
+        isUpdatingUsers={isUpdatingUsers}
+      />
     );
   };
 


### PR DESCRIPTION
## Issue
Cerra #11087 

## Description
- Transition to edit user modal looked wonky (small to big)
- Fix redundant nested frontend code that was putting a `<Modal/>` component inside a returned `<Modal/>`
- Removed outside layer `<Modal/>` to match pattern of other modals on page

## Screenrecording of fix
https://user-images.githubusercontent.com/71795832/231189579-57540293-5706-4e54-9dae-50fd79f41b10.mov



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality