### PR TITLE
Website: update earliest supported version of Edge

### DIFF
--- a/website/views/layouts/layout-customer.ejs
+++ b/website/views/layouts/layout-customer.ejs
@@ -295,7 +295,7 @@
           Android: '7' // « earliest version we can test for compatibility issues with on browserstack
         };
         var LATEST_SUPPORTED_VERSION_BY_USER_AGENT = {
-          msedge: '17',//« earliest version to support the backdrop filter css property.
+          msedge: '80',//« earliest version to support the backdrop filter css property.
           safari: '11',//« earliest version that suppports the hubspot chatbot.
           firefox: '102',//« earliest version to support the backdrop filter css property.
           chrome: '76',//« earliest version to support the backdrop filter css property.

--- a/website/views/layouts/layout-landing.ejs
+++ b/website/views/layouts/layout-landing.ejs
@@ -295,7 +295,7 @@
           Android: '7' // « earliest version we can test for compatibility issues with on browserstack
         };
         var LATEST_SUPPORTED_VERSION_BY_USER_AGENT = {
-          msedge: '17',//« earliest version to support the backdrop filter css property.
+          msedge: '80',//« earliest version to support the backdrop filter css property.
           safari: '11',//« earliest version that suppports the hubspot chatbot.
           firefox: '102',//« earliest version to support the backdrop filter css property.
           chrome: '76',//« earliest version to support the backdrop filter css property.

--- a/website/views/layouts/layout-sandbox.ejs
+++ b/website/views/layouts/layout-sandbox.ejs
@@ -422,7 +422,7 @@
           Android: '7' // « earliest version we can test for compatibility issues with on browserstack
         };
         var LATEST_SUPPORTED_VERSION_BY_USER_AGENT = {
-          msedge: '17',//« earliest version to support the backdrop filter css property.
+          msedge: '80',//« earliest version to support the backdrop filter css property.
           safari: '11',//« earliest version that suppports the hubspot chatbot.
           firefox: '102',//« earliest version to support the backdrop filter css property.
           chrome: '76',//« earliest version to support the backdrop filter css property.

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -495,7 +495,7 @@
           Android: '7' // « earliest version we can test for compatibility issues with on browserstack
         };
         var LATEST_SUPPORTED_VERSION_BY_USER_AGENT = {
-          msedge: '17',//« earliest version to support the backdrop filter css property.
+          msedge: '80',//« earliest version to support the backdrop filter css property.
           safari: '11',//« earliest version that suppports the hubspot chatbot.
           firefox: '102',//« earliest version to support the backdrop filter css property.
           chrome: '76',//« earliest version to support the backdrop filter css property.


### PR DESCRIPTION
Changes:
- Changed the earliest version of Edge that the Fleet website supports from `v17` » `v80` (Global usage 0.02% for edge <`v18` (from caniuse.com) )