### PR TITLE
Add ability for `fleetctl package` to use local WiX v3 binaries when generating installer .msi

### DIFF
--- a/changes/13338-use-local-wix
+++ b/changes/13338-use-local-wix
@@ -1,0 +1,2 @@
+* Add the option to use locally-installed WiX v3 binaries when generating the Fleetd installer for
+Windows on a Windows machine.

--- a/cmd/fleetctl/package.go
+++ b/cmd/fleetctl/package.go
@@ -182,6 +182,12 @@ func packageCommand() *cli.Command {
 				EnvVars:     []string{"FLEETCTL_NATIVE_TOOLING"},
 				Destination: &opt.NativeTooling,
 			},
+			&cli.BoolFlag{
+				Name:        "local-wix",
+				Usage:       "Use local install of WiX instead of Docker Hub (only available on Windows)",
+				EnvVars:     []string{"FLEETCTL_LOCAL_WIX"},
+				Destination: &opt.LocalWix,
+			},
 			&cli.StringFlag{
 				Name:        "macos-devid-pem-content",
 				Usage:       "Dev ID certificate keypair content in PEM format",
@@ -260,6 +266,11 @@ func packageCommand() *cli.Command {
 
 			if opt.NativeTooling && runtime.GOOS != "linux" {
 				return errors.New("native tooling is only available in Linux")
+			}
+
+			if opt.LocalWix && runtime.GOOS != "windows" {
+				return errors.New(`Could not use local WiX to generate an osquery installer. This option is only available on Windows.
+				Visit https://wixtoolset.org/ for more information about how to use WiX.`)
 			}
 
 			if opt.FleetCertificate != "" {

--- a/cmd/fleetctl/package.go
+++ b/cmd/fleetctl/package.go
@@ -184,7 +184,7 @@ func packageCommand() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:        "local-wix-dir",
-				Usage:       "Use locally installed binaries of WiX tools in the provided directory instead of those from a prepared Docker Hub container. Available on Windows only.)",
+				Usage:       "Use local install of WiX instead of Docker Hub (only available on Windows w/ WiX v3)",
 				EnvVars:     []string{"FLEETCTL_LOCAL_WIX_DIR"},
 				Destination: &opt.LocalWixDir,
 			},

--- a/cmd/fleetctl/package.go
+++ b/cmd/fleetctl/package.go
@@ -182,11 +182,11 @@ func packageCommand() *cli.Command {
 				EnvVars:     []string{"FLEETCTL_NATIVE_TOOLING"},
 				Destination: &opt.NativeTooling,
 			},
-			&cli.BoolFlag{
-				Name:        "local-wix",
-				Usage:       "Use local install of WiX instead of Docker Hub (only available on Windows)",
-				EnvVars:     []string{"FLEETCTL_LOCAL_WIX"},
-				Destination: &opt.LocalWix,
+			&cli.StringFlag{
+				Name:        "local-wix-dir",
+				Usage:       "Use locally installed binaries of WiX tools in the provided directory instead of those from a prepared Docker Hub container. Available on Windows only.)",
+				EnvVars:     []string{"FLEETCTL_LOCAL_WIX_DIR"},
+				Destination: &opt.LocalWixDir,
 			},
 			&cli.StringFlag{
 				Name:        "macos-devid-pem-content",
@@ -268,7 +268,7 @@ func packageCommand() *cli.Command {
 				return errors.New("native tooling is only available in Linux")
 			}
 
-			if opt.LocalWix && runtime.GOOS != "windows" {
+			if opt.LocalWixDir != "" && runtime.GOOS != "windows" {
 				return errors.New(`Could not use local WiX to generate an osquery installer. This option is only available on Windows.
 				Visit https://wixtoolset.org/ for more information about how to use WiX.`)
 			}

--- a/docs/Using Fleet/enroll-hosts.md
+++ b/docs/Using Fleet/enroll-hosts.md
@@ -3,12 +3,11 @@
 
 - [Enroll hosts](#enroll-hosts)
   - [Introduction](#introduction)
-  - [Enroll hosts with Fleetd](#enroll-hosts-with-fleetd)
+  - [Add hosts with Fleetd](#add-hosts-with-fleetd)
     - [Signing installers](#signing-installers)
     - [Including Fleet Desktop](#including-fleet-desktop)
-    - [Adding multiple hosts](#adding-multiple-hosts)
+    - [Enrolling multiple hosts](#adding-multiple-hosts)
     - [Automatically adding hosts to a team](#automatically-adding-hosts-to-a-team)
-    - [Generating Windows installers using local WiX toolset v3 binaries on Windows](#generating-windows-installers-using-local-wix-toolset-v3-binaries-on-windows)
     - [Configuration options](#configuration-options)
   - [Add hosts with plain osquery](#add-hosts-with-plain-osquery)
     - [Set up your Fleet enroll secret](#set-up-your-fleet-enroll-secret)
@@ -115,26 +114,9 @@ To generate an osquery installer for a team:
 3. Next, select **Add hosts** and copy the `fleetctl package` command for the platform (macOS, Windows, Linux) of the hosts you'd like to add to a team in Fleet.
 4. Run the copied `fleetctl package` command and [distribute your installer](#adding-multiple-hosts) to add your hosts to a team in Fleet.
 
-### Generating Windows installers using local WiX toolset v3 binaries on Windows
-
-When creating a Fleetd installer for Windows hosts (**.msi**) on a Windows machine, you can tell `fleetctl package` to
-use a local installation of the WiX v3 binaries instead of those in a pre-configured container, which is the default behavior. To do so:
-  0. If you need to install the WiX v3 binaries, you can download them
-     [here](https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip).
-     Unzip the downloaded file.
-  1. Find the absolute filepath of the directory containing your local WiX v3 binaries. If you just
-     downloaded them in step 0. above, this will be wherever you saved the unzipped package contents.
-  2. Run `fleetctl package`, and pass the absolute path above as the string argument to the
-     `--local-wix-dir` flag. For example:
-     ```
-      fleetctl package --type msi --fleet-url=[YOUR FLEET URL] --enroll-secret=[YOUR ENROLLMENT SECRET] --local-wix-dir "\Users\me\AppData\Local\Temp\wix311-binaries"
-     ```
-     If the provided path doesn't contain all 3 binaries, the command will fail.
-
-
 ### Configuration options
 
-The following command-line flags to `fleetctl package` allow you to configure an osquery installer further to communicate with a specific Fleet instance.
+The following command-line flags allow you to configure an osquery installer further to communicate with a specific Fleet instance.
 
 | Flag                       | Options                                                                                                                                 |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
@@ -159,7 +141,6 @@ The following command-line flags to `fleetctl package` allow you to configure an
 | --enable-scripts           | Enable script execution (default: `false`)                                                                                              |
 | --debug                    | Enable debug logging (default: `false`)                                                                                                 |
 | --verbose                  | Log detailed information when building the package (default: false)                                                                     |
-| --local-wix-dir            | Use local install of WiX instead of Docker Hub (only available on Windows w/ WiX v3)                                                    |
 | --help, -h                 | show help (default: `false`)                                                                                                            |
 
 

--- a/docs/Using Fleet/enroll-hosts.md
+++ b/docs/Using Fleet/enroll-hosts.md
@@ -3,11 +3,12 @@
 
 - [Enroll hosts](#enroll-hosts)
   - [Introduction](#introduction)
-  - [Add hosts with Fleetd](#add-hosts-with-fleetd)
+  - [Enroll hosts with Fleetd](#enroll-hosts-with-fleetd)
     - [Signing installers](#signing-installers)
     - [Including Fleet Desktop](#including-fleet-desktop)
-    - [Enrolling multiple hosts](#adding-multiple-hosts)
+    - [Adding multiple hosts](#adding-multiple-hosts)
     - [Automatically adding hosts to a team](#automatically-adding-hosts-to-a-team)
+    - [Generating Windows installers using local WiX toolset v3 binaries on Windows](#generating-windows-installers-using-local-wix-toolset-v3-binaries-on-windows)
     - [Configuration options](#configuration-options)
   - [Add hosts with plain osquery](#add-hosts-with-plain-osquery)
     - [Set up your Fleet enroll secret](#set-up-your-fleet-enroll-secret)
@@ -114,9 +115,26 @@ To generate an osquery installer for a team:
 3. Next, select **Add hosts** and copy the `fleetctl package` command for the platform (macOS, Windows, Linux) of the hosts you'd like to add to a team in Fleet.
 4. Run the copied `fleetctl package` command and [distribute your installer](#adding-multiple-hosts) to add your hosts to a team in Fleet.
 
+### Generating Windows installers using local WiX toolset v3 binaries on Windows
+
+When creating a Fleetd installer for Windows hosts (**.msi**) on a Windows machine, you can tell `fleetctl package` to
+use a local installation of the WiX v3 binaries instead of those in a pre-configured container, which is the default behavior. To do so:
+  0. If you need to install the WiX v3 binaries, you can download them
+     [here](https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip).
+     Unzip the downloaded file.
+  1. Find the absolute filepath of the directory containing your local WiX v3 binaries. If you just
+     downloaded them in step 0. above, this will be wherever you saved the unzipped package contents.
+  2. Run `fleetctl package`, and pass the absolute path above as the string argument to the
+     `--local-wix-dir` flag. For example:
+     ```
+      fleetctl package --type msi --fleet-url=[YOUR FLEET URL] --enroll-secret=[YOUR ENROLLMENT SECRET] --local-wix-dir "\Users\me\AppData\Local\Temp\wix311-binaries"
+     ```
+     If the provided path doesn't contain all 3 binaries, the command will fail.
+
+
 ### Configuration options
 
-The following command-line flags allow you to configure an osquery installer further to communicate with a specific Fleet instance.
+The following command-line flags to `fleetctl package` allow you to configure an osquery installer further to communicate with a specific Fleet instance.
 
 | Flag                       | Options                                                                                                                                 |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
@@ -141,6 +159,7 @@ The following command-line flags allow you to configure an osquery installer fur
 | --enable-scripts           | Enable script execution (default: `false`)                                                                                              |
 | --debug                    | Enable debug logging (default: `false`)                                                                                                 |
 | --verbose                  | Log detailed information when building the package (default: false)                                                                     |
+| --local-wix-dir            | Use local install of WiX instead of Docker Hub (only available on Windows w/ WiX v3)                                                    |
 | --help, -h                 | show help (default: `false`)                                                                                                            |
 
 

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -113,9 +113,9 @@ type Options struct {
 	UseSystemConfiguration bool
 	// EnableScripts enables script execution on the agent.
 	EnableScripts bool
-	// LocalWix uses a Windows machine's local WiX installation instead of a containerized
+	// LocalWixDir uses a Windows machine's local WiX installation instead of a containerized
 	// emulation to build an MSI fleetd installer
-	LocalWix bool
+	LocalWixDir string
 }
 
 func initializeTempDir() (string, error) {

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -113,6 +113,9 @@ type Options struct {
 	UseSystemConfiguration bool
 	// EnableScripts enables script execution on the agent.
 	EnableScripts bool
+	// LocalWix uses a Windows machine's local WiX installation instead of a containerized
+	// emulation to build an MSI fleetd installer
+	LocalWix bool
 }
 
 func initializeTempDir() (string, error) {

--- a/orbit/pkg/packaging/windows.go
+++ b/orbit/pkg/packaging/windows.go
@@ -150,7 +150,7 @@ func BuildMSI(opt Options) (string, error) {
 		}
 	}
 
-	if err := wix.Heat(tmpDir, opt.NativeTooling); err != nil {
+	if err := wix.Heat(tmpDir, opt.NativeTooling, opt.LocalWix); err != nil {
 		return "", fmt.Errorf("package root files: %w", err)
 	}
 
@@ -158,11 +158,11 @@ func BuildMSI(opt Options) (string, error) {
 		return "", fmt.Errorf("transform heat: %w", err)
 	}
 
-	if err := wix.Candle(tmpDir, opt.NativeTooling); err != nil {
+	if err := wix.Candle(tmpDir, opt.NativeTooling, opt.LocalWix); err != nil {
 		return "", fmt.Errorf("build package: %w", err)
 	}
 
-	if err := wix.Light(tmpDir, opt.NativeTooling); err != nil {
+	if err := wix.Light(tmpDir, opt.NativeTooling, opt.LocalWix); err != nil {
 		return "", fmt.Errorf("build package: %w", err)
 	}
 

--- a/orbit/pkg/packaging/windows.go
+++ b/orbit/pkg/packaging/windows.go
@@ -150,7 +150,7 @@ func BuildMSI(opt Options) (string, error) {
 		}
 	}
 
-	if err := wix.Heat(tmpDir, opt.NativeTooling, opt.LocalWix); err != nil {
+	if err := wix.Heat(tmpDir, opt.NativeTooling, opt.LocalWixDir); err != nil {
 		return "", fmt.Errorf("package root files: %w", err)
 	}
 
@@ -158,11 +158,11 @@ func BuildMSI(opt Options) (string, error) {
 		return "", fmt.Errorf("transform heat: %w", err)
 	}
 
-	if err := wix.Candle(tmpDir, opt.NativeTooling, opt.LocalWix); err != nil {
+	if err := wix.Candle(tmpDir, opt.NativeTooling, opt.LocalWixDir); err != nil {
 		return "", fmt.Errorf("build package: %w", err)
 	}
 
-	if err := wix.Light(tmpDir, opt.NativeTooling, opt.LocalWix); err != nil {
+	if err := wix.Light(tmpDir, opt.NativeTooling, opt.LocalWixDir); err != nil {
 		return "", fmt.Errorf("build package: %w", err)
 	}
 

--- a/orbit/pkg/packaging/wix/wix.go
+++ b/orbit/pkg/packaging/wix/wix.go
@@ -13,18 +13,15 @@ const (
 	directoryReference = "ORBITROOT"
 )
 
-// TODO(jacob) - make this flexible
-var localWixDir = `C:\Users\jacob\AppData\Local\Temp\wix311-binaries`
-
 // Heat runs the WiX Heat command on the provided directory.
 //
 // The Heat command creates XML fragments allowing WiX to include the entire
 // directory. See
 // https://wixtoolset.org/documentation/manual/v3/overview/heat.html.
-func Heat(path string, native bool, localWix bool) error {
+func Heat(path string, native bool, localWixDir string) error {
 	var args []string
 
-	if !native && !localWix {
+	if !native && localWixDir == "" {
 		args = append(
 			args,
 			"docker", "run", "--rm", "--platform", "linux/amd64",
@@ -34,7 +31,7 @@ func Heat(path string, native bool, localWix bool) error {
 	}
 
 	heatPath := `heat`
-	if localWix {
+	if localWixDir != "" {
 		heatPath = localWixDir + `\heat.exe`
 	}
 
@@ -51,7 +48,7 @@ func Heat(path string, native bool, localWix bool) error {
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 
-	if native || localWix {
+	if native || localWixDir != "" {
 		cmd.Dir = path
 	}
 
@@ -66,10 +63,10 @@ func Heat(path string, native bool, localWix bool) error {
 //
 // See
 // https://wixtoolset.org/documentation/manual/v3/overview/candle.html.
-func Candle(path string, native bool, localWix bool) error {
+func Candle(path string, native bool, localWixDir string) error {
 	var args []string
 
-	if !native && !localWix {
+	if !native && localWixDir == "" {
 		args = append(
 			args,
 			"docker", "run", "--rm", "--platform", "linux/amd64",
@@ -79,7 +76,7 @@ func Candle(path string, native bool, localWix bool) error {
 	}
 
 	candlePath := `candle`
-	if localWix {
+	if localWixDir != "" {
 		candlePath = localWixDir + `\candle.exe`
 	}
 	args = append(args,
@@ -91,7 +88,7 @@ func Candle(path string, native bool, localWix bool) error {
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 
-	if native || localWix {
+	if native || localWixDir != "" {
 		cmd.Dir = path
 	}
 
@@ -106,10 +103,10 @@ func Candle(path string, native bool, localWix bool) error {
 //
 // See
 // https://wixtoolset.org/documentation/manual/v3/overview/light.html.
-func Light(path string, native bool, localWix bool) error {
+func Light(path string, native bool, localWixDir string) error {
 	var args []string
 
-	if !native && !localWix {
+	if !native && localWixDir == "" {
 		args = append(
 			args,
 			"docker", "run", "--rm", "--platform", "linux/amd64",
@@ -119,7 +116,7 @@ func Light(path string, native bool, localWix bool) error {
 	}
 
 	lightPath := `light`
-	if localWix {
+	if localWixDir != "" {
 		lightPath = localWixDir + `\light.exe`
 	}
 	args = append(args,
@@ -133,7 +130,7 @@ func Light(path string, native bool, localWix bool) error {
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 
-	if native || localWix {
+	if native || localWixDir != "" {
 		cmd.Dir = path
 	}
 


### PR DESCRIPTION
## Addresses #13338 

Success on Windows 11:
<img width="1278" alt="success-on-windows-11" src="https://github.com/fleetdm/fleet/assets/61553566/f6e8c71d-4dcc-492d-8972-40059b15bc45">

Fails when provided path doesn't contain the 3 WiX v3 binaries: 
<img width="1130" alt="fails-when-dir-does-not-have-binaries" src="https://github.com/fleetdm/fleet/assets/61553566/354a5f01-8c52-4eb6-a73d-c5e7b8d1c876">

Fails on mac:
<img width="1037" alt="fails-on-mac" src="https://github.com/fleetdm/fleet/assets/61553566/3a021f40-a30a-40ac-9af8-6cc22c75a514">

New flag included in help text:
<img width="1131" alt="Screenshot 2023-09-20 at 5 19 38 PM" src="https://github.com/fleetdm/fleet/assets/61553566/ba88d50b-a4b7-4b59-a2ad-34a0457caf75">


## Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`.
- [x] Manual QA for all new/changed functionality