### PR TITLE
Fleet UI: Hide reset sessions from current user dropdown

### DIFF
--- a/changes/11340-cannot-reset-self
+++ b/changes/11340-cannot-reset-self
@@ -1,0 +1,1 @@
+- Hide reset sessions in user dropdown for current user

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
@@ -258,6 +258,14 @@ const generateActionDropdownOptions = (
       value: "delete",
     },
   ];
+
+  if (isCurrentUser) {
+    // remove "Reset sessions" from dropdownOptions
+    dropdownOptions = dropdownOptions.filter(
+      (option) => option.label !== "Reset sessions"
+    );
+  }
+
   if (isSsoEnabled) {
     // remove "Require password reset" from dropdownOptions
     dropdownOptions = dropdownOptions.filter(


### PR DESCRIPTION
## Issue
Cerra #11340 

## Description
- Hide reset sessions in user dropdown for current user (which kicks the current user out of the UI)

## Screenshot
<img width="1498" alt="Screenshot 2023-04-27 at 10 40 57 AM" src="https://user-images.githubusercontent.com/71795832/234898266-d5d1c1f7-254e-4cd9-ac23-75e853045f4e.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
