### PR TITLE
Fleet UI: [fix] SQL editor remove multiple cursor functionality

### DIFF
--- a/changes/bug-11314-disable-multicursor-editor
+++ b/changes/bug-11314-disable-multicursor-editor
@@ -1,0 +1,1 @@
+- Fleet UI: Disable multicursor editing for SQL editors

--- a/frontend/pages/LabelPage/LabelForm/LabelForm.tsx
+++ b/frontend/pages/LabelPage/LabelForm/LabelForm.tsx
@@ -104,6 +104,7 @@ const LabelForm = ({
   const onLoad = (editor: IAceEditor) => {
     editor.setOptions({
       enableLinking: true,
+      enableMultiselect: false, // Disables command + click creating multiple cursors
     });
 
     // @ts-expect-error

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -179,6 +179,7 @@ const PolicyForm = ({
   const onLoad = (editor: IAceEditor) => {
     editor.setOptions({
       enableLinking: true,
+      enableMultiselect: false, // Disables command + click creating multiple cursors
     });
 
     // @ts-expect-error

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -208,6 +208,7 @@ const QueryForm = ({
   const onLoad = (editor: IAceEditor) => {
     editor.setOptions({
       enableLinking: true,
+      enableMultiselect: false,
     });
 
     // @ts-expect-error

--- a/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
+++ b/frontend/pages/queries/QueryPage/components/QueryForm/QueryForm.tsx
@@ -208,7 +208,7 @@ const QueryForm = ({
   const onLoad = (editor: IAceEditor) => {
     editor.setOptions({
       enableLinking: true,
-      enableMultiselect: false,
+      enableMultiselect: false, // Disables command + click creating multiple cursors
     });
 
     // @ts-expect-error


### PR DESCRIPTION
## Issue
Fix cerra #11314 

## Description
React ace allows for multiple cursor functionality, remove this functionality

## Link to solution
https://github.com/ajaxorg/ace/issues/4117#issuecomment-557237662


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

