### PR TITLE
Fleet UI: Live query UI and export results tables include all columns returned

### DIFF
--- a/changes/12476-ui-export-shows-all-columns
+++ b/changes/12476-ui-export-shows-all-columns
@@ -1,0 +1,1 @@
+- Bug fix: Live query UI and Export data tables show all returned columns

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1286,7 +1286,6 @@ const ManageHostsPage = ({
       { [`${baseClass}__status-dropdown-sandbox`]: isSandboxMode }
     );
 
-    console.log("status", status);
     return (
       <div className={`${baseClass}__filter-dropdowns`}>
         <Dropdown

--- a/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
@@ -1,12 +1,10 @@
 import React, { useState, useContext } from "react";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import classnames from "classnames";
-import { format } from "date-fns";
 import FileSaver from "file-saver";
 import { get } from "lodash";
 import { PolicyContext } from "context/policy";
 
-import convertToCSV from "utilities/convert_to_csv";
 import {
   generateCSVFilename,
   generateCSVPolicyResults,
@@ -39,7 +37,7 @@ interface IQueryResultsProps {
 }
 
 const baseClass = "query-results";
-const CSV_TITLE = "New Policy Results";
+const CSV_TITLE = "New Policy";
 const NAV_TITLES = {
   RESULTS: "Results",
   ERRORS: "Errors",
@@ -80,7 +78,7 @@ const QueryResults = ({
       FileSaver.saveAs(
         generateCSVPolicyResults(
           hostsExport,
-          generateCSVFilename(policyName || CSV_TITLE)
+          generateCSVFilename(`${policyName || CSV_TITLE} - Results`)
         )
       );
     }
@@ -93,7 +91,7 @@ const QueryResults = ({
       FileSaver.saveAs(
         generateCSVPolicyErrors(
           errors,
-          generateCSVFilename(`${policyName || CSV_TITLE} | Errors`)
+          generateCSVFilename(`${policyName || CSV_TITLE} - Errors`)
         )
       );
     }

--- a/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
@@ -63,41 +63,41 @@ const QueryResults = ({
   const onExportQueryResults = (evt: React.MouseEvent<HTMLButtonElement>) => {
     evt.preventDefault();
 
-    if (hostsOnline) {
-      const hostsExport = hostsOnline.map((host) => {
-        return {
-          host: host.display_name,
-          status:
-            host.query_results && host.query_results.length ? "yes" : "no",
-        };
-      });
-      const csv = convertToCSV(hostsExport);
-      const formattedTime = format(new Date(), "MM-dd-yy hh-mm-ss");
-      const filename = `${policyName || CSV_TITLE} (${formattedTime}).csv`;
-      const file = new global.window.File([csv], filename, {
-        type: "text/csv",
-      });
+    // if (hostsOnline) {
+    //   const hostsExport = hostsOnline.map((host) => {
+    //     return {
+    //       host: host.display_name,
+    //       status:
+    //         host.query_results && host.query_results.length ? "yes" : "no",
+    //     };
+    //   });
+    //   const csv = convertToCSV(hostsExport);
+    //   const formattedTime = format(new Date(), "MM-dd-yy hh-mm-ss");
+    //   const filename = `${policyName || CSV_TITLE} (${formattedTime}).csv`;
+    //   const file = new global.window.File([csv], filename, {
+    //     type: "text/csv",
+    //   });
 
-      FileSaver.saveAs(file);
-    }
+    //   FileSaver.saveAs(file);
+    // }
   };
 
   const onExportErrorsResults = (evt: React.MouseEvent<HTMLButtonElement>) => {
     evt.preventDefault();
 
-    if (errors) {
-      const csv = convertToCSV(errors);
+    // if (errors) {
+    //   const csv = convertToCSV(errors);
 
-      const formattedTime = format(new Date(), "MM-dd-yy hh-mm-ss");
-      const filename = `${
-        policyName || CSV_TITLE
-      } Errors (${formattedTime}).csv`;
-      const file = new global.window.File([csv], filename, {
-        type: "text/csv",
-      });
+    //   const formattedTime = format(new Date(), "MM-dd-yy hh-mm-ss");
+    //   const filename = `${
+    //     policyName || CSV_TITLE
+    //   } Errors (${formattedTime}).csv`;
+    //   const file = new global.window.File([csv], filename, {
+    //     type: "text/csv",
+    //   });
 
-      FileSaver.saveAs(file);
-    }
+    //   FileSaver.saveAs(file);
+    // }
   };
 
   const onShowQueryModal = () => {

--- a/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
@@ -63,41 +63,41 @@ const QueryResults = ({
   const onExportQueryResults = (evt: React.MouseEvent<HTMLButtonElement>) => {
     evt.preventDefault();
 
-    // if (hostsOnline) {
-    //   const hostsExport = hostsOnline.map((host) => {
-    //     return {
-    //       host: host.display_name,
-    //       status:
-    //         host.query_results && host.query_results.length ? "yes" : "no",
-    //     };
-    //   });
-    //   const csv = convertToCSV(hostsExport);
-    //   const formattedTime = format(new Date(), "MM-dd-yy hh-mm-ss");
-    //   const filename = `${policyName || CSV_TITLE} (${formattedTime}).csv`;
-    //   const file = new global.window.File([csv], filename, {
-    //     type: "text/csv",
-    //   });
+    if (hostsOnline) {
+      const hostsExport = hostsOnline.map((host) => {
+        return {
+          host: host.display_name,
+          status:
+            host.query_results && host.query_results.length ? "yes" : "no",
+        };
+      });
+      const csv = convertToCSV({ objArray: hostsExport });
+      const formattedTime = format(new Date(), "MM-dd-yy hh-mm-ss");
+      const filename = `${policyName || CSV_TITLE} (${formattedTime}).csv`;
+      const file = new global.window.File([csv], filename, {
+        type: "text/csv",
+      });
 
-    //   FileSaver.saveAs(file);
-    // }
+      FileSaver.saveAs(file);
+    }
   };
 
   const onExportErrorsResults = (evt: React.MouseEvent<HTMLButtonElement>) => {
     evt.preventDefault();
 
-    // if (errors) {
-    //   const csv = convertToCSV(errors);
+    if (errors) {
+      const csv = convertToCSV({ objArray: errors });
 
-    //   const formattedTime = format(new Date(), "MM-dd-yy hh-mm-ss");
-    //   const filename = `${
-    //     policyName || CSV_TITLE
-    //   } Errors (${formattedTime}).csv`;
-    //   const file = new global.window.File([csv], filename, {
-    //     type: "text/csv",
-    //   });
+      const formattedTime = format(new Date(), "MM-dd-yy hh-mm-ss");
+      const filename = `${
+        policyName || CSV_TITLE
+      } Errors (${formattedTime}).csv`;
+      const file = new global.window.File([csv], filename, {
+        type: "text/csv",
+      });
 
-    //   FileSaver.saveAs(file);
-    // }
+      FileSaver.saveAs(file);
+    }
   };
 
   const onShowQueryModal = () => {

--- a/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
@@ -7,6 +7,11 @@ import { get } from "lodash";
 import { PolicyContext } from "context/policy";
 
 import convertToCSV from "utilities/convert_to_csv";
+import {
+  generateCSVFilename,
+  generateCSVPolicyResults,
+  generateCSVPolicyErrors,
+} from "utilities/generate_csv";
 import { ICampaign } from "interfaces/campaign";
 import { ITarget } from "interfaces/target";
 
@@ -34,7 +39,7 @@ interface IQueryResultsProps {
 }
 
 const baseClass = "query-results";
-const CSV_TITLE = "New Policy";
+const CSV_TITLE = "New Policy Results";
 const NAV_TITLES = {
   RESULTS: "Results",
   ERRORS: "Errors",
@@ -71,14 +76,13 @@ const QueryResults = ({
             host.query_results && host.query_results.length ? "yes" : "no",
         };
       });
-      const csv = convertToCSV({ objArray: hostsExport });
-      const formattedTime = format(new Date(), "MM-dd-yy hh-mm-ss");
-      const filename = `${policyName || CSV_TITLE} (${formattedTime}).csv`;
-      const file = new global.window.File([csv], filename, {
-        type: "text/csv",
-      });
 
-      FileSaver.saveAs(file);
+      FileSaver.saveAs(
+        generateCSVPolicyResults(
+          hostsExport,
+          generateCSVFilename(policyName || CSV_TITLE)
+        )
+      );
     }
   };
 
@@ -86,17 +90,12 @@ const QueryResults = ({
     evt.preventDefault();
 
     if (errors) {
-      const csv = convertToCSV({ objArray: errors });
-
-      const formattedTime = format(new Date(), "MM-dd-yy hh-mm-ss");
-      const filename = `${
-        policyName || CSV_TITLE
-      } Errors (${formattedTime}).csv`;
-      const file = new global.window.File([csv], filename, {
-        type: "text/csv",
-      });
-
-      FileSaver.saveAs(file);
+      FileSaver.saveAs(
+        generateCSVPolicyErrors(
+          errors,
+          generateCSVFilename(`${policyName || CSV_TITLE} | Errors`)
+        )
+      );
     }
   };
 

--- a/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
@@ -35,7 +35,7 @@ interface IQueryResultsProps {
 }
 
 const baseClass = "query-results";
-const CSV_QUERY_TITLE = "New Query Results";
+const CSV_TITLE = "New Query";
 const NAV_TITLES = {
   RESULTS: "Results",
   ERRORS: "Errors",
@@ -119,7 +119,7 @@ const QueryResults = ({
     FileSaver.saveAs(
       generateCSVQueryResults(
         filteredResults,
-        generateCSVFilename(queryName || CSV_QUERY_TITLE),
+        generateCSVFilename(`${queryName || CSV_TITLE} - Results`),
         tableHeaders
       )
     );
@@ -131,7 +131,7 @@ const QueryResults = ({
     FileSaver.saveAs(
       generateCSVQueryResults(
         filteredErrors,
-        generateCSVFilename(`${queryName || CSV_QUERY_TITLE} | Errors`),
+        generateCSVFilename(`${queryName || CSV_TITLE} - Errors`),
         errorTableHeaders
       )
     );

--- a/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
@@ -84,15 +84,10 @@ const QueryResults = ({
   }, [queryResults, debounceQueryResults]);
 
   useEffect(() => {
-    console.log("USEEFFECT TO SET TABLE HEADERS IS CALLED");
-    console.log("tableHeaders", tableHeaders);
-    console.log("queryResults", queryResults);
     if (queryResults && queryResults.length > 0) {
       const generatedTableHeaders = generateResultsTableHeaders(queryResults);
-      console.log("generatedTableHeaders", generatedTableHeaders);
       // Update tableHeaders if new headers are found
       if (generatedTableHeaders !== tableHeaders) {
-        console.log("tableHeaders updated", tableHeaders);
         setTableHeaders(generatedTableHeaders);
       }
     }
@@ -115,7 +110,6 @@ const QueryResults = ({
 
   const onExportQueryResults = (evt: React.MouseEvent<HTMLButtonElement>) => {
     evt.preventDefault();
-    console.log("filteredResults", filteredResults);
     FileSaver.saveAs(
       generateCSVQueryResults(
         filteredResults,

--- a/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
@@ -2,12 +2,14 @@ import React, { useState, useContext, useEffect, useCallback } from "react";
 import { Row, Column } from "react-table";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import classnames from "classnames";
-import { format } from "date-fns";
 import FileSaver from "file-saver";
 import { QueryContext } from "context/query";
 import { useDebouncedCallback } from "use-debounce";
 
-import generateExportCSVFile from "utilities/generate_csv";
+import {
+  generateCSVFilename,
+  generateCSVQueryResults,
+} from "utilities/generate_csv";
 import { ICampaign } from "interfaces/campaign";
 import { ITarget } from "interfaces/target";
 
@@ -24,6 +26,7 @@ import generateResultsTableHeaders from "./QueryResultsTableConfig";
 interface IQueryResultsProps {
   campaign: ICampaign;
   isQueryFinished: boolean;
+  queryName?: string;
   onRunQuery: () => void;
   onStopQuery: (evt: React.MouseEvent<HTMLButtonElement>) => void;
   setSelectedTargets: (value: ITarget[]) => void;
@@ -32,19 +35,16 @@ interface IQueryResultsProps {
 }
 
 const baseClass = "query-results";
-const CSV_QUERY_TITLE = "Query Results";
+const CSV_QUERY_TITLE = "New Query Results";
 const NAV_TITLES = {
   RESULTS: "Results",
   ERRORS: "Errors",
 };
 
-const generateExportFilename = (descriptor: string) => {
-  return `${descriptor} (${format(new Date(), "MM-dd-yy hh-mm-ss")}).csv`;
-};
-
 const QueryResults = ({
   campaign,
   isQueryFinished,
+  queryName,
   onRunQuery,
   onStopQuery,
   setSelectedTargets,
@@ -117,9 +117,9 @@ const QueryResults = ({
     evt.preventDefault();
     console.log("filteredResults", filteredResults);
     FileSaver.saveAs(
-      generateExportCSVFile(
+      generateCSVQueryResults(
         filteredResults,
-        generateExportFilename(CSV_QUERY_TITLE),
+        generateCSVFilename(queryName || CSV_QUERY_TITLE),
         tableHeaders
       )
     );
@@ -129,9 +129,9 @@ const QueryResults = ({
     evt.preventDefault();
 
     FileSaver.saveAs(
-      generateExportCSVFile(
+      generateCSVQueryResults(
         filteredErrors,
-        generateExportFilename(`${CSV_QUERY_TITLE} Errors`),
+        generateCSVFilename(`${queryName || CSV_QUERY_TITLE} | Errors`),
         errorTableHeaders
       )
     );

--- a/frontend/pages/queries/QueryPage/components/QueryResults/QueryResultsTableConfig.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/QueryResultsTableConfig.tsx
@@ -48,14 +48,17 @@ const _unshiftHostname = (headers: IDataColumn[]) => {
 };
 
 const generateResultsTableHeaders = (results: any[]): Column[] => {
-  const keys = Array.from(
+  /* Results include an array of objects, each representing a table row
+  Each key value pair in an object represents a column name and value
+  To create headers, use JS set to create an array of all unique column names */
+  const uniqueColumnNames = Array.from(
     results.reduce(
       (s, o) => Object.keys(o).reduce((t, k) => t.add(k), s),
       new Set() // Set prevents listing duplicate headers
     )
   );
 
-  const headers = keys.map((key) => {
+  const headers = uniqueColumnNames.map((key) => {
     return {
       id: key as string,
       title: key as string,

--- a/frontend/pages/queries/QueryPage/components/QueryResults/QueryResultsTableConfig.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/QueryResultsTableConfig.tsx
@@ -54,7 +54,6 @@ const generateResultsTableHeaders = (results: any[]): Column[] => {
       new Set() // Set prevents listing duplicate headers
     )
   );
-  console.log("keys", keys);
 
   const headers = keys.map((key) => {
     return {

--- a/frontend/pages/queries/QueryPage/components/QueryResults/QueryResultsTableConfig.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/QueryResultsTableConfig.tsx
@@ -47,28 +47,26 @@ const _unshiftHostname = (headers: IDataColumn[]) => {
   return newHeaders;
 };
 
-const generateResultsTableHeaders = (results: unknown[]): Column[] => {
-  // Table headers are derived from the shape of the first result.
-  // Note: It is possible that results may vary from the shape of the first result.
-  // For example, different versions of osquery may have new columns in a table
-  // However, this is believed to be a very unlikely scenario and there have been
-  // no reported issues.
-  const shape = results[0];
-  const keys =
-    shape && typeof shape === "object" && isPlainObject(shape)
-      ? Object.keys(shape)
-      : [];
+const generateResultsTableHeaders = (results: any[]): Column[] => {
+  const keys = Array.from(
+    results.reduce(
+      (s, o) => Object.keys(o).reduce((t, k) => t.add(k), s),
+      new Set() // Set prevents listing duplicate headers
+    )
+  );
+  console.log("keys", keys);
+
   const headers = keys.map((key) => {
     return {
-      id: key,
-      title: key,
+      id: key as string,
+      title: key as string,
       Header: (headerProps: IHeaderProps) => (
         <HeaderCell
           value={headerProps.column.title || headerProps.column.id}
           isSortedDesc={headerProps.column.isSortedDesc}
         />
       ),
-      accessor: key,
+      accessor: key as string,
       Cell: (cellProps: ICellProps) => cellProps?.cell?.value || null,
       Filter: DefaultColumnFilter,
       // filterType: "text",

--- a/frontend/pages/queries/QueryPage/screens/RunQuery.tsx
+++ b/frontend/pages/queries/QueryPage/screens/RunQuery.tsx
@@ -205,6 +205,7 @@ const RunQuery = ({
       isQueryFinished={isQueryFinished}
       setSelectedTargets={setSelectedTargets}
       goToQueryEditor={goToQueryEditor}
+      queryName={storedQuery?.name}
       targetsTotalCount={targetsTotalCount}
     />
   );

--- a/frontend/utilities/convert_to_csv/convert_to_csv.tests.ts
+++ b/frontend/utilities/convert_to_csv/convert_to_csv.tests.ts
@@ -11,10 +11,10 @@ const objArray = [
   },
 ];
 
-// describe("convertToCSV - utility", () => {
-//   it("converts an array of objects to CSV format", () => {
-//     expect(convertToCSV(objArray)).toEqual(
-//       '"first_name","last_name"\n"Mike","Stone"\n"Paul","Simon"'
-//     );
-//   });
-// });
+describe("convertToCSV - utility", () => {
+  it("converts an array of objects to CSV format", () => {
+    expect(convertToCSV({ objArray })).toEqual(
+      '"first_name","last_name"\n"Mike","Stone"\n"Paul","Simon"'
+    );
+  });
+});

--- a/frontend/utilities/convert_to_csv/convert_to_csv.tests.ts
+++ b/frontend/utilities/convert_to_csv/convert_to_csv.tests.ts
@@ -11,10 +11,10 @@ const objArray = [
   },
 ];
 
-describe("convertToCSV - utility", () => {
-  it("converts an array of objects to CSV format", () => {
-    expect(convertToCSV(objArray)).toEqual(
-      '"first_name","last_name"\n"Mike","Stone"\n"Paul","Simon"'
-    );
-  });
-});
+// describe("convertToCSV - utility", () => {
+//   it("converts an array of objects to CSV format", () => {
+//     expect(convertToCSV(objArray)).toEqual(
+//       '"first_name","last_name"\n"Mike","Stone"\n"Paul","Simon"'
+//     );
+//   });
+// });

--- a/frontend/utilities/convert_to_csv/index.ts
+++ b/frontend/utilities/convert_to_csv/index.ts
@@ -1,11 +1,12 @@
 import { ICampaignError } from "interfaces/campaign";
+import { Row, Column } from "react-table";
 
 const defaultFieldSortFunc = (fields: string[]) => fields;
 
 interface ConvertToCSV {
-  objArray: any | ICampaignError[];
+  objArray: any; // TODO: typing
   fieldSortFunc?: (fields: string[]) => string[];
-  tableHeaders?: any; // TODO: typing
+  tableHeaders?: any[]; // TODO: typing
 }
 
 const convertToCSV = ({
@@ -17,12 +18,7 @@ const convertToCSV = ({
     ? tableHeaders.map((header: { id: string }) => header.id) // TODO: typing
     : Object.keys(objArray[0]);
 
-  console.log("objArray", objArray);
-
   const fields = fieldSortFunc(tableHeadersStrings);
-
-  console.log("tableHeaderStrings", tableHeadersStrings);
-  console.log("fields", fields);
 
   // TODO: Remove after v5 when host_hostname is removed rom API response.
   const hostNameIndex = fields.indexOf("host_hostname");
@@ -32,6 +28,7 @@ const convertToCSV = ({
   // Remove end
   const jsonFields = fields.map((field) => JSON.stringify(field));
   const rows = objArray.map((row: any) => {
+    // TODO: typing
     return fields.map((field) => JSON.stringify(row[field])).join(",");
   });
 

--- a/frontend/utilities/convert_to_csv/index.ts
+++ b/frontend/utilities/convert_to_csv/index.ts
@@ -1,19 +1,29 @@
-// import { keys } from "lodash"; // REMOVED
+import { ICampaignError } from "interfaces/campaign";
 
 const defaultFieldSortFunc = (fields: string[]) => fields;
 
-const convertToCSV = (
-  objArray: any[], // TODO: typing
-  fieldSortFunc = defaultFieldSortFunc,
-  tableHeaders: any // TODO: typing
-) => {
-  const tableHeadersStrings = tableHeaders.map((header: any) => header.title); // TODO: typing
+interface ConvertToCSV {
+  objArray: any | ICampaignError[];
+  fieldSortFunc?: (fields: string[]) => string[];
+  tableHeaders?: any[]; // TODO: typing
+}
 
-  console.log("convertToCSV objArray wtf", objArray);
-  // const fields = fieldSortFunc(keys(objArray[0])); // THIS IS WRONG, SHOULD NOT TAKE FIRST ROW ONLY
+const convertToCSV = ({
+  objArray,
+  fieldSortFunc = defaultFieldSortFunc,
+  tableHeaders,
+}: ConvertToCSV) => {
+  const tableHeadersStrings: string[] = tableHeaders
+    ? tableHeaders.map((header: { id: string }) => header.id) // TODO: typing
+    : [];
+
+  console.log("objArray");
+
   const fields = fieldSortFunc(tableHeadersStrings);
 
-  // TODO: 8/18 FIX HOST column on csv
+  console.log("tableHeaderStrings", tableHeadersStrings);
+  console.log("fields", fields);
+
   // TODO: Remove after v5 when host_hostname is removed rom API response.
   const hostNameIndex = fields.indexOf("host_hostname");
   if (hostNameIndex >= 0) {
@@ -21,7 +31,7 @@ const convertToCSV = (
   }
   // Remove end
   const jsonFields = fields.map((field) => JSON.stringify(field));
-  const rows = objArray.map((row) => {
+  const rows = objArray.map((row: any) => {
     return fields.map((field) => JSON.stringify(row[field])).join(",");
   });
 

--- a/frontend/utilities/convert_to_csv/index.ts
+++ b/frontend/utilities/convert_to_csv/index.ts
@@ -5,7 +5,7 @@ const defaultFieldSortFunc = (fields: string[]) => fields;
 interface ConvertToCSV {
   objArray: any | ICampaignError[];
   fieldSortFunc?: (fields: string[]) => string[];
-  tableHeaders?: any[]; // TODO: typing
+  tableHeaders?: any; // TODO: typing
 }
 
 const convertToCSV = ({
@@ -15,9 +15,9 @@ const convertToCSV = ({
 }: ConvertToCSV) => {
   const tableHeadersStrings: string[] = tableHeaders
     ? tableHeaders.map((header: { id: string }) => header.id) // TODO: typing
-    : [];
+    : Object.keys(objArray[0]);
 
-  console.log("objArray");
+  console.log("objArray", objArray);
 
   const fields = fieldSortFunc(tableHeadersStrings);
 

--- a/frontend/utilities/convert_to_csv/index.ts
+++ b/frontend/utilities/convert_to_csv/index.ts
@@ -1,12 +1,19 @@
-import { keys } from "lodash";
+// import { keys } from "lodash"; // REMOVED
 
 const defaultFieldSortFunc = (fields: string[]) => fields;
 
 const convertToCSV = (
-  objArray: any[],
-  fieldSortFunc = defaultFieldSortFunc
+  objArray: any[], // TODO: typing
+  fieldSortFunc = defaultFieldSortFunc,
+  tableHeaders: any // TODO: typing
 ) => {
-  const fields = fieldSortFunc(keys(objArray[0]));
+  const tableHeadersStrings = tableHeaders.map((header: any) => header.title); // TODO: typing
+
+  console.log("convertToCSV objArray wtf", objArray);
+  // const fields = fieldSortFunc(keys(objArray[0])); // THIS IS WRONG, SHOULD NOT TAKE FIRST ROW ONLY
+  const fields = fieldSortFunc(tableHeadersStrings);
+
+  // TODO: 8/18 FIX HOST column on csv
   // TODO: Remove after v5 when host_hostname is removed rom API response.
   const hostNameIndex = fields.indexOf("host_hostname");
   if (hostNameIndex >= 0) {

--- a/frontend/utilities/generate_csv/index.ts
+++ b/frontend/utilities/generate_csv/index.ts
@@ -1,0 +1,33 @@
+import convertToCSV from "utilities/convert_to_csv";
+import { Row, Column } from "react-table";
+
+const reorderCSVFields = (tableHeaders: string[]) => {
+  const result = tableHeaders.filter((field) => field !== "host_display_name");
+  result.unshift("host_display_name");
+
+  console.log("result", result);
+  return result;
+};
+
+const generateExportCSVFile = (
+  rows: Row[],
+  filename: string,
+  tableHeaders: Column[]
+) => {
+  console.log("generateExportCSVFile rows", rows);
+  return new global.window.File(
+    [
+      convertToCSV({
+        objArray: rows.map((r) => r.original),
+        fieldSortFunc: reorderCSVFields,
+        tableHeaders,
+      }),
+    ],
+    filename,
+    {
+      type: "text/csv",
+    }
+  );
+};
+
+export default generateExportCSVFile;

--- a/frontend/utilities/generate_csv/index.ts
+++ b/frontend/utilities/generate_csv/index.ts
@@ -1,5 +1,7 @@
 import convertToCSV from "utilities/convert_to_csv";
 import { Row, Column } from "react-table";
+import { ICampaignError } from "interfaces/campaign";
+import { format } from "date-fns";
 
 const reorderCSVFields = (tableHeaders: string[]) => {
   const result = tableHeaders.filter((field) => field !== "host_display_name");
@@ -9,10 +11,16 @@ const reorderCSVFields = (tableHeaders: string[]) => {
   return result;
 };
 
-const generateExportCSVFile = (
+export const generateCSVFilename = (descriptor: string) => {
+  return `${descriptor} (${format(new Date(), "MM-dd-yy hh-mm-ss")}).csv`;
+};
+
+// Query results and query errors
+export const generateCSVQueryResults = (
   rows: Row[],
+  // | ICampaignError[],
   filename: string,
-  tableHeaders: Column[]
+  tableHeaders: Column[] | string[]
 ) => {
   console.log("generateExportCSVFile rows", rows);
   return new global.window.File(
@@ -30,4 +38,40 @@ const generateExportCSVFile = (
   );
 };
 
-export default generateExportCSVFile;
+// Policy results only
+export const generateCSVPolicyResults = (
+  rows: { host: string; status: string }[],
+  filename: string
+) => {
+  console.log("generateExportCSVFile rows", rows);
+  return new global.window.File(
+    [
+      convertToCSV({
+        objArray: rows,
+        fieldSortFunc: reorderCSVFields,
+      }),
+    ],
+    filename,
+    {
+      type: "text/csv",
+    }
+  );
+};
+
+// Policy errors only
+export const generateCSVPolicyErrors = (
+  rows: ICampaignError[],
+  filename: string
+) => {
+  console.log("generateExportCSVFile rows", rows);
+  return new global.window.File([convertToCSV({ objArray: rows })], filename, {
+    type: "text/csv",
+  });
+};
+
+export default {
+  generateCSVFilename,
+  generateCSVQueryResults,
+  generateCSVPolicyResults,
+  generateCSVPolicyErrors,
+};

--- a/frontend/utilities/generate_csv/index.ts
+++ b/frontend/utilities/generate_csv/index.ts
@@ -7,7 +7,6 @@ const reorderCSVFields = (tableHeaders: string[]) => {
   const result = tableHeaders.filter((field) => field !== "host_display_name");
   result.unshift("host_display_name");
 
-  console.log("result", result);
   return result;
 };
 
@@ -21,7 +20,6 @@ export const generateCSVQueryResults = (
   filename: string,
   tableHeaders: Column[] | string[]
 ) => {
-  console.log("generateExportCSVFile rows", rows);
   return new global.window.File(
     [
       convertToCSV({
@@ -42,7 +40,6 @@ export const generateCSVPolicyResults = (
   rows: { host: string; status: string }[],
   filename: string
 ) => {
-  console.log("generateExportCSVFile rows", rows);
   return new global.window.File([convertToCSV({ objArray: rows })], filename, {
     type: "text/csv",
   });
@@ -53,7 +50,6 @@ export const generateCSVPolicyErrors = (
   rows: ICampaignError[],
   filename: string
 ) => {
-  console.log("generateExportCSVFile rows", rows);
   return new global.window.File([convertToCSV({ objArray: rows })], filename, {
     type: "text/csv",
   });

--- a/frontend/utilities/generate_csv/index.ts
+++ b/frontend/utilities/generate_csv/index.ts
@@ -18,7 +18,6 @@ export const generateCSVFilename = (descriptor: string) => {
 // Query results and query errors
 export const generateCSVQueryResults = (
   rows: Row[],
-  // | ICampaignError[],
   filename: string,
   tableHeaders: Column[] | string[]
 ) => {
@@ -44,18 +43,9 @@ export const generateCSVPolicyResults = (
   filename: string
 ) => {
   console.log("generateExportCSVFile rows", rows);
-  return new global.window.File(
-    [
-      convertToCSV({
-        objArray: rows,
-        fieldSortFunc: reorderCSVFields,
-      }),
-    ],
-    filename,
-    {
-      type: "text/csv",
-    }
-  );
+  return new global.window.File([convertToCSV({ objArray: rows })], filename, {
+    type: "text/csv",
+  });
 };
 
 // Policy errors only


### PR DESCRIPTION
## Issue
Cerra #12476 

## Description
- Live query UI and export results was originally built to grab first returned results column headers only
- Causes a bug if subsequent results include additional columns
- Fix uses JS `Set()` to create a set of all columns returned by live query
- Other:
  - Rename CSV files to include Query/Policy name OR New Query/Policy along with - Results OR Errors (see screenshot of examples)
- Required a ton of refactoring of both fleet UI table and export results CSV table
- Consider QA wolf E2E test this edge case

## Steps to QA
1. Run a live query on hosts that will return different columns (e.g., select * from osquery_info; for macOS vs. chromeOS hosts)
- [x] Ensure all columns are showing in UI table
- [x] Ensure all columns are showing in export results CSV
- [x] Note: the document name of a CSV is the query name, or "New Query" if ran not on a saved query
- [x] Note: the document name of a CSV includes "Results"
2. Run a live query on hosts that will return an error (e.g., a windows only table query on a chromebook)
- [x] Ensure error columns and export results CSV columns match
- [x] Note the document name of a CSV is the query name, or "New Query" if ran not on a saved query
- [x] Note: the document name of a CSV includes "Errors"
3. Run a live policy on hosts (Out of scope of the bug fix but generating CSV refactored as a part of this work):
- [x] Ensure columns and export results CSV columns match
- [x] Note: the document name of a CSV is the policy name, or "New Policy" if ran not on a saved policy
- [x] Note: the document name of a CSV includes "Results" or "Errors" respectively

## Screen recording

https://github.com/fleetdm/fleet/assets/71795832/53c3b290-3686-4d82-8934-f2fbff3cef1f

## Screenshots of new CSV file names
<img width="1063" alt="Screenshot 2023-08-23 at 1 13 40 PM" src="https://github.com/fleetdm/fleet/assets/71795832/023410e6-ac4c-4d2b-8a3e-8ee199a46058">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

