### PR TITLE
Website: Update documentation scroll event handler

### DIFF
--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -265,27 +265,31 @@ parasails.registerPage('basic-documentation', {
     },
 
     handleScrollingInDocumentation: function () {
-      let rightNavBar = document.querySelector('div[purpose="right-sidebar"]');
-      let backToTopButton = document.querySelector('div[purpose="back-to-top-button"]');
-      let scrollTop = window.pageYOffset;
-      let windowHeight = window.innerHeight;
+      if(!this.isDocsLandingPage) {
+        let rightNavBar = document.querySelector('div[purpose="right-sidebar"]');
+        let backToTopButton = document.querySelector('div[purpose="back-to-top-button"]');
+        let scrollTop = window.pageYOffset;
+        let windowHeight = window.innerHeight;
 
-      if (rightNavBar) {
-        if (scrollTop > this.scrollDistance && scrollTop > windowHeight * 1.5) {
-          rightNavBar.classList.add('header-hidden', 'scrolled');
-        } else if (scrollTop === 0) {
-          rightNavBar.classList.remove('header-hidden', 'scrolled');
-        } else {
-          rightNavBar.classList.remove('header-hidden');
+        if (rightNavBar) {
+          if (scrollTop > this.scrollDistance && scrollTop > windowHeight * 1.5) {
+            rightNavBar.classList.add('header-hidden', 'scrolled');
+          } else if (scrollTop === 0) {
+            rightNavBar.classList.remove('header-hidden', 'scrolled');
+          } else {
+            rightNavBar.classList.remove('header-hidden');
+          }
         }
-      }
-      if (backToTopButton && scrollTop > 2500) {
-        backToTopButton.classList.add('show');
-      } else if (scrollTop === 0) {
-        backToTopButton.classList.remove('show');
-      }
+        if (backToTopButton){
+          if (scrollTop > 2500) {
+            backToTopButton.classList.add('show');
+          } else if (scrollTop === 0) {
+            backToTopButton.classList.remove('show');
+          }
+        }
 
-      this.scrollDistance = scrollTop;
+        this.scrollDistance = scrollTop;
+      }
     },
     clickScrollToTop: function() {
       window.scrollTo({

--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -267,7 +267,6 @@ parasails.registerPage('basic-documentation', {
     },
 
     handleScrollingInDocumentation: function () {
-      // Don't show the back to top button on the docs landing page.
       let rightNavBar = document.querySelector('div[purpose="right-sidebar"]');
       let backToTopButton = document.querySelector('div[purpose="back-to-top-button"]');
       let scrollTop = window.pageYOffset;

--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -265,12 +265,13 @@ parasails.registerPage('basic-documentation', {
     },
 
     handleScrollingInDocumentation: function () {
+      // Don't show the back to top button on the docs landing page.
       if(!this.isDocsLandingPage) {
         let rightNavBar = document.querySelector('div[purpose="right-sidebar"]');
         let backToTopButton = document.querySelector('div[purpose="back-to-top-button"]');
         let scrollTop = window.pageYOffset;
         let windowHeight = window.innerHeight;
-
+        // If the right nav bar exists, add and remove a class based on the current scroll position.
         if (rightNavBar) {
           if (scrollTop > this.scrollDistance && scrollTop > windowHeight * 1.5) {
             rightNavBar.classList.add('header-hidden', 'scrolled');
@@ -280,6 +281,7 @@ parasails.registerPage('basic-documentation', {
             rightNavBar.classList.remove('header-hidden');
           }
         }
+        // If back to top button exists, add and remove a class based on the current scroll position.
         if (backToTopButton){
           if (scrollTop > 2500) {
             backToTopButton.classList.add('show');

--- a/website/assets/js/pages/docs/basic-documentation.page.js
+++ b/website/assets/js/pages/docs/basic-documentation.page.js
@@ -77,7 +77,9 @@ parasails.registerPage('basic-documentation', {
       return pagesBySectionSlug;
     })();
     // Adding a scroll event listener for scrolling sidebars and showing the back to top button.
-    window.addEventListener('scroll', this.handleScrollingInDocumentation);
+    if(!this.isDocsLandingPage){
+      window.addEventListener('scroll', this.handleScrollingInDocumentation);
+    }
   },
 
   mounted: async function() {
@@ -266,32 +268,29 @@ parasails.registerPage('basic-documentation', {
 
     handleScrollingInDocumentation: function () {
       // Don't show the back to top button on the docs landing page.
-      if(!this.isDocsLandingPage) {
-        let rightNavBar = document.querySelector('div[purpose="right-sidebar"]');
-        let backToTopButton = document.querySelector('div[purpose="back-to-top-button"]');
-        let scrollTop = window.pageYOffset;
-        let windowHeight = window.innerHeight;
-        // If the right nav bar exists, add and remove a class based on the current scroll position.
-        if (rightNavBar) {
-          if (scrollTop > this.scrollDistance && scrollTop > windowHeight * 1.5) {
-            rightNavBar.classList.add('header-hidden', 'scrolled');
-          } else if (scrollTop === 0) {
-            rightNavBar.classList.remove('header-hidden', 'scrolled');
-          } else {
-            rightNavBar.classList.remove('header-hidden');
-          }
+      let rightNavBar = document.querySelector('div[purpose="right-sidebar"]');
+      let backToTopButton = document.querySelector('div[purpose="back-to-top-button"]');
+      let scrollTop = window.pageYOffset;
+      let windowHeight = window.innerHeight;
+      // If the right nav bar exists, add and remove a class based on the current scroll position.
+      if (rightNavBar) {
+        if (scrollTop > this.scrollDistance && scrollTop > windowHeight * 1.5) {
+          rightNavBar.classList.add('header-hidden', 'scrolled');
+        } else if (scrollTop === 0) {
+          rightNavBar.classList.remove('header-hidden', 'scrolled');
+        } else {
+          rightNavBar.classList.remove('header-hidden');
         }
-        // If back to top button exists, add and remove a class based on the current scroll position.
-        if (backToTopButton){
-          if (scrollTop > 2500) {
-            backToTopButton.classList.add('show');
-          } else if (scrollTop === 0) {
-            backToTopButton.classList.remove('show');
-          }
-        }
-
-        this.scrollDistance = scrollTop;
       }
+      // If back to top button exists, add and remove a class based on the current scroll position.
+      if (backToTopButton){
+        if (scrollTop > 2500) {
+          backToTopButton.classList.add('show');
+        } else if (scrollTop === 0) {
+          backToTopButton.classList.remove('show');
+        }
+      }
+      this.scrollDistance = scrollTop;
     },
     clickScrollToTop: function() {
       window.scrollTo({


### PR DESCRIPTION
Changes: 
- Updated the event handler for the sticky right-side navigation and the "Back to the top" button on docs pages only to run if those elements exist, and disabled the event handler on the documentation landing page.