### PR TITLE
reduce DB usage when listing profiles for a team

### DIFF
--- a/changes/14694-db-usage
+++ b/changes/14694-db-usage
@@ -1,0 +1,1 @@
+* Reduced the DB usage when listing MDM profiles for a team

--- a/server/datastore/cached_mysql/cached_mysql.go
+++ b/server/datastore/cached_mysql/cached_mysql.go
@@ -284,6 +284,9 @@ func (ds *cachedMysql) TeamMDMConfig(ctx context.Context, teamID uint) (*fleet.T
 	if err != nil {
 		return nil, err
 	}
+
+	ds.c.Set(key, cfg, ds.teamMDMConfigExp)
+
 	return cfg, nil
 }
 

--- a/server/datastore/mysql/teams_test.go
+++ b/server/datastore/mysql/teams_test.go
@@ -34,6 +34,7 @@ func TestTeams(t *testing.T) {
 		{"DeleteIntegrationsFromTeams", testTeamsDeleteIntegrationsFromTeams},
 		{"TeamsFeatures", testTeamsFeatures},
 		{"TeamsMDMConfig", testTeamsMDMConfig},
+		{"TeamExists", testTeamExists},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -593,4 +594,21 @@ func testTeamsMDMConfig(t *testing.T, ds *Datastore) {
 			},
 		}, mdm)
 	})
+}
+
+func testTeamExists(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	team, err := ds.NewTeam(ctx, &fleet.Team{
+		Name:        t.Name(),
+		Description: t.Name() + "_description",
+	})
+	require.NoError(t, err)
+	require.NotZero(t, team.ID)
+
+	err = ds.TeamExists(ctx, team.ID)
+	require.NoError(t, err)
+
+	err = ds.TeamExists(ctx, team.ID+1000)
+	var nfe fleet.NotFoundError
+	require.ErrorAs(t, err, &nfe)
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -411,6 +411,8 @@ type Datastore interface {
 	SaveTeam(ctx context.Context, team *Team) (*Team, error)
 	// Team retrieves the Team by ID.
 	Team(ctx context.Context, tid uint) (*Team, error)
+	// Team exists is a lightweight check to verify if a team exists
+	TeamExists(ctx context.Context, id uint) error
 	// Team deletes the Team by ID.
 	DeleteTeam(ctx context.Context, tid uint) error
 	// TeamByName retrieves the Team by Name.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -310,6 +310,8 @@ type SaveTeamFunc func(ctx context.Context, team *fleet.Team) (*fleet.Team, erro
 
 type TeamFunc func(ctx context.Context, tid uint) (*fleet.Team, error)
 
+type TeamExistsFunc func(ctx context.Context, id uint) error
+
 type DeleteTeamFunc func(ctx context.Context, tid uint) error
 
 type TeamByNameFunc func(ctx context.Context, name string) (*fleet.Team, error)
@@ -1152,6 +1154,9 @@ type DataStore struct {
 
 	TeamFunc        TeamFunc
 	TeamFuncInvoked bool
+
+	TeamExistsFunc        TeamExistsFunc
+	TeamExistsFuncInvoked bool
 
 	DeleteTeamFunc        DeleteTeamFunc
 	DeleteTeamFuncInvoked bool
@@ -2782,6 +2787,13 @@ func (s *DataStore) Team(ctx context.Context, tid uint) (*fleet.Team, error) {
 	s.TeamFuncInvoked = true
 	s.mu.Unlock()
 	return s.TeamFunc(ctx, tid)
+}
+
+func (s *DataStore) TeamExists(ctx context.Context, id uint) error {
+	s.mu.Lock()
+	s.TeamExistsFuncInvoked = true
+	s.mu.Unlock()
+	return s.TeamExistsFunc(ctx, id)
 }
 
 func (s *DataStore) DeleteTeam(ctx context.Context, tid uint) error {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -394,14 +394,14 @@ func (svc *Service) ListMDMAppleConfigProfiles(ctx context.Context, teamID uint)
 
 	if teamID >= 1 {
 		// confirm that team exists
-		if _, err := svc.ds.Team(ctx, teamID); err != nil {
-			return nil, ctxerr.Wrap(ctx, err)
+		if err := svc.ds.TeamExists(ctx, teamID); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "checking team existence")
 		}
 	}
 
 	cps, err := svc.ds.ListMDMAppleConfigProfiles(ctx, &teamID)
 	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err)
+		return nil, ctxerr.Wrap(ctx, err, "listing profiles")
 	}
 
 	return cps, nil

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -576,6 +576,13 @@ func TestMDMAppleConfigProfileAuthz(t *testing.T) {
 	for _, tt := range testCases {
 		ctx := viewer.NewContext(ctx, viewer.Viewer{User: tt.user})
 		ds.TeamFunc = mockTeamFuncWithUser(tt.user)
+		ds.TeamExistsFunc = func(ctx context.Context, id uint) error {
+			_, err := ds.TeamFunc(ctx, id)
+			if err != nil {
+				return err
+			}
+			return nil
+		}
 
 		t.Run(tt.name, func(t *testing.T) {
 			// test authz create new profile (no team)


### PR DESCRIPTION
for https://github.com/fleetdm/fleet/issues/14694, this reduces the db usage when doing a check for the
existence of a team.

it also introduces a fix for an issue related to caching of MDM
configurations found by @lucasmrod

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
