### PR TITLE
Optimize SubmitResultLogs when query_reports_disabled is true

### DIFF
--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -700,7 +700,7 @@ func TestSaveResultLogsToQueryReports(t *testing.T) {
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &fleet.AppConfig{ServerSettings: fleet.ServerSettings{QueryReportsDisabled: true}}, nil
 	}
-	serv.saveResultLogsToQueryReports(ctx, results, queriesDBData)
+	serv.saveResultLogsToQueryReports(ctx, results, queriesDBData, true)
 	assert.False(t, ds.OverwriteQueryResultRowsFuncInvoked)
 
 	// Result not saved if result is not a snapshot
@@ -715,7 +715,7 @@ func TestSaveResultLogsToQueryReports(t *testing.T) {
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &fleet.AppConfig{ServerSettings: fleet.ServerSettings{QueryReportsDisabled: false}}, nil
 	}
-	serv.saveResultLogsToQueryReports(ctx, notSnapshotResult, queriesDBData)
+	serv.saveResultLogsToQueryReports(ctx, notSnapshotResult, queriesDBData, false)
 	assert.False(t, ds.OverwriteQueryResultRowsFuncInvoked)
 
 	// Results not saved if DiscardData is true in Query
@@ -726,7 +726,7 @@ func TestSaveResultLogsToQueryReports(t *testing.T) {
 			Logging:     fleet.LoggingSnapshot,
 		},
 	}
-	serv.saveResultLogsToQueryReports(ctx, results, discardDataFalse)
+	serv.saveResultLogsToQueryReports(ctx, results, discardDataFalse, false)
 	assert.False(t, ds.OverwriteQueryResultRowsFuncInvoked)
 
 	// Happy Path: Results saved
@@ -740,7 +740,7 @@ func TestSaveResultLogsToQueryReports(t *testing.T) {
 	ds.OverwriteQueryResultRowsFunc = func(ctx context.Context, rows []*fleet.ScheduledQueryResultRow) error {
 		return nil
 	}
-	serv.saveResultLogsToQueryReports(ctx, results, discardDataTrue)
+	serv.saveResultLogsToQueryReports(ctx, results, discardDataTrue, false)
 	require.True(t, ds.OverwriteQueryResultRowsFuncInvoked)
 }
 


### PR DESCRIPTION
#7766

When receiving /api/v1/osquery/log requests do not load the queries if `query_reports_disabled=true`.
This change should bring the load similar to the baseline (when `query_reports_disabled=true`).

- ~[ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.~
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- ~[ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)~
- ~[ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)~
- ~[ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.~
- [ ] Added/updated tests
- ~[ ] Manual QA for all new/changed functionality~
  - ~For Orbit and Fleet Desktop changes:~
    - ~[ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.~
    - ~[ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).~
