### PR TITLE
Tables Part 1

### DIFF
--- a/orbit/pkg/table/extension.go
+++ b/orbit/pkg/table/extension.go
@@ -134,8 +134,8 @@ func OrbitDefaultTables() []osquery.OsqueryPlugin {
 		table.NewPlugin("sntp_request", sntp_request.Columns(), sntp_request.GenerateFunc),
 
 		// Kolide extensions.
-		zfs.ZfsPropertiesPlugin(serverClient, kolideLogger),   // table name is "kolide_zfs"
-		zfs.ZpoolPropertiesPlugin(serverClient, kolideLogger), // table name is "kolide_zfs"
+		zfs.ZfsPropertiesPlugin(nil, kolideLogger),   // table name is "kolide_zfs"
+		zfs.ZpoolPropertiesPlugin(nil, kolideLogger), // table name is "kolide_zfs"
 	}
 	return plugins
 }

--- a/orbit/pkg/table/extension.go
+++ b/orbit/pkg/table/extension.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/sntp_request"
+	"github.com/kolide/launcher/pkg/osquery/tables/zfs"
 	"github.com/macadmins/osquery-extension/tables/chromeuserprofiles"
 	"github.com/macadmins/osquery-extension/tables/fileline"
 	"github.com/macadmins/osquery-extension/tables/puppet"
@@ -133,7 +134,8 @@ func OrbitDefaultTables() []osquery.OsqueryPlugin {
 		table.NewPlugin("sntp_request", sntp_request.Columns(), sntp_request.GenerateFunc),
 
 		// Kolide extensions.
-
+		zfs.ZfsPropertiesPlugin(serverClient, kolideLogger),   // table name is "kolide_zfs"
+		zfs.ZpoolPropertiesPlugin(serverClient, kolideLogger), // table name is "kolide_zfs"
 	}
 	return plugins
 }

--- a/orbit/pkg/table/extension.go
+++ b/orbit/pkg/table/extension.go
@@ -134,8 +134,8 @@ func OrbitDefaultTables() []osquery.OsqueryPlugin {
 		table.NewPlugin("sntp_request", sntp_request.Columns(), sntp_request.GenerateFunc),
 
 		// Kolide extensions.
-		zfs.ZfsPropertiesPlugin(nil, kolideLogger),   // table name is "kolide_zfs"
-		zfs.ZpoolPropertiesPlugin(nil, kolideLogger), // table name is "kolide_zfs"
+		zfs.ZfsPropertiesPlugin(nil, kolideLogger),   // table name is "kolide_zfs_properties"
+		zfs.ZpoolPropertiesPlugin(nil, kolideLogger), // table name is "kolide_zpool_properties"
 	}
 	return plugins
 }

--- a/orbit/pkg/table/extension_darwin.go
+++ b/orbit/pkg/table/extension_darwin.go
@@ -62,6 +62,6 @@ func PlatformTables() []osquery.OsqueryPlugin {
 		table.NewPlugin("macadmins_unified_log", unifiedlog.UnifiedLogColumns(), unifiedlog.UnifiedLogGenerate),
 
 		// Kolide tables
-		systemprofiler.TablePlugin(serverClient, kolideLogger), // table name is "kolide_systemprofiler"
+		systemprofiler.TablePlugin(nil, kolideLogger), // table name is "kolide_systemprofiler"
 	}
 }

--- a/orbit/pkg/table/extension_darwin.go
+++ b/orbit/pkg/table/extension_darwin.go
@@ -18,6 +18,7 @@ import (
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/software_update"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/sudo_info"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/user_login_settings"
+	"github.com/kolide/launcher/pkg/osquery/tables/systemprofiler"
 	"github.com/macadmins/osquery-extension/tables/filevaultusers"
 	"github.com/macadmins/osquery-extension/tables/macos_profiles"
 	"github.com/macadmins/osquery-extension/tables/macosrsr"
@@ -59,5 +60,8 @@ func PlatformTables() []osquery.OsqueryPlugin {
 		// osquery version 5.5.0 and up ships a unified_log table in core
 		// we are renaming the one from the macadmins extension to avoid collision
 		table.NewPlugin("macadmins_unified_log", unifiedlog.UnifiedLogColumns(), unifiedlog.UnifiedLogGenerate),
+
+		// Kolide tables
+		systemprofiler.TablePlugin(serverClient, kolideLogger), // table name is "kolide_systemprofiler"
 	}
 }

--- a/orbit/pkg/table/extension_linux.go
+++ b/orbit/pkg/table/extension_linux.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package table
+
+import (
+	"github.com/kolide/launcher/pkg/osquery/tables/xconf"
+	"github.com/kolide/launcher/pkg/osquery/tables/xrdb"
+	"github.com/osquery/osquery-go"
+)
+
+func PlatformTables() []osquery.OsqueryPlugin {
+	return []osquery.OsqueryPlugin{
+		// Kolide tables
+		xconf.TablePlugin(serverClient, kolideLogger), // table name is "kolide_xconf"
+		xrdb.TablePlugin(serverClient, kolideLogger),  // table name is "kolide_xrdb"
+	}
+}

--- a/orbit/pkg/table/extension_linux.go
+++ b/orbit/pkg/table/extension_linux.go
@@ -11,7 +11,7 @@ import (
 func PlatformTables() []osquery.OsqueryPlugin {
 	return []osquery.OsqueryPlugin{
 		// Kolide tables
-		xconf.TablePlugin(serverClient, kolideLogger), // table name is "kolide_xconf"
-		xrdb.TablePlugin(serverClient, kolideLogger),  // table name is "kolide_xrdb"
+		xconf.TablePlugin(nil, kolideLogger), // table name is "kolide_xconf"
+		xrdb.TablePlugin(nil, kolideLogger),  // table name is "kolide_xrdb"
 	}
 }

--- a/orbit/pkg/table/extension_windows.go
+++ b/orbit/pkg/table/extension_windows.go
@@ -3,8 +3,11 @@
 package table
 
 import (
-	"github.com/fleetdm/fleet/v4/orbit/pkg/table/cis_audit"
-	"github.com/fleetdm/fleet/v4/orbit/pkg/table/mdm"
+	cisaudit "github.com/fleetdm/fleet/v4/orbit/pkg/table/cis_audit"
+	mdmbridge "github.com/fleetdm/fleet/v4/orbit/pkg/table/mdm"
+	"github.com/kolide/launcher/pkg/osquery/tables/wifi_networks"
+	"github.com/kolide/launcher/pkg/osquery/tables/windowsupdatetable"
+	"github.com/kolide/launcher/pkg/osquery/tables/wmitable"
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 )
@@ -14,5 +17,10 @@ func PlatformTables() []osquery.OsqueryPlugin {
 		// Fleet tables
 		table.NewPlugin("mdm_bridge", mdmbridge.Columns(), mdmbridge.Generate),
 		table.NewPlugin("cis_audit", cisaudit.Columns(), cisaudit.Generate),
+
+		// Kolide tables
+		wifi_networks.TablePlugin(serverClient, kolideLogger),      // table name is "kolide_wifi_networks"
+		windowsupdatetable.TablePlugin(serverClient, kolideLogger), // table name is "kolide_windowsupdatetable" // TODO, more complicated
+		wmitable.TablePlugin(serverClient, kolideLogger),           // table name is "kolide_wmitable"
 	}
 }

--- a/orbit/pkg/table/extension_windows.go
+++ b/orbit/pkg/table/extension_windows.go
@@ -5,6 +5,8 @@ package table
 import (
 	cisaudit "github.com/fleetdm/fleet/v4/orbit/pkg/table/cis_audit"
 	mdmbridge "github.com/fleetdm/fleet/v4/orbit/pkg/table/mdm"
+	"github.com/kolide/launcher/pkg/osquery/tables/dsim_default_associations"
+	"github.com/kolide/launcher/pkg/osquery/tables/secedit"
 	"github.com/kolide/launcher/pkg/osquery/tables/wifi_networks"
 	"github.com/kolide/launcher/pkg/osquery/tables/wmitable"
 	"github.com/osquery/osquery-go"
@@ -18,7 +20,9 @@ func PlatformTables() []osquery.OsqueryPlugin {
 		table.NewPlugin("cis_audit", cisaudit.Columns(), cisaudit.Generate),
 
 		// Kolide tables
-		wifi_networks.TablePlugin(serverClient, kolideLogger), // table name is "kolide_wifi_networks"
-		wmitable.TablePlugin(serverClient, kolideLogger),      // table name is "kolide_wmi"
+		dsim_default_associations.TablePlugin(serverClient, kolideLogger), // table name is "kolide_dsim_default_associations"
+		secedit.TablePlugin(serverClient, kolideLogger),                   // table name is "kolide_secedit"
+		wifi_networks.TablePlugin(serverClient, kolideLogger),             // table name is "kolide_wifi_networks"
+		wmitable.TablePlugin(serverClient, kolideLogger),                  // table name is "kolide_wmi"
 	}
 }

--- a/orbit/pkg/table/extension_windows.go
+++ b/orbit/pkg/table/extension_windows.go
@@ -6,7 +6,6 @@ import (
 	cisaudit "github.com/fleetdm/fleet/v4/orbit/pkg/table/cis_audit"
 	mdmbridge "github.com/fleetdm/fleet/v4/orbit/pkg/table/mdm"
 	"github.com/kolide/launcher/pkg/osquery/tables/wifi_networks"
-	"github.com/kolide/launcher/pkg/osquery/tables/windowsupdatetable"
 	"github.com/kolide/launcher/pkg/osquery/tables/wmitable"
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
@@ -19,8 +18,7 @@ func PlatformTables() []osquery.OsqueryPlugin {
 		table.NewPlugin("cis_audit", cisaudit.Columns(), cisaudit.Generate),
 
 		// Kolide tables
-		wifi_networks.TablePlugin(serverClient, kolideLogger),      // table name is "kolide_wifi_networks"
-		windowsupdatetable.TablePlugin(serverClient, kolideLogger), // table name is "kolide_windowsupdatetable" // TODO, more complicated
-		wmitable.TablePlugin(serverClient, kolideLogger),           // table name is "kolide_wmitable"
+		wifi_networks.TablePlugin(serverClient, kolideLogger), // table name is "kolide_wifi_networks"
+		wmitable.TablePlugin(serverClient, kolideLogger),      // table name is "kolide_wmi"
 	}
 }


### PR DESCRIPTION
## Issue
Part 1 of #14466 

## Description
- Simpler of the 10 tables

Table `kolide_dsim_default_associations` (windows)
- [x] Added
- [x] Tested windows

Table `kolide_secedit` (windows)
- [x] Added
- [x] Tested windows

Table `kolide_systemprofiler` (darwin only)
- [x] Added
- [ ] Tested darwin

Table `kolide_xconf` (linux)
- [x] Added
- [ ] Tested linux

Table `kolide_xrdb` (linux)
- [x] Added
- [ ] Tested linux

Table kolide_zfs_properties (darwin, linux, windows)
- [x] Added
- [ ] Tested darwin
- [ ] Tested linux
- [ ] Tested windows
<img width="1046" alt="Screenshot 2023-10-24 at 2 38 53 PM" src="https://github.com/fleetdm/fleet/assets/71795832/9c13367e-aecd-4d5c-b8da-5d0631914e0d">


kolide_zpool_properties (darwin, linux, windows)
- [x] Added
- [ ] Tested darwin
- [ ] Tested linux
- [ ] Tested windows
<img width="1051" alt="Screenshot 2023-10-24 at 2 38 48 PM" src="https://github.com/fleetdm/fleet/assets/71795832/b5c82814-d967-421c-8fe5-aa4aae7d18e2">


Table `kolide_wifi_networks` (windows)
- [x] Added
- [ ] Tested windows
- (See screenshot of error testing table on VM) I don't have a wifi interface on my VM, make sense I get an error when running this table, needs test on non-VM because my network interface isn't exposed to my windows VM through my mac
<img width="1035" alt="Screenshot 2023-10-24 at 9 36 21 AM" src="https://github.com/fleetdm/fleet/assets/71795832/2400c515-6d8a-4595-9049-c978327bb71b">

Table `kolide_wmi` (windows)
- [x] Added
- [ ] Tested windows
<img width="616" alt="Screenshot 2023-10-24 at 2 33 10 PM" src="https://github.com/fleetdm/fleet/assets/71795832/e6b0ee66-6622-444e-b115-ed211cca2898">


## Screenshots
<img width="1339" alt="Screenshot 2023-10-20 at 11 20 57 AM" src="https://github.com/fleetdm/fleet/assets/71795832/05274d4e-f0f9-4365-ac4a-c3a7312365c2">



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
