### PR TITLE
Update "Hiring a new team member" to include adding location

### DIFF
--- a/handbook/company/leadership.md
+++ b/handbook/company/leadership.md
@@ -275,6 +275,7 @@ Here are the steps hiring managers follow to get an offer out to a candidate:
    - First and last name
    - Preferred pronoun _("them", "her", or "him")_
    - LinkedIn URL _(If the fleetie does not have a LinkedIn account, enter `N/A`)_
+   - Location of candidate
    - GitHub username _(Every candidate must have a GitHub account in "Fleeties" before the company makes them an offer.  If the the candidate does not have a GitHub account, ask them to create one, and make sure it's tracked in "Fleeties".)_
      > _**Tip:** A revealing live interview question can be to ask a candidate to quickly share their screen, sign up for GitHub, and then hit the "Edit" button on one of the pages in [the Fleet handbook](https://fleetdm.com/handbook) to make their first pull request.  This should not take more than 5 minutes._
 2. **Call references:** Ask the candidate for at least 2+ references and contact each reference in parallel using the instructions and tips in [Fleet's reference check template](https://docs.google.com/document/d/1LMOUkLJlAohuFykdgxTPL0RjAQxWkypzEYP_AT-bUAw/edit?usp=sharing).  Be respectful and keep these calls very short.


### PR DESCRIPTION
It's consistently a todo I send back for HM's prior to an offer going out, realized we don't actually ask them to fill in that specific cell in fleeties. Updating to fix.