### PR TITLE
fixes for the puppet module

### DIFF
--- a/ee/tools/puppet/fleetdm/examples/multiple-teams.pp
+++ b/ee/tools/puppet/fleetdm/examples/multiple-teams.pp
@@ -1,10 +1,10 @@
 node default {
-  fleetdm::profile { 'cis.macOSBenchmark.section2.BluetoothSharing':
+  fleetdm::profile { 'com.apple.SoftwareUpdate':
     template => template('fleetdm/automatic_updates.mobileconfig.erb'),
     group    => 'base',
   }
 
-  fleetdm::profile { 'com.apple.SoftwareUpdate':
+  fleetdm::profile { 'cis.macOSBenchmark.section2.BluetoothSharing':
     template => template('fleetdm/disable_bluetooth_file_sharing.mobileconfig.erb'),
     group    => 'workstations',
   }

--- a/ee/tools/puppet/fleetdm/lib/puppet/functions/fleetdm/preassign_profile.rb
+++ b/ee/tools/puppet/fleetdm/lib/puppet/functions/fleetdm/preassign_profile.rb
@@ -24,9 +24,8 @@ Puppet::Functions.create_function(:"fleetdm::preassign_profile") do
       if host_profiles['error'].empty?
         Puppet.info("successfully pre-set profile #{profile_identifier} as #{ensure_profile}")
 
-        # if this profile is not in the list of profiles assigned to the host,
-        # signal that the resource has changed.
-        unless host_profiles['body']['profiles'].any? { |p| p['checksum'] == base64_checksum }
+        has_profile = host_profiles['body']['profiles'].any? { |p| p['checksum'] == base64_checksum }
+        if (has_profile && ensure_profile == 'absent') || (!has_profile && ensure_profile == 'present')
           response['resource_changed'] = true
         end
       end

--- a/ee/tools/puppet/fleetdm/lib/puppet/util/fleet_client.rb
+++ b/ee/tools/puppet/fleetdm/lib/puppet/util/fleet_client.rb
@@ -99,7 +99,7 @@ module Puppet::Util
     # @param host_id [Number] Fleet's internal host id.
     # @return [Hash] The response status code, headers, and body.
     def get_host_profiles(host_id)
-      req(method: :get, path: "/api/latest/fleet/mdm/hosts/#{host_id}/profiles", cached: true)
+      req(method: :get, path: "/api/latest/fleet/mdm/hosts/#{host_id}/profiles", cached: false)
     end
 
     # Gets host details by host identifier.

--- a/ee/tools/puppet/fleetdm/metadata.json
+++ b/ee/tools/puppet/fleetdm/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetdm-fleetdm",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Fleet Device Management Inc",
   "summary": "MDM management and profile assignment using FleetDM",
   "license": "proprietary",


### PR DESCRIPTION
- Don't cache requests to get profiles, they don't happen in order when run agains a real Puppet server
- Report resource has changed if the profile was in the host but the new resource type is absent

# Checklist for submitter

- [x] Manual QA for all new/changed functionality
