### PR TITLE
Fleet UI: [small released styling bugs] Fix live query icons (size, alignment, style, color)

### DIFF
--- a/changes/13576-fix-filter-icon
+++ b/changes/13576-fix-filter-icon
@@ -1,0 +1,1 @@
+- Fix live query filter icon and various other live query icons

--- a/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
+++ b/frontend/components/LiveQuery/TargetsInput/TargetsInput.tsx
@@ -52,7 +52,7 @@ const TargetsInput = ({
         <Input
           autofocus
           type="search"
-          iconName="search"
+          iconSvg="search"
           value={searchText}
           tabIndex={tabIndex}
           iconPosition="start"

--- a/frontend/components/TableContainer/DataTable/DefaultColumnFilter/DefaultColumnFilter.tsx
+++ b/frontend/components/TableContainer/DataTable/DefaultColumnFilter/DefaultColumnFilter.tsx
@@ -15,6 +15,7 @@ const DefaultColumnFilter = ({
         onChange={(searchString) => {
           setFilter(searchString || undefined); // Set undefined to remove the filter entirely
         }}
+        icon="filter-funnel"
       />
     </div>
   );

--- a/frontend/components/TableContainer/DataTable/DefaultColumnFilter/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/DefaultColumnFilter/_styles.scss
@@ -1,13 +1,13 @@
 .filter-cell {
   input {
-    height: 28px;
+    height: 40px;
     width: 100%;
     font-size: $x-small;
     background-color: $ui-off-white;
     border: 1px solid $ui-fleet-black-10;
     border-radius: 4px;
     padding: 4px;
-    padding-left: 20px;
+    padding-left: 32px;
     margin-top: $pad-xsmall;
   }
 
@@ -15,13 +15,14 @@
     position: relative;
     color: $core-fleet-blue;
     width: 100%;
+  }
 
-    &::before {
-      display: inline-block;
-      position: absolute;
-      content: url(../assets/images/icon-filter-grey-12x12@2x.png);
-      transform: scale(0.5);
-      top: 4px;
+  .icon {
+    left: 10px;
+    top: 17px;
+
+    path {
+      fill: $ui-fleet-black-33; // Override input icon color
     }
   }
 }

--- a/frontend/components/forms/fields/SearchField/SearchField.tsx
+++ b/frontend/components/forms/fields/SearchField/SearchField.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
+import { IconNames } from "components/icons";
 // @ts-ignore
 import InputFieldWithIcon from "../InputFieldWithIcon";
 
@@ -9,12 +10,14 @@ export interface ISearchFieldProps {
   placeholder: string;
   defaultValue?: string;
   onChange: (value: string) => void;
+  icon?: IconNames;
 }
 
 const SearchField = ({
   placeholder,
   defaultValue = "",
   onChange,
+  icon = "search",
 }: ISearchFieldProps): JSX.Element => {
   const [searchQueryInput, setSearchQueryInput] = useState(defaultValue);
 
@@ -29,13 +32,13 @@ const SearchField = ({
 
   return (
     <InputFieldWithIcon
-      name="search"
+      name={icon}
       placeholder={placeholder}
       value={searchQueryInput}
       // inputWrapperClass={`${baseClass}__input-wrapper`}
       onChange={onInputChange}
       iconPosition="start"
-      iconSvg="search"
+      iconSvg={icon}
     />
   );
 };

--- a/frontend/components/icons/FilterFunnel.tsx
+++ b/frontend/components/icons/FilterFunnel.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { COLORS, Colors } from "styles/var/colors";
+import { ICON_SIZES, IconSizes } from "styles/var/icon_sizes";
+
+interface IFilterFunnelProps {
+  color?: Colors;
+  size?: IconSizes;
+}
+
+const FilterFunnel = ({
+  size = "medium",
+  color = "ui-fleet-black-33",
+}: IFilterFunnelProps) => {
+  console.log("color", color);
+  return (
+    <svg
+      width={ICON_SIZES[size]}
+      height={ICON_SIZES[size]}
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="m15.86 1.497-.01-.01A.934.934 0 0 0 16 .991.999.999 0 0 0 15 0H1C.45 0 0 .446 0 .991c0 .189.06.347.15.496l-.01.01L6 7.371V14l4 2V7.371l5.86-5.874Z"
+        fill={COLORS[color]}
+      />
+    </svg>
+  );
+};
+
+export default FilterFunnel;

--- a/frontend/components/icons/index.ts
+++ b/frontend/components/icons/index.ts
@@ -22,6 +22,7 @@ import EmptyTeams from "./EmptyTeams";
 import ExternalLink from "./ExternalLink";
 import Filter from "./Filter";
 import FilterAlt from "./FilterAlt";
+import FilterFunnel from "./FilterFunnel";
 import Info from "./Info";
 import Issue from "./Issue";
 import More from "./More";
@@ -101,6 +102,7 @@ export const ICON_MAP = {
   "external-link": ExternalLink,
   filter: Filter,
   "filter-alt": FilterAlt,
+  "filter-funnel": FilterFunnel,
   "low-disk-space-hosts": LowDiskSpaceHosts,
   "missing-hosts": MissingHosts,
   lightbulb: Lightbulb,

--- a/frontend/pages/policies/PolicyPage/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/_styles.scss
@@ -75,6 +75,7 @@
       margin-bottom: 8px;
       font-size: $x-small;
     }
+
     .selector-block {
       display: flex;
       align-items: center;
@@ -174,6 +175,11 @@
     gap: $pad-xsmall;
     .form-field--checkbox {
       margin-bottom: 0;
+    }
+  }
+  .targets-input {
+    .input-icon-field__icon {
+      top: 34px; // Override styling to include label header
     }
   }
 }

--- a/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/policies/PolicyPage/components/QueryResults/QueryResults.tsx
@@ -115,7 +115,7 @@ const QueryResults = ({
           variant="text-icon"
         >
           <>
-            Show query <Icon name="eye" size="small" />
+            Show query <Icon name="eye" />
           </>
         </Button>
         <Button

--- a/frontend/pages/queries/QueryPage/_styles.scss
+++ b/frontend/pages/queries/QueryPage/_styles.scss
@@ -78,6 +78,7 @@
       margin-bottom: 8px;
       font-size: $x-small;
     }
+
     .selector-block {
       display: flex;
       align-items: center;
@@ -169,6 +170,12 @@
       margin: 0;
       margin-top: $pad-medium;
       font-size: $x-small;
+    }
+  }
+
+  .targets-input {
+    .input-icon-field__icon {
+      top: 34px; // Override styling to include label header
     }
   }
 }

--- a/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryResults/QueryResults.tsx
@@ -162,7 +162,7 @@ const QueryResults = ({
           variant="text-icon"
         >
           <>
-            Show query <Icon name="eye" size="small" />
+            Show query <Icon name="eye" />
           </>
         </Button>
         <Button


### PR DESCRIPTION
## Issue
Cerra #13576 

## Description
- Initially fixed just the filter results icon was the wrong icon and misaligned (magnifying glass should've been a funnel)
- Realized needed to fix the search target icon alignment
- Realized needed to fix the show query icon size (12x12 > 16x16)

## Screenshots


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

