### PR TITLE
Changed "Find a meeting time" link

### DIFF
--- a/handbook/business-operations/README.md
+++ b/handbook/business-operations/README.md
@@ -14,7 +14,7 @@ We use the Zoom add-on for Google Calendar to schedule Zoom meetings when we cre
 We configure our Zoom meetings to let participants join before the host starts the meeting. We do this to make sure meetings start on time, even if the host isn't there.
 
 #### Internal meeting scheduling
-Use the Google Calendar "[Find a meeting time](https://support.google.com/calendar/answer/37161?hl=en&co=GENIE.Platform%3DDesktop#zippy=%2Cfind-a-meeting-time)" feature to coordinate meetings with Fleet team members. Enter the `@fleetdm.com` emails for each
+Use the Google Calendar "[Find a meeting time](https://support.google.com/calendar/answer/72143?hl=en&ref_topic=10510646&sjid=7187599067132459840-NA#zippy=%2Cclick-an-empty-time-in-your-calendar)" feature to coordinate meetings with Fleet team members. Enter the `@fleetdm.com` emails for each
 participant into the "Meet with..." box in Google Calendar, and the calendar availability for each
 participant will appear in your view. Then, when you select a meeting time, those participants will
 automatically be invited, and a video conference will be attached to the invite.


### PR DESCRIPTION
Changed to include specification about what "available" means in Google Calendar when scheduling internal meeting. 

Current: 
![image](https://github.com/fleetdm/fleet/assets/108141731/c0f49386-e81a-4bf3-8b55-46c9944d19d6)


With proposed changes: 

![image](https://github.com/fleetdm/fleet/assets/108141731/66b55ebb-9e3b-44c6-a3de-4d82e942e740)
