### PR TITLE
Fleet UI: Fix released bug where deleting multiple pages of hosts only deleted first 50

### DIFF
--- a/changes/11885-fix-bulk-delete-hosts
+++ b/changes/11885-fix-bulk-delete-hosts
@@ -1,0 +1,1 @@
+Users can delete multiple pages of hosts

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1003,20 +1003,17 @@ const ManageHostsPage = ({
   const onDeleteHostSubmit = async () => {
     setIsUpdatingHosts(true);
 
-    let action = hostsAPI.destroyBulk(selectedHostIds);
+    const teamId = isAnyTeamSelected ? currentTeamId ?? null : null;
+    const labelId = selectedLabel?.id;
 
-    if (isAllMatchingHostsSelected) {
-      const teamId = isAnyTeamSelected ? currentTeamId ?? null : null;
-
-      const labelId = selectedLabel?.id;
-
-      action = hostsAPI.destroyByFilter({
-        teamId,
-        query: searchQuery,
-        status,
-        labelId,
-      });
-    }
+    const action = isAllMatchingHostsSelected
+      ? hostsAPI.destroyByFilter({
+          teamId,
+          query: searchQuery,
+          status,
+          labelId,
+        })
+      : hostsAPI.destroyBulk(selectedHostIds);
 
     try {
       await action;

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1005,16 +1005,16 @@ const ManageHostsPage = ({
 
     const teamId = isAnyTeamSelected ? currentTeamId ?? null : null;
     const labelId = selectedLabel?.id;
-    
+
     try {
-      await  isAllMatchingHostsSelected
-      ? hostsAPI.destroyByFilter({
-          teamId,
-          query: searchQuery,
-          status,
-          labelId,
-        })
-      : hostsAPI.destroyBulk(selectedHostIds);
+      (await isAllMatchingHostsSelected)
+        ? hostsAPI.destroyByFilter({
+            teamId,
+            query: searchQuery,
+            status,
+            labelId,
+          })
+        : hostsAPI.destroyBulk(selectedHostIds);
 
       const successMessage = `${
         selectedHostIds.length === 1 ? "Host" : "Hosts"

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1005,8 +1005,9 @@ const ManageHostsPage = ({
 
     const teamId = isAnyTeamSelected ? currentTeamId ?? null : null;
     const labelId = selectedLabel?.id;
-
-    const action = isAllMatchingHostsSelected
+    
+    try {
+      await  isAllMatchingHostsSelected
       ? hostsAPI.destroyByFilter({
           teamId,
           query: searchQuery,
@@ -1014,9 +1015,6 @@ const ManageHostsPage = ({
           labelId,
         })
       : hostsAPI.destroyBulk(selectedHostIds);
-
-    try {
-      await action;
 
       const successMessage = `${
         selectedHostIds.length === 1 ? "Host" : "Hosts"

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1007,14 +1007,14 @@ const ManageHostsPage = ({
     const labelId = selectedLabel?.id;
 
     try {
-      (await isAllMatchingHostsSelected)
+      await (isAllMatchingHostsSelected
         ? hostsAPI.destroyByFilter({
             teamId,
             query: searchQuery,
             status,
             labelId,
           })
-        : hostsAPI.destroyBulk(selectedHostIds);
+        : hostsAPI.destroyBulk(selectedHostIds));
 
       const successMessage = `${
         selectedHostIds.length === 1 ? "Host" : "Hosts"


### PR DESCRIPTION
## Issue
Cerra #11885 

## Description
Somehow both actions were being performed, replaced `let action` with a `ternary` for either action so only one action will be performed

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
