### PR TITLE
Fleet UI: Fix responsiveness to hid vuln/exploit column at smaller widths

### DIFF
--- a/changes/11055-10799-fix-responsive-software-table
+++ b/changes/11055-10799-fix-responsive-software-table
@@ -1,0 +1,1 @@
+- Fleet UI: Fix Software table to match UI spec (responsively hidden vulnerabilities/probability of export column under 990px width)

--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -127,6 +127,10 @@
               .version__header {
                 width: 0;
               }
+              .vulnerabilities__header {
+                display: none;
+                width: 0;
+              }
               .source__header {
                 display: none;
                 width: 0;
@@ -134,6 +138,11 @@
               .hosts_count__header {
                 width: auto;
                 border-right: 0;
+              }
+              @media (min-width: $break-990) {
+                .vulnerabilities__header {
+                  display: table-cell;
+                }
               }
               @media (min-width: $break-990) {
                 .version__header {
@@ -164,6 +173,8 @@
                 width: 0;
               }
               .vulnerabilities__cell {
+                display: none;
+                width: 0;
                 span {
                   display: inline;
                 }
@@ -186,6 +197,11 @@
               @media (min-width: $break-990) {
                 .version_cell {
                   width: $col-md;
+                }
+              }
+              @media (min-width: $break-990) {
+                .vulnerabilities__cell {
+                  display: table-cell;
                 }
               }
               @media (min-width: $break-1400) {


### PR DESCRIPTION
## Issues
Cerra #11055 
Cerra #10799 

## Description
- Bug is the columns were overflowing on the right
- Root cause determined by QA wolf is that the vulnerabilities/exploit column wasn't properly being hidden as specced in responsive design work #3052 

## Screenrecording of fix
Note: The columns don't overflow horizontally due to too many columns

https://user-images.githubusercontent.com/71795832/231196867-c2fc97a0-829a-42d6-9ce4-a65cfa19792b.mov





# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
