### PR TITLE
Fleet UI: [tiny released styling bug] Fix alignment on long label names

### DIFF
--- a/changes/13521-label-alignment
+++ b/changes/13521-label-alignment
@@ -1,0 +1,1 @@
+- Bug fix: Fix alignment on long label names on host details label filter dropdown

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/_styles.scss
@@ -60,6 +60,10 @@
     font-size: $small;
   }
 
+  .label-filter-select__single-value {
+    max-width: 84%; // Must override default styling of .css-qc6sy-singleValue
+  }
+
   .label-filter-select__placeholder {
     width: 75px; // Truncates text for smaller filter width
     overflow: hidden;
@@ -142,8 +146,12 @@
   }
 }
 
-@media (min-width: 1100px) {
+@media (min-width: 1150px) {
   .label-filter-select {
-    width: 180px;
+    width: 220px;
+
+    &__single-value {
+      max-width: 135px !important; // Must override default styling of .css-qc6sy-singleValue
+    }
   }
 }


### PR DESCRIPTION
## Issue
Cerra #13521 

## Description
- Update responsive widths for label dropdown filter to fit long label names

## Screen recordings
### Chrome

https://github.com/fleetdm/fleet/assets/71795832/be52a710-425a-4853-9e22-2a33f531d4d9

### Firefox

https://github.com/fleetdm/fleet/assets/71795832/1eb29576-79c9-43b9-a531-7be175e6e929

### Safari

https://github.com/fleetdm/fleet/assets/71795832/bbe3d6b5-b168-4780-b8d8-49bd2aecc5ae


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
