### PR TITLE
Fix software ingestion when fields are larger than supported

### DIFF
--- a/changes/fix-software-reinserts-when-fields-are-too-long
+++ b/changes/fix-software-reinserts-when-fields-are-too-long
@@ -1,1 +1,2 @@
-* Fixed software ingestion to not re-insert software when incoming fields from hosts are longer than what Fleet supports.
+* Fixed software ingestion to not re-insert software when incoming fields from hosts are longer than what Fleet supports. This bug caused some CVEs to be reported every time the vulnerability cron ran.
+IMPORTANT: After deploying this fix, the vulnerability cron will report the CVEs one last time, and subsequent cron runs will not report the CVE (as expected).

--- a/changes/fix-software-reinserts-when-fields-are-too-long
+++ b/changes/fix-software-reinserts-when-fields-are-too-long
@@ -1,0 +1,1 @@
+* Fixed software ingestion to not re-insert software when incoming fields from hosts are longer than what Fleet supports.

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -1,15 +1,30 @@
 package fleet
 
 import (
+	"errors"
+	"fmt"
+	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
-// Must be kept in sync with the vendor column definition.
 const (
-	SoftwareVendorMaxLength    = 114
 	SoftwareVendorMaxLengthFmt = "%.111s..."
 	SoftwareFieldSeparator     = "\u0000"
+
+	//
+	// The following length values must be kept in sync with the DB column definitions.
+	//
+
+	SoftwareNameMaxLength             = 255
+	SoftwareVersionMaxLength          = 255
+	SoftwareSourceMaxLength           = 64
+	SoftwareBundleIdentifierMaxLength = 255
+
+	SoftwareReleaseMaxLength = 64
+	SoftwareVendorMaxLength  = 114
+	SoftwareArchMaxLength    = 16
 )
 
 type Vulnerabilities []CVE
@@ -169,4 +184,67 @@ func (uhsdbr *UpdateHostSoftwareDBResult) CurrInstalled() []Software {
 	}
 
 	return r
+}
+
+// ParseSoftwareLastOpenedAtRowValue attempts to parse the last_opened_at
+// software column value. If the value is empty or if the parsed time is
+// 0 it returns (time.Time{}, nil).
+func ParseSoftwareLastOpenedAtRowValue(value string) (time.Time, error) {
+	// We don't fail if only the last_opened_at cannot be parsed.
+	if value == "" {
+		return time.Time{}, nil
+	}
+	lastOpenedEpoch, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if lastOpenedEpoch == 0 {
+		return time.Time{}, nil
+	}
+	return time.Unix(int64(lastOpenedEpoch), 0).UTC(), nil
+}
+
+// SoftwareFromOsqueryRow creates a fleet.Software from the values reported by osquery.
+// Arguments name and source must be defined, all other fields are optional.
+// This method doesn't fail if lastOpenedAt is empty or cannot be parsed.
+//
+// All fields are trimmed to fit on Fleet's database.
+// The vendor field is currently trimmed by removing the extra characters and adding `...` at the end.
+func SoftwareFromOsqueryRow(name, version, source, vendor, installedPath, release, arch, bundleIdentifier, lastOpenedAt string) (*Software, error) {
+	if name == "" {
+		return nil, errors.New("host reported software with empty name")
+	}
+	if source == "" {
+		return nil, errors.New("host reported software with empty source")
+	}
+
+	// We don't fail if only the last_opened_at cannot be parsed.
+	lastOpenedAtTime, _ := ParseSoftwareLastOpenedAtRowValue(lastOpenedAt)
+
+	// Check whether the vendor is longer than the max allowed width and if so, truncate it.
+	if utf8.RuneCountInString(vendor) >= SoftwareVendorMaxLength {
+		vendor = fmt.Sprintf(SoftwareVendorMaxLengthFmt, vendor)
+	}
+
+	truncateString := func(str string, length int) string {
+		if len(str) > length {
+			return str[:length]
+		}
+		return str
+	}
+
+	software := Software{
+		Name:             truncateString(name, SoftwareNameMaxLength),
+		Version:          truncateString(version, SoftwareVersionMaxLength),
+		Source:           truncateString(source, SoftwareSourceMaxLength),
+		BundleIdentifier: truncateString(bundleIdentifier, SoftwareBundleIdentifierMaxLength),
+
+		Release: truncateString(release, SoftwareReleaseMaxLength),
+		Vendor:  vendor,
+		Arch:    truncateString(arch, SoftwareArchMaxLength),
+	}
+	if !lastOpenedAtTime.IsZero() {
+		software.LastOpenedAt = &lastOpenedAtTime
+	}
+	return &software, nil
 }

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -187,8 +187,10 @@ func (uhsdbr *UpdateHostSoftwareDBResult) CurrInstalled() []Software {
 }
 
 // ParseSoftwareLastOpenedAtRowValue attempts to parse the last_opened_at
-// software column value. If the value is empty or if the parsed time is
-// 0 it returns (time.Time{}, nil).
+// software column value. If the value is empty or if the parsed value is
+// less or equal than 0 it returns (time.Time{}, nil). We do this because
+// some macOS apps return "-1.0" when the app was never opened and we hardcode
+// to 0 for some tables that don't have such info.
 func ParseSoftwareLastOpenedAtRowValue(value string) (time.Time, error) {
 	if value == "" {
 		return time.Time{}, nil
@@ -197,7 +199,7 @@ func ParseSoftwareLastOpenedAtRowValue(value string) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, err
 	}
-	if lastOpenedEpoch == 0 {
+	if lastOpenedEpoch <= 0 {
 		return time.Time{}, nil
 	}
 	return time.Unix(int64(lastOpenedEpoch), 0).UTC(), nil

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -190,7 +190,6 @@ func (uhsdbr *UpdateHostSoftwareDBResult) CurrInstalled() []Software {
 // software column value. If the value is empty or if the parsed time is
 // 0 it returns (time.Time{}, nil).
 func ParseSoftwareLastOpenedAtRowValue(value string) (time.Time, error) {
-	// We don't fail if only the last_opened_at cannot be parsed.
 	if value == "" {
 		return time.Time{}, nil
 	}
@@ -227,8 +226,9 @@ func SoftwareFromOsqueryRow(name, version, source, vendor, installedPath, releas
 	}
 
 	truncateString := func(str string, length int) string {
-		if len(str) > length {
-			return str[:length]
+		runes := []rune(str)
+		if len(runes) > length {
+			return string(runes[:length])
 		}
 		return str
 	}

--- a/server/fleet/software_test.go
+++ b/server/fleet/software_test.go
@@ -54,3 +54,24 @@ func TestSoftwareIterQueryOptionsIsValid(t *testing.T) {
 		}
 	}
 }
+
+func TestParseSoftwareLastOpenedAtRowValue(t *testing.T) {
+	// Some macOS apps return last_opened_at=-1.0 on apps
+	// that were never opened.
+	lastOpenedAt, err := ParseSoftwareLastOpenedAtRowValue("-1.0")
+	require.NoError(t, err)
+	require.Zero(t, lastOpenedAt)
+
+	// Our software queries hardcode to 0 if such info is not available.
+	lastOpenedAt, err = ParseSoftwareLastOpenedAtRowValue("0")
+	require.NoError(t, err)
+	require.Zero(t, lastOpenedAt)
+
+	lastOpenedAt, err = ParseSoftwareLastOpenedAtRowValue("foobar")
+	require.Error(t, err)
+	require.Zero(t, lastOpenedAt)
+
+	lastOpenedAt, err = ParseSoftwareLastOpenedAtRowValue("1694026958")
+	require.NoError(t, err)
+	require.NotZero(t, lastOpenedAt)
+}

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"database/sql"
 	"encoding/base64"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -7256,4 +7258,271 @@ func (s *integrationTestSuite) TestDirectIngestScheduledQueryStats() {
 	require.Equal(t, strconv.FormatInt(int64(sqs.SystemTime), 10), row["system_time"])
 	require.Equal(t, strconv.FormatInt(int64(sqs.UserTime), 10), row["user_time"])
 	require.Equal(t, strconv.FormatInt(int64(sqs.WallTime), 10), row["wall_time"])
+}
+
+// TestDirectIngestSoftwareWithLongFields tests that software with reported long fields
+// are inserted properly and subsequent reports of the same software do not generate new
+// entries in the `software` table. (It mainly tests the comparison between the currenly
+// inserted software and the incoming software from a host.)
+func (s *integrationTestSuite) TestDirectIngestSoftwareWithLongFields() {
+	t := s.T()
+
+	appConfig, err := s.ds.AppConfig(context.Background())
+	require.NoError(t, err)
+	appConfig.Features.EnableSoftwareInventory = true
+
+	globalHost, err := s.ds.NewHost(context.Background(), &fleet.Host{
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now().Add(-1 * time.Minute),
+		OsqueryHostID:   ptr.String(uuid.New().String()),
+		NodeKey:         ptr.String(uuid.New().String()),
+		UUID:            uuid.New().String(),
+		Hostname:        fmt.Sprintf("%sfoo.global", t.Name()),
+		Platform:        "darwin",
+	})
+	require.NoError(t, err)
+
+	// Simulate a osquery agent on Windows reporting a software row for Wireshark.
+	rows := []map[string]string{
+		{
+			"name":           "Wireshark 4.0.8 64-bit",
+			"version":        "4.0.8",
+			"type":           "Program (Windows)",
+			"source":         "programs",
+			"vendor":         "The Wireshark developer community, https://www.wireshark.org",
+			"installed_path": "C:\\Program Files\\Wireshark",
+		},
+	}
+	detailQueries := osquery_utils.GetDetailQueries(context.Background(), config.FleetConfig{}, appConfig, &appConfig.Features)
+	err = detailQueries["software_windows"].DirectIngestFunc(
+		context.Background(),
+		log.NewNopLogger(),
+		globalHost,
+		s.ds,
+		rows,
+	)
+	require.NoError(t, err)
+
+	// Check that the software was properly ingested.
+	softwareQueryByName := "SELECT id, name, version, source, bundle_identifier, `release`, arch, vendor FROM software WHERE name = ?;"
+	var wiresharkSoftware fleet.Software
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(context.Background(), q, &wiresharkSoftware, softwareQueryByName, "Wireshark 4.0.8 64-bit")
+	})
+	require.NotZero(t, wiresharkSoftware.ID)
+	require.Equal(t, "Wireshark 4.0.8 64-bit", wiresharkSoftware.Name)
+	require.Equal(t, "4.0.8", wiresharkSoftware.Version)
+	require.Equal(t, "programs", wiresharkSoftware.Source)
+	require.Empty(t, wiresharkSoftware.BundleIdentifier)
+	require.Empty(t, wiresharkSoftware.Release)
+	require.Empty(t, wiresharkSoftware.Arch)
+	require.Equal(t, "The Wireshark developer community, https://www.wireshark.org", wiresharkSoftware.Vendor)
+	hostSoftwareInstalledPathsQuery := `SELECT installed_path FROM host_software_installed_paths WHERE software_id = ?;`
+	var wiresharkSoftwareInstalledPath string
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(context.Background(), q, &wiresharkSoftwareInstalledPath, hostSoftwareInstalledPathsQuery, wiresharkSoftware.ID)
+	})
+	require.Equal(t, "C:\\Program Files\\Wireshark", wiresharkSoftwareInstalledPath)
+
+	// We now check that the same software is not created again as a new row when it is received again during software ingestion.
+	err = detailQueries["software_windows"].DirectIngestFunc(
+		context.Background(),
+		log.NewNopLogger(),
+		globalHost,
+		s.ds,
+		rows,
+	)
+	require.NoError(t, err)
+	var wiresharkSoftware2 fleet.Software
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(context.Background(), q, &wiresharkSoftware2, softwareQueryByName, "Wireshark 4.0.8 64-bit")
+	})
+	require.NotZero(t, wiresharkSoftware2.ID)
+	require.Equal(t, wiresharkSoftware.ID, wiresharkSoftware2.ID)
+
+	// Simulate a osquery agent on Windows reporting a software row with a longer than 114 chars vendor field.
+	rows = []map[string]string{
+		{
+			"name":              "Foobar" + strings.Repeat("A", fleet.SoftwareNameMaxLength),
+			"version":           "4.0.8" + strings.Repeat("B", fleet.SoftwareVersionMaxLength),
+			"type":              "Program (Windows)",
+			"source":            "programs" + strings.Repeat("C", fleet.SoftwareSourceMaxLength),
+			"vendor":            strings.Repeat("D", fleet.SoftwareVendorMaxLength+1),
+			"installed_path":    "C:\\Program Files\\Foobar",
+			"bundle_identifier": strings.Repeat("E", fleet.SoftwareBundleIdentifierMaxLength+1),
+			"release":           strings.Repeat("F", fleet.SoftwareBundleIdentifierMaxLength+1),
+			"arch":              strings.Repeat("G", fleet.SoftwareArchMaxLength+1),
+		},
+	}
+
+	err = detailQueries["software_windows"].DirectIngestFunc(
+		context.Background(),
+		log.NewNopLogger(),
+		globalHost,
+		s.ds,
+		rows,
+	)
+	require.NoError(t, err)
+
+	var foobarSoftware fleet.Software
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(context.Background(), q, &foobarSoftware, softwareQueryByName, "Foobar"+strings.Repeat("A", fleet.SoftwareNameMaxLength-6))
+	})
+	require.NotZero(t, foobarSoftware.ID)
+	require.Equal(t, "Foobar"+strings.Repeat("A", fleet.SoftwareNameMaxLength-6), foobarSoftware.Name)
+	require.Equal(t, "4.0.8"+strings.Repeat("B", fleet.SoftwareNameMaxLength-5), foobarSoftware.Version)
+	require.Equal(t, "programs"+strings.Repeat("C", fleet.SoftwareSourceMaxLength-8), foobarSoftware.Source)
+	// Vendor field is currenty trimmed with a different method (... appended at the end)
+	require.Equal(t, strings.Repeat("D", fleet.SoftwareVendorMaxLength-3)+"...", foobarSoftware.Vendor)
+	require.Equal(t, strings.Repeat("E", fleet.SoftwareBundleIdentifierMaxLength), foobarSoftware.BundleIdentifier)
+	require.Equal(t, strings.Repeat("F", fleet.SoftwareReleaseMaxLength), foobarSoftware.Release)
+	require.Equal(t, strings.Repeat("G", fleet.SoftwareArchMaxLength), foobarSoftware.Arch)
+
+	// We now check that the same software with long (to be trimmed) fields is not created again as a new row.
+	err = detailQueries["software_windows"].DirectIngestFunc(
+		context.Background(),
+		log.NewNopLogger(),
+		globalHost,
+		s.ds,
+		rows,
+	)
+	require.NoError(t, err)
+
+	var foobarSoftware2 fleet.Software
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(context.Background(), q, &foobarSoftware2, softwareQueryByName, "Foobar"+strings.Repeat("A", fleet.SoftwareNameMaxLength-6))
+	})
+	require.Equal(t, foobarSoftware.ID, foobarSoftware2.ID)
+}
+
+func (s *integrationTestSuite) TestDirectIngestSoftwareWithInvalidFields() {
+	t := s.T()
+
+	appConfig, err := s.ds.AppConfig(context.Background())
+	require.NoError(t, err)
+	appConfig.Features.EnableSoftwareInventory = true
+
+	globalHost, err := s.ds.NewHost(context.Background(), &fleet.Host{
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now().Add(-1 * time.Minute),
+		OsqueryHostID:   ptr.String(uuid.New().String()),
+		NodeKey:         ptr.String(uuid.New().String()),
+		UUID:            uuid.New().String(),
+		Hostname:        fmt.Sprintf("%sfoo.global", t.Name()),
+		Platform:        "darwin",
+	})
+	require.NoError(t, err)
+
+	// Ingesting software without name should not fail, but the software won't be inserted.
+	rows := []map[string]string{
+		{
+			"version":        "4.0.8",
+			"type":           "Program (Windows)",
+			"source":         "programs",
+			"vendor":         "The Wireshark developer community, https://www.wireshark.org",
+			"installed_path": "C:\\Program Files\\Wireshark",
+			"last_opened_at": "foobar",
+		},
+	}
+	var w1 bytes.Buffer
+	logger1 := log.NewJSONLogger(&w1)
+	detailQueries := osquery_utils.GetDetailQueries(context.Background(), config.FleetConfig{}, appConfig, &appConfig.Features)
+	err = detailQueries["software_windows"].DirectIngestFunc(
+		context.Background(),
+		logger1,
+		globalHost,
+		s.ds,
+		rows,
+	)
+	require.NoError(t, err)
+	logs1, err := io.ReadAll(&w1)
+	require.NoError(t, err)
+	require.Contains(t, string(logs1), "host reported software with empty name", fmt.Sprintf("%s", logs1))
+	require.Contains(t, string(logs1), "debug")
+
+	// Check that the software was not ingested.
+	softwareQueryByVendor := "SELECT id, name, version, source, bundle_identifier, `release`, arch, vendor FROM software WHERE vendor = ?;"
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		var wiresharkSoftware fleet.Software
+		if sqlx.GetContext(context.Background(), q, &wiresharkSoftware, softwareQueryByVendor, "The Wireshark developer community, https://www.wireshark.org") != sql.ErrNoRows {
+			return errors.New("expected no results")
+		}
+		return nil
+	})
+
+	// Ingesting software without source should not fail, but the software won't be inserted.
+	rows = []map[string]string{
+		{
+			"name":           "Wireshark 4.0.8 64-bit",
+			"version":        "4.0.8",
+			"type":           "Program (Windows)",
+			"vendor":         "The Wireshark developer community, https://www.wireshark.org",
+			"installed_path": "C:\\Program Files\\Wireshark",
+			"last_opened_at": "foobar",
+		},
+	}
+	detailQueries = osquery_utils.GetDetailQueries(context.Background(), config.FleetConfig{}, appConfig, &appConfig.Features)
+	var w2 bytes.Buffer
+	logger2 := log.NewJSONLogger(&w2)
+	err = detailQueries["software_windows"].DirectIngestFunc(
+		context.Background(),
+		logger2,
+		globalHost,
+		s.ds,
+		rows,
+	)
+	require.NoError(t, err)
+	logs2, err := io.ReadAll(&w2)
+	require.NoError(t, err)
+	require.Contains(t, string(logs2), "host reported software with empty source")
+	require.Contains(t, string(logs2), "debug")
+
+	// Check that the software was not ingested.
+	softwareQueryByName := "SELECT id, name, version, source, bundle_identifier, `release`, arch, vendor FROM software WHERE name = ?;"
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		var wiresharkSoftware fleet.Software
+		if sqlx.GetContext(context.Background(), q, &wiresharkSoftware, softwareQueryByName, "Wireshark 4.0.8 64-bit") != sql.ErrNoRows {
+			return errors.New("expected no results")
+		}
+		return nil
+	})
+
+	// Ingesting software with invalid last_opened_at should not fail (only log a debug error)
+	rows = []map[string]string{
+		{
+			"name":           "Wireshark 4.0.8 64-bit",
+			"version":        "4.0.8",
+			"type":           "Program (Windows)",
+			"source":         "programs",
+			"vendor":         "The Wireshark developer community, https://www.wireshark.org",
+			"installed_path": "C:\\Program Files\\Wireshark",
+			"last_opened_at": "foobar",
+		},
+	}
+	var w3 bytes.Buffer
+	logger3 := log.NewJSONLogger(&w3)
+	detailQueries = osquery_utils.GetDetailQueries(context.Background(), config.FleetConfig{}, appConfig, &appConfig.Features)
+	err = detailQueries["software_windows"].DirectIngestFunc(
+		context.Background(),
+		logger3,
+		globalHost,
+		s.ds,
+		rows,
+	)
+	require.NoError(t, err)
+	logs3, err := io.ReadAll(&w3)
+	require.NoError(t, err)
+	require.Contains(t, string(logs3), "host reported software with invalid last opened timestamp")
+	require.Contains(t, string(logs3), "debug")
+
+	// Check that the software was properly ingested.
+	var wiresharkSoftware fleet.Software
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(context.Background(), q, &wiresharkSoftware, softwareQueryByName, "Wireshark 4.0.8 64-bit")
+	})
+	require.NotZero(t, wiresharkSoftware.ID)
 }

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -7345,14 +7345,15 @@ func (s *integrationTestSuite) TestDirectIngestSoftwareWithLongFields() {
 	// Simulate a osquery agent on Windows reporting a software row with a longer than 114 chars vendor field.
 	rows = []map[string]string{
 		{
-			"name":              "Foobar" + strings.Repeat("A", fleet.SoftwareNameMaxLength),
-			"version":           "4.0.8" + strings.Repeat("B", fleet.SoftwareVersionMaxLength),
-			"type":              "Program (Windows)",
-			"source":            "programs" + strings.Repeat("C", fleet.SoftwareSourceMaxLength),
-			"vendor":            strings.Repeat("D", fleet.SoftwareVendorMaxLength+1),
-			"installed_path":    "C:\\Program Files\\Foobar",
-			"bundle_identifier": strings.Repeat("E", fleet.SoftwareBundleIdentifierMaxLength+1),
-			"release":           strings.Repeat("F", fleet.SoftwareBundleIdentifierMaxLength+1),
+			"name":           "Foobar" + strings.Repeat("A", fleet.SoftwareNameMaxLength),
+			"version":        "4.0.8" + strings.Repeat("B", fleet.SoftwareVersionMaxLength),
+			"type":           "Program (Windows)",
+			"source":         "programs" + strings.Repeat("C", fleet.SoftwareSourceMaxLength),
+			"vendor":         strings.Repeat("D", fleet.SoftwareVendorMaxLength+1),
+			"installed_path": "C:\\Program Files\\Foobar",
+			// Test UTF-8 encoded strings.
+			"bundle_identifier": strings.Repeat("⌘", fleet.SoftwareBundleIdentifierMaxLength+1),
+			"release":           strings.Repeat("F", fleet.SoftwareReleaseMaxLength-1) + "⌘⌘",
 			"arch":              strings.Repeat("G", fleet.SoftwareArchMaxLength+1),
 		},
 	}
@@ -7376,8 +7377,8 @@ func (s *integrationTestSuite) TestDirectIngestSoftwareWithLongFields() {
 	require.Equal(t, "programs"+strings.Repeat("C", fleet.SoftwareSourceMaxLength-8), foobarSoftware.Source)
 	// Vendor field is currenty trimmed with a different method (... appended at the end)
 	require.Equal(t, strings.Repeat("D", fleet.SoftwareVendorMaxLength-3)+"...", foobarSoftware.Vendor)
-	require.Equal(t, strings.Repeat("E", fleet.SoftwareBundleIdentifierMaxLength), foobarSoftware.BundleIdentifier)
-	require.Equal(t, strings.Repeat("F", fleet.SoftwareReleaseMaxLength), foobarSoftware.Release)
+	require.Equal(t, strings.Repeat("⌘", fleet.SoftwareBundleIdentifierMaxLength), foobarSoftware.BundleIdentifier)
+	require.Equal(t, strings.Repeat("F", fleet.SoftwareReleaseMaxLength-1)+"⌘", foobarSoftware.Release)
 	require.Equal(t, strings.Repeat("G", fleet.SoftwareArchMaxLength), foobarSoftware.Arch)
 
 	// We now check that the same software with long (to be trimmed) fields is not created again as a new row.


### PR DESCRIPTION
Should fix the issue reported in #12230. For Wireshark, osquery was reporting a `vendor` value larger than what we allowed storing in the `vendor` column (32 bytes). But recently we enlarged the `vendor` column to fit `114` chars. The direct software ingestion routine was inserting a new software entry every time because the incoming software vendor was different to what Fleet had stored in the previous ingestion (`vendor` column trimmed from `The Wireshark developer community, https://www.wireshark.org/` to `The Wireshark developer communit`).

I've now made sure that all fields are trimmed as soon as they are received by osquery thus not triggering any re-inserts when any field is larger than what Fleet supports.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- ~[ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~[ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
  - ~For Orbit and Fleet Desktop changes:~
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
