### PR TITLE
expose env var for orbit enrollment retry interval

### DIFF
--- a/server/service/orbit_client.go
+++ b/server/service/orbit_client.go
@@ -202,7 +202,7 @@ func (oc *OrbitClient) getNodeKeyOrEnroll() (string, error) {
 				return err
 			}
 		},
-		retry.WithInterval(constant.OrbitEnrollRetrySleep),
+		retry.WithInterval(OrbitRetryInterval()),
 		retry.WithMaxAttempts(constant.OrbitEnrollMaxRetries),
 	); err != nil {
 		return "", fmt.Errorf("orbit node key enroll failed, attempts=%d", constant.OrbitEnrollMaxRetries)
@@ -291,4 +291,15 @@ func (oc *OrbitClient) setLastRecordedError(err error) {
 	defer oc.lastRecordedErrMu.Unlock()
 
 	oc.lastRecordedErr = fmt.Errorf("%s: %w", time.Now().UTC().Format("2006-01-02T15:04:05Z"), err)
+}
+
+func OrbitRetryInterval() time.Duration {
+	interval := os.Getenv("FLEETD_ENROLL_RETRY_INTERVAL")
+	if interval != "" {
+		d, err := time.ParseDuration(interval)
+		if err == nil {
+			return d
+		}
+	}
+	return constant.OrbitEnrollRetrySleep
 }


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
