### PR TITLE
Filter out `"null"` string in `installed_path` from osquery

### DIFF
--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1172,7 +1172,10 @@ func directIngestSoftware(ctx context.Context, logger log.Logger, host *fleet.Ho
 		software = append(software, s)
 
 		installedPath := strings.TrimSpace(row["installed_path"])
-		if installedPath != "" {
+		if installedPath != "" &&
+			// NOTE: osquery is sometimes incorrectly returning the value "null" for some install paths.
+			// Thus, explicitly ignore them here.
+			installedPath != "null" {
 			key := fmt.Sprintf("%s%s%s", installedPath, fleet.SoftwareFieldSeparator, s.ToUniqueStr())
 			sPaths[key] = struct{}{}
 		}

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1174,8 +1174,8 @@ func directIngestSoftware(ctx context.Context, logger log.Logger, host *fleet.Ho
 		installedPath := strings.TrimSpace(row["installed_path"])
 		if installedPath != "" &&
 			// NOTE: osquery is sometimes incorrectly returning the value "null" for some install paths.
-			// Thus, explicitly ignore them here.
-			installedPath != "null" {
+			// Thus, we explicitly ignore such value here.
+			strings.ToLower(installedPath) != "null" {
 			key := fmt.Sprintf("%s%s%s", installedPath, fleet.SoftwareFieldSeparator, s.ToUniqueStr())
 			sPaths[key] = struct{}{}
 		}


### PR DESCRIPTION
#11851 

(The installed path issue hasn't been released so we don't need to migrate or fix any existing devices.)