### PR TITLE
Add premium star to "issues" header on host details page

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -112,6 +112,7 @@ const HostDetailsPage = ({
     isGlobalAdmin = false,
     isGlobalObserver,
     isPremiumTier = false,
+    isSandboxMode,
     isOnlyObserver,
     filteredHostsPath,
   } = useContext(AppContext);
@@ -655,6 +656,7 @@ const HostDetailsPage = ({
           titleData={titleData}
           diskEncryption={hostDiskEncryption}
           isPremiumTier={isPremiumTier}
+          isSandboxMode={isSandboxMode}
           isOnlyObserver={isOnlyObserver}
           toggleOSPolicyModal={toggleOSPolicyModal}
           toggleMacSettingsModal={toggleMacSettingsModal}

--- a/frontend/pages/hosts/details/_styles.scss
+++ b/frontend/pages/hosts/details/_styles.scss
@@ -40,7 +40,7 @@
 
           .info-flex__data {
             display: flex;
-            gap: 4px;
+            gap: $pad-xsmall;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -101,7 +101,7 @@ const HostSummary = ({
   const renderIssues = () => (
     <div className="info-flex__item info-flex__item--title">
       <span className="info-flex__header">
-        {isSandboxMode && <PremiumFeatureIconWithTooltip />}Issues
+        Issues{isSandboxMode && <PremiumFeatureIconWithTooltip />}
       </span>
       <span className="info-flex__data">
         <span

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -11,6 +11,7 @@ import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 import StatusIndicator from "components/StatusIndicator";
 import { IHostMacMdmProfile } from "interfaces/mdm";
 import getHostStatusTooltipText from "pages/hosts/helpers";
+import PremiumFeatureIconWithTooltip from "components/PremiumFeatureIconWithTooltip";
 import IssueIcon from "../../../../../../assets/images/icon-issue-fleet-black-50-16x16@2x.png";
 import MacSettingsIndicator from "./MacSettingsIndicator";
 import HostSummaryIndicator from "./HostSummaryIndicator";
@@ -99,7 +100,9 @@ const HostSummary = ({
 
   const renderIssues = () => (
     <div className="info-flex__item info-flex__item--title">
-      <span className="info-flex__header">Issues</span>
+      <span className="info-flex__header">
+        {isSandboxMode && <PremiumFeatureIconWithTooltip />}Issues
+      </span>
       <span className="info-flex__data">
         <span
           className="host-issue tooltip tooltip__tooltip-icon"
@@ -241,7 +244,7 @@ const HostSummary = ({
   );
 
   return (
-    <>
+    <div className={baseClass}>
       <div className="header title">
         <div className="title__inner">
           <div className="display-name-container">
@@ -263,7 +266,7 @@ const HostSummary = ({
       <div className="section title">
         <div className="title__inner">{renderSummary()}</div>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -27,6 +27,7 @@ interface IHostSummaryProps {
   titleData: any; // TODO: create interfaces for this and use consistently across host pages and related helpers
   diskEncryption?: IHostDiskEncryptionProps;
   isPremiumTier?: boolean;
+  isSandboxMode?: boolean;
   isOnlyObserver?: boolean;
   toggleOSPolicyModal?: () => void;
   toggleMacSettingsModal?: () => void;
@@ -45,6 +46,7 @@ const HostSummary = ({
   titleData,
   diskEncryption,
   isPremiumTier,
+  isSandboxMode = false,
   isOnlyObserver,
   toggleOSPolicyModal,
   toggleMacSettingsModal,
@@ -154,7 +156,7 @@ const HostSummary = ({
           />
         </div>
 
-        {titleData.issues?.total_issues_count > 0 &&
+        {(titleData.issues?.total_issues_count > 0 || isSandboxMode) &&
           isPremiumTier &&
           renderIssues()}
 

--- a/frontend/pages/hosts/details/cards/HostSummary/_styles.scss
+++ b/frontend/pages/hosts/details/cards/HostSummary/_styles.scss
@@ -3,10 +3,11 @@
     &__header {
       display: flex;
       align-items: center;
+      gap: $pad-xxsmall;
+      max-height: 20px;
       .premium-icon-tip {
-        position: absolute;
-        top: 256px;
-        left: 148px;
+        position: relative;
+        top: 3px;
       }
     }
   }

--- a/frontend/pages/hosts/details/cards/HostSummary/_styles.scss
+++ b/frontend/pages/hosts/details/cards/HostSummary/_styles.scss
@@ -1,0 +1,13 @@
+.host-summary {
+  .info-flex {
+    &__header {
+      display: flex;
+      align-items: center;
+      .premium-icon-tip {
+        position: absolute;
+        top: 256px;
+        left: 148px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Addresses #10823 
- also displays the 'issues' data, even when no issues are present, to show it to potential customers using sandbox
![Screenshot 2023-04-26 at 11 50 48 AM](https://user-images.githubusercontent.com/61553566/234675410-d3a8ab0a-1d37-4cee-acd4-041ead0de346.png)


## Checklist for submitter
- [x] Manual QA for all new/changed functionality