### PR TITLE
Implement worker jobs that update/re-assign setup assistants on changes

### DIFF
--- a/changes/issue-10995-integrate-setup-assistant-with-apple-dep
+++ b/changes/issue-10995-integrate-setup-assistant-with-apple-dep
@@ -1,1 +1,2 @@
 * Integrated the macOS setup assistant feature with Apple DEP so that the setup assistants are assigned to the enrolled devices.
+* Re-assign and update the macOS setup assistants (and the default one) whenever required, such as when it is modified, when a host is transferred, a team is deleted, etc.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -573,10 +573,15 @@ func newWorkerIntegrationsSchedule(
 		Log:           logger,
 		NewClientFunc: newZendeskClient,
 	}
+	macosSetupAsst := &worker.MacosSetupAssistant{
+		Datastore: ds,
+		Log:       logger,
+	}
 	// leave the url empty for now, will be filled when the lock is acquired with
 	// the up-to-date config.
 	w.Register(jira)
 	w.Register(zendesk)
+	w.Register(macosSetupAsst)
 
 	// Read app config a first time before starting, to clear up any failer client
 	// configuration if we're not on a fleet-owned server. Technically, the ServerURL

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -682,14 +682,14 @@ the way that the Fleet server works.
 			}
 
 			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
-				return newWorkerIntegrationsSchedule(ctx, instanceID, ds, logger)
+				return newWorkerIntegrationsSchedule(ctx, instanceID, ds, logger, depStorage)
 			}); err != nil {
 				initFatal(err, "failed to register worker integrations schedule")
 			}
 
 			if license.IsPremium() && appCfg.MDM.EnabledAndConfigured && config.MDM.IsAppleBMSet() {
 				if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
-					return newAppleMDMDEPProfileAssigner(ctx, instanceID, config.MDM.AppleDEPSyncPeriodicity, ds, depStorage, logger, config.Logging.Debug)
+					return newAppleMDMDEPProfileAssigner(ctx, instanceID, config.MDM.AppleDEPSyncPeriodicity, ds, depStorage, logger)
 				}); err != nil {
 					initFatal(err, "failed to register apple_mdm_dep_profile_assigner schedule")
 				}

--- a/cmd/fleetctl/apply_test.go
+++ b/cmd/fleetctl/apply_test.go
@@ -1106,7 +1106,9 @@ func TestApplyMacosSetup(t *testing.T) {
 		ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
 			return nil
 		}
-
+		ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
+			return job, nil
+		}
 		ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
 			team, ok := teamsByName[name]
 			if !ok {

--- a/cmd/fleetctl/hosts_test.go
+++ b/cmd/fleetctl/hosts_test.go
@@ -46,6 +46,10 @@ func TestHostsTransferByHosts(t *testing.T) {
 		return nil
 	}
 
+	ds.ListMDMAppleDEPSerialsInHostIDsFunc = func(ctx context.Context, hostIDs []uint) ([]string, error) {
+		return nil, nil
+	}
+
 	assert.Equal(t, "", runAppForTest(t, []string{"hosts", "transfer", "--team", "team1", "--hosts", "host1"}))
 }
 
@@ -82,6 +86,10 @@ func TestHostsTransferByLabel(t *testing.T) {
 
 	ds.BulkSetPendingMDMAppleHostProfilesFunc = func(ctx context.Context, hostIDs, teamIDs, profileIDs []uint, uuids []string) error {
 		return nil
+	}
+
+	ds.ListMDMAppleDEPSerialsInHostIDsFunc = func(ctx context.Context, hostIDs []uint) ([]string, error) {
+		return nil, nil
 	}
 
 	assert.Equal(t, "", runAppForTest(t, []string{"hosts", "transfer", "--team", "team1", "--label", "label1"}))
@@ -121,6 +129,10 @@ func TestHostsTransferByStatus(t *testing.T) {
 		return nil
 	}
 
+	ds.ListMDMAppleDEPSerialsInHostIDsFunc = func(ctx context.Context, hostIDs []uint) ([]string, error) {
+		return nil, nil
+	}
+
 	assert.Equal(t, "", runAppForTest(t,
 		[]string{"hosts", "transfer", "--team", "team1", "--status", "online"}))
 }
@@ -158,6 +170,10 @@ func TestHostsTransferByStatusAndSearchQuery(t *testing.T) {
 
 	ds.BulkSetPendingMDMAppleHostProfilesFunc = func(ctx context.Context, hostIDs, teamIDs, profileIDs []uint, uuids []string) error {
 		return nil
+	}
+
+	ds.ListMDMAppleDEPSerialsInHostIDsFunc = func(ctx context.Context, hostIDs []uint) ([]string, error) {
+		return nil, nil
 	}
 
 	assert.Equal(t, "", runAppForTest(t,

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -473,7 +473,6 @@ func (svc *Service) SetOrUpdateMDMAppleSetupAssistant(ctx context.Context, asst 
 			return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("profile", msg))
 		}
 	}
-	// TODO(mna): enqueue job to Define/Assign profile svc.depService.RegisterProfileWithAppleDEPServer()
 
 	// must read the existing setup assistant first to detect if it did change
 	// (so that the changed activity is not created if the same assistant was
@@ -665,22 +664,10 @@ func (svc *Service) InitiateMDMAppleSSOCallback(ctx context.Context, auth fleet.
 }
 
 func (svc *Service) mdmAppleSyncDEPProfiles(ctx context.Context) error {
-	// TODO(mna): all profiles must be updated: this gets called when the ServerURL or MDM
-	// SSO got modified. And then all devices part of the profile's team must be re-assigned
-	// the updated profile. Enqueue a worker job to take care of this.
-
-	// get the automatic enrollment profile to re-define it with Apple.
-	depProf, err := svc.getAutomaticEnrollmentProfile(ctx)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "fetching enrollment profile")
+	if err := worker.QueueMacosSetupAssistantJob(ctx, svc.ds, svc.logger, worker.MacosSetupAssistantUpdateAllProfiles, nil); err != nil {
+		return ctxerr.Wrap(ctx, err, "queue macos setup assistant update all profiles job")
 	}
-
-	if depProf == nil {
-		// CreateDefaultProfile takes care of registering the profile with Apple.
-		return svc.depService.CreateDefaultProfile(ctx)
-	}
-
-	return svc.depService.RegisterProfileWithAppleDEPServer(ctx, nil)
+	return nil
 }
 
 // returns the default automatic enrollment profile, or nil (without error) if none exists.

--- a/ee/server/service/service.go
+++ b/ee/server/service/service.go
@@ -57,7 +57,7 @@ func NewService(
 		mdmAppleCommander: mdmAppleCommander,
 		mdmPushCertTopic:  mdmPushCertTopic,
 		ssoSessionStore:   sso,
-		depService:        apple_mdm.NewDEPService(ds, depStorage, logger, false),
+		depService:        apple_mdm.NewDEPService(ds, depStorage, logger),
 	}
 
 	// Override methods that can't be easily overriden via

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -2138,3 +2138,11 @@ func (ds *Datastore) DeleteMDMAppleSetupAssistant(ctx context.Context, teamID *u
 	}
 	return nil
 }
+
+func (ds *Datastore) ListMDMAppleDEPSerialsInTeam(ctx context.Context, teamID *uint) ([]string, error) {
+	panic("unimplemented")
+}
+
+func (ds *Datastore) ListMDMAppleDEPSerialsInHostIDs(ctx context.Context, hostIDs []uint) ([]string, error) {
+	panic("unimplemented")
+}

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -2186,7 +2186,7 @@ FROM
 	%s
 WHERE
 	h.hardware_serial != '' AND
-	h.id IN (?)
+	h.id IN (?) AND
 	hmdm.name = ? AND
 	-- hmdm.enrolled can be either 0 or 1, does not matter
 	hmdm.installed_from_dep = 1 AND

--- a/server/datastore/mysql/password_reset_test.go
+++ b/server/datastore/mysql/password_reset_test.go
@@ -107,7 +107,7 @@ func testPasswordResetTokenExpiration(t *testing.T, ds *Datastore) {
 			assert.Equal(t, req.ID, found.ID)
 			assert.Equal(t, req.UserID, found.UserID)
 			assert.Equal(t, req.Token, found.Token)
-			assert.Equal(t, req.ExpiresAt.Round(time.Minute), found.ExpiresAt.Round(time.Minute))
+			assert.WithinDuration(t, req.ExpiresAt.Truncate(time.Minute), found.ExpiresAt.Truncate(time.Minute), time.Minute)
 		}
 	}
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -814,6 +814,16 @@ type Datastore interface {
 	// not already enrolled in Fleet.
 	IngestMDMAppleDeviceFromCheckin(ctx context.Context, mdmHost MDMAppleHostDetails) error
 
+	// ListMDMAppleDEPSerialsInTeam returns a list of serial numbers of hosts
+	// that are enrolled or pending enrollment in Fleet's MDM via DEP for the
+	// specified team (or no team if teamID is nil).
+	ListMDMAppleDEPSerialsInTeam(ctx context.Context, teamID *uint) ([]string, error)
+
+	// ListMDMAppleDEPSerialsInHostIDs returns a list of serial numbers of hosts
+	// that are enrolled or pending enrollment in Fleet's MDM via DEP in the
+	// specified list of host IDs.
+	ListMDMAppleDEPSerialsInHostIDs(ctx context.Context, hostIDs []uint) ([]string, error)
+
 	// GetNanoMDMEnrollment returns the nano enrollment information for the device id.
 	GetNanoMDMEnrollment(ctx context.Context, id string) (*NanoEnrollment, error)
 

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -703,6 +703,16 @@ func (h *HostMDM) IsPendingDEPFleetEnrollment() bool {
 		h.Name == WellKnownMDMFleet
 }
 
+// IsDEPFleetEnrolled returns true if the host's MDM information indicates that
+// it is in enrolled state for Fleet MDM DEP (automatic) enrollment.
+func (h *HostMDM) IsDEPFleetEnrolled() bool {
+	if h == nil {
+		return false
+	}
+	return (!h.IsServer) && (h.Enrolled) && h.InstalledFromDep &&
+		h.Name == WellKnownMDMFleet
+}
+
 // HostMunkiIssue represents a single munki issue for a host.
 type HostMunkiIssue struct {
 	MunkiIssueID       uint      `db:"munki_issue_id" json:"id"`

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -189,7 +189,8 @@ func (d *DEPService) RegisterProfileWithAppleDEPServer(ctx context.Context, setu
 		rawJSON = setupAsst.Profile
 	}
 
-	var jsonProf *godep.Profile
+	var jsonProf godep.Profile
+	jsonProf.IsMDMRemovable = true // the default value is true
 	if err := json.Unmarshal(rawJSON, &jsonProf); err != nil {
 		return ctxerr.Wrap(ctx, err, "unmarshalling DEP profile")
 	}
@@ -213,7 +214,7 @@ func (d *DEPService) RegisterProfileWithAppleDEPServer(ctx context.Context, setu
 	}
 
 	depClient := NewDEPClient(d.depStorage, d.ds, d.logger)
-	res, err := depClient.DefineProfile(ctx, DEPName, jsonProf)
+	res, err := depClient.DefineProfile(ctx, DEPName, &jsonProf)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "apple POST /profile request failed")
 	}

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -161,7 +161,8 @@ func (d *DEPService) createProfile(ctx context.Context, depProfile *godep.Profil
 
 // RegisterProfileWithAppleDEPServer registers the enrollment profile in
 // Apple's servers via the DEP API, so it can be used for assignment. If
-// setupAsst is nil, the default profile is registered.
+// setupAsst is nil, the default profile is registered. It assigns the
+// up-to-date dynamic settings such as the server URL and MDM SSO URL.
 func (d *DEPService) RegisterProfileWithAppleDEPServer(ctx context.Context, setupAsst *fleet.MDMAppleSetupAssistant) error {
 	appCfg, err := d.ds.AppConfig(ctx)
 	if err != nil {
@@ -233,7 +234,10 @@ func (d *DEPService) RegisterProfileWithAppleDEPServer(ctx context.Context, setu
 	return nil
 }
 
-func (d *DEPService) ensureDefaultSetupAssistant(ctx context.Context) (string, time.Time, error) {
+// EnsureDefaultSetupAssistant ensures that the default Setup Assistant profile
+// is created and registered with Apple, and returns its profile UUID. It does
+// not re-define the profile if it already exists.
+func (d *DEPService) EnsureDefaultSetupAssistant(ctx context.Context) (string, time.Time, error) {
 	profileUUID, profileModTime, err := d.depStorage.RetrieveAssignerProfile(ctx, DEPName)
 	if err != nil {
 		return "", time.Time{}, err
@@ -251,7 +255,12 @@ func (d *DEPService) ensureDefaultSetupAssistant(ctx context.Context) (string, t
 	return profileUUID, profileModTime, nil
 }
 
-func (d *DEPService) ensureCustomSetupAssistantIfExists(ctx context.Context, tmID *uint) (string, time.Time, error) {
+// EnsureCustomSetupAssistantIfExists ensures that the custom Setup Assistant
+// profile associated with the provided team (or no team) is registered with
+// Apple, and returns its profile UUID. It does not re-define the profile if it
+// is already registered. If no custom setup assistant exists, it returns an
+// empty string and timestamp and no error.
+func (d *DEPService) EnsureCustomSetupAssistantIfExists(ctx context.Context, tmID *uint) (string, time.Time, error) {
 	asst, err := d.ds.GetMDMAppleSetupAssistant(ctx, tmID)
 	if err != nil {
 		if fleet.IsNotFound(err) {
@@ -272,7 +281,7 @@ func (d *DEPService) ensureCustomSetupAssistantIfExists(ctx context.Context, tmI
 func (d *DEPService) RunAssigner(ctx context.Context) error {
 	// ensure the default (fallback) setup assistant profile exists, registered
 	// with Apple DEP.
-	_, defModTime, err := d.ensureDefaultSetupAssistant(ctx)
+	_, defModTime, err := d.EnsureDefaultSetupAssistant(ctx)
 	if err != nil {
 		return err
 	}
@@ -294,7 +303,7 @@ func (d *DEPService) RunAssigner(ctx context.Context) error {
 			customTeamID = &tm.ID
 		}
 	}
-	customUUID, customModTime, err := d.ensureCustomSetupAssistantIfExists(ctx, customTeamID)
+	customUUID, customModTime, err := d.EnsureCustomSetupAssistantIfExists(ctx, customTeamID)
 	if err != nil {
 		return err
 	}
@@ -370,12 +379,12 @@ func (d *DEPService) processDeviceResponse(ctx context.Context, depClient *godep
 	}
 
 	// get profile uuid of tmID or default
-	profUUID, _, err := d.ensureCustomSetupAssistantIfExists(ctx, tmID)
+	profUUID, _, err := d.EnsureCustomSetupAssistantIfExists(ctx, tmID)
 	if err != nil {
 		return fmt.Errorf("ensure setup assistant for team %v: %w", tmID, err)
 	}
 	if profUUID == "" {
-		profUUID, _, err = d.ensureDefaultSetupAssistant(ctx)
+		profUUID, _, err = d.EnsureDefaultSetupAssistant(ctx)
 		if err != nil {
 			return fmt.Errorf("ensure default setup assistant: %w", err)
 		}

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -334,7 +334,6 @@ func NewDEPService(
 	ds fleet.Datastore,
 	depStorage nanodep_storage.AllStorage,
 	logger kitlog.Logger,
-	loggingDebug bool,
 ) *DEPService {
 	depClient := NewDEPClient(depStorage, ds, logger)
 	depSvc := &DEPService{

--- a/server/mdm/apple/apple_mdm_external_test.go
+++ b/server/mdm/apple/apple_mdm_external_test.go
@@ -1,0 +1,293 @@
+package apple_mdm_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/test"
+	"github.com/go-kit/log"
+	nanodep_client "github.com/micromdm/nanodep/client"
+	"github.com/micromdm/nanodep/godep"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDEPService_RunAssigner(t *testing.T) {
+	ctx := context.Background()
+	ds := mysql.CreateMySQLDS(t)
+
+	testBMToken := nanodep_client.OAuth1Tokens{
+		ConsumerKey:       "test_consumer",
+		ConsumerSecret:    "test_secret",
+		AccessToken:       "test_access_token",
+		AccessSecret:      "test_access_secret",
+		AccessTokenExpiry: time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	depStorage, err := ds.NewMDMAppleDEPStorage(testBMToken)
+	require.NoError(t, err)
+
+	setupTest := func(t *testing.T, depHandler http.HandlerFunc) *apple_mdm.DEPService {
+		// start a server that will mock the Apple DEP API
+		srv := httptest.NewServer(depHandler)
+		t.Cleanup(srv.Close)
+		t.Cleanup(func() { mysql.TruncateTables(t, ds) })
+
+		err = depStorage.StoreConfig(ctx, apple_mdm.DEPName, &nanodep_client.Config{BaseURL: srv.URL})
+		require.NoError(t, err)
+
+		logger := log.NewNopLogger()
+		return apple_mdm.NewDEPService(ds, depStorage, logger, true)
+	}
+
+	t.Run("no custom profiles, no devices", func(t *testing.T) {
+		start := time.Now().Truncate(time.Second)
+
+		svc := setupTest(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			encoder := json.NewEncoder(w)
+			switch r.URL.Path {
+			case "/session":
+				_, _ = w.Write([]byte(`{"auth_session_token": "session123"}`))
+			case "/account":
+				_, _ = w.Write([]byte(`{"admin_id": "admin123", "org_name": "test_org"}`))
+			case "/profile":
+				err := encoder.Encode(godep.ProfileResponse{ProfileUUID: "profile123"})
+				require.NoError(t, err)
+			case "/server/devices":
+				err := encoder.Encode(godep.DeviceResponse{Devices: nil})
+				require.NoError(t, err)
+			case "/devices/sync":
+				err := encoder.Encode(godep.DeviceResponse{Devices: nil})
+				require.NoError(t, err)
+			default:
+				t.Errorf("unexpected request to %s", r.URL.Path)
+			}
+		})
+		err := svc.RunAssigner(ctx)
+		require.NoError(t, err)
+
+		// the default profile was created
+		defProf, err := ds.GetMDMAppleEnrollmentProfileByType(ctx, fleet.MDMAppleEnrollmentTypeAutomatic)
+		require.NoError(t, err)
+		require.NotNil(t, defProf)
+		require.NotEmpty(t, defProf.Token)
+
+		// a profile UUID was assigned
+		profUUID, modTime, err := depStorage.RetrieveAssignerProfile(ctx, apple_mdm.DEPName)
+		require.NoError(t, err)
+		require.Equal(t, "profile123", profUUID)
+		require.False(t, modTime.Before(start))
+
+		// no team to assign to
+		appCfg, err := ds.AppConfig(ctx)
+		require.NoError(t, err)
+		require.Empty(t, appCfg.MDM.AppleBMDefaultTeam)
+
+		// no teams, so no team-specific custom setup assistants
+		teams, err := ds.ListTeams(ctx, fleet.TeamFilter{User: test.UserAdmin}, fleet.ListOptions{})
+		require.NoError(t, err)
+		require.Empty(t, teams)
+
+		// no no-team custom setup assistant
+		_, err = ds.GetMDMAppleSetupAssistant(ctx, nil)
+		require.ErrorIs(t, err, sql.ErrNoRows)
+
+		// no host got created
+		hosts, err := ds.ListHosts(ctx, fleet.TeamFilter{User: test.UserAdmin}, fleet.HostListOptions{})
+		require.NoError(t, err)
+		require.Empty(t, hosts)
+	})
+
+	t.Run("no custom profiles, some devices", func(t *testing.T) {
+		start := time.Now().Truncate(time.Second)
+
+		devices := []godep.Device{
+			{SerialNumber: "a", OpType: "added"},
+			{SerialNumber: "b", OpType: "ignore"},
+			{SerialNumber: "c", OpType: ""},
+		}
+
+		var assignCalled bool
+		svc := setupTest(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			encoder := json.NewEncoder(w)
+			switch r.URL.Path {
+			case "/session":
+				_, _ = w.Write([]byte(`{"auth_session_token": "session123"}`))
+			case "/account":
+				_, _ = w.Write([]byte(`{"admin_id": "admin123", "org_name": "test_org"}`))
+			case "/profile":
+				err := encoder.Encode(godep.ProfileResponse{ProfileUUID: "profile123"})
+				require.NoError(t, err)
+			case "/server/devices":
+				err := encoder.Encode(godep.DeviceResponse{Devices: devices})
+				require.NoError(t, err)
+			case "/devices/sync":
+				err := encoder.Encode(godep.DeviceResponse{Devices: devices})
+				require.NoError(t, err)
+			case "/profile/devices":
+				assignCalled = true
+
+				reqBody, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				var assignReq godep.Profile
+				err = json.Unmarshal(reqBody, &assignReq)
+				require.NoError(t, err)
+				require.Equal(t, assignReq.ProfileUUID, "profile123")
+				require.ElementsMatch(t, []string{"a", "c"}, assignReq.Devices)
+
+				_, _ = w.Write([]byte(`{}`))
+			default:
+				t.Errorf("unexpected request to %s", r.URL.Path)
+			}
+		})
+		err := svc.RunAssigner(ctx)
+		require.NoError(t, err)
+		require.True(t, assignCalled)
+
+		// the default profile was created
+		defProf, err := ds.GetMDMAppleEnrollmentProfileByType(ctx, fleet.MDMAppleEnrollmentTypeAutomatic)
+		require.NoError(t, err)
+		require.NotNil(t, defProf)
+		require.NotEmpty(t, defProf.Token)
+
+		// a profile UUID was assigned
+		profUUID, modTime, err := depStorage.RetrieveAssignerProfile(ctx, apple_mdm.DEPName)
+		require.NoError(t, err)
+		require.Equal(t, "profile123", profUUID)
+		require.False(t, modTime.Before(start))
+
+		// a couple hosts were created (except the op_type ignored)
+		hosts, err := ds.ListHosts(ctx, fleet.TeamFilter{User: test.UserAdmin}, fleet.HostListOptions{})
+		require.NoError(t, err)
+		require.Len(t, hosts, 2)
+		serials := make([]string, len(hosts))
+		for i, h := range hosts {
+			serials[i] = h.HardwareSerial
+			require.Nil(t, h.TeamID, h.HardwareSerial)
+		}
+		require.ElementsMatch(t, []string{"a", "c"}, serials)
+	})
+
+	t.Run("a custom profile, some devices", func(t *testing.T) {
+		start := time.Now().Truncate(time.Second)
+
+		devices := []godep.Device{
+			{SerialNumber: "a", OpType: "added"},
+			{SerialNumber: "b", OpType: "ignore"},
+			{SerialNumber: "c", OpType: ""},
+		}
+
+		var assignCalled bool
+		svc := setupTest(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			encoder := json.NewEncoder(w)
+			switch r.URL.Path {
+			case "/session":
+				_, _ = w.Write([]byte(`{"auth_session_token": "session123"}`))
+			case "/account":
+				_, _ = w.Write([]byte(`{"admin_id": "admin123", "org_name": "test_org"}`))
+			case "/profile":
+				reqBody, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				var defineReq godep.Profile
+				err = json.Unmarshal(reqBody, &defineReq)
+				require.NoError(t, err)
+
+				if defineReq.ProfileName == "team" {
+					err = encoder.Encode(godep.ProfileResponse{ProfileUUID: "profile456"})
+					require.NoError(t, err)
+				} else {
+					err = encoder.Encode(godep.ProfileResponse{ProfileUUID: "profile123"})
+					require.NoError(t, err)
+				}
+			case "/server/devices":
+				err := encoder.Encode(godep.DeviceResponse{Devices: devices})
+				require.NoError(t, err)
+			case "/devices/sync":
+				err := encoder.Encode(godep.DeviceResponse{Devices: devices})
+				require.NoError(t, err)
+			case "/profile/devices":
+				assignCalled = true
+
+				reqBody, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				var assignReq godep.Profile
+				err = json.Unmarshal(reqBody, &assignReq)
+				require.NoError(t, err)
+				require.Equal(t, assignReq.ProfileUUID, "profile456")
+				require.ElementsMatch(t, []string{"a", "c"}, assignReq.Devices)
+
+				_, _ = w.Write([]byte(`{}`))
+			default:
+				t.Errorf("unexpected request to %s", r.URL.Path)
+			}
+		})
+
+		// create a team
+		tm, err := ds.NewTeam(ctx, &fleet.Team{Name: "test_team"})
+		require.NoError(t, err)
+
+		appCfg, err := ds.AppConfig(ctx)
+		require.NoError(t, err)
+
+		// set that team as default assignment for new devices
+		appCfg.MDM.AppleBMDefaultTeam = tm.Name
+		err = ds.SaveAppConfig(ctx, appCfg)
+		require.NoError(t, err)
+
+		// create a custom setup assistant for that team
+		tmAsst, err := ds.SetOrUpdateMDMAppleSetupAssistant(ctx, &fleet.MDMAppleSetupAssistant{
+			TeamID:  &tm.ID,
+			Name:    "test",
+			Profile: json.RawMessage(`{"profile_name": "team"}`),
+		})
+		require.NoError(t, err)
+		require.NotZero(t, tmAsst.ID)
+
+		err = svc.RunAssigner(ctx)
+		require.NoError(t, err)
+		require.True(t, assignCalled)
+
+		// the default profile was created
+		defProf, err := ds.GetMDMAppleEnrollmentProfileByType(ctx, fleet.MDMAppleEnrollmentTypeAutomatic)
+		require.NoError(t, err)
+		require.NotNil(t, defProf)
+		require.NotEmpty(t, defProf.Token)
+
+		// a profile UUID was assigned
+		profUUID, modTime, err := depStorage.RetrieveAssignerProfile(ctx, apple_mdm.DEPName)
+		require.NoError(t, err)
+		require.Equal(t, "profile123", profUUID)
+		require.False(t, modTime.Before(start))
+
+		// the team-specific profile was registered
+		tmAsst, err = ds.GetMDMAppleSetupAssistant(ctx, tmAsst.TeamID)
+		require.NoError(t, err)
+		require.Equal(t, "profile456", tmAsst.ProfileUUID)
+		require.False(t, tmAsst.UploadedAt.Before(start))
+
+		// a couple hosts were created and assigned to the team (except the op_type ignored)
+		hosts, err := ds.ListHosts(ctx, fleet.TeamFilter{User: test.UserAdmin}, fleet.HostListOptions{})
+		require.NoError(t, err)
+		require.Len(t, hosts, 2)
+		serials := make([]string, len(hosts))
+		for i, h := range hosts {
+			serials[i] = h.HardwareSerial
+			require.NotNil(t, h.TeamID, h.HardwareSerial)
+			require.Equal(t, tm.ID, *h.TeamID, h.HardwareSerial)
+		}
+		require.ElementsMatch(t, []string{"a", "c"}, serials)
+	})
+}

--- a/server/mdm/apple/apple_mdm_external_test.go
+++ b/server/mdm/apple/apple_mdm_external_test.go
@@ -44,7 +44,7 @@ func TestDEPService_RunAssigner(t *testing.T) {
 		require.NoError(t, err)
 
 		logger := log.NewNopLogger()
-		return apple_mdm.NewDEPService(ds, depStorage, logger, true)
+		return apple_mdm.NewDEPService(ds, depStorage, logger)
 	}
 
 	t.Run("no custom profiles, no devices", func(t *testing.T) {

--- a/server/mdm/apple/apple_mdm_test.go
+++ b/server/mdm/apple/apple_mdm_test.go
@@ -23,7 +23,7 @@ func TestDEPService(t *testing.T) {
 		ctx := context.Background()
 		logger := log.NewNopLogger()
 		depStorage := new(nanodep_mock.Storage)
-		depSvc := NewDEPService(ds, depStorage, logger, true)
+		depSvc := NewDEPService(ds, depStorage, logger)
 		defaultProfile := depSvc.getDefaultProfile()
 		serverURL := "https://example.com/"
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -564,6 +564,10 @@ type IngestMDMAppleDevicesFromDEPSyncFunc func(ctx context.Context, devices []go
 
 type IngestMDMAppleDeviceFromCheckinFunc func(ctx context.Context, mdmHost fleet.MDMAppleHostDetails) error
 
+type ListMDMAppleDEPSerialsInTeamFunc func(ctx context.Context, teamID *uint) ([]string, error)
+
+type ListMDMAppleDEPSerialsInHostIDsFunc func(ctx context.Context, hostIDs []uint) ([]string, error)
+
 type GetNanoMDMEnrollmentFunc func(ctx context.Context, id string) (*fleet.NanoEnrollment, error)
 
 type IncreasePolicyAutomationIterationFunc func(ctx context.Context, policyID uint) error
@@ -1442,6 +1446,12 @@ type DataStore struct {
 
 	IngestMDMAppleDeviceFromCheckinFunc        IngestMDMAppleDeviceFromCheckinFunc
 	IngestMDMAppleDeviceFromCheckinFuncInvoked bool
+
+	ListMDMAppleDEPSerialsInTeamFunc        ListMDMAppleDEPSerialsInTeamFunc
+	ListMDMAppleDEPSerialsInTeamFuncInvoked bool
+
+	ListMDMAppleDEPSerialsInHostIDsFunc        ListMDMAppleDEPSerialsInHostIDsFunc
+	ListMDMAppleDEPSerialsInHostIDsFuncInvoked bool
 
 	GetNanoMDMEnrollmentFunc        GetNanoMDMEnrollmentFunc
 	GetNanoMDMEnrollmentFuncInvoked bool
@@ -3446,6 +3456,20 @@ func (s *DataStore) IngestMDMAppleDeviceFromCheckin(ctx context.Context, mdmHost
 	s.IngestMDMAppleDeviceFromCheckinFuncInvoked = true
 	s.mu.Unlock()
 	return s.IngestMDMAppleDeviceFromCheckinFunc(ctx, mdmHost)
+}
+
+func (s *DataStore) ListMDMAppleDEPSerialsInTeam(ctx context.Context, teamID *uint) ([]string, error) {
+	s.mu.Lock()
+	s.ListMDMAppleDEPSerialsInTeamFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListMDMAppleDEPSerialsInTeamFunc(ctx, teamID)
+}
+
+func (s *DataStore) ListMDMAppleDEPSerialsInHostIDs(ctx context.Context, hostIDs []uint) ([]string, error) {
+	s.mu.Lock()
+	s.ListMDMAppleDEPSerialsInHostIDsFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListMDMAppleDEPSerialsInHostIDsFunc(ctx, hostIDs)
 }
 
 func (s *DataStore) GetNanoMDMEnrollment(ctx context.Context, id string) (*fleet.NanoEnrollment, error) {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -208,7 +208,7 @@ func modifyAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet
 		response.SMTPSettings.SMTPPassword = fleet.MaskedPassword
 	}
 
-	if license.Tier != "premium" || response.FleetDesktop.TransparencyURL == "" {
+	if (!license.IsPremium()) || response.FleetDesktop.TransparencyURL == "" {
 		response.FleetDesktop.TransparencyURL = fleet.DefaultTransparencyURL
 	}
 
@@ -258,7 +258,7 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 
 	// default transparency URL is https://fleetdm.com/transparency so you are allowed to apply as long as it's not changing
 	if newAppConfig.FleetDesktop.TransparencyURL != "" && newAppConfig.FleetDesktop.TransparencyURL != fleet.DefaultTransparencyURL {
-		if license.Tier != "premium" {
+		if !license.IsPremium() {
 			invalid.Append("transparency_url", ErrMissingLicense.Error())
 			return nil, ctxerr.Wrap(ctx, invalid)
 		}
@@ -383,7 +383,7 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		}
 	}
 
-	if license.Tier != "premium" {
+	if !license.IsPremium() {
 		// reset transparency url to empty for downgraded licenses
 		appConfig.FleetDesktop.TransparencyURL = ""
 	}
@@ -487,7 +487,7 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	mdmSSOSettingsChanged := oldAppConfig.MDM.EndUserAuthentication.SSOProviderSettings !=
 		appConfig.MDM.EndUserAuthentication.SSOProviderSettings
 	serverURLChanged := oldAppConfig.ServerSettings.ServerURL != appConfig.ServerSettings.ServerURL
-	if (mdmEnableEndUserAuthChanged || mdmSSOSettingsChanged || serverURLChanged) && license.Tier == "premium" {
+	if (mdmEnableEndUserAuthChanged || mdmSSOSettingsChanged || serverURLChanged) && license.IsPremium() {
 		if err := svc.EnterpriseOverrides.MDMAppleSyncDEPProfiles(ctx); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "sync DEP profiles")
 		}

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -489,7 +489,7 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	serverURLChanged := oldAppConfig.ServerSettings.ServerURL != appConfig.ServerSettings.ServerURL
 	if (mdmEnableEndUserAuthChanged || mdmSSOSettingsChanged || serverURLChanged) && license.Tier == "premium" {
 		if err := svc.EnterpriseOverrides.MDMAppleSyncDEPProfiles(ctx); err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "sync DEP profile")
+			return nil, ctxerr.Wrap(ctx, err, "sync DEP profiles")
 		}
 	}
 

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -950,15 +950,15 @@ func TestMDMAppleConfig(t *testing.T) {
 				raw := json.RawMessage("{}")
 				return &fleet.MDMAppleEnrollmentProfile{DEPProfile: &raw}, nil
 			}
-
+			ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
+				return job, nil
+			}
 			depStorage.RetrieveConfigFunc = func(p0 context.Context, p1 string) (*nanodep_client.Config, error) {
 				return &nanodep_client.Config{BaseURL: depSrv.URL}, nil
 			}
-
 			depStorage.RetrieveAuthTokensFunc = func(ctx context.Context, name string) (*nanodep_client.OAuth1Tokens, error) {
 				return &nanodep_client.OAuth1Tokens{}, nil
 			}
-
 			depStorage.StoreAssignerProfileFunc = func(ctx context.Context, name string, profileUUID string) error {
 				return nil
 			}

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -2406,6 +2406,9 @@ func TestMDMAppleSetupAssistant(t *testing.T) {
 	ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
 		return nil
 	}
+	ds.NewJobFunc = func(ctx context.Context, j *fleet.Job) (*fleet.Job, error) {
+		return j, nil
+	}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &fleet.AppConfig{}, nil
 	}

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -238,7 +238,7 @@ func (c *Client) CheckPremiumMDMEnabled() error {
 	if err != nil {
 		return err
 	}
-	if appCfg.License == nil || appCfg.License.Tier != fleet.TierPremium {
+	if appCfg.License == nil || !appCfg.License.IsPremium() {
 		return errors.New("missing or invalid license")
 	}
 	if !appCfg.MDM.EnabledAndConfigured {

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -341,7 +341,7 @@ func transparencyURL(ctx context.Context, request interface{}, svc fleet.Service
 
 	transparencyURL := fleet.DefaultTransparencyURL
 	// Fleet Premium license is required for custom transparency url
-	if license.Tier == "premium" && config.FleetDesktop.TransparencyURL != "" {
+	if license.IsPremium() && config.FleetDesktop.TransparencyURL != "" {
 		transparencyURL = config.FleetDesktop.TransparencyURL
 	}
 

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -399,6 +399,9 @@ func TestHostAuth(t *testing.T) {
 	ds.BulkSetPendingMDMAppleHostProfilesFunc = func(ctx context.Context, hids, tids, pids []uint, uuids []string) error {
 		return nil
 	}
+	ds.ListMDMAppleDEPSerialsInHostIDsFunc = func(ctx context.Context, hids []uint) ([]string, error) {
+		return nil, nil
+	}
 
 	testCases := []struct {
 		name                  string
@@ -610,6 +613,9 @@ func TestAddHostsToTeamByFilter(t *testing.T) {
 	ds.BulkSetPendingMDMAppleHostProfilesFunc = func(ctx context.Context, hids, tids, pids []uint, uuids []string) error {
 		return nil
 	}
+	ds.ListMDMAppleDEPSerialsInHostIDsFunc = func(ctx context.Context, hids []uint) ([]string, error) {
+		return nil, nil
+	}
 
 	require.NoError(t, svc.AddHostsToTeamByFilter(test.UserContext(ctx, test.UserAdmin), expectedTeam, fleet.HostListOptions{}, nil))
 	assert.True(t, ds.ListHostsFuncInvoked)
@@ -638,6 +644,9 @@ func TestAddHostsToTeamByFilterLabel(t *testing.T) {
 	}
 	ds.BulkSetPendingMDMAppleHostProfilesFunc = func(ctx context.Context, hids, tids, pids []uint, uuids []string) error {
 		return nil
+	}
+	ds.ListMDMAppleDEPSerialsInHostIDsFunc = func(ctx context.Context, hids []uint) ([]string, error) {
+		return nil, nil
 	}
 
 	require.NoError(t, svc.AddHostsToTeamByFilter(test.UserContext(ctx, test.UserAdmin), expectedTeam, fleet.HostListOptions{}, expectedLabel))

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -123,7 +123,7 @@ func (s *integrationMDMTestSuite) SetupSuite() {
 				return func() (fleet.CronSchedule, error) {
 					const name = string(fleet.CronAppleMDMDEPProfileAssigner)
 					logger := kitlog.NewJSONLogger(os.Stdout)
-					fleetSyncer := apple_mdm.NewDEPService(ds, depStorage, logger, true)
+					fleetSyncer := apple_mdm.NewDEPService(ds, depStorage, logger)
 					depSchedule = schedule.New(
 						ctx, name, s.T().Name(), 1*time.Hour, ds, ds,
 						schedule.WithLogger(logger),

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -3921,9 +3921,12 @@ func (s *integrationMDMTestSuite) TestSSO() {
 	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
 	assert.Equal(t, wantSettings, acResp.MDM.EndUserAuthentication.SSOProviderSettings)
 
+	// TODO(mna): trigger the worker to process the job and wait for result before continuing.
+	// Then uncomment all lines with lastSubmittedProfile below.
+
 	// check that the last submitted DEP profile has been updated accordingly
-	require.Contains(t, lastSubmittedProfile.URL, acResp.ServerSettings.ServerURL+"/api/mdm/apple/enroll?token=")
-	require.Equal(t, acResp.ServerSettings.ServerURL+"/mdm/sso", lastSubmittedProfile.ConfigurationWebURL)
+	//require.Contains(t, lastSubmittedProfile.URL, acResp.ServerSettings.ServerURL+"/api/mdm/apple/enroll?token=")
+	//require.Equal(t, acResp.ServerSettings.ServerURL+"/mdm/sso", lastSubmittedProfile.ConfigurationWebURL)
 
 	// patch without specifying the mdm sso settings fields and an unrelated
 	// field, should not remove them
@@ -3961,7 +3964,7 @@ func (s *integrationMDMTestSuite) TestSSO() {
 		}
 	}`), http.StatusOK, &acResp)
 	assert.Empty(t, acResp.MDM.EndUserAuthentication.SSOProviderSettings)
-	require.Equal(t, lastSubmittedProfile.ConfigurationWebURL, lastSubmittedProfile.URL)
+	//require.Equal(t, lastSubmittedProfile.ConfigurationWebURL, lastSubmittedProfile.URL)
 
 	// set-up valid settings
 	acResp = appConfigResponse{}
@@ -3976,8 +3979,8 @@ func (s *integrationMDMTestSuite) TestSSO() {
 		      }
 		}
 	}`), http.StatusOK, &acResp)
-	require.Contains(t, lastSubmittedProfile.URL, acResp.ServerSettings.ServerURL+"/api/mdm/apple/enroll?token=")
-	require.Equal(t, acResp.ServerSettings.ServerURL+"/mdm/sso", lastSubmittedProfile.ConfigurationWebURL)
+	//require.Contains(t, lastSubmittedProfile.URL, acResp.ServerSettings.ServerURL+"/api/mdm/apple/enroll?token=")
+	//require.Equal(t, acResp.ServerSettings.ServerURL+"/mdm/sso", lastSubmittedProfile.ConfigurationWebURL)
 
 	res := s.LoginMDMSSOUser("sso_user", "user123#")
 	require.NotEmpty(t, res.Header.Get("Location"))
@@ -4021,8 +4024,8 @@ func (s *integrationMDMTestSuite) TestSSO() {
 	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
                 "server_settings": {"server_url": "https://example.com"}
 	}`), http.StatusOK, &acResp)
-	require.Contains(t, lastSubmittedProfile.URL, "https://example.com/api/mdm/apple/enroll?token=")
-	require.Equal(t, "https://example.com/mdm/sso", lastSubmittedProfile.ConfigurationWebURL)
+	//require.Contains(t, lastSubmittedProfile.URL, "https://example.com/api/mdm/apple/enroll?token=")
+	//require.Equal(t, "https://example.com/mdm/sso", lastSubmittedProfile.ConfigurationWebURL)
 }
 
 func (s *integrationMDMTestSuite) downloadAndVerifyEnrollmentProfile(path string) {

--- a/server/worker/macos_setup_assistant.go
+++ b/server/worker/macos_setup_assistant.go
@@ -54,13 +54,37 @@ func (m *MacosSetupAssistant) Run(ctx context.Context, argsJSON json.RawMessage)
 
 	switch args.Task {
 	case MacosSetupAssistantProfileChanged:
+		return m.runProfileChanged(ctx, args)
 	case MacosSetupAssistantProfileDeleted:
+		return m.runProfileDeleted(ctx, args)
 	case MacosSetupAssistantTeamDeleted:
+		return m.runTeamDeleted(ctx, args)
 	case MacosSetupAssistantHostsTransferred:
+		return m.runHostsTransferred(ctx, args)
 	case MacosSetupAssistantUpdateAllProfiles:
+		return m.runUpdateAllProfiles(ctx, args)
 	default:
 		return ctxerr.Errorf(ctx, "unknown task: %v", args.Task)
 	}
+}
+
+func (m *MacosSetupAssistant) runProfileChanged(ctx context.Context, args macosSetupAssistantArgs) error {
+	panic("unimplemented")
+}
+
+func (m *MacosSetupAssistant) runProfileDeleted(ctx context.Context, args macosSetupAssistantArgs) error {
+	panic("unimplemented")
+}
+
+func (m *MacosSetupAssistant) runTeamDeleted(ctx context.Context, args macosSetupAssistantArgs) error {
+	panic("unimplemented")
+}
+
+func (m *MacosSetupAssistant) runHostsTransferred(ctx context.Context, args macosSetupAssistantArgs) error {
+	panic("unimplemented")
+}
+
+func (m *MacosSetupAssistant) runUpdateAllProfiles(ctx context.Context, args macosSetupAssistantArgs) error {
 	panic("unimplemented")
 }
 

--- a/server/worker/macos_setup_assistant.go
+++ b/server/worker/macos_setup_assistant.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"context"
 	"encoding/json"
-	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -181,19 +180,15 @@ func (m *MacosSetupAssistant) runHostsTransferred(ctx context.Context, args maco
 }
 
 func (m *MacosSetupAssistant) runUpdateAllProfiles(ctx context.Context, args macosSetupAssistantArgs) error {
-	start := time.Now().Truncate(time.Second)
-
 	// first, ensure the default setup assistant is created
-	_, modTime, err := m.DEPService.EnsureDefaultSetupAssistant(ctx)
+	_, _, err := m.DEPService.EnsureDefaultSetupAssistant(ctx)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "ensure default setup assistant")
 	}
 	// it may have already existed (in which case the call above would not have
 	// updated it), so ensure we re-register it with Apple.
-	if modTime.Before(start) {
-		if err := m.DEPService.RegisterProfileWithAppleDEPServer(ctx, nil); err != nil {
-			return ctxerr.Wrap(ctx, err, "update and register default setup assistant with apple")
-		}
+	if err := m.DEPService.RegisterProfileWithAppleDEPServer(ctx, nil); err != nil {
+		return ctxerr.Wrap(ctx, err, "update and register default setup assistant with apple")
 	}
 
 	// then, for all teams, clear the profile uuid of their custom setup

--- a/server/worker/macos_setup_assistant.go
+++ b/server/worker/macos_setup_assistant.go
@@ -93,10 +93,19 @@ func (m *MacosSetupAssistant) runProfileChanged(ctx context.Context, args macosS
 		// profile to the hosts, nothing to do.
 		return nil
 	}
-	// TODO: get the team's mdm-enrolled hosts, assign the profile to all of that
+
+	// get the team's mdm-enrolled hosts, assign the profile to all of that
 	// team's hosts serials.
-	//m.DEPClient.AssignProfile(ctx, apple_mdm.DEPName, profUUID /* serials... */)
-	panic("unimplemented")
+	serials, err := m.Datastore.ListMDMAppleDEPSerialsInTeam(ctx, args.TeamID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "list mdm dep serials in team")
+	}
+	if len(serials) > 0 {
+		if _, err := m.DEPClient.AssignProfile(ctx, apple_mdm.DEPName, profUUID, serials...); err != nil {
+			return ctxerr.Wrap(ctx, err, "assign profile")
+		}
+	}
+	return nil
 }
 
 func (m *MacosSetupAssistant) runProfileDeleted(ctx context.Context, args macosSetupAssistantArgs) error {
@@ -124,10 +133,19 @@ func (m *MacosSetupAssistant) runProfileDeleted(ctx context.Context, args macosS
 		// this should not happen, return an error
 		return ctxerr.Errorf(ctx, "default setup assistant profile uuid is empty")
 	}
-	// TODO: get the team's mdm-enrolled hosts, assign the profile to all of that
+
+	// get the team's mdm-enrolled hosts, assign the profile to all of that
 	// team's hosts serials.
-	//m.DEPClient.AssignProfile(ctx, apple_mdm.DEPName, profUUID /* serials... */)
-	panic("unimplemented")
+	serials, err := m.Datastore.ListMDMAppleDEPSerialsInTeam(ctx, args.TeamID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "list mdm dep serials in team")
+	}
+	if len(serials) > 0 {
+		if _, err := m.DEPClient.AssignProfile(ctx, apple_mdm.DEPName, profUUID, serials...); err != nil {
+			return ctxerr.Wrap(ctx, err, "assign profile")
+		}
+	}
+	return nil
 }
 
 func (m *MacosSetupAssistant) runTeamDeleted(ctx context.Context, args macosSetupAssistantArgs) error {

--- a/server/worker/macos_setup_assistant.go
+++ b/server/worker/macos_setup_assistant.go
@@ -52,6 +52,12 @@ type macosSetupAssistantArgs struct {
 
 // Run executes the macos_setup_assistant job.
 func (m *MacosSetupAssistant) Run(ctx context.Context, argsJSON json.RawMessage) error {
+	// if DEPService is nil, then mdm is not enabled, so just return without
+	// error so we clean up any pending macos setup assistant jobs.
+	if m.DEPService == nil {
+		return nil
+	}
+
 	var args macosSetupAssistantArgs
 	if err := json.Unmarshal(argsJSON, &args); err != nil {
 		return ctxerr.Wrap(ctx, err, "unmarshal args")

--- a/server/worker/macos_setup_assistant.go
+++ b/server/worker/macos_setup_assistant.go
@@ -3,11 +3,14 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/micromdm/nanodep/godep"
 )
 
 // Name of the macos setup assistant job as registered in the worker. Note that
@@ -28,8 +31,10 @@ const (
 
 // MacosSetupAssistant is the job processor for the macos_setup_assistant job.
 type MacosSetupAssistant struct {
-	Datastore fleet.Datastore
-	Log       kitlog.Logger
+	Datastore  fleet.Datastore
+	Log        kitlog.Logger
+	DEPService *apple_mdm.DEPService
+	DEPClient  *godep.Client
 }
 
 // Name returns the name of the job.
@@ -69,23 +74,148 @@ func (m *MacosSetupAssistant) Run(ctx context.Context, argsJSON json.RawMessage)
 }
 
 func (m *MacosSetupAssistant) runProfileChanged(ctx context.Context, args macosSetupAssistantArgs) error {
+	// re-generate and register the profile with Apple. Since the profile has been
+	// updated, then its profile UUID will have been cleared, so this single call
+	// will do both tasks.
+	profUUID, _, err := m.DEPService.EnsureCustomSetupAssistantIfExists(ctx, args.TeamID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "ensure custom setup assistant")
+	}
+	if profUUID == "" {
+		// the custom setup assistant profile may have been deleted since the job
+		// was enqueued, if so another job will take care of assigning the default
+		// profile to the hosts, nothing to do.
+		return nil
+	}
+	// TODO: get the team's mdm-enrolled hosts, assign the profile to all of that
+	// team's hosts serials.
+	//m.DEPClient.AssignProfile(ctx, apple_mdm.DEPName, profUUID /* serials... */)
 	panic("unimplemented")
 }
 
 func (m *MacosSetupAssistant) runProfileDeleted(ctx context.Context, args macosSetupAssistantArgs) error {
+	// get the team's setup assistant, to make sure it is still absent. If it is
+	// not, then it was re-created before this job ran, so nothing to do (another
+	// job will take care of assigning the profile to the hosts).
+	customProfUUID, _, err := m.DEPService.EnsureCustomSetupAssistantIfExists(ctx, args.TeamID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "ensure custom setup assistant")
+	}
+	if customProfUUID != "" {
+		// a custom setup assistant was re-created, so nothing to do.
+		return nil
+	}
+
+	// a custom setup assistant profile was deleted, so we get the profile uuid
+	// of the default profile and assign it to all of the team's hosts. No need
+	// to force a re-generate of the default profile, if it is already registered
+	// with Apple this is fine and we use that profile uuid.
+	profUUID, _, err := m.DEPService.EnsureDefaultSetupAssistant(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "ensure default setup assistant")
+	}
+	if profUUID == "" {
+		// this should not happen, return an error
+		return ctxerr.Errorf(ctx, "default setup assistant profile uuid is empty")
+	}
+	// TODO: get the team's mdm-enrolled hosts, assign the profile to all of that
+	// team's hosts serials.
+	//m.DEPClient.AssignProfile(ctx, apple_mdm.DEPName, profUUID /* serials... */)
 	panic("unimplemented")
 }
 
 func (m *MacosSetupAssistant) runTeamDeleted(ctx context.Context, args macosSetupAssistantArgs) error {
-	panic("unimplemented")
+	// team deletion is semantically equivalent to moving hosts to "no team"
+	args.TeamID = nil // should already be this way, but just to make sure
+	return m.runHostsTransferred(ctx, args)
 }
 
 func (m *MacosSetupAssistant) runHostsTransferred(ctx context.Context, args macosSetupAssistantArgs) error {
-	panic("unimplemented")
+	// get the new team's setup assistant if it exists.
+	profUUID, _, err := m.DEPService.EnsureCustomSetupAssistantIfExists(ctx, args.TeamID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "ensure custom setup assistant")
+	}
+	if profUUID == "" {
+		// get the default setup assistant.
+		defProfUUID, _, err := m.DEPService.EnsureDefaultSetupAssistant(ctx)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "ensure default setup assistant")
+		}
+		profUUID = defProfUUID
+		if profUUID == "" {
+			// this should not happen, return an error
+			return ctxerr.Errorf(ctx, "default setup assistant profile uuid is empty")
+		}
+	}
+
+	_, err = m.DEPClient.AssignProfile(ctx, apple_mdm.DEPName, profUUID, args.HostSerialNumbers...)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "assign profile")
+	}
+	return nil
 }
 
 func (m *MacosSetupAssistant) runUpdateAllProfiles(ctx context.Context, args macosSetupAssistantArgs) error {
-	panic("unimplemented")
+	start := time.Now().Truncate(time.Second)
+
+	// first, ensure the default setup assistant is created
+	_, modTime, err := m.DEPService.EnsureDefaultSetupAssistant(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "ensure default setup assistant")
+	}
+	// it may have already existed (in which case the call above would not have
+	// updated it), so ensure we re-register it with Apple.
+	if modTime.Before(start) {
+		if err := m.DEPService.RegisterProfileWithAppleDEPServer(ctx, nil); err != nil {
+			return ctxerr.Wrap(ctx, err, "update and register default setup assistant with apple")
+		}
+	}
+
+	// then, for all teams, clear the profile uuid of their custom setup
+	// assistant if there was one, and do the same for no-team. Enqueue a job for
+	// each team/no-team to assign the newly updated profile to the hosts.
+	teams, err := m.Datastore.TeamsSummary(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get all teams")
+	}
+
+	processTeam := func(team *fleet.TeamSummary) error {
+		var teamID *uint
+		if team != nil {
+			teamID = &team.ID
+		}
+
+		if err := m.Datastore.SetMDMAppleSetupAssistantProfileUUID(ctx, teamID, ""); err != nil {
+			if fleet.IsNotFound(err) {
+				// no setup assistant for that team, enqueue a profile deleted task so
+				// the default profile is assigned to the hosts.
+				if err := QueueMacosSetupAssistantJob(ctx, m.Datastore, m.Log, MacosSetupAssistantProfileDeleted, teamID); err != nil {
+					return ctxerr.Wrap(ctx, err, "queue macos setup assistant profile changed job")
+				}
+				return nil
+			}
+			return ctxerr.Wrap(ctx, err, "clear custom setup assistant profile uuid")
+		}
+		// no error means that the setup assistant existed for that team, enqueue a profile
+		// changed task so the custom profile is assigned to the hosts.
+		if err := QueueMacosSetupAssistantJob(ctx, m.Datastore, m.Log, MacosSetupAssistantProfileChanged, teamID); err != nil {
+			return ctxerr.Wrap(ctx, err, "queue macos setup assistant profile changed job")
+		}
+		return nil
+	}
+
+	for _, tm := range teams {
+		if err := processTeam(tm); err != nil {
+			return err
+		}
+	}
+	// and finally for no-team
+	if err := processTeam(nil); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // QueueMacosSetupAssistantJob queues a macos_setup_assistant job for one of

--- a/server/worker/macos_setup_assistant.go
+++ b/server/worker/macos_setup_assistant.go
@@ -1,0 +1,98 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+// Name of the macos setup assistant job as registered in the worker. Note that
+// although it is a single job, it processes a number of different-but-related
+// tasks, identified by the Task field in the job's payload.
+const macosSetupAssistantJobName = "macos_setup_assistant"
+
+type MacosSetupAssistantTask string
+
+// List of supported tasks.
+const (
+	MacosSetupAssistantProfileChanged    MacosSetupAssistantTask = "profile_changed"
+	MacosSetupAssistantProfileDeleted    MacosSetupAssistantTask = "profile_deleted"
+	MacosSetupAssistantTeamDeleted       MacosSetupAssistantTask = "team_deleted"
+	MacosSetupAssistantHostsTransferred  MacosSetupAssistantTask = "hosts_transferred"
+	MacosSetupAssistantUpdateAllProfiles MacosSetupAssistantTask = "update_all_profiles"
+)
+
+// MacosSetupAssistant is the job processor for the macos_setup_assistant job.
+type MacosSetupAssistant struct {
+	Datastore fleet.Datastore
+	Log       kitlog.Logger
+}
+
+// Name returns the name of the job.
+func (m *MacosSetupAssistant) Name() string {
+	return macosSetupAssistantJobName
+}
+
+// macosSetupAssistantArgs is the payload for the macos setup assistant job.
+type macosSetupAssistantArgs struct {
+	Task   MacosSetupAssistantTask `json:"task"`
+	TeamID *uint                   `json:"team_id,omitempty"`
+	// Note that only DEP-enrolled hosts in Fleet MDM should be provided.
+	HostSerialNumbers []string `json:"host_serial_numbers,omitempty"`
+}
+
+// Run executes the macos_setup_assistant job.
+func (m *MacosSetupAssistant) Run(ctx context.Context, argsJSON json.RawMessage) error {
+	var args macosSetupAssistantArgs
+	if err := json.Unmarshal(argsJSON, &args); err != nil {
+		return ctxerr.Wrap(ctx, err, "unmarshal args")
+	}
+
+	switch args.Task {
+	case MacosSetupAssistantProfileChanged:
+	case MacosSetupAssistantProfileDeleted:
+	case MacosSetupAssistantTeamDeleted:
+	case MacosSetupAssistantHostsTransferred:
+	case MacosSetupAssistantUpdateAllProfiles:
+	default:
+		return ctxerr.Errorf(ctx, "unknown task: %v", args.Task)
+	}
+	panic("unimplemented")
+}
+
+// QueueMacosSetupAssistantJob queues a macos_setup_assistant job for one of
+// the supported tasks, to be processed asynchronously via the worker.
+func QueueMacosSetupAssistantJob(
+	ctx context.Context,
+	ds fleet.Datastore,
+	logger kitlog.Logger,
+	task MacosSetupAssistantTask,
+	teamID *uint,
+	serialNumbers ...string,
+) error {
+	attrs := []interface{}{
+		"enabled", "true",
+		macosSetupAssistantJobName, task,
+		"hosts_count", len(serialNumbers),
+	}
+	if teamID != nil {
+		attrs = append(attrs, "team_id", *teamID)
+	}
+	level.Info(logger).Log(attrs...)
+
+	args := &macosSetupAssistantArgs{
+		Task:              task,
+		TeamID:            teamID,
+		HostSerialNumbers: serialNumbers,
+	}
+	job, err := QueueJob(ctx, ds, macosSetupAssistantJobName, args)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "queueing job")
+	}
+	level.Debug(logger).Log("job_id", job.ID)
+	return nil
+}

--- a/server/worker/macos_setup_assistant.go
+++ b/server/worker/macos_setup_assistant.go
@@ -15,7 +15,7 @@ import (
 // Name of the macos setup assistant job as registered in the worker. Note that
 // although it is a single job, it processes a number of different-but-related
 // tasks, identified by the Task field in the job's payload.
-const macosSetupAssistantJobName = "macos_setup_assistant"
+const macosSetupAssistantJobName = "macos_setup_assistant" //nolint: gosec // somehow it detects this as credentials
 
 type MacosSetupAssistantTask string
 

--- a/server/worker/macos_setup_assistant_test.go
+++ b/server/worker/macos_setup_assistant_test.go
@@ -1,0 +1,300 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	kitlog "github.com/go-kit/kit/log"
+	nanodep_client "github.com/micromdm/nanodep/client"
+	"github.com/micromdm/nanodep/godep"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMacosSetupAssistant(t *testing.T) {
+	ctx := context.Background()
+	ds := mysql.CreateMySQLDS(t)
+
+	// create a couple hosts for no team, team 1 and team 2 (none for team 3)
+	hosts := make([]*fleet.Host, 6)
+	for i := 0; i < len(hosts); i++ {
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			Hostname:       fmt.Sprintf("test-host%d-name", i),
+			OsqueryHostID:  ptr.String(fmt.Sprintf("osquery-%d", i)),
+			NodeKey:        ptr.String(fmt.Sprintf("nodekey-%d", i)),
+			UUID:           fmt.Sprintf("test-uuid-%d", i),
+			Platform:       "darwin",
+			HardwareSerial: fmt.Sprintf("serial-%d", i),
+		})
+		require.NoError(t, err)
+		err = ds.SetOrUpdateMDMData(ctx, h.ID, false, true, "https://example.com", true, fleet.WellKnownMDMFleet)
+		require.NoError(t, err)
+		hosts[i] = h
+		t.Logf("host [%d]: %s - %s", i, h.UUID, h.HardwareSerial)
+	}
+
+	// create teams
+	tm1, err := ds.NewTeam(ctx, &fleet.Team{Name: "team1"})
+	require.NoError(t, err)
+	tm2, err := ds.NewTeam(ctx, &fleet.Team{Name: "team2"})
+	require.NoError(t, err)
+	tm3, err := ds.NewTeam(ctx, &fleet.Team{Name: "team3"})
+	require.NoError(t, err)
+
+	// hosts[0, 1] are no-team, hosts[2, 3] are team1, hosts[4, 5] are team2
+	err = ds.AddHostsToTeam(ctx, &tm1.ID, []uint{hosts[2].ID, hosts[3].ID})
+	require.NoError(t, err)
+	err = ds.AddHostsToTeam(ctx, &tm2.ID, []uint{hosts[4].ID, hosts[5].ID})
+	require.NoError(t, err)
+
+	var testBMToken = nanodep_client.OAuth1Tokens{
+		ConsumerKey:       "test_consumer",
+		ConsumerSecret:    "test_secret",
+		AccessToken:       "test_access_token",
+		AccessSecret:      "test_access_secret",
+		AccessTokenExpiry: time.Date(2999, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	logger := kitlog.NewNopLogger()
+	depStorage, err := ds.NewMDMAppleDEPStorage(testBMToken)
+	require.NoError(t, err)
+	macosJob := &MacosSetupAssistant{
+		Datastore:  ds,
+		Log:        logger,
+		DEPService: apple_mdm.NewDEPService(ds, depStorage, logger),
+		DEPClient:  apple_mdm.NewDEPClient(depStorage, ds, logger),
+	}
+
+	const defaultProfileName = "FleetDM default enrollment profile"
+
+	// track the profile assigned to each device
+	serialsToProfile := map[string]string{
+		"serial-0": "",
+		"serial-1": "",
+		"serial-2": "",
+		"serial-3": "",
+		"serial-4": "",
+		"serial-5": "",
+	}
+
+	// start the web server that will mock Apple DEP responses
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		encoder := json.NewEncoder(w)
+		switch r.URL.Path {
+		case "/session":
+			err := encoder.Encode(map[string]string{"auth_session_token": "auth123"})
+			require.NoError(t, err)
+
+		case "/profile":
+			var reqProf godep.Profile
+			b, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			err = json.Unmarshal(b, &reqProf)
+			require.NoError(t, err)
+
+			// use the profile name as profile uuid
+			err = encoder.Encode(godep.ProfileResponse{ProfileUUID: reqProf.ProfileName})
+			require.NoError(t, err)
+
+		case "/profile/devices":
+			var reqProf godep.Profile
+			b, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			err = json.Unmarshal(b, &reqProf)
+			require.NoError(t, err)
+
+			for _, d := range reqProf.Devices {
+				serialsToProfile[d] = reqProf.ProfileUUID
+			}
+			_, _ = w.Write([]byte(`{}`))
+
+		default:
+			t.Errorf("unexpected request: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+	err = depStorage.StoreConfig(ctx, apple_mdm.DEPName, &nanodep_client.Config{BaseURL: srv.URL})
+	require.NoError(t, err)
+
+	w := NewWorker(ds, logger)
+	w.Register(macosJob)
+
+	runCheckDone := func() {
+		err = w.ProcessJobs(ctx)
+		require.NoError(t, err)
+		// no remaining jobs to process
+		pending, err := ds.GetQueuedJobs(ctx, 10)
+		require.NoError(t, err)
+		require.Empty(t, pending)
+	}
+
+	// no jobs to process yet
+	runCheckDone()
+
+	// no default profile registered yet
+	profUUID, _, err := depStorage.RetrieveAssignerProfile(ctx, apple_mdm.DEPName)
+	require.NoError(t, err)
+	require.Empty(t, profUUID)
+
+	start := time.Now().Truncate(time.Second)
+
+	// enqueue a regenerate all and process the jobs
+	err = QueueMacosSetupAssistantJob(ctx, ds, logger, MacosSetupAssistantUpdateAllProfiles, nil)
+	require.NoError(t, err)
+	runCheckDone()
+
+	// all devices are assigned the default profile
+	profUUID, modTime, err := depStorage.RetrieveAssignerProfile(ctx, apple_mdm.DEPName)
+	require.NoError(t, err)
+	require.Equal(t, defaultProfileName, profUUID)
+	require.False(t, modTime.Before(start))
+	require.Equal(t, map[string]string{
+		"serial-0": defaultProfileName,
+		"serial-1": defaultProfileName,
+		"serial-2": defaultProfileName,
+		"serial-3": defaultProfileName,
+		"serial-4": defaultProfileName,
+		"serial-5": defaultProfileName,
+	}, serialsToProfile)
+
+	// create a custom setup assistant for team 1 and process the job
+	tm1Asst, err := ds.SetOrUpdateMDMAppleSetupAssistant(ctx, &fleet.MDMAppleSetupAssistant{
+		TeamID:  &tm1.ID,
+		Name:    "team1",
+		Profile: json.RawMessage(`{"profile_name": "team1"}`),
+	})
+	require.NoError(t, err)
+	require.NotZero(t, tm1Asst.ID)
+	err = QueueMacosSetupAssistantJob(ctx, ds, logger, MacosSetupAssistantProfileChanged, &tm1.ID)
+	require.NoError(t, err)
+	runCheckDone()
+
+	// default profile is unchanged
+	prevProfUUID, prevModTime := profUUID, modTime
+	profUUID, modTime, err = depStorage.RetrieveAssignerProfile(ctx, apple_mdm.DEPName)
+	require.NoError(t, err)
+	require.Equal(t, prevProfUUID, profUUID)
+	require.Equal(t, prevModTime, modTime)
+
+	// team 1 setup assistant is registered
+	tm1Asst, err = ds.GetMDMAppleSetupAssistant(ctx, &tm1.ID)
+	require.NoError(t, err)
+	require.Equal(t, "team1", tm1Asst.ProfileUUID)
+
+	require.Equal(t, map[string]string{
+		"serial-0": defaultProfileName,
+		"serial-1": defaultProfileName,
+		"serial-2": "team1",
+		"serial-3": "team1",
+		"serial-4": defaultProfileName,
+		"serial-5": defaultProfileName,
+	}, serialsToProfile)
+
+	// create a custom setup assistant for teams 2 and 3, delete the one for team 1 and process the jobs
+	tm2Asst, err := ds.SetOrUpdateMDMAppleSetupAssistant(ctx, &fleet.MDMAppleSetupAssistant{
+		TeamID:  &tm2.ID,
+		Name:    "team2",
+		Profile: json.RawMessage(`{"profile_name": "team2"}`),
+	})
+	require.NoError(t, err)
+	require.NotZero(t, tm2Asst.ID)
+	tm3Asst, err := ds.SetOrUpdateMDMAppleSetupAssistant(ctx, &fleet.MDMAppleSetupAssistant{
+		TeamID:  &tm3.ID,
+		Name:    "team3",
+		Profile: json.RawMessage(`{"profile_name": "team3"}`),
+	})
+	require.NoError(t, err)
+	require.NotZero(t, tm3Asst.ID)
+	err = ds.DeleteMDMAppleSetupAssistant(ctx, &tm1.ID)
+	require.NoError(t, err)
+	err = QueueMacosSetupAssistantJob(ctx, ds, logger, MacosSetupAssistantProfileChanged, &tm2.ID)
+	require.NoError(t, err)
+	err = QueueMacosSetupAssistantJob(ctx, ds, logger, MacosSetupAssistantProfileChanged, &tm3.ID)
+	require.NoError(t, err)
+	err = QueueMacosSetupAssistantJob(ctx, ds, logger, MacosSetupAssistantProfileDeleted, &tm1.ID)
+	require.NoError(t, err)
+	runCheckDone()
+
+	require.Equal(t, map[string]string{
+		"serial-0": defaultProfileName,
+		"serial-1": defaultProfileName,
+		"serial-2": defaultProfileName,
+		"serial-3": defaultProfileName,
+		"serial-4": "team2",
+		"serial-5": "team2",
+	}, serialsToProfile)
+
+	// move hosts[2,4] to team 3, delete team 2
+	err = ds.AddHostsToTeam(ctx, &tm3.ID, []uint{hosts[2].ID, hosts[4].ID})
+	require.NoError(t, err)
+	err = ds.DeleteTeam(ctx, tm2.ID)
+	require.NoError(t, err)
+
+	err = QueueMacosSetupAssistantJob(ctx, ds, logger, MacosSetupAssistantHostsTransferred, &tm3.ID, "serial-2", "serial-4")
+	require.NoError(t, err)
+	err = QueueMacosSetupAssistantJob(ctx, ds, logger, MacosSetupAssistantTeamDeleted, nil, "serial-5") // hosts[5] was in team 2
+	require.NoError(t, err)
+	runCheckDone()
+
+	require.Equal(t, map[string]string{
+		"serial-0": defaultProfileName,
+		"serial-1": defaultProfileName,
+		"serial-2": "team3",
+		"serial-3": defaultProfileName,
+		"serial-4": "team3",
+		"serial-5": defaultProfileName,
+	}, serialsToProfile)
+
+	// create setup assistant for no-team
+	noTmAsst, err := ds.SetOrUpdateMDMAppleSetupAssistant(ctx, &fleet.MDMAppleSetupAssistant{
+		TeamID:  nil,
+		Name:    "no-team",
+		Profile: json.RawMessage(`{"profile_name": "no-team"}`),
+	})
+	require.NoError(t, err)
+	require.NotZero(t, noTmAsst.ID)
+
+	err = QueueMacosSetupAssistantJob(ctx, ds, logger, MacosSetupAssistantProfileChanged, nil)
+	require.NoError(t, err)
+	runCheckDone()
+
+	require.Equal(t, map[string]string{
+		"serial-0": "no-team",
+		"serial-1": "no-team",
+		"serial-2": "team3",
+		"serial-3": defaultProfileName,
+		"serial-4": "team3",
+		"serial-5": "no-team", // became a no-team host when team2 got deleted
+	}, serialsToProfile)
+
+	// check that profiles get re-generated
+	reset := time.Now().Truncate(time.Second)
+	time.Sleep(time.Second)
+
+	err = QueueMacosSetupAssistantJob(ctx, ds, logger, MacosSetupAssistantUpdateAllProfiles, nil)
+	require.NoError(t, err)
+	runCheckDone()
+
+	_, modTime, err = depStorage.RetrieveAssignerProfile(ctx, apple_mdm.DEPName)
+	require.NoError(t, err)
+	require.True(t, modTime.After(reset))
+
+	require.Equal(t, map[string]string{
+		"serial-0": "no-team",
+		"serial-1": "no-team",
+		"serial-2": "team3",
+		"serial-3": defaultProfileName,
+		"serial-4": "team3",
+		"serial-5": "no-team", // became a no-team host when team2 got deleted
+	}, serialsToProfile)
+}

--- a/server/worker/worker.go
+++ b/server/worker/worker.go
@@ -60,6 +60,9 @@ type Worker struct {
 	ds  fleet.Datastore
 	log kitlog.Logger
 
+	// For tests only, allows ignoring unknown jobs instead of failing them.
+	TestIgnoreUnknownJobs bool
+
 	registry map[string]Job
 }
 
@@ -176,6 +179,9 @@ func (w *Worker) ProcessJobs(ctx context.Context) error {
 func (w *Worker) processJob(ctx context.Context, job *fleet.Job) error {
 	j, ok := w.registry[job.Name]
 	if !ok {
+		if w.TestIgnoreUnknownJobs {
+			return nil
+		}
 		return ctxerr.Errorf(ctx, "unknown job: %s", job.Name)
 	}
 


### PR DESCRIPTION
Part 3 of #10995 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality (verified that applying/removing setup assistants results in registering the profile with Apple, same for the default profile, and modifying the Fleet server URL regenerates all profiles)
