### PR TITLE
Scripts: update host timeout error message

### DIFF
--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -1137,9 +1137,9 @@ func (hsr HostScriptResult) AuthzType() string {
 func (hsr HostScriptResult) UserMessage(hostTimeout bool) string {
 	switch {
 	case hostTimeout:
-		return "Fleet hasn’t heard from the host in over 1 minute. Fleet doesn’t know if the script ran because the host went offline."
+		return "Fleet hasn't heard from the host in over 1 minute. Fleet doesn’t know if the script ran because the host went offline."
 	case !hostTimeout && time.Since(hsr.CreatedAt) > time.Minute:
-		return "Fleet hasn’t heard from the host in over 1 minute. Fleet doesn’t know if the script ran because the host went offline."
+		return "Fleet hasn't heard from the host in over 1 minute. Fleet doesn’t know if the script ran because the host went offline."
 	case hsr.ExitCode.Int64 == -1:
 		return "Timeout. Fleet stopped the script after 30 seconds to protect host performance."
 	case hsr.ExitCode.Int64 == -2:

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -1137,9 +1137,9 @@ func (hsr HostScriptResult) AuthzType() string {
 func (hsr HostScriptResult) UserMessage(hostTimeout bool) string {
 	switch {
 	case hostTimeout:
-		return "Fleet hasn't heard from the host in over 1 minute. Fleet doesn’t know if the script ran because the host went offline."
+		return "Fleet hasn't heard from the host in over 1 minute. Fleet doesn't know if the script ran because the host went offline."
 	case !hostTimeout && time.Since(hsr.CreatedAt) > time.Minute:
-		return "Fleet hasn't heard from the host in over 1 minute. Fleet doesn’t know if the script ran because the host went offline."
+		return "Fleet hasn't heard from the host in over 1 minute. Fleet doesn't know if the script ran because the host went offline."
 	case hsr.ExitCode.Int64 == -1:
 		return "Timeout. Fleet stopped the script after 30 seconds to protect host performance."
 	case hsr.ExitCode.Int64 == -2:

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -1137,9 +1137,9 @@ func (hsr HostScriptResult) AuthzType() string {
 func (hsr HostScriptResult) UserMessage(hostTimeout bool) string {
 	switch {
 	case hostTimeout:
-		return "Fleet hasn't heard from the host in over 1 minute because it went offline. Run the script again when the host comes back online."
+		return "Fleet hasn’t heard from the host in over 1 minute. Fleet doesn’t know if the script ran because the host went offline."
 	case !hostTimeout && time.Since(hsr.CreatedAt) > time.Minute:
-		return "Fleet hasn't heard from the host in over 1 minute because it went offline. Run the script again when the host comes back online."
+		return "Fleet hasn’t heard from the host in over 1 minute. Fleet doesn’t know if the script ran because the host went offline."
 	case hsr.ExitCode.Int64 == -1:
 		return "Timeout. Fleet stopped the script after 30 seconds to protect host performance."
 	case hsr.ExitCode.Int64 == -2:

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -3762,7 +3762,7 @@ func (s *integrationEnterpriseTestSuite) TestRunHostScript() {
 	require.Equal(t, host.ID, runSyncResp.HostID)
 	require.NotEmpty(t, runSyncResp.ExecutionID)
 	require.True(t, runSyncResp.HostTimeout)
-	require.Contains(t, runSyncResp.Message, "Fleet hasn’t heard from the host in over 1 minute. Fleet doesn’t know if the script ran because the host went offline.")
+	require.Contains(t, runSyncResp.Message, "Fleet hasn't heard from the host in over 1 minute. Fleet doesn't know if the script ran because the host went offline.")
 
 	s.DoJSON("POST", "/api/fleet/orbit/scripts/result",
 		json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q, "execution_id": %q, "exit_code": 0, "output": "ok"}`, *host.OrbitNodeKey, runSyncResp.ExecutionID)),

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -3762,7 +3762,7 @@ func (s *integrationEnterpriseTestSuite) TestRunHostScript() {
 	require.Equal(t, host.ID, runSyncResp.HostID)
 	require.NotEmpty(t, runSyncResp.ExecutionID)
 	require.True(t, runSyncResp.HostTimeout)
-	require.Contains(t, runSyncResp.Message, "Fleet hasn't heard from the host in over 1 minute because it went offline.")
+	require.Contains(t, runSyncResp.Message, "Fleet hasn’t heard from the host in over 1 minute. Fleet doesn’t know if the script ran because the host went offline.")
 
 	s.DoJSON("POST", "/api/fleet/orbit/scripts/result",
 		json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q, "execution_id": %q, "exit_code": 0, "output": "ok"}`, *host.OrbitNodeKey, runSyncResp.ExecutionID)),


### PR DESCRIPTION
Part of the Run a script via CLI story (#9583)

- Update copy for erorr message we display when we haven't heard back from the host in over 1 minute.

This copy change discussed during today's MDM design review. Figma [here](https://www.figma.com/file/030moybHDEurtYx52D70sF/%239583-Script-execution%3A-Run-a-script-via-CLI?type=design&node-id=231%3A1084&mode=design&t=infeGdAnf7faqUkJ-1) is also updated.
