### PR TITLE
fix formatting on the script content and output UI

### DIFF
--- a/changes/issue-13847-fix-script-content-and-output-formatting
+++ b/changes/issue-13847-fix-script-content-and-output-formatting
@@ -1,0 +1,1 @@
+- fix script content and output formatting on the scripts detail modal.

--- a/frontend/__mocks__/scriptMock.ts
+++ b/frontend/__mocks__/scriptMock.ts
@@ -1,0 +1,21 @@
+import { IScriptResultResponse } from "services/entities/scripts";
+
+const DEFAULT_SCRIPT_RESULT_MOCK: IScriptResultResponse = {
+  hostname: "Test Host",
+  host_id: 1,
+  execution_id: "123",
+  script_contents: "ls /home/*\necho 'testing'\necho 'lines'\nexit $?",
+  exit_code: 0,
+  output: "test\nlines\n",
+  message: "",
+  runtime: 0,
+  host_timeout: false,
+};
+
+const createMockScriptResult = (
+  overrides?: Partial<IScriptResultResponse>
+): IScriptResultResponse => {
+  return { ...DEFAULT_SCRIPT_RESULT_MOCK, ...overrides };
+};
+
+export default createMockScriptResult;

--- a/frontend/components/Textarea/_styles.scss
+++ b/frontend/components/Textarea/_styles.scss
@@ -3,4 +3,5 @@
   border-radius: $border-radius;
   border: 1px solid $ui-fleet-black-10;
   background-color: $ui-off-white;
+  white-space: pre-wrap;
 }

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptDetailsModal/ScriptDetailsModal.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptDetailsModal/ScriptDetailsModal.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useQuery } from "react-query";
 
-import scriptsAPI, { IScriptResult } from "services/entities/scripts";
+import scriptsAPI, { IScriptResultResponse } from "services/entities/scripts";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
@@ -166,7 +166,7 @@ const ScriptDetailsModal = ({
   scriptExecutionId,
   onCancel,
 }: IScriptDetailsModalProps) => {
-  const { data, isLoading, isError } = useQuery<IScriptResult>(
+  const { data, isLoading, isError } = useQuery<IScriptResultResponse>(
     ["scriptDetailsModal"],
     () => {
       return scriptsAPI.getScriptResult(scriptExecutionId);

--- a/frontend/services/entities/scripts.ts
+++ b/frontend/services/entities/scripts.ts
@@ -1,7 +1,7 @@
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
 
-export interface IScriptResult {
+export interface IScriptResultResponse {
   hostname: string;
   host_id: number;
   execution_id: string;


### PR DESCRIPTION
relates to #13847

fixes the formatting of the script content and output fields. we now preserve the spacing and line breaks.

![image](https://github.com/fleetdm/fleet/assets/1153709/70e28637-ea4b-4679-a38a-02d42f49830c)


- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
