### PR TITLE
feat(terraform): add zone_id variable to ses module

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -291,6 +291,7 @@ module "notify_slack" {
 }
 
 module "ses" {
-  source = "github.com/fleetdm/fleet//terraform/addons/ses?ref=main"
-  domain = "dogfood.fleetdm.com"
+  source  = "github.com/fleetdm/fleet//terraform/addons/ses?ref=main"
+  zone_id = aws_route53_zone.main.zone_id
+  domain  = "dogfood.fleetdm.com"
 }

--- a/terraform/addons/ses/main.tf
+++ b/terraform/addons/ses/main.tf
@@ -1,7 +1,3 @@
-data "aws_route53_zone" "main" {
-  name = var.domain
-}
-
 resource "aws_ses_domain_identity" "default" {
   domain = var.domain
 }
@@ -12,18 +8,19 @@ resource "aws_ses_domain_dkim" "default" {
 
 ###DKIM VERIFICATION#######
 
-resource "aws_route53_record" "dkim" {
-  for_each = toset(aws_ses_domain_dkim.default.dkim_tokens)
-  zone_id  = data.aws_route53_zone.main.zone_id
-  name     = format("%s._domainkey.%s", each.key, var.domain)
-  type     = "CNAME"
-  ttl      = 600
-  records  = [format("%s.dkim.amazonses.com", each.key)]
+resource "aws_route53_record" "amazonses_dkim_record" {
+  count   = 3 // no clue why this is three, but multiple modules all did the same thing
+  zone_id = var.zone_id
+  name    = "${element(aws_ses_domain_dkim.default.dkim_tokens, count.index)}._domainkey.${var.domain}"
+  type    = "CNAME"
+  ttl     = "600"
+  records = ["${element(aws_ses_domain_dkim.default.dkim_tokens, count.index)}.dkim.amazonses.com"]
 }
 
+
 resource "aws_route53_record" "spf_domain" {
-  zone_id = data.aws_route53_zone.main.zone_id
-  name    = ""
+  zone_id = var.zone_id
+  name    = "_amazonses.${aws_ses_domain_identity.default.domain}"
   type    = "TXT"
   ttl     = "600"
   records = ["v=spf1 include:amazonses.com -all"]

--- a/terraform/addons/ses/variables.tf
+++ b/terraform/addons/ses/variables.tf
@@ -2,3 +2,8 @@ variable "domain" {
   type        = string
   description = "Domain to use for SES."
 }
+
+variable "zone_id" {
+  type = string
+  description = "Route53 Zone ID"
+}


### PR DESCRIPTION
The zone_id variable is added to the ses module to allow the module to be used with different Route53 zones. The variable is used in the aws_route53_record resource to set the zone_id attribute. The aws_route53_zone data source is removed from the module and the zone_id attribute is set directly. The count attribute is added to the aws_route53_record resource to allow for multiple DKIM records to be created.


