### PR TITLE
Fleet UI: [Unreleased bug] Fix position of host issue icon

### DIFF
--- a/frontend/components/LiveQuery/TargetsInput/_styles.scss
+++ b/frontend/components/LiveQuery/TargetsInput/_styles.scss
@@ -52,6 +52,11 @@
       &__wrapper {
         margin: 0;
       }
+      .host-issue {
+        .icon {
+          vertical-align: inherit;
+        }
+      }
     }
   }
   &__hosts-selected-table {


### PR DESCRIPTION
## Issue
Hopefully last cleanup of #12052

## Description
- Somehow this icon is aligning low but others are not, local fix

## Screenshot of fix
<img width="595" alt="Screenshot 2023-06-06 at 3 18 21 PM" src="https://github.com/fleetdm/fleet/assets/71795832/5b3a1eb0-39bb-46fd-92cb-8b2aa9bbd7ec">


# Checklist for submitter

- [x] Manual QA for all new/changed functionality
