### PR TITLE
Fleet UI: Store host's team on details page for correct RBAC dropdown

### DIFF
--- a/changes/13495-host-details-rbac
+++ b/changes/13495-host-details-rbac
@@ -1,0 +1,1 @@
+- Host details page - Bug fix RBAC dropdown options on refresh

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -124,6 +124,8 @@ const HostDetailsPage = ({
     isSandboxMode,
     isOnlyObserver,
     filteredHostsPath,
+    availableTeams,
+    setCurrentTeam,
   } = useContext(AppContext);
   const {
     setLastEditedQueryName,
@@ -345,6 +347,16 @@ const HostDetailsPage = ({
   useEffect(() => {
     setPathname(location.pathname + location.search);
   }, [location]);
+
+  // Used to set host's team in AppContext for RBAC action dropdown
+  useEffect(() => {
+    if (host?.team_id) {
+      const hostsTeam = availableTeams?.find(
+        (team) => team.id === host.team_id
+      );
+      setCurrentTeam(hostsTeam);
+    }
+  }, [host]);
 
   const titleData = normalizeEmptyValues(
     pick(host, [


### PR DESCRIPTION
## Issue 
Cerra #13495 

## Description
### Issue
- On refresh, AppContext doesn't have what team we're looking at saved, so team was showing up as undefined. A team level user then is locked out of doing any RBAC to a host that is not on their team
### Solution
- Grab the host's team when loading this page and save it to AppContext to determine RBAC permissions of user (fixed functionality: can refresh, use a direct link, etc)


## Screenrecording of fixed team admin and team maintainer
https://github.com/fleetdm/fleet/assets/71795832/ee4286c6-ac3c-49ed-97a7-edb0a93aaf53



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
