### PR TITLE
Add warning log when a distributed query with excessive CPU usage

### DIFF
--- a/changes/10292-parse-new-distributed-stats-in-write
+++ b/changes/10292-parse-new-distributed-stats-in-write
@@ -1,0 +1,1 @@
+* Fleet now parses the `stats` in `distributed/write` requests (stats for distributed queries were added to osquery in v5.8.1).

--- a/server/fleet/osquery.go
+++ b/server/fleet/osquery.go
@@ -8,6 +8,30 @@ type OsqueryDistributedQueryResults map[string][]map[string]string
 // failure)
 type OsqueryStatus int
 
+// QueryExcessiveCPUUsageThreshMs is the currently agreed upon value to
+// consider a query to be "excessive" in CPU usage.
+//
+// This time includes both system_time (kernel space code) +
+// user_time (user space code).
+//
+// NOTE(lucas): The value must match what we use in
+// frontend/utilities/helpers.ts:performanceIndicator.
+const QueryExcessiveCPUUsageThreshMs = 4000
+
+// OsqueryStats are stats of a executed distributed query reported by a host.
+type OsqueryStats struct {
+	// WallTimeMs is the time in milliseconds that a clock on the wall
+	// would measure as having elapsed between the start of the
+	// process and 'now'.
+	WallTimeMs uint64 `json:"wall_time_ms"`
+	// UserTimeMs is the time in milliseconds spent in user space code.
+	UserTimeMs uint64 `json:"user_time"`
+	// SystemTimeMs is the time in milliseconds spent in kernel space code.
+	SystemTimeMs uint64 `json:"system_time"`
+	// Memory is the memory footprint in bytes.
+	Memory uint64 `json:"memory"`
+}
+
 const (
 	// StatusOK is the success code returned by osquery
 	StatusOK OsqueryStatus = 0

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -57,6 +57,7 @@ type OsqueryService interface {
 		results OsqueryDistributedQueryResults,
 		statuses map[string]OsqueryStatus,
 		messages map[string]string,
+		stats map[string]OsqueryStats,
 	) (err error)
 	SubmitStatusLogs(ctx context.Context, logs []json.RawMessage) (err error)
 	SubmitResultLogs(ctx context.Context, logs []json.RawMessage) (err error)

--- a/server/launcher/launcher.go
+++ b/server/launcher/launcher.go
@@ -130,9 +130,11 @@ func (svc *launcherWrapper) PublishResults(ctx context.Context, nodeKey string, 
 		osqueryResults[result.QueryName] = result.Rows
 	}
 
-	// TODO can Launcher expose the error messages?
+	// TODO can Launcher expose the error messages or stats?
 	messages := make(map[string]string)
-	err = svc.tls.SubmitDistributedQueryResults(newCtx, osqueryResults, statuses, messages)
+	stats := make(map[string]fleet.OsqueryStats)
+
+	err = svc.tls.SubmitDistributedQueryResults(newCtx, osqueryResults, statuses, messages, stats)
 	return "", "", false, ctxerr.Wrap(ctx, err, "submit launcher results")
 }
 

--- a/server/launcher/launcher_test.go
+++ b/server/launcher/launcher_test.go
@@ -68,6 +68,7 @@ func TestLauncherPublishResults(t *testing.T) {
 		results fleet.OsqueryDistributedQueryResults,
 		statuses map[string]fleet.OsqueryStatus,
 		messages map[string]string,
+		stats map[string]fleet.OsqueryStats,
 	) (err error) {
 		assert.Equal(t, results["query"][0], result)
 		return nil
@@ -151,6 +152,7 @@ func newTLSService(t *testing.T) *mock.TLSService {
 			results fleet.OsqueryDistributedQueryResults,
 			statuses map[string]fleet.OsqueryStatus,
 			messages map[string]string,
+			stats map[string]fleet.OsqueryStats,
 		) (err error) {
 			return
 		},

--- a/server/service/mock/service_osquery.go
+++ b/server/service/mock/service_osquery.go
@@ -20,7 +20,7 @@ type GetClientConfigFunc func(ctx context.Context) (config map[string]interface{
 
 type GetDistributedQueriesFunc func(ctx context.Context) (queries map[string]string, discovery map[string]string, accelerate uint, err error)
 
-type SubmitDistributedQueryResultsFunc func(ctx context.Context, results fleet.OsqueryDistributedQueryResults, statuses map[string]fleet.OsqueryStatus, messages map[string]string) (err error)
+type SubmitDistributedQueryResultsFunc func(ctx context.Context, results fleet.OsqueryDistributedQueryResults, statuses map[string]fleet.OsqueryStatus, messages map[string]string, stats map[string]fleet.OsqueryStats) (err error)
 
 type SubmitStatusLogsFunc func(ctx context.Context, logs []json.RawMessage) (err error)
 
@@ -79,11 +79,11 @@ func (s *TLSService) GetDistributedQueries(ctx context.Context) (queries map[str
 	return s.GetDistributedQueriesFunc(ctx)
 }
 
-func (s *TLSService) SubmitDistributedQueryResults(ctx context.Context, results fleet.OsqueryDistributedQueryResults, statuses map[string]fleet.OsqueryStatus, messages map[string]string) (err error) {
+func (s *TLSService) SubmitDistributedQueryResults(ctx context.Context, results fleet.OsqueryDistributedQueryResults, statuses map[string]fleet.OsqueryStatus, messages map[string]string, stats map[string]fleet.OsqueryStats) (err error) {
 	s.mu.Lock()
 	s.SubmitDistributedQueryResultsFuncInvoked = true
 	s.mu.Unlock()
-	return s.SubmitDistributedQueryResultsFunc(ctx, results, statuses, messages)
+	return s.SubmitDistributedQueryResultsFunc(ctx, results, statuses, messages, stats)
 }
 
 func (s *TLSService) SubmitStatusLogs(ctx context.Context, logs []json.RawMessage) (err error) {

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -829,6 +829,7 @@ func TestLabelQueries(t *testing.T) {
 		},
 		map[string]fleet.OsqueryStatus{},
 		map[string]string{},
+		map[string]fleet.OsqueryStats{},
 	)
 	require.NoError(t, err)
 	host.LabelUpdatedAt = mockClock.Now()
@@ -848,6 +849,7 @@ func TestLabelQueries(t *testing.T) {
 		},
 		map[string]fleet.OsqueryStatus{},
 		map[string]string{},
+		map[string]fleet.OsqueryStats{},
 	)
 	require.NoError(t, err)
 	host.LabelUpdatedAt = mockClock.Now()
@@ -885,6 +887,7 @@ func TestLabelQueries(t *testing.T) {
 		},
 		map[string]fleet.OsqueryStatus{},
 		map[string]string{},
+		map[string]fleet.OsqueryStats{},
 	)
 	require.NoError(t, err)
 	host.LabelUpdatedAt = mockClock.Now()
@@ -1045,7 +1048,12 @@ func TestDetailQueriesWithEmptyStrings(t *testing.T) {
 	}
 
 	// Verify that results are ingested properly
-	require.NoError(t, svc.SubmitDistributedQueryResults(ctx, results, map[string]fleet.OsqueryStatus{}, map[string]string{}))
+	require.NoError(t, svc.SubmitDistributedQueryResults(ctx,
+		results,
+		map[string]fleet.OsqueryStatus{},
+		map[string]string{},
+		map[string]fleet.OsqueryStats{}),
+	)
 
 	// osquery_info
 	assert.Equal(t, "darwin", gotHost.Platform)
@@ -1333,7 +1341,12 @@ func TestDetailQueries(t *testing.T) {
 	}
 
 	// Verify that results are ingested properly
-	require.NoError(t, svc.SubmitDistributedQueryResults(ctx, results, map[string]fleet.OsqueryStatus{}, map[string]string{}))
+	require.NoError(t, svc.SubmitDistributedQueryResults(ctx,
+		results,
+		map[string]fleet.OsqueryStatus{},
+		map[string]string{},
+		map[string]fleet.OsqueryStats{}),
+	)
 	require.NotNil(t, gotHost)
 
 	require.True(t, ds.SetOrUpdateMDMDataFuncInvoked)
@@ -1675,7 +1688,12 @@ func TestDistributedQueryResults(t *testing.T) {
 	// this test.
 	time.Sleep(10 * time.Millisecond)
 
-	err = svc.SubmitDistributedQueryResults(hostCtx, results, map[string]fleet.OsqueryStatus{}, map[string]string{})
+	err = svc.SubmitDistributedQueryResults(hostCtx,
+		results,
+		map[string]fleet.OsqueryStatus{},
+		map[string]string{},
+		map[string]fleet.OsqueryStats{},
+	)
 	require.NoError(t, err)
 }
 
@@ -2233,6 +2251,7 @@ func TestDistributedQueriesLogsManyErrors(t *testing.T) {
 		},
 		map[string]fleet.OsqueryStatus{},
 		map[string]string{},
+		map[string]fleet.OsqueryStats{},
 	)
 	require.NoError(t, err)
 
@@ -2274,6 +2293,7 @@ func TestDistributedQueriesReloadsHostIfDetailsAreIn(t *testing.T) {
 		},
 		map[string]fleet.OsqueryStatus{},
 		map[string]string{},
+		map[string]fleet.OsqueryStats{},
 	)
 	require.NoError(t, err)
 	assert.True(t, ds.UpdateHostFuncInvoked)
@@ -2486,6 +2506,7 @@ func TestPolicyQueries(t *testing.T) {
 			hostPolicyQueryPrefix + "2": 1,
 		},
 		map[string]string{},
+		map[string]fleet.OsqueryStats{},
 	)
 	require.NoError(t, err)
 	require.Len(t, recordedResults, 2)
@@ -2535,6 +2556,7 @@ func TestPolicyQueries(t *testing.T) {
 			hostPolicyQueryPrefix + "2": 1,
 		},
 		map[string]string{},
+		map[string]fleet.OsqueryStats{},
 	)
 	require.NoError(t, err)
 	require.Len(t, recordedResults, 2)
@@ -2573,6 +2595,7 @@ func TestPolicyQueries(t *testing.T) {
 			hostPolicyQueryPrefix + "2": 1,
 		},
 		map[string]string{},
+		map[string]fleet.OsqueryStats{},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, recordedResults[1])
@@ -2694,6 +2717,7 @@ func TestPolicyWebhooks(t *testing.T) {
 			hostPolicyQueryPrefix + "2": 1, // didn't execute
 		},
 		map[string]string{},
+		map[string]fleet.OsqueryStats{},
 	)
 	require.NoError(t, err)
 	require.Len(t, recordedResults, 3)
@@ -2797,6 +2821,7 @@ func TestPolicyWebhooks(t *testing.T) {
 			hostPolicyQueryPrefix + "2": 1, // didn't execute
 		},
 		map[string]string{},
+		map[string]fleet.OsqueryStats{},
 	)
 	require.NoError(t, err)
 	require.Len(t, recordedResults, 3)
@@ -2841,6 +2866,7 @@ func TestPolicyWebhooks(t *testing.T) {
 		},
 		map[string]fleet.OsqueryStatus{},
 		map[string]string{},
+		map[string]fleet.OsqueryStats{},
 	)
 	require.NoError(t, err)
 	require.Len(t, recordedResults, 3)


### PR DESCRIPTION
This change useful for detecting expensive macOS CIS queries (#10292).

I'm all ears if we prefer not to log a warning and log a debug line instead.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- ~[ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~[ ] Documented any permissions changes~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [x] Added/updated tests
- [X] Manual QA for all new/changed functionality
  - ~For Orbit and Fleet Desktop changes:~
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
