### PR TITLE
UI: 2 Query name styling issues

### DIFF
--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -216,8 +216,6 @@ $shadow-transition-width: 10px;
         .link-cell,
         .text-cell {
           display: block;
-          overflow: hidden;
-          text-overflow: ellipsis;
           white-space: nowrap;
           margin: 0;
           .__react_component_tooltip {

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -15,6 +15,7 @@ import PATHS from "router/paths";
 import sortUtils from "utilities/sort";
 import { PolicyResponse } from "utilities/constants";
 import { buildQueryStringFromParams } from "utilities/url";
+import { COLORS } from "styles/var/colors";
 import PassingColumnHeader from "../PassingColumnHeader";
 
 interface IGetToggleAllRowsSelectedProps {
@@ -138,7 +139,7 @@ const generateTableHeaders = (
                     type="dark"
                     effect="solid"
                     id={`critical-tooltip-${cellProps.row.original.id}`}
-                    backgroundColor="#3e4771"
+                    backgroundColor={COLORS["tooltip-bg"]}
                   >
                     This policy has been marked as critical.
                     {isSandboxMode && (

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -179,6 +179,14 @@
       }
     }
 
+    .query-name-cell {
+      .children-wrapper {
+        .query-name-text {
+          text-overflow: ellipsis;
+          overflow: hidden;
+        }
+      }
+    }
     .query-icon {
       position: relative;
       top: 2px;

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -20,6 +20,7 @@ import PlatformCell from "components/TableContainer/DataTable/PlatformCell";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import PillCell from "components/TableContainer/DataTable/PillCell";
 import TooltipWrapper from "components/TooltipWrapper";
+import { COLORS } from "styles/var/colors";
 import QueryAutomationsStatusIndicator from "../QueryAutomationsStatusIndicator";
 
 interface IQueryRow {
@@ -124,7 +125,7 @@ const generateTableHeaders = ({
       Cell: (cellProps: ICellProps): JSX.Element => {
         return (
           <LinkCell
-            classes="w400"
+            classes="w400 query-name-cell"
             value={
               <>
                 <div className="query-name-text">{cellProps.cell.value}</div>
@@ -143,7 +144,7 @@ const generateTableHeaders = ({
                       type="dark"
                       effect="solid"
                       id={`observer-can-run-tooltip-${cellProps.row.original.id}`}
-                      backgroundColor="#3e4771"
+                      backgroundColor={COLORS["tooltip-bg"]}
                     >
                       Observers can run this query.
                     </ReactTooltip>


### PR DESCRIPTION
## Addresses #12883 and #12877 

- Truncate long query names such that the name itself is truncated with ellipses while the "Observer can run" icon and associated tooltip, if present, remain visible.
- Address lower-case "p"s in query name getting cutoff.

<img width="944" alt="Screenshot 2023-07-20 at 2 21 16 PM" src="https://github.com/fleetdm/fleet/assets/61553566/09c141e8-a6bf-4380-8bd2-cdcc57019f73">

## QA
@xpkoala –The style that was removed here to address the text cutoff issue is a far-reaching change, since this problem may be happening elsewhere the TextCell component is used. I did manually QA this, but please take a careful look at other tables to double check that other text cells are still styled correctly.


- [x] Manual QA for all new/changed functionality