### PR TITLE
Fix false positive vulnerability for python on macOS

### DIFF
--- a/changes/11923-python-false-positive-macos
+++ b/changes/11923-python-false-positive-macos
@@ -1,0 +1,1 @@
+* Fix python's false positive CVE-2021-42919 found on macOS that should only affect linux hosts.

--- a/server/vulnerabilities/nvd/cpe_matching_rules.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rules.go
@@ -147,6 +147,40 @@ func GetKnownNVDBugRules() (CPEMatchingRules, error) {
 				"CVE-2013-0340": {},
 			},
 		},
+		// CVE-2022-42919 only affects Python on Linux but the NVD dataset doesn't set target_sw=linux.
+		// For instance, here's an invalid CPE sample from the NVD dataset from this vulnerability as of Oct 13th 2023:
+		// `cpe:2.3:a:python:python:3.7.3:-:*:*:*:*:*:*`.
+		CPEMatchingRule{
+			CVEs: map[string]struct{}{
+				"CVE-2022-42919": {},
+			},
+			CPESpecs: []CPEMatchingRuleSpec{
+				{
+					Vendor:           "python",
+					Product:          "python",
+					TargetSW:         "linux",
+					SemVerConstraint: ">= 3.9.0, < 3.9.16",
+				},
+				{
+					Vendor:           "python",
+					Product:          "python",
+					TargetSW:         "linux",
+					SemVerConstraint: ">= 3.10.0, < 3.10.9",
+				},
+				{
+					Vendor:           "python",
+					Product:          "python",
+					TargetSW:         "linux",
+					SemVerConstraint: ">= 3.8.3, <= 3.8.15",
+				},
+				{
+					Vendor:           "python",
+					Product:          "python",
+					TargetSW:         "linux",
+					SemVerConstraint: ">= 3.7.3, <= 3.7.15",
+				},
+			},
+		},
 	}
 
 	for i, rule := range rules {

--- a/tools/nvdvuln/README.md
+++ b/tools/nvdvuln/README.md
@@ -1,0 +1,28 @@
+# nvdvuln
+
+This tool can be used to reproduce false positive vulnerabilities found by Fleet.
+
+The tool allows you to run vulnerability processing using the NVD dataset on a specific software item.
+Such software item should be specified to the tool with the fields as stored in Fleet's `software` MySQL table.
+
+PS: This tool is only useful on systems and software where the NVD dataset is used to detect vulnerabilities. For instance, this tool should not be used with Microsoft Office applications for macOS because Fleet uses a different dataset to detect vulnerabilities on such applications.
+
+## Example
+
+```sh
+go run -tags fts5 ./tools/nvdvuln \
+    -software_name Python.app \
+    -software_version 3.7.3 \
+    -software_source apps \
+    -software_bundle_identifier com.apple.python3 \
+    -sync \
+    -vuln_db_dir /tmp/vulndbtest
+[...]
+CVEs found for Python.app (3.7.3): CVE-2007-4559, CVE-2019-10160, CVE-2019-15903, CVE-2022-0391,
+CVE-2020-14422, CVE-2020-10735, CVE-2023-40217, CVE-2015-20107, CVE-2016-3189, CVE-2018-25032,
+CVE-2019-20907, CVE-2019-9740, CVE-2020-8315, CVE-2019-16056, CVE-2021-3177, CVE-2021-23336,
+CVE-2022-48560, CVE-2022-45061, CVE-2019-18348, CVE-2019-16935, CVE-2019-9947, CVE-2021-4189,
+CVE-2021-3426, CVE-2022-48566, CVE-2021-3733, CVE-2022-48564, CVE-2023-24329, CVE-2023-27043,
+CVE-2019-12900, CVE-2021-28861, CVE-2023-36632, CVE-2022-48565, CVE-2019-9948, CVE-2020-8492,
+CVE-2020-27619, CVE-2020-26116, CVE-2021-3737, CVE-2022-37454
+```

--- a/tools/nvdvuln/nvdvuln.go
+++ b/tools/nvdvuln/nvdvuln.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/nvd"
+	"github.com/go-kit/log"
+)
+
+func main() {
+	sync := flag.Bool("sync", false, "...")
+	vulnDBDir := flag.String("vuln_db_dir", "/tmp/vulndbs", "...")
+
+	softwareName := flag.String("software_name", "", "Name of the software as ingested by Fleet")
+	softwareVersion := flag.String("software_version", "", "Version of the software as ingested by Fleet")
+	softwareSource := flag.String("software_source", "", "Source for this software (e.g. 'apps' for macOS applications)")
+	softwareBundleIdentifier := flag.String("software_bundle_identifier", "", "Bundle identifier of the software as ingested by Fleet (for macOS apps only)")
+
+	flag.Parse()
+
+	if *softwareName == "" {
+		fmt.Println("Must set -software_name flag.")
+		return
+	}
+	if *softwareVersion == "" {
+		fmt.Println("Must set -software_version flag.")
+		return
+	}
+	if *softwareSource == "" {
+		fmt.Println("Must set -software_source flag.")
+		return
+	}
+
+	if err := os.MkdirAll(*vulnDBDir, os.ModePerm); err != nil {
+		panic(err)
+	}
+
+	logger := log.NewJSONLogger(os.Stdout)
+
+	if *sync {
+		fmt.Printf("Syncing into %s...\n", *vulnDBDir)
+		if err := vulnDBSync(*vulnDBDir, logger); err != nil {
+			panic(err)
+		}
+	}
+
+	ctx := context.Background()
+
+	ds := new(mock.Store)
+
+	ds.AllSoftwareIteratorFunc = func(ctx context.Context, query fleet.SoftwareIterQueryOptions) (fleet.SoftwareIterator, error) {
+		return &softwareIterator{
+			software: []fleet.Software{
+				{
+					Name:             *softwareName,
+					Version:          *softwareVersion,
+					Source:           *softwareSource,
+					BundleIdentifier: *softwareBundleIdentifier,
+				},
+			},
+		}, nil
+	}
+	var softwareCPEs []fleet.SoftwareCPE
+	ds.UpsertSoftwareCPEsFunc = func(ctx context.Context, cpes []fleet.SoftwareCPE) (int64, error) {
+		softwareCPEs = cpes
+		return int64(len(cpes)), nil
+	}
+	ds.ListSoftwareCPEsFunc = func(ctx context.Context) ([]fleet.SoftwareCPE, error) {
+		return softwareCPEs, nil
+	}
+	ds.InsertSoftwareVulnerabilityFunc = func(ctx context.Context, vuln fleet.SoftwareVulnerability, source fleet.VulnerabilitySource) (bool, error) {
+		return true, nil
+	}
+	ds.DeleteOutOfDateVulnerabilitiesFunc = func(ctx context.Context, source fleet.VulnerabilitySource, duration time.Duration) error {
+		return nil
+	}
+
+	fmt.Println("Translating software to CPE...")
+	err := nvd.TranslateSoftwareToCPE(ctx, ds, *vulnDBDir, logger)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Translating CPEs to CVEs...")
+	vulns, err := nvd.TranslateCPEToCVE(ctx, ds, *vulnDBDir, logger, true, 1*time.Hour)
+	if err != nil {
+		panic(err)
+	}
+	var cves []string
+	for _, vuln := range vulns {
+		cves = append(cves, vuln.CVE)
+	}
+	fmt.Printf("CVEs found for %s (%s): %s\n", *softwareName, *softwareVersion, strings.Join(cves, ", "))
+}
+
+type softwareIterator struct {
+	software []fleet.Software
+	i        int
+}
+
+func (s *softwareIterator) Next() bool {
+	if s.i >= len(s.software) {
+		return false
+	}
+	return true
+}
+
+func (s *softwareIterator) Value() (*fleet.Software, error) {
+	ss := &s.software[s.i]
+	s.i += 1
+	return ss, nil
+}
+
+func (s *softwareIterator) Err() error {
+	return nil
+}
+
+func (s *softwareIterator) Close() error {
+	return nil
+}
+
+func vulnDBSync(vulnDBDir string, logger log.Logger) error {
+	opts := nvd.SyncOptions{
+		VulnPath: vulnDBDir,
+	}
+	err := nvd.Sync(opts, logger)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
#11923

- [X] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- ~[ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)~
- ~[ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- ~[ ] Added/updated tests~
- [x] Manual QA for all new/changed functionality
  - ~For Orbit and Fleet Desktop changes:~
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
