### PR TITLE
Revert "Use GITHUB_TOKEN in merge gatekeeper (#13980)"

### DIFF
--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -24,6 +24,6 @@ jobs:
         #       https://github.com/upsidr/merge-gatekeeper/branches
         uses: upsidr/merge-gatekeeper@09af7a82c1666d0e64d2bd8c01797a0bcfd3bb5d # v1.2.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.FLEET_RELEASE_GITHUB_PAT }}
           timeout: 1800
           ignored: test-packaging


### PR DESCRIPTION
This reverts commit 043976d2504fb6e6156294e387718197402eecd3 since the new token is getting rate limited, blocking all PRs to the repo.
