### PR TITLE
Fleet UI: Fix autosize text field to not cut off placeholder text

### DIFF
--- a/changes/13095-fix-empty-query-policy-placeholders
+++ b/changes/13095-fix-empty-query-policy-placeholders
@@ -1,0 +1,1 @@
+- Fleet UI - Fix empty query/policy placeholders

--- a/frontend/components/forms/fields/AutoSizeInputField/_styles.scss
+++ b/frontend/components/forms/fields/AutoSizeInputField/_styles.scss
@@ -30,7 +30,6 @@
 
     textarea {
       height: 100%;
-      overflow: hidden;
     }
 
     &::after {


### PR DESCRIPTION
## Issue
Cerra #13095 

## Description
- Remove overflow set to hidden that cutting off autosize text placeholders

TODO: 
- Fix FF and Safari alignment with icon!

## Screenshots of fixes
<img width="1048" alt="Screenshot 2023-09-08 at 11 38 57 AM" src="https://github.com/fleetdm/fleet/assets/71795832/792a9a66-3192-4382-ba9a-fb4f2e2ddb58">
<img width="925" alt="Screenshot 2023-09-08 at 11 38 11 AM" src="https://github.com/fleetdm/fleet/assets/71795832/71320150-9d9f-43ee-aae1-426418f1b1e3">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
- [x] Manually QAed lengthy name, description and resolution to ensure there was no bug introduced by removing `overflow: hidden`
