### PR TITLE
Fleet UI: (Styling bug) Search bar alignment, hover state

### DIFF
--- a/changes/13068-fix-cut-off-filter-dropdown
+++ b/changes/13068-fix-cut-off-filter-dropdown
@@ -1,0 +1,1 @@
+* Style fix to filter host by status dropdown

--- a/changes/bug-13061-table-search-styling
+++ b/changes/bug-13061-table-search-styling
@@ -1,0 +1,1 @@
+- Clean up styling around table search bars

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -9,7 +9,6 @@
     width: 100%;
     justify-content: space-between;
     align-items: center;
-    padding-bottom: $pad-medium;
     gap: $pad-small;
 
     &.stack-table-controls {
@@ -49,15 +48,23 @@
         align-items: center;
       }
     }
+
+    .Select-multi-value-wrapper {
+      height: 38px; // Fixes overlap with .Select outline
+    }
+  }
+  .results-count {
+    height: 40px; // Match height of search/filters
   }
 
   &__results-count {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     font-size: $x-small;
     font-weight: $bold;
     color: $core-fleet-black;
     margin: 0;
+    height: 40px;
 
     :first-child {
       margin-right: $pad-small;
@@ -68,14 +75,6 @@
     }
     .count-loading {
       color: $ui-fleet-black-50;
-    }
-
-    &.stack-table-controls {
-      padding-top: $pad-large;
-
-      @media (min-width: $break-md) {
-        padding-top: 0;
-      }
     }
   }
 
@@ -91,14 +90,8 @@
     width: 100%;
 
     .input-with-icon {
-      width: 250px;
-      margin-bottom: 0;
-      @media (min-width: $break-xs) {
-        width: 300px;
-      }
-      @media (min-width: $break-md) {
-        width: 344px;
-      }
+      width: 100%;
+      min-width: 250px;
     }
 
     &.stack-table-controls {
@@ -126,6 +119,7 @@
 
   .table-container__search-input.wide-search {
     margin-left: 0;
+    margin-bottom: $pad-small;
   }
 
   #search-tooltip {

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -10,6 +10,7 @@
     justify-content: space-between;
     align-items: center;
     padding-bottom: $pad-medium;
+    gap: $pad-small;
 
     &.stack-table-controls {
       flex-direction: column-reverse;
@@ -82,10 +83,6 @@
     cursor: pointer;
     text-decoration: underline;
     color: $core-vibrant-blue-over;
-  }
-
-  &__search {
-    margin-left: $pad-small;
   }
 
   &__search-input {

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -24,6 +24,12 @@
         align-items: center;
       }
     }
+
+    // filter and search bar height
+    .dropdown__select,
+    .input-with-icon {
+      height: 40px;
+    }
   }
 
   &__header-left {
@@ -78,13 +84,16 @@
     color: $core-vibrant-blue-over;
   }
 
+  &__search {
+    margin-left: $pad-small;
+  }
+
   &__search-input {
     position: relative;
     color: $core-fleet-blue;
     width: 100%;
-    margin-left: $pad-small;
 
-    .search-field__input-wrapper {
+    .input-with-icon {
       width: 250px;
       margin-bottom: 0;
       @media (min-width: $break-xs) {
@@ -100,7 +109,6 @@
       margin-left: 0;
 
       @media (min-width: $break-xs) {
-        margin-left: $pad-medium;
         padding-bottom: 0;
       }
     }
@@ -121,12 +129,6 @@
 
   .table-container__search-input.wide-search {
     margin-left: 0;
-
-    .search-field__input-wrapper {
-      width: 100%;
-      margin-bottom: 0;
-      padding-bottom: $pad-medium;
-    }
   }
 
   #search-tooltip {

--- a/frontend/components/forms/fields/Dropdown/Dropdown.jsx
+++ b/frontend/components/forms/fields/Dropdown/Dropdown.jsx
@@ -35,6 +35,7 @@ class Dropdown extends Component {
     parseTarget: PropTypes.bool,
     tooltip: PropTypes.string,
     autoFocus: PropTypes.bool,
+    tableFilterDropdown: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -50,6 +51,7 @@ class Dropdown extends Component {
     parseTarget: false,
     tooltip: "",
     autoFocus: false,
+    tableFilterDropdown: false,
   };
 
   onMenuOpen = () => {
@@ -119,6 +121,15 @@ class Dropdown extends Component {
     );
   };
 
+  renderCustomTableDropdownValue = () => {
+    return (
+      <div className={`${baseClass}__custom-value`}>
+        <Icon name="filter" className={`${baseClass}__icon`} />
+        <div className={`${baseClass}__custom-value-label`}>Hi</div>
+      </div>
+    );
+  };
+
   render() {
     const {
       handleChange,
@@ -126,6 +137,7 @@ class Dropdown extends Component {
       onMenuOpen,
       onMenuClose,
       renderCustomDropdownArrow,
+      renderCustomTableDropdownValue,
     } = this;
     const {
       error,
@@ -140,6 +152,7 @@ class Dropdown extends Component {
       wrapperClassName,
       searchable,
       autoFocus,
+      tableFilterDropdown,
     } = this.props;
 
     const formFieldProps = pick(this.props, [
@@ -153,6 +166,7 @@ class Dropdown extends Component {
       [`${baseClass}__select--error`]: error,
     });
 
+    console.log("renderOption", renderOption);
     return (
       <FormField
         {...formFieldProps}
@@ -175,6 +189,9 @@ class Dropdown extends Component {
           onClose={onMenuClose}
           autoFocus={autoFocus}
           arrowRenderer={renderCustomDropdownArrow}
+          valueComponent={
+            tableFilterDropdown ? renderCustomTableDropdownValue : undefined
+          }
         />
       </FormField>
     );

--- a/frontend/components/forms/fields/Dropdown/Dropdown.jsx
+++ b/frontend/components/forms/fields/Dropdown/Dropdown.jsx
@@ -35,6 +35,7 @@ class Dropdown extends Component {
     parseTarget: PropTypes.bool,
     tooltip: PropTypes.string,
     autoFocus: PropTypes.bool,
+    /** Includes styled filter icon */
     tableFilterDropdown: PropTypes.bool,
   };
 
@@ -121,11 +122,17 @@ class Dropdown extends Component {
     );
   };
 
-  renderCustomTableDropdownValue = () => {
+  // Adds styled filter icon to dropdown
+  renderCustomTableFilter = () => {
+    const { options, value } = this.props;
+    const customLabel = options
+      .filter((option) => option.value === value)
+      .map((option) => option.label);
+
     return (
       <div className={`${baseClass}__custom-value`}>
         <Icon name="filter" className={`${baseClass}__icon`} />
-        <div className={`${baseClass}__custom-value-label`}>Hi</div>
+        <div className={`${baseClass}__custom-value-label`}>{customLabel}</div>
       </div>
     );
   };
@@ -137,7 +144,7 @@ class Dropdown extends Component {
       onMenuOpen,
       onMenuClose,
       renderCustomDropdownArrow,
-      renderCustomTableDropdownValue,
+      renderCustomTableFilter,
     } = this;
     const {
       error,
@@ -166,7 +173,6 @@ class Dropdown extends Component {
       [`${baseClass}__select--error`]: error,
     });
 
-    console.log("renderOption", renderOption);
     return (
       <FormField
         {...formFieldProps}
@@ -190,7 +196,7 @@ class Dropdown extends Component {
           autoFocus={autoFocus}
           arrowRenderer={renderCustomDropdownArrow}
           valueComponent={
-            tableFilterDropdown ? renderCustomTableDropdownValue : undefined
+            tableFilterDropdown ? renderCustomTableFilter : undefined
           }
         />
       </FormField>

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -6,7 +6,7 @@
     }
 
     &-label {
-      width: 100px;
+      width: 105px;
       line-height: 38px;
       font-size: $small;
     }

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -1,4 +1,17 @@
 .dropdown {
+  &__custom-value {
+    display: inline-flex;
+    svg {
+      padding: 0 $pad-small;
+    }
+
+    &-label {
+      width: 100px;
+      line-height: 38px;
+      font-size: $small;
+    }
+  }
+
   &__custom-arrow {
     display: flex;
 
@@ -134,7 +147,7 @@
   }
 
   &.is-open {
-    .dropdown__icon {
+    .dropdown__custom-arrow .dropdown__icon {
       svg {
         transform: rotate(180deg);
         transition: transform 0.25s ease;
@@ -143,25 +156,38 @@
         }
       }
     }
+    .dropdown__custom-value .dropdown__icon {
+      svg path {
+        fill: $core-vibrant-blue-over;
+      }
+    }
     .Select-control {
       border-radius: $border-radius;
     }
   }
   :hover {
-    .dropdown__icon {
+    .dropdown__custom-arrow .dropdown__icon {
       svg {
         path {
           stroke: $core-vibrant-blue-over;
         }
       }
     }
+    .dropdown__custom-value .dropdown__icon {
+      svg path {
+        fill: $core-vibrant-blue-over;
+      }
+    }
 
     &.is-open {
-      .dropdown__icon {
-        svg {
-          path {
-            stroke: $core-vibrant-blue-over;
-          }
+      .dropdown__custom-arrow .dropdown__icon {
+        svg path {
+          stroke: $core-vibrant-blue-over;
+        }
+      }
+      .dropdown__custom-value .dropdown__icon {
+        svg path {
+          fill: $core-vibrant-blue-over;
         }
       }
     }

--- a/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
+++ b/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
@@ -106,7 +106,6 @@ class InputFieldWithIcon extends InputField {
     return (
       <div className={wrapperClasses}>
         {this.props.label && this.renderHeading()}
-        {iconSvg && <Icon name={iconSvg} className={iconClasses} />}
         <input
           id={name}
           name={name}
@@ -122,6 +121,7 @@ class InputFieldWithIcon extends InputField {
           disabled={disabled}
           {...inputOptions}
         />
+        {iconSvg && <Icon name={iconSvg} className={iconClasses} />}
         {iconName && <FleetIcon name={iconName} className={iconClasses} />}
         {renderHint()}
       </div>

--- a/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
+++ b/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
@@ -56,6 +56,15 @@
     &:hover,
     &:focus {
       border: 1px solid $core-vibrant-blue;
+
+      // Icon color matches border color on focus and on hover
+      + .input-icon-field__icon {
+        svg {
+          path {
+            fill: $core-vibrant-blue;
+          }
+        }
+      }
     }
 
     &:focus {

--- a/frontend/components/icons/Filter.tsx
+++ b/frontend/components/icons/Filter.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { COLORS, Colors } from "styles/var/colors";
+import { ICON_SIZES, IconSizes } from "styles/var/icon_sizes";
+
+interface IFilterProps {
+  color?: Colors;
+  size?: IconSizes;
+}
+
+const Filter = ({
+  size = "medium",
+  color = "ui-fleet-black-75",
+}: IFilterProps) => {
+  return (
+    <svg
+      width={ICON_SIZES[size]}
+      height={ICON_SIZES[size]}
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M2 3a1 1 0 0 1 1-1h10a1 1 0 1 1 0 2H3a1 1 0 0 1-1-1Zm2 10a1 1 0 0 1 1-1h6a1 1 0 1 1 0 2H5a1 1 0 0 1-1-1Zm0-6a1 1 0 0 0 0 2h8a1 1 0 1 0 0-2H4Z"
+        fill={COLORS[color]}
+      />
+    </svg>
+  );
+};
+
+export default Filter;

--- a/frontend/components/icons/FilterAlt.tsx
+++ b/frontend/components/icons/FilterAlt.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { COLORS, Colors } from "styles/var/colors";
+import { ICON_SIZES, IconSizes } from "styles/var/icon_sizes";
+
+interface IFilterAltProps {
+  color?: Colors;
+  size?: IconSizes;
+}
+
+const FilterAlt = ({
+  size = "medium",
+  color = "ui-fleet-black-75",
+}: IFilterAltProps) => {
+  return (
+    <svg
+      width={ICON_SIZES[size]}
+      height={ICON_SIZES[size]}
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M5 4a1 1 0 1 0 0 2 1 1 0 0 0 0-2ZM1 4h1.17a3.001 3.001 0 0 1 5.66 0H15a1 1 0 1 1 0 2H7.83a3.001 3.001 0 0 1-5.66 0H1a1 1 0 0 1 0-2Zm0 6a1 1 0 1 0 0 2h7.17a3.001 3.001 0 0 0 5.664-.014c.054.01.11.014.166.014h1a1 1 0 1 0 0-2h-1c-.056 0-.112.005-.166.014A3.001 3.001 0 0 0 8.171 10H1Zm9 1a1 1 0 1 0 2 0 1 1 0 0 0-2 0Z"
+        fill={COLORS[color]}
+      />
+    </svg>
+  );
+};
+
+export default FilterAlt;

--- a/frontend/components/icons/index.ts
+++ b/frontend/components/icons/index.ts
@@ -20,6 +20,8 @@ import EmptySchedule from "./EmptySchedule";
 import EmptySoftware from "./EmptySoftware";
 import EmptyTeams from "./EmptyTeams";
 import ExternalLink from "./ExternalLink";
+import Filter from "./Filter";
+import FilterAlt from "./FilterAlt";
 import Issue from "./Issue";
 import More from "./More";
 import Plus from "./Plus";
@@ -95,6 +97,8 @@ export const ICON_MAP = {
   "empty-software": EmptySoftware,
   "empty-teams": EmptyTeams,
   "external-link": ExternalLink,
+  filter: Filter,
+  "filter-alt": FilterAlt,
   "low-disk-space-hosts": LowDiskSpaceHosts,
   "missing-hosts": MissingHosts,
   lightbulb: Lightbulb,

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
@@ -537,7 +537,7 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
           isLoading={loadingTableData}
           defaultSortHeader={"name"}
           defaultSortDirection={"asc"}
-          inputPlaceHolder={"Search"}
+          inputPlaceHolder={"Search by name or email"}
           actionButton={{
             name: "create user",
             buttonText: "Create user",

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1285,6 +1285,8 @@ const ManageHostsPage = ({
       `${baseClass}__status_dropdown`,
       { [`${baseClass}__status-dropdown-sandbox`]: isSandboxMode }
     );
+
+    console.log("status", status);
     return (
       <div className={`${baseClass}__filter-dropdowns`}>
         <Dropdown
@@ -1293,6 +1295,7 @@ const ManageHostsPage = ({
           options={getHostSelectStatuses(isSandboxMode)}
           searchable={false}
           onChange={handleStatusDropdownChange}
+          tableFilterDropdown
         />
         <LabelFilterSelect
           className={`${baseClass}__label-filter-dropdown`}

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -109,6 +109,18 @@
         .manage-hosts__filter-dropdowns {
           display: flex;
           margin-left: $pad-medium;
+
+          // Dropdown height matches search bar height
+          .manage-hosts__status_dropdown {
+            .Select-control,
+            .Select-input {
+              height: 33px;
+            }
+            .Select-value {
+              line-height: 38px;
+            }
+          }
+
           .manage-hosts__status-dropdown-sandbox {
             width: auto;
             .Select-control {
@@ -253,16 +265,6 @@
     .Select-value {
       padding-left: $pad-medium;
       padding-right: $pad-medium;
-
-      &::before {
-        display: inline-block;
-        position: absolute;
-        padding: 5px 0 0 0; // centers spin
-        content: url(../assets/images/icon-filter-black-16x16@2x.png);
-        transform: scale(0.5);
-        height: 26px;
-        left: 2px;
-      }
     }
     .Select-value-label {
       padding-left: $pad-large;

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -248,15 +248,15 @@
   }
 
   &__status_dropdown {
-    width: 165px;
+    width: 175px;
 
     @media (min-width: 1140px) {
-      width: 180px;
+      width: 190px;
     }
 
     .Select-menu-outer {
       width: 364px;
-      max-height: 310px;
+      max-height: 325px;
 
       .Select-menu {
         max-height: none;

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -120,9 +120,9 @@
     }
 
     // table header content responsive styles
-    // NOTE: 1100px is a custom breakpoint to deal with responsiveness of the
+    // NOTE: 1140px is a custom breakpoint to deal with responsiveness of the
     // table controls. 990px doesnt work for us in this case.
-    @media (max-width: 1100px) {
+    @media (max-width: 1140px) {
       &__header {
         flex-direction: column;
       }
@@ -134,6 +134,10 @@
 
         .table-container__search-input {
           margin-left: 0;
+
+          .input-with-icon {
+            width: 100%;
+          }
 
           & .search-field__input-wrapper {
             width: auto;
@@ -234,7 +238,7 @@
   &__status_dropdown {
     width: 165px;
 
-    @media (min-width: 1100px) {
+    @media (min-width: 1140px) {
       width: 180px;
     }
 

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -132,9 +132,9 @@
     }
 
     // table header content responsive styles
-    // NOTE: 1140px is a custom breakpoint to deal with responsiveness of the
+    // NOTE: 1150px is a custom breakpoint to deal with responsiveness of the
     // table controls. 990px doesnt work for us in this case.
-    @media (max-width: 1140px) {
+    @media (max-width: 1150px) {
       &__header {
         flex-direction: column;
       }
@@ -169,14 +169,13 @@
 
         .controls {
           order: 1;
-          margin-bottom: $pad-large;
+          margin-bottom: $pad-medium;
 
           .manage-hosts__filter-dropdowns {
             flex: 1;
 
             .form-field--dropdown,
             .manage-hosts__label-filter-dropdown {
-              max-width: 366px;
               flex: 1;
             }
 
@@ -250,7 +249,7 @@
   &__status_dropdown {
     width: 175px;
 
-    @media (min-width: 1140px) {
+    @media (min-width: 1150px) {
       width: 190px;
     }
 

--- a/frontend/pages/hosts/ManageHostsPage/components/CustomValueContainer/CustomValueContainer.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/CustomValueContainer/CustomValueContainer.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { ValueContainerProps, components } from "react-select-5";
+
+import Icon from "components/Icon";
+
+const baseClass = "custom-dropdown-indicator";
+
+const CustomDropdownIndicator = ({ props }: ValueContainerProps | any) => {
+  const { children } = props;
+  // no access to hover state here from react-select so that is done in the scss
+  // file of LabelFilterSelect.
+
+  return (
+    <components.DropdownIndicator {...props} className={baseClass}>
+      <Icon name="filter-alt" className={`${baseClass}__icon`} />
+      {children}
+    </components.DropdownIndicator>
+  );
+};
+
+export default CustomDropdownIndicator;

--- a/frontend/pages/hosts/ManageHostsPage/components/CustomValueContainer/index.ts
+++ b/frontend/pages/hosts/ManageHostsPage/components/CustomValueContainer/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CustomValueContainer";

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/_styles.scss
@@ -2,7 +2,7 @@
   &__labels-active-filter-wrap {
     display: flex;
     align-items: center;
-    margin-bottom: $pad-medium;
+    margin-bottom: $pad-small;
     gap: $pad-small; // between multiple filter pills
   }
 

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef, useState } from "react";
-import Select, { GroupBase, SelectInstance } from "react-select-5";
+import Select, { GroupBase, SelectInstance, components } from "react-select-5";
 import classnames from "classnames";
 
 import { ILabel } from "interfaces/label";
@@ -10,6 +10,7 @@ import CustomLabelGroupHeading from "../CustomLabelGroupHeading";
 import { PLATFORM_TYPE_ICONS } from "./constants";
 import { createDropdownOptions, IEmptyOption, IGroupOption } from "./helpers";
 import CustomDropdownIndicator from "../CustomDropdownIndicator";
+import CustomValueContainer from "../CustomValueContainer";
 
 // Extending the react-select module to add custom props we need for our custom
 // group heading. More info here:
@@ -148,6 +149,17 @@ const LabelFilterSelect = ({
 
   const classes = classnames(baseClass, className);
 
+  const ValueContainer = ({ children, ...props }: any) => {
+    return (
+      components.ValueContainer && (
+        <components.ValueContainer {...props}>
+          {!!children && <Icon name="filter-alt" className="filter-icon" />}
+          {children}
+        </components.ValueContainer>
+      )
+    );
+  };
+
   return (
     <Select<ILabel | IEmptyOption, false, IGroupOption>
       ref={selectRef}
@@ -166,6 +178,7 @@ const LabelFilterSelect = ({
       components={{
         GroupHeading: CustomLabelGroupHeading,
         DropdownIndicator: CustomDropdownIndicator,
+        ValueContainer,
       }}
       labelQuery={labelQuery}
       canAddNewLabels={canAddNewLabels}

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -61,12 +61,12 @@
   }
 
   .label-filter-select__placeholder {
-    width: 75px;
+    width: 75px; // Truncates text for smaller filter width
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 
-    @media (max-width: $break-md) {
+    @media (max-width: 1150px) {
       width: auto;
     }
   }

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -18,6 +18,7 @@
     border: 1px solid $ui-fleet-black-10;
     background-color: $ui-light-grey;
     border-radius: $border-radius;
+    height: 40px;
 
     &--is-focused,
     &--menu-is-open,

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -12,6 +12,12 @@
         stroke: $core-vibrant-blue;
       }
     }
+
+    .filter-icon {
+      & path {
+        fill: $core-vibrant-blue;
+      }
+    }
   }
 
   .label-filter-select__control {
@@ -28,25 +34,24 @@
     }
     &--is-focused,
     &--menu-is-open {
-      svg {
-        transform: rotate(180deg);
-        transition: transform 0.25s ease;
+      .custom-dropdown-indicator {
+        svg {
+          transform: rotate(180deg);
+          transition: transform 0.25s ease;
+        }
+      }
+      .filter-icon {
+        & path {
+          fill: $core-vibrant-blue;
+        }
       }
     }
   }
 
   .label-filter-select__value-container {
-    margin-left: 10px;
-    padding-left: 27px;
-
-    &::before {
-      display: inline-block;
-      position: absolute;
-      content: url(../assets/images/icon-filter-v2-black-16x16@2x.png);
-      transform: scale(0.5);
-      left: -6px;
-      margin-top: 4px;
-    }
+    display: flex;
+    gap: $pad-small;
+    margin-left: $pad-xsmall;
   }
 
   .label-filter-select__single-value,

--- a/frontend/pages/hosts/details/cards/Software/Software.tsx
+++ b/frontend/pages/hosts/details/cards/Software/Software.tsx
@@ -200,6 +200,7 @@ const SoftwareTable = ({
         options={VULNERABLE_DROPDOWN_OPTIONS}
         searchable={false}
         onChange={handleVulnFilterDropdownChange}
+        tableFilterDropdown
       />
     );
   };

--- a/frontend/pages/hosts/details/cards/Software/Software.tsx
+++ b/frontend/pages/hosts/details/cards/Software/Software.tsx
@@ -232,7 +232,7 @@ const SoftwareTable = ({
                 defaultSearchQuery={searchQuery}
                 defaultPageIndex={page}
                 pageSize={DEFAULT_PAGE_SIZE}
-                inputPlaceHolder="Search software by name or vulnerabilities (CVEs)"
+                inputPlaceHolder="Search by name or vulnerabilities (CVEs)"
                 onQueryChange={onQueryChange}
                 emptyComponent={() => (
                   <EmptySoftwareTable

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -38,6 +38,10 @@
     }
   }
 
+  .table-container__search-input {
+    width: 325px; // Custom to fit placeholder text
+  }
+
   .data-table-block {
     .last_used_tooltip {
       text-align: center;
@@ -196,6 +200,10 @@
   // NOTE: 990px is a custom breakpoint to deal with responsiveness of the
   // table controls.
   @media (max-width: $break-md) {
+    .table-container__search-input {
+      width: 100%; // Override custom placeholder width
+    }
+
     thead .name__header {
       width: $col-md;
       min-width: 252px;

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -68,8 +68,6 @@
       }
     }
     &__platform-dropdown {
-      width: 159px;
-
       .Select-menu-outer {
         width: 364px;
         max-height: 380px;

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -231,6 +231,7 @@ const QueriesTable = ({
         options={PLATFORM_FILTER_OPTIONS}
         searchable={false}
         onChange={handlePlatformFilterDropdownChange}
+        tableFilterDropdown
       />
     );
   };

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -550,6 +550,7 @@ const ManageSoftwarePage = ({
         options={VULNERABLE_DROPDOWN_OPTIONS}
         searchable={false}
         onChange={handleVulnFilterDropdownChange}
+        tableFilterDropdown
       />
     );
   };

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -655,7 +655,7 @@ const ManageSoftwarePage = ({
         resetPageIndex={resetPageIndex}
         disableNextPage={isLastPage}
         searchable={searchable}
-        inputPlaceHolder="Search software by name or vulnerabilities (CVEs)"
+        inputPlaceHolder="Search by name or vulnerabilities (CVEs)"
         onQueryChange={onQueryChange}
         additionalQueries={filterVuln ? "vulnerable" : ""} // additionalQueries serves as a trigger
         // for the useDeepEffect hook to fire onQueryChange for events happeing outside of

--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -58,7 +58,16 @@
 
   &__table {
     .table-container {
+      &__header {
+        flex-direction: column-reverse; // Search bar on top
+
+        @media (min-width: $break-md) {
+          flex-direction: row;
+        }
+      }
+
       &__header-left {
+        flex-direction: row; // Filter dropdown aligned with count
         .controls {
           .form-field--dropdown {
             margin: 0;
@@ -92,15 +101,16 @@
           }
         }
       }
+      &__search-input,
       &__search {
-        width: 100%;
-        .search-field__input-wrapper {
+        width: 100%; // Search bar across entire table
+        .input-icon-field__input {
           width: 100%;
         }
-        @media (min-width: $break-xs) {
+        @media (min-width: $break-md) {
           width: auto;
-          .search-field__input-wrapper {
-            width: 411px;
+          .input-icon-field__input {
+            width: 375px;
           }
         }
       }


### PR DESCRIPTION
## Issue 
Cerra #13061 , Cerra #13068 

## Description
- Fixes alignment of search bar to not go past table
- Fixes height of dropdown and search bar to both be 40px
- Adds focus and hover color to search icon to match outline color
- Adds focus and hover color of filter icons to match outline color
- Updates filter icons to svgs
- Update search bar placeholder text to suggested text in 13061
- Update height of filter dropdown as outlined in bug #13068 

## Screen recording updated Aug 8

https://github.com/fleetdm/fleet/assets/71795832/0540808e-c030-4d2a-8a02-b13f0eb951ed



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

