### PR TITLE
Add https-listener-rules to test filtering unauthenticated endpoints

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/.terraform.lock.hcl
+++ b/infrastructure/dogfood/terraform/aws-tf-module/.terraform.lock.hcl
@@ -3,8 +3,9 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.57.0"
-  constraints = ">= 2.67.0, >= 3.0.0, >= 3.73.0, >= 4.6.0, >= 4.9.0, >= 4.18.0, >= 4.27.0, >= 4.30.0, >= 4.40.0, 4.57.0"
+  constraints = ">= 2.67.0, >= 3.0.0, >= 3.73.0, >= 4.6.0, >= 4.8.0, >= 4.9.0, >= 4.18.0, >= 4.27.0, >= 4.30.0, >= 4.40.0, 4.57.0"
   hashes = [
+    "h1:07cB50nnQkmdSHw5ehVEOny4czNYxAAdp00RUKWVa/w=",
     "h1:0bd5IKkEF1TGE4tgm0VuVMFQg2s6GOXJBU+/b/siYKw=",
     "zh:07d89ad94267b7d6285fd65fbd67f8680e111abf9bbcbcac2e30154262fbbe46",
     "zh:0eeee044e6fc285c20241d3de7f9b79450cab2df1452a9c18c0bed1090085a25",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/external" {
   constraints = ">= 1.0.0"
   hashes = [
     "h1:bROCw6g5D/3fFnWeJ01L4IrdnJl1ILU8DGDgXCtYzaY=",
+    "h1:gznGscVJ0USxy4CdihpjRKPsKvyGr/zqPvBoFLJTQDc=",
     "zh:001e2886dc81fc98cf17cf34c0d53cb2dae1e869464792576e11b0f34ee92f54",
     "zh:2eeac58dd75b1abdf91945ac4284c9ccb2bfb17fa9bdb5f5d408148ff553b3ee",
     "zh:2fc39079ba61411a737df2908942e6970cb67ed2f4fb19090cd44ce2082903dd",
@@ -49,6 +51,7 @@ provider "registry.terraform.io/hashicorp/local" {
   constraints = ">= 1.0.0"
   hashes = [
     "h1:R97FTYETo88sT2VHfMgkPU3lzCsZLunPftjSI5vfKe8=",
+    "h1:ZUEYUmm2t4vxwzxy1BvN1wL6SDWrDxfH7pxtzX8c6d0=",
     "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
     "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
     "zh:70a6f6a852dd83768d0778ce9817d81d4b3f073fab8fa570bff92dcb0824f732",
@@ -65,9 +68,11 @@ provider "registry.terraform.io/hashicorp/local" {
 }
 
 provider "registry.terraform.io/hashicorp/null" {
-  version = "3.2.1"
+  version     = "3.2.1"
+  constraints = ">= 2.0.0"
   hashes = [
     "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
+    "h1:ydA0/SNRVB1o95btfshvYsmxA+jZFRZcvKzZSB+4S1M=",
     "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
     "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
     "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
@@ -87,6 +92,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.5.1"
   constraints = ">= 2.2.0"
   hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
     "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
@@ -106,6 +112,7 @@ provider "registry.terraform.io/hashicorp/random" {
 provider "registry.terraform.io/hashicorp/tls" {
   version = "4.0.4"
   hashes = [
+    "h1:GZcFizg5ZT2VrpwvxGBHQ/hO9r6g0vYdQqx3bFD3anY=",
     "h1:pe9vq86dZZKCm+8k1RhzARwENslF3SXb9ErHbQfgjXU=",
     "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
     "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -120,7 +120,7 @@ module "main" {
         protocol    = "HTTPS"
         port        = "443"
         host        = "fleetdm.com"
-        path        = "/handbook/company/why-this-way#why-open-source"
+        path        = "/handbook/company/why-this-way"
         status_code = "HTTP_302"
       }]
       conditions = [{

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -133,7 +133,7 @@ module "main" {
         target_group_index = 0
       }]
       conditions = [{
-        path_patterns = ["/api/*/fleet/device/*/migrate_mdm", "/api/*/fleet/device/*/rotate_encryption_key", "/api/*/fleet/device/*/debug/errors" "/api/*/fleet/device/*/debug/desktop"]
+        path_patterns = ["/api/*/fleet/device/*/migrate_mdm", "/api/*/fleet/device/*/rotate_encryption_key", "/api/*/fleet/device/*/debug/errors", "/api/*/fleet/device/*/debug/desktop"]
       }]
     }]
   }

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -56,7 +56,7 @@ locals {
 }
 
 module "main" {
-  source          = "github.com/fleetdm/fleet//terraform?ref=tf-mod-root-v1.1.0"
+  source          = "github.com/fleetdm/fleet//terraform?ref=tf-mod-root-v1.3.0"
   certificate_arn = module.acm.acm_certificate_arn
   vpc = {
     name = local.customer
@@ -112,6 +112,30 @@ module "main" {
       prefix  = local.customer
       enabled = true
     }
+    https_listener_rules = [{
+      https_listener_index = 0
+      priority             = 1
+      actions = [{
+        type         = "fixed-response"
+        content_type = "text/html"
+        status_code  = "403"
+        message_body = "<h1>Forbidden</h1>"
+
+      }]
+      conditions = [{
+        path_patterns = ["/device/*", "/api/*/fleet/device/*"]
+      }]
+      }, {
+      https_listener_index = 0
+      priority             = 9000
+      actions = [{
+        type               = "forward"
+        target_group_index = 0
+      }]
+      conditions = [{
+        path_patterns = ["/api/*/fleet/device/*/migrate_mdm", "/api/*/fleet/device/*/rotate_encryption_key", "/api/*/fleet/device/*/debug/errors"]
+      }]
+    }]
   }
 }
 

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -133,7 +133,7 @@ module "main" {
         target_group_index = 0
       }]
       conditions = [{
-        path_patterns = ["/api/*/fleet/device/*/migrate_mdm", "/api/*/fleet/device/*/rotate_encryption_key", "/api/*/fleet/device/*/debug/errors"]
+        path_patterns = ["/api/*/fleet/device/*/migrate_mdm", "/api/*/fleet/device/*/rotate_encryption_key", "/api/*/fleet/device/*/debug/errors" "/api/*/fleet/device/*/debug/desktop"]
       }]
     }]
   }

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -114,7 +114,7 @@ module "main" {
     }
     https_listener_rules = [{
       https_listener_index = 0
-      priority             = 1
+      priority             = 9000
       actions = [{
         type         = "fixed-response"
         content_type = "text/html"
@@ -127,7 +127,7 @@ module "main" {
       }]
     }, {
       https_listener_index = 0
-      priority             = 9000
+      priority             = 1
       actions = [{
         type               = "forward"
         target_group_index = 0
@@ -137,7 +137,7 @@ module "main" {
       }]
     }, {
       https_listener_index = 0
-      priority             = 9001
+      priority             = 2
       actions = [{
         type               = "forward"
         target_group_index = 0

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -125,7 +125,7 @@ module "main" {
       conditions = [{
         path_patterns = ["/device/*", "/api/*/fleet/device/*"]
       }]
-      }, {
+    }, {
       https_listener_index = 0
       priority             = 9000
       actions = [{
@@ -133,7 +133,17 @@ module "main" {
         target_group_index = 0
       }]
       conditions = [{
-        path_patterns = ["/api/*/fleet/device/*/migrate_mdm", "/api/*/fleet/device/*/rotate_encryption_key", "/api/*/fleet/device/*/debug/errors", "/api/*/fleet/device/*/desktop"]
+        path_patterns = ["/api/*/fleet/device/*/migrate_mdm", "/api/*/fleet/device/*/rotate_encryption_key"]
+      }]
+    }, {
+      https_listener_index = 0
+      priority             = 9001
+      actions = [{
+        type               = "forward"
+        target_group_index = 0
+      }]
+      conditions = [{
+        path_patterns = ["/api/*/fleet/device/*/debug/errors", "/api/*/fleet/device/*/desktop"]
       }]
     }]
   }

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -116,16 +116,17 @@ module "main" {
       https_listener_index = 0
       priority             = 9000
       actions = [{
-        type         = "fixed-response"
-        content_type = "text/html"
-        status_code  = "403"
-        message_body = "<h1>Forbidden</h1>"
-
+        type        = "redirect"
+        protocol    = "HTTPS"
+        port        = "443"
+        host        = "fleetdm.com"
+        path        = "/handbook/company/why-this-way#why-open-source"
+        status_code = "HTTP_302"
       }]
       conditions = [{
         path_patterns = ["/device/*", "/api/*/fleet/device/*"]
       }]
-    }, {
+      }, {
       https_listener_index = 0
       priority             = 1
       actions = [{
@@ -135,7 +136,7 @@ module "main" {
       conditions = [{
         path_patterns = ["/api/*/fleet/device/*/migrate_mdm", "/api/*/fleet/device/*/rotate_encryption_key"]
       }]
-    }, {
+      }, {
       https_listener_index = 0
       priority             = 2
       actions = [{
@@ -144,6 +145,16 @@ module "main" {
       }]
       conditions = [{
         path_patterns = ["/api/*/fleet/device/*/debug/errors", "/api/*/fleet/device/*/desktop"]
+      }]
+      }, {
+      https_listener_index = 0
+      priority             = 3
+      actions = [{
+        type               = "forward"
+        target_group_index = 0
+      }]
+      conditions = [{
+        path_patterns = ["/api/*/fleet/device/*/refetch", "/api/*/fleet/device/*/transparency"]
       }]
     }]
   }

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -133,7 +133,7 @@ module "main" {
         target_group_index = 0
       }]
       conditions = [{
-        path_patterns = ["/api/*/fleet/device/*/migrate_mdm", "/api/*/fleet/device/*/rotate_encryption_key", "/api/*/fleet/device/*/debug/errors", "/api/*/fleet/device/*/debug/desktop"]
+        path_patterns = ["/api/*/fleet/device/*/migrate_mdm", "/api/*/fleet/device/*/rotate_encryption_key", "/api/*/fleet/device/*/debug/errors", "/api/*/fleet/device/*/desktop"]
       }]
     }]
   }


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
