### PR TITLE
Add required meta tag to docs page

### DIFF
--- a/docs/Contributing/adding-new-UI-components.md
+++ b/docs/Contributing/adding-new-UI-components.md
@@ -10,3 +10,5 @@
 
 You can also run `./generate -h` for information about the other options available (overwrite and
 specifying destination)
+
+<meta name="pageOrderInSection" value="450">


### PR DESCRIPTION
Changes: 
- Added the required `pageOrderInSection` meta tag to `adding-new-ui-components.md`

I just guessed what the `pageOrderInSection` value should be. This PR is just to fix the website deploy script caused by this page not having the required meta tag.

FYI: @jacobshandling 