### PR TITLE
handle "modified" and "deleted" operation types in DEP sync

### DIFF
--- a/changes/10605-abm-assignment
+++ b/changes/10605-abm-assignment
@@ -1,0 +1,3 @@
+* Improved ingestion of MDM devices from ABM:
+  - If a device's operation_type is `modified`, but the device doesn't exists in Fleet yet, a DEP profile will be assigned to the device and a new record will be created in Fleet.
+  - If a devive's operation_type is `deleted`, the device won't be prompted to migrate to Fleet if the feature has been configured.

--- a/changes/10605-abm-assignment
+++ b/changes/10605-abm-assignment
@@ -1,3 +1,3 @@
 * Improved ingestion of MDM devices from ABM:
-  - If a device's operation_type is `modified`, but the device doesn't exists in Fleet yet, a DEP profile will be assigned to the device and a new record will be created in Fleet.
-  - If a devive's operation_type is `deleted`, the device won't be prompted to migrate to Fleet if the feature has been configured.
+  - If a device's operation_type is `modified`, but the device doesn't exist in Fleet yet, a DEP profile will be assigned to the device and a new record will be created in Fleet.
+  - If a device's operation_type is `deleted`, the device won't be prompted to migrate to Fleet if the feature has been configured.

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -62,6 +62,7 @@ func TestMDMApple(t *testing.T) {
 		{"TestSetVerifiedMacOSProfiles", testSetVerifiedMacOSProfiles},
 		{"TestMDMAppleConfigProfileHash", testMDMAppleConfigProfileHash},
 		{"TestMatchMDMAppleConfigProfiles", testMatchMDMAppleConfigProfiles},
+		{"TestMDMAppleDeleteHostDEPAssignments", testMDMAppleDeleteHostDEPAssignments},
 	}
 
 	for _, c := range cases {
@@ -438,20 +439,21 @@ func TestIngestMDMAppleDevicesFromDEPSync(t *testing.T) {
 
 	// mock results incoming from depsync.Syncer
 	depDevices := []godep.Device{
-		{SerialNumber: "abc", Model: "MacBook Pro", OS: "OSX", OpType: "added"},                   // ingested; new serial, macOS, "added" op type
-		{SerialNumber: "abc", Model: "MacBook Pro", OS: "OSX", OpType: "added"},                   // not ingested; duplicate serial
-		{SerialNumber: hosts[0].HardwareSerial, Model: "MacBook Pro", OS: "OSX", OpType: "added"}, // not ingested; existing serial
-		{SerialNumber: "ijk", Model: "MacBook Pro", OS: "", OpType: "added"},                      // ingested; empty OS
-		{SerialNumber: "tuv", Model: "MacBook Pro", OS: "OSX", OpType: "modified"},                // not ingested; op type "modified"
-		{SerialNumber: "xyz", Model: "MacBook Pro", OS: "OSX", OpType: "updated"},                 // not ingested; op type "updated"
-		{SerialNumber: "xyz", Model: "MacBook Pro", OS: "OSX", OpType: "deleted"},                 // not ingested; op type "deleted"
-		{SerialNumber: "xyz", Model: "MacBook Pro", OS: "OSX", OpType: "added"},                   // ingested; new serial, macOS, "added" op type
+		{SerialNumber: "abc", Model: "MacBook Pro", OS: "OSX", OpType: "added"},                      // ingested; new serial, macOS, "added" op type
+		{SerialNumber: "abc", Model: "MacBook Pro", OS: "OSX", OpType: "added"},                      // not ingested; duplicate serial
+		{SerialNumber: hosts[0].HardwareSerial, Model: "MacBook Pro", OS: "OSX", OpType: "added"},    // not ingested; existing serial
+		{SerialNumber: "ijk", Model: "MacBook Pro", OS: "", OpType: "added"},                         // ingested; empty OS
+		{SerialNumber: "tuv", Model: "MacBook Pro", OS: "OSX", OpType: "modified"},                   // ingested; op type "modified", but new serial
+		{SerialNumber: hosts[1].HardwareSerial, Model: "MacBook Pro", OS: "OSX", OpType: "modified"}, // not ingested; op type "modified", existing serial
+		{SerialNumber: "xyz", Model: "MacBook Pro", OS: "OSX", OpType: "updated"},                    // not ingested; op type "updated"
+		{SerialNumber: "xyz", Model: "MacBook Pro", OS: "OSX", OpType: "deleted"},                    // not ingested; op type "deleted"
+		{SerialNumber: "xyz", Model: "MacBook Pro", OS: "OSX", OpType: "added"},                      // ingested; new serial, macOS, "added" op type
 	}
-	wantSerials = append(wantSerials, "abc", "xyz", "ijk")
+	wantSerials = append(wantSerials, "abc", "xyz", "ijk", "tuv")
 
 	n, tmID, err := ds.IngestMDMAppleDevicesFromDEPSync(ctx, depDevices)
 	require.NoError(t, err)
-	require.Equal(t, int64(3), n) // 3 new hosts ("abc", "xyz", "ijk")
+	require.EqualValues(t, 4, n) // 4 new hosts ("abc", "xyz", "ijk", "tuv")
 	require.Nil(t, tmID)
 
 	hosts = listHostsCheckCount(t, ds, fleet.TeamFilter{User: test.UserAdmin}, fleet.HostListOptions{}, len(wantSerials))
@@ -4321,6 +4323,51 @@ func testMatchMDMAppleConfigProfiles(t *testing.T, ds *Datastore) {
 			matches, err := ds.MatchMDMAppleConfigProfiles(ctx, c.hashes)
 			require.NoError(t, err)
 			require.ElementsMatch(t, c.teamIDs, matches)
+		})
+	}
+}
+
+func testMDMAppleDeleteHostDEPAssignments(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+		err  string
+	}{
+		{"no serials provided", []string{}, []string{"foo", "bar", "baz"}, ""},
+		{"no matching serials", []string{"oof", "rab"}, []string{"foo", "bar", "baz"}, ""},
+		{"partial matches", []string{"foo", "rab"}, []string{"bar", "baz"}, ""},
+		{"all matching", []string{"foo", "bar", "baz"}, []string{}, ""},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			devices := []godep.Device{
+				{SerialNumber: "foo"},
+				{SerialNumber: "bar"},
+				{SerialNumber: "baz"},
+			}
+			_, _, err := ds.IngestMDMAppleDevicesFromDEPSync(ctx, devices)
+			require.NoError(t, err)
+
+			err = ds.DeleteHostDEPAssignments(ctx, tt.in)
+			if tt.err == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.err)
+			}
+			var got []string
+			ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+				return sqlx.SelectContext(
+					ctx, q, &got,
+					`SELECT hardware_serial FROM hosts h
+                                         JOIN host_dep_assignments hda ON hda.host_id = h.id
+                                         WHERE hda.deleted_at IS NULL`,
+				)
+			})
+			require.ElementsMatch(t, tt.want, got)
 		})
 	}
 }

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -3964,5 +3964,10 @@ func (ds *Datastore) GetMatchingHostSerials(ctx context.Context, serials []strin
 		}
 		result[serial] = struct{}{}
 	}
+
+	if err := rows.Err(); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "scanning rows")
+	}
+
 	return result, nil
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -965,8 +965,8 @@ type Datastore interface {
 	// a map with all the matching serial numbers in the database.
 	GetMatchingHostSerials(ctx context.Context, serials []string) (map[string]struct{}, error)
 
-	// DeleteHostDEPAssignments deletes entries in host_dep_assignments for
-	// host with matching serials.
+	// DeleteHostDEPAssignments marks as deleted entries in
+	// host_dep_assignments for host with matching serials.
 	DeleteHostDEPAssignments(ctx context.Context, serials []string) error
 }
 

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -960,6 +960,14 @@ type Datastore interface {
 	// Get the profile UUID and last update timestamp for the default setup
 	// assistant for a team or no team.
 	GetMDMAppleDefaultSetupAssistant(ctx context.Context, teamID *uint) (profileUUID string, updatedAt time.Time, err error)
+
+	// GetMatchingHostSerials receives a list of serial numbers and returns
+	// a map with all the matching serial numbers in the database.
+	GetMatchingHostSerials(ctx context.Context, serials []string) (map[string]struct{}, error)
+
+	// DeleteHostDEPAssignments deletes entries in host_dep_assignments for
+	// host with matching serials.
+	DeleteHostDEPAssignments(ctx context.Context, serials []string) error
 }
 
 const (

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -374,20 +374,7 @@ func NewDEPService(
 		depStorage,
 		depsync.WithLogger(logging.NewNanoDEPLogger(kitlog.With(logger, "component", "nanodep-syncer"))),
 		depsync.WithCallback(func(ctx context.Context, isFetch bool, resp *godep.DeviceResponse) error {
-			n, teamID, err := ds.IngestMDMAppleDevicesFromDEPSync(ctx, resp.Devices)
-			switch {
-			case err != nil:
-				level.Error(kitlog.With(logger)).Log("err", err)
-				sentry.CaptureException(err)
-			case n > 0:
-				level.Info(kitlog.With(logger)).Log("msg", fmt.Sprintf("added %d new mdm device(s) to pending hosts", n))
-			case n == 0:
-				level.Info(kitlog.With(logger)).Log("msg", "no DEP hosts to add")
-			}
-
-			// at this point, the hosts rows are created for the devices, with the
-			// correct team_id, so we know what team-specific profile needs to be applied.
-			return depSvc.processDeviceResponse(ctx, depClient, resp, teamID)
+			return depSvc.processDeviceResponse(ctx, depClient, resp)
 		}),
 	)
 
@@ -397,12 +384,80 @@ func NewDEPService(
 // processDeviceResponse processes the device response from the device sync
 // DEP API endpoints and assigns the profile UUID associated with the DEP
 // client DEP name.
-func (d *DEPService) processDeviceResponse(ctx context.Context, depClient *godep.Client, resp *godep.DeviceResponse, tmID *uint) error {
+func (d *DEPService) processDeviceResponse(ctx context.Context, depClient *godep.Client, resp *godep.DeviceResponse) error {
 	if len(resp.Devices) < 1 {
 		// no devices means we can't assign anything
 		return nil
 	}
 
+	var addedDevices []godep.Device
+	var deletedSerials []string
+	var modifiedDevices []godep.Device
+	var modifiedSerials []string
+	for _, device := range resp.Devices {
+		level.Debug(d.logger).Log(
+			"msg", "device",
+			"serial_number", device.SerialNumber,
+			"device_assigned_by", device.DeviceAssignedBy,
+			"device_assigned_date", device.DeviceAssignedDate,
+			"op_date", device.OpDate,
+			"op_type", device.OpType,
+			"profile_assign_time", device.ProfileAssignTime,
+			"push_push_time", device.ProfilePushTime,
+			"profile_uuid", device.ProfileUUID,
+		)
+
+		switch device.OpType {
+		// The op_type field is only applicable with the SyncDevices API call,
+		// Empty op_type come from the first call to FetchDevices without a cursor,
+		// and we do want to assign profiles to them.
+		case "added", "":
+			addedDevices = append(addedDevices, device)
+		case "modified":
+			modifiedDevices = append(modifiedDevices, device)
+			modifiedSerials = append(modifiedSerials, device.SerialNumber)
+		case "deleted":
+			deletedSerials = append(deletedSerials, device.SerialNumber)
+		default:
+			level.Warn(d.logger).Log(
+				"msg", "unrecognized op_type",
+				"op_type", device.OpType,
+				"serial_number", device.SerialNumber,
+			)
+		}
+	}
+
+	existingSerials, err := d.ds.GetMatchingHostSerials(ctx, modifiedSerials)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get matching host serials")
+	}
+
+	// treat device that's coming as "modified" but doesn't exist in the
+	// `hosts` table, as an "added" device.
+	for _, d := range modifiedDevices {
+		if _, ok := existingSerials[d.SerialNumber]; !ok {
+			addedDevices = append(addedDevices, d)
+		}
+	}
+
+	err = d.ds.DeleteHostDEPAssignments(ctx, deletedSerials)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "deleting DEP assignments")
+	}
+
+	n, tmID, err := d.ds.IngestMDMAppleDevicesFromDEPSync(ctx, addedDevices)
+	switch {
+	case err != nil:
+		level.Error(kitlog.With(d.logger)).Log("err", err)
+		sentry.CaptureException(err)
+	case n > 0:
+		level.Info(kitlog.With(d.logger)).Log("msg", fmt.Sprintf("added %d new mdm device(s) to pending hosts", n))
+	case n == 0:
+		level.Info(kitlog.With(d.logger)).Log("msg", "no DEP hosts to add")
+	}
+
+	// at this point, the hosts rows are created for the devices, with the
+	// correct team_id, so we know what team-specific profile needs to be applied.
 	var appleBMTeam *fleet.Team
 	if tmID != nil {
 		tm, err := d.ds.Team(ctx, *tmID)
@@ -429,34 +484,9 @@ func (d *DEPService) processDeviceResponse(ctx context.Context, depClient *godep
 		return nil
 	}
 
-	var serials []string
-	for _, device := range resp.Devices {
-		level.Debug(d.logger).Log(
-			"msg", "device",
-			"serial_number", device.SerialNumber,
-			"device_assigned_by", device.DeviceAssignedBy,
-			"device_assigned_date", device.DeviceAssignedDate,
-			"op_date", device.OpDate,
-			"op_type", device.OpType,
-			"profile_assign_time", device.ProfileAssignTime,
-			"push_push_time", device.ProfilePushTime,
-			"profile_uuid", device.ProfileUUID,
-		)
-		// We currently only listen for an op_type of "added", the other
-		// op_types are ambiguous and it would be needless to assign the
-		// profile UUID every single time we get an update.
-		if strings.ToLower(device.OpType) == "added" ||
-			// The op_type field is only applicable with the SyncDevices API call,
-			// Empty op_type come from the first call to FetchDevices without a cursor,
-			// and we do want to assign profiles to them.
-			strings.ToLower(device.OpType) == "" {
-			serials = append(serials, device.SerialNumber)
-		}
-	}
-
 	logger := kitlog.With(d.logger, "profile_uuid", profUUID)
 
-	if len(serials) < 1 {
+	if len(addedDevices) < 1 {
 		level.Debug(logger).Log(
 			"msg", "no serials to assign",
 			"devices", len(resp.Devices),
@@ -464,11 +494,16 @@ func (d *DEPService) processDeviceResponse(ctx context.Context, depClient *godep
 		return nil
 	}
 
-	apiResp, err := depClient.AssignProfile(ctx, DEPName, profUUID, serials...)
+	var addedSerials []string
+	for _, d := range addedDevices {
+		addedSerials = append(addedSerials, d.SerialNumber)
+	}
+
+	apiResp, err := depClient.AssignProfile(ctx, DEPName, profUUID, addedSerials...)
 	if err != nil {
 		level.Info(logger).Log(
 			"msg", "assign profile",
-			"devices", len(serials),
+			"devices", len(addedSerials),
 			"err", err,
 		)
 		return fmt.Errorf("assign profile: %w", err)
@@ -476,7 +511,7 @@ func (d *DEPService) processDeviceResponse(ctx context.Context, depClient *godep
 
 	logs := []interface{}{
 		"msg", "profile assigned",
-		"devices", len(serials),
+		"devices", len(addedSerials),
 	}
 	logs = append(logs, logCountsForResults(apiResp.Devices)...)
 	level.Info(logger).Log(logs...)

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -407,7 +407,7 @@ func (d *DEPService) processDeviceResponse(ctx context.Context, depClient *godep
 			"profile_uuid", device.ProfileUUID,
 		)
 
-		switch device.OpType {
+		switch strings.ToLower(device.OpType) {
 		// The op_type field is only applicable with the SyncDevices API call,
 		// Empty op_type come from the first call to FetchDevices without a cursor,
 		// and we do want to assign profiles to them.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -638,6 +638,10 @@ type SetMDMAppleDefaultSetupAssistantProfileUUIDFunc func(ctx context.Context, t
 
 type GetMDMAppleDefaultSetupAssistantFunc func(ctx context.Context, teamID *uint) (profileUUID string, updatedAt time.Time, err error)
 
+type GetMatchingHostSerialsFunc func(ctx context.Context, serials []string) (map[string]struct{}, error)
+
+type DeleteHostDEPAssignmentsFunc func(ctx context.Context, serials []string) error
+
 type DataStore struct {
 	HealthCheckFunc        HealthCheckFunc
 	HealthCheckFuncInvoked bool
@@ -1571,6 +1575,12 @@ type DataStore struct {
 
 	GetMDMAppleDefaultSetupAssistantFunc        GetMDMAppleDefaultSetupAssistantFunc
 	GetMDMAppleDefaultSetupAssistantFuncInvoked bool
+
+	GetMatchingHostSerialsFunc        GetMatchingHostSerialsFunc
+	GetMatchingHostSerialsFuncInvoked bool
+
+	DeleteHostDEPAssignmentsFunc        DeleteHostDEPAssignmentsFunc
+	DeleteHostDEPAssignmentsFuncInvoked bool
 
 	mu sync.Mutex
 }
@@ -3750,4 +3760,18 @@ func (s *DataStore) GetMDMAppleDefaultSetupAssistant(ctx context.Context, teamID
 	s.GetMDMAppleDefaultSetupAssistantFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetMDMAppleDefaultSetupAssistantFunc(ctx, teamID)
+}
+
+func (s *DataStore) GetMatchingHostSerials(ctx context.Context, serials []string) (map[string]struct{}, error) {
+	s.mu.Lock()
+	s.GetMatchingHostSerialsFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetMatchingHostSerialsFunc(ctx, serials)
+}
+
+func (s *DataStore) DeleteHostDEPAssignments(ctx context.Context, serials []string) error {
+	s.mu.Lock()
+	s.DeleteHostDEPAssignmentsFuncInvoked = true
+	s.mu.Unlock()
+	return s.DeleteHostDEPAssignmentsFunc(ctx, serials)
 }

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -18,7 +18,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -738,13 +737,22 @@ func createHostThenEnrollMDM(ds fleet.Datastore, fleetServerURL string, t *testi
 
 func (s *integrationMDMTestSuite) TestDEPProfileAssignment() {
 	t := s.T()
+	ctx := context.Background()
 	devices := []godep.Device{
 		{SerialNumber: uuid.New().String(), Model: "MacBook Pro", OS: "osx", OpType: "added"},
 		{SerialNumber: uuid.New().String(), Model: "MacBook Mini", OS: "osx", OpType: "added"},
+		{SerialNumber: uuid.New().String(), Model: "MacBook Mini", OS: "osx", OpType: ""},
+		{SerialNumber: uuid.New().String(), Model: "MacBook Mini", OS: "osx", OpType: "modified"},
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(2)
+	runDEPSchedule := func() {
+		ch := make(chan bool)
+		s.onDEPScheduleDone = func() { close(ch) }
+		_, err := s.depSchedule.Trigger()
+		require.NoError(t, err)
+		<-ch
+	}
+
 	s.mockDEPResponse(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		encoder := json.NewEncoder(w)
@@ -763,10 +771,9 @@ func (s *integrationMDMTestSuite) TestDEPProfileAssignment() {
 		case "/devices/sync":
 			// This endpoint is polled over time to sync devices from
 			// ABM, send a repeated serial and a new one
-			err := encoder.Encode(godep.DeviceResponse{Devices: devices})
+			err := encoder.Encode(godep.DeviceResponse{Devices: devices, Cursor: "foo"})
 			require.NoError(t, err)
 		case "/profile/devices":
-			wg.Done()
 			_, _ = w.Write([]byte(`{}`))
 		default:
 			_, _ = w.Write([]byte(`{}`))
@@ -779,32 +786,33 @@ func (s *integrationMDMTestSuite) TestDEPProfileAssignment() {
 	require.Empty(t, listHostsRes.Hosts)
 
 	// trigger a profile sync
-	_, err := s.depSchedule.Trigger()
-	require.NoError(t, err)
-	wg.Wait()
+	runDEPSchedule()
 
-	// both hosts should be returned from the hosts endpoint
+	// all hosts should be returned from the hosts endpoint
 	listHostsRes = listHostsResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/hosts", nil, http.StatusOK, &listHostsRes)
-	require.Len(t, listHostsRes.Hosts, 2)
-	require.Equal(t, listHostsRes.Hosts[0].HardwareSerial, devices[0].SerialNumber)
-	require.Equal(t, listHostsRes.Hosts[1].HardwareSerial, devices[1].SerialNumber)
-	require.EqualValues(
-		t,
-		[]string{devices[0].SerialNumber, devices[1].SerialNumber},
-		[]string{listHostsRes.Hosts[0].HardwareSerial, listHostsRes.Hosts[1].HardwareSerial},
-	)
+	require.Len(t, listHostsRes.Hosts, len(devices))
+	var wantSerials []string
+	var gotSerials []string
+	for i, device := range devices {
+		wantSerials = append(wantSerials, device.SerialNumber)
+		gotSerials = append(gotSerials, listHostsRes.Hosts[i].HardwareSerial)
+		// entries for all hosts should be created in the host_dep_assignments table
+		_, err := s.ds.GetHostDEPAssignment(ctx, listHostsRes.Hosts[i].ID)
+		require.NoError(t, err)
+	}
+	require.ElementsMatch(t, wantSerials, gotSerials)
 
 	// create a new host
-	createHostAndDeviceToken(t, s.ds, "not-dep")
+	nonDEPHost := createHostAndDeviceToken(t, s.ds, "not-dep")
 	listHostsRes = listHostsResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/hosts", nil, http.StatusOK, &listHostsRes)
-	require.Len(t, listHostsRes.Hosts, 3)
+	require.Len(t, listHostsRes.Hosts, len(devices)+1)
 
 	// filtering by MDM status works
 	listHostsRes = listHostsResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/hosts?mdm_enrollment_status=pending", nil, http.StatusOK, &listHostsRes)
-	require.Len(t, listHostsRes.Hosts, 2)
+	require.Len(t, listHostsRes.Hosts, len(devices))
 
 	s.pushProvider.PushFunc = func(pushes []*mdm.Push) (map[string]*push.Response, error) {
 		return map[string]*push.Response{}, nil
@@ -814,7 +822,7 @@ func (s *integrationMDMTestSuite) TestDEPProfileAssignment() {
 	depURLToken := loadEnrollmentProfileDEPToken(t, s.ds)
 	mdmDevice := mdmtest.NewTestMDMClientDEP(s.server.URL, depURLToken)
 	mdmDevice.SerialNumber = devices[0].SerialNumber
-	err = mdmDevice.Enroll()
+	err := mdmDevice.Enroll()
 	require.NoError(t, err)
 
 	// run the worker to process the DEP enroll request
@@ -839,7 +847,7 @@ func (s *integrationMDMTestSuite) TestDEPProfileAssignment() {
 	// only one shows up as pending
 	listHostsRes = listHostsResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/hosts?mdm_enrollment_status=pending", nil, http.StatusOK, &listHostsRes)
-	require.Len(t, listHostsRes.Hosts, 1)
+	require.Len(t, listHostsRes.Hosts, len(devices)-1)
 
 	activities := listActivitiesResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &activities, "order_key", "created_at")
@@ -861,6 +869,50 @@ func (s *integrationMDMTestSuite) TestDEPProfileAssignment() {
 		}
 	}
 	require.True(t, found)
+
+	// modify the response and trigger another sync to include:
+	//
+	// 1. A repeated device with "added"
+	// 2. A repeated device with "modified"
+	// 3. A device with "deleted"
+	// 4. A new device
+	deletedSerial := devices[2].SerialNumber
+	addedSerial := uuid.New().String()
+	devices = []godep.Device{
+		{SerialNumber: devices[0].SerialNumber, Model: "MacBook Pro", OS: "osx", OpType: "added"},
+		{SerialNumber: devices[1].SerialNumber, Model: "MacBook Mini", OS: "osx", OpType: "modified"},
+		{SerialNumber: deletedSerial, Model: "MacBook Mini", OS: "osx", OpType: "deleted"},
+		{SerialNumber: addedSerial, Model: "MacBook Mini", OS: "osx", OpType: "added"},
+	}
+	runDEPSchedule()
+
+	// all hosts should be returned from the hosts endpoint
+	listHostsRes = listHostsResponse{}
+	s.DoJSON("GET", "/api/latest/fleet/hosts", nil, http.StatusOK, &listHostsRes)
+	// all previous devices + the manually added host + the new `addedSerial`
+	wantSerials = append(wantSerials, devices[3].SerialNumber, nonDEPHost.HardwareSerial)
+	require.Len(t, listHostsRes.Hosts, len(wantSerials))
+	gotSerials = []string{}
+	var deletedHostID uint
+	var addedHostID uint
+	for _, device := range listHostsRes.Hosts {
+		gotSerials = append(gotSerials, device.HardwareSerial)
+		switch device.HardwareSerial {
+		case deletedSerial:
+			deletedHostID = device.ID
+		case addedSerial:
+			addedHostID = device.ID
+		}
+	}
+	require.ElementsMatch(t, wantSerials, gotSerials)
+
+	// entries for all hosts except for the one with OpType = "deleted"
+	assignment, err := s.ds.GetHostDEPAssignment(ctx, deletedHostID)
+	require.NoError(t, err)
+	require.NotZero(t, assignment.DeletedAt)
+
+	_, err = s.ds.GetHostDEPAssignment(ctx, addedHostID)
+	require.NoError(t, err)
 }
 
 func loadEnrollmentProfileDEPToken(t *testing.T, ds *mysql.Datastore) string {


### PR DESCRIPTION
for #10605, this modifies the cron used to ping the list/sync devices API from ABM to account for the "deleted" and "modified" operation types.

We know that:

1. Sometimes, Apple sends a "modified" operation type when a device's MDM server is reassigned in ABM, up until now, we were ignoring these devices.
2. Devices that are no longer assigned to Fleet in ABM can't be migrated.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
