### PR TITLE
UI: Multiple team oberver plus bug

### DIFF
--- a/changes/11674-observer_plus-on-multiple-teams
+++ b/changes/11674-observer_plus-on-multiple-teams
@@ -1,0 +1,2 @@
+- Fix a bug in the users table where users that are observer+ for all of more than one team were
+  listed as "Various roles"

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -506,6 +506,9 @@ export const generateRole = (
     } else if (listOfRoles.every((role): boolean => role === "observer")) {
       // only team observers
       return "Observer";
+    } else if (listOfRoles.every((role): boolean => role === "observer_plus")) {
+      // only team observers plus
+      return "Observer+";
     }
 
     return "Various"; // no global role and multiple teams


### PR DESCRIPTION
## Addresses #11674
Correctly display that a user's overall role is "Observer+" in the case where they have the Observer+ role on all of multiple teams
![Screenshot 2023-05-23 at 12 30 55 PM](https://github.com/fleetdm/fleet/assets/61553566/c5724e4f-c310-4ea5-8c46-2a992f2de73c)



## Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality