### PR TITLE
Return 403 instead of 500 when conditions are not met to perform a required pwd reset

### DIFF
--- a/changes/issue-12633-required-password-reset
+++ b/changes/issue-12633-required-password-reset
@@ -1,0 +1,1 @@
+* Fixed response status code to 403 when a user cannot change their password due to not being requested to by the admin or due to this user having Single-Sign-On (SSO) enabled.

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -3360,7 +3360,7 @@ func (s *integrationTestSuite) TestUsers() {
 	s.DoJSON("POST", "/api/latest/fleet/perform_required_password_reset", performRequiredPasswordResetRequest{
 		Password: newRawPwd,
 		ID:       u.ID,
-	}, http.StatusInternalServerError, &perfPwdResetResp) // TODO: should be 40?, see #4406
+	}, http.StatusForbidden, &perfPwdResetResp)
 	s.token = s.getTestAdminToken()
 
 	// login as that user to verify that the new password is active (userRawPwd was updated to the new pwd)

--- a/server/service/users.go
+++ b/server/service/users.go
@@ -845,7 +845,10 @@ func (svc *Service) PerformRequiredPasswordReset(ctx context.Context, password s
 	}
 
 	if user.SSOEnabled {
-		return nil, ctxerr.New(ctx, "password reset for single sign on user not allowed")
+		// should never happen because this would get caught by the
+		// CanPerformPasswordReset check above
+		err := fleet.NewPermissionError("password reset for single sign on user not allowed")
+		return nil, ctxerr.Wrap(ctx, err)
 	}
 	if !user.IsAdminForcedPasswordReset() {
 		// should never happen because this would get caught by the


### PR DESCRIPTION
#12633 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
