### PR TITLE
Fleet UI: Fix jumpy tabs

### DIFF
--- a/changes/issue-11960-fix-jumpy-tabs
+++ b/changes/issue-11960-fix-jumpy-tabs
@@ -1,0 +1,1 @@
+- Fix jump tabs caused by new font

--- a/frontend/components/TabsWrapper/_styles.scss
+++ b/frontend/components/TabsWrapper/_styles.scss
@@ -16,7 +16,7 @@
       display: inline-flex;
       flex-direction: column;
       align-items: center;
-      bottom: -2px; // Fix shift of new font
+      bottom: -2px; // Fix shifty text
 
       &:focus {
         box-shadow: none;
@@ -41,7 +41,7 @@
       }
       &--selected {
         font-weight: $bold;
-        bottom: -4px; // fix shift with bold text
+        bottom: -4px; // fix shifty bold text
 
         &::after {
           content: "";

--- a/frontend/components/TabsWrapper/_styles.scss
+++ b/frontend/components/TabsWrapper/_styles.scss
@@ -16,6 +16,7 @@
       display: inline-flex;
       flex-direction: column;
       align-items: center;
+      bottom: -2px; // Fix shift of new font
 
       &:focus {
         box-shadow: none;
@@ -40,6 +41,7 @@
       }
       &--selected {
         font-weight: $bold;
+        bottom: -4px; // fix shift with bold text
 
         &::after {
           content: "";

--- a/frontend/components/TabsWrapper/_styles.scss
+++ b/frontend/components/TabsWrapper/_styles.scss
@@ -16,7 +16,7 @@
       display: inline-flex;
       flex-direction: column;
       align-items: center;
-      bottom: -2px; // Fix shifty text
+      line-height: 19px; // Fix shifty bold text
 
       &:focus {
         box-shadow: none;
@@ -41,7 +41,6 @@
       }
       &--selected {
         font-weight: $bold;
-        bottom: -4px; // fix shifty bold text
 
         &::after {
           content: "";


### PR DESCRIPTION
## Issue
Cerra #11960 

## Description
- Fix new font (bold and normal) not compatible with tab height causing font to jump up and down when clicked

## Screenrecording of fix
https://github.com/fleetdm/fleet/assets/71795832/a9765b6f-040d-488c-bd3d-e0890b587309



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

