### PR TITLE
Implement script execution on the fleetd agent (disabled by default)

### DIFF
--- a/changes/issue-13307-run-script-on-agent
+++ b/changes/issue-13307-run-script-on-agent
@@ -1,0 +1,1 @@
+* Added support in fleetd to execute scripts and send back results (disabled by default).

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -625,9 +625,9 @@ func (a *agent) execScripts(execIDs []string, orbitClient *service.OrbitClient) 
 			// send a no-op result without executing if script exec is disabled
 			if err := orbitClient.SaveHostScriptResult(&fleet.HostScriptResultPayload{
 				ExecutionID: execID,
-				Output:      "script execution is disabled",
+				Output:      "script execution disabled",
 				Runtime:     0,
-				ExitCode:    -1,
+				ExitCode:    -2,
 			}); err != nil {
 				log.Println("save disabled host script result:", err)
 				return

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -624,6 +624,9 @@ func main() {
 			windowsMDMEnrollmentCommandFrequency   = time.Hour
 		)
 		configFetcher := update.ApplyRenewEnrollmentProfileConfigFetcherMiddleware(orbitClient, renewEnrollmentProfileCommandFrequency, fleetURL)
+		// TODO(mna): for script execution, pass along the new flag that indicates
+		// if execution is enabled or not (and/or via mdm profile)
+		configFetcher = update.ApplyRunScriptsConfigFetcherMiddleware(configFetcher, true /* TODO: the --scripts-enabled flag */, orbitClient)
 
 		switch runtime.GOOS {
 		case "darwin":

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -624,9 +624,7 @@ func main() {
 			windowsMDMEnrollmentCommandFrequency   = time.Hour
 		)
 		configFetcher := update.ApplyRenewEnrollmentProfileConfigFetcherMiddleware(orbitClient, renewEnrollmentProfileCommandFrequency, fleetURL)
-		// TODO(mna): for script execution, pass along the new flag that indicates
-		// if execution is enabled or not (and/or via mdm profile)
-		configFetcher = update.ApplyRunScriptsConfigFetcherMiddleware(configFetcher, false /* TODO: the --scripts-enabled flag */, orbitClient)
+		configFetcher = update.ApplyRunScriptsConfigFetcherMiddleware(configFetcher, c.Bool("enable-scripts"), orbitClient)
 
 		switch runtime.GOOS {
 		case "darwin":

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -626,7 +626,7 @@ func main() {
 		configFetcher := update.ApplyRenewEnrollmentProfileConfigFetcherMiddleware(orbitClient, renewEnrollmentProfileCommandFrequency, fleetURL)
 		// TODO(mna): for script execution, pass along the new flag that indicates
 		// if execution is enabled or not (and/or via mdm profile)
-		configFetcher = update.ApplyRunScriptsConfigFetcherMiddleware(configFetcher, true /* TODO: the --scripts-enabled flag */, orbitClient)
+		configFetcher = update.ApplyRunScriptsConfigFetcherMiddleware(configFetcher, false /* TODO: the --scripts-enabled flag */, orbitClient)
 
 		switch runtime.GOOS {
 		case "darwin":

--- a/orbit/pkg/scripts/exec_nonwindows.go
+++ b/orbit/pkg/scripts/exec_nonwindows.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package scripts
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+)
+
+func execCmd(ctx context.Context, scriptPath string) (output []byte, exitCode int, err error) {
+	// initialize to -1 in case the process never starts
+	exitCode = -1
+
+	cmd := exec.CommandContext(ctx, "/bin/sh", scriptPath)
+	cmd.Dir = filepath.Dir(scriptPath)
+	output, err = cmd.CombinedOutput()
+	if cmd.ProcessState != nil {
+		exitCode = cmd.ProcessState.ExitCode()
+	}
+	return output, exitCode, err
+}

--- a/orbit/pkg/scripts/exec_windows.go
+++ b/orbit/pkg/scripts/exec_windows.go
@@ -8,13 +8,12 @@ import (
 	"path/filepath"
 )
 
-func execCmd(ctx context.Context, scriptPath string) ([]byte, error) {
+func execCmd(ctx context.Context, scriptPath string) (output []byte, exitCode int, err error) {
 	// initialize to -1 in case the process never starts
 	exitCode = -1
 
-	// for Windows, we execute the file directly. It has the '.ps1' extension and
-	// as such will be executed as a PowerShell script.
-	cmd := exec.CommandContext(ctx, scriptPath)
+	// for Windows, we execute the file with powershell.
+	cmd := exec.CommandContext(ctx, "powershell", "-ExecutionPolicy", "Bypass", "-File", scriptPath)
 	cmd.Dir = filepath.Dir(scriptPath)
 	output, err = cmd.CombinedOutput()
 	if cmd.ProcessState != nil {

--- a/orbit/pkg/scripts/exec_windows.go
+++ b/orbit/pkg/scripts/exec_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package scripts
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+)
+
+func execCmd(ctx context.Context, scriptPath string) ([]byte, error) {
+	// initialize to -1 in case the process never starts
+	exitCode = -1
+
+	// for Windows, we execute the file directly. It has the '.ps1' extension and
+	// as such will be executed as a PowerShell script.
+	cmd := exec.CommandContext(ctx, scriptPath)
+	cmd.Dir = filepath.Dir(scriptPath)
+	output, err = cmd.CombinedOutput()
+	if cmd.ProcessState != nil {
+		exitCode = cmd.ProcessState.ExitCode()
+	}
+	return output, exitCode, err
+}

--- a/orbit/pkg/scripts/scripts.go
+++ b/orbit/pkg/scripts/scripts.go
@@ -99,7 +99,6 @@ func (r *Runner) runOne(execID string) (finalErr error) {
 		return fmt.Errorf("create run directory: %w", err)
 	}
 	// prevent destruction of dir if this env var is set
-	// TODO(mna): should we document this? Just an env var at the moment, not a cli flag.
 	if os.Getenv("FLEET_PREVENT_SCRIPT_TEMPDIR_DELETION") == "" {
 		defer func() {
 			fn := os.RemoveAll

--- a/orbit/pkg/scripts/scripts.go
+++ b/orbit/pkg/scripts/scripts.go
@@ -158,7 +158,7 @@ func (r *Runner) runOneDisabled(execID string) error {
 	err := r.Client.SaveHostScriptResult(&fleet.HostScriptResultPayload{
 		ExecutionID: execID,
 		Output:      "script execution disabled",
-		ExitCode:    -1,
+		ExitCode:    -2, // fleetctl knows that -2 means script was disabled on host
 	})
 	if err != nil {
 		return fmt.Errorf("save script result: %w", err)

--- a/orbit/pkg/scripts/scripts.go
+++ b/orbit/pkg/scripts/scripts.go
@@ -92,6 +92,8 @@ func (r *Runner) runOne(execID string) error {
 
 	ext := ".sh"
 	if runtime.GOOS == "windows" {
+		// on Windows, we need to allow script execution otherwise it will be
+		// blocked by default (this only impacts the executing session).
 		ext = ".ps1"
 	}
 	scriptFile := filepath.Join(runDir, "script"+ext)

--- a/orbit/pkg/scripts/scripts.go
+++ b/orbit/pkg/scripts/scripts.go
@@ -1,0 +1,139 @@
+// Package scripts implements support to execute scripts on the host when
+// requested by the Fleet server.
+package scripts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+)
+
+const scriptExecTimeout = 30 * time.Second
+
+// Client defines the methods required for the API requests to the server. The
+// fleet.OrbitClient type satisfies this interface.
+type Client interface {
+	GetHostScript(execID string) (*fleet.HostScriptResult, error)
+	SaveHostScriptResult(result *fleet.HostScriptResultPayload) error
+}
+
+type Runner struct {
+	Client                 Client
+	ScriptExecutionEnabled bool
+
+	// tempDirFn is the function to call to get the temporary directory to use,
+	// inside of which the script-specific subdirectories will be created. If nil,
+	// the user's temp dir will be used (can be set to t.TempDir in tests).
+	tempDirFn func() string
+
+	// execCmdFn can be set for tests to mock actual execution of the script. If
+	// nil, execCmd will be used, which has a different implementation on Windows
+	// and non-Windows platforms.
+	execCmdFn func(ctx context.Context, scriptPath string) ([]byte, int, error)
+}
+
+func (r *Runner) Run(execIDs []string) error {
+	var errs []error
+
+	for _, execID := range execIDs {
+		if !r.ScriptExecutionEnabled {
+			if err := r.runOneDisabled(execID); err != nil {
+				errs = append(errs, err)
+			}
+			continue
+		}
+
+		if err := r.runOne(execID); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// NOTE: when we upgrade to Go1.20, we can use errors.Join, but for now we
+	// just concatenate the error messages in a single error that will be logged
+	// by orbit.
+	var sb strings.Builder
+	for i, e := range errs {
+		if i > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString(e.Error())
+	}
+	return errors.New(sb.String())
+}
+
+func (r *Runner) runOne(execID string) error {
+	script, err := r.Client.GetHostScript(execID)
+	if err != nil {
+		return fmt.Errorf("get host script: %w", err)
+	}
+
+	if script.ExitCode.Valid {
+		// already a result stored for this execution, skip, it shouldn't be sent
+		// again by Fleet.
+		return nil
+	}
+
+	runDir, err := r.createRunDir(execID)
+	if err != nil {
+		return fmt.Errorf("create run directory: %w", err)
+	}
+	// TODO(mna): prevent destruction of dir if some env var is set?
+	defer os.RemoveAll(runDir) // TODO(mna): we should probably capture any error it returns
+
+	ext := ".sh"
+	if runtime.GOOS == "windows" {
+		ext = ".ps1"
+	}
+	scriptFile := filepath.Join(runDir, "script"+ext)
+	if err := os.WriteFile(scriptFile, []byte(script.ScriptContents), 0700); err != nil {
+		return fmt.Errorf("write script file: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), scriptExecTimeout)
+	defer cancel()
+
+	execCmdFn := r.execCmdFn
+	if execCmdFn == nil {
+		execCmdFn = execCmd
+	}
+	start := time.Now()
+	output, exitCode, err := execCmdFn(ctx, scriptFile)
+	duration := time.Since(start)
+
+	// report the output or the error
+	err = r.Client.SaveHostScriptResult(&fleet.HostScriptResultPayload{
+		ExecutionID: execID,
+		Output:      string(output),
+		Runtime:     int(duration.Seconds()),
+		ExitCode:    exitCode,
+	})
+	if err != nil {
+		return fmt.Errorf("save script result: %w", err)
+	}
+	return nil
+}
+
+func (r *Runner) createRunDir(execID string) (string, error) {
+	var tempDir string // empty tempDir means use system default
+	if r.tempDirFn != nil {
+		tempDir = r.tempDirFn()
+	}
+	// MkdirTemp will only allow read/write by current user (root), which is what
+	// we want.
+	return os.MkdirTemp(tempDir, "fleet-"+execID+"-*")
+}
+
+func (r *Runner) runOneDisabled(execID string) error {
+	return r.Client.SaveHostScriptResult(&fleet.HostScriptResultPayload{
+		ExecutionID: execID,
+		Output:      "script execution disabled",
+		ExitCode:    -1,
+	})
+}

--- a/orbit/pkg/scripts/scripts.go
+++ b/orbit/pkg/scripts/scripts.go
@@ -105,7 +105,9 @@ func (r *Runner) runOne(execID string) error {
 		ext = ".ps1"
 	}
 	scriptFile := filepath.Join(runDir, "script"+ext)
-	if err := os.WriteFile(scriptFile, []byte(script.ScriptContents), 0700); err != nil {
+	// the file does not need the executable bit set, it will be executed as
+	// argument to powershell or /bin/sh.
+	if err := os.WriteFile(scriptFile, []byte(script.ScriptContents), 0600); err != nil {
 		return fmt.Errorf("write script file: %w", err)
 	}
 

--- a/orbit/pkg/scripts/scripts_test.go
+++ b/orbit/pkg/scripts/scripts_test.go
@@ -2,7 +2,13 @@ package scripts
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -55,6 +61,85 @@ func TestRunner(t *testing.T) {
 			execCalls:   1,
 			errContains: "no such script: b",
 		},
+		{
+			desc:        "one ok, one unknown, disabled",
+			client:      &mockClient{scripts: map[string]*fleet.HostScriptResult{"a": {}}},
+			execer:      &mockExecCmd{},
+			enabled:     false,
+			execIDs:     []string{"a", "b"},
+			execCalls:   0,
+			errContains: "", // no error because when scripts are disabled, the script is not fetched (save will not update anything)
+		},
+		{
+			desc:      "multiple, success",
+			client:    &mockClient{scripts: map[string]*fleet.HostScriptResult{"a": {}, "b": {}, "c": {}}},
+			execer:    &mockExecCmd{},
+			enabled:   true,
+			execIDs:   []string{"a", "b", "c"},
+			execCalls: 3,
+		},
+		{
+			desc:      "multiple, disabled, success",
+			client:    &mockClient{scripts: map[string]*fleet.HostScriptResult{"a": {}, "b": {}, "c": {}}},
+			execer:    &mockExecCmd{},
+			enabled:   false,
+			execIDs:   []string{"a", "b", "c"},
+			execCalls: 0,
+		},
+		{
+			desc:        "failed to get script",
+			client:      &mockClient{getErr: io.ErrUnexpectedEOF, scripts: map[string]*fleet.HostScriptResult{"a": {}}},
+			execer:      &mockExecCmd{},
+			enabled:     true,
+			execIDs:     []string{"a"},
+			execCalls:   0,
+			errContains: "get host script: unexpected EOF",
+		},
+		{
+			desc:        "failed to save script",
+			client:      &mockClient{saveErr: io.ErrUnexpectedEOF, scripts: map[string]*fleet.HostScriptResult{"a": {}}},
+			execer:      &mockExecCmd{},
+			enabled:     true,
+			execIDs:     []string{"a"},
+			execCalls:   1,
+			errContains: "save script result: unexpected EOF",
+		},
+		{
+			desc:        "run returns error",
+			client:      &mockClient{scripts: map[string]*fleet.HostScriptResult{"a": {}}},
+			execer:      &mockExecCmd{err: io.ErrUnexpectedEOF},
+			enabled:     true,
+			execIDs:     []string{"a"},
+			execCalls:   1,
+			errContains: "", // no error reported, the run error is included in the results
+		},
+		{
+			desc:        "failed to save script, disabled",
+			client:      &mockClient{saveErr: io.ErrUnexpectedEOF, scripts: map[string]*fleet.HostScriptResult{"a": {}}},
+			execer:      &mockExecCmd{},
+			enabled:     false,
+			execIDs:     []string{"a"},
+			execCalls:   0,
+			errContains: "save script result: unexpected EOF",
+		},
+		{
+			desc:        "script with existing results",
+			client:      &mockClient{scripts: map[string]*fleet.HostScriptResult{"a": {ExitCode: sql.NullInt64{Valid: true}}}},
+			execer:      &mockExecCmd{},
+			enabled:     true,
+			execIDs:     []string{"a"},
+			execCalls:   0,
+			errContains: "", // no errors reported, script is just skipped
+		},
+		{
+			desc:        "multiple errors reported, one get fails, one non-existing",
+			client:      &mockClient{getErr: errFailOnce, scripts: map[string]*fleet.HostScriptResult{"a": {ExitCode: sql.NullInt64{Valid: true}}}},
+			execer:      &mockExecCmd{},
+			enabled:     true,
+			execIDs:     []string{"a", "b"},
+			execCalls:   0,
+			errContains: "get host script: fail once\nget host script: no such script: b",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
@@ -75,6 +160,124 @@ func TestRunner(t *testing.T) {
 	}
 }
 
+func TestRunnerTempDir(t *testing.T) {
+	tempDir := t.TempDir()
+	client := &mockClient{scripts: map[string]*fleet.HostScriptResult{"a": {ScriptContents: "echo 'Hi'"}}}
+	execer := &mockExecCmd{output: []byte("output"), exitCode: 0, err: nil}
+	runner := &Runner{
+		Client:                 client,
+		ScriptExecutionEnabled: true,
+		tempDirFn:              func() string { return tempDir },
+		execCmdFn:              execer.run,
+	}
+	err := runner.Run([]string{"a"})
+	require.NoError(t, err)
+	require.Equal(t, 1, execer.count)
+	require.Equal(t, "output", client.results["a"].Output)
+
+	// ensure the temp directory was removed after execution
+	entries, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
+	require.Empty(t, entries)
+
+	// run again, this time preventing dir deletion
+	t.Setenv("FLEET_PREVENT_SCRIPT_TEMPDIR_DELETION", "1")
+	execer.count = 0
+
+	err = runner.Run([]string{"a"})
+	require.NoError(t, err)
+	require.Equal(t, 1, execer.count)
+	require.Equal(t, "output", client.results["a"].Output)
+
+	entries, err = os.ReadDir(tempDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	// the entry is the script's execution directory
+	require.True(t, entries[0].IsDir())
+	require.Contains(t, entries[0].Name(), "fleet-a-")
+
+	runDir := filepath.Join(tempDir, entries[0].Name())
+	runEntries, err := os.ReadDir(runDir)
+	require.NoError(t, err)
+	require.Len(t, runEntries, 1) // run directory contains the script
+
+	b, err := os.ReadFile(filepath.Join(runDir, runEntries[0].Name()))
+	require.NoError(t, err)
+	require.Equal(t, "echo 'Hi'", string(b))
+}
+
+func TestRunnerResults(t *testing.T) {
+	output40K := strings.Repeat("a", 4000) +
+		strings.Repeat("b", 4000) +
+		strings.Repeat("c", 4000) +
+		strings.Repeat("d", 4000) +
+		strings.Repeat("e", 4000) +
+		strings.Repeat("f", 4000) +
+		strings.Repeat("g", 4000) +
+		strings.Repeat("h", 4000) +
+		strings.Repeat("i", 4000) +
+		strings.Repeat("j", 4000)
+
+	output44K := output40K + strings.Repeat("k", 4000)
+
+	errSuffix := "\nscript execution error: " + io.ErrUnexpectedEOF.Error()
+
+	cases := []struct {
+		desc       string
+		output     string
+		exitCode   int
+		runErr     error
+		wantOutput string
+	}{
+		{
+			desc:       "exactly the limit",
+			output:     output40K,
+			exitCode:   1,
+			runErr:     nil,
+			wantOutput: output40K,
+		},
+		{
+			desc:       "too many bytes",
+			output:     output44K,
+			exitCode:   1,
+			runErr:     nil,
+			wantOutput: output44K[strings.Index(output44K, "b"):],
+		},
+		{
+			desc:       "empty with error",
+			output:     "",
+			exitCode:   -1,
+			runErr:     io.ErrUnexpectedEOF,
+			wantOutput: errSuffix,
+		},
+		{
+			desc:       "limit with error",
+			output:     output40K,
+			exitCode:   -1,
+			runErr:     io.ErrUnexpectedEOF,
+			wantOutput: output40K[len(errSuffix):] + errSuffix,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			client := &mockClient{scripts: map[string]*fleet.HostScriptResult{"a": {ScriptContents: "echo 'Hi'"}}}
+			execer := &mockExecCmd{output: []byte(c.output), exitCode: c.exitCode, err: c.runErr}
+			runner := &Runner{
+				Client:                 client,
+				ScriptExecutionEnabled: true,
+				tempDirFn:              t.TempDir,
+				execCmdFn:              execer.run,
+			}
+			err := runner.Run([]string{"a"})
+			require.NoError(t, err)
+			require.Equal(t, 1, execer.count)
+			require.Equal(t, c.wantOutput, client.results["a"].Output)
+			require.Equal(t, c.exitCode, client.results["a"].ExitCode)
+		})
+	}
+}
+
 type mockExecCmd struct {
 	output   []byte
 	exitCode int
@@ -87,15 +290,22 @@ func (m *mockExecCmd) run(ctx context.Context, scriptPath string) ([]byte, int, 
 	return m.output, m.exitCode, m.err
 }
 
+var errFailOnce = errors.New("fail once")
+
 type mockClient struct {
 	scripts map[string]*fleet.HostScriptResult
+	results map[string]*fleet.HostScriptResultPayload
 	getErr  error
 	saveErr error
 }
 
 func (m *mockClient) GetHostScript(execID string) (*fleet.HostScriptResult, error) {
 	if m.getErr != nil {
-		return nil, m.getErr
+		err := m.getErr
+		if err == errFailOnce {
+			m.getErr = nil
+		}
+		return nil, err
 	}
 
 	script := m.scripts[execID]
@@ -106,5 +316,14 @@ func (m *mockClient) GetHostScript(execID string) (*fleet.HostScriptResult, erro
 }
 
 func (m *mockClient) SaveHostScriptResult(result *fleet.HostScriptResultPayload) error {
-	return m.saveErr
+	if m.results == nil {
+		m.results = make(map[string]*fleet.HostScriptResultPayload)
+	}
+	m.results[result.ExecutionID] = result
+
+	err := m.saveErr
+	if err == errFailOnce {
+		m.saveErr = nil
+	}
+	return err
 }

--- a/orbit/pkg/scripts/scripts_test.go
+++ b/orbit/pkg/scripts/scripts_test.go
@@ -1,0 +1,110 @@
+package scripts
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunner(t *testing.T) {
+	cases := []struct {
+		desc string
+
+		// setup
+		client  *mockClient
+		execer  *mockExecCmd
+		enabled bool
+		execIDs []string
+
+		// expected
+		errContains string
+		execCalls   int
+	}{
+		{
+			desc:      "no exec ids",
+			client:    &mockClient{},
+			execer:    &mockExecCmd{},
+			enabled:   true,
+			execCalls: 0,
+		},
+		{
+			desc:      "one exec id, success",
+			client:    &mockClient{scripts: map[string]*fleet.HostScriptResult{"a": {}}},
+			execer:    &mockExecCmd{},
+			enabled:   true,
+			execIDs:   []string{"a"},
+			execCalls: 1,
+		},
+		{
+			desc:      "one exec id disabled, success",
+			client:    &mockClient{scripts: map[string]*fleet.HostScriptResult{"a": {}}},
+			execer:    &mockExecCmd{},
+			enabled:   false,
+			execIDs:   []string{"a"},
+			execCalls: 0,
+		},
+		{
+			desc:        "one ok, one unknown",
+			client:      &mockClient{scripts: map[string]*fleet.HostScriptResult{"a": {}}},
+			execer:      &mockExecCmd{},
+			enabled:     true,
+			execIDs:     []string{"a", "b"},
+			execCalls:   1,
+			errContains: "no such script: b",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			runner := &Runner{
+				Client:                 c.client,
+				ScriptExecutionEnabled: c.enabled,
+				tempDirFn:              t.TempDir,
+				execCmdFn:              c.execer.run,
+			}
+			err := runner.Run(c.execIDs)
+			if c.errContains != "" {
+				require.ErrorContains(t, err, c.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, c.execCalls, c.execer.count)
+		})
+	}
+}
+
+type mockExecCmd struct {
+	output   []byte
+	exitCode int
+	err      error
+	count    int
+}
+
+func (m *mockExecCmd) run(ctx context.Context, scriptPath string) ([]byte, int, error) {
+	m.count++
+	return m.output, m.exitCode, m.err
+}
+
+type mockClient struct {
+	scripts map[string]*fleet.HostScriptResult
+	getErr  error
+	saveErr error
+}
+
+func (m *mockClient) GetHostScript(execID string) (*fleet.HostScriptResult, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+
+	script := m.scripts[execID]
+	if script == nil {
+		return nil, fmt.Errorf("no such script: %s", execID)
+	}
+	return script, nil
+}
+
+func (m *mockClient) SaveHostScriptResult(result *fleet.HostScriptResultPayload) error {
+	return m.saveErr
+}

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -4219,7 +4219,7 @@ func (ds *Datastore) SetHostScriptExecutionResult(ctx context.Context, result *f
 	if len(output) > utf8.UTFMax*maxOutputRuneLen {
 		// truncate the bytes as we know the output is too long, no point
 		// converting more bytes than needed to runes.
-		output = output[len(output)-utf8.UTFMax*maxOutputRuneLen:]
+		output = output[len(output)-(utf8.UTFMax*maxOutputRuneLen):]
 	}
 	if utf8.RuneCountInString(output) > maxOutputRuneLen {
 		outputRunes := []rune(output)

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -3802,6 +3802,7 @@ func (s *integrationEnterpriseTestSuite) TestRunHostScript() {
 	require.Equal(t, host.ID, runSyncResp.HostID)
 	require.NotEmpty(t, runSyncResp.ExecutionID)
 	require.Equal(t, "ok", runSyncResp.Output)
+	require.True(t, runSyncResp.ExitCode.Valid)
 	require.Equal(t, int64(0), runSyncResp.ExitCode.Int64)
 	require.Empty(t, runSyncResp.ErrorMessage)
 

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -163,7 +163,7 @@ func getOrbitConfigEndpoint(ctx context.Context, request interface{}, svc fleet.
 }
 
 func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, error) {
-	const pendingScriptMaxAge = 24 * time.Hour
+	const pendingScriptMaxAge = time.Minute
 
 	// this is not a user-authenticated endpoint
 	svc.authz.SkipAuthorization(ctx)

--- a/tools/run-scripts/main.go
+++ b/tools/run-scripts/main.go
@@ -1,0 +1,84 @@
+// Command run-scripts is a tool for testing script execution on hosts exactly
+// as Orbit would do following reception of a Fleet server notification of
+// pending script(s) to execute.
+//
+// It allows to run such scripts without having to build and deploy orbit on
+// the target host and without having to enroll that host in fleet and have the
+// fleet server send script execution requests to it.
+//
+// The results of script execution, as reported by the host, are printed to the
+// standard output.
+//
+// Usage on the host:
+//
+//	run-scripts
+//	run-scripts -exec-id my-specific-id -content 'echo "Hello, world!"'
+//	run-scripts -scripts-disabled -content 'echo "Hello, world!"'
+//	run-scripts -scripts-count 10
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/fleetdm/fleet/v4/orbit/pkg/scripts"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/google/uuid"
+)
+
+func main() {
+	execIDFlag := flag.String("exec-id", "", "Execution ID of the script, will be auto-generated if empty.")
+	contentFlag := flag.String("content", "echo \"Hello\"", "Content of the script to execute.")
+	scriptsDisabledFlag := flag.Bool("scripts-disabled", false, "Disable execution of scripts on the host.")
+	scriptsCountFlag := flag.Int("scripts-count", 1, "Number of scripts to execute. If > 1, the content will all be the same and exec-id will be auto-generated.")
+
+	flag.Parse()
+
+	if *scriptsCountFlag < 1 {
+		log.Fatal("scripts-count must be >= 1")
+	}
+
+	cli := mockClient{content: *contentFlag}
+	runner := &scripts.Runner{
+		ScriptExecutionEnabled: !*scriptsDisabledFlag,
+		Client:                 cli,
+	}
+
+	execIDs := make([]string, *scriptsCountFlag)
+	for i := range execIDs {
+		if *execIDFlag != "" && len(execIDs) == 1 {
+			execIDs[i] = *execIDFlag
+			break
+		}
+		execIDs[i] = uuid.New().String()
+	}
+
+	if err := runner.Run(execIDs); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type mockClient struct {
+	content string
+}
+
+func (m mockClient) GetHostScript(execID string) (*fleet.HostScriptResult, error) {
+	return &fleet.HostScriptResult{
+		HostID:         1,
+		ExecutionID:    execID,
+		ScriptContents: m.content,
+	}, nil
+}
+
+func (m mockClient) SaveHostScriptResult(result *fleet.HostScriptResultPayload) error {
+	fmt.Printf(`
+Script result for %q:
+  Exit code: %d
+  Runtime:   %d second(s)
+  Output:
+%s
+---
+`, result.ExecutionID, result.ExitCode, result.Runtime, result.Output)
+	return nil
+}


### PR DESCRIPTION
#13307 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux. (done using the tool, not orbit itself)
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
