### PR TITLE
Set MySQL table-definition-cache to 2048

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
         "--log_output=TABLE",
         "--log-queries-not-using-indexes",
         "--innodb-file-per-table=OFF",
+        "--table-definition-cache=2048",
         # These 3 keys run MySQL with GTID consistency enforced to avoid issues with production deployments that use it.
         "--enforce-gtid-consistency=ON",
         "--log-bin=bin.log",


### PR DESCRIPTION
Go tests are flaky because of this error:

Failing due to Error 1615 (HY000): Prepared statement needs to be re-prepared

We believe increasing [table_definition_cache](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_table_definition_cache) will resolve it.