### PR TITLE
fix flaky test by ignoring order of elements

### DIFF
--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -818,7 +818,7 @@ func TestGetMostRecentResults(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			results := getMostRecentResults(tt.input)
-			assert.Equal(t, tt.expected, results)
+			assert.ElementsMatch(t, tt.expected, results)
 		})
 	}
 }


### PR DESCRIPTION
As far as I can tell, the order doesn't matter here, we wan to test that the slice has the elements with the higher `UnixTime` value

# Checklist for submitter

-  [x] Added/updated tests
