### PR TITLE
Update 'install go' Github Actions to use tag as it uses deprecated commands

### DIFF
--- a/.github/workflows/build-and-push-fleetctl-docker.yml
+++ b/.github/workflows/build-and-push-fleetctl-docker.yml
@@ -39,7 +39,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: 1.19.8
 

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: 1.19.8
 

--- a/.github/workflows/build-orbit.yaml
+++ b/.github/workflows/build-orbit.yaml
@@ -41,7 +41,7 @@ jobs:
           rm certificate.p12
 
       - name: Set up Go
-        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: 1.19.4
 

--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -54,7 +54,7 @@ jobs:
 
     # Install the right version of Go for the Golang child process that we are currently using for CSR signing
     - name: Set up Go
-      uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: 1.19
 

--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
 
     - name: Install Go
-      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -151,7 +151,7 @@ jobs:
     steps:
 
     - name: Install Go
-      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -190,7 +190,7 @@ jobs:
     steps:
 
     - name: Install Go
-      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -233,7 +233,7 @@ jobs:
     steps:
 
     - name: Install Go
-      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/fleetctl-preview-latest.yml
+++ b/.github/workflows/fleetctl-preview-latest.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
 
     - name: Install Go
-      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/generate-desktop-targets.yml
+++ b/.github/workflows/generate-desktop-targets.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
 
       - name: Install Go
-        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: '^1.19.8'
 
@@ -83,7 +83,7 @@ jobs:
     steps:
 
       - name: Install Go
-        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: '^1.19.8'
 
@@ -106,7 +106,7 @@ jobs:
     steps:
 
       - name: Install Go
-        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: '^1.19.8'
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2
 
       - name: Install Go
-        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -37,7 +37,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: ${{ vars.GO_VERSION }}
 

--- a/.github/workflows/goreleaser-orbit.yaml
+++ b/.github/workflows/goreleaser-orbit.yaml
@@ -49,7 +49,7 @@ jobs:
           rm certificate.p12
 
       - name: Set up Go
-        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: ${{ vars.GO_VERSION }}
 
@@ -83,7 +83,7 @@ jobs:
         run: git tag $(echo ${{ github.ref_name }} | sed -e 's/orbit-//g') && git tag -d ${{ github.ref_name }}
 
       - name: Set up Go
-        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: ${{ vars.GO_VERSION }}
 
@@ -111,7 +111,7 @@ jobs:
         run: git tag $(echo ${{ github.ref_name }} | sed -e 's/orbit-//g') && git tag -d ${{ github.ref_name }}
 
       - name: Set up Go
-        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: ${{ vars.GO_VERSION }}
 

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -45,7 +45,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: 1.19.8
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -211,7 +211,7 @@ jobs:
         fleetctl config set --address ${{ needs.gen.outputs.address }} --token ${{ needs.login.outputs.token }}
 
     - name: Install Go
-      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: '^1.19.1'
 

--- a/.github/workflows/test-db-changes.yml
+++ b/.github/workflows/test-db-changes.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # v2
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: '^1.19.8'
     - name: Checkout Code

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/test-native-tooling-packaging.yml
+++ b/.github/workflows/test-native-tooling-packaging.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -69,7 +69,7 @@ jobs:
       run: docker pull fleetdm/wix:latest &
 
     - name: Install Go
-      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/test-yml-specs.yml
+++ b/.github/workflows/test-yml-specs.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f # v2
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 


### PR DESCRIPTION
At the moment, in Github Actions, when a job has `uses: actions/setup-go` it uses a specific commit from that repo.

In that commit, it used `set-output` somewhere, which is now deprecated and will be disabled within the next month or so.

See here for more information: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR changes every instance where `actions/setup-go@...` was used and replaces it with release `v2.1.3`. [From the release notes](https://github.com/actions/setup-go/releases/tag/v2.1.3):

> Updated communication with runner to use environment files rather then workflow commands

Which is what the above Github blog recommends doing.

---

Addationally, the latest version of this Github Action is [`v4.0.0`](https://github.com/actions/setup-go/releases/tag/v4.0.0), which you may want to update to in the future.

