### PR TITLE
Ignore invalid unique constraint violation error

### DIFF
--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1690,6 +1690,12 @@ func (ds *Datastore) SetOrUpdateDeviceAuthToken(ctx context.Context, hostID uint
 `
 	_, err := ds.writer.ExecContext(ctx, stmt, hostID, authToken)
 	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "duplicate entry") {
+			// This could throw an unexpected unique constraint violation because 'host_device_auth'
+			// has two unique keys ('host_id' and 'token'), having more than one unique key is known
+			// to be unsafe: https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html
+			return nil
+		}
 		return ctxerr.Wrap(ctx, err, "upsert host's device auth token")
 	}
 	return nil


### PR DESCRIPTION
Relates to https://github.com/fleetdm/fleet/issues/9394

I couldn't reproduce this bug locally but reading the MySQL docs I found of that:

> An INSERT ... ON DUPLICATE KEY UPDATE statement against a table having more than one unique or primary key is also marked as unsafe.

Which I'm guessing is what happened here.

The 'proper' solution here would be to recreate the table with the correct index structure, but such a risky operation might not be worth it for patching a bug that only seem to have happened once?

AFAIK when this happens, MySQL won't update the underlying 'token' value, so if we choose to ignore the error, the orbit client will be kept in an 'unauthorized' state until the next 'orbit/device_token' call.