### PR TITLE
fix MDM migration modal to send the webhook if the host is still enrolled

### DIFF
--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -300,24 +300,22 @@ func main() {
 					(sum.Notifications.NeedsMDMMigration || sum.Notifications.RenewEnrollmentProfile) &&
 					mdmMigrator.CanRun() {
 
-					// if the device is unmanaged or we're
-					// in force mode and the device needs
-					// migration, enable aggressive mode.
-					aggressive := sum.Notifications.RenewEnrollmentProfile ||
-						(sum.Notifications.NeedsMDMMigration && sum.Config.MDM.MacOSMigration.Mode == fleet.MacOSMigrationModeForced)
-
 					// update org info in case it changed
 					mdmMigrator.SetProps(useraction.MDMMigratorProps{
-						OrgInfo:    sum.Config.OrgInfo,
-						Aggressive: aggressive,
+						OrgInfo:     sum.Config.OrgInfo,
+						IsUnmanaged: sum.Notifications.RenewEnrollmentProfile,
 					})
 
 					// enable tray items
 					migrateMDMItem.Enable()
 					migrateMDMItem.Show()
 
-					if aggressive {
-						log.Info().Msg("MDM migration is in aggressive mode, automatically showing dialog")
+					// if the device is unmanaged or we're
+					// in force mode and the device needs
+					// migration, enable aggressive mode.
+					if sum.Notifications.RenewEnrollmentProfile ||
+						(sum.Notifications.NeedsMDMMigration && sum.Config.MDM.MacOSMigration.Mode == fleet.MacOSMigrationModeForced) {
+						log.Info().Msg("MDM device is unmanaged or force mode enabled, automatically showing dialog")
 						if err := mdmMigrator.ShowInterval(); err != nil {
 							log.Error().Err(err).Msg("showing MDM migration dialog at interval")
 						}

--- a/orbit/pkg/useraction/mdm_migration.go
+++ b/orbit/pkg/useraction/mdm_migration.go
@@ -24,8 +24,8 @@ type MDMMigrator interface {
 // MDMMigratorProps are props required to display the dialog. It's akin to the
 // concept of props in UI frameworks like React.
 type MDMMigratorProps struct {
-	OrgInfo    fleet.DesktopOrgInfo
-	Aggressive bool
+	OrgInfo     fleet.DesktopOrgInfo
+	IsUnmanaged bool
 }
 
 // MDMMigratorHandler handles remote actions/callbacks that the migrator calls.

--- a/orbit/pkg/useraction/mdm_migration_darwin.go
+++ b/orbit/pkg/useraction/mdm_migration_darwin.go
@@ -32,7 +32,7 @@ var mdmMigrationTemplate = template.Must(template.New("mdmMigrationTemplate").Pa
 
 To begin, click "Start." Your default browser will open your My Device page.
 
-{{ if .Aggressive }}You {{ else }} Once you start, you {{ end -}} will see this dialog every 15 minutes until you click "Turn on MDM" and complete the instructions.` +
+{{ if .IsUnmanaged }}You {{ else }} Once you start, you {{ end -}} will see this dialog every 15 minutes until you click "Turn on MDM" and complete the instructions.` +
 
 	"\n\n![Image showing the Fleet UI](https://fleetdm.com/images/permanent/mdm-migration-screenshot-768x180-2x.png)\n\n" +
 
@@ -231,7 +231,7 @@ func (m *swiftDialogMDMMigrator) renderMigration() error {
 			return nil
 		}
 
-		if !m.props.Aggressive {
+		if !m.props.IsUnmanaged {
 			// show the loading spinner
 			m.renderLoadingSpinner()
 


### PR DESCRIPTION
For https://github.com/fleetdm/fleet/issues/11857, to send the webhook and show the appropriate copy, it shouldn't matter what mode is configured.

Only thing that matters is if the device is currently unmanaged.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
