### PR TITLE
Fleet UI: Various team users save inherited queries to current team

### DIFF
--- a/changes/14620-save-inherited-query
+++ b/changes/14620-save-inherited-query
@@ -1,0 +1,1 @@
+- Fix bug where save as new for an inherited query will correctly save on the currently selected team

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -340,6 +340,7 @@ const ManageQueriesPage = ({
         router={router}
         queryParams={queryParams}
         isInherited
+        currentTeamId={currentTeamId}
       />
     );
   };

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -42,6 +42,7 @@ interface IQueriesTableProps {
     team_id?: string;
   };
   isInherited?: boolean;
+  currentTeamId?: number;
 }
 
 const DEFAULT_SORT_DIRECTION = "asc";
@@ -93,6 +94,7 @@ const QueriesTable = ({
   router,
   queryParams,
   isInherited = false,
+  currentTeamId,
 }: IQueriesTableProps): JSX.Element | null => {
   const { currentUser } = useContext(AppContext);
 
@@ -237,8 +239,10 @@ const QueriesTable = ({
   };
 
   const tableHeaders = useMemo(
-    () => currentUser && generateTableHeaders({ currentUser, isInherited }),
-    [currentUser, isInherited]
+    () =>
+      currentUser &&
+      generateTableHeaders({ currentUser, isInherited, currentTeamId }),
+    [currentUser, isInherited, currentTeamId]
   );
 
   const searchable =

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -102,6 +102,7 @@ interface IDataColumn {
 interface IGenerateTableHeaders {
   currentUser: IUser;
   isInherited?: boolean;
+  currentTeamId?: number;
 }
 
 // NOTE: cellProps come from react-table
@@ -109,6 +110,7 @@ interface IGenerateTableHeaders {
 const generateTableHeaders = ({
   currentUser,
   isInherited = false,
+  currentTeamId,
 }: IGenerateTableHeaders): IDataColumn[] => {
   const isOnlyObserver = permissionsUtils.isOnlyObserver(currentUser);
 
@@ -154,7 +156,7 @@ const generateTableHeaders = ({
             }
             path={PATHS.QUERY(
               cellProps.row.original.id,
-              cellProps.row.original.team_id ?? undefined
+              cellProps.row.original.team_id ?? currentTeamId
             )}
           />
         );

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -49,12 +49,14 @@ const baseClass = "query-details-page";
 
 const QueryDetailsPage = ({
   router,
-  params: { id: paramsQueryId, team_id: paramsTeamId },
+  params: { id: paramsQueryId },
   location,
 }: IQueryDetailsPageProps): JSX.Element => {
   const queryId = parseInt(paramsQueryId, 10);
   const queryParams = location.query;
-  const teamId = parseInt(paramsTeamId, 10);
+  const teamId = location.query.team_id
+    ? parseInt(location.query.team_id, 10)
+    : undefined;
 
   // Functions to avoid race conditions
   const serverSortBy: ISortOption[] = (() => {
@@ -77,6 +79,7 @@ const QueryDetailsPage = ({
     filteredQueriesPath,
     availableTeams,
     setCurrentTeam,
+    currentTeam,
   } = useContext(AppContext);
   const {
     lastEditedQueryName,
@@ -198,7 +201,7 @@ const QueryDetailsPage = ({
                 {canEditQuery && (
                   <Button
                     onClick={() => {
-                      queryId && router.push(PATHS.EDIT_QUERY(queryId));
+                      queryId && router.push(PATHS.EDIT_QUERY(queryId, teamId));
                     }}
                     className={`${baseClass}__manage-automations button`}
                     variant="brand"

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -328,7 +328,9 @@ const EditQueryForm = ({
         })
         .then((response: { query: ISchedulableQuery }) => {
           setIsSaveAsNewLoading(false);
-          router.push(PATHS.EDIT_QUERY(response.query.id));
+          router.push(
+            PATHS.QUERY(response.query.id, response.query.team_id ?? undefined)
+          );
           renderFlash("success", `Successfully added query.`);
         })
         .catch((createError: { data: IApiError }) => {


### PR DESCRIPTION
## Issue
Cerra #14620 

## Description
- Team id was not being passed down from current selected team
- When a user on multiple teams saves an inherited query as new, they save it to the current selected team and are re-routed properly to the query details page

## Screenrecording
- Select team with team id 4, go to an inherited query, save as new, see that the query is saved to team id 4

https://github.com/fleetdm/fleet/assets/71795832/5dc61a57-3b9c-4a94-8564-9f3b38a880ee


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality

