### PR TITLE
Fleet UI: Add usage statistics always on for premium users to to app settings page

### DIFF
--- a/changes/10888-premium-usage-statistics
+++ b/changes/10888-premium-usage-statistics
@@ -1,0 +1,1 @@
+- App Settings informs premium users they are sending usage statistics and cannot disable feature

--- a/frontend/pages/admin/OrgSettingsPage/_styles.scss
+++ b/frontend/pages/admin/OrgSettingsPage/_styles.scss
@@ -205,6 +205,10 @@
         margin-bottom: $pad-large;
       }
 
+      &__disabled-usage-statistics-checkbox {
+        @include disabled;
+      }
+
       .component__tooltip-wrapper {
         margin-bottom: $pad-xsmall;
       }

--- a/frontend/pages/admin/OrgSettingsPage/cards/Statistics/Statistics.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Statistics/Statistics.tsx
@@ -11,6 +11,7 @@ const baseClass = "app-config-form";
 const Statistics = ({
   appConfig,
   handleSubmit,
+  isPremiumTier,
   isUpdatingSettings,
 }: IAppConfigFormProps): JSX.Element => {
   const [formData, setFormData] = useState<any>({
@@ -45,12 +46,13 @@ const Statistics = ({
         <div className={`${baseClass}__section`}>
           <h2>Usage statistics</h2>
           <p className={`${baseClass}__section-description`}>
-            Help improve Fleet by sending usage statistics.
+            Help us improve Fleet by sending us anonymous usage statistics.
             <br />
             <br />
             This information helps our team better understand feature adoption
             and usage, and allows us to see how Fleet is adding value, so that
-            we can make better product decisions.
+            we can make better product decisions. Fleet Premium customers always
+            submit usage statistics data.
             <br />
             <br />
             <CustomLink
@@ -63,8 +65,13 @@ const Statistics = ({
             <Checkbox
               onChange={handleInputChange}
               name="enableUsageStatistics"
-              value={enableUsageStatistics}
+              value={isPremiumTier ? true : enableUsageStatistics} // Set to true for all premium customers
               parseTarget
+              wrapperClassName={
+                isPremiumTier
+                  ? `${baseClass}__disabled-usage-statistics-checkbox`
+                  : ""
+              }
             >
               Enable usage statistics
             </Checkbox>


### PR DESCRIPTION
## Issue
Frontend portion of #10888 

## Description
- Update usage statistics description
- Render `true` for usage statistics checkbox for premium users
- Disable usage statistics checkbox for premium users

## Screenshot
<img width="1342" alt="Screenshot 2023-10-17 at 4 12 52 PM" src="https://github.com/fleetdm/fleet/assets/71795832/506bb209-a504-4d64-b620-31ea73f24448">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality

