### PR TITLE
Website: add middleware function to set HSTS header

### DIFF
--- a/website/config/http.js
+++ b/website/config/http.js
@@ -29,16 +29,24 @@ module.exports.http = {
     *                                                                          *
     ***************************************************************************/
 
-    // order: [
-    //   'cookieParser',
-    //   'session',
-    //   'bodyParser',
-    //   'compress',
-    //   'poweredBy',
-    //   'router',
-    //   'www',
-    //   'favicon',
-    // ],
+    order: [
+      'cookieParser',
+      'session',
+      'bodyParser',
+      'compress',
+      'hsts',
+      'poweredBy',
+      'router',
+      'www',
+      'favicon',
+    ],
+
+
+    // Set the HTTP Strict-Transport-Security (HSTS) header on all responses. « See https://github.com/fleetdm/confidential/issues/2505 for more info.
+    hsts: function (req, res, next) {
+      res.header('Strict-Transport-Security', 'max-age=31536000; includeSubDomains;');
+      next();
+    },
 
 
     /***************************************************************************


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/2505

Changes:
- Added a new middleware function in `website/config/http.js` that sets a `Strict-Transport-Security` header on all responses.
