### PR TITLE
Website: Change bootstrap class added to tables on pages built from Markdown

### DIFF
--- a/website/api/helpers/strings/to-html.js
+++ b/website/api/helpers/strings/to-html.js
@@ -125,7 +125,7 @@ module.exports = {
 
     // Creating a custom table renderer to add Bootstrap's responsive table styles to markdown tables.
     customRenderer.table = function(headerHtml, bodyHtml) {
-      return `<div class="table-responsive-xl"><table class="table">\n<thead>\n${headerHtml}\n</thead>\n<tbody>${bodyHtml}\n</tbody>\n</table>\n</div>`;
+      return `<div class="table-responsive"><table class="table">\n<thead>\n${headerHtml}\n</thead>\n<tbody>${bodyHtml}\n</tbody>\n</table>\n</div>`;
     };
 
     markedOpts.renderer = customRenderer;


### PR DESCRIPTION
Closes: #11989
Changes:
- Changed the Bootstrap 4 class that is added to every table in content built from Markdown so our tables are responsive at all widths (`table-responsive-xl` » `table-responsive`)