### PR TITLE
ensure file permissions of the nudge config file are consistent

### DIFF
--- a/orbit/changes/11218-nudge-config-permissinos
+++ b/orbit/changes/11218-nudge-config-permissinos
@@ -1,0 +1,1 @@
+* Fixed an issue preventing Nudge to read the configuration file delivered by Fleet on some installations. This only affects you if Nudge was enabled and configured on a host using Orbit v1.8.0

--- a/orbit/pkg/update/nudge.go
+++ b/orbit/pkg/update/nudge.go
@@ -17,6 +17,7 @@ import (
 )
 
 const nudgeConfigFile = "nudge-config.json"
+const nudgeConfigFileMode = os.FileMode(constant.DefaultWorldReadableFileMode)
 
 // NudgeConfigFetcher is a kind of middleware that wraps an OrbitConfigFetcher and a Runner.
 // It checks the config supplied by the wrapped OrbitConfigFetcher to detects whether the Fleet
@@ -133,6 +134,17 @@ func (n *NudgeConfigFetcher) configure(nudgeCfg fleet.NudgeConfig) error {
 			return writeConfig()
 		}
 		return err
+	}
+
+	// ensure the config file has the right permissions, a call to
+	// WriteFile preserves existing permissions if the file already exists,
+	// and previous versions of orbit set the permissions of this file to
+	// constant.DefaultFileMode.
+	if fileInfo.Mode() != nudgeConfigFileMode {
+		log.Info().Msgf("%s config file had wrong permissions (%v) setting permissions to %v", cfgFile, fileInfo.Mode(), nudgeConfigFileMode)
+		if err := os.Chmod(cfgFile, nudgeConfigFileMode); err != nil {
+			return fmt.Errorf("ensuring permissions of config file, chmod %q: %w", cfgFile, err)
+		}
 	}
 
 	// this not only an optimization, but mostly a safeguard: if the file


### PR DESCRIPTION
For #11218, In the initial implementation of the feature, we used to launch Nudge as a root, so setting the permissions of the config file to 0600 was okay.

As part of the fix for #10044, we now launch Nudge as the current user (which is also recommended in the Nudge wiki), but previous installations of the beta version (probably only Fleeties using Dogfood) still have the configuration file with restrictive permissions, so Nudge wasn't able to read the config when launched as a user.

This is kind of hidden because `os.WriteFile` takes a permission arugment, but it's only used if it's writing the file for the first time.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
