### PR TITLE
UI: Ensure 'Not supported' cell for Chromebooks never wraps

### DIFF
--- a/frontend/components/NotSupported/_styles.scss
+++ b/frontend/components/NotSupported/_styles.scss
@@ -1,3 +1,4 @@
 .not-supported {
   color: $ui-fleet-black-50;
+  white-space: nowrap;
 }


### PR DESCRIPTION
Bug:
<img width="313" alt="Screenshot 2023-06-08 at 12 02 26 PM" src="https://github.com/fleetdm/fleet/assets/61553566/13c23e7e-9d3f-4684-acf9-c36805ec686e">
Fixed:
<img width="325" alt="Screenshot 2023-06-08 at 12 05 03 PM" src="https://github.com/fleetdm/fleet/assets/61553566/fbadcd67-fbf8-42d6-9150-ce9911ba537e">
