### PR TITLE
UI – Queries page updates pt.2

### DIFF
--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -124,7 +124,7 @@ const ManageQueriesPage = ({
     isFetching: isFetchingCurTeamQueries,
     refetch: refetchCurTeamQueries,
   } = useQuery<
-    IListQueriesResponse,
+    IEnhancedQuery[],
     Error,
     IEnhancedQuery[],
     IQueryKeyQueriesLoadAll[]
@@ -148,7 +148,7 @@ const ManageQueriesPage = ({
     isFetching: isFetchingGlobalQueries,
     refetch: refetchGlobalQueries,
   } = useQuery<
-    IListQueriesResponse,
+    IEnhancedQuery[],
     Error,
     IEnhancedQuery[],
     IQueryKeyQueriesLoadAll[]

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -227,19 +227,17 @@ const ManageQueriesPage = ({
       return <TableDataError />;
     }
     return (
-      <div>
-        <QueriesTable
-          queriesList={curTeamEnhancedQueries || []}
-          isLoading={isFetchingCurTeamQueries}
-          onCreateQueryClick={onCreateQueryClick}
-          onDeleteQueryClick={onDeleteQueryClick}
-          isOnlyObserver={isOnlyObserver}
-          isObserverPlus={isObserverPlus}
-          isAnyTeamObserverPlus={isAnyTeamObserverPlus || false}
-          router={router}
-          queryParams={queryParams}
-        />
-      </div>
+      <QueriesTable
+        queriesList={curTeamEnhancedQueries || []}
+        isLoading={isFetchingCurTeamQueries}
+        onCreateQueryClick={onCreateQueryClick}
+        onDeleteQueryClick={onDeleteQueryClick}
+        isOnlyObserver={isOnlyObserver}
+        isObserverPlus={isObserverPlus}
+        isAnyTeamObserverPlus={isAnyTeamObserverPlus || false}
+        router={router}
+        queryParams={queryParams}
+      />
     );
   };
 
@@ -274,19 +272,18 @@ const ManageQueriesPage = ({
       return <TableDataError />;
     }
     return (
-      <div>
-        <QueriesTable
-          queriesList={globalEnhancedQueries || []}
-          isLoading={isFetchingGlobalQueries}
-          onCreateQueryClick={onCreateQueryClick}
-          onDeleteQueryClick={onDeleteQueryClick}
-          isOnlyObserver={isOnlyObserver}
-          isObserverPlus={isObserverPlus}
-          isAnyTeamObserverPlus={isAnyTeamObserverPlus || false}
-          router={router}
-          queryParams={queryParams}
-        />
-      </div>
+      <QueriesTable
+        queriesList={globalEnhancedQueries || []}
+        isLoading={isFetchingGlobalQueries}
+        onCreateQueryClick={onCreateQueryClick}
+        onDeleteQueryClick={onDeleteQueryClick}
+        isOnlyObserver={isOnlyObserver}
+        isObserverPlus={isObserverPlus}
+        isAnyTeamObserverPlus={isAnyTeamObserverPlus || false}
+        router={router}
+        queryParams={queryParams}
+        isInherited
+      />
     );
   };
 

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -59,11 +59,14 @@
     gap: $pad-small;
   }
 
-  form-field--dropdown {
-    margin: 0;
-  }
-
   .queries-table {
+    .controls {
+      .form-field {
+        &--dropdown {
+          margin: 0;
+        }
+      }
+    }
     &__platform-dropdown {
       width: 159px;
 

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -41,6 +41,7 @@ interface IQueriesTableProps {
     order_direction?: "asc" | "desc";
     team_id?: string;
   };
+  isInherited?: boolean;
 }
 
 const DEFAULT_SORT_DIRECTION = "desc";
@@ -89,8 +90,9 @@ const QueriesTable = ({
   isOnlyObserver,
   isObserverPlus,
   isAnyTeamObserverPlus,
-  queryParams,
   router,
+  queryParams,
+  isInherited = false,
 }: IQueriesTableProps): JSX.Element | null => {
   const { currentUser } = useContext(AppContext);
 
@@ -239,11 +241,13 @@ const QueriesTable = ({
     [currentUser]
   );
 
-  const searchable = !(queriesList?.length === 0 && searchQuery === "");
+  const searchable =
+    !(queriesList?.length === 0 && searchQuery === "") && !isInherited;
 
   return tableHeaders && !isLoading ? (
     <div className={`${baseClass}`}>
       <TableContainer
+        disableCount={isInherited}
         resultsTitle="queries"
         columns={tableHeaders}
         data={queriesList}
@@ -269,7 +273,9 @@ const QueriesTable = ({
         isAllPagesSelected={false}
         searchable={searchable}
         searchQueryColumn="name"
-        customControl={searchable ? renderPlatformDropdown : undefined}
+        customControl={
+          searchable && !isInherited ? renderPlatformDropdown : undefined
+        }
         isClientSidePagination
         onClientSidePaginationChange={onClientSidePaginationChange}
         isClientSideFilter

--- a/frontend/pages/queries/QueryPage/QueryPage.tsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.tsx
@@ -47,7 +47,7 @@ const QueryPage = ({
   location,
 }: IQueryPageProps): JSX.Element => {
   const queryId = paramsQueryId ? parseInt(paramsQueryId, 10) : null;
-  const { teamIdForApi: teamIdForQuery } = useTeamIdParam({
+  const { currentTeamSummary: teamForQuery } = useTeamIdParam({
     location,
     router,
     includeAllTeams: true,
@@ -198,7 +198,7 @@ const QueryPage = ({
       router,
       baseClass,
       queryIdForEdit: queryId,
-      teamIdForQuery,
+      teamForQuery,
       showOpenSchemaActionText,
       storedQuery,
       isStoredQueryLoading,

--- a/frontend/pages/queries/QueryPage/components/SaveQueryModal/SaveQueryModal.tsx
+++ b/frontend/pages/queries/QueryPage/components/SaveQueryModal/SaveQueryModal.tsx
@@ -166,22 +166,20 @@ const SaveQueryModal = ({
             type="textarea"
             placeholder="What information does your query reveal? (optional)"
           />
-          <div>
-            <Dropdown
-              searchable={false}
-              options={FREQUENCY_DROPDOWN_OPTIONS}
-              onChange={(value: number) => {
-                setSelectedFrequency(value);
-              }}
-              placeholder={"Every hour"}
-              value={selectedFrequency}
-              label="Frequency"
-              wrapperClassName={`${baseClass}__form-field ${baseClass}__form-field--frequency`}
-            />
-            <p className="help-text">
-              If automations are on, this is how often your query collects data.
-            </p>
-          </div>
+          <Dropdown
+            searchable={false}
+            options={FREQUENCY_DROPDOWN_OPTIONS}
+            onChange={(value: number) => {
+              setSelectedFrequency(value);
+            }}
+            placeholder={"Every hour"}
+            value={selectedFrequency}
+            label="Frequency"
+            wrapperClassName={`${baseClass}__form-field ${baseClass}__form-field--frequency`}
+          />
+          <p className="help-text">
+            If automations are on, this is how often your query collects data.
+          </p>
           <Checkbox
             name="observerCanRun"
             onChange={setObserverCanRun}

--- a/frontend/pages/queries/QueryPage/screens/QueryEditor.tsx
+++ b/frontend/pages/queries/QueryPage/screens/QueryEditor.tsx
@@ -23,7 +23,10 @@ interface IQueryEditorProps {
   router: InjectedRouter;
   baseClass: string;
   queryIdForEdit: number | null;
-  teamIdForQuery?: number;
+  teamForQuery?: {
+    name: string;
+    id: number;
+  };
   storedQuery: IQuery | undefined;
   storedQueryError: Error | null;
   showOpenSchemaActionText: boolean;
@@ -43,7 +46,7 @@ const QueryEditor = ({
   router,
   baseClass,
   queryIdForEdit,
-  teamIdForQuery,
+  teamForQuery,
   storedQuery,
   storedQueryError,
   showOpenSchemaActionText,
@@ -90,9 +93,14 @@ const QueryEditor = ({
       renderFlash("success", "Query created!");
       setBackendValidators({});
     } catch (createError: any) {
-      console.error(createError);
       if (createError.data.errors[0].reason.includes("already exists")) {
-        setBackendValidators({ name: "A query with this name already exists" });
+        const teamErrorText =
+          teamForQuery && teamForQuery?.id !== -1
+            ? `the ${teamForQuery.name} team`
+            : "all teams";
+        setBackendValidators({
+          name: `A query with that name already exists for ${teamErrorText}.`,
+        });
       } else {
         renderFlash(
           "error",
@@ -160,7 +168,7 @@ const QueryEditor = ({
         onUpdate={onUpdateQuery}
         storedQuery={storedQuery}
         queryIdForEdit={queryIdForEdit}
-        teamIdForQuery={teamIdForQuery}
+        teamIdForQuery={teamForQuery?.id}
         isStoredQueryLoading={isStoredQueryLoading}
         showOpenSchemaActionText={showOpenSchemaActionText}
         onOpenSchemaSidebar={onOpenSchemaSidebar}


### PR DESCRIPTION
## Addresses #12636 – follow-up work to PRs #12713 & #12784 

- Fix alignment of the Platforms dropdown
<img width="1256" alt="Screenshot 2023-07-17 at 7 37 56 PM" src="https://github.com/fleetdm/fleet/assets/61553566/5f162a99-6840-474f-9679-3115782329cf">

- Hide redundant table headers for inherited queries table
<img width="1255" alt="Screenshot 2023-07-17 at 7 39 35 PM" src="https://github.com/fleetdm/fleet/assets/61553566/8ef91588-4e5a-4203-a2fc-ae24ab0493db">

- Update SaveQueryModal name field's error state copy (note - [awaiting product decision](https://github.com/fleetdm/fleet/issues/12646#issuecomment-1639159107) on further updates to the UI here - likely for separate ticket):

- Avoid redundant processing by moving it outside of useQuery's `select` option.

- Leverage query key design to cache global queries for inherited table

- [x] Manual QA