### PR TITLE
Schema: Remove `platforms` for columns that are compatible with all platforms.

### DIFF
--- a/schema/tables/chrome_extensions.yml
+++ b/schema/tables/chrome_extensions.yml
@@ -59,11 +59,6 @@ columns:
   - name: path
     type: string
     description: Defaults to '' on ChromeOS
-    platforms: 
-      - darwin
-      - windows
-      - linux
-      - chromeos
   - name: optional_permissions
     platforms: 
       - darwin
@@ -91,11 +86,6 @@ columns:
       - linux
   - name: state
     type: string
-    platforms: 
-      - darwin
-      - windows
-      - linux
-      - chromeos
   - name: install_time
     platforms: 
       - darwin

--- a/schema/tables/system_info.yml
+++ b/schema/tables/system_info.yml
@@ -58,64 +58,24 @@ columns:
   - name: hostname
     type: string
     description: For ChromeOS, this is only available if the extension was force-installed by an enterprise policy
-    platforms:
-      - darwin
-      - windows
-      - linux
-      - chromeos
   - name: computer_name
     type: string
     description: For ChromeOS, if the extension wasn't force-installed by an enterprise policy this will default to 'ChromeOS' only
-    platforms:
-      - darwin
-      - windows
-      - linux
-      - chromeos
   - name: hardware_serial
     type: string
     description: The device's serial number (For chromeos, this is only available if the extension was force-installed by an enterprise policy)
-    platforms:
-      - darwin
-      - windows
-      - linux
-      - chromeos
   - name: hardware_vendor
     type: string
     description: For ChromeOS, this is only available if the extension was force-installed by an enterprise policy
-    platforms:
-      - darwin
-      - windows
-      - linux
-      - chromeos
   - name: hardware_model
     type: string
     description: For ChromeOS, this is only available if the extension was force-installed by an enterprise policy
-    platforms:
-      - darwin
-      - windows
-      - linux
-      - chromeos
   - name: cpu_brand
     type: string
-    platforms:
-      - darwin
-      - windows
-      - linux
-      - chromeos
   - name: cpu_type
     type: string
-    platforms:
-      - darwin
-      - windows
-      - linux
-      - chromeos
   - name: physical_memory
     type: string
-    platforms:
-      - darwin
-      - windows
-      - linux
-      - chromeos
 
 examples: >-
   See the CPU architecture of a machine as well as who made it and what its

--- a/schema/tables/users.yml
+++ b/schema/tables/users.yml
@@ -44,11 +44,6 @@ columns:
       - windows
       - linux
   - name: uuid
-    platforms:
-      - darwin
-      - windows
-      - linux
-      - chromeos
   - name: email
     required: false
     type: string
@@ -66,8 +61,3 @@ columns:
       - linux
   - name: username
     description: Username
-    platforms:
-      - darwin
-      - windows
-      - linux
-      - chromeos


### PR DESCRIPTION
Changes:
- Removed the `platforms` value of columns that support all platforms on the schema tables added in https://github.com/fleetdm/fleet/pull/11784. Columns in our YAML table overrides should only have a `platforms` value if it is not compatible with all platforms
