### PR TITLE
Fleet UI: [tiny bug] Autosize input does not scroll within itself

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
@@ -72,7 +72,7 @@
         .component__auto-size-input-field {
           letter-spacing: -0.5px;
           line-height: 2.3rem;
-          padding-top: 2px;
+          margin-top: 2px;
         }
       }
       .policy-description-wrapper {

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -64,7 +64,7 @@
         .component__auto-size-input-field {
           letter-spacing: -0.5px;
           line-height: 2.3rem;
-          padding-top: 2px;
+          margin-top: 2px;
         }
       }
       .query-description-wrapper {


### PR DESCRIPTION
## Issue
Cerra #14272 

## Description
- Keep 2px padding but remove it from inside the element which is causing the scrollbar by making it a 2px margin

## Screenrecording of before and after the fix

https://github.com/fleetdm/fleet/assets/71795832/13e96482-2b81-47cb-a646-730917744017



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
