### PR TITLE
Website: Update external footer links in a new tab

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -320,16 +320,16 @@
             </div>
 
             <div purpose="footer-socials" style="" class="flex-row d-inline-flex font-weight-bold order-first order-md-last justify-content-start justify-content-md-end pl-md-3 py-3">
-              <a href="https://twitter.com/fleetctl">
+              <a target="_blank" href="https://twitter.com/fleetctl">
                 <img alt="Twitter logo" src="/images/logo-twitter-dark-25x20@2x.png" class="pr-4"/>
               </a>
-              <a href="https://www.youtube.com/channel/UCZyoqZ4exJvoibmTKJrQ-dQ">
+              <a target="_blank" href="https://www.youtube.com/channel/UCZyoqZ4exJvoibmTKJrQ-dQ">
                 <img alt="Youtube logo" src="/images/logo-youtube-29x20@2x.png"  class="pr-4"/>
               </a>
-              <a href="/slack">
+              <a target="_blank" href="/slack">
                 <img alt="Slack logo" src="/images/logo-slack-dark-20x20@2x.png" class="pr-4"/>
               </a>
-              <a href="https://github.com/fleetdm/fleet">
+              <a target="_blank" href="https://github.com/fleetdm/fleet">
                 <img alt="GitHub logo" src="/images/logo-github-dark-24x24@2x.png" />
               </a>
             </div>


### PR DESCRIPTION
Changes:
- Updated the external links in the Fleet website footer to open in a new tab.
