### PR TITLE
account for possible NULL values in profile description

### DIFF
--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -1266,7 +1266,7 @@ WHERE
 			hmap.checksum as checksum,
 			hmap.status as status,
 			hmap.operation_type as operation_type,
-			hmap.detail as detail,
+			COALESCE(hmap.detail, '') as detail,
 			hmap.command_uuid as command_uuid
 		FROM (
 			SELECT
@@ -1469,7 +1469,7 @@ func (ds *Datastore) ListMDMAppleProfilesToRemove(ctx context.Context) ([]*fleet
 	    hmap.host_uuid,
 	    hmap.checksum,
 	    hmap.operation_type,
-	    hmap.detail,
+	    COALESCE(hmap.detail, '') as detail,
 	    hmap.status,
 	    hmap.command_uuid
           FROM (

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -2885,6 +2885,15 @@ func testBulkSetPendingMDMAppleHostProfiles(t *testing.T, ds *Datastore) {
 		linuxHost:      {},
 	})
 
+	// simulate an entry with some values set to NULL
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `UPDATE host_mdm_apple_profiles SET detail = NULL WHERE profile_id = ?`, globalProfiles[2].ProfileID)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
 	// do a final sync of all hosts, should not change anything
 	err = ds.BulkSetPendingMDMAppleHostProfiles(ctx, hostIDsFromHosts(append(enrolledHosts, unenrolledHost, linuxHost)...), nil, nil, nil)
 	require.NoError(t, err)


### PR DESCRIPTION
in previous releases we weren't setting the value of description in some of our `INSERT ON DUPLICATE KEY UPDATE` clauses, which caused some queries to fail.

we could additionally add a migration to set all NULL values to '' and make the column non-nullable, but as a first step I'm fixing this at the application logic level.

related to: https://github.com/fleetdm/fleet/issues/12923

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
