### PR TITLE
Update icloud_private_relay.yml

### DIFF
--- a/schema/tables/icloud_private_relay.yml
+++ b/schema/tables/icloud_private_relay.yml
@@ -1,6 +1,6 @@
 name: icloud_private_relay
 platforms:
-  - macOS
+  - darwin
 description: Whether [iCloud Private Relay](https://support.apple.com/en-us/HT212614) is enabled.
 columns: 
   - name: status


### PR DESCRIPTION
Updated the platform name to "darwin" to fix missing icon:
<img width="977" alt="Screenshot 2023-05-15 at 1 19 17 PM" src="https://github.com/fleetdm/fleet/assets/3065949/4c2163b8-aa30-4b55-838e-c0a36cb20a6d">
