### PR TITLE
Fleet CTL: Surface password requirements to console for FleetCTL use, update API only password example

### DIFF
--- a/docs/Using Fleet/fleetctl-CLI.md
+++ b/docs/Using Fleet/fleetctl-CLI.md
@@ -202,7 +202,7 @@ An API-only user does not have access to the Fleet UI. Instead, it's only purpos
 To create your new API-only user, run `fleetctl user create` and pass values for `--name`, `--email`, and `--password`, and include the `--api-only` flag:
 
 ```sh
-fleetctl user create --name "API User" --email api@example.com --password temp!pass --api-only
+fleetctl user create --name "API User" --email api@example.com --password temp@pass123 --api-only
 ```
 
 ### Creating an API-only user

--- a/server/fleet/users.go
+++ b/server/fleet/users.go
@@ -353,7 +353,7 @@ func ValidatePasswordRequirements(password string) error {
 		return nil
 	}
 
-	return errors.New("Password does not meet required criteria")
+	return errors.New("Password does not meet required criteria: Must include 12 characters, at least 1 number (e.g. 0 - 9), and at least 1 symbol (e.g. &*#).")
 }
 
 // ValidateEmail checks that the provided email address is valid, this function

--- a/server/service/users.go
+++ b/server/service/users.go
@@ -863,7 +863,7 @@ func (svc *Service) PerformRequiredPasswordReset(ctx context.Context, password s
 	}
 
 	if err := fleet.ValidatePasswordRequirements(password); err != nil {
-		return nil, fleet.NewInvalidArgumentError("new_password", "Password does not meet required criteria")
+		return nil, fleet.NewInvalidArgumentError("new_password", "Password does not meet required criteria: Must include 12 characters, at least 1 number (e.g. 0 - 9), and at least 1 symbol (e.g. &*#).")
 	}
 
 	user.AdminForcedPasswordReset = false


### PR DESCRIPTION
## Oncall stuff

### Description
- Update fleetctl api only user example to use a password that works with our latest password requirements
- Update API errors surfaced to fleetctl and in network requests to include the password requirements

Better user experience.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Manual QA for all new/changed functionality

