### PR TITLE
Handbook: Add clarification about packs to "Why this way"

### DIFF
--- a/handbook/company/why-this-way.md
+++ b/handbook/company/why-this-way.md
@@ -237,6 +237,15 @@ Many companies encourage salespeople to "spray and pray" email blasts, and to do
 - **Be genuine.**  No puffery. No impressive-sounding words.  We are [🟣open and outsider friendly](https://fleetdm.com/handbook/company#openness).  We expand acronyms, and insist on using simple language that lets everyone understand and contribute.  We help the people we work with grow in their careers and learn from each other.  We are sincere, curious, and [🔵fair to competitors](https://fleetdm.com/handbook/company#objectivity).
 - **Step up.** We look at the [🟠big picture](https://fleetdm.com/handbook/company#ownership).  The goal is for the organization using Fleet to be successful, as well as the individuals who decide to use or buy the product.  There are multiple versions of Fleet, and so many ways to "do" open-source security and IT.  It is in the company's best interest to help engineers pick the right one; even if that's Fleet Free, or another solution altogether.  We think about our customer's needs like they are our own.
 
+## Why don't we consider "packs" deprecated?
+
+As originally envisioned by Zach Wasserman and team when creating osquery, packs are a way to import and export queries into (and out of!) any platform that speaks osquery, whether that's Fleet, SecurityOnion, an EDR, or even Rapid7. Queries [should be portable](https://github.com/fleetdm/fleet/blob/f711e60de47c69ab8be5bc13cf73fedf88adc338/README.md#lighter-than-air) to minimize lock-in to particular tools.
+
+The "Packs" section of the UI that existed in `kolide/fleet` c. 2017 was using an overloaded definition of the word "packs". It existed as an early attempt to get to the right way of segmenting and targeting particular formations of hosts that share certain characteristics.  This came with some difficulties with debugging and collaboration, since it could be hard to tell which queries were running on which hosts. It also made it harder to understand what performance impact running all those queries might be causing.
+
+When we started adding long-requested improvements, it became clear to us that Fleet needed a better way to organize hosts, controls, reports, and configuration that wasn't tied exclusively to data collection in Splunk.  It was time to learn from the original design and come up with a way to semantically group hosts, and then apply query packs to those.
+
+The first step towards that was to add a simpler way to schedule queries, and tuck away the legacy feature called "Packs", so that "packs" refer to what they were originally: a portable way to import and export queries. Packs will always be supported in Fleet.
 
 <meta name="maintainedBy" value="mikermcneil">
 <meta name="title" value="Why this way?">

--- a/handbook/company/why-this-way.md
+++ b/handbook/company/why-this-way.md
@@ -237,15 +237,17 @@ Many companies encourage salespeople to "spray and pray" email blasts, and to do
 - **Be genuine.**  No puffery. No impressive-sounding words.  We are [🟣open and outsider friendly](https://fleetdm.com/handbook/company#openness).  We expand acronyms, and insist on using simple language that lets everyone understand and contribute.  We help the people we work with grow in their careers and learn from each other.  We are sincere, curious, and [🔵fair to competitors](https://fleetdm.com/handbook/company#objectivity).
 - **Step up.** We look at the [🟠big picture](https://fleetdm.com/handbook/company#ownership).  The goal is for the organization using Fleet to be successful, as well as the individuals who decide to use or buy the product.  There are multiple versions of Fleet, and so many ways to "do" open-source security and IT.  It is in the company's best interest to help engineers pick the right one; even if that's Fleet Free, or another solution altogether.  We think about our customer's needs like they are our own.
 
-## Why don't we consider "packs" deprecated?
+## Why does Fleet support query packs?
 
-As originally envisioned by Zach Wasserman and team when creating osquery, packs are a way to import and export queries into (and out of!) any platform that speaks osquery, whether that's Fleet, SecurityOnion, an EDR, or even Rapid7. Queries [should be portable](https://github.com/fleetdm/fleet/blob/f711e60de47c69ab8be5bc13cf73fedf88adc338/README.md#lighter-than-air) to minimize lock-in to particular tools.
+As originally envisioned by Zach Wasserman and the team when creating osquery, packs are a way to import and export queries into (and out of!) any platform that speaks osquery, whether that's Fleet, [Security Onion](https://securityonionsolutions.com/), an EDR, or even Rapid7. Queries [should be portable](https://github.com/fleetdm/fleet/blob/f711e60de47c69ab8be5bc13cf73fedf88adc338/README.md#lighter-than-air) to minimize lock-in to particular tools.
 
-The "Packs" section of the UI that existed in `kolide/fleet` c. 2017 was using an overloaded definition of the word "packs". It existed as an early attempt to get to the right way of segmenting and targeting particular formations of hosts that share certain characteristics.  This came with some difficulties with debugging and collaboration, since it could be hard to tell which queries were running on which hosts. It also made it harder to understand what performance impact running all those queries might be causing.
+The "Packs" section of the UI that began in `kolide/fleet` c. 2017 was an early attempt to  segment and target formations of hosts that share certain characteristics.  This came with some difficulties with debugging and collaboration, since it could be hard to tell which queries were running on which hosts. It also made it harder to understand what performance impact running all those queries might cause.
 
-When we started adding long-requested improvements, it became clear to us that Fleet needed a better way to organize hosts, controls, reports, and configuration that wasn't tied exclusively to data collection in Splunk.  It was time to learn from the original design and come up with a way to semantically group hosts, and then apply query packs to those.
+Eventually, when working on some related improvements, it became clear that Fleet needed a better way to organize hosts, controls, reports, and configuration that wasn't tied exclusively to data collection in Splunk.  It was time to learn from the original design and come up with a smarter way to group hosts.
 
-The first step towards that was to add a simpler way to schedule queries, and tuck away the legacy feature called "Packs", so that "packs" refer to what they were originally: a portable way to import and export queries. Packs will always be supported in Fleet.
+The first step was to add a simpler way to schedule queries, and tuck away the legacy feature called "Packs", so that "packs" refer to what they were originally: a portable way to import and export queries. 
+
+Packs will always be supported in Fleet.
 
 <meta name="maintainedBy" value="mikermcneil">
 <meta name="title" value="Why this way?">


### PR DESCRIPTION
Add clarification about what "packs" are and why they aren't considered deprecated in spite of removing the "Packs" section of the UI.

This is a modified version of [an answer](https://osquery.slack.com/archives/C01DXJL16D8/p1685473347649069?thread_ts=1685447394.383489&cid=C01DXJL16D8) @mikermcneil posted in the osquery slack. I trimmed a little bit of the content in hopes of making this clearer (namely the specific list of improvements that led to removing the "Packs" UI) but if you think that context is too important to leave out I'll include it here.

.