### PR TITLE
Scale down and delete cronjob for expired instances

### DIFF
--- a/infrastructure/sandbox/JITProvisioner/ingress_destroyer/main.go
+++ b/infrastructure/sandbox/JITProvisioner/ingress_destroyer/main.go
@@ -66,14 +66,18 @@ func deleteIngress(id, name, ddbTable string) {
 		log.Fatal(err)
 	}
 
-	/*
+	// Delete the cronjob so we don't spam the database for stuff that's not running
+	_, err = clientset.BatchV1().CronJob("default").ApplyScale(context.Background(), id, v1.DeleteOptions{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Scale it down to save money
 	time.sleep(60)
 	_, err = clientset.AppsV1().Deployments("default").ApplyScale(context.Background(), id, &autoscaling.ScaleApplyConfiguration{Spec: &autoscaling.ScaleSpecApplyConfiguration{Replicas: new(int32)}}, v1.ApplyOptions{})
 	if err != nil {
 		log.Fatal(err)
 	}
-	*/
 
 	svc := dynamodb.New(sess)
 	err = updateFleetInstanceState(id, ddbTable, svc)

--- a/infrastructure/sandbox/JITProvisioner/ingress_destroyer/main.go
+++ b/infrastructure/sandbox/JITProvisioner/ingress_destroyer/main.go
@@ -6,13 +6,13 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	//"time"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	//autoscaling "k8s.io/client-go/applyconfigurations/autoscaling/v1"
+	autoscaling "k8s.io/client-go/applyconfigurations/autoscaling/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -67,13 +67,13 @@ func deleteIngress(id, name, ddbTable string) {
 	}
 
 	// Delete the cronjob so we don't spam the database for stuff that's not running
-	_, err = clientset.BatchV1().CronJob("default").ApplyScale(context.Background(), id, v1.DeleteOptions{})
+	err = clientset.BatchV1().CronJobs("default").Delete(context.Background(), id, v1.DeleteOptions{})
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Scale it down to save money
-	time.sleep(60)
+	time.Sleep(60)
 	_, err = clientset.AppsV1().Deployments("default").ApplyScale(context.Background(), id, &autoscaling.ScaleApplyConfiguration{Spec: &autoscaling.ScaleSpecApplyConfiguration{Replicas: new(int32)}}, v1.ApplyOptions{})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
