### PR TITLE
Docs: fix heading indentation

### DIFF
--- a/docs/Using-Fleet/REST-API.md
+++ b/docs/Using-Fleet/REST-API.md
@@ -5995,6 +5995,7 @@ Deletes the session specified by ID. When the user associated with the session n
 
 - [List all software](#list-all-software)
 - [Count software](#count-software)
+
 ### List all software
 
 `GET /api/v1/fleet/software`


### PR DESCRIPTION
Added a newline to fix "List all sofware" heading indentation on the website:
<img width="816" alt="Screenshot 2023-06-15 at 4 22 36 PM" src="https://github.com/fleetdm/fleet/assets/3065949/4a0cc555-18c5-470b-8879-c535988b3243">
