### PR TITLE
Allow manual run of docker publish CI action

### DIFF
--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -11,6 +11,7 @@ on:
       - 'handbook/**'
       - 'website/**'
       - 'mdm-profiles/**'
+  workflow_dispatch: # Manual
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:


### PR DESCRIPTION
I need this change to load test #13926.

Due to recent changes we are not triggering a build on every branch/commit pushed.
For load testing we need a way to trigger a build manually.