### PR TITLE
fix: we should discard by default to avoid anything happening with existing queries

### DIFF
--- a/server/datastore/mysql/migrations/tables/20231002120317_AddDiscardToQueries.go
+++ b/server/datastore/mysql/migrations/tables/20231002120317_AddDiscardToQueries.go
@@ -9,7 +9,7 @@ func init() {
 }
 
 func Up_20231002120317(tx *sql.Tx) error {
-	_, err := tx.Exec(`ALTER TABLE queries ADD COLUMN discard_data TINYINT(1) NOT NULL DEFAULT FALSE;`)
+	_, err := tx.Exec(`ALTER TABLE queries ADD COLUMN discard_data TINYINT(1) NOT NULL DEFAULT TRUE;`)
 	return err
 }
 

--- a/server/datastore/mysql/migrations/tables/20231002120317_AddDiscardToQueries_test.go
+++ b/server/datastore/mysql/migrations/tables/20231002120317_AddDiscardToQueries_test.go
@@ -18,7 +18,7 @@ func TestUp_20231002120317(t *testing.T) {
 		name, description, query, discard_data
 	) VALUES (?, ?, ?, ?)`
 
-	res, err := db.Exec(insertStmt, "test", "test description", "SELECT 1 from hosts", true)
+	res, err := db.Exec(insertStmt, "test", "test description", "SELECT 1 from hosts", false)
 	require.NoError(t, err)
 	id, _ := res.LastInsertId()
 	require.NotNil(t, id)
@@ -33,7 +33,7 @@ func TestUp_20231002120317(t *testing.T) {
 		discard_data
 	FROM queries WHERE id = ?`, id)
 	require.NoError(t, err)
-	require.True(t, query[0].DiscardData)
+	require.False(t, query[0].DiscardData)
 
 	// Insert without discard_data, verify that default is correct
 
@@ -56,5 +56,5 @@ func TestUp_20231002120317(t *testing.T) {
 		discard_data
 	FROM queries WHERE id = ?`, id)
 	require.NoError(t, err)
-	require.False(t, queryNoDiscard[0].DiscardData)
+	require.True(t, queryNoDiscard[0].DiscardData)
 }

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -1049,7 +1049,7 @@ CREATE TABLE `queries` (
   `schedule_interval` int(10) unsigned NOT NULL DEFAULT '0',
   `automations_enabled` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `logging_type` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'snapshot',
-  `discard_data` tinyint(1) NOT NULL DEFAULT '0',
+  `discard_data` tinyint(1) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_team_id_name_unq` (`team_id_char`,`name`),
   UNIQUE KEY `idx_name_team_id_unq` (`name`,`team_id_char`),


### PR DESCRIPTION
# Checklist for submitter

The implementation #13488 was wrong; we needed to have query results discarded by default, so customers shouldn't notice anything when they upgrade.

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
