### PR TITLE
Fleet UI: Fix gap in manage automations modal

### DIFF
--- a/frontend/pages/queries/ManageQueriesPage/components/ManageAutomationsModal/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/components/ManageAutomationsModal/_styles.scss
@@ -1,7 +1,6 @@
 .manage-automations-modal {
   display: flex;
   flex-direction: column;
-  gap: $pad-xlarge;
 
   &__selection {
     margin-bottom: $pad-small;
@@ -31,6 +30,8 @@
   }
 
   .info-banner {
+    margin: $pad-large 0;
+
     &__info {
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
## Issue
Cerra #13347 

## Description
- Fix gap on top of manage automations modal
- Manual QA, update gap around info banner of queries manage automations modal

## Screenshots of 3 manage automations modals
<img width="707" alt="Screenshot 2023-09-06 at 12 58 47 PM" src="https://github.com/fleetdm/fleet/assets/71795832/cc9a90d1-ed13-4417-a3ba-b1fe6fd99c03">
<img width="815" alt="Screenshot 2023-09-06 at 12 58 38 PM" src="https://github.com/fleetdm/fleet/assets/71795832/e7eb9090-6349-4dc4-bbde-907310f9aa02">
<img width="700" alt="Screenshot 2023-09-06 at 12 58 29 PM" src="https://github.com/fleetdm/fleet/assets/71795832/73862062-c8f5-4d07-9890-1d44344c00c6">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

