### PR TITLE
Add premium feature icon to premium activities

### DIFF
--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -491,6 +491,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
       <ActivityFeed
         setShowActivityFeedTitle={setShowActivityFeedTitle}
         isPremiumTier={isPremiumTier || false}
+        isSandboxMode={isSandboxMode}
       />
     ),
   });

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tsx
@@ -20,6 +20,7 @@ const baseClass = "activity-feed";
 interface IActvityCardProps {
   setShowActivityFeedTitle: (showActivityFeedTitle: boolean) => void;
   isPremiumTier: boolean;
+  isSandboxMode?: boolean;
 }
 
 const DEFAULT_PAGE_SIZE = 8;
@@ -27,6 +28,7 @@ const DEFAULT_PAGE_SIZE = 8;
 const ActivityFeed = ({
   setShowActivityFeedTitle,
   isPremiumTier,
+  isSandboxMode = false,
 }: IActvityCardProps): JSX.Element => {
   const [pageIndex, setPageIndex] = useState(0);
   const [showShowQueryModal, setShowShowQueryModal] = useState(false);
@@ -115,6 +117,7 @@ const ActivityFeed = ({
               <ActivityItem
                 activity={activity}
                 isPremiumTier={isPremiumTier}
+                isSandboxMode={isSandboxMode}
                 onDetailsClick={handleDetailsClick}
                 key={activity.id}
               />

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -9,8 +9,20 @@ import Avatar from "components/Avatar";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon";
 import ReactTooltip from "react-tooltip";
+import PremiumFeatureIconWithTooltip from "components/PremiumFeatureIconWithTooltip";
 
 const baseClass = "activity-item";
+
+const PREMIUM_ACTIVITIES = new Set([
+  "created_team",
+  "deleted_team",
+  "applied_spec_team",
+  "changed_user_team_role",
+  "deleted_user_team_role",
+  "read_host_disk_encryption_key",
+  "enabled_macos_disk_encryption",
+  "disabled_macos_disk_encryption",
+]);
 
 const getProfileMessageSuffix = (
   isPremiumTier: boolean,
@@ -499,6 +511,7 @@ const getDetail = (
 interface IActivityItemProps {
   activity: IActivity;
   isPremiumTier: boolean;
+  isSandboxMode?: boolean;
 
   /** A handler for handling clicking on the details of an activity. Not all
    * activites have more details so this is optional. An example of additonal
@@ -510,6 +523,7 @@ interface IActivityItemProps {
 const ActivityItem = ({
   activity,
   isPremiumTier,
+  isSandboxMode = false,
   onDetailsClick = noop,
 }: IActivityItemProps) => {
   const { actor_email } = activity;
@@ -518,6 +532,8 @@ const ActivityItem = ({
     : { gravatar_url: DEFAULT_GRAVATAR_LINK };
 
   const activityCreatedAt = new Date(activity.created_at);
+  const indicatePremiumFeature =
+    isSandboxMode && PREMIUM_ACTIVITIES.has(activity.type);
 
   return (
     <div className={baseClass}>
@@ -529,6 +545,7 @@ const ActivityItem = ({
       />
       <div className={`${baseClass}__details`}>
         <p>
+          {indicatePremiumFeature && <PremiumFeatureIconWithTooltip />}
           <span className={`${baseClass}__details-topline`}>
             {activity.type === ActivityType.UserLoggedIn ? (
               <b>{activity.actor_email} </b>

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/_styles.scss
@@ -30,6 +30,12 @@
   &__details {
     padding-left: $pad-large;
 
+    .premium-icon-tip {
+      position: relative;
+      top: 4px;
+      padding-right: $pad-xsmall;
+    }
+
     p {
       margin: 0;
       line-height: 16px;


### PR DESCRIPTION
## Addresses #10822
![Screenshot 2023-04-26 at 8 21 18 PM](https://user-images.githubusercontent.com/61553566/234751878-2abb52a4-ccc6-428f-a863-7d60de4b182b.png)
- Issue said there are 21 premium-only activities – 8 are covered here. Once identified, the others can be trivially added to this class by adding their name to the `ActivityItem.tsx` > `PREMIUM_ACTIVITIES` set
- [x] Manual QA for all new/changed functionality