### PR TITLE
fleetdm.com/pricing: custom scripts are available

### DIFF
--- a/handbook/company/pricing-features-table.yml
+++ b/handbook/company/pricing-features-table.yml
@@ -15,9 +15,9 @@
     - name: Zero-touch setup for macOS computers
       tier: Premium
       comingSoon: false
-    - name: Safely execute remote scripts
+    - name: Safely execute custom scripts
       tier: Premium
-      comingSoon: true      
+      comingSoon: false      
     - name: End-user macOS update reminders (via Nudge)
       tier: Premium
       comingSoon: false


### PR DESCRIPTION
- Remove "coming soon" asterisk from scripts
- Update "remote scripts" to "custom scripts." I think it's obvious that the scripts are remote. Communicate the value: these scripts are custom (anything you want)
