### PR TITLE
chore: replace `github.com/ghodss/yaml` with `sigs.k8s.io/yaml`

### DIFF
--- a/cmd/fleetctl/config.go
+++ b/cmd/fleetctl/config.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/pkg/secure"
-	"github.com/ghodss/yaml"
 	"github.com/urfave/cli/v2"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/cmd/fleetctl/convert.go
+++ b/cmd/fleetctl/convert.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/fleetdm/fleet/v4/pkg/spec"
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	"github.com/ghodss/yaml"
 	"github.com/urfave/cli/v2"
+	"sigs.k8s.io/yaml"
 )
 
 func specGroupFromPack(name string, inputPack fleet.PermissivePackContent) (*spec.Group, error) {

--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -18,9 +18,9 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/service"
-	"github.com/ghodss/yaml"
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v2"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/cmd/fleetctl/get_test.go
+++ b/cmd/fleetctl/get_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/pkg/spec"

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/fleetdm/goose v0.0.0-20221011170007-06aacf8ac547
 	github.com/getlantern/systray v1.2.2-0.20220329111105-6065fda28be8
 	github.com/getsentry/sentry-go v0.18.0
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-kit/kit v0.12.0
 	github.com/go-kit/log v0.2.1
 	github.com/go-sql-driver/mysql v1.6.0
@@ -115,6 +114,7 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.4.0
 	howett.net/plist v1.0.0
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -203,6 +203,7 @@ require (
 	github.com/getlantern/hex v0.0.0-20220104173244-ad7e4b9194dc // indirect
 	github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 // indirect
 	github.com/getlantern/ops v0.0.0-20200403153110-8476b16edcd6 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/go-git/go-git/v5 v5.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1955,4 +1955,6 @@ nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
+sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
 software.sslmate.com/src/go-pkcs12 v0.0.0-20210415151418-c5206de65a78/go.mod h1:B7Wf0Ya4DHF9Yw+qfZuJijQYkWicqDa+79Ytmmq3Kjg=

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 var yamlSeparator = regexp.MustCompile(`(?m:^---[\t ]*)`)

--- a/server/fleet/queries.go
+++ b/server/fleet/queries.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 type QueryPayload struct {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -28,13 +28,13 @@ import (
 	"github.com/fleetdm/fleet/v4/server/live_query/live_query_mock"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/test"
-	"github.com/ghodss/yaml"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/guregu/null.v3"
+	"sigs.k8s.io/yaml"
 )
 
 type integrationTestSuite struct {

--- a/server/service/testing_client.go
+++ b/server/service/testing_client.go
@@ -24,10 +24,10 @@ import (
 	"github.com/fleetdm/fleet/v4/server/pubsub"
 	"github.com/fleetdm/fleet/v4/server/sso"
 	"github.com/fleetdm/fleet/v4/server/test"
-	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"sigs.k8s.io/yaml"
 )
 
 type withDS struct {


### PR DESCRIPTION
The `github.com/ghodss/yaml` package is no longer being actively maintained. `sigs.k8s.io/yaml` is a permanent fork of `github.com/ghodss/yaml`, which is actively maintained by Kubernetes SIG and widely used in K8s projects.

There is a bug in `go mod tidy` that doesn't rearrange direct and `// indirect` dependencies (https://github.com/golang/go/issues/56471), so I had to manually join `require` blocks and use `go mod tidy` to split them again.

# Checklist for submitter

- [x] Manual QA for all new/changed functionality
