### PR TITLE
Adding error logging for SOAP faults. Relaxing enrollment request checks

### DIFF
--- a/changes/13875-fix-windows-automatic-enrollment
+++ b/changes/13875-fix-windows-automatic-enrollment
@@ -1,0 +1,1 @@
+* Fix for strict checks on Windows MDM Automatic Enrollment

--- a/server/fleet/microsoft_mdm.go
+++ b/server/fleet/microsoft_mdm.go
@@ -224,7 +224,7 @@ func (req *SoapRequest) IsValidRequestSecurityTokenMsg() error {
 	}
 
 	reqEnrollType, err := req.Body.RequestSecurityToken.GetContextItem(mdm.ReqSecTokenContextItemEnrollmentType)
-	if err != nil || reqEnrollType != mdm.ReqSecTokenEnrollType {
+	if err != nil {
 		return fmt.Errorf("invalid requestsecuritytoken message %s: %s - %v", mdm.ReqSecTokenContextItemEnrollmentType, reqEnrollType, err)
 	}
 

--- a/server/fleet/microsoft_mdm.go
+++ b/server/fleet/microsoft_mdm.go
@@ -224,7 +224,7 @@ func (req *SoapRequest) IsValidRequestSecurityTokenMsg() error {
 	}
 
 	reqEnrollType, err := req.Body.RequestSecurityToken.GetContextItem(mdm.ReqSecTokenContextItemEnrollmentType)
-	if err != nil {
+	if err != nil || (reqEnrollType != mdm.ReqSecTokenEnrollTypeDevice && reqEnrollType != mdm.ReqSecTokenEnrollTypeFull) {
 		return fmt.Errorf("invalid requestsecuritytoken message %s: %s - %v", mdm.ReqSecTokenContextItemEnrollmentType, reqEnrollType, err)
 	}
 

--- a/server/mdm/microsoft/microsoft_mdm.go
+++ b/server/mdm/microsoft/microsoft_mdm.go
@@ -153,8 +153,14 @@ const (
 	// Certificate Renewal Period in seconds (180 days)
 	PolicyCertRenewalPeriodInSecs = "15552000"
 
-	// Supported Enroll Type
-	ReqSecTokenEnrollType = "Full"
+	// Supported Enroll types gathered from MS-MDE2 Spec Section 2.2.9.3
+	// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-mde2/f7553554-b6e1-4a0d-abd6-6a2534503af7
+
+	// Supported Enroll Type Device
+	ReqSecTokenEnrollTypeDevice = "Device"
+
+	// Supported Enroll Type Full
+	ReqSecTokenEnrollTypeFull = "Full"
 
 	// Provisioning Doc Certificate Renewal Period (365 days)
 	WstepCertRenewalPeriodInDays = "365"

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -1505,7 +1505,7 @@ func GetContextItem(secTokenMsg *fleet.RequestSecurityToken, contextItem string)
 // GetAuthorizedSoapFault authorize the request so SoapFault message can be returned
 func (svc *Service) GetAuthorizedSoapFault(ctx context.Context, eType string, origMsg int, errorMsg error) *fleet.SoapFault {
 	svc.authz.SkipAuthorization(ctx)
-
+	logging.WithErr(ctx, ctxerr.Wrap(ctx, errorMsg, "soap fault"))
 	soapFault := NewSoapFault(eType, origMsg, errorMsg)
 
 	return &soapFault


### PR DESCRIPTION
This relates to #13875 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Manual QA for all new/changed functionality

