### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -8,7 +8,6 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -882,12 +881,12 @@ the way that the Fleet server works.
 
 			if path, ok := os.LookupEnv("FLEET_TEST_PAGE_PATH"); ok {
 				// test that we can load this
-				_, err := ioutil.ReadFile(path)
+				_, err := os.ReadFile(path)
 				if err != nil {
 					initFatal(err, "loading FLEET_TEST_PAGE_PATH")
 				}
 				rootMux.HandleFunc("/test", func(rw http.ResponseWriter, req *http.Request) {
-					testPage, err := ioutil.ReadFile(path)
+					testPage, err := os.ReadFile(path)
 					if err != nil {
 						rw.WriteHeader(http.StatusNotFound)
 						return

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -75,7 +75,7 @@ func TestMaybeSendStatistics(t *testing.T) {
 	requestBody := ""
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestBodyBytes, err := ioutil.ReadAll(r.Body)
+		requestBodyBytes, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		requestBody = string(requestBodyBytes)
 	}))

--- a/cmd/fleetctl/api.go
+++ b/cmd/fleetctl/api.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -157,7 +156,7 @@ func rawHTTPClientFromConfig(cc Context) (*http.Client, *url.URL, error) {
 	if cc.RootCA != "" {
 		rootCA = x509.NewCertPool()
 		// read in the root cert file specified in the context
-		certs, err := ioutil.ReadFile(cc.RootCA)
+		certs, err := os.ReadFile(cc.RootCA)
 		if err != nil {
 			return nil, nil, fmt.Errorf("reading root CA: %w", err)
 		}

--- a/cmd/fleetctl/config.go
+++ b/cmd/fleetctl/config.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -71,7 +70,7 @@ func makeConfigIfNotExists(fp string) error {
 
 func readConfig(fp string) (configFile, error) {
 	var c configFile
-	b, err := ioutil.ReadFile(fp)
+	b, err := os.ReadFile(fp)
 	if err != nil {
 		return c, err
 	}
@@ -94,7 +93,7 @@ func writeConfig(fp string, c configFile) error {
 		return err
 	}
 
-	return ioutil.WriteFile(fp, b, configFilePerms)
+	return os.WriteFile(fp, b, configFilePerms)
 }
 
 func getConfigValue(configPath, context, key string) (interface{}, error) {

--- a/cmd/fleetctl/convert.go
+++ b/cmd/fleetctl/convert.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -165,7 +164,7 @@ func convertCommand() *cli.Command {
 				return errors.New("-f must be specified")
 			}
 
-			b, err := ioutil.ReadFile(flFilename)
+			b, err := os.ReadFile(flFilename)
 			if err != nil {
 				return err
 			}

--- a/cmd/fleetctl/convert_test.go
+++ b/cmd/fleetctl/convert_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,11 +19,11 @@ func TestConvertFileOutput(t *testing.T) {
 	app.Setup()
 
 	// read the expected output file
-	expected, err := ioutil.ReadFile(filepath.Join("testdata", "convert_output.yml"))
+	expected, err := os.ReadFile(filepath.Join("testdata", "convert_output.yml"))
 	require.NoError(t, err)
 
 	// setup a file for the convert command to write to
-	file, err := ioutil.TempFile(t.TempDir(), "convert_output.yml")
+	file, err := os.CreateTemp(t.TempDir(), "convert_output.yml")
 	defer file.Close()
 	require.NoError(t, err)
 
@@ -34,7 +34,7 @@ func TestConvertFileOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	// convert command ran and wrote converted file to output destination
-	got, err := ioutil.ReadFile(file.Name())
+	got, err := os.ReadFile(file.Name())
 	require.NoError(t, err)
 	require.YAMLEq(t, string(expected), string(got))
 }
@@ -52,7 +52,7 @@ func TestConvertFileStdout(t *testing.T) {
 	app.Setup()
 
 	// read the expected output file
-	expected, err := ioutil.ReadFile(filepath.Join("testdata", "convert_output.yml"))
+	expected, err := os.ReadFile(filepath.Join("testdata", "convert_output.yml"))
 	require.NoError(t, err)
 
 	// get the program name
@@ -63,6 +63,6 @@ func TestConvertFileStdout(t *testing.T) {
 
 	os.Stdout = oldStdout
 	w.Close()
-	out, _ := ioutil.ReadAll(r)
+	out, _ := io.ReadAll(r)
 	require.YAMLEq(t, string(expected), string(out))
 }

--- a/cmd/fleetctl/debug.go
+++ b/cmd/fleetctl/debug.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -57,7 +56,7 @@ func debugCommand() *cli.Command {
 }
 
 func writeFile(filename string, bytes []byte, mode os.FileMode) error {
-	if err := ioutil.WriteFile(filename, bytes, mode); err != nil {
+	if err := os.WriteFile(filename, bytes, mode); err != nil {
 		return err
 	}
 

--- a/cmd/fleetctl/debug_test.go
+++ b/cmd/fleetctl/debug_test.go
@@ -8,9 +8,9 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -99,7 +99,7 @@ func TestDebugConnectionCommand(t *testing.T) {
 		// get the invalid certificate (for example.com)
 		dir := t.TempDir()
 		certPath := filepath.Join(dir, "cert.pem")
-		require.NoError(t, ioutil.WriteFile(certPath, []byte(exampleDotComCertDotPem), 0o600))
+		require.NoError(t, os.WriteFile(certPath, []byte(exampleDotComCertDotPem), 0o600))
 
 		buf, err := runAppNoChecks([]string{"debug", "connection", "--fleet-certificate", certPath, srv.URL})
 		// 2 successes: resolve host, dial address
@@ -123,7 +123,7 @@ func rawCertToPemFile(t *testing.T, raw []byte) string {
 
 	dir := t.TempDir()
 	certPath := filepath.Join(dir, "cert.pem")
-	require.NoError(t, ioutil.WriteFile(certPath, buf.Bytes(), 0o600))
+	require.NoError(t, os.WriteFile(certPath, buf.Bytes(), 0o600))
 	return certPath
 }
 

--- a/cmd/fleetctl/delete.go
+++ b/cmd/fleetctl/delete.go
@@ -3,7 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/fleetdm/fleet/v4/pkg/spec"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -34,7 +34,7 @@ func deleteCommand() *cli.Command {
 				return errors.New("-f must be specified")
 			}
 
-			b, err := ioutil.ReadFile(flFilename)
+			b, err := os.ReadFile(flFilename)
 			if err != nil {
 				return err
 			}

--- a/cmd/fleetctl/package.go
+++ b/cmd/fleetctl/package.go
@@ -5,7 +5,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -365,7 +365,7 @@ func shouldRetry(pkgType string, opt packaging.Options, err error) bool {
 }
 
 func checkPEMCertificate(path string) error {
-	cert, err := ioutil.ReadFile(path)
+	cert, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/cmd/fleetctl/preview.go
+++ b/cmd/fleetctl/preview.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -289,7 +288,7 @@ Use the stop and reset subcommands to manage the server and dependencies once st
 			var buf []byte
 			if fp := c.String(stdQueryLibFilePath); fp != "" {
 				var err error
-				buf, err = ioutil.ReadFile(fp)
+				buf, err = os.ReadFile(fp)
 				if err != nil {
 					return fmt.Errorf("failed to read standard query library file %q: %w", fp, err)
 				}
@@ -417,7 +416,7 @@ func downloadFiles(branch string) error {
 		return fmt.Errorf("download got status %d", resp.StatusCode)
 	}
 
-	zipContents, err := ioutil.ReadAll(resp.Body)
+	zipContents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("read download contents: %w", err)
 	}
@@ -443,7 +442,7 @@ func downloadStandardQueryLibrary() ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("status: %d", resp.StatusCode)
 	}
-	buf, err := ioutil.ReadAll(resp.Body)
+	buf, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read response body: %w", err)
 	}

--- a/cmd/fleetctl/query.go
+++ b/cmd/fleetctl/query.go
@@ -3,7 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -136,7 +136,7 @@ func queryCommand() *cli.Command {
 			s := spinner.New(spinner.CharSets[24], 200*time.Millisecond)
 			s.Writer = os.Stderr
 			if flQuiet {
-				s.Writer = ioutil.Discard
+				s.Writer = io.Discard
 			}
 			s.Start()
 

--- a/cmd/fleetctl/session_test.go
+++ b/cmd/fleetctl/session_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -27,7 +27,7 @@ func TestEarlySessionCheck(t *testing.T) {
   default:
     tls-skip-verify: true
     token: phIEGWGzKxXui1uZYFBXFwZ1Wv1iMxl79gbqMbOmMxgyZP2O5jga5qyhvEjzlGsdM7ax93iDqjnVSu9Fi8q1/w==`
-	err := ioutil.WriteFile(configPath, []byte(config), configFilePerms)
+	err := os.WriteFile(configPath, []byte(config), configFilePerms)
 	require.NoError(t, err)
 
 	_, err = runAppNoChecks([]string{"get", "queries", "--config", configPath})

--- a/cmd/fleetctl/trigger_test.go
+++ b/cmd/fleetctl/trigger_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -80,7 +80,7 @@ func TestTrigger(t *testing.T) {
 
 	os.Stdout = oldStdout
 	w.Close()
-	out, _ := ioutil.ReadAll(r)
+	out, _ := io.ReadAll(r)
 	outlines := strings.Split(string(out), "\n")
 	require.Len(t, outlines, len(testCases)+1)
 

--- a/cmd/fleetctl/users_test.go
+++ b/cmd/fleetctl/users_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/csv"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"strings"
@@ -111,7 +110,7 @@ func TestUserCreateForcePasswordReset(t *testing.T) {
 }
 
 func writeTmpCsv(t *testing.T, contents string) string {
-	tmpFile, err := ioutil.TempFile(t.TempDir(), "*.csv")
+	tmpFile, err := os.CreateTemp(t.TempDir(), "*.csv")
 	require.NoError(t, err)
 	_, err = tmpFile.WriteString(contents)
 	require.NoError(t, err)

--- a/ee/fleetctl/updates_test.go
+++ b/ee/fleetctl/updates_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -148,7 +147,7 @@ func getRoots(t *testing.T, tmpDir string) string {
 	require.NoError(t, runUpdatesCommand("roots", "--path", tmpDir))
 	require.NoError(t, w.Close())
 
-	out, err := ioutil.ReadAll(r)
+	out, err := io.ReadAll(r)
 	require.NoError(t, err)
 
 	// Check output contains the root.json

--- a/orbit/pkg/packaging/linux_shared.go
+++ b/orbit/pkg/packaging/linux_shared.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -240,7 +239,7 @@ func writeSystemdUnit(opt Options, rootPath string) error {
 	if err := secure.MkdirAll(systemdRoot, constant.DefaultDirMode); err != nil {
 		return fmt.Errorf("create systemd dir: %w", err)
 	}
-	if err := ioutil.WriteFile(
+	if err := os.WriteFile(
 		filepath.Join(systemdRoot, "orbit.service"),
 		[]byte(`
 [Unit]
@@ -302,7 +301,7 @@ func writeEnvFile(opt Options, rootPath string) error {
 		return fmt.Errorf("execute template: %w", err)
 	}
 
-	if err := ioutil.WriteFile(
+	if err := os.WriteFile(
 		filepath.Join(envRoot, "orbit"),
 		contents.Bytes(),
 		constant.DefaultFileMode,
@@ -334,7 +333,7 @@ func writePostInstall(opt Options, path string) error {
 		return fmt.Errorf("execute template: %w", err)
 	}
 
-	if err := ioutil.WriteFile(path, contents.Bytes(), constant.DefaultFileMode); err != nil {
+	if err := os.WriteFile(path, contents.Bytes(), constant.DefaultFileMode); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}
 
@@ -349,7 +348,7 @@ func writePreRemove(opt Options, path string) error {
 	// "pkill fleet-desktop" is required because the application
 	// runs as user (separate from sudo command that launched it),
 	// so on some systems it's not killed properly.
-	if err := ioutil.WriteFile(path, []byte(`#!/bin/sh
+	if err := os.WriteFile(path, []byte(`#!/bin/sh
 
 systemctl stop orbit.service || true
 systemctl disable orbit.service || true
@@ -362,7 +361,7 @@ pkill fleet-desktop || true
 }
 
 func writePostRemove(opt Options, path string) error {
-	if err := ioutil.WriteFile(path, []byte(`#!/bin/sh
+	if err := os.WriteFile(path, []byte(`#!/bin/sh
 
 rm -rf /var/lib/orbit /var/log/orbit /usr/local/bin/orbit /etc/default/orbit /usr/lib/systemd/system/orbit.service /opt/orbit
 `), constant.DefaultFileMode); err != nil {

--- a/orbit/pkg/packaging/macos.go
+++ b/orbit/pkg/packaging/macos.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -221,7 +220,7 @@ func writePackageInfo(opt Options, rootPath string) error {
 		return fmt.Errorf("execute template: %w", err)
 	}
 
-	if err := ioutil.WriteFile(path, contents.Bytes(), constant.DefaultFileMode); err != nil {
+	if err := os.WriteFile(path, contents.Bytes(), constant.DefaultFileMode); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}
 
@@ -240,7 +239,7 @@ func writeScripts(opt Options, rootPath string) error {
 		return fmt.Errorf("execute template: %w", err)
 	}
 
-	if err := ioutil.WriteFile(path, contents.Bytes(), 0o744); err != nil {
+	if err := os.WriteFile(path, contents.Bytes(), 0o744); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}
 
@@ -259,7 +258,7 @@ func writeLaunchd(opt Options, rootPath string) error {
 		return fmt.Errorf("execute template: %w", err)
 	}
 
-	if err := ioutil.WriteFile(path, contents.Bytes(), 0o644); err != nil {
+	if err := os.WriteFile(path, contents.Bytes(), 0o644); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}
 
@@ -278,7 +277,7 @@ func writeDistribution(opt Options, rootPath string) error {
 		return fmt.Errorf("execute template: %w", err)
 	}
 
-	if err := ioutil.WriteFile(path, contents.Bytes(), constant.DefaultFileMode); err != nil {
+	if err := os.WriteFile(path, contents.Bytes(), constant.DefaultFileMode); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}
 
@@ -368,7 +367,7 @@ func xarBom(opt Options, rootPath string) error {
 			return fmt.Errorf("lsbom inBom: %w", err)
 		}
 		bomContents = bomReplace(bomContents)
-		if err := ioutil.WriteFile(inBomPath, bomContents, 0); err != nil {
+		if err := os.WriteFile(inBomPath, bomContents, 0); err != nil {
 			return fmt.Errorf("write inBom: %w", err)
 		}
 

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -8,7 +8,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -120,7 +119,7 @@ type Options struct {
 
 func initializeTempDir() (string, error) {
 	// Initialize directories
-	tmpDir, err := ioutil.TempDir("", "orbit-package")
+	tmpDir, err := os.MkdirTemp("", "orbit-package")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp dir: %w", err)
 	}

--- a/orbit/pkg/packaging/windows.go
+++ b/orbit/pkg/packaging/windows.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -190,7 +189,7 @@ func writeWixFile(opt Options, rootPath string) error {
 		return fmt.Errorf("execute template: %w", err)
 	}
 
-	if err := ioutil.WriteFile(path, contents.Bytes(), 0o666); err != nil {
+	if err := os.WriteFile(path, contents.Bytes(), 0o666); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}
 
@@ -209,7 +208,7 @@ func writeEventLogFile(opt Options, rootPath string) error {
 		return fmt.Errorf("event log manifest creation: %w", err)
 	}
 
-	if err := ioutil.WriteFile(path, contents.Bytes(), constant.DefaultFileMode); err != nil {
+	if err := os.WriteFile(path, contents.Bytes(), constant.DefaultFileMode); err != nil {
 		return fmt.Errorf("event log manifest creation: %w", err)
 	}
 
@@ -228,7 +227,7 @@ func writePowershellInstallerUtilsFile(opt Options, rootPath string) error {
 		return fmt.Errorf("powershell installer utils transform: %w", err)
 	}
 
-	if err := ioutil.WriteFile(path, contents.Bytes(), constant.DefaultFileMode); err != nil {
+	if err := os.WriteFile(path, contents.Bytes(), constant.DefaultFileMode); err != nil {
 		return fmt.Errorf("powershell installer utils file write: %w", err)
 	}
 
@@ -251,7 +250,7 @@ func writeManifestXML(vParts []string, orbitPath string) (string, error) {
 		return "", fmt.Errorf("parsing manifest.xml template: %w", err)
 	}
 
-	if err := ioutil.WriteFile(filePath, contents.Bytes(), constant.DefaultFileMode); err != nil {
+	if err := os.WriteFile(filePath, contents.Bytes(), constant.DefaultFileMode); err != nil {
 		return "", fmt.Errorf("writing manifest.xml file: %w", err)
 	}
 

--- a/orbit/pkg/packaging/wix/transform.go
+++ b/orbit/pkg/packaging/wix/transform.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -42,7 +41,7 @@ func xmlNode(name string, attrs ...*xml.Attr) *node {
 }
 
 func TransformHeat(path string) error {
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("read file: %w", err)
 	}
@@ -70,7 +69,7 @@ func TransformHeat(path string) error {
 		return fmt.Errorf("remove old file: %w", err)
 	}
 
-	if err := ioutil.WriteFile(path, contents, 0o600); err != nil {
+	if err := os.WriteFile(path, contents, 0o600); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}
 

--- a/orbit/pkg/update/hash_test.go
+++ b/orbit/pkg/update/hash_test.go
@@ -4,7 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/sha512"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -19,7 +19,7 @@ func createFile(t *testing.T, name string, length int) (string, *data.TargetFile
 	require.NoError(t, err)
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, name)
-	err = ioutil.WriteFile(filePath, b, constant.DefaultFileMode)
+	err = os.WriteFile(filePath, b, constant.DefaultFileMode)
 	require.NoError(t, err)
 	sha256Bytes := sha256.Sum256(b)
 	sha512Bytes := sha512.Sum512(b)

--- a/orbit/tools/build/build-windows.go
+++ b/orbit/tools/build/build-windows.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -186,7 +185,7 @@ func writeManifestXML(vParts []string, orbitPath string) (string, error) {
 		return "", fmt.Errorf("parsing manifest.xml template: %w", err)
 	}
 
-	if err := ioutil.WriteFile(filePath, contents.Bytes(), constant.DefaultFileMode); err != nil {
+	if err := os.WriteFile(filePath, contents.Bytes(), constant.DefaultFileMode); err != nil {
 		return "", fmt.Errorf("writing manifest.xml file: %w", err)
 	}
 

--- a/pkg/buildpkg/buildpkg.go
+++ b/pkg/buildpkg/buildpkg.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -32,7 +31,7 @@ func MakeMacOSFatExecutable(outPath string, inPaths ...string) error {
 	var inputs []input
 	offset := int64(align)
 	for _, i := range inPaths {
-		data, err := ioutil.ReadFile(i)
+		data, err := os.ReadFile(i)
 		if err != nil {
 			return err
 		}

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -20,7 +19,7 @@ import (
 func LoadPEM(path string) (*x509.CertPool, error) {
 	pool := x509.NewCertPool()
 
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read certificate file: %w", err)
 	}

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -32,7 +31,7 @@ func download(client *http.Client, u *url.URL, path string, extract bool) error 
 	dir, file := filepath.Split(path)
 	if dir == "" {
 		// If the file is in the current working directory, then dir will be "".
-		// However, this means that ioutil.TempFile will use the default directory
+		// However, this means that os.CreateTemp will use the default directory
 		// for temporary files, which is wrong.
 		dir = "."
 	}
@@ -42,7 +41,7 @@ func download(client *http.Client, u *url.URL, path string, extract bool) error 
 		return err
 	}
 
-	tmpFile, err := ioutil.TempFile(dir, file)
+	tmpFile, err := os.CreateTemp(dir, file)
 	if err != nil {
 		return fmt.Errorf("create temporary file: %w", err)
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -716,7 +715,7 @@ func (t *TLS) ToTLSConfig() (*tls.Config, error) {
 	var rootCertPool *x509.CertPool
 	if t.TLSCA != "" {
 		rootCertPool = x509.NewCertPool()
-		pem, err := ioutil.ReadFile(t.TLSCA)
+		pem, err := os.ReadFile(t.TLSCA)
 		if err != nil {
 			return nil, fmt.Errorf("read server-ca pem: %w", err)
 		}

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -7,8 +7,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -487,7 +487,7 @@ func checkConfig(conf *config.MysqlConfig) error {
 	// Check if file exists on disk
 	// If file exists read contents
 	if conf.PasswordPath != "" {
-		fileContents, err := ioutil.ReadFile(conf.PasswordPath)
+		fileContents, err := os.ReadFile(conf.PasswordPath)
 		if err != nil {
 			return err
 		}

--- a/server/datastore/mysql/testing_utils.go
+++ b/server/datastore/mysql/testing_utils.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -181,7 +180,7 @@ func setupReadReplica(t testing.TB, testName string, ds *Datastore, opts *Datast
 func initializeDatabase(t testing.TB, testName string, opts *DatastoreTestOptions) *Datastore {
 	_, filename, _, _ := runtime.Caller(0)
 	base := path.Dir(filename)
-	schema, err := ioutil.ReadFile(path.Join(base, "schema.sql"))
+	schema, err := os.ReadFile(path.Join(base, "schema.sql"))
 	if err != nil {
 		t.Error(err)
 		t.FailNow()

--- a/server/datastore/s3/carves.go
+++ b/server/datastore/s3/carves.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"time"
 
@@ -264,7 +264,7 @@ func (c *CarveStore) GetBlock(ctx context.Context, metadata *fleet.CarveMetadata
 		return nil, ctxerr.Wrap(ctx, err, "s3 carve get block")
 	}
 	defer res.Body.Close()
-	carveData, err := ioutil.ReadAll(res.Body)
+	carveData, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "s3 carve get block")
 	}

--- a/server/logging/kafkarest.go
+++ b/server/logging/kafkarest.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -81,7 +80,7 @@ func (l *kafkaRESTProducer) Write(ctx context.Context, logs []json.RawMessage) e
 
 func checkResponse(resp *http.Response) (err error) {
 	if resp.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("Error: %d. %s", resp.StatusCode, string(body))
 	}
 

--- a/server/logging/kafkarest_test.go
+++ b/server/logging/kafkarest_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -17,7 +17,7 @@ func TestKafkaRestWrite(t *testing.T) {
 	var buf []byte
 	var err error
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		buf, err = ioutil.ReadAll(r.Body)
+		buf, err = io.ReadAll(r.Body)
 		require.NoError(t, err)
 		require.Equal(t, r.URL.Path, "/topics/foo")
 		require.Equal(t, r.Header.Get("Content-Type"), "foobar")

--- a/server/mdm/apple/cert.go
+++ b/server/mdm/apple/cert.go
@@ -8,7 +8,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -110,7 +110,7 @@ func GetSignedAPNSCSR(client *http.Client, csr *x509.CertificateRequest) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, _ := io.ReadAll(resp.Body)
 		return FleetWebsiteError{Status: resp.StatusCode, message: string(b)}
 	}
 	return nil

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -6,11 +6,11 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 
@@ -319,7 +319,7 @@ func TestCertificateChain(t *testing.T) {
 	have, want := len(conn.ConnectionState().PeerCertificates), len(cert.Certificate)
 	require.Equal(t, have, want)
 
-	original, _ := ioutil.ReadFile(certFile)
+	original, _ := os.ReadFile(certFile)
 	returned, err := chain(context.Background(), conn.ConnectionState(), "")
 	require.Nil(t, err)
 	require.Equal(t, returned, original)

--- a/server/service/client_debug.go
+++ b/server/service/client_debug.go
@@ -3,7 +3,6 @@ package service
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -20,7 +19,7 @@ func (c *Client) getRawBody(endpoint string) ([]byte, error) {
 		return nil, fmt.Errorf("get %s received status %d", endpoint, response.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read %s response body: %w", endpoint, err)
 	}

--- a/server/service/http_auth_test.go
+++ b/server/service/http_auth_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -99,7 +98,7 @@ func TestLogin(t *testing.T) {
 		require.Nil(t, err)
 		assert.Equal(t, http.StatusOK, resp.StatusCode, strconv.Itoa(tt.status))
 
-		_, err = ioutil.ReadAll(resp.Body)
+		_, err = io.ReadAll(resp.Body)
 		assert.Nil(t, err)
 
 		// ensure that our user's session was deleted from the store

--- a/server/service/orbit_client.go
+++ b/server/service/orbit_client.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -199,7 +198,7 @@ func (oc *OrbitClient) getNodeKeyOrEnroll() (string, error) {
 	enrollLock.Lock()
 	defer enrollLock.Unlock()
 
-	orbitNodeKey, err := ioutil.ReadFile(oc.nodeKeyFilePath)
+	orbitNodeKey, err := os.ReadFile(oc.nodeKeyFilePath)
 	switch {
 	case err == nil:
 		return string(orbitNodeKey), nil

--- a/server/sso/settings.go
+++ b/server/sso/settings.go
@@ -3,7 +3,7 @@ package sso
 import (
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -105,7 +105,7 @@ func getMetadata(metadataURL string) (*Metadata, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("SAML metadata server at %s returned %s", metadataURL, resp.Status)
 	}
-	xmlData, err := ioutil.ReadAll(resp.Body)
+	xmlData, err := io.ReadAll(resp.Body)
 
 	if err != nil {
 		return nil, err

--- a/server/utils.go
+++ b/server/utils.go
@@ -12,7 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -58,7 +58,7 @@ func PostJSONWithTimeout(ctx context.Context, url string, v interface{}) error {
 	defer resp.Body.Close()
 
 	if !httpSuccessStatus(resp.StatusCode) {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("error posting to %s: %d. %s", MaskSecretURLParams(url), resp.StatusCode, string(body))
 	}
 

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -3,7 +3,6 @@ package nvd
 import (
 	"compress/gzip"
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -377,7 +376,7 @@ func TestSyncsCPEFromURL(t *testing.T) {
 	require.NoError(t, err)
 
 	dbPath := filepath.Join(tempDir, "cpe.sqlite")
-	stored, err := ioutil.ReadFile(dbPath)
+	stored, err := os.ReadFile(dbPath)
 	require.NoError(t, err)
 	assert.Equal(t, "Hello world!", string(stored))
 }

--- a/server/vulnerabilities/oval/analyzer.go
+++ b/server/vulnerabilities/oval/analyzer.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -133,7 +133,7 @@ func loadDef(platform Platform, vulnPath string) (oval_parsed.Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	payload, err := ioutil.ReadFile(latest)
+	payload, err := os.ReadFile(latest)
 	if err != nil {
 		return nil, err
 	}

--- a/server/vulnerabilities/oval/analyzer_test.go
+++ b/server/vulnerabilities/oval/analyzer_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,7 +68,7 @@ func loadSoftware(
 	require.NoError(t, err)
 
 	var fixtures []softwareFixture
-	contents, err := ioutil.ReadFile(filepath.Join(vulnPath, fmt.Sprintf("%s-software.json", p)))
+	contents, err := os.ReadFile(filepath.Join(vulnPath, fmt.Sprintf("%s-software.json", p)))
 	require.NoError(t, err)
 
 	err = json.Unmarshal(contents, &fixtures)

--- a/server/vulnerabilities/oval/downloader.go
+++ b/server/vulnerabilities/oval/downloader.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -27,7 +26,7 @@ func getOvalSources(getter func(string) (io.ReadCloser, error)) (OvalSources, er
 	}
 	defer src.Close()
 
-	contents, err := ioutil.ReadAll(src)
+	contents, err := io.ReadAll(src)
 	if err != nil {
 		return nil, err
 	}

--- a/server/vulnerabilities/oval/parser.go
+++ b/server/vulnerabilities/oval/parser.go
@@ -5,7 +5,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	oval_input "github.com/fleetdm/fleet/v4/server/vulnerabilities/oval/input"
@@ -30,7 +29,7 @@ func parseDefinitions(platform Platform, inputFile string, outputFile string) er
 		return fmt.Errorf("oval parser: %w", err)
 	}
 
-	err = ioutil.WriteFile(outputFile, payload, 0o644)
+	err = os.WriteFile(outputFile, payload, 0o644)
 	if err != nil {
 		return fmt.Errorf("oval parser: %w", err)
 	}

--- a/server/webhooks/failing_policies_test.go
+++ b/server/webhooks/failing_policies_test.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -51,7 +51,7 @@ func TestTriggerFailingPoliciesWebhookBasic(t *testing.T) {
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestBodyBytes, err := ioutil.ReadAll(r.Body)
+		requestBodyBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
@@ -165,7 +165,7 @@ func TestTriggerFailingPoliciesWebhookTeam(t *testing.T) {
 	webhookCalled := false
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		webhookCalled = true
-		requestBodyBytes, err := ioutil.ReadAll(r.Body)
+		requestBodyBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
@@ -341,7 +341,7 @@ func TestSendBatchedPOSTs(t *testing.T) {
 	allHosts := []uint{}
 	requestCount := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 		}

--- a/server/webhooks/host_status_test.go
+++ b/server/webhooks/host_status_test.go
@@ -2,7 +2,7 @@ package webhooks
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,7 +20,7 @@ func TestTriggerHostStatusWebhook(t *testing.T) {
 	requestBody := ""
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestBodyBytes, err := ioutil.ReadAll(r.Body)
+		requestBodyBytes, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		requestBody = string(requestBodyBytes)
 	}))

--- a/server/webhooks/vulnerabilities_test.go
+++ b/server/webhooks/vulnerabilities_test.go
@@ -3,7 +3,7 @@ package webhooks
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -170,7 +170,7 @@ func TestTriggerVulnerabilitiesWebhook(t *testing.T) {
 				var requests []string
 
 				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					b, err := ioutil.ReadAll(r.Body)
+					b, err := io.ReadAll(r.Body)
 					assert.NoError(t, err)
 					requests = append(requests, string(b))
 					_, err = w.Write(nil)

--- a/server/worker/jira_test.go
+++ b/server/worker/jira_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -71,7 +70,7 @@ func TestJiraRun(t *testing.T) {
 		}
 
 		// the request body is the JSON payload sent to Jira, i.e. the rendered templates
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		if expectedSummary != "" {
 			require.Contains(t, string(body), expectedSummary)

--- a/server/worker/zendesk_test.go
+++ b/server/worker/zendesk_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -69,7 +68,7 @@ func TestZendeskRun(t *testing.T) {
 			return
 		}
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		if expectedSubject != "" {
 			require.Contains(t, string(body), expectedSubject)

--- a/tools/dbutils/schema_generator.go
+++ b/tools/dbutils/schema_generator.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"time"
@@ -76,5 +75,5 @@ func main() {
 	cmd.Stdout = &stdoutBuf
 	panicif(cmd.Run())
 
-	panicif(ioutil.WriteFile(os.Args[1], stdoutBuf.Bytes(), 0o655))
+	panicif(os.WriteFile(os.Args[1], stdoutBuf.Bytes(), 0o655))
 }

--- a/tools/desktop/desktop.go
+++ b/tools/desktop/desktop.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -143,7 +142,7 @@ func createMacOSApp(version, authority string, notarize bool) error {
 
 	infoFile := filepath.Join(contentsDir, "Info.plist")
 	infoPListContents := fmt.Sprintf(infoPList, bundleIdentifier, version, version)
-	if err := ioutil.WriteFile(infoFile, []byte(infoPListContents), 0o644); err != nil {
+	if err := os.WriteFile(infoFile, []byte(infoPListContents), 0o644); err != nil {
 		return fmt.Errorf("create Info.plist file %q: %w", infoFile, err)
 	}
 

--- a/tools/inspect-cert/main.go
+++ b/tools/inspect-cert/main.go
@@ -6,8 +6,8 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -65,7 +65,7 @@ func validate(certFile, keyFile string) {
 }
 
 func inspect(certFile string) {
-	b, err := ioutil.ReadFile(certFile)
+	b, err := os.ReadFile(certFile)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tools/mdm/apple/getaccount/main.go
+++ b/tools/mdm/apple/getaccount/main.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -34,7 +33,7 @@ func main() {
 	if *appleBMToken == "" {
 		log.Fatal("must provide Apple BM token")
 	}
-	tok, err := ioutil.ReadFile(*appleBMToken)
+	tok, err := os.ReadFile(*appleBMToken)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
