### PR TITLE
Fleet UI: Sort (and bookmark) Manage Policies tables by failing host count

### DIFF
--- a/changes/issue-7166-order-policies-by-failing-count
+++ b/changes/issue-7166-order-policies-by-failing-count
@@ -1,0 +1,1 @@
+- Can reorder (and bookmark) policy tables by failing count

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -21,6 +21,7 @@ export interface ITableQueryData {
   sortHeader: string;
   sortDirection: string;
   showInheritedTable?: boolean; // Only used for policies tables
+  inheritedTable?: boolean; // Only used for policies tables
 }
 interface IRowProps extends Row {
   original: {

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -20,8 +20,10 @@ export interface ITableQueryData {
   searchQuery: string;
   sortHeader: string;
   sortDirection: string;
-  showInheritedTable?: boolean; // Only used for policies tables
-  inheritedTable?: boolean; // Only used for policies tables
+  /**  Only used for showing inherited policies table */
+  showInheritedTable?: boolean;
+  /** Only used for sort/query changes to inherited policies table */
+  editingInheritedTable?: boolean;
 }
 interface IRowProps extends Row {
   original: {

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -30,7 +30,6 @@ const rebuildQueryStringWithTeamId = (
   newTeamId: number
 ) => {
   const parts = splitQueryStringParts(queryString);
-  console.log("\n\nSTART parts", parts);
 
   // Reset page to 0
   const pageIndex = parts.findIndex((p) => p.startsWith("page="));
@@ -47,8 +46,6 @@ const rebuildQueryStringWithTeamId = (
   if (inheritedPageIndex) {
     parts.splice(inheritedPageIndex, 1, newInheritedPagePart);
   }
-
-  console.log("END parts", parts);
 
   const teamIndex = parts.findIndex((p) => p.startsWith("team_id="));
 

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -30,6 +30,26 @@ const rebuildQueryStringWithTeamId = (
   newTeamId: number
 ) => {
   const parts = splitQueryStringParts(queryString);
+  console.log("\n\nSTART parts", parts);
+
+  // Reset page to 0
+  const pageIndex = parts.findIndex((p) => p.startsWith("page="));
+  const inheritedPageIndex = parts.findIndex((p) =>
+    p.startsWith("inherited_page=")
+  );
+
+  const newPagePart = "page=0";
+  const newInheritedPagePart = "inherited_page=0";
+
+  if (pageIndex) {
+    parts.splice(pageIndex, 1, newPagePart);
+  }
+  if (inheritedPageIndex) {
+    parts.splice(inheritedPageIndex, 1, newInheritedPagePart);
+  }
+
+  console.log("END parts", parts);
+
   const teamIndex = parts.findIndex((p) => p.startsWith("team_id="));
 
   // URLs for the app represent "All teams" by the absence of the team id param
@@ -54,6 +74,7 @@ const rebuildQueryStringWithTeamId = (
   } else {
     parts.splice(teamIndex, 1); // just remove the old team part
   }
+
   return joinQueryStringParts(parts);
 };
 

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -146,22 +146,14 @@ const ManagePolicyPage = ({
       ? parseInt(queryParams?.inherited_page, 10)
       : 0)();
 
-  // Never set as state as URL is source of truth
-  // State only used for handling team change
-  const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
-  const [page, setPage] = useState(initialPage);
-  const [sortDirection, setSortDirection] = useState(initialSortDirection);
-  const [sortHeader, setSortHeader] = useState(initialSortHeader);
-  const [showInheritedTable, setShowInheritedTable] = useState(
-    initialShowInheritedTable
-  );
-  const [inheritedSortDirection, setInheritedSortDirection] = useState(
-    initialSortDirection
-  );
-  const [inheritedSortHeader, setInheritedSortHeader] = useState(
-    initialSortHeader
-  );
-  const [inheritedPage, setInheritedPage] = useState(initialInheritedPage);
+  const page = initialPage;
+  const sortDirection = initialSortDirection;
+  const sortHeader = initialSortHeader;
+  const showInheritedTable = initialShowInheritedTable;
+  const inheritedSortDirection = initialInheritedSortDirection;
+  const inheritedSortHeader = initialInheritedSortHeader;
+  const inheritedPage = initialInheritedPage;
+  const searchQuery = initialSearchQuery;
 
   useEffect(() => {
     setLastEditedQueryPlatform(null);
@@ -173,18 +165,6 @@ const ManagePolicyPage = ({
       setFilteredPoliciesPath(path);
     }
   }, [location, filteredPoliciesPath, setFilteredPoliciesPath]);
-
-  useEffect(() => {
-    setShowInheritedTable(initialShowInheritedTable);
-    setPage(initialPage);
-    setSearchQuery(initialSearchQuery);
-    setSortDirection(initialSortDirection);
-    setSortHeader(initialSortHeader);
-    setInheritedSortDirection(initialInheritedSortDirection);
-    setInheritedSortHeader(initialInheritedSortHeader);
-    setInheritedPage(initialInheritedPage);
-    // TODO: handle invalid values for params
-  }, [location]);
 
   const {
     data: globalPolicies,
@@ -269,8 +249,6 @@ const ManagePolicyPage = ({
     (teamId: number) => {
       setSelectedPolicyIds([]);
       handleTeamChange(teamId);
-      setPage(0);
-      setSearchQuery("");
     },
     [handleTeamChange]
   );
@@ -341,7 +319,6 @@ const ManagePolicyPage = ({
         newQueryParams.team_id = teamIdForApi;
       }
 
-      console.log("onQueryChange newQueryParams", newQueryParams);
       const locationPath = getNextLocationPath({
         pathPrefix: PATHS.MANAGE_POLICIES,
         queryParams: newQueryParams,
@@ -360,12 +337,17 @@ const ManagePolicyPage = ({
           ...queryParams,
           page: pageIndex,
           query: searchQuery,
+          order_direction: sortDirection,
+          order_key: sortHeader,
+          inherited_order_direction: inheritedSortDirection,
+          inherited_order_key: inheritedSortHeader,
+          inherited_page: inheritedPage,
         },
       });
 
       router?.replace(locationPath);
     },
-    [searchQuery, queryParams] // Dependencies required for correct variable state
+    [searchQuery, queryParams, sortHeader, sortDirection] // Dependencies required for correct variable state
   );
 
   const onClientSideInheritedPaginationChange = useCallback(
@@ -377,11 +359,16 @@ const ManagePolicyPage = ({
           inherited_table: "true",
           inherited_page: pageIndex,
           query: searchQuery,
+          page,
+          order_direction: sortDirection,
+          order_key: sortHeader,
+          inherited_order_direction: inheritedSortDirection,
+          inherited_order_key: inheritedSortHeader,
         },
       });
       router?.replace(locationPath);
     },
-    [queryParams] // Dependencies required for correct variable state
+    [queryParams, inheritedSortHeader, inheritedSortDirection] // Dependencies required for correct variable state
   );
 
   const toggleManageAutomationsModal = () =>

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -327,12 +327,13 @@ const ManagePolicyPage = ({
         newQueryParams.order_key = sortHeader;
         newQueryParams.order_direction = sortDirection;
         newQueryParams.page = page;
+        newQueryParams.query = searchQuery;
         // Reset page number to 0 for new filters
         if (
           newSortDirection !== inheritedSortDirection ||
           newSortHeader !== inheritedSortHeader
         ) {
-          newQueryParams.page = 0;
+          newQueryParams.inherited_page = 0;
         }
       }
 
@@ -340,6 +341,7 @@ const ManagePolicyPage = ({
         newQueryParams.team_id = teamIdForApi;
       }
 
+      console.log("onQueryChange newQueryParams", newQueryParams);
       const locationPath = getNextLocationPath({
         pathPrefix: PATHS.MANAGE_POLICIES,
         queryParams: newQueryParams,
@@ -347,18 +349,7 @@ const ManagePolicyPage = ({
 
       router?.replace(locationPath);
     },
-    [
-      sortHeader,
-      sortDirection,
-      page,
-      teamIdForApi,
-      searchQuery,
-      showInheritedTable,
-      inheritedSortHeader,
-      inheritedSortDirection,
-      inheritedPage,
-      router,
-    ]
+    [teamIdForApi, searchQuery, showInheritedTable] // Other dependencies can cause infinite re-renders as URL is source of truth
   );
 
   const onClientSidePaginationChange = useCallback(
@@ -374,7 +365,7 @@ const ManagePolicyPage = ({
 
       router?.replace(locationPath);
     },
-    [searchQuery] // Dependencies required for correct variable state
+    [searchQuery, queryParams] // Dependencies required for correct variable state
   );
 
   const onClientSideInheritedPaginationChange = useCallback(
@@ -390,7 +381,7 @@ const ManagePolicyPage = ({
       });
       router?.replace(locationPath);
     },
-    [] // Dependencies required for correct variable state
+    [queryParams] // Dependencies required for correct variable state
   );
 
   const toggleManageAutomationsModal = () =>

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import { noop } from "lodash";
 
 import createMockPolicy from "__mocks__/policyMock";
 import PoliciesTable from "./PoliciesTable";
@@ -19,6 +20,7 @@ describe("Policies table", () => {
         isSandboxMode
         searchQuery=""
         page={0}
+        onQueryChange={noop}
       />
     );
 
@@ -44,6 +46,7 @@ describe("Policies table", () => {
         isSandboxMode={false}
         searchQuery=""
         page={0}
+        onQueryChange={noop}
       />
     );
 

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -129,8 +129,6 @@ const PoliciesTable = ({
 
   const searchable = !(policiesList?.length === 0 && searchQuery === "");
 
-  console.log("PoliciesTable.tsx, sortHeader", sortHeader);
-  console.log("PoilciesTable.tsx, sortDirection", sortDirection);
   return (
     <div
       className={`${baseClass} ${

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -21,20 +21,25 @@ const TAGGED_TEMPLATES = {
   },
 };
 
+const DEFAULT_SORT_DIRECTION = "asc";
+const DEFAULT_SORT_HEADER = "updated_at";
+
 interface IPoliciesTableProps {
   policiesList: IPolicyStats[];
   isLoading: boolean;
   onAddPolicyClick?: () => void;
   onDeletePolicyClick: (selectedTableIds: number[]) => void;
   canAddOrDeletePolicy?: boolean;
-  tableType?: string;
+  tableType?: "inheritedPolicies";
   currentTeam: ITeamSummary | undefined;
   currentAutomatedPolicies?: number[];
   isPremiumTier?: boolean;
   isSandboxMode?: boolean;
   onClientSidePaginationChange?: (pageIndex: number) => void;
-  onQueryChange?: (newTableQuery: ITableQueryData) => void;
+  onQueryChange: (newTableQuery: ITableQueryData) => void;
   searchQuery: string;
+  sortHeader?: "name" | "failing_host_count";
+  sortDirection?: "asc" | "desc";
   page: number;
 }
 
@@ -52,9 +57,19 @@ const PoliciesTable = ({
   onQueryChange,
   onClientSidePaginationChange,
   searchQuery,
+  sortHeader,
+  sortDirection,
   page,
 }: IPoliciesTableProps): JSX.Element => {
   const { config } = useContext(AppContext);
+
+  // Inherited table uses the same onQueryChange but require different URL params
+  const onTableQueryChange = (newTableQuery: ITableQueryData) => {
+    onQueryChange({
+      ...newTableQuery,
+      inheritedTable: tableType === "inheritedPolicies",
+    });
+  };
 
   const emptyState = () => {
     const emptyPolicies: IEmptyTableProps = {
@@ -114,6 +129,8 @@ const PoliciesTable = ({
 
   const searchable = !(policiesList?.length === 0 && searchQuery === "");
 
+  console.log("PoliciesTable.tsx, sortHeader", sortHeader);
+  console.log("PoilciesTable.tsx, sortDirection", sortDirection);
   return (
     <div
       className={`${baseClass} ${
@@ -124,7 +141,7 @@ const PoliciesTable = ({
         <Spinner />
       ) : (
         <TableContainer
-          resultsTitle={"policies"}
+          resultsTitle="policies"
           columns={generateTableHeaders(
             {
               selectedTeamId: currentTeam?.id,
@@ -141,11 +158,10 @@ const PoliciesTable = ({
           )}
           filters={{ global: searchQuery }}
           isLoading={isLoading}
-          defaultSortHeader={"name"}
-          defaultSortDirection={"asc"}
+          defaultSortHeader={sortHeader || DEFAULT_SORT_HEADER}
+          defaultSortDirection={sortDirection || DEFAULT_SORT_DIRECTION}
           defaultSearchQuery={searchQuery}
           defaultPageIndex={page}
-          manualSortBy
           showMarkAllPages={false}
           isAllPagesSelected={false}
           primarySelectAction={{
@@ -169,7 +185,7 @@ const PoliciesTable = ({
           onClientSidePaginationChange={onClientSidePaginationChange}
           isClientSideFilter
           searchQueryColumn="name"
-          onQueryChange={onQueryChange}
+          onQueryChange={onTableQueryChange}
           inputPlaceHolder="Search by name"
           searchable={searchable}
         />

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -67,7 +67,7 @@ const PoliciesTable = ({
   const onTableQueryChange = (newTableQuery: ITableQueryData) => {
     onQueryChange({
       ...newTableQuery,
-      inheritedTable: tableType === "inheritedPolicies",
+      editingInheritedTable: tableType === "inheritedPolicies",
     });
   };
 

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -6,6 +6,7 @@ import { millisecondsToHours, millisecondsToMinutes, isAfter } from "date-fns";
 import ReactTooltip from "react-tooltip";
 // @ts-ignore
 import Checkbox from "components/forms/fields/Checkbox";
+import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 import LinkCell from "components/TableContainer/DataTable/LinkCell/LinkCell";
 import StatusIndicator from "components/StatusIndicator";
 import Icon from "components/Icon";
@@ -106,8 +107,12 @@ const generateTableHeaders = (
   const tableHeaders: IDataColumn[] = [
     {
       title: "Name",
-      Header: "Name",
-      disableSortBy: true,
+      Header: (cellProps) => (
+        <HeaderCell
+          value={cellProps.column.title}
+          isSortedDesc={cellProps.column.isSortedDesc}
+        />
+      ),
       accessor: "name",
       Cell: (cellProps: ICellProps): JSX.Element => (
         <LinkCell
@@ -150,6 +155,7 @@ const generateTableHeaders = (
           path={PATHS.EDIT_POLICY(cellProps.row.original)}
         />
       ),
+      sortType: "caseInsensitive",
     },
     {
       title: "Yes",
@@ -195,8 +201,12 @@ const generateTableHeaders = (
     },
     {
       title: "No",
-      Header: () => <PassingColumnHeader isPassing={false} />,
-      disableSortBy: true,
+      Header: (cellProps) => (
+        <HeaderCell
+          value={<PassingColumnHeader isPassing={false} />}
+          isSortedDesc={cellProps.column.isSortedDesc}
+        />
+      ),
       accessor: "failing_host_count",
       Cell: (cellProps: ICellProps): JSX.Element => {
         if (cellProps.row.original.has_run) {
@@ -234,6 +244,7 @@ const generateTableHeaders = (
           </>
         );
       },
+      sortType: "caseInsensitive",
     },
   ];
 


### PR DESCRIPTION
## Issue
Cerra #7166 

## Description
- Add sortability to `name` and `failing_host_count` columns on manage policies page's main table and inherited table that shows up on team view
- Add bookmarkability to the sort for both the main table and inherited table that shows up on team view
- Fix unrelated bug where switching teams should reset the page to 0 on any table!

## Screenrecording
- NEW! Table states are being saved for both tables when clicking into a host count list and when clicking into a policy's details
- NEW! Sortability of failing policies and policies by name
- NEW! All of this is added to the URL params

https://github.com/fleetdm/fleet/assets/71795832/3709f1f5-4fc9-47a6-8d9e-708b255574ca




# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

