### PR TITLE
Fleet UI: Improvements to highlighting while tabbing and not clicking

### DIFF
--- a/changes/13064-highlighter-bug
+++ b/changes/13064-highlighter-bug
@@ -1,0 +1,1 @@
+- Fleet UI - Tabs highlight while tabbing but not on multiple clicks

--- a/frontend/components/BackLink/_styles.scss
+++ b/frontend/components/BackLink/_styles.scss
@@ -2,6 +2,7 @@
   display: inline-flex;
   align-items: center;
   padding: $pad-small $pad-xxsmall; // larger clickable area
+  border-radius: 3px; // Visible while tabbing;
   gap: $pad-xsmall;
 
   &:hover {

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -332,7 +332,7 @@ const TableContainer = ({
                 <Button
                   disabled={disableActionButton}
                   onClick={actionButton.onActionButtonClick}
-                  variant={actionButton.variant}
+                  variant={actionButton.variant || "brand"}
                   className={`${baseClass}__table-action-button`}
                 >
                   <>

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -10,6 +10,7 @@
     justify-content: space-between;
     align-items: center;
     gap: $pad-small;
+    margin-top: 3px; // Fits button highlight during tabbing
 
     &.stack-table-controls {
       flex-direction: column-reverse;
@@ -65,10 +66,6 @@
     color: $core-fleet-black;
     margin: 0;
     height: 40px;
-
-    :first-child {
-      margin-right: $pad-small;
-    }
 
     .count-error {
       color: $ui-error;

--- a/frontend/components/TabsWrapper/_styles.scss
+++ b/frontend/components/TabsWrapper/_styles.scss
@@ -21,13 +21,17 @@
       &:focus {
         box-shadow: none;
         outline: 0;
-        background-color: $ui-vibrant-blue-10;
-
         &:after {
           left: 0;
           bottom: 0;
         }
       }
+
+      // focus-visible only highlights when tabbing not clicking
+      &:focus-visible {
+        background-color: $ui-vibrant-blue-10;
+      }
+
       // Bolding text when the button is active causes a layout shift
       // so we add a hidden pseudo element with the same text string
       &:before {

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -222,6 +222,19 @@ $base-class: "button";
       outline: none;
     }
 
+    &:focus-visible {
+      @include button-focus-outline();
+
+      &::after {
+        content: "";
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        border: 1px solid #6a67fe;
+        border-radius: 6px;
+      }
+    }
+
     &:hover,
     &:focus {
       color: $core-vibrant-blue-over;

--- a/frontend/pages/DashboardPage/cards/HostsSummary/SummaryTile/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/HostsSummary/SummaryTile/_styles.scss
@@ -7,6 +7,7 @@
     font-weight: normal;
     color: $core-fleet-black;
     text-decoration: none;
+    border-radius: 3px;
   }
 
   &__tile {

--- a/frontend/pages/hosts/ManageHostsPage/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/_styles.scss
@@ -290,7 +290,7 @@
   }
 
   &__export-btn {
-    padding-left: $pad-medium;
+    margin-left: $pad-medium;
 
     img {
       width: 13px;

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -57,6 +57,13 @@ a {
   font-weight: $bold;
   font-size: $x-small;
   text-decoration: none;
+
+  &:focus-visible {
+    outline-color: #d9d9fe;
+    outline-offset: 3px;
+    outline-style: solid;
+    outline-width: 2px;
+  }
 }
 
 .__react_component_tooltip {


### PR DESCRIPTION
## Issue
Cerra #13064 

## Description
- All UI tabs do not highlight on multiple clicks, but still highlight while tabbing through app

## Screen recording (one example of the global implementation)
https://github.com/fleetdm/fleet/assets/71795832/30eea5f7-b5f8-4850-9859-914477849a88

## Other improvements (with screenshots)
> Note: not perfect but open to future iterations 

- Add outline to table buttons while tabbing through app
<img width="1455" alt="Screenshot 2023-08-24 at 2 57 00 PM" src="https://github.com/fleetdm/fleet/assets/71795832/40cb11f5-0c04-4908-83b4-acc1c217c352">
- Add outline to "back to" buttons while tabbing through app 
<img width="547" alt="Screenshot 2023-08-24 at 2 59 26 PM" src="https://github.com/fleetdm/fleet/assets/71795832/2045bd3a-e960-46db-b8b5-f3e5c0410fa1">





# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
