### PR TITLE
Add documentation for how to specify platforms on fleetdm.com/tables

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -18,14 +18,14 @@ examples: >- # (optional) string - An example query for this table. Note: This f
 	# Add examples here
 notes: >- # (optional) string - Notes about this table. Note: This field supports markdown.
 	# Add notes here
-platforms: >- # (optional) array - A list of supported platforms for this table (any of: `darwin`, `windows`, `linux`, `chromeos`)
+platforms: >- # (optional) array - A list of supported platforms for this table (any of: `darwin`, `windows`, `linux`, `chrome`)
 	# Add platforms here
 columns: # (required) array - An array of columns in this table
   - name: # (required) string - The name of the column
     description: # (required) string - The column's description
     type: # (required) string - the column's data type
     required: # (required) boolean - whether or not this column is required to query this table.
-    platforms: # (optional) array - List of supported platforms, used to clarify when a column isn't available on every platform its table supports (any of: `darwin`, `windows`, `linux`, `chromeos`)
+    platforms: # (optional) array - List of supported platforms, used to clarify when a column isn't available on every platform its table supports (any of: `darwin`, `windows`, `linux`, `chrome`)
 ```
 
 Alternatively, if you want to add documentation about an osquery table for which we don't have a YAML override, you can find the table's page on the [Fleet website](https://fleetdm.com/tables) and click the "edit page" button. Clicking this button will take you to the GitHub web editor with the template pre-filled. After you add information about the table and its columns, you can open a new pull request to add the new YAML file to Fleet's overrides.

--- a/schema/README.md
+++ b/schema/README.md
@@ -18,11 +18,14 @@ examples: >- # (optional) string - An example query for this table. Note: This f
 	# Add examples here
 notes: >- # (optional) string - Notes about this table. Note: This field supports markdown.
 	# Add notes here
+platforms: >- # (optional) array - A list of supported platforms for this table (any of: `darwin`, `windows`, `linux`, `chromeos`)
+	# Add platforms here
 columns: # (required) array - An array of columns in this table
   - name: # (required) string - The name of the column
     description: # (required) string - The column's description
     type: # (required) string - the column's data type
     required: # (required) boolean - whether or not this column is required to query this table.
+    platforms: # (optional) array - List of supported platforms, used to clarify when a column isn't available on every platform its table supports (any of: `darwin`, `windows`, `linux`, `chromeos`)
 ```
 
 Alternatively, if you want to add documentation about an osquery table for which we don't have a YAML override, you can find the table's page on the [Fleet website](https://fleetdm.com/tables) and click the "edit page" button. Clicking this button will take you to the GitHub web editor with the template pre-filled. After you add information about the table and its columns, you can open a new pull request to add the new YAML file to Fleet's overrides.


### PR DESCRIPTION
Updated the README to clarify how to document platform support for the entire table or for specific columns.