### PR TITLE
Fleet UI: Improve host details/device user responsiveness

### DIFF
--- a/frontend/pages/hosts/details/_styles.scss
+++ b/frontend/pages/hosts/details/_styles.scss
@@ -83,10 +83,18 @@
     .info-grid {
       display: grid;
       grid-auto-flow: column;
-      grid-template-columns: repeat(4, max-content);
-      grid-template-rows: repeat(3, 1fr);
+      grid-template-columns: repeat(
+        3,
+        max-content
+      ); // Prevents overflow off screen
+      grid-template-rows: repeat(4, 1fr);
       column-gap: $pad-xxlarge;
       row-gap: $pad-medium;
+
+      @media (min-width: $break-990) {
+        grid-template-columns: repeat(4, max-content);
+        grid-template-rows: repeat(3, 1fr);
+      }
 
       &__block {
         font-size: $x-small;

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -193,6 +193,7 @@ const About = ({
       </div>
     );
   };
+
   return (
     <div className="section about">
       <p className="section__header">About</p>

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -43,7 +43,17 @@
       text-align: center;
     }
     .data-table__table {
+      // Adds border to headers except for empty last header to view filtered hosts
       thead {
+        th {
+          border-right: none;
+          border-left: 1px solid $ui-fleet-black-10;
+        }
+
+        .linkToFilteredHosts__header {
+          border-left: none;
+        }
+
         .version__header {
           width: $col-xs;
         }
@@ -53,9 +63,6 @@
         .source__header {
           display: none;
           width: 0px;
-        }
-        .hosts_count__header {
-          border-right: 0;
         }
         .last_opened_at__header {
           display: none;
@@ -88,7 +95,7 @@
             justify-content: left;
 
             .children-wrapper {
-              overflow: hidden;
+              overflow-x: clip; // Truncates the text but does not hide tooltip outside cell
               white-space: nowrap;
               display: block;
               text-overflow: ellipsis;
@@ -221,10 +228,6 @@
   }
 
   .data-table-block .data-table__table {
-    .installed_paths__header {
-      border-right: none;
-    }
-
     @media (min-width: $break-990) {
       thead .version__header {
         width: $col-sm;

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -51,7 +51,7 @@
           width: $col-xs;
         }
         .vulnerabilities__header {
-          min-width: 130px;
+          min-width: 120px;
         }
         .source__header {
           display: none;
@@ -67,7 +67,7 @@
           display: none;
         }
         .linkToFilteredHosts__header {
-          min-width: 115px;
+          width: 115px;
         }
         @media (min-width: $break-1400) {
           .version__header {
@@ -209,8 +209,14 @@
   }
 
   .data-table-block .data-table__table {
-    .installed_paths__header {
+    th {
       border-right: none;
+      border-left: 1px solid #e2e4ea;
+    }
+
+    .linkToFilteredHosts__header,
+    .name__header {
+      border-left: none;
     }
 
     @media (min-width: $break-990) {

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -44,14 +44,11 @@
     }
     .data-table__table {
       thead {
-        .name__header {
-          width: $col-md;
-        }
         .version__header {
           width: $col-xs;
         }
         .vulnerabilities__header {
-          min-width: 120px;
+          width: 130px;
         }
         .source__header {
           display: none;
@@ -82,7 +79,22 @@
       }
 
       tbody {
-        .name__cell,
+        .name__cell {
+          // Long software names overflow the software card
+          max-width: 0;
+
+          .button--text-link {
+            width: 100%;
+            justify-content: left;
+
+            .children-wrapper {
+              overflow: hidden;
+              white-space: nowrap;
+              display: block;
+              text-overflow: ellipsis;
+            }
+          }
+        }
         .version__cell {
           white-space: nowrap;
           text-overflow: ellipsis;
@@ -209,14 +221,8 @@
   }
 
   .data-table-block .data-table__table {
-    th {
+    .installed_paths__header {
       border-right: none;
-      border-left: 1px solid #e2e4ea;
-    }
-
-    .linkToFilteredHosts__header,
-    .name__header {
-      border-left: none;
     }
 
     @media (min-width: $break-990) {
@@ -233,11 +239,8 @@
       tbody {
         .last_opened_at__cell {
           display: table-cell;
-        }
-        .linkToFilteredHosts__cell {
-          .view-all-hosts-link {
-            width: 120px;
-          }
+          width: 100px;
+          min-width: min-content;
         }
       }
     }
@@ -246,7 +249,7 @@
       thead {
         .installed_paths__header {
           display: table-cell;
-          width: $col-lg;
+          width: $col-md;
         }
       }
       tbody {
@@ -254,7 +257,7 @@
           display: table-cell;
 
           .text-cell {
-            width: $col-lg;
+            width: $col-md;
             text-overflow: initial;
             overflow: initial;
             white-space: initial;

--- a/frontend/pages/hosts/details/cards/Users/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Users/_styles.scss
@@ -10,11 +10,6 @@
         .shell__header {
           width: $col-md;
         }
-        @media (min-width: $break-768) {
-          .username__header {
-            width: $col-lg;
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
## Issue
Cerra #11765 

## Description
- Clean up tables and columns that are causing cards to flow off the screen horizontally
  - Software name truncates wider to accommodate white space instead of pushing entire table off the screen
  - Clean up header cells so link to view all host header does not have a border
  - About section reduces to 3 columns from 4 columns wide when the screen cannot fit 4 columns

## Screenrecording

### Software table no longer overflows
https://github.com/fleetdm/fleet/assets/71795832/8b33e622-5ef5-454a-a3ee-23b69ca5c841

### About section no longer overflows
https://github.com/fleetdm/fleet/assets/71795832/15ea2c3e-0abd-436d-9e96-7d5cae7e52fe



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality