### PR TITLE
ChromeOS: [bug] Surface chrome extensions as software for ChromeOS hosts 

### DIFF
--- a/changes/14170-chromeos-software-bug
+++ b/changes/14170-chromeos-software-bug
@@ -1,0 +1,1 @@
+- For ChromeOS hosts, surface chrome extensions as software

--- a/docs/Using Fleet/Understanding-host-vitals.md
+++ b/docs/Using Fleet/Understanding-host-vitals.md
@@ -462,7 +462,7 @@ SELECT
   'Browser plugin (Chrome)' AS type,
   'chrome_extensions' AS source,
   '' AS vendor,
-  path AS installed_path
+  '' AS installed_path
 FROM chrome_extensions
 ```
 

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -376,7 +376,7 @@ CREATE TABLE `host_software_installed_paths` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `host_id` int(10) unsigned NOT NULL,
   `software_id` bigint(20) unsigned NOT NULL,
-  `installed_path` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `installed_path` text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `host_id_software_id_idx` (`host_id`,`software_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -376,7 +376,7 @@ CREATE TABLE `host_software_installed_paths` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `host_id` int(10) unsigned NOT NULL,
   `software_id` bigint(20) unsigned NOT NULL,
-  `installed_path` text COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `installed_path` text COLLATE utf8mb4_unicode_ci NOT NULL,
   PRIMARY KEY (`id`),
   KEY `host_id_software_id_idx` (`host_id`,`software_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -103,7 +103,7 @@ type HostSoftwareEntry struct {
 	Software
 	// Where this software was installed on the host, value is derived from the
 	// host_software_installed_paths table.
-	InstalledPaths []string `json:"installed_paths,omitempty"`
+	InstalledPaths []string `json:"installed_paths"`
 }
 
 // HostSoftware is the set of software installed on a specific host

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -910,7 +910,7 @@ var softwareChrome = DetailQuery{
   'Browser plugin (Chrome)' AS type,
   'chrome_extensions' AS source,
   '' AS vendor,
-  path AS installed_path
+  '' AS installed_path
 FROM chrome_extensions`,
 	Platforms:        []string{"chrome"},
 	DirectIngestFunc: directIngestSoftware,


### PR DESCRIPTION
## Issue
Cerra #14170 

## Description
- Fix: `select * from chrome_extensions;` returns Chrome extensions for chrome OS hosts where path now returns as an empty string

## Issues testing TLDR
- Locally pushing the fix the dirty way to my chromebook using chrome extensions is hitting a limitation
  - My chromebook when it hits the hour of waiting for the software inventory to be updated, spontaneously creates a new host and removes the last host, resetting the create date as well as the software update date, which software continues to show as none
  - My hunch is if we push the fix to dogfood, we can properly test if the empty string path fix for the sql/database fixes the issue with chrome extensions with no path (like on ChromeOS) not showing


## Screenshot
- path was returning error in the sql query as it was being omitted
<img width="1693" alt="Screenshot 2023-10-19 at 11 25 57 AM" src="https://github.com/fleetdm/fleet/assets/71795832/c72de56d-14a0-47e9-8e39-f382df81d4b7">

## Screenshot of my host spontaneously being reset in dev environment after 1 hour making it impossible to test the fix in dev
<img width="1268" alt="Screenshot 2023-10-19 at 1 23 08 PM" src="https://github.com/fleetdm/fleet/assets/71795832/2f558f66-2453-467e-90d1-f084f24cc1da">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [ ] Manual QA for all new/changed functionality

