### PR TITLE
Optimize macOS CIS query 5.1.5

### DIFF
--- a/changes/10292-optimize-macos-cis-query-5.1.5
+++ b/changes/10292-optimize-macos-cis-query-5.1.5
@@ -1,0 +1,1 @@
+* Optimize macOS CIS query "Ensure Appropriate Permissions Are Enabled for System Wide Applications" (5.1.5).

--- a/ee/cis/macos-13/cis-policy-queries.yml
+++ b/ee/cis/macos-13/cis-policy-queries.yml
@@ -2619,11 +2619,9 @@ spec:
       done
   query: |
     SELECT 1 WHERE NOT EXISTS (
-    SELECT 1 FROM file WHERE 
-      path LIKE '/Applications/%%'  
-      AND type = 'directory' 
-      AND directory LIKE '%.app' 
-      AND  CAST( SUBSTRING( mode ,-1) AS INTEGER)  & 0x2 !=0 -- mode last char is others' permissions. bitwise with 0x2 means write permissions. (which we do not want here) 
+      SELECT apps.path FROM apps
+      LEFT JOIN file on file.path = apps.path
+      WHERE CAST(SUBSTRING(file.mode, -1) AS INTEGER) & 0x2 != 0
     );
   purpose: Informational
   tags: compliance, CIS, CIS_Level1, CIS-macos-13-5.1.5
@@ -2637,7 +2635,9 @@ spec:
   platform: darwin
   description: |
     Software sometimes insists on being installed in the /System/Volumes/Data/System Directory and has inappropriate world-writable permissions.
-    Macs with writable files in System should be investigated forensically. A file with open writable permissions is a sign of at best a rogue application. It could also be a sign of a computer compromise and a persistent presence on the system.
+    Macs with writable files in System should be investigated forensically. A file with open writable permissions is a sign of at best a rogue application.
+    It could also be a sign of a computer compromise and a persistent presence on the system.
+    The audit check excludes the "Drop Box" folder that is part of Apple's default user template.
   resolution: |
     Ask your system administrator to deploy a script that will ensure folders are not world-writable in the /System folder. 
     /usr/bin/sudo IFS=$'\n'

--- a/ee/cis/macos-13/cis-policy-queries.yml
+++ b/ee/cis/macos-13/cis-policy-queries.yml
@@ -2621,6 +2621,9 @@ spec:
     SELECT 1 WHERE NOT EXISTS (
       SELECT apps.path FROM apps
       LEFT JOIN file on file.path = apps.path
+      -- file.mode's last character are the permissions for 'other',
+      -- bitwise && with '0x2' selects the write permission,
+      -- which we do not want here.
       WHERE CAST(SUBSTRING(file.mode, -1) AS INTEGER) & 0x2 != 0
     );
   purpose: Informational


### PR DESCRIPTION
#10292

The query was processing *every* file under `/Applications/`, which makes it super expensive both in CPU usage and Memory footprint. This query was the main culprit of triggering worker process kills by the watchdog.

On some runs it triggered CPU usage alerts:
```
7716:W0623 15:38:05.402959 221732864 watcher.cpp:415] osqueryd worker (72976) stopping:
Maximum sustainable CPU utilization limit 1200ms exceeded for 12 seconds
```
And on other runs it triggered memory usage alerts:
```
4431 W0626 07:28:50.868021 147312640 watcher.cpp:424] osqueryd worker (21453) stopping:
Memory limits exceeded: 214020096 bytes (limit is 200MB)
```

For the above logs I used a custom osqueryd branch to be able to print more information: https://github.com/osquery/osquery/pull/8070

The metrics for the old query were CPU usage: ~4521 ms
```
435:level=warn ts=2023-06-26T09:58:29.665712Z query=fleet_policy_query_1233 queryTime=4521 memory=12226560 msg="distributed query performance is excessive" hostID=308 platform=darwin
```
With the new query, CPU usage: ~210 ms.
```
23893:level=debug ts=2023-06-26T18:06:08.242456Z query=fleet_policy_query_1233 queryTime=210 msg=stats memory=0 hostID=308 platform=darwin
```
Basically a ~20x improvement.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- ~[ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~[ ] Documented any permissions changes~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- ~[ ] Added/updated tests~
- [X] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
