### PR TITLE
lowercase DisplayName attributes when reading SSO response

### DIFF
--- a/changes/sso-display-name-case
+++ b/changes/sso-display-name-case
@@ -1,0 +1,1 @@
+- Ignore casing in SAML response for display name. For example the display name attribute can be provided now as `displayname` or `displayName`.

--- a/server/sso/authorization_response.go
+++ b/server/sso/authorization_response.go
@@ -6,6 +6,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 )
@@ -108,7 +109,7 @@ func (r resp) UserID() string {
 func (r resp) UserDisplayName() string {
 	if r.response != nil {
 		for _, attr := range r.response.Assertion.AttributeStatement.Attributes {
-			if _, ok := validDisplayNameAttrs[attr.Name]; ok {
+			if _, ok := validDisplayNameAttrs[strings.ToLower(attr.Name)]; ok {
 				for _, v := range attr.AttributeValues {
 					if v.Value != "" {
 						return v.Value

--- a/server/sso/authorization_response_test.go
+++ b/server/sso/authorization_response_test.go
@@ -508,6 +508,7 @@ func TestUserDisplayName(t *testing.T) {
 	}{
 		{"name", []AttributeValue{{Value: "Name Surname"}}, "Name Surname"},
 		{"displayname", []AttributeValue{{Value: "Name Surname"}}, "Name Surname"},
+		{"displayName", []AttributeValue{{Value: "Name Surname"}}, "Name Surname"},
 		{"cn", []AttributeValue{{Value: "Name Surname"}}, "Name Surname"},
 		{"urn:oid:2.5.4.3", []AttributeValue{{Value: "Name Surname"}}, "Name Surname"},
 		{"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name", []AttributeValue{{Value: "Name Surname"}}, "Name Surname"},


### PR DESCRIPTION
this is to accommodate providers like [Okta][1] that send the user's full name as an attribute named `displayName`

[1]: https://developer.okta.com/docs/reference/api/users/#default-profile-properties

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
