### PR TITLE
MDM docs: Explain what happens automatically 

### DIFF
--- a/docs/Using-Fleet/MDM-macOS-settings.md
+++ b/docs/Using-Fleet/MDM-macOS-settings.md
@@ -1,10 +1,12 @@
 # macOS settings
 
-In Fleet you can enforce settings on your macOS hosts remotely.
+In Fleet you can enforce settings on your macOS hosts remotely:
 
-If you enforce disk encryption with Fleet, the disk encryption key (recovery key) will be stored in Fleet automatically. Learn how [here](#disk-encryption).
+* Disk encryption (FileVault): If enforced, the disk encryption key (recovery key) will be stored in Fleet automatically. Learn how [here](#disk-encryption).
 
-You can also enforce custom macOS settings. Learn how [here](#custom-settings).
+* Custom settings: learn how [here](#custom-settings).
+
+In addition to the above, Fleet automatically enforces settings for the fleetd agent using a "Fleetd configuration" configuration profile.
 
 ## Disk encryption
 

--- a/docs/Using-Fleet/MDM-macOS-setup.md
+++ b/docs/Using-Fleet/MDM-macOS-setup.md
@@ -8,6 +8,8 @@ In Fleet, you can customize the first-time macOS setup experience for your end u
 
 * Install a bootstrap package to gain full control over the setup experience by installing tools like Puppet, Munki, DEP notify, custom scrips, and more.
 
+In addition to the customization above, Fleet automatically installs the fleetd agent during first-time macOS setup. This agent is responsible for reporting host vitals to Fleet and presenting Fleet Desktop to the end user.
+
 ## End user authentication
 
 > This feature is currently in development.
@@ -26,9 +28,7 @@ The following are examples of what some organizations deploy using a bootstrap p
 
 * Puppet agent to run custom scripts on your Macs
 
-* Custom scripts and several packages bundled into one bootstrap package using a tool like [InstallApplications](https://github.com/macadmins/installapplications) to install a base set of applications, set the Mac's background, and install the latest macOS update for the end user. 
-
-> In addition to installing the bootstrap package, Fleet automatically installs the fleetd agent on hosts that automatically enroll. This agent is responsible for reporting host vitals to Fleet and presenting Fleet Desktop to the end user.
+* Custom scripts and several packages bundled into one bootstrap package using a tool like [InstallApplications](https://github.com/macadmins/installapplications) to install a base set of applications, set the Mac's background, and install the latest macOS update for the end user.
 
 To add a bootstrap package to Fleet, we will do the following steps:
 

--- a/docs/Using-Fleet/MDM-macOS-setup.md
+++ b/docs/Using-Fleet/MDM-macOS-setup.md
@@ -2,7 +2,7 @@
 
 _Available in Fleet Premium_
 
-In Fleet, you can customize the first-time macOS setup experience for your end users:
+In Fleet, you can customize the out-of-the-box macOS setup experience for your end users:
 
 * Require end users to authenticate with your identity provider (IdP) and agree to an end user license agreement (EULA) before they can use their new Mac
 
@@ -10,7 +10,7 @@ In Fleet, you can customize the first-time macOS setup experience for your end u
 
 * Install a bootstrap package to gain full control over the setup experience by installing tools like Puppet, Munki, DEP notify, custom scrips, and more.
 
-In addition to the customization above, Fleet automatically installs the fleetd agent during first-time macOS setup. This agent is responsible for reporting host vitals to Fleet and presenting Fleet Desktop to the end user.
+In addition to the customization above, Fleet automatically installs the fleetd agent during out-of-the-box macOS setup. This agent is responsible for reporting host vitals to Fleet and presenting Fleet Desktop to the end user.
 
 MacOS setup features require connecting Fleet to Apple Business Manager (ABM). Learn how [here](./MDM-setup.md#apple-business-manager-abm).
 

--- a/docs/Using-Fleet/MDM-macOS-setup.md
+++ b/docs/Using-Fleet/MDM-macOS-setup.md
@@ -1,5 +1,7 @@
 # macOS setup
 
+_Available in Fleet Premium_
+
 In Fleet, you can customize the first-time macOS setup experience for your end users:
 
 * Require end users to authenticate with your identity provider (IdP) and agree to an end user license agreement (EULA) before they can use their new Mac
@@ -10,13 +12,13 @@ In Fleet, you can customize the first-time macOS setup experience for your end u
 
 In addition to the customization above, Fleet automatically installs the fleetd agent during first-time macOS setup. This agent is responsible for reporting host vitals to Fleet and presenting Fleet Desktop to the end user.
 
+MacOS setup features require connecting Fleet to Apple Business Manager (ABM). Learn how [here](./MDM-setup.md#apple-business-manager-abm).
+
 ## End user authentication
 
 > This feature is currently in development.
 
 ## Bootstrap package
-
-_Available in Fleet Premium_
 
 Fleet supports installing a bootstrap package on macOS hosts that automatically enroll to Fleet. 
 


### PR DESCRIPTION
- On MDM macOS setup page:
  - Add sentence to explain that Fleet installs fleetd automatically on hosts
  - Add sentence to explain that setup features require ABM
- On MDM macOS settings page, add sentence that explains that Fleet automatically deploys a "Fleetd configuration" profile.
