### PR TITLE
Return proper status code if SMTP conf is invalid

### DIFF
--- a/changes/bug-2888-return-proper-status-code-if-smtp-invalid
+++ b/changes/bug-2888-return-proper-status-code-if-smtp-invalid
@@ -1,0 +1,1 @@
+- Return the proper HTTP status code if SMTP is invalid.

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -376,7 +376,7 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		if appConfig.SMTPSettings.SMTPEnabled {
 			if oldSMTPSettings != *appConfig.SMTPSettings || !appConfig.SMTPSettings.SMTPConfigured {
 				if err = svc.sendTestEmail(ctx, appConfig); err != nil {
-					return nil, ctxerr.Wrap(ctx, err)
+					return nil, fleet.NewInvalidArgumentError("SMTP Options", err.Error())
 				}
 			}
 			appConfig.SMTPSettings.SMTPConfigured = true

--- a/server/service/integration_smtp_test.go
+++ b/server/service/integration_smtp_test.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type integrationSMTPTestSuite struct {
+	suite.Suite
+	withServer
+}
+
+func (s *integrationSMTPTestSuite) SetupSuite() {
+	s.withDS.SetupSuite("integrationSMTPTestSuite")
+
+	users, server := RunServerForTestsWithDS(
+		s.T(),
+		s.ds,
+		&TestServerOpts{
+			UseMailService: true,
+		})
+	s.server = server
+	s.users = users
+	s.token = s.getTestAdminToken()
+}
+
+func TestIntegrationsSMTP(t *testing.T) {
+	testingSuite := new(integrationSMTPTestSuite)
+	testingSuite.s = &testingSuite.Suite
+	suite.Run(t, testingSuite)
+}
+
+func (s *integrationSMTPTestSuite) TestSMTPValidation() {
+	t := s.T()
+
+	acResp := appConfigResponse{}
+	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+		"smtp_settings": {
+			"enable_smtp": true,
+			"sender_address": "sender@email.com",
+			"server": "http://localhost:62000"
+		}
+	}`), http.StatusUnprocessableEntity, &acResp)
+	require.NotNil(t, acResp)
+}


### PR DESCRIPTION
Addresses one of the issues reported in https://github.com/fleetdm/confidential/issues/2888

When setting up SMTP return the proper status code if config is invalid.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality