### PR TITLE
When authorizing users on the PolicySpec endpoint, return proper status code if team not found

### DIFF
--- a/changes/bug-2790-return-proper-status-code
+++ b/changes/bug-2790-return-proper-status-code
@@ -1,0 +1,1 @@
+- When creating a PolicySpec, return the proper HTTP status code if the Team is not found.

--- a/server/service/global_policies.go
+++ b/server/service/global_policies.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 
@@ -439,6 +440,9 @@ func (svc *Service) checkPolicySpecAuthorization(ctx context.Context, policies [
 		if policy.Team != "" {
 			team, err := svc.ds.TeamByName(ctx, policy.Team)
 			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return newNotFoundError()
+				}
 				return ctxerr.Wrap(ctx, err, "getting team by name")
 			}
 			if err := svc.authz.Authorize(ctx, &fleet.Policy{

--- a/server/service/global_policies.go
+++ b/server/service/global_policies.go
@@ -440,9 +440,13 @@ func (svc *Service) checkPolicySpecAuthorization(ctx context.Context, policies [
 		if policy.Team != "" {
 			team, err := svc.ds.TeamByName(ctx, policy.Team)
 			if err != nil {
+				// This is so that the proper HTTP status code is returned
+				svc.authz.SkipAuthorization(ctx)
+
 				if errors.Is(err, sql.ErrNoRows) {
 					return newNotFoundError()
 				}
+
 				return ctxerr.Wrap(ctx, err, "getting team by name")
 			}
 			if err := svc.authz.Authorize(ctx, &fleet.Policy{

--- a/server/service/global_policies_test.go
+++ b/server/service/global_policies_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
@@ -10,6 +11,31 @@ import (
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCheckPolicySpecAuthorization(t *testing.T) {
+	t.Run("when team not found", func(t *testing.T) {
+		ds := new(mock.Store)
+		ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+			return nil, sql.ErrNoRows
+		}
+
+		svc, ctx := newTestService(t, ds, nil, nil)
+
+		req := []*fleet.PolicySpec{
+			{
+				Team: "some_team",
+			},
+		}
+
+		user := &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}
+		ctx = viewer.NewContext(ctx, viewer.Viewer{User: user})
+
+		actual := svc.ApplyPolicySpecs(ctx, req)
+		var expected *notFoundError
+
+		require.ErrorAs(t, actual, &expected)
+	})
+}
 
 func TestGlobalPoliciesAuth(t *testing.T) {
 	ds := new(mock.Store)


### PR DESCRIPTION
Relates to https://github.com/fleetdm/confidential/issues/2790

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality