### PR TITLE
Fleet UI: Disable 1password autofills in random inputs

### DIFF
--- a/changes/13368-disable-1password-over-autofill
+++ b/changes/13368-disable-1password-over-autofill
@@ -1,0 +1,1 @@
+- UI improvement: Remove 1password from overly autofilling forms

--- a/frontend/components/forms/fields/InputField/InputField.jsx
+++ b/frontend/components/forms/fields/InputField/InputField.jsx
@@ -39,6 +39,7 @@ class InputField extends Component {
       PropTypes.object,
     ]),
     enableCopy: PropTypes.bool,
+    ignore1password: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -56,6 +57,7 @@ class InputField extends Component {
     tooltip: "",
     hint: "",
     enableCopy: false,
+    ignore1password: false,
   };
 
   componentDidMount() {
@@ -97,6 +99,7 @@ class InputField extends Component {
       type,
       blockAutoComplete,
       value,
+      ignore1password,
     } = this.props;
 
     const { onInputChange } = this;
@@ -170,6 +173,7 @@ class InputField extends Component {
             {...inputOptions}
             value={value}
             autoComplete={blockAutoComplete ? "new-password" : ""}
+            data-1p-ignore={ignore1password}
           />
           <div className={`${baseClass}__copy-wrapper`}>
             {this.props.enableCopy && (

--- a/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
+++ b/frontend/components/forms/fields/InputFieldWithIcon/InputFieldWithIcon.jsx
@@ -27,6 +27,7 @@ class InputFieldWithIcon extends InputField {
     iconPosition: PropTypes.oneOf(["start", "end"]),
     inputOptions: PropTypes.object, // eslint-disable-line react/forbid-prop-types
     tooltip: PropTypes.string,
+    ignore1Password: PropTypes.bool,
   };
 
   renderHeading = () => {
@@ -78,6 +79,7 @@ class InputFieldWithIcon extends InputField {
       disabled,
       iconPosition,
       inputOptions,
+      ignore1Password,
     } = this.props;
     const { onInputChange, renderHint } = this;
 
@@ -120,6 +122,7 @@ class InputFieldWithIcon extends InputField {
           value={value}
           disabled={disabled}
           {...inputOptions}
+          data-1p-ignore={ignore1Password}
         />
         {iconSvg && <Icon name={iconSvg} className={iconClasses} />}
         {iconName && <FleetIcon name={iconName} className={iconClasses} />}

--- a/frontend/pages/admin/TeamManagementPage/components/CreateTeamModal/CreateTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/CreateTeamModal/CreateTeamModal.tsx
@@ -65,6 +65,7 @@ const CreateTeamModal = ({
           placeholder="Workstations"
           value={name}
           error={errors.name}
+          ignore1password
         />
         <InfoBanner className={`${baseClass}__sandbox-info`}>
           To organize your hosts, create a team, like

--- a/frontend/pages/admin/TeamManagementPage/components/EditTeamModal/EditTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/EditTeamModal/EditTeamModal.tsx
@@ -61,6 +61,7 @@ const EditTeamModal = ({
           placeholder="Team name"
           value={name}
           error={errors.name}
+          ignore1password
         />
         <div className="modal-cta-wrap">
           <Button

--- a/frontend/pages/queries/QueryPage/components/SaveQueryModal/SaveQueryModal.tsx
+++ b/frontend/pages/queries/QueryPage/components/SaveQueryModal/SaveQueryModal.tsx
@@ -156,6 +156,7 @@ const SaveQueryModal = ({
             label="Name"
             placeholder="What is your query called?"
             autofocus
+            ignore1password
           />
           <InputField
             name="description"


### PR DESCRIPTION
## Issue
Cerra #13368 

## Description
- 1password extension over generalizes and adds autofill excessively to inputs
- Lots of digging through years of forums and requests that they fixed the issue using a `input` attirbute `data-1p-ignore` https://developer.1password.com/docs/web/compatible-website-design/

## Screenshots of fixes (no autofills)
<img width="629" alt="Screenshot 2023-09-06 at 3 52 13 PM" src="https://github.com/fleetdm/fleet/assets/71795832/f1aa2f2b-776e-479b-bd58-52b2e3d160f7">
<img width="623" alt="Screenshot 2023-09-06 at 3 52 06 PM" src="https://github.com/fleetdm/fleet/assets/71795832/89e5c0d1-627c-45bc-9f2c-99082449152c">
<img width="650" alt="Screenshot 2023-09-06 at 3 51 57 PM" src="https://github.com/fleetdm/fleet/assets/71795832/56ecc6a8-0729-4ed6-b6f9-b3d9bb97e60f">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
