### PR TITLE
Add some improvements to the loadtesting environment

### DIFF
--- a/infrastructure/loadtesting/terraform/ecs.tf
+++ b/infrastructure/loadtesting/terraform/ecs.tf
@@ -141,6 +141,10 @@ resource "aws_ecs_task_definition" "backend" {
             value = "${module.aurora_mysql.rds_cluster_endpoint}:3306"
           },
           {
+            name  = "FLEET_MYSQL_MAX_OPEN_CONNS"
+            value = "5"
+          },
+          {
             name  = "FLEET_MYSQL_READ_REPLICA_USERNAME"
             value = module.aurora_mysql.rds_cluster_master_username
           },
@@ -151,6 +155,10 @@ resource "aws_ecs_task_definition" "backend" {
           {
             name  = "FLEET_MYSQL_READ_REPLICA_ADDRESS"
             value = "${module.aurora_mysql.rds_cluster_reader_endpoint}:3306"
+          },
+          {
+            name  = "FLEET_MYSQL_READ_REPLICA_MAX_OPEN_CONNS"
+            value = "5"
           },
           {
             name  = "FLEET_REDIS_ADDRESS"

--- a/infrastructure/loadtesting/terraform/redis.tf
+++ b/infrastructure/loadtesting/terraform/redis.tf
@@ -7,7 +7,7 @@ resource "aws_elasticache_replication_group" "default" {
   replication_group_id       = "${local.prefix}-redis"
   num_cache_clusters         = 3
   node_type                  = var.redis_instance_type
-  engine_version             = "5.0.6"
+  engine_version             = "6.2"
   port                       = "6379"
   snapshot_retention_limit   = 0
   automatic_failover_enabled = true
@@ -20,7 +20,7 @@ resource "aws_elasticache_replication_group" "default" {
 
 resource "aws_elasticache_parameter_group" "default" { #tfsec:ignore:aws-vpc-add-description-to-security-group-rule
   name   = "${local.prefix}-redis"
-  family = "redis5.0"
+  family = "redis6.x"
 
   parameter {
     name  = "client-output-buffer-limit-pubsub-hard-limit"


### PR DESCRIPTION
The default max open conns (50) was causing issues with small DB instances (`db.t4g.medium`) in loadtesting (we run 10 fleet instances, and 500 was over the limit number of connections for that instance type).

Also upgrading Redis version to a more recent version that users are most likely using.