### PR TITLE
Website: Update license dispenser text when creating a quote for over 1k hosts.

### DIFF
--- a/website/assets/styles/pages/customers/new-license.less
+++ b/website/assets/styles/pages/customers/new-license.less
@@ -121,6 +121,9 @@
     }
   }
   @media (max-width: 400px) {
+    [purpose='over-1000-linebreak'] {
+      display: none;
+    }
     [purpose='order-form-line-break'] {
       display: block;
     }

--- a/website/views/pages/customers/new-license.ejs
+++ b/website/views/pages/customers/new-license.ejs
@@ -28,7 +28,7 @@
             <strong>Order total</strong>
           </div>
           <div class="d-flex flex-row justify-content-between">
-            <p class="mb-0">Fleet Premium <br purpose="order-form-line-break">(self-hosted)</p>
+            <p class="mb-0">Fleet Premium <br purpose="order-form-line-break"><span purpose="over-1000-linebreak"><br :class="[numberOfHostsQuoted >= 1000 ? 'd-block' : 'd-none']"></span>(self-hosted<span v-if="numberOfHostsQuoted >= 1000" > or managed cloud</span>)</p>
           <div class="ml-auto text-right">
             <strong>${{(!showQuotedPrice || _.isNaN(formData.numberOfHosts * 7.00 * 12)) ? quotedPrice : formData.numberOfHosts * 7.00 * 12}}.00 <br purpose="order-form-line-break">/year</strong>
           </div>

--- a/website/views/pages/customers/new-license.ejs
+++ b/website/views/pages/customers/new-license.ejs
@@ -23,7 +23,7 @@
 
         </div>
         <cloud-error purpose="cloud-error" v-if="cloudError && !showBillingForm"></cloud-error>
-        <div class="mt-2 pt-3 pb-3 border-top d-flex flex-column" v-if="showQuotedPrice && formData.numberOfHosts">
+        <div class="mt-2 pt-3 pb-3 border-top d-flex flex-column" v-if="showQuotedPrice && formData.numberOfHosts && numberOfHostsQuoted">
           <div class="pb-2">
             <strong>Order total</strong>
           </div>


### PR DESCRIPTION
Closes: #14013

Changes:
- Updated the license dispenser to say "Fleet Premium (self-hosted or managed cloud)" when a user creates a quote for a license for over 1000 hosts.