### PR TITLE
Add inheritedTable property to inheritedTable type

### DIFF
--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -20,6 +20,7 @@ export interface ITableQueryData {
   searchQuery: string;
   sortHeader: string;
   sortDirection: string;
+  inheritedTable?: boolean; // Only used for policies tables
   /**  Only used for showing inherited policies table */
   showInheritedTable?: boolean;
   /** Only used for sort/query changes to inherited policies table */


### PR DESCRIPTION
A [line in the original PR](https://github.com/fleetdm/fleet/pull/11735#discussion_r1197102521) was removed, which caused the build to fail on the `make-generate` step. This adds the line back in. It fixes the build, but @RachelElysia please confirm this is correct tomorrow. I'm going to go ahead and merge so we can get a build for dogfood. 