### PR TITLE
remove s3 acl from terraform/addons/logging-alb

### DIFF
--- a/terraform/addons/logging-alb/main.tf
+++ b/terraform/addons/logging-alb/main.tf
@@ -39,10 +39,9 @@ resource "aws_kms_alias" "logs_alias" {
 
 module "s3_bucket_for_logs" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "3.6.0"
+  version = "3.11.0"
 
   bucket = "${var.prefix}-alb-logs"
-  acl    = "log-delivery-write"
 
   # Allow deletion of non-empty bucket
   force_destroy = true
@@ -92,10 +91,9 @@ resource "aws_athena_database" "logs" {
 module "athena-s3-bucket" {
   count  = var.enable_athena == true ? 1 : 0
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "3.6.0"
+  version = "3.11.0"
 
   bucket = "${var.prefix}-alb-logs-athena"
-  acl    = "log-delivery-write"
 
   # Allow deletion of non-empty bucket
   force_destroy = true


### PR DESCRIPTION
Fixes "the bucket does not allow acls".  If it doesn't allow them, then don't make one.

Validated logging still works.