### PR TITLE
Add mechanism to force read from primary DB, use it for puppet matching

### DIFF
--- a/changes/issue-12392-use-primary
+++ b/changes/issue-12392-use-primary
@@ -1,0 +1,2 @@
+* Fixed a bug where reading from the replica would not read recent writes when matching a set of MDM profiles to a team (the `GET /mdm/apple/profiles/match` endpoint).
+* Added milliseconds to the timestamp of auto-generated team name when creating a new team in `GET /mdm/apple/profiles/match`.

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/pkg/file"
 	"github.com/fleetdm/fleet/v4/server/authz"
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -762,6 +763,11 @@ func (svc *Service) MDMAppleMatchPreassignment(ctx context.Context, externalHost
 		return nil // nothing to do
 	}
 
+	// force-use the primary DB instance for all the following reads/writes
+	// (we may create a team and need to read it back, but also to get latest
+	// team matching the profiles)
+	ctx = ctxdb.RequirePrimary(ctx, true)
+
 	// load the host and ensure it is enrolled in Fleet MDM
 	host, err := svc.ds.HostByIdentifier(ctx, profs.HostUUID)
 	if err != nil {
@@ -885,5 +891,5 @@ func teamNameFromPreassignGroups(groups []string) string {
 		groups = []string{defaultName}
 	}
 
-	return fmt.Sprintf("%s (%s)", strings.Join(groups, " - "), time.Now().UTC().Format("2006-01-02:15:04:05"))
+	return fmt.Sprintf("%s (%s)", strings.Join(groups, " - "), time.Now().UTC().Format("2006-01-02:15:04:05.999"))
 }

--- a/server/contexts/ctxdb/ctxdb.go
+++ b/server/contexts/ctxdb/ctxdb.go
@@ -1,0 +1,23 @@
+package ctxdb
+
+import (
+	"context"
+)
+
+type key int
+
+const requirePrimaryKey key = 0
+
+// RequirePrimary returns a new context that indicates to the database layer if
+// the primary instance must always be used instead of the replica, even for
+// reads (to be able to read recent writes).
+func RequirePrimary(ctx context.Context, requirePrimary bool) context.Context {
+	return context.WithValue(ctx, requirePrimaryKey, requirePrimary)
+}
+
+// IsPrimaryRequired returns true if the context indicates that the primary
+// instance is required for reads, false otherwise.
+func IsPrimaryRequired(ctx context.Context) bool {
+	v, _ := ctx.Value(requirePrimaryKey).(bool)
+	return v
+}

--- a/server/contexts/ctxdb/ctxdb_test.go
+++ b/server/contexts/ctxdb/ctxdb_test.go
@@ -1,0 +1,27 @@
+package ctxdb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsPrimaryRequired(t *testing.T) {
+	cases := []struct {
+		desc string
+		ctx  context.Context
+		want bool
+	}{
+		{"not set", context.Background(), false},
+		{"set to true", RequirePrimary(context.Background(), true), true},
+		{"set to false", RequirePrimary(context.Background(), false), false},
+		{"set to true then false", RequirePrimary(RequirePrimary(context.Background(), true), false), false},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			got := IsPrimaryRequired(c.ctx)
+			require.Equal(t, c.want, got)
+		})
+	}
+}

--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -24,7 +24,7 @@ func (ds *Datastore) NewActivity(ctx context.Context, user *fleet.User, activity
 		userName = &user.Name
 	}
 
-	_, err = ds.writer.ExecContext(ctx,
+	_, err = ds.writer(ctx).ExecContext(ctx,
 		`INSERT INTO activities (user_id, user_name, activity_type, details) VALUES(?,?,?,?)`,
 		userID,
 		userName,
@@ -63,7 +63,7 @@ func (ds *Datastore) ListActivities(ctx context.Context, opt fleet.ListActivitie
 
 	activitiesQ, args = appendListOptionsWithCursorToSQL(activitiesQ, args, &opt.ListOptions)
 
-	err := sqlx.SelectContext(ctx, ds.reader, &activities, activitiesQ, args...)
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &activities, activitiesQ, args...)
 	if err == sql.ErrNoRows {
 		return nil, nil, ctxerr.Wrap(ctx, notFound("Activity"))
 	} else if err != nil {
@@ -102,7 +102,7 @@ func (ds *Datastore) ListActivities(ctx context.Context, opt fleet.ListActivitie
 			Email       string `db:"email"`
 		}
 
-		err = sqlx.SelectContext(ctx, ds.reader, &usersR, usersQ, usersArgs...)
+		err = sqlx.SelectContext(ctx, ds.reader(ctx), &usersR, usersQ, usersArgs...)
 		if err != nil && err != sql.ErrNoRows {
 			return nil, nil, ctxerr.Wrap(ctx, err, "selecting users")
 		}
@@ -143,7 +143,7 @@ func (ds *Datastore) MarkActivitiesAsStreamed(ctx context.Context, activityIDs [
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "sqlx.In mark activities as streamed")
 	}
-	if _, err := ds.writer.ExecContext(ctx, query, args...); err != nil {
+	if _, err := ds.writer(ctx).ExecContext(ctx, query, args...); err != nil {
 		return ctxerr.Wrap(ctx, err, "exec mark activities as streamed")
 	}
 	return nil

--- a/server/datastore/mysql/aggregated_stats.go
+++ b/server/datastore/mysql/aggregated_stats.go
@@ -108,8 +108,8 @@ func setP50AndP95Map(ctx context.Context, tx sqlx.QueryerContext, aggregate aggr
 }
 
 func (ds *Datastore) UpdateScheduledQueryAggregatedStats(ctx context.Context) error {
-	err := walkIdsInTable(ctx, ds.reader, "scheduled_queries", func(id uint) error {
-		return calculatePercentiles(ctx, ds.writer, aggregatedStatsTypeScheduledQuery, id)
+	err := walkIdsInTable(ctx, ds.reader(ctx), "scheduled_queries", func(id uint) error {
+		return calculatePercentiles(ctx, ds.writer(ctx), aggregatedStatsTypeScheduledQuery, id)
 	})
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "looping through ids")
@@ -119,8 +119,8 @@ func (ds *Datastore) UpdateScheduledQueryAggregatedStats(ctx context.Context) er
 }
 
 func (ds *Datastore) UpdateQueryAggregatedStats(ctx context.Context) error {
-	err := walkIdsInTable(ctx, ds.reader, "queries", func(id uint) error {
-		return calculatePercentiles(ctx, ds.writer, aggregatedStatsTypeQuery, id)
+	err := walkIdsInTable(ctx, ds.reader(ctx), "queries", func(id uint) error {
+		return calculatePercentiles(ctx, ds.writer(ctx), aggregatedStatsTypeQuery, id)
 	})
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "looping through ids")

--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -25,7 +25,7 @@ func (ds *Datastore) NewAppConfig(ctx context.Context, info *fleet.AppConfig) (*
 }
 
 func (ds *Datastore) AppConfig(ctx context.Context) (*fleet.AppConfig, error) {
-	return appConfigDB(ctx, ds.reader)
+	return appConfigDB(ctx, ds.reader(ctx))
 }
 
 func appConfigDB(ctx context.Context, q sqlx.QueryerContext) (*fleet.AppConfig, error) {
@@ -76,7 +76,7 @@ func (ds *Datastore) SaveAppConfig(ctx context.Context, info *fleet.AppConfig) e
 
 func (ds *Datastore) VerifyEnrollSecret(ctx context.Context, secret string) (*fleet.EnrollSecret, error) {
 	var s fleet.EnrollSecret
-	err := sqlx.GetContext(ctx, ds.reader, &s, "SELECT team_id FROM enroll_secrets WHERE secret = ?", secret)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &s, "SELECT team_id FROM enroll_secrets WHERE secret = ?", secret)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ctxerr.Wrap(ctx, notFound("EnrollSecret"), "no matching secret found")
@@ -160,7 +160,7 @@ func applyEnrollSecretsDB(ctx context.Context, q sqlx.ExtContext, teamID *uint, 
 }
 
 func (ds *Datastore) GetEnrollSecrets(ctx context.Context, teamID *uint) ([]*fleet.EnrollSecret, error) {
-	return getEnrollSecretsDB(ctx, ds.reader, teamID)
+	return getEnrollSecretsDB(ctx, ds.reader(ctx), teamID)
 }
 
 func getEnrollSecretsDB(ctx context.Context, q sqlx.QueryerContext, teamID *uint) ([]*fleet.EnrollSecret, error) {
@@ -207,7 +207,7 @@ func (ds *Datastore) AggregateEnrollSecretPerTeam(ctx context.Context) ([]*fleet
                 created_at DESC LIMIT 1)
 	`
 	var secrets []*fleet.EnrollSecret
-	if err := sqlx.SelectContext(ctx, ds.reader, &secrets, query); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &secrets, query); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get secrets")
 	}
 	return secrets, nil

--- a/server/datastore/mysql/app_configs_test.go
+++ b/server/datastore/mysql/app_configs_test.go
@@ -331,7 +331,7 @@ func testAppConfigEnrollSecretUniqueness(t *testing.T, ds *Datastore) {
 
 func testAppConfigDefaults(t *testing.T, ds *Datastore) {
 	insertAppConfigQuery := `INSERT INTO app_config_json(json_value) VALUES(?) ON DUPLICATE KEY UPDATE json_value = VALUES(json_value)`
-	_, err := ds.writer.Exec(insertAppConfigQuery, `{}`)
+	_, err := ds.writer(context.Background()).Exec(insertAppConfigQuery, `{}`)
 	require.NoError(t, err)
 
 	ac, err := ds.AppConfig(context.Background())
@@ -341,7 +341,7 @@ func testAppConfigDefaults(t *testing.T, ds *Datastore) {
 	require.True(t, ac.Features.EnableHostUsers)
 	require.False(t, ac.Features.EnableSoftwareInventory)
 
-	_, err = ds.writer.Exec(
+	_, err = ds.writer(context.Background()).Exec(
 		insertAppConfigQuery,
 		`{"webhook_settings": {"interval": "12h"}, "features": {"enable_host_users": false}}`,
 	)
@@ -357,7 +357,7 @@ func testAppConfigDefaults(t *testing.T, ds *Datastore) {
 
 func testAppConfigBackwardsCompatibility(t *testing.T, ds *Datastore) {
 	insertAppConfigQuery := `INSERT INTO app_config_json(json_value) VALUES(?) ON DUPLICATE KEY UPDATE json_value = VALUES(json_value)`
-	_, err := ds.writer.Exec(insertAppConfigQuery, `
+	_, err := ds.writer(context.Background()).Exec(insertAppConfigQuery, `
 {
   "host_settings": {
     "enable_host_users": false,

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -31,7 +31,7 @@ VALUES (?, ?, ?, ?, UNHEX(MD5(mobileconfig)))`
 		teamID = *cp.TeamID
 	}
 
-	res, err := ds.writer.ExecContext(ctx, stmt, teamID, cp.Identifier, cp.Name, cp.Mobileconfig)
+	res, err := ds.writer(ctx).ExecContext(ctx, stmt, teamID, cp.Identifier, cp.Name, cp.Mobileconfig)
 	if err != nil {
 		switch {
 		case isDuplicate(err):
@@ -101,7 +101,7 @@ ORDER BY name`
 	}
 
 	var res []*fleet.MDMAppleConfigProfile
-	if err = sqlx.SelectContext(ctx, ds.reader, &res, stmt, args...); err != nil {
+	if err = sqlx.SelectContext(ctx, ds.reader(ctx), &res, stmt, args...); err != nil {
 		return nil, err
 	}
 	return res, nil
@@ -150,7 +150,7 @@ HAVING
 	}
 
 	var teamIDs []uint
-	if err := sqlx.SelectContext(ctx, ds.reader, &teamIDs, stmt, args...); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &teamIDs, stmt, args...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "execute query")
 	}
 	return teamIDs, nil
@@ -172,7 +172,7 @@ WHERE
 	profile_id=?`
 
 	var res fleet.MDMAppleConfigProfile
-	err := sqlx.GetContext(ctx, ds.reader, &res, stmt, profileID)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &res, stmt, profileID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("MDMAppleConfigProfile").WithID(profileID))
@@ -184,7 +184,7 @@ WHERE
 }
 
 func (ds *Datastore) DeleteMDMAppleConfigProfile(ctx context.Context, profileID uint) error {
-	res, err := ds.writer.ExecContext(ctx, `DELETE FROM mdm_apple_configuration_profiles WHERE profile_id=?`, profileID)
+	res, err := ds.writer(ctx).ExecContext(ctx, `DELETE FROM mdm_apple_configuration_profiles WHERE profile_id=?`, profileID)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err)
 	}
@@ -205,7 +205,7 @@ func (ds *Datastore) DeleteMDMAppleConfigProfileByTeamAndIdentifier(ctx context.
 		teamID = ptr.Uint(0)
 	}
 
-	res, err := ds.writer.ExecContext(ctx, `DELETE FROM mdm_apple_configuration_profiles WHERE team_id = ? AND identifier = ?`, teamID, profileIdentifier)
+	res, err := ds.writer(ctx).ExecContext(ctx, `DELETE FROM mdm_apple_configuration_profiles WHERE team_id = ? AND identifier = ?`, teamID, profileIdentifier)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err)
 	}
@@ -243,7 +243,7 @@ WHERE
 	)
 
 	var profiles []fleet.HostMDMAppleProfile
-	if err := sqlx.SelectContext(ctx, ds.reader, &profiles, stmt, hostUUID); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &profiles, stmt, hostUUID); err != nil {
 		return nil, err
 	}
 	return profiles, nil
@@ -253,7 +253,7 @@ func (ds *Datastore) NewMDMAppleEnrollmentProfile(
 	ctx context.Context,
 	payload fleet.MDMAppleEnrollmentProfilePayload,
 ) (*fleet.MDMAppleEnrollmentProfile, error) {
-	res, err := ds.writer.ExecContext(ctx,
+	res, err := ds.writer(ctx).ExecContext(ctx,
 		`
 INSERT INTO
     mdm_apple_enrollment_profiles (token, type, dep_profile)
@@ -281,7 +281,7 @@ func (ds *Datastore) ListMDMAppleEnrollmentProfiles(ctx context.Context) ([]*fle
 	var enrollmentProfiles []*fleet.MDMAppleEnrollmentProfile
 	if err := sqlx.SelectContext(
 		ctx,
-		ds.writer,
+		ds.writer(ctx),
 		&enrollmentProfiles,
 		`
 SELECT
@@ -303,7 +303,7 @@ ORDER BY created_at DESC
 
 func (ds *Datastore) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, token string) (*fleet.MDMAppleEnrollmentProfile, error) {
 	var enrollment fleet.MDMAppleEnrollmentProfile
-	if err := sqlx.GetContext(ctx, ds.reader,
+	if err := sqlx.GetContext(ctx, ds.reader(ctx),
 		&enrollment,
 		`
 SELECT
@@ -330,7 +330,7 @@ WHERE
 
 func (ds *Datastore) GetMDMAppleEnrollmentProfileByType(ctx context.Context, typ fleet.MDMAppleEnrollmentType) (*fleet.MDMAppleEnrollmentProfile, error) {
 	var enrollment fleet.MDMAppleEnrollmentProfile
-	if err := sqlx.GetContext(ctx, ds.writer, // use writer as it is used just after creation in some cases
+	if err := sqlx.GetContext(ctx, ds.writer(ctx), // use writer as it is used just after creation in some cases
 		&enrollment,
 		`
 SELECT
@@ -357,7 +357,7 @@ WHERE
 
 func (ds *Datastore) GetMDMAppleCommandRequestType(ctx context.Context, commandUUID string) (string, error) {
 	var rt string
-	err := sqlx.GetContext(ctx, ds.reader, &rt, `SELECT request_type FROM nano_commands WHERE command_uuid = ?`, commandUUID)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &rt, `SELECT request_type FROM nano_commands WHERE command_uuid = ?`, commandUUID)
 	if err == sql.ErrNoRows {
 		return "", ctxerr.Wrap(ctx, notFound("MDMAppleCommand").WithName(commandUUID))
 	}
@@ -386,7 +386,7 @@ WHERE
 	var results []*fleet.MDMAppleCommandResult
 	err := sqlx.SelectContext(
 		ctx,
-		ds.reader,
+		ds.reader(ctx),
 		&results,
 		query,
 		commandUUID,
@@ -423,14 +423,14 @@ WHERE
 	stmt, params := appendListOptionsWithCursorToSQL(stmt, nil, &listOpts.ListOptions)
 
 	var results []*fleet.MDMAppleCommand
-	if err := sqlx.SelectContext(ctx, ds.reader, &results, stmt, params...); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &results, stmt, params...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list commands")
 	}
 	return results, nil
 }
 
 func (ds *Datastore) NewMDMAppleInstaller(ctx context.Context, name string, size int64, manifest string, installer []byte, urlToken string) (*fleet.MDMAppleInstaller, error) {
-	res, err := ds.writer.ExecContext(
+	res, err := ds.writer(ctx).ExecContext(
 		ctx,
 		`INSERT INTO mdm_apple_installers (name, size, manifest, installer, url_token) VALUES (?, ?, ?, ?, ?)`,
 		name, size, manifest, installer, urlToken,
@@ -453,7 +453,7 @@ func (ds *Datastore) MDMAppleInstaller(ctx context.Context, token string) (*flee
 	var installer fleet.MDMAppleInstaller
 	if err := sqlx.GetContext(
 		ctx,
-		ds.writer,
+		ds.writer(ctx),
 		&installer,
 		`SELECT id, name, size, manifest, installer, url_token FROM mdm_apple_installers WHERE url_token = ?`,
 		token,
@@ -470,7 +470,7 @@ func (ds *Datastore) MDMAppleInstallerDetailsByID(ctx context.Context, id uint) 
 	var installer fleet.MDMAppleInstaller
 	if err := sqlx.GetContext(
 		ctx,
-		ds.writer,
+		ds.writer(ctx),
 		&installer,
 		`SELECT id, name, size, manifest, url_token FROM mdm_apple_installers WHERE id = ?`,
 		id,
@@ -484,7 +484,7 @@ func (ds *Datastore) MDMAppleInstallerDetailsByID(ctx context.Context, id uint) 
 }
 
 func (ds *Datastore) DeleteMDMAppleInstaller(ctx context.Context, id uint) error {
-	if _, err := ds.writer.ExecContext(ctx, `DELETE FROM mdm_apple_installers WHERE id = ?`, id); err != nil {
+	if _, err := ds.writer(ctx).ExecContext(ctx, `DELETE FROM mdm_apple_installers WHERE id = ?`, id); err != nil {
 		return ctxerr.Wrap(ctx, err)
 	}
 	return nil
@@ -494,7 +494,7 @@ func (ds *Datastore) MDMAppleInstallerDetailsByToken(ctx context.Context, token 
 	var installer fleet.MDMAppleInstaller
 	if err := sqlx.GetContext(
 		ctx,
-		ds.writer,
+		ds.writer(ctx),
 		&installer,
 		`SELECT id, name, size, manifest, url_token FROM mdm_apple_installers WHERE url_token = ?`,
 		token,
@@ -509,7 +509,7 @@ func (ds *Datastore) MDMAppleInstallerDetailsByToken(ctx context.Context, token 
 
 func (ds *Datastore) ListMDMAppleInstallers(ctx context.Context) ([]fleet.MDMAppleInstaller, error) {
 	var installers []fleet.MDMAppleInstaller
-	if err := sqlx.SelectContext(ctx, ds.writer,
+	if err := sqlx.SelectContext(ctx, ds.writer(ctx),
 		&installers,
 		`SELECT id, name, size, manifest, url_token FROM mdm_apple_installers`,
 	); err != nil {
@@ -522,7 +522,7 @@ func (ds *Datastore) MDMAppleListDevices(ctx context.Context) ([]fleet.MDMAppleD
 	var devices []fleet.MDMAppleDevice
 	if err := sqlx.SelectContext(
 		ctx,
-		ds.writer,
+		ds.writer(ctx),
 		&devices,
 		`
 SELECT
@@ -1005,7 +1005,7 @@ func unionSelectDevices(devices []godep.Device) (stmt string, args []interface{}
 
 func (ds *Datastore) GetHostDEPAssignment(ctx context.Context, hostID uint) (*fleet.HostDEPAssignment, error) {
 	var res fleet.HostDEPAssignment
-	err := sqlx.GetContext(ctx, ds.reader, &res, `
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &res, `
 		SELECT host_id, added_at, deleted_at FROM host_dep_assignments hdep WHERE hdep.host_id = ?`, hostID)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -1034,7 +1034,7 @@ func (ds *Datastore) DeleteHostDEPAssignments(ctx context.Context, serials []str
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "building IN statement")
 	}
-	if _, err := ds.writer.ExecContext(ctx, stmt, args...); err != nil {
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, args...); err != nil {
 		return ctxerr.Wrap(ctx, err, "deleting DEP assignment by serial")
 	}
 	return nil
@@ -1043,7 +1043,7 @@ func (ds *Datastore) DeleteHostDEPAssignments(ctx context.Context, serials []str
 func (ds *Datastore) GetNanoMDMEnrollment(ctx context.Context, id string) (*fleet.NanoEnrollment, error) {
 	var nanoEnroll fleet.NanoEnrollment
 	// use writer as it is used just after creation in some cases
-	err := sqlx.GetContext(ctx, ds.writer, &nanoEnroll, `SELECT id, device_id, type, enabled, token_update_tally
+	err := sqlx.GetContext(ctx, ds.writer(ctx), &nanoEnroll, `SELECT id, device_id, type, enabled, token_update_tally
 		FROM nano_enrollments WHERE id = ?`, id)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -1449,7 +1449,7 @@ func (ds *Datastore) ListMDMAppleProfilesToInstall(ctx context.Context) ([]*flee
 `
 
 	var profiles []*fleet.MDMAppleProfilePayload
-	err := sqlx.SelectContext(ctx, ds.reader, &profiles, query, fleet.MDMAppleOperationTypeRemove, fleet.MDMAppleOperationTypeInstall)
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &profiles, query, fleet.MDMAppleOperationTypeRemove, fleet.MDMAppleOperationTypeInstall)
 	return profiles, err
 }
 
@@ -1489,7 +1489,7 @@ func (ds *Datastore) ListMDMAppleProfilesToRemove(ctx context.Context) ([]*fleet
 `
 
 	var profiles []*fleet.MDMAppleProfilePayload
-	err := sqlx.SelectContext(ctx, ds.reader, &profiles, query, fleet.MDMAppleOperationTypeRemove)
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &profiles, query, fleet.MDMAppleOperationTypeRemove)
 	return profiles, err
 }
 
@@ -1506,7 +1506,7 @@ func (ds *Datastore) GetMDMAppleProfilesContents(ctx context.Context, ids []uint
 	if err != nil {
 		return nil, err
 	}
-	rows, err := ds.reader.QueryxContext(ctx, query, args...)
+	rows, err := ds.reader(ctx).QueryxContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -1555,7 +1555,7 @@ func (ds *Datastore) BulkUpsertMDMAppleHostProfiles(ctx context.Context, payload
 		strings.TrimSuffix(sb.String(), ","),
 	)
 
-	_, err := ds.writer.ExecContext(ctx, stmt, args...)
+	_, err := ds.writer(ctx).ExecContext(ctx, stmt, args...)
 	return err
 }
 
@@ -1563,14 +1563,14 @@ func (ds *Datastore) UpdateOrDeleteHostMDMAppleProfile(ctx context.Context, prof
 	if profile.OperationType == fleet.MDMAppleOperationTypeRemove &&
 		profile.Status != nil &&
 		(*profile.Status == fleet.MDMAppleDeliveryVerifying || *profile.Status == fleet.MDMAppleDeliveryVerified || profile.IgnoreMDMClientError()) {
-		_, err := ds.writer.ExecContext(ctx, `
+		_, err := ds.writer(ctx).ExecContext(ctx, `
           DELETE FROM host_mdm_apple_profiles
           WHERE host_uuid = ? AND command_uuid = ?
         `, profile.HostUUID, profile.CommandUUID)
 		return err
 	}
 
-	_, err := ds.writer.ExecContext(ctx, `
+	_, err := ds.writer(ctx).ExecContext(ctx, `
           UPDATE host_mdm_apple_profiles
           SET status = ?, operation_type = ?, detail = ?
           WHERE host_uuid = ? AND command_uuid = ?
@@ -1589,7 +1589,7 @@ func (ds *Datastore) SetVerifiedHostMacOSProfiles(ctx context.Context, host *fle
 		teamID = *host.TeamID
 	}
 	var expectedProfs []*fleet.MDMAppleConfigProfile
-	if err := sqlx.SelectContext(ctx, ds.reader, &expectedProfs, `
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &expectedProfs, `
 SELECT
 	name,
 	identifier,
@@ -1641,7 +1641,7 @@ WHERE
 		return ctxerr.Wrap(ctx, err, "building sql statement to set verified host macOS profiles")
 	}
 
-	if _, err := ds.writer.ExecContext(ctx, stmt, args...); err != nil {
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, args...); err != nil {
 		return ctxerr.Wrap(ctx, err, "setting verified host macOS profiles")
 	}
 
@@ -1838,7 +1838,7 @@ WHERE
 	stmt := fmt.Sprintf(sqlFmt, subqueryFailed, subqueryPending, subqueryVerifying, subqueryVerified, teamFilter)
 
 	var res fleet.MDMAppleConfigProfilesSummary
-	err := sqlx.GetContext(ctx, ds.reader, &res, stmt, args...)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &res, stmt, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -1856,14 +1856,14 @@ func (ds *Datastore) InsertMDMIdPAccount(ctx context.Context, account *fleet.MDM
         username   = VALUES(username),
         fullname   = VALUES(fullname)`
 
-	_, err := ds.writer.ExecContext(ctx, stmt, account.UUID, account.Username, account.Fullname)
+	_, err := ds.writer(ctx).ExecContext(ctx, stmt, account.UUID, account.Username, account.Fullname)
 	return ctxerr.Wrap(ctx, err, "creating new MDM IdP account")
 }
 
 func (ds *Datastore) GetMDMIdPAccount(ctx context.Context, uuid string) (*fleet.MDMIdPAccount, error) {
 	stmt := `SELECT uuid, username, fullname FROM mdm_idp_accounts WHERE uuid = ?`
 	var acct fleet.MDMIdPAccount
-	err := sqlx.GetContext(ctx, ds.reader, &acct, stmt, uuid)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &acct, stmt, uuid)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("MDMIdPAccount").WithMessage(fmt.Sprintf("with uuid %s", uuid)))
@@ -2040,7 +2040,7 @@ WHERE
 	stmt := fmt.Sprintf(sqlFmt, subqueryVerified, subqueryVerifying, subqueryActionRequired, subqueryEnforcing, subqueryFailed, subqueryRemovingEnforcement, teamFilter)
 
 	var res fleet.MDMAppleFileVaultSummary
-	err := sqlx.GetContext(ctx, ds.reader, &res, stmt, args...)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &res, stmt, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -2073,7 +2073,7 @@ func (ds *Datastore) BulkUpsertMDMAppleConfigProfiles(ctx context.Context, paylo
             mobileconfig = VALUES(mobileconfig),
 	    checksum = UNHEX(MD5(VALUES(mobileconfig)))`, strings.TrimSuffix(sb.String(), ","))
 
-	if _, err := ds.writer.ExecContext(ctx, stmt, args...); err != nil {
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, args...); err != nil {
 		return ctxerr.Wrapf(ctx, err, "upsert mdm config profiles")
 	}
 
@@ -2086,7 +2086,7 @@ func (ds *Datastore) InsertMDMAppleBootstrapPackage(ctx context.Context, bp *fle
 	  VALUES (?, ?, ?, ?, ?)
 	`
 
-	_, err := ds.writer.ExecContext(ctx, stmt, bp.TeamID, bp.Name, bp.Sha256, bp.Bytes, bp.Token)
+	_, err := ds.writer(ctx).ExecContext(ctx, stmt, bp.TeamID, bp.Name, bp.Sha256, bp.Bytes, bp.Token)
 	if err != nil {
 		if isDuplicate(err) {
 			return ctxerr.Wrap(ctx, alreadyExists("BootstrapPackage", fmt.Sprintf("for team %d", bp.TeamID)))
@@ -2099,7 +2099,7 @@ func (ds *Datastore) InsertMDMAppleBootstrapPackage(ctx context.Context, bp *fle
 
 func (ds *Datastore) DeleteMDMAppleBootstrapPackage(ctx context.Context, teamID uint) error {
 	stmt := "DELETE FROM mdm_apple_bootstrap_packages WHERE team_id = ?"
-	res, err := ds.writer.ExecContext(ctx, stmt, teamID)
+	res, err := ds.writer(ctx).ExecContext(ctx, stmt, teamID)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "delete bootstrap package")
 	}
@@ -2114,7 +2114,7 @@ func (ds *Datastore) DeleteMDMAppleBootstrapPackage(ctx context.Context, teamID 
 func (ds *Datastore) GetMDMAppleBootstrapPackageBytes(ctx context.Context, token string) (*fleet.MDMAppleBootstrapPackage, error) {
 	stmt := "SELECT name, bytes FROM mdm_apple_bootstrap_packages WHERE token = ?"
 	var bp fleet.MDMAppleBootstrapPackage
-	if err := sqlx.GetContext(ctx, ds.reader, &bp, stmt, token); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &bp, stmt, token); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("BootstrapPackage").WithMessage(token))
 		}
@@ -2141,7 +2141,7 @@ func (ds *Datastore) GetMDMAppleBootstrapPackageSummary(ctx context.Context, tea
               hm.installed_from_dep = 1 AND COALESCE(h.team_id, 0) = ?`
 
 	var bp fleet.MDMAppleBootstrapPackageSummary
-	if err := sqlx.GetContext(ctx, ds.reader, &bp, stmt, teamID); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &bp, stmt, teamID); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get bootstrap package summary")
 	}
 	return &bp, nil
@@ -2150,7 +2150,7 @@ func (ds *Datastore) GetMDMAppleBootstrapPackageSummary(ctx context.Context, tea
 func (ds *Datastore) RecordHostBootstrapPackage(ctx context.Context, commandUUID string, hostUUID string) error {
 	stmt := `INSERT INTO host_mdm_apple_bootstrap_packages (command_uuid, host_uuid) VALUES (?, ?)
         ON DUPLICATE KEY UPDATE command_uuid = command_uuid`
-	_, err := ds.writer.ExecContext(ctx, stmt, commandUUID, hostUUID)
+	_, err := ds.writer(ctx).ExecContext(ctx, stmt, commandUUID, hostUUID)
 	return ctxerr.Wrap(ctx, err, "record bootstrap package command")
 }
 
@@ -2180,7 +2180,7 @@ WHERE
 	args := []interface{}{fleet.MDMBootstrapPackageInstalled, fleet.MDMBootstrapPackageFailed, fleet.MDMBootstrapPackagePending, hostID}
 
 	var dest fleet.HostMDMMacOSSetup
-	if err := sqlx.GetContext(ctx, ds.reader, &dest, stmt, args...); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &dest, stmt, args...); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("HostMDMMacOSSetup").WithID(hostID))
 		}
@@ -2201,7 +2201,7 @@ WHERE
 func (ds *Datastore) GetMDMAppleBootstrapPackageMeta(ctx context.Context, teamID uint) (*fleet.MDMAppleBootstrapPackage, error) {
 	stmt := "SELECT team_id, name, sha256, token, created_at, updated_at FROM mdm_apple_bootstrap_packages WHERE team_id = ?"
 	var bp fleet.MDMAppleBootstrapPackage
-	if err := sqlx.GetContext(ctx, ds.reader, &bp, stmt, teamID); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &bp, stmt, teamID); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("BootstrapPackage").WithID(teamID))
 		}
@@ -2283,7 +2283,7 @@ func (ds *Datastore) MDMAppleGetEULAMetadata(ctx context.Context) (*fleet.MDMApp
 	// hardcoding it's id to be 1 in order to enforce this restriction.
 	stmt := "SELECT name, created_at, token FROM eulas WHERE id = 1"
 	var eula fleet.MDMAppleEULA
-	if err := sqlx.GetContext(ctx, ds.reader, &eula, stmt); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &eula, stmt); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("MDMAppleEULA"))
 		}
@@ -2295,7 +2295,7 @@ func (ds *Datastore) MDMAppleGetEULAMetadata(ctx context.Context) (*fleet.MDMApp
 func (ds *Datastore) MDMAppleGetEULABytes(ctx context.Context, token string) (*fleet.MDMAppleEULA, error) {
 	stmt := "SELECT name, bytes FROM eulas WHERE token = ?"
 	var eula fleet.MDMAppleEULA
-	if err := sqlx.GetContext(ctx, ds.reader, &eula, stmt, token); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &eula, stmt, token); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("MDMAppleEULA"))
 		}
@@ -2312,7 +2312,7 @@ func (ds *Datastore) MDMAppleInsertEULA(ctx context.Context, eula *fleet.MDMAppl
 	  VALUES (1, ?, ?, ?)
 	`
 
-	_, err := ds.writer.ExecContext(ctx, stmt, eula.Name, eula.Bytes, eula.Token)
+	_, err := ds.writer(ctx).ExecContext(ctx, stmt, eula.Name, eula.Bytes, eula.Token)
 	if err != nil {
 		if isDuplicate(err) {
 			return ctxerr.Wrap(ctx, alreadyExists("MDMAppleEULA", eula.Token))
@@ -2325,7 +2325,7 @@ func (ds *Datastore) MDMAppleInsertEULA(ctx context.Context, eula *fleet.MDMAppl
 
 func (ds *Datastore) MDMAppleDeleteEULA(ctx context.Context, token string) error {
 	stmt := "DELETE FROM eulas WHERE token = ?"
-	res, err := ds.writer.ExecContext(ctx, stmt, token)
+	res, err := ds.writer(ctx).ExecContext(ctx, stmt, token)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "delete EULA")
 	}
@@ -2353,13 +2353,13 @@ func (ds *Datastore) SetOrUpdateMDMAppleSetupAssistant(ctx context.Context, asst
 	if asst.TeamID != nil {
 		globalOrTmID = *asst.TeamID
 	}
-	_, err := ds.writer.ExecContext(ctx, stmt, asst.TeamID, globalOrTmID, asst.Name, asst.Profile)
+	_, err := ds.writer(ctx).ExecContext(ctx, stmt, asst.TeamID, globalOrTmID, asst.Name, asst.Profile)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "upsert mdm apple setup assistant")
 	}
 
 	// reload to return the proper timestamp and id
-	return ds.getMDMAppleSetupAssistant(ctx, ds.writer, asst.TeamID)
+	return ds.getMDMAppleSetupAssistant(ctx, ds.writer(ctx), asst.TeamID)
 }
 
 func (ds *Datastore) SetMDMAppleSetupAssistantProfileUUID(ctx context.Context, teamID *uint, profileUUID string) error {
@@ -2378,7 +2378,7 @@ func (ds *Datastore) SetMDMAppleSetupAssistantProfileUUID(ctx context.Context, t
 	if teamID != nil {
 		globalOrTmID = *teamID
 	}
-	res, err := ds.writer.ExecContext(ctx, stmt, profileUUID, globalOrTmID)
+	res, err := ds.writer(ctx).ExecContext(ctx, stmt, profileUUID, globalOrTmID)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "set mdm apple setup assistant profile uuid")
 	}
@@ -2389,7 +2389,7 @@ func (ds *Datastore) SetMDMAppleSetupAssistantProfileUUID(ctx context.Context, t
 }
 
 func (ds *Datastore) GetMDMAppleSetupAssistant(ctx context.Context, teamID *uint) (*fleet.MDMAppleSetupAssistant, error) {
-	return ds.getMDMAppleSetupAssistant(ctx, ds.reader, teamID)
+	return ds.getMDMAppleSetupAssistant(ctx, ds.reader(ctx), teamID)
 }
 
 func (ds *Datastore) getMDMAppleSetupAssistant(ctx context.Context, q sqlx.QueryerContext, teamID *uint) (*fleet.MDMAppleSetupAssistant, error) {
@@ -2428,7 +2428,7 @@ func (ds *Datastore) DeleteMDMAppleSetupAssistant(ctx context.Context, teamID *u
 	if teamID != nil {
 		globalOrTmID = *teamID
 	}
-	_, err := ds.writer.ExecContext(ctx, stmt, globalOrTmID)
+	_, err := ds.writer(ctx).ExecContext(ctx, stmt, globalOrTmID)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "delete mdm apple setup assistant")
 	}
@@ -2462,7 +2462,7 @@ WHERE
 	args = append(args, fleet.WellKnownMDMFleet)
 
 	var serials []string
-	if err := sqlx.SelectContext(ctx, ds.reader, &serials, stmt, args...); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &serials, stmt, args...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list mdm apple dep serials")
 	}
 	return serials, nil
@@ -2495,7 +2495,7 @@ WHERE
 	}
 
 	var serials []string
-	if err := sqlx.SelectContext(ctx, ds.reader, &serials, stmt, args...); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &serials, stmt, args...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list mdm apple dep serials")
 	}
 	return serials, nil
@@ -2514,7 +2514,7 @@ func (ds *Datastore) SetMDMAppleDefaultSetupAssistantProfileUUID(ctx context.Con
 	if teamID != nil {
 		globalOrTmID = *teamID
 	}
-	_, err := ds.writer.ExecContext(ctx, stmt, teamID, globalOrTmID, profileUUID)
+	_, err := ds.writer(ctx).ExecContext(ctx, stmt, teamID, globalOrTmID, profileUUID)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "upsert mdm apple default setup assistant")
 	}
@@ -2535,7 +2535,7 @@ func (ds *Datastore) GetMDMAppleDefaultSetupAssistant(ctx context.Context, teamI
 		globalOrTmID = *teamID
 	}
 	var asst fleet.MDMAppleSetupAssistant
-	if err := sqlx.GetContext(ctx, ds.writer /* needs to read recent writes */, &asst, stmt, globalOrTmID); err != nil {
+	if err := sqlx.GetContext(ctx, ds.writer(ctx) /* needs to read recent writes */, &asst, stmt, globalOrTmID); err != nil {
 		if err == sql.ErrNoRows {
 			return "", time.Time{}, ctxerr.Wrap(ctx, notFound("MDMAppleDefaultSetupAssistant").WithID(globalOrTmID))
 		}
@@ -2549,7 +2549,7 @@ func (ds *Datastore) ResetMDMAppleNanoEnrollment(ctx context.Context, hostUUID s
 	// are created on `TokenUpdate`, and this function is called on
 	// `Authenticate` to make sure we start on a clean state if a host is
 	// re-enrolling.
-	_, err := ds.writer.ExecContext(ctx, `UPDATE nano_enrollments SET token_update_tally = 0 WHERE id = ?`, hostUUID)
+	_, err := ds.writer(ctx).ExecContext(ctx, `UPDATE nano_enrollments SET token_update_tally = 0 WHERE id = ?`, hostUUID)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "updating nano_enrollments")
 	}

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -773,7 +773,7 @@ func testUpdateHostTablesOnMDMUnenroll(t *testing.T, ds *Datastore) {
 	require.Len(t, hostProfs, len(profiles))
 
 	var hostID uint
-	err = sqlx.GetContext(context.Background(), ds.reader, &hostID, `SELECT id  FROM hosts WHERE uuid = ?`, testUUID)
+	err = sqlx.GetContext(context.Background(), ds.reader(context.Background()), &hostID, `SELECT id  FROM hosts WHERE uuid = ?`, testUUID)
 	require.NoError(t, err)
 	err = ds.SetOrUpdateHostDiskEncryptionKey(ctx, hostID, "asdf")
 	require.NoError(t, err)
@@ -784,14 +784,14 @@ func testUpdateHostTablesOnMDMUnenroll(t *testing.T, ds *Datastore) {
 
 	// check that an entry in host_mdm exists
 	var count int
-	err = sqlx.GetContext(context.Background(), ds.reader, &count, `SELECT COUNT(*) FROM host_mdm WHERE host_id = (SELECT id FROM hosts WHERE uuid = ?)`, testUUID)
+	err = sqlx.GetContext(context.Background(), ds.reader(context.Background()), &count, `SELECT COUNT(*) FROM host_mdm WHERE host_id = (SELECT id FROM hosts WHERE uuid = ?)`, testUUID)
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
 
 	err = ds.UpdateHostTablesOnMDMUnenroll(ctx, testUUID)
 	require.NoError(t, err)
 
-	err = sqlx.GetContext(context.Background(), ds.reader, &count, `SELECT COUNT(*) FROM host_mdm WHERE host_id = ?`, testUUID)
+	err = sqlx.GetContext(context.Background(), ds.reader(context.Background()), &count, `SELECT COUNT(*) FROM host_mdm WHERE host_id = ?`, testUUID)
 	require.NoError(t, err)
 	require.Equal(t, 0, count)
 
@@ -1003,7 +1003,7 @@ func testMDMAppleProfileManagement(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Len(t, globalPfs, len(globalProfiles))
 
-	_, err = ds.writer.Exec(`
+	_, err = ds.writer(ctx).Exec(`
           INSERT INTO nano_commands (command_uuid, request_type, command)
           VALUES ('command-uuid', 'foo', '<?xml')
 	`)
@@ -1278,12 +1278,12 @@ func testMDMAppleProfileManagement(t *testing.T, ds *Datastore) {
 // testIngestMDMAppleHostAlreadyExistsInFleet)
 func checkMDMHostRelatedTables(t *testing.T, ds *Datastore, hostID uint, expectedSerial string, expectedModel string) {
 	var displayName string
-	err := sqlx.GetContext(context.Background(), ds.reader, &displayName, `SELECT display_name FROM host_display_names WHERE host_id = ?`, hostID)
+	err := sqlx.GetContext(context.Background(), ds.reader(context.Background()), &displayName, `SELECT display_name FROM host_display_names WHERE host_id = ?`, hostID)
 	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("%s (%s)", expectedModel, expectedSerial), displayName)
 
 	var labelsOK []bool
-	err = sqlx.SelectContext(context.Background(), ds.reader, &labelsOK, `SELECT 1 FROM label_membership WHERE host_id = ?`, hostID)
+	err = sqlx.SelectContext(context.Background(), ds.reader(context.Background()), &labelsOK, `SELECT 1 FROM label_membership WHERE host_id = ?`, hostID)
 	require.NoError(t, err)
 	require.Len(t, labelsOK, 2)
 	require.True(t, labelsOK[0])
@@ -1292,7 +1292,7 @@ func checkMDMHostRelatedTables(t *testing.T, ds *Datastore, hostID uint, expecte
 	appCfg, err := ds.AppConfig(context.Background())
 	require.NoError(t, err)
 	var hmdm fleet.HostMDM
-	err = sqlx.GetContext(context.Background(), ds.reader, &hmdm, `SELECT host_id, server_url, mdm_id FROM host_mdm WHERE host_id = ?`, hostID)
+	err = sqlx.GetContext(context.Background(), ds.reader(context.Background()), &hmdm, `SELECT host_id, server_url, mdm_id FROM host_mdm WHERE host_id = ?`, hostID)
 	require.NoError(t, err)
 	require.Equal(t, hostID, hmdm.HostID)
 	serverURL, err := apple_mdm.ResolveAppleMDMURL(appCfg.ServerSettings.ServerURL)
@@ -1301,7 +1301,7 @@ func checkMDMHostRelatedTables(t *testing.T, ds *Datastore, hostID uint, expecte
 	require.NotEmpty(t, hmdm.MDMID)
 
 	var mdmSolution fleet.MDMSolution
-	err = sqlx.GetContext(context.Background(), ds.reader, &mdmSolution, `SELECT name, server_url FROM mobile_device_management_solutions WHERE id = ?`, hmdm.MDMID)
+	err = sqlx.GetContext(context.Background(), ds.reader(context.Background()), &mdmSolution, `SELECT name, server_url FROM mobile_device_management_solutions WHERE id = ?`, hmdm.MDMID)
 	require.NoError(t, err)
 	require.Equal(t, fleet.WellKnownMDMFleet, mdmSolution.Name)
 	require.Equal(t, serverURL, mdmSolution.ServerURL)
@@ -1347,7 +1347,7 @@ func testGetMDMAppleProfilesContents(t *testing.T, ds *Datastore) {
 // createBuiltinLabels creates entries for "All Hosts" and "macOS" labels, which are assumed to be
 // extant for MDM flows
 func createBuiltinLabels(t *testing.T, ds *Datastore) {
-	_, err := ds.writer.Exec(`
+	_, err := ds.writer(context.Background()).Exec(`
 		INSERT INTO labels (
 			name,
 			description,
@@ -1370,10 +1370,10 @@ func createBuiltinLabels(t *testing.T, ds *Datastore) {
 }
 
 func nanoEnroll(t *testing.T, ds *Datastore, host *fleet.Host, withUser bool) {
-	_, err := ds.writer.Exec(`INSERT INTO nano_devices (id, authenticate) VALUES (?, 'test')`, host.UUID)
+	_, err := ds.writer(context.Background()).Exec(`INSERT INTO nano_devices (id, authenticate) VALUES (?, 'test')`, host.UUID)
 	require.NoError(t, err)
 
-	_, err = ds.writer.Exec(`
+	_, err = ds.writer(context.Background()).Exec(`
 INSERT INTO nano_enrollments
 	(id, device_id, user_id, type, topic, push_magic, token_hex, token_update_tally)
 VALUES
@@ -1390,7 +1390,7 @@ VALUES
 	require.NoError(t, err)
 
 	if withUser {
-		_, err = ds.writer.Exec(`
+		_, err = ds.writer(context.Background()).Exec(`
 INSERT INTO nano_enrollments
 	(id, device_id, user_id, type, topic, push_magic, token_hex)
 VALUES
@@ -1803,7 +1803,7 @@ func testMDMAppleHostsProfilesStatus(t *testing.T, ds *Datastore) {
 	require.True(t, checkListHosts(fleet.MacOSSettingsVerified, ptr.Uint(0), []*fleet.Host{}))
 
 	// hosts[6] deletes all its profiles
-	tx, err := ds.writer.BeginTxx(ctx, nil)
+	tx, err := ds.writer(ctx).BeginTxx(ctx, nil)
 	require.NoError(t, err)
 	require.NoError(t, ds.deleteMDMAppleProfilesForHost(ctx, tx, hosts[6].UUID))
 	require.NoError(t, tx.Commit())
@@ -2120,7 +2120,7 @@ func testDeleteMDMAppleProfilesForHost(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Len(t, gotProfs, 1)
 
-	tx, err := ds.writer.BeginTxx(ctx, nil)
+	tx, err := ds.writer(ctx).BeginTxx(ctx, nil)
 	require.NoError(t, err)
 	require.NoError(t, ds.deleteMDMAppleProfilesForHost(ctx, tx, h.UUID))
 	require.NoError(t, tx.Commit())
@@ -3983,7 +3983,7 @@ func TestHostDEPAssignments(t *testing.T) {
 		require.Equal(t, int64(1), n)
 
 		var depHostID uint
-		err = sqlx.GetContext(ctx, ds.reader, &depHostID, "SELECT id FROM hosts WHERE hardware_serial = ?", depSerial)
+		err = sqlx.GetContext(ctx, ds.reader(ctx), &depHostID, "SELECT id FROM hosts WHERE hardware_serial = ?", depSerial)
 		require.NoError(t, err)
 
 		// host MDM row is created when DEP device is ingested
@@ -4132,7 +4132,7 @@ func TestHostDEPAssignments(t *testing.T) {
 		require.NoError(t, err)
 
 		var manualHostID uint
-		err = sqlx.GetContext(ctx, ds.reader, &manualHostID, "SELECT id FROM hosts WHERE hardware_serial = ?", manualSerial)
+		err = sqlx.GetContext(ctx, ds.reader(ctx), &manualHostID, "SELECT id FROM hosts WHERE hardware_serial = ?", manualSerial)
 		require.NoError(t, err)
 
 		// host MDM is "On (manual)"

--- a/server/datastore/mysql/carves.go
+++ b/server/datastore/mysql/carves.go
@@ -57,7 +57,7 @@ func upsertCarveDB(ctx context.Context, writer sqlx.ExecerContext, metadata *fle
 }
 
 func (ds *Datastore) NewCarve(ctx context.Context, metadata *fleet.CarveMetadata) (*fleet.CarveMetadata, error) {
-	id, err := upsertCarveDB(ctx, ds.writer, metadata)
+	id, err := upsertCarveDB(ctx, ds.writer(ctx), metadata)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "insert carve metadata")
 	}
@@ -68,7 +68,7 @@ func (ds *Datastore) NewCarve(ctx context.Context, metadata *fleet.CarveMetadata
 // UpdateCarve updates the carve metadata in database
 // Only max_block and expired are updatable
 func (ds *Datastore) UpdateCarve(ctx context.Context, metadata *fleet.CarveMetadata) error {
-	return updateCarveDB(ctx, ds.writer, metadata)
+	return updateCarveDB(ctx, ds.writer(ctx), metadata)
 }
 
 func updateCarveDB(ctx context.Context, exec sqlx.ExecerContext, metadata *fleet.CarveMetadata) error {
@@ -177,7 +177,7 @@ func (ds *Datastore) Carve(ctx context.Context, carveId int64) (*fleet.CarveMeta
 	)
 
 	var metadata fleet.CarveMetadata
-	if err := sqlx.GetContext(ctx, ds.reader, &metadata, stmt, carveId); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &metadata, stmt, carveId); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("Carve").WithID(uint(carveId)))
 		}
@@ -196,7 +196,7 @@ func (ds *Datastore) CarveBySessionId(ctx context.Context, sessionId string) (*f
 	)
 
 	var metadata fleet.CarveMetadata
-	if err := sqlx.GetContext(ctx, ds.reader, &metadata, stmt, sessionId); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &metadata, stmt, sessionId); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("CarveBySessionId").WithName(sessionId))
 		}
@@ -215,7 +215,7 @@ func (ds *Datastore) CarveByName(ctx context.Context, name string) (*fleet.Carve
 	)
 
 	var metadata fleet.CarveMetadata
-	if err := sqlx.GetContext(ctx, ds.reader, &metadata, stmt, name); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &metadata, stmt, name); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("Carve").WithName(name))
 		}
@@ -236,7 +236,7 @@ func (ds *Datastore) ListCarves(ctx context.Context, opt fleet.CarveListOptions)
 	}
 	stmt = appendListOptionsToSQL(stmt, &opt.ListOptions)
 	carves := []*fleet.CarveMetadata{}
-	if err := sqlx.SelectContext(ctx, ds.reader, &carves, stmt); err != nil && err != sql.ErrNoRows {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &carves, stmt); err != nil && err != sql.ErrNoRows {
 		return nil, ctxerr.Wrap(ctx, err, "list carves")
 	}
 
@@ -278,7 +278,7 @@ func (ds *Datastore) GetBlock(ctx context.Context, metadata *fleet.CarveMetadata
 		WHERE metadata_id = ? AND block_id = ?
 	`
 	var data []byte
-	if err := sqlx.GetContext(ctx, ds.reader, &data, stmt, metadata.ID, blockId); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &data, stmt, metadata.ID, blockId); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("CarveBlock").WithID(uint(blockId)))
 		}

--- a/server/datastore/mysql/cron_stats.go
+++ b/server/datastore/mysql/cron_stats.go
@@ -40,7 +40,7 @@ UNION
 	LIMIT 1)`
 
 	var res []fleet.CronStats
-	err := sqlx.SelectContext(ctx, ds.reader, &res, stmt, name, name)
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &res, stmt, name, name)
 	if err != nil {
 		return []fleet.CronStats{}, ctxerr.Wrap(ctx, err, "select cron stats")
 	}
@@ -51,7 +51,7 @@ UNION
 func (ds *Datastore) InsertCronStats(ctx context.Context, statsType fleet.CronStatsType, name string, instance string, status fleet.CronStatsStatus) (int, error) {
 	stmt := `INSERT INTO cron_stats (stats_type, name, instance, status) VALUES (?, ?, ?, ?)`
 
-	res, err := ds.writer.ExecContext(ctx, stmt, statsType, name, instance, status)
+	res, err := ds.writer(ctx).ExecContext(ctx, stmt, statsType, name, instance, status)
 	if err != nil {
 		return 0, ctxerr.Wrap(ctx, err, "insert cron stats")
 	}
@@ -66,7 +66,7 @@ func (ds *Datastore) InsertCronStats(ctx context.Context, statsType fleet.CronSt
 func (ds *Datastore) UpdateCronStats(ctx context.Context, id int, status fleet.CronStatsStatus) error {
 	stmt := `UPDATE cron_stats SET status = ? WHERE id = ?`
 
-	if _, err := ds.writer.ExecContext(ctx, stmt, status, id); err != nil {
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, status, id); err != nil {
 		return ctxerr.Wrap(ctx, err, "update cron stats")
 	}
 
@@ -76,7 +76,7 @@ func (ds *Datastore) UpdateCronStats(ctx context.Context, id int, status fleet.C
 func (ds *Datastore) UpdateAllCronStatsForInstance(ctx context.Context, instance string, fromStatus fleet.CronStatsStatus, toStatus fleet.CronStatsStatus) error {
 	stmt := `UPDATE cron_stats SET status = ? WHERE instance = ? AND status = ?`
 
-	if _, err := ds.writer.ExecContext(ctx, stmt, toStatus, instance, fromStatus); err != nil {
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, toStatus, instance, fromStatus); err != nil {
 		return ctxerr.Wrap(ctx, err, "update all cron stats for instance")
 	}
 

--- a/server/datastore/mysql/cron_stats_test.go
+++ b/server/datastore/mysql/cron_stats_test.go
@@ -49,7 +49,7 @@ func TestGetLatestCronStats(t *testing.T) {
 
 	insertTestCS := func(name string, statsType fleet.CronStatsType, status fleet.CronStatsStatus, createdAt time.Time) {
 		stmt := `INSERT INTO cron_stats (stats_type, name, instance, status, created_at) VALUES (?, ?, ?, ?, ?)`
-		_, err := ds.writer.ExecContext(ctx, stmt, statsType, name, instanceID, status, createdAt)
+		_, err := ds.writer(ctx).ExecContext(ctx, stmt, statsType, name, instanceID, status, createdAt)
 		require.NoError(t, err)
 	}
 
@@ -167,12 +167,12 @@ func TestCleanupCronStats(t *testing.T) {
 
 	for _, c := range cases {
 		stmt := `INSERT INTO cron_stats (stats_type, name, instance, status, created_at) VALUES (?, ?, ?, ?, ?)`
-		_, err := ds.writer.ExecContext(ctx, stmt, fleet.CronStatsTypeScheduled, name, instance, c.status, c.createdAt)
+		_, err := ds.writer(ctx).ExecContext(ctx, stmt, fleet.CronStatsTypeScheduled, name, instance, c.status, c.createdAt)
 		require.NoError(t, err)
 	}
 
 	var stats []fleet.CronStats
-	err := sqlx.SelectContext(ctx, ds.reader, &stats, `SELECT * FROM cron_stats ORDER BY id`)
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &stats, `SELECT * FROM cron_stats ORDER BY id`)
 	require.NoError(t, err)
 	require.Len(t, stats, len(cases))
 	for i, s := range stats {
@@ -184,7 +184,7 @@ func TestCleanupCronStats(t *testing.T) {
 	require.NoError(t, err)
 
 	stats = []fleet.CronStats{}
-	err = sqlx.SelectContext(ctx, ds.reader, &stats, `SELECT * FROM cron_stats ORDER BY id`)
+	err = sqlx.SelectContext(ctx, ds.reader(ctx), &stats, `SELECT * FROM cron_stats ORDER BY id`)
 	require.NoError(t, err)
 	require.Len(t, stats, len(cases)-1) // case[7] was deleted because it exceeded max age
 	for i, c := range cases {
@@ -250,12 +250,12 @@ func TestUpdateAllCronStatsForInstance(t *testing.T) {
 
 	for _, c := range cases {
 		stmt := `INSERT INTO cron_stats (stats_type, name, instance, status) VALUES (?, ?, ?, ?)`
-		_, err := ds.writer.ExecContext(ctx, stmt, fleet.CronStatsTypeScheduled, c.schedName, c.instance, c.status)
+		_, err := ds.writer(ctx).ExecContext(ctx, stmt, fleet.CronStatsTypeScheduled, c.schedName, c.instance, c.status)
 		require.NoError(t, err)
 	}
 
 	var stats []fleet.CronStats
-	err := sqlx.SelectContext(ctx, ds.reader, &stats, `SELECT * FROM cron_stats ORDER BY id`)
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &stats, `SELECT * FROM cron_stats ORDER BY id`)
 	require.NoError(t, err)
 	require.Len(t, stats, len(cases))
 	for i, s := range stats {
@@ -268,7 +268,7 @@ func TestUpdateAllCronStatsForInstance(t *testing.T) {
 	require.NoError(t, err)
 
 	stats = []fleet.CronStats{}
-	err = sqlx.SelectContext(ctx, ds.reader, &stats, `SELECT * FROM cron_stats ORDER BY id`)
+	err = sqlx.SelectContext(ctx, ds.reader(ctx), &stats, `SELECT * FROM cron_stats ORDER BY id`)
 	require.NoError(t, err)
 	require.Len(t, stats, len(cases))
 	for i, c := range cases {

--- a/server/datastore/mysql/delete.go
+++ b/server/datastore/mysql/delete.go
@@ -12,7 +12,7 @@ import (
 // returning a notFound error if appropriate.
 func (ds *Datastore) deleteEntity(ctx context.Context, dbTable entity, id uint) error {
 	deleteStmt := fmt.Sprintf(`DELETE FROM %s WHERE id = ?`, dbTable.name)
-	result, err := ds.writer.ExecContext(ctx, deleteStmt, id)
+	result, err := ds.writer(ctx).ExecContext(ctx, deleteStmt, id)
 	if err != nil {
 		return ctxerr.Wrapf(ctx, err, "delete %s", dbTable)
 	}
@@ -27,7 +27,7 @@ func (ds *Datastore) deleteEntity(ctx context.Context, dbTable entity, id uint) 
 // table, returning a notFound error if appropriate.
 func (ds *Datastore) deleteEntityByName(ctx context.Context, dbTable entity, name string) error {
 	deleteStmt := fmt.Sprintf("DELETE FROM %s WHERE name = ?", dbTable.name)
-	result, err := ds.writer.ExecContext(ctx, deleteStmt, name)
+	result, err := ds.writer(ctx).ExecContext(ctx, deleteStmt, name)
 	if err != nil {
 		if isMySQLForeignKey(err) {
 			return ctxerr.Wrap(ctx, foreignKey(dbTable.name, name))
@@ -51,7 +51,7 @@ func (ds *Datastore) deleteEntities(ctx context.Context, dbTable entity, ids []u
 		return 0, ctxerr.Wrapf(ctx, err, "building delete entities query %s", dbTable)
 	}
 
-	result, err := ds.writer.ExecContext(ctx, query, args...)
+	result, err := ds.writer(ctx).ExecContext(ctx, query, args...)
 	if err != nil {
 		return 0, ctxerr.Wrapf(ctx, err, "executing delete entities query %s", dbTable)
 	}

--- a/server/datastore/mysql/email_changes.go
+++ b/server/datastore/mysql/email_changes.go
@@ -16,7 +16,7 @@ func (ds *Datastore) PendingEmailChange(ctx context.Context, uid uint, newEmail,
       new_email
     ) VALUES( ?, ?, ? )
   `
-	_, err := ds.writer.ExecContext(ctx, sqlStatement, uid, token, newEmail)
+	_, err := ds.writer(ctx).ExecContext(ctx, sqlStatement, uid, token, newEmail)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "inserting email change record")
 	}

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -137,7 +137,7 @@ func (ds *Datastore) SerialUpdateHost(ctx context.Context, host *fleet.Host) err
 }
 
 func (ds *Datastore) SaveHostPackStats(ctx context.Context, hostID uint, stats []fleet.PackStats) error {
-	return saveHostPackStatsDB(ctx, ds.writer, hostID, stats)
+	return saveHostPackStatsDB(ctx, ds.writer(ctx), hostID, stats)
 }
 
 func saveHostPackStatsDB(ctx context.Context, db sqlx.ExecerContext, hostID uint, stats []fleet.PackStats) error {
@@ -359,7 +359,7 @@ func (ds *Datastore) DeleteHost(ctx context.Context, hid uint) error {
 
 	// load just the host uuid for the MDM tables that rely on this to be cleared.
 	var hostUUID string
-	if err := ds.writer.GetContext(ctx, &hostUUID, `SELECT uuid FROM hosts WHERE id = ?`, hid); err != nil {
+	if err := ds.writer(ctx).GetContext(ctx, &hostUUID, `SELECT uuid FROM hosts WHERE id = ?`, hid); err != nil {
 		return ctxerr.Wrapf(ctx, err, "get uuid for host %d", hid)
 	}
 
@@ -477,7 +477,7 @@ LIMIT
 	args := []interface{}{id, id}
 
 	var host fleet.Host
-	err := sqlx.GetContext(ctx, ds.reader, &host, sqlStatement, args...)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &host, sqlStatement, args...)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("Host").WithID(id))
@@ -491,13 +491,13 @@ LIMIT
 		host.DiskEncryptionEnabled = nil
 	}
 
-	packStats, err := loadHostPackStatsDB(ctx, ds.reader, host.ID, host.Platform)
+	packStats, err := loadHostPackStatsDB(ctx, ds.reader(ctx), host.ID, host.Platform)
 	if err != nil {
 		return nil, err
 	}
 	host.PackStats = packStats
 
-	users, err := loadHostUsersDB(ctx, ds.reader, host.ID)
+	users, err := loadHostUsersDB(ctx, ds.reader(ctx), host.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -681,7 +681,7 @@ func (ds *Datastore) ListHosts(ctx context.Context, filter fleet.TeamFilter, opt
 	sql, params = ds.applyHostFilters(opt, sql, filter, params)
 
 	hosts := []*fleet.Host{}
-	if err := sqlx.SelectContext(ctx, ds.reader, &hosts, sql, params...); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hosts, sql, params...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list hosts")
 	}
 
@@ -993,7 +993,7 @@ func (ds *Datastore) CountHosts(ctx context.Context, filter fleet.TeamFilter, op
 	sql, params = ds.applyHostFilters(opt, sql, filter, params)
 
 	var count int
-	if err := sqlx.GetContext(ctx, ds.reader, &count, sql, params...); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &count, sql, params...); err != nil {
 		return 0, ctxerr.Wrap(ctx, err, "count hosts")
 	}
 
@@ -1083,7 +1083,7 @@ func (ds *Datastore) GenerateHostStatusStatistics(ctx context.Context, filter fl
 		return nil, ctxerr.Wrap(ctx, err, "generating host statistics statement")
 	}
 	summary := fleet.HostSummary{TeamID: filter.TeamID}
-	err = sqlx.GetContext(ctx, ds.reader, &summary, stmt, args...)
+	err = sqlx.GetContext(ctx, ds.reader(ctx), &summary, stmt, args...)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, ctxerr.Wrap(ctx, err, "generating host statistics")
 	}
@@ -1112,7 +1112,7 @@ func (ds *Datastore) GenerateHostStatusStatistics(ctx context.Context, filter fl
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "generating host platforms statement")
 	}
-	err = sqlx.SelectContext(ctx, ds.reader, &platforms, stmt, args...)
+	err = sqlx.SelectContext(ctx, ds.reader(ctx), &platforms, stmt, args...)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "generating host platforms statistics")
 	}
@@ -1451,7 +1451,7 @@ func (ds *Datastore) getContextTryStmt(ctx context.Context, dest interface{}, qu
 	if stmt := ds.loadOrPrepareStmt(ctx, query); stmt != nil {
 		err = stmt.GetContext(ctx, dest, args...)
 	} else {
-		err = sqlx.GetContext(ctx, ds.reader, dest, query, args...)
+		err = sqlx.GetContext(ctx, ds.reader(ctx), dest, query, args...)
 	}
 	return err
 }
@@ -1741,7 +1741,7 @@ func (ds *Datastore) SetOrUpdateDeviceAuthToken(ctx context.Context, hostID uint
 		ON DUPLICATE KEY UPDATE
 			token = VALUES(token)
 `
-	_, err := ds.writer.ExecContext(ctx, stmt, hostID, authToken)
+	_, err := ds.writer(ctx).ExecContext(ctx, stmt, hostID, authToken)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "upsert host's device auth token")
 	}
@@ -1852,8 +1852,8 @@ func (ds *Datastore) SearchHosts(ctx context.Context, filter fleet.TeamFilter, m
 			args = wildCardArgs
 		}
 		searchHostsQuery += " AND TRUE ORDER BY id DESC LIMIT 10"
-		searchHostsQuery = ds.reader.Rebind(searchHostsQuery)
-		err := sqlx.SelectContext(ctx, ds.reader, &matchingHostIDs, searchHostsQuery, args...)
+		searchHostsQuery = ds.reader(ctx).Rebind(searchHostsQuery)
+		err := sqlx.SelectContext(ctx, ds.reader(ctx), &matchingHostIDs, searchHostsQuery, args...)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "searching hosts")
 		}
@@ -1883,9 +1883,9 @@ func (ds *Datastore) SearchHosts(ctx context.Context, filter fleet.TeamFilter, m
 		}
 	}
 
-	query = ds.reader.Rebind(query)
+	query = ds.reader(ctx).Rebind(query)
 	var hosts []*fleet.Host
-	if err = sqlx.SelectContext(ctx, ds.reader, &hosts, query, args...); err != nil {
+	if err = sqlx.SelectContext(ctx, ds.reader(ctx), &hosts, query, args...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "searching hosts")
 	}
 
@@ -1909,7 +1909,7 @@ func (ds *Datastore) HostIDsByName(ctx context.Context, filter fleet.TeamFilter,
 	}
 
 	var hostIDs []uint
-	if err := sqlx.SelectContext(ctx, ds.reader, &hostIDs, sql, args...); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hostIDs, sql, args...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get host IDs")
 	}
 
@@ -1955,7 +1955,7 @@ WHERE uuid IN (?) AND %s
 	}
 
 	var hosts []*fleet.Host
-	if err := sqlx.SelectContext(ctx, ds.reader, &hosts, stmt, args...); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hosts, stmt, args...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "select hosts by uuid")
 	}
 
@@ -1999,7 +1999,7 @@ WHERE id IN (?)`
 	}
 
 	var hosts []*fleet.Host
-	if err := sqlx.SelectContext(ctx, ds.reader, &hosts, stmt, args...); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hosts, stmt, args...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "select hosts by id")
 	}
 
@@ -2063,7 +2063,7 @@ func (ds *Datastore) HostByIdentifier(ctx context.Context, identifier string) (*
     LIMIT 1
 	`
 	host := &fleet.Host{}
-	err := sqlx.GetContext(ctx, ds.reader, host, stmt, identifier)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), host, stmt, identifier)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("Host").WithName(identifier))
@@ -2071,7 +2071,7 @@ func (ds *Datastore) HostByIdentifier(ctx context.Context, identifier string) (*
 		return nil, ctxerr.Wrap(ctx, err, "get host by identifier")
 	}
 
-	packStats, err := loadHostPackStatsDB(ctx, ds.reader, host.ID, host.Platform)
+	packStats, err := loadHostPackStatsDB(ctx, ds.reader(ctx), host.ID, host.Platform)
 	if err != nil {
 		return nil, err
 	}
@@ -2108,7 +2108,7 @@ func (ds *Datastore) AddHostsToTeam(ctx context.Context, teamID *uint, hostIDs [
 }
 
 func (ds *Datastore) SaveHostAdditional(ctx context.Context, hostID uint, additional *json.RawMessage) error {
-	return saveHostAdditionalDB(ctx, ds.writer, hostID, additional)
+	return saveHostAdditionalDB(ctx, ds.writer(ctx), hostID, additional)
 }
 
 func saveHostAdditionalDB(ctx context.Context, exec sqlx.ExecerContext, hostID uint, additional *json.RawMessage) error {
@@ -2189,7 +2189,7 @@ func (ds *Datastore) TotalAndUnseenHostsSince(ctx context.Context, daysCount int
 	// convert daysCount to integer number of seconds for more precision in sql query
 	unseenSeconds := daysCount * 24 * 60 * 60
 
-	err = sqlx.GetContext(ctx, ds.reader, &counts,
+	err = sqlx.GetContext(ctx, ds.reader(ctx), &counts,
 		`SELECT
 			COUNT(*) as total,
 			SUM(IF(TIMESTAMPDIFF(SECOND, COALESCE(hst.seen_time, h.created_at), CURRENT_TIMESTAMP) >= ?, 1, 0)) as unseen
@@ -2229,7 +2229,7 @@ func (ds *Datastore) FailingPoliciesCount(ctx context.Context, host *fleet.Host)
 	`
 
 	var r uint
-	if err := sqlx.GetContext(ctx, ds.reader, &r, query, host.ID); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &r, query, host.ID); err != nil {
 		if err == sql.ErrNoRows {
 			return 0, nil
 		}
@@ -2259,14 +2259,14 @@ func (ds *Datastore) ListPoliciesForHost(ctx context.Context, host *fleet.Host) 
 	AND (p.platforms IS NULL OR p.platforms = '' OR FIND_IN_SET(?, p.platforms) != 0)`
 
 	var policies []*fleet.HostPolicy
-	if err := sqlx.SelectContext(ctx, ds.reader, &policies, query, host.ID, host.ID, host.FleetPlatform()); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &policies, query, host.ID, host.ID, host.FleetPlatform()); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get host policies")
 	}
 	return policies, nil
 }
 
 func (ds *Datastore) CleanupExpiredHosts(ctx context.Context) ([]uint, error) {
-	ac, err := appConfigDB(ctx, ds.reader)
+	ac, err := appConfigDB(ctx, ds.reader(ctx))
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "getting app config")
 	}
@@ -2281,7 +2281,7 @@ func (ds *Datastore) CleanupExpiredHosts(ctx context.Context) ([]uint, error) {
 	// it might take longer, but it should lock only the row we need
 
 	var ids []uint
-	err = ds.writer.SelectContext(
+	err = ds.writer(ctx).SelectContext(
 		ctx,
 		&ids,
 		`SELECT h.id FROM hosts h
@@ -2301,7 +2301,7 @@ func (ds *Datastore) CleanupExpiredHosts(ctx context.Context) ([]uint, error) {
 		}
 	}
 
-	_, err = ds.writer.ExecContext(ctx, `DELETE FROM host_seen_times WHERE seen_time < DATE_SUB(NOW(), INTERVAL ? DAY)`, ac.HostExpirySettings.HostExpiryWindow)
+	_, err = ds.writer(ctx).ExecContext(ctx, `DELETE FROM host_seen_times WHERE seen_time < DATE_SUB(NOW(), INTERVAL ? DAY)`, ac.HostExpirySettings.HostExpiryWindow)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "deleting expired host seen times")
 	}
@@ -2323,7 +2323,7 @@ func (ds *Datastore) ListHostDeviceMapping(ctx context.Context, id uint) ([]*fle
       email, source`
 
 	var mappings []*fleet.HostDeviceMapping
-	err := sqlx.SelectContext(ctx, ds.reader, &mappings, stmt, id)
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &mappings, stmt, id)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "select host emails by host id")
 	}
@@ -2479,7 +2479,7 @@ func (ds *Datastore) ReplaceHostBatteries(ctx context.Context, hid uint, mapping
 }
 
 func (ds *Datastore) updateOrInsert(ctx context.Context, updateQuery string, insertQuery string, args ...interface{}) error {
-	res, err := ds.writer.ExecContext(ctx, updateQuery, args...)
+	res, err := ds.writer(ctx).ExecContext(ctx, updateQuery, args...)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "update")
 	}
@@ -2488,7 +2488,7 @@ func (ds *Datastore) updateOrInsert(ctx context.Context, updateQuery string, ins
 		return ctxerr.Wrap(ctx, err, "rows affected by update")
 	}
 	if affected == 0 {
-		_, err = ds.writer.ExecContext(ctx, insertQuery, args...)
+		_, err = ds.writer(ctx).ExecContext(ctx, insertQuery, args...)
 	}
 	return ctxerr.Wrap(ctx, err, "insert")
 }
@@ -2513,7 +2513,7 @@ func (ds *Datastore) SetOrUpdateMunkiInfo(ctx context.Context, hostID uint, vers
 	if version == "" {
 		// Only update deleted_at if there wasn't any deleted at for this host
 		updateQuery := `UPDATE host_munki_info SET deleted_at = NOW() WHERE host_id = ? AND deleted_at is NULL`
-		_, err := ds.writer.ExecContext(ctx, updateQuery, hostID)
+		_, err := ds.writer(ctx).ExecContext(ctx, updateQuery, hostID)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err)
 		}
@@ -2571,7 +2571,7 @@ func (ds *Datastore) replaceHostMunkiIssues(ctx context.Context, hostID uint, ms
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "prepare read host_munki_issues counts arguments")
 	}
-	if err := sqlx.GetContext(ctx, ds.reader, &counts, stmt, args...); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &counts, stmt, args...); err != nil {
 		return ctxerr.Wrap(ctx, err, "read host_munki_issues counts")
 	}
 	if counts.CountNew == len(newIDs) && counts.CountOld == 0 {
@@ -2585,7 +2585,7 @@ func (ds *Datastore) replaceHostMunkiIssues(ctx context.Context, hostID uint, ms
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "prepare delete host_munki_issues arguments")
 		}
-		if _, err := ds.writer.ExecContext(ctx, stmt, args...); err != nil {
+		if _, err := ds.writer(ctx).ExecContext(ctx, stmt, args...); err != nil {
 			return ctxerr.Wrap(ctx, err, "delete host_munki_issues")
 		}
 	}
@@ -2602,7 +2602,7 @@ func (ds *Datastore) replaceHostMunkiIssues(ctx context.Context, hostID uint, ms
 		for _, id := range newIDs {
 			args = append(args, hostID, id)
 		}
-		if _, err := ds.writer.ExecContext(ctx, stmt, args...); err != nil {
+		if _, err := ds.writer(ctx).ExecContext(ctx, stmt, args...); err != nil {
 			return ctxerr.Wrap(ctx, err, "insert host_munki_issues")
 		}
 	}
@@ -2689,10 +2689,10 @@ func (ds *Datastore) getOrInsertMunkiIssues(ctx context.Context, errors, warning
 	}
 
 	// get the IDs for existing munki issues (from the read replica)
-	if err := readIDs(ds.reader, allMsgs, "error"); err != nil {
+	if err := readIDs(ds.reader(ctx), allMsgs, "error"); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "load error message IDs from reader")
 	}
-	if err := readIDs(ds.reader, allMsgs, "warning"); err != nil {
+	if err := readIDs(ds.reader(ctx), allMsgs, "warning"); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "load warning message IDs from reader")
 	}
 
@@ -2719,17 +2719,17 @@ func (ds *Datastore) getOrInsertMunkiIssues(ctx context.Context, errors, warning
 				args = append(args, msg[0], msg[1])
 			}
 			stmt := fmt.Sprintf(insStmt, strings.TrimSuffix(strings.Repeat(stmtParts, len(batch)), ","))
-			if _, err := ds.writer.ExecContext(ctx, stmt, args...); err != nil {
+			if _, err := ds.writer(ctx).ExecContext(ctx, stmt, args...); err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "batch-insert munki issues")
 			}
 		}
 
 		// load the IDs for the missing munki issues, from the primary as we just
 		// inserted them
-		if err := readIDs(ds.writer, msgsToReload, "error"); err != nil {
+		if err := readIDs(ds.writer(ctx), msgsToReload, "error"); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "load error message IDs from writer")
 		}
-		if err := readIDs(ds.writer, msgsToReload, "warning"); err != nil {
+		if err := readIDs(ds.writer(ctx), msgsToReload, "warning"); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "load warning message IDs from writer")
 		}
 		if missing := missingIDs(); len(missing) > 0 {
@@ -2755,11 +2755,11 @@ func (ds *Datastore) SetOrUpdateMDMData(
 		// because it will eventually catch up on subsequent ingestions and
 		// the entry will be deleted.
 		var id uint
-		switch err := sqlx.GetContext(ctx, ds.reader, &id,
+		switch err := sqlx.GetContext(ctx, ds.reader(ctx), &id,
 			`SELECT host_id FROM host_mdm WHERE host_id = ?`, hostID,
 		); {
 		case err == nil:
-			if _, err := ds.writer.ExecContext(ctx, `DELETE FROM host_mdm WHERE host_id = ?`, hostID); err != nil {
+			if _, err := ds.writer(ctx).ExecContext(ctx, `DELETE FROM host_mdm WHERE host_id = ?`, hostID); err != nil {
 				return ctxerr.Wrapf(ctx, err, "delete host_mdm row: %d", hostID)
 			}
 			return nil
@@ -2807,7 +2807,7 @@ func (ds *Datastore) SetOrUpdateHostDisksEncryption(ctx context.Context, hostID 
 }
 
 func (ds *Datastore) SetOrUpdateHostDiskEncryptionKey(ctx context.Context, hostID uint, encryptedBase64Key string) error {
-	_, err := ds.writer.ExecContext(ctx, `
+	_, err := ds.writer(ctx).ExecContext(ctx, `
            INSERT INTO host_disk_encryption_keys (host_id, base64_encrypted)
 	   VALUES (?, ?)
 	   ON DUPLICATE KEY UPDATE
@@ -2820,7 +2820,7 @@ func (ds *Datastore) SetOrUpdateHostDiskEncryptionKey(ctx context.Context, hostI
 
 func (ds *Datastore) GetUnverifiedDiskEncryptionKeys(ctx context.Context) ([]fleet.HostDiskEncryptionKey, error) {
 	var keys []fleet.HostDiskEncryptionKey
-	err := sqlx.SelectContext(ctx, ds.reader, &keys, `
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &keys, `
           SELECT
             base64_encrypted,
             host_id,
@@ -2850,13 +2850,13 @@ func (ds *Datastore) SetHostsDiskEncryptionKeyStatus(
 	if err != nil {
 		return err
 	}
-	_, err = ds.writer.ExecContext(ctx, query, args...)
+	_, err = ds.writer(ctx).ExecContext(ctx, query, args...)
 	return err
 }
 
 func (ds *Datastore) GetHostDiskEncryptionKey(ctx context.Context, hostID uint) (*fleet.HostDiskEncryptionKey, error) {
 	var key fleet.HostDiskEncryptionKey
-	err := sqlx.GetContext(ctx, ds.reader, &key, `
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &key, `
           SELECT
             host_id, base64_encrypted, decryptable, updated_at
           FROM
@@ -2895,7 +2895,7 @@ func (ds *Datastore) getOrInsertMDMSolution(ctx context.Context, serverURL strin
 
 func (ds *Datastore) GetHostMunkiVersion(ctx context.Context, hostID uint) (string, error) {
 	var version string
-	err := sqlx.GetContext(ctx, ds.reader, &version, `SELECT version FROM host_munki_info WHERE deleted_at is NULL AND host_id = ?`, hostID)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &version, `SELECT version FROM host_munki_info WHERE deleted_at is NULL AND host_id = ?`, hostID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return "", ctxerr.Wrap(ctx, notFound("MunkiInfo").WithID(hostID))
@@ -2908,7 +2908,7 @@ func (ds *Datastore) GetHostMunkiVersion(ctx context.Context, hostID uint) (stri
 
 func (ds *Datastore) GetHostMDM(ctx context.Context, hostID uint) (*fleet.HostMDM, error) {
 	var hmdm fleet.HostMDM
-	err := sqlx.GetContext(ctx, ds.reader, &hmdm, `
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &hmdm, `
 		SELECT
 			hm.host_id, hm.enrolled, hm.server_url, hm.installed_from_dep, hm.mdm_id, COALESCE(hm.is_server, false) AS is_server, COALESCE(mdms.name, ?) AS name
 		FROM
@@ -2930,7 +2930,7 @@ func (ds *Datastore) GetHostMDMCheckinInfo(ctx context.Context, hostUUID string)
 	var hmdm fleet.HostMDMCheckinInfo
 
 	// use writer as it is used just after creation in some cases
-	err := sqlx.GetContext(ctx, ds.writer, &hmdm, `
+	err := sqlx.GetContext(ctx, ds.writer(ctx), &hmdm, `
 		SELECT
 			h.hardware_serial,
 			COALESCE(hm.installed_from_dep, false) as installed_from_dep,
@@ -2956,7 +2956,7 @@ func (ds *Datastore) GetHostMDMCheckinInfo(ctx context.Context, hostUUID string)
 
 func (ds *Datastore) GetMDMSolution(ctx context.Context, mdmID uint) (*fleet.MDMSolution, error) {
 	var solution fleet.MDMSolution
-	err := sqlx.GetContext(ctx, ds.reader, &solution, `
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &solution, `
     SELECT
       id,
       name,
@@ -2975,7 +2975,7 @@ func (ds *Datastore) GetMDMSolution(ctx context.Context, mdmID uint) (*fleet.MDM
 
 func (ds *Datastore) GetHostMunkiIssues(ctx context.Context, hostID uint) ([]*fleet.HostMunkiIssue, error) {
 	var issues []*fleet.HostMunkiIssue
-	err := sqlx.SelectContext(ctx, ds.reader, &issues, `
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &issues, `
     SELECT
       hmi.munki_issue_id,
       mi.name,
@@ -2997,7 +2997,7 @@ func (ds *Datastore) GetHostMunkiIssues(ctx context.Context, hostID uint) ([]*fl
 
 func (ds *Datastore) GetMunkiIssue(ctx context.Context, munkiIssueID uint) (*fleet.MunkiIssue, error) {
 	var issue fleet.MunkiIssue
-	err := sqlx.GetContext(ctx, ds.reader, &issue, `
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &issue, `
     SELECT
       id,
       name,
@@ -3028,7 +3028,7 @@ func (ds *Datastore) AggregatedMunkiVersion(ctx context.Context, teamID *uint) (
 		UpdatedAt time.Time `db:"updated_at"`
 	}
 	err := sqlx.GetContext(
-		ctx, ds.reader, &versionsJson,
+		ctx, ds.reader(ctx), &versionsJson,
 		`SELECT json_value, updated_at FROM aggregated_stats WHERE id = ? AND global_stats = ? AND type = ?`,
 		id, globalStats, aggregatedStatsTypeMunkiVersions,
 	)
@@ -3060,7 +3060,7 @@ func (ds *Datastore) AggregatedMunkiIssues(ctx context.Context, teamID *uint) ([
 		UpdatedAt time.Time `db:"updated_at"`
 	}
 	err := sqlx.GetContext(
-		ctx, ds.reader, &resultJSON,
+		ctx, ds.reader(ctx), &resultJSON,
 		`SELECT json_value, updated_at FROM aggregated_stats WHERE id = ? AND global_stats = ? AND type = ?`,
 		id, globalStats, aggregatedStatsTypeMunkiIssues,
 	)
@@ -3092,7 +3092,7 @@ func (ds *Datastore) AggregatedMDMStatus(ctx context.Context, teamID *uint, plat
 		UpdatedAt time.Time `db:"updated_at"`
 	}
 	err := sqlx.GetContext(
-		ctx, ds.reader, &statusJson,
+		ctx, ds.reader(ctx), &statusJson,
 		`select json_value, updated_at from aggregated_stats where id = ? and global_stats = ? and type = ?`,
 		id, globalStats, platformKey(aggregatedStatsTypeMDMStatusPartial, platform),
 	)
@@ -3131,7 +3131,7 @@ func (ds *Datastore) AggregatedMDMSolutions(ctx context.Context, teamID *uint, p
 		UpdatedAt time.Time `db:"updated_at"`
 	}
 	err := sqlx.GetContext(
-		ctx, ds.reader, &resultJSON,
+		ctx, ds.reader(ctx), &resultJSON,
 		`SELECT json_value, updated_at FROM aggregated_stats WHERE id = ? AND global_stats = ? AND type = ?`,
 		id, globalStats, platformKey(aggregatedStatsTypeMDMSolutionsPartial, platform),
 	)
@@ -3154,7 +3154,7 @@ func (ds *Datastore) GenerateAggregatedMunkiAndMDM(ctx context.Context) error {
 		teamIDs   []uint
 	)
 
-	if err := sqlx.SelectContext(ctx, ds.reader, &teamIDs, `SELECT id FROM teams`); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &teamIDs, `SELECT id FROM teams`); err != nil {
 		return ctxerr.Wrap(ctx, err, "list teams")
 	}
 
@@ -3216,7 +3216,7 @@ func (ds *Datastore) generateAggregatedMunkiVersion(ctx context.Context, teamID 
 		query += `  WHERE `
 	}
 	query += ` hm.deleted_at IS NULL GROUP BY hm.version`
-	err := sqlx.SelectContext(ctx, ds.reader, &versions, query, args...)
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &versions, query, args...)
 	if err != nil {
 		return ctxerr.Wrapf(ctx, err, "getting aggregated data from host_munki")
 	}
@@ -3225,7 +3225,7 @@ func (ds *Datastore) generateAggregatedMunkiVersion(ctx context.Context, teamID 
 		return ctxerr.Wrap(ctx, err, "marshaling stats")
 	}
 
-	_, err = ds.writer.ExecContext(ctx,
+	_, err = ds.writer(ctx).ExecContext(ctx,
 		`
 INSERT INTO aggregated_stats (id, global_stats, type, json_value)
 VALUES (?, ?, ?, ?)
@@ -3273,7 +3273,7 @@ func (ds *Datastore) generateAggregatedMunkiIssues(ctx context.Context, teamID *
 	}
 	query += `GROUP BY hmi.munki_issue_id, mi.name, mi.issue_type`
 
-	err := sqlx.SelectContext(ctx, ds.reader, &issues, query, args...)
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &issues, query, args...)
 	if err != nil {
 		return ctxerr.Wrapf(ctx, err, "getting aggregated data from host_munki_issues")
 	}
@@ -3283,7 +3283,7 @@ func (ds *Datastore) generateAggregatedMunkiIssues(ctx context.Context, teamID *
 		return ctxerr.Wrap(ctx, err, "marshaling stats")
 	}
 
-	_, err = ds.writer.ExecContext(ctx, `
+	_, err = ds.writer(ctx).ExecContext(ctx, `
 INSERT INTO aggregated_stats (id, global_stats, type, json_value)
 VALUES (?, ?, ?, ?)
 ON DUPLICATE KEY UPDATE
@@ -3331,7 +3331,7 @@ func (ds *Datastore) generateAggregatedMDMStatus(ctx context.Context, teamID *ui
 		args = append(args, platform)
 		query += " AND h.platform = ? "
 	}
-	err := sqlx.GetContext(ctx, ds.reader, &status, query, args...)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &status, query, args...)
 	if err != nil {
 		return ctxerr.Wrapf(ctx, err, "getting aggregated data from host_mdm")
 	}
@@ -3341,7 +3341,7 @@ func (ds *Datastore) generateAggregatedMDMStatus(ctx context.Context, teamID *ui
 		return ctxerr.Wrap(ctx, err, "marshaling stats")
 	}
 
-	_, err = ds.writer.ExecContext(ctx,
+	_, err = ds.writer(ctx).ExecContext(ctx,
 		`
 INSERT INTO aggregated_stats (id, global_stats, type, json_value)
 VALUES (?, ?, ?, ?)
@@ -3395,7 +3395,7 @@ func (ds *Datastore) generateAggregatedMDMSolutions(ctx context.Context, teamID 
 		query += whereAnd + ` h.platform = ? `
 	}
 	query += ` GROUP BY id, server_url, name`
-	err := sqlx.SelectContext(ctx, ds.reader, &results, query, args...)
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &results, query, args...)
 	if err != nil {
 		return ctxerr.Wrapf(ctx, err, "getting aggregated data from host_mdm")
 	}
@@ -3405,7 +3405,7 @@ func (ds *Datastore) generateAggregatedMDMSolutions(ctx context.Context, teamID 
 		return ctxerr.Wrap(ctx, err, "marshaling stats")
 	}
 
-	_, err = ds.writer.ExecContext(ctx,
+	_, err = ds.writer(ctx).ExecContext(ctx,
 		`
 INSERT INTO aggregated_stats (id, global_stats, type, json_value)
 VALUES (?, ?, ?, ?)
@@ -3454,7 +3454,7 @@ func (ds *Datastore) HostLite(ctx context.Context, id uint) (*fleet.Host, error)
 		return nil, ctxerr.Wrap(ctx, err, "sql build")
 	}
 	var host fleet.Host
-	if err := sqlx.GetContext(ctx, ds.reader, &host, query, args...); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &host, query, args...); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("Host").WithID(id))
 		}
@@ -3472,7 +3472,7 @@ func (ds *Datastore) UpdateHostOsqueryIntervals(ctx context.Context, id uint, in
 			logger_tls_period = ?
 		WHERE id = ?
 	`
-	_, err := ds.writer.ExecContext(ctx, sqlStatement,
+	_, err := ds.writer(ctx).ExecContext(ctx, sqlStatement,
 		intervals.DistributedInterval,
 		intervals.ConfigTLSRefresh,
 		intervals.LoggerTLSPeriod,
@@ -3487,7 +3487,7 @@ func (ds *Datastore) UpdateHostOsqueryIntervals(ctx context.Context, id uint, in
 // UpdateHostRefetchRequested updates a host's refetch requested field.
 func (ds *Datastore) UpdateHostRefetchRequested(ctx context.Context, id uint, value bool) error {
 	sqlStatement := `UPDATE hosts SET refetch_requested = ? WHERE id = ?`
-	_, err := ds.writer.ExecContext(ctx, sqlStatement, value, id)
+	_, err := ds.writer(ctx).ExecContext(ctx, sqlStatement, value, id)
 	if err != nil {
 		return ctxerr.Wrapf(ctx, err, "update host %d refetch_requested", id)
 	}
@@ -3535,7 +3535,7 @@ func (ds *Datastore) UpdateHost(ctx context.Context, host *fleet.Host) error {
 			refetch_critical_queries_until = ?
 		WHERE id = ?
 	`
-	_, err := ds.writer.ExecContext(ctx, sqlStatement,
+	_, err := ds.writer(ctx).ExecContext(ctx, sqlStatement,
 		host.DetailUpdatedAt,
 		host.LabelUpdatedAt,
 		host.PolicyUpdatedAt,
@@ -3575,7 +3575,7 @@ func (ds *Datastore) UpdateHost(ctx context.Context, host *fleet.Host) error {
 	if err != nil {
 		return ctxerr.Wrapf(ctx, err, "save host with id %d", host.ID)
 	}
-	_, err = ds.writer.ExecContext(ctx, `
+	_, err = ds.writer(ctx).ExecContext(ctx, `
 			UPDATE host_display_names
 			SET display_name=?
 			WHERE host_id=?`,
@@ -3623,7 +3623,7 @@ WHERE
 		globalStats = false
 	}
 
-	err := sqlx.GetContext(ctx, ds.reader, &row, query, id, globalStats, aggregatedStatsTypeOSVersions)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &row, query, id, globalStats, aggregatedStatsTypeOSVersions)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("OSVersions"))
@@ -3712,7 +3712,7 @@ func (ds *Datastore) UpdateOSVersions(ctx context.Context) error {
 		ID         uint   `db:"id"`
 		TeamID     *uint  `db:"team_id"`
 	}
-	if err := sqlx.SelectContext(ctx, ds.reader, &rows, selectStmt); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, selectStmt); err != nil {
 		return ctxerr.Wrap(ctx, err, "update os versions")
 	}
 
@@ -3749,7 +3749,7 @@ func (ds *Datastore) UpdateOSVersions(ctx context.Context) error {
 
 	// if an existing team has no hosts assigned, we still want to store empty stats
 	var teamIDs []uint
-	if err := sqlx.SelectContext(ctx, ds.reader, &teamIDs, "SELECT id FROM teams"); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &teamIDs, "SELECT id FROM teams"); err != nil {
 		return ctxerr.Wrap(ctx, err, "update os versions")
 	}
 	for _, id := range teamIDs {
@@ -3787,7 +3787,7 @@ func (ds *Datastore) UpdateOSVersions(ctx context.Context) error {
 	insertStmt += strings.TrimSuffix(strings.Repeat("(?,?,?,?),", len(statsByTeamID)+1), ",") // +1 due to global stats
 	insertStmt += " ON DUPLICATE KEY UPDATE json_value = VALUES(json_value), updated_at = CURRENT_TIMESTAMP"
 
-	if _, err := ds.writer.ExecContext(ctx, insertStmt, args...); err != nil {
+	if _, err := ds.writer(ctx).ExecContext(ctx, insertStmt, args...); err != nil {
 		return ctxerr.Wrapf(ctx, err, "insert os versions into aggregated stats")
 	}
 
@@ -3799,7 +3799,7 @@ func (ds *Datastore) EnrolledHostIDs(ctx context.Context) ([]uint, error) {
 	const stmt = `SELECT id FROM hosts`
 
 	var ids []uint
-	if err := sqlx.SelectContext(ctx, ds.reader, &ids, stmt); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &ids, stmt); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get enrolled host IDs")
 	}
 	return ids, nil
@@ -3810,7 +3810,7 @@ func (ds *Datastore) CountEnrolledHosts(ctx context.Context) (int, error) {
 	const stmt = `SELECT count(*) FROM hosts`
 
 	var count int
-	if err := sqlx.SelectContext(ctx, ds.reader, &count, stmt); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &count, stmt); err != nil {
 		return 0, ctxerr.Wrap(ctx, err, "count enrolled host")
 	}
 	return count, nil
@@ -3837,7 +3837,7 @@ func (ds *Datastore) HostIDsByOSID(
 		return nil, ctxerr.Wrap(ctx, err, "get host IDs")
 	}
 
-	if err := sqlx.SelectContext(ctx, ds.reader, &ids, sql, args...); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &ids, sql, args...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get host IDs")
 	}
 
@@ -3867,7 +3867,7 @@ func (ds *Datastore) HostIDsByOSVersion(
 		return nil, ctxerr.Wrap(ctx, err, "get host IDs")
 	}
 
-	if err := sqlx.SelectContext(ctx, ds.reader, &ids, sql, args...); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &ids, sql, args...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get host IDs")
 	}
 
@@ -3894,7 +3894,7 @@ func (ds *Datastore) ListHostBatteries(ctx context.Context, hid uint) ([]*fleet.
 `
 
 	var batteries []*fleet.HostBattery
-	if err := sqlx.SelectContext(ctx, ds.reader, &batteries, stmt, hid); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &batteries, stmt, hid); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "select host batteries")
 	}
 	return batteries, nil
@@ -3907,7 +3907,7 @@ func (ds *Datastore) SetDiskEncryptionResetStatus(ctx context.Context, hostID ui
           ON DUPLICATE KEY UPDATE
             reset_requested = VALUES(reset_requested)`
 
-	_, err := ds.writer.ExecContext(ctx, stmt, hostID, status)
+	_, err := ds.writer(ctx).ExecContext(ctx, stmt, hostID, status)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "upsert disk encryption reset status")
 	}
@@ -3996,7 +3996,7 @@ func (ds *Datastore) GetMatchingHostSerials(ctx context.Context, serials []strin
 		return nil, ctxerr.Wrap(ctx, err, "building IN statement for matching hosts")
 	}
 	var matchingSerials []string
-	if err := sqlx.SelectContext(ctx, ds.reader, &matchingSerials, stmt, args...); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &matchingSerials, stmt, args...); err != nil {
 		return nil, err
 	}
 

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -2536,7 +2536,7 @@ func testHostsTotalAndUnseenSince(t *testing.T, ds *Datastore) {
 	assert.Equal(t, 2, unseen)
 
 	// host not counted as unseen if less than a full 24 hours has passed
-	_, err = ds.writer.ExecContext(context.Background(), `UPDATE host_seen_times SET seen_time = ? WHERE host_id = 2`, time.Now().Add(-1*time.Duration(1)*86399*time.Second))
+	_, err = ds.writer(context.Background()).ExecContext(context.Background(), `UPDATE host_seen_times SET seen_time = ? WHERE host_id = 2`, time.Now().Add(-1*time.Duration(1)*86399*time.Second))
 	require.NoError(t, err)
 
 	total, unseen, err = ds.TotalAndUnseenHostsSince(context.Background(), 1)
@@ -2545,7 +2545,7 @@ func testHostsTotalAndUnseenSince(t *testing.T, ds *Datastore) {
 	assert.Equal(t, 1, unseen)
 
 	// host counted as unseen if more than 24 hours has passed
-	_, err = ds.writer.ExecContext(context.Background(), `UPDATE host_seen_times SET seen_time = ? WHERE host_id = 2`, time.Now().Add(-1*time.Duration(1)*86401*time.Second))
+	_, err = ds.writer(context.Background()).ExecContext(context.Background(), `UPDATE host_seen_times SET seen_time = ? WHERE host_id = 2`, time.Now().Add(-1*time.Duration(1)*86401*time.Second))
 	require.NoError(t, err)
 
 	total, unseen, err = ds.TotalAndUnseenHostsSince(context.Background(), 1)
@@ -3076,7 +3076,7 @@ func printReadsInTest(test func(t *testing.T, ds *Datastore)) func(t *testing.T,
 }
 
 func getReads(t *testing.T, ds *Datastore) int {
-	rows, err := ds.writer.Query("show engine innodb status")
+	rows, err := ds.writer(context.Background()).Query("show engine innodb status")
 	require.NoError(t, err)
 	defer rows.Close()
 	r := 0
@@ -4212,7 +4212,7 @@ func testHostsNoSeenTime(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	removeHostSeenTimes := func(hostID uint) {
-		result, err := ds.writer.Exec("DELETE FROM host_seen_times WHERE host_id = ?", hostID)
+		result, err := ds.writer(context.Background()).Exec("DELETE FROM host_seen_times WHERE host_id = ?", hostID)
 		require.NoError(t, err)
 		rowsAffected, err := result.RowsAffected()
 		require.NoError(t, err)
@@ -4267,7 +4267,7 @@ func testHostsNoSeenTime(t *testing.T, ds *Datastore) {
 	assert.Equal(t, uint(1), summary.NewCount)
 
 	var count []int
-	err = ds.writer.Select(&count, "SELECT COUNT(*) FROM host_seen_times")
+	err = ds.writer(context.Background()).Select(&count, "SELECT COUNT(*) FROM host_seen_times")
 	require.NoError(t, err)
 	require.Len(t, count, 1)
 	require.Zero(t, count[0])
@@ -4277,7 +4277,7 @@ func testHostsNoSeenTime(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	var seenTime1 []time.Time
-	err = ds.writer.Select(&seenTime1, "SELECT seen_time FROM host_seen_times WHERE host_id = ?", h1.ID)
+	err = ds.writer(context.Background()).Select(&seenTime1, "SELECT seen_time FROM host_seen_times WHERE host_id = ?", h1.ID)
 	require.NoError(t, err)
 	require.Len(t, seenTime1, 1)
 	require.NotZero(t, seenTime1[0])
@@ -4289,7 +4289,7 @@ func testHostsNoSeenTime(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	var seenTime2 []time.Time
-	err = ds.writer.Select(&seenTime2, "SELECT seen_time FROM host_seen_times WHERE host_id = ?", h1.ID)
+	err = ds.writer(context.Background()).Select(&seenTime2, "SELECT seen_time FROM host_seen_times WHERE host_id = ?", h1.ID)
 	require.NoError(t, err)
 	require.Len(t, seenTime2, 1)
 	require.NotZero(t, seenTime2[0])
@@ -4396,14 +4396,14 @@ func testHostDeviceMapping(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// add device mapping for host
-	_, err = ds.writer.ExecContext(ctx, `INSERT INTO host_emails (host_id, email, source) VALUES (?, ?, ?)`,
+	_, err = ds.writer(ctx).ExecContext(ctx, `INSERT INTO host_emails (host_id, email, source) VALUES (?, ?, ?)`,
 		h.ID, "a@b.c", "src1")
 	require.NoError(t, err)
-	_, err = ds.writer.ExecContext(ctx, `INSERT INTO host_emails (host_id, email, source) VALUES (?, ?, ?)`,
+	_, err = ds.writer(ctx).ExecContext(ctx, `INSERT INTO host_emails (host_id, email, source) VALUES (?, ?, ?)`,
 		h.ID, "b@b.c", "src1")
 	require.NoError(t, err)
 
-	_, err = ds.writer.ExecContext(ctx, `INSERT INTO host_emails (host_id, email, source) VALUES (?, ?, ?)`,
+	_, err = ds.writer(ctx).ExecContext(ctx, `INSERT INTO host_emails (host_id, email, source) VALUES (?, ?, ?)`,
 		h.ID, "a@b.c", "src2")
 	require.NoError(t, err)
 
@@ -4440,7 +4440,7 @@ func testHostDeviceMapping(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// add device mapping for second host
-	_, err = ds.writer.ExecContext(ctx, `INSERT INTO host_emails (host_id, email, source) VALUES (?, ?, ?)`,
+	_, err = ds.writer(ctx).ExecContext(ctx, `INSERT INTO host_emails (host_id, email, source) VALUES (?, ?, ?)`,
 		h2.ID, "a@b.c", "src2")
 	require.NoError(t, err)
 
@@ -5741,7 +5741,7 @@ func testHostsDeleteHosts(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	// Insert a windows update for the host
 	stmt := `INSERT INTO windows_updates (host_id, date_epoch, kb_id) VALUES (?, ?, ?)`
-	_, err = ds.writer.Exec(stmt, host.ID, 1, 123)
+	_, err = ds.writer(context.Background()).Exec(stmt, host.ID, 1, 123)
 	require.NoError(t, err)
 	// set host' disk space
 	err = ds.SetOrUpdateHostDisksSpace(context.Background(), host.ID, 12, 25)
@@ -5761,28 +5761,28 @@ func testHostsDeleteHosts(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// Operating system vulnerabilities
-	_, err = ds.writer.Exec(
+	_, err = ds.writer(context.Background()).Exec(
 		`INSERT INTO operating_system_vulnerabilities(host_id,operating_system_id,cve) VALUES (?,?,?)`,
 		host.ID, 1, "cve-1",
 	)
 	require.NoError(t, err)
 
-	_, err = ds.writer.Exec(`INSERT INTO host_software_installed_paths (host_id, software_id, installed_path) VALUES (?, ?, ?)`, host.ID, 1, "some_path")
+	_, err = ds.writer(context.Background()).Exec(`INSERT INTO host_software_installed_paths (host_id, software_id, installed_path) VALUES (?, ?, ?)`, host.ID, 1, "some_path")
 	require.NoError(t, err)
 
-	_, err = ds.writer.Exec(`INSERT INTO host_dep_assignments (host_id) VALUES (?)`, host.ID)
+	_, err = ds.writer(context.Background()).Exec(`INSERT INTO host_dep_assignments (host_id) VALUES (?)`, host.ID)
 	require.NoError(t, err)
 
 	// Check there's an entry for the host in all the associated tables.
 	for _, hostRef := range hostRefs {
 		var ok bool
-		err = ds.writer.Get(&ok, fmt.Sprintf("SELECT 1 FROM %s WHERE host_id = ?", hostRef), host.ID)
+		err = ds.writer(context.Background()).Get(&ok, fmt.Sprintf("SELECT 1 FROM %s WHERE host_id = ?", hostRef), host.ID)
 		require.NoError(t, err, hostRef)
 		require.True(t, ok, "table: %s", hostRef)
 	}
 	for tbl, col := range additionalHostRefsByUUID {
 		var ok bool
-		err = ds.writer.Get(&ok, fmt.Sprintf("SELECT 1 FROM %s WHERE %s = ?", tbl, col), host.UUID)
+		err = ds.writer(context.Background()).Get(&ok, fmt.Sprintf("SELECT 1 FROM %s WHERE %s = ?", tbl, col), host.UUID)
 		require.NoError(t, err, tbl)
 		require.True(t, ok, "table: %s", tbl)
 	}
@@ -5793,13 +5793,13 @@ func testHostsDeleteHosts(t *testing.T, ds *Datastore) {
 	// Check that all the associated tables were cleaned up.
 	for _, hostRef := range hostRefs {
 		var ok bool
-		err = ds.writer.Get(&ok, fmt.Sprintf("SELECT 1 FROM %s WHERE host_id = ?", hostRef), host.ID)
+		err = ds.writer(context.Background()).Get(&ok, fmt.Sprintf("SELECT 1 FROM %s WHERE host_id = ?", hostRef), host.ID)
 		require.True(t, err == nil || errors.Is(err, sql.ErrNoRows), "table: %s", hostRef)
 		require.False(t, ok, "table: %s", hostRef)
 	}
 	for tbl, col := range additionalHostRefsByUUID {
 		var ok bool
-		err = ds.writer.Get(&ok, fmt.Sprintf("SELECT 1 FROM %s WHERE %s = ?", tbl, col), host.UUID)
+		err = ds.writer(context.Background()).Get(&ok, fmt.Sprintf("SELECT 1 FROM %s WHERE %s = ?", tbl, col), host.UUID)
 		require.True(t, err == nil || errors.Is(err, sql.ErrNoRows), "table: %s", tbl)
 		require.False(t, ok, "table: %s", tbl)
 	}
@@ -5960,7 +5960,7 @@ func testCountHostsNotResponding(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	count, err := countHostsNotRespondingDB(ctx, ds.writer, ds.logger, config)
+	count, err := countHostsNotRespondingDB(ctx, ds.writer(ctx), ds.logger, config)
 	require.NoError(t, err)
 	require.Equal(t, 0, count)
 
@@ -5979,7 +5979,7 @@ func testCountHostsNotResponding(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	count, err = countHostsNotRespondingDB(ctx, ds.writer, ds.logger, config)
+	count, err = countHostsNotRespondingDB(ctx, ds.writer(ctx), ds.logger, config)
 	require.NoError(t, err)
 	require.Equal(t, 1, count) // count increased by 1
 
@@ -5997,7 +5997,7 @@ func testCountHostsNotResponding(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	count, err = countHostsNotRespondingDB(ctx, ds.writer, ds.logger, config)
+	count, err = countHostsNotRespondingDB(ctx, ds.writer(ctx), ds.logger, config)
 	require.NoError(t, err)
 	require.Equal(t, 1, count) // count unchanged
 
@@ -6015,7 +6015,7 @@ func testCountHostsNotResponding(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	count, err = countHostsNotRespondingDB(ctx, ds.writer, ds.logger, config)
+	count, err = countHostsNotRespondingDB(ctx, ds.writer(ctx), ds.logger, config)
 	require.NoError(t, err)
 	require.Equal(t, 2, count) // count increased by 1
 
@@ -6033,7 +6033,7 @@ func testCountHostsNotResponding(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	count, err = countHostsNotRespondingDB(ctx, ds.writer, ds.logger, config)
+	count, err = countHostsNotRespondingDB(ctx, ds.writer(ctx), ds.logger, config)
 	require.NoError(t, err)
 	require.Equal(t, 2, count) // count unchanged
 
@@ -6052,7 +6052,7 @@ func testCountHostsNotResponding(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	count, err = countHostsNotRespondingDB(ctx, ds.writer, ds.logger, config)
+	count, err = countHostsNotRespondingDB(ctx, ds.writer(ctx), ds.logger, config)
 	require.NoError(t, err)
 	require.Equal(t, 2, count) // count unchanged
 }
@@ -6234,7 +6234,7 @@ func testHostOrder(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	chk(hosts, "0001", "0003", "0004")
 
-	_, err = ds.writer.Exec(`UPDATE hosts SET created_at = DATE_ADD(created_at, INTERVAL id DAY)`)
+	_, err = ds.writer(ctx).Exec(`UPDATE hosts SET created_at = DATE_ADD(created_at, INTERVAL id DAY)`)
 	require.NoError(t, err)
 
 	hosts, err = ds.ListHosts(ctx, fleet.TeamFilter{User: test.UserAdmin}, fleet.HostListOptions{

--- a/server/datastore/mysql/invites.go
+++ b/server/datastore/mysql/invites.go
@@ -69,7 +69,7 @@ func (ds *Datastore) ListInvites(ctx context.Context, opt fleet.ListOptions) ([]
 	query, params := searchLike(query, nil, opt.MatchQuery, inviteSearchColumns...)
 	query = appendListOptionsToSQL(query, &opt)
 
-	err := sqlx.SelectContext(ctx, ds.reader, &invites, query, params...)
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &invites, query, params...)
 	if err == sql.ErrNoRows {
 		return nil, ctxerr.Wrap(ctx, notFound("Invite"))
 	} else if err != nil {
@@ -86,7 +86,7 @@ func (ds *Datastore) ListInvites(ctx context.Context, opt fleet.ListOptions) ([]
 // Invite returns Invite identified by id.
 func (ds *Datastore) Invite(ctx context.Context, id uint) (*fleet.Invite, error) {
 	var invite fleet.Invite
-	err := sqlx.GetContext(ctx, ds.reader, &invite, "SELECT * FROM invites WHERE id = ?", id)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &invite, "SELECT * FROM invites WHERE id = ?", id)
 	if err == sql.ErrNoRows {
 		return nil, ctxerr.Wrap(ctx, notFound("Invite").WithID(id))
 	} else if err != nil {
@@ -103,7 +103,7 @@ func (ds *Datastore) Invite(ctx context.Context, id uint) (*fleet.Invite, error)
 // InviteByEmail finds an Invite with a particular email, if one exists.
 func (ds *Datastore) InviteByEmail(ctx context.Context, email string) (*fleet.Invite, error) {
 	var invite fleet.Invite
-	err := sqlx.GetContext(ctx, ds.reader, &invite, "SELECT * FROM invites WHERE email = ?", email)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &invite, "SELECT * FROM invites WHERE email = ?", email)
 	if err == sql.ErrNoRows {
 		return nil, ctxerr.Wrap(ctx, notFound("Invite").
 			WithMessage(fmt.Sprintf("with email %s", email)))
@@ -121,7 +121,7 @@ func (ds *Datastore) InviteByEmail(ctx context.Context, email string) (*fleet.In
 // InviteByToken finds an Invite with a particular token, if one exists.
 func (ds *Datastore) InviteByToken(ctx context.Context, token string) (*fleet.Invite, error) {
 	var invite fleet.Invite
-	err := sqlx.GetContext(ctx, ds.reader, &invite, "SELECT * FROM invites WHERE token = ?", token)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &invite, "SELECT * FROM invites WHERE token = ?", token)
 	if err == sql.ErrNoRows {
 		return nil, ctxerr.Wrap(ctx, notFound("Invite").
 			WithMessage(fmt.Sprintf("with token %s", token)))
@@ -169,7 +169,7 @@ func (ds *Datastore) loadTeamsForInvites(ctx context.Context, invites []*fleet.I
 		fleet.UserTeam
 		InviteID uint `db:"invite_id"`
 	}
-	if err := sqlx.SelectContext(ctx, ds.reader, &rows, sql, args...); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, sql, args...); err != nil {
 		return ctxerr.Wrap(ctx, err, "get loadTeamsForInvites")
 	}
 

--- a/server/datastore/mysql/jobs.go
+++ b/server/datastore/mysql/jobs.go
@@ -24,7 +24,7 @@ VALUES (?, ?, ?, ?, ?, COALESCE(?, NOW()))
 	if !job.NotBefore.IsZero() {
 		notBefore = &job.NotBefore
 	}
-	result, err := ds.writer.ExecContext(ctx, query, job.Name, job.Args, job.State, job.Retries, job.Error, notBefore)
+	result, err := ds.writer(ctx).ExecContext(ctx, query, job.Name, job.Args, job.State, job.Retries, job.Error, notBefore)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ LIMIT ?
 `
 
 	var jobs []*fleet.Job
-	err := sqlx.SelectContext(ctx, ds.reader, &jobs, query, fleet.JobStateQueued, maxNumJobs)
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &jobs, query, fleet.JobStateQueued, maxNumJobs)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ WHERE
 	if !job.NotBefore.IsZero() {
 		notBefore = &job.NotBefore
 	}
-	_, err := ds.writer.ExecContext(ctx, query, job.State, job.Retries, job.Error, notBefore, id)
+	_, err := ds.writer(ctx).ExecContext(ctx, query, job.State, job.Retries, job.Error, notBefore, id)
 	if err != nil {
 		return nil, err
 	}

--- a/server/datastore/mysql/migrations_test.go
+++ b/server/datastore/mysql/migrations_test.go
@@ -40,12 +40,12 @@ func TestMigrationStatus(t *testing.T) {
 	assert.Empty(t, status.MissingData)
 
 	// Insert unknown migration.
-	_, err = ds.writer.Exec(`INSERT INTO ` + tables.MigrationClient.TableName + ` (version_id, is_applied) VALUES (1638994765, 1)`)
+	_, err = ds.writer(context.Background()).Exec(`INSERT INTO ` + tables.MigrationClient.TableName + ` (version_id, is_applied) VALUES (1638994765, 1)`)
 	require.NoError(t, err)
 	status, err = ds.MigrationStatus(context.Background())
 	require.NoError(t, err)
 	assert.EqualValues(t, fleet.UnknownMigrations, status.StatusCode)
-	_, err = ds.writer.Exec(`DELETE FROM ` + tables.MigrationClient.TableName + ` WHERE version_id = 1638994765`)
+	_, err = ds.writer(context.Background()).Exec(`DELETE FROM ` + tables.MigrationClient.TableName + ` WHERE version_id = 1638994765`)
 	require.NoError(t, err)
 
 	status, err = ds.MigrationStatus(context.Background())

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -22,6 +22,7 @@ import (
 	"github.com/doug-martin/goqu/v9"
 	"github.com/doug-martin/goqu/v9/exp"
 	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/migrations/data"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/migrations/tables"
@@ -60,8 +61,8 @@ type dbReader interface {
 // Datastore is an implementation of fleet.Datastore interface backed by
 // MySQL
 type Datastore struct {
-	reader dbReader // so it cannot be used to perform writes
-	writer *sqlx.DB
+	replica dbReader // so it cannot be used to perform writes
+	primary *sqlx.DB
 
 	logger log.Logger
 	clock  clock.Clock
@@ -82,18 +83,39 @@ type Datastore struct {
 	stmtCache map[string]*sqlx.Stmt
 }
 
+// reader returns the DB instance to use for read-only statements, which is the
+// replica unless the primary has been explicitly required via
+// ctxdb.RequirePrimary.
+func (ds *Datastore) reader(ctx context.Context) dbReader {
+	if ctxdb.IsPrimaryRequired(ctx) {
+		return ds.primary
+	}
+	return ds.replica
+}
+
+// writer returns the DB instance to use for write statements, which is always
+// the primary.
+func (ds *Datastore) writer(ctx context.Context) *sqlx.DB {
+	return ds.primary
+}
+
 // loadOrPrepareStmt will load a statement from the statements cache.
 // If not available, it will attempt to prepare (create) it.
 //
 // Returns nil if it failed to prepare a statement.
 func (ds *Datastore) loadOrPrepareStmt(ctx context.Context, query string) *sqlx.Stmt {
+	// the cache is only available on the replica
+	if ctxdb.IsPrimaryRequired(ctx) {
+		return nil
+	}
+
 	ds.stmtCacheMu.Lock()
 	defer ds.stmtCacheMu.Unlock()
 
 	stmt, ok := ds.stmtCache[query]
 	if !ok {
 		var err error
-		stmt, err = sqlx.PreparexContext(ctx, ds.reader, query)
+		stmt, err = sqlx.PreparexContext(ctx, ds.replica, query)
 		if err != nil {
 			level.Error(ds.logger).Log(
 				"msg", "failed to prepare statement",
@@ -110,13 +132,13 @@ func (ds *Datastore) loadOrPrepareStmt(ctx context.Context, query string) *sqlx.
 // NewMDMAppleSCEPDepot returns a scep_depot.Depot that uses the Datastore
 // underlying MySQL writer *sql.DB.
 func (ds *Datastore) NewSCEPDepot(caCertPEM []byte, caKeyPEM []byte) (scep_depot.Depot, error) {
-	return newSCEPDepot(ds.writer.DB, caCertPEM, caKeyPEM)
+	return newSCEPDepot(ds.primary.DB, caCertPEM, caKeyPEM)
 }
 
 // NewMDMAppleMDMStorage returns a MySQL nanomdm storage that uses the Datastore
 // underlying MySQL writer *sql.DB.
 func (ds *Datastore) NewMDMAppleMDMStorage(pushCertPEM []byte, pushKeyPEM []byte) (*NanoMDMStorage, error) {
-	s, err := nanomdm_mysql.New(nanomdm_mysql.WithDB(ds.writer.DB))
+	s, err := nanomdm_mysql.New(nanomdm_mysql.WithDB(ds.primary.DB))
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +192,7 @@ func (s *NanoMDMStorage) StorePushCert(ctx context.Context, pemCert, pemKey []by
 // NewMDMAppleDEPStorage returns a MySQL nanodep storage that uses the Datastore
 // underlying MySQL writer *sql.DB.
 func (ds *Datastore) NewMDMAppleDEPStorage(tok nanodep_client.OAuth1Tokens) (*NanoDEPStorage, error) {
-	s, err := nanodep_mysql.New(nanodep_mysql.WithDB(ds.writer.DB))
+	s, err := nanodep_mysql.New(nanodep_mysql.WithDB(ds.primary.DB))
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +265,7 @@ func retryableError(err error) bool {
 // withRetryTxx provides a common way to commit/rollback a txFn wrapped in a retry with exponential backoff
 func (ds *Datastore) withRetryTxx(ctx context.Context, fn txFn) (err error) {
 	operation := func() error {
-		tx, err := ds.writer.BeginTxx(ctx, nil)
+		tx, err := ds.writer(ctx).BeginTxx(ctx, nil)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "create transaction")
 		}
@@ -292,7 +314,7 @@ func (ds *Datastore) withRetryTxx(ctx context.Context, fn txFn) (err error) {
 
 // withTx provides a common way to commit/rollback a txFn
 func (ds *Datastore) withTx(ctx context.Context, fn txFn) (err error) {
-	tx, err := ds.writer.BeginTxx(ctx, nil)
+	tx, err := ds.writer(ctx).BeginTxx(ctx, nil)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "create transaction")
 	}
@@ -359,8 +381,8 @@ func New(config config.MysqlConfig, c clock.Clock, opts ...DBOption) (*Datastore
 	}
 
 	ds := &Datastore{
-		writer:              dbWriter,
-		reader:              dbReader,
+		primary:             dbWriter,
+		replica:             dbReader,
 		logger:              options.logger,
 		clock:               c,
 		config:              config,
@@ -394,7 +416,7 @@ func (ds *Datastore) writeChanLoop() {
 			item.errCh <- ds.UpdateHost(item.ctx, actualItem)
 		case hostXUpdatedAt:
 			query := fmt.Sprintf(`UPDATE hosts SET %s = ? WHERE id=?`, actualItem.what)
-			_, err := ds.writer.ExecContext(item.ctx, query, actualItem.updatedAt, actualItem.hostID)
+			_, err := ds.writer(item.ctx).ExecContext(item.ctx, query, actualItem.updatedAt, actualItem.hostID)
 			item.errCh <- ctxerr.Wrap(item.ctx, err, "updating hosts label updated at")
 		}
 	}
@@ -483,11 +505,11 @@ func checkConfig(conf *config.MysqlConfig) error {
 }
 
 func (ds *Datastore) MigrateTables(ctx context.Context) error {
-	return tables.MigrationClient.Up(ds.writer.DB, "")
+	return tables.MigrationClient.Up(ds.writer(ctx).DB, "")
 }
 
 func (ds *Datastore) MigrateData(ctx context.Context) error {
-	return data.MigrationClient.Up(ds.writer.DB, "")
+	return data.MigrationClient.Up(ds.writer(ctx).DB, "")
 }
 
 // loadMigrations manually loads the applied migrations in ascending
@@ -530,7 +552,7 @@ func (ds *Datastore) MigrationStatus(ctx context.Context) (*fleet.MigrationStatu
 	if tables.MigrationClient.Migrations == nil || data.MigrationClient.Migrations == nil {
 		return nil, errors.New("unexpected nil migrations list")
 	}
-	appliedTable, appliedData, err := ds.loadMigrations(ctx, ds.writer.DB, ds.reader)
+	appliedTable, appliedData, err := ds.loadMigrations(ctx, ds.primary.DB, ds.replica)
 	if err != nil {
 		return nil, fmt.Errorf("cannot load migrations: %w", err)
 	}
@@ -662,12 +684,12 @@ func (ds *Datastore) HealthCheck() error {
 	// NOTE: does not receive a context as argument here, because the HealthCheck
 	// interface potentially affects more than the datastore layer, and I'm not
 	// sure we can safely identify and change them all at this moment.
-	if _, err := ds.writer.ExecContext(context.Background(), "select 1"); err != nil {
+	if _, err := ds.primary.ExecContext(context.Background(), "select 1"); err != nil {
 		return err
 	}
 	if ds.readReplicaConfig != nil {
 		var dst int
-		if err := sqlx.GetContext(context.Background(), ds.reader, &dst, "select 1"); err != nil {
+		if err := sqlx.GetContext(context.Background(), ds.replica, &dst, "select 1"); err != nil {
 			return err
 		}
 	}
@@ -694,11 +716,11 @@ func (ds *Datastore) Close() error {
 	if errStmt := ds.closeStmts(); errStmt != nil {
 		err = multierror.Append(err, errStmt)
 	}
-	if errWriter := ds.writer.Close(); errWriter != nil {
+	if errWriter := ds.primary.Close(); errWriter != nil {
 		err = multierror.Append(err, errWriter)
 	}
 	if ds.readReplicaConfig != nil {
-		if errRead := ds.reader.Close(); errRead != nil {
+		if errRead := ds.replica.Close(); errRead != nil {
 			err = multierror.Append(err, errRead)
 		}
 	}
@@ -1130,7 +1152,7 @@ func (ds *Datastore) InnoDBStatus(ctx context.Context) (string, error) {
 		Status string `db:"Status"`
 	}{}
 	// using the writer even when doing a read to get the data from the main db node
-	err := ds.writer.GetContext(ctx, &status, "show engine innodb status")
+	err := ds.writer(ctx).GetContext(ctx, &status, "show engine innodb status")
 	if err != nil {
 		return "", ctxerr.Wrap(ctx, err, "Getting innodb status")
 	}
@@ -1140,7 +1162,7 @@ func (ds *Datastore) InnoDBStatus(ctx context.Context) (string, error) {
 func (ds *Datastore) ProcessList(ctx context.Context) ([]fleet.MySQLProcess, error) {
 	var processList []fleet.MySQLProcess
 	// using the writer even when doing a read to get the data from the main db node
-	err := ds.writer.SelectContext(ctx, &processList, "show processlist")
+	err := ds.writer(ctx).SelectContext(ctx, &processList, "show processlist")
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "Getting process list")
 	}
@@ -1214,16 +1236,16 @@ func (ds *Datastore) optimisticGetOrInsert(ctx context.Context, readStmt, insert
 	}
 
 	// 1. read from the read replica, as it is likely to already exist
-	id, err = readID(ds.reader)
+	id, err = readID(ds.reader(ctx))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			// this does not exist yet, try to insert it
-			res, err := ds.writer.ExecContext(ctx, insertStmt.Statement, insertStmt.Args...)
+			res, err := ds.writer(ctx).ExecContext(ctx, insertStmt.Statement, insertStmt.Args...)
 			if err != nil {
 				if isDuplicate(err) {
 					// it might've been created between the select and the insert, read
 					// again this time from the primary database connection.
-					id, err := readID(ds.writer)
+					id, err := readID(ds.writer(ctx))
 					if err != nil {
 						return 0, ctxerr.Wrap(ctx, err, "get id from writer")
 					}

--- a/server/datastore/mysql/mysql_test.go
+++ b/server/datastore/mysql/mysql_test.go
@@ -74,13 +74,18 @@ func TestDatastoreReplica(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, host.ID, got.ID)
 
+		// but from replica still fails
+		ctx = ctxdb.RequirePrimary(ctx, false)
+		_, err = ds.Host(ctx, host.ID)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, sql.ErrNoRows))
+
 		opts.RunReplication()
 
 		// now it can read it from replica
-		ctx = ctxdb.RequirePrimary(ctx, false)
-		host2, err := ds.Host(ctx, host.ID)
+		got, err = ds.Host(ctx, host.ID)
 		require.NoError(t, err)
-		require.Equal(t, host.ID, host2.ID)
+		require.Equal(t, host.ID, got.ID)
 	})
 }
 

--- a/server/datastore/mysql/operating_system_vulnerabilities.go
+++ b/server/datastore/mysql/operating_system_vulnerabilities.go
@@ -28,7 +28,7 @@ func (ds *Datastore) ListOSVulnerabilities(ctx context.Context, hostIDs []uint) 
 		return nil, ctxerr.Wrap(ctx, err, "error generating SQL statement")
 	}
 
-	if err := sqlx.SelectContext(ctx, ds.reader, &r, sql, args...); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &r, sql, args...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "error executing SQL statement")
 	}
 
@@ -48,7 +48,7 @@ func (ds *Datastore) InsertOSVulnerabilities(ctx context.Context, vulnerabilitie
 	for _, v := range vulnerabilities {
 		args = append(args, v.HostID, v.OSID, v.CVE, source)
 	}
-	res, err := ds.writer.ExecContext(ctx, sql, args...)
+	res, err := ds.writer(ctx).ExecContext(ctx, sql, args...)
 	if err != nil {
 		return 0, ctxerr.Wrap(ctx, err, "insert operating system vulnerabilities")
 	}
@@ -71,7 +71,7 @@ func (ds *Datastore) DeleteOSVulnerabilities(ctx context.Context, vulnerabilitie
 	for _, v := range vulnerabilities {
 		args = append(args, v.HostID, v.CVE)
 	}
-	if _, err := ds.writer.ExecContext(ctx, sql, args...); err != nil {
+	if _, err := ds.writer(ctx).ExecContext(ctx, sql, args...); err != nil {
 		return ctxerr.Wrapf(ctx, err, "deleting operating system vulnerabilities")
 	}
 	return nil

--- a/server/datastore/mysql/operating_system_vulnerabilities_test.go
+++ b/server/datastore/mysql/operating_system_vulnerabilities_test.go
@@ -46,7 +46,7 @@ func testListOSVulnerabilities(t *testing.T, ds *Datastore) {
 	}
 
 	for _, v := range vulns {
-		_, err := ds.writer.Exec(
+		_, err := ds.writer(ctx).Exec(
 			`INSERT INTO operating_system_vulnerabilities(host_id,operating_system_id,cve) VALUES (?,?,?)`,
 			v.HostID, v.OSID, v.CVE,
 		)

--- a/server/datastore/mysql/operating_systems.go
+++ b/server/datastore/mysql/operating_systems.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (ds *Datastore) ListOperatingSystems(ctx context.Context) ([]fleet.OperatingSystem, error) {
-	return listOperatingSystemsDB(ctx, ds.reader)
+	return listOperatingSystemsDB(ctx, ds.reader(ctx))
 }
 
 func listOperatingSystemsDB(ctx context.Context, tx sqlx.QueryerContext) ([]fleet.OperatingSystem, error) {
@@ -134,7 +134,7 @@ func (ds *Datastore) CleanupHostOperatingSystems(ctx context.Context) error {
 	LEFT JOIN host_operating_system hop ON op.id = hop.os_id
 	WHERE hop.os_id IS NULL
 	`
-	if _, err := ds.writer.ExecContext(ctx, stmt); err != nil {
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt); err != nil {
 		return ctxerr.Wrap(ctx, err, "clean up host operating systems")
 	}
 

--- a/server/datastore/mysql/operating_systems_test.go
+++ b/server/datastore/mysql/operating_systems_test.go
@@ -55,7 +55,7 @@ func TestUpdateHostOperatingSystem(t *testing.T) {
 	list, err := ds.ListOperatingSystems(ctx)
 	require.NoError(t, err)
 	require.Len(t, list, 0)
-	_, err = getHostOperatingSystemDB(ctx, ds.writer, testHostID)
+	_, err = getHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID)
 	require.ErrorIs(t, err, sql.ErrNoRows)
 
 	// insert new os record and host operating system record
@@ -65,7 +65,7 @@ func TestUpdateHostOperatingSystem(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, list, 1)
 	require.Equal(t, true, isSameOS(t, testOS, list[0]))
-	storedOS, err := getHostOperatingSystemDB(ctx, ds.writer, testHostID)
+	storedOS, err := getHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID)
 	require.NoError(t, err)
 	require.Equal(t, true, isSameOS(t, testOS, *storedOS))
 
@@ -77,7 +77,7 @@ func TestUpdateHostOperatingSystem(t *testing.T) {
 	list, err = ds.ListOperatingSystems(ctx)
 	require.NoError(t, err)
 	require.Len(t, list, 2)
-	storedOS, err = getHostOperatingSystemDB(ctx, ds.writer, testHostID)
+	storedOS, err = getHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID)
 	require.NoError(t, err)
 	require.Equal(t, true, isSameOS(t, testNewVersion, *storedOS))
 
@@ -88,7 +88,7 @@ func TestUpdateHostOperatingSystem(t *testing.T) {
 	list, err = ds.ListOperatingSystems(ctx)
 	require.NoError(t, err)
 	require.Len(t, list, 2)
-	storedOS, err = getHostOperatingSystemDB(ctx, ds.writer, testNewHostID)
+	storedOS, err = getHostOperatingSystemDB(ctx, ds.writer(ctx), testNewHostID)
 	require.NoError(t, err)
 	require.Equal(t, true, isSameOS(t, testOS, *storedOS))
 
@@ -98,7 +98,7 @@ func TestUpdateHostOperatingSystem(t *testing.T) {
 	list, err = ds.ListOperatingSystems(ctx)
 	require.NoError(t, err)
 	require.Len(t, list, 2)
-	storedOS, err = getHostOperatingSystemDB(ctx, ds.writer, testNewHostID)
+	storedOS, err = getHostOperatingSystemDB(ctx, ds.writer(ctx), testNewHostID)
 	require.NoError(t, err)
 	require.Equal(t, true, isSameOS(t, testOS, *storedOS))
 }
@@ -153,7 +153,7 @@ func TestMaybeNewOperatingSystem(t *testing.T) {
 	}
 
 	// new os, returns a newly inserted record
-	result1, err := getOrGenerateOperatingSystemDB(ctx, ds.writer, testOS)
+	result1, err := getOrGenerateOperatingSystemDB(ctx, ds.writer(ctx), testOS)
 	require.NoError(t, err)
 	require.True(t, isSameOS(t, testOS, *result1))
 	require.NotContains(t, osByID, result1.ID)
@@ -170,7 +170,7 @@ func TestMaybeNewOperatingSystem(t *testing.T) {
 	require.True(t, isSameOS(t, osByID[result1.ID], testOS))
 
 	// no change, returns the existing record
-	result2, err := getOrGenerateOperatingSystemDB(ctx, ds.writer, testOS)
+	result2, err := getOrGenerateOperatingSystemDB(ctx, ds.writer(ctx), testOS)
 	require.NoError(t, err)
 	require.True(t, isSameOS(t, *result1, *result2))
 
@@ -188,7 +188,7 @@ func TestMaybeNewOperatingSystem(t *testing.T) {
 	// new version, returns new record
 	testNewVersion := testOS
 	testNewVersion.Version = "22.04 LTS"
-	result3, err := getOrGenerateOperatingSystemDB(ctx, ds.writer, testNewVersion)
+	result3, err := getOrGenerateOperatingSystemDB(ctx, ds.writer(ctx), testNewVersion)
 	require.NoError(t, err)
 	require.True(t, isSameOS(t, testNewVersion, *result3))
 
@@ -217,27 +217,27 @@ func TestMaybeUpdateHostOperatingSystem(t *testing.T) {
 	testHostID := uint(42)
 
 	// no record exists for test host
-	_, err = getIDHostOperatingSystemDB(ctx, ds.writer, testHostID)
+	_, err = getIDHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID)
 	require.ErrorIs(t, err, sql.ErrNoRows)
 
 	// insert test host and os id
-	err = upsertHostOperatingSystemDB(ctx, ds.writer, testHostID, osList[0].ID)
+	err = upsertHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID, osList[0].ID)
 	require.NoError(t, err)
-	osID, err := getIDHostOperatingSystemDB(ctx, ds.writer, testHostID)
+	osID, err := getIDHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID)
 	require.NoError(t, err)
 	require.Equal(t, osList[0].ID, osID)
 
 	// update test host with new os id
-	err = upsertHostOperatingSystemDB(ctx, ds.writer, testHostID, osList[1].ID)
+	err = upsertHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID, osList[1].ID)
 	require.NoError(t, err)
-	osID, err = getIDHostOperatingSystemDB(ctx, ds.writer, testHostID)
+	osID, err = getIDHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID)
 	require.NoError(t, err)
 	require.Equal(t, osList[1].ID, osID)
 
 	// no change
-	err = upsertHostOperatingSystemDB(ctx, ds.writer, testHostID, osList[1].ID)
+	err = upsertHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID, osList[1].ID)
 	require.NoError(t, err)
-	osID, err = getIDHostOperatingSystemDB(ctx, ds.writer, testHostID)
+	osID, err = getIDHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID)
 	require.NoError(t, err)
 	require.Equal(t, osList[1].ID, osID)
 }
@@ -253,27 +253,27 @@ func TestGetHostOperatingSystem(t *testing.T) {
 	testHostID := uint(42)
 
 	// no record exists for test host
-	_, err = getHostOperatingSystemDB(ctx, ds.writer, testHostID)
+	_, err = getHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID)
 	require.ErrorIs(t, err, sql.ErrNoRows)
 
 	// insert test host and os id
-	err = upsertHostOperatingSystemDB(ctx, ds.writer, testHostID, osList[0].ID)
+	err = upsertHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID, osList[0].ID)
 	require.NoError(t, err)
-	os, err := getHostOperatingSystemDB(ctx, ds.writer, testHostID)
+	os, err := getHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID)
 	require.NoError(t, err)
 	require.Equal(t, osList[0], *os)
 
 	// update test host with new os id
-	err = upsertHostOperatingSystemDB(ctx, ds.writer, testHostID, osList[1].ID)
+	err = upsertHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID, osList[1].ID)
 	require.NoError(t, err)
-	os, err = getHostOperatingSystemDB(ctx, ds.writer, testHostID)
+	os, err = getHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID)
 	require.NoError(t, err)
 	require.Equal(t, osList[1], *os)
 
 	// no change
-	err = upsertHostOperatingSystemDB(ctx, ds.writer, testHostID, osList[1].ID)
+	err = upsertHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID, osList[1].ID)
 	require.NoError(t, err)
-	os, err = getHostOperatingSystemDB(ctx, ds.writer, testHostID)
+	os, err = getHostOperatingSystemDB(ctx, ds.writer(ctx), testHostID)
 	require.NoError(t, err)
 	require.Equal(t, osList[1], *os)
 }
@@ -305,14 +305,14 @@ func TestCleanupHostOperatingSystems(t *testing.T) {
 
 		// insert host operating system record so initially each os is seeded with two hosts
 		hostOS := testOSs[i%len(testOSs)]
-		err = upsertHostOperatingSystemDB(ctx, ds.writer, h.ID, hostOS.ID)
+		err = upsertHostOperatingSystemDB(ctx, ds.writer(ctx), h.ID, hostOS.ID)
 		require.NoError(t, err)
 		osByHostID[h.ID] = hostOS
 	}
 
 	assertDeletedHostOS := func(expectDeletedIDs []uint) {
 		for _, h := range testHosts {
-			os, err := getHostOperatingSystemDB(ctx, ds.writer, h.ID)
+			os, err := getHostOperatingSystemDB(ctx, ds.writer(ctx), h.ID)
 			if err == sql.ErrNoRows {
 				require.Contains(t, expectDeletedIDs, h.ID)
 				return
@@ -417,7 +417,7 @@ func seedOperatingSystems(t *testing.T, ds *Datastore) map[uint]fleet.OperatingS
 	}
 	storedById := make(map[uint]fleet.OperatingSystem)
 	for _, os := range osSeeds {
-		stored, err := newOperatingSystemDB(context.Background(), ds.writer, os)
+		stored, err := newOperatingSystemDB(context.Background(), ds.writer(context.Background()), os)
 		require.NoError(t, err)
 		require.True(t, isSameOS(t, os, *stored))
 		storedById[stored.ID] = *stored

--- a/server/datastore/mysql/packs.go
+++ b/server/datastore/mysql/packs.go
@@ -232,7 +232,7 @@ func (ds *Datastore) PackByName(ctx context.Context, name string, opts ...fleet.
 			WHERE name = ?
 	`
 	var pack fleet.Pack
-	err := sqlx.GetContext(ctx, ds.reader, &pack, sqlStatement, name)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &pack, sqlStatement, name)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, false, nil
@@ -240,7 +240,7 @@ func (ds *Datastore) PackByName(ctx context.Context, name string, opts ...fleet.
 		return nil, false, ctxerr.Wrap(ctx, err, "fetch pack by name")
 	}
 
-	if err := loadPackTargetsDB(ctx, ds.reader, &pack); err != nil {
+	if err := loadPackTargetsDB(ctx, ds.reader(ctx), &pack); err != nil {
 		return nil, false, err
 	}
 
@@ -413,7 +413,7 @@ func (ds *Datastore) DeletePack(ctx context.Context, name string) error {
 
 // Pack fetch fleet.Pack with matching ID
 func (ds *Datastore) Pack(ctx context.Context, pid uint) (*fleet.Pack, error) {
-	return packDB(ctx, ds.reader, pid)
+	return packDB(ctx, ds.reader(ctx), pid)
 }
 
 func packDB(ctx context.Context, q sqlx.QueryerContext, pid uint) (*fleet.Pack, error) {
@@ -550,13 +550,13 @@ func (ds *Datastore) ListPacks(ctx context.Context, opt fleet.PackListOptions) (
 		query = `SELECT * FROM packs`
 	}
 	var packs []*fleet.Pack
-	err := sqlx.SelectContext(ctx, ds.reader, &packs, appendListOptionsToSQL(query, &opt.ListOptions))
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &packs, appendListOptionsToSQL(query, &opt.ListOptions))
 	if err != nil && err != sql.ErrNoRows {
 		return nil, ctxerr.Wrap(ctx, err, "listing packs")
 	}
 
 	for _, pack := range packs {
-		if err := loadPackTargetsDB(ctx, ds.reader, pack); err != nil {
+		if err := loadPackTargetsDB(ctx, ds.reader(ctx), pack); err != nil {
 			return nil, err
 		}
 	}
@@ -565,7 +565,7 @@ func (ds *Datastore) ListPacks(ctx context.Context, opt fleet.PackListOptions) (
 }
 
 func (ds *Datastore) ListPacksForHost(ctx context.Context, hid uint) ([]*fleet.Pack, error) {
-	return listPacksForHost(ctx, ds.reader, hid)
+	return listPacksForHost(ctx, ds.reader(ctx), hid)
 }
 
 // listPacksForHost returns all the packs that are configured to run on the given host.

--- a/server/datastore/mysql/packs_test.go
+++ b/server/datastore/mysql/packs_test.go
@@ -521,7 +521,7 @@ func testPacksTeamScheduleNamesMigrateToNewFormat(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// insert team pack by hand with the old naming scheme
-	_, err = ds.writer.Exec(
+	_, err = ds.writer(context.Background()).Exec(
 		"INSERT INTO packs(name, description, platform, disabled, pack_type) VALUES (?, ?, ?, ?, ?)",
 		teamSchedulePackType(team1), "desc", "windows", false, teamSchedulePackType(team1),
 	)
@@ -621,7 +621,7 @@ func testPacksApplyStatsNotLocking(t *testing.T, ds *Datastore) {
 				require.NoError(t, err)
 
 				amount := rand.Intn(5000)
-				require.NoError(t, saveHostPackStatsDB(context.Background(), ds.writer, host.ID, randomPackStatsForHost(pack.ID, pack.Name, *pack.Type, schedQueries, amount)))
+				require.NoError(t, saveHostPackStatsDB(context.Background(), ds.writer(context.Background()), host.ID, randomPackStatsForHost(pack.ID, pack.Name, *pack.Type, schedQueries, amount)))
 			}
 		}
 	}()
@@ -673,7 +673,7 @@ func testPacksApplyStatsNotLockingTryTwo(t *testing.T, ds *Datastore) {
 					require.NoError(t, err)
 
 					amount := rand.Intn(5000)
-					require.NoError(t, saveHostPackStatsDB(context.Background(), ds.writer, host.ID, randomPackStatsForHost(pack.ID, pack.Name, *pack.Type, schedQueries, amount)))
+					require.NoError(t, saveHostPackStatsDB(context.Background(), ds.writer(context.Background()), host.ID, randomPackStatsForHost(pack.ID, pack.Name, *pack.Type, schedQueries, amount)))
 				}
 			}
 		}()

--- a/server/datastore/mysql/password_reset_test.go
+++ b/server/datastore/mysql/password_reset_test.go
@@ -91,7 +91,7 @@ func testPasswordResetTokenExpiration(t *testing.T, ds *Datastore) {
 
 		stmt := `INSERT INTO password_reset_requests ( user_id, token, expires_at)
 			VALUES (?,?, ?)`
-		res, err := ds.writer.ExecContext(ctx, stmt, req.UserID, req.Token, req.ExpiresAt)
+		res, err := ds.writer(ctx).ExecContext(ctx, stmt, req.UserID, req.Token, req.ExpiresAt)
 		require.NoError(t, err)
 
 		id, _ := res.LastInsertId()
@@ -118,15 +118,15 @@ func testCleanupExpiredPasswordResetRequests(t *testing.T, ds *Datastore) {
 	stmt := `INSERT INTO password_reset_requests ( user_id, token, expires_at)
 			VALUES (?,?, DATE_ADD(CURRENT_TIMESTAMP, INTERVAL ? HOUR))`
 
-	_, err := ds.writer.ExecContext(ctx, stmt, uint(1), "now", 0)
+	_, err := ds.writer(ctx).ExecContext(ctx, stmt, uint(1), "now", 0)
 	require.NoError(t, err)
-	_, err = ds.writer.ExecContext(ctx, stmt, uint(1), "tomorrow", 24)
+	_, err = ds.writer(ctx).ExecContext(ctx, stmt, uint(1), "tomorrow", 24)
 	require.NoError(t, err)
-	_, err = ds.writer.ExecContext(ctx, stmt, uint(1), "yesterday", -24)
+	_, err = ds.writer(ctx).ExecContext(ctx, stmt, uint(1), "yesterday", -24)
 	require.NoError(t, err)
 
 	var res1 []fleet.PasswordResetRequest
-	err = ds.writer.SelectContext(ctx, &res1, `SELECT * FROM password_reset_requests`)
+	err = ds.writer(ctx).SelectContext(ctx, &res1, `SELECT * FROM password_reset_requests`)
 	require.NoError(t, err)
 	require.Len(t, res1, 3)
 
@@ -134,7 +134,7 @@ func testCleanupExpiredPasswordResetRequests(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	var res2 []fleet.PasswordResetRequest
-	err = ds.writer.SelectContext(ctx, &res2, `SELECT * FROM password_reset_requests`)
+	err = ds.writer(ctx).SelectContext(ctx, &res2, `SELECT * FROM password_reset_requests`)
 	require.NoError(t, err)
 	require.Len(t, res2, 1)
 	require.Equal(t, "tomorrow", res2[0].Token)

--- a/server/datastore/mysql/queries.go
+++ b/server/datastore/mysql/queries.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (ds *Datastore) ApplyQueries(ctx context.Context, authorID uint, queries []*fleet.Query) (err error) {
-	tx, err := ds.writer.BeginTxx(ctx, nil)
+	tx, err := ds.writer(ctx).BeginTxx(ctx, nil)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "begin ApplyQueries transaction")
 	}
@@ -73,7 +73,7 @@ func (ds *Datastore) QueryByName(ctx context.Context, name string, opts ...fleet
 			WHERE name = ?
 	`
 	var query fleet.Query
-	err := sqlx.GetContext(ctx, ds.reader, &query, sqlStatement, name)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &query, sqlStatement, name)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("Query").WithName(name))
@@ -100,7 +100,7 @@ func (ds *Datastore) NewQuery(ctx context.Context, query *fleet.Query, opts ...f
 			observer_can_run
 		) VALUES ( ?, ?, ?, ?, ?, ? )
 	`
-	result, err := ds.writer.ExecContext(ctx, sqlStatement, query.Name, query.Description, query.Query, query.Saved, query.AuthorID, query.ObserverCanRun)
+	result, err := ds.writer(ctx).ExecContext(ctx, sqlStatement, query.Name, query.Description, query.Query, query.Saved, query.AuthorID, query.ObserverCanRun)
 
 	if err != nil && isDuplicate(err) {
 		return nil, ctxerr.Wrap(ctx, alreadyExists("Query", query.Name))
@@ -121,7 +121,7 @@ func (ds *Datastore) SaveQuery(ctx context.Context, q *fleet.Query) error {
 			SET name = ?, description = ?, query = ?, author_id = ?, saved = ?, observer_can_run = ?
 			WHERE id = ?
 	`
-	result, err := ds.writer.ExecContext(ctx, sql, q.Name, q.Description, q.Query, q.AuthorID, q.Saved, q.ObserverCanRun, q.ID)
+	result, err := ds.writer(ctx).ExecContext(ctx, sql, q.Name, q.Description, q.Query, q.AuthorID, q.Saved, q.ObserverCanRun, q.ID)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "updating query")
 	}
@@ -157,7 +157,7 @@ func (ds *Datastore) Query(ctx context.Context, id uint) (*fleet.Query, error) {
 		WHERE q.id = ?
 	`
 	query := &fleet.Query{}
-	if err := sqlx.GetContext(ctx, ds.reader, query, sqlQuery, id); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), query, sqlQuery, id); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("Query").WithID(id))
 		}
@@ -196,7 +196,7 @@ func (ds *Datastore) ListQueries(ctx context.Context, opt fleet.ListQueryOptions
 
 	results := []*fleet.Query{}
 
-	if err := sqlx.SelectContext(ctx, ds.reader, &results, sql, false, aggregatedStatsTypeQuery); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &results, sql, false, aggregatedStatsTypeQuery); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "listing queries")
 	}
 
@@ -241,7 +241,7 @@ func (ds *Datastore) loadPacksForQueries(ctx context.Context, queries []*fleet.Q
 		fleet.Pack
 	}{}
 
-	err = sqlx.SelectContext(ctx, ds.reader, &rows, query, args...)
+	err = sqlx.SelectContext(ctx, ds.reader(ctx), &rows, query, args...)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "selecting load packs for queries")
 	}
@@ -261,7 +261,7 @@ func (ds *Datastore) ObserverCanRunQuery(ctx context.Context, queryID uint) (boo
 		WHERE id = ?
 	`
 	var observerCanRun bool
-	err := sqlx.GetContext(ctx, ds.reader, &observerCanRun, sql, queryID)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &observerCanRun, sql, queryID)
 	if err != nil {
 		return false, ctxerr.Wrap(ctx, err, "selecting observer_can_run")
 	}

--- a/server/datastore/mysql/queries_test.go
+++ b/server/datastore/mysql/queries_test.go
@@ -232,7 +232,7 @@ func testQueriesList(t *testing.T, ds *Datastore) {
 
 	idWithAgg := results[0].ID
 
-	_, err = ds.writer.Exec(
+	_, err = ds.writer(context.Background()).Exec(
 		`INSERT INTO aggregated_stats(id,global_stats,type,json_value) VALUES (?,?,?,?)`,
 		idWithAgg, false, aggregatedStatsTypeQuery, `{"user_time_p50": 10.5777, "user_time_p95": 111.7308, "system_time_p50": 0.6936, "system_time_p95": 95.8654, "total_executions": 5038}`,
 	)

--- a/server/datastore/mysql/scheduled_queries_test.go
+++ b/server/datastore/mysql/scheduled_queries_test.go
@@ -105,7 +105,7 @@ func testScheduledQueriesListInPackWithStats(t *testing.T, ds *Datastore) {
 
 	idWithAgg := gotQueries[0].ID
 
-	_, err = ds.writer.Exec(
+	_, err = ds.writer(context.Background()).Exec(
 		`INSERT INTO aggregated_stats(id,global_stats,type,json_value) VALUES (?,?,?,?)`,
 		idWithAgg, false, aggregatedStatsTypeScheduledQuery, `{"user_time_p50": 10.5777, "user_time_p95": 111.7308, "system_time_p50": 0.6936, "system_time_p95": 95.8654, "total_executions": 5038}`,
 	)

--- a/server/datastore/mysql/statistics_test.go
+++ b/server/datastore/mysql/statistics_test.go
@@ -153,7 +153,7 @@ func testStatisticsShouldSend(t *testing.T, ds *Datastore) {
 	// Initialize policy violation days for test
 	pvdJSON, err := json.Marshal(PolicyViolationDays{FailingHostCount: 5, TotalHostCount: 10})
 	require.NoError(t, err)
-	_, err = ds.writer.ExecContext(ctx, `
+	_, err = ds.writer(ctx).ExecContext(ctx, `
 		INSERT INTO
 			aggregated_stats (id, global_stats, type, json_value, created_at, updated_at)
 		VALUES (?, ?, ?, CAST(? AS JSON), ?, ?)

--- a/server/datastore/mysql/targets.go
+++ b/server/datastore/mysql/targets.go
@@ -43,7 +43,7 @@ func (ds *Datastore) CountHostsInTargets(ctx context.Context, filter fleet.TeamF
 	}
 
 	res := fleet.TargetMetrics{}
-	err = sqlx.GetContext(ctx, ds.reader, &res, query, args...)
+	err = sqlx.GetContext(ctx, ds.reader(ctx), &res, query, args...)
 	if err != nil {
 		return fleet.TargetMetrics{}, ctxerr.Wrap(ctx, err, "sqlx.Get CountHostsInTargets")
 	}
@@ -143,7 +143,7 @@ func (ds *Datastore) HostIDsInTargets(ctx context.Context, filter fleet.TeamFilt
 	}
 
 	var res []uint
-	err = sqlx.SelectContext(ctx, ds.reader, &res, query, args...)
+	err = sqlx.SelectContext(ctx, ds.reader(ctx), &res, query, args...)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "sqlx.Get HostIDsInTargets")
 	}

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -47,7 +47,7 @@ func (ds *Datastore) NewTeam(ctx context.Context, team *fleet.Team) (*fleet.Team
 }
 
 func (ds *Datastore) Team(ctx context.Context, tid uint) (*fleet.Team, error) {
-	return teamDB(ctx, ds.reader, tid)
+	return teamDB(ctx, ds.reader(ctx), tid)
 }
 
 func teamDB(ctx context.Context, q sqlx.QueryerContext, tid uint) (*fleet.Team, error) {
@@ -122,21 +122,21 @@ func (ds *Datastore) TeamByName(ctx context.Context, name string) (*fleet.Team, 
 	`
 	team := &fleet.Team{}
 
-	if err := sqlx.GetContext(ctx, ds.reader, team, stmt, name); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), team, stmt, name); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "select team")
 	}
 
-	if err := loadSecretsForTeamsDB(ctx, ds.reader, []*fleet.Team{team}); err != nil {
+	if err := loadSecretsForTeamsDB(ctx, ds.reader(ctx), []*fleet.Team{team}); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "getting secrets for teams")
 	}
 
-	if err := loadUsersForTeamDB(ctx, ds.reader, team); err != nil {
+	if err := loadUsersForTeamDB(ctx, ds.reader(ctx), team); err != nil {
 		return nil, err
 	}
-	if err := loadHostCountForTeamDB(ctx, ds.reader, team); err != nil {
+	if err := loadHostCountForTeamDB(ctx, ds.reader(ctx), team); err != nil {
 		return nil, err
 	}
-	if err := loadFeaturesForTeamDB(ctx, ds.reader, team); err != nil {
+	if err := loadFeaturesForTeamDB(ctx, ds.reader(ctx), team); err != nil {
 		return nil, err
 	}
 
@@ -260,10 +260,10 @@ func (ds *Datastore) ListTeams(ctx context.Context, filter fleet.TeamFilter, opt
 	query, params := searchLike(query, nil, opt.MatchQuery, teamSearchColumns...)
 	query = appendListOptionsToSQL(query, &opt)
 	teams := []*fleet.Team{}
-	if err := sqlx.SelectContext(ctx, ds.reader, &teams, query, params...); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &teams, query, params...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list teams")
 	}
-	if err := loadSecretsForTeamsDB(ctx, ds.reader, teams); err != nil {
+	if err := loadSecretsForTeamsDB(ctx, ds.reader(ctx), teams); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "getting secrets for teams")
 	}
 	return teams, nil
@@ -282,7 +282,7 @@ func loadSecretsForTeamsDB(ctx context.Context, q sqlx.QueryerContext, teams []*
 
 func (ds *Datastore) TeamsSummary(ctx context.Context) ([]*fleet.TeamSummary, error) {
 	teamsSummary := []*fleet.TeamSummary{}
-	if err := sqlx.SelectContext(ctx, ds.reader, &teamsSummary, "SELECT id, name, description FROM teams"); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &teamsSummary, "SELECT id, name, description FROM teams"); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "teams summary")
 	}
 	return teamsSummary, nil
@@ -301,10 +301,10 @@ func (ds *Datastore) SearchTeams(ctx context.Context, filter fleet.TeamFilter, m
 	)
 	sql, params := searchLike(sql, nil, matchQuery, teamSearchColumns...)
 	teams := []*fleet.Team{}
-	if err := sqlx.SelectContext(ctx, ds.reader, &teams, sql, params...); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &teams, sql, params...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "search teams")
 	}
-	if err := loadSecretsForTeamsDB(ctx, ds.reader, teams); err != nil {
+	if err := loadSecretsForTeamsDB(ctx, ds.reader(ctx), teams); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "getting secrets for teams")
 	}
 	return teams, nil
@@ -316,7 +316,7 @@ func (ds *Datastore) TeamEnrollSecrets(ctx context.Context, teamID uint) ([]*fle
 		WHERE team_id = ?
 	`
 	var secrets []*fleet.EnrollSecret
-	if err := sqlx.SelectContext(ctx, ds.reader, &secrets, sql, teamID); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &secrets, sql, teamID); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get secrets")
 	}
 	return secrets, nil
@@ -335,7 +335,7 @@ func amountTeamsDB(ctx context.Context, db sqlx.QueryerContext) (int, error) {
 func (ds *Datastore) TeamAgentOptions(ctx context.Context, tid uint) (*json.RawMessage, error) {
 	sql := `SELECT config->'$.agent_options' FROM teams WHERE id = ?`
 	var agentOptions *json.RawMessage
-	if err := sqlx.GetContext(ctx, ds.reader, &agentOptions, sql, tid); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &agentOptions, sql, tid); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "select team")
 	}
 	return agentOptions, nil
@@ -343,7 +343,7 @@ func (ds *Datastore) TeamAgentOptions(ctx context.Context, tid uint) (*json.RawM
 
 // TeamFeatures loads the features enabled for a team.
 func (ds *Datastore) TeamFeatures(ctx context.Context, tid uint) (*fleet.Features, error) {
-	return teamFeaturesDB(ctx, ds.reader, tid)
+	return teamFeaturesDB(ctx, ds.reader(ctx), tid)
 }
 
 func teamFeaturesDB(ctx context.Context, q sqlx.QueryerContext, tid uint) (*fleet.Features, error) {
@@ -366,7 +366,7 @@ func teamFeaturesDB(ctx context.Context, q sqlx.QueryerContext, tid uint) (*flee
 func (ds *Datastore) TeamMDMConfig(ctx context.Context, tid uint) (*fleet.TeamMDM, error) {
 	sql := `SELECT config->'$.mdm' AS mdm FROM teams WHERE id = ?`
 	var raw *json.RawMessage
-	if err := sqlx.GetContext(ctx, ds.reader, &raw, sql, tid); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &raw, sql, tid); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "select team MDM config")
 	}
 	var mdmConfig *fleet.TeamMDM
@@ -386,7 +386,7 @@ func (ds *Datastore) DeleteIntegrationsFromTeams(ctx context.Context, deletedInt
 		updateTeam = `UPDATE teams SET config = ? WHERE id = ?`
 	)
 
-	rows, err := ds.writer.QueryxContext(ctx, listTeams)
+	rows, err := ds.writer(ctx).QueryxContext(ctx, listTeams)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "query teams")
 	}
@@ -421,7 +421,7 @@ func (ds *Datastore) DeleteIntegrationsFromTeams(ctx context.Context, deletedInt
 
 			tm.Config.Integrations.Jira = keepJira
 			tm.Config.Integrations.Zendesk = keepZendesk
-			if _, err := ds.writer.ExecContext(ctx, updateTeam, tm.Config, tm.ID); err != nil {
+			if _, err := ds.writer(ctx).ExecContext(ctx, updateTeam, tm.Config, tm.ID); err != nil {
 				return ctxerr.Wrap(ctx, err, "update team config")
 			}
 		}

--- a/server/datastore/mysql/testing_utils.go
+++ b/server/datastore/mysql/testing_utils.go
@@ -80,8 +80,8 @@ func setupReadReplica(t testing.TB, testName string, ds *Datastore, opts *Datast
 		// immediately so that RunReplication is unblocked too.
 		defer cancel()
 
-		primary := ds.writer
-		replica := ds.reader.(*sqlx.DB)
+		primary := ds.primary
+		replica := ds.replica.(*sqlx.DB)
 		replicaDB := testName + testReplicaDatabaseSuffix
 		last := time.Now().Add(-time.Minute)
 
@@ -275,7 +275,7 @@ func CreateNamedMySQLDS(t *testing.T, name string) *Datastore {
 }
 
 func ExecAdhocSQL(tb testing.TB, ds *Datastore, fn func(q sqlx.ExtContext) error) {
-	err := fn(ds.writer)
+	err := fn(ds.primary)
 	require.NoError(tb, err)
 }
 

--- a/server/datastore/mysql/users.go
+++ b/server/datastore/mysql/users.go
@@ -74,7 +74,7 @@ func (ds *Datastore) findUser(ctx context.Context, searchCol string, searchVal i
 
 	user := &fleet.User{}
 
-	err := sqlx.GetContext(ctx, ds.reader, user, sqlStatement, searchVal)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), user, sqlStatement, searchVal)
 	if err != nil && err == sql.ErrNoRows {
 		return nil, ctxerr.Wrap(ctx, notFound("User").
 			WithMessage(fmt.Sprintf("with %s=%v", searchCol, searchVal)))
@@ -112,7 +112,7 @@ func (ds *Datastore) ListUsers(ctx context.Context, opt fleet.UserListOptions) (
 	sqlStatement = appendListOptionsToSQL(sqlStatement, &opt.ListOptions)
 	users := []*fleet.User{}
 
-	if err := sqlx.SelectContext(ctx, ds.reader, &users, sqlStatement, params...); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &users, sqlStatement, params...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list users")
 	}
 
@@ -228,7 +228,7 @@ func (ds *Datastore) loadTeamsForUsers(ctx context.Context, users []*fleet.User)
 		fleet.UserTeam
 		UserID uint `db:"user_id"`
 	}
-	if err := sqlx.SelectContext(ctx, ds.reader, &rows, sql, args...); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, sql, args...); err != nil {
 		return ctxerr.Wrap(ctx, err, "get loadTeamsForUsers")
 	}
 

--- a/server/datastore/mysql/windows_updates.go
+++ b/server/datastore/mysql/windows_updates.go
@@ -23,7 +23,7 @@ func (ds *Datastore) ListWindowsUpdatesByHostID(
 	`
 	updates := []fleet.WindowsUpdate{}
 
-	if err := sqlx.SelectContext(ctx, ds.reader, &updates, stmt, hostID); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &updates, stmt, hostID); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list windows updates")
 	}
 
@@ -44,7 +44,7 @@ func (ds *Datastore) InsertWindowsUpdates(ctx context.Context, hostID uint, upda
 	var placeholders []string
 
 	lastUpdateSmt := `SELECT date_epoch FROM windows_updates WHERE host_id = ? ORDER BY date_epoch DESC LIMIT 1`
-	if err := sqlx.GetContext(ctx, ds.reader, &lastUpdateEpoch, lastUpdateSmt, hostID); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &lastUpdateEpoch, lastUpdateSmt, hostID); err != nil {
 		if err != sql.ErrNoRows {
 			return ctxerr.Wrap(ctx, err, "inserting windows updates")
 		}
@@ -64,7 +64,7 @@ func (ds *Datastore) InsertWindowsUpdates(ctx context.Context, hostID uint, upda
 			strings.Join(placeholders, ","),
 		)
 
-		if _, err := ds.writer.ExecContext(ctx, smt, args...); err != nil {
+		if _, err := ds.writer(ctx).ExecContext(ctx, smt, args...); err != nil {
 			return ctxerr.Wrap(ctx, err, "inserting windows updates")
 		}
 

--- a/server/datastore/mysql/windows_updates_test.go
+++ b/server/datastore/mysql/windows_updates_test.go
@@ -84,7 +84,7 @@ func testInsertWindowsUpdates(t *testing.T, ds *Datastore) {
 		require.NoError(t, err)
 
 		var actual []fleet.WindowsUpdate
-		err = sqlx.SelectContext(ctx, ds.reader, &actual, smt, hostID)
+		err = sqlx.SelectContext(ctx, ds.reader(ctx), &actual, smt, hostID)
 		require.NoError(t, err)
 
 		require.ElementsMatch(t, updates, actual)
@@ -105,7 +105,7 @@ func testInsertWindowsUpdates(t *testing.T, ds *Datastore) {
 		require.NoError(t, err)
 
 		var actual []fleet.WindowsUpdate
-		err = sqlx.SelectContext(ctx, ds.reader, &actual, smt, hostID)
+		err = sqlx.SelectContext(ctx, ds.reader(ctx), &actual, smt, hostID)
 		require.NoError(t, err)
 
 		require.ElementsMatch(t, updates, actual)

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -591,7 +591,7 @@ func (s *integrationMDMTestSuite) TestPuppetMatchPreassignProfiles() {
 	require.NotNil(t, h.TeamID)
 	tm1, err := s.ds.Team(ctx, *h.TeamID)
 	require.NoError(t, err)
-	require.Regexp(t, `^g1 \(\d+-\d+-\d+:\d+:\d+:\d+\)$`, tm1.Name)
+	require.Regexp(t, `^g1 \(\d+-\d+-\d+:\d+:\d+:\d+\.\d\d\d\)$`, tm1.Name)
 
 	// it create activities for the new team, the profiles assigned to it, and
 	// the host moved to it


### PR DESCRIPTION
#12392 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
