### PR TITLE
Fix certain datetimes to display "Never" when they are prior to Fleet's launch date

### DIFF
--- a/frontend/components/HumanTimeDiffWithDateTip/HumanTimeDiffWithDateTip.stories.tsx
+++ b/frontend/components/HumanTimeDiffWithDateTip/HumanTimeDiffWithDateTip.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 
-import HumanTimeDiffWithDateTip from "./HumanTimeDiffWithDateTip";
+import { HumanTimeDiffWithDateTip } from "./HumanTimeDiffWithDateTip";
 
 const meta: Meta<typeof HumanTimeDiffWithDateTip> = {
   title: "Components/HumanTimeDiffWithDateTip",

--- a/frontend/components/HumanTimeDiffWithDateTip/HumanTimeDiffWithDateTip.tests.tsx
+++ b/frontend/components/HumanTimeDiffWithDateTip/HumanTimeDiffWithDateTip.tests.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { renderWithSetup } from "test/test-utils";
 
-import HumanTimeDiffWithDateTip from "./HumanTimeDiffWithDateTip";
+import {
+  HumanTimeDiffWithDateTip,
+  HumanTimeDiffWithFleetLaunchCutoff,
+} from "./HumanTimeDiffWithDateTip";
 
 const EMPTY_STRING = "Unavailable";
 const INVALID_STRING = "Invalid date";
@@ -32,5 +35,13 @@ describe("HumanTimeDiffWithDateTip - component", () => {
 
     const invalidStringText = screen.getByText(INVALID_STRING);
     expect(invalidStringText).toBeInTheDocument();
+  });
+
+  it("returns never if configured to cutoff dates before Fleet was created", async () => {
+    render(
+      <HumanTimeDiffWithFleetLaunchCutoff timeString="1970-01-02T00:00:00Z" />
+    );
+
+    expect(screen.getByText(/never/i)).toBeInTheDocument();
   });
 });

--- a/frontend/components/HumanTimeDiffWithDateTip/HumanTimeDiffWithDateTip.tsx
+++ b/frontend/components/HumanTimeDiffWithDateTip/HumanTimeDiffWithDateTip.tsx
@@ -2,19 +2,32 @@ import React from "react";
 
 import { uniqueId } from "lodash";
 import { humanLastSeen, internationalTimeFormat } from "utilities/helpers";
+import { INITIAL_FLEET_DATE } from "utilities/constants";
 import ReactTooltip from "react-tooltip";
 
 interface IHumanTimeDiffWithDateTip {
   timeString: string;
+  cutoffBeforeFleetLaunch?: boolean;
 }
 
 /** Returns "Unavailable" if date is empty string or "Unavailable"
- * Returns "Invalid date" if date is invalid */
-export default ({ timeString }: IHumanTimeDiffWithDateTip): JSX.Element => {
+ * Returns "Invalid date" if date is invalid
+ * Returns "Never" if cutoffBeforeFleetLaunch is true and date is before the
+ * initial launch of Fleet */
+export const HumanTimeDiffWithDateTip = ({
+  timeString,
+  cutoffBeforeFleetLaunch = false,
+}: IHumanTimeDiffWithDateTip): JSX.Element => {
   const id = uniqueId();
 
   if (timeString === "Unavailable" || timeString === "") {
     return <span>Unavailable</span>;
+  }
+
+  // There are cases where dates are set in Fleet to be the "zero date" which
+  // serves as an indicator that a particular date isn't set.
+  if (cutoffBeforeFleetLaunch && timeString < INITIAL_FLEET_DATE) {
+    return <span>Never</span>;
   }
 
   try {
@@ -41,4 +54,14 @@ export default ({ timeString }: IHumanTimeDiffWithDateTip): JSX.Element => {
     }
     return <span>Unavailable</span>;
   }
+};
+
+/** Returns a HumanTimeDiffWithDateTip configured to return "Never" in the case
+ * that the timeString is before the launch date of Fleet */
+export const HumanTimeDiffWithFleetLaunchCutoff = ({
+  timeString,
+}: IHumanTimeDiffWithDateTip): JSX.Element => {
+  return (
+    <HumanTimeDiffWithDateTip timeString={timeString} cutoffBeforeFleetLaunch />
+  );
 };

--- a/frontend/components/HumanTimeDiffWithDateTip/index.ts
+++ b/frontend/components/HumanTimeDiffWithDateTip/index.ts
@@ -1,1 +1,4 @@
-export { default } from "./HumanTimeDiffWithDateTip";
+export {
+  HumanTimeDiffWithDateTip,
+  HumanTimeDiffWithFleetLaunchCutoff,
+} from "./HumanTimeDiffWithDateTip";

--- a/frontend/pages/UserSettingsPage/UserSidePanel/UserSidePanel.tsx
+++ b/frontend/pages/UserSettingsPage/UserSidePanel/UserSidePanel.tsx
@@ -9,7 +9,7 @@ import versionAPI from "services/entities/version";
 
 import Avatar from "components/Avatar";
 import Button from "components/buttons/Button";
-import HumanTimeDiffWithDateTip from "components/HumanTimeDiffWithDateTip";
+import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 
 import {
   generateRole,

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -15,7 +15,7 @@ import StatusIndicator from "components/StatusIndicator";
 import TextCell from "components/TableContainer/DataTable/TextCell/TextCell";
 import TruncatedTextCell from "components/TableContainer/DataTable/TruncatedTextCell";
 import TooltipWrapper from "components/TooltipWrapper";
-import HumanTimeDiffWithDateTip from "components/HumanTimeDiffWithDateTip";
+import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 import CustomLink from "components/CustomLink";
 import NotSupported from "components/NotSupported";
 

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -15,7 +15,7 @@ import StatusIndicator from "components/StatusIndicator";
 import TextCell from "components/TableContainer/DataTable/TextCell/TextCell";
 import TruncatedTextCell from "components/TableContainer/DataTable/TruncatedTextCell";
 import TooltipWrapper from "components/TooltipWrapper";
-import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
+import { HumanTimeDiffWithFleetLaunchCutoff } from "components/HumanTimeDiffWithDateTip";
 import CustomLink from "components/CustomLink";
 import NotSupported from "components/NotSupported";
 
@@ -527,7 +527,7 @@ const allHostTableHeaders: IDataColumn[] = [
     Cell: (cellProps: ICellProps) => (
       <TextCell
         value={{ timeString: cellProps.cell.value }}
-        formatter={HumanTimeDiffWithDateTip}
+        formatter={HumanTimeDiffWithFleetLaunchCutoff}
       />
     ),
   },
@@ -555,7 +555,7 @@ const allHostTableHeaders: IDataColumn[] = [
     Cell: (cellProps: ICellProps) => (
       <TextCell
         value={{ timeString: cellProps.cell.value }}
-        formatter={HumanTimeDiffWithDateTip}
+        formatter={HumanTimeDiffWithFleetLaunchCutoff}
       />
     ),
   },
@@ -594,7 +594,7 @@ const allHostTableHeaders: IDataColumn[] = [
           value={{
             timeString: humanHostLastRestart(detail_updated_at, uptime),
           }}
-          formatter={HumanTimeDiffWithDateTip}
+          formatter={HumanTimeDiffWithFleetLaunchCutoff}
         />
       );
     },

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import ReactTooltip from "react-tooltip";
-import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
+import { HumanTimeDiffWithFleetLaunchCutoff } from "components/HumanTimeDiffWithDateTip";
 import TooltipWrapper from "components/TooltipWrapper";
 import CustomLink from "components/CustomLink";
 
@@ -201,7 +201,7 @@ const About = ({
         <div className="info-grid__block">
           <span className="info-grid__header">Added to Fleet</span>
           <span className="info-grid__data">
-            <HumanTimeDiffWithDateTip
+            <HumanTimeDiffWithFleetLaunchCutoff
               timeString={aboutData.last_enrolled_at ?? "Unavailable"}
             />
           </span>
@@ -209,7 +209,7 @@ const About = ({
         <div className="info-grid__block">
           <span className="info-grid__header">Last restarted</span>
           <span className="info-grid__data">
-            <HumanTimeDiffWithDateTip
+            <HumanTimeDiffWithFleetLaunchCutoff
               timeString={humanHostLastRestart(
                 aboutData.detail_updated_at,
                 aboutData.uptime

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import ReactTooltip from "react-tooltip";
-import HumanTimeDiffWithDateTip from "components/HumanTimeDiffWithDateTip";
+import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 import TooltipWrapper from "components/TooltipWrapper";
 import CustomLink from "components/CustomLink";
 

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -13,7 +13,7 @@ import TooltipWrapper from "components/TooltipWrapper";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon/Icon";
 import DiskSpaceGraph from "components/DiskSpaceGraph";
-import HumanTimeDiffWithDateTip from "components/HumanTimeDiffWithDateTip";
+import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 import PremiumFeatureIconWithTooltip from "components/PremiumFeatureIconWithTooltip";
 import {
   getHostDiskEncryptionTooltipMessage,

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -13,7 +13,7 @@ import TooltipWrapper from "components/TooltipWrapper";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon/Icon";
 import DiskSpaceGraph from "components/DiskSpaceGraph";
-import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
+import { HumanTimeDiffWithFleetLaunchCutoff } from "components/HumanTimeDiffWithDateTip";
 import PremiumFeatureIconWithTooltip from "components/PremiumFeatureIconWithTooltip";
 import {
   getHostDiskEncryptionTooltipMessage,
@@ -299,7 +299,9 @@ const HostSummary = ({
   };
 
   const lastFetched = titleData.detail_updated_at ? (
-    <HumanTimeDiffWithDateTip timeString={titleData.detail_updated_at} />
+    <HumanTimeDiffWithFleetLaunchCutoff
+      timeString={titleData.detail_updated_at}
+    />
   ) : (
     ": unavailable"
   );

--- a/frontend/pages/software/SoftwareDetailsPage/components/Vulnerabilities/VulnTableConfig.tsx
+++ b/frontend/pages/software/SoftwareDetailsPage/components/Vulnerabilities/VulnTableConfig.tsx
@@ -8,7 +8,7 @@ import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCel
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import TooltipWrapper from "components/TooltipWrapper";
 import CustomLink from "components/CustomLink";
-import HumanTimeDiffWithDateTip from "components/HumanTimeDiffWithDateTip";
+import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 import PremiumFeatureIconWithTooltip from "components/PremiumFeatureIconWithTooltip";
 
 interface IHeaderProps {


### PR DESCRIPTION
# Checklist for submitter

- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality

> [!NOTE]  
> For the reviewer, you won't hurt my feelings at all if you have a better implementation in mind and want to close this out! I'll be upfront that I'm much more of a Go dev than a frontend dev. I'm just using this issue as an opportunity to become more familiar with Fleet, since I'm a fan of what y'all are doing and have been looking for a project to spend some spare-time contributing to 😄 
>
> You should also have edit access to this branch, so feel free to commandeer it as you see fit.

# Summary

This PR aims to fix a regression identified in #14353 in which certain "zero" datetimes are displayed as "54 years ago" instead of the preferred "Never". The "zero" datetimes are commonly used [as a proxy to indicate](https://github.com/fleetdm/fleet/blob/5cb8051a409df9e82178d9cbe67e7d2370016db2/server/datastore/mysql/hosts.go#L1649) that a date wasn't set, e.g. when a host hasn't had its details fetched yet.

We don't want to apply this treatment to _all_ datetimes, since some (like vulnerability data) have valid dates before Fleet was created.

To support both use cases, I:

* Added an optional boolean, `cutoffBeforeFleetLaunch`, to indicate that dates should be cutoff prior to the hardcoded Fleet launch date. This is set to `false` in `HumanTimeDiffWithDateTip` for backwards-compatibility.
* Created `HumanTimeDiffWithFleetLaunchCutoff` which is a drop-in replacement for `HumanTimeDiffWithDateTip` that sets the `cutoffBeforeFleetLaunch` flag to `true`.

I then used `HumanTimeDiffWithFleetLaunchCutoff` in the various host related fields I could find. It's possible I missed some, so please double-check me! I'm still getting my bearings on the codebase.

Here's a screenshot showing the host table with a host that I had deleted and waited to appear again:

<img width="1381" alt="Screenshot 2023-10-11 at 11 27 29 PM" src="https://github.com/fleetdm/fleet/assets/1317288/3cd23879-3233-409f-91a0-8b5e02d09deb">

You may find it helpful to review this commit-by-commit.

Closes #14353