### PR TITLE
ensure ds.TeamByName returns a 4xx response if no team is found

### DIFF
--- a/cmd/fleetctl/apply_test.go
+++ b/cmd/fleetctl/apply_test.go
@@ -128,7 +128,7 @@ func TestApplyTeamSpecs(t *testing.T) {
 	ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
 		team, ok := teamsByName[name]
 		if !ok {
-			return nil, sql.ErrNoRows
+			return nil, &notFoundError{}
 		}
 		return team, nil
 	}
@@ -1344,11 +1344,7 @@ func TestApplyMacosSetup(t *testing.T) {
 		ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
 			team, ok := teamsByName[name]
 			if !ok {
-				// TeamByName in the real Datastore does not return notFoundError, it
-				// returns ErrNoRows directly, we're a bit inconsistent with that at
-				// the moment. This is important as ApplyTeamSpecs checks if TeamByName
-				// returns an error that wraps ErrNoRows (and not an IsNotFound).
-				return nil, sql.ErrNoRows
+				return nil, &notFoundError{}
 			}
 			clone := *team
 			return &clone, nil
@@ -2052,7 +2048,7 @@ func TestApplySpecs(t *testing.T) {
 		ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
 			team, ok := teamsByName[name]
 			if !ok {
-				return nil, sql.ErrNoRows
+				return nil, &notFoundError{}
 			}
 			return team, nil
 		}

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -3,9 +3,7 @@ package service
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -605,14 +603,6 @@ func (svc *Service) teamByIDOrName(ctx context.Context, id *uint, name *string) 
 	} else if name != nil {
 		tm, err = svc.ds.TeamByName(ctx, *name)
 		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				// this should really be handled in TeamByName so that it returns a
-				// notFound error as is usually the case for this scenario, but
-				// changing it causes a number of test failures that indicates this
-				// might be tricky and even maybe a breaking change in some places. For
-				// now, handling it here.
-				return nil, notFoundError{}
-			}
 			return nil, err
 		}
 	}
@@ -635,7 +625,7 @@ func (svc *Service) checkAuthorizationForTeams(ctx context.Context, specs []*fle
 	for _, spec := range specs {
 		team, err := svc.ds.TeamByName(ctx, spec.Name)
 		if err != nil {
-			if err := ctxerr.Cause(err); err == sql.ErrNoRows {
+			if fleet.IsNotFound(err) {
 				// Can the user create a new team?
 				if err := svc.authz.Authorize(ctx, &fleet.Team{}, fleet.ActionWrite); err != nil {
 					return err
@@ -688,7 +678,7 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 		switch {
 		case err == nil:
 			// OK
-		case ctxerr.Cause(err) == sql.ErrNoRows:
+		case fleet.IsNotFound(err):
 			if spec.Name == "" {
 				return nil, fleet.NewInvalidArgumentError("name", "name may not be empty")
 			}

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -693,7 +693,7 @@ func (ds *Datastore) IngestMDMAppleDevicesFromDEPSync(ctx context.Context, devic
 	if name := appCfg.MDM.AppleBMDefaultTeam; name != "" {
 		team, err := ds.TeamByName(ctx, name)
 		switch {
-		case errors.Is(err, sql.ErrNoRows):
+		case fleet.IsNotFound(err):
 			level.Debug(ds.logger).Log(
 				"msg",
 				"ingesting devices from DEP: unable to find default team assigned in config, the devices won't be assigned to a team",

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -123,6 +124,9 @@ func (ds *Datastore) TeamByName(ctx context.Context, name string) (*fleet.Team, 
 	team := &fleet.Team{}
 
 	if err := sqlx.GetContext(ctx, ds.reader(ctx), team, stmt, name); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ctxerr.Wrap(ctx, notFound("Team").WithName(name))
+		}
 		return nil, ctxerr.Wrap(ctx, err, "select team")
 	}
 

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -3,10 +3,8 @@ package apple_mdm
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"encoding/json"
 	"encoding/xml"
-	"errors"
 	"fmt"
 	"strings"
 	"text/template"
@@ -300,8 +298,7 @@ func (d *DEPService) RunAssigner(ctx context.Context) error {
 	var appleBMTeam *fleet.Team
 	if appCfg.MDM.AppleBMDefaultTeam != "" {
 		tm, err := d.ds.TeamByName(ctx, appCfg.MDM.AppleBMDefaultTeam)
-		// NOTE: TeamByName does NOT return a not found error if it does not exist
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		if err != nil && fleet.IsNotFound(err) {
 			return err
 		}
 		appleBMTeam = tm

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -298,7 +298,7 @@ func (d *DEPService) RunAssigner(ctx context.Context) error {
 	var appleBMTeam *fleet.Team
 	if appCfg.MDM.AppleBMDefaultTeam != "" {
 		tm, err := d.ds.TeamByName(ctx, appCfg.MDM.AppleBMDefaultTeam)
-		if err != nil && fleet.IsNotFound(err) {
+		if err != nil && !fleet.IsNotFound(err) {
 			return err
 		}
 		appleBMTeam = tm

--- a/server/service/global_policies.go
+++ b/server/service/global_policies.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 
@@ -442,11 +441,6 @@ func (svc *Service) checkPolicySpecAuthorization(ctx context.Context, policies [
 			if err != nil {
 				// This is so that the proper HTTP status code is returned
 				svc.authz.SkipAuthorization(ctx)
-
-				if errors.Is(err, sql.ErrNoRows) {
-					return newNotFoundError()
-				}
-
 				return ctxerr.Wrap(ctx, err, "getting team by name")
 			}
 			if err := svc.authz.Authorize(ctx, &fleet.Policy{

--- a/server/service/global_policies_test.go
+++ b/server/service/global_policies_test.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
@@ -16,7 +15,7 @@ func TestCheckPolicySpecAuthorization(t *testing.T) {
 	t.Run("when team not found", func(t *testing.T) {
 		ds := new(mock.Store)
 		ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
-			return nil, sql.ErrNoRows
+			return nil, &notFoundError{}
 		}
 
 		svc, ctx := newTestService(t, ds, nil, nil)
@@ -31,7 +30,7 @@ func TestCheckPolicySpecAuthorization(t *testing.T) {
 		ctx = viewer.NewContext(ctx, viewer.Viewer{User: user})
 
 		actual := svc.ApplyPolicySpecs(ctx, req)
-		var expected *notFoundError
+		var expected fleet.NotFoundError
 
 		require.ErrorAs(t, actual, &expected)
 	})

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -522,6 +522,20 @@ func (s *integrationTestSuite) TestUserRolesSpec() {
 	require.NoError(t, err)
 	require.Len(t, user.Teams, 1)
 	assert.Equal(t, fleet.RoleMaintainer, user.Teams[0].Role)
+
+	spec = []byte(fmt.Sprintf(`
+  roles:
+    %s:
+      global_role: null
+      teams:
+      - role: maintainer
+        team: non-existent
+`,
+		email))
+	userRoleSpec = applyUserRoleSpecsRequest{}
+	err = yaml.Unmarshal(spec, &userRoleSpec.Spec)
+	require.NoError(t, err)
+	s.Do("POST", "/api/latest/fleet/users/roles/spec", &userRoleSpec, http.StatusBadRequest)
 }
 
 func (s *integrationTestSuite) TestGlobalSchedule() {

--- a/server/service/teams_test.go
+++ b/server/service/teams_test.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -262,7 +261,7 @@ func TestApplyTeamSpecs(t *testing.T) {
 		for _, tt := range cases {
 			t.Run(tt.name, func(t *testing.T) {
 				ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
-					return nil, sql.ErrNoRows
+					return nil, &notFoundError{}
 				}
 
 				ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {

--- a/server/service/user_roles.go
+++ b/server/service/user_roles.go
@@ -47,6 +47,12 @@ func (svc *Service) ApplyUserRolesSpecs(ctx context.Context, specs fleet.UsersRo
 		for _, team := range spec.Teams {
 			t, err := svc.ds.TeamByName(ctx, team.Name)
 			if err != nil {
+				if fleet.IsNotFound(err) {
+					return &fleet.BadRequestError{
+						Message:     err.Error(),
+						InternalErr: err,
+					}
+				}
 				return err
 			}
 			teams = append(teams, fleet.UserTeam{


### PR DESCRIPTION
this helps consumer of the datastore method handle the not found scenario better and ensures we always return a 4xx code by default if we can't find a matching team.

seems like calls to this method were special-cased everywhere except in the apply user roles endpoint, where we returned a `500` status code if we couldn't find a team.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
