### PR TITLE
Fleet UI: [unreleased bug] hide ChromeOS in schedule dropdown

### DIFF
--- a/frontend/pages/packs/EditPackPage/components/PackQueryEditorModal/PackQueryEditorModal.tsx
+++ b/frontend/pages/packs/EditPackPage/components/PackQueryEditorModal/PackQueryEditorModal.tsx
@@ -11,7 +11,7 @@ import InputField from "components/forms/fields/InputField";
 import { IQuery } from "interfaces/query";
 import { IScheduledQuery } from "interfaces/scheduled_query";
 import {
-  PLATFORM_DROPDOWN_OPTIONS,
+  SCHEDULE_PLATFORM_DROPDOWN_OPTIONS,
   LOGGING_TYPE_OPTIONS,
   MAX_OSQUERY_SCHEDULED_QUERY_INTERVAL,
   MIN_OSQUERY_VERSION_OPTIONS,
@@ -218,7 +218,7 @@ const PackQueryEditorModal = ({
           wrapperClassName={`${baseClass}__form-field ${baseClass}__form-field--logging`}
         />
         <Dropdown
-          options={PLATFORM_DROPDOWN_OPTIONS}
+          options={SCHEDULE_PLATFORM_DROPDOWN_OPTIONS}
           placeholder="Select"
           label="Platform"
           onChange={onChangeSelectPlatformOptions}

--- a/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
+++ b/frontend/pages/schedule/ManageSchedulePage/components/ScheduleEditorModal/ScheduleEditorModal.tsx
@@ -18,7 +18,7 @@ import InputField from "components/forms/fields/InputField";
 import CustomLink from "components/CustomLink";
 import {
   FREQUENCY_DROPDOWN_OPTIONS,
-  PLATFORM_DROPDOWN_OPTIONS,
+  SCHEDULE_PLATFORM_DROPDOWN_OPTIONS,
   LOGGING_TYPE_OPTIONS,
   MIN_OSQUERY_VERSION_OPTIONS,
 } from "utilities/constants";
@@ -303,7 +303,7 @@ const ScheduleEditorModal = ({
                 wrapperClassName={`${baseClass}__form-field ${baseClass}__form-field--logging`}
               />
               <Dropdown
-                options={PLATFORM_DROPDOWN_OPTIONS}
+                options={SCHEDULE_PLATFORM_DROPDOWN_OPTIONS}
                 placeholder="Select"
                 label="Platform"
                 onChange={onChangeSelectPlatformOptions}

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -197,6 +197,12 @@ export const PLATFORM_DROPDOWN_OPTIONS: IPlatformDropdownOptions[] = [
   { label: "ChromeOS", value: "chrome", path: paths.DASHBOARD_CHROME },
 ];
 
+// Schedules does not support ChromeOS
+export const SCHEDULE_PLATFORM_DROPDOWN_OPTIONS: IPlatformDropdownOptions[] = PLATFORM_DROPDOWN_OPTIONS.slice(
+  0,
+  -1
+);
+
 export const PLATFORM_NAME_TO_LABEL_NAME = {
   all: "",
   darwin: "macOS",


### PR DESCRIPTION
## Issue
Cerra #12252 

## Description
Modify options of platform dropdown for schedule platform dropdown and hidden packs dropdown (how did I remember this) to not include ChromeOS


# Checklist for submitter

- [x] Manual QA for all new/changed functionality
