### PR TITLE
Adding CPE support for different Jetbrains IDEA and PyCharm app names.

### DIFF
--- a/changes/13889-IDEA-apps-with-similar-names
+++ b/changes/13889-IDEA-apps-with-similar-names
@@ -1,0 +1,2 @@
+Adding vulnerability data support for JetBrains applications (like IDEA, PyCharm, etc.) that have similar names.
+- For example: IntelliJ IDEA.app and IntelliJ IDEA Ultimate.app

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -1290,6 +1290,46 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 				Version: "6.0.1",
 			}, cpe: "",
 		},
+		{
+			software: fleet.Software{
+				Name:             "IntelliJ IDEA.app",
+				Source:           "apps",
+				Version:          "2022.3.3",
+				Vendor:           "",
+				BundleIdentifier: "com.jetbrains.intellij",
+			},
+			cpe: "cpe:2.3:a:jetbrains:intellij_idea:2022.3.3:*:*:*:*:macos:*:*",
+		},
+		{
+			software: fleet.Software{
+				Name:             "IntelliJ IDEA CE.app",
+				Source:           "apps",
+				Version:          "2022.3.3",
+				Vendor:           "",
+				BundleIdentifier: "com.jetbrains.intellij.ce",
+			},
+			cpe: "cpe:2.3:a:jetbrains:intellij_idea:2022.3.3:*:*:*:*:macos:*:*",
+		},
+		{
+			software: fleet.Software{
+				Name:             "PyCharm.app",
+				Source:           "apps",
+				Version:          "2022.1",
+				Vendor:           "",
+				BundleIdentifier: "com.jetbrains.pycharm",
+			},
+			cpe: "cpe:2.3:a:jetbrains:pycharm:2022.1:*:*:*:*:macos:*:*",
+		},
+		{
+			software: fleet.Software{
+				Name:             "PyCharm Community Edition.app",
+				Source:           "apps",
+				Version:          "2022.1",
+				Vendor:           "",
+				BundleIdentifier: "com.jetbrains.pycharm.ce",
+			},
+			cpe: "cpe:2.3:a:jetbrains:pycharm:2022.1:*:*:*:*:macos:*:*",
+		},
 	}
 
 	tempDir := t.TempDir()

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -1312,13 +1312,13 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 		},
 		{
 			software: fleet.Software{
-				Name:             "PyCharm.app",
+				Name:             "User PyCharm Custom Name.app", // 2023/10/31: The actual product name must be part of the app name per our code in CPEFromSoftware
 				Source:           "apps",
-				Version:          "2022.1",
+				Version:          "2019.2",
 				Vendor:           "",
 				BundleIdentifier: "com.jetbrains.pycharm",
 			},
-			cpe: "cpe:2.3:a:jetbrains:pycharm:2022.1:*:*:*:*:macos:*:*",
+			cpe: "cpe:2.3:a:jetbrains:pycharm:2019.2:*:*:*:*:macos:*:*",
 		},
 		{
 			software: fleet.Software{

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -119,5 +119,25 @@
       "product": ["flock"],
       "vendor": ["flock"]
     }
+  },
+  {
+    "software": {
+      "bundle_identifier": ["/^com\\.jetbrains\\.intellij/"],
+      "source": ["apps"]
+    },
+    "filter": {
+      "product": ["intellij_idea"],
+      "vendor": ["jetbrains"]
+    }
+  },
+  {
+    "software": {
+      "bundle_identifier": ["/^com\\.jetbrains\\.pycharm/"],
+      "source": ["apps"]
+    },
+    "filter": {
+      "product": ["pycharm"],
+      "vendor": ["jetbrains"]
+    }
   }
 ]

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -129,15 +129,5 @@
       "product": ["intellij_idea"],
       "vendor": ["jetbrains"]
     }
-  },
-  {
-    "software": {
-      "bundle_identifier": ["/^com\\.jetbrains\\.pycharm/"],
-      "source": ["apps"]
-    },
-    "filter": {
-      "product": ["pycharm"],
-      "vendor": ["jetbrains"]
-    }
   }
 ]


### PR DESCRIPTION
Adding vulnerability data support for JetBrains applications (like IDEA, PyCharm, etc.) that have similar names.
- For example: IntelliJ IDEA.app and IntelliJ IDEA Ultimate.app

Resolves #13889 

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] Added/updated tests
- [x] Manual QA for all new/changed functionality
