### PR TITLE
Fleet UI: Click dropdown label option again to deselect on manage host table

### DIFF
--- a/changes/7601-deselect-label-filter
+++ b/changes/7601-deselect-label-filter
@@ -1,0 +1,1 @@
+- Ability to deselect label filter on host table

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -501,7 +501,8 @@ const ManageHostsPage = ({
   const handleLabelChange = ({ slug }: ILabel): boolean => {
     const { MANAGE_HOSTS } = PATHS;
 
-    const isDeselectingLabel = slug?.slice(7) === selectedLabel?.id.toString();
+    const isDeselectingLabel =
+      labelID && labelID === selectedLabel?.id.toString();
 
     // Non-status labels are not compatible with policies or software filters
     // so omit policies and software params from next location

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -501,6 +501,8 @@ const ManageHostsPage = ({
   const handleLabelChange = ({ slug }: ILabel): boolean => {
     const { MANAGE_HOSTS } = PATHS;
 
+    const isDeselectingLabel = slug?.slice(7) === selectedLabel?.id.toString();
+
     // Non-status labels are not compatible with policies or software filters
     // so omit policies and software params from next location
     let newQueryParams = queryParams;
@@ -514,7 +516,9 @@ const ManageHostsPage = ({
 
     router.replace(
       getNextLocationPath({
-        pathPrefix: `${MANAGE_HOSTS}/${slug}`,
+        pathPrefix: isDeselectingLabel
+          ? MANAGE_HOSTS
+          : `${MANAGE_HOSTS}/${slug}`,
         queryParams: newQueryParams,
       })
     );

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
@@ -94,7 +94,6 @@ const LabelFilterSelect = ({
   ]);
 
   const handleChange = (option: ILabel | IEmptyOption | null) => {
-    console.log("option", option);
     if (option === null) return;
     if ("type" in option) {
       setShouldOpenMenu(false);

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
@@ -94,6 +94,7 @@ const LabelFilterSelect = ({
   ]);
 
   const handleChange = (option: ILabel | IEmptyOption | null) => {
+    console.log("option", option);
     if (option === null) return;
     if ("type" in option) {
       setShouldOpenMenu(false);


### PR DESCRIPTION
## Issue
Cerra #7601 

## Description
- URL source of truth, if label is clicked again, change URL to not include current label slug
- No need to dig into react-select which was our initial concern for the 3 estimate

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
