### PR TITLE
Improve `osquery-perf` support for live queries (simulate no results and/or query failures)

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -211,20 +211,22 @@ func (n *nodeKeyManager) Add(nodekey string) {
 }
 
 type agent struct {
-	agentIndex      int
-	softwareCount   softwareEntityCount
-	userCount       entityCount
-	policyPassProb  float64
-	munkiIssueProb  float64
-	munkiIssueCount int
-	strings         map[string]string
-	serverAddress   string
-	fastClient      fasthttp.Client
-	stats           *Stats
-	nodeKeyManager  *nodeKeyManager
-	nodeKey         string
-	templates       *template.Template
-	os              string
+	agentIndex             int
+	softwareCount          softwareEntityCount
+	userCount              entityCount
+	policyPassProb         float64
+	munkiIssueProb         float64
+	munkiIssueCount        int
+	liveQueryFailProb      float64
+	liveQueryNoResultsProb float64
+	strings                map[string]string
+	serverAddress          string
+	fastClient             fasthttp.Client
+	stats                  *Stats
+	nodeKeyManager         *nodeKeyManager
+	nodeKey                string
+	templates              *template.Template
+	os                     string
 	// deviceAuthToken holds Fleet Desktop device authentication token.
 	//
 	// Non-nil means the agent is identified as orbit osquery,
@@ -283,6 +285,8 @@ func newAgent(
 	emptySerialProb float64,
 	mdmProb float64,
 	mdmSCEPChallenge string,
+	liveQueryFailProb float64,
+	liveQueryNoResultsProb float64,
 ) *agent {
 	var deviceAuthToken *string
 	if rand.Float64() <= orbitProb {
@@ -309,14 +313,16 @@ func newAgent(
 		uuid = mdmClient.UUID
 	}
 	return &agent{
-		agentIndex:      agentIndex,
-		serverAddress:   serverAddress,
-		softwareCount:   softwareCount,
-		userCount:       userCount,
-		strings:         make(map[string]string),
-		policyPassProb:  policyPassProb,
-		munkiIssueProb:  munkiIssueProb,
-		munkiIssueCount: munkiIssueCount,
+		agentIndex:             agentIndex,
+		serverAddress:          serverAddress,
+		softwareCount:          softwareCount,
+		userCount:              userCount,
+		strings:                make(map[string]string),
+		policyPassProb:         policyPassProb,
+		munkiIssueProb:         munkiIssueProb,
+		munkiIssueCount:        munkiIssueCount,
+		liveQueryFailProb:      liveQueryFailProb,
+		liveQueryNoResultsProb: liveQueryNoResultsProb,
 		fastClient: fasthttp.Client{
 			TLSConfig: tlsConfig,
 		},
@@ -1153,67 +1159,95 @@ func (a *agent) diskEncryptionLinux() []map[string]string {
 	}
 }
 
-func (a *agent) processQuery(name, query string) (handled bool, results []map[string]string, status *fleet.OsqueryStatus) {
+func (a *agent) runLiveQuery(query string) (results []map[string]string, status *fleet.OsqueryStatus, message *string) {
+	if a.liveQueryFailProb > 0.0 && rand.Float64() <= a.liveQueryFailProb {
+		ss := fleet.OsqueryStatus(1)
+		return []map[string]string{}, &ss, ptr.String("live query failed with error foobar")
+	}
+	ss := fleet.OsqueryStatus(0)
+	if a.liveQueryNoResultsProb > 0.0 && rand.Float64() <= a.liveQueryNoResultsProb {
+		return []map[string]string{}, &ss, nil
+	}
+	return []map[string]string{{
+		"admindir":   "/var/lib/dpkg",
+		"arch":       "amd64",
+		"maintainer": "foobar",
+		"name":       "netconf",
+		"priority":   "optional",
+		"revision":   "",
+		"section":    "default",
+		"size":       "112594",
+		"source":     "",
+		"status":     "install ok installed",
+		"version":    "20230224000000",
+	}}, &ss, nil
+}
+
+func (a *agent) processQuery(name, query string) (handled bool, results []map[string]string, status *fleet.OsqueryStatus, message *string) {
 	const (
 		hostPolicyQueryPrefix = "fleet_policy_query_"
 		hostDetailQueryPrefix = "fleet_detail_query_"
+		liveQueryPrefix       = "fleet_distributed_query_"
 	)
 	statusOK := fleet.StatusOK
 	statusNotOK := fleet.OsqueryStatus(1)
 
 	switch {
+	case strings.HasPrefix(name, liveQueryPrefix):
+		results, status, message = a.runLiveQuery(query)
+		return true, results, status, message
 	case strings.HasPrefix(name, hostPolicyQueryPrefix):
-		return true, a.runPolicy(query), &statusOK
+		return true, a.runPolicy(query), &statusOK, nil
 	case name == hostDetailQueryPrefix+"scheduled_query_stats":
-		return true, a.randomQueryStats(), &statusOK
+		return true, a.randomQueryStats(), &statusOK, nil
 	case name == hostDetailQueryPrefix+"mdm":
 		ss := fleet.OsqueryStatus(rand.Intn(2))
 		if ss == fleet.StatusOK {
 			results = a.mdmMac()
 		}
-		return true, results, &ss
+		return true, results, &ss, nil
 	case name == hostDetailQueryPrefix+"mdm_windows":
 		ss := fleet.OsqueryStatus(rand.Intn(2))
 		if ss == fleet.StatusOK {
 			results = a.mdmWindows()
 		}
-		return true, results, &ss
+		return true, results, &ss, nil
 	case name == hostDetailQueryPrefix+"munki_info":
 		ss := fleet.OsqueryStatus(rand.Intn(2))
 		if ss == fleet.StatusOK {
 			results = a.munkiInfo()
 		}
-		return true, results, &ss
+		return true, results, &ss, nil
 	case name == hostDetailQueryPrefix+"google_chrome_profiles":
 		ss := fleet.OsqueryStatus(rand.Intn(2))
 		if ss == fleet.StatusOK {
 			results = a.googleChromeProfiles()
 		}
-		return true, results, &ss
+		return true, results, &ss, nil
 	case name == hostDetailQueryPrefix+"battery":
 		ss := fleet.OsqueryStatus(rand.Intn(2))
 		if ss == fleet.StatusOK {
 			results = a.batteries()
 		}
-		return true, results, &ss
+		return true, results, &ss, nil
 	case name == hostDetailQueryPrefix+"users":
 		ss := fleet.OsqueryStatus(rand.Intn(2))
 		if ss == fleet.StatusOK {
 			results = a.hostUsers()
 		}
-		return true, results, &ss
+		return true, results, &ss, nil
 	case name == hostDetailQueryPrefix+"software_macos":
 		ss := fleet.OsqueryStatus(rand.Intn(2))
 		if ss == fleet.StatusOK {
 			results = a.softwareMacOS()
 		}
-		return true, results, &ss
+		return true, results, &ss, nil
 	case name == hostDetailQueryPrefix+"software_windows":
 		ss := fleet.OsqueryStatus(rand.Intn(2))
 		if ss == fleet.StatusOK {
 			results = a.softwareWindows11()
 		}
-		return true, results, &ss
+		return true, results, &ss, nil
 	case name == hostDetailQueryPrefix+"software_linux":
 		ss := fleet.OsqueryStatus(rand.Intn(2))
 		if ss == fleet.StatusOK {
@@ -1222,37 +1256,37 @@ func (a *agent) processQuery(name, query string) (handled bool, results []map[st
 				results = a.softwareUbuntu2204()
 			}
 		}
-		return true, results, &ss
+		return true, results, &ss, nil
 	case name == hostDetailQueryPrefix+"disk_space_unix" || name == hostDetailQueryPrefix+"disk_space_windows":
 		ss := fleet.OsqueryStatus(rand.Intn(2))
 		if ss == fleet.StatusOK {
 			results = a.diskSpace()
 		}
-		return true, results, &ss
+		return true, results, &ss, nil
 
 	case strings.HasPrefix(name, hostDetailQueryPrefix+"disk_encryption_linux"):
 		ss := fleet.OsqueryStatus(rand.Intn(2))
 		if ss == fleet.StatusOK {
 			results = a.diskEncryptionLinux()
 		}
-		return true, results, &ss
+		return true, results, &ss, nil
 	case name == hostDetailQueryPrefix+"disk_encryption_darwin" ||
 		name == hostDetailQueryPrefix+"disk_encryption_windows":
 		ss := fleet.OsqueryStatus(rand.Intn(2))
 		if ss == fleet.StatusOK {
 			results = a.diskEncryption()
 		}
-		return true, results, &ss
+		return true, results, &ss, nil
 	case name == hostDetailQueryPrefix+"kubequery_info" && a.os != "kubequery":
 		// Real osquery running on hosts would return no results if it was not
 		// running kubequery (due to discovery query). Returning true here so that
 		// the caller knows it is handled, will not try to return lorem-ipsum-style
 		// results.
-		return true, nil, &statusNotOK
+		return true, nil, &statusNotOK, nil
 	default:
 		// Look for results in the template file.
 		if t := a.templates.Lookup(name); t == nil {
-			return false, nil, nil
+			return false, nil, nil, nil
 		}
 		var ni bytes.Buffer
 		err := a.templates.ExecuteTemplate(&ni, name, a)
@@ -1264,7 +1298,7 @@ func (a *agent) processQuery(name, query string) (handled bool, results []map[st
 			panic(err)
 		}
 
-		return true, results, &statusOK
+		return true, results, &statusOK, nil
 	}
 }
 
@@ -1272,10 +1306,11 @@ func (a *agent) DistributedWrite(queries map[string]string) {
 	r := service.SubmitDistributedQueryResultsRequest{
 		Results:  make(fleet.OsqueryDistributedQueryResults),
 		Statuses: make(map[string]fleet.OsqueryStatus),
+		Messages: make(map[string]string),
 	}
 	r.NodeKey = a.nodeKey
 	for name, query := range queries {
-		handled, results, status := a.processQuery(name, query)
+		handled, results, status, message := a.processQuery(name, query)
 		if !handled {
 			// If osquery-perf does not handle the incoming query,
 			// always return status OK and the default query result.
@@ -1287,6 +1322,9 @@ func (a *agent) DistributedWrite(queries map[string]string) {
 			}
 			if status != nil {
 				r.Statuses[name] = *status
+			}
+			if message != nil {
+				r.Messages[name] = *message
 			}
 		}
 	}
@@ -1353,10 +1391,13 @@ func main() {
 		munkiIssueProb              = flag.Float64("munki_issue_prob", 0.5, "Probability of a host having munki issues (note that ~50% of hosts have munki installed) [0, 1]")
 		munkiIssueCount             = flag.Int("munki_issue_count", 10, "Number of munki issues reported by hosts identified to have munki issues")
 		osTemplates                 = flag.String("os_templates", "mac10.14.6", fmt.Sprintf("Comma separated list of host OS templates to use (any of %v, with or without the .tmpl extension)", allowedTemplateNames))
-		emptySerialProb             = flag.Float64("empty_serial_prob", 0.0, "Probability of a host having no serial number [0, 1]")
+		emptySerialProb             = flag.Float64("empty_serial_prob", 0.1, "Probability of a host having no serial number [0, 1]")
 
-		mdmProb          = flag.Float64("mdm_prob", 0.1, "Probability of a host enrolling via MDM (for macOS) [0, 1]")
+		mdmProb          = flag.Float64("mdm_prob", 0.0, "Probability of a host enrolling via MDM (for macOS) [0, 1]")
 		mdmSCEPChallenge = flag.String("mdm_scep_challenge", "", "SCEP challenge to use when running MDM enroll")
+
+		liveQueryFailProb      = flag.Float64("live_query_fail_prob", 0.0, "Probability of a live query failing execution in the host")
+		liveQueryNoResultsProb = flag.Float64("live_query_no_results_prob", 0.2, "Probability of a live query returning no results")
 	)
 
 	flag.Parse()
@@ -1436,6 +1477,8 @@ func main() {
 			*emptySerialProb,
 			*mdmProb,
 			*mdmSCEPChallenge,
+			*liveQueryFailProb,
+			*liveQueryNoResultsProb,
 		)
 		a.stats = stats
 		a.nodeKeyManager = nodeKeyManager


### PR DESCRIPTION
These osquery-perf changes were useful to test/troubleshoot #10957.
It basically allows osquery-perf to simulate no results and/or failures when running live queries on the devices.

- ~[ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.~
- ~[ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~[ ] Documented any permissions changes~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- [X] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- ~[ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality
  - ~For Orbit and Fleet Desktop changes:~
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
