### PR TITLE
fix icon not being aligned properly on Host details/ My device page.

### DIFF
--- a/changes/issue-11763-fix-misaligned-icons
+++ b/changes/issue-11763-fix-misaligned-icons
@@ -1,0 +1,1 @@
+- fix misaligned icons in UI

--- a/frontend/components/Icon/_styles.scss
+++ b/frontend/components/Icon/_styles.scss
@@ -2,8 +2,4 @@
   // keeps this element the same size as the svg
   // aligns properly in text, buttons, dropdowns, summary tile custom component
   display: inline-flex;
-
-  svg {
-    padding: 1px;
-  }
 }

--- a/frontend/components/icons/PendingPartial.tsx
+++ b/frontend/components/icons/PendingPartial.tsx
@@ -1,18 +1,18 @@
 import React from "react";
 
-const PendingPartial = () => {
+import { COLORS, Colors } from "styles/var/colors";
+
+interface ICheckProps {
+  color?: Colors;
+}
+
+const PendingPartial = ({ color = "ui-fleet-black-50" }: ICheckProps) => {
   return (
-    <svg
-      width="18"
-      height="18"
-      viewBox="0 0 18 18"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <circle cx="9" cy="9" r="8" stroke="#8B8FA2" strokeWidth="2" />
-      <circle cx="5.6665" cy="9" r="1" fill="#8B8FA2" />
-      <circle cx="8.6665" cy="9" r="1" fill="#8B8FA2" />
-      <circle cx="11.6665" cy="9" r="1" fill="#8B8FA2" />
+    <svg width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="8" cy="8" r="7" stroke={COLORS[color]} strokeWidth="2" />
+      <circle cx="4.667" cy="8" r="1" fill={COLORS[color]} />
+      <circle cx="7.667" cy="8" r="1" fill={COLORS[color]} />
+      <circle cx="10.666" cy="8" r="1" fill={COLORS[color]} />
     </svg>
   );
 };

--- a/frontend/components/icons/SuccessPartial.tsx
+++ b/frontend/components/icons/SuccessPartial.tsx
@@ -1,18 +1,17 @@
 import React from "react";
+import { COLORS, Colors } from "styles/var/colors";
 
-const SuccessPartial = () => {
+interface ICheckProps {
+  color?: Colors;
+}
+
+const SuccessPartial = ({ color = "status-success" }: ICheckProps) => {
   return (
-    <svg
-      width="18"
-      height="18"
-      viewBox="0 0 18 18"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <ellipse cx="9" cy="9" rx="8" ry="8" stroke="#3DB67B" strokeWidth="2" />
+    <svg width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="8" cy="8" r="7" stroke={COLORS[color]} strokeWidth="2" />
       <path
-        d="M6 10L8 12L12 6"
-        stroke="#3DB67B"
+        d="m5 9 2 2 4-6"
+        stroke={COLORS[color]}
         strokeWidth="1.5"
         strokeLinecap="round"
         strokeLinejoin="round"

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -18,8 +18,6 @@ body {
 html,
 body {
   height: 100%;
-  // desired default line-height for text is 1.5x the font size.
-  line-height: 1.5;
 
   .__react_component_tooltip {
     text-align: center;
@@ -37,6 +35,13 @@ h1,
 h2,
 h3 {
   line-height: 1.2;
+}
+
+p {
+  // Desired default line-height for text is 1.5x the font size for paragrah text.
+  // This allows for a comfortable reading experience by adding space between
+  // multiline paragraphs.
+  line-height: 1.5;
 }
 
 h1 {


### PR DESCRIPTION
relates to #11763

fixes misaligned icons with text on host details page. This was a combination of using the wrong icon size and a line height set from a previous PR. We have now removed the line height set on the `body` tag and have moved it to the `p` tag. This was done as the original issue was multiline sentences not having enough space, and adding the line-height on the `p` tag fixes this.

![image](https://github.com/fleetdm/fleet/assets/1153709/aea4ca1a-0cff-4f3e-b03a-82ecbd001cb5)

![image](https://github.com/fleetdm/fleet/assets/1153709/d4e816d6-672c-4ea8-a759-4e54456f76d1)


- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality