### PR TITLE
update OSversion service method to not search on for `no team`

### DIFF
--- a/changes/issue-12986-fix-no-teams-error
+++ b/changes/issue-12986-fix-no-teams-error
@@ -1,0 +1,1 @@
+- fix bug where os_version enpoint returned 404 for `no teams` on controls page

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1496,7 +1496,7 @@ func (svc *Service) OSVersions(ctx context.Context, teamID *uint, platform *stri
 	osVersions, err := svc.ds.OSVersions(ctx, teamID, platform, name, version)
 	if err != nil && fleet.IsNotFound(err) {
 		// differentiate case where team was added after UpdateOSVersions last ran
-		if teamID != nil {
+		if teamID != nil && *teamID > 0 {
 			// most of the time, team should exist so checking here saves unnecessary db calls
 			_, err := svc.ds.Team(ctx, *teamID)
 			if err != nil {


### PR DESCRIPTION
relates to #12986

This is a fix for a case where the `os_versions` endpoint was returning a 404 when searching for `no teams`.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality