### PR TITLE
Website: Update browser versions supported by the Fleet website.

### DIFF
--- a/website/views/layouts/layout-landing.ejs
+++ b/website/views/layouts/layout-landing.ejs
@@ -280,14 +280,14 @@
         //    - https://github.com/lancedikson/bowser/tree/1fb99ced0e8834fd9662604bad7e0f0c3eba2786#rendering-engine-flags
         // --------------------------------------------------------------------
         var LATEST_SUPPORTED_VERSION_BY_OS = {
-          iOS: '12',//« earliest version that suppports the hubspot chatbot.
+          iOS: '13',//« earliest version that suppports the embedded podcast player.
           Android: '7' // « earliest version we can test for compatibility issues with on browserstack
         };
         var LATEST_SUPPORTED_VERSION_BY_USER_AGENT = {
           msedge: '80',//« earliest version to support the backdrop filter css property.
-          safari: '12',//« earliest version that suppports the hubspot chatbot.
-          firefox: '102',//« earliest version to support the backdrop filter css property.
-          chrome: '76',//« earliest version to support the backdrop filter css property.
+          safari: '13',//« earliest version that suppports the hubspot chatbot.
+          firefox: '103',//« earliest version to support the backdrop filter css property.
+          chrome: '80',//« earliest version to support the embedded podcast player.
           opera: '64',//« earliest version to support the backdrop filter css property.
         };
         var LATEST_SUPPORTED_VERSION_BY_BROWSER_NAME = {

--- a/website/views/layouts/layout-sandbox.ejs
+++ b/website/views/layouts/layout-sandbox.ejs
@@ -407,14 +407,14 @@
         //    - https://github.com/lancedikson/bowser/tree/1fb99ced0e8834fd9662604bad7e0f0c3eba2786#rendering-engine-flags
         // --------------------------------------------------------------------
         var LATEST_SUPPORTED_VERSION_BY_OS = {
-          iOS: '11',//« earliest version that suppports the hubspot chatbot.
+          iOS: '13',//« earliest version that suppports the embedded podcast player.
           Android: '7' // « earliest version we can test for compatibility issues with on browserstack
         };
         var LATEST_SUPPORTED_VERSION_BY_USER_AGENT = {
           msedge: '80',//« earliest version to support the backdrop filter css property.
-          safari: '11',//« earliest version that suppports the hubspot chatbot.
-          firefox: '102',//« earliest version to support the backdrop filter css property.
-          chrome: '76',//« earliest version to support the backdrop filter css property.
+          safari: '13',//« earliest version that suppports the hubspot chatbot.
+          firefox: '103',//« earliest version to support the backdrop filter css property.
+          chrome: '80',//« earliest version to support the embedded podcast player.
           opera: '64',//« earliest version to support the backdrop filter css property.
         };
         var LATEST_SUPPORTED_VERSION_BY_BROWSER_NAME = {

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -484,14 +484,14 @@
         //    - https://github.com/lancedikson/bowser/tree/1fb99ced0e8834fd9662604bad7e0f0c3eba2786#rendering-engine-flags
         // --------------------------------------------------------------------
         var LATEST_SUPPORTED_VERSION_BY_OS = {
-          iOS: '12',//« earliest version that suppports the hubspot chatbot.
+          iOS: '13',//« earliest version that suppports the embedded podcast player.
           Android: '7' // « earliest version we can test for compatibility issues with on browserstack
         };
         var LATEST_SUPPORTED_VERSION_BY_USER_AGENT = {
           msedge: '80',//« earliest version to support the backdrop filter css property.
-          safari: '12',//« earliest version that suppports the hubspot chatbot.
-          firefox: '102',//« earliest version to support the backdrop filter css property.
-          chrome: '76',//« earliest version to support the backdrop filter css property.
+          safari: '13',//« earliest version that suppports the hubspot chatbot.
+          firefox: '103',//« earliest version to support the backdrop filter css property.
+          chrome: '80',//« earliest version to support the embedded podcast player.
           opera: '64',//« earliest version to support the backdrop filter css property.
         };
         var LATEST_SUPPORTED_VERSION_BY_BROWSER_NAME = {


### PR DESCRIPTION
Closes: #13777

Changes:
- Updated the Fleet website's supported browser versions:
   - Chrome v76 » v80
   - Safari v12 » v13
   - iOS v12 » v13
   - Firefox v102 » v103 