### PR TITLE
Prevent host page label filter text from jumping at low viewport width

### DIFF
--- a/changes/13254-jumping-text
+++ b/changes/13254-jumping-text
@@ -1,0 +1,1 @@
+- Fix jumping text on the host page label filter dropdown at low viewport widths

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -77,6 +77,9 @@
 
   .label-filter-select__indicator {
     color: $core-fleet-black;
+    // override react-select default styles to increase flexibility of dropdown styling
+    padding: 0;
+    padding-right: $pad-small;
   }
 
   .label-filter-select__menu {


### PR DESCRIPTION
## Addresses #13254 


https://github.com/fleetdm/fleet/assets/61553566/19ea1276-cf5d-42b8-873d-39276d7b9c09



## Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality