### PR TITLE
allow to set an orbit destination via env variable

### DIFF
--- a/orbit/changes/14657-log-flag
+++ b/orbit/changes/14657-log-flag
@@ -1,0 +1,1 @@
+* Allow to configure the orbit `--log-file` flag via an environment variable `ORBIT_LOG_FILE`.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -144,8 +144,9 @@ func main() {
 			Usage: "Get Orbit version",
 		},
 		&cli.StringFlag{
-			Name:  "log-file",
-			Usage: "Log to this file path in addition to stderr",
+			Name:    "log-file",
+			Usage:   "Log to this file path in addition to stderr",
+			EnvVars: []string{"ORBIT_LOG_FILE"},
 		},
 		&cli.BoolFlag{
 			Name:    "fleet-desktop",


### PR DESCRIPTION
for #14657. Seems like we're not documenting any of the orbit flags.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [x] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
