### PR TITLE
Fleet UI: [tiny fix] Body background color for auth pages on resize

### DIFF
--- a/changes/bug-14106-setup-resizing-body-color
+++ b/changes/bug-14106-setup-resizing-body-color
@@ -1,0 +1,1 @@
+- Setup flows background covers the entire viewport when resized

--- a/frontend/components/AuthenticationFormWrapper/_styles.scss
+++ b/frontend/components/AuthenticationFormWrapper/_styles.scss
@@ -14,3 +14,8 @@
     height: 100vh;
   }
 }
+
+// Ensures resizing viewport matches bottom of page color gradients-dark-gradient-vertical
+body {
+  background-color: #201e43;
+}


### PR DESCRIPTION
## Issue
Cerra #14106 

## Description
- When resizing a login/setup page to be taller than viewport, app `body` shows white beyond the viewport
- Add background color for `body`

## Screenrecording of fix on 3 different browsers

https://github.com/fleetdm/fleet/assets/71795832/eb985408-61b3-4411-93f9-2105a0d2e342



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

