### PR TITLE
Fleet UI: [bug fix] Text cells in all tables no longer overflow into next column

### DIFF
--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -216,7 +216,9 @@ $shadow-transition-width: 10px;
         .link-cell,
         .text-cell {
           display: block;
+          overflow: hidden;
           white-space: nowrap;
+          text-overflow: ellipsis;
           margin: 0;
           .__react_component_tooltip {
             white-space: normal;

--- a/frontend/pages/DashboardPage/cards/MDM/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/MDM/_styles.scss
@@ -31,11 +31,6 @@
       }
 
       tbody {
-        .name__cell {
-          overflow: hidden;
-          white-space: nowrap;
-          text-overflow: ellipsis;
-        }
         .mdm-solution-link {
           opacity: 0;
           transition: 250ms;


### PR DESCRIPTION
## Issue
Cerra #13086 

## Description
- Global fix to all tables (specific instance of bug found was server URL of MDM dashboard card)
- If text cell is too long, truncate text with ellipses instead of overflowing into the next cell

## Screenshot
New truncated text can be seen in various tables where the text is too long for the column width
Example:
<img width="654" alt="Screenshot 2023-08-09 at 12 02 24 PM" src="https://github.com/fleetdm/fleet/assets/71795832/0a274735-db57-4e5f-9cf9-20efa4603341">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

