### PR TITLE
UI: Allow admins to edit their own accounts

### DIFF
--- a/changes/10729-allow-self-edit
+++ b/changes/10729-allow-self-edit
@@ -1,0 +1,1 @@
+* Allow admins to edit their own user information

--- a/docs/Using-Fleet/Permissions.md
+++ b/docs/Using-Fleet/Permissions.md
@@ -94,7 +94,7 @@ GitOps is an API-only and write-only role that can be used on CI/CD pipelines.
 
 \*** Applies only to [Fleet REST API](https://fleetdm.com/docs/using-fleet/rest-api)
 
-\**** Global admins can neither demote their own role nor change themselves to be a Team-specific user.
+\**** Global admins can neither demote their own role nor change themselves to be a team-specific user.
 ## Team member permissions
 
 `Applies only to Fleet Premium`

--- a/docs/Using-Fleet/Permissions.md
+++ b/docs/Using-Fleet/Permissions.md
@@ -94,7 +94,7 @@ GitOps is an API-only and write-only role that can be used on CI/CD pipelines.
 
 \*** Applies only to [Fleet REST API](https://fleetdm.com/docs/using-fleet/rest-api)
 
-\**** Global admins can neither demote their own role nor change themselves to be a team-specific user.
+\**** Global admins can neither demote their own roles nor change themselves to be team-specific users.
 ## Team member permissions
 
 `Applies only to Fleet Premium`

--- a/docs/Using-Fleet/Permissions.md
+++ b/docs/Using-Fleet/Permissions.md
@@ -58,7 +58,7 @@ GitOps is an API-only and write-only role that can be used on CI/CD pipelines.
 | Create, edit, and delete policies for all hosts                                                                                            |          |            | ✅         | ✅    | ✅      |
 | Create, edit, and delete policies for all hosts assigned to team\*                                                                         |          |            | ✅         | ✅    | ✅      |
 | Manage [policy automations](https://fleetdm.com/docs/using-fleet/automations#policy-automations)                                           |          |            |            | ✅    | ✅      |
-| Create, edit, view, and delete users                                                                                                       |          |            |            | ✅    |         |
+| Create, edit, view, and delete users\****                                                                                                       |          |            |            | ✅    |         |
 | Add and remove team members\*                                                                                                              |          |            |            | ✅    | ✅      |
 | Create, edit, and delete teams\*                                                                                                           |          |            |            | ✅    | ✅      |
 | Create, edit, and delete [enroll secrets](https://fleetdm.com/docs/deploying/faq#when-do-i-need-to-deploy-a-new-enroll-secret-to-my-hosts) |          |            | ✅         | ✅    | ✅      |
@@ -94,6 +94,7 @@ GitOps is an API-only and write-only role that can be used on CI/CD pipelines.
 
 \*** Applies only to [Fleet REST API](https://fleetdm.com/docs/using-fleet/rest-api)
 
+\**** Global admins can neither demote their own role nor change themselves to be a Team-specific user.
 ## Team member permissions
 
 `Applies only to Fleet Premium`

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/MembersPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/MembersPage/MembersPage.tsx
@@ -94,7 +94,7 @@ const MembersPage = ({ location, router }: IMembersPageProps): JSX.Element => {
   const toggleRemoveMemberModal = useCallback(
     (user?: IUser) => {
       setShowRemoveMemberModal(!showRemoveMemberModal);
-      user ? setUserToEdit(user) : setUserToEdit(undefined);
+      setUserToEdit(user);
     },
     [showRemoveMemberModal, setShowRemoveMemberModal, setUserToEdit]
   );

--- a/frontend/pages/admin/UserManagementPage/components/EditUserModal/EditUserModal.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/EditUserModal/EditUserModal.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 
 import { ITeam } from "interfaces/team";
-import { IUserFormErrors, UserRole } from "interfaces/user";
+import { IUser, IUserFormErrors } from "interfaces/user";
+import { IInvite } from "interfaces/invite";
 import Modal from "components/Modal";
 import UserForm from "../UserForm";
 import { IFormData } from "../UserForm/UserForm";
@@ -9,19 +10,14 @@ import { IFormData } from "../UserForm/UserForm";
 interface IEditUserModalProps {
   onCancel: () => void;
   onSubmit: (formData: IFormData) => void;
-  defaultName?: string;
-  defaultEmail?: string;
-  defaultGlobalRole?: UserRole | null;
-  defaultTeamRole?: UserRole;
-  defaultTeams?: ITeam[];
+  userToEdit?: IUser | IInvite;
+  currentUser?: IUser;
   availableTeams: ITeam[];
   currentTeam?: ITeam;
   isPremiumTier: boolean;
   smtpConfigured: boolean;
   sesConfigured: boolean;
   canUseSso: boolean; // corresponds to whether SSO is enabled for the organization
-  isSsoEnabled?: boolean; // corresponds to whether SSO is enabled for the individual user
-  isApiOnly?: boolean;
   editUserErrors?: IUserFormErrors;
   isModifiedByGlobalAdmin?: boolean | false;
   isInvitePending?: boolean;
@@ -33,24 +29,23 @@ const baseClass = "edit-user-modal";
 const EditUserModal = ({
   onCancel,
   onSubmit,
-  defaultName,
-  defaultEmail,
-  defaultGlobalRole,
-  defaultTeamRole,
-  defaultTeams,
+  userToEdit,
+  currentUser,
   availableTeams,
   isPremiumTier,
   smtpConfigured,
   sesConfigured,
   canUseSso,
-  isSsoEnabled,
-  isApiOnly,
   currentTeam,
   editUserErrors,
   isModifiedByGlobalAdmin,
   isInvitePending,
   isUpdatingUsers,
 }: IEditUserModalProps): JSX.Element => {
+  const isUser = (userOrInvite: IUser | IInvite): userOrInvite is IUser => {
+    return (userToEdit as IInvite).invited_by === undefined;
+  };
+
   return (
     <Modal
       title="Edit user"
@@ -59,21 +54,25 @@ const EditUserModal = ({
     >
       <UserForm
         createOrEditUserErrors={editUserErrors}
-        defaultName={defaultName}
-        defaultEmail={defaultEmail}
-        defaultGlobalRole={defaultGlobalRole}
-        defaultTeamRole={defaultTeamRole}
-        defaultTeams={defaultTeams}
+        userToEditId={userToEdit?.id}
+        currentUserId={currentUser?.id}
+        defaultName={userToEdit?.name}
+        defaultEmail={userToEdit?.email}
+        defaultGlobalRole={userToEdit?.global_role || null}
+        defaultTeamRole={
+          (!!userToEdit && isUser(userToEdit) && userToEdit?.role) || undefined
+        }
+        defaultTeams={userToEdit?.teams}
         onCancel={onCancel}
         onSubmit={onSubmit}
         availableTeams={availableTeams}
-        submitText={"Save"}
+        submitText="Save"
         isPremiumTier={isPremiumTier}
         smtpConfigured={smtpConfigured}
         sesConfigured={sesConfigured}
         canUseSso={canUseSso}
-        isSsoEnabled={isSsoEnabled}
-        isApiOnly={isApiOnly}
+        isSsoEnabled={userToEdit?.sso_enabled}
+        isApiOnly={userToEdit?.api_only || false}
         isModifiedByGlobalAdmin={isModifiedByGlobalAdmin}
         isInvitePending={isInvitePending}
         currentTeam={currentTeam}

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -5,7 +5,6 @@ import PATHS from "router/paths";
 import { NotificationContext } from "context/notification";
 import { ITeam } from "interfaces/team";
 import { IUserFormErrors, UserRole } from "interfaces/user";
-import { IRole } from "interfaces/role";
 
 import Button from "components/buttons/Button";
 import validatePresence from "components/forms/validators/validate_presence";

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -122,6 +122,8 @@ const UserForm = ({
     setErrors(createOrEditUserErrors);
   }, [createOrEditUserErrors]);
 
+  const editingSelf = userToEditId === currentUserId;
+
   const onInputChange = (formField: string): ((value: string) => void) => {
     return (value: string) => {
       setErrors({
@@ -376,9 +378,54 @@ const UserForm = ({
     );
   }
 
+  const renderTeamGlobalOptions = () => {
+    return (
+      <>
+        {isPremiumTier ? (
+          <div className={`${baseClass}__selected-teams-container`}>
+            <div className={`${baseClass}__team-radios`}>
+              <p className={`${baseClass}__label`}>Team</p>
+              {isModifiedByGlobalAdmin ? (
+                <>
+                  <Radio
+                    className={`${baseClass}__radio-input`}
+                    label={"Global user"}
+                    id={"global-user"}
+                    checked={isGlobalUser}
+                    value={UserTeamType.GlobalUser}
+                    name={"userTeamType"}
+                    onChange={onIsGlobalUserChange}
+                  />
+                  <Radio
+                    className={`${baseClass}__radio-input`}
+                    label={"Assign teams"}
+                    id={"assign-teams"}
+                    checked={!isGlobalUser}
+                    value={UserTeamType.AssignTeams}
+                    name={"userTeamType"}
+                    onChange={onIsGlobalUserChange}
+                    disabled={!availableTeams.length}
+                  />
+                </>
+              ) : (
+                <p className="current-team">
+                  {currentTeam ? currentTeam.name : ""}
+                </p>
+              )}
+            </div>
+            <div className={`${baseClass}__teams-form-container`}>
+              {isGlobalUser ? renderGlobalRoleForm() : renderTeamsForm()}
+            </div>
+          </div>
+        ) : (
+          renderGlobalRoleForm()
+        )}
+      </>
+    );
+  };
+
   return (
     <form className={baseClass} autoComplete="off">
-      {/* {baseError && <div className="form__base-error">{baseError}</div>} */}
       <InputField
         label="Full name"
         autofocus
@@ -429,25 +476,32 @@ const UserForm = ({
             </div>
           </div>
         )}
-      <div className={`${baseClass}__sso-input`}>
-        <Checkbox
-          name="sso_enabled"
-          onChange={onCheckboxChange("sso_enabled")}
-          value={canUseSso && formData.sso_enabled}
-          disabled={!canUseSso}
-          wrapperClassName={`${baseClass}__invite-admin`}
-          tooltip={`
+
+      {/* Enable SSO */}
+      {/* Gated until back end support is implemented */}
+      {!editingSelf && (
+        <div className={`${baseClass}__sso-input`}>
+          <Checkbox
+            name="sso_enabled"
+            onChange={onCheckboxChange("sso_enabled")}
+            value={canUseSso && formData.sso_enabled}
+            disabled={!canUseSso}
+            wrapperClassName={`${baseClass}__invite-admin`}
+            tooltip={`
               Enabling single sign-on for a user requires that SSO is first enabled for the organization.
               <br /><br />
               Users with Admin role can configure SSO in <strong>Settings &gt; Organization settings</strong>.
             `}
-        >
-          Enable single sign-on
-        </Checkbox>
-        <p className={`${baseClass}__sso-input sublabel`}>
-          Password authentication will be disabled for this user.
-        </p>
-      </div>
+          >
+            Enable single sign-on
+          </Checkbox>
+          <p className={`${baseClass}__sso-input sublabel`}>
+            Password authentication will be disabled for this user.
+          </p>
+        </div>
+      )}
+
+      {/* New User options */}
       {isNewUser && (
         <div className={`${baseClass}__new-user-container`}>
           <div className={`${baseClass}__new-user-radios`}>
@@ -518,44 +572,9 @@ const UserForm = ({
             )}
         </div>
       )}
-      {isPremiumTier && (
-        <div className={`${baseClass}__selected-teams-container`}>
-          <div className={`${baseClass}__team-radios`}>
-            <p className={`${baseClass}__label`}>Team</p>
-            {isModifiedByGlobalAdmin ? (
-              <>
-                <Radio
-                  className={`${baseClass}__radio-input`}
-                  label={"Global user"}
-                  id={"global-user"}
-                  checked={isGlobalUser}
-                  value={UserTeamType.GlobalUser}
-                  name={"userTeamType"}
-                  onChange={onIsGlobalUserChange}
-                />
-                <Radio
-                  className={`${baseClass}__radio-input`}
-                  label={"Assign teams"}
-                  id={"assign-teams"}
-                  checked={!isGlobalUser}
-                  value={UserTeamType.AssignTeams}
-                  name={"userTeamType"}
-                  onChange={onIsGlobalUserChange}
-                  disabled={!availableTeams.length}
-                />
-              </>
-            ) : (
-              <p className="current-team">
-                {currentTeam ? currentTeam.name : ""}
-              </p>
-            )}
-          </div>
-          <div className={`${baseClass}__teams-form-container`}>
-            {isGlobalUser ? renderGlobalRoleForm() : renderTeamsForm()}
-          </div>
-        </div>
-      )}
-      {!isPremiumTier && renderGlobalRoleForm()}
+
+      {/*  Team / Global Assignments */}
+      {!editingSelf && renderTeamGlobalOptions()}
 
       <div className="modal-cta-wrap">
         <Button

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -40,6 +40,7 @@ export interface IFormData {
   name: string;
   newUserType?: NewUserType | null;
   password?: string | null;
+  new_password?: string | null;
   sso_enabled?: boolean;
   global_role: UserRole | null;
   teams: ITeam[];
@@ -53,6 +54,7 @@ interface ICreateUserFormProps {
   onCancel: () => void;
   onSubmit: (formData: IFormData) => void;
   submitText: string;
+  userToEditId?: number;
   defaultName?: string;
   defaultEmail?: string;
   currentUserId?: number;
@@ -79,6 +81,7 @@ const UserForm = ({
   onCancel,
   onSubmit,
   submitText,
+  userToEditId,
   defaultName,
   defaultEmail,
   currentUserId,
@@ -102,7 +105,7 @@ const UserForm = ({
   const { renderFlash } = useContext(NotificationContext);
 
   const [errors, setErrors] = useState<any>(createOrEditUserErrors);
-  const [formData, setFormData] = useState<any>({
+  const [formData, setFormData] = useState<IFormData>({
     email: defaultEmail || "",
     name: defaultName || "",
     newUserType: isNewUser ? NewUserType.AdminCreated : null,
@@ -153,7 +156,7 @@ const UserForm = ({
     });
   };
 
-  const onGlobalUserRoleChange = (value: string): void => {
+  const onGlobalUserRoleChange = (value: UserRole): void => {
     setFormData({
       ...formData,
       global_role: value,

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/_styles.scss
@@ -9,7 +9,8 @@
     margin-bottom: $pad-large;
 
     .fleet-checkbox {
-      margin-top: 5px;
+      display: flex;
+      align-items: center;
 
       &__label {
         font-size: $x-small;

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
@@ -433,10 +433,7 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
 
     return (
       <EditUserModal
-        defaultEmail={userData?.email}
-        defaultName={userData?.name}
-        defaultGlobalRole={userData?.global_role}
-        defaultTeams={userData?.teams}
+        userToEdit={userData}
         onCancel={toggleEditUserModal}
         onSubmit={onEditUser}
         availableTeams={teams || []}
@@ -444,8 +441,6 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
         smtpConfigured={config?.smtp_settings.configured || false}
         sesConfigured={config?.email?.backend === "ses" || false}
         canUseSso={config?.sso_settings.enable_sso || false}
-        isSsoEnabled={userData?.sso_enabled}
-        isApiOnly={userData?.api_only || false}
         isModifiedByGlobalAdmin
         isInvitePending={userEditing.type === "invite"}
         editUserErrors={editUserErrors}

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
@@ -434,6 +434,7 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
     return (
       <EditUserModal
         userToEdit={userData}
+        currentUser={currentUser ?? undefined}
         onCancel={toggleEditUserModal}
         onSubmit={onEditUser}
         availableTeams={teams || []}

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
@@ -240,7 +240,7 @@ const generateActionDropdownOptions = (
     {
       label: "Edit",
       disabled: false,
-      value: isCurrentUser ? "editMyAccount" : "edit",
+      value: "edit",
     },
     {
       label: "Require password reset",


### PR DESCRIPTION
## Addresses frontend portion of #10729

- Allow admins to access the Edit user modal for their own account, with SSO <–> password auth toggle, Global/Teams assignment, and Role management disabled :

### Admin with SSO auth (can't change to PW):
<img width="602" alt="Screenshot 2023-06-30 at 10 48 38 AM" src="https://github.com/fleetdm/fleet/assets/61553566/72c72fbf-82e3-4ed1-8a8f-3b809880c3ed">

### Admin with PW auth (can't change to SSO):
<img width="638" alt="Screenshot 2023-06-30 at 10 44 31 AM" src="https://github.com/fleetdm/fleet/assets/61553566/2e852dc3-3de4-457d-ae3c-ba3315ce40b8">

- Update permissions docs to reflect these new capabilities

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`
- [ ] Manual QA for all new/changed functionality - TBD once backend portion of the issue is completed