### PR TITLE
Remove infra maintainers from auto-approval

### DIFF
--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -211,10 +211,7 @@ module.exports.custom = {
     'README.md': ['mikermcneil', 'jarodreyes', 'mike-j-thomas', 'zwass'],//« github brandfront (github.com/fleetdm/fleet)
     'tools/fleetctl-npm/README.md': ['mikermcneil', 'mike-j-thomas', 'jarodreyes', 'zwass'],//« brandfront for fleetctl package on npm (npmjs.com/package/fleetctl)
 
-    // Config as code for infrastructure, internal security and IT use cases, and more.
-    'infrastructure': ['edwardsb', 'zwinnerman-fleetdm', 'rfairburn', 'lukeheath'],
-    'charts': ['edwardsb', 'zwinnerman-fleetdm', 'rfairburn', 'lukeheath'],
-    'terraform': ['edwardsb', 'zwinnerman-fleetdm', 'rfairburn', 'lukeheath'],
+    // Github workflows
     '.github/workflows/deploy-fleet-website.yml': ['eashaw','mikermcneil'],// (website deploy script)
     '.github/workflows/test-website.yml': ['eashaw','mikermcneil'],//« website CI test script
     '.github/workflows': ['zwass', 'mikermcneil'],//« CI/CD workflows & misc GitHub Actions. Note that some are also addressed more specifically below in relevant sections)

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -211,6 +211,11 @@ module.exports.custom = {
     'README.md': ['mikermcneil', 'jarodreyes', 'mike-j-thomas', 'zwass'],//« github brandfront (github.com/fleetdm/fleet)
     'tools/fleetctl-npm/README.md': ['mikermcneil', 'mike-j-thomas', 'jarodreyes', 'zwass'],//« brandfront for fleetctl package on npm (npmjs.com/package/fleetctl)
 
+    // Config as code for infrastructure, internal security and IT use cases, and more.
+    //'infrastructure': [],// Decided against in https://github.com/fleetdm/fleet/pull/12890
+    //'charts': [], //Decided against in https://github.com/fleetdm/fleet/pull/12890
+    //'terraform': [],//Decided against in https://github.com/fleetdm/fleet/pull/12890
+
     // Github workflows
     '.github/workflows/deploy-fleet-website.yml': ['eashaw','mikermcneil'],// (website deploy script)
     '.github/workflows/test-website.yml': ['eashaw','mikermcneil'],//« website CI test script


### PR DESCRIPTION
I missed that infrastructure directories were also listed in the maintainers section, which also auto-approves. 