### PR TITLE
Hide sandbox register form, add outage message

### DIFF
--- a/website/views/pages/try-fleet/register.ejs
+++ b/website/views/pages/try-fleet/register.ejs
@@ -6,9 +6,15 @@
     <div style="max-width: 400px;" class="flex-column d-flex">
       <h2>Play in Fleet Sandbox</h2>
       <p class="pt-3">
-        The fastest way to test Fleet. Get up and running in minutes. Ready for production deployments? <a href="https://fleetdm.com/docs/deploying">Learn how to deploy Fleet</a>.
+        The fastest way to test Fleet. Get up and running in minutes. Ready for production
+        deployments? <a href="https://fleetdm.com/docs/deploying">Learn how to deploy Fleet</a>.
+        <br><br>
+        We are currently experiencing increased demand and are working to resolve the issue. Sandbox
+        signups will be available again soon.
+        <br><br>
+        <em>8:30 AM PST - April 12, 2023</em>
       </p>
-      <div class="pt-3">
+      <!-- <div class="pt-3">
         <ajax-form :handle-submitting="handleSubmittingRegisterForm" :syncing.sync="syncing" :cloud-error.sync="cloudError" :form-errors.sync="formErrors" :form-data="formData" :form-rules="formRules" @submitted="submittedRegisterForm()">
           <div class="form-group mb-3">
             <div class="d-flex flex-row">
@@ -52,7 +58,7 @@
       <div class="d-flex flex-column" v-if="!cloudError">
         <a class="mx-auto d-flex py-3" href="/try-fleet/login">I have an account</a>
         <p class="pt-4">By continuing you agree to the<br><a href="https://docs.google.com/document/d/1OM6YDVIs7bP8wg6iA3VG13X086r64tWDqBSRudG4a0Y" target="_blank">terms of service</a> and <a href="https://docs.google.com/document/d/17i_g1aGpnuSmlqj35-yHJiwj7WRrLdC_Typc1Yb7aBE" target="_blank">privacy policy</a>.</p>
-      </div>
+      </div> -->
     </div>
   </div>
   <modal v-if="modal === 'video'" @close="closeModal()" v-cloak>


### PR DESCRIPTION
Our sandbox provisioner has run out of resources due to high demand, and we cannot provision new sandbox instances. We have increased our resources in AWS but are waiting for the increase to be applied. While we wait, we should hide the register form so folks don't receive an error. 