### PR TITLE
Fleet Documentation: Remove docs about cgroups

### DIFF
--- a/docs/Using Fleet/fleetd.md
+++ b/docs/Using Fleet/fleetd.md
@@ -83,7 +83,6 @@ graph LR;
 | Package tooling for Linux `.rpm`     | ✅      |
 | Package tooling for Windows `.msi`   | ✅      |
 | Manage/update osquery extensions     | ✅      |
-| Manage cgroups for Linux performance | 🔜      |
 
 
 ## Packaging

--- a/orbit/README.md
+++ b/orbit/README.md
@@ -60,7 +60,6 @@ Additionally, Orbit aims to tackle problems out of scope for Launcher:
 - Manage osquery startup flags from a remote (Fleet) server.
 - Support for deploying and updating osquery extensions (🔜).
 - Manage osquery versions from a remote (Fleet) server (🔜).
-- Further control of osquery performance via cgroups (🔜).
 
 ### Is Orbit Free?
 


### PR DESCRIPTION
## Description
- Remove proposed initiative of managing linux through cgroups from docs

## Reasoning
Internal slack thread: https://fleetdm.slack.com/archives/C02A8BRABB5/p1691080810346349?thread_ts=1691077742.465109&cid=C02A8BRABB5

- [x] Documentation

