### PR TITLE
align Log destination; shrink underline gap

### DIFF
--- a/frontend/pages/queries/details/QueryDetailsPage/_styles.scss
+++ b/frontend/pages/queries/details/QueryDetailsPage/_styles.scss
@@ -38,12 +38,17 @@
     display: flex;
     gap: $pad-large;
     font-size: $x-small;
+    // TODO - remove once refactored tooltip wrapper is merged
+    .component__tooltip-wrapper__element__underline::after {
+      bottom: 0px;
+    }
   }
 
   &__automations,
   &__log-destination {
     display: flex;
     gap: $pad-small;
+    align-items: center;
 
     .component__tooltip-wrapper__element {
       font-weight: $bold;


### PR DESCRIPTION
before:
<img width="860" alt="Screenshot 2023-10-11 at 10 32 03 AM" src="https://github.com/fleetdm/fleet/assets/61553566/94556ce3-5f1f-437a-a370-398b39bb3ad7">

after:
<img width="860" alt="Screenshot 2023-10-11 at 10 30 26 AM" src="https://github.com/fleetdm/fleet/assets/61553566/b457560c-7459-414f-bb7c-be943150c9a7">
