### PR TITLE
Fleet UI: Fix searchability/loading state focus, fix hidden buttons

### DIFF
--- a/frontend/components/icons/FilterFunnel.tsx
+++ b/frontend/components/icons/FilterFunnel.tsx
@@ -11,7 +11,6 @@ const FilterFunnel = ({
   size = "medium",
   color = "ui-fleet-black-33",
 }: IFilterFunnelProps) => {
-  console.log("color", color);
   return (
     <svg
       width={ICON_SIZES[size]}

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -137,60 +137,52 @@ const PoliciesTable = ({
         canAddOrDeletePolicy ? "" : "hide-selection-column"
       }`}
     >
-      {isLoading ? (
-        <Spinner />
-      ) : (
-        <TableContainer
-          resultsTitle="policies"
-          columns={generateTableHeaders(
-            {
-              selectedTeamId: currentTeam?.id,
-              canAddOrDeletePolicy,
-              tableType,
-            },
-            isPremiumTier,
-            isSandboxMode
-          )}
-          data={generateDataSet(
-            policiesList,
-            currentAutomatedPolicies,
-            config?.update_interval.osquery_policy
-          )}
-          // filters={{ global: searchQuery }}
-          isLoading={isLoading}
-          defaultSortHeader={sortHeader || DEFAULT_SORT_HEADER}
-          defaultSortDirection={sortDirection || DEFAULT_SORT_DIRECTION}
-          defaultSearchQuery={searchQuery}
-          defaultPageIndex={page}
-          showMarkAllPages={false}
-          isAllPagesSelected={false}
-          primarySelectAction={{
-            name: "delete policy",
-            buttonText: "Delete",
-            iconSvg: "trash",
-            variant: "text-icon",
-            onActionButtonClick: onDeletePolicyClick,
-          }}
-          emptyComponent={() =>
-            EmptyTable({
-              iconName: emptyState().iconName,
-              header: emptyState().header,
-              info: emptyState().info,
-              additionalInfo: emptyState().additionalInfo,
-              primaryButton: emptyState().primaryButton,
-            })
-          }
-          disableCount={tableType === "inheritedPolicies"}
-          renderCount={renderPoliciesCount}
-          // isClientSidePagination
-          // onClientSidePaginationChange={onClientSidePaginationChange}
-          // isClientSideFilter
-          // searchQueryColumn="name"
-          onQueryChange={onTableQueryChange}
-          inputPlaceHolder="Search by name"
-          searchable={searchable}
-        />
-      )}
+      <TableContainer
+        resultsTitle="policies"
+        columns={generateTableHeaders(
+          {
+            selectedTeamId: currentTeam?.id,
+            canAddOrDeletePolicy,
+            tableType,
+          },
+          isPremiumTier,
+          isSandboxMode
+        )}
+        data={generateDataSet(
+          policiesList,
+          currentAutomatedPolicies,
+          config?.update_interval.osquery_policy
+        )}
+        // filters={{ global: searchQuery }}
+        isLoading={isLoading}
+        defaultSortHeader={sortHeader || DEFAULT_SORT_HEADER}
+        defaultSortDirection={sortDirection || DEFAULT_SORT_DIRECTION}
+        defaultSearchQuery={searchQuery}
+        defaultPageIndex={page}
+        showMarkAllPages={false}
+        isAllPagesSelected={false}
+        primarySelectAction={{
+          name: "delete policy",
+          buttonText: "Delete",
+          iconSvg: "trash",
+          variant: "text-icon",
+          onActionButtonClick: onDeletePolicyClick,
+        }}
+        emptyComponent={() =>
+          EmptyTable({
+            iconName: emptyState().iconName,
+            header: emptyState().header,
+            info: emptyState().info,
+            additionalInfo: emptyState().additionalInfo,
+            primaryButton: emptyState().primaryButton,
+          })
+        }
+        disableCount={tableType === "inheritedPolicies"}
+        renderCount={renderPoliciesCount}
+        onQueryChange={onTableQueryChange}
+        inputPlaceHolder="Search by name"
+        searchable={searchable}
+      />
     </div>
   );
 };

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTable.tsx
@@ -153,7 +153,6 @@ const PoliciesTable = ({
           currentAutomatedPolicies,
           config?.update_interval.osquery_policy
         )}
-        // filters={{ global: searchQuery }}
         isLoading={isLoading}
         defaultSortHeader={sortHeader || DEFAULT_SORT_HEADER}
         defaultSortDirection={sortDirection || DEFAULT_SORT_DIRECTION}

--- a/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/ManageSoftwarePage.tsx
@@ -616,14 +616,6 @@ const ManageSoftwarePage = ({
 
   const renderSoftwareTable = () => {
     if (
-      isFetchingCount ||
-      isFetchingSoftware ||
-      !globalConfig ||
-      (!softwareConfig && !softwareConfigError)
-    ) {
-      return <Spinner />;
-    }
-    if (
       (softwareError && !isFetchingSoftware) ||
       (softwareConfigError && !isFetchingSoftwareConfig)
     ) {
@@ -633,7 +625,12 @@ const ManageSoftwarePage = ({
       <TableContainer
         columns={softwareTableHeaders}
         data={(isSoftwareEnabled && software?.software) || []}
-        isLoading={false}
+        isLoading={
+          isFetchingCount ||
+          isFetchingSoftware ||
+          !globalConfig ||
+          (!softwareConfig && !softwareConfigError)
+        }
         resultsTitle={"software items"}
         emptyComponent={() => (
           <EmptySoftwareTable

--- a/frontend/pages/software/ManageSoftwarePage/_styles.scss
+++ b/frontend/pages/software/ManageSoftwarePage/_styles.scss
@@ -16,6 +16,11 @@
     padding: $pad-small $pad-medium;
   }
 
+  &__count {
+    display: flex;
+    gap: 12px;
+  }
+
   &__header {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Issue
Cerra #13659

## Description
- Policies page: When 0 search results are returned the 'manage' and 'add policy' buttons are no longer removed from view, they are only removed from view if there are no results with no search (completely empty state)
  - Fix:   Show CTA buttons if there is no errors AND there are policy results OR a search filter
- Policies page: When entering search input the page no longer refreshes which can cause the page to unfocus the search input field
  - Fix: Moved loading state to the table level so the search bar doesn't get reloaded on the API call 
- Software page: When entering search input the page no longer refreshes which can cause the page to unfocus the search input field
  - Fix: Moved loading state to the table level so the search bar doesn't get reloaded on the API call 


## Screenrecordings

### Policies page fixed

https://github.com/fleetdm/fleet/assets/71795832/9e9dc5ba-2294-4641-a5e4-dff38fe4c01b


### Software page fixed

https://github.com/fleetdm/fleet/assets/71795832/2c47a9d3-ff38-4e00-abb7-f22bab645576


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
