### PR TITLE
Fix expected number of hosts in fleetctl-preview-latest workflow

### DIFF
--- a/.github/workflows/fleetctl-preview-latest.yml
+++ b/.github/workflows/fleetctl-preview-latest.yml
@@ -70,7 +70,7 @@ jobs:
         ./build/fleetctl preview --std-query-lib-file-path $(pwd)/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
         sleep 10
         ./build/fleetctl get hosts | tee hosts.txt
-        [ $( cat hosts.txt | grep online | wc -l) -eq 8 ]
+        [ $( cat hosts.txt | grep online | wc -l) -eq 9 ]
 
     - name: Get fleet logs
       run: |


### PR DESCRIPTION
#13182

[This PR](https://github.com/fleetdm/osquery-in-a-box/pull/18) in the osquery-in-a-box repository recently added a new host to the simulated host list which broke the CI job in the fleetdm/fleet repository.

PR run with this branch: https://github.com/fleetdm/fleet/actions/runs/5866786432

PS: One of the reasons we had this osquery-in-a-box repository outside the monorepo was to not break customers using `fleetctl preview`. But now that we have Fleet Sandbox and we don't encourage users to use `fleetctl preview`:
1. Does it  make sense to have the separate repository?
2. Does it make sense to continue supporting this workflow in CI?