### PR TITLE
prevent input secret from overflowing

### DIFF
--- a/frontend/components/forms/fields/InputFieldHiddenContent/_styles.scss
+++ b/frontend/components/forms/fields/InputFieldHiddenContent/_styles.scss
@@ -21,6 +21,8 @@
     }
 
     .input-field {
+      padding-right: 16%;
+
       &--disabled {
         letter-spacing: 0;
       }


### PR DESCRIPTION
this implements the exact same fix as the component in `frontend/components/EnrollSecrets/SecretField/_styles.scss`

we should probably refactor the three different components we have: `SecretField`, `InputFieldHiddenContent` and the ad-hoc component (which has a TODO) we have inside `EnrollSecretRow`.

for now, adding the padding for #14416

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
