### PR TITLE
Fleet UI: Convert URLs in Policy resolution text to be clickable links

### DIFF
--- a/changes/12243-policy-resolution-urls
+++ b/changes/12243-policy-resolution-urls
@@ -1,0 +1,1 @@
+- Policy resolutions that include URLs are clickable in the UI

--- a/frontend/components/ClickableUrls/ClickableUrls.tests.tsx
+++ b/frontend/components/ClickableUrls/ClickableUrls.tests.tsx
@@ -8,7 +8,7 @@ const URL_1 =
   "https://privacyinternational.org/guide-step/4335/macos-opt-out-targeted-ads";
 const URL_2 = "https://support.apple.com/en-us/HT202074";
 
-describe("BackLink - component", () => {
+describe("ClickableUrls - component", () => {
   it("renders text and icon", () => {
     render(<ClickableUrls text={TEXT_WITH_URLS} />);
 

--- a/frontend/components/ClickableUrls/ClickableUrls.tests.tsx
+++ b/frontend/components/ClickableUrls/ClickableUrls.tests.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import ClickableUrls from "./ClickableUrls";
+
+const TEXT_WITH_URLS =
+  "Contact your IT administrator to ensure your Mac is receiving a profile that disables advertisement tracking. https://privacyinternational.org/guide-step/4335/macos-opt-out-targeted-ads or https://support.apple.com/en-us/HT202074";
+const URL_1 =
+  "https://privacyinternational.org/guide-step/4335/macos-opt-out-targeted-ads";
+const URL_2 = "https://support.apple.com/en-us/HT202074";
+
+describe("BackLink - component", () => {
+  it("renders text and icon", () => {
+    render(<ClickableUrls text={TEXT_WITH_URLS} />);
+
+    const link1 = screen.getByRole("link", { name: URL_1 });
+    const link2 = screen.getByRole("link", { name: URL_2 });
+
+    expect(link1).toHaveAttribute("href", URL_1);
+    expect(link1).toHaveAttribute("target", "_blank");
+    expect(link2).toHaveAttribute("href", URL_2);
+    expect(link2).toHaveAttribute("target", "_blank");
+  });
+});

--- a/frontend/components/ClickableUrls/ClickableUrls.tsx
+++ b/frontend/components/ClickableUrls/ClickableUrls.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import * as DOMPurify from "dompurify";
+import classnames from "classnames";
+
+interface IClickableUrls {
+  text: string;
+  className?: string;
+}
+
+const baseClass = "back-link";
+
+const ClickableUrls = ({ text, className }: IClickableUrls): JSX.Element => {
+  const clickableUrlClasses = classnames(baseClass, className);
+
+  // take that text, identify all links
+  const findLinks = (): string => {
+    return text;
+  };
+
+  const replacedLinks = text.replace(
+    /(^|[^a-z0-9\.\-\/])(https?:\/\/[a-z0-9\.\-\/]+)([^a-z0-9\.\-\/]|$)/g,
+    '$1<a href="$2" target="_blank">$2</a>$3'
+  );
+
+  const sanitizedResolutionContent = DOMPurify.sanitize(replacedLinks);
+
+  const textWithLinks = (
+    <div
+      className={clickableUrlClasses}
+      dangerouslySetInnerHTML={{ __html: sanitizedResolutionContent }}
+    />
+  );
+  // take those links and replace them with custom links to a new tab
+  // Return as JSX.Element
+
+  return textWithLinks;
+};
+export default ClickableUrls;

--- a/frontend/components/ClickableUrls/ClickableUrls.tsx
+++ b/frontend/components/ClickableUrls/ClickableUrls.tsx
@@ -14,7 +14,7 @@ const ClickableUrls = ({ text, className }: IClickableUrls): JSX.Element => {
 
   // Regex to find case insensitive URLs and replace with link
   const replacedLinks = text.replaceAll(
-    /(^|[^a-z0-9\.\-\/])(https?:\/\/[A-Za-z0-9\.\-\/]+)([^A-Za-z0-9\.\-\/]|$)/g,
+    /(^|[^a-z0-9.\-/])(https?:\/\/[A-Za-z0-9.\-/]+)([^A-Za-z0-9.\-/]|$)/g,
     '$1<a href="$2" target="_blank">$2</a>$3'
   );
 

--- a/frontend/components/ClickableUrls/ClickableUrls.tsx
+++ b/frontend/components/ClickableUrls/ClickableUrls.tsx
@@ -9,15 +9,21 @@ interface IClickableUrls {
 
 const baseClass = "clickable-urls";
 
+const urlReplacer = (match: string) => {
+  const url = match.startsWith("http") ? match : `https://${match}`;
+  return `<a href=${url} target="_blank" rel="noreferrer">
+      ${match}
+    </a>`;
+};
+
 const ClickableUrls = ({ text, className }: IClickableUrls): JSX.Element => {
   const clickableUrlClasses = classnames(baseClass, className);
 
   // Regex to find case insensitive URLs and replace with link
   const replacedLinks = text.replaceAll(
-    /(^|[^a-z0-9.\-/])((https?)?(:\/\/)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*))([^A-Za-z0-9.\-/]|$)/g,
-    '$1<a href="$2" target="_blank">$2</a> '
+    /(https?)?(:\/\/)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/g,
+    urlReplacer
   );
-
   const sanitizedResolutionContent = DOMPurify.sanitize(replacedLinks, {
     ADD_ATTR: ["target"], // Allows opening in a new tab
   });

--- a/frontend/components/ClickableUrls/ClickableUrls.tsx
+++ b/frontend/components/ClickableUrls/ClickableUrls.tsx
@@ -7,22 +7,20 @@ interface IClickableUrls {
   className?: string;
 }
 
-const baseClass = "back-link";
+const baseClass = "clickable-urls";
 
 const ClickableUrls = ({ text, className }: IClickableUrls): JSX.Element => {
   const clickableUrlClasses = classnames(baseClass, className);
 
-  // take that text, identify all links
-  const findLinks = (): string => {
-    return text;
-  };
-
-  const replacedLinks = text.replace(
-    /(^|[^a-z0-9\.\-\/])(https?:\/\/[a-z0-9\.\-\/]+)([^a-z0-9\.\-\/]|$)/g,
+  // Regex to find case insensitive URLs and replace with link
+  const replacedLinks = text.replaceAll(
+    /(^|[^a-z0-9\.\-\/])(https?:\/\/[A-Za-z0-9\.\-\/]+)([^A-Za-z0-9\.\-\/]|$)/g,
     '$1<a href="$2" target="_blank">$2</a>$3'
   );
 
-  const sanitizedResolutionContent = DOMPurify.sanitize(replacedLinks);
+  const sanitizedResolutionContent = DOMPurify.sanitize(replacedLinks, {
+    ADD_ATTR: ["target"], // Allows opening in a new tab
+  });
 
   const textWithLinks = (
     <div
@@ -30,8 +28,6 @@ const ClickableUrls = ({ text, className }: IClickableUrls): JSX.Element => {
       dangerouslySetInnerHTML={{ __html: sanitizedResolutionContent }}
     />
   );
-  // take those links and replace them with custom links to a new tab
-  // Return as JSX.Element
 
   return textWithLinks;
 };

--- a/frontend/components/ClickableUrls/ClickableUrls.tsx
+++ b/frontend/components/ClickableUrls/ClickableUrls.tsx
@@ -14,8 +14,8 @@ const ClickableUrls = ({ text, className }: IClickableUrls): JSX.Element => {
 
   // Regex to find case insensitive URLs and replace with link
   const replacedLinks = text.replaceAll(
-    /(^|[^a-z0-9.\-/])(https?:\/\/[A-Za-z0-9.\-/]+)([^A-Za-z0-9.\-/]|$)/g,
-    '$1<a href="$2" target="_blank">$2</a>$3'
+    /(^|[^a-z0-9.\-/])((https?)?(:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*))([^A-Za-z0-9.\-/]|$)/g,
+    '$1<a href="$2" target="_blank">$2</a> '
   );
 
   const sanitizedResolutionContent = DOMPurify.sanitize(replacedLinks, {

--- a/frontend/components/ClickableUrls/ClickableUrls.tsx
+++ b/frontend/components/ClickableUrls/ClickableUrls.tsx
@@ -14,7 +14,7 @@ const ClickableUrls = ({ text, className }: IClickableUrls): JSX.Element => {
 
   // Regex to find case insensitive URLs and replace with link
   const replacedLinks = text.replaceAll(
-    /(^|[^a-z0-9.\-/])((https?)?(:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*))([^A-Za-z0-9.\-/]|$)/g,
+    /(^|[^a-z0-9.\-/])((https?)?(:\/\/)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*))([^A-Za-z0-9.\-/]|$)/g,
     '$1<a href="$2" target="_blank">$2</a> '
   );
 

--- a/frontend/components/ClickableUrls/index.ts
+++ b/frontend/components/ClickableUrls/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ClickableUrls";

--- a/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/PolicyDetailsModal/PolicyDetailsModal.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/PolicyDetailsModal/PolicyDetailsModal.tsx
@@ -3,6 +3,7 @@ import Button from "components/buttons/Button";
 import Modal from "components/Modal";
 
 import { IHostPolicy } from "interfaces/policy";
+import ClickableUrls from "components/ClickableUrls/ClickableUrls";
 
 interface IPolicyDetailsProps {
   onCancel: () => void;
@@ -27,6 +28,7 @@ const PolicyDetailsModal = ({
           <div className={`${baseClass}__resolution`}>
             <span className={`${baseClass}__resolve-header`}> Resolve:</span>
             <p>{policy?.resolution}</p>
+            {policy?.resolution && <ClickableUrls text={policy?.resolution} />}
           </div>
         )}
         <div className="modal-cta-wrap">

--- a/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/PolicyDetailsModal/PolicyDetailsModal.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/PolicyDetailsModal/PolicyDetailsModal.tsx
@@ -27,7 +27,6 @@ const PolicyDetailsModal = ({
         {policy?.resolution && (
           <div className={`${baseClass}__resolution`}>
             <span className={`${baseClass}__resolve-header`}> Resolve:</span>
-            <p>{policy?.resolution}</p>
             {policy?.resolution && <ClickableUrls text={policy?.resolution} />}
           </div>
         )}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,15 +6,10 @@
     "sourceMap": true,
     "jsx": "react",
     "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "lib": ["ES2021.String"]
   },
-  "include": [
-    "./frontend/**/*"
-  ],
-  "exclude": [
-    "node_modules"
-  ],
-  "typeRoots": [
-    "./node_modules/@types", "./typings"
-  ]
+  "include": ["./frontend/**/*"],
+  "exclude": ["node_modules"],
+  "typeRoots": ["./node_modules/@types", "./typings"]
 }


### PR DESCRIPTION
## Issue
Cerra #12243

## Description
- Component that takes text, searches for URLs, and replaces each with html links that open in a new tab
- Uses DOMpurify.sanitize to prevent html injection security risks
- Note: `string.replaceAll()` requires `"ES2021.String"` to `tsconfig.json`
- Also note: This was a product design decision to make the URLs clickable this way instead of using markdown

## Screenrecording
https://github.com/fleetdm/fleet/assets/71795832/6a3a0e4a-6e90-428f-97b8-1a033f57fd09

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Add automated test
- [x] Manual QA for all new/changed functionality

