### PR TITLE
Fix permissions on GitOps user for searching hosts or count targets

### DIFF
--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -415,11 +415,18 @@ allow {
 # Targets
 ##
 
-# All users can read targets (filtered appropriately based on their
-# teams/roles).
+# Global admin, maintainer, observer_plus and observer can read targets.
 allow {
-  not is_null(subject)
   object.type == "target"
+  subject.global_role == [admin, maintainer, observer_plus, observer][_]
+  action == read
+}
+
+# Team admin, maintainer, observer_plus and observer can read global config.
+allow {
+  object.type == "target"
+  # If role is admin, maintainer, observer_plus or observer on any team.
+  team_role(subject, subject.teams[_].id) == [admin, maintainer, observer_plus, observer][_]
   action == read
 }
 

--- a/server/authz/policy_test.go
+++ b/server/authz/policy_test.go
@@ -910,13 +910,18 @@ func TestAuthorizeTarget(t *testing.T) {
 	runTestCases(t, []authTestCase{
 		{user: nil, object: target, action: read, allow: false},
 
-		// Everyone logged in can retrieve target (filter appropriately for their
-		// access)
-		{user: test.UserNoRoles, object: target, action: read, allow: true},
+		{user: test.UserNoRoles, object: target, action: read, allow: false},
 		{user: test.UserAdmin, object: target, action: read, allow: true},
 		{user: test.UserMaintainer, object: target, action: read, allow: true},
 		{user: test.UserObserver, object: target, action: read, allow: true},
 		{user: test.UserObserverPlus, object: target, action: read, allow: true},
+		{user: test.UserGitOps, object: target, action: read, allow: false},
+
+		{user: test.UserTeamAdminTeam1, object: target, action: read, allow: true},
+		{user: test.UserTeamMaintainerTeam1, object: target, action: read, allow: true},
+		{user: test.UserTeamObserverTeam1, object: target, action: read, allow: true},
+		{user: test.UserTeamObserverPlusTeam1, object: target, action: read, allow: true},
+		{user: test.UserTeamGitOpsTeam1, object: target, action: read, allow: false},
 	})
 }
 

--- a/server/fleet/packs.go
+++ b/server/fleet/packs.go
@@ -169,13 +169,6 @@ type PackSpecQuery struct {
 	Denylist    *bool   `json:"denylist,omitempty"`
 }
 
-// PackTarget targets a pack to a host, label, or team.
-type PackTarget struct {
-	ID     uint `db:"id" json:"-"`
-	PackID uint `db:"pack_id" json:"-"`
-	Target
-}
-
 type PackStats struct {
 	PackID   uint   `json:"pack_id"`
 	PackName string `json:"pack_name"`

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -3153,6 +3153,22 @@ func (s *integrationEnterpriseTestSuite) TestGitOpsUserActions() {
 	// Attempt to get a carved file, should fail.
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/carves/%d", carveID), listCarvesRequest{}, http.StatusForbidden, &listCarvesResponse{})
 
+	// Attempt to search hosts, should fail.
+	s.DoJSON("POST", "/api/latest/fleet/targets", searchTargetsRequest{
+		MatchQuery: "foo",
+		QueryID:    &q1.ID,
+	}, http.StatusForbidden, &searchTargetsResponse{})
+
+	// Attempt to count target hosts, should fail.
+	s.DoJSON("POST", "/api/latest/fleet/targets/count", countTargetsRequest{
+		Selected: fleet.HostTargets{
+			HostIDs:  []uint{h1.ID},
+			LabelIDs: []uint{clr.Label.ID},
+			TeamIDs:  []uint{t1.ID},
+		},
+		QueryID: &q1.ID,
+	}, http.StatusForbidden, &countTargetsResponse{})
+
 	//
 	// Start running permission tests with user gitops2 (which is a GitOps use for team t1).
 	//
@@ -3331,6 +3347,22 @@ func (s *integrationEnterpriseTestSuite) TestGitOpsUserActions() {
 			},
 		},
 	}, http.StatusForbidden, &teamResponse{})
+
+	// Attempt to search hosts, should fail.
+	s.DoJSON("POST", "/api/latest/fleet/targets", searchTargetsRequest{
+		MatchQuery: "foo",
+		QueryID:    &q1.ID,
+	}, http.StatusForbidden, &searchTargetsResponse{})
+
+	// Attempt to count target hosts, should fail.
+	s.DoJSON("POST", "/api/latest/fleet/targets/count", countTargetsRequest{
+		Selected: fleet.HostTargets{
+			HostIDs:  []uint{h1.ID},
+			LabelIDs: []uint{clr.Label.ID},
+			TeamIDs:  []uint{t1.ID},
+		},
+		QueryID: &q1.ID,
+	}, http.StatusForbidden, &countTargetsResponse{})
 }
 
 func (s *integrationEnterpriseTestSuite) setTokenForTest(t *testing.T, email, password string) {


### PR DESCRIPTION
#11447

- ~[ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.~
- ~[ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~[ ] Documented any permissions changes~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
  - ~For Orbit and Fleet Desktop changes:~
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
