### PR TITLE
Fleet UI: Hiding tables and columns from the UI if they are set to hidden

### DIFF
--- a/changes/11655-hide-osquery-table-info
+++ b/changes/11655-hide-osquery-table-info
@@ -1,0 +1,1 @@
+- Hide any osquery tables or columns from Fleet UI that has hidden set to true to match Fleet website

--- a/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tests.tsx
+++ b/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tests.tsx
@@ -60,7 +60,7 @@ describe("QuerySidePanel - component", () => {
       />
     );
 
-    const tooltip = screen.getByText(/only available on windows/i);
+    const tooltip = screen.getByText(/only available on chrome/i);
     expect(tooltip).toBeInTheDocument();
   });
 

--- a/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tests.tsx
+++ b/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tests.tsx
@@ -38,7 +38,7 @@ describe("QuerySidePanel - component", () => {
     expect(platformCompatibility).toHaveTextContent(/chromeos/i);
   });
 
-  it("renders the correct number of columns", () => {
+  it("renders the correct number of columns including hiding columns set to hidden", () => {
     const { container } = render(
       <QuerySidePanel
         selectedOsqueryTable={createMockOsqueryTable()}
@@ -48,7 +48,7 @@ describe("QuerySidePanel - component", () => {
     );
 
     const platformList = container.getElementsByClassName("column-list-item");
-    expect(platformList.length).toBe(13);
+    expect(platformList.length).toBe(11); // 2 columns are set to hidden
   });
 
   it("renders the platform specific column tooltip", () => {

--- a/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tsx
+++ b/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tsx
@@ -47,11 +47,9 @@ const QuerySidePanel = ({
   };
 
   const renderTableSelect = () => {
-    const tableNames = osqueryTableNames
-      ?.filter((tableName) => !tableName.hidden)
-      .map((tableName: string) => {
-        return { label: tableName, value: tableName };
-      });
+    const tableNames = osqueryTableNames.map((tableName: string) => {
+      return { label: tableName, value: tableName };
+    });
 
     return (
       <Dropdown

--- a/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tsx
+++ b/frontend/components/side_panels/QuerySidePanel/QuerySidePanel.tsx
@@ -47,9 +47,11 @@ const QuerySidePanel = ({
   };
 
   const renderTableSelect = () => {
-    const tableNames = osqueryTableNames?.map((tableName: string) => {
-      return { label: tableName, value: tableName };
-    });
+    const tableNames = osqueryTableNames
+      ?.filter((tableName) => !tableName.hidden)
+      .map((tableName: string) => {
+        return { label: tableName, value: tableName };
+      });
 
     return (
       <Dropdown

--- a/frontend/components/side_panels/QuerySidePanel/QueryTableColumns/QueryTableColumns.tsx
+++ b/frontend/components/side_panels/QuerySidePanel/QueryTableColumns/QueryTableColumns.tsx
@@ -35,15 +35,17 @@ const baseClass = "query-table-columns";
 const QueryTableColumns = ({ columns }: IQueryTableColumnsProps) => {
   const { selectedOsqueryTable } = useContext(QueryContext);
 
-  const columnListItems = orderColumns(columns).map((column) => {
-    return (
-      <ColumnListItem
-        key={column.name}
-        column={column}
-        selectedTableName={selectedOsqueryTable.name}
-      />
-    );
-  });
+  const columnListItems = orderColumns(columns)
+    .filter((column) => !column.hidden)
+    .map((column) => {
+      return (
+        <ColumnListItem
+          key={column.name}
+          column={column}
+          selectedTableName={selectedOsqueryTable.name}
+        />
+      );
+    });
 
   return (
     <div className={baseClass}>

--- a/frontend/interfaces/osquery_table.ts
+++ b/frontend/interfaces/osquery_table.ts
@@ -42,6 +42,7 @@ export interface IOsQueryTable {
   columns: IQueryTableColumn[];
   examples?: string;
   notes?: string;
+  hidden?: boolean;
 }
 
 // Also used for testing

--- a/frontend/utilities/osquery_tables.ts
+++ b/frontend/utilities/osquery_tables.ts
@@ -13,5 +13,5 @@ export const osqueryTables = queryTable.sort((a, b) => {
 
 // Note: Hiding tables where key hidden is set to true
 export const osqueryTableNames = flatMap(osqueryTables, (table) => {
-  return !table.hidden ? table.name : [];
+  return table.hidden ? [] : table.name;
 });

--- a/frontend/utilities/osquery_tables.ts
+++ b/frontend/utilities/osquery_tables.ts
@@ -11,6 +11,7 @@ export const osqueryTables = queryTable.sort((a, b) => {
   return a.name >= b.name ? 1 : -1;
 });
 
+// Note: Hiding tables where key hidden is set to true
 export const osqueryTableNames = flatMap(osqueryTables, (table) => {
-  return table.name;
+  return !table.hidden ? table.name : [];
 });


### PR DESCRIPTION
## Issue
Cerra #11655 

## Description
- If `hidden: true` is set for either a table (2 instances) or a column (57 instances) the table or column is hidden from the UI
- Behavior matches fleetdm.com/tables

## Examples
- `acpi_tables` table should be hidden in UI to match fleetdm.com docs
- Column `eid` in `apparmor_events` table should be hidden in UI to match fleetdm.com docs

## Screenshot of fixes
<img width="474" alt="Screenshot 2023-06-12 at 4 23 29 PM" src="https://github.com/fleetdm/fleet/assets/71795832/371be821-1c86-49a5-9942-d774bae0f045">
<img width="1354" alt="Screenshot 2023-06-12 at 4 23 21 PM" src="https://github.com/fleetdm/fleet/assets/71795832/8839f1c7-5368-4214-85a9-8af1b5375181">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
