### PR TITLE
Fleet UI bug fix: Show software card with no vulnerabilities

### DIFF
--- a/changes/11413-dashboard-vuln-card-bug
+++ b/changes/11413-dashboard-vuln-card-bug
@@ -1,0 +1,1 @@
+- Bug fix: If there is software but no vulnerabilities, still show software card on dashboard when clicking on vulnerabilities

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -305,17 +305,9 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
     {
       enabled: isRouteOk && !software?.software,
       keepPreviousData: true,
-      staleTime: 30000, // stale time can be adjusted if fresher data is desired based on software inventory interval
       refetchOnWindowFocus: false,
       retry: 1,
       select: (data) => data.count,
-      onSuccess: (data) => {
-        if (data > 0) {
-          setShowSoftwareCard(true);
-        } else {
-          setShowSoftwareCard(false);
-        }
-      },
     }
   );
 
@@ -392,6 +384,12 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
       );
     },
   });
+
+  useEffect(() => {
+    softwareCount && softwareCount > 0
+      ? setShowSoftwareCard(true)
+      : setShowSoftwareCard(false);
+  }, [softwareCount]);
 
   // Sets selected platform label id for links to filtered manage host page
   useEffect(() => {


### PR DESCRIPTION
## Issue
Cerra #11413

## Description
- Software card is always shown if software count (without vulnerabilities) is > 0
- Ensure that software count is being called on every team change and setShowSoftwareCard is being set on every team change

## Screenshot of fix
<img width="885" alt="Screenshot 2023-04-28 at 3 28 16 PM" src="https://user-images.githubusercontent.com/71795832/235236333-650fdc91-7c26-4d95-904f-4c643d981a5e.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

