### PR TITLE
prevent a bug preventing .mobileconfig uploads in Linux/Windows

### DIFF
--- a/changes/14056-file-ext
+++ b/changes/14056-file-ext
@@ -1,0 +1,1 @@
+* Fixed a bug preventing Windows and Linux users to upload .mobileconfig files in the UI.

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/CustomSettings.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/CustomSettings.tsx
@@ -61,7 +61,9 @@ const CustomSettings = ({
     const file = files[0];
 
     if (
-      file.type !== "application/x-apple-aspen-config" ||
+      // file.type might be empty on some systems as uncommon file extensions
+      // would return an empty string.
+      (file.type !== "" && file.type !== "application/x-apple-aspen-config") ||
       !file.name.includes(".mobileconfig")
     ) {
       renderFlash("error", UPLOAD_ERROR_MESSAGES.wrongType.message);


### PR DESCRIPTION
For #14056, per the [mdn web docs](https://developer.mozilla.org/en-US/docs/Web/API/File/type)

> Note: Based on the current implementation, browsers won't actually
> read the bytestream of a file to determine its media type. It is assumed
> based on the file extension; a PNG image file renamed to .txt would give
> "text/plain" and not "image/png". Moreover, file.type is generally
> reliable only for common file types like images, HTML documents, audio
> and video. Uncommon file extensions would return an empty string. Client
> configuration (for instance, the Windows Registry) may result in
> unexpected values even for common types. Developers are advised not to
> rely on this property as a sole validation scheme.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
