### PR TITLE
CX Hackathon: End-user dark mode

### DIFF
--- a/docs/Deploy/Deploy-Fleet-on-Kubernetes.md
+++ b/docs/Deploy/Deploy-Fleet-on-Kubernetes.md
@@ -93,6 +93,8 @@ If you have not used Helm before, you must run the following to initialize your 
 helm init
 ```
 
+> Note: The helm init command has been removed in Helm v3. It performed two primary functions. First, it installed Tiller which is no longer needed. Second, it set up directories and repositories where Helm configuration lived. This is now automated in Helm v3; if the directory is not present it will be created.
+
 ### Deploying Fleet with Helm
 
 To configure preferences for Fleet for use in Helm, including secret names, MySQL and Redis hostnames, and TLS certificates, download the [values.yaml](https://raw.githubusercontent.com/fleetdm/fleet/main/charts/fleet/values.yaml) and change the settings to match your configuration.
@@ -117,16 +119,24 @@ For the sake of this tutorial, we will again use Helm, this time to install MySQ
 
 The MySQL that we will use for this tutorial is not replicated and it is not Highly Available. If you're deploying Fleet on a Kubernetes managed by a cloud provider (GCP, Azure, AWS, etc), I suggest using their MySQL product if possible as running HA MySQL in Kubernetes can be difficult. To make this tutorial cloud provider agnostic however, we will use a non-replicated instance of MySQL.
 
-To install MySQL from Helm, run the following command. Note that there are some options that are specified. These options basically just enumerate that:
+To install MySQL from Helm, run the following command. Note that there are some options that need to be defined:
 
 - There should be a `fleet` database created
 - The default user's username should be `fleet`
 
+Helm v2
 ```sh
 helm install \
   --name fleet-database \
   --set mysqlUser=fleet,mysqlDatabase=fleet \
-  stable/mysql
+  oci://registry-1.docker.io/bitnamicharts/mysql
+```
+
+Helm v3
+```sh
+helm install fleet-database \
+  --set mysqlUser=fleet,mysqlDatabase=fleet \
+  oci://registry-1.docker.io/bitnamicharts/mysql 
 ```
 
 This helm package will create a Kubernetes `Service` which exposes the MySQL server to the rest of the cluster on the following DNS address:
@@ -156,11 +166,19 @@ kubectl create -f ./docs/Using-Fleet/configuration-files/kubernetes/fleet-migrat
 
 #### Redis
 
+Helm v2
 ```sh
 helm install \
   --name fleet-cache \
   --set persistence.enabled=false \
-  stable/redis
+  oci://registry-1.docker.io/bitnamicharts/redis
+```
+
+Helm v3
+```sh
+helm install fleet-cache \
+  --set persistence.enabled=false \
+  oci://registry-1.docker.io/bitnamicharts/redis
 ```
 
 This helm package will create a Kubernetes `Service` which exposes the Redis server to the rest of the cluster on the following DNS address:

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -87,18 +87,15 @@ const DeviceUserPage = ({
     null
   );
 
-  // const userColorThemePreference = window.matchMedia(
-  //   "(prefers-color-scheme: dark)"
-  // );
+  const userColorThemePreference: MediaQueryList = window.matchMedia(
+    "(prefers-color-scheme: dark)"
+  );
 
-  // console.log("userColorThemePreference: ", userColorThemePreference);
+  userColorThemePreference.addEventListener("change", () => {
+    router.push(location.pathname);
+  });
 
-  console.log("Y U NO WORK?!?!");
-
-  const setDarkMode = true; // TODO: identify if dark mode is on
-
-  const darkMode = setDarkMode && "dark-mode";
-
+  const darkMode = userColorThemePreference.matches && "dark-mode";
   const darkModeClass = classNames(baseClass, darkMode);
 
   const { data: deviceMapping, refetch: refetchDeviceMapping } = useQuery(

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useContext, useCallback, useEffect } from "react";
 import { InjectedRouter, Params } from "react-router/lib/Router";
 import { useQuery } from "react-query";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
+import classNames from "classnames";
 
 import { pick, findIndex } from "lodash";
 
@@ -85,6 +86,20 @@ const DeviceUserPage = ({
   const [globalConfig, setGlobalConfig] = useState<IDeviceGlobalConfig | null>(
     null
   );
+
+  // const userColorThemePreference = window.matchMedia(
+  //   "(prefers-color-scheme: dark)"
+  // );
+
+  // console.log("userColorThemePreference: ", userColorThemePreference);
+
+  console.log("Y U NO WORK?!?!");
+
+  const setDarkMode = true; // TODO: identify if dark mode is on
+
+  const darkMode = setDarkMode && "dark-mode";
+
+  const darkModeClass = classNames(baseClass, darkMode);
 
   const { data: deviceMapping, refetch: refetchDeviceMapping } = useQuery(
     ["deviceMapping", deviceAuthToken],
@@ -507,7 +522,7 @@ const DeviceUserPage = ({
   };
 
   return (
-    <div className="app-wrap">
+    <div className={`app-wrap ${darkModeClass}`}>
       <nav className="site-nav-container">
         <div className="site-nav-content">
           <ul className="site-nav-list">

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -102,13 +102,37 @@
 }
 
 .dark-mode {
+  background-color: $ui-dark-fleet-50;
+
+  .site-nav-container {
+    background-color: $ui-dark-fleet-50;
+  }
+
   .device-user {
     background-color: $ui-dark-fleet-50;
     color: $ui-dark-white;
+
+    h1,
+    .react-tabs__tab--selected,
+    .table-container__results-count {
+      background-color: $ui-dark-fleet-50;
+      color: $ui-dark-white;
+    }
+
+    p,
+    .last-fetched {
+      color: $ui-dark-grey;
+    }
+
+    .section {
+      box-shadow: 0px 3px 0px rgba(226, 228, 234, 0.2);
+    }
   }
 
-  table {
+  table,
+  .data-table-block {
     border-color: $ui-dark-fleet-25;
+    color: $ui-dark-grey;
   }
 
   th {
@@ -118,11 +142,9 @@
   }
   tbody,
   .section,
-  .policy-failing-count {
+  .policy-failing-count,
+  .software-vuln-count {
     background-color: $ui-dark-fleet-75;
-  }
-  .data-table-block {
-    color: $ui-dark-grey;
   }
 
   .component__tabs-wrapper {
@@ -130,5 +152,33 @@
   }
   .react-tabs__tab-list {
     border-color: $ui-dark-grey;
+  }
+
+  .info-flex,
+  .info-grid {
+    .info-flex__header,
+    .info-grid__header {
+      color: $ui-dark-white;
+    }
+    .info-flex__data,
+    .info-grid__data {
+      color: $ui-dark-grey;
+    }
+  }
+
+  .info__header {
+    color: $ui-dark-white;
+  }
+  .info__data {
+    color: $ui-dark-grey;
+  }
+
+  .modal__modal_container,
+  .__react_component_tooltip {
+    background-color: $ui-dark-fleet-10;
+
+    p {
+      color: $ui-dark-white;
+    }
   }
 }

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -115,9 +115,13 @@
     background-color: $ui-dark-fleet-50;
 
     h1,
-    .react-tabs__tab--selected,
-    .table-container__results-count {
+    .react-tabs__tab--selected {
       background-color: $ui-dark-fleet-50;
+      color: $ui-dark-white;
+    }
+
+    .table-container__results-count {
+      background-color: $ui-dark-fleet-75;
       color: $ui-dark-white;
     }
 

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -106,15 +106,13 @@
 
 .dark-mode {
   background-color: $ui-dark-fleet-50;
+  color: $ui-dark-white;
 
   .site-nav-container {
     background-color: $ui-dark-fleet-50;
-    border-bottom: 1px solid $ui-dark-border
   }
-
   .device-user {
     background-color: $ui-dark-fleet-50;
-    color: $ui-dark-white;
 
     h1,
     .react-tabs__tab--selected,
@@ -129,74 +127,80 @@
     }
 
     .section {
+      background-color: $ui-dark-fleet-75;
       box-shadow: 0px 3px 0px rgba(226, 228, 234, 0.2);
     }
-  }
-  .Select.dropdown__select {
-    border: 1px solid $ui-dark-border;
-  }
-  .input-icon-field__input {
-    border: 1px solid $ui-dark-border;
-    color: $ui-dark-grey;
-    background: $ui-dark-fleet-50;
-  }
-  .Select {
-    .dropdown__select {
-      color: $ui-dark-grey;
+
+    .Select.dropdown__select {
+      border: 1px solid $ui-dark-border;
     }
-    .Select-control {
+
+    .input-icon-field__input {
+      border: 1px solid $ui-dark-border;
       color: $ui-dark-grey;
       background: $ui-dark-fleet-50;
     }
-    .Select-menu-outer {
-      background-color: $ui-dark-modal-background;
-      border-radius: 12px;
-      border: 1px solid rgba(255, 255, 255, 0.25);
-      background: rgba(122, 134, 158, 0.10);
-      box-shadow: 0px 4px 8px 0px rgba(25, 33, 71, 0.25);
-    }
-    .Select-option {
-      color: $ui-dark-grey;
-      background-color: $ui-dark-modal-background;
-      .dropdown__help-text {
-        color: $ui-dark-white;
+
+    .Select {
+      .dropdown__select {
+        color: $ui-dark-grey;
+      }
+      .Select-control {
+        color: $ui-dark-grey;
+        background: $ui-dark-fleet-50;
+      }
+      .Select-menu-outer {
+        background-color: $ui-dark-modal-background;
+        border-radius: 12px;
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        background: rgba(122, 134, 158, 0.1);
+        box-shadow: 0px 4px 8px 0px rgba(25, 33, 71, 0.25);
+      }
+      .Select-option {
+        color: $ui-dark-grey;
+        background-color: $ui-dark-modal-background;
+        .dropdown__help-text {
+          color: $ui-dark-white;
+        }
+      }
+      .Select-option.is-focused {
+        background-color: $ui-dark-fleet-75;
       }
     }
-    .Select-option.is-focused {
+
+    table,
+    tr,
+    .data-table-block {
+      .table-container__header {
+        svg {
+          path {
+            fill: $ui-dark-grey;
+          }
+        }
+      }
+    }
+
+    .data-table-block,
+    .data-table__table {
+      border-color: $ui-dark-fleet-25;
+      color: $ui-dark-grey;
+    }
+
+    th {
+      background-color: $ui-dark-fleet-50;
+      border-color: $ui-dark-fleet-25;
+      color: $ui-dark-white;
+    }
+    tbody,
+    .section,
+    .policy-failing-count,
+    .software-vuln-count {
       background-color: $ui-dark-fleet-75;
     }
-  } 
-  table,
-  tr,
-  .data-table-block {
-  .table-container__header {
-    svg {
-      path {
-        fill: $ui-dark-grey;
-      }
-    }
-  }
-
-  .data-table-block,
-  .data-table__table {
-    border-color: $ui-dark-fleet-25;
-    color: $ui-dark-grey;
-  }
-
-  th {
-    background-color: $ui-dark-fleet-50;
-    border-color: $ui-dark-fleet-25;
-    color: $ui-dark-white;
-  }
-  tbody,
-  .section,
-  .policy-failing-count,
-  .software-vuln-count {
-    background-color: $ui-dark-fleet-75;
   }
 
   .component__tabs-wrapper {
-    background-color: $ui-dark-fleet-75;
+    background-color: $ui-dark-fleet-50;
   }
   .react-tabs__tab-list {
     border-color: $ui-dark-grey;
@@ -210,7 +214,7 @@
   }
   .data-table-block__pagination button:hover,
   .data-table-block__pagination button:focus {
-    background-color: $ui-dark-fleet-50; 
+    background-color: $ui-dark-fleet-50;
   }
 
   .info-flex,
@@ -239,14 +243,14 @@
     &:before {
       background: $ui-dark-button-gradient;
       opacity: 1;
-      content: ' ';
+      content: " ";
       position: absolute;
       top: 0;
       left: -5px;
       width: 50%;
       height: 100%;
       transform: skew(-10deg);
-      transition: left 0.5s ease-in, opacity 0.50s ease-in, width 0.5s ease-in;
+      transition: left 0.5s ease-in, opacity 0.5s ease-in, width 0.5s ease-in;
     }
     &:hover:before {
       opacity: 0;
@@ -347,7 +351,8 @@
       background-color: $ui-dark-fleet-25;
     }
   }
-  .Select-input {
+  .Select-input,
+  .Select-input:focus {
     background-color: $ui-dark-fleet-50;
   }
   .dropdown__option {

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -130,7 +130,8 @@
     }
 
     p,
-    .last-fetched {
+    .last-fetched,
+    .status-indicator {
       color: $ui-dark-grey;
     }
 
@@ -190,7 +191,8 @@
     }
 
     .data-table__wrapper {
-      background-color: $ui-dark-fleet-25;
+      background-color: $ui-dark-fleet-50;
+      background-image: none;
       border-color: $ui-dark-fleet-25;
     }
 
@@ -200,7 +202,6 @@
 
     .data-table-block,
     .data-table__table {
-      background-color: transparent;
       border-color: $ui-dark-fleet-25;
       color: $ui-dark-grey;
       tr {
@@ -213,7 +214,6 @@
       border-color: $ui-dark-fleet-25;
       color: $ui-dark-white;
     }
-    tbody,
     .section,
     .policy-failing-count,
     .software-vuln-count {
@@ -283,9 +283,13 @@
   .button--brand:hover:not(.button--disabled) {
     background-color: $ui-dark-button;
   }
-
-  .modal__modal_container,
   .__react_component_tooltip {
+    background-color: $ui-dark-fleet-25;
+    &::after {
+      border-right-color: $ui-dark-fleet-25;
+    }
+  } 
+  .modal__modal_container {
     background-color: $ui-dark-modal-background;
     backdrop-filter: blur(25px);
     border: 1px solid rgba(255, 255, 255, 0.25);

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -136,6 +136,7 @@
 
     .section {
       background-color: $ui-dark-fleet-75;
+      border-color: $ui-dark-fleet-25; 
       box-shadow: 0px 3px 0px rgba(226, 228, 234, 0.2);
     }
 

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -2,6 +2,9 @@
   .site-nav {
     height: 50px;
   }
+  .site-nav-item:hover {
+    background-color: initial;
+  }
 }
 
 .device-user {
@@ -166,6 +169,16 @@
   table,
   tr,
   .data-table-block {
+  .table-container__header {
+    svg {
+      path {
+        fill: $ui-dark-grey;
+      }
+    }
+  }
+
+  .data-table-block,
+  .data-table__table {
     border-color: $ui-dark-fleet-25;
     color: $ui-dark-grey;
   }
@@ -250,9 +263,97 @@
     background-color: $ui-dark-modal-background;
     backdrop-filter: blur(25px);
     border: 1px solid rgba(255, 255, 255, 0.25);
+    color: $ui-dark-white;
 
     p {
       color: $ui-dark-white;
     }
+
+    .modal__ex {
+      svg {
+        path {
+          stroke: $ui-dark-blue-gray;
+        }
+      }
+      :hover {
+        svg {
+          path {
+            stroke: $ui-dark-grey;
+          }
+        }
+      }
+    }
+  }
+  .component__tooltip-wrapper__tip-text {
+    background: $ui-dark-fleet-25;
+  }
+  .host-summary__tooltip-text::after {
+    border-top-color: $ui-dark-fleet-25;
+  }
+
+  .text-muted {
+    color: $ui-dark-fleet-10;
+  }
+
+  .button--text-icon:hover {
+    color: $core-vibrant-blue-over;
+  }
+
+  .input-icon-field__input,
+  .Select-control {
+    border-color: $ui-dark-grey;
+    background-color: $ui-dark-fleet-50;
+    color: $ui-dark-grey;
+  }
+
+  // Arrow stroke/fill behaves differently
+  .dropdown__custom-arrow {
+    svg {
+      path {
+        stroke: $ui-dark-grey;
+        fill: none;
+      }
+    }
+  }
+  .input-icon-field {
+    :hover,
+    :focus {
+      border-color: $core-vibrant-blue-over;
+
+      svg {
+        path {
+          fill: $ui-dark-white;
+        }
+      }
+    }
+  }
+
+  .Select.is-focused > .Select-control {
+    background-color: $ui-dark-fleet-50;
+  }
+
+  .Select.is-focused,
+  .Select.is-open {
+    background-color: $ui-dark-fleet-50;
+
+    .Select-menu-outer,
+    .Select-menu {
+      background-color: $ui-dark-fleet-50;
+    }
+    .Select.is-focused {
+      background-color: $ui-dark-fleet-75;
+    }
+    .Select-option.is-selected {
+      background-color: $ui-dark-fleet-25;
+    }
+  }
+  .Select-input {
+    background-color: $ui-dark-fleet-50;
+  }
+  .dropdown__option {
+    color: $ui-dark-white;
+  }
+  .dropdown__help-text {
+    color: $ui-dark-grey;
   }
 }

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -100,3 +100,35 @@
 .dup-org-logo {
   cursor: default;
 }
+
+.dark-mode {
+  .device-user {
+    background-color: $ui-dark-fleet-50;
+    color: $ui-dark-white;
+  }
+
+  table {
+    border-color: $ui-dark-fleet-25;
+  }
+
+  th {
+    background-color: $ui-dark-fleet-50;
+    border-color: $ui-dark-fleet-25;
+    color: $ui-dark-white;
+  }
+  tbody,
+  .section,
+  .policy-failing-count {
+    background-color: $ui-dark-fleet-75;
+  }
+  .data-table-block {
+    color: $ui-dark-grey;
+  }
+
+  .component__tabs-wrapper {
+    background-color: $ui-dark-fleet-50;
+  }
+  .react-tabs__tab-list {
+    border-color: $ui-dark-grey;
+  }
+}

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -106,6 +106,7 @@
 
   .site-nav-container {
     background-color: $ui-dark-fleet-50;
+    border-bottom: 1px solid $ui-dark-border
   }
 
   .device-user {
@@ -128,8 +129,42 @@
       box-shadow: 0px 3px 0px rgba(226, 228, 234, 0.2);
     }
   }
-
+  .Select.dropdown__select {
+    border: 1px solid $ui-dark-border;
+  }
+  .input-icon-field__input {
+    border: 1px solid $ui-dark-border;
+    color: $ui-dark-grey;
+    background: $ui-dark-fleet-50;
+  }
+  .Select {
+    .dropdown__select {
+      color: $ui-dark-grey;
+    }
+    .Select-control {
+      color: $ui-dark-grey;
+      background: $ui-dark-fleet-50;
+    }
+    .Select-menu-outer {
+      background-color: $ui-dark-modal-background;
+      border-radius: 12px;
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      background: rgba(122, 134, 158, 0.10);
+      box-shadow: 0px 4px 8px 0px rgba(25, 33, 71, 0.25);
+    }
+    .Select-option {
+      color: $ui-dark-grey;
+      background-color: $ui-dark-modal-background;
+      .dropdown__help-text {
+        color: $ui-dark-white;
+      }
+    }
+    .Select-option.is-focused {
+      background-color: $ui-dark-fleet-75;
+    }
+  } 
   table,
+  tr,
   .data-table-block {
     border-color: $ui-dark-fleet-25;
     color: $ui-dark-grey;
@@ -148,10 +183,21 @@
   }
 
   .component__tabs-wrapper {
-    background-color: $ui-dark-fleet-50;
+    background-color: $ui-dark-fleet-75;
   }
   .react-tabs__tab-list {
     border-color: $ui-dark-grey;
+  }
+
+  .refetch {
+    color: $ui-dark-focus;
+    .refetch-offline {
+      opacity: 85%;
+    }
+  }
+  .data-table-block__pagination button:hover,
+  .data-table-block__pagination button:focus {
+    background-color: $ui-dark-fleet-50; 
   }
 
   .info-flex,
@@ -173,9 +219,37 @@
     color: $ui-dark-grey;
   }
 
+  .button--brand {
+    background-color: $ui-dark-button;
+    overflow: hidden;
+    position: relative;
+    &:before {
+      background: $ui-dark-button-gradient;
+      opacity: 1;
+      content: ' ';
+      position: absolute;
+      top: 0;
+      left: -5px;
+      width: 50%;
+      height: 100%;
+      transform: skew(-10deg);
+      transition: left 0.5s ease-in, opacity 0.50s ease-in, width 0.5s ease-in;
+    }
+    &:hover:before {
+      opacity: 0;
+      left: 160px;
+      width: 110%;
+    }
+  }
+  .button--brand:hover:not(.button--disabled) {
+    background-color: $ui-dark-button;
+  }
+
   .modal__modal_container,
   .__react_component_tooltip {
-    background-color: $ui-dark-fleet-10;
+    background-color: $ui-dark-modal-background;
+    backdrop-filter: blur(25px);
+    border: 1px solid rgba(255, 255, 255, 0.25);
 
     p {
       color: $ui-dark-white;

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -108,6 +108,10 @@
   background-color: $ui-dark-fleet-50;
   color: $ui-dark-white;
 
+  .loading-spinner {
+    background-color: initial;
+  }
+
   .site-nav-container {
     background-color: $ui-dark-fleet-50;
   }

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -104,7 +104,7 @@
   cursor: default;
 }
 
-.dark-mode {
+#app .dark-mode { // Add specificity to ensure dark-mode styles are applied.
   background-color: $ui-dark-fleet-50;
   color: $ui-dark-white;
 
@@ -137,7 +137,7 @@
     .section {
       background-color: $ui-dark-fleet-75;
       border-color: $ui-dark-fleet-25; 
-      box-shadow: 0px 3px 0px rgba(226, 228, 234, 0.2);
+      box-shadow: 3px 3px 3px rgba(0, 0, 0, 0.2);
     }
 
     .Select.dropdown__select {
@@ -189,10 +189,23 @@
       }
     }
 
+    .data-table__wrapper {
+      background-color: $ui-dark-fleet-25;
+      border-color: $ui-dark-fleet-25;
+    }
+
+    .data-table-block .data-table thead {
+      border-bottom-color: $ui-dark-fleet-25;
+    }
+
     .data-table-block,
     .data-table__table {
+      background-color: transparent;
       border-color: $ui-dark-fleet-25;
       color: $ui-dark-grey;
+      tr {
+        border-bottom-color: $ui-dark-fleet-25;
+      }
     }
 
     th {

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -29,8 +29,9 @@ $ui-vibrant-blue-10: #f1f0ff; // rgba(241, 240, 255, 1)
 $ui-dark-fleet-75: #161722; // Background of page
 $ui-dark-fleet-50: #20222e; // Nav bar and table header
 $ui-dark-fleet-25: #3a3e4f; // Border color
+$ui-dark-fleet-10: #8388a4; // Background of modal
 $ui-dark-white: #fff; // Primary text
-$ui-dark-grey: #808294; // Secondary text
+$ui-dark-grey: #a1a4b7; // Secondary text
 $ui-dark-focus: $core-vibrant-blue; // Focus outlines
 $ui-dark-button: $core-vibrant-red; // Primary buttons
 $ui-dark-button-gradient: linear-gradient(

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -33,7 +33,7 @@ $ui-dark-fleet-10: #8388a4; // Background of modal
 $ui-dark-white: #fff; // Primary text
 $ui-dark-grey: #a1a4b7; // Secondary text
 $ui-dark-border: #414557; // Modal border color
-$ui-dark-modal-background: rgba(122, 134, 158, 0.10); // Secondary text
+$ui-dark-modal-background: rgba(122, 134, 158, 0.05); // Modal background
 $ui-dark-focus: $core-vibrant-blue; // Focus outlines
 $ui-dark-button: $core-vibrant-red; // Primary buttons
 $ui-dark-button-gradient: linear-gradient(

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -32,6 +32,8 @@ $ui-dark-fleet-25: #3a3e4f; // Border color
 $ui-dark-fleet-10: #8388a4; // Background of modal
 $ui-dark-white: #fff; // Primary text
 $ui-dark-grey: #a1a4b7; // Secondary text
+$ui-dark-border: #414557; // Modal border color
+$ui-dark-modal-background: rgba(122, 134, 158, 0.10); // Secondary text
 $ui-dark-focus: $core-vibrant-blue; // Focus outlines
 $ui-dark-button: $core-vibrant-red; // Primary buttons
 $ui-dark-button-gradient: linear-gradient(

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -25,6 +25,20 @@ $ui-vibrant-blue-50: rgba(106, 103, 254, 0.5);
 $ui-vibrant-blue-25: #d9d9fe;
 $ui-vibrant-blue-10: #f1f0ff; // rgba(241, 240, 255, 1)
 
+// UI Dark
+$ui-dark-fleet-75: #161722; // Background of page
+$ui-dark-fleet-50: #20222e; // Nav bar and table header
+$ui-dark-fleet-25: #3a3e4f; // Border color
+$ui-dark-white: #fff; // Primary text
+$ui-dark-grey: #808294; // Secondary text
+$ui-dark-focus: $core-vibrant-blue; // Focus outlines
+$ui-dark-button: $core-vibrant-red; // Primary buttons
+$ui-dark-button-gradient: linear-gradient(
+  180deg,
+  rgba(255, 255, 255, 0.2) 0%,
+  rgba(255, 255, 255, 0) 100%
+); // Gradient used in Primary button
+
 // Notifications & status & specific messages
 $ui-offline: #8b8fa2;
 $ui-success: #3db67b;
@@ -75,3 +89,13 @@ $ui-off-white-opaque: rgba(
   (252-249) / $ui-off-white-alpha,
   $ui-off-white-alpha
 );
+
+// Dark mode
+$dark-mode-background: #161722; // Background of page
+$dark-mode-table-header: #20222e; // Nav bar and table header
+$dark-mode-table-border: #3a3e4f; // Border color
+$dark-mode-text: #fff;
+$dark-mode-secondary-text: #808294;
+$dark-mode-focus: $core-vibrant-blue;
+$dark-mode-button: #ff6289;
+$dark-mode-secondary-button: #fe7394;

--- a/frontend/test/test-setup.ts
+++ b/frontend/test/test-setup.ts
@@ -2,6 +2,17 @@ import "@testing-library/jest-dom";
 
 import mockServer from "./mock-server";
 
+window.matchMedia =
+  window.matchMedia ||
+  function matchMedia() {
+    return {
+      matches: false,
+      addEventListener() {
+        return null;
+      },
+    };
+  };
+
 // Mock server setup
 beforeAll(() => mockServer.listen());
 afterEach(() => mockServer.resetHandlers());


### PR DESCRIPTION
## Issue
Related to #665 

## Authors
Co-authored by @eashaw and @lukeheath 

## Description
- Add dark mode to the end user view that matches the end user's browser settings for dark mode

## Testing instructions (macOS)
1. Open a dev environment for a device user page (e.g., https://localhost:8080/device/TokenFromHostDeviceAuthTable)
2. Toggle your macOS settings between Light and Dark mode in Apple > System Settings > Appearance
3. You should see the device user page toggle between light and dark mode

## Screen recording of test instructions

<img width="895" alt="Screenshot 2023-10-02 at 7 52 27 AM" src="https://github.com/fleetdm/fleet/assets/71795832/d41ca66f-758b-48e9-aabe-eab9dea514e8">


https://github.com/fleetdm/fleet/assets/71795832/bba076ce-cb90-4d89-86a2-dd8f3a715530

## TODO steps!
- [ ] @eashaw Merge any other changes you have made on Friday (in hopes they don't conflict!) (any edge cases for this page we might have forgotten? Call out boxes?)
- [ ] @mike-j-thomas @rachaelshaw please test and review the color choices, feel free to make a loom of any changes you want to add (any edge cases for this page we might have forgotten? Call out boxes?)
- [ ] @RachelElysia Update changes based on design review (any edge cases for this page we might have forgotten? Call out boxes?)
- [ ] @fleetdm/frontend approve (any edge cases for this page we might have forgotten? Call out boxes?)
- [ ] @xpkoala QA (any edge cases for this page we might have forgotten? Call out boxes?)
- [ ] Be sure to add all 3 coauthors when merging into main

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
