### PR TITLE
Fix a typo

### DIFF
--- a/terraform/addons/vuln-processing/variables.tf
+++ b/terraform/addons/vuln-processing/variables.tf
@@ -23,7 +23,7 @@ variable "fleet_config" {
     vuln_processing_mem                  = optional(number, 4096)
     vuln_processing_cpu                  = optional(number, 2048)
     vuln_data_stream_mem                 = optional(number, 1024)
-    vuln_data_stream_cpu                 = optinal(number, 512)
+    vuln_data_stream_cpu                 = optional(number, 512)
     image                                = optional(string, "fleetdm/fleet:v4.28.1")
     family                               = optional(string, "fleet-vuln-processing")
     sidecars                             = optional(list(any), [])


### PR DESCRIPTION
Fix a typo in vuln_data_stream_cpu variable definition.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
