### PR TITLE
Fleet UI: Manage queries page uses URL params as source of truth for table and inherited table views

### DIFF
--- a/changes/14733-14661-queries-page-fix
+++ b/changes/14733-14661-queries-page-fix
@@ -1,0 +1,1 @@
+- Add inherited table information to URL params and use URL params for source of truth to fix any bugs between multi-table view

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -84,6 +84,7 @@ interface ITableContainerProps {
   customControl?: () => JSX.Element;
   stackControls?: boolean;
   onSelectSingleRow?: (value: Row | IRowProps) => void;
+  /** Use for clientside filtering: Use key global for filtering on any column, or use column id as key */
   filters?: Record<string, string | number | boolean>;
   renderCount?: () => JSX.Element | null;
   renderFooter?: () => JSX.Element | null;

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -50,6 +50,9 @@ interface IManageQueriesPageProps {
       order_key?: string;
       order_direction?: "asc" | "desc";
       team_id?: string;
+      inherited_order_key?: string;
+      inherited_order_direction?: "asc" | "desc";
+      inherited_page?: string;
     };
     search: string;
   };
@@ -76,7 +79,6 @@ const ManageQueriesPage = ({
   location,
 }: IManageQueriesPageProps): JSX.Element => {
   const queryParams = location.query;
-
   const {
     isGlobalAdmin,
     isTeamAdmin,
@@ -93,7 +95,6 @@ const ManageQueriesPage = ({
   const { setLastEditedQueryBody, setSelectedQueryTargetsByType } = useContext(
     QueryContext
   );
-
   const { setResetSelectedRows } = useContext(TableContext);
   const { renderFlash } = useContext(NotificationContext);
 

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -147,8 +147,6 @@ const QueriesTable = ({
       // Rebuild queryParams to dispatch new browser location to react-router
       const newQueryParams: { [key: string]: string | number | undefined } = {};
 
-      newQueryParams.query = newSearchQuery;
-
       // Updates main query table URL params
       // No change to inherited query table URL params
       if (!isInherited) {
@@ -156,6 +154,7 @@ const QueriesTable = ({
         newQueryParams.order_direction = newSortDirection;
         newQueryParams.platform = platform; // must set from URL
         newQueryParams.page = newPageIndex;
+        newQueryParams.query = newSearchQuery;
         // Reset page number to 0 for new filters
         if (
           newSortDirection !== sortDirection ||
@@ -198,10 +197,12 @@ const QueriesTable = ({
         ? {
             ...queryParams,
             inherited_page: pageIndex, // update inherited page index
+            query: searchQuery,
           }
         : {
             ...queryParams,
             page: pageIndex, // update main table index
+            query: searchQuery,
           };
 
       const locationPath = getNextLocationPath({
@@ -290,7 +291,7 @@ const QueriesTable = ({
         resultsTitle="queries"
         columns={tableHeaders}
         data={queriesList}
-        filters={{ global: isInherited ? "" : searchQuery }}
+        filters={{ name: isInherited ? "" : searchQuery }}
         isLoading={isLoading}
         defaultSortHeader={sortHeader || DEFAULT_SORT_HEADER}
         defaultSortDirection={sortDirection || DEFAULT_SORT_DIRECTION}

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -165,8 +165,8 @@ const QueriesTable = ({
         }
       }
 
-      // Updates inherited policy table URL params
-      // No change to main policy table URL params
+      // Updates inherited query table URL params
+      // No change to main query table URL params
       if (isInherited) {
         newQueryParams.inherited_order_key = newSortHeader;
         newQueryParams.inherited_order_direction = newSortDirection;

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -40,7 +40,6 @@ interface IQueriesTableProps {
     order_key?: string;
     order_direction?: "asc" | "desc";
     team_id?: string;
-    inherited_table?: "true";
     inherited_order_key?: string;
     inherited_order_direction?: "asc" | "desc";
     inherited_page?: string;
@@ -103,17 +102,19 @@ const QueriesTable = ({
   // Functions to avoid race conditions
   const initialSearchQuery = (() => queryParams?.query ?? "")();
   const initialSortHeader = (() =>
-    (queryParams?.order_key as "name" | "updated_at" | "author") ?? "name")();
+    (queryParams?.order_key as "name" | "updated_at" | "author") ??
+    DEFAULT_SORT_HEADER)();
   const initialSortDirection = (() =>
-    (queryParams?.order_direction as "asc" | "desc") ?? "asc")();
+    (queryParams?.order_direction as "asc" | "desc") ??
+    DEFAULT_SORT_DIRECTION)();
   const initialPlatform = (() =>
     (queryParams?.platform as "all" | "windows" | "linux" | "darwin") ??
-    "all")();
+    DEFAULT_PLATFORM)();
   const initialPage = (() =>
     queryParams && queryParams.page ? parseInt(queryParams?.page, 10) : 0)();
   const initialInheritedSortHeader = (() =>
     (queryParams?.inherited_order_key as "name" | "failing_host_count") ??
-    "name")();
+    DEFAULT_SORT_HEADER)();
   const initialInheritedSortDirection = (() =>
     (queryParams?.inherited_order_direction as "asc" | "desc") ??
     DEFAULT_SORT_DIRECTION)();


### PR DESCRIPTION
## Issues
Cerra #14733 
Cerra #14661 

## Description
- URL bar should always serve as source of truth for views of tables, Add inherited table params to the URL bar
- NOTE: Because these are client side filters, if a user goes directly to the URL, there is a flash of the entire data returned by the API and then after the client side filters apply, the correct filtered list is shown (Future iteration can look into a loading state for client side filters to apply but it's complicated because it's happening within the table container component)

## Screen recording

### All teams tables updating the URL params properly

https://github.com/fleetdm/fleet/assets/71795832/4766b792-29a5-4b65-bcb6-4f5fa6d51deb

### Team table view updating the URL params properly between both tables

https://github.com/fleetdm/fleet/assets/71795832/14f36445-505a-49ea-aa3d-0d2043b4b1de

## Dev Manually Tested

### When viewing a team's queries:
- [x] Main table: Updating sort header updates main table only, URL bar correctly and can hit refresh
- [x] Main table: Updating sort direction updates main table only, URL bar correctly and can hit refresh
- [x] Main table: Update search query updates main table only, URL bar correctly and can hit refresh
- [x] Main table: Update platform updates main table only, URL bar correctly and can hit refresh
- [x] Main table: Paginating updates main table only, URL bar correctly and can hit refresh
- [x] Inherited table: Updating sort header updates inherited table only, URL bar correctly and can hit refresh
- [x] Inherited table: Updating sort direction updates inherited table only, URL bar correctly and can hit refresh
- [x] Inherited table: Paginating updates inherited table only, URL bar correctly and can hit refresh

### When viewing a "All teams" queries (only 1 table is being shown):
- [x] Main table: Updating sort header updates URL bar and can hit refresh
- [x] Main table: Updating sort direction updates URL bar and can hit refresh
- [x] Main table: Update search query updates URL bar and can hit refresh
- [x] Main table: Update platform updates URL bar and can hit refresh
- [x] Main table: Paginating updates URL bar and can hit refresh


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [ ] Added/updated tests
- [x] Manual QA for all new/changed functionality

