### PR TITLE
update max-height logo in nav bar

### DIFF
--- a/frontend/components/icons/OrgLogoIcon/_styles.scss
+++ b/frontend/components/icons/OrgLogoIcon/_styles.scss
@@ -1,7 +1,7 @@
 .org-logo-icon {
   // ensures consistent nav bar height regardless of the logo image used
   min-height: 24px;
-  max-height: 46px;
+  max-height: 40px;
   max-width: 150px;
   padding: 0 $pad-small;
 }


### PR DESCRIPTION
quick change to make logo in nav bad have a smaller height. This was done to give the logo a little more breathing space in the nav bar.

**before:**

![image](https://github.com/fleetdm/fleet/assets/1153709/e3e791bb-1d55-4d60-8245-22fb0a0e0171)

**after:**

![image](https://github.com/fleetdm/fleet/assets/1153709/1b303d11-9e73-444a-8b3a-a39b8b519f4f)


