### PR TITLE
prevent panic when orbit is run with updates disabled

### DIFF
--- a/orbit/changes/11980-updates-panic
+++ b/orbit/changes/11980-updates-panic
@@ -1,0 +1,1 @@
+* Fixed a crash that happened when updates where disabled and certain conditions (Nudge configuration set or host elegible for MDM migration) were met.

--- a/orbit/pkg/update/nudge.go
+++ b/orbit/pkg/update/nudge.go
@@ -71,6 +71,11 @@ func (n *NudgeConfigFetcher) GetConfig() (*fleet.OrbitConfig, error) {
 		return nil, nil
 	}
 
+	if n.opt.UpdateRunner == nil {
+		log.Debug().Msg("NudgeConfigFetcher received nil UpdateRunner, this probably indicates that updates are turned off. Skipping any actions related to Nudge")
+		return cfg, nil
+	}
+
 	if cfg.NudgeConfig == nil {
 		log.Debug().Msg("empty nudge config, removing nudge as target")
 		// TODO(roberto): by early returning and removing the target from the

--- a/orbit/pkg/update/swift_dialog.go
+++ b/orbit/pkg/update/swift_dialog.go
@@ -35,6 +35,11 @@ func (s *SwiftDialogDownloader) GetConfig() (*fleet.OrbitConfig, error) {
 		return nil, nil
 	}
 
+	if s.UpdateRunner == nil {
+		log.Debug().Msg("SwiftDialogDownloader received nil UpdateRunner, this probably indicates that updates are turned off. Skipping any actions related to swiftDialog")
+		return cfg, nil
+	}
+
 	if !cfg.Notifications.NeedsMDMMigration && !cfg.Notifications.RenewEnrollmentProfile {
 		return cfg, nil
 	}

--- a/orbit/pkg/update/swift_dialog_test.go
+++ b/orbit/pkg/update/swift_dialog_test.go
@@ -1,0 +1,21 @@
+package update
+
+import (
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSwiftDialogUpdatesDisabled(t *testing.T) {
+	cfg := &fleet.OrbitConfig{}
+	cfg.Notifications.NeedsMDMMigration = true
+	cfg.Notifications.RenewEnrollmentProfile = true
+	var f OrbitConfigFetcher = &dummyConfigFetcher{cfg: cfg}
+	f = ApplySwiftDialogDownloaderMiddleware(f, nil)
+
+	// we used to get a panic if updates were disabled (see #11980)
+	gotCfg, err := f.GetConfig()
+	require.NoError(t, err)
+	require.Equal(t, cfg, gotCfg)
+}


### PR DESCRIPTION
for #11980

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
