### PR TITLE
Fix TestListDevicePolicies flaky tests (and possibly other flaky tests)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,7 @@ services:
         # Required for storage of Apple MDM installers.
         "--max_allowed_packet=536870912"
       ]
-    environment:
-      &mysql-default-environment
+    environment: &mysql-default-environment
       MYSQL_ROOT_PASSWORD: toor
       MYSQL_DATABASE: fleet
       MYSQL_USER: fleet
@@ -41,7 +40,7 @@ services:
         "--log_output=TABLE",
         "--log-queries-not-using-indexes",
         "--innodb-file-per-table=OFF",
-        "--table-definition-cache=2048",
+        "--table-definition-cache=8192",
         # These 3 keys run MySQL with GTID consistency enforced to avoid issues with production deployments that use it.
         "--enforce-gtid-consistency=ON",
         "--log-bin=bin.log",
@@ -141,4 +140,5 @@ services:
 volumes:
   mysql-persistent-volume:
   data-minio:
+
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -79,7 +79,6 @@ func (s *integrationTestSuite) TestSlowOsqueryHost() {
 			SkipCreateTestUsers: true,
 			//nolint:gosec // G112: server is just run for testing this explicit config.
 			HTTPServerConfig: &http.Server{ReadTimeout: 2 * time.Second},
-			EnableCachedDS:   true,
 		},
 	)
 	defer func() {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -54,10 +54,9 @@ func (s *integrationEnterpriseTestSuite) SetupSuite() {
 		License: &fleet.LicenseInfo{
 			Tier: fleet.TierPremium,
 		},
-		Pool:           s.redisPool,
-		Lq:             s.lq,
-		Logger:         log.NewLogfmtLogger(os.Stdout),
-		EnableCachedDS: true,
+		Pool:   s.redisPool,
+		Lq:     s.lq,
+		Logger: log.NewLogfmtLogger(os.Stdout),
 	}
 	users, server := RunServerForTestsWithDS(s.T(), s.ds, &config)
 	s.server = server

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -17,7 +17,6 @@ import (
 	eeservice "github.com/fleetdm/fleet/v4/ee/server/service"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
-	"github.com/fleetdm/fleet/v4/server/datastore/cached_mysql"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/logging"
 	"github.com/fleetdm/fleet/v4/server/mail"
@@ -289,13 +288,9 @@ type TestServerOpts struct {
 	UseMailService      bool
 	APNSTopic           string
 	ProfileMatcher      fleet.ProfileMatcher
-	EnableCachedDS      bool
 }
 
 func RunServerForTestsWithDS(t *testing.T, ds fleet.Datastore, opts ...*TestServerOpts) (map[string]fleet.User, *httptest.Server) {
-	if len(opts) > 0 && opts[0].EnableCachedDS {
-		ds = cached_mysql.New(ds)
-	}
 	var rs fleet.QueryResultStore
 	if len(opts) > 0 && opts[0].Rs != nil {
 		rs = opts[0].Rs


### PR DESCRIPTION
The recently added `EnableCachedDS` was causing flakiness on some tests, e.g. `TestListDevicePolicies`.

Some integration tests were making direct datastore calls using `s.ds`, which was not cached, so the cache and the real datastore were out of sync, causing flakiness depending in the order they were called.