### PR TITLE
Fleet UI: [unreleased bug] Fix ChromeOS platform no longer showing with API change

### DIFF
--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -85,7 +85,7 @@ const parseLabels = (list?: ILabelSummary[]) => {
         l.name === "macOS" ||
         l.name === "MS Windows" ||
         l.name === "All Linux" ||
-        l.name === "ChromeOS"
+        l.name === "chrome"
     ) || [];
   const other = list?.filter((l) => l.label_type === "regular") || [];
 
@@ -103,6 +103,8 @@ const TargetPillSelector = ({
         return "All hosts";
       case "All Linux":
         return "Linux";
+      case "chrome":
+        return "ChromeOS";
       default:
         return entity.name || "Missing display name"; // TODO
     }


### PR DESCRIPTION

## Description
- change to label summary name to "chrome" needed frontend change to continue showing the label for selecting a platform for a live query / live policy

# Checklist for submitter

If some of the following don't apply, delete the relevant line.


- [x] Manual QA for all new/changed functionality

