### PR TITLE
add os-setup-preview and reuse empty table for empty state 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist
 assets/bundle*.*
 assets/*@*.svg
 assets/*@*.png
+assets/*@*.gif
 assets/*@*.eot
 assets/*@*.woff
 assets/*@*.woff2

--- a/frontend/pages/ManageControlsPage/MacOSSetup/MacOSSetup.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSetup/MacOSSetup.tsx
@@ -7,6 +7,7 @@ import { AppContext } from "context/app";
 import SideNav from "pages/admin/components/SideNav";
 import Button from "components/buttons/Button/Button";
 import PremiumFeatureMessage from "components/PremiumFeatureMessage";
+import EmptyTable from "components/EmptyTable";
 
 import MAC_OS_SETUP_NAV_ITEMS from "./MacOSSetupNavItems";
 
@@ -18,17 +19,19 @@ interface ISetupEmptyState {
 
 const SetupEmptyState = ({ router }: ISetupEmptyState) => {
   const onClickEmptyConnect = () => {
-    router.push(PATHS.CONTROLS_MAC_SETTINGS);
+    router.push(PATHS.ADMIN_INTEGRATIONS_MDM);
   };
 
   return (
-    <div className={`${baseClass}__empty-state`}>
-      <h2>Setup experience for macOS hosts</h2>
-      <p>Connect Fleet to the Apple Business Manager to get started.</p>
-      <Button variant="brand" onClick={onClickEmptyConnect}>
-        Connect
-      </Button>
-    </div>
+    <EmptyTable
+      header="Setup experience for macOS hosts"
+      info="Connect Fleet to the Apple Business Manager to get started."
+      primaryButton={
+        <Button variant="brand" onClick={onClickEmptyConnect}>
+          Connect
+        </Button>
+      }
+    />
   );
 };
 
@@ -56,7 +59,6 @@ const MacOSSetup = ({
 
   const CurrentCard = currentFormSection.Card;
 
-  // TODO: uncomment when API done
   if (!config?.mdm.apple_bm_enabled_and_configured) {
     return <SetupEmptyState router={router} />;
   }

--- a/frontend/pages/ManageControlsPage/MacOSSetup/cards/BootstrapPackage/components/BootstrapPackagePreview/BootstrapPackagePreview.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSetup/cards/BootstrapPackage/components/BootstrapPackagePreview/BootstrapPackagePreview.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import OsSetupPreview from "../../../../../../../../assets/images/os-setup-preview.gif";
+
 const baseClass = "bootstrap-package-preview";
 
 const BootstrapPackagePreview = () => {
@@ -8,8 +10,8 @@ const BootstrapPackagePreview = () => {
       <h2>End user experience</h2>
       <p>
         The bootstrap package is automatically installed after the end user
-        authenticates and agrees to the EULA during the Remote Management pane
-        in macOS Setup Assistant.
+        authenticates and agrees to the EULA during the <b>Remote Management</b>{" "}
+        pane in macOS Setup Assistant.
       </p>
       <p>
         The end user is allowed to continue to the next setup pane before the
@@ -18,7 +20,7 @@ const BootstrapPackagePreview = () => {
       <p>The package isn&apos;t installed on hosts that already enrolled.</p>
       <img
         className={`${baseClass}__preview-img`}
-        src={"test"}
+        src={OsSetupPreview}
         alt="OS setup preview"
       />
     </div>

--- a/frontend/pages/ManageControlsPage/MacOSSetup/cards/BootstrapPackage/components/BootstrapPackagePreview/_styles.scss
+++ b/frontend/pages/ManageControlsPage/MacOSSetup/cards/BootstrapPackage/components/BootstrapPackagePreview/_styles.scss
@@ -13,7 +13,6 @@
     margin-top: $pad-xxlarge;
     width: 100%;
     display: block;
-    max-width: 560px;
     margin: 40px auto 0;
   }
 }

--- a/frontend/typings/index.d.ts
+++ b/frontend/typings/index.d.ts
@@ -11,3 +11,8 @@ declare module "*.svg" {
   const value: string;
   export = value;
 }
+
+declare module "*.gif" {
+  const value: string;
+  export = value;
+}


### PR DESCRIPTION
relates to #10935

This adds the os setup gif and also reuses the EmptyTable component for the empty state on the mac setup page.

![image](https://user-images.githubusercontent.com/1153709/234918995-10529140-f5ef-4808-8288-4b2dac30579a.png)

- [x] Manual QA for all new/changed functionality
