### PR TITLE
update default text line-height

### DIFF
--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -62,6 +62,8 @@ a {
   padding: $pad-xlarge;
   border-radius: 3px;
   background-color: $core-white;
+  // desired default line-height for text is 1.5x the font size.
+  line-height: 1.5;
 }
 
 .has-sidebar {


### PR DESCRIPTION
Had a chat with @mike-j-thomas and decided to set the default text line height in fleet UI to 1.5. This will align with the new styleguide components going forward.