### PR TITLE
Logout to return HTTP 401 if unauthorized

### DIFF
--- a/changes/issue-10798-unauthd-logout-return-401
+++ b/changes/issue-10798-unauthd-logout-return-401
@@ -1,0 +1,1 @@
+* Fix `/api/_version/fleet/logout` to return HTTP 401 if unauthorized.

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -3329,7 +3329,7 @@ func (s *integrationTestSuite) TestUsers() {
 	s.DoJSON("POST", "/api/latest/fleet/logout", nil, http.StatusOK, &logoutResp)
 
 	// logout again, even though not logged in
-	s.DoJSON("POST", "/api/latest/fleet/logout", nil, http.StatusInternalServerError, &logoutResp) // TODO: should be OK even if not logged in, see #4406.
+	s.DoJSON("POST", "/api/latest/fleet/logout", nil, http.StatusUnauthorized, &logoutResp)
 
 	s.token = s.getTestAdminToken()
 

--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -232,14 +232,13 @@ func (svc *Service) Logout(ctx context.Context) error {
 
 	logging.WithLevel(ctx, level.Info)
 
-	// TODO: this should not return an error if the user wasn't logged in
 	return svc.DestroySession(ctx)
 }
 
 func (svc *Service) DestroySession(ctx context.Context) error {
 	vc, ok := viewer.FromContext(ctx)
 	if !ok {
-		return fleet.ErrNoContext
+		return fleet.NewAuthRequiredError(fleet.ErrNoContext.Error())
 	}
 
 	session, err := svc.ds.SessionByID(ctx, vc.SessionID())


### PR DESCRIPTION
#10798

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- ~[ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~[ ] Documented any permissions changes~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
