### PR TITLE
wip: Puppet reporter webhook

### DIFF
--- a/changes/12897-puppet-envs
+++ b/changes/12897-puppet-envs
@@ -1,0 +1,1 @@
+* Allow the puppet module to read different Fleet URL/token combinations for different environments

--- a/ee/tools/puppet/fleetdm/lib/puppet/reports/fleetdm.rb
+++ b/ee/tools/puppet/fleetdm/lib/puppet/reports/fleetdm.rb
@@ -2,6 +2,7 @@
 
 require 'puppet'
 require 'puppet/util/fleet_client'
+require 'puppet/util/env'
 
 Puppet::Reports.register_report(:fleetdm) do
   desc 'Used to signal the Fleet server that a Puppet run is done to match a device to a team for profile delivery'
@@ -17,6 +18,16 @@ Puppet::Reports.register_report(:fleetdm) do
       Puppet.info("successfully matched #{node_name} with a team containing configuration profiles")
     else
       Puppet.err("error matching node #{node_name} with a team containing configuration profiles: #{response['error']}")
+
+      error_webhook_url = Puppet::Util.read_hiera('fleetdm::error_webhook_url')
+      return unless error_webhook_url
+
+      uri = URI(error_webhook_url)
+      res = Net::HTTP.post_form(uri, 'title' => 'foo', 'body' => 'bar', 'userID' => 1)
+
+      unless res.is_a?(Net::HTTPSuccess)
+        Puppet.err("error sending webhook in reporter: #{res}")
+      end
     end
   end
 end

--- a/ee/tools/puppet/fleetdm/lib/puppet/util/env.rb
+++ b/ee/tools/puppet/fleetdm/lib/puppet/util/env.rb
@@ -1,0 +1,14 @@
+require 'puppet'
+require 'hiera_puppet'
+
+module Puppet::Util
+  def read_hiera(key)
+    node_name = Puppet[:node_name_value]
+    node = Puppet::Node.new(node_name)
+    node.environment = Puppet.lookup(:current_environment).name.to_s
+    compiler = Puppet::Parser::Compiler.new(node)
+    scope = Puppet::Parser::Scope.new(compiler)
+    lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, nil)
+    Puppet::Pops::Lookup.lookup(key, nil, '', false, nil, lookup_invocation)
+  end
+end

--- a/ee/tools/puppet/fleetdm/lib/puppet/util/fleet_client.rb
+++ b/ee/tools/puppet/fleetdm/lib/puppet/util/fleet_client.rb
@@ -25,13 +25,6 @@ module Puppet::Util
     end
 
     def initialize
-      node_name = Puppet[:node_name_value]
-      node = Puppet::Node.new(node_name)
-      compiler = Puppet::Parser::Compiler.new(node)
-      scope = Puppet::Parser::Scope.new(compiler)
-      lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, nil)
-      @host = Puppet::Pops::Lookup.lookup('fleetdm::host', nil, '', false, nil, lookup_invocation)
-      @token = Puppet::Pops::Lookup.lookup('fleetdm::token', nil, '', false, nil, lookup_invocation)
       @cache = {}
       @cache_mutex = Mutex.new
     end
@@ -114,6 +107,14 @@ module Puppet::Util
     private
 
     def req(method: :get, path: '', body: nil, headers: {}, cached: false)
+      node_name = Puppet[:node_name_value]
+      node = Puppet::Node.new(node_name)
+      compiler = Puppet::Parser::Compiler.new(node)
+      scope = Puppet::Parser::Scope.new(compiler)
+      lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, nil)
+      host = Puppet::Pops::Lookup.lookup('fleetdm::host', nil, '', false, nil, lookup_invocation)
+      token = Puppet::Pops::Lookup.lookup('fleetdm::token', nil, '', false, nil, lookup_invocation)
+
       if cached
         @cache_mutex.synchronize do
           unless @cache[path].nil?
@@ -123,7 +124,7 @@ module Puppet::Util
       end
 
       out = { 'error' => '' }
-      uri = URI.parse("#{@host}#{path}")
+      uri = URI.parse("#{host}#{path}")
       uri.path.squeeze! '/'
       uri.path.chomp! '/'
 
@@ -139,7 +140,7 @@ module Puppet::Util
         throw "HTTP method #{method} not implemented"
       end
 
-      headers['Authorization'] = "Bearer #{@token}"
+      headers['Authorization'] = "Bearer #{token}"
       headers.each { |key, value| request[key] = value }
       request.body = body.to_json if body
 

--- a/ee/tools/puppet/fleetdm/lib/puppet/util/fleet_client.rb
+++ b/ee/tools/puppet/fleetdm/lib/puppet/util/fleet_client.rb
@@ -4,6 +4,8 @@ require 'json'
 require 'puppet'
 require 'hiera_puppet'
 
+require_relative './env'
+
 module Puppet::Util
   # FleetClient provides an interface for making HTTP requests to a Fleet server.
   class FleetClient
@@ -107,14 +109,8 @@ module Puppet::Util
     private
 
     def req(method: :get, path: '', body: nil, headers: {}, cached: false)
-      node_name = Puppet[:node_name_value]
-      node = Puppet::Node.new(node_name)
-      node.environment = Puppet.lookup(:current_environment).name.to_s
-      compiler = Puppet::Parser::Compiler.new(node)
-      scope = Puppet::Parser::Scope.new(compiler)
-      lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, nil)
-      host = Puppet::Pops::Lookup.lookup('fleetdm::host', nil, '', false, nil, lookup_invocation)
-      token = Puppet::Pops::Lookup.lookup('fleetdm::token', nil, '', false, nil, lookup_invocation)
+      host = Puppet::Util.read_hiera('fleetdm::host')
+      token = Puppet::Util.read_hiera('fleetdm::token')
 
       if cached
         @cache_mutex.synchronize do

--- a/ee/tools/puppet/fleetdm/lib/puppet/util/fleet_client.rb
+++ b/ee/tools/puppet/fleetdm/lib/puppet/util/fleet_client.rb
@@ -109,6 +109,7 @@ module Puppet::Util
     def req(method: :get, path: '', body: nil, headers: {}, cached: false)
       node_name = Puppet[:node_name_value]
       node = Puppet::Node.new(node_name)
+      node.environment = Puppet.lookup(:current_environment).name.to_s
       compiler = Puppet::Parser::Compiler.new(node)
       scope = Puppet::Parser::Scope.new(compiler)
       lookup_invocation = Puppet::Pops::Lookup::Invocation.new(scope, {}, {}, nil)

--- a/ee/tools/puppet/fleetdm/metadata.json
+++ b/ee/tools/puppet/fleetdm/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetdm-fleetdm",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "Fleet Device Management Inc",
   "summary": "MDM management and profile assignment using FleetDM",
   "license": "proprietary",


### PR DESCRIPTION
for #12356. Left to do:

- [ ] Modify the request body to send the right parameters. I was imagining we could send the fields required by the Slack API since that's how this webhook  is going to be used.
- [ ] E2E integration test

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
