### PR TITLE
Update terraform logging addon

### DIFF
--- a/terraform/addons/logging-alb/README.md
+++ b/terraform/addons/logging-alb/README.md
@@ -58,8 +58,8 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_athena-s3-bucket"></a> [athena-s3-bucket](#module\_athena-s3-bucket) | terraform-aws-modules/s3-bucket/aws | 3.6.0 |
-| <a name="module_s3_bucket_for_logs"></a> [s3\_bucket\_for\_logs](#module\_s3\_bucket\_for\_logs) | terraform-aws-modules/s3-bucket/aws | 3.6.0 |
+| <a name="module_athena-s3-bucket"></a> [athena-s3-bucket](#module\_athena-s3-bucket) | terraform-aws-modules/s3-bucket/aws | 3.11.0 |
+| <a name="module_s3_bucket_for_logs"></a> [s3\_bucket\_for\_logs](#module\_s3\_bucket\_for\_logs) | terraform-aws-modules/s3-bucket/aws | 3.11.0 |
 
 ## Resources
 
@@ -71,6 +71,8 @@ No requirements.
 | [aws_kms_key.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.s3_athena_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.s3_log_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
@@ -78,6 +80,9 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_enable_athena"></a> [enable\_athena](#input\_enable\_athena) | n/a | `bool` | `true` | no |
+| <a name="input_extra_kms_policies"></a> [extra\_kms\_policies](#input\_extra\_kms\_policies) | n/a | `list(any)` | `[]` | no |
+| <a name="input_extra_s3_athena_policies"></a> [extra\_s3\_athena\_policies](#input\_extra\_s3\_athena\_policies) | n/a | `list(any)` | `[]` | no |
+| <a name="input_extra_s3_log_policies"></a> [extra\_s3\_log\_policies](#input\_extra\_s3\_log\_policies) | n/a | `list(any)` | `[]` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | n/a | `string` | `"fleet"` | no |
 | <a name="input_s3_expiration_days"></a> [s3\_expiration\_days](#input\_s3\_expiration\_days) | n/a | `number` | `90` | no |
 | <a name="input_s3_newer_noncurrent_versions"></a> [s3\_newer\_noncurrent\_versions](#input\_s3\_newer\_noncurrent\_versions) | n/a | `number` | `5` | no |

--- a/terraform/addons/logging-alb/main.tf
+++ b/terraform/addons/logging-alb/main.tf
@@ -2,27 +2,114 @@ data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}
 
-data "aws_iam_policy_document" "kms" {
-  statement {
-    actions = ["kms:*"]
-    principals {
+locals {
+
+  kms_policies = concat([{
+    actions = ["kms:*"],
+    principals = [{
       type        = "AWS"
       identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }]
+    resources = ["*"]
+
+    },
+    {
+      actions = [
+        "kms:Encrypt*",
+        "kms:Decrypt*",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:Describe*",
+      ]
+      resources = ["*"]
+      principals = [{
+        type        = "Service"
+        identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+      }]
+  }], var.extra_kms_policies)
+
+}
+
+
+data "aws_iam_policy_document" "kms" {
+  dynamic "statement" {
+    for_each = local.kms_policies
+    content {
+      sid       = try(statement.value.sid, "")
+      actions   = try(statement.value.actions, [])
+      resources = try(statement.value.resources, [])
+      effect    = try(statement.value.effect, null)
+      dynamic "principals" {
+        for_each = try(statement.value.principals, [])
+        content {
+          type        = principals.value.type
+          identifiers = principals.value.identifiers
+        }
+      }
+      dynamic "condition" {
+        for_each = try(statement.value.conditions, [])
+        content {
+          test     = condition.value.test
+          variable = condition.value.variable
+          values   = condition.value.values
+        }
+      }
     }
-    resources = ["*"]
   }
-  statement {
-    actions = [
-      "kms:Encrypt*",
-      "kms:Decrypt*",
-      "kms:ReEncrypt*",
-      "kms:GenerateDataKey*",
-      "kms:Describe*",
-    ]
-    resources = ["*"]
-    principals {
-      type = "Service"
-      identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+}
+
+data "aws_iam_policy_document" "s3_log_bucket" {
+  count = var.extra_s3_log_policies == [] ? 0 : 1
+  dynamic "statement" {
+    for_each = var.extra_s3_log_policies
+    content {
+      sid       = try(statement.value.sid, "")
+      actions   = try(statement.value.actions, [])
+      resources = try(statement.value.resources, [])
+      effect    = try(statement.value.effect, null)
+      dynamic "principals" {
+        for_each = try(statement.value.principals, [])
+        content {
+          type        = principals.value.type
+          identifiers = principals.value.identifiers
+        }
+      }
+      dynamic "condition" {
+        for_each = try(statement.value.conditions, [])
+        content {
+          test     = condition.value.test
+          variable = condition.value.variable
+          values   = condition.value.values
+        }
+      }
+    }
+  }
+}
+
+data "aws_iam_policy_document" "s3_athena_bucket" {
+  count = var.extra_s3_athena_policies == [] ? 0 : 1
+  dynamic "statement" {
+    for_each = var.extra_s3_athena_policies
+    content {
+      sid       = try(statement.value.sid, "")
+      actions   = try(statement.value.actions, [])
+      resources = try(statement.value.resources, [])
+      effect    = try(statement.value.effect, null)
+      dynamic "principals" {
+        for_each = try(statement.value.principals, [])
+        content {
+          type        = principals.value.type
+          identifiers = principals.value.identifiers
+        }
+      }
+      dynamic "condition" {
+        for_each = try(statement.value.conditions, [])
+        content {
+          test     = condition.value.test
+          variable = condition.value.variable
+          values   = condition.value.values
+        }
+      }
     }
   }
 }
@@ -50,13 +137,15 @@ module "s3_bucket_for_logs" {
   attach_lb_log_delivery_policy         = true # Required for ALB/NLB logs
   attach_deny_insecure_transport_policy = true
   attach_require_latest_tls_policy      = true
+  attach_policy                         = var.extra_s3_log_policies != []
+  policy                                = var.extra_s3_log_policies != [] ? data.aws_iam_policy_document.s3_log_bucket[0].json : null
   block_public_acls                     = true
   block_public_policy                   = true
   ignore_public_acls                    = true
   restrict_public_buckets               = true
   server_side_encryption_configuration = {
     rule = {
-       bucket_key_enabled = true
+      bucket_key_enabled = true
     }
   }
   lifecycle_rule = [
@@ -89,7 +178,7 @@ resource "aws_athena_database" "logs" {
 }
 
 module "athena-s3-bucket" {
-  count  = var.enable_athena == true ? 1 : 0
+  count   = var.enable_athena == true ? 1 : 0
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "3.11.0"
 
@@ -102,6 +191,8 @@ module "athena-s3-bucket" {
   attach_lb_log_delivery_policy         = true # Required for ALB/NLB logs
   attach_deny_insecure_transport_policy = true
   attach_require_latest_tls_policy      = true
+  attach_policy                         = var.extra_s3_athena_policies != []
+  policy                                = var.extra_s3_athena_policies != [] ? data.aws_iam_policy_document.s3_athena_bucket[0].json : null
   block_public_acls                     = true
   block_public_policy                   = true
   ignore_public_acls                    = true
@@ -138,8 +229,8 @@ module "athena-s3-bucket" {
 }
 
 resource "aws_athena_workgroup" "logs" {
-  count  = var.enable_athena == true ? 1 : 0
-  name = "${var.prefix}-logs"
+  count = var.enable_athena == true ? 1 : 0
+  name  = "${var.prefix}-logs"
 
   configuration {
     enforce_workgroup_configuration    = true

--- a/terraform/addons/logging-alb/variables.tf
+++ b/terraform/addons/logging-alb/variables.tf
@@ -28,3 +28,17 @@ variable "s3_noncurrent_version_expiration_days" {
   default = 30
 }
 
+variable "extra_kms_policies" {
+  type    = list(any)
+  default = []
+}
+
+variable "extra_s3_log_policies" {
+  type    = list(any)
+  default = []
+}
+
+variable "extra_s3_athena_policies" {
+  type    = list(any)
+  default = []
+}


### PR DESCRIPTION
This should allow us to pass in policies for kms and both s3 buckets.  This is needed in order to allow for the new sns alerting lambda to query athena for 5xx errors.