### PR TITLE
Fleet UI: [second fix] Sentence case fixes

### DIFF
--- a/frontend/components/StatusIndicator/_styles.scss
+++ b/frontend/components/StatusIndicator/_styles.scss
@@ -2,7 +2,6 @@
   display: flex;
   align-items: center;
   color: $core-fleet-blue;
-  text-transform: capitalize;
 
   &:before {
     border-radius: 100%;

--- a/frontend/utilities/helpers.ts
+++ b/frontend/utilities/helpers.ts
@@ -530,7 +530,7 @@ export const generateTeam = (
   if (globalRole === null) {
     if (teams.length === 0) {
       // no global role and no teams
-      return "No Team";
+      return "No team";
     } else if (teams.length === 1) {
       // no global role and only one team
       return teams[0].name;
@@ -546,7 +546,7 @@ export const generateTeam = (
 };
 
 export const greyCell = (roleOrTeamText: string): boolean => {
-  const GREYED_TEXT = ["Global", "Unassigned", "Various", "No Team", "Unknown"];
+  const GREYED_TEXT = ["Global", "Unassigned", "Various", "No team", "Unknown"];
 
   return (
     GREYED_TEXT.includes(roleOrTeamText) || roleOrTeamText.includes(" teams")


### PR DESCRIPTION
## Issue
Cerra #13296 

## Description
- Sorry, CSS was overriding, I just assumed string fix was good enough
- Also fix "No Team" capitalization to "No team"

## Screenshot
<img width="1319" alt="Screenshot 2023-09-13 at 2 17 55 PM" src="https://github.com/fleetdm/fleet/assets/71795832/70d4296f-8e95-43e8-881a-d64aa139ae58">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.


- [x] Manual QA for all new/changed functionality