### PR TITLE
Website: Update regex used to change markdown links

### DIFF
--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -322,7 +322,7 @@ module.exports = {
                   if (isBaseUrl) {
                     return hrefString.replace(/href="https?:\/\//, '').replace(/([^\.]+\.)*fleetdm\.com/, 'href="/');
                   } else {
-                    return hrefString.replace(/href="https?:\/\//, '').replace(/^fleetdm\.com/, 'href="');
+                    return hrefString.replace(/href="https?:\/\//, '').replace(/([^\.]+\.)*fleetdm\.com/, 'href="');
                   }
                 }
 

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -322,7 +322,7 @@ module.exports = {
                   if (isBaseUrl) {
                     return hrefString.replace(/href="https?:\/\//, '').replace(/([^\.]+\.)*fleetdm\.com/, 'href="/');
                   } else {
-                    return hrefString.replace(/href="https?:\/\//, '').replace(/([^\.]+\.)*fleetdm\.com/, 'href="');
+                    return hrefString.replace(/href="https?:\/\//, '').replace(/^([^\.]+\.)*fleetdm\.com/, 'href="');
                   }
                 }
 


### PR DESCRIPTION
Closes: #12315
Changes:
- Updated the regex that is used to change Markdown links to fleetdm.com into web root-relative links to support fleetdm.com links that start with `www.`
