### PR TITLE
UI: Enforce normal text styling in premium icon tooltips

### DIFF
--- a/frontend/components/PremiumFeatureIconWithTooltip/_styles.scss
+++ b/frontend/components/PremiumFeatureIconWithTooltip/_styles.scss
@@ -1,4 +1,5 @@
 .premium-icon-tip {
+  font-style: normal;
   font-size: $x-small;
   font-weight: normal;
 }


### PR DESCRIPTION
## Addresses [this italicization issue](https://github.com/fleetdm/fleet/issues/10824#issuecomment-1527750889)
<img width="222" alt="Screenshot 2023-04-28 at 12 01 19 PM" src="https://user-images.githubusercontent.com/61553566/235231898-13d76e87-4a2c-4fb1-b563-ecec87dc4957.png">

- [x] Manual QA for all new/changed functionality