### PR TITLE
add better loading UI for disk encryption page

### DIFF
--- a/changes/issue-11048-improve-disk-encryption-ui-loading
+++ b/changes/issue-11048-improve-disk-encryption-ui-loading
@@ -1,0 +1,1 @@
+- improve loading UI for disk encryption controls page.

--- a/frontend/pages/ManageControlsPage/MacOSSettings/AggregateMacSettingsIndicators/AggregateMacSettingsIndicators.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/AggregateMacSettingsIndicators/AggregateMacSettingsIndicators.tsx
@@ -6,6 +6,7 @@ import { MdmProfileStatus, ProfileSummaryResponse } from "interfaces/mdm";
 import MacSettingsIndicator from "pages/hosts/details/MacSettingsIndicator";
 
 import { IconNames } from "components/icons";
+import Spinner from "components/Spinner";
 
 const baseClass = "aggregate-mac-settings-indicators";
 
@@ -41,15 +42,19 @@ const AGGREGATE_STATUS_DISPLAY_OPTIONS: IAggregateDisplayOption[] = [
 ];
 
 interface AggregateMacSettingsIndicatorsProps {
+  isLoading: boolean;
   teamId: number;
-  aggregateProfileStatusData: ProfileSummaryResponse;
+  aggregateProfileStatusData?: ProfileSummaryResponse;
 }
 
 const AggregateMacSettingsIndicators = ({
+  isLoading,
   teamId,
   aggregateProfileStatusData,
 }: AggregateMacSettingsIndicatorsProps) => {
   const indicators = AGGREGATE_STATUS_DISPLAY_OPTIONS.map((status) => {
+    if (!aggregateProfileStatusData) return null;
+
     const { value, text, iconName, tooltipText } = status;
     const count = aggregateProfileStatusData[value];
 
@@ -71,6 +76,14 @@ const AggregateMacSettingsIndicators = ({
       </div>
     );
   });
+
+  if (isLoading) {
+    return (
+      <div className={baseClass}>
+        <Spinner className={`${baseClass}__loading-spinner`} centered={false} />
+      </div>
+    );
+  }
 
   return <div className={baseClass}>{indicators}</div>;
 };

--- a/frontend/pages/ManageControlsPage/MacOSSettings/AggregateMacSettingsIndicators/_styles.scss
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/AggregateMacSettingsIndicators/_styles.scss
@@ -6,6 +6,10 @@
   border-left: 1px solid #e2e4ea;
   border-radius: 6px;
 
+  &__loading-spinner {
+    margin: auto;
+  }
+
   .aggregate-mac-settings-indicator {
     flex-grow: 1;
 

--- a/frontend/pages/ManageControlsPage/MacOSSettings/MacOSSettings.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSSettings/MacOSSettings.tsx
@@ -1,14 +1,10 @@
-import React, { useContext, useState } from "react";
+import React, { useContext } from "react";
 import { Params } from "react-router/lib/Router";
 
 import { AppContext } from "context/app";
 import SideNav from "pages/admin/components/SideNav";
 import { useQuery } from "react-query";
-import {
-  IMdmProfile,
-  IMdmProfilesResponse,
-  ProfileSummaryResponse,
-} from "interfaces/mdm";
+import { ProfileSummaryResponse } from "interfaces/mdm";
 import { API_NO_TEAM_ID, APP_CONTEXT_NO_TEAM_ID } from "interfaces/team";
 import mdmAPI from "services/entities/mdm";
 
@@ -40,6 +36,7 @@ const MacOSSettings = ({
   const {
     data: aggregateProfileStatusData,
     refetch: refetchAggregateProfileStatus,
+    isLoading: isLoadingAggregateProfileStatus,
   } = useQuery<ProfileSummaryResponse>(
     ["aggregateProfileStatuses", teamId],
     () => mdmAPI.getAggregateProfileStatuses(teamId),
@@ -62,12 +59,11 @@ const MacOSSettings = ({
       <p className={`${baseClass}__description`}>
         Remotely enforce settings on macOS hosts assigned to this team.
       </p>
-      {aggregateProfileStatusData && (
-        <AggregateMacSettingsIndicators
-          teamId={teamId}
-          aggregateProfileStatusData={aggregateProfileStatusData}
-        />
-      )}
+      <AggregateMacSettingsIndicators
+        isLoading={isLoadingAggregateProfileStatus}
+        teamId={teamId}
+        aggregateProfileStatusData={aggregateProfileStatusData}
+      />
       <SideNav
         className={`${baseClass}__side-nav`}
         navItems={MAC_OS_SETTINGS_NAV_ITEMS.map((navItem) => ({


### PR DESCRIPTION
relates to #11048

improves the  loading UI for the disk encryption page. The aggregate profile summary no longer pops in and pushed down disk encryption section.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
