### PR TITLE
account for NULL values in scheduled_query columns in data migration

### DIFF
--- a/changes/13137-migration-fix
+++ b/changes/13137-migration-fix
@@ -1,0 +1,1 @@
+* Fixed a migration to account for columns with NULL values as a result of either creating schedules via the API without providing all values or by a race condition with database replicas.

--- a/server/datastore/mysql/migrations/tables/20230721161508_QueriesDataMigrator.go
+++ b/server/datastore/mysql/migrations/tables/20230721161508_QueriesDataMigrator.go
@@ -50,14 +50,14 @@ func _20230719152138_migrate_global_packs(tx *sql.Tx) error {
 						q.author_id,
 						q.saved,
 						q.observer_can_run,
-						sq.id       AS scheduled_query_id,
-						sq.interval AS scheduled_query_interval,
-						sq.snapshot AS scheduled_query_snapshot,
-						sq.removed  AS scheduled_query_removed,
-						sq.platform AS scheduled_query_platform,
-						sq.version  AS scheduled_query_version,
-						sq.created_at AS scheduled_created_at,
-						p.pack_type AS pack_type
+						sq.id                     AS scheduled_query_id,
+						sq.interval               AS scheduled_query_interval,
+						sq.snapshot               AS scheduled_query_snapshot,
+						sq.removed                AS scheduled_query_removed,
+						COALESCE(sq.platform, '') AS scheduled_query_platform,
+						COALESCE(sq.version, '')  AS scheduled_query_version,
+						sq.created_at             AS scheduled_created_at,
+						p.pack_type               AS pack_type
 		FROM queries q
 				INNER JOIN scheduled_queries sq ON q.name = sq.query_name
 				INNER JOIN packs p ON sq.pack_id = p.id
@@ -161,14 +161,14 @@ func _20230719152138_migrate_team_packs(tx *sql.Tx) error {
 						q.author_id,
 						q.saved,
 						q.observer_can_run,
-						sq.id         AS scheduled_query_id,
-						sq.interval   AS scheduled_query_interval,
-						sq.snapshot   AS scheduled_query_snapshot,
-						sq.removed    AS scheduled_query_removed,
-						sq.platform   AS scheduled_query_platform,
-						sq.version    AS scheduled_query_version,
-						sq.created_at AS scheduled_created_at,
-						p.pack_type   AS pack_type
+						sq.id                      AS scheduled_query_id,
+						sq.interval                AS scheduled_query_interval,
+						sq.snapshot                AS scheduled_query_snapshot,
+						sq.removed                 AS scheduled_query_removed,
+						COALESCE(sq.platform, '')  AS scheduled_query_platform,
+						COALESCE(sq.version, '')   AS scheduled_query_version,
+						sq.created_at              AS scheduled_created_at,
+						p.pack_type                AS pack_type
 		FROM queries q
 				INNER JOIN scheduled_queries sq ON q.team_id IS NULL AND q.name = sq.query_name
 				INNER JOIN packs p ON sq.pack_id = p.id

--- a/server/datastore/mysql/migrations/tables/20230721161508_QueriesDataMigrator_test.go
+++ b/server/datastore/mysql/migrations/tables/20230721161508_QueriesDataMigrator_test.go
@@ -55,12 +55,15 @@ func TestUp_20230721161508(t *testing.T) {
 
 			-- Global pack
 			(7,'2023-07-21 20:34:46','2023-07-21 20:34:46',1,2,86400,1,0,'','',NULL,'per_query_perf','per_query_perf','',NULL,''),
-			(8,'2023-07-21 20:34:51','2023-07-21 20:34:51',1,2,86400,1,0,'','',NULL,'per_query_perf','per_query_perf-1','',NULL,''),
+			-- NULL platform
+			(8,'2023-07-21 20:34:51','2023-07-21 20:34:51',1,2,86400,1,0,NULL,'',NULL,'per_query_perf','per_query_perf-1','',NULL,''),
 
 			-- Team-1 pack
 			(9,'2023-07-21 20:36:08','2023-07-21 20:36:08',3,6,86400,1,0,'','',NULL,'User 1 Query','User 1 Query','',NULL,''),
-			(10,'2023-07-21 20:36:13','2023-07-21 20:36:13',3,6,86400,1,0,'','',NULL,'User 1 Query','User 1 Query-1','',NULL,''),
-			(11,'2023-07-21 20:36:25','2023-07-21 20:36:25',3,2,86400,1,0,'','',NULL,'per_query_perf','per_query_perf','',NULL,''),
+			-- NULL version
+			(10,'2023-07-21 20:36:13','2023-07-21 20:36:13',3,6,86400,1,0,'',NULL,NULL,'User 1 Query','User 1 Query-1','',NULL,''),
+			-- NULL platform
+			(11,'2023-07-21 20:36:25','2023-07-21 20:36:25',3,2,86400,1,0,NULL,'',NULL,'per_query_perf','per_query_perf','',NULL,''),
 
 			-- Team-2 pack
 			(12,'2023-07-21 20:36:50','2023-07-21 20:36:50',4,5,86400,1,0,'','',NULL,'backup_tool_perf','backup_tool_perf','',NULL,'');


### PR DESCRIPTION
Prior to 4.35.0, some rows in the scheduled_query table might have a `NULL` value due to a race condition with database replicas and the way `ds.EnsureGlobalPack` and `ApplyPackSpecs` work together.

This is no longer the case, but some databases are left in weird states, which were not accounted by this migration.

Chaning the migration in-place because that's the approach we took in previous migrations with similar problems.

This is related to #13137

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
