### PR TITLE
Update calendly link

### DIFF
--- a/website/views/pages/try-fleet/register.ejs
+++ b/website/views/pages/try-fleet/register.ejs
@@ -9,7 +9,7 @@
         The fastest way to test Fleet. Get up and running in minutes. Ready for production deployments? <a href="https://fleetdm.com/docs/deploying">Learn how to deploy Fleet</a>.
       </p>
       <div purpose="sandbox-mdm-note" class="d-flex flex-column">
-        <p class="mb-0">Interested in testing Fleet’s MDM capabilities? <a target="_blank" href="https://calendly.com/d/ykd-hqy-p7t/chat-with-fleet">Meet with us to learn more</a></p>
+        <p class="mb-0">Interested in testing Fleet’s MDM capabilities? <a target="_blank" href="https://calendly.com/fleetdm/demo?utm_source=sandbox+registration">Meet with us to learn more</a></p>
       </div>
       <div class="pt-3">
         <ajax-form :handle-submitting="handleSubmittingRegisterForm" :syncing.sync="syncing" :cloud-error.sync="cloudError" :form-errors.sync="formErrors" :form-data="formData" :form-rules="formRules" @submitted="submittedRegisterForm()">


### PR DESCRIPTION
Updating calendly link listed here:
https://fleetdm.com/try-fleet/register
![image](https://user-images.githubusercontent.com/89049099/234967794-6dc3fc9e-a6b8-498b-82b6-7a2d3717aa11.png)

This should set up meetings with SDR's instead of AE's

