### PR TITLE
Implement API changes for query reports

### DIFF
--- a/changes/13489-implement-api-changes
+++ b/changes/13489-implement-api-changes
@@ -1,0 +1,2 @@
+* Add `GET /api/_version_/fleet/queries/{id}/report` API endpoint to retrieve the stored results of a given query.
+* Add `discard_data` field to API query endpoints.

--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -14,14 +14,13 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/fleetdm/fleet/v4/pkg/secure"
-	kithttp "github.com/go-kit/kit/transport/http"
-	"gopkg.in/guregu/null.v3"
-
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/service"
 	"github.com/ghodss/yaml"
+	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v2"
+	"gopkg.in/guregu/null.v3"
 )
 
 const (
@@ -451,6 +450,7 @@ func getQueriesCommand() *cli.Command {
 							MinOsqueryVersion:  query.MinOsqueryVersion,
 							AutomationsEnabled: query.AutomationsEnabled,
 							Logging:            query.Logging,
+							DiscardData:        query.DiscardData,
 						}); err != nil {
 							return fmt.Errorf("unable to print query: %w", err)
 						}

--- a/cmd/fleetctl/get_test.go
+++ b/cmd/fleetctl/get_test.go
@@ -1129,6 +1129,7 @@ kind: query
 spec:
   automations_enabled: false
   description: some desc
+  discard_data: false
   interval: 0
   logging: ""
   min_osquery_version: ""
@@ -1143,6 +1144,7 @@ kind: query
 spec:
   automations_enabled: false
   description: some desc 2
+  discard_data: false
   interval: 0
   logging: ""
   min_osquery_version: ""
@@ -1157,6 +1159,7 @@ kind: query
 spec:
   automations_enabled: true
   description: some desc 4
+  discard_data: false
   interval: 60
   logging: differential_ignore_removals
   min_osquery_version: 5.3.0
@@ -1166,9 +1169,9 @@ spec:
   query: select 4;
   team: ""
 `
-	expectedJSONGlobal := `{"kind":"query","apiVersion":"v1","spec":{"name":"query1","description":"some desc","query":"select 1;","team":"","interval":0,"observer_can_run":false,"platform":"","min_osquery_version":"","automations_enabled":false,"logging":""}}
-{"kind":"query","apiVersion":"v1","spec":{"name":"query2","description":"some desc 2","query":"select 2;","team":"","interval":0,"observer_can_run":false,"platform":"","min_osquery_version":"","automations_enabled":false,"logging":""}}
-{"kind":"query","apiVersion":"v1","spec":{"name":"query4","description":"some desc 4","query":"select 4;","team":"","interval":60,"observer_can_run":true,"platform":"darwin,windows","min_osquery_version":"5.3.0","automations_enabled":true,"logging":"differential_ignore_removals"}}
+	expectedJSONGlobal := `{"kind":"query","apiVersion":"v1","spec":{"name":"query1","description":"some desc","query":"select 1;","team":"","interval":0,"observer_can_run":false,"platform":"","min_osquery_version":"","automations_enabled":false,"logging":"","discard_data":false}}
+{"kind":"query","apiVersion":"v1","spec":{"name":"query2","description":"some desc 2","query":"select 2;","team":"","interval":0,"observer_can_run":false,"platform":"","min_osquery_version":"","automations_enabled":false,"logging":"","discard_data":false}}
+{"kind":"query","apiVersion":"v1","spec":{"name":"query4","description":"some desc 4","query":"select 4;","team":"","interval":60,"observer_can_run":true,"platform":"darwin,windows","min_osquery_version":"5.3.0","automations_enabled":true,"logging":"differential_ignore_removals","discard_data":false}}
 `
 
 	expectedTeam := `+--------+-------------+-----------+--------+----------------------------+
@@ -1192,6 +1195,7 @@ kind: query
 spec:
   automations_enabled: false
   description: some desc 3
+  discard_data: false
   interval: 3600
   logging: snapshot
   min_osquery_version: 5.4.0
@@ -1201,7 +1205,7 @@ spec:
   query: select 3;
   team: Foobar
 `
-	expectedJSONTeam := `{"kind":"query","apiVersion":"v1","spec":{"name":"query3","description":"some desc 3","query":"select 3;","team":"Foobar","interval":3600,"observer_can_run":true,"platform":"darwin","min_osquery_version":"5.4.0","automations_enabled":false,"logging":"snapshot"}}
+	expectedJSONTeam := `{"kind":"query","apiVersion":"v1","spec":{"name":"query3","description":"some desc 3","query":"select 3;","team":"Foobar","interval":3600,"observer_can_run":true,"platform":"darwin","min_osquery_version":"5.4.0","automations_enabled":false,"logging":"snapshot","discard_data":false}}
 `
 
 	assert.Equal(t, expectedGlobal, runAppForTest(t, []string{"get", "queries"}))
@@ -1277,6 +1281,7 @@ kind: query
 spec:
   automations_enabled: false
   description: some desc
+  discard_data: false
   interval: 0
   logging: ""
   min_osquery_version: ""
@@ -1286,7 +1291,7 @@ spec:
   query: select 1;
   team: ""
 `
-	expectedJson := `{"kind":"query","apiVersion":"v1","spec":{"name":"globalQuery1","description":"some desc","query":"select 1;","team":"","interval":0,"observer_can_run":false,"platform":"","min_osquery_version":"","automations_enabled":false,"logging":""}}
+	expectedJson := `{"kind":"query","apiVersion":"v1","spec":{"name":"globalQuery1","description":"some desc","query":"select 1;","team":"","interval":0,"observer_can_run":false,"platform":"","min_osquery_version":"","automations_enabled":false,"logging":"","discard_data":false}}
 `
 
 	assert.Equal(t, expectedYaml, runAppForTest(t, []string{"get", "query", "globalQuery1"}))
@@ -1299,6 +1304,7 @@ kind: query
 spec:
   automations_enabled: true
   description: some team desc
+  discard_data: false
   interval: 3600
   logging: differential
   min_osquery_version: 5.2.0
@@ -1308,7 +1314,7 @@ spec:
   query: select 2;
   team: Foobar
 `
-	expectedJson = `{"kind":"query","apiVersion":"v1","spec":{"name":"teamQuery1","description":"some team desc","query":"select 2;","team":"Foobar","interval":3600,"observer_can_run":true,"platform":"linux","min_osquery_version":"5.2.0","automations_enabled":true,"logging":"differential"}}
+	expectedJson = `{"kind":"query","apiVersion":"v1","spec":{"name":"teamQuery1","description":"some team desc","query":"select 2;","team":"Foobar","interval":3600,"observer_can_run":true,"platform":"linux","min_osquery_version":"5.2.0","automations_enabled":true,"logging":"differential","discard_data":false}}
 `
 
 	assert.Equal(t, expectedYaml, runAppForTest(t, []string{"get", "query", "--team", "1", "teamQuery1"}))
@@ -1433,6 +1439,7 @@ kind: query
 spec:
   automations_enabled: false
   description: some desc 2
+  discard_data: false
   interval: 0
   logging: ""
   min_osquery_version: ""
@@ -1442,7 +1449,7 @@ spec:
   query: select 2;
   team: ""
 `
-			expectedJson := `{"kind":"query","apiVersion":"v1","spec":{"name":"query2","description":"some desc 2","query":"select 2;","team":"","interval":0,"observer_can_run":true,"platform":"","min_osquery_version":"","automations_enabled":false,"logging":""}}
+			expectedJson := `{"kind":"query","apiVersion":"v1","spec":{"name":"query2","description":"some desc 2","query":"select 2;","team":"","interval":0,"observer_can_run":true,"platform":"","min_osquery_version":"","automations_enabled":false,"logging":"","discard_data":false}}
 `
 
 			assert.Equal(t, expected, runAppForTest(t, []string{"get", "queries"}))
@@ -1510,6 +1517,7 @@ kind: query
 spec:
   automations_enabled: false
   description: some desc
+  discard_data: false
   interval: 0
   logging: ""
   min_osquery_version: ""
@@ -1524,6 +1532,7 @@ kind: query
 spec:
   automations_enabled: false
   description: some desc 2
+  discard_data: false
   interval: 0
   logging: ""
   min_osquery_version: ""
@@ -1538,6 +1547,7 @@ kind: query
 spec:
   automations_enabled: false
   description: some desc 3
+  discard_data: false
   interval: 0
   logging: ""
   min_osquery_version: ""
@@ -1547,9 +1557,9 @@ spec:
   query: select 3;
   team: ""
 `
-	expectedJson := `{"kind":"query","apiVersion":"v1","spec":{"name":"query1","description":"some desc","query":"select 1;","team":"","interval":0,"observer_can_run":false,"platform":"","min_osquery_version":"","automations_enabled":false,"logging":""}}
-{"kind":"query","apiVersion":"v1","spec":{"name":"query2","description":"some desc 2","query":"select 2;","team":"","interval":0,"observer_can_run":true,"platform":"","min_osquery_version":"","automations_enabled":false,"logging":""}}
-{"kind":"query","apiVersion":"v1","spec":{"name":"query3","description":"some desc 3","query":"select 3;","team":"","interval":0,"observer_can_run":false,"platform":"","min_osquery_version":"","automations_enabled":false,"logging":""}}
+	expectedJson := `{"kind":"query","apiVersion":"v1","spec":{"name":"query1","description":"some desc","query":"select 1;","team":"","interval":0,"observer_can_run":false,"platform":"","min_osquery_version":"","automations_enabled":false,"logging":"","discard_data":false}}
+{"kind":"query","apiVersion":"v1","spec":{"name":"query2","description":"some desc 2","query":"select 2;","team":"","interval":0,"observer_can_run":true,"platform":"","min_osquery_version":"","automations_enabled":false,"logging":"","discard_data":false}}
+{"kind":"query","apiVersion":"v1","spec":{"name":"query3","description":"some desc 3","query":"select 3;","team":"","interval":0,"observer_can_run":false,"platform":"","min_osquery_version":"","automations_enabled":false,"logging":"","discard_data":false}}
 `
 
 	assert.Equal(t, expected, runAppForTest(t, []string{"get", "queries"}))

--- a/cmd/fleetctl/testdata/convert_output.yml
+++ b/cmd/fleetctl/testdata/convert_output.yml
@@ -4,6 +4,7 @@ kind: query
 spec:
   automations_enabled: false
   description: Retrieves the list of application scheme/protocol-based IPC handlers.
+  discard_data: false
   interval: 86400
   logging: ""
   min_osquery_version: 1.4.7
@@ -18,6 +19,7 @@ kind: query
 spec:
   automations_enabled: false
   description: Retrieves the current disk encryption status for the target system.
+  discard_data: false
   interval: 86400
   logging: ""
   min_osquery_version: 1.4.5
@@ -32,6 +34,7 @@ kind: query
 spec:
   automations_enabled: false
   description: Retrieves the current disk encryption status for the target system.
+  discard_data: false
   interval: 300
   logging: ""
   min_osquery_version: 1.4.5
@@ -46,6 +49,7 @@ kind: query
 spec:
   automations_enabled: false
   description: Retrieve basic information about the physical disks of a system.
+  discard_data: false
   interval: 86400
   logging: ""
   min_osquery_version: 1.4.7
@@ -60,6 +64,7 @@ kind: query
 spec:
   automations_enabled: false
   description: Retrieves the current filters and chains per filter in the target system.
+  discard_data: false
   interval: 3600
   logging: ""
   min_osquery_version: 1.4.5
@@ -76,6 +81,7 @@ spec:
   description:
     Retrieves all the daemons that will run in the start of the target
     OSX system.
+  discard_data: false
   interval: 3600
   logging: ""
   min_osquery_version: 1.4.5
@@ -90,6 +96,7 @@ kind: query
 spec:
   automations_enabled: false
   description: Retrieves the list of listening ports.
+  discard_data: false
   interval: 3600
   logging: ""
   min_osquery_version: 1.4.7
@@ -104,6 +111,7 @@ kind: query
 spec:
   automations_enabled: false
   description: Retrieves the list of listening ports.
+  discard_data: false
   interval: 3600
   logging: ""
   min_osquery_version: 1.4.7
@@ -118,6 +126,7 @@ kind: query
 spec:
   automations_enabled: false
   description: Lists the application bundle that owns a sandbox label.
+  discard_data: false
   interval: 86400
   logging: ""
   min_osquery_version: 1.4.7
@@ -132,6 +141,7 @@ kind: query
 spec:
   automations_enabled: false
   description: System resource usage limits.
+  discard_data: false
   interval: 300
   logging: ""
   min_osquery_version: 1.4.7
@@ -146,6 +156,7 @@ kind: query
 spec:
   automations_enabled: false
   description: System uptime.
+  discard_data: false
   interval: 600
   logging: ""
   min_osquery_version: 1.4.7
@@ -160,6 +171,7 @@ kind: query
 spec:
   automations_enabled: false
   description: System uptime.
+  discard_data: false
   interval: 600
   logging: ""
   min_osquery_version: 1.4.7
@@ -174,6 +186,7 @@ kind: query
 spec:
   automations_enabled: false
   description: System uptime.
+  discard_data: false
   interval: 600
   logging: ""
   min_osquery_version: 1.4.7
@@ -188,6 +201,7 @@ kind: query
 spec:
   automations_enabled: false
   description: System uptime.
+  discard_data: false
   interval: 600
   logging: ""
   min_osquery_version: 1.4.7
@@ -202,6 +216,7 @@ kind: query
 spec:
   automations_enabled: false
   description: Lists the application bundle that owns a sandbox label.
+  discard_data: false
   interval: 86400
   logging: ""
   min_osquery_version: 1.4.7
@@ -216,6 +231,7 @@ kind: query
 spec:
   automations_enabled: false
   description: List of all user groups.
+  discard_data: false
   interval: 3600
   logging: ""
   min_osquery_version: 1.4.7
@@ -230,6 +246,7 @@ kind: query
 spec:
   automations_enabled: false
   description: List of all user groups.
+  discard_data: false
   interval: 3600
   logging: ""
   min_osquery_version: 1.4.7
@@ -244,6 +261,7 @@ kind: query
 spec:
   automations_enabled: false
   description: List of all user groups.
+  discard_data: false
   interval: 3600
   logging: ""
   min_osquery_version: 1.4.7
@@ -258,6 +276,7 @@ kind: query
 spec:
   automations_enabled: false
   description: List of all user groups.
+  discard_data: false
   interval: 3600
   logging: ""
   min_osquery_version: ""
@@ -272,6 +291,7 @@ kind: query
 spec:
   automations_enabled: false
   description: List of all user groups.
+  discard_data: false
   interval: 3600
   logging: ""
   min_osquery_version: 1.4.7
@@ -286,6 +306,7 @@ kind: query
 spec:
   automations_enabled: false
   description: List of all user groups.
+  discard_data: false
   interval: 3600
   logging: ""
   min_osquery_version: 1.4.7
@@ -300,6 +321,7 @@ kind: query
 spec:
   automations_enabled: false
   description: List of all user groups.
+  discard_data: false
   interval: 3600
   logging: ""
   min_osquery_version: ""
@@ -314,6 +336,7 @@ kind: query
 spec:
   automations_enabled: false
   description: List of all user groups.
+  discard_data: false
   interval: 3600
   logging: ""
   min_osquery_version: 1.4.7
@@ -328,6 +351,7 @@ kind: query
 spec:
   automations_enabled: false
   description: Extracted information from Windows crash logs (Minidumps).
+  discard_data: false
   interval: 3600
   logging: ""
   min_osquery_version: 1.4.7
@@ -344,6 +368,7 @@ spec:
   description:
     Triggers one-off YARA query for files at the specified path. Requires
     one of sig_group, sigfile, or sigrule.
+  discard_data: false
   interval: 0
   logging: ""
   min_osquery_version: 1.4.7

--- a/cmd/fleetctl/testdata/expectedGetConfigAppConfigJson.json
+++ b/cmd/fleetctl/testdata/expectedGetConfigAppConfigJson.json
@@ -11,6 +11,7 @@
     "server_settings": {
       "server_url": "",
       "live_query_disabled": false,
+      "query_reports_disabled": false,
       "enable_analytics": false,
       "deferred_save_host": false
     },

--- a/cmd/fleetctl/testdata/expectedGetConfigAppConfigYaml.yml
+++ b/cmd/fleetctl/testdata/expectedGetConfigAppConfigYaml.yml
@@ -48,6 +48,7 @@ spec:
     deferred_save_host: false
     enable_analytics: false
     live_query_disabled: false
+    query_reports_disabled: false
     server_url: ""
   smtp_settings:
     authentication_method: ""

--- a/cmd/fleetctl/testdata/expectedGetConfigIncludeServerConfigJson.json
+++ b/cmd/fleetctl/testdata/expectedGetConfigIncludeServerConfigJson.json
@@ -11,6 +11,7 @@
     "server_settings": {
       "server_url": "",
       "live_query_disabled": false,
+      "query_reports_disabled": false,
       "enable_analytics": false,
       "deferred_save_host": false
     },

--- a/cmd/fleetctl/testdata/expectedGetConfigIncludeServerConfigYaml.yml
+++ b/cmd/fleetctl/testdata/expectedGetConfigIncludeServerConfigYaml.yml
@@ -87,6 +87,7 @@ spec:
     deferred_save_host: false
     enable_analytics: false
     live_query_disabled: false
+    query_reports_disabled: false
     server_url: ""
   smtp_settings:
     authentication_method: ""

--- a/cmd/fleetctl/testdata/macosSetupExpectedAppConfigEmpty.yml
+++ b/cmd/fleetctl/testdata/macosSetupExpectedAppConfigEmpty.yml
@@ -48,6 +48,7 @@ spec:
     deferred_save_host: false
     enable_analytics: false
     live_query_disabled: false
+    query_reports_disabled: false
     server_url: https://example.org
   smtp_settings:
     authentication_method: ""

--- a/cmd/fleetctl/testdata/macosSetupExpectedAppConfigSet.yml
+++ b/cmd/fleetctl/testdata/macosSetupExpectedAppConfigSet.yml
@@ -48,6 +48,7 @@ spec:
     deferred_save_host: false
     enable_analytics: false
     live_query_disabled: false
+    query_reports_disabled: false
     server_url: https://example.org
   smtp_settings:
     authentication_method: ""

--- a/cmd/fleetctl/upgrade_packs_test.go
+++ b/cmd/fleetctl/upgrade_packs_test.go
@@ -255,7 +255,7 @@ func TestFleetctlUpgradePacks_EmptyPacks(t *testing.T) {
 	outputFile := filepath.Join(tempDir, "output.yml")
 
 	// write some dummy data in the file, it should be overwritten
-	err := os.WriteFile(outputFile, []byte("dummy"), 0644)
+	err := os.WriteFile(outputFile, []byte("dummy"), 0o644)
 	require.NoError(t, err)
 
 	got := runAppForTest(t, []string{"upgrade-packs", "-o", outputFile})
@@ -328,6 +328,7 @@ kind: query
 spec:
   automations_enabled: false
   description: (converted from pack "p1", query "q1")
+  discard_data: false
   interval: 0
   logging: snapshot
   min_osquery_version: ""
@@ -342,6 +343,7 @@ kind: query
 spec:
   automations_enabled: true
   description: (converted from pack "p2", query "q2")
+  discard_data: false
   interval: 90
   logging: differential
   min_osquery_version: ""
@@ -356,6 +358,7 @@ kind: query
 spec:
   automations_enabled: true
   description: (converted from pack "p2", query "q2")
+  discard_data: false
   interval: 90
   logging: differential
   min_osquery_version: ""
@@ -371,7 +374,7 @@ spec:
 	outputFile := filepath.Join(tempDir, "output.yml")
 
 	// write some dummy data in the file, it should be overwritten
-	err := os.WriteFile(outputFile, []byte("dummy"), 0644)
+	err := os.WriteFile(outputFile, []byte("dummy"), 0o644)
 	require.NoError(t, err)
 
 	testUpgradePacksTimestamp = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -394,7 +397,7 @@ func TestFleetctlUpgradePacks_NotAdmin(t *testing.T) {
 	outputFile := filepath.Join(tempDir, "output.yml")
 
 	// write some dummy data in the file, it should NOT be overwritten
-	err := os.WriteFile(outputFile, []byte("dummy"), 0644)
+	err := os.WriteFile(outputFile, []byte("dummy"), 0o644)
 	require.NoError(t, err)
 
 	// first try without the required output file flag
@@ -422,7 +425,7 @@ func TestFleetctlUpgradePacks_NoPack(t *testing.T) {
 	outputFile := filepath.Join(tempDir, "output.yml")
 
 	// write some dummy data in the file, it should NOT be overwritten
-	err := os.WriteFile(outputFile, []byte("dummy"), 0644)
+	err := os.WriteFile(outputFile, []byte("dummy"), 0o644)
 	require.NoError(t, err)
 
 	got := runAppForTest(t, []string{"upgrade-packs", "-o", outputFile})

--- a/server/datastore/mysql/queries_test.go
+++ b/server/datastore/mysql/queries_test.go
@@ -59,6 +59,7 @@ func testQueriesApply(t *testing.T, ds *Datastore) {
 			MinOsqueryVersion:  "5.2.1",
 			AutomationsEnabled: true,
 			Logging:            "differential",
+			DiscardData:        true,
 		},
 		{
 			Name:        "bar",
@@ -88,6 +89,7 @@ func testQueriesApply(t *testing.T, ds *Datastore) {
 	// Victor modifies a query (but also pushes the same version of the
 	// first query)
 	expectedQueries[1].Query = "not really a valid query ;)"
+	expectedQueries[1].DiscardData = true
 	err = ds.ApplyQueries(context.Background(), groob.ID, expectedQueries)
 	require.NoError(t, err)
 

--- a/server/datastore/mysql/query_results_test.go
+++ b/server/datastore/mysql/query_results_test.go
@@ -110,7 +110,7 @@ func getQueryResultRows(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// Assert that Query1 returns 2 results
-	results, err := ds.QueryResultRows(context.Background(), resultRows[0].QueryID, resultRows[0].HostID)
+	results, err := ds.QueryResultRowsForHost(context.Background(), resultRows[0].QueryID, resultRows[0].HostID)
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 	require.Equal(t, resultRows[0].QueryID, results[0].QueryID)
@@ -123,7 +123,7 @@ func getQueryResultRows(t *testing.T, ds *Datastore) {
 	require.JSONEq(t, string(resultRows[1].Data), string(results[1].Data))
 
 	// Assert that Query2 returns 1 result
-	results, err = ds.QueryResultRows(context.Background(), resultRow3[0].QueryID, resultRow3[0].HostID)
+	results, err = ds.QueryResultRowsForHost(context.Background(), resultRow3[0].QueryID, resultRow3[0].HostID)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.Equal(t, resultRow3[0].QueryID, results[0].QueryID)
@@ -132,7 +132,7 @@ func getQueryResultRows(t *testing.T, ds *Datastore) {
 	require.JSONEq(t, string(resultRow3[0].Data), string(results[0].Data))
 
 	// Assert that QueryResultRows returns empty slice when no results are found
-	results, err = ds.QueryResultRows(context.Background(), 999, 999)
+	results, err = ds.QueryResultRowsForHost(context.Background(), 999, 999)
 	require.NoError(t, err)
 	require.Len(t, results, 0)
 }
@@ -188,12 +188,12 @@ func testDeleteQueryResultsForHost(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// Assert that Query1 returns 0 results
-	results, err := ds.QueryResultRows(context.Background(), query.ID, host.ID)
+	results, err := ds.QueryResultRowsForHost(context.Background(), query.ID, host.ID)
 	require.NoError(t, err)
 	require.Len(t, results, 0)
 
 	// Assert that Query2 returns 1 result
-	results, err = ds.QueryResultRows(context.Background(), query2.ID, host.ID)
+	results, err = ds.QueryResultRowsForHost(context.Background(), query2.ID, host.ID)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.Equal(t, resultRow3[0].QueryID, results[0].QueryID)
@@ -364,7 +364,7 @@ func testOverwriteQueryResultRows(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// Assert that we get the overwritten data (1 result with USB Mouse data)
-	results, err := ds.QueryResultRows(context.Background(), overwriteRows[0].QueryID, overwriteRows[0].HostID)
+	results, err := ds.QueryResultRowsForHost(context.Background(), overwriteRows[0].QueryID, overwriteRows[0].HostID)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.Equal(t, overwriteRows[0].QueryID, results[0].QueryID)
@@ -373,7 +373,7 @@ func testOverwriteQueryResultRows(t *testing.T, ds *Datastore) {
 	require.JSONEq(t, string(overwriteRows[0].Data), string(results[0].Data))
 
 	// Assert that QueryResultRows returns empty slice when no results are found
-	results, err = ds.QueryResultRows(context.Background(), 999, 999)
+	results, err = ds.QueryResultRowsForHost(context.Background(), 999, 999)
 	require.NoError(t, err)
 	require.Len(t, results, 0)
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -393,9 +393,16 @@ type Datastore interface {
 
 	///////////////////////////////////////////////////////////////////////////////
 	// QueryResultsStore
+
+	// SaveQueryResultRow stores the given schedule query results.
 	SaveQueryResultRows(ctx context.Context, rows []*ScheduledQueryResultRow) error
-	QueryResultRows(ctx context.Context, queryID, hostID uint) ([]*ScheduledQueryResultRow, error)
+	// QueryResultRowsForHost returns the stored results of a query of a specified host.
+	QueryResultRowsForHost(ctx context.Context, queryID, hostID uint) ([]*ScheduledQueryResultRow, error)
+	// QueryResultRows returns all the stored results of a query (from all hosts).
+	QueryResultRows(ctx context.Context, queryID uint) ([]*ScheduledQueryResultRow, error)
+	// DeleteQueryResultsForHost deletes the results of a query of a specified host.
 	DeleteQueryResultsForHost(ctx context.Context, hostID, queryID uint) error
+	// ResultCountForQuery returns the number of results stored of a query.
 	ResultCountForQuery(ctx context.Context, queryID uint) (int, error)
 	ResultCountForQueryAndHost(ctx context.Context, queryID, hostID uint) (int, error)
 	OverwriteQueryResultRows(ctx context.Context, rows []*ScheduledQueryResultRow) error

--- a/server/fleet/queries.go
+++ b/server/fleet/queries.go
@@ -1,6 +1,7 @@
 package fleet
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -36,6 +37,11 @@ type QueryPayload struct {
 	AutomationsEnabled *bool `json:"automations_enabled"`
 	// Logging is set to "snapshot" if not set when creating a query.
 	Logging *string `json:"logging"`
+	// DiscardData indicates if the scheduled query results should be discarded (true)
+	// or kept (false) in a query report.
+	//
+	// If not set during creation of a query, then the default value is false.
+	DiscardData *bool `json:"discard_data"`
 }
 
 // Query represents a osquery query to run on devices.
@@ -91,7 +97,8 @@ type Query struct {
 	//
 	// This field has null values if the query did not run as a schedule on any host.
 	AggregatedStats `json:"stats"`
-	// DiscardData indicates if the scheduled query results should be discarded (true) or kept (false) in a query report.
+	// DiscardData indicates if the scheduled query results should be discarded (true)
+	// or kept (false) in a query report.
 	DiscardData bool `json:"discard_data" db:"discard_data"`
 }
 
@@ -288,6 +295,11 @@ type QuerySpec struct {
 	AutomationsEnabled bool `json:"automations_enabled"`
 	// Logging is set to "snapshot" if not set.
 	Logging string `json:"logging"`
+	// DiscardData indicates if the scheduled query results should be discarded (true)
+	// or kept (false) in a query report.
+	//
+	// If not set, then the default value is false.
+	DiscardData bool `json:"discard_data"`
 }
 
 func LoadQueriesFromYaml(yml string) ([]*Query, error) {
@@ -356,4 +368,65 @@ type QueryStats struct {
 	SystemTime   int       `json:"system_time" db:"system_time"`
 	UserTime     int       `json:"user_time" db:"user_time"`
 	WallTime     int       `json:"wall_time" db:"wall_time"`
+}
+
+// MapQueryReportsResultsToRows converts the scheduled query results as stored in Fleet's database
+// to HostQueryResultRows to be exposed to the API.
+func MapQueryReportResultsToRows(rows []*ScheduledQueryResultRow) ([]HostQueryResultRow, error) {
+	var results []HostQueryResultRow
+	for _, row := range rows {
+		var columns map[string]string
+		if err := json.Unmarshal(row.Data, &columns); err != nil {
+			return nil, err
+		}
+		results = append(results, HostQueryResultRow{
+			HostID:      row.HostID,
+			Hostname:    row.Hostname,
+			LastFetched: row.LastFetched,
+			Columns:     columns,
+		})
+	}
+	return results, nil
+}
+
+// HostQueryResultRow contains a single scheduled query result row from a host.
+// This type is used to expose the results on the API.
+type HostQueryResultRow struct {
+	// HostID is the unique ID of the host.
+	HostID uint `json:"host_id"`
+	// Hostname is the host's hostname.
+	Hostname string `json:"host_name"`
+	// LastFetched is the time this result row was received.
+	LastFetched time.Time `json:"last_fetched"`
+	// Columns contains the key-value pairs of a result row.
+	// The map key is the name of the column, and the map value is the value.
+	Columns map[string]string `json:"columns"`
+}
+
+// ScheduledQueryResult holds results of a scheduled query received from a osquery agent.
+type ScheduledQueryResult struct {
+	// QueryName is the name of the query.
+	QueryName string `json:"name,omitempty"`
+	// OsqueryHostID is the identifier of the host.
+	OsqueryHostID string `json:"hostIdentifier"`
+	// Snapshot holds the result rows. It's an array of maps, where the map keys
+	// are column names and map values are the values.
+	Snapshot []json.RawMessage `json:"snapshot"`
+	// LastFetched is the time this result was received.
+	LastFetched uint `json:"unixTime"`
+}
+
+// ScheduledQueryResultRow is a scheduled query result row.
+type ScheduledQueryResultRow struct {
+	// QueryID is the unique identifier of the query.
+	QueryID uint `db:"query_id"`
+	// HostID is the unique identifier of the host.
+	HostID uint `db:"host_id"`
+	// Hostname is the host's hostname.
+	Hostname string `db:"hostname"`
+	// Data holds a single result row. It holds a map where the map keys
+	// are column names and map values are the values.
+	Data json.RawMessage `db:"data"`
+	// LastFetched is the time this result was received.
+	LastFetched time.Time `db:"last_fetched"`
 }

--- a/server/fleet/queries_test.go
+++ b/server/fleet/queries_test.go
@@ -1,7 +1,9 @@
 package fleet
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/stretchr/testify/assert"
@@ -208,5 +210,218 @@ func TestVerifyQueryPlatforms(t *testing.T) {
 				require.NoError(t, err)
 			}
 		})
+	}
+}
+
+func TestMapQueryReportResultRows(t *testing.T) {
+	macOSUSBDevicesLastFetched := time.Now()
+	ubuntuUSBDevicesLastFetched := time.Now().Add(-1 * time.Hour)
+	macOSOsqueryInfoLastFetched := time.Now().Add(-2 * time.Hour)
+	for _, tc := range []struct {
+		name       string
+		rows       []*ScheduledQueryResultRow
+		expected   []HostQueryResultRow
+		shouldFail bool
+	}{
+		{
+			name: "USB devices query with results from a macOS and Linux host",
+			rows: []*ScheduledQueryResultRow{
+				{
+					HostID:      1,
+					Hostname:    "macOS host",
+					LastFetched: macOSUSBDevicesLastFetched,
+					Data: json.RawMessage(`{
+						"class": "9",
+						"model": "AppleUSBVHCIBCE Root Hub Simulation",
+						"model_id": "8000",
+						"protocol": "",
+						"removable": "0",
+						"serial": "0",
+						"subclass": "255",
+						"usb_address": "",
+						"usb_port": "",
+						"vendor": "Apple Inc.",
+						"vendor_id": "05bc",
+						"version": "0.0"
+					}`),
+				},
+				{
+					HostID:      1,
+					Hostname:    "macOS host",
+					LastFetched: macOSUSBDevicesLastFetched,
+					Data: json.RawMessage(`{
+						"class": "9",
+						"model": "AppleUSBXHCI Root Hub Simulation",
+						"model_id": "8007",
+						"protocol": "",
+						"removable": "0",
+						"serial": "0",
+						"subclass": "255",
+						"usb_address": "",
+						"usb_port": "",
+						"vendor": "Apple Inc.",
+						"vendor_id": "05ac",
+						"version": "0.0"
+					}`),
+				},
+				{
+					HostID:      2,
+					Hostname:    "ubuntu host",
+					LastFetched: ubuntuUSBDevicesLastFetched,
+					Data: json.RawMessage(`{
+						"class": "9",
+						"model": "1.1 root hub",
+						"model_id": "0001",
+						"protocol": "0",
+						"removable": "-1",
+						"serial": "0000:02:00.0",
+						"subclass": "0",
+						"usb_address": "1",
+						"usb_port": "1",
+						"vendor": "Linux Foundation",
+						"vendor_id": "1d6b",
+						"version": "0602"
+					}`),
+				},
+			},
+			expected: []HostQueryResultRow{
+				{
+					HostID:      1,
+					Hostname:    "macOS host",
+					LastFetched: macOSUSBDevicesLastFetched,
+					Columns: map[string]string{
+						"class":       "9",
+						"model":       "AppleUSBVHCIBCE Root Hub Simulation",
+						"model_id":    "8000",
+						"protocol":    "",
+						"removable":   "0",
+						"serial":      "0",
+						"subclass":    "255",
+						"usb_address": "",
+						"usb_port":    "",
+						"vendor":      "Apple Inc.",
+						"vendor_id":   "05bc",
+						"version":     "0.0",
+					},
+				},
+				{
+					HostID:      1,
+					Hostname:    "macOS host",
+					LastFetched: macOSUSBDevicesLastFetched,
+					Columns: map[string]string{
+						"class":       "9",
+						"model":       "AppleUSBXHCI Root Hub Simulation",
+						"model_id":    "8007",
+						"protocol":    "",
+						"removable":   "0",
+						"serial":      "0",
+						"subclass":    "255",
+						"usb_address": "",
+						"usb_port":    "",
+						"vendor":      "Apple Inc.",
+						"vendor_id":   "05ac",
+						"version":     "0.0",
+					},
+				},
+				{
+					HostID:      2,
+					Hostname:    "ubuntu host",
+					LastFetched: ubuntuUSBDevicesLastFetched,
+					Columns: map[string]string{
+						"class":       "9",
+						"model":       "1.1 root hub",
+						"model_id":    "0001",
+						"protocol":    "0",
+						"removable":   "-1",
+						"serial":      "0000:02:00.0",
+						"subclass":    "0",
+						"usb_address": "1",
+						"usb_port":    "1",
+						"vendor":      "Linux Foundation",
+						"vendor_id":   "1d6b",
+						"version":     "0602",
+					},
+				},
+			},
+			shouldFail: false,
+		},
+		{
+			name: "macOS osquery_info result",
+			rows: []*ScheduledQueryResultRow{
+				{
+					HostID:      1,
+					Hostname:    "macOS host",
+					LastFetched: macOSOsqueryInfoLastFetched,
+					Data: json.RawMessage(`{
+						"build_distro": "10.14",
+						"build_platform": "darwin",
+						"config_hash": "eed0d8296e5f90b790a23814a9db7a127b13498d",
+						"config_valid": "1",
+						"extensions": "active",
+						"instance_id": "7f02ff0f-f8a7-4ba9-a1d2-66836b154f4a",
+						"pid": "96730",
+						"platform_mask": "21",
+						"start_time": "1696421866",
+						"uuid": "589966AE-074A-503B-B17B-54B05684A120",
+						"version": "5.9.1",
+						"watcher": "96729"
+					}`),
+				},
+			},
+			expected: []HostQueryResultRow{
+				{
+					HostID:      1,
+					Hostname:    "macOS host",
+					LastFetched: macOSOsqueryInfoLastFetched,
+					Columns: map[string]string{
+						"build_distro":   "10.14",
+						"build_platform": "darwin",
+						"config_hash":    "eed0d8296e5f90b790a23814a9db7a127b13498d",
+						"config_valid":   "1",
+						"extensions":     "active",
+						"instance_id":    "7f02ff0f-f8a7-4ba9-a1d2-66836b154f4a",
+						"pid":            "96730",
+						"platform_mask":  "21",
+						"start_time":     "1696421866",
+						"uuid":           "589966AE-074A-503B-B17B-54B05684A120",
+						"version":        "5.9.1",
+						"watcher":        "96729",
+					},
+				},
+			},
+			shouldFail: false,
+		},
+		{
+			name: "invalid JSON result",
+			rows: []*ScheduledQueryResultRow{
+				{
+					HostID:      3,
+					Hostname:    "bar",
+					LastFetched: time.Now(),
+					Data:        json.RawMessage(`invalid JSON`),
+				},
+			},
+			shouldFail: true,
+		},
+		{
+			name: "invalid item value type",
+			rows: []*ScheduledQueryResultRow{
+				{
+					HostID:      3,
+					Hostname:    "bar",
+					LastFetched: time.Now(),
+					Data:        json.RawMessage(`{"foobar": 1}`),
+				},
+			},
+			shouldFail: true,
+		},
+	} {
+		results, err := MapQueryReportResultsToRows(tc.rows)
+		if !tc.shouldFail {
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, results)
+		} else {
+			require.Error(t, err)
+		}
 	}
 }

--- a/server/fleet/scheduled_queries.go
+++ b/server/fleet/scheduled_queries.go
@@ -1,7 +1,6 @@
 package fleet
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -87,20 +86,6 @@ func (sql ScheduledQueryList) Clone() (interface{}, error) {
 		cloned = append(cloned, &newSq)
 	}
 	return cloned, nil
-}
-
-type ScheduledQueryResult struct {
-	QueryName     string            `json:"name,omitempty"`
-	OsqueryHostID string            `json:"hostIdentifier"`
-	Snapshot      []json.RawMessage `json:"snapshot"`
-	LastFetched   uint              `json:"unixTime"`
-}
-
-type ScheduledQueryResultRow struct {
-	QueryID     uint            `db:"query_id"`
-	HostID      uint            `db:"host_id"`
-	Data        json.RawMessage `db:"data"`
-	LastFetched time.Time       `db:"last_fetched"`
 }
 
 type AggregatedStats struct {

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -268,6 +268,8 @@ type Service interface {
 	// and only non-scheduled queries will be returned if `*scheduled == false`.
 	ListQueries(ctx context.Context, opt ListOptions, teamID *uint, scheduled *bool) ([]*Query, error)
 	GetQuery(ctx context.Context, id uint) (*Query, error)
+	// GetQueryReportResults returns all the stored results of a query.
+	GetQueryReportResults(ctx context.Context, id uint) ([]HostQueryResultRow, error)
 	NewQuery(ctx context.Context, p QueryPayload) (*Query, error)
 	ModifyQuery(ctx context.Context, id uint, p QueryPayload) (*Query, error)
 	DeleteQuery(ctx context.Context, teamID *uint, name string) error

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -338,6 +338,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 
 	ue.GET("/api/_version_/fleet/queries/{id:[0-9]+}", getQueryEndpoint, getQueryRequest{})
 	ue.GET("/api/_version_/fleet/queries", listQueriesEndpoint, listQueriesRequest{})
+	ue.GET("/api/_version_/fleet/queries/{id:[0-9]+}/report", getQueryReportEndpoint, getQueryReportRequest{})
 	ue.POST("/api/_version_/fleet/queries", createQueryEndpoint, createQueryRequest{})
 	ue.PATCH("/api/_version_/fleet/queries/{id:[0-9]+}", modifyQueryEndpoint, modifyQueryRequest{})
 	ue.DELETE("/api/_version_/fleet/queries/{name}", deleteQueryEndpoint, deleteQueryRequest{})

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -1898,21 +1898,26 @@ func (s *integrationEnterpriseTestSuite) TestListDevicePolicies() {
 
 	// try with invalid token
 	res := s.DoRawNoAuth("GET", "/api/latest/fleet/device/invalid_token/policies", nil, http.StatusUnauthorized)
-	res.Body.Close()
+	err = res.Body.Close()
+	require.NoError(t, err)
 
 	// GET `/api/_version_/fleet/device/{token}/policies`
 	listDevicePoliciesResp := listDevicePoliciesResponse{}
 	res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/policies", nil, http.StatusOK)
-	json.NewDecoder(res.Body).Decode(&listDevicePoliciesResp) //nolint:errcheck
-	res.Body.Close()                                          //nolint:errcheck
+	err = json.NewDecoder(res.Body).Decode(&listDevicePoliciesResp)
+	require.NoError(t, err)
+	err = res.Body.Close()
+	require.NoError(t, err)
 	require.Len(t, listDevicePoliciesResp.Policies, 2)
 	require.NoError(t, listDevicePoliciesResp.Err)
 
 	// GET `/api/_version_/fleet/device/{token}`
 	getDeviceHostResp := getDeviceHostResponse{}
 	res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token, nil, http.StatusOK)
-	json.NewDecoder(res.Body).Decode(&getDeviceHostResp) //nolint:errcheck
-	res.Body.Close()                                     //nolint:errcheck
+	err = json.NewDecoder(res.Body).Decode(&getDeviceHostResp)
+	require.NoError(t, err)
+	err = res.Body.Close()
+	require.NoError(t, err)
 	require.NoError(t, getDeviceHostResp.Err)
 	require.Equal(t, host.ID, getDeviceHostResp.Host.ID)
 	require.False(t, getDeviceHostResp.Host.RefetchRequested)
@@ -1922,8 +1927,10 @@ func (s *integrationEnterpriseTestSuite) TestListDevicePolicies() {
 	// GET `/api/_version_/fleet/device/{token}/desktop`
 	getDesktopResp := fleetDesktopResponse{}
 	res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/desktop", nil, http.StatusOK)
-	require.NoError(t, json.NewDecoder(res.Body).Decode(&getDesktopResp))
-	require.NoError(t, res.Body.Close())
+	err = json.NewDecoder(res.Body).Decode(&getDesktopResp)
+	require.NoError(t, err)
+	err = res.Body.Close()
+	require.NoError(t, err)
 	require.NoError(t, getDesktopResp.Err)
 	require.Equal(t, *getDesktopResp.FailingPolicies, uint(1))
 	require.False(t, getDesktopResp.Notifications.NeedsMDMMigration)

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -1359,7 +1359,7 @@ func submitLogsEndpoint(ctx context.Context, request interface{}, svc fleet.Serv
 	switch req.LogType {
 	case "status":
 		var statuses []json.RawMessage
-		if err := json.Unmarshal(req.Data, &statuses); err != nil {
+		if err = json.Unmarshal(req.Data, &statuses); err != nil {
 			err = newOsqueryError("unmarshalling status logs: " + err.Error())
 			break
 		}
@@ -1371,7 +1371,7 @@ func submitLogsEndpoint(ctx context.Context, request interface{}, svc fleet.Serv
 
 	case "result":
 		var results []json.RawMessage
-		if err := json.Unmarshal(req.Data, &results); err != nil {
+		if err = json.Unmarshal(req.Data, &results); err != nil {
 			err = newOsqueryError("unmarshalling result logs: " + err.Error())
 			break
 		}

--- a/server/service/queries.go
+++ b/server/service/queries.go
@@ -123,6 +123,56 @@ func onlyShowObserverCanRunQueries(user *fleet.User, teamID *uint) bool {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Get query report
+////////////////////////////////////////////////////////////////////////////////
+
+type getQueryReportRequest struct {
+	ID uint `url:"id"`
+}
+
+type getQueryReportResponse struct {
+	QueryID uint                       `json:"query_id"`
+	Results []fleet.HostQueryResultRow `json:"results"`
+	Err     error                      `json:"error,omitempty"`
+}
+
+func (r getQueryReportResponse) error() error { return r.Err }
+
+func getQueryReportEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (errorer, error) {
+	req := request.(*getQueryReportRequest)
+	queryReportResults, err := svc.GetQueryReportResults(ctx, req.ID)
+	if err != nil {
+		return listQueriesResponse{Err: err}, nil
+	}
+	return getQueryReportResponse{
+		QueryID: req.ID,
+		Results: queryReportResults,
+	}, nil
+}
+
+func (svc *Service) GetQueryReportResults(ctx context.Context, id uint) ([]fleet.HostQueryResultRow, error) {
+	// Load query first to get its teamID.
+	query, err := svc.ds.Query(ctx, id)
+	if err != nil {
+		setAuthCheckedOnPreAuthErr(ctx)
+		return nil, ctxerr.Wrap(ctx, err, "get query from datastore")
+	}
+	if err := svc.authz.Authorize(ctx, query, fleet.ActionRead); err != nil {
+		return nil, err
+	}
+
+	queryReportResultRows, err := svc.ds.QueryResultRows(ctx, id)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get query report results")
+	}
+	queryReportResults, err := fleet.MapQueryReportResultsToRows(queryReportResultRows)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "map db rows to results")
+	}
+	return queryReportResults, nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Create Query
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -192,6 +242,9 @@ func (svc *Service) NewQuery(ctx context.Context, p fleet.QueryPayload) (*fleet.
 	}
 	if p.ObserverCanRun != nil {
 		query.ObserverCanRun = *p.ObserverCanRun
+	}
+	if p.DiscardData != nil {
+		query.DiscardData = *p.DiscardData
 	}
 
 	logging.WithExtras(ctx, "name", query.Name, "sql", query.Query)
@@ -290,6 +343,9 @@ func (svc *Service) ModifyQuery(ctx context.Context, id uint, p fleet.QueryPaylo
 	}
 	if p.ObserverCanRun != nil {
 		query.ObserverCanRun = *p.ObserverCanRun
+	}
+	if p.DiscardData != nil {
+		query.DiscardData = *p.DiscardData
 	}
 
 	logging.WithExtras(ctx, "name", query.Name, "sql", query.Query)
@@ -560,6 +616,7 @@ func (svc *Service) queryFromSpec(ctx context.Context, spec *fleet.QuerySpec) (*
 		MinOsqueryVersion:  spec.MinOsqueryVersion,
 		AutomationsEnabled: spec.AutomationsEnabled,
 		Logging:            spec.Logging,
+		DiscardData:        spec.DiscardData,
 	}, nil
 }
 
@@ -630,6 +687,7 @@ func (svc *Service) specFromQuery(ctx context.Context, query *fleet.Query) (*fle
 		MinOsqueryVersion:  query.MinOsqueryVersion,
 		AutomationsEnabled: query.AutomationsEnabled,
 		Logging:            query.Logging,
+		DiscardData:        query.DiscardData,
 	}, nil
 }
 


### PR DESCRIPTION
#13489

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [X] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- ~[ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)~
- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [X] Added/updated tests
- [X] Manual QA for all new/changed functionality
  - ~For Orbit and Fleet Desktop changes:~
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
