### PR TITLE
Updated cache strategy on queries used in GetClientConfig

### DIFF
--- a/server/datastore/cached_mysql/cached_mysql_test.go
+++ b/server/datastore/cached_mysql/cached_mysql_test.go
@@ -571,7 +571,7 @@ func TestCachedGetTeamName(t *testing.T) {
 	// updating updates the cache
 	result, err := ds.GetTeamName(ctx, 1)
 	require.NoError(t, err)
-	require.Equal(t, team, *result)
+	require.Equal(t, team.Name, *result)
 
 	updatedTeam := &fleet.Team{
 		ID:        team.ID,
@@ -583,7 +583,7 @@ func TestCachedGetTeamName(t *testing.T) {
 
 	result, err = ds.GetTeamName(ctx, team.ID)
 	require.NoError(t, err)
-	require.Equal(t, *updatedTeam, *result)
+	require.Equal(t, updatedTeam.Name, *result)
 
 	// deleting updates the cache
 	err = ds.DeleteTeam(ctx, team.ID)

--- a/server/datastore/cached_mysql/cached_mysql_test.go
+++ b/server/datastore/cached_mysql/cached_mysql_test.go
@@ -539,7 +539,7 @@ func TestCachedTeamMDMConfig(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestCachedTeam(t *testing.T) {
+func TestCachedGetTeamName(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -554,11 +554,11 @@ func TestCachedTeam(t *testing.T) {
 	}
 
 	deleted := false
-	mockedDS.TeamFunc = func(ctx context.Context, teamID uint) (*fleet.Team, error) {
+	mockedDS.GetTeamNameFunc = func(ctx context.Context, teamID uint) (*string, error) {
 		if deleted {
 			return nil, errors.New("not found")
 		}
-		return &team, nil
+		return &team.Name, nil
 	}
 	mockedDS.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
 		return team, nil
@@ -569,7 +569,7 @@ func TestCachedTeam(t *testing.T) {
 	}
 
 	// updating updates the cache
-	result, err := ds.Team(ctx, 1)
+	result, err := ds.GetTeamName(ctx, 1)
 	require.NoError(t, err)
 	require.Equal(t, team, *result)
 
@@ -581,7 +581,7 @@ func TestCachedTeam(t *testing.T) {
 	_, err = ds.SaveTeam(ctx, updatedTeam)
 	require.NoError(t, err)
 
-	result, err = ds.Team(ctx, team.ID)
+	result, err = ds.GetTeamName(ctx, team.ID)
 	require.NoError(t, err)
 	require.Equal(t, *updatedTeam, *result)
 
@@ -589,7 +589,7 @@ func TestCachedTeam(t *testing.T) {
 	err = ds.DeleteTeam(ctx, team.ID)
 	require.NoError(t, err)
 
-	_, err = ds.Team(ctx, team.ID)
+	_, err = ds.GetTeamName(ctx, team.ID)
 	require.Error(t, err)
 }
 

--- a/server/datastore/cached_mysql/cached_mysql_test.go
+++ b/server/datastore/cached_mysql/cached_mysql_test.go
@@ -591,3 +591,94 @@ func TestCachedTeam(t *testing.T) {
 	_, err = ds.Team(ctx, team.ID)
 	require.Error(t, err)
 }
+
+func TestCachedListQueries(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	mockedDS := new(mock.Store)
+	ds := New(mockedDS, WithScheduledQueriesExpiration(10_000*time.Millisecond))
+
+	scheduledQueries := []*fleet.Query{
+		{
+			ID:                 1,
+			Name:               "test",
+			ScheduleInterval:   100,
+			AutomationsEnabled: true,
+		},
+		{
+			ID:                 2,
+			Name:               "test II",
+			ScheduleInterval:   100,
+			AutomationsEnabled: true,
+			TeamID:             ptr.Uint(1),
+		},
+	}
+	nonScheduledQueries := []*fleet.Query{
+		{
+			ID:                 1,
+			Name:               "test III",
+			ScheduleInterval:   0,
+			AutomationsEnabled: false,
+		},
+		{
+			ID:                 1,
+			Name:               "test IV",
+			ScheduleInterval:   0,
+			AutomationsEnabled: false,
+			TeamID:             ptr.Uint(1),
+		},
+	}
+	mockedDS.ListQueriesFunc = func(ctx context.Context, opt fleet.ListQueryOptions) ([]*fleet.Query, error) {
+		if opt.IsScheduled != nil && *opt.IsScheduled {
+			if opt.TeamID != nil {
+				return []*fleet.Query{scheduledQueries[1]}, nil
+			}
+			return []*fleet.Query{scheduledQueries[0]}, nil
+		}
+		if opt.TeamID != nil {
+			return []*fleet.Query{nonScheduledQueries[1]}, nil
+		}
+		return []*fleet.Query{nonScheduledQueries[0]}, nil
+	}
+
+	// Tests that queries for non-scheduled queries objects always hit the DB
+	opt := fleet.ListQueryOptions{IsScheduled: ptr.Bool(false)}
+	result, err := ds.ListQueries(ctx, opt)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, *nonScheduledQueries[0], *result[0])
+
+	opt = fleet.ListQueryOptions{IsScheduled: ptr.Bool(false), TeamID: ptr.Uint(1)}
+	result, err = ds.ListQueries(ctx, opt)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, *nonScheduledQueries[1], *result[0])
+
+	nonScheduledQueries[1].Name = "Some other name"
+	result, err = ds.ListQueries(ctx, opt)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, *nonScheduledQueries[1], *result[0])
+
+	// Test that queries for scheduled queries objects are cached.
+	opt = fleet.ListQueryOptions{IsScheduled: ptr.Bool(true)}
+	result, err = ds.ListQueries(ctx, opt)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, *scheduledQueries[0], *result[0])
+
+	opt = fleet.ListQueryOptions{IsScheduled: ptr.Bool(true), TeamID: ptr.Uint(1)}
+	result, err = ds.ListQueries(ctx, opt)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, *scheduledQueries[1], *result[0])
+
+	oldName := scheduledQueries[1].Name
+	scheduledQueries[1].Name = "Some change"
+	result, err = ds.ListQueries(ctx, opt)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, oldName, (*result[0]).Name)
+}

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -428,3 +428,17 @@ func (ds *Datastore) DeleteIntegrationsFromTeams(ctx context.Context, deletedInt
 	}
 	return rows.Err()
 }
+
+func (ds *Datastore) GetTeamName(ctx context.Context, teamID uint) (*string, error) {
+	stmt := `SELECT name FROM teams WHERE id = ?`
+	var teamName string
+
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &teamName, stmt, teamID); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ctxerr.Wrap(ctx, notFound("Team").WithID(teamID))
+		}
+		return nil, ctxerr.Wrap(ctx, err, "select team")
+	}
+
+	return &teamName, nil
+}

--- a/server/datastore/mysql/teams_test.go
+++ b/server/datastore/mysql/teams_test.go
@@ -35,6 +35,7 @@ func TestTeams(t *testing.T) {
 		{"DeleteIntegrationsFromTeams", testTeamsDeleteIntegrationsFromTeams},
 		{"TeamsFeatures", testTeamsFeatures},
 		{"TeamsMDMConfig", testTeamsMDMConfig},
+		{"GetTeamByName", testGetTeamByName},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -622,5 +623,26 @@ func testTeamsMDMConfig(t *testing.T, ds *Datastore) {
 				MacOSSetupAssistant: optjson.SetString("assistant"),
 			},
 		}, mdm)
+	})
+}
+
+func testGetTeamByName(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	t.Run("team does not exists", func(t *testing.T) {
+		r, err := ds.GetTeamName(ctx, 123)
+		require.Nil(t, r)
+		require.Error(t, err)
+	})
+
+	t.Run("returns the team name", func(t *testing.T) {
+		team, err := ds.NewTeam(ctx, &fleet.Team{
+			Name: "team1",
+		})
+		require.NoError(t, err)
+
+		result, err := ds.GetTeamName(ctx, team.ID)
+		require.NoError(t, err)
+		require.Equal(t, team.Name, *result)
 	})
 }

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -767,8 +767,6 @@ type ListQueryOptions struct {
 	// IsScheduled filters queries that are meant to run at a set interval.
 	IsScheduled        *bool
 	OnlyObserverCanRun bool
-	// ExcludeStats whehter aggregated_stats should be excluded or not.
-	ExcludeStats bool
 }
 
 type ListActivitiesOptions struct {

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -767,6 +767,8 @@ type ListQueryOptions struct {
 	// IsScheduled filters queries that are meant to run at a set interval.
 	IsScheduled        *bool
 	OnlyObserverCanRun bool
+	// ExcludeStats whehter aggregated_stats should be excluded or not.
+	ExcludeStats bool
 }
 
 type ListActivitiesOptions struct {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -82,6 +82,9 @@ type Datastore interface {
 	// ListQueries returns a list of queries with the provided sorting and paging options. Associated packs should also
 	// be loaded.
 	ListQueries(ctx context.Context, opt ListQueryOptions) ([]*Query, error)
+	// ListScheduledQueriesForAgents returns a list of scheduled queries (without stats) for the
+	// given teamID. If teamID is nil, then all scheduled queries for the 'global' team are returned.
+	ListScheduledQueriesForAgents(ctx context.Context, teamID *uint) ([]*Query, error)
 	// QueryByName looks up a query by name on a team. If teamID is nil, then the query is looked up in
 	// the 'global' team.
 	QueryByName(ctx context.Context, teamID *uint, name string, opts ...OptionalArg) (*Query, error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -400,6 +400,8 @@ type Datastore interface {
 	SaveTeam(ctx context.Context, team *Team) (*Team, error)
 	// Team retrieves the Team by ID.
 	Team(ctx context.Context, tid uint) (*Team, error)
+	// GetTeamName retrieves the team name by their ID.
+	GetTeamName(ctx context.Context, teamID uint) (*string, error)
 	// Team deletes the Team by ID.
 	DeleteTeam(ctx context.Context, tid uint) error
 	// TeamByName retrieves the Team by Name.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -70,6 +70,8 @@ type QueryFunc func(ctx context.Context, id uint) (*fleet.Query, error)
 
 type ListQueriesFunc func(ctx context.Context, opt fleet.ListQueryOptions) ([]*fleet.Query, error)
 
+type ListScheduledQueriesForAgentsFunc func(ctx context.Context, teamID *uint) ([]*fleet.Query, error)
+
 type QueryByNameFunc func(ctx context.Context, teamID *uint, name string, opts ...fleet.OptionalArg) (*fleet.Query, error)
 
 type ObserverCanRunQueryFunc func(ctx context.Context, queryID uint) (bool, error)
@@ -738,6 +740,9 @@ type DataStore struct {
 
 	ListQueriesFunc        ListQueriesFunc
 	ListQueriesFuncInvoked bool
+
+	ListScheduledQueriesForAgentsFunc        ListScheduledQueriesForAgentsFunc
+	ListScheduledQueriesForAgentsFuncInvoked bool
 
 	QueryByNameFunc        QueryByNameFunc
 	QueryByNameFuncInvoked bool
@@ -1807,6 +1812,13 @@ func (s *DataStore) ListQueries(ctx context.Context, opt fleet.ListQueryOptions)
 	s.ListQueriesFuncInvoked = true
 	s.mu.Unlock()
 	return s.ListQueriesFunc(ctx, opt)
+}
+
+func (s *DataStore) ListScheduledQueriesForAgents(ctx context.Context, teamID *uint) ([]*fleet.Query, error) {
+	s.mu.Lock()
+	s.ListScheduledQueriesForAgentsFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListScheduledQueriesForAgentsFunc(ctx, teamID)
 }
 
 func (s *DataStore) QueryByName(ctx context.Context, teamID *uint, name string, opts ...fleet.OptionalArg) (*fleet.Query, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -302,6 +302,8 @@ type SaveTeamFunc func(ctx context.Context, team *fleet.Team) (*fleet.Team, erro
 
 type TeamFunc func(ctx context.Context, tid uint) (*fleet.Team, error)
 
+type GetTeamNameFunc func(ctx context.Context, teamID uint) (*string, error)
+
 type DeleteTeamFunc func(ctx context.Context, tid uint) error
 
 type TeamByNameFunc func(ctx context.Context, name string) (*fleet.Team, error)
@@ -1088,6 +1090,9 @@ type DataStore struct {
 
 	TeamFunc        TeamFunc
 	TeamFuncInvoked bool
+
+	GetTeamNameFunc        GetTeamNameFunc
+	GetTeamNameFuncInvoked bool
 
 	DeleteTeamFunc        DeleteTeamFunc
 	DeleteTeamFuncInvoked bool
@@ -2624,6 +2629,13 @@ func (s *DataStore) Team(ctx context.Context, tid uint) (*fleet.Team, error) {
 	s.TeamFuncInvoked = true
 	s.mu.Unlock()
 	return s.TeamFunc(ctx, tid)
+}
+
+func (s *DataStore) GetTeamName(ctx context.Context, teamID uint) (*string, error) {
+	s.mu.Lock()
+	s.GetTeamNameFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetTeamNameFunc(ctx, teamID)
 }
 
 func (s *DataStore) DeleteTeam(ctx context.Context, tid uint) error {

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -347,8 +347,7 @@ func getClientConfigEndpoint(ctx context.Context, request interface{}, svc fleet
 }
 
 func (svc *Service) getScheduledQueries(ctx context.Context, teamID *uint) (fleet.Queries, error) {
-	opts := fleet.ListQueryOptions{IsScheduled: ptr.Bool(true), TeamID: teamID}
-	queries, err := svc.ds.ListQueries(ctx, opts)
+	queries, err := svc.ds.ListScheduledQueriesForAgents(ctx, teamID)
 	if err != nil {
 		return nil, err
 	}

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -443,18 +443,18 @@ func (svc *Service) GetClientConfig(ctx context.Context) (map[string]interface{}
 	}
 
 	if host.TeamID != nil {
-		team, err := svc.ds.Team(ctx, *host.TeamID)
+		teamName, err := svc.ds.GetTeamName(ctx, *host.TeamID)
 		if err != nil {
 			return nil, newOsqueryError("database error: " + err.Error())
 		}
 
-		if team != nil {
+		if teamName != nil {
 			teamQueries, err := svc.getScheduledQueries(ctx, host.TeamID)
 			if err != nil {
 				return nil, newOsqueryError("database error: " + err.Error())
 			}
 			if len(teamQueries) > 0 {
-				packName := fmt.Sprintf("Team: %s", team.Name)
+				packName := fmt.Sprintf("Team: %s", *teamName)
 				packConfig[packName] = fleet.PackContent{
 					Queries: teamQueries,
 				}

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -2006,6 +2006,14 @@ func TestUpdateHostIntervals(t *testing.T) {
 
 	svc, ctx := newTestService(t, ds, nil, nil)
 
+	ds.TeamFunc = func(ctx context.Context, tid uint) (*fleet.Team, error) {
+		return nil, nil
+	}
+
+	ds.ListQueriesFunc = func(ctx context.Context, opt fleet.ListQueryOptions) ([]*fleet.Query, error) {
+		return nil, nil
+	}
+
 	ds.ListPacksForHostFunc = func(ctx context.Context, hid uint) ([]*fleet.Pack, error) {
 		return []*fleet.Pack{}, nil
 	}

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -2004,11 +2004,11 @@ func TestUpdateHostIntervals(t *testing.T) {
 
 	svc, ctx := newTestService(t, ds, nil, nil)
 
-	ds.TeamFunc = func(ctx context.Context, tid uint) (*fleet.Team, error) {
+	ds.GetTeamNameFunc = func(ctx context.Context, tid uint) (*string, error) {
 		return nil, nil
 	}
 
-	ds.ListQueriesFunc = func(ctx context.Context, opt fleet.ListQueryOptions) ([]*fleet.Query, error) {
+	ds.ListScheduledQueriesForAgentsFunc = func(ctx context.Context, teamID *uint) ([]*fleet.Query, error) {
 		return nil, nil
 	}
 

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -71,8 +71,8 @@ func TestGetClientConfig(t *testing.T) {
 			return []*fleet.ScheduledQuery{}, nil
 		}
 	}
-	ds.ListQueriesFunc = func(ctx context.Context, opt fleet.ListQueryOptions) ([]*fleet.Query, error) {
-		if opt.TeamID == nil {
+	ds.ListScheduledQueriesForAgentsFunc = func(ctx context.Context, teamID *uint) ([]*fleet.Query, error) {
+		if teamID == nil {
 			return nil, nil
 		}
 		return []*fleet.Query{

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -40,11 +40,9 @@ import (
 
 func TestGetClientConfig(t *testing.T) {
 	ds := new(mock.Store)
-	ds.TeamFunc = func(ctx context.Context, tid uint) (*fleet.Team, error) {
-		return &fleet.Team{
-			Name: "Alamo",
-			ID:   1,
-		}, nil
+	ds.GetTeamNameFunc = func(ctx context.Context, tid uint) (*string, error) {
+		teamName := "Alamo"
+		return &teamName, nil
 	}
 
 	ds.TeamAgentOptionsFunc = func(ctx context.Context, teamID uint) (*json.RawMessage, error) {


### PR DESCRIPTION
1. Cached results of `svc.ds.Team`
2. Cached results of `svc.ds.ListQueries` too for scheduled queries only.
3. Do not load aggregated stats on `svc.ds.ListQueries` insde `GetClientConfig`