### PR TITLE
Fleet UI: Improvements to Sandbox mode styling

### DIFF
--- a/changes/12065-sandbox-styling-improvements
+++ b/changes/12065-sandbox-styling-improvements
@@ -1,0 +1,1 @@
+- Improvements to styling in Sandbox mode

--- a/frontend/components/PremiumFeatureMessage/PremiumFeatureMessage.tsx
+++ b/frontend/components/PremiumFeatureMessage/PremiumFeatureMessage.tsx
@@ -17,8 +17,11 @@ const PremiumFeatureMessage = ({ className }: IPremiumFeatureMessage) => {
         <Icon name="premium-feature" />
         <p>This feature is included in Fleet Premium.</p>
         <div className="external-link-and-icon">
-          <CustomLink url="https://fleetdm.com/upgrade" text="Learn more" />
-          <Icon name="external-link" />
+          <CustomLink
+            url="https://fleetdm.com/upgrade"
+            text="Learn more"
+            newTab
+          />
         </div>
       </div>
     </div>

--- a/frontend/components/Sandbox/SandboxExpiryMessage/_styles.scss
+++ b/frontend/components/Sandbox/SandboxExpiryMessage/_styles.scss
@@ -10,6 +10,8 @@
   font-size: $x-small;
   color: $core-fleet-black;
   font-weight: $regular;
+  position: relative; // Position in front of settings sticky header space
+  z-index: 9; // Position in front of settings sticky header space
 
   p {
     margin: 0;

--- a/frontend/pages/admin/_styles.scss
+++ b/frontend/pages/admin/_styles.scss
@@ -22,17 +22,6 @@
     }
   }
 
-  // These styles are here to make the sticky header and nav work correctly
-  // with the sandbox mode expiry message.
-  &.sandbox-mode {
-    h1 {
-      &::before {
-        height: 0;
-        top: 0;
-      }
-    }
-  }
-
   .component__tabs-wrapper {
     top: $pad-xxlarge; // for sticky
     z-index: 3;

--- a/frontend/pages/schedule/ManageSchedulePage/_styles.scss
+++ b/frontend/pages/schedule/ManageSchedulePage/_styles.scss
@@ -108,6 +108,10 @@
         }
       }
     }
+
+    .empty-table__container {
+      max-width: 465px; // Fixes wider font causing orphaned word on all teams empty state
+    }
   }
 
   .no-team-schedule {


### PR DESCRIPTION
## Issue
Cerra #12065 

## Description
- Fix for sticky scroll header in Sandbox mode
- Learn more link opens in a new tab
- Hanging "orphaned" word on schedule empty state now fits on first line

## Unable to reproduce
- No issue with empty software image
- No issue with centering Fleet premium message

## Screenshot/recording

### Screenshot of non-issue
<img width="1375" alt="Screenshot 2023-06-07 at 10 59 05 AM" src="https://github.com/fleetdm/fleet/assets/71795832/2f989cff-f935-4916-b1cb-b0df65cddef8">

### Settings scrolling fix tested on Chrome, FF, and Safari
https://github.com/fleetdm/fleet/assets/71795832/29d7cd1c-5695-439e-bb5a-31001c65ea4a


### Screenshot of non-issue
<img width="544" alt="Screenshot 2023-06-07 at 10 29 12 AM" src="https://github.com/fleetdm/fleet/assets/71795832/9f9fbe42-1f1e-4294-b782-bb248065496e">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

