### PR TITLE
MDM docs: End user auth

### DIFF
--- a/docs/Using Fleet/MDM-macOS-setup.md
+++ b/docs/Using Fleet/MDM-macOS-setup.md
@@ -85,7 +85,7 @@ fleetctl CLI:
 
 1. Choose which team you want to enable end user authentication on.
 
-In this example, we'll enable end user authentication on the "Workstations (canary)" team so that the authentication is only required for hosts that automatically enroll to this team.
+   In this example, we'll enable end user authentication on the "Workstations (canary)" team so that the authentication is only required for hosts that automatically enroll to this team.
 
 3. Create a `workstations-canary-config.yaml` file:
 

--- a/docs/Using Fleet/MDM-macOS-setup.md
+++ b/docs/Using Fleet/MDM-macOS-setup.md
@@ -77,7 +77,7 @@ Fleet UI:
 
 1. Head to the **Controls > macOS settings > macOS setup > End user authentication** page.
 
-2. Choose which team you want to enable end user authentication for to to by selecting the desired team in the teams dropdown in the upper left corner.
+2. Choose which team you want to enable end user authentication for by selecting the desired team in the teams dropdown in the upper left corner.
 
 3. Select the **On** checkbox and select **Save**.
 

--- a/docs/Using Fleet/MDM-macOS-setup.md
+++ b/docs/Using Fleet/MDM-macOS-setup.md
@@ -21,16 +21,10 @@ Using Fleet, you can require end users to authenticate with your identity provid
 To require end user authentication, we will do the following steps:
 
 1. Connect Fleet to your IdP
-2. Upload a EULA to Fleet
+2. Upload a EULA to Fleet (optional)
 3. Enable end user authentication
 
 ### Step 1: connect Fleet to your IdP
-
-You can connect Fleet to your IdP using the Fleet UI or fleetctl command-line tool.
-
-The Fleet UI method is a good start if you're just getting familiar with Fleet.
-
-The fleetctl CLI method enables managing your IdP credentials in a Git repository. This way you can enforce code review and benefit from Git's change history.
 
 Fleet UI:
 
@@ -40,7 +34,7 @@ Fleet UI:
 
 fleetctl CLI:
 
-1. Create `fleet-config.yaml` file:
+1. Create `fleet-config.yaml` file or add to your existing `config` YAML file:
 
 ```yaml
 apiVersion: v1
@@ -55,19 +49,19 @@ spec:
   ...
 ```
 
-2. Add an `mdm.end_user_authentication` key to your YAML document. This key accepts the above keys for your IdP credentials. 
+2. Fill in the relevant information from your IdP under the `mdm.end_user_authentication` key. 
 
 3. Run the fleetctl `apply -f fleet-config.yml` command to add your IdP credentials.
 
 4. Confirm that your IdP credentials were saved by running `fleetctl get config`.
-
-Learn more about "No team" configuration options [here](./configuration-files/README.md#organization-settings).
 
 ### Step 2: upload a EULA to Fleet
 
 1. Head to the **Settings > Integrations > Automatic enrollment** page.
 
 2. Under **End user license agreement (EULA)**, select **Upload** and choose your EULA.
+
+> Uploading a EULA is optional. If you don't upload a EULA, the end user will skip this step and continue to the next step of the new Mac setup experience after they authenticate with your IdP.
 
 ### Step 3: enable end user authentication
 
@@ -203,12 +197,6 @@ $ pkgutil --check-signature /path/to/signed-package.pkg
 In the output you should see that package has a "signed" status.
 
 ### Step 3: upload the package to Fleet
-
-In Fleet, you can upload the package using the Fleet UI or fleetctl command-line tool.
-
-The Fleet UI method is a good start if you're just getting familiar with Fleet.
-
-The fleetctl CLI method enables managing the package in a Git repository. This way you can enforce code review and benefit from Git's change history.
 
 Fleet UI:
 

--- a/docs/Using Fleet/MDM-macOS-setup.md
+++ b/docs/Using Fleet/MDM-macOS-setup.md
@@ -119,7 +119,7 @@ Learn more about "No team" configuration options [here](./configuration-files/RE
 
 3. Add an `mdm.macos_setup.enable_end_user_authentication` key to your YAML document. This key accepts a boolean value.
 
-4. Run the fleetctl `apply -f workstations-canary-config.yml` command to enable authentication for this team.
+4. Run the `fleetctl apply -f workstations-canary-config.yml` command to enable authentication for this team.
 
 5. Confirm that end user authentication is enabled by running the `fleetctl get teams --name=Workstations --yaml` command.
 

--- a/docs/Using Fleet/MDM-macOS-setup.md
+++ b/docs/Using Fleet/MDM-macOS-setup.md
@@ -87,7 +87,7 @@ fleetctl CLI:
 
    In this example, we'll enable end user authentication on the "Workstations (canary)" team so that the authentication is only required for hosts that automatically enroll to this team.
 
-3. Create a `workstations-canary-config.yaml` file:
+2. Create a `workstations-canary-config.yaml` file:
 
 ```yaml
 apiVersion: v1

--- a/docs/Using Fleet/MDM-macOS-setup.md
+++ b/docs/Using Fleet/MDM-macOS-setup.md
@@ -14,7 +14,7 @@ In addition to the customization above, Fleet automatically installs the fleetd 
 
 MacOS setup features require connecting Fleet to Apple Business Manager (ABM). Learn how [here](./MDM-setup.md#apple-business-manager-abm).
 
-## End user authentication
+## End user authentication and EULA
 
 Using Fleet, you can require end users to authenticate with your identity provider (IdP) and agree to an end user license agreement (EULA) before they can use their new Mac.
 

--- a/docs/Using Fleet/MDM-macOS-setup.md
+++ b/docs/Using Fleet/MDM-macOS-setup.md
@@ -26,7 +26,7 @@ To require end user authentication, we will do the following steps:
 
 ### Step 1: connect Fleet to your IdP
 
-In Fleet, you can connect Fleet to your IdP using the Fleet UI or fleetctl command-line tool.
+You can connect Fleet to your IdP using the Fleet UI or fleetctl command-line tool.
 
 The Fleet UI method is a good start if you're just getting familiar with Fleet.
 


### PR DESCRIPTION
Docs for these stories: #10689, #11329, #11350

- Add instructions for how to enable end user auth during automatic enrollment for Macs
- Add instructions for how to add bootstrap package via UI
