### PR TITLE
UI: Fix a bug in routing index for sandboxMode

### DIFF
--- a/frontend/pages/admin/OrgSettingsPage/OrgSettingsPage.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/OrgSettingsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useState } from "react";
-import { Params } from "react-router/lib/Router";
+import { InjectedRouter, Params } from "react-router/lib/Router";
 import { useQuery } from "react-query";
 import { useErrorHandler } from "react-error-boundary";
 
@@ -10,22 +10,31 @@ import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import deepDifference from "utilities/deep_difference";
 import Spinner from "components/Spinner";
+import paths from "router/paths";
 
 import SideNav from "../components/SideNav";
 import ORG_SETTINGS_NAV_ITEMS from "./OrgSettingsNavItems";
 
 interface IOrgSettingsPageProps {
   params: Params;
+  router: InjectedRouter; // v3
 }
 
 export const baseClass = "org-settings";
 
-const OrgSettingsPage = ({ params }: IOrgSettingsPageProps) => {
+const OrgSettingsPage = ({ params, router }: IOrgSettingsPageProps) => {
   const { section } = params;
   const DEFAULT_SETTINGS_SECTION = ORG_SETTINGS_NAV_ITEMS[0];
 
   const [isUpdatingSettings, setIsUpdatingSettings] = useState(false);
-  const { isFreeTier, isPremiumTier, setConfig } = useContext(AppContext);
+  const { isFreeTier, isPremiumTier, setConfig, isSandboxMode } = useContext(
+    AppContext
+  );
+
+  if (isSandboxMode) {
+    // redirect to Integrations page in sandbox mode
+    router.push(paths.ADMIN_INTEGRATIONS);
+  }
   const { renderFlash } = useContext(NotificationContext);
   const handlePageError = useErrorHandler();
 

--- a/frontend/pages/admin/SettingsWrapper/SettingsWrapper.tsx
+++ b/frontend/pages/admin/SettingsWrapper/SettingsWrapper.tsx
@@ -34,7 +34,7 @@ const SettingsWrapper = ({
   const settingsSubNav: ISettingSubNavItem[] = [
     {
       name: "Organization settings",
-      pathname: PATHS.ADMIN_SETTINGS,
+      pathname: PATHS.ADMIN_SETTINGS_INFO,
       exclude: isSandboxMode,
     },
     {

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -55,7 +55,7 @@ import MacOSSetup from "pages/ManageControlsPage/MacOSSetup/MacOSSetup";
 
 import PATHS from "router/paths";
 
-import AppProvider, { AppContext } from "context/app";
+import AppProvider from "context/app";
 import RoutingProvider from "context/routing";
 
 import AuthGlobalAdminRoutes from "./components/AuthGlobalAdminRoutes";
@@ -112,12 +112,10 @@ const routes = (
             <Route path="windows" component={DashboardPage} />
           </Route>
           <Route path="settings" component={AuthAnyAdminRoutes}>
-            <IndexRedirect to="integrations" />
+            <IndexRedirect to="organization/info" />
             <Route component={SettingsWrapper}>
               <Route component={AuthGlobalAdminRoutes}>
-                <Route component={ExcludeInSandboxRoutes}>
-                  <Route path="organization" component={OrgSettingsPage} />
-                </Route>
+                <Route path="organization" component={OrgSettingsPage} />
                 <Route
                   path="organization/:section"
                   component={OrgSettingsPage}

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -68,7 +68,6 @@ import AuthAnyMaintainerAdminObserverPlusRoutes from "./components/AuthAnyMainta
 import PremiumRoutes from "./components/PremiumRoutes";
 import ExcludeInSandboxRoutes from "./components/ExcludeInSandboxRoutes";
 
-const isSandboxMode = { AppContext };
 interface IAppWrapperProps {
   children: JSX.Element;
 }
@@ -81,7 +80,6 @@ const AppWrapper = ({ children }: IAppWrapperProps) => (
     </RoutingProvider>
   </AppProvider>
 );
-
 const routes = (
   <Router history={browserHistory}>
     <Route path={PATHS.ROOT} component={AppWrapper}>
@@ -114,9 +112,7 @@ const routes = (
             <Route path="windows" component={DashboardPage} />
           </Route>
           <Route path="settings" component={AuthAnyAdminRoutes}>
-            <IndexRedirect
-              to={isSandboxMode ? "integrations" : "organization"}
-            />
+            <IndexRedirect to="integrations" />
             <Route component={SettingsWrapper}>
               <Route component={AuthGlobalAdminRoutes}>
                 <Route component={ExcludeInSandboxRoutes}>


### PR DESCRIPTION
## Addresses #11394 (and dup #11397)

Lower sandbox reroute logic from router index into OrgSettingsPage, where the value of AppContext.isSandboxMode can be correctly read

https://www.loom.com/share/8f3eb546a58d4c93a268b4d02b42c54c

## Checklist for submitter
- [x] Manual QA for all new/changed functionality