### PR TITLE
Move code for `--local-wix-dir` into `ee` directory

### DIFF
--- a/cmd/fleetctl/package.go
+++ b/cmd/fleetctl/package.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	eefleetctl "github.com/fleetdm/fleet/v4/ee/fleetctl"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/packaging"
 	"github.com/rs/zerolog"
 	zlog "github.com/rs/zerolog/log"
@@ -182,12 +183,7 @@ func packageCommand() *cli.Command {
 				EnvVars:     []string{"FLEETCTL_NATIVE_TOOLING"},
 				Destination: &opt.NativeTooling,
 			},
-			&cli.StringFlag{
-				Name:        "local-wix-dir",
-				Usage:       "Use local install of WiX instead of Docker Hub (only available on Windows w/ WiX v3)",
-				EnvVars:     []string{"FLEETCTL_LOCAL_WIX_DIR"},
-				Destination: &opt.LocalWixDir,
-			},
+			eefleetctl.LocalWixDirFlag(&opt.LocalWixDir),
 			&cli.StringFlag{
 				Name:        "macos-devid-pem-content",
 				Usage:       "Dev ID certificate keypair content in PEM format",

--- a/ee/fleetctl/local_wix.go
+++ b/ee/fleetctl/local_wix.go
@@ -1,0 +1,14 @@
+package eefleetctl
+
+import "github.com/urfave/cli/v2"
+
+func LocalWixDirFlag(dest *string) *cli.StringFlag {
+	return &cli.StringFlag{
+		Name: "local-wix-dir",
+		Usage: `Use local install of WiX instead of Docker Hub (only available on Windows w/ WiX v3).
+
+This functionality is licensed under the Fleet EE License. Usage requires a current Fleet EE subscription.`,
+		EnvVars:     []string{"FLEETCTL_LOCAL_WIX_DIR"},
+		Destination: dest,
+	}
+}

--- a/ee/fleetctl/local_wix.go
+++ b/ee/fleetctl/local_wix.go
@@ -4,11 +4,8 @@ import "github.com/urfave/cli/v2"
 
 func LocalWixDirFlag(dest *string) *cli.StringFlag {
 	return &cli.StringFlag{
-		Name: "local-wix-dir",
-		Usage: `Use local install of WiX instead of Docker Hub (only available on Windows w/ WiX v3).
-
-This functionality is licensed under the Fleet EE License. Usage requires a current Fleet EE subscription.`,
-		EnvVars:     []string{"FLEETCTL_LOCAL_WIX_DIR"},
+		Name:        "local-wix-dir",
+		Usage:       "Use local install of WiX instead of Docker Hub (only available on Windows w/ WiX v3). This functionality is licensed under the Fleet EE License. Usage requires a current Fleet EE subscription.",
 		Destination: dest,
 	}
 }


### PR DESCRIPTION
## Addresses #13338 

This doesn't affect functionality, but nominally classifies this as a premium-only feature and adds help text to that end.

Successful QA with paid-feature text:
<img width="1278" alt="Screenshot 2023-09-22 at 4 36 46 PM" src="https://github.com/fleetdm/fleet/assets/61553566/ef4aa6a7-c6cd-40f7-8da3-371c820f4c35">

## Checklist for submitter

- [x] Manual QA for all new/changed functionality