### PR TITLE
UI: Update tooltip/link structure & functionality in Software tables

### DIFF
--- a/changes/12948-fix-software-bundle-clickability
+++ b/changes/12948-fix-software-bundle-clickability
@@ -1,0 +1,3 @@
+- Restored the ability to click on and select/copy text from software bundle tooltips while
+  maintaining the abilities to click the software's name to get more details and to click anywhere
+  else in the row to view all hosts with that software installed.

--- a/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tsx
+++ b/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tsx
@@ -25,28 +25,22 @@ const LinkCell = ({
   title,
   tooltipContent,
 }: ILinkCellProps): JSX.Element => {
-  const cellClasses = classnames(
-    baseClass,
-    className,
-    tooltipContent && "link-cell-tooltip"
-  );
+  const cellClasses = classnames(baseClass, className);
 
   const onClick = (e: React.MouseEvent): void => {
     customOnClick && customOnClick(e);
   };
 
   return tooltipContent ? (
-    <span className="name-container">
-      <TooltipWrapper
-        position="top"
-        className="link-cell-tooltip"
-        tipContent={tooltipContent}
-      >
-        <Link className={cellClasses} to={path} onClick={onClick} title={title}>
-          {value}
-        </Link>
-      </TooltipWrapper>
-    </span>
+    <TooltipWrapper
+      position="top"
+      className="link-cell-tooltip-wrapper"
+      tipContent={tooltipContent}
+    >
+      <Link className={cellClasses} to={path} onClick={onClick} title={title}>
+        {value}
+      </Link>
+    </TooltipWrapper>
   ) : (
     <Link
       className={cellClasses}

--- a/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tsx
+++ b/frontend/components/TableContainer/DataTable/LinkCell/LinkCell.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import { Link } from "react-router";
 import classnames from "classnames";
+import TooltipWrapper from "components/TooltipWrapper";
 
 interface ILinkCellProps {
   value: string | JSX.Element;
@@ -10,7 +11,7 @@ interface ILinkCellProps {
   className?: string;
   customOnClick?: (e: React.MouseEvent) => void;
   /** allows viewing overflow for tooltip */
-  withTooltip?: boolean;
+  tooltipContent?: string;
   title?: string;
 }
 
@@ -21,21 +22,38 @@ const LinkCell = ({
   path,
   className,
   customOnClick,
-  withTooltip,
   title,
+  tooltipContent,
 }: ILinkCellProps): JSX.Element => {
   const cellClasses = classnames(
     baseClass,
     className,
-    withTooltip && "link-cell-tooltip"
+    tooltipContent && "link-cell-tooltip"
   );
 
   const onClick = (e: React.MouseEvent): void => {
     customOnClick && customOnClick(e);
   };
 
-  return (
-    <Link className={cellClasses} to={path} onClick={onClick} title={title}>
+  return tooltipContent ? (
+    <span className="name-container">
+      <TooltipWrapper
+        position="top"
+        className="link-cell-tooltip"
+        tipContent={tooltipContent}
+      >
+        <Link className={cellClasses} to={path} onClick={onClick} title={title}>
+          {value}
+        </Link>
+      </TooltipWrapper>
+    </span>
+  ) : (
+    <Link
+      className={cellClasses}
+      to={path}
+      onClick={customOnClick}
+      title={title}
+    >
       {value}
     </Link>
   );

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -241,21 +241,28 @@ $shadow-transition-width: 10px;
           }
         }
         // css to properly style link-cell with tooltip
-        .link-cell-tooltip {
+        .link-cell-tooltip-wrapper {
           overflow: visible; // fixes tooltip overflow cut off by cell
+          white-space: nowrap; // single line
+          margin: 0; // padding applied to .link-cell for larger clickable area
           .component__tooltip-wrapper {
-            display: block;
-            white-space: nowrap; // single line
-            margin: 0; // padding applied to .link-cell for larger clickable area
-            .component__tooltip-wrapper__element {
+            &__element {
               display: block;
               white-space: nowrap; // single line
               text-overflow: ellipsis; // truncates text
               overflow: hidden;
-
-              .component__tooltip-wrapper__underline {
-                max-width: 100%; // fixes underline overflowing past truncated text
+              &__underline {
+                width: 100%;
               }
+              // TODO – this naming is now confusing, as this .link-cell is not the outermost layer of
+              // the cell – it's a NameCell
+              .link-cell {
+                padding: 0;
+              }
+            }
+
+            &__tip-text {
+              cursor: auto;
             }
           }
         }

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -253,11 +253,15 @@ $shadow-transition-width: 10px;
               overflow: hidden;
               &__underline {
                 width: 100%;
+
+                &::after {
+                  bottom: 9px; // compensate for padding to make larger clickable area
+                }
               }
               // TODO – this naming is now confusing, as this .link-cell is not the outermost layer of
               // the cell – it's a NameCell
               .link-cell {
-                padding: 0;
+                padding: 10px 0;
               }
             }
 

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -33,7 +33,10 @@ const TooltipWrapper = ({
     <div className={classname} data-position={position}>
       <div className={`${baseClass}__element`}>
         {children}
-        <div className={`${baseClass}__underline`} data-text={children} />
+        <div
+          className={`${baseClass}__element__underline`}
+          data-text={children}
+        />
       </div>
       <div
         className={tipClass}

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import * as DOMPurify from "dompurify";
 
 interface ITooltipWrapperProps {
-  children: string;
+  children: string | JSX.Element;
   tipContent: string;
   position?: "top" | "bottom";
   isDelayed?: boolean;
@@ -38,6 +38,9 @@ const TooltipWrapper = ({
       <div
         className={tipClass}
         dangerouslySetInnerHTML={{ __html: sanitizedTipContent }}
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
       />
     </div>
   );

--- a/frontend/components/TooltipWrapper/_styles.scss
+++ b/frontend/components/TooltipWrapper/_styles.scss
@@ -18,6 +18,11 @@
     position: static;
     display: inline; // treat like a span but allow other tags as children
     white-space: nowrap;
+
+    a {
+      position: relative;
+      z-index: 99;
+    }
   }
   &__underline {
     position: absolute;
@@ -59,6 +64,11 @@
     transition: opacity 0.3s ease;
     line-height: 1.375;
     white-space: initial;
+
+    // &__show-tip {
+    //   visibility: visible;
+    //   opacity: 1;
+    // }
 
     // invisible block to cover space so
     // hover state can continue from text to bubble

--- a/frontend/components/TooltipWrapper/_styles.scss
+++ b/frontend/components/TooltipWrapper/_styles.scss
@@ -18,31 +18,31 @@
     position: static;
     display: inline; // treat like a span but allow other tags as children
     white-space: nowrap;
+    &__underline {
+      position: absolute;
+      top: 0;
+      left: 0;
+      bottom: 0;
+
+      &::before {
+        content: attr(data-text);
+        opacity: 0;
+        visibility: hidden;
+      }
+      &::after {
+        content: "";
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        bottom: -2px;
+        left: 0;
+        border-bottom: 1px dashed $ui-fleet-black-50;
+      }
+    }
 
     a {
       position: relative;
       z-index: 99;
-    }
-  }
-  &__underline {
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-
-    &::before {
-      content: attr(data-text);
-      opacity: 0;
-      visibility: hidden;
-    }
-    &::after {
-      content: "";
-      width: 100%;
-      height: 100%;
-      position: absolute;
-      bottom: -2px;
-      left: 0;
-      border-bottom: 1px dashed $ui-fleet-black-50;
     }
   }
   &__tip-text {

--- a/frontend/components/TooltipWrapper/_styles.scss
+++ b/frontend/components/TooltipWrapper/_styles.scss
@@ -65,11 +65,6 @@
     line-height: 1.375;
     white-space: initial;
 
-    // &__show-tip {
-    //   visibility: visible;
-    //   opacity: 1;
-    // }
-
     // invisible block to cover space so
     // hover state can continue from text to bubble
     &::before {

--- a/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
@@ -14,6 +14,7 @@ import TooltipWrapper from "components/TooltipWrapper";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 import { COLORS } from "styles/var/colors";
+import { getSoftwareBundleTooltipMarkup } from "utilities/helpers";
 
 interface IHeaderProps {
   column: {
@@ -220,14 +221,7 @@ export const generateSoftwareTableHeaders = ({
             customOnClick={onClickSoftware}
             value={name}
             tooltipContent={
-              (bundle ?? undefined) &&
-              `
-        <span>
-          <b>Bundle identifier: </b>
-          <br />
-          ${bundle}
-        </span>
-      `
+              bundle ? getSoftwareBundleTooltipMarkup(bundle) : undefined
             }
           />
         );

--- a/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SoftwareTableConfig.tsx
@@ -218,8 +218,17 @@ export const generateSoftwareTableHeaders = ({
           <LinkCell
             path={PATHS.SOFTWARE_DETAILS(id.toString())}
             customOnClick={onClickSoftware}
-            value={bundle ? renderBundleTooltip(name, bundle) : name}
-            withTooltip={!!bundle}
+            value={name}
+            tooltipContent={
+              (bundle ?? undefined) &&
+              `
+        <span>
+          <b>Bundle identifier: </b>
+          <br />
+          ${bundle}
+        </span>
+      `
+            }
           />
         );
       },

--- a/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
@@ -65,23 +65,6 @@ const condenseVulnerabilities = (
     : condensed;
 };
 
-const renderBundleTooltip = (name: string, bundle: string) => (
-  <span className="name-container">
-    <TooltipWrapper
-      position="top"
-      tipContent={`
-        <span>
-          <b>Bundle identifier: </b>
-          <br />
-          ${bundle}
-        </span>
-      `}
-    >
-      {name}
-    </TooltipWrapper>
-  </span>
-);
-
 const getMaxProbability = (vulns: IVulnerability[]) =>
   vulns.reduce(
     (max, { epss_probability }) => Math.max(max, epss_probability || 0),
@@ -217,8 +200,17 @@ const generateTableHeaders = (
           <LinkCell
             path={PATHS.SOFTWARE_DETAILS(id.toString())}
             customOnClick={onClickSoftware}
-            value={bundle ? renderBundleTooltip(name, bundle) : name}
-            withTooltip={!!bundle}
+            value={name}
+            tooltipContent={
+              (bundle ?? undefined) &&
+              `
+        <span>
+          <b>Bundle identifier: </b>
+          <br />
+          ${bundle}
+        </span>
+      `
+            }
           />
         );
       },

--- a/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
+++ b/frontend/pages/software/ManageSoftwarePage/SoftwareTableConfig.tsx
@@ -6,7 +6,10 @@ import ReactTooltip from "react-tooltip";
 import { formatSoftwareType, ISoftware } from "interfaces/software";
 import { IVulnerability } from "interfaces/vulnerability";
 import PATHS from "router/paths";
-import { formatFloatAsPercentage } from "utilities/helpers";
+import {
+  formatFloatAsPercentage,
+  getSoftwareBundleTooltipMarkup,
+} from "utilities/helpers";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
@@ -202,14 +205,7 @@ const generateTableHeaders = (
             customOnClick={onClickSoftware}
             value={name}
             tooltipContent={
-              (bundle ?? undefined) &&
-              `
-        <span>
-          <b>Bundle identifier: </b>
-          <br />
-          ${bundle}
-        </span>
-      `
+              bundle ? getSoftwareBundleTooltipMarkup(bundle) : undefined
             }
           />
         );

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -900,6 +900,16 @@ export const getNextLocationPath = ({
   return queryString ? `/${nextLocation}?${queryString}` : `/${nextLocation}`;
 };
 
+export const getSoftwareBundleTooltipMarkup = (bundle: string) => {
+  return `
+        <span>
+          <b>Bundle identifier: </b>
+          <br />
+          ${bundle}
+        </span>
+      `;
+};
+
 export default {
   addGravatarUrlToResource,
   formatConfigDataForServer,


### PR DESCRIPTION
## Addresses #12948 

### In each software table (Software page and host details > software), for a software name with a tooltip:
- (new) User can click on and/or select text from the tooltip. When the user does so, they don't click through to either the software description or the "View all hosts" link
- (maintained) User can click on the software name, not its tooltip, and be taken to a detailed view of that software.
- (maintained) User can click anywhere else in the row to be taken to the Hosts page filtered for hosts with that software

https://www.loom.com/share/b0e6d86bc8ec4167ae360ca161555e96?sid=ca4f6f11-d957-4b9d-be6a-63f19d26758a

<img width="535" alt="Screenshot 2023-09-12 at 12 41 22 PM" src="https://github.com/fleetdm/fleet/assets/61553566/cbfdaf84-a586-4a9a-aeec-4ee289f0ae2f">

## Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`
- [x] Manual QA for all new/changed functionality
