### PR TITLE
Fix panic in `osquery-perf`

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -843,7 +843,7 @@ func (a *agent) config() {
 			q.Name = queryName
 			q.NumResults = 1
 			parts := strings.Split(q.Name, "_")
-			if len(parts) > 0 {
+			if len(parts) == 2 {
 				num, err := strconv.ParseInt(parts[1], 10, 32)
 				if err != nil {
 					num = 1


### PR DESCRIPTION
This is safe to merge during freeze as this is an osquery-perf only change.
```
panic: runtime error: index out of range [1] with length 1

goroutine 14 [running]:
main.(*agent).config(0xc0001e5b80)
        /Users/luk/fleetdm/git/fleet/cmd/osquery-perf/agent.go:847 +0xb74
main.(*agent).runLoop(0xc0001e5b80, 0x0?, 0x0?)
        /Users/luk/fleetdm/git/fleet/cmd/osquery-perf/agent.go:463 +0x4d2
created by main.main in goroutine 1
        /Users/luk/fleetdm/git/fleet/cmd/osquery-perf/agent.go:1666 +0x1285
```