### PR TITLE
add page header for macos updates page

### DIFF
--- a/changes/issue-11376-add-page-header-for-macos-updates
+++ b/changes/issue-11376-add-page-header-for-macos-updates
@@ -1,0 +1,1 @@
+- add page header for macos updates UI

--- a/frontend/pages/ManageControlsPage/MacOSUpdates/MacOSUpdates.tsx
+++ b/frontend/pages/ManageControlsPage/MacOSUpdates/MacOSUpdates.tsx
@@ -37,28 +37,24 @@ const MacOSUpdates = ({ teamIdForApi }: IMacOSUpdates) => {
 
   return isPremiumTier ? (
     <div className={baseClass}>
-      <>
-        <p className={`${baseClass}__description`}>
-          Remotely encourage the installation of macOS updates on hosts assigned
-          to this team.
-        </p>
-        <div className={`${baseClass}__content`}>
-          <div className={`${baseClass}__form-table-content`}>
-            <div className={`${baseClass}__os-versions-card`}>
-              {OperatingSystemCard}
-            </div>
-            <div className={`${baseClass}__os-version-form`}>
-              <OsMinVersionForm
-                currentTeamId={teamIdForApi}
-                key={teamIdForApi}
-              />
-            </div>
+      <p className={`${baseClass}__description`}>
+        Remotely encourage the installation of macOS updates on hosts assigned
+        to this team.
+      </p>
+      <h2 className={`${baseClass}__title`}>MacOS updates settings</h2>
+      <div className={`${baseClass}__content`}>
+        <div className={`${baseClass}__form-table-content`}>
+          <div className={`${baseClass}__os-versions-card`}>
+            {OperatingSystemCard}
           </div>
-          <div className={`${baseClass}__nudge-preview`}>
-            <NudgePreview />
+          <div className={`${baseClass}__os-version-form`}>
+            <OsMinVersionForm currentTeamId={teamIdForApi} key={teamIdForApi} />
           </div>
         </div>
-      </>
+        <div className={`${baseClass}__nudge-preview`}>
+          <NudgePreview />
+        </div>
+      </div>
     </div>
   ) : (
     <PremiumFeatureMessage

--- a/frontend/pages/ManageControlsPage/MacOSUpdates/_styles.scss
+++ b/frontend/pages/ManageControlsPage/MacOSUpdates/_styles.scss
@@ -1,13 +1,17 @@
 .mac-os-updates {
   font-size: $x-small;
 
-  h2 {
-    font-size: $small;
-    margin: 0;
-  }
-
   &__description {
     margin: $pad-xxlarge 0;
+  }
+
+  &__title {
+    margin: 0 0 $pad-large;
+    padding-bottom: $pad-small;
+    font-size: $medium;
+    font-weight: $regular;
+    color: $core-fleet-black;
+    border-bottom: solid 1px $ui-fleet-black-10;
   }
 
   &__content {
@@ -16,6 +20,11 @@
     display: flex;
     justify-content: space-between;
     gap: $pad-xxlarge;
+
+    h2 {
+      font-size: $small;
+      margin: 0;
+    }
   }
 
   &__os-versions-card {


### PR DESCRIPTION
relates to #11354

This adds a page header to the macOS updates.

Had a talk with @marko-lisica and we decided the best UI improvement would to add a page header on the macOS updates page. This adds consistency across the pages and also gives a little more context of what the purpose of this page is.

![image](https://github.com/fleetdm/fleet/assets/1153709/da046823-69c4-4cbd-bca3-4efde4ad2d8c)

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality

