### PR TITLE
Updating desktop-linux builder to Debian 12 to resolve glibc

### DIFF
--- a/.github/workflows/test-native-tooling-packaging.yml
+++ b/.github/workflows/test-native-tooling-packaging.yml
@@ -15,6 +15,7 @@ on:
       - 'server/context/**.go'
       - 'orbit/**.go'
       - 'ee/fleetctl/**.go'
+      - 'Dockerfile-desktop-linux'
       - 'tools/fleetctl-docker/**'
       - 'tools/wix-docker/**'
       - 'tools/bomutils-docker/**'

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -17,6 +17,7 @@ on:
       - 'server/context/**.go'
       - 'orbit/**.go'
       - 'ee/fleetctl/**.go'
+      - 'Dockerfile-desktop-linux'
       - 'tools/fleetctl-docker/**'
       - 'tools/wix-docker/**'
       - 'tools/bomutils-docker/**'

--- a/Dockerfile-desktop-linux
+++ b/Dockerfile-desktop-linux
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.20.5-bullseye@sha256:419bc8954c0e08c539830c8669ccd116a063303481c748fabd09d8fd6d4e2c5f
+FROM --platform=linux/amd64 golang:1.20.7-bookworm@sha256:3d0878a1192d931876c9f21feb06beaf2771d2e53d6a3092093cf84b9205c1c1
 LABEL maintainer="Fleet Developers"
 
 RUN apt-get update && apt-get install -y \

--- a/changes/12351-11958-update-linux-desktop-builder
+++ b/changes/12351-11958-update-linux-desktop-builder
@@ -1,0 +1,1 @@
+Updating docker base for linux desktop builder to use debian 12 which includes glibc2.36 as the base.


### PR DESCRIPTION
Our workflows use debian:latest or debian:latest-slim in most cases which updated to use Debian 12 which includes glibc version 2.36. The desktop builder was locked on bullseye or Debian 11 which only supports glibc2.31 and our package process was untarring the build from Debian 11 and copying the shared object library files we package to override the hosts shared library files thus resulting in glibc thinking it's still on 2.31 when it was just the libm.so.6 library that we replaced.

This update will use Debian 12 to build the tar ball and should resolve the conflicts found in https://github.com/fleetdm/fleet/issues/12351 and https://github.com/fleetdm/fleet/issues/11958

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
