### PR TITLE
Remove to be scheduled column from bugs board

### DIFF
--- a/handbook/product/README.md
+++ b/handbook/product/README.md
@@ -122,17 +122,15 @@ Bugs are always prioritized. (Fleet takes quality and stability [very seriously]
 
 If a bug is unreleased or [critical](https://fleetdm.com/handbook/engineering#critical-bugs), it is addressed in the current sprint. Otherwise, it may be prioritized and estimated for the next sprint. If a bug [requires drafting](https://fleetdm.com/handbook/engineering#in-product-drafting-as-needed) to determine the expected functionality, the bug should undergo [expedited drafting](#expedited-drafting). 
 
-If a bug is not addressed within six weeks, it is [sent to the product team for triage](https://fleetdm.com/handbook/engineering#in-engineering). Each sprint, the Head of Product meets with the group product managers to review these bugs (churned bug review). In this session, bugs are categorized as follows:
-- **Schedule**: the bug should be prioritized in the next sprint.
-- **Needs prioritization**: the bug will likely not be worked on within the next six weeks, but it is still a valid bug.
+If a bug is not addressed within six weeks, it is [sent to the product team for triage](https://fleetdm.com/handbook/engineering#in-engineering). Each sprint, the Head of Product design reviews these bugs. Bugs are categorized as follows:
+- **Schedule**: the bug should be prioritized in the next sprint if there's engineering capacity for it.
 - **De-prioritized**: the issue will be closed and the necessary subsequent steps will be initiated. This might include updating documentation and informing the community.
 
-After aligning with the group product managers, the Head of Product meets with the CEO and Director of Product Development to discuss and finalize the outcomes for the churned bugs.
+The Head of Product Design meets with the CEO and Director of Product Development to discuss and finalize the outcomes for the churned bugs.
 
-Once outcomes have been approved by the CEO, Product Operations will complete the churned bug clean-up ritual. Below are the steps for each category:
-- **Schedule**: Product Operations should remove the `:product` label, move the bug ticket to the 'Sprint backlog' column on the bug board, and assign it to the appropriate group's Product Manager so that it can be prioritized into the sprint backlog.
-- **Needs prioritization**: Product Operations should remove both the `bug` and `:product` labels, then apply the `needs prioritization` label.
-- **De-prioritized**: Product Operations should close the issue and, as the DRI, ensure all follow-up actions are finalized.
+Once outcomes have been approved by the CEO, The Head of Product Design will complete the churned bug clean-up ritual. Below are the steps for each category:
+- **Schedule**: Product Operations should remove the `:product` label, move the bug ticket to the 'Sprint backlog' column on the bug board, and assign it to the appropriate group's Engineering Manager so that it can be prioritized into the sprint backlog.
+- **De-prioritized**: The Head of Product Design should close the issue and, as the DRI, ensure all follow-up actions are finalized.
 
 ## Writing user stories
 Product Managers [write user stories](https://fleetdm.com/handbook/company/development-groups#writing-a-good-user-story) in the [drafting board](https://app.zenhub.com/workspaces/-product-backlog-coming-soon-6192dd66ea2562000faea25c/board). The drafting board is shared by every [product group](https://fleetdm.com/handbook/company/development-groups).

--- a/handbook/product/README.md
+++ b/handbook/product/README.md
@@ -81,7 +81,7 @@ Once the draft has been approved, it moves to the "Settled" column on the drafti
 
 Before assigning an engineering manager to [estimate](https://fleetdm.com/handbook/engineering#sprint-ceremonies) a user story, the product designer ensures the product section of the user story [checklist](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=story&projects=&template=story.md&title=) is complete. 
 
-Once a bug has gone through design and is considered "Settled", the designer removes the `:product` label and moves the issue to the 'Sprint backlog' column on the "Bugs" board. The product manager then prioritizes the bug into the "Sprint backlog" and assigns the group engineering manager. 
+Once a bug has gone through design and is considered "Settled", the designer removes the `:product` label and moves the issue to the 'Sprint backlog' column on the "Bugs" board and assigns the group engineering manager. 
 
 Learn https://fleetdm.com/handbook/company/development-groups#making-changes
 

--- a/handbook/product/README.md
+++ b/handbook/product/README.md
@@ -122,13 +122,13 @@ Bugs are always prioritized. (Fleet takes quality and stability [very seriously]
 
 If a bug is unreleased or [critical](https://fleetdm.com/handbook/engineering#critical-bugs), it is addressed in the current sprint. Otherwise, it may be prioritized and estimated for the next sprint. If a bug [requires drafting](https://fleetdm.com/handbook/engineering#in-product-drafting-as-needed) to determine the expected functionality, the bug should undergo [expedited drafting](#expedited-drafting). 
 
-If a bug is not addressed within six weeks, it is [sent to the product team for triage](https://fleetdm.com/handbook/engineering#in-engineering). Each sprint, the Head of Product design reviews these bugs. Bugs are categorized as follows:
+If a bug is not addressed within six weeks, it is [sent to the product team for triage](https://fleetdm.com/handbook/engineering#in-engineering). Each sprint, the Head of Product Design reviews these bugs. Bugs are categorized as follows:
 - **Schedule**: the bug should be prioritized in the next sprint if there's engineering capacity for it.
 - **De-prioritized**: the issue will be closed and the necessary subsequent steps will be initiated. This might include updating documentation and informing the community.
 
-The Head of Product Design meets with the CEO to discuss and finalize the outcomes for the churned bugs.
+The Head of Product Design meets with the Head of Product Development to discuss and finalize the outcomes for the churned bugs.
 
-Once outcomes have been approved by the CEO, The Head of Product Design will complete the churned bug clean-up ritual. Below are the steps for each category:
+After aligning with the Head of Product Development on the outcomes, The Head of Product Design will clean up churned bugs. Below are the steps for each category:
 - **Schedule**: Remove the `:product` label, move the bug ticket to the 'Sprint backlog' column on the bug board, and assign it to the appropriate group's Engineering Manager so that it can be prioritized into the sprint backlog.
 - **De-prioritized**: The Head of Product Design should close the issue and, as the DRI, ensure all follow-up actions are finalized.
 

--- a/handbook/product/README.md
+++ b/handbook/product/README.md
@@ -126,7 +126,7 @@ If a bug is not addressed within six weeks, it is [sent to the product team for 
 - **Schedule**: the bug should be prioritized in the next sprint if there's engineering capacity for it.
 - **De-prioritized**: the issue will be closed and the necessary subsequent steps will be initiated. This might include updating documentation and informing the community.
 
-The Head of Product Design meets with the CEO and Director of Product Development to discuss and finalize the outcomes for the churned bugs.
+The Head of Product Design meets with the CEO to discuss and finalize the outcomes for the churned bugs.
 
 Once outcomes have been approved by the CEO, The Head of Product Design will complete the churned bug clean-up ritual. Below are the steps for each category:
 - **Schedule**: Product Operations should remove the `:product` label, move the bug ticket to the 'Sprint backlog' column on the bug board, and assign it to the appropriate group's Engineering Manager so that it can be prioritized into the sprint backlog.

--- a/handbook/product/README.md
+++ b/handbook/product/README.md
@@ -129,7 +129,7 @@ If a bug is not addressed within six weeks, it is [sent to the product team for 
 The Head of Product Design meets with the CEO to discuss and finalize the outcomes for the churned bugs.
 
 Once outcomes have been approved by the CEO, The Head of Product Design will complete the churned bug clean-up ritual. Below are the steps for each category:
-- **Schedule**: Product Operations should remove the `:product` label, move the bug ticket to the 'Sprint backlog' column on the bug board, and assign it to the appropriate group's Engineering Manager so that it can be prioritized into the sprint backlog.
+- **Schedule**: Remove the `:product` label, move the bug ticket to the 'Sprint backlog' column on the bug board, and assign it to the appropriate group's Engineering Manager so that it can be prioritized into the sprint backlog.
 - **De-prioritized**: The Head of Product Design should close the issue and, as the DRI, ensure all follow-up actions are finalized.
 
 ## Writing user stories

--- a/handbook/product/README.md
+++ b/handbook/product/README.md
@@ -81,7 +81,7 @@ Once the draft has been approved, it moves to the "Settled" column on the drafti
 
 Before assigning an engineering manager to [estimate](https://fleetdm.com/handbook/engineering#sprint-ceremonies) a user story, the product designer ensures the product section of the user story [checklist](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=story&projects=&template=story.md&title=) is complete. 
 
-Once a bug has gone through design and is considered "Settled", the designer removes the `:product` label and moves the issue to the 'To be scheduled' column on the "Bugs" board. The product manager then prioritizes the bug into the "Sprint backlog" and assigns the group engineering manager. 
+Once a bug has gone through design and is considered "Settled", the designer removes the `:product` label and moves the issue to the 'Sprint backlog' column on the "Bugs" board. The product manager then prioritizes the bug into the "Sprint backlog" and assigns the group engineering manager. 
 
 Learn https://fleetdm.com/handbook/company/development-groups#making-changes
 
@@ -130,7 +130,7 @@ If a bug is not addressed within six weeks, it is [sent to the product team for 
 After aligning with the group product managers, the Head of Product meets with the CEO and Director of Product Development to discuss and finalize the outcomes for the churned bugs.
 
 Once outcomes have been approved by the CEO, Product Operations will complete the churned bug clean-up ritual. Below are the steps for each category:
-- **Schedule**: Product Operations should remove the `:product` label, move the bug ticket to the 'to be scheduled' column on the bug board, and assign it to the appropriate group's Product Manager so that it can be prioritized into the sprint backlog.
+- **Schedule**: Product Operations should remove the `:product` label, move the bug ticket to the 'Sprint backlog' column on the bug board, and assign it to the appropriate group's Product Manager so that it can be prioritized into the sprint backlog.
 - **Needs prioritization**: Product Operations should remove both the `bug` and `:product` labels, then apply the `needs prioritization` label.
 - **De-prioritized**: Product Operations should close the issue and, as the DRI, ensure all follow-up actions are finalized.
 

--- a/handbook/product/README.md
+++ b/handbook/product/README.md
@@ -126,9 +126,9 @@ If a bug is not addressed within six weeks, it is [sent to the product team for 
 - **Schedule**: the bug should be prioritized in the next sprint if there's engineering capacity for it.
 - **De-prioritized**: the issue will be closed and the necessary subsequent steps will be initiated. This might include updating documentation and informing the community.
 
-The Head of Product Design meets with the Head of Product Development to discuss and finalize the outcomes for the churned bugs.
+The Head of Product Design meets with the Director of Product Development to discuss and finalize the outcomes for the churned bugs.
 
-After aligning with the Head of Product Development on the outcomes, The Head of Product Design will clean up churned bugs. Below are the steps for each category:
+After aligning with the Director of Product Development on the outcomes, The Head of Product Design will clean up churned bugs. Below are the steps for each category:
 - **Schedule**: Remove the `:product` label, move the bug ticket to the 'Sprint backlog' column on the bug board, and assign it to the appropriate group's Engineering Manager so that it can be prioritized into the sprint backlog.
 - **De-prioritized**: The Head of Product Design should close the issue and, as the DRI, ensure all follow-up actions are finalized.
 


### PR DESCRIPTION
- Redundant; tickets should go straight from drafting > sprint backlog. 
- Remove `Needs prioritization` category. Aged out bugs either are scheduled for the next sprint (if there's capacity) or close.
...