### PR TITLE
Feature 1183: Updated validation rule for policies platforms

### DIFF
--- a/changes/11836-allow-users-create-chromeos-policies
+++ b/changes/11836-allow-users-create-chromeos-policies
@@ -1,0 +1,1 @@
+Allow users to create policies that target ChromeOS

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -82,7 +82,7 @@ func verifyPolicyPlatforms(platforms string) error {
 	}
 	for _, s := range strings.Split(platforms, ",") {
 		switch strings.TrimSpace(s) {
-		case "windows", "linux", "darwin":
+		case "windows", "linux", "darwin", "chrome":
 			// OK
 		default:
 			return errPolicyInvalidPlatform

--- a/server/fleet/policies_test.go
+++ b/server/fleet/policies_test.go
@@ -1,0 +1,28 @@
+package fleet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyPolicyPlatforms(t *testing.T) {
+	testCases := []struct {
+		platforms string
+		isValid   bool
+	}{
+		{"windows,chrome", true},
+		{"chrome", true},
+		{"bados", false},
+	}
+
+	for _, tc := range testCases {
+		actual := verifyPolicyPlatforms(tc.platforms)
+
+		if tc.isValid {
+			require.NoError(t, actual)
+			continue
+		}
+		require.Error(t, actual)
+	}
+}


### PR DESCRIPTION
Relates to https://github.com/fleetdm/fleet/issues/11836

Users should be able to create policies that target ChromeOS

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
~- [ ] Documented any permissions changes~
~- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [x] Added/updated tests
~- [ ] Manual QA for all new/changed functionality~
  ~- For Orbit and Fleet Desktop changes:~
    ~- [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    ~- [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
