### PR TITLE
Fleet UI: Policy description now multi-line

### DIFF
--- a/changes/11704-policy-description-overflow
+++ b/changes/11704-policy-description-overflow
@@ -1,0 +1,1 @@
+- Policy description has text area instead of one-line area

--- a/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
+++ b/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
@@ -129,6 +129,7 @@ const SaveNewPolicyModal = ({
             value={description}
             inputClassName={`${baseClass}__policy-save-modal-description`}
             label="Description"
+            type="textarea"
             placeholder="Add a description here (optional)"
           />
           <InputField


### PR DESCRIPTION
## Issue
Cerra #11704

## Description
- Policy descriptions can be long, update UI to use multiline text area instead of single line text field

## Screenshot
<img width="1629" alt="Screenshot 2023-05-18 at 3 22 28 PM" src="https://github.com/fleetdm/fleet/assets/71795832/6edcd178-1ce0-4675-b3b1-6fd670df2af0">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

