### PR TITLE
Fleet UI: [bug squashes] Fix team dropdown z-index issue, fix copy icon hover state, fix spacing before icons

### DIFF
--- a/frontend/components/TeamsDropdown/_styles.scss
+++ b/frontend/components/TeamsDropdown/_styles.scss
@@ -52,6 +52,7 @@
     border-radius: 6px;
     padding-right: 0;
     margin: 0;
+    z-index: 999; // in front of tooltip wrapper
   }
 
   .Select-control {

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -244,6 +244,16 @@ $base-class: "button";
           fill: $core-vibrant-blue-over;
         }
       }
+
+      // Copy button uses stroke color instead of fill color to darken
+      &.input-field__copy-value-button {
+        svg {
+          path {
+            fill: none;
+            stroke: $core-vibrant-blue-over;
+          }
+        }
+      }
     }
 
     // globally styled gap between text and icon

--- a/frontend/pages/policies/ManagePoliciesPage/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/_styles.scss
@@ -164,6 +164,7 @@
           .name__cell {
             .policy-name-cell {
               display: flex; // required for inline icon
+              gap: $pad-xsmall;
 
               .tooltip-base {
                 display: inline-flex;

--- a/frontend/pages/queries/ManageQueriesPage/_styles.scss
+++ b/frontend/pages/queries/ManageQueriesPage/_styles.scss
@@ -137,6 +137,8 @@
 
               .query-name-cell {
                 display: flex; // required for inline icon
+                gap: $pad-xsmall;
+
                 .children-wrapper {
                   .query-name-text {
                     text-overflow: ellipsis;


### PR DESCRIPTION
## Issue
Cerra #13860, Cerra #14001 

## Description
- Recent change to z-index of link cell requires a higher z-index for the teams dropdown menu
- Icons in link cell were not rendering spaced away from the text, added back 4px spacing
- Most icons modify fill color on hover, copy icon needed stroke color modified. Globally fixed with css

## Screenshots and screen recordings

https://github.com/fleetdm/fleet/assets/71795832/68856496-a093-46a9-9a0d-28f61fc2e86c

<img width="900" alt="Screenshot 2023-09-20 at 3 58 20 PM" src="https://github.com/fleetdm/fleet/assets/71795832/d7595a7f-47cd-4d8c-b207-3a8c6bea2fbf">
<img width="643" alt="Screenshot 2023-09-20 at 3 58 05 PM" src="https://github.com/fleetdm/fleet/assets/71795832/2423ae30-ce04-4cab-81ac-6822347f6035">

https://github.com/fleetdm/fleet/assets/71795832/479dfc46-3fd7-46c4-b63b-cc9bb6896dda


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
