### PR TITLE
Check for "No access" for authenticated routes

### DIFF
--- a/changes/11188-no-access-user
+++ b/changes/11188-no-access-user
@@ -1,0 +1,1 @@
+* Present the 403 error page when a user with no access logs in.

--- a/frontend/router/components/AuthenticatedRoutes/AuthenticatedRoutes.tsx
+++ b/frontend/router/components/AuthenticatedRoutes/AuthenticatedRoutes.tsx
@@ -5,7 +5,7 @@ import paths from "router/paths";
 import { AppContext } from "context/app";
 import { RoutingContext } from "context/routing";
 import useDeepEffect from "hooks/useDeepEffect";
-import { authToken } from "utilities/local";
+import local, { authToken } from "utilities/local";
 import { useErrorHandler } from "react-error-boundary";
 import permissions from "utilities/permissions";
 
@@ -95,6 +95,7 @@ export const AuthenticatedRoutes = ({
     }
 
     if (currentUser && permissions.isNoAccess(currentUser)) {
+      local.removeItem("auth_token");
       return handlePageError({ status: 403 });
     }
   }, [currentUser]);

--- a/frontend/router/components/AuthenticatedRoutes/AuthenticatedRoutes.tsx
+++ b/frontend/router/components/AuthenticatedRoutes/AuthenticatedRoutes.tsx
@@ -6,6 +6,8 @@ import { AppContext } from "context/app";
 import { RoutingContext } from "context/routing";
 import useDeepEffect from "hooks/useDeepEffect";
 import { authToken } from "utilities/local";
+import { useErrorHandler } from "react-error-boundary";
+import permissions from "utilities/permissions";
 
 interface IAppProps {
   children: JSX.Element;
@@ -23,6 +25,8 @@ export const AuthenticatedRoutes = ({
 
   const { setRedirectLocation } = useContext(RoutingContext);
   const { currentUser, config, isSandboxMode } = useContext(AppContext);
+
+  const handlePageError = useErrorHandler();
 
   const redirectToLogin = () => {
     const { LOGIN } = paths;
@@ -88,6 +92,10 @@ export const AuthenticatedRoutes = ({
 
     if (currentUser?.api_only) {
       return redirectToApiUserOnly();
+    }
+
+    if (currentUser && permissions.isNoAccess(currentUser)) {
+      return handlePageError({ status: 403 });
     }
   }, [currentUser]);
 


### PR DESCRIPTION
## Addresses #11188 

When an _already authenticated_ no-access user tries to access any authenticated routes:
- Log the user out
- Display the 403 'Forbidden' error page

https://www.loom.com/share/358fd5b534984ab9ab40220986a7d094
The user _can_ still log in – see attached issue.

## Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality