### PR TITLE
Website: Fix bug in customer migration webhook

### DIFF
--- a/website/api/controllers/webhooks/receive-from-customer-fleet-instance.js
+++ b/website/api/controllers/webhooks/receive-from-customer-fleet-instance.js
@@ -69,7 +69,7 @@ module.exports = {
 
     // Send a request to Workspace ONE to get an authorization token to use for the request to the Workspace ONE instance.
     // [?] https://docs.vmware.com/en/VMware-Workspace-ONE-Access/services/ws1_access_service_administration_cloud/GUID-2B419DC4-7332-448A-9285-E10FF90890F8.html
-    let oauthResponse = await sails.helpers.http.sendHttpRequest.with({
+    // Note: We're using the sendHttpRequest helper so we can set the enctype to be application/x-www-form-urlencoded.
       method: 'POST',
       url: 'https://na.uemauth.vmwservices.com/connect/token',
       enctype: 'application/x-www-form-urlencoded',
@@ -83,7 +83,7 @@ module.exports = {
       return new Error(`When sending a request to get a Workspace ONE authorization token for the recieve-from-customer-fleet-instance webhook, an error occured. Full error: ${err.stack}`);
     });
 
-    // The body in responses returned from the sendHTTPRequest helper will always be a string, so we need to parse the raw JSON response body to get the access_token returned from the OAuth URL.
+    // The body in responses returned from the sendHttpRequest helper will always be a string, so we need to parse the raw JSON response body to get the access_token returned from the OAuth URL.
     // [?]: https://github.com/sailshq/machinepack-http/blob/9770e75db5f005c21068f5411177bf7e072bfd78/lib/send-http-request.js#L91C27-L94
     let oauthResponseBody = JSON.parse(oauthResponse.body);
 

--- a/website/api/controllers/webhooks/receive-from-customer-fleet-instance.js
+++ b/website/api/controllers/webhooks/receive-from-customer-fleet-instance.js
@@ -69,7 +69,8 @@ module.exports = {
 
     // Send a request to Workspace ONE to get an authorization token to use for the request to the Workspace ONE instance.
     // [?] https://docs.vmware.com/en/VMware-Workspace-ONE-Access/services/ws1_access_service_administration_cloud/GUID-2B419DC4-7332-448A-9285-E10FF90890F8.html
-    // Note: We're using the sendHttpRequest helper so we can set the enctype to be application/x-www-form-urlencoded.
+    // Note: We're using the sendHttpRequest helper so we can set the enctype to be application/x-www-form-urlencoded
+    let oauthResponse = await sails.helpers.http.sendHttpRequest.with({
       method: 'POST',
       url: 'https://na.uemauth.vmwservices.com/connect/token',
       enctype: 'application/x-www-form-urlencoded',

--- a/website/api/controllers/webhooks/receive-from-customer-fleet-instance.js
+++ b/website/api/controllers/webhooks/receive-from-customer-fleet-instance.js
@@ -77,13 +77,13 @@ module.exports = {
         grant_type: 'client_credentials',//eslint-disable-line camelcase
         client_id: sails.config.custom.customerWorkspaceOneOauthId,//eslint-disable-line camelcase
         client_secret: sails.config.custom.customerWorkspaceOneOauthSecret,//eslint-disable-line camelcase
-      }
+      },
     })
     .intercept((err)=>{
       return new Error(`When sending a request to get a Workspace ONE authorization token for the recieve-from-customer-fleet-instance webhook, an error occured. Full error: ${err.stack}`);
     });
 
-    // The body in responses returned from the sendHTTPRequest helper will always be a string, so we need to parse the JSON response body to get the access_token returned from the OAuth URL.
+    // The body in responses returned from the sendHTTPRequest helper will always be a string, so we need to parse the raw JSON response body to get the access_token returned from the OAuth URL.
     // [?]: https://github.com/sailshq/machinepack-http/blob/9770e75db5f005c21068f5411177bf7e072bfd78/lib/send-http-request.js#L91C27-L94
     let oauthResponseBody = JSON.parse(oauthResponse.body);
 


### PR DESCRIPTION
Changes:
- Updated the `receive-from-customer-fleet-instance` webhook to parse the JSON response body from the request to the OAuth URL.
.