### PR TITLE
Update cloud banner on home page

### DIFF
--- a/website/views/layouts/layout-sandbox.ejs
+++ b/website/views/layouts/layout-sandbox.ejs
@@ -135,11 +135,11 @@
     <div style="padding-bottom: <%= optimizeForAppleWebview  ?  '0px' : '60px' %>; background-color: #FFF;" purpose="page-wrap">
       <div class="header <%= optimizeForAppleWebview  ?  'd-none' : '' %>" purpose="header-container">
         <%// Call to action ribbon above page header %>
-        <div purpose="header-ribbon-cta" class="<%= headerCTAHidden  ?  'd-none' : 'd-flex' %> flex-row justify-content-center align-items-md-center">
+        <!--<div purpose="header-ribbon-cta" class="<%= headerCTAHidden  ?  'd-none' : 'd-flex' %> flex-row justify-content-center align-items-md-center">
           <div class="mb-0 d-flex flex-lg-row flex-column justify-content-center py-3 px-2">
             <p class="text-center pr-1 mb-0">Instant deployment with Fleet Managed Cloud. <a target="_blank" href="https://kqphpqst851.typeform.com/to/yoo5smT9">Join the beta</a></p>
           </div>
-        </div>
+        </div>-->
         <%// Page header%>
         <div purpose="page-header" class="container-fluid d-flex justify-content-between align-items-center pt-3 pb-3 px-3 px-md-4">
           <a purpose="header-logo" href="/">

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -136,11 +136,11 @@
     <div purpose="page-wrap">
       <div class="header" purpose="header-container">
         <%// Call to action ribbon above page header %>
-        <div purpose="header-ribbon-cta" class="<%= headerCTAHidden  ?  'd-none' : 'd-flex' %> flex-row justify-content-center align-items-md-center">
+        <!--<div purpose="header-ribbon-cta" class="<%= headerCTAHidden  ?  'd-none' : 'd-flex' %> flex-row justify-content-center align-items-md-center">
           <div class="mb-0 d-flex flex-lg-row flex-column justify-content-center py-3 px-2">
             <p class="text-center pr-1 mb-0">Instant deployment with Fleet Managed Cloud. <a href="https://kqphpqst851.typeform.com/to/yoo5smT9">Join the beta</a></p>
           </div>
-        </div>
+        </div>-->
         <%// Page header%>
         <div purpose="page-header" class="container-fluid d-flex justify-content-between align-items-center pt-3 pb-3 px-3 px-md-4">
           <a purpose="header-logo" href="/">

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -108,9 +108,9 @@
         </div>
         <div purpose="banner-text">
           <div class="d-flex flex-column">
-            <h2>Instant deployment with Fleet Managed Cloud.</h2>
+            <h2>Instant deployment with Fleet Premium Cloud.</h2>
             <p>Focus on device management, and leave your Fleet server management to us.</p>
-            <a style="max-width: 144px;" href="https://kqphpqst851.typeform.com/to/yoo5smT9" target="_blank" purpose="animated-arrow-button-red">Join the beta</a>
+            <a @click="clickOpenChatWidget()" purpose="animated-arrow-button-red">Talk to an expert</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Changes:

- Changed the headline and CTA button text on the Premium Cloud banner, on the homepage.
- Removed the call to action ribbon from above the masthead.

# Checklist for submitter

- [x] Manual QA for all new/changed functionality
