### PR TITLE
Fix link formatting in "Get a list of Visual Studio Code extensions" query

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -1051,7 +1051,7 @@ kind: query
 spec:
   name: Get a list of Visual Studio Code extensions
   platform: darwin
-  description: Get a list of installed VS Code extensions. Requires (fleetd)[https://fleetdm.com/docs/using-fleet/fleetd].
+  description: Get a list of installed VS Code extensions. Requires [fleetd](https://fleetdm.com/docs/using-fleet/fleetd).
   query: |
     SELECT  split(user_path, '/', 1) as username,
         json_extract(value, '$.identifier.id') as id,


### PR DESCRIPTION
Fixed link formatting in "Get a list of Visual Studio Code extensions" query