### PR TITLE
Use `hostIDs` in team deletion when setting status to pending

### DIFF
--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -409,6 +409,7 @@ func (svc *Service) DeleteTeam(ctx context.Context, teamID uint) error {
 	if !ok {
 		return fleet.ErrNoContext
 	}
+
 	filter := fleet.TeamFilter{User: vc.User, IncludeObserver: true}
 	hosts, err := svc.ds.ListHosts(ctx, filter, fleet.HostListOptions{TeamFilter: &teamID})
 	if err != nil {
@@ -426,24 +427,26 @@ func (svc *Service) DeleteTeam(ctx context.Context, teamID uint) error {
 	if err := svc.ds.DeleteTeam(ctx, teamID); err != nil {
 		return err
 	}
-	// team id 0 is provided since the team's hosts are now part of no team
-	if err := svc.ds.BulkSetPendingMDMAppleHostProfiles(ctx, nil, []uint{0}, nil, nil); err != nil {
-		return ctxerr.Wrap(ctx, err, "bulk set pending host profiles")
-	}
 
-	if err := svc.ds.CleanupDiskEncryptionKeysOnTeamChange(ctx, hostIDs, ptr.Uint(0)); err != nil {
-		return ctxerr.Wrap(ctx, err, "reconcile profiles on team change cleanup disk encryption keys")
-	}
+	if len(hostIDs) > 0 {
+		if err := svc.ds.BulkSetPendingMDMAppleHostProfiles(ctx, hostIDs, nil, nil, nil); err != nil {
+			return ctxerr.Wrap(ctx, err, "bulk set pending host profiles")
+		}
 
-	if len(mdmHostSerials) > 0 {
-		if err := worker.QueueMacosSetupAssistantJob(
-			ctx,
-			svc.ds,
-			svc.logger,
-			worker.MacosSetupAssistantTeamDeleted,
-			nil,
-			mdmHostSerials...); err != nil {
-			return ctxerr.Wrap(ctx, err, "queue macos setup assistant team deleted job")
+		if err := svc.ds.CleanupDiskEncryptionKeysOnTeamChange(ctx, hostIDs, ptr.Uint(0)); err != nil {
+			return ctxerr.Wrap(ctx, err, "reconcile profiles on team change cleanup disk encryption keys")
+		}
+
+		if len(mdmHostSerials) > 0 {
+			if err := worker.QueueMacosSetupAssistantJob(
+				ctx,
+				svc.ds,
+				svc.logger,
+				worker.MacosSetupAssistantTeamDeleted,
+				nil,
+				mdmHostSerials...); err != nil {
+				return ctxerr.Wrap(ctx, err, "queue macos setup assistant team deleted job")
+			}
 		}
 	}
 


### PR DESCRIPTION
Found this while working on #11531.

Team deletion for an empty team is taking ~30 seconds with 2632 hosts that belong to no team.
This change attempts to fix that issue.

- ~[ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.~
- ~[ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~[ ] Documented any permissions changes~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - ~For Orbit and Fleet Desktop changes:~
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
