### PR TITLE
UI: Center 'download installers' modal;  misc cleanup

### DIFF
--- a/frontend/components/AddHostsModal/DownloadInstallers/_styles.scss
+++ b/frontend/components/AddHostsModal/DownloadInstallers/_styles.scss
@@ -3,6 +3,7 @@
   flex-direction: column;
   padding: 0;
   padding-bottom: 20px;
+  width: 650px;
 
   p {
     padding-top: $pad-small;
@@ -27,7 +28,6 @@
 
   &__select-installer {
     display: flex;
-    flex-direction: row;
     flex-wrap: wrap;
     align-items: flex-start;
     gap: 8px;
@@ -38,11 +38,9 @@
     cursor: pointer;
     font-size: $small;
     display: flex;
-    flex-direction: row;
     justify-content: center;
-    align-items: center;
+    flex-grow: 1;
     padding: 16px;
-    gap: 16px;
     width: 247px;
 
     border: 1px solid #c5c7d1;
@@ -50,7 +48,6 @@
 
     span {
       display: flex;
-      flex-direction: row;
       justify-content: center;
       align-items: center;
 


### PR DESCRIPTION
## Addresses #10815
* Code is already in the desired state per this issue, remaining work to clean up the "Download installers" modal:
<img width="697" alt="Screenshot 2023-04-19 at 2 41 56 PM" src="https://user-images.githubusercontent.com/61553566/233206990-d13a8778-b090-4c6f-98ab-4f0d2825e504.png">
