### PR TITLE
Update MDM profile verification

### DIFF
--- a/changes/12886-failed-profiles-earliest-install-date
+++ b/changes/12886-failed-profiles-earliest-install-date
@@ -1,0 +1,2 @@
+- Updated MDM profile verification to fix issue where profiles were marked as failed when a host is
+  transferred to a newly created team that has an identical profile as an older team.

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -322,18 +322,6 @@ func (cp MDMAppleConfigProfile) ValidateUserProvided() error {
 	return cp.Mobileconfig.ScreenPayloads()
 }
 
-// IsWithinGracePeriod returns true if the host is within the grace period for the profile.
-//
-// The grace period is defined as 1 hour after the profile was updated. It is checked against the
-// host's detail_updated_at timestamp to allow for the host to check in at least once before the
-// profile is considered failed. If the host is online, it should report detail queries hourly by
-// default. If the host is offline, it should report detail queries shortly after it comes back
-// online.
-func (cp MDMAppleConfigProfile) IsWithinGracePeriod(hostDetailUpdatedAt time.Time) bool {
-	gracePeriod := 1 * time.Hour
-	return hostDetailUpdatedAt.Before(cp.UpdatedAt.Add(gracePeriod))
-}
-
 // HostMDMAppleProfile represents the status of an Apple MDM profile in a host.
 type HostMDMAppleProfile struct {
 	HostUUID      string                  `db:"host_uuid" json:"-"`

--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -370,7 +370,8 @@ func TestMDMProfileIsWithinGracePeriod(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.testName, func(t *testing.T) {
-			require.Equal(t, c.expect, testProfile.IsWithinGracePeriod(c.hostDetailUpdatedAt))
+			ep := ExpectedMDMProfile{Identifier: testProfile.Identifier, EarliestInstallDate: testProfile.UpdatedAt}
+			require.Equal(t, c.expect, ep.IsWithinGracePeriod(c.hostDetailUpdatedAt))
 		})
 	}
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -698,7 +698,10 @@ type Datastore interface {
 	SetDiskEncryptionResetStatus(ctx context.Context, hostID uint, status bool) error
 
 	// UpdateVerificationHostMacOSProfiles updates status of macOS profiles installed on a given host to verified.
-	UpdateVerificationHostMacOSProfiles(ctx context.Context, host *Host, installedProfiles []*HostMacOSProfile) error
+	UpdateHostMDMProfilesVerification(ctx context.Context, host *Host, verified, failed []string) error
+	// GetHostMDMProfilesExpected returns the expected MDM profiles for a given host. The map is
+	// keyed by the profile identifier.
+	GetHostMDMProfilesExpectedForVerification(ctx context.Context, host *Host) (map[string]*ExpectedMDMProfile, error)
 
 	// SetOrUpdateHostOrbitInfo inserts of updates the orbit info for a host
 	SetOrUpdateHostOrbitInfo(ctx context.Context, hostID uint, version string) error

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -98,3 +98,32 @@ type MDMAppleEULA struct {
 func (e MDMAppleEULA) AuthzType() string {
 	return "mdm_apple"
 }
+
+// ExpectedMDMProfile represents an MDM profile that is expected to be installed on a host.
+type ExpectedMDMProfile struct {
+	Identifier string `db:"identifier"`
+	// EarliestInstallDate is the earliest updated_at of all team profiles with the same checksum.
+	// It is used to assess the case where a host has installed a profile with the identifier
+	// expected by the host's current team, but the host's install_date is earlier than the
+	// updated_at expected by the host's current. This can happen, for example, if a host is
+	// transferred to a team created after the host installed the profile. To avoid treating this as
+	// a missing profile, we use the earliest_updated_at of all profiles with the same checksum.
+	// Ideally, we would simply compare the checksums of the installed and expected profiles, but
+	// the checksums are not available in the osquery profiles table.
+	EarliestInstallDate time.Time `db:"earliest_install_date"`
+}
+
+// IsWithinGracePeriod returns true if the host is within the grace period for the profile.
+//
+// The grace period is defined as 1 hour after the profile was updated. It is checked against the
+// host's detail_updated_at timestamp to allow for the host to check in at least once before the
+// profile is considered failed. If the host is online, it should report detail queries hourly by
+// default. If the host is offline, it should report detail queries shortly after it comes back
+// online.
+//
+// Note: The host detail timestamp is updated after the current set is ingested
+// see https://github.com/fleetdm/fleet/blob/e9fd28717d474668ca626efbacdd0615d42b2e0a/server/service/osquery.go#L950
+func (ep ExpectedMDMProfile) IsWithinGracePeriod(hostDetailUpdatedAt time.Time) bool {
+	gracePeriod := 1 * time.Hour
+	return hostDetailUpdatedAt.Before(ep.EarliestInstallDate.Add(gracePeriod))
+}

--- a/server/mdm/apple/profile_verifier.go
+++ b/server/mdm/apple/profile_verifier.go
@@ -1,0 +1,50 @@
+package apple_mdm
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+)
+
+// ProfileVerificationStore is the minimal interface required to get and update the verification
+// status of a host's MDM profiles. The Fleet Datastore satisfies this interface.
+type ProfileVerificationStore interface {
+	GetHostMDMProfilesExpectedForVerification(ctx context.Context, host *fleet.Host) (map[string]*fleet.ExpectedMDMProfile, error)
+	UpdateHostMDMProfilesVerification(ctx context.Context, host *fleet.Host, verified, failed []string) error
+}
+
+var _ ProfileVerificationStore = (fleet.Datastore)(nil)
+
+// VerifyHostMDMProfiles performs the verification of the MDM profiles installed on a host and
+// updates the verification status in the datastore. It is intended to be called by Fleet osquery
+// service when the Fleet server ingests host details.
+func VerifyHostMDMProfiles(ctx context.Context, ds ProfileVerificationStore, host *fleet.Host, installed map[string]*fleet.HostMacOSProfile) error {
+	expected, err := ds.GetHostMDMProfilesExpectedForVerification(ctx, host)
+	if err != nil {
+		return err
+	}
+
+	failed := make([]string, 0, len(expected))
+	verified := make([]string, 0, len(expected))
+	for key, ep := range expected {
+		withinGracePeriod := ep.IsWithinGracePeriod(host.DetailUpdatedAt)
+		ip, ok := installed[key]
+		if !ok {
+			// expected profile is missing from host
+			if !withinGracePeriod {
+				failed = append(failed, key)
+			}
+			continue
+		}
+		if ip.InstallDate.Before(ep.EarliestInstallDate) {
+			// installed profile is outdated
+			if !withinGracePeriod {
+				failed = append(failed, key)
+			}
+			continue
+		}
+		verified = append(verified, key)
+	}
+
+	return ds.UpdateHostMDMProfilesVerification(ctx, host, verified, failed)
+}

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -484,7 +484,9 @@ type GetHostDiskEncryptionKeyFunc func(ctx context.Context, hostID uint) (*fleet
 
 type SetDiskEncryptionResetStatusFunc func(ctx context.Context, hostID uint, status bool) error
 
-type UpdateVerificationHostMacOSProfilesFunc func(ctx context.Context, host *fleet.Host, installedProfiles []*fleet.HostMacOSProfile) error
+type UpdateHostMDMProfilesVerificationFunc func(ctx context.Context, host *fleet.Host, verified []string, failed []string) error
+
+type GetHostMDMProfilesExpectedForVerificationFunc func(ctx context.Context, host *fleet.Host) (map[string]*fleet.ExpectedMDMProfile, error)
 
 type SetOrUpdateHostOrbitInfoFunc func(ctx context.Context, hostID uint, version string) error
 
@@ -1356,8 +1358,11 @@ type DataStore struct {
 	SetDiskEncryptionResetStatusFunc        SetDiskEncryptionResetStatusFunc
 	SetDiskEncryptionResetStatusFuncInvoked bool
 
-	UpdateVerificationHostMacOSProfilesFunc        UpdateVerificationHostMacOSProfilesFunc
-	UpdateVerificationHostMacOSProfilesFuncInvoked bool
+	UpdateHostMDMProfilesVerificationFunc        UpdateHostMDMProfilesVerificationFunc
+	UpdateHostMDMProfilesVerificationFuncInvoked bool
+
+	GetHostMDMProfilesExpectedForVerificationFunc        GetHostMDMProfilesExpectedForVerificationFunc
+	GetHostMDMProfilesExpectedForVerificationFuncInvoked bool
 
 	SetOrUpdateHostOrbitInfoFunc        SetOrUpdateHostOrbitInfoFunc
 	SetOrUpdateHostOrbitInfoFuncInvoked bool
@@ -3248,11 +3253,18 @@ func (s *DataStore) SetDiskEncryptionResetStatus(ctx context.Context, hostID uin
 	return s.SetDiskEncryptionResetStatusFunc(ctx, hostID, status)
 }
 
-func (s *DataStore) UpdateVerificationHostMacOSProfiles(ctx context.Context, host *fleet.Host, installedProfiles []*fleet.HostMacOSProfile) error {
+func (s *DataStore) UpdateHostMDMProfilesVerification(ctx context.Context, host *fleet.Host, verified []string, failed []string) error {
 	s.mu.Lock()
-	s.UpdateVerificationHostMacOSProfilesFuncInvoked = true
+	s.UpdateHostMDMProfilesVerificationFuncInvoked = true
 	s.mu.Unlock()
-	return s.UpdateVerificationHostMacOSProfilesFunc(ctx, host, installedProfiles)
+	return s.UpdateHostMDMProfilesVerificationFunc(ctx, host, verified, failed)
+}
+
+func (s *DataStore) GetHostMDMProfilesExpectedForVerification(ctx context.Context, host *fleet.Host) (map[string]*fleet.ExpectedMDMProfile, error) {
+	s.mu.Lock()
+	s.GetHostMDMProfilesExpectedForVerificationFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetHostMDMProfilesExpectedForVerificationFunc(ctx, host)
 }
 
 func (s *DataStore) SetOrUpdateHostOrbitInfo(ctx context.Context, hostID uint, version string) error {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -2468,7 +2468,7 @@ func (s *integrationMDMTestSuite) TestMDMAppleDiskEncryptionAggregate() {
 	require.Equal(t, uint(0), fvsResp.RemovingEnforcement)
 
 	// verified status for host 1
-	require.NoError(t, s.ds.UpdateVerificationHostMacOSProfiles(ctx, hosts[0], []*fleet.HostMacOSProfile{{Identifier: prof.Identifier, DisplayName: prof.Name, InstallDate: time.Now()}}))
+	require.NoError(t, apple_mdm.VerifyHostMDMProfiles(ctx, s.ds, hosts[0], map[string]*fleet.HostMacOSProfile{prof.Identifier: {Identifier: prof.Identifier, DisplayName: prof.Name, InstallDate: time.Now()}}))
 	fvsResp = getMDMAppleFileVauleSummaryResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/mdm/apple/filevault/summary", nil, http.StatusOK, &fvsResp, "team_id", strconv.Itoa(int(tm.ID)))
 	require.Equal(t, uint(2), fvsResp.Verifying)
@@ -3329,8 +3329,8 @@ func (s *integrationMDMTestSuite) TestHostMDMProfilesStatus() {
 	})
 
 	// h1 verified one of the profiles
-	require.NoError(t, s.ds.UpdateVerificationHostMacOSProfiles(context.Background(), h1, []*fleet.HostMacOSProfile{
-		{Identifier: "G2b", DisplayName: "G2b", InstallDate: time.Now()},
+	require.NoError(t, apple_mdm.VerifyHostMDMProfiles(context.Background(), s.ds, h1, map[string]*fleet.HostMacOSProfile{
+		"G2b": {Identifier: "G2b", DisplayName: "G2b", InstallDate: time.Now()},
 	}))
 	s.assertHostConfigProfiles(map[*fleet.Host][]fleet.HostMDMAppleProfile{
 		h1: {

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -1206,29 +1206,6 @@ func TestDirectIngestHostMacOSProfiles(t *testing.T) {
 	logger := log.NewNopLogger()
 	h := &fleet.Host{ID: 1}
 
-	var expectedProfiles []*fleet.HostMacOSProfile
-	ds.UpdateVerificationHostMacOSProfilesFunc = func(ctx context.Context, host *fleet.Host, installedProfiles []*fleet.HostMacOSProfile) error {
-		require.Equal(t, h.ID, host.ID)
-		require.Len(t, installedProfiles, len(expectedProfiles))
-		expectedByIdentifier := make(map[string]*fleet.HostMacOSProfile, len(expectedProfiles))
-		for _, ep := range expectedProfiles {
-			expectedByIdentifier[ep.Identifier] = ep
-		}
-		for _, ip := range installedProfiles {
-			ep, ok := expectedByIdentifier[ip.Identifier]
-			require.True(t, ok)
-			require.Equal(t, *ep, *ip)
-		}
-
-		return nil
-	}
-	expectedProfiles = []*fleet.HostMacOSProfile{
-		{
-			Identifier:  "com.example.test",
-			DisplayName: "Test Profile",
-			InstallDate: time.Now().Truncate(time.Second),
-		},
-	}
 	toRows := func(profs []*fleet.HostMacOSProfile) []map[string]string {
 		rows := make([]map[string]string, len(profs))
 		for i, p := range profs {
@@ -1241,17 +1218,46 @@ func TestDirectIngestHostMacOSProfiles(t *testing.T) {
 		return rows
 	}
 
+	var installedProfiles []*fleet.HostMacOSProfile
+	ds.GetHostMDMProfilesExpectedForVerificationFunc = func(ctx context.Context, host *fleet.Host) (map[string]*fleet.ExpectedMDMProfile, error) {
+		require.Equal(t, h.ID, host.ID)
+		expected := make(map[string]*fleet.ExpectedMDMProfile, len(installedProfiles))
+		for _, p := range installedProfiles {
+			expected[p.Identifier] = &fleet.ExpectedMDMProfile{
+				Identifier:          p.Identifier,
+				EarliestInstallDate: p.InstallDate,
+			}
+		}
+		return expected, nil
+	}
+	ds.UpdateHostMDMProfilesVerificationFunc = func(ctx context.Context, host *fleet.Host, verified, failed []string) error {
+		require.Equal(t, h.ID, host.ID)
+		require.Equal(t, len(installedProfiles), len(verified))
+		require.Len(t, failed, 0)
+		for _, p := range installedProfiles {
+			require.Contains(t, verified, p.Identifier)
+		}
+		return nil
+	}
+
 	// expect no error: happy path
-	rows := toRows(expectedProfiles)
+	installedProfiles = []*fleet.HostMacOSProfile{
+		{
+			Identifier:  "com.example.test",
+			DisplayName: "Test Profile",
+			InstallDate: time.Now().Truncate(time.Second),
+		},
+	}
+	rows := toRows(installedProfiles)
 	require.NoError(t, directIngestMacOSProfiles(ctx, logger, h, ds, rows))
 
 	// expect no error: identifer or display name is empty
-	expectedProfiles = append(expectedProfiles, &fleet.HostMacOSProfile{
+	installedProfiles = append(installedProfiles, &fleet.HostMacOSProfile{
 		Identifier:  "",
 		DisplayName: "",
 		InstallDate: time.Now().Truncate(time.Second),
 	})
-	rows = toRows(expectedProfiles)
+	rows = toRows(installedProfiles)
 	require.NoError(t, directIngestMacOSProfiles(ctx, logger, h, ds, rows))
 
 	// expect no error: empty rows


### PR DESCRIPTION
Issue #12886

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [x] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
