### PR TITLE
Website: Throw error in build script if a handbook page is missing a `maintainedBy` meta tag

### DIFF
--- a/handbook/company/head-of-public-sector.md
+++ b/handbook/company/head-of-public-sector.md
@@ -67,3 +67,5 @@ Learn more about the company and [why you should join us here](https://fleetdm.c
 Want to join the team?
 
 Reach out to Alex Mitchell on Linkedin.
+
+<meta name="maintainedBy" value="mikermcneil">

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -436,8 +436,8 @@ module.exports = {
               }
 
               if(sectionRepoPath === 'handbook/') {
-                 if(!embeddedMetadata.maintainedBy){
-                  // throw an error if a Handbook page is missing a maintainedBy value
+                if(!embeddedMetadata.maintainedBy) {
+                  // Throw an error if a handbook page is missing a maintainedBy meta tag.
                   throw new Error(`Failed compiling markdown content: A handbook page is missing a maintainedBy meta tag (<meta name="maintainedBy" value="">) at "${path.join(topLvlRepoPath, pageSourcePath)}".  To resolve, add a maintainedBy meta tag with the page maintainer's GitHub username as the value.`);
                 }
               }

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -435,6 +435,13 @@ module.exports = {
                 }
               }
 
+              if(sectionRepoPath === 'handbook/') {
+                 if(!embeddedMetadata.maintainedBy){
+                  // throw an error if a Handbook page is missing a maintainedBy value
+                  throw new Error(`Failed compiling markdown content: A handbook page is missing a maintainedBy meta tag (<meta name="maintainedBy" value="">) at "${path.join(topLvlRepoPath, pageSourcePath)}".  To resolve, add a maintainedBy meta tag with the page maintainer's GitHub username as the value.`);
+                }
+              }
+
               // Checking the metadata on /articles pages, and adding the category to the each article's URL.
               if(sectionRepoPath === 'articles/') {
                 if(!embeddedMetadata.authorGitHubUsername) {


### PR DESCRIPTION
Closes: #12361
Changes:
- Added an error to the `build-static-content` script that is thrown if a a handbook page is missing a `maintainedBy` meta tag.
- Added a `maintainedBy` meta tag to `handbook/company/head-of-public-sector.md`
