### PR TITLE
Report empty command status as "Pending", fix test

### DIFF
--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -326,7 +326,7 @@ func (ds *Datastore) ListMDMAppleCommands(
 SELECT
     nvq.id as device_id,
     nvq.command_uuid,
-    COALESCE(nvq.status, '') as status,
+    COALESCE(NULLIF(nvq.status, ''), 'Pending') as status,
     COALESCE(nvq.result_updated_at, nvq.created_at) as updated_at,
     nvq.request_type,
     h.hostname,

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -2798,7 +2798,7 @@ func testListMDMAppleCommands(t *testing.T, ds *Datastore) {
 		{
 			DeviceID:    enrolledHosts[0].UUID,
 			CommandUUID: uuid1,
-			Status:      "",
+			Status:      "Pending",
 			RequestType: "ListApps",
 			Hostname:    enrolledHosts[0].Hostname,
 			TeamID:      nil,
@@ -2806,7 +2806,7 @@ func testListMDMAppleCommands(t *testing.T, ds *Datastore) {
 		{
 			DeviceID:    enrolledHosts[1].UUID,
 			CommandUUID: uuid1,
-			Status:      "",
+			Status:      "Pending",
 			RequestType: "ListApps",
 			Hostname:    enrolledHosts[1].Hostname,
 			TeamID:      nil,
@@ -2847,7 +2847,7 @@ func testListMDMAppleCommands(t *testing.T, ds *Datastore) {
 		{
 			DeviceID:    enrolledHosts[1].UUID,
 			CommandUUID: uuid1,
-			Status:      "",
+			Status:      "Pending",
 			RequestType: "ListApps",
 			Hostname:    enrolledHosts[1].Hostname,
 			TeamID:      nil,


### PR DESCRIPTION
#11008 (specifically the empty/idle status part, that we decided to report as "Pending": https://github.com/fleetdm/fleet/issues/11008#issuecomment-1511716855).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- ~~Changes file added for user-visible changes in `changes/` or `orbit/changes/`.~~ (follow-up to #11163 )
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
