### PR TITLE
Fleet UI: [Unreleased bug] Replace static enroll secret with variable one for ChromeOS

### DIFF
--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -61,19 +61,6 @@ interface IPlatformWrapperProps {
   config: IConfig | null;
 }
 
-const CHROME_OS_INFO = {
-  extensionId: "fleeedmmihkfkeemmipgmhhjemlljidg",
-  url: "https://chrome.fleetdm.com/updates.xml",
-  policyForExtension: `{
-  "fleet_url": {
-    "Value": "https://dogfood.fleetdm.com"
-  },
-  "enroll_secret": {
-    "Value": "eeb2e8a7d132d9cbbdd0f024f9419f88"
-  }
-}`,
-};
-
 const baseClass = "platform-wrapper";
 
 const PlatformWrapper = ({
@@ -358,6 +345,19 @@ const PlatformWrapper = ({
   };
 
   const renderTab = (packageType: string) => {
+    const CHROME_OS_INFO = {
+      extensionId: "fleeedmmihkfkeemmipgmhhjemlljidg",
+      installationUrl: "https://chrome.fleetdm.com/updates.xml",
+      policyForExtension: `{
+  "fleet_url": {
+    "Value": "https://dogfood.fleetdm.com"
+  },
+  "enroll_secret": {
+    "Value": "${enrollSecret}"
+  }
+}`,
+    };
+
     if (packageType === "chromeos") {
       return (
         <div className={baseClass}>
@@ -393,9 +393,12 @@ const PlatformWrapper = ({
                 <InputField
                   disabled
                   inputWrapperClass={`${baseClass}__installer-input ${baseClass}__chromeos-url`}
-                  name="URL"
-                  label={renderChromeOSLabel("URL", CHROME_OS_INFO.url)}
-                  value={CHROME_OS_INFO.url}
+                  name="Installation URL"
+                  label={renderChromeOSLabel(
+                    "Installation URL",
+                    CHROME_OS_INFO.installationUrl
+                  )}
+                  value={CHROME_OS_INFO.installationUrl}
                 />
                 <InputField
                   disabled

--- a/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
+++ b/frontend/components/AddHostsModal/PlatformWrapper/_styles.scss
@@ -48,7 +48,7 @@
 
   .input-field {
     &__textarea {
-      min-height: 68px;
+      min-height: 88px;
     }
 
     &__textarea,
@@ -65,7 +65,7 @@
 
   &__advanced--installer {
     .input-field {
-      height: 85px;
+      height: 105px;
     }
   }
 


### PR DESCRIPTION
Whoops

## Other
- Installation URL instead of URL to match Google Admin field name
- Fix too short height of text areas affected by some line height changes

## Screen recording

https://github.com/fleetdm/fleet/assets/71795832/c060fcce-2cd3-4981-ae9e-df94630839bf



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

