### PR TITLE
Attempt to stabilize the broken integration.yml workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -83,16 +83,19 @@ jobs:
         ./build/fleetctl get enroll-secret
         docker compose -f ~/.fleet/preview/docker-compose.yml logs --follow fleet01 fleet02 &
         # Wait for all of the hosts to be enrolled
-        EXPECTED=12
+        EXPECTED=3
         until [ $(./build/fleetctl get hosts --json | wc -l | tee hostcount) -ge $EXPECTED ]; do
           echo -n "Waiting for hosts to enroll: "
           cat hostcount | xargs echo -n
           echo " / $EXPECTED"
           sleep 20
-          ./build/fleetctl get hosts --json
         done
-        ./build/fleetctl get hosts --json
         echo "Success! $EXPECTED hosts enrolled."
+
+    - name: Show enrolled hosts
+      if: always()
+      run: |
+        ./build/fleetctl get hosts --json
 
     - name: Slack Notification
       if: failure()
@@ -161,8 +164,13 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        orbit-channel: [ 'stable', 'edge' ]
-        osqueryd-channel: ['stable', 'edge' ]
+        # To run multiple VMs that have the same UUID we need to implement
+        # https://github.com/fleetdm/fleet/issues/8021 (otherwise orbit and osqueryd
+        # in the same host are enrolled as two hosts in Fleet).
+        # Until then we will just test the `stable` channel in all components.
+        orbit-channel: [ 'stable' ]
+        osqueryd-channel: [ 'stable' ]
+        desktop-channel: [ 'stable' ]
     runs-on: macos-latest
     needs: [gen, login]
     steps:
@@ -182,7 +190,7 @@ jobs:
         SECRET=$(echo $SECRET_JSON | jq -r '.spec.secrets[0].secret')
         echo "Secret: $SECRET"
         echo "Hostname: $(hostname -s)"
-        fleetctl package --type pkg --fleet-url=${{ needs.gen.outputs.address }} --enroll-secret=$SECRET --orbit-channel=${{ matrix.orbit-channel }} --osqueryd-channel=${{ matrix.osqueryd-channel }} --fleet-desktop --debug
+        fleetctl package --type pkg --fleet-url=${{ needs.gen.outputs.address }} --enroll-secret=$SECRET --orbit-channel=${{ matrix.orbit-channel }} --osqueryd-channel=${{ matrix.osqueryd-channel }} --desktop-channel=${{ matrix.desktop-channel }} --fleet-desktop --debug
         sudo installer -pkg fleet-osquery.pkg -target /
         until fleetctl get hosts | grep -iF $(hostname -s);
         do
@@ -200,7 +208,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v2
       with:
-        name: orbit-macos-${{ matrix.orbit-channel }}-${{ matrix.osqueryd-channel }}-logs
+        name: orbit-macos-${{ matrix.orbit-channel }}-${{ matrix.osqueryd-channel }}-${{ matrix.desktop-channel }}-logs
         path: |
           orbit-logs
 
@@ -212,8 +220,13 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        orbit-channel: [ 'stable', 'edge' ]
-        osqueryd-channel: ['stable', 'edge' ]
+        # To run multiple VMs that have the same UUID we need to implement
+        # https://github.com/fleetdm/fleet/issues/8021 (otherwise orbit and osqueryd
+        # in the same host are enrolled as two hosts in Fleet).
+        # Until then we will just test the `stable` channel in all components.
+        orbit-channel: [ 'stable' ]
+        osqueryd-channel: [ 'stable' ]
+        desktop-channel: [ 'stable' ]
     runs-on: ubuntu-latest
     needs: [gen, login]
     steps:
@@ -242,7 +255,7 @@ jobs:
         SECRET=$(echo $SECRET_JSON | jq -r '.spec.secrets[0].secret')
         echo "Secret: $SECRET"
         echo "Hostname: $(hostname -s)"
-        ./build/fleetctl package --type deb --fleet-url=${{ needs.gen.outputs.address }} --enroll-secret=$SECRET  --orbit-channel=${{ matrix.orbit-channel }} --osqueryd-channel=${{ matrix.osqueryd-channel }} --fleet-desktop --debug
+        ./build/fleetctl package --type deb --fleet-url=${{ needs.gen.outputs.address }} --enroll-secret=$SECRET  --orbit-channel=${{ matrix.orbit-channel }} --osqueryd-channel=${{ matrix.osqueryd-channel }} --desktop-channel=${{ matrix.desktop-channel }} --fleet-desktop --debug
         sudo dpkg -i fleet-osquery*
         until fleetctl get hosts | grep -iF $(hostname -s);
         do
@@ -260,7 +273,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v2
       with:
-        name: orbit-ubuntu-${{ matrix.orbit-channel }}-${{ matrix.osqueryd-channel }}-logs
+        name: orbit-ubuntu-${{ matrix.orbit-channel }}-${{ matrix.osqueryd-channel }}-${{ matrix.desktop-channel }}-logs
         path: |
           orbit-logs
 
@@ -272,8 +285,13 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        orbit-channel: [ 'stable', 'edge' ]
-        osqueryd-channel: ['stable', 'edge' ]
+        # To run multiple VMs that have the same UUID we need to implement
+        # https://github.com/fleetdm/fleet/issues/8021 (otherwise orbit and osqueryd
+        # in the same host are enrolled as two hosts in Fleet).
+        # Until then we will just test the `stable` channel in all components.
+        orbit-channel: [ 'stable' ]
+        osqueryd-channel: [ 'stable' ]
+        desktop-channel: [ 'stable' ]
     runs-on: ubuntu-latest
     needs: [gen, login]
     steps:
@@ -290,21 +308,26 @@ jobs:
         SECRET=$(echo $SECRET_JSON | jq -r '.spec.secrets[0].secret')
         echo "Secret: $SECRET"
         echo "Hostname: $(hostname -s)"
-        fleetctl package --type msi --fleet-url=${{ needs.gen.outputs.address }} --enroll-secret=$SECRET --orbit-channel=${{ matrix.orbit-channel }} --osqueryd-channel=${{ matrix.osqueryd-channel }} --fleet-desktop --debug
-        mv fleet-osquery.msi orbit-${{ matrix.orbit-channel }}-osqueryd-${{ matrix.osqueryd-channel }}.msi
+        fleetctl package --type msi --fleet-url=${{ needs.gen.outputs.address }} --enroll-secret=$SECRET --orbit-channel=${{ matrix.orbit-channel }} --osqueryd-channel=${{ matrix.osqueryd-channel }} --desktop-channel=${{ matrix.desktop-channel }} --fleet-desktop --debug
+        mv fleet-osquery.msi orbit-${{ matrix.orbit-channel }}-osqueryd-${{ matrix.osqueryd-channel }}-desktop-${{ matrix.desktop-channel }}.msi
 
     - name: Upload MSI
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v2
       with:
-        name: orbit-${{ matrix.orbit-channel }}-osqueryd-${{ matrix.osqueryd-channel }}.msi
-        path: orbit-${{ matrix.orbit-channel }}-osqueryd-${{ matrix.osqueryd-channel }}.msi
+        name: orbit-${{ matrix.orbit-channel }}-osqueryd-${{ matrix.osqueryd-channel }}-desktop-${{ matrix.desktop-channel }}.msi
+        path: orbit-${{ matrix.orbit-channel }}-osqueryd-${{ matrix.osqueryd-channel }}-desktop-${{ matrix.desktop-channel }}.msi
 
   orbit-windows:
     timeout-minutes: 10
     strategy:
       matrix:
-        orbit-channel: [ 'stable', 'edge' ]
-        osqueryd-channel: ['stable', 'edge' ]
+        # To run multiple VMs that have the same UUID we need to implement
+        # https://github.com/fleetdm/fleet/issues/8021 (otherwise orbit and osqueryd
+        # in the same host are enrolled as two hosts in Fleet).
+        # Until then we will just test the `stable` channel in all components.
+        orbit-channel: [ 'stable' ]
+        osqueryd-channel: [ 'stable' ]
+        desktop-channel: [ 'stable' ]
     needs: [gen, login, orbit-windows-build]
     runs-on: windows-latest
     steps:
@@ -318,12 +341,12 @@ jobs:
       id: download
       uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v2
       with:
-        name: orbit-${{ matrix.orbit-channel }}-osqueryd-${{ matrix.osqueryd-channel }}.msi
+        name: orbit-${{ matrix.orbit-channel }}-osqueryd-${{ matrix.osqueryd-channel }}-desktop-${{ matrix.desktop-channel }}.msi
 
     - name: Install Orbit
       shell: cmd
       run: |
-        msiexec /i ${{steps.download.outputs.download-path}}\orbit-${{ matrix.orbit-channel }}-osqueryd-${{ matrix.osqueryd-channel }}.msi /quiet /passive /lv log.txt
+        msiexec /i ${{steps.download.outputs.download-path}}\orbit-${{ matrix.orbit-channel }}-osqueryd-${{ matrix.osqueryd-channel }}-desktop-${{ matrix.desktop-channel }}.msi /quiet /passive /lv log.txt
         sleep 30
 
     # We can't very accurately check the install on these Windows hosts since the hostnames tend to
@@ -341,5 +364,5 @@ jobs:
       if: always()
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v2
       with:
-        name: orbit-windows-${{ matrix.orbit-channel }}-${{ matrix.osqueryd-channel }}-logs
+        name: orbit-windows-${{ matrix.orbit-channel }}-${{ matrix.osqueryd-channel }}-${{ matrix.desktop-channel }}-logs
         path: C:\Windows\system32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,7 +75,7 @@ jobs:
         check_artifacts: true
 
     - name: Run Fleet server
-      timeout-minutes: 15
+      timeout-minutes: 10
       run: |
         chmod +x ./build/fleetctl
         ./build/fleetctl preview --no-hosts
@@ -88,7 +88,8 @@ jobs:
           echo -n "Waiting for hosts to enroll: "
           cat hostcount | xargs echo -n
           echo " / $EXPECTED"
-          sleep 10
+          sleep 20
+          ./build/fleetctl get hosts --json
         done
         ./build/fleetctl get hosts --json
         echo "Success! $EXPECTED hosts enrolled."

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -184,7 +184,7 @@ jobs:
         SECRET=$(echo $SECRET_JSON | jq -r '.spec.secrets[0].secret')
         echo "Secret: $SECRET"
         echo "Hostname: $(hostname -s)"
-        fleetctl package --type pkg --fleet-url=${{ needs.gen.outputs.address }} --enroll-secret=$SECRET --orbit-channel=${{ matrix.orbit-channel }} --osqueryd-channel=${{ matrix.osqueryd-channel }} --fleet-desktop
+        fleetctl package --type pkg --fleet-url=${{ needs.gen.outputs.address }} --enroll-secret=$SECRET --orbit-channel=${{ matrix.orbit-channel }} --osqueryd-channel=${{ matrix.osqueryd-channel }} --fleet-desktop --debug
         sudo installer -pkg fleet-osquery.pkg -target /
         until fleetctl get hosts | grep -iF $(hostname -s);
         do
@@ -244,7 +244,7 @@ jobs:
         SECRET=$(echo $SECRET_JSON | jq -r '.spec.secrets[0].secret')
         echo "Secret: $SECRET"
         echo "Hostname: $(hostname -s)"
-        ./build/fleetctl package --type deb --fleet-url=${{ needs.gen.outputs.address }} --enroll-secret=$SECRET  --orbit-channel=${{ matrix.orbit-channel }} --osqueryd-channel=${{ matrix.osqueryd-channel }}
+        ./build/fleetctl package --type deb --fleet-url=${{ needs.gen.outputs.address }} --enroll-secret=$SECRET  --orbit-channel=${{ matrix.orbit-channel }} --osqueryd-channel=${{ matrix.osqueryd-channel }} --fleet-desktop --debug
         sudo dpkg -i fleet-osquery*
         until fleetctl get hosts | grep -iF $(hostname -s);
         do
@@ -292,7 +292,7 @@ jobs:
         SECRET=$(echo $SECRET_JSON | jq -r '.spec.secrets[0].secret')
         echo "Secret: $SECRET"
         echo "Hostname: $(hostname -s)"
-        fleetctl package --type msi --fleet-url=${{ needs.gen.outputs.address }} --enroll-secret=$SECRET --orbit-channel=${{ matrix.orbit-channel }} --osqueryd-channel=${{ matrix.osqueryd-channel }} --fleet-desktop
+        fleetctl package --type msi --fleet-url=${{ needs.gen.outputs.address }} --enroll-secret=$SECRET --orbit-channel=${{ matrix.orbit-channel }} --osqueryd-channel=${{ matrix.osqueryd-channel }} --fleet-desktop --debug
         mv fleet-osquery.msi orbit-${{ matrix.orbit-channel }}-osqueryd-${{ matrix.osqueryd-channel }}.msi
 
     - name: Upload MSI

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -168,6 +168,10 @@ jobs:
         # https://github.com/fleetdm/fleet/issues/8021 (otherwise orbit and osqueryd
         # in the same host are enrolled as two hosts in Fleet).
         # Until then we will just test the `stable` channel in all components.
+        #
+        # Alternatively, we can bring back the `edge` channel when we decide to upgrade
+        # our worker to macOS 13 in the future, as they changed the virtualization
+        # layer for 13 and now it has random UUIDs (https://github.com/actions/runner-images/issues/7591).
         orbit-channel: [ 'stable' ]
         osqueryd-channel: [ 'stable' ]
         desktop-channel: [ 'stable' ]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -76,9 +76,6 @@ jobs:
 
     - name: Run Fleet server
       timeout-minutes: 15
-      env:
-        # Use instance identifier to allow for duplicate UUIDs
-        FLEET_OSQUERY_HOST_IDENTIFIER: instance
       run: |
         chmod +x ./build/fleetctl
         ./build/fleetctl preview --no-hosts


### PR DESCRIPTION
#13547

This is an attempt to stabilize this workflow that has been broken for 4-6 months.

# Issue and proposed solution

Github runner VMs re-use UUIDs, which is not supported by Orbit (this causes a host to be enrolled as two hosts in Fleet), thus, until that is fixed in https://github.com/fleetdm/fleet/issues/8021 I propose we stabilize this workflow by testing all `stable` channels only (which is better than having the build broken all the time IMO).

Once https://github.com/fleetdm/fleet/issues/8021 is fixed we can re-add the edge channels.