### PR TITLE
Fix auto-removal of integrations when an unrelated setting is saved

### DIFF
--- a/changes/issue-13372-fix-integrations-auto-removed
+++ b/changes/issue-13372-fix-integrations-auto-removed
@@ -1,0 +1,1 @@
+* Fixed a bug where Jira and/or Zendesk integrations were being removed when an unrelated setting was changed.

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1041,8 +1041,6 @@ Modifies the Fleet's configuration with the supplied information.
 | force                             | bool    | query | Force apply the agent options even if there are validation errors.                                                                                                 |
 | dry_run                           | bool    | query | Validate the configuration and return any validation errors, but do not apply the changes.                                                                         |
 
-Note that when making changes to the `integrations` object, all integrations must be provided (not just the one being modified). This is because the endpoint will consider missing integrations as deleted.
-
 #### Example
 
 `PATCH /api/v1/fleet/config`

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1041,6 +1041,8 @@ Modifies the Fleet's configuration with the supplied information.
 | force                             | bool    | query | Force apply the agent options even if there are validation errors.                                                                                                 |
 | dry_run                           | bool    | query | Validate the configuration and return any validation errors, but do not apply the changes.                                                                         |
 
+Note that when making changes to the `integrations` object, all integrations must be provided (not just the one being modified). This is because the endpoint will consider missing integrations as deleted.
+
 #### Example
 
 `PATCH /api/v1/fleet/config`

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -615,9 +615,6 @@ type Service interface {
 	GetMDMAppleFileVaultSummary(ctx context.Context, teamID *uint) (*MDMAppleFileVaultSummary, error)
 
 	// GetMDMAppleEnrollmentProfileByToken returns the Apple enrollment from its secret token.
-	// TODO(mna): this may have to be removed if we don't end up supporting
-	// manual enrollment via a token (currently we only support it via Fleet
-	// Desktop, in the My Device page). See #8701.
 	GetMDMAppleEnrollmentProfileByToken(ctx context.Context, enrollmentToken string, enrollmentRef string) (profile []byte, err error)
 
 	// GetDeviceMDMAppleEnrollmentProfile loads the raw (PList-format) enrollment

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -392,9 +392,14 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		}
 	}
 
-	// TODO(mna): should the condition be "if Jira == nil && Zendesk == nil -> then do not change any integration"
-	// or should they be treated separately (that is, "if Jira == nil -> do not change Jira", and same for zendesk)?
-	// To clarify with how the frontend works.
+	// NOTE: the frontend will always send all integrations back when making
+	// changes, so as soon as Jira or Zendesk has something set, it's fair to
+	// assume that integrations are being modified and we have the full set of
+	// those integrations. When deleting, it does send empty arrays (not nulls),
+	// so this is fine - e.g. when deleting the last integration it sends:
+	//
+	//   {"integrations":{"zendesk":[],"jira":[]}}
+	//
 	if newAppConfig.Integrations.Jira != nil || newAppConfig.Integrations.Zendesk != nil {
 		delJira, err := fleet.ValidateJiraIntegrations(ctx, storedJiraByProjectKey, newAppConfig.Integrations.Jira)
 		if err != nil {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -1109,6 +1109,9 @@ func (s *integrationEnterpriseTestSuite) TestTeamSecretsAreObfuscated() {
 }
 
 func (s *integrationEnterpriseTestSuite) TestExternalIntegrationsTeamConfig() {
+	// TODO(mna): add test cases that check that no integrations are auto-removed
+	// if unrelated changes are made.
+
 	t := s.T()
 
 	// create a test http server to act as the Jira and Zendesk server


### PR DESCRIPTION
#13372 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
