### PR TITLE
Add `null` logging to avoid issues on load tests

### DIFF
--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -986,8 +986,8 @@ Valid time units are `s`, `m`, `h`.
 
 This is the log output plugin that should be used for osquery status logs received from clients. Check out the [reference documentation for log destinations](https://fleetdm.com/docs/using-fleet/log-destinations).
 
-
-Options are `filesystem`, `firehose`, `kinesis`, `lambda`, `pubsub`, `kafkarest`, and `stdout`.
+Options are [`filesystem`](#filesystem), [`firehose`](#firehose), [`kinesis`](#kinesis), [`lambda`](#lambda), [`pubsub`](#pubsub), [`kafkarest`](#kafka-rest-proxy-logging), `stdout` and `null`.
+Using `null` will make Fleet discard logs. For `stdout` and `null` there's no additional configuration needed.
 
 - Default value: `filesystem`
 - Environment variable: `FLEET_OSQUERY_STATUS_LOG_PLUGIN`
@@ -1001,7 +1001,8 @@ Options are `filesystem`, `firehose`, `kinesis`, `lambda`, `pubsub`, `kafkarest`
 
 This is the log output plugin that should be used for osquery result logs received from clients. Check out the [reference documentation for log destinations](https://fleetdm.com/docs/using-fleet/log-destinations).
 
-Options are `filesystem`, `firehose`, `kinesis`, `lambda`, `pubsub`, `kafkarest`, and `stdout`.
+Options are [`filesystem`](#filesystem), [`firehose`](#firehose), [`kinesis`](#kinesis), [`lambda`](#lambda), [`pubsub`](#pubsub), [`kafkarest`](#kafka-rest-proxy-logging), `stdout` and `null`.
+Using `null` will make Fleet discard logs. For `stdout` and `null` there's no additional configuration needed.
 
 - Default value: `filesystem`
 - Environment variable: `FLEET_OSQUERY_RESULT_LOG_PLUGIN`
@@ -1211,7 +1212,8 @@ This flag only has effect if `activity_enable_audit_log` is set to `true`.
 
 Each plugin has additional configuration options. Please see the configuration section linked below for your logging plugin.
 
-Options are [`filesystem`](#filesystem), [`firehose`](#firehose), [`kinesis`](#kinesis), [`lambda`](#lambda), [`pubsub`](#pubsub), [`kafkarest`](#kafka-rest-proxy-logging), and `stdout` (no additional configuration needed).
+Options are [`filesystem`](#filesystem), [`firehose`](#firehose), [`kinesis`](#kinesis), [`lambda`](#lambda), [`pubsub`](#pubsub), [`kafkarest`](#kafka-rest-proxy-logging), `stdout` and `null`.
+Using `null` will make Fleet discard logs. For `stdout` and `null` there's no additional configuration needed.
 
 - Default value: `filesystem`
 - Environment variable: `FLEET_ACTIVITY_AUDIT_LOG_PLUGIN`

--- a/frontend/components/LogDestinationIndicator/LogDestinationIndicator.tsx
+++ b/frontend/components/LogDestinationIndicator/LogDestinationIndicator.tsx
@@ -25,6 +25,8 @@ const LogDestinationIndicator = ({
   );
   const readableLogDestination = () => {
     switch (logDestination) {
+      case "null":
+        return "Discarded";
       case "filesystem":
         return "Filesystem";
       case "firehose":
@@ -48,10 +50,12 @@ const LogDestinationIndicator = ({
 
   const tooltipText = () => {
     switch (logDestination) {
+      case "null":
+        return `Each time a query runs, the data is received <br />
+            by the Fleet server and discarded.`;
       case "filesystem":
-        return `Each time a query runs, the data is sent to <br />
-            /var/log/osquery/osqueryd.snapshots.log <br />
-            in each host&apos;s filesystem.`;
+        return `Each time a query runs, the data is sent to < br />
+            a file on the Fleet server.`;
       case "firehose":
         return `Each time a query runs, the data is sent to <br />
             Amazon Kinesis Data Firehose.`;

--- a/server/logging/logging.go
+++ b/server/logging/logging.go
@@ -166,6 +166,8 @@ func NewJSONLogger(name string, config Config, logger log.Logger) (fleet.JSONLog
 			return nil, fmt.Errorf("create kafka rest %s logger: %w", name, err)
 		}
 		return fleet.JSONLogger(writer), nil
+	case "null":
+		return fleet.JSONLogger(&nullLogging{}), nil
 	default:
 		return nil, fmt.Errorf(
 			"unknown %s log plugin: %s", name, config.Plugin,

--- a/server/logging/null.go
+++ b/server/logging/null.go
@@ -1,0 +1,12 @@
+package logging
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type nullLogging struct{}
+
+func (b *nullLogging) Write(ctx context.Context, logs []json.RawMessage) error {
+	return nil
+}

--- a/server/service/service_appconfig.go
+++ b/server/service/service_appconfig.go
@@ -227,6 +227,10 @@ func (svc *Service) LoggingConfig(ctx context.Context) (*fleet.Logging, error) {
 					ProxyHost:   conf.KafkaREST.ProxyHost,
 				},
 			}
+		case "null":
+			*lp.target = fleet.LoggingPlugin{
+				Plugin: "null",
+			}
 		default:
 			return nil, ctxerr.Errorf(ctx, "unrecognized logging plugin: %s", lp.plugin)
 		}


### PR DESCRIPTION
We really needed something like this during load tests for #7766 (to not get those Firehose errors while working at a high load using scheduled queries). This will be useful for any subsequent load test.

@rachaelshaw/@noahtalerman  Let me know if:
- We want to name it something different than `null`.
- We want to hide this option from our docs. (*)
- We want a different wording on the UI when using this. (*)

Let me know if you want me to create an issue for this.

(*) AFAICS this is only useful for load-testing/internal-use.

![Screenshot 2023-10-26 at 14 45 00](https://github.com/fleetdm/fleet/assets/2073526/81a705fa-7db1-4ea2-8b2a-0a861c347394)
