### PR TITLE
Configure bootstrap package and end user auth for newly created teams in MDM pre-assignment flow

### DIFF
--- a/changes/12896-preassign-with-default-mdm
+++ b/changes/12896-preassign-with-default-mdm
@@ -1,0 +1,3 @@
+- Updated the `POST /mdm/apple/profiles/match` endpoint to set the bootstrap package and enable end
+  user authentication settings for each new team created via the endpoint to the corresponding
+  values specified in the app config as of the time the applicable team is created.

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -890,8 +890,8 @@ func (svc *Service) getOrCreatePreassignTeam(ctx context.Context, groups []strin
 				EnableDiskEncryption: true,
 			},
 			MacOSSetup: &fleet.MacOSSetup{
-				// // NOTE: BootstrapPackage is currently ignored by svc.ModifyTeam and gets set
-				// // instead by CopyDefaultMDMAppleBootstrapPackage below
+				// NOTE: BootstrapPackage is currently ignored by svc.ModifyTeam and gets set
+				// instead by CopyDefaultMDMAppleBootstrapPackage below
 				// BootstrapPackage:            ac.MDM.MacOSSetup.BootstrapPackage,
 				EnableEndUserAuthentication: ac.MDM.MacOSSetup.EnableEndUserAuthentication,
 			},

--- a/ee/server/service/mdm_test.go
+++ b/ee/server/service/mdm_test.go
@@ -126,7 +126,7 @@ func TestGetOrCreatePreassignTeam(t *testing.T) {
 	}
 	teamStore := map[uint]*fleet.Team{1: team1, 2: team2}
 
-	resetDSFuncsInvoked := func() {
+	resetInvoked := func() {
 		ds.TeamByNameFuncInvoked = false
 		ds.NewTeamFuncInvoked = false
 		ds.SaveTeamFuncInvoked = false
@@ -136,7 +136,7 @@ func TestGetOrCreatePreassignTeam(t *testing.T) {
 		ds.NewJobFuncInvoked = false
 	}
 	setupDS := func(t *testing.T) {
-		resetDSFuncsInvoked()
+		resetInvoked()
 
 		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 			return appConfig, nil
@@ -200,7 +200,7 @@ func TestGetOrCreatePreassignTeam(t *testing.T) {
 		require.False(t, ds.CopyDefaultMDMAppleBootstrapPackageFuncInvoked)
 		require.False(t, ds.AppConfigFuncInvoked)
 		require.False(t, ds.NewJobFuncInvoked)
-		resetDSFuncsInvoked()
+		resetInvoked()
 	})
 
 	t.Run("create preassign team", func(t *testing.T) {
@@ -283,7 +283,7 @@ func TestGetOrCreatePreassignTeam(t *testing.T) {
 		require.True(t, team.Config.MDM.MacOSSetup.EnableEndUserAuthentication)
 		require.Equal(t, appConfig.MDM.MacOSSetup.EnableEndUserAuthentication, team.Config.MDM.MacOSSetup.EnableEndUserAuthentication)
 		require.True(t, ds.NewJobFuncInvoked)
-		resetDSFuncsInvoked()
+		resetInvoked()
 
 		// when called again, simply get the previously created team
 		team, err = svc.getOrCreatePreassignTeam(ctx, preassignGroups)
@@ -301,7 +301,7 @@ func TestGetOrCreatePreassignTeam(t *testing.T) {
 		require.Equal(t, appConfig.MDM.MacOSSetup.BootstrapPackage.Value, team.Config.MDM.MacOSSetup.BootstrapPackage.Value)
 		require.True(t, team.Config.MDM.MacOSSetup.EnableEndUserAuthentication)
 		require.Equal(t, appConfig.MDM.MacOSSetup.EnableEndUserAuthentication, team.Config.MDM.MacOSSetup.EnableEndUserAuthentication)
-		resetDSFuncsInvoked()
+		resetInvoked()
 	})
 
 	t.Run("modify team", func(t *testing.T) {
@@ -331,7 +331,7 @@ func TestGetOrCreatePreassignTeam(t *testing.T) {
 		require.False(t, ds.NewMDMAppleConfigProfileFuncInvoked)
 		require.False(t, ds.CopyDefaultMDMAppleBootstrapPackageFuncInvoked)
 		require.False(t, ds.NewJobFuncInvoked)
-		resetDSFuncsInvoked()
+		resetInvoked()
 	})
 
 	t.Run("new team", func(t *testing.T) {
@@ -368,7 +368,7 @@ func TestGetOrCreatePreassignTeam(t *testing.T) {
 		require.False(t, ds.NewMDMAppleConfigProfileFuncInvoked)
 		require.False(t, ds.CopyDefaultMDMAppleBootstrapPackageFuncInvoked)
 		require.False(t, ds.NewJobFuncInvoked)
-		resetDSFuncsInvoked()
+		resetInvoked()
 	})
 
 	t.Run("apply team spec", func(t *testing.T) {
@@ -419,7 +419,7 @@ func TestGetOrCreatePreassignTeam(t *testing.T) {
 		}
 
 		// apply team spec creates new team without defaults
-		_, err := (*Service)(svc).ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplySpecOptions{})
+		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplySpecOptions{})
 		require.NoError(t, err)
 		require.True(t, ds.NewTeamFuncInvoked)
 		require.True(t, ds.AppConfigFuncInvoked)
@@ -428,11 +428,11 @@ func TestGetOrCreatePreassignTeam(t *testing.T) {
 		require.False(t, ds.NewMDMAppleConfigProfileFuncInvoked)
 		require.False(t, ds.CopyDefaultMDMAppleBootstrapPackageFuncInvoked)
 		require.False(t, ds.NewJobFuncInvoked)
-		resetDSFuncsInvoked()
+		resetInvoked()
 
 		// apply team spec edits existing team without applying defaults
 		spec.MDM.MacOSUpdates.Deadline = optjson.SetString("2025-01-01")
-		_, err = (*Service)(svc).ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplySpecOptions{})
+		_, err = svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplySpecOptions{})
 		require.NoError(t, err)
 		require.True(t, ds.SaveTeamFuncInvoked)
 		require.True(t, ds.AppConfigFuncInvoked)
@@ -441,7 +441,7 @@ func TestGetOrCreatePreassignTeam(t *testing.T) {
 		require.False(t, ds.NewMDMAppleConfigProfileFuncInvoked)
 		require.False(t, ds.CopyDefaultMDMAppleBootstrapPackageFuncInvoked)
 		require.False(t, ds.NewJobFuncInvoked)
-		resetDSFuncsInvoked()
+		resetInvoked()
 	})
 }
 

--- a/ee/server/service/mdm_test.go
+++ b/ee/server/service/mdm_test.go
@@ -2,15 +2,23 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
 
+	"github.com/fleetdm/fleet/v4/pkg/optjson"
+	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/fleetdm/fleet/v4/server/test"
+	"github.com/fleetdm/fleet/v4/server/worker"
+	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -79,7 +87,362 @@ func TestMDMAppleDisableFileVaultAndEscrow(t *testing.T) {
 	err := svc.MDMAppleDisableFileVaultAndEscrow(context.Background(), ptr.Uint(wantTeamID))
 	require.NoError(t, err)
 	require.True(t, ds.DeleteMDMAppleConfigProfileByTeamAndIdentifierFuncInvoked)
+}
 
+func TestGetOrCreatePreassignTeam(t *testing.T) {
+	ds, svc := setup(t)
+	a, err := authz.NewAuthorizer()
+	require.NoError(t, err)
+	svc.authz = a
+	svc.logger = log.NewNopLogger()
+
+	ssoSettings := fleet.SSOProviderSettings{
+		EntityID:    "foo",
+		MetadataURL: "https://example.com/metadata.xml",
+		IssuerURI:   "https://example.com",
+	}
+	appConfig := &fleet.AppConfig{MDM: fleet.MDM{
+		EnabledAndConfigured:  true,
+		EndUserAuthentication: fleet.MDMEndUserAuthentication{SSOProviderSettings: ssoSettings},
+		MacOSSetup: fleet.MacOSSetup{
+			BootstrapPackage:            optjson.SetString("https://example.com/bootstrap.pkg"),
+			EnableEndUserAuthentication: true,
+		},
+	}}
+	preassignGroups := []string{"one", "three"}
+	// initialize team store with team one and two already created
+	team1 := &fleet.Team{
+		ID:   1,
+		Name: preassignGroups[0],
+	}
+	team2 := &fleet.Team{
+		ID:   2,
+		Name: "two",
+		Config: fleet.TeamConfig{
+			MDM: fleet.TeamMDM{
+				MacOSSetup: fleet.MacOSSetup{MacOSSetupAssistant: optjson.SetString("foo/bar")},
+			},
+		},
+	}
+	teamStore := map[uint]*fleet.Team{1: team1, 2: team2}
+
+	resetDSFuncsInvoked := func() {
+		ds.TeamByNameFuncInvoked = false
+		ds.NewTeamFuncInvoked = false
+		ds.SaveTeamFuncInvoked = false
+		ds.NewMDMAppleConfigProfileFuncInvoked = false
+		ds.CopyDefaultMDMAppleBootstrapPackageFuncInvoked = false
+		ds.AppConfigFuncInvoked = false
+		ds.NewJobFuncInvoked = false
+	}
+	setupDS := func(t *testing.T) {
+		resetDSFuncsInvoked()
+
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return appConfig, nil
+		}
+		ds.NewActivityFunc = func(ctx context.Context, u *fleet.User, a fleet.ActivityDetails) error {
+			return nil
+		}
+		ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+			for _, team := range teamStore {
+				if team.Name == name {
+					return team, nil
+				}
+			}
+			return nil, ctxerr.Wrap(ctx, &notFoundError{})
+		}
+		ds.TeamFunc = func(ctx context.Context, id uint) (*fleet.Team, error) {
+			tm, ok := teamStore[id]
+			if !ok {
+				return nil, errors.New("team id not found")
+			}
+			if id != tm.ID {
+				// sanity chec
+				return nil, errors.New("team id mismatch")
+			}
+			return tm, nil
+		}
+		ds.NewTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+			return nil, errors.New("not implemented")
+		}
+		ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+			return nil, errors.New("not implemented")
+		}
+		ds.NewMDMAppleConfigProfileFunc = func(ctx context.Context, profile fleet.MDMAppleConfigProfile) (*fleet.MDMAppleConfigProfile, error) {
+			return nil, errors.New("not implemented")
+		}
+		ds.DeleteMDMAppleConfigProfileByTeamAndIdentifierFunc = func(ctx context.Context, teamID *uint, profileIdentifier string) error {
+			return errors.New("not implemented")
+		}
+		ds.CopyDefaultMDMAppleBootstrapPackageFunc = func(ctx context.Context, ac *fleet.AppConfig, toTeamID uint) error {
+			return errors.New("not implemented")
+		}
+		ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
+			return nil, errors.New("not implemented")
+		}
+	}
+
+	ctx := viewer.NewContext(context.Background(), viewer.Viewer{User: test.UserAdmin})
+
+	t.Run("get preassign team", func(t *testing.T) {
+		setupDS(t)
+
+		// preasign group corresponds to existing team so simply get it
+		team, err := svc.getOrCreatePreassignTeam(ctx, preassignGroups[0:1])
+		require.NoError(t, err)
+		require.Equal(t, uint(1), team.ID)
+		require.Equal(t, preassignGroups[0], team.Name)
+		require.True(t, ds.TeamByNameFuncInvoked)
+		require.False(t, ds.NewTeamFuncInvoked)
+		require.False(t, ds.SaveTeamFuncInvoked)
+		require.False(t, ds.NewMDMAppleConfigProfileFuncInvoked)
+		require.False(t, ds.CopyDefaultMDMAppleBootstrapPackageFuncInvoked)
+		require.False(t, ds.AppConfigFuncInvoked)
+		require.False(t, ds.NewJobFuncInvoked)
+		resetDSFuncsInvoked()
+	})
+
+	t.Run("create preassign team", func(t *testing.T) {
+		// setup ds with assertions for this test
+		setupDS(t)
+		ds.NewTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+			for _, tm := range teamStore {
+				if tm.Name == team.Name {
+					return nil, errors.New("team name already exists")
+				}
+			}
+			id := uint(len(teamStore) + 1)
+			_, ok := teamStore[id]
+			require.False(t, ok) // sanity check
+			team.ID = id
+			teamStore[id] = team
+			return team, nil
+		}
+		ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+			tm, ok := teamStore[team.ID]
+			if !ok {
+				return nil, errors.New("invalid team id")
+			}
+			require.Equal(t, tm.ID, team.ID)     // sanity check
+			require.Equal(t, tm.Name, team.Name) // sanity check
+			// // NOTE: BootstrapPackage is currently ignored by svc.ModifyTeam and gets set
+			// // instead by CopyDefaultMDMAppleBootstrapPackage below
+			// require.Equal(t, appConfig.MDM.MacOSSetup.BootstrapPackage.Value, team.Config.MDM.MacOSSetup.BootstrapPackage.Value)
+			require.Equal(t, appConfig.MDM.MacOSSetup.EnableEndUserAuthentication, team.Config.MDM.MacOSSetup.EnableEndUserAuthentication) // set to default
+			teamStore[tm.ID] = team
+			return team, nil
+		}
+		ds.NewMDMAppleConfigProfileFunc = func(ctx context.Context, profile fleet.MDMAppleConfigProfile) (*fleet.MDMAppleConfigProfile, error) {
+			require.Equal(t, uint(3), *profile.TeamID)
+			require.Equal(t, mobileconfig.FleetFileVaultPayloadIdentifier, profile.Identifier)
+			return &profile, nil
+		}
+		ds.DeleteMDMAppleConfigProfileByTeamAndIdentifierFunc = func(ctx context.Context, teamID *uint, profileIdentifier string) error {
+			require.Equal(t, uint(3), *teamID)
+			require.Equal(t, mobileconfig.FleetFileVaultPayloadIdentifier, profileIdentifier)
+			return nil
+		}
+		ds.CopyDefaultMDMAppleBootstrapPackageFunc = func(ctx context.Context, ac *fleet.AppConfig, toTeamID uint) error {
+			require.Equal(t, uint(3), toTeamID)
+			require.NotNil(t, ac)
+			require.Equal(t, "https://example.com/bootstrap.pkg", ac.MDM.MacOSSetup.BootstrapPackage.Value)
+			teamStore[toTeamID].Config.MDM.MacOSSetup.BootstrapPackage = optjson.SetString(ac.MDM.MacOSSetup.BootstrapPackage.Value)
+			return nil
+		}
+		ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
+			wantArgs, err := json.Marshal(map[string]interface{}{
+				"task":    worker.MacosSetupAssistantUpdateProfile,
+				"team_id": 3,
+			})
+			require.NoError(t, err)
+			wantJob := &fleet.Job{
+				Name:  "macos_setup_assistant",
+				Args:  (*json.RawMessage)(&wantArgs),
+				State: fleet.JobStateQueued,
+			}
+			require.Equal(t, wantJob.Name, job.Name)
+			require.Equal(t, string(*wantJob.Args), string(*job.Args))
+			require.Equal(t, wantJob.State, job.State)
+			return job, nil
+		}
+
+		// new team is created with bootstrap package and end user auth based on app config
+		team, err := svc.getOrCreatePreassignTeam(ctx, preassignGroups)
+		require.NoError(t, err)
+		require.Equal(t, uint(3), team.ID)
+		require.Equal(t, teamNameFromPreassignGroups(preassignGroups), team.Name)
+		require.True(t, ds.TeamByNameFuncInvoked)
+		require.True(t, ds.NewTeamFuncInvoked)
+		require.True(t, ds.SaveTeamFuncInvoked)
+		require.True(t, ds.NewMDMAppleConfigProfileFuncInvoked)
+		require.True(t, ds.CopyDefaultMDMAppleBootstrapPackageFuncInvoked)
+		require.True(t, ds.AppConfigFuncInvoked)
+		require.NotEmpty(t, team.Config.MDM.MacOSSetup.BootstrapPackage.Value)
+		require.Equal(t, appConfig.MDM.MacOSSetup.BootstrapPackage.Value, team.Config.MDM.MacOSSetup.BootstrapPackage.Value)
+		require.True(t, team.Config.MDM.MacOSSetup.EnableEndUserAuthentication)
+		require.Equal(t, appConfig.MDM.MacOSSetup.EnableEndUserAuthentication, team.Config.MDM.MacOSSetup.EnableEndUserAuthentication)
+		require.True(t, ds.NewJobFuncInvoked)
+		resetDSFuncsInvoked()
+
+		// when called again, simply get the previously created team
+		team, err = svc.getOrCreatePreassignTeam(ctx, preassignGroups)
+		require.NoError(t, err)
+		require.Equal(t, uint(3), team.ID)
+		require.Equal(t, teamNameFromPreassignGroups(preassignGroups), team.Name)
+		require.True(t, ds.TeamByNameFuncInvoked)
+		require.False(t, ds.NewTeamFuncInvoked)
+		require.False(t, ds.SaveTeamFuncInvoked)
+		require.False(t, ds.NewMDMAppleConfigProfileFuncInvoked)
+		require.False(t, ds.CopyDefaultMDMAppleBootstrapPackageFuncInvoked)
+		require.False(t, ds.AppConfigFuncInvoked)
+		require.False(t, ds.NewJobFuncInvoked)
+		require.NotEmpty(t, team.Config.MDM.MacOSSetup.BootstrapPackage.Value)
+		require.Equal(t, appConfig.MDM.MacOSSetup.BootstrapPackage.Value, team.Config.MDM.MacOSSetup.BootstrapPackage.Value)
+		require.True(t, team.Config.MDM.MacOSSetup.EnableEndUserAuthentication)
+		require.Equal(t, appConfig.MDM.MacOSSetup.EnableEndUserAuthentication, team.Config.MDM.MacOSSetup.EnableEndUserAuthentication)
+		resetDSFuncsInvoked()
+	})
+
+	t.Run("modify team", func(t *testing.T) {
+		// setup ds with assertions this test
+		setupDS(t)
+		ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+			tm, ok := teamStore[team.ID]
+			if !ok {
+				return nil, errors.New("invalid team id")
+			}
+			require.Equal(t, tm.ID, team.ID)                                         // sanity check
+			require.Equal(t, tm.Name, team.Name)                                     // sanity check
+			require.Empty(t, team.Config.MDM.MacOSSetup.EnableEndUserAuthentication) // not modified
+			require.Empty(t, team.Config.MDM.MacOSSetup.BootstrapPackage.Value)      // not modified
+			require.NotEmpty(t, team.Description)                                    // modified
+			teamStore[tm.ID].Description = team.Description
+			return teamStore[tm.ID], nil
+		}
+
+		// modify team does not apply defaults
+		_, err := svc.ModifyTeam(ctx, 2, fleet.TeamPayload{Description: ptr.String("new description")})
+		require.NoError(t, err)
+		require.True(t, ds.SaveTeamFuncInvoked)
+		require.True(t, ds.AppConfigFuncInvoked)
+		require.False(t, ds.TeamByNameFuncInvoked)
+		require.False(t, ds.NewTeamFuncInvoked)
+		require.False(t, ds.NewMDMAppleConfigProfileFuncInvoked)
+		require.False(t, ds.CopyDefaultMDMAppleBootstrapPackageFuncInvoked)
+		require.False(t, ds.NewJobFuncInvoked)
+		resetDSFuncsInvoked()
+	})
+
+	t.Run("new team", func(t *testing.T) {
+		// setup ds with assertions this test
+		setupDS(t)
+		ds.NewTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+			for _, tm := range teamStore {
+				if tm.Name == team.Name {
+					return nil, errors.New("team name already exists")
+				}
+			}
+			id := uint(len(teamStore) + 1)
+			_, ok := teamStore[id]
+			require.False(t, ok) // sanity check
+			require.Equal(t, "new team", team.Name)
+			require.Equal(t, "new description", team.Description)
+			require.Empty(t, team.Config.MDM.MacOSSetup.EnableEndUserAuthentication) // not set
+			require.Empty(t, team.Config.MDM.MacOSSetup.BootstrapPackage.Value)      // not set
+			team.ID = id
+			teamStore[id] = team
+			return team, nil
+		}
+
+		// new team does not apply defaults
+		_, err := svc.NewTeam(ctx, fleet.TeamPayload{
+			Name:        ptr.String("new team"),
+			Description: ptr.String("new description"),
+		})
+		require.NoError(t, err)
+		require.True(t, ds.NewTeamFuncInvoked)
+		require.True(t, ds.AppConfigFuncInvoked)
+		require.False(t, ds.TeamByNameFuncInvoked)
+		require.False(t, ds.SaveTeamFuncInvoked)
+		require.False(t, ds.NewMDMAppleConfigProfileFuncInvoked)
+		require.False(t, ds.CopyDefaultMDMAppleBootstrapPackageFuncInvoked)
+		require.False(t, ds.NewJobFuncInvoked)
+		resetDSFuncsInvoked()
+	})
+
+	t.Run("apply team spec", func(t *testing.T) {
+		// setup ds with assertions this test
+		setupDS(t)
+		ds.NewTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+			for _, tm := range teamStore {
+				if tm.Name == team.Name {
+					return nil, errors.New("team name already exists")
+				}
+			}
+			id := uint(len(teamStore) + 1)
+			_, ok := teamStore[id]
+			require.False(t, ok)                                                        // sanity check
+			require.Equal(t, "new team spec", team.Name)                                // set
+			require.Equal(t, "12.0", team.Config.MDM.MacOSUpdates.MinimumVersion.Value) // set
+			require.Equal(t, "2024-01-01", team.Config.MDM.MacOSUpdates.Deadline.Value) // set                                    // not set
+			require.Empty(t, team.Config.MDM.MacOSSetup.EnableEndUserAuthentication)    // not set
+			require.Empty(t, team.Config.MDM.MacOSSetup.BootstrapPackage.Value)         // not set
+			team.ID = id
+			teamStore[id] = team
+			return team, nil
+		}
+		ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+			tm, ok := teamStore[team.ID]
+			if !ok {
+				return nil, errors.New("invalid team id")
+			}
+			require.Equal(t, tm.ID, team.ID)                                            // sanity check
+			require.Equal(t, tm.Name, team.Name)                                        // sanity check
+			require.Equal(t, "12.0", team.Config.MDM.MacOSUpdates.MinimumVersion.Value) // unchanged
+			require.Equal(t, "2025-01-01", team.Config.MDM.MacOSUpdates.Deadline.Value) // modified                                    // not set
+			require.Empty(t, team.Config.MDM.MacOSSetup.EnableEndUserAuthentication)    // not set
+			require.Empty(t, team.Config.MDM.MacOSSetup.BootstrapPackage.Value)         // not set
+
+			teamStore[tm.ID].Description = team.Description
+			return teamStore[tm.ID], nil
+		}
+
+		spec := &fleet.TeamSpec{
+			Name: "new team spec",
+			MDM: fleet.TeamSpecMDM{
+				MacOSUpdates: fleet.MacOSUpdates{
+					MinimumVersion: optjson.SetString("12.0"),
+					Deadline:       optjson.SetString("2024-01-01"),
+				},
+			},
+		}
+
+		// apply team spec creates new team without defaults
+		_, err := (*Service)(svc).ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplySpecOptions{})
+		require.NoError(t, err)
+		require.True(t, ds.NewTeamFuncInvoked)
+		require.True(t, ds.AppConfigFuncInvoked)
+		require.True(t, ds.TeamByNameFuncInvoked)
+		require.False(t, ds.SaveTeamFuncInvoked)
+		require.False(t, ds.NewMDMAppleConfigProfileFuncInvoked)
+		require.False(t, ds.CopyDefaultMDMAppleBootstrapPackageFuncInvoked)
+		require.False(t, ds.NewJobFuncInvoked)
+		resetDSFuncsInvoked()
+
+		// apply team spec edits existing team without applying defaults
+		spec.MDM.MacOSUpdates.Deadline = optjson.SetString("2025-01-01")
+		_, err = (*Service)(svc).ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplySpecOptions{})
+		require.NoError(t, err)
+		require.True(t, ds.SaveTeamFuncInvoked)
+		require.True(t, ds.AppConfigFuncInvoked)
+		require.True(t, ds.TeamByNameFuncInvoked)
+		require.False(t, ds.NewTeamFuncInvoked)
+		require.False(t, ds.NewMDMAppleConfigProfileFuncInvoked)
+		require.False(t, ds.CopyDefaultMDMAppleBootstrapPackageFuncInvoked)
+		require.False(t, ds.NewJobFuncInvoked)
+		resetDSFuncsInvoked()
+	})
 }
 
 var (

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -2220,7 +2220,7 @@ WHERE team_id = 0
 		if url != "" {
 			updateConfigStmt := `
 UPDATE teams 
-SET config = JSON_MERGE_PATCH(config, '{ "mdm": { "macos_setup": { "bootstrap_package": "%s" } } }') 
+SET config = JSON_SET(config, '$.mdm.macos_setup.bootstrap_package', '%s') 
 WHERE id = ?
 `
 			_, err = tx.ExecContext(ctx, fmt.Sprintf(updateConfigStmt, url), toTeamID)

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/VividCortex/mysqlerr"
+	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
@@ -4052,6 +4053,125 @@ func testSetVerifiedMacOSProfiles(t *testing.T, ds *Datastore) {
 	}))
 	expectedHostMDMStatus[hosts[2].ID][cp2.Identifier] = fleet.MDMAppleDeliveryFailed // cp2 is outdated
 	checkHostMDMProfileStatuses()
+}
+
+func TestCopyDefaultMDMAppleBootstrapPackage(t *testing.T) {
+	ds := CreateMySQLDS(t)
+	defer ds.Close()
+
+	ctx := context.Background()
+
+	checkStoredBP := func(teamID uint, wantErr error, wantNewToken bool, wantBP *fleet.MDMAppleBootstrapPackage) {
+		var gotBP fleet.MDMAppleBootstrapPackage
+		err := sqlx.GetContext(ctx, ds.primary, &gotBP, "SELECT * FROM mdm_apple_bootstrap_packages WHERE team_id = ?", teamID)
+		if wantErr != nil {
+			require.EqualError(t, err, wantErr.Error())
+			return
+		}
+		require.NoError(t, err)
+		if wantNewToken {
+			require.NotEqual(t, wantBP.Token, gotBP.Token)
+		} else {
+			require.Equal(t, wantBP.Token, gotBP.Token)
+		}
+		require.Equal(t, wantBP.Name, gotBP.Name)
+		require.Equal(t, wantBP.Sha256[:32], gotBP.Sha256)
+		require.Equal(t, wantBP.Bytes, gotBP.Bytes)
+	}
+
+	checkAppConfig := func(wantURL string) {
+		ac, err := ds.AppConfig(ctx)
+		require.NoError(t, err)
+		require.Equal(t, wantURL, ac.MDM.MacOSSetup.BootstrapPackage.Value)
+	}
+
+	checkTeamConfig := func(teamID uint, wantURL string) {
+		tm, err := ds.Team(ctx, teamID)
+		require.NoError(t, err)
+		require.Equal(t, wantURL, tm.Config.MDM.MacOSSetup.BootstrapPackage.Value)
+	}
+
+	tm, err := ds.NewTeam(ctx, &fleet.Team{Name: "test"})
+	require.NoError(t, err)
+	teamID := tm.ID
+	noTeamID := uint(0)
+
+	// confirm bootstrap package url is empty by default
+	checkAppConfig("")
+	checkTeamConfig(teamID, "")
+
+	// create a default bootstrap package
+	defaultBP := &fleet.MDMAppleBootstrapPackage{
+		TeamID: noTeamID,
+		Name:   "name",
+		Sha256: sha256.New().Sum([]byte("content")),
+		Bytes:  []byte("content"),
+		Token:  uuid.New().String(),
+	}
+	err = ds.InsertMDMAppleBootstrapPackage(ctx, defaultBP)
+	require.NoError(t, err)
+	checkStoredBP(noTeamID, nil, false, defaultBP)   // default bootstrap package is stored
+	checkStoredBP(teamID, sql.ErrNoRows, false, nil) // no bootstrap package yet for team
+
+	ac, err := ds.AppConfig(ctx)
+	require.NoError(t, err)
+	require.Empty(t, ac.MDM.MacOSSetup.BootstrapPackage.Value)
+	err = ds.CopyDefaultMDMAppleBootstrapPackage(ctx, ac, teamID)
+	require.NoError(t, err)
+
+	checkAppConfig("")                             // no bootstrap package url set in app config
+	checkTeamConfig(teamID, "")                    // no bootstrap package url set in team config
+	checkStoredBP(noTeamID, nil, false, defaultBP) // no change to default bootstrap package
+	checkStoredBP(teamID, nil, true, defaultBP)    // copied default bootstrap package
+
+	// delete and update the default bootstrap package
+	err = ds.DeleteMDMAppleBootstrapPackage(ctx, noTeamID)
+	require.NoError(t, err)
+	checkStoredBP(noTeamID, sql.ErrNoRows, false, nil) // deleted
+	checkStoredBP(teamID, nil, true, defaultBP)        // still exists
+
+	// update the default bootstrap package
+	defaultBP2 := &fleet.MDMAppleBootstrapPackage{
+		TeamID: noTeamID,
+		Name:   "new name",
+		Sha256: sha256.New().Sum([]byte("new content")),
+		Bytes:  []byte("new content"),
+		Token:  uuid.New().String(),
+	}
+	err = ds.InsertMDMAppleBootstrapPackage(ctx, defaultBP2)
+	require.NoError(t, err)
+	checkStoredBP(noTeamID, nil, false, defaultBP2)
+	// set bootstrap package url in app config
+	ac.MDM.MacOSSetup.BootstrapPackage = optjson.SetString("https://example.com/bootstrap.pkg")
+	err = ds.SaveAppConfig(ctx, ac)
+	require.NoError(t, err)
+	checkAppConfig("https://example.com/bootstrap.pkg")
+
+	// copy default bootstrap package fails when there is already a team bootstrap package
+	var wantErr error = &existsError{ResourceType: "BootstrapPackage", TeamID: &teamID}
+	err = ds.CopyDefaultMDMAppleBootstrapPackage(ctx, ac, teamID)
+	require.ErrorContains(t, err, wantErr.Error())
+	// confirm team bootstrap package is unchanged
+	checkStoredBP(teamID, nil, true, defaultBP)
+	checkTeamConfig(teamID, "")
+
+	// delete the team bootstrap package
+	err = ds.DeleteMDMAppleBootstrapPackage(ctx, teamID)
+	require.NoError(t, err)
+	checkStoredBP(teamID, sql.ErrNoRows, false, nil)
+	checkTeamConfig(teamID, "")
+
+	// confirm no change to default bootstrap package
+	checkStoredBP(noTeamID, nil, false, defaultBP2)
+	checkAppConfig("https://example.com/bootstrap.pkg")
+
+	// copy default bootstrap package succeeds when there is no team bootstrap package
+	err = ds.CopyDefaultMDMAppleBootstrapPackage(ctx, ac, teamID)
+	require.NoError(t, err)
+	// confirm team bootstrap package gets new token and otherwise matches default bootstrap package
+	checkStoredBP(teamID, nil, true, defaultBP2)
+	// confirm bootstrap package url was set in team config to match app config
+	checkTeamConfig(teamID, "https://example.com/bootstrap.pkg")
 }
 
 func TestHostDEPAssignments(t *testing.T) {

--- a/server/datastore/mysql/errors.go
+++ b/server/datastore/mysql/errors.go
@@ -91,7 +91,10 @@ func (e *existsError) WithTeamID(teamID uint) error {
 }
 
 func (e *existsError) Error() string {
-	msg := fmt.Sprintf("%s %v already exists", e.ResourceType, e.Identifier)
+	msg := fmt.Sprintf("%s", e.ResourceType)
+	if e.Identifier != nil {
+		msg += fmt.Sprintf(" %v", e.Identifier)
+	}
 	if e.TeamID != nil {
 		msg += fmt.Sprintf(" with TeamID %d", *e.TeamID)
 	}

--- a/server/datastore/mysql/errors.go
+++ b/server/datastore/mysql/errors.go
@@ -95,6 +95,7 @@ func (e *existsError) Error() string {
 	if e.Identifier != nil {
 		msg += fmt.Sprintf(" %v", e.Identifier)
 	}
+	msg += " already exists"
 	if e.TeamID != nil {
 		msg += fmt.Sprintf(" with TeamID %d", *e.TeamID)
 	}

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -922,6 +922,9 @@ type Datastore interface {
 
 	// InsertMDMAppleBootstrapPackage insterts a new bootstrap package in the database
 	InsertMDMAppleBootstrapPackage(ctx context.Context, bp *MDMAppleBootstrapPackage) error
+	// CopyMDMAppleBootstrapPackage copies the bootstrap package specified in the app config (if any)
+	// specified team (and a new token is assigned). It also updates the team config with the default bootstrap package URL.
+	CopyDefaultMDMAppleBootstrapPackage(ctx context.Context, ac *AppConfig, toTeamID uint) error
 	// DeleteMDMAppleBootstrapPackage deletes the bootstrap package for the given team id
 	DeleteMDMAppleBootstrapPackage(ctx context.Context, teamID uint) error
 	// GetMDMAppleBootstrapPackageMeta returns metadata about the bootstrap package for a team

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -608,6 +608,8 @@ type GetMDMAppleFileVaultSummaryFunc func(ctx context.Context, teamID *uint) (*f
 
 type InsertMDMAppleBootstrapPackageFunc func(ctx context.Context, bp *fleet.MDMAppleBootstrapPackage) error
 
+type CopyDefaultMDMAppleBootstrapPackageFunc func(ctx context.Context, ac *fleet.AppConfig, toTeamID uint) error
+
 type DeleteMDMAppleBootstrapPackageFunc func(ctx context.Context, teamID uint) error
 
 type GetMDMAppleBootstrapPackageMetaFunc func(ctx context.Context, teamID uint) (*fleet.MDMAppleBootstrapPackage, error)
@@ -1541,6 +1543,9 @@ type DataStore struct {
 
 	InsertMDMAppleBootstrapPackageFunc        InsertMDMAppleBootstrapPackageFunc
 	InsertMDMAppleBootstrapPackageFuncInvoked bool
+
+	CopyDefaultMDMAppleBootstrapPackageFunc        CopyDefaultMDMAppleBootstrapPackageFunc
+	CopyDefaultMDMAppleBootstrapPackageFuncInvoked bool
 
 	DeleteMDMAppleBootstrapPackageFunc        DeleteMDMAppleBootstrapPackageFunc
 	DeleteMDMAppleBootstrapPackageFuncInvoked bool
@@ -3680,6 +3685,13 @@ func (s *DataStore) InsertMDMAppleBootstrapPackage(ctx context.Context, bp *flee
 	s.InsertMDMAppleBootstrapPackageFuncInvoked = true
 	s.mu.Unlock()
 	return s.InsertMDMAppleBootstrapPackageFunc(ctx, bp)
+}
+
+func (s *DataStore) CopyDefaultMDMAppleBootstrapPackage(ctx context.Context, ac *fleet.AppConfig, toTeamID uint) error {
+	s.mu.Lock()
+	s.CopyDefaultMDMAppleBootstrapPackageFuncInvoked = true
+	s.mu.Unlock()
+	return s.CopyDefaultMDMAppleBootstrapPackageFunc(ctx, ac, toTeamID)
 }
 
 func (s *DataStore) DeleteMDMAppleBootstrapPackage(ctx context.Context, teamID uint) error {


### PR DESCRIPTION
Issue #12896

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [x] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
