### PR TITLE
Revert UI query path fix

### DIFF
--- a/changes/13154-fix-host-details-custom-query-route
+++ b/changes/13154-fix-host-details-custom-query-route
@@ -1,2 +1,0 @@
-- Fixed a bug that occurred when a user tries to create a custom query from the "query" action on a
-  host's details page.

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -486,9 +486,7 @@ const HostDetailsPage = ({
   };
 
   const onQueryHostCustom = () => {
-    router.push(
-      PATHS.NEW_QUERY() + TAGGED_TEMPLATES.queryByHostRoute(host?.id)
-    );
+    router.push(PATHS.NEW_QUERY + TAGGED_TEMPLATES.queryByHostRoute(host?.id));
   };
 
   const onQueryHostSaved = (selectedQuery: ISchedulableQuery) => {


### PR DESCRIPTION
This PR reverts this change: https://github.com/fleetdm/fleet/commit/a8d99c327373de85fbbe8f7fa820a3e41c356ec4

Because it was merged as a merge commit. We will re-merge as a squashed megre so there is a single commit to cherry-pick into the patch branch. 