### PR TITLE
Continue fetching global queries even when a team is selected

### DIFF
--- a/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/ManageSchedulePage.tsx
@@ -181,7 +181,7 @@ const ManageSchedulePage = ({
     Error,
     IScheduledQuery[]
   >(["globalScheduledQueries"], () => globalScheduledQueriesAPI.loadAll(), {
-    enabled: isRouteOk && !teamIdForApi,
+    enabled: isRouteOk,
     select: (data) => data.global_schedule,
   });
 


### PR DESCRIPTION
## Addresses #11174

- Global queries were being disabled when a team was selected. Removed this disabling logic, since intended functionality is to still fetch the global queries, and list them as "inherited"

- [x] Manual QA for all new/changed functionality
