### PR TITLE
Revert docker publish filtering on pull requests

### DIFF
--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -31,8 +31,8 @@ jobs:
     # Only run it when the push is to the fleetdm/fleet repo. Otherwise the secrets for pushing to
     # Docker will not be available.
     #
-    # Also do not run if author is dependabot or is on a fork (it doesn't have access to Github secrets).
-    if: ${{ (github.repository == 'fleetdm/fleet') && (github.actor != 'dependabot[bot]') && ((github.event_name == 'push' && github.ref_name == 'main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)) }}
+    # Also not run if author is dependabot (it doesn't have access to Github secrets).
+    if: ${{ (github.repository == 'fleetdm/fleet') && (github.actor != 'dependabot[bot]') }}
     runs-on: ubuntu-20.04
     environment: Docker Hub
     steps:


### PR DESCRIPTION
I need to revert this because it's stopping the workflow from running on other branches, which is needed during our release and patch processes.