### PR TITLE
Fix small `fleetctl query` bug when running with `--exit` flag

### DIFF
--- a/cmd/fleetctl/query.go
+++ b/cmd/fleetctl/query.go
@@ -174,9 +174,6 @@ func queryCommand() *cli.Command {
 						if online > 0 {
 							percentOnline = 100 * float64(responded) / float64(online)
 						}
-						if responded >= online && flExit {
-							return nil
-						}
 					}
 
 					msg := fmt.Sprintf(" %.f%% responded (%.f%% online) | %d/%d targeted hosts (%d/%d online)", percentTotal, percentOnline, responded, total, responded, online)
@@ -190,6 +187,11 @@ func queryCommand() *cli.Command {
 						if !flQuiet {
 							fmt.Fprintln(os.Stderr, msg)
 						}
+						return nil
+					}
+
+					if status != nil && totals != nil && responded >= online && flExit {
+						s.Stop()
 						return nil
 					}
 

--- a/cmd/fleetctl/query.go
+++ b/cmd/fleetctl/query.go
@@ -192,6 +192,9 @@ func queryCommand() *cli.Command {
 
 					if status != nil && totals != nil && responded >= online && flExit {
 						s.Stop()
+						if !flQuiet {
+							fmt.Fprintln(os.Stderr, msg)
+						}
 						return nil
 					}
 

--- a/cmd/fleetctl/query.go
+++ b/cmd/fleetctl/query.go
@@ -174,10 +174,9 @@ func queryCommand() *cli.Command {
 						if online > 0 {
 							percentOnline = 100 * float64(responded) / float64(online)
 						}
-					}
-
-					if responded >= online && flExit {
-						return nil
+						if responded >= online && flExit {
+							return nil
+						}
 					}
 
 					msg := fmt.Sprintf(" %.f%% responded (%.f%% online) | %d/%d targeted hosts (%d/%d online)", percentTotal, percentOnline, responded, total, responded, online)


### PR DESCRIPTION
Bug found while working on #10957.

Can be reproduced in our dogfood environment:
```
fleetctl query --context dogfood --query "SELECT * from osquery_info;" --hosts dogfood-centos-box --exit
⠋ %
```

With the changes in this PR:
```
fleetctl query --context dogfood --query "SELECT * from osquery_info;" --hosts dogfood-centos-box --exit
{"host":"dogfood-centos-box","rows":[{"build_distro":"centos7","build_platform":"linux","config_hash":"e3832343af2f8dc3e5ab62e709c78d3c3ef32b86","config_valid":"1","extensions":"active","host_display_name":"dogfood-centos-box","host_hostname":"dogfood-centos-box","instance_id":"9f0f6433-fbcf-4f15-8f1b-4dedc669ee2d","pid":"2760450","platform_mask":"9","start_time":"1684821735","uuid":"911CBDBA-7B3A-4B96-88F7-B28CECBEF400","version":"5.8.2","watcher":"2760447"}]}
⠦ 0% responded (0% online) | 0/1 targeted hosts (0/1 online) %
```