### PR TITLE
Fix `CVE-2020-10146` false positive being detected on all Microsoft Teams versions

### DIFF
--- a/changes/11922-microsoft-teams-fp
+++ b/changes/11922-microsoft-teams-fp
@@ -1,0 +1,2 @@
+* Fixed wrong version numbers for Microsoft Teams in macOS (from invalid format of the form `1.00.XYYYYY` to correct format `1.X.00.YYYYY`).
+* Fixed false positive CVE-2020-10146 found on Microsoft Teams.

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -1267,3 +1267,60 @@ func TestDirectIngestHostMacOSProfiles(t *testing.T) {
 	rows[0]["install_date"] = time.Now().Format(time.UnixDate)
 	require.ErrorContains(t, directIngestMacOSProfiles(ctx, logger, h, ds, rows), "parsing time")
 }
+
+func TestSanitizeSoftware(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		h         *fleet.Host
+		s         *fleet.Software
+		sanitized *fleet.Software
+	}{
+		{
+			name: "Microsoft Teams.app on macOS",
+			h: &fleet.Host{
+				Platform: "darwin",
+			},
+			s: &fleet.Software{
+				Name:    "Microsoft Teams.app",
+				Version: "1.00.622155",
+			},
+			sanitized: &fleet.Software{
+				Name:    "Microsoft Teams.app",
+				Version: "1.6.00.22155",
+			},
+		},
+		{
+			name: "Microsoft Teams not on macOS",
+			h: &fleet.Host{
+				Platform: "windows",
+			},
+			s: &fleet.Software{
+				Name:    "Microsoft Teams",
+				Version: "1.6.00.22378",
+			},
+			sanitized: &fleet.Software{
+				Name:    "Microsoft Teams",
+				Version: "1.6.00.22378",
+			},
+		},
+		{
+			name: "Other.app on macOS",
+			h: &fleet.Host{
+				Platform: "darwin",
+			},
+			s: &fleet.Software{
+				Name:    "Other.app",
+				Version: "1.2.3",
+			},
+			sanitized: &fleet.Software{
+				Name:    "Other.app",
+				Version: "1.2.3",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sanitizeSoftware(tc.h, tc.s)
+			require.Equal(t, tc.sanitized, tc.s)
+		})
+	}
+}

--- a/server/vulnerabilities/nvd/cpe_matching_rule.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rule.go
@@ -35,14 +35,21 @@ func (rule CPEMatchingRuleSpec) getCPEMeta() *wfn.Attributes {
 // cpe:2.3:a:apple:icloud:*:*:*:*:*:*:*:* which will match with any iCloud installation, but the
 // vulnerability in question only affects iCloud on Windows up to 7.0.x.
 type CPEMatchingRule struct {
+	// CPESpecs are the rules that will be used to match a CPE.
 	CPESpecs []CPEMatchingRuleSpec
-	// Set of CVEs that this rule targets
+	// CVEs is the set of CVEs that this rule targets.
 	CVEs map[string]struct{}
+	// IgnoreAll will cause all CPEs to not match hence ignoring a CVE.
+	IgnoreAll bool
 }
 
-// CPEMatches returns true if both the provided CPE match the rule.
+// CPEMatches returns true if the provided CPE matches the rule.
 func (rule CPEMatchingRule) CPEMatches(cpeMeta *wfn.Attributes) bool {
 	if cpeMeta == nil {
+		return false
+	}
+
+	if rule.IgnoreAll {
 		return false
 	}
 

--- a/server/vulnerabilities/nvd/cpe_matching_rule_test.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rule_test.go
@@ -242,3 +242,17 @@ func TestCPEProcessingRule(t *testing.T) {
 		}
 	})
 }
+
+func TestGetKnownNVDBugRules(t *testing.T) {
+	cpeMatchingRules, err := GetKnownNVDBugRules()
+	require.NoError(t, err)
+
+	cpeMeta, err := wfn.Parse("cpe:2.3:a:microsoft:teams:*:*:*:*:*:*:*:*")
+	require.NoError(t, err)
+
+	// Test that CVE-2020-10146 never matches (i.e. is ignored).
+	rule, ok := cpeMatchingRules.FindMatch("CVE-2020-10146")
+	require.True(t, ok)
+	ok = rule.CPEMatches(cpeMeta)
+	require.False(t, ok)
+}

--- a/server/vulnerabilities/nvd/cpe_matching_rules.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rules.go
@@ -106,6 +106,40 @@ func GetKnownNVDBugRules() (CPEMatchingRules, error) {
 				"CVE-2016-7656": {},
 			},
 		},
+		// The NVD dataset contains an invalid rule for CVE-2020-10146 that matches all versions of
+		// Microsoft Teams.
+		//
+		//	"cve" : {
+		//		"data_type" : "CVE",
+		//		"data_format" : "MITRE",
+		//		"data_version" : "4.0",
+		//		"CVE_data_meta" : {
+		// 			"ID" : "CVE-2020-10146",
+		// 			"ASSIGNER" : "cert@cert.org"
+		// 		},
+		//	[...]
+		//	"configurations" : {
+		//		"CVE_data_version" : "4.0",
+		//		"nodes" : [ {
+		//			"operator" : "OR",
+		//			"children" : [ ],
+		//			"cpe_match" : [ {
+		//				"vulnerable" : true,
+		//				"cpe23Uri" : "cpe:2.3:a:microsoft:teams:*:*:*:*:*:*:*:*", <<<<<<
+		//				"versionEndExcluding" : "2020-10-29",
+		//				"cpe_name" : [ ]
+		//			} ]
+		//		} ]
+		//	},
+		//
+		// Such CVE corresponds to a vulnerability on Microsoft's online service
+		// that has been patched since October 2020.
+		CPEMatchingRule{
+			IgnoreAll: true,
+			CVEs: map[string]struct{}{
+				"CVE-2020-10146": {},
+			},
+		},
 	}
 
 	for i, rule := range rules {

--- a/server/vulnerabilities/nvd/cve.go
+++ b/server/vulnerabilities/nvd/cve.go
@@ -179,6 +179,8 @@ func TranslateCPEToCVE(
 	// Delete any stale vulnerabilities. A vulnerability is stale iff the last time it was
 	// updated was more than `2 * periodicity` ago. This assumes that the whole vulnerability
 	// process completes in less than `periodicity` units of time.
+	//
+	// This is used to get rid of false positives once they are fixed and no longer detected as vulnerabilities.
 	if err = ds.DeleteOutOfDateVulnerabilities(ctx, fleet.NVDSource, 2*periodicity); err != nil {
 		level.Error(logger).Log("msg", "error deleting out of date vulnerabilities", "err", err)
 	}


### PR DESCRIPTION
#11922

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- ~[ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~[ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
  - ~For Orbit and Fleet Desktop changes:~
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
