### PR TITLE
Add rachaelshaw to CODEOWNERS for docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,16 +28,16 @@ go.mod @fleetdm/go
 /CHANGELOG.md @noahtalerman
 
 # Fleet documentation (who is auto-requested as reviewer for changes to docs?)
-/docs/ @ksatter
+/docs/ @ksatter @rachaelshaw
 
 # REST API reference documentation
-/docs/Using-Fleet/REST-API.md @ksatter @lukeheath
-/docs/Contributing/API-for-contributors.md @ksatter @lukeheath
+/docs/Using-Fleet/REST-API.md @ksatter @lukeheath @rachaelshaw
+/docs/Contributing/API-for-contributors.md @ksatter @lukeheath @rachaelshaw
 
 # Standard query library YAML
 /docs/01-Using-Fleet/standard-query-library/standard-query-library.yml @zwass
 
-# Exapnded table documentation
+# Expanded table documentation
 /schema @eashaw
 
 # Articles

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,11 +28,11 @@ go.mod @fleetdm/go
 /CHANGELOG.md @noahtalerman
 
 # Fleet documentation (who is auto-requested as reviewer for changes to docs?)
-/docs/ @ksatter @rachaelshaw
+/docs/ @rachaelshaw
 
 # REST API reference documentation
-/docs/Using-Fleet/REST-API.md @ksatter @lukeheath @rachaelshaw
-/docs/Contributing/API-for-contributors.md @ksatter @lukeheath @rachaelshaw
+/docs/Using-Fleet/REST-API.md @rachaelshaw
+/docs/Contributing/API-for-contributors.md @rachaelshaw
 
 # Standard query library YAML
 /docs/01-Using-Fleet/standard-query-library/standard-query-library.yml @zwass


### PR DESCRIPTION
+ Added myself to `/docs/` as discussed with @mikermcneil 
+ Also to the specific doc sections for the REST API and API for contributors because they were separated out (let me know if you'd rather I remove myself from those, don't mean to get grabby!)
+ Fixed a typo ✨

.