### PR TITLE
Automation: Only attach #g-ceo label if not draft

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -410,13 +410,13 @@ module.exports = {
 
         // Add the appropriate label to PRs awaiting review from the CEO so that these PRs show up in kanban.
         // [?] https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=edited#pull_request
-        let isPRStillDependentOnCeoReview = expectedReviewers.includes('mikermcneil');
-        if (isPRStillDependentOnCeoReview && !existingLabels.includes('#g-ceo')) {
+        let isPRStillDependentOnAndReadyForCeoReview = expectedReviewers.includes('mikermcneil') && !issueOrPr.draft;
+        if (isPRStillDependentOnAndReadyForCeoReview && !existingLabels.includes('#g-ceo')) {
           // [?] https://docs.github.com/en/rest/issues/labels#add-labels-to-an-issue
           await sails.helpers.http.post(`https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/labels`, {
             labels: ['#g-ceo']
           }, baseHeaders);
-        } else if (!isPRStillDependentOnCeoReview && existingLabels.includes('#g-ceo')) {
+        } else if (!isPRStillDependentOnAndReadyForCeoReview && existingLabels.includes('#g-ceo')) {
           // [?] https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#remove-a-label-from-an-issue
           await sails.helpers.http.del(`https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/labels/${encodeURIComponent('#g-ceo')}`, {}, baseHeaders);
         }//ﬁ


### PR DESCRIPTION
Why? So it doesn't show up in the #g-ceo board until it's time to review it
