### PR TITLE
Add mdm_enabled field to response of PATCH /config

### DIFF
--- a/changes/bug-add-mdm-feature-flag-in-modify-appconfig
+++ b/changes/bug-add-mdm-feature-flag-in-modify-appconfig
@@ -1,0 +1,1 @@
+* Added the `mdm_enabled` feature flag information to the response payload of the `PATCH /config` endpoint.

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -196,7 +196,7 @@ type modifyAppConfigRequest struct {
 
 func modifyAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
 	req := request.(*modifyAppConfigRequest)
-	config, err := svc.ModifyAppConfig(ctx, req.RawMessage, fleet.ApplySpecOptions{
+	appConfig, err := svc.ModifyAppConfig(ctx, req.RawMessage, fleet.ApplySpecOptions{
 		Force:  req.Force,
 		DryRun: req.DryRun,
 	})
@@ -212,10 +212,11 @@ func modifyAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet
 		return nil, err
 	}
 	response := appConfigResponse{
-		AppConfig: *config,
+		AppConfig: *appConfig,
 		appConfigResponseFields: appConfigResponseFields{
-			License: license,
-			Logging: loggingConfig,
+			License:    license,
+			Logging:    loggingConfig,
+			MDMEnabled: config.IsMDMFeatureFlagEnabled(),
 		},
 	}
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -4692,6 +4692,7 @@ func (s *integrationTestSuite) TestAppConfig() {
   }`), http.StatusOK, &acResp)
 	assert.Equal(t, "test", acResp.OrgInfo.OrgName)
 	assert.True(t, acResp.MDM.AppleBMTermsExpired)
+	assert.False(t, acResp.MDMEnabled)
 
 	// the global agent options were not modified by the last call, so the
 	// corresponding activity should not have been created.

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -5066,10 +5066,12 @@ func (s *integrationMDMTestSuite) TestAppConfigMicrosoftMDM() {
 	}
 
 	// enable Microsoft MDM
+	acResp = appConfigResponse{}
 	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
 		"mdm": { "windows_enabled_and_configured": true }
   }`), http.StatusOK, &acResp)
 	assert.True(t, acResp.MDM.MicrosoftEnabledAndConfigured)
+	assert.True(t, acResp.MDMEnabled)
 
 	// get the orbit config for each host, verify that only the expected ones
 	// receive the "needs enrollment to Microsoft MDM" notification.


### PR DESCRIPTION
As discussed on Slack, would be helpful to have the status of the feature flag in response of a `PATCH /config` too.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] ~~Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~~ (feature flag is deliberately undocumented)
- [x] Added/updated tests
