### PR TITLE
Do vuln scans only during peak hours

### DIFF
--- a/infrastructure/sandbox/PreProvisioner/lambda/deploy_terraform/main.tf
+++ b/infrastructure/sandbox/PreProvisioner/lambda/deploy_terraform/main.tf
@@ -195,7 +195,7 @@ resource "helm_release" "main" {
 
   set {
     name  = "crons.vulnerabilities"
-    value = "${random_integer.cron_offset.result}\\,${random_integer.cron_offset.result + 15}\\,${random_integer.cron_offset.result + 30}\\,${random_integer.cron_offset.result + 45} * * * *"
+    value = "${random_integer.cron_offset.result}\\,${random_integer.cron_offset.result + 15}\\,${random_integer.cron_offset.result + 30}\\,${random_integer.cron_offset.result + 45} 13-0 * * *"
   }
 
   set {

--- a/infrastructure/sandbox/PreProvisioner/lambda/deploy_terraform/main.tf
+++ b/infrastructure/sandbox/PreProvisioner/lambda/deploy_terraform/main.tf
@@ -195,7 +195,7 @@ resource "helm_release" "main" {
 
   set {
     name  = "crons.vulnerabilities"
-    value = "${random_integer.cron_offset.result}\\,${random_integer.cron_offset.result + 15}\\,${random_integer.cron_offset.result + 30}\\,${random_integer.cron_offset.result + 45} 13-0 * * *"
+    value = "${random_integer.cron_offset.result}\\,${random_integer.cron_offset.result + 15}\\,${random_integer.cron_offset.result + 30}\\,${random_integer.cron_offset.result + 45} 0,13-23 * * *"
   }
 
   set {


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
