### PR TITLE
Website: Fix overlapping edit button on documentation pages

### DIFF
--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -528,6 +528,10 @@
         padding: 0px;
         display: none;
       }
+      h1:first-of-type {
+        // Note: We're adding right margin to the first h1 to make sure it won't overlap the edit page button.
+        margin-right: 100px;
+      }
       h1 {
         padding-bottom: 16px;
       }

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -862,6 +862,9 @@
 
       [purpose='right-sidebar'] {
         width: 100%;
+        // Note: we're specifying a minimum height for this element to be the height of the edit page button.
+        // Even if there are no subtopics on a documentation page, we can be sure that the edit page button will not overlap the pages content.
+        min-height: 30px;
 
         [purpose='subtopics'] {
           color: @core-fleet-black;


### PR DESCRIPTION
Closes: #12354
Changes:
- Added right margin to the first h1 in documentation pages to prevent headings from overflowing onto the edit page button.
- Added a minimum height to the subtopics of documentation pages on mobile screens to prevent the edit page button from being positioned over the page's content.
