### PR TITLE
Fleet UI: [styling bugs] Scrollbars attack pt. 2 and unreleased checkbox bug introduced

### DIFF
--- a/frontend/components/forms/fields/Checkbox/_styles.scss
+++ b/frontend/components/forms/fields/Checkbox/_styles.scss
@@ -97,6 +97,8 @@
 }
 
 .inverse {
+  flex-direction: row-reverse; // Switches the text to the left side of checkbox as all checkboxes are now display flex
+
   .fleet-checkbox {
     &__input {
       float: right;

--- a/frontend/pages/policies/PolicyPage/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/_styles.scss
@@ -149,5 +149,9 @@
     .form-field--checkbox {
       margin-bottom: 0;
     }
+
+    // .inverse {
+    //   flex-direction: row-reverse; // Switches the text to the left side of checkbox as all checkboxes are now display flex
+    // }
   }
 }

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
@@ -136,6 +136,7 @@
     resize: none;
     white-space: normal;
     background-color: transparent;
+    overflow: hidden;
     &:hover:not(.focus-visible):not(.no-hover) {
       color: $core-vibrant-blue;
       cursor: pointer;

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -138,6 +138,7 @@
     resize: none;
     white-space: normal;
     background-color: transparent;
+    overflow: hidden;
     &:hover:not(.focus-visible):not(.no-hover) {
       color: $core-vibrant-blue;
       cursor: pointer;


### PR DESCRIPTION
## Issue
Cerra #14627 (checkbox collide with text)
Cerra #14272 (scrollbar issue)

## Description
- Hide scrollbars no matter what, QA @xpkoala confirmed functionality is not affectd by hiding scrollbars
- Fix alignment of text for critical checkbox (bug introduced by display: flex usage in #14545)

## Screenshots
<img width="926" alt="Screenshot 2023-10-18 at 4 56 50 PM" src="https://github.com/fleetdm/fleet/assets/71795832/6e876c7f-871e-4c62-b8e5-7e3a85e98242">
<img width="924" alt="Screenshot 2023-10-18 at 4 56 39 PM" src="https://github.com/fleetdm/fleet/assets/71795832/b9790da5-35fe-4481-9a9a-ed096751f3b5">


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manual QA for all new/changed functionality
