### PR TITLE
Enable real API service, handle null results

### DIFF
--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -142,7 +142,7 @@ const QueryDetailsPage = ({
   const isLoading = isStoredQueryLoading || isQueryReportLoading;
   const isApiError = storedQueryError || queryReportError;
   const isClipped =
-    queryReport && queryReport.results.length >= QUERY_REPORT_RESULTS_LIMIT;
+    (queryReport?.results?.length ?? 0) >= QUERY_REPORT_RESULTS_LIMIT;
 
   const renderHeader = () => {
     const canEditQuery =
@@ -253,7 +253,7 @@ const QueryDetailsPage = ({
     const loggingSnapshot = storedQuery?.logging === "snapshot";
     const disabledCaching =
       disabledCachingGlobally || discardDataEnabled || !loggingSnapshot;
-    const emptyCache = queryReport?.results.length === 0; // TODO: Update with API response
+    const emptyCache = (queryReport?.results?.length ?? 0) === 0; // TODO: Update with API response
 
     // Loading state
     if (isLoading) {

--- a/frontend/services/entities/query_report.ts
+++ b/frontend/services/entities/query_report.ts
@@ -1,11 +1,8 @@
 /* eslint-disable  @typescript-eslint/explicit-module-boundary-types */
-// import sendRequest from "services";
+import sendRequest from "services";
 import endpoints from "utilities/endpoints";
 
 import { buildQueryStringFromParams } from "utilities/url";
-
-// Mock API requests to be used in developing FE for #7766 in parallel with BE development
-import { sendRequest } from "services/mock_service/service/service";
 
 export interface ISortOption {
   key: string;
@@ -42,8 +39,7 @@ export default {
 
     const queryString = buildQueryStringFromParams(queryParams);
 
-    // const endpoint = `${QUERIES}/${id}/report`;
-    const endpoint = `${QUERIES}/113/report`;
+    const endpoint = `${QUERIES}/${id}/report`;
     const path = `${endpoint}?${queryString}`;
     return sendRequest("GET", path);
   },


### PR DESCRIPTION
- Remove mock api service and uncomment real api service
- Handle if query_report.results is `null` – should be updated on backend to return empty array, but doing this as well to facilitate team-wide manual testing/QA