### PR TITLE
Automation: Try removing trailing slash on handbook/

### DIFF
--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -149,7 +149,7 @@ module.exports.custom = {
     'website/config/custom.js': 'mikermcneil',
 
     // 🦿 Handbook
-    'handbook/': 'mikermcneil', // See https://github.com/fleetdm/fleet/pull/13195
+    'handbook': 'mikermcneil', // See https://github.com/fleetdm/fleet/pull/13195
     //'handbook/company/ceo.md': 'sampfluger88',
     //'handbook/company': 'mikermcneil',
     //'handbook/business-operations': 'mikermcneil',


### PR DESCRIPTION
Automation: Try removing trailing slash on `handbook/` in this config to verify that editing https://github.com/fleetdm/fleet/pull/13196 as me does put the `#g-ceo` label properly back on this PR.

If that doesn't work, then we need to keep digging into what's wrong.