### PR TITLE
wildcard host search support

### DIFF
--- a/changes/issue-9996-host-search-wildcard
+++ b/changes/issue-9996-host-search-wildcard
@@ -1,0 +1,1 @@
+- Added wildcards to host search so when searching for different accented characters you get more results

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1788,7 +1788,7 @@ func (ds *Datastore) SearchHosts(ctx context.Context, filter fleet.TeamFilter, m
 		var args []interface{}
 		searchHostsQuery, args, matchesEmail := hostSearchLike(matchingHosts, args, matchQuery, hostSearchColumns...)
 		// if matchQuery is "email like" then don't bother with the additional wildcard searching
-		if !matchesEmail && hasNonASCIIRegex(matchQuery) {
+		if !matchesEmail && hasNonASCIIRegex(matchQuery) && len(matchQuery) >= 3 {
 			union, wildCardArgs := hostSearchLikeAny(matchingHosts, args, replaceMatchAny(matchQuery), wildCardableHostSearchColumns...)
 			searchHostsQuery += " UNION " + union
 			args = wildCardArgs

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -22,6 +22,7 @@ import (
 )
 
 var hostSearchColumns = []string{"hostname", "computer_name", "uuid", "hardware_serial", "primary_ip"}
+var wildCardableHostSearchColumns = []string{"hostname", "computer_name"}
 
 // Fixme: We should not make implementation details of the database schema part of the API.
 var defaultHostColumnTableAliases = map[string]string{
@@ -780,7 +781,7 @@ func (ds *Datastore) applyHostFilters(opt fleet.HostListOptions, sql string, fil
 	sql, params = filterHostsByMacOSDiskEncryptionStatus(sql, opt, params)
 	sql, params = filterHostsByMDMBootstrapPackageStatus(sql, opt, params)
 	sql, params = filterHostsByOS(sql, opt, params)
-	sql, params = hostSearchLike(sql, params, opt.MatchQuery, hostSearchColumns...)
+	sql, params, _ = hostSearchLike(sql, params, opt.MatchQuery, hostSearchColumns...)
 	sql, params = appendListOptionsWithCursorToSQL(sql, params, &opt.ListOptions)
 
 	return sql, params
@@ -1146,13 +1147,13 @@ func matchHostDuringEnrollment(ctx context.Context, q sqlx.QueryerContext, isMDM
 	// (the latter shows that it might not be top priority to index this field, if we're
 	// going to recommend using the host uuid as osquery identifier, as osquery_host_id
 	// _is_ indexed and unique).
-	//if uuid != "" {
+	// if uuid != "" {
 	//	if query.Len() > 0 {
 	//		_, _ = query.WriteString(" UNION ")
 	//	}
 	//	_, _ = query.WriteString(`(SELECT id, last_enrolled_at, 2 priority FROM hosts WHERE uuid = ? ORDER BY id LIMIT 1)`)
 	//	args = append(args, uuid)
-	//}
+	// }
 
 	if serial != "" && isMDMEnabled {
 		if query.Len() > 0 {
@@ -1428,7 +1429,7 @@ func (ds *Datastore) EnrollHost(ctx context.Context, isMDMEnabled bool, osqueryH
 // getContextTryStmt will attempt to run sqlx.GetContext on a cached statement if available, resorting to ds.reader.
 func (ds *Datastore) getContextTryStmt(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
 	var err error
-	//nolint the statements are closed in Datastore.Close.
+	// nolint the statements are closed in Datastore.Close.
 	if stmt := ds.loadOrPrepareStmt(ctx, query); stmt != nil {
 		err = stmt.GetContext(ctx, dest, args...)
 	} else {
@@ -1777,31 +1778,56 @@ func (ds *Datastore) SearchHosts(ctx context.Context, filter fleet.TeamFilter, m
   LEFT JOIN host_updates hu ON (h.id = hu.host_id)
   LEFT JOIN host_disks hd ON hd.host_id = h.id
   ` + hostMDMJoin + `
-  WHERE TRUE`
+  WHERE TRUE AND `
 
-	var args []interface{}
+	matchingHostIDs := make([]int, 0)
 	if len(matchQuery) > 0 {
-		query, args = hostSearchLike(query, args, matchQuery, hostSearchColumns...)
+		// first we'll find the hosts that match the search criteria, to keep thing simple, then we'll query again
+		// to get all the additional data for hosts that match the search criteria by host_id
+		matchingHosts := "SELECT id FROM hosts WHERE TRUE"
+		var args []interface{}
+		searchHostsQuery, args, matchesEmail := hostSearchLike(matchingHosts, args, matchQuery, hostSearchColumns...)
+		// if matchQuery is "email like" then don't bother with the additional wildcard searching
+		if !matchesEmail && hasNonASCIIRegex(matchQuery) {
+			union, wildCardArgs := hostSearchLikeAny(matchingHosts, args, replaceMatchAny(matchQuery), wildCardableHostSearchColumns...)
+			searchHostsQuery += " UNION " + union
+			args = wildCardArgs
+		}
+		searchHostsQuery += " AND TRUE ORDER BY id DESC LIMIT 10"
+		searchHostsQuery = ds.reader.Rebind(searchHostsQuery)
+		err := sqlx.SelectContext(ctx, ds.reader, &matchingHostIDs, searchHostsQuery, args...)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "searching hosts")
+		}
 	}
-	var in interface{}
-	// use -1 if there are no values to omit.
-	// Avoids empty args error for `sqlx.In`
-	in = omit
-	if len(omit) == 0 {
-		in = -1
+
+	// we attempted to search for something that yielded no results, this should return empty set, no point in continuing
+	if len(matchingHostIDs) == 0 && len(matchQuery) > 0 {
+		return []*fleet.Host{}, nil
 	}
-	args = append(args, in)
-	query += " AND id NOT IN (?) AND "
+	var args []interface{}
+	if len(matchingHostIDs) > 0 {
+		args = append(args, matchingHostIDs)
+		query += " id IN (?) AND "
+	}
+	if len(omit) > 0 {
+		args = append(args, omit)
+		query += " id NOT IN (?) AND "
+	}
 	query += ds.whereFilterHostsByTeams(filter, "h")
 	query += ` ORDER BY h.id DESC LIMIT 10`
 
-	query, args, err := sqlx.In(query, args...)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "searching default hosts")
+	var err error
+	if len(args) > 0 {
+		query, args, err = sqlx.In(query, args...)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "searching default hosts")
+		}
 	}
+
 	query = ds.reader.Rebind(query)
-	hosts := []*fleet.Host{}
-	if err := sqlx.SelectContext(ctx, ds.reader, &hosts, query, args...); err != nil {
+	var hosts []*fleet.Host
+	if err = sqlx.SelectContext(ctx, ds.reader, &hosts, query, args...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "searching hosts")
 	}
 

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1788,8 +1788,8 @@ func (ds *Datastore) SearchHosts(ctx context.Context, filter fleet.TeamFilter, m
 		var args []interface{}
 		searchHostsQuery, args, matchesEmail := hostSearchLike(matchingHosts, args, matchQuery, hostSearchColumns...)
 		// if matchQuery is "email like" then don't bother with the additional wildcard searching
-		if !matchesEmail && hasNonASCIIRegex(matchQuery) && len(matchQuery) >= 3 {
-			union, wildCardArgs := hostSearchLikeAny(matchingHosts, args, replaceMatchAny(matchQuery), wildCardableHostSearchColumns...)
+		if !matchesEmail && len(matchQuery) > 2 && hasNonASCIIRegex(matchQuery) {
+			union, wildCardArgs := hostSearchLikeAny(matchingHosts, args, matchQuery, wildCardableHostSearchColumns...)
 			searchHostsQuery += " UNION " + union
 			args = wildCardArgs
 		}

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -87,6 +87,7 @@ func TestHosts(t *testing.T) {
 		{"LoadHostByNodeKey", testHostsLoadHostByNodeKey},
 		{"LoadHostByNodeKeyCaseSensitive", testHostsLoadHostByNodeKeyCaseSensitive},
 		{"Search", testHostsSearch},
+		{"SearchWildCards", testSearchHostsWildCards},
 		{"SearchLimit", testHostsSearchLimit},
 		{"GenerateStatusStatistics", testHostsGenerateStatusStatistics},
 		{"MarkSeen", testHostsMarkSeen},
@@ -1612,6 +1613,153 @@ func testHostsSearch(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	assert.Len(t, hits, 3)
 	assert.Equal(t, []uint{h3.ID, h2.ID, h1.ID}, []uint{hits[0].ID, hits[1].ID, hits[2].ID})
+}
+
+func testSearchHostsWildCards(t *testing.T, ds *Datastore) {
+	/*
+		+------------------+
+		|hostname          |
+		+------------------+
+		|Molly‘s MacbookPro|
+		|Molly's MacbookPro|
+		|Molly‘s MacbookPro|
+		|Molly❛s MacbookPro|
+		|Molly❜s MacbookPro|
+		|Alex's MacbookPro |
+		+------------------+
+
+	*/
+	hostnames := []string{
+		"Molly‘s MacbookPro",
+		"Molly's MacbookPro",
+		"Molly‘s MacbookPro",
+		"Molly❛s MacbookPro",
+		"Molly❜s MacbookPro",
+		"Alex's MacbookPro",
+	}
+	hostsMap := make(map[uint]*fleet.Host, len(hostnames))
+	hostsList := make([]*fleet.Host, len(hostnames))
+	hostIDs := make([]uint, len(hostnames))
+	for i, name := range hostnames {
+		h, err := ds.NewHost(context.Background(), &fleet.Host{
+			OsqueryHostID:   ptr.String(strconv.Itoa(i)),
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now(),
+			NodeKey:         ptr.String(strconv.Itoa(i)),
+			UUID:            strconv.Itoa(i),
+			Hostname:        name,
+		})
+		require.NoError(t, err)
+		hostsMap[h.ID] = h
+		hostsList[i] = h
+		hostIDs[i] = h.ID
+	}
+	sort.Slice(hostsList, func(i, j int) bool {
+		return hostsList[i].ID < hostsList[j].ID
+	})
+	// hosts are returned in ORDER BY host.id DESC
+	sort.Slice(hostIDs, func(i, j int) bool {
+		return hostIDs[i] > hostIDs[j]
+	})
+
+	userAdmin := &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}
+	filter := fleet.TeamFilter{User: userAdmin}
+
+	type args struct {
+		ctx        context.Context
+		filter     fleet.TeamFilter
+		matchQuery string
+		omit       []uint
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []uint
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "empty match criteria should match everything",
+			args: args{
+				ctx:        context.Background(),
+				matchQuery: "",
+				filter:     filter,
+				omit:       nil,
+			},
+			want:    hostIDs,
+			wantErr: assert.NoError,
+		},
+		{
+			name: "searching for host with regular apostrophe should return just that result",
+			args: args{
+				ctx:        context.Background(),
+				matchQuery: "Molly's",
+				filter:     filter,
+				omit:       nil,
+			},
+			want:    []uint{2}, // hosts.id autoincrement starts at 1
+			wantErr: assert.NoError,
+		},
+		{
+			name: "excluding the host you are searching for should return an empty set",
+			args: args{
+				ctx:        context.Background(),
+				matchQuery: "Molly's",
+				filter:     filter,
+				omit:       []uint{2},
+			},
+			want:    []uint{},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "searching for non-ascii characters should use wildcard searching",
+			args: args{
+				ctx:        context.Background(),
+				matchQuery: "Molly‘s",
+				filter:     filter,
+				omit:       []uint{},
+			},
+			want:    []uint{5, 4, 3, 2, 1}, // all Molly_s endpoints should return
+			wantErr: assert.NoError,
+		},
+		{
+			name: "searching for criteria that doesn't match anything should yield empty results",
+			args: args{
+				ctx:        context.Background(),
+				matchQuery: "Foobar",
+				filter:     filter,
+				omit:       []uint{},
+			},
+			want:    []uint{},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "searching for criteria that doesn't match anything should yield empty results, omitting id that isn't in the potential result set shouldn't effect result",
+			args: args{
+				ctx:        context.Background(),
+				matchQuery: "Foobar",
+				filter:     filter,
+				omit:       []uint{1},
+			},
+			want:    []uint{},
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got, err := ds.SearchHosts(tt.args.ctx, tt.args.filter, tt.args.matchQuery, tt.args.omit...)
+			if !tt.wantErr(t, err, fmt.Sprintf("SearchHosts(%v, %v, %v, %v)", tt.args.ctx, tt.args.filter, tt.args.matchQuery, tt.args.omit)) {
+				return
+			}
+			resultHostIDs := make([]uint, len(got))
+			for i, h := range got {
+				resultHostIDs[i] = h.ID
+			}
+			assert.Equalf(t, tt.want, resultHostIDs, "SearchHosts(%v, %v, %v, %v)", tt.args.ctx, tt.args.filter, tt.args.matchQuery, tt.args.omit)
+		})
+	}
 }
 
 func testHostsSearchLimit(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -1033,7 +1033,7 @@ func isChildForeignKeyError(err error) bool {
 	return mysqlErr.Number == ER_NO_REFERENCED_ROW_2
 }
 
-type PatternReplacer func(string) string
+type patternReplacer func(string) string
 
 // likePattern returns a pattern to match m with LIKE.
 func likePattern(m string) string {
@@ -1054,7 +1054,7 @@ func searchLike(sql string, params []interface{}, match string, columns ...strin
 	return searchLikePattern(sql, params, match, likePattern, columns...)
 }
 
-func searchLikePattern(sql string, params []interface{}, match string, replacer PatternReplacer, columns ...string) (string, []interface{}) {
+func searchLikePattern(sql string, params []interface{}, match string, replacer patternReplacer, columns ...string) (string, []interface{}) {
 	if len(columns) == 0 || len(match) == 0 {
 		return sql, params
 	}

--- a/server/datastore/mysql/mysql_test.go
+++ b/server/datastore/mysql/mysql_test.go
@@ -218,7 +218,7 @@ func TestHostSearchLike(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run("", func(t *testing.T) {
-			sql, params := hostSearchLike(tt.inSQL, tt.inParams, tt.match, tt.columns...)
+			sql, params, _ := hostSearchLike(tt.inSQL, tt.inParams, tt.match, tt.columns...)
 			assert.Equal(t, tt.outSQL, sql)
 			assert.Equal(t, tt.outParams, params)
 		})

--- a/server/datastore/mysql/mysql_test.go
+++ b/server/datastore/mysql/mysql_test.go
@@ -987,3 +987,55 @@ func TestANSIQuotesEnabled(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, sqlMode, "ANSI_QUOTES")
 }
+
+func Test_buildWildcardMatchPhrase(t *testing.T) {
+	type args struct {
+		matchQuery string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "",
+			args: args{matchQuery: "test"},
+			want: "%test%",
+		},
+		{
+			name: "underscores are escaped",
+			args: args{matchQuery: "Host_1"},
+			want: "%Host\\_1%",
+		},
+		{
+			name: "percent are escaped",
+			args: args{matchQuery: "Host%1"},
+			want: "%Host\\%1%",
+		},
+		{
+			name: "percent & underscore are escaped",
+			args: args{matchQuery: "Host_%1"},
+			want: "%Host\\_\\%1%",
+		},
+		{
+			name: "underscores added for wildcard search are not escaped",
+			args: args{matchQuery: "Alice‘s MacbookPro"},
+			want: "%Alice_s MacbookPro%",
+		},
+		{
+			name: "underscores added for wildcard search are not escaped, but underscores in matchQuery are",
+			args: args{matchQuery: "Alice‘s Macbook_Pro"},
+			want: "%Alice_s Macbook\\_Pro%",
+		},
+		{
+			name: "multiple occurances of wildcard are not escaped",
+			args: args{matchQuery: "Alice‘‘s Macbook_Pro"},
+			want: "%Alice__s Macbook\\_Pro%",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, buildWildcardMatchPhrase(tt.args.matchQuery), "buildWildcardMatchPhrase(%v)", tt.args.matchQuery)
+		})
+	}
+}


### PR DESCRIPTION
relates to #9996 

Added support for wildcard search on host search.

say for example you have the following hosts:

```
+------------------+
|hostname          |
+------------------+
|Molly‘s MacbookPro|
|Molly's MacbookPro|
|Molly‘s MacbookPro|
|Molly❛s MacbookPro|
|Molly❜s MacbookPro|
|Alex's MacbookPro |
+------------------+
```

searching for `Molly's` yields just the single host, but searching for `Molly❜s` will perform a broader wildcard search using the literal `_` character to match any character _in that position_.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Added/updated tests

