### PR TITLE
Fleet UI: Fix agent options link

### DIFF
--- a/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
@@ -74,7 +74,7 @@ const Agents = ({
           Agent options configure the osquery agent. When you update agent
           options, they will be applied the next time a host checks in to Fleet.{" "}
           <CustomLink
-            url="https://fleetdm.com/docs/using-fleet/fleet-ui#configuring-agent-options"
+            url="https://fleetdm.com/docs/configuration/agent-configuration"
             text="Learn more about agent options"
             newTab
             multiline

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
@@ -156,7 +156,7 @@ const AgentOptionsPage = ({
         options, they will be applied the next time a host checks in to Fleet.
         <br />
         <CustomLink
-          url="https://fleetdm.com/docs/using-fleet/fleet-ui#configuring-agent-options"
+          url="https://fleetdm.com/docs/configuration/configuration-files#team-agent-options"
           text="Learn more about agent options"
           newTab
           multiline


### PR DESCRIPTION
### Description

This PR fixes the broken links pointing to the agent options identified in #14389.

I chose to link to `https://fleetdm.com/docs/configuration/agent-configuration` for the non-team agent options, and `https://fleetdm.com/docs/configuration/configuration-files#team-agent-options` for the agent options specific to teams. I'm open to changing this, but these felt like the most intuitive links for those particular contexts.

Closes #14389

### Test Plan

- [x] Manual QA for all new/changed functionality