### PR TITLE
Fleet UI: (Unreleased bug) Team admin/maintainers cannot save global queries

### DIFF
--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -694,7 +694,7 @@ const QueryForm = ({
                 </div>{" "}
                 <ReactTooltip
                   className={`save-query-button-tooltip`}
-                  place="bottom"
+                  place="top"
                   effect="solid"
                   backgroundColor={COLORS["tooltip-bg"]}
                   id="save-query-button"

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -30,6 +30,7 @@ import {
 } from "interfaces/schedulable_query";
 import { SelectedPlatformString } from "interfaces/platform";
 import queryAPI from "services/entities/queries";
+import { COLORS } from "styles/var/colors";
 
 import { IAceEditor } from "react-ace/lib/types";
 import ReactTooltip from "react-tooltip";
@@ -670,14 +671,40 @@ const QueryForm = ({
                 </Button>
               )}
               <div className="query-form__button-wrap--save-query-button">
-                <Button
-                  className="save-loading"
-                  variant="brand"
-                  onClick={promptSaveQuery()}
-                  isLoading={isQueryUpdating}
+                <div
+                  data-tip
+                  data-for="save-query-button"
+                  // Tooltip shows for team maintainer/admins viewing global queries
+                  data-tip-disable={
+                    !(isAnyTeamMaintainerOrTeamAdmin && !storedQuery?.team_id)
+                  }
                 >
-                  Save
-                </Button>
+                  <Button
+                    className="save-loading"
+                    variant="brand"
+                    onClick={promptSaveQuery()}
+                    // Button disabled for team maintainer/admins viewing global queries
+                    disabled={
+                      isAnyTeamMaintainerOrTeamAdmin && !storedQuery?.team_id
+                    }
+                    isLoading={isQueryUpdating}
+                  >
+                    Save
+                  </Button>
+                </div>{" "}
+                <ReactTooltip
+                  className={`save-query-button-tooltip`}
+                  place="bottom"
+                  effect="solid"
+                  backgroundColor={COLORS["tooltip-bg"]}
+                  id="save-query-button"
+                  data-html
+                >
+                  <>
+                    You can only save changes
+                    <br /> to a team level query.
+                  </>
+                </ReactTooltip>
               </div>
             </>
           )}


### PR DESCRIPTION
## Issue
Cerra unreleased bug related to #12647


## Description
- Leave functionality where team user can click save as new for a global level query and it will add a team level query
- Update functionality where team user cannot click save for global level query as team members don't have permission to update global level queries

## Screenshot of what a team admin/maintainer user sees while viewing a global query

<img width="808" alt="Screenshot 2023-07-20 at 3 19 13 PM" src="https://github.com/fleetdm/fleet/assets/71795832/ab2b36cc-4826-4aca-aae2-c5803e483825">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
