### PR TITLE
read orbit profile configuration values using osascript in macOS

### DIFF
--- a/orbit/changes/11692-profile-config-read
+++ b/orbit/changes/11692-profile-config-read
@@ -1,0 +1,1 @@
+* Improve the logic to read enroll secrets from macOS configuration profiles to be compatible with different MDM providers.

--- a/orbit/pkg/profiles/profiles_darwin_test.go
+++ b/orbit/pkg/profiles/profiles_darwin_test.go
@@ -5,7 +5,6 @@ package profiles
 import (
 	"bytes"
 	"errors"
-	"io"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -19,18 +18,38 @@ func TestGetFleetdConfig(t *testing.T) {
 		cmdOut  *string
 		cmdErr  error
 		wantOut *fleet.MDMAppleFleetdConfig
-		wantErr error
+		wantErr string
 	}{
-		{nil, testErr, nil, testErr},
-		{ptr.String("invalid-xml"), nil, nil, io.EOF},
-		{&emptyOutput, nil, nil, ErrNotFound},
-		{&withFleetdConfig, nil, &fleet.MDMAppleFleetdConfig{EnrollSecret: "ENROLL_SECRET", FleetURL: "https://test.example.com"}, nil},
+		{nil, testErr, nil, testErr.Error()},
+		{ptr.String("invalid-json"), nil, nil, "unmarshaling configuration"},
+		{ptr.String("{}"), nil, nil, ErrNotFound.Error()},
+		{
+			ptr.String(`{"EnrollSecret": "ENROLL_SECRET", "FleetURL": "https://test.example.com"}`),
+			nil,
+			&fleet.MDMAppleFleetdConfig{
+				EnrollSecret: "ENROLL_SECRET",
+				FleetURL:     "https://test.example.com",
+			},
+			"",
+		},
+		{
+			ptr.String(`{"EnrollSecret": "ENROLL_SECRET", "FleetURL": ""}`),
+			nil,
+			nil,
+			ErrNotFound.Error(),
+		},
+		{
+			ptr.String(`{"EnrollSecret": "", "FleetURL": "https://test.example.com"}`),
+			nil,
+			nil,
+			ErrNotFound.Error(),
+		},
 	}
 
-	origExecProfileCmd := execProfileCmd
-	t.Cleanup(func() { execProfileCmd = origExecProfileCmd })
+	origExecScript := execScript
+	t.Cleanup(func() { execScript = origExecScript })
 	for _, c := range cases {
-		execProfileCmd = func() (*bytes.Buffer, error) {
+		execScript = func(script string) (*bytes.Buffer, error) {
 			if c.cmdOut == nil {
 				return nil, c.cmdErr
 			}
@@ -41,69 +60,12 @@ func TestGetFleetdConfig(t *testing.T) {
 		}
 
 		out, err := GetFleetdConfig()
-		require.ErrorIs(t, err, c.wantErr)
+		if c.wantErr != "" {
+			require.ErrorContains(t, err, c.wantErr)
+		} else {
+			require.NoError(t, err)
+		}
 		require.Equal(t, c.wantOut, out)
 	}
 
 }
-
-var (
-	emptyOutput = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict/>
-</plist>`
-
-	withFleetdConfig = `
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>_computerlevel</key>
-	<array>
-		<dict>
-			<key>ProfileDescription</key>
-			<string>test descripiton</string>
-			<key>ProfileDisplayName</key>
-			<string>test name</string>
-			<key>ProfileIdentifier</key>
-			<string>com.fleetdm.fleetd.config</string>
-			<key>ProfileInstallDate</key>
-			<string>2023-02-27 18:55:07 +0000</string>
-			<key>ProfileItems</key>
-			<array>
-				<dict>
-					<key>PayloadContent</key>
-					<dict>
-						<key>EnrollSecret</key>
-						<string>ENROLL_SECRET</string>
-						<key>FleetURL</key>
-						<string>https://test.example.com</string>
-					</dict>
-					<key>PayloadDescription</key>
-					<string>test description</string>
-					<key>PayloadDisplayName</key>
-					<string>test name</string>
-					<key>PayloadIdentifier</key>
-					<string>com.fleetdm.fleetd.config</string>
-					<key>PayloadType</key>
-					<string>com.fleetdm.fleetd</string>
-					<key>PayloadUUID</key>
-					<string>0C6AFB45-01B6-4E19-944A-123CD16381C7</string>
-					<key>PayloadVersion</key>
-					<integer>1</integer>
-				</dict>
-			</array>
-			<key>ProfileRemovalDisallowed</key>
-			<string>true</string>
-			<key>ProfileType</key>
-			<string>Configuration</string>
-			<key>ProfileUUID</key>
-			<string>8D0F62E6-E24F-4B2F-AFA8-CAC1F07F4FDC</string>
-			<key>ProfileVersion</key>
-			<integer>1</integer>
-		</dict>
-	</array>
-</dict>
-</plist>`
-)


### PR DESCRIPTION
The current approach to read the enroll secret and fleet url from a configuration profile is not ideal because:

1. (important) We're looking for a profile with a `ProfileIdentifier` equal to `com.fleetdm.fleetd.config`. This is not ideal because `ProfileIdentifier` is often modified by MDM vendors to ensure that's unique across all profiles in the system.
2. (nit) To look for the relevant profile, we were running `profiles list -o stdout-xml`, which can output a large amount of data that we need to parse and loop through to find the right profile.

I have also considered:

1. Reading the value from a file that gets created at `/Library/Managed Preferences/com.fleetdm.fleetd.config.plist`, but I couldn't find any official sources on the reliablity of this, and after consulting internally and in the macAdmins slack I decided to not rely on it.
2. Keep on reading from the output of `profiles` but be smarter parsing the output (we should still be able to find the right profile)

At the end, I decided to use osascript to read the value directly from the system.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
