### PR TITLE
Fleet UI: (Unreleased bug) Redirect to query editor on creating a new query

### DIFF
--- a/frontend/pages/queries/QueryPage/QueryPage.tsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.tsx
@@ -13,7 +13,6 @@ import { IHost, IHostResponse } from "interfaces/host";
 import { ILabel } from "interfaces/label";
 import { ITeam } from "interfaces/team";
 import {
-  ICreateQueryRequestBody,
   IGetQueryResponse,
   ISchedulableQuery,
 } from "interfaces/schedulable_query";
@@ -143,12 +142,6 @@ const QueryPage = ({
     }
   );
 
-  const {
-    mutateAsync: createQuery,
-  } = useMutation((formData: ICreateQueryRequestBody) =>
-    queryAPI.create(formData)
-  );
-
   const detectIsFleetQueryRunnable = () => {
     statusAPI.live_query().catch(() => {
       setIsLiveQueryRunnable(false);
@@ -221,7 +214,6 @@ const QueryPage = ({
       storedQuery,
       isStoredQueryLoading,
       storedQueryError,
-      createQuery,
       onOsqueryTableSelect,
       goToSelectTargets: () => setStep(QUERIES_PAGE_STEPS[2]),
       onOpenSchemaSidebar,

--- a/frontend/pages/queries/QueryPage/screens/QueryEditor.tsx
+++ b/frontend/pages/queries/QueryPage/screens/QueryEditor.tsx
@@ -28,11 +28,6 @@ interface IQueryEditorProps {
   storedQueryError: Error | null;
   showOpenSchemaActionText: boolean;
   isStoredQueryLoading: boolean;
-  createQuery: UseMutateAsyncFunction<
-    ISchedulableQuery,
-    unknown,
-    ICreateQueryRequestBody
-  >;
   onOsqueryTableSelect: (tableName: string) => void;
   goToSelectTargets: () => void;
   onOpenSchemaSidebar: () => void;
@@ -49,7 +44,6 @@ const QueryEditor = ({
   storedQueryError,
   showOpenSchemaActionText,
   isStoredQueryLoading,
-  createQuery,
   onOsqueryTableSelect,
   goToSelectTargets,
   onOpenSchemaSidebar,
@@ -90,7 +84,7 @@ const QueryEditor = ({
   const saveQuery = debounce(async (formData: ICreateQueryRequestBody) => {
     setIsQuerySaving(true);
     try {
-      const query = await createQuery(formData);
+      const { query } = await queryAPI.create(formData);
       router.push(PATHS.EDIT_QUERY(query.id));
       renderFlash("success", "Query created!");
       setBackendValidators({});


### PR DESCRIPTION
## Issue
Unreleased bug #12857 

## Description
Clean up create call so we can easily go to the newly created query using the newly created query id

## QA
- Rachel and @jacobshandling tested this on the fullstack branch already and works great
NOTE: Reed should still test :) 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

