### PR TITLE
Fleet UI: Move observer + to under observer to conform with permissions ordering

### DIFF
--- a/frontend/pages/admin/UserManagementPage/helpers/userManagementHelpers.ts
+++ b/frontend/pages/admin/UserManagementPage/helpers/userManagementHelpers.ts
@@ -78,7 +78,7 @@ export const roleOptions = ({
   ];
 
   if (isPremiumTier) {
-    roles.unshift({
+    roles.splice(1, 0, {
       disabled: false,
       label: "Observer+",
       value: "observer_plus",


### PR DESCRIPTION
## Issue
Cerra #13063 

## Description
- Observer + moved between observer and maintainer as it has more permissions than observer

## No change file needed as this is such a small "bug"

## Screenshot
<img width="747" alt="Screenshot 2023-08-09 at 4 15 19 PM" src="https://github.com/fleetdm/fleet/assets/71795832/89479a80-12fe-4c0b-856a-f4441f634391">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

