### PR TITLE
Add activities when Windows MDM is turned on/off

### DIFF
--- a/changes/issue-12288-windows-mdm-activities
+++ b/changes/issue-12288-windows-mdm-activities
@@ -1,0 +1,1 @@
+* Added `enabled_windows_mdm` and `disabled_windows_mdm` activities when a user turns on/off Windows MDM.

--- a/docs/Using-Fleet/Audit-Activities.md
+++ b/docs/Using-Fleet/Audit-Activities.md
@@ -826,13 +826,13 @@ This activity contains the following fields:
 
 ### Type `enabled_windows_mdm`
 
-Generated when a user turns on Windows MDM.
+Generated when a user turns on MDM features for all Windows hosts (servers excluded).
 
 This activity does not contain any detail fields.
 
 ### Type `disabled_windows_mdm`
 
-Generated when a user turns off Windows MDM.
+Generated when a user turns off MDM features for all Windows hosts.
 
 This activity does not contain any detail fields.
 

--- a/docs/Using-Fleet/Audit-Activities.md
+++ b/docs/Using-Fleet/Audit-Activities.md
@@ -824,6 +824,18 @@ This activity contains the following fields:
 }
 ```
 
+### Type `enabled_windows_mdm`
+
+Generated when a user turns on Windows MDM.
+
+This activity does not contain any detail fields.
+
+### Type `disabled_windows_mdm`
+
+Generated when a user turns off Windows MDM.
+
+This activity does not contain any detail fields.
+
 
 
 <meta name="pageOrderInSection" value="1400">

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -1016,7 +1016,7 @@ func (a ActivityTypeEnabledWindowsMDM) ActivityName() string {
 }
 
 func (a ActivityTypeEnabledWindowsMDM) Documentation() (activity, details, detailsExample string) {
-	return `Generated when a user turns on Windows MDM.`,
+	return `Generated when a user turns on MDM features for all Windows hosts (servers excluded).`,
 		`This activity does not contain any detail fields.`, ``
 }
 
@@ -1027,7 +1027,7 @@ func (a ActivityTypeDisabledWindowsMDM) ActivityName() string {
 }
 
 func (a ActivityTypeDisabledWindowsMDM) Documentation() (activity, details, detailsExample string) {
-	return `Generated when a user turns off Windows MDM.`,
+	return `Generated when a user turns off MDM features for all Windows hosts.`,
 		`This activity does not contain any detail fields.`, ``
 }
 

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -67,6 +67,9 @@ var ActivityDetailsList = []ActivityDetails{
 
 	ActivityTypeEnabledMacosSetupEndUserAuth{},
 	ActivityTypeDisabledMacosSetupEndUserAuth{},
+
+	ActivityTypeEnabledWindowsMDM{},
+	ActivityTypeDisabledWindowsMDM{},
 }
 
 type ActivityDetails interface {
@@ -1004,6 +1007,28 @@ func (a ActivityTypeDisabledMacosSetupEndUserAuth) Documentation() (activity, de
   "team_id": 123,
   "team_name": "Workstations"
 }`
+}
+
+type ActivityTypeEnabledWindowsMDM struct{}
+
+func (a ActivityTypeEnabledWindowsMDM) ActivityName() string {
+	return "enabled_windows_mdm"
+}
+
+func (a ActivityTypeEnabledWindowsMDM) Documentation() (activity, details, detailsExample string) {
+	return `Generated when a user turns on Windows MDM.`,
+		`This activity does not contain any detail fields.`, ``
+}
+
+type ActivityTypeDisabledWindowsMDM struct{}
+
+func (a ActivityTypeDisabledWindowsMDM) ActivityName() string {
+	return "disabled_windows_mdm"
+}
+
+func (a ActivityTypeDisabledWindowsMDM) Documentation() (activity, details, detailsExample string) {
+	return `Generated when a user turns off Windows MDM.`,
+		`This activity does not contain any detail fields.`, ``
 }
 
 // LogRoleChangeActivities logs activities for each role change, globally and one for each change in teams.

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -527,9 +527,9 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	}
 
 	// if Windows MDM was enabled or disabled, create the corresponding activity
-	if oldAppConfig.MDM.MicrosoftEnabledAndConfigured != appConfig.MDM.MicrosoftEnabledAndConfigured {
+	if oldAppConfig.MDM.WindowsEnabledAndConfigured != appConfig.MDM.WindowsEnabledAndConfigured {
 		var act fleet.ActivityDetails
-		if appConfig.MDM.MicrosoftEnabledAndConfigured {
+		if appConfig.MDM.WindowsEnabledAndConfigured {
 			act = fleet.ActivityTypeEnabledWindowsMDM{}
 		} else {
 			act = fleet.ActivityTypeDisabledWindowsMDM{}

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -526,6 +526,19 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		}
 	}
 
+	// if Windows MDM was enabled or disabled, create the corresponding activity
+	if oldAppConfig.MDM.MicrosoftEnabledAndConfigured != appConfig.MDM.MicrosoftEnabledAndConfigured {
+		var act fleet.ActivityDetails
+		if appConfig.MDM.MicrosoftEnabledAndConfigured {
+			act = fleet.ActivityTypeEnabledWindowsMDM{}
+		} else {
+			act = fleet.ActivityTypeDisabledWindowsMDM{}
+		}
+		if err := svc.ds.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
+			return nil, ctxerr.Wrapf(ctx, err, "create activity %s", act.ActivityName())
+		}
+	}
+
 	return obfuscatedAppConfig, nil
 }
 

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -5072,6 +5072,7 @@ func (s *integrationMDMTestSuite) TestAppConfigMicrosoftMDM() {
   }`), http.StatusOK, &acResp)
 	assert.True(t, acResp.MDM.MicrosoftEnabledAndConfigured)
 	assert.True(t, acResp.MDMEnabled)
+	s.lastActivityOfTypeMatches(fleet.ActivityTypeEnabledWindowsMDM{}.ActivityName(), `{}`, 0)
 
 	// get the orbit config for each host, verify that only the expected ones
 	// receive the "needs enrollment to Microsoft MDM" notification.
@@ -5093,6 +5094,7 @@ func (s *integrationMDMTestSuite) TestAppConfigMicrosoftMDM() {
 		"mdm": { "windows_enabled_and_configured": false }
   }`), http.StatusOK, &acResp)
 	assert.False(t, acResp.MDM.MicrosoftEnabledAndConfigured)
+	s.lastActivityOfTypeMatches(fleet.ActivityTypeDisabledWindowsMDM{}.ActivityName(), `{}`, 0)
 }
 
 func (s *integrationMDMTestSuite) TestValidDiscoveryRequest() {


### PR DESCRIPTION
#12288 (partial implementation of the ticket, per-host activities are not implemented yet, see https://github.com/fleetdm/fleet/issues/12288#issuecomment-1609633452)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
