### PR TITLE
Fleet UI: Server side filtering for global, team, and inherited policies

### DIFF
--- a/frontend/interfaces/policy.ts
+++ b/frontend/interfaces/policy.ts
@@ -22,6 +22,10 @@ export interface IStoredPolicyResponse {
   policy: IPolicy;
 }
 
+export interface IPoliciesCountResponse {
+  count: number;
+}
+
 export interface IPolicy {
   id: number;
   name: string;

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -307,7 +307,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
         teamId: teamIdForApi,
       },
     ],
-    ({ queryKey }) => softwareAPI.count(queryKey[0]),
+    ({ queryKey }) => softwareAPI.getCount(queryKey[0]),
     {
       enabled: isRouteOk && !software?.software,
       keepPreviousData: true,

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -253,7 +253,7 @@ const ManagePolicyPage = ({
     [
       {
         scope: "policiesCount",
-        query: searchQuery,
+        query: isAnyTeamSelected ? "" : searchQuery, // Search query not used for inherited count
       },
     ],
     ({ queryKey }) => globalPoliciesAPI.count(queryKey[0]),

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -157,12 +157,13 @@ const ManagePolicyPage = ({
 
   // const page = initialPage;
   const showInheritedTable = initialShowInheritedTable;
-  const inheritedPage = initialInheritedPage;
+  // const inheritedPage = initialInheritedPage;
   // const searchQuery = initialSearchQuery;
 
   // Needs update on location change or table state might not match URL
   const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
   const [page, setPage] = useState(initialPage);
+  const [inheritedPage, setInheritedPage] = useState(initialInheritedPage);
   const [tableQueryData, setTableQueryData] = useState<ITableQueryData>();
   const [resetPageIndex, setResetPageIndex] = useState<boolean>(false);
   const [sortHeader, setSortHeader] = useState(initialSortHeader);
@@ -454,47 +455,47 @@ const ManagePolicyPage = ({
     ] // Other dependencies can cause infinite re-renders as URL is source of truth
   );
 
-  const onClientSidePaginationChange = useCallback(
-    (pageIndex: number) => {
-      const locationPath = getNextLocationPath({
-        pathPrefix: PATHS.MANAGE_POLICIES,
-        queryParams: {
-          ...queryParams,
-          page: pageIndex,
-          query: searchQuery,
-          order_direction: sortDirection,
-          order_key: sortHeader,
-          inherited_order_direction: inheritedSortDirection,
-          inherited_order_key: inheritedSortHeader,
-          inherited_page: inheritedPage,
-        },
-      });
+  // const onClientSidePaginationChange = useCallback(
+  //   (pageIndex: number) => {
+  //     const locationPath = getNextLocationPath({
+  //       pathPrefix: PATHS.MANAGE_POLICIES,
+  //       queryParams: {
+  //         ...queryParams,
+  //         page: pageIndex,
+  //         query: searchQuery,
+  //         order_direction: sortDirection,
+  //         order_key: sortHeader,
+  //         inherited_order_direction: inheritedSortDirection,
+  //         inherited_order_key: inheritedSortHeader,
+  //         inherited_page: inheritedPage,
+  //       },
+  //     });
 
-      router?.replace(locationPath);
-    },
-    [searchQuery, queryParams, sortHeader, sortDirection] // Dependencies required for correct variable state
-  );
+  //     router?.replace(locationPath);
+  //   },
+  //   [searchQuery, queryParams, sortHeader, sortDirection] // Dependencies required for correct variable state
+  // );
 
-  const onClientSideInheritedPaginationChange = useCallback(
-    (pageIndex: number) => {
-      const locationPath = getNextLocationPath({
-        pathPrefix: PATHS.MANAGE_POLICIES,
-        queryParams: {
-          ...queryParams,
-          inherited_table: "true",
-          inherited_page: pageIndex,
-          query: searchQuery,
-          page,
-          order_direction: sortDirection,
-          order_key: sortHeader,
-          inherited_order_direction: inheritedSortDirection,
-          inherited_order_key: inheritedSortHeader,
-        },
-      });
-      router?.replace(locationPath);
-    },
-    [queryParams, inheritedSortHeader, inheritedSortDirection] // Dependencies required for correct variable state
-  );
+  // const onClientSideInheritedPaginationChange = useCallback(
+  //   (pageIndex: number) => {
+  //     const locationPath = getNextLocationPath({
+  //       pathPrefix: PATHS.MANAGE_POLICIES,
+  //       queryParams: {
+  //         ...queryParams,
+  //         inherited_table: "true",
+  //         inherited_page: pageIndex,
+  //         query: searchQuery,
+  //         page,
+  //         order_direction: sortDirection,
+  //         order_key: sortHeader,
+  //         inherited_order_direction: inheritedSortDirection,
+  //         inherited_order_key: inheritedSortHeader,
+  //       },
+  //     });
+  //     router?.replace(locationPath);
+  //   },
+  //   [queryParams, inheritedSortHeader, inheritedSortDirection] // Dependencies required for correct variable state
+  // );
 
   const toggleManageAutomationsModal = () =>
     setShowManageAutomationsModal(!showManageAutomationsModal);
@@ -733,7 +734,9 @@ const ManagePolicyPage = ({
                 canAddOrDeletePolicy={canAddOrDeletePolicy}
                 currentTeam={currentTeamSummary}
                 currentAutomatedPolicies={currentAutomatedPolicies}
-                renderPoliciesCount={renderPoliciesCount(teamPoliciesCount)}
+                renderPoliciesCount={() =>
+                  renderPoliciesCount(teamPoliciesCount)
+                }
                 isPremiumTier={isPremiumTier}
                 isSandboxMode={isSandboxMode}
                 searchQuery={searchQuery}
@@ -760,7 +763,9 @@ const ManagePolicyPage = ({
                 isPremiumTier={isPremiumTier}
                 isSandboxMode={isSandboxMode}
                 // onClientSidePaginationChange={onClientSidePaginationChange}
-                renderPoliciesCount={renderPoliciesCount(globalPoliciesCount)}
+                renderPoliciesCount={() =>
+                  renderPoliciesCount(globalPoliciesCount)
+                }
                 searchQuery={searchQuery}
                 sortHeader={sortHeader}
                 sortDirection={sortDirection}
@@ -769,25 +774,27 @@ const ManagePolicyPage = ({
               />
             ))}
         </div>
-        {showInheritedPoliciesButton && globalPolicies && (
-          <RevealButton
-            isShowing={showInheritedTable}
-            className={baseClass}
-            hideText={inheritedPoliciesButtonText(
-              showInheritedTable,
-              globalPolicies.length
-            )}
-            showText={inheritedPoliciesButtonText(
-              showInheritedTable,
-              globalPolicies.length
-            )}
-            caretPosition={"before"}
-            tooltipHtml={
-              '"All teams" policies are checked <br/> for this team’s hosts.'
-            }
-            onClick={toggleShowInheritedPolicies}
-          />
-        )}
+        {showInheritedPoliciesButton &&
+          globalPolicies &&
+          globalPoliciesCount && (
+            <RevealButton
+              isShowing={showInheritedTable}
+              className={baseClass}
+              hideText={inheritedPoliciesButtonText(
+                showInheritedTable,
+                globalPoliciesCount
+              )}
+              showText={inheritedPoliciesButtonText(
+                showInheritedTable,
+                globalPoliciesCount
+              )}
+              caretPosition={"before"}
+              tooltipHtml={
+                '"All teams" policies are checked <br/> for this team’s hosts.'
+              }
+              onClick={toggleShowInheritedPolicies}
+            />
+          )}
         {showInheritedPoliciesButton && showInheritedTable && (
           <div className={`${baseClass}__inherited-policies-table`}>
             {globalPoliciesError && <TableDataError />}
@@ -806,7 +813,9 @@ const ManagePolicyPage = ({
                   // onClientSidePaginationChange={
                   //   onClientSideInheritedPaginationChange
                   // }
-                  renderPoliciesCount={renderPoliciesCount(teamPoliciesCount)}
+                  renderPoliciesCount={() =>
+                    renderPoliciesCount(teamPoliciesCount)
+                  }
                   sortHeader={inheritedSortHeader}
                   sortDirection={inheritedSortDirection}
                   page={inheritedPage}

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -284,6 +284,10 @@ const ManagePolicyPage = ({
         query: searchQuery,
         orderDirection: sortDirection,
         orderKey: sortHeader,
+        inheritedPage: inheritedTableQueryData?.pageIndex,
+        inheritedPerPage: DEFAULT_PAGE_SIZE,
+        inheritedOrderDirection: inheritedSortDirection,
+        inheritedOrderKey: inheritedSortHeader,
         teamId: teamIdForApi || 0, // TODO: Fix number/undefined type
       },
     ],
@@ -750,7 +754,7 @@ const ManagePolicyPage = ({
                 currentTeam={currentTeamSummary}
                 currentAutomatedPolicies={currentAutomatedPolicies}
                 renderPoliciesCount={() =>
-                  renderPoliciesCount(teamPoliciesCount)
+                  !isFetchingTeamCount && renderPoliciesCount(teamPoliciesCount)
                 }
                 isPremiumTier={isPremiumTier}
                 isSandboxMode={isSandboxMode}
@@ -779,6 +783,7 @@ const ManagePolicyPage = ({
                 isSandboxMode={isSandboxMode}
                 // onClientSidePaginationChange={onClientSidePaginationChange}
                 renderPoliciesCount={() =>
+                  !isFetchingGlobalCount &&
                   renderPoliciesCount(globalPoliciesCount)
                 }
                 searchQuery={searchQuery}

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -263,7 +263,7 @@ const ManagePolicyPage = ({
     isFetching: isFetchingTeamPolicies,
     refetch: refetchTeamPolicies,
   } = useQuery<
-    ILoadAllPoliciesResponse,
+    ILoadTeamPoliciesResponse,
     Error,
     IPolicyStats[],
     ITeamPoliciesQueryKey[]

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -265,7 +265,7 @@ const ManagePolicyPage = ({
   } = useQuery<
     ILoadTeamPoliciesResponse,
     Error,
-    IPolicyStats[],
+    ILoadTeamPoliciesResponse,
     ITeamPoliciesQueryKey[]
   >(
     [
@@ -276,7 +276,7 @@ const ManagePolicyPage = ({
         query: searchQuery,
         orderDirection: sortDirection,
         orderKey: sortHeader,
-        teamId: teamIdForApi,
+        teamId: teamIdForApi || 0, // TODO: Fix number/undefined type
       },
     ],
     ({ queryKey }) => {
@@ -305,12 +305,12 @@ const ManagePolicyPage = ({
       {
         scope: "teamPoliciesCount",
         query: searchQuery,
-        teamId: teamIdForApi,
+        teamId: teamIdForApi || 0, // TODO: Fix number/undefined type
       },
     ],
     ({ queryKey }) => teamPoliciesAPI.count(queryKey[0]),
     {
-      enabled: isRouteOk,
+      enabled: isRouteOk && !!teamIdForApi,
       keepPreviousData: true,
       refetchOnWindowFocus: false,
       retry: 1,
@@ -318,9 +318,9 @@ const ManagePolicyPage = ({
     }
   );
 
-  const canAddOrDeletePolicy =
+  const canAddOrDeletePolicy: boolean =
     isGlobalAdmin || isGlobalMaintainer || isTeamMaintainer || isTeamAdmin;
-  const canManageAutomations = isGlobalAdmin || isTeamAdmin;
+  const canManageAutomations: boolean = isGlobalAdmin || isTeamAdmin;
 
   const {
     data: config,
@@ -636,6 +636,16 @@ const ManagePolicyPage = ({
     }
   }
 
+  const renderPoliciesCount = (count?: number) => {
+    return (
+      <div className={`${baseClass}__count`}>
+        {count !== undefined && (
+          <span>{`${count} polic${count === 1 ? "y" : "ies"}`}</span>
+        )}
+      </div>
+    );
+  };
+
   return !isRouteOk || (isPremiumTier && !userTeams) ? (
     <Spinner />
   ) : (
@@ -723,6 +733,7 @@ const ManagePolicyPage = ({
                 canAddOrDeletePolicy={canAddOrDeletePolicy}
                 currentTeam={currentTeamSummary}
                 currentAutomatedPolicies={currentAutomatedPolicies}
+                renderPoliciesCount={renderPoliciesCount(teamPoliciesCount)}
                 isPremiumTier={isPremiumTier}
                 isSandboxMode={isSandboxMode}
                 searchQuery={searchQuery}
@@ -748,7 +759,8 @@ const ManagePolicyPage = ({
                 currentAutomatedPolicies={currentAutomatedPolicies}
                 isPremiumTier={isPremiumTier}
                 isSandboxMode={isSandboxMode}
-                onClientSidePaginationChange={onClientSidePaginationChange}
+                // onClientSidePaginationChange={onClientSidePaginationChange}
+                renderPoliciesCount={renderPoliciesCount(globalPoliciesCount)}
                 searchQuery={searchQuery}
                 sortHeader={sortHeader}
                 sortDirection={sortDirection}
@@ -791,9 +803,10 @@ const ManagePolicyPage = ({
                   tableType="inheritedPolicies"
                   currentTeam={currentTeamSummary}
                   searchQuery=""
-                  onClientSidePaginationChange={
-                    onClientSideInheritedPaginationChange
-                  }
+                  // onClientSidePaginationChange={
+                  //   onClientSideInheritedPaginationChange
+                  // }
+                  renderPoliciesCount={renderPoliciesCount(teamPoliciesCount)}
                   sortHeader={inheritedSortHeader}
                   sortDirection={inheritedSortDirection}
                   page={inheritedPage}

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useContext, useEffect, useState } from "react";
 import { useQuery } from "react-query";
 import { InjectedRouter } from "react-router/lib/Router";
 import PATHS from "router/paths";
-import { noop, isEmpty } from "lodash";
+import { noop, isEqual } from "lodash";
 
 import { getNextLocationPath } from "utilities/helpers";
 
@@ -165,6 +165,10 @@ const ManagePolicyPage = ({
   const [page, setPage] = useState(initialPage);
   const [inheritedPage, setInheritedPage] = useState(initialInheritedPage);
   const [tableQueryData, setTableQueryData] = useState<ITableQueryData>();
+  const [
+    inheritedTableQueryData,
+    setInheritedTableQueryData,
+  ] = useState<ITableQueryData>();
   const [resetPageIndex, setResetPageIndex] = useState<boolean>(false);
   const [sortHeader, setSortHeader] = useState(initialSortHeader);
   const [sortDirection, setSortDirection] = useState<
@@ -185,8 +189,11 @@ const ManagePolicyPage = ({
     if (!isRouteOk) {
       return;
     }
+    setPage(initialPage);
+    setSearchQuery(initialSearchQuery);
     setSortHeader(initialSortHeader);
     setSortDirection(initialSortDirection);
+    setInheritedPage(initialInheritedPage);
     setInheritedSortHeader(initialInheritedSortHeader);
     setInheritedSortDirection(initialInheritedSortDirection);
   }, [location, isRouteOk]);
@@ -377,6 +384,14 @@ const ManagePolicyPage = ({
   // Inherited table uses the same onQueryChange function but routes to different URL params
   const onQueryChange = useCallback(
     async (newTableQuery: ITableQueryData) => {
+      if (!isRouteOk || isEqual(newTableQuery, tableQueryData)) {
+        return;
+      }
+
+      newTableQuery.editingInheritedTable
+        ? setInheritedTableQueryData({ ...newTableQuery })
+        : setTableQueryData({ ...newTableQuery });
+
       const {
         pageIndex: newPageIndex,
         searchQuery: newSearchQuery,

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tests.tsx
@@ -21,6 +21,7 @@ describe("Policies table", () => {
         searchQuery=""
         page={0}
         onQueryChange={noop}
+        renderPoliciesCount={noop}
       />
     );
 
@@ -47,6 +48,7 @@ describe("Policies table", () => {
         searchQuery=""
         page={0}
         onQueryChange={noop}
+        renderPoliciesCount={noop}
       />
     );
 

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -35,7 +35,8 @@ interface IPoliciesTableProps {
   currentAutomatedPolicies?: number[];
   isPremiumTier?: boolean;
   isSandboxMode?: boolean;
-  onClientSidePaginationChange?: (pageIndex: number) => void;
+  // onClientSidePaginationChange?: (pageIndex: number) => void;
+  renderPoliciesCount: any; // TODO: typing
   onQueryChange: (newTableQuery: ITableQueryData) => void;
   searchQuery: string;
   sortHeader?: "name" | "failing_host_count";
@@ -55,7 +56,8 @@ const PoliciesTable = ({
   isPremiumTier,
   isSandboxMode,
   onQueryChange,
-  onClientSidePaginationChange,
+  // onClientSidePaginationChange,
+  renderPoliciesCount,
   searchQuery,
   sortHeader,
   sortDirection,
@@ -179,9 +181,10 @@ const PoliciesTable = ({
             })
           }
           disableCount={tableType === "inheritedPolicies"}
-          isClientSidePagination
-          onClientSidePaginationChange={onClientSidePaginationChange}
-          isClientSideFilter
+          renderCount={renderPoliciesCount}
+          // isClientSidePagination
+          // onClientSidePaginationChange={onClientSidePaginationChange}
+          // isClientSideFilter
           searchQueryColumn="name"
           onQueryChange={onTableQueryChange}
           inputPlaceHolder="Search by name"

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -156,7 +156,7 @@ const PoliciesTable = ({
             currentAutomatedPolicies,
             config?.update_interval.osquery_policy
           )}
-          filters={{ global: searchQuery }}
+          // filters={{ global: searchQuery }}
           isLoading={isLoading}
           defaultSortHeader={sortHeader || DEFAULT_SORT_HEADER}
           defaultSortDirection={sortDirection || DEFAULT_SORT_DIRECTION}
@@ -185,7 +185,7 @@ const PoliciesTable = ({
           // isClientSidePagination
           // onClientSidePaginationChange={onClientSidePaginationChange}
           // isClientSideFilter
-          searchQueryColumn="name"
+          // searchQueryColumn="name"
           onQueryChange={onTableQueryChange}
           inputPlaceHolder="Search by name"
           searchable={searchable}

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -327,7 +327,7 @@ const ManageSoftwarePage = ({
         teamId: teamIdForApi,
       },
     ],
-    ({ queryKey }) => softwareAPI.count(queryKey[0]),
+    ({ queryKey }) => softwareAPI.getCount(queryKey[0]),
     {
       enabled: isRouteOk && isSoftwareConfigLoaded,
       keepPreviousData: true,

--- a/frontend/services/entities/global_policies.ts
+++ b/frontend/services/entities/global_policies.ts
@@ -94,7 +94,7 @@ export default {
 
     return sendRequest("GET", path);
   },
-  count: async ({
+  getCount: async ({
     query,
   }: Pick<IPoliciesApiParams, "query">): Promise<IPoliciesCountResponse> => {
     const { GLOBAL_POLICIES } = endpoints;

--- a/frontend/services/entities/global_policies.ts
+++ b/frontend/services/entities/global_policies.ts
@@ -1,7 +1,46 @@
 /* eslint-disable  @typescript-eslint/explicit-module-boundary-types */
+import { snakeCase, reduce } from "lodash";
+
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
-import { IPolicyFormData, ILoadAllPoliciesResponse } from "interfaces/policy";
+import {
+  IPolicyFormData,
+  ILoadAllPoliciesResponse,
+  IPoliciesCountResponse,
+} from "interfaces/policy";
+import { buildQueryStringFromParams, QueryParams } from "utilities/url";
+
+interface IPoliciesApiParams {
+  page?: number;
+  perPage?: number;
+  orderKey?: string;
+  orderDirection?: "asc" | "desc";
+  query?: string;
+  teamId?: number; // Used for /count
+}
+
+export interface IPoliciesQueryKey extends IPoliciesApiParams {
+  scope: "globalPolicies";
+}
+
+export interface IPoliciesCountQueryKey
+  extends Pick<IPoliciesApiParams, "query" | "teamId"> {
+  scope: "policiesCount";
+}
+
+const ORDER_KEY = "name";
+const ORDER_DIRECTION = "asc";
+
+const convertParamsToSnakeCase = (params: IPoliciesApiParams) => {
+  return reduce<typeof params, QueryParams>(
+    params,
+    (result, val, key) => {
+      result[snakeCase(key)] = val;
+      return result;
+    },
+    {}
+  );
+};
 
 export default {
   // TODO: How does the frontend need to support legacy policies?
@@ -32,5 +71,46 @@ export default {
     const { GLOBAL_POLICIES } = endpoints;
 
     return sendRequest("GET", GLOBAL_POLICIES);
+  },
+  loadAllNew: async ({
+    page,
+    perPage,
+    orderKey = ORDER_KEY,
+    orderDirection: orderDir = ORDER_DIRECTION,
+    query,
+  }: IPoliciesApiParams): Promise<ILoadAllPoliciesResponse> => {
+    const { GLOBAL_POLICIES } = endpoints;
+
+    const queryParams = {
+      page,
+      perPage,
+      orderKey,
+      orderDirection: orderDir,
+      query,
+    };
+
+    const snakeCaseParams = convertParamsToSnakeCase(queryParams);
+    const queryString = buildQueryStringFromParams(snakeCaseParams);
+    const path = `${GLOBAL_POLICIES}?${queryString}`;
+
+    return sendRequest("GET", path);
+  },
+  count: async ({
+    query,
+    teamId,
+  }: Pick<
+    IPoliciesApiParams,
+    "query" | "teamId"
+  >): Promise<IPoliciesCountResponse> => {
+    const { GLOBAL_POLICIES } = endpoints;
+    const path = `${GLOBAL_POLICIES}/count`;
+    const queryParams = {
+      query,
+      teamId,
+    };
+    const snakeCaseParams = convertParamsToSnakeCase(queryParams);
+    const queryString = buildQueryStringFromParams(snakeCaseParams);
+
+    return sendRequest("GET", path.concat(`?${queryString}`));
   },
 };

--- a/frontend/services/entities/global_policies.ts
+++ b/frontend/services/entities/global_policies.ts
@@ -16,7 +16,6 @@ interface IPoliciesApiParams {
   orderKey?: string;
   orderDirection?: "asc" | "desc";
   query?: string;
-  teamId?: number; // Used for /count
 }
 
 export interface IPoliciesQueryKey extends IPoliciesApiParams {
@@ -24,7 +23,7 @@ export interface IPoliciesQueryKey extends IPoliciesApiParams {
 }
 
 export interface IPoliciesCountQueryKey
-  extends Pick<IPoliciesApiParams, "query" | "teamId"> {
+  extends Pick<IPoliciesApiParams, "query"> {
   scope: "policiesCount";
 }
 
@@ -97,16 +96,11 @@ export default {
   },
   count: async ({
     query,
-    teamId,
-  }: Pick<
-    IPoliciesApiParams,
-    "query" | "teamId"
-  >): Promise<IPoliciesCountResponse> => {
+  }: Pick<IPoliciesApiParams, "query">): Promise<IPoliciesCountResponse> => {
     const { GLOBAL_POLICIES } = endpoints;
     const path = `${GLOBAL_POLICIES}/count`;
     const queryParams = {
       query,
-      teamId,
     };
     const snakeCaseParams = convertParamsToSnakeCase(queryParams);
     const queryString = buildQueryStringFromParams(snakeCaseParams);

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -74,7 +74,7 @@ export default {
     }
   },
 
-  count: async ({
+  getCount: async ({
     query,
     teamId,
     vulnerable,

--- a/frontend/services/entities/team_policies.ts
+++ b/frontend/services/entities/team_policies.ts
@@ -163,7 +163,7 @@ export default {
 
     return sendRequest("GET", path);
   },
-  count: async ({
+  getCount: async ({
     query,
     teamId,
   }: Pick<

--- a/frontend/services/entities/team_policies.ts
+++ b/frontend/services/entities/team_policies.ts
@@ -3,16 +3,34 @@ import { snakeCase, reduce } from "lodash";
 
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
-import { ILoadTeamPoliciesResponse, IPolicyFormData } from "interfaces/policy";
+import {
+  ILoadTeamPoliciesResponse,
+  IPolicyFormData,
+  IPoliciesCountResponse,
+} from "interfaces/policy";
 import { API_NO_TEAM_ID } from "interfaces/team";
 import { buildQueryStringFromParams, QueryParams } from "utilities/url";
 
 interface IPoliciesApiParams {
-  team_id?: number;
+  teamId?: number;
   page?: number;
   perPage?: number;
   orderKey?: string;
   orderDirection?: "asc" | "desc";
+  query?: string;
+}
+
+export interface ITeamPoliciesQueryKey extends IPoliciesApiParams {
+  scope: "teamPolicies";
+}
+
+export interface ITeamPoliciesCountQueryKey
+  extends Pick<IPoliciesApiParams, "query"> {
+  scope: "teamPoliciesCount";
+}
+
+interface IPoliciesCountApiParams {
+  teamId: number;
   query?: string;
 }
 
@@ -104,7 +122,7 @@ export default {
     return sendRequest("GET", path);
   },
   loadAllNew: async ({
-    team_id,
+    teamId,
     page,
     perPage,
     orderKey = ORDER_KEY,
@@ -123,11 +141,28 @@ export default {
 
     const snakeCaseParams = convertParamsToSnakeCase(queryParams);
     const queryString = buildQueryStringFromParams(snakeCaseParams);
-    const path = `${TEAMS}/${team_id}/policies?${queryString}`;
-    if (!team_id) {
+    const path = `${TEAMS}/${teamId}/policies?${queryString}`;
+    if (!teamId) {
       throw new Error("Invalid team id");
     }
 
     return sendRequest("GET", path);
+  },
+  count: async ({
+    query,
+    teamId,
+  }: Pick<
+    IPoliciesCountApiParams,
+    "query" | "teamId"
+  >): Promise<IPoliciesCountResponse> => {
+    const { TEAM_POLICIES } = endpoints;
+    const path = `${TEAM_POLICIES(teamId)}/count`;
+    const queryParams = {
+      query,
+    };
+    const snakeCaseParams = convertParamsToSnakeCase(queryParams);
+    const queryString = buildQueryStringFromParams(snakeCaseParams);
+
+    return sendRequest("GET", path.concat(`?${queryString}`));
   },
 };

--- a/frontend/services/entities/team_policies.ts
+++ b/frontend/services/entities/team_policies.ts
@@ -11,13 +11,16 @@ import {
 import { API_NO_TEAM_ID } from "interfaces/team";
 import { buildQueryStringFromParams, QueryParams } from "utilities/url";
 
-interface IPoliciesApiParams {
-  teamId?: number;
+interface IPoliciesApiQueryParams {
   page?: number;
   perPage?: number;
   orderKey?: string;
   orderDirection?: "asc" | "desc";
   query?: string;
+}
+
+export interface IPoliciesApiParams extends IPoliciesApiQueryParams {
+  teamId: number;
 }
 
 export interface ITeamPoliciesQueryKey extends IPoliciesApiParams {
@@ -37,7 +40,7 @@ interface IPoliciesCountApiParams {
 const ORDER_KEY = "name";
 const ORDER_DIRECTION = "asc";
 
-const convertParamsToSnakeCase = (params: IPoliciesApiParams) => {
+const convertParamsToSnakeCase = (params: IPoliciesApiQueryParams) => {
   return reduce<typeof params, QueryParams>(
     params,
     (result, val, key) => {

--- a/frontend/services/entities/team_policies.ts
+++ b/frontend/services/entities/team_policies.ts
@@ -1,8 +1,34 @@
 /* eslint-disable  @typescript-eslint/explicit-module-boundary-types */
+import { snakeCase, reduce } from "lodash";
+
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
 import { ILoadTeamPoliciesResponse, IPolicyFormData } from "interfaces/policy";
 import { API_NO_TEAM_ID } from "interfaces/team";
+import { buildQueryStringFromParams, QueryParams } from "utilities/url";
+
+interface IPoliciesApiParams {
+  team_id?: number;
+  page?: number;
+  perPage?: number;
+  orderKey?: string;
+  orderDirection?: "asc" | "desc";
+  query?: string;
+}
+
+const ORDER_KEY = "name";
+const ORDER_DIRECTION = "asc";
+
+const convertParamsToSnakeCase = (params: IPoliciesApiParams) => {
+  return reduce<typeof params, QueryParams>(
+    params,
+    (result, val, key) => {
+      result[snakeCase(key)] = val;
+      return result;
+    },
+    {}
+  );
+};
 
 export default {
   create: (data: IPolicyFormData) => {
@@ -71,6 +97,33 @@ export default {
   loadAll: (team_id?: number): Promise<ILoadTeamPoliciesResponse> => {
     const { TEAMS } = endpoints;
     const path = `${TEAMS}/${team_id}/policies`;
+    if (!team_id) {
+      throw new Error("Invalid team id");
+    }
+
+    return sendRequest("GET", path);
+  },
+  loadAllNew: async ({
+    team_id,
+    page,
+    perPage,
+    orderKey = ORDER_KEY,
+    orderDirection: orderDir = ORDER_DIRECTION,
+    query,
+  }: IPoliciesApiParams): Promise<ILoadTeamPoliciesResponse> => {
+    const { TEAMS } = endpoints;
+
+    const queryParams = {
+      page,
+      perPage,
+      orderKey,
+      orderDirection: orderDir,
+      query,
+    };
+
+    const snakeCaseParams = convertParamsToSnakeCase(queryParams);
+    const queryString = buildQueryStringFromParams(snakeCaseParams);
+    const path = `${TEAMS}/${team_id}/policies?${queryString}`;
     if (!team_id) {
       throw new Error("Invalid team id");
     }

--- a/frontend/services/entities/team_policies.ts
+++ b/frontend/services/entities/team_policies.ts
@@ -25,7 +25,7 @@ export interface ITeamPoliciesQueryKey extends IPoliciesApiParams {
 }
 
 export interface ITeamPoliciesCountQueryKey
-  extends Pick<IPoliciesApiParams, "query"> {
+  extends Pick<IPoliciesApiParams, "query" | "teamId"> {
   scope: "teamPoliciesCount";
 }
 

--- a/frontend/services/entities/team_policies.ts
+++ b/frontend/services/entities/team_policies.ts
@@ -17,6 +17,10 @@ interface IPoliciesApiQueryParams {
   orderKey?: string;
   orderDirection?: "asc" | "desc";
   query?: string;
+  inheritedPage?: number;
+  inheritedPerPage?: number;
+  inheritedOrderKey?: string;
+  inheritedOrderDirection?: "asc" | "desc";
 }
 
 export interface IPoliciesApiParams extends IPoliciesApiQueryParams {
@@ -131,6 +135,10 @@ export default {
     orderKey = ORDER_KEY,
     orderDirection: orderDir = ORDER_DIRECTION,
     query,
+    inheritedPage,
+    inheritedPerPage,
+    inheritedOrderKey = ORDER_KEY,
+    inheritedOrderDirection: inheritedOrderDir = ORDER_DIRECTION,
   }: IPoliciesApiParams): Promise<ILoadTeamPoliciesResponse> => {
     const { TEAMS } = endpoints;
 
@@ -140,6 +148,10 @@ export default {
       orderKey,
       orderDirection: orderDir,
       query,
+      inheritedPage,
+      inheritedPerPage,
+      inheritedOrderKey,
+      inheritedOrderDirection: inheritedOrderDir,
     };
 
     const snakeCaseParams = convertParamsToSnakeCase(queryParams);


### PR DESCRIPTION
## Issue
Cerra #13458 

## Description
- Convert global policies API call to use server side filtering
- Convert team policies API call to use server side filtering
- Create and use global policies count API call (new endpoint)
- Create and use team policies count API call (new endpoint)
- Convert current client side tables filtering (global, team, inherited) to use server side filtering
- Convert client side URL params to use server side URL params

## QA
- [x] Test global count
- [x] Test global order key and direction
- [x] Test global search
- [x] Test global pagination
- [x] Test global combination of everything above (e.g. does it go back to page 0 when you change the search query when on page 3?)
- [x] Test team count
- [x] Test team order key and direction
- [x] Test team search
- [x] Test team pagination (e.g. does it go back to page 0 when you change the search query when on page 3? does modifying these params not modify the inherited table?)
- [x] Test team combination of everything above
- [x] Test inherited policies table count
- [x] Test inherited policies table order key and direction
- [x] Test inherited policies pagination
- [x] Test every combination of the above (e.g. does it go back to page 0 when you switch order key when on page 3?)


## Screen recordings

https://github.com/fleetdm/fleet/assets/71795832/ae42368a-2bbe-4f9c-8740-2b49e7a6f451



## TODO
- Once merged, update QA wolf for any holes in test coverage (QA Wolf e2e or integration test)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
