### PR TITLE
Useful to allow easy troubleshooting of process_file_events table

### DIFF
--- a/server/fleet/agent_options.go
+++ b/server/fleet/agent_options.go
@@ -492,15 +492,19 @@ type OsqueryCommandLineFlagsMacOS struct {
 // osqueryd --help or select * from osquery_flags, so they can't be generated
 // by the osquery-agent-options script.
 type OsqueryCommandLineFlagsHidden struct {
-	AlsoLogToStderr       bool   `json:"alsologtostderr"`
-	EventsStreamingPlugin string `json:"events_streaming_plugin"`
-	LogBufSecs            int32  `json:"logbufsecs"`
-	LogDir                string `json:"log_dir"`
-	MaxLogSize            int32  `json:"max_log_size"`
-	MinLogLevel           int32  `json:"minloglevel"`
-	StopLoggingIfFullDisk bool   `json:"stop_logging_if_full_disk"`
-	AllowUnsafe           bool   `json:"allow_unsafe"`
-	TLSDump               bool   `json:"tls_dump"`
+	AlsoLogToStderr               bool   `json:"alsologtostderr"`
+	EventsStreamingPlugin         string `json:"events_streaming_plugin"`
+	LogBufSecs                    int32  `json:"logbufsecs"`
+	LogDir                        string `json:"log_dir"`
+	MaxLogSize                    int32  `json:"max_log_size"`
+	MinLogLevel                   int32  `json:"minloglevel"`
+	StopLoggingIfFullDisk         bool   `json:"stop_logging_if_full_disk"`
+	AllowUnsafe                   bool   `json:"allow_unsafe"`
+	TLSDump                       bool   `json:"tls_dump"`
+	AuditDebug                    bool   `json:"audit_debug"`
+	AuditFIMDebug                 bool   `json:"audit_fim_debug"`
+	AuditShowPartialFIMEvents     bool   `json:"audit_show_partial_fim_events"`
+	AuditShowUntrackedResWarnings bool   `json:"audit_show_untracked_res_warnings"`
 }
 
 // while ValidateJSONAgentOptions validates an entire Agent Options payload,


### PR DESCRIPTION
Useful while working on #11890.

Hidden flags `--audit_debug`, `--audit_fim_debug`, `--audit_show_partial_fim_events` and `--audit_show_untracked_res_warnings` are useful when troubleshooting the `process_file_events` table. This change allows setting the flags in the agent settings:

![Screenshot 2023-05-30 at 16 28 41](https://github.com/fleetdm/fleet/assets/2073526/cd871c4e-a228-4010-9f0c-2c2d274b6f77)