### PR TITLE
Fleet UI: Observer+ can run policies in the UI, update docs accordingly

### DIFF
--- a/changes/14577-observer-plus-run-policies
+++ b/changes/14577-observer-plus-run-policies
@@ -1,0 +1,1 @@
+- Bug fix: Allow Observer+ ability to run all existing policies in the UI

--- a/docs/Using Fleet/manage-access.md
+++ b/docs/Using Fleet/manage-access.md
@@ -50,10 +50,11 @@ GitOps is an API-only and write-only role that can be used on CI/CD pipelines.
 | Run queries designated "**observer can run**" as live queries against all hosts                                                            | ✅       | ✅         | ✅         | ✅    |         |
 | Run any query as [live query](https://fleetdm.com/docs/using-fleet/fleet-ui#run-a-query) against all hosts                                 |          | ✅         | ✅         | ✅    |         |
 | Create, edit, and delete queries                                                                                                           |          |            | ✅         | ✅    | ✅      |
-| View all queries and their reports\**                                                                                                       | ✅       | ✅         | ✅         | ✅    |         |
-| Manage [query automations](https://fleetdm.com/docs/using-fleet/fleet-ui#schedule-a-query)                                                 |          |            |    ✅      | ✅    |   ✅    |
+| View all queries and their reports\**                                                                                                      | ✅       | ✅         | ✅         | ✅    |         |
+| Manage [query automations](https://fleetdm.com/docs/using-fleet/fleet-ui#schedule-a-query)                                                 |          |            | ✅         | ✅    | ✅      |
 | Create, edit, view, and delete packs                                                                                                       |          |            | ✅         | ✅    | ✅      |
 | View all policies                                                                                                                          | ✅       | ✅         | ✅         | ✅    |         |
+| Run all policies                                                                                                                           |          | ✅         | ✅         | ✅    |         |
 | Filter hosts using policies                                                                                                                | ✅       | ✅         | ✅         | ✅    |         |
 | Create, edit, and delete policies for all hosts                                                                                            |          |            | ✅         | ✅    | ✅      |
 | Create, edit, and delete policies for all hosts assigned to team\*                                                                         |          |            | ✅         | ✅    | ✅      |
@@ -75,7 +76,7 @@ GitOps is an API-only and write-only role that can be used on CI/CD pipelines.
 | View Apple mobile device management (MDM) certificate information                                                                          |          |            |            | ✅    |         |
 | View Apple business manager (BM) information                                                                                               |          |            |            | ✅    |         |
 | Generate Apple mobile device management (MDM) certificate signing request (CSR)                                                            |          |            |            | ✅    |         |
-| View disk encryption key for macOS and Windows hosts                                                                                              | ✅       | ✅         | ✅         | ✅    |         |
+| View disk encryption key for macOS and Windows hosts                                                                                       | ✅       | ✅         | ✅         | ✅    |         |
 | Create edit and delete configuration profiles for macOS hosts                                                                              |          |            | ✅         | ✅    | ✅      |
 | Execute MDM commands on macOS and Windows hosts***                                                                                         |          |            | ✅         | ✅    |         |
 | View results of MDM commands executed on macOS and Windows hosts***                                                                        | ✅       | ✅         | ✅         | ✅    |         |
@@ -127,11 +128,12 @@ Users that are members of multiple teams can be assigned different roles for eac
 | Run queries designated "**observer can run**" as live queries against hosts                                                      | ✅            | ✅             | ✅              | ✅         |             |
 | Run any query as [live query](https://fleetdm.com/docs/using-fleet/fleet-ui#run-a-query)                                         |               | ✅             | ✅              | ✅         |             |
 | Create, edit, and delete only **self authored** queries                                                                          |               |                | ✅              | ✅         | ✅          |
-| View all queries and their reports\**                                                                                              | ✅            | ✅             | ✅              | ✅         |             |
-| Manage [query automations](https://fleetdm.com/docs/using-fleet/fleet-ui#schedule-a-query)                                       |               |                 | ✅              | ✅         | ✅          |
-| View policies                                                                                                                    | ✅            | ✅             | ✅              | ✅         |             |
+| View all queries and their reports\**                                                                                            | ✅            | ✅             | ✅              | ✅         |             |
+| Manage [query automations](https://fleetdm.com/docs/using-fleet/fleet-ui#schedule-a-query)                                       |               |                | ✅              | ✅         | ✅          |
+| View team policies                                                                                                               | ✅            | ✅             | ✅              | ✅         |             |
+| Run team policies as a live policy                                                                                               |               | ✅             | ✅              | ✅         |             |
 | View global (inherited) policies                                                                                                 | ✅            | ✅             | ✅              | ✅         |             |
-| Run global (inherited) policies as a live policy                                                                                 |               |                | ✅              | ✅         |             |
+| Run global (inherited) policies as a live policy                                                                                 |               | ✅             | ✅              | ✅         |             |
 | Filter hosts using policies                                                                                                      | ✅            | ✅             | ✅              | ✅         |             |
 | Create, edit, and delete team policies                                                                                           |               |                | ✅              | ✅         | ✅          |
 | Manage [policy automations](https://fleetdm.com/docs/using-fleet/automations#policy-automations)                                 |               |                |                 | ✅         | ✅          |

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -343,6 +343,10 @@ export const useTeamIdParam = ({
     isTeamObserver:
       !!currentTeam?.id &&
       permissions.isTeamObserver(currentUser, currentTeam.id),
+    isObserverPlus:
+      !!currentTeam?.id &&
+      !!currentUser &&
+      permissions.isObserverPlus(currentUser, currentTeam.id),
     teamIdForApi: getTeamIdForApi({ currentTeam, includeNoTeam }),
     userTeams,
     handleTeamChange,

--- a/frontend/pages/policies/PolicyPage/PolicyPage.tsx
+++ b/frontend/pages/policies/PolicyPage/PolicyPage.tsx
@@ -77,6 +77,7 @@ const PolicyPage = ({
     isTeamMaintainer,
     isTeamObserver,
     teamIdForApi,
+    isObserverPlus,
   } = useTeamIdParam({
     location,
     router,
@@ -257,6 +258,7 @@ const PolicyPage = ({
       isTeamAdmin,
       isTeamMaintainer,
       isTeamObserver,
+      isObserverPlus,
       storedPolicyError,
       createPolicy,
       onOsqueryTableSelect,

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -114,6 +114,7 @@ const PolicyForm = ({
     isGlobalObserver,
     isGlobalAdmin,
     isGlobalMaintainer,
+    isObserverPlus,
     isOnGlobalTeam,
     isPremiumTier,
     isSandboxMode,
@@ -170,7 +171,7 @@ const PolicyForm = ({
   }, [lastEditedQueryBody, lastEditedQueryId]);
 
   const hasSavePermissions =
-    !isEditMode || // save a new policy
+    (!isEditMode && !isObserverPlus) || // save a new policy
     isGlobalAdmin ||
     isGlobalMaintainer ||
     (isTeamAdmin && policyTeamId === storedPolicy?.team_id) || // team admin cannot save global policy
@@ -466,7 +467,8 @@ const PolicyForm = ({
     );
   };
 
-  // Observers and observer+ of existing query, team role viewing inherited policy
+  // Observers and observer+ of existing policy, team role viewing inherited policy
+  // Observer+ can run existing policy
   const renderNonEditableForm = (
     <form className={`${baseClass}__wrapper`}>
       <div className={`${baseClass}__title-bar`}>
@@ -503,6 +505,18 @@ const PolicyForm = ({
         />
       )}
       {renderLiveQueryWarning()}
+      {isObserverPlus && ( // Observer+ can run existing policies
+        <div className={`${baseClass}__button-wrap`}>
+          <Button
+            className={`${baseClass}__run`}
+            variant="blue-green"
+            onClick={goToSelectTargets}
+            disabled={isEditMode && !isAnyPlatformSelected}
+          >
+            Run
+          </Button>
+        </div>
+      )}
     </form>
   );
 

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -467,8 +467,8 @@ const PolicyForm = ({
     );
   };
 
-  // Observers and observer+ of existing policy, team role viewing inherited policy
-  // Observer+ can run existing policy
+  // Non-editable form used for Team Observers and Observer+ of their team policy and inherited policies
+  // And Global Observers and Observer+ of all policies
   const renderNonEditableForm = (
     <form className={`${baseClass}__wrapper`}>
       <div className={`${baseClass}__title-bar`}>

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -171,7 +171,7 @@ const PolicyForm = ({
   }, [lastEditedQueryBody, lastEditedQueryId]);
 
   const hasSavePermissions =
-    (!isEditMode && !isObserverPlus) || // save a new policy
+    !isEditMode || // save a new policy
     isGlobalAdmin ||
     isGlobalMaintainer ||
     (isTeamAdmin && policyTeamId === storedPolicy?.team_id) || // team admin cannot save global policy

--- a/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
+++ b/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
@@ -25,7 +25,6 @@ interface IQueryEditorProps {
   isTeamAdmin: boolean;
   isTeamMaintainer: boolean;
   isTeamObserver: boolean;
-  isObserverPlus: boolean;
   createPolicy: (formData: IPolicyFormData) => Promise<any>;
   onOsqueryTableSelect: (tableName: string) => void;
   goToSelectTargets: () => void;
@@ -44,7 +43,6 @@ const QueryEditor = ({
   isTeamAdmin,
   isTeamMaintainer,
   isTeamObserver,
-  isObserverPlus,
   createPolicy,
   onOsqueryTableSelect,
   goToSelectTargets,

--- a/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
+++ b/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
@@ -25,6 +25,7 @@ interface IQueryEditorProps {
   isTeamAdmin: boolean;
   isTeamMaintainer: boolean;
   isTeamObserver: boolean;
+  isObserverPlus: boolean;
   createPolicy: (formData: IPolicyFormData) => Promise<any>;
   onOsqueryTableSelect: (tableName: string) => void;
   goToSelectTargets: () => void;
@@ -43,6 +44,7 @@ const QueryEditor = ({
   isTeamAdmin,
   isTeamMaintainer,
   isTeamObserver,
+  isObserverPlus,
   createPolicy,
   onOsqueryTableSelect,
   goToSelectTargets,


### PR DESCRIPTION
## Issue
Cerra #14577 

## Description
- Allow observer + to see and click the run button on an existing policy
- Ensure that observers do not have access
- Update permissions docs for Global Observer+ and Team Observer+

## Other
- Align several misaligned column spacing so doc tables show clean rows when viewing on a widescreen editor
<img width="702" alt="Screenshot 2023-10-30 at 11 57 05 AM" src="https://github.com/fleetdm/fleet/assets/71795832/1182e143-ac28-4c25-a98f-f9d59d6b3872">


## Screen recording (Team observer+ running an inherited policy)

https://github.com/fleetdm/fleet/assets/71795832/8d0f39ab-1b01-4a2a-8aad-4e8a4735fac5


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Manual QA for all new/changed functionality
