### PR TITLE
Added Apple Rapid Security Response version to host details.

### DIFF
--- a/changes/12888-apple-rapid-security-response
+++ b/changes/12888-apple-rapid-security-response
@@ -1,1 +1,2 @@
-Added Apple Rapid Security Response version to host details.
+Added Apple Rapid Security Response version to macOS host details.
+- This feature (new `extra` column on `os_version` for macOS devices) was added to osquery in v5.9.1. So macOS devices will need >= v5.9.1 version installed to use this feature.

--- a/changes/12888-apple-rapid-security-response
+++ b/changes/12888-apple-rapid-security-response
@@ -1,0 +1,1 @@
+Added Apple Rapid Security Response version to host details.

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -158,6 +158,7 @@ var hostDetailQueries = map[string]DetailQuery{
 					rows[0]["minor"],
 					rows[0]["patch"],
 					rows[0]["build"],
+					rows[0]["extra"],
 				))
 			}
 
@@ -513,6 +514,7 @@ var extraDetailQueries = map[string]DetailQuery{
 		os.major,
 		os.minor,
 		os.patch,
+		os.extra,
 		os.build,
 		os.arch,
 		os.platform,
@@ -985,12 +987,13 @@ func directIngestOSUnixLike(ctx context.Context, logger log.Logger, host *fleet.
 	minor := rows[0]["minor"]
 	patch := rows[0]["patch"]
 	build := rows[0]["build"]
+	extra := rows[0]["extra"]
 	arch := rows[0]["arch"]
 	kernelVersion := rows[0]["kernel_version"]
 	platform := rows[0]["platform"]
 
 	hostOS := fleet.OperatingSystem{Name: name, Arch: arch, KernelVersion: kernelVersion, Platform: platform}
-	hostOS.Version = parseOSVersion(name, version, major, minor, patch, build)
+	hostOS.Version = parseOSVersion(name, version, major, minor, patch, build, extra)
 
 	if err := ds.UpdateHostOperatingSystem(ctx, host.ID, hostOS); err != nil {
 		return ctxerr.Wrap(ctx, err, "directIngestOSUnixLike update host operating system")
@@ -1000,7 +1003,7 @@ func directIngestOSUnixLike(ctx context.Context, logger log.Logger, host *fleet.
 
 // parseOSVersion returns a point release string for an operating system. Parsing rules
 // depend on available data, which varies between operating systems.
-func parseOSVersion(name string, version string, major string, minor string, patch string, build string) string {
+func parseOSVersion(name string, version string, major string, minor string, patch string, build string, extra string) string {
 	var osVersion string
 	switch {
 	case strings.Contains(strings.ToLower(name), "ubuntu"):
@@ -1017,6 +1020,11 @@ func parseOSVersion(name string, version string, major string, minor string, pat
 	}
 
 	osVersion = strings.Trim(osVersion, ".")
+
+	// extra is the Apple Rapid Security Response version
+	if extra != "" {
+		osVersion = fmt.Sprintf("%s %s", osVersion, strings.TrimSpace(extra))
+	}
 
 	return osVersion
 }

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -762,6 +762,28 @@ func TestDirectIngestOSUnixLike(t *testing.T) {
 				KernelVersion: "21.6.0",
 			},
 		},
+		// macOS with Rapid Security Response version
+		{
+			data: []map[string]string{
+				{
+					"name":           "macOS",
+					"version":        "13.4.1",
+					"major":          "13",
+					"minor":          "4",
+					"patch":          "1",
+					"build":          "22F82",
+					"arch":           "arm64",
+					"kernel_version": "21.6.0",
+					"extra":          "(c) ",
+				},
+			},
+			expected: fleet.OperatingSystem{
+				Name:          "macOS",
+				Version:       "13.4.1 (c)",
+				Arch:          "arm64",
+				KernelVersion: "21.6.0",
+			},
+		},
 		{
 			data: []map[string]string{
 				{


### PR DESCRIPTION
#12888 

Updated code so that macOS version returns RSR, if available. For example: `14.3.1 (a)` as opposed to simply `14.3.1`
This feature is supported by osquery with the `extra` column in `os_version` table.

Since I could not get a real macOS running a version with RSR, I did the following manual checks:
- ensured that `extra` column from osquery `os_version` table was being received for processing
- hard coded the `extra` column result on the server and verified the OS version was correct in GUI and REST APIs

Main testing was done by Zach following these [instructions](https://docs.google.com/document/d/18xsCEFlpcBL-5EbQhvmUNuJz3XM0Ak-NfCCwxEQXVic/edit)
- I confirmed that the one incorrect query result was due to a bad query

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
