### PR TITLE
Fleet UI: Policies URL params (bookmarkability)

### DIFF
--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -20,7 +20,7 @@ export interface ITableQueryData {
   searchQuery: string;
   sortHeader: string;
   sortDirection: string;
-  showInheritedTable?: string;
+  showInheritedTable?: boolean; // Only used for policies tables
 }
 interface IRowProps extends Row {
   original: {

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -20,6 +20,7 @@ export interface ITableQueryData {
   searchQuery: string;
   sortHeader: string;
   sortDirection: string;
+  showInheritedTable?: string;
 }
 interface IRowProps extends Row {
   original: {

--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -23,6 +23,7 @@ enum ACTIONS {
   SET_FILTERED_HOSTS_PATH = "SET_FILTERED_HOSTS_PATH",
   SET_FILTERED_SOFTWARE_PATH = "SET_FILTERED_SOFTWARE_PATH",
   SET_FILTERED_QUERIES_PATH = "SET_FILTERED_QUERIES_PATH",
+  SET_FILTERED_POLICIES_PATH = "SET_FILTERED_POLICIES_PATH",
 }
 
 interface ISetAvailableTeamsAction {
@@ -74,6 +75,10 @@ interface ISetFilteredQueriesPathAction {
   filteredQueriesPath: string;
 }
 
+interface ISetFilteredPoliciesPathAction {
+  type: ACTIONS.SET_FILTERED_POLICIES_PATH;
+  filteredPoliciesPath: string;
+}
 type IAction =
   | ISetAvailableTeamsAction
   | ISetConfigAction
@@ -84,7 +89,8 @@ type IAction =
   | ISetNoSandboxHostsAction
   | ISetFilteredHostsPathAction
   | ISetFilteredSoftwarePathAction
-  | ISetFilteredQueriesPathAction;
+  | ISetFilteredQueriesPathAction
+  | ISetFilteredPoliciesPathAction;
 
 type Props = {
   children: ReactNode;
@@ -121,6 +127,7 @@ type InitialStateType = {
   filteredHostsPath?: string;
   filteredSoftwarePath?: string;
   filteredQueriesPath?: string;
+  filteredPoliciesPath?: string;
   setAvailableTeams: (
     user: IUser | null,
     availableTeams: ITeamSummary[]
@@ -134,6 +141,7 @@ type InitialStateType = {
   setFilteredHostsPath: (filteredHostsPath: string) => void;
   setFilteredSoftwarePath: (filteredSoftwarePath: string) => void;
   setFilteredQueriesPath: (filteredQueriesPath: string) => void;
+  setFilteredPoliciesPath: (filteredPoliciesPath: string) => void;
 };
 
 export type IAppContext = InitialStateType;
@@ -167,6 +175,7 @@ export const initialState = {
   filteredHostsPath: undefined,
   filteredSoftwarePath: undefined,
   filteredQueriesPath: undefined,
+  filteredPoliciesPath: undefined,
   setAvailableTeams: () => null,
   setCurrentUser: () => null,
   setCurrentTeam: () => null,
@@ -177,6 +186,7 @@ export const initialState = {
   setFilteredHostsPath: () => null,
   setFilteredSoftwarePath: () => null,
   setFilteredQueriesPath: () => null,
+  setFilteredPoliciesPath: () => null,
 };
 
 const detectPreview = () => {
@@ -321,6 +331,13 @@ const reducer = (state: InitialStateType, action: IAction) => {
         filteredQueriesPath,
       };
     }
+    case ACTIONS.SET_FILTERED_POLICIES_PATH: {
+      const { filteredPoliciesPath } = action;
+      return {
+        ...state,
+        filteredPoliciesPath,
+      };
+    }
     default:
       return state;
   }
@@ -342,6 +359,7 @@ const AppProvider = ({ children }: Props): JSX.Element => {
     filteredHostsPath: state.filteredHostsPath,
     filteredSoftwarePath: state.filteredSoftwarePath,
     filteredQueriesPath: state.filteredQueriesPath,
+    filteredPoliciesPath: state.filteredPoliciesPath,
     isPreviewMode: detectPreview(),
     isSandboxMode: state.isSandboxMode,
     isFreeTier: state.isFreeTier,
@@ -403,6 +421,12 @@ const AppProvider = ({ children }: Props): JSX.Element => {
       dispatch({
         type: ACTIONS.SET_FILTERED_QUERIES_PATH,
         filteredQueriesPath,
+      });
+    },
+    setFilteredPoliciesPath: (filteredPoliciesPath: string) => {
+      dispatch({
+        type: ACTIONS.SET_FILTERED_POLICIES_PATH,
+        filteredPoliciesPath,
       });
     },
   };

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -159,6 +159,7 @@ const ManageHostsPage = ({
     ? JSON.parse(hostHiddenColumns)
     : null;
 
+  // Functions to avoid race conditions
   const initialSortBy: ISortOption[] = (() => {
     let key = DEFAULT_SORT_HEADER;
     let direction = DEFAULT_SORT_DIRECTION;
@@ -171,26 +172,9 @@ const ManageHostsPage = ({
 
     return [{ key, direction }];
   })();
-
-  const initialQuery = (() => {
-    let query = "";
-
-    if (queryParams && queryParams.query) {
-      query = queryParams.query;
-    }
-
-    return query;
-  })();
-
-  const initialPage = (() => {
-    let page = 0;
-
-    if (queryParams && queryParams.page) {
-      page = parseInt(queryParams.page, 10);
-    }
-
-    return page;
-  })();
+  const initialQuery = (() => queryParams.query ?? "")();
+  const initialPage = (() =>
+    queryParams && queryParams.page ? parseInt(queryParams?.page, 10) : 0)();
 
   // ========= states
   const [selectedLabel, setSelectedLabel] = useState<ILabel>();

--- a/frontend/pages/hosts/details/cards/Software/Software.tsx
+++ b/frontend/pages/hosts/details/cards/Software/Software.tsx
@@ -72,45 +72,14 @@ const SoftwareTable = ({
 }: ISoftwareTableProps): JSX.Element => {
   const { isSandboxMode, setFilteredSoftwarePath } = useContext(AppContext);
 
-  const initialSearchQuery = (() => {
-    let query = "";
-    if (queryParams && queryParams.query) {
-      query = queryParams.query;
-    }
-    return query;
-  })();
-
-  const initialSortHeader = (() => {
-    let sortHeader = "name";
-    if (queryParams && queryParams.order_key) {
-      sortHeader = queryParams.order_key;
-    }
-    return sortHeader;
-  })();
-
-  const initialSortDirection = ((): "asc" | "desc" | undefined => {
-    let sortDirection = "asc";
-    if (queryParams && queryParams.order_direction) {
-      sortDirection = queryParams.order_direction;
-    }
-    return sortDirection as "asc" | "desc" | undefined;
-  })();
-
-  const initialVulnFilter = (() => {
-    let isFilteredByVulnerabilities = false;
-    if (queryParams && queryParams.vulnerable === "true") {
-      isFilteredByVulnerabilities = true;
-    }
-    return isFilteredByVulnerabilities;
-  })();
-
-  const initialPage = (() => {
-    let page = 0;
-    if (queryParams && queryParams.page) {
-      page = parseInt(queryParams?.page, 10) || 0;
-    }
-    return page;
-  })();
+  // Functions to avoid race conditions
+  const initialSearchQuery = (() => queryParams?.query ?? "")();
+  const initialSortHeader = (() => queryParams?.order_key ?? "name")();
+  const initialSortDirection = (() =>
+    (queryParams?.order_direction as "asc" | "desc") ?? "asc")();
+  const initialVulnFilter = (() => queryParams?.vulnerable === "true")();
+  const initialPage = (() =>
+    queryParams && queryParams.page ? parseInt(queryParams?.page, 10) : 0)();
 
   // Never set as state as URL is source of truth
   const searchQuery = initialSearchQuery;

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -161,10 +161,13 @@ const ManagePolicyPage = ({
   })();
 
   // Never set as state as URL is source of truth
-  const searchQuery = initialSearchQuery;
-  const page = initialPage;
-  const showInheritedTable = initialShowInheritedTable;
-  const inheritedPage = initialInheritedPage;
+  // State only used for handling team change
+  const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
+  const [page, setPage] = useState(initialPage);
+  const [showInheritedTable, setShowInheritedTable] = useState(
+    initialShowInheritedTable
+  );
+  const [inheritedPage, setInheritedPage] = useState(initialInheritedPage);
 
   console.log("showInheritedTable", showInheritedTable);
   useEffect(() => {
@@ -176,6 +179,8 @@ const ManagePolicyPage = ({
     if (filteredPoliciesPath !== path) {
       setFilteredPoliciesPath(path);
     }
+    setShowInheritedTable(initialShowInheritedTable);
+    setInheritedPage(initialInheritedPage);
   }, [location, filteredPoliciesPath, setFilteredPoliciesPath]);
 
   console.log("filteredPoliciesPath", filteredPoliciesPath);
@@ -263,6 +268,10 @@ const ManagePolicyPage = ({
       // setShowInheritedPolicies(false);
       setSelectedPolicyIds([]);
       handleTeamChange(teamId);
+      setPage(0);
+      setSearchQuery("");
+      setShowInheritedTable(false);
+      setInheritedPage(0);
     },
     [handleTeamChange]
   );
@@ -293,11 +302,11 @@ const ManagePolicyPage = ({
         newQueryParams.team_id = teamIdForApi;
       }
 
-      if (showInheritedTable !== undefined) {
+      if (showInheritedTable) {
         newQueryParams.inherited_table = showInheritedTable.toString();
       }
 
-      if (inheritedPage !== undefined) {
+      if (showInheritedTable && inheritedPage !== 0) {
         newQueryParams.inherited_page = inheritedPage;
       }
 

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -465,6 +465,7 @@ const ManagePolicyPage = ({
       currentAutomatedPolicies = webhook?.policy_ids || [];
     }
   }
+
   return !isRouteOk || (isPremiumTier && !userTeams) ? (
     <Spinner />
   ) : (

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -122,37 +122,16 @@ const ManagePolicyPage = ({
   const [teamPolicies, setTeamPolicies] = useState<IPolicyStats[]>();
   const [inheritedPolicies, setInheritedPolicies] = useState<IPolicyStats[]>();
 
-  const initialSearchQuery = (() => {
-    let query = "";
-    if (queryParams && queryParams.query) {
-      query = queryParams.query;
-    }
-    return query;
-  })();
-
-  const initialPage = (() => {
-    let page = 0;
-    if (queryParams && queryParams.page) {
-      page = parseInt(queryParams?.page, 10) || 0;
-    }
-    return page;
-  })();
-
-  const initialShowInheritedTable = (() => {
-    let inheritedTable = false;
-    if (queryParams && queryParams.inherited_table === "true") {
-      inheritedTable = true;
-    }
-    return inheritedTable;
-  })();
-
-  const initialInheritedPage = (() => {
-    let inheritedPage = 0;
-    if (queryParams && queryParams.inherited_page) {
-      inheritedPage = parseInt(queryParams?.inherited_page, 10) || 0;
-    }
-    return inheritedPage;
-  })();
+  // Functions to avoid race conditions
+  const initialSearchQuery = (() => queryParams.query ?? "")();
+  const initialPage = (() =>
+    queryParams && queryParams.page ? parseInt(queryParams?.page, 10) : 0)();
+  const initialShowInheritedTable = (() =>
+    queryParams && queryParams.inherited_table === "true")();
+  const initialInheritedPage = (() =>
+    queryParams && queryParams.inherited_page
+      ? parseInt(queryParams?.inherited_page, 10)
+      : 0)();
 
   // Never set as state as URL is source of truth
   // State only used for handling team change
@@ -303,11 +282,7 @@ const ManagePolicyPage = ({
 
       if (teamIdForApi !== undefined) {
         newQueryParams.team_id = teamIdForApi;
-        // newQueryParams.page = 0;
-        // newQueryParams.query = "";
       }
-      console.log("teamIdForApi", teamIdForApi);
-      console.log("location", location);
 
       const locationPath = getNextLocationPath({
         pathPrefix: PATHS.MANAGE_POLICIES,

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
@@ -17,6 +17,7 @@ describe("Policies table", () => {
         currentTeam={{ id: -1, name: "All teams" }}
         isPremiumTier
         isSandboxMode
+        searchQuery=""
       />
     );
 
@@ -40,6 +41,7 @@ describe("Policies table", () => {
         currentTeam={{ id: -1, name: "All teams" }}
         isPremiumTier
         isSandboxMode={false}
+        searchQuery=""
       />
     );
 

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
@@ -18,6 +18,7 @@ describe("Policies table", () => {
         isPremiumTier
         isSandboxMode
         searchQuery=""
+        page={0}
       />
     );
 
@@ -42,6 +43,7 @@ describe("Policies table", () => {
         isPremiumTier
         isSandboxMode={false}
         searchQuery=""
+        page={0}
       />
     );
 

--- a/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
+++ b/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
@@ -181,7 +181,7 @@ const QueryEditor = ({
   return (
     <div className={`${baseClass}__form`}>
       <div className={`${baseClass}__header-links`}>
-        <BackLink text="Back to queries" path={backToPoliciesPath()} />
+        <BackLink text="Back to policies" path={backToPoliciesPath()} />
       </div>
       <PolicyForm
         onCreatePolicy={onCreatePolicy}

--- a/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
+++ b/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
@@ -49,7 +49,9 @@ const QueryEditor = ({
   onOpenSchemaSidebar,
   renderLiveQueryWarning,
 }: IQueryEditorProps): JSX.Element | null => {
-  const { currentUser, isPremiumTier } = useContext(AppContext);
+  const { currentUser, isPremiumTier, filteredPoliciesPath } = useContext(
+    AppContext
+  );
   const { renderFlash } = useContext(NotificationContext);
 
   // Note: The PolicyContext values should always be used for any mutable policy data such as query name
@@ -171,17 +173,15 @@ const QueryEditor = ({
     return null;
   }
 
+  // Function instead of constant eliminates race condition with filteredSoftwarePath
+  const backToPoliciesPath = () => {
+    return filteredPoliciesPath || PATHS.MANAGE_QUERIES;
+  };
+
   return (
     <div className={`${baseClass}__form`}>
       <div className={`${baseClass}__header-links`}>
-        <BackLink
-          text="Back to policies"
-          path={
-            policyTeamId
-              ? `${PATHS.MANAGE_POLICIES}?team_id=${policyTeamId}`
-              : PATHS.MANAGE_POLICIES
-          }
-        />
+        <BackLink text="Back to queries" path={backToPoliciesPath()} />
       </div>
       <PolicyForm
         onCreatePolicy={onCreatePolicy}

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -87,54 +87,18 @@ const QueriesTable = ({
 }: IQueriesTableProps): JSX.Element | null => {
   const { currentUser } = useContext(AppContext);
 
-  const initialSearchQuery = (() => {
-    let query = "";
-    if (queryParams && queryParams.query) {
-      query = queryParams.query;
-    }
-    return query;
-  })();
-
-  const initialSortHeader = (() => {
-    let sortHeader = "updated_at";
-    if (
-      queryParams &&
-      (queryParams.order_key === "name" ||
-        queryParams.order_key === "author_name")
-    ) {
-      sortHeader = queryParams.order_key;
-    }
-    return sortHeader;
-  })();
-
-  const initialSortDirection = ((): "asc" | "desc" | undefined => {
-    let sortDirection = "asc";
-    if (queryParams && queryParams.order_direction) {
-      sortDirection = queryParams.order_direction;
-    }
-    return sortDirection as "asc" | "desc" | undefined;
-  })();
-
-  const initialPlatform = (() => {
-    let platformSelected = "all";
-    if (
-      queryParams &&
-      (queryParams.platform === "windows" ||
-        queryParams.platform === "linux" ||
-        queryParams.platform === "darwin")
-    ) {
-      platformSelected = queryParams.platform;
-    }
-    return platformSelected;
-  })();
-
-  const initialPage = (() => {
-    let page = 0;
-    if (queryParams && queryParams.page) {
-      page = parseInt(queryParams?.page, 10) || 0;
-    }
-    return page;
-  })();
+  // Functions to avoid race conditions
+  const initialSearchQuery = (() => queryParams?.query ?? "")();
+  const initialSortHeader = (() =>
+    (queryParams?.order_key as "updated_at" | "name" | "author") ??
+    "updated_at")();
+  const initialSortDirection = (() =>
+    (queryParams?.order_direction as "asc" | "desc") ?? "asc")();
+  const initialPlatform = (() =>
+    (queryParams?.platform as "all" | "windows" | "linux" | "darwin") ??
+    "all")();
+  const initialPage = (() =>
+    queryParams && queryParams.page ? parseInt(queryParams?.page, 10) : 0)();
 
   // Never set as state as URL is source of truth
   const searchQuery = initialSearchQuery;
@@ -160,10 +124,6 @@ const QueriesTable = ({
         newQueryParams.query = newSearchQuery;
       }
 
-      console.log("page", page);
-      console.log("newPageIndex", newPageIndex);
-      console.log("searchQuery", searchQuery);
-      console.log("newSearchQuery", newSearchQuery);
       newQueryParams.order_key = newSortHeader || DEFAULT_SORT_HEADER;
       newQueryParams.order_direction =
         newSortDirection || DEFAULT_SORT_DIRECTION;

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -160,6 +160,10 @@ const QueriesTable = ({
         newQueryParams.query = newSearchQuery;
       }
 
+      console.log("page", page);
+      console.log("newPageIndex", newPageIndex);
+      console.log("searchQuery", searchQuery);
+      console.log("newSearchQuery", newSearchQuery);
       newQueryParams.order_key = newSortHeader || DEFAULT_SORT_HEADER;
       newQueryParams.order_direction =
         newSortDirection || DEFAULT_SORT_DIRECTION;

--- a/frontend/pages/queries/QueryPage/screens/QueryEditor.tsx
+++ b/frontend/pages/queries/QueryPage/screens/QueryEditor.tsx
@@ -139,10 +139,7 @@ const QueryEditor = ({
 
   // Function instead of constant eliminates race condition with filteredSoftwarePath
   const backToQueriesPath = () => {
-    if (filteredQueriesPath) {
-      return filteredQueriesPath;
-    }
-    return PATHS.MANAGE_QUERIES;
+    return filteredQueriesPath || PATHS.MANAGE_QUERIES;
   };
 
   return (


### PR DESCRIPTION
## Issue
Cerra #11343 

## Description
- Policies page has bookmarkability including:
  - Page number
  - Search
  - Inherited policies open or closed
  - Inherited policies page number

## Screenshot/screen recording

### Back to policies goes back to same screen
Ignore "Back to queries" in screen recording, pushed fix to say "Back to policies"

https://github.com/fleetdm/fleet/assets/71795832/253787d7-80d0-4e3e-bbfe-8c78e737e5c0

### Bookmarkability, can hit refresh or copy and paste url and will show exact same screen
https://github.com/fleetdm/fleet/assets/71795832/7ae82eec-3403-43f7-ac9b-81ee7a835f47


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
