### PR TITLE
Fleet UI: GitOps added to frontend

### DIFF
--- a/frontend/pages/admin/UserManagementPage/helpers/userManagementHelpers.ts
+++ b/frontend/pages/admin/UserManagementPage/helpers/userManagementHelpers.ts
@@ -126,14 +126,14 @@ export const roleOptions = ({
       label: "Observer+",
       value: "observer_plus",
     });
-    // Next release:
-    // if (isApiOnly) {
-    //   roles.splice(3, 0, {
-    //     disabled: false,
-    //     label: "GitOps",
-    //     value: "gitops",
-    //   });
-    // }
+
+    if (isApiOnly) {
+      roles.splice(3, 0, {
+        disabled: false,
+        label: "GitOps",
+        value: "gitops",
+      });
+    }
   }
 
   return roles;


### PR DESCRIPTION
## Issue
Frontend #8593 

## Description
- An admin can see a GitOps user in the user management page and the team management page
- An admin can change the role of an API only to and from Gitops to other API only user roles
- A gitops api only user cannot log into the UI

## Screenshot
<img width="1554" alt="Screenshot 2023-04-14 at 2 32 46 PM" src="https://user-images.githubusercontent.com/71795832/232128089-bec3ced2-2143-418e-8319-d4d1bcbf4869.png">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality