### PR TITLE
Fleet UI: [released tiny bug] Fix dashboard double scroll bar

### DIFF
--- a/changes/13082-fix-dashboard-double-scrollbar
+++ b/changes/13082-fix-dashboard-double-scrollbar
@@ -1,0 +1,1 @@
+- UI fix double scroll bar bug on dashboard page

--- a/frontend/components/MainContent/_styles.scss
+++ b/frontend/components/MainContent/_styles.scss
@@ -3,8 +3,8 @@
   background-color: $core-white;
   flex-grow: 1;
   // overflow: auto allows for horizontal scrolling
-  // of the main-content when there is a sidebar.
-  // Without it the main content pushes the sidebar off the page.
+  // of the main-content when there is a banner. (e.g. sandbox mode)
+  // Without it the main content pushes the banner off the page.
   overflow: auto;
   animation: fade-in 250ms ease-out;
 }

--- a/frontend/pages/DashboardPage/_styles.scss
+++ b/frontend/pages/DashboardPage/_styles.scss
@@ -1,5 +1,7 @@
 .dashboard-page {
   background-color: $ui-off-white;
+  overflow: initial; // auto causes double scroll bar  but still needed for other pages .main-content div
+  padding-bottom: 60px; // replaces white padding on off-white page
 
   .data-error {
     &__inner {


### PR DESCRIPTION
## Issue
Cerra #13082 

## Description
For 4.37
- `overflow: auto` causes slight additional scroll behavior on dashboard page
- Diggin in, `overflow: auto` is needed for the fleet sandbox banner to not overflow the page on wide table pages as left in a frontend comment, however, it is unneeded on dashboard page
- Targeting `overflow-x` or `overflow-y` only does not solve the issue
- Localized fix `overflow: initial` and `padding` to not introduce global bug with fix

## Screenrecording of bug (before)

https://github.com/fleetdm/fleet/assets/71795832/baece6fc-7c15-4788-baf7-832695809f69


## Screenrecording of fix (after)

https://github.com/fleetdm/fleet/assets/71795832/36dfe45f-bfdc-4887-9ada-3212a5a97734



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality (Tested on Chrome, Firefox, and Safari)