### PR TITLE
Bug: spec/labels endpoint should include the id

### DIFF
--- a/changes/bug_spec_labels_api_not_including_ids
+++ b/changes/bug_spec_labels_api_not_including_ids
@@ -1,0 +1,1 @@
+- GET /api/v1/fleet/spec/labels/{name} endpoint should include the label id

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -140,7 +140,7 @@ func (ds *Datastore) GetLabelSpecs(ctx context.Context) ([]*fleet.LabelSpec, err
 func (ds *Datastore) GetLabelSpec(ctx context.Context, name string) (*fleet.LabelSpec, error) {
 	var specs []*fleet.LabelSpec
 	query := `
-SELECT name, description, query, platform, label_type, label_membership_type
+SELECT id, name, description, query, platform, label_type, label_membership_type
 FROM labels
 WHERE name = ?
 `

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/test"
+	"github.com/google/go-cmp/cmp"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -708,7 +709,10 @@ func testLabelsGetSpec(t *testing.T, ds *Datastore) {
 	for _, s := range expectedSpecs {
 		spec, err := ds.GetLabelSpec(context.Background(), s.Name)
 		require.Nil(t, err)
-		assert.Equal(t, s, spec)
+
+		require.True(t, cmp.Equal(s, spec, cmp.FilterPath(func(p cmp.Path) bool {
+			return p.String() == "ID"
+		}, cmp.Ignore())))
 	}
 }
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -3185,6 +3185,7 @@ func (s *integrationTestSuite) TestLabelSpecs() {
 	var getResp getLabelSpecResponse
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/spec/labels/%s", url.PathEscape(name)), nil, http.StatusOK, &getResp)
 	assert.Equal(t, name, getResp.Spec.Name)
+	assert.NotEqual(t, 0, getResp.Spec.ID)
 
 	// get a non-existing label spec
 	s.DoJSON("GET", "/api/latest/fleet/spec/labels/zzz", nil, http.StatusNotFound, &getResp)


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
~- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
~- [ ] Documented any permissions changes~
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
~- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
~- [ ] Added/updated tests~
- [x] Manual QA for all new/changed functionality
  ~- For Orbit and Fleet Desktop changes:~
    ~- [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    ~- [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
