### PR TITLE
Fleet UI: Schedule page ChromeOS update

### DIFF
--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
@@ -233,6 +233,15 @@ const ScheduleEditorModal = ({
       width="large"
     >
       <form className={`${baseClass}__form`}>
+        <p className={`${baseClass}__platform-compatibility`}>
+          Scheduled queries can currently be run on macOS, Windows, and Linux
+          hosts. Interested in collecting data from your Chromebooks?{" "}
+          <CustomLink
+            url="https://www.fleetdm.com/contact"
+            text="Let us know"
+            newTab
+          />
+        </p>
         {!editQuery && (
           <Dropdown
             searchable

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/_styles.scss
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/_styles.scss
@@ -1,4 +1,8 @@
 .schedule-editor-modal {
+  &__platform-compatibility {
+    margin-bottom: $pad-large;
+  }
+
   &__sandbox-info {
     margin-top: $pad-medium;
 

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -184,9 +184,9 @@ interface IPlatformDropdownOptions {
 }
 export const PLATFORM_DROPDOWN_OPTIONS: IPlatformDropdownOptions[] = [
   { label: "All", value: "all", path: paths.DASHBOARD },
+  { label: "macOS", value: "darwin", path: paths.DASHBOARD_MAC },
   { label: "Windows", value: "windows", path: paths.DASHBOARD_WINDOWS },
   { label: "Linux", value: "linux", path: paths.DASHBOARD_LINUX },
-  { label: "macOS", value: "darwin", path: paths.DASHBOARD_MAC },
 ];
 
 export const PLATFORM_NAME_TO_LABEL_NAME = {


### PR DESCRIPTION
## Issue
Cerra #11834 

## Description
- Add copy that says ChromeOS is not supported on schedules
- Reorder platform dropdown

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
