### PR TITLE
Website: update meta descriptions

### DIFF
--- a/website/api/controllers/articles/view-articles.js
+++ b/website/api/controllers/articles/view-articles.js
@@ -51,7 +51,7 @@ module.exports = {
     }
 
     let pageTitleForMeta = 'Fleet blog | Fleet for osquery';
-    let pageDescriptionForMeta = 'Read the latest articles written by Fleet';
+    let pageDescriptionForMeta = 'Read the latest articles written by Fleet.';
     // Create a currentSection variable, this will be used to highlight the header dropdown that this article category lives under.
     // There are three possible values for this (documentation, community, and platform), so we'll default to the one with the most article categories (community) and set the value to another section if needed.
     // If the category is deploy, guides, or releases, currentSection will be set to 'documentation', and if the category is 'success-stories', currentSection will be set to 'platform'.
@@ -93,7 +93,7 @@ module.exports = {
         break;
       case 'podcasts':
         pageTitleForMeta = 'Podcasts | Fleet for osquery';
-        pageDescriptionForMeta = 'Listen to the Future of Device Management podcast';
+        pageDescriptionForMeta = 'Listen to the Future of Device Management podcast.';
         break;
     }
 

--- a/website/api/controllers/articles/view-articles.js
+++ b/website/api/controllers/articles/view-articles.js
@@ -66,7 +66,7 @@ module.exports = {
         break;
       case 'deploy':
         pageTitleForMeta = 'Deployment guides | Fleet for osquery';
-        pageDescriptionForMeta = 'Learn more about how to deploy Fleet.';
+        pageDescriptionForMeta = 'Learn how to deploy Fleet on a variety of production environments.';
         currentSection = 'documentation';
         break;
       case 'releases':

--- a/website/api/controllers/articles/view-articles.js
+++ b/website/api/controllers/articles/view-articles.js
@@ -76,7 +76,7 @@ module.exports = {
         break;
       case 'guides':
         pageTitleForMeta = 'Guides | Fleet for osquery';
-        pageDescriptionForMeta = 'Learn how to use Fleet to accomplish your goals.';
+        pageDescriptionForMeta = 'A collection of how-to guides for Fleet and osquery.';
         currentSection = 'documentation';
         break;
       case 'securing':

--- a/website/api/controllers/articles/view-articles.js
+++ b/website/api/controllers/articles/view-articles.js
@@ -71,7 +71,7 @@ module.exports = {
         break;
       case 'releases':
         pageTitleForMeta = 'Releases | Fleet for osquery';
-        pageDescriptionForMeta = 'Read about the latest release of Fleet.';
+        pageDescriptionForMeta = 'Fleet releases new and updated features every three weeks. Read about the latest product improvements here.';
         currentSection = 'documentation';
         break;
       case 'guides':

--- a/website/api/controllers/articles/view-articles.js
+++ b/website/api/controllers/articles/view-articles.js
@@ -49,18 +49,54 @@ module.exports = {
         }
       });
     }
-    // Set a currentSection variable for the website header based on how the articles category page is linked to in the header navigation dropdown menus.
-    let currentSection;
-    if(category === 'success-stories'){
-      // If the category is success-stories, highlight the "Platform" dropdown.
-      currentSection = 'platform';
-    } else if(_.contains(['deploy','guides','releases'], category)) {
-      // If the category is deploy, guides, or release, highlight the "Documentation" dropdown.
-      currentSection = 'documentation';
-    } else {
-      // If the category is anything else, highlight the "Community" dropdown.
-      currentSection = 'community';
+
+    let pageTitleForMeta = 'Fleet blog | Fleet for osquery';
+    let pageDescriptionForMeta = 'Read the latest articles written by Fleet';
+    // Create a currentSection variable, this will be used to highlight the header dropdown that this article category lives under.
+    // There are three possible values for this (docuementation, community, and platform), so we'll default to the one with the most article categories (community), and set the value to another section if needed.
+    // If the category is deploy, guides, or releases, currentSection will be set to 'documentation', and if the category is 'success-stories', currentSection will be set to 'platform'.
+    let currentSection = 'community';
+
+    // Set a pageTitleForMeta, pageDescriptionForMeta, and currentSection variable based on the article category.
+    switch(category) {
+      case 'success-stories':
+        pageTitleForMeta = 'Success stories | Fleet for osquery';
+        pageDescriptionForMeta = 'Read about how others are using Fleet and osquery.';
+        currentSection = 'platform';
+        break;
+      case 'deploy':
+        pageTitleForMeta = 'Deployment guides | Fleet for osquery';
+        pageDescriptionForMeta = 'Learn more about how to deploy Fleet.';
+        currentSection = 'documentation';
+        break;
+      case 'releases':
+        pageTitleForMeta = 'Releases | Fleet for osquery';
+        pageDescriptionForMeta = 'Read about the latest release of Fleet.';
+        currentSection = 'documentation';
+        break;
+      case 'guides':
+        pageTitleForMeta = 'Guides | Fleet for osquery';
+        pageDescriptionForMeta = 'Learn how to use Fleet to accomplish your goals.';
+        currentSection = 'documentation';
+        break;
+      case 'securing':
+        pageTitleForMeta = 'Security articles | Fleet for osquery';
+        pageDescriptionForMeta = 'Learn more about how we secure Fleet.';
+        break;
+      case 'engineering':
+        pageTitleForMeta = 'Engineering articles | Fleet for osquery';
+        pageDescriptionForMeta = 'Read about engineering at Fleet and beyond.';
+        break;
+      case 'announcements':
+        pageTitleForMeta = 'Announcements | Fleet for osquery';
+        pageDescriptionForMeta = 'Read the latest news from Fleet.';
+        break;
+      case 'podcasts':
+        pageTitleForMeta = 'Podcasts | Fleet for osquery';
+        pageDescriptionForMeta = 'Listen to the Future of Device Management podcast';
+        break;
     }
+
 
     return {
       path: require('path'),
@@ -69,6 +105,8 @@ module.exports = {
       markdownPages: sails.config.builtStaticContent.markdownPages,
       compiledPagePartialsAppPath: sails.config.builtStaticContent.compiledPagePartialsAppPath,
       currentSection,
+      pageTitleForMeta,
+      pageDescriptionForMeta,
     };
 
   }

--- a/website/api/controllers/articles/view-articles.js
+++ b/website/api/controllers/articles/view-articles.js
@@ -53,7 +53,7 @@ module.exports = {
     let pageTitleForMeta = 'Fleet blog | Fleet for osquery';
     let pageDescriptionForMeta = 'Read the latest articles written by Fleet';
     // Create a currentSection variable, this will be used to highlight the header dropdown that this article category lives under.
-    // There are three possible values for this (docuementation, community, and platform), so we'll default to the one with the most article categories (community), and set the value to another section if needed.
+    // There are three possible values for this (documentation, community, and platform), so we'll default to the one with the most article categories (community) and set the value to another section if needed.
     // If the category is deploy, guides, or releases, currentSection will be set to 'documentation', and if the category is 'success-stories', currentSection will be set to 'platform'.
     let currentSection = 'community';
 

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -289,7 +289,7 @@ module.exports.routes = {
     action: 'view-support',
     locals: {
       pageTitleForMeta: 'Support | Fleet for osquery',
-      pageDescriptionForMeta: 'Learn how to get support for Fleet. Find community resources, report a bug, suggest a new feature, or ask us a question.',
+      pageDescriptionForMeta: 'Ask a question, chat with other engineers, or get in touch with the Fleet team.',
       currentSection: 'documentation',
     }
   },

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -171,6 +171,8 @@ module.exports.routes = {
     action: 'try-fleet/view-register',
     locals: {
       layout: 'layouts/layout-sandbox',
+      pageTitleForMeta: 'Fleet Sandbox | Fleet for osquery',
+      pageDescriptionForMeta: 'Fleet Sandbox - The fastest way to test Fleet. Get up and running in minutes to try out Fleet.',
     }
   },
 
@@ -178,6 +180,8 @@ module.exports.routes = {
     action: 'try-fleet/view-sandbox-login',
     locals: {
       layout: 'layouts/layout-sandbox',
+      pageTitleForMeta: 'Log in to Fleet Sandbox | Fleet for osquery',
+      pageDescriptionForMeta: 'Log in to Fleet Sandbox.',
     }
   },
 
@@ -243,7 +247,7 @@ module.exports.routes = {
     action: 'view-fleet-mdm',
     locals: {
       pageTitleForMeta: 'Device management | Fleet for osquery',
-      pageDescriptionForMeta: 'Learn about upcoming features and join the Fleet MDM beta today.',
+      pageDescriptionForMeta: 'Read about Fleet\'s device management features.',
       currentSection: 'platform',
     }
   },
@@ -281,7 +285,14 @@ module.exports.routes = {
     }
   },
 
-  'GET /support': { action: 'view-support' },
+  'GET /support': {
+    action: 'view-support',
+    locals: {
+      pageTitleForMeta: 'Support | Fleet for osquery',
+      pageDescriptionForMeta: 'Learn how to get support for Fleet. Find community resources, report a bug, suggest a new feature, or ask us a question.',
+      currentSection: 'documentation',
+    }
+  },
 
 
   //  ╦╔╦╗╔═╗╔═╗╦╔╗╔╔═╗  ┌─┬  ┌─┐┌┐┌┌┬┐┬┌┐┌┌─┐  ┌─┐┌─┐┌─┐┌─┐┌─┐─┐

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -247,7 +247,7 @@ module.exports.routes = {
     action: 'view-fleet-mdm',
     locals: {
       pageTitleForMeta: 'Device management | Fleet for osquery',
-      pageDescriptionForMeta: 'Read about Fleet\'s device management features.',
+      pageDescriptionForMeta: 'GitOps-driven MDM. Automate the management of your fleet of devices with increased visibility, control, and improved stability.',
       currentSection: 'platform',
     }
   },


### PR DESCRIPTION
Closes: #12492
closes: #12494

Changes:
- Added meta descriptions and titles to our article category pages (e.g., fleetdm.com/releases)
- Added meta description and title to the /support, /try-fleet/register, and /try-fleet/login
- Updated the meta description on /device-management