### PR TITLE
fleet tf module config

### DIFF
--- a/terraform/byo-vpc/byo-db/byo-ecs/main.tf
+++ b/terraform/byo-vpc/byo-db/byo-ecs/main.tf
@@ -131,12 +131,28 @@ resource "aws_ecs_task_definition" "backend" {
   dynamic "volume" {
     for_each = var.fleet_config.volumes
     content {
-      name                        = volume.value["name"]
-      efs_volume_configuration    = lookup(volume.value, "efs_volume_configuration", null)
-      docker_volume_configuration = lookup(volume.value, "docker_volume_configuration", null)
-      host_path                   = lookup(volume.value, "host_path", null)
+      name      = volume["name"]
+      host_path = lookup(volume.value, "host_path", null)
+
+      dynamic "docker_volume_configuration" {
+        for_each = lookup(volume.value, "docker_volume_configuration", [])
+        content {
+          scope         = lookup(docker_volume_configuration.value, "scope", null)
+          autoprovision = lookup(docker_volume_configuration.value, "autoprovision", null)
+          driver        = lookup(docker_volume_configuration.value, "driver", null)
+          driver_opts   = lookup(docker_volume_configuration.value, "driver_opts", null)
+          labels        = lookup(docker_volume_configuration.value, "labels", null)
+        }
+      }
+
+      dynamic "efs_volume_configuration" {
+        for_each = lookup(volume.value, "efs_volume_configuration", [])
+        content {
+          file_system_id = lookup(efs_volume_configuration.value, "file_system_id", null)
+          root_directory = lookup(efs_volume_configuration.value, "root_directory", null)
+        }
+      }
     }
-  }
 }
 
 resource "aws_appautoscaling_target" "ecs_target" {

--- a/terraform/byo-vpc/byo-db/byo-ecs/main.tf
+++ b/terraform/byo-vpc/byo-db/byo-ecs/main.tf
@@ -153,6 +153,7 @@ resource "aws_ecs_task_definition" "backend" {
         }
       }
     }
+  }
 }
 
 resource "aws_appautoscaling_target" "ecs_target" {

--- a/terraform/byo-vpc/byo-db/byo-ecs/main.tf
+++ b/terraform/byo-vpc/byo-db/byo-ecs/main.tf
@@ -52,7 +52,7 @@ resource "aws_ecs_task_definition" "backend" {
         image       = var.fleet_config.image
         cpu         = var.fleet_config.cpu
         memory      = var.fleet_config.mem
-        mountPoints = []
+        mountPoints = var.fleet_config.mount_points
         volumesFrom = []
         essential   = true
         portMappings = [
@@ -128,6 +128,15 @@ resource "aws_ecs_task_definition" "backend" {
         ], local.environment)
       }
   ], var.fleet_config.sidecars))
+  dynamic "volume" {
+    for_each = var.fleet_config.volumes
+    content {
+      name                        = volume.value["name"]
+      efs_volume_configuration    = lookup(volume.value, "efs_volume_configuration", null)
+      docker_volume_configuration = lookup(volume.value, "docker_volume_configuration", null)
+      host_path                   = lookup(volume.value, "host_path", null)
+    }
+  }
 }
 
 resource "aws_appautoscaling_target" "ecs_target" {

--- a/terraform/byo-vpc/byo-db/byo-ecs/main.tf
+++ b/terraform/byo-vpc/byo-db/byo-ecs/main.tf
@@ -53,6 +53,7 @@ resource "aws_ecs_task_definition" "backend" {
         cpu         = var.fleet_config.cpu
         memory      = var.fleet_config.mem
         mountPoints = var.fleet_config.mount_points
+        dependsOn   = var.fleet_config.depends_on
         volumesFrom = []
         essential   = true
         portMappings = [
@@ -131,7 +132,7 @@ resource "aws_ecs_task_definition" "backend" {
   dynamic "volume" {
     for_each = var.fleet_config.volumes
     content {
-      name      = volume["name"]
+      name      = volume.value.name
       host_path = lookup(volume.value, "host_path", null)
 
       dynamic "docker_volume_configuration" {

--- a/terraform/byo-vpc/byo-db/byo-ecs/variables.tf
+++ b/terraform/byo-vpc/byo-db/byo-ecs/variables.tf
@@ -16,6 +16,9 @@ variable "fleet_config" {
     image                        = optional(string, "fleetdm/fleet:v4.31.1")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
+    depends_on                   = optional(list(any), [])
+    mount_points                 = optional(list(any), [])
+    volumes                      = optional(list(any), [])
     extra_environment_variables  = optional(map(string), {})
     extra_iam_policies           = optional(list(string), [])
     extra_execution_iam_policies = optional(list(string), [])
@@ -94,6 +97,9 @@ variable "fleet_config" {
     image                        = "fleetdm/fleet:v4.31.1"
     family                       = "fleet"
     sidecars                     = []
+    depends_on                   = []
+    mount_points                 = []
+    volumes                      = []
     extra_environment_variables  = {}
     extra_iam_policies           = []
     extra_execution_iam_policies = []

--- a/terraform/byo-vpc/byo-db/variables.tf
+++ b/terraform/byo-vpc/byo-db/variables.tf
@@ -55,6 +55,9 @@ variable "fleet_config" {
     image                        = optional(string, "fleetdm/fleet:v4.31.1")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
+    depends_on                   = optional(list(any), [])
+    mount_points                 = optional(list(any), [])
+    volumes                      = optional(list(any), [])
     extra_environment_variables  = optional(map(string), {})
     extra_iam_policies           = optional(list(string), [])
     extra_execution_iam_policies = optional(list(string), [])
@@ -133,6 +136,9 @@ variable "fleet_config" {
     image                        = "fleetdm/fleet:v4.31.1"
     family                       = "fleet"
     sidecars                     = []
+    depends_on                   = []
+    volumes                      = []
+    mount_points                 = []
     extra_environment_variables  = {}
     extra_iam_policies           = []
     extra_execution_iam_policies = []

--- a/terraform/byo-vpc/variables.tf
+++ b/terraform/byo-vpc/variables.tf
@@ -145,6 +145,9 @@ variable "fleet_config" {
     image                        = optional(string, "fleetdm/fleet:v4.31.1")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
+    depends_on                   = optional(list(any), [])
+    mount_points                 = optional(list(any), [])
+    volumes                      = optional(list(any), [])
     extra_environment_variables  = optional(map(string), {})
     extra_iam_policies           = optional(list(string), [])
     extra_execution_iam_policies = optional(list(string), [])
@@ -223,6 +226,9 @@ variable "fleet_config" {
     image                        = "fleetdm/fleet:v4.31.1"
     family                       = "fleet"
     sidecars                     = []
+    depends_on                   = []
+    volumes                      = []
+    mount_points                 = []
     extra_environment_variables  = {}
     extra_iam_policies           = []
     extra_execution_iam_policies = []

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -218,6 +218,9 @@ variable "fleet_config" {
     image                        = optional(string, "fleetdm/fleet:v4.31.1")
     family                       = optional(string, "fleet")
     sidecars                     = optional(list(any), [])
+    depends_on                   = optional(list(any), [])
+    mount_points                 = optional(list(any), [])
+    volumes                      = optional(list(any), [])
     extra_environment_variables  = optional(map(string), {})
     extra_iam_policies           = optional(list(string), [])
     extra_execution_iam_policies = optional(list(string), [])
@@ -310,6 +313,9 @@ variable "fleet_config" {
     image                        = "fleetdm/fleet:v4.31.1"
     family                       = "fleet"
     sidecars                     = []
+    depends_on                   = []
+    volumes                      = []
+    mount_points                 = []
     extra_environment_variables  = {}
     extra_iam_policies           = []
     extra_execution_iam_policies = []


### PR DESCRIPTION
add the ability to define the following for fleet config:

- mount points
- depends on
- volumes

adding this with the existing sidecar support enabled utilization of https://github.com/aws-samples/aws-secret-sidecar-injector as discovered by @rfairburn 