### PR TITLE
Website: Update customer migration webhook

### DIFF
--- a/website/api/controllers/webhooks/receive-from-customer-fleet-instance.js
+++ b/website/api/controllers/webhooks/receive-from-customer-fleet-instance.js
@@ -68,6 +68,7 @@ module.exports = {
     }
 
     // Send a request to Workspace ONE to get an authorization token to use for the request to the Workspace ONE instance.
+    // [?] https://docs.vmware.com/en/VMware-Workspace-ONE-Access/services/ws1_access_service_administration_cloud/GUID-2B419DC4-7332-448A-9285-E10FF90890F8.html
     let oauthResponse = await sails.helpers.http.sendHttpRequest.with({
       method: 'POST',
       url: 'https://na.uemauth.vmwservices.com/connect/token',
@@ -89,7 +90,6 @@ module.exports = {
       url: `/api/mdm/devices/commands?searchby=Serialnumber&id=${encodeURIComponent(host.hardware_serial)}&command=EnterpriseWipe`,
       headers: {
         'Authorization': 'Bearer '+oauthResponse.access_token,
-        'aw-tenant-code': sails.config.custom.customerWorkspaceOneTenantId,
       },
       baseUrl: sails.config.custom.customerWorkspaceOneBaseUrl
     })

--- a/website/api/controllers/webhooks/receive-from-customer-fleet-instance.js
+++ b/website/api/controllers/webhooks/receive-from-customer-fleet-instance.js
@@ -73,9 +73,9 @@ module.exports = {
       url: 'https://na.uemauth.vmwservices.com/connect/token',
       enctype: 'application/x-www-form-urlencoded',
       body: {
-        grant_type: 'client_credentials',
-        client_id: sails.config.custom.customerWorkspaceOneOauthId,
-        client_secret: sails.config.custom.customerWorkspaceOneOauthSecret,
+        grant_type: 'client_credentials',//eslint-disable-line camelcase
+        client_id: sails.config.custom.customerWorkspaceOneOauthId,//eslint-disable-line camelcase
+        client_secret: sails.config.custom.customerWorkspaceOneOauthSecret,//eslint-disable-line camelcase
       }
     })
     .intercept((err)=>{

--- a/website/api/controllers/webhooks/receive-from-customer-fleet-instance.js
+++ b/website/api/controllers/webhooks/receive-from-customer-fleet-instance.js
@@ -51,12 +51,12 @@ module.exports = {
       throw new Error('No sails.config.custom.customerWorkspaceOneBaseUrl configured! Please set this value to be the base url of the customers Workspace One instance.');
     }
 
-    if(!sails.config.custom.customerWorkspaceOneTenantId) {
-      throw new Error('No sails.config.custom.customerWorkspaceOneTenantId configured! Please set this value to be a the "AirWatch" API token from the Customer\'s Workspace One instance.');
+    if(!sails.config.custom.customerWorkspaceOneOauthId) {
+      throw new Error('No sails.config.custom.customerWorkspaceOneOauthId configured! Please set this value to be the client id of the Oauth token for requests to the customer\'s Workspace One instance.');
     }
 
-    if(!sails.config.custom.customerWorkspaceOneAuthorizationToken) {
-      throw new Error('No sails.config.custom.customerWorkspaceOneAuthorizationToken configured! Please set this value to be the authorization header for requests to the customer\'s Workspace One instance.');
+    if(!sails.config.custom.customerWorkspaceOneOauthSecret) {
+      throw new Error('No sails.config.custom.customerWorkspaceOneOauthSecret configured! Please set this value to be the client id of the Oauth token for requests to the customer\'s Workspace One instance.');
     }
 
     if(!sails.config.custom.customerMigrationWebhookSecret) {
@@ -67,13 +67,28 @@ module.exports = {
       throw 'unauthorized';
     }
 
+    // Send a request to Workspace ONE to get an authorization token to use for the request to the Workspace ONE instance.
+    let oauthResponse = await sails.helpers.http.sendHttpRequest.with({
+      method: 'POST',
+      url: 'https://na.uemauth.vmwservices.com/connect/token',
+      enctype: 'application/x-www-form-urlencoded',
+      body: {
+        grant_type: 'client_credentials',
+        client_id: sails.config.custom.customerWorkspaceOneOauthId,
+        client_secret: sails.config.custom.customerWorkspaceOneOauthSecret,
+      }
+    })
+    .intercept((err)=>{
+      return new Error(`When sending a request to get a Workspace ONE authorization token for the recieve-from-customer-fleet-instance webhook, an error occured. Full error: ${err.stack}`);
+    });
+
     // Send a request to unenroll this host in the customer's Workspace One instance.
     await sails.helpers.http.post.with({
       // Contrary to what you what think the EnterpriseWipe command only unenrolls the host from a Workspace One instance.
       // [?] [Workspace One URL]/API/help/#!/CommandsV1/CommandsV1_ExecuteByAlternateIdAsync
       url: `/api/mdm/devices/commands?searchby=Serialnumber&id=${encodeURIComponent(host.hardware_serial)}&command=EnterpriseWipe`,
       headers: {
-        'Authorization': sails.config.custom.customerWorkspaceOneAuthorizationToken,
+        'Authorization': 'Bearer '+oauthResponse.access_token,
         'aw-tenant-code': sails.config.custom.customerWorkspaceOneTenantId,
       },
       baseUrl: sails.config.custom.customerWorkspaceOneBaseUrl

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -187,6 +187,12 @@ module.exports.custom = {
   // mergeFreezeAccessToken: '…',
   // datadogApiKey: '…',
 
+  // For receive-from-customer-fleet-instance webhook.
+  // customerWorkspaceOneBaseUrl: '…',
+  // customerWorkspaceOneOauthId: '…',
+  // customerWorkspaceOneOauthSecret: '…',
+  // customerMigrationWebhookSecret: '…',
+
   //…
 
 };


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/2964

Changes:

- Updated the `receive-from-customer-fleet-instance` webhook to send a request to a Workspace One OAuth URL to get the authorization token used to send requests to a Workspace one instance.


Before this is merged, we will need to:
- [ ] remove the `sails.custom.config.customerWorkspaceOneTenantId` and `customerWorkspaceOneAuthorizationToken` config variables.
- [ ] Add two new config variables: `sails.config.custom.customerWorkspaceOneOauthSecret` and `sails.config.custom.customerWorkspaceOneOauthId`

.