### PR TITLE
Fix link formatting

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -1021,7 +1021,7 @@ kind: query
 spec:
   name: Geolocate via ipapi.co
   platform: darwin, linux, windows
-  description: Geolocate a host using the (ipapi.co)[https://ipapi.co] in an emergency. Requires the curl table. [Learn more](https://fleetdm.com/guides/locate-assets-with-osquery).
+  description: Geolocate a host using the [ipapi.co](https://ipapi.co) in an emergency. Requires the curl table. [Learn more](https://fleetdm.com/guides/locate-assets-with-osquery).
   query: >-
     SELECT JSON_EXTRACT(result, '$.ip') AS ip,
     JSON_EXTRACT(result, '$.city') AS city,

--- a/docs/Deploy/Reference-Architectures.md
+++ b/docs/Deploy/Reference-Architectures.md
@@ -189,7 +189,7 @@ GCP reference architecture can be found in [the Fleet repository](https://github
 
 ### Azure
 
-Coming soon. Get (commmunity support)[https://chat.osquery.io/c/fleet].
+Coming soon. Get [commmunity support](https://chat.osquery.io/c/fleet).
 
 ### Render
 


### PR DESCRIPTION
Fixed markdown syntax for links in a couple places where it was formatted incorrectly (`(…)[…]` instead of `[…](…)`)

(Fixed one earlier and just searched the docs folder for `)[` to find these; hopefully this PR nabs the rest.)