### PR TITLE
Fleet UI: [4.36 unreleased bug] Dropdown width styling fix

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -6,8 +6,6 @@
     .controls {
       // vulnerable software dropdown filter
       .Select {
-        width: 225px;
-
         .Select-menu-outer {
           width: 364px;
           max-height: 310px;
@@ -19,19 +17,13 @@
         .Select-value {
           padding-left: $pad-medium;
           padding-right: $pad-medium;
-
-          &::before {
-            display: inline-block;
-            position: absolute;
-            padding: 5px 0 0 0; // centers spin
-            content: url(../assets/images/icon-filter-black-16x16@2x.png);
-            transform: scale(0.5);
-            height: 26px;
-            left: 2px;
-          }
         }
         .Select-value-label {
           padding-left: $pad-large;
+          font-size: $small !important;
+        }
+        .dropdown__custom-value-label {
+          width: 155px; // Override 105px for longer text options
           font-size: $small !important;
         }
       }

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -18,13 +18,9 @@
           padding-left: $pad-medium;
           padding-right: $pad-medium;
         }
-        .Select-value-label {
-          padding-left: $pad-large;
-          font-size: $small !important;
-        }
+
         .dropdown__custom-value-label {
           width: 155px; // Override 105px for longer text options
-          font-size: $small !important;
         }
       }
     }

--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -73,7 +73,6 @@
             margin: 0;
           }
           .manage-software-page__vuln_dropdown {
-            width: 225px;
             .Select-menu-outer {
               width: 364px;
               max-height: 310px;
@@ -84,19 +83,13 @@
             .Select-value {
               padding-left: $pad-medium;
               padding-right: $pad-medium;
-              &::before {
-                display: inline-block;
-                position: absolute;
-                padding: 5px 0 0 0; // centers spin
-                content: url(../assets/images/icon-filter-black-16x16@2x.png);
-                transform: scale(0.5);
-                height: 26px;
-                left: 2px;
-              }
             }
             .Select-value-label {
               padding-left: $pad-large;
               font-size: $small !important;
+            }
+            .dropdown__custom-value-label {
+              width: 155px; // Override 105
             }
           }
         }

--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -84,10 +84,6 @@
               padding-left: $pad-medium;
               padding-right: $pad-medium;
             }
-            .Select-value-label {
-              padding-left: $pad-large;
-              font-size: $small !important;
-            }
             .dropdown__custom-value-label {
               width: 155px; // Override 105px for longer text options
             }

--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -74,7 +74,7 @@
           }
           .manage-software-page__vuln_dropdown {
             .Select-menu-outer {
-              width: 364px;
+              width: 250px;
               max-height: 310px;
               .Select-menu {
                 max-height: none;

--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -89,7 +89,7 @@
               font-size: $small !important;
             }
             .dropdown__custom-value-label {
-              width: 155px; // Override 105
+              width: 155px; // Override 105px for longer text options
             }
           }
         }


### PR DESCRIPTION
## Issue
None, unreleased, caught by me on main

## Screen recording of current `main`

https://github.com/fleetdm/fleet/assets/71795832/1b79c8cc-e045-4516-9e5b-9de21f1ab697

Also, bleeding off the screen fix
<img width="337" alt="Screenshot 2023-08-15 at 4 11 09 PM" src="https://github.com/fleetdm/fleet/assets/71795832/f9611771-1e66-46c0-9f38-0f1b3efb5e52">


##  Fix on this PR

https://github.com/fleetdm/fleet/assets/71795832/a4e1bf5c-02a8-4c57-a52e-8eda82d272a7


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality