### PR TITLE
Modify `GET /mdm/apple/profiles` API endpoint to return empty array instead of `null` when results set is empty

### DIFF
--- a/changes/issue-11280-list-mdm-config-profiles
+++ b/changes/issue-11280-list-mdm-config-profiles
@@ -1,0 +1,1 @@
+- Updated `GET /mdm/apple/profiles` endpoint to return empty array instead of null if no profiles are found.

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -372,15 +372,16 @@ func (r listMDMAppleConfigProfilesResponse) error() error { return r.Err }
 
 func listMDMAppleConfigProfilesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*listMDMAppleConfigProfilesRequest)
-	res := listMDMAppleConfigProfilesResponse{}
 
 	cps, err := svc.ListMDMAppleConfigProfiles(ctx, req.TeamID)
 	if err != nil {
-		res.Err = err
-		return &res, err
+		return &listMDMAppleConfigProfilesResponse{Err: err}, nil
 	}
-	res.ConfigProfiles = cps
 
+	res := listMDMAppleConfigProfilesResponse{ConfigProfiles: cps}
+	if cps == nil {
+		res.ConfigProfiles = []*fleet.MDMAppleConfigProfile{} // return empty json array instead of json null
+	}
 	return &res, nil
 }
 
@@ -2181,7 +2182,6 @@ func (svc *MDMAppleCheckinAndCommandService) TokenUpdate(r *mdm.Request, m *mdm.
 				if info.TeamID != 0 {
 					team, err := svc.ds.Team(r.Context, info.TeamID)
 					if err != nil {
-
 						return fmt.Errorf("fetch team to send AccountConfiguration: %w", err)
 					}
 					ssoEnabled = team.Config.MDM.MacOSSetup.EnableEndUserAuthentication

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -1198,6 +1198,71 @@ func (s *integrationMDMTestSuite) TestMDMAppleGetEncryptionKey() {
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/mdm/hosts/%d/encryption_key", host.ID), nil, http.StatusForbidden, &resp)
 }
 
+func (s *integrationMDMTestSuite) TestMDMAppleListConfigProfiles() {
+	t := s.T()
+	ctx := context.Background()
+
+	testTeam, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "TestTeam"})
+	require.NoError(t, err)
+
+	t.Run("no profiles", func(t *testing.T) {
+		var resp listMDMAppleConfigProfilesResponse
+		s.DoJSON("GET", "/api/v1/fleet/mdm/apple/profiles", nil, http.StatusOK, &resp)
+		require.NotNil(t, resp.ConfigProfiles) // expect empty slice instead of nil
+		require.Len(t, resp.ConfigProfiles, 0)
+
+		resp = listMDMAppleConfigProfilesResponse{}
+		s.DoJSON("GET", fmt.Sprintf(`/api/v1/fleet/mdm/apple/profiles?team_id=%d`, testTeam.ID), nil, http.StatusOK, &resp)
+		require.NotNil(t, resp.ConfigProfiles) // expect empty slice instead of nil
+		require.Len(t, resp.ConfigProfiles, 0)
+	})
+
+	t.Run("with profiles", func(t *testing.T) {
+		p1, err := fleet.NewMDMAppleConfigProfile(mcBytesForTest("p1", "p1.identifier", "p1.uuid"), nil)
+		require.NoError(t, err)
+		_, err = s.ds.NewMDMAppleConfigProfile(ctx, *p1)
+		require.NoError(t, err)
+
+		p2, err := fleet.NewMDMAppleConfigProfile(mcBytesForTest("p2", "p2.identifier", "p2.uuid"), &testTeam.ID)
+		require.NoError(t, err)
+		_, err = s.ds.NewMDMAppleConfigProfile(ctx, *p2)
+		require.NoError(t, err)
+
+		var resp listMDMAppleConfigProfilesResponse
+		s.DoJSON("GET", "/api/latest/fleet/mdm/apple/profiles", listMDMAppleConfigProfilesRequest{TeamID: 0}, http.StatusOK, &resp)
+		require.NotNil(t, resp.ConfigProfiles)
+		require.Len(t, resp.ConfigProfiles, 1)
+		require.Equal(t, p1.Name, resp.ConfigProfiles[0].Name)
+		require.Equal(t, p1.Identifier, resp.ConfigProfiles[0].Identifier)
+
+		resp = listMDMAppleConfigProfilesResponse{}
+		s.DoJSON("GET", fmt.Sprintf(`/api/v1/fleet/mdm/apple/profiles?team_id=%d`, testTeam.ID), nil, http.StatusOK, &resp)
+		require.NotNil(t, resp.ConfigProfiles)
+		require.Len(t, resp.ConfigProfiles, 1)
+		require.Equal(t, p2.Name, resp.ConfigProfiles[0].Name)
+		require.Equal(t, p2.Identifier, resp.ConfigProfiles[0].Identifier)
+
+		p3, err := fleet.NewMDMAppleConfigProfile(mcBytesForTest("p3", "p3.identifier", "p3.uuid"), &testTeam.ID)
+		require.NoError(t, err)
+		_, err = s.ds.NewMDMAppleConfigProfile(ctx, *p3)
+		require.NoError(t, err)
+
+		resp = listMDMAppleConfigProfilesResponse{}
+		s.DoJSON("GET", fmt.Sprintf(`/api/v1/fleet/mdm/apple/profiles?team_id=%d`, testTeam.ID), nil, http.StatusOK, &resp)
+		require.NotNil(t, resp.ConfigProfiles)
+		require.Len(t, resp.ConfigProfiles, 2)
+		for _, p := range resp.ConfigProfiles {
+			if p.Name == p2.Name {
+				require.Equal(t, p2.Identifier, p.Identifier)
+			} else if p.Name == p3.Name {
+				require.Equal(t, p3.Identifier, p.Identifier)
+			} else {
+				require.Fail(t, "unexpected profile name")
+			}
+		}
+	})
+}
+
 func (s *integrationMDMTestSuite) TestMDMAppleConfigProfileCRUD() {
 	t := s.T()
 	ctx := context.Background()


### PR DESCRIPTION
Issue #11280 

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Added/updated tests
