### PR TITLE
If the fleet/forgot_password endpoint is rate limited, it should return the proper status code

### DIFF
--- a/changes/bug-10720-ratelimits-should-return-proper-status-code
+++ b/changes/bug-10720-ratelimits-should-return-proper-status-code
@@ -1,1 +1,3 @@
-- If the `fleet/forgot_password` endpoint is rate limited it should return the proper HTTP status code.
+- If the `fleet/forgot_password` endpoint is rate limited it should return the proper HTTP status
+  code.
+- Fixed MaxBurst limit parameter for `fleet/forgot_password` endpoint.

--- a/changes/bug-10720-ratelimits-should-return-proper-status-code
+++ b/changes/bug-10720-ratelimits-should-return-proper-status-code
@@ -1,0 +1,1 @@
+- If the `fleet/forgot_password` endpoint is rate limited it should return the proper HTTP status code.

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -244,10 +244,11 @@ func addMetrics(r *mux.Router) {
 	r.Walk(walkFn) //nolint:errcheck
 }
 
-// desktopRateLimitMaxBurst is the max burst used for device request rate limiting.
-//
-// Defined as const to be used in tests.
-const desktopRateLimitMaxBurst = 100
+// These are defined as const so that they can be used in tests.
+const (
+	desktopRateLimitMaxBurst        = 100 // Max burst used for device request rate limiting.
+	forgotPasswordRateLimitMaxBurst = 90  // Max burst used for rate limiting on the the forgot_password endpoint.
+)
 
 func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetConfig,
 	logger kitlog.Logger, limitStore throttled.GCRAStore, opts []kithttp.ServerOption,
@@ -613,7 +614,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	// the handler.
 	ne.UsePathPrefix().PathHandler("GET", "/api/_version_/fleet/results/", makeStreamDistributedQueryCampaignResultsHandler(config.Server, svc, logger))
 
-	quota := throttled.RateQuota{MaxRate: throttled.PerHour(10), MaxBurst: 90}
+	quota := throttled.RateQuota{MaxRate: throttled.PerHour(10), MaxBurst: forgotPasswordRateLimitMaxBurst}
 	limiter := ratelimit.NewMiddleware(limitStore)
 	ne.
 		WithCustomMiddleware(limiter.Limit("forgot_password", quota)).

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -247,7 +247,7 @@ func addMetrics(r *mux.Router) {
 // These are defined as const so that they can be used in tests.
 const (
 	desktopRateLimitMaxBurst        = 100 // Max burst used for device request rate limiting.
-	forgotPasswordRateLimitMaxBurst = 90  // Max burst used for rate limiting on the the forgot_password endpoint.
+	forgotPasswordRateLimitMaxBurst = 9   // Max burst used for rate limiting on the the forgot_password endpoint.
 )
 
 func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetConfig,

--- a/server/service/integration_desktop_test.go
+++ b/server/service/integration_desktop_test.go
@@ -241,13 +241,13 @@ func (s *integrationTestSuite) TestRateLimitOfEndpoints() {
 			endpoint: "/api/latest/fleet/forgot_password",
 			verb:     "POST",
 			payload:  forgotPasswordRequest{Email: "some@one.com"},
-			burst:    forgotPasswordRateLimitMaxBurst,
+			burst:    forgotPasswordRateLimitMaxBurst - 1,
 			status:   http.StatusAccepted,
 		},
 		{
 			endpoint: "/api/latest/fleet/device/" + uuid.NewString(),
 			verb:     "GET",
-			burst:    desktopRateLimitMaxBurst,
+			burst:    desktopRateLimitMaxBurst + 1,
 			status:   http.StatusUnauthorized,
 		},
 	}
@@ -256,7 +256,7 @@ func (s *integrationTestSuite) TestRateLimitOfEndpoints() {
 		b, err := json.Marshal(tCase.payload)
 		require.NoError(s.T(), err)
 
-		for i := 0; i < tCase.burst+1; i++ {
+		for i := 0; i < tCase.burst; i++ {
 			s.DoRawWithHeaders(tCase.verb, tCase.endpoint, b, tCase.status, headers).Body.Close()
 		}
 		s.DoRawWithHeaders(tCase.verb, tCase.endpoint, b, http.StatusTooManyRequests, headers).Body.Close()

--- a/server/service/integration_desktop_test.go
+++ b/server/service/integration_desktop_test.go
@@ -225,12 +225,40 @@ func (s *integrationTestSuite) TestDefaultTransparencyURL() {
 	require.Equal(t, fleet.DefaultTransparencyURL, rawResp.Header.Get("Location"))
 }
 
-func (s *integrationTestSuite) TestDesktopRateLimit() {
+func (s *integrationTestSuite) TestRateLimitOfEndpoints() {
 	headers := map[string]string{
 		"X-Forwarded-For": "1.2.3.4",
 	}
-	for i := 0; i < desktopRateLimitMaxBurst+1; i++ { // rate limiting off-by-one
-		s.DoRawWithHeaders("GET", "/api/latest/fleet/device/"+uuid.NewString(), nil, http.StatusUnauthorized, headers).Body.Close()
+
+	testCases := []struct {
+		endpoint string
+		verb     string
+		payload  interface{}
+		burst    int
+		status   int
+	}{
+		{
+			endpoint: "/api/latest/fleet/forgot_password",
+			verb:     "POST",
+			payload:  forgotPasswordRequest{Email: "some@one.com"},
+			burst:    forgotPasswordRateLimitMaxBurst,
+			status:   http.StatusAccepted,
+		},
+		{
+			endpoint: "/api/latest/fleet/device/" + uuid.NewString(),
+			verb:     "GET",
+			burst:    desktopRateLimitMaxBurst,
+			status:   http.StatusUnauthorized,
+		},
 	}
-	s.DoRawWithHeaders("GET", "/api/latest/fleet/device/"+uuid.NewString(), nil, http.StatusTooManyRequests, headers).Body.Close()
+
+	for _, tCase := range testCases {
+		b, err := json.Marshal(tCase.payload)
+		require.NoError(s.T(), err)
+
+		for i := 0; i < tCase.burst+1; i++ {
+			s.DoRawWithHeaders(tCase.verb, tCase.endpoint, b, tCase.status, headers).Body.Close()
+		}
+		s.DoRawWithHeaders(tCase.verb, tCase.endpoint, b, http.StatusTooManyRequests, headers).Body.Close()
+	}
 }

--- a/server/service/middleware/ratelimit/ratelimit.go
+++ b/server/service/middleware/ratelimit/ratelimit.go
@@ -40,7 +40,13 @@ func (m *Middleware) Limit(keyName string, quota throttled.RateQuota) endpoint.M
 			if err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "check rate limit")
 			}
+
 			if limited {
+				// We need to set authentication as checked, otherwise we end up returning HTTP 500
+				// errors.
+				if az, ok := authz_ctx.FromContext(ctx); ok {
+					az.SetChecked()
+				}
 				return nil, ctxerr.Wrap(ctx, &ratelimitError{result: result})
 			}
 


### PR DESCRIPTION
Relates to https://github.com/fleetdm/fleet/issues/10720

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality