### PR TITLE
Website: update template used in landing page generator

### DIFF
--- a/website/generators/landing-page/index.js
+++ b/website/generators/landing-page/index.js
@@ -253,7 +253,7 @@ module.exports = {
 
       <div purpose="bottom-cta" class="text-center">
         <h4>Open-source device management</h4>
-        <h1>Think for yourself</h1>
+        <h1>Lighter than air</h1>
         <div purpose="button-row" style="margin-top: 60px;" class="d-flex flex-sm-row flex-column justify-content-center align-items-center mx-auto">
           <a purpose="cta-button" href="/try-fleet/register?tryitnow">Try it out</a>
           <a @click="clickOpenChatWidget()" purpose="animated-arrow-button-red">Talk to an expert</a>


### PR DESCRIPTION
Changes:
- Updated the bottom heading on pages generated by the landing page generator to match our current landing page layout ("Think for yourself" » "Lighter than air")
