### PR TITLE
Website: fix alignment issue in Handbook mobile navigation

### DIFF
--- a/website/assets/styles/pages/handbook/basic-handbook.less
+++ b/website/assets/styles/pages/handbook/basic-handbook.less
@@ -59,7 +59,7 @@
     padding-top: 16px;
     p, a, strong {
       font-size: 12px;
-      line-height: 24px;
+      line-height: 18px;
     }
     a {
       text-decoration: none;

--- a/website/views/pages/handbook/basic-handbook.ejs
+++ b/website/views/pages/handbook/basic-handbook.ejs
@@ -24,19 +24,19 @@
       <div class="d-flex flex-column handbook-content">
 
         <div purpose="breadcrumbs" class="d-flex m-0 align-items-center breadcrumbs">
-          <div class="d-flex" v-if="breadcrumbs.length > 1">
-            <a :href="'/' + breadcrumbs[0]" class="pr-3 my-auto">
+          <div class="d-flex flex-row align-items-center" v-if="breadcrumbs.length > 1">
+            <a :href="'/' + breadcrumbs[0]" class="pr-3">
               {{breadcrumbs[0] === 'handbook' ? 'Introduction' : breadcrumbs[0]}}
             </a>
             <div class="d-flex p-0 m-0 align-items-center" v-if="breadcrumbs.length === 3">
               <img style="width: 6px; height: 9px;" alt="right chevron" src="/images/chevron-right-6x9@2x.png" />
-              <a :href="'/' + breadcrumbs[0] + '/' + breadcrumbs[1]" class="px-3 my-auto">
+              <a :href="'/' + breadcrumbs[0] + '/' + breadcrumbs[1]" class="px-3">
                 {{_getTitleFromUrl(breadcrumbs[1])}}
               </a>
             </div>
             <div class="d-flex p-0 m-0 align-items-center" v-if="breadcrumbs.length > 1">
               <img style="width: 6px; height: 9px;" alt="right chevron" src="/images/chevron-right-6x9@2x.png"/>
-              <p class="px-3 m-0 my-auto">
+              <p class="px-3 m-0">
                 {{thisPage.title}}
               </p>
             </div>

--- a/website/views/pages/handbook/basic-handbook.ejs
+++ b/website/views/pages/handbook/basic-handbook.ejs
@@ -25,18 +25,18 @@
 
         <div purpose="breadcrumbs" class="d-flex m-0 align-items-center breadcrumbs">
           <div class="d-flex" v-if="breadcrumbs.length > 1">
-            <a :href="'/' + breadcrumbs[0]" class="pr-3">
+            <a :href="'/' + breadcrumbs[0]" class="pr-3 my-auto">
               {{breadcrumbs[0] === 'handbook' ? 'Introduction' : breadcrumbs[0]}}
             </a>
             <div class="d-flex p-0 m-0 align-items-center" v-if="breadcrumbs.length === 3">
               <img style="width: 6px; height: 9px;" alt="right chevron" src="/images/chevron-right-6x9@2x.png" />
-              <a :href="'/' + breadcrumbs[0] + '/' + breadcrumbs[1]" class="px-3">
+              <a :href="'/' + breadcrumbs[0] + '/' + breadcrumbs[1]" class="px-3 my-auto">
                 {{_getTitleFromUrl(breadcrumbs[1])}}
               </a>
             </div>
             <div class="d-flex p-0 m-0 align-items-center" v-if="breadcrumbs.length > 1">
               <img style="width: 6px; height: 9px;" alt="right chevron" src="/images/chevron-right-6x9@2x.png"/>
-              <p class="px-3 m-0">
+              <p class="px-3 m-0 my-auto">
                 {{thisPage.title}}
               </p>
             </div>


### PR DESCRIPTION
Closes: #12218

Changes:
- Updated the alignment of the mobile navigation "breadcrumbs" in the Fleet handbook.