### PR TITLE
fix bug in deprovisioner

### DIFF
--- a/infrastructure/sandbox/JITProvisioner/ingress_destroyer/main.go
+++ b/infrastructure/sandbox/JITProvisioner/ingress_destroyer/main.go
@@ -12,12 +12,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	autoscaling "k8s.io/client-go/applyconfigurations/autoscaling/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 func main() {
+    log.SetFlags(log.LstdFlags | log.Lshortfile)
 	instanceID := getOrPanic("INSTANCE_ID")
 	ddbTable := getOrPanic("DYNAMODB_LIFECYCLE_TABLE")
 	clusterName := getOrPanic("CLUSTER_NAME")
@@ -74,7 +74,14 @@ func deleteIngress(id, name, ddbTable string) {
 
 	// Scale it down to save money
 	time.Sleep(60)
-	_, err = clientset.AppsV1().Deployments("default").ApplyScale(context.Background(), id, &autoscaling.ScaleApplyConfiguration{Spec: &autoscaling.ScaleSpecApplyConfiguration{Replicas: new(int32)}}, v1.ApplyOptions{})
+    s, err := clientset.AppsV1().Deployments("default").GetScale(context.Background(), id, v1.GetOptions{})
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    sc := *s
+    sc.Spec.Replicas = 0
+	_, err = clientset.AppsV1().Deployments("default").UpdateScale(context.Background(), id, &sc, v1.UpdateOptions{})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
