### PR TITLE
fix firehose addon take 2

### DIFF
--- a/terraform/addons/byo-firehose-logging-destination/target-account/iam.tf
+++ b/terraform/addons/byo-firehose-logging-destination/target-account/iam.tf
@@ -35,11 +35,11 @@ data "aws_iam_policy_document" "firehose" {
 
 }
 
-resource "aws_iam_policy" "fleet-firehose" {
+resource "aws_iam_policy" "fleet_firehose" {
   policy = data.aws_iam_policy_document.firehose.json
 }
 
-resource "aws_iam_policy_attachment" "fleet-firehose" {
-  name       = aws_iam_role.fleet_role.name
-  policy_arn = aws_iam_policy.fleet-firehose.arn
+resource "aws_iam_role_policy_attachment" "fleet_firehose" {
+  policy_arn = aws_iam_policy.fleet_firehose.arn
+  role       = aws_iam_role.fleet_role.name
 }


### PR DESCRIPTION
rename aws_iam_policy and aws_iam_policy_attachment resources to use underscore instead of hyphen in their names. Also, change aws_iam_policy_attachment to aws_iam_role_policy_attachment to match the correct resource type.
