### PR TITLE
Amend GitOps permissions for the 4.31.0 release

### DIFF
--- a/docs/Using-Fleet/Permissions.md
+++ b/docs/Using-Fleet/Permissions.md
@@ -79,7 +79,7 @@ GitOps is an API-only and write-only role that can be used on CI/CD pipelines.
 | Edit [MDM settings](https://fleetdm.com/docs/using-fleet/mdm-macos-settings)                                                               |          |           |            | ✅     | ✅      |
 | Edit [MDM settings for teams](https://fleetdm.com/docs/using-fleet/mdm-macos-settings)                                                     |          |           |            | ✅     | ✅      |
 | View/download MDM macOS setup assistant\*                                                                                                  |          |           | ✅          | ✅     |        |
-| Edit/upload MDM macOS setup assistant\*                                                                                                    |          |           | ✅          | ✅     | ✅     |
+| Edit/upload MDM macOS setup assistant\*                                                                                                    |          |           | ✅          | ✅     |       |
 
 \* Applies only to Fleet Premium
 
@@ -136,7 +136,7 @@ Users that are members of multiple teams can be assigned different roles for eac
 | View results of MDM commands executed on macOS hosts enrolled in Fleet's MDM                                                     | ✅             | ✅              | ✅               | ✅          |             |
 | Edit [team MDM settings](https://fleetdm.com/docs/using-fleet/mdm-macos-settings)                                                |               |                |                 | ✅          | ✅           |
 | View/download MDM macOS setup assistant                                                                                          |               |                | ✅              | ✅          |              |
-| Edit/upload MDM macOS setup assistant                                                                                            |               |                | ✅              | ✅          | ✅           |
+| Edit/upload MDM macOS setup assistant                                                                                            |               |                | ✅              | ✅          |             |
 
 \* Applies only to [Fleet REST API](https://fleetdm.com/docs/using-fleet/rest-api)
 


### PR DESCRIPTION
Related to #8593

To not block the 4.31.0 release, we remove the ✅ from [Permissions.md](https://github.com/fleetdm/fleet/blob/main/docs/Using-Fleet/Permissions.md) and will work on adding such feature in https://github.com/fleetdm/fleet/issues/11449.

