### PR TITLE
create a reusable UI card component

### DIFF
--- a/frontend/components/Card/Card.stories.tsx
+++ b/frontend/components/Card/Card.stories.tsx
@@ -1,0 +1,17 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import Card from ".";
+
+const meta: Meta<typeof Card> = {
+  component: Card,
+  title: "Components/Card",
+  args: {
+    children: "card content",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Card>;
+
+export const Default: Story = {};

--- a/frontend/components/Card/Card.tsx
+++ b/frontend/components/Card/Card.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import classnames from "classnames";
+
+const baseClass = "card";
+
+type CardColors = "white" | "gray" | "purple" | "yellow";
+
+interface ICardProps {
+  children?: React.ReactNode;
+  /** defaults to white */
+  color?: CardColors;
+  className?: string;
+}
+
+/**
+ * A generic card component that will be used to render content within a card with a border and
+ * and selected background color.
+ */
+const Card = ({ children, color = "white", className }: ICardProps) => {
+  const classNames = classnames(baseClass, `${baseClass}__${color}`, className);
+
+  return <div className={classNames}>{children}</div>;
+};
+
+export default Card;

--- a/frontend/components/Card/_styles.scss
+++ b/frontend/components/Card/_styles.scss
@@ -1,0 +1,23 @@
+.card {
+  border-radius: $border-radius;
+  border: 1px solid $ui-fleet-black-10;
+  padding: $pad-large;
+
+  &__white {
+    background-color: $core-white;
+  }
+
+  &__gray {
+    background-color: $ui-off-white;
+  }
+
+  &__purple {
+    background-color: $ui-vibrant-blue-10;
+    border-color: $ui-vibrant-blue-50;
+  }
+
+  &__yellow {
+    background-color: $ui-yellow-banner;
+    border-color: $ui-yellow-banner-outline;
+  }
+}

--- a/frontend/components/Card/index.ts
+++ b/frontend/components/Card/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Card";


### PR DESCRIPTION
I notices we were reusing styles alot for the card like container UI so I created a reusable `Card` component

The component is used like this:

```tsx

// default card is white background
<Card>
  <p>whatever JSX you want</p>
</Card>

<Card color="gray">
  <p>whatever JSX you want</p>
</Card>

<Card color="yellow">
  <p>whatever JSX you want</p>
</Card>

<Card color="purple">
  <p>whatever JSX you want</p>
</Card>
```

**white**

![image](https://github.com/fleetdm/fleet/assets/1153709/53ee43a7-982b-480b-8bcf-0c585e0e01b5)

**gray**

![image](https://github.com/fleetdm/fleet/assets/1153709/5afa85df-d63f-4c5a-8f31-d7d6d9174862)

**yellow**

![image](https://github.com/fleetdm/fleet/assets/1153709/334291d6-c5af-4caa-adcb-b28696a054d7)

**purple**

![image](https://github.com/fleetdm/fleet/assets/1153709/0cc87478-f507-4c7f-9807-328e2384a8b1)

- [x] Manual QA for all new/changed functionality
