### PR TITLE
Fleet UI: (Unreleased bug) Platform compatibility always loads

### DIFF
--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -165,7 +165,7 @@ const QueryForm = ({
     }
 
     debounceSQL(lastEditedQueryBody);
-  }, [lastEditedQueryBody, lastEditedQueryId]);
+  }, [lastEditedQueryBody, lastEditedQueryId, isStoredQueryLoading]);
 
   const hasTeamMaintainerPermissions = savedQueryMode
     ? isAnyTeamMaintainerOrTeamAdmin &&


### PR DESCRIPTION
## Issue
Cerra #12859 

## Description
- Ensure compatibility is being calculated and rendered even if query has loaded before

## Screen recording clicking back and forth into same query and still seeing compatibility

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

