### PR TITLE
Fleet UI: Add more specific page titles to browser tab

### DIFF
--- a/changes/13205-browser-page-titles-added
+++ b/changes/13205-browser-page-titles-added
@@ -1,0 +1,1 @@
+- More specific page titles shown in browser to match page of Fleet UI

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -109,7 +109,7 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
       location?.pathname.includes(item.path)
     );
 
-    // Override title if MDM not configured
+    // Override Controls page title if MDM not configured
     if (
       !config?.mdm.enabled_and_configured &&
       curTitle?.path === "/controls/mac-os-updates"

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -107,13 +107,12 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
     const curTitle = page_titles.find((item) =>
       location?.pathname.includes(item.path)
     );
-    console.log("curTitle", curTitle);
+
     if (curTitle && curTitle.title) {
       document.title = curTitle.title;
     }
   }, [location]);
 
-  console.log("LOCATION", location);
   useDeepEffect(() => {
     const canGetEnrollSecret =
       currentUser &&

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -53,6 +53,46 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
 
   const [isLoading, setIsLoading] = useState(false);
 
+  const titleMap = [
+    { path: "/dashboard", title: "Dashboard | Fleet for osquery" },
+    { path: "/hosts/manage", title: "Manage hosts | Fleet for osquery" },
+    {
+      path: "/controls/mac-os-updates",
+      title: "Manage macOS MDM controls | Fleet for osquery",
+    },
+    { path: "/software/manage", title: "Manage software | Fleet for osquery" },
+    { path: "/queries/manage", title: "Manage queries | Fleet for osquery" },
+    { path: "/policies/manage", title: "Manage policies | Fleet for osquery" },
+    {
+      path: "/settings/organization",
+      title: "Manage organization settings | Fleet for osquery",
+    },
+    {
+      path: "/settings/integration",
+      title: "Manage integration settings | Fleet for osquery",
+    },
+    {
+      path: "/settings/users",
+      title: "Manage user settings | Fleet for osquery",
+    },
+    {
+      path: "/settings/teams",
+      title: "Manage team settings | Fleet for osquery",
+    },
+    {
+      path: "/settings/teams/members",
+      title: "Manage team members | Fleet for osquery",
+    },
+    {
+      path: "/settings/teams/options",
+      title: "Manage team options | Fleet for osquery",
+    },
+    {
+      path: "/profile",
+      title: "Manage my account | Fleet for osquery",
+    },
+  ];
+
   const fetchConfig = async () => {
     try {
       const config = await configAPI.loadAll();
@@ -100,6 +140,14 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
     }
   }, [location?.pathname]);
 
+  useEffect(() => {
+    const curTitle = titleMap.find((item) => item.path === location?.pathname);
+    if (curTitle && curTitle.title) {
+      document.title = curTitle.title;
+    }
+  }, [location]);
+
+  console.log("LOCATION", location);
   useDeepEffect(() => {
     const canGetEnrollSecret =
       currentUser &&

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { AxiosResponse } from "axios";
 import { QueryClient, QueryClientProvider } from "react-query";
 
+import page_titles from "router/page_titles";
 import TableProvider from "context/table";
 import QueryProvider from "context/query";
 import PolicyProvider from "context/policy";
@@ -53,46 +54,6 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
 
   const [isLoading, setIsLoading] = useState(false);
 
-  const titleMap = [
-    { path: "/dashboard", title: "Dashboard | Fleet for osquery" },
-    { path: "/hosts/manage", title: "Manage hosts | Fleet for osquery" },
-    {
-      path: "/controls/mac-os-updates",
-      title: "Manage macOS MDM controls | Fleet for osquery",
-    },
-    { path: "/software/manage", title: "Manage software | Fleet for osquery" },
-    { path: "/queries/manage", title: "Manage queries | Fleet for osquery" },
-    { path: "/policies/manage", title: "Manage policies | Fleet for osquery" },
-    {
-      path: "/settings/organization",
-      title: "Manage organization settings | Fleet for osquery",
-    },
-    {
-      path: "/settings/integration",
-      title: "Manage integration settings | Fleet for osquery",
-    },
-    {
-      path: "/settings/users",
-      title: "Manage user settings | Fleet for osquery",
-    },
-    {
-      path: "/settings/teams",
-      title: "Manage team settings | Fleet for osquery",
-    },
-    {
-      path: "/settings/teams/members",
-      title: "Manage team members | Fleet for osquery",
-    },
-    {
-      path: "/settings/teams/options",
-      title: "Manage team options | Fleet for osquery",
-    },
-    {
-      path: "/profile",
-      title: "Manage my account | Fleet for osquery",
-    },
-  ];
-
   const fetchConfig = async () => {
     try {
       const config = await configAPI.loadAll();
@@ -140,8 +101,13 @@ const App = ({ children, location }: IAppProps): JSX.Element => {
     }
   }, [location?.pathname]);
 
+  // Updates title that shows up on browser tabs
   useEffect(() => {
-    const curTitle = titleMap.find((item) => item.path === location?.pathname);
+    // Also applies title to subpaths such as settings/organization/webaddress
+    const curTitle = page_titles.find((item) =>
+      location?.pathname.includes(item.path)
+    );
+    console.log("curTitle", curTitle);
     if (curTitle && curTitle.title) {
       document.title = curTitle.title;
     }

--- a/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
+++ b/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
@@ -105,7 +105,7 @@ const ManageControlsPage = ({
     if (!config?.mdm.enabled_and_configured) {
       document.title = "Manage macOS hosts | Fleet for osquery";
     }
-  }, [location.pathname, config?.mdm.enabled_and_configured]);
+  }, [location, config]);
 
   const onConnectClick = () => {
     router.push(PATHS.ADMIN_INTEGRATIONS_MDM);

--- a/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
+++ b/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect } from "react";
+import React, { useCallback, useContext } from "react";
 import { Tab, Tabs, TabList } from "react-tabs";
 import { InjectedRouter } from "react-router";
 

--- a/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
+++ b/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
@@ -99,14 +99,6 @@ const ManageControlsPage = ({
     [location, router]
   );
 
-  // If MDM not configured, override title that shows up on browser tabs to generic title
-  useEffect(() => {
-    // e.g., Manage macOS hosts | Fleet for osquery
-    if (!config?.mdm.enabled_and_configured) {
-      document.title = "Manage macOS hosts | Fleet for osquery";
-    }
-  }, [location, config]);
-
   const onConnectClick = () => {
     router.push(PATHS.ADMIN_INTEGRATIONS_MDM);
   };

--- a/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
+++ b/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from "react";
+import React, { useCallback, useContext, useEffect } from "react";
 import { Tab, Tabs, TabList } from "react-tabs";
 import { InjectedRouter } from "react-router";
 
@@ -98,6 +98,14 @@ const ManageControlsPage = ({
     },
     [location, router]
   );
+
+  // If MDM not configured, override title that shows up on browser tabs to generic title
+  useEffect(() => {
+    // e.g., Manage macOS hosts | Fleet for osquery
+    if (!config?.mdm.enabled_and_configured) {
+      document.title = "Manage macOS hosts | Fleet for osquery";
+    }
+  }, [location.pathname, config?.mdm.enabled_and_configured]);
 
   const onConnectClick = () => {
     router.push(PATHS.ADMIN_INTEGRATIONS_MDM);

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1285,7 +1285,6 @@ const ManageHostsPage = ({
       { [`${baseClass}__status-dropdown-sandbox`]: isSandboxMode }
     );
 
-    console.log("status", status);
     return (
       <div className={`${baseClass}__filter-dropdowns`}>
         <Dropdown

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useCallback } from "react";
+import React, { useState, useContext, useCallback, useEffect } from "react";
 import { InjectedRouter, Params } from "react-router/lib/Router";
 import { useQuery } from "react-query";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
@@ -290,6 +290,27 @@ const DeviceUserPage = ({
       }
     }
   };
+
+  // Updates title that shows up on browser tabs
+  useEffect(() => {
+    const hostTab = () => {
+      if (location.pathname.includes("software")) {
+        return "software";
+      }
+      if (location.pathname.includes("schedule")) {
+        return "schedule";
+      }
+      if (location.pathname.includes("policies")) {
+        return "policies";
+      }
+      return "";
+    };
+
+    // e.g., Rachel's Macbook Pro schedule details | Fleet for osquery
+    document.title = `My device ${hostTab()} details | ${
+      host?.display_name || "Unknown host"
+    } | Fleet for osquery`;
+  }, [location.pathname, host]);
 
   const renderActionButtons = () => {
     return (

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -343,6 +343,27 @@ const HostDetailsPage = ({
     });
   }, [usersSearchString, host?.users]);
 
+  // Updates title that shows up on browser tabs
+  useEffect(() => {
+    const hostTab = () => {
+      if (location.pathname.includes("software")) {
+        return "software";
+      }
+      if (location.pathname.includes("schedule")) {
+        return "schedule";
+      }
+      if (location.pathname.includes("policies")) {
+        return "policies";
+      }
+      return "";
+    };
+
+    // e.g., Rachel's Macbook Pro schedule details | Fleet for osquery
+    document.title = `Host ${hostTab()} details | ${
+      host?.display_name || "Unknown host"
+    } | Fleet for osquery`;
+  }, [location.pathname, host]);
+
   // Used for back to software pathname
   useEffect(() => {
     setPathname(location.pathname + location.search);

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -359,9 +359,9 @@ const HostDetailsPage = ({
     };
 
     // e.g., Rachel's Macbook Pro schedule details | Fleet for osquery
-    document.title = `Host ${hostTab()} details | ${
-      host?.display_name || "Unknown host"
-    } | Fleet for osquery`;
+    document.title = `Host ${hostTab()} details ${
+      host?.display_name ? `| ${host?.display_name} |` : "|"
+    } Fleet for osquery`;
   }, [location.pathname, host]);
 
   // Used for back to software pathname

--- a/frontend/pages/policies/PolicyPage/PolicyPage.tsx
+++ b/frontend/pages/policies/PolicyPage/PolicyPage.tsx
@@ -202,6 +202,12 @@ const PolicyPage = ({
     detectIsFleetQueryRunnable();
   }, []);
 
+  // Updates title that shows up on browser tabs
+  useEffect(() => {
+    // e.g., Policy details | Antivirus healthy (Linux) | Fleet for osquery
+    document.title = `Policy details | ${storedPolicy?.name} | Fleet for osquery`;
+  }, [location.pathname, storedPolicy?.name]);
+
   useEffect(() => {
     setShowOpenSchemaActionText(!isSidebarOpen);
   }, [isSidebarOpen]);

--- a/frontend/pages/queries/QueryPage/QueryPage.tsx
+++ b/frontend/pages/queries/QueryPage/QueryPage.tsx
@@ -163,6 +163,12 @@ const QueryPage = ({
     }
   }, [queryId]);
 
+  // Updates title that shows up on browser tabs
+  useEffect(() => {
+    // e.g., Query details | Discover TLS certificates | Fleet for osquery
+    document.title = `Query details | ${storedQuery?.name} | Fleet for osquery`;
+  }, [location.pathname, storedQuery?.name]);
+
   useEffect(() => {
     setShowOpenSchemaActionText(!isSidebarOpen);
   }, [isSidebarOpen]);

--- a/frontend/pages/software/SoftwareDetailsPage/SoftwareDetailsPage.tsx
+++ b/frontend/pages/software/SoftwareDetailsPage/SoftwareDetailsPage.tsx
@@ -74,9 +74,9 @@ const SoftwareDetailsPage = ({
   // Updates title that shows up on browser tabs
   useEffect(() => {
     // e.g., Software horizon, 5.2.0 details | Fleet for osquery
-    document.title = `Software ${
+    document.title = `Software details | ${
       software && renderName(software)
-    } details | Fleet for osquery`;
+    } | Fleet for osquery`;
   }, [location.pathname, software]);
 
   if (!software || isPremiumTier === undefined) {

--- a/frontend/pages/software/SoftwareDetailsPage/SoftwareDetailsPage.tsx
+++ b/frontend/pages/software/SoftwareDetailsPage/SoftwareDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 import { useErrorHandler } from "react-error-boundary";
 import { useQuery } from "react-query";
 import PATHS from "router/paths";
@@ -70,6 +70,14 @@ const SoftwareDetailsPage = ({
 
     return `${name}, ${version}`;
   };
+
+  // Updates title that shows up on browser tabs
+  useEffect(() => {
+    // e.g., Software horizon, 5.2.0 details | Fleet for osquery
+    document.title = `Software ${
+      software && renderName(software)
+    } details | Fleet for osquery`;
+  }, [location.pathname, software]);
 
   if (!software || isPremiumTier === undefined) {
     return <Spinner />;

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -74,13 +74,14 @@ import ExcludeInSandboxRoutes from "./components/ExcludeInSandboxRoutes";
 
 interface IAppWrapperProps {
   children: JSX.Element;
+  location?: any;
 }
 
 // App.tsx needs the context for user and config
-const AppWrapper = ({ children }: IAppWrapperProps) => (
+const AppWrapper = ({ children, location }: IAppWrapperProps) => (
   <AppProvider>
     <RoutingProvider>
-      <App>{children}</App>
+      <App location={location}>{children}</App>
     </RoutingProvider>
   </AppProvider>
 );

--- a/frontend/router/page_titles.ts
+++ b/frontend/router/page_titles.ts
@@ -1,0 +1,51 @@
+// Note: Dynamic page titles are constructed for host, software, query, and policy details on their respective *DetailsPage.tsx file
+// Note: Order matters for use of array.find() (specific subpaths must be listed before their parent path)
+export default [
+  { path: "/dashboard", title: "Dashboard | Fleet for osquery" },
+  { path: "/hosts/manage", title: "Manage hosts | Fleet for osquery" },
+  {
+    path: "/controls/mac-os-updates",
+    title: "Manage macOS updates | Fleet for osquery",
+  },
+  {
+    path: "/controls/mac-settings",
+    title: "Manage macOS settings | Fleet for osquery",
+  },
+  {
+    path: "/controls/mac-setup",
+    title: "Manage macOS MDM setup | Fleet for osquery",
+  },
+  { path: "/software/manage", title: "Manage software | Fleet for osquery" },
+  { path: "/queries/manage", title: "Manage queries | Fleet for osquery" },
+  { path: "/queries/new", title: "New query | Fleet for osquery" },
+  { path: "/policies/manage", title: "Manage policies | Fleet for osquery" },
+  { path: "/policies/new", title: "New policy | Fleet for osquery" },
+  {
+    path: "/settings/organization",
+    title: "Manage organization settings | Fleet for osquery",
+  },
+  {
+    path: "/settings/integrations",
+    title: "Manage integration settings | Fleet for osquery",
+  },
+  {
+    path: "/settings/users",
+    title: "Manage user settings | Fleet for osquery",
+  },
+  {
+    path: "/settings/teams/members",
+    title: "Manage team members | Fleet for osquery",
+  },
+  {
+    path: "/settings/teams/options",
+    title: "Manage team options | Fleet for osquery",
+  },
+  {
+    path: "/settings/teams",
+    title: "Manage team settings | Fleet for osquery",
+  },
+  {
+    path: "/profile",
+    title: "Manage my account | Fleet for osquery",
+  },
+];

--- a/frontend/router/paths.ts
+++ b/frontend/router/paths.ts
@@ -1,6 +1,7 @@
 import { IPolicy } from "../interfaces/policy";
 import URL_PREFIX from "./url_prefix";
 
+// Note: changes to paths.ts should change page_titles.ts respectively
 export default {
   ROOT: `${URL_PREFIX}/`,
   CONTROLS: `${URL_PREFIX}/controls`,


### PR DESCRIPTION
## Issue
First half of #13205 

## Description
- Page titles appear for all major pages of Fleet UI
  - Page titles created match patterns found on titles of the fleetdm.com website (e.g. "{page title here} | Fleet for osquery"
- Dynamic titles are rendered for host details, software details, query details, and policy details to include the name of the respective source

## Screen shots on various browsers
<img width="1002" alt="Screenshot 2023-08-15 at 12 12 08 PM" src="https://github.com/fleetdm/fleet/assets/71795832/6a120a97-6008-4499-9ee0-0cead48e13b2">
<img width="1570" alt="Screenshot 2023-08-15 at 12 11 25 PM" src="https://github.com/fleetdm/fleet/assets/71795832/5426044d-8c4a-4a32-b8b9-3a320255adc7">
<img width="1405" alt="Screenshot 2023-08-15 at 12 10 51 PM" src="https://github.com/fleetdm/fleet/assets/71795832/d028825a-954d-473f-824a-1145a2ac0f03">


## Dev testing
- Manually tested on Chrome, Firefox, Safari

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

