### PR TITLE
Fix invalid digest used in loadtest dockerfile

### DIFF
--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.19.12@sha:ddbb6cbbc88a5e8d802c3ab7dc717d7a0634401c030266f4ff0f1933806f2ed9
+FROM golang:1.19.12@sha256:ddbb6cbbc88a5e8d802c3ab7dc717d7a0634401c030266f4ff0f1933806f2ed9
 ARG TAG
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/cmd/osquery-perf/ && go build .
 
-FROM golang:1.19.12@sha:ddbb6cbbc88a5e8d802c3ab7dc717d7a0634401c030266f4ff0f1933806f2ed9
+FROM golang:1.19.12@sha256:ddbb6cbbc88a5e8d802c3ab7dc717d7a0634401c030266f4ff0f1933806f2ed9
 COPY --from=0 /go/fleet/cmd/osquery-perf/osquery-perf /go/osquery-perf


### PR DESCRIPTION
Resulted in this error when trying to spin up a load test:

```
│ Error: Error building docker image: 0: unsupported digest algorithm
│ 
│   with docker_registry_image.loadtest,
│   on ecr.tf line 46, in resource "docker_registry_image" "loadtest":
│   46: resource "docker_registry_image" "loadtest" {
```
