### PR TITLE
Fleet UI (Unreleased bug): Fix edit policy and query pencil icon

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -328,14 +328,13 @@ const PolicyForm = ({
               isFocused={isEditingName}
             />
             <Button
-              variant="small-icon"
+              variant="text-icon"
               className="edit-link"
               onClick={() => setIsEditingName(true)}
             >
               <Icon
                 name="pencil"
                 className={`edit-icon ${isEditingName ? "hide" : ""}`}
-                size="small"
               />
             </Button>
           </div>
@@ -377,7 +376,6 @@ const PolicyForm = ({
               <Icon
                 name="pencil"
                 className={`edit-icon ${isEditingDescription ? "hide" : ""}`}
-                size="small"
               />
             </Button>
           </div>
@@ -409,14 +407,13 @@ const PolicyForm = ({
               isFocused={isEditingResolution}
             />
             <Button
-              variant="small-icon"
+              variant="text-icon"
               className="edit-link"
               onClick={() => setIsEditingResolution(true)}
             >
               <Icon
                 name="pencil"
                 className={`edit-icon ${isEditingResolution ? "hide" : ""}`}
-                size="small"
               />
             </Button>
           </div>

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
@@ -42,7 +42,7 @@
     .edit-link {
       cursor: pointer;
       padding-left: $pad-small;
-      height: 16px;
+      height: 18px;
     }
 
     .name-description-resolve {

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -345,14 +345,13 @@ const QueryForm = ({
               isFocused={isEditingName}
             />
             <Button
-              variant="small-icon"
+              variant="text-icon"
               className="edit-link"
               onClick={() => setIsEditingName(true)}
             >
               <Icon
                 name="pencil"
                 className={`edit-icon ${isEditingName ? "hide" : ""}`}
-                size="small"
               />
             </Button>
           </div>
@@ -381,14 +380,13 @@ const QueryForm = ({
               isFocused={isEditingDescription}
             />
             <Button
-              variant="small-icon"
+              variant="text-icon"
               className="edit-link"
               onClick={() => setIsEditingDescription(true)}
             >
               <Icon
                 name="pencil"
                 className={`edit-icon ${isEditingDescription ? "hide" : ""}`}
-                size="small"
               />
             </Button>
           </div>

--- a/frontend/pages/queries/QueryPage/components/QueryForm/_styles.scss
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/_styles.scss
@@ -42,7 +42,7 @@
     .edit-link {
       cursor: pointer;
       padding-left: $pad-small;
-      height: 16px;
+      height: 18px;
     }
 
     .name-description {


### PR DESCRIPTION
## Issue
Cerra #12016

## Fix
- Button variant "icon" and "small-icon" has padding built in, but for these icons, they aren't on your typical button causing it to be hidden in the UI
- Fix is by using "text-icon" variant which more relates to what this is, an icon inline with text.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

