### PR TITLE
Increase Go test timeout to 15m

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -46,7 +46,7 @@ jobs:
 
     env:
       RACE_ENABLED: false
-      GO_TEST_TIMEOUT: 10m
+      GO_TEST_TIMEOUT: 15m
 
     steps:
     - name: Install Go


### PR DESCRIPTION
Migrations tests have started failing due to 10m timeout (more frequently on mysql 8). In the future we should probably only run migration tests for new/unreleased migrations (no value in running old migrations' tests as they are immutable and applied in sequence from an empty db).