### PR TITLE
Website: exclude text from website header and footer from google search results

### DIFF
--- a/website/views/layouts/layout-customer.ejs
+++ b/website/views/layouts/layout-customer.ejs
@@ -132,7 +132,7 @@
     <%/* End Google Tag Manager (noscript) */%>
     <div style="padding-bottom: 60px; background-color: #F9FAFC;" purpose="page-wrap">
 
-      <div class="header" purpose="header-container">
+      <div class="header" purpose="header-container" data-nosnippet>
         <div purpose="page-header" class="container-fluid d-flex align-items-center justify-content-between pt-3 pb-3 px-3 px-md-4">
           <a purpose="header-logo" href="/">
             <img alt="Fleet logo" src="/images/logo-blue-118x41@2x.png"/>
@@ -157,7 +157,7 @@
 
       <%- body %>
 
-      <div purpose="footer" style="position: absolute; bottom:  0px; width: 100%; height:  60px; color: #515774;">
+      <div purpose="footer" style="position: absolute; bottom:  0px; width: 100%; height:  60px; color: #515774;" data-nosnippet>
         <div style="max-width: 500px;" class="container-fluid">
           <div style="font-size: 11px; line-height: 18px;" class="d-sm-flex d-block flex-sm-row justify-content-center mr-4 mr-md-auto">
             <img alt="Creative Commons Licence CC BY-SA 4.0" src="/images/logo-creative-commons-160x30@2x.png" style="width: 80px; height: 15px;" class="mr-2 mb-2 mb-sm-0"/>

--- a/website/views/layouts/layout-landing.ejs
+++ b/website/views/layouts/layout-landing.ejs
@@ -132,7 +132,7 @@
     </noscript>
     <%/* End Google Tag Manager (noscript) */%>
     <div style="padding-bottom: 60px; background-color: #FFFFFF;" purpose="page-wrap">
-      <div purpose="header-container" class="header">
+      <div purpose="header-container" class="header" data-nosnippet>
         <div purpose="page-header" class="container-fluid d-flex align-items-center justify-content-between pt-3 pb-3 px-3 px-md-4">
           <a purpose="header-logo" href="/">
             <img alt="Fleet logo" src="/images/logo-blue-118x41@2x.png"/>
@@ -145,7 +145,7 @@
 
       <%- body %>
 
-      <div purpose="landing-footer" class="d-flex">
+      <div purpose="landing-footer" class="d-flex" data-nosnippet>
         <div style="max-width: 1200px;" class="container-fluid align-items-center d-sm-flex d-block flex-sm-row ">
           <div style="font-size: 11px; line-height: 18px;" class="justify-content-start mr-4 pt-3 pt-sm-0 mr-md-auto">
             <div class="d-sm-flex d-block">

--- a/website/views/layouts/layout-sandbox.ejs
+++ b/website/views/layouts/layout-sandbox.ejs
@@ -132,7 +132,7 @@
     </noscript>
     <%/* End Google Tag Manager (noscript) */%>
     <div style="padding-bottom: <%= optimizeForAppleWebview  ?  '0px' : '60px' %>; background-color: #FFF;" purpose="page-wrap">
-      <div class="header <%= optimizeForAppleWebview  ?  'd-none' : '' %>" purpose="header-container">
+      <div class="header <%= optimizeForAppleWebview  ?  'd-none' : '' %>" purpose="header-container" data-nosnippet>
         <%// Page header%>
         <div purpose="page-header" class="container-fluid d-flex justify-content-between align-items-center pt-3 pb-3 px-3 px-md-4">
           <a purpose="header-logo" href="/">
@@ -272,7 +272,7 @@
 
       <%- body %>
 
-      <div purpose="footer" class="<%= optimizeForAppleWebview  ?  'd-none' : '' %>" style="position: absolute; bottom:  0px; width: 100%; height: 60px; color: #515774;">
+      <div purpose="footer" class="<%= optimizeForAppleWebview  ?  'd-none' : '' %>" style="position: absolute; bottom:  0px; width: 100%; height: 60px; color: #515774;" data-nosnippet>
         <div style="max-width: 500px;" class="container-fluid">
           <div style="font-size: 11px; line-height: 18px;" class="d-sm-flex d-block flex-sm-row justify-content-center mr-4 mr-md-auto">
             <img alt="Creative Commons Licence CC BY-SA 4.0" src="/images/logo-creative-commons-160x30@2x.png" style="width: 80px; height: 15px;" class="mr-2 mb-2 mb-sm-0"/>

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -133,7 +133,7 @@
     </noscript>
     <%/* End Google Tag Manager (noscript) */%>
     <div purpose="page-wrap">
-      <div class="header" purpose="header-container">
+      <div class="header" purpose="header-container" data-nosnippet>
         <%// Page header%>
         <div purpose="page-header" class="container-fluid d-flex justify-content-between align-items-center pt-3 pb-3 px-3 px-md-4">
           <a purpose="header-logo" href="/">
@@ -274,7 +274,7 @@
       <%- body %>
 
       <%/* Note: footer is hidden until the page is loaded. See «script» tag at the bottom of this file. */%>
-      <div class="invisible" purpose="page-footer" data-hide-until-rendered>
+      <div class="invisible" purpose="page-footer" data-hide-until-rendered data-nosnippet>
         <div purpose="footer-container" class="container-fluid d-flex flex-column flex-sm-row align-items-sm-end justify-content-center justify-content-sm-between">
           <div class="d-flex flex-column order-first justify-content-start">
             <div class="d-flex pb-4 pr-4">


### PR DESCRIPTION
Related to #12569

Changes:
- Added a [`data-nosnippet` attribute](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#data-nosnippet-attr) to the header and footer on our layouts. This attribute will exclude content inside these elements from appearing in Google search results.