### PR TITLE
2023-10-05 Handbook/product#settled 

### DIFF
--- a/handbook/product/README.md
+++ b/handbook/product/README.md
@@ -79,7 +79,7 @@ Once the draft has been approved, it moves to the "Settled" column on the drafti
 
 Before assigning an engineering manager to [estimate](https://fleetdm.com/handbook/engineering#sprint-ceremonies) a user story, the product designer ensures the product section of the user story [checklist](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=story&projects=&template=story.md&title=) is complete. 
 
-Once a bug has gone through design and is considered "Settled", the designer removes the `:product` label and moves the issue to the 'To be scheduled' column on the "Bugs" board for the attention of the product manager.
+Once a bug has gone through design and is considered "Settled", the designer removes the `:product` label and moves the issue to the 'To be scheduled' column on the "Bugs" board. The product manager then prioritizes the bug into the "Sprint backlog" and assigns the group engineering manager. 
 
 > The story's designer is responsible for ensuring the checklist has been completed, the requirements section is consistent with the Figma, and the group engineering manager has been assigned. 
 

--- a/handbook/product/README.md
+++ b/handbook/product/README.md
@@ -81,8 +81,6 @@ Before assigning an engineering manager to [estimate](https://fleetdm.com/handbo
 
 Once a bug has gone through design and is considered "Settled", the designer removes the `:product` label and moves the issue to the 'To be scheduled' column on the "Bugs" board. The product manager then prioritizes the bug into the "Sprint backlog" and assigns the group engineering manager. 
 
-> The story's designer is responsible for ensuring the checklist has been completed, the requirements section is consistent with the Figma, and the group engineering manager has been assigned. 
-
 Learn https://fleetdm.com/handbook/company/development-groups#making-changes
 
 ### Expedited drafting

--- a/handbook/product/README.md
+++ b/handbook/product/README.md
@@ -77,7 +77,9 @@ For external contributors: please consider opening an issue with reference scree
 
 Once the draft has been approved, it moves to the "Settled" column on the drafting board. 
 
-Before assigning an engineering manager for [estimation](https://fleetdm.com/handbook/engineering#sprint-ceremonies), the product team should ensure the product section of the user story [checklist](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=story&projects=&template=story.md&title=) is complete. 
+Before assigning an engineering manager to [estimate](https://fleetdm.com/handbook/engineering#sprint-ceremonies) a user story, the product team should ensure the product section of the user story [checklist](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=story&projects=&template=story.md&title=) is complete. 
+
+For bugs that have gone through design and are considered "Settled", the designer should remove the `:product` label and move the issue to the 'To be scheduled' column on the bugs board for the attention of the product manager.
 
 > The story's designer is responsible for ensuring the checklist has been completed, the requirements section is consistent with the Figma, and the group engineering manager has been assigned. 
 

--- a/handbook/product/README.md
+++ b/handbook/product/README.md
@@ -79,7 +79,7 @@ Once the draft has been approved, it moves to the "Settled" column on the drafti
 
 Before assigning an engineering manager to [estimate](https://fleetdm.com/handbook/engineering#sprint-ceremonies) a user story, the product team should ensure the product section of the user story [checklist](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=story&projects=&template=story.md&title=) is complete. 
 
-For bugs that have gone through design and are considered "Settled", the designer should remove the `:product` label and move the issue to the 'To be scheduled' column on the bugs board for the attention of the product manager.
+Once a bug has gone through design and is considered "Settled", the designer removes the `:product` label and moves the issue to the 'To be scheduled' column on the "Bugs" board for the attention of the product manager.
 
 > The story's designer is responsible for ensuring the checklist has been completed, the requirements section is consistent with the Figma, and the group engineering manager has been assigned. 
 

--- a/handbook/product/README.md
+++ b/handbook/product/README.md
@@ -77,7 +77,7 @@ For external contributors: please consider opening an issue with reference scree
 
 Once the draft has been approved, it moves to the "Settled" column on the drafting board. 
 
-Before assigning an engineering manager to [estimate](https://fleetdm.com/handbook/engineering#sprint-ceremonies) a user story, the product team should ensure the product section of the user story [checklist](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=story&projects=&template=story.md&title=) is complete. 
+Before assigning an engineering manager to [estimate](https://fleetdm.com/handbook/engineering#sprint-ceremonies) a user story, the product designer ensures the product section of the user story [checklist](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=story&projects=&template=story.md&title=) is complete. 
 
 Once a bug has gone through design and is considered "Settled", the designer removes the `:product` label and moves the issue to the 'To be scheduled' column on the "Bugs" board for the attention of the product manager.
 


### PR DESCRIPTION
Once bugs have been settled, they should be removed from the drafting board and moved into the 'to be scheduled' column of the bugs board so that the PM knows they need to be prioritized into the sprint backlog. 