### PR TITLE
Fleet UI: Surface delete previous results modals

### DIFF
--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext } from "react";
 import { useQuery } from "react-query";
 import { InjectedRouter, Params } from "react-router/lib/Router";
 import { useErrorHandler } from "react-error-boundary";
@@ -112,7 +112,7 @@ const QueryDetailsPage = ({
   );
 
   const isLoading = isStoredQueryLoading; // TODO: Add || isCachedResultsLoading for new API response
-  const isApiError = storedQueryError || true; // TODO: Add || isCachedResultsError for new API response
+  const isApiError = storedQueryError || false; // TODO: Add || isCachedResultsError for new API response
 
   const renderHeader = () => {
     const canEditQuery =

--- a/frontend/pages/queries/edit/EditQueryPage/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage/EditQueryPage.tsx
@@ -100,13 +100,14 @@ const EditQueryPage = ({
   const [showOpenSchemaActionText, setShowOpenSchemaActionText] = useState(
     false
   );
+  const [showSaveChangesModal, setShowSaveChangesModal] = useState(false);
 
   // disabled on page load so we can control the number of renders
   // else it will re-populate the context on occasion
   const {
     isLoading: isStoredQueryLoading,
     data: storedQuery,
-    error: storedQueryError,
+    refetch: refetchStoredQuery,
   } = useQuery<IGetQueryResponse, Error, ISchedulableQuery>(
     ["query", queryId],
     () => queryAPI.load(queryId as number),
@@ -215,6 +216,7 @@ const EditQueryPage = ({
     try {
       await queryAPI.update(queryId, updatedQuery);
       renderFlash("success", "Query updated!");
+      refetchStoredQuery(); // Required to compare recently saved query to a subsequent save to the query
     } catch (updateError: any) {
       console.error(updateError);
       if (updateError.data.errors[0].reason.includes("Duplicate")) {
@@ -228,6 +230,7 @@ const EditQueryPage = ({
     }
 
     setIsQueryUpdating(false);
+    setShowSaveChangesModal(false); // Closes conditionally opened modal when discarding previous results
 
     return false;
   };
@@ -304,6 +307,8 @@ const EditQueryPage = ({
               isQuerySaving={isQuerySaving}
               isQueryUpdating={isQueryUpdating}
               hostId={parseInt(location.query.host_ids as string, 10)}
+              showSaveChangesModal={showSaveChangesModal}
+              setShowSaveChangesModal={setShowSaveChangesModal}
             />
           </div>
         </div>

--- a/frontend/pages/queries/edit/components/QueryForm/QueryForm.tests.tsx
+++ b/frontend/pages/queries/edit/components/QueryForm/QueryForm.tests.tsx
@@ -72,6 +72,8 @@ describe("QueryForm - component", () => {
         onOpenSchemaSidebar={jest.fn()}
         renderLiveQueryWarning={jest.fn()}
         backendValidators={{}}
+        showSaveChangesModal={false}
+        setShowSaveChangesModal={jest.fn()}
       />
     );
 

--- a/frontend/pages/queries/edit/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/edit/components/QueryForm/QueryForm.tsx
@@ -73,6 +73,8 @@ interface IQueryFormProps {
   renderLiveQueryWarning: () => JSX.Element | null;
   backendValidators: { [key: string]: string };
   hostId?: number;
+  showSaveChangesModal: boolean;
+  setShowSaveChangesModal: (bool: boolean) => void;
 }
 
 const validateQuerySQL = (query: string) => {
@@ -120,6 +122,8 @@ const QueryForm = ({
   renderLiveQueryWarning,
   backendValidators,
   hostId,
+  showSaveChangesModal,
+  setShowSaveChangesModal,
 }: IQueryFormProps): JSX.Element => {
   // Note: The QueryContext values should always be used for any mutable query data such as query name
   // The storedQuery prop should only be used to access immutable metadata such as author id
@@ -158,7 +162,6 @@ const QueryForm = ({
   const savedQueryMode = !!queryIdForEdit;
   const [errors, setErrors] = useState<{ [key: string]: any }>({}); // string | null | undefined or boolean | undefined
   const [showSaveQueryModal, setShowSaveQueryModal] = useState(false);
-  const [showSaveChangesModal, setShowSaveChangesModal] = useState(false); // #7766 implementation
   const [showQueryEditor, setShowQueryEditor] = useState(
     isObserverPlus || isAnyTeamObserverPlus || false
   );
@@ -211,7 +214,6 @@ const QueryForm = ({
     setShowSaveQueryModal(!showSaveQueryModal);
   };
 
-  // #7766 implementation
   const toggleSaveChangesModal = () => {
     setShowSaveChangesModal(!showSaveChangesModal);
   };
@@ -619,7 +621,7 @@ const QueryForm = ({
   };
 
   const confirmSqlChange = (): boolean => {
-    // Confirm sql changes
+    // Confirm sql changes message if sql changed but snapshot and enabling discard data has not
     return !!hasSqlChange && !hasSnapshotChange && !hasEnabledDiscardData;
   };
 
@@ -816,9 +818,9 @@ const QueryForm = ({
         )}
         {showSaveChangesModal && (
           <SaveChangesModal
-            onSaveChanges={promptSaveQuery}
+            onSaveChanges={promptSaveQuery()}
             toggleSaveChangesModal={toggleSaveChangesModal}
-            isUpdating={isQuerySaving}
+            isUpdating={isQueryUpdating}
             sqlUpdated={confirmSqlChange()}
           />
         )}

--- a/frontend/pages/queries/edit/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/edit/components/QueryForm/QueryForm.tsx
@@ -603,20 +603,24 @@ const QueryForm = ({
 
   const hasSavePermissions = isGlobalAdmin || isGlobalMaintainer;
 
-  const confirmChanges = (): boolean => {
-    const hasSqlChange =
-      storedQuery && lastEditedQueryBody !== storedQuery.query;
-    const hasSnapshotChange =
-      storedQuery &&
-      lastEditedQueryLoggingType !== "snapshot" &&
-      storedQuery.logging === "snapshot";
-    // Use commented out logic when discard data checkbox is implemented #13470
-    const hasEnabledDiscardData = false;
-    // const hasEnabledDiscardData =
-    //   storedQuery && lastEditedDiscardData && !storedQuery.discardData;
+  const hasSqlChange = storedQuery && lastEditedQueryBody !== storedQuery.query;
+  const hasSnapshotChange =
+    storedQuery &&
+    lastEditedQueryLoggingType !== "snapshot" &&
+    storedQuery.logging === "snapshot";
+  // Use commented out logic when discard data checkbox is implemented #13470
+  const hasEnabledDiscardData = false;
+  // const hasEnabledDiscardData =
+  //   storedQuery && lastEditedDiscardData && !storedQuery.discardData;
 
+  const confirmChanges = (): boolean => {
     // Confirm changes if the query has been edited, removed snapshot logging, or enabled discard data
     return hasSqlChange || hasSnapshotChange || hasEnabledDiscardData;
+  };
+
+  const confirmSqlChange = (): boolean => {
+    // Confirm sql changes
+    return !!hasSqlChange && !hasSnapshotChange && !hasEnabledDiscardData;
   };
 
   // Global admin, any maintainer, any observer+ on new query
@@ -815,6 +819,7 @@ const QueryForm = ({
             onSaveChanges={promptSaveQuery}
             toggleSaveChangesModal={toggleSaveChangesModal}
             isUpdating={isQuerySaving}
+            sqlUpdated={confirmSqlChange()}
           />
         )}
       </>

--- a/frontend/pages/queries/edit/components/SaveChangesModal/SaveChangesModal.tsx
+++ b/frontend/pages/queries/edit/components/SaveChangesModal/SaveChangesModal.tsx
@@ -8,7 +8,7 @@ const baseClass = "save-changes-modal";
 
 export interface ISaveChangesModalProps {
   isUpdating: boolean;
-  onSaveChanges: (formData: ICreateQueryRequestBody) => void;
+  onSaveChanges: (evt: React.MouseEvent<HTMLButtonElement>) => void;
   toggleSaveChangesModal: () => void;
   sqlUpdated?: boolean;
 }


### PR DESCRIPTION
## Issue
#13473 

## Description
- Surfaces delete previous results modals
- Still need #13470 discard data checkbox to be on page for logic for surfacing modal for checking discard data

## Screenshots
<img width="1279" alt="Screenshot 2023-10-02 at 4 25 32 PM" src="https://github.com/fleetdm/fleet/assets/71795832/f4c46ff4-35de-41b2-aeca-3deaa63135f6">
<img width="1280" alt="Screenshot 2023-10-02 at 4 25 05 PM" src="https://github.com/fleetdm/fleet/assets/71795832/7bcb3e1e-05ed-4aa6-aabb-69d54512fdcf">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

