### PR TITLE
Update supported Windows versions

### DIFF
--- a/docs/Using Fleet/Supported-host-operating-systems.md
+++ b/docs/Using Fleet/Supported-host-operating-systems.md
@@ -6,8 +6,8 @@ Fleet supports the following operating system versions on hosts.
 
 | OS      | Supported version(s)                    |
 | :------ | :-------------------------------------  |
-| MacOS   | 12 (Monterey) and higher                                  |
-| Windows | 10+                                     |
+| MacOS   | 12 (Monterey) and higher                |
+| Windows | 10 (Pro and Enterprise) and higher      |
 | Linux   | CentOS 7.1+,  Ubuntu 16.04+             |
 | ChromeOS | 112.0.5615.134+                        |
 


### PR DESCRIPTION
- Clarify that Fleet supports Windows 10+ for "Pro" and "Enterprise." Not "Home"
  - Why? Microsoft makes it so automatic enrollment for Windows (MDM feature) isn't supported on "Home"
