### PR TITLE
Fleet UI: [unreleased bug] Fix info banner gap/padding issue

### DIFF
--- a/frontend/components/InfoBanner/_styles.scss
+++ b/frontend/components/InfoBanner/_styles.scss
@@ -36,7 +36,7 @@
 
   &__info {
     p {
-      margin: $pad-medium 0 0 0;
+      margin: $pad-small 0 0 0;
     }
   }
 

--- a/frontend/components/InfoBanner/_styles.scss
+++ b/frontend/components/InfoBanner/_styles.scss
@@ -36,7 +36,7 @@
 
   &__info {
     p {
-      margin-top: $pad-small;
+      margin: $pad-medium 0 0 0;
     }
   }
 
@@ -64,9 +64,5 @@
         stroke: $core-vibrant-blue;
       }
     }
-  }
-
-  p {
-    margin: 0;
   }
 }

--- a/frontend/components/InfoBanner/_styles.scss
+++ b/frontend/components/InfoBanner/_styles.scss
@@ -35,9 +35,9 @@
   }
 
   &__info {
-    display: flex;
-    flex-direction: column;
-    gap: $pad-small;
+    p {
+      margin-top: $pad-small;
+    }
   }
 
   &__cta {


### PR DESCRIPTION
## Issue
Cerra #14381

## Description
- #14136 caused buggy issues around child elements of `.info-banner__info`
- Undo buggy issues by removing `display: flex` all together and only adding padding between `p` elements

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

