### PR TITLE
Update the run scripts endpoints (sync and async) to support an optional script_id parameter

### DIFF
--- a/changes/issue-9829-scripts-api
+++ b/changes/issue-9829-scripts-api
@@ -1,1 +1,2 @@
 * Added API endpoints for script management.
+* Updated the `POST /scripts/run` and `POST /scripts/run/sync` endpoints to accept an optional saved script ID instead of the script contents.

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6404,10 +6404,11 @@ Creates a script execution request and returns the execution identifier to retri
 
 #### Parameters
 
-| Name            | Type    | In   | Description                                      |
-| ----            | ------- | ---- | --------------------------------------------     |
-| host_id         | integer | body | **Required**. The host id to run the script on.  |
-| script_contents | string  | body | **Required**. The contents of the script to run. |
+| Name            | Type    | In   | Description                                                                                    |
+| ----            | ------- | ---- | --------------------------------------------                                                   |
+| host_id         | integer | body | **Required**. The host id to run the script on.                                                |
+| script_id       | integer | body | The script to run. The current contents of this saved script will be executed on the host. Only one of script_id and script_contents must be provided.  |
+| script_contents | string  | body | The contents of the script to run. Only one of script_id and script_contents must be provided. |
 
 #### Example
 
@@ -6437,7 +6438,8 @@ Creates a script execution request and waits for a result to return (up to a 1 m
 | Name            | Type    | In   | Description                                      |
 | ----            | ------- | ---- | --------------------------------------------     |
 | host_id         | integer | body | **Required**. The host id to run the script on.  |
-| script_contents | string  | body | **Required**. The contents of the script to run. |
+| script_id       | integer | body | The script to run. The current contents of this saved script will be executed on the host. Only one of script_id and script_contents must be provided.  |
+| script_contents | string  | body | The contents of the script to run. Only one of script_id and script_contents must be provided. |
 
 #### Example
 

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -15,8 +15,8 @@ import (
 
 func (ds *Datastore) NewHostScriptExecutionRequest(ctx context.Context, request *fleet.HostScriptRequestPayload) (*fleet.HostScriptResult, error) {
 	const (
-		insStmt = `INSERT INTO host_script_results (host_id, execution_id, script_contents, output) VALUES (?, ?, ?, '')`
-		getStmt = `SELECT id, host_id, execution_id, script_contents, created_at FROM host_script_results WHERE id = ?`
+		insStmt = `INSERT INTO host_script_results (host_id, execution_id, script_contents, output, script_id) VALUES (?, ?, ?, '', ?)`
+		getStmt = `SELECT id, host_id, execution_id, script_contents, created_at, script_id FROM host_script_results WHERE id = ?`
 	)
 
 	execID := uuid.New().String()
@@ -24,6 +24,7 @@ func (ds *Datastore) NewHostScriptExecutionRequest(ctx context.Context, request 
 		request.HostID,
 		execID,
 		request.ScriptContents,
+		request.ScriptID,
 	)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "new host script execution request")

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -78,6 +78,7 @@ func (ds *Datastore) ListPendingHostScriptExecutions(ctx context.Context, hostID
     id,
     host_id,
     execution_id,
+    script_id,
     script_contents
   FROM
     host_script_results
@@ -101,6 +102,7 @@ func (ds *Datastore) GetHostScriptExecutionResult(ctx context.Context, execID st
     host_id,
     execution_id,
     script_contents,
+    script_id,
     output,
     runtime,
     exit_code,

--- a/server/fleet/scripts.go
+++ b/server/fleet/scripts.go
@@ -68,6 +68,9 @@ type HostScriptResult struct {
 	// not returned as part of the payloads, but is used to determine if the script
 	// is too old to still expect a response from the host.
 	CreatedAt time.Time `json:"-" db:"created_at"`
+	// ScriptID is the id of the saved script to execute, or nil if this was an
+	// anonymous script execution.
+	ScriptID *uint `json:"script_id" db:"script_id"`
 
 	// TeamID is only used for authorization, it must be set to the team id of
 	// the host when checking authorization and is otherwise not set.

--- a/server/fleet/scripts.go
+++ b/server/fleet/scripts.go
@@ -31,6 +31,7 @@ func (s Script) AuthzType() string {
 
 type HostScriptRequestPayload struct {
 	HostID         uint   `json:"host_id"`
+	ScriptID       *uint  `json:"script_id"`
 	ScriptContents string `json:"script_contents"`
 }
 

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -23,6 +23,7 @@ import (
 
 type runScriptRequest struct {
 	HostID         uint   `json:"host_id"`
+	ScriptID       *uint  `json:"script_id"`
 	ScriptContents string `json:"script_contents"`
 }
 
@@ -41,6 +42,7 @@ func runScriptEndpoint(ctx context.Context, request interface{}, svc fleet.Servi
 	var noWait time.Duration
 	result, err := svc.RunHostScript(ctx, &fleet.HostScriptRequestPayload{
 		HostID:         req.HostID,
+		ScriptID:       req.ScriptID,
 		ScriptContents: req.ScriptContents,
 	}, noWait)
 	if err != nil {
@@ -82,6 +84,7 @@ func runScriptSyncEndpoint(ctx context.Context, request interface{}, svc fleet.S
 	req := request.(*runScriptRequest)
 	result, err := svc.RunHostScript(ctx, &fleet.HostScriptRequestPayload{
 		HostID:         req.HostID,
+		ScriptID:       req.ScriptID,
 		ScriptContents: req.ScriptContents,
 	}, waitForResult)
 	var hostTimeout bool

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -123,6 +123,7 @@ type getScriptResultRequest struct {
 
 type getScriptResultResponse struct {
 	ScriptContents string `json:"script_contents"`
+	ScriptID       *uint  `json:"script_id"`
 	ExitCode       *int64 `json:"exit_code"`
 	Output         string `json:"output"`
 	Message        string `json:"message"`
@@ -150,6 +151,7 @@ func getScriptResultEndpoint(ctx context.Context, request interface{}, svc fleet
 
 	return &getScriptResultResponse{
 		ScriptContents: scriptResult.ScriptContents,
+		ScriptID:       scriptResult.ScriptID,
 		ExitCode:       scriptResult.ExitCode,
 		Output:         scriptResult.Output,
 		Message:        scriptResult.Message,


### PR DESCRIPTION
#9829 (final PR, for point 5.)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
