### PR TITLE
Frontend: 1000 total results has tooltip

### DIFF
--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -287,7 +287,7 @@ const QueryDetailsPage = ({
         />
       );
     }
-    return <QueryReport queryReport={queryReport} />; // TODO: Everything related to new APIs including surfacing errorsOnly
+    return <QueryReport queryReport={queryReport} isClipped={isClipped} />;
   };
 
   return (

--- a/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
+++ b/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useEffect } from "react";
+import React, { useState, useContext, useEffect, useCallback } from "react";
 
 import { Row, Column } from "react-table";
 import FileSaver from "file-saver";
@@ -14,6 +14,7 @@ import Button from "components/buttons/Button";
 import Icon from "components/Icon/Icon";
 import TableContainer from "components/TableContainer";
 import ShowQueryModal from "components/modals/ShowQueryModal";
+import TooltipWrapper from "components/TooltipWrapper";
 
 import generateResultsTableHeaders from "./QueryReportTableConfig";
 
@@ -105,6 +106,30 @@ const QueryReport = ({ queryReport }: IQueryReportProps): JSX.Element => {
     );
   };
 
+  const renderSoftwareCount = useCallback(() => {
+    const count = filteredResults.length;
+
+    if (isClipped) {
+      return (
+        <div className={`${baseClass}__count `}>
+          <TooltipWrapper
+            tipContent={`Fleet has retained a sample of early results for 
+            reference. Reporting is paused until existing data is deleted. 
+            You can reset this report by updating the query's SQL, or by
+            temporarily enabling the <b>discard data</b> setting and disabling it again.`}
+          >
+            {`${count} results`}
+          </TooltipWrapper>
+        </div>
+      );
+    }
+    return (
+      <div className={`${baseClass}__count `}>
+        <span>{`${count} result${count === 1 ? "" : "s"}`}</span>
+      </div>
+    );
+  }, [filteredResults]);
+
   const renderTable = () => {
     return (
       <div className={`${baseClass}__results-table-container`}>
@@ -121,6 +146,7 @@ const QueryReport = ({ queryReport }: IQueryReportProps): JSX.Element => {
           resultsTitle="results"
           customControl={() => renderTableButtons()}
           setExportRows={setFilteredResults}
+          renderCount={renderSoftwareCount}
         />
       </div>
     );

--- a/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
+++ b/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
@@ -122,7 +122,7 @@ const QueryReport = ({
             You can reset this report by updating the query's SQL, or by
             temporarily enabling the <b>discard data</b> setting and disabling it again.`}
           >
-            {`${count} results`}
+            {`${count} result${count === 1 ? "" : "s"}`}
           </TooltipWrapper>
         </div>
       );

--- a/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
+++ b/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
@@ -118,7 +118,7 @@ const QueryReport = ({
         <div className={`${baseClass}__count `}>
           <TooltipWrapper
             tipContent={`Fleet has retained a sample of early results for 
-            reference. Reporting is paused until existing data is deleted. 
+            reference. Reporting is paused until existing data is deleted. <br/><br/>
             You can reset this report by updating the query's SQL, or by
             temporarily enabling the <b>discard data</b> setting and disabling it again.`}
           >

--- a/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
+++ b/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
@@ -20,6 +20,7 @@ import generateResultsTableHeaders from "./QueryReportTableConfig";
 
 interface IQueryReportProps {
   queryReport?: IQueryReport;
+  isClipped?: boolean;
 }
 
 const baseClass = "query-report";
@@ -38,7 +39,10 @@ const tableResults = (results: IQueryReportResultRow[]) => {
   });
 };
 
-const QueryReport = ({ queryReport }: IQueryReportProps): JSX.Element => {
+const QueryReport = ({
+  queryReport,
+  isClipped,
+}: IQueryReportProps): JSX.Element => {
   const { lastEditedQueryName, lastEditedQueryBody } = useContext(QueryContext);
 
   const [showQueryModal, setShowQueryModal] = useState(false);
@@ -106,7 +110,7 @@ const QueryReport = ({ queryReport }: IQueryReportProps): JSX.Element => {
     );
   };
 
-  const renderSoftwareCount = useCallback(() => {
+  const renderResultsCount = useCallback(() => {
     const count = filteredResults.length;
 
     if (isClipped) {
@@ -146,7 +150,7 @@ const QueryReport = ({ queryReport }: IQueryReportProps): JSX.Element => {
           resultsTitle="results"
           customControl={() => renderTableButtons()}
           setExportRows={setFilteredResults}
-          renderCount={renderSoftwareCount}
+          renderCount={renderResultsCount}
         />
       </div>
     );


### PR DESCRIPTION
## Description
- Show tooltip on top left count of table IFF the total results === 1000
- The filtered results count still has the tooltip if total results === 1000 and the filtered results are less

## Screenshot

<img width="1620" alt="Screenshot 2023-10-09 at 6 02 26 PM" src="https://github.com/fleetdm/fleet/assets/71795832/d53053fd-bbf5-4492-9a49-4b9cf7c7a07c">




# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
