### PR TITLE
Fleet docs: Clarify to use chrome extension only on ChromeOS

### DIFF
--- a/docs/Using-Fleet/Adding-hosts.md
+++ b/docs/Using-Fleet/Adding-hosts.md
@@ -29,7 +29,7 @@ Fleet gathers information from an [osquery](https://github.com/osquery/osquery) 
 
 You can also install plain osquery on your hosts and connect to Fleet using osquery's `TLS API` plugins.
 
-> For ChromeOS hosts, the fleetd Chrome extension is installed instead of osquery.
+> For ChromeOS hosts, the fleetd Chrome extension is installed instead of osquery. This Chrome browser extension is only supported on ChromeOS operating systems that are managed using [Google Admin](https://admin.google.com). 
 
 ## Add hosts with Orbit
 

--- a/docs/Using-Fleet/ChromeOS.md
+++ b/docs/Using-Fleet/ChromeOS.md
@@ -3,6 +3,8 @@
 ## Adding ChromeOS hosts to Fleet
 Fleet provides a Chrome extension which you can install via Google Admin.
 
+> For ChromeOS hosts, the fleetd Chrome extension is installed instead of osquery. This Chrome browser extension is only supported on ChromeOS operating systems that are managed using [Google Admin](https://admin.google.com). 
+
 To learn how to add ChromeOS hosts to Fleet, visit [here](https://fleetdm.com/docs/using-fleet/adding-hosts#add-chromebooks-with-the-fleetd-chrome-extension).
 
 ## Available tables


### PR DESCRIPTION

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Documented any permissions changes

