### PR TITLE
fix host details page not showing cause missing mac_settings and mac_setup

### DIFF
--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -118,8 +118,8 @@ export interface IHostMdmData {
   server_url: string | null;
   id?: number;
   profiles: IHostMacMdmProfile[] | null;
-  macos_settings: IMdmMacOsSettings;
-  macos_setup: IMdmMacOsSetup;
+  macos_settings?: IMdmMacOsSettings;
+  macos_setup?: IMdmMacOsSetup;
 }
 
 export interface IMunkiIssue {

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -247,9 +247,9 @@ const DeviceUserPage = ({
   );
 
   const bootstrapPackageData = {
-    status: host?.mdm.macos_setup.bootstrap_package_status,
-    details: host?.mdm.macos_setup.details,
-    name: host?.mdm.macos_setup.bootstrap_package_name,
+    status: host?.mdm.macos_setup?.bootstrap_package_status,
+    details: host?.mdm.macos_setup?.details,
+    name: host?.mdm.macos_setup?.bootstrap_package_name,
   };
 
   const toggleMacSettingsModal = useCallback(() => {
@@ -324,12 +324,12 @@ const DeviceUserPage = ({
 
     const showDiskEncryptionLogoutRestart =
       diskEncryptionBannersEnabled &&
-      host?.mdm.macos_settings.disk_encryption === "action_required" &&
-      host?.mdm.macos_settings.action_required === "log_out";
+      host?.mdm.macos_settings?.disk_encryption === "action_required" &&
+      host?.mdm.macos_settings?.action_required === "log_out";
     const showDiskEncryptionKeyResetRequired =
       diskEncryptionBannersEnabled &&
-      host?.mdm.macos_settings.disk_encryption === "action_required" &&
-      host?.mdm.macos_settings.action_required === "rotate_key";
+      host?.mdm.macos_settings?.disk_encryption === "action_required" &&
+      host?.mdm.macos_settings?.action_required === "rotate_key";
 
     return (
       <div className="fleet-desktop-wrapper">

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -633,7 +633,7 @@ const HostDetailsPage = ({
   const showDiskEncryptionUserActionRequired =
     config?.mdm.enabled_and_configured &&
     host?.mdm.name === "Fleet" &&
-    host?.mdm.macos_settings.disk_encryption === "action_required";
+    host?.mdm.macos_settings?.disk_encryption === "action_required";
 
   /*  Context team id might be different that host's team id
   Observer plus must be checked against host's team id  */
@@ -653,9 +653,9 @@ const HostDetailsPage = ({
     !isHostsTeamObserver;
 
   const bootstrapPackageData = {
-    status: host?.mdm.macos_setup.bootstrap_package_status,
-    details: host?.mdm.macos_setup.details,
-    name: host?.mdm.macos_setup.bootstrap_package_name,
+    status: host?.mdm.macos_setup?.bootstrap_package_status,
+    details: host?.mdm.macos_setup?.details,
+    name: host?.mdm.macos_setup?.bootstrap_package_name,
   };
 
   return (


### PR DESCRIPTION
relates to #11406 and #11398

Fixes an issue where the host details and my device pages were not showing an error because of missing mdm data.

- [x] Manual QA for all new/changed functionality