### PR TITLE
terraform module -- firehose audit logs

### DIFF
--- a/terraform/addons/byo-firehose-logging-destination/firehose/outputs.tf
+++ b/terraform/addons/byo-firehose-logging-destination/firehose/outputs.tf
@@ -6,6 +6,8 @@ output "fleet_extra_environment_variables" {
     FLEET_FIREHOSE_REGION              = var.region
     FLEET_OSQUERY_STATUS_LOG_PLUGIN    = "firehose"
     FLEET_OSQUERY_RESULT_LOG_PLUGIN    = "firehose"
+    FLEET_ACTIVITY_ENABLE_AUDIT_LOG    = length(var.firehose_audit_name) > 0 ? "true" : "false"
+    FLEET_ACTIVITY_AUDIT_LOG_PLUGIN    = "firehose" # only has an effect if ^ is true
   }
 }
 

--- a/terraform/addons/byo-firehose-logging-destination/firehose/variables.tf
+++ b/terraform/addons/byo-firehose-logging-destination/firehose/variables.tf
@@ -13,6 +13,11 @@ variable "firehose_status_name" {
   description = "name of the firehose delivery stream for osquery status logs"
 }
 
+variable "firehose_audit_name" {
+  type        = string
+  description = "name of the firehose delivery stream for fleet audit logs"
+}
+
 variable "region" {
   type        = string
   description = "region the target firehose delivery stream is in"

--- a/terraform/addons/byo-firehose-logging-destination/target-account/firehose.tf
+++ b/terraform/addons/byo-firehose-logging-destination/target-account/firehose.tf
@@ -30,11 +30,13 @@ data "aws_iam_policy_document" "firehose_policy" {
   statement {
     effect  = "Allow"
     actions = ["logs:PutLogEvents"]
-    resources = [
+    resources = join([
       "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kinesisfirehose/${var.firehose_results_name}:*",
       "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kinesisfirehose/${var.firehose_status_name}:*",
-      "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kinesisfirehose/${var.firehose_audit_name}:*"
-    ]
+      ],
+      var.firehose_status_name == "" ? [] : [
+        "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kinesisfirehose/${var.firehose_audit_name}:*"
+    ])
   }
 
   statement {

--- a/terraform/addons/byo-firehose-logging-destination/target-account/firehose.tf
+++ b/terraform/addons/byo-firehose-logging-destination/target-account/firehose.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "firehose_policy" {
   statement {
     effect  = "Allow"
     actions = ["logs:PutLogEvents"]
-    resources = join([
+    resources = concat([
       "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kinesisfirehose/${var.firehose_results_name}:*",
       "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kinesisfirehose/${var.firehose_status_name}:*",
       ],

--- a/terraform/addons/byo-firehose-logging-destination/target-account/firehose.tf
+++ b/terraform/addons/byo-firehose-logging-destination/target-account/firehose.tf
@@ -32,7 +32,8 @@ data "aws_iam_policy_document" "firehose_policy" {
     actions = ["logs:PutLogEvents"]
     resources = [
       "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kinesisfirehose/${var.firehose_results_name}:*",
-      "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kinesisfirehose/${var.firehose_status_name}:*"
+      "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kinesisfirehose/${var.firehose_status_name}:*",
+      "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kinesisfirehose/${var.firehose_audit_name}:*"
     ]
   }
 
@@ -89,6 +90,22 @@ resource "aws_kinesis_firehose_delivery_stream" "osquery_status" {
 
   s3_configuration {
     prefix     = var.status_prefix
+    role_arn   = aws_iam_role.firehose.arn
+    bucket_arn = aws_s3_bucket.destination.arn
+  }
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "fleet_audit" {
+  count       = length(var.firehose_audit_name) > 0 ? 1 : 0
+  name        = var.firehose_audit_name
+  destination = "s3"
+
+  server_side_encryption {
+    key_arn = aws_kms_key.firehose.arn
+  }
+
+  s3_configuration {
+    prefix     = var.audit_prefix
     role_arn   = aws_iam_role.firehose.arn
     bucket_arn = aws_s3_bucket.destination.arn
   }

--- a/terraform/addons/byo-firehose-logging-destination/target-account/s3.tf
+++ b/terraform/addons/byo-firehose-logging-destination/target-account/s3.tf
@@ -1,7 +1,7 @@
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_kms_alias" "s3" {
-  name = "aws/s3"
+  name = "alias/s3"
 }
 
 resource "aws_s3_bucket" "destination" {

--- a/terraform/addons/byo-firehose-logging-destination/target-account/s3.tf
+++ b/terraform/addons/byo-firehose-logging-destination/target-account/s3.tf
@@ -1,7 +1,7 @@
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_kms_alias" "s3" {
-  name = "alias/s3"
+  name = "aws/s3"
 }
 
 resource "aws_s3_bucket" "destination" {

--- a/terraform/addons/byo-firehose-logging-destination/target-account/variables.tf
+++ b/terraform/addons/byo-firehose-logging-destination/target-account/variables.tf
@@ -15,6 +15,12 @@ variable "firehose_status_name" {
   default     = "osquery_status"
 }
 
+variable "firehose_audit_name" {
+  type        = string
+  description = "firehose delivery stream name for Fleet audit logs"
+  default     = ""
+}
+
 variable "fleet_iam_role_arn" {
   type        = string
   description = "the arn of the fleet role that firehose will assume to write data to your bucket"
@@ -28,4 +34,9 @@ variable "results_prefix" {
 variable "status_prefix" {
   default     = "status/"
   description = "s3 object prefix to give status logs"
+}
+
+variable "audit_prefix" {
+  default     = "audit/"
+  description = "s3 object prefix to give Fleet audit logs"
 }


### PR DESCRIPTION
Add support for Fleet audit logs by adding a new variable `firehose_audit_name` to the `firehose` module. If the variable is set, a new delivery stream is created for Fleet audit logs. The IAM role is updated to allow writing to the new delivery stream. The `outputs.tf` file is updated to include the new environment variable `FLEET_ACTIVITY_ENABLE_AUDIT_LOG` and `FLEET_ACTIVITY_AUDIT_LOG_PLUGIN` to the `fleet_extra_environment_variables` output. The `firehose_policy` in `firehose.tf` is updated to allow writing to the new delivery stream. The `firehose_audit` policy is created and attached to the IAM role if the `firehose_audit_name` variable is set.

