### PR TITLE
Website: update earliest supported browser versions

### DIFF
--- a/website/views/layouts/layout-customer.ejs
+++ b/website/views/layouts/layout-customer.ejs
@@ -291,16 +291,15 @@
         //    - https://github.com/lancedikson/bowser/tree/1fb99ced0e8834fd9662604bad7e0f0c3eba2786#rendering-engine-flags
         // --------------------------------------------------------------------
         var LATEST_SUPPORTED_VERSION_BY_OS = {
-          iOS: '11',//« earliest version to eliminate rare bug where `window.location` doesn't exist momentarily after doing a server-side redirect
-          Android: '6'
+          iOS: '11',//« earliest version that suppports the hubspot chatbot.
+          Android: '7' // « earliest version we can test for compatibility issues with on browserstack
         };
         var LATEST_SUPPORTED_VERSION_BY_USER_AGENT = {
-          msedge: '16',
-          // msie: '11',
-          safari: '11',//« earliest version to eliminate rare bug where `window.location` doesn't exist momentarily after doing a server-side redirect
-          firefox: '54',//« earliest version to support both ES6 (for Vue.js) and unprefixed flexbox (for Bootstrap 4)
-          chrome: '51',//« earliest version to support both ES6 (for Vue.js) and unprefixed flexbox (for Bootstrap 4)
-          opera: '38',//« earliest version to support both ES6 (for Vue.js) and unprefixed flexbox (for Bootstrap 4)
+          msedge: '17',//« earliest version to support the backdrop filter css property.
+          safari: '11',//« earliest version that suppports the hubspot chatbot.
+          firefox: '102',//« earliest version to support the backdrop filter css property.
+          chrome: '76',//« earliest version to support the backdrop filter css property.
+          opera: '64',//« earliest version to support the backdrop filter css property.
         };
         var LATEST_SUPPORTED_VERSION_BY_BROWSER_NAME = {
           'microsoft edge': LATEST_SUPPORTED_VERSION_BY_USER_AGENT.msedge,

--- a/website/views/layouts/layout-landing.ejs
+++ b/website/views/layouts/layout-landing.ejs
@@ -291,16 +291,15 @@
         //    - https://github.com/lancedikson/bowser/tree/1fb99ced0e8834fd9662604bad7e0f0c3eba2786#rendering-engine-flags
         // --------------------------------------------------------------------
         var LATEST_SUPPORTED_VERSION_BY_OS = {
-          iOS: '11',//« earliest version to eliminate rare bug where `window.location` doesn't exist momentarily after doing a server-side redirect
-          Android: '6'
+          iOS: '11',//« earliest version that suppports the hubspot chatbot.
+          Android: '7' // « earliest version we can test for compatibility issues with on browserstack
         };
         var LATEST_SUPPORTED_VERSION_BY_USER_AGENT = {
-          msedge: '16',
-          // msie: '11',
-          safari: '11',//« earliest version to eliminate rare bug where `window.location` doesn't exist momentarily after doing a server-side redirect
-          firefox: '54',//« earliest version to support both ES6 (for Vue.js) and unprefixed flexbox (for Bootstrap 4)
-          chrome: '51',//« earliest version to support both ES6 (for Vue.js) and unprefixed flexbox (for Bootstrap 4)
-          opera: '38',//« earliest version to support both ES6 (for Vue.js) and unprefixed flexbox (for Bootstrap 4)
+          msedge: '17',//« earliest version to support the backdrop filter css property.
+          safari: '11',//« earliest version that suppports the hubspot chatbot.
+          firefox: '102',//« earliest version to support the backdrop filter css property.
+          chrome: '76',//« earliest version to support the backdrop filter css property.
+          opera: '64',//« earliest version to support the backdrop filter css property.
         };
         var LATEST_SUPPORTED_VERSION_BY_BROWSER_NAME = {
           'microsoft edge': LATEST_SUPPORTED_VERSION_BY_USER_AGENT.msedge,

--- a/website/views/layouts/layout-sandbox.ejs
+++ b/website/views/layouts/layout-sandbox.ejs
@@ -418,16 +418,15 @@
         //    - https://github.com/lancedikson/bowser/tree/1fb99ced0e8834fd9662604bad7e0f0c3eba2786#rendering-engine-flags
         // --------------------------------------------------------------------
         var LATEST_SUPPORTED_VERSION_BY_OS = {
-          iOS: '11',//« earliest version to eliminate rare bug where `window.location` doesn't exist momentarily after doing a server-side redirect
-          Android: '6'
+          iOS: '11',//« earliest version that suppports the hubspot chatbot.
+          Android: '7' // « earliest version we can test for compatibility issues with on browserstack
         };
         var LATEST_SUPPORTED_VERSION_BY_USER_AGENT = {
-          msedge: '16',
-          // msie: '11',
-          safari: '11',//« earliest version to eliminate rare bug where `window.location` doesn't exist momentarily after doing a server-side redirect
-          firefox: '54',//« earliest version to support both ES6 (for Vue.js) and unprefixed flexbox (for Bootstrap 4)
-          chrome: '51',//« earliest version to support both ES6 (for Vue.js) and unprefixed flexbox (for Bootstrap 4)
-          opera: '38',//« earliest version to support both ES6 (for Vue.js) and unprefixed flexbox (for Bootstrap 4)
+          msedge: '17',//« earliest version to support the backdrop filter css property.
+          safari: '11',//« earliest version that suppports the hubspot chatbot.
+          firefox: '102',//« earliest version to support the backdrop filter css property.
+          chrome: '76',//« earliest version to support the backdrop filter css property.
+          opera: '64',//« earliest version to support the backdrop filter css property.
         };
         var LATEST_SUPPORTED_VERSION_BY_BROWSER_NAME = {
           'microsoft edge': LATEST_SUPPORTED_VERSION_BY_USER_AGENT.msedge,

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -491,20 +491,18 @@
         //    - https://github.com/lancedikson/bowser/tree/1fb99ced0e8834fd9662604bad7e0f0c3eba2786#rendering-engine-flags
         // --------------------------------------------------------------------
         var LATEST_SUPPORTED_VERSION_BY_OS = {
-          iOS: '11',//« earliest version to eliminate rare bug where `window.location` doesn't exist momentarily after doing a server-side redirect
-          Android: '6'
+          iOS: '11',//« earliest version that suppports the hubspot chatbot.
+          Android: '7' // « earliest version we can test for compatibility issues with on browserstack
         };
         var LATEST_SUPPORTED_VERSION_BY_USER_AGENT = {
-          msedge: '17',
-          // msie: '11',
-          safari: '11',//« earliest version to eliminate rare bug where `window.location` doesn't exist momentarily after doing a server-side redirect
-          firefox: '54',//« earliest version to support both ES6 (for Vue.js) and unprefixed flexbox (for Bootstrap 4)
-          chrome: '55',//« earliest version to support both ES6 (for Vue.js), unprefixed flexbox (for Bootstrap 4), and async functions
-          opera: '42',//« earliest version to support both ES6 (for Vue.js), unprefixed flexbox (for Bootstrap 4), and async functions
+          msedge: '17',//« earliest version to support the backdrop filter css property.
+          safari: '11',//« earliest version that suppports the hubspot chatbot.
+          firefox: '102',//« earliest version to support the backdrop filter css property.
+          chrome: '76',//« earliest version to support the backdrop filter css property.
+          opera: '64',//« earliest version to support the backdrop filter css property.
         };
         var LATEST_SUPPORTED_VERSION_BY_BROWSER_NAME = {
           'microsoft edge': LATEST_SUPPORTED_VERSION_BY_USER_AGENT.msedge,
-          // 'internet explorer': LATEST_SUPPORTED_VERSION_BY_USER_AGENT.msie,
           'safari': LATEST_SUPPORTED_VERSION_BY_USER_AGENT.safari,
           'firefox': LATEST_SUPPORTED_VERSION_BY_USER_AGENT.firefox,
           'chrome': LATEST_SUPPORTED_VERSION_BY_USER_AGENT.chrome,


### PR DESCRIPTION
Closes #11682
Closes #11685
Changes:
- Updated the Fleet website's earliest supported browser versions:
   - Android 6 » 7 - Updated because we can no longer test android 6 devices on BrowserStack.
   - firefox v54 » v102: updated to support all of the CSS properties the Fleet website uses (global usage of v54 - v101: 0.3%)
   - Chrome v55 » v76: updated to support all of the CSS properties the Fleet website uses (global usage of v55 - v75: 0.46%)
   - Opera v38 » v64: updated to support all of the CSS properties the Fleet website uses (global usage of v38 - v63: 0.16%)