### PR TITLE
MDM docs: Custom macOS settings

### DIFF
--- a/docs/Using-Fleet/MDM-custom-macOS-settings.md
+++ b/docs/Using-Fleet/MDM-custom-macOS-settings.md
@@ -16,7 +16,7 @@ How to create a configuration profile with iMazing Profile Creator:
 
 1. Download and install [iMazing Profile Creator](https://imazing.com/profile-editor).
 
-2. Open iMazing Profile Creator and select macOS in the top bar. Fleet only supports enforcing settings on macOS hosts.
+2. Open iMazing Profile Creator and select macOS in the top bar.
 
 3. Find and choose the settings you'd like to enforce on your macOS hosts. Fleet recommends limiting the scope of the settings a single profile: only include settings from one tab in iMazing Profile Creator (ex. **Restrictions** tab). To enforce more settings, you can create and add additional profiles.
 


### PR DESCRIPTION
Changes address the feedback below:

> Disk encryption docs should say that you shouldn’t use custom settings to enforce disk encryption (prevent user from trying to do filevault via imazing)

I decided not to call this out in the docs because this is handled by the product. The UI (and CLI) show this error if the user tries to use custom settings to enforce disk encryption:
![Screenshot 2023-05-16 at 9 48 59 AM](https://github.com/fleetdm/fleet/assets/47070608/d5f5de9b-f3c2-4b4f-b8a0-30fbf5292b9e)

> Custom settings docs says randomly that it only works for macOS. Should be obvious.  No need to state?

I removed sentence about Fleet only supporting macOS
