### PR TITLE
Add possibility to append new environments variables with helm chart …

### DIFF
--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -262,6 +262,11 @@ spec:
             value: "{{ .Values.osquery.logging.pubsub.resultTopic }}"
           {{- end }}
           ## END OSQUERY SECTION
+          ## APPEND ENVIRONMENT VARIABLES FROM VALUES
+          {{- range $key, $value := .Values.environments }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -191,3 +191,16 @@ gke:
     useManagedCertificate: false
   # Workload Identity allows the K8s service account to assume the IAM permissions of a GCP service account
   workloadIdentityEmail: ""
+
+## Section: Environment Variables
+# All of the environment variables that can be set for Fleet
+environments:
+  # MDM Settings
+  # The following environment variables are used to configure Fleet to work with
+  # Apple's MDM service. These are optional and only required if you are using
+  # Fleet to manage Apple devices.
+  # To more information: https://fleetdm.com/docs/using-fleet/mdm-setup#step-3-configure-fleet-with-the-required-files
+  FLEET_MDM_APPLE_APNS_CERT_BYTES: ""
+  FLEET_MDM_APPLE_APNS_KEY_BYTES: ""
+  FLEET_MDM_APPLE_SCEP_CERT_BYTES: ""
+  FLEET_MDM_APPLE_SCEP_KEY_BYTES: ""


### PR DESCRIPTION
Add possibility to append new environments variables with helm chart on values.yaml

Currently, the installation of fleetdm through helm does not allow you to configure environment variables for the apple mdm configuration.

With this pull request, you are allowed to add any environment variable to the deployment made by helm. To do this you can append the environment variables in the values.yaml

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
