### PR TITLE
Provide feedback to user in fleetctl login when using env vars

### DIFF
--- a/changes/provide-feedback-fleetctl-login-when-using-env-vars
+++ b/changes/provide-feedback-fleetctl-login-when-using-env-vars
@@ -1,0 +1,1 @@
+* Provide feedback to users when `fleetctl login` is using EMAIL and PASSWORD environment variables.

--- a/cmd/fleetctl/login.go
+++ b/cmd/fleetctl/login.go
@@ -50,7 +50,7 @@ Trying to login with SSO? First, login to the Fleet UI and retrieve your API tok
 				return err
 			}
 
-			definedAsEnv := func(flagName, envName string) bool {
+			definedAsEnvOnly := func(flagName, envName string) bool {
 				cliArgPresent := false
 				for _, arg := range os.Args {
 					if arg == flagName {
@@ -70,7 +70,7 @@ Trying to login with SSO? First, login to the Fleet UI and retrieve your API tok
 					return fmt.Errorf("error reading email: %w", err)
 				}
 			} else {
-				if definedAsEnv("--email", "EMAIL") {
+				if definedAsEnvOnly("--email", "EMAIL") {
 					fmt.Printf("Using value of environment variable $EMAIL as email.\n")
 				}
 			}
@@ -83,7 +83,7 @@ Trying to login with SSO? First, login to the Fleet UI and retrieve your API tok
 				fmt.Println()
 				flPassword = string(passBytes)
 			} else {
-				if definedAsEnv("--password", "PASSWORD") {
+				if definedAsEnvOnly("--password", "PASSWORD") {
 					fmt.Printf("Using value of environment variable $PASSWORD as password.\n")
 				}
 			}

--- a/cmd/fleetctl/login.go
+++ b/cmd/fleetctl/login.go
@@ -50,6 +50,16 @@ Trying to login with SSO? First, login to the Fleet UI and retrieve your API tok
 				return err
 			}
 
+			definedAsEnv := func(flagName, envName string) bool {
+				cliArgPresent := false
+				for _, arg := range os.Args {
+					if arg == flagName {
+						cliArgPresent = true
+					}
+				}
+				return os.Getenv(envName) != "" && !cliArgPresent
+			}
+
 			// Allow interactive entry to discourage passwords in
 			// CLI history.
 			if flEmail == "" {
@@ -58,6 +68,10 @@ Trying to login with SSO? First, login to the Fleet UI and retrieve your API tok
 				_, err := fmt.Scanln(&flEmail)
 				if err != nil {
 					return fmt.Errorf("error reading email: %w", err)
+				}
+			} else {
+				if definedAsEnv("--email", "EMAIL") {
+					fmt.Printf("Using value of environment variable $EMAIL as email.\n")
 				}
 			}
 			if flPassword == "" {
@@ -68,6 +82,10 @@ Trying to login with SSO? First, login to the Fleet UI and retrieve your API tok
 				}
 				fmt.Println()
 				flPassword = string(passBytes)
+			} else {
+				if definedAsEnv("--password", "PASSWORD") {
+					fmt.Printf("Using value of environment variable $PASSWORD as password.\n")
+				}
 			}
 
 			token, err := fleet.Login(flEmail, flPassword)


### PR DESCRIPTION
Issue reported by @jarodreyes.

The user was not informed that `fleetctl login` was using the PASSWORD environment variable:

`main`:
```sh
export PASSWORD=wrong

fleetctl login
Log in using the standard Fleet credentials.
Email: a@b.c
Error: Login failed: login received status 401 Authentication failed: Authentication failed
```
And with the changes on this PR:
```
export PASSWORD=wrong

fleetctl login
Log in using the standard Fleet credentials.
Email: a@b.c
Using value of environment variable $PASSWORD as password.
Error: Login failed: login received status 401 Authentication failed: Authentication failed
```