### PR TITLE
Fleet UI: Queries default to alpha order

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -22,7 +22,7 @@ const TAGGED_TEMPLATES = {
 };
 
 const DEFAULT_SORT_DIRECTION = "asc";
-const DEFAULT_SORT_HEADER = "updated_at";
+const DEFAULT_SORT_HEADER = "name";
 
 interface IPoliciesTableProps {
   policiesList: IPolicyStats[];

--- a/frontend/pages/queries/ManageQueriesPage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/ManageAutomationsModal/ManageAutomationsModal.tsx
@@ -66,8 +66,14 @@ const ManageAutomationsModal = ({
   // TODO: Error handling, if any
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
 
+  // Client side sort queries alphabetically
+  const sortedAvailableQueries =
+    availableQueries?.sort((a, b) =>
+      a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+    ) || [];
+
   const { queryItems, updateQueryItems } = useCheckboxListStateManagement(
-    availableQueries || [],
+    sortedAvailableQueries,
     automatedQueryIds || []
   );
 

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -44,8 +44,8 @@ interface IQueriesTableProps {
   isInherited?: boolean;
 }
 
-const DEFAULT_SORT_DIRECTION = "desc";
-const DEFAULT_SORT_HEADER = "updated_at";
+const DEFAULT_SORT_DIRECTION = "asc";
+const DEFAULT_SORT_HEADER = "name";
 const DEFAULT_PAGE_SIZE = 20;
 const DEFAULT_PLATFORM = "all";
 
@@ -99,8 +99,7 @@ const QueriesTable = ({
   // Functions to avoid race conditions
   const initialSearchQuery = (() => queryParams?.query ?? "")();
   const initialSortHeader = (() =>
-    (queryParams?.order_key as "updated_at" | "name" | "author") ??
-    "updated_at")();
+    (queryParams?.order_key as "name" | "updated_at" | "author") ?? "name")();
   const initialSortDirection = (() =>
     (queryParams?.order_direction as "asc" | "desc") ?? "asc")();
   const initialPlatform = (() =>


### PR DESCRIPTION
## Issue
Cerra #12879 

## Description
- Both queries table and manage automations check boxes default sort is alphabetically

## Screenshot
<img width="1463" alt="Screenshot 2023-07-24 at 10 08 07 AM" src="https://github.com/fleetdm/fleet/assets/71795832/35dd6a06-e9ee-4472-9abf-cc5b92396a1b">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

