### PR TITLE
Add infrastructure directories to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -43,6 +43,15 @@ go.mod @fleetdm/go
 /frontend/ @fleetdm/frontend
 
 ##############################################################################################
+# Config as code for infrastructure, internal security and IT use cases, and more.
+# (1 or more infra-literate engineers is required to review changes.)
+# FUTURE: Look for a way to not have this notify every single person in this "github team".
+##############################################################################################
+/infrastructure/ @fleetdm/infra
+/charts/ @fleetdm/infra
+/terraform/ @fleetdm/infra
+
+##############################################################################################
 # Key handbook pages w/ required reviewers
 #
 # (Especially useful for paths that tend to end up in PRs with lots of other reviewers)

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -144,11 +144,6 @@ module.exports.custom = {
     'README.md': 'mikermcneil',// « GitHub brandfront
     'tools/fleetctl-npm/README.md': 'mikermcneil',// « NPM brandfront (npmjs.com/package/fleetctl)
 
-    // Config as code for infrastructure, internal security and IT use cases, and more.
-    'infrastructure': 'lukeheath',//« infrastructure and related terraform configuration files
-    'charts': 'lukeheath',
-    'terraform': 'lukeheath',
-
     // Repo automation and change control settings
     'CODEOWNERS': 'mikermcneil',
 


### PR DESCRIPTION
We need to move the infrastructure directories back into the codeowners file. Otherwise, the `*.go` rule is applied to Go files in the `infrastructure` directory, blocking the PR and requiring approval from a Go engineer, even though it's an infra-related change. 

I'd also like the `fleetdm/infra` team to be codeowners so that I am not a blocker to merging. Otherwise, if I'm out and a critical infra bug needs to merge, we would have to override the approval process, which creates problems during audits.