### PR TITLE
Fix UI bug that caused "Show inherited policies" button to be incorrectly hidden

### DIFF
--- a/changes/issue-11136-bugfix-show-inherited-policies-button
+++ b/changes/issue-11136-bugfix-show-inherited-policies-button
@@ -1,0 +1,2 @@
+- Fixed a UI bug introduced in version 4.30 where the "Show inherited policies" button was not being
+  displayed.

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -124,7 +124,7 @@ const ManagePolicyPage = ({
       return globalPoliciesAPI.loadAll();
     },
     {
-      enabled: isRouteOk && !teamIdForApi,
+      enabled: isRouteOk,
       select: (data) => data.policies,
       staleTime: 5000,
     }


### PR DESCRIPTION
Issue #11136 