### PR TITLE
Check interval when determining if 'collecting results'

### DIFF
--- a/frontend/pages/queries/details/components/NoResults/NoResults.tsx
+++ b/frontend/pages/queries/details/components/NoResults/NoResults.tsx
@@ -36,7 +36,8 @@ const NoResults = ({
   };
 
   // Update status of collecting cached results
-  const collectingResults = secondsCheckbackTime() > 0;
+  const collectingResults =
+    (queryInterval ?? 0) > 0 && secondsCheckbackTime() > 0;
 
   // Converts seconds takes to update to human readable format
   const readableCheckbackTime = formatDistance(


### PR DESCRIPTION
## Addresses #14515 

- Include a check that a query's interval is set to something other than never when deciding whether to display "Collecting results"