### PR TITLE
Changes for second step in investigating 7765 in load testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -245,6 +245,7 @@ require (
 	github.com/jonboulle/clockwork v0.2.2 // indirect
 	github.com/kevinburke/ssh_config v1.1.0 // indirect
 	github.com/klauspost/compress v1.15.11 // indirect
+	github.com/lib/pq v1.10.6 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
@@ -293,6 +294,7 @@ require (
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	github.com/yashtewari/glob-intersection v0.1.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
+	github.com/ziutek/mymysql v1.5.4 // indirect
 	go.elastic.co/apm/module/apmhttp/v2 v2.3.0 // indirect
 	go.elastic.co/fastjson v1.1.0 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -847,6 +847,7 @@ github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.1/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.6 h1:jbk+ZieJ0D7EVGJYpL9QTz7/YW6UHbmdnZWYyK5cdBs=
+github.com/lib/pq v1.10.6/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/macadmins/osquery-extension v0.0.14 h1:GhTdqp5fEfD9AsIng1r9jIsYpmahelXwxVVd8by5NEk=
@@ -1206,6 +1207,7 @@ github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPR
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
+github.com/ziutek/mymysql v1.5.4 h1:GB0qdRGsTwQSBVYuVShFBKaXSnSnYYC2d9knnE1LHFs=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
 github.com/zwass/kit v0.0.0-20210625184505-ec5b5c5cce9c h1:TWQ2UvXPkhPxI2KmApKBOCaV6yD2N4mlvqFQ/DlPtpQ=
 github.com/zwass/kit v0.0.0-20210625184505-ec5b5c5cce9c/go.mod h1:OYYulo9tUqRadRLwB0+LE914sa1ui2yL7OrcU3Q/1XY=

--- a/server/datastore/cached_mysql/cached_mysql.go
+++ b/server/datastore/cached_mysql/cached_mysql.go
@@ -324,22 +324,22 @@ func (ds *cachedMysql) DeleteTeam(ctx context.Context, teamID uint) error {
 }
 
 func (ds *cachedMysql) ListScheduledQueriesForAgents(ctx context.Context, teamID *uint) ([]*fleet.Query, error) {
-	var teamIDVal uint
-	if teamID != nil {
-		teamIDVal = *teamID
-	}
+	//var teamIDVal uint
+	//if teamID != nil {
+	//	teamIDVal = *teamID
+	//}
 
-	key := fmt.Sprintf(scheduledQueriesForAgentsKey, teamIDVal)
-	if x, found := ds.c.Get(key); found {
-		if queries, ok := x.([]*fleet.Query); ok {
-			return queries, nil
-		}
-	}
+	//key := fmt.Sprintf(scheduledQueriesForAgentsKey, teamIDVal)
+	//if x, found := ds.c.Get(key); found {
+	//	if queries, ok := x.([]*fleet.Query); ok {
+	//		return queries, nil
+	//	}
+	//}
 
 	queries, err := ds.Datastore.ListScheduledQueriesForAgents(ctx, teamID)
 	if err != nil {
 		return nil, err
 	}
-	ds.c.Set(key, queries, ds.scheduledQueriesExp)
+	//ds.c.Set(key, queries, ds.scheduledQueriesExp)
 	return queries, nil
 }

--- a/server/datastore/mysql/migrations/tables/20230726115701_AddQueriesIndices.go
+++ b/server/datastore/mysql/migrations/tables/20230726115701_AddQueriesIndices.go
@@ -1,0 +1,26 @@
+package tables
+
+import (
+	"database/sql"
+
+	"github.com/pkg/errors"
+)
+
+func init() {
+	MigrationClient.AddMigration(Up_20230726115701, Down_20230726115701)
+}
+
+func Up_20230726115701(tx *sql.Tx) error {
+	if _, err := tx.Exec(`
+		ALTER TABLE queries
+			ADD UNIQUE INDEX idx_name_team_id_unq (name, team_id_char),
+			ADD INDEX idx_team_id_saved_auto_interval (team_id, saved, automations_enabled, schedule_interval);
+	`); err != nil {
+		return errors.Wrap(err, "updating queries indices")
+	}
+	return nil
+}
+
+func Down_20230726115701(tx *sql.Tx) error {
+	return nil
+}


### PR DESCRIPTION
Drops the cache that was cloning the slice of queries, adds indices to improve reading scheduled queries.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
