### PR TITLE
Fleet UI: New filepath column on host details > software table

### DIFF
--- a/changes/10196-surface-software-filepath
+++ b/changes/10196-surface-software-filepath
@@ -1,0 +1,1 @@
+- Users can now see the filepath of software on a host

--- a/frontend/components/DiskSpaceGraph/DiskSpaceGraph.tsx
+++ b/frontend/components/DiskSpaceGraph/DiskSpaceGraph.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import ReactTooltip from "react-tooltip";
+import { COLORS } from "styles/var/colors";
 
 interface IDiskSpaceGraphProps {
   baseClass: string;
@@ -71,7 +72,7 @@ const DiskSpaceGraph = ({
           type="dark"
           effect="solid"
           id={`tooltip-${id}`}
-          backgroundColor="#3e4771"
+          backgroundColor={COLORS["tooltip-bg"]}
         >
           <span
             className={`${baseClass}__tooltip-text`}

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -31,7 +31,6 @@ const rebuildQueryStringWithTeamId = (
 ) => {
   const parts = splitQueryStringParts(queryString);
   const teamIndex = parts.findIndex((p) => p.startsWith("team_id="));
-
   // URLs for the app represent "All teams" by the absence of the team id param
   const newTeamPart =
     newTeamId > APP_CONTEXT_ALL_TEAMS_ID ? `team_id=${newTeamId}` : "";

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -33,7 +33,7 @@ export interface ISoftware {
   vulnerabilities: IVulnerability[] | null;
   hosts_count?: number;
   last_opened_at?: string | null; // e.g., "2021-08-18T15:11:35Z”
-  installed_path?: string[];
+  installed_paths?: string[];
 }
 
 export const TYPE_CONVERSION: Record<string, string> = {

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -33,7 +33,7 @@ export interface ISoftware {
   vulnerabilities: IVulnerability[] | null;
   hosts_count?: number;
   last_opened_at?: string | null; // e.g., "2021-08-18T15:11:35Z”
-  installed_path?: string;
+  installed_path?: string[];
 }
 
 export const TYPE_CONVERSION: Record<string, string> = {

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -33,6 +33,7 @@ export interface ISoftware {
   vulnerabilities: IVulnerability[] | null;
   hosts_count?: number;
   last_opened_at?: string | null; // e.g., "2021-08-18T15:11:35Z”
+  installed_path?: string;
 }
 
 export const TYPE_CONVERSION: Record<string, string> = {

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -353,6 +353,8 @@ const allHostTableHeaders: IDataColumn[] = [
               backgroundColor="#3e4771"
               id={`device_mapping__${cellProps.row.original.id}`}
               data-html
+              clickable
+              delayHide={300}
             >
               <span className={`tooltip__tooltip-text`}>{tooltipText}</span>
             </ReactTooltip>

--- a/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
@@ -353,7 +353,30 @@ export const generateSoftwareTableHeaders = ({
         );
       },
       accessor: "installed_path",
-      Cell: (cellProps: IInstalledPathCellProps): JSX.Element => {
+      Cell: (cellProps1: IInstalledPathCellProps): JSX.Element => {
+        const randomizePaths = () => {
+          const items = [
+            [
+              "three/path/found",
+              "directory/dir/example/of",
+              "three/different/paths",
+            ],
+            undefined,
+            ["example/of/a/single/path"],
+            [
+              "4/four",
+              "directory/dir/different/paths",
+              "installed/various",
+              "places/ohmy/wow/ok/bye",
+            ],
+            ["root/cool/2paths/here", "cool/byebye"],
+          ];
+          return items[Math.floor(Math.random() * items.length)];
+        };
+
+        const cellProps = {
+          cell: { value: randomizePaths() },
+        };
         const numInstalledPaths = cellProps.cell.value?.length || 0;
         const installedPaths = condenseInstalledPaths(
           cellProps.cell.value || []
@@ -367,7 +390,7 @@ export const generateSoftwareTableHeaders = ({
                   installedPaths.length > 1 ? "text-muted tooltip" : ""
                 }`}
                 data-tip
-                data-for={`installed_path__${cellProps.row.original.id}`}
+                data-for={`installed_path__${cellProps1.row.original.id}`}
                 data-tip-disable={installedPaths.length <= 1}
               >
                 {numInstalledPaths === 1
@@ -377,7 +400,7 @@ export const generateSoftwareTableHeaders = ({
               <ReactTooltip
                 effect="solid"
                 backgroundColor={COLORS["tooltip-bg"]}
-                id={`installed_path__${cellProps.row.original.id}`}
+                id={`installed_path__${cellProps1.row.original.id}`}
                 data-html
                 clickable
                 delayHide={300}

--- a/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
@@ -309,6 +309,20 @@ export const generateSoftwareTableHeaders = ({
       sortType: "dateStrings",
     },
     {
+      title: "File path",
+      Header: () => {
+        return (
+          <TooltipWrapper tipContent="This is where the software is <br />located on this host.">
+            File path
+          </TooltipWrapper>
+        );
+      },
+      accessor: "installed_path",
+      Cell: (cellProps: IStringCellProps) => {
+        return <TextCell value={cellProps.cell.value} />;
+      },
+    },
+    {
       title: "",
       Header: "",
       disableSortBy: true,

--- a/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
@@ -352,7 +352,7 @@ export const generateSoftwareTableHeaders = ({
           </TooltipWrapper>
         );
       },
-      accessor: "installed_path",
+      accessor: "installed_paths",
       Cell: (cellProps: IInstalledPathCellProps): JSX.Element => {
         const numInstalledPaths = cellProps.cell.value?.length || 0;
         const installedPaths = condenseInstalledPaths(
@@ -367,7 +367,7 @@ export const generateSoftwareTableHeaders = ({
                   installedPaths.length > 1 ? "text-muted tooltip" : ""
                 }`}
                 data-tip
-                data-for={`installed_path__${cellProps.row.original.id}`}
+                data-for={`installed_paths__${cellProps.row.original.id}`}
                 data-tip-disable={installedPaths.length <= 1}
               >
                 {numInstalledPaths === 1
@@ -377,7 +377,7 @@ export const generateSoftwareTableHeaders = ({
               <ReactTooltip
                 effect="solid"
                 backgroundColor={COLORS["tooltip-bg"]}
-                id={`installed_path__${cellProps.row.original.id}`}
+                id={`installed_paths__${cellProps.row.original.id}`}
                 data-html
                 clickable
                 delayHide={300}

--- a/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
@@ -353,30 +353,7 @@ export const generateSoftwareTableHeaders = ({
         );
       },
       accessor: "installed_path",
-      Cell: (cellProps1: IInstalledPathCellProps): JSX.Element => {
-        const randomizePaths = () => {
-          const items = [
-            [
-              "three/path/found",
-              "directory/dir/example/of",
-              "three/different/paths",
-            ],
-            undefined,
-            ["example/of/a/single/path"],
-            [
-              "4/four",
-              "directory/dir/different/paths",
-              "installed/various",
-              "places/ohmy/wow/ok/bye",
-            ],
-            ["root/cool/2paths/here", "cool/byebye"],
-          ];
-          return items[Math.floor(Math.random() * items.length)];
-        };
-
-        const cellProps = {
-          cell: { value: randomizePaths() },
-        };
+      Cell: (cellProps: IInstalledPathCellProps): JSX.Element => {
         const numInstalledPaths = cellProps.cell.value?.length || 0;
         const installedPaths = condenseInstalledPaths(
           cellProps.cell.value || []
@@ -390,7 +367,7 @@ export const generateSoftwareTableHeaders = ({
                   installedPaths.length > 1 ? "text-muted tooltip" : ""
                 }`}
                 data-tip
-                data-for={`installed_path__${cellProps1.row.original.id}`}
+                data-for={`installed_path__${cellProps.row.original.id}`}
                 data-tip-disable={installedPaths.length <= 1}
               >
                 {numInstalledPaths === 1
@@ -400,7 +377,7 @@ export const generateSoftwareTableHeaders = ({
               <ReactTooltip
                 effect="solid"
                 backgroundColor={COLORS["tooltip-bg"]}
-                id={`installed_path__${cellProps1.row.original.id}`}
+                id={`installed_path__${cellProps.row.original.id}`}
                 data-html
                 clickable
                 delayHide={300}

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -184,7 +184,7 @@
 
   // Only show this column to macos users
   .macos .data-table-block .data-table__table {
-    .installed_path__header {
+    .installed_paths__header {
       border-right: none;
     }
 
@@ -198,7 +198,7 @@
         .last_opened_at__header {
           display: table-cell;
         }
-        .installed_path__header {
+        .installed_paths__header {
           width: $col-md;
         }
       }
@@ -207,7 +207,7 @@
           display: table-cell;
         }
 
-        .installed_path__cell {
+        .installed_paths__cell {
           .tooltip {
             display: inline; // center tooltip with hovered text
           }

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -106,7 +106,7 @@
         @media (min-width: $break-1400) {
           .source__cell {
             display: table-cell;
-            width: $col-md;
+            width: $col-sm;
           }
           .hosts_count__cell {
             .hosts-cell__wrapper {
@@ -184,6 +184,10 @@
 
   // Only show this column to macos users
   .macos .data-table-block .data-table__table {
+    .installed_path__header {
+      border-right: none;
+    }
+
     @media (min-width: $break-990) {
       thead .version__header {
         width: $col-sm;
@@ -191,16 +195,20 @@
     }
     @media (min-width: $break-1400) {
       thead {
-        .vulnerabilities__header {
-          width: $col-md;
-        }
         .last_opened_at__header {
           display: table-cell;
+        }
+        .installed_path__header {
+          width: $col-md;
         }
       }
       tbody {
         .last_opened_at__cell {
           display: table-cell;
+        }
+
+        .linkToFilteredHosts__cell {
+          width: 120px;
         }
       }
     }

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -207,6 +207,12 @@
           display: table-cell;
         }
 
+        .installed_path__cell {
+          .tooltip {
+            display: inline; // center tooltip with hovered text
+          }
+        }
+
         .linkToFilteredHosts__cell {
           width: 120px;
         }


### PR DESCRIPTION
## Issue
Cerra #10196

## Description
- Frontend code for UI to surface filepath name on host details page's software table
- Ensure view all hosts link still has space and table looks good on various widths
- UI modeled after manage host page table users column where there can be multiple users

## Screenshot
MOCK DATA
<img width="1537" alt="Screenshot 2023-05-10 at 11 27 18 AM" src="https://github.com/fleetdm/fleet/assets/71795832/29c137ce-4e91-4735-bbe1-fe88f849b084">

REAL DATA 5:23 PM day before freeze after backend has been merged and rebased off backend.
<img width="1706" alt="Screenshot 2023-05-17 at 5 21 44 PM" src="https://github.com/fleetdm/fleet/assets/71795832/a8ec18d7-cd83-4dde-83aa-07f9cbd820f5">

## TODO Decisions around UX/UI design
- what width do we want to truncate
- what width do we want tooltip because filepath won't fit a normal tooltip

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

