### PR TITLE
Fleet UI: Remove hosts pack information from observers and observer plus

### DIFF
--- a/changes/11074-hide-hosts-packs-info-from-observers
+++ b/changes/11074-hide-hosts-packs-info-from-observers
@@ -1,0 +1,1 @@
+- UI: Remove any host's packs information for observers and observer plus

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -40,6 +40,7 @@ import {
   humanHostDiskEncryptionEnabled,
   wrapFleetHelper,
 } from "utilities/helpers";
+import permissions from "utilities/permissions";
 
 import HostSummaryCard from "../cards/HostSummary";
 import AboutCard from "../cards/About";
@@ -107,10 +108,11 @@ const HostDetailsPage = ({
   const hostIdFromURL = parseInt(host_id, 10);
   const {
     config,
+    currentUser,
     isGlobalAdmin = false,
+    isGlobalObserver,
     isPremiumTier = false,
     isOnlyObserver,
-    isObserverPlus,
     filteredHostsPath,
   } = useContext(AppContext);
   const {
@@ -606,6 +608,21 @@ const HostDetailsPage = ({
     host?.mdm.name === "Fleet" &&
     host?.mdm.macos_settings.disk_encryption === "action_required";
 
+  /*  Context team id might be different that host's team id
+  Observer plus must be checked against host's team id  */
+  const isHostsTeamObserverPlus =
+    currentUser && host?.team_id
+      ? permissions.isObserverPlus(currentUser, host.team_id)
+      : false;
+
+  const isHostsTeamObserver =
+    currentUser && host?.team_id
+      ? permissions.isObserverPlus(currentUser, host.team_id)
+      : false;
+
+  const canViewPacks =
+    !isGlobalObserver && !isHostsTeamObserverPlus && !isHostsTeamObserver;
+
   return (
     <MainContent className={baseClass}>
       <div className={`${baseClass}__wrapper`}>
@@ -704,7 +721,9 @@ const HostDetailsPage = ({
                 scheduleState={scheduleState}
                 isLoading={isLoadingHost}
               />
-              <PacksCard packsState={packsState} isLoading={isLoadingHost} />
+              {canViewPacks && (
+                <PacksCard packsState={packsState} isLoading={isLoadingHost} />
+              )}
             </TabPanel>
             <TabPanel>
               <PoliciesCard

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -610,18 +610,20 @@ const HostDetailsPage = ({
 
   /*  Context team id might be different that host's team id
   Observer plus must be checked against host's team id  */
-  const isHostsTeamObserverPlus =
+  const isGlobalOrHostsTeamObserverPlus =
     currentUser && host?.team_id
       ? permissions.isObserverPlus(currentUser, host.team_id)
       : false;
 
   const isHostsTeamObserver =
     currentUser && host?.team_id
-      ? permissions.isObserverPlus(currentUser, host.team_id)
+      ? permissions.isTeamObserver(currentUser, host.team_id)
       : false;
 
   const canViewPacks =
-    !isGlobalObserver && !isHostsTeamObserverPlus && !isHostsTeamObserver;
+    !isGlobalObserver &&
+    !isGlobalOrHostsTeamObserverPlus &&
+    !isHostsTeamObserver;
 
   return (
     <MainContent className={baseClass}>


### PR DESCRIPTION
## Issue
Cerra #11074 

## Description
- Packs information on host details page are hidden from: Global Observers / Global Observers +, Team Observers for the host's team, Team Observers+ for the host's team

## Screenrecording of fix (Shows no packs stats on host details page for observer+ but shows for admin)

https://user-images.githubusercontent.com/71795832/231225534-18d8d0cf-5709-4a54-b70e-d7e71a76fe99.mov



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
 