### PR TITLE
Fleet UI: [released bug] Add hover state/ tabbing state to user side panel buttons

### DIFF
--- a/frontend/pages/UserSettingsPage/UserSidePanel/UserSidePanel.tsx
+++ b/frontend/pages/UserSettingsPage/UserSidePanel/UserSidePanel.tsx
@@ -113,13 +113,18 @@ const UserSidePanel = ({
         onClick={onChangePassword}
         disabled={ssoEnabled}
         className={`${baseClass}__button`}
+        variant="brand"
       >
         Change password
       </Button>
       <p className={`${baseClass}__last-updated`}>
         Last changed: {lastUpdatedAt}
       </p>
-      <Button onClick={onGetApiToken} className={`${baseClass}__button`}>
+      <Button
+        onClick={onGetApiToken}
+        className={`${baseClass}__button`}
+        variant="brand"
+      >
         Get API token
       </Button>
       <span


### PR DESCRIPTION
## Issue
#13293 

## Description
- Add `variant="brand"` to buttons on user side panel to match rest of button styling on app which has a slight hover state and a on-focus state for tabbing through the app

## Screen recording before (released bug/legacy buttons) of no styling on hover or when tabbing through the app

https://github.com/fleetdm/fleet/assets/71795832/dca3fc7b-8425-4753-8ba9-10a23ec512c1

## Screen recording after with darken button on hover and outline when tabbing through the app

https://github.com/fleetdm/fleet/assets/71795832/fdc2bd4c-e74b-414c-977a-d26f031580c6



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- so small no changelog
- [x] Manual QA for all new/changed functionality
