### PR TITLE
UI: Exclude 'Manage users' menu item in sandbox mode

### DIFF
--- a/frontend/components/top_nav/SiteTopNav/SiteTopNav.tsx
+++ b/frontend/components/top_nav/SiteTopNav/SiteTopNav.tsx
@@ -87,6 +87,7 @@ const SiteTopNav = ({
     isAnyTeamMaintainer,
     isNoAccess,
     isMdmEnabledAndConfigured, // TODO: confirm
+    isSandboxMode,
   } = useContext(AppContext);
 
   const isActiveDetailPage = isDetailPage(currentPath);
@@ -213,6 +214,7 @@ const SiteTopNav = ({
           currentUser={currentUser}
           isAnyTeamAdmin={isAnyTeamAdmin}
           isGlobalAdmin={isGlobalAdmin}
+          isSandboxMode={isSandboxMode}
         />
       </div>
     );

--- a/frontend/components/top_nav/UserMenu/UserMenu.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tsx
@@ -17,6 +17,7 @@ interface IUserMenuProps {
   isAnyTeamAdmin: boolean | undefined;
   isGlobalAdmin: boolean | undefined;
   currentUser: IUser;
+  isSandboxMode?: boolean;
 }
 
 const UserMenu = ({
@@ -25,6 +26,7 @@ const UserMenu = ({
   isAnyTeamAdmin,
   isGlobalAdmin,
   currentUser,
+  isSandboxMode = false,
 }: IUserMenuProps): JSX.Element => {
   const accountNavigate = onNavItemClick(PATHS.USER_SETTINGS);
   const dropdownItems = [
@@ -42,7 +44,7 @@ const UserMenu = ({
     },
   ];
 
-  if (isGlobalAdmin) {
+  if (isGlobalAdmin && !isSandboxMode) {
     const manageUsersNavigate = onNavItemClick(PATHS.ADMIN_USERS);
 
     const manageUserNavItem = {


### PR DESCRIPTION
## Addresses #10819
Exclude the "Manage users" menu option in sandbox mode.

- [x] Manual QA for all new/changed functionality