### PR TITLE
Remove build-storybook step from deploy website workflow

### DIFF
--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -58,9 +58,6 @@ jobs:
       with:
         go-version: 1.19
 
-    # Download top-level dependencies and build Storybook in the website's assets/ folder
-    - run: npm install && npm run build-storybook -- -o ./website/assets/storybook --loglevel verbose
-
     # Now start building!
     # > …but first, get a little crazy for a sec and delete the top-level package.json file
     # > i.e. the one used by the Fleet server.  This is because require() in node will go

--- a/website/.eslintignore
+++ b/website/.eslintignore
@@ -1,4 +1,3 @@
 assets/dependencies/**/*.js
 views/**/*.ejs
-assets/storybook/*
 


### PR DESCRIPTION
Changes:
- Removed the build-storybook step from the "Deploy Fleet website" workflow
- Removed the storybook directory from `website/.eslintignore`