### PR TITLE
Fleet UI Bug fix: Team admin/maintainer do not see save button for global policies

### DIFF
--- a/changes/issue-11556-hide-save-global-policy-from-team-roles
+++ b/changes/issue-11556-hide-save-global-policy-from-team-roles
@@ -1,0 +1,1 @@
+- Team admin and team maintainer cannot save/update a global policy so hide the save button when viewing or running a global policy

--- a/docs/Using-Fleet/Permissions.md
+++ b/docs/Using-Fleet/Permissions.md
@@ -34,54 +34,54 @@ GitOps is an API-only and write-only role that can be used on CI/CD pipelines.
 ## User permissions
 
 | **Action**                                                                                                                                 | Observer | Observer+ *| Maintainer | Admin | GitOps *|
-| ------------------------------------------------------------------------------------------------------------------------------------------ | -------- | --------- | ---------- | ----- | ------ |
-| View all [activity](https://fleetdm.com/docs/using-fleet/rest-api#activities)                                                              | ✅        | ✅         | ✅          | ✅     |        |
-| View all hosts                                                                                                                             | ✅        | ✅         | ✅          | ✅     |        |
-| Filter hosts using [labels](https://fleetdm.com/docs/using-fleet/rest-api#labels)                                                          | ✅        | ✅         | ✅          | ✅     |        |
-| Target hosts using labels                                                                                                                  | ✅        | ✅         | ✅          | ✅     |        |
-| Add and delete hosts                                                                                                                       |          |           | ✅          | ✅     |        |
-| Transfer hosts between teams\*                                                                                                             |          |           | ✅          | ✅     | ✅      |
-| Create, edit, and delete labels                                                                                                            |          |           | ✅          | ✅     | ✅      |
-| View all software                                                                                                                          | ✅        | ✅         | ✅          | ✅     |        |
-| Filter software by [vulnerabilities](https://fleetdm.com/docs/using-fleet/vulnerability-processing#vulnerability-processing)               | ✅        | ✅         | ✅          | ✅     |        |
-| Filter hosts by software                                                                                                                   | ✅        | ✅         | ✅          | ✅     |        |
-| Filter software by team\*                                                                                                                  | ✅        | ✅         | ✅          | ✅     |        |
-| Manage [vulnerability automations](https://fleetdm.com/docs/using-fleet/automations#vulnerability-automations)                             |          |           |            | ✅     | ✅      |
-| Run queries designated "**observer can run**" as live queries against all hosts                                                       | ✅        | ✅         | ✅          | ✅     |        |
-| Run any query as [live query](https://fleetdm.com/docs/using-fleet/fleet-ui#run-a-query) against all hosts                                 |          | ✅         | ✅          | ✅     |        |
-| Create, edit, and delete queries                                                                                                           |          |           | ✅          | ✅     | ✅      |
-| View all queries\**                                                                                                                        | ✅        | ✅         | ✅          | ✅     |        |
-| Add, edit, and remove queries from all schedules                                                                                           |          |           | ✅          | ✅     | ✅      |
-| Create, edit, view, and delete packs                                                                                                       |          |           | ✅          | ✅     | ✅      |
-| View all policies                                                                                                                          | ✅        | ✅         | ✅          | ✅     |        |
-| Filter hosts using policies                                                                                                                | ✅        | ✅         | ✅          | ✅     |        |
-| Create, edit, and delete policies for all hosts                                                                                            |          |           | ✅          | ✅     | ✅      |
-| Create, edit, and delete policies for all hosts assigned to team\*                                                                         |          |           | ✅          | ✅     | ✅      |
-| Manage [policy automations](https://fleetdm.com/docs/using-fleet/automations#policy-automations)                                           |          |           |            | ✅     | ✅      |
-| Create, edit, view, and delete users                                                                                                       |          |           |            | ✅     |        |
-| Add and remove team members\*                                                                                                              |          |           |            | ✅     | ✅      |
-| Create, edit, and delete teams\*                                                                                                           |          |           |            | ✅     | ✅      |
-| Create, edit, and delete [enroll secrets](https://fleetdm.com/docs/deploying/faq#when-do-i-need-to-deploy-a-new-enroll-secret-to-my-hosts) |          |           | ✅          | ✅     | ✅      |
-| Create, edit, and delete [enroll secrets for teams](https://fleetdm.com/docs/using-fleet/rest-api#get-enroll-secrets-for-a-team)\*         |          |           | ✅          | ✅     |        |
-| Read organization settings and agent options\***                                                                                           | ✅        | ✅         | ✅          | ✅     |        |
-| Edit [organization settings](https://fleetdm.com/docs/using-fleet/configuration-files#organization-settings)                               |          |           |            | ✅     | ✅      |
-| Edit [agent options](https://fleetdm.com/docs/using-fleet/configuration-files#agent-options)                                               |          |           |            | ✅     | ✅      |
-| Edit [agent options for hosts assigned to teams](https://fleetdm.com/docs/using-fleet/configuration-files#team-agent-options)\*            |          |           |            | ✅     | ✅      |
-| Initiate [file carving](https://fleetdm.com/docs/using-fleet/rest-api#file-carving)                                                        |          |           | ✅          | ✅     |        |
-| Retrieve contents from file carving                                                                                                        |          |           |            | ✅     |        |
-| View Apple mobile device management (MDM) certificate information                                                                          |          |           |            | ✅     |        |
-| View Apple business manager (BM) information                                                                                               |          |           |            | ✅     |        |
-| Generate Apple mobile device management (MDM) certificate signing request (CSR)                                                            |          |           |            | ✅     |        |
-| View disk encryption key for macOS hosts                                                                           | ✅        | ✅         | ✅          | ✅     |        |
-| Create edit and delete configuration profiles for macOS hosts                                                     |          |           | ✅          | ✅     | ✅      |
-| Execute MDM commands on macOS hosts***                                                                                |          |           | ✅          | ✅     |        |
-| View results of MDM commands executed on macOS hosts***                                                               | ✅        | ✅         | ✅          | ✅     |        |
-| Edit [MDM settings](https://fleetdm.com/docs/using-fleet/mdm-macos-settings)                                                               |          |           |            | ✅     | ✅      |
-| Edit [MDM settings for teams](https://fleetdm.com/docs/using-fleet/mdm-macos-settings)                                                     |          |           |            | ✅     | ✅      |
-| Upload an EULA file for MDM automatic enrollment\*                                                                                         |          |           |            | ✅     |         |
-| View/download MDM macOS setup assistant\*                                                                                                  |          |           | ✅          | ✅     |        |
-| Edit/upload MDM macOS setup assistant\*                                                                                                    |          |           | ✅          | ✅     |       |
-| Enable/disable MDM macOS setup end user authentication\*                                                                                                    |          |           | ✅          | ✅     |       |
+| ------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ---------- | ---------- | ----- | ------- |
+| View all [activity](https://fleetdm.com/docs/using-fleet/rest-api#activities)                                                              | ✅       | ✅         | ✅         | ✅    |         |
+| View all hosts                                                                                                                             | ✅       | ✅         | ✅         | ✅    |         |
+| Filter hosts using [labels](https://fleetdm.com/docs/using-fleet/rest-api#labels)                                                          | ✅       | ✅         | ✅         | ✅    |         |
+| Target hosts using labels                                                                                                                  | ✅       | ✅         | ✅         | ✅    |         |
+| Add and delete hosts                                                                                                                       |          |            | ✅         | ✅    |         |
+| Transfer hosts between teams\*                                                                                                             |          |            | ✅         | ✅    | ✅      |
+| Create, edit, and delete labels                                                                                                            |          |            | ✅         | ✅    | ✅      |
+| View all software                                                                                                                          | ✅       | ✅         | ✅         | ✅    |         |
+| Filter software by [vulnerabilities](https://fleetdm.com/docs/using-fleet/vulnerability-processing#vulnerability-processing)               | ✅       | ✅         | ✅         | ✅    |         |
+| Filter hosts by software                                                                                                                   | ✅       | ✅         | ✅         | ✅    |         |
+| Filter software by team\*                                                                                                                  | ✅       | ✅         | ✅         | ✅    |         |
+| Manage [vulnerability automations](https://fleetdm.com/docs/using-fleet/automations#vulnerability-automations)                             |          |            |            | ✅    | ✅      |
+| Run queries designated "**observer can run**" as live queries against all hosts                                                            | ✅       | ✅         | ✅         | ✅    |         |
+| Run any query as [live query](https://fleetdm.com/docs/using-fleet/fleet-ui#run-a-query) against all hosts                                 |          | ✅         | ✅         | ✅    |         |
+| Create, edit, and delete queries                                                                                                           |          |            | ✅         | ✅    | ✅      |
+| View all queries\**                                                                                                                        | ✅       | ✅         | ✅         | ✅    |         |
+| Add, edit, and remove queries from all schedules                                                                                           |          |            | ✅         | ✅    | ✅      |
+| Create, edit, view, and delete packs                                                                                                       |          |            | ✅         | ✅    | ✅      |
+| View all policies                                                                                                                          | ✅       | ✅         | ✅         | ✅    |         |
+| Filter hosts using policies                                                                                                                | ✅       | ✅         | ✅         | ✅    |         |
+| Create, edit, and delete policies for all hosts                                                                                            |          |            | ✅         | ✅    | ✅      |
+| Create, edit, and delete policies for all hosts assigned to team\*                                                                         |          |            | ✅         | ✅    | ✅      |
+| Manage [policy automations](https://fleetdm.com/docs/using-fleet/automations#policy-automations)                                           |          |            |            | ✅    | ✅      |
+| Create, edit, view, and delete users                                                                                                       |          |            |            | ✅    |         |
+| Add and remove team members\*                                                                                                              |          |            |            | ✅    | ✅      |
+| Create, edit, and delete teams\*                                                                                                           |          |            |            | ✅    | ✅      |
+| Create, edit, and delete [enroll secrets](https://fleetdm.com/docs/deploying/faq#when-do-i-need-to-deploy-a-new-enroll-secret-to-my-hosts) |          |            | ✅         | ✅    | ✅      |
+| Create, edit, and delete [enroll secrets for teams](https://fleetdm.com/docs/using-fleet/rest-api#get-enroll-secrets-for-a-team)\*         |          |            | ✅         | ✅    |         |
+| Read organization settings and agent options\***                                                                                           | ✅       | ✅         | ✅         | ✅    |         |
+| Edit [organization settings](https://fleetdm.com/docs/using-fleet/configuration-files#organization-settings)                               |          |            |            | ✅    | ✅      |
+| Edit [agent options](https://fleetdm.com/docs/using-fleet/configuration-files#agent-options)                                               |          |            |            | ✅    | ✅      |
+| Edit [agent options for hosts assigned to teams](https://fleetdm.com/docs/using-fleet/configuration-files#team-agent-options)\*            |          |            |            | ✅    | ✅      |
+| Initiate [file carving](https://fleetdm.com/docs/using-fleet/rest-api#file-carving)                                                        |          |            | ✅         | ✅    |         |
+| Retrieve contents from file carving                                                                                                        |          |            |            | ✅    |         |
+| View Apple mobile device management (MDM) certificate information                                                                          |          |            |            | ✅    |         |
+| View Apple business manager (BM) information                                                                                               |          |            |            | ✅    |         |
+| Generate Apple mobile device management (MDM) certificate signing request (CSR)                                                            |          |            |            | ✅    |         |
+| View disk encryption key for macOS hosts enrolled in Fleet's MDM                                                                           | ✅       | ✅         | ✅         | ✅    |         |
+| Create edit and delete configuration profiles for macOS hosts enrolled in Fleet's MDM                                                      |          |            | ✅         | ✅    | ✅      |
+| Execute MDM commands on macOS hosts enrolled in Fleet's MDM                                                                                |          |            | ✅         | ✅    |         |
+| View results of MDM commands executed on macOS hosts enrolled in Fleet's MDM                                                               | ✅       | ✅         | ✅         | ✅    |         |
+| Edit [MDM settings](https://fleetdm.com/docs/using-fleet/mdm-macos-settings)                                                               |          |            |            | ✅    | ✅      |
+| Edit [MDM settings for teams](https://fleetdm.com/docs/using-fleet/mdm-macos-settings)                                                     |          |            |            | ✅    | ✅      |
+| Upload an EULA file for MDM automatic enrollment\*                                                                                         |          |            |            | ✅    |         |
+| View/download MDM macOS setup assistant\*                                                                                                  |          |            | ✅         | ✅    |         |
+| Edit/upload MDM macOS setup assistant\*                                                                                                    |          |            | ✅         | ✅    |         |
+| Enable/disable MDM macOS setup end user authentication\*                                                                                   |          |            | ✅         | ✅    |         |
 
 \* Applies only to Fleet Premium
 
@@ -108,40 +108,6 @@ Users that are members of multiple teams can be assigned different roles for eac
 
 | **Action**                                                                                                                       | Team observer | Team observer+ | Team maintainer | Team admin | Team GitOps |
 | -------------------------------------------------------------------------------------------------------------------------------- | ------------- | -------------- | --------------- | ---------- | ----------- |
-<<<<<<< HEAD
-| View hosts                                                                                                                       | ✅             | ✅              | ✅               | ✅          |             |
-| Filter hosts using [labels](https://fleetdm.com/docs/using-fleet/rest-api#labels)                                                | ✅             | ✅              | ✅               | ✅          |             |
-| Target hosts using labels                                                                                                        | ✅             | ✅              | ✅               | ✅          |             |
-| Add and delete hosts                                                                                                             |               |                | ✅               | ✅          |             |
-| Filter software by [vulnerabilities](https://fleetdm.com/docs/using-fleet/vulnerability-processing#vulnerability-processing) | ✅             | ✅              | ✅               | ✅          |             |
-| Filter hosts by software                                                                                                         | ✅             | ✅              | ✅               | ✅          |             |
-| Filter software                                                                                                                  | ✅             | ✅              | ✅               | ✅          |             |
-| Run queries designated "**observer can run**" as live queries against hosts                                              | ✅             | ✅              | ✅               | ✅          |             |
-| Run any query as [live query](https://fleetdm.com/docs/using-fleet/fleet-ui#run-a-query)                                         |               | ✅              | ✅               | ✅          |             |
-| Create, edit, and delete only **self authored** queries                                                                          |               |                | ✅               | ✅          | ✅           |
-| View all queries\**                                                                                                              | ✅             | ✅              | ✅               | ✅          |             |
-| Add, edit, and remove queries from the schedule                                                                                  |               |                | ✅               | ✅          | ✅           |
-| View policies                                                                                                                    | ✅             | ✅              | ✅               | ✅          |             |
-| View global (inherited) policies                                                                                                 | ✅             | ✅              | ✅               | ✅          |             |
-| Filter hosts using policies                                                                                                      | ✅             | ✅              | ✅               | ✅          |             |
-| Create, edit, and delete policies                                                                                                |               |                | ✅               | ✅          | ✅           |
-| Manage [policy automations](https://fleetdm.com/docs/using-fleet/automations#policy-automations)                                 |               |                |                 | ✅          | ✅           |
-| Add and remove team members                                                                                                      |               |                |                 | ✅          | ✅           |
-| Edit team name                                                                                                                   |               |                |                 | ✅          | ✅           |
-| Create, edit, and delete [team enroll secrets](https://fleetdm.com/docs/using-fleet/rest-api#get-enroll-secrets-for-a-team)      |               |                | ✅               | ✅          |             |
-| Read agent options\*                                                                                                             | ✅             | ✅              | ✅               | ✅          |             |
-| Edit [agent options](https://fleetdm.com/docs/using-fleet/configuration-files#agent-options)                                     |               |                |                 | ✅          | ✅           |
-| Initiate [file carving](https://fleetdm.com/docs/using-fleet/rest-api#file-carving)                                              |               |                | ✅               | ✅          |             |
-| View disk encryption key for macOS hosts                                                                 | ✅             | ✅              | ✅               | ✅          |             |
-| Create edit and delete configuration profiles for macOS hosts                                            |               |                | ✅               | ✅          | ✅           |
-| Execute MDM commands on macOS hosts, and read command results*                                            |               |                | ✅               | ✅          |             |
-| Execute MDM commands on macOS hosts*                                                                      |               |                | ✅               | ✅          |             |
-| View results of MDM commands executed on macOS hosts*                                                     | ✅             | ✅              | ✅               | ✅          |             |
-| Edit [team MDM settings](https://fleetdm.com/docs/using-fleet/mdm-macos-settings)                                                |               |                |                 | ✅          | ✅           |
-| View/download MDM macOS setup assistant                                                                                          |               |                | ✅              | ✅          |              |
-| Edit/upload MDM macOS setup assistant                                                                                            |               |                | ✅              | ✅          |             |
-| Enable/disable MDM macOS setup end user authentication                                                                                            |               |                | ✅              | ✅          |             |
-=======
 | View hosts                                                                                                                       | ✅            | ✅             | ✅              | ✅         |             |
 | Filter hosts using [labels](https://fleetdm.com/docs/using-fleet/rest-api#labels)                                                | ✅            | ✅             | ✅              | ✅         |             |
 | Target hosts using labels                                                                                                        | ✅            | ✅             | ✅              | ✅         |             |
@@ -175,7 +141,6 @@ Users that are members of multiple teams can be assigned different roles for eac
 | View/download MDM macOS setup assistant                                                                                          |               |                | ✅              | ✅         |             |
 | Edit/upload MDM macOS setup assistant                                                                                            |               |                | ✅              | ✅         |             |
 | Enable/disable MDM macOS setup end user authentication                                                                           |               |                | ✅              | ✅         |             |
->>>>>>> 2e27f71ce (Add run policies permissions for team roles, specify team roles can only create update and delete TEAM policies)
 
 \* Applies only to [Fleet REST API](https://fleetdm.com/docs/using-fleet/rest-api)
 

--- a/docs/Using-Fleet/Permissions.md
+++ b/docs/Using-Fleet/Permissions.md
@@ -108,6 +108,7 @@ Users that are members of multiple teams can be assigned different roles for eac
 
 | **Action**                                                                                                                       | Team observer | Team observer+ | Team maintainer | Team admin | Team GitOps |
 | -------------------------------------------------------------------------------------------------------------------------------- | ------------- | -------------- | --------------- | ---------- | ----------- |
+<<<<<<< HEAD
 | View hosts                                                                                                                       | ✅             | ✅              | ✅               | ✅          |             |
 | Filter hosts using [labels](https://fleetdm.com/docs/using-fleet/rest-api#labels)                                                | ✅             | ✅              | ✅               | ✅          |             |
 | Target hosts using labels                                                                                                        | ✅             | ✅              | ✅               | ✅          |             |
@@ -140,6 +141,41 @@ Users that are members of multiple teams can be assigned different roles for eac
 | View/download MDM macOS setup assistant                                                                                          |               |                | ✅              | ✅          |              |
 | Edit/upload MDM macOS setup assistant                                                                                            |               |                | ✅              | ✅          |             |
 | Enable/disable MDM macOS setup end user authentication                                                                                            |               |                | ✅              | ✅          |             |
+=======
+| View hosts                                                                                                                       | ✅            | ✅             | ✅              | ✅         |             |
+| Filter hosts using [labels](https://fleetdm.com/docs/using-fleet/rest-api#labels)                                                | ✅            | ✅             | ✅              | ✅         |             |
+| Target hosts using labels                                                                                                        | ✅            | ✅             | ✅              | ✅         |             |
+| Add and delete hosts                                                                                                             |               |                | ✅              | ✅         |             |
+| Filter software by [vulnerabilities](https://fleetdm.com/docs/using-fleet/vulnerability-processing#vulnerability-processing)     | ✅            | ✅             | ✅              | ✅         |             |
+| Filter hosts by software                                                                                                         | ✅            | ✅             | ✅              | ✅         |             |
+| Filter software                                                                                                                  | ✅            | ✅             | ✅              | ✅         |             |
+| Run queries designated "**observer can run**" as live queries against hosts                                                      | ✅            | ✅             | ✅              | ✅         |             |
+| Run any query as [live query](https://fleetdm.com/docs/using-fleet/fleet-ui#run-a-query)                                         |               | ✅             | ✅              | ✅         |             |
+| Create, edit, and delete only **self authored** queries                                                                          |               |                | ✅              | ✅         | ✅          |
+| View all queries\**                                                                                                              | ✅            | ✅             | ✅              | ✅         |             |
+| Add, edit, and remove queries from the schedule                                                                                  |               |                | ✅              | ✅         | ✅          |
+| View policies                                                                                                                    | ✅            | ✅             | ✅              | ✅         |             |
+| View global (inherited) policies                                                                                                 | ✅            | ✅             | ✅              | ✅         |             |
+| Run global (inherited) policies as a live policy                                                                                 |               |                | ✅              | ✅         |             |
+| Filter hosts using policies                                                                                                      | ✅            | ✅             | ✅              | ✅         |             |
+| Create, edit, and delete team policies                                                                                           |               |                | ✅              | ✅         | ✅          |
+| Manage [policy automations](https://fleetdm.com/docs/using-fleet/automations#policy-automations)                                 |               |                |                 | ✅         | ✅          |
+| Add and remove team members                                                                                                      |               |                |                 | ✅         | ✅          |
+| Edit team name                                                                                                                   |               |                |                 | ✅         | ✅          |
+| Create, edit, and delete [team enroll secrets](https://fleetdm.com/docs/using-fleet/rest-api#get-enroll-secrets-for-a-team)      |               |                | ✅              | ✅         |             |
+| Read agent options\*                                                                                                             | ✅            | ✅             | ✅              | ✅         |             |
+| Edit [agent options](https://fleetdm.com/docs/using-fleet/configuration-files#agent-options)                                     |               |                |                 | ✅         | ✅          |
+| Initiate [file carving](https://fleetdm.com/docs/using-fleet/rest-api#file-carving)                                              |               |                | ✅              | ✅         |             |
+| View disk encryption key for macOS hosts enrolled in Fleet's MDM                                                                 | ✅            | ✅             | ✅              | ✅         |             |
+| Create edit and delete configuration profiles for macOS hosts enrolled in Fleet's MDM                                            |               |                | ✅              | ✅         | ✅          |
+| Execute MDM commands on macOS hosts enrolled in Fleet's MDM, and read command results                                            |               |                | ✅              | ✅         |             |
+| Execute MDM commands on macOS hosts enrolled in Fleet's MDM                                                                      |               |                | ✅              | ✅         |             |
+| View results of MDM commands executed on macOS hosts enrolled in Fleet's MDM                                                     | ✅            | ✅             | ✅              | ✅         |             |
+| Edit [team MDM settings](https://fleetdm.com/docs/using-fleet/mdm-macos-settings)                                                |               |                |                 | ✅         | ✅          |
+| View/download MDM macOS setup assistant                                                                                          |               |                | ✅              | ✅         |             |
+| Edit/upload MDM macOS setup assistant                                                                                            |               |                | ✅              | ✅         |             |
+| Enable/disable MDM macOS setup end user authentication                                                                           |               |                | ✅              | ✅         |             |
+>>>>>>> 2e27f71ce (Add run policies permissions for team roles, specify team roles can only create update and delete TEAM policies)
 
 \* Applies only to [Fleet REST API](https://fleetdm.com/docs/using-fleet/rest-api)
 

--- a/docs/Using-Fleet/Permissions.md
+++ b/docs/Using-Fleet/Permissions.md
@@ -72,10 +72,10 @@ GitOps is an API-only and write-only role that can be used on CI/CD pipelines.
 | View Apple mobile device management (MDM) certificate information                                                                          |          |            |            | ✅    |         |
 | View Apple business manager (BM) information                                                                                               |          |            |            | ✅    |         |
 | Generate Apple mobile device management (MDM) certificate signing request (CSR)                                                            |          |            |            | ✅    |         |
-| View disk encryption key for macOS hosts enrolled in Fleet's MDM                                                                           | ✅       | ✅         | ✅         | ✅    |         |
-| Create edit and delete configuration profiles for macOS hosts enrolled in Fleet's MDM                                                      |          |            | ✅         | ✅    | ✅      |
-| Execute MDM commands on macOS hosts enrolled in Fleet's MDM                                                                                |          |            | ✅         | ✅    |         |
-| View results of MDM commands executed on macOS hosts enrolled in Fleet's MDM                                                               | ✅       | ✅         | ✅         | ✅    |         |
+| View disk encryption key for macOS hosts                                                                                                   | ✅       | ✅         | ✅         | ✅    |         |
+| Create edit and delete configuration profiles for macOS hosts                                                                              |          |            | ✅         | ✅    | ✅      |
+| Execute MDM commands on macOS hosts***                                                                                                     |          |            | ✅         | ✅    |         |
+| View results of MDM commands executed on macOS hosts***                                                                                    | ✅       | ✅         | ✅         | ✅    |         |
 | Edit [MDM settings](https://fleetdm.com/docs/using-fleet/mdm-macos-settings)                                                               |          |            |            | ✅    | ✅      |
 | Edit [MDM settings for teams](https://fleetdm.com/docs/using-fleet/mdm-macos-settings)                                                     |          |            |            | ✅    | ✅      |
 | Upload an EULA file for MDM automatic enrollment\*                                                                                         |          |            |            | ✅    |         |
@@ -132,11 +132,11 @@ Users that are members of multiple teams can be assigned different roles for eac
 | Read agent options\*                                                                                                             | ✅            | ✅             | ✅              | ✅         |             |
 | Edit [agent options](https://fleetdm.com/docs/using-fleet/configuration-files#agent-options)                                     |               |                |                 | ✅         | ✅          |
 | Initiate [file carving](https://fleetdm.com/docs/using-fleet/rest-api#file-carving)                                              |               |                | ✅              | ✅         |             |
-| View disk encryption key for macOS hosts enrolled in Fleet's MDM                                                                 | ✅            | ✅             | ✅              | ✅         |             |
-| Create edit and delete configuration profiles for macOS hosts enrolled in Fleet's MDM                                            |               |                | ✅              | ✅         | ✅          |
-| Execute MDM commands on macOS hosts enrolled in Fleet's MDM, and read command results                                            |               |                | ✅              | ✅         |             |
-| Execute MDM commands on macOS hosts enrolled in Fleet's MDM                                                                      |               |                | ✅              | ✅         |             |
-| View results of MDM commands executed on macOS hosts enrolled in Fleet's MDM                                                     | ✅            | ✅             | ✅              | ✅         |             |
+| View disk encryption key for macOS hosts                                                                                         | ✅            | ✅             | ✅              | ✅         |             |
+| Create edit and delete configuration profiles for macOS hosts                                                                    |               |                | ✅              | ✅         | ✅          |
+| Execute MDM commands on macOS hosts, and read command results*                                                                   |               |                | ✅              | ✅         |             |
+| Execute MDM commands on macOS hosts*                                                                                             |               |                | ✅              | ✅         |             |
+| View results of MDM commands executed on macOS hosts*                                                                            | ✅            | ✅             | ✅              | ✅         |             |
 | Edit [team MDM settings](https://fleetdm.com/docs/using-fleet/mdm-macos-settings)                                                |               |                |                 | ✅         | ✅          |
 | View/download MDM macOS setup assistant                                                                                          |               |                | ✅              | ✅         |             |
 | Edit/upload MDM macOS setup assistant                                                                                            |               |                | ✅              | ✅         |             |

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -169,7 +169,10 @@ const PolicyForm = ({
   }, [lastEditedQueryBody, lastEditedQueryId]);
 
   const hasSavePermissions =
-    isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer;
+    isGlobalAdmin ||
+    isGlobalMaintainer ||
+    (isTeamAdmin && policyTeamId === storedPolicy?.team_id) || // team admin cannot save global policy
+    (isTeamMaintainer && policyTeamId === storedPolicy?.team_id); // team maintainer cannot save global policy
 
   const onLoad = (editor: IAceEditor) => {
     editor.setOptions({
@@ -519,37 +522,39 @@ const PolicyForm = ({
         {isEditMode && isPremiumTier && renderCriticalPolicy()}
         {renderLiveQueryWarning()}
         <div className={`${baseClass}__button-wrap`}>
-          <span
-            className={`${baseClass}__button-wrap--tooltip`}
-            data-tip
-            data-for={`${baseClass}__button-wrap--tooltip`}
-            data-tip-disable={!isEditMode || isAnyPlatformSelected}
-          >
-            {hasSavePermissions && (
-              <Button
-                variant="brand"
-                onClick={promptSavePolicy()}
-                disabled={isEditMode && !isAnyPlatformSelected}
-                className="save-loading"
-                isLoading={isUpdatingPolicy}
+          {hasSavePermissions && (
+            <>
+              <span
+                className={`${baseClass}__button-wrap--tooltip`}
+                data-tip
+                data-for={`${baseClass}__button-wrap--tooltip`}
+                data-tip-disable={!isEditMode || isAnyPlatformSelected}
               >
-                Save
-              </Button>
-            )}
-          </span>
-          <ReactTooltip
-            className={`${baseClass}__button-wrap--tooltip`}
-            place="bottom"
-            effect="solid"
-            id={`${baseClass}__button-wrap--tooltip`}
-            backgroundColor="#3e4771"
-          >
-            Select the platform(s) this
-            <br />
-            policy will be checked on
-            <br />
-            to save or run the policy.
-          </ReactTooltip>
+                <Button
+                  variant="brand"
+                  onClick={promptSavePolicy()}
+                  disabled={isEditMode && !isAnyPlatformSelected}
+                  className="save-loading"
+                  isLoading={isUpdatingPolicy}
+                >
+                  Save
+                </Button>
+              </span>
+              <ReactTooltip
+                className={`${baseClass}__button-wrap--tooltip`}
+                place="bottom"
+                effect="solid"
+                id={`${baseClass}__button-wrap--tooltip`}
+                backgroundColor="#3e4771"
+              >
+                Select the platform(s) this
+                <br />
+                policy will be checked on
+                <br />
+                to save or run the policy.
+              </ReactTooltip>
+            </>
+          )}
           <span
             className={`${baseClass}__button-wrap--tooltip`}
             data-tip

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
@@ -177,7 +177,7 @@
     margin: 0;
     margin-top: $pad-large;
     display: flex;
-    gap: $pad-medium;
+    column-gap: $pad-medium;
 
     &--tooltip {
       display: flex;


### PR DESCRIPTION
## Issue
Cerra #11556 

## Description
- Hides the Save button from users who cannot save a global policy (team admin and maintainer) 😶‍🌫️
- Clarify on permissions table that team admin and team maintainer **can** run a policy as a live policy (and team observer, team observer +, team gitops cannot) 🧐
- Clean up permissions table formatting 🧹🧽

## Screenshots
Permissions table before 😳
<img width="1302" alt="Screenshot 2023-05-12 at 1 42 56 PM" src="https://github.com/fleetdm/fleet/assets/71795832/07ba7cd0-4f45-4cad-bd75-c5d9bec606d0">

Permissions table after 😍 (note new line for _running global policy_, and new clarification for create, edit, delete _team_ policy)
<img width="1304" alt="Screenshot 2023-05-12 at 1 41 37 PM" src="https://github.com/fleetdm/fleet/assets/71795832/e34cd851-47a1-46d2-8df9-390b2794fbc2">

UI for team admin and team maintainer for a global policy only includes the run button and no longer has a broken save button
<img width="1320" alt="Screenshot 2023-05-12 at 1 48 58 PM" src="https://github.com/fleetdm/fleet/assets/71795832/08f4ceab-343c-44f5-9526-4257a01a4237">


# Checklist for submitter


If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
