### PR TITLE
UI – prevent vertical scrolling for single queries

### DIFF
--- a/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
+++ b/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
@@ -103,7 +103,6 @@ class InputFieldWithIcon extends InputField {
       { [`${baseClass}__icon--active`]: value }
     );
 
-    console.log("iconSvg", iconSvg);
     return (
       <div className={wrapperClasses}>
         {this.props.label && this.renderHeading()}

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -101,6 +101,7 @@
       .data-table {
         &__wrapper {
           overflow-x: scroll;
+          overflow-y: hidden;
         }
         &__table {
           thead {


### PR DESCRIPTION
## Addresses #12976 

Prevent vertical scrolling when only a single query is present while maintaining horizontal scrolling in presence of queries with long names:
<img width="1056" alt="Screenshot 2023-07-26 at 2 26 03 PM" src="https://github.com/fleetdm/fleet/assets/61553566/9188afdf-c216-49c6-89fd-1dadca4edee0">

- [x] Manual QA for all new/changed functionality
