### PR TITLE
Add codecov token for repo

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -100,7 +100,7 @@ jobs:
           make test-go 2>&1 | tee /tmp/gotest.log
 
     - name: Upload to Codecov
-      uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
+      uses: codecov/codecov-action@v3
       with:
         files: coverage.txt
         flags: backend

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
         yarn test:ci
 
     - name: Upload to Codecov
-      uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
+      uses: codecov/codecov-action@v3
       with:
         flags: frontend
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  token: 55f60f3b-5cf1-4e6a-a98b-6f32bc840b7b
+
 coverage:
   status:
     project: false

--- a/frontend/utilities/url/index.ts
+++ b/frontend/utilities/url/index.ts
@@ -70,6 +70,16 @@ export const reconcileMutuallyInclusiveHostParams = ({
   // ensure macos_settings filter is always applied in
   // conjuction with a team_id, 0 (no teams) by default
   const reconciled = { macos_settings: macSettingsStatus, team_id: teamId };
+
+  const testHere = () => {
+    console.log("testHere");
+  };
+
+  if (false) {
+    console.log("testHere");
+    testHere();
+  }
+
   if (macSettingsStatus) {
     reconciled.team_id = teamId ?? 0;
   }


### PR DESCRIPTION
add codecov repo token for uploading codecov report. This is recommended to prevent against GitHub action rate limits preventing codecov from uploading the report https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954