### PR TITLE
trigger orbit build on version bump

### DIFF
--- a/.github/workflows/build-orbit.yaml
+++ b/.github/workflows/build-orbit.yaml
@@ -2,9 +2,15 @@ name: Build, Sign and Notarize Orbit for macOS
 
 on:
   workflow_dispatch: # allow manual action
+  push:
+    paths:
+      # The workflow can be triggered by modifying ORBIT_VERSION env.
+      - '.github/workflows/build-orbit.yml'
   pull_request:
     paths:
       - 'orbit/**.go'
+      # The workflow can be triggered by modifying ORBIT_VERSION env.
+      - '.github/workflows/build-orbit.yml'
 
 env:
   ORBIT_VERSION: 1.17.0

--- a/.github/workflows/build-orbit.yaml
+++ b/.github/workflows/build-orbit.yaml
@@ -5,12 +5,12 @@ on:
   push:
     paths:
       # The workflow can be triggered by modifying ORBIT_VERSION env.
-      - '.github/workflows/build-orbit.yml'
+      - '.github/workflows/build-orbit.yaml'
   pull_request:
     paths:
       - 'orbit/**.go'
       # The workflow can be triggered by modifying ORBIT_VERSION env.
-      - '.github/workflows/build-orbit.yml'
+      - '.github/workflows/build-orbit.yaml'
 
 env:
   ORBIT_VERSION: 1.17.0


### PR DESCRIPTION
The [goreleaser-orbit.yaml](https://github.com/fleetdm/fleet/actions/workflows/goreleaser-orbit.yaml) workflow tends to timeout up to 9-10 times before successfully building a macOS binary.

We have been using this workflow as a back-up, but it requires doing the version bump and manually triggering the workflow, which can be error prone.

This change follows the `workflows/generate-desktop-targets.yml` to trigger the workflow when the workflow file itself is modified.