### PR TITLE
Add @JoStableford to business operations handbook codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -76,8 +76,8 @@ go.mod @fleetdm/go
 # Handbook
 /handbook/company @mikermcneil
 /handbook/company/* @mikermcneil
-/handbook/business-operations @mikermcneil
-/handbook/business-operations/* @mikermcneil
+/handbook/business-operations @mikermcneil @JoStableford
+/handbook/business-operations/* @mikermcneil @JoStableford
 /handbook/engineering @lukeheath
 /handbook/engineering/* @lukeheath
 /handbook/product @zhumo


### PR DESCRIPTION
Adding @JoStableford to codeowners so that her PR approvals to the bizops handbook will allow merging. 