### PR TITLE
remove quotes from FLEET_URL property in Windows templates

### DIFF
--- a/orbit/changes/13175-windows-url
+++ b/orbit/changes/13175-windows-url
@@ -1,0 +1,1 @@
+* Fixed a bug that set a wrong Fleet URL in Windows installers.

--- a/orbit/pkg/packaging/windows_templates.go
+++ b/orbit/pkg/packaging/windows_templates.go
@@ -54,7 +54,7 @@ var windowsWixTemplate = template.Must(template.New("").Option("missingkey=error
     <Property Id="ARPNOREPAIR" Value="yes" Secure="yes" />
     <Property Id="ARPNOMODIFY" Value="yes" Secure="yes" />
 
-    <Property Id="FLEET_URL" Value="{{ if .FleetURL }}'{{ .FleetURL }}'{{ end }}"/>
+    <Property Id="FLEET_URL" Value="{{ if .FleetURL }}{{ .FleetURL }}{{ end }}"/>
     <Property Id="FLEET_SECRET" Value="dummy"/>
 
     <MediaTemplate EmbedCab="yes" />


### PR DESCRIPTION
related to #13175 and #13186

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
