### PR TITLE
document flags required for fleetd error reporting

### DIFF
--- a/docs/Contributing/API-for-contributors.md
+++ b/docs/Contributing/API-for-contributors.md
@@ -2548,6 +2548,8 @@ Notifies the server about an agent error, resulting in two outcomes:
 - The error gets saved in Redis and can later be accessed using `fleetctl debug archive`.
 - The server consistently replies with a `500` status code, which can serve as a signal to activate an alarm through a monitoring tool.
 
+> Note: to allow `fleetd` agents to use this endpoint, you need to set a [custom environment variable](./Configuration-for-contributors#fleet_enable_post_client_debug_errors)
+
 `POST /api/v1/fleet/device/{token}/debug/errors`
 
 #### Parameters

--- a/docs/Contributing/Configuration-for-contributors.md
+++ b/docs/Contributing/Configuration-for-contributors.md
@@ -2,6 +2,7 @@
 
 - [Integrations](#integrations)
 - [SMTP-settings](#smtp-settings)
+- [Environment variables](#environment-variables)
 
 This document includes configuration files and settings that are helpful when developing or contributing to Fleet.
 
@@ -360,6 +361,12 @@ Whether the SMTP server's SSL certificates should be verified. This can be turne
   smtp_settings:
     verify_ssl_certs: false
   ```
+
+## Environment variables
+
+### FLEET_ENABLE_POST_CLIENT_DEBUG_ERRORS
+
+Use this environment variable to allow `fleetd` to report errors to the server using the [endpoint to report an agent error](./API-for-contributors#report-an-agent-error).
 
 <meta name="pageOrderInSection" value="1100">
 <meta name="description" value="Learn about the configuration files and settings that are helpful when developing or contributing to Fleet.">


### PR DESCRIPTION
For #13189, this documents the server config flag required to report errors.
...

