### PR TITLE
rename url to Installation URL to better match google Workspace

### DIFF
--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -63,7 +63,7 @@ interface IPlatformWrapperProps {
 
 const CHROME_OS_INFO = {
   extensionId: "fleeedmmihkfkeemmipgmhhjemlljidg",
-  url: "https://chrome.fleetdm.com/updates.xml",
+  installationUrl: "https://chrome.fleetdm.com/updates.xml",
   policyForExtension: `{
   "fleet_url": {
     "Value": "https://dogfood.fleetdm.com"
@@ -393,9 +393,9 @@ const PlatformWrapper = ({
                 <InputField
                   disabled
                   inputWrapperClass={`${baseClass}__installer-input ${baseClass}__chromeos-url`}
-                  name="URL"
-                  label={renderChromeOSLabel("URL", CHROME_OS_INFO.url)}
-                  value={CHROME_OS_INFO.url}
+                  name="Installation URL"
+                  label={renderChromeOSLabel("Installation URL", CHROME_OS_INFO.installationUrl)}
+                  value={CHROME_OS_INFO.installationUrl}
                 />
                 <InputField
                   disabled


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).

# Background
Follow up to this comment: https://github.com/fleetdm/fleet/pull/11747#discussion_r1223542104