### PR TITLE
Handbook: update sentence case section and UI to follow

### DIFF
--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -491,7 +491,7 @@ const QueryForm = ({
               Observers can run
             </Checkbox>
             <p>
-              Users with the Observer role will be able to run this query on
+              Users with the observer role will be able to run this query on
               hosts where they have access.
             </p>
           </>

--- a/handbook/company/why-this-way.md
+++ b/handbook/company/why-this-way.md
@@ -257,7 +257,7 @@ In sentence case, we write and capitalize words as if they were in sentences:
 
 > Ask questions about your servers, containers, and laptops running Linux, Windows, and macOS
 
-As we use sentence case, only the first word is capitalized. But, if a word would normally be capitalized in the sentence (e.g., a proper noun, an acronym, or a stylization) it should remain capitalized.
+As we use sentence case, only the first word is capitalized. But, if a word would normally be capitalized in the sentence (e.g., a proper noun, an acronym, or a stylization) it should remain capitalized. User roles (e.g., "observer" or "maintainer" and features (e.g. "automations") in the Fleet product aren't treated as proper nouns and shouldn't be capitalized.
 
 The reason for sentence case at Fleet is that everyone capitalizes differently in English, and capitalization conventions have not been taught very consistently in schools.  Sentence case simplifies capitalization rules so that contributors can deliver more natural, even-looking content with a voice that feels similar no matter where you're reading it.
 


### PR DESCRIPTION
- Update sentence case section in the handbook to clarify that role names and features in the Fleet product are not proper nouns and thus shouldn't be capitalized
- Update one spot in the Fleet UI to reflect this
