### PR TITLE
Add separate kms key for installers

### DIFF
--- a/infrastructure/sandbox/PreProvisioner/main.tf
+++ b/infrastructure/sandbox/PreProvisioner/main.tf
@@ -136,7 +136,7 @@ data "aws_iam_policy_document" "lambda" {
       "kms:GenerateDataKey*",
       "kms:Describe*"
     ]
-    resources = [aws_kms_key.ecr.arn, var.kms_key.arn]
+    resources = [aws_kms_key.ecr.arn, var.kms_key.arn, var.installer_kms_key.arn]
   }
 
   statement {
@@ -289,7 +289,7 @@ resource "aws_ecs_task_definition" "main" {
           },
           {
             name  = "TF_VAR_kms_key_arn"
-            value = var.kms_key.arn
+            value = var.installer_kms_key.arn
           },
           {
             name  = "TF_VAR_ecr_url"

--- a/infrastructure/sandbox/PreProvisioner/variables.tf
+++ b/infrastructure/sandbox/PreProvisioner/variables.tf
@@ -8,6 +8,7 @@ variable "redis_cluster" {}
 variable "base_domain" {}
 variable "ecs_cluster" {}
 variable "kms_key" {}
+variable "installer_kms_key" {}
 variable "installer_bucket" {}
 variable "oidc_provider_arn" {}
 variable "oidc_provider" {}

--- a/infrastructure/sandbox/SharedInfrastructure/s3.tf
+++ b/infrastructure/sandbox/SharedInfrastructure/s3.tf
@@ -23,3 +23,12 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "installers" {
 output "installer_bucket" {
   value = aws_s3_bucket.installers
 }
+
+resource "aws_kms_key" "installers" {
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+}
+
+output "installer_kms_key" {
+  value = aws_kms_key.installers
+}

--- a/infrastructure/sandbox/main.tf
+++ b/infrastructure/sandbox/main.tf
@@ -187,6 +187,7 @@ module "pre-provisioner" {
   prefix            = local.prefix
   vpc               = module.vpc
   kms_key           = aws_kms_key.main
+  installer_kms_key = module.SharedInfrastructure.installer_kms_key
   dynamodb_table    = aws_dynamodb_table.lifecycle-table
   remote_state      = module.remote_state
   mysql_secret      = module.shared-infrastructure.mysql_secret


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
