### PR TITLE
Remove `navSection` meta tags from configuration documentation pages

### DIFF
--- a/docs/Configuration/agent-configuration.md
+++ b/docs/Configuration/agent-configuration.md
@@ -464,4 +464,3 @@ The agents may take several seconds to update because Fleet has to wait for the 
 
 <meta name="pageOrderInSection" value="300">
 <meta name="description" value="Learn how to use configuration files and the fleetctl command line tool to configure agent options.">
-<meta name="navSection" value="Agent">

--- a/docs/Configuration/configuration-files/README.md
+++ b/docs/Configuration/configuration-files/README.md
@@ -1202,4 +1202,3 @@ List of saved scripts that can be run on all hosts.
 > **Note:** More settings are included in the [contributor documentation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/Configuration-for-contributors.md). It's possible, although not recommended, to configure these settings in the YAML configuration file.
 
 <meta name="description" value="Learn how to use configuration files and the fleetctl command line tool to configure Fleet.">
-<meta name="navSection" value="Fleet server">

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -2958,4 +2958,3 @@ This content was moved to [Public IPs](http://fleetdm.com/docs/deploy/public-ip)
 
 <meta name="pageOrderInSection" value="100">
 <meta name="description" value="This page includes resources for configuring the Fleet binary, managing osquery configurations, and running with systemd.">
-<meta name="navSection" value="Fleet server">


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/14467
