### PR TITLE
Website: Update platform icon position on osquery schema table pages.

### DIFF
--- a/website/assets/styles/pages/osquery-table-details.less
+++ b/website/assets/styles/pages/osquery-table-details.less
@@ -239,7 +239,7 @@
       height: 0px;
       position: absolute;
       right: 0;
-      top: 76px;
+      top: 40px;
     }
     a:not(.btn):not([purpose='evented-table-label']) {
       color: @core-vibrant-blue;


### PR DESCRIPTION
Closes: #14792

Changes:
 - Updated the position of platform icons on `/tables/` pages