### PR TITLE
Frontend: [hour/s old bug] Ensure type null option for lastEditedQueryId

### DIFF
--- a/frontend/context/policy.tsx
+++ b/frontend/context/policy.tsx
@@ -165,12 +165,15 @@ const PolicyProvider = ({ children }: Props): JSX.Element => {
     dispatch({ type: ACTIONS.SET_POLICY_TEAM_ID, id });
   }, []);
 
-  const setLastEditedQueryId = useCallback((lastEditedQueryId: number) => {
-    dispatch({
-      type: ACTIONS.SET_LAST_EDITED_QUERY_INFO,
-      lastEditedQueryId,
-    });
-  }, []);
+  const setLastEditedQueryId = useCallback(
+    (lastEditedQueryId: number | null) => {
+      dispatch({
+        type: ACTIONS.SET_LAST_EDITED_QUERY_INFO,
+        lastEditedQueryId,
+      });
+    },
+    []
+  );
 
   const setLastEditedQueryName = useCallback((lastEditedQueryName: string) => {
     dispatch({

--- a/frontend/context/query.tsx
+++ b/frontend/context/query.tsx
@@ -22,7 +22,7 @@ type InitialStateType = {
   lastEditedQueryPlatforms: SelectedPlatformString;
   lastEditedQueryMinOsqueryVersion: string;
   lastEditedQueryLoggingType: QueryLoggingOption;
-  setLastEditedQueryId: (value: number) => void;
+  setLastEditedQueryId: (value: number | null) => void;
   setLastEditedQueryName: (value: string) => void;
   setLastEditedQueryDescription: (value: string) => void;
   setLastEditedQueryBody: (value: string) => void;
@@ -135,7 +135,7 @@ const QueryProvider = ({ children }: Props) => {
     lastEditedQueryPlatforms: state.lastEditedQueryPlatforms,
     lastEditedQueryMinOsqueryVersion: state.lastEditedQueryMinOsqueryVersion,
     lastEditedQueryLoggingType: state.lastEditedQueryLoggingType,
-    setLastEditedQueryId: (lastEditedQueryId: number) => {
+    setLastEditedQueryId: (lastEditedQueryId: number | null) => {
       dispatch({
         type: actions.SET_LAST_EDITED_QUERY_INFO,
         lastEditedQueryId,


### PR DESCRIPTION
Fix FE: Mismatching types causing build to fail on main

`lastEditedQueryId` can be null (in the case of creating a new query or new policy), needed to match throughout frontend code

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality