### PR TITLE
400 status code when a DEP request to /mdm/apple_bm receives AuthError

### DIFF
--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -275,6 +275,14 @@ func (s *integrationMDMTestSuite) TestAppleGetAppleMDM() {
 	require.Equal(t, "test_org", getAppleBMResp.OrgName)
 	require.Equal(t, "https://example.org/mdm/apple/mdm", getAppleBMResp.MDMServerURL)
 	require.Equal(t, tm.Name, getAppleBMResp.DefaultTeam)
+
+	// simulate a bad request (eg: bad certificate)
+	s.mockDEPResponse(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	res := s.Do("GET", "/api/latest/fleet/mdm/apple_bm", nil, http.StatusBadRequest)
+	errMsg := extractServerErrorText(res.Body)
+	assert.Contains(s.T(), errMsg, "failed to authenticate with configured Apple BM certificates")
 }
 
 func (s *integrationMDMTestSuite) TestABMExpiredToken() {


### PR DESCRIPTION
#11416

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
