### PR TITLE
Frontend: Remove storybook from lint check

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     "plugin:@typescript-eslint/recommended",
     "plugin:cypress/recommended",
     "plugin:prettier/recommended",
-    "plugin:storybook/recommended",
+    // "plugin:storybook/recommended", // storybook temporarily removed
   ],
   parser: "@typescript-eslint/parser",
   plugins: ["jest", "react", "@typescript-eslint"],


### PR DESCRIPTION
## Description
- Couldn't run `yarn lint` or `make lint-js` without removing storybook check because storybook is removed

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

