### PR TITLE
Convert remaining uses of set-output for Github Actions

### DIFF
--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -46,11 +46,11 @@ jobs:
     - id: gen
       run: |
         UUID=$(uuidgen)
-        echo "::set-output name=subdomain::fleet-test-$UUID"
-        echo "::set-output name=domain::fleet-test-$UUID.fleetuem.com"
-        echo "::set-output name=address::https://fleet-test-$UUID.fleetuem.com"
+        echo "subdomain=fleet-test-$UUID" >> $GITHUB_OUTPUT
+        echo "domain=fleet-test-$UUID.fleetuem.com" >> $GITHUB_OUTPUT
+        echo "address=https://fleet-test-$UUID.fleetuem.com" >> $GITHUB_OUTPUT
         ENROLL=$(uuidgen)
-        echo "::set-output name=enroll_secret::$ENROLL"
+        echo "enroll_secret=$ENROLL" >> $GITHUB_OUTPUT
 
   run-server:
     timeout-minutes: 60

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -143,7 +143,7 @@ jobs:
           sleep 5
         done
         TOKEN=$(cat ~/.fleet/config| grep token | awk '{ print $2 }')
-        echo "::set-output name=token::$TOKEN"
+        echo "token=$TOKEN" >> $GITHUB_OUTPUT
 
   orbit-macos:
     timeout-minutes: 15


### PR DESCRIPTION
This resolves #11293

Following on from #11282 this PR converts the remaining uses of `set-output` to the new method recommended by Github.