### PR TITLE
Adding libcairo to packaged shared libraries to fix version mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -428,6 +428,7 @@ desktop-linux:
 		/usr/lib/x86_64-linux-gnu/libayatana-ido3-0.4.so.0 \
 		/usr/lib/x86_64-linux-gnu/libayatana-indicator3.so.7 \
 		/lib/x86_64-linux-gnu/libm.so.6 \
+		/usr/lib/x86_64-linux-gnu/libcairo.so.2 \
 		/usr/lib/x86_64-linux-gnu/libdbusmenu-gtk3.so.4 \
 		/usr/lib/x86_64-linux-gnu/libdbusmenu-glib.so.4 \
 		/output/fleet-desktop && cd /output && \

--- a/Makefile
+++ b/Makefile
@@ -429,7 +429,7 @@ desktop-linux:
 		/usr/lib/x86_64-linux-gnu/libayatana-indicator3.so.7 \
 		/lib/x86_64-linux-gnu/libm.so.6 \
 		/usr/lib/x86_64-linux-gnu/libcairo.so.2 \
-		/usr/lib/x86_64-linux-gnu/libpng16.so.16 \
+		/usr/lib/x86_64-linux-gnu/libharfbuzz.so.0.20704.0 \
 		/usr/lib/x86_64-linux-gnu/libdbusmenu-gtk3.so.4 \
 		/usr/lib/x86_64-linux-gnu/libdbusmenu-glib.so.4 \
 		/output/fleet-desktop && cd /output && \

--- a/Makefile
+++ b/Makefile
@@ -429,6 +429,7 @@ desktop-linux:
 		/usr/lib/x86_64-linux-gnu/libayatana-indicator3.so.7 \
 		/lib/x86_64-linux-gnu/libm.so.6 \
 		/usr/lib/x86_64-linux-gnu/libcairo.so.2 \
+		/usr/lib/x86_64-linux-gnu/libpng16.so.16 \
 		/usr/lib/x86_64-linux-gnu/libdbusmenu-gtk3.so.4 \
 		/usr/lib/x86_64-linux-gnu/libdbusmenu-glib.so.4 \
 		/output/fleet-desktop && cd /output && \

--- a/Makefile
+++ b/Makefile
@@ -429,7 +429,6 @@ desktop-linux:
 		/usr/lib/x86_64-linux-gnu/libayatana-indicator3.so.7 \
 		/lib/x86_64-linux-gnu/libm.so.6 \
 		/usr/lib/x86_64-linux-gnu/libcairo.so.2 \
-		/usr/lib/x86_64-linux-gnu/libharfbuzz.so.0.20704.0 \
 		/usr/lib/x86_64-linux-gnu/libdbusmenu-gtk3.so.4 \
 		/usr/lib/x86_64-linux-gnu/libdbusmenu-glib.so.4 \
 		/output/fleet-desktop && cd /output && \


### PR DESCRIPTION
# Checklist for submitter
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [x] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
