### PR TITLE
Return DB results even if nothing has changed

### DIFF
--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -355,7 +355,7 @@ func applyChangesForNewSoftwareDB(
 	r.WasCurrInstalled = currentSoftware
 
 	if nothingChanged(currentSoftware, software, minLastOpenedAtDiff) {
-		return nil, nil
+		return r, nil
 	}
 
 	current := softwareSliceToMap(currentSoftware)


### PR DESCRIPTION
https://github.com/fleetdm/fleet/issues/11929

We want to return the DB results even if nothing has changed, to avoid error-ing out when synching the software installed paths.