### PR TITLE
Fleet UI: [unreleased bug] Fix hover fill of reveal button

### DIFF
--- a/frontend/components/buttons/RevealButton/_styles.scss
+++ b/frontend/components/buttons/RevealButton/_styles.scss
@@ -2,4 +2,23 @@
   display: inline-flex;
   align-items: center;
   padding: $pad-small $pad-xxsmall; // larger clickable area
+
+  svg {
+    path {
+      fill: none; // Chevron icon uses stroke color
+    }
+  }
+
+  &:hover,
+  &:focus {
+    .component__tooltip-wrapper__element {
+      color: $core-vibrant-blue-over;
+    }
+
+    svg {
+      path {
+        stroke: $core-vibrant-blue-over;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Issue
Fix small styling bug introduced by #13151

## Description
- Most buttons use `svg` `path` `fill` for icon color changes on hover and on focus, however, the reveal button `Chevron.tsx` `svg` doesn't use `fill`, it uses `stroke` so the hover styling needed a one off fix

## Screen recording before (unreleased bug)

https://github.com/fleetdm/fleet/assets/71795832/8eb71eb6-1ee0-463d-9e42-4b578d6a124d

## Screen recording after

https://github.com/fleetdm/fleet/assets/71795832/cacc66f8-355b-4ca1-b490-620e4e5ea602



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

-unreleased so no change doc

- [x] Manual QA for all new/changed functionality