### PR TITLE
13071 disable orbit logs

### DIFF
--- a/changes/13071-disable-fleetd-enroll-errors
+++ b/changes/13071-disable-fleetd-enroll-errors
@@ -1,2 +1,2 @@
-- EXPERIMENTAL: Applying the environmental variable SILENCE_FLEETD_ENROLL_ERROR=1 will silence fleetd errors if not setting `--fleet-url` when generating an orbit installer.
+- EXPERIMENTAL: Applying the environmental variable "FLEETD_SILENCE_ENROLL_ERROR"=1 will silence fleetd errors if not setting `--fleet-url` when generating an orbit installer.
 - Note: Set this variable before upgrading orbit, or restart the orbit service after setting it.

--- a/changes/13071-disable-fleetd-enroll-errors
+++ b/changes/13071-disable-fleetd-enroll-errors
@@ -1,0 +1,2 @@
+- EXPERIMENTAL: Applying the environmental variable SILENCE_FLEETD_ENROLL_ERROR=1 will silence fleetd errors if not setting `--fleet-url` when generating an orbit installer.
+- Note: Set this variable before upgrading orbit, or restart the orbit service after setting it.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -342,7 +342,7 @@ func main() {
 		g.Add(systemChecker.Execute, systemChecker.Interrupt)
 		go osservice.SetupServiceManagement(constant.SystemServiceName, systemChecker.svcInterruptCh, appDoneCh)
 
-		if !c.Bool("disable-kickstart-softwareupdated") {
+		if !c.Bool("disable-kickstart-softwareupdated") && runtime.GOOS == "darwin" {
 			log.Warn().Msg("fleetd no longer automatically kickstarts softwareupdated. The --disable-kickstart-softwareupdated flag, which was previously used to disable this behavior, has been deprecated and will be removed in a future version")
 		}
 
@@ -644,7 +644,7 @@ func main() {
 		if _, err := flagRunner.DoFlagsUpdate(); err != nil {
 			// Just log, OK to continue, since flagRunner will retry
 			// in flagRunner.Execute.
-			log.Info().Err(err).Msg("initial flags update failed")
+			log.Debug().Err(err).Msg("initial flags update failed")
 		}
 		g.Add(flagRunner.Execute, flagRunner.Interrupt)
 
@@ -667,7 +667,7 @@ func main() {
 			_, err := updateRunner.UpdateAction()
 			if err != nil {
 				// OK, initial call may fail, ok to continue
-				log.Info().Err(err).Msg("initial extensions update action failed")
+				logging.LogErrIfEnvNotSet(constant.SilenceEnrollLogErrorEnvVar, err, "initial extensions update action failed")
 			}
 
 			extensionAutoLoadFile := filepath.Join(c.String("root-dir"), "extensions.load")
@@ -685,7 +685,7 @@ func main() {
 			case errors.Is(err, os.ErrNotExist):
 				// OK, nothing to do.
 			default:
-				log.Error().Err(err).Msg("error with extensions.load file at " + extensionAutoLoadFile)
+				logging.LogErrIfEnvNotSet(constant.SilenceEnrollLogErrorEnvVar, err, "error with extensions.load file at "+extensionAutoLoadFile)
 			}
 			g.Add(extRunner.Execute, extRunner.Interrupt)
 		}

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -893,7 +893,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		log.Info().Err(err).Msg("run orbit failed")
+		log.Error().Err(err).Msg("run orbit failed")
 	}
 }
 

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -342,6 +342,7 @@ func main() {
 		g.Add(systemChecker.Execute, systemChecker.Interrupt)
 		go osservice.SetupServiceManagement(constant.SystemServiceName, systemChecker.svcInterruptCh, appDoneCh)
 
+		// sofwareupdated is a macOS daemon that automatically updates Apple software.
 		if !c.Bool("disable-kickstart-softwareupdated") && runtime.GOOS == "darwin" {
 			log.Warn().Msg("fleetd no longer automatically kickstarts softwareupdated. The --disable-kickstart-softwareupdated flag, which was previously used to disable this behavior, has been deprecated and will be removed in a future version")
 		}
@@ -892,7 +893,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		logging.LogErrIfEnvNotSet(constant.SilenceEnrollLogErrorEnvVar, err, "run orbit failed")
+		log.Info().Err(err).Msg("run orbit failed")
 	}
 }
 

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -22,6 +22,7 @@ import (
 	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/execuser"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/insecure"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/logging"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/osquery"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/osservice"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/platform"
@@ -659,7 +660,7 @@ func main() {
 
 			if _, err := extRunner.DoExtensionConfigUpdate(); err != nil {
 				// just log, OK to continue since this will get retry
-				log.Info().Err(err).Msg("initial update to fetch extensions from /config API failed")
+				logging.LogErrIfEnvNotSet(constant.SilenceEnrollLogErrorEnvVar, err, "initial update to fetch extensions from /config API failed")
 			}
 
 			// call UpdateAction on the updateRunner after we have fetched extensions from Fleet
@@ -891,7 +892,7 @@ func main() {
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		log.Error().Err(err).Msg("run orbit failed")
+		logging.LogErrIfEnvNotSet(constant.SilenceEnrollLogErrorEnvVar, err, "run orbit failed")
 	}
 }
 
@@ -1226,7 +1227,7 @@ func (f *capabilitiesChecker) execute() error {
 
 	// do an initial ping to store the initial capabilities
 	if err := f.client.Ping(); err != nil {
-		log.Error().Err(err).Msg("pinging the server")
+		logging.LogErrIfEnvNotSet(constant.SilenceEnrollLogErrorEnvVar, err, "pinging the server")
 	}
 
 	for {
@@ -1235,7 +1236,7 @@ func (f *capabilitiesChecker) execute() error {
 			oldCapabilities := f.client.GetServerCapabilities()
 			// ping the server to get the latest capabilities
 			if err := f.client.Ping(); err != nil {
-				log.Error().Err(err).Msg("pinging the server")
+				logging.LogErrIfEnvNotSet(constant.SilenceEnrollLogErrorEnvVar, err, "pinging the server")
 				continue
 			}
 			newCapabilities := f.client.GetServerCapabilities()

--- a/orbit/pkg/constant/constant.go
+++ b/orbit/pkg/constant/constant.go
@@ -47,6 +47,6 @@ const (
 	// UpdateTLSClientKeyFileName is the name of the TLS client private key file
 	// used when connecting to the update server.
 	UpdateTLSClientKeyFileName = "update_client.key"
-	// Environment variable name for disabling enroll log errors
-	SilenceEnrollLogErrorEnvVar = "FLEET_SILENCE_ENROLL_LOG_ERROR"
+	// SilenceEnrollLogErrorEnvVer is an environment variable name for disabling enroll log errors
+	SilenceEnrollLogErrorEnvVar = "FLEETD_SILENCE_ENROLL_ERROR"
 )

--- a/orbit/pkg/constant/constant.go
+++ b/orbit/pkg/constant/constant.go
@@ -47,4 +47,6 @@ const (
 	// UpdateTLSClientKeyFileName is the name of the TLS client private key file
 	// used when connecting to the update server.
 	UpdateTLSClientKeyFileName = "update_client.key"
+	// Environment variable name for disabling enroll log errors
+	SilenceEnrollLogErrorEnvVar = "FLEET_SILENCE_ENROLL_LOG_ERROR"
 )

--- a/orbit/pkg/logging/logging.go
+++ b/orbit/pkg/logging/logging.go
@@ -1,0 +1,15 @@
+package logging
+
+import (
+	"os"
+
+	"github.com/rs/zerolog/log"
+)
+
+// ConditionalLog logs if the environment variable is set to "1".
+func LogErrIfEnvNotSet(envVarName string, err error, message string) {
+	actualValue := os.Getenv(envVarName)
+	if actualValue == "1" {
+		log.Info().Err(err).Msg(message)
+	}
+}

--- a/orbit/pkg/logging/logging.go
+++ b/orbit/pkg/logging/logging.go
@@ -9,7 +9,7 @@ import (
 // ConditionalLog logs if the environment variable is set to "1".
 func LogErrIfEnvNotSet(envVarName string, err error, message string) {
 	actualValue := os.Getenv(envVarName)
-	if actualValue == "1" {
+	if actualValue != "1" {
 		log.Info().Err(err).Msg(message)
 	}
 }

--- a/orbit/pkg/logging/logging.go
+++ b/orbit/pkg/logging/logging.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// ConditionalLog logs if the environment variable is set to "1".
+// LogErrIfEnvNotSet logs if the environment variable is not set to "1".
 func LogErrIfEnvNotSet(envVarName string, err error, message string) {
 	actualValue := os.Getenv(envVarName)
 	if actualValue != "1" {

--- a/orbit/pkg/update/flag_runner.go
+++ b/orbit/pkg/update/flag_runner.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/logging"
 	"github.com/rs/zerolog/log"
 )
 
@@ -59,7 +60,7 @@ func (r *FlagRunner) Execute() error {
 			log.Info().Msg("calling flags update")
 			didUpdate, err := r.DoFlagsUpdate()
 			if err != nil {
-				log.Info().Err(err).Msg("flags updates failed")
+				logging.LogErrIfEnvNotSet(constant.SilenceEnrollLogErrorEnvVar, err, "flags update failed")
 			}
 			if didUpdate {
 				log.Info().Msg("flags updated, exiting")
@@ -166,7 +167,7 @@ func (r *ExtensionRunner) Execute() error {
 			log.Debug().Msg("calling /config API to fetch/update extensions")
 			extensionsCleared, err := r.DoExtensionConfigUpdate()
 			if err != nil {
-				log.Info().Err(err).Msg("ext update failed")
+				logging.LogErrIfEnvNotSet(constant.SilenceEnrollLogErrorEnvVar, err, "ext update failed")
 			}
 			if extensionsCleared {
 				log.Info().Msg("extensions were cleared on the server")

--- a/orbit/pkg/update/flag_runner.go
+++ b/orbit/pkg/update/flag_runner.go
@@ -57,10 +57,10 @@ func (r *FlagRunner) Execute() error {
 		case <-r.cancel:
 			return nil
 		case <-ticker.C:
-			log.Info().Msg("calling flags update")
+			log.Debug().Msg("calling flags update")
 			didUpdate, err := r.DoFlagsUpdate()
 			if err != nil {
-				logging.LogErrIfEnvNotSet(constant.SilenceEnrollLogErrorEnvVar, err, "flags update failed")
+				logging.LogErrIfEnvNotSet(constant.SilenceEnrollLogErrorEnvVar, err, "flags updates failed")
 			}
 			if didUpdate {
 				log.Info().Msg("flags updated, exiting")

--- a/server/service/orbit_client.go
+++ b/server/service/orbit_client.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/logging"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/platform"
 	"github.com/fleetdm/fleet/v4/pkg/retry"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -223,7 +224,7 @@ func (oc *OrbitClient) getNodeKeyOrEnroll() (string, error) {
 				endpointDoesNotExist = true
 				return nil
 			default:
-				log.Info().Err(err).Msg("enroll failed, retrying")
+				logging.LogIfEnvNotSet(constant.SilenceEnrollLogErrorEnvVar, err, "enroll failed, retrying")
 				return err
 			}
 		},

--- a/server/service/orbit_client.go
+++ b/server/service/orbit_client.go
@@ -224,7 +224,7 @@ func (oc *OrbitClient) getNodeKeyOrEnroll() (string, error) {
 				endpointDoesNotExist = true
 				return nil
 			default:
-				logging.LogIfEnvNotSet(constant.SilenceEnrollLogErrorEnvVar, err, "enroll failed, retrying")
+				logging.LogErrIfEnvNotSet(constant.SilenceEnrollLogErrorEnvVar, err, "enroll failed, retrying")
 				return err
 			}
 		},


### PR DESCRIPTION
# Checklist for submitter

#13071 

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [X] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
