### PR TITLE
Fixed query used when aggregating WinOS stats

### DIFF
--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -185,7 +185,10 @@ var hostDetailQueries = map[string]DetailQuery{
 				)
 			}
 
-			host.OSVersion = fmt.Sprintf("%v %v", rows[0]["name"], version)
+			s := fmt.Sprintf("%v %v", rows[0]["name"], version)
+			// Shorten "Microsoft Windows" to "Windows" to facilitate display and sorting in UI
+			s = strings.Replace(s, "Microsoft Windows", "Windows", 1)
+			host.OSVersion = s
 
 			return nil
 		},

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -166,8 +166,7 @@ var hostDetailQueries = map[string]DetailQuery{
 		Query: `
 	SELECT
 		os.name,
-		os.version as display_version
-
+		os.version
 	FROM
 		os_version os`,
 		Platforms: []string{"windows"},
@@ -178,7 +177,7 @@ var hostDetailQueries = map[string]DetailQuery{
 				return nil
 			}
 
-			version := rows[0]["display_version"]
+			version := rows[0]["version"]
 			if version == "" {
 				level.Debug(logger).Log(
 					"msg", "unable to identify windows version",
@@ -186,10 +185,7 @@ var hostDetailQueries = map[string]DetailQuery{
 				)
 			}
 
-			s := fmt.Sprintf("%v %v", rows[0]["name"], version)
-			// Shorten "Microsoft Windows" to "Windows" to facilitate display and sorting in UI
-			s = strings.Replace(s, "Microsoft Windows", "Windows", 1)
-			host.OSVersion = s
+			host.OSVersion = fmt.Sprintf("%v %v", rows[0]["name"], version)
 
 			return nil
 		},
@@ -487,8 +483,7 @@ var extraDetailQueries = map[string]DetailQuery{
 		os.platform,
 		os.arch,
 		k.version as kernel_version,
-		os.codename as display_version
-
+		os.version
 	FROM
 		os_version os,
 		kernel_info k`,
@@ -907,7 +902,7 @@ func directIngestOSWindows(ctx context.Context, logger log.Logger, host *fleet.H
 		Platform:      rows[0]["platform"],
 	}
 
-	version := rows[0]["display_version"]
+	version := rows[0]["version"]
 	if version == "" {
 		level.Debug(logger).Log(
 			"msg", "unable to identify windows version",

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -547,7 +547,7 @@ func TestDirectIngestOSWindows(t *testing.T) {
 				KernelVersion: "10.0.22000.795",
 			},
 			data: []map[string]string{
-				{"name": "Microsoft Windows 11 Enterprise", "display_version": "21H2", "release_id": "", "arch": "64-bit", "kernel_version": "10.0.22000.795"},
+				{"name": "Microsoft Windows 11 Enterprise", "version": "21H2", "release_id": "", "arch": "64-bit", "kernel_version": "10.0.22000.795"},
 			},
 		},
 	}

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -386,7 +386,7 @@ func TestDetailQueriesOSVersionWindows(t *testing.T) {
 	))
 
 	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, rows))
-	assert.Equal(t, "Windows 11 Enterprise 21H2", host.OSVersion)
+	assert.Equal(t, "Windows 11 Enterprise 10.0.22000", host.OSVersion)
 
 	require.NoError(t, json.Unmarshal([]byte(`
 [{
@@ -408,7 +408,7 @@ func TestDetailQueriesOSVersionWindows(t *testing.T) {
 	))
 
 	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, rows))
-	assert.Equal(t, "Windows 10 Enterprise LTSC ", host.OSVersion)
+	assert.Equal(t, "Windows 10 Enterprise LTSC 10.0.17763", host.OSVersion)
 }
 
 func TestDetailQueriesOSVersionChrome(t *testing.T) {


### PR DESCRIPTION
Addresses https://github.com/fleetdm/fleet/issues/10709

Fixed bugs raised in linked issue regarding the aggregated stats shown on the dashboard page.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

~- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.~
  ~See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.~
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
~- [ ] Documented any permissions changes~
~- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
  ~- For Orbit and Fleet Desktop changes:~
    ~- [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    ~- [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
