### PR TITLE
Improve error handling for `fleetctl mdm run-comand`

### DIFF
--- a/cmd/fleetctl/mdm_test.go
+++ b/cmd/fleetctl/mdm_test.go
@@ -136,6 +136,19 @@ func TestMDMRunCommand(t *testing.T) {
 	_, err = runAppNoChecks([]string{"mdm", "run-command", "--host", "valid-host", "--payload", cmdFilePath})
 	require.Error(t, err)
 	require.ErrorContains(t, err, `missing or invalid license`)
+
+	// try to run an empty plist as a command
+	tmpFile, err := os.CreateTemp(t.TempDir(), "*.xml")
+	require.NoError(t, err)
+	_, err = tmpFile.WriteString(fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+</plist>`))
+	require.NoError(t, err)
+
+	_, err = runAppNoChecks([]string{"mdm", "run-command", "--host", "valid-host", "--payload", tmpFile.Name()})
+	require.Error(t, err)
+	require.ErrorContains(t, err, `The payload isn't valid. Please provide a valid MDM command in the form of a plist-encoded XML file.`)
 }
 
 func writeTmpMDMCmd(t *testing.T, commandName string) string {

--- a/server/service/client_apple_mdm.go
+++ b/server/service/client_apple_mdm.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -15,6 +16,10 @@ func (c *Client) EnqueueCommand(deviceIDs []string, rawPlist []byte) (*fleet.Com
 	var commandPayload map[string]interface{}
 	if _, err := plist.Unmarshal(rawPlist, &commandPayload); err != nil {
 		return nil, fmt.Errorf("The payload isn't valid XML. Please provide a file with valid XML: %w", err)
+	}
+
+	if commandPayload == nil {
+		return nil, errors.New("The payload isn't valid. Please provide a valid MDM command in the form of a plist-encoded XML file.")
 	}
 
 	// generate a random command UUID


### PR DESCRIPTION
Addresses QA comments raised in this [thread](https://github.com/fleetdm/fleet/issues/11040#issuecomment-1540490486)

