### PR TITLE
Fleet UI: [tiny bug fixes] Table text cell vertical alignment [released], fix first letter capitalization [unreleased]

### DIFF
--- a/frontend/components/StatusIndicator/_styles.scss
+++ b/frontend/components/StatusIndicator/_styles.scss
@@ -3,6 +3,10 @@
   align-items: center;
   color: $core-fleet-blue;
 
+  ::first-letter {
+    text-transform: capitalize;
+  }
+
   &:before {
     border-radius: 100%;
     content: " ";

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -215,6 +215,7 @@ $shadow-transition-width: 10px;
         }
         .link-cell,
         .text-cell {
+          display: block; // inline-block is not vertically centered
           overflow: hidden;
           white-space: nowrap;
           text-overflow: ellipsis;
@@ -223,11 +224,7 @@ $shadow-transition-width: 10px;
             white-space: normal;
           }
         }
-        .text-cell {
-          display: inline-block;
-        }
         .link-cell {
-          display: block;
           padding: $pad-small 0; // larger clickable area
 
           &:hover {


### PR DESCRIPTION
## Issue
Cerra #14076 

## Description
- `text-cell` `display: inline-block` is not vertically centered, changed text-cell to be centered by using `block`
- `StatusIndicator` uses CSS to capitalize `:first-letter` of status only (before it was set to `capitalize` which capitalized every word, then it was fixed for hardcoded multiword string values like "No Access" and "No Team", now this css is a global fix)

## Screenshots of fixes
<img width="1457" alt="Screenshot 2023-09-22 at 10 32 32 AM" src="https://github.com/fleetdm/fleet/assets/71795832/41517c03-0eb9-4d9c-9c18-26249230b755">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

