### PR TITLE
Unreleased bug: Fix inherited policy API call bug

### DIFF
--- a/frontend/pages/policies/PolicyPage/PolicyPage.tsx
+++ b/frontend/pages/policies/PolicyPage/PolicyPage.tsx
@@ -145,10 +145,7 @@ const PolicyPage = ({
     error: storedPolicyError,
   } = useQuery<IStoredPolicyResponse, Error, IPolicy>(
     ["policy", policyId],
-    () =>
-      teamIdForApi
-        ? teamPoliciesAPI.load(teamIdForApi, policyId as number)
-        : globalPoliciesAPI.load(policyId as number),
+    () => globalPoliciesAPI.load(policyId as number), // Note: Team members have access to policies through global API
     {
       enabled: isRouteOk && !!policyId, // Note: this justifies the number type assertions above
       refetchOnWindowFocus: false,


### PR DESCRIPTION
## Issue
Cerra #11396

## Description
- API call no longer using team id (not required) which was causing a bug for inherited policies

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

(No change file as this is unreleased)
~~- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.~~
- [x] Manual QA for all new/changed functionality
