### PR TITLE
update copy for ABM terms banner message

### DIFF
--- a/changes/issue-13012-update-abm-terms-banner-copy
+++ b/changes/issue-13012-update-abm-terms-banner-copy
@@ -1,0 +1,2 @@
+- update the copy of the ABM terms banner to reflect that Apple may take a while to report the
+  correct status back to Fleet.

--- a/frontend/components/MDM/AppleBMTermsMessage/AppleBMTermsMessage.tsx
+++ b/frontend/components/MDM/AppleBMTermsMessage/AppleBMTermsMessage.tsx
@@ -1,27 +1,17 @@
 import React from "react";
 
-import PATHS from "router/paths";
-import { browserHistory } from "react-router";
-import Button from "components/buttons/Button";
 import CustomLink from "components/CustomLink";
 
 const baseClass = "apple-bm-terms-message";
 
 const AppleBMTermsMessage = () => {
-  const onClick = (): void => {
-    browserHistory.push(PATHS.MANAGE_HOSTS);
-  };
-
   return (
     <div className={baseClass}>
       <p>
-        Your organization can’t automatically enroll macOS hosts until you
+        Your organization can&apos;t automatically enroll macOS hosts until you
         accept the new terms and conditions for Apple Business Manager (ABM). An
-        ABM administrator can accept these terms. Done?{" "}
-        <Button onClick={onClick} variant="unstyled">
-          Go to Hosts
-        </Button>{" "}
-        to remove this banner.
+        ABM administrator can accept these terms. Done? It might take some time
+        for ABM to report back to Fleet.
       </p>
       <CustomLink
         url="https://business.apple.com/"

--- a/frontend/components/MDM/AppleBMTermsMessage/_styles.scss
+++ b/frontend/components/MDM/AppleBMTermsMessage/_styles.scss
@@ -1,5 +1,6 @@
 .apple-bm-terms-message {
   display: flex;
+  gap: $pad-medium;
   justify-content: space-between;
   align-items: center;
   padding: 12px $pad-large;


### PR DESCRIPTION
relates to #13012

Updates the copy of the ABM terms banner message to reflect that Apple may take a long time to update that the terms have been accepted.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [x] Manual QA for all new/changed functionality
