### PR TITLE
UI: Reroute Live query Cancel and Done buttons

### DIFF
--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -46,7 +46,7 @@ interface ISelectTargetsProps {
   targetedHosts: IHost[];
   targetedLabels: ILabel[];
   targetedTeams: ITeam[];
-  exitLiveQueryFlow: () => void;
+  exitLiveFlow: () => void;
   goToRunQuery: () => void;
   setSelectedTargets: // TODO: Refactor policy targets to streamline selectedTargets/selectedTargetsByType
   | React.Dispatch<React.SetStateAction<ITarget[]>> // Used for policies page level useState hook
@@ -132,7 +132,7 @@ const SelectTargets = ({
   targetedHosts,
   targetedLabels,
   targetedTeams,
-  exitLiveQueryFlow,
+  exitLiveFlow,
   goToRunQuery,
   setSelectedTargets,
   setTargetedHosts,
@@ -451,7 +451,7 @@ const SelectTargets = ({
         <Button
           className={`${baseClass}__btn`}
           onClick={() => {
-            exitLiveQueryFlow();
+            exitLiveFlow();
           }}
           variant="text-link"
         >

--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -46,7 +46,7 @@ interface ISelectTargetsProps {
   targetedHosts: IHost[];
   targetedLabels: ILabel[];
   targetedTeams: ITeam[];
-  goToQueryEditor: () => void;
+  exitLiveQueryFlow: () => void;
   goToRunQuery: () => void;
   setSelectedTargets: // TODO: Refactor policy targets to streamline selectedTargets/selectedTargetsByType
   | React.Dispatch<React.SetStateAction<ITarget[]>> // Used for policies page level useState hook
@@ -132,7 +132,7 @@ const SelectTargets = ({
   targetedHosts,
   targetedLabels,
   targetedTeams,
-  goToQueryEditor,
+  exitLiveQueryFlow,
   goToRunQuery,
   setSelectedTargets,
   setTargetedHosts,
@@ -261,10 +261,6 @@ const SelectTargets = ({
     setIsDebouncing(true);
     debounceSearch(searchText);
   }, [searchText]);
-
-  const handleClickCancel = () => {
-    goToQueryEditor();
-  };
 
   const handleButtonSelect = (selectedEntity: ISelectTargetsEntity) => (
     e: React.MouseEvent<HTMLButtonElement>
@@ -454,7 +450,9 @@ const SelectTargets = ({
       <div className={`${baseClass}__targets-button-wrap`}>
         <Button
           className={`${baseClass}__btn`}
-          onClick={handleClickCancel}
+          onClick={() => {
+            exitLiveQueryFlow();
+          }}
           variant="text-link"
         >
           Cancel

--- a/frontend/pages/policies/PolicyPage/PolicyPage.tsx
+++ b/frontend/pages/policies/PolicyPage/PolicyPage.tsx
@@ -247,7 +247,7 @@ const PolicyPage = ({
   };
 
   const renderScreen = () => {
-    const step1Opts = {
+    const step1Props = {
       router,
       baseClass,
       policyIdForEdit: policyId,
@@ -265,14 +265,14 @@ const PolicyPage = ({
       renderLiveQueryWarning,
     };
 
-    const step2Opts = {
+    const step2Props = {
       baseClass,
       selectedTargets,
       targetedHosts,
       targetedLabels,
       targetedTeams,
       targetsTotalCount,
-      goToQueryEditor: () => setStep(LIVE_POLICY_STEPS[1]),
+      exitLiveFlow: () => setStep(LIVE_POLICY_STEPS[1]),
       goToRunQuery: () => setStep(LIVE_POLICY_STEPS[3]),
       setSelectedTargets,
       setTargetedHosts,
@@ -281,7 +281,7 @@ const PolicyPage = ({
       setTargetsTotalCount,
     };
 
-    const step3Opts = {
+    const step3Props = {
       selectedTargets,
       storedPolicy,
       setSelectedTargets,
@@ -291,11 +291,11 @@ const PolicyPage = ({
 
     switch (step) {
       case LIVE_POLICY_STEPS[2]:
-        return <SelectTargets {...step2Opts} />;
+        return <SelectTargets {...step2Props} />;
       case LIVE_POLICY_STEPS[3]:
-        return <RunQuery {...step3Opts} />;
+        return <RunQuery {...step3Props} />;
       default:
-        return <QueryEditor {...step1Opts} />;
+        return <QueryEditor {...step1Props} />;
     }
   };
 

--- a/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
@@ -30,7 +30,7 @@ interface IQueryResultsProps {
   onRunQuery: () => void;
   onStopQuery: (evt: React.MouseEvent<HTMLButtonElement>) => void;
   setSelectedTargets: (value: ITarget[]) => void;
-  goToQueryEditor: () => void;
+  exitLiveQueryFlow: () => void;
   targetsTotalCount: number;
 }
 
@@ -48,7 +48,7 @@ const QueryResults = ({
   onRunQuery,
   onStopQuery,
   setSelectedTargets,
-  goToQueryEditor,
+  exitLiveQueryFlow,
   targetsTotalCount,
 }: IQueryResultsProps): JSX.Element => {
   const { lastEditedQueryBody } = useContext(QueryContext);
@@ -137,7 +137,7 @@ const QueryResults = ({
 
   const onQueryDone = () => {
     setSelectedTargets([]);
-    goToQueryEditor();
+    exitLiveQueryFlow();
   };
 
   const renderNoResults = () => {

--- a/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
@@ -30,7 +30,7 @@ interface IQueryResultsProps {
   onRunQuery: () => void;
   onStopQuery: (evt: React.MouseEvent<HTMLButtonElement>) => void;
   setSelectedTargets: (value: ITarget[]) => void;
-  exitLiveQueryFlow: () => void;
+  exitLiveFlow: () => void;
   targetsTotalCount: number;
 }
 
@@ -48,7 +48,7 @@ const QueryResults = ({
   onRunQuery,
   onStopQuery,
   setSelectedTargets,
-  exitLiveQueryFlow,
+  exitLiveFlow,
   targetsTotalCount,
 }: IQueryResultsProps): JSX.Element => {
   const { lastEditedQueryBody } = useContext(QueryContext);
@@ -137,7 +137,7 @@ const QueryResults = ({
 
   const onQueryDone = () => {
     setSelectedTargets([]);
-    exitLiveQueryFlow();
+    exitLiveFlow();
   };
 
   const renderNoResults = () => {

--- a/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
+++ b/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
@@ -136,7 +136,7 @@ const RunQueryPage = ({
     document.title = `Run live query | ${storedQuery?.name} | Fleet for osquery`;
   }, [location.pathname, storedQuery?.name]);
 
-  const exitLiveQueryFlow = useCallback(
+  const exitLiveFlow = useCallback(
     () =>
       queryId
         ? router.push(PATHS.QUERY(queryId))
@@ -153,7 +153,7 @@ const RunQueryPage = ({
       targetedLabels,
       targetedTeams,
       targetsTotalCount,
-      exitLiveQueryFlow,
+      exitLiveFlow,
       goToRunQuery: () => setStep(LIVE_QUERY_STEPS[2]),
       setSelectedTargets: setSelectedQueryTargets,
       setTargetedHosts,
@@ -167,7 +167,7 @@ const RunQueryPage = ({
       selectedTargets: selectedQueryTargets,
       storedQuery,
       setSelectedTargets: setSelectedQueryTargets,
-      exitLiveQueryFlow,
+      exitLiveFlow,
       targetsTotalCount,
     };
 

--- a/frontend/pages/queries/live/screens/RunQuery.tsx
+++ b/frontend/pages/queries/live/screens/RunQuery.tsx
@@ -22,7 +22,7 @@ interface IRunQueryProps {
   selectedTargets: ITarget[];
   queryId: number | null;
   setSelectedTargets: (value: ITarget[]) => void;
-  goToQueryEditor: () => void;
+  exitLiveQueryFlow: () => void;
   targetsTotalCount: number;
 }
 
@@ -31,7 +31,7 @@ const RunQuery = ({
   selectedTargets,
   queryId,
   setSelectedTargets,
-  goToQueryEditor,
+  exitLiveQueryFlow,
   targetsTotalCount,
 }: IRunQueryProps): JSX.Element | null => {
   const { lastEditedQueryBody } = useContext(QueryContext);
@@ -199,14 +199,16 @@ const RunQuery = ({
   const { campaign } = campaignState;
   return (
     <QueryResults
-      campaign={campaign}
-      onRunQuery={onRunQuery}
-      onStopQuery={onStopQuery}
-      isQueryFinished={isQueryFinished}
-      setSelectedTargets={setSelectedTargets}
-      goToQueryEditor={goToQueryEditor}
       queryName={storedQuery?.name}
-      targetsTotalCount={targetsTotalCount}
+      {...{
+        campaign,
+        onRunQuery,
+        onStopQuery,
+        isQueryFinished,
+        setSelectedTargets,
+        exitLiveQueryFlow,
+        targetsTotalCount,
+      }}
     />
   );
 };

--- a/frontend/pages/queries/live/screens/RunQuery.tsx
+++ b/frontend/pages/queries/live/screens/RunQuery.tsx
@@ -22,7 +22,7 @@ interface IRunQueryProps {
   selectedTargets: ITarget[];
   queryId: number | null;
   setSelectedTargets: (value: ITarget[]) => void;
-  exitLiveQueryFlow: () => void;
+  exitLiveFlow: () => void;
   targetsTotalCount: number;
 }
 
@@ -31,7 +31,7 @@ const RunQuery = ({
   selectedTargets,
   queryId,
   setSelectedTargets,
-  exitLiveQueryFlow,
+  exitLiveFlow,
   targetsTotalCount,
 }: IRunQueryProps): JSX.Element | null => {
   const { lastEditedQueryBody } = useContext(QueryContext);
@@ -206,7 +206,7 @@ const RunQuery = ({
         onStopQuery,
         isQueryFinished,
         setSelectedTargets,
-        exitLiveQueryFlow,
+        exitLiveFlow,
         targetsTotalCount,
       }}
     />


### PR DESCRIPTION
## Addresses part 2 of #14498 

- When a saved query is being run (queryId is present), route to that query's details page in both cases.
  - This flow can be accessed by anyone who can view a given query, including Observers and Observer+s.
- When there is no saved query, meaning a new live query is being run (querId null), route to the manage queries page in both cases.
  - This flow can be accessed by Observer+s (and higher) but not Observers.
- Update names
- Remove unused logic

## Checklist for submitter

- [x] Manual QA for all new/changed functionality