### PR TITLE
add activity items when a Windows host turns MDM on

### DIFF
--- a/docs/Using-Fleet/Audit-Activities.md
+++ b/docs/Using-Fleet/Audit-Activities.md
@@ -553,7 +553,7 @@ This activity contains the following fields:
 - "host_serial": Serial number of the host.
 - "host_display_name": Display name of the host.
 - "installed_from_dep": Whether the host was enrolled via DEP.
-- "mdm_platform": Used to distinguish between Apple and Microsoft enrollments, can be "apple", "microsoft" or empty. An empty value should be considered as "apple" for backwards compatibility.
+- "mdm_platform": Used to distinguish between Apple and Microsoft enrollments. Can be "apple", "microsoft" or not present. If missing, this value is treated as "apple" for backwards compatibility.
 
 #### Example
 

--- a/docs/Using-Fleet/Audit-Activities.md
+++ b/docs/Using-Fleet/Audit-Activities.md
@@ -553,6 +553,7 @@ This activity contains the following fields:
 - "host_serial": Serial number of the host.
 - "host_display_name": Display name of the host.
 - "installed_from_dep": Whether the host was enrolled via DEP.
+- "mdm_platform": Used to distinguish between Apple and Microsoft enrollments, can be "apple", "microsoft" or empty. An empty value should be considered as "apple" for backwards compatibility.
 
 #### Example
 
@@ -560,7 +561,8 @@ This activity contains the following fields:
 {
   "host_serial": "C08VQ2AXHT96",
   "host_display_name": "MacBookPro16,1 (C08VQ2AXHT96)",
-  "installed_from_dep": true
+  "installed_from_dep": true,
+  "mdm_platform": "apple"
 }
 ```
 

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -82,6 +82,7 @@ export interface IActivityDetails {
   host_display_names?: string[];
   host_ids?: number[];
   installed_from_dep?: boolean;
+  mdm_platform?: "microsoft" | "apple";
   minimum_version?: string;
   deadline?: string;
   profile_name?: string;

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tests.tsx
@@ -754,7 +754,7 @@ describe("Activity Feed", () => {
       type: ActivityType.MdmEnrolled,
       details: {
         mdm_platform: "microsoft",
-        host_serial: "ABCD",
+        host_display_name: "ABCD",
       },
     });
     render(<ActivityItem activity={activity} isPremiumTier />);

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tests.tsx
@@ -764,7 +764,7 @@ describe("Activity Feed", () => {
         console.log(node?.innerHTML);
         return (
           node?.innerHTML ===
-          "<b>Test User </b>Mobile device management (MDM) was turned on for a host with serial number <b>ABCD (manual)</b>."
+          "<b>Test User </b>Mobile device management (MDM) was turned on for <b>ABCD (manual)</b>."
         );
       })
     ).toBeInTheDocument();

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tests.tsx
@@ -708,4 +708,65 @@ describe("Activity Feed", () => {
     expect(screen.queryByText("baz")).toBeNull();
     expect(screen.getByText("Alphas", { exact: false })).toBeInTheDocument();
   });
+
+  it("renders a 'mdm_enrolled' type for apple if mdm_platform is not provided", () => {
+    const activity = createMockActivity({
+      type: ActivityType.MdmEnrolled,
+      details: {
+        host_serial: "ABCD",
+      },
+    });
+    render(<ActivityItem activity={activity} isPremiumTier />);
+
+    expect(
+      screen.getByText((content, node) => {
+        return (
+          node?.innerHTML ===
+          "<b>Test User </b>An end user turned on MDM features for a host with serial number <b>ABCD (manual)</b>."
+        );
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("renders a 'mdm_enrolled' type for apple with all details provided", () => {
+    const activity = createMockActivity({
+      type: ActivityType.MdmEnrolled,
+      details: {
+        host_serial: "ABCD",
+        installed_from_dep: true,
+        mdm_platform: "apple",
+      },
+    });
+    render(<ActivityItem activity={activity} isPremiumTier />);
+
+    expect(
+      screen.getByText((content, node) => {
+        return (
+          node?.innerHTML ===
+          "<b>Test User </b>An end user turned on MDM features for a host with serial number <b>ABCD (automatic)</b>."
+        );
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("renders a 'mdm_enrolled' type activity for windows hosts.", () => {
+    const activity = createMockActivity({
+      type: ActivityType.MdmEnrolled,
+      details: {
+        mdm_platform: "microsoft",
+        host_serial: "ABCD",
+      },
+    });
+    render(<ActivityItem activity={activity} isPremiumTier />);
+
+    expect(
+      screen.getByText((content, node) => {
+        console.log(node?.innerHTML);
+        return (
+          node?.innerHTML ===
+          "<b>Test User </b>Mobile device management (MDM) was turned on for a host with serial number <b>ABCD (manual)</b>."
+        );
+      })
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -215,6 +215,17 @@ const TAGGED_TEMPLATES = {
     );
   },
   mdmEnrolled: (activity: IActivity) => {
+    if (activity.details?.mdm_platform === "microsoft") {
+      return (
+        <>
+          Mobile device management (MDM) was turned on for a host with serial
+          number <b>{activity.details?.host_serial} (manual)</b>.
+        </>
+      );
+    }
+
+    // note: if mdm_platform is missing, we assume this is Apple MDM for backwards
+    // compatibility
     return (
       <>
         An end user turned on MDM features for a host with serial number{" "}

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -218,8 +218,8 @@ const TAGGED_TEMPLATES = {
     if (activity.details?.mdm_platform === "microsoft") {
       return (
         <>
-          Mobile device management (MDM) was turned on for a host with serial
-          number <b>{activity.details?.host_serial} (manual)</b>.
+          Mobile device management (MDM) was turned on for{" "}
+          <b>{activity.details?.host_serial} (manual)</b>.
         </>
       );
     }

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityItem/ActivityItem.tsx
@@ -219,7 +219,7 @@ const TAGGED_TEMPLATES = {
       return (
         <>
           Mobile device management (MDM) was turned on for{" "}
-          <b>{activity.details?.host_serial} (manual)</b>.
+          <b>{activity.details?.host_display_name} (manual)</b>.
         </>
       );
     }

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -692,6 +692,7 @@ type ActivityTypeMDMEnrolled struct {
 	HostSerial       string `json:"host_serial"`
 	HostDisplayName  string `json:"host_display_name"`
 	InstalledFromDEP bool   `json:"installed_from_dep"`
+	MDMPlatform      string `json:"mdm_platform"`
 }
 
 func (a ActivityTypeMDMEnrolled) ActivityName() string {
@@ -703,10 +704,12 @@ func (a ActivityTypeMDMEnrolled) Documentation() (activity string, details strin
 		`This activity contains the following fields:
 - "host_serial": Serial number of the host.
 - "host_display_name": Display name of the host.
-- "installed_from_dep": Whether the host was enrolled via DEP.`, `{
+- "installed_from_dep": Whether the host was enrolled via DEP.
+- "mdm_platform": Used to distinguish between Apple and Microsoft enrollments, can be "apple", "microsoft" or empty. An empty value should be considered as "apple" for backwards compatibility.`, `{
   "host_serial": "C08VQ2AXHT96",
   "host_display_name": "MacBookPro16,1 (C08VQ2AXHT96)",
-  "installed_from_dep": true
+  "installed_from_dep": true,
+  "mdm_platform": "apple"
 }`
 }
 

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -705,7 +705,7 @@ func (a ActivityTypeMDMEnrolled) Documentation() (activity string, details strin
 - "host_serial": Serial number of the host.
 - "host_display_name": Display name of the host.
 - "installed_from_dep": Whether the host was enrolled via DEP.
-- "mdm_platform": Used to distinguish between Apple and Microsoft enrollments, can be "apple", "microsoft" or empty. An empty value should be considered as "apple" for backwards compatibility.`, `{
+- "mdm_platform": Used to distinguish between Apple and Microsoft enrollments. Can be "apple", "microsoft" or not present. If missing, this value is treated as "apple" for backwards compatibility.`, `{
   "host_serial": "C08VQ2AXHT96",
   "host_display_name": "MacBookPro16,1 (C08VQ2AXHT96)",
   "installed_from_dep": true,

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -7,6 +7,11 @@ import (
 	"time"
 )
 
+const (
+	MDMPlatformApple     = "apple"
+	MDMPlatformMicrosoft = "microsoft"
+)
+
 type AppleMDM struct {
 	CommonName   string    `json:"common_name"`
 	SerialNumber string    `json:"serial_number"`

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2211,6 +2211,7 @@ func (svc *MDMAppleCheckinAndCommandService) Authenticate(r *mdm.Request, m *mdm
 		HostSerial:       info.HardwareSerial,
 		HostDisplayName:  info.DisplayName,
 		InstalledFromDEP: info.InstalledFromDEP,
+		MDMPlatform:      fleet.MDMPlatformApple,
 	})
 }
 

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -972,6 +972,7 @@ func TestMDMAuthenticate(t *testing.T) {
 		require.Equal(t, serial, a.HostSerial)
 		require.Equal(t, a.HostDisplayName, fmt.Sprintf("%s (%s)", model, serial))
 		require.False(t, a.InstalledFromDEP)
+		require.Equal(t, fleet.MDMPlatformApple, a.MDMPlatform)
 		return nil
 	}
 

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -925,7 +925,7 @@ func (s *integrationMDMTestSuite) TestDEPProfileAssignment() {
 			require.JSONEq(
 				t,
 				fmt.Sprintf(
-					`{"host_serial": "%s", "host_display_name": "%s (%s)", "installed_from_dep": true}`,
+					`{"host_serial": "%s", "host_display_name": "%s (%s)", "installed_from_dep": true, "mdm_platform": "apple"}`,
 					devices[0].SerialNumber, devices[0].Model, devices[0].SerialNumber,
 				),
 				string(*activity.Details),
@@ -1068,8 +1068,8 @@ func (s *integrationMDMTestSuite) TestAppleMDMDeviceEnrollment() {
 		}
 	}
 	require.Len(t, details, 2)
-	require.JSONEq(t, fmt.Sprintf(`{"host_serial": "%s", "host_display_name": "%s (%s)", "installed_from_dep": false}`, mdmDeviceA.SerialNumber, mdmDeviceA.Model, mdmDeviceA.SerialNumber), string(*details[len(details)-2]))
-	require.JSONEq(t, fmt.Sprintf(`{"host_serial": "%s", "host_display_name": "%s (%s)", "installed_from_dep": false}`, mdmDeviceB.SerialNumber, mdmDeviceB.Model, mdmDeviceB.SerialNumber), string(*details[len(details)-1]))
+	require.JSONEq(t, fmt.Sprintf(`{"host_serial": "%s", "host_display_name": "%s (%s)", "installed_from_dep": false, "mdm_platform": "apple"}`, mdmDeviceA.SerialNumber, mdmDeviceA.Model, mdmDeviceA.SerialNumber), string(*details[len(details)-2]))
+	require.JSONEq(t, fmt.Sprintf(`{"host_serial": "%s", "host_display_name": "%s (%s)", "installed_from_dep": false, "mdm_platform": "apple"}`, mdmDeviceB.SerialNumber, mdmDeviceB.Model, mdmDeviceB.SerialNumber), string(*details[len(details)-1]))
 
 	// set an enroll secret
 	var applyResp applyEnrollSecretSpecResponse

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -5420,9 +5420,9 @@ func (s *integrationMDMTestSuite) TestValidRequestSecurityTokenRequest() {
 		fleet.ActivityTypeMDMEnrolled{}.ActivityName(),
 		`{
 			"mdm_platform": "microsoft",
-			"host_serial": "DESKTOP-0C89RC0",
+			"host_serial": "",
 			"installed_from_dep": false,
-			"host_display_name": ""
+			"host_display_name": "DESKTOP-0C89RC0"
 		 }`,
 		0)
 }

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -5420,7 +5420,7 @@ func (s *integrationMDMTestSuite) TestValidRequestSecurityTokenRequest() {
 		fleet.ActivityTypeMDMEnrolled{}.ActivityName(),
 		`{
 			"mdm_platform": "microsoft",
-			"host_serial": "AB157C3A18778F4FB21E2739066C1F27",
+			"host_serial": "DESKTOP-0C89RC0",
 			"installed_from_dep": false,
 			"host_display_name": ""
 		 }`,

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -5414,6 +5414,17 @@ func (s *integrationMDMTestSuite) TestValidRequestSecurityTokenRequest() {
 	require.True(t, s.isXMLTagContentPresent("TokenType", resSoapMsg))
 	require.True(t, s.isXMLTagContentPresent("RequestID", resSoapMsg))
 	require.True(t, s.isXMLTagContentPresent("BinarySecurityToken", resSoapMsg))
+
+	// Checking if an activity was created for the enrollment
+	s.lastActivityOfTypeMatches(
+		fleet.ActivityTypeMDMEnrolled{}.ActivityName(),
+		`{
+			"mdm_platform": "microsoft",
+			"host_serial": "AB157C3A18778F4FB21E2739066C1F27",
+			"installed_from_dep": false,
+			"host_display_name": ""
+		 }`,
+		0)
 }
 
 func (s *integrationMDMTestSuite) TestInvalidRequestSecurityTokenRequestWithMissingAdditionalContext() {

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -1009,8 +1009,11 @@ func (svc *Service) storeWindowsMDMEnrolledDevice(ctx context.Context, secTokenM
 		return err
 	}
 
+	// note: computer name is coming provisorily in place of `host_serial`
+	// until we get other bits of the MDM protocol in place. This will be
+	// updated to actually use the serial number in the future.
 	err = svc.ds.NewActivity(ctx, nil, &fleet.ActivityTypeMDMEnrolled{
-		HostSerial:  reqDeviceID,
+		HostSerial:  reqDeviceName,
 		MDMPlatform: fleet.MDMPlatformMicrosoft,
 	})
 	if err != nil {

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -1009,12 +1009,9 @@ func (svc *Service) storeWindowsMDMEnrolledDevice(ctx context.Context, secTokenM
 		return err
 	}
 
-	// note: computer name is coming provisorily in place of `host_serial`
-	// until we get other bits of the MDM protocol in place. This will be
-	// updated to actually use the serial number in the future.
 	err = svc.ds.NewActivity(ctx, nil, &fleet.ActivityTypeMDMEnrolled{
-		HostSerial:  reqDeviceName,
-		MDMPlatform: fleet.MDMPlatformMicrosoft,
+		HostDisplayName: reqDeviceName,
+		MDMPlatform:     fleet.MDMPlatformMicrosoft,
 	})
 	if err != nil {
 		// only logging, the device is enrolled at this point, and we

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -819,7 +819,7 @@ func (svc *Service) GetMDMWindowsEnrollResponse(ctx context.Context, secTokenMsg
 		return nil, ctxerr.Wrap(ctx, err, "creation of RequestSecurityTokenResponseCollection message")
 	}
 
-	// RequestSecurityTokenResponseCollection message is ready The identity
+	// RequestSecurityTokenResponseCollection message is ready. The identity
 	// and provisioning information will be sent to the Windows MDM
 	// Enrollment Client
 


### PR DESCRIPTION
For #12427, and its sub-tasks #12288 and #12612


![image](https://github.com/fleetdm/fleet/assets/4419992/b4c019dd-fbd3-4c1d-a2ad-a0bb4ebac817)



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
