### PR TITLE
Warn against deploying fleetdm/fleet:main directly

### DIFF
--- a/.github/workflows/dogfood-deploy.yml
+++ b/.github/workflows/dogfood-deploy.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       DOCKER_IMAGE:
-        description: 'The full name of the docker image to be deployed. (e.g. fleetdm/fleet:v4.30.0)'
+        description: 'The full name of the docker image to be deployed. (e.g. fleetdm/fleet:v4.30.0). Note: do not use fleetdm/fleet:main directly.  Use the short hash instead.  If pull-rate limited, try using the quay.io/fleetdm/fleet mirror.'
         required: true
 
 # This allows a subsequently queued workflow run to interrupt previous runs


### PR DESCRIPTION
Deploying `fleetdm/fleet:main` directly to dogfood has problems if migrations are needed and an image restarts.  This causes crashloops in the containers and leads to being rate-limited for pulls on dockerhub.  Warn against this and also suggest using quay.io as an alternative image location.