### PR TITLE
Website: update link to /queries & change /queries heading

### DIFF
--- a/website/views/layouts/layout-sandbox.ejs
+++ b/website/views/layouts/layout-sandbox.ejs
@@ -170,7 +170,7 @@
                 <div id="mobileNavbarToggleDocumentation" purpose="mobile-dropdown" class="collapse" data-parent="#mobileDropdowns">
                   <a href="/docs">Docs</a>
                   <a href="/releases">Releases</a>
-                  <a href="/queries">Health checks &amp; queries</a>
+                  <a href="/queries">Device health</a>
                   <a href="/tables">Explore data</a>
                   <a href="/support">Support</a>
                   <span>GUIDES</span>
@@ -220,7 +220,7 @@
               <div purpose="header-dropdown" class="dropdown-menu">
                 <a class="dropdown-item mb-1" href="/docs">Docs</a>
                 <a class="dropdown-item mb-1" href="/releases">Releases</a>
-                <a class="dropdown-item mb-1" href="/queries">Health checks &amp; queries</a>
+                <a class="dropdown-item mb-1" href="/queries">Device health</a>
                 <a class="dropdown-item mb-1" href="/tables">Explore data</a>
                 <a class="dropdown-item mb-1" href="/support">Support</a>
                 <div class="dropdown-divider"></div>

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -171,7 +171,7 @@
                 <div id="mobileNavbarToggleDocumentation" purpose="mobile-dropdown" class="collapse" data-parent="#mobileDropdowns">
                   <a href="/docs">Docs</a>
                   <a href="/releases">Releases</a>
-                  <a href="/queries">Health checks &amp; queries</a>
+                  <a href="/queries">Device health</a>
                   <a href="/tables">Explore data</a>
                   <a href="/support">Support</a>
                   <span>GUIDES</span>
@@ -221,7 +221,7 @@
               <div purpose="header-dropdown" class="dropdown-menu">
                 <a class="dropdown-item mb-1" href="/docs">Docs</a>
                 <a class="dropdown-item mb-1" href="/releases">Releases</a>
-                <a class="dropdown-item mb-1" href="/queries">Health checks &amp; queries</a>
+                <a class="dropdown-item mb-1" href="/queries">Device health</a>
                 <a class="dropdown-item mb-1" href="/tables">Explore data</a>
                 <a class="dropdown-item mb-1" href="/support">Support</a>
                 <div class="dropdown-divider"></div>

--- a/website/views/pages/query-library.ejs
+++ b/website/views/pages/query-library.ejs
@@ -2,7 +2,7 @@
 
   <div class="d-flex justify-content-center">
     <div class="container justify-content-center library">
-      <h2 class="mb-3">Standard query library</h2>
+      <h2 class="mb-3">Device health checks</h2>
       <p class="pb-3 description">Fleet's standard query library includes a growing collection of useful queries for organizations deploying Fleet and osquery. Want to add your own query? Please contribute <a target="_blank" href="https://github.com/fleetdm/fleet/edit/main/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml">over on GitHub</a>.</p>
       <div class="p-0 m-0">
         <div class="d-md-none">


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/14132

Changes:
- Changed the nav link for /queries ("Health checks & queries" » "Device health")
- Changed the heading on the /queries page ("Standard query library" » "Device health checks")
