### PR TITLE
Adjust teams dropdown arrow position

### DIFF
--- a/frontend/components/TeamsDropdown/_styles.scss
+++ b/frontend/components/TeamsDropdown/_styles.scss
@@ -73,6 +73,10 @@
 
     .Select-arrow-zone {
       padding-left: 15px;
+      svg {
+        position: relative;
+        top: 3px;
+      }
     }
 
     .Select-multi-value-wrapper {


### PR DESCRIPTION
I noticed the teams dropdown arrow was not vertically centered with the text.

Before: 
![image](https://github.com/fleetdm/fleet/assets/2495927/90828913-a2df-460e-9a7e-eaf017640f70)

After: 
![image](https://github.com/fleetdm/fleet/assets/2495927/b203495a-0500-4d5a-b5c9-e0c04fe4ee55)
