### PR TITLE
Fix vuln scans terraform addon

### DIFF
--- a/terraform/addons/external-vuln-scans/main.tf
+++ b/terraform/addons/external-vuln-scans/main.tf
@@ -10,7 +10,7 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "Service"
-      identifiers = ["events.amazonaws.com"]
+      identifiers = ["events.amazonaws.com", "ecs-tasks.amazonaws.com"]
     }
 
     actions = ["sts:AssumeRole"]
@@ -32,6 +32,11 @@ data "aws_iam_policy_document" "ecs_events_run_task_with_any_role" {
     effect    = "Allow"
     actions   = ["ecs:RunTask"]
     resources = [replace(var.task_definition.arn, "/:\\d+$/", ":*")]
+    condition {
+      test     = "ArnEquals"
+      values   = [var.ecs_cluster.cluster_arn]
+      variable = "ecs:cluster"
+    }
   }
 }
 resource "aws_iam_role_policy" "ecs_events_run_task_with_any_role" {


### PR DESCRIPTION
🐛 fix(main.tf): add ecs-tasks.amazonaws.com as an identifier in the assume_role policy document to allow ECS tasks to assume the role

✨ feat(main.tf): add condition to the ecs_events_run_task_with_any_role policy document to restrict running tasks to a specific ECS cluster

