### PR TITLE
Fix setup page styling

### DIFF
--- a/changes/12935-fix-setup-flow-styling
+++ b/changes/12935-fix-setup-flow-styling
@@ -1,0 +1,1 @@
+* Fixed the styling of the initial setup flow

--- a/frontend/pages/RegistrationPage/Breadcrumbs/_styles.scss
+++ b/frontend/pages/RegistrationPage/Breadcrumbs/_styles.scss
@@ -81,7 +81,6 @@
         &::after {
           background-color: transparent;
           border: 2px solid $core-white;
-          margin-top: 13px;
         }
       }
 
@@ -119,7 +118,6 @@
         &::after {
           background-color: transparent;
           border: 2px solid $core-white;
-          margin-top: 13px;
         }
       }
 
@@ -160,7 +158,6 @@
         &::after {
           background-color: transparent;
           border: 2px solid $core-white;
-          margin-top: 13px;
         }
       }
 

--- a/frontend/pages/RegistrationPage/Breadcrumbs/_styles.scss
+++ b/frontend/pages/RegistrationPage/Breadcrumbs/_styles.scss
@@ -20,6 +20,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
 
     &::before {
       content: "";
@@ -31,7 +32,7 @@
       left: 90px;
 
       @include breakpoint(tablet) {
-        bottom: 25px;
+        bottom: 21px;
       }
     }
 


### PR DESCRIPTION
## Addresses #12935 
<img width="780" alt="Screenshot 2023-07-24 at 11 04 11 AM" src="https://github.com/fleetdm/fleet/assets/61553566/5d4b335a-3abd-4f7c-beaa-79ee151c490f">
<img width="1243" alt="Screenshot 2023-07-24 at 11 03 10 AM" src="https://github.com/fleetdm/fleet/assets/61553566/3b79ce91-34d6-4b6a-8eb6-50a7ac9f39d3">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality