### PR TITLE
Fleet UI: [bug fix for release] Team admin and team maintainer can edit query

### DIFF
--- a/frontend/context/app.tsx
+++ b/frontend/context/app.tsx
@@ -376,7 +376,7 @@ const AppProvider = ({ children }: Props): JSX.Element => {
     isTeamObserver: state.isTeamObserver,
     isTeamMaintainer: state.isTeamMaintainer,
     isTeamAdmin: state.isTeamAdmin,
-    isTeamMaintainerOrTeamAdmin: state.isTeamMaintainer,
+    isTeamMaintainerOrTeamAdmin: state.isTeamMaintainerOrTeamAdmin,
     isAnyTeamAdmin: state.isAnyTeamAdmin,
     isOnlyObserver: state.isOnlyObserver,
     isObserverPlus: state.isObserverPlus,

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -15,6 +15,10 @@ import { IQueryReport } from "interfaces/query_report";
 
 import queryAPI from "services/entities/queries";
 import queryReportAPI, { ISortOption } from "services/entities/query_report";
+import teamsAPI, {
+  ILoadTeamResponse,
+  ITeamConfig,
+} from "services/entities/teams";
 
 import Spinner from "components/Spinner/Spinner";
 import Button from "components/buttons/Button";
@@ -49,11 +53,12 @@ const baseClass = "query-details-page";
 
 const QueryDetailsPage = ({
   router,
-  params: { id: paramsQueryId },
+  params: { id: paramsQueryId, team_id: paramsTeamId },
   location,
 }: IQueryDetailsPageProps): JSX.Element => {
   const queryId = parseInt(paramsQueryId, 10);
   const queryParams = location.query;
+  const teamId = parseInt(paramsTeamId, 10);
 
   // Functions to avoid race conditions
   const serverSortBy: ISortOption[] = (() => {
@@ -74,6 +79,8 @@ const QueryDetailsPage = ({
     isAnyTeamObserverPlus,
     config,
     filteredQueriesPath,
+    availableTeams,
+    setCurrentTeam,
   } = useContext(AppContext);
   const {
     lastEditedQueryName,
@@ -150,6 +157,16 @@ const QueryDetailsPage = ({
       onError: (error) => handlePageError(error),
     }
   );
+
+  // Used to set host's team in AppContext for RBAC action buttons
+  useEffect(() => {
+    if (storedQuery?.team_id) {
+      const querysTeam = availableTeams?.find(
+        (team) => team.id === storedQuery.team_id
+      );
+      setCurrentTeam(querysTeam);
+    }
+  }, [storedQuery]);
 
   const isLoading = isStoredQueryLoading || isQueryReportLoading;
   const isApiError = storedQueryError || queryReportError;

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -15,10 +15,6 @@ import { IQueryReport } from "interfaces/query_report";
 
 import queryAPI from "services/entities/queries";
 import queryReportAPI, { ISortOption } from "services/entities/query_report";
-import teamsAPI, {
-  ILoadTeamResponse,
-  ITeamConfig,
-} from "services/entities/teams";
 
 import Spinner from "components/Spinner/Spinner";
 import Button from "components/buttons/Button";

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -92,7 +92,7 @@ const EditQueryPage = ({
     setLastEditedQueryPlatforms,
     setLastEditedQueryDiscardData,
   } = useContext(QueryContext);
-  const { setConfig } = useContext(AppContext);
+  const { setConfig, availableTeams, setCurrentTeam } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 
   const [isLiveQueryRunnable, setIsLiveQueryRunnable] = useState(true);
@@ -145,6 +145,16 @@ const EditQueryPage = ({
     }
   );
 
+  // Used to set host's team in AppContext for RBAC actions
+  useEffect(() => {
+    if (storedQuery?.team_id) {
+      const querysTeam = availableTeams?.find(
+        (team) => team.id === storedQuery.team_id
+      );
+      setCurrentTeam(querysTeam);
+    }
+  }, [storedQuery]);
+
   const detectIsFleetQueryRunnable = () => {
     statusAPI.live_query().catch(() => {
       setIsLiveQueryRunnable(false);
@@ -157,10 +167,15 @@ const EditQueryPage = ({
     const canEditExistingQuery =
       isGlobalAdmin || isGlobalMaintainer || isTeamMaintainerOrTeamAdmin;
 
-    if (queryId && queryId > 0 && !canEditExistingQuery) {
+    if (
+      !isStoredQueryLoading && // Confirms teamId for storedQuery before RBAC reroute
+      queryId &&
+      queryId > 0 &&
+      !canEditExistingQuery
+    ) {
       router.push(PATHS.QUERY(queryId));
     }
-  }, [queryId, isTeamMaintainerOrTeamAdmin]);
+  }, [queryId, isTeamMaintainerOrTeamAdmin, isStoredQueryLoading]);
 
   useEffect(() => {
     detectIsFleetQueryRunnable();


### PR DESCRIPTION
## Issue
Cerra #14599

## Description
- Checks permissions of a user's RBAC based on the query's `team_id` before determining RBAC on the `QueryDetailsPage.tsx` and `EditQueryPage.tsx`
- Similar to host details page > action dropdown, the view of the query report buttons and access to the edit query page relies on RBAC. These RBAC are based on what team the query belongs to and the current user's roles (similar to RBAC of host details page relying on what team the host belongs to and the current user's roles). Similar to the host details page and `team_id` of a host, the `team_id` of a query can get lost when navigating through URLs as the teamsDropdown is not used on these pages
- This fix applies the fix already in place on the `HostDetailsPage.tsx` to the `QueryDetailsPage.tsx` and `EditQueryPage.tsx`

## Screenrecording of intended behavior including fixes
- Team admin and team maintainer can see and click edit button and go to edit URL directly

https://github.com/fleetdm/fleet/assets/71795832/a2ddd476-5593-4aa5-8fc3-3af497a6d470


- User with mixed roles can see and click the edit button and go to edit URL directly only for the team they are a maintainer on, for team queries they are observer on, the edit button does not show and going to the edit page re-routes to query report page

https://github.com/fleetdm/fleet/assets/71795832/648832fe-53d9-441f-a8ff-3c42c3d97f27



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

