### PR TITLE
Documentation: Update testing docs with instructions how to run live QA Wolf e2e tests

### DIFF
--- a/docs/Contributing/Fleet-UI-Testing.md
+++ b/docs/Contributing/Fleet-UI-Testing.md
@@ -287,6 +287,8 @@ Our E2E layer tests all the systems of the software (frontend and backend) toget
 ensure the application works as intended. We have partnered with QA Wolf to cover these flows, and
 the E2E tests are written and maintained by them.
 
+The code is deployed and tested once daily on the testing instance. However, development may necessitate running E2E tests on demand. To run E2E tests live on a branch such as the `main` branch, developers can navigate to [Deploy Cloud Environments](https://github.com/fleetdm/confidential/actions/workflows/cloud-deploy.yml) in our [/confidential](https://github.com/fleetdm/confidential) repo's Actions and select "Run workflow".
+
 
 ### Tooling
 

--- a/docs/Contributing/Testing-and-local-development.md
+++ b/docs/Contributing/Testing-and-local-development.md
@@ -172,6 +172,8 @@ The code is deployed and tested once daily on the testing instance.
 QA Wolf manages any issues found from these tests and will raise github issues. Engineers should not
 have to worry about working with E2E testing code or raising issues themselves.
 
+However, development may necessitate running E2E tests on demand. To run E2E tests live on a branch such as the `main` branch, developers can navigate to [Deploy Cloud Environments](https://github.com/fleetdm/confidential/actions/workflows/cloud-deploy.yml) in our [/confidential](https://github.com/fleetdm/confidential) repo's Actions and select "Run workflow".
+
 For Fleet employees, if you would like access to the QA Wolf platform you can reach out in the [#help-engineering](https://fleetdm.slack.com/archives/C019WG4GH0A) slack channel.
 
 ### Preparation


### PR DESCRIPTION
## Description
- Add instructions how developers can run QA Wolf E2E tests live
- Per Zach Wasserman's [request](https://fleetdm.slack.com/archives/C019WG4GH0A/p1682441223729289?thread_ts=1682441188.356709&cid=C019WG4GH0A)