### PR TITLE
Fleet UI: Ability to save new policies (team admin/team maintainer)

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -171,6 +171,7 @@ const PolicyForm = ({
   }, [lastEditedQueryBody, lastEditedQueryId]);
 
   const hasSavePermissions =
+    !isEditMode || // save a new policy
     isGlobalAdmin ||
     isGlobalMaintainer ||
     (isTeamAdmin && policyTeamId === storedPolicy?.team_id) || // team admin cannot save global policy


### PR DESCRIPTION
## Issue
Cerra #11733 

## Description
- Hide save button from team admin and team maintainer for global policies, but when creating a new policy, needs to be able to see save button
- Note: If user doesn't have permission to create a new policy, they cannot reach this screen anyway (Access denied UI if directed from a URL)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- Unreleased bug so no change file
- [x] Manual QA for all new/changed functionality

