### PR TITLE
Revert major version bump due to release errors

### DIFF
--- a/.github/workflows/build-and-push-fleetctl-docker.yml
+++ b/.github/workflows/build-and-push-fleetctl-docker.yml
@@ -39,7 +39,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@v4.0.1
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: 1.19.10
 

--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v4.0.1
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: 1.19.10
 

--- a/.github/workflows/build-orbit.yaml
+++ b/.github/workflows/build-orbit.yaml
@@ -41,7 +41,7 @@ jobs:
           rm certificate.p12
 
       - name: Set up Go
-        uses: actions/setup-go@v4.0.1
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: 1.19.10
 

--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -54,7 +54,7 @@ jobs:
 
     # Install the right version of Go for the Golang child process that we are currently using for CSR signing
     - name: Set up Go
-      uses: actions/setup-go@v4.0.1
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: 1.19
 

--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
 
     - name: Install Go
-      uses: actions/setup-go@v4.0.1
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -151,7 +151,7 @@ jobs:
     steps:
 
     - name: Install Go
-      uses: actions/setup-go@v4.0.1
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -190,7 +190,7 @@ jobs:
     steps:
 
     - name: Install Go
-      uses: actions/setup-go@v4.0.1
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -233,7 +233,7 @@ jobs:
     steps:
 
     - name: Install Go
-      uses: actions/setup-go@v4.0.1
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/fleetctl-preview-latest.yml
+++ b/.github/workflows/fleetctl-preview-latest.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
 
     - name: Install Go
-      uses: actions/setup-go@v4.0.1
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/generate-desktop-targets.yml
+++ b/.github/workflows/generate-desktop-targets.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
 
       - name: Install Go
-        uses: actions/setup-go@v4.0.1
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: '^1.19.10'
 
@@ -83,7 +83,7 @@ jobs:
     steps:
 
       - name: Install Go
-        uses: actions/setup-go@v4.0.1
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: '^1.19.10'
 
@@ -106,7 +106,7 @@ jobs:
     steps:
 
       - name: Install Go
-        uses: actions/setup-go@v4.0.1
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: '^1.19.10'
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2
 
       - name: Install Go
-        uses: actions/setup-go@v4.0.1
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -37,7 +37,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@v4.0.1
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: ${{ vars.GO_VERSION }}
 

--- a/.github/workflows/goreleaser-orbit.yaml
+++ b/.github/workflows/goreleaser-orbit.yaml
@@ -49,7 +49,7 @@ jobs:
           rm certificate.p12
 
       - name: Set up Go
-        uses: actions/setup-go@v4.0.1
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: ${{ vars.GO_VERSION }}
 
@@ -83,7 +83,7 @@ jobs:
         run: git tag $(echo ${{ github.ref_name }} | sed -e 's/orbit-//g') && git tag -d ${{ github.ref_name }}
 
       - name: Set up Go
-        uses: actions/setup-go@v4.0.1
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: ${{ vars.GO_VERSION }}
 
@@ -111,7 +111,7 @@ jobs:
         run: git tag $(echo ${{ github.ref_name }} | sed -e 's/orbit-//g') && git tag -d ${{ github.ref_name }}
 
       - name: Set up Go
-        uses: actions/setup-go@v4.0.1
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: ${{ vars.GO_VERSION }}
 

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -45,7 +45,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Set up Go
-        uses: actions/setup-go@v4.0.1
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: 1.19.10
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -211,7 +211,7 @@ jobs:
         fleetctl config set --address ${{ needs.gen.outputs.address }} --token ${{ needs.login.outputs.token }}
 
     - name: Install Go
-      uses: actions/setup-go@v4.0.1
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: '^1.19.10'
 

--- a/.github/workflows/test-db-changes.yml
+++ b/.github/workflows/test-db-changes.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v4.0.1
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: '^1.19.10'
     - name: Checkout Code

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v4.0.1
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/test-native-tooling-packaging.yml
+++ b/.github/workflows/test-native-tooling-packaging.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v4.0.1
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -69,7 +69,7 @@ jobs:
       run: docker pull fleetdm/wix:latest &
 
     - name: Install Go
-      uses: actions/setup-go@v4.0.1
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/test-yml-specs.yml
+++ b/.github/workflows/test-yml-specs.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v4.0.1
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go-version }}
 


### PR DESCRIPTION
During `goreleaser` [run for v4.34.0](https://github.com/fleetdm/fleet/actions/runs/5525147993/jobs/10078387009) received a build error likely due to the major version bump in this PR: https://github.com/fleetdm/fleet/pull/12294. Reverting to the previous working version until this can be addressed. 