### PR TITLE
Ignore fleet profiles when matching a set of custom profiles to a team

### DIFF
--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -120,12 +120,14 @@ SELECT
 FROM
 	mdm_apple_configuration_profiles p1
 WHERE
+	p1.identifier NOT IN (?) AND
 	NOT EXISTS (
 		SELECT
 			1
 		FROM
 			mdm_apple_configuration_profiles p2
 		WHERE
+			p2.identifier NOT IN (?) AND
 			p1.team_id = p2.team_id AND
 			HEX(p2.checksum) NOT IN (?)
 	)
@@ -134,7 +136,15 @@ GROUP BY
 HAVING
 	COUNT(*) = ?`
 
-	stmt, args, err := sqlx.In(stmt, hexMD5Hashes, len(hexMD5Hashes))
+	// when matching a set of profiles to a team, only the custom profiles need
+	// to match, i.e. we ignore any fleet-specific profiles.
+	idents := mobileconfig.FleetPayloadIdentifiers()
+	fleetIdents := make([]string, 0, len(idents))
+	for ident := range idents {
+		fleetIdents = append(fleetIdents, ident)
+	}
+
+	stmt, args, err := sqlx.In(stmt, fleetIdents, fleetIdents, hexMD5Hashes, len(hexMD5Hashes))
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "prepare query arguments")
 	}


### PR DESCRIPTION
#12204 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- ~~[ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.~~ (fix for an unreleased feature)
- [x] Added/updated tests
