### PR TITLE
Update `fleetctl convert` for schedulable queries

### DIFF
--- a/changes/12657-update-fleetctl-convert
+++ b/changes/12657-update-fleetctl-convert
@@ -1,0 +1,1 @@
+- Update `fleetctl convert` to convert packs to the new combined schedule and query format

--- a/cmd/fleetctl/convert.go
+++ b/cmd/fleetctl/convert.go
@@ -106,8 +106,6 @@ func specGroupFromPack(name string, inputPack fleet.PermissivePackContent) (*spe
 		var queryPlatforms string
 		if query.Platform != nil {
 			queryPlatforms = *query.Platform
-		} else {
-			queryPlatforms = ""
 		}
 		convertedPlatforms, err := convertPlatforms(queryPlatforms)
 		if err != nil {
@@ -118,8 +116,6 @@ func specGroupFromPack(name string, inputPack fleet.PermissivePackContent) (*spe
 		var minOsqueryVersion string
 		if query.Version != nil {
 			minOsqueryVersion = *query.Version
-		} else {
-			minOsqueryVersion = ""
 		}
 
 		spec := &fleet.QuerySpec{

--- a/cmd/fleetctl/convert.go
+++ b/cmd/fleetctl/convert.go
@@ -40,8 +40,6 @@ var platformMapping = map[string][]string{
 }
 
 func convertPlatforms(platformsIn string) (string, error) {
-	resultOrder := []string{"darwin", "linux", "windows", "chrome"}
-
 	splitPlatformsIn := strings.Split(platformsIn, ",")
 
 	// validate and convert each substring
@@ -59,11 +57,13 @@ func convertPlatforms(platformsIn string) (string, error) {
 
 	// convert set to slice
 	result := make([]string, 0, len(mapped))
-	for _, p := range resultOrder {
-		if _, ok := mapped[p]; ok {
-			result = append(result, p)
-		}
+
+	for p := range mapped {
+		result = append(result, p)
 	}
+
+	// sort for deterministic output
+	sort.Strings(result)
 
 	resultString := strings.Join(result, ",")
 

--- a/cmd/fleetctl/convert.go
+++ b/cmd/fleetctl/convert.go
@@ -39,7 +39,7 @@ var platformMapping = map[string][]string{
 	"":          {""},
 }
 
-func convertPlatform(platformsIn string) (string, error) {
+func convertPlatforms(platformsIn string) (string, error) {
 	resultOrder := []string{"darwin", "linux", "windows", "chrome"}
 
 	splitPlatformsIn := strings.Split(platformsIn, ",")
@@ -102,15 +102,24 @@ func specGroupFromPack(name string, inputPack fleet.PermissivePackContent) (*spe
 			interval = uint(i)
 		}
 
-		var queryPlatform string
+		// handle nil query.Platform
+		var queryPlatforms string
 		if query.Platform != nil {
-			queryPlatform = *query.Platform
+			queryPlatforms = *query.Platform
 		} else {
-			queryPlatform = ""
+			queryPlatforms = ""
 		}
-		convertedPlatforms, err := convertPlatform(queryPlatform)
+		convertedPlatforms, err := convertPlatforms(queryPlatforms)
 		if err != nil {
 			return nil, err
+		}
+
+		// handle nil query.Version
+		var minOsqueryVersion string
+		if query.Version != nil {
+			minOsqueryVersion = *query.Version
+		} else {
+			minOsqueryVersion = ""
 		}
 
 		spec := &fleet.QuerySpec{
@@ -119,7 +128,7 @@ func specGroupFromPack(name string, inputPack fleet.PermissivePackContent) (*spe
 			Query:             query.Query,
 			Interval:          interval,
 			Platform:          convertedPlatforms,
-			MinOsqueryVersion: *query.Version,
+			MinOsqueryVersion: minOsqueryVersion,
 		}
 
 		specs.Queries = append(specs.Queries, spec)

--- a/cmd/fleetctl/convert.go
+++ b/cmd/fleetctl/convert.go
@@ -108,11 +108,12 @@ func specGroupFromPack(name string, inputPack fleet.PermissivePackContent) (*spe
 		}
 
 		spec := &fleet.QuerySpec{
-			Name:        name,
-			Description: query.Description,
-			Query:       query.Query,
-			Interval:    interval,
-			Platform:    *convertedPlatforms,
+			Name:              name,
+			Description:       query.Description,
+			Query:             query.Query,
+			Interval:          interval,
+			Platform:          *convertedPlatforms,
+			MinOsqueryVersion: *query.Version,
 		}
 
 		specs.Queries = append(specs.Queries, spec)

--- a/cmd/fleetctl/convert_test.go
+++ b/cmd/fleetctl/convert_test.go
@@ -64,5 +64,5 @@ func TestConvertFileStdout(t *testing.T) {
 	os.Stdout = oldStdout
 	w.Close()
 	out, _ := ioutil.ReadAll(r)
-	require.Equal(t, string(expected), string(out))
+	require.YAMLEq(t, string(expected), string(out))
 }

--- a/cmd/fleetctl/testdata/convert_input.conf
+++ b/cmd/fleetctl/testdata/convert_input.conf
@@ -64,7 +64,6 @@
       "description": "Retrieves the list of listening ports.",
       "value": "Identify unwanted open ports."
     },
-
     "listening_ports (utility)": {
       "query": "select * from listening_ports;",
       "interval": "3600",
@@ -73,7 +72,6 @@
       "description": "Retrieves the list of listening ports.",
       "value": "Identify unwanted open ports."
     },
-
     "yara (yara)": {
       "query": "select * from yara;",
       "interval": "0",
@@ -82,7 +80,6 @@
       "description": "Triggers one-off YARA query for files at the specified path. Requires one of sig_group, sigfile, or sigrule.",
       "value": "TBD"
     },
-
     "ulimit_info (smart)": {
       "query": "select * from ulimit_info;",
       "interval": "300",
@@ -91,7 +88,6 @@
       "description": "System resource usage limits.",
       "value": "Identify potential resource exhaustion attacks."
     },
-
     "uptime (kernel)": {
       "query": "select * from uptime;",
       "interval": "600",
@@ -132,12 +128,25 @@
       "description": "Extracted information from Windows crash logs (Minidumps).",
       "value": "Identify systems that have been rebooted recently."
     },
-
     "user groups (any)": {
       "query": "select * from user_groups;",
       "interval": "3600",
       "platform": "any",
       "version": "1.4.7",
+      "description": "List of all user groups.",
+      "value": "Identify unwanted user groups."
+    },
+    "user groups (missing platform)": {
+      "query": "select * from user_groups;",
+      "interval": "3600",
+      "version": "1.4.7",
+      "description": "List of all user groups.",
+      "value": "Identify unwanted user groups."
+    },
+    "user groups (missing version)": {
+      "query": "select * from user_groups;",
+      "interval": "3600",
+      "platform": "darwin",
       "description": "List of all user groups.",
       "value": "Identify unwanted user groups."
     },
@@ -149,8 +158,7 @@
       "description": "List of all user groups.",
       "value": "Identify unwanted user groups."
     },
-
-    "user groups (empty, no version)": {
+    "user groups (empty string platform, empty string version)": {
       "query": "select * from user_groups;",
       "interval": "3600",
       "platform": "",
@@ -158,7 +166,6 @@
       "description": "List of all user groups.",
       "value": "Identify unwanted user groups."
     },
-
     "user groups (darwin,linux)": {
       "query": "select * from user_groups;",
       "interval": "3600",

--- a/cmd/fleetctl/testdata/convert_input.conf
+++ b/cmd/fleetctl/testdata/convert_input.conf
@@ -1,52 +1,187 @@
 {
   "queries": {
     "launchd": {
-      "query" : "select * from launchd;",
-      "interval" : "3600",
-      "platform" : "darwin",
-      "version" : "1.4.5",
-      "description" : "Retrieves all the daemons that will run in the start of the target OSX system.",
-      "value" : "Identify malware that uses this persistence mechanism to launch at system boot"
+      "query": "select * from launchd;",
+      "interval": "3600",
+      "platform": "darwin",
+      "version": "1.4.5",
+      "description": "Retrieves all the daemons that will run in the start of the target OSX system.",
+      "value": "Identify malware that uses this persistence mechanism to launch at system boot"
     },
     "disk_encryption": {
-      "query" : "select * from disk_encryption;",
-      "interval" : "86400",
+      "query": "select * from disk_encryption;",
+      "interval": "86400",
       "platform": "posix",
-      "version" : "1.4.5",
-      "description" : "Retrieves the current disk encryption status for the target system.",
-      "value" : "Identifies a system potentially vulnerable to disk cloning."
+      "version": "1.4.5",
+      "description": "Retrieves the current disk encryption status for the target system.",
+      "value": "Identifies a system potentially vulnerable to disk cloning."
     },
-    "disk_encryption": {
-      "query" : "select * from disk_encryption;",
-      "interval" : "300",
+    "disk_encryption (posix)": {
+      "query": "select * from disk_encryption;",
+      "interval": "300",
       "platform": "darwin,linux",
-      "version" : "1.4.5",
-      "description" : "Retrieves the current disk encryption status for the target system.",
-      "value" : "Identifies a system potentially vulnerable to disk cloning."
+      "version": "1.4.5",
+      "description": "Retrieves the current disk encryption status for the target system.",
+      "value": "Identifies a system potentially vulnerable to disk cloning."
     },
     "iptables": {
-      "query" : "select * from iptables;",
-      "interval" : "3600",
-      "platform" : "linux",
-      "version" : "1.4.5",
-      "description" : "Retrieves the current filters and chains per filter in the target system.",
-      "value" : "Verify firewall settings are as restrictive as you need. Identify unwanted firewall holes made by malware or humans"
+      "query": "select * from iptables;",
+      "interval": "3600",
+      "platform": "linux",
+      "version": "1.4.5",
+      "description": "Retrieves the current filters and chains per filter in the target system.",
+      "value": "Verify firewall settings are as restrictive as you need. Identify unwanted firewall holes made by malware or humans"
     },
     "app_schemes": {
-      "query" : "select * from app_schemes;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.7",
-      "description" : "Retrieves the list of application scheme/protocol-based IPC handlers.",
-      "value" : "Post-priori hijack detection, detect potential sensitive information leakage."
+      "query": "select * from app_schemes;",
+      "interval": "86400",
+      "platform": "darwin",
+      "version": "1.4.7",
+      "description": "Retrieves the list of application scheme/protocol-based IPC handlers.",
+      "value": "Post-priori hijack detection, detect potential sensitive information leakage."
     },
     "sandboxes": {
-      "query" : "select * from sandboxes;",
-      "interval" : "86400",
-      "platform" : "darwin",
-      "version" : "1.4.7",
-      "description" : "Lists the application bundle that owns a sandbox label.",
-      "value" : "Post-priori hijack detection, detect potential sensitive information leakage."
+      "query": "select * from sandboxes;",
+      "interval": "86400",
+      "platform": "darwin",
+      "version": "1.4.7",
+      "description": "Lists the application bundle that owns a sandbox label.",
+      "value": "Post-priori hijack detection, detect potential sensitive information leakage."
+    },
+    "disk_info": {
+      "query": "select * from disk_info;",
+      "interval": "86400",
+      "platform": "chrome,windows",
+      "version": "1.4.7",
+      "description": "Retrieve basic information about the physical disks of a system.",
+      "value": "Identify scary possibilities with disks."
+    },
+    "listening_ports (specs)": {
+      "query": "select * from listening_ports;",
+      "interval": "3600",
+      "platform": "specs",
+      "version": "1.4.7",
+      "description": "Retrieves the list of listening ports.",
+      "value": "Identify unwanted open ports."
+    },
+
+    "listening_ports (utility)": {
+      "query": "select * from listening_ports;",
+      "interval": "3600",
+      "platform": "utility",
+      "version": "1.4.7",
+      "description": "Retrieves the list of listening ports.",
+      "value": "Identify unwanted open ports."
+    },
+
+    "yara (yara)": {
+      "query": "select * from yara;",
+      "interval": "0",
+      "platform": "yara",
+      "version": "1.4.7",
+      "description": "Triggers one-off YARA query for files at the specified path. Requires one of sig_group, sigfile, or sigrule.",
+      "value": "TBD"
+    },
+
+    "ulimit_info (smart)": {
+      "query": "select * from ulimit_info;",
+      "interval": "300",
+      "platform": "smart",
+      "version": "1.4.7",
+      "description": "System resource usage limits.",
+      "value": "Identify potential resource exhaustion attacks."
+    },
+
+    "uptime (kernel)": {
+      "query": "select * from uptime;",
+      "interval": "600",
+      "platform": "kernel",
+      "version": "1.4.7",
+      "description": "System uptime.",
+      "value": "Identify systems that have been rebooted recently."
+    },
+    "uptime (linwin)": {
+      "query": "select * from uptime;",
+      "interval": "600",
+      "platform": "linwin",
+      "version": "1.4.7",
+      "description": "System uptime.",
+      "value": "Identify systems that have been rebooted recently."
+    },
+    "uptime (macwin)": {
+      "query": "select * from uptime;",
+      "interval": "600",
+      "platform": "macwin",
+      "version": "1.4.7",
+      "description": "System uptime.",
+      "value": "Identify systems that have been rebooted recently."
+    },
+    "uptime (sleuthkit)": {
+      "query": "select * from uptime;",
+      "interval": "600",
+      "platform": "sleuthkit",
+      "version": "1.4.7",
+      "description": "System uptime.",
+      "value": "Identify systems that have been rebooted recently."
+    },
+    "windows crashes": {
+      "query": "select * from windows_crashes;",
+      "interval": "3600",
+      "platform": "windows",
+      "version": "1.4.7",
+      "description": "Extracted information from Windows crash logs (Minidumps).",
+      "value": "Identify systems that have been rebooted recently."
+    },
+
+    "user groups (any)": {
+      "query": "select * from user_groups;",
+      "interval": "3600",
+      "platform": "any",
+      "version": "1.4.7",
+      "description": "List of all user groups.",
+      "value": "Identify unwanted user groups."
+    },
+    "user groups (all)": {
+      "query": "select * from user_groups;",
+      "interval": "3600",
+      "platform": "all",
+      "version": "1.4.7",
+      "description": "List of all user groups.",
+      "value": "Identify unwanted user groups."
+    },
+
+    "user groups (empty)": {
+      "query": "select * from user_groups;",
+      "interval": "3600",
+      "platform": "",
+      "version": "1.4.7",
+      "description": "List of all user groups.",
+      "value": "Identify unwanted user groups."
+    },
+
+    "user groups (darwin,linux)": {
+      "query": "select * from user_groups;",
+      "interval": "3600",
+      "platform": "darwin,linux",
+      "version": "1.4.7",
+      "description": "List of all user groups.",
+      "value": "Identify unwanted user groups."
+    },
+    "user groups (linux,darwin)": {
+      "query": "select * from user_groups;",
+      "interval": "3600",
+      "platform": "linux,darwin",
+      "version": "1.4.7",
+      "description": "List of all user groups.",
+      "value": "Identify unwanted user groups."
+    },
+    "user groups (windows,chrome)": {
+      "query": "select * from user_groups;",
+      "interval": "3600",
+      "platform": "windows,chrome",
+      "version": "1.4.7",
+      "description": "List of all user groups.",
+      "value": "Identify unwanted user groups."
     }
   }
 }

--- a/cmd/fleetctl/testdata/convert_input.conf
+++ b/cmd/fleetctl/testdata/convert_input.conf
@@ -8,7 +8,7 @@
       "description": "Retrieves all the daemons that will run in the start of the target OSX system.",
       "value": "Identify malware that uses this persistence mechanism to launch at system boot"
     },
-    "disk_encryption": {
+    "disk_encryption (posix)": {
       "query": "select * from disk_encryption;",
       "interval": "86400",
       "platform": "posix",
@@ -16,7 +16,7 @@
       "description": "Retrieves the current disk encryption status for the target system.",
       "value": "Identifies a system potentially vulnerable to disk cloning."
     },
-    "disk_encryption (posix)": {
+    "disk_encryption (darwin,linux)": {
       "query": "select * from disk_encryption;",
       "interval": "300",
       "platform": "darwin,linux",
@@ -150,11 +150,11 @@
       "value": "Identify unwanted user groups."
     },
 
-    "user groups (empty)": {
+    "user groups (empty, no version)": {
       "query": "select * from user_groups;",
       "interval": "3600",
       "platform": "",
-      "version": "1.4.7",
+      "version": "",
       "description": "List of all user groups.",
       "value": "Identify unwanted user groups."
     },

--- a/cmd/fleetctl/testdata/convert_input.conf
+++ b/cmd/fleetctl/testdata/convert_input.conf
@@ -16,6 +16,14 @@
       "description" : "Retrieves the current disk encryption status for the target system.",
       "value" : "Identifies a system potentially vulnerable to disk cloning."
     },
+    "disk_encryption": {
+      "query" : "select * from disk_encryption;",
+      "interval" : "300",
+      "platform": "darwin,linux",
+      "version" : "1.4.5",
+      "description" : "Retrieves the current disk encryption status for the target system.",
+      "value" : "Identifies a system potentially vulnerable to disk cloning."
+    },
     "iptables": {
       "query" : "select * from iptables;",
       "interval" : "3600",

--- a/cmd/fleetctl/testdata/convert_output.yml
+++ b/cmd/fleetctl/testdata/convert_output.yml
@@ -261,7 +261,7 @@ spec:
   interval: 3600
   logging: ""
   min_osquery_version: ""
-  name: user groups (empty, no version)
+  name: user groups (empty string platform, empty string version)
   observer_can_run: false
   platform: ""
   query: select * from user_groups;
@@ -278,6 +278,34 @@ spec:
   name: user groups (linux,darwin)
   observer_can_run: false
   platform: darwin,linux
+  query: select * from user_groups;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
+  description: List of all user groups.
+  interval: 3600
+  logging: ""
+  min_osquery_version: 1.4.7
+  name: user groups (missing platform)
+  observer_can_run: false
+  platform: ""
+  query: select * from user_groups;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
+  description: List of all user groups.
+  interval: 3600
+  logging: ""
+  min_osquery_version: ""
+  name: user groups (missing version)
+  observer_can_run: false
+  platform: darwin
   query: select * from user_groups;
   team: ""
 ---

--- a/cmd/fleetctl/testdata/convert_output.yml
+++ b/cmd/fleetctl/testdata/convert_output.yml
@@ -51,7 +51,7 @@ spec:
   min_osquery_version: 1.4.7
   name: disk_info
   observer_can_run: false
-  platform: windows,chrome
+  platform: chrome,windows
   query: select * from disk_info;
   team: ""
 ---
@@ -319,7 +319,7 @@ spec:
   min_osquery_version: 1.4.7
   name: user groups (windows,chrome)
   observer_can_run: false
-  platform: windows,chrome
+  platform: chrome,windows
   query: select * from user_groups;
   team: ""
 ---

--- a/cmd/fleetctl/testdata/convert_output.yml
+++ b/cmd/fleetctl/testdata/convert_output.yml
@@ -6,7 +6,7 @@ spec:
   description: Retrieves the list of application scheme/protocol-based IPC handlers.
   interval: 86400
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.7"
   name: app_schemes
   observer_can_run: false
   platform: "darwin"
@@ -20,7 +20,7 @@ spec:
   description: Retrieves the current disk encryption status for the target system.
   interval: 86400
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.5"
   name: disk_encryption (posix)
   observer_can_run: false
   platform: "darwin,linux"
@@ -34,7 +34,7 @@ spec:
   description: Retrieves the current disk encryption status for the target system.
   interval: 300
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.5"
   name: disk_encryption (darwin,linux)
   observer_can_run: false
   platform: "darwin,linux"
@@ -48,7 +48,7 @@ spec:
   description: Retrieve basic information about the physical disks of a system.
   interval: 86400
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.7"
   name: disk_info
   observer_can_run: false
   platform: "windows,chrome"
@@ -62,7 +62,7 @@ spec:
   description: Retrieves the current filters and chains per filter in the target system.
   interval: 3600
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.5"
   name: iptables
   observer_can_run: false
   platform: "linux"
@@ -78,7 +78,7 @@ spec:
     OSX system.
   interval: 3600
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.5"
   name: launchd
   observer_can_run: false
   platform: "darwin"
@@ -92,7 +92,7 @@ spec:
   description: Retrieves the list of listening ports.
   interval: 3600
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.7"
   name: listening_ports (specs)
   observer_can_run: false
   platform: "darwin,linux,windows"
@@ -106,7 +106,7 @@ spec:
   description: Retrieves the list of listening ports.
   interval: 3600
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.7"
   name: listening_ports (utility)
   observer_can_run: false
   platform: "darwin,linux,windows"
@@ -120,7 +120,7 @@ spec:
   description: Lists the application bundle that owns a sandbox label.
   interval: 86400
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.7"
   name: sandboxes
   observer_can_run: false
   platform: "darwin"
@@ -134,7 +134,7 @@ spec:
   description: System resource usage limits.
   interval: 300
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.7"
   name: ulimit_info (smart)
   observer_can_run: false
   platform: "darwin,linux"
@@ -148,7 +148,7 @@ spec:
   description: System uptime.
   interval: 600
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.7"
   name: uptime (kernel)
   observer_can_run: false
   platform: "darwin"
@@ -162,7 +162,7 @@ spec:
   description: System uptime.
   interval: 600
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.7"
   name: uptime (linwin)
   observer_can_run: false
   platform: "linux,windows"
@@ -176,7 +176,7 @@ spec:
   description: System uptime.
   interval: 600
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.7"
   name: uptime (macwin)
   observer_can_run: false
   platform: "darwin,windows"
@@ -190,7 +190,7 @@ spec:
   description: System uptime.
   interval: 600
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.7"
   name: uptime (sleuthkit)
   observer_can_run: false
   platform: "darwin,linux"
@@ -204,7 +204,7 @@ spec:
   description: Lists the application bundle that owns a sandbox label.
   interval: 86400
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.7"
   name: sandboxes
   observer_can_run: false
   platform: "darwin"
@@ -218,7 +218,7 @@ spec:
   description: List of all user groups.
   interval: 3600
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.7"
   name: user groups (all)
   observer_can_run: false
   platform: ""
@@ -232,7 +232,7 @@ spec:
   description: List of all user groups.
   interval: 3600
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.7"
   name: user groups (any)
   observer_can_run: false
   platform: ""
@@ -246,8 +246,22 @@ spec:
   description: List of all user groups.
   interval: 3600
   logging: ""
+  min_osquery_version: "1.4.7"
+  name: user groups (darwin,linux)
+  observer_can_run: false
+  platform: "darwin,linux"
+  query: select * from user_groups;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
+  description: List of all user groups.
+  interval: 3600
+  logging: ""
   min_osquery_version: ""
-  name: user groups (empty)
+  name: user groups (empty, no version)
   observer_can_run: false
   platform: ""
   query: select * from user_groups;
@@ -257,10 +271,52 @@ apiVersion: v1
 kind: query
 spec:
   automations_enabled: false
+  description: List of all user groups.
+  interval: 3600
+  logging: ""
+  min_osquery_version: "1.4.7"
+  name: user groups (linux,darwin)
+  observer_can_run: false
+  platform: "darwin,linux"
+  query: select * from user_groups;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
+  description: List of all user groups.
+  interval: 3600
+  logging: ""
+  min_osquery_version: "1.4.7"
+  name: user groups (windows,chrome)
+  observer_can_run: false
+  platform: "windows,chrome"
+  query: select * from user_groups;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
+  description: Extracted information from Windows crash logs (Minidumps).
+  interval: 3600
+  logging: ""
+  min_osquery_version: "1.4.7"
+  name: windows crashes
+  observer_can_run: false
+  platform: "windows"
+  query: select * windows_crashes;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
   description: Triggers one-off YARA query for files at the specified path. Requires one of sig_group, sigfile, or sigrule.
   interval: 0
   logging: ""
-  min_osquery_version: ""
+  min_osquery_version: "1.4.7"
   name: yara (yara)
   observer_can_run: false
   platform: "darwin,linux,windows"

--- a/cmd/fleetctl/testdata/convert_output.yml
+++ b/cmd/fleetctl/testdata/convert_output.yml
@@ -6,10 +6,10 @@ spec:
   description: Retrieves the list of application scheme/protocol-based IPC handlers.
   interval: 86400
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: app_schemes
   observer_can_run: false
-  platform: "darwin"
+  platform: darwin
   query: select * from app_schemes;
   team: ""
 ---
@@ -20,10 +20,10 @@ spec:
   description: Retrieves the current disk encryption status for the target system.
   interval: 86400
   logging: ""
-  min_osquery_version: "1.4.5"
+  min_osquery_version: 1.4.5
   name: disk_encryption (posix)
   observer_can_run: false
-  platform: "darwin,linux"
+  platform: darwin,linux
   query: select * from disk_encryption;
   team: ""
 ---
@@ -34,10 +34,10 @@ spec:
   description: Retrieves the current disk encryption status for the target system.
   interval: 300
   logging: ""
-  min_osquery_version: "1.4.5"
+  min_osquery_version: 1.4.5
   name: disk_encryption (darwin,linux)
   observer_can_run: false
-  platform: "darwin,linux"
+  platform: darwin,linux
   query: select * from disk_encryption;
   team: ""
 ---
@@ -48,10 +48,10 @@ spec:
   description: Retrieve basic information about the physical disks of a system.
   interval: 86400
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: disk_info
   observer_can_run: false
-  platform: "windows,chrome"
+  platform: windows,chrome
   query: select * from disk_info;
   team: ""
 ---
@@ -62,10 +62,10 @@ spec:
   description: Retrieves the current filters and chains per filter in the target system.
   interval: 3600
   logging: ""
-  min_osquery_version: "1.4.5"
+  min_osquery_version: 1.4.5
   name: iptables
   observer_can_run: false
-  platform: "linux"
+  platform: linux
   query: select * from iptables;
   team: ""
 ---
@@ -78,10 +78,10 @@ spec:
     OSX system.
   interval: 3600
   logging: ""
-  min_osquery_version: "1.4.5"
+  min_osquery_version: 1.4.5
   name: launchd
   observer_can_run: false
-  platform: "darwin"
+  platform: darwin
   query: select * from launchd;
   team: ""
 ---
@@ -92,10 +92,10 @@ spec:
   description: Retrieves the list of listening ports.
   interval: 3600
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: listening_ports (specs)
   observer_can_run: false
-  platform: "darwin,linux,windows"
+  platform: darwin,linux,windows
   query: select * from listening_ports;
   team: ""
 ---
@@ -106,10 +106,10 @@ spec:
   description: Retrieves the list of listening ports.
   interval: 3600
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: listening_ports (utility)
   observer_can_run: false
-  platform: "darwin,linux,windows"
+  platform: darwin,linux,windows
   query: select * from listening_ports;
   team: ""
 ---
@@ -120,10 +120,10 @@ spec:
   description: Lists the application bundle that owns a sandbox label.
   interval: 86400
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: sandboxes
   observer_can_run: false
-  platform: "darwin"
+  platform: darwin
   query: select * from sandboxes;
   team: ""
 ---
@@ -134,10 +134,10 @@ spec:
   description: System resource usage limits.
   interval: 300
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: ulimit_info (smart)
   observer_can_run: false
-  platform: "darwin,linux"
+  platform: darwin,linux
   query: select * from ulimit_info;
   team: ""
 ---
@@ -148,10 +148,10 @@ spec:
   description: System uptime.
   interval: 600
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: uptime (kernel)
   observer_can_run: false
-  platform: "darwin"
+  platform: darwin
   query: select * from uptime;
   team: ""
 ---
@@ -162,10 +162,10 @@ spec:
   description: System uptime.
   interval: 600
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: uptime (linwin)
   observer_can_run: false
-  platform: "linux,windows"
+  platform: linux,windows
   query: select * from uptime;
   team: ""
 ---
@@ -176,10 +176,10 @@ spec:
   description: System uptime.
   interval: 600
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: uptime (macwin)
   observer_can_run: false
-  platform: "darwin,windows"
+  platform: darwin,windows
   query: select * from uptime;
   team: ""
 ---
@@ -190,10 +190,10 @@ spec:
   description: System uptime.
   interval: 600
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: uptime (sleuthkit)
   observer_can_run: false
-  platform: "darwin,linux"
+  platform: darwin,linux
   query: select * from uptime;
   team: ""
 ---
@@ -204,10 +204,10 @@ spec:
   description: Lists the application bundle that owns a sandbox label.
   interval: 86400
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: sandboxes
   observer_can_run: false
-  platform: "darwin"
+  platform: darwin
   query: select * from sandboxes;
   team: ""
 ---
@@ -218,7 +218,7 @@ spec:
   description: List of all user groups.
   interval: 3600
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: user groups (all)
   observer_can_run: false
   platform: ""
@@ -232,7 +232,7 @@ spec:
   description: List of all user groups.
   interval: 3600
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: user groups (any)
   observer_can_run: false
   platform: ""
@@ -246,10 +246,10 @@ spec:
   description: List of all user groups.
   interval: 3600
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: user groups (darwin,linux)
   observer_can_run: false
-  platform: "darwin,linux"
+  platform: darwin,linux
   query: select * from user_groups;
   team: ""
 ---
@@ -274,10 +274,10 @@ spec:
   description: List of all user groups.
   interval: 3600
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: user groups (linux,darwin)
   observer_can_run: false
-  platform: "darwin,linux"
+  platform: darwin,linux
   query: select * from user_groups;
   team: ""
 ---
@@ -288,10 +288,10 @@ spec:
   description: List of all user groups.
   interval: 3600
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: user groups (windows,chrome)
   observer_can_run: false
-  platform: "windows,chrome"
+  platform: windows,chrome
   query: select * from user_groups;
   team: ""
 ---
@@ -302,23 +302,25 @@ spec:
   description: Extracted information from Windows crash logs (Minidumps).
   interval: 3600
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: windows crashes
   observer_can_run: false
-  platform: "windows"
-  query: select * windows_crashes;
+  platform: windows
+  query: select * from windows_crashes;
   team: ""
 ---
 apiVersion: v1
 kind: query
 spec:
   automations_enabled: false
-  description: Triggers one-off YARA query for files at the specified path. Requires one of sig_group, sigfile, or sigrule.
+  description:
+    Triggers one-off YARA query for files at the specified path. Requires
+    one of sig_group, sigfile, or sigrule.
   interval: 0
   logging: ""
-  min_osquery_version: "1.4.7"
+  min_osquery_version: 1.4.7
   name: yara (yara)
   observer_can_run: false
-  platform: "darwin,linux,windows"
+  platform: darwin,linux,windows
   query: select * from yara;
   team: ""

--- a/cmd/fleetctl/testdata/convert_output.yml
+++ b/cmd/fleetctl/testdata/convert_output.yml
@@ -3,13 +3,27 @@ apiVersion: v1
 kind: query
 spec:
   automations_enabled: false
+  description: Retrieves the list of application scheme/protocol-based IPC handlers.
+  interval: 86400
+  logging: ""
+  min_osquery_version: ""
+  name: app_schemes
+  observer_can_run: false
+  platform: "darwin"
+  query: select * from app_schemes;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
   description: Retrieves the current disk encryption status for the target system.
   interval: 86400
   logging: ""
   min_osquery_version: ""
-  name: disk_encryption
+  name: disk_encryption (posix)
   observer_can_run: false
-  platform: ""
+  platform: "darwin,linux"
   query: select * from disk_encryption;
   team: ""
 ---
@@ -21,10 +35,24 @@ spec:
   interval: 300
   logging: ""
   min_osquery_version: ""
-  name: disk_encryption
+  name: disk_encryption (darwin,linux)
   observer_can_run: false
   platform: "darwin,linux"
   query: select * from disk_encryption;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
+  description: Retrieve basic information about the physical disks of a system.
+  interval: 86400
+  logging: ""
+  min_osquery_version: ""
+  name: disk_info
+  observer_can_run: false
+  platform: "windows,chrome"
+  query: select * from disk_info;
   team: ""
 ---
 apiVersion: v1
@@ -61,6 +89,34 @@ apiVersion: v1
 kind: query
 spec:
   automations_enabled: false
+  description: Retrieves the list of listening ports.
+  interval: 3600
+  logging: ""
+  min_osquery_version: ""
+  name: listening_ports (specs)
+  observer_can_run: false
+  platform: "darwin,linux,windows"
+  query: select * from listening_ports;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
+  description: Retrieves the list of listening ports.
+  interval: 3600
+  logging: ""
+  min_osquery_version: ""
+  name: listening_ports (utility)
+  observer_can_run: false
+  platform: "darwin,linux,windows"
+  query: select * from listening_ports;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
   description: Lists the application bundle that owns a sandbox label.
   interval: 86400
   logging: ""
@@ -69,4 +125,144 @@ spec:
   observer_can_run: false
   platform: "darwin"
   query: select * from sandboxes;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
+  description: System resource usage limits.
+  interval: 300
+  logging: ""
+  min_osquery_version: ""
+  name: ulimit_info (smart)
+  observer_can_run: false
+  platform: "darwin,linux"
+  query: select * from ulimit_info;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
+  description: System uptime.
+  interval: 600
+  logging: ""
+  min_osquery_version: ""
+  name: uptime (kernel)
+  observer_can_run: false
+  platform: "darwin"
+  query: select * from uptime;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
+  description: System uptime.
+  interval: 600
+  logging: ""
+  min_osquery_version: ""
+  name: uptime (linwin)
+  observer_can_run: false
+  platform: "linux,windows"
+  query: select * from uptime;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
+  description: System uptime.
+  interval: 600
+  logging: ""
+  min_osquery_version: ""
+  name: uptime (macwin)
+  observer_can_run: false
+  platform: "darwin,windows"
+  query: select * from uptime;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
+  description: System uptime.
+  interval: 600
+  logging: ""
+  min_osquery_version: ""
+  name: uptime (sleuthkit)
+  observer_can_run: false
+  platform: "darwin,linux"
+  query: select * from uptime;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
+  description: Lists the application bundle that owns a sandbox label.
+  interval: 86400
+  logging: ""
+  min_osquery_version: ""
+  name: sandboxes
+  observer_can_run: false
+  platform: "darwin"
+  query: select * from sandboxes;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
+  description: List of all user groups.
+  interval: 3600
+  logging: ""
+  min_osquery_version: ""
+  name: user groups (all)
+  observer_can_run: false
+  platform: ""
+  query: select * from user_groups;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
+  description: List of all user groups.
+  interval: 3600
+  logging: ""
+  min_osquery_version: ""
+  name: user groups (any)
+  observer_can_run: false
+  platform: ""
+  query: select * from user_groups;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
+  description: List of all user groups.
+  interval: 3600
+  logging: ""
+  min_osquery_version: ""
+  name: user groups (empty)
+  observer_can_run: false
+  platform: ""
+  query: select * from user_groups;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
+  description: Triggers one-off YARA query for files at the specified path. Requires one of sig_group, sigfile, or sigrule.
+  interval: 0
+  logging: ""
+  min_osquery_version: ""
+  name: yara (yara)
+  observer_can_run: false
+  platform: "darwin,linux,windows"
+  query: select * from yara;
   team: ""

--- a/cmd/fleetctl/testdata/convert_output.yml
+++ b/cmd/fleetctl/testdata/convert_output.yml
@@ -1,66 +1,10 @@
 ---
 apiVersion: v1
-kind: pack
-spec:
-  disabled: false
-  name: convert_input
-  queries:
-  - description: Retrieves the list of application scheme/protocol-based IPC handlers.
-    interval: 86400
-    name: app_schemes
-    platform: darwin
-    query: app_schemes
-    version: 1.4.7
-  - description: Retrieves the current disk encryption status for the target system.
-    interval: 86400
-    name: disk_encryption
-    platform: posix
-    query: disk_encryption
-    version: 1.4.5
-  - description: Retrieves the current filters and chains per filter in the target
-      system.
-    interval: 3600
-    name: iptables
-    platform: linux
-    query: iptables
-    version: 1.4.5
-  - description: Retrieves all the daemons that will run in the start of the target
-      OSX system.
-    interval: 3600
-    name: launchd
-    platform: darwin
-    query: launchd
-    version: 1.4.5
-  - description: Lists the application bundle that owns a sandbox label.
-    interval: 86400
-    name: sandboxes
-    platform: darwin
-    query: sandboxes
-    version: 1.4.7
-  targets:
-    labels: null
-    teams: null
----
-apiVersion: v1
-kind: query
-spec:
-  automations_enabled: false
-  description: Retrieves the list of application scheme/protocol-based IPC handlers.
-  interval: 0
-  logging: ""
-  min_osquery_version: ""
-  name: app_schemes
-  observer_can_run: false
-  platform: ""
-  query: select * from app_schemes;
-  team: ""
----
-apiVersion: v1
 kind: query
 spec:
   automations_enabled: false
   description: Retrieves the current disk encryption status for the target system.
-  interval: 0
+  interval: 86400
   logging: ""
   min_osquery_version: ""
   name: disk_encryption
@@ -73,13 +17,27 @@ apiVersion: v1
 kind: query
 spec:
   automations_enabled: false
+  description: Retrieves the current disk encryption status for the target system.
+  interval: 300
+  logging: ""
+  min_osquery_version: ""
+  name: disk_encryption
+  observer_can_run: false
+  platform: "darwin,linux"
+  query: select * from disk_encryption;
+  team: ""
+---
+apiVersion: v1
+kind: query
+spec:
+  automations_enabled: false
   description: Retrieves the current filters and chains per filter in the target system.
-  interval: 0
+  interval: 3600
   logging: ""
   min_osquery_version: ""
   name: iptables
   observer_can_run: false
-  platform: ""
+  platform: "linux"
   query: select * from iptables;
   team: ""
 ---
@@ -87,14 +45,15 @@ apiVersion: v1
 kind: query
 spec:
   automations_enabled: false
-  description: Retrieves all the daemons that will run in the start of the target
+  description:
+    Retrieves all the daemons that will run in the start of the target
     OSX system.
-  interval: 0
+  interval: 3600
   logging: ""
   min_osquery_version: ""
   name: launchd
   observer_can_run: false
-  platform: ""
+  platform: "darwin"
   query: select * from launchd;
   team: ""
 ---
@@ -103,11 +62,11 @@ kind: query
 spec:
   automations_enabled: false
   description: Lists the application bundle that owns a sandbox label.
-  interval: 0
+  interval: 86400
   logging: ""
   min_osquery_version: ""
   name: sandboxes
   observer_can_run: false
-  platform: ""
+  platform: "darwin"
   query: select * from sandboxes;
   team: ""


### PR DESCRIPTION
## Addresses #12657  – update `fleetctl convert`
Allows users to convert their existing packs into a config .yml with the new combined schedule/queries structure
  - Remove 'packs' key from output, leaving only queries
  - Include `interval`, `platform`, and `min_osquery_version` fields in output. Other new fields are Fleet-specific, so are left empty.
  - Convert `platform`s from possible osquery values to possible Fleet values

## Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality