### PR TITLE
Add "MDM on/off" to why this way

### DIFF
--- a/handbook/company/why-this-way.md
+++ b/handbook/company/why-this-way.md
@@ -261,5 +261,17 @@ As we use sentence case, only the first word is capitalized. But, if a word woul
 
 The reason for sentence case at Fleet is that everyone capitalizes differently in English, and capitalization conventions have not been taught very consistently in schools.  Sentence case simplifies capitalization rules so that contributors can deliver more natural, even-looking content with a voice that feels similar no matter where you're reading it.
 
+## Why does Fleet use "MDM on/off" instead of "MDM enrolled/unenrolled"?
+
+Fleet is more than an MDM (mobile device management) solution.
+
+With Fleet, you can collect telemetry from Macs, Windows servers, Chromebooks, and more by installing the fleetd agent (or chrome extension for Chromebooks). When we use the word "enroll" in Fleet, we want this to mean anytime one of these hosts shows up in Fleet and the user can see that sweet telemetry.
+
+Fleet also has MDM features that allow IT admins to enforce OS settings, OS updates, and more. When we use the phrase "MDM on" in Fleet, we want this to mean anytime a host has these features activated.
+
+Jamf, and other MDM solutions use "enroll" to mean both telemetry is being colecting and enforcement features are activated.
+
+Since Fleet is more than MDM, as a user, you can collect telemtry on your Windows servers and you can enforce OS settings on your Macs. Or, you can collecting telemtry for both without enforcing OS settings.
+
 <meta name="maintainedBy" value="mikermcneil">
 <meta name="title" value="Why this way?">

--- a/handbook/company/why-this-way.md
+++ b/handbook/company/why-this-way.md
@@ -269,9 +269,9 @@ With Fleet, you can collect telemetry from Macs, Windows servers, Chromebooks, a
 
 Fleet also has MDM features that allow IT admins to enforce OS settings, OS updates, and more. When we use the phrase "MDM on" in Fleet, we want this to mean anytime a host has these features activated.
 
-Jamf, and other MDM solutions use "enroll" to mean both telemetry is being colecting and enforcement features are activated.
+Jamf, and other MDM solutions use "enroll" to mean both telemetry is being collecting and enforcement features are activated.
 
-Since Fleet is more than MDM, as a user, you can collect telemtry on your Windows servers and you can enforce OS settings on your Macs. Or, you can collecting telemtry for both without enforcing OS settings.
+Since Fleet is more than MDM, as a user, you can collect telemetry on your Windows servers and you can enforce OS settings on your Macs. Or, you can collecting telemtry for both without enforcing OS settings.
 
 <meta name="maintainedBy" value="mikermcneil">
 <meta name="title" value="Why this way?">

--- a/handbook/company/why-this-way.md
+++ b/handbook/company/why-this-way.md
@@ -265,13 +265,13 @@ The reason for sentence case at Fleet is that everyone capitalizes differently i
 
 Fleet is more than an MDM (mobile device management) solution.
 
-With Fleet, you can collect telemetry from Macs, Windows servers, Chromebooks, and more by installing the fleetd agent (or chrome extension for Chromebooks). When we use the word "enroll" in Fleet, we want this to mean anytime one of these hosts shows up in Fleet and the user can see that sweet telemetry.
+With Fleet, you can secure and investigate Macs, Windows servers, Chromebooks, and more by installing the fleetd agent (or chrome extension for Chromebooks). When we use the word "enroll" in Fleet, we want this to mean anytime one of these hosts shows up in Fleet and the user can see that sweet telemetry.
 
-Fleet also has MDM features that allow IT admins to enforce OS settings, OS updates, and more. When we use the phrase "MDM on" in Fleet, we want this to mean anytime a host has these features activated.
+Fleet also has MDM features that allow IT admins to enforce OS settings, OS updates, and more. When we use the phrase "MDM on" in Fleet, it means a host has these features activated.
 
-Jamf, and other MDM solutions use "enroll" to mean both telemetry is being collecting and enforcement features are activated.
+Workspace ONE and other MDM solutions use "enroll" to mean both telemetry is being collecting and enforcement features are activated.
 
-Since Fleet is more than MDM, as a user, you can collect telemetry on your Windows servers and you can enforce OS settings on your Macs. Or, you can collecting telemtry for both without enforcing OS settings.
+Since Fleet is more than MDM, you can collect telemetry on your Windows servers and you can enforce OS settings on your Macs. Or you can collect telemetry for both without enforcing OS settings.
 
 <meta name="maintainedBy" value="mikermcneil">
 <meta name="title" value="Why this way?">


### PR DESCRIPTION
- Handbook why we use "MDM on/off" instead of "MDM enrolled/unenrolled" at Fleet
