### PR TITLE
Fleet UI: Add hover/focus state to icon and border of label filter search

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/components/CustomLabelGroupHeading/CustomLabelGroupHeading.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/CustomLabelGroupHeading/CustomLabelGroupHeading.tsx
@@ -61,7 +61,6 @@ const CustomLabelGroupHeading = (
         </div>
       </div>
       <div className={`${baseClass}__field`}>
-        <Icon name="search" />
         <input
           className={`${baseClass}__input`}
           ref={inputRef}
@@ -77,6 +76,7 @@ const CustomLabelGroupHeading = (
           onClick={handleInputClick}
           onBlur={onBlurLabelSearchInput}
         />
+        <Icon name="search" />
       </div>
     </components.GroupHeading>
   );

--- a/frontend/pages/hosts/ManageHostsPage/components/CustomLabelGroupHeading/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/CustomLabelGroupHeading/_styles.scss
@@ -48,9 +48,18 @@
       color: $ui-fleet-black-50;
     }
 
-    &:focus {
+    &:focus,
+    &:hover {
       outline: none;
       border-color: $core-vibrant-blue;
+
+      + .icon {
+        svg {
+          path {
+            fill: $core-vibrant-blue;
+          }
+        }
+      }
     }
 
     &--disabled {


### PR DESCRIPTION
## Issue

## Description
- Cleaner icons and hover/focus state

## Screen recording

https://github.com/fleetdm/fleet/assets/71795832/ec49bb01-8475-49ed-ac54-e724f90a86f3




# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality