### PR TITLE
UI: Fix dropdown height bug

### DIFF
--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -182,17 +182,13 @@
   }
 
   .Select-menu-outer {
-    max-height: none;
     box-shadow: 0 4px 10px rgba(52, 59, 96, 0.15);
     z-index: 6;
+    overflow: hidden;
     border: 0;
     margin: 1px 0 0;
     padding: $pad-small;
     animation: fade-in 150ms ease-out;
-
-    .Select-menu {
-      max-height: none;
-    }
   }
 
   .Select-noresults {

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -182,13 +182,17 @@
   }
 
   .Select-menu-outer {
+    max-height: none;
     box-shadow: 0 4px 10px rgba(52, 59, 96, 0.15);
     z-index: 6;
-    overflow: hidden;
     border: 0;
     margin: 1px 0 0;
     padding: $pad-small;
     animation: fade-in 150ms ease-out;
+
+    .Select-menu {
+      max-height: none;
+    }
   }
 
   .Select-noresults {

--- a/frontend/pages/DashboardPage/_styles.scss
+++ b/frontend/pages/DashboardPage/_styles.scss
@@ -63,6 +63,14 @@
 
   &__platform_dropdown {
     width: 138px;
+
+    .Select-menu-outer {
+      max-height: none;
+
+      .Select-menu {
+        max-height: none;
+      }
+    }
   }
 
   &__section {


### PR DESCRIPTION
**Disabled the Platform dropdown's default max-height to allow it to fully encompass its contents, which are now longer with the addition of the ChromeOS option.** 

Before (Chrome and Safari):
<img width="273" alt="Screenshot 2023-06-07 at 6 14 56 PM" src="https://github.com/fleetdm/fleet/assets/61553566/8fb6d0b6-20e2-4a80-ad75-a56fc60f1697">

After (All 3 browsers):
<img width="246" alt="Screenshot 2023-06-07 at 6 08 35 PM" src="https://github.com/fleetdm/fleet/assets/61553566/374ca4bc-b532-487c-846a-46e505b77bf2">

- [x] Manual QA for all new/changed functionality
