### PR TITLE
add windows bitlocker to mdm controls page

### DIFF
--- a/changes/issue-13953-changes-to-controls-page-for-bitlocker
+++ b/changes/issue-13953-changes-to-controls-page-for-bitlocker
@@ -1,0 +1,1 @@
+- change Contorls/Disk Encryption page to include windows bitlocker information

--- a/frontend/components/StatusIndicatorWithIcon/StatusIndicatorWithIcon.tsx
+++ b/frontend/components/StatusIndicatorWithIcon/StatusIndicatorWithIcon.tsx
@@ -25,6 +25,8 @@ interface IStatusIndicatorWithIconProps {
   };
   layout?: "horizontal" | "vertical";
   className?: string;
+  /** Classname to add to the value text */
+  valueClassName?: string;
 }
 
 const statusIconNameMapping: Record<IndicatorStatus, IconNames> = {
@@ -41,11 +43,12 @@ const StatusIndicatorWithIcon = ({
   tooltip,
   layout = "horizontal",
   className,
+  valueClassName,
 }: IStatusIndicatorWithIconProps) => {
   const classNames = classnames(baseClass, className);
   const id = `status-${uniqueId()}`;
 
-  const valueClasses = classnames(`${baseClass}__value`, {
+  const valueClasses = classnames(`${baseClass}__value`, valueClassName, {
     [`${baseClass}__value-vertical`]: layout === "vertical",
   });
   const valueContent = (

--- a/frontend/components/StatusIndicatorWithIcon/StatusIndicatorWithIcon.tsx
+++ b/frontend/components/StatusIndicatorWithIcon/StatusIndicatorWithIcon.tsx
@@ -23,6 +23,7 @@ interface IStatusIndicatorWithIconProps {
     tooltipText: string | JSX.Element;
     position?: "top" | "bottom";
   };
+  layout?: "horizontal" | "vertical";
   className?: string;
 }
 
@@ -38,13 +39,17 @@ const StatusIndicatorWithIcon = ({
   status,
   value,
   tooltip,
+  layout = "horizontal",
   className,
 }: IStatusIndicatorWithIconProps) => {
   const classNames = classnames(baseClass, className);
   const id = `status-${uniqueId()}`;
 
+  const valueClasses = classnames(`${baseClass}__value`, {
+    [`${baseClass}__value-vertical`]: layout === "vertical",
+  });
   const valueContent = (
-    <span className={`${baseClass}__value`}>
+    <span className={valueClasses}>
       <Icon name={statusIconNameMapping[status]} />
       <span>{value}</span>
     </span>

--- a/frontend/components/StatusIndicatorWithIcon/_styles.scss
+++ b/frontend/components/StatusIndicatorWithIcon/_styles.scss
@@ -1,4 +1,5 @@
 .status-indicator-with-icon {
+  // default layout is horizontal
   &__value {
     display: inline-flex;
     align-items: center;
@@ -7,5 +8,11 @@
     .icon {
       margin-right: $pad-xsmall;
     }
+  }
+
+  // overrides for different layout
+  &__value-vertical {
+    flex-direction: column;
+    gap: $pad-xsmall;
   }
 }

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -285,7 +285,10 @@ export interface IConfig {
     };
   };
   mdm: IMdmConfig;
-  mdm_enabled?: boolean; // TODO: remove when windows MDM is released. Only used for windows MDM dev currently.
+  /** This is the flag that determines if the windwos mdm feature flag is enabled.
+      TODO: remove when windows MDM is released. Only used for windows MDM dev currently.
+  */
+  mdm_enabled?: boolean;
 }
 
 export interface IWebhookSettings {

--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -22,8 +22,6 @@ export const MDM_ENROLLMENT_STATUS = {
 
 export type MdmEnrollmentStatus = keyof typeof MDM_ENROLLMENT_STATUS;
 
-export type ProfileSummaryResponse = Record<MdmProfileStatus, number>;
-
 export interface IMdmStatusCardData {
   status: MdmEnrollmentStatus;
   hosts: number;

--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -83,17 +83,13 @@ export interface IHostMacMdmProfile {
   detail: string;
 }
 
-export type FileVaultProfileStatus =
+export type DiskEncryptionStatus =
   | "verified"
   | "verifying"
   | "action_required"
   | "enforcing"
   | "failed"
   | "removing_enforcement";
-
-// // TODO: update when list profiles API returns identifier
-// export const FLEET_FILEVAULT_PROFILE_IDENTIFIER =
-//   "com.fleetdm.fleet.mdm.filevault";
 
 export const FLEET_FILEVAULT_PROFILE_DISPLAY_NAME = "Disk encryption";
 

--- a/frontend/pages/ManageControlsPage/OSSettings/AggregateMacSettingsIndicators/index.ts
+++ b/frontend/pages/ManageControlsPage/OSSettings/AggregateMacSettingsIndicators/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./AggregateMacSettingsIndicators";

--- a/frontend/pages/ManageControlsPage/OSSettings/OSSettings.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/OSSettings.tsx
@@ -4,7 +4,6 @@ import { useQuery } from "react-query";
 
 import { AppContext } from "context/app";
 import SideNav from "pages/admin/components/SideNav";
-import { ProfileSummaryResponse } from "interfaces/mdm";
 import { API_NO_TEAM_ID, APP_CONTEXT_NO_TEAM_ID } from "interfaces/team";
 import mdmAPI from "services/entities/mdm";
 
@@ -40,9 +39,10 @@ const OSSettings = ({
     data: aggregateProfileStatusData,
     refetch: refetchAggregateProfileStatus,
     isLoading: isLoadingAggregateProfileStatus,
-  } = useQuery<ProfileSummaryResponse>(
+  } = useQuery(
     ["aggregateProfileStatuses", teamId],
-    () => mdmAPI.getAggregateProfileStatuses(teamId),
+    () =>
+      mdmAPI.getAggregateProfileStatuses(teamId, config?.mdm_enabled ?? false),
     {
       refetchOnWindowFocus: false,
       retry: false,
@@ -61,6 +61,8 @@ const OSSettings = ({
     DEFAULT_SETTINGS_SECTION;
 
   const CurrentCard = currentFormSection.Card;
+
+  console.log("aggregate data:", aggregateProfileStatusData);
 
   return (
     <div className={baseClass}>

--- a/frontend/pages/ManageControlsPage/OSSettings/OSSettings.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/OSSettings.tsx
@@ -9,7 +9,7 @@ import { API_NO_TEAM_ID, APP_CONTEXT_NO_TEAM_ID } from "interfaces/team";
 import mdmAPI from "services/entities/mdm";
 
 import OS_SETTINGS_NAV_ITEMS from "./OSSettingsNavItems";
-import AggregateMacSettingsIndicators from "./AggregateMacSettingsIndicators";
+import ProfileStatusAggregate from "./ProfileStatusAggregate";
 import TurnOnMdmMessage from "../components/TurnOnMdmMessage";
 
 const baseClass = "os-settings";
@@ -67,7 +67,7 @@ const OSSettings = ({
       <p className={`${baseClass}__description`}>
         Remotely enforce settings on macOS hosts assigned to this team.
       </p>
-      <AggregateMacSettingsIndicators
+      <ProfileStatusAggregate
         isLoading={isLoadingAggregateProfileStatus}
         teamId={teamId}
         aggregateProfileStatusData={aggregateProfileStatusData}

--- a/frontend/pages/ManageControlsPage/OSSettings/OSSettings.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/OSSettings.tsx
@@ -62,8 +62,6 @@ const OSSettings = ({
 
   const CurrentCard = currentFormSection.Card;
 
-  console.log("aggregate data:", aggregateProfileStatusData);
-
   return (
     <div className={baseClass}>
       <p className={`${baseClass}__description`}>

--- a/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/ProfileStatusAggregate.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/ProfileStatusAggregate.tsx
@@ -2,7 +2,8 @@ import React from "react";
 
 import paths from "router/paths";
 import { buildQueryStringFromParams } from "utilities/url";
-import { MdmProfileStatus, ProfileSummaryResponse } from "interfaces/mdm";
+import { MdmProfileStatus } from "interfaces/mdm";
+import { ProfileStatusSummaryResponse } from "services/entities/mdm";
 
 import Spinner from "components/Spinner";
 import StatusIndicatorWithIcon, {
@@ -54,7 +55,7 @@ const ProfileStatusCount = ({
 interface ProfileStatusAggregateProps {
   isLoading: boolean;
   teamId: number;
-  aggregateProfileStatusData?: ProfileSummaryResponse;
+  aggregateProfileStatusData?: ProfileStatusSummaryResponse;
 }
 
 const ProfileStatusAggregate = ({

--- a/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/ProfileStatusAggregate.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/ProfileStatusAggregate.tsx
@@ -9,46 +9,47 @@ import StatusIndicatorWithIcon, {
   IndicatorStatus,
 } from "components/StatusIndicatorWithIcon/StatusIndicatorWithIcon";
 
+import AGGREGATE_STATUS_DISPLAY_OPTIONS from "./ProfileStatusAggregateOptions";
+
 const baseClass = "profile-status-aggregate";
 
-interface IAggregateDisplayOption {
-  value: MdmProfileStatus;
-  text: string;
-  iconName: IndicatorStatus;
+interface IProfileStatusCountProps {
+  statusIcon: IndicatorStatus;
+  statusValue: MdmProfileStatus;
+  title: string;
+  teamId: number;
+  hostCount: number;
   tooltipText: string;
 }
 
-const AGGREGATE_STATUS_DISPLAY_OPTIONS: IAggregateDisplayOption[] = [
-  {
-    value: "verified",
-    text: "Verified",
-    iconName: "success",
-    tooltipText:
-      "These hosts installed all configuration profiles. Fleet verified with osquery.",
-  },
-  {
-    value: "verifying",
-    text: "Verifying",
-    iconName: "successPartial",
-    tooltipText:
-      "These hosts acknowledged all MDM commands to install configuration profiles. " +
-      "Fleet is verifying the profiles are installed with osquery.",
-  },
-  {
-    value: "pending",
-    text: "Pending",
-    iconName: "pendingPartial",
-    tooltipText:
-      "These hosts will receive MDM commands to install configuration profiles when the hosts come online.",
-  },
-  {
-    value: "failed",
-    text: "Failed",
-    iconName: "error",
-    tooltipText:
-      "These hosts failed to install configuration profiles. Click on a host to view error(s).",
-  },
-];
+const ProfileStatusCount = ({
+  statusIcon,
+  statusValue,
+  teamId,
+  title,
+  hostCount,
+  tooltipText,
+}: IProfileStatusCountProps) => {
+  const generateFilterHostsByStatusLink = () => {
+    return `${paths.MANAGE_HOSTS}?${buildQueryStringFromParams({
+      team_id: teamId,
+      macos_settings: statusValue,
+    })}`;
+  };
+
+  return (
+    <div className={`${baseClass}__profile-status-count`}>
+      <StatusIndicatorWithIcon
+        status={statusIcon}
+        value={title}
+        tooltip={{ tooltipText, position: "top" }}
+        layout="vertical"
+        valueClassName={`${baseClass}__status-indicator-value`}
+      />
+      <a href={generateFilterHostsByStatusLink()}>{hostCount} hosts</a>
+    </div>
+  );
+};
 
 interface ProfileStatusAggregateProps {
   isLoading: boolean;
@@ -68,23 +69,14 @@ const ProfileStatusAggregate = ({
     const count = aggregateProfileStatusData[value];
 
     return (
-      <div className={`${baseClass}__profile-status-count`}>
-        <StatusIndicatorWithIcon
-          status={iconName}
-          value={text}
-          tooltip={{ tooltipText, position: "top" }}
-          layout="vertical"
-          className={`${baseClass}__status-indicator`}
-        />
-        <a
-          href={`${paths.MANAGE_HOSTS}?${buildQueryStringFromParams({
-            team_id: teamId,
-            macos_settings: value,
-          })}`}
-        >
-          {count} hosts
-        </a>
-      </div>
+      <ProfileStatusCount
+        statusIcon={iconName}
+        statusValue={value}
+        teamId={teamId}
+        title={text}
+        hostCount={count}
+        tooltipText={tooltipText}
+      />
     );
   });
 

--- a/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/ProfileStatusAggregate.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/ProfileStatusAggregate.tsx
@@ -66,6 +66,8 @@ const ProfileStatusAggregate = ({
     if (!aggregateProfileStatusData) return null;
 
     const { value, text, iconName, tooltipText } = status;
+
+    // TODO: figure out how to get windows hosts count in here too.
     const count = aggregateProfileStatusData[value];
 
     return (

--- a/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/ProfileStatusAggregate.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/ProfileStatusAggregate.tsx
@@ -3,17 +3,18 @@ import React from "react";
 import paths from "router/paths";
 import { buildQueryStringFromParams } from "utilities/url";
 import { MdmProfileStatus, ProfileSummaryResponse } from "interfaces/mdm";
-import MacSettingsIndicator from "pages/hosts/details/MacSettingsIndicator";
 
-import { IconNames } from "components/icons";
 import Spinner from "components/Spinner";
+import StatusIndicatorWithIcon, {
+  IndicatorStatus,
+} from "components/StatusIndicatorWithIcon/StatusIndicatorWithIcon";
 
-const baseClass = "aggregate-mac-settings-indicators";
+const baseClass = "profile-status-aggregate";
 
 interface IAggregateDisplayOption {
   value: MdmProfileStatus;
   text: string;
-  iconName: IconNames;
+  iconName: IndicatorStatus;
   tooltipText: string;
 }
 
@@ -28,7 +29,7 @@ const AGGREGATE_STATUS_DISPLAY_OPTIONS: IAggregateDisplayOption[] = [
   {
     value: "verifying",
     text: "Verifying",
-    iconName: "success-partial",
+    iconName: "successPartial",
     tooltipText:
       "These hosts acknowledged all MDM commands to install configuration profiles. " +
       "Fleet is verifying the profiles are installed with osquery.",
@@ -36,7 +37,7 @@ const AGGREGATE_STATUS_DISPLAY_OPTIONS: IAggregateDisplayOption[] = [
   {
     value: "pending",
     text: "Pending",
-    iconName: "pending-partial",
+    iconName: "pendingPartial",
     tooltipText:
       "These hosts will receive MDM commands to install configuration profiles when the hosts come online.",
   },
@@ -49,17 +50,17 @@ const AGGREGATE_STATUS_DISPLAY_OPTIONS: IAggregateDisplayOption[] = [
   },
 ];
 
-interface AggregateMacSettingsIndicatorsProps {
+interface ProfileStatusAggregateProps {
   isLoading: boolean;
   teamId: number;
   aggregateProfileStatusData?: ProfileSummaryResponse;
 }
 
-const AggregateMacSettingsIndicators = ({
+const ProfileStatusAggregate = ({
   isLoading,
   teamId,
   aggregateProfileStatusData,
-}: AggregateMacSettingsIndicatorsProps) => {
+}: ProfileStatusAggregateProps) => {
   const indicators = AGGREGATE_STATUS_DISPLAY_OPTIONS.map((status) => {
     if (!aggregateProfileStatusData) return null;
 
@@ -67,11 +68,13 @@ const AggregateMacSettingsIndicators = ({
     const count = aggregateProfileStatusData[value];
 
     return (
-      <div className="aggregate-mac-settings-indicator">
-        <MacSettingsIndicator
-          indicatorText={text}
-          iconName={iconName}
+      <div className={`${baseClass}__profile-status-count`}>
+        <StatusIndicatorWithIcon
+          status={iconName}
+          value={text}
           tooltip={{ tooltipText, position: "top" }}
+          layout="vertical"
+          className={`${baseClass}__status-indicator`}
         />
         <a
           href={`${paths.MANAGE_HOSTS}?${buildQueryStringFromParams({
@@ -96,4 +99,4 @@ const AggregateMacSettingsIndicators = ({
   return <div className={baseClass}>{indicators}</div>;
 };
 
-export default AggregateMacSettingsIndicators;
+export default ProfileStatusAggregate;

--- a/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/ProfileStatusAggregate.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/ProfileStatusAggregate.tsx
@@ -67,8 +67,6 @@ const ProfileStatusAggregate = ({
     if (!aggregateProfileStatusData) return null;
 
     const { value, text, iconName, tooltipText } = status;
-
-    // TODO: figure out how to get windows hosts count in here too.
     const count = aggregateProfileStatusData[value];
 
     return (

--- a/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/ProfileStatusAggregateOptions.ts
+++ b/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/ProfileStatusAggregateOptions.ts
@@ -1,0 +1,43 @@
+import { MdmProfileStatus } from "interfaces/mdm";
+import { IndicatorStatus } from "components/StatusIndicatorWithIcon/StatusIndicatorWithIcon";
+
+interface IAggregateDisplayOption {
+  value: MdmProfileStatus;
+  text: string;
+  iconName: IndicatorStatus;
+  tooltipText: string;
+}
+
+const AGGREGATE_STATUS_DISPLAY_OPTIONS: IAggregateDisplayOption[] = [
+  {
+    value: "verified",
+    text: "Verified",
+    iconName: "success",
+    tooltipText:
+      "The host applied all OS settings. Fleet verified with osquery.",
+  },
+  {
+    value: "verifying",
+    text: "Verifying",
+    iconName: "successPartial",
+    tooltipText:
+      "The hosts acknowledged all MDM commands to apply OS settings. " +
+      "Fleet is verifying the OS settings are applied with osquery.",
+  },
+  {
+    value: "pending",
+    text: "Pending",
+    iconName: "pendingPartial",
+    tooltipText:
+      "Host will receive MDM command to apply OS settings when the host come online.",
+  },
+  {
+    value: "failed",
+    text: "Failed",
+    iconName: "error",
+    tooltipText:
+      "Host failed to apply the latest OS settings. Click to view error(s).",
+  },
+];
+
+export default AGGREGATE_STATUS_DISPLAY_OPTIONS;

--- a/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/_styles.scss
@@ -39,7 +39,7 @@
     border-bottom-right-radius: 6px;
   }
 
-  &__status-indicator {
+  &__status-indicator-value {
     font-weight: $bold;
   }
 }

--- a/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/_styles.scss
@@ -1,4 +1,4 @@
-.aggregate-mac-settings-indicators {
+.profile-status-aggregate {
   display: flex;
   height: 94px;
   border-top: 1px solid #e2e4ea;
@@ -10,7 +10,7 @@
     margin: auto;
   }
 
-  .aggregate-mac-settings-indicator {
+  &__profile-status-count {
     flex-grow: 1;
 
     display: flex;
@@ -29,13 +29,17 @@
       font-weight: $regular;
     }
 
-    .settings-indicator {
+    .profile-status-indicator {
       flex-direction: column;
     }
   }
 
-  .aggregate-mac-settings-indicator:last-child {
+  &__profile-status-count:last-child {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
+  }
+
+  &__status-indicator {
+    font-weight: $bold;
   }
 }

--- a/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/index.ts
+++ b/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ProfileStatusAggregate";

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/DiskEncryption.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/DiskEncryption.tsx
@@ -100,9 +100,12 @@ const DiskEncryption = ({
     setIsLoadingTeam(false);
   }
 
-  // TODO: remove when we release windows MDM. This is temporary dynamic text
-  // depending on the feature flag.
   const createDescriptionText = () => {
+    // table is showing disk encryption status.
+    if (showAggregate) {
+      return "If turned on, hosts' disk encryption keys will be stored in Fleet. ";
+    }
+
     const isWindowsFeatureFlagEnabled = config?.mdm_enabled ?? false;
     const dynamicText = isWindowsFeatureFlagEnabled
       ? " and “BitLocker” on Windows"

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/DiskEncryption.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/DiskEncryption.tsx
@@ -100,6 +100,16 @@ const DiskEncryption = ({
     setIsLoadingTeam(false);
   }
 
+  // TODO: remove when we release windows MDM. This is temporary dynamic text
+  // depending on the feature flag.
+  const createDescriptionText = () => {
+    const isWindowsFeatureFlagEnabled = config?.mdm_enabled ?? false;
+    const dynamicText = isWindowsFeatureFlagEnabled
+      ? " and “BitLocker” on Windows"
+      : "";
+    return `Also known as “FileVault” on macOS${dynamicText}. If turned on, hosts' disk encryption keys will be stored in Fleet. `;
+  };
+
   return (
     <div className={baseClass}>
       <h2>Disk encryption</h2>
@@ -124,8 +134,7 @@ const DiskEncryption = ({
                 On
               </Checkbox>
               <p>
-                Apple calls this “FileVault.” If turned on, hosts&apos; disk
-                encryption keys will be stored in Fleet.{" "}
+                {createDescriptionText()}
                 <CustomLink
                   text="Learn more"
                   url="https://fleetdm.com/docs/using-fleet/mdm-disk-encryption"

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/_styles.scss
@@ -2,6 +2,7 @@
   h2 {
     margin-top: 0;
     padding-bottom: $pad-small;
+    margin-bottom: $pad-xxlarge;
     font-size: $medium;
     font-weight: $regular;
     color: $core-fleet-black;

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTable.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTable.tsx
@@ -53,8 +53,9 @@ const DiskEncryptionTable = ({ currentTeamId }: IDiskEncryptionTableProps) => {
         isLoading={false}
         showMarkAllPages={false}
         isAllPagesSelected={false}
-        defaultSortHeader={DEFAULT_SORT_HEADER}
-        defaultSortDirection={DEFAULT_SORT_DIRECTION}
+        manualSortBy
+        // defaultSortHeader={DEFAULT_SORT_HEADER}
+        // defaultSortDirection={DEFAULT_SORT_DIRECTION}
         disableTableHeader
         disablePagination
         disableCount

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTable.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTable.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useContext } from "react";
 import { useQuery } from "react-query";
 
+import { AppContext } from "context/app";
 import mdmAPI, { IDiskEncryptionSummaryResponse } from "services/entities/mdm";
 
 import TableContainer from "components/TableContainer";
@@ -18,10 +19,9 @@ interface IDiskEncryptionTableProps {
   currentTeamId?: number;
 }
 
-const DEFAULT_SORT_HEADER = "hosts";
-const DEFAULT_SORT_DIRECTION = "asc";
-
 const DiskEncryptionTable = ({ currentTeamId }: IDiskEncryptionTableProps) => {
+  const { config } = useContext(AppContext);
+
   const {
     data: diskEncryptionStatusData,
     error: diskEncryptionStatusError,
@@ -34,9 +34,15 @@ const DiskEncryptionTable = ({ currentTeamId }: IDiskEncryptionTableProps) => {
     }
   );
 
-  const tableHeaders = generateTableHeaders();
-
-  const tableData = generateTableData(diskEncryptionStatusData, currentTeamId);
+  // TODO: WINDOWS FEATURE FLAG: remove this when windows feature flag is removed.
+  // this is used to conditianlly show "View all hosts" link in table cells.
+  const windowsFeatureFlagEnabled = config?.mdm_enabled ?? false;
+  const tableHeaders = generateTableHeaders(windowsFeatureFlagEnabled);
+  const tableData = generateTableData(
+    windowsFeatureFlagEnabled,
+    diskEncryptionStatusData,
+    currentTeamId
+  );
 
   if (diskEncryptionStatusError) {
     return <DataError />;
@@ -54,8 +60,6 @@ const DiskEncryptionTable = ({ currentTeamId }: IDiskEncryptionTableProps) => {
         showMarkAllPages={false}
         isAllPagesSelected={false}
         manualSortBy
-        // defaultSortHeader={DEFAULT_SORT_HEADER}
-        // defaultSortDirection={DEFAULT_SORT_DIRECTION}
         disableTableHeader
         disablePagination
         disableCount

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTable.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTable.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useQuery } from "react-query";
 
-import mdmAPI, { IFileVaultSummaryResponse } from "services/entities/mdm";
+import mdmAPI, { IDiskEncryptionSummaryResponse } from "services/entities/mdm";
 
 import TableContainer from "components/TableContainer";
 import EmptyTable from "components/EmptyTable";
@@ -25,9 +25,9 @@ const DiskEncryptionTable = ({ currentTeamId }: IDiskEncryptionTableProps) => {
   const {
     data: diskEncryptionStatusData,
     error: diskEncryptionStatusError,
-  } = useQuery<IFileVaultSummaryResponse, Error, IFileVaultSummaryResponse>(
+  } = useQuery<IDiskEncryptionSummaryResponse, Error>(
     ["disk-encryption-summary", currentTeamId],
-    () => mdmAPI.getDiskEncryptionAggregate(currentTeamId),
+    () => mdmAPI.getDiskEncryptionSummary(currentTeamId),
     {
       refetchOnWindowFocus: false,
       retry: false,

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTableConfig.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTableConfig.tsx
@@ -80,9 +80,10 @@ const defaultTableHeaders: IDataColumn[] = [
       <HeaderCell
         value={cellProps.column.title}
         isSortedDesc={cellProps.column.isSortedDesc}
-        disableSortBy={false}
+        disableSortBy
       />
     ),
+    disableSortBy: true,
     accessor: "macosHosts",
     Cell: ({ cell: { value: aggregateCount } }: ICellProps) => {
       return (
@@ -98,9 +99,10 @@ const defaultTableHeaders: IDataColumn[] = [
       <HeaderCell
         value={cellProps.column.title}
         isSortedDesc={cellProps.column.isSortedDesc}
-        disableSortBy={false}
+        disableSortBy
       />
     ),
+    disableSortBy: true,
     accessor: "windowsHosts",
     Cell: ({
       cell: { value: aggregateCount },
@@ -176,6 +178,16 @@ const STATUS_CELL_VALUES: Record<DiskEncryptionStatus, IStatusCellValue> = {
 
 type StatusEntry = [DiskEncryptionStatus, IDiskEncryptionStatusAggregate];
 
+// Order of the status column. We want the order to always be the same.
+const statusOrder: DiskEncryptionStatus[] = [
+  "verified",
+  "verifying",
+  "failed",
+  "action_required",
+  "enforcing",
+  "removing_enforcement",
+];
+
 export const generateTableData = (
   data?: IDiskEncryptionSummaryResponse,
   currentTeamId?: number
@@ -184,6 +196,11 @@ export const generateTableData = (
 
   // type cast here gives a little more typing information than Object.entries alone.
   const entries = Object.entries(data) as StatusEntry[];
+
+  // ensure the order of the status column is always the same.
+  entries.sort(([statusA], [statusB]) => {
+    return statusOrder.indexOf(statusA) - statusOrder.indexOf(statusB);
+  });
 
   return entries.map(([status, statusAggregate]) => ({
     status: STATUS_CELL_VALUES[status],

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTableConfig.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTableConfig.tsx
@@ -6,6 +6,8 @@ import {
   IDiskEncryptionSummaryResponse,
 } from "services/entities/mdm";
 
+import { DISK_ENCRYPTION_QUERY_PARAM_NAME } from "pages/hosts/ManageHostsPage/HostsPageConfig";
+
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 import StatusIndicatorWithIcon from "components/StatusIndicatorWithIcon";
@@ -100,7 +102,7 @@ const defaultTableHeaders: IDataColumn[] = [
             <ViewAllHostsLink
               className="view-hosts-link"
               queryParams={{
-                macos_settings_disk_encryption: original.status.value,
+                [DISK_ENCRYPTION_QUERY_PARAM_NAME]: original.status.value,
                 team_id: original.teamId,
               }}
             />
@@ -133,7 +135,7 @@ const windowsTableHeader: IDataColumn[] = [
           <ViewAllHostsLink
             className="view-hosts-link"
             queryParams={{
-              macos_settings_disk_encryption: original.status.value,
+              [DISK_ENCRYPTION_QUERY_PARAM_NAME]: original.status.value,
               team_id: original.teamId,
             }}
           />

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/_styles.scss
@@ -1,7 +1,4 @@
 .disk-encryption-table {
-  padding: $pad-xxlarge;
-  border: 1px solid $ui-fleet-black-10;
-  border-radius: $border-radius;
   margin-bottom: $pad-xxlarge;
 
   .data-table-block .data-table tbody td .w250 {

--- a/frontend/pages/hosts/ManageHostsPage/HostsPageConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostsPageConfig.tsx
@@ -2,6 +2,12 @@ import React from "react";
 
 import Icon from "components/Icon";
 
+// the source of truth for the filter option names.
+// there are used on many other pages but we define them here.
+// TODO: add other filter options here. Also look to define this in
+// the host entities file later.
+export const DISK_ENCRYPTION_QUERY_PARAM_NAME = "os_settings_disk_encryption";
+
 export const MANAGE_HOSTS_PAGE_FILTER_KEYS = [
   "query",
   "team_id",
@@ -17,7 +23,7 @@ export const MANAGE_HOSTS_PAGE_FILTER_KEYS = [
   "os_version",
   "munki_issue_id",
   "low_disk_space",
-  "macos_settings_disk_encryption",
+  DISK_ENCRYPTION_QUERY_PARAM_NAME,
   "bootstrap_package",
 ] as const;
 

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -49,7 +49,7 @@ import { IOperatingSystemVersion } from "interfaces/operating_system";
 import { IPolicy, IStoredPolicyResponse } from "interfaces/policy";
 import { ITeam } from "interfaces/team";
 import { IEmptyTableProps } from "interfaces/empty_table";
-import { FileVaultProfileStatus, BootstrapPackageStatus } from "interfaces/mdm";
+import { DiskEncryptionStatus, BootstrapPackageStatus } from "interfaces/mdm";
 
 import sortUtils from "utilities/sort";
 import {
@@ -232,7 +232,7 @@ const ManageHostsPage = ({
       ? parseInt(queryParams.low_disk_space, 10)
       : undefined;
   const missingHosts = queryParams?.status === "missing";
-  const diskEncryptionStatus: FileVaultProfileStatus | undefined =
+  const diskEncryptionStatus: DiskEncryptionStatus | undefined =
     queryParams?.macos_settings_disk_encryption;
   const bootstrapPackageStatus: BootstrapPackageStatus | undefined =
     queryParams?.bootstrap_package;
@@ -558,7 +558,7 @@ const ManageHostsPage = ({
   };
 
   const handleChangeDiskEncryptionStatusFilter = (
-    newStatus: FileVaultProfileStatus
+    newStatus: DiskEncryptionStatus
   ) => {
     handleResetPageIndex();
 

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -85,6 +85,7 @@ import {
   DEFAULT_PAGE_INDEX,
   getHostSelectStatuses,
   MANAGE_HOSTS_PAGE_FILTER_KEYS,
+  DISK_ENCRYPTION_QUERY_PARAM_NAME,
 } from "./HostsPageConfig";
 import { isAcceptableStatus } from "./helpers";
 
@@ -233,7 +234,7 @@ const ManageHostsPage = ({
       : undefined;
   const missingHosts = queryParams?.status === "missing";
   const diskEncryptionStatus: DiskEncryptionStatus | undefined =
-    queryParams?.macos_settings_disk_encryption;
+    queryParams?.[DISK_ENCRYPTION_QUERY_PARAM_NAME];
   const bootstrapPackageStatus: BootstrapPackageStatus | undefined =
     queryParams?.bootstrap_package;
 
@@ -569,7 +570,7 @@ const ManageHostsPage = ({
         routeParams,
         queryParams: {
           ...queryParams,
-          macos_settings_disk_encryption: newStatus,
+          [DISK_ENCRYPTION_QUERY_PARAM_NAME]: newStatus,
           page: 0, // resets page index
         },
       })
@@ -768,7 +769,7 @@ const ManageHostsPage = ({
         newQueryParams.os_version = osVersion;
       } else if (diskEncryptionStatus && isPremiumTier) {
         // Premium feature only
-        newQueryParams.macos_settings_disk_encryption = diskEncryptionStatus;
+        newQueryParams[DISK_ENCRYPTION_QUERY_PARAM_NAME] = diskEncryptionStatus;
       } else if (bootstrapPackageStatus && isPremiumTier) {
         newQueryParams.bootstrap_package = bootstrapPackageStatus;
       }

--- a/frontend/pages/hosts/ManageHostsPage/components/DiskEncryptionStatusFilter/DiskEncryptionStatusFilter.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/DiskEncryptionStatusFilter/DiskEncryptionStatusFilter.tsx
@@ -4,7 +4,7 @@ import { IDropdownOption } from "interfaces/dropdownOption";
 
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
-import { FileVaultProfileStatus } from "interfaces/mdm";
+import { DiskEncryptionStatus } from "interfaces/mdm";
 
 const baseClass = "disk-encryption-status-filter";
 
@@ -42,8 +42,8 @@ const DISK_ENCRYPTION_STATUS_OPTIONS: IDropdownOption[] = [
 ];
 
 interface IDiskEncryptionStatusFilterProps {
-  diskEncryptionStatus: FileVaultProfileStatus;
-  onChange: (value: FileVaultProfileStatus) => void;
+  diskEncryptionStatus: DiskEncryptionStatus;
+  onChange: (value: DiskEncryptionStatus) => void;
 }
 
 const DiskEncryptionStatusFilter = ({

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -7,7 +7,7 @@ import {
   IOperatingSystemVersion,
 } from "interfaces/operating_system";
 import {
-  FileVaultProfileStatus,
+  DiskEncryptionStatus,
   BootstrapPackageStatus,
   IMdmSolution,
   MDM_ENROLLMENT_STATUS,
@@ -60,7 +60,7 @@ interface IHostsFilterBlockProps {
     osVersions?: IOperatingSystemVersion[];
     softwareDetails: ISoftware | null;
     mdmSolutionDetails: IMdmSolution | null;
-    diskEncryptionStatus?: FileVaultProfileStatus;
+    diskEncryptionStatus?: DiskEncryptionStatus;
     bootstrapPackageStatus?: BootstrapPackageStatus;
   };
   selectedLabel?: ILabel;
@@ -68,9 +68,7 @@ interface IHostsFilterBlockProps {
   handleClearRouteParam: () => void;
   handleClearFilter: (omitParams: string[]) => void;
   onChangePoliciesFilter: (response: PolicyResponse) => void;
-  onChangeDiskEncryptionStatusFilter: (
-    response: FileVaultProfileStatus
-  ) => void;
+  onChangeDiskEncryptionStatusFilter: (response: DiskEncryptionStatus) => void;
   onChangeBootstrapPackageStatusFilter: (
     response: BootstrapPackageStatus
   ) => void;

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -29,7 +29,10 @@ import Icon from "components/Icon/Icon";
 
 import FilterPill from "../FilterPill";
 import PoliciesFilter from "../PoliciesFilter";
-import { MAC_SETTINGS_FILTER_OPTIONS } from "../../HostsPageConfig";
+import {
+  DISK_ENCRYPTION_QUERY_PARAM_NAME,
+  MAC_SETTINGS_FILTER_OPTIONS,
+} from "../../HostsPageConfig";
 import DiskEncryptionStatusFilter from "../DiskEncryptionStatusFilter";
 import BootstrapPackageStatusFilter from "../BootstrapPackageStatusFilter/BootstrapPackageStatusFilter";
 
@@ -374,8 +377,8 @@ const HostsFilterBlock = ({
           onChange={onChangeDiskEncryptionStatusFilter}
         />
         <FilterPill
-          label="macOS settings: Disk encryption"
-          onClear={() => handleClearFilter(["macos_settings_disk_encryption"])}
+          label="OS settings: Disk encryption"
+          onClear={() => handleClearFilter([DISK_ENCRYPTION_QUERY_PARAM_NAME])}
         />
       </>
     );

--- a/frontend/pages/hosts/details/MacSettingsIndicator/index.ts
+++ b/frontend/pages/hosts/details/MacSettingsIndicator/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./MacSettingsIndicator";

--- a/frontend/pages/hosts/details/ProfileStatusIndicator/ProfileStatusIndicator.tests.tsx
+++ b/frontend/pages/hosts/details/ProfileStatusIndicator/ProfileStatusIndicator.tests.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
-import MacSettingsIndicator from "./MacSettingsIndicator";
+import ProfileStatusIndicator from "./ProfileStatusIndicator";
 
 describe("MacSettingsIndicator", () => {
   it("Renders the text and icon", () => {
     const indicatorText = "test text";
     render(
-      <MacSettingsIndicator indicatorText={indicatorText} iconName="success" />
+      <ProfileStatusIndicator
+        indicatorText={indicatorText}
+        iconName="success"
+      />
     );
     const renderedIndicatorText = screen.getByText(indicatorText);
     const renderedIcon = screen.getByTestId("success-icon");
@@ -19,7 +22,7 @@ describe("MacSettingsIndicator", () => {
     const indicatorText = "test text";
     const tooltipText = "test tooltip text";
     render(
-      <MacSettingsIndicator
+      <ProfileStatusIndicator
         indicatorText={indicatorText}
         iconName="success"
         tooltip={{ tooltipText }}
@@ -42,7 +45,7 @@ describe("MacSettingsIndicator", () => {
       document.body.appendChild(newDiv);
     };
     render(
-      <MacSettingsIndicator
+      <ProfileStatusIndicator
         indicatorText={indicatorText}
         iconName="success"
         onClick={() => {

--- a/frontend/pages/hosts/details/ProfileStatusIndicator/ProfileStatusIndicator.tsx
+++ b/frontend/pages/hosts/details/ProfileStatusIndicator/ProfileStatusIndicator.tsx
@@ -4,9 +4,9 @@ import { IconNames } from "components/icons";
 import Icon from "components/Icon";
 import Button from "components/buttons/Button";
 
-const baseClass = "settings-indicator";
+const baseClass = "profile-status-indicator";
 
-export interface IMacSettingsIndicator {
+export interface ProfileStatusIndicator {
   indicatorText: string;
   iconName: IconNames;
   onClick?: () => void;
@@ -16,12 +16,12 @@ export interface IMacSettingsIndicator {
   };
 }
 
-const MacSettingsIndicator = ({
+const ProfileStatusIndicator = ({
   indicatorText,
   iconName,
   onClick,
   tooltip,
-}: IMacSettingsIndicator): JSX.Element => {
+}: ProfileStatusIndicator): JSX.Element => {
   const getIndicatorTextWrapped = () => {
     if (onClick && tooltip?.tooltipText) {
       return (
@@ -103,4 +103,4 @@ const MacSettingsIndicator = ({
   );
 };
 
-export default MacSettingsIndicator;
+export default ProfileStatusIndicator;

--- a/frontend/pages/hosts/details/ProfileStatusIndicator/_styles.scss
+++ b/frontend/pages/hosts/details/ProfileStatusIndicator/_styles.scss
@@ -1,4 +1,4 @@
-.settings-indicator {
+.profile-status-indicator {
   display: flex;
   gap: 4px;
 

--- a/frontend/pages/hosts/details/ProfileStatusIndicator/index.ts
+++ b/frontend/pages/hosts/details/ProfileStatusIndicator/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ProfileStatusIndicator";

--- a/frontend/services/entities/host_count.ts
+++ b/frontend/services/entities/host_count.ts
@@ -1,7 +1,7 @@
 /* eslint-disable  @typescript-eslint/explicit-module-boundary-types */
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
-import { FileVaultProfileStatus, BootstrapPackageStatus } from "interfaces/mdm";
+import { DiskEncryptionStatus, BootstrapPackageStatus } from "interfaces/mdm";
 import { HostStatus } from "interfaces/host";
 import {
   buildQueryStringFromParams,
@@ -43,7 +43,7 @@ export interface IHostCountLoadOptions {
   osId?: number;
   osName?: string;
   osVersion?: string;
-  diskEncryptionStatus?: FileVaultProfileStatus;
+  diskEncryptionStatus?: DiskEncryptionStatus;
   bootstrapPackageStatus?: BootstrapPackageStatus;
 }
 

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -11,7 +11,7 @@ import {
 import { SelectedPlatform } from "interfaces/platform";
 import { ISoftware } from "interfaces/software";
 import {
-  FileVaultProfileStatus,
+  DiskEncryptionStatus,
   BootstrapPackageStatus,
   IMdmSolution,
 } from "interfaces/mdm";
@@ -57,7 +57,7 @@ export interface ILoadHostsOptions {
   device_mapping?: boolean;
   columns?: string;
   visibleColumns?: string;
-  diskEncryptionStatus?: FileVaultProfileStatus;
+  diskEncryptionStatus?: DiskEncryptionStatus;
   bootstrapPackageStatus?: BootstrapPackageStatus;
 }
 
@@ -83,7 +83,7 @@ export interface IExportHostsOptions {
   device_mapping?: boolean;
   columns?: string;
   visibleColumns?: string;
-  diskEncryptionStatus?: FileVaultProfileStatus;
+  diskEncryptionStatus?: DiskEncryptionStatus;
 }
 
 export interface IActionByFilter {

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -1,17 +1,25 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import { FileVaultProfileStatus } from "interfaces/mdm";
+import { DiskEncryptionStatus } from "interfaces/mdm";
 import { APP_CONTEXT_NO_TEAM_ID } from "interfaces/team";
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
 import { buildQueryStringFromParams } from "utilities/url";
-
-export type IFileVaultSummaryResponse = Record<FileVaultProfileStatus, number>;
 
 export interface IEulaMetadataResponse {
   name: string;
   token: string;
   created_at: string;
 }
+
+export interface IDiskEncryptionStatusAggregate {
+  macos: string;
+  windows: string;
+}
+
+export type IDiskEncryptionSummaryResponse = Record<
+  DiskEncryptionStatus,
+  IDiskEncryptionStatusAggregate
+>;
 
 export default {
   downloadDeviceUserEnrollmentProfile: (token: string) => {
@@ -80,14 +88,25 @@ export default {
     return sendRequest("GET", path);
   },
 
-  getDiskEncryptionAggregate: (teamId?: number) => {
-    let { MDM_APPLE_DISK_ENCRYPTION_AGGREGATE: path } = endpoints;
+  getDiskEncryptionSummary: (teamId?: number) => {
+    let { MDM_DISK_ENCRYPTION_SUMMARY: path } = endpoints;
 
     if (teamId) {
       path = `${path}?${buildQueryStringFromParams({ team_id: teamId })}`;
     }
 
-    return sendRequest("GET", path);
+    // TODO: change when API is implemented
+    return new Promise<IDiskEncryptionSummaryResponse>((resolve) => {
+      resolve({
+        verified: { macos: "0", windows: "5" },
+        verifying: { macos: "1", windows: "4" },
+        action_required: { macos: "2", windows: "3" },
+        enforcing: { macos: "3", windows: "2" },
+        failed: { macos: "4", windows: "1" },
+        removing_enforcement: { macos: "5", windows: "0" },
+      });
+    });
+    // return sendRequest("GET", path);
   },
 
   updateAppleMdmSettings: (enableDiskEncryption: boolean, teamId?: number) => {

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -51,7 +51,7 @@ export default {
   MDM_PROFILE: (id: number) => `/${API_VERSION}/fleet/mdm/apple/profiles/${id}`,
   MDM_UPDATE_APPLE_SETTINGS: `/${API_VERSION}/fleet/mdm/apple/settings`,
   MDM_PROFILES_AGGREGATE_STATUSES: `/${API_VERSION}/fleet/mdm/apple/profiles/summary`,
-  MDM_APPLE_DISK_ENCRYPTION_AGGREGATE: `/${API_VERSION}/fleet/mdm/apple/filevault/summary`,
+  MDM_DISK_ENCRYPTION_SUMMARY: `/${API_VERSION}/fleet/mdm/disk_encryption/summary`,
   MDM_APPLE_SSO: `/${API_VERSION}/fleet/mdm/sso`,
   MDM_APPLE_ENROLLMENT_PROFILE: (token: string, ref?: string) => {
     const query = new URLSearchParams({ token });

--- a/frontend/utilities/url/index.ts
+++ b/frontend/utilities/url/index.ts
@@ -1,5 +1,7 @@
-import { DiskEncryptionStatus, BootstrapPackageStatus } from "interfaces/mdm";
 import { isEmpty, reduce, omitBy, Dictionary } from "lodash";
+
+import { DISK_ENCRYPTION_QUERY_PARAM_NAME } from "pages/hosts/ManageHostsPage/HostsPageConfig";
+import { DiskEncryptionStatus, BootstrapPackageStatus } from "interfaces/mdm";
 import { MacSettingsStatusQueryParam } from "services/entities/hosts";
 
 type QueryValues = string | number | boolean | undefined | null;
@@ -123,7 +125,7 @@ export const reconcileMutuallyExclusiveHostParams = ({
     case !!lowDiskSpaceHosts:
       return { low_disk_space: lowDiskSpaceHosts };
     case !!diskEncryptionStatus:
-      return { macos_settings_disk_encryption: diskEncryptionStatus };
+      return { [DISK_ENCRYPTION_QUERY_PARAM_NAME]: diskEncryptionStatus };
     case !!bootstrapPackageStatus:
       return { bootstrap_package: bootstrapPackageStatus };
     default:

--- a/frontend/utilities/url/index.ts
+++ b/frontend/utilities/url/index.ts
@@ -1,4 +1,4 @@
-import { FileVaultProfileStatus, BootstrapPackageStatus } from "interfaces/mdm";
+import { DiskEncryptionStatus, BootstrapPackageStatus } from "interfaces/mdm";
 import { isEmpty, reduce, omitBy, Dictionary } from "lodash";
 import { MacSettingsStatusQueryParam } from "services/entities/hosts";
 
@@ -24,7 +24,7 @@ interface IMutuallyExclusiveHostParams {
   osId?: number;
   osName?: string;
   osVersion?: string;
-  diskEncryptionStatus?: FileVaultProfileStatus;
+  diskEncryptionStatus?: DiskEncryptionStatus;
   bootstrapPackageStatus?: BootstrapPackageStatus;
 }
 


### PR DESCRIPTION
relates to #12926

This implements the changes to the Controls page that add the windows Bitlocker functionality.
There is some work that needs to be complete when the API is done. For now we are mocking the new disk encryption API response

**new column for windows hosts:**

![image](https://github.com/fleetdm/fleet/assets/1153709/39adb0fa-c59f-483f-a2c3-45a2b95492aa)

also includes various other changes behind the scenes that include windows hosts into the disk encryption as well as changes to the profiles status summary to use StatusIndicatorWithIcon

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality