### PR TITLE
Backend (ListHostsInLabels): Surface used by data when filtering hosts by labels

### DIFF
--- a/changes/11346-add-used-by-data-filtered-by-labels
+++ b/changes/11346-add-used-by-data-filtered-by-labels
@@ -1,0 +1,1 @@
+- Bug fix: surface used by data when filtering hosts by labels

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -547,8 +547,7 @@ func (ds *Datastore) ListHostsInLabel(ctx context.Context, filter fleet.TeamFilt
 	var deviceMappingSelect string
 	if opt.DeviceMapping {
 		deviceMappingSelect = `,
-	COALESCE(dm.device_mapping, 'null') as device_mapping
-	`
+		COALESCE(dm.device_mapping, 'null') as device_mapping`
 	}
 	
 	query := fmt.Sprintf(queryFmt, hostMDMSelect, failingPoliciesSelect, deviceMappingSelect, hostMDMJoin, failingPoliciesJoin, deviceMappingJoin)

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -549,7 +549,7 @@ func (ds *Datastore) ListHostsInLabel(ctx context.Context, filter fleet.TeamFilt
 		deviceMappingSelect = `,
 		COALESCE(dm.device_mapping, 'null') as device_mapping`
 	}
-	
+
 	query := fmt.Sprintf(queryFmt, hostMDMSelect, failingPoliciesSelect, deviceMappingSelect, hostMDMJoin, failingPoliciesJoin, deviceMappingJoin)
 
 	query, params := ds.applyHostLabelFilters(filter, lid, query, opt)

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -547,7 +547,7 @@ func (ds *Datastore) ListHostsInLabel(ctx context.Context, filter fleet.TeamFilt
 	var deviceMappingSelect string
 	if opt.DeviceMapping {
 		deviceMappingSelect = `,
-		COALESCE(dm.device_mapping, 'null') as device_mapping`
+	COALESCE(dm.device_mapping, 'null') as device_mapping`
 	}
 
 	query := fmt.Sprintf(queryFmt, hostMDMSelect, failingPoliciesSelect, deviceMappingSelect, hostMDMJoin, failingPoliciesJoin, deviceMappingJoin)

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -546,7 +546,7 @@ func (ds *Datastore) ListHostsInLabel(ctx context.Context, filter fleet.TeamFilt
 
 	var deviceMappingSelect string
 	if opt.DeviceMapping {
-	deviceMappingSelect = `,
+		deviceMappingSelect = `,
 	COALESCE(dm.device_mapping, 'null') as device_mapping
 	`
 	}


### PR DESCRIPTION
## Issue
Cerra #11346 

## Description
- Add device_mapping data to the sql query that requests the ListHostsInLabels data

## Screen recording of fix

https://github.com/fleetdm/fleet/assets/71795832/243bcb25-56aa-4488-ae26-8865075e6d2d



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

