### PR TITLE
Docs: Rename "Deploy Fleet on Cloud.gov" page in nav

### DIFF
--- a/docs/Deploy/cloudgov.md
+++ b/docs/Deploy/cloudgov.md
@@ -110,7 +110,7 @@ variables](https://fleetdm.com/docs/deploying/configuration#using-only-environme
 }
 ```
 
-<meta name="title" value="Deploy Fleet on Cloud.gov">
+<meta name="title" value="Cloud.gov">
 <meta name="pageOrderInSection" value="700">
 <meta name="description" value="A guide for deploying Fleet on Cloud.gov.">
 <meta name="navSection" value="Deployment guides">


### PR DESCRIPTION
Rename "Deploy Fleet on Cloud.gov" to "Cloud.gov" to match updated names for other deployment guides:
![Screenshot 2023-08-31 at 10 22 27 AM](https://github.com/fleetdm/fleet/assets/3065949/50e7e1a2-c439-46bc-a8f8-74a3a71e016b)
