### PR TITLE
Website: Remove `/handbook/sales` redirect

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -381,7 +381,6 @@ module.exports.routes = {
   'GET /use-cases/using-elasticsearch-and-kibana-to-visualize-osquery-performance': '/guides/using-elasticsearch-and-kibana-to-visualize-osquery-performance',
   'GET /use-cases/work-may-be-watching-but-it-might-not-be-as-bad-as-you-think': '/securing/work-may-be-watching-but-it-might-not-be-as-bad-as-you-think',
   'GET /docs/contributing/testing':  '/docs/contributing/testing-and-local-development',
-  'GET /handbook/sales': '/handbook/customers#sales',
   'GET /handbook/people': '/handbook/business-operations',
   'GET /handbook/people/ceo-handbook': '/handbook/ceo',
   'GET /handbook/company/ceo-handbook': '/handbook/ceo',


### PR DESCRIPTION
Changes:
- Removed the redirect for `/handbook/sales`. It is currently redirecting to `/handbook/customers/` (which redirects to `/hanbook/sales`, creating an infinite redirect loop.)