### PR TITLE
Fleet UI: (Unreleased bug) When no platforms are selected, empty string platforms, show ALL platform icons in table and All in platform dropdown

### DIFF
--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -10,11 +10,7 @@ import permissionsUtils from "utilities/permissions";
 import { IUser } from "interfaces/user";
 import { secondsToDhms } from "utilities/helpers";
 import { ISchedulableQuery } from "interfaces/schedulable_query";
-import {
-  SelectedPlatformString,
-  SupportedPlatform,
-  SUPPORTED_PLATFORMS,
-} from "interfaces/platform";
+import { SupportedPlatform } from "interfaces/platform";
 
 import Icon from "components/Icon";
 import Checkbox from "components/forms/fields/Checkbox";
@@ -166,18 +162,11 @@ const generateTableHeaders = ({
       accessor: "platforms",
       Cell: (cellProps: IPlatformCellProps): JSX.Element => {
         // translate the SelectedPlatformString into an array of `SupportedPlatform`s
-        const selectedPlatforms =
-          (cellProps.row.original.platform
-            ?.split(",")
-            .filter((platform) => platform !== "") as SupportedPlatform[]) ??
-          [];
-
-        const platformIconsToRender: SupportedPlatform[] =
-          selectedPlatforms.length === 0
-            ? // User didn't select any platforms, so we render all compatible
-              cellProps.cell.value
-            : // Render the platforms the user has selected for this query
-              selectedPlatforms;
+        const platformIconsToRender = (cellProps.row.original.platform === ""
+          ? ["darwin", "windows", "linux", "chrome"]
+          : cellProps.row.original.platform
+              ?.split(",")
+              .filter((platform) => platform !== "")) as SupportedPlatform[];
 
         return <PlatformCell platforms={platformIconsToRender} />;
       },

--- a/frontend/services/mock_service/mocks/responses.ts
+++ b/frontend/services/mock_service/mocks/responses.ts
@@ -486,7 +486,7 @@ const globalQueries = {
       query: "SELECT * FROM osquery_info",
       team_id: 2,
       interval: 604800, // Every week
-      platform: "Windows",
+      platform: "windows",
       min_osquery_version: "",
       automations_enabled: false,
       logging: "differential",
@@ -563,7 +563,6 @@ const teamQueries = {
         total_executions: 1,
       },
       performance: "Undetermined",
-      platforms: ["windows"],
     },
     {
       created_at: "2023-06-08T15:31:35Z",

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -201,8 +201,8 @@ export const PLATFORM_LABEL_DISPLAY_TYPES: Record<string, string> = {
 
 interface IPlatformDropdownOptions {
   label: "All" | "Windows" | "Linux" | "macOS" | "ChromeOS";
-  value: "all" | "windows" | "linux" | "darwin" | "chrome";
-  path: string;
+  value: "all" | "windows" | "linux" | "darwin" | "chrome" | "";
+  path?: string;
 }
 export const PLATFORM_DROPDOWN_OPTIONS: IPlatformDropdownOptions[] = [
   { label: "All", value: "all", path: paths.DASHBOARD },
@@ -213,10 +213,12 @@ export const PLATFORM_DROPDOWN_OPTIONS: IPlatformDropdownOptions[] = [
 ];
 
 // Schedules does not support ChromeOS
-export const SCHEDULE_PLATFORM_DROPDOWN_OPTIONS: IPlatformDropdownOptions[] = PLATFORM_DROPDOWN_OPTIONS.slice(
-  0,
-  -1
-);
+export const SCHEDULE_PLATFORM_DROPDOWN_OPTIONS: IPlatformDropdownOptions[] = [
+  { label: "All", value: "" }, // API empty string runs on all platforms
+  { label: "macOS", value: "darwin" },
+  { label: "Windows", value: "windows" },
+  { label: "Linux", value: "linux" },
+];
 
 export const PLATFORM_NAME_TO_LABEL_NAME = {
   all: "",


### PR DESCRIPTION
## Issue
Cerra #12860 (unreleased bug)

## Description
- On the manage queries page: When a query platform is saved as `platform: ""`, show all platform icons in the UI as the backend is running "" option on all platforms
- On the edit query page: When a query platform is saved as `platform: ""`, show "All" selected in the platform dropdown picker

## QA
- [x] Personally QAed on frontend
NOTE: Will need to QA all functionality E2E with test branch

## Screenrecording of `platform: ""` query:

https://github.com/fleetdm/fleet/assets/71795832/1640905c-5b2e-469f-93d8-7ee4aa3732b9


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

