### PR TITLE
Reduce size of `DistributedQueryResult` to improve live query performance

### DIFF
--- a/changes/10957-reduce-size-distributed-query-result-struct
+++ b/changes/10957-reduce-size-distributed-query-result-struct
@@ -1,0 +1,1 @@
+* Reduce size of live query websocket message by removing unused host data.

--- a/cmd/fleetctl/query_test.go
+++ b/cmd/fleetctl/query_test.go
@@ -99,16 +99,10 @@ func TestLiveQuery(t *testing.T) {
 			fleet.DistributedQueryResult{
 				DistributedQueryCampaignID: 321,
 				Rows:                       []map[string]string{{"bing": "fds"}},
-				Host: fleet.HostResponseForHostCheap(&fleet.Host{
-					ID: 99,
-					UpdateCreateTimestamps: fleet.UpdateCreateTimestamps{
-						UpdateTimestamp: fleet.UpdateTimestamp{
-							UpdatedAt: time.Now().UTC(),
-						},
-					},
-					DetailUpdatedAt: time.Now().UTC(),
-					Hostname:        "somehostname",
-				}),
+				Host: fleet.ResultHostData{
+					ID:       99,
+					Hostname: "somehostname",
+				},
 			},
 		))
 	}()

--- a/cmd/fleetctl/query_test.go
+++ b/cmd/fleetctl/query_test.go
@@ -100,8 +100,9 @@ func TestLiveQuery(t *testing.T) {
 				DistributedQueryCampaignID: 321,
 				Rows:                       []map[string]string{{"bing": "fds"}},
 				Host: fleet.ResultHostData{
-					ID:       99,
-					Hostname: "somehostname",
+					ID:          99,
+					Hostname:    "somehostname",
+					DisplayName: "somehostname",
 				},
 			},
 		))

--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -586,12 +586,12 @@ Once base64-decoded, they are PEM-encoded certificate and keys.
 
 #### Parameters
 
-| Name          | Type   | In    | Description                                                                                                                       |
-| ------------- | ------ | ----  | --------------------------------------------------------------------------------------                                            |
-| team_id       | number | query | _Available in Fleet Premium_ The team ID to apply the custom settings to. Only one of team_name/team_id can be provided.          |
-| team_name     | string | query | _Available in Fleet Premium_ The name of the team to apply the custom settings to. Only one of team_name/team_id can be provided. |
-| dry_run       | bool   | query | Validate the provided profiles and return any validation errors, but do not apply the changes.                                    |
-| profiles      | json   | body  | An array of strings, the base64-encoded .mobileconfig files to apply.                                                             |
+| Name      | Type   | In    | Description                                                                                                                       |
+| --------- | ------ | ----- | --------------------------------------------------------------------------------------------------------------------------------- |
+| team_id   | number | query | _Available in Fleet Premium_ The team ID to apply the custom settings to. Only one of team_name/team_id can be provided.          |
+| team_name | string | query | _Available in Fleet Premium_ The name of the team to apply the custom settings to. Only one of team_name/team_id can be provided. |
+| dry_run   | bool   | query | Validate the provided profiles and return any validation errors, but do not apply the changes.                                    |
+| profiles  | json   | body  | An array of strings, the base64-encoded .mobileconfig files to apply.                                                             |
 
 If no team (id or name) is provided, the profiles are applied for all hosts (for _Fleet Free_) or for hosts that are not part of a team (for _Fleet Premium_). After the call, the provided list of `profiles` will be the active profiles for that team (or no team) - that is, any existing profile that is not part of that list will be removed, and an existing profile with the same payload identifier as a new profile will be edited. If the list of provided `profiles` is empty, all profiles are removed for that team (or no team).
 
@@ -1154,18 +1154,18 @@ If the `name` is not already associated with an existing team, this API route cr
 #### Parameters
 
 | Name                                      | Type   | In    | Description                                                                                                                                                                                                                         |
-| -------------                             | ------ | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ----------------------------------------- | ------ | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | name                                      | string | body  | **Required.** The team's name.                                                                                                                                                                                                      |
 | agent_options                             | object | body  | The agent options spec that is applied to the hosts assigned to the specified to team. These agent options completely override the global agent options specified in the [`GET /api/v1/fleet/config API route`](#get-configuration) |
 | features                                  | object | body  | The features that are applied to the hosts assigned to the specified to team. These features completely override the global features specified in the [`GET /api/v1/fleet/config API route`](#get-configuration)                    |
 | secrets                                   | list   | body  | A list of plain text strings is used as the enroll secrets. Existing secrets are replaced with this list, or left unmodified if this list is empty. Note that there is a limit of 50 secrets allowed.                               |
 | mdm                                       | object | body  | The team's MDM configuration options.                                                                                                                                                                                               |
-| mdm.macos_updates                         | object | body  | The OS updates macOS configuration options for Nudge. |
-| mdm.macos_updates.minimum_version         | string | body  | The required minimum operating system version. |
-| mdm.macos_updates.deadline                | string | body  | The required installation date for Nudge to enforce the operating system version. |
-| mdm.macos_settings                        | object | body  | The macOS-specific MDM settings. |
-| mdm.macos_settings.custom_settings        | list   | body  | The list of .mobileconfig files to apply to hosts that belong to this team. |
-| mdm.macos_settings.enable_disk_encryption | bool   | body  | Whether disk encryption should be enabled for hosts that belong to this team. |
+| mdm.macos_updates                         | object | body  | The OS updates macOS configuration options for Nudge.                                                                                                                                                                               |
+| mdm.macos_updates.minimum_version         | string | body  | The required minimum operating system version.                                                                                                                                                                                      |
+| mdm.macos_updates.deadline                | string | body  | The required installation date for Nudge to enforce the operating system version.                                                                                                                                                   |
+| mdm.macos_settings                        | object | body  | The macOS-specific MDM settings.                                                                                                                                                                                                    |
+| mdm.macos_settings.custom_settings        | list   | body  | The list of .mobileconfig files to apply to hosts that belong to this team.                                                                                                                                                         |
+| mdm.macos_settings.enable_disk_encryption | bool   | body  | Whether disk encryption should be enabled for hosts that belong to this team.                                                                                                                                                       |
 | force                                     | bool   | query | Force apply the spec even if there are (ignorable) validation errors. Those are unknown keys and agent options-related validations.                                                                                                 |
 | dry_run                                   | bool   | query | Validate the provided JSON for unknown keys and invalid value types and return any validation errors, but do not apply the changes.                                                                                                 |
 
@@ -1933,7 +1933,9 @@ o
     "data": {
       "distributed_query_execution_id": 39,
       "host": {
-        // host data
+        "id": 42,
+        "hostname": "foobar",
+        "display_name": "foobar"
       },
       "rows": [
         // query results data for the given host
@@ -2072,7 +2074,9 @@ o
     "data": {
       "distributed_query_execution_id": 39,
       "host": {
-        // host data
+        "id": 42,
+        "hostname": "foobar",
+        "display_name": "foobar"
       },
       "rows": [
         // query results data for the given host

--- a/server/fleet/campaigns.go
+++ b/server/fleet/campaigns.go
@@ -33,15 +33,30 @@ type DistributedQueryCampaignTarget struct {
 
 // DistributedQueryResult is the result returned from the execution of a
 // distributed query on a single host.
+//
+// IMPORTANT: This struct is stored in the result store (e.g. Redis)
+// and is streamed to a pubsub listener (browser or fleetctl user) via websockets,
+// thus it should be kept as small as possible.
 type DistributedQueryResult struct {
-	DistributedQueryCampaignID uint                `json:"distributed_query_execution_id"`
-	Host                       *HostResponse       `json:"host"`
-	Rows                       []map[string]string `json:"rows"`
-	// osquery currently doesn't return any helpful error information,
-	// but we use string here instead of bool for future-proofing. Note also
-	// that we can't use the error interface here because something
+	// DistributedQueryCampaignID is the unique ID of the live query campaign.
+	DistributedQueryCampaignID uint `json:"distributed_query_execution_id"`
+	// Host holds the host's data from where the query result comes from.
+	Host ResultHostData      `json:"host"`
+	Rows []map[string]string `json:"rows"`
+	// Error contains any error reported by osquery when running the query.
+	// Note we can't use the error interface here because something
 	// implementing that interface may not (un)marshal properly
-	Error *string `json:"error"`
+	Error *string `json:"error,omitempty"`
+}
+
+// ResultHostData holds the host's data from where a query result comes from.
+type ResultHostData struct {
+	// ID is the unique ID of the host.
+	ID uint `json:"id"`
+	// Hostname is the host's hostname.
+	Hostname string `json:"hostname"`
+	// DisplayName holds the display name of the host.
+	DisplayName string `json:"display_name"`
 }
 
 type QueryResult struct {

--- a/server/pubsub/query_results_test.go
+++ b/server/pubsub/query_results_test.go
@@ -34,15 +34,9 @@ func TestQueryResultsStoreErrors(t *testing.T) {
 		result := fleet.DistributedQueryResult{
 			DistributedQueryCampaignID: 9999,
 			Rows:                       []map[string]string{{"bing": "fds"}},
-			Host: fleet.HostResponseForHostCheap(&fleet.Host{
+			Host: fleet.ResultHostData{
 				ID: 4,
-				UpdateCreateTimestamps: fleet.UpdateCreateTimestamps{
-					UpdateTimestamp: fleet.UpdateTimestamp{
-						UpdatedAt: time.Now().UTC(),
-					},
-				},
-				DetailUpdatedAt: time.Now().UTC(),
-			}),
+			},
 		}
 
 		// Write with no subscriber
@@ -108,59 +102,23 @@ func TestQueryResultsStore(t *testing.T) {
 			{
 				DistributedQueryCampaignID: 1,
 				Rows:                       []map[string]string{{"foo": "bar"}},
-				Host: fleet.HostResponseForHostCheap(&fleet.Host{
+				Host: fleet.ResultHostData{
 					ID: 1,
-					// Note these times need to be set to avoid
-					// issues with roundtrip serializing the zero
-					// time value. See https://goo.gl/CCEs8x
-					UpdateCreateTimestamps: fleet.UpdateCreateTimestamps{
-						UpdateTimestamp: fleet.UpdateTimestamp{
-							UpdatedAt: time.Now().UTC(),
-						},
-						CreateTimestamp: fleet.CreateTimestamp{
-							CreatedAt: time.Now().UTC(),
-						},
-					},
-
-					DetailUpdatedAt: time.Now().UTC(),
-					SeenTime:        time.Now().UTC(),
-				}),
+				},
 			},
 			{
 				DistributedQueryCampaignID: 1,
 				Rows:                       []map[string]string{{"whoo": "wahh"}},
-				Host: fleet.HostResponseForHostCheap(&fleet.Host{
+				Host: fleet.ResultHostData{
 					ID: 3,
-					UpdateCreateTimestamps: fleet.UpdateCreateTimestamps{
-						UpdateTimestamp: fleet.UpdateTimestamp{
-							UpdatedAt: time.Now().UTC(),
-						},
-						CreateTimestamp: fleet.CreateTimestamp{
-							CreatedAt: time.Now().UTC(),
-						},
-					},
-
-					DetailUpdatedAt: time.Now().UTC(),
-					SeenTime:        time.Now().UTC(),
-				}),
+				},
 			},
 			{
 				DistributedQueryCampaignID: 1,
 				Rows:                       []map[string]string{{"bing": "fds"}},
-				Host: fleet.HostResponseForHostCheap(&fleet.Host{
+				Host: fleet.ResultHostData{
 					ID: 4,
-					UpdateCreateTimestamps: fleet.UpdateCreateTimestamps{
-						UpdateTimestamp: fleet.UpdateTimestamp{
-							UpdatedAt: time.Now().UTC(),
-						},
-						CreateTimestamp: fleet.CreateTimestamp{
-							CreatedAt: time.Now().UTC(),
-						},
-					},
-
-					DetailUpdatedAt: time.Now().UTC(),
-					SeenTime:        time.Now().UTC(),
-				}),
+				},
 			},
 		}
 
@@ -174,38 +132,16 @@ func TestQueryResultsStore(t *testing.T) {
 			{
 				DistributedQueryCampaignID: 2,
 				Rows:                       []map[string]string{{"tim": "tom"}},
-				Host: fleet.HostResponseForHostCheap(&fleet.Host{
+				Host: fleet.ResultHostData{
 					ID: 1,
-					UpdateCreateTimestamps: fleet.UpdateCreateTimestamps{
-						UpdateTimestamp: fleet.UpdateTimestamp{
-							UpdatedAt: time.Now().UTC(),
-						},
-						CreateTimestamp: fleet.CreateTimestamp{
-							CreatedAt: time.Now().UTC(),
-						},
-					},
-
-					DetailUpdatedAt: time.Now().UTC(),
-					SeenTime:        time.Now().UTC(),
-				}),
+				},
 			},
 			{
 				DistributedQueryCampaignID: 2,
 				Rows:                       []map[string]string{{"slim": "slam"}},
-				Host: fleet.HostResponseForHostCheap(&fleet.Host{
+				Host: fleet.ResultHostData{
 					ID: 3,
-					UpdateCreateTimestamps: fleet.UpdateCreateTimestamps{
-						UpdateTimestamp: fleet.UpdateTimestamp{
-							UpdatedAt: time.Now().UTC(),
-						},
-						CreateTimestamp: fleet.CreateTimestamp{
-							CreatedAt: time.Now().UTC(),
-						},
-					},
-
-					DetailUpdatedAt: time.Now().UTC(),
-					SeenTime:        time.Now().UTC(),
-				}),
+				},
 			},
 		}
 
@@ -222,7 +158,6 @@ func TestQueryResultsStore(t *testing.T) {
 					results1 = append(results1, res)
 				}
 			}
-
 		}()
 		readerWg.Add(1)
 		go func() {
@@ -233,7 +168,6 @@ func TestQueryResultsStore(t *testing.T) {
 					results2 = append(results2, res)
 				}
 			}
-
 		}()
 
 		// Wait to ensure subscriptions are activated before writing

--- a/server/service/client_live_query_test.go
+++ b/server/service/client_live_query_test.go
@@ -50,7 +50,6 @@ func TestLiveQueryWithContext(t *testing.T) {
 				time.Sleep(1 * time.Second)
 				mt, message, _ := ws.ReadMessage()
 				if string(message) == `{"type":"auth","data":{"token":"1234"}}` {
-
 					return
 				}
 				if string(message) == `{"type":"select_campaign","data":{"campaign_id":99}}` {
@@ -64,10 +63,10 @@ func TestLiveQueryWithContext(t *testing.T) {
 					Type: "result",
 					Data: fleet.DistributedQueryResult{
 						DistributedQueryCampaignID: 99,
-						Host: fleet.HostResponseForHostCheap(&fleet.Host{
+						Host: fleet.ResultHostData{
 							ID:       23,
 							Hostname: "somehostaaa",
-						}),
+						},
 						Rows: []map[string]string{
 							{
 								"col1": "aaa",

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -1074,8 +1074,12 @@ func (svc *Service) ingestDistributedQuery(ctx context.Context, host fleet.Host,
 	// Write the results to the pubsub store
 	res := fleet.DistributedQueryResult{
 		DistributedQueryCampaignID: uint(campaignID),
-		Host:                       fleet.HostResponseForHostCheap(&host),
-		Rows:                       rows,
+		Host: fleet.ResultHostData{
+			ID:          host.ID,
+			Hostname:    host.Hostname,
+			DisplayName: host.DisplayName(),
+		},
+		Rows: rows,
 	}
 	if failed {
 		res.Error = &errMsg

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -1578,7 +1578,9 @@ func TestDistributedQueryResults(t *testing.T) {
 			if res, ok := val.(fleet.DistributedQueryResult); ok {
 				assert.Equal(t, campaign.ID, res.DistributedQueryCampaignID)
 				assert.Equal(t, expectedRows, res.Rows)
-				assert.Equal(t, host, res.Host.Host)
+				assert.Equal(t, host.ID, res.Host.ID)
+				assert.Equal(t, host.Hostname, res.Host.Hostname)
+				assert.Equal(t, host.DisplayName(), res.Host.DisplayName)
 			} else {
 				t.Error("Wrong result type")
 			}


### PR DESCRIPTION
This was found while working on #10957.

When running a live query, a lot of unused host data is stored in Redis and sent on every live query result message via websockets. The frontend and fleetctl just need `id`, `hostname` and `display_name`. (This becomes worse every time we add new fields to the `Host` struct.)

Sample of one websocket message result when running `SELECT * from osquery_info;`:

size in `main`: 2234 bytes
```
a["{\"type\":\"result\",\"data\":{\"distributed_query_execution_id\":57,\"host\":
{\"created_at\":\"2023-05-22T12:14:11Z\",\"updated_at\":\"2023-05-23T12:31:51Z\",
\"software_updated_at\":\"0001-01-01T00:00:00Z\",\"id\":106,\"detail_updated_at\":\"2023-05-23T11:50:04Z\",
\"label_updated_at\":\"2023-05-23T11:50:04Z\",\"policy_updated_at\":\"1970-01-02T00:00:00Z\",
\"last_enrolled_at\":\"2023-05-22T12:14:12Z\",
\"seen_time\":\"2023-05-23T09:52:23.876311-03:00\",\"refetch_requested\":false,
\"hostname\":\"lucass-macbook-pro.local\",\"uuid\":\"BD4DFA10-E334-41D9-8136-D2163A8FE588\",\"platform\":\"darwin\",\"osquery_version\":\"5.8.2\",\"os_version\":\"macOS 13.3.1\",\"build\":\"22E261\",\"platform_like\":\"darwin\",\"code_name\":\"\",
\"uptime\":91125000000000,\"memory\":34359738368,\"cpu_type\":\"x86_64h\",\"cpu_subtype\":\"Intel x86-64h Haswell\",\"cpu_brand\":\"Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz\",\"cpu_physical_cores\":4,\"cpu_logical_cores\":8,\"hardware_vendor\":\"Apple Inc.\",\"hardware_model\":\"MacBookPro16,2\",\"hardware_version\":\"1.0\",
\"hardware_serial\":\"0DPQR4HMD1FZ\",
\"computer_name\":\"Lucas’s MacBook Pro\",\"public_ip\":\"\",
\"primary_ip\":\"192.168.0.230\",\"primary_mac\":\"68:2f:67:8e:b6:1f\",
\"distributed_interval\":1,\"config_tls_refresh\":60,\"logger_tls_period\":10,\"team_id\":null,
\"pack_stats\":null,\"team_name\":null,
\"gigs_disk_space_available\":386.23,\"percent_disk_space_available\":40,
\"issues\":{\"total_issues_count\":0,\"failing_policies_count\":0},
\"mdm\":{\"enrollment_status\":null,\"server_url\":null,\"name\":\"\",\"encryption_key_available\":false},
\"status\":\"online\",\"display_text\":\"lucass-macbook-pro.local\",\"display_name\":\"Lucas’s MacBook Pro\"},
\"rows\":[{\"build_distro\":\"10.14\",\"build_platform\":\"darwin\",
\"config_hash\":\"b7ee9363a7c686e76e99ffb122e9c5241a791e69\",\"config_valid\":\"1\",
\"extensions\":\"active\",\"host_display_name\":\"Lucas’s MacBook Pro\",
\"host_hostname\":\"lucass-macbook-pro.local\",\"instance_id\":\"cde5de81-344b-4c76-b1c5-dae964fdd4f2\",\"pid\":\"8370\",\"platform_mask\":\"21\",\"start_time\":\"1684757652\",
\"uuid\":\"BD4DFA10-E334-41D9-8136-D2163A8FE588\",
\"version\":\"5.8.2\",\"watcher\":\"8364\"}],\"error\":null}}"]
```

vs. size of the message result on this branch: 675 bytes
```
a["{\"type\":\"result\",\"data\":{\"distributed_query_execution_id\":59,
\"host\":{\"id\":106,\"hostname\":\"lucass-macbook-pro.local\",
\"display_name\":\"Lucas’s MacBook Pro\"},
\"rows\":[{\"build_distro\":\"10.14\",\"build_platform\":\"darwin\",
\"config_hash\":\"f80dee827635db39077a458243379b3ad63311fd\",
\"config_valid\":\"1\",\"extensions\":\"active\",\"host_display_name\":\"Lucas’s MacBook Pro\",
\"host_hostname\":\"lucass-macbook-pro.local\",
\"instance_id\":\"cde5de81-344b-4c76-b1c5-dae964fdd4f2\",\"pid\":\"8370\",\"platform_mask\":\"21\",
\"start_time\":\"1684757652\",\"uuid\":\"BD4DFA10-E334-41D9-8136-D2163A8FE588\",\"version\":\"5.8.2\",
\"watcher\":\"8364\"}]}}"]
```

Manual tests included running with an old fleetctl running with a new fleet server, and vice-versa, a new fleetctl running against an old fleet server.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- ~[ ] Documented any permissions changes~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
  - ~For Orbit and Fleet Desktop changes:~
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
