### PR TITLE
Fleet UI: Add ChromeOS to user flows related to policies

### DIFF
--- a/frontend/components/PlatformSelector/PlatformSelector.stories.tsx
+++ b/frontend/components/PlatformSelector/PlatformSelector.stories.tsx
@@ -10,9 +10,11 @@ const meta: Meta<typeof PlatformSelector> = {
     checkDarwin: true,
     checkWindows: true,
     checkLinux: false,
+    checkChrome: false,
     setCheckDarwin: noop,
     setCheckWindows: noop,
     setCheckLinux: noop,
+    setCheckChrome: noop,
   },
 };
 

--- a/frontend/components/PlatformSelector/PlatformSelector.tsx
+++ b/frontend/components/PlatformSelector/PlatformSelector.tsx
@@ -6,9 +6,11 @@ interface IPlatformSelectorProps {
   checkDarwin: boolean;
   checkWindows: boolean;
   checkLinux: boolean;
+  checkChrome: boolean;
   setCheckDarwin: (val: boolean) => void;
   setCheckWindows: (val: boolean) => void;
   setCheckLinux: (val: boolean) => void;
+  setCheckChrome: (val: boolean) => void;
 }
 
 export const PlatformSelector = ({
@@ -16,9 +18,11 @@ export const PlatformSelector = ({
   checkDarwin,
   checkWindows,
   checkLinux,
+  checkChrome,
   setCheckDarwin,
   setCheckWindows,
   setCheckLinux,
+  setCheckChrome,
 }: IPlatformSelectorProps): JSX.Element => {
   const baseClass = "platform-selector";
 
@@ -47,6 +51,13 @@ export const PlatformSelector = ({
             wrapperClassName={`${baseClass}__platform-checkbox-wrapper`}
           >
             Linux
+          </Checkbox>
+          <Checkbox
+            value={checkChrome}
+            onChange={(value: boolean) => setCheckChrome(value)}
+            wrapperClassName={`${baseClass}__platform-checkbox-wrapper`}
+          >
+            ChromeOS
           </Checkbox>
         </span>
       </span>

--- a/frontend/hooks/usePlatformSelector.tsx
+++ b/frontend/hooks/usePlatformSelector.tsx
@@ -7,7 +7,11 @@ import PlatformSelector from "components/PlatformSelector";
 
 export interface IPlatformSelector {
   setSelectedPlatforms: (platforms: string[]) => void;
+<<<<<<< HEAD
   getSelectedPlatforms: () => ("darwin" | "windows" | "linux" | "chrome")[];
+=======
+  getSelectedPlatforms: () => ("darwin" | "linux" | "windows" | "chrome")[];
+>>>>>>> 7dcd68424 (Update policies page, dependent on queries page merged first)
   isAnyPlatformSelected: boolean;
   render: () => JSX.Element;
 }
@@ -19,17 +23,20 @@ const usePlatformSelector = (
   const [checkDarwin, setCheckDarwin] = useState(false);
   const [checkWindows, setCheckWindows] = useState(false);
   const [checkLinux, setCheckLinux] = useState(false);
+  const [checkChrome, setCheckChrome] = useState(false);
 
   const checksByPlatform: Record<string, boolean> = {
     darwin: checkDarwin,
     windows: checkWindows,
     linux: checkLinux,
+    chrome: checkChrome,
   };
 
   const settersByPlatform: Record<string, (val: boolean) => void> = {
     darwin: setCheckDarwin,
     windows: setCheckWindows,
     linux: setCheckLinux,
+    chrome: setCheckChrome,
   };
 
   const setSelectedPlatforms = (platformsToCheck: string[]) => {
@@ -46,7 +53,7 @@ const usePlatformSelector = (
 
   useEffect(() => {
     if (platformContext === "") {
-      setSelectedPlatforms(["darwin", "windows", "linux"]);
+      setSelectedPlatforms(["darwin", "windows", "linux", "chrome"]);
     }
     platformContext && setSelectedPlatforms(platformContext.split(","));
   }, [platformContext]);
@@ -58,12 +65,14 @@ const usePlatformSelector = (
         checkDarwin={checkDarwin}
         checkWindows={checkWindows}
         checkLinux={checkLinux}
+        checkChrome={checkChrome}
         setCheckDarwin={setCheckDarwin}
         setCheckWindows={setCheckWindows}
         setCheckLinux={setCheckLinux}
+        setCheckChrome={setCheckChrome}
       />
     );
-  }, [checkDarwin, checkWindows, checkLinux]);
+  }, [checkDarwin, checkWindows, checkLinux, checkChrome]);
 
   return {
     setSelectedPlatforms,

--- a/frontend/hooks/usePlatformSelector.tsx
+++ b/frontend/hooks/usePlatformSelector.tsx
@@ -7,11 +7,7 @@ import PlatformSelector from "components/PlatformSelector";
 
 export interface IPlatformSelector {
   setSelectedPlatforms: (platforms: string[]) => void;
-<<<<<<< HEAD
   getSelectedPlatforms: () => ("darwin" | "windows" | "linux" | "chrome")[];
-=======
-  getSelectedPlatforms: () => ("darwin" | "linux" | "windows" | "chrome")[];
->>>>>>> 7dcd68424 (Update policies page, dependent on queries page merged first)
   isAnyPlatformSelected: boolean;
   render: () => JSX.Element;
 }

--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -5,8 +5,12 @@ export type IOsqueryPlatform =
   | "Windows"
   | "linux"
   | "Linux"
+<<<<<<< HEAD
   | "chrome"
   | "ChromeOS";
+=======
+  | "chrome";
+>>>>>>> 02540d807 (Add platform)
 
 export type ISelectedPlatform =
   | "all"

--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -5,12 +5,8 @@ export type IOsqueryPlatform =
   | "Windows"
   | "linux"
   | "Linux"
-<<<<<<< HEAD
   | "chrome"
   | "ChromeOS";
-=======
-  | "chrome";
->>>>>>> 02540d807 (Add platform)
 
 export type ISelectedPlatform =
   | "all"


### PR DESCRIPTION
## Issue
Cerra #11835 

## Description
- Confirm new addition of Compatibility checker for editing/creating a policy (should be work from 11832)
- Adds Checks on checkboxes to override compatibility checker
- Adds ChromeOS to platform for selecting target (should be work from 11832)

## Screenshots
<img width="690" alt="Screenshot 2023-06-01 at 2 00 09 PM" src="https://github.com/fleetdm/fleet/assets/71795832/a67ba8ca-96f5-4f16-a2b7-f6e199a490bc">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`. (Written by backend work already)
- [x] Manual QA for all new/changed functionality