### PR TITLE
Add list scripts and get/download a script endpoints

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6391,6 +6391,7 @@ This allows you to easily configure scheduled queries that will impact a whole t
 - [Get script result](#get-script-result)
 - [Upload a script](#upload-a-script)
 - [Delete a script](#delete-a-script)
+- [List scripts](#list-scripts)
 
 ### Run script asynchronously
 
@@ -6567,6 +6568,53 @@ Deletes an existing script.
 ##### Default response
 
 `Status: 204`
+
+### List scripts
+
+_Available in Fleet Premium_
+
+`GET /api/v1/fleet/scripts`
+
+#### Parameters
+
+| Name            | Type    | In    | Description                                                                                                                   |
+| --------------- | ------- | ----- | ----------------------------------------------------------------------------------------------------------------------------- |
+| page            | integer | query | Page number of the results to fetch.                                                                                          |
+| per_page        | integer | query | Results per page.                                                                                                             |
+
+#### Example
+
+`GET /api/v1/fleet/scripts`
+
+##### Default response
+
+`Status: 200`
+
+```json
+{
+  "scripts": [
+    {
+      "id": 1,
+      "team_id": null,
+      "name": "script_1.sh",
+      "created_at": "2023-07-30T13:41:07Z",
+      "updated_at": "2023-07-30T13:41:07Z"
+    },
+    {
+      "id": 2,
+      "team_id": null,
+      "name": "script_2.sh",
+      "created_at": "2023-08-30T13:41:07Z",
+      "updated_at": "2023-08-30T13:41:07Z"
+    }
+  ],
+  "meta": {
+    "has_next_results": false,
+    "has_previous_results": false
+  }
+}
+
+```
 
 ---
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6392,6 +6392,7 @@ This allows you to easily configure scheduled queries that will impact a whole t
 - [Upload a script](#upload-a-script)
 - [Delete a script](#delete-a-script)
 - [List scripts](#list-scripts)
+- [Get or download a script](#get-or-download-a-script)
 
 ### Run script asynchronously
 
@@ -6614,6 +6615,58 @@ _Available in Fleet Premium_
   }
 }
 
+```
+
+### Get or download a script
+
+_Available in Fleet Premium_
+
+`GET /api/v1/fleet/scripts/{id}`
+
+#### Parameters
+
+| Name | Type    | In    | Description                                                       |
+| ---- | ------- | ----  | -------------------------------------                             |
+| id   | integer | path  | **Required.** The desired script's ID.                            |
+| alt  | string  | query | If specified and set to "media", downloads the script's contents. |
+
+#### Example (get a script)
+
+`GET /api/v1/fleet/scripts/123`
+
+##### Default response
+
+`Status: 200`
+
+```json
+{
+  "id": 123,
+  "team_id": null,
+  "name": "script_1.sh",
+  "created_at": "2023-07-30T13:41:07Z",
+  "updated_at": "2023-07-30T13:41:07Z"
+}
+
+```
+
+#### Example (download a script's contents)
+
+`GET /api/v1/fleet/scripts/123?alt=media`
+
+##### Example response headers
+
+```http
+Content-Length: 13
+Content-Type: application/octet-stream
+Content-Disposition: attachment;filename="2023-09-27 script_1.sh"
+```
+
+###### Example response body
+
+`Status: 200`
+
+```
+echo "hello"
 ```
 
 ---

--- a/ee/server/service/scripts.go
+++ b/ee/server/service/scripts.go
@@ -214,3 +214,7 @@ func (svc *Service) DeleteScript(ctx context.Context, scriptID uint) error {
 	}
 	return ctxerr.Wrap(ctx, svc.ds.DeleteScript(ctx, scriptID), "delete script")
 }
+
+func (svc *Service) ListScripts(ctx context.Context, teamID *uint, opt fleet.ListOptions) ([]*fleet.Script, *fleet.PaginationMetadata, error) {
+	panic("unimplemented")
+}

--- a/ee/server/service/scripts.go
+++ b/ee/server/service/scripts.go
@@ -216,5 +216,19 @@ func (svc *Service) DeleteScript(ctx context.Context, scriptID uint) error {
 }
 
 func (svc *Service) ListScripts(ctx context.Context, teamID *uint, opt fleet.ListOptions) ([]*fleet.Script, *fleet.PaginationMetadata, error) {
-	panic("unimplemented")
+	if err := svc.authz.Authorize(ctx, &fleet.Script{TeamID: teamID}, fleet.ActionRead); err != nil {
+		return nil, nil, err
+	}
+
+	// cursor-based pagination is not supported for scripts
+	opt.After = ""
+	// custom ordering is not supported, always by name
+	opt.OrderKey = "name"
+	opt.OrderDirection = fleet.OrderAscending
+	// no matching query support
+	opt.MatchQuery = ""
+	// always include metadata for scripts
+	opt.IncludeMetadata = true
+
+	return svc.ds.ListScripts(ctx, teamID, opt)
 }

--- a/ee/server/service/scripts.go
+++ b/ee/server/service/scripts.go
@@ -232,3 +232,7 @@ func (svc *Service) ListScripts(ctx context.Context, teamID *uint, opt fleet.Lis
 
 	return svc.ds.ListScripts(ctx, teamID, opt)
 }
+
+func (svc *Service) GetScript(ctx context.Context, scriptID uint, withContent bool) (*fleet.Script, []byte, error) {
+	panic("unimplemented")
+}

--- a/ee/server/service/scripts.go
+++ b/ee/server/service/scripts.go
@@ -197,22 +197,11 @@ func (svc *Service) NewScript(ctx context.Context, teamID *uint, name string, r 
 }
 
 func (svc *Service) DeleteScript(ctx context.Context, scriptID uint) error {
-	script, err := svc.ds.Script(ctx, scriptID)
+	script, err := svc.authorizeScriptByID(ctx, scriptID, fleet.ActionWrite)
 	if err != nil {
-		if fleet.IsNotFound(err) {
-			// couldn't get the script to have its team, authorize with a no-team script
-			if err := svc.authz.Authorize(ctx, &fleet.Script{}, fleet.ActionWrite); err != nil {
-				return err
-			}
-		}
-		svc.authz.SkipAuthorization(ctx)
-		return ctxerr.Wrap(ctx, err, "get script")
-	}
-
-	if err := svc.authz.Authorize(ctx, script, fleet.ActionWrite); err != nil {
 		return err
 	}
-	return ctxerr.Wrap(ctx, svc.ds.DeleteScript(ctx, scriptID), "delete script")
+	return ctxerr.Wrap(ctx, svc.ds.DeleteScript(ctx, script.ID), "delete script")
 }
 
 func (svc *Service) ListScripts(ctx context.Context, teamID *uint, opt fleet.ListOptions) ([]*fleet.Script, *fleet.PaginationMetadata, error) {
@@ -234,5 +223,41 @@ func (svc *Service) ListScripts(ctx context.Context, teamID *uint, opt fleet.Lis
 }
 
 func (svc *Service) GetScript(ctx context.Context, scriptID uint, withContent bool) (*fleet.Script, []byte, error) {
-	panic("unimplemented")
+	script, err := svc.authorizeScriptByID(ctx, scriptID, fleet.ActionRead)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var content []byte
+	if withContent {
+		content, err = svc.ds.GetScriptContents(ctx, scriptID)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return script, content, nil
+}
+
+func (svc *Service) authorizeScriptByID(ctx context.Context, scriptID uint, authzAction string) (*fleet.Script, error) {
+	// first, get the script because we don't know which team id it is for.
+	script, err := svc.ds.Script(ctx, scriptID)
+	if err != nil {
+		if fleet.IsNotFound(err) {
+			// couldn't get the script to have its team, authorize with a no-team
+			// script as a fallback - the requested script does not exist so there's
+			// no way to know what team it would be for, and returning a 404 without
+			// authorization would leak the existing/non existing ids.
+			if err := svc.authz.Authorize(ctx, &fleet.Script{}, authzAction); err != nil {
+				return nil, err
+			}
+		}
+		svc.authz.SkipAuthorization(ctx)
+		return nil, ctxerr.Wrap(ctx, err, "get script")
+	}
+
+	// do the actual authorization with the script's team id
+	if err := svc.authz.Authorize(ctx, script, authzAction); err != nil {
+		return nil, err
+	}
+	return script, nil
 }

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -175,6 +175,25 @@ WHERE
 	return &script, nil
 }
 
+func (ds *Datastore) GetScriptContents(ctx context.Context, id uint) ([]byte, error) {
+	const getStmt = `
+SELECT
+  script_contents
+FROM
+  scripts
+WHERE
+  id = ?
+`
+	var contents []byte
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &contents, getStmt, id); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, notFound("Script").WithID(id)
+		}
+		return nil, ctxerr.Wrap(ctx, err, "get script contents")
+	}
+	return contents, nil
+}
+
 func (ds *Datastore) DeleteScript(ctx context.Context, id uint) error {
 	_, err := ds.writer(ctx).ExecContext(ctx, `DELETE FROM scripts WHERE id = ?`, id)
 	if err != nil {

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -182,3 +182,41 @@ func (ds *Datastore) DeleteScript(ctx context.Context, id uint) error {
 	}
 	return nil
 }
+
+func (ds *Datastore) ListScripts(ctx context.Context, teamID *uint, opt fleet.ListOptions) ([]*fleet.Script, *fleet.PaginationMetadata, error) {
+	var scripts []*fleet.Script
+
+	const selectStmt = `
+SELECT
+  s.id,
+  s.team_id,
+  s.name,
+  s.created_at,
+  s.updated_at
+FROM
+  scripts s
+WHERE
+  s.global_or_team_id = ?
+`
+	var globalOrTeamID uint
+	if teamID != nil {
+		globalOrTeamID = *teamID
+	}
+
+	args := []any{globalOrTeamID}
+	stmt, args := appendListOptionsWithCursorToSQL(selectStmt, args, &opt)
+
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &scripts, stmt, args...); err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "select scripts")
+	}
+
+	var metaData *fleet.PaginationMetadata
+	if opt.IncludeMetadata {
+		metaData = &fleet.PaginationMetadata{HasPreviousResults: opt.Page > 0}
+		if len(scripts) > int(opt.PerPage) {
+			metaData.HasNextResults = true
+			scripts = scripts[:len(scripts)-1]
+		}
+	}
+	return scripts, metaData, nil
+}

--- a/server/datastore/mysql/scripts_test.go
+++ b/server/datastore/mysql/scripts_test.go
@@ -320,11 +320,15 @@ func testListScripts(t *testing.T, ds *Datastore) {
 			require.Equal(t, len(c.wantNames), len(scripts))
 			require.Equal(t, c.wantMeta, meta)
 
-			gotNames := make([]string, len(scripts))
-			for i, s := range scripts {
-				gotNames[i] = s.Name
-				require.Equal(t, c.teamID, s.TeamID)
+			var gotNames []string
+			if len(scripts) > 0 {
+				gotNames = make([]string, len(scripts))
+				for i, s := range scripts {
+					gotNames[i] = s.Name
+					require.Equal(t, c.teamID, s.TeamID)
+				}
 			}
+			require.Equal(t, c.wantNames, gotNames)
 		})
 	}
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1057,6 +1057,10 @@ type Datastore interface {
 
 	// DeleteScript deletes the script identified by its id.
 	DeleteScript(ctx context.Context, id uint) error
+
+	// ListScripts returns a paginated list of scripts corresponding to the
+	// criteria.
+	ListScripts(ctx context.Context, teamID *uint, opt ListOptions) ([]*Script, *PaginationMetadata, error)
 }
 
 const (

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1055,6 +1055,10 @@ type Datastore interface {
 	// Script returns the saved script corresponding to id.
 	Script(ctx context.Context, id uint) (*Script, error)
 
+	// GetScriptContents returns the raw script contents of the corresponding
+	// script.
+	GetScriptContents(ctx context.Context, id uint) ([]byte, error)
+
 	// DeleteScript deletes the script identified by its id.
 	DeleteScript(ctx context.Context, id uint) error
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -816,4 +816,8 @@ type Service interface {
 
 	// ListScripts returns a list of paginated saved scripts.
 	ListScripts(ctx context.Context, teamID *uint, opt ListOptions) ([]*Script, *PaginationMetadata, error)
+
+	// GetScript returns the script corresponding to the provided id. If the
+	// download is requested, it also returns the script's contents.
+	GetScript(ctx context.Context, scriptID uint, downloadRequested bool) (*Script, []byte, error)
 }

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -813,4 +813,7 @@ type Service interface {
 
 	// DeleteScript deletes an existing (saved) script.
 	DeleteScript(ctx context.Context, scriptID uint) error
+
+	// ListScripts returns a list of paginated saved scripts.
+	ListScripts(ctx context.Context, teamID *uint, opt ListOptions) ([]*Script, *PaginationMetadata, error)
 }

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -688,6 +688,8 @@ type ScriptFunc func(ctx context.Context, id uint) (*fleet.Script, error)
 
 type DeleteScriptFunc func(ctx context.Context, id uint) error
 
+type ListScriptsFunc func(ctx context.Context, teamID *uint, opt fleet.ListOptions) ([]*fleet.Script, *fleet.PaginationMetadata, error)
+
 type DataStore struct {
 	HealthCheckFunc        HealthCheckFunc
 	HealthCheckFuncInvoked bool
@@ -1693,6 +1695,9 @@ type DataStore struct {
 
 	DeleteScriptFunc        DeleteScriptFunc
 	DeleteScriptFuncInvoked bool
+
+	ListScriptsFunc        ListScriptsFunc
+	ListScriptsFuncInvoked bool
 
 	mu sync.Mutex
 }
@@ -4040,4 +4045,11 @@ func (s *DataStore) DeleteScript(ctx context.Context, id uint) error {
 	s.DeleteScriptFuncInvoked = true
 	s.mu.Unlock()
 	return s.DeleteScriptFunc(ctx, id)
+}
+
+func (s *DataStore) ListScripts(ctx context.Context, teamID *uint, opt fleet.ListOptions) ([]*fleet.Script, *fleet.PaginationMetadata, error) {
+	s.mu.Lock()
+	s.ListScriptsFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListScriptsFunc(ctx, teamID, opt)
 }

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -686,6 +686,8 @@ type NewScriptFunc func(ctx context.Context, script *fleet.Script) (*fleet.Scrip
 
 type ScriptFunc func(ctx context.Context, id uint) (*fleet.Script, error)
 
+type GetScriptContentsFunc func(ctx context.Context, id uint) ([]byte, error)
+
 type DeleteScriptFunc func(ctx context.Context, id uint) error
 
 type ListScriptsFunc func(ctx context.Context, teamID *uint, opt fleet.ListOptions) ([]*fleet.Script, *fleet.PaginationMetadata, error)
@@ -1692,6 +1694,9 @@ type DataStore struct {
 
 	ScriptFunc        ScriptFunc
 	ScriptFuncInvoked bool
+
+	GetScriptContentsFunc        GetScriptContentsFunc
+	GetScriptContentsFuncInvoked bool
 
 	DeleteScriptFunc        DeleteScriptFunc
 	DeleteScriptFuncInvoked bool
@@ -4038,6 +4043,13 @@ func (s *DataStore) Script(ctx context.Context, id uint) (*fleet.Script, error) 
 	s.ScriptFuncInvoked = true
 	s.mu.Unlock()
 	return s.ScriptFunc(ctx, id)
+}
+
+func (s *DataStore) GetScriptContents(ctx context.Context, id uint) ([]byte, error) {
+	s.mu.Lock()
+	s.GetScriptContentsFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetScriptContentsFunc(ctx, id)
 }
 
 func (s *DataStore) DeleteScript(ctx context.Context, id uint) error {

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -447,7 +447,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.GET("/api/_version_/fleet/scripts/results/{execution_id}", getScriptResultEndpoint, getScriptResultRequest{})
 	ue.POST("/api/_version_/fleet/scripts", createScriptEndpoint, createScriptRequest{})
 	ue.GET("/api/_version_/fleet/scripts", listScriptsEndpoint, listScriptsRequest{})
-	//ue.GET("/api/_version_/fleet/scripts/{script_id:[0-9]+}", getScriptEndpoint, getScriptRequest{})
+	ue.GET("/api/_version_/fleet/scripts/{script_id:[0-9]+}", getScriptEndpoint, getScriptRequest{})
 	ue.DELETE("/api/_version_/fleet/scripts/{script_id:[0-9]+}", deleteScriptEndpoint, deleteScriptRequest{})
 
 	// Only Fleet MDM specific endpoints should be within the root /mdm/ path.

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -446,7 +446,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.POST("/api/_version_/fleet/scripts/run/sync", runScriptSyncEndpoint, runScriptRequest{})
 	ue.GET("/api/_version_/fleet/scripts/results/{execution_id}", getScriptResultEndpoint, getScriptResultRequest{})
 	ue.POST("/api/_version_/fleet/scripts", createScriptEndpoint, createScriptRequest{})
-	//ue.GET("/api/_version_/fleet/scripts", listScriptsEndpoint, listScriptsRequest{})
+	ue.GET("/api/_version_/fleet/scripts", listScriptsEndpoint, listScriptsRequest{})
 	//ue.GET("/api/_version_/fleet/scripts/{script_id:[0-9]+}", getScriptEndpoint, getScriptRequest{})
 	ue.DELETE("/api/_version_/fleet/scripts/{script_id:[0-9]+}", deleteScriptEndpoint, deleteScriptRequest{})
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -4674,6 +4674,10 @@ func (s *integrationTestSuite) TestPremiumEndpointsWithoutLicense() {
 	// delete a saved script
 	var delScriptResp deleteScriptResponse
 	s.DoJSON("DELETE", "/api/latest/fleet/scripts/123", nil, http.StatusPaymentRequired, &delScriptResp)
+
+	// list saved scripts
+	var listScriptsResp listScriptsResponse
+	s.DoJSON("GET", "/api/latest/fleet/scripts", nil, http.StatusPaymentRequired, &listScriptsResp, "per_page", "10")
 }
 
 // TestGlobalPoliciesBrowsing tests that team users can browse (read) global policies (see #3722).

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -4678,6 +4678,10 @@ func (s *integrationTestSuite) TestPremiumEndpointsWithoutLicense() {
 	// list saved scripts
 	var listScriptsResp listScriptsResponse
 	s.DoJSON("GET", "/api/latest/fleet/scripts", nil, http.StatusPaymentRequired, &listScriptsResp, "per_page", "10")
+
+	// get a saved script
+	var getScriptResp getScriptResponse
+	s.DoJSON("GET", "/api/latest/fleet/scripts/123", nil, http.StatusPaymentRequired, &getScriptResp)
 }
 
 // TestGlobalPoliciesBrowsing tests that team users can browse (read) global policies (see #3722).

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -265,3 +265,40 @@ func (svc *Service) DeleteScript(ctx context.Context, scriptID uint) error {
 
 	return fleet.ErrMissingLicense
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// List (saved) scripts (paginated)
+////////////////////////////////////////////////////////////////////////////////
+
+type listScriptsRequest struct {
+	TeamID      *uint             `query:"team_id,optional"`
+	ListOptions fleet.ListOptions `url:"list_options"`
+}
+
+type listScriptsResponse struct {
+	Meta    *fleet.PaginationMetadata `json:"meta"`
+	Scripts []*fleet.Script           `json:"scripts"`
+	Err     error                     `json:"error,omitempty"`
+}
+
+func (r listScriptsResponse) error() error { return r.Err }
+
+func listScriptsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
+	req := request.(*listScriptsRequest)
+	scripts, meta, err := svc.ListScripts(ctx, req.TeamID, req.ListOptions)
+	if err != nil {
+		return listScriptsResponse{Err: err}, nil
+	}
+	return listScriptsResponse{
+		Meta:    meta,
+		Scripts: scripts,
+	}, nil
+}
+
+func (svc *Service) ListScripts(ctx context.Context, teamID *uint, opt fleet.ListOptions) ([]*fleet.Script, *fleet.PaginationMetadata, error) {
+	// skipauth: No authorization check needed due to implementation returning
+	// only license error.
+	svc.authz.SkipAuthorization(ctx)
+
+	return nil, nil, fleet.ErrMissingLicense
+}

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -354,7 +354,7 @@ func getScriptEndpoint(ctx context.Context, request interface{}, svc fleet.Servi
 	if downloadRequested {
 		return downloadScriptResponse{
 			content:  content,
-			filename: fmt.Sprintf("%s-%s", "zzzz", script.Name),
+			filename: fmt.Sprintf("%s %s", time.Now().Format(time.DateOnly), script.Name),
 		}, nil
 	}
 	return getScriptResponse{Script: script}, nil

--- a/server/service/scripts_test.go
+++ b/server/service/scripts_test.go
@@ -392,102 +392,137 @@ func TestSavedScripts(t *testing.T) {
 	ds.DeleteScriptFunc = func(ctx context.Context, id uint) error {
 		return nil
 	}
+	ds.ListScriptsFunc = func(ctx context.Context, teamID *uint, opt fleet.ListOptions) ([]*fleet.Script, *fleet.PaginationMetadata, error) {
+		return nil, &fleet.PaginationMetadata{}, nil
+	}
 
 	testCases := []struct {
 		name                  string
 		user                  *fleet.User
 		shouldFailTeamWrite   bool
 		shouldFailGlobalWrite bool
+		shouldFailTeamRead    bool
+		shouldFailGlobalRead  bool
 	}{
 		{
 			name:                  "global admin",
 			user:                  &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
 			shouldFailTeamWrite:   false,
 			shouldFailGlobalWrite: false,
+			shouldFailTeamRead:    false,
+			shouldFailGlobalRead:  false,
 		},
 		{
 			name:                  "global maintainer",
 			user:                  &fleet.User{GlobalRole: ptr.String(fleet.RoleMaintainer)},
 			shouldFailTeamWrite:   false,
 			shouldFailGlobalWrite: false,
+			shouldFailTeamRead:    false,
+			shouldFailGlobalRead:  false,
 		},
 		{
 			name:                  "global observer",
 			user:                  &fleet.User{GlobalRole: ptr.String(fleet.RoleObserver)},
 			shouldFailTeamWrite:   true,
 			shouldFailGlobalWrite: true,
+			shouldFailTeamRead:    false,
+			shouldFailGlobalRead:  false,
 		},
 		{
 			name:                  "global observer+",
 			user:                  &fleet.User{GlobalRole: ptr.String(fleet.RoleObserverPlus)},
 			shouldFailTeamWrite:   true,
 			shouldFailGlobalWrite: true,
+			shouldFailTeamRead:    false,
+			shouldFailGlobalRead:  false,
 		},
 		{
 			name:                  "global gitops",
 			user:                  &fleet.User{GlobalRole: ptr.String(fleet.RoleGitOps)},
 			shouldFailTeamWrite:   true,
 			shouldFailGlobalWrite: true,
+			shouldFailTeamRead:    true,
+			shouldFailGlobalRead:  true,
 		},
 		{
 			name:                  "team admin, belongs to team",
 			user:                  &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleAdmin}}},
 			shouldFailTeamWrite:   false,
 			shouldFailGlobalWrite: true,
+			shouldFailTeamRead:    false,
+			shouldFailGlobalRead:  true,
 		},
 		{
 			name:                  "team maintainer, belongs to team",
 			user:                  &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleMaintainer}}},
 			shouldFailTeamWrite:   false,
 			shouldFailGlobalWrite: true,
+			shouldFailTeamRead:    false,
+			shouldFailGlobalRead:  true,
 		},
 		{
 			name:                  "team observer, belongs to team",
 			user:                  &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserver}}},
 			shouldFailTeamWrite:   true,
 			shouldFailGlobalWrite: true,
+			shouldFailTeamRead:    false,
+			shouldFailGlobalRead:  true,
 		},
 		{
 			name:                  "team observer+, belongs to team",
 			user:                  &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserverPlus}}},
 			shouldFailTeamWrite:   true,
 			shouldFailGlobalWrite: true,
+			shouldFailTeamRead:    false,
+			shouldFailGlobalRead:  true,
 		},
 		{
 			name:                  "team gitops, belongs to team",
 			user:                  &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleGitOps}}},
 			shouldFailTeamWrite:   true,
 			shouldFailGlobalWrite: true,
+			shouldFailTeamRead:    true,
+			shouldFailGlobalRead:  true,
 		},
 		{
 			name:                  "team admin, DOES NOT belong to team",
 			user:                  &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 2}, Role: fleet.RoleAdmin}}},
 			shouldFailTeamWrite:   true,
 			shouldFailGlobalWrite: true,
+			shouldFailTeamRead:    true,
+			shouldFailGlobalRead:  true,
 		},
 		{
 			name:                  "team maintainer, DOES NOT belong to team",
 			user:                  &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 2}, Role: fleet.RoleMaintainer}}},
 			shouldFailTeamWrite:   true,
 			shouldFailGlobalWrite: true,
+			shouldFailTeamRead:    true,
+			shouldFailGlobalRead:  true,
 		},
 		{
 			name:                  "team observer, DOES NOT belong to team",
 			user:                  &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 2}, Role: fleet.RoleObserver}}},
 			shouldFailTeamWrite:   true,
 			shouldFailGlobalWrite: true,
+			shouldFailTeamRead:    true,
+			shouldFailGlobalRead:  true,
 		},
 		{
 			name:                  "team observer+, DOES NOT belong to team",
 			user:                  &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 2}, Role: fleet.RoleObserverPlus}}},
 			shouldFailTeamWrite:   true,
 			shouldFailGlobalWrite: true,
+			shouldFailTeamRead:    true,
+			shouldFailGlobalRead:  true,
 		},
 		{
 			name:                  "team gitops, DOES NOT belong to team",
 			user:                  &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 2}, Role: fleet.RoleGitOps}}},
 			shouldFailTeamWrite:   true,
 			shouldFailGlobalWrite: true,
+			shouldFailTeamRead:    true,
+			shouldFailGlobalRead:  true,
 		},
 	}
 	for _, tt := range testCases {
@@ -498,10 +533,15 @@ func TestSavedScripts(t *testing.T) {
 			checkAuthErr(t, tt.shouldFailGlobalWrite, err)
 			err = svc.DeleteScript(ctx, noTeamScriptID)
 			checkAuthErr(t, tt.shouldFailGlobalWrite, err)
+			_, _, err = svc.ListScripts(ctx, nil, fleet.ListOptions{})
+			checkAuthErr(t, tt.shouldFailGlobalRead, err)
+
 			_, err = svc.NewScript(ctx, ptr.Uint(1), "test.sh", strings.NewReader("echo"))
 			checkAuthErr(t, tt.shouldFailTeamWrite, err)
 			err = svc.DeleteScript(ctx, team1ScriptID)
 			checkAuthErr(t, tt.shouldFailTeamWrite, err)
+			_, _, err = svc.ListScripts(ctx, ptr.Uint(1), fleet.ListOptions{})
+			checkAuthErr(t, tt.shouldFailTeamRead, err)
 		})
 	}
 }

--- a/server/service/scripts_test.go
+++ b/server/service/scripts_test.go
@@ -389,6 +389,9 @@ func TestSavedScripts(t *testing.T) {
 			return &fleet.Script{ID: id}, nil
 		}
 	}
+	ds.GetScriptContentsFunc = func(ctx context.Context, id uint) ([]byte, error) {
+		return []byte("echo"), nil
+	}
 	ds.DeleteScriptFunc = func(ctx context.Context, id uint) error {
 		return nil
 	}
@@ -535,12 +538,20 @@ func TestSavedScripts(t *testing.T) {
 			checkAuthErr(t, tt.shouldFailGlobalWrite, err)
 			_, _, err = svc.ListScripts(ctx, nil, fleet.ListOptions{})
 			checkAuthErr(t, tt.shouldFailGlobalRead, err)
+			_, _, err = svc.GetScript(ctx, noTeamScriptID, false)
+			checkAuthErr(t, tt.shouldFailGlobalRead, err)
+			_, _, err = svc.GetScript(ctx, noTeamScriptID, true)
+			checkAuthErr(t, tt.shouldFailGlobalRead, err)
 
 			_, err = svc.NewScript(ctx, ptr.Uint(1), "test.sh", strings.NewReader("echo"))
 			checkAuthErr(t, tt.shouldFailTeamWrite, err)
 			err = svc.DeleteScript(ctx, team1ScriptID)
 			checkAuthErr(t, tt.shouldFailTeamWrite, err)
 			_, _, err = svc.ListScripts(ctx, ptr.Uint(1), fleet.ListOptions{})
+			checkAuthErr(t, tt.shouldFailTeamRead, err)
+			_, _, err = svc.GetScript(ctx, team1ScriptID, false)
+			checkAuthErr(t, tt.shouldFailTeamRead, err)
+			_, _, err = svc.GetScript(ctx, team1ScriptID, true)
 			checkAuthErr(t, tt.shouldFailTeamRead, err)
 		})
 	}


### PR DESCRIPTION
#9829  (partial, implements 2 and 3).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`. (was already created in the ticket's first PR)
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Documented any permissions changes (docs/Using Fleet/manage-access.md) (was done in first PR)
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
