### PR TITLE
Fleet UI: [small bug] Creating multiple new policies save button always enabled

### DIFF
--- a/changes/14038-fix-save-multiple-new-policies
+++ b/changes/14038-fix-save-multiple-new-policies
@@ -1,0 +1,1 @@
+* Fix save button for a new policy after newly creating another policy

--- a/frontend/context/policy.tsx
+++ b/frontend/context/policy.tsx
@@ -57,7 +57,7 @@ type InitialStateType = {
   lastEditedQueryCritical: boolean;
   lastEditedQueryPlatform: SelectedPlatformString | null;
   defaultPolicy: boolean;
-  setLastEditedQueryId: (value: number) => void;
+  setLastEditedQueryId: (value: number | null) => void;
   setLastEditedQueryName: (value: string) => void;
   setLastEditedQueryDescription: (value: string) => void;
   setLastEditedQueryBody: (value: string) => void;

--- a/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AddPolicyModal/AddPolicyModal.tsx
@@ -33,6 +33,7 @@ const AddPolicyModal = ({
     setLastEditedQueryResolution,
     setLastEditedQueryCritical,
     setLastEditedQueryPlatform,
+    setLastEditedQueryId,
     setPolicyTeamId,
     setDefaultPolicy,
   } = useContext(PolicyContext);
@@ -46,6 +47,7 @@ const AddPolicyModal = ({
     setLastEditedQueryBody(selectedPolicy.query);
     setLastEditedQueryResolution(selectedPolicy.resolution);
     setLastEditedQueryCritical(selectedPolicy.critical || false);
+    setLastEditedQueryId(null);
     setPolicyTeamId(teamId);
     setLastEditedQueryPlatform(selectedPolicy.platform || null);
     router.push(
@@ -56,10 +58,17 @@ const AddPolicyModal = ({
   const onCreateYourOwnPolicyClick = useCallback(() => {
     setPolicyTeamId(teamId);
     setLastEditedQueryBody(DEFAULT_POLICY.query);
+    setLastEditedQueryId(null);
     router.push(
       !teamId ? PATHS.NEW_POLICY : `${PATHS.NEW_POLICY}?team_id=${teamId}`
     );
-  }, [router, setLastEditedQueryBody, setPolicyTeamId, teamId]);
+  }, [
+    router,
+    setLastEditedQueryBody,
+    setLastEditedQueryId,
+    setPolicyTeamId,
+    teamId,
+  ]);
 
   const policiesAvailable = DEFAULT_POLICIES.map((policy: IPolicyNew) => {
     return (


### PR DESCRIPTION
## Issue
Cerra #14038 

## Description
- The last policy ID was being stored despite starting the create new policy flow which was causing the logic for disabling save (logic disables save for existing policies only if there is a policy ID but missing a policy name)
- Reset policy ID to null every time a user starts creating a new policy

## Recording of fix

https://github.com/fleetdm/fleet/assets/71795832/5fe5a971-5541-45dd-b5ee-42c4eaadc74c


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

