### PR TITLE
Website: Increase self-service license dispenser host cap

### DIFF
--- a/website/assets/js/pages/customers/new-license.page.js
+++ b/website/assets/js/pages/customers/new-license.page.js
@@ -73,7 +73,7 @@ parasails.registerPage('new-license', {
       this.showQuotedPrice = true;
       this.quotedPrice = quote.quotedPrice;
       this.numberOfHostsQuoted = quote.numberOfHosts;
-      if(quote.numberOfHosts <= 100) {
+      if(quote.numberOfHosts <= 999) {
         this.formData.quoteId = quote.id;
         this.showBillingForm = true;
       }


### PR DESCRIPTION
Changes:
- Changed the self-service license dispenser cap from 100 hosts to 999 hosts.