### PR TITLE
 UI: Set sandbox add hosts modal to standard width

### DIFF
--- a/changes/11993-sandbox-add-hosts-modal
+++ b/changes/11993-sandbox-add-hosts-modal
@@ -1,0 +1,1 @@
+- Fix a styling bug in the add hosts modal in sandbox mode

--- a/frontend/components/AddHostsModal/AddHostsModal.tsx
+++ b/frontend/components/AddHostsModal/AddHostsModal.tsx
@@ -36,6 +36,13 @@ const AddHostsModal = ({
     openEnrollSecretModal && openEnrollSecretModal();
   };
 
+  // TODO: Currently, prepacked installers in Fleet Sandbox use the global enroll secret,
+  // and Fleet Sandbox runs Fleet Free so the currentTeam check here is an
+  // additional precaution/reminder to revisit this in connection with future changes.
+  // See https://github.com/fleetdm/fleet/issues/4970#issuecomment-1187679407.
+  const shouldRenderDownloadInstallersContent =
+    isSandboxMode && !isAnyTeamSelected;
+
   const renderModalContent = () => {
     if (isLoading) {
       return <Spinner />;
@@ -58,11 +65,7 @@ const AddHostsModal = ({
       );
     }
 
-    // TODO: Currently, prepacked installers in Fleet Sandbox use the global enroll secret,
-    // and Fleet Sandbox runs Fleet Free so the currentTeam check here is an
-    // additional precaution/reminder to revisit this in connection with future changes.
-    // See https://github.com/fleetdm/fleet/issues/4970#issuecomment-1187679407.
-    return isSandboxMode && !isAnyTeamSelected ? (
+    return shouldRenderDownloadInstallersContent ? (
       <DownloadInstallers onCancel={onCancel} enrollSecret={enrollSecret} />
     ) : (
       <PlatformWrapper onCancel={onCancel} enrollSecret={enrollSecret} />
@@ -70,7 +73,12 @@ const AddHostsModal = ({
   };
 
   return (
-    <Modal onExit={onCancel} title={"Add hosts"} className={baseClass}>
+    <Modal
+      onExit={onCancel}
+      title={"Add hosts"}
+      className={baseClass}
+      width={shouldRenderDownloadInstallersContent ? "large" : "medium"}
+    >
       {renderModalContent()}
     </Modal>
   );

--- a/frontend/components/AddHostsModal/DownloadInstallers/_styles.scss
+++ b/frontend/components/AddHostsModal/DownloadInstallers/_styles.scss
@@ -3,7 +3,6 @@
   flex-direction: column;
   padding: 0;
   padding-bottom: 20px;
-  width: 650px;
 
   p {
     padding-top: $pad-small;


### PR DESCRIPTION
## Addresses #11993 

**before:**
<img width="730" alt="dc2b128e-a8b2-46ac-a61d-945c04344c02" src="https://github.com/fleetdm/fleet/assets/61553566/d9366265-5de1-41ef-971c-3c9c02ea986c">

**now:**
<img width="1504" alt="Screenshot 2023-05-26 at 7 26 09 PM" src="https://github.com/fleetdm/fleet/assets/61553566/f549fe5c-02fc-4216-bb2c-295360da6656">

## Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
