### PR TITLE
Fleet UI: [small unreleased bug fix] Fix empty team policies search to still show inherited policies table, faster team policies page

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -576,9 +576,9 @@ const ManagePolicyPage = ({
     isAnyTeamSelected &&
     !isFetchingTeamPolicies &&
     !teamPoliciesError &&
-    !isFetchingGlobalPolicies &&
-    !globalPoliciesError &&
-    !!globalPolicies?.length;
+    !!inheritedPolicies?.length;
+  console.log("!!inheritedPolicies?.length;", !!inheritedPolicies?.length);
+  console.log("showInheritedPoliciesButton", showInheritedPoliciesButton);
 
   const availablePoliciesForAutomation =
     (isAnyTeamSelected ? teamPolicies : globalPolicies) || [];
@@ -735,7 +735,6 @@ const ManagePolicyPage = ({
                 currentAutomatedPolicies={currentAutomatedPolicies}
                 isPremiumTier={isPremiumTier}
                 isSandboxMode={isSandboxMode}
-                // onClientSidePaginationChange={onClientSidePaginationChange}
                 renderPoliciesCount={() =>
                   !isFetchingGlobalCount &&
                   renderPoliciesCount(globalPoliciesCount)
@@ -748,27 +747,25 @@ const ManagePolicyPage = ({
               />
             ))}
         </div>
-        {showInheritedPoliciesButton &&
-          globalPolicies &&
-          globalPoliciesCount && (
-            <RevealButton
-              isShowing={showInheritedTable}
-              className={baseClass}
-              hideText={inheritedPoliciesButtonText(
-                showInheritedTable,
-                globalPoliciesCount
-              )}
-              showText={inheritedPoliciesButtonText(
-                showInheritedTable,
-                globalPoliciesCount
-              )}
-              caretPosition={"before"}
-              tooltipHtml={
-                '"All teams" policies are checked <br/> for this team’s hosts.'
-              }
-              onClick={toggleShowInheritedPolicies}
-            />
-          )}
+        {showInheritedPoliciesButton && globalPoliciesCount && (
+          <RevealButton
+            isShowing={showInheritedTable}
+            className={baseClass}
+            hideText={inheritedPoliciesButtonText(
+              showInheritedTable,
+              globalPoliciesCount
+            )}
+            showText={inheritedPoliciesButtonText(
+              showInheritedTable,
+              globalPoliciesCount
+            )}
+            caretPosition={"before"}
+            tooltipHtml={
+              '"All teams" policies are checked <br/> for this team’s hosts.'
+            }
+            onClick={toggleShowInheritedPolicies}
+          />
+        )}
         {showInheritedPoliciesButton && showInheritedTable && (
           <div className={`${baseClass}__inherited-policies-table`}>
             {globalPoliciesError && <TableDataError />}
@@ -784,9 +781,6 @@ const ManagePolicyPage = ({
                   tableType="inheritedPolicies"
                   currentTeam={currentTeamSummary}
                   searchQuery=""
-                  // onClientSidePaginationChange={
-                  //   onClientSideInheritedPaginationChange
-                  // }
                   renderPoliciesCount={() =>
                     renderPoliciesCount(teamPoliciesCount)
                   }

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -239,7 +239,7 @@ const ManagePolicyPage = ({
       return globalPoliciesAPI.loadAllNew(queryKey[0]);
     },
     {
-      enabled: isRouteOk,
+      enabled: isRouteOk && !isAnyTeamSelected,
       select: (data) => data.policies,
       staleTime: 5000,
     }
@@ -362,9 +362,10 @@ const ManagePolicyPage = ({
   );
 
   const refetchPolicies = (teamId?: number) => {
-    refetchGlobalPolicies();
     if (teamId) {
       refetchTeamPolicies();
+    } else {
+      refetchGlobalPolicies(); // Only call on global policies as this is expensive
     }
   };
 

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -576,9 +576,7 @@ const ManagePolicyPage = ({
     isAnyTeamSelected &&
     !isFetchingTeamPolicies &&
     !teamPoliciesError &&
-    !!inheritedPolicies?.length;
-  console.log("!!inheritedPolicies?.length;", !!inheritedPolicies?.length);
-  console.log("showInheritedPoliciesButton", showInheritedPoliciesButton);
+    !!inheritedPolicies?.length; // Returned with team policies
 
   const availablePoliciesForAutomation =
     (isAnyTeamSelected ? teamPolicies : globalPolicies) || [];


### PR DESCRIPTION
## Issue 
Small unreleased bug from #13458 

## Description
- Don't want to hide inherited policies table if the search of a team policies table returns no results
- Update to use new globalPolicies.getCount API call instead of the globalPolicies API call to conditionally show the button and table
- Remove old global policies API calls on team level pages to make them faster!

## Screenshot
### Before (Search team policies no results hid the inherited policies)
<img width="1422" alt="Screenshot 2023-08-31 at 1 32 24 PM" src="https://github.com/fleetdm/fleet/assets/71795832/3d051f3e-631b-4eba-b9d7-6f2315916c1d">

### After (Search team policies no results still shows the inherited policies)
<img width="1419" alt="Screenshot 2023-08-31 at 1 28 55 PM" src="https://github.com/fleetdm/fleet/assets/71795832/01bd34cf-dbc5-4f75-8f18-ed05a739a637">

## How to QA
1. Go to a team policies page
2. Search using the search input for something that shows no results
3. Confirm you can still see the inherited policies table below (bug was that it disappeared)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

