### PR TITLE
UI:  Make all Modal widths consistent

### DIFF
--- a/changes/11356-bring-all-modals-into-consistent-style-regime
+++ b/changes/11356-bring-all-modals-into-consistent-style-regime
@@ -1,0 +1,1 @@
+* Made sure every modal in the UI conforms to a consistent system of widths

--- a/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/_styles.scss
+++ b/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/_styles.scss
@@ -44,7 +44,7 @@
     display: flex;
     align-items: center;
     position: absolute;
-    right: 16px;
+    right: 4px;
     top: 12px;
     height: 16px;
 

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -4,7 +4,7 @@ import { NotificationContext } from "context/notification";
 
 const baseClass = "modal";
 
-type ModalWidth = "m" | "l" | "xl";
+type ModalWidth = "m" | "l" | "xl" | "auto";
 
 export interface IModalProps {
   title: string | JSX.Element;
@@ -60,7 +60,8 @@ const Modal = ({
     `${baseClass}__modal_container`,
     className,
     { [`${baseClass}__modal_container__l`]: width === "l" },
-    { [`${baseClass}__modal_container__xl`]: width === "xl" }
+    { [`${baseClass}__modal_container__xl`]: width === "xl" },
+    { [`${baseClass}__modal_container__auto`]: width === "auto" }
   );
 
   return (

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -5,18 +5,20 @@ import { NotificationContext } from "context/notification";
 const baseClass = "modal";
 
 export interface IModalProps {
+  title: string | JSX.Element;
   children: JSX.Element;
   onExit: () => void;
   onEnter?: () => void;
-  title: string | JSX.Element;
+  wide?: boolean;
   className?: string;
 }
 
 const Modal = ({
+  title,
   children,
   onExit,
   onEnter,
-  title,
+  wide = false,
   className,
 }: IModalProps): JSX.Element => {
   const { hideFlash } = useContext(NotificationContext);
@@ -54,7 +56,8 @@ const Modal = ({
 
   const modalContainerClassName = classnames(
     `${baseClass}__modal_container`,
-    className
+    className,
+    { [`${baseClass}__modal_container__wide`]: wide }
   );
 
   return (

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -4,12 +4,14 @@ import { NotificationContext } from "context/notification";
 
 const baseClass = "modal";
 
+type ModalWidth = "m" | "l" | "xl";
+
 export interface IModalProps {
   title: string | JSX.Element;
   children: JSX.Element;
   onExit: () => void;
   onEnter?: () => void;
-  wide?: boolean;
+  width?: ModalWidth;
   className?: string;
 }
 
@@ -18,7 +20,7 @@ const Modal = ({
   children,
   onExit,
   onEnter,
-  wide = false,
+  width = "m",
   className,
 }: IModalProps): JSX.Element => {
   const { hideFlash } = useContext(NotificationContext);
@@ -57,7 +59,8 @@ const Modal = ({
   const modalContainerClassName = classnames(
     `${baseClass}__modal_container`,
     className,
-    { [`${baseClass}__modal_container__wide`]: wide }
+    { [`${baseClass}__modal_container__l`]: width === "l" },
+    { [`${baseClass}__modal_container__xl`]: width === "xl" }
   );
 
   return (

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -4,7 +4,7 @@ import { NotificationContext } from "context/notification";
 
 const baseClass = "modal";
 
-type ModalWidth = "m" | "l" | "xl" | "auto";
+type ModalWidth = "medium" | "large" | "xlarge" | "auto";
 
 export interface IModalProps {
   title: string | JSX.Element;
@@ -20,7 +20,7 @@ const Modal = ({
   children,
   onExit,
   onEnter,
-  width = "m",
+  width = "medium",
   className,
 }: IModalProps): JSX.Element => {
   const { hideFlash } = useContext(NotificationContext);
@@ -59,8 +59,8 @@ const Modal = ({
   const modalContainerClassName = classnames(
     `${baseClass}__modal_container`,
     className,
-    { [`${baseClass}__modal_container__l`]: width === "l" },
-    { [`${baseClass}__modal_container__xl`]: width === "xl" },
+    { [`${baseClass}__modal_container__l`]: width === "large" },
+    { [`${baseClass}__modal_container__xl`]: width === "xlarge" },
     { [`${baseClass}__modal_container__auto`]: width === "auto" }
   );
 

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -38,7 +38,7 @@ const Modal = ({
     return () => {
       document.removeEventListener("keydown", closeWithEscapeKey);
     };
-  }, []);
+  }, [hideFlash, onExit]);
 
   useEffect(() => {
     if (onEnter) {

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -59,8 +59,9 @@ const Modal = ({
   const modalContainerClassName = classnames(
     `${baseClass}__modal_container`,
     className,
-    { [`${baseClass}__modal_container__l`]: width === "large" },
-    { [`${baseClass}__modal_container__xl`]: width === "xlarge" },
+    { [`${baseClass}__modal_container__medium`]: width === "medium" },
+    { [`${baseClass}__modal_container__large`]: width === "large" },
+    { [`${baseClass}__modal_container__xlarge`]: width === "xlarge" },
     { [`${baseClass}__modal_container__auto`]: width === "auto" }
   );
 

--- a/frontend/components/Modal/_styles.scss
+++ b/frontend/components/Modal/_styles.scss
@@ -66,11 +66,15 @@
 
   &__modal_container {
     @include position(absolute, 22px null null null);
+    box-sizing: border-box;
     background-color: $core-white;
-    min-width: 650px;
-    max-width: 800px;
+    width: 650px;
     padding: $pad-xxlarge;
     border-radius: 8px;
     animation: scale-up 150ms ease-out;
+
+    &__wide {
+      width: 800px;
+    }
   }
 }

--- a/frontend/components/Modal/_styles.scss
+++ b/frontend/components/Modal/_styles.scss
@@ -73,8 +73,14 @@
     border-radius: 8px;
     animation: scale-up 150ms ease-out;
 
-    &__wide {
+    &__l {
       width: 800px;
+    }
+    &__xl {
+      width: 850px;
+    }
+    &__auto {
+      width: auto;
     }
   }
 }

--- a/frontend/components/Modal/_styles.scss
+++ b/frontend/components/Modal/_styles.scss
@@ -73,10 +73,10 @@
     border-radius: 8px;
     animation: scale-up 150ms ease-out;
 
-    &__l {
+    &__large {
       width: 800px;
     }
-    &__xl {
+    &__xlarge {
       width: 850px;
     }
     &__auto {

--- a/frontend/components/Modal/_styles.scss
+++ b/frontend/components/Modal/_styles.scss
@@ -68,11 +68,13 @@
     @include position(absolute, 22px null null null);
     box-sizing: border-box;
     background-color: $core-white;
-    width: 650px;
     padding: $pad-xxlarge;
     border-radius: 8px;
     animation: scale-up 150ms ease-out;
 
+    &__medium {
+      width: 650px;
+    }
     &__large {
       width: 800px;
     }

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -278,7 +278,6 @@ $base-class: "button";
     color: $core-vibrant-red;
     border: 0;
     box-sizing: border-box;
-    padding: 0;
 
     &:hover,
     &:focus {

--- a/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/components/DeleteProfileModal/DeleteProfileModal.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/components/DeleteProfileModal/DeleteProfileModal.tsx
@@ -37,6 +37,7 @@ const DeleteProfileModal = ({
       title={"Delete configuration profile"}
       onExit={onCancel}
       onEnter={() => onDelete(profileId)}
+      width="l"
     >
       <>
         <p>

--- a/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/components/DeleteProfileModal/DeleteProfileModal.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/cards/CustomSettings/components/DeleteProfileModal/DeleteProfileModal.tsx
@@ -37,7 +37,7 @@ const DeleteProfileModal = ({
       title={"Delete configuration profile"}
       onExit={onCancel}
       onEnter={() => onDelete(profileId)}
-      width="l"
+      width="large"
     >
       <>
         <p>

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
@@ -76,8 +76,6 @@
   }
 
   &__password {
-    width: 98%;
-    padding: 0 $pad-medium 0 0;
     box-sizing: border-box;
 
     .input-icon-field {

--- a/frontend/pages/hosts/details/DeviceUserPage/AutoEnrollMdmModal/AutoEnrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/AutoEnrollMdmModal/AutoEnrollMdmModal.tsx
@@ -13,7 +13,7 @@ const AutoEnrollMdmModal = ({
   onCancel,
 }: IAutoEnrollMdmModalProps): JSX.Element => {
   return (
-    <Modal title="Turn on MDM" onExit={onCancel} className={baseClass}>
+    <Modal title="Turn on MDM" onExit={onCancel} className={baseClass} wide>
       <div>
         <p className={`${baseClass}__description`}>
           To turn on MDM, Apple Inc. requires that you install a profile.

--- a/frontend/pages/hosts/details/DeviceUserPage/AutoEnrollMdmModal/AutoEnrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/AutoEnrollMdmModal/AutoEnrollMdmModal.tsx
@@ -17,7 +17,7 @@ const AutoEnrollMdmModal = ({
       title="Turn on MDM"
       onExit={onCancel}
       className={baseClass}
-      width="xl"
+      width="xlarge"
     >
       <div>
         <p className={`${baseClass}__description`}>

--- a/frontend/pages/hosts/details/DeviceUserPage/AutoEnrollMdmModal/AutoEnrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/AutoEnrollMdmModal/AutoEnrollMdmModal.tsx
@@ -13,7 +13,12 @@ const AutoEnrollMdmModal = ({
   onCancel,
 }: IAutoEnrollMdmModalProps): JSX.Element => {
   return (
-    <Modal title="Turn on MDM" onExit={onCancel} className={baseClass} wide>
+    <Modal
+      title="Turn on MDM"
+      onExit={onCancel}
+      className={baseClass}
+      width="xl"
+    >
       <div>
         <p className={`${baseClass}__description`}>
           To turn on MDM, Apple Inc. requires that you install a profile.

--- a/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
@@ -72,7 +72,7 @@ const ManualEnrollMdmModal = ({
       title="Turn on MDM"
       onExit={onCancel}
       className={baseClass}
-      width="xl"
+      width="xlarge"
     >
       <div>
         <p className={`${baseClass}__description`}>

--- a/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
@@ -68,7 +68,7 @@ const ManualEnrollMdmModal = ({
   }
 
   return (
-    <Modal title="Turn on MDM" onExit={onCancel} className={baseClass}>
+    <Modal title="Turn on MDM" onExit={onCancel} className={baseClass} wide>
       <div>
         <p className={`${baseClass}__description`}>
           To turn on MDM, Apple Inc. requires that you download and install a

--- a/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
@@ -68,7 +68,12 @@ const ManualEnrollMdmModal = ({
   }
 
   return (
-    <Modal title="Turn on MDM" onExit={onCancel} className={baseClass} wide>
+    <Modal
+      title="Turn on MDM"
+      onExit={onCancel}
+      className={baseClass}
+      width="xl"
+    >
       <div>
         <p className={`${baseClass}__description`}>
           To turn on MDM, Apple Inc. requires that you download and install a

--- a/frontend/pages/hosts/details/DeviceUserPage/ResetKeyModal/ResetKeyModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/ResetKeyModal/ResetKeyModal.tsx
@@ -56,7 +56,12 @@ const ResetKeyModal = ({
     );
   };
   return (
-    <Modal title="Reset key" onExit={onClose} className={baseClass}>
+    <Modal
+      title="Reset key"
+      onExit={onClose}
+      className={baseClass}
+      width="auto"
+    >
       {renderModalBody()}
     </Modal>
   );

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -4,8 +4,6 @@
   }
 }
 .enroll-mdm-modal {
-  width: 800px;
-
   &__description {
     margin: $pad-large 0;
   }

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -144,7 +144,7 @@ const HostDetailsPage = ({
 
   const [showDeleteHostModal, setShowDeleteHostModal] = useState(false);
   const [showTransferHostModal, setShowTransferHostModal] = useState(false);
-  const [showQueryHostModal, setShowQueryHostModal] = useState(false);
+  const [showSelectQueryModal, setShowSelectQueryModal] = useState(false);
   const [showPolicyDetailsModal, setPolicyDetailsModal] = useState(false);
   const [showOSPolicyModal, setShowOSPolicyModal] = useState(false);
   const [showMacSettingsModal, setShowMacSettingsModal] = useState(false);
@@ -549,7 +549,7 @@ const HostDetailsPage = ({
         setShowTransferHostModal(true);
         break;
       case "query":
-        setShowQueryHostModal(true);
+        setShowSelectQueryModal(true);
         break;
       case "diskEncryption":
         setShowDiskEncryptionModal(true);
@@ -783,9 +783,9 @@ const HostDetailsPage = ({
             isUpdating={isUpdatingHost}
           />
         )}
-        {showQueryHostModal && host && (
+        {showSelectQueryModal && host && (
           <SelectQueryModal
-            onCancel={() => setShowQueryHostModal(false)}
+            onCancel={() => setShowSelectQueryModal(false)}
             queries={fleetQueries || []}
             queryErrors={fleetQueriesError}
             isOnlyObserver={isOnlyObserver}

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/DiskEncryptionKeyModal/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/DiskEncryptionKeyModal/_styles.scss
@@ -1,3 +1,0 @@
-.disk-encryption-key-modal {
-  width: 500px;
-}

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/OSPolicyModal/OSPolicyModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/OSPolicyModal/OSPolicyModal.tsx
@@ -24,7 +24,7 @@ interface IRenderOSPolicyModal {
 
 const baseClass = "os-policy-modal";
 
-const RenderOSPolicyModal = ({
+const OSPolicyModal = ({
   onCancel,
   onCreateNewPolicy,
   osVersion,
@@ -106,4 +106,4 @@ const RenderOSPolicyModal = ({
   );
 };
 
-export default RenderOSPolicyModal;
+export default OSPolicyModal;

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/SelectQueryModal/SelectQueryModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/SelectQueryModal/SelectQueryModal.tsx
@@ -195,6 +195,7 @@ const SelectQueryModal = ({
       title="Select a query"
       onExit={onCancel}
       className={`${baseClass}__modal`}
+      width="xl"
     >
       {results()}
     </Modal>

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/SelectQueryModal/SelectQueryModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/SelectQueryModal/SelectQueryModal.tsx
@@ -195,7 +195,7 @@ const SelectQueryModal = ({
       title="Select a query"
       onExit={onCancel}
       className={`${baseClass}__modal`}
-      width="xl"
+      width="xlarge"
     >
       {results()}
     </Modal>

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
@@ -68,7 +68,7 @@ const UnenrollMdmModal = ({ hostId, onClose }: IUnenrollMdmModalProps) => {
       title="Turn off MDM"
       onExit={onClose}
       className={baseClass}
-      width="l"
+      width="large"
     >
       {renderModalContent()}
     </Modal>

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
@@ -64,7 +64,12 @@ const UnenrollMdmModal = ({ hostId, onClose }: IUnenrollMdmModalProps) => {
   };
 
   return (
-    <Modal title="Turn off MDM" onExit={onClose} className={baseClass}>
+    <Modal
+      title="Turn off MDM"
+      onExit={onClose}
+      className={baseClass}
+      width="l"
+    >
       {renderModalContent()}
     </Modal>
   );

--- a/frontend/pages/hosts/details/MacSettingsModal/MacSettingsModal.tsx
+++ b/frontend/pages/hosts/details/MacSettingsModal/MacSettingsModal.tsx
@@ -20,7 +20,7 @@ const MacSettingsModal = ({
       title="macOS settings"
       onExit={onClose}
       className={baseClass}
-      width="l"
+      width="large"
     >
       <>
         <MacSettingsTable hostMacSettings={hostMacSettings} />

--- a/frontend/pages/hosts/details/MacSettingsModal/MacSettingsModal.tsx
+++ b/frontend/pages/hosts/details/MacSettingsModal/MacSettingsModal.tsx
@@ -16,7 +16,12 @@ const MacSettingsModal = ({
   onClose,
 }: IMacSettingsModalProps) => {
   return (
-    <Modal title="macOS settings" onExit={onClose} className={baseClass}>
+    <Modal
+      title="macOS settings"
+      onExit={onClose}
+      className={baseClass}
+      width="l"
+    >
       <>
         <MacSettingsTable hostMacSettings={hostMacSettings} />
         <div className="modal-cta-wrap">

--- a/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
@@ -83,7 +83,12 @@ const AddPolicyModal = ({
   });
 
   return (
-    <Modal title="Add a policy" onExit={onCancel} className={baseClass}>
+    <Modal
+      title="Add a policy"
+      onExit={onCancel}
+      className={baseClass}
+      width="xl"
+    >
       <>
         <div className={`${baseClass}__create-policy`}>
           Choose a policy template to get started or{" "}

--- a/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
@@ -87,7 +87,7 @@ const AddPolicyModal = ({
       title="Add a policy"
       onExit={onCancel}
       className={baseClass}
-      width="xl"
+      width="xlarge"
     >
       <>
         <div className={`${baseClass}__create-policy`}>

--- a/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -342,7 +342,7 @@ const ManageAutomationsModal = ({
       onExit={onExit}
       title={"Manage automations"}
       className={baseClass}
-      width="l"
+      width="large"
     >
       <>
         <div className={`${baseClass}__software-select-items`}>

--- a/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -338,8 +338,13 @@ const ManageAutomationsModal = ({
   return showPreviewPayloadModal ? (
     renderPreview()
   ) : (
-    <Modal onExit={onExit} title={"Manage automations"} className={baseClass}>
-      <div className={baseClass}>
+    <Modal
+      onExit={onExit}
+      title={"Manage automations"}
+      className={baseClass}
+      width="l"
+    >
+      <>
         <div className={`${baseClass}__software-select-items`}>
           <Slider
             value={isPolicyAutomationsEnabled}
@@ -438,7 +443,7 @@ const ManageAutomationsModal = ({
             Cancel
           </Button>
         </div>
-      </div>
+      </>
     </Modal>
   );
 };

--- a/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/ManageAutomationsModal/_styles.scss
@@ -1,6 +1,4 @@
 .manage-automations-modal {
-  width: 778px;
-
   pre,
   code {
     background-color: $ui-off-white;

--- a/frontend/pages/policies/ManagePoliciesPage/components/PreviewTicketModal/PreviewTicketModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PreviewTicketModal/PreviewTicketModal.tsx
@@ -45,7 +45,7 @@ const PreviewTicketModal = ({
       title={"Example ticket"}
       onExit={onCancel}
       className={baseClass}
-      width="l"
+      width="large"
     >
       <div className={`${baseClass}`}>
         <p className="automations-learn-more">

--- a/frontend/pages/policies/ManagePoliciesPage/components/PreviewTicketModal/PreviewTicketModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PreviewTicketModal/PreviewTicketModal.tsx
@@ -41,9 +41,14 @@ const PreviewTicketModal = ({
     );
 
   return (
-    <Modal title={"Example ticket"} onExit={onCancel} className={baseClass}>
+    <Modal
+      title={"Example ticket"}
+      onExit={onCancel}
+      className={baseClass}
+      width="l"
+    >
       <div className={`${baseClass}`}>
-        <p>
+        <p className="automations-learn-more">
           Want to learn more about how automations in Fleet work?{" "}
           <CustomLink
             url="https://fleetdm.com/docs/using-fleet/automations"

--- a/frontend/pages/policies/PolicyPage/components/NewPolicyModal/index.ts
+++ b/frontend/pages/policies/PolicyPage/components/NewPolicyModal/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./NewPolicyModal";

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -28,7 +28,7 @@ import TooltipWrapper from "components/TooltipWrapper";
 import Spinner from "components/Spinner";
 import AutoSizeInputField from "components/forms/fields/AutoSizeInputField";
 import PremiumFeatureIconWithTooltip from "components/PremiumFeatureIconWithTooltip";
-import NewPolicyModal from "../NewPolicyModal";
+import SaveNewPolicyModal from "../SaveNewPolicyModal";
 import InfoIcon from "../../../../../../assets/images/icon-info-purple-14x14@2x.png";
 import PencilIcon from "../../../../../../assets/images/icon-pencil-14x14@2x.png";
 
@@ -82,7 +82,9 @@ const PolicyForm = ({
   backendValidators,
 }: IPolicyFormProps): JSX.Element => {
   const [errors, setErrors] = useState<{ [key: string]: any }>({}); // string | null | undefined or boolean | undefined
-  const [isNewPolicyModalOpen, setIsNewPolicyModalOpen] = useState(false);
+  const [isSaveNewPolicyModalOpen, setIsSaveNewPolicyModalOpen] = useState(
+    false
+  );
   const [showQueryEditor, setShowQueryEditor] = useState(false);
   const [isEditingName, setIsEditingName] = useState(false);
   const [isEditingDescription, setIsEditingDescription] = useState(false);
@@ -235,7 +237,7 @@ const PolicyForm = ({
     }
 
     if (!isEditMode) {
-      setIsNewPolicyModalOpen(true);
+      setIsSaveNewPolicyModalOpen(true);
     } else {
       const payload: IPolicyFormData = {
         name: lastEditedQueryName,
@@ -580,15 +582,14 @@ const PolicyForm = ({
           </ReactTooltip>
         </div>
       </form>
-      {isNewPolicyModalOpen && (
-        <NewPolicyModal
+      {isSaveNewPolicyModalOpen && (
+        <SaveNewPolicyModal
           baseClass={baseClass}
           queryValue={lastEditedQueryBody}
           onCreatePolicy={onCreatePolicy}
-          setIsNewPolicyModalOpen={setIsNewPolicyModalOpen}
+          setIsSaveNewPolicyModalOpen={setIsSaveNewPolicyModalOpen}
           backendValidators={backendValidators}
           platformSelector={platformSelector}
-          lastEditedQueryPlatform={lastEditedQueryPlatform}
           isUpdatingPolicy={isUpdatingPolicy}
         />
       )}

--- a/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
+++ b/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
@@ -15,17 +15,15 @@ import TooltipWrapper from "components/TooltipWrapper";
 import Button from "components/buttons/Button";
 import Modal from "components/Modal";
 import ReactTooltip from "react-tooltip";
-import { platform } from "process";
 import PremiumFeatureIconWithTooltip from "components/PremiumFeatureIconWithTooltip";
 
-export interface INewPolicyModalProps {
+export interface ISaveNewPolicyModalProps {
   baseClass: string;
   queryValue: string;
   onCreatePolicy: (formData: IPolicyFormData) => void;
-  setIsNewPolicyModalOpen: (isOpen: boolean) => void;
+  setIsSaveNewPolicyModalOpen: (isOpen: boolean) => void;
   backendValidators: { [key: string]: string };
   platformSelector: IPlatformSelector;
-  lastEditedQueryPlatform: IPlatformString | null;
   isUpdatingPolicy: boolean;
 }
 
@@ -40,23 +38,21 @@ const validatePolicyName = (name: string) => {
   return { valid, errors };
 };
 
-const NewPolicyModal = ({
+const SaveNewPolicyModal = ({
   baseClass,
   queryValue,
   onCreatePolicy,
-  setIsNewPolicyModalOpen,
+  setIsSaveNewPolicyModalOpen,
   backendValidators,
   platformSelector,
-  lastEditedQueryPlatform,
   isUpdatingPolicy,
-}: INewPolicyModalProps): JSX.Element => {
+}: ISaveNewPolicyModalProps): JSX.Element => {
   const { isPremiumTier, isSandboxMode } = useContext(AppContext);
   const {
     lastEditedQueryName,
     lastEditedQueryDescription,
     lastEditedQueryResolution,
     lastEditedQueryCritical,
-    defaultPolicy,
     setLastEditedQueryPlatform,
   } = useContext(PolicyContext);
 
@@ -107,7 +103,10 @@ const NewPolicyModal = ({
   };
 
   return (
-    <Modal title={"Save policy"} onExit={() => setIsNewPolicyModalOpen(false)}>
+    <Modal
+      title={"Save policy"}
+      onExit={() => setIsSaveNewPolicyModalOpen(false)}
+    >
       <>
         <form
           onSubmit={handleSavePolicy}
@@ -195,7 +194,7 @@ const NewPolicyModal = ({
             </span>
             <Button
               className={`${baseClass}__button--modal-cancel`}
-              onClick={() => setIsNewPolicyModalOpen(false)}
+              onClick={() => setIsSaveNewPolicyModalOpen(false)}
               variant="inverse"
             >
               Cancel
@@ -207,4 +206,4 @@ const NewPolicyModal = ({
   );
 };
 
-export default NewPolicyModal;
+export default SaveNewPolicyModal;

--- a/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/index.ts
+++ b/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SaveNewPolicyModal";

--- a/frontend/pages/queries/QueryPage/components/QueryForm/_styles.scss
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/_styles.scss
@@ -162,6 +162,11 @@
       margin: 0;
       margin-top: $pad-small;
     }
+
+    .fleet-checkbox {
+      display: flex;
+      align-items: center;
+    }
   }
 
   &__button-wrap {

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
@@ -230,7 +230,7 @@ const ScheduleEditorModal = ({
       onExit={onClose}
       onEnter={onFormSubmit}
       className={baseClass}
-      width="l"
+      width="large"
     >
       <form className={`${baseClass}__form`}>
         {!editQuery && (

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
@@ -230,6 +230,7 @@ const ScheduleEditorModal = ({
       onExit={onClose}
       onEnter={onFormSubmit}
       className={baseClass}
+      width="l"
     >
       <form className={`${baseClass}__form`}>
         {!editQuery && (

--- a/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -436,7 +436,7 @@ const ManageAutomationsModal = ({
       onExit={onReturnToApp}
       title={"Manage automations"}
       className={baseClass}
-      width="l"
+      width="large"
     >
       <>
         <div className={`${baseClass}__software-select-items`}>

--- a/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -436,8 +436,9 @@ const ManageAutomationsModal = ({
       onExit={onReturnToApp}
       title={"Manage automations"}
       className={baseClass}
+      width="l"
     >
-      <div className={baseClass}>
+      <>
         <div className={`${baseClass}__software-select-items`}>
           <Slider
             value={softwareAutomationsEnabled}
@@ -525,7 +526,7 @@ const ManageAutomationsModal = ({
             Cancel
           </Button>
         </div>
-      </div>
+      </>
     </Modal>
   );
 };

--- a/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/components/ManageAutomationsModal/_styles.scss
@@ -1,6 +1,4 @@
 .manage-automations-modal {
-  width: 778px;
-
   pre,
   code {
     background-color: $ui-off-white;

--- a/frontend/pages/software/ManageSoftwarePage/components/PreviewTicketModal/PreviewTicketModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/PreviewTicketModal/PreviewTicketModal.tsx
@@ -44,7 +44,7 @@ const PreviewTicketModal = ({
       onExit={onCancel}
       onEnter={onCancel}
       className={baseClass}
-      width="l"
+      width="large"
     >
       <>
         <p className="automations-learn-more">

--- a/frontend/pages/software/ManageSoftwarePage/components/PreviewTicketModal/PreviewTicketModal.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/components/PreviewTicketModal/PreviewTicketModal.tsx
@@ -44,9 +44,10 @@ const PreviewTicketModal = ({
       onExit={onCancel}
       onEnter={onCancel}
       className={baseClass}
+      width="l"
     >
       <>
-        <p>
+        <p className="automations-learn-more">
           Want to learn more about how automations in Fleet work?{" "}
           <CustomLink
             url="https://fleetdm.com/docs/using-fleet/automations"

--- a/frontend/pages/software/ManageSoftwarePage/components/PreviewTicketModal/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/components/PreviewTicketModal/_styles.scss
@@ -12,4 +12,8 @@
     border-radius: 8px;
     filter: drop-shadow(0px 4px 16px rgba(0, 0, 0, 0.1));
   }
+
+  .automations-learn-more {
+    text-align: center;
+  }
 }


### PR DESCRIPTION
## Addresses #11356

[Before –> After](https://www.loom.com/share/759c39f8687745f883dd9989962c9f1b)

Images of 3 fixed modals referenced in the issue:
<img width="1235" alt="Screenshot 2023-05-12 at 4 11 52 PM" src="https://github.com/fleetdm/fleet/assets/61553566/098081c7-15d4-4009-92a0-7a2e14ffaab1">
<img width="1235" alt="Screenshot 2023-05-12 at 4 12 50 PM" src="https://github.com/fleetdm/fleet/assets/61553566/7d0f268d-f2dc-4686-a64d-94e28a94c717">
<img width="1235" alt="Screenshot 2023-05-12 at 4 13 26 PM" src="https://github.com/fleetdm/fleet/assets/61553566/d486b005-1344-4656-adec-c4929332816b">

## Implemented:
- [x] Updated global modal styles for consistency
- [x] Add optional "width" prop to `Modal`
- [x] Misc cleanup:
  - [x]  Restore missing padding from inverse-alert buttons
  - [x]  Improve naming, lots of cleanup
  - [x] More coming in separate PR
- [x]  Check each of the following modals, define `width` where necessary:
  - [x]  Add hosts
  - [x]  EnrollSecret
    - [x] Also fix misaligned icons  
  - [x]  SecretEditor
  - [x]  DeleteSecret
  - [x]  ShowQuery
  - [x]  AddIntegration
  - [x]  DeleteIntegration
  - [x]  EditIntegration
  - [x]  EditTeam
  - [x]  RequestCSR
  - [x]  HostStatusWebhook
  - [x]  CreateTeam
  - [x]  DeleteTeam
  - [x]  EditTeam
  - [x]  AddMember
  - [x]  RemoveMember
  - [x]  CreateUser
  - [x]  DeleteUser
  - [x]  EditUser
    - [x] Also fix randomly shorter 'Password' field  
  - [x]  ResetPassword
  - [x]  ResetSessions
  - [x]  WelcomeHost
  - [x]  DeletHost
  - [x]  TransferHost
  - [x]  POlicyDetails
  - [x]  AutoEnrollMdm
  - [x]  Info
  - [x]  ManualEnrollMdm
  - [x]  ResetKey
  - [x]  BootstrapPackage
  - [x]  DiskEncryption
  - [x]  OSPOlicy
  - [x]  SelectQuery
  - [x]  UnenrollMdm
  - [x]  MacSettings
  - [x]  DeleteLabel
  - [x]  EditCOlumns
  -  WIP, cannot QA yet (cc @ghernandez345):
      - DeleteScript
      - RerunScript
  - [x]  DeleteProfile
  - [x]  DeletePackage - allow to conform to default "m" width, 650px
  - [x]  PackQueryEditor - allow to conform to default "m" width
  - [x]  RemovePackQuery - allow to conform to default "m" width
  - [x]  DeletePack - allow to conform to default "m" width
  - [x]  AddPolicy 
  - [x]  DeletePolicy - allow to conform to default "m" width
  - [x]  NewPolicy (now "SaveNewPolicyModal") - allow to conform to default "m" width
  - [x]  DeleteQuery
  - [x]  NewQuery - allow to conform to default "m" width
  - [x]  PreviewData
  - [x]  RemoveScheduledQuery
  - [x]  ScheduleEditor
  - [x]  UserSettingsPage (aka "get API token")
  - [x]  2 x ManageAutomations –  set to large
  - [x]  2 x PreviewPayload - allow to conform to default "m" width 
  - [x]  2 x PreviewTicket - same as ManageAutomations

## Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/` 
- [x] Manual QA for all new/changed functionality