### PR TITLE
Redirect old macos-settings route to new custom macos settings page, rather than disk encryption

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -349,7 +349,7 @@ module.exports.routes = {
   'GET /handbook/security/security-policies':'/handbook/business-operations/security-policies#information-security-policy-and-acceptable-use-policy',// « reasoning: https://github.com/fleetdm/fleet/pull/9624
   'GET /handbook/handbook': '/handbook/company/handbook',
   'GET /handbook/company/product-groups': '/handbook/company/development-groups',
-  'GET /docs/using-fleet/mdm-macos-settings': '/docs/using-fleet/mdm-disk-encryption',
+  'GET /docs/using-fleet/mdm-macos-settings': '/docs/using-fleet/mdm-custom-macos-settings',
   'GET /platform': (req,res)=> {return res.redirect(302, '/');},// FUTURE: change this to a 301 (permanent) redirect once we are sure what the page that replaces this is.
 
   //  ╔╦╗╦╔═╗╔═╗  ╦═╗╔═╗╔╦╗╦╦═╗╔═╗╔═╗╔╦╗╔═╗   ┬   ╔╦╗╔═╗╦ ╦╔╗╔╦  ╔═╗╔═╗╔╦╗╔═╗


### PR DESCRIPTION
Seems like a more appropriate place for that redirection.