### PR TITLE
Consider an empty EULA pdf file the same as an invalid one, returning 400 Bad Request

### DIFF
--- a/changes/bug-12403-fix-post-eula-status-code
+++ b/changes/bug-12403-fix-post-eula-status-code
@@ -1,0 +1,1 @@
+* Fixed a bug where an empty file uploaded to `POST /api/latest/fleet/mdm/apple/setup/eula` resulted in a 500, now returns a 400 Bad Request.

--- a/pkg/file/pdf.go
+++ b/pkg/file/pdf.go
@@ -16,7 +16,9 @@ var pdfMagic = []byte{0x25, 0x50, 0x44, 0x46}
 func CheckPDF(pdf io.Reader) error {
 	buf := make([]byte, len(pdfMagic))
 	if _, err := io.ReadFull(pdf, buf); err != nil {
-		if errors.Is(err, io.ErrUnexpectedEOF) {
+		// ReadFull returns ErrUnexpectedEOF if it can't read enough bytes, or EOF
+		// if it cannot read a single byte.
+		if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
 			return ErrInvalidType
 		}
 		return fmt.Errorf("reading magic bytes: %w", err)

--- a/pkg/file/pdf_test.go
+++ b/pkg/file/pdf_test.go
@@ -12,9 +12,13 @@ func TestCheckPDF(t *testing.T) {
 		in     []byte
 		outErr string
 	}{
-		{[]byte{}, "reading magic bytes: EOF"},
+		{[]byte{}, ErrInvalidType.Error()},
 		{[]byte("--"), ErrInvalidType.Error()},
 		{[]byte("invalid"), ErrInvalidType.Error()},
+		{[]byte("%"), ErrInvalidType.Error()},
+		{[]byte("%P"), ErrInvalidType.Error()},
+		{[]byte("%PD"), ErrInvalidType.Error()},
+		{[]byte("%PDF"), ""},
 		{[]byte("%PDF-"), ""},
 		{[]byte("%PDF-1"), ""},
 		{[]byte("%PDF-2"), ""},

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -3573,7 +3573,9 @@ func (s *integrationMDMTestSuite) TestEULA() {
 	s.DoJSON("GET", "/api/latest/fleet/mdm/apple/setup/eula/metadata", nil, http.StatusNotFound, &metadataResp)
 
 	// trying to upload a file that is not a PDF fails
-	s.uploadEULA(&fleet.MDMAppleEULA{Bytes: []byte("should-fail"), Name: "should-fail.pdf"}, http.StatusBadRequest, "")
+	s.uploadEULA(&fleet.MDMAppleEULA{Bytes: []byte("should-fail"), Name: "should-fail.pdf"}, http.StatusBadRequest, "invalid file type")
+	// trying to upload an empty file fails
+	s.uploadEULA(&fleet.MDMAppleEULA{Bytes: []byte{}, Name: "should-fail.pdf"}, http.StatusBadRequest, "invalid file type")
 
 	// admin is able to upload a new EULA
 	s.uploadEULA(&fleet.MDMAppleEULA{Bytes: pdfBytes, Name: pdfName}, http.StatusOK, "")


### PR DESCRIPTION
#12403 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
