### PR TITLE
Fix integration Github action using the deprecated command set-output

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,8 +34,8 @@ jobs:
     - id: gen
       run: |
         UUID=$(uuidgen)
-        echo "::set-output name=subdomain::fleet-test-$UUID"
-        echo "::set-output name=address::https://fleet-test-$UUID.fleetuem.com"
+        echo "subdomain=fleet-test-$UUID" >> $GITHUB_OUTPUT
+        echo "address=https://fleet-test-$UUID.fleetuem.com" >> $GITHUB_OUTPUT
 
   run-server:
     runs-on: ubuntu-latest


### PR DESCRIPTION
In Github actions, the `set-output` command is deprecated and will be disabled within the next 2 months.

Currently, the `integration.yml` still uses `set-output`, but I have updated this to use the format recommended by Github.

More information can be found here: 
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files

I used the documentation on the link above, and everything should continue as normal. Please verify this first before merging.