### PR TITLE
Handle RPM upgrade in %postun script

### DIFF
--- a/orbit/changes/14380-rpm-graceful-upgrade
+++ b/orbit/changes/14380-rpm-graceful-upgrade
@@ -1,0 +1,1 @@
+* Add a conditional check in the %postun script to prevent file deletion during RPM upgrade. The check ensures that files and directories are only removed during a full uninstall ( equals 0), safeguarding necessary files from unintended deletion during an upgrade.

--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -364,7 +364,9 @@ pkill fleet-desktop || true
 func writePostRemove(opt Options, path string) error {
 	if err := ioutil.WriteFile(path, []byte(`#!/bin/sh
 
-rm -rf /var/lib/orbit /var/log/orbit /usr/local/bin/orbit /etc/default/orbit /usr/lib/systemd/system/orbit.service /opt/orbit
+if [ "$1" = 0 ]; then
+	rm -rf /var/lib/orbit /var/log/orbit /usr/local/bin/orbit /etc/default/orbit /usr/lib/systemd/system/orbit.service /opt/orbit
+fi
 `), constant.DefaultFileMode); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}

--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -364,7 +364,9 @@ pkill fleet-desktop || true
 func writePostRemove(opt Options, path string) error {
 	if err := ioutil.WriteFile(path, []byte(`#!/bin/sh
 
-if [ "$1" = 0 ]; then
+# For RPM during uninstall, $1 is 0
+# For Debian during remove, $1 is "remove"
+if [ "$1" = 0 ] || [ "$1" = "remove" ]; then
 	rm -rf /var/lib/orbit /var/log/orbit /usr/local/bin/orbit /etc/default/orbit /usr/lib/systemd/system/orbit.service /opt/orbit
 fi
 `), constant.DefaultFileMode); err != nil {


### PR DESCRIPTION
This pull request addresses a key aspect of the RPM upgrade process - handling of scripts during upgrades vice pure deletion events.

An RPM upgrade operation consists of both an Install and an Uninstall operation, meaning that during an upgrade, our %postun script is run and previously, it was causing the accidental deletion of binaries needed for the upgrade.

To prevent this unwanted removal during upgrade scenarios, the %postun script now checks for the execution scenario in which it finds itself.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
