### PR TITLE
Upversion markdown-link-check Github action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1.0.15
+    - uses: gaurav-nelson/github-action-markdown-link-check@1.0.15
       with:
         use-quiet-mode: 'yes'
         config-file: .github/workflows/config/markdown-link-check-config.json

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,8 +28,8 @@ jobs:
       contents: read # to read files to check dead links
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # master
-    - uses: gaurav-nelson/github-action-markdown-link-check@58f84fd654812d0d8da4e4d4a559eda087daf8ce # v1.0.13
+    - uses: actions/checkout@v3
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1.0.15
       with:
         use-quiet-mode: 'yes'
         config-file: .github/workflows/config/markdown-link-check-config.json


### PR DESCRIPTION
Upversions the actions in the `docs.yaml` (markdown-link-check) github action.

Done so because of the deprecation warnings located at the bottom of this page: https://github.com/fleetdm/fleet/actions/runs/5116497962