### PR TITLE
Fix expected number of hosts for the `Test fleetctl preview` workflow

### DIFF
--- a/.github/workflows/fleetctl-preview.yml
+++ b/.github/workflows/fleetctl-preview.yml
@@ -39,7 +39,7 @@ jobs:
         fleetctl preview
         sleep 10
         fleetctl get hosts | tee hosts.txt
-        [ $( cat hosts.txt | grep online | wc -l) -eq 8 ]
+        [ $( cat hosts.txt | grep online | wc -l) -eq 9 ]
       shell: bash
 
     - name: Get fleet logs


### PR DESCRIPTION
Similar to the other we fixed recently the same way: https://github.com/fleetdm/fleet/pull/13329