### PR TITLE
Updated osquery/config endpoint to include scheduled queries

### DIFF
--- a/changes/12644-include-scheduled-queries-in-getclientconfig
+++ b/changes/12644-include-scheduled-queries-in-getclientconfig
@@ -1,0 +1,2 @@
+- The `osquery/config` endpoint should include scheduled queries for the host's team stored in the
+  `queries` table.

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -3745,6 +3745,7 @@ func testHostsPackStatsMultipleHosts(t *testing.T, ds *Datastore) {
 		Name:    "test1",
 		HostIDs: []uint{host1.ID, host2.ID},
 	})
+	require.NoError(t, err)
 
 	userQuery := test.NewQuery(t, ds, nil, "global-time", "select * from time", 0, true)
 	userSQuery := test.NewScheduledQuery(t, ds, userPack.ID, userQuery.ID, 30, true, true, "time-scheduled-global")

--- a/server/datastore/mysql/packs.go
+++ b/server/datastore/mysql/packs.go
@@ -611,7 +611,6 @@ func listPacksForHost(ctx context.Context, db sqlx.QueryerContext, hid uint) ([]
 	if err := sqlx.SelectContext(ctx, db, &packs, query,
 		fleet.TargetLabel, hid, fleet.TargetHost, hid, fleet.TargetTeam, hid,
 	); err != nil && err != sql.ErrNoRows {
-		fmt.Println(err)
 		return nil, ctxerr.Wrap(ctx, err, "listing hosts in pack")
 	}
 

--- a/server/datastore/mysql/queries.go
+++ b/server/datastore/mysql/queries.go
@@ -371,9 +371,9 @@ func (ds *Datastore) ListQueries(ctx context.Context, opt fleet.ListQueryOptions
 
 	if opt.IsScheduled != nil {
 		if *opt.IsScheduled {
-			whereClauses += " AND q.schedule_interval>0 AND q.automations_enabled=1"
+			whereClauses += " AND (q.schedule_interval>0 AND q.automations_enabled=1)"
 		} else {
-			whereClauses += " AND q.schedule_interval=0 OR q.automations_enabled=0"
+			whereClauses += " AND (q.schedule_interval=0 OR q.automations_enabled=0)"
 		}
 	}
 

--- a/server/datastore/mysql/queries.go
+++ b/server/datastore/mysql/queries.go
@@ -363,10 +363,10 @@ func (ds *Datastore) ListQueries(ctx context.Context, opt fleet.ListQueryOptions
 	}
 
 	if opt.TeamID != nil {
-		args = append(args, fmt.Sprint(*opt.TeamID))
-		whereClauses += " AND team_id_char = ?"
+		args = append(args, *opt.TeamID)
+		whereClauses += " AND team_id = ?"
 	} else {
-		whereClauses += " AND team_id_char = ''"
+		whereClauses += " AND team_id IS NULL"
 	}
 
 	if opt.IsScheduled != nil {

--- a/server/datastore/mysql/queries_test.go
+++ b/server/datastore/mysql/queries_test.go
@@ -32,7 +32,6 @@ func TestQueries(t *testing.T) {
 		{"ObserverCanRunQuery", testObserverCanRunQuery},
 		{"ListFiltersByTeamID", testQueriesListFiltersByTeamID},
 		{"ListFiltersByIsScheduled", testQueriesListFiltersByIsScheduled},
-		{"ListFiltersByExcludedIDs", testQueriesListFiltersByExcludedIDs},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -627,17 +626,19 @@ func testQueriesListFiltersByIsScheduled(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 	q2, err := ds.NewQuery(context.Background(), &fleet.Query{
-		Name:             "query2",
-		Query:            "select 1;",
-		Saved:            true,
-		ScheduleInterval: 10,
+		Name:               "query2",
+		Query:              "select 1;",
+		Saved:              true,
+		ScheduleInterval:   10,
+		AutomationsEnabled: false,
 	})
 	require.NoError(t, err)
 	q3, err := ds.NewQuery(context.Background(), &fleet.Query{
-		Name:             "query3",
-		Query:            "select 1;",
-		Saved:            true,
-		ScheduleInterval: 20,
+		Name:               "query3",
+		Query:              "select 1;",
+		Saved:              true,
+		ScheduleInterval:   20,
+		AutomationsEnabled: true,
 	})
 	require.NoError(t, err)
 
@@ -651,56 +652,11 @@ func testQueriesListFiltersByIsScheduled(t *testing.T, ds *Datastore) {
 		},
 		{
 			opts:     fleet.ListQueryOptions{IsScheduled: ptr.Bool(true)},
-			expected: []*fleet.Query{q2, q3},
+			expected: []*fleet.Query{q3},
 		},
 		{
 			opts:     fleet.ListQueryOptions{IsScheduled: ptr.Bool(false)},
-			expected: []*fleet.Query{q1},
-		},
-	}
-
-	for i, tCase := range testCases {
-		queries, err := ds.ListQueries(
-			context.Background(),
-			tCase.opts,
-		)
-		require.NoError(t, err)
-		test.QueryElementsMatch(t, queries, tCase.expected, i)
-	}
-}
-
-func testQueriesListFiltersByExcludedIDs(t *testing.T, ds *Datastore) {
-	q1, err := ds.NewQuery(context.Background(), &fleet.Query{
-		Name:             "query1",
-		Query:            "select 1;",
-		Saved:            true,
-		ScheduleInterval: 0,
-	})
-	require.NoError(t, err)
-
-	q2, err := ds.NewQuery(context.Background(), &fleet.Query{
-		Name:             "query2",
-		Query:            "select 1;",
-		Saved:            true,
-		ScheduleInterval: 10,
-	})
-	require.NoError(t, err)
-
-	testCases := []struct {
-		opts     fleet.ListQueryOptions
-		expected []*fleet.Query
-	}{
-		{
-			opts:     fleet.ListQueryOptions{},
 			expected: []*fleet.Query{q1, q2},
-		},
-		{
-			opts:     fleet.ListQueryOptions{ExcludeIDs: make(map[uint]struct{})},
-			expected: []*fleet.Query{q1, q2},
-		},
-		{
-			opts:     fleet.ListQueryOptions{ExcludeIDs: map[uint]struct{}{q1.ID: {}}},
-			expected: []*fleet.Query{q2},
 		},
 	}
 

--- a/server/datastore/mysql/queries_test.go
+++ b/server/datastore/mysql/queries_test.go
@@ -639,6 +639,7 @@ func testQueriesListFiltersByIsScheduled(t *testing.T, ds *Datastore) {
 		Saved:            true,
 		ScheduleInterval: 20,
 	})
+	require.NoError(t, err)
 
 	testCases := []struct {
 		opts     fleet.ListQueryOptions
@@ -676,12 +677,15 @@ func testQueriesListFiltersByExcludedIDs(t *testing.T, ds *Datastore) {
 		ScheduleInterval: 0,
 	})
 	require.NoError(t, err)
+
 	q2, err := ds.NewQuery(context.Background(), &fleet.Query{
 		Name:             "query2",
 		Query:            "select 1;",
 		Saved:            true,
 		ScheduleInterval: 10,
 	})
+	require.NoError(t, err)
+
 	testCases := []struct {
 		opts     fleet.ListQueryOptions
 		expected []*fleet.Query

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -763,7 +763,11 @@ type ListQueryOptions struct {
 
 	// TeamID which team the queries belong to. If teamID is nil, then it is assumed the 'global'
 	// team
-	TeamID             *uint
+	TeamID *uint
+	// IsScheduled filters queries that are meant to run at a set interval
+	IsScheduled *bool
+	// IsIncludedInPacks filters queries included/excluded in packs
+	IsIncludedInPacks  *bool
 	OnlyObserverCanRun bool
 }
 

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -765,9 +765,7 @@ type ListQueryOptions struct {
 	// team.
 	TeamID *uint
 	// IsScheduled filters queries that are meant to run at a set interval.
-	IsScheduled *bool
-	// ExcludeIDs set with ids of queries that should not be included in the result.
-	ExcludeIDs         map[uint]struct{}
+	IsScheduled        *bool
 	OnlyObserverCanRun bool
 }
 

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -762,12 +762,12 @@ type ListQueryOptions struct {
 	ListOptions
 
 	// TeamID which team the queries belong to. If teamID is nil, then it is assumed the 'global'
-	// team
+	// team.
 	TeamID *uint
-	// IsScheduled filters queries that are meant to run at a set interval
+	// IsScheduled filters queries that are meant to run at a set interval.
 	IsScheduled *bool
-	// IsIncludedInPacks filters queries included/excluded in packs
-	IsIncludedInPacks  *bool
+	// ExcludeIDs set with ids of queries that should not be included in the result.
+	ExcludeIDs         map[uint]struct{}
 	OnlyObserverCanRun bool
 }
 

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -140,7 +140,7 @@ type Datastore interface {
 	// PackByName fetches pack if it exists, if the pack exists the bool return value is true
 	PackByName(ctx context.Context, name string, opts ...OptionalArg) (*Pack, bool, error)
 
-	// ListPacksForHost lists the packs that a host should execute.
+	// ListPacksForHost lists the "user packs" that a host should execute.
 	ListPacksForHost(ctx context.Context, hid uint) (packs []*Pack, err error)
 
 	// EnsureGlobalPack gets or inserts a pack with type global

--- a/server/fleet/queries.go
+++ b/server/fleet/queries.go
@@ -69,6 +69,14 @@ func (q *Query) TeamIDStr() string {
 	return fmt.Sprint(*q.TeamID)
 }
 
+func (q *Query) GetSnapshot() *bool {
+	return nil
+}
+
+func (q *Query) GetRemoved() *bool {
+	return nil
+}
+
 // Verify verifies the query payload is valid.
 func (q *QueryPayload) Verify() error {
 	if q.Name != nil {

--- a/server/fleet/queries.go
+++ b/server/fleet/queries.go
@@ -126,6 +126,17 @@ func (q *Query) Verify() error {
 	return nil
 }
 
+func (q *Query) ToQueryContent() QueryContent {
+	return QueryContent{
+		Query:    q.Query,
+		Interval: q.ScheduleInterval,
+		Platform: &q.Platform,
+		Version:  &q.MinOsqueryVersion,
+		Removed:  q.GetRemoved(),
+		Snapshot: q.GetSnapshot(),
+	}
+}
+
 type TargetedQuery struct {
 	*Query
 	HostTargets HostTargets `json:"host_targets"`

--- a/server/fleet/queries.go
+++ b/server/fleet/queries.go
@@ -79,11 +79,8 @@ func (q *Query) GetSnapshot() *bool {
 	switch loggingType {
 	case "snapshot":
 		return ptr.Bool(true)
-	case "differential", "differential_ignore_removals":
-		return ptr.Bool(false)
 	default:
-		// Default value of `snapshot` according the docs is false
-		return ptr.Bool(false)
+		return nil
 	}
 }
 
@@ -94,11 +91,12 @@ func (q *Query) GetRemoved() *bool {
 	}
 
 	switch loggingType {
-	case "snapshot", "differential_ignore_removals":
+	case "differential":
+		return ptr.Bool(true)
+	case "differential_ignore_removals":
 		return ptr.Bool(false)
 	default:
-		// Default value of `removed` according the docs is true
-		return ptr.Bool(true)
+		return nil
 	}
 }
 

--- a/server/fleet/queries.go
+++ b/server/fleet/queries.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/ghodss/yaml"
 )
 
@@ -70,11 +71,35 @@ func (q *Query) TeamIDStr() string {
 }
 
 func (q *Query) GetSnapshot() *bool {
-	return nil
+	var loggingType string
+	if q != nil {
+		loggingType = q.LoggingType
+	}
+
+	switch loggingType {
+	case "snapshot":
+		return ptr.Bool(true)
+	case "differential", "differential_ignore_removals":
+		return ptr.Bool(false)
+	default:
+		// Default value of `snapshot` according the docs is false
+		return ptr.Bool(false)
+	}
 }
 
 func (q *Query) GetRemoved() *bool {
-	return nil
+	var loggingType string
+	if q != nil {
+		loggingType = q.LoggingType
+	}
+
+	switch loggingType {
+	case "snapshot", "differential_ignore_removals":
+		return ptr.Bool(false)
+	default:
+		// Default value of `removed` according the docs is true
+		return ptr.Bool(true)
+	}
 }
 
 // Verify verifies the query payload is valid.

--- a/server/fleet/queries_test.go
+++ b/server/fleet/queries_test.go
@@ -15,7 +15,7 @@ func TestGetSnapshot(t *testing.T) {
 	}{
 		{
 			query:    nil,
-			expected: ptr.Bool(false),
+			expected: nil,
 		},
 		{
 			query:    &Query{LoggingType: "snapshot"},
@@ -23,11 +23,11 @@ func TestGetSnapshot(t *testing.T) {
 		},
 		{
 			query:    &Query{LoggingType: "differential"},
-			expected: ptr.Bool(false),
+			expected: nil,
 		},
 		{
 			query:    &Query{LoggingType: "differential_ignore_removals"},
-			expected: ptr.Bool(false),
+			expected: nil,
 		},
 	}
 	for _, tCase := range testCases {
@@ -46,7 +46,7 @@ func TestGetRemoved(t *testing.T) {
 		},
 		{
 			query:    &Query{LoggingType: "snapshot"},
-			expected: ptr.Bool(false),
+			expected: nil,
 		},
 		{
 			query:    &Query{LoggingType: "differential"},

--- a/server/fleet/queries_test.go
+++ b/server/fleet/queries_test.go
@@ -8,6 +8,60 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGetSnapshot(t *testing.T) {
+	testCases := []struct {
+		query    *Query
+		expected *bool
+	}{
+		{
+			query:    nil,
+			expected: ptr.Bool(false),
+		},
+		{
+			query:    &Query{LoggingType: "snapshot"},
+			expected: ptr.Bool(true),
+		},
+		{
+			query:    &Query{LoggingType: "differential"},
+			expected: ptr.Bool(false),
+		},
+		{
+			query:    &Query{LoggingType: "differential_ignore_removals"},
+			expected: ptr.Bool(false),
+		},
+	}
+	for _, tCase := range testCases {
+		require.Equal(t, tCase.expected, tCase.query.GetSnapshot())
+	}
+}
+
+func TestGetRemoved(t *testing.T) {
+	testCases := []struct {
+		query    *Query
+		expected *bool
+	}{
+		{
+			query:    nil,
+			expected: ptr.Bool(true),
+		},
+		{
+			query:    &Query{LoggingType: "snapshot"},
+			expected: ptr.Bool(false),
+		},
+		{
+			query:    &Query{LoggingType: "differential"},
+			expected: ptr.Bool(true),
+		},
+		{
+			query:    &Query{LoggingType: "differential_ignore_removals"},
+			expected: ptr.Bool(false),
+		},
+	}
+	for _, tCase := range testCases {
+		require.Equal(t, tCase.expected, tCase.query.GetRemoved())
+	}
+}
+
 func TestTeamIDStr(t *testing.T) {
 	testCases := []struct {
 		query    *Query

--- a/server/fleet/queries_test.go
+++ b/server/fleet/queries_test.go
@@ -42,7 +42,7 @@ func TestGetRemoved(t *testing.T) {
 	}{
 		{
 			query:    nil,
-			expected: ptr.Bool(true),
+			expected: nil,
 		},
 		{
 			query:    &Query{LoggingType: "snapshot"},
@@ -57,8 +57,8 @@ func TestGetRemoved(t *testing.T) {
 			expected: ptr.Bool(false),
 		},
 	}
-	for _, tCase := range testCases {
-		require.Equal(t, tCase.expected, tCase.query.GetRemoved())
+	for i, tCase := range testCases {
+		require.Equal(t, tCase.expected, tCase.query.GetRemoved(), i)
 	}
 }
 

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -443,17 +443,25 @@ func (svc *Service) GetClientConfig(ctx context.Context) (map[string]interface{}
 		}
 	}
 
-	if host.TeamID != nil && host.TeamName != nil {
-		teamQueries, err := svc.getScheduledQueries(ctx, host.TeamID)
+	if host.TeamID != nil {
+		team, err := svc.ds.Team(ctx, *host.TeamID)
 		if err != nil {
 			return nil, newOsqueryError("database error: " + err.Error())
 		}
-		if len(teamQueries) > 0 {
-			packName := fmt.Sprintf("Team: %s", *host.TeamName)
-			packConfig[packName] = fleet.PackContent{
-				Queries: teamQueries,
+
+		if team != nil {
+			teamQueries, err := svc.getScheduledQueries(ctx, host.TeamID)
+			if err != nil {
+				return nil, newOsqueryError("database error: " + err.Error())
+			}
+			if len(teamQueries) > 0 {
+				packName := fmt.Sprintf("Team: %s", team.Name)
+				packConfig[packName] = fleet.PackContent{
+					Queries: teamQueries,
+				}
 			}
 		}
+
 	}
 
 	if len(packConfig) > 0 {

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -40,6 +40,9 @@ import (
 
 func TestGetClientConfig(t *testing.T) {
 	ds := new(mock.Store)
+	ds.TeamAgentOptionsFunc = func(ctx context.Context, teamID uint) (*json.RawMessage, error) {
+		return nil, nil
+	}
 	ds.ListPacksForHostFunc = func(ctx context.Context, hid uint) ([]*fleet.Pack, error) {
 		return []*fleet.Pack{}, nil
 	}
@@ -62,7 +65,28 @@ func TestGetClientConfig(t *testing.T) {
 		}
 	}
 	ds.ListQueriesFunc = func(ctx context.Context, opt fleet.ListQueryOptions) ([]*fleet.Query, error) {
-		return nil, nil
+		if opt.TeamID == nil {
+			return nil, nil
+		}
+		return []*fleet.Query{
+			{
+				Query:             "SELECT 1 FROM table_1",
+				Name:              "Some strings carry more weight than others",
+				ScheduleInterval:  10,
+				Platform:          "linux",
+				MinOsqueryVersion: "5.12.2",
+				LoggingType:       "snapshot",
+				TeamID:            ptr.Uint(1),
+			},
+			{
+				Query:            "SELECT 1 FROM table_2",
+				Name:             "You shall not pass",
+				ScheduleInterval: 20,
+				Platform:         "macos",
+				LoggingType:      "differential",
+				TeamID:           ptr.Uint(1),
+			},
+		}, nil
 	}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &fleet.AppConfig{AgentOptions: ptr.RawMessage(json.RawMessage(`{"config":{"options":{"baz":"bar"}}}`))}, nil
@@ -81,6 +105,7 @@ func TestGetClientConfig(t *testing.T) {
 
 	ctx1 := hostctx.NewContext(ctx, &fleet.Host{ID: 1})
 	ctx2 := hostctx.NewContext(ctx, &fleet.Host{ID: 2})
+	ctx3 := hostctx.NewContext(ctx, &fleet.Host{ID: 1, TeamID: ptr.Uint(1)})
 
 	expectedOptions := map[string]interface{}{
 		"baz": "bar",
@@ -146,6 +171,28 @@ func TestGetClientConfig(t *testing.T) {
 		}
 	}`,
 		string(conf["packs"].(json.RawMessage)),
+	)
+
+	// Check scheduled queries are loaded properly
+	conf, err = svc.GetClientConfig(ctx3)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"Some strings carry more weight than others": {
+			"query": "SELECT 1 FROM table_1",
+			"interval": 10,
+			"platform": "linux",
+			"version": "5.12.2",
+			"snapshot": true
+		},
+		"You shall not pass": {
+			"query": "SELECT 1 FROM table_2",
+			"interval": 20,
+			"platform": "macos",
+			"removed": true,
+			"version": ""
+		}
+	}`,
+		string(conf["schedule"].(json.RawMessage)),
 	)
 }
 

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -40,6 +40,12 @@ import (
 
 func TestGetClientConfig(t *testing.T) {
 	ds := new(mock.Store)
+	ds.TeamFunc = func(ctx context.Context, tid uint) (*fleet.Team, error) {
+		return &fleet.Team{
+			Name: "Alamo",
+			ID: 1,
+		}, nil
+	}
 	ds.TeamAgentOptionsFunc = func(ctx context.Context, teamID uint) (*json.RawMessage, error) {
 		return nil, nil
 	}
@@ -105,7 +111,7 @@ func TestGetClientConfig(t *testing.T) {
 
 	ctx1 := hostctx.NewContext(ctx, &fleet.Host{ID: 1})
 	ctx2 := hostctx.NewContext(ctx, &fleet.Host{ID: 2})
-	ctx3 := hostctx.NewContext(ctx, &fleet.Host{ID: 1, TeamID: ptr.Uint(1), TeamName: ptr.String("Alamo")})
+	ctx3 := hostctx.NewContext(ctx, &fleet.Host{ID: 1, TeamID: ptr.Uint(1)})
 
 	expectedOptions := map[string]interface{}{
 		"baz": "bar",

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -43,9 +43,10 @@ func TestGetClientConfig(t *testing.T) {
 	ds.TeamFunc = func(ctx context.Context, tid uint) (*fleet.Team, error) {
 		return &fleet.Team{
 			Name: "Alamo",
-			ID: 1,
+			ID:   1,
 		}, nil
 	}
+
 	ds.TeamAgentOptionsFunc = func(ctx context.Context, teamID uint) (*json.RawMessage, error) {
 		return nil, nil
 	}

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -61,6 +61,9 @@ func TestGetClientConfig(t *testing.T) {
 			return []*fleet.ScheduledQuery{}, nil
 		}
 	}
+	ds.ListQueriesFunc = func(ctx context.Context, opt fleet.ListQueryOptions) ([]*fleet.Query, error) {
+		return nil, nil
+	}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &fleet.AppConfig{AgentOptions: ptr.RawMessage(json.RawMessage(`{"config":{"options":{"baz":"bar"}}}`))}, nil
 	}


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
