### PR TITLE
Fleet UI: More picky regex (Add alternative where must have http and/or www in link)

### DIFF
--- a/frontend/components/ClickableUrls/ClickableUrls.tsx
+++ b/frontend/components/ClickableUrls/ClickableUrls.tsx
@@ -21,7 +21,7 @@ const ClickableUrls = ({ text, className }: IClickableUrls): JSX.Element => {
 
   // Regex to find case insensitive URLs and replace with link
   const replacedLinks = text.replaceAll(
-    /(https?)?(:\/\/)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/g,
+    /(((https?)?(:\/\/))|((https?)?(:\/\/)?(www\.)))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&\/\/=]*)/g,
     urlReplacer
   );
   const sanitizedResolutionContent = DOMPurify.sanitize(replacedLinks, {

--- a/frontend/components/ClickableUrls/ClickableUrls.tsx
+++ b/frontend/components/ClickableUrls/ClickableUrls.tsx
@@ -21,7 +21,7 @@ const ClickableUrls = ({ text, className }: IClickableUrls): JSX.Element => {
 
   // Regex to find case insensitive URLs and replace with link
   const replacedLinks = text.replaceAll(
-    /(((https?)?(:\/\/))|((https?)?(:\/\/)?(www\.)))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&\/\/=]*)/g,
+    /(((https?)?(:\/\/))|((https?)?(:\/\/)?(www\.)))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/g,
     urlReplacer
   );
   const sanitizedResolutionContent = DOMPurify.sanitize(replacedLinks, {


### PR DESCRIPTION
## Issue
Refine #12243 

## Description
- The regex solution to catch URLs in the policy resolution was catching things like com.safari
- Be more picky so the URL must include http/https OR www (OR both)

## Screenshot
<img width="1419" alt="Screenshot 2023-08-31 at 4 40 02 PM" src="https://github.com/fleetdm/fleet/assets/71795832/8a2cb507-c37e-422a-9eca-8ea3a93d8063">

## regex Tester (showing example matches for links)
https://regex101.com/r/sZL3Jo/1

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
