### PR TITLE
Update `fleetctl mdm run-command` to target platform-agnostic endpoint, support Windows

### DIFF
--- a/changes/issue-13594-run-mdm-command-on-windows
+++ b/changes/issue-13594-run-mdm-command-on-windows
@@ -1,0 +1,1 @@
+* Updated the `fleetctl mdm run-command` sub-command to use the new platform-agnostic endpoint and support for running MDM commands on Windows hosts.

--- a/cmd/fleetctl/apply_test.go
+++ b/cmd/fleetctl/apply_test.go
@@ -2968,7 +2968,7 @@ spec:
       macos_setup:
         macos_setup_assistant: %s
 `, macSetupFile),
-			wantErr: `MDM features aren't turned on.`,
+			wantErr: `macOS MDM isn't turned on.`,
 		},
 		{
 			desc: "app config macos setup assistant",
@@ -2980,7 +2980,7 @@ spec:
     macos_setup:
       macos_setup_assistant: %s
 `, macSetupFile),
-			wantErr: `MDM features aren't turned on.`,
+			wantErr: `macOS MDM isn't turned on.`,
 		},
 	}
 	// NOTE: Integrations required fields are not tested (Jira/Zendesk) because

--- a/cmd/fleetctl/get.go
+++ b/cmd/fleetctl/get.go
@@ -819,7 +819,7 @@ func getHostsCommand() *cli.Command {
 
 				if c.Bool("mdm") || c.Bool("mdm-pending") {
 					// print an error if MDM is not configured
-					if err := client.CheckMDMEnabled(); err != nil {
+					if err := client.CheckAnyMDMEnabled(); err != nil {
 						return err
 					}
 
@@ -1390,7 +1390,7 @@ func getMDMCommandResultsCommand() *cli.Command {
 			}
 
 			// print an error if MDM is not configured
-			if err := client.CheckMDMEnabled(); err != nil {
+			if err := client.CheckAnyMDMEnabled(); err != nil {
 				return err
 			}
 
@@ -1451,7 +1451,7 @@ func getMDMCommandsCommand() *cli.Command {
 			}
 
 			// print an error if MDM is not configured
-			if err := client.CheckMDMEnabled(); err != nil {
+			if err := client.CheckAnyMDMEnabled(); err != nil {
 				return err
 			}
 

--- a/cmd/fleetctl/mdm.go
+++ b/cmd/fleetctl/mdm.go
@@ -52,7 +52,7 @@ func mdmRunCommand() *cli.Command {
 			}
 
 			// print an error if MDM is not configured
-			if err := client.CheckMDMEnabled(); err != nil {
+			if err := client.CheckAnyMDMEnabled(); err != nil {
 				return err
 			}
 

--- a/cmd/fleetctl/mdm.go
+++ b/cmd/fleetctl/mdm.go
@@ -132,7 +132,7 @@ func mdmRunCommand() *cli.Command {
 			result, err := client.RunMDMCommand(hostUUIDs, payload, platform)
 			if err != nil {
 				if errors.Is(err, service.ErrMissingLicense) && platform == "windows" {
-					return errors.New("Missing or invalid license. Wipe command is available in Fleet Premium only.")
+					return errors.New(fleet.WindowsMDMRequiresPremiumCmdMessage)
 				}
 
 				var sce kithttp.StatusCoder

--- a/cmd/fleetctl/mdm.go
+++ b/cmd/fleetctl/mdm.go
@@ -85,7 +85,7 @@ func mdmRunCommand() *cli.Command {
 				return errors.New("Can't run the MDM command because the host doesn't have MDM turned on. Run the following command to see a list of hosts with MDM on: fleetctl get hosts --mdm")
 			}
 
-			result, err := client.EnqueueCommand([]string{host.UUID}, payload)
+			result, err := client.RunMDMCommand([]string{host.UUID}, payload, host.Platform)
 			if err != nil {
 				var sce kithttp.StatusCoder
 				if errors.As(err, &sce) {

--- a/cmd/fleetctl/mdm.go
+++ b/cmd/fleetctl/mdm.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -56,36 +57,71 @@ func mdmRunCommand() *cli.Command {
 				return err
 			}
 
+			// dedupe and remove any empty host identifier
 			hostIdents := c.StringSlice("hosts")
+			slices.Sort(hostIdents)
+			hostIdents = slices.Compact(hostIdents)
+			if len(hostIdents) > 0 && hostIdents[0] == "" {
+				// because it is sorted, an empty ident can only be at the start
+				hostIdents = hostIdents[1:]
+			}
+			if len(hostIdents) == 0 {
+				return errors.New(`Required flag "hosts" not set`)
+			}
+
 			payloadFile := c.String("payload")
 			payload, err := os.ReadFile(payloadFile)
 			if err != nil {
 				return fmt.Errorf("read payload: %w", err)
 			}
 
-			host, err := client.HostByIdentifier(hostIdents[0]) // TODO(mna): loop for all hosts
-			if err != nil {
-				var nfe service.NotFoundErr
-				if errors.As(err, &nfe) {
-					return errors.New("The host doesn't exist. Please provide a valid hostname, uuid, osquery_host_id or node_key.")
-				}
-				var sce kithttp.StatusCoder
-				if errors.As(err, &sce) {
-					if sce.StatusCode() == http.StatusForbidden {
-						return fmt.Errorf("Permission denied. You don't have permission to run an MDM command on this host: %w", err)
+			// fetch all specified hosts by their identifier
+			var (
+				hostUUIDs     []string
+				notFoundCount int
+				platform      string
+			)
+			for i, ident := range hostIdents {
+				host, err := client.HostByIdentifier(ident)
+				if err != nil {
+					var nfe service.NotFoundErr
+					if errors.As(err, &nfe) {
+						notFoundCount++
+						continue
 					}
+					var sce kithttp.StatusCoder
+					if errors.As(err, &sce) {
+						if sce.StatusCode() == http.StatusForbidden {
+							return fmt.Errorf("Permission denied. You don't have permission to run an MDM command on this host: %w", err)
+						}
+					}
+					return err
 				}
-				return err
+
+				if host.Platform != platform && i > 0 {
+					return errors.New(`Command can't run on hosts with different platforms. Make sure the hosts specified in the "hosts" flag are either all macOS or all Windows hosts.`)
+				}
+				platform = host.Platform
+
+				// TODO(mna): this "On" check is brittle, but looks like it's the only
+				// enrollment indication we have right now...
+				if host.MDM.EnrollmentStatus == nil || !strings.HasPrefix(*host.MDM.EnrollmentStatus, "On") ||
+					host.MDM.Name != fleet.WellKnownMDMFleet {
+					return errors.New("Can't run the MDM command because the host doesn't have MDM turned on. Run the following command to see a list of hosts with MDM on: fleetctl get hosts --mdm")
+				}
+
+				hostUUIDs = append(hostUUIDs, host.UUID)
 			}
 
-			// TODO(mna): this "On" check is brittle, but looks like it's the only
-			// enrollment indication we have right now...
-			if host.MDM.EnrollmentStatus == nil || !strings.HasPrefix(*host.MDM.EnrollmentStatus, "On") ||
-				host.MDM.Name != fleet.WellKnownMDMFleet {
-				return errors.New("Can't run the MDM command because the host doesn't have MDM turned on. Run the following command to see a list of hosts with MDM on: fleetctl get hosts --mdm")
+			if len(hostUUIDs) == 0 {
+				return errors.New("No hosts targeted. Make sure you provide a valid hostname, UUID, osquery host ID, or node key.")
+			}
+			if notFoundCount > 0 {
+				// at least one was not found
+				return errors.New("One or more targeted hosts don't exist. Make sure you provide a valid hostname, UUID, osquery host ID, or node key.")
 			}
 
-			result, err := client.RunMDMCommand([]string{host.UUID}, payload, host.Platform)
+			result, err := client.RunMDMCommand(hostUUIDs, payload, platform)
 			if err != nil {
 				var sce kithttp.StatusCoder
 				if errors.As(err, &sce) {
@@ -93,6 +129,7 @@ func mdmRunCommand() *cli.Command {
 						return fmt.Errorf("Permission denied. You don't have permission to run an MDM command on this host: %w", err)
 					}
 					if sce.StatusCode() == http.StatusUnsupportedMediaType {
+						// this status code is only returned for an Apple MDM command, so this message is correct.
 						return fmt.Errorf("The payload isn't valid. Please provide a valid MDM command in the form of a plist-encoded XML file: %w", err)
 					}
 				}
@@ -100,7 +137,7 @@ func mdmRunCommand() *cli.Command {
 			}
 
 			fmt.Fprintf(c.App.Writer, `
-The hosts will run the command the next time it checks into Fleet.
+Hosts will run the command the next time they check into Fleet.
 
 Copy and run this command to see results:
 

--- a/cmd/fleetctl/mdm.go
+++ b/cmd/fleetctl/mdm.go
@@ -32,11 +32,11 @@ func mdmRunCommand() *cli.Command {
 	return &cli.Command{
 		Name:    "run-command",
 		Aliases: []string{"run_command"},
-		Usage:   "Run a custom MDM command on one macOS host. Head to Apple's documentation for a list of available commands and example payloads here:  https://developer.apple.com/documentation/devicemanagement/commands_and_queries",
+		Usage:   "Run a custom MDM command on macOS and Windows hosts.",
 		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:     "host",
-				Usage:    "The host, specified by hostname, uuid, osquery_host_id or node_key, that you want to run the MDM command on.",
+			&cli.StringSliceFlag{
+				Name:     "hosts",
+				Usage:    "Hosts specified by hostname, uuid, osquery_host_id or node_key that you want to target.",
 				Required: true,
 			},
 			&cli.StringFlag{
@@ -56,14 +56,14 @@ func mdmRunCommand() *cli.Command {
 				return err
 			}
 
-			hostIdent := c.String("host")
+			hostIdents := c.StringSlice("hosts")
 			payloadFile := c.String("payload")
 			payload, err := os.ReadFile(payloadFile)
 			if err != nil {
 				return fmt.Errorf("read payload: %w", err)
 			}
 
-			host, err := client.HostByIdentifier(hostIdent)
+			host, err := client.HostByIdentifier(hostIdents[0]) // TODO(mna): loop for all hosts
 			if err != nil {
 				var nfe service.NotFoundErr
 				if errors.As(err, &nfe) {

--- a/cmd/fleetctl/mdm.go
+++ b/cmd/fleetctl/mdm.go
@@ -87,7 +87,7 @@ func mdmRunCommand() *cli.Command {
 				notFoundCount int
 				platform      string
 			)
-			for i, ident := range hostIdents {
+			for _, ident := range hostIdents {
 				host, err := client.HostByIdentifier(ident)
 				if err != nil {
 					var nfe service.NotFoundErr
@@ -105,7 +105,7 @@ func mdmRunCommand() *cli.Command {
 					return err
 				}
 
-				if host.Platform != platform && i > 0 {
+				if host.Platform != platform && platform != "" {
 					return errors.New(`Command can't run on hosts with different platforms. Make sure the hosts specified in the "hosts" flag are either all macOS or all Windows hosts.`)
 				}
 				platform = host.Platform
@@ -114,7 +114,7 @@ func mdmRunCommand() *cli.Command {
 				// enrollment indication we have right now...
 				if host.MDM.EnrollmentStatus == nil || !strings.HasPrefix(*host.MDM.EnrollmentStatus, "On") ||
 					host.MDM.Name != fleet.WellKnownMDMFleet {
-					return errors.New("Can't run the MDM command because the host doesn't have MDM turned on. Run the following command to see a list of hosts with MDM on: fleetctl get hosts --mdm")
+					return errors.New(`Can't run the MDM command because one or more hosts have MDM turned off. Run the following command to see a list of hosts with MDM on: fleetctl get hosts --mdm.`)
 				}
 
 				hostUUIDs = append(hostUUIDs, host.UUID)

--- a/cmd/fleetctl/mdm.go
+++ b/cmd/fleetctl/mdm.go
@@ -114,9 +114,6 @@ func mdmRunCommand() *cli.Command {
 				// enrollment indication we have right now...
 				if host.MDM.EnrollmentStatus == nil || !strings.HasPrefix(*host.MDM.EnrollmentStatus, "On") ||
 					host.MDM.Name != fleet.WellKnownMDMFleet {
-					// TODO(mna): on my manual QA with a Windows VM, the mdm name was
-					// FleetDM, not Fleet. If that is correct and expected, we should
-					// change the WellKnown constant (or accept both)?
 					return errors.New(`Can't run the MDM command because one or more hosts have MDM turned off. Run the following command to see a list of hosts with MDM on: fleetctl get hosts --mdm.`)
 				}
 

--- a/cmd/fleetctl/mdm_test.go
+++ b/cmd/fleetctl/mdm_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	mock "github.com/fleetdm/fleet/v4/server/mock/nanomdm"
@@ -27,137 +28,262 @@ func (mockPusher) Push(ctx context.Context, ids []string) (map[string]*push.Resp
 }
 
 func TestMDMRunCommand(t *testing.T) {
-	enqueuer := new(mock.Storage)
-	_, ds := runServerWithMockedDS(t, &service.TestServerOpts{MDMStorage: enqueuer, MDMPusher: mockPusher{}})
+	// define some hosts to use in the tests
+	macEnrolled := &fleet.Host{
+		ID:       1,
+		UUID:     "mac-enrolled",
+		Platform: "darwin",
+		MDMInfo:  &fleet.HostMDM{Enrolled: true, Name: fleet.WellKnownMDMFleet},
+		MDM:      fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("On (manual)")},
+	}
+	winEnrolled := &fleet.Host{
+		ID:       2,
+		UUID:     "win-enrolled",
+		Platform: "windows",
+		MDMInfo:  &fleet.HostMDM{Enrolled: true, Name: fleet.WellKnownMDMFleet},
+		MDM:      fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("On (manual)")},
+	}
+	macUnenrolled := &fleet.Host{
+		ID:       3,
+		UUID:     "mac-unenrolled",
+		Platform: "darwin",
+	}
+	winUnenrolled := &fleet.Host{
+		ID:       4,
+		UUID:     "win-unenrolled",
+		Platform: "windows",
+	}
+	linuxUnenrolled := &fleet.Host{
+		ID:       5,
+		UUID:     "linux-unenrolled",
+		Platform: "linux",
+	}
+	macEnrolled2 := &fleet.Host{
+		ID:       6,
+		UUID:     "mac-enrolled-2",
+		Platform: "darwin",
+		MDMInfo:  &fleet.HostMDM{Enrolled: true, Name: fleet.WellKnownMDMFleet},
+		MDM:      fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("On (manual)")},
+	}
+	winEnrolled2 := &fleet.Host{
+		ID:       7,
+		UUID:     "win-enrolled-2",
+		Platform: "windows",
+		MDMInfo:  &fleet.HostMDM{Enrolled: true, Name: fleet.WellKnownMDMFleet},
+		MDM:      fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("On (manual)")},
+	}
+	macNonFleetEnrolled := &fleet.Host{
+		ID:       8,
+		UUID:     "mac-non-fleet-enrolled",
+		Platform: "darwin",
+		MDMInfo:  &fleet.HostMDM{Enrolled: true, Name: fleet.WellKnownMDMJamf},
+		MDM:      fleet.MDMHostData{Name: fleet.WellKnownMDMJamf, EnrollmentStatus: ptr.String("On (manual)")},
+	}
+	winNonFleetEnrolled := &fleet.Host{
+		ID:       9,
+		UUID:     "win-non-fleet-enrolled",
+		Platform: "windows",
+		MDMInfo:  &fleet.HostMDM{Enrolled: true, Name: fleet.WellKnownMDMIntune},
+		MDM:      fleet.MDMHostData{Name: fleet.WellKnownMDMIntune, EnrollmentStatus: ptr.String("On (manual)")},
+	}
+	macPending := &fleet.Host{
+		ID:       10,
+		UUID:     "mac-pending",
+		Platform: "darwin",
+		MDMInfo:  &fleet.HostMDM{Enrolled: false, Name: fleet.WellKnownMDMFleet},
+		MDM:      fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("Pending")},
+	}
+	winPending := &fleet.Host{
+		ID:       11,
+		UUID:     "win-pending",
+		Platform: "windows",
+		MDMInfo:  &fleet.HostMDM{Enrolled: false, Name: fleet.WellKnownMDMFleet},
+		MDM:      fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("Pending")},
+	}
+	hostByUUID := make(map[string]*fleet.Host)
+	for _, h := range []*fleet.Host{macEnrolled, winEnrolled, macUnenrolled, winUnenrolled, linuxUnenrolled, macEnrolled2, winEnrolled2, macNonFleetEnrolled, winNonFleetEnrolled, macPending, winPending} {
+		hostByUUID[h.UUID] = h
+	}
 
-	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-		return &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true}}, nil
-	}
-	ds.HostByIdentifierFunc = func(ctx context.Context, identifier string) (*fleet.Host, error) {
-		switch identifier {
-		case "no-such-host":
-			return nil, &notFoundError{}
-		case "no-mdm-host":
-			return &fleet.Host{ID: 1, UUID: identifier}, nil
-		case "no-fleet-mdm-host":
-			return &fleet.Host{ID: 2, UUID: identifier, MDM: fleet.MDMHostData{Name: fleet.WellKnownMDMJamf, EnrollmentStatus: ptr.String("On (manual)")}}, nil
-		case "fleet-mdm-pending-host":
-			return &fleet.Host{ID: 3, UUID: identifier, MDM: fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("Pending")}}, nil
-		default:
-			return &fleet.Host{ID: 4, Platform: "darwin", UUID: identifier, MDM: fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("On (manual)")}}, nil
-		}
-	}
-	ds.LoadHostSoftwareFunc = func(ctx context.Context, host *fleet.Host, includeCVEScores bool) error {
-		return nil
-	}
-	ds.ListLabelsForHostFunc = func(ctx context.Context, hid uint) ([]*fleet.Label, error) {
-		return nil, nil
-	}
-	ds.ListPacksForHostFunc = func(ctx context.Context, hid uint) (packs []*fleet.Pack, err error) {
-		return nil, nil
-	}
-	ds.ListHostBatteriesFunc = func(ctx context.Context, id uint) ([]*fleet.HostBattery, error) {
-		return nil, nil
-	}
-	ds.ListPoliciesForHostFunc = func(ctx context.Context, host *fleet.Host) ([]*fleet.HostPolicy, error) {
-		return nil, nil
-	}
-	ds.GetHostMDMProfilesFunc = func(ctx context.Context, hostUUID string) ([]fleet.HostMDMAppleProfile, error) {
-		return nil, nil
-	}
-	ds.GetHostMDMMacOSSetupFunc = func(ctx context.Context, hostID uint) (*fleet.HostMDMMacOSSetup, error) {
-		return nil, nil
-	}
-	ds.ListHostsLiteByUUIDsFunc = func(ctx context.Context, filter fleet.TeamFilter, uuids []string) ([]*fleet.Host, error) {
-		if len(uuids) == 0 {
-			return nil, nil
-		}
-		return []*fleet.Host{
-			{
-				ID:       4,
-				UUID:     uuids[0],
-				Platform: "darwin",
-				MDMInfo:  &fleet.HostMDM{Enrolled: true, Name: fleet.WellKnownMDMFleet},
-				MDM:      fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("On (manual)")},
-			},
-		}, nil
-	}
-	enqueuer.EnqueueCommandFunc = func(ctx context.Context, id []string, cmd *mdm.Command) (map[string]error, error) {
-		return map[string]error{}, nil
-	}
-
-	_, err := runAppNoChecks([]string{"mdm", "run-command"})
-	require.Error(t, err)
-	require.ErrorContains(t, err, `Required flags "hosts, payload" not set`)
-
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "abc"})
-	require.Error(t, err)
-	require.ErrorContains(t, err, `Required flag "payload" not set`)
-
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "abc", "--payload", "no-such-file"})
-	require.Error(t, err)
-	require.ErrorContains(t, err, `open no-such-file: no such file or directory`)
-
-	// pass a yaml file instead of xml
+	// define some files to use in the tests
 	yamlFilePath := writeTmpYml(t, `invalid`)
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "valid", "--payload", yamlFilePath})
-	require.Error(t, err)
-	require.ErrorContains(t, err, `The payload isn't valid XML.`)
+	mobileConfigFilePath := writeTmpMobileconfig(t, "Mobileconfig")
+	appleCmdFilePath := writeTmpAppleMDMCmd(t, "FooBar")
+	winCmdFilePath := writeTmpWindowsMDMCmd(t, "FooBar")
+	applePremiumCmdFilePath := writeTmpAppleMDMCmd(t, "EraseDevice")
+	winPremiumCmdFilePath := writeTmpWindowsMDMCmd(t, "RemoteWipe")
 
-	// pass valid xml plist that doesn't match the MDM command schema
-	mcFilePath := writeTmpMobileconfig(t, "Mobileconfig")
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "valid-host", "--payload", mcFilePath})
-	require.Error(t, err)
-	require.ErrorContains(t, err, `The payload isn't valid. Please provide a valid MDM command in the form of a plist-encoded XML file:`)
-
-	// host not found
-	cmdFilePath := writeTmpMDMCmd(t, "FooBar")
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "no-such-host", "--payload", cmdFilePath})
-	require.Error(t, err)
-	require.ErrorContains(t, err, `No hosts targeted.`)
-
-	// host not in mdm
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "no-mdm-host", "--payload", cmdFilePath})
-	require.Error(t, err)
-	require.ErrorContains(t, err, `Can't run the MDM command because the host doesn't have MDM turned on.`)
-
-	// host not in fleet mdm
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "no-fleet-mdm-host", "--payload", cmdFilePath})
-	require.Error(t, err)
-	require.ErrorContains(t, err, `Can't run the MDM command because the host doesn't have MDM turned on.`)
-
-	// host in fleet mdm but pending
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "fleet-mdm-pending-host", "--payload", cmdFilePath})
-	require.Error(t, err)
-	require.ErrorContains(t, err, `Can't run the MDM command because the host doesn't have MDM turned on.`)
-
-	// host enrolled in fleet mdm
-	buf, err := runAppNoChecks([]string{"mdm", "run-command", "--hosts", "valid-host", "--payload", cmdFilePath})
+	emptyAppleCmdFilePath, err := os.CreateTemp(t.TempDir(), "*.xml")
 	require.NoError(t, err)
-	require.Contains(t, buf.String(), `Hosts will run the command the next time they check into Fleet.`)
-	require.Contains(t, buf.String(), `fleetctl get mdm-command-results --id=`)
-
-	// try to run a fleet premium command
-	cmdFilePath = writeTmpMDMCmd(t, "EraseDevice")
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "valid-host", "--payload", cmdFilePath})
-	require.Error(t, err)
-	require.ErrorContains(t, err, `missing or invalid license`)
-
-	// try to run an empty plist as a command
-	tmpFile, err := os.CreateTemp(t.TempDir(), "*.xml")
-	require.NoError(t, err)
-	_, err = tmpFile.WriteString(fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+	_, err = emptyAppleCmdFilePath.WriteString(fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 </plist>`))
 	require.NoError(t, err)
+	emptyAppleCmdFilePath.Close()
 
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "valid-host", "--payload", tmpFile.Name()})
-	require.Error(t, err)
-	require.ErrorContains(t, err, `The payload isn't valid. Please provide a valid MDM command in the form of a plist-encoded XML file.`)
+	emptyWinCmdFilePath, err := os.CreateTemp(t.TempDir(), "*.xml")
+	require.NoError(t, err)
+	_, err = emptyWinCmdFilePath.WriteString(fmt.Sprintf(`<Exec>
+</Exec>`))
+	require.NoError(t, err)
+	emptyWinCmdFilePath.Close()
+
+	nonExecWinCmdFilePath, err := os.CreateTemp(t.TempDir(), "*.xml")
+	require.NoError(t, err)
+	_, err = nonExecWinCmdFilePath.WriteString(fmt.Sprintf(`<Get>
+	<CmdID>22</CmdID>
+	<Item>
+		<Target>
+			<LocURI>FooBar</LocURI>
+		</Target>
+		<Meta>
+			<Format xmlns="syncml:metinf">chr</Format>
+			<Type xmlns="syncml:metinf">text/plain</Type>
+		</Meta>
+		<Data>NamedValuesList=MinPasswordLength,8;</Data>
+	</Item>
+</Get>`))
+	require.NoError(t, err)
+	nonExecWinCmdFilePath.Close()
+
+	// define some app configs variations to use in the tests
+	appCfgAllMDM := &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true, WindowsEnabledAndConfigured: true}}
+	appCfgWinMDM := &fleet.AppConfig{MDM: fleet.MDM{WindowsEnabledAndConfigured: true}}
+	appCfgMacMDM := &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true}}
+	appCfgNoMDM := &fleet.AppConfig{MDM: fleet.MDM{}}
+
+	for _, lic := range []string{fleet.TierFree, fleet.TierPremium} {
+		t.Run(lic, func(t *testing.T) {
+			enqueuer := new(mock.Storage)
+			license := &fleet.LicenseInfo{Tier: lic, Expiration: time.Now().Add(24 * time.Hour)}
+
+			_, ds := runServerWithMockedDS(t, &service.TestServerOpts{
+				MDMStorage:       enqueuer,
+				MDMPusher:        mockPusher{},
+				License:          license,
+				NoCacheDatastore: true,
+			})
+
+			ds.HostByIdentifierFunc = func(ctx context.Context, identifier string) (*fleet.Host, error) {
+				h, ok := hostByUUID[identifier]
+				if !ok {
+					return nil, &notFoundError{}
+				}
+				return h, nil
+			}
+			ds.LoadHostSoftwareFunc = func(ctx context.Context, host *fleet.Host, includeCVEScores bool) error {
+				return nil
+			}
+			ds.ListLabelsForHostFunc = func(ctx context.Context, hid uint) ([]*fleet.Label, error) {
+				return nil, nil
+			}
+			ds.ListPacksForHostFunc = func(ctx context.Context, hid uint) (packs []*fleet.Pack, err error) {
+				return nil, nil
+			}
+			ds.ListHostBatteriesFunc = func(ctx context.Context, id uint) ([]*fleet.HostBattery, error) {
+				return nil, nil
+			}
+			ds.ListPoliciesForHostFunc = func(ctx context.Context, host *fleet.Host) ([]*fleet.HostPolicy, error) {
+				return nil, nil
+			}
+			ds.GetHostMDMProfilesFunc = func(ctx context.Context, hostUUID string) ([]fleet.HostMDMAppleProfile, error) {
+				return nil, nil
+			}
+			ds.GetHostMDMMacOSSetupFunc = func(ctx context.Context, hostID uint) (*fleet.HostMDMMacOSSetup, error) {
+				return nil, nil
+			}
+			ds.ListHostsLiteByUUIDsFunc = func(ctx context.Context, filter fleet.TeamFilter, uuids []string) ([]*fleet.Host, error) {
+				if len(uuids) == 0 {
+					return nil, nil
+				}
+				hosts := make([]*fleet.Host, 0, len(uuids))
+				for _, uid := range uuids {
+					if h := hostByUUID[uid]; h != nil {
+						hosts = append(hosts, h)
+					}
+				}
+				return hosts, nil
+			}
+			ds.MDMWindowsInsertPendingCommandForDevicesFunc = func(ctx context.Context, deviceIDs []string, cmd *fleet.MDMWindowsPendingCommand) error {
+				return nil
+			}
+			enqueuer.EnqueueCommandFunc = func(ctx context.Context, id []string, cmd *mdm.Command) (map[string]error, error) {
+				return map[string]error{}, nil
+			}
+
+			cases := []struct {
+				desc    string
+				flags   []string
+				appCfg  *fleet.AppConfig
+				wantErr string
+			}{
+				{"no flags", nil, appCfgAllMDM, `Required flags "hosts, payload" not set`},
+				{"no payload", []string{"--hosts", "abc"}, appCfgAllMDM, `Required flag "payload" not set`},
+				{"no hosts", []string{"--payload", winCmdFilePath}, appCfgAllMDM, `Required flag "hosts" not set`},
+				{"invalid payload", []string{"--hosts", "abc", "--payload", "no-such-file"}, appCfgAllMDM, `open no-such-file: no such file or directory`},
+				{"macOS yaml payload", []string{"--hosts", "mac-enrolled", "--payload", yamlFilePath}, appCfgAllMDM, `The payload isn't valid XML`},
+				{"win yaml payload", []string{"--hosts", "win-enrolled", "--payload", yamlFilePath}, appCfgAllMDM, `The payload isn't valid XML`},
+				{"non-mdm-command plist payload", []string{"--hosts", "mac-enrolled", "--payload", mobileConfigFilePath}, appCfgAllMDM, `The payload isn't valid. Please provide a valid MDM command in the form of a plist-encoded XML file:`},
+				{"single host not found", []string{"--hosts", "no-such-host", "--payload", appleCmdFilePath}, appCfgAllMDM, `No hosts targeted.`},
+				{"unenrolled macOS host", []string{"--hosts", "mac-unenrolled", "--payload", appleCmdFilePath}, appCfgAllMDM, `Can't run the MDM command because one or more hosts have MDM turned off.`},
+				{"unenrolled windows host", []string{"--hosts", "win-unenrolled", "--payload", winCmdFilePath}, appCfgAllMDM, `Can't run the MDM command because one or more hosts have MDM turned off.`},
+				{"macOS non-fleet host", []string{"--hosts", "mac-non-fleet-enrolled", "--payload", appleCmdFilePath}, appCfgAllMDM, `Can't run the MDM command because one or more hosts have MDM turned off.`},
+				{"windows non-fleet host", []string{"--hosts", "win-non-fleet-enrolled", "--payload", winCmdFilePath}, appCfgAllMDM, `Can't run the MDM command because one or more hosts have MDM turned off.`},
+				{"macOS pending host", []string{"--hosts", "mac-pending", "--payload", appleCmdFilePath}, appCfgAllMDM, `Can't run the MDM command because one or more hosts have MDM turned off.`},
+				{"windows pending host", []string{"--hosts", "win-pending", "--payload", winCmdFilePath}, appCfgAllMDM, `Can't run the MDM command because one or more hosts have MDM turned off.`},
+				{"valid single mac", []string{"--hosts", "mac-enrolled", "--payload", appleCmdFilePath}, appCfgAllMDM, ""},
+				{"valid single windows", []string{"--hosts", "win-enrolled", "--payload", winCmdFilePath}, appCfgAllMDM, ""},
+				{"no mdm enabled", []string{"--hosts", "win-enrolled", "--payload", winCmdFilePath}, appCfgNoMDM, "MDM features aren't turned on in Fleet."},
+				{"valid single mac only win mdm", []string{"--hosts", "mac-enrolled", "--payload", appleCmdFilePath}, appCfgWinMDM, "macOS MDM isn't turned on."},
+				{"valid single win only mac mdm", []string{"--hosts", "win-enrolled", "--payload", winCmdFilePath}, appCfgMacMDM, "Windows MDM isn't turned on."},
+				{"macOS premium cmd", []string{"--hosts", "mac-enrolled", "--payload", applePremiumCmdFilePath}, appCfgAllMDM, func() string {
+					if lic == fleet.TierFree {
+						return `missing or invalid license`
+					}
+					return ""
+				}()},
+				{"windows premium cmd", []string{"--hosts", "win-enrolled", "--payload", winPremiumCmdFilePath}, appCfgAllMDM, func() string {
+					if lic == fleet.TierFree {
+						return `Missing or invalid license. Wipe command is available in Fleet Premium only.`
+					}
+					return ""
+				}()},
+				{"empty plist file", []string{"--hosts", "mac-enrolled", "--payload", emptyAppleCmdFilePath.Name()}, appCfgAllMDM, `The payload isn't valid. Please provide a valid MDM command in the form of a plist-encoded XML file.`},
+				{"non-Exec win file", []string{"--hosts", "win-enrolled", "--payload", nonExecWinCmdFilePath.Name()}, appCfgAllMDM, `You can run only <Exec> command type.`},
+				{"empty win file", []string{"--hosts", "win-enrolled", "--payload", emptyWinCmdFilePath.Name()}, appCfgAllMDM, `You can run only a single <Exec> command.`},
+				{"hosts with different platforms", []string{"--hosts", "win-enrolled,mac-enrolled", "--payload", winCmdFilePath}, appCfgAllMDM, `Command can't run on hosts with different platforms.`},
+				{"all hosts not found", []string{"--hosts", "no-such-1,no-such-2,no-such-3", "--payload", winCmdFilePath}, appCfgAllMDM, `No hosts targeted.`},
+				{"one host not found", []string{"--hosts", "win-enrolled,no-such-2,win-enrolled-2", "--payload", winCmdFilePath}, appCfgAllMDM, `One or more targeted hosts don't exist.`},
+				{"one windows host not enrolled", []string{"--hosts", "win-enrolled,win-unenrolled,win-enrolled-2", "--payload", winCmdFilePath}, appCfgAllMDM, `Can't run the MDM command because one or more hosts have MDM turned off.`},
+				{"one macOS host not enrolled", []string{"--hosts", "mac-enrolled,mac-unenrolled,mac-enrolled-2", "--payload", appleCmdFilePath}, appCfgAllMDM, `Can't run the MDM command because one or more hosts have MDM turned off.`},
+				{"valid multiple mac", []string{"--hosts", "mac-enrolled,mac-enrolled-2", "--payload", appleCmdFilePath}, appCfgAllMDM, ""},
+				{"valid multiple windows", []string{"--hosts", "win-enrolled,win-enrolled-2", "--payload", winCmdFilePath}, appCfgAllMDM, ""},
+				{"valid multiple mac mac-enabled only", []string{"--hosts", "mac-enrolled,mac-enrolled-2", "--payload", appleCmdFilePath}, appCfgMacMDM, ""},
+				{"valid multiple windows win-enabled only", []string{"--hosts", "win-enrolled,win-enrolled-2", "--payload", winCmdFilePath}, appCfgWinMDM, ""},
+			}
+			for _, c := range cases {
+				t.Run(c.desc, func(t *testing.T) {
+					ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+						return c.appCfg, nil
+					}
+
+					buf, err := runAppNoChecks(append([]string{"mdm", "run-command"}, c.flags...))
+					if c.wantErr != "" {
+						require.Error(t, err)
+						require.ErrorContains(t, err, c.wantErr)
+					} else {
+						require.NoError(t, err)
+						require.Contains(t, buf.String(), `Hosts will run the command the next time they check into Fleet.`)
+						require.Contains(t, buf.String(), `fleetctl get mdm-command-results --id=`)
+					}
+				})
+			}
+		})
+	}
 }
 
-func writeTmpMDMCmd(t *testing.T, commandName string) string {
+func writeTmpAppleMDMCmd(t *testing.T, commandName string) string {
 	tmpFile, err := os.CreateTemp(t.TempDir(), "*.xml")
 	require.NoError(t, err)
 	_, err = tmpFile.WriteString(fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
@@ -173,6 +299,26 @@ func writeTmpMDMCmd(t *testing.T, commandName string) string {
     </dict>
   </dict>
 </plist>`, uuid.New().String(), commandName))
+	require.NoError(t, err)
+	return tmpFile.Name()
+}
+
+func writeTmpWindowsMDMCmd(t *testing.T, commandName string) string {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "*.xml")
+	require.NoError(t, err)
+	_, err = tmpFile.WriteString(fmt.Sprintf(`<Exec>
+	<CmdID>11</CmdID>
+	<Item>
+		<Target>
+			<LocURI>%s</LocURI>
+		</Target>
+		<Meta>
+			<Format xmlns="syncml:metinf">chr</Format>
+			<Type xmlns="syncml:metinf">text/plain</Type>
+		</Meta>
+		<Data>NamedValuesList=MinPasswordLength,8;</Data>
+	</Item>
+</Exec>`, commandName))
 	require.NoError(t, err)
 	return tmpFile.Name()
 }

--- a/cmd/fleetctl/mdm_test.go
+++ b/cmd/fleetctl/mdm_test.go
@@ -44,7 +44,7 @@ func TestMDMRunCommand(t *testing.T) {
 		case "fleet-mdm-pending-host":
 			return &fleet.Host{ID: 3, UUID: identifier, MDM: fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("Pending")}}, nil
 		default:
-			return &fleet.Host{ID: 4, UUID: identifier, MDM: fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("On (manual)")}}, nil
+			return &fleet.Host{ID: 4, Platform: "darwin", UUID: identifier, MDM: fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("On (manual)")}}, nil
 		}
 	}
 	ds.LoadHostSoftwareFunc = func(ctx context.Context, host *fleet.Host, includeCVEScores bool) error {
@@ -73,7 +73,13 @@ func TestMDMRunCommand(t *testing.T) {
 			return nil, nil
 		}
 		return []*fleet.Host{
-			{ID: 4, UUID: uuids[0], MDM: fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("On (manual)")}},
+			{
+				ID:       4,
+				UUID:     uuids[0],
+				Platform: "darwin",
+				MDMInfo:  &fleet.HostMDM{Enrolled: true, Name: fleet.WellKnownMDMFleet},
+				MDM:      fleet.MDMHostData{Name: fleet.WellKnownMDMFleet, EnrollmentStatus: ptr.String("On (manual)")},
+			},
 		}, nil
 	}
 	enqueuer.EnqueueCommandFunc = func(ctx context.Context, id []string, cmd *mdm.Command) (map[string]error, error) {

--- a/cmd/fleetctl/mdm_test.go
+++ b/cmd/fleetctl/mdm_test.go
@@ -82,58 +82,58 @@ func TestMDMRunCommand(t *testing.T) {
 
 	_, err := runAppNoChecks([]string{"mdm", "run-command"})
 	require.Error(t, err)
-	require.ErrorContains(t, err, `Required flags "host, payload" not set`)
+	require.ErrorContains(t, err, `Required flags "hosts, payload" not set`)
 
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--host", "abc"})
+	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "abc"})
 	require.Error(t, err)
 	require.ErrorContains(t, err, `Required flag "payload" not set`)
 
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--host", "abc", "--payload", "no-such-file"})
+	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "abc", "--payload", "no-such-file"})
 	require.Error(t, err)
 	require.ErrorContains(t, err, `open no-such-file: no such file or directory`)
 
 	// pass a yaml file instead of xml
 	yamlFilePath := writeTmpYml(t, `invalid`)
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--host", "valid", "--payload", yamlFilePath})
+	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "valid", "--payload", yamlFilePath})
 	require.Error(t, err)
 	require.ErrorContains(t, err, `The payload isn't valid XML.`)
 
 	// pass valid xml plist that doesn't match the MDM command schema
 	mcFilePath := writeTmpMobileconfig(t, "Mobileconfig")
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--host", "valid-host", "--payload", mcFilePath})
+	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "valid-host", "--payload", mcFilePath})
 	require.Error(t, err)
 	require.ErrorContains(t, err, `The payload isn't valid. Please provide a valid MDM command in the form of a plist-encoded XML file:`)
 
 	// host not found
 	cmdFilePath := writeTmpMDMCmd(t, "FooBar")
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--host", "no-such-host", "--payload", cmdFilePath})
+	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "no-such-host", "--payload", cmdFilePath})
 	require.Error(t, err)
 	require.ErrorContains(t, err, `The host doesn't exist.`)
 
 	// host not in mdm
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--host", "no-mdm-host", "--payload", cmdFilePath})
+	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "no-mdm-host", "--payload", cmdFilePath})
 	require.Error(t, err)
 	require.ErrorContains(t, err, `Can't run the MDM command because the host doesn't have MDM turned on.`)
 
 	// host not in fleet mdm
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--host", "no-fleet-mdm-host", "--payload", cmdFilePath})
+	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "no-fleet-mdm-host", "--payload", cmdFilePath})
 	require.Error(t, err)
 	require.ErrorContains(t, err, `Can't run the MDM command because the host doesn't have MDM turned on.`)
 
 	// host in fleet mdm but pending
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--host", "fleet-mdm-pending-host", "--payload", cmdFilePath})
+	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "fleet-mdm-pending-host", "--payload", cmdFilePath})
 	require.Error(t, err)
 	require.ErrorContains(t, err, `Can't run the MDM command because the host doesn't have MDM turned on.`)
 
 	// host enrolled in fleet mdm
-	buf, err := runAppNoChecks([]string{"mdm", "run-command", "--host", "valid-host", "--payload", cmdFilePath})
+	buf, err := runAppNoChecks([]string{"mdm", "run-command", "--hosts", "valid-host", "--payload", cmdFilePath})
 	require.NoError(t, err)
 	require.Contains(t, buf.String(), `The hosts will run the command the next time it checks into Fleet.`)
 	require.Contains(t, buf.String(), `fleetctl get mdm-command-results --id=`)
 
 	// try to run a fleet premium command
 	cmdFilePath = writeTmpMDMCmd(t, "EraseDevice")
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--host", "valid-host", "--payload", cmdFilePath})
+	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "valid-host", "--payload", cmdFilePath})
 	require.Error(t, err)
 	require.ErrorContains(t, err, `missing or invalid license`)
 
@@ -146,7 +146,7 @@ func TestMDMRunCommand(t *testing.T) {
 </plist>`))
 	require.NoError(t, err)
 
-	_, err = runAppNoChecks([]string{"mdm", "run-command", "--host", "valid-host", "--payload", tmpFile.Name()})
+	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "valid-host", "--payload", tmpFile.Name()})
 	require.Error(t, err)
 	require.ErrorContains(t, err, `The payload isn't valid. Please provide a valid MDM command in the form of a plist-encoded XML file.`)
 }

--- a/cmd/fleetctl/mdm_test.go
+++ b/cmd/fleetctl/mdm_test.go
@@ -111,7 +111,7 @@ func TestMDMRunCommand(t *testing.T) {
 	appleCmdFilePath := writeTmpAppleMDMCmd(t, "FooBar")
 	winCmdFilePath := writeTmpWindowsMDMCmd(t, "FooBar")
 	applePremiumCmdFilePath := writeTmpAppleMDMCmd(t, "EraseDevice")
-	winPremiumCmdFilePath := writeTmpWindowsMDMCmd(t, "RemoteWipe")
+	winPremiumCmdFilePath := writeTmpWindowsMDMCmd(t, "./Device/Vendor/MSFT/RemoteWipe/doWipe")
 
 	emptyAppleCmdFilePath, err := os.CreateTemp(t.TempDir(), "*.xml")
 	require.NoError(t, err)

--- a/cmd/fleetctl/mdm_test.go
+++ b/cmd/fleetctl/mdm_test.go
@@ -114,7 +114,7 @@ func TestMDMRunCommand(t *testing.T) {
 	cmdFilePath := writeTmpMDMCmd(t, "FooBar")
 	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "no-such-host", "--payload", cmdFilePath})
 	require.Error(t, err)
-	require.ErrorContains(t, err, `The host doesn't exist.`)
+	require.ErrorContains(t, err, `No hosts targeted.`)
 
 	// host not in mdm
 	_, err = runAppNoChecks([]string{"mdm", "run-command", "--hosts", "no-mdm-host", "--payload", cmdFilePath})
@@ -134,7 +134,7 @@ func TestMDMRunCommand(t *testing.T) {
 	// host enrolled in fleet mdm
 	buf, err := runAppNoChecks([]string{"mdm", "run-command", "--hosts", "valid-host", "--payload", cmdFilePath})
 	require.NoError(t, err)
-	require.Contains(t, buf.String(), `The hosts will run the command the next time it checks into Fleet.`)
+	require.Contains(t, buf.String(), `Hosts will run the command the next time they check into Fleet.`)
 	require.Contains(t, buf.String(), `fleetctl get mdm-command-results --id=`)
 
 	// try to run a fleet premium command

--- a/cmd/fleetctl/testing_utils.go
+++ b/cmd/fleetctl/testing_utils.go
@@ -56,7 +56,12 @@ func runServerWithMockedDS(t *testing.T, opts ...*service.TestServerOpts) (*http
 		return &fleet.AppConfig{}, nil
 	}
 
-	cachedDS := cached_mysql.New(ds)
+	var cachedDS fleet.Datastore
+	if len(opts) > 0 && opts[0].NoCacheDatastore {
+		cachedDS = ds
+	} else {
+		cachedDS = cached_mysql.New(ds)
+	}
 	_, server := service.RunServerForTestsWithDS(t, cachedDS, opts...)
 	os.Setenv("FLEET_SERVER_ADDRESS", server.URL)
 

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -1228,6 +1228,44 @@ func testHostsListMDM(t *testing.T, ds *Datastore) {
 
 	hosts = listHostsCheckCount(t, ds, filter, fleet.HostListOptions{MDMNameFilter: ptr.String(fleet.WellKnownMDMJamf)}, 0)
 	assert.Equal(t, 0, len(hosts))
+
+	// create a couple Windows host and ensure they are properly returned by that filter too
+	for i := 10; i < 12; i++ {
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now().Add(-1 * time.Minute * 2),
+			OsqueryHostID:   ptr.String(strconv.Itoa(i)),
+			NodeKey:         ptr.String(fmt.Sprintf("%d", i)),
+			UUID:            fmt.Sprintf("%d", i),
+			Hostname:        fmt.Sprintf("foo.local%d", i),
+			Platform:        "windows",
+		})
+		require.NoError(t, err)
+		hostIDs = append(hostIDs, h.ID)
+	}
+	err = ds.SetOrUpdateMDMData(ctx, hostIDs[10], false, true, "http://intuneexample.com", false, fleet.WellKnownMDMIntune) // enrolled in Intune
+	require.NoError(t, err)
+	err = ds.SetOrUpdateMDMData(ctx, hostIDs[11], false, true, "http://example.com", false, fleet.WellKnownMDMFleet) // enrolled in Fleet
+	require.NoError(t, err)
+
+	hosts = listHostsCheckCount(t, ds, filter, fleet.HostListOptions{MDMNameFilter: ptr.String(fleet.WellKnownMDMIntune)}, 1)
+	assert.Equal(t, 1, len(hosts))
+	assert.Equal(t, hostIDs[10], hosts[0].ID)
+
+	hosts = listHostsCheckCount(t, ds, filter, fleet.HostListOptions{MDMNameFilter: ptr.String(fleet.WellKnownMDMFleet), MDMEnrollmentStatusFilter: fleet.MDMEnrollStatusEnrolled}, 1)
+	assert.Equal(t, 1, len(hosts))
+	assert.Equal(t, hostIDs[11], hosts[0].ID)
+
+	hosts = listHostsCheckCount(t, ds, filter, fleet.HostListOptions{MDMEnrollmentStatusFilter: fleet.MDMEnrollStatusEnrolled}, 5)
+	// simplemdm, kandji, unknown, intune and fleet (both are Windows)
+	assert.Equal(t, 5, len(hosts))
+	gotIDs := make([]uint, 0, len(hosts))
+	for _, h := range hosts {
+		gotIDs = append(gotIDs, h.ID)
+	}
+	assert.ElementsMatch(t, []uint{hostIDs[0], hostIDs[1], hostIDs[2], hostIDs[10], hostIDs[11]}, gotIDs)
 }
 
 func testHostMDMSelect(t *testing.T, ds *Datastore) {

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -19,6 +19,10 @@ var (
 	ErrPasswordResetRequired = &passwordResetRequiredError{}
 	ErrMissingLicense        = &licenseError{}
 	ErrMDMNotConfigured      = &MDMNotConfiguredError{}
+
+	MDMNotConfiguredMessage        = "MDM features aren't turned on in Fleet. For more information about setting up MDM, please visit https://fleetdm.com/docs/using-fleet"
+	WindowsMDMNotConfiguredMessage = "Windows MDM isn't turned on. Visit https://fleetdm.com/docs/using-fleet to learn how to turn on MDM."
+	AppleMDMNotConfiguredMessage   = "macOS MDM isn't turned on. Visit https://fleetdm.com/docs/using-fleet to learn how to turn on MDM."
 )
 
 // ErrWithStatusCode is an interface for errors that should set a specific HTTP
@@ -310,7 +314,7 @@ func (e *MDMNotConfiguredError) StatusCode() int {
 }
 
 func (e *MDMNotConfiguredError) Error() string {
-	return "MDM features aren't turned on in Fleet. For more information about setting up MDM, please visit https://fleetdm.com/docs/using-fleet"
+	return MDMNotConfiguredMessage
 }
 
 // GatewayError is an error type that generates a 502 or 504 status code.

--- a/server/fleet/microsoft_mdm.go
+++ b/server/fleet/microsoft_mdm.go
@@ -963,7 +963,7 @@ func (cmd SyncMLCmd) DataType() SyncMLDataType {
 		return SFNoFormat
 	}
 
-	switch *cmd.Items[0].Meta.Format.Content {
+	switch strings.TrimSpace(*cmd.Items[0].Meta.Format.Content) {
 	case "chr":
 		return SFText
 	case "xml":

--- a/server/fleet/microsoft_mdm.go
+++ b/server/fleet/microsoft_mdm.go
@@ -947,10 +947,18 @@ func ParseWindowsMDMCommand(rawXMLCmd []byte) (*SyncMLCmd, error) {
 	return &cmdMsg, nil
 }
 
+// WindowsMDMRequiresPremiumCmdMessage is the error message displayed by fleetctl mdm
+// run-command when a Premium license is required. It must be kept in sync with
+// the SyncMLCmd.IsPremium implementation below so that it reflects the proper
+// command names.
+const WindowsMDMRequiresPremiumCmdMessage = "Missing or invalid license. Wipe command is available in Fleet Premium only."
+
 // IsPremium returns true if the command is available for Fleet premium only.
 // See e.g. https://learn.microsoft.com/en-us/windows/client-management/mdm/remotewipe-csp#dowipe
 // for details.
 func (cmd SyncMLCmd) IsPremium() bool {
+	// NOTE: if this implementation changes, make sure to also update the error
+	// message above - the WindowsMDMRequiresPremiumCmdMessage constant.
 	return strings.Contains(cmd.GetTargetURI(), "/Device/Vendor/MSFT/RemoteWipe/")
 }
 

--- a/server/fleet/microsoft_mdm_test.go
+++ b/server/fleet/microsoft_mdm_test.go
@@ -1,0 +1,66 @@
+package fleet
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseWindowsMDMCommand(t *testing.T) {
+	cases := []struct {
+		desc    string
+		raw     string
+		wantCmd SyncMLCmd
+		wantErr string
+	}{
+		{"not xml", "zzz", SyncMLCmd{}, "The payload isn't valid XML"},
+		{"multi Exec top-level", `<Exec></Exec><Exec></Exec>`, SyncMLCmd{}, "You can run only a single <Exec> command"},
+		{"not Exec", `<Get></Get>`, SyncMLCmd{}, "You can run only <Exec> command type"},
+		{"valid Exec", `<Exec><Item><Target><LocURI>./test</LocURI></Target></Item></Exec>`, SyncMLCmd{
+			XMLName: xml.Name{Local: "Exec"},
+			Items: []CmdItem{
+				{Target: ptr.String("./test")},
+			},
+		}, ""},
+		{"valid Exec with spaces", `
+			<Exec>
+				<Item>
+					<Target>
+						<LocURI>./test</LocURI>
+					</Target>
+				</Item>
+			</Exec>`, SyncMLCmd{
+			XMLName: xml.Name{Local: "Exec"},
+			Items: []CmdItem{
+				{Target: ptr.String("./test")},
+			},
+		}, ""},
+		{"Exec with multiple Items", `
+			<Exec>
+				<Item>
+					<Target>
+						<LocURI>./test</LocURI>
+					</Target>
+				</Item>
+				<Item>
+					<Target>
+						<LocURI>./test2</LocURI>
+					</Target>
+				</Item>
+			</Exec>`, SyncMLCmd{}, "You can run only a single <Exec> command"},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			got, err := ParseWindowsMDMCommand([]byte(c.raw))
+			if c.wantErr != "" {
+				require.ErrorContains(t, err, c.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, got)
+				require.Equal(t, c.wantCmd, *got)
+			}
+		})
+	}
+}

--- a/server/mdm/microsoft/microsoft_mdm.go
+++ b/server/mdm/microsoft/microsoft_mdm.go
@@ -174,7 +174,7 @@ const (
 	WstepRenewRetryInterval = "4"
 
 	// The PROVIDER-ID paramer specifies the server identifier for a management server used in the current management session
-	DocProvisioningAppProviderID = "FleetDM"
+	DocProvisioningAppProviderID = "Fleet"
 
 	// The NAME parameter is used in the APPLICATION characteristic to specify a user readable application identity
 	DocProvisioningAppName = DocProvisioningAppProviderID

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -231,10 +231,19 @@ func (c *Client) authenticatedRequest(params interface{}, verb string, path stri
 	return c.authenticatedRequestWithQuery(params, verb, path, responseDest, "")
 }
 
-func (c *Client) CheckMDMEnabled() error {
+func (c *Client) CheckAnyMDMEnabled() error {
+	return c.runAppConfigChecks(func(ac *fleet.EnrichedAppConfig) error {
+		if !ac.MDM.EnabledAndConfigured && !ac.MDM.WindowsEnabledAndConfigured {
+			return errors.New(fleet.MDMNotConfiguredMessage)
+		}
+		return nil
+	})
+}
+
+func (c *Client) CheckAppleMDMEnabled() error {
 	return c.runAppConfigChecks(func(ac *fleet.EnrichedAppConfig) error {
 		if !ac.MDM.EnabledAndConfigured {
-			return errors.New("MDM features aren't turned on. Use `fleetctl generate mdm-apple` and then `fleet serve` with `mdm` configuration to turn on MDM features.")
+			return errors.New(fleet.AppleMDMNotConfiguredMessage)
 		}
 		return nil
 	})
@@ -246,7 +255,7 @@ func (c *Client) CheckPremiumMDMEnabled() error {
 			return errors.New("missing or invalid license")
 		}
 		if !ac.MDM.EnabledAndConfigured {
-			return errors.New("MDM features aren't turned on. Use `fleetctl generate mdm-apple` and then `fleet serve` with `mdm` configuration to turn on MDM features.")
+			return errors.New(fleet.AppleMDMNotConfiguredMessage)
 		}
 		return nil
 	})

--- a/server/service/client_mdm.go
+++ b/server/service/client_mdm.go
@@ -236,7 +236,7 @@ func downloadRemoteMacosBootstrapPackage(pkgURL string) (*fleet.MDMAppleBootstra
 }
 
 func (c *Client) validateMacOSSetupAssistant(fileName string) ([]byte, error) {
-	if err := c.CheckMDMEnabled(); err != nil {
+	if err := c.CheckAppleMDMEnabled(); err != nil {
 		return nil, err
 	}
 

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -461,7 +461,7 @@ func runMDMCommandEndpoint(ctx context.Context, request interface{}, svc fleet.S
 }
 
 func (svc *Service) RunMDMCommand(ctx context.Context, rawBase64Cmd string, hostUUIDs []string) (result *fleet.CommandEnqueueResult, err error) {
-	hosts, err := svc.authorizeAllHostsTeams(ctx, hostUUIDs, false, fleet.ActionWrite, &fleet.MDMCommandAuthz{})
+	hosts, err := svc.authorizeAllHostsTeams(ctx, hostUUIDs, fleet.ActionWrite, &fleet.MDMCommandAuthz{})
 	if err != nil {
 		return nil, err
 	}

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1,9 +1,7 @@
 package service
 
 import (
-	"bytes"
 	"context"
-	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
@@ -591,27 +589,10 @@ func (svc *Service) enqueueAppleMDMCommand(ctx context.Context, rawXMLCmd []byte
 }
 
 func (svc *Service) enqueueMicrosoftMDMCommand(ctx context.Context, rawXMLCmd []byte, deviceIDs []string) (result *fleet.CommandEnqueueResult, err error) {
-	// a command must have the <Exec> element as top-level
-	var cmdMsg fleet.SyncMLCmd
-	dec := xml.NewDecoder(bytes.NewReader(bytes.TrimSpace(rawXMLCmd)))
-	if err := dec.Decode(&cmdMsg); err != nil {
-		err = fleet.NewInvalidArgumentError("command", fmt.Sprintf("The payload isn't valid XML: %v", err))
+	cmdMsg, err := fleet.ParseWindowsMDMCommand(rawXMLCmd)
+	if err != nil {
+		err = fleet.NewInvalidArgumentError("command", err.Error())
 		return nil, ctxerr.Wrap(ctx, err, "decode SyncML command")
-	}
-
-	// check if there were multiple top-level elements provided
-	if _, err := dec.Token(); err != io.EOF {
-		err = fleet.NewInvalidArgumentError("command", "You can run only a single <Exec> command.")
-		return nil, ctxerr.Wrap(ctx, err, "decode SyncML command")
-	}
-
-	if cmdMsg.XMLName.Local != fleet.CmdExec {
-		err = fleet.NewInvalidArgumentError("command", "You can run only <Exec> command type.")
-		return nil, ctxerr.Wrap(ctx, err, "validate SyncML commands")
-	}
-	if len(cmdMsg.Items) != 1 {
-		err = fleet.NewInvalidArgumentError("command", "You can run only a single <Exec> command.")
-		return nil, ctxerr.Wrap(ctx, err, "validate SyncML Exec commands")
 	}
 
 	if cmdMsg.IsPremium() {

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -501,12 +501,12 @@ func (svc *Service) RunMDMCommand(ctx context.Context, rawBase64Cmd string, host
 	switch commandPlatform {
 	case "windows":
 		if err := svc.VerifyMDMWindowsConfigured(ctx); err != nil {
-			err := fleet.NewInvalidArgumentError("host_uuids", "Windows MDM isn't turned on. Visit https://fleetdm.com/docs/using-fleet to learn how to turn on MDM.").WithStatus(http.StatusBadRequest)
+			err := fleet.NewInvalidArgumentError("host_uuids", fleet.WindowsMDMNotConfiguredMessage).WithStatus(http.StatusBadRequest)
 			return nil, ctxerr.Wrap(ctx, err, "check windows MDM enabled")
 		}
 	default:
 		if err := svc.VerifyMDMAppleConfigured(ctx); err != nil {
-			err := fleet.NewInvalidArgumentError("host_uuids", "macOS MDM isn't turned on. Visit https://fleetdm.com/docs/using-fleet to learn how to turn on MDM.").WithStatus(http.StatusBadRequest)
+			err := fleet.NewInvalidArgumentError("host_uuids", fleet.AppleMDMNotConfiguredMessage).WithStatus(http.StatusBadRequest)
 			return nil, ctxerr.Wrap(ctx, err, "check macOS MDM enabled")
 		}
 	}

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -253,7 +253,7 @@ func TestMicrosoftWSTEPConfig(t *testing.T) {
 	parsedCert, err := x509.ParseCertificate(rawDER)
 	require.NoError(t, err)
 	require.Equal(t, "test-client", parsedCert.Subject.CommonName)
-	require.Equal(t, "FleetDM", parsedCert.Subject.OrganizationalUnit[0])
+	require.Equal(t, "Fleet", parsedCert.Subject.OrganizationalUnit[0])
 }
 
 func TestRunMDMCommandAuthz(t *testing.T) {

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -197,7 +197,7 @@ func TestMicrosoftWSTEPConfig(t *testing.T) {
 	ds.WSTEPStoreCertificateFunc = func(ctx context.Context, name string, crt *x509.Certificate) error {
 		require.Equal(t, "test-client", name)
 		require.Equal(t, "test-client", crt.Subject.CommonName)
-		require.Equal(t, "FleetDM", crt.Subject.OrganizationalUnit[0])
+		require.Equal(t, "Fleet", crt.Subject.OrganizationalUnit[0])
 		return nil
 	}
 

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -288,6 +288,7 @@ type TestServerOpts struct {
 	UseMailService      bool
 	APNSTopic           string
 	ProfileMatcher      fleet.ProfileMatcher
+	NoCacheDatastore    bool
 }
 
 func RunServerForTestsWithDS(t *testing.T, ds fleet.Datastore, opts ...*TestServerOpts) (map[string]fleet.User, *httptest.Server) {


### PR DESCRIPTION
#13594 

**NOTE** that this targets this branch and PR: https://github.com/fleetdm/fleet/pull/14259 and as such should only be reviewed/merged once the other PR has been merged in the feature branch.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
(manual QA for "forbidden" error message and success cases, with a macOS and a Windows host)