### PR TITLE
UI: Restore visibility of tooltips over software names in hosts > details > software card

### DIFF
--- a/changes/11217-hidden-software-tooltips
+++ b/changes/11217-hidden-software-tooltips
@@ -1,0 +1,2 @@
+- Fixed a bug where bundle information displayed in tooltips over a software's name was mistakenly
+  hidden.

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -119,6 +119,10 @@
       }
 
       tr {
+        .name__cell .children-wrapper {
+          overflow: visible;
+        }
+
         .software-link {
           opacity: 0;
           transition: 250ms;


### PR DESCRIPTION
## Addresses #11217 

<img width="498" alt="Screenshot 2023-04-17 at 1 29 39 PM" src="https://user-images.githubusercontent.com/61553566/232604991-029316f2-ec8b-4297-b02c-d6e3a80d30c5.png">


## Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`.
- [x] Manual QA for all new/changed functionality