### PR TITLE
Fleet UI: [1 edge case fix] 7766 Logging set to empty string

### DIFF
--- a/frontend/interfaces/schedulable_query.ts
+++ b/frontend/interfaces/schedulable_query.ts
@@ -126,4 +126,5 @@ export interface IEditQueryFormFields {
 export type QueryLoggingOption =
   | "snapshot"
   | "differential"
-  | "differential_ignore_removals";
+  | "differential_ignore_removals"
+  | ""; // Edge case where logging can be set to empty string using fleetctl prior to v4.39

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -261,7 +261,11 @@ const QueryDetailsPage = ({
   );
 
   const renderReport = () => {
-    const loggingSnapshot = lastEditedQueryLoggingType === "snapshot";
+    // Includes edge case where logging can be set to empty string using fleetctl prior to v4.39
+    // Backend treats logging set to "" as "snapshot"
+    const loggingSnapshot =
+      lastEditedQueryLoggingType === "snapshot" ||
+      lastEditedQueryLoggingType === "";
     const disabledCaching =
       disabledCachingGlobally || lastEditedQueryDiscardData || !loggingSnapshot;
     const emptyCache = (queryReport?.results?.length ?? 0) === 0;

--- a/frontend/pages/queries/edit/components/DiscardDataOption/DiscardDataOption.tsx
+++ b/frontend/pages/queries/edit/components/DiscardDataOption/DiscardDataOption.tsx
@@ -84,6 +84,15 @@ const DiscardDataOption = ({
           </>
         </InfoBanner>
       )}
+      {selectedLoggingType === "" && (
+        <InfoBanner color="purple-bold-border">
+          <>
+            The <b>Discard data</b> setting is ignored when logging is not set
+            to <b>snapshot</b>. This query&apos;s results will not be saved in
+            Fleet.
+          </>
+        </InfoBanner>
+      )}
       <Checkbox
         name="discardData"
         onChange={setDiscardData}

--- a/frontend/pages/queries/edit/components/DiscardDataOption/DiscardDataOption.tsx
+++ b/frontend/pages/queries/edit/components/DiscardDataOption/DiscardDataOption.tsx
@@ -84,15 +84,6 @@ const DiscardDataOption = ({
           </>
         </InfoBanner>
       )}
-      {selectedLoggingType === "" && (
-        <InfoBanner color="purple-bold-border">
-          <>
-            The <b>Discard data</b> setting is ignored when logging is not set
-            to <b>snapshot</b>. This query&apos;s results will not be saved in
-            Fleet.
-          </>
-        </InfoBanner>
-      )}
       <Checkbox
         name="discardData"
         onChange={setDiscardData}

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -320,7 +320,12 @@ const EditQueryForm = ({
           interval: lastEditedQueryFrequency,
           platform: lastEditedQueryPlatforms,
           min_osquery_version: lastEditedQueryMinOsqueryVersion,
-          logging: lastEditedQueryLoggingType,
+          // Converts edge case where logging can be set to empty string using fleetctl prior to v4.39
+          // Backend treats logging set to "" as "snapshot"
+          logging:
+            lastEditedQueryLoggingType === ""
+              ? "snapshot"
+              : lastEditedQueryLoggingType,
         })
         .then((response: { query: ISchedulableQuery }) => {
           setIsSaveAsNewLoading(false);
@@ -730,7 +735,13 @@ const EditQueryForm = ({
                     options={LOGGING_TYPE_OPTIONS}
                     onChange={onChangeSelectLoggingType}
                     placeholder="Select"
-                    value={lastEditedQueryLoggingType}
+                    // Backend treats edge case logging set to ""  using fleetctl prior to v4.39 as "snapshot"
+                    // Displays logging set to empty string as snapshot
+                    value={
+                      lastEditedQueryLoggingType === ""
+                        ? "snapshot"
+                        : lastEditedQueryLoggingType
+                    }
                     label="Logging"
                     wrapperClassName={`${baseClass}__form-field ${baseClass}__form-field--logging`}
                   />


### PR DESCRIPTION
## Description
- UI components treat `logging: ""` as `logging: "snapshot"` to match backend behavior 



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality