### PR TITLE
UI: Title Case bug

### DIFF
--- a/changes/11737-Sentence-case-label-bug
+++ b/changes/11737-Sentence-case-label-bug
@@ -1,0 +1,1 @@
+* Ensure sentence casing on labels in host details page

--- a/frontend/pages/hosts/details/cards/Labels/Labels.tsx
+++ b/frontend/pages/hosts/details/cards/Labels/Labels.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import Button from "components/buttons/Button";
 import { ILabel } from "interfaces/label";
-import { enforceFleetSentenceCasing } from "utilities/helpers";
+import { enforceFleetSentenceCasing } from "utilities/strings/stringUtils";
 
 interface ILabelsProps {
   onLabelClick: (label: ILabel) => void;

--- a/frontend/pages/hosts/details/cards/Labels/Labels.tsx
+++ b/frontend/pages/hosts/details/cards/Labels/Labels.tsx
@@ -19,7 +19,6 @@ const Labels = ({ onLabelClick, labels }: ILabelsProps): JSX.Element => {
           className="list__button"
         >
           {enforceFleetSentenceCasing(label.name)}
-          {/* {upperFirst(lowerCase(label.name))} */}
         </Button>
       </li>
     );

--- a/frontend/pages/hosts/details/cards/Labels/Labels.tsx
+++ b/frontend/pages/hosts/details/cards/Labels/Labels.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import Button from "components/buttons/Button";
 import { ILabel } from "interfaces/label";
-import { upperFirst, lowerCase } from "lodash";
+import { enforceFleetSentenceCasing } from "utilities/helpers";
 
 interface ILabelsProps {
   onLabelClick: (label: ILabel) => void;
@@ -18,7 +18,8 @@ const Labels = ({ onLabelClick, labels }: ILabelsProps): JSX.Element => {
           variant="label"
           className="list__button"
         >
-          {upperFirst(lowerCase(label.name))}
+          {enforceFleetSentenceCasing(label.name)}
+          {/* {upperFirst(lowerCase(label.name))} */}
         </Button>
       </li>
     );

--- a/frontend/pages/hosts/details/cards/Labels/Labels.tsx
+++ b/frontend/pages/hosts/details/cards/Labels/Labels.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import Button from "components/buttons/Button";
 import { ILabel } from "interfaces/label";
+import { upperFirst, lowerCase } from "lodash";
 
 interface ILabelsProps {
   onLabelClick: (label: ILabel) => void;
@@ -17,7 +18,7 @@ const Labels = ({ onLabelClick, labels }: ILabelsProps): JSX.Element => {
           variant="label"
           className="list__button"
         >
-          {label.name}
+          {upperFirst(lowerCase(label.name))}
         </Button>
       </li>
     );

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -899,31 +899,3 @@ export default {
   normalizeEmptyValues,
   wrapFleetHelper,
 };
-
-export const STYLIZATIONS_AND_ACRONYMS = [
-  "macOS",
-  "osquery",
-  "MySQL",
-  "MDM",
-  "REST",
-  "API",
-  "JSON",
-];
-
-// fleetdm.com/handbook/marketing/content-style-guide#sentence-case
-// * doesn't recognize proper nouns!
-export const enforceFleetSentenceCasing = (s: string) => {
-  const resArr = s.split(" ").map((word, i) => {
-    if (!STYLIZATIONS_AND_ACRONYMS.includes(word)) {
-      const lowered = word.toLowerCase();
-      if (i === 0) {
-        // title case the first word
-        return lowered[0].toUpperCase() + lowered.slice(1);
-      }
-      return lowered;
-    }
-    return word;
-  });
-
-  return resArr.join(" ");
-};

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -911,6 +911,19 @@ export const STYLIZATIONS_AND_ACRONYMS = [
 ];
 
 // fleetdm.com/handbook/marketing/content-style-guide#sentence-case
+// * doesn't recognize proper nouns!
 export const enforceFleetSentenceCasing = (s: string) => {
-  // TODO
+  const resArr = s.split(" ").map((word, i) => {
+    if (!STYLIZATIONS_AND_ACRONYMS.includes(word)) {
+      const lowered = word.toLowerCase();
+      if (i === 0) {
+        // title case the first word
+        return lowered[0].toUpperCase() + lowered.slice(1);
+      }
+      return lowered;
+    }
+    return word;
+  });
+
+  return resArr.join(" ");
 };

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -899,3 +899,18 @@ export default {
   normalizeEmptyValues,
   wrapFleetHelper,
 };
+
+export const STYLIZATIONS_AND_ACRONYMS = [
+  "macOS",
+  "osquery",
+  "MySQL",
+  "MDM",
+  "REST",
+  "API",
+  "JSON",
+];
+
+// fleetdm.com/handbook/marketing/content-style-guide#sentence-case
+export const enforceFleetSentenceCasing = (s: string) => {
+  // TODO
+};

--- a/frontend/utilities/strings/stringUtils.tests.ts
+++ b/frontend/utilities/strings/stringUtils.tests.ts
@@ -1,0 +1,23 @@
+import { enforceFleetSentenceCasing } from "./stringUtils";
+
+describe("enforceFleetSentenceCasing utility", () => {
+  it("fixes a Title Cased String with no ignore words", () => {
+    expect(enforceFleetSentenceCasing("All Hosts")).toEqual("All hosts");
+    expect(enforceFleetSentenceCasing("all Hosts")).toEqual("All hosts");
+    expect(enforceFleetSentenceCasing("all hosts")).toEqual("All hosts");
+    expect(enforceFleetSentenceCasing("All HosTs ")).toEqual("All hosts");
+  });
+
+  it("fixes a title cased string while ignoring special words in various places ", () => {
+    expect(enforceFleetSentenceCasing("macOS")).toEqual("macOS");
+    expect(enforceFleetSentenceCasing("macOS Settings")).toEqual(
+      "macOS settings"
+    );
+    expect(
+      enforceFleetSentenceCasing("osquery shouldn't be Capitalized")
+    ).toEqual("osquery shouldn't be capitalized");
+  });
+  expect(enforceFleetSentenceCasing("fleet uses MySQL")).toEqual(
+    "Fleet uses MySQL"
+  );
+});

--- a/frontend/utilities/strings/stringUtils.ts
+++ b/frontend/utilities/strings/stringUtils.ts
@@ -18,6 +18,33 @@ const capitalizeRole = (str: UserRole): UserRole => {
   return str.replace(/\b\w/g, (letter) => letter.toUpperCase()) as UserRole;
 };
 
+export const STYLIZATIONS_AND_ACRONYMS = [
+  "macOS",
+  "osquery",
+  "MySQL",
+  "MDM",
+  "REST",
+  "API",
+  "JSON",
+];
+
+// fleetdm.com/handbook/marketing/content-style-guide#sentence-case
+// * doesn't recognize proper nouns!
+export const enforceFleetSentenceCasing = (s: string) => {
+  const resArr = s.split(" ").map((word, i) => {
+    if (!STYLIZATIONS_AND_ACRONYMS.includes(word)) {
+      const lowered = word.toLowerCase();
+      if (i === 0) {
+        // title case the first word
+        return lowered[0].toUpperCase() + lowered.slice(1);
+      }
+      return lowered;
+    }
+    return word;
+  });
+
+  return resArr.join(" ").trim();
+};
 export default {
   capitalize,
   capitalizeRole,


### PR DESCRIPTION
## Addresses #11737

- Write function to enforce Fleet sentence-casing standards
- Apply it to this bug

<img width="642" alt="Screenshot 2023-05-18 at 12 43 20 PM" src="https://github.com/fleetdm/fleet/assets/61553566/670f4f8d-1c23-4609-bb23-c38038e9bbd8">

*NOTE - this (the host details) endpoint currently returns label names in Sentence Case – this solution deals with only the UI presentation, but it might be worth changing the API response in the future:
<img width="369" alt="Screenshot 2023-05-18 at 12 48 58 PM" src="https://github.com/fleetdm/fleet/assets/61553566/27236524-9c0a-4818-8a74-f445b5765d94">

## Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` 
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
