### PR TITLE
Avoid migration actions if the host is already enrolled into Fleet

### DIFF
--- a/orbit/changes/12068-migration-sanity-check
+++ b/orbit/changes/12068-migration-sanity-check
@@ -1,0 +1,1 @@
+* Ensure MDM migration modal is not shown, and enrollment commands are not run if the host is already enrolled into Fleet

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -237,6 +237,7 @@ func main() {
 			)
 			mdmMigrator = useraction.NewMDMMigrator(
 				swiftDialogPath,
+				fleetURL,
 				15*time.Minute,
 				&mdmMigrationHandler{
 					client:      client,

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -618,7 +618,7 @@ func main() {
 			renewEnrollmentProfileCommandFrequency = time.Hour
 			windowsMDMEnrollmentCommandFrequency   = time.Hour
 		)
-		configFetcher := update.ApplyRenewEnrollmentProfileConfigFetcherMiddleware(orbitClient, renewEnrollmentProfileCommandFrequency)
+		configFetcher := update.ApplyRenewEnrollmentProfileConfigFetcherMiddleware(orbitClient, renewEnrollmentProfileCommandFrequency, fleetURL)
 
 		switch runtime.GOOS {
 		case "darwin":

--- a/orbit/pkg/profiles/profiles_darwin.go
+++ b/orbit/pkg/profiles/profiles_darwin.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os/exec"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -51,4 +52,55 @@ var execScript = func(script string) (*bytes.Buffer, error) {
 		return nil, err
 	}
 	return &outBuf, nil
+}
+
+// IsEnrolledIntoMatchingURL runs the `profiles` command to get the current MDM
+// enrollment information and reports if the hostname of the MDM server
+// supervising the device matches the hostname of the provided URL.
+func IsEnrolledIntoMatchingURL(serverURL string) (bool, error) {
+	out, err := getMDMInfoFromProfilesCmd()
+	if err != nil {
+		return false, fmt.Errorf("calling /usr/bin/profiles: %w", err)
+	}
+
+	// The output of the command is in the form:
+	//
+	// ```
+	// Enrolled via DEP: No
+	// MDM enrollment: Yes (User Approved)
+	// MDM server: https://test.example.com/mdm/apple/mdm
+	// ```
+	//
+	// If the host is not enrolled into an MDM, the last line is ommitted,
+	// so we need to check that:
+	//
+	// 1. We've got three rows
+	// 2. The last row matches our server URL
+	lines := bytes.Split(bytes.TrimSpace(out), []byte("\n"))
+	if len(lines) < 3 {
+		return false, nil
+	}
+
+	parts := bytes.SplitN(lines[2], []byte(":"), 2)
+	if len(parts) < 2 {
+		return false, fmt.Errorf("splitting profiles output to get MDM server URL: %w", err)
+	}
+
+	u, err := url.Parse(string(bytes.TrimSpace(parts[1])))
+	if err != nil {
+		return false, fmt.Errorf("parsing URL from profiles command: %w", err)
+	}
+
+	fu, err := url.Parse(serverURL)
+	if err != nil {
+		return false, fmt.Errorf("parsing provided Fleet URL: %w", err)
+	}
+
+	return u.Hostname() == fu.Hostname(), nil
+}
+
+// getMDMInfoFromProfilesCmd is declared as a variable so it can be overwritten by tests.
+var getMDMInfoFromProfilesCmd = func() ([]byte, error) {
+	cmd := exec.Command("/usr/bin/profiles", "status", "-type", "enrollment")
+	return cmd.Output()
 }

--- a/orbit/pkg/profiles/profiles_darwin_test.go
+++ b/orbit/pkg/profiles/profiles_darwin_test.go
@@ -69,3 +69,73 @@ func TestGetFleetdConfig(t *testing.T) {
 	}
 
 }
+
+func TestIsEnrolledIntoMatchingURL(t *testing.T) {
+	fleetURL := "https://valid.com"
+	cases := []struct {
+		cmdOut  *string
+		cmdErr  error
+		wantOut bool
+		wantErr bool
+	}{
+		{nil, errors.New("test error"), false, true},
+		{ptr.String(""), nil, false, false},
+		{ptr.String(`
+Enrolled via DEP: No
+MDM enrollment: No
+		`), nil, false, false},
+		{
+			ptr.String(`
+Enrolled via DEP: Yes
+MDM enrollment: Yes
+MDM server: https://test.example.com
+			`),
+			nil,
+			false,
+			false,
+		},
+		{
+			ptr.String(`
+Enrolled via DEP: Yes
+MDM enrollment: Yes
+MDM server /  https://test.example.com
+			`),
+			nil,
+			false,
+			false,
+		},
+		{
+			ptr.String(`
+Enrolled via DEP: Yes
+MDM enrollment: Yes
+MDM server: https://valid.com/mdm/apple/mdm
+			`),
+			nil,
+			true,
+			false,
+		},
+	}
+
+	origCmd := getMDMInfoFromProfilesCmd
+	t.Cleanup(func() { getMDMInfoFromProfilesCmd = origCmd })
+	for _, c := range cases {
+		getMDMInfoFromProfilesCmd = func() ([]byte, error) {
+			if c.cmdOut == nil {
+				return nil, c.cmdErr
+			}
+
+			var buf bytes.Buffer
+			buf.WriteString(*c.cmdOut)
+			return []byte(*c.cmdOut), nil
+		}
+
+		out, err := IsEnrolledIntoMatchingURL(fleetURL)
+		if c.wantErr {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+		}
+		require.Equal(t, c.wantOut, out)
+	}
+
+}

--- a/orbit/pkg/profiles/profiles_notdarwin.go
+++ b/orbit/pkg/profiles/profiles_notdarwin.go
@@ -7,3 +7,7 @@ import "github.com/fleetdm/fleet/v4/server/fleet"
 func GetFleetdConfig() (*fleet.MDMAppleFleetdConfig, error) {
 	return nil, ErrNotImplemented
 }
+
+func IsEnrolledIntoMatchingURL(u string) (bool, error) {
+	return false, ErrNotImplemented
+}

--- a/orbit/pkg/profiles/profiles_notdarwin_test.go
+++ b/orbit/pkg/profiles/profiles_notdarwin_test.go
@@ -15,7 +15,7 @@ func TestGetFleetdConfig(t *testing.T) {
 }
 
 func TestIsEnrolledIntoMatchingURL(t *testing.T) {
-	enrolled, err := IsEnrolledIntoMatchingURL()
+	enrolled, err := IsEnrolledIntoMatchingURL("https://test.example.com")
 	require.ErrorIs(t, ErrNotImplemented, err)
 	require.False(t, enrolled)
 }

--- a/orbit/pkg/profiles/profiles_notdarwin_test.go
+++ b/orbit/pkg/profiles/profiles_notdarwin_test.go
@@ -13,3 +13,9 @@ func TestGetFleetdConfig(t *testing.T) {
 	require.ErrorIs(t, ErrNotImplemented, err)
 	require.Nil(t, config)
 }
+
+func TestIsEnrolledIntoMatchingURL(t *testing.T) {
+	enrolled, err := IsEnrolledIntoMatchingURL()
+	require.ErrorIs(t, ErrNotImplemented, err)
+	require.False(t, enrolled)
+}

--- a/orbit/pkg/useraction/mdm_migration_notdarwin.go
+++ b/orbit/pkg/useraction/mdm_migration_notdarwin.go
@@ -4,7 +4,7 @@ package useraction
 
 import "time"
 
-func NewMDMMigrator(path string, frequency time.Duration, handler MDMMigratorHandler) MDMMigrator {
+func NewMDMMigrator(path, fleetURL string, frequency time.Duration, handler MDMMigratorHandler) MDMMigrator {
 	return &NoopMDMMigrator{}
 }
 


### PR DESCRIPTION
for #12068

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
