### PR TITLE
Fleet UI: Fix small unreleased bug

### DIFF
--- a/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
+++ b/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
@@ -175,7 +175,7 @@ const QueryEditor = ({
 
   // Function instead of constant eliminates race condition with filteredSoftwarePath
   const backToPoliciesPath = () => {
-    return filteredPoliciesPath || PATHS.MANAGE_QUERIES;
+    return filteredPoliciesPath || PATHS.MANAGE_POLICIES;
   };
 
   return (


### PR DESCRIPTION
## Issue
Related to #11343

## Description
If no filtered policy table path (like when hitting refresh on browser), back to policies link should default to manage policies page _not_ manage queries page (unreleased bug)

- [x] Manual QA for all new/changed functionality

