### PR TITLE
Fleet UI: Fix vertical alignment of truncated cell

### DIFF
--- a/frontend/components/TableContainer/DataTable/TruncatedTextCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/TruncatedTextCell/_styles.scss
@@ -12,7 +12,7 @@
     }
 
     .truncated {
-      display: inline-block;
+      display: block;
       max-width: 100%;
 
       // Removes secondary unstyled tooltip created by browser


### PR DESCRIPTION
## Issue 
Cerra #14076 

## Description
- Fixes vertical alignment of text for truncated table cells (`display: inline-block` uncentering text compared to `display: block`)

## Screenshot of fix
<img width="1271" alt="Screenshot 2023-09-22 at 2 55 46 PM" src="https://github.com/fleetdm/fleet/assets/71795832/dc63ce05-35d1-4f03-a41a-8ce7544c6e82">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

