### PR TITLE
Fleet UI: Responsive nav bar sizing

### DIFF
--- a/changes/10801-responsive-nav-bar
+++ b/changes/10801-responsive-nav-bar
@@ -1,0 +1,1 @@
+- Fleet UI: Nav bar buttons responsively resize when small screen widths cannot fit default size nav bar

--- a/frontend/components/top_nav/SiteTopNav/_styles.scss
+++ b/frontend/components/top_nav/SiteTopNav/_styles.scss
@@ -71,6 +71,11 @@
     color: $core-white;
     padding: 15px 24px;
     text-decoration: none;
+
+    // Prevents user menu from overlapping with nav bar buttons
+    @media (max-width: 825px) {
+      padding: 15px 18px;
+    }
   }
 
   &__logo-wrapper {


### PR DESCRIPTION
## Issue
Cerra #10801 

## Description
- Fix nav bar buttons to not overlap with user menu at low screen widths
- Original solution was going to be make the nav bar buttons parent div a fixed width so the user menu won't overlap, but then that results in a user needing to scroll off the page to reach the user menu
- Solution: (Responsive design) Between 768px and 825px, nav bar buttons have horizontal padding of 18px instead of 24px for better user view at smaller screen widths

## Screenrecording of fix
https://user-images.githubusercontent.com/71795832/231209371-7e5f43cf-b54a-4357-82f7-aacadf6b1979.mov


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
