### PR TITLE
UI - Queries page updates, pt.1

### DIFF
--- a/frontend/components/PlatformCompatibility/PlatformCompatibility.tsx
+++ b/frontend/components/PlatformCompatibility/PlatformCompatibility.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 
-import { IOsqueryPlatform } from "interfaces/platform";
+import { OsqueryPlatform } from "interfaces/platform";
 import { PLATFORM_DISPLAY_NAMES } from "utilities/constants";
 
 import TooltipWrapper from "components/TooltipWrapper";
 import Icon from "components/Icon";
 
 interface IPlatformCompatibilityProps {
-  compatiblePlatforms: IOsqueryPlatform[] | null;
+  compatiblePlatforms: OsqueryPlatform[] | null;
   error: Error | null;
 }
 
@@ -18,13 +18,13 @@ const DISPLAY_ORDER = [
   "Windows",
   "Linux",
   "ChromeOS",
-] as IOsqueryPlatform[];
+] as OsqueryPlatform[];
 
 const ERROR_NO_COMPATIBLE_TABLES = Error("no tables in query");
 
 const formatPlatformsForDisplay = (
-  compatiblePlatforms: IOsqueryPlatform[]
-): IOsqueryPlatform[] => {
+  compatiblePlatforms: OsqueryPlatform[]
+): OsqueryPlatform[] => {
   return compatiblePlatforms.map((str) => PLATFORM_DISPLAY_NAMES[str] || str);
 };
 

--- a/frontend/components/StatusIndicator/StatusIndicator.stories.tsx
+++ b/frontend/components/StatusIndicator/StatusIndicator.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta<typeof StatusIndicator> = {
   args: {
     value: "100",
     tooltip: {
-      id: 1,
       tooltipText: "Tooltip text",
     },
   },

--- a/frontend/components/StatusIndicator/StatusIndicator.tsx
+++ b/frontend/components/StatusIndicator/StatusIndicator.tsx
@@ -2,11 +2,12 @@ import React from "react";
 import classnames from "classnames";
 import ReactTooltip from "react-tooltip";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
+import { uniqueId } from "lodash";
+import { COLORS } from "styles/var/colors";
 
 interface IStatusIndicatorProps {
   value: string;
   tooltip?: {
-    id: number;
     tooltipText: string | JSX.Element;
     position?: "top" | "bottom";
   };
@@ -29,30 +30,34 @@ const StatusIndicator = ({
     `status-indicator--${classTag}`,
     `status--${classTag}`
   );
-  const indicatorContent = tooltip ? (
-    <>
-      <span
-        className="host-status tooltip tooltip__tooltip-icon"
-        data-tip
-        data-for={`status-${tooltip.id}`}
-        data-tip-disable={false}
-      >
-        {value}
-      </span>
-      <ReactTooltip
-        className="status-tooltip"
-        place={tooltip?.position ? tooltip.position : "top"}
-        type="dark"
-        effect="solid"
-        id={`status-${tooltip.id}`}
-        backgroundColor="#3e4771"
-      >
-        {tooltip.tooltipText}
-      </ReactTooltip>
-    </>
-  ) : (
-    <>{value}</>
-  );
+  let indicatorContent;
+  if (tooltip) {
+    const tooltipId = uniqueId();
+    indicatorContent = (
+      <>
+        <span
+          className="host-status tooltip tooltip__tooltip-icon"
+          data-tip
+          data-for={`status-${tooltipId}`}
+          data-tip-disable={false}
+        >
+          {value}
+        </span>
+        <ReactTooltip
+          className="status-tooltip"
+          place={tooltip?.position ? tooltip.position : "top"}
+          type="dark"
+          effect="solid"
+          id={`status-${tooltipId}`}
+          backgroundColor={COLORS["tooltip-bg"]}
+        >
+          {tooltip.tooltipText}
+        </ReactTooltip>
+      </>
+    );
+  } else {
+    indicatorContent = <>{value}</>;
+  }
   return <span className={statusClassName}>{indicatorContent}</span>;
 };
 

--- a/frontend/components/StatusIndicator/StatusIndicator.tsx
+++ b/frontend/components/StatusIndicator/StatusIndicator.tsx
@@ -11,24 +11,33 @@ interface IStatusIndicatorProps {
     tooltipText: string | JSX.Element;
     position?: "top" | "bottom";
   };
+  customIndicatorType?: string;
 }
 
-const generateClassTag = (rawValue: string): string => {
+const generateIndicatorStateClassTag = (
+  rawValue: string,
+  customIndicatorType?: string
+): string => {
   if (rawValue === DEFAULT_EMPTY_CELL_VALUE) {
     return "indeterminate";
   }
-  return rawValue.replace(" ", "-").toLowerCase();
+  const prefix = customIndicatorType ? `${customIndicatorType}-` : "";
+  return `${prefix}${rawValue.replace(" ", "-").toLowerCase()}`;
 };
 
 const StatusIndicator = ({
   value,
   tooltip,
+  customIndicatorType,
 }: IStatusIndicatorProps): JSX.Element => {
-  const classTag = generateClassTag(value);
-  const statusClassName = classnames(
+  const indicatorStateClassTag = generateIndicatorStateClassTag(
+    value,
+    customIndicatorType
+  );
+  const indicatorClassNames = classnames(
     "status-indicator",
-    `status-indicator--${classTag}`,
-    `status--${classTag}`
+    `status-indicator--${indicatorStateClassTag}`,
+    `status--${indicatorStateClassTag}`
   );
   let indicatorContent;
   if (tooltip) {
@@ -58,7 +67,7 @@ const StatusIndicator = ({
   } else {
     indicatorContent = <>{value}</>;
   }
-  return <span className={statusClassName}>{indicatorContent}</span>;
+  return <span className={indicatorClassNames}>{indicatorContent}</span>;
 };
 
 export default StatusIndicator;

--- a/frontend/components/StatusIndicator/_styles.scss
+++ b/frontend/components/StatusIndicator/_styles.scss
@@ -52,24 +52,4 @@
       background-color: $ui-warning;
     }
   }
-
-  // Query automations status
-  &--on {
-    &:before {
-      background-color: $ui-success;
-    }
-  }
-  &--off {
-    &:before {
-      background-color: $ui-offline;
-    }
-  }
-  &--paused {
-    .status-tooltip {
-      text-transform: none;
-    }
-    &:before {
-      background-color: $ui-offline;
-    }
-  }
 }

--- a/frontend/components/TableContainer/DataTable/PillCell/PillCell.tsx
+++ b/frontend/components/TableContainer/DataTable/PillCell/PillCell.tsx
@@ -70,7 +70,7 @@ const PillCell = ({ value, customIdPrefix }: IPillCellProps): JSX.Element => {
       case "Undetermined":
         return (
           <>
-            To see performance impact, this query must have run with
+            To see performance impact, this query must have run with{" "}
             <b>automations</b> on at least one host.
           </>
         );

--- a/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.stories.tsx
+++ b/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.stories.tsx
@@ -6,7 +6,7 @@ const meta: Meta<typeof PlatformCell> = {
   title: "Components/Table/PlatformCell",
   component: PlatformCell,
   args: {
-    value: ["darwin", "windows", "linux"],
+    platforms: ["darwin", "windows", "linux"],
   },
 };
 

--- a/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tests.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 
-import { OsqueryPlatform } from "interfaces/platform";
+import { SupportedPlatform } from "interfaces/platform";
 import PlatformCell from "./PlatformCell";
 
-const PLATFORMS: OsqueryPlatform[] = ["windows", "darwin", "linux", "chrome"];
+const PLATFORMS: SupportedPlatform[] = ["windows", "darwin", "linux", "chrome"];
 
 describe("Platform cell", () => {
   it("renders platform icons in correct order", () => {

--- a/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tests.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 
-import { IOsqueryPlatform } from "interfaces/platform";
+import { OsqueryPlatform } from "interfaces/platform";
 import PlatformCell from "./PlatformCell";
 
-const PLATFORMS: IOsqueryPlatform[] = ["windows", "darwin", "linux", "chrome"];
+const PLATFORMS: OsqueryPlatform[] = ["windows", "darwin", "linux", "chrome"];
 
 describe("Platform cell", () => {
   it("renders platform icons in correct order", () => {

--- a/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tests.tsx
@@ -1,14 +1,15 @@
 import React from "react";
-import { getByTestId, render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 
+import { IOsqueryPlatform } from "interfaces/platform";
 import PlatformCell from "./PlatformCell";
 
-const PLATFORMS = ["windows", "darwin", "linux", "chrome"];
+const PLATFORMS: IOsqueryPlatform[] = ["windows", "darwin", "linux", "chrome"];
 
 describe("Platform cell", () => {
   it("renders platform icons in correct order", () => {
-    render(<PlatformCell value={PLATFORMS} />);
+    render(<PlatformCell platforms={PLATFORMS} />);
 
     const icons = screen.queryAllByTestId("icon");
     const appleIcon = screen.queryByTestId("apple-icon");
@@ -23,7 +24,7 @@ describe("Platform cell", () => {
     expect(icons[3].firstChild).toBe(chromeIcon);
   });
   it("renders empty state", () => {
-    render(<PlatformCell value={[]} />);
+    render(<PlatformCell platforms={[]} />);
 
     const icons = screen.queryAllByTestId("icon");
     const emptyText = screen.queryByText(DEFAULT_EMPTY_CELL_VALUE);

--- a/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tsx
+++ b/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import Icon from "components/Icon";
+import { IOsqueryPlatform } from "interfaces/platform";
 
 interface IPlatformCellProps {
-  value: string[];
+  platforms: IOsqueryPlatform[];
 }
 
 const baseClass = "platform-cell";
@@ -14,7 +15,7 @@ const ICONS: Record<string, "darwin" | "windows" | "linux" | "chrome"> = {
   chrome: "chrome",
 };
 
-const DISPLAY_ORDER = [
+const DISPLAY_ORDER: IOsqueryPlatform[] = [
   "darwin",
   "windows",
   "linux",
@@ -23,9 +24,7 @@ const DISPLAY_ORDER = [
   // "Invalid query",
 ];
 
-const PlatformCell = ({
-  value: platforms,
-}: IPlatformCellProps): JSX.Element => {
+const PlatformCell = ({ platforms }: IPlatformCellProps): JSX.Element => {
   const orderedList = DISPLAY_ORDER.filter((platform) =>
     platforms.includes(platform)
   );

--- a/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tsx
+++ b/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import Icon from "components/Icon";
-import { IOsqueryPlatform } from "interfaces/platform";
+import { OsqueryPlatform } from "interfaces/platform";
 
 interface IPlatformCellProps {
-  platforms: IOsqueryPlatform[];
+  platforms: OsqueryPlatform[];
 }
 
 const baseClass = "platform-cell";
@@ -15,7 +15,7 @@ const ICONS: Record<string, "darwin" | "windows" | "linux" | "chrome"> = {
   chrome: "chrome",
 };
 
-const DISPLAY_ORDER: IOsqueryPlatform[] = [
+const DISPLAY_ORDER: OsqueryPlatform[] = [
   "darwin",
   "windows",
   "linux",

--- a/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tsx
+++ b/frontend/components/TableContainer/DataTable/PlatformCell/PlatformCell.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import Icon from "components/Icon";
-import { OsqueryPlatform } from "interfaces/platform";
+import { SupportedPlatform } from "interfaces/platform";
 
 interface IPlatformCellProps {
-  platforms: OsqueryPlatform[];
+  platforms: SupportedPlatform[];
 }
 
 const baseClass = "platform-cell";
@@ -15,7 +15,7 @@ const ICONS: Record<string, "darwin" | "windows" | "linux" | "chrome"> = {
   chrome: "chrome",
 };
 
-const DISPLAY_ORDER: OsqueryPlatform[] = [
+const DISPLAY_ORDER: SupportedPlatform[] = [
   "darwin",
   "windows",
   "linux",

--- a/frontend/components/TableContainer/DataTable/TextCell/TextCell.tsx
+++ b/frontend/components/TableContainer/DataTable/TextCell/TextCell.tsx
@@ -51,7 +51,7 @@ const TextCell = ({
 
   return (
     <span className={`text-cell ${classes} ${greyed && "grey-cell"}`}>
-      {formatter(val) || renderEmptyCell()}
+      {val ? formatter(val) : renderEmptyCell()}
     </span>
   );
 };

--- a/frontend/components/TableContainer/DataTable/TextCell/TextCell.tsx
+++ b/frontend/components/TableContainer/DataTable/TextCell/TextCell.tsx
@@ -51,7 +51,7 @@ const TextCell = ({
 
   return (
     <span className={`text-cell ${classes} ${greyed && "grey-cell"}`}>
-      {val ? formatter(val) : renderEmptyCell()}
+      {formatter(val) || renderEmptyCell()}
     </span>
   );
 };

--- a/frontend/components/side_panels/QuerySidePanel/QueryTablePlatforms/QueryTablePlatforms.tsx
+++ b/frontend/components/side_panels/QuerySidePanel/QueryTablePlatforms/QueryTablePlatforms.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 
-import { IOsqueryPlatform } from "interfaces/platform";
+import { OsqueryPlatform } from "interfaces/platform";
 import { PLATFORM_DISPLAY_NAMES } from "utilities/constants";
 import Icon from "components/Icon";
 
 interface IPLatformListItemProps {
-  platform: IOsqueryPlatform;
+  platform: OsqueryPlatform;
 }
 
 const baseClassListItem = "platform-list-item";
@@ -20,7 +20,7 @@ const PlatformListItem = ({ platform }: IPLatformListItemProps) => {
 };
 
 // TODO: remove when freebsd is removed
-type IPlatformsWithFreebsd = IOsqueryPlatform | "freebsd";
+type IPlatformsWithFreebsd = OsqueryPlatform | "freebsd";
 
 interface IQueryTablePlatformsProps {
   platforms: IPlatformsWithFreebsd[];
@@ -38,7 +38,7 @@ const QueryTablePlatforms = ({ platforms }: IQueryTablePlatformsProps) => {
       return (
         <PlatformListItem
           key={platform}
-          platform={platform as IOsqueryPlatform} // TODO: remove when freebsd is removed
+          platform={platform as OsqueryPlatform} // TODO: remove when freebsd is removed
         />
       );
     });

--- a/frontend/context/policy.tsx
+++ b/frontend/context/policy.tsx
@@ -9,7 +9,7 @@ import { find } from "lodash";
 
 import { osqueryTables } from "utilities/osquery_tables";
 import { IOsQueryTable, DEFAULT_OSQUERY_TABLE } from "interfaces/osquery_table";
-import { IPlatformString } from "interfaces/platform";
+import { SelectedPlatformString } from "interfaces/platform";
 
 enum ACTIONS {
   SET_LAST_EDITED_QUERY_INFO = "SET_LAST_EDITED_QUERY_INFO",
@@ -25,7 +25,7 @@ interface ISetLastEditedQueryInfo {
   lastEditedQueryBody?: string;
   lastEditedQueryResolution?: string;
   lastEditedQueryCritical?: boolean;
-  lastEditedQueryPlatform?: IPlatformString | null;
+  lastEditedQueryPlatform?: SelectedPlatformString | null;
   defaultPolicy?: boolean;
 }
 
@@ -55,7 +55,7 @@ type InitialStateType = {
   lastEditedQueryBody: string;
   lastEditedQueryResolution: string;
   lastEditedQueryCritical: boolean;
-  lastEditedQueryPlatform: IPlatformString | null;
+  lastEditedQueryPlatform: SelectedPlatformString | null;
   defaultPolicy: boolean;
   setLastEditedQueryId: (value: number) => void;
   setLastEditedQueryName: (value: string) => void;
@@ -63,7 +63,7 @@ type InitialStateType = {
   setLastEditedQueryBody: (value: string) => void;
   setLastEditedQueryResolution: (value: string) => void;
   setLastEditedQueryCritical: (value: boolean) => void;
-  setLastEditedQueryPlatform: (value: IPlatformString | null) => void;
+  setLastEditedQueryPlatform: (value: SelectedPlatformString | null) => void;
   setDefaultPolicy: (value: boolean) => void;
   policyTeamId: number;
   setPolicyTeamId: (id: number) => void;
@@ -210,7 +210,7 @@ const PolicyProvider = ({ children }: Props): JSX.Element => {
     []
   );
   const setLastEditedQueryPlatform = useCallback(
-    (lastEditedQueryPlatform: IPlatformString | null | undefined) => {
+    (lastEditedQueryPlatform: SelectedPlatformString | null | undefined) => {
       dispatch({
         type: ACTIONS.SET_LAST_EDITED_QUERY_INFO,
         lastEditedQueryPlatform,

--- a/frontend/hooks/usePlatformCompatibility.tsx
+++ b/frontend/hooks/usePlatformCompatibility.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
 
-import { IOsqueryPlatform, SUPPORTED_PLATFORMS } from "interfaces/platform";
+import { OsqueryPlatform, SUPPORTED_PLATFORMS } from "interfaces/platform";
 import checkPlatformCompatibility from "utilities/sql_tools";
 
 import PlatformCompatibility from "components/PlatformCompatibility";
@@ -16,7 +16,7 @@ const DEBOUNCE_DELAY = 300;
 
 const usePlatformCompatibility = (): IPlatformCompatibility => {
   const [compatiblePlatforms, setCompatiblePlatforms] = useState<
-    IOsqueryPlatform[] | null
+    OsqueryPlatform[] | null
   >(null);
   const [error, setError] = useState<Error | null>(null);
 

--- a/frontend/hooks/usePlatformSelector.tsx
+++ b/frontend/hooks/usePlatformSelector.tsx
@@ -1,7 +1,10 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { forEach } from "lodash";
 
-import { IPlatformString, SUPPORTED_PLATFORMS } from "interfaces/platform";
+import {
+  SelectedPlatformString,
+  SUPPORTED_PLATFORMS,
+} from "interfaces/platform";
 
 import PlatformSelector from "components/PlatformSelector";
 
@@ -13,7 +16,7 @@ export interface IPlatformSelector {
 }
 
 const usePlatformSelector = (
-  platformContext: IPlatformString | null | undefined,
+  platformContext: SelectedPlatformString | null | undefined,
   baseClass = ""
 ): IPlatformSelector => {
   const [checkDarwin, setCheckDarwin] = useState(false);

--- a/frontend/interfaces/osquery_table.ts
+++ b/frontend/interfaces/osquery_table.ts
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { IOsqueryPlatform } from "./platform";
+import { OsqueryPlatform } from "./platform";
 
 export default PropTypes.shape({
   columns: PropTypes.arrayOf(
@@ -28,7 +28,7 @@ export interface IQueryTableColumn {
   hidden: boolean;
   required: boolean;
   index: boolean;
-  platforms?: IOsqueryPlatform[];
+  platforms?: OsqueryPlatform[];
   requires_user_context?: boolean;
 }
 
@@ -36,7 +36,7 @@ export interface IOsQueryTable {
   name: string;
   description: string;
   url: string;
-  platforms: IOsqueryPlatform[];
+  platforms: OsqueryPlatform[];
   evented: boolean;
   cacheable: boolean;
   columns: IQueryTableColumn[];

--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -1,4 +1,4 @@
-export type IOsqueryPlatform =
+export type OsqueryPlatform =
   | "darwin"
   | "macOS"
   | "windows"
@@ -41,7 +41,7 @@ export const SUPPORTED_PLATFORMS = [
 ] as const;
 
 // TODO: revisit this approach pending resolution of https://github.com/fleetdm/fleet/issues/3555.
-export const MACADMINS_EXTENSION_TABLES: Record<string, IOsqueryPlatform[]> = {
+export const MACADMINS_EXTENSION_TABLES: Record<string, OsqueryPlatform[]> = {
   file_lines: ["darwin", "linux", "windows"],
   filevault_users: ["darwin"],
   google_chrome_profiles: ["darwin", "linux", "windows"],

--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -8,7 +8,7 @@ export type OsqueryPlatform =
   | "chrome"
   | "ChromeOS";
 
-export type ISelectedPlatform =
+export type SelectedPlatform =
   | "all"
   | "darwin"
   | "windows"

--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -15,7 +15,7 @@ export type ISelectedPlatform =
   | "linux"
   | "chrome";
 
-export type IPlatformString =
+export type SelectedPlatformString =
   | ""
   | "darwin"
   | "windows"

--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -8,12 +8,15 @@ export type OsqueryPlatform =
   | "chrome"
   | "ChromeOS";
 
-export type SelectedPlatform =
-  | "all"
-  | "darwin"
-  | "windows"
-  | "linux"
-  | "chrome";
+export type SupportedPlatform = "darwin" | "windows" | "linux" | "chrome";
+
+export const SUPPORTED_PLATFORMS: SupportedPlatform[] = [
+  "darwin",
+  "windows",
+  "linux",
+  "chrome",
+];
+export type SelectedPlatform = SupportedPlatform | "all";
 
 export type SelectedPlatformString =
   | ""
@@ -32,13 +35,6 @@ export type SelectedPlatformString =
   | "windows,linux"
   | "windows,chrome"
   | "linux,chrome";
-
-export const SUPPORTED_PLATFORMS = [
-  "darwin",
-  "windows",
-  "linux",
-  "chrome",
-] as const;
 
 // TODO: revisit this approach pending resolution of https://github.com/fleetdm/fleet/issues/3555.
 export const MACADMINS_EXTENSION_TABLES: Record<string, OsqueryPlatform[]> = {

--- a/frontend/interfaces/policy.ts
+++ b/frontend/interfaces/policy.ts
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { IPlatformString } from "interfaces/platform";
+import { SelectedPlatformString } from "interfaces/platform";
 
 // Legacy PropTypes used on host interface
 export default PropTypes.shape({
@@ -31,7 +31,7 @@ export interface IPolicy {
   author_name: string;
   author_email: string;
   resolution: string;
-  platform: IPlatformString;
+  platform: SelectedPlatformString;
   team_id?: number;
   created_at: string;
   updated_at: string;
@@ -80,7 +80,7 @@ export interface IPolicyFormData {
   description?: string | number | boolean | undefined;
   resolution?: string | number | boolean | undefined;
   critical?: boolean;
-  platform?: IPlatformString;
+  platform?: SelectedPlatformString;
   name?: string | number | boolean | undefined;
   query?: string | number | boolean | undefined;
   team_id?: number;
@@ -95,6 +95,6 @@ export interface IPolicyNew {
   query: string;
   resolution: string;
   critical: boolean;
-  platform: IPlatformString;
+  platform: SelectedPlatformString;
   mdm_required?: boolean;
 }

--- a/frontend/interfaces/schedulable_query.ts
+++ b/frontend/interfaces/schedulable_query.ts
@@ -1,6 +1,6 @@
 import { IFormField } from "./form_field";
 import { IPack } from "./pack";
-import { IPlatformString } from "./platform";
+import { SelectedPlatformString } from "./platform";
 
 // Query itself
 export interface ISchedulableQuery {
@@ -12,7 +12,7 @@ export interface ISchedulableQuery {
   query: string;
   team_id: number | null;
   interval: number;
-  platform: IPlatformString; // Might more accurately be called `platforms_to_query` – comma-sepparated string of platforms to query, default all platforms if ommitted
+  platform: SelectedPlatformString; // Might more accurately be called `platforms_to_query` – comma-sepparated string of platforms to query, default all platforms if ommitted
   min_osquery_version: string;
   automations_enabled: boolean;
   logging: QueryLoggingOption;
@@ -55,7 +55,7 @@ export interface ICreateQueryRequestBody {
   observer_can_run?: boolean;
   team_id?: number; // global query if ommitted
   interval?: number; // default 0 means never run
-  platform?: IPlatformString; // Might more accurately be called `platforms_to_query` – comma-sepparated string of platforms to query, default all platforms if ommitted
+  platform?: SelectedPlatformString; // Might more accurately be called `platforms_to_query` – comma-sepparated string of platforms to query, default all platforms if ommitted
   min_osquery_version?: string; // default all versions if ommitted
   automations_enabled?: boolean; // whether to send data to the configured log destination according to the query's `interval`. Default false if ommitted.
   logging?: QueryLoggingOption;
@@ -100,7 +100,7 @@ export interface IQueryFormFields {
   query: IFormField<string>;
   observer_can_run: IFormField<boolean>;
   frequency: IFormField<number>;
-  platforms: IFormField<IPlatformString>;
+  platforms: IFormField<SelectedPlatformString>;
   min_osquery_version: IFormField<string>;
   logging: IFormField<QueryLoggingOption>;
 }

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -21,7 +21,7 @@ import {
   IMdmSolution,
   IMdmSummaryResponse,
 } from "interfaces/mdm";
-import { ISelectedPlatform } from "interfaces/platform";
+import { SelectedPlatform } from "interfaces/platform";
 import { ISoftwareResponse, ISoftwareCountResponse } from "interfaces/software";
 import { ITeam } from "interfaces/team";
 import { useTeamIdParam } from "hooks/useTeamIdParam";
@@ -107,7 +107,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
     includeNoTeam: false,
   });
 
-  const [selectedPlatform, setSelectedPlatform] = useState<ISelectedPlatform>(
+  const [selectedPlatform, setSelectedPlatform] = useState<SelectedPlatform>(
     "all"
   );
   const [
@@ -757,7 +757,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
             className={`${baseClass}__platform_dropdown`}
             options={PLATFORM_DROPDOWN_OPTIONS}
             searchable={false}
-            onChange={(value: ISelectedPlatform) => {
+            onChange={(value: SelectedPlatform) => {
               const selectedPlatformOption = PLATFORM_DROPDOWN_OPTIONS.find(
                 (platform) => platform.value === value
               );

--- a/frontend/pages/DashboardPage/cards/HostsSummary/HostsSummary.tsx
+++ b/frontend/pages/DashboardPage/cards/HostsSummary/HostsSummary.tsx
@@ -3,7 +3,7 @@ import PATHS from "router/paths";
 
 import labelsAPI from "services/entities/labels";
 import DataError from "components/DataError";
-import { ISelectedPlatform } from "interfaces/platform";
+import { SelectedPlatform } from "interfaces/platform";
 import { useQuery } from "react-query";
 import { ILabelSpecResponse } from "interfaces/label";
 
@@ -20,7 +20,7 @@ interface IHostSummaryProps {
   isLoadingHostsSummary: boolean;
   showHostsUI: boolean;
   errorHosts: boolean;
-  selectedPlatform?: ISelectedPlatform;
+  selectedPlatform?: SelectedPlatform;
 }
 
 const HostsSummary = ({

--- a/frontend/pages/DashboardPage/cards/OperatingSystems/OperatingSystems.tsx
+++ b/frontend/pages/DashboardPage/cards/OperatingSystems/OperatingSystems.tsx
@@ -5,7 +5,7 @@ import {
   OS_END_OF_LIFE_LINK_BY_PLATFORM,
   OS_VENDOR_BY_PLATFORM,
 } from "interfaces/operating_system";
-import { ISelectedPlatform } from "interfaces/platform";
+import { SelectedPlatform } from "interfaces/platform";
 import {
   getOSVersions,
   IGetOSVersionsQueryKey,
@@ -26,7 +26,7 @@ import generateTableHeaders from "./OperatingSystemsTableConfig";
 
 interface IOperatingSystemsCardProps {
   currentTeamId: number | undefined;
-  selectedPlatform: ISelectedPlatform;
+  selectedPlatform: SelectedPlatform;
   showTitle: boolean;
   /** controls the displaying of description text under the title. Defaults to `true` */
   showDescription?: boolean;
@@ -42,7 +42,7 @@ const DEFAULT_SORT_HEADER = "hosts_count";
 const PAGE_SIZE = 8;
 const baseClass = "operating-systems";
 
-const EmptyOperatingSystems = (platform: ISelectedPlatform): JSX.Element => (
+const EmptyOperatingSystems = (platform: SelectedPlatform): JSX.Element => (
   <EmptyTable
     className={`${baseClass}__os-empty-table`}
     header={`No${

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -260,7 +260,6 @@ const allHostTableHeaders: IDataColumn[] = [
     Cell: (cellProps: ICellProps) => {
       const value = cellProps.cell.value;
       const tooltip = {
-        id: cellProps.row.original.id,
         tooltipText: getHostStatusTooltipText(value),
       };
       return <StatusIndicator value={value} tooltip={tooltip} />;

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -187,7 +187,6 @@ const HostSummary = ({
           <StatusIndicator
             value={status || ""} // temporary work around of integration test bug
             tooltip={{
-              id,
               tooltipText: getHostStatusTooltipText(status),
               position: "bottom",
             }}

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -14,7 +14,7 @@ import usePlatformCompatibility from "hooks/usePlatformCompatibility";
 import usePlatformSelector from "hooks/usePlatformSelector";
 
 import { IPolicy, IPolicyFormData } from "interfaces/policy";
-import { IOsqueryPlatform, IPlatformString } from "interfaces/platform";
+import { IOsqueryPlatform, SelectedPlatformString } from "interfaces/platform";
 import { DEFAULT_POLICIES } from "pages/policies/constants";
 
 import Avatar from "components/Avatar";
@@ -234,7 +234,9 @@ const PolicyForm = ({
       setSelectedPlatforms(selectedPlatforms);
     }
 
-    const newPlatformString = selectedPlatforms.join(",") as IPlatformString;
+    const newPlatformString = selectedPlatforms.join(
+      ","
+    ) as SelectedPlatformString;
 
     if (!defaultPolicy) {
       setLastEditedQueryPlatform(newPlatformString);

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -14,7 +14,7 @@ import usePlatformCompatibility from "hooks/usePlatformCompatibility";
 import usePlatformSelector from "hooks/usePlatformSelector";
 
 import { IPolicy, IPolicyFormData } from "interfaces/policy";
-import { IOsqueryPlatform, SelectedPlatformString } from "interfaces/platform";
+import { OsqueryPlatform, SelectedPlatformString } from "interfaces/platform";
 import { DEFAULT_POLICIES } from "pages/policies/constants";
 
 import Avatar from "components/Avatar";
@@ -226,7 +226,7 @@ const PolicyForm = ({
       });
     }
 
-    let selectedPlatforms: IOsqueryPlatform[] = [];
+    let selectedPlatforms: OsqueryPlatform[] = [];
     if (isEditMode || defaultPolicy) {
       selectedPlatforms = getSelectedPlatforms();
     } else {

--- a/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
+++ b/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
@@ -5,7 +5,7 @@ import { AppContext } from "context/app";
 import { PolicyContext } from "context/policy";
 import { IPlatformSelector } from "hooks/usePlatformSelector";
 import { IPolicyFormData } from "interfaces/policy";
-import { IPlatformString } from "interfaces/platform";
+import { SelectedPlatformString } from "interfaces/platform";
 import useDeepEffect from "hooks/useDeepEffect";
 
 // @ts-ignore
@@ -81,7 +81,7 @@ const SaveNewPolicyModal = ({
 
     const newPlatformString = platformSelector
       .getSelectedPlatforms()
-      .join(",") as IPlatformString;
+      .join(",") as SelectedPlatformString;
     setLastEditedQueryPlatform(newPlatformString);
 
     const { valid: validName, errors: newErrors } = validatePolicyName(name);

--- a/frontend/pages/policies/constants.ts
+++ b/frontend/pages/policies/constants.ts
@@ -1,7 +1,7 @@
 import { IPolicyNew } from "interfaces/policy";
-import { IPlatformString } from "interfaces/platform";
+import { SelectedPlatformString } from "interfaces/platform";
 
-const DEFAULT_POLICY_PLATFORM: IPlatformString = "";
+const DEFAULT_POLICY_PLATFORM: SelectedPlatformString = "";
 
 export const DEFAULT_POLICY = {
   id: 1,

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useContext,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { useContext, useCallback, useEffect, useState } from "react";
 import { InjectedRouter } from "react-router";
 import { useQuery } from "react-query";
 import { pick } from "lodash";

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -7,7 +7,7 @@ import { AppContext } from "context/app";
 import { TableContext } from "context/table";
 import { NotificationContext } from "context/notification";
 import { performanceIndicator } from "utilities/helpers";
-import { OsqueryPlatform } from "interfaces/platform";
+import { SupportedPlatform } from "interfaces/platform";
 import {
   IListQueriesResponse,
   ISchedulableQuery,
@@ -46,10 +46,12 @@ interface IManageQueriesPageProps {
 
 interface IEnhancedQuery extends ISchedulableQuery {
   performance: string;
-  platforms: string[];
+  platforms: SupportedPlatform[] | typeof DEFAULT_EMPTY_CELL_VALUE[];
 }
 
-const getPlatforms = (queryString: string): Array<OsqueryPlatform | "---"> => {
+const getPlatforms = (
+  queryString: string
+): SupportedPlatform[] | typeof DEFAULT_EMPTY_CELL_VALUE[] => {
   const { platforms } = checkPlatformCompatibility(queryString);
 
   return platforms || [DEFAULT_EMPTY_CELL_VALUE];

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -7,7 +7,7 @@ import { AppContext } from "context/app";
 import { TableContext } from "context/table";
 import { NotificationContext } from "context/notification";
 import { performanceIndicator } from "utilities/helpers";
-import { IOsqueryPlatform } from "interfaces/platform";
+import { OsqueryPlatform } from "interfaces/platform";
 import {
   IListQueriesResponse,
   ISchedulableQuery,
@@ -49,7 +49,7 @@ interface IEnhancedQuery extends ISchedulableQuery {
   platforms: string[];
 }
 
-const getPlatforms = (queryString: string): Array<IOsqueryPlatform | "---"> => {
+const getPlatforms = (queryString: string): Array<OsqueryPlatform | "---"> => {
   const { platforms } = checkPlatformCompatibility(queryString);
 
   return platforms || [DEFAULT_EMPTY_CELL_VALUE];

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -179,6 +179,7 @@
     .query-icon {
       position: relative;
       top: 2px;
+      display: block;
     }
   }
 }

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -95,76 +95,81 @@
     }
 
     .data-table-block {
-      .data-table__table {
-        thead {
-          .name__header {
-            width: auto;
-          }
-          .platforms__header {
-            width: $col-sm;
-          }
-          .updated_at__header {
-            display: none;
-            width: 0;
-          }
-          .performance__header {
-            display: none;
-            width: 0;
-            @media (min-width: $break-md) {
-              display: table-cell;
+      .data-table {
+        &__wrapper {
+          overflow-x: scroll;
+        }
+        &__table {
+          thead {
+            .name__header {
               width: auto;
             }
-          }
-          @media (min-width: $break-lg) {
-            .author_name__header {
-              width: $col-md;
+            .platforms__header {
+              width: $col-sm;
             }
             .updated_at__header {
-              display: table-cell;
-              width: auto;
+              display: none;
+              width: 0;
             }
-          }
-        }
-        tbody {
-          .name__cell {
-            max-width: $col-lg;
-
-            .children-wrapper {
-              display: flex;
-              gap: $pad-xsmall;
-
-              .observer-can-run-tooltip {
-                font-weight: $regular;
+            .performance__header {
+              display: none;
+              width: 0;
+              @media (min-width: $break-md) {
+                display: table-cell;
+                width: auto;
+              }
+            }
+            @media (min-width: $break-lg) {
+              .author_name__header {
+                width: $col-md;
+              }
+              .updated_at__header {
+                display: table-cell;
+                width: auto;
               }
             }
           }
-
-          @media (max-width: $break-md) {
+          tbody {
             .name__cell {
-              .w400 {
-                max-width: calc(400px - 81px);
+              max-width: $col-lg;
+
+              .children-wrapper {
+                display: flex;
+                gap: $pad-xsmall;
+
+                .observer-can-run-tooltip {
+                  font-weight: $regular;
+                }
               }
             }
-          }
-          .platforms__cell {
-            max-width: $col-md;
-          }
-          .updated_at__cell {
-            display: none;
-            max-width: $col-md;
-          }
-          .performance__cell {
-            display: none;
-            max-width: $col-md;
-          }
-          @media (min-width: $break-md) {
-            .performance__cell {
-              display: table-cell;
+
+            @media (max-width: $break-md) {
+              .name__cell {
+                .w400 {
+                  max-width: calc(400px - 81px);
+                }
+              }
             }
-          }
-          @media (min-width: $break-lg) {
+            .platforms__cell {
+              max-width: $col-md;
+            }
             .updated_at__cell {
-              display: table-cell;
+              display: none;
+              max-width: $col-md;
+            }
+            .performance__cell {
+              display: none;
+              max-width: $col-md;
+            }
+            @media (min-width: $break-md) {
+              .performance__cell {
+                display: table-cell;
+              }
+            }
+            @media (min-width: $break-lg) {
+              .updated_at__cell {
+                display: table-cell;
+              }
             }
           }
         }

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -19,7 +19,7 @@ import PlatformCell from "components/TableContainer/DataTable/PlatformCell";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import PillCell from "components/TableContainer/DataTable/PillCell";
 import TooltipWrapper from "components/TooltipWrapper";
-import StatusIndicator from "components/StatusIndicator";
+import QueryAutomationsStatusIndicator from "../QueryAutomationsStatusIndicator";
 
 interface IQueryRow {
   id: string;
@@ -66,11 +66,12 @@ interface INumberCellProps extends IRowProps {
 }
 
 interface IStringCellProps extends IRowProps {
-  cell: {
-    value: string;
-  };
+  cell: { value: string };
 }
 
+interface IBoolCellProps extends IRowProps {
+  cell: { value: boolean };
+}
 interface IPlatformCellProps extends IRowProps {
   cell: {
     value: string[];
@@ -83,7 +84,8 @@ interface IDataColumn {
     | ((props: ICellProps) => JSX.Element)
     | ((props: IPlatformCellProps) => JSX.Element)
     | ((props: IStringCellProps) => JSX.Element)
-    | ((props: INumberCellProps) => JSX.Element);
+    | ((props: INumberCellProps) => JSX.Element)
+    | ((props: IBoolCellProps) => JSX.Element);
   id?: string;
   title?: string;
   accessor?: string;
@@ -215,31 +217,13 @@ const generateTableHeaders = ({
       Header: "Automations",
       disableSortBy: true,
       accessor: "automations_enabled",
-      Cell: (cellProps: IStringCellProps): JSX.Element => {
-        let status;
-        if (cellProps.cell.value) {
-          if (cellProps.row.original.interval === 0) {
-            status = "paused";
-          } else {
-            status = "on";
-          }
-        } else {
-          status = "off";
-        }
-
-        const tooltip =
-          status === "paused"
-            ? {
-                id: cellProps.row.original.id,
-                tooltipText: (
-                  <>
-                    <strong>Automations</strong> will resume for this query when
-                    a frequency is set.
-                  </>
-                ),
-              }
-            : undefined;
-        return <StatusIndicator value={status} tooltip={tooltip} />;
+      Cell: (cellProps: IBoolCellProps): JSX.Element => {
+        return (
+          <QueryAutomationsStatusIndicator
+            automationsEnabled={cellProps.cell.value}
+            interval={cellProps.row.original.interval}
+          />
+        );
       },
     },
     {

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -79,7 +79,7 @@ interface IBoolCellProps extends IRowProps {
 }
 interface IPlatformCellProps extends IRowProps {
   cell: {
-    value: SelectedPlatformString;
+    value: SupportedPlatform[];
   };
 }
 
@@ -166,17 +166,16 @@ const generateTableHeaders = ({
       accessor: "platforms",
       Cell: (cellProps: IPlatformCellProps): JSX.Element => {
         // translate the SelectedPlatformString into an array of `SupportedPlatform`s
-        const selectedPlatforms = cellProps.cell.value
+        const selectedPlatforms = cellProps.row.original.platform
           .split(",")
           .filter((platform) => platform !== "") as SupportedPlatform[];
 
-        let platformIconsToRender: SupportedPlatform[];
-        if (selectedPlatforms.length === 0) {
-          // User didn't select any platforms, so we render all of them
-          platformIconsToRender = SUPPORTED_PLATFORMS;
-        } else {
-          platformIconsToRender = selectedPlatforms;
-        }
+        const platformIconsToRender: SupportedPlatform[] =
+          selectedPlatforms.length === 0
+            ? // User didn't select any platforms, so we render all compatible
+              cellProps.cell.value
+            : // Render the platforms the user has selected for this query
+              selectedPlatforms;
 
         return <PlatformCell platforms={platformIconsToRender} />;
       },

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -10,7 +10,11 @@ import permissionsUtils from "utilities/permissions";
 import { IUser } from "interfaces/user";
 import { secondsToDhms } from "utilities/helpers";
 import { ISchedulableQuery } from "interfaces/schedulable_query";
-import { OsqueryPlatform } from "interfaces/platform";
+import {
+  SelectedPlatformString,
+  SupportedPlatform,
+  SUPPORTED_PLATFORMS,
+} from "interfaces/platform";
 
 import Icon from "components/Icon";
 import Checkbox from "components/forms/fields/Checkbox";
@@ -75,7 +79,7 @@ interface IBoolCellProps extends IRowProps {
 }
 interface IPlatformCellProps extends IRowProps {
   cell: {
-    value: OsqueryPlatform[];
+    value: SelectedPlatformString;
   };
 }
 
@@ -161,7 +165,20 @@ const generateTableHeaders = ({
       disableSortBy: true,
       accessor: "platforms",
       Cell: (cellProps: IPlatformCellProps): JSX.Element => {
-        return <PlatformCell platforms={cellProps.cell.value} />;
+        // translate the SelectedPlatformString into an array of `SupportedPlatform`s
+        const selectedPlatforms = cellProps.cell.value
+          .split(",")
+          .filter((platform) => platform !== "") as SupportedPlatform[];
+
+        let platformIconsToRender: SupportedPlatform[];
+        if (selectedPlatforms.length === 0) {
+          // User didn't select any platforms, so we render all of them
+          platformIconsToRender = SUPPORTED_PLATFORMS;
+        } else {
+          platformIconsToRender = selectedPlatforms;
+        }
+
+        return <PlatformCell platforms={platformIconsToRender} />;
       },
     },
     {

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -10,6 +10,7 @@ import permissionsUtils from "utilities/permissions";
 import { IUser } from "interfaces/user";
 import { secondsToDhms } from "utilities/helpers";
 import { ISchedulableQuery } from "interfaces/schedulable_query";
+import { IOsqueryPlatform } from "interfaces/platform";
 
 import Icon from "components/Icon";
 import Checkbox from "components/forms/fields/Checkbox";
@@ -74,7 +75,7 @@ interface IBoolCellProps extends IRowProps {
 }
 interface IPlatformCellProps extends IRowProps {
   cell: {
-    value: string[];
+    value: IOsqueryPlatform[];
   };
 }
 
@@ -160,7 +161,7 @@ const generateTableHeaders = ({
       disableSortBy: true,
       accessor: "platforms",
       Cell: (cellProps: IPlatformCellProps): JSX.Element => {
-        return <PlatformCell value={cellProps.cell.value} />;
+        return <PlatformCell platforms={cellProps.cell.value} />;
       },
     },
     {

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -10,7 +10,7 @@ import permissionsUtils from "utilities/permissions";
 import { IUser } from "interfaces/user";
 import { secondsToDhms } from "utilities/helpers";
 import { ISchedulableQuery } from "interfaces/schedulable_query";
-import { IOsqueryPlatform } from "interfaces/platform";
+import { OsqueryPlatform } from "interfaces/platform";
 
 import Icon from "components/Icon";
 import Checkbox from "components/forms/fields/Checkbox";
@@ -75,7 +75,7 @@ interface IBoolCellProps extends IRowProps {
 }
 interface IPlatformCellProps extends IRowProps {
   cell: {
-    value: IOsqueryPlatform[];
+    value: OsqueryPlatform[];
   };
 }
 

--- a/frontend/pages/queries/ManageQueriesPage/components/QueryAutomationsStatusIndicator/QueryAutomationsStatusIndicator.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueryAutomationsStatusIndicator/QueryAutomationsStatusIndicator.tsx
@@ -1,0 +1,44 @@
+import StatusIndicator from "components/StatusIndicator";
+import React from "react";
+
+interface IQueryAutomationsStatusIndicator {
+  automationsEnabled: boolean;
+  interval: number;
+}
+
+const QueryAutomationsStatusIndicator = ({
+  automationsEnabled,
+  interval,
+}: IQueryAutomationsStatusIndicator) => {
+  let status;
+  if (automationsEnabled) {
+    if (interval === 0) {
+      status = "paused";
+    } else {
+      status = "on";
+    }
+  } else {
+    status = "off";
+  }
+
+  const tooltip =
+    status === "paused"
+      ? {
+          tooltipText: (
+            <>
+              <strong>Automations</strong> will resume for this query when a
+              frequency is set.
+            </>
+          ),
+        }
+      : undefined;
+  return (
+    <StatusIndicator
+      value={status}
+      tooltip={tooltip}
+      customIndicatorType={"query-automations"}
+    />
+  );
+};
+
+export default QueryAutomationsStatusIndicator;

--- a/frontend/pages/queries/ManageQueriesPage/components/QueryAutomationsStatusIndicator/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueryAutomationsStatusIndicator/_styles.scss
@@ -1,0 +1,21 @@
+.status-indicator {
+  // Query automations status
+  &--query-automations-on {
+    &:before {
+      background-color: $ui-success;
+    }
+  }
+  &--query-automations-off {
+    &:before {
+      background-color: $ui-offline;
+    }
+  }
+  &--query-automations-paused {
+    .status-tooltip {
+      text-transform: none;
+    }
+    &:before {
+      background-color: $ui-offline;
+    }
+  }
+}

--- a/frontend/pages/queries/ManageQueriesPage/components/QueryAutomationsStatusIndicator/index.ts
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueryAutomationsStatusIndicator/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./QueryAutomationsStatusIndicator";

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -8,7 +8,7 @@ import {
   reconcileMutuallyExclusiveHostParams,
   reconcileMutuallyInclusiveHostParams,
 } from "utilities/url";
-import { ISelectedPlatform } from "interfaces/platform";
+import { SelectedPlatform } from "interfaces/platform";
 import { ISoftware } from "interfaces/software";
 import {
   FileVaultProfileStatus,
@@ -127,7 +127,7 @@ const getSortParams = (sortOptions?: ISortOption[]) => {
   };
 };
 
-const createMdmParams = (platform?: ISelectedPlatform, teamId?: number) => {
+const createMdmParams = (platform?: SelectedPlatform, teamId?: number) => {
   if (platform === "all") {
     return buildQueryStringFromParams({ team_id: teamId });
   }
@@ -328,7 +328,7 @@ export default {
     return sendRequest("GET", HOST_MDM(id));
   },
 
-  getMdmSummary: (platform?: ISelectedPlatform, teamId?: number) => {
+  getMdmSummary: (platform?: SelectedPlatform, teamId?: number) => {
     const { MDM_SUMMARY } = endpoints;
 
     if (!platform || platform === "linux") {

--- a/frontend/services/entities/operating_systems.ts
+++ b/frontend/services/entities/operating_systems.ts
@@ -2,7 +2,7 @@
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
 import { IOperatingSystemVersion } from "interfaces/operating_system";
-import { IOsqueryPlatform } from "interfaces/platform";
+import { OsqueryPlatform } from "interfaces/platform";
 import { buildQueryStringFromParams } from "utilities/url";
 
 // TODO: add platforms to this constant as new ones are supported
@@ -14,7 +14,7 @@ export const OS_VERSIONS_API_SUPPORTED_PLATFORMS = [
 
 export interface IGetOSVersionsRequest {
   id?: number;
-  platform?: IOsqueryPlatform;
+  platform?: OsqueryPlatform;
   teamId?: number;
 }
 

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -1,5 +1,5 @@
 import URL_PREFIX from "router/url_prefix";
-import { IOsqueryPlatform } from "interfaces/platform";
+import { OsqueryPlatform } from "interfaces/platform";
 import paths from "router/paths";
 
 const { origin } = global.window.location;
@@ -141,7 +141,7 @@ export const DEFAULT_CAMPAIGN_STATE = {
   campaign: { ...DEFAULT_CAMPAIGN },
 };
 
-export const PLATFORM_DISPLAY_NAMES: Record<string, IOsqueryPlatform> = {
+export const PLATFORM_DISPLAY_NAMES: Record<string, OsqueryPlatform> = {
   darwin: "macOS",
   macOS: "macOS",
   windows: "Windows",

--- a/frontend/utilities/osquery_tables.ts
+++ b/frontend/utilities/osquery_tables.ts
@@ -4,7 +4,7 @@ import { IOsQueryTable } from "interfaces/osquery_table";
 import osqueryFleetTablesJSON from "../../schema/osquery_fleet_schema.json";
 
 // Typecasting explicity here as we are adding more rigid types such as
-// IOsqueryPlatform for platform names, instead of just any strings.
+// OsqueryPlatform for platform names, instead of just any strings.
 const queryTable = osqueryFleetTablesJSON as IOsQueryTable[];
 
 export const osqueryTables = queryTable.sort((a, b) => {

--- a/frontend/utilities/sql_tools.ts
+++ b/frontend/utilities/sql_tools.ts
@@ -6,6 +6,7 @@ import {
   OsqueryPlatform,
   MACADMINS_EXTENSION_TABLES,
   SUPPORTED_PLATFORMS,
+  SupportedPlatform,
 } from "interfaces/platform";
 
 type IAstNode = Record<string | number | symbol, unknown>;
@@ -64,7 +65,9 @@ const _visit = (
   }
 };
 
-const filterCompatiblePlatforms = (sqlTables: string[]): OsqueryPlatform[] => {
+const filterCompatiblePlatforms = (
+  sqlTables: string[]
+): SupportedPlatform[] => {
   if (!sqlTables.length) {
     return [...SUPPORTED_PLATFORMS]; // if a query has no tables but is still syntatically valid sql, it is treated as compatible with all platforms
   }
@@ -122,7 +125,7 @@ const parseSqlTables = (
 const checkPlatformCompatibility = (
   sqlString: string,
   includeCteTables = false
-): { platforms: OsqueryPlatform[] | null; error: Error | null } => {
+): { platforms: SupportedPlatform[] | null; error: Error | null } => {
   let sqlTables: string[] | undefined;
   try {
     sqlTables = parseSqlTables(sqlString, includeCteTables);

--- a/frontend/utilities/sql_tools.ts
+++ b/frontend/utilities/sql_tools.ts
@@ -3,7 +3,7 @@ import sqliteParser from "sqlite-parser";
 import { intersection, isPlainObject } from "lodash";
 import { osqueryTables } from "utilities/osquery_tables";
 import {
-  IOsqueryPlatform,
+  OsqueryPlatform,
   MACADMINS_EXTENSION_TABLES,
   SUPPORTED_PLATFORMS,
 } from "interfaces/platform";
@@ -24,10 +24,10 @@ interface ISqlCteNode {
 // TODO: Is it ever possible that osquery_tables.json would be missing name or platforms?
 interface IOsqueryTable {
   name: string;
-  platforms: IOsqueryPlatform[];
+  platforms: OsqueryPlatform[];
 }
 
-type IPlatformDictionay = Record<string, IOsqueryPlatform[]>;
+type IPlatformDictionay = Record<string, OsqueryPlatform[]>;
 
 const platformsByTableDictionary: IPlatformDictionay = (osqueryTables as IOsqueryTable[]).reduce(
   (dictionary: IPlatformDictionay, osqueryTable) => {
@@ -64,7 +64,7 @@ const _visit = (
   }
 };
 
-const filterCompatiblePlatforms = (sqlTables: string[]): IOsqueryPlatform[] => {
+const filterCompatiblePlatforms = (sqlTables: string[]): OsqueryPlatform[] => {
   if (!sqlTables.length) {
     return [...SUPPORTED_PLATFORMS]; // if a query has no tables but is still syntatically valid sql, it is treated as compatible with all platforms
   }
@@ -122,7 +122,7 @@ const parseSqlTables = (
 const checkPlatformCompatibility = (
   sqlString: string,
   includeCteTables = false
-): { platforms: IOsqueryPlatform[] | null; error: Error | null } => {
+): { platforms: OsqueryPlatform[] | null; error: Error | null } => {
   let sqlTables: string[] | undefined;
   try {
     sqlTables = parseSqlTables(sqlString, includeCteTables);


### PR DESCRIPTION
## Addresses #12636 – follow-up work for PR #12713

- Update Platforms column to render the user-selected platforms for a query if any, otherwise those that are compatible
<img width="686" alt="Screenshot 2023-07-14 at 6 03 06 PM" src="https://github.com/fleetdm/fleet/assets/61553566/abd1f079-bdfe-45be-b1dd-58eb903672ef">

  - Clean up typing and names around this column 
- Encapsulate logic for query automations column cells into new QueryAutomationsStatusIndicator component
  - Increase modularity and decrease coupling of StatusIndicator
- Cleanly handle overflowing queries table due to very long query name
<img width="512" alt="Screenshot 2023-07-14 at 6 07 20 PM" src="https://github.com/fleetdm/fleet/assets/61553566/6e970038-0aac-4f71-b21d-ececfa66b94f">

- Small copy and layout fixes

- [x] Manual QA for all new/changed functionality
