### PR TITLE
Fleet UI: Grey out unusable select all queries checkbox

### DIFF
--- a/changes/issue-11345-grey-out-unusable-checkbox
+++ b/changes/issue-11345-grey-out-unusable-checkbox
@@ -1,0 +1,1 @@
+- Grey out unusable select all queries checkbox

--- a/frontend/components/icons/Query.tsx
+++ b/frontend/components/icons/Query.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { COLORS, Colors } from "styles/var/colors";
+
+interface IQuery {
+  color?: Colors;
+}
+const Query = ({ color = "core-fleet-blue" }: IQuery) => {
+  return (
+    <svg
+      width="16"
+      height="16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 16 16"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M6.5 11a4.5 4.5 0 1 0 0-9 4.5 4.5 0 0 0 0 9Zm0 2a6.47 6.47 0 0 0 3.835-1.251l3.958 3.958a1 1 0 0 0 1.414-1.414l-3.958-3.958A6.5 6.5 0 1 0 6.5 13Zm2.814-7.419A1 1 0 0 0 7.686 4.42l-1.814 2.54-.665-.666a1 1 0 0 0-1.414 1.414l1.5 1.5a1 1 0 0 0 1.52-.126l2.5-3.5Z"
+        fill={COLORS[color]}
+      />
+    </svg>
+  );
+};
+
+export default Query;

--- a/frontend/components/icons/Query.tsx
+++ b/frontend/components/icons/Query.tsx
@@ -1,14 +1,15 @@
 import React from "react";
 import { COLORS, Colors } from "styles/var/colors";
-
+import { ICON_SIZES, IconSizes } from "styles/var/icon_sizes";
 interface IQuery {
   color?: Colors;
+  size?: IconSizes;
 }
-const Query = ({ color = "core-fleet-blue" }: IQuery) => {
+const Query = ({ color = "core-fleet-blue", size = "medium" }: IQuery) => {
   return (
     <svg
-      width="16"
-      height="16"
+      width={ICON_SIZES[size]}
+      height={ICON_SIZES[size]}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 16 16"

--- a/frontend/components/icons/Query.tsx
+++ b/frontend/components/icons/Query.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { COLORS, Colors } from "styles/var/colors";
 import { ICON_SIZES, IconSizes } from "styles/var/icon_sizes";
+
 interface IQuery {
   color?: Colors;
   size?: IconSizes;

--- a/frontend/components/icons/index.ts
+++ b/frontend/components/icons/index.ts
@@ -18,6 +18,7 @@ import ExternalLink from "./ExternalLink";
 import Issue from "./Issue";
 import Plus from "./Plus";
 import PremiumFeature from "./PremiumFeature";
+import Query from "./Query";
 
 import LowDiskSpaceHosts from "./LowDiskSpaceHosts";
 import MissingHosts from "./MissingHosts";
@@ -80,6 +81,7 @@ export const ICON_MAP = {
   lightbulb: Lightbulb,
   issue: Issue,
   plus: Plus,
+  query: Query,
   clipboard: Clipboard,
   eye: Eye,
   pencil: Pencil,

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -130,6 +130,15 @@
         tbody {
           .name__cell {
             max-width: $col-lg;
+
+            .children-wrapper {
+              display: flex;
+              gap: $pad-xsmall;
+
+              .observer-can-run-tooltip {
+                font-weight: $regular;
+              }
+            }
           }
 
           @media (max-width: $break-990) {

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -240,9 +240,8 @@ const generateTableHeaders = ({
                 (r: IQueryRow) => r.original.author_id === currentUser.id
               ).length === 0
             );
-          } else {
-            return false;
           }
+          return false;
         };
 
         const checkboxProps = {

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -230,10 +230,25 @@ const generateTableHeaders = ({
           toggleRowSelected,
         } = cellProps;
         const { checked, indeterminate } = getToggleAllRowsSelectedProps();
+
+        const disableToggleAllRowsSelected = () => {
+          /* Team admin or team maintainer can only delete queries they authored
+          If team admin or team maintainer authored 0 queries, disable select all queries for deletion */
+          if (isAnyTeamMaintainerOrTeamAdmin) {
+            return (
+              rows.filter(
+                (r: IQueryRow) => r.original.author_id === currentUser.id
+              ).length === 0
+            );
+          } else {
+            return false;
+          }
+        };
+
         const checkboxProps = {
           value: checked,
           indeterminate,
-          disabled: false, // TODO: Disable if all the other ones are disabled
+          disabled: disableToggleAllRowsSelected(), // Disable select all if all rows are disabled
           onChange: () => {
             if (!isAnyTeamMaintainerOrTeamAdmin) {
               toggleAllRowsSelected();

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -117,7 +117,7 @@ const generateTableHeaders = ({
                       data-tip
                       data-for={`observer-can-run-tooltip-${cellProps.row.original.id}`}
                     >
-                      <Icon className="query-icon" name="query" />
+                      <Icon className="query-icon" name="query" size="small" />
                     </span>
                     <ReactTooltip
                       className="observer-can-run-tooltip"
@@ -233,6 +233,7 @@ const generateTableHeaders = ({
         const checkboxProps = {
           value: checked,
           indeterminate,
+          disabled: false, // TODO: Disable if all the other ones are disabled
           onChange: () => {
             if (!isAnyTeamMaintainerOrTeamAdmin) {
               toggleAllRowsSelected();

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -11,6 +11,7 @@ import { IQuery } from "interfaces/query";
 import { IUser } from "interfaces/user";
 import { addGravatarUrlToResource } from "utilities/helpers";
 
+import Icon from "components/Icon";
 import Avatar from "components/Avatar";
 import Checkbox from "components/forms/fields/Checkbox";
 import LinkCell from "components/TableContainer/DataTable/LinkCell/LinkCell";
@@ -101,13 +102,41 @@ const generateTableHeaders = ({
         />
       ),
       accessor: "name",
-      Cell: (cellProps: ICellProps): JSX.Element => (
-        <LinkCell
-          classes="w400"
-          value={cellProps.cell.value}
-          path={PATHS.EDIT_QUERY(cellProps.row.original)}
-        />
-      ),
+      Cell: (cellProps: ICellProps): JSX.Element => {
+        console.log("cellProps.row.original", cellProps.row.original);
+        return (
+          <LinkCell
+            classes="w400"
+            value={
+              <>
+                <div className="query-name-text">{cellProps.cell.value}</div>
+                {!isOnlyObserver && cellProps.row.original.observer_can_run && (
+                  <>
+                    <span
+                      className="tooltip-base"
+                      data-tip
+                      data-for={`observer-can-run-tooltip-${cellProps.row.original.id}`}
+                    >
+                      <Icon className="query-icon" name="query" />
+                    </span>
+                    <ReactTooltip
+                      className="observer-can-run-tooltip"
+                      place="top"
+                      type="dark"
+                      effect="solid"
+                      id={`observer-can-run-tooltip-${cellProps.row.original.id}`}
+                      backgroundColor="#3e4771"
+                    >
+                      Observers can run this query.
+                    </ReactTooltip>
+                  </>
+                )}
+              </>
+            }
+            path={PATHS.EDIT_QUERY(cellProps.row.original)}
+          />
+        );
+      },
       sortType: "caseInsensitive",
     },
     {


### PR DESCRIPTION
## Description
- If all query checkboxes are disabled for team admin and team maintainer, select all queries checkbox is also disabled
  - This must be a localized fix as it's set in the `QueriesTableConfig.tsx` headers and cannot be set on `TableContainer.tsx`
- Add an icon so users know which queries observers can run (observers view cannot see icon)

## Screenshot
<img width="1288" alt="Screenshot 2023-05-04 at 4 51 41 PM" src="https://user-images.githubusercontent.com/71795832/236327227-dc48aa01-cf3b-4df9-b122-d3fe207d0bd8.png">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
