### PR TITLE
Add `--verbose` flag to `fleetd_tables` (needed when `osqueryd` runs in verbose mode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ orbit/cmd/desktop/manifest.xml
 orbit/cmd/desktop/resource.syso
 orbit/cmd/orbit/manifest.xml
 orbit/cmd/orbit/resource.syso
+
+# Residual files when building fleetd_tables extension.
+fleetd_tables_*

--- a/orbit/cmd/fleetd_tables/fleetd_tables.go
+++ b/orbit/cmd/fleetd_tables/fleetd_tables.go
@@ -16,6 +16,8 @@ var (
 	socket   = flag.String("socket", "", "Path to the extensions UNIX domain socket")
 	timeout  = flag.Int("timeout", 3, "Seconds to wait for autoloaded extensions")
 	interval = flag.Int("interval", 3, "Seconds delay between connectivity checks")
+	// verbose must be set because osqueryd will set it on the extension when running in verbose mode.
+	_ = flag.Bool("verbose", false, "Enable verbose informational messages")
 )
 
 func main() {


### PR DESCRIPTION
Found while load testing the macOS CIS benchmark policy queries using `fleetd_tables` as an extension (#10292).

Basically, osqueryd passes the `--verbose` flag to the extension, so we need to add it here to not fail the extension execution.