### PR TITLE
Add activities for macOS setup assistant.

### DIFF
--- a/changes/issue-10994-add-macos-setup-assistant-activities
+++ b/changes/issue-10994-add-macos-setup-assistant-activities
@@ -1,0 +1,1 @@
+* Added `changed_macos_setup_assistant` and `deleted_macos_setup_assistant` activities for the macOS setup assistant setting.

--- a/docs/Using-Fleet/Audit-Activities.md
+++ b/docs/Using-Fleet/Audit-Activities.md
@@ -659,6 +659,44 @@ This activity contains the following fields:
 }
 ```
 
+### Type `changed_macos_setup_assistant`
+
+Generated when a user sets the macOS setup assistant for a team (or no team).
+
+This activity contains the following fields:
+- "name": Name of the macOS setup assistant file.
+- "team_id": The ID of the team that the setup assistant applies to, null if it applies to devices that are not in a team.
+- "team_name": The name of the team that the setup assistant applies to, null if it applies to devices that are not in a team.
+
+#### Example
+
+```json
+{
+  "name": "dep_profile.json",
+  "team_id": 123,
+  "team_name": "Workstations"
+}
+```
+
+### Type `deleted_macos_setup_assistant`
+
+Generated when a user deletes the macOS setup assistant for a team (or no team).
+
+This activity contains the following fields:
+- "name": Name of the deleted macOS setup assistant file.
+- "team_id": The ID of the team that the setup assistant applied to, null if it applied to devices that are not in a team.
+- "team_name": The name of the team that the setup assistant applied to, null if it applied to devices that are not in a team.
+
+#### Example
+
+```json
+{
+  "name": "dep_profile.json",
+  "team_id": 123,
+  "team_name": "Workstations"
+}
+```
+
 ### Type `enabled_macos_disk_encryption`
 
 Generated when a user turns on macOS disk encryption for a team (or no team).

--- a/docs/Using-Fleet/Detail-Queries-Summary.md
+++ b/docs/Using-Fleet/Detail-Queries-Summary.md
@@ -20,12 +20,12 @@ SELECT serial_number, cycle_count, health FROM battery;
 - Query:
 
 ```sql
-SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT "" AND filevault_status = 'on' LIMIT 1;
+SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT "" AND filevault_status = 'on' LIMIT 1
 ```
 
 ## disk_encryption_linux
 
-- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed
 
 - Query:
 
@@ -45,7 +45,7 @@ SELECT 1 FROM bitlocker_info WHERE drive_letter = 'C:' AND protection_status = 1
 
 ## disk_space_unix
 
-- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, darwin
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed, darwin
 
 - Query:
 
@@ -176,7 +176,7 @@ SELECT address, mac FROM network_interfaces LIMIT 1
 
 ## network_interface_unix
 
-- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, darwin
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed, darwin
 
 - Query:
 
@@ -270,7 +270,7 @@ SELECT version FROM orbit_info
 
 ## os_unix_like
 
-- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, darwin
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed, darwin
 
 - Query:
 
@@ -310,7 +310,7 @@ SELECT * FROM os_version LIMIT 1
 SELECT
 		os.name,
 		os.codename as display_version
-	
+
 	FROM
 		os_version os
 ```
@@ -328,7 +328,7 @@ SELECT
 		os.arch,
 		k.version as kernel_version,
 		os.codename as display_version
-	
+
 	FROM
 		os_version os,
 		kernel_info k
@@ -366,9 +366,25 @@ SELECT *,
 			FROM osquery_schedule
 ```
 
+## software_chrome
+
+- Platforms: chrome
+
+- Query:
+
+```sql
+SELECT
+  name AS name,
+  version AS version,
+  'Browser plugin (Chrome)' AS type,
+  'chrome_extensions' AS source,
+  '' AS vendor
+FROM chrome_extensions
+```
+
 ## software_linux
 
-- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed
 
 - Query:
 
@@ -472,7 +488,7 @@ WITH cached_users AS (WITH cached_groups AS (select * from groups)
  WHERE type <> 'special' AND shell NOT LIKE '%/false' AND shell NOT LIKE '%/nologin' AND shell NOT LIKE '%/shutdown' AND shell NOT LIKE '%/halt' AND username NOT LIKE '%$' AND username NOT LIKE '\_%' ESCAPE '\' AND NOT (username = 'sync' AND shell ='/bin/sync' AND directory <> ''))
 SELECT
   name AS name,
-  bundle_short_version AS version,
+  COALESCE(NULLIF(bundle_short_version, ''), bundle_version) AS version,
   'Application (macOS)' AS type,
   bundle_identifier AS bundle_identifier,
   'apps' AS source,
@@ -624,7 +640,7 @@ select * from uptime limit 1
 
 ## users
 
-- Platforms: all
+- Platforms: linux, darwin, windows
 
 - Query:
 
@@ -633,6 +649,16 @@ WITH cached_groups AS (select * from groups)
  SELECT uid, username, type, groupname, shell
  FROM users LEFT JOIN cached_groups USING (gid)
  WHERE type <> 'special' AND shell NOT LIKE '%/false' AND shell NOT LIKE '%/nologin' AND shell NOT LIKE '%/shutdown' AND shell NOT LIKE '%/halt' AND username NOT LIKE '%$' AND username NOT LIKE '\_%' ESCAPE '\' AND NOT (username = 'sync' AND shell ='/bin/sync' AND directory <> '')
+```
+
+## users_chrome
+
+- Platforms: chrome
+
+- Query:
+
+```sql
+SELECT uid, username, email FROM users
 ```
 
 ## windows_update_history

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -10,6 +10,7 @@ import (
 	"io"
 
 	"github.com/fleetdm/fleet/v4/pkg/file"
+	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
@@ -269,7 +270,37 @@ func (svc *Service) SetOrUpdateMDMAppleSetupAssistant(ctx context.Context, asst 
 		}
 	}
 
-	return svc.ds.SetOrUpdateMDMAppleSetupAssistant(ctx, asst)
+	// must read the existing setup assistant first to detect if it did change
+	// (so that the changed activity is not created if the same assistant was
+	// uploaded).
+	prevAsst, err := svc.ds.GetMDMAppleSetupAssistant(ctx, asst.TeamID)
+	if err != nil && !fleet.IsNotFound(err) {
+		return nil, ctxerr.Wrap(ctx, err, "get previous setup assistant")
+	}
+	newAsst, err := svc.ds.SetOrUpdateMDMAppleSetupAssistant(ctx, asst)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "set or update setup assistant")
+	}
+
+	// if the name is the same and the content did not change, uploaded at will stay the same
+	if prevAsst == nil || newAsst.Name != prevAsst.Name || newAsst.UploadedAt.After(prevAsst.UploadedAt) {
+		var teamName *string
+		if newAsst.TeamID != nil {
+			tm, err := svc.ds.Team(ctx, *newAsst.TeamID)
+			if err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "get team")
+			}
+			teamName = &tm.Name
+		}
+		if err := svc.ds.NewActivity(ctx, authz.UserFromContext(ctx), &fleet.ActivityTypeChangedMacosSetupAssistant{
+			TeamID:   newAsst.TeamID,
+			TeamName: teamName,
+			Name:     newAsst.Name,
+		}); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "create activity for changed macos setup assistant")
+		}
+	}
+	return newAsst, nil
 }
 
 func (svc *Service) GetMDMAppleSetupAssistant(ctx context.Context, teamID *uint) (*fleet.MDMAppleSetupAssistant, error) {

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -55,6 +55,9 @@ var ActivityDetailsList = []ActivityDetails{
 	ActivityTypeDeletedMacosProfile{},
 	ActivityTypeEditedMacosProfile{},
 
+	ActivityTypeChangedMacosSetupAssistant{},
+	ActivityTypeDeletedMacosSetupAssistant{},
+
 	ActivityTypeEnabledMacosDiskEncryption{},
 	ActivityTypeDisabledMacosDiskEncryption{},
 }
@@ -802,6 +805,50 @@ func (a ActivityTypeEditedMacosProfile) Documentation() (activity, details, deta
 		`This activity contains the following fields:
 - "team_id": The ID of the team that the profiles apply to, null if they apply to devices that are not in a team.
 - "team_name": The name of the team that the profiles apply to, null if they apply to devices that are not in a team.`, `{
+  "team_id": 123,
+  "team_name": "Workstations"
+}`
+}
+
+type ActivityTypeChangedMacosSetupAssistant struct {
+	Name     string  `json:"name"`
+	TeamID   *uint   `json:"team_id"`
+	TeamName *string `json:"team_name"`
+}
+
+func (a ActivityTypeChangedMacosSetupAssistant) ActivityName() string {
+	return "changed_macos_setup_assistant"
+}
+
+func (a ActivityTypeChangedMacosSetupAssistant) Documentation() (activity, details, detailsExample string) {
+	return `Generated when a user sets the macOS setup assistant for a team (or no team).`,
+		`This activity contains the following fields:
+- "name": Name of the macOS setup assistant file.
+- "team_id": The ID of the team that the setup assistant applies to, null if it applies to devices that are not in a team.
+- "team_name": The name of the team that the setup assistant applies to, null if it applies to devices that are not in a team.`, `{
+  "name": "dep_profile.json",
+  "team_id": 123,
+  "team_name": "Workstations"
+}`
+}
+
+type ActivityTypeDeletedMacosSetupAssistant struct {
+	Name     string  `json:"name"`
+	TeamID   *uint   `json:"team_id"`
+	TeamName *string `json:"team_name"`
+}
+
+func (a ActivityTypeDeletedMacosSetupAssistant) ActivityName() string {
+	return "deleted_macos_setup_assistant"
+}
+
+func (a ActivityTypeDeletedMacosSetupAssistant) Documentation() (activity, details, detailsExample string) {
+	return `Generated when a user deletes the macOS setup assistant for a team (or no team).`,
+		`This activity contains the following fields:
+- "name": Name of the deleted macOS setup assistant file.
+- "team_id": The ID of the team that the setup assistant applied to, null if it applied to devices that are not in a team.
+- "team_name": The name of the team that the setup assistant applied to, null if it applied to devices that are not in a team.`, `{
+  "name": "dep_profile.json",
   "team_id": 123,
   "team_name": "Workstations"
 }`

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2,6 +2,7 @@ package fleet
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"io"
@@ -974,6 +975,10 @@ func IsNotFound(err error) bool {
 	var nfe NotFoundError
 	if errors.As(err, &nfe) {
 		return nfe.IsNotFound()
+	}
+	// consider sql.ErrNoRows as not found too
+	if errors.Is(err, sql.ErrNoRows) {
+		return true
 	}
 	return false
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2,7 +2,6 @@ package fleet
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"io"
@@ -975,10 +974,6 @@ func IsNotFound(err error) bool {
 	var nfe NotFoundError
 	if errors.As(err, &nfe) {
 		return nfe.IsNotFound()
-	}
-	// consider sql.ErrNoRows as not found too
-	if errors.Is(err, sql.ErrNoRows) {
-		return true
 	}
 	return false
 }

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -2298,6 +2298,9 @@ func TestMDMAppleSetupAssistant(t *testing.T) {
 	ds.DeleteMDMAppleSetupAssistantFunc = func(ctx context.Context, teamID *uint) error {
 		return nil
 	}
+	ds.TeamFunc = func(ctx context.Context, id uint) (*fleet.Team, error) {
+		return &fleet.Team{ID: id}, nil
+	}
 
 	testCases := []struct {
 		name            string


### PR DESCRIPTION
#10994 (bullet 4)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
