### PR TITLE
Fleet UI: Surface policy resolution to observers in UI

### DIFF
--- a/changes/bug-14431-surface-resolution-to-observers
+++ b/changes/bug-14431-surface-resolution-to-observers
@@ -1,0 +1,1 @@
+- Observers and observer+ can view policy resolutions in UI

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -477,6 +477,12 @@ const PolicyForm = ({
           <p className={`${baseClass}__policy-description no-hover`}>
             {lastEditedQueryDescription}
           </p>
+          <p className="resolve-title">
+            <strong>Resolve:</strong>
+          </p>
+          <p className={`${baseClass}__policy-resolution no-hover`}>
+            {lastEditedQueryResolution}
+          </p>
         </div>
         <div className="author">{renderAuthor()}</div>
       </div>


### PR DESCRIPTION
## Issue
Cerra #14431 

## Description
- Observer can see policy resolution in API but it's hidden in the UI, surface this data in the UI
- TODO: wait on clarification if we also want to surface other policy data returned to observers in API but hidden in UI only for observers

## Screenshot
<img width="982" alt="Screenshot 2023-10-16 at 12 29 12 PM" src="https://github.com/fleetdm/fleet/assets/71795832/2c591a02-11ff-45e6-8599-3345cd57116d">

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

