### PR TITLE
UI: Hide Org and User settings in Sandbox mode

### DIFF
--- a/frontend/components/Sandbox/SandboxMessage/_styles.scss
+++ b/frontend/components/Sandbox/SandboxMessage/_styles.scss
@@ -2,8 +2,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: flex-start;
-  gap: $pad-small;
+  align-items: center;
   width: 350px;
   margin: $pad-xxlarge auto;
 

--- a/frontend/pages/UserSettingsPage/UserSettingsPage.tsx
+++ b/frontend/pages/UserSettingsPage/UserSettingsPage.tsx
@@ -21,8 +21,6 @@ import Modal from "components/Modal";
 import UserSettingsForm from "components/forms/UserSettingsForm";
 import InfoBanner from "components/InfoBanner";
 import SecretField from "components/EnrollSecrets/SecretField";
-import SandboxGate from "components/Sandbox/SandboxGate";
-import SandboxMessage from "components/Sandbox/SandboxMessage";
 import MainContent from "components/MainContent";
 import SidePanelContent from "components/SidePanelContent";
 import CustomLink from "components/CustomLink";
@@ -225,15 +223,7 @@ const UserSettingsPage = ({
   return (
     <>
       <MainContent className={baseClass}>
-        <SandboxGate
-          fallbackComponent={() => (
-            <SandboxMessage
-              className={`${baseClass}__sandboxMode`}
-              message="Account management is only available in self-managed Fleet"
-              utmSource="fleet-ui-my-account-page"
-            />
-          )}
-        >
+        <>
           <div className={`${baseClass}__manage`}>
             <h1>My account</h1>
             <UserSettingsForm
@@ -248,17 +238,15 @@ const UserSettingsPage = ({
           {renderEmailModal()}
           {renderPasswordModal()}
           {renderApiTokenModal()}
-        </SandboxGate>
+        </>
       </MainContent>
-      <SandboxGate>
-        <SidePanelContent>
-          <UserSidePanel
-            currentUser={currentUser}
-            onChangePassword={onShowPasswordModal}
-            onGetApiToken={onShowApiTokenModal}
-          />
-        </SidePanelContent>
-      </SandboxGate>
+      <SidePanelContent>
+        <UserSidePanel
+          currentUser={currentUser}
+          onChangePassword={onShowPasswordModal}
+          onGetApiToken={onShowApiTokenModal}
+        />
+      </SidePanelContent>
     </>
   );
 };

--- a/frontend/pages/admin/OrgSettingsPage/OrgSettingsPage.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/OrgSettingsPage.tsx
@@ -9,8 +9,6 @@ import configAPI from "services/entities/config";
 import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import deepDifference from "utilities/deep_difference";
-import SandboxGate from "components/Sandbox/SandboxGate";
-import SandboxMessage from "components/Sandbox/SandboxMessage";
 import Spinner from "components/Spinner";
 
 import SideNav from "../components/SideNav";
@@ -121,33 +119,23 @@ const OrgSettingsPage = ({ params }: IOrgSettingsPageProps) => {
       <p className={`${baseClass}__page-description`}>
         Set your organization information and configure SSO and SMTP
       </p>
-      <SandboxGate
-        fallbackComponent={() => (
-          <SandboxMessage
-            message="Organization settings are only available in self-managed Fleet"
-            utmSource="fleet-ui-organization-settings-page"
-            className={`${baseClass}__sandbox-demo-message`}
-          />
-        )}
-      >
-        <SideNav
-          className={`${baseClass}__side-nav`}
-          navItems={navItems}
-          activeItem={currentFormSection.urlSection}
-          CurrentCard={
-            !isLoadingAppConfig && appConfig ? (
-              <CurrentCard
-                appConfig={appConfig}
-                handleSubmit={onFormSubmit}
-                isUpdatingSettings={isUpdatingSettings}
-                isPremiumTier={isPremiumTier}
-              />
-            ) : (
-              <Spinner />
-            )
-          }
-        />
-      </SandboxGate>
+      <SideNav
+        className={`${baseClass}__side-nav`}
+        navItems={navItems}
+        activeItem={currentFormSection.urlSection}
+        CurrentCard={
+          !isLoadingAppConfig && appConfig ? (
+            <CurrentCard
+              appConfig={appConfig}
+              handleSubmit={onFormSubmit}
+              isUpdatingSettings={isUpdatingSettings}
+              isPremiumTier={isPremiumTier}
+            />
+          ) : (
+            <Spinner />
+          )
+        }
+      />
     </div>
   );
 };

--- a/frontend/pages/admin/SettingsWrapper/SettingsWrapper.tsx
+++ b/frontend/pages/admin/SettingsWrapper/SettingsWrapper.tsx
@@ -11,22 +11,8 @@ import classnames from "classnames";
 interface ISettingSubNavItem {
   name: string;
   pathname: string;
+  exclude?: boolean;
 }
-
-const settingsSubNav: ISettingSubNavItem[] = [
-  {
-    name: "Organization settings",
-    pathname: PATHS.ADMIN_SETTINGS,
-  },
-  {
-    name: "Integrations",
-    pathname: PATHS.ADMIN_INTEGRATIONS,
-  },
-  {
-    name: "Users",
-    pathname: PATHS.ADMIN_USERS,
-  },
-];
 
 interface ISettingsWrapperProp {
   children: JSX.Element;
@@ -35,13 +21,6 @@ interface ISettingsWrapperProp {
   };
   router: InjectedRouter; // v3
 }
-
-const getTabIndex = (path: string): number => {
-  return settingsSubNav.findIndex((navItem) => {
-    // tab stays highlighted for paths that start with same pathname
-    return path.startsWith(navItem.pathname);
-  });
-};
 
 const baseClass = "settings-wrapper";
 
@@ -52,16 +31,42 @@ const SettingsWrapper = ({
 }: ISettingsWrapperProp): JSX.Element => {
   const { isPremiumTier, isSandboxMode } = useContext(AppContext);
 
-  if (isPremiumTier && settingsSubNav.length === 3) {
-    settingsSubNav.push({
+  const settingsSubNav: ISettingSubNavItem[] = [
+    {
+      name: "Organization settings",
+      pathname: PATHS.ADMIN_SETTINGS,
+      exclude: isSandboxMode,
+    },
+    {
+      name: "Integrations",
+      pathname: PATHS.ADMIN_INTEGRATIONS,
+    },
+    {
+      name: "Users",
+      pathname: PATHS.ADMIN_USERS,
+      exclude: isSandboxMode,
+    },
+    {
       name: "Teams",
       pathname: PATHS.ADMIN_TEAMS,
-    });
-  }
+      exclude: !isPremiumTier,
+    },
+  ];
+
+  const filteredSettingsSubNav = settingsSubNav.filter((navItem) => {
+    return !navItem.exclude;
+  });
 
   const navigateToNav = (i: number): void => {
-    const navPath = settingsSubNav[i].pathname;
+    const navPath = filteredSettingsSubNav[i].pathname;
     router.push(navPath);
+  };
+
+  const getTabIndex = (path: string): number => {
+    return settingsSubNav.findIndex((navItem) => {
+      // tab stays highlighted for paths that start with same pathname
+      return path.startsWith(navItem.pathname);
+    });
   };
 
   // we add a conditional sandbox-mode class here as we will need to make some
@@ -79,7 +84,7 @@ const SettingsWrapper = ({
             onSelect={(i) => navigateToNav(i)}
           >
             <TabList>
-              {settingsSubNav.map((navItem) => {
+              {filteredSettingsSubNav.map((navItem) => {
                 // Bolding text when the tab is active causes a layout shift
                 // so we add a hidden pseudo element with the same text string
                 return (

--- a/frontend/pages/admin/SettingsWrapper/SettingsWrapper.tsx
+++ b/frontend/pages/admin/SettingsWrapper/SettingsWrapper.tsx
@@ -63,7 +63,7 @@ const SettingsWrapper = ({
   };
 
   const getTabIndex = (path: string): number => {
-    return settingsSubNav.findIndex((navItem) => {
+    return filteredSettingsSubNav.findIndex((navItem) => {
       // tab stays highlighted for paths that start with same pathname
       return path.startsWith(navItem.pathname);
     });

--- a/frontend/router/components/ExcludeInSandboxRoutes/ExcludeInSandboxRoutes.tsx
+++ b/frontend/router/components/ExcludeInSandboxRoutes/ExcludeInSandboxRoutes.tsx
@@ -1,0 +1,20 @@
+import React, { useContext } from "react";
+import { useErrorHandler } from "react-error-boundary";
+import { AppContext } from "context/app";
+
+interface IExcludeInSandboxRoutesProps {
+  children: JSX.Element;
+}
+
+const ExcludeInSandboxRoutes = ({ children }: IExcludeInSandboxRoutesProps) => {
+  const handlePageError = useErrorHandler();
+  const { isSandboxMode } = useContext(AppContext);
+
+  if (isSandboxMode) {
+    handlePageError({ status: 403 });
+    return null;
+  }
+  return <>{children}</>;
+};
+
+export default ExcludeInSandboxRoutes;

--- a/frontend/router/components/ExcludeInSandboxRoutes/index.ts
+++ b/frontend/router/components/ExcludeInSandboxRoutes/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ExcludeInSandboxRoutes";

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -53,7 +53,7 @@ import MacOSSettings from "pages/ManageControlsPage/MacOSSettings";
 
 import PATHS from "router/paths";
 
-import AppProvider from "context/app";
+import AppProvider, { AppContext } from "context/app";
 import RoutingProvider from "context/routing";
 
 import AuthGlobalAdminRoutes from "./components/AuthGlobalAdminRoutes";
@@ -64,7 +64,9 @@ import AuthGlobalAdminMaintainerRoutes from "./components/AuthGlobalAdminMaintai
 import AuthAnyMaintainerAnyAdminRoutes from "./components/AuthAnyMaintainerAnyAdminRoutes";
 import AuthAnyMaintainerAdminObserverPlusRoutes from "./components/AuthAnyMaintainerAdminObserverPlusRoutes";
 import PremiumRoutes from "./components/PremiumRoutes";
+import ExcludeInSandboxRoutes from "./components/ExcludeInSandboxRoutes";
 
+const isSandboxMode = { AppContext };
 interface IAppWrapperProps {
   children: JSX.Element;
 }
@@ -102,17 +104,21 @@ const routes = (
         <Route path="email/change/:token" component={EmailTokenRedirect} />
         <Route path="logout" component={LogoutPage} />
         <Route component={CoreLayout}>
-          <IndexRedirect to={"/dashboard"} />
+          <IndexRedirect to="/dashboard" />
           <Route path="dashboard" component={DashboardPage}>
             <Route path="linux" component={DashboardPage} />
             <Route path="mac" component={DashboardPage} />
             <Route path="windows" component={DashboardPage} />
           </Route>
           <Route path="settings" component={AuthAnyAdminRoutes}>
-            <IndexRedirect to={"organization"} />
+            <IndexRedirect
+              to={isSandboxMode ? "integrations" : "organization"}
+            />
             <Route component={SettingsWrapper}>
               <Route component={AuthGlobalAdminRoutes}>
-                <Route path="organization" component={OrgSettingsPage} />
+                <Route component={ExcludeInSandboxRoutes}>
+                  <Route path="organization" component={OrgSettingsPage} />
+                </Route>
                 <Route
                   path="organization/:section"
                   component={OrgSettingsPage}
@@ -122,7 +128,9 @@ const routes = (
                   path="integrations/:section"
                   component={AdminIntegrationsPage}
                 />
-                <Route path="users" component={AdminUserManagementPage} />
+                <Route component={ExcludeInSandboxRoutes}>
+                  <Route path="users" component={AdminUserManagementPage} />
+                </Route>
                 <Route component={PremiumRoutes}>
                   <Route path="teams" component={AdminTeamManagementPage} />
                 </Route>
@@ -137,12 +145,12 @@ const routes = (
             <Redirect from="teams/:team_id/options" to="teams" />
           </Route>
           <Route path="labels">
-            <IndexRedirect to={"new"} />
+            <IndexRedirect to="new" />
             <Route path=":label_id" component={LabelPage} />
             <Route path="new" component={LabelPage} />
           </Route>
           <Route path="hosts">
-            <IndexRedirect to={"manage"} />
+            <IndexRedirect to="manage" />
             <Route path="manage" component={ManageHostsPage} />
             <Route path="manage/labels/:label_id" component={ManageHostsPage} />
             <Route path="manage/:active_label" component={ManageHostsPage} />
@@ -155,7 +163,7 @@ const routes = (
               component={ManageHostsPage}
             />
 
-            <IndexRedirect to={":host_id"} />
+            <IndexRedirect to=":host_id" />
             <Route component={HostDetailsPage}>
               <Route path=":host_id" component={HostDetailsPage}>
                 <Route path="software" component={HostDetailsPage} />
@@ -166,7 +174,7 @@ const routes = (
           </Route>
 
           <Route path="controls" component={AuthAnyMaintainerAnyAdminRoutes}>
-            <IndexRedirect to={"mac-os-updates"} />
+            <IndexRedirect to="mac-os-updates" />
             <Route component={ManageControlsPage}>
               <Route path="mac-os-updates" component={MacOSUpdates} />
               <Route path="mac-settings" component={MacOSSettings} />
@@ -175,13 +183,13 @@ const routes = (
           </Route>
 
           <Route path="software">
-            <IndexRedirect to={"manage"} />
+            <IndexRedirect to="manage" />
             <Route path="manage" component={ManageSoftwarePage} />
             <Route path=":software_id" component={SoftwareDetailsPage} />
           </Route>
           <Route component={AuthGlobalAdminMaintainerRoutes}>
             <Route path="packs">
-              <IndexRedirect to={"manage"} />
+              <IndexRedirect to="manage" />
               <Route path="manage" component={ManagePacksPage} />
               <Route path="new" component={PackComposerPage} />
               <Route path=":id">
@@ -192,14 +200,14 @@ const routes = (
           </Route>
           <Route component={AuthAnyMaintainerAnyAdminRoutes}>
             <Route path="schedule">
-              <IndexRedirect to={"manage"} />
+              <IndexRedirect to="manage" />
               <Route path="manage" component={ManageSchedulePage} />
               <Redirect from="manage/teams" to="manage" />
               <Redirect from="manage/teams/:team_id" to="manage" />
             </Route>
           </Route>
           <Route path="queries">
-            <IndexRedirect to={"manage"} />
+            <IndexRedirect to="manage" />
             <Route path="manage" component={ManageQueriesPage} />
             <Route component={AuthAnyMaintainerAdminObserverPlusRoutes}>
               <Route path="new" component={QueryPage} />
@@ -207,7 +215,7 @@ const routes = (
             <Route path=":id" component={QueryPage} />
           </Route>
           <Route path="policies">
-            <IndexRedirect to={"manage"} />
+            <IndexRedirect to="manage" />
             <Route path="manage" component={ManagePoliciesPage} />
             <Route component={AuthAnyMaintainerAnyAdminRoutes}>
               <Route path="new" component={PolicyPage} />

--- a/frontend/router/paths.ts
+++ b/frontend/router/paths.ts
@@ -19,7 +19,7 @@ export default {
   ADMIN_INTEGRATIONS_TICKET_DESTINATIONS: `${URL_PREFIX}/settings/integrations/ticket-destinations`,
   ADMIN_INTEGRATIONS_MDM: `${URL_PREFIX}/settings/integrations/mdm`,
   ADMIN_TEAMS: `${URL_PREFIX}/settings/teams`,
-  ADMIN_SETTINGS: `${URL_PREFIX}/settings/organization`,
+  ADMIN_SETTINGS: `${URL_PREFIX}/settings`,
   ADMIN_SETTINGS_INFO: `${URL_PREFIX}/settings/organization/info`,
   ADMIN_SETTINGS_WEBADDRESS: `${URL_PREFIX}/settings/organization/webaddress`,
   ADMIN_SETTINGS_SSO: `${URL_PREFIX}/settings/organization/sso`,


### PR DESCRIPTION
## Addresses #10819 

In Sandbox mode:
* Hide the "Organization settings" and "Users" tabs under settings tabs
* Disable the respective URL routes
* Redirect `/settings` to `/settings/integrations` instead of the now blocked `/settings/organization`
* Center the "Premium feature" message under Teams in Sandbox mode
<img width="501" alt="Screenshot 2023-04-19 at 1 38 44 PM" src="https://user-images.githubusercontent.com/61553566/233194920-53975594-e9ab-4638-b7f3-c7b9d01e0ff6.png">

## Checklist for submitter

- [x] Manual QA for all new/changed functionality
