### PR TITLE
Fleet UI: [Released styling bug] Fix setup icon pushed off setup steps

### DIFF
--- a/changes/12310-setup-styling
+++ b/changes/12310-setup-styling
@@ -1,0 +1,1 @@
+Fix styling bug on setup caused by new font being much wider

--- a/frontend/pages/RegistrationPage/Breadcrumbs/_styles.scss
+++ b/frontend/pages/RegistrationPage/Breadcrumbs/_styles.scss
@@ -17,15 +17,17 @@
     font-weight: $regular;
     color: $core-white;
     position: relative;
-    padding-bottom: 5px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 
     &::before {
       content: "";
       position: absolute;
-      width: 197px;
+      width: 198px;
       height: 2px;
       background-color: $core-vibrant-blue;
-      bottom: 46px;
+      bottom: 78px;
       left: 90px;
 
       @include breakpoint(tablet) {
@@ -41,7 +43,7 @@
       border-radius: 50%;
       content: "";
       font-size: $x-large;
-      margin: 14px auto 0;
+      margin-top: 12px;
       position: relative;
       z-index: 1;
       cursor: pointer;
@@ -64,6 +66,7 @@
     &--1 {
       &::after {
         border: 2px solid $core-white;
+        margin-top: 11px;
       }
 
       &.registration-breadcrumbs__page--active {
@@ -78,6 +81,7 @@
         &::after {
           background-color: transparent;
           border: 2px solid $core-white;
+          margin-top: 13px;
         }
       }
 
@@ -100,6 +104,7 @@
     &--2 {
       &::after {
         border: solid 1px $core-vibrant-blue;
+        margin-top: 11px;
       }
 
       &.registration-breadcrumbs__page--active {
@@ -114,6 +119,7 @@
         &::after {
           background-color: transparent;
           border: 2px solid $core-white;
+          margin-top: 13px;
         }
       }
 
@@ -139,6 +145,7 @@
 
       &::after {
         border: solid 1px $core-vibrant-blue;
+        margin-top: 11px;
       }
 
       &.registration-breadcrumbs__page--active {
@@ -153,6 +160,7 @@
         &::after {
           background-color: transparent;
           border: 2px solid $core-white;
+          margin-top: 13px;
         }
       }
 

--- a/frontend/pages/RegistrationPage/Breadcrumbs/_styles.scss
+++ b/frontend/pages/RegistrationPage/Breadcrumbs/_styles.scss
@@ -12,7 +12,7 @@
 
   &__page {
     text-align: center;
-    width: 150px;
+    width: 156px;
     font-size: $small;
     font-weight: $regular;
     color: $core-white;
@@ -22,11 +22,11 @@
     &::before {
       content: "";
       position: absolute;
-      width: 200px;
+      width: 197px;
       height: 2px;
       background-color: $core-vibrant-blue;
       bottom: 46px;
-      left: 87px;
+      left: 90px;
 
       @include breakpoint(tablet) {
         bottom: 25px;


### PR DESCRIPTION
## Issue
Cerra #12310 

## Description
- Width was not wide enough to keep styling with new wide font
- Instead of just moving a few pixels, implemented flex boxes to help style

## Screenrecording of fix

https://github.com/fleetdm/fleet/assets/71795832/f154ede1-6d01-4036-9cf9-5e068dc8ad78


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

