### PR TITLE
Fleet UI: [feature] All table links can open in a new tab

### DIFF
--- a/changes/13205-table-links-can-open-in-new-tab
+++ b/changes/13205-table-links-can-open-in-new-tab
@@ -1,0 +1,1 @@
+* All table links are right-clickable

--- a/frontend/components/LiveQuery/TargetsInput/_styles.scss
+++ b/frontend/components/LiveQuery/TargetsInput/_styles.scss
@@ -74,12 +74,6 @@
   &__hosts-selected-table {
     margin-top: 8px;
 
-    img {
-      cursor: pointer;
-      transform: scale(0.5);
-      position: relative;
-      top: 2px;
-    }
     .data-table__wrapper {
       width: 100%;
       overflow: auto;

--- a/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tests.tsx
+++ b/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tests.tsx
@@ -7,13 +7,12 @@ import LinkCell from "./LinkCell";
 
 const VALUE = "40 hosts";
 describe("Link cell", () => {
-  it("renders text and path", async () => {
+  it("renders text", async () => {
     const { user } = renderWithSetup(
       <LinkCell value={VALUE} path={PATHS.MANAGE_HOSTS} />
     );
 
-    await user.click(screen.getByText("40 hosts"));
-
-    expect(window.location.pathname).toContain("/hosts");
+    expect(screen.getByText("40 hosts")).toBeInTheDocument();
+    // Note: Testing react-router Link would require Router or MemoryRouter wrapper which is app level
   });
 });

--- a/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tsx
+++ b/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tsx
@@ -1,19 +1,15 @@
+// Utilizes Link over Button so we can right click links
 import React from "react";
 
-// using browserHistory directly because "router"
-// is difficult to pass as a prop
-import { browserHistory, Link } from "react-router";
+import { Link } from "react-router";
 import classnames from "classnames";
-
-import Button from "components/buttons/Button/Button";
 
 interface ILinkCellProps {
   value: string | JSX.Element;
   path: string;
-  title?: string;
   className?: string;
   customOnClick?: (e: React.MouseEvent) => void;
-  /** allows viewing of tooltip */
+  /** allows viewing overflow for tooltip */
   withTooltip?: boolean;
 }
 
@@ -22,7 +18,6 @@ const baseClass = "link-cell";
 const LinkCell = ({
   value,
   path,
-  title,
   className,
   customOnClick,
   withTooltip,
@@ -32,27 +27,15 @@ const LinkCell = ({
     className,
     withTooltip && "link-cell-tooltip"
   );
-  console.log("cellClassess", cellClasses);
 
   const onClick = (e: React.MouseEvent): void => {
     customOnClick && customOnClick(e);
-    // browserHistory.push(path);
   };
 
   return (
     <Link className={cellClasses} to={path} onClick={onClick}>
       {value}
     </Link>
-  );
-  return (
-    <Button
-      className={`link-cell ${classes}`}
-      onClick={onClick}
-      variant="text-link"
-      title={title}
-    >
-      {value}
-    </Button>
   );
 };
 

--- a/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tsx
+++ b/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 // using browserHistory directly because "router"
 // is difficult to pass as a prop
-import { browserHistory } from "react-router";
+import { browserHistory, Link } from "react-router";
 
 import Button from "components/buttons/Button/Button";
 
@@ -26,6 +26,11 @@ const LinkCell = ({
     browserHistory.push(path);
   };
 
+  return (
+    <Link className={`link-cell ${classes}`} to={path}>
+      {value}
+    </Link>
+  );
   return (
     <Button
       className={`link-cell ${classes}`}

--- a/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tsx
+++ b/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tsx
@@ -11,6 +11,7 @@ interface ILinkCellProps {
   customOnClick?: (e: React.MouseEvent) => void;
   /** allows viewing overflow for tooltip */
   withTooltip?: boolean;
+  title?: string;
 }
 
 const baseClass = "link-cell";
@@ -21,6 +22,7 @@ const LinkCell = ({
   className,
   customOnClick,
   withTooltip,
+  title,
 }: ILinkCellProps): JSX.Element => {
   const cellClasses = classnames(
     baseClass,
@@ -33,7 +35,7 @@ const LinkCell = ({
   };
 
   return (
-    <Link className={cellClasses} to={path} onClick={onClick}>
+    <Link className={cellClasses} to={path} onClick={onClick} title={title}>
       {value}
     </Link>
   );

--- a/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tsx
+++ b/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tsx
@@ -3,6 +3,7 @@ import React from "react";
 // using browserHistory directly because "router"
 // is difficult to pass as a prop
 import { browserHistory, Link } from "react-router";
+import classnames from "classnames";
 
 import Button from "components/buttons/Button/Button";
 
@@ -10,24 +11,36 @@ interface ILinkCellProps {
   value: string | JSX.Element;
   path: string;
   title?: string;
-  classes?: string;
-  customOnClick?: () => void;
+  className?: string;
+  customOnClick?: (e: React.MouseEvent) => void;
+  /** allows viewing of tooltip */
+  withTooltip?: boolean;
 }
+
+const baseClass = "link-cell";
 
 const LinkCell = ({
   value,
   path,
   title,
-  classes,
+  className,
   customOnClick,
+  withTooltip,
 }: ILinkCellProps): JSX.Element => {
-  const onClick = (): void => {
-    customOnClick && customOnClick();
-    browserHistory.push(path);
+  const cellClasses = classnames(
+    baseClass,
+    className,
+    withTooltip && "link-cell-tooltip"
+  );
+  console.log("cellClassess", cellClasses);
+
+  const onClick = (e: React.MouseEvent): void => {
+    customOnClick && customOnClick(e);
+    // browserHistory.push(path);
   };
 
   return (
-    <Link className={`link-cell ${classes}`} to={path}>
+    <Link className={cellClasses} to={path} onClick={onClick}>
       {value}
     </Link>
   );

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -242,7 +242,7 @@ $shadow-transition-width: 10px;
         }
         // css to properly style link-cell with tooltip
         .link-cell-tooltip {
-          overflow: visible; // fixes tooltip cut off within cell
+          overflow: visible; // fixes tooltip overflow cut off by cell
           .component__tooltip-wrapper {
             display: block;
             white-space: nowrap; // single line

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -215,7 +215,6 @@ $shadow-transition-width: 10px;
         }
         .link-cell,
         .text-cell {
-          display: inline-flex;
           overflow: hidden;
           white-space: nowrap;
           text-overflow: ellipsis;
@@ -224,16 +223,40 @@ $shadow-transition-width: 10px;
             white-space: normal;
           }
         }
+        .text-cell {
+          display: inline-flex;
+        }
         .link-cell {
+          display: block;
+          padding: $pad-small 0; // larger clickable area
+
           &:hover {
             text-decoration: underline;
           }
-
           > div {
             display: block;
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
+          }
+        }
+        // css to properly style link-cell with tooltip
+        .link-cell-tooltip {
+          overflow: visible; // fixes tooltip cut off within cell
+          .component__tooltip-wrapper {
+            display: block;
+            white-space: nowrap; // single line
+            margin: 0; // padding applied to .link-cell for larger clickable area
+            .component__tooltip-wrapper__element {
+              display: block;
+              white-space: nowrap; // single line
+              text-overflow: ellipsis; // truncates text
+              overflow: hidden;
+
+              .component__tooltip-wrapper__underline {
+                max-width: 100%; // fixes underline overflowing past truncated text
+              }
+            }
           }
         }
         .w400 {

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -215,13 +215,25 @@ $shadow-transition-width: 10px;
         }
         .link-cell,
         .text-cell {
-          display: block;
+          display: inline-flex;
           overflow: hidden;
           white-space: nowrap;
           text-overflow: ellipsis;
           margin: 0;
           .__react_component_tooltip {
             white-space: normal;
+          }
+        }
+        .link-cell {
+          &:hover {
+            text-decoration: underline;
+          }
+
+          > div {
+            display: block;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
           }
         }
         .w400 {

--- a/frontend/pages/hosts/ManageHostsPage/components/FilterPill/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/FilterPill/_styles.scss
@@ -32,7 +32,6 @@
     .premium-icon-tip {
       .premium-feature-icon {
         position: relative;
-        top: 2px;
         margin-right: 6px;
       }
     }

--- a/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { InjectedRouter, Link } from "react-router";
+import { InjectedRouter } from "react-router";
 import ReactTooltip from "react-tooltip";
 
 import { formatDistanceToNow } from "date-fns";
@@ -7,9 +7,9 @@ import { formatDistanceToNow } from "date-fns";
 import { ISoftware } from "interfaces/software";
 import PATHS from "router/paths";
 
-import Button from "components/buttons/Button";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";
 import TextCell from "components/TableContainer/DataTable/TextCell";
+import LinkCell from "components/TableContainer/DataTable/LinkCell";
 import TooltipWrapper from "components/TooltipWrapper";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
@@ -215,19 +215,13 @@ export const generateSoftwareTableHeaders = ({
         };
 
         return (
-          <Link
-            className="link-cell"
-            to={PATHS.SOFTWARE_DETAILS(id.toString())}
-            onClick={onClickSoftware}
-          >
-            {bundle ? renderBundleTooltip(name, bundle) : name}
-          </Link>
+          <LinkCell
+            path={PATHS.SOFTWARE_DETAILS(id.toString())}
+            customOnClick={onClickSoftware}
+            value={bundle ? renderBundleTooltip(name, bundle) : name}
+            withTooltip={!!bundle}
+          />
         );
-        // return (
-        //   <Button onClick={onClickSoftware} variant="text-link">
-        //     {bundle ? renderBundleTooltip(name, bundle) : name}
-        //   </Button>
-        // );
       },
       sortType: "caseInsensitive",
     },

--- a/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { InjectedRouter } from "react-router";
+import { InjectedRouter, Link } from "react-router";
 import ReactTooltip from "react-tooltip";
 
 import { formatDistanceToNow } from "date-fns";
@@ -215,10 +215,19 @@ export const generateSoftwareTableHeaders = ({
         };
 
         return (
-          <Button onClick={onClickSoftware} variant="text-link">
+          <Link
+            className="link-cell"
+            to={PATHS.SOFTWARE_DETAILS(id.toString())}
+            onClick={onClickSoftware}
+          >
             {bundle ? renderBundleTooltip(name, bundle) : name}
-          </Button>
+          </Link>
         );
+        // return (
+        //   <Button onClick={onClickSoftware} variant="text-link">
+        //     {bundle ? renderBundleTooltip(name, bundle) : name}
+        //   </Button>
+        // );
       },
       sortType: "caseInsensitive",
     },

--- a/frontend/pages/policies/ManagePoliciesPage/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/_styles.scss
@@ -157,19 +157,25 @@
     position: relative;
   }
 
-  .policy-name-cell {
-    .children-wrapper {
-      display: flex;
-      align-items: center;
-      gap: 2px;
+  .policies-table {
+    .data-table-block {
+      .data-table {
+        tbody {
+          .name__cell {
+            .policy-name-cell {
+              display: flex; // required for inline icon
 
-      .tooltip-base {
-        display: inline-flex;
-      }
+              .tooltip-base {
+                display: inline-flex;
+              }
 
-      .policy-name-text {
-        text-overflow: ellipsis;
-        overflow: hidden;
+              .policy-name-text {
+                text-overflow: ellipsis;
+                overflow: hidden;
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -117,7 +117,7 @@ const generateTableHeaders = (
       accessor: "name",
       Cell: (cellProps: ICellProps): JSX.Element => (
         <LinkCell
-          classes="w250 policy-name-cell"
+          className="w250 policy-name-cell"
           value={
             <>
               <div className="policy-name-text">{cellProps.cell.value}</div>

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -135,13 +135,25 @@
             .name__cell {
               max-width: $col-lg;
 
+              .query-name-cell {
+                display: flex; // required for inline icon
+                .children-wrapper {
+                  .query-name-text {
+                    text-overflow: ellipsis;
+                    overflow: hidden;
+                  }
+                }
+              }
+              .query-icon {
+                display: block;
+              }
+
               .children-wrapper {
                 display: flex;
                 gap: $pad-xsmall;
-
-                .observer-can-run-tooltip {
-                  font-weight: $regular;
-                }
+              }
+              .observer-can-run-tooltip {
+                font-weight: $regular;
               }
             }
 
@@ -176,18 +188,6 @@
           }
         }
       }
-    }
-
-    .query-name-cell {
-      .children-wrapper {
-        .query-name-text {
-          text-overflow: ellipsis;
-          overflow: hidden;
-        }
-      }
-    }
-    .query-icon {
-      display: block;
     }
   }
 }

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -187,8 +187,6 @@
       }
     }
     .query-icon {
-      position: relative;
-      top: 2px;
       display: block;
     }
   }

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -125,7 +125,7 @@ const generateTableHeaders = ({
       Cell: (cellProps: ICellProps): JSX.Element => {
         return (
           <LinkCell
-            classes="w400 query-name-cell"
+            className="w400 query-name-cell"
             value={
               <>
                 <div className="query-name-text">{cellProps.cell.value}</div>

--- a/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
@@ -9,9 +9,9 @@ import PATHS from "router/paths";
 import { formatFloatAsPercentage } from "utilities/helpers";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 
-import Button from "components/buttons/Button";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 import TextCell from "components/TableContainer/DataTable/TextCell";
+import LinkCell from "components/TableContainer/DataTable/LinkCell/LinkCell";
 import TooltipWrapper from "components/TooltipWrapper";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 import PremiumFeatureIconWithTooltip from "components/PremiumFeatureIconWithTooltip";
@@ -214,9 +214,12 @@ const generateTableHeaders = (
         };
 
         return (
-          <Button onClick={onClickSoftware} variant="text-link">
-            {bundle ? renderBundleTooltip(name, bundle) : name}
-          </Button>
+          <LinkCell
+            path={PATHS.SOFTWARE_DETAILS(id.toString())}
+            customOnClick={onClickSoftware}
+            value={bundle ? renderBundleTooltip(name, bundle) : name}
+            withTooltip={!!bundle}
+          />
         );
       },
       sortType: "caseInsensitive",

--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -154,12 +154,10 @@
                   display: table-cell;
                 }
               }
-              @media (min-width: $break-md) {
+              @media (min-width: $break-lg) {
                 .version__header {
                   width: $col-md;
                 }
-              }
-              @media (min-width: $break-lg) {
                 .source__header {
                   display: table-cell;
                 }
@@ -168,8 +166,7 @@
 
             tbody {
               .name__cell {
-                width: $col-md;
-
+                max-width: $col-md;
                 // Tooltip does not get cut off
                 .children-wrapper {
                   overflow: initial;
@@ -204,9 +201,9 @@
                   }
                 }
               }
-              @media (min-width: $break-md) {
-                .version_cell {
-                  width: $col-md;
+              @media (min-width: $break-sm) {
+                .name__cell {
+                  max-width: $col-lg;
                 }
               }
               @media (min-width: $break-md) {
@@ -215,6 +212,9 @@
                 }
               }
               @media (min-width: $break-lg) {
+                .version_cell {
+                  width: $col-md;
+                }
                 .source__cell {
                   display: table-cell;
                 }


### PR DESCRIPTION
## Issue
Part of issue #13205

## Description
- Updates all table links to be right-clickable
- Includes table links that have a tooltip (e.g., host details > software table, manage software page)
- Fixes any styling issues introduced by switching from button to link
  - Fixes icon next to link to be inline (e.g., manage queries page, manage policies page)
  - Fixes text wrapping/truncation issues (e.g., software tables with tooltip)

## Screenrecording of BEFORE

https://github.com/fleetdm/fleet/assets/71795832/fc24553f-da94-4a98-8b03-cdabcfdb32d7

## Screenrecording of fix AFTER

https://github.com/fleetdm/fleet/assets/71795832/809d3cfa-531a-420a-b67a-6b8a0936d5c6


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [ ] Manual QA for all new/changed functionality

