### PR TITLE
Remove Eric from CX product group

### DIFF
--- a/handbook/company/development-groups.md
+++ b/handbook/company/development-groups.md
@@ -52,7 +52,7 @@ The goal of the customer experience (CX) group is to make users and customers ha
 | Engineering manager               | Sharon Katz
 | Quality assurance                 | Reed Haynes
 | Product manager                   | Zay Hanlon
-| Software engineers (developers)   | Jacob Shandling, Juan Fernandez*, Lucas Rodriguez, Rachel Perkins, Marcos Oviedo, Eric Shaw
+| Software engineers (developers)   | Jacob Shandling, Juan Fernandez*, Lucas Rodriguez, Rachel Perkins, Marcos Oviedo
 
 > The Slack channel, kanban release board, and label for this product group is `#g-cx`.
 


### PR DESCRIPTION
Now that the g-website group has been added, can we track Eric's work there? Will save him double meetings, and streamline the CX rituals.
