### PR TITLE
Increase goreleaser orbit timeout to 60m

### DIFF
--- a/.github/workflows/goreleaser-orbit.yaml
+++ b/.github/workflows/goreleaser-orbit.yaml
@@ -54,7 +54,7 @@ jobs:
           go-version: ${{ vars.GO_VERSION }}
 
       - name: Run GoReleaser
-        run: go run github.com/goreleaser/goreleaser@56c9d09a1b925e2549631c6d180b0a1c2ebfac82 release --debug --rm-dist --skip-publish -f orbit/goreleaser-macos.yml # v1.20.0
+        run: go run github.com/goreleaser/goreleaser@56c9d09a1b925e2549631c6d180b0a1c2ebfac82 release --debug --rm-dist --skip-publish --timeout 60m -f orbit/goreleaser-macos.yml # v1.20.0
         env:
           GITHUB_TOKEN: ${{ secrets.FLEET_RELEASE_GITHUB_PAT }}
           AC_USERNAME: ${{ secrets.APPLE_USERNAME }}


### PR DESCRIPTION
Orbit goreleaser action for MacOS keeps failing with timeout:

```sh
dist/orbit-macos_darwin_all/orbit: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64Mach-O 64-bit executable x86_64] [arm64]
dist/orbit-macos_darwin_all/orbit (for architecture x86_64):	Mach-O 64-bit executable x86_64
dist/orbit-macos_darwin_all/orbit (for architecture arm64):	Mach-O 64-bit executable arm64
    ⨯ release failed after 30m0s             error=context deadline exceeded
exit status 1
Error: Process completed with exit code 1.
```