### PR TITLE
Disable edit query for o and o+

### DIFF
--- a/frontend/components/AuthenticationFormWrapper/_styles.scss
+++ b/frontend/components/AuthenticationFormWrapper/_styles.scss
@@ -14,8 +14,3 @@
     height: 100vh;
   }
 }
-
-// Ensures resizing viewport matches bottom of page color gradients-dark-gradient-vertical
-body {
-  background-color: #201e43;
-}

--- a/frontend/components/forms/RegistrationForm/_styles.scss
+++ b/frontend/components/forms/RegistrationForm/_styles.scss
@@ -3,7 +3,7 @@
   justify-content: center;
   align-items: stretch;
   margin-top: $pad-large;
-  min-height: 750px;
+  min-height: 950px;
 
   &__container {
     @include size(500px auto);

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -232,7 +232,9 @@ const routes = (
             </Route>
             <Route path=":id">
               <IndexRoute component={QueryDetailsPage} />
-              <Route path="edit" component={EditQueryPage} />
+              <Route component={AuthAnyMaintainerAnyAdminRoutes}>
+                <Route path="edit" component={EditQueryPage} />
+              </Route>
               <Route path="live" component={LiveQueryPage} />
             </Route>
           </Route>


### PR DESCRIPTION
## Addresses pt.1 of #14498 

- Block access to edit query page for Observer and Observer+ roles
- Fix a styling problem on the 403 page, while maintaining the previous fix elsewhere that caused it