### PR TITLE
Feature 11829: Tailor host table response to ChromeOS

### DIFF
--- a/changes/11829-tailor-host-chromeos-responses
+++ b/changes/11829-tailor-host-chromeos-responses
@@ -1,0 +1,3 @@
+- Changed `os_version` from ChromeOS hosts from `Chrome OS` to `ChromeOS`
+- Changed ChromeOS host's computer name prefix from `ChromeOS` to `Chromebook`
+- Added query to fill in `device_mapping` from ChromeOS hosts.

--- a/changes/11829-tailor-host-chromeos-responses
+++ b/changes/11829-tailor-host-chromeos-responses
@@ -1,3 +1,3 @@
-- Changed `os_version` from ChromeOS hosts from `Chrome OS` to `ChromeOS`
+- Changed `os_version` column reported from ChromeOS hosts from `Chrome OS` to `ChromeOS`
 - Changed ChromeOS host's computer name prefix from `ChromeOS` to `Chromebook`
 - Added query to fill in `device_mapping` from ChromeOS hosts.

--- a/docs/Using-Fleet/Supported-browsers.md
+++ b/docs/Using-Fleet/Supported-browsers.md
@@ -21,6 +21,6 @@ We test each browser on Windows whenever possible, because our engineering team 
 
 ### Note
 > - Mobile web is not yet supported in the Fleet product.
-> - The Fleet user interface [may not be fully supported](https://github.com/fleetdm/fleet/issues/969) in Google Chrome when the browser is running on Chrome OS
+> - The Fleet user interface [may not be fully supported](https://github.com/fleetdm/fleet/issues/969) in Google Chrome when the browser is running on ChromeOS
 
 <meta name="pageOrderInSection" value="1200">

--- a/ee/fleetd-chrome/src/tables/os_version.test.ts
+++ b/ee/fleetd-chrome/src/tables/os_version.test.ts
@@ -1,6 +1,15 @@
 import VirtualDatabase from "../db";
+import TableOSVersion from "./os_version";
 
 describe("os_version", () => {
+  describe("getCodename", () => {
+    const sut = new TableOSVersion(null, null)
+
+    it("has the proper prefix", () => {
+      expect(sut.getCodename("10.0.0").startsWith("ChromeOS")).toBe(true)
+    })
+  })
+
   test("success", async () => {
     // @ts-expect-error Typescript doesn't include the userAgentData API yet.
     global.navigator.userAgentData = {
@@ -36,7 +45,7 @@ describe("os_version", () => {
         build: "5481",
         patch: "177",
         arch: "x86-64",
-        codename: "Chrome OS 13.2.1",
+        codename: "ChromeOS 13.2.1",
       },
     ]);
   });
@@ -77,7 +86,7 @@ describe("os_version", () => {
         build: "",
         patch: "",
         arch: "x86-64",
-        codename: "Chrome OS 13.2.1",
+        codename: "ChromeOS 13.2.1",
       },
     ]);
     expect(console.warn).toHaveBeenCalledWith(

--- a/ee/fleetd-chrome/src/tables/os_version.test.ts
+++ b/ee/fleetd-chrome/src/tables/os_version.test.ts
@@ -2,9 +2,15 @@ import VirtualDatabase from "../db";
 import TableOSVersion from "./os_version";
 
 describe("os_version", () => {
+  describe("getName", () => {
+    const sut = new TableOSVersion(null, null)
+    it("returns platform name properly formatted", () => {
+      expect(sut.getName("Chrome OS")).toBe("ChromeOS")
+    })
+  })
+
   describe("getCodename", () => {
     const sut = new TableOSVersion(null, null)
-
     it("has the proper prefix", () => {
       expect(sut.getCodename("10.0.0").startsWith("ChromeOS")).toBe(true)
     })
@@ -36,7 +42,7 @@ describe("os_version", () => {
     const res = await db.query("select * from os_version");
     expect(res).toEqual([
       {
-        name: "Chrome OS",
+        name: "ChromeOS",
         platform: "chrome",
         platform_like: "chrome",
         version: "110.0.5481.177",
@@ -77,7 +83,7 @@ describe("os_version", () => {
     const res = await db.query("select * from os_version");
     expect(res).toEqual([
       {
-        name: "Chrome OS",
+        name: "ChromeOS",
         platform: "chrome",
         platform_like: "chrome",
         version: "110.weird_version",

--- a/ee/fleetd-chrome/src/tables/os_version.ts
+++ b/ee/fleetd-chrome/src/tables/os_version.ts
@@ -15,6 +15,10 @@ export default class TableOSVersion extends Table {
     "codename",
   ];
 
+  getCodename(platformVersion: string): string {
+    return `ChromeOS ${platformVersion}`
+  }
+
   async generate() {
     // @ts-expect-error Typescript doesn't include the userAgentData API yet.
     const data = await navigator.userAgentData.getHighEntropyValues([
@@ -51,8 +55,8 @@ export default class TableOSVersion extends Table {
     // Note we can actually get the platform of Chrome running on non-ChromeOS devices, but instead
     // we just hardcode to "chrome" so that Fleet always sees this Chrome extension as a Chrome
     // device even when we are doing local dev on a non-ChromeOS machine.
-    const platform_info = await chrome.runtime.getPlatformInfo();
-    const { arch } = platform_info;
+    const platformInfo = await chrome.runtime.getPlatformInfo();
+    const { arch } = platformInfo;
 
     // Some of these values won't actually be correct on a non-chromeOS machine.
     return [
@@ -65,7 +69,7 @@ export default class TableOSVersion extends Table {
         minor,
         build,
         patch,
-        codename: `Chrome OS ${data.platformVersion}`,
+        codename: this.getCodename(data.platformVersion),
         arch: arch,
       },
     ];

--- a/ee/fleetd-chrome/src/tables/os_version.ts
+++ b/ee/fleetd-chrome/src/tables/os_version.ts
@@ -15,6 +15,10 @@ export default class TableOSVersion extends Table {
     "codename",
   ];
 
+  getName(platform: string): string {
+    return platform.replace("Chrome OS", "ChromeOS")
+  }
+
   getCodename(platformVersion: string): string {
     return `ChromeOS ${platformVersion}`
   }
@@ -61,7 +65,7 @@ export default class TableOSVersion extends Table {
     // Some of these values won't actually be correct on a non-chromeOS machine.
     return [
       {
-        name: data.platform,
+        name: this.getName(data.platform),
         platform: "chrome",
         platform_like: "chrome",
         version,

--- a/ee/fleetd-chrome/src/tables/system_info.test.ts
+++ b/ee/fleetd-chrome/src/tables/system_info.test.ts
@@ -1,0 +1,21 @@
+import TableSystemInfo from "./system_info";
+
+describe("system_info", () => {
+    describe("getComputerName", () => {
+        const sut = new TableSystemInfo(null, null)
+        it("is computed from the hostname and hw serial", () => {
+            const testCases: [string, string, string][] = [
+                [null, null, "Chromebook"],
+                [undefined, undefined, "Chromebook"],
+                ["", "", "Chromebook"],
+                ["mychromebook", "", "mychromebook"],
+                ["mychromebook", "123", "mychromebook"],
+                ["", "123", "Chromebook 123"],
+            ]
+
+            for (let [hostname, hwSerial, expected] of testCases) {
+                expect(sut.getComputerName(hostname, hwSerial)).toEqual(expected)
+            }
+        })
+    })
+})

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -465,6 +465,12 @@ var extraDetailQueries = map[string]DetailQuery{
 		Platforms:        []string{"darwin"},
 		Discovery:        discoveryTable("munki_info"),
 	},
+	// On ChromeOS, the `users` table returns only information about the primary account.
+	"chromeos_users": {
+		Query:            `SELECT email FROM user`,
+		DirectIngestFunc: directIngestChromeProfiles,
+		Platforms:        []string{"chrome"},
+	},
 	"google_chrome_profiles": {
 		Query:            `SELECT email FROM google_chrome_profiles WHERE NOT ephemeral AND email <> ''`,
 		DirectIngestFunc: directIngestChromeProfiles,

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -467,7 +467,7 @@ var extraDetailQueries = map[string]DetailQuery{
 	},
 	// On ChromeOS, the `users` table returns only the user signed into the primary chrome profile.
 	"chromeos_profile_user_info": {
-		Query:            `SELECT email FROM user`,
+		Query:            `SELECT email FROM users`,
 		DirectIngestFunc: directIngestChromeProfiles,
 		Platforms:        []string{"chrome"},
 	},

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -465,8 +465,8 @@ var extraDetailQueries = map[string]DetailQuery{
 		Platforms:        []string{"darwin"},
 		Discovery:        discoveryTable("munki_info"),
 	},
-	// On ChromeOS, the `users` table returns only information about the primary account.
-	"chromeos_users": {
+	// On ChromeOS, the `users` table returns only the user signed into the primary chrome profile.
+	"chromeos_profile_user_info": {
 		Query:            `SELECT email FROM user`,
 		DirectIngestFunc: directIngestChromeProfiles,
 		Platforms:        []string{"chrome"},

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -264,13 +264,14 @@ func TestGetDetailQueries(t *testing.T) {
 		"disk_encryption_darwin",
 		"disk_encryption_linux",
 		"disk_encryption_windows",
+		"chromeos_profile_user_info",
 	}
 
 	require.Len(t, queriesNoConfig, len(baseQueries))
 	sortedKeysCompare(t, queriesNoConfig, baseQueries)
 
 	queriesWithoutWinOSVuln := GetDetailQueries(context.Background(), config.FleetConfig{Vulnerabilities: config.VulnerabilitiesConfig{DisableWinOSVulnerabilities: true}}, nil, nil)
-	require.Len(t, queriesWithoutWinOSVuln, 24)
+	require.Len(t, queriesWithoutWinOSVuln, 25)
 
 	queriesWithUsers := GetDetailQueries(context.Background(), config.FleetConfig{App: config.AppConfig{EnableScheduledQueryStats: true}}, nil, &fleet.Features{EnableHostUsers: true})
 	qs := append(baseQueries, "users", "users_chrome", "scheduled_query_stats")


### PR DESCRIPTION
Relates to https://github.com/fleetdm/fleet/issues/11829

Updated ingestion logic and fixed ChromeOS virtual tables to accommodate the requested UI changes.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
~- [ ] Documented any permissions changes~
~- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
  ~- For Orbit and Fleet Desktop changes:~
    ~- [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    ~- [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~