### PR TITLE
Fleet UI: [Unreleased bug] Observer/Observer+ trying to reach edit query page fix redirects to query report page

### DIFF
--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -69,7 +69,7 @@ const QueryDetailsPage = ({
   const {
     isGlobalAdmin,
     isGlobalMaintainer,
-    isAnyTeamMaintainerOrTeamAdmin,
+    isTeamMaintainerOrTeamAdmin,
     isObserverPlus,
     isAnyTeamObserverPlus,
     config,
@@ -158,7 +158,7 @@ const QueryDetailsPage = ({
 
   const renderHeader = () => {
     const canEditQuery =
-      isGlobalAdmin || isGlobalMaintainer || isAnyTeamMaintainerOrTeamAdmin;
+      isGlobalAdmin || isGlobalMaintainer || isTeamMaintainerOrTeamAdmin;
 
     // Function instead of constant eliminates race condition with filteredQueriesPath
     const backToQueriesPath = () => {

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -64,6 +64,7 @@ const EditQueryPage = ({
   const {
     isGlobalAdmin,
     isGlobalMaintainer,
+    isTeamMaintainerOrTeamAdmin,
     isAnyTeamMaintainerOrTeamAdmin,
     isObserverPlus,
     isAnyTeamObserverPlus,
@@ -149,6 +150,17 @@ const EditQueryPage = ({
       setIsLiveQueryRunnable(false);
     });
   };
+
+  /* Observer/Observer+ cannot edit existing query (O+ has access to edit new query to run live),
+ reroute edit existing query page (/:queryId/edit) to query report page (/:queryId) */
+  useEffect(() => {
+    const canEditExistingQuery =
+      isGlobalAdmin || isGlobalMaintainer || isTeamMaintainerOrTeamAdmin;
+
+    if (queryId && queryId > 0 && !canEditExistingQuery) {
+      router.push(PATHS.QUERY(queryId));
+    }
+  }, [queryId, isTeamMaintainerOrTeamAdmin]);
 
   useEffect(() => {
     detectIsFleetQueryRunnable();

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -232,9 +232,7 @@ const routes = (
             </Route>
             <Route path=":id">
               <IndexRoute component={QueryDetailsPage} />
-              <Route component={AuthAnyMaintainerAnyAdminRoutes}>
-                <Route path="edit" component={EditQueryPage} />
-              </Route>
+              <Route path="edit" component={EditQueryPage} />
               <Route path="live" component={LiveQueryPage} />
             </Route>
           </Route>


### PR DESCRIPTION
## Issue
Cerra #14498 

## Description 
- When trying to navigate directly to `queries/:queryId/edit`, reroute any users who do not have access to edit the query (are not global admin, global maintainer, or a team admin or team maintainer of the query) to the query report page on `queries/:queryId`

## QA 

Engineer tested trying to view `queries/:queryId/edit` for both global queries and team specific queries for
- Global admin
- Global observer
- Global observer +
- Team observer
- Team observer +
- Mixed roles (Team observer for team Apples, team maintainer for team Oranges, should be able to edit queries assigned on team Oranges, but redirected for queries assigned to team Apples)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

