### PR TITLE
Update saml-auth-proxy addon to output its secret_id

### DIFF
--- a/terraform/addons/saml-auth-proxy/outputs.tf
+++ b/terraform/addons/saml-auth-proxy/outputs.tf
@@ -11,3 +11,7 @@ output "name" {
 output "lb_target_group_arn" {
   value = module.saml_auth_proxy_alb.target_group_arns[0]
 }
+
+output "secretsmanager_secret_id" {
+  value = aws_secretsmanager_secret.saml_auth_proxy_cert.id
+}


### PR DESCRIPTION
This is needed to automatically populate the secret from outside of the module with an `aws_secretsmanager_secret_version`