### PR TITLE
Update detail query ingestion and UI related to Windows MDM status

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -154,7 +154,19 @@ const allHostTableHeaders: IDataColumn[] = [
     ),
     accessor: "display_name",
     Cell: (cellProps: ICellProps) => {
-      if (cellProps.row.original.mdm.enrollment_status === "Pending") {
+      console.log(
+        cellProps.cell.value,
+        cellProps.row.original.mdm.enrollment_status
+      );
+      if (
+        // if the host is pending, we want to disable the link to host details
+        cellProps.row.original.mdm.enrollment_status === "Pending" &&
+        // pending status is only supported for macos devices
+        cellProps.row.original.platform === "darwin" &&
+        // osquery version is populated along with the rest of host details so use it
+        // here to check if we already have host details and don't need to disable the link
+        !cellProps.row.original.osquery_version
+      ) {
         return (
           <>
             <span

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -154,10 +154,6 @@ const allHostTableHeaders: IDataColumn[] = [
     ),
     accessor: "display_name",
     Cell: (cellProps: ICellProps) => {
-      console.log(
-        cellProps.cell.value,
-        cellProps.row.original.mdm.enrollment_status
-      );
       if (
         // if the host is pending, we want to disable the link to host details
         cellProps.row.original.mdm.enrollment_status === "Pending" &&

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -287,8 +287,9 @@ const HostsFilterBlock = ({
           MDM was turned on <br />
           automatically using Apple <br />
           Automated Device <br />
-          Enrollment (DEP) or <br />
-          Windows Autopilot. <br />
+          Enrollment (DEP), <br />
+          Windows Autopilot, or <br />
+          Windows Azure AD Join. <br />
           Administrators can block <br />
           device users from turning
           <br /> MDM off.

--- a/frontend/utilities/constants.ts
+++ b/frontend/utilities/constants.ts
@@ -235,7 +235,7 @@ export const VULNERABLE_DROPDOWN_OPTIONS = [
 
 // Keys from API
 export const MDM_STATUS_TOOLTIP: Record<string, string> = {
-  "On (automatic)": `<span>MDM was turned on automatically using Apple Automated Device Enrollment (DEP) or Windows Autopilot. Administrators can block end users from turning MDM off.</span>`,
+  "On (automatic)": `<span>MDM was turned on automatically using Apple Automated Device Enrollment (DEP), Windows Autopilot, or Windows Azure AD Join. Administrators can block end users from turning MDM off.</span>`,
   "On (manual)": `<span>MDM was turned on manually. End users can turn MDM off.</span>`,
   Off: `<span>Hosts with MDM off don&apos;t receive macOS <br /> settings and macOS update encouragement.</span>`,
   Pending: `<span>Hosts ordered via Apple Business Manager <br /> (ABM). These will automatically enroll to Fleet <br /> and turn on MDM when they&apos;re unboxed.</span>`,

--- a/server/service/osquery_utils/gen_queries_doc.go
+++ b/server/service/osquery_utils/gen_queries_doc.go
@@ -16,17 +16,21 @@ import (
 )
 
 func main() {
-	detailQueriesMap := osquery_utils.GetDetailQueries(context.Background(), config.FleetConfig{
-		Vulnerabilities: config.VulnerabilitiesConfig{
-			DisableWinOSVulnerabilities: false,
+	detailQueriesMap := osquery_utils.GetDetailQueries(context.Background(),
+		config.FleetConfig{
+			Vulnerabilities: config.VulnerabilitiesConfig{
+				DisableWinOSVulnerabilities: false,
+			},
+			App: config.AppConfig{
+				EnableScheduledQueryStats: true,
+			},
 		},
-		App: config.AppConfig{
-			EnableScheduledQueryStats: true,
+		&fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true}},
+		&fleet.Features{
+			EnableSoftwareInventory: true,
+			EnableHostUsers:         true,
 		},
-	}, nil, &fleet.Features{
-		EnableSoftwareInventory: true,
-		EnableHostUsers:         true,
-	})
+	)
 	var b strings.Builder
 
 	b.WriteString(`<!-- DO NOT EDIT. This document is automatically generated. -->

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -447,9 +447,7 @@ var extraDetailQueries = map[string]DetailQuery{
 			)
 			UNION ALL
 			SELECT * FROM (
-				SELECT "autopilot" AS "key", 1=1 AS "value" FROM registry
-				WHERE path = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Provisioning\AutopilotPolicyCache'
-				LIMIT 1
+				SELECT "is_federated" AS "key", data as "value" FROM registry WHERE path LIKE 'HKEY_LOCAL_MACHINE\Software\Microsoft\Enrollments\%\IsFederated'
 			)
 			UNION ALL
 			SELECT * FROM (
@@ -1341,10 +1339,14 @@ func deduceMDMNameMacOS(row map[string]string) string {
 }
 
 func deduceMDMNameWindows(data map[string]string) string {
+	serverURL := data["discovery_service_url"]
+	if serverURL == "" {
+		return ""
+	}
 	if name := data["provider_id"]; name != "" {
 		return name
 	}
-	return fleet.MDMNameFromServerURL(data["discovery_service_url"])
+	return fleet.MDMNameFromServerURL(serverURL)
 }
 
 func directIngestMDMWindows(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
@@ -1352,15 +1354,26 @@ func directIngestMDMWindows(ctx context.Context, logger log.Logger, host *fleet.
 	for _, r := range rows {
 		data[r["key"]] = r["value"]
 	}
-	_, autoPilot := data["autopilot"]
+	var enrolled bool
+	var automatic bool
+	serverURL := data["discovery_service_url"]
+	if serverURL != "" {
+		enrolled = true
+		if isFederated := data["is_federated"]; isFederated == "1" {
+			// NOTE: We intentionally nest this condition to eliminate `enrolled == false && automatic == true`
+			// as a possible status for Windows hosts (which would be otherwise be categorized as
+			// "Pending"). Currently, the "Pending" status is supported only for macOS hosts.
+			automatic = true
+		}
+	}
 	isServer := strings.Contains(strings.ToLower(data["installation_type"]), "server")
-	_, enrolled := data["provider_id"]
+
 	return ds.SetOrUpdateMDMData(ctx,
 		host.ID,
 		isServer,
 		enrolled,
-		data["discovery_service_url"],
-		autoPilot,
+		serverURL,
+		automatic,
 		deduceMDMNameWindows(data),
 	)
 }

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -447,7 +447,9 @@ var extraDetailQueries = map[string]DetailQuery{
 			)
 			UNION ALL
 			SELECT * FROM (
-				SELECT "is_federated" AS "key", data as "value" FROM registry WHERE path LIKE 'HKEY_LOCAL_MACHINE\Software\Microsoft\Enrollments\%\IsFederated'
+				SELECT "is_federated" AS "key", data as "value" FROM registry 
+				WHERE path LIKE 'HKEY_LOCAL_MACHINE\Software\Microsoft\Enrollments\%\IsFederated'
+				LIMIT 1
 			)
 			UNION ALL
 			SELECT * FROM (

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -647,7 +647,6 @@ func TestDirectIngestMDMWindows(t *testing.T) {
 		err := directIngestMDMWindows(context.Background(), log.NewNopLogger(), &fleet.Host{}, ds, c.data)
 		require.NoError(t, err)
 		require.True(t, ds.SetOrUpdateMDMDataFuncInvoked)
-		require.NoError(t, err)
 		ds.SetOrUpdateMDMDataFuncInvoked = false
 	}
 }

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -549,23 +549,107 @@ func TestDirectIngestMDMMac(t *testing.T) {
 
 func TestDirectIngestMDMWindows(t *testing.T) {
 	ds := new(mock.Store)
-	ds.SetOrUpdateMDMDataFunc = func(ctx context.Context, hostID uint, isServer, enrolled bool, serverURL string, installedFromDep bool, name string) error {
-		require.True(t, enrolled)
-		require.True(t, installedFromDep)
-		require.True(t, isServer)
-		require.NotEmpty(t, serverURL)
-		return nil
+	cases := []struct {
+		name                 string
+		data                 []map[string]string
+		wantEnrolled         bool
+		wantInstalledFromDep bool
+		wantIsServer         bool
+		wantServerURL        string
+	}{
+		{
+			name: "off empty server URL",
+			data: []map[string]string{
+				{"key": "discovery_service_url", "value": ""},
+				{"key": "is_federated", "value": "1"},
+				{"key": "provider_id", "value": "Some_ID"},
+				{"key": "installation_type", "value": "Client"},
+			},
+			wantEnrolled:         false,
+			wantInstalledFromDep: false,
+			wantIsServer:         false,
+			wantServerURL:        "",
+		},
+		{
+			name: "off missing is_federated and server url",
+			data: []map[string]string{
+				{"key": "provider_id", "value": "Some_ID"},
+				{"key": "installation_type", "value": "Client"},
+			},
+			wantEnrolled:         false,
+			wantInstalledFromDep: false,
+			wantIsServer:         false,
+			wantServerURL:        "",
+		},
+		{
+			name: "on automatic",
+			data: []map[string]string{
+				{"key": "discovery_service_url", "value": "https://example.com"},
+				{"key": "is_federated", "value": "1"},
+				{"key": "provider_id", "value": "Some_ID"},
+				{"key": "installation_type", "value": "Client"},
+			},
+			wantEnrolled:         true,
+			wantInstalledFromDep: true,
+			wantIsServer:         false,
+			wantServerURL:        "https://example.com",
+		},
+		{
+			name: "on manual",
+			data: []map[string]string{
+				{"key": "discovery_service_url", "value": "https://example.com"},
+				{"key": "is_federated", "value": "0"},
+				{"key": "provider_id", "value": "Local_Management"},
+				{"key": "installation_type", "value": "Client"},
+			},
+			wantEnrolled:         true,
+			wantInstalledFromDep: false,
+			wantIsServer:         false,
+			wantServerURL:        "https://example.com",
+		},
+		{
+			name: "on manual missing is_federated",
+			data: []map[string]string{
+				{"key": "discovery_service_url", "value": "https://example.com"},
+				{"key": "provider_id", "value": "Some_ID"},
+				{"key": "installation_type", "value": "Client"},
+			},
+			wantEnrolled:         true,
+			wantInstalledFromDep: false,
+			wantIsServer:         false,
+			wantServerURL:        "https://example.com",
+		},
+		{
+			name: "is_server",
+			data: []map[string]string{
+				{"key": "discovery_service_url", "value": "https://example.com"},
+				{"key": "is_federated", "value": "1"},
+				{"key": "provider_id", "value": "Some_ID"},
+				{"key": "installation_type", "value": "Windows SeRvEr 99.9"},
+			},
+			wantEnrolled:         true,
+			wantInstalledFromDep: true,
+			wantIsServer:         true,
+			wantServerURL:        "https://example.com",
+		},
 	}
 
-	var host fleet.Host
-	err := directIngestMDMWindows(context.Background(), log.NewNopLogger(), &host, ds, []map[string]string{
-		{"key": "discovery_service_url", "value": "some url"},
-		{"key": "autopilot", "value": "true"},
-		{"key": "provider_id", "value": "1337"},
-		{"key": "installation_type", "value": "Windows SeRvEr 99.9"},
-	})
-	require.NoError(t, err)
-	require.True(t, ds.SetOrUpdateMDMDataFuncInvoked)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ds.SetOrUpdateMDMDataFunc = func(ctx context.Context, hostID uint, isServer, enrolled bool, serverURL string, installedFromDep bool, name string) error {
+				require.Equal(t, c.wantEnrolled, enrolled)
+				require.Equal(t, c.wantInstalledFromDep, installedFromDep)
+				require.Equal(t, c.wantIsServer, isServer)
+				require.Equal(t, c.wantServerURL, serverURL)
+				return nil
+			}
+		})
+		err := directIngestMDMWindows(context.Background(), log.NewNopLogger(), &fleet.Host{}, ds, c.data)
+		require.NoError(t, err)
+		require.True(t, ds.SetOrUpdateMDMDataFuncInvoked)
+		require.NoError(t, err)
+		ds.SetOrUpdateMDMDataFuncInvoked = false
+	}
 }
 
 func TestDirectIngestChromeProfiles(t *testing.T) {


### PR DESCRIPTION
Issue #12695 

- Modify `mdm_windows` detail query to capture `IsFederated` registry key 
- Modify ingest of `mdm_windows` detail query to better differentiate the "automatic" MDM-enrollment scenarios (i.e. Windows Autopilot or Windows Azure AD Join) from "manual" scenarios.
- Modify ingest of `mdm_windows` detail query to exclude Windows devices from "pending" MDM-enrollment status.
- Update UI tooltips to reflect inclusion of Windows Azure AD Join.