### PR TITLE
add default line height to body

### DIFF
--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -18,6 +18,8 @@ body {
 html,
 body {
   height: 100%;
+  // desired default line-height for text is 1.5x the font size.
+  line-height: 1.5;
 
   .__react_component_tooltip {
     text-align: center;
@@ -62,8 +64,6 @@ a {
   padding: $pad-xlarge;
   border-radius: 3px;
   background-color: $core-white;
-  // desired default line-height for text is 1.5x the font size.
-  line-height: 1.5;
 }
 
 .has-sidebar {


### PR DESCRIPTION
is related to this PR https://github.com/fleetdm/fleet/pull/11711

I meant to put this on the `body` selector, not `.body-wrapper`
