### PR TITLE
Enable correct behavior of Discard Data option on direct navigation to Edit Query page

### DIFF
--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -88,6 +88,7 @@ const QueryDetailsPage = ({
     setLastEditedQueryLoggingType,
     setLastEditedQueryMinOsqueryVersion,
     setLastEditedQueryPlatforms,
+    setLastEditedQueryDiscardData,
   } = useContext(QueryContext);
 
   // Title that shows up on browser tabs (e.g., Query details | Discover TLS certificates | Fleet for osquery)
@@ -116,6 +117,7 @@ const QueryDetailsPage = ({
         setLastEditedQueryPlatforms(returnedQuery.platform);
         setLastEditedQueryLoggingType(returnedQuery.logging);
         setLastEditedQueryMinOsqueryVersion(returnedQuery.min_osquery_version);
+        setLastEditedQueryDiscardData(returnedQuery.discard_data);
       },
       onError: (error) => handlePageError(error),
     }

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -79,6 +79,7 @@ const EditQueryPage = ({
     lastEditedQueryPlatforms,
     lastEditedQueryLoggingType,
     lastEditedQueryMinOsqueryVersion,
+    lastEditedQueryDiscardData,
     setLastEditedQueryId,
     setLastEditedQueryName,
     setLastEditedQueryDescription,
@@ -88,6 +89,7 @@ const EditQueryPage = ({
     setLastEditedQueryLoggingType,
     setLastEditedQueryMinOsqueryVersion,
     setLastEditedQueryPlatforms,
+    setLastEditedQueryDiscardData,
   } = useContext(QueryContext);
   const { setConfig } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
@@ -136,6 +138,7 @@ const EditQueryPage = ({
         setLastEditedQueryPlatforms(returnedQuery.platform);
         setLastEditedQueryLoggingType(returnedQuery.logging);
         setLastEditedQueryMinOsqueryVersion(returnedQuery.min_osquery_version);
+        setLastEditedQueryDiscardData(returnedQuery.discard_data);
       },
       onError: (error) => handlePageError(error),
     }
@@ -159,6 +162,7 @@ const EditQueryPage = ({
       setLastEditedQueryLoggingType(DEFAULT_QUERY.logging);
       setLastEditedQueryMinOsqueryVersion(DEFAULT_QUERY.min_osquery_version);
       setLastEditedQueryPlatforms(DEFAULT_QUERY.platform);
+      setLastEditedQueryDiscardData(DEFAULT_QUERY.discard_data);
     }
   }, [queryId]);
 
@@ -222,6 +226,7 @@ const EditQueryPage = ({
       lastEditedQueryPlatforms,
       lastEditedQueryLoggingType,
       lastEditedQueryMinOsqueryVersion,
+      lastEditedQueryDiscardData,
     });
 
     try {


### PR DESCRIPTION
- Correctly sets `queryContext.lastEditedQueryDiscardData` when loading directly from the edit page
- Preserves already working flow from the ManageQueries page

https://github.com/fleetdm/fleet/assets/61553566/193c0fd6-3585-4f36-a77a-28257f7131b2

