### PR TITLE
Remove accidental escalation of approval requests

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -361,6 +361,7 @@ module.exports = {
                 if (isAuthorAncestralDRI || isSenderAncestralDRI) {
                   // For the same reasons as above, if the original PR author or you (current author/editor)
                   // are the editor, then we do nothing.
+                  break;
                 } else if (nearestAncestralDri) {// Otherwise, if we have our DRI, we can stop here.
                   reviewer = nearestAncestralDri;
                   break;


### PR DESCRIPTION
This fix reduces the extra approval requests that started appearing recently for stuff like /imagine pages