### PR TITLE
add support for displaying EULA during ADE/DEP

### DIFF
--- a/changes/11477-eula-support
+++ b/changes/11477-eula-support
@@ -1,0 +1,1 @@
+* Added support to add an EULA as part of the AEP/DEP unboxing flow.

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -655,8 +655,8 @@ This is the callback endpoint that the identity provider will use to send securi
 
 If the credentials are valid, the server redirects the client to the Fleet UI. The URL contains the following query parameters that can be used to complete the DEP enrollment flow:
 
-- `profile_url` is an URL that can be used to download an enrollment profile (.mobileconfig). Redirect the user to this URL to complete the enrollment.
-- `eula_url` (optional) if an EULA was uploaded, this contains an URL that can be used to view the document.
+- `profile_token` is a token that can be used to download an enrollment profile (.mobileconfig).
+- `eula_token` (optional) if an EULA was uploaded, this contains a token that can be used to view the EULA document.
 
 ## Get or apply configuration files
 

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -527,7 +527,8 @@ The MDM endpoints exist to support the related command-line interface sub-comman
 - [Generate Apple DEP Key Pair](#generate-apple-dep-key-pair)
 - [Request Certificate Signing Request (CSR)](#request-certificate-signing-request-csr)
 - [Batch-apply Apple MDM custom settings](#batch-apply-apple-mdm-custom-settings)
-- [Download an enrollment profile using IdP authentication](#download-an-enrollment-profile-using-idp-authentication)
+- [Initiate SSO during DEP enrollment](#initiate-sso-during-dep-enrollment)
+- [Complete SSO during DEP enrollment](#complete-sso-during-dep-enrollment)
 
 ### Generate Apple DEP Key Pair
 
@@ -601,6 +602,61 @@ If no team (id or name) is provided, the profiles are applied for all hosts (for
 ##### Default response
 
 `204`
+
+### Initiate SSO during DEP enrollment
+
+This endpoint initiates the SSO flow, the response contains an URL that the client can use to redirect the user to initiate the SSO flow in the configured IdP.
+
+`POST /api/v1/fleet/mdm/sso`
+
+#### Parameters
+
+None.
+
+#### Example
+
+`POST /api/v1/fleet/mdm/sso`
+
+##### Default response
+
+```
+{
+  "url": "https://idp-provider.com/saml?SAMLRequest=...",
+}
+```
+
+### Complete SSO during DEP enrollment
+
+This is the callback endpoint that the identity provider will use to send security assertions to Fleet. This is where Fleet receives and processes the response from the identify provider.
+
+`POST /api/v1/fleet/mdm/sso/callback`
+
+#### Parameters
+
+| Name         | Type   | In   | Description                                                 |
+| ------------ | ------ | ---- | ----------------------------------------------------------- |
+| SAMLResponse | string | body | **Required**. The SAML response from the identity provider. |
+
+#### Example
+
+`POST /api/v1/fleet/mdm/sso/callback`
+
+##### Request body
+
+```json
+{
+  "SAMLResponse": "<SAML response from IdP>"
+}
+```
+
+##### Default response
+
+`Status: 302`
+
+If the credentials are valid, the server redirects the client to the Fleet UI. The URL contains the following query parameters that can be used to complete the DEP enrollment flow:
+
+- `profile_url` is an URL that can be used to download an enrollment profile (.mobileconfig). Redirect the user to this URL to complete the enrollment.
+- `eula_url` (optional) if an EULA was uploaded, this contains an URL that can be used to view the document.
 
 ## Get or apply configuration files
 

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -552,21 +552,12 @@ func (svc *Service) InitiateMDMAppleSSOCallback(ctx context.Context, auth fleet.
 		return "", ctxerr.Wrap(ctx, err, "missing profile")
 	}
 
-	profileURL, err := apple_mdm.EnrollURL(depProf.Token, appConfig)
-	if err != nil {
-		return "", ctxerr.Wrap(ctx, err, "generating profile URL")
-	}
-
-	q := url.Values{
-		"profile_url": {profileURL},
-	}
-
+	q := url.Values{"profile_token": {depProf.Token}}
 	if eula != nil {
-		q.Add("eula_url", appConfig.ServerSettings.ServerURL+"/api/latest/fleet/mdm/apple/setup/eula/"+eula.Token)
+		q.Add("eula_token", eula.Token)
 	}
 
 	return appConfig.ServerSettings.ServerURL + "/mdm/sso/callback?" + q.Encode(), nil
-
 }
 
 func (svc *Service) mdmAppleSyncDEPProfile(ctx context.Context) error {

--- a/frontend/components/MDM/SSOError/SSOError.tsx
+++ b/frontend/components/MDM/SSOError/SSOError.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+import DataError from "components/DataError";
+
+const baseClass = "mdm-sso-error";
+
+const SSOError = () => {
+  return (
+    <DataError className={baseClass}>
+      <p>Please contact your IT admin at +1-(415)-651-2575.</p>
+    </DataError>
+  );
+};
+
+export default SSOError;

--- a/frontend/components/MDM/SSOError/SSOError.tsx
+++ b/frontend/components/MDM/SSOError/SSOError.tsx
@@ -1,12 +1,19 @@
 import React from "react";
+import classnames from "classnames";
 
 import DataError from "components/DataError";
 
 const baseClass = "mdm-sso-error";
 
-const SSOError = () => {
+interface ISSOErrorProps {
+  className?: string;
+}
+
+const SSOError = ({ className }: ISSOErrorProps) => {
+  const classNames = classnames(baseClass, className);
+
   return (
-    <DataError className={baseClass}>
+    <DataError className={classNames}>
       <p>Please contact your IT admin at +1-(415)-651-2575.</p>
     </DataError>
   );

--- a/frontend/components/MDM/SSOError/_styles.scss
+++ b/frontend/components/MDM/SSOError/_styles.scss
@@ -1,0 +1,6 @@
+.mdm-sso-error {
+  p {
+    font-size: $x-small;
+    margin: 12px 0 0;
+  }
+}

--- a/frontend/components/MDM/SSOError/index.ts
+++ b/frontend/components/MDM/SSOError/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SSOError";

--- a/frontend/components/buttons/Button/Button.stories.tsx
+++ b/frontend/components/buttons/Button/Button.stories.tsx
@@ -30,6 +30,7 @@ export default {
         "unstyled-modal-query",
         "contextual-nav-item",
         "small-text-icon",
+        "oversized",
       ],
       control: "select",
     },

--- a/frontend/components/buttons/Button/Button.tsx
+++ b/frontend/components/buttons/Button/Button.tsx
@@ -21,7 +21,8 @@ export type ButtonVariant =
   | "unstyled"
   | "unstyled-modal-query"
   | "contextual-nav-item"
-  | "small-text-icon";
+  | "small-text-icon"
+  | "oversized";
 
 export interface IButtonProps {
   autofocus?: boolean;

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -382,6 +382,6 @@ $base-class: "button";
     background-color: $core-fleet-black;
     padding: $pad-large $pad-small;
     font-size: $medium;
-    width: 80%;
+    width: 100%;
   }
 }

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -377,4 +377,11 @@ $base-class: "button";
     display: flex;
     justify-content: space-between;
   }
+
+  &--oversized {
+    background-color: $core-fleet-black;
+    padding: $pad-large $pad-small;
+    font-size: $medium;
+    width: 80%;
+  }
 }

--- a/frontend/pages/MDMAppleSSOCallbackPage/MDMAppleSSOCallbackPage.tsx
+++ b/frontend/pages/MDMAppleSSOCallbackPage/MDMAppleSSOCallbackPage.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from "react";
+
+import Spinner from "components/Spinner/Spinner";
+import SSOError from "components/MDM/SSOError";
+import Button from "components/buttons/Button";
+
+const baseClass = "mdm-apple-sso-callback-page";
+
+const RedirectTo = ({ url }: { url: string }) => {
+  window.location.href = url;
+  return <Spinner />;
+};
+
+const EnrollmentGate = () => {
+  const query = new URLSearchParams(location.search);
+  const [showEULA, setShowEULA] = useState(query.has("eula_url"));
+  const profileURL = query.get("profile_url");
+  const eulaURL = query.get("eula_url") || "";
+
+  if (!profileURL) {
+    return <SSOError />;
+  }
+
+  if (showEULA) {
+    return (
+      <div className={`${baseClass}__eula-wrapper`}>
+        <h3>Terms and conditions</h3>
+        <iframe src={eulaURL} width="100%" title="eula" />
+        <Button onClick={() => setShowEULA(false)} variant="oversized">
+          Agree and continue
+        </Button>
+      </div>
+    );
+  }
+
+  return <RedirectTo url={profileURL} />;
+};
+
+const MDMAppleSSOCallbackPage = () => {
+  return (
+    <div className={baseClass}>
+      <EnrollmentGate />
+    </div>
+  );
+};
+
+export default MDMAppleSSOCallbackPage;

--- a/frontend/pages/MDMAppleSSOCallbackPage/MDMAppleSSOCallbackPage.tsx
+++ b/frontend/pages/MDMAppleSSOCallbackPage/MDMAppleSSOCallbackPage.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 
+import endpoints from "utilities/endpoints";
+
 import Spinner from "components/Spinner/Spinner";
 import SSOError from "components/MDM/SSOError";
 import Button from "components/buttons/Button";
@@ -11,13 +13,16 @@ const RedirectTo = ({ url }: { url: string }) => {
   return <Spinner />;
 };
 
+// appConfig.ServerSettings.ServerURL+"/api/latest/fleet/mdm/apple/setup/eula/"
+// /api/mdm/apple/enroll?token=
+
 const EnrollmentGate = () => {
   const query = new URLSearchParams(location.search);
-  const [showEULA, setShowEULA] = useState(query.has("eula_url"));
-  const profileURL = query.get("profile_url");
-  const eulaURL = query.get("eula_url") || "";
+  const [showEULA, setShowEULA] = useState(query.has("eula_token"));
+  const profileToken = query.get("profile_token");
+  const eulaToken = query.get("eula_token") || "";
 
-  if (!profileURL) {
+  if (!profileToken) {
     return <SSOError />;
   }
 
@@ -25,7 +30,11 @@ const EnrollmentGate = () => {
     return (
       <div className={`${baseClass}__eula-wrapper`}>
         <h3>Terms and conditions</h3>
-        <iframe src={eulaURL} width="100%" title="eula" />
+        <iframe
+          src={`/api/${endpoints.MDM_APPLE_EULA_FILE(eulaToken)}`}
+          width="100%"
+          title="eula"
+        />
         <Button onClick={() => setShowEULA(false)} variant="oversized">
           Agree and continue
         </Button>
@@ -33,7 +42,9 @@ const EnrollmentGate = () => {
     );
   }
 
-  return <RedirectTo url={profileURL} />;
+  return (
+    <RedirectTo url={endpoints.MDM_APPLE_ENROLLMENT_PROFILE(profileToken)} />
+  );
 };
 
 const MDMAppleSSOCallbackPage = () => {

--- a/frontend/pages/MDMAppleSSOCallbackPage/MDMAppleSSOCallbackPage.tsx
+++ b/frontend/pages/MDMAppleSSOCallbackPage/MDMAppleSSOCallbackPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { WithRouterProps } from "react-router";
 
 import endpoints from "utilities/endpoints";
 
@@ -13,20 +14,19 @@ const RedirectTo = ({ url }: { url: string }) => {
   return <Spinner />;
 };
 
-// appConfig.ServerSettings.ServerURL+"/api/latest/fleet/mdm/apple/setup/eula/"
-// /api/mdm/apple/enroll?token=
+interface IEnrollmentGateProps {
+  profileToken?: string;
+  eulaToken?: string;
+}
 
-const EnrollmentGate = () => {
-  const query = new URLSearchParams(location.search);
-  const [showEULA, setShowEULA] = useState(query.has("eula_token"));
-  const profileToken = query.get("profile_token");
-  const eulaToken = query.get("eula_token") || "";
+const EnrollmentGate = ({ profileToken, eulaToken }: IEnrollmentGateProps) => {
+  const [showEULA, setShowEULA] = useState(Boolean(eulaToken));
 
   if (!profileToken) {
     return <SSOError />;
   }
 
-  if (showEULA) {
+  if (showEULA && eulaToken) {
     return (
       <div className={`${baseClass}__eula-wrapper`}>
         <h3>Terms and conditions</h3>
@@ -35,7 +35,11 @@ const EnrollmentGate = () => {
           width="100%"
           title="eula"
         />
-        <Button onClick={() => setShowEULA(false)} variant="oversized">
+        <Button
+          onClick={() => setShowEULA(false)}
+          variant="oversized"
+          className={`${baseClass}__agree-btn`}
+        >
           Agree and continue
         </Button>
       </div>
@@ -47,10 +51,18 @@ const EnrollmentGate = () => {
   );
 };
 
-const MDMAppleSSOCallbackPage = () => {
+interface IMDMSSOCallbackQuery {
+  eula_token?: string;
+  profile_token?: string;
+}
+
+const MDMAppleSSOCallbackPage = (
+  props: WithRouterProps<object, IMDMSSOCallbackQuery>
+) => {
+  const { eula_token, profile_token } = props.location.query;
   return (
     <div className={baseClass}>
-      <EnrollmentGate />
+      <EnrollmentGate eulaToken={eula_token} profileToken={profile_token} />
     </div>
   );
 };

--- a/frontend/pages/MDMAppleSSOCallbackPage/_styles.scss
+++ b/frontend/pages/MDMAppleSSOCallbackPage/_styles.scss
@@ -13,4 +13,8 @@
       height: 65vh;
     }
   }
+
+  &__agree-btn {
+    width: 80%;
+  }
 }

--- a/frontend/pages/MDMAppleSSOCallbackPage/_styles.scss
+++ b/frontend/pages/MDMAppleSSOCallbackPage/_styles.scss
@@ -1,7 +1,16 @@
-.mdm-apple-sso-page {
+.mdm-apple-sso-callback-page {
   height: 100vh; // expend height to make entire viewport a white background
   background-color: $core-white;
   display: flex;
   align-items: center;
   justify-content: center;
+
+  &__eula-wrapper {
+    width: 80vw;
+    text-align: center;
+
+    iframe {
+      height: 65vh;
+    }
+  }
 }

--- a/frontend/pages/MDMAppleSSOCallbackPage/index.ts
+++ b/frontend/pages/MDMAppleSSOCallbackPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MDMAppleSSOCallbackPage";

--- a/frontend/pages/MDMAppleSSOPage/MDMAppleSSOPage.tsx
+++ b/frontend/pages/MDMAppleSSOPage/MDMAppleSSOPage.tsx
@@ -4,19 +4,11 @@ import { AxiosError } from "axios";
 
 import mdmAPI from "services/entities/mdm";
 
-import DataError from "components/DataError";
+import SSOError from "components/MDM/SSOError";
 import Spinner from "components/Spinner/Spinner";
 import { IMdmSSOReponse } from "interfaces/mdm";
 
 const baseClass = "mdm-apple-sso-page";
-
-const SSOError = () => {
-  return (
-    <DataError className={`${baseClass}__sso-error`}>
-      <p>Please contact your IT admin at +1-(415)-651-2575.</p>
-    </DataError>
-  );
-};
 
 const DEPSSOLoginPage = () => {
   const { error } = useQuery<void, AxiosError, IMdmSSOReponse>(

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -40,6 +40,7 @@ import QueryPage from "pages/queries/QueryPage";
 import RegistrationPage from "pages/RegistrationPage";
 import ResetPasswordPage from "pages/ResetPasswordPage";
 import MDMAppleSSOPage from "pages/MDMAppleSSOPage";
+import MDMAppleSSOCallbackPage from "pages/MDMAppleSSOCallbackPage";
 import SoftwareDetailsPage from "pages/software/SoftwareDetailsPage";
 import ApiOnlyUser from "pages/ApiOnlyUser";
 import Fleet403 from "pages/errors/Fleet403";
@@ -98,6 +99,7 @@ const routes = (
           />
           <Route path="login/forgot" component={ForgotPasswordPage} />
           <Route path="login/reset" component={ResetPasswordPage} />
+          <Route path="mdm/sso/callback" component={MDMAppleSSOCallbackPage} />
           <Route path="mdm/sso" component={MDMAppleSSOPage} />
         </Route>
       </Route>

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -48,6 +48,10 @@ export default {
   MDM_PROFILES_AGGREGATE_STATUSES: `/${API_VERSION}/fleet/mdm/apple/profiles/summary`,
   MDM_APPLE_DISK_ENCRYPTION_AGGREGATE: `/${API_VERSION}/fleet/mdm/apple/filevault/summary`,
   MDM_APPLE_SSO: `/${API_VERSION}/fleet/mdm/sso`,
+  MDM_APPLE_EULA_FILE: (token: string) =>
+    `/${API_VERSION}/fleet/mdm/apple/setup/eula/${token}`,
+  MDM_APPLE_ENROLLMENT_PROFILE: (token: string) =>
+    `/api/mdm/apple/enroll?token=${token}`,
   MDM_BOOTSTRAP_PACKAGE_METADATA: (teamId: number) =>
     `/${API_VERSION}/fleet/mdm/apple/bootstrap/${teamId}/metadata`,
   MDM_BOOTSTRAP_PACKAGE: `/${API_VERSION}/fleet/mdm/apple/bootstrap`,

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -168,8 +168,7 @@ type Service interface {
 
 	// InitSSOCallback handles the IDP response and ensures the credentials
 	// are valid, then responds with an enrollment profile.
-	// TODO: add support for EULAs too
-	InitiateMDMAppleSSOCallback(ctx context.Context, auth Auth) ([]byte, error)
+	InitiateMDMAppleSSOCallback(ctx context.Context, auth Auth) (string, error)
 
 	// GetSSOUser handles retrieval of an user that is trying to authenticate
 	// via SSO

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1161,6 +1161,8 @@ type mdmAppleEnrollResponse struct {
 func (r mdmAppleEnrollResponse) hijackRender(ctx context.Context, w http.ResponseWriter) {
 	w.Header().Set("Content-Length", strconv.FormatInt(int64(len(r.Profile)), 10))
 	w.Header().Set("Content-Type", "application/x-apple-aspen-config")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Disposition", "attachment;fleet-enrollment-profile.mobileconfig")
 
 	// OK to just log the error here as writing anything on
 	// `http.ResponseWriter` sets the status code to 200 (and it can't be
@@ -2112,44 +2114,33 @@ func (callbackMDMAppleSSORequest) DecodeRequest(ctx context.Context, r *http.Req
 type callbackMDMAppleSSOResponse struct {
 	Err error `json:"error,omitempty"`
 
-	// used in hijackRender for the response
-	profile []byte
+	redirectURL string
+}
+
+func (r callbackMDMAppleSSOResponse) hijackRender(ctx context.Context, w http.ResponseWriter) {
+	w.Header().Set("Location", r.redirectURL)
+	w.WriteHeader(http.StatusTemporaryRedirect)
 }
 
 func (r callbackMDMAppleSSOResponse) error() error { return r.Err }
-
-func (r callbackMDMAppleSSOResponse) hijackRender(ctx context.Context, w http.ResponseWriter) {
-	w.Header().Set("Content-Length", strconv.FormatInt(int64(len(r.profile)), 10))
-	w.Header().Set("Content-Type", "application/x-apple-aspen-config")
-	w.Header().Add("Content-Disposition", `attachment; filename="fleet-mdm-enrollment-profile.mobileconfig"`)
-	w.Header().Set("X-Content-Type-Options", "nosniff")
-
-	// OK to just log the error here as writing anything on
-	// `http.ResponseWriter` sets the status code to 200 (and it can't be
-	// changed.) Clients should rely on matching content-length with the
-	// header provided.
-	if n, err := w.Write(r.profile); err != nil {
-		logging.WithExtras(ctx, "err", err, "written", n)
-	}
-}
 
 func callbackMDMAppleSSOEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	auth := request.(fleet.Auth)
 
 	// validate that the SSO response is valid
-	profile, err := svc.InitiateMDMAppleSSOCallback(ctx, auth)
+	redirectURL, err := svc.InitiateMDMAppleSSOCallback(ctx, auth)
 	if err != nil {
 		return callbackMDMAppleSSOResponse{Err: err}, nil
 	}
-	return callbackMDMAppleSSOResponse{profile: profile}, nil
+	return callbackMDMAppleSSOResponse{redirectURL: redirectURL}, nil
 }
 
-func (svc *Service) InitiateMDMAppleSSOCallback(ctx context.Context, auth fleet.Auth) ([]byte, error) {
+func (svc *Service) InitiateMDMAppleSSOCallback(ctx context.Context, auth fleet.Auth) (string, error) {
 	// skipauth: No authorization check needed due to implementation
 	// returning only license error.
 	svc.authz.SkipAuthorization(ctx)
 
-	return nil, fleet.ErrMissingLicense
+	return "", fleet.ErrMissingLicense
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -3865,12 +3865,10 @@ func (s *integrationMDMTestSuite) TestSSO() {
 	require.NoError(t, err)
 	q := u.Query()
 	// without an EULA uploaded, only the profile token is provided
-	require.False(t, q.Has("eula_url"))
-	require.True(t, q.Has("profile_url"))
+	require.False(t, q.Has("eula_token"))
+	require.True(t, q.Has("profile_token"))
 	// the url retrieves a valid profile
-	pu, err := url.Parse(q.Get("profile_url"))
-	require.NoError(t, err)
-	s.downloadAndVerifyEnrollmentProfile(pu.Path + "?" + pu.RawQuery)
+	s.downloadAndVerifyEnrollmentProfile("/api/mdm/apple/enroll?token=" + q.Get("profile_token"))
 
 	// upload an EULA
 	pdfBytes := []byte("%PDF-1.pdf-contents")
@@ -3884,16 +3882,12 @@ func (s *integrationMDMTestSuite) TestSSO() {
 	require.NoError(t, err)
 	q = u.Query()
 	// with an EULA uploaded, both values are present
-	require.True(t, q.Has("eula_url"))
-	require.True(t, q.Has("profile_url"))
+	require.True(t, q.Has("eula_token"))
+	require.True(t, q.Has("profile_token"))
 	// the url retrieves a valid profile
-	pu, err = url.Parse(q.Get("profile_url"))
-	require.NoError(t, err)
-	s.downloadAndVerifyEnrollmentProfile(pu.Path + "?" + pu.RawQuery)
+	s.downloadAndVerifyEnrollmentProfile("/api/mdm/apple/enroll?token=" + q.Get("profile_token"))
 	// the url retrieves a valid EULA
-	eu, err := url.Parse(q.Get("eula_url"))
-	require.NoError(t, err)
-	resp := s.DoRaw("GET", eu.Path+"?"+eu.RawQuery, nil, http.StatusOK)
+	resp := s.DoRaw("GET", "/api/latest/fleet/mdm/apple/setup/eula/"+q.Get("eula_token"), nil, http.StatusOK)
 	require.EqualValues(t, len(pdfBytes), resp.ContentLength)
 	require.Equal(t, "application/pdf", resp.Header.Get("content-type"))
 	respBytes, err := io.ReadAll(resp.Body)

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -17,6 +17,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -611,25 +612,7 @@ func (s *integrationMDMTestSuite) TestDeviceMDMManualEnroll() {
 	s.DoRaw("GET", "/api/latest/fleet/device/invalid_token/mdm/apple/manual_enrollment_profile", nil, http.StatusUnauthorized)
 
 	// valid token downloads the profile
-	resp := s.DoRaw("GET", "/api/latest/fleet/device/"+token+"/mdm/apple/manual_enrollment_profile", nil, http.StatusOK)
-	body, err := io.ReadAll(resp.Body)
-	resp.Body.Close()
-	require.NoError(t, err)
-	require.Contains(t, resp.Header, "Content-Disposition")
-	require.Contains(t, resp.Header, "Content-Type")
-	require.Contains(t, resp.Header, "X-Content-Type-Options")
-	require.Contains(t, resp.Header.Get("Content-Disposition"), "attachment;")
-	require.Contains(t, resp.Header.Get("Content-Type"), "application/x-apple-aspen-config")
-	require.Contains(t, resp.Header.Get("X-Content-Type-Options"), "nosniff")
-	headerLen, err := strconv.Atoi(resp.Header.Get("Content-Length"))
-	require.NoError(t, err)
-	require.Equal(t, len(body), headerLen)
-
-	var profile struct {
-		PayloadIdentifier string `plist:"PayloadIdentifier"`
-	}
-	require.NoError(t, plist.Unmarshal(body, &profile))
-	require.Equal(t, apple_mdm.FleetPayloadIdentifier, profile.PayloadIdentifier)
+	s.downloadAndVerifyEnrollmentProfile("/api/latest/fleet/device/" + token + "/mdm/apple/manual_enrollment_profile")
 }
 
 func (s *integrationMDMTestSuite) TestAppleMDMDeviceEnrollment() {
@@ -3875,25 +3858,47 @@ func (s *integrationMDMTestSuite) TestSSO() {
 	require.Equal(t, acResp.ServerSettings.ServerURL+"/mdm/sso", lastSubmittedProfile.ConfigurationWebURL)
 
 	res := s.LoginMDMSSOUser("sso_user", "user123#")
+	require.NotEmpty(t, res.Header.Get("Location"))
+	require.Equal(t, http.StatusTemporaryRedirect, res.StatusCode)
 
-	body, err := io.ReadAll(res.Body)
+	u, err := url.Parse(res.Header.Get("Location"))
 	require.NoError(t, err)
-	defer res.Body.Close()
-	require.Contains(t, res.Header, "Content-Disposition")
-	require.Contains(t, res.Header, "Content-Type")
-	require.Contains(t, res.Header, "X-Content-Type-Options")
-	require.Contains(t, res.Header.Get("Content-Disposition"), "attachment;")
-	require.Contains(t, res.Header.Get("Content-Type"), "application/x-apple-aspen-config")
-	require.Contains(t, res.Header.Get("X-Content-Type-Options"), "nosniff")
-	headerLen, err := strconv.Atoi(res.Header.Get("Content-Length"))
+	q := u.Query()
+	// without an EULA uploaded, only the profile token is provided
+	require.False(t, q.Has("eula_url"))
+	require.True(t, q.Has("profile_url"))
+	// the url retrieves a valid profile
+	pu, err := url.Parse(q.Get("profile_url"))
 	require.NoError(t, err)
-	require.Equal(t, len(body), headerLen)
+	s.downloadAndVerifyEnrollmentProfile(pu.Path + "?" + pu.RawQuery)
 
-	var profile struct {
-		PayloadIdentifier string `plist:"PayloadIdentifier"`
-	}
-	require.NoError(t, plist.Unmarshal(body, &profile))
-	require.Equal(t, apple_mdm.FleetPayloadIdentifier, profile.PayloadIdentifier)
+	// upload an EULA
+	pdfBytes := []byte("%PDF-1.pdf-contents")
+	pdfName := "eula.pdf"
+	s.uploadEULA(&fleet.MDMAppleEULA{Bytes: pdfBytes, Name: pdfName}, http.StatusOK, "")
+
+	res = s.LoginMDMSSOUser("sso_user", "user123#")
+	require.NotEmpty(t, res.Header.Get("Location"))
+	require.Equal(t, http.StatusTemporaryRedirect, res.StatusCode)
+	u, err = url.Parse(res.Header.Get("Location"))
+	require.NoError(t, err)
+	q = u.Query()
+	// with an EULA uploaded, both values are present
+	require.True(t, q.Has("eula_url"))
+	require.True(t, q.Has("profile_url"))
+	// the url retrieves a valid profile
+	pu, err = url.Parse(q.Get("profile_url"))
+	require.NoError(t, err)
+	s.downloadAndVerifyEnrollmentProfile(pu.Path + "?" + pu.RawQuery)
+	// the url retrieves a valid EULA
+	eu, err := url.Parse(q.Get("eula_url"))
+	require.NoError(t, err)
+	resp := s.DoRaw("GET", eu.Path+"?"+eu.RawQuery, nil, http.StatusOK)
+	require.EqualValues(t, len(pdfBytes), resp.ContentLength)
+	require.Equal(t, "application/pdf", resp.Header.Get("content-type"))
+	respBytes, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.EqualValues(t, pdfBytes, respBytes)
 
 	// changing the server URL also updates the remote DEP profile
 	acResp = appConfigResponse{}
@@ -3902,4 +3907,27 @@ func (s *integrationMDMTestSuite) TestSSO() {
 	}`), http.StatusOK, &acResp)
 	require.Contains(t, lastSubmittedProfile.URL, "https://example.com/api/mdm/apple/enroll?token=")
 	require.Equal(t, "https://example.com/mdm/sso", lastSubmittedProfile.ConfigurationWebURL)
+}
+
+func (s *integrationMDMTestSuite) downloadAndVerifyEnrollmentProfile(path string) {
+	t := s.T()
+
+	resp := s.DoRaw("GET", path, nil, http.StatusOK)
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	require.Contains(t, resp.Header, "Content-Disposition")
+	require.Contains(t, resp.Header, "Content-Type")
+	require.Contains(t, resp.Header, "X-Content-Type-Options")
+	require.Contains(t, resp.Header.Get("Content-Disposition"), "attachment;")
+	require.Contains(t, resp.Header.Get("Content-Type"), "application/x-apple-aspen-config")
+	require.Contains(t, resp.Header.Get("X-Content-Type-Options"), "nosniff")
+	headerLen, err := strconv.Atoi(resp.Header.Get("Content-Length"))
+	require.NoError(t, err)
+	require.Equal(t, len(body), headerLen)
+	var profile struct {
+		PayloadIdentifier string `plist:"PayloadIdentifier"`
+	}
+	require.NoError(t, plist.Unmarshal(body, &profile))
+	require.Equal(t, apple_mdm.FleetPayloadIdentifier, profile.PayloadIdentifier)
 }

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -295,7 +295,6 @@ func (r getMDMAppleEULAResponse) hijackRender(ctx context.Context, w http.Respon
 	w.Header().Set("Content-Length", strconv.Itoa(len(r.eula.Bytes)))
 	w.Header().Set("Content-Type", "application/pdf")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment;filename="%s.pdf"`, r.eula.Name))
 
 	// OK to just log the error here as writing anything on
 	// `http.ResponseWriter` sets the status code to 200 (and it can't be


### PR DESCRIPTION
Related to #11350 and the sub-tasks for stuff that happens in setup assistant: #11477 and #11479

This adds back-end and UI logic to show an EULA during DEP enrollment if one was uploaded via the UI, if an EULA wasn't uploaded, we just proceed to enroll the device right after authentication.

https://user-images.githubusercontent.com/4419992/236316655-282ee74a-5f79-4095-a950-82b77b80a5c0.mov


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
